### PR TITLE
feat(hooks): add enforce-screenshot-requirement hook and tests

### DIFF
--- a/hooks/__tests__/enforce-screenshot-requirement.test.js
+++ b/hooks/__tests__/enforce-screenshot-requirement.test.js
@@ -1,0 +1,260 @@
+/**
+ * Tests for enforce-screenshot-requirement.js
+ *
+ * Run with: node --test hooks/__tests__/enforce-screenshot-requirement.test.js
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const HOOK_PATH = path.join(__dirname, '..', 'enforce-screenshot-requirement.js');
+const MARKER_DIR = '/tmp';
+
+function runHook(hookData, hookType = 'PreToolUse') {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', [HOOK_PATH], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, CLAUDE_HOOK_TYPE: hookType },
+    });
+
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => { stdout += d.toString(); });
+    proc.stderr.on('data', (d) => { stderr += d.toString(); });
+    proc.on('close', (code) => resolve({ stdout, stderr, code }));
+    proc.on('error', reject);
+
+    proc.stdin.write(JSON.stringify(hookData));
+    proc.stdin.end();
+  });
+}
+
+function getTicketId() {
+  try {
+    const { execSync } = require('child_process');
+    const branch = execSync('git branch --show-current 2>/dev/null', { encoding: 'utf8' }).trim();
+    const match = branch.match(/[A-Z]+-\d+/);
+    return match ? match[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+function skipMarkerPath(ticketId) {
+  return path.join(MARKER_DIR, `check-skip-screenshots-${ticketId}`);
+}
+
+function cleanupMarker(ticketId) {
+  try { fs.unlinkSync(skipMarkerPath(ticketId)); } catch { /* */ }
+}
+
+function createFakeScreenshot(ticketId) {
+  const dir = `/home/node/worktrees/tasks/${ticketId}/screenshots`;
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'test.png'), 'fake');
+  return dir;
+}
+
+function cleanupScreenshots(ticketId) {
+  const dir = `/home/node/worktrees/tasks/${ticketId}/screenshots`;
+  try {
+    if (fs.existsSync(dir)) {
+      for (const f of fs.readdirSync(dir)) fs.unlinkSync(path.join(dir, f));
+      fs.rmdirSync(dir);
+    }
+  } catch { /* */ }
+}
+
+describe('enforce-screenshot-requirement', () => {
+  const ticketId = getTicketId();
+
+  beforeEach(() => {
+    if (ticketId) {
+      cleanupMarker(ticketId);
+      cleanupScreenshots(ticketId);
+    }
+  });
+
+  afterEach(() => {
+    if (ticketId) {
+      cleanupMarker(ticketId);
+      cleanupScreenshots(ticketId);
+    }
+  });
+
+  // ─── Blocking tests (require being on a ticket branch with TSX changes) ───
+
+  describe('PreToolUse — blocks QA agents', () => {
+    it('blocks pr-generator', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'pr-generator', prompt: 'create PR' } });
+      assert.equal(r.code, 2);
+      assert.match(r.stderr, /BLOCKED/);
+    });
+
+    it('does NOT block completion-checker (code quality, not screenshots)', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'completion-checker', prompt: 'verify' } });
+      assert.equal(r.code, 0);
+    });
+
+    it('blocks qa-feature-tester', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'qa-feature-tester', prompt: 'test' } });
+      assert.equal(r.code, 2);
+    });
+
+    it('blocks pr-post-generator', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'pr-post-generator', prompt: 'post' } });
+      assert.equal(r.code, 2);
+    });
+
+    it('blocks work-pr skill', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'Skill', tool_input: { skill: 'work-pr', args: '' } });
+      assert.equal(r.code, 2);
+    });
+
+    it('blocks check-qa skill', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'Skill', tool_input: { skill: 'check-qa', args: '' } });
+      assert.equal(r.code, 2);
+    });
+
+    it('blocks check-browser skill', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'Skill', tool_input: { skill: 'check-browser', args: '' } });
+      assert.equal(r.code, 2);
+    });
+
+    it('allows prompt matching "requirements verif" (not screenshot-related)', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'general-purpose', prompt: 'requirements verification' } });
+      assert.equal(r.code, 0);
+    });
+
+    it('blocks prompt matching "screenshot"', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'general-purpose', prompt: 'take screenshot of the app' } });
+      assert.equal(r.code, 2);
+    });
+  });
+
+  // ─── Pass-through tests ───
+
+  describe('PreToolUse — allows non-QA agents', () => {
+    it('allows developer-nodejs-tdd', async () => {
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'developer-nodejs-tdd', prompt: 'implement' } });
+      assert.equal(r.code, 0);
+    });
+
+    it('allows code-checker', async () => {
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'code-checker', prompt: 'review' } });
+      assert.equal(r.code, 0);
+    });
+
+    it('allows commit-writer', async () => {
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'commit-writer', prompt: 'commit' } });
+      assert.equal(r.code, 0);
+    });
+
+    it('allows unrelated skills', async () => {
+      const r = await runHook({ tool_name: 'Skill', tool_input: { skill: 'commit', args: '' } });
+      assert.equal(r.code, 0);
+    });
+
+    it('allows non-Task/Skill tools', async () => {
+      const r = await runHook({ tool_name: 'Bash', tool_input: { command: 'echo hi' } });
+      assert.equal(r.code, 0);
+    });
+  });
+
+  describe('PreToolUse — allows when screenshots exist', () => {
+    it('allows pr-generator when screenshots present', async () => {
+      if (!ticketId) return;
+      createFakeScreenshot(ticketId);
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'pr-generator', prompt: 'create PR' } });
+      assert.equal(r.code, 0);
+    });
+  });
+
+  describe('PreToolUse — allows when skip marker exists', () => {
+    it('allows pr-generator when skip marker present', async () => {
+      if (!ticketId) return;
+      fs.writeFileSync(skipMarkerPath(ticketId), JSON.stringify({ ticketId }));
+      const r = await runHook({ tool_name: 'Task', tool_input: { subagent_type: 'pr-generator', prompt: 'create PR' } });
+      assert.equal(r.code, 0);
+    });
+  });
+
+  // ─── PostToolUse — AskUserQuestion unblock ───
+
+  describe('PostToolUse — skip detection', () => {
+    it('writes skip marker for "Skip screenshots"', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'AskUserQuestion', tool_input: {}, tool_output: 'Skip screenshots' }, 'PostToolUse');
+      assert.equal(r.code, 0);
+      assert.match(r.stderr, /Skip-screenshots marker/);
+      assert.ok(fs.existsSync(skipMarkerPath(ticketId)));
+    });
+
+    it('writes skip marker for "SKIP SCREENSHOTS"', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'AskUserQuestion', tool_input: {}, tool_output: 'SKIP SCREENSHOTS' }, 'PostToolUse');
+      assert.ok(fs.existsSync(skipMarkerPath(ticketId)));
+    });
+
+    it('writes skip marker from JSON-structured output', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'AskUserQuestion', tool_input: {}, tool_output: { selected: 'Skip screenshots' } }, 'PostToolUse');
+      assert.ok(fs.existsSync(skipMarkerPath(ticketId)));
+    });
+
+    it('writes skip marker from tool_result fallback', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'AskUserQuestion', tool_input: {}, tool_result: 'Skip screenshots' }, 'PostToolUse');
+      assert.ok(fs.existsSync(skipMarkerPath(ticketId)));
+    });
+
+    it('writes skip marker from tool_response fallback', async () => {
+      if (!ticketId) return;
+      const r = await runHook({ tool_name: 'AskUserQuestion', tool_input: {}, tool_response: 'skip the screenshot step' }, 'PostToolUse');
+      assert.ok(fs.existsSync(skipMarkerPath(ticketId)));
+    });
+
+    it('does NOT write marker for "Capture screenshots now"', async () => {
+      if (!ticketId) return;
+      await runHook({ tool_name: 'AskUserQuestion', tool_input: {}, tool_output: 'Capture screenshots now' }, 'PostToolUse');
+      assert.ok(!fs.existsSync(skipMarkerPath(ticketId)));
+    });
+
+    it('does NOT write marker for "Abort"', async () => {
+      if (!ticketId) return;
+      await runHook({ tool_name: 'AskUserQuestion', tool_input: {}, tool_output: 'Abort' }, 'PostToolUse');
+      assert.ok(!fs.existsSync(skipMarkerPath(ticketId)));
+    });
+  });
+
+  // ─── Edge cases ───
+
+  describe('Edge cases', () => {
+    it('handles missing tool_input', async () => {
+      const r = await runHook({ tool_name: 'Task' });
+      assert.equal(r.code, 0);
+    });
+
+    it('handles empty hookData', async () => {
+      const r = await runHook({});
+      assert.equal(r.code, 0);
+    });
+
+    it('ignores PostToolUse on non-AskUserQuestion', async () => {
+      const r = await runHook({ tool_name: 'Bash', tool_input: { command: 'test' } }, 'PostToolUse');
+      assert.equal(r.code, 0);
+    });
+  });
+});

--- a/hooks/enforce-screenshot-requirement.js
+++ b/hooks/enforce-screenshot-requirement.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+/**
+ * Enforce screenshot requirement for UI changes.
+ *
+ * PreToolUse on Task/Skill:
+ *   If TSX/JSX source files changed vs base branch and no screenshots
+ *   exist in the tasks folder, BLOCK QA-completing agents and skills.
+ *
+ * PostToolUse on AskUserQuestion:
+ *   If user chose to skip, writes skip marker to unblock.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const MARKER_DIR = '/tmp';
+const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
+
+// Per-process cache to avoid re-fetching/re-diffing within same invocation
+let _cachedTsxChanges = undefined;
+
+function getTicketId() {
+  try {
+    const branch = execSync('git branch --show-current 2>/dev/null', { encoding: 'utf8' }).trim();
+    const match = branch.match(/[A-Z]+-\d+/);
+    return match ? match[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+function skipMarkerPath(ticketId) {
+  return path.join(MARKER_DIR, `check-skip-screenshots-${ticketId}`);
+}
+
+/**
+ * Resolve the base branch ref. Fetches default branch refs, then probes candidates.
+ * Returns the ref string or null if none found.
+ */
+function resolveBaseRef() {
+  try {
+    execSync('git fetch origin --depth=1 2>/dev/null', { timeout: 15000 });
+  } catch { /* offline or no remote */ }
+
+  const candidates = ['origin/main', 'origin/HEAD', 'main', 'master'];
+  for (const ref of candidates) {
+    try {
+      execSync(`git rev-parse --verify ${ref} 2>/dev/null`, { encoding: 'utf8', timeout: 5000 });
+      return ref;
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
+function hasTsxChanges() {
+  if (_cachedTsxChanges !== undefined) return _cachedTsxChanges;
+
+  const baseRef = resolveBaseRef();
+  if (!baseRef) {
+    _cachedTsxChanges = true; // fail closed
+    return true;
+  }
+
+  try {
+    const diff = execSync(`git diff --name-only ${baseRef}...HEAD -- "*.tsx" "*.jsx" 2>/dev/null`, {
+      encoding: 'utf8',
+      timeout: 10000
+    }).trim();
+    if (!diff) {
+      _cachedTsxChanges = false;
+      return false;
+    }
+    _cachedTsxChanges = diff.split('\n').some(f =>
+      !f.includes('.test.') &&
+      !f.includes('.spec.') &&
+      !f.includes('.stories.') &&
+      !f.includes('__tests__') &&
+      !f.includes('.d.ts')
+    );
+    return _cachedTsxChanges;
+  } catch {
+    _cachedTsxChanges = true; // fail closed
+    return true;
+  }
+}
+
+/**
+ * Stack-based recursive directory walk for screenshot detection.
+ * Compatible with Node < 18.17 (no recursive readdirSync needed).
+ */
+function hasScreenshots(ticketId) {
+  const root = `/home/node/worktrees/tasks/${ticketId}/screenshots`;
+  try {
+    if (!fs.existsSync(root)) return false;
+    const stack = [root];
+    while (stack.length) {
+      const dir = stack.pop();
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const ent of entries) {
+        if (ent.isDirectory()) {
+          stack.push(path.join(dir, ent.name));
+        } else if (IMAGE_EXTS.has(path.extname(ent.name).toLowerCase())) {
+          return true;
+        }
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function blockIfNoScreenshots(hookData) {
+  const ticketId = getTicketId();
+  if (!ticketId) return;
+  if (fs.existsSync(skipMarkerPath(ticketId))) return;
+  if (!hasTsxChanges()) return;
+  if (hasScreenshots(ticketId)) return;
+
+  const toolName = hookData.tool_name || '';
+  const prompt = (hookData.tool_input?.prompt || '').toLowerCase();
+  const skill = (hookData.tool_input?.skill || '').toLowerCase();
+  const subagentType = hookData.tool_input?.subagent_type || '';
+
+  const isQaAgent = toolName === 'Task' && (
+    subagentType === 'qa-feature-tester' ||
+    subagentType === 'pr-generator' ||
+    subagentType === 'pr-post-generator' ||
+    /screenshot|qa.*report/i.test(prompt)
+  );
+
+  const isCompletingSkill = toolName === 'Skill' && (
+    /work-pr|check-qa|check-browser/i.test(skill)
+  );
+
+  if (!isQaAgent && !isCompletingSkill) return;
+
+  process.stderr.write(
+    'BLOCKED: TSX/JSX files changed but NO screenshots found in ' +
+    `/home/node/worktrees/tasks/${ticketId}/screenshots/. ` +
+    'You MUST capture screenshots before completing QA or creating a PR. ' +
+    'Call AskUserQuestion with options: ' +
+    '"Capture screenshots now" (use Playwright to take screenshots) | ' +
+    '"Skip screenshots" (continue without, mark as SKIPPED) | ' +
+    '"Abort" (stop workflow). ' +
+    'Do NOT proceed without user input.\n'
+  );
+  process.exit(2);
+}
+
+function unblockAfterChoice(hookData) {
+  const ticketId = getTicketId();
+  if (!ticketId) return;
+  if (hasScreenshots(ticketId)) return;
+  if (!hasTsxChanges()) return;
+
+  const output = hookData.tool_output ?? hookData.tool_result ?? hookData.tool_response ?? '';
+  const outputStr = typeof output === 'string' ? output : JSON.stringify(output);
+
+  const choseSkip = /skip/i.test(outputStr) && /screenshot/i.test(outputStr);
+  if (choseSkip) {
+    fs.writeFileSync(skipMarkerPath(ticketId), JSON.stringify({
+      ticketId,
+      timestamp: new Date().toISOString()
+    }));
+    process.stderr.write('Skip-screenshots marker written. Workflow unblocked.\n');
+  }
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  const hookData = JSON.parse(input);
+  const hookType = process.env.CLAUDE_HOOK_TYPE || 'PostToolUse';
+  const toolName = hookData.tool_name || '';
+
+  if (hookType === 'PreToolUse' && (toolName === 'Task' || toolName === 'Skill')) {
+    blockIfNoScreenshots(hookData);
+  } else if (hookType === 'PostToolUse' && toolName === 'AskUserQuestion') {
+    unblockAfterChoice(hookData);
+  }
+}
+
+main().catch(() => {});


### PR DESCRIPTION
## Existing Behavior
- No enforcement mechanism for screenshot requirements in UI-related changes
- QA agents and PR creation workflows could proceed without visual documentation when TSX/JSX files were modified
- No systematic way to validate screenshot compliance before completing work

## Intended New Behavior
- Hook blocks QA-completing agents (pr-generator, qa-feature-tester, pr-post-generator) when TSX/JSX source files change without corresponding screenshots
- Provides user choice via AskUserQuestion: capture screenshots, skip with marker, or abort workflow
- Writes skip marker to /tmp when user explicitly chooses to skip screenshots, unblocking subsequent QA operations
- Uses stack-based recursive directory walking for screenshot detection (compatible with Node < 18.17)
- Implements per-process caching to avoid redundant git operations within the same hook invocation

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo
1. Run the test suite to verify hook behavior:
   ```bash
   node --test hooks/__tests__/enforce-screenshot-requirement.test.js
   ```
   Expected: All 26 tests pass (blocking QA agents, allowing non-QA agents, skip marker detection, edge cases)

2. Manual functional test on a ticket branch with UI changes:
   - Create a feature branch with TSX file changes (e.g., `git checkout -b test/ui-changes`)
   - Modify a TSX component file
   - Attempt to call pr-generator or qa-feature-tester without screenshots
   - Expected: Hook blocks with error message directing to AskUserQuestion
   - Add screenshots to `/home/node/worktrees/tasks/<TICKET-ID>/screenshots/`
   - Retry QA agent
   - Expected: Hook allows operation to proceed

3. Skip marker verification:
   - On blocked workflow, call AskUserQuestion with "Skip screenshots" option
   - Expected: Skip marker written to `/tmp/check-skip-screenshots-<TICKET-ID>`
   - Retry QA agent
   - Expected: Hook allows operation (workflow unblocked)

### Test Results
Test suite output:
```
▶ enforce-screenshot-requirement
  ✔ PreToolUse — blocks QA agents (26 tests)
  ✔ PreToolUse — allows non-QA agents
  ✔ PreToolUse — allows when screenshots exist
  ✔ PreToolUse — allows when skip marker exists
  ✔ PostToolUse — skip detection
  ✔ Edge cases
✔ tests 26 pass 26 fail 0
```