### PR TITLE
fix(skills): correct tool references and argument-hint formatting

### DIFF
--- a/skills/check-browser/SKILL.md
+++ b/skills/check-browser/SKILL.md
@@ -3,7 +3,7 @@ name: check-browser
 description: Verify browser/UI state using API-first approach with browser fallback
 argument-hint: <question>
 user-invocable: true
-allowed-tools: Bash, Read, mcp__playwright_headed__browser_navigate, mcp__playwright_headed__browser_snapshot, mcp__playwright_headed__browser_evaluate, mcp__playwright_headed__browser_take_screenshot
+allowed-tools: Bash, Read, mcp__playwright__browser_navigate, mcp__playwright__browser_snapshot, mcp__playwright__browser_evaluate, mcp__playwright__browser_take_screenshot
 ---
 
 # Browser Verification Command

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check
-argument-hint: [jira-ticket-id]
+argument-hint: jira-ticket-id
 description: Run full quality check - QA testing, code review, and requirements verification in parallel
 user-invocable: true
 allowed-tools: Task, Bash, Read, Write, Edit, Grep, Glob, TodoWrite, Skill, AskUserQuestion, mcp__atlassian__jira_get_issue, mcp__playwright__browser_navigate, mcp__playwright__browser_snapshot, mcp__playwright__browser_click, mcp__playwright__browser_type, mcp__playwright__browser_fill_form, mcp__playwright__browser_take_screenshot


### PR DESCRIPTION
## Existing Behavior
- check-browser skill references headed playwright tools (mcp__playwright_headed__*) which don't exist in the current configuration
- check skill uses brackets in argument-hint field ([jira-ticket-id]) which is inconsistent with other skills
- Tool invocations fail when check-browser tries to use non-existent headed tools

## Intended New Behavior
- check-browser skill uses correct non-headed playwright tools (mcp__playwright__*) that are actually available
- check skill uses clean argument-hint without brackets (jira-ticket-id) matching the convention used by other skills
- Browser verification commands work correctly with proper tool references

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo
1. Verify check-browser skill metadata is valid:
   - Review skills/check-browser/SKILL.md and confirm allowed-tools only references mcp__playwright__* tools
   - Confirm no mcp__playwright_headed__* references remain
2. Verify check skill metadata is valid:
   - Review skills/check/SKILL.md and confirm argument-hint has no brackets
   - Compare with other skills to verify consistency
3. Test skill invocation:
   - Run a command that uses check-browser skill
   - Verify playwright tools are invoked successfully without tool-not-found errors