### PR TITLE
fix(commit-writer): use PLUGIN_ROOT and fail-fast on parsing errors

### DIFF
--- a/agents/commit-writer.md
+++ b/agents/commit-writer.md
@@ -9,7 +9,7 @@ hooks:
     - matcher: ".*"
       hooks:
         - type: command
-          command: "sh -c 'node $HOME/.claude/plugins/work-workflow/hooks/agents/commit-writer/commit-writer-block-write.js'"
+          command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/agents/commit-writer/commit-writer-block-write.js"
 ---
 
 You are a Git Commit Expert. Analyze staged changes, create semantic commit messages, commit, and push.

--- a/hooks/agents/commit-writer/commit-writer-block-write.js
+++ b/hooks/agents/commit-writer/commit-writer-block-write.js
@@ -10,11 +10,6 @@
  *   exit 2  = block the tool call (stderr message fed back to Claude)
  */
 
-// CANARY: write to log file to prove hook is executing
-const fs = require('fs');
-const logFile = '/tmp/commit-writer-hook-canary.log';
-fs.appendFileSync(logFile, `[${new Date().toISOString()}] Hook invoked\n`);
-
 async function main() {
   let input = '';
   for await (const chunk of process.stdin) {
@@ -24,8 +19,9 @@ async function main() {
   let hookData;
   try {
     hookData = JSON.parse(input);
-  } catch {
-    process.exit(0); // Can't parse input — don't block
+  } catch (err) {
+    process.stderr.write(`COMMIT-WRITER GUARD: Failed to parse hook input: ${err.message}\n`);
+    process.exit(2);
   }
 
   const toolName = hookData.tool_name || '';
@@ -88,4 +84,7 @@ async function main() {
   process.exit(2);
 }
 
-main().catch(() => process.exit(0));
+main().catch((err) => {
+  process.stderr.write(`COMMIT-WRITER GUARD ERROR: ${err.message}\n`);
+  process.exit(2);
+});

--- a/hooks/agents/commit-writer/commit-writer-block-write.spec.js
+++ b/hooks/agents/commit-writer/commit-writer-block-write.spec.js
@@ -42,6 +42,24 @@ function execHook(input) {
   }
 }
 
+/** Pipe raw string input into the hook (for malformed JSON tests) */
+function execHookRaw(rawInput) {
+  const escaped = rawInput.replace(/'/g, "'\\''");
+  try {
+    const stdout = execSync(`echo '${escaped}' | node "${HOOK}"`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { exitCode: 0, stdout: stdout.trim(), stderr: '' };
+  } catch (err) {
+    return {
+      exitCode: err.status,
+      stdout: (err.stdout || '').trim(),
+      stderr: (err.stderr || '').trim(),
+    };
+  }
+}
+
 function describe(suite, fn) {
   console.log(`\n  ${suite}`);
   fn();
@@ -158,6 +176,21 @@ describe('non-Bash tools → exit 2 (block)', () => {
       assert.match(r.stderr, /not allowed/);
     });
   }
+});
+
+describe('malformed input → exit 2 (fail-fast)', () => {
+  it('should exit 2 on malformed JSON', () => {
+    const r = execHookRaw('{invalid');
+    assert.strictEqual(r.exitCode, 2, `Expected exit 2, got ${r.exitCode}`);
+    assert.match(r.stderr, /COMMIT-WRITER GUARD/, 'stderr should contain guard message');
+    assert.match(r.stderr, /Failed to parse/, 'stderr should mention parse failure');
+  });
+
+  it('should exit 2 on empty stdin', () => {
+    const r = execHookRaw('');
+    assert.strictEqual(r.exitCode, 2, `Expected exit 2, got ${r.exitCode}`);
+    assert.match(r.stderr, /COMMIT-WRITER GUARD/, 'stderr should contain guard message');
+  });
 });
 
 describe('edge cases', () => {

--- a/hooks/agents/commit-writer/commit-writer-preflight.js
+++ b/hooks/agents/commit-writer/commit-writer-preflight.js
@@ -82,8 +82,9 @@ async function main() {
   let hookData;
   try {
     hookData = JSON.parse(input);
-  } catch {
-    process.exit(0);
+  } catch (err) {
+    process.stderr.write(`COMMIT-WRITER PREFLIGHT: Failed to parse hook input: ${err.message}\n`);
+    process.exit(2);
   }
 
   // Only intercept Task tool calls
@@ -147,4 +148,7 @@ async function main() {
   process.exit(0);
 }
 
-main().catch(() => process.exit(0));
+main().catch((err) => {
+  process.stderr.write(`COMMIT-WRITER PREFLIGHT ERROR: ${err.message}\n`);
+  process.exit(2);
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -79,6 +79,15 @@
             "command": "CLAUDE_HOOK_TYPE=PreToolUse node ${CLAUDE_PLUGIN_ROOT}/hooks/work-enforce-steps.js"
           }
         ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/agents/commit-writer/commit-writer-preflight.js"
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
## Existing Behavior
- Hook paths use hardcoded absolute paths which fail when the plugin is installed in non-standard locations
- Parsing errors in commit-writer hooks silently exit with code 0, allowing malformed input to pass through without validation
- Unhandled promise rejections in hook main functions exit with code 0, masking runtime errors
- Canary debug logging remains in production code

## Intended New Behavior
- Hook paths dynamically resolve via PLUGIN_ROOT environment variable for portable plugin installation across environments
- Parsing errors fail-fast with exit code 2 and emit descriptive stderr messages
- Promise rejections propagate as exit code 2 with error messages to stderr, ensuring failures surface to LLM
- Debug canary logging removed from commit-writer-block-write.js for cleaner production code

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo
1. Run the commit-writer hook test suite to verify all 51 specs pass
2. Verify hook registration uses portable path syntax
3. Test fail-fast behavior with malformed JSON input
4. Verify hooks function correctly when commit-writer agent is invoked with staged changes