### PR TITLE
chore(release): bump version to 2.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
-    "version": "2.1.0"
+    "version": "2.2.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Self-contained workflow plugin with agents, hooks, skills, and orchestration. Includes 16 specialized agents, agent-specific hooks, and 23 skills.",
   "author": {
     "name": "Custom",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Existing Behavior

- Version is set to `2.1.0` in `plugin.json` and `marketplace.json`
- Version is set to `2.1.2` in `package.json`
- Version identifiers across the three manifest files are inconsistent with each other

## Intended New Behavior

- Version is unified to `2.2.0` across `package.json`, `plugin.json`, and `marketplace.json`
- This version bump accompanies the PR review comment polling and feedback addressing feature merged in #13

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Verify `plugin.json` reports `"version": "2.2.0"`
2. Verify `marketplace.json` reports `"version": "2.2.0"` under `metadata`
3. Verify `package.json` reports `"version": "2.2.0"`
4. Confirm all three files are consistent with one another — no version drift
