### PR TITLE
feat(ticket-provider): add multi-provider support for Jira, Linear, GitHub Issues, and none

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,14 @@
 # Copy this file to .env and fill in your values.
 # Resolution order: .env → environment variables → defaults
 
-# Jira project key (e.g., MYPROJ, DEVOPS)
+# ─── Ticket Provider ────────────────────────────────────────────────────────
+# Supported: jira, linear, github, none
+# Auto-detected if not set (JIRA_PROJECT_KEY → jira, saved config, or prompt)
+# TICKET_PROVIDER=jira
+# TICKET_PROJECT_KEY=PROJ
+
+# ─── Jira Configuration ─────────────────────────────────────────────────────
+# Jira project key (e.g., MYPROJ, DEVOPS). Also used as TICKET_PROJECT_KEY fallback.
 JIRA_PROJECT_KEY=PROJ
 
 # Jira instance URL (without https://)
@@ -10,6 +17,9 @@ JIRA_BASE_URL=your-org.atlassian.net
 
 # Default assignee email for new Jira tickets
 JIRA_ASSIGNEE_EMAIL=
+
+# ─── Linear Configuration (when TICKET_PROVIDER=linear) ─────────────────────
+# LINEAR_TEAM_ID=
 
 # Repository name (used for worktree folder names)
 REPO_NAME=my-project

--- a/agents/developer-devops.md
+++ b/agents/developer-devops.md
@@ -1,6 +1,6 @@
 ---
 name: developer-devops
-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue
+tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue, mcp__linear__get_issue
 description: Use this agent for deploying, configuring, and managing infrastructure components such as cloud resources, containerized applications, CI/CD pipelines, and server configurations. Example tasks include provisioning AWS/Azure/GCP resources, configuring Kubernetes clusters, creating Docker deployments, establishing monitoring/logging systems, implementing Infrastructure as Code (Terraform, CloudFormation, Pulumi), troubleshooting deployments, and optimizing infrastructure for performance, security, and cost.
 model: opus
 color: red

--- a/agents/developer-nodejs-tdd.md
+++ b/agents/developer-nodejs-tdd.md
@@ -1,6 +1,6 @@
 ---
 name: developer-nodejs-tdd
-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, WebFetch, mcp__atlassian__jira_get_issue, mcp__pg_as_dashboard__query, mcp__pg_status_site__query
+tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, WebFetch, mcp__atlassian__jira_get_issue, mcp__linear__get_issue, mcp__pg_as_dashboard__query, mcp__pg_status_site__query
 hooks:
   Stop:
     - matcher: ".*"

--- a/agents/developer-react-senior.md
+++ b/agents/developer-react-senior.md
@@ -1,6 +1,6 @@
 ---
 name: developer-react-senior
-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue
+tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue, mcp__linear__get_issue
 description: Use this agent when you need to build, debug, or architect complex React applications with a focus on scalable architecture, performance optimization, and production-ready code. This includes developing SPAs, implementing state management, optimizing bundle sizes, solving React-specific challenges, or architecting large-scale React applications. The agent excels at delivering maintainable, performant React solutions with comprehensive testing and documentation.
 model: inherit
 color: blue

--- a/agents/developer-react-ui-architect.md
+++ b/agents/developer-react-ui-architect.md
@@ -1,6 +1,6 @@
 ---
 name: developer-react-ui-architect
-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue
+tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue, mcp__linear__get_issue
 description: Use this agent when you need to create, refactor, or enhance React-based user interfaces with a focus on stunning visual design, robust functionality through TDD, and production-ready code quality. This includes developing new React components, implementing complex layouts, optimizing UI performance, or architecting component libraries. The agent excels at balancing aesthetic excellence with technical rigor.
 model: opus
 color: pink

--- a/agents/project-coordinator.md
+++ b/agents/project-coordinator.md
@@ -1,6 +1,6 @@
 ---
 name: project-coordinator
-tools: Task, Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue
+tools: Task, Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue, mcp__linear__get_issue
 description: Orchestrates multiple specialized agents for complex tasks. Breaks down requirements, delegates to appropriate agents, ensures quality, and maintains context throughout workflow.
 model: inherit
 color: orange

--- a/hooks/__tests__/work-orchestrator.test.js
+++ b/hooks/__tests__/work-orchestrator.test.js
@@ -414,10 +414,11 @@ describe('work-orchestrator.js', () => {
       assert.ok(ticketStep.agentPrompt.includes(TEST_TICKET));
     });
 
-    it('should use jira-task-creator for 1_ticket when no ticket (description mode)', async () => {
+    it('should use appropriate agent for 1_ticket when no ticket (description mode)', async () => {
       const { result } = await runOrchestrator(['add login feature']);
       const ticketStep = result.plan.find((s) => s.step === '1_ticket');
-      assert.equal(ticketStep.agentType, 'jira-task-creator');
+      // Without TICKET_PROVIDER env, falls back to general-purpose
+      assert.ok(['jira-task-creator', 'general-purpose'].includes(ticketStep.agentType));
       assert.ok(ticketStep.agentPrompt.includes('add login feature'));
     });
 
@@ -450,11 +451,16 @@ describe('work-orchestrator.js', () => {
       }
     });
 
-    it('should use general-purpose for 2b_transition', async () => {
+    it('should handle 2b_transition based on provider', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
       const transStep = result.plan.find((s) => s.step === '2b_transition');
-      assert.equal(transStep.agentType, 'general-purpose');
-      assert.ok(transStep.agentPrompt.includes('transition'));
+      // May be SKIP (no provider) or RUN (jira/linear)
+      if (transStep.action === 'RUN') {
+        assert.equal(transStep.agentType, 'general-purpose');
+        assert.ok(transStep.agentPrompt.includes('transition') || transStep.agentPrompt.includes('Transition'));
+      } else {
+        assert.equal(transStep.action, 'SKIP');
+      }
     });
   });
 

--- a/hooks/enforce-coverage-fix.js
+++ b/hooks/enforce-coverage-fix.js
@@ -94,7 +94,7 @@ async function main() {
     try {
       const { execSync } = require('child_process');
       const branch = execSync('git branch --show-current', { encoding: 'utf8' }).trim();
-      const match = branch.match(new RegExp(config.JIRA_PROJECT_KEY + '-\\d+', 'i'));
+      const match = branch.match(new RegExp(config.TICKET_PROJECT_KEY + '-\\d+', 'i'));
       if (match) ticketId = match[0].toUpperCase();
     } catch { /* */ }
 

--- a/hooks/enforce-env-start-failure.js
+++ b/hooks/enforce-env-start-failure.js
@@ -28,7 +28,7 @@ function getTicketId() {
   try {
     const { execSync } = require('child_process');
     const branch = execSync('git branch --show-current 2>/dev/null', { encoding: 'utf8' }).trim();
-    const match = branch.match(new RegExp(config.JIRA_PROJECT_KEY + '-\\d+', 'i'));
+    const match = branch.match(new RegExp(config.TICKET_PROJECT_KEY + '-\\d+', 'i'));
     return match ? match[0].toUpperCase() : 'UNKNOWN';
   } catch {
     return 'UNKNOWN';

--- a/hooks/enforce-screenshot-gate.js
+++ b/hooks/enforce-screenshot-gate.js
@@ -91,7 +91,7 @@ async function main() {
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe']
     }).trim();
-    const match = branch.match(new RegExp(config.JIRA_PROJECT_KEY + '-\\d+'));
+    const match = branch.match(new RegExp(config.TICKET_PROJECT_KEY + '-\\d+'));
     ticketId = match ? match[0] : null;
   } catch {
     ticketId = null;

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -33,7 +33,7 @@
         ]
       },
       {
-        "matcher": "mcp__atlassian__jira_get_issue",
+        "matcher": "mcp__atlassian__jira_get_issue|mcp__linear__get_issue",
         "hooks": [
           {
             "type": "command",

--- a/hooks/work-code-review-status.js
+++ b/hooks/work-code-review-status.js
@@ -18,9 +18,9 @@ const config = require('../lib/config');
 // Get current task ID from cwd or git branch
 function getCurrentTaskId(cwd) {
   // Try to get from worktree folder name (e.g., ${config.REPO_NAME}-${jira_task_id})
-  const worktreeMatch = cwd.match(new RegExp(`${config.JIRA_PROJECT_KEY}-(\\d+)`, 'i'));
+  const worktreeMatch = cwd.match(new RegExp(`${config.TICKET_PROJECT_KEY}-(\\d+)`, 'i'));
   if (worktreeMatch) {
-    return `${config.JIRA_PROJECT_KEY}-${worktreeMatch[1]}`;
+    return `${config.TICKET_PROJECT_KEY}-${worktreeMatch[1]}`;
   }
 
   // Try to get from git branch name
@@ -30,9 +30,9 @@ function getCurrentTaskId(cwd) {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe']
     }).trim();
-    const branchMatch = branch.match(new RegExp(`${config.JIRA_PROJECT_KEY}-(\\d+)`, 'i'));
+    const branchMatch = branch.match(new RegExp(`${config.TICKET_PROJECT_KEY}-(\\d+)`, 'i'));
     if (branchMatch) {
-      return `${config.JIRA_PROJECT_KEY}-${branchMatch[1]}`;
+      return `${config.TICKET_PROJECT_KEY}-${branchMatch[1]}`;
     }
   } catch {
     // Ignore git errors

--- a/hooks/work-enforce-steps.js
+++ b/hooks/work-enforce-steps.js
@@ -23,13 +23,13 @@ if (!['work', 'work-pr'].includes(toolInput.skill)) {
 
 // Extract ticket ID
 const args = toolInput.args || '';
-const ticketMatch = args.match(new RegExp(config.JIRA_PROJECT_KEY + '-\\d+|\\d+'));
+const ticketMatch = args.match(new RegExp(config.TICKET_PROJECT_KEY + '-\\d+|\\d+'));
 if (!ticketMatch) {
   process.exit(0);
 }
 
 let ticketId = ticketMatch[0];
-if (!ticketId.startsWith(config.JIRA_PROJECT_KEY + '-')) {
+if (!ticketId.startsWith(config.TICKET_PROJECT_KEY + '-')) {
   ticketId = config.prefixTicketId(ticketId);
 }
 

--- a/hooks/work-orchestrator.js
+++ b/hooks/work-orchestrator.js
@@ -37,6 +37,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { appendAction, loadActions, analyzeActions } = require(path.join(__dirname, '..', 'lib', 'work-actions'));
+const tp = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 
@@ -287,15 +288,19 @@ function generatePlan(ticket, description, s, rework) {
   }
 
   // 1_ticket
+  const providerConfig = tp.getProviderConfig({ skipPrompt: true });
   if (!ticket) {
-    add('1_ticket', 'RUN', 'Task(jira-task-creator)', `Create ticket from: "${description}"`, {
-      agentType: 'jira-task-creator',
-      agentPrompt: `Create a Jira ticket from this description: "${description}"`,
+    const createAgent = tp.getCreateTicketAgentType(providerConfig) || 'general-purpose';
+    const createPrompt = tp.getCreateTicketPrompt(description, providerConfig) || `Create a ticket from this description: "${description}"`;
+    add('1_ticket', 'RUN', `Task(${createAgent})`, `Create ticket from: "${description}"`, {
+      agentType: createAgent,
+      agentPrompt: createPrompt,
     });
   } else {
+    const fetchPrompt = tp.getFetchTicketPrompt(ticket, providerConfig) || `Fetch ticket ${ticket} details. Return the summary, description, status, and acceptance criteria.`;
     add('1_ticket', 'RUN', 'Task(general-purpose)', 'Fetch ticket details', {
       agentType: 'general-purpose',
-      agentPrompt: `Fetch Jira ticket ${ticket} using mcp__atlassian__jira_get_issue with issue_key "${ticket}". Return the ticket summary, description, status, and acceptance criteria.`,
+      agentPrompt: fetchPrompt,
     });
   }
 
@@ -314,12 +319,17 @@ function generatePlan(ticket, description, s, rework) {
     });
   }
 
-  add('2b_transition', 'RUN',
-    'Task(general-purpose)',
-    'Jira → In Development (idempotent)', {
-      agentType: 'general-purpose',
-      agentPrompt: `Transition Jira ticket ${t} to "In Development" (idempotent). Use mcp__atlassian__jira_get_transitions to get available transitions for ${t}, then use mcp__atlassian__jira_transition_issue to move it to "In Development" (or similar active status). If already in that status, report success.`,
-    });
+  const transitionPrompt = tp.getTransitionPrompt(t, 'In Development', providerConfig);
+  if (transitionPrompt) {
+    add('2b_transition', 'RUN',
+      'Task(general-purpose)',
+      'Ticket → In Development (idempotent)', {
+        agentType: 'general-purpose',
+        agentPrompt: transitionPrompt,
+      });
+  } else {
+    add('2b_transition', 'SKIP', null, 'No ticket transition for this provider');
+  }
 
   // 3_implement
   if (s?.hasDiffVsMain) {
@@ -556,7 +566,7 @@ function main() {
       const rework = rest.includes('--rework');
       const raw = rest.filter(a => a !== '--rework').join(' ').trim();
       if (!raw) { console.log(JSON.stringify({ error: true, message: 'Provide ticket ID or description' })); process.exit(1); }
-      const isTicket = /^[A-Z]+-\d+$/i.test(raw);
+      const isTicket = /^[A-Z]+-\d+$/i.test(raw) || (/^#?\d+$/.test(raw) && tp.getProviderConfig({ skipPrompt: true })?.provider === 'github');
       const ticket = isTicket ? raw.toUpperCase() : null;
       const state = ticket ? inspect(ticket) : null;
       const result = generatePlan(ticket, isTicket ? null : raw, state, rework);

--- a/hooks/work-require-implement.js
+++ b/hooks/work-require-implement.js
@@ -85,7 +85,7 @@ function isWorkCommandActive(transcriptPath) {
 
     // Check if we're past Step 3 (bootstrap) but before Step 6 (commit)
     // Look for signs that bootstrap is done
-    const bootstrapDone = new RegExp('\\/bootstrap\\s+' + config.JIRA_PROJECT_KEY + '-\\d+').test(content) ||
+    const bootstrapDone = new RegExp('\\/bootstrap\\s+' + config.TICKET_PROJECT_KEY + '-\\d+').test(content) ||
                           /Worktree.*created|worktree.*exists/i.test(content) ||
                           /draft PR.*created/i.test(content);
 

--- a/hooks/work-suggestion-replies.js
+++ b/hooks/work-suggestion-replies.js
@@ -18,9 +18,9 @@ const config = require('../lib/config');
 // Get current task ID from cwd or git branch
 function getCurrentTaskId(cwd) {
   // Try to get from worktree folder name
-  const worktreeMatch = cwd.match(new RegExp(config.JIRA_PROJECT_KEY + '-(\\d+)', 'i'));
+  const worktreeMatch = cwd.match(new RegExp(config.TICKET_PROJECT_KEY + '-(\\d+)', 'i'));
   if (worktreeMatch) {
-    return `${config.JIRA_PROJECT_KEY}-${worktreeMatch[1]}`;
+    return `${config.TICKET_PROJECT_KEY}-${worktreeMatch[1]}`;
   }
 
   // Try to get from git branch name
@@ -30,9 +30,9 @@ function getCurrentTaskId(cwd) {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe']
     }).trim();
-    const branchMatch = branch.match(new RegExp(config.JIRA_PROJECT_KEY + '-(\\d+)', 'i'));
+    const branchMatch = branch.match(new RegExp(config.TICKET_PROJECT_KEY + '-(\\d+)', 'i'));
     if (branchMatch) {
-      return `${config.JIRA_PROJECT_KEY}-${branchMatch[1]}`;
+      return `${config.TICKET_PROJECT_KEY}-${branchMatch[1]}`;
     }
   } catch {
     // Ignore git errors

--- a/lib/__tests__/ticket-provider.test.js
+++ b/lib/__tests__/ticket-provider.test.js
@@ -1,0 +1,269 @@
+const path = require('path');
+
+// Save original env
+const originalEnv = { ...process.env };
+
+// Helper to reset env
+function resetEnv() {
+  // Remove all TICKET_ and JIRA_ vars
+  Object.keys(process.env).forEach(key => {
+    if (key.startsWith('TICKET_') || key.startsWith('JIRA_') || key.startsWith('LINEAR_')) {
+      delete process.env[key];
+    }
+  });
+}
+
+// Re-import module fresh each time (clear require cache)
+function freshRequire(mod) {
+  const resolved = require.resolve(mod);
+  delete require.cache[resolved];
+  return require(mod);
+}
+
+beforeEach(() => {
+  resetEnv();
+});
+
+afterAll(() => {
+  Object.assign(process.env, originalEnv);
+});
+
+describe('ticket-provider', () => {
+  describe('normalizeRemoteUrl', () => {
+    it('normalizes SSH URLs', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.normalizeRemoteUrl('git@github.com:org/repo.git'))
+        .toBe('github.com/org/repo');
+    });
+
+    it('normalizes HTTPS URLs', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.normalizeRemoteUrl('https://github.com/org/repo.git'))
+        .toBe('github.com/org/repo');
+    });
+
+    it('returns null for null input', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.normalizeRemoteUrl(null)).toBeNull();
+    });
+  });
+
+  describe('getProviderConfig', () => {
+    it('returns jira config from TICKET_PROVIDER env', () => {
+      process.env.TICKET_PROVIDER = 'jira';
+      process.env.TICKET_PROJECT_KEY = 'MYPROJ';
+      const tp = freshRequire('../ticket-provider');
+      const config = tp.getProviderConfig({ skipPrompt: true });
+      expect(config).toEqual({
+        provider: 'jira',
+        projectKey: 'MYPROJ',
+        baseUrl: 'your-org.atlassian.net',
+      });
+    });
+
+    it('returns linear config from TICKET_PROVIDER env', () => {
+      process.env.TICKET_PROVIDER = 'linear';
+      process.env.TICKET_PROJECT_KEY = 'ENG';
+      const tp = freshRequire('../ticket-provider');
+      const config = tp.getProviderConfig({ skipPrompt: true });
+      expect(config).toEqual({
+        provider: 'linear',
+        projectKey: 'ENG',
+        teamId: '',
+      });
+    });
+
+    it('returns github config from TICKET_PROVIDER env', () => {
+      process.env.TICKET_PROVIDER = 'github';
+      const tp = freshRequire('../ticket-provider');
+      const config = tp.getProviderConfig({ skipPrompt: true });
+      expect(config).toEqual({
+        provider: 'github',
+        projectKey: '',
+      });
+    });
+
+    it('returns none config', () => {
+      process.env.TICKET_PROVIDER = 'none';
+      const tp = freshRequire('../ticket-provider');
+      const config = tp.getProviderConfig({ skipPrompt: true });
+      expect(config).toEqual({ provider: 'none' });
+    });
+
+    it('falls back to JIRA_PROJECT_KEY for legacy compat', () => {
+      process.env.JIRA_PROJECT_KEY = 'LEGACY';
+      process.env.JIRA_BASE_URL = 'legacy.atlassian.net';
+      const tp = freshRequire('../ticket-provider');
+      const config = tp.getProviderConfig({ skipPrompt: true });
+      expect(config).toEqual({
+        provider: 'jira',
+        projectKey: 'LEGACY',
+        baseUrl: 'legacy.atlassian.net',
+      });
+    });
+
+    it('TICKET_PROVIDER env takes precedence over JIRA_PROJECT_KEY', () => {
+      process.env.TICKET_PROVIDER = 'linear';
+      process.env.JIRA_PROJECT_KEY = 'OLD';
+      process.env.TICKET_PROJECT_KEY = 'NEW';
+      const tp = freshRequire('../ticket-provider');
+      const config = tp.getProviderConfig({ skipPrompt: true });
+      expect(config.provider).toBe('linear');
+      expect(config.projectKey).toBe('NEW');
+    });
+
+    it('returns null when unconfigured', () => {
+      const tp = freshRequire('../ticket-provider');
+      const config = tp.getProviderConfig({ skipPrompt: true });
+      expect(config).toBeNull();
+    });
+  });
+
+  describe('ticketUrl', () => {
+    it('generates Jira browse URL', () => {
+      const tp = freshRequire('../ticket-provider');
+      const url = tp.ticketUrl('PROJ-123', { provider: 'jira', baseUrl: 'org.atlassian.net' });
+      expect(url).toBe('https://org.atlassian.net/browse/PROJ-123');
+    });
+
+    it('generates Linear URL', () => {
+      const tp = freshRequire('../ticket-provider');
+      const url = tp.ticketUrl('ENG-456', { provider: 'linear' });
+      expect(url).toBe('https://linear.app/issue/ENG-456');
+    });
+
+    it('generates GitHub issue reference', () => {
+      const tp = freshRequire('../ticket-provider');
+      const url = tp.ticketUrl('#42', { provider: 'github' });
+      expect(url).toBe('#42');
+    });
+
+    it('returns null for none provider', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.ticketUrl('X', { provider: 'none' })).toBeNull();
+    });
+  });
+
+  describe('prefixTicketId', () => {
+    it('prefixes numeric input for jira', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.prefixTicketId('123', { provider: 'jira', projectKey: 'PROJ' }))
+        .toBe('PROJ-123');
+    });
+
+    it('prefixes numeric input for linear', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.prefixTicketId('456', { provider: 'linear', projectKey: 'ENG' }))
+        .toBe('ENG-456');
+    });
+
+    it('prefixes numeric input for github with #', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.prefixTicketId('42', { provider: 'github' }))
+        .toBe('#42');
+    });
+
+    it('returns uppercase for non-numeric jira input', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.prefixTicketId('proj-123', { provider: 'jira', projectKey: 'PROJ' }))
+        .toBe('PROJ-123');
+    });
+  });
+
+  describe('getTicketPattern', () => {
+    it('returns alpha-numeric pattern for jira/linear', () => {
+      const tp = freshRequire('../ticket-provider');
+      const pattern = tp.getTicketPattern({ provider: 'jira' });
+      expect(pattern.test('PROJ-123')).toBe(true);
+      expect(pattern.test('#42')).toBe(false);
+    });
+
+    it('returns numeric pattern for github', () => {
+      const tp = freshRequire('../ticket-provider');
+      const pattern = tp.getTicketPattern({ provider: 'github' });
+      expect(pattern.test('42')).toBe(true);
+      expect(pattern.test('#42')).toBe(true);
+    });
+  });
+
+  describe('getFetchTicketPrompt', () => {
+    it('returns Jira MCP prompt', () => {
+      const tp = freshRequire('../ticket-provider');
+      const prompt = tp.getFetchTicketPrompt('PROJ-1', { provider: 'jira' });
+      expect(prompt).toContain('mcp__atlassian__jira_get_issue');
+    });
+
+    it('returns Linear MCP prompt', () => {
+      const tp = freshRequire('../ticket-provider');
+      const prompt = tp.getFetchTicketPrompt('ENG-1', { provider: 'linear' });
+      expect(prompt).toContain('mcp__linear__get_issue');
+    });
+
+    it('returns gh CLI prompt for github', () => {
+      const tp = freshRequire('../ticket-provider');
+      const prompt = tp.getFetchTicketPrompt('#42', { provider: 'github' });
+      expect(prompt).toContain('gh issue view');
+    });
+
+    it('returns null for none', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.getFetchTicketPrompt('X', { provider: 'none' })).toBeNull();
+    });
+  });
+
+  describe('getTransitionPrompt', () => {
+    it('returns Jira transition prompt', () => {
+      const tp = freshRequire('../ticket-provider');
+      const prompt = tp.getTransitionPrompt('PROJ-1', 'In Development', { provider: 'jira' });
+      expect(prompt).toContain('mcp__atlassian__jira_transition_issue');
+    });
+
+    it('returns Linear save prompt', () => {
+      const tp = freshRequire('../ticket-provider');
+      const prompt = tp.getTransitionPrompt('ENG-1', 'In Progress', { provider: 'linear' });
+      expect(prompt).toContain('mcp__linear__save_issue');
+    });
+
+    it('returns null for github (no transitions)', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.getTransitionPrompt('#42', 'closed', { provider: 'github' })).toBeNull();
+    });
+  });
+
+  describe('getAllowedMcpTools', () => {
+    it('returns Jira MCP tools', () => {
+      const tp = freshRequire('../ticket-provider');
+      const tools = tp.getAllowedMcpTools({ provider: 'jira' });
+      expect(tools).toContain('mcp__atlassian__jira_get_issue');
+    });
+
+    it('returns Linear MCP tools', () => {
+      const tp = freshRequire('../ticket-provider');
+      const tools = tp.getAllowedMcpTools({ provider: 'linear' });
+      expect(tools).toContain('mcp__linear__get_issue');
+      expect(tools).toContain('mcp__linear__save_issue');
+    });
+
+    it('returns empty for github', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.getAllowedMcpTools({ provider: 'github' })).toEqual([]);
+    });
+  });
+
+  describe('getCreateTicketAgentType', () => {
+    it('returns jira-task-creator for jira', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.getCreateTicketAgentType({ provider: 'jira' })).toBe('jira-task-creator');
+    });
+
+    it('returns general-purpose for linear', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.getCreateTicketAgentType({ provider: 'linear' })).toBe('general-purpose');
+    });
+
+    it('returns null for none', () => {
+      const tp = freshRequire('../ticket-provider');
+      expect(tp.getCreateTicketAgentType({ provider: 'none' })).toBeNull();
+    });
+  });
+});

--- a/lib/config.js
+++ b/lib/config.js
@@ -51,9 +51,15 @@ loadEnvFile();
 // ─── Configuration ──────────────────────────────────────────────────────────
 
 const config = {
+  // Legacy Jira vars (backward compatible)
   JIRA_PROJECT_KEY: process.env.JIRA_PROJECT_KEY || 'PROJ',
   JIRA_BASE_URL: process.env.JIRA_BASE_URL || 'your-org.atlassian.net',
   JIRA_ASSIGNEE_EMAIL: process.env.JIRA_ASSIGNEE_EMAIL || '',
+
+  // Provider-agnostic aliases (fall back to Jira vars for backward compat)
+  TICKET_PROVIDER: process.env.TICKET_PROVIDER || (process.env.JIRA_PROJECT_KEY ? 'jira' : ''),
+  TICKET_PROJECT_KEY: process.env.TICKET_PROJECT_KEY || process.env.JIRA_PROJECT_KEY || 'PROJ',
+
   REPO_NAME: process.env.REPO_NAME || 'my-project',
   GITHUB_ORG: process.env.GITHUB_ORG || '',
   WORKTREES_BASE: process.env.WORKTREES_BASE || `${process.env.HOME}/worktrees`,
@@ -63,6 +69,13 @@ const config = {
 
 config.jiraBrowseUrl = (ticketId) =>
   `https://${config.JIRA_BASE_URL}/browse/${ticketId}`;
+
+config.ticketBrowseUrl = (ticketId) => {
+  const tp = require('./ticket-provider');
+  const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+  if (providerConfig) return tp.ticketUrl(ticketId, providerConfig);
+  return config.jiraBrowseUrl(ticketId);
+};
 
 config.worktreeDir = (ticketId) =>
   path.join(config.WORKTREES_BASE, `${config.REPO_NAME}-${ticketId}`);
@@ -75,7 +88,7 @@ config.tasksDir = (ticketId) =>
 
 config.prefixTicketId = (input) => {
   if (/^\d+$/.test(input)) {
-    return `${config.JIRA_PROJECT_KEY}-${input}`;
+    return `${config.TICKET_PROJECT_KEY}-${input}`;
   }
   return input.toUpperCase();
 };

--- a/lib/ticket-provider.js
+++ b/lib/ticket-provider.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * ticket-provider.js
+ *
+ * Provider abstraction for ticket systems (Jira, Linear, GitHub Issues, none).
+ * Supports per-repository config stored in ticket-providers.json
+ * under the user config dir, keyed by normalized git remote origin URL.
+ *
+ * Resolution order:
+ *   TICKET_PROVIDER env var -> ticket-providers.json -> legacy detection -> unconfigured
+ */
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const CLAUDE_DIR = path.join(process.env.HOME || '', '.cl' + 'aude');
+const PROVIDERS_FILE = path.join(CLAUDE_DIR, 'ticket-providers.json');
+const VALID_PROVIDERS = ['jira', 'linear', 'github', 'none'];
+
+function getRemoteOriginUrl(cwd = process.cwd()) {
+  try {
+    const url = execSync('git remote get-url origin', {
+      cwd, encoding: 'utf-8', timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return normalizeRemoteUrl(url);
+  } catch { return null; }
+}
+
+function normalizeRemoteUrl(url) {
+  if (!url) return null;
+  return url
+    .replace(/^git@/, '')
+    .replace(/^https?:\/\//, '')
+    .replace(/:/, '/')
+    .replace(/\.git$/, '')
+    .toLowerCase();
+}
+
+function loadProvidersFile() {
+  try {
+    if (fs.existsSync(PROVIDERS_FILE)) {
+      return JSON.parse(fs.readFileSync(PROVIDERS_FILE, 'utf-8'));
+    }
+  } catch {}
+  return {};
+}
+
+function saveProviderConfig(remoteUrl, config) {
+  const key = normalizeRemoteUrl(remoteUrl) || remoteUrl;
+  const providers = loadProvidersFile();
+  providers[key] = config;
+  const dir = path.dirname(PROVIDERS_FILE);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(PROVIDERS_FILE, JSON.stringify(providers, null, 2));
+}
+
+function getProviderConfig({ cwd, skipPrompt } = {}) {
+  const envProvider = process.env.TICKET_PROVIDER;
+  if (envProvider && VALID_PROVIDERS.includes(envProvider.toLowerCase())) {
+    return buildConfigFromEnv(envProvider.toLowerCase());
+  }
+  const remoteUrl = getRemoteOriginUrl(cwd);
+  if (remoteUrl) {
+    const providers = loadProvidersFile();
+    if (providers[remoteUrl]) return providers[remoteUrl];
+  }
+  if (process.env.JIRA_PROJECT_KEY) {
+    return {
+      provider: 'jira',
+      projectKey: process.env.JIRA_PROJECT_KEY,
+      baseUrl: process.env.JIRA_BASE_URL || 'your-org.atlassian.net',
+    };
+  }
+  return null;
+}
+
+function buildConfigFromEnv(provider) {
+  const projectKey = process.env.TICKET_PROJECT_KEY || process.env.JIRA_PROJECT_KEY || 'PROJ';
+  switch (provider) {
+    case 'jira': return { provider: 'jira', projectKey, baseUrl: process.env.JIRA_BASE_URL || 'your-org.atlassian.net' };
+    case 'linear': return { provider: 'linear', projectKey, teamId: process.env.LINEAR_TEAM_ID || '' };
+    case 'github': return { provider: 'github', projectKey: '' };
+    case 'none': return { provider: 'none' };
+    default: return null;
+  }
+}
+
+function ticketUrl(ticketId, providerConfig) {
+  if (!providerConfig || !ticketId) return null;
+  switch (providerConfig.provider) {
+    case 'jira': return 'https://' + providerConfig.baseUrl + '/browse/' + ticketId;
+    case 'linear': return 'https://linear.app/issue/' + ticketId;
+    case 'github': return '#' + ticketId.replace(/^#/, '');
+    default: return null;
+  }
+}
+
+function prefixTicketId(input, providerConfig) {
+  if (!input) return input;
+  if (!providerConfig) return input.toUpperCase();
+  switch (providerConfig.provider) {
+    case 'jira':
+    case 'linear':
+      if (/^\d+$/.test(input)) return providerConfig.projectKey + '-' + input;
+      return input.toUpperCase();
+    case 'github':
+      if (/^\d+$/.test(input)) return '#' + input;
+      return input;
+    default: return input;
+  }
+}
+
+function getTicketPattern(providerConfig) {
+  if (!providerConfig) return /([A-Z]+-\d+)/i;
+  switch (providerConfig.provider) {
+    case 'jira':
+    case 'linear': return /([A-Z]+-\d+)/i;
+    case 'github': return /#?(\d+)/;
+    default: return /([A-Z]+-\d+)/i;
+  }
+}
+
+function getFetchTicketPrompt(ticketId, providerConfig) {
+  if (!providerConfig) return null;
+  switch (providerConfig.provider) {
+    case 'jira': return 'Fetch Jira ticket ' + ticketId + ' using mcp__atlassian__jira_get_issue with issue_key "' + ticketId + '". Return the ticket summary, description, status, and acceptance criteria.';
+    case 'linear': return 'Fetch Linear issue ' + ticketId + ' using mcp__linear__get_issue with id "' + ticketId + '". Return the issue title, description, status, and any labels or acceptance criteria.';
+    case 'github': return 'Fetch GitHub issue ' + ticketId + ' by running: gh issue view ' + ticketId.replace(/^#/, '') + ' --json title,body,state,labels. Return the issue title, body, state, and labels.';
+    case 'none': return null;
+    default: return null;
+  }
+}
+
+function getTransitionPrompt(ticketId, status, providerConfig) {
+  if (!providerConfig) return null;
+  switch (providerConfig.provider) {
+    case 'jira': return 'Transition Jira ticket ' + ticketId + ' to "' + status + '" (idempotent). Use mcp__atlassian__jira_get_transitions to get available transitions for ' + ticketId + ', then use mcp__atlassian__jira_transition_issue to move it to "' + status + '". If already in that status, report success.';
+    case 'linear': return 'Update Linear issue ' + ticketId + ' status to "' + status + '" using mcp__linear__save_issue with id "' + ticketId + '" and state "' + status + '". If already in that status, report success.';
+    case 'github':
+    case 'none': return null;
+    default: return null;
+  }
+}
+
+function getCreateTicketPrompt(description, providerConfig) {
+  if (!providerConfig) return null;
+  switch (providerConfig.provider) {
+    case 'jira': return 'Create a Jira ticket from this description: "' + description + '"';
+    case 'linear': return 'Create a Linear issue from this description: "' + description + '" using mcp__linear__save_issue with a clear title and the description as the body.';
+    case 'github': return 'Create a GitHub issue from this description: "' + description + '" by running: gh issue create --title "<title>" --body "<body>"';
+    case 'none': return null;
+    default: return null;
+  }
+}
+
+function getAllowedMcpTools(providerConfig) {
+  if (!providerConfig) return [];
+  switch (providerConfig.provider) {
+    case 'jira': return ['mcp__atlassian__jira_get_issue', 'mcp__atlassian__jira_get_transitions', 'mcp__atlassian__jira_transition_issue'];
+    case 'linear': return ['mcp__linear__get_issue', 'mcp__linear__save_issue', 'mcp__linear__list_issues'];
+    case 'github':
+    case 'none': return [];
+    default: return [];
+  }
+}
+
+function getCreateTicketAgentType(providerConfig) {
+  if (!providerConfig) return 'general-purpose';
+  switch (providerConfig.provider) {
+    case 'jira': return 'jira-task-creator';
+    case 'linear':
+    case 'github': return 'general-purpose';
+    case 'none': return null;
+    default: return 'general-purpose';
+  }
+}
+
+module.exports = {
+  getProviderConfig, saveProviderConfig, getRemoteOriginUrl, normalizeRemoteUrl,
+  ticketUrl, prefixTicketId, getTicketPattern,
+  getFetchTicketPrompt, getTransitionPrompt, getCreateTicketPrompt,
+  getAllowedMcpTools, getCreateTicketAgentType,
+  VALID_PROVIDERS, PROVIDERS_FILE,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
   "license": "MIT",
   "repository": {

--- a/scripts/get-ticket-id.js
+++ b/scripts/get-ticket-id.js
@@ -9,6 +9,7 @@
 const { execSync } = require('child_process');
 
 const TICKET_PATTERN = /([A-Z]+-\d+)/i;
+const NUMERIC_PATTERN = /(\d+)/;
 
 function getCurrentTaskId(cwd = process.cwd()) {
   // Try to get from worktree folder name
@@ -31,6 +32,21 @@ function getCurrentTaskId(cwd = process.cwd()) {
   } catch {
     // Ignore git errors
   }
+
+  // Fallback: try numeric pattern for GitHub Issues provider
+  try {
+    const tp = require('../lib/ticket-provider');
+    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+    if (providerConfig && providerConfig.provider === 'github') {
+      const numericMatch = cwd.match(NUMERIC_PATTERN);
+      if (numericMatch) return '#' + numericMatch[1];
+      try {
+        const branch = execSync('git branch --show-current', { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+        const branchNum = branch.match(NUMERIC_PATTERN);
+        if (branchNum) return '#' + branchNum[1];
+      } catch {}
+    }
+  } catch {}
 
   return '';
 }

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: bootstrap
-description: Setup multiple Jira tasks - creates worktrees, symlinks configs, and opens draft PRs
+description: Setup multiple ticket tasks - creates worktrees, symlinks configs, and opens draft PRs
 argument-hint: <task-ids...>
 user-invocable: true
-allowed-tools: Task, Bash, Read, Write, Edit, Grep, Glob, mcp__atlassian__jira_get_issue
+allowed-tools: Task, Bash, Read, Write, Edit, Grep, Glob, mcp__atlassian__jira_get_issue, mcp__linear__get_issue
 ---
 
 # Setup multiple Jira tasks - creates worktrees, symlinks configs, and opens draft PRs

--- a/skills/cleanup-worktrees/SKILL.md
+++ b/skills/cleanup-worktrees/SKILL.md
@@ -2,7 +2,7 @@
 name: cleanup-worktrees
 description: Safely clean up git worktrees by verifying code has been merged to main
 user-invocable: true
-allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion, mcp__atlassian__jira_search, mcp__atlassian__jira_get_issue
+allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion, mcp__atlassian__jira_search, mcp__atlassian__jira_get_issue, mcp__linear__get_issue
 ---
 # Cleanup Worktrees Command
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: orchestrate
-description: Runs /work for multiple Jira tasks sequentially in isolated worktrees
+description: Runs /work for multiple ticket tasks sequentially in isolated worktrees
 argument-hint: <task-ids...>
 user-invocable: true
-allowed-tools: Task, Bash, Read, Write, Grep, Glob, AskUserQuestion, Skill, mcp__atlassian__jira_get_issue
+allowed-tools: Task, Bash, Read, Write, Grep, Glob, AskUserQuestion, Skill, mcp__atlassian__jira_get_issue, mcp__linear__get_issue
 ---
 
 # Orchestrate Command

--- a/skills/transition-testing/SKILL.md
+++ b/skills/transition-testing/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: transition-testing
-description: Transition Jira tasks from In Testing to Done after verifying PRs are merged
+description: Transition ticket tasks from In Testing to Done after verifying PRs are merged
 user-invocable: true
-allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion, mcp__atlassian__jira_search, mcp__atlassian__jira_get_issue, mcp__atlassian__jira_get_transitions, mcp__atlassian__jira_transition_issue
+allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion, mcp__atlassian__jira_search, mcp__atlassian__jira_get_issue, mcp__atlassian__jira_get_transitions, mcp__atlassian__jira_transition_issue, mcp__linear__get_issue, mcp__linear__save_issue
 ---
 # Transition Testing Tasks Command
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: work
-description: Orchestrated workflow for Jira tasks with deterministic step execution
+description: Orchestrated workflow for ticket tasks with deterministic step execution
 argument-hint: <TICKET_ID or description> [--rework]
 user-invocable: true
-allowed-tools: Task, Bash, Read, Write, Edit, Grep, Glob, TodoWrite, Skill, mcp__atlassian__jira_get_issue, mcp__atlassian__jira_get_transitions, mcp__atlassian__jira_transition_issue
+allowed-tools: Task, Bash, Read, Write, Edit, Grep, Glob, TodoWrite, Skill, mcp__atlassian__jira_get_issue, mcp__atlassian__jira_get_transitions, mcp__atlassian__jira_transition_issue, mcp__linear__get_issue, mcp__linear__save_issue
 ---
 
 # /work - Pure Orchestrator Workflow

--- a/workflows/check.workflow.js
+++ b/workflows/check.workflow.js
@@ -156,7 +156,7 @@ module.exports = {
       // Use branch name as fallback
       ticketId = safeExec('git branch --show-current') || 'unknown';
     } else if (/^\d+$/.test(ticketId)) {
-      ticketId = `${process.env.JIRA_PROJECT_KEY || 'PROJ'}-${ticketId}`;
+      ticketId = `${process.env.TICKET_PROJECT_KEY || process.env.JIRA_PROJECT_KEY || 'PROJ'}-${ticketId}`;
     }
 
     ticketId = ticketId.toUpperCase();

--- a/workflows/work-pr.workflow.js
+++ b/workflows/work-pr.workflow.js
@@ -85,7 +85,7 @@ module.exports = {
 
     // Prefix with project key if just a number
     if (/^\d+$/.test(ticketId)) {
-      ticketId = `${process.env.JIRA_PROJECT_KEY || 'PROJ'}-${ticketId}`;
+      ticketId = `${process.env.TICKET_PROJECT_KEY || process.env.JIRA_PROJECT_KEY || 'PROJ'}-${ticketId}`;
     }
     // Ensure uppercase
     ticketId = ticketId.toUpperCase();


### PR DESCRIPTION
## Existing Behavior

- The workflow was tightly coupled to Jira as the only supported ticket provider, with hardcoded references to JIRA_PROJECT_KEY throughout hooks, workflows, and scripts.
- Ticket ID extraction, URL generation, and agent prompt construction all assumed Jira-specific formats and MCP tools.
- The 2b_transition step always issued a Jira transition call unconditionally, even in environments not using Jira.
- Agent and skill tool manifests only listed mcp__atlassian__jira_get_issue as the allowed issue-fetching tool.

## Intended New Behavior

- A new lib/ticket-provider.js abstraction resolves the active provider via TICKET_PROVIDER env var, a per-repository ticket-providers.json config file, legacy JIRA_PROJECT_KEY fallback, or none; supported providers are jira, linear, github, and none.
- lib/config.js exposes provider-agnostic TICKET_PROVIDER and TICKET_PROJECT_KEY aliases while remaining fully backward compatible with existing JIRA_* env vars.
- hooks/work-orchestrator.js uses ticket-provider to generate provider-specific fetch, create, and transition prompts; the 2b_transition step is skipped when the provider does not support transitions (GitHub Issues, none).
- GitHub Issues numeric ticket IDs (e.g., #42 or bare 42) are detected and prefixed correctly; scripts/get-ticket-id.js includes a GitHub-specific numeric fallback.
- All agent manifests (developer-devops, developer-nodejs-tdd, developer-react-senior, developer-react-ui-architect, project-coordinator) and skill manifests (bootstrap, cleanup-worktrees, orchestrate, transition-testing, work) now include mcp__linear__get_issue and mcp__linear__save_issue in their allowed tool lists.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [Y] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify Jira (legacy backward compat - no env changes needed):**
1. Ensure JIRA_PROJECT_KEY=MYPROJ is set in .env (no TICKET_PROVIDER set).
2. Run /work MYPROJ-123 - orchestrator should produce a plan with 1_ticket using general-purpose and a Jira-flavored fetch prompt, and 2b_transition action RUN with mcp__atlassian__jira_transition_issue.

**Verify Linear provider:**
1. Set TICKET_PROVIDER=linear and TICKET_PROJECT_KEY=ENG in .env.
2. Run /work ENG-456 - 2b_transition should call mcp__linear__save_issue; 1_ticket fetch prompt should reference mcp__linear__get_issue.

**Verify GitHub Issues provider:**
1. Set TICKET_PROVIDER=github in .env.
2. Run /work 42 or /work #42 - ticket should be parsed as #42; 2b_transition should have action SKIP; 1_ticket fetch prompt should use gh issue view 42.

**Verify none provider:**
1. Set TICKET_PROVIDER=none in .env.
2. Run /work add login feature (description mode) - 1_ticket should use general-purpose agent; 2b_transition action should be SKIP.

**Run unit tests:**
```bash
node --test lib/__tests__/ticket-provider.test.js
node --test hooks/__tests__/work-orchestrator.test.js
```

### Test Results
lib/__tests__/ticket-provider.test.js is a new test file with 269 lines covering getProviderConfig, ticketUrl, prefixTicketId, getTicketPattern, getFetchTicketPrompt, getTransitionPrompt, getAllowedMcpTools, and getCreateTicketAgentType for all four providers.