### PR TITLE
fix(hooks): use dynamic repo root in enforce-screenshot-requirement hook

### DIFF
--- a/hooks/__tests__/enforce-screenshot-requirement.test.js
+++ b/hooks/__tests__/enforce-screenshot-requirement.test.js
@@ -13,6 +13,20 @@ const assert = require('node:assert/strict');
 const HOOK_PATH = path.join(__dirname, '..', 'enforce-screenshot-requirement.js');
 const MARKER_DIR = '/tmp';
 
+function getRepoRoot() {
+  try {
+    const { execSync } = require('child_process');
+    return execSync('git rev-parse --show-toplevel 2>/dev/null', { encoding: 'utf8' }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+function getScreenshotDir(ticketId) {
+  const repoRoot = getRepoRoot();
+  return path.join(path.dirname(repoRoot), 'tasks', ticketId, 'screenshots');
+}
+
 function runHook(hookData, hookType = 'PreToolUse') {
   return new Promise((resolve, reject) => {
     const proc = spawn('node', [HOOK_PATH], {
@@ -52,14 +66,14 @@ function cleanupMarker(ticketId) {
 }
 
 function createFakeScreenshot(ticketId) {
-  const dir = `/home/node/worktrees/tasks/${ticketId}/screenshots`;
+  const dir = getScreenshotDir(ticketId);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'test.png'), 'fake');
   return dir;
 }
 
 function cleanupScreenshots(ticketId) {
-  const dir = `/home/node/worktrees/tasks/${ticketId}/screenshots`;
+  const dir = getScreenshotDir(ticketId);
   try {
     if (fs.existsSync(dir)) {
       for (const f of fs.readdirSync(dir)) fs.unlinkSync(path.join(dir, f));

--- a/hooks/enforce-screenshot-requirement.js
+++ b/hooks/enforce-screenshot-requirement.js
@@ -20,6 +20,26 @@ const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
 
 // Per-process cache to avoid re-fetching/re-diffing within same invocation
 let _cachedTsxChanges = undefined;
+let _cachedRepoRoot = undefined;
+
+function getRepoRoot() {
+  if (_cachedRepoRoot !== undefined) return _cachedRepoRoot;
+  try {
+    _cachedRepoRoot = execSync('git rev-parse --show-toplevel 2>/dev/null', { encoding: 'utf8' }).trim();
+  } catch {
+    _cachedRepoRoot = null;
+  }
+  return _cachedRepoRoot;
+}
+
+function getScreenshotDir(ticketId) {
+  const repoRoot = getRepoRoot();
+  if (repoRoot) {
+    return path.join(path.dirname(repoRoot), 'tasks', ticketId, 'screenshots');
+  }
+  // Fallback: use cwd parent
+  return path.join(process.cwd(), '..', 'tasks', ticketId, 'screenshots');
+}
 
 function getTicketId() {
   try {
@@ -91,7 +111,7 @@ function hasTsxChanges() {
  * Compatible with Node < 18.17 (no recursive readdirSync needed).
  */
 function hasScreenshots(ticketId) {
-  const root = `/home/node/worktrees/tasks/${ticketId}/screenshots`;
+  const root = getScreenshotDir(ticketId);
   try {
     if (!fs.existsSync(root)) return false;
     const stack = [root];
@@ -138,9 +158,10 @@ function blockIfNoScreenshots(hookData) {
 
   if (!isQaAgent && !isCompletingSkill) return;
 
+  const screenshotDir = getScreenshotDir(ticketId);
   process.stderr.write(
     'BLOCKED: TSX/JSX files changed but NO screenshots found in ' +
-    `/home/node/worktrees/tasks/${ticketId}/screenshots/. ` +
+    `${screenshotDir}/. ` +
     'You MUST capture screenshots before completing QA or creating a PR. ' +
     'Call AskUserQuestion with options: ' +
     '"Capture screenshots now" (use Playwright to take screenshots) | ' +


### PR DESCRIPTION
## Existing Behavior

- The `enforce-screenshot-requirement.js` hook used a hardcoded path `/home/node/worktrees/tasks/TICKET/screenshots` to locate screenshot directories.
- The block message emitted the hardcoded path in its error output.
- Tests hardcoded the same `/home/node/worktrees/tasks/` base path in `createFakeScreenshot` and `cleanupScreenshots` helpers, so tests only passed in that specific environment.

## Intended New Behavior

- The hook dynamically resolves the repo root via `git rev-parse --show-toplevel`, then derives the screenshot path as `parent-of-repo-root/tasks/TICKET/screenshots`.
- A per-process cache (`_cachedRepoRoot`) avoids redundant `git rev-parse` calls within a single hook invocation.
- A fallback to `process.cwd()/../` is used when `git rev-parse` fails (e.g. detached or non-git environments).
- The block message now references the dynamically resolved path instead of the hardcoded one.
- Tests use the same `getRepoRoot()` / `getScreenshotDir()` helpers so they resolve correctly regardless of clone location.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Run the enforce-screenshot-requirement tests directly to verify all 26 pass:

```bash
node --test hooks/__tests__/enforce-screenshot-requirement.test.js
```

Expected output:
```
tests 26
pass  26
fail  0
```

To verify dynamic path resolution end-to-end:

1. Clone the repo at any path (e.g. `/tmp/my-repo` or a worktree at `/home/user/projects/tasks`)
2. Check out this branch and trigger a scenario where TSX files are changed but no screenshots exist
3. Confirm the BLOCKED message references the correct dynamic path (sibling `tasks/` directory next to repo root) rather than the old hardcoded `/home/node/worktrees/tasks/` path

### Test Results

All 26 tests in `hooks/__tests__/enforce-screenshot-requirement.test.js` pass.