### PR TITLE
ci: add GitHub Actions workflow for automatic patch version bumping

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,34 @@
+name: Bump Version
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    # Skip bump commits to avoid infinite loop
+    if: "!contains(github.event.head_commit.message, 'chore(release):')"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Bump patch version
+        run: node scripts/bump-version.js patch
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          VERSION=$(node -p "require('./package.json').version")
+          git add package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git commit -m "chore(release): bump version to ${VERSION}"
+          git push


### PR DESCRIPTION
## Existing Behavior

- Version files (package.json, plugin.json, marketplace.json) are bumped manually via scripts/bump-version.js and committed by hand.
- There is no automated mechanism to increment the version when changes land on main.
- Developers must remember to run the bump script and push a release commit as a separate step.

## Intended New Behavior

- A new GitHub Actions workflow triggers on every push to main and automatically runs the bump-version.js patch script to increment the patch version across all 3 version files.
- The workflow commits the updated files with a chore(release) message using the github-actions[bot] identity and pushes directly to main.
- A guard condition prevents execution when the triggering commit is itself a release bump, stopping infinite loop scenarios.
- The workflow requires only Node 20 and the built-in GITHUB_TOKEN — no additional secrets or dependencies are needed.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a CI-only change. To verify the workflow behaves correctly:

1. Merge any non-release commit to main (e.g., a small doc fix).
2. Navigate to the repository Actions tab on GitHub and confirm the Bump Version workflow run is triggered.
3. Verify the run completes successfully and a new commit appears on main with message chore(release): bump version to X.Y.Z.
4. Confirm the patch version is incremented by 1 in all 3 version files (package.json, plugin.json, marketplace.json).
5. Merge a commit whose message starts with 'chore(release):' and confirm the workflow is skipped with no new bump commit pushed.
