### PR TITLE
fix(ci): use BUMP_TOKEN secret in bump-version workflow to bypass branch protection

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BUMP_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Existing Behavior

The `bump-version.yml` workflow uses `GITHUB_TOKEN` for checkout, which is the default Actions token. When the workflow attempts to push a version bump commit directly to `main`, GitHub rejects the push with "Changes must be made through a pull request" because `GITHUB_TOKEN` cannot bypass branch protection rules.

## Intended New Behavior

The checkout step now uses `secrets.BUMP_TOKEN`, a fine-grained PAT configured with Contents: Read/Write and branch protection bypass permissions. This allows the `github-actions[bot]` to push version bump commits directly to `main` without triggering the pull request requirement.

**Setup required:** A repository admin must create a fine-grained PAT with the following permissions and add it as a repo secret named `BUMP_TOKEN`:
- Contents: Read and Write
- Bypass branch protections (or the PAT owner must be listed as a bypass actor in the branch protection rules)

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Ensure the `BUMP_TOKEN` secret is created in the repository settings (Settings > Secrets and variables > Actions > New repository secret).
2. Merge this PR into `main`.
3. Push any non-release commit to `main` (or merge a PR that does not start with `chore(release):`).
4. Navigate to the Actions tab and observe the "Bump Version" workflow run.
5. Confirm the workflow completes successfully and a new commit appears on `main` with message `chore(release): bump version to X.Y.Z`.
6. Previously, the workflow would fail at the `git push` step with "Changes must be made through a pull request" — that error should no longer appear.