### PR TITLE
ci(bump-version): replace BUMP_TOKEN PAT with GitHub App token

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -4,18 +4,22 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-
 jobs:
   bump:
     runs-on: ubuntu-latest
     # Skip bump commits to avoid infinite loop
     if: "!contains(github.event.head_commit.message, 'chore(release):')"
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.BUMP_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v4
         with:
@@ -26,8 +30,8 @@ jobs:
 
       - name: Commit and push
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "claude-plugin-work-botApp[bot]"
+          git config user.email "claude-plugin-work-botApp[bot]@users.noreply.github.com"
           VERSION=$(node -p "require('./package.json').version")
           git add package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json
           git commit -m "chore(release): bump version to ${VERSION}"


### PR DESCRIPTION
## Existing Behavior

- The bump-version.yml workflow authenticates actions/checkout using a BUMP_TOKEN personal access token (PAT) stored as a repo secret.
- A top-level permissions: contents: write block is declared in the workflow.
- Commit author identity is set to github-actions[bot].

## Intended New Behavior

- A GitHub App installation token is generated at runtime using actions/create-github-app-token@v1 with APP_ID and APP_PRIVATE_KEY repo secrets, replacing the BUMP_TOKEN PAT.
- The botApp GitHub App, already added as a bypass actor in the branch protection ruleset, handles authentication and allows the workflow to push version bump commits directly to main.
- The redundant top-level permissions block is removed since the App token handles authorization.
- Commit author identity is updated to botApp[bot] to reflect the actual actor.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [Y] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Ensure APP_ID and APP_PRIVATE_KEY secrets are set in the repository settings (Settings > Secrets and variables > Actions).
2. Merge a non-chore(release): commit to main.
3. Observe the bump-version workflow run in the Actions tab.
4. Confirm the Generate App Token step completes successfully.
5. Confirm the Commit and push step pushes a chore(release): bump version to X.X.X commit authored by botApp[bot] to main.
6. Confirm no branch protection bypass errors occur.