### PR TITLE
feat(hooks): migrate 12 hooks into plugin repo with centralized config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
-    "version": "1.0.0"
+    "version": "2.1.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Self-contained workflow plugin with agents, hooks, skills, and orchestration. Includes 16 specialized agents, agent-specific hooks, and 23 skills.",
   "author": {
     "name": "Custom",

--- a/hooks/__tests__/enforce-step-workflow.test.js
+++ b/hooks/__tests__/enforce-step-workflow.test.js
@@ -1030,4 +1030,142 @@ describe('enforce-step-workflow', () => {
       assert.ok(stderr.includes('WARNING: Multiple steps in_progress'), 'WARNING always visible');
     });
   });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Patch 14: Bash dev:check command matching for 4_quality
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('Bash dev:check → 4_quality command matching (Patch 14)', () => {
+    it('blocks pnpm dev:check when step is NOT 4_quality', async () => {
+      writeWorkState(makeStepStatus('3_implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'pnpm dev:check' },
+      });
+      assert.equal(code, 2);
+      assert.ok(stderr.includes('BLOCKED'), 'Should block dev:check outside 4_quality');
+      assert.ok(stderr.includes('4_quality'), 'Should mention 4_quality');
+    });
+
+    it('allows pnpm dev:check when step IS 4_quality', async () => {
+      writeWorkState(makeStepStatus('4_quality', WORK_STEPS));
+
+      const { code } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'pnpm dev:check' },
+      });
+      assert.equal(code, 0);
+    });
+
+    it('blocks LOW_CONCURRENCY=1 pnpm dev:check outside 4_quality', async () => {
+      writeWorkState(makeStepStatus('6_check', WORK_STEPS));
+
+      const { code, stderr } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'LOW_CONCURRENCY=1 pnpm dev:check' },
+      });
+      assert.equal(code, 2);
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('allows LOW_CONCURRENCY=1 pnpm dev:check during 4_quality', async () => {
+      writeWorkState(makeStepStatus('4_quality', WORK_STEPS));
+
+      const { code } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'LOW_CONCURRENCY=1 pnpm dev:check' },
+      });
+      assert.equal(code, 0);
+    });
+
+    it('blocks npm run dev:check outside 4_quality', async () => {
+      writeWorkState(makeStepStatus('5_commit', WORK_STEPS));
+
+      const { code, stderr } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'npm run dev:check' },
+      });
+      assert.equal(code, 2);
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('records evidence for pnpm dev:check via PostToolUse during 4_quality', async () => {
+      writeWorkState(makeStepStatus('4_quality', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: 'pnpm dev:check' } },
+        'PostToolUse',
+      );
+      assert.equal(code, 0);
+
+      const evidence = readEvidence();
+      assert.ok(evidence['4_quality']?.executed, 'Should record evidence for 4_quality');
+      assert.equal(evidence['4_quality']?.tool, 'Bash');
+    });
+
+    it('matches pnpm dev:check-types as 4_quality (\\b matches at hyphen)', async () => {
+      writeWorkState(makeStepStatus('3_implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: 'pnpm dev:check-types' },
+      });
+      // \b matches at word boundary before hyphen — this IS caught as 4_quality
+      assert.equal(code, 2);
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Patch 14: 10_ready as soft step
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('10_ready soft step (Patch 14)', () => {
+    it('allows transition from 10_ready without evidence', async () => {
+      writeWorkState(makeStepStatus('10_ready', WORK_STEPS));
+      // No evidence written for 10_ready
+
+      const { code } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: `node /path/to/work-orchestrator.js transition ${TEST_TICKET} 11_ci` },
+      });
+      // Soft step → should allow transition without evidence
+      assert.equal(code, 0);
+    });
+
+    it('source confirms 10_ready is in softSteps set', () => {
+      const hookSource = fs.readFileSync(HOOK_PATH, 'utf-8');
+      // Check that softSteps contains 10_ready
+      const softStepsMatch = hookSource.match(/softSteps:\s*new Set\(\[([^\]]+)\]\)/);
+      assert.ok(softStepsMatch, 'Should have softSteps declaration');
+      assert.ok(softStepsMatch[1].includes("'10_ready'"), 'softSteps should include 10_ready');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Patch 14: 9_pr evidence validation
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('9_pr evidence validation (Patch 14)', () => {
+    it('does NOT record evidence for 9_pr when .pr-update-sha is missing', async () => {
+      writeWorkState(makeStepStatus('9_pr', WORK_STEPS));
+      // Do NOT create .pr-update-sha file
+
+      const { code } = await runHook(
+        { tool_name: 'Skill', tool_input: { skill: 'work-pr' } },
+        'PostToolUse',
+      );
+      assert.equal(code, 0);
+
+      const evidence = readEvidence();
+      assert.equal(evidence['9_pr'], undefined, 'Should NOT record evidence without .pr-update-sha');
+    });
+
+    it('source has Patch 14 evidence validation block', () => {
+      const hookSource = fs.readFileSync(HOOK_PATH, 'utf-8');
+      assert.ok(hookSource.includes("(Patch 14) Strengthen 9_pr evidence"), 'Should have Patch 14 comment');
+      assert.ok(hookSource.includes('.pr-update-sha'), 'Should reference .pr-update-sha file');
+    });
+  });
 });

--- a/hooks/__tests__/work-orchestrator.test.js
+++ b/hooks/__tests__/work-orchestrator.test.js
@@ -1,10 +1,13 @@
 /**
  * Tests for work-orchestrator.js
  *
- * Run with: cd ~/.claude && pnpm test:hooks
+ * Uses node:test + node:assert/strict.
+ * Run: node --test hooks/__tests__/work-orchestrator.test.js
  */
 
-const { spawn, execSync } = require('child_process');
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -14,9 +17,8 @@ const TASKS_BASE = fs.existsSync('/home/node/worktrees/tasks')
   ? '/home/node/worktrees/tasks'
   : path.join(os.homedir(), 'tasks');
 
-/**
- * Helper to run the orchestrator with given args
- */
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
 function runOrchestrator(args = [], opts = {}) {
   return new Promise((resolve, reject) => {
     const proc = spawn('node', [HOOK_PATH, ...args], {
@@ -28,13 +30,8 @@ function runOrchestrator(args = [], opts = {}) {
     let stdout = '';
     let stderr = '';
 
-    proc.stdout.on('data', (data) => {
-      stdout += data.toString();
-    });
-
-    proc.stderr.on('data', (data) => {
-      stderr += data.toString();
-    });
+    proc.stdout.on('data', (data) => { stdout += data.toString(); });
+    proc.stderr.on('data', (data) => { stderr += data.toString(); });
 
     proc.on('close', (code) => {
       try {
@@ -49,408 +46,294 @@ function runOrchestrator(args = [], opts = {}) {
   });
 }
 
-/**
- * Create a temporary work state file for testing
- */
-function createTempWorkState(ticket, state) {
-  const dir = path.join(TASKS_BASE, ticket);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-  const filePath = path.join(dir, '.work-state.json');
-  fs.writeFileSync(filePath, JSON.stringify(state, null, 2));
-  return filePath;
-}
-
-/**
- * Remove temp work state
- */
 function cleanupTempWorkState(ticket) {
   const dir = path.join(TASKS_BASE, ticket);
   const filePath = path.join(dir, '.work-state.json');
-  if (fs.existsSync(filePath)) {
-    fs.unlinkSync(filePath);
-  }
+  try { if (fs.existsSync(filePath)) fs.unlinkSync(filePath); } catch {}
+  // Also clean up actions file
+  const actionsFile = path.join(dir, '.work-actions.jsonl');
+  try { if (fs.existsSync(actionsFile)) fs.unlinkSync(actionsFile); } catch {}
 }
 
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
 describe('work-orchestrator.js', () => {
+
   describe('CLI usage', () => {
     it('should show error when no arguments provided', async () => {
       const { result, code } = await runOrchestrator([]);
-
-      expect(code).toBe(1);
-      expect(result.error).toBe(true);
-      expect(result.message).toContain('Usage');
+      assert.equal(code, 1);
+      assert.equal(result.error, true);
+      assert.ok(result.message.includes('Usage'));
     });
 
     it('should show error when plan command has no ticket', async () => {
       const { result, code } = await runOrchestrator(['plan']);
-
-      expect(code).toBe(1);
-      expect(result.error).toBe(true);
-      expect(result.message).toContain('Provide ticket ID or description');
+      assert.equal(code, 1);
+      assert.equal(result.error, true);
+      assert.ok(result.message.includes('Provide ticket ID or description'));
     });
   });
 
   describe('graph command', () => {
     it('should output the state machine graph', async () => {
       const { result, code } = await runOrchestrator(['graph']);
-
-      expect(code).toBe(0);
-      expect(result).toHaveProperty('steps');
-      expect(result).toHaveProperty('transitions');
-      expect(result.steps).toContain('1_ticket');
-      expect(result.steps).toContain('13_complete');
-      expect(result.steps.length).toBe(13);
+      assert.equal(code, 0);
+      assert.ok(result.steps);
+      assert.ok(result.transitions);
+      assert.ok(result.steps.includes('1_ticket'));
+      assert.ok(result.steps.includes('13_complete'));
+      assert.equal(result.steps.length, 13);
     });
 
     it('should have valid transitions for each step', async () => {
       const { result } = await runOrchestrator(['graph']);
-
-      // Each step should have an entry in transitions
       for (const step of result.steps) {
-        expect(result.transitions).toHaveProperty(step);
-        expect(Array.isArray(result.transitions[step])).toBe(true);
+        assert.ok(step in result.transitions, `Missing transition for ${step}`);
+        assert.ok(Array.isArray(result.transitions[step]));
       }
-
-      // Verify some specific transitions
-      expect(result.transitions['1_ticket']).toContain('2_bootstrap');
-      expect(result.transitions['13_complete']).toEqual([]);
+      assert.ok(result.transitions['1_ticket'].includes('2_bootstrap'));
+      assert.deepEqual(result.transitions['13_complete'], []);
     });
 
     it('should include retry loop transitions', async () => {
       const { result } = await runOrchestrator(['graph']);
-
-      // 6_check can go back to 3_implement
-      expect(result.transitions['6_check']).toContain('3_implement');
-      // 11_ci can go back to 3_implement or 8_test_enhancement
-      expect(result.transitions['11_ci']).toContain('3_implement');
-      expect(result.transitions['11_ci']).toContain('8_test_enhancement');
+      assert.ok(result.transitions['6_check'].includes('3_implement'));
+      assert.ok(result.transitions['11_ci'].includes('3_implement'));
+      assert.ok(result.transitions['11_ci'].includes('8_test_enhancement'));
     });
 
     it('should include skip edge transitions', async () => {
       const { result } = await runOrchestrator(['graph']);
-
-      // 2_bootstrap can skip to 4_quality, 5_commit, or 6_check
-      expect(result.transitions['2_bootstrap']).toContain('4_quality');
-      expect(result.transitions['2_bootstrap']).toContain('5_commit');
-      expect(result.transitions['2_bootstrap']).toContain('6_check');
+      assert.ok(result.transitions['2_bootstrap'].includes('4_quality'));
+      assert.ok(result.transitions['2_bootstrap'].includes('5_commit'));
+      assert.ok(result.transitions['2_bootstrap'].includes('6_check'));
     });
   });
 
   describe('plan command', () => {
     const TEST_TICKET = 'TEST-999';
-
-    afterEach(() => {
-      cleanupTempWorkState(TEST_TICKET);
-    });
+    afterEach(() => { cleanupTempWorkState(TEST_TICKET); });
 
     it('should generate a plan for a new ticket', async () => {
       const { result, code } = await runOrchestrator([TEST_TICKET]);
-
-      expect(code).toBe(0);
-      expect(result.ticket).toBe(TEST_TICKET);
-      expect(result.mode).toBe('resume');
-      expect(result).toHaveProperty('plan');
-      expect(result).toHaveProperty('summary');
-      expect(result).toHaveProperty('timestamp');
+      assert.equal(code, 0);
+      assert.equal(result.ticket, TEST_TICKET);
+      assert.equal(result.mode, 'resume');
+      assert.ok(result.plan);
+      assert.ok(result.summary);
+      assert.ok(result.timestamp);
     });
 
     it('should detect ticket format correctly', async () => {
       const { result: ticketResult } = await runOrchestrator(['PROJ-123']);
-      expect(ticketResult.ticket).toBe('PROJ-123');
+      assert.equal(ticketResult.ticket, 'PROJ-123');
 
       const { result: descResult } = await runOrchestrator(['add new feature']);
-      expect(descResult.ticket).toContain('TBD');
-      expect(descResult.ticket).toContain('add new feature');
+      assert.ok(descResult.ticket.includes('TBD'));
+      assert.ok(descResult.ticket.includes('add new feature'));
     });
 
     it('should include all required steps in plan', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const stepNames = result.plan.map((s) => s.step);
-      expect(stepNames).toContain('1_ticket');
-      expect(stepNames).toContain('2_bootstrap');
-      expect(stepNames).toContain('3_implement');
-      expect(stepNames).toContain('4_quality');
-      expect(stepNames).toContain('5_commit');
-      expect(stepNames).toContain('6_check');
-      expect(stepNames).toContain('7_cleanup');
-      expect(stepNames).toContain('8_test_enhancement');
-      expect(stepNames).toContain('9_pr');
-      expect(stepNames).toContain('10_ready');
-      expect(stepNames).toContain('11_ci');
-      expect(stepNames).toContain('12_reports');
-      expect(stepNames).toContain('13_complete');
+      for (const expected of [
+        '1_ticket', '2_bootstrap', '3_implement', '4_quality',
+        '5_commit', '6_check', '7_cleanup', '8_test_enhancement',
+        '9_pr', '10_ready', '11_ci', '12_reports', '13_complete',
+      ]) {
+        assert.ok(stepNames.includes(expected), `Missing step: ${expected}`);
+      }
     });
 
     it('should generate summary with correct counts', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
-      expect(result.summary).toHaveProperty('total');
-      expect(result.summary).toHaveProperty('run');
-      expect(result.summary).toHaveProperty('skip');
-      expect(result.summary).toHaveProperty('pending');
-      expect(result.summary).toHaveProperty('firstAction');
-      expect(result.summary).toHaveProperty('stepsToRun');
-      expect(result.summary).toHaveProperty('stepsSkipped');
-
-      // Total should equal sum of actions
-      expect(result.summary.total).toBe(
-        result.summary.run + result.summary.skip + result.summary.pending
-      );
+      assert.ok('total' in result.summary);
+      assert.ok('run' in result.summary);
+      assert.ok('skip' in result.summary);
+      assert.ok('pending' in result.summary);
+      assert.ok('firstAction' in result.summary);
+      assert.ok('stepsToRun' in result.summary);
+      assert.ok('stepsSkipped' in result.summary);
+      assert.equal(result.summary.total, result.summary.run + result.summary.skip + result.summary.pending);
     });
 
     it('should use rework mode when --rework flag is passed', async () => {
       const { result } = await runOrchestrator([TEST_TICKET, '--rework']);
-
-      expect(result.mode).toBe('rework');
-
-      // In rework mode, 6_check should always be RUN
+      assert.equal(result.mode, 'rework');
       const checkStep = result.plan.find((s) => s.step === '6_check');
-      expect(checkStep.action).toBe('RUN');
-      expect(checkStep.reason).toContain('REWORK');
+      assert.equal(checkStep.action, 'RUN');
+      assert.ok(checkStep.reason.includes('REWORK'));
     });
 
     it('should include preCommands in rework mode for 6_check', async () => {
       const { result } = await runOrchestrator([TEST_TICKET, '--rework']);
-
       const checkStep = result.plan.find((s) => s.step === '6_check');
-      expect(checkStep).toHaveProperty('preCommands');
-      expect(checkStep.preCommands.length).toBeGreaterThan(0);
+      assert.ok(checkStep.preCommands);
+      assert.ok(checkStep.preCommands.length > 0);
     });
   });
 
   describe('transitions command', () => {
     const TEST_TICKET = 'TEST-888';
-
-    afterEach(() => {
-      cleanupTempWorkState(TEST_TICKET);
-    });
+    afterEach(() => { cleanupTempWorkState(TEST_TICKET); });
 
     it('should show error when no ticket provided', async () => {
       const { result, code } = await runOrchestrator(['transitions']);
-
-      expect(code).toBe(1);
-      expect(result.error).toBe(true);
-      expect(result.message).toContain('Usage');
+      assert.equal(code, 1);
+      assert.equal(result.error, true);
+      assert.ok(result.message.includes('Usage'));
     });
 
     it('should return current step and allowed transitions', async () => {
       const { result } = await runOrchestrator(['transitions', TEST_TICKET]);
-
-      expect(result).toHaveProperty('ticket');
-      expect(result).toHaveProperty('currentStep');
-      expect(result).toHaveProperty('allowed');
-      expect(Array.isArray(result.allowed)).toBe(true);
+      assert.ok('ticket' in result);
+      assert.ok('currentStep' in result);
+      assert.ok('allowed' in result);
+      assert.ok(Array.isArray(result.allowed));
     });
 
     it('should convert ticket to uppercase', async () => {
       const { result } = await runOrchestrator(['transitions', 'test-888']);
-
-      expect(result.ticket).toBe('TEST-888');
+      assert.equal(result.ticket, 'TEST-888');
     });
   });
 
   describe('transition command', () => {
     const TEST_TICKET = 'TEST-777';
-
-    afterEach(() => {
-      cleanupTempWorkState(TEST_TICKET);
-    });
+    afterEach(() => { cleanupTempWorkState(TEST_TICKET); });
 
     it('should show error when missing arguments', async () => {
       const { result, code } = await runOrchestrator(['transition']);
-
-      expect(code).toBe(1);
-      expect(result.error).toBe(true);
-      expect(result.message).toContain('Usage');
-      expect(result.validSteps).toBeDefined();
+      assert.equal(code, 1);
+      assert.equal(result.error, true);
+      assert.ok(result.message.includes('Usage'));
+      assert.ok(result.validSteps);
     });
 
     it('should show error when target step is invalid', async () => {
-      const { result } = await runOrchestrator([
-        'transition',
-        TEST_TICKET,
-        'invalid_step',
-      ]);
-
-      expect(result.error).toBe(true);
-      expect(result.message).toContain('Invalid step');
-      expect(result.validSteps).toBeDefined();
+      const { result } = await runOrchestrator(['transition', TEST_TICKET, 'invalid_step']);
+      assert.equal(result.error, true);
+      assert.ok(result.message.includes('Invalid step'));
+      assert.ok(result.validSteps);
     });
 
     it('should allow valid transition from 1_ticket to 2_bootstrap', async () => {
-      const { result } = await runOrchestrator([
-        'transition',
-        TEST_TICKET,
-        '2_bootstrap',
-      ]);
-
-      expect(result.success).toBe(true);
-      expect(result.from).toBe('1_ticket');
-      expect(result.to).toBe('2_bootstrap');
-      expect(result.direction).toBe('forward');
+      const { result } = await runOrchestrator(['transition', TEST_TICKET, '2_bootstrap']);
+      assert.equal(result.success, true);
+      assert.equal(result.from, '1_ticket');
+      assert.equal(result.to, '2_bootstrap');
+      assert.equal(result.direction, 'forward');
     });
 
     it('should block invalid transition', async () => {
-      // First transition to 3_implement
       await runOrchestrator(['transition', TEST_TICKET, '2_bootstrap']);
       await runOrchestrator(['transition', TEST_TICKET, '3_implement']);
-
-      // Now try to skip directly to 9_pr (not allowed)
-      const { result } = await runOrchestrator([
-        'transition',
-        TEST_TICKET,
-        '9_pr',
-      ]);
-
-      expect(result.error).toBe(true);
-      expect(result.message).toContain('BLOCKED');
-      expect(result.allowed).toBeDefined();
-      expect(result.hint).toBeDefined();
+      const { result } = await runOrchestrator(['transition', TEST_TICKET, '9_pr']);
+      assert.equal(result.error, true);
+      assert.ok(result.message.includes('BLOCKED'));
+      assert.ok(result.allowed);
+      assert.ok(result.hint);
     });
 
     it('should allow retry loop (backward transition)', async () => {
-      // Progress to 6_check
       await runOrchestrator(['transition', TEST_TICKET, '2_bootstrap']);
       await runOrchestrator(['transition', TEST_TICKET, '6_check']);
-
-      // Go back to 3_implement (valid retry loop)
-      const { result } = await runOrchestrator([
-        'transition',
-        TEST_TICKET,
-        '3_implement',
-      ]);
-
-      expect(result.success).toBe(true);
-      expect(result.from).toBe('6_check');
-      expect(result.to).toBe('3_implement');
-      expect(result.direction).toBe('backward');
+      const { result } = await runOrchestrator(['transition', TEST_TICKET, '3_implement']);
+      assert.equal(result.success, true);
+      assert.equal(result.from, '6_check');
+      assert.equal(result.to, '3_implement');
+      assert.equal(result.direction, 'backward');
     });
 
     it('should allow skip edge transition', async () => {
-      // From 2_bootstrap, skip to 6_check
       await runOrchestrator(['transition', TEST_TICKET, '2_bootstrap']);
-
-      const { result } = await runOrchestrator([
-        'transition',
-        TEST_TICKET,
-        '6_check',
-      ]);
-
-      expect(result.success).toBe(true);
-      expect(result.from).toBe('2_bootstrap');
-      expect(result.to).toBe('6_check');
+      const { result } = await runOrchestrator(['transition', TEST_TICKET, '6_check']);
+      assert.equal(result.success, true);
+      assert.equal(result.from, '2_bootstrap');
+      assert.equal(result.to, '6_check');
     });
 
     it('should persist state after transition', async () => {
       await runOrchestrator(['transition', TEST_TICKET, '2_bootstrap']);
       await runOrchestrator(['transition', TEST_TICKET, '3_implement']);
-
-      // Check current state
       const { result } = await runOrchestrator(['transitions', TEST_TICKET]);
-
-      expect(result.currentStep).toBe('3_implement');
-      expect(result.allStatuses['1_ticket']).toBe('completed');
-      expect(result.allStatuses['2_bootstrap']).toBe('completed');
-      expect(result.allStatuses['3_implement']).toBe('in_progress');
+      assert.equal(result.currentStep, '3_implement');
+      assert.equal(result.allStatuses['1_ticket'], 'completed');
+      assert.equal(result.allStatuses['2_bootstrap'], 'completed');
+      assert.equal(result.allStatuses['3_implement'], 'in_progress');
     });
 
     it('should reset intermediate steps on backward transition', async () => {
-      // Progress through several steps
       await runOrchestrator(['transition', TEST_TICKET, '2_bootstrap']);
       await runOrchestrator(['transition', TEST_TICKET, '3_implement']);
       await runOrchestrator(['transition', TEST_TICKET, '4_quality']);
       await runOrchestrator(['transition', TEST_TICKET, '5_commit']);
       await runOrchestrator(['transition', TEST_TICKET, '6_check']);
-
-      // Go back to 3_implement
       await runOrchestrator(['transition', TEST_TICKET, '3_implement']);
-
       const { result } = await runOrchestrator(['transitions', TEST_TICKET]);
-
-      // Steps after 3_implement should be reset to pending
-      expect(result.allStatuses['4_quality']).toBe('pending');
-      expect(result.allStatuses['5_commit']).toBe('pending');
-      expect(result.allStatuses['6_check']).toBe('pending');
+      assert.equal(result.allStatuses['4_quality'], 'pending');
+      assert.equal(result.allStatuses['5_commit'], 'pending');
+      assert.equal(result.allStatuses['6_check'], 'pending');
     });
   });
 
   describe('state machine logic', () => {
     it('should have 13 steps total', async () => {
       const { result } = await runOrchestrator(['graph']);
-
-      expect(result.steps.length).toBe(13);
+      assert.equal(result.steps.length, 13);
     });
 
     it('should not allow self-transitions', async () => {
       const { result } = await runOrchestrator(['graph']);
-
       for (const step of result.steps) {
-        expect(result.transitions[step]).not.toContain(step);
+        assert.ok(!result.transitions[step].includes(step), `${step} has self-transition`);
       }
     });
 
     it('should have terminal state at 13_complete', async () => {
       const { result } = await runOrchestrator(['graph']);
-
-      expect(result.transitions['13_complete']).toEqual([]);
+      assert.deepEqual(result.transitions['13_complete'], []);
     });
 
     it('should have exactly one entry point', async () => {
       const { result } = await runOrchestrator(['graph']);
-
-      // Only 1_ticket should not be a target of any transition
       const allTargets = new Set();
       for (const targets of Object.values(result.transitions)) {
         targets.forEach((t) => allTargets.add(t));
       }
-
       const entryPoints = result.steps.filter((s) => !allTargets.has(s));
-      expect(entryPoints).toEqual(['1_ticket']);
+      assert.deepEqual(entryPoints, ['1_ticket']);
     });
   });
 
   describe('plan action types', () => {
     const TEST_TICKET = 'TEST-666';
-
-    afterEach(() => {
-      cleanupTempWorkState(TEST_TICKET);
-    });
+    afterEach(() => { cleanupTempWorkState(TEST_TICKET); });
 
     it('should use RUN for steps that need execution', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const runSteps = result.plan.filter((s) => s.action === 'RUN');
-      expect(runSteps.length).toBeGreaterThan(0);
-
+      assert.ok(runSteps.length > 0);
       for (const step of runSteps) {
-        expect(step).toHaveProperty('reason');
+        assert.ok('reason' in step, `RUN step ${step.step} missing reason`);
       }
     });
 
     it('should use PENDING for steps dependent on earlier steps', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
-      // When no changes exist, 4_quality and 5_commit should be PENDING
       const qualityStep = result.plan.find((s) => s.step === '4_quality');
       const commitStep = result.plan.find((s) => s.step === '5_commit');
-
-      // These depend on 3_implement completing first
-      expect(qualityStep.action).toBe('PENDING');
-      expect(commitStep.action).toBe('PENDING');
+      assert.equal(qualityStep.action, 'PENDING');
+      assert.equal(commitStep.action, 'PENDING');
     });
 
     it('should include command for RUN steps', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const runSteps = result.plan.filter((s) => s.action === 'RUN');
-
       for (const step of runSteps) {
-        // Most RUN steps should have a command (some might not)
         if (step.command) {
-          expect(typeof step.command).toBe('string');
+          assert.equal(typeof step.command, 'string');
         }
       }
     });
@@ -459,182 +342,241 @@ describe('work-orchestrator.js', () => {
   describe('ticket format handling', () => {
     it('should accept uppercase ticket IDs', async () => {
       const { result } = await runOrchestrator(['PROJ-123']);
-      expect(result.ticket).toBe('PROJ-123');
+      assert.equal(result.ticket, 'PROJ-123');
     });
 
     it('should convert lowercase ticket IDs to uppercase', async () => {
       const { result } = await runOrchestrator(['proj-123']);
-      expect(result.ticket).toBe('PROJ-123');
+      assert.equal(result.ticket, 'PROJ-123');
     });
 
     it('should treat non-ticket format as description', async () => {
       const { result } = await runOrchestrator(['fix the login bug']);
-      expect(result.ticket).toContain('TBD');
-      expect(result.ticket).toContain('fix the login bug');
+      assert.ok(result.ticket.includes('TBD'));
+      assert.ok(result.ticket.includes('fix the login bug'));
     });
 
     it('should handle multi-word descriptions', async () => {
-      const { result } = await runOrchestrator([
-        'add',
-        'new',
-        'authentication',
-        'feature',
-      ]);
-      expect(result.ticket).toContain('add new authentication feature');
+      const { result } = await runOrchestrator(['add', 'new', 'authentication', 'feature']);
+      assert.ok(result.ticket.includes('add new authentication feature'));
     });
   });
 
   describe('agentType and agentPrompt fields', () => {
     const TEST_TICKET = 'TEST-444';
-
-    afterEach(() => {
-      cleanupTempWorkState(TEST_TICKET);
-    });
+    afterEach(() => { cleanupTempWorkState(TEST_TICKET); });
 
     it('should include agentType and agentPrompt for RUN steps', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const runSteps = result.plan.filter((s) => s.action === 'RUN');
-      expect(runSteps.length).toBeGreaterThan(0);
-
+      assert.ok(runSteps.length > 0);
       for (const step of runSteps) {
-        expect(step).toHaveProperty('agentType');
-        expect(step).toHaveProperty('agentPrompt');
-        expect(typeof step.agentType).toBe('string');
-        expect(typeof step.agentPrompt).toBe('string');
-        expect(step.agentType.length).toBeGreaterThan(0);
-        expect(step.agentPrompt.length).toBeGreaterThan(0);
+        assert.ok('agentType' in step, `RUN step ${step.step} missing agentType`);
+        assert.ok('agentPrompt' in step, `RUN step ${step.step} missing agentPrompt`);
+        assert.equal(typeof step.agentType, 'string');
+        assert.equal(typeof step.agentPrompt, 'string');
+        assert.ok(step.agentType.length > 0);
+        assert.ok(step.agentPrompt.length > 0);
       }
     });
 
     it('should not include agentType for SKIP steps', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const skipSteps = result.plan.filter((s) => s.action === 'SKIP');
       for (const step of skipSteps) {
-        expect(step.agentType).toBeUndefined();
-        expect(step.agentPrompt).toBeUndefined();
+        assert.equal(step.agentType, undefined);
+        assert.equal(step.agentPrompt, undefined);
       }
     });
 
     it('should not include agentType for PENDING steps', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const pendingSteps = result.plan.filter((s) => s.action === 'PENDING');
       for (const step of pendingSteps) {
-        expect(step.agentType).toBeUndefined();
-        expect(step.agentPrompt).toBeUndefined();
+        assert.equal(step.agentType, undefined);
+        assert.equal(step.agentPrompt, undefined);
       }
     });
 
     it('should use general-purpose for 1_ticket fetch when ticket exists', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const ticketStep = result.plan.find((s) => s.step === '1_ticket');
-      expect(ticketStep.agentType).toBe('general-purpose');
-      expect(ticketStep.agentPrompt).toContain(TEST_TICKET);
+      assert.equal(ticketStep.agentType, 'general-purpose');
+      assert.ok(ticketStep.agentPrompt.includes(TEST_TICKET));
     });
 
     it('should use jira-task-creator for 1_ticket when no ticket (description mode)', async () => {
       const { result } = await runOrchestrator(['add login feature']);
-
       const ticketStep = result.plan.find((s) => s.step === '1_ticket');
-      expect(ticketStep.agentType).toBe('jira-task-creator');
-      expect(ticketStep.agentPrompt).toContain('add login feature');
+      assert.equal(ticketStep.agentType, 'jira-task-creator');
+      assert.ok(ticketStep.agentPrompt.includes('add login feature'));
     });
 
-    it('should use quality-checker for 4_quality when code exists', async () => {
-      // Create a state where 4_quality would be RUN (hasDiffVsMain but not completed)
-      // Since TEST-444 likely has no worktree, 4_quality will be PENDING
-      // We test the plan structure for steps that ARE RUN
+    it('should use Bash agent for 11_ci', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
-      // 11_ci is always RUN so let's check its agentType
       const ciStep = result.plan.find((s) => s.step === '11_ci');
-      expect(ciStep.agentType).toBe('Bash');
-      expect(ciStep.agentPrompt).toContain('gh pr checks');
+      assert.equal(ciStep.agentType, 'Bash');
+      assert.ok(ciStep.agentPrompt.includes('gh pr checks'));
     });
 
     it('should use Bash agent for 13_complete', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const completeStep = result.plan.find((s) => s.step === '13_complete');
-      expect(completeStep.agentType).toBe('Bash');
-      expect(completeStep.agentPrompt).toContain('work-state.js complete');
+      assert.equal(completeStep.agentType, 'Bash');
+      assert.ok(completeStep.agentPrompt.includes('work-state.js complete'));
     });
 
     it('should use Bash agent for 12_reports', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const reportsStep = result.plan.find((s) => s.step === '12_reports');
-      expect(reportsStep.agentType).toBe('Bash');
+      assert.equal(reportsStep.agentType, 'Bash');
     });
 
     it('should use skill for bootstrap', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const bootstrapStep = result.plan.find((s) => s.step === '2_bootstrap');
       if (bootstrapStep.action === 'RUN') {
-        expect(bootstrapStep.agentType).toBe('skill');
-        expect(bootstrapStep.agentPrompt).toContain('bootstrap');
+        assert.equal(bootstrapStep.agentType, 'skill');
+        assert.ok(bootstrapStep.agentPrompt.includes('bootstrap'));
       }
     });
 
     it('should use general-purpose for 2b_transition', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       const transStep = result.plan.find((s) => s.step === '2b_transition');
-      expect(transStep.agentType).toBe('general-purpose');
-      expect(transStep.agentPrompt).toContain('transition');
+      assert.equal(transStep.agentType, 'general-purpose');
+      assert.ok(transStep.agentPrompt.includes('transition'));
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Patch 14: New transition edges
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('new transition edges (Patch 14)', () => {
+    it('should include 5_commit → 4_quality (quality re-verify)', async () => {
+      const { result } = await runOrchestrator(['graph']);
+      assert.ok(result.transitions['5_commit'].includes('4_quality'));
+    });
+
+    it('should include 6_check → 4_quality (quality re-run)', async () => {
+      const { result } = await runOrchestrator(['graph']);
+      assert.ok(result.transitions['6_check'].includes('4_quality'));
+    });
+
+    it('should include 8_test_enhancement → 4_quality (new tests need quality)', async () => {
+      const { result } = await runOrchestrator(['graph']);
+      assert.ok(result.transitions['8_test_enhancement'].includes('4_quality'));
+    });
+
+    it('should include 8_test_enhancement → 3_implement (tests reveal impl flaw)', async () => {
+      const { result } = await runOrchestrator(['graph']);
+      assert.ok(result.transitions['8_test_enhancement'].includes('3_implement'));
+    });
+
+    it('should include 9_pr → 11_ci (skip 10_ready)', async () => {
+      const { result } = await runOrchestrator(['graph']);
+      assert.ok(result.transitions['9_pr'].includes('11_ci'));
+    });
+
+    it('should allow transition from 6_check → 4_quality', async () => {
+      const TEST_TICKET = 'TEST-614';
+      try {
+        await runOrchestrator(['transition', TEST_TICKET, '2_bootstrap']);
+        await runOrchestrator(['transition', TEST_TICKET, '6_check']);
+        const { result } = await runOrchestrator(['transition', TEST_TICKET, '4_quality']);
+        assert.equal(result.success, true);
+        assert.equal(result.direction, 'backward');
+      } finally {
+        cleanupTempWorkState(TEST_TICKET);
+      }
+    });
+
+    it('should allow transition from 8_test_enhancement → 3_implement', async () => {
+      const TEST_TICKET = 'TEST-813';
+      try {
+        await runOrchestrator(['transition', TEST_TICKET, '2_bootstrap']);
+        await runOrchestrator(['transition', TEST_TICKET, '6_check']);
+        await runOrchestrator(['transition', TEST_TICKET, '8_test_enhancement']);
+        const { result } = await runOrchestrator(['transition', TEST_TICKET, '3_implement']);
+        assert.equal(result.success, true);
+        assert.equal(result.direction, 'backward');
+      } finally {
+        cleanupTempWorkState(TEST_TICKET);
+      }
+    });
+
+    it('should allow transition from 9_pr → 11_ci (skip 10_ready)', async () => {
+      const TEST_TICKET = 'TEST-911';
+      try {
+        await runOrchestrator(['transition', TEST_TICKET, '2_bootstrap']);
+        await runOrchestrator(['transition', TEST_TICKET, '6_check']);
+        await runOrchestrator(['transition', TEST_TICKET, '8_test_enhancement']);
+        await runOrchestrator(['transition', TEST_TICKET, '9_pr']);
+        const { result } = await runOrchestrator(['transition', TEST_TICKET, '11_ci']);
+        assert.equal(result.success, true);
+        assert.equal(result.from, '9_pr');
+        assert.equal(result.to, '11_ci');
+      } finally {
+        cleanupTempWorkState(TEST_TICKET);
+      }
+    });
+
+    it('should reset intermediate steps when skipping 9_pr → 11_ci', async () => {
+      const TEST_TICKET = 'TEST-912';
+      try {
+        await runOrchestrator(['transition', TEST_TICKET, '2_bootstrap']);
+        await runOrchestrator(['transition', TEST_TICKET, '6_check']);
+        await runOrchestrator(['transition', TEST_TICKET, '8_test_enhancement']);
+        await runOrchestrator(['transition', TEST_TICKET, '9_pr']);
+        await runOrchestrator(['transition', TEST_TICKET, '11_ci']);
+        const { result } = await runOrchestrator(['transitions', TEST_TICKET]);
+        // 10_ready should be marked completed (skipped)
+        assert.equal(result.allStatuses['10_ready'], 'completed');
+        assert.equal(result.allStatuses['11_ci'], 'in_progress');
+      } finally {
+        cleanupTempWorkState(TEST_TICKET);
+      }
     });
   });
 
   describe('error handling', () => {
     it('should handle missing work state gracefully', async () => {
-      // Use proper ticket format (LETTERS-DIGITS)
       const { result, code } = await runOrchestrator(['TEST-99999']);
-
-      expect(code).toBe(0);
-      expect(result.ticket).toBe('TEST-99999');
-      expect(result.plan).toBeDefined();
+      assert.equal(code, 0);
+      assert.equal(result.ticket, 'TEST-99999');
+      assert.ok(result.plan);
     });
 
     it('should handle invalid transition subcommand args', async () => {
       const { result, code } = await runOrchestrator(['transition', 'TICKET']);
-
-      expect(code).toBe(1);
-      expect(result.error).toBe(true);
+      assert.equal(code, 1);
+      assert.equal(result.error, true);
     });
   });
 
   describe('summary output', () => {
     const TEST_TICKET = 'TEST-555';
-
-    afterEach(() => {
-      cleanupTempWorkState(TEST_TICKET);
-    });
+    afterEach(() => { cleanupTempWorkState(TEST_TICKET); });
 
     it('should include stepsToRun array', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
-      expect(Array.isArray(result.summary.stepsToRun)).toBe(true);
-      expect(result.summary.stepsToRun.length).toBe(result.summary.run);
+      assert.ok(Array.isArray(result.summary.stepsToRun));
+      assert.equal(result.summary.stepsToRun.length, result.summary.run);
     });
 
     it('should include stepsSkipped array', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
-      expect(Array.isArray(result.summary.stepsSkipped)).toBe(true);
-      expect(result.summary.stepsSkipped.length).toBe(result.summary.skip);
+      assert.ok(Array.isArray(result.summary.stepsSkipped));
+      assert.equal(result.summary.stepsSkipped.length, result.summary.skip);
     });
 
     it('should identify firstAction correctly', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
-
       if (result.summary.run > 0) {
-        expect(result.summary.firstAction).toBe(result.summary.stepsToRun[0]);
+        assert.equal(result.summary.firstAction, result.summary.stepsToRun[0]);
       } else {
-        expect(result.summary.firstAction).toBe('none');
+        assert.equal(result.summary.firstAction, 'none');
       }
     });
   });

--- a/hooks/enforce-completion-protocol.js
+++ b/hooks/enforce-completion-protocol.js
@@ -1,0 +1,478 @@
+#!/usr/bin/env node
+
+/**
+ * Stop hook to enforce Task Completion Protocol
+ *
+ * Blocks Claude from declaring tasks complete without proper verification:
+ * - Lint/typecheck output (for code changes)
+ * - Test output (for code changes)
+ * - requirements-verifier agent called
+ * - Functional testing evidence (for config changes)
+ *
+ * Dynamically determines required checks based on files modified.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Completion phrases to detect
+const COMPLETION_PHRASES = [
+  /\bimplementation\s+(?:is\s+)?complete/i,
+  /\btask\s+(?:is\s+)?complete/i,
+  /\bwork\s+(?:is\s+)?complete/i,
+  /\ball\s+(?:tasks?\s+)?(?:are\s+)?done/i,
+  /\bfinished\s+(?:the\s+)?implementation/i,
+  /\bcompleted\s+(?:the\s+)?(?:task|work|implementation)/i,
+  /\btask\s+(?:has\s+been\s+)?finished/i,
+  /\bchanges\s+(?:are\s+)?complete/i,
+  /\bready\s+for\s+review/i,
+  /\bready\s+to\s+(?:merge|commit|push)/i,
+  /\bI(?:'ve|'m)\s+(?:now\s+)?(?:done|finished|completed)/i,
+  /\bthat\s+(?:completes?|finishes?)/i,
+  /\bthe\s+(?:feature|fix|change|documentation|update)\s+is\s+(?:now\s+)?(?:complete|done|ready)/i,
+  /\bdocumentation\s+(?:is\s+)?(?:complete|done|updated)/i,
+  /\bupdates?\s+(?:are\s+)?(?:complete|done)/i,
+  /\bthis\s+(?:is\s+)?(?:complete|done|finished)/i,
+  /\beverything\s+(?:is\s+)?(?:complete|done|ready)/i,
+  /\b(?:code|feature|fix)\s+(?:is\s+)?(?:complete|done|ready)/i,
+];
+
+// Phrases that indicate ongoing work (NOT completion)
+const ONGOING_PHRASES = [
+  /\blet\s+me\s+(?:now\s+)?(?:run|check|verify|test)/i,
+  /\bnow\s+(?:I(?:'ll|'m going to))\s+(?:run|check|verify|test)/i,
+  /\bI(?:'ll|'m going to)\s+(?:run|verify|check)/i,
+  /\bstarting\s+(?:to\s+)?(?:run|check|verify)/i,
+  /\bmarking.*(?:in.progress|pending)/i,
+  /\bnext\s+(?:step|I(?:'ll|'m going to))/i,
+  /\bcontinue\s+(?:by|with|to)/i,
+];
+
+// File extensions and their categories
+const FILE_CATEGORIES = {
+  code: ['.ts', '.tsx', '.js', '.jsx', '.py', '.java', '.go', '.rs', '.cpp', '.c', '.cs', '.php', '.rb'],
+  config: ['vite.config', 'webpack.config', 'tsconfig', 'eslint', 'prettier', 'jest.config', 'vitest.config'],
+  docs: ['.md', '.mdx', '.txt', '.rst'],
+  ci: ['.yml', '.yaml', '.github'],
+  test: ['.test.', '.spec.', '__tests__', 'test/', 'tests/'],
+  migration: ['migration/', 'migrations/'],
+};
+
+// Required checks by category
+const REQUIRED_CHECKS = {
+  code: ['lint', 'typecheck', 'test', 'requirements-verifier', 'steps-done'],
+  config: ['lint', 'typecheck', 'functional-test', 'requirements-verifier', 'steps-done'],
+  docs: ['requirements-verifier', 'steps-done'],
+  ci: ['requirements-verifier', 'steps-done'],
+  test: ['lint', 'typecheck', 'test', 'requirements-verifier', 'steps-done'],
+  migration: ['migration-test', 'requirements-verifier', 'steps-done'],
+};
+
+/**
+ * Check if a file path is inside a git repository
+ */
+function isInsideGitRepo(filePath) {
+  try {
+    const dirPath = path.dirname(filePath);
+    // Check if directory exists
+    if (!fs.existsSync(dirPath)) {
+      return false;
+    }
+    // Try to run git rev-parse to check if we're in a git repo
+    execSync('git rev-parse --git-dir', { cwd: dirPath, stdio: 'pipe' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Categorize a file based on its path/extension
+ */
+function categorizeFile(filePath) {
+  const lowerPath = filePath.toLowerCase();
+
+  // Check for migration files first
+  if (FILE_CATEGORIES.migration.some(pattern => lowerPath.includes(pattern))) {
+    return 'migration';
+  }
+
+  // Check for test files
+  if (FILE_CATEGORIES.test.some(pattern => lowerPath.includes(pattern))) {
+    return 'test';
+  }
+
+  // Check for CI files
+  if (FILE_CATEGORIES.ci.some(pattern => lowerPath.includes(pattern))) {
+    return 'ci';
+  }
+
+  // Check for docs
+  if (FILE_CATEGORIES.docs.some(ext => lowerPath.endsWith(ext))) {
+    return 'docs';
+  }
+
+  // Check for config files
+  if (FILE_CATEGORIES.config.some(pattern => lowerPath.includes(pattern))) {
+    return 'config';
+  }
+
+  // Check for code files
+  if (FILE_CATEGORIES.code.some(ext => lowerPath.endsWith(ext))) {
+    return 'code';
+  }
+
+  return 'other';
+}
+
+/**
+ * Determine what checks are required based on modified files
+ */
+function determineRequiredChecks(modifiedFiles) {
+  const categories = new Set();
+
+  for (const file of modifiedFiles) {
+    categories.add(categorizeFile(file));
+  }
+
+  // Aggregate required checks
+  const checks = new Set();
+
+  for (const category of categories) {
+    const categoryChecks = REQUIRED_CHECKS[category] || [];
+    for (const check of categoryChecks) {
+      checks.add(check);
+    }
+  }
+
+  // If we have any code/config, add lint/typecheck
+  if (categories.has('code') || categories.has('config') || categories.has('test')) {
+    checks.add('lint');
+    checks.add('typecheck');
+  }
+
+  // Always require requirements-verifier for non-trivial changes
+  if (modifiedFiles.length > 0 && !categories.has('other')) {
+    checks.add('requirements-verifier');
+  }
+
+  return Array.from(checks);
+}
+
+/**
+ * Parse transcript and extract relevant information
+ */
+function parseTranscript(transcriptPath) {
+  if (!fs.existsSync(transcriptPath)) {
+    return { modifiedFiles: [], checks: {} };
+  }
+
+  const content = fs.readFileSync(transcriptPath, 'utf8');
+  const lines = content.trim().split('\n');
+
+  const modifiedFiles = new Set();
+  const checks = {
+    lint: false,
+    typecheck: false,
+    test: false,
+    'functional-test': false,
+    'migration-test': false,
+    'requirements-verifier': false,
+    'code-checker': false,
+    'steps-done': false,  // Always marked as done if we got this far (assistant is declaring completion)
+  };
+
+  // Evidence patterns
+  const lintPatterns = [
+    /pnpm\s+lint/i,
+    /npm\s+run\s+lint/i,
+    /eslint/i,
+    /0\s+(?:errors?|warnings?)/i,
+    /no\s+(?:lint\s+)?(?:errors?|issues?)/i,
+  ];
+
+  const typecheckPatterns = [
+    /pnpm\s+typecheck/i,
+    /npm\s+run\s+typecheck/i,
+    /tsc/i,
+    /no\s+(?:type\s*)?errors?/i,
+    /type\s*check(?:ing)?\s+(?:passed|succeeded|complete)/i,
+  ];
+
+  const testPatterns = [
+    /pnpm\s+test/i,
+    /npm\s+run\s+test/i,
+    /vitest/i,
+    /jest/i,
+    /tests?\s+passed/i,
+    /\d+\s+passed/i,
+  ];
+
+  const migrationPatterns = [
+    /pnpm\s+run\s+migration/i,
+    /npm\s+run\s+migration/i,
+    /migration:(?:up|down|run|test)/i,
+    /db:migrate/i,
+    /migrate(?::\w+)?/i,
+  ];
+
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+      const msgContent = entry.message?.content;
+
+      if (!msgContent) continue;
+
+      // Convert to string for pattern matching
+      const contentStr = typeof msgContent === 'string' ? msgContent : JSON.stringify(msgContent);
+
+      // Check for modified files from Edit/Write tool calls
+      if (Array.isArray(msgContent)) {
+        for (const block of msgContent) {
+          if (block.type === 'tool_use') {
+            if (block.name === 'Edit' || block.name === 'Write' || block.name === 'MultiEdit') {
+              const filePath = block.input?.file_path || block.input?.path;
+              if (filePath) {
+                modifiedFiles.add(filePath);
+              }
+            }
+
+            // Check for requirements-verifier agent call
+            if (block.name === 'Task' && block.input?.subagent_type) {
+              const agentType = block.input.subagent_type.toLowerCase();
+              if (agentType.includes('requirements') || agentType.includes('verifier') || agentType.includes('completion-checker')) {
+                checks['requirements-verifier'] = true;
+              }
+              if (agentType.includes('code-checker') || agentType.includes('quality')) {
+                checks['code-checker'] = true;
+              }
+            }
+
+            // Check for quality check commands
+            if (block.name === 'Bash' && block.input?.command) {
+              const cmd = block.input.command;
+
+              if (lintPatterns.some(p => p.test(cmd))) {
+                checks.lint = true;
+              }
+              if (typecheckPatterns.some(p => p.test(cmd))) {
+                checks.typecheck = true;
+              }
+              if (testPatterns.some(p => p.test(cmd))) {
+                checks.test = true;
+              }
+              if (migrationPatterns.some(p => p.test(cmd))) {
+                checks['migration-test'] = true;
+              }
+            }
+          }
+        }
+      }
+
+      // Also check tool results for success indicators
+      if (entry.type === 'tool_result') {
+        const resultStr = typeof entry.content === 'string' ? entry.content : JSON.stringify(entry.content || '');
+
+        if (lintPatterns.some(p => p.test(resultStr))) {
+          checks.lint = true;
+        }
+        if (typecheckPatterns.some(p => p.test(resultStr))) {
+          checks.typecheck = true;
+        }
+        if (testPatterns.some(p => p.test(resultStr))) {
+          checks.test = true;
+        }
+      }
+
+    } catch (e) {
+      // Skip malformed lines
+    }
+  }
+
+  return {
+    modifiedFiles: Array.from(modifiedFiles),
+    checks,
+  };
+}
+
+/**
+ * Check if the assistant message contains completion language
+ */
+function containsCompletionLanguage(message) {
+  // First check for ongoing work phrases (not completion)
+  for (const pattern of ONGOING_PHRASES) {
+    if (pattern.test(message)) {
+      return false;
+    }
+  }
+
+  // Then check for completion phrases
+  for (const pattern of COMPLETION_PHRASES) {
+    if (pattern.test(message)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Get the last assistant message from hook data
+ */
+function getAssistantMessage(hookData) {
+  // Check the assistant_message field
+  if (hookData.assistant_message) {
+    const content = hookData.assistant_message.content;
+    return typeof content === 'string' ? content : JSON.stringify(content || '');
+  }
+
+  // Fallback to reading from transcript
+  if (hookData.transcript_path && fs.existsSync(hookData.transcript_path)) {
+    const content = fs.readFileSync(hookData.transcript_path, 'utf8');
+    const lines = content.trim().split('\n');
+
+    // Get last assistant message
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const entry = JSON.parse(lines[i]);
+        if (entry.type === 'assistant' || entry.message?.role === 'assistant') {
+          const msgContent = entry.message?.content;
+          return typeof msgContent === 'string' ? msgContent : JSON.stringify(msgContent || '');
+        }
+      } catch (e) {}
+    }
+  }
+
+  return '';
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  let hookData;
+  try {
+    hookData = JSON.parse(input);
+  } catch (e) {
+    process.exit(0);
+  }
+
+  // Prevent infinite loops
+  if (hookData.stop_hook_active) {
+    process.exit(0);
+  }
+
+  // Get the assistant message
+  const assistantMessage = getAssistantMessage(hookData);
+
+  // Check if message contains completion language
+  if (!containsCompletionLanguage(assistantMessage)) {
+    process.exit(0);
+  }
+
+  // Parse transcript for evidence
+  const transcriptPath = hookData.transcript_path;
+  if (!transcriptPath) {
+    process.exit(0);
+  }
+
+  const { modifiedFiles: allModifiedFiles, checks } = parseTranscript(transcriptPath);
+
+  // Filter to only files inside git repositories
+  const modifiedFiles = allModifiedFiles.filter(f => isInsideGitRepo(f));
+
+  // If no files modified in git repos, allow completion
+  if (modifiedFiles.length === 0) {
+    process.exit(0);
+  }
+
+  // Determine required checks based on files modified
+  const requiredChecks = determineRequiredChecks(modifiedFiles);
+
+  // Filter out checks that aren't required for docs-only changes
+  const allDocs = modifiedFiles.every(f => categorizeFile(f) === 'docs');
+  if (allDocs) {
+    // For docs-only, just need requirements-verifier
+    const docsRequired = requiredChecks.filter(c => c === 'requirements-verifier');
+    requiredChecks.length = 0;
+    requiredChecks.push(...docsRequired);
+  }
+
+  // Determine what categories of files we have
+  const hasCodeFiles = modifiedFiles.some(f => {
+    const cat = categorizeFile(f);
+    return cat === 'code' || cat === 'test' || cat === 'config';
+  });
+  const hasMigrationFiles = modifiedFiles.some(f => categorizeFile(f) === 'migration');
+
+  // Build the checklist items with status
+  const checklist = [];
+
+  // Lint (if code)
+  if (hasCodeFiles) {
+    const status = checks.lint ? '[x]' : '[ ]';
+    checklist.push(`${status} lint only on changed files (code changes detected)`);
+  }
+
+  // Typecheck (if code)
+  if (hasCodeFiles) {
+    const status = checks.typecheck ? '[x]' : '[ ]';
+    checklist.push(`${status} typecheck only on changed files (code changes detected)`);
+  }
+
+  // Tests (if code)
+  if (hasCodeFiles) {
+    const status = checks.test ? '[x]' : '[ ]';
+    checklist.push(`${status} tests only on changed files (code changes detected)`);
+  }
+
+  // Migration test (if migration files changed)
+  if (hasMigrationFiles) {
+    const status = checks['migration-test'] ? '[x]' : '[ ]';
+    checklist.push(`${status} tested migration with appropriate command (migration/** changed)`);
+  }
+
+  // Requirements verifier (always)
+  const reqStatus = checks['requirements-verifier'] ? '[x]' : '[ ]';
+  checklist.push(`${reqStatus} req verifier (always required)`);
+
+  // Steps done (always - will be shown but we don't track this automatically)
+  checklist.push(`[ ] steps done to achieve (always required - describe what you did)`);
+
+  // Check what's actually missing
+  const missing = [];
+
+  if (hasCodeFiles && !checks.lint) {
+    missing.push('lint');
+  }
+  if (hasCodeFiles && !checks.typecheck) {
+    missing.push('typecheck');
+  }
+  if (hasCodeFiles && !checks.test) {
+    missing.push('tests');
+  }
+  if (hasMigrationFiles && !checks['migration-test']) {
+    missing.push('migration test');
+  }
+  if (!checks['requirements-verifier']) {
+    missing.push('requirements verifier');
+  }
+
+  if (missing.length > 0) {
+    const fileCategories = modifiedFiles.map(f => `  - ${f} (${categorizeFile(f)})`).join('\n');
+
+    process.stderr.write(`BLOCKED: Task Completion Protocol Violation\n\nYou declared the task complete, but verification is missing!\n\nFiles Modified:\n${fileCategories}\n\nVerification Checklist:\n${checklist.join('\n')}\n\nMissing: ${missing.join(', ')}\n\nREQUIRED: Complete all unchecked items above, then declare the task done.\n`);
+    process.exit(2);
+  }
+
+  // All checks passed
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Hook error:', err.message);
+  process.exit(0);
+});

--- a/hooks/enforce-coverage-fix.js
+++ b/hooks/enforce-coverage-fix.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+/**
+ * PostToolUse hook: Enforce /test-coordination for coverage failures
+ *
+ * Triggers on Bash commands that check CI status (gh run view, gh pr checks).
+ * Reads the transcript to check if the output contains coverage failure patterns.
+ * If detected, injects a mandatory reminder to run /test-coordination.
+ *
+ * This prevents the AI from rationalizing coverage failures as "pre-existing"
+ * or "infrastructure issues" instead of following /follow-up-pr section 4.3.
+ */
+
+const fs = require('fs');
+const config = require('../lib/config');
+
+const COVERAGE_FAILURE_PATTERNS = [
+  /coverage\s+decrease/i,
+  /please add tests to maintain/i,
+  /check.?modified.?files.?coverage/i,
+  /coverage.?summary\.json/i,
+  /below\s+\d+%\s+(test\s+)?coverage/i,
+  /vitest-coverage-report/i,
+  /check-coverage-decrease/i,
+  /coverage.*fail/i,
+  /fail.*coverage/i,
+];
+
+// CI-checking command patterns
+const CI_CHECK_COMMANDS = [
+  /gh\s+run\s+view/,
+  /gh\s+pr\s+checks/,
+  /gh\s+run\s+list.*--status\s+failure/,
+];
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  const hookData = JSON.parse(input);
+
+  // Only check Bash commands
+  if (hookData.tool_name !== 'Bash') {
+    return;
+  }
+
+  const command = hookData.tool_input?.command || '';
+
+  // Only trigger on CI-checking commands
+  const isCICheck = CI_CHECK_COMMANDS.some(p => p.test(command));
+  if (!isCICheck) {
+    return;
+  }
+
+  // Read transcript to find the tool output
+  const transcriptPath = hookData.transcript_path;
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+    return;
+  }
+
+  // Read last 50 lines of transcript (tool output should be recent)
+  let output = '';
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+    const lines = content.split('\n').filter(Boolean);
+    // Check last 50 entries for tool_result containing our output
+    const recentLines = lines.slice(-50);
+    for (const line of recentLines) {
+      try {
+        const entry = JSON.parse(line);
+        // tool_result entries contain the output
+        if (entry.type === 'tool_result' || entry.content) {
+          const text = typeof entry.content === 'string'
+            ? entry.content
+            : JSON.stringify(entry.content || '');
+          output += text + '\n';
+        }
+      } catch {
+        // Not JSON, skip
+      }
+    }
+  } catch {
+    return;
+  }
+
+  // Check if output contains coverage failure patterns
+  const hasCoverageFailure = COVERAGE_FAILURE_PATTERNS.some(p => p.test(output));
+
+  if (hasCoverageFailure) {
+    // Determine ticket ID from branch
+    let ticketId = 'TICKET_ID';
+    try {
+      const { execSync } = require('child_process');
+      const branch = execSync('git branch --show-current', { encoding: 'utf8' }).trim();
+      const match = branch.match(new RegExp(config.JIRA_PROJECT_KEY + '-\\d+', 'i'));
+      if (match) ticketId = match[0].toUpperCase();
+    } catch { /* */ }
+
+    console.log(`🛑 COVERAGE FAILURE DETECTED IN CI OUTPUT
+
+╔══════════════════════════════════════════════════════════════════════╗
+║  MANDATORY: Run /test-coordination NOW                               ║
+║                                                                      ║
+║  DO NOT investigate CI config.                                       ║
+║  DO NOT argue it's "pre-existing" or "infrastructure".               ║
+║  DO NOT rationalize that "real tests passed".                        ║
+║                                                                      ║
+║  Run: Skill(test-coordination): ${ticketId.padEnd(16)}               ║
+║  Then: git push                                                      ║
+║  Then: Continue CI check loop                                        ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+Per /follow-up-pr section 4.3: ANY coverage-related CI failure → /test-coordination. No exceptions.`);
+  }
+}
+
+main().catch(() => {});

--- a/hooks/enforce-env-start-failure.js
+++ b/hooks/enforce-env-start-failure.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+/**
+ * Enforce dev environment failure handling via hard blocks.
+ *
+ * PHASE 1 (PostToolUse on Bash):
+ *   When check-start-env.js output has "started": false,
+ *   writes marker to /tmp/check-env-failed-<ticket>.
+ *
+ * PHASE 2 (PreToolUse on Task/Skill):
+ *   BLOCKS ALL Task/Skill launches while marker exists.
+ *   Only AskUserQuestion is allowed (to force user choice).
+ *   stderr tells AI exactly what to do.
+ *
+ * PHASE 3 (PostToolUse on AskUserQuestion):
+ *   When AskUserQuestion is called and marker exists,
+ *   deletes the marker (unblocks everything).
+ *   If user chose "Skip QA", writes skip-qa marker instead.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const config = require('../lib/config');
+
+const MARKER_DIR = '/tmp';
+
+function getTicketId() {
+  try {
+    const { execSync } = require('child_process');
+    const branch = execSync('git branch --show-current 2>/dev/null', { encoding: 'utf8' }).trim();
+    const match = branch.match(new RegExp(config.JIRA_PROJECT_KEY + '-\\d+', 'i'));
+    return match ? match[0].toUpperCase() : 'UNKNOWN';
+  } catch {
+    return 'UNKNOWN';
+  }
+}
+
+function markerPath(ticketId) {
+  return path.join(MARKER_DIR, `check-env-failed-${ticketId}`);
+}
+
+function skipQaMarkerPath(ticketId) {
+  return path.join(MARKER_DIR, `check-skip-qa-${ticketId}`);
+}
+
+// ─── PHASE 1: PostToolUse/Bash — detect failure, write marker ───
+
+function phase1_detectFailure(hookData) {
+  const command = hookData.tool_input?.command || '';
+  if (!command.includes('check-start-env')) return;
+
+  const transcriptPath = hookData.transcript_path;
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) return;
+
+  let output = '';
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+    const lines = content.split('\n').filter(Boolean);
+    for (const line of lines.slice(-30)) {
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type === 'tool_result' || entry.content) {
+          const text = typeof entry.content === 'string'
+            ? entry.content
+            : JSON.stringify(entry.content || '');
+          output += text + '\n';
+        }
+      } catch { /* skip */ }
+    }
+  } catch { return; }
+
+  const hasFail = /"started":\s*false/.test(output)
+    || /Timeout waiting for app to start/.test(output);
+  const hasEmptyApps = /"runningApps":\s*\{\s*\}/.test(output)
+    && /"apps":\s*\{/.test(output);
+
+  const ticketId = getTicketId();
+  const mp = markerPath(ticketId);
+
+  if (hasFail || hasEmptyApps) {
+    const failedMatches = output.match(/"name":\s*"([^"]+)"[^}]*"started":\s*false/g) || [];
+    const failedApps = failedMatches.map(m => {
+      const n = m.match(/"name":\s*"([^"]+)"/);
+      return n ? n[1] : 'unknown';
+    });
+
+    fs.writeFileSync(mp, JSON.stringify({ failedApps, timestamp: new Date().toISOString(), ticketId }));
+    process.stderr.write(`ENV_FAILURE: marker written (${failedApps.join(', ')})\n`);
+  } else {
+    try { fs.unlinkSync(mp); } catch { /* */ }
+  }
+}
+
+// ─── PHASE 2: PreToolUse/Task+Skill — block everything until user chooses ───
+
+function phase2_blockUntilUserChoice(hookData) {
+  const ticketId = getTicketId();
+  const mp = markerPath(ticketId);
+
+  if (!fs.existsSync(mp)) return; // No failure, allow
+
+  let failInfo = {};
+  try { failInfo = JSON.parse(fs.readFileSync(mp, 'utf8')); } catch { /* */ }
+  const appList = (failInfo.failedApps || []).join(', ') || 'apps';
+
+  process.stderr.write(
+    `BLOCKED: Dev apps failed to start (${appList}). ` +
+    'Call AskUserQuestion with options: "Retry" | "Start manually" | "Skip QA" | "Abort /check". ' +
+    `Marker: ${mp}\n`
+  );
+  process.exit(2);
+}
+
+// ─── PHASE 3: PostToolUse/AskUserQuestion — user chose, unblock ───
+
+function phase3_unblockAfterChoice(hookData) {
+  const ticketId = getTicketId();
+  const mp = markerPath(ticketId);
+
+  if (!fs.existsSync(mp)) return; // No marker, nothing to do
+
+  // Delete the block marker — user has been consulted
+  try { fs.unlinkSync(mp); } catch { /* */ }
+  process.stderr.write(`ENV_FAILURE: marker cleared after AskUserQuestion\n`);
+
+  // Check if user chose to skip QA (look at transcript for the answer)
+  const transcriptPath = hookData.transcript_path;
+  if (transcriptPath && fs.existsSync(transcriptPath)) {
+    try {
+      const content = fs.readFileSync(transcriptPath, 'utf8');
+      const lines = content.split('\n').filter(Boolean);
+      const recent = lines.slice(-10).join(' ');
+      if (/skip\s*qa/i.test(recent)) {
+        fs.writeFileSync(skipQaMarkerPath(ticketId), JSON.stringify({ ticketId, timestamp: new Date().toISOString() }));
+        process.stderr.write('Skip-QA marker written. QA agents will be skipped.\n');
+      }
+    } catch { /* */ }
+  }
+}
+
+// ─── Main ───
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  const hookData = JSON.parse(input);
+  const hookType = process.env.CLAUDE_HOOK_TYPE || 'PostToolUse';
+  const toolName = hookData.tool_name;
+
+  if (hookType === 'PreToolUse') {
+    // Phase 2: Block Task and Skill while marker exists
+    if (toolName === 'Task' || toolName === 'Skill') {
+      phase2_blockUntilUserChoice(hookData);
+    }
+  } else if (hookType === 'PostToolUse') {
+    if (toolName === 'Bash') {
+      // Phase 1: Detect check-start-env failure
+      phase1_detectFailure(hookData);
+    } else if (toolName === 'AskUserQuestion') {
+      // Phase 3: User made a choice, unblock
+      phase3_unblockAfterChoice(hookData);
+    }
+  }
+}
+
+main().catch(() => {});

--- a/hooks/enforce-screenshot-gate.js
+++ b/hooks/enforce-screenshot-gate.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+/**
+ * PostToolUse hook (Skill: work-pr) — Screenshot Gate
+ *
+ * After /work-pr completes, checks if:
+ *   1. TSX/JSX source files (not test files) were changed vs origin/main
+ *   2. No screenshot files exist in the tasks folder
+ *
+ * If both true, blocks and requires screenshots before marking complete.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const config = require('../lib/config');
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  let hookData;
+  try {
+    hookData = JSON.parse(input);
+  } catch {
+    process.exit(0);
+  }
+
+  // Only run for work-pr skill
+  const toolName = hookData.tool_name || '';
+  const skillName = hookData.tool_input?.skill || hookData.input?.skill || '';
+
+  if (toolName !== 'Skill' || skillName !== 'work-pr') {
+    process.exit(0);
+  }
+
+  // Check if --force was passed as args
+  const skillArgs = hookData.tool_input?.args || hookData.input?.args || '';
+  if (skillArgs.includes('--force')) {
+    process.exit(0);
+  }
+
+  // Get the current working directory / git root
+  let gitRoot;
+  try {
+    gitRoot = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+  } catch {
+    process.exit(0);
+  }
+
+  // Check for TSX/JSX source file changes (exclude test files)
+  let tsxChanged = [];
+  try {
+    const diff = execSync('git diff --name-only origin/main...HEAD -- "*.tsx" "*.jsx"', {
+      encoding: 'utf8',
+      timeout: 10000,
+      cwd: gitRoot,
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+
+    if (diff) {
+      tsxChanged = diff.split('\n').filter(f =>
+        !f.includes('.test.') &&
+        !f.includes('.spec.') &&
+        !f.includes('.stories.') &&
+        !f.includes('__tests__') &&
+        !f.includes('.d.ts')
+      );
+    }
+  } catch {
+    process.exit(0);
+  }
+
+  // No UI source files changed — no screenshots required
+  if (tsxChanged.length === 0) {
+    process.exit(0);
+  }
+
+  // Extract ticket ID from branch name
+  let ticketId;
+  try {
+    const branch = execSync('git branch --show-current', {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    const match = branch.match(new RegExp(config.JIRA_PROJECT_KEY + '-\\d+'));
+    ticketId = match ? match[0] : null;
+  } catch {
+    ticketId = null;
+  }
+
+  // Check for screenshots in tasks folder
+  const tasksDir = ticketId ? config.tasksDir(ticketId) : null;
+  let screenshotCount = 0;
+
+  if (tasksDir) {
+    const screenshotDir = path.join(tasksDir, 'screenshots');
+    try {
+      if (fs.existsSync(screenshotDir)) {
+        const files = fs.readdirSync(screenshotDir, { recursive: true });
+        screenshotCount = files.filter(f => {
+          const ext = path.extname(String(f)).toLowerCase();
+          return ['.png', '.jpg', '.jpeg', '.gif', '.webp'].includes(ext);
+        }).length;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  if (screenshotCount > 0) {
+    process.exit(0);
+  }
+
+  // BLOCK: TSX changed but no screenshots
+  const fileList = tsxChanged.slice(0, 10).map(f => `  - ${f}`).join('\n');
+  const moreFiles = tsxChanged.length > 10 ? `\n  ... and ${tsxChanged.length - 10} more` : '';
+
+  process.stderr.write(`
+╔══════════════════════════════════════════════════════════════════════╗
+║  📸 SCREENSHOT GATE: UI changes require visual documentation         ║
+╠══════════════════════════════════════════════════════════════════════╣
+║                                                                      ║
+║  /work-pr completed but TSX/JSX source files were modified           ║
+║  without screenshots.                                                ║
+║                                                                      ║
+║  Changed UI files:                                                   ║
+${fileList}${moreFiles}
+║                                                                      ║
+║  REQUIRED before marking PR complete:                                ║
+║    1. Run /check-qa or /check-browser to capture screenshots         ║
+║    2. Or add screenshots to:                                         ║
+║       ${tasksDir ? tasksDir + '/screenshots/' : 'tasks/<TICKET>/screenshots/'}
+║    3. Then re-run /work-pr to update the PR                          ║
+║                                                                      ║
+║  To bypass (non-visual TSX changes only):                            ║
+║    /work-pr <TICKET> --force                                         ║
+║                                                                      ║
+╚══════════════════════════════════════════════════════════════════════╝
+`);
+  process.exit(2);
+}
+
+main().catch(err => {
+  console.error('Hook error:', err.message);
+  process.exit(0);
+});

--- a/hooks/enforce-step-workflow.js
+++ b/hooks/enforce-step-workflow.js
@@ -69,12 +69,13 @@ const WORKFLOWS = [
       '5_commit', '6_check', '7_cleanup', '8_test_enhancement',
       '9_pr', '10_ready', '11_ci', '12_reports', '13_complete',
     ],
-    softSteps: new Set(['1_ticket', '12_reports']),
+    softSteps: new Set(['1_ticket', '10_ready', '12_reports']),
     commandMap: [
       { step: '1_ticket',           tool: 'Task',  field: 'description',    pattern: /^1_ticket/i },
       { step: '3_implement',        tool: 'Skill', field: 'skill',          pattern: /^work-implement$/ },
       { step: '4_quality',          tool: 'Task',  field: 'subagent_type',  pattern: /^quality-checker$/ },
       { step: '4_quality',          tool: 'Task',  field: 'description',    pattern: /^4_quality/i },
+      { step: '4_quality',          tool: 'Bash',  field: 'command',        pattern: /(^|\s)(LOW_CONCURRENCY=\d+\s+)?(pnpm|npm)\s+(run\s+)?dev:check\b/ },
       { step: '5_commit',           tool: 'Task',  field: 'subagent_type',  pattern: /^commit-writer$/ },
       { step: '6_check',            tool: 'Skill', field: 'skill',          pattern: /^check$/ },
       { step: '7_cleanup',          tool: 'Task',  field: 'description',    pattern: /^7_cleanup/i },
@@ -101,7 +102,7 @@ const WORKFLOWS = [
       '1_preflight', '2_setup', '3_pr_gen',
       '4_screenshot_gate', '5_post_pr_gen', '6_summary',
     ],
-    softSteps: new Set(['1_preflight', '2_setup', '6_summary']),
+    softSteps: new Set(['1_preflight', '2_setup', '4_screenshot_gate', '6_summary']),
     commandMap: [
       { step: '3_pr_gen',       tool: 'Task',  field: 'subagent_type', pattern: /^pr-generator$/ },
       { step: '3_pr_gen',       tool: 'Bash',  field: 'command', pattern: /gh\s+pr\s+create/ },
@@ -419,6 +420,34 @@ function handlePostToolUse(hookData) {
     // 4. Map tool call to step and record evidence
     const matchedStep = matchToolToStep(toolName, toolInput, wf.commandIndex);
     if (!matchedStep) continue;
+
+    // (Patch 14) Strengthen 9_pr evidence: verify .pr-update-sha matches HEAD
+    if (wf.name === 'work' && matchedStep === '9_pr') {
+      const tasksDir = path.join(TASKS_BASE, ticketId);
+      const prShaFile = path.join(tasksDir, '.pr-update-sha');
+      let prShaOk = false;
+      try {
+        let head;
+        try { head = resolveGitHead(); } catch {
+          head = fs.readFileSync(path.join('.git', 'HEAD'), 'utf-8').trim();
+        }
+        const ref = head.startsWith('ref: ') ? head.slice(5) : head;
+        // For ref pointers, we can't easily get the SHA without git — skip validation
+        if (/^[0-9a-f]{40}$/.test(ref)) {
+          const storedSha = fs.readFileSync(prShaFile, 'utf-8').trim();
+          prShaOk = storedSha === ref;
+        } else {
+          // Can't compare ref to SHA — trust the file exists
+          prShaOk = fs.existsSync(prShaFile);
+        }
+      } catch {
+        prShaOk = false;
+      }
+      if (!prShaOk) {
+        if (DEBUG) process.stderr.write(`[enforce] 9_pr: pr-update-sha missing or stale\n`);
+        continue; // Skip evidence recording — PR wasn't actually updated
+      }
+    }
 
     const evidence = loadEvidence(ticketId, wf.evidenceFile);
     evidence[matchedStep] = {

--- a/hooks/enforce-work-command.js
+++ b/hooks/enforce-work-command.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+/**
+ * PreToolUse hook: Enforce /work workflow via file-based state.
+ *
+ * Blocks Edit/Write/MultiEdit when a work-state folder exists for the
+ * current branch, meaning /work has been initiated and should manage edits.
+ *
+ * State directory: ~/.claude/work-state/<branch-name>/
+ * Transition file: ~/.claude/work-state/<branch-name>/active
+ *
+ * The /work command creates the state folder. This hook enforces it.
+ * No state folder = no enforcement (free edits allowed).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const WORK_STATE_DIR = path.join(process.env.HOME, '.claude', 'work-state');
+
+// Files allowed without /work (config/non-code files)
+const ALLOWED_PATTERNS = [
+  /\.md$/,
+  /\.json$/,
+  /\.ya?ml$/,
+  /\.env/,
+  /\.gitignore$/,
+  /\.eslintrc/,
+  /\.prettierrc/,
+  /package\.json$/,
+  /tsconfig/,
+  /\/home\/node\/worktrees\/tasks\//,
+  /\.task-/,
+  /\.claude\//,
+  /plan[-_]?\w*\./i,
+];
+
+const WORK_PATTERNS = [
+  /<command-name>\/work<\/command-name>/,
+  /"skill"\s*:\s*"work"/,
+];
+
+function getCurrentBranch() {
+  try {
+    return execSync('git branch --show-current', {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function hasWorkStateFile(branch) {
+  if (!branch) return false;
+  const stateFile = path.join(WORK_STATE_DIR, branch, 'active');
+  return fs.existsSync(stateFile);
+}
+
+function isWorkActiveInTranscript(transcriptPath) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) return false;
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+    return WORK_PATTERNS.some(p => p.test(content));
+  } catch {
+    return false;
+  }
+}
+
+function isFileAllowed(filePath) {
+  if (!filePath) return false;
+  return ALLOWED_PATTERNS.some(p => p.test(filePath));
+}
+
+function hasSkipWorkBypass(transcriptPath) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) return false;
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+    return /no \/work|skip \/work/i.test(content);
+  } catch {
+    return false;
+  }
+}
+
+function isInsideSubagent(transcriptPath) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) return false;
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+    const agentTypes = [
+      'developer-nodejs-tdd',
+      'developer-react-senior',
+      'developer-react-ui-architect',
+      'developer-devops',
+      'code-checker',
+      'commit-writer',
+      'pr-generator',
+    ];
+    for (const agent of agentTypes) {
+      if (new RegExp(`^name:\\s*${agent}`, 'm').test(content)) return true;
+      if (new RegExp(`"subagent_type"\\s*:\\s*"${agent}"`, 'i').test(content)) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  const hookData = JSON.parse(input);
+  const toolInput = hookData.tool_input || {};
+  const transcriptPath = hookData.transcript_path;
+  const filePath = toolInput.file_path || toolInput.path || '';
+
+  // 1. Get current branch
+  const branch = getCurrentBranch();
+  if (!branch) {
+    process.exit(0);
+  }
+
+  // 2. Only enforce if work-state folder exists for this branch
+  if (!hasWorkStateFile(branch)) {
+    process.exit(0);
+  }
+
+  // 3. Allow config/non-code files
+  if (isFileAllowed(filePath)) {
+    process.exit(0);
+  }
+
+  // 4. Allow if /work is active in this session
+  if (isWorkActiveInTranscript(transcriptPath)) {
+    process.exit(0);
+  }
+
+  // 5. Allow inside subagents
+  if (isInsideSubagent(transcriptPath)) {
+    process.exit(0);
+  }
+
+  // 6. Escape hatch
+  if (hasSkipWorkBypass(transcriptPath)) {
+    process.exit(0);
+  }
+
+  // Block — work-state exists but /work not active in this session
+  process.stderr.write(`╔══════════════════════════════════════════════════════════════════════╗
+║  ⚠️  /work workflow is managing this branch                          ║
+╠══════════════════════════════════════════════════════════════════════╣
+║                                                                      ║
+║  Branch: ${branch.padEnd(58)}║
+║  Direct code edits are blocked — use /work to continue.             ║
+║                                                                      ║
+║  Options:                                                            ║
+║    /work <ticket>        Resume the orchestrated workflow            ║
+║    "skip /work"          Bypass enforcement for this session         ║
+║                                                                      ║
+║  /work ensures: Jira transitions, quality checks, code review,      ║
+║  requirements verification, and proper PR generation.                ║
+║                                                                      ║
+╚══════════════════════════════════════════════════════════════════════╝
+`);
+  process.exit(2);
+}
+
+main().catch(err => {
+  console.error('Hook error:', err.message);
+  process.exit(0);
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -40,6 +40,45 @@
             "command": "CLAUDE_HOOK_TYPE=PreToolUse node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-step-workflow.js"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-work-command.js"
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/work-implement-enforce.js"
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/work-require-implement.js"
+          }
+        ]
+      },
+      {
+        "matcher": "Task|Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CLAUDE_HOOK_TYPE=PreToolUse node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-env-start-failure.js"
+          },
+          {
+            "type": "command",
+            "command": "CLAUDE_HOOK_TYPE=PreToolUse node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-screenshot-requirement.js"
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CLAUDE_HOOK_TYPE=PreToolUse node ${CLAUDE_PLUGIN_ROOT}/hooks/work-enforce-steps.js"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -58,6 +97,61 @@
           {
             "type": "command",
             "command": "CLAUDE_HOOK_TYPE=PostToolUse node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-step-workflow.js"
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CLAUDE_HOOK_TYPE=PostToolUse node ${CLAUDE_PLUGIN_ROOT}/hooks/work-enforce-steps.js"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CLAUDE_HOOK_TYPE=PostToolUse node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-env-start-failure.js"
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-coverage-fix.js"
+          }
+        ]
+      },
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CLAUDE_HOOK_TYPE=PostToolUse node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-env-start-failure.js"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-completion-protocol.js"
+          }
+        ]
+      },
+      {
+        "matcher": ".*(/check|code.?review|quality.?check|APPROVED|PASS|tests?.?md|code-review.?md|qa.?md).*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/work-code-review-status.js"
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/work-suggestion-replies.js"
           }
         ]
       }

--- a/hooks/work-code-review-status.js
+++ b/hooks/work-code-review-status.js
@@ -1,0 +1,476 @@
+#!/usr/bin/env node
+
+/**
+ * Stop hook to verify code-review reports don't have CRITICAL/IMPORTANT issues
+ * that were incorrectly marked as APPROVED.
+ *
+ * This hook runs at the end of turns and checks:
+ * 1. ONLY the current task's code-review.md (based on cwd or branch)
+ * 2. If it contains CRITICAL or IMPORTANT issues
+ * 3. If the summary incorrectly says APPROVED
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const config = require('../lib/config');
+
+// Get current task ID from cwd or git branch
+function getCurrentTaskId(cwd) {
+  // Try to get from worktree folder name (e.g., ${config.REPO_NAME}-${jira_task_id})
+  const worktreeMatch = cwd.match(new RegExp(`${config.JIRA_PROJECT_KEY}-(\\d+)`, 'i'));
+  if (worktreeMatch) {
+    return `${config.JIRA_PROJECT_KEY}-${worktreeMatch[1]}`;
+  }
+
+  // Try to get from git branch name
+  try {
+    const branch = execSync('git branch --show-current', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    const branchMatch = branch.match(new RegExp(`${config.JIRA_PROJECT_KEY}-(\\d+)`, 'i'));
+    if (branchMatch) {
+      return `${config.JIRA_PROJECT_KEY}-${branchMatch[1]}`;
+    }
+  } catch {
+    // Ignore git errors
+  }
+
+  return null;
+}
+
+// Find code-review.check.md for a specific task
+function findCodeReviewForTask(baseDir, taskId) {
+  if (!taskId) return null;
+
+  const tasksDir = path.join(baseDir, 'tasks');
+  const taskFolder = path.join(tasksDir, taskId);
+  const reviewFile = path.join(taskFolder, 'code-review.check.md');
+
+  if (fs.existsSync(reviewFile)) {
+    return reviewFile;
+  }
+
+  return null;
+}
+
+// Find QA reports for a specific task
+function findQaReportsForTask(baseDir, taskId) {
+  if (!taskId) return [];
+
+  const tasksDir = path.join(baseDir, 'tasks');
+  const taskFolder = path.join(tasksDir, taskId);
+
+  if (!fs.existsSync(taskFolder)) return [];
+
+  const files = fs.readdirSync(taskFolder);
+  return files
+    .filter(f => f.startsWith('qa') && f.endsWith('.check.md'))
+    .map(f => path.join(taskFolder, f));
+}
+
+// Check QA report for Playwright verification
+function checkQaReport(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const issues = {
+      hasPlaywrightVerification: false,
+      hasConnectivityVerification: false,
+      hasGoogleTest: false,
+      hasHealthCheck: false,
+      hasScreenshots: false,
+      hasForbiddenExcuse: false,
+      claimsPass: false
+    };
+
+    // Check for NEW Connectivity Verification section (MANDATORY)
+    if (/##\s*Playwright\s*Connectivity\s*Verification/i.test(content)) {
+      issues.hasConnectivityVerification = true;
+    }
+
+    // Check for google.com test
+    if (/###\s*External\s*Connectivity\s*\(google\.com\)/i.test(content)) {
+      issues.hasGoogleTest = true;
+    }
+    // Alternative: check for google.com URL with status
+    if (/google\.com.*Status:\s*(✅|SUCCESS|FAILED|❌)/i.test(content) ||
+        /Status:.*google\.com/i.test(content)) {
+      issues.hasGoogleTest = true;
+    }
+
+    // Check for app health check
+    if (/###\s*App\s*Health\s*Check/i.test(content)) {
+      issues.hasHealthCheck = true;
+    }
+    // Alternative: check for health endpoint or app URL with status
+    if (/\/health.*Status:\s*(✅|SUCCESS|FAILED|❌)/i.test(content) ||
+        /host\.docker\.internal.*Status:/i.test(content)) {
+      issues.hasHealthCheck = true;
+    }
+
+    // Check for Playwright Verification section (old check, still valid)
+    if (/##\s*Playwright\s*Verification/i.test(content)) {
+      issues.hasPlaywrightVerification = true;
+    }
+
+    // Check for actual Playwright tool calls in report
+    if (/mcp__playwright__browser_navigate/i.test(content) && /Result:\s*(SUCCESS|Page loaded)/i.test(content)) {
+      issues.hasPlaywrightVerification = true;
+    }
+
+    // Check for screenshots
+    if (/!\[.*\]\(.*\.png\)/i.test(content) || /screenshots?\//i.test(content)) {
+      issues.hasScreenshots = true;
+    }
+
+    // Check for forbidden excuses
+    const forbiddenExcuses = [
+      /CI\s*(e2e|tests?)\s*provide\s*coverage/i,
+      /deferred\s*to\s*(automated|CI)\s*tests/i,
+      /API\s*tests?\s*(are|is)\s*sufficient/i,
+      /browser\s*testing\s*not\s*needed/i,
+      /screenshots?\s*not\s*required/i,
+      /didn'?t\s*use\s*Playwright/i,
+      /Playwright\s*not\s*used/i,
+      /Playwright\s*(MCP\s*)?tools?\s*unavailable/i,
+      /skipped\s*browser\s*test/i
+    ];
+
+    for (const pattern of forbiddenExcuses) {
+      if (pattern.test(content)) {
+        issues.hasForbiddenExcuse = true;
+        break;
+      }
+    }
+
+    // Check if claims PASS
+    if (/Status:\s*PASS|✅\s*PASS|All\s*tests?\s*pass/i.test(content)) {
+      issues.claimsPass = true;
+    }
+
+    return issues;
+  } catch {
+    return null;
+  }
+}
+
+// Check if file was modified in last 10 minutes
+function isRecentlyModified(filePath) {
+  try {
+    const stats = fs.statSync(filePath);
+    const tenMinutesAgo = Date.now() - (10 * 60 * 1000);
+    return stats.mtimeMs > tenMinutesAgo;
+  } catch {
+    return false;
+  }
+}
+
+// Parse code-review.md for issues
+function checkCodeReview(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n');
+
+    const issues = {
+      hasCritical: false,
+      hasImportant: false,
+      hasBlocked: false,
+      claimsApproved: false,
+      criticalCount: 0,
+      importantCount: 0
+    };
+
+    // Check for CRITICAL issues - but verify they're actual issues, not just headers
+    // Look for patterns like "### CRITICAL" or "🔴 CRITICAL" followed by actual content
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+
+      // Check for CRITICAL section
+      if (/CRITICAL/i.test(line) && /###|🔴|\*\*/.test(line)) {
+        // Check next few lines to see if there are actual issues
+        const nextLines = lines.slice(i + 1, i + 5).join(' ').toLowerCase();
+
+        // If next lines say "none found", "no critical", "0 issues" - skip
+        if (/none\s*found|no\s*critical|no\s*issues|0\s*issues|\*\*0\*\*|:\s*0($|\s)/i.test(nextLines)) {
+          continue;
+        }
+
+        // If there's actual content (numbered list, bullet points, etc.)
+        if (/^\s*[-*\d]/.test(lines[i + 1] || '') || /^\s*[-*\d]/.test(lines[i + 2] || '')) {
+          issues.hasCritical = true;
+          issues.criticalCount++;
+        }
+      }
+
+      // Check for IMPORTANT section
+      if (/IMPORTANT/i.test(line) && /###|🟡|\*\*/.test(line)) {
+        // Check next few lines to see if there are actual issues
+        const nextLines = lines.slice(i + 1, i + 5).join(' ').toLowerCase();
+
+        // If next lines say "none found", "no important", "0 issues" - skip
+        if (/none\s*found|no\s*important|no\s*issues|0\s*issues|\*\*0\*\*|:\s*0($|\s)/i.test(nextLines)) {
+          continue;
+        }
+
+        // If there's actual content (numbered list, bullet points, etc.)
+        if (/^\s*[-*\d]/.test(lines[i + 1] || '') || /^\s*[-*\d]/.test(lines[i + 2] || '')) {
+          issues.hasImportant = true;
+          issues.importantCount++;
+        }
+      }
+    }
+
+    // Also check for inline critical/important issue markers
+    const criticalInlineMatches = content.match(/🔴\s*CRITICAL[^#\n]*:/gi) || [];
+    const importantInlineMatches = content.match(/🟡\s*IMPORTANT[^#\n]*:/gi) || [];
+
+    if (criticalInlineMatches.length > 0) {
+      issues.hasCritical = true;
+      issues.criticalCount = Math.max(issues.criticalCount, criticalInlineMatches.length);
+    }
+
+    if (importantInlineMatches.length > 0) {
+      issues.hasImportant = true;
+      issues.importantCount = Math.max(issues.importantCount, importantInlineMatches.length);
+    }
+
+    // Check for BLOCKED tests (but not "0 BLOCKED" or "BLOCKED: 0")
+    if (/BLOCKED/i.test(content)) {
+      // Make sure it's not "0 BLOCKED" or "BLOCKED: 0" or "no blocked"
+      if (!/0\s*BLOCKED|BLOCKED\s*:\s*0|no\s*blocked|none\s*blocked/i.test(content)) {
+        // Check if there's a number before BLOCKED (like "2 BLOCKED")
+        const blockedMatch = content.match(/(\d+)\s*BLOCKED/i);
+        if (blockedMatch && parseInt(blockedMatch[1]) > 0) {
+          issues.hasBlocked = true;
+        } else if (/tests?\s*BLOCKED|BLOCKED\s*tests?|BLOCKED\s*\(/i.test(content)) {
+          // "tests BLOCKED" or "BLOCKED tests" or "BLOCKED (reason)"
+          issues.hasBlocked = true;
+        }
+      }
+    }
+
+    // Check for forbidden QA excuses
+    const forbiddenExcuses = [
+      /CI\s*(e2e|tests?)\s*provide\s*coverage/i,
+      /deferred\s*to\s*(automated|CI)\s*tests/i,
+      /API\s*tests?\s*(are|is)\s*sufficient/i,
+      /browser\s*testing\s*not\s*needed/i,
+      /screenshots?\s*not\s*required/i,
+      /didn'?t\s*use\s*Playwright/i,
+      /Playwright\s*not\s*used/i,
+      /skipped\s*browser\s*test/i
+    ];
+
+    for (const pattern of forbiddenExcuses) {
+      if (pattern.test(content)) {
+        issues.hasForbiddenExcuse = true;
+        break;
+      }
+    }
+
+    // Check if it claims to be APPROVED despite issues
+    if (/APPROVED/i.test(content) || /Status:\s*PASS/i.test(content)) {
+      issues.claimsApproved = true;
+    }
+
+    return issues;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  const hookData = JSON.parse(input);
+  const cwd = process.cwd();
+
+  // Get current task ID
+  const currentTaskId = getCurrentTaskId(cwd);
+
+  if (!currentTaskId) {
+    // Not working on a specific task - approve
+    process.exit(0);
+  }
+
+  // Check directories for the current task's report
+  const mainWorktree = config.repoDir();
+  const dirsToCheck = [cwd];
+  if (cwd !== mainWorktree) {
+    dirsToCheck.push(mainWorktree);
+  }
+
+  const warnings = [];
+
+  for (const dir of dirsToCheck) {
+    // Only check the CURRENT task's code-review.md
+    const filePath = findCodeReviewForTask(dir, currentTaskId);
+
+    if (!filePath) continue;
+
+    // Only check recently modified files
+    if (!isRecentlyModified(filePath)) {
+      continue;
+    }
+
+    const issues = checkCodeReview(filePath);
+    if (!issues) continue;
+
+    // Check if reply file exists
+    const taskFolder = path.dirname(filePath);
+    const replyPath = path.join(taskFolder, 'code-review-reply.check.md');
+    const hasReplyFile = fs.existsSync(replyPath);
+
+    // Check for violations - CRITICAL issues MUST have reply file
+    if (issues.hasCritical && !hasReplyFile) {
+      warnings.push(
+        `CODE REVIEW: CRITICAL ISSUES REQUIRE RESPONSE\n\n` +
+        `Task: ${currentTaskId}\n` +
+        `File: ${currentTaskId}/code-review.check.md\n\n` +
+        `Report contains ${issues.criticalCount} CRITICAL issue(s)\n` +
+        `No code-review-reply.check.md found\n\n` +
+        `You MUST either:\n` +
+        `1. Fix all CRITICAL issues in code, OR\n` +
+        `2. Create code-review-reply.check.md with responses for each issue\n\n` +
+        `Reply format for each issue:\n` +
+        `  ## Issue: [title]\n` +
+        `  **Decision:** FIXED | DEFERRED | NOT_APPLICABLE\n` +
+        `  **Reason:** [specific justification]`
+      );
+    }
+
+    // IMPORTANT issues also need reply file
+    if (issues.hasImportant && !hasReplyFile) {
+      warnings.push(
+        `CODE REVIEW: IMPORTANT ISSUES REQUIRE RESPONSE\n\n` +
+        `Task: ${currentTaskId}\n` +
+        `File: ${currentTaskId}/code-review.check.md\n\n` +
+        `Report contains ${issues.importantCount} IMPORTANT issue(s)\n` +
+        `No code-review-reply.check.md found\n\n` +
+        `You MUST either:\n` +
+        `1. Fix all IMPORTANT issues in code, OR\n` +
+        `2. Create code-review-reply.check.md with responses for each issue\n\n` +
+        `Reply format for each issue:\n` +
+        `  ## Issue: [title]\n` +
+        `  **Decision:** FIXED | DEFERRED | NOT_APPLICABLE\n` +
+        `  **Reason:** [specific justification]`
+      );
+    }
+
+    if (issues.hasBlocked) {
+      warnings.push(
+        `BLOCKED TESTS DETECTED\n\n` +
+        `Task: ${currentTaskId}\n` +
+        `File: ${currentTaskId}/code-review.check.md\n\n` +
+        `Report contains BLOCKED tests\n` +
+        `BLOCKED = FAIL, not PASS\n\n` +
+        `Fix the blocking issue (likely Playwright MCP) and re-run /check.`
+      );
+    }
+
+    if (issues.hasForbiddenExcuse) {
+      warnings.push(
+        `QA REPORT CONTAINS FORBIDDEN EXCUSE\n\n` +
+        `Task: ${currentTaskId}\n` +
+        `File: ${currentTaskId}/code-review.check.md\n\n` +
+        `Report uses a forbidden excuse to skip Playwright testing\n` +
+        `"CI tests provide coverage" is NOT acceptable\n` +
+        `"Deferred to automated tests" is NOT acceptable\n\n` +
+        `QA MUST use Playwright browser tools - no exceptions.\n` +
+        `Re-run /check with proper Playwright browser testing.`
+      );
+    }
+  }
+
+  // Check QA reports for Playwright verification
+  for (const dir of dirsToCheck) {
+    const qaReports = findQaReportsForTask(dir, currentTaskId);
+
+    for (const qaFile of qaReports) {
+      if (!isRecentlyModified(qaFile)) continue;
+
+      const qaIssues = checkQaReport(qaFile);
+      if (!qaIssues) continue;
+
+      const fileName = path.basename(qaFile);
+
+      // Check for forbidden excuses in QA report
+      if (qaIssues.hasForbiddenExcuse) {
+        warnings.push(
+          `QA REPORT CONTAINS FORBIDDEN EXCUSE\n\n` +
+          `Task: ${currentTaskId}\n` +
+          `File: ${currentTaskId}/${fileName}\n\n` +
+          `Report uses a forbidden excuse to skip Playwright testing\n` +
+          `"CI tests provide coverage" is NOT acceptable\n` +
+          `"Playwright unavailable" is NOT acceptable without trying\n\n` +
+          `QA MUST use Playwright browser tools - no exceptions.\n` +
+          `Re-run /check with proper Playwright browser testing.`
+        );
+      }
+
+      // Check for missing Playwright verification when claiming PASS
+      if (qaIssues.claimsPass && !qaIssues.hasPlaywrightVerification) {
+        warnings.push(
+          `QA REPORT MISSING PLAYWRIGHT VERIFICATION\n\n` +
+          `Task: ${currentTaskId}\n` +
+          `File: ${currentTaskId}/${fileName}\n\n` +
+          `Report claims PASS but has no Playwright verification\n` +
+          `Missing "## Playwright Verification" section\n\n` +
+          `QA reports MUST include Playwright verification showing:\n` +
+          `- mcp__playwright__browser_navigate call\n` +
+          `- Result: SUCCESS with page title\n\n` +
+          `Re-run /check with proper Playwright browser testing.`
+        );
+      }
+
+      // Check for missing CONNECTIVITY verification section (NEW - MANDATORY)
+      if (!qaIssues.hasConnectivityVerification && !qaIssues.hasGoogleTest) {
+        warnings.push(
+          `QA REPORT MISSING CONNECTIVITY VERIFICATION\n\n` +
+          `Task: ${currentTaskId}\n` +
+          `File: ${currentTaskId}/${fileName}\n\n` +
+          `Report is MISSING mandatory connectivity verification\n` +
+          `Must include "## Playwright Connectivity Verification" section\n\n` +
+          `QA reports MUST include:\n` +
+          `1. External Connectivity (google.com) - test with screenshot\n` +
+          `2. App Health Check - test with screenshot\n\n` +
+          `This proves Playwright actually works BEFORE claiming any result.\n` +
+          `Re-run /check - QA agent MUST call mcp__playwright__browser_navigate\n` +
+          `on google.com FIRST, then on app health endpoint.`
+        );
+      }
+
+      // Check for missing health check specifically
+      if (qaIssues.hasGoogleTest && !qaIssues.hasHealthCheck) {
+        warnings.push(
+          `QA REPORT MISSING APP HEALTH CHECK\n\n` +
+          `Task: ${currentTaskId}\n` +
+          `File: ${currentTaskId}/${fileName}\n\n` +
+          `External connectivity (google.com) verified\n` +
+          `But App Health Check is missing\n\n` +
+          `QA reports MUST include App Health Check showing:\n` +
+          `- Navigate to app URL/health or app URL\n` +
+          `- Screenshot of the health check result\n\n` +
+          `Re-run /check with app health verification.`
+        );
+      }
+    }
+  }
+
+  if (warnings.length > 0) {
+    process.stderr.write(warnings.join('\n\n---\n\n') + '\n');
+    process.exit(2);
+  } else {
+    process.exit(0);
+  }
+}
+
+main().catch(err => {
+  console.error('Hook error:', err.message);
+  process.exit(0);
+});

--- a/hooks/work-enforce-steps.js
+++ b/hooks/work-enforce-steps.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+/**
+ * Enforces that /work-pr is called before /work can complete.
+ *
+ * Flow:
+ * - PreToolUse on /work: Creates .work-session file
+ * - PreToolUse on /work-pr: Creates .work-pr-executed file
+ * - PostToolUse on /work: Verifies .work-pr-executed exists, blocks if not
+ */
+
+const fs = require('fs');
+const path = require('path');
+const config = require('../lib/config');
+
+const toolInput = JSON.parse(process.env.TOOL_INPUT || '{}');
+const hookType = process.env.CLAUDE_HOOK_TYPE || 'PostToolUse'; // PreToolUse or PostToolUse
+
+// Only handle work and work-pr skills
+if (!['work', 'work-pr'].includes(toolInput.skill)) {
+  process.exit(0);
+}
+
+// Extract ticket ID
+const args = toolInput.args || '';
+const ticketMatch = args.match(new RegExp(config.JIRA_PROJECT_KEY + '-\\d+|\\d+'));
+if (!ticketMatch) {
+  process.exit(0);
+}
+
+let ticketId = ticketMatch[0];
+if (!ticketId.startsWith(config.JIRA_PROJECT_KEY + '-')) {
+  ticketId = config.prefixTicketId(ticketId);
+}
+
+const TASKS_DIR = config.tasksDir(ticketId);
+const SESSION_FILE = path.join(TASKS_DIR, '.work-session');
+const WORK_PR_EXECUTED_FILE = path.join(TASKS_DIR, '.work-pr-executed');
+
+// Ensure tasks directory exists
+if (!fs.existsSync(TASKS_DIR)) {
+  fs.mkdirSync(TASKS_DIR, { recursive: true });
+}
+
+if (hookType === 'PreToolUse') {
+  // ========== PRE TOOL USE ==========
+
+  if (toolInput.skill === 'work') {
+    // /work starting - create session file, clear any previous work-pr-executed
+    const sessionData = {
+      startedAt: new Date().toISOString(),
+      ticketId,
+      workPrExecuted: false
+    };
+    fs.writeFileSync(SESSION_FILE, JSON.stringify(sessionData, null, 2));
+
+    // Clear previous work-pr-executed flag (fresh session)
+    if (fs.existsSync(WORK_PR_EXECUTED_FILE)) {
+      fs.unlinkSync(WORK_PR_EXECUTED_FILE);
+    }
+
+    console.log(`📋 /work session started for ${ticketId}`);
+  }
+
+  if (toolInput.skill === 'work-pr') {
+    // /work-pr being called - mark it as executed
+    const executedData = {
+      executedAt: new Date().toISOString(),
+      ticketId
+    };
+    fs.writeFileSync(WORK_PR_EXECUTED_FILE, JSON.stringify(executedData, null, 2));
+    console.log(`✅ /work-pr marked as executed for ${ticketId}`);
+  }
+
+  process.exit(0);
+
+} else {
+  // ========== POST TOOL USE ==========
+
+  if (toolInput.skill === 'work') {
+    // /work completing - verify /work-pr was called
+
+    const workPrExecuted = fs.existsSync(WORK_PR_EXECUTED_FILE);
+    const prShaExists = fs.existsSync(path.join(TASKS_DIR, '.pr-update-sha'));
+    const postPrShaExists = fs.existsSync(path.join(TASKS_DIR, '.post-pr-update-sha'));
+
+    console.log('');
+    console.log('╔══════════════════════════════════════════════════════════════════════╗');
+    console.log('║  /work STEP VERIFICATION                                             ║');
+    console.log('╠══════════════════════════════════════════════════════════════════════╣');
+    console.log(`║  Ticket: ${ticketId.padEnd(58)}║`);
+    console.log('╚══════════════════════════════════════════════════════════════════════╝');
+    console.log('');
+
+    const checks = [];
+
+    if (workPrExecuted) {
+      console.log('✅ /work-pr was executed during this session');
+      checks.push(true);
+    } else {
+      console.log('❌ /work-pr was NOT executed during this session');
+      checks.push(false);
+    }
+
+    if (prShaExists) {
+      console.log('✅ .pr-update-sha exists');
+      checks.push(true);
+    } else {
+      console.log('❌ .pr-update-sha is MISSING');
+      checks.push(false);
+    }
+
+    if (postPrShaExists) {
+      console.log('✅ .post-pr-update-sha exists');
+      checks.push(true);
+    } else {
+      console.log('❌ .post-pr-update-sha is MISSING');
+      checks.push(false);
+    }
+
+    console.log('');
+
+    // Clean up session file
+    if (fs.existsSync(SESSION_FILE)) {
+      fs.unlinkSync(SESSION_FILE);
+    }
+
+    // Block if any check failed
+    if (checks.includes(false)) {
+      console.log('╔══════════════════════════════════════════════════════════════════════╗');
+      console.log('║  🛑 BLOCKED: /work cannot complete without /work-pr                  ║');
+      console.log('╠══════════════════════════════════════════════════════════════════════╣');
+      console.log('║                                                                      ║');
+      console.log('║  You MUST run:  /work-pr ' + ticketId.padEnd(40) + '║');
+      console.log('║                                                                      ║');
+      console.log('║  This command updates the PR and creates required SHA tracking.     ║');
+      console.log('║                                                                      ║');
+      console.log('╚══════════════════════════════════════════════════════════════════════╝');
+      process.exit(1);
+    }
+
+    // All good - clean up work-pr-executed file
+    if (fs.existsSync(WORK_PR_EXECUTED_FILE)) {
+      fs.unlinkSync(WORK_PR_EXECUTED_FILE);
+    }
+
+    console.log('✅ All /work steps verified. Proceeding...');
+  }
+
+  process.exit(0);
+}

--- a/hooks/work-implement-enforce.js
+++ b/hooks/work-implement-enforce.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+/**
+ * PreToolUse hook to enforce agent usage during /work-implement command.
+ *
+ * When /work-implement is active, blocks direct Write/Edit operations
+ * unless a developer-* agent has been invoked first.
+ */
+
+const fs = require('fs');
+
+// Developer agents that satisfy the requirement
+const DEVELOPER_AGENTS = [
+  'developer-nodejs-tdd',
+  'developer-react-senior',
+  'developer-react-ui-architect',
+  'developer-devops'
+];
+
+// Tools that require agent invocation first
+const BLOCKED_TOOLS = ['Write', 'Edit', 'MultiEdit'];
+
+// Files that are allowed without agent (config, non-code files)
+const ALLOWED_PATTERNS = [
+  /\.md$/,           // Markdown files
+  /\.json$/,         // JSON config files
+  /\.ya?ml$/,        // YAML files
+  /\.env/,           // Environment files
+  /\.gitignore$/,    // Git ignore
+  /\.eslintrc/,      // ESLint config
+  /\.prettierrc/,    // Prettier config
+  /package\.json$/,  // Package files
+  /tsconfig/,        // TypeScript config
+  /\/\.claude\//,    // Files in .claude folder (hooks, commands, agents)
+];
+
+/**
+ * Check if /work-implement command is active in the transcript
+ */
+function isWorkImplementActive(transcriptPath) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+    return false;
+  }
+
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+
+    // Look for /work-implement invocation
+    // Pattern: Skill tool with skill: "work-implement" or direct /work-implement mention
+    const patterns = [
+      /<command-name>\/work-implement<\/command-name>/,
+      /"skill"\s*:\s*"work-implement"/,
+      /# Implement Command/  // The command's header from work-implement.md
+    ];
+
+    return patterns.some(pattern => pattern.test(content));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a developer agent has been invoked
+ */
+function hasDeveloperAgentBeenInvoked(transcriptPath) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+    return false;
+  }
+
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+
+    // Check if any developer agent has been called via Task tool
+    for (const agent of DEVELOPER_AGENTS) {
+      const pattern = new RegExp(`"subagent_type"\\s*:\\s*"${agent}"`, 'i');
+      if (pattern.test(content)) {
+        return true;
+      }
+    }
+
+    // Also check if we're currently INSIDE a developer agent
+    for (const agent of DEVELOPER_AGENTS) {
+      const frontmatterPattern = new RegExp(`^name:\\s*${agent}`, 'm');
+      if (frontmatterPattern.test(content)) {
+        return true;
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if the file being edited is allowed without agent
+ */
+function isFileAllowed(filePath) {
+  if (!filePath) return false;
+  return ALLOWED_PATTERNS.some(pattern => pattern.test(filePath));
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  const hookData = JSON.parse(input);
+  const toolName = hookData.tool_name;
+  const toolInput = hookData.tool_input || {};
+  const transcriptPath = hookData.transcript_path;
+
+  // Only check blocked tools
+  if (!BLOCKED_TOOLS.includes(toolName)) {
+    process.exit(0);
+  }
+
+  // Check if /work-implement is active
+  if (!isWorkImplementActive(transcriptPath)) {
+    process.exit(0);
+  }
+
+  // Get the file path being edited
+  const filePath = toolInput.file_path || toolInput.path || '';
+
+  // Allow config/non-code files
+  if (isFileAllowed(filePath)) {
+    process.exit(0);
+  }
+
+  // Check if a developer agent has been invoked
+  if (hasDeveloperAgentBeenInvoked(transcriptPath)) {
+    process.exit(0);
+  }
+
+  // Block the operation
+  process.stderr.write(
+    `/work-implement requires agent delegation\n\n` +
+    `Direct ${toolName} blocked. Use a developer agent first:\n\n` +
+    `Task({\n` +
+    `  subagent_type: "developer-nodejs-tdd",      // Backend\n` +
+    `  subagent_type: "developer-react-senior",    // React logic\n` +
+    `  subagent_type: "developer-react-ui-architect", // UI design\n` +
+    `  subagent_type: "developer-devops",          // Infrastructure\n` +
+    `  prompt: "Implement: <your task>"\n` +
+    `})\n\n` +
+    `Or for simple config changes, edit allowed files:\n` +
+    `(.md, .json, .yml, .env, package.json, tsconfig.*, etc.)\n`
+  );
+  process.exit(2);
+}
+
+main().catch(err => {
+  console.error('Hook error:', err.message);
+  // On error, approve to avoid blocking legitimate operations
+  process.exit(0);
+});

--- a/hooks/work-orchestrator.js
+++ b/hooks/work-orchestrator.js
@@ -81,9 +81,13 @@ function canTransition(statusTransitions) {
 //  Happy path:  1→2→3→4→5→6→7→8→9→10→11→12→13
 //
 //  Retry loops (backward edges):
-//    6_check     → 3_implement   (check failed, fix code)
 //    4_quality   → 3_implement   (quality failed, re-implement)
+//    5_commit    → 4_quality     (re-verify quality after commit)
+//    6_check     → 3_implement   (check failed, fix code)
+//    6_check     → 4_quality     (check needs quality re-run)
 //    8_test_enh  → 5_commit      (enhanced tests need committing)
+//    8_test_enh  → 4_quality     (new tests need quality check)
+//    8_test_enh  → 3_implement   (tests reveal implementation flaw)
 //    11_ci       → 3_implement   (CI failed, fix code)
 //    11_ci       → 8_test_enh    (coverage failed)
 //
@@ -92,17 +96,18 @@ function canTransition(statusTransitions) {
 //    2_bootstrap → 5_commit      (resume: code + quality done)
 //    2_bootstrap → 6_check       (resume: committed, need check)
 //    6_check     → 8_test_enh    (no cleanup needed)
+//    9_pr        → 11_ci         (PR already ready, skip 10_ready)
 
 const STEP_TRANSITIONS = createStatusTransitions([
   { source: '1_ticket',            targets: ['2_bootstrap'] },
   { source: '2_bootstrap',         targets: ['3_implement', '4_quality', '5_commit', '6_check'] },
   { source: '3_implement',         targets: ['4_quality'] },
   { source: '4_quality',           targets: ['5_commit', '3_implement'] },
-  { source: '5_commit',            targets: ['6_check'] },
-  { source: '6_check',             targets: ['7_cleanup', '8_test_enhancement', '3_implement'] },
+  { source: '5_commit',            targets: ['6_check', '4_quality'] },
+  { source: '6_check',             targets: ['7_cleanup', '8_test_enhancement', '3_implement', '4_quality'] },
   { source: '7_cleanup',           targets: ['8_test_enhancement'] },
-  { source: '8_test_enhancement',  targets: ['9_pr', '5_commit'] },
-  { source: '9_pr',                targets: ['10_ready'] },
+  { source: '8_test_enhancement',  targets: ['9_pr', '5_commit', '4_quality', '3_implement'] },
+  { source: '9_pr',                targets: ['10_ready', '11_ci'] },
   { source: '10_ready',            targets: ['11_ci'] },
   { source: '11_ci',               targets: ['12_reports', '3_implement', '8_test_enhancement'] },
   { source: '12_reports',          targets: ['13_complete'] },
@@ -411,8 +416,8 @@ function generatePlan(ticket, description, s, rework) {
       agentType: 'skill',
       agentPrompt: `/work-pr ${ticket} --force`,
     });
-  } else if (s?.prShaMatch && s?.prEverUpdated) {
-    add('9_pr', 'SKIP', null, `SHA match (${s.headSha?.substring(0, 8)})`);
+  } else if (s?.prShaMatch && s?.prEverUpdated && (s?.postPrShaMatch || !s?.contentSha)) {
+    add('9_pr', 'SKIP', null, `SHA match (${s.headSha?.substring(0, 8)}, content: ${s?.postPrShaMatch ? 'match' : 'n/a'})`);
   } else if (s?.prEverUpdated) {
     add('9_pr', 'RUN', `/work-pr ${ticket}`, `HEAD: ${s.prUpdateSha?.substring(0, 8) || '?'} → ${s.headSha?.substring(0, 8) || '?'}`, {
       agentType: 'skill',

--- a/hooks/work-require-implement.js
+++ b/hooks/work-require-implement.js
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+/**
+ * PreToolUse hook to enforce /work-implement usage during /work command.
+ *
+ * When /work is active (after bootstrap, before commit), blocks direct
+ * Write/Edit operations unless /work-implement has been invoked.
+ *
+ * Also provides hard protection for /work-implement assets themselves,
+ * preventing escape-hatch edits via allowed patterns.
+ */
+
+const fs = require('fs');
+const config = require('../lib/config');
+
+// Tools that require /work-implement first
+const BLOCKED_TOOLS = ['Write', 'Edit', 'MultiEdit'];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Protect only /work-implement command assets from being edited as an escape hatch
+// ─────────────────────────────────────────────────────────────────────────────
+const WORK_IMPLEMENT_UNLOCK_PHRASE = 'edit work-implement';
+const PROTECTED_WORK_IMPLEMENT_PATTERNS = [
+  /(?:^|\/)work-implement-enforce\.js$/i,
+  /(?:^|\/)work-implement\.md$/i,
+  /(?:^|\/)work-implement(?:\/|$)/i, // if you keep a folder for the command
+];
+
+// Files that are allowed without /work-implement (config, non-code files)
+const ALLOWED_PATTERNS = [
+  /\.md$/,           // Markdown files
+  /\.json$/,         // JSON config files
+  /\.ya?ml$/,        // YAML files
+  /\.env/,           // Environment files
+  /\.gitignore$/,    // Git ignore
+  /\.eslintrc/,      // ESLint config
+  /\.prettierrc/,    // Prettier config
+  /package\.json$/,  // Package files
+  /tsconfig/,        // TypeScript config
+  new RegExp(config.TASKS_BASE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),  // Global task tracking files
+  /\.task-/,         // Task files
+];
+
+function isProtectedWorkImplementFile(filePath) {
+  if (!filePath) return false;
+  return PROTECTED_WORK_IMPLEMENT_PATTERNS.some(p => p.test(filePath));
+}
+
+function hasUnlockPhrase(transcriptPath, phrase) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) return false;
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+    return content.includes(phrase);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if /work command is active in the transcript
+ */
+function isWorkCommandActive(transcriptPath) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+    return false;
+  }
+
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+
+    // Look for /work invocation (but not /work-implement or /work-pr)
+    const workPatterns = [
+      /<command-name>\/work<\/command-name>/,
+      /"skill"\s*:\s*"work"[^-]/,  // "work" but not "work-implement" or "work-pr"
+      /# Start Work Command/  // The command's header from work.md
+    ];
+
+    // Check if /work is active
+    const hasWork = workPatterns.some(pattern => pattern.test(content));
+
+    if (!hasWork) return false;
+
+    // Check if we're past Step 3 (bootstrap) but before Step 6 (commit)
+    // Look for signs that bootstrap is done
+    const bootstrapDone = new RegExp('\\/bootstrap\\s+' + config.JIRA_PROJECT_KEY + '-\\d+').test(content) ||
+                          /Worktree.*created|worktree.*exists/i.test(content) ||
+                          /draft PR.*created/i.test(content);
+
+    // Check if commit step has been reached
+    const commitReached = /commit-writer|Step 6.*commit/i.test(content);
+
+    // Only enforce during implementation phase (after bootstrap, before commit)
+    return bootstrapDone && !commitReached;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if /work-implement has been invoked
+ */
+function hasWorkImplementBeenInvoked(transcriptPath) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+    return false;
+  }
+
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+
+    // Check for /work-implement invocation
+    const patterns = [
+      /<command-name>\/work-implement<\/command-name>/,
+      /"skill"\s*:\s*"work-implement"/,
+      /# Implement Command/  // The command's header
+    ];
+
+    return patterns.some(pattern => pattern.test(content));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if currently inside a developer agent.
+ * Only checks the tail of the transcript to avoid matching stale historical invocations.
+ */
+function isInsideDeveloperAgent(transcriptPath, opts = {}) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+    return false;
+  }
+
+  try {
+    const full = fs.readFileSync(transcriptPath, 'utf8');
+    const tailBytes = typeof opts.tailBytes === 'number' ? opts.tailBytes : 20000;
+    const content = full.slice(Math.max(0, full.length - tailBytes));
+    const developerAgents = opts.allowAgents || [
+      'developer-nodejs-tdd',
+      'developer-react-senior',
+      'developer-react-ui-architect',
+      'developer-devops',
+    ];
+
+    // Check if we're inside a developer agent
+    for (const agent of developerAgents) {
+      const frontmatterPattern = new RegExp(`^name:\\s*${agent}`, 'm');
+      if (frontmatterPattern.test(content)) {
+        return true;
+      }
+      // Also check if agent was invoked via Task
+      const taskPattern = new RegExp(`"subagent_type"\\s*:\\s*"${agent}"`, 'i');
+      if (taskPattern.test(content)) {
+        return true;
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if the file being edited is allowed without /work-implement
+ */
+function isFileAllowed(filePath) {
+  if (!filePath) return false;
+  return ALLOWED_PATTERNS.some(pattern => pattern.test(filePath));
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  const hookData = JSON.parse(input);
+  const toolName = hookData.tool_name;
+  const toolInput = hookData.tool_input || {};
+  const transcriptPath = hookData.transcript_path;
+
+  // Only check blocked tools
+  if (!BLOCKED_TOOLS.includes(toolName)) {
+    process.exit(0);
+  }
+
+  // Get the file path being edited
+  const filePath = toolInput.file_path || toolInput.path || '';
+
+  // ── Hard protection: /work-implement assets ────────────────────────────────
+  // This runs regardless of /work being active, so it can't be used as an escape hatch.
+  if (isProtectedWorkImplementFile(filePath)) {
+    const unlocked = hasUnlockPhrase(transcriptPath, WORK_IMPLEMENT_UNLOCK_PHRASE);
+    const insideNodejsTdd = isInsideDeveloperAgent(transcriptPath, {
+      allowAgents: ['developer-nodejs-tdd'],
+      tailBytes: 20000,
+    });
+
+    if (!unlocked || !insideNodejsTdd) {
+      process.stderr.write(
+        `/work-implement protection\n\n` +
+        `Direct ${toolName} blocked for protected /work-implement assets:\n` +
+        `  ${filePath}\n\n` +
+        `To edit these files you must:\n` +
+        `  1) include the exact unlock phrase in the prompt:\n` +
+        `     "${WORK_IMPLEMENT_UNLOCK_PHRASE}"\n` +
+        `  2) delegate via developer-nodejs-tdd\n`
+      );
+      process.exit(2);
+    }
+
+    process.exit(0);
+  }
+
+  // Check if /work command is active in implementation phase
+  if (!isWorkCommandActive(transcriptPath)) {
+    process.exit(0);
+  }
+
+  // Allow config/non-code files
+  if (isFileAllowed(filePath)) {
+    process.exit(0);
+  }
+
+  // Check if /work-implement has been invoked
+  if (hasWorkImplementBeenInvoked(transcriptPath)) {
+    process.exit(0);
+  }
+
+  // Check if inside a developer agent (which means /work-implement delegated properly)
+  if (isInsideDeveloperAgent(transcriptPath)) {
+    process.exit(0);
+  }
+
+  // Block the operation
+  process.stderr.write(
+    `/work Step 4 requires /work-implement\n\n` +
+    `Direct ${toolName} blocked during /work implementation phase.\n\n` +
+    `You MUST invoke /work-implement first:\n\n` +
+    `  /work-implement <summary of ticket requirements>\n\n` +
+    `This ensures:\n` +
+    `  - Proper agent delegation (developer-*)\n` +
+    `  - TodoWrite planning\n` +
+    `  - Quality checks before proceeding\n\n` +
+    `See /work Step 4 for details.\n`
+  );
+  process.exit(2);
+}
+
+main().catch(err => {
+  console.error('Hook error:', err.message);
+  // On error, approve to avoid blocking legitimate operations
+  process.exit(0);
+});

--- a/hooks/work-state.js
+++ b/hooks/work-state.js
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+
+/**
+ * Work State Machine Helper
+ *
+ * Manages persistent state for /work command to enable resume on context loss.
+ * State is stored in: {TASKS_BASE}/{TICKET_ID}/.work-state.json
+ *
+ * Usage:
+ *   node work-state.js init PROJ-815
+ *   node work-state.js get PROJ-815
+ *   node work-state.js set-step PROJ-815 3_implement in_progress
+ *   node work-state.js set-check PROJ-815 qa_as_dashboard in_progress
+ *   node work-state.js complete PROJ-815
+ */
+
+const fs = require('fs');
+const path = require('path');
+const config = require('../lib/config');
+
+const TASKS_BASE = config.TASKS_BASE;
+
+const STEPS = [
+  '1_ticket',
+  '2_bootstrap',
+  '3_implement',
+  '4_quality',
+  '5_commit',
+  '6_check',
+  '7_cleanup',
+  '8_test_enhancement',  // Test enhancement loop (after /check, before PR)
+  '9_pr',
+  '10_ready',
+  '11_ci',
+  '12_reports',
+  '13_complete'
+];
+
+const CHECK_AGENTS = [
+  'quality_checker',
+  'code_checker',
+  'completion_checker'
+  // QA agents are dynamic based on impacted apps
+];
+
+/**
+ * Get state file path for a ticket
+ */
+function getStatePath(ticketId) {
+  return path.join(TASKS_BASE, ticketId, '.work-state.json');
+}
+
+/**
+ * Load state for a ticket
+ */
+function loadState(ticketId) {
+  const statePath = getStatePath(ticketId);
+  if (fs.existsSync(statePath)) {
+    return JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  }
+  return null;
+}
+
+/**
+ * Save state for a ticket
+ */
+function saveState(ticketId, state) {
+  const taskDir = path.join(TASKS_BASE, ticketId);
+  if (!fs.existsSync(taskDir)) {
+    fs.mkdirSync(taskDir, { recursive: true });
+  }
+
+  state.lastUpdate = new Date().toISOString();
+  const statePath = getStatePath(ticketId);
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+  return state;
+}
+
+/**
+ * Initialize a new work state
+ */
+function initState(ticketId, description = '') {
+  const stepStatus = {};
+  STEPS.forEach(step => {
+    stepStatus[step] = 'pending';
+  });
+
+  const state = {
+    ticketId,
+    description,
+    currentStep: 1,
+    status: 'in_progress',
+    stepStatus,
+    checkProgress: {},
+    testEnhancement: {
+      initialRating: 0,
+      finalRating: 0,
+      iterations: 0,
+      skipped: false,
+      skipReason: null
+    },
+    errors: [],
+    startTime: new Date().toISOString(),
+    lastUpdate: new Date().toISOString()
+  };
+
+  return saveState(ticketId, state);
+}
+
+/**
+ * Set step status
+ */
+function setStepStatus(ticketId, step, status) {
+  let state = loadState(ticketId);
+  if (!state) {
+    state = initState(ticketId);
+  }
+
+  state.stepStatus[step] = status;
+
+  // Update current step based on what's in progress
+  const stepIndex = STEPS.indexOf(step);
+  if (status === 'in_progress' && stepIndex >= 0) {
+    state.currentStep = stepIndex + 1;
+  }
+
+  return saveState(ticketId, state);
+}
+
+/**
+ * Set check agent progress
+ */
+function setCheckProgress(ticketId, agent, status, details = null) {
+  let state = loadState(ticketId);
+  if (!state) {
+    state = initState(ticketId);
+  }
+
+  state.checkProgress[agent] = {
+    status,
+    details,
+    lastUpdate: new Date().toISOString()
+  };
+
+  return saveState(ticketId, state);
+}
+
+/**
+ * Add an error to the state
+ */
+function addError(ticketId, step, error) {
+  let state = loadState(ticketId);
+  if (!state) {
+    state = initState(ticketId);
+  }
+
+  state.errors.push({
+    step,
+    error,
+    timestamp: new Date().toISOString()
+  });
+
+  return saveState(ticketId, state);
+}
+
+/**
+ * Mark work as complete
+ */
+function completeWork(ticketId) {
+  let state = loadState(ticketId);
+  if (!state) {
+    return { error: 'No state found' };
+  }
+
+  state.status = 'completed';
+  state.completedTime = new Date().toISOString();
+  STEPS.forEach(step => {
+    state.stepStatus[step] = 'completed';
+  });
+
+  return saveState(ticketId, state);
+}
+
+/**
+ * Get resume info - what step to resume from
+ */
+function getResumeInfo(ticketId) {
+  const state = loadState(ticketId);
+  if (!state) {
+    return { exists: false };
+  }
+
+  // Find first incomplete step
+  let resumeStep = null;
+  let resumeStepIndex = 0;
+
+  for (let i = 0; i < STEPS.length; i++) {
+    const step = STEPS[i];
+    const status = state.stepStatus[step];
+
+    if (status === 'in_progress') {
+      resumeStep = step;
+      resumeStepIndex = i + 1;
+      break;
+    } else if (status === 'pending') {
+      resumeStep = step;
+      resumeStepIndex = i + 1;
+      break;
+    }
+  }
+
+  // Check for incomplete check agents
+  const incompleteChecks = [];
+  for (const [agent, progress] of Object.entries(state.checkProgress || {})) {
+    if (progress.status === 'in_progress' || progress.status === 'pending') {
+      incompleteChecks.push(agent);
+    }
+  }
+
+  return {
+    exists: true,
+    ticketId: state.ticketId,
+    status: state.status,
+    currentStep: state.currentStep,
+    resumeStep,
+    resumeStepIndex,
+    completedSteps: STEPS.filter(s => state.stepStatus[s] === 'completed'),
+    incompleteChecks,
+    lastError: state.errors.length > 0 ? state.errors[state.errors.length - 1] : null,
+    lastUpdate: state.lastUpdate
+  };
+}
+
+/**
+ * Format state for display
+ */
+function formatState(state) {
+  if (!state) {
+    return 'No state found';
+  }
+
+  let output = `
+Work State: ${state.ticketId}
+════════════════════════════════════════════
+Status: ${state.status}
+Current Step: ${state.currentStep}
+Started: ${state.startTime}
+Last Update: ${state.lastUpdate}
+
+Steps:
+`;
+
+  STEPS.forEach((step, index) => {
+    const status = state.stepStatus[step];
+    const icon = status === 'completed' ? '✅' :
+                 status === 'in_progress' ? '🔄' :
+                 status === 'failed' ? '❌' : '⏳';
+    output += `  ${index + 1}. ${icon} ${step}: ${status}\n`;
+  });
+
+  if (Object.keys(state.checkProgress).length > 0) {
+    output += '\nCheck Agents:\n';
+    for (const [agent, progress] of Object.entries(state.checkProgress)) {
+      const icon = progress.status === 'completed' ? '✅' :
+                   progress.status === 'in_progress' ? '🔄' :
+                   progress.status === 'failed' ? '❌' : '⏳';
+      output += `  ${icon} ${agent}: ${progress.status}\n`;
+    }
+  }
+
+  if (state.errors.length > 0) {
+    output += '\nRecent Errors:\n';
+    state.errors.slice(-3).forEach(err => {
+      output += `  - [${err.step}] ${err.error}\n`;
+    });
+  }
+
+  return output;
+}
+
+// CLI handler
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+  const ticketId = args[1];
+
+  if (!command) {
+    console.error('Usage: node work-state.js <command> <ticket-id> [args...]');
+    console.error('Commands: init, get, set-step, set-check, set-test-enhancement, add-error, complete, resume-info');
+    process.exit(1);
+  }
+
+  let result;
+
+  switch (command) {
+    case 'init':
+      result = initState(ticketId, args[2] || '');
+      console.log(JSON.stringify(result, null, 2));
+      break;
+
+    case 'get':
+      result = loadState(ticketId);
+      if (args[2] === '--format') {
+        console.log(formatState(result));
+      } else {
+        console.log(JSON.stringify(result, null, 2));
+      }
+      break;
+
+    case 'set-step':
+      result = setStepStatus(ticketId, args[2], args[3]);
+      console.log(JSON.stringify({ success: true, step: args[2], status: args[3] }));
+      break;
+
+    case 'set-check':
+      result = setCheckProgress(ticketId, args[2], args[3], args[4] ? JSON.parse(args[4]) : null);
+      console.log(JSON.stringify({ success: true, agent: args[2], status: args[3] }));
+      break;
+
+    case 'set-test-enhancement':
+      {
+        let state = loadState(ticketId);
+        if (!state) state = initState(ticketId);
+        if (!state.testEnhancement) state.testEnhancement = {};
+
+        const field = args[2];
+        const value = args[3];
+        // Handle boolean values
+        if (value === 'true') {
+          state.testEnhancement[field] = true;
+        } else if (value === 'false') {
+          state.testEnhancement[field] = false;
+        } else if (value === 'null') {
+          state.testEnhancement[field] = null;
+        } else {
+          state.testEnhancement[field] = isNaN(value) ? value : Number(value);
+        }
+        saveState(ticketId, state);
+        console.log(JSON.stringify({ success: true, field, value: state.testEnhancement[field] }));
+      }
+      break;
+
+    case 'add-error':
+      result = addError(ticketId, args[2], args[3]);
+      console.log(JSON.stringify({ success: true, error: 'added' }));
+      break;
+
+    case 'complete':
+      result = completeWork(ticketId);
+      console.log(JSON.stringify(result, null, 2));
+      break;
+
+    case 'resume-info':
+      result = getResumeInfo(ticketId);
+      console.log(JSON.stringify(result, null, 2));
+      break;
+
+    default:
+      console.error(`Unknown command: ${command}`);
+      process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});
+
+module.exports = {
+  loadState,
+  saveState,
+  initState,
+  setStepStatus,
+  setCheckProgress,
+  addError,
+  completeWork,
+  getResumeInfo,
+  STEPS,
+  CHECK_AGENTS
+};

--- a/hooks/work-suggestion-replies.js
+++ b/hooks/work-suggestion-replies.js
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+
+/**
+ * Stop hook to verify all issues (CRITICAL, IMPORTANT, SUGGESTIONS) in
+ * code-review.md have responses in code-review-reply.md.
+ *
+ * This hook runs at the end of turns and checks:
+ * 1. Extracts all issues from code-review.md (CRITICAL, IMPORTANT, NICE-TO-HAVE)
+ * 2. Checks if code-review-reply.md exists and has a response for each
+ * 3. Blocks if any issue is missing a reply
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const config = require('../lib/config');
+
+// Get current task ID from cwd or git branch
+function getCurrentTaskId(cwd) {
+  // Try to get from worktree folder name
+  const worktreeMatch = cwd.match(new RegExp(config.JIRA_PROJECT_KEY + '-(\\d+)', 'i'));
+  if (worktreeMatch) {
+    return `${config.JIRA_PROJECT_KEY}-${worktreeMatch[1]}`;
+  }
+
+  // Try to get from git branch name
+  try {
+    const branch = execSync('git branch --show-current', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    const branchMatch = branch.match(new RegExp(config.JIRA_PROJECT_KEY + '-(\\d+)', 'i'));
+    if (branchMatch) {
+      return `${config.JIRA_PROJECT_KEY}-${branchMatch[1]}`;
+    }
+  } catch {
+    // Ignore git errors
+  }
+
+  return null;
+}
+
+// Extract issues from a specific section of code-review.md
+function extractIssuesFromSection(content, sectionPattern, stopPattern) {
+  const issues = [];
+
+  // Find the section
+  const sectionMatch = content.match(new RegExp(
+    sectionPattern + '[^\\n]*\\n([\\s\\S]*?)(?=' + stopPattern + '|$)',
+    'i'
+  ));
+
+  if (!sectionMatch) return issues;
+
+  const sectionContent = sectionMatch[1];
+
+  // Check for "none found" or similar
+  if (/none\s*found|no\s*(critical|important|issues?)|0\s*issues/i.test(sectionContent.substring(0, 200))) {
+    return [];
+  }
+
+  // Extract individual issue titles
+  // Match patterns like:
+  // **🔴 Security: Hardcoded Admin Email Fallback**
+  // **🟡 Error Handling: Silent Failure**
+  // - **Title**: description
+  // 1. **Title**: description
+  const patterns = [
+    /\*\*(?:🔴|🟡|🟢)?\s*([^*\n]+)\*\*/g,  // **Title** or **🔴 Title**
+    /[-*]\s*\*\*([^*:]+)\*\*\s*:/g,        // - **Title**:
+    /\d+\.\s*\*\*([^*:]+)\*\*\s*:/g,       // 1. **Title**:
+  ];
+
+  for (const pattern of patterns) {
+    let match;
+    while ((match = pattern.exec(sectionContent)) !== null) {
+      const title = match[1].trim();
+      // Filter out non-issue items and headers
+      if (title.length > 3 &&
+          !title.match(/^(none|n\/a|no\s+|issues?\s*found|CRITICAL|IMPORTANT|NICE-TO-HAVE)/i) &&
+          !title.match(/^(File|Description|Impact|Recommendation):/i)) {
+        issues.push(title);
+      }
+    }
+  }
+
+  return [...new Set(issues)]; // Remove duplicates
+}
+
+// Extract all issues from code-review.md (CRITICAL, IMPORTANT, NICE-TO-HAVE/SUGGESTIONS)
+function extractAllIssues(content) {
+  const allIssues = {
+    critical: [],
+    important: [],
+    suggestions: []
+  };
+
+  // Extract CRITICAL issues
+  // Pattern: ### 🔴 CRITICAL ISSUES or ### CRITICAL
+  allIssues.critical = extractIssuesFromSection(
+    content,
+    '###?\\s*(?:🔴\\s*)?CRITICAL\\s*ISSUES?',
+    '###?\\s*(?:🟡|IMPORTANT|🟢|NICE-TO-HAVE|SUGGESTIONS?|---)'
+  );
+
+  // Extract IMPORTANT issues
+  // Pattern: ### 🟡 IMPORTANT ISSUES or ### IMPORTANT
+  allIssues.important = extractIssuesFromSection(
+    content,
+    '###?\\s*(?:🟡\\s*)?IMPORTANT\\s*ISSUES?',
+    '###?\\s*(?:🟢|NICE-TO-HAVE|SUGGESTIONS?|---)'
+  );
+
+  // Extract NICE-TO-HAVE / SUGGESTIONS
+  // Pattern: ### 🟢 NICE-TO-HAVE IMPROVEMENTS or ### SUGGESTIONS
+  allIssues.suggestions = extractIssuesFromSection(
+    content,
+    '###?\\s*(?:🟢\\s*)?(?:NICE-TO-HAVE|SUGGESTIONS?)\\s*(?:IMPROVEMENTS?)?',
+    '###?\\s*(?:Test|Security|Performance|Next|Conclusion|---)'
+  );
+
+  return allIssues;
+}
+
+// Check if a suggestion has a reply
+function findReplyForSuggestion(replyContent, suggestionTitle) {
+  // Normalize the title for comparison
+  const normalizedTitle = suggestionTitle.toLowerCase().replace(/[^\w\s]/g, '').trim();
+
+  // Look for "## Suggestion: [title]" or similar patterns
+  const patterns = [
+    new RegExp(`##\\s*Suggestion:\\s*${escapeRegex(suggestionTitle)}`, 'i'),
+    new RegExp(`##\\s*${escapeRegex(suggestionTitle)}`, 'i'),
+    new RegExp(`\\*\\*Suggestion:\\*\\*\\s*${escapeRegex(suggestionTitle)}`, 'i'),
+    new RegExp(`[-*]\\s*\\*\\*${escapeRegex(suggestionTitle)}\\*\\*`, 'i')
+  ];
+
+  for (const pattern of patterns) {
+    if (pattern.test(replyContent)) {
+      return true;
+    }
+  }
+
+  // Fuzzy match - check if similar words appear
+  const titleWords = normalizedTitle.split(/\s+/).filter(w => w.length > 3);
+  const contentNormalized = replyContent.toLowerCase().replace(/[^\w\s]/g, '');
+
+  // If most words from the title appear near each other in the reply
+  let matchCount = 0;
+  for (const word of titleWords) {
+    if (contentNormalized.includes(word)) {
+      matchCount++;
+    }
+  }
+
+  // If 70%+ of significant words match, consider it a match
+  if (titleWords.length > 0 && matchCount / titleWords.length >= 0.7) {
+    return true;
+  }
+
+  return false;
+}
+
+function escapeRegex(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Check if file was modified in last 10 minutes
+function isRecentlyModified(filePath) {
+  try {
+    const stats = fs.statSync(filePath);
+    const now = Date.now();
+    const mtime = stats.mtimeMs;
+    const tenMinutes = 10 * 60 * 1000;
+    return (now - mtime) < tenMinutes;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  const cwd = process.cwd();
+  const currentTaskId = getCurrentTaskId(cwd);
+
+  if (!currentTaskId) {
+    process.exit(0);
+  }
+
+  // Check directories
+  const mainWorktree = config.repoDir();
+  const dirsToCheck = [cwd];
+  if (cwd !== mainWorktree) {
+    dirsToCheck.push(mainWorktree);
+  }
+
+  for (const dir of dirsToCheck) {
+    const taskFolder = path.join(dir, 'tasks', currentTaskId);
+    const codeReviewPath = path.join(taskFolder, 'code-review.check.md');
+    const replyPath = path.join(taskFolder, 'code-review-reply.check.md');
+
+    if (!fs.existsSync(codeReviewPath)) continue;
+    if (!isRecentlyModified(codeReviewPath)) continue;
+
+    // Read code-review.check.md and extract all issues (CRITICAL, IMPORTANT, SUGGESTIONS)
+    const codeReviewContent = fs.readFileSync(codeReviewPath, 'utf8');
+
+    // Extract Changes Hash from code-review.check.md
+    const reviewHashMatch = codeReviewContent.match(/\*\*Changes Hash:\*\*\s*([a-f0-9]+)/i);
+    const reviewHash = reviewHashMatch ? reviewHashMatch[1] : null;
+
+    const allIssues = extractAllIssues(codeReviewContent);
+
+    const totalCritical = allIssues.critical.length;
+    const totalImportant = allIssues.important.length;
+    const totalSuggestions = allIssues.suggestions.length;
+    const totalIssues = totalCritical + totalImportant + totalSuggestions;
+
+    // If no issues found, approve
+    if (totalIssues === 0) {
+      process.exit(0);
+    }
+
+    // Check if reply file exists
+    if (!fs.existsSync(replyPath)) {
+      // Build issue list for display
+      const issuesList = [];
+      if (totalCritical > 0) {
+        issuesList.push(`CRITICAL (${totalCritical}):`);
+        allIssues.critical.slice(0, 3).forEach(s => {
+          issuesList.push(`  - ${s.substring(0, 55)}${s.length > 55 ? '...' : ''}`);
+        });
+        if (totalCritical > 3) issuesList.push(`  ... and ${totalCritical - 3} more`);
+      }
+      if (totalImportant > 0) {
+        issuesList.push(`IMPORTANT (${totalImportant}):`);
+        allIssues.important.slice(0, 3).forEach(s => {
+          issuesList.push(`  - ${s.substring(0, 55)}${s.length > 55 ? '...' : ''}`);
+        });
+        if (totalImportant > 3) issuesList.push(`  ... and ${totalImportant - 3} more`);
+      }
+      if (totalSuggestions > 0) {
+        issuesList.push(`SUGGESTIONS (${totalSuggestions}):`);
+        allIssues.suggestions.slice(0, 2).forEach(s => {
+          issuesList.push(`  - ${s.substring(0, 55)}${s.length > 55 ? '...' : ''}`);
+        });
+        if (totalSuggestions > 2) issuesList.push(`  ... and ${totalSuggestions - 2} more`);
+      }
+
+      process.stderr.write(
+        `MISSING CODE REVIEW REPLY\n\n` +
+        `Task: ${currentTaskId}\n` +
+        `Found ${totalIssues} issue(s) in code-review.check.md:\n` +
+        `  ${totalCritical} CRITICAL | ${totalImportant} IMPORTANT | ${totalSuggestions} suggestions\n\n` +
+        `code-review-reply.check.md does not exist\n\n` +
+        `${issuesList.join('\n')}\n\n` +
+        `You MUST create code-review-reply.check.md with responses.\n` +
+        `Each issue needs:\n` +
+        `  ## Issue: [title]\n` +
+        `  **Decision:** FIXED | DEFERRED | NOT_APPLICABLE\n` +
+        `  **Reason:** [specific justification]\n`
+      );
+      process.exit(2);
+    }
+
+    // Read reply file and check for missing responses
+    const replyContent = fs.readFileSync(replyPath, 'utf8');
+
+    // Validate SHA/Changes Hash matches between code-review.check.md and code-review-reply.check.md
+    const replyHashMatch = replyContent.match(/\*\*Changes Hash:\*\*\s*([a-f0-9]+)/i);
+    const replyHash = replyHashMatch ? replyHashMatch[1] : null;
+
+    if (reviewHash && replyHash && reviewHash !== replyHash) {
+      process.stderr.write(
+        `CODE REVIEW REPLY SHA MISMATCH\n\n` +
+        `Task: ${currentTaskId}\n\n` +
+        `The Changes Hash in code-review-reply.check.md does not match\n` +
+        `the Changes Hash in code-review.check.md:\n\n` +
+        `  code-review.check.md:       ${reviewHash}\n` +
+        `  code-review-reply.check.md: ${replyHash}\n\n` +
+        `This means the reply is outdated and needs to be regenerated.\n\n` +
+        `ACTION: Re-run the developer agent to generate a new reply\n` +
+        `        based on the current code-review.check.md\n`
+      );
+      process.exit(2);
+    }
+
+    if (reviewHash && !replyHash) {
+      process.stderr.write(
+        `CODE REVIEW REPLY MISSING CHANGES HASH\n\n` +
+        `Task: ${currentTaskId}\n\n` +
+        `code-review-reply.check.md is missing **Changes Hash:** header.\n\n` +
+        `Expected hash: ${reviewHash}\n\n` +
+        `ACTION: Add the following line at top of code-review-reply.check.md:\n\n` +
+        `  **Changes Hash:** ${reviewHash}\n`
+      );
+      process.exit(2);
+    }
+
+    const missingIssues = {
+      critical: allIssues.critical.filter(s => !findReplyForSuggestion(replyContent, s)),
+      important: allIssues.important.filter(s => !findReplyForSuggestion(replyContent, s)),
+      suggestions: allIssues.suggestions.filter(s => !findReplyForSuggestion(replyContent, s))
+    };
+
+    const totalMissing = missingIssues.critical.length + missingIssues.important.length + missingIssues.suggestions.length;
+
+    if (totalMissing > 0) {
+      // Build missing issues list for display
+      const missingList = [];
+      if (missingIssues.critical.length > 0) {
+        missingList.push(`CRITICAL (missing ${missingIssues.critical.length}):`);
+        missingIssues.critical.forEach(s => {
+          missingList.push(`  - ${s.substring(0, 55)}${s.length > 55 ? '...' : ''}`);
+        });
+      }
+      if (missingIssues.important.length > 0) {
+        missingList.push(`IMPORTANT (missing ${missingIssues.important.length}):`);
+        missingIssues.important.forEach(s => {
+          missingList.push(`  - ${s.substring(0, 55)}${s.length > 55 ? '...' : ''}`);
+        });
+      }
+      if (missingIssues.suggestions.length > 0) {
+        missingList.push(`SUGGESTIONS (missing ${missingIssues.suggestions.length}):`);
+        missingIssues.suggestions.forEach(s => {
+          missingList.push(`  - ${s.substring(0, 55)}${s.length > 55 ? '...' : ''}`);
+        });
+      }
+
+      process.stderr.write(
+        `INCOMPLETE CODE REVIEW REPLY\n\n` +
+        `Task: ${currentTaskId}\n` +
+        `Missing replies for ${totalMissing}/${totalIssues} issue(s)\n\n` +
+        `${missingList.join('\n')}\n\n` +
+        `Add to code-review-reply.check.md:\n` +
+        `  ## Issue: [exact title from above]\n` +
+        `  **Decision:** FIXED | DEFERRED | NOT_APPLICABLE\n` +
+        `  **Reason:** [specific justification]\n`
+      );
+      process.exit(2);
+    }
+  }
+
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Hook error:', err.message);
+  process.exit(0);
+});

--- a/hooks/workflow-router-hook.js
+++ b/hooks/workflow-router-hook.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * workflow-router-hook.js
+ *
+ * Single UserPromptSubmit hook that routes slash commands to the workflow engine.
+ * Scans ~/.claude/workflows/*.workflow.js to find matching commands.
+ *
+ * When a match is found, runs the workflow engine's `plan` subcommand
+ * and injects the formatted plan into the chat context.
+ *
+ * Pattern follows work2-orchestrator-hook.js.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOWS_DIR = path.join(__dirname, '..', 'workflows');
+const ENGINE_PATH = path.join(__dirname, '..', 'lib', 'workflow-engine.js');
+
+function main() {
+  const userPrompt = process.env.CLAUDE_USER_PROMPT || '';
+
+  // Build a map of command → workflow name from discovered workflows
+  const commandMap = buildCommandMap();
+  if (Object.keys(commandMap).length === 0) {
+    process.exit(0); // No workflows found, pass through
+  }
+
+  // Check if prompt matches any registered workflow command
+  let matched = null;
+  let args = '';
+
+  for (const [command, workflowName] of Object.entries(commandMap)) {
+    // Build regex: command at start of prompt, followed by space + args
+    const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`^\\s*${escaped}\\s+(.+)`, 'i');
+    const m = userPrompt.match(re);
+    if (m) {
+      matched = workflowName;
+      args = m[1].trim();
+      break;
+    }
+  }
+
+  if (!matched) {
+    process.exit(0); // Not a workflow command, pass through
+  }
+
+  try {
+    // Run the workflow engine
+    const result = execSync(
+      `node "${ENGINE_PATH}" ${matched} plan ${args}`,
+      { encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+
+    const plan = JSON.parse(result);
+
+    if (plan.error) {
+      console.log(`WORKFLOW ENGINE ERROR: ${plan.message}`);
+      process.exit(0);
+    }
+
+    // Use the formatted output from the engine
+    if (plan.formatted) {
+      console.log(plan.formatted);
+    } else {
+      // Fallback: output raw JSON
+      console.log(JSON.stringify(plan, null, 2));
+    }
+
+  } catch (err) {
+    console.log(`WORKFLOW ENGINE FAILED: ${err.message}`);
+  }
+
+  process.exit(0);
+}
+
+/**
+ * Scan workflows directory and build command → name map.
+ * @returns {{ [command: string]: string }}
+ */
+function buildCommandMap() {
+  const map = {};
+
+  if (!fs.existsSync(WORKFLOWS_DIR)) return map;
+
+  const files = fs.readdirSync(WORKFLOWS_DIR).filter(f => f.endsWith('.workflow.js'));
+
+  for (const file of files) {
+    try {
+      const wf = require(path.join(WORKFLOWS_DIR, file));
+      if (wf.command && wf.name) {
+        map[wf.command] = wf.name;
+      }
+    } catch {
+      // Skip invalid workflow files
+    }
+  }
+
+  return map;
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
   "name": "work-workflow",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/user/claude-plugin-work"
+  },
+  "scripts": {
+    "test": "node --test hooks/__tests__/*.test.js lib/__tests__/*.test.js workflows/__tests__/*.test.js",
+    "test:enforce": "node --test hooks/__tests__/enforce-step-workflow.test.js",
+    "test:orchestrator": "node --test hooks/__tests__/work-orchestrator.test.js",
+    "test:work-pr": "node --test workflows/__tests__/work-pr.workflow.test.js"
   }
 }

--- a/skills/work-pr/SKILL.md
+++ b/skills/work-pr/SKILL.md
@@ -37,7 +37,11 @@ Set these variables from params:
 - `FORCE_MODE` = params.force
 - `TASKS_DIR` = `$HOME/worktrees/tasks/${TICKET_ID}`
 
-If `summary.run === 0`, print "Everything up-to-date" and stop.
+If `summary.run === 0`, print "Everything up-to-date", then transition to `6_summary` and complete the workflow:
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/lib/workflow-engine.js work-pr transition ${TICKET_ID} 6_summary
+echo "✅ Everything up-to-date — nothing to do."
+```
 
 ### Phase 2: Execute RUN Steps
 
@@ -95,6 +99,8 @@ mkdir -p "$TASKS_DIR"
 
 Check the plan to determine next transition:
 - If both `3_pr_gen` and `5_post_pr_gen` are SKIP → transition to `6_summary`
+- If `3_pr_gen` is SKIP but `5_post_pr_gen` is RUN → transition to `5_post_pr_gen`
+- If `3_pr_gen` is SKIP but `4_screenshot_gate` is RUN → transition to `4_screenshot_gate`
 - Otherwise → transition to `3_pr_gen`
 
 ---
@@ -117,14 +123,20 @@ Task(pr-generator):
   "PR_UPDATE_RESULT: SUCCESS" or "PR_UPDATE_RESULT: FAILED"
 ```
 
-On success, record SHA:
+On success, record compound key (HEAD SHA + screenshot hash):
 ```bash
-echo "$CURRENT_SHA" > "$PR_SHA_FILE"
-echo "✅ PR updated. Recorded SHA: $CURRENT_SHA"
+SCREENSHOT_DIR="${TASKS_DIR}/screenshots"
+SCREENSHOT_HASH="none"
+if [ -d "$SCREENSHOT_DIR" ] && [ "$(find "$SCREENSHOT_DIR" -type f 2>/dev/null | head -1)" ]; then
+  SCREENSHOT_HASH=$(find "$SCREENSHOT_DIR" -type f -print0 2>/dev/null | sort -z | xargs -0 sha256sum 2>/dev/null | sha256sum | cut -d' ' -f1)
+fi
+echo "${CURRENT_SHA}|${SCREENSHOT_HASH}" > "$PR_SHA_FILE"
+echo "✅ PR updated. Recorded key: ${CURRENT_SHA}|${SCREENSHOT_HASH}"
 ```
 
 Check plan for next transition:
 - If `4_screenshot_gate` is RUN → transition to `4_screenshot_gate`
+- If `5_post_pr_gen` is SKIP → transition to `6_summary`
 - Otherwise → transition to `5_post_pr_gen`
 
 ---
@@ -151,16 +163,20 @@ If screenshots are missing (`SCREENSHOT_COUNT == 0`), use `AskUserQuestion`:
   - Option 3: "Skip screenshots (non-visual change)"
 
 **Based on user choice:**
-- If skip → transition to `5_post_pr_gen`
+- If skip and `5_post_pr_gen` is SKIP → transition to `6_summary`
+- If skip and `5_post_pr_gen` is RUN → transition to `5_post_pr_gen`
 - If capture → run selected command, then transition **backward** to `3_pr_gen` (re-generates PR with screenshots)
 
 ---
 
 #### Step: 5_post_pr_gen — Run pr-post-generator (content SHA-gated)
 
-Calculate content SHA:
+Calculate content SHA (all `*.check.md` reports + screenshots):
 ```bash
-CONTENT_SHA=$( (cat ${TASKS_DIR}/qa*.md 2>/dev/null; find ${TASKS_DIR}/screenshots -type f 2>/dev/null | sort | xargs cat 2>/dev/null) | sha256sum | cut -d' ' -f1)
+CONTENT_SHA=$( (
+  find "${TASKS_DIR}" -maxdepth 1 -name '*.check.md' -print0 2>/dev/null | sort -z | xargs -0 sha256sum 2>/dev/null
+  find "${TASKS_DIR}/screenshots" -type f -print0 2>/dev/null | sort -z | xargs -0 sha256sum 2>/dev/null
+) | sha256sum | cut -d' ' -f1)
 ```
 
 Run pr-post-generator:
@@ -205,17 +221,29 @@ node ${CLAUDE_PLUGIN_ROOT}/lib/workflow-engine.js work-pr transition ${TICKET_ID
 ## State Machine
 
 ```
-1_preflight → 2_setup → 3_pr_gen → 4_screenshot_gate → 5_post_pr_gen → 6_summary
-                  ↓                       ↓ (backward)
-              6_summary               3_pr_gen (after screenshots captured)
+Happy path: 1_preflight → 2_setup → 3_pr_gen → 4_screenshot_gate → 5_post_pr_gen → 6_summary
+
+Skip edges (forward):
+  2_setup → 4_screenshot_gate  (pr_gen SKIP, screenshot gate RUN)
+  2_setup → 5_post_pr_gen      (pr_gen SKIP, screenshot gate SKIP, post_pr_gen RUN)
+  2_setup → 6_summary          (all SKIP — everything up-to-date)
+  3_pr_gen → 5_post_pr_gen     (screenshot gate SKIP — no TSX changes)
+  3_pr_gen → 6_summary         (both screenshot gate and post_pr_gen SKIP)
+  4_screenshot_gate → 6_summary (post_pr_gen SKIP — skip screenshots)
+
+Retry loop (backward):
+  4_screenshot_gate → 3_pr_gen  (after screenshots captured, re-gen PR)
+
+No-op path:
+  summary.run === 0 → transition to 6_summary and complete
 ```
 
 ## Tracking Files
 
 | File | Location | SHA Source | Purpose |
 |------|----------|------------|---------|
-| `.pr-update-sha` | `tasks/{TICKET}/` | `git rev-parse HEAD` | Tracks last pr-generator run |
-| `.post-pr-update-sha` | `tasks/{TICKET}/` | `qa*.md + screenshots/**/*` | Tracks last pr-post-generator run |
+| `.pr-update-sha` | `tasks/{TICKET}/` | `HEAD_SHA\|SCREENSHOT_HASH` (compound key) | Tracks last pr-generator run |
+| `.post-pr-update-sha` | `tasks/{TICKET}/` | `*.check.md + screenshots/**/*` | Tracks last pr-post-generator run |
 | `.workflow-state.json` | `tasks/{TICKET}/` | Workflow engine | Tracks step execution state |
 
 ## When to Use

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -174,8 +174,12 @@ Happy path:  1→2→3→4→5→6→7→8→9→10→11→12→13
 
 Retry loops (backward):
   4_quality   → 3_implement   (quality failed)
+  5_commit    → 4_quality     (re-verify after commit)
   6_check     → 3_implement   (check found issues)
+  6_check     → 4_quality     (check needs quality re-run)
   8_test_enh  → 5_commit      (new tests need commit)
+  8_test_enh  → 4_quality     (new tests need quality check)
+  8_test_enh  → 3_implement   (tests reveal implementation flaw)
   11_ci       → 3_implement   (CI failed)
   11_ci       → 8_test_enh    (coverage failed)
 
@@ -184,6 +188,7 @@ Skip edges (forward):
   2_bootstrap → 5_commit      (quality done)
   2_bootstrap → 6_check       (committed)
   6_check     → 8_test_enh    (no cleanup needed)
+  9_pr        → 11_ci         (PR already ready, skip 10_ready)
 ```
 
 ---

--- a/workflows/__tests__/work-pr.workflow.test.js
+++ b/workflows/__tests__/work-pr.workflow.test.js
@@ -1,0 +1,389 @@
+/**
+ * Tests for work-pr.workflow.js
+ *
+ * Covers: transitions, skip combinations, params(), detectStepState(), inspect helpers.
+ * Uses node:test + node:assert/strict.
+ * Run: node --test workflows/__tests__/work-pr.workflow.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const WORKFLOW_PATH = path.join(__dirname, '..', 'work-pr.workflow.js');
+
+describe('work-pr.workflow.js', () => {
+  const wf = require(WORKFLOW_PATH);
+
+  // ─── Transition Graph ────────────────────────────────────────────────
+
+  describe('transitions', () => {
+    it('should have 6 steps', () => {
+      assert.equal(wf.steps.length, 6);
+    });
+
+    it('should define transitions for all steps', () => {
+      const stepIds = wf.steps.map(s => s.id);
+      const transitionSources = wf.transitions.map(t => t.source);
+      for (const id of stepIds) {
+        assert.ok(transitionSources.includes(id), `Missing transition for ${id}`);
+      }
+    });
+
+    // 2_setup edges
+    it('2_setup → 3_pr_gen (happy path)', () => {
+      const t = wf.transitions.find(t => t.source === '2_setup');
+      assert.ok(t.targets.includes('3_pr_gen'));
+    });
+
+    it('2_setup → 4_screenshot_gate (pr_gen SKIP, screenshot gate RUN)', () => {
+      const t = wf.transitions.find(t => t.source === '2_setup');
+      assert.ok(t.targets.includes('4_screenshot_gate'));
+    });
+
+    it('2_setup → 5_post_pr_gen (pr_gen SKIP, post_pr_gen RUN)', () => {
+      const t = wf.transitions.find(t => t.source === '2_setup');
+      assert.ok(t.targets.includes('5_post_pr_gen'));
+    });
+
+    it('2_setup → 6_summary (all SKIP)', () => {
+      const t = wf.transitions.find(t => t.source === '2_setup');
+      assert.ok(t.targets.includes('6_summary'));
+    });
+
+    // 3_pr_gen edges
+    it('3_pr_gen → 4_screenshot_gate (happy path)', () => {
+      const t = wf.transitions.find(t => t.source === '3_pr_gen');
+      assert.ok(t.targets.includes('4_screenshot_gate'));
+    });
+
+    it('3_pr_gen → 5_post_pr_gen (screenshot_gate SKIP)', () => {
+      const t = wf.transitions.find(t => t.source === '3_pr_gen');
+      assert.ok(t.targets.includes('5_post_pr_gen'));
+    });
+
+    it('3_pr_gen → 6_summary (screenshot_gate + post_pr_gen both SKIP)', () => {
+      const t = wf.transitions.find(t => t.source === '3_pr_gen');
+      assert.ok(t.targets.includes('6_summary'));
+    });
+
+    // 4_screenshot_gate edges
+    it('4_screenshot_gate → 5_post_pr_gen (forward)', () => {
+      const t = wf.transitions.find(t => t.source === '4_screenshot_gate');
+      assert.ok(t.targets.includes('5_post_pr_gen'));
+    });
+
+    it('4_screenshot_gate → 3_pr_gen (backward retry)', () => {
+      const t = wf.transitions.find(t => t.source === '4_screenshot_gate');
+      assert.ok(t.targets.includes('3_pr_gen'));
+    });
+
+    it('4_screenshot_gate → 6_summary (post_pr_gen SKIP)', () => {
+      const t = wf.transitions.find(t => t.source === '4_screenshot_gate');
+      assert.ok(t.targets.includes('6_summary'));
+    });
+
+    // Terminal
+    it('6_summary is terminal', () => {
+      const t = wf.transitions.find(t => t.source === '6_summary');
+      assert.deepEqual(t.targets, []);
+    });
+  });
+
+  // ─── Skip Combination Reachability ───────────────────────────────────
+
+  describe('all skip combinations have legal paths', () => {
+    const transitionMap = {};
+    for (const t of wf.transitions) {
+      transitionMap[t.source] = t.targets;
+    }
+
+    function canReach(from, to) {
+      const visited = new Set();
+      const queue = [from];
+      while (queue.length > 0) {
+        const current = queue.shift();
+        if (current === to) return true;
+        if (visited.has(current)) continue;
+        visited.add(current);
+        for (const next of (transitionMap[current] || [])) {
+          queue.push(next);
+        }
+      }
+      return false;
+    }
+
+    it('all RUN: 2_setup → 3 → 4 → 5 → 6', () => {
+      assert.ok(canReach('2_setup', '3_pr_gen'));
+      assert.ok(canReach('3_pr_gen', '4_screenshot_gate'));
+      assert.ok(canReach('4_screenshot_gate', '5_post_pr_gen'));
+      assert.ok(canReach('5_post_pr_gen', '6_summary'));
+    });
+
+    it('all SKIP: 2_setup → 6_summary (direct)', () => {
+      assert.ok(transitionMap['2_setup'].includes('6_summary'));
+    });
+
+    it('pr_gen=RUN, rest SKIP: 3_pr_gen → 6_summary', () => {
+      assert.ok(transitionMap['3_pr_gen'].includes('6_summary'));
+    });
+
+    it('pr_gen=SKIP, post_pr_gen=RUN: 2_setup → 5_post_pr_gen', () => {
+      assert.ok(transitionMap['2_setup'].includes('5_post_pr_gen'));
+    });
+
+    it('no TSX (screenshot_gate=SKIP): 3_pr_gen → 5_post_pr_gen', () => {
+      assert.ok(transitionMap['3_pr_gen'].includes('5_post_pr_gen'));
+    });
+
+    it('pr_gen=SKIP, screenshot_gate=RUN: 2_setup → 4_screenshot_gate', () => {
+      assert.ok(transitionMap['2_setup'].includes('4_screenshot_gate'));
+    });
+
+    it('screenshot_gate=RUN, post_pr_gen=SKIP: 4_screenshot_gate → 6_summary', () => {
+      assert.ok(transitionMap['4_screenshot_gate'].includes('6_summary'));
+    });
+
+    it('screenshot retry loop: 4_screenshot_gate → 3_pr_gen → 4_screenshot_gate', () => {
+      assert.ok(canReach('4_screenshot_gate', '3_pr_gen'));
+      assert.ok(canReach('3_pr_gen', '4_screenshot_gate'));
+    });
+  });
+
+  // ─── params() ────────────────────────────────────────────────────────
+
+  describe('params()', () => {
+    it('parses ticket ID', () => {
+      const p = wf.params('PROJ-123');
+      assert.equal(p.ticketId, 'PROJ-123');
+      assert.equal(p.force, false);
+    });
+
+    it('parses --force flag', () => {
+      const p = wf.params('PROJ-123 --force');
+      assert.equal(p.ticketId, 'PROJ-123');
+      assert.equal(p.force, true);
+    });
+
+    it('prefixes numeric IDs with project key', () => {
+      const p = wf.params('856');
+      assert.ok(p.ticketId.endsWith('-856'));
+    });
+
+    it('uppercases ticket ID', () => {
+      const p = wf.params('proj-123');
+      assert.equal(p.ticketId, 'PROJ-123');
+    });
+
+    it('sets instanceId same as ticketId', () => {
+      const p = wf.params('PROJ-500');
+      assert.equal(p.instanceId, p.ticketId);
+    });
+
+    it('throws on empty args', () => {
+      assert.throws(() => wf.params(''), /Usage/);
+    });
+  });
+
+  // ─── detectStepState() ──────────────────────────────────────────────
+
+  describe('detectStepState()', () => {
+    // Helper to build inspect data with defaults
+    function makeInspect(overrides = {}) {
+      return {
+        headSha: 'abc12345abc12345abc12345abc12345abc12345',
+        screenshotHash: 'none',
+        prKey: 'abc12345abc12345abc12345abc12345abc12345|none',
+        lastPrSha: '',
+        prUpToDate: false,
+        hasTsxChanges: false,
+        screenshotsExist: false,
+        screenshotCount: 0,
+        hasContent: true,
+        contentSha: 'def456',
+        lastPostPrSha: '',
+        postPrUpToDate: false,
+        ...overrides,
+      };
+    }
+
+    // 1_preflight and 2_setup always RUN
+    it('1_preflight always RUN', () => {
+      const r = wf.detectStepState('1_preflight', 'X-1', null, makeInspect());
+      assert.equal(r.action, 'RUN');
+    });
+
+    it('2_setup always RUN', () => {
+      const r = wf.detectStepState('2_setup', 'X-1', null, makeInspect());
+      assert.equal(r.action, 'RUN');
+    });
+
+    // 3_pr_gen
+    it('3_pr_gen: RUN when no previous SHA', () => {
+      const r = wf.detectStepState('3_pr_gen', 'X-1', null, makeInspect());
+      assert.equal(r.action, 'RUN');
+      assert.match(r.reason, /No previous/);
+    });
+
+    it('3_pr_gen: SKIP when compound key matches', () => {
+      const key = 'abc12345|none';
+      const r = wf.detectStepState('3_pr_gen', 'X-1', null, makeInspect({
+        prKey: key,
+        lastPrSha: key,
+        prUpToDate: true,
+      }));
+      assert.equal(r.action, 'SKIP');
+      assert.match(r.reason, /Compound key matches/);
+    });
+
+    it('3_pr_gen: RUN when compound key changed', () => {
+      const r = wf.detectStepState('3_pr_gen', 'X-1', null, makeInspect({
+        prKey: 'newsha|none',
+        lastPrSha: 'oldsha|none',
+        prUpToDate: false,
+      }));
+      assert.equal(r.action, 'RUN');
+      assert.match(r.reason, /Key changed/);
+    });
+
+    it('3_pr_gen: RUN with force even when up-to-date', () => {
+      const key = 'abc|none';
+      const r = wf.detectStepState('3_pr_gen', 'X-1', { force: true }, makeInspect({
+        prKey: key,
+        lastPrSha: key,
+        prUpToDate: true,
+      }));
+      assert.equal(r.action, 'RUN');
+      assert.match(r.reason, /Force mode/);
+    });
+
+    it('3_pr_gen: compound key includes screenshot hash', () => {
+      const r = wf.detectStepState('3_pr_gen', 'X-1', null, makeInspect({
+        headSha: 'aaa',
+        screenshotHash: 'bbb',
+        prKey: 'aaa|bbb',
+        lastPrSha: 'aaa|none',
+        prUpToDate: false,
+      }));
+      assert.equal(r.action, 'RUN');
+      assert.match(r.reason, /Key changed/);
+    });
+
+    // 4_screenshot_gate — no force bypass (B4)
+    it('4_screenshot_gate: SKIP when no TSX changes', () => {
+      const r = wf.detectStepState('4_screenshot_gate', 'X-1', null, makeInspect({
+        hasTsxChanges: false,
+      }));
+      assert.equal(r.action, 'SKIP');
+      assert.match(r.reason, /No TSX/);
+    });
+
+    it('4_screenshot_gate: SKIP when screenshots exist', () => {
+      const r = wf.detectStepState('4_screenshot_gate', 'X-1', null, makeInspect({
+        hasTsxChanges: true,
+        screenshotsExist: true,
+        screenshotCount: 3,
+      }));
+      assert.equal(r.action, 'SKIP');
+      assert.match(r.reason, /3 screenshot/);
+    });
+
+    it('4_screenshot_gate: RUN when TSX changed but no screenshots', () => {
+      const r = wf.detectStepState('4_screenshot_gate', 'X-1', null, makeInspect({
+        hasTsxChanges: true,
+        screenshotsExist: false,
+        screenshotCount: 0,
+      }));
+      assert.equal(r.action, 'RUN');
+      assert.match(r.reason, /gate required/);
+    });
+
+    it('4_screenshot_gate: NO force bypass — still RUN with force when gate needed', () => {
+      const r = wf.detectStepState('4_screenshot_gate', 'X-1', { force: true }, makeInspect({
+        hasTsxChanges: true,
+        screenshotsExist: false,
+        screenshotCount: 0,
+      }));
+      assert.equal(r.action, 'RUN', 'Force should NOT bypass screenshot gate');
+    });
+
+    // 5_post_pr_gen
+    it('5_post_pr_gen: SKIP when no content (empty SHA)', () => {
+      const r = wf.detectStepState('5_post_pr_gen', 'X-1', null, makeInspect({
+        hasContent: false,
+        contentSha: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      }));
+      assert.equal(r.action, 'SKIP');
+      assert.match(r.reason, /No content/);
+    });
+
+    it('5_post_pr_gen: SKIP when content SHA matches', () => {
+      const r = wf.detectStepState('5_post_pr_gen', 'X-1', null, makeInspect({
+        hasContent: true,
+        contentSha: 'abc123',
+        lastPostPrSha: 'abc123',
+        postPrUpToDate: true,
+      }));
+      assert.equal(r.action, 'SKIP');
+      assert.match(r.reason, /Content SHA matches/);
+    });
+
+    it('5_post_pr_gen: RUN when content changed', () => {
+      const r = wf.detectStepState('5_post_pr_gen', 'X-1', null, makeInspect({
+        hasContent: true,
+        contentSha: 'new123',
+        lastPostPrSha: 'old456',
+        postPrUpToDate: false,
+      }));
+      assert.equal(r.action, 'RUN');
+      assert.match(r.reason, /Content changed/);
+    });
+
+    it('5_post_pr_gen: RUN with force even when up-to-date', () => {
+      const r = wf.detectStepState('5_post_pr_gen', 'X-1', { force: true }, makeInspect({
+        hasContent: true,
+        contentSha: 'abc',
+        lastPostPrSha: 'abc',
+        postPrUpToDate: true,
+      }));
+      assert.equal(r.action, 'RUN');
+      assert.match(r.reason, /Force mode/);
+    });
+
+    // 6_summary
+    it('6_summary always RUN', () => {
+      const r = wf.detectStepState('6_summary', 'X-1', null, makeInspect());
+      assert.equal(r.action, 'RUN');
+    });
+
+    // Unknown step
+    it('unknown step defaults to RUN', () => {
+      const r = wf.detectStepState('99_unknown', 'X-1', null, makeInspect());
+      assert.equal(r.action, 'RUN');
+    });
+  });
+
+  // ─── Structural checks ──────────────────────────────────────────────
+
+  describe('structure', () => {
+    it('exports name, command, stateDir', () => {
+      assert.equal(wf.name, 'work-pr');
+      assert.equal(wf.command, '/work-pr');
+      assert.ok(wf.stateDir);
+    });
+
+    it('exports extraStateFields with force, prUpdated, postPrUpdated', () => {
+      assert.equal(wf.extraStateFields.force, false);
+      assert.equal(wf.extraStateFields.prUpdated, false);
+      assert.equal(wf.extraStateFields.postPrUpdated, false);
+    });
+
+    it('exports inspect function', () => {
+      assert.equal(typeof wf.inspect, 'function');
+    });
+
+    it('exports detectStepState function', () => {
+      assert.equal(typeof wf.detectStepState, 'function');
+    });
+  });
+});

--- a/workflows/work-pr.workflow.js
+++ b/workflows/work-pr.workflow.js
@@ -10,7 +10,7 @@
  * Steps:
  *   1. Pre-flight memory & zombie check
  *   2. Parse args, set variables
- *   3. Run pr-generator (SHA-gated)
+ *   3. Run pr-generator (SHA-gated with compound key: HEAD|screenshotHash)
  *   4. Screenshot gate for TSX/JSX changes
  *   5. Run pr-post-generator (content SHA-gated)
  *   6. Print summary
@@ -23,7 +23,6 @@ const { execSync } = require('child_process');
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 const TASKS_BASE = `${process.env.HOME}/worktrees/tasks`;
-const REPO_DIR = `${process.env.HOME}/worktrees/${process.env.REPO_NAME || 'my-project'}`;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -31,9 +30,14 @@ function getTasksDir(ticketId) {
   return path.join(TASKS_BASE, ticketId);
 }
 
+function getWorktreeDir(ticketId) {
+  const repo = process.env.REPO_NAME || 'my-project';
+  return path.join(process.env.HOME, 'worktrees', `${repo}-${ticketId}`);
+}
+
 function safeExec(cmd, options = {}) {
   try {
-    return execSync(cmd, { encoding: 'utf8', cwd: REPO_DIR, ...options }).trim();
+    return execSync(cmd, { encoding: 'utf8', ...options }).trim();
   } catch {
     return '';
   }
@@ -57,9 +61,9 @@ module.exports = {
 
   transitions: [
     { source: '1_preflight',       targets: ['2_setup'] },
-    { source: '2_setup',           targets: ['3_pr_gen', '6_summary'] },
-    { source: '3_pr_gen',          targets: ['4_screenshot_gate', '5_post_pr_gen'] },
-    { source: '4_screenshot_gate', targets: ['5_post_pr_gen', '3_pr_gen'] },
+    { source: '2_setup',           targets: ['3_pr_gen', '4_screenshot_gate', '5_post_pr_gen', '6_summary'] },
+    { source: '3_pr_gen',          targets: ['4_screenshot_gate', '5_post_pr_gen', '6_summary'] },
+    { source: '4_screenshot_gate', targets: ['5_post_pr_gen', '3_pr_gen', '6_summary'] },
     { source: '5_post_pr_gen',     targets: ['6_summary'] },
     { source: '6_summary',         targets: [] },
   ],
@@ -91,30 +95,33 @@ module.exports = {
 
   /**
    * Inspect real filesystem state for an instance.
+   * Uses the ticket-specific worktree directory for all git commands.
    * @param {string} instanceId - The ticket ID
    * @returns {object} Inspection data
    */
   inspect(instanceId) {
     const tasksDir = getTasksDir(instanceId);
+    const worktreeDir = getWorktreeDir(instanceId);
     const data = {
       tasksDir,
       tasksDirExists: fs.existsSync(tasksDir),
+      worktreeDir,
+      worktreeExists: fs.existsSync(worktreeDir),
     };
 
-    // Current HEAD SHA
-    data.headSha = safeExec('git rev-parse HEAD');
+    // Current HEAD SHA (from ticket worktree)
+    data.headSha = safeExec('git rev-parse HEAD', { cwd: worktreeDir });
 
-    // .pr-update-sha
+    // .pr-update-sha (stores compound key: HEAD_SHA|SCREENSHOT_HASH)
     const prShaFile = path.join(tasksDir, '.pr-update-sha');
     data.prShaFile = prShaFile;
     data.lastPrSha = '';
     if (fs.existsSync(prShaFile)) {
       try { data.lastPrSha = fs.readFileSync(prShaFile, 'utf8').trim(); } catch { /* */ }
     }
-    data.prUpToDate = data.headSha && data.headSha === data.lastPrSha;
 
-    // TSX/JSX changes vs main
-    data.tsxChanged = safeExec("git diff --name-only origin/main...HEAD -- '*.tsx' '*.jsx'");
+    // TSX/JSX changes vs main (from ticket worktree)
+    data.tsxChanged = safeExec("git diff --name-only origin/main...HEAD -- '*.tsx' '*.jsx'", { cwd: worktreeDir });
     data.hasTsxChanges = data.tsxChanged.length > 0;
 
     // Screenshot count
@@ -129,9 +136,25 @@ module.exports = {
     }
     data.screenshotsExist = data.screenshotCount > 0;
 
-    // Content SHA for post-pr (qa*.md + screenshots)
+    // Screenshot hash for compound gating key
+    let screenshotHash = 'none';
+    if (data.screenshotsExist) {
+      screenshotHash = safeExec(
+        `find "${screenshotDir}" -type f -print0 2>/dev/null | sort -z | xargs -0 sha256sum 2>/dev/null | sha256sum | cut -d' ' -f1`
+      ) || 'none';
+    }
+    data.screenshotHash = screenshotHash;
+
+    // Compound pr-gen gating key: HEAD_SHA|SCREENSHOT_HASH
+    data.prKey = `${data.headSha}|${data.screenshotHash}`;
+    data.prUpToDate = !!(data.prKey && data.prKey === data.lastPrSha);
+
+    // Content SHA for post-pr (all *.check.md + screenshots)
     data.contentSha = safeExec(
-      `(cat ${tasksDir}/qa*.md 2>/dev/null; find ${tasksDir}/screenshots -type f 2>/dev/null | sort | xargs cat 2>/dev/null) | sha256sum | cut -d' ' -f1`
+      `(
+        find "${tasksDir}" -maxdepth 1 -name '*.check.md' -print0 2>/dev/null | sort -z | xargs -0 sha256sum 2>/dev/null
+        find "${tasksDir}/screenshots" -type f -print0 2>/dev/null | sort -z | xargs -0 sha256sum 2>/dev/null
+      ) | sha256sum | cut -d' ' -f1`
     );
 
     // .post-pr-update-sha
@@ -141,7 +164,10 @@ module.exports = {
     if (fs.existsSync(postPrShaFile)) {
       try { data.lastPostPrSha = fs.readFileSync(postPrShaFile, 'utf8').trim(); } catch { /* */ }
     }
-    data.postPrUpToDate = data.contentSha && data.contentSha === data.lastPostPrSha;
+    data.postPrUpToDate = !!(data.contentSha && data.contentSha === data.lastPostPrSha);
+
+    // SKIP 5_post_pr_gen if no content to post
+    data.hasContent = !!(data.contentSha && data.contentSha !== 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
 
     return data;
   },
@@ -170,21 +196,18 @@ module.exports = {
         if (!force && d.prUpToDate) {
           return {
             action: 'SKIP',
-            reason: `HEAD SHA matches .pr-update-sha (${d.headSha?.slice(0, 8)})`,
+            reason: `Compound key matches (${d.headSha?.slice(0, 8)}|${d.screenshotHash?.slice(0, 8)})`,
           };
         }
         return {
           action: 'RUN',
           reason: force ? 'Force mode — regenerating PR description' :
-            d.lastPrSha ? `SHA changed: ${d.lastPrSha?.slice(0, 8)} → ${d.headSha?.slice(0, 8)}` :
+            d.lastPrSha ? `Key changed: ${d.lastPrSha?.slice(0, 16)}… → ${d.prKey?.slice(0, 16)}…` :
             'No previous PR update recorded',
           command: 'Task(pr-generator)',
         };
 
       case '4_screenshot_gate':
-        if (force) {
-          return { action: 'SKIP', reason: 'Force mode — bypassing screenshot gate' };
-        }
         if (!d.hasTsxChanges) {
           return { action: 'SKIP', reason: 'No TSX/JSX files changed' };
         }
@@ -201,16 +224,22 @@ module.exports = {
         };
 
       case '5_post_pr_gen':
+        if (!d.hasContent) {
+          return {
+            action: 'SKIP',
+            reason: 'No content to post (no check reports or screenshots)',
+          };
+        }
         if (!force && d.postPrUpToDate) {
           return {
             action: 'SKIP',
-            reason: `Content SHA matches .post-pr-update-sha`,
+            reason: 'Content SHA matches .post-pr-update-sha',
           };
         }
         return {
           action: 'RUN',
           reason: force ? 'Force mode — regenerating post-PR content' :
-            d.lastPostPrSha ? 'QA content changed since last run' :
+            d.lastPostPrSha ? 'Content changed since last run' :
             'No previous post-PR update recorded',
           command: 'Task(pr-post-generator)',
         };


### PR DESCRIPTION
- Migrate enforce-completion-protocol, enforce-coverage-fix, enforce-env-start-failure, enforce-screenshot-gate, enforce-work-command, work-code-review-status, work-enforce-steps, work-implement-enforce, work-require-implement, work-state, work-suggestion-replies, workflow-router-hook from global ~/.claude/hooks/
- Register all hooks in hooks.json with event mappings
- Update hooks to use centralized lib/config.js instead of hardcoded APPSUPEN/app-services-monitoring/worktree paths
- Add comprehensive workflow tests for enforce-step-workflow and work-orchestrator
- Update work-pr workflow with improved error handling and state validation
- Bump version to 2.1.0 in plugin.json and marketplace.json
- Replace jest assertions with node assert for consistency