### PR TITLE
chore(release): bump version to 2.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
-    "version": "2.3.1"
+    "version": "2.4.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Self-contained workflow plugin with agents, hooks, skills, and orchestration. Includes 16 specialized agents, agent-specific hooks, and 23 skills.",
   "author": {
     "name": "Custom",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Existing Behavior

- `package.json`, `plugin.json`, and `marketplace.json` all declare version `2.3.1` for the `work-workflow` plugin.

## Intended New Behavior

- All three version fields are updated from `2.3.1` to `2.4.0`, keeping plugin metadata consistent across `package.json`, `plugin.json`, and `marketplace.json`.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a version-only bump with no functional code changes. Verify the release is correct by confirming:

1. Check `package.json` — `"version"` field reads `"2.4.0"`.
2. Check `plugin.json` — `"version"` field reads `"2.4.0"`.
3. Check `marketplace.json` — `"metadata.version"` field reads `"2.4.0"`.
4. Confirm no source code, tests, or configuration logic was changed in this commit.