### PR TITLE
fix(work-orchestrator): honor WORKTREES_BASE environment variable

### DIFF
--- a/hooks/work-orchestrator.js
+++ b/hooks/work-orchestrator.js
@@ -72,7 +72,7 @@ if (!tp) process.exit(0);
 
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.join(__dirname, '..');
 const MAIN_WORKTREE_FOLDER = process.env.REPO_NAME || 'my-project';
-const WORKTREES_BASE = `${process.env.HOME}/worktrees`;
+const WORKTREES_BASE = process.env.WORKTREES_BASE || `${process.env.HOME}/worktrees`;
 const TASKS_BASE = path.join(WORKTREES_BASE, 'tasks');
 
 // ─── State Machine ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Existing Behavior

- `WORKTREES_BASE` in `hooks/work-orchestrator.js` was always hardcoded to `~/worktrees` regardless of any environment configuration.
- The `WORKTREES_BASE` environment variable was silently ignored, making it impossible to override the worktree base path for this hook.
- This was inconsistent with `lib/config.js` and `hooks/enforce-step-workflow.js`, which both read `process.env.WORKTREES_BASE` with a `~/worktrees` fallback.

## Intended New Behavior

- `hooks/work-orchestrator.js` now reads `process.env.WORKTREES_BASE` with a fallback to `~/worktrees`, matching the pattern in `lib/config.js` and `enforce-step-workflow.js`.
- Users can override the worktree base path via the `WORKTREES_BASE` environment variable and the change is respected uniformly across all hooks.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [Y] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Verify the fix by setting `WORKTREES_BASE` to a custom path before running a task through the orchestrator:

1. Export a custom path: `export WORKTREES_BASE=/tmp/my-worktrees`
2. Trigger the work-orchestrator hook (e.g. run a task that invokes `hooks/work-orchestrator.js`).
3. Confirm that worktrees and the `tasks/` directory are created under `/tmp/my-worktrees` instead of `~/worktrees`.
4. Unset the variable (`unset WORKTREES_BASE`) and repeat — confirm it falls back to `~/worktrees`.