### PR TITLE
fix(skills): add work-workflow prefix to qa-feature-tester subagent_type

### DIFF
--- a/skills/check-qa/SKILL.md
+++ b/skills/check-qa/SKILL.md
@@ -315,7 +315,7 @@ const resumeInfo = JSON.parse(RESUME_INFO);
 **YOU MUST launch the qa-feature-tester agent using Task tool.**
 
 ```
-Task(subagent_type: "qa-feature-tester", prompt: "
+Task(subagent_type: "work-workflow:qa-feature-tester", prompt: "
 Test ${APP_NAME} application.
 
 ## SERVER IS ALREADY RUNNING — DO NOT START ANY DEV SERVERS


### PR DESCRIPTION
## Existing Behavior

The `check-qa` skill's `SKILL.md` invokes the `qa-feature-tester` agent via the `Task` tool using `subagent_type: "qa-feature-tester"`. This bare agent name lacks the required `work-workflow:` namespace prefix, causing the runtime to fail with an "Agent type not found" error whenever the `check-qa` skill is triggered.

## Intended New Behavior

The `subagent_type` value is updated to `"work-workflow:qa-feature-tester"`, matching the namespaced format required by the plugin's agent registry. The `check-qa` skill can now successfully spawn the `qa-feature-tester` subagent without errors.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Invoke a workflow that triggers the `check-qa` skill (e.g., any flow that calls `check-qa` as a post-step).
2. Confirm the `Task` tool is called with `subagent_type: "work-workflow:qa-feature-tester"` in the logs.
3. Verify the `qa-feature-tester` agent launches successfully and the skill completes without an "Agent type not found" error.
4. Compare against the previous behaviour on `main` to confirm the error no longer occurs.