### PR TITLE
fix(follow-up-pr): fail fast on conflicts and blocking reviews regardless of CI status

### DIFF
--- a/scripts/__tests__/follow-up-pr.test.js
+++ b/scripts/__tests__/follow-up-pr.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { classifyCommentPriority, isBlockingPriority, getResolvedCommentIds, dismissOutdatedThreads, decideNextAction } = require('../follow-up-pr.js');
+const { classifyCommentPriority, isBlockingPriority, getResolvedCommentIds, resolveOutdatedThreads, decideNextAction } = require('../follow-up-pr.js');
 
 describe('classifyCommentPriority', () => {
   describe('Copilot (copilot-pull-request-reviewer)', () => {
@@ -300,14 +300,14 @@ describe('getResolvedCommentIds', () => {
   });
 });
 
-describe('dismissOutdatedThreads', () => {
+describe('resolveOutdatedThreads', () => {
   it('calls resolveReviewThread mutation for each thread ID', () => {
     const calls = [];
     const exec = (args) => {
       calls.push(args);
       return { data: { resolveReviewThread: { thread: { isResolved: true } } } };
     };
-    const dismissed = dismissOutdatedThreads(['PRRT_1', 'PRRT_2'], exec);
+    const dismissed = resolveOutdatedThreads(['PRRT_1', 'PRRT_2'], exec);
     assert.equal(dismissed, 2);
     assert.equal(calls.length, 2);
     assert.ok(calls[0].includes('threadId=PRRT_1'));
@@ -316,7 +316,7 @@ describe('dismissOutdatedThreads', () => {
 
   it('returns 0 for empty array', () => {
     const exec = () => { throw new Error('should not be called'); };
-    const dismissed = dismissOutdatedThreads([], exec);
+    const dismissed = resolveOutdatedThreads([], exec);
     assert.equal(dismissed, 0);
   });
 
@@ -327,7 +327,7 @@ describe('dismissOutdatedThreads', () => {
       if (callCount === 2) throw new Error('Permission denied');
       return { data: { resolveReviewThread: { thread: { isResolved: true } } } };
     };
-    const dismissed = dismissOutdatedThreads(['PRRT_1', 'PRRT_2', 'PRRT_3'], exec);
+    const dismissed = resolveOutdatedThreads(['PRRT_1', 'PRRT_2', 'PRRT_3'], exec);
     assert.equal(dismissed, 2);
     assert.equal(callCount, 3);
   });

--- a/scripts/follow-up-pr.js
+++ b/scripts/follow-up-pr.js
@@ -358,9 +358,9 @@ function getResolvedCommentIds(repo, prNumber, execFn = ghExec) {
 
 /**
  * Resolve outdated review threads on GitHub via GraphQL mutation.
- * Only called when ENABLE_DISMISS_OUTDATED_COMMENTS=true.
+ * Only called when ENABLE_RESOLVE_OUTDATED_COMMENTS=true.
  */
-function dismissOutdatedThreads(threadIds, execFn = ghExec) {
+function resolveOutdatedThreads(threadIds, execFn = ghExec) {
   let dismissed = 0;
   for (const threadId of threadIds) {
     try {
@@ -410,8 +410,8 @@ function getReviews(prNumber) {
     const { resolved: resolvedCommentIds, outdatedThreadIds } = getResolvedCommentIds(repo, prNumber);
 
     // Optionally resolve outdated threads on GitHub
-    if (process.env.ENABLE_DISMISS_OUTDATED_COMMENTS === 'true' && outdatedThreadIds.length > 0) {
-      dismissOutdatedThreads(outdatedThreadIds);
+    if (process.env.ENABLE_RESOLVE_OUTDATED_COMMENTS === 'true' && outdatedThreadIds.length > 0) {
+      resolveOutdatedThreads(outdatedThreadIds);
     }
 
     const isActiveComment = (cm) => {
@@ -673,16 +673,14 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
     }
   }
 
-  // Action hint
+  // Action hint — order matches fail-fast exit priority
   lines.push('');
   if (ci.status === 'failing') {
     lines.push(`→ Fix the failure, push, then re-run: ${c.dim('node scripts/follow-up-pr.js')}`);
-  } else if (ci.status === 'passing' && !opts.noReviews && reviews.hasBlocking) {
-    lines.push(`→ Address blocking reviews, push, then re-run: ${c.dim('node scripts/follow-up-pr.js')}`);
   } else if (isConflicting) {
     lines.push(`→ Resolve conflicts, push, then re-run: ${c.dim('node scripts/follow-up-pr.js')}`);
-  } else if (!isMergeReady) {
-    lines.push(`→ Merge status not ready (${prInfo.mergeable || 'UNKNOWN'}). Waiting...`);
+  } else if (!opts.noReviews && reviews.hasBlocking) {
+    lines.push(`→ Address blocking reviews, push, then re-run: ${c.dim('node scripts/follow-up-pr.js')}`);
   } else if (ci.status === 'passing' && (!reviews.hasBlocking || opts.noReviews) && reviews.pendingBots.length === 0 && isMergeReady) {
     lines.push(c.green('═══════════════════════════════════════'));
     lines.push(c.green('  PR READY TO REVIEW'));
@@ -694,6 +692,8 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
     lines.push(`→ Waiting ${opts.interval}s for checks... (attempt ${attempt}/${maxAttempts})`);
   } else if (!opts.noReviews && reviews.pendingBots.length > 0) {
     lines.push(`→ Waiting ${opts.interval}s for bot reviews... (attempt ${attempt}/${maxAttempts})`);
+  } else if (!isMergeReady) {
+    lines.push(`→ Merge status not ready (${prInfo.mergeable || 'UNKNOWN'}). Waiting...`);
   }
 
   return lines.join('\n');
@@ -792,6 +792,8 @@ async function main() {
   });
 
   const maxAttempts = opts.once ? 1 : opts.maxAttempts;
+  let ci;
+  let reviews = { all: [], comments: [], actionable: [], blocking: [], nonBlocking: [], pendingBots: [], hasBlocking: false, hasActionable: false };
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     // Refresh PR info each attempt (mergeable status may change)
@@ -802,7 +804,6 @@ async function main() {
     }
 
     // Check CI
-    let ci;
     try {
       ci = checkCI(prInfo.number);
     } catch (err) {
@@ -811,7 +812,7 @@ async function main() {
     }
 
     // Check reviews (unless --no-reviews)
-    let reviews = { all: [], comments: [], actionable: [], blocking: [], nonBlocking: [], pendingBots: [], hasBlocking: false, hasActionable: false };
+    reviews = { all: [], comments: [], actionable: [], blocking: [], nonBlocking: [], pendingBots: [], hasBlocking: false, hasActionable: false };
     if (!opts.noReviews) {
       try {
         reviews = getReviews(prInfo.number);
@@ -874,4 +875,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { classifyCommentPriority, isBlockingPriority, getResolvedCommentIds, dismissOutdatedThreads, decideNextAction };
+module.exports = { classifyCommentPriority, isBlockingPriority, getResolvedCommentIds, resolveOutdatedThreads, decideNextAction };


### PR DESCRIPTION
## Existing Behavior

- The follow-up-pr polling loop checks CI failure first and exits immediately, but merge conflicts and blocking reviews only trigger an exit when CI has also passed.
- Blocking reviews are evaluated as part of a combined condition (`ciPassed && !hasPendingBotsOnly && (reviews.hasBlocking || !isMergeReady)`), meaning they are silently skipped while CI is still pending.
- A conflicting PR continues polling through all remaining attempts before the blocking condition is evaluated alongside the CI state.

## Intended New Behavior

- Merge conflicts and blocking reviews are now fail-fast exits, evaluated immediately after the CI-failure check and before any other conditions, independent of CI status.
- The decision logic is restructured into three clearly separated phases: fail-fast exits (CI failure, conflicts, blocking reviews), success exit, and continue-polling for pending CI or pending bot reviews.
- A conflicting PR or a PR with a blocking review exits on the very first polling attempt rather than waiting for CI to resolve.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Verify the fail-fast behavior with the `follow-up-pr.js` script:

1. **Conflict fail-fast:** Open a PR with a merge conflict (`mergeable: CONFLICTING` or `mergeStateStatus: DIRTY`). Run `node scripts/follow-up-pr.js <pr-number>`. Confirm the script exits immediately on the first poll with `state.finalStatus = 'conflicting'` and exit code 1, without waiting for CI.

2. **Blocking review fail-fast:** Request a blocking review (high-priority change request) on a PR where CI is still running. Run `node scripts/follow-up-pr.js <pr-number>`. Confirm the script exits on the first poll with `state.finalStatus = 'reviews-blocking'` and exit code 1.

3. **CI failure (unchanged behavior):** Trigger a failing CI check on a clean PR. Confirm the script still exits immediately with `state.finalStatus = 'ci-failing'` and exit code 1.

4. **Happy path (unchanged behavior):** On a PR with passing CI, no conflicts, and no blocking reviews, confirm the script exits with `state.finalStatus = 'ready'` and exit code 0.