### PR TITLE
fix(screenshot-requirement): switch to fail-open when git state is unclear

### DIFF
--- a/hooks/__tests__/enforce-screenshot-requirement.test.js
+++ b/hooks/__tests__/enforce-screenshot-requirement.test.js
@@ -27,11 +27,11 @@ function getScreenshotDir(ticketId) {
   return path.join(path.dirname(repoRoot), 'tasks', ticketId, 'screenshots');
 }
 
-function runHook(hookData, hookType = 'PreToolUse') {
+function runHookWithEnv(hookData, hookType = 'PreToolUse', extraEnv = {}) {
   return new Promise((resolve, reject) => {
     const proc = spawn('node', [HOOK_PATH], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, CLAUDE_HOOK_TYPE: hookType },
+      env: { ...process.env, ...extraEnv, CLAUDE_HOOK_TYPE: hookType }, // hookType always wins over extraEnv
     });
 
     let stdout = '';
@@ -44,6 +44,10 @@ function runHook(hookData, hookType = 'PreToolUse') {
     proc.stdin.write(JSON.stringify(hookData));
     proc.stdin.end();
   });
+}
+
+function runHook(hookData, hookType = 'PreToolUse') {
+  return runHookWithEnv(hookData, hookType);
 }
 
 function getTicketId() {
@@ -269,6 +273,36 @@ describe('enforce-screenshot-requirement', () => {
       if (!ticketId) return;
       await runHook({ tool_name: 'AskUserQuestion', tool_input: {}, tool_output: 'Abort' }, 'PostToolUse');
       assert.ok(!fs.existsSync(skipMarkerPath(ticketId)));
+    });
+  });
+
+  // ─── Fail-open behavior ───
+
+  describe('Fail-open — does NOT block when git state is unclear', () => {
+    const FAKE_TICKET = 'FAKE-999';
+    const testEnv = { NODE_ENV: 'test', TEST_FORCE_TICKET_ID: FAKE_TICKET };
+
+    beforeEach(() => { cleanupMarker(FAKE_TICKET); });
+    afterEach(() => { cleanupMarker(FAKE_TICKET); });
+
+    it('does not block when resolveBaseRef fails', async () => {
+      const r = await runHookWithEnv(
+        { tool_name: 'Task', tool_input: { subagent_type: 'pr-generator', prompt: 'create PR' } },
+        'PreToolUse',
+        { ...testEnv, TEST_FORCE_BASE_REF_FAIL: '1' }
+      );
+      assert.equal(r.code, 0, 'should exit 0 (fail-open) when base ref unavailable');
+      assert.match(r.stderr, /could not resolve base ref/);
+    });
+
+    it('does not block when git diff fails', async () => {
+      const r = await runHookWithEnv(
+        { tool_name: 'Task', tool_input: { subagent_type: 'pr-generator', prompt: 'create PR' } },
+        'PreToolUse',
+        { ...testEnv, TEST_FORCE_DIFF_FAIL: '1' }
+      );
+      assert.equal(r.code, 0, 'should exit 0 (fail-open) when git diff unavailable');
+      assert.match(r.stderr, /git diff failed/);
     });
   });
 

--- a/hooks/enforce-screenshot-requirement.js
+++ b/hooks/enforce-screenshot-requirement.js
@@ -42,6 +42,9 @@ function getScreenshotDir(ticketId) {
 }
 
 function getTicketId() {
+  if (process.env.NODE_ENV === 'test' && process.env.TEST_FORCE_TICKET_ID) {
+    return process.env.TEST_FORCE_TICKET_ID;
+  }
   try {
     const branch = execSync('git branch --show-current 2>/dev/null', { encoding: 'utf8' }).trim();
     const match = branch.match(/[A-Z]+-\d+/);
@@ -60,6 +63,8 @@ function skipMarkerPath(ticketId) {
  * Returns the ref string or null if none found.
  */
 function resolveBaseRef() {
+  if (process.env.NODE_ENV === 'test' && process.env.TEST_FORCE_BASE_REF_FAIL === '1') return null;
+
   try {
     execSync('git fetch origin --depth=1 2>/dev/null', { timeout: 15000 });
   } catch { /* offline or no remote */ }
@@ -79,11 +84,16 @@ function hasTsxChanges() {
 
   const baseRef = resolveBaseRef();
   if (!baseRef) {
-    _cachedTsxChanges = true; // fail closed
-    return true;
+    process.stderr.write('warn: screenshot-requirement: could not resolve base ref; skipping TSX check\n');
+    _cachedTsxChanges = false; // fail open — don't block when git state is unclear
+    return false;
   }
 
   try {
+    // Test-only: simulate diff failure (guarded by NODE_ENV=test)
+    if (process.env.NODE_ENV === 'test' && process.env.TEST_FORCE_DIFF_FAIL === '1') {
+      throw new Error('forced diff failure');
+    }
     const diff = execSync(`git diff --name-only ${baseRef}...HEAD -- "*.tsx" "*.jsx" 2>/dev/null`, {
       encoding: 'utf8',
       timeout: 10000
@@ -101,8 +111,9 @@ function hasTsxChanges() {
     );
     return _cachedTsxChanges;
   } catch {
-    _cachedTsxChanges = true; // fail closed
-    return true;
+    process.stderr.write('warn: screenshot-requirement: git diff failed; skipping TSX check\n');
+    _cachedTsxChanges = false; // fail open — don't block when git diff is unavailable
+    return false;
   }
 }
 


### PR DESCRIPTION
## Existing Behavior

- The `enforce-screenshot-requirement` hook used a fail-closed strategy when git state was unavailable: if `resolveBaseRef()` returned null (e.g., detached HEAD, no remote, shallow clone), the hook assumed TSX/JSX changes existed and blocked QA agents.
- Similarly, if `git diff` threw an error during the changed-file scan, the hook defaulted to `_cachedTsxChanges = true`, producing false positive blocks.
- Backend-only branches with no frontend changes were incorrectly blocked when the git diff could not be resolved, requiring manual workarounds. (Closes #44)

## Intended New Behavior

- When `resolveBaseRef()` returns null, the hook now sets `_cachedTsxChanges = false` (fail-open) and emits a warning to stderr, allowing agents to proceed unblocked.
- When `git diff` throws, the hook also fails open with a stderr warning instead of blocking.
- Two escape-hatch env vars (`TEST_FORCE_BASE_REF_FAIL`, `TEST_FORCE_DIFF_FAIL`) are added for deterministic testing of both failure paths without needing real git failures.
- Two new tests cover the fail-open behavior and are verified passing as part of this commit.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The fix applies to the `PreToolUse` hook path inside `hooks/enforce-screenshot-requirement.js`.

**Automated verification (already passing):**

```
pnpm dev:check
```

Both new test cases pass under the "Fail-open" describe block:
1. `does not block when resolveBaseRef fails (TEST_FORCE_BASE_REF_FAIL)` — exit code 0, stderr contains `could not resolve base ref`
2. `does not block when git diff fails (TEST_FORCE_DIFF_FAIL)` — exit code 0, stderr contains `git diff failed`

**Manual reproduction of the original issue:**

1. Check out a backend-only branch (no `.tsx`/`.jsx` files in the diff).
2. Put the repo in a state where `git diff origin/main...HEAD` cannot be resolved (e.g., no remote reachable, detached HEAD, or shallow clone without full history).
3. Trigger a `pr-generator` Task tool call.
4. Before this fix: hook exits non-zero and blocks the agent with a false positive screenshot requirement.
5. After this fix: hook exits 0, emits a warning to stderr, and the agent proceeds normally.

### Test Results

```
# tests 31
# suites 8
# pass  31
# fail  0
# duration_ms 670
```