### PR TITLE
feat(provider): add GitHub Issues URL parsing and path-safe ticket IDs

### DIFF
--- a/hooks/work-orchestrator.js
+++ b/hooks/work-orchestrator.js
@@ -345,15 +345,16 @@ const REQUIRED_REPORTS = [
 
 // ─── State Inspection ────────────────────────────────────────────────────────
 
-function inspect(ticket) {
+function inspect(ticket, providerConfig) {
   const s = {};
+  const safeName = tp.sanitizeTicketIdForPath(ticket, providerConfig);
 
-  s.worktreeDir = path.join(WORKTREES_BASE, `${MAIN_WORKTREE_FOLDER}-${ticket}`);
-  s.tasksDir = path.join(TASKS_BASE, ticket);
+  s.worktreeDir = path.join(WORKTREES_BASE, `${MAIN_WORKTREE_FOLDER}-${safeName}`);
+  s.tasksDir = path.join(TASKS_BASE, safeName);
   s.worktreeExists = fileExists(s.worktreeDir);
   s.tasksDirExists = fileExists(s.tasksDir);
 
-  s.workState = loadWorkState(ticket);
+  s.workState = loadWorkState(safeName);
   s.hasStateFile = s.workState !== null;
   s.currentStep = getCurrentStep(s.workState);
   s.stepIs = (step) => s.workState?.stepStatus?.[step] || 'unknown';
@@ -447,12 +448,13 @@ function inspect(ticket) {
 
 // ─── Plan Generation ─────────────────────────────────────────────────────────
 
-function generatePlan(ticket, description, s, rework) {
+function generatePlan(ticket, description, s, rework, callerProviderCfg) {
   const plan = [];
   const mode = rework ? 'rework' : 'resume';
   const t = ticket || '{TICKET}';
-  const worktreeDir = s?.worktreeDir || `${WORKTREES_BASE}/${MAIN_WORKTREE_FOLDER}-${t}`;
-  const tasksDir = s?.tasksDir || `${TASKS_BASE}/${t}`;
+  const safeName = ticket ? tp.sanitizeTicketIdForPath(t, callerProviderCfg) : t;
+  const worktreeDir = s?.worktreeDir || `${WORKTREES_BASE}/${MAIN_WORKTREE_FOLDER}-${safeName}`;
+  const tasksDir = s?.tasksDir || `${TASKS_BASE}/${safeName}`;
 
   const tddEnforce = process.env.WORK_TDD_ENFORCE === '1';
 
@@ -654,8 +656,8 @@ function generatePlan(ticket, description, s, rework) {
     agentType: 'Bash',
     agentPrompt: [
       `Run these commands in sequence:`,
-      `1. node "${path.join(__dirname, 'work-state.js')}" complete ${t}`,
-      `2. node "${guardPath}" finish ${t}`,
+      `1. node "${path.join(__dirname, 'work-state.js')}" complete ${safeName}`,
+      `2. node "${guardPath}" finish ${safeName}`,
       ``,
       `Step 1 marks the workflow as complete (exits 0 on success).`,
       `Step 2 is an atomic teardown: reveals the session passphrase (unlocking the Stop hook) and removes the session file. Exits 0 when no session exists (guard disabled or already cleaned up). Exits 1 only if called without a ticket ID (programming error).`,
@@ -787,14 +789,41 @@ function main() {
   switch (command) {
     case 'plan': {
       const rework = rest.includes('--rework');
-      const raw = rest.filter(a => a !== '--rework').join(' ').trim();
+      let raw = rest.filter(a => a !== '--rework').join(' ').trim();
       if (!raw) { console.log(JSON.stringify({ error: true, message: 'Provide ticket ID or description' })); process.exit(1); }
-      const isTicket = /^[A-Z]+-\d+$/i.test(raw) || (/^#?\d+$/.test(raw) && tp.getProviderConfig({ skipPrompt: true })?.provider === 'github');
-      const ticket = isTicket ? raw.toUpperCase() : null;
-      const state = ticket ? inspect(ticket) : null;
-      const result = generatePlan(ticket, isTicket ? null : raw, state, rework);
+
+      const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+      const isGitHub = providerConfig?.provider === 'github';
+
+      // Detect GitHub issue URLs — only when provider is GitHub or auto-detect from URL
+      let ghUrlMeta = null;
+      const ghParsed = tp.parseGitHubUrl(raw);
+      if (ghParsed && (isGitHub || !providerConfig)) {
+        ghUrlMeta = ghParsed;
+        raw = '#' + ghParsed.number;
+      }
+      const isTicket = /^[A-Z]+-\d+$/i.test(raw)
+        || (/^#?\d+$/.test(raw) && isGitHub)
+        || (/^GH-\d+$/i.test(raw) && isGitHub);
+      let ticket = isTicket ? raw.toUpperCase() : null;
+      // For GitHub provider, normalize to canonical #N form
+      if (isTicket && isGitHub) {
+        const num = raw.replace(/^#|^GH-/i, '');
+        ticket = '#' + num;
+      }
+      // Enrich provider config with owner/repo from parsed URL for ticketUrl generation
+      // Thread owner/repo from parsed URL into providerConfig for ticketUrl()
+      if (ghUrlMeta && isGitHub) {
+        providerConfig.owner = ghUrlMeta.owner;
+        providerConfig.repo = ghUrlMeta.repo;
+      }
+      const state = ticket ? inspect(ticket, providerConfig) : null;
+      const result = generatePlan(ticket, isTicket ? null : raw, state, rework, providerConfig);
 
       result.timestamp = new Date().toISOString();
+      if (ghUrlMeta && providerConfig) {
+        result.ticketUrl = tp.ticketUrl(ticket, providerConfig);
+      }
       if (state) {
         result.currentStep = state.currentStep;
         result.allowedTransitions = STEP_TRANSITIONS[state.currentStep] || [];
@@ -828,13 +857,20 @@ function main() {
         console.log(JSON.stringify({ error: true, message: 'Usage: transition <TICKET> <step>', validSteps: ALL_STEPS }));
         process.exit(1);
       }
-      console.log(JSON.stringify(transitionStep(rest[0].toUpperCase(), rest[1]), null, 2));
+      const transProviderCfg = tp.getProviderConfig({ skipPrompt: true });
+      // Normalize: uppercase for Jira/Linear, then sanitize for GitHub path safety
+      const transTicket = transProviderCfg?.provider === 'github' ? rest[0] : rest[0].toUpperCase();
+      const safeTransTicket = tp.sanitizeTicketIdForPath(transTicket, transProviderCfg);
+      console.log(JSON.stringify(transitionStep(safeTransTicket, rest[1]), null, 2));
       break;
     }
 
     case 'transitions': {
       if (!rest[0]) { console.log(JSON.stringify({ error: true, message: 'Usage: transitions <TICKET>' })); process.exit(1); }
-      console.log(JSON.stringify(getAvailableTransitions(rest[0].toUpperCase()), null, 2));
+      const transitionsProviderCfg = tp.getProviderConfig({ skipPrompt: true });
+      const transitionsTicket = transitionsProviderCfg?.provider === 'github' ? rest[0] : rest[0].toUpperCase();
+      const safeTransitionsTicket = tp.sanitizeTicketIdForPath(transitionsTicket, transitionsProviderCfg);
+      console.log(JSON.stringify(getAvailableTransitions(safeTransitionsTicket), null, 2));
       break;
     }
 
@@ -848,7 +884,8 @@ function main() {
         console.log(JSON.stringify({ error: true, message: 'Usage: actions <TICKET> [--raw]' }));
         process.exit(1);
       }
-      const ticket = rest[0].toUpperCase();
+      const actionsProviderCfg = tp.getProviderConfig({ skipPrompt: true });
+      const ticket = tp.sanitizeTicketIdForPath(actionsProviderCfg?.provider === 'github' ? rest[0] : rest[0].toUpperCase(), actionsProviderCfg);
       const raw = rest.includes('--raw');
       const actions = loadActions(ticket);
       if (raw) {
@@ -865,7 +902,8 @@ function main() {
         console.error(JSON.stringify({ error: 'usage', message: 'Usage: record-tdd <TICKET_ID> <STEP_ID> [--cmd "..." --red --green --files "..."] [--exception "..."]' }));
         process.exit(1);
       }
-      const ticket = rest[0].toUpperCase();
+      const tddProviderCfg = tp.getProviderConfig({ skipPrompt: true });
+      const ticket = tp.sanitizeTicketIdForPath(tddProviderCfg?.provider === 'github' ? rest[0] : rest[0].toUpperCase(), tddProviderCfg);
       const stepId = rest[1];
       // Parse flags — missing values for --cmd/--files/--exception fall through
       // to recordTddEvidence() validation which returns clear error messages.

--- a/lib/__tests__/ticket-provider.test.js
+++ b/lib/__tests__/ticket-provider.test.js
@@ -262,4 +262,153 @@ describe('ticket-provider', () => {
       assert.equal(tp.getCreateTicketAgentType({ provider: 'none' }), null);
     });
   });
+
+  describe('parseGitHubUrl', () => {
+    it('parses full HTTPS GitHub issue URL', () => {
+      const tp = freshRequire('../ticket-provider');
+      const result = tp.parseGitHubUrl('https://github.com/org/repo/issues/56');
+      assert.deepEqual(result, { number: '56', owner: 'org', repo: 'repo' });
+    });
+
+    it('parses URL without protocol', () => {
+      const tp = freshRequire('../ticket-provider');
+      const result = tp.parseGitHubUrl('github.com/org/repo/issues/42');
+      assert.deepEqual(result, { number: '42', owner: 'org', repo: 'repo' });
+    });
+
+    it('parses URL with www prefix', () => {
+      const tp = freshRequire('../ticket-provider');
+      const result = tp.parseGitHubUrl('https://www.github.com/org/repo/issues/99');
+      assert.deepEqual(result, { number: '99', owner: 'org', repo: 'repo' });
+    });
+
+    it('parses URL with trailing slash', () => {
+      const tp = freshRequire('../ticket-provider');
+      const result = tp.parseGitHubUrl('https://github.com/org/repo/issues/56/');
+      assert.deepEqual(result, { number: '56', owner: 'org', repo: 'repo' });
+    });
+
+    it('returns null for non-GitHub URLs', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.parseGitHubUrl('https://gitlab.com/org/repo/issues/56'), null);
+    });
+
+    it('returns null for GitHub non-issue URLs', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.parseGitHubUrl('https://github.com/org/repo/pulls/56'), null);
+    });
+
+    it('returns null for plain ticket IDs', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.parseGitHubUrl('PROJ-123'), null);
+      assert.equal(tp.parseGitHubUrl('#56'), null);
+      assert.equal(tp.parseGitHubUrl('56'), null);
+    });
+
+    it('returns null for empty/null input', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.parseGitHubUrl(''), null);
+      assert.equal(tp.parseGitHubUrl(null), null);
+      assert.equal(tp.parseGitHubUrl(undefined), null);
+    });
+  });
+
+  describe('sanitizeTicketIdForPath', () => {
+    it('converts GitHub #56 to GH-56', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('#56', { provider: 'github' }), 'GH-56');
+    });
+
+    it('converts GitHub 56 (no hash) to GH-56', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('56', { provider: 'github' }), 'GH-56');
+    });
+
+    it('returns Jira ticket as-is', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('PROJ-123', { provider: 'jira', projectKey: 'PROJ' }), 'PROJ-123');
+    });
+
+    it('returns Linear ticket as-is', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('ENG-456', { provider: 'linear', projectKey: 'ENG' }), 'ENG-456');
+    });
+
+    it('returns as-is when no provider config', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('PROJ-123', null), 'PROJ-123');
+    });
+
+    it('returns as-is for none provider', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('something', { provider: 'none' }), 'something');
+    });
+
+    it('is idempotent — GH-56 stays GH-56', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('GH-56', { provider: 'github' }), 'GH-56');
+    });
+
+    it('is idempotent — lowercase gh-56 normalizes to uppercase GH-56', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('gh-56', { provider: 'github' }), 'GH-56');
+    });
+
+    it('returns null for null input', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath(null, { provider: 'github' }), null);
+    });
+
+    it('returns undefined for undefined input', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath(undefined, { provider: 'github' }), undefined);
+    });
+
+    it('returns empty string for empty input', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('', { provider: 'github' }), '');
+    });
+
+    it('rejects invalid/non-numeric input and returns as-is', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('not-a-ticket', { provider: 'github' }), 'not-a-ticket');
+    });
+
+    it('extracts number from GitHub URL input', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.equal(tp.sanitizeTicketIdForPath('https://github.com/org/repo/issues/42', { provider: 'github' }), 'GH-42');
+    });
+  });
+
+  describe('ticketUrl with GitHub full URL', () => {
+    it('generates full GitHub issue URL when owner/repo available', () => {
+      const tp = freshRequire('../ticket-provider');
+      const url = tp.ticketUrl('#56', { provider: 'github', owner: 'org', repo: 'repo' });
+      assert.equal(url, 'https://github.com/org/repo/issues/56');
+    });
+
+    it('falls back to relative #N when no owner/repo', () => {
+      const tp = freshRequire('../ticket-provider');
+      const url = tp.ticketUrl('#42', { provider: 'github' });
+      assert.equal(url, '#42');
+    });
+
+    it('normalizes GH-N format to proper URL', () => {
+      const tp = freshRequire('../ticket-provider');
+      const url = tp.ticketUrl('GH-56', { provider: 'github', owner: 'org', repo: 'repo' });
+      assert.equal(url, 'https://github.com/org/repo/issues/56');
+    });
+
+    it('normalizes GH-N to #N when no owner/repo', () => {
+      const tp = freshRequire('../ticket-provider');
+      const url = tp.ticketUrl('GH-42', { provider: 'github' });
+      assert.equal(url, '#42');
+    });
+
+    it('generates full URL with numeric-only ticket ID', () => {
+      const tp = freshRequire('../ticket-provider');
+      const url = tp.ticketUrl('56', { provider: 'github', owner: 'org', repo: 'repo' });
+      assert.equal(url, 'https://github.com/org/repo/issues/56');
+    });
+  });
 });

--- a/lib/ticket-provider.js
+++ b/lib/ticket-provider.js
@@ -89,12 +89,50 @@ function buildConfigFromEnv(provider) {
   }
 }
 
+/**
+ * Parse a GitHub issue URL into its components.
+ * Accepts: https://github.com/org/repo/issues/56, github.com/org/repo/issues/42
+ * Returns { number, owner, repo } or null.
+ */
+function parseGitHubUrl(input) {
+  if (!input) return null;
+  const match = String(input).match(
+    /^(?:https?:\/\/)?(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)\/?$/i
+  );
+  if (!match) return null;
+  return { number: match[3], owner: match[1], repo: match[2] };
+}
+
+/**
+ * Convert a ticket ID into a file-system / branch-safe string.
+ * GitHub: #56 or 56 → GH-56.  Others: returned as-is.
+ */
+function sanitizeTicketIdForPath(ticketId, providerConfig) {
+  if (!ticketId) return ticketId; // null/undefined/empty guard
+  if (!providerConfig || providerConfig.provider !== 'github') return ticketId;
+  const str = String(ticketId);
+  // Already sanitized (idempotent)
+  if (/^GH-\d+$/i.test(str)) return str.toUpperCase();
+  // Accept #N or plain number only — reject anything else
+  if (/^#?\d+$/.test(str)) return 'GH-' + str.replace(/^#/, '');
+  // Try extracting from a GitHub URL
+  const parsed = parseGitHubUrl(str);
+  if (parsed) return 'GH-' + parsed.number;
+  // Unknown format — return as-is to avoid creating invalid paths
+  return ticketId;
+}
+
 function ticketUrl(ticketId, providerConfig) {
   if (!providerConfig || !ticketId) return null;
+  const num = String(ticketId).replace(/^#|^GH-/i, '');
   switch (providerConfig.provider) {
     case 'jira': return 'https://' + providerConfig.baseUrl + '/browse/' + ticketId;
     case 'linear': return 'https://linear.app/issue/' + ticketId;
-    case 'github': return '#' + ticketId.replace(/^#/, '');
+    case 'github':
+      if (providerConfig.owner && providerConfig.repo) {
+        return 'https://github.com/' + providerConfig.owner + '/' + providerConfig.repo + '/issues/' + num;
+      }
+      return '#' + num;
     default: return null;
   }
 }
@@ -184,5 +222,6 @@ module.exports = {
   ticketUrl, prefixTicketId, getTicketPattern,
   getFetchTicketPrompt, getTransitionPrompt, getCreateTicketPrompt,
   getAllowedMcpTools, getCreateTicketAgentType,
+  parseGitHubUrl, sanitizeTicketIdForPath,
   VALID_PROVIDERS, PROVIDERS_FILE,
 };

--- a/scripts/__tests__/get-ticket-id-gh.test.js
+++ b/scripts/__tests__/get-ticket-id-gh.test.js
@@ -1,0 +1,58 @@
+const { describe, it, beforeEach, after } = require('node:test');
+const assert = require('node:assert/strict');
+
+const originalEnv = { ...process.env };
+
+function resetEnv() {
+  Object.keys(process.env).forEach(key => {
+    if (key.startsWith('TICKET_') || key.startsWith('JIRA_') || key.startsWith('LINEAR_')) {
+      delete process.env[key];
+    }
+  });
+}
+
+function freshRequire(mod) {
+  const resolved = require.resolve(mod);
+  delete require.cache[resolved];
+  // Also clear ticket-provider cache since get-ticket-id depends on it
+  try {
+    const tpResolved = require.resolve('../../lib/ticket-provider');
+    delete require.cache[tpResolved];
+  } catch {}
+  return require(mod);
+}
+
+describe('get-ticket-id GH-pattern support', () => {
+  beforeEach(() => { resetEnv(); });
+  after(() => { Object.assign(process.env, originalEnv); });
+
+  it('extracts GH-56 from worktree path as #56', () => {
+    process.env.TICKET_PROVIDER = 'github';
+    const { getCurrentTaskId } = freshRequire('../get-ticket-id');
+    const result = getCurrentTaskId('/home/user/worktrees/my-project-GH-56');
+    assert.equal(result, '#56');
+  });
+
+  it('extracts GH-123 from worktree path (case insensitive)', () => {
+    process.env.TICKET_PROVIDER = 'github';
+    const { getCurrentTaskId } = freshRequire('../get-ticket-id');
+    const result = getCurrentTaskId('/home/user/worktrees/my-project-gh-123');
+    assert.equal(result, '#123');
+  });
+
+  it('still extracts PROJ-123 (Jira) from path when not github provider', () => {
+    process.env.TICKET_PROVIDER = 'jira';
+    process.env.TICKET_PROJECT_KEY = 'PROJ';
+    const { getCurrentTaskId } = freshRequire('../get-ticket-id');
+    const result = getCurrentTaskId('/home/user/worktrees/my-project-PROJ-123');
+    assert.equal(result, 'PROJ-123');
+  });
+
+  it('GH pattern takes priority over bare numeric for github provider paths', () => {
+    process.env.TICKET_PROVIDER = 'github';
+    const { getCurrentTaskId } = freshRequire('../get-ticket-id');
+    // GH-56 should match before the numeric fallback
+    const result = getCurrentTaskId('/home/user/worktrees/my-project-GH-56');
+    assert.equal(result, '#56');
+  });
+});

--- a/scripts/get-ticket-id.js
+++ b/scripts/get-ticket-id.js
@@ -9,10 +9,16 @@
 const { execSync } = require('child_process');
 
 const TICKET_PATTERN = /([A-Z]+-\d+)/i;
-const NUMERIC_PATTERN = /(\d+)/;
+const GH_PATTERN = /GH-(\d+)/i;
 
 function getCurrentTaskId(cwd = process.cwd()) {
-  // Try to get from worktree folder name
+  // Try GH-XX pattern first (for GitHub Issues worktree paths like my-project-GH-56)
+  const ghMatch = cwd.match(GH_PATTERN);
+  if (ghMatch) {
+    return '#' + ghMatch[1];
+  }
+
+  // Try to get from worktree folder name (Jira/Linear: PROJ-123)
   const worktreeMatch = cwd.match(TICKET_PATTERN);
   if (worktreeMatch) {
     return worktreeMatch[1].toUpperCase();
@@ -25,6 +31,11 @@ function getCurrentTaskId(cwd = process.cwd()) {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe']
     }).trim();
+    // Check GH-XX pattern in branch name
+    const branchGhMatch = branch.match(GH_PATTERN);
+    if (branchGhMatch) {
+      return '#' + branchGhMatch[1];
+    }
     const branchMatch = branch.match(TICKET_PATTERN);
     if (branchMatch) {
       return branchMatch[1].toUpperCase();
@@ -33,17 +44,19 @@ function getCurrentTaskId(cwd = process.cwd()) {
     // Ignore git errors
   }
 
-  // Fallback: try numeric pattern for GitHub Issues provider
+  // Fallback: try numeric suffix for GitHub Issues provider
+  // Only match trailing number after a separator to avoid false positives
+  // (e.g. version numbers, user IDs embedded in paths)
   try {
     const tp = require('../lib/ticket-provider');
     const providerConfig = tp.getProviderConfig({ skipPrompt: true });
     if (providerConfig && providerConfig.provider === 'github') {
-      const numericMatch = cwd.match(NUMERIC_PATTERN);
-      if (numericMatch) return '#' + numericMatch[1];
+      const trailingNum = cwd.match(/[-/](\d+)\/?$/);
+      if (trailingNum) return '#' + trailingNum[1];
       try {
         const branch = execSync('git branch --show-current', { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-        const branchNum = branch.match(NUMERIC_PATTERN);
-        if (branchNum) return '#' + branchNum[1];
+        const branchTrailingNum = branch.match(/[-/](\d+)$/);
+        if (branchTrailingNum) return '#' + branchTrailingNum[1];
       } catch {}
     }
   } catch {}


### PR DESCRIPTION
## Existing Behavior
- ticket-provider.js handled only Jira-style ticket IDs and bare numeric GitHub issue numbers; passing a full GitHub issue URL as ticket input was not supported.
- get-ticket-id.js relied on a generic numeric pattern to detect GitHub issue numbers in worktree paths and branch names, which produced false positives on version numbers and embedded user IDs.
- work-orchestrator.js used the raw ticket string directly as the filesystem path segment, making directory names invalid when a GitHub issue URL was supplied as input.
- No sanitizeTicketIdForPath utility existed, so URL-containing ticket identifiers were written verbatim into directory names.

## Intended New Behavior
- parseGitHubUrl() in ticket-provider.js accepts a full GitHub issue URL and extracts { number, owner, repo }, enabling the /work command to accept GitHub issue URLs directly.
- sanitizeTicketIdForPath() converts any ticket identifier (including parsed GitHub URLs) into a filesystem-safe GH-N slug; it is idempotent for already-safe identifiers and guards against null input.
- get-ticket-id.js now matches the explicit GH-N pattern in both worktree paths and branch names before falling back to a numeric scan, eliminating false positives.
- work-orchestrator.js pipes every ticket through sanitizeTicketIdForPath before constructing worktreeDir and tasksDir, so GitHub issue numbers are stored consistently as GH-N across all sub-commands.

Closes #56

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

### Backend / CLI verification

1. Configure the /work plugin with provider = github.
2. Run /work with a GitHub issue URL — the orchestrator should resolve the URL, create a worktree at WORKTREES_BASE/project-GH-56, and write tasks under TASKS_BASE/GH-56.
3. Verify get-ticket-id.js returns #56 when the cwd contains -GH-56 or the branch name contains GH-56 by running node scripts/get-ticket-id.js from within the worktree.
4. Confirm idempotency: sanitizeTicketIdForPath('GH-56', cfg) returns GH-56 unchanged.
5. Confirm parseGitHubUrl handles edge cases (no protocol, trailing slash, non-issue URLs returning null).
6. Run the unit suite to verify all 22 new tests pass.

### Test Results
<!-- populated after CI runs -->