### PR TITLE
test(work-orchestrator): add LINEAR_TEAM_ID clearing and improve test isolation

### DIFF
--- a/hooks/__tests__/work-orchestrator.test.js
+++ b/hooks/__tests__/work-orchestrator.test.js
@@ -203,13 +203,14 @@ describe('work-orchestrator.js', () => {
             JIRA_PROJECT_KEY: '',
             JIRA_BASE_URL: '',
             TICKET_PROJECT_KEY: '',
+            LINEAR_TEAM_ID: '',
           },
-          cwd: tmpBase,
+          cwd: tmpHome,
         });
         assert.equal(code, 0);
         assert.equal(result.ticket, '#42');
       } finally {
-        try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch {}
+        try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch (e) { console.warn('cleanup failed:', e.message); }
       }
     });
   });


### PR DESCRIPTION
## Existing Behavior

- The `#N` shorthand test cleared Jira env vars but left `LINEAR_TEAM_ID` set, risking cross-test env pollution.
- The test ran with `cwd` set to `tmpBase` (the worktrees directory) rather than the fake `HOME` directory, weakening isolation guarantees.
- Cleanup failures in the `finally` block were silently swallowed with an empty `catch {}`, hiding filesystem errors.

## Intended New Behavior

- `LINEAR_TEAM_ID` is now explicitly cleared alongside the other provider env vars in the `#N` shorthand test, preventing env pollution between tests.
- `cwd` is set to `tmpHome` so the test environment matches the fake home directory used for full isolation.
- Cleanup failures in `finally` now emit a `console.warn` with the error message, making filesystem issues visible during test runs.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Run the work-orchestrator test suite: `pnpm dev:test hooks/__tests__/work-orchestrator.test.js`
2. Confirm the `#N shorthand` test passes without flakiness when `LINEAR_TEAM_ID` is set in the outer environment.
3. Temporarily set `LINEAR_TEAM_ID=some-team` in your shell before running the tests to verify the clearing logic prevents pollution.
4. Verify no other tests in the suite regress due to the `cwd` change.

### Test Results

All 62 tests in `hooks/__tests__/work-orchestrator.test.js` pass with the isolation improvements applied.

Refs #67