### PR TITLE
feat(work-orchestrator): add brief and spec stages to /work workflow

### DIFF
--- a/hooks/work-orchestrator.js
+++ b/hooks/work-orchestrator.js
@@ -72,7 +72,7 @@ if (!tp) process.exit(0);
 
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.join(__dirname, '..');
 const MAIN_WORKTREE_FOLDER = process.env.REPO_NAME || 'my-project';
-const WORKTREES_BASE = `${process.env.HOME}/worktrees`;
+const WORKTREES_BASE = process.env.WORKTREES_BASE || `${process.env.HOME}/worktrees`;
 const TASKS_BASE = path.join(WORKTREES_BASE, 'tasks');
 
 // ─── State Machine ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Existing Behavior

- The /work workflow has 13 steps (1_ticket through 13_complete), jumping directly from 2_bootstrap to 3_implement with no brief or spec stage
- No product brief or technical spec generation stages exist; implementation begins immediately after bootstrapping
- All downstream step IDs are numbered 3-13, with 4_quality, 5_commit, 6_check, etc.
- WORK_BRIEF_ENABLED and WORK_SPEC_ENABLED environment variables are not documented in .env.example

## Intended New Behavior

- The /work workflow is extended to 15 steps by inserting 3_brief and 4_spec before implementation, shifting all subsequent step IDs by +2 (e.g. 3_implement becomes 5_implement, 4_quality becomes 6_quality, through 15_complete)
- Two new agents are introduced: brief-writer (generates a structured brief.md from ticket requirements) and spec-writer (explores the codebase and produces spec.md with Given/When/Then test scenarios)
- Both stages are opt-out via WORK_BRIEF_ENABLED=0 / WORK_SPEC_ENABLED=0 and are skipped automatically if their output files already exist
- The 2_bootstrap step gains skip edges directly to 5_implement, 6_quality, 7_commit, and 8_check to support resume flows that bypass the brief/spec stages
- .env.example is expanded with grouped sections documenting all workflow-control, bootstrap, and web-app environment variables

## Dev Checks

- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [Y] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Run the orchestrator plan command for any ticket and confirm steps 3 and 4 appear as 3_brief and 4_spec before 5_implement
2. Set WORK_BRIEF_ENABLED=0 and re-run; confirm 3_brief shows as SKIP in the plan output
3. Set WORK_SPEC_ENABLED=0 and re-run; confirm 4_spec shows as SKIP
4. Create a brief.md in the ticket task directory and re-run; confirm 3_brief is auto-skipped with reason "brief.md already exists"
5. Run the graph command and verify the state machine includes all 15 steps and new skip edges (3_brief to 5_implement, 11_pr to 13_ci, etc.)
6. Verify pnpm dev:check passes (all 266 tests green)

### Test Results

All 266 tests pass with 0 failures across enforce-step-workflow, TDD enforcement, orchestrator, work-state, and work-actions suites.
