### PR TITLE
ci: add GitHub Actions CI workflow for Node 20/22 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          # Note: npm cache disabled — no package-lock.json in repo
 
       - name: Install dependencies
-        run: npm install --ignore-scripts
+        run: npm install --ignore-scripts # npm install (not ci) — no lockfile in repo
 
       - name: Run tests
         run: npm test

--- a/hooks/__tests__/work-state.test.js
+++ b/hooks/__tests__/work-state.test.js
@@ -65,7 +65,7 @@ describe('work-state.js', () => {
     const TICKET = 'TEST-INIT-001';
     after(() => { cleanupTempWorkState(TICKET); });
 
-    it('should create state with all 15 steps as pending', async () => {
+    it('should create state with all 16 steps as pending', async () => {
       const { result, code } = await runWorkState(['init', TICKET]);
       assert.equal(code, 0);
       assert.equal(result.ticketId, TICKET);
@@ -76,7 +76,7 @@ describe('work-state.js', () => {
       assert.equal(result.errors.length, 0);
 
       const steps = Object.keys(result.stepStatus);
-      assert.equal(steps.length, 15);
+      assert.equal(steps.length, 16);
       for (const step of steps) {
         assert.equal(result.stepStatus[step], 'pending', `Step ${step} should be pending`);
       }
@@ -85,7 +85,7 @@ describe('work-state.js', () => {
       const expectedSteps = [
         'ticket', 'bootstrap', 'brief', 'spec', 'implement', 'quality',
         'commit', 'check', 'test_enhancement',
-        'pr', 'ready', 'ci', 'cleanup', 'reports', 'complete',
+        'pr', 'ready', 'follow_up', 'ci', 'cleanup', 'reports', 'complete',
       ];
       assert.deepEqual(steps, expectedSteps);
     });
@@ -125,7 +125,7 @@ describe('work-state.js', () => {
       assert.equal(code, 0);
       assert.equal(result.ticketId, TICKET_EXISTS);
       assert.equal(result.status, 'in_progress');
-      assert.equal(Object.keys(result.stepStatus).length, 15);
+      assert.equal(Object.keys(result.stepStatus).length, 16);
       for (const step of Object.keys(result.stepStatus)) {
         assert.equal(result.stepStatus[step], 'pending');
       }


### PR DESCRIPTION
## Existing Behavior

- No CI workflow exists; tests must be run manually by contributors.
- There is no automated check on PRs targeting `main` or on pushes to `main`.

## Intended New Behavior

- A GitHub Actions CI workflow runs the test suite automatically on all PRs targeting `main` and on pushes to `main`.
- Tests execute in a Node 20/22 matrix, ensuring compatibility across both LTS releases.
- Concurrency groups cancel in-progress runs for PRs (but not for pushes to `main`), reducing wasted runner minutes.
- Workflow runs with least-privilege permissions (`contents: read`).
- Dependencies installed via `npm install --ignore-scripts` (no lockfile in repo, so `npm ci` and npm caching are not available).

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Open this PR and verify the "CI / Test (Node 20)" and "CI / Test (Node 22)" checks appear and pass in the GitHub Checks tab.
2. Push a new commit to this branch and confirm both matrix jobs are triggered and cancel any previously in-progress run for this PR (concurrency cancel-in-progress behaviour).
3. After merge, push a commit directly to `main` and verify both jobs run to completion without cancellation.
4. Inspect the "Install dependencies" step logs — uses `npm install --ignore-scripts` (no lockfile committed, so `npm ci` is not used).

### Additional fix
- Fixed pre-existing test failures in `hooks/__tests__/work-state.test.js` (step count 15→16, added missing `follow_up` step).

Closes #75