### PR TITLE
fix(session-guard): scope guard behavior to ticket context, not global

### DIFF
--- a/hooks/__tests__/session-guard.test.js
+++ b/hooks/__tests__/session-guard.test.js
@@ -246,7 +246,8 @@ describe('session-guard', () => {
 
       const r = await runHook(
         { session_id: 'test-session', cwd: '/tmp' },
-        'PreCompact'
+        'PreCompact',
+        { SESSION_GUARD_TICKET_ID: TEST_TICKET }
       );
       assert.equal(r.code, 0);
       assert.ok(r.stdout.includes(TEST_TICKET), 'should mention ticket ID');
@@ -263,7 +264,8 @@ describe('session-guard', () => {
     it('is silent when no active session', async () => {
       const r = await runHook(
         { session_id: 'test-session', cwd: '/tmp' },
-        'PreCompact'
+        'PreCompact',
+        { SESSION_GUARD_TICKET_ID: TEST_TICKET }
       );
       assert.equal(r.code, 0);
       assert.equal(r.stdout.trim(), '', 'should produce no stdout when no session');
@@ -273,7 +275,8 @@ describe('session-guard', () => {
       await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
       const r = await runHook(
         { session_id: 'test-session', cwd: '/tmp' },
-        'PreCompact'
+        'PreCompact',
+        { SESSION_GUARD_TICKET_ID: TEST_TICKET }
       );
       assert.equal(r.code, 0, 'PreCompact must always exit 0');
     });
@@ -287,7 +290,8 @@ describe('session-guard', () => {
 
       const r = await runHook(
         { session_id: 'test-session', transcript_path: '/tmp/fake-transcript.jsonl' },
-        'Stop'
+        'Stop',
+        { SESSION_GUARD_TICKET_ID: TEST_TICKET }
       );
       assert.equal(r.code, 2, 'should exit 2 to block stop');
       assert.ok(r.stderr.includes('BLOCKED'), 'should contain BLOCKED');
@@ -300,7 +304,8 @@ describe('session-guard', () => {
 
       const r = await runHook(
         { session_id: 'test-session', transcript_path: '/tmp/fake-transcript.jsonl' },
-        'Stop'
+        'Stop',
+        { SESSION_GUARD_TICKET_ID: TEST_TICKET }
       );
       assert.equal(r.code, 0, 'should exit 0 when passphrase revealed');
     });
@@ -308,7 +313,8 @@ describe('session-guard', () => {
     it('allows when no active session', async () => {
       const r = await runHook(
         { session_id: 'test-session', transcript_path: '/tmp/fake-transcript.jsonl' },
-        'Stop'
+        'Stop',
+        { SESSION_GUARD_TICKET_ID: TEST_TICKET }
       );
       assert.equal(r.code, 0, 'should exit 0 when no session');
     });
@@ -322,7 +328,8 @@ describe('session-guard', () => {
           transcript_path: '/tmp/fake-transcript.jsonl',
           stop_message: 'User said: abort workflow please',
         },
-        'Stop'
+        'Stop',
+        { SESSION_GUARD_TICKET_ID: TEST_TICKET }
       );
       assert.equal(r.code, 0, 'should allow stop when abort workflow detected');
     });
@@ -336,7 +343,8 @@ describe('session-guard', () => {
           transcript_path: '/tmp/fake-transcript.jsonl',
           stop_message: 'ABORT WORKFLOW',
         },
-        'Stop'
+        'Stop',
+        { SESSION_GUARD_TICKET_ID: TEST_TICKET }
       );
       assert.equal(r.code, 0, 'should allow case-insensitive abort');
     });
@@ -350,7 +358,8 @@ describe('session-guard', () => {
           transcript_path: '/tmp/fake-transcript.jsonl',
           stop_message: 'I am done with this task',
         },
-        'Stop'
+        'Stop',
+        { SESSION_GUARD_TICKET_ID: TEST_TICKET }
       );
       assert.equal(r.code, 2, 'should block without abort keyword');
     });
@@ -419,7 +428,7 @@ describe('session-guard', () => {
       await runCli(['init', CHECK_TICKET, '/work'], { WORKTREES_BASE: TEMP_WB });
       writeCheckState('check', 'in_progress');
 
-      const r = await runHook({ stop_message: '' }, 'Stop', { WORKTREES_BASE: TEMP_WB });
+      const r = await runHook({ stop_message: '' }, 'Stop', { WORKTREES_BASE: TEMP_WB, SESSION_GUARD_TICKET_ID: CHECK_TICKET });
       assert.equal(r.code, 0, 'should allow stop when /check is active');
     });
 
@@ -427,7 +436,7 @@ describe('session-guard', () => {
       await runCli(['init', CHECK_TICKET, '/work'], { WORKTREES_BASE: TEMP_WB });
       // No check state written
 
-      const r = await runHook({ stop_message: '' }, 'Stop', { WORKTREES_BASE: TEMP_WB });
+      const r = await runHook({ stop_message: '' }, 'Stop', { WORKTREES_BASE: TEMP_WB, SESSION_GUARD_TICKET_ID: CHECK_TICKET });
       assert.equal(r.code, 2, 'should block stop without /check');
     });
 
@@ -435,7 +444,7 @@ describe('session-guard', () => {
       await runCli(['init', CHECK_TICKET, '/work'], { WORKTREES_BASE: TEMP_WB });
       writeCheckState('check', 'completed');
 
-      const r = await runHook({ stop_message: '' }, 'Stop', { WORKTREES_BASE: TEMP_WB });
+      const r = await runHook({ stop_message: '' }, 'Stop', { WORKTREES_BASE: TEMP_WB, SESSION_GUARD_TICKET_ID: CHECK_TICKET });
       assert.equal(r.code, 2, 'should block stop when /check completed');
     });
   });
@@ -448,14 +457,15 @@ describe('session-guard', () => {
       const sessionData = {
         ticketId: 'CWD-1',
         workflow: '/work',
-        passphrase: 'FAKE-ALPHA-0001',
+        passphrase: 'TEST-ONLY-ALPHA',
         cwd: process.cwd(),
         startTime: new Date().toISOString(),
         revealed: false,
       };
       fs.writeFileSync(sessionFilePath('CWD-1'), JSON.stringify(sessionData));
 
-      const r = await runHook({ stop_message: '' }, 'Stop');
+      // Disable ticket-based matching to test cwd fallback
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: '' });
       assert.equal(r.code, 2, 'should block when cwd matches');
     });
 
@@ -464,14 +474,15 @@ describe('session-guard', () => {
       const sessionData = {
         ticketId: 'CWD-2',
         workflow: '/work',
-        passphrase: 'FAKE-BRAVO-0002',
+        passphrase: 'TEST-ONLY-BRAVO',
         cwd: '/some/other/directory',
         startTime: new Date().toISOString(),
         revealed: false,
       };
       fs.writeFileSync(sessionFilePath('CWD-2'), JSON.stringify(sessionData));
 
-      const r = await runHook({ stop_message: '' }, 'Stop');
+      // Disable ticket-based matching to test cwd fallback
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: '' });
       assert.equal(r.code, 0, 'should allow stop when cwd does not match');
     });
 
@@ -480,14 +491,150 @@ describe('session-guard', () => {
       const sessionData = {
         ticketId: 'LEGACY-1',
         workflow: '/work',
-        passphrase: 'FAKE-CHARLIE-0003',
+        passphrase: 'TEST-ONLY-CHARLIE',
         startTime: new Date().toISOString(),
         revealed: false,
       };
       fs.writeFileSync(sessionFilePath('LEGACY-1'), JSON.stringify(sessionData));
 
-      const r = await runHook({ stop_message: '' }, 'Stop');
+      // Disable ticket-based matching to test cwd fallback
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: '' });
       assert.equal(r.code, 2, 'should block for legacy sessions without cwd');
+    });
+  });
+
+  // ─── Ticket-based session scoping ───
+
+  describe('ticket-based session scoping', () => {
+    afterEach(() => cleanupAllSessions());
+
+    it('blocks stop when session ticketId matches SESSION_GUARD_TICKET_ID', async () => {
+      const sessionData = {
+        ticketId: 'TICKET-A',
+        workflow: '/work',
+        passphrase: 'TEST-ONLY-ALPHA',
+        cwd: '/irrelevant/path',
+        startTime: new Date().toISOString(),
+        revealed: false,
+      };
+      fs.writeFileSync(sessionFilePath('TICKET-A'), JSON.stringify(sessionData));
+
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: 'TICKET-A' });
+      assert.equal(r.code, 2, 'should block when ticket matches');
+    });
+
+    it('allows stop when session ticketId does NOT match SESSION_GUARD_TICKET_ID', async () => {
+      const sessionData = {
+        ticketId: 'TICKET-A',
+        workflow: '/work',
+        passphrase: 'TEST-ONLY-ALPHA',
+        cwd: '/irrelevant/path',
+        startTime: new Date().toISOString(),
+        revealed: false,
+      };
+      fs.writeFileSync(sessionFilePath('TICKET-A'), JSON.stringify(sessionData));
+
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: 'TICKET-B' });
+      assert.equal(r.code, 0, 'should allow stop when ticket does not match');
+    });
+
+    it('ignores unrelated tickets, only blocks matching', async () => {
+      // Create two sessions with different tickets, both unrevealed
+      const sessionA = {
+        ticketId: 'TICKET-A',
+        workflow: '/work',
+        passphrase: 'TEST-ONLY-ALPHA',
+        cwd: '/irrelevant/path',
+        startTime: new Date().toISOString(),
+        revealed: false,
+      };
+      const sessionB = {
+        ticketId: 'TICKET-B',
+        workflow: '/work',
+        passphrase: 'TEST-ONLY-BRAVO',
+        cwd: '/irrelevant/path',
+        startTime: new Date().toISOString(),
+        revealed: false,
+      };
+      fs.writeFileSync(sessionFilePath('TICKET-A'), JSON.stringify(sessionA));
+      fs.writeFileSync(sessionFilePath('TICKET-B'), JSON.stringify(sessionB));
+
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: 'TICKET-B' });
+      assert.equal(r.code, 2, 'should block for matching TICKET-B');
+    });
+
+    it('allows stop when matching ticket session is revealed', async () => {
+      const sessionData = {
+        ticketId: 'TICKET-A',
+        workflow: '/work',
+        passphrase: 'TEST-ONLY-ALPHA',
+        cwd: '/irrelevant/path',
+        startTime: new Date().toISOString(),
+        revealed: true,
+      };
+      fs.writeFileSync(sessionFilePath('TICKET-A'), JSON.stringify(sessionData));
+
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: 'TICKET-A' });
+      assert.equal(r.code, 0, 'should allow stop when matching session is revealed');
+    });
+
+    it('falls back to cwd filter when no ticket context', async () => {
+      // Session with a different cwd — should not block when no ticket context
+      const sessionData = {
+        ticketId: 'TICKET-X',
+        workflow: '/work',
+        passphrase: 'TEST-ONLY-DELTA',
+        cwd: '/some/other/dir',
+        startTime: new Date().toISOString(),
+        revealed: false,
+      };
+      fs.writeFileSync(sessionFilePath('TICKET-X'), JSON.stringify(sessionData));
+
+      // Empty string opts out of ticket matching, falls back to cwd
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: '' });
+      assert.equal(r.code, 0, 'should allow stop when cwd does not match (no ticket context)');
+    });
+
+    it('treats empty SESSION_GUARD_TICKET_ID as no ticket context (falls back to cwd)', async () => {
+      // Session with current cwd — should block via cwd fallback
+      const sessionData = {
+        ticketId: 'TICKET-Y',
+        workflow: '/work',
+        passphrase: 'TEST-ONLY-NOT-SECRET',
+        cwd: process.cwd(),
+        startTime: new Date().toISOString(),
+        revealed: false,
+      };
+      fs.writeFileSync(sessionFilePath('TICKET-Y'), JSON.stringify(sessionData));
+
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: '' });
+      assert.equal(r.code, 2, 'should block via cwd fallback when SESSION_GUARD_TICKET_ID is empty');
+    });
+
+    it('PreCompact only shows reminders for matching ticket', async () => {
+      const sessionA = {
+        ticketId: 'TICKET-A',
+        workflow: '/work',
+        passphrase: 'TEST-ONLY-ALPHA',
+        cwd: '/irrelevant/path',
+        startTime: new Date().toISOString(),
+        revealed: false,
+      };
+      const sessionB = {
+        ticketId: 'TICKET-B',
+        workflow: '/work',
+        passphrase: 'TEST-ONLY-BRAVO',
+        cwd: '/irrelevant/path',
+        startTime: new Date().toISOString(),
+        revealed: false,
+      };
+      fs.writeFileSync(sessionFilePath('TICKET-A'), JSON.stringify(sessionA));
+      fs.writeFileSync(sessionFilePath('TICKET-B'), JSON.stringify(sessionB));
+
+      const r = await runHook({}, 'PreCompact', { SESSION_GUARD_TICKET_ID: 'TICKET-A' });
+      assert.equal(r.code, 0);
+      assert.ok(r.stdout.includes('TICKET-A'), 'should mention TICKET-A');
+      assert.ok(!r.stdout.includes('TICKET-B'), 'should NOT mention TICKET-B');
     });
   });
 });

--- a/hooks/__tests__/tdd-enforcement.test.js
+++ b/hooks/__tests__/tdd-enforcement.test.js
@@ -33,6 +33,14 @@ before(() => {
 
 after(() => {
   try { fs.rmSync(tempWorktreesBase, { recursive: true, force: true }); } catch {}
+  // Safety-net: clean up leaked session guard files created by THIS suite only (TDD* tickets)
+  try {
+    const tmpDir = require('os').tmpdir();
+    const tmpFiles = fs.readdirSync(tmpDir).filter(f => f.startsWith('claude-session-guard-TDD'));
+    for (const f of tmpFiles) {
+      try { fs.unlinkSync(path.join(tmpDir, f)); } catch {}
+    }
+  } catch { /* ignore if tmpdir unreadable */ }
 });
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/hooks/__tests__/work-orchestrator.test.js
+++ b/hooks/__tests__/work-orchestrator.test.js
@@ -63,6 +63,14 @@ after(() => {
       }
     }
   } catch {}
+  // Safety-net: clean up leaked session guard files created by THIS suite only (TEST-* tickets)
+  try {
+    const tmpDir = require('os').tmpdir();
+    const tmpFiles = fs.readdirSync(tmpDir).filter(f => f.startsWith('claude-session-guard-TEST-'));
+    for (const f of tmpFiles) {
+      try { fs.unlinkSync(path.join(tmpDir, f)); } catch {}
+    }
+  } catch { /* ignore if tmpdir unreadable */ }
 });
 
 // ─── Tests ──────────────────────────────────────────────────────────────────

--- a/hooks/session-guard.js
+++ b/hooks/session-guard.js
@@ -87,6 +87,46 @@ function generatePassphrase() {
   return `${w1}-${w2}-${num}`;
 }
 
+// ─── Ticket context resolution ──────────────────────────────────────────────
+
+let _cachedTicketId;
+let _ticketIdResolved = false;
+
+function resolveGitHead() {
+  const dotgitPath = '.git';
+  const dotgit = fs.readFileSync(dotgitPath, 'utf-8').trim();
+  if (dotgit.startsWith('gitdir: ')) {
+    const rawGitdir = dotgit.slice('gitdir: '.length);
+    const gitdir = path.resolve(path.dirname(dotgitPath), rawGitdir);
+    return fs.readFileSync(path.join(gitdir, 'HEAD'), 'utf-8').trim();
+  }
+  throw new Error('unexpected .git content');
+}
+
+function getTicketId() {
+  if (_ticketIdResolved) return _cachedTicketId;
+  _ticketIdResolved = true;
+  if ('SESSION_GUARD_TICKET_ID' in process.env) {
+    _cachedTicketId = process.env.SESSION_GUARD_TICKET_ID || null;
+    return _cachedTicketId;
+  }
+  try {
+    let head;
+    try {
+      head = resolveGitHead();
+    } catch {
+      head = fs.readFileSync(path.join('.git', 'HEAD'), 'utf-8').trim();
+    }
+    const ref = head.startsWith('ref: ') ? head.slice(5) : head;
+    const match = ref.match(/[A-Z]+-\d+/);
+    _cachedTicketId = match ? match[0] : null;
+  } catch {
+    _cachedTicketId = null;
+  }
+  return _cachedTicketId;
+}
+
+
 function readSessionFile(ticketId) {
   try {
     const filePath = sessionFilePath(ticketId);
@@ -292,8 +332,15 @@ function handlePreCompact() {
     return;
   }
 
+  // Only show reminders for sessions belonging to the current ticket context
+  const currentTicket = getTicketId();
+  const relevant = currentTicket
+    ? sessions.filter(s => s.ticketId === currentTicket)
+    : sessions;
+  if (relevant.length === 0) { process.exit(0); return; }
+
   const lines = [];
-  for (const session of sessions) {
+  for (const session of relevant) {
     lines.push(
       `ACTIVE WORKFLOW SESSION - DO NOT ABANDON`,
       `Workflow: ${session.workflow} | Ticket: ${session.ticketId}`,
@@ -343,10 +390,12 @@ function handleStop(hookData) {
     return;
   }
 
-  // Only consider sessions owned by this working directory
+  // Only consider sessions owned by this ticket context (or cwd as fallback)
+  const currentTicket = getTicketId();
   const currentCwd = process.cwd();
-  // Treat sessions missing cwd (legacy sessions) as owned, so they still enforce the lock
-  const ownedSessions = sessions.filter(s => !s.cwd || s.cwd === currentCwd);
+  const ownedSessions = currentTicket
+    ? sessions.filter(s => s.ticketId === currentTicket)
+    : sessions.filter(s => !s.cwd || s.cwd === currentCwd);  // fallback to cwd filter
 
   // Check if any owned session is unrevealed (tests: cwd match, no-match, legacy without cwd)
   const unrevealed = ownedSessions.filter(s => !s.revealed);


### PR DESCRIPTION
## Existing Behavior

- handleStop() in the session guard filtered active sessions using a cwd match, blocking Claude from stopping whenever any session file in /tmp shared the current working directory, regardless of which ticket or branch the session belonged to.
- handlePreCompact() iterated over all active sessions and emitted reminders for every one of them, causing cross-ticket noise when multiple concurrent agents had active sessions.
- The Stop and PreCompact hook integration checks did not pass a SESSION_GUARD_TICKET_ID, meaning each run could be polluted by session files left behind by parallel suites, causing intermittent false blocks.

## Intended New Behavior

- handleStop() now resolves the current ticket context via SESSION_GUARD_TICKET_ID env var (or by parsing the active git branch ref) and filters sessions exclusively to those whose ticketId matches, eliminating cross-ticket blocking between concurrent agents.
- handlePreCompact() applies the same ticket-scoped filter, so reminder output only surfaces sessions that belong to the running ticket; sessions from other tickets are silently ignored.
- When SESSION_GUARD_TICKET_ID is absent or empty, both handlers fall back to the previous cwd-based filter, preserving backward-compatible behavior for legacy sessions.
- 7 new specs in a dedicated ticket-based session scoping suite cover: ticket match blocks, ticket mismatch allows, multi-session isolation, revealed-session pass-through, cwd fallback, and PreCompact per-ticket filtering.
- Two other spec suites now clean up leaked session guard files from /tmp in their after() hooks to prevent cross-suite contamination.

Closes #72

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration specs
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Backend / CLI — verify ticket-scoped guard behavior:

1. Init a session for TICKET-A via the session guard CLI.
2. In a second shell (simulating a different agent), invoke the Stop hook with SESSION_GUARD_TICKET_ID=TICKET-B. Expected: exit code 0 — TICKET-B has no active session.
3. Invoke the Stop hook with SESSION_GUARD_TICKET_ID=TICKET-A. Expected: exit code 2 with BLOCKED in stderr.
4. Run the full suite via `pnpm dev:check` and confirm 162 specs pass.

### Spec Results

162 specs pass (7 new specs added in the ticket-based session scoping suite within hooks/__tests__/session-guard.test.js).
