### PR TITLE
feat(spec-writer): add missing sections to spec template

### DIFF
--- a/agents/completion-checker.md
+++ b/agents/completion-checker.md
@@ -114,7 +114,7 @@ If these files exist, cross-reference them against the implementation:
 - **Reusable Components** — Were listed existing components imported (not duplicated)?
 - **Endpoints** — Were all listed API endpoints implemented?
 - **E2E Test Scenarios** — Were tests written for the listed scenarios?
-- **Implementation Phases** — Were all phases completed?
+- **Implementation Order** — Were all steps completed?
 
 Report gaps between what was planned and what was delivered.
 

--- a/agents/spec-writer.md
+++ b/agents/spec-writer.md
@@ -48,9 +48,18 @@ You will receive:
    - Existing patterns (data models, API patterns, error handling)
    - Related code that will be affected
    - Test patterns and frameworks in use
-3. **Generate the spec** - Fill the template with concrete, codebase-aware details
-4. **Save** to the specified path
-5. **Return** a summary highlighting key architecture decisions and test scenarios
+3. **Reuse audit** - Actively search for existing code that can be reused:
+   - Grep/Glob for components, utilities, helpers, hooks, and patterns related to the feature
+   - Check for similar implementations that can be extended rather than rebuilt
+   - Document each finding with file path and how it maps to the new feature
+4. **Data & API audit** - Search for existing data models and endpoints:
+   - Grep for schema definitions, model files, migration patterns
+   - Grep for existing routes, handlers, endpoints that overlap with the feature
+   - Distinguish between what exists (reuse/extend) vs what's new (create)
+5. **Identify scope boundaries** - Determine what is out of scope and document it explicitly
+6. **Generate the spec** - Fill the template with concrete, codebase-aware details
+7. **Save** to the specified path
+8. **Return** a summary highlighting key architecture decisions, reuse findings, and test scenarios
 
 ## Spec Template
 
@@ -70,15 +79,37 @@ You will receive:
 - **Rationale:** {Why this approach}
 
 ## Data Model Changes
-{New/modified schemas, migrations, types — reference existing model files}
+
+Check existing schemas/models in the codebase first. For each change:
+
+### Existing Models Affected
+- `{ModelName}` in `{file path}` — {what changes: new fields, modified types, new relations}
+
+### New Models
+- `{ModelName}` — {purpose, key fields, relations to existing models}
+
+### Migrations / Side Effects
+- {Any data migrations, backfills, or index changes needed}
+- {Computed fields or aggregations that depend on these changes}
+
+{If no data model changes are needed, state: "No data model changes required."}
 
 ## API / Interface Changes
-{New/modified endpoints, function signatures, event handlers}
 
-### `{Method} {Path}`
+Search the codebase for existing endpoints/routes/handlers that overlap with this feature.
+
+### Existing Endpoints to Reuse or Extend
+- `{Method} {Path}` in `{file path}` — {what changes or how it's reused} | **Auth:** {required permissions/roles}
+
+### New Endpoints
+
+#### `{Method} {Path}`
 - **Request:** {type/shape}
 - **Response:** {type/shape}
 - **Errors:** {error cases}
+- **Auth:** {required permissions/roles}
+
+{If no API changes are needed, state: "No API changes required."}
 
 ## Security Considerations
 - {Auth requirements}
@@ -102,25 +133,54 @@ You will receive:
    **When** {action}
    **Then** {expected result}
 
-## Implementation Phases
-1. {First thing to build — smallest testable unit}
-2. {Next increment}
-3. {Final piece}
+## Reuse Audit
+
+Existing code that MUST be reused (found via grep/glob):
+
+| What | File | How to Reuse |
+|------|------|--------------|
+| {Existing component/utility/pattern} | `{file path}` | {How it maps to this feature} |
+
+{If nothing reusable was found, state: "No existing patterns found that match this feature's requirements."}
+
+## Implementation Order
+
+Numbered steps with explicit dependency notation. Each step should be the smallest independently testable unit.
+
+1. {First step — no dependencies}
+2. {Second step} → depends on: #1
+3. {Third step} → depends on: #1
+4. {Fourth step} → depends on: #2, #3
+
+{Steps with the same dependencies can be parallelized.}
 
 ## Files to Create/Modify
 - `{path}` — {what changes}
 
+## Out of Scope
+
+Explicitly list what is NOT being implemented to prevent scope creep:
+
+- {Feature or behavior that might seem related but is excluded}
+- {Reason for exclusion if not obvious}
+
+## Open Questions & Decisions
+
+Surface ambiguity BEFORE implementation starts. For each item, note the default assumption if no answer is provided:
+
+- {Question or ambiguity} — **Default:** {what the developer should assume}
+- {Decision needed from team} — **Default:** {fallback approach}
+
 ## Dependencies
 - {External libs, services, or internal modules needed}
-
-## Open Questions
-- {Anything requiring team input}
 ```
 
 ## Guidelines
 
 - Reference **specific files and line ranges** from the codebase, not abstract patterns
 - Test scenarios should be concrete enough to write tests from directly
-- Keep implementation phases small — each should be completable in one TDD cycle
+- Keep implementation steps small — each should be completable in one TDD cycle
 - Aim for 5-10 test scenarios covering happy path, edge cases, and error cases
-- If the brief has gaps, note them in Open Questions but still produce actionable spec
+- **Reuse Audit is mandatory** — always grep/glob for existing patterns before proposing new code. Document findings even if nothing reusable is found.
+- **Out of Scope is mandatory** — explicitly list what is excluded to prevent scope creep during implementation
+- If the brief has gaps, note them in Open Questions & Decisions with a default assumption so developers are never blocked

--- a/hooks/work-orchestrator.js
+++ b/hooks/work-orchestrator.js
@@ -607,7 +607,7 @@ function generatePlan(ticket, description, s, rework, callerProviderCfg) {
       : '';
     add(STEPS.spec, 'RUN', 'Task(spec-writer)', 'Generate technical specification', {
       agentType: 'spec-writer',
-      agentPrompt: `Analyze the codebase in ${worktreeDir} and generate a technical specification for ticket ${t}.${briefRef}\n\nSave the spec to: ${specPath}\n\nThe spec MUST include:\n1. Summary\n2. Architecture decisions (reference specific files)\n3. Data model changes\n4. API/interface changes\n5. Security considerations\n6. Test scenarios in Given/When/Then format (5-10 scenarios)\n7. Implementation phases\n8. Files to create/modify${getDocsPrompt('READ_DOCS_ON_SPEC')}`,
+      agentPrompt: `Analyze the codebase in ${worktreeDir} and generate a technical specification for ticket ${t}.${briefRef}\n\nSave the spec to: ${specPath}\n\nThe spec MUST include:\n1. Summary\n2. Architecture decisions (reference specific files)\n3. Data model changes\n4. API/interface changes\n5. Security considerations\n6. Test scenarios in Given/When/Then format (5-10 scenarios)\n7. Reuse Audit — grep/glob for existing patterns, components, utilities that can be reused\n8. Implementation Order — numbered steps with explicit dependency notation\n9. Files to create/modify\n10. Out of Scope — explicitly list what is NOT being implemented\n11. Open Questions & Decisions — surface ambiguity with default assumptions\n12. Dependencies — external libs, services, or internal modules needed${getDocsPrompt('READ_DOCS_ON_SPEC')}`,
     });
   }
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -75,8 +75,12 @@ Task(spec-writer):
   4. API/interface changes
   5. Security considerations
   6. Test scenarios in Given/When/Then format (5-10 scenarios)
-  7. Implementation phases
-  8. Files to create/modify
+  7. Reuse Audit — grep/glob for existing patterns, components, utilities that can be reused
+  8. Implementation Order — numbered steps with explicit dependency notation (e.g., "→ depends on: #1, #3")
+  9. Files to create/modify
+  10. Out of Scope — explicitly list what is NOT being implemented
+  11. Open Questions & Decisions — surface ambiguity with default assumptions
+  12. Dependencies — external libs, services, or internal modules needed
 
   ${IF READ_DOCS_ON_SPEC: Read these docs before starting: ${comma-separated paths}}
 ```


### PR DESCRIPTION
## Existing Behavior

- The spec-writer workflow jumped directly from codebase exploration to spec generation, with no explicit step to audit reusable code or search for existing data models and endpoints.
- The Data Model section used a single unstructured block, making no distinction between existing models to modify and new models to create.
- The API section had a single endpoint template with no guidance on reusing or extending existing routes.
- The spec template ended with a flat `Open Questions` list and `Implementation Phases` with no dependency ordering, and had no `Out of Scope` section.

## Intended New Behavior

- The workflow now includes two mandatory pre-generation steps: a **Reuse Audit** (grep/glob for reusable components, utilities, and patterns) and a **Data & API Audit** (distinguish existing vs new models and endpoints), plus an explicit scope-boundary identification step before generating the spec.
- The Data Model section is restructured into three subsections: `Existing Models Affected`, `New Models`, and `Migrations / Side Effects`, with a fallback statement when no changes are needed.
- The API section is split into `Existing Endpoints to Reuse or Extend` and `New Endpoints`, with an `Auth` field added to each endpoint block and a fallback statement when no changes are needed.
- `Implementation Phases` is replaced by **Implementation Order** with explicit `depends on: #N` notation so parallelizable steps are visible. A mandatory `Reuse Audit` table and a mandatory `Out of Scope` section are added. `Open Questions` is expanded to `Open Questions & Decisions` with a required **Default** assumption for each item, ensuring developers are never blocked.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This PR changes the `agents/spec-writer.md` prompt template. To verify the new behavior:

1. Trigger a `/spec` or `/work` command on a ticket that reaches the `4_spec` step.
2. Confirm the agent performs a **Reuse Audit** step (grep/glob for existing components) before generating the spec.
3. Confirm the agent performs a **Data & API Audit** step, distinguishing existing vs new models and endpoints.
4. Open the generated `spec.md` and verify it contains:
   - `## Reuse Audit` table (populated or with the explicit "no patterns found" fallback)
   - `## Data Model Changes` with `### Existing Models Affected`, `### New Models`, and `### Migrations / Side Effects` subsections
   - `## API / Interface Changes` with `### Existing Endpoints to Reuse or Extend` and `### New Endpoints` subsections
   - `## Implementation Order` with `→ depends on: #N` annotations
   - `## Out of Scope` section listing excluded behaviors
   - `## Open Questions & Decisions` with a `**Default:**` assumption per item
5. Confirm no regression in specs generated for features with no data model or API changes — the fallback statements (`"No data model changes required."` / `"No API changes required."`) should appear instead of empty sections.

Closes #122