### PR TITLE
fix(copilot-instructions): add Review Scope section to prevent over-reviewing moved files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,7 @@ Every review comment MUST include a severity tag at the start:
 ## Review Scope
 
 - Only review lines that were MODIFIED in this PR — do not review entire files that were added or moved
-- If a file was copied or moved from another location, focus only on the changes made during the move, not pre-existing code
+- If a file was copied or moved from another location, focus only on the changes made during the move, not pre-existing code. Example: if `scripts/symlink.js` is moved to `external_scripts/symlink.js`, git shows the entire file as "added" — do not review the 400 lines of pre-existing logic, only comment on lines that were actually modified during the move
 - Do not flag issues in code that existed before this PR unless the PR explicitly changed that code
 ## Review Focus
 


### PR DESCRIPTION
## Existing Behavior

- Copilot reviews the full content of any file added or moved in a PR, including pre-existing code that was not modified
- No explicit boundary was defined to distinguish between lines changed in this PR versus code that already existed before the PR

## Intended New Behavior

- Copilot only reviews lines that were explicitly modified in the PR, not entire files that were added or moved
- Files copied or moved from another location are reviewed only for changes made during the move, not for pre-existing code
- Code that existed before the PR and was not touched is treated as out of scope for review comments
- Newly tracked files whose content is unchanged are explicitly marked as out of scope

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a documentation-only change to `.github/copilot-instructions.md`.

To verify the change works as expected:

1. Open a PR in this repository that moves or renames a file without modifying its content
2. Request a Copilot review on that PR
3. Confirm that Copilot does not raise review comments on the pre-existing, unmodified lines inside the moved file
4. Open a PR that moves a file AND modifies a few lines
5. Confirm Copilot only comments on the modified lines, not on the unchanged pre-existing code