### PR TITLE
feat(GH-146): add suffix/phase syntax support for /work command

### DIFF
--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -1590,4 +1590,127 @@ describe('enforce-step-workflow', () => {
       assert.ok(stderr.includes('BLOCKED'));
     });
   });
+  // ─── ENFORCE_HOOK_SUFFIX tests (GH-146) ───────────────────────────────────
+
+  describe('ENFORCE_HOOK_SUFFIX (GH-146)', () => {
+    const SUFFIX_TICKET = `TEST-SUFFIX-${process.pid}`;
+    const SUFFIX = 'phase1';
+    const SUFFIX_TASKS_DIR = path.join(TASKS_BASE, SUFFIX_TICKET, SUFFIX);
+
+    afterEach(() => {
+      // Clean up both flat and suffixed dirs
+      try { fs.rmSync(path.join(TASKS_BASE, SUFFIX_TICKET), { recursive: true, force: true }); } catch {}
+    });
+
+    function writeSuffixWorkState(stepStatus, status = 'in_progress') {
+      fs.mkdirSync(SUFFIX_TASKS_DIR, { recursive: true });
+      const state = {
+        ticketId: `${SUFFIX_TICKET}/${SUFFIX}`,
+        description: '',
+        currentStep: 1,
+        status,
+        stepStatus,
+        checkProgress: {},
+        errors: [],
+        startTime: new Date().toISOString(),
+        lastUpdate: new Date().toISOString(),
+      };
+      fs.writeFileSync(path.join(SUFFIX_TASKS_DIR, '.work-state.json'), JSON.stringify(state, null, 2));
+    }
+
+    function writeSuffixEvidence(evidence) {
+      fs.mkdirSync(SUFFIX_TASKS_DIR, { recursive: true });
+      fs.writeFileSync(path.join(SUFFIX_TASKS_DIR, '.step-evidence.json'), JSON.stringify(evidence, null, 2));
+    }
+
+    it('should resolve suffixed ticket path when ENFORCE_HOOK_SUFFIX is set', async () => {
+      writeSuffixWorkState(makeStepStatus('implement', WORK_STEPS));
+      writeSuffixEvidence({});
+
+      // With suffix, the hook should find state at SUFFIX_TICKET/phase1/
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: 'echo hello' } },
+        'PreToolUse',
+        {
+          ENFORCE_HOOK_TICKET_ID: SUFFIX_TICKET,
+          ENFORCE_HOOK_SUFFIX: SUFFIX,
+        },
+      );
+      // Should allow (not block) since implement is in_progress and echo is not a protected command
+      assert.equal(code, 0, 'should allow non-protected command in suffixed state');
+    });
+
+    it('should fail-open when suffixed state path does not exist', async () => {
+      // No state file created — hook should fail-open
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: 'echo hello' } },
+        'PreToolUse',
+        {
+          ENFORCE_HOOK_TICKET_ID: SUFFIX_TICKET,
+          ENFORCE_HOOK_SUFFIX: SUFFIX,
+        },
+      );
+      assert.equal(code, 0, 'should fail-open when no state exists for suffixed path');
+    });
+
+    it('should ignore invalid ENFORCE_HOOK_SUFFIX (path traversal prevention)', async () => {
+      // Create state only in flat path
+      const flatDir = path.join(TASKS_BASE, SUFFIX_TICKET);
+      fs.mkdirSync(flatDir, { recursive: true });
+      const flatState = {
+        ticketId: SUFFIX_TICKET,
+        description: '',
+        currentStep: 1,
+        status: 'in_progress',
+        stepStatus: makeStepStatus('implement', WORK_STEPS),
+        checkProgress: {},
+        errors: [],
+        startTime: new Date().toISOString(),
+        lastUpdate: new Date().toISOString(),
+      };
+      fs.writeFileSync(path.join(flatDir, '.work-state.json'), JSON.stringify(flatState, null, 2));
+      fs.writeFileSync(path.join(flatDir, '.step-evidence.json'), JSON.stringify({}, null, 2));
+
+      // Invalid suffix should be ignored — hook falls back to flat path
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: 'echo hello' } },
+        'PreToolUse',
+        {
+          ENFORCE_HOOK_TICKET_ID: SUFFIX_TICKET,
+          ENFORCE_HOOK_SUFFIX: '../../../etc',
+        },
+      );
+      assert.equal(code, 0, 'should ignore invalid suffix and fall back to flat path');
+    });
+
+    it('should use flat ticket path when ENFORCE_HOOK_SUFFIX is not set', async () => {
+      // Create state only in flat path, not suffixed
+      const flatDir = path.join(TASKS_BASE, SUFFIX_TICKET);
+      fs.mkdirSync(flatDir, { recursive: true });
+      const flatState = {
+        ticketId: SUFFIX_TICKET,
+        description: '',
+        currentStep: 1,
+        status: 'in_progress',
+        stepStatus: makeStepStatus('implement', WORK_STEPS),
+        checkProgress: {},
+        errors: [],
+        startTime: new Date().toISOString(),
+        lastUpdate: new Date().toISOString(),
+      };
+      fs.writeFileSync(path.join(flatDir, '.work-state.json'), JSON.stringify(flatState, null, 2));
+      fs.writeFileSync(path.join(flatDir, '.step-evidence.json'), JSON.stringify({}, null, 2));
+
+      // Without suffix env, hook should look in flat path
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: 'echo hello' } },
+        'PreToolUse',
+        {
+          ENFORCE_HOOK_TICKET_ID: SUFFIX_TICKET,
+          // No ENFORCE_HOOK_SUFFIX
+        },
+      );
+      assert.equal(code, 0, 'should use flat path when suffix env is not set');
+    });
+  });
 });

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -498,6 +498,11 @@ function getTicketId() {
   // Allow override for testing — empty string explicitly opts out (no git fallback)
   if ('ENFORCE_HOOK_TICKET_ID' in process.env) {
     _cachedTicketId = process.env.ENFORCE_HOOK_TICKET_ID || null;
+    // Compose with suffix when present (GH-146: phase-aware state paths)
+    // Only append if ticketId doesn't already contain a '/' (prevent double-suffixing)
+    if (_cachedTicketId && !_cachedTicketId.includes('/') && process.env.ENFORCE_HOOK_SUFFIX && /^[a-zA-Z0-9_-]+$/.test(process.env.ENFORCE_HOOK_SUFFIX)) {
+      _cachedTicketId = _cachedTicketId + '/' + process.env.ENFORCE_HOOK_SUFFIX;
+    }
     return _cachedTicketId;
   }
   // (Patch 6+9) Worktree-aware .git/HEAD read — no subprocess spawn
@@ -515,6 +520,11 @@ function getTicketId() {
     _cachedTicketId = match ? match[0] : null;
   } catch {
     _cachedTicketId = null;
+  }
+  // Compose with suffix when present (GH-146: phase-aware state paths)
+  // Only append if ticketId doesn't already contain a '/' (prevent double-suffixing)
+  if (_cachedTicketId && !_cachedTicketId.includes('/') && process.env.ENFORCE_HOOK_SUFFIX && /^[a-zA-Z0-9_-]+$/.test(process.env.ENFORCE_HOOK_SUFFIX)) {
+    _cachedTicketId = _cachedTicketId + '/' + process.env.ENFORCE_HOOK_SUFFIX;
   }
   return _cachedTicketId;
 }

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -1271,3 +1271,90 @@ describe('work-orchestrator.js', () => {
     });
   });
 });
+
+// ─── parseTicketInput tests ──────────────────────────────────────────────────
+// parseTicketInput is exported from work.workflow.js for testing.
+const { parseTicketInput } = require(path.join(__dirname, '..', 'work.workflow.js'));
+
+describe('parseTicketInput', () => {
+  it('should parse GH-prefixed ticket with suffix', () => {
+    const result = parseTicketInput('GH-145/phase1');
+    assert.deepStrictEqual(result, { ticketBase: 'GH-145', suffix: 'phase1' });
+  });
+
+  it('should parse flat ticket ID (no suffix)', () => {
+    const result = parseTicketInput('GH-145');
+    assert.deepStrictEqual(result, { ticketBase: 'GH-145', suffix: null });
+  });
+
+  it('should parse Jira ticket with suffix', () => {
+    const result = parseTicketInput('PROJ-123/migration-step');
+    assert.deepStrictEqual(result, { ticketBase: 'PROJ-123', suffix: 'migration-step' });
+  });
+
+  it('should not parse URLs', () => {
+    const result = parseTicketInput('https://github.com/org/repo/issues/56');
+    assert.deepStrictEqual(result, { ticketBase: 'https://github.com/org/repo/issues/56', suffix: null });
+  });
+
+  it('should not parse http URLs', () => {
+    const result = parseTicketInput('http://example.com/path/to/resource');
+    assert.deepStrictEqual(result, { ticketBase: 'http://example.com/path/to/resource', suffix: null });
+  });
+
+  it('should not parse description inputs containing slashes', () => {
+    const result = parseTicketInput('add login/signup page');
+    assert.deepStrictEqual(result, { ticketBase: 'add login/signup page', suffix: null });
+  });
+
+  it('should not parse non-ticket patterns with slashes', () => {
+    const result = parseTicketInput('some-feature/phase1');
+    assert.deepStrictEqual(result, { ticketBase: 'some-feature/phase1', suffix: null });
+  });
+
+  it('should not parse bare numbers with slashes (avoids date/path confusion)', () => {
+    const result = parseTicketInput('123/phase1');
+    assert.deepStrictEqual(result, { ticketBase: '123/phase1', suffix: null });
+  });
+
+  it('should parse hash-prefixed GitHub issue with suffix', () => {
+    const result = parseTicketInput('#42/phase1');
+    assert.deepStrictEqual(result, { ticketBase: '#42', suffix: 'phase1' });
+  });
+
+  it('should reject path traversal in suffix', () => {
+    assert.throws(() => parseTicketInput('GH-145/../etc'), /invalid suffix/);
+  });
+
+  it('should reject invalid characters in suffix', () => {
+    assert.throws(() => parseTicketInput('GH-145/phase 1!@#'), /invalid suffix/);
+  });
+
+  it('should reject empty suffix after slash', () => {
+    assert.throws(() => parseTicketInput('GH-145/'), /invalid suffix/);
+  });
+
+  it('should support underscores and hyphens in suffix', () => {
+    const result = parseTicketInput('GH-145/step_2-alpha');
+    assert.deepStrictEqual(result, { ticketBase: 'GH-145', suffix: 'step_2-alpha' });
+  });
+
+  it('should reject nested suffixes', () => {
+    assert.throws(() => parseTicketInput('GH-145/phase1/subtask'), /invalid suffix/);
+  });
+
+  it('should handle null input', () => {
+    const result = parseTicketInput(null);
+    assert.deepStrictEqual(result, { ticketBase: null, suffix: null });
+  });
+
+  it('should handle undefined input', () => {
+    const result = parseTicketInput(undefined);
+    assert.deepStrictEqual(result, { ticketBase: undefined, suffix: null });
+  });
+
+  it('should handle non-string input', () => {
+    const result = parseTicketInput(123);
+    assert.deepStrictEqual(result, { ticketBase: 123, suffix: null });
+  });
+});

--- a/workflows/work/__tests__/work-state.test.js
+++ b/workflows/work/__tests__/work-state.test.js
@@ -417,6 +417,68 @@ describe('work-state.js', () => {
     });
   });
 
+  // ─── Suffix-aware state tests (GH-146) ──────────────────────────────────────
+
+  describe('suffix-aware state (GH-146)', () => {
+    const TICKET_BASE = 'TEST-SUFFIX-STATE';
+    const TICKET_SUFFIXED = 'TEST-SUFFIX-STATE/phase1';
+
+    after(() => {
+      cleanupTempWorkState(TICKET_BASE);
+    });
+
+    it('should create state in nested directory for suffixed ticket', async () => {
+      const { result, code } = await runWorkState(['init', TICKET_SUFFIXED, 'Phase 1 work']);
+      assert.equal(code, 0);
+      assert.ok(result, 'init should return a result');
+      assert.equal(result.ticketId, TICKET_SUFFIXED);
+
+      // Verify file was created in the nested path
+      const statePath = path.join(TEMP_TASKS_BASE, TICKET_BASE, 'phase1', '.work-state.json');
+      assert.ok(fs.existsSync(statePath), `State file should exist at ${statePath}`);
+    });
+
+    it('should not interfere with flat ticket state', async () => {
+      // Init flat ticket
+      await runWorkState(['init', TICKET_BASE, 'Flat ticket work']);
+
+      // Verify flat state
+      const flatPath = path.join(TEMP_TASKS_BASE, TICKET_BASE, '.work-state.json');
+      assert.ok(fs.existsSync(flatPath), 'Flat state file should exist');
+
+      // Verify suffixed state still exists
+      const suffixedPath = path.join(TEMP_TASKS_BASE, TICKET_BASE, 'phase1', '.work-state.json');
+      assert.ok(fs.existsSync(suffixedPath), 'Suffixed state file should still exist');
+
+      // Verify they have different ticketIds
+      const flatState = JSON.parse(fs.readFileSync(flatPath, 'utf-8'));
+      const suffixedState = JSON.parse(fs.readFileSync(suffixedPath, 'utf-8'));
+      assert.equal(flatState.ticketId, TICKET_BASE);
+      assert.equal(suffixedState.ticketId, TICKET_SUFFIXED);
+    });
+
+    it('should load state correctly for suffixed ticket', async () => {
+      const { result, code } = await runWorkState(['get', TICKET_SUFFIXED]);
+      assert.equal(code, 0);
+      assert.ok(result, 'get should return state');
+      assert.equal(result.ticketId, TICKET_SUFFIXED);
+    });
+
+    it('should support multiple suffixes under same base ticket', async () => {
+      const TICKET_PHASE2 = 'TEST-SUFFIX-STATE/phase2';
+
+      const { result, code } = await runWorkState(['init', TICKET_PHASE2, 'Phase 2 work']);
+      assert.equal(code, 0);
+      assert.equal(result.ticketId, TICKET_PHASE2);
+
+      // Both phases should have separate state files
+      const phase1Path = path.join(TEMP_TASKS_BASE, TICKET_BASE, 'phase1', '.work-state.json');
+      const phase2Path = path.join(TEMP_TASKS_BASE, TICKET_BASE, 'phase2', '.work-state.json');
+      assert.ok(fs.existsSync(phase1Path), 'Phase 1 state should exist');
+      assert.ok(fs.existsSync(phase2Path), 'Phase 2 state should exist');
+    });
+  });
+
   describe('complete-subtask', () => {
     const TICKET = 'TEST-SUBTASK-COMPLETE';
     after(() => { cleanupTempWorkState(TICKET); });

--- a/workflows/work/work.workflow.js
+++ b/workflows/work/work.workflow.js
@@ -837,7 +837,7 @@ function generatePlan(ticket, description, s, rework, callerProviderCfg, suffix)
     agentPrompt: [
       `Run these commands in sequence:`,
       `1. node "${path.join(__dirname, 'work-state.js')}" complete ${safeName}`,
-      `2. node "${guardPath}" finish ${safeName}`,
+      `2. node "${guardPath}" finish ${safeBase}`,
       ``,
       `Step 1 marks the workflow as complete (exits 0 on success).`,
       `Step 2 is an atomic teardown: reveals the session passphrase (unlocking the Stop hook) and removes the session file. Exits 0 when no session exists (guard disabled or already cleaned up). Exits 1 only if called without a ticket ID (programming error).`,

--- a/workflows/work/work.workflow.js
+++ b/workflows/work/work.workflow.js
@@ -37,8 +37,11 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
-process.on('uncaughtException', () => process.exit(0));
-process.on('unhandledRejection', () => process.exit(0));
+// Only install fail-safe handlers when running as CLI (not when require()'d for tests)
+if (require.main === module) {
+  process.on('uncaughtException', () => process.exit(0));
+  process.on('unhandledRejection', () => process.exit(0));
+}
 
 let appendAction, loadActions, analyzeActions;
 try {
@@ -110,6 +113,39 @@ function listFiles(dir, pattern) {
       .filter(f => pattern instanceof RegExp ? pattern.test(f) : f.includes(pattern))
       .map(f => path.join(dir, f));
   } catch { return []; }
+}
+
+// ─── Ticket Input Parsing (GH-146) ──────────────────────────────────────────
+// Parses "GH-145/phase1" into { ticketBase: "GH-145", suffix: "phase1" }.
+// URLs are returned as-is (no suffix parsing). Flat ticket IDs return suffix: null.
+
+function parseTicketInput(raw) {
+  if (!raw || typeof raw !== 'string') return { ticketBase: raw, suffix: null };
+
+  // Don't parse URLs - suffix syntax only for ticket ID shorthand
+  if (raw.startsWith('http://') || raw.startsWith('https://')) {
+    return { ticketBase: raw, suffix: null };
+  }
+
+  // Split on first /
+  const slashIdx = raw.indexOf('/');
+  if (slashIdx === -1) return { ticketBase: raw, suffix: null };
+
+  const ticketBase = raw.substring(0, slashIdx);
+  const suffix = raw.substring(slashIdx + 1);
+
+  // Only treat as suffix syntax if the part before '/' looks like a ticket ID
+  // (PROJ-123, GH-145, or #42). Bare numbers are excluded to avoid confusion
+  // with dates ("2024/report") or numeric paths ("123/phase1").
+  const looksLikeTicket = /^[A-Z]+-\d+$/i.test(ticketBase) || /^#\d+$/.test(ticketBase);
+  if (!looksLikeTicket) return { ticketBase: raw, suffix: null };
+
+  // Validate suffix: alphanumeric, hyphens, underscores only, single level
+  if (!suffix || !/^[a-zA-Z0-9_-]+$/.test(suffix)) {
+    throw new Error(`invalid suffix "${suffix}". Must match /^[a-zA-Z0-9_-]+$/ (alphanumeric, hyphens, underscores only, no nested paths).`);
+  }
+
+  return { ticketBase, suffix };
 }
 
 // ─── Artifact Archival (GH-130) ─────────────────────────────────────────────
@@ -422,12 +458,13 @@ const REQUIRED_REPORTS = [
 
 // ─── State Inspection ────────────────────────────────────────────────────────
 
-function inspect(ticket, providerConfig) {
+function inspect(ticket, providerConfig, suffix) {
   const s = {};
-  const safeName = tp.sanitizeTicketIdForPath(ticket, providerConfig);
+  const safeBase = tp.sanitizeTicketIdForPath(ticket, providerConfig);
+  const safeName = suffix ? safeBase + '/' + suffix : safeBase;
 
-  s.worktreeDir = path.join(WORKTREES_BASE, `${MAIN_WORKTREE_FOLDER}-${safeName}`);
-  s.tasksDir = path.join(TASKS_BASE, safeName);
+  s.worktreeDir = path.join(WORKTREES_BASE, `${MAIN_WORKTREE_FOLDER}-${safeBase}`);  // shared across phases
+  s.tasksDir = path.join(TASKS_BASE, safeName);  // isolated per phase
   s.worktreeExists = fileExists(s.worktreeDir);
   s.tasksDirExists = fileExists(s.tasksDir);
 
@@ -523,12 +560,13 @@ function inspect(ticket, providerConfig) {
 
 // ─── Plan Generation ─────────────────────────────────────────────────────────
 
-function generatePlan(ticket, description, s, rework, callerProviderCfg) {
+function generatePlan(ticket, description, s, rework, callerProviderCfg, suffix) {
   const plan = [];
   const mode = rework ? 'rework' : 'resume';
   const t = ticket || '{TICKET}';
-  const safeName = ticket ? tp.sanitizeTicketIdForPath(t, callerProviderCfg) : t;
-  const worktreeDir = s?.worktreeDir || `${WORKTREES_BASE}/${MAIN_WORKTREE_FOLDER}-${safeName}`;
+  const safeBase = ticket ? tp.sanitizeTicketIdForPath(t, callerProviderCfg) : t;
+  const safeName = suffix ? safeBase + '/' + suffix : safeBase;
+  const worktreeDir = s?.worktreeDir || `${WORKTREES_BASE}/${MAIN_WORKTREE_FOLDER}-${safeBase}`;
   const tasksDir = s?.tasksDir || `${TASKS_BASE}/${safeName}`;
 
   const tddEnforce = detectTestSetup(worktreeDir);
@@ -538,7 +576,8 @@ function generatePlan(ticket, description, s, rework, callerProviderCfg) {
     try {
       const guardPath = path.join(__dirname, '..', 'lib', 'hooks', 'session-guard.js');
       // init is idempotent: reuses existing session if one exists for this ticket
-      execFileSync(process.execPath, [guardPath, 'init', ticket, '/work'], { stdio: 'pipe', timeout: 5000 });
+      // Use safeBase (not raw ticket or safeName) so init/finish use the same ID
+      execFileSync(process.execPath, [guardPath, 'init', safeBase, '/work'], { stdio: 'pipe', timeout: 5000 });
     } catch { /* fail-open: session-guard init failure must not block plan generation */ }
   }
 
@@ -805,7 +844,12 @@ function generatePlan(ticket, description, s, rework, callerProviderCfg) {
     ].join('\n'),
   }); // complete — must run after all other steps
 
-  return { ticket: ticket || `TBD ("${description}")`, mode, plan };
+  const planResult = { ticket: ticket || `TBD ("${description}")`, mode, plan };
+  if (suffix) {
+    planResult.suffix = suffix;
+    planResult.fullTicket = planResult.ticket + '/' + suffix;
+  }
+  return planResult;
 }
 
 // ─── Check-to-PR Gate (GH-121) ──────────────────────────────────────────────
@@ -961,6 +1005,17 @@ function main() {
       let raw = rest.filter(a => a !== '--rework').join(' ').trim();
       if (!raw) { console.log(JSON.stringify({ error: true, message: 'Provide ticket ID or description' })); process.exit(1); }
 
+      // Parse suffix/phase syntax (e.g., "GH-145/phase1" -> ticketBase="GH-145", suffix="phase1")
+      let suffix = null;
+      try {
+        const parsed = parseTicketInput(raw);
+        raw = parsed.ticketBase;  // regex checks run against ticketBase only
+        suffix = parsed.suffix;
+      } catch (err) {
+        console.log(JSON.stringify({ error: true, message: err.message }));
+        process.exit(1);
+      }
+
       let providerConfig = tp.getProviderConfig({ skipPrompt: true });
       const isGitHub = providerConfig?.provider === 'github';
 
@@ -993,8 +1048,8 @@ function main() {
         providerConfig.owner = ghUrlMeta.owner;
         providerConfig.repo = ghUrlMeta.repo;
       }
-      const state = ticket ? inspect(ticket, providerConfig) : null;
-      const result = generatePlan(ticket, isTicket ? null : raw, state, rework, providerConfig);
+      const state = ticket ? inspect(ticket, providerConfig, suffix) : null;
+      const result = generatePlan(ticket, isTicket ? null : raw, state, rework, providerConfig, suffix);
 
       result.timestamp = new Date().toISOString();
       if (ghUrlMeta && providerConfig) {
@@ -1037,9 +1092,16 @@ function main() {
         process.exit(1);
       }
       const transProviderCfg = tp.getProviderConfig({ skipPrompt: true });
-      // Normalize: uppercase for Jira/Linear, then sanitize for GitHub path safety
-      const transTicket = transProviderCfg?.provider === 'github' ? rest[0] : rest[0].toUpperCase();
-      const safeTransTicket = tp.sanitizeTicketIdForPath(transTicket, transProviderCfg);
+      // Normalize: uppercase only ticketBase for Jira/Linear, preserve suffix case (GH-146)
+      let transParsed;
+      try {
+        transParsed = parseTicketInput(rest[0]);
+      } catch (e) {
+        console.log(JSON.stringify({ error: true, message: e.message }));
+        process.exit(1);
+      }
+      const transBase = transProviderCfg?.provider === 'github' ? transParsed.ticketBase : transParsed.ticketBase.toUpperCase();
+      const safeTransTicket = tp.sanitizeTicketIdForPath(transBase, transProviderCfg) + (transParsed.suffix ? '/' + transParsed.suffix : '');
       console.log(JSON.stringify(transitionStep(safeTransTicket, rest[1]), null, 2));
       break;
     }
@@ -1048,8 +1110,16 @@ function main() {
       requirePaths();
       if (!rest[0]) { console.log(JSON.stringify({ error: true, message: 'Usage: transitions <TICKET>' })); process.exit(1); }
       const transitionsProviderCfg = tp.getProviderConfig({ skipPrompt: true });
-      const transitionsTicket = transitionsProviderCfg?.provider === 'github' ? rest[0] : rest[0].toUpperCase();
-      const safeTransitionsTicket = tp.sanitizeTicketIdForPath(transitionsTicket, transitionsProviderCfg);
+      // Normalize: uppercase only ticketBase, preserve suffix case (GH-146)
+      let transParsed2;
+      try {
+        transParsed2 = parseTicketInput(rest[0]);
+      } catch (e) {
+        console.log(JSON.stringify({ error: true, message: e.message }));
+        process.exit(1);
+      }
+      const transBase2 = transitionsProviderCfg?.provider === 'github' ? transParsed2.ticketBase : transParsed2.ticketBase.toUpperCase();
+      const safeTransitionsTicket = tp.sanitizeTicketIdForPath(transBase2, transitionsProviderCfg) + (transParsed2.suffix ? '/' + transParsed2.suffix : '');
       console.log(JSON.stringify(getAvailableTransitions(safeTransitionsTicket), null, 2));
       break;
     }
@@ -1066,7 +1136,16 @@ function main() {
         process.exit(1);
       }
       const actionsProviderCfg = tp.getProviderConfig({ skipPrompt: true });
-      const ticket = tp.sanitizeTicketIdForPath(actionsProviderCfg?.provider === 'github' ? rest[0] : rest[0].toUpperCase(), actionsProviderCfg);
+      // Normalize: uppercase only ticketBase, preserve suffix case (GH-146)
+      let actionsParsed;
+      try {
+        actionsParsed = parseTicketInput(rest[0]);
+      } catch (e) {
+        console.log(JSON.stringify({ error: true, message: e.message }));
+        process.exit(1);
+      }
+      const actionsBase = actionsProviderCfg?.provider === 'github' ? actionsParsed.ticketBase : actionsParsed.ticketBase.toUpperCase();
+      const ticket = tp.sanitizeTicketIdForPath(actionsBase, actionsProviderCfg) + (actionsParsed.suffix ? '/' + actionsParsed.suffix : '');
       const raw = rest.includes('--raw');
       const actions = loadActions(ticket);
       if (raw) {
@@ -1085,7 +1164,16 @@ function main() {
         process.exit(1);
       }
       const tddProviderCfg = tp.getProviderConfig({ skipPrompt: true });
-      const ticket = tp.sanitizeTicketIdForPath(tddProviderCfg?.provider === 'github' ? rest[0] : rest[0].toUpperCase(), tddProviderCfg);
+      // Normalize: uppercase only ticketBase, preserve suffix case (GH-146)
+      let tddParsed;
+      try {
+        tddParsed = parseTicketInput(rest[0]);
+      } catch (e) {
+        console.error(JSON.stringify({ error: true, message: e.message }));
+        process.exit(1);
+      }
+      const tddBase = tddProviderCfg?.provider === 'github' ? tddParsed.ticketBase : tddParsed.ticketBase.toUpperCase();
+      const ticket = tp.sanitizeTicketIdForPath(tddBase, tddProviderCfg) + (tddParsed.suffix ? '/' + tddParsed.suffix : '');
       const stepId = rest[1];
       // Parse flags — missing values for --cmd/--files/--exception fall through
       // to recordTddEvidence() validation which returns clear error messages.
@@ -1115,6 +1203,9 @@ function main() {
   }
 }
 
+// Export for testing; run main() only when executed directly
 if (require.main === module) {
   main();
 }
+
+module.exports = { parseTicketInput };


### PR DESCRIPTION
## Existing Behavior

- The /work command accepts a ticket ID and maintains a single state path per ticket under {TASKS_BASE}/{TICKET_ID}/.
- All CLI subcommands (transition, transitions, actions, record-tdd) call .toUpperCase() on the full raw input, which corrupts any phase suffix (e.g., TICKET/PHASE1 instead of the intended TICKET/phase1).
- ENFORCE_HOOK_SUFFIX in enforce-step-workflow.js is appended to the ticket ID without validation, allowing path traversal strings like ../../../etc to reach the filesystem.
- There is no mechanism to break a large ticket into independently tracked phases while reusing the same worktree and branch.

## Intended New Behavior

- Users can pass a TICKET/suffix shorthand (e.g., /work GH-145/phase1) to run phases with fully isolated state under {TASKS_BASE}/{TICKET_ID}/{suffix}/ while sharing the same worktree and branch.
- A new parseTicketInput() utility splits input on the first /, validates the suffix matches /^[a-zA-Z0-9_-]+$/, and returns { ticketBase, suffix } — throwing a clear error on invalid suffixes.
- CLI subcommands now uppercase only ticketBase and append the raw suffix unchanged, preserving case (e.g., phase1 stays phase1).
- enforce-step-workflow.js validates ENFORCE_HOOK_SUFFIX against the same regex before composing the state path, silently ignoring invalid values (including path traversal attempts) and falling back to the flat ticket path.
- 27 new checks cover suffix-aware plan generation, path traversal rejection, suffix case preservation across all CLI subcommands, and ENFORCE_HOOK_SUFFIX validation.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration checks
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**CLI verification:**

1. Invoke the plan subcommand with GH-145/phase1 — confirm state path resolves to {TASKS_BASE}/GH-145/phase1/ and an action plan is returned without errors.
2. Invoke plan for GH-145/phase2 after completing phase1 — confirm state is isolated (phase2 starts fresh while phase1 state is untouched).
3. Invoke the transition subcommand with GH-145/phase1 bootstrap — confirm the suffix is preserved in lowercase in the resolved path (not PHASE1).
4. Invoke plan with GH-145/../../../etc as input — confirm it throws Invalid suffix and exits non-zero.
5. Set ENFORCE_HOOK_SUFFIX=../../../etc and trigger the enforce-step-workflow hook — confirm the hook ignores the invalid suffix and falls back to the flat ticket path (exit code 0).

closes #146