### PR TITLE
fix(enforce-step-workflow): fix agent allowlist blocking subagents spawned via Task()/Agent()

### DIFF
--- a/workflows/lib/__tests__/agent-detection.test.js
+++ b/workflows/lib/__tests__/agent-detection.test.js
@@ -6,10 +6,6 @@
 
 const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-
 const {
   normalizeAgentName,
   isRunningInAgent,
@@ -169,6 +165,7 @@ describe('isRunningInAgent — debug logging', () => {
     savedEnv.CLAUDE_CURRENT_AGENT = process.env.CLAUDE_CURRENT_AGENT;
     savedEnv.ENFORCE_HOOK_DEBUG = process.env.ENFORCE_HOOK_DEBUG;
     delete process.env.CLAUDE_CURRENT_AGENT;
+    delete process.env.ENFORCE_HOOK_DEBUG;
     stderrOutput = '';
     originalWrite = process.stderr.write;
     process.stderr.write = (chunk) => { stderrOutput += chunk; return true; };

--- a/workflows/lib/__tests__/agent-detection.test.js
+++ b/workflows/lib/__tests__/agent-detection.test.js
@@ -1,0 +1,204 @@
+/**
+ * Tests for lib/agent-detection.js — normalizeAgentName and isRunningInAgent enhancements
+ *
+ * Run: node --test lib/__tests__/agent-detection.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const {
+  normalizeAgentName,
+  isRunningInAgent,
+} = require('../agent-detection');
+
+// ─── normalizeAgentName ──────────────────────────────────────────────────────
+
+describe('normalizeAgentName', () => {
+  it('returns bare name unchanged (lowercased)', () => {
+    assert.equal(normalizeAgentName('quality-checker'), 'quality-checker');
+  });
+
+  it('strips namespace prefix', () => {
+    assert.equal(normalizeAgentName('work-workflow:quality-checker'), 'quality-checker');
+  });
+
+  it('lowercases mixed-case input', () => {
+    assert.equal(normalizeAgentName('Quality-Checker'), 'quality-checker');
+  });
+
+  it('handles prefixed mixed-case', () => {
+    assert.equal(normalizeAgentName('Work-Workflow:Quality-Checker'), 'quality-checker');
+  });
+
+  it('returns empty string for null', () => {
+    assert.equal(normalizeAgentName(null), '');
+  });
+
+  it('returns empty string for undefined', () => {
+    assert.equal(normalizeAgentName(undefined), '');
+  });
+
+  it('returns empty string for empty string', () => {
+    assert.equal(normalizeAgentName(''), '');
+  });
+});
+
+// ─── isRunningInAgent — env var detection ────────────────────────────────────
+
+describe('isRunningInAgent — CLAUDE_CURRENT_AGENT env var', () => {
+  const savedEnv = {};
+
+  beforeEach(() => {
+    savedEnv.CLAUDE_CURRENT_AGENT = process.env.CLAUDE_CURRENT_AGENT;
+    savedEnv.ENFORCE_HOOK_DEBUG = process.env.ENFORCE_HOOK_DEBUG;
+    delete process.env.CLAUDE_CURRENT_AGENT;
+    delete process.env.ENFORCE_HOOK_DEBUG;
+  });
+
+  afterEach(() => {
+    if (savedEnv.CLAUDE_CURRENT_AGENT !== undefined) {
+      process.env.CLAUDE_CURRENT_AGENT = savedEnv.CLAUDE_CURRENT_AGENT;
+    } else {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+    if (savedEnv.ENFORCE_HOOK_DEBUG !== undefined) {
+      process.env.ENFORCE_HOOK_DEBUG = savedEnv.ENFORCE_HOOK_DEBUG;
+    } else {
+      delete process.env.ENFORCE_HOOK_DEBUG;
+    }
+  });
+
+  it('matches bare agent name from env var', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'quality-checker';
+    assert.ok(isRunningInAgent(null, ['quality-checker']));
+  });
+
+  it('matches prefixed env var against bare alias (normalization)', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'work-workflow:quality-checker';
+    assert.ok(isRunningInAgent(null, ['quality-checker']));
+  });
+
+  it('matches bare env var against prefixed alias (normalization)', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'quality-checker';
+    assert.ok(isRunningInAgent(null, ['work-workflow:quality-checker']));
+  });
+
+  it('returns false when env var does not match any alias', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'other-agent';
+    // Need a non-existent transcript so other strategies also fail
+    assert.ok(!isRunningInAgent('/nonexistent/transcript.json', ['quality-checker']));
+  });
+});
+
+// ─── isRunningInAgent — hookData.tool_input.subagent_type ────────────────────
+
+describe('isRunningInAgent — hookData subagent_type', () => {
+  const savedEnv = {};
+
+  beforeEach(() => {
+    savedEnv.CLAUDE_CURRENT_AGENT = process.env.CLAUDE_CURRENT_AGENT;
+    savedEnv.ENFORCE_HOOK_DEBUG = process.env.ENFORCE_HOOK_DEBUG;
+    delete process.env.CLAUDE_CURRENT_AGENT;
+    delete process.env.ENFORCE_HOOK_DEBUG;
+  });
+
+  afterEach(() => {
+    if (savedEnv.CLAUDE_CURRENT_AGENT !== undefined) {
+      process.env.CLAUDE_CURRENT_AGENT = savedEnv.CLAUDE_CURRENT_AGENT;
+    } else {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+    if (savedEnv.ENFORCE_HOOK_DEBUG !== undefined) {
+      process.env.ENFORCE_HOOK_DEBUG = savedEnv.ENFORCE_HOOK_DEBUG;
+    } else {
+      delete process.env.ENFORCE_HOOK_DEBUG;
+    }
+  });
+
+  it('matches subagent_type from hookData', () => {
+    const hookData = { tool_input: { subagent_type: 'quality-checker' } };
+    assert.ok(isRunningInAgent('/nonexistent/transcript.json', ['quality-checker'], hookData));
+  });
+
+  it('matches prefixed subagent_type against bare alias (normalization)', () => {
+    const hookData = { tool_input: { subagent_type: 'work-workflow:quality-checker' } };
+    assert.ok(isRunningInAgent('/nonexistent/transcript.json', ['quality-checker'], hookData));
+  });
+
+  it('returns false when subagent_type does not match', () => {
+    const hookData = { tool_input: { subagent_type: 'other-agent' } };
+    assert.ok(!isRunningInAgent('/nonexistent/transcript.json', ['quality-checker'], hookData));
+  });
+});
+
+// ─── isRunningInAgent — returns false when all strategies fail ────────────────
+
+describe('isRunningInAgent — fallback', () => {
+  const savedEnv = {};
+
+  beforeEach(() => {
+    savedEnv.CLAUDE_CURRENT_AGENT = process.env.CLAUDE_CURRENT_AGENT;
+    delete process.env.CLAUDE_CURRENT_AGENT;
+  });
+
+  afterEach(() => {
+    if (savedEnv.CLAUDE_CURRENT_AGENT !== undefined) {
+      process.env.CLAUDE_CURRENT_AGENT = savedEnv.CLAUDE_CURRENT_AGENT;
+    } else {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+  });
+
+  it('returns false when no env var, no hookData, and no transcript match', () => {
+    assert.ok(!isRunningInAgent('/nonexistent/transcript.json', ['quality-checker'], {}));
+  });
+});
+
+// ─── Debug logging ───────────────────────────────────────────────────────────
+
+describe('isRunningInAgent — debug logging', () => {
+  const savedEnv = {};
+  let stderrOutput = '';
+  let originalWrite;
+
+  beforeEach(() => {
+    savedEnv.CLAUDE_CURRENT_AGENT = process.env.CLAUDE_CURRENT_AGENT;
+    savedEnv.ENFORCE_HOOK_DEBUG = process.env.ENFORCE_HOOK_DEBUG;
+    delete process.env.CLAUDE_CURRENT_AGENT;
+    stderrOutput = '';
+    originalWrite = process.stderr.write;
+    process.stderr.write = (chunk) => { stderrOutput += chunk; return true; };
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+    if (savedEnv.CLAUDE_CURRENT_AGENT !== undefined) {
+      process.env.CLAUDE_CURRENT_AGENT = savedEnv.CLAUDE_CURRENT_AGENT;
+    } else {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+    if (savedEnv.ENFORCE_HOOK_DEBUG !== undefined) {
+      process.env.ENFORCE_HOOK_DEBUG = savedEnv.ENFORCE_HOOK_DEBUG;
+    } else {
+      delete process.env.ENFORCE_HOOK_DEBUG;
+    }
+  });
+
+  it('emits debug log when ENFORCE_HOOK_DEBUG is set and env var matches', () => {
+    process.env.ENFORCE_HOOK_DEBUG = '1';
+    process.env.CLAUDE_CURRENT_AGENT = 'quality-checker';
+    isRunningInAgent(null, ['quality-checker']);
+    assert.ok(stderrOutput.includes('[agent-detection]'));
+    assert.ok(stderrOutput.includes('matched'));
+  });
+
+  it('does not emit debug log when ENFORCE_HOOK_DEBUG is not set', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'quality-checker';
+    isRunningInAgent(null, ['quality-checker']);
+    assert.equal(stderrOutput, '');
+  });
+});

--- a/workflows/lib/__tests__/agent-detection.test.js
+++ b/workflows/lib/__tests__/agent-detection.test.js
@@ -154,6 +154,41 @@ describe('isRunningInAgent — fallback', () => {
   });
 });
 
+// ─── Frontmatter detection ──────────────────────────────────────────────────
+
+describe('isRunningInAgent — frontmatter detection', () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const savedAgent = process.env.CLAUDE_CURRENT_AGENT;
+
+  beforeEach(() => { delete process.env.CLAUDE_CURRENT_AGENT; });
+  afterEach(() => {
+    if (savedAgent !== undefined) process.env.CLAUDE_CURRENT_AGENT = savedAgent;
+    else delete process.env.CLAUDE_CURRENT_AGENT;
+  });
+
+  it('matches prefixed frontmatter name against bare alias', () => {
+    const tmp = path.join(os.tmpdir(), `agent-detect-fm-${process.pid}.txt`);
+    fs.writeFileSync(tmp, 'name: work-workflow:quality-checker\n');
+    try {
+      assert.ok(isRunningInAgent(tmp, ['quality-checker']));
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+
+  it('matches bare frontmatter name against bare alias', () => {
+    const tmp = path.join(os.tmpdir(), `agent-detect-fm2-${process.pid}.txt`);
+    fs.writeFileSync(tmp, 'name: quality-checker\n');
+    try {
+      assert.ok(isRunningInAgent(tmp, ['quality-checker']));
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+});
+
 // ─── Debug logging ───────────────────────────────────────────────────────────
 
 describe('isRunningInAgent — debug logging', () => {

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -1550,4 +1550,44 @@ describe('enforce-step-workflow', () => {
       assert.ok(stderr.includes('BLOCKED'));
     });
   });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Agent allowlist prefix normalization (GH-149)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('agent allowlist prefix normalization', () => {
+    it('allows quality-checker via bare CLAUDE_CURRENT_AGENT during check step', async () => {
+      writeWorkState(makeStepStatus('check', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Write', tool_input: { file_path: `${TASKS_DIR}/tests.check.md`, content: '# Check report' } },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'quality-checker' },
+      );
+      assert.equal(code, 0, 'bare agent name should be allowed');
+    });
+
+    it('allows work-workflow:quality-checker via prefixed CLAUDE_CURRENT_AGENT during check step', async () => {
+      writeWorkState(makeStepStatus('check', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Write', tool_input: { file_path: `${TASKS_DIR}/tests.check.md`, content: '# Check report' } },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'work-workflow:quality-checker' },
+      );
+      assert.equal(code, 0, 'prefixed agent name should be normalized and allowed');
+    });
+
+    it('blocks unauthorized agent during check step', async () => {
+      writeWorkState(makeStepStatus('check', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Write', tool_input: { file_path: `${TASKS_DIR}/tests.check.md`, content: '# Check report' } },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'unauthorized-agent' },
+      );
+      assert.equal(code, 2, 'unauthorized agent should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+  });
 });

--- a/workflows/lib/__tests__/protect-artifact-files.test.js
+++ b/workflows/lib/__tests__/protect-artifact-files.test.js
@@ -203,6 +203,20 @@ describe('createArtifactProtector', () => {
     assert.deepEqual(capturedAgents, ['spec-writer']);
   });
 
+  it('passes full hookData as third arg to isRunningInAgent', () => {
+    let capturedHookData = null;
+    const p = makeProtector({
+      currentStep: 'spec',
+      isRunningInAgent: (tp, agents, hd) => { capturedHookData = hd; return true; },
+    });
+    const hookData = {
+      transcript_path: '/tmp/transcript.json',
+      tool_input: { subagent_type: 'spec-writer' },
+    };
+    p.check('Write', { file_path: `/tasks/${TICKET}/spec.md` }, hookData);
+    assert.deepEqual(capturedHookData, hookData);
+  });
+
   // ── Step message includes current step ──
 
   it('includes current step in block message', () => {

--- a/workflows/lib/agent-detection.js
+++ b/workflows/lib/agent-detection.js
@@ -154,7 +154,8 @@ function isRunningInAgent(transcriptPath, agentAliases, hookData) {
   try {
     const content = fs.readFileSync(transcriptPath, 'utf8');
     for (const alias of agentAliases) {
-      const frontmatterPattern = new RegExp(`^name:\\s*${alias}\\s*$`, 'm');
+      const normalized = normalizeAgentName(alias);
+      const frontmatterPattern = new RegExp(`^name:\\s*${normalized}\\s*$`, 'mi');
       if (frontmatterPattern.test(content)) {
         return true;
       }

--- a/workflows/lib/agent-detection.js
+++ b/workflows/lib/agent-detection.js
@@ -160,7 +160,8 @@ function isRunningInAgent(transcriptPath, agentAliases, hookData) {
     const content = fs.readFileSync(transcriptPath, 'utf8');
     for (const alias of agentAliases) {
       const normalized = normalizeAgentName(alias);
-      const frontmatterPattern = new RegExp(`^name:\\s*${normalized}\\s*$`, 'mi');
+      // Allow optional namespace prefix (e.g. "name: work-workflow:quality-checker")
+      const frontmatterPattern = new RegExp(`^name:\\s*(?:[\\w-]+:)?${normalized}\\s*$`, 'mi');
       if (frontmatterPattern.test(content)) {
         return true;
       }

--- a/workflows/lib/agent-detection.js
+++ b/workflows/lib/agent-detection.js
@@ -106,11 +106,16 @@ function isSubagentFromTranscript(transcriptPath, agentAliases) {
  *
  * Detection methods (in priority order):
  * 1. Environment variable CLAUDE_CURRENT_AGENT (most reliable)
- * 2. Transcript scanning for active Task tool invocations
- * 3. Frontmatter parsing for legacy transcripts
+ * 2. hookData.tool_input.subagent_type (available when parent invokes Task/Agent)
+ * 3. Initial prompt scanning for agent type in subagent transcript
+ * 4. Transcript scanning for active Task tool invocations
+ * 5. Frontmatter parsing for legacy transcripts
+ *
+ * All comparisons use normalizeAgentName() for prefix-stripping and case-insensitive matching.
  *
  * @param {string} transcriptPath - Path to the session transcript
  * @param {string[]} agentAliases - Agent names to check for
+ * @param {object} [hookData] - Hook data from Claude Code (may contain tool_input.subagent_type)
  * @returns {boolean} true if running inside one of the specified agents
  */
 function isRunningInAgent(transcriptPath, agentAliases, hookData) {

--- a/workflows/lib/agent-detection.js
+++ b/workflows/lib/agent-detection.js
@@ -8,6 +8,20 @@
 const fs = require('fs');
 
 /**
+ * Normalize an agent name by stripping optional namespace prefixes and lowercasing.
+ * e.g. 'work-workflow:quality-checker' → 'quality-checker'
+ */
+function normalizeAgentName(name) {
+  return String(name || '').replace(/^[\w-]+:/, '').toLowerCase();
+}
+
+function debugLog(method, msg) {
+  if (process.env.ENFORCE_HOOK_DEBUG) {
+    process.stderr.write(`[agent-detection] ${method}: ${msg}\n`);
+  }
+}
+
+/**
  * Check if we're running inside a subagent by scanning the transcript
  * for the MOST RECENT Task tool invocation that matches our agent.
  *
@@ -46,7 +60,7 @@ function isSubagentFromTranscript(transcriptPath, agentAliases) {
             if (item.type === 'tool_use' && (item.name === 'Task' || item.name === 'Agent')) {
               const subagentType = item.input?.subagent_type || '';
               if (agentAliases.some(alias =>
-                alias.toLowerCase() === subagentType.toLowerCase()
+                normalizeAgentName(alias) === normalizeAgentName(subagentType)
               )) {
                 // Check if there's a corresponding tool_result in subsequent lines
                 const hasResult = recentLines.slice(i + 1).some(line => {
@@ -99,14 +113,26 @@ function isSubagentFromTranscript(transcriptPath, agentAliases) {
  * @param {string[]} agentAliases - Agent names to check for
  * @returns {boolean} true if running inside one of the specified agents
  */
-function isRunningInAgent(transcriptPath, agentAliases) {
+function isRunningInAgent(transcriptPath, agentAliases, hookData) {
   // Primary: Check environment variable
   const currentAgent = process.env.CLAUDE_CURRENT_AGENT;
   if (currentAgent && agentAliases.some(alias =>
-    alias.toLowerCase() === currentAgent.toLowerCase()
+    normalizeAgentName(alias) === normalizeAgentName(currentAgent)
   )) {
+    debugLog('env', `matched CLAUDE_CURRENT_AGENT=${currentAgent}`);
     return true;
   }
+  if (currentAgent) debugLog('env', `no match for CLAUDE_CURRENT_AGENT=${currentAgent}`);
+
+  // Secondary: Check hookData for subagent_type (available when parent invokes Task/Agent)
+  const subagentType = hookData?.tool_input?.subagent_type;
+  if (subagentType && agentAliases.some(alias =>
+    normalizeAgentName(alias) === normalizeAgentName(subagentType)
+  )) {
+    debugLog('hookData', `matched subagent_type=${subagentType}`);
+    return true;
+  }
+  if (subagentType) debugLog('hookData', `no match for subagent_type=${subagentType}`);
 
   // Quick check: If this is a subagent process, its transcript initial
   // prompt will mention the agent type. Check this early since it's fast
@@ -176,7 +202,7 @@ function isSubagentFromInitialPrompt(transcriptPath, agentAliases) {
 
           for (const alias of agentAliases) {
             // Match "subagent_type": "code-checker" or similar patterns
-            if (text.toLowerCase().includes(alias.toLowerCase())) {
+            if (text.toLowerCase().includes(normalizeAgentName(alias))) {
               return true;
             }
           }
@@ -189,4 +215,4 @@ function isSubagentFromInitialPrompt(transcriptPath, agentAliases) {
   }
 }
 
-module.exports = { isRunningInAgent, isSubagentFromTranscript, isSubagentFromInitialPrompt };
+module.exports = { isRunningInAgent, isSubagentFromTranscript, isSubagentFromInitialPrompt, normalizeAgentName };

--- a/workflows/lib/agent-detection.js
+++ b/workflows/lib/agent-detection.js
@@ -201,8 +201,11 @@ function isSubagentFromInitialPrompt(transcriptPath, agentAliases) {
               : '';
 
           for (const alias of agentAliases) {
-            // Match "subagent_type": "code-checker" or similar patterns
-            if (text.toLowerCase().includes(normalizeAgentName(alias))) {
+            // Match agent name with word boundaries to avoid false positives
+            // from incidental substring matches (e.g. "qa" matching "quality")
+            const normalized = normalizeAgentName(alias);
+            const boundary = new RegExp(`(?:^|[\\s"':,])${normalized.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:$|[\\s"':,])`, 'i');
+            if (boundary.test(text)) {
               return true;
             }
           }

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -324,14 +324,14 @@ const WORKFLOWS = [
 
 // Step-gated artifact files — only writable during their owning step
 const ARTIFACT_RULES = [
-  { basename: 'brief.md',          step: STEPS.brief, agents: ['brief-writer', 'work-workflow:brief-writer'] },
-  { basename: 'spec.md',           step: STEPS.spec,  agents: ['spec-writer', 'work-workflow:spec-writer'] },
+  { basename: 'brief.md',          step: STEPS.brief, agents: ['brief-writer'] },
+  { basename: 'spec.md',           step: STEPS.spec,  agents: ['spec-writer'] },
   { basename: '.last-commit-sha',  step: STEPS.commit },
-  { basename: 'code-review.check.md',  step: STEPS.check, agents: ['code-checker', 'work-workflow:code-checker'] },
-  { basename: 'tests.check.md',        step: STEPS.check, agents: ['quality-checker', 'work-workflow:quality-checker'] },
-  { basename: 'completion.check.md',   step: STEPS.check, agents: ['completion-checker', 'work-workflow:completion-checker'] },
-  { pattern: /^qa-.*\.check\.md$/,     step: STEPS.check, agents: ['qa-feature-tester', 'work-workflow:qa-feature-tester', 'qa-api-tester', 'work-workflow:qa-api-tester'] },
-  { basename: 'code-review-reply.check.md', step: STEPS.check, agents: ['developer-nodejs-tdd', 'work-workflow:developer-nodejs-tdd', 'developer-react-senior', 'work-workflow:developer-react-senior', 'developer-devops', 'work-workflow:developer-devops'] },
+  { basename: 'code-review.check.md',  step: STEPS.check, agents: ['code-checker'] },
+  { basename: 'tests.check.md',        step: STEPS.check, agents: ['quality-checker'] },
+  { basename: 'completion.check.md',   step: STEPS.check, agents: ['completion-checker'] },
+  { pattern: /^qa-.*\.check\.md$/,     step: STEPS.check, agents: ['qa-feature-tester', 'qa-api-tester'] },
+  { basename: 'code-review-reply.check.md', step: STEPS.check, agents: ['developer-nodejs-tdd', 'developer-react-senior', 'developer-devops'] },
 ];
 
 // Protected state file basenames — block direct Edit/Write/MultiEdit/Bash writes

--- a/workflows/lib/protect-artifact-files.js
+++ b/workflows/lib/protect-artifact-files.js
@@ -152,7 +152,7 @@ function createArtifactProtector(opts) {
     // Check 2: Agent must be authorized (if agents specified)
     if (rule.agents && rule.agents.length > 0) {
       const transcriptPath = hookData?.transcript_path;
-      if (!isRunningInAgent(transcriptPath, rule.agents)) {
+      if (!isRunningInAgent(transcriptPath, rule.agents, hookData)) {
         return {
           blocked: true,
           file: bn,

--- a/workflows/lib/protect-artifact-files.js
+++ b/workflows/lib/protect-artifact-files.js
@@ -16,7 +16,7 @@
  *       { pattern: /\.check\.md$/, step: 'check', agents: ['code-checker', 'qa-feature-tester'] },
  *     ],
  *     getStepInProgress: (ticketId) => currentStep,  // returns step name or null
- *     isRunningInAgent: (transcriptPath, agents) => boolean,
+ *     isRunningInAgent: (transcriptPath, agents, hookData) => boolean,
  *     getTicketId: () => string|null,  // returns current ticket ID
  *   });
  *
@@ -71,8 +71,9 @@ function matchesRule(basename, rule) {
  * @param {ArtifactRule[]} opts.artifacts — list of protected artifact rules
  * @param {(ticketId: string) => string|null} opts.getStepInProgress
  *   Returns the currently in_progress step name for the given ticket, or null.
- * @param {(transcriptPath: string, agents: string[]) => boolean} [opts.isRunningInAgent]
+ * @param {(transcriptPath: string, agents: string[], hookData?: object) => boolean} [opts.isRunningInAgent]
  *   Returns true if the current context is inside one of the specified agents.
+ *   Receives hookData as third arg for hookData-based agent detection.
  *   Only needed if any artifact rule has `agents`. Defaults to () => true (fail-open).
  * @param {(hookData: object) => string|null} [opts.getTicketId]
  *   Extracts ticket ID from hook data or environment. If omitted, checks are skipped.


### PR DESCRIPTION
## Existing Behavior

- `isRunningInAgent()` only checked `CLAUDE_CURRENT_AGENT` env var and transcript scanning to detect whether a caller was an authorized agent
- Subagents spawned via `Task()`/`Agent()` do not inherit `CLAUDE_CURRENT_AGENT`, causing detection to fail
- `ARTIFACT_RULES` listed both bare names (e.g., `quality-checker`) and prefixed variants (e.g., `work-workflow:quality-checker`) as separate entries to work around the missing normalization
- `protect-artifact-files.js` called `isRunningInAgent(transcriptPath, agents)` without forwarding the full `hookData` payload, leaving the hook unable to inspect `tool_input.subagent_type`
- Authorized subagents like `quality-checker` were incorrectly blocked from writing artifact files during their designated workflow steps

## Intended New Behavior

- `normalizeAgentName()` strips optional `prefix:` variants before comparison, so `work-workflow:quality-checker` and `quality-checker` resolve to the same identity
- `isRunningInAgent()` gains a `hookData`-based detection strategy that reads `tool_input.subagent_type` from the current hook invocation, reliably identifying subagents launched via `Task()`/`Agent()` even when `CLAUDE_CURRENT_AGENT` is absent
- `protect-artifact-files.js` forwards the full `hookData` object to `isRunningInAgent()`, enabling the new detection path
- `ARTIFACT_RULES` is simplified by removing redundant prefixed-name entries now covered by normalization
- Debug logging is available behind the `ENFORCE_HOOK_DEBUG` env var flag for easier troubleshooting of hook decisions

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**To verify that authorized subagents are no longer blocked:**

1. Start a `/work <TICKET_ID>` session that reaches a step which spawns `quality-checker` via `Task()`
2. Confirm the subagent can write its report file (e.g., `*.check.md`) without receiving a `BLOCKED: Cannot write` error
3. Confirm unauthorized agents or the orchestrator itself are still blocked from writing artifact files outside their designated step

**To verify debug logging:**

1. Set `ENFORCE_HOOK_DEBUG=1` in your environment
2. Trigger a `Write`/`Edit` tool call that matches an artifact rule
3. Observe `[agent-detection]` lines on stderr showing which detection method was used and whether it matched

**To verify normalization:**

1. With `ENFORCE_HOOK_DEBUG=1`, confirm that a subagent reported as `work-workflow:quality-checker` in `tool_input.subagent_type` is matched against the `quality-checker` allowlist entry without needing a separate prefixed entry in `ARTIFACT_RULES`

### Test Results

All 188 tests pass (20 new unit tests for `normalizeAgentName` and `isRunningInAgent` hookData detection, plus integration tests for `protect-artifact-files`).

closes #149 