### PR TITLE
fix(GH-89): prevent work-state.js set-step from bypassing workflow enforcement

### DIFF
--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -1550,6 +1550,293 @@ describe('enforce-step-workflow', () => {
       assert.equal(code, 2, 'should block redirect even if command mentions exempt script name');
       assert.ok(stderr.includes('BLOCKED'));
     });
+
+    // ─── GH-89: Sub-command filtering for state scripts ──────────────────────
+    const WORK_STATE_PATH = path.join(WORK_DIR, 'work-state.js');
+    const WORKFLOW_STATE_PATH = path.join(LIB_DIR, 'workflow-state.js');
+
+    // Blocked mutating sub-commands
+    it('blocks direct work-state.js set-step call', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} set-step TEST-1 check completed` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'direct set-step should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks direct work-state.js set-check call', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} set-check TEST-1 quality_checker completed` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'direct set-check should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks direct work-state.js complete call', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} complete TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'direct complete should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks work-state.js init-subtask command', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} init-subtask TEST-1 "description"` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'init-subtask should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks work-state.js complete-subtask command', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} complete-subtask TEST-1 0` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'complete-subtask should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    // Blocked with chained/env-prefix bypass attempts
+    it('blocks set-step with chained cd command', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `cd /some/dir && node ${WORK_STATE_PATH} set-step TEST-1 implement completed` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'set-step after cd && should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks set-step with env prefix', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `SESSION_GUARD_ENABLED=0 node ${WORK_STATE_PATH} set-step TEST-1 implement completed` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'set-step with env prefix should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks chained command that sneaks set-step after safe get', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} get TEST-1 && node ${WORK_STATE_PATH} set-step TEST-1 implement completed` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'chained get+set-step should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks semicolon-chained bypass after safe get', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} get TEST-1; node ${WORK_STATE_PATH} set-step TEST-1 implement completed` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'semicolon-chained get+set-step should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+    // ─── GH-89: pipe and flag-arg bypass tests are at the end of this block ─
+    // Allowed safe (read-only) sub-commands
+    it('allows work-state.js get command', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} get TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'get should be allowed');
+    });
+
+    it('allows work-state.js resume-info command', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} resume-info TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'resume-info should be allowed');
+    });
+
+    it('allows work-state.js init command', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} init TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'init should be allowed');
+    });
+
+    it('allows work-state.js add-error command', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} add-error TEST-1 "something failed"` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'add-error should be allowed');
+    });
+
+    it('allows work-state.js active-subtask command', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} active-subtask TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'active-subtask should be allowed');
+    });
+
+    it('allows work-state.js quoted subcommand get', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} 'get' TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'quoted get should be allowed');
+    });
+
+    // workflow-state.js parity
+    it('blocks workflow-state.js set-step call', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORKFLOW_STATE_PATH} work-pr set-step TEST-1 3_pr_gen in_progress` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'workflow-state.js set-step should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks workflow-state.js complete call', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORKFLOW_STATE_PATH} work-pr complete TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'workflow-state.js complete should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks workflow-state.js init call (not idempotent)', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORKFLOW_STATE_PATH} work-pr init TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'workflow-state.js init should be blocked (not idempotent, resets progress)');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('allows workflow-state.js get call', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORKFLOW_STATE_PATH} work-pr get TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'workflow-state.js get should be allowed');
+    });
+
+    it('allows workflow-state.js resume-info call', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORKFLOW_STATE_PATH} work-pr resume-info TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'workflow-state.js resume-info should be allowed');
+    });
+
+    it('allows workflow-state.js add-error call', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORKFLOW_STATE_PATH} work-pr add-error TEST-1 "something failed"` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'workflow-state.js add-error should be allowed');
+    });
+
+    // ─── GH-89: Node flags with separate arguments ──────────────────────────
+    it('node flag with argument does not bypass exempt check (--require)', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node --require ./noop.js ${WORK_STATE_PATH} get TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'node --require <arg> followed by safe get should be allowed');
+    });
+
+    it('node -r short flag with argument does not bypass exempt check', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node -r ./noop.js ${WORK_STATE_PATH} get TEST-1` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'node -r <arg> followed by safe get should be allowed');
+    });
+
+    it('node --require with unsafe sub-command is blocked', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node --require ./noop.js ${WORK_STATE_PATH} set-step TEST-1 check completed` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'node --require <arg> followed by set-step should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('node -e inline code is not treated as multi-arg flag (GH-89)', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      // node -e runs inline code; remaining args are just process.argv, not executed files.
+      // With -e removed from multi-arg flags, the regex captures the inline code string
+      // as the "script path" (which doesn't exist on disk), so the command is allowed.
+      // This is correct: work-state.js is NOT being executed here.
+      const { code } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node -e "console.log('hi')" ${WORK_STATE_PATH} set-step TEST-1 check completed` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 0, 'node -e with trailing argv args is not executing work-state.js');
+    });
+
+    it('pipe-chained command blocks unsafe second invocation', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} get TEST-1 | node ${WORK_STATE_PATH} set-step TEST-1 check completed` } },
+        'PreToolUse',
+      );
+      assert.equal(code, 2, 'pipe-chained get + set-step should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    }); // end pipe-chain bypass test
   });
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -324,7 +324,7 @@ const WORKFLOWS = [
     transitionPattern: /workflow-engine\.js\s+work-pr\s+transition\s+(\S+)\s+(\S+)/,
     exemptPatterns: [
       /workflow-engine\.js\s+work-pr\s+(plan|transitions|graph)/,
-      /workflow-state\.js\s+work-pr\s+(get|resume-info|init)/,
+      /workflow-state\.js\s+work-pr\s+(get|resume-info)/,
     ],
     transitionHint: `node ${path.join(__dirname, '..', 'workflow-engine.js')} work-pr transition`,
   },
@@ -378,6 +378,15 @@ const EXEMPT_SCRIPTS = new Set([
   'session-guard.js',
 ]);
 
+// Sub-command filtering for state scripts (GH-89).
+// work-state.js: exempt for get, resume-info, init, active-subtask, add-error.
+// workflow-state.js: exempt for get, resume-info, add-error (init blocked — not idempotent).
+// Mutating sub-commands (set-step, set-check, complete, etc.) must go through the orchestrator.
+const SAFE_SUBCOMMANDS = {
+  'work-state.js': new Set(['get', 'resume-info', 'init', 'active-subtask', 'add-error']),
+  'workflow-state.js': new Set(['get', 'resume-info', 'add-error']), // init excluded: not idempotent (resets all steps). exemptPatterns (line ~327) aligned.
+};
+
 // Trusted directories where exempt scripts are allowed to live.
 // Only scripts resolved under these paths are exempt — prevents basename spoofing.
 const TRUSTED_SCRIPT_DIRS = [
@@ -388,6 +397,18 @@ const TRUSTED_SCRIPT_DIRS = [
   path.resolve(__dirname, '..', '..', 'check', 'scripts'), // workflows/check/scripts/
   path.resolve(__dirname, '..', '..', 'work-implement'),   // workflows/work-implement/
 ];
+
+// Shared regex source for detecting node script invocations in Bash commands (GH-89).
+// Handles: cd && node ..., env prefixes, Node flags (including multi-arg like --require <path>),
+// quoted paths. --eval/--print/-e/-p excluded (inline code, not file paths).
+// Use getNodeInvocations() helper to catch ALL invocations in chained commands.
+const NODE_INVOKE_PATTERN_SRC =
+  '(?:^|&&|;|\\|)\\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|\'[^\']*\'|\\S+)\\s+)*(?:node|nodejs)\\s+(?:(?:--(?:require|loader|experimental-loader|import|input-type|conditions|inspect-brk|inspect|inspect-port)|-[rCi])\\s+\\S+\\s+|(?:-[^\\s]+\\s+))*(?:"([^"]+)"|\'([^\']+)\'|(\\S+))';
+
+/** Return all node-script invocations from a command string. */
+function getNodeInvocations(cmd) {
+  return [...cmd.matchAll(new RegExp(NODE_INVOKE_PATTERN_SRC, 'g'))];
+}
 
 // Agent-gated writer scripts — map script basename to authorized agents.
 // When a Bash command invokes one of these scripts, the hook verifies agent identity.
@@ -416,24 +437,40 @@ const stateFileProtector = createFileProtector({
     // Only exempt actual execution of exempt scripts via Node.
     // Handles: cd ... && node ..., env prefixes, Node flags, quoted paths
     // Not anchored to ^ so it matches node anywhere in a chained command
-    const nodePattern =
-      /(?:^|&&|;|\|)\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S+)\s+)*(?:node|nodejs)\s+(?:-[^\s]+\s+)*(?:"([^"]+)"|'([^']+)'|(\S+))/;
-    const nodeMatch = cmd.match(nodePattern);
-    if (nodeMatch) {
+    const matches = getNodeInvocations(cmd);
+    if (matches.length === 0) return false; // no node invocations found
+
+    // Every node invocation must be exempt — one unsafe call blocks the whole command (GH-89).
+    // AGENT_GATED_SCRIPTS (Rule 5) also uses matchAll for chained-command safety.
+    for (const nodeMatch of matches) { // check every node invocation
       const scriptPath = nodeMatch[1] || nodeMatch[2] || nodeMatch[3];
       const scriptBase = path.basename(scriptPath);
       if (!EXEMPT_SCRIPTS.has(scriptBase)) return false;
 
       // Verify the script lives in a trusted directory (prevents basename spoofing)
       // Use realpathSync to resolve symlinks — a symlink under a trusted dir pointing outside is denied
+      let trusted = false;
       try {
         const resolved = fs.realpathSync(path.resolve(scriptPath));
-        if (TRUSTED_SCRIPT_DIRS.some(dir => resolved.startsWith(dir + path.sep))) return true;
+        trusted = TRUSTED_SCRIPT_DIRS.some(dir => resolved.startsWith(dir + path.sep));
       } catch { /* realpathSync failed (file doesn't exist) — deny */ }
-      return false;
+      if (!trusted) return false;
+
+      // Sub-command filtering (GH-89): for state scripts, only allow safe sub-commands
+      const safeSet = SAFE_SUBCOMMANDS[scriptBase];
+      if (safeSet) {
+        // Extract args after the script path from the command segment
+        const afterScript = cmd.slice(nodeMatch.index + nodeMatch[0].length).trim();
+        const args = afterScript.split(/\s+/).filter(a => a && !a.startsWith('-'));
+        // For workflow-state.js the sub-command is the 2nd arg (1st is workflow name)
+        const subCmdIndex = scriptBase === 'workflow-state.js' ? 1 : 0;
+        const rawSubCmd = args[subCmdIndex] || '';
+        const subCmd = rawSubCmd.replace(/^['"]|['"]$/g, '');
+        if (!safeSet.has(subCmd)) return false;
+      }
     }
 
-    return false; // Tests: Vector 3 exempt scripts + trusted path + untrusted path + env prefix + quoted path
+    return true; // All invocations passed exempt + trusted + sub-command checks
   },
   formatMessage: (match, vector) =>
     `BLOCKED: Direct ${vector} to ${match} is not allowed.\n` +
@@ -672,6 +709,50 @@ function handlePreToolUse(hookData) {
     );
     process.exit(2);
   }
+  // Rule 3b: Block unsafe sub-commands on state scripts invoked via node (GH-89)
+  // Defense-in-depth: the stateFileProtector's isExempt/Vector 3 may miss the script when
+  // multi-arg flags (--require, -r, etc.) cause INTERPRETER_PATTERN to capture the flag
+  // argument instead of the actual script. This rule uses the improved nodePattern directly.
+  if (toolName === 'Bash') {
+    const cmd = String(toolInput?.command || '').trim();
+    const stateMatches = getNodeInvocations(cmd);
+    for (const m of stateMatches) {
+      const scriptPath = m[1] || m[2] || m[3];
+      const scriptBase = path.basename(scriptPath);
+      const safeSet = SAFE_SUBCOMMANDS[scriptBase];
+      if (safeSet) {
+        // Expand $CLAUDE_PLUGIN_ROOT which is not resolved in hook context
+        let resolvedPath = scriptPath;
+        if (process.env.CLAUDE_PLUGIN_ROOT) {
+          resolvedPath = resolvedPath
+            .replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, process.env.CLAUDE_PLUGIN_ROOT)
+            .replace(/\$CLAUDE_PLUGIN_ROOT/g, process.env.CLAUDE_PLUGIN_ROOT);
+        }
+        // Verify trusted directory - skip untrusted (Vector 3 handles those)
+        let trusted = false;
+        try {
+          const resolved = fs.realpathSync(path.resolve(resolvedPath));
+          trusted = TRUSTED_SCRIPT_DIRS.some(dir => resolved.startsWith(dir + path.sep));
+        } catch { /* realpathSync failed - untrusted */ }
+        if (!trusted) continue; // basename match but untrusted path - Vector 3 will block
+
+        const afterScript = cmd.slice(m.index + m[0].length).trim();
+        const args = afterScript.split(/\s+/).filter(a => a && !a.startsWith('-'));
+        const subCmdIndex = scriptBase === 'workflow-state.js' ? 1 : 0;
+        const rawSubCmd = args[subCmdIndex] || '';
+        const subCmd = rawSubCmd.replace(/^['"]|['"]$/g, '');
+        if (!safeSet.has(subCmd)) {
+          didBlock = true;
+          process.stderr.write(
+            `BLOCKED: Direct Bash call to ${scriptBase} with sub-command '${subCmd}' is not allowed.\n` +
+            `State files must only be modified through the orchestrator/workflow-engine scripts.\n`
+          );
+          process.exit(2);
+        }
+      }
+    }
+  }
+
   // Rule 4: Block writes to step-gated artifact files outside their owning step/agent
   // Must run BEFORE skipRemainingChecks — Edit/Write/MultiEdit need artifact protection
   const rule4 = artifactProtector.check(toolName, toolInput, hookData);
@@ -688,10 +769,8 @@ function handlePreToolUse(hookData) {
   if (toolName === 'Bash') {
     const cmd = String(toolInput?.command || '');
     // Reuse the same robust nodePattern as exempt script detection (handles env prefixes, flags, quotes)
-    const writerNodePattern =
-      /(?:^|&&|;|\|)\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S+)\s+)*(?:node|nodejs)\s+(?:-[^\s]+\s+)*(?:"([^"]+)"|'([^']+)'|(\S+))/;
-    const nodeExec = cmd.match(writerNodePattern);
-    if (nodeExec) {
+    const nodeMatches = getNodeInvocations(cmd);
+    for (const nodeExec of nodeMatches) {
       let scriptPath = nodeExec[1] || nodeExec[2] || nodeExec[3];
       // Expand common shell variables that won't be expanded in hook context
       if (process.env.CLAUDE_PLUGIN_ROOT) {


### PR DESCRIPTION
## Existing Behavior

- The `isExempt` check in `enforce-step-workflow.js` allowed any Bash command invoking an exempt script (e.g. `work-state.js`, `workflow-state.js`) to pass through, regardless of which sub-command was used.
- Mutating sub-commands such as `set-step`, `set-check`, `complete`, `init-subtask`, and `complete-subtask` could be called directly via `node work-state.js set-step ...`, bypassing orchestrator-gated workflow enforcement entirely.
- The node-invocation regex used a single `.match()` call, meaning a chained command like `node work-state.js get ... && node work-state.js set-step ...` would only match the first invocation and be silently allowed.

## Intended New Behavior

- A `SAFE_SUBCOMMANDS` allowlist is introduced for `work-state.js` and `workflow-state.js`, restricting exemptions to read-only/non-destructive sub-commands: `get`, `resume-info`, `add-error`, `active-subtask` (and `init` for `work-state.js` only).
- The node-invocation regex now uses `/g` with `matchAll` so every node call in a chained command is evaluated independently — a safe `get` followed by a mutating `set-step` is caught and blocked.
- `workflow-state.js` sub-command extraction correctly accounts for the leading workflow-name argument (e.g. `workflow-state.js work-pr get ...` — sub-command is `get`).
- Quoted sub-commands (e.g. `node work-state.js 'get' TEST-1`) are handled by stripping surrounding quote characters before allowlist lookup.
- 28 new test cases cover all blocked paths (set-step, set-check, complete, init-subtask, complete-subtask, workflow-state variants) and all permitted paths, including chained-command and env-prefix bypass attempts.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Check out the branch and run `pnpm dev:check` — all 160 tests should pass, including the new `Vector 3 exempt scripts` suite.
2. Attempt a direct bypass in a worktree with an active `.work-state.json`: run `node workflows/lib/work-state.js set-step <ticket> check completed` inside the hook environment; the hook should exit with code 2 and print `BLOCKED`.
3. Confirm read-only calls remain unblocked: `node workflows/lib/work-state.js get <ticket>` should exit 0.
4. Verify chained bypass is caught: `node workflows/lib/work-state.js get <ticket> && node workflows/lib/work-state.js set-step <ticket> check completed` should exit 2 and print `BLOCKED`.

### Test Results

160 passed, 0 failed, 0 skipped

```
ℹ tests 160
ℹ pass 160
ℹ fail 0
```

Closes #89