### PR TITLE
feat(bootstrap): use .envrc env vars instead of hardcoded values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,7 @@ GITHUB_ORG=
 # ─── Bootstrap Features ──────────────────────────────────────────────────
 # ENABLE_EMPTY_COMMIT=0
 # ENABLE_DRAFT_PR=0
+# ENABLE_SYMLINK=0
 # ENABLE_RESOLVE_OUTDATED_COMMENTS=0
 
 # ─── Web Apps (JSON array for QA testing) ─────────────────────────────────

--- a/workflows/lib/__tests__/config.test.js
+++ b/workflows/lib/__tests__/config.test.js
@@ -10,6 +10,7 @@ const CONFIG_KEYS = [
   'TICKET_PROVIDER', 'TICKET_PROJECT_KEY',
   'REPO_NAME', 'GITHUB_ORG', 'WORKTREES_BASE', 'TASKS_BASE',
   'FOLLOW_UP_PR_POLL_REVIEWS', 'BASE_BRANCH', 'WEB_APPS',
+  'ENABLE_SYMLINK',
 ];
 
 // Defaults matching config.js fallback values — used to block .env file loading.
@@ -28,6 +29,7 @@ const CONFIG_DEFAULTS = {
   FOLLOW_UP_PR_POLL_REVIEWS: 'true',
   BASE_BRANCH: '',
   WEB_APPS: '[]',
+  ENABLE_SYMLINK: '0',
 };
 
 function resetEnv() {
@@ -165,6 +167,26 @@ describe('config', () => {
       const map = config.webAppsMap();
       assert.equal(Object.getPrototypeOf(map), null);
     });
+  });
+
+  // ─── ENABLE_SYMLINK ─────────────────────────────────────────────────────
+
+  describe('ENABLE_SYMLINK', () => {
+    it('defaults to 0 when not set', () => {
+      const config = freshRequire();
+      assert.equal(config.ENABLE_SYMLINK, '0');
+    });
+
+    it('preserves 0 when explicitly set', () => {
+      const config = freshRequire({ ENABLE_SYMLINK: '0' });
+      assert.equal(config.ENABLE_SYMLINK, '0');
+    });
+
+    it('preserves 1 when explicitly set', () => {
+      const config = freshRequire({ ENABLE_SYMLINK: '1' });
+      assert.equal(config.ENABLE_SYMLINK, '1');
+    });
+
   });
 
   // ─── getBaseBranch ──────────────────────────────────────────────────────

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -74,7 +74,8 @@ function writeWorkflowState(stepStatus, workflow = 'work-pr', status = 'in_progr
     startTime: new Date().toISOString(),
     lastUpdate: new Date().toISOString(),
   };
-  fs.writeFileSync(path.join(TASKS_DIR, '.workflow-state.json'), JSON.stringify(state, null, 2));
+  const stateFile = `.${workflow}.workflow-state.json`;
+  fs.writeFileSync(path.join(TASKS_DIR, stateFile), JSON.stringify(state, null, 2));
 }
 
 function writeEvidence(evidence, evidenceFile = '.step-evidence.json') {
@@ -519,7 +520,7 @@ describe('enforce-step-workflow', () => {
         fs.readFileSync(path.join(TASKS_DIR, '.work-state.json'), 'utf-8'),
       );
       const workPrState = JSON.parse(
-        fs.readFileSync(path.join(TASKS_DIR, '.workflow-state.json'), 'utf-8'),
+        fs.readFileSync(path.join(TASKS_DIR, '.work-pr.workflow-state.json'), 'utf-8'),
       );
 
       assert.equal(workState.stepStatus['pr'], 'in_progress');
@@ -591,7 +592,7 @@ describe('enforce-step-workflow', () => {
 
     it('handles corrupt workflow-state file gracefully', () => {
       if (!fs.existsSync(TASKS_DIR)) fs.mkdirSync(TASKS_DIR, { recursive: true });
-      fs.writeFileSync(path.join(TASKS_DIR, '.workflow-state.json'), 'corrupted');
+      fs.writeFileSync(path.join(TASKS_DIR, '.work-pr.workflow-state.json'), 'corrupted');
       // Should not crash — fail-open
     });
   });
@@ -1162,7 +1163,7 @@ describe('enforce-step-workflow', () => {
 
     const PROTECTED_FILES = [
       '.work-state.json',
-      '.workflow-state.json',
+      '.work-pr.workflow-state.json',
       '.step-evidence.json',
       '.step-evidence-work-pr.json',
       '.work-actions.json',
@@ -1308,11 +1309,11 @@ describe('enforce-step-workflow', () => {
       assert.ok(stderr.includes('BLOCKED'));
     });
 
-    it('blocks Bash cp to .workflow-state.json', async () => {
+    it('blocks Bash cp to .work-pr.workflow-state.json', async () => {
       writeWorkState(makeStepStatus('implement', WORK_STEPS));
 
       const { code, stderr } = await runHook(
-        { tool_name: 'Bash', tool_input: { command: 'cp /tmp/fake.json /tasks/.workflow-state.json' } },
+        { tool_name: 'Bash', tool_input: { command: 'cp /tmp/fake.json /tasks/.work-pr.workflow-state.json' } },
         'PreToolUse',
       );
       assert.equal(code, 2, 'Should block Bash cp to state file');

--- a/workflows/lib/__tests__/session-guard.test.js
+++ b/workflows/lib/__tests__/session-guard.test.js
@@ -411,12 +411,12 @@ describe('session-guard', () => {
     after(() => { try { fs.rmSync(TEMP_WB, { recursive: true, force: true }); } catch {} });
 
     function writeCheckState(workflow, status) {
-      const statePath = path.join(TEMP_TASKS, CHECK_TICKET, '.workflow-state.json');
+      const statePath = path.join(TEMP_TASKS, CHECK_TICKET, '.check.workflow-state.json');
       fs.writeFileSync(statePath, JSON.stringify({ workflow, instanceId: CHECK_TICKET, status, stepStatus: {} }));
     }
 
     function removeCheckState() {
-      try { fs.unlinkSync(path.join(TEMP_TASKS, CHECK_TICKET, '.workflow-state.json')); } catch {}
+      try { fs.unlinkSync(path.join(TEMP_TASKS, CHECK_TICKET, '.check.workflow-state.json')); } catch {}
     }
 
     afterEach(() => {

--- a/workflows/lib/__tests__/workflow-state.test.js
+++ b/workflows/lib/__tests__/workflow-state.test.js
@@ -59,7 +59,7 @@ describe('WorkflowState', () => {
       }
 
       // State file should exist on disk
-      const filePath = path.join(TEST_BASE, INSTANCE, '.workflow-state.json');
+      const filePath = path.join(TEST_BASE, INSTANCE, '.test-workflow.workflow-state.json');
       assert.ok(fs.existsSync(filePath));
     });
   });
@@ -89,7 +89,7 @@ describe('WorkflowState', () => {
       // Create the instance directory and write corrupt JSON
       const instanceDir = path.join(TEST_BASE, INSTANCE);
       fs.mkdirSync(instanceDir, { recursive: true });
-      fs.writeFileSync(path.join(instanceDir, '.workflow-state.json'), '{not valid json!!!');
+      fs.writeFileSync(path.join(instanceDir, '.test-workflow.workflow-state.json'), '{not valid json!!!');
 
       const result = ws.load(INSTANCE);
       assert.strictEqual(result, null);
@@ -110,7 +110,7 @@ describe('WorkflowState', () => {
         startTime: '2025-01-01T00:00:00.000Z',
       };
       fs.writeFileSync(
-        path.join(instanceDir, '.workflow-state.json'),
+        path.join(instanceDir, '.test-workflow.workflow-state.json'),
         JSON.stringify(legacyState, null, 2),
       );
 
@@ -145,7 +145,7 @@ describe('WorkflowState', () => {
       assert.ok(saved.lastUpdate <= afterSave, 'lastUpdate should be <= time after save');
 
       // Verify it was written to disk
-      const filePath = path.join(TEST_BASE, INSTANCE, '.workflow-state.json');
+      const filePath = path.join(TEST_BASE, INSTANCE, '.test-workflow.workflow-state.json');
       const onDisk = JSON.parse(fs.readFileSync(filePath, 'utf8'));
       assert.strictEqual(onDisk.lastUpdate, saved.lastUpdate);
     });
@@ -338,6 +338,37 @@ describe('WorkflowState', () => {
       ws = createWs();
       const output = ws.formatState('nonexistent');
       assert.strictEqual(output, 'No state found');
+    });
+  });
+
+  // ─── legacy fallback ────────────────────────────────────────────────────────
+
+  describe('legacy fallback', () => {
+    it('loads legacy .workflow-state.json when workflow matches', () => {
+      const ws = new WorkflowState('test-workflow', TEST_BASE);
+      const instanceDir = path.join(TEST_BASE, INSTANCE);
+      if (!fs.existsSync(instanceDir)) fs.mkdirSync(instanceDir, { recursive: true });
+
+      // Write only the legacy file
+      const legacyState = { workflow: 'test-workflow', status: 'in_progress', stepStatus: { step1: 'completed' } };
+      fs.writeFileSync(path.join(instanceDir, '.workflow-state.json'), JSON.stringify(legacyState));
+
+      const loaded = ws.load(INSTANCE);
+      assert.ok(loaded, 'Should load from legacy file');
+      assert.strictEqual(loaded.workflow, 'test-workflow');
+    });
+
+    it('returns null when legacy file workflow does not match', () => {
+      const ws = new WorkflowState('test-workflow', TEST_BASE);
+      const instanceDir = path.join(TEST_BASE, INSTANCE);
+      if (!fs.existsSync(instanceDir)) fs.mkdirSync(instanceDir, { recursive: true });
+
+      // Write legacy file with different workflow name
+      const legacyState = { workflow: 'other-workflow', status: 'in_progress', stepStatus: {} };
+      fs.writeFileSync(path.join(instanceDir, '.workflow-state.json'), JSON.stringify(legacyState));
+
+      const loaded = ws.load(INSTANCE);
+      assert.strictEqual(loaded, null, 'Should not load mismatched workflow');
     });
   });
 });

--- a/workflows/lib/config.js
+++ b/workflows/lib/config.js
@@ -72,6 +72,7 @@ const config = {
     }
   })(),
   TASKS_BASE: null, // set below after WORKTREES_BASE is resolved
+  ENABLE_SYMLINK: process.env.ENABLE_SYMLINK ?? '0',
   FOLLOW_UP_PR_POLL_REVIEWS: (process.env.FOLLOW_UP_PR_POLL_REVIEWS || 'true').toLowerCase() === 'true',
 
   // Comma-separated relative paths to docs agents should read during their workflows

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -298,7 +298,7 @@ const WORKFLOWS = [
   },
   {
     name: 'work-pr',
-    stateFile: '.workflow-state.json',
+    stateFile: '.work-pr.workflow-state.json',
     evidenceFile: '.step-evidence-work-pr.json',
     isActive: (state) => state?.status === 'in_progress' && state?.workflow === 'work-pr',
     steps: [
@@ -336,7 +336,7 @@ const ARTIFACT_RULES = [
 
 // Protected state file basenames — block direct Edit/Write/MultiEdit/Bash writes
 const { buildProtectedBasenames, basenameProtector, createFileProtector } = require(path.join(__dirname, '..', 'protect-state-files'));
-const PROTECTED_STATE_BASENAMES = buildProtectedBasenames(WORKFLOWS, ['.work-actions.json', '.pr-update-sha']);
+const PROTECTED_STATE_BASENAMES = buildProtectedBasenames(WORKFLOWS, ['.work-actions.json', '.pr-update-sha', '.workflow-state.json', '.check.workflow-state.json']);
 
 // Map each protected basename to its workflow's transition hint
 const BASENAME_TO_HINT = {};
@@ -534,6 +534,18 @@ function loadStateFile(ticketId, stateFile) {
   try {
     return JSON.parse(fs.readFileSync(p, 'utf-8'));
   } catch {
+    // Legacy fallback: per-workflow files (e.g. .work-pr.workflow-state.json)
+    // may not exist if the state was written before per-workflow split.
+    // Try the legacy .workflow-state.json and check the workflow field matches.
+    if (stateFile !== '.workflow-state.json' && stateFile.endsWith('.workflow-state.json')) {
+      const legacyPath = path.join(TASKS_BASE, ticketId, '.workflow-state.json');
+      try {
+        const legacy = JSON.parse(fs.readFileSync(legacyPath, 'utf-8'));
+        // Derive expected workflow name from stateFile: .work-pr.workflow-state.json -> work-pr
+        const expectedWorkflow = stateFile.replace(/^\./, '').replace(/\.workflow-state\.json$/, '');
+        if (legacy?.workflow === expectedWorkflow) return legacy;
+      } catch {} /* no legacy file either */
+    }
     return null;
   }
 }
@@ -712,7 +724,11 @@ function handlePreToolUse(hookData) {
     if (wf.name === 'work' && matchedStep !== currentStep) {
       const agentType = toolInput?.subagent_type || '';
       if (CHECK_AGENTS.has(agentType)) {
-        const checkState = loadStateFile(ticketId, '.workflow-state.json');
+        let checkState = loadStateFile(ticketId, '.check.workflow-state.json');
+        if (!checkState) {
+          const legacyState = loadStateFile(ticketId, '.workflow-state.json');
+          if (legacyState?.workflow === 'check') checkState = legacyState; // legacy compat
+        }
         if (checkState?.workflow === 'check' && checkState?.status === 'in_progress') {
           continue; // Allow — /check owns this agent
         }

--- a/workflows/lib/hooks/session-guard.js
+++ b/workflows/lib/hooks/session-guard.js
@@ -365,7 +365,7 @@ function isCheckWorkflowActive(ticketId) {
     if (!ticketId || /[/\\:\0]/.test(ticketId)) return false;
 
     const tasksBase = getTasksBase();
-    const resolved = path.resolve(tasksBase, ticketId, '.workflow-state.json');
+    const resolved = path.resolve(tasksBase, ticketId, '.check.workflow-state.json');
     // Guard against path traversal — resolved path must stay under tasksBase
     if (!resolved.startsWith(path.resolve(tasksBase) + path.sep)) return false;
 

--- a/workflows/lib/workflow-state.js
+++ b/workflows/lib/workflow-state.js
@@ -36,14 +36,26 @@ class WorkflowState {
 
   /** Get state file path for an instance */
   _statePath(instanceId) {
-    return path.join(this.stateDir, instanceId, '.workflow-state.json');
+    const safeName = path.basename(this.workflowName).replace(/[^a-zA-Z0-9._-]/g, '');
+    if (!safeName) throw new Error('Invalid workflow name');
+    return path.join(this.stateDir, instanceId, `.${safeName}.workflow-state.json`);
   }
 
   /** Load state for an instance (returns null if not found) */
   load(instanceId) {
     const p = this._statePath(instanceId);
-    if (!fs.existsSync(p)) return null;
-    try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; }
+    if (fs.existsSync(p)) {
+      try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; }
+    }
+    // Legacy fallback — load .workflow-state.json only when workflow field matches (tested)
+    const legacyPath = path.join(this.stateDir, instanceId, '.workflow-state.json');
+    if (fs.existsSync(legacyPath)) {
+      try {
+        const state = JSON.parse(fs.readFileSync(legacyPath, 'utf8'));
+        if (state?.workflow === this.workflowName) return state;
+      } catch { /* ignore */ }
+    }
+    return null;
   }
 
   /** Save state for an instance */


### PR DESCRIPTION
## Summary

- Add ENABLE_SYMLINK config property (defaults to 0, opt-in for symlinks)
- Fix workflow-state file collision between /check and /work-pr
- Sanitize workflow name in state file path to prevent path traversal
- Add legacy fallback for pre-existing workflow state files

## Test plan

- 222 tests pass
- ENABLE_SYMLINK config resolution verified
- Workflow state files no longer collide

Closes #160