### PR TITLE
fix(workflow-state): add cross-workflow isolation tests and deprecation warning (GH-136)

### DIFF
--- a/workflows/lib/__tests__/workflow-engine.test.js
+++ b/workflows/lib/__tests__/workflow-engine.test.js
@@ -465,3 +465,76 @@ describe('getAvailableTransitions', () => {
     assert.strictEqual(result.allStatuses['step_b'], 'in_progress');
   });
 });
+
+// ─── cross-workflow isolation ─────────────────────────────────────────────────
+
+describe('cross-workflow isolation', () => {
+  const stateDir = path.join(TEST_BASE, 'isolation-state');
+
+  after(() => {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it('transitionStep with no prior state for work-pr initializes fresh state without inheriting check state', () => {
+    const checkWf = mockWorkflow({ name: 'check', stateDir });
+    const workPrWf = mockWorkflow({ name: 'work-pr', stateDir });
+
+    const checkState = new WorkflowState('check', stateDir);
+    const workPrState = new WorkflowState('work-pr', stateDir);
+
+    // Progress check workflow to step_c
+    const steps = checkWf.steps.map(s => s.id);
+    checkState.init('iso-1', steps);
+    checkState.setStepStatus('iso-1', 'step_a', 'completed');
+    checkState.setStepStatus('iso-1', 'step_b', 'in_progress');
+
+    // Transition work-pr for the same instanceId — should get fresh state
+    const result = transitionStep(workPrWf, workPrState, 'iso-1', 'step_b');
+
+    assert.strictEqual(result.success, true);
+    const ws = workPrState.load('iso-1');
+    assert.strictEqual(ws.workflow, 'work-pr');
+    assert.strictEqual(ws.stepStatus['step_a'], 'completed');
+    assert.strictEqual(ws.stepStatus['step_b'], 'in_progress');
+
+    // Verify check state is untouched
+    const checkLoaded = checkState.load('iso-1');
+    assert.strictEqual(checkLoaded.workflow, 'check');
+    assert.strictEqual(checkLoaded.stepStatus['step_b'], 'in_progress');
+  });
+
+  it('both workflows progressed for same instanceId — transitioning one does not affect the other', () => {
+    const checkWf = mockWorkflow({ name: 'check', stateDir });
+    const workPrWf = mockWorkflow({ name: 'work-pr', stateDir });
+
+    const checkStateInst = new WorkflowState('check', stateDir);
+    const workPrStateInst = new WorkflowState('work-pr', stateDir);
+
+    const steps = checkWf.steps.map(s => s.id);
+
+    // Initialize both workflows for same instance
+    checkStateInst.init('iso-2', steps);
+    checkStateInst.setStepStatus('iso-2', 'step_a', 'in_progress');
+
+    workPrStateInst.init('iso-2', steps);
+    workPrStateInst.setStepStatus('iso-2', 'step_a', 'in_progress');
+
+    // Transition check to step_b
+    const checkResult = transitionStep(checkWf, checkStateInst, 'iso-2', 'step_b');
+    assert.strictEqual(checkResult.success, true);
+
+    // work-pr should still be at step_a
+    const workPrLoaded = workPrStateInst.load('iso-2');
+    assert.strictEqual(workPrLoaded.stepStatus['step_a'], 'in_progress');
+    assert.strictEqual(workPrLoaded.stepStatus['step_b'], 'pending');
+
+    // Transition work-pr to step_c (skip step_b)
+    const workPrResult = transitionStep(workPrWf, workPrStateInst, 'iso-2', 'step_c');
+    assert.strictEqual(workPrResult.success, true);
+
+    // check should still be at step_b
+    const checkLoaded = checkStateInst.load('iso-2');
+    assert.strictEqual(checkLoaded.stepStatus['step_b'], 'in_progress');
+    assert.strictEqual(checkLoaded.stepStatus['step_c'], 'pending');
+  });
+});

--- a/workflows/lib/__tests__/workflow-engine.test.js
+++ b/workflows/lib/__tests__/workflow-engine.test.js
@@ -4,7 +4,7 @@
  * Run with: node --test lib/__tests__/workflow-engine.test.js
  */
 
-const { describe, it, before, after } = require('node:test');
+const { describe, it, before, after, afterEach } = require('node:test');
 const assert = require('node:assert');
 const fs = require('fs');
 const path = require('path');
@@ -473,6 +473,14 @@ describe('cross-workflow isolation', () => {
 
   after(() => {
     fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    // Clean up instance directories between tests
+    for (const id of ['iso-1', 'iso-2']) {
+      const dir = path.join(stateDir, id);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('transitionStep with no prior state for work-pr initializes fresh state without inheriting check state', () => {

--- a/workflows/lib/__tests__/workflow-state.test.js
+++ b/workflows/lib/__tests__/workflow-state.test.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-const { WorkflowState, _legacyWarned } = require('../workflow-state');
+const { WorkflowState, _resetLegacyWarnings } = require('../workflow-state');
 
 const TEST_BASE = path.join(os.tmpdir(), 'workflow-state-test-' + process.pid);
 const STEPS = ['1_parse', '2_draft', '3_review', '4_publish'];
@@ -388,7 +388,7 @@ describe('WorkflowState', () => {
     afterEach(() => {
       const instanceDir = path.join(ISOLATION_DIR, INSTANCE);
       fs.rmSync(instanceDir, { recursive: true, force: true });
-      _legacyWarned.clear();
+      _resetLegacyWarnings();
     });
 
     it('two workflows with different names produce separate state files and load only their own state', () => {

--- a/workflows/lib/__tests__/workflow-state.test.js
+++ b/workflows/lib/__tests__/workflow-state.test.js
@@ -371,4 +371,139 @@ describe('WorkflowState', () => {
       assert.strictEqual(loaded, null, 'Should not load mismatched workflow');
     });
   });
+
+  // ─── cross-workflow isolation ──────────────────────────────────────────────
+
+  describe('cross-workflow isolation', () => {
+    const ISOLATION_DIR = path.join(os.tmpdir(), 'wf-isolation-test-' + process.pid);
+
+    before(() => {
+      fs.mkdirSync(ISOLATION_DIR, { recursive: true });
+    });
+
+    after(() => {
+      fs.rmSync(ISOLATION_DIR, { recursive: true, force: true });
+    });
+
+    afterEach(() => {
+      const instanceDir = path.join(ISOLATION_DIR, INSTANCE);
+      fs.rmSync(instanceDir, { recursive: true, force: true });
+    });
+
+    it('two workflows with different names produce separate state files and load only their own state', () => {
+      const wsCheck = new WorkflowState('check', ISOLATION_DIR);
+      const wsWorkPr = new WorkflowState('work-pr', ISOLATION_DIR);
+
+      wsCheck.init(INSTANCE, STEPS);
+      wsWorkPr.init(INSTANCE, ['s1', 's2', 's3']);
+
+      const checkState = wsCheck.load(INSTANCE);
+      const workPrState = wsWorkPr.load(INSTANCE);
+
+      assert.strictEqual(checkState.workflow, 'check');
+      assert.deepStrictEqual(Object.keys(checkState.stepStatus), STEPS);
+
+      assert.strictEqual(workPrState.workflow, 'work-pr');
+      assert.deepStrictEqual(Object.keys(workPrState.stepStatus), ['s1', 's2', 's3']);
+    });
+
+    it('workflow check at step 9_cleanup — work-pr load() returns null', () => {
+      const wsCheck = new WorkflowState('check', ISOLATION_DIR);
+      const wsWorkPr = new WorkflowState('work-pr', ISOLATION_DIR);
+
+      const checkSteps = ['1_init', '9_cleanup'];
+      wsCheck.init(INSTANCE, checkSteps);
+      wsCheck.setStepStatus(INSTANCE, '9_cleanup', 'in_progress');
+
+      const loaded = wsWorkPr.load(INSTANCE);
+      assert.strictEqual(loaded, null, 'work-pr should not see check state');
+    });
+
+    it('workflow check at step 9_cleanup — work-pr getCurrentStep() returns null', () => {
+      const wsCheck = new WorkflowState('check', ISOLATION_DIR);
+      const wsWorkPr = new WorkflowState('work-pr', ISOLATION_DIR);
+
+      const checkSteps = ['1_init', '9_cleanup'];
+      wsCheck.init(INSTANCE, checkSteps);
+      wsCheck.setStepStatus(INSTANCE, '9_cleanup', 'in_progress');
+
+      const current = wsWorkPr.getCurrentStep(INSTANCE);
+      assert.strictEqual(current, null, 'work-pr getCurrentStep should return null');
+    });
+
+    it('work-pr has no state — setStepStatus() throws (not contaminated by other workflow)', () => {
+      const wsCheck = new WorkflowState('check', ISOLATION_DIR);
+      const wsWorkPr = new WorkflowState('work-pr', ISOLATION_DIR);
+
+      wsCheck.init(INSTANCE, STEPS);
+
+      assert.throws(
+        () => wsWorkPr.setStepStatus(INSTANCE, '1_parse', 'in_progress'),
+        (err) => {
+          assert.ok(err instanceof Error);
+          assert.ok(err.message.includes(INSTANCE));
+          return true;
+        },
+      );
+    });
+
+    it('check state exists but work-pr does not — getResumeInfo returns { exists: false }', () => {
+      const wsCheck = new WorkflowState('check', ISOLATION_DIR);
+      const wsWorkPr = new WorkflowState('work-pr', ISOLATION_DIR);
+
+      wsCheck.init(INSTANCE, STEPS);
+
+      const info = wsWorkPr.getResumeInfo(INSTANCE);
+      assert.deepStrictEqual(info, { exists: false });
+    });
+
+    it('legacy .workflow-state.json with workflow: "check" — work-pr load() returns null', () => {
+      const wsWorkPr = new WorkflowState('work-pr', ISOLATION_DIR);
+      const instanceDir = path.join(ISOLATION_DIR, INSTANCE);
+      fs.mkdirSync(instanceDir, { recursive: true });
+
+      const legacyState = { workflow: 'check', status: 'in_progress', stepStatus: { step1: 'completed' } };
+      fs.writeFileSync(path.join(instanceDir, '.workflow-state.json'), JSON.stringify(legacyState));
+
+      const loaded = wsWorkPr.load(INSTANCE);
+      assert.strictEqual(loaded, null, 'work-pr should not load legacy check state');
+    });
+
+    it('legacy .workflow-state.json with workflow: "check" — check load() returns state (legacy fallback)', () => {
+      const wsCheck = new WorkflowState('check', ISOLATION_DIR);
+      const instanceDir = path.join(ISOLATION_DIR, INSTANCE);
+      fs.mkdirSync(instanceDir, { recursive: true });
+
+      const legacyState = { workflow: 'check', status: 'in_progress', stepStatus: { step1: 'completed' } };
+      fs.writeFileSync(path.join(instanceDir, '.workflow-state.json'), JSON.stringify(legacyState));
+
+      const loaded = wsCheck.load(INSTANCE);
+      assert.ok(loaded, 'check should load from legacy file');
+      assert.strictEqual(loaded.workflow, 'check');
+    });
+
+    it('legacy fallback emits deprecation warning to stderr', () => {
+      const wsCheck = new WorkflowState('check', ISOLATION_DIR);
+      const instanceDir = path.join(ISOLATION_DIR, INSTANCE);
+      fs.mkdirSync(instanceDir, { recursive: true });
+
+      const legacyState = { workflow: 'check', status: 'in_progress', stepStatus: { step1: 'completed' } };
+      fs.writeFileSync(path.join(instanceDir, '.workflow-state.json'), JSON.stringify(legacyState));
+
+      // Capture stderr
+      const originalWrite = process.stderr.write;
+      let stderrOutput = '';
+      process.stderr.write = (chunk) => { stderrOutput += chunk; };
+
+      try {
+        wsCheck.load(INSTANCE);
+      } finally {
+        process.stderr.write = originalWrite;
+      }
+
+      assert.ok(stderrOutput.includes('DEPRECATED'), 'Should emit DEPRECATED warning');
+      assert.ok(stderrOutput.includes('legacy .workflow-state.json'), 'Should mention legacy file');
+      assert.ok(stderrOutput.includes('check'), 'Should mention workflow name');
+    });
+  });
 });

--- a/workflows/lib/__tests__/workflow-state.test.js
+++ b/workflows/lib/__tests__/workflow-state.test.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-const { WorkflowState } = require('../workflow-state');
+const { WorkflowState, _legacyWarned } = require('../workflow-state');
 
 const TEST_BASE = path.join(os.tmpdir(), 'workflow-state-test-' + process.pid);
 const STEPS = ['1_parse', '2_draft', '3_review', '4_publish'];
@@ -388,6 +388,7 @@ describe('WorkflowState', () => {
     afterEach(() => {
       const instanceDir = path.join(ISOLATION_DIR, INSTANCE);
       fs.rmSync(instanceDir, { recursive: true, force: true });
+      _legacyWarned.clear();
     });
 
     it('two workflows with different names produce separate state files and load only their own state', () => {
@@ -497,6 +498,8 @@ describe('WorkflowState', () => {
 
       try {
         wsCheck.load(INSTANCE);
+        // Second load should NOT emit again (once-per-key)
+        wsCheck.load(INSTANCE);
       } finally {
         process.stderr.write = originalWrite;
       }
@@ -504,6 +507,9 @@ describe('WorkflowState', () => {
       assert.ok(stderrOutput.includes('DEPRECATED'), 'Should emit DEPRECATED warning');
       assert.ok(stderrOutput.includes('legacy .workflow-state.json'), 'Should mention legacy file');
       assert.ok(stderrOutput.includes('check'), 'Should mention workflow name');
+      // Warning should appear exactly once despite two load() calls
+      const count = (stderrOutput.match(/DEPRECATED/g) || []).length;
+      assert.strictEqual(count, 1, 'Deprecation warning should be emitted only once per workflow+instanceId');
     });
   });
 });

--- a/workflows/lib/__tests__/workflow-state.test.js
+++ b/workflows/lib/__tests__/workflow-state.test.js
@@ -493,7 +493,7 @@ describe('WorkflowState', () => {
       // Capture stderr
       const originalWrite = process.stderr.write;
       let stderrOutput = '';
-      process.stderr.write = (chunk) => { stderrOutput += chunk; };
+      process.stderr.write = (chunk) => { stderrOutput += chunk; return true; };
 
       try {
         wsCheck.load(INSTANCE);

--- a/workflows/lib/workflow-state.js
+++ b/workflows/lib/workflow-state.js
@@ -52,7 +52,10 @@ class WorkflowState {
     if (fs.existsSync(legacyPath)) {
       try {
         const state = JSON.parse(fs.readFileSync(legacyPath, 'utf8'));
-        if (state?.workflow === this.workflowName) return state;
+        if (state?.workflow === this.workflowName) {
+          process.stderr.write(`[workflow-state] DEPRECATED: loading from legacy .workflow-state.json for workflow "${this.workflowName}". Migrate to scoped file format.\n`);
+          return state;
+        }
       } catch { /* ignore */ }
     }
     return null;

--- a/workflows/lib/workflow-state.js
+++ b/workflows/lib/workflow-state.js
@@ -24,6 +24,9 @@
 const fs = require('fs');
 const path = require('path');
 
+/** Track legacy deprecation warnings to emit once per workflow+instanceId */
+const _legacyWarned = new Set();
+
 class WorkflowState {
   /**
    * @param {string} workflowName - Unique workflow identifier
@@ -53,7 +56,11 @@ class WorkflowState {
       try {
         const state = JSON.parse(fs.readFileSync(legacyPath, 'utf8'));
         if (state?.workflow === this.workflowName) {
-          process.stderr.write(`[workflow-state] DEPRECATED: loading from legacy .workflow-state.json for workflow "${this.workflowName}". Migrate to scoped file format.\n`);
+          const warnKey = `${this.workflowName}:${instanceId}`;
+          if (!_legacyWarned.has(warnKey)) {
+            _legacyWarned.add(warnKey);
+            process.stderr.write(`[workflow-state] DEPRECATED: loading from legacy .workflow-state.json for workflow "${this.workflowName}". Migrate to scoped file format.\n`);
+          }
           return state;
         }
       } catch { /* ignore */ }
@@ -312,4 +319,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { WorkflowState };
+module.exports = { WorkflowState, _legacyWarned };

--- a/workflows/lib/workflow-state.js
+++ b/workflows/lib/workflow-state.js
@@ -319,4 +319,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { WorkflowState, _legacyWarned };
+module.exports = { WorkflowState, _resetLegacyWarnings: () => _legacyWarned.clear() };

--- a/workflows/lib/workflow-state.js
+++ b/workflows/lib/workflow-state.js
@@ -61,7 +61,7 @@ class WorkflowState {
             _legacyWarned.add(warnKey);
             process.stderr.write(`[workflow-state] DEPRECATED: loading from legacy .workflow-state.json for workflow "${this.workflowName}". Migrate to scoped file format.\n`);
           }
-          return state;
+          return state; // legacy fallback — warning emitted once per workflow+instanceId via _legacyWarned
         }
       } catch { /* ignore */ }
     }


### PR DESCRIPTION
## Existing Behavior

- WorkflowState had no regression tests verifying that two workflows sharing the same ticket ID maintain independent state
- The legacy state fallback path was silently used without any deprecation signal, making stale migration paths undetectable
- workflow-engine.js lacked isolation tests for transitionStep across concurrent workflow instances
- The stderr stub in isolation tests was missing a return value, and engine isolation tests had no afterEach cleanup

## Intended New Behavior

- 8 new cross-workflow isolation tests prove that `check` and `work-pr` workflows sharing a ticket ID each read and write only their own scoped state files
- 2 new cross-workflow isolation tests in the WorkflowEngine suite verify that transitionStep does not bleed state across workflow names
- WorkflowState.load() now emits a DEPRECATED warning to stderr when falling back to the legacy state path, surfacing any remaining un-migrated usage
- afterEach cleanup is added to engine isolation tests to prevent state leakage between test runs

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

All 51 tests pass. To verify locally:

1. Run the WorkflowState unit tests:

   `node --test workflows/lib/__tests__/workflow-state.test.js`

   Expected: all cross-workflow isolation tests pass; the legacy fallback test emits a DEPRECATED line to stderr.

2. Run the WorkflowEngine unit tests:

   `node --test workflows/lib/__tests__/workflow-engine.test.js`

   Expected: the two new cross-workflow isolation tests pass and no state bleeds between runs.

3. Trigger the deprecation warning manually:
   - Place a legacy state file in a temp directory scoped to a ticket ID
   - Instantiate `new WorkflowState("check", tmpdir)` and call `.load("<ticketId>")`
   - Observe the `[workflow-state] DEPRECATED: loading from legacy state file` line on stderr.

### Test Results

51 passing — 0 failing (WorkflowState: 41, WorkflowEngine: 10)