### PR TITLE
enforce: detect python3/ruby/perl inline interpreter file-write bypass (Vector 4)

### DIFF
--- a/workflows/lib/__tests__/protect-state-files.test.js
+++ b/workflows/lib/__tests__/protect-state-files.test.js
@@ -411,6 +411,15 @@ describe('createFileProtector — inline interpreter bypass', () => {
     assert.equal(result.blocked, true);
     assert.ok(result.vector.includes('base64'));
   });
+
+  it('blocks second interpreter in compound command', () => {
+    // First python3 -c is benign, second writes to protected file
+    const result = protector.check('Bash', {
+      command: 'python3 -c "print(1)"; python3 -c "open(\'.state.json\',\'w\').write(\'x\')"',
+    });
+    assert.equal(result.blocked, true, 'should detect write in second interpreter invocation');
+    assert.equal(result.vector, 'Bash(python3 -c)');
+  });
 });
 
 // ─── createFileProtector — isExempt ─────────────────────────────────────────

--- a/workflows/lib/protect-state-files.js
+++ b/workflows/lib/protect-state-files.js
@@ -260,8 +260,13 @@ function createFileProtector(opts) {
   }
 
   function checkInlineInterpreterBypass(cmd, toolInput, hookData) {
-    const interpreterMatch = cmd.match(INLINE_INTERPRETER_PATTERN);
-    if (!interpreterMatch) return { blocked: false, skipRemainingChecks: false };
+    // Use global scan to check ALL inline interpreter occurrences in compound commands
+    // (e.g. `python3 -c "print(1)"; python3 -c "open('.state.json','w')..."`)
+    const globalPattern = new RegExp(INLINE_INTERPRETER_PATTERN.source, 'g');
+    const allMatches = [...cmd.matchAll(globalPattern)];
+    if (allMatches.length === 0) return { blocked: false, skipRemainingChecks: false };
+
+    for (const interpreterMatch of allMatches) {
 
     // Extract the interpreter name and flag from the match (e.g. "python3 -c", "ruby -e")
     const matchStr = interpreterMatch[0].trim();
@@ -273,7 +278,7 @@ function createFileProtector(opts) {
     // avoiding false positives when protected filenames or base64 appear
     // in other command segments (e.g. `echo .state.json; python3 -c "..."`)
     // or in pipeline stages (e.g. `python3 -c "print('hello')" | base64`).
-    const flagIdx = cmd.indexOf(interpreterMatch[0]);
+    const flagIdx = interpreterMatch.index;
     const afterFlag = cmd.slice(flagIdx);
     // Try to extract the quoted code argument first (respects quotes around inline code).
     // If unquoted, capture up to the first unquoted shell operator (|, ;, &&, ||).
@@ -315,6 +320,7 @@ function createFileProtector(opts) {
         };
       }
     } // end base64 evasion check
+    } // end for each interpreter match
 
     return { blocked: false, skipRemainingChecks: false };
   }


### PR DESCRIPTION
## Existing Behavior

- `protect-state-files.js` detects file-write attempts via Bash shell redirects (Vector 1), direct tool calls (Vector 2), and interpreter script files (Vector 3, e.g. `python3 script.py`).
- Inline interpreter invocations using `-c` / `-e` flags (e.g. `python3 -c "open('.state.json','w').write('{}')"`) are not detected and can bypass all three existing vectors.
- Base64-encoded filename evasion (e.g. `base64.b64decode(...)` passed to `open()`) is not detected.

## Intended New Behavior

- Adds Vector 4: `checkInlineInterpreterBypass()` detects `python3 -c`, `python -c`, `ruby -e`, and `perl -e` invocations (including `/usr/bin/env` prefix) that contain a write operation targeting a protected file.
- Three new exported regex constants (`INLINE_INTERPRETER_PATTERN`, `INLINE_INTERPRETER_WRITES`, `BASE64_EVASION_PATTERN`) narrowly target write-mode `open()` calls, `os.rename`, `shutil.copy/move`, `File.write`, `IO.write`, and base64 function references — read-only `open()` is explicitly not matched.
- Base64 evasion (no visible filename, but `base64`/`b64decode`/`atob` present with a write op inside an inline interpreter) is blocked and reported with vector label `Bash(<interpreter> base64)`.
- `checkInlineInterpreterBypass` is exported on the protector object for direct testability.
- Test suite grows from 48 to 64 cases (+16), covering all new paths including benign allow-list cases.

Closes #107

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Run the existing test suite to confirm all 64 tests pass:

```bash
node --test workflows/lib/__tests__/protect-state-files.test.js
```

To manually exercise Vector 4, use the hook directly. With `.state.json` in the protected set:

1. Blocked — direct write mode:
   ```bash
   python3 -c "open('.state.json','w').write('{}')"
   ```
   Expected: hook blocks the command, vector reported as `Bash(python3 -c)`.

2. Blocked — `/usr/bin/env` prefix:
   ```bash
   /usr/bin/env python3 -c "open('.state.json','w').write('{}')"
   ```
   Expected: blocked, same vector label.

3. Blocked — `os.rename` trick:
   ```bash
   python3 -c "import os; os.rename('/tmp/x', '.state.json')"
   ```
   Expected: blocked.

4. Blocked — base64 evasion (no visible filename):
   ```bash
   python3 -c "import base64; open(base64.b64decode('LnN0YXRlLmpzb24=').decode(),'w').write('{}')"
   ```
   Expected: blocked, vector reported as `Bash(python3 -c base64)`.

5. Allowed — read-only open():
   ```bash
   python3 -c "data = open('.state.json').read()"
   ```
   Expected: not blocked.

6. Allowed — benign command with no write op:
   ```bash
   python3 -c "print('hello')"
   ```
   Expected: not blocked.

### Test Results

64 tests — 64 passing, 0 failing.