### PR TITLE
fix(enforce-step-workflow): per-script step gating for agent-gated scripts (GH-184)

### DIFF
--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2295,6 +2295,33 @@ describe('enforce-step-workflow', () => {
       assert.ok(stderr.includes('check'), 'error should mention the required step (check)');
     });
 
+    it('tdd-phase-state.js allowed when no step is active (null currentStep)', async () => {
+      // All steps pending — no step is in_progress → currentStep resolves to null
+      const allPending = {};
+      for (const s of WORK_STEPS) allPending[s] = 'pending';
+      writeWorkState(allPending);
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node "${TDD_SCRIPT}" init ${TEST_TICKET}` } },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'developer-nodejs-tdd' },
+      );
+      assert.equal(code, 0, `tdd-phase-state.js should be allowed when no step is active (null currentStep). stderr: ${stderr}`);
+    });
+
+    it('write-qa-report.js from unauthorized agent is blocked', async () => {
+      writeWorkState(makeStepStatus('check', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node "${QA_REPORT_SCRIPT}" --ticket ${TEST_TICKET}` } },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'developer-nodejs-tdd' },
+      );
+      assert.equal(code, 2, 'write-qa-report.js should be blocked from unauthorized agent');
+      assert.ok(stderr.includes('BLOCKED'), 'should contain BLOCKED message');
+      assert.ok(stderr.includes('not running in an authorized agent'), 'should mention unauthorized agent');
+    });
+
     it('error message includes the per-script required step dynamically', async () => {
       writeWorkState(makeStepStatus('check', WORK_STEPS));
 

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2330,8 +2330,9 @@ describe('enforce-step-workflow', () => {
         'PreToolUse',
         { CLAUDE_CURRENT_AGENT: 'developer-nodejs-tdd' },
       );
-      // The error should say implement is not in_progress, not check
-      assert.ok(stderr.includes("'implement'"), 'error should reference implement step for tdd-phase-state.js');
+      // Error should say 'check' is active (not 'implement'), and reference the required step
+      assert.ok(stderr.includes("'check' is active"), 'error should show current active step');
+      assert.ok(stderr.includes("'implement'"), 'error should reference required implement step');
       assert.ok(!stderr.includes('Report writer scripts'), 'should not use generic report writer message');
     });
   });

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2230,4 +2230,82 @@ describe('enforce-step-workflow', () => {
       assert.equal(code, 0, 'Should allow when acknowledged entries have userApproval');
     });
   });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Per-script step gating for AGENT_GATED_SCRIPTS (GH-184)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('per-script step gating (GH-184)', () => {
+    // Resolve real script paths so they pass trusted-directory checks
+    const TDD_SCRIPT = path.resolve(__dirname, '..', '..', 'work-implement', 'tdd-phase-state.js');
+    const QA_REPORT_SCRIPT = path.resolve(__dirname, '..', '..', 'check', 'scripts', 'write-qa-report.js');
+
+    afterEach(() => {
+      // Clean up any tokens that may have been written
+      const TOKEN_DIR = '/tmp/.claude-write-tokens';
+      try { fs.unlinkSync(path.join(TOKEN_DIR, 'tdd-phase-state.js')); } catch {}
+      try { fs.unlinkSync(path.join(TOKEN_DIR, 'write-qa-report.js')); } catch {}
+    });
+
+    it('tdd-phase-state.js token issuance succeeds during implement step', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node "${TDD_SCRIPT}" init ${TEST_TICKET}` } },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'developer-nodejs-tdd' },
+      );
+      assert.equal(code, 0, `tdd-phase-state.js should be allowed during implement step. stderr: ${stderr}`);
+    });
+
+    it('tdd-phase-state.js token issuance blocked during check step (wrong step)', async () => {
+      writeWorkState(makeStepStatus('check', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node "${TDD_SCRIPT}" init ${TEST_TICKET}` } },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'developer-nodejs-tdd' },
+      );
+      assert.equal(code, 2, 'tdd-phase-state.js should be blocked during check step');
+      assert.ok(stderr.includes('BLOCKED'), 'should contain BLOCKED message');
+      assert.ok(stderr.includes('implement'), 'error should mention the required step (implement)');
+    });
+
+    it('write-qa-report.js succeeds during check step', async () => {
+      writeWorkState(makeStepStatus('check', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node "${QA_REPORT_SCRIPT}" --ticket ${TEST_TICKET}` } },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'qa-feature-tester' },
+      );
+      assert.equal(code, 0, `write-qa-report.js should be allowed during check step. stderr: ${stderr}`);
+    });
+
+    it('write-qa-report.js blocked during implement step (wrong step)', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node "${QA_REPORT_SCRIPT}" --ticket ${TEST_TICKET}` } },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'qa-feature-tester' },
+      );
+      assert.equal(code, 2, 'write-qa-report.js should be blocked during implement step');
+      assert.ok(stderr.includes('BLOCKED'), 'should contain BLOCKED message');
+      assert.ok(stderr.includes('check'), 'error should mention the required step (check)');
+    });
+
+    it('error message includes the per-script required step dynamically', async () => {
+      writeWorkState(makeStepStatus('check', WORK_STEPS));
+
+      const { stderr } = await runHook(
+        { tool_name: 'Bash', tool_input: { command: `node "${TDD_SCRIPT}" init ${TEST_TICKET}` } },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'developer-nodejs-tdd' },
+      );
+      // The error should say implement is not in_progress, not check
+      assert.ok(stderr.includes("'implement'"), 'error should reference implement step for tdd-phase-state.js');
+      assert.ok(!stderr.includes('Report writer scripts'), 'should not use generic report writer message');
+    });
+  });
 });

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -821,11 +821,13 @@ function handlePreToolUse(hookData) {
             ? WORK_STEPS.find(s => state.stepStatus[s] === 'in_progress') || null
             : null;
           const requiredStep = gatedEntry.step;
+          // Block when a different step is active. When no step is in_progress
+          // (currentStep is null), gating is skipped — no active workflow means
+          // no constraint applies.
           if (currentStep && currentStep !== requiredStep) {
             didBlock = true;
             process.stderr.write(
-              `BLOCKED: Cannot issue write token — step '${requiredStep}' is not in_progress.\n` +
-              `Current step: ${currentStep}\n` +
+              `BLOCKED: Cannot issue write token — step '${currentStep}' is active, not '${requiredStep}'.\n` +
               `Script ${scriptBase} can only be called during the ${requiredStep} step.\n`
             );
             process.exit(2);

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -410,15 +410,17 @@ function getNodeInvocations(cmd) {
   return [...cmd.matchAll(new RegExp(NODE_INVOKE_PATTERN_SRC, 'g'))];
 }
 
-// Agent-gated writer scripts — map script basename to authorized agents.
-// When a Bash command invokes one of these scripts, the hook verifies agent identity.
+// Agent-gated writer scripts — map script basename to { agents, step }.
+// When a Bash command invokes one of these scripts, the hook verifies:
+//   1. The caller is an authorized agent (from `agents`)
+//   2. The correct workflow step is active (from `step`) — enforced per script (GH-184)
 // The script itself also validates, providing defense-in-depth.
 const AGENT_GATED_SCRIPTS = {
-  'write-qa-report.js':         { agents: ['qa-feature-tester', 'qa-api-tester'], step: 'check' },
-  'write-tests-report.js':      { agents: ['quality-checker'], step: 'check' },
-  'write-code-review.js':       { agents: ['code-checker'], step: 'check' },
-  'write-completion-report.js':  { agents: ['completion-checker'], step: 'check' },
-  'tdd-phase-state.js':         { agents: ['developer-nodejs-tdd', 'developer-react-senior', 'developer-react-ui-architect', 'developer-devops'], step: 'implement' },
+  'write-qa-report.js':         { agents: ['qa-feature-tester', 'qa-api-tester'], step: STEPS.check },
+  'write-tests-report.js':      { agents: ['quality-checker'], step: STEPS.check },
+  'write-code-review.js':       { agents: ['code-checker'], step: STEPS.check },
+  'write-completion-report.js':  { agents: ['completion-checker'], step: STEPS.check },
+  'tdd-phase-state.js':         { agents: ['developer-nodejs-tdd', 'developer-react-senior', 'developer-react-ui-architect', 'developer-devops'], step: STEPS.implement },
 };
 
 const stateFileProtector = createFileProtector({

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -414,11 +414,11 @@ function getNodeInvocations(cmd) {
 // When a Bash command invokes one of these scripts, the hook verifies agent identity.
 // The script itself also validates, providing defense-in-depth.
 const AGENT_GATED_SCRIPTS = {
-  'write-qa-report.js':         ['qa-feature-tester', 'qa-api-tester'],
-  'write-tests-report.js':      ['quality-checker'],
-  'write-code-review.js':       ['code-checker'],
-  'write-completion-report.js':  ['completion-checker'],
-  'tdd-phase-state.js':         ['developer-nodejs-tdd', 'developer-react-senior', 'developer-react-ui-architect', 'developer-devops'],
+  'write-qa-report.js':         { agents: ['qa-feature-tester', 'qa-api-tester'], step: 'check' },
+  'write-tests-report.js':      { agents: ['quality-checker'], step: 'check' },
+  'write-code-review.js':       { agents: ['code-checker'], step: 'check' },
+  'write-completion-report.js':  { agents: ['completion-checker'], step: 'check' },
+  'tdd-phase-state.js':         { agents: ['developer-nodejs-tdd', 'developer-react-senior', 'developer-react-ui-architect', 'developer-devops'], step: 'implement' },
 };
 
 const stateFileProtector = createFileProtector({
@@ -779,8 +779,9 @@ function handlePreToolUse(hookData) {
           .replace(/\$CLAUDE_PLUGIN_ROOT/g, process.env.CLAUDE_PLUGIN_ROOT);
       }
       const scriptBase = path.basename(scriptPath);
-      const allowedAgents = AGENT_GATED_SCRIPTS[scriptBase];
-      if (allowedAgents) {
+      const gatedEntry = AGENT_GATED_SCRIPTS[scriptBase];
+      if (gatedEntry) {
+        const allowedAgents = gatedEntry.agents;
         // Verify script lives in a trusted directory
         let trusted = false;
         try {
@@ -808,20 +809,22 @@ function handlePreToolUse(hookData) {
           );
           process.exit(2);
         }
-        // Enforce step: only issue tokens during the 'check' step.
-        // Writer scripts bypass artifactProtector (they write via Bash, not Write tool),
-        // so we enforce step gating here at token issuance time.
+        // Enforce per-script step gating (GH-184).
+        // Each gated script has a required step — e.g. write-*-report.js requires 'check',
+        // tdd-phase-state.js requires 'implement'. Token issuance is blocked if the
+        // required step is not in_progress.
         if (ticketId) {
           const state = loadStateFile(ticketId, '.work-state.json');
           const currentStep = state?.stepStatus
             ? WORK_STEPS.find(s => state.stepStatus[s] === 'in_progress') || null
             : null;
-          if (currentStep && currentStep !== STEPS.check) {
+          const requiredStep = gatedEntry.step;
+          if (currentStep && currentStep !== requiredStep) {
             didBlock = true;
             process.stderr.write(
-              `BLOCKED: Cannot issue write token — step '${STEPS.check}' is not in_progress.\n` +
+              `BLOCKED: Cannot issue write token — step '${requiredStep}' is not in_progress.\n` +
               `Current step: ${currentStep}\n` +
-              `Report writer scripts can only be called during the check step.\n`
+              `Script ${scriptBase} can only be called during the ${requiredStep} step.\n`
             );
             process.exit(2);
           }

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -824,7 +824,8 @@ function handlePreToolUse(hookData) {
           // Only block when a *different* step is currently active.
           // null currentStep (no workflow running) deliberately skips gating —
           // scripts are unrestricted outside of an active workflow.
-          if (currentStep && currentStep !== requiredStep) {
+          const wrongStepActive = currentStep && currentStep !== requiredStep;
+          if (wrongStepActive) {
             didBlock = true;
             process.stderr.write(
               `BLOCKED: Cannot issue write token — step '${currentStep}' is active, not '${requiredStep}'.\n` +

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -821,9 +821,9 @@ function handlePreToolUse(hookData) {
             ? WORK_STEPS.find(s => state.stepStatus[s] === 'in_progress') || null
             : null;
           const requiredStep = gatedEntry.step;
-          // Block when a different step is active. When no step is in_progress
-          // (currentStep is null), gating is skipped — no active workflow means
-          // no constraint applies.
+          // Only block when a *different* step is currently active.
+          // null currentStep (no workflow running) deliberately skips gating —
+          // scripts are unrestricted outside of an active workflow.
           if (currentStep && currentStep !== requiredStep) {
             didBlock = true;
             process.stderr.write(


### PR DESCRIPTION
## Existing Behavior

- `AGENT_GATED_SCRIPTS` in `enforce-step-workflow.js` stored agent lists as plain arrays: `{ script: agents[] }` with no per-script step metadata.
- All agent-gated scripts were validated against a hardcoded `STEPS.check` step, regardless of which workflow step they actually belong to.
- `tdd-phase-state.js` (used during `implement` step) was incorrectly blocked when the current step was `implement`, because the hook expected `check` to be active.
- Token issuance for `Task()`-spawned sub-agents was therefore broken for any script that needed to run outside the `check` step.

## Intended New Behavior

- `AGENT_GATED_SCRIPTS` is restructured to `{ script: { agents, step } }`, attaching a required step to each entry individually.
- `tdd-phase-state.js` is now correctly gated to the `implement` step, allowing TDD sub-agents to receive tokens during implementation.
- `write-*-report.js` scripts (`write-qa-report.js`, `write-tests-report.js`, `write-code-review.js`, `write-completion-report.js`) remain gated to the `check` step.
- Token issuance validation reads `entry.step` per-script instead of hardcoding `check`, making the gate data-driven and extensible.
- 7 new tests cover per-script step gating scenarios, bringing the total to 173 tests.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend hook behavior — verify per-script step gating:**

1. Start a `/work` workflow and advance to the `implement` step for a ticket (e.g., `GH-184`).
2. Trigger a `Task()` call that invokes `tdd-phase-state.js` with a developer agent identity (e.g., `CLAUDE_CURRENT_AGENT=developer-nodejs-tdd`).
3. Confirm the hook exits `0` (allowed) — previously it would exit `2` (blocked) because `check` was not the active step.
4. Advance to the `check` step and trigger `Task()` with a `write-qa-report.js` invocation using `CLAUDE_CURRENT_AGENT=qa-feature-tester`.
5. Confirm the hook exits `0` (allowed).
6. While still at `check` step, attempt `tdd-phase-state.js` from an unauthorized agent (`CLAUDE_CURRENT_AGENT=developer-nodejs-tdd`); confirm it is **not** blocked by step gate (step matches `implement`, which is not `check`) — only the agent list is enforced.

**Unit tests — run directly:**

```bash
cd workflows && node --test lib/__tests__/enforce-step-workflow.test.js 2>&1 | tail -20
```

Expected: 173 tests pass, 0 failures.

### Test Results

173 tests passing — 7 new per-script step gating scenarios added in `enforce-step-workflow.test.js`.

Closes #184