### PR TITLE
fix(gh-issues): sanitize GitHub Issues ticket IDs to GH- prefix in task directory paths

### DIFF
--- a/workflows/check/hooks/qa-progress.js
+++ b/workflows/check/hooks/qa-progress.js
@@ -24,12 +24,19 @@ process.on('unhandledRejection', () => process.exit(0));
 
 const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
 const TASKS_BASE = getConfig.orExit('TASKS_BASE');
+const tp = require(path.join(__dirname, '..', '..', 'lib', 'ticket-provider'));
+function safeId(ticketId) {
+  try {
+    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+    return tp.sanitizeTicketIdForPath(ticketId, providerConfig);
+  } catch { return ticketId; }
+}
 
 /**
  * Get progress file path for a ticket/app
  */
 function getProgressPath(ticketId, appName) {
-  return path.join(TASKS_BASE, ticketId, `.qa-progress-${appName}.json`);
+  return path.join(TASKS_BASE, safeId(ticketId), `.qa-progress-${appName}.json`);
 }
 
 /**
@@ -47,7 +54,7 @@ function loadProgress(ticketId, appName) {
  * Save progress for a ticket/app
  */
 function saveProgress(ticketId, appName, progress) {
-  const taskDir = path.join(TASKS_BASE, ticketId);
+  const taskDir = path.join(TASKS_BASE, safeId(ticketId));
   if (!fs.existsSync(taskDir)) {
     fs.mkdirSync(taskDir, { recursive: true });
   }
@@ -62,7 +69,7 @@ function saveProgress(ticketId, appName, progress) {
  * Initialize QA progress for an app
  */
 function initProgress(ticketId, appName, appUrl, testPlan = []) {
-  const screenshotsDir = path.join(TASKS_BASE, ticketId, 'screenshots', appName);
+  const screenshotsDir = path.join(TASKS_BASE, safeId(ticketId), 'screenshots', appName);
   if (!fs.existsSync(screenshotsDir)) {
     fs.mkdirSync(screenshotsDir, { recursive: true });
   }

--- a/workflows/check/hooks/qa-progress.js
+++ b/workflows/check/hooks/qa-progress.js
@@ -24,12 +24,9 @@ process.on('unhandledRejection', () => process.exit(0));
 
 const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
 const TASKS_BASE = getConfig.orExit('TASKS_BASE');
-const tp = require(path.join(__dirname, '..', '..', 'lib', 'ticket-provider'));
 function safeId(ticketId) {
-  try {
-    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
-    return tp.sanitizeTicketIdForPath(ticketId, providerConfig);
-  } catch { return ticketId; }
+  try { return require(path.join(__dirname, '..', '..', 'lib', 'config')).safeTicketId(ticketId); }
+  catch { return ticketId; }
 }
 
 /**

--- a/workflows/lib/config.js
+++ b/workflows/lib/config.js
@@ -135,12 +135,27 @@ config.worktreeDir = (ticketId) =>
 config.repoDir = () =>
   config.WORKTREES_BASE ? path.join(config.WORKTREES_BASE, config.REPO_NAME) : null;
 
+/**
+ * Sanitize ticket ID for file-system paths (#N → GH-N for GitHub Issues).
+ * Cached: provider config is resolved once per process.
+ */
+let _cachedProviderConfig;
+let _providerConfigLoaded = false;
+config.safeTicketId = (ticketId) => {
+  try {
+    if (!_providerConfigLoaded) {
+      const tp = require('./ticket-provider');
+      _cachedProviderConfig = tp.getProviderConfig({ skipPrompt: true });
+      _providerConfigLoaded = true;
+    }
+    const tp = require('./ticket-provider');
+    return tp.sanitizeTicketIdForPath(ticketId, _cachedProviderConfig);
+  } catch { return ticketId; }
+};
+
 config.tasksDir = (ticketId) => {
   if (!config.TASKS_BASE) return null;
-  const tp = require('./ticket-provider');
-  const providerConfig = tp.getProviderConfig({ skipPrompt: true });
-  const safeId = tp.sanitizeTicketIdForPath(ticketId, providerConfig);
-  return path.join(config.TASKS_BASE, safeId);
+  return path.join(config.TASKS_BASE, config.safeTicketId(ticketId));
 };
 
 config.webAppNames = () =>

--- a/workflows/lib/config.js
+++ b/workflows/lib/config.js
@@ -135,8 +135,13 @@ config.worktreeDir = (ticketId) =>
 config.repoDir = () =>
   config.WORKTREES_BASE ? path.join(config.WORKTREES_BASE, config.REPO_NAME) : null;
 
-config.tasksDir = (ticketId) =>
-  config.TASKS_BASE ? path.join(config.TASKS_BASE, ticketId) : null;
+config.tasksDir = (ticketId) => {
+  if (!config.TASKS_BASE) return null;
+  const tp = require('./ticket-provider');
+  const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+  const safeId = tp.sanitizeTicketIdForPath(ticketId, providerConfig);
+  return path.join(config.TASKS_BASE, safeId);
+};
 
 config.webAppNames = () =>
   config.WEB_APPS.filter(app => app && app.name).map(app => app.name);

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -61,18 +61,9 @@ const TASKS_BASE = getConfig('TASKS_BASE') || (() => {
   return path.join(wb, 'tasks');
 })();
 
-// Sanitize ticket ID for file-system paths (#N → GH-N for GitHub Issues)
-const tp = require(path.join(__dirname, '..', 'ticket-provider'));
-let _cachedProviderConfig;
-let _providerConfigLoaded = false;
 function safeTicketPath(ticketId) {
-  try {
-    if (!_providerConfigLoaded) {
-      _cachedProviderConfig = tp.getProviderConfig({ skipPrompt: true });
-      _providerConfigLoaded = true;
-    }
-    return tp.sanitizeTicketIdForPath(ticketId, _cachedProviderConfig);
-  } catch { return ticketId; }
+  try { return require(path.join(__dirname, '..', 'config')).safeTicketId(ticketId); }
+  catch { return ticketId; }
 }
 
 // ─── Workflow Definitions ───────────────────────────────────────────────────

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -63,10 +63,15 @@ const TASKS_BASE = getConfig('TASKS_BASE') || (() => {
 
 // Sanitize ticket ID for file-system paths (#N → GH-N for GitHub Issues)
 const tp = require(path.join(__dirname, '..', 'ticket-provider'));
+let _cachedProviderConfig;
+let _providerConfigLoaded = false;
 function safeTicketPath(ticketId) {
   try {
-    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
-    return tp.sanitizeTicketIdForPath(ticketId, providerConfig);
+    if (!_providerConfigLoaded) {
+      _cachedProviderConfig = tp.getProviderConfig({ skipPrompt: true });
+      _providerConfigLoaded = true;
+    }
+    return tp.sanitizeTicketIdForPath(ticketId, _cachedProviderConfig);
   } catch { return ticketId; }
 }
 
@@ -114,7 +119,7 @@ const WORKFLOWS = [
         try {
           const stateFile = path.join(TASKS_BASE, safeTicketPath(ticketId), '.work-state.json');
           const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
-          return state?.status === 'in_progress' && state?.ticketId === ticketId;
+          return state?.status === 'in_progress' && (state?.ticketId === ticketId || state?.ticketId === safeTicketPath(ticketId));
         } catch { return false; }
       }},
       { step: STEPS.brief, verify: (ticketId) => {

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -61,6 +61,15 @@ const TASKS_BASE = getConfig('TASKS_BASE') || (() => {
   return path.join(wb, 'tasks');
 })();
 
+// Sanitize ticket ID for file-system paths (#N → GH-N for GitHub Issues)
+const tp = require(path.join(__dirname, '..', 'ticket-provider'));
+function safeTicketPath(ticketId) {
+  try {
+    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+    return tp.sanitizeTicketIdForPath(ticketId, providerConfig);
+  } catch { return ticketId; }
+}
+
 // ─── Workflow Definitions ───────────────────────────────────────────────────
 //
 // Each workflow defines its own state file, step-to-command mapping,
@@ -103,24 +112,24 @@ const WORKFLOWS = [
       { step: STEPS.ticket, verify: (ticketId) => {
         // Ticket is proven if the work state file exists and is active for this ticket
         try {
-          const stateFile = path.join(TASKS_BASE, ticketId, '.work-state.json');
+          const stateFile = path.join(TASKS_BASE, safeTicketPath(ticketId), '.work-state.json');
           const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
           return state?.status === 'in_progress' && state?.ticketId === ticketId;
         } catch { return false; }
       }},
       { step: STEPS.brief, verify: (ticketId) => {
-        try { return fs.existsSync(path.join(TASKS_BASE, ticketId, 'brief.md')); }
+        try { return fs.existsSync(path.join(TASKS_BASE, safeTicketPath(ticketId), 'brief.md')); }
         catch { return false; }
       }},
       { step: STEPS.spec, verify: (ticketId) => {
-        try { return fs.existsSync(path.join(TASKS_BASE, ticketId, 'spec.md')); }
+        try { return fs.existsSync(path.join(TASKS_BASE, safeTicketPath(ticketId), 'spec.md')); }
         catch { return false; }
       }},
       { step: STEPS.implement, verify: (ticketId) => {
         // Implement is proven if tdd-phase.json has at least one cycle with red + green evidence
         try {
           const state = JSON.parse(fs.readFileSync(
-            path.join(TASKS_BASE, ticketId, 'tdd-phase.json'), 'utf-8'
+            path.join(TASKS_BASE, safeTicketPath(ticketId), 'tdd-phase.json'), 'utf-8'
           ));
           // Exception mode: config-only or mechanical changes that skip TDD
           if (typeof state.exception === 'string' && state.exception.trim() !== '') return true;
@@ -134,7 +143,7 @@ const WORKFLOWS = [
         try {
           const { execFileSync } = require('child_process');
           const opts = { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] };
-          const shaFile = path.join(TASKS_BASE, ticketId, '.last-commit-sha');
+          const shaFile = path.join(TASKS_BASE, safeTicketPath(ticketId), '.last-commit-sha');
           const headSha = execFileSync('git', ['rev-parse', 'HEAD'], opts).trim();
 
           let baseBranch = 'origin/main';
@@ -188,7 +197,7 @@ const WORKFLOWS = [
       { step: STEPS.check, verify: (ticketId) => {
         // Check is proven if all required report files exist
         try {
-          const dir = path.join(TASKS_BASE, ticketId);
+          const dir = path.join(TASKS_BASE, safeTicketPath(ticketId));
           const required = ['code-review.check.md', 'tests.check.md', 'completion.check.md', 'README.md'];
           if (!required.every(f => fs.existsSync(path.join(dir, f)))) return false;
           // At least one QA report must exist (qa-*.check.md)
@@ -260,7 +269,7 @@ const WORKFLOWS = [
             10
           );
           if (commentCount > 0) {
-            const accountabilityFile = path.join(TASKS_BASE, ticketId, 'review-accountability.json');
+            const accountabilityFile = path.join(TASKS_BASE, safeTicketPath(ticketId), 'review-accountability.json');
             if (!fs.existsSync(accountabilityFile)) return false;
             const entries = JSON.parse(fs.readFileSync(accountabilityFile, 'utf-8'));
             if (!Array.isArray(entries) || entries.length < commentCount) return false;
@@ -290,7 +299,7 @@ const WORKFLOWS = [
       { step: STEPS.reports, verify: (ticketId) => {
         // Reports is proven if all required check files exist and show APPROVED/COMPLETE
         try {
-          const dir = path.join(TASKS_BASE, ticketId);
+          const dir = path.join(TASKS_BASE, safeTicketPath(ticketId));
           const required = [
             { file: 'tests.check.md',       pattern: /Status:\s*APPROVED/i },
             { file: 'code-review.check.md',  pattern: /Status:\s*APPROVED/i },
@@ -631,7 +640,7 @@ function getTicketId() {
 }
 
 function loadStateFile(ticketId, stateFile) {
-  const p = path.join(TASKS_BASE, ticketId, stateFile);
+  const p = path.join(TASKS_BASE, safeTicketPath(ticketId), stateFile);
   try {
     return JSON.parse(fs.readFileSync(p, 'utf-8'));
   } catch {
@@ -639,7 +648,7 @@ function loadStateFile(ticketId, stateFile) {
     // may not exist if the state was written before per-workflow split.
     // Try the legacy .workflow-state.json and check the workflow field matches.
     if (stateFile !== '.workflow-state.json' && stateFile.endsWith('.workflow-state.json')) {
-      const legacyPath = path.join(TASKS_BASE, ticketId, '.workflow-state.json');
+      const legacyPath = path.join(TASKS_BASE, safeTicketPath(ticketId), '.workflow-state.json');
       try {
         const legacy = JSON.parse(fs.readFileSync(legacyPath, 'utf-8'));
         // Derive expected workflow name from stateFile: .work-pr.workflow-state.json -> work-pr
@@ -662,7 +671,7 @@ function getCurrentStep(state, steps) {
 }
 
 function loadEvidence(ticketId, evidenceFile) {
-  const p = path.join(TASKS_BASE, ticketId, evidenceFile);
+  const p = path.join(TASKS_BASE, safeTicketPath(ticketId), evidenceFile);
   try {
     return JSON.parse(fs.readFileSync(p, 'utf-8'));
   } catch {
@@ -672,7 +681,7 @@ function loadEvidence(ticketId, evidenceFile) {
 
 // Atomic evidence writes — write to tmp then rename
 function saveEvidence(ticketId, evidenceFile, evidence) {
-  const dir = path.join(TASKS_BASE, ticketId);
+  const dir = path.join(TASKS_BASE, safeTicketPath(ticketId));
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   const target = path.join(dir, evidenceFile);
   const tmp = `${target}.tmp.${process.pid}`;
@@ -907,7 +916,7 @@ function handlePreToolUse(hookData) {
             const tokenData = {
               agent: normalizeAgentName(detectedAgent),
               timestamp: Date.now(),
-              tasksBase: ticketId ? path.join(TASKS_BASE, ticketId) : null,
+              tasksBase: ticketId ? path.join(TASKS_BASE, safeTicketPath(ticketId)) : null,
             };
             fs.writeSync(fd, JSON.stringify(tokenData));
           } finally {
@@ -1072,7 +1081,7 @@ function handlePostToolUse(hookData) {
 
     // (Patch 14) Strengthen pr evidence: verify .pr-update-sha matches HEAD
     if (wf.name === 'work' && matchedStep === STEPS.pr) {
-      const tasksDir = path.join(TASKS_BASE, ticketId);
+      const tasksDir = path.join(TASKS_BASE, safeTicketPath(ticketId));
       const prShaFile = path.join(tasksDir, '.pr-update-sha');
       let prShaOk = false;
       try {

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -118,6 +118,7 @@ const WORKFLOWS = [
         catch { return false; }
       }},
       { step: STEPS.spec, verify: (ticketId) => {
+        // safeTicketPath() converts #N → GH-N via cached config.safeTicketId()
         try { return fs.existsSync(path.join(TASKS_BASE, safeTicketPath(ticketId), 'spec.md')); }
         catch { return false; }
       }},

--- a/workflows/lib/hooks/session-guard.js
+++ b/workflows/lib/hooks/session-guard.js
@@ -366,11 +366,7 @@ function isCheckWorkflowActive(ticketId) {
 
     const tasksBase = getTasksBase();
     let safeId = ticketId;
-    try {
-      const tp = require(path.join(__dirname, '..', 'ticket-provider'));
-      const pc = tp.getProviderConfig({ skipPrompt: true });
-      safeId = tp.sanitizeTicketIdForPath(ticketId, pc);
-    } catch {}
+    try { safeId = require(path.join(__dirname, '..', 'config')).safeTicketId(ticketId); } catch {}
     const resolved = path.resolve(tasksBase, safeId, '.check.workflow-state.json');
     // Guard against path traversal — resolved path must stay under tasksBase
     if (!resolved.startsWith(path.resolve(tasksBase) + path.sep)) return false;

--- a/workflows/lib/hooks/session-guard.js
+++ b/workflows/lib/hooks/session-guard.js
@@ -365,7 +365,13 @@ function isCheckWorkflowActive(ticketId) {
     if (!ticketId || /[/\\:\0]/.test(ticketId)) return false;
 
     const tasksBase = getTasksBase();
-    const resolved = path.resolve(tasksBase, ticketId, '.check.workflow-state.json');
+    let safeId = ticketId;
+    try {
+      const tp = require(path.join(__dirname, '..', 'ticket-provider'));
+      const pc = tp.getProviderConfig({ skipPrompt: true });
+      safeId = tp.sanitizeTicketIdForPath(ticketId, pc);
+    } catch {}
+    const resolved = path.resolve(tasksBase, safeId, '.check.workflow-state.json');
     // Guard against path traversal — resolved path must stay under tasksBase
     if (!resolved.startsWith(path.resolve(tasksBase) + path.sep)) return false;
 

--- a/workflows/lib/scripts/__tests__/get-ticket-id-gh.test.js
+++ b/workflows/lib/scripts/__tests__/get-ticket-id-gh.test.js
@@ -26,18 +26,18 @@ describe('get-ticket-id GH-pattern support', () => {
   beforeEach(() => { resetEnv(); });
   after(() => { Object.assign(process.env, originalEnv); });
 
-  it('extracts GH-56 from worktree path as #56', () => {
+  it('extracts GH-56 from worktree path as GH-56', () => {
     process.env.TICKET_PROVIDER = 'github';
     const { getCurrentTaskId } = freshRequire('../get-ticket-id');
     const result = getCurrentTaskId('/home/user/worktrees/my-project-GH-56');
-    assert.equal(result, '#56');
+    assert.equal(result, 'GH-56');
   });
 
   it('extracts GH-123 from worktree path (case insensitive)', () => {
     process.env.TICKET_PROVIDER = 'github';
     const { getCurrentTaskId } = freshRequire('../get-ticket-id');
     const result = getCurrentTaskId('/home/user/worktrees/my-project-gh-123');
-    assert.equal(result, '#123');
+    assert.equal(result, 'GH-123');
   });
 
   it('still extracts PROJ-123 (Jira) from path when not github provider', () => {
@@ -53,6 +53,6 @@ describe('get-ticket-id GH-pattern support', () => {
     const { getCurrentTaskId } = freshRequire('../get-ticket-id');
     // GH-56 should match before the numeric fallback
     const result = getCurrentTaskId('/home/user/worktrees/my-project-GH-56');
-    assert.equal(result, '#56');
+    assert.equal(result, 'GH-56');
   });
 });

--- a/workflows/lib/scripts/get-ticket-id.js
+++ b/workflows/lib/scripts/get-ticket-id.js
@@ -15,7 +15,7 @@ function getCurrentTaskId(cwd = process.cwd()) {
   // Try GH-XX pattern first (for GitHub Issues worktree paths like my-project-GH-56)
   const ghMatch = cwd.match(GH_PATTERN);
   if (ghMatch) {
-    return '#' + ghMatch[1];
+    return 'GH-' + ghMatch[1];
   }
 
   // Try to get from worktree folder name (Jira/Linear: PROJ-123)
@@ -34,7 +34,7 @@ function getCurrentTaskId(cwd = process.cwd()) {
     // Check GH-XX pattern in branch name
     const branchGhMatch = branch.match(GH_PATTERN);
     if (branchGhMatch) {
-      return '#' + branchGhMatch[1];
+      return 'GH-' + branchGhMatch[1];
     }
     const branchMatch = branch.match(TICKET_PATTERN);
     if (branchMatch) {
@@ -52,11 +52,11 @@ function getCurrentTaskId(cwd = process.cwd()) {
     const providerConfig = tp.getProviderConfig({ skipPrompt: true });
     if (providerConfig && providerConfig.provider === 'github') {
       const trailingNum = cwd.match(/[-/](\d+)\/?$/);
-      if (trailingNum) return '#' + trailingNum[1];
+      if (trailingNum) return 'GH-' + trailingNum[1];
       try {
         const branch = execSync('git branch --show-current', { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
         const branchTrailingNum = branch.match(/[-/](\d+)$/);
-        if (branchTrailingNum) return '#' + branchTrailingNum[1];
+        if (branchTrailingNum) return 'GH-' + branchTrailingNum[1];
       } catch {}
     }
   } catch {}

--- a/workflows/lib/scripts/get-ticket-id.js
+++ b/workflows/lib/scripts/get-ticket-id.js
@@ -13,6 +13,7 @@ const GH_PATTERN = /GH-(\d+)/i;
 
 function getCurrentTaskId(cwd = process.cwd()) {
   // Try GH-XX pattern first (for GitHub Issues worktree paths like my-project-GH-56)
+  // Return GH-N (path-safe) instead of #N to avoid filesystem issues with # in directory names
   const ghMatch = cwd.match(GH_PATTERN);
   if (ghMatch) {
     return 'GH-' + ghMatch[1];

--- a/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -344,6 +344,26 @@ describe('tdd-phase-state CLI', () => {
     });
   });
 
+  describe('GitHub Issues ticket ID sanitization', () => {
+    it('#NNN ticket IDs resolve to the same path as GH-NNN', () => {
+      // Init with #144 format
+      const { exitCode: initExit } = runCli('init "#144"', homeDir);
+      assert.strictEqual(initExit, 0);
+
+      // The state should be stored under GH-144, not #144
+      const ghState = readState(homeDir, 'GH-144');
+      assert.strictEqual(ghState.currentPhase, 'red');
+      assert.strictEqual(ghState.currentCycle, 1);
+
+      // Reading current with #144 should find the same state
+      const { stdout, exitCode } = runCli('current "#144"', homeDir);
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.phase, 'red');
+      assert.strictEqual(result.cycle, 1);
+    });
+  });
+
   describe('token gating', () => {
     it('record-red fails without token when WORK_TDD_TOKEN_SKIP is not set', () => {
       runCli('init TEST-TOK', homeDir);

--- a/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -346,21 +346,28 @@ describe('tdd-phase-state CLI', () => {
 
   describe('GitHub Issues ticket ID sanitization', () => {
     it('#NNN ticket IDs resolve to the same path as GH-NNN', () => {
-      // Init with #144 format
-      const { exitCode: initExit } = runCli('init "#144"', homeDir);
-      assert.strictEqual(initExit, 0);
+      const origProvider = process.env.TICKET_PROVIDER;
+      process.env.TICKET_PROVIDER = 'github';
+      try {
+        // Init with #144 format
+        const { exitCode: initExit } = runCli('init "#144"', homeDir);
+        assert.strictEqual(initExit, 0);
 
-      // The state should be stored under GH-144, not #144
-      const ghState = readState(homeDir, 'GH-144');
-      assert.strictEqual(ghState.currentPhase, 'red');
-      assert.strictEqual(ghState.currentCycle, 1);
+        // The state should be stored under GH-144, not #144
+        const ghState = readState(homeDir, 'GH-144');
+        assert.strictEqual(ghState.currentPhase, 'red');
+        assert.strictEqual(ghState.currentCycle, 1);
 
-      // Reading current with #144 should find the same state
-      const { stdout, exitCode } = runCli('current "#144"', homeDir);
-      assert.strictEqual(exitCode, 0);
-      const result = JSON.parse(stdout);
-      assert.strictEqual(result.phase, 'red');
-      assert.strictEqual(result.cycle, 1);
+        // Reading current with #144 should find the same state
+        const { stdout, exitCode } = runCli('current "#144"', homeDir);
+        assert.strictEqual(exitCode, 0);
+        const result = JSON.parse(stdout);
+        assert.strictEqual(result.phase, 'red');
+        assert.strictEqual(result.cycle, 1);
+      } finally {
+        if (origProvider === undefined) delete process.env.TICKET_PROVIDER;
+        else process.env.TICKET_PROVIDER = origProvider;
+      }
     });
   });
 

--- a/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -352,7 +352,7 @@ describe('tdd-phase-state CLI', () => {
         // Init with #144 format
         const { exitCode: initExit } = runCli('init "#144"', homeDir);
         assert.strictEqual(initExit, 0);
-
+        // TICKET_PROVIDER=github is set at line 350, so sanitizeTicketIdForPath converts #N → GH-N
         // The state should be stored under GH-144, not #144
         const ghState = readState(homeDir, 'GH-144');
         assert.strictEqual(ghState.currentPhase, 'red');

--- a/workflows/work-implement/hooks/work-implement-enforce.js
+++ b/workflows/work-implement/hooks/work-implement-enforce.js
@@ -141,7 +141,13 @@ function checkTddPhase(filePath) {
       taskBase = require('path').join(process.env.HOME, 'worktrees', 'tasks');
     }
     // Use TASKS_BASE from env, config module, or default HOME-based fallback
-    const statePath = require('path').join(taskBase, ticketId, 'tdd-phase.json');
+    let safeTicketId = ticketId;
+    try {
+      const tp = require(require('path').join(__dirname, '..', '..', 'lib', 'ticket-provider'));
+      const pc = tp.getProviderConfig({ skipPrompt: true });
+      safeTicketId = tp.sanitizeTicketIdForPath(ticketId, pc);
+    } catch {}
+    const statePath = require('path').join(taskBase, safeTicketId, 'tdd-phase.json');
     if (!require('fs').existsSync(statePath)) return 'no-file';
 
     const state = JSON.parse(require('fs').readFileSync(statePath, 'utf8'));

--- a/workflows/work-implement/hooks/work-implement-enforce.js
+++ b/workflows/work-implement/hooks/work-implement-enforce.js
@@ -142,11 +142,7 @@ function checkTddPhase(filePath) {
     }
     // Use TASKS_BASE from env, config module, or default HOME-based fallback
     let safeTicketId = ticketId;
-    try {
-      const tp = require(require('path').join(__dirname, '..', '..', 'lib', 'ticket-provider'));
-      const pc = tp.getProviderConfig({ skipPrompt: true });
-      safeTicketId = tp.sanitizeTicketIdForPath(ticketId, pc);
-    } catch {}
+    try { safeTicketId = require(require('path').join(__dirname, '..', '..', 'lib', 'config')).safeTicketId(ticketId); } catch {}
     const statePath = require('path').join(taskBase, safeTicketId, 'tdd-phase.json');
     if (!require('fs').existsSync(statePath)) return 'no-file';
 

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -35,13 +35,22 @@ const TOKEN_MAX_AGE_MS = 10_000; // 10 seconds
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+function sanitizeId(ticketId) {
+  try {
+    const tp = require('../lib/ticket-provider');
+    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+    return tp.sanitizeTicketIdForPath(ticketId, providerConfig);
+  } catch { return ticketId; }
+}
+
 function getStatePath(ticketId) {
   if (!ticketId || /\.\./.test(ticketId) || /\\/.test(ticketId)) {
     throw new Error(`Invalid ticket ID: ${ticketId}`);
   }
   // Resolve from TASKS_BASE env, config module, or default HOME-based path
   const base = process.env.TASKS_BASE || (config && config.TASKS_BASE) || path.join(process.env.HOME, 'worktrees', 'tasks');
-  const resolved = path.resolve(base, ticketId, 'tdd-phase.json');
+  const safeId = sanitizeId(ticketId);
+  const resolved = path.resolve(base, safeId, 'tdd-phase.json');
   // Validate resolved path stays within TASKS_BASE (prevents traversal)
   if (!resolved.startsWith(path.resolve(base) + path.sep)) {
     throw new Error(`Invalid ticket ID: ${ticketId}`);

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -36,11 +36,8 @@ const TOKEN_MAX_AGE_MS = 10_000; // 10 seconds
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function sanitizeId(ticketId) {
-  try {
-    const tp = require('../lib/ticket-provider');
-    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
-    return tp.sanitizeTicketIdForPath(ticketId, providerConfig);
-  } catch { return ticketId; }
+  try { return require('../lib/config').safeTicketId(ticketId); }
+  catch { return ticketId; }
 }
 
 function getStatePath(ticketId) {

--- a/workflows/work-pr/work-pr.workflow.js
+++ b/workflows/work-pr/work-pr.workflow.js
@@ -25,12 +25,14 @@ const { execSync } = require('child_process');
 const getConfig = require(path.join(__dirname, '..', 'lib', 'get-config'));
 const WORKTREES_BASE = getConfig.require('WORKTREES_BASE');
 const TASKS_BASE = getConfig('TASKS_BASE') || path.join(WORKTREES_BASE, 'tasks');
-const { normalizeTicketId } = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
+const tp = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
+const { normalizeTicketId } = tp;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function getTasksDir(ticketId) {
-  return path.join(TASKS_BASE, ticketId);
+  const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+  return path.join(TASKS_BASE, tp.sanitizeTicketIdForPath(ticketId, providerConfig));
 }
 
 function getWorktreeDir(ticketId) {

--- a/workflows/work-pr/work-pr.workflow.js
+++ b/workflows/work-pr/work-pr.workflow.js
@@ -25,14 +25,13 @@ const { execSync } = require('child_process');
 const getConfig = require(path.join(__dirname, '..', 'lib', 'get-config'));
 const WORKTREES_BASE = getConfig.require('WORKTREES_BASE');
 const TASKS_BASE = getConfig('TASKS_BASE') || path.join(WORKTREES_BASE, 'tasks');
-const tp = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
-const { normalizeTicketId } = tp;
+const { normalizeTicketId } = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
+const safeTicketId = require(path.join(__dirname, '..', 'lib', 'config')).safeTicketId;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function getTasksDir(ticketId) {
-  const providerConfig = tp.getProviderConfig({ skipPrompt: true });
-  return path.join(TASKS_BASE, tp.sanitizeTicketIdForPath(ticketId, providerConfig));
+  return path.join(TASKS_BASE, safeTicketId(ticketId));
 }
 
 function getWorktreeDir(ticketId) {

--- a/workflows/work/hooks/enforce-review-accountability.js
+++ b/workflows/work/hooks/enforce-review-accountability.js
@@ -86,7 +86,13 @@ async function main() {
   // Check for accountability file
   const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
   const TASKS_BASE = getConfig('TASKS_BASE') || path.join(getConfig.orExit('WORKTREES_BASE'), 'tasks');
-  const accountabilityFile = path.join(TASKS_BASE, ticketId, 'review-accountability.json');
+  let safeTicketId = ticketId;
+  try {
+    const tp = require(path.join(__dirname, '..', '..', 'lib', 'ticket-provider'));
+    const pc = tp.getProviderConfig({ skipPrompt: true });
+    safeTicketId = tp.sanitizeTicketIdForPath(ticketId, pc);
+  } catch {}
+  const accountabilityFile = path.join(TASKS_BASE, safeTicketId, 'review-accountability.json');
 
   if (!fs.existsSync(accountabilityFile)) {
     process.stderr.write(

--- a/workflows/work/hooks/enforce-review-accountability.js
+++ b/workflows/work/hooks/enforce-review-accountability.js
@@ -87,11 +87,7 @@ async function main() {
   const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
   const TASKS_BASE = getConfig('TASKS_BASE') || path.join(getConfig.orExit('WORKTREES_BASE'), 'tasks');
   let safeTicketId = ticketId;
-  try {
-    const tp = require(path.join(__dirname, '..', '..', 'lib', 'ticket-provider'));
-    const pc = tp.getProviderConfig({ skipPrompt: true });
-    safeTicketId = tp.sanitizeTicketIdForPath(ticketId, pc);
-  } catch {}
+  try { safeTicketId = require(path.join(__dirname, '..', '..', 'lib', 'config')).safeTicketId(ticketId); } catch {}
   const accountabilityFile = path.join(TASKS_BASE, safeTicketId, 'review-accountability.json');
 
   if (!fs.existsSync(accountabilityFile)) {

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1285,7 +1285,13 @@ async function main() {
                 ? 'Blocking comment addressed during follow-up'
                 : 'Non-blocking low-priority comment',
           }));
-          const accountabilityPath = path.join(tasksBase, ticketId, 'review-accountability.json');
+          let safeTicketId = ticketId;
+          try {
+            const tp = require(path.join(__dirname, '..', '..', 'lib', 'ticket-provider'));
+            const pc = tp.getProviderConfig({ skipPrompt: true });
+            safeTicketId = tp.sanitizeTicketIdForPath(ticketId, pc);
+          } catch {}
+          const accountabilityPath = path.join(tasksBase, safeTicketId, 'review-accountability.json');
           fs.mkdirSync(path.dirname(accountabilityPath), { recursive: true });
           fs.writeFileSync(accountabilityPath, JSON.stringify(entries, null, 2));
         }

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1286,11 +1286,7 @@ async function main() {
                 : 'Non-blocking low-priority comment',
           }));
           let safeTicketId = ticketId;
-          try {
-            const tp = require(path.join(__dirname, '..', '..', 'lib', 'ticket-provider'));
-            const pc = tp.getProviderConfig({ skipPrompt: true });
-            safeTicketId = tp.sanitizeTicketIdForPath(ticketId, pc);
-          } catch {}
+          try { safeTicketId = require(path.join(__dirname, '..', '..', 'lib', 'config')).safeTicketId(ticketId); } catch {}
           const accountabilityPath = path.join(tasksBase, safeTicketId, 'review-accountability.json');
           fs.mkdirSync(path.dirname(accountabilityPath), { recursive: true });
           fs.writeFileSync(accountabilityPath, JSON.stringify(entries, null, 2));

--- a/workflows/work/work-actions.js
+++ b/workflows/work/work-actions.js
@@ -22,11 +22,8 @@ function getTasksBase() {
 // TASKS_BASE is lazy-resolved on first use via getTasksBase() — safe at require() time
 
 function safeId(ticketId) {
-  try {
-    const tp = require('../lib/ticket-provider');
-    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
-    return tp.sanitizeTicketIdForPath(ticketId, providerConfig);
-  } catch { return ticketId; }
+  try { return require('../lib/config').safeTicketId(ticketId); }
+  catch { return ticketId; }
 }
 
 /**

--- a/workflows/work/work-actions.js
+++ b/workflows/work/work-actions.js
@@ -21,6 +21,14 @@ function getTasksBase() {
 }
 // TASKS_BASE is lazy-resolved on first use via getTasksBase() — safe at require() time
 
+function safeId(ticketId) {
+  try {
+    const tp = require('../lib/ticket-provider');
+    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+    return tp.sanitizeTicketIdForPath(ticketId, providerConfig);
+  } catch { return ticketId; }
+}
+
 /**
  * Load actions from .work-actions.json for a given ticket.
  * @param {string} ticketId
@@ -28,7 +36,7 @@ function getTasksBase() {
  */
 function loadActions(ticketId) {
   try {
-    const filePath = path.join(getTasksBase(), ticketId, '.work-actions.json');
+    const filePath = path.join(getTasksBase(), safeId(ticketId), '.work-actions.json');
     return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
   } catch {
     return [];
@@ -42,7 +50,7 @@ function loadActions(ticketId) {
  */
 function appendAction(ticketId, action) {
   try {
-    const dir = path.join(getTasksBase(), ticketId);
+    const dir = path.join(getTasksBase(), safeId(ticketId));
     const filePath = path.join(dir, '.work-actions.json');
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -66,10 +66,21 @@ const CHECK_AGENTS = [
 ];
 
 /**
+ * Sanitize ticket ID for file-system paths (#N → GH-N for GitHub Issues).
+ */
+function safeId(ticketId) {
+  try {
+    const tp = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
+    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+    return tp.sanitizeTicketIdForPath(ticketId, providerConfig);
+  } catch { return ticketId; }
+}
+
+/**
  * Get state file path for a ticket
  */
 function getStatePath(ticketId) {
-  return path.join(TASKS_BASE, ticketId, '.work-state.json');
+  return path.join(TASKS_BASE, safeId(ticketId), '.work-state.json');
 }
 
 /**
@@ -91,7 +102,7 @@ function loadState(ticketId) {
  * Save state for a ticket
  */
 function saveState(ticketId, state) {
-  const taskDir = path.join(TASKS_BASE, ticketId);
+  const taskDir = path.join(TASKS_BASE, safeId(ticketId));
   if (!fs.existsSync(taskDir)) {
     fs.mkdirSync(taskDir, { recursive: true });
   }
@@ -142,7 +153,7 @@ function autoInitTdd(ticketId) {
   try {
     // Validate ticketId — reject traversal chars and verify resolved path stays within TASKS_BASE
     if (!ticketId || /\.\./.test(ticketId) || /\\/.test(ticketId)) return;
-    const tddStatePath = path.join(TASKS_BASE, ticketId, 'tdd-phase.json');
+    const tddStatePath = path.join(TASKS_BASE, safeId(ticketId), 'tdd-phase.json');
     if (!path.resolve(tddStatePath).startsWith(path.resolve(TASKS_BASE) + path.sep)) return;
     // Create directory and write initial RED phase state
     fs.mkdirSync(path.dirname(tddStatePath), { recursive: true });
@@ -155,7 +166,7 @@ function autoInitTdd(ticketId) {
     if (err && err.code === 'EEXIST') return; // already initialized
     // fail-open: TDD init failure must not block step transition
     if (created) {
-      try { fs.unlinkSync(path.join(TASKS_BASE, ticketId, 'tdd-phase.json')); } catch {}
+      try { fs.unlinkSync(path.join(TASKS_BASE, safeId(ticketId), 'tdd-phase.json')); } catch {}
     }
   } finally {
     if (fd !== undefined) {
@@ -362,7 +373,7 @@ Steps:
  * @returns {{ path: string, index: number }}
  */
 function getNextSubtaskStatePath(ticketId) {
-  const taskDir = path.join(TASKS_BASE, ticketId);
+  const taskDir = path.join(TASKS_BASE, safeId(ticketId));
   const prefix = `.work-state-${ticketId}-subtask-`;
   let maxIndex = 0;
 
@@ -395,7 +406,7 @@ function getNextSubtaskStatePath(ticketId) {
  */
 function initSubtaskState(ticketId, description = '') {
   const { path: statePath, index } = getNextSubtaskStatePath(ticketId);
-  const taskDir = path.join(TASKS_BASE, ticketId);
+  const taskDir = path.join(TASKS_BASE, safeId(ticketId));
 
   if (!fs.existsSync(taskDir)) {
     fs.mkdirSync(taskDir, { recursive: true });
@@ -432,7 +443,7 @@ function initSubtaskState(ticketId, description = '') {
  * @returns {object|null}
  */
 function loadActiveSubtaskState(ticketId) {
-  const taskDir = path.join(TASKS_BASE, ticketId);
+  const taskDir = path.join(TASKS_BASE, safeId(ticketId));
   const prefix = `.work-state-${ticketId}-subtask-`;
 
   if (!fs.existsSync(taskDir)) return null;
@@ -472,7 +483,7 @@ function loadActiveSubtaskState(ticketId) {
  * @returns {object} the completed subtask state
  */
 function completeSubtask(ticketId, subtaskIndex) {
-  const taskDir = path.join(TASKS_BASE, ticketId);
+  const taskDir = path.join(TASKS_BASE, safeId(ticketId));
   const prefix = `.work-state-${ticketId}-subtask-`;
   const statePath = path.join(taskDir, `${prefix}${subtaskIndex}.json`);
 

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -374,7 +374,7 @@ Steps:
  */
 function getNextSubtaskStatePath(ticketId) {
   const taskDir = path.join(TASKS_BASE, safeId(ticketId));
-  const prefix = `.work-state-${ticketId}-subtask-`;
+  const prefix = `.work-state-${safeId(ticketId)}-subtask-`;
   let maxIndex = 0;
 
   if (fs.existsSync(taskDir)) {
@@ -444,7 +444,7 @@ function initSubtaskState(ticketId, description = '') {
  */
 function loadActiveSubtaskState(ticketId) {
   const taskDir = path.join(TASKS_BASE, safeId(ticketId));
-  const prefix = `.work-state-${ticketId}-subtask-`;
+  const prefix = `.work-state-${safeId(ticketId)}-subtask-`;
 
   if (!fs.existsSync(taskDir)) return null;
 
@@ -484,7 +484,7 @@ function loadActiveSubtaskState(ticketId) {
  */
 function completeSubtask(ticketId, subtaskIndex) {
   const taskDir = path.join(TASKS_BASE, safeId(ticketId));
-  const prefix = `.work-state-${ticketId}-subtask-`;
+  const prefix = `.work-state-${safeId(ticketId)}-subtask-`;
   const statePath = path.join(taskDir, `${prefix}${subtaskIndex}.json`);
 
   if (!fs.existsSync(statePath)) {

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -65,16 +65,7 @@ const CHECK_AGENTS = [
   // QA agents are dynamic based on impacted apps
 ];
 
-/**
- * Sanitize ticket ID for file-system paths (#N → GH-N for GitHub Issues).
- */
-function safeId(ticketId) {
-  try {
-    const tp = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
-    const providerConfig = tp.getProviderConfig({ skipPrompt: true });
-    return tp.sanitizeTicketIdForPath(ticketId, providerConfig);
-  } catch { return ticketId; }
-}
+const safeId = config.safeTicketId;
 
 /**
  * Get state file path for a ticket

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -65,6 +65,7 @@ const CHECK_AGENTS = [
   // QA agents are dynamic based on impacted apps
 ];
 
+// Delegates to config.safeTicketId() — provider config is cached, resolved once per process
 const safeId = config.safeTicketId;
 
 /**


### PR DESCRIPTION
## Existing Behavior

- When using GitHub Issues as the ticket provider, `get-ticket-id.js` returns ticket IDs with a `#` prefix (e.g., `#144`) for worktree paths and branch names matching the `GH-XX` pattern.
- Task directory paths are constructed directly from the raw ticket ID, so GitHub Issues tickets create directories named `#144` instead of `GH-144`.
- All workflow state files (`work-state.js`, `tdd-phase-state.js`, `enforce-step-workflow.js`, `qa-progress.js`, etc.) write to and read from these `#`-prefixed paths, causing breakage when the ticket ID is sourced differently across calls.
- The `#` character is not valid in directory names on some file systems and causes path resolution failures.

## Intended New Behavior

- `get-ticket-id.js` now returns `GH-<number>` (e.g., `GH-144`) consistently for all GitHub Issues ticket ID detections from worktree paths and branch names.
- All modules that build task directory paths (`work-state.js`, `tdd-phase-state.js`, `work-actions.js`, `work-pr.workflow.js`, `qa-progress.js`, `config.js`, `session-guard.js`, and all enforce/review hooks) call `tp.sanitizeTicketIdForPath()` before joining the ticket ID into a file-system path.
- `#NNN` format ticket IDs passed at runtime are transparently converted to `GH-NNN` paths, so legacy callers still work without changes.
- A new integration test in `tdd-phase-state.test.js` verifies that `#144` and `GH-144` resolve to the same on-disk state.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

For backend/CLI verification:

1. Set up a GitHub Issues worktree with a path ending in `GH-144` (or a branch named `fix/GH-144-something`) and confirm `TICKET_PROVIDER=github` is set.
2. Run any workflow step command (e.g., `work ticket GH-144`) and verify the task directory is created as `$TASKS_BASE/GH-144/` — not `$TASKS_BASE/#144/`.
3. Pass a `#144` formatted ticket ID directly to `tdd-phase-state.js init "#144"` and verify:
   - Exit code is `0`.
   - The state file lands at `$TASKS_BASE/GH-144/tdd-phase.json`.
   - Running `tdd-phase-state.js current "#144"` reads back the same state.
4. Run the existing test suite:
   ```bash
   node --test workflows/lib/scripts/__tests__/get-ticket-id-gh.test.js
   node --test workflows/work-implement/__tests__/tdd-phase-state.test.js
   ```
   All assertions for `GH-XX` extraction and `#NNN` → `GH-NNN` path resolution should pass.

### Test Results

Test files modified in this PR: `get-ticket-id-gh.test.js`, `tdd-phase-state.test.js`

Closes #144