### PR TITLE
feat(code-review): add /code-review skill to launch code review against target branch

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,61 +1,86 @@
 ---
 name: code-review
-description: Review code changes against main using code-checker agent
+description: Review code changes against target branch using code-checker agent
 user-invocable: true
-allowed-tools: Agent, Bash, Read, Grep, Glob
+allowed-tools: Task, Bash, Read, Grep, Glob, AskUserQuestion
 ---
 
-# /code-review — Code Review Against Main
+# /code-review — Code Review Against Target Branch
 
-Review all changes on the current branch compared to main using the code-checker agent.
+Review all changes on the current branch compared to the target branch using the code-checker agent.
 
 ## Instructions
 
 ### Step 1: Detect target branch and verify changes
 
 ```bash
-# Use repo-defined BASE_BRANCH if available, otherwise detect
-if [ -n "$BASE_BRANCH" ]; then
-  TARGET_BRANCH="$BASE_BRANCH"
-elif TARGET_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}') && [ -n "$TARGET_BRANCH" ]; then
-  :
+# Reuse the centralized getBaseBranch() from the plugin (returns "origin/<branch>")
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+if [ -n "$PLUGIN_ROOT" ] && [ -f "$PLUGIN_ROOT/workflows/lib/config.js" ]; then
+  TARGET_REF=$(node -e "const c = require('$PLUGIN_ROOT/workflows/lib/config.js'); console.log(c.getBaseBranch())")
 else
-  for branch in main master dev develop; do
-    if git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
-      TARGET_BRANCH="$branch"
-      break
+  # Fallback: manual detection
+  TARGET_REF=""
+  if [ -n "$BASE_BRANCH" ]; then
+    SANITIZED=$(echo "$BASE_BRANCH" | sed 's|^refs/remotes/||; s|^origin/||')
+    if git rev-parse --verify "origin/$SANITIZED" >/dev/null 2>&1; then
+      TARGET_REF="origin/$SANITIZED"
     fi
-  done
+  fi
+  if [ -z "$TARGET_REF" ]; then
+    HEAD_REF=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/||')
+    if [ -n "$HEAD_REF" ]; then
+      TARGET_REF="$HEAD_REF"
+    fi
+  fi
+  if [ -z "$TARGET_REF" ]; then
+    for branch in main dev master; do
+      if git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+        TARGET_REF="origin/$branch"
+        break
+      fi
+    done
+  fi
 fi
 
-if [ -z "$TARGET_BRANCH" ]; then
+if [ -z "$TARGET_REF" ]; then
   echo "ERROR: Could not detect target branch."
   echo "Set BASE_BRANCH in your environment or .envrc, or specify manually."
   exit 1
 fi
 
-echo "Target branch: origin/$TARGET_BRANCH"
+echo "Target branch: $TARGET_REF"
 
-CHANGED_FILES=$(git diff "origin/$TARGET_BRANCH...HEAD" --name-only)
+# Fetch latest to avoid stale comparisons
+git fetch origin "${TARGET_REF#origin/}" --quiet 2>/dev/null || true
+
+# Exclude deleted files (--diff-filter=d) so the reviewer doesn't try to read removed files
+CHANGED_FILES=$(git diff "$TARGET_REF...HEAD" --name-only --diff-filter=d)
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "No changes found compared to $TARGET_REF."
+  exit 0
+fi
+
 echo "$CHANGED_FILES"
 ```
 
 If `CHANGED_FILES` is empty, inform the user there are no changes to review and stop.
 
-If the target branch could not be detected, ask the user which branch to compare against.
+If the target branch could not be detected (exit 1), use AskUserQuestion to ask the user which branch to compare against.
 
 ### Step 2: Launch code-checker
 
-Launch a **code-checker** agent with this prompt:
+Launch a **code-checker** agent (`Task(code-checker)`) with this prompt:
 
 ```
-Review all changes on the current branch compared to origin/${TARGET_BRANCH}.
+Review all changes on the current branch compared to ${TARGET_REF}.
 
 To get the full diff:
-  git diff origin/${TARGET_BRANCH}...HEAD
+  git diff ${TARGET_REF}...HEAD
 
 To get the list of changed files:
-  git diff origin/${TARGET_BRANCH}...HEAD --name-only
+  git diff ${TARGET_REF}...HEAD --name-only --diff-filter=d
 
 Changed files:
 ${CHANGED_FILES}

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: code-review
+description: Review code changes against main using code-checker agent
+user-invocable: true
+allowed-tools: Agent, Bash, Read, Grep, Glob
+---
+
+# /code-review — Code Review Against Main
+
+Review all changes on the current branch compared to main using the code-checker agent.
+
+## Instructions
+
+### Step 1: Detect target branch and verify changes
+
+```bash
+# Use repo-defined BASE_BRANCH if available, otherwise detect
+if [ -n "$BASE_BRANCH" ]; then
+  TARGET_BRANCH="$BASE_BRANCH"
+elif TARGET_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}') && [ -n "$TARGET_BRANCH" ]; then
+  :
+else
+  for branch in main master dev develop; do
+    if git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+      TARGET_BRANCH="$branch"
+      break
+    fi
+  done
+fi
+
+if [ -z "$TARGET_BRANCH" ]; then
+  echo "ERROR: Could not detect target branch."
+  echo "Set BASE_BRANCH in your environment or .envrc, or specify manually."
+  exit 1
+fi
+
+echo "Target branch: origin/$TARGET_BRANCH"
+
+CHANGED_FILES=$(git diff "origin/$TARGET_BRANCH...HEAD" --name-only)
+echo "$CHANGED_FILES"
+```
+
+If `CHANGED_FILES` is empty, inform the user there are no changes to review and stop.
+
+If the target branch could not be detected, ask the user which branch to compare against.
+
+### Step 2: Launch code-checker
+
+Launch a **code-checker** agent with this prompt:
+
+```
+Review all changes on the current branch compared to origin/${TARGET_BRANCH}.
+
+To get the full diff:
+  git diff origin/${TARGET_BRANCH}...HEAD
+
+To get the list of changed files:
+  git diff origin/${TARGET_BRANCH}...HEAD --name-only
+
+Changed files:
+${CHANGED_FILES}
+
+Follow your full pre-review workflow:
+1. Read task documents (brief.md, spec.md) if they exist
+2. Review all changed implementation files
+3. Review all changed test files
+4. Verify file coverage
+5. Classify the change type
+6. Evaluate against all engineering standards
+7. Produce the report using your standard Report Structure
+
+Output the review directly — do NOT save to a file.
+```
+
+### Step 3: Present results
+
+Show the code-checker's review output to the user.


### PR DESCRIPTION
## Existing Behavior

- No `/code-review` skill exists; developers must manually invoke the code-checker agent and construct the diff command themselves.
- There is no automated way to detect the target branch or enumerate changed files for a review session.

## Intended New Behavior

- A new `/code-review` skill (`skills/code-review/SKILL.md`) automates launching a review against the current branch's diff.
- The skill dynamically detects the target branch via `$BASE_BRANCH`, `git remote show origin`, or a fallback list (`main`, `master`, `dev`, `develop`).
- It enumerates all changed files with `git diff origin/<target>...HEAD --name-only` and passes them plus full diff context to the review agent.
- The skill stops gracefully with a clear error message if no changes are found or the target branch cannot be resolved.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Checkout any branch that has commits ahead of `main`.
2. Run `/code-review` in the tool.
3. Verify the skill detects the target branch (e.g., `main`) and prints `Target branch: origin/main`.
4. Confirm the skill lists the changed files correctly.
5. Confirm the review agent is launched with the correct diff prompt and produces a review report in the terminal.
6. On a branch with no changes ahead of `main`, run `/code-review` and confirm it exits with "no changes to review" without launching the review agent.
7. In an environment where `git remote show origin` fails and no `$BASE_BRANCH` is set, confirm the skill asks the user to specify a branch manually.