### PR TITLE
feat(code-architect): harden prompt with specificity constraints and anti-overengineering guards

### DIFF
--- a/agents/__tests__/code-architect.test.js
+++ b/agents/__tests__/code-architect.test.js
@@ -1,0 +1,201 @@
+/**
+ * Tests for agents/code-architect.md — hardened prompt with specificity
+ * constraints and anti-overengineering guards.
+ *
+ * Run: node --test agents/__tests__/code-architect.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const AGENT_PATH = path.resolve(__dirname, '..', 'code-architect.md');
+const content = fs.readFileSync(AGENT_PATH, 'utf-8');
+const lines = content.split('\n');
+
+// ─── Helper: extract YAML frontmatter ────────────────────────────────────────
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx > 0) {
+      fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+    }
+  }
+  return fm;
+}
+
+const frontmatter = parseFrontmatter(content);
+
+// ─── 1. Frontmatter unchanged ────────────────────────────────────────────────
+
+describe('Frontmatter fields are unchanged', () => {
+  it('name is code-architect', () => {
+    assert.equal(frontmatter.name, 'code-architect');
+  });
+
+  it('tools list is preserved', () => {
+    assert.equal(
+      frontmatter.tools,
+      'Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput'
+    );
+  });
+
+  it('description is preserved', () => {
+    assert.ok(frontmatter.description.startsWith('Designs feature architectures'));
+  });
+
+  it('model is opus', () => {
+    assert.equal(frontmatter.model, 'opus');
+  });
+
+  it('color is blue', () => {
+    assert.equal(frontmatter.color, 'blue');
+  });
+});
+
+// ─── 2. Pattern Anchoring section exists after Working Principles ────────────
+
+describe('Pattern Anchoring section', () => {
+  it('exists in the document', () => {
+    assert.ok(content.includes('### Pattern Anchoring'));
+  });
+
+  it('appears after Working Principles', () => {
+    const wpIdx = content.indexOf('### Working Principles');
+    const paIdx = content.indexOf('### Pattern Anchoring');
+    assert.ok(wpIdx > -1 && paIdx > -1);
+    assert.ok(paIdx > wpIdx, 'Pattern Anchoring must come after Working Principles');
+  });
+
+  it('appears before Output Format', () => {
+    const paIdx = content.indexOf('### Pattern Anchoring');
+    const ofIdx = content.indexOf('### Output Format');
+    assert.ok(paIdx < ofIdx, 'Pattern Anchoring must come before Output Format');
+  });
+});
+
+// ─── 3. Simplicity Constraint section exists after Pattern Anchoring ─────────
+
+describe('Simplicity Constraint section', () => {
+  it('exists in the document', () => {
+    assert.ok(content.includes('### Simplicity Constraint'));
+  });
+
+  it('appears after Pattern Anchoring', () => {
+    const paIdx = content.indexOf('### Pattern Anchoring');
+    const scIdx = content.indexOf('### Simplicity Constraint');
+    assert.ok(scIdx > paIdx, 'Simplicity Constraint must come after Pattern Anchoring');
+  });
+
+  it('mentions "Extending existing modules"', () => {
+    assert.ok(content.includes('Extending existing modules'));
+  });
+
+  it('mentions "explicit justification"', () => {
+    assert.ok(content.includes('explicit justification'));
+  });
+});
+
+// ─── 4. Strict Specificity Rule section exists after Simplicity Constraint ───
+
+describe('Strict Specificity Rule section', () => {
+  it('exists in the document', () => {
+    assert.ok(content.includes('### Strict Specificity Rule'));
+  });
+
+  it('appears after Simplicity Constraint', () => {
+    const scIdx = content.indexOf('### Simplicity Constraint');
+    const ssIdx = content.indexOf('### Strict Specificity Rule');
+    assert.ok(ssIdx > scIdx, 'Strict Specificity Rule must come after Simplicity Constraint');
+  });
+
+  it('contains banned terms list', () => {
+    const banned = [
+      'handle logic',
+      'manage state',
+      'connect components',
+      'process data',
+      'coordinate between',
+    ];
+    for (const term of banned) {
+      assert.ok(
+        content.includes(`"${term}"`),
+        `Banned term "${term}" must appear in Strict Specificity Rule`
+      );
+    }
+  });
+});
+
+// ─── 5. Role Boundary section exists after CRITICAL: NEVER CALL YOURSELF ─────
+
+describe('Role Boundary section', () => {
+  it('exists in the document', () => {
+    assert.ok(content.includes('## ROLE BOUNDARY'));
+  });
+
+  it('appears after CRITICAL: NEVER CALL YOURSELF', () => {
+    const critIdx = content.indexOf('## CRITICAL: NEVER CALL YOURSELF');
+    const rbIdx = content.indexOf('## ROLE BOUNDARY');
+    assert.ok(rbIdx > critIdx, 'ROLE BOUNDARY must come after CRITICAL section');
+  });
+
+  it('appears before Core Capabilities', () => {
+    const rbIdx = content.indexOf('## ROLE BOUNDARY');
+    const ccIdx = content.indexOf('### Core Capabilities');
+    assert.ok(rbIdx < ccIdx, 'ROLE BOUNDARY must come before Core Capabilities');
+  });
+});
+
+// ─── 6. Working Principles #1 enhanced ───────────────────────────────────────
+
+describe('Working Principles #1 enhancement', () => {
+  it('contains "list" and "files" and "inspected" and "line range"', () => {
+    // Find the line with principle #1
+    const wp1Line = lines.find((l) => l.match(/^1\.\s+\*\*Analyze First/));
+    assert.ok(wp1Line, 'Working Principles #1 must exist');
+    assert.ok(wp1Line.includes('list'), '#1 must contain "list"');
+    assert.ok(wp1Line.includes('files'), '#1 must contain "files"');
+    assert.ok(wp1Line.includes('inspected'), '#1 must contain "inspected"');
+    assert.ok(wp1Line.includes('line range'), '#1 must contain "line range"');
+  });
+});
+
+// ─── 7. Working Principles #4 enhanced ───────────────────────────────────────
+
+describe('Working Principles #4 enhancement', () => {
+  it('contains "BEFORE" and "AFTER" and "breaking changes"', () => {
+    const wp4Line = lines.find((l) => l.match(/^4\.\s+\*\*Consider Dependencies/));
+    assert.ok(wp4Line, 'Working Principles #4 must exist');
+    assert.ok(wp4Line.includes('BEFORE'), '#4 must contain "BEFORE"');
+    assert.ok(wp4Line.includes('AFTER'), '#4 must contain "AFTER"');
+    assert.ok(wp4Line.includes('breaking changes'), '#4 must contain "breaking changes"');
+  });
+});
+
+// ─── 8. Output Format item 2 is "Existing Patterns" ─────────────────────────
+
+describe('Output Format item 2', () => {
+  it('is "Existing Patterns"', () => {
+    const of2Line = lines.find((l) => l.match(/^2\.\s+\*\*Existing Patterns\*\*/));
+    assert.ok(of2Line, 'Output Format item 2 must be "Existing Patterns"');
+  });
+
+  it('Output Format has 9 items total', () => {
+    // Find all numbered items after "### Output Format"
+    const ofIdx = lines.findIndex((l) => l.includes('### Output Format'));
+    assert.ok(ofIdx > -1);
+    const ofItems = lines.slice(ofIdx).filter((l) => l.match(/^\d+\.\s+\*\*/));
+    assert.equal(ofItems.length, 9, 'Output Format should have 9 items');
+  });
+});
+
+// ─── 9. Strict Specificity Rule banned terms ─────────────────────────────────
+// (covered in test 4 above)
+
+// ─── 10. Simplicity Constraint content ───────────────────────────────────────
+// (covered in test 3 above)

--- a/agents/__tests__/code-architect.test.js
+++ b/agents/__tests__/code-architect.test.js
@@ -2,7 +2,8 @@
  * Tests for agents/code-architect.md — hardened prompt with specificity
  * constraints and anti-overengineering guards.
  *
- * Run: node --test agents/__tests__/code-architect.test.js (also discovered by scripts/run-tests.sh)
+ * Run: node --test agents/__tests__/code-architect.test.js
+ * Also discovered by scripts/run-tests.sh (searches workflows/, agents/, skills/)
  */
 
 const { describe, it } = require('node:test');
@@ -190,10 +191,16 @@ describe('Output Format item 2', () => {
   });
 
   it('Output Format has 9 items total', () => {
-    // Find all numbered items after "### Output Format"
+    // Find numbered items only within the "### Output Format" section
     const ofIdx = lines.findIndex((l) => l.includes('### Output Format'));
     assert.ok(ofIdx > -1);
-    const ofItems = lines.slice(ofIdx).filter((l) => l.match(/^\d+\.\s+\*\*/));
+    const nextHeadingOffset = lines
+      .slice(ofIdx + 1)
+      .findIndex((l) => l.match(/^###\s+/));
+    const sectionEnd = nextHeadingOffset === -1 ? lines.length : ofIdx + 1 + nextHeadingOffset;
+    const ofItems = lines
+      .slice(ofIdx, sectionEnd)
+      .filter((l) => l.match(/^\d+\.\s+\*\*/));
     assert.equal(ofItems.length, 9, 'Output Format should have 9 items');
   });
 });

--- a/agents/__tests__/code-architect.test.js
+++ b/agents/__tests__/code-architect.test.js
@@ -139,19 +139,19 @@ describe('Strict Specificity Rule section', () => {
 
 describe('Role Boundary section', () => {
   it('exists in the document', () => {
-    assert.ok(content.includes('## ROLE BOUNDARY'));
+    assert.ok(content.includes('## Role Boundary'));
   });
 
   it('appears after CRITICAL: NEVER CALL YOURSELF', () => {
     const critIdx = content.indexOf('## CRITICAL: NEVER CALL YOURSELF');
-    const rbIdx = content.indexOf('## ROLE BOUNDARY');
-    assert.ok(rbIdx > critIdx, 'ROLE BOUNDARY must come after CRITICAL section');
+    const rbIdx = content.indexOf('## Role Boundary');
+    assert.ok(rbIdx > critIdx, 'Role Boundary must come after CRITICAL section');
   });
 
   it('appears before Core Capabilities', () => {
-    const rbIdx = content.indexOf('## ROLE BOUNDARY');
+    const rbIdx = content.indexOf('## Role Boundary');
     const ccIdx = content.indexOf('### Core Capabilities');
-    assert.ok(rbIdx < ccIdx, 'ROLE BOUNDARY must come before Core Capabilities');
+    assert.ok(rbIdx < ccIdx, 'Role Boundary must come before Core Capabilities');
   });
 });
 

--- a/agents/__tests__/code-architect.test.js
+++ b/agents/__tests__/code-architect.test.js
@@ -121,6 +121,10 @@ describe('Strict Specificity Rule section', () => {
       'connect components',
       'process data',
       'coordinate between',
+      'consider',
+      'could',
+      'might',
+      'optionally',
     ];
     for (const term of banned) {
       assert.ok(

--- a/agents/__tests__/code-architect.test.js
+++ b/agents/__tests__/code-architect.test.js
@@ -173,7 +173,7 @@ describe('Working Principles #1 enhancement', () => {
 
 describe('Working Principles #4 enhancement', () => {
   it('contains "BEFORE" and "AFTER" and "breaking changes"', () => {
-    const wp4Line = lines.find((l) => l.match(/^4\.\s+\*\*Consider Dependencies/));
+    const wp4Line = lines.find((l) => l.match(/^4\.\s+\*\*Map Dependencies/));
     assert.ok(wp4Line, 'Working Principles #4 must exist');
     assert.ok(wp4Line.includes('BEFORE'), '#4 must contain "BEFORE"');
     assert.ok(wp4Line.includes('AFTER'), '#4 must contain "AFTER"');

--- a/agents/__tests__/code-architect.test.js
+++ b/agents/__tests__/code-architect.test.js
@@ -2,8 +2,8 @@
  * Tests for agents/code-architect.md — hardened prompt with specificity
  * constraints and anti-overengineering guards.
  *
- * Run: node --test agents/__tests__/code-architect.test.js
- * Also discovered by scripts/run-tests.sh (searches workflows/, agents/, skills/)
+ * Discovered by scripts/run-tests.sh which searches: workflows/, agents/, skills/
+ * Manual: node --test agents/__tests__/code-architect.test.js
  */
 
 const { describe, it } = require('node:test');

--- a/agents/__tests__/code-architect.test.js
+++ b/agents/__tests__/code-architect.test.js
@@ -2,7 +2,7 @@
  * Tests for agents/code-architect.md — hardened prompt with specificity
  * constraints and anti-overengineering guards.
  *
- * Run: node --test agents/__tests__/code-architect.test.js
+ * Run: node --test agents/__tests__/code-architect.test.js (also discovered by scripts/run-tests.sh)
  */
 
 const { describe, it } = require('node:test');

--- a/agents/__tests__/code-architect.test.js
+++ b/agents/__tests__/code-architect.test.js
@@ -1,10 +1,8 @@
-/**
- * Tests for agents/code-architect.md — hardened prompt with specificity
- * constraints and anti-overengineering guards.
- *
- * Discovered by scripts/run-tests.sh which searches: workflows/, agents/, skills/
- * Manual: node --test agents/__tests__/code-architect.test.js
- */
+// Tests for agents/code-architect.md — hardened prompt with specificity
+// constraints and anti-overengineering guards.
+//
+// Discovered by scripts/run-tests.sh which searches: workflows/, agents/, skills/
+// Manual: node --test agents/__tests__/code-architect.test.js
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -31,7 +31,7 @@ You are a read-only analysis agent. You produce blueprints. You never write, edi
 
 When designing architecture, you will:
 
-1. **Analyze First:** Thoroughly read existing code before proposing anything. Use Grep, Glob, and Read to understand the codebase. Your blueprint MUST list the files you inspected and name the patterns you identified (by file path and line range). If this section is missing, the blueprint is invalid.
+1. **Analyze First:** Thoroughly read existing code before proposing anything. Use Grep, Glob, and Read to understand the codebase. In the blueprint's **Existing Patterns** section, you MUST list the files you inspected and name the patterns you identified (by file path and line range). If the **Existing Patterns** section is missing or empty, the blueprint is invalid.
 2. **Follow Conventions:** Match the project's existing patterns for naming, file organization, error handling, testing, and typing.
 3. **Be Specific:** Reference exact file paths, function signatures, and type definitions. Never give vague or generic advice.
 4. **Map Dependencies:** For every change, list impacted modules and describe how data flows BEFORE vs AFTER the change. Identify any breaking changes to existing consumers.
@@ -58,7 +58,7 @@ New abstractions, layers, or patterns require explicit justification: what exist
 
 ### Strict Specificity Rule
 
-Never use vague terms in your blueprint. The following are banned:
+Never use vague terms in your blueprint prose. The following are banned:
 - "handle logic", "manage state", "connect components", "process data", "coordinate between"
 - "consider", "could", "might", "optionally"
 

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -14,6 +14,10 @@ You are a **Code Architect** specializing in analyzing existing codebases and de
 - You ARE the code-architect agent - do the work directly
 - Calling yourself creates infinite recursion loops
 
+## ROLE BOUNDARY
+
+You are a read-only analysis agent. You produce blueprints. You never write, edit, or scaffold code files. Your output is a document that an implementing agent will execute.
+
 ### Core Capabilities
 
 * **Codebase Analysis:** Deeply examine existing code to identify patterns, conventions, module boundaries, and architectural decisions already in place.
@@ -27,23 +31,53 @@ You are a **Code Architect** specializing in analyzing existing codebases and de
 
 When designing architecture, you will:
 
-1. **Analyze First:** Thoroughly read existing code before proposing anything. Use Grep, Glob, and Read to understand the codebase.
+1. **Analyze First:** Thoroughly read existing code before proposing anything. Use Grep, Glob, and Read to understand the codebase. Your blueprint MUST list the files you inspected and name the patterns you identified (by file path and line range). If this section is missing, the blueprint is invalid.
 2. **Follow Conventions:** Match the project's existing patterns for naming, file organization, error handling, testing, and typing.
 3. **Be Specific:** Reference exact file paths, function signatures, and type definitions. Never give vague or generic advice.
-4. **Consider Dependencies:** Map out which existing modules will be affected and how changes propagate through the system.
+4. **Consider Dependencies:** For every change, list impacted modules and describe how data flows BEFORE vs AFTER the change. Identify any breaking changes to existing consumers.
 5. **Plan for Testing:** Include test file locations, test patterns to follow, and specific scenarios to cover.
 6. **Minimize Scope:** Propose the smallest set of changes that fully satisfies requirements. Avoid unnecessary refactoring.
 7. **Document Decisions:** Explain trade-offs and why specific architectural choices were made.
+
+### Pattern Anchoring
+
+Every new component, module, or function you propose MUST reference an existing equivalent in the codebase:
+- "This follows the same pattern as: `<file/path>`"
+- If no similar pattern exists, explicitly state why a new pattern is justified and what alternatives you considered.
+
+You are not inventing architecture. You are extending what already exists.
+
+### Simplicity Constraint
+
+Prefer:
+- Extending existing modules over creating new ones
+- Adding small functions over introducing new abstractions
+- Reusing existing patterns over designing new ones
+
+New abstractions, layers, or patterns require explicit justification: what existing approach was considered, why it doesn't work, and why the new approach is the minimum viable alternative.
+
+### Strict Specificity Rule
+
+Never use vague terms in your blueprint. The following are banned:
+- "handle logic", "manage state", "connect components", "process data", "coordinate between"
+
+Instead, specify:
+- Exact function names and signatures
+- Exact props, parameters, and return types
+- Exact data transformations (input shape → output shape)
+
+If you cannot be specific, you have not analyzed the codebase enough. Go back and read more code.
 
 ### Output Format
 
 Your architecture blueprint should include:
 
 1. **Summary** - What the feature does and why this approach was chosen
-2. **Files to Create** - New files with their purpose, exports, and key interfaces
-3. **Files to Modify** - Existing files with specific changes needed and why
-4. **Data Model** - New types, interfaces, or schema changes
-5. **Component Design** - How components interact, with dependency diagrams if helpful
-6. **Implementation Sequence** - Ordered steps with dependencies noted
-7. **Test Plan** - Test files to create, scenarios to cover, following existing test patterns
-8. **Risk Assessment** - Potential issues and mitigation strategies
+2. **Existing Patterns** - Files inspected, patterns identified (by path and line range), and which pattern each new component follows
+3. **Files to Create** - New files with their purpose, exports, and key interfaces
+4. **Files to Modify** - Existing files with specific changes needed and why
+5. **Data Model** - New types, interfaces, or schema changes
+6. **Component Design** - How components interact, with dependency diagrams if helpful
+7. **Implementation Sequence** - Ordered steps with dependencies noted
+8. **Test Plan** - Exact test file paths, matching existing naming conventions. For each unit: cover the happy path, error path, and any edge cases specific to that component. Reference an existing test file as the structural template.
+9. **Risk Assessment** - Potential issues and mitigation strategies

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -60,6 +60,7 @@ New abstractions, layers, or patterns require explicit justification: what exist
 
 Never use vague terms in your blueprint. The following are banned:
 - "handle logic", "manage state", "connect components", "process data", "coordinate between"
+- "consider", "could", "might", "optionally"
 
 Instead, specify:
 - Exact function names and signatures

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -14,7 +14,7 @@ You are a **Code Architect** specializing in analyzing existing codebases and de
 - You ARE the code-architect agent - do the work directly
 - Calling yourself creates infinite recursion loops
 
-## ROLE BOUNDARY
+## Role Boundary
 
 You are a read-only analysis agent. You produce blueprints. You never write, edit, or scaffold code files. Your output is a document that an implementing agent will execute.
 

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -34,7 +34,7 @@ When designing architecture, you will:
 1. **Analyze First:** Thoroughly read existing code before proposing anything. Use Grep, Glob, and Read to understand the codebase. Your blueprint MUST list the files you inspected and name the patterns you identified (by file path and line range). If this section is missing, the blueprint is invalid.
 2. **Follow Conventions:** Match the project's existing patterns for naming, file organization, error handling, testing, and typing.
 3. **Be Specific:** Reference exact file paths, function signatures, and type definitions. Never give vague or generic advice.
-4. **Consider Dependencies:** For every change, list impacted modules and describe how data flows BEFORE vs AFTER the change. Identify any breaking changes to existing consumers.
+4. **Map Dependencies:** For every change, list impacted modules and describe how data flows BEFORE vs AFTER the change. Identify any breaking changes to existing consumers.
 5. **Plan for Testing:** Include test file locations, test patterns to follow, and specific scenarios to cover.
 6. **Minimize Scope:** Propose the smallest set of changes that fully satisfies requirements. Avoid unnecessary refactoring.
 7. **Document Decisions:** Explain trade-offs and why specific architectural choices were made.

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -43,7 +43,7 @@ When designing architecture, you will:
 
 Every new component, module, or function you propose MUST reference an existing equivalent in the codebase:
 - "This follows the same pattern as: `<file/path>`"
-- If no similar pattern exists, explicitly state why a new pattern is justified and what alternatives you considered.
+- If no similar pattern exists, explicitly state why a new pattern is justified and what alternatives you evaluated.
 
 You are not inventing architecture. You are extending what already exists.
 
@@ -54,7 +54,7 @@ Prefer:
 - Adding small functions over introducing new abstractions
 - Reusing existing patterns over designing new ones
 
-New abstractions, layers, or patterns require explicit justification: what existing approach was considered, why it doesn't work, and why the new approach is the minimum viable alternative.
+New abstractions, layers, or patterns require explicit justification: what existing approach was evaluated, why it doesn't work, and why the new approach is the minimum viable alternative.
 
 ### Strict Specificity Rule
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Discovers and runs all test files under workflows/ and skills/
+# Discovers and runs all test files under workflows/, agents/, and skills/
 # Works on Node 20+ without glob support in `node --test`
 #
 # To skip a broken test, add its path to .test-skip (one per line).
@@ -8,7 +8,7 @@ set -euo pipefail
 SKIP_FILE=".test-skip"
 
 # Build space-separated file list (node --test expects positional args, not newlines)
-mapfile -t FILES < <(find workflows skills -type f \( -name '*.test.js' -o -name '*.spec.js' \) | sort)
+mapfile -t FILES < <(find workflows agents skills -type f \( -name '*.test.js' -o -name '*.spec.js' \) | sort)
 
 if [ -f "$SKIP_FILE" ]; then
   FILTERED=()

--- a/workflows/check/check.workflow.js
+++ b/workflows/check/check.workflow.js
@@ -44,7 +44,7 @@ function safeExec(cmd, options = {}) {
 const getBaseBranch = () => config.getBaseBranch({ cwd: REPO_DIR });
 
 function getReportFolder(instanceId) {
-  return path.join(TASKS_BASE, instanceId);
+  return config.tasksDir(instanceId) || path.join(TASKS_BASE, instanceId);
 }
 
 function getCurrentChangesHash() {

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2960,10 +2960,10 @@ describe('enforce-step-workflow', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // PR verify: --head branch flag (GH-191)
+  // PR verify: branch positional arg (GH-191, GH-203)
   // ═══════════════════════════════════════════════════════════════════════════
 
-  describe('PR verify --head branch flag (GH-191)', () => {
+  describe('PR verify branch positional arg (GH-191, GH-203)', () => {
     const FAKE_GIT_DIR = path.join(os.tmpdir(), `fake-git-pr-191-${process.pid}`);
     const FAKE_GIT_PATH = path.join(FAKE_GIT_DIR, 'git');
     const FAKE_GH_DIR = path.join(os.tmpdir(), `fake-gh-pr-191-${process.pid}`);
@@ -2973,7 +2973,7 @@ describe('enforce-step-workflow', () => {
 
     function writeFakeGit() {
       if (!fs.existsSync(FAKE_GIT_DIR)) fs.mkdirSync(FAKE_GIT_DIR, { recursive: true });
-      // Provide controlled branch name so --head flag is always added,
+      // Provide controlled branch name so positional arg is always added,
       // even in CI where the checkout may be in detached HEAD state.
       const script = [
         '#!/bin/bash',
@@ -3031,22 +3031,22 @@ describe('enforce-step-workflow', () => {
       cleanup();
     });
 
-    it('passes --head flag with current branch name to gh pr view', async () => {
-      // The fake gh should receive --head with the branch name
+    it('passes branch as positional arg to gh pr view', async () => {
+      // The fake gh should receive the branch name as positional arg (not --head)
       writeFakeGh({
-        'pr view --head': '{"number":42,"state":"OPEN"}',
+        [`pr view ${PR_TEST_BRANCH}`]: '{"number":42,"state":"OPEN"}',
       });
-      // Fake git provides deterministic branch name for --head flag (CI-safe)
+      // Fake git provides deterministic branch name for positional arg (CI-safe)
       const { code } = await transitionFromPr();
-      assert.equal(code, 0, 'Should pass transition when --head flag resolves the PR');
+      assert.equal(code, 0, 'Should pass transition when branch positional arg resolves the PR');
     });
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // follow_up verify: --head branch flag (GH-191)
+  // follow_up verify: branch positional arg (GH-191, GH-203)
   // ═══════════════════════════════════════════════════════════════════════════
 
-  describe('follow_up verify --head branch flag (GH-191)', () => {
+  describe('follow_up verify branch positional arg (GH-191, GH-203)', () => {
     const FAKE_GIT_DIR = path.join(os.tmpdir(), `fake-git-followup-191-${process.pid}`);
     const FAKE_GIT_PATH = path.join(FAKE_GIT_DIR, 'git');
     const FAKE_GH_DIR = path.join(os.tmpdir(), `fake-gh-followup-191-${process.pid}`);
@@ -3056,7 +3056,7 @@ describe('enforce-step-workflow', () => {
 
     function writeFakeGit() {
       if (!fs.existsSync(FAKE_GIT_DIR)) fs.mkdirSync(FAKE_GIT_DIR, { recursive: true });
-      // Provide controlled branch name so --head flag is always added,
+      // Provide controlled branch name so positional arg is always added,
       // even in CI where the checkout may be in detached HEAD state.
       const script = [
         '#!/bin/bash',
@@ -3114,15 +3114,16 @@ describe('enforce-step-workflow', () => {
       cleanup();
     });
 
-    it('passes --head flag to initial gh pr view in follow_up verify', async () => {
+    it('passes branch as positional arg to gh pr view in follow_up verify', async () => {
       writeFakeGh({
-        'pr view --head': '42',
+        [`pr view ${FOLLOWUP_TEST_BRANCH}`]: '42',
         'pr checks 42 --json': '[{"state":"SUCCESS","name":"build"}]',
+        'pr checks 42': 'build\tpass\t1s\thttps://example.com',
         'pr view 42 --json reviewDecision': '{"reviewDecision":"APPROVED"}',
         'repos/{owner}/{repo}/pulls/42/comments': '0',
-      }); // fake git (writeFakeGit above) provides deterministic branch for --head (CI-safe)
+      }); // fake git (writeFakeGit above) provides deterministic branch for positional arg (CI-safe)
       const { code } = await transitionFromFollowUp();
-      assert.equal(code, 0, 'Should use --head flag for initial PR number resolution');
+      assert.equal(code, 0, 'Should use branch positional arg for initial PR number resolution');
     });
   });
 

--- a/workflows/lib/hooks/enforce-screenshot-requirement.js
+++ b/workflows/lib/hooks/enforce-screenshot-requirement.js
@@ -36,11 +36,14 @@ function getRepoRoot() {
 }
 
 function getScreenshotDir(ticketId) {
+  const config = require('../config');
+  const tasksDir = config.tasksDir(ticketId);
+  if (tasksDir) return path.join(tasksDir, 'screenshots');
+  // Fallback: use repo root or cwd parent
   const repoRoot = getRepoRoot();
   if (repoRoot) {
     return path.join(path.dirname(repoRoot), 'tasks', ticketId, 'screenshots');
   }
-  // Fallback: use cwd parent
   return path.join(process.cwd(), '..', 'tasks', ticketId, 'screenshots');
 }
 

--- a/workflows/work-pr/__tests__/work-pr.workflow.test.js
+++ b/workflows/work-pr/__tests__/work-pr.workflow.test.js
@@ -520,8 +520,10 @@ describe('work-pr.workflow.js', () => {
       // Clear require cache to pick up new env vars
       const wfPath = require.resolve(path.join(__dirname, '..', 'work-pr.workflow.js'));
       const configPath = require.resolve(path.join(__dirname, '..', '..', 'lib', 'get-config.js'));
+      const libConfigPath = require.resolve(path.join(__dirname, '..', '..', 'lib', 'config.js'));
       delete require.cache[wfPath];
       delete require.cache[configPath];
+      delete require.cache[libConfigPath];
 
       try {
         const freshWf = require(wfPath);
@@ -544,6 +546,7 @@ describe('work-pr.workflow.js', () => {
         }
         delete require.cache[wfPath];
         delete require.cache[configPath];
+        delete require.cache[libConfigPath];
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
     });

--- a/workflows/work-pr/work-pr.workflow.js
+++ b/workflows/work-pr/work-pr.workflow.js
@@ -36,7 +36,8 @@ function getTasksDir(ticketId) {
 }
 
 function getWorktreeDir(ticketId) {
-  return config.worktreeDir(safeTicketId(ticketId)) || path.join(WORKTREES_BASE, `${config.REPO_NAME}-${safeTicketId(ticketId)}`);
+  const safe = safeTicketId(ticketId);
+  return config.worktreeDir(safe) || path.join(WORKTREES_BASE, `${config.REPO_NAME}-${safe}`);
 }
 
 function safeExec(cmd, options = {}) {

--- a/workflows/work-pr/work-pr.workflow.js
+++ b/workflows/work-pr/work-pr.workflow.js
@@ -22,21 +22,21 @@ const { execSync } = require('child_process');
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
+const config = require(path.join(__dirname, '..', 'lib', 'config'));
 const getConfig = require(path.join(__dirname, '..', 'lib', 'get-config'));
 const WORKTREES_BASE = getConfig.require('WORKTREES_BASE');
 const TASKS_BASE = getConfig('TASKS_BASE') || path.join(WORKTREES_BASE, 'tasks');
 const { normalizeTicketId } = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
-const safeTicketId = require(path.join(__dirname, '..', 'lib', 'config')).safeTicketId;
+const safeTicketId = config.safeTicketId;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function getTasksDir(ticketId) {
-  return path.join(TASKS_BASE, safeTicketId(ticketId));
+  return config.tasksDir(ticketId) || path.join(TASKS_BASE, safeTicketId(ticketId));
 }
 
 function getWorktreeDir(ticketId) {
-  const repo = process.env.REPO_NAME || 'my-project';
-  return path.join(WORKTREES_BASE, `${repo}-${ticketId}`);
+  return config.worktreeDir(safeTicketId(ticketId)) || path.join(WORKTREES_BASE, `${config.REPO_NAME}-${safeTicketId(ticketId)}`);
 }
 
 function safeExec(cmd, options = {}) {

--- a/workflows/work/hooks/work-code-review-status.js
+++ b/workflows/work/hooks/work-code-review-status.js
@@ -72,7 +72,7 @@ function findCodeReviewForTask(baseDir, taskId) {
   if (!taskId) return null;
 
   const tasksDir = path.join(baseDir, 'tasks');
-  const taskFolder = path.join(tasksDir, taskId);
+  const taskFolder = path.join(tasksDir, config.safeTicketId(taskId));
   const reviewFile = path.join(taskFolder, 'code-review.check.md');
 
   if (fs.existsSync(reviewFile)) {
@@ -87,7 +87,7 @@ function findQaReportsForTask(baseDir, taskId) {
   if (!taskId) return [];
 
   const tasksDir = path.join(baseDir, 'tasks');
-  const taskFolder = path.join(tasksDir, taskId);
+  const taskFolder = path.join(tasksDir, config.safeTicketId(taskId));
 
   if (!fs.existsSync(taskFolder)) return [];
 

--- a/workflows/work/unstick-complete.js
+++ b/workflows/work/unstick-complete.js
@@ -45,19 +45,22 @@ const SESSION_GUARD_PATH = require('path').resolve(
 
 /**
  * Validate and sanitize a ticket ID to prevent path traversal.
+ * Delegates ID sanitization to config.safeTicketId, then validates
+ * the resolved path stays within TASKS_BASE.
  * Allows base ticket IDs (e.g. GH-106) and suffix tickets (e.g. GH-145/phase1).
  */
 function sanitizeTicketId(ticketId) {
   if (!ticketId || typeof ticketId !== 'string') return null;
   if (!TASKS_BASE || typeof TASKS_BASE !== 'string') return null;
   if (ticketId.includes('\\')) return null;
-  const parts = ticketId.split('/');
+  const safeId = config.safeTicketId(ticketId);
+  const parts = safeId.split('/');
   if (parts.length < 1 || parts.length > 2) return null;
   if (parts.some((part) => !part || !/^[A-Za-z0-9_-]+$/.test(part))) return null;
   const baseResolved = path.resolve(TASKS_BASE);
   const resolved = path.resolve(TASKS_BASE, ...parts);
   if (resolved !== baseResolved && !resolved.startsWith(baseResolved + path.sep)) return null;
-  return ticketId; // validated: alphanumeric with optional single /suffix, resolves within TASKS_BASE
+  return safeId; // validated: alphanumeric with optional single /suffix, resolves within TASKS_BASE
 }
 
 /**

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -364,34 +364,15 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             const { execFileSync } = require('child_process');
             const opts = { encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] };
 
-            // Resolve branch for --head flag to support worktree contexts (GH-191)
+            // Resolve branch to support worktree contexts (GH-191, GH-203)
+            // Note: gh pr view uses positional branch arg, not --head flag
             let ghArgs = ['pr', 'view', '--json', 'number,state'];
-            let branch = '';
             try {
-              branch = execFileSync('git', ['branch', '--show-current'], opts).trim();
-              if (branch) ghArgs = ['pr', 'view', '--head', branch, '--json', 'number,state'];
-            } catch {
-              /* detached HEAD -- fall back to no --head */
-            }
+              const branch = execFileSync('git', ['branch', '--show-current'], opts).trim();
+              if (branch) ghArgs = ['pr', 'view', branch, '--json', 'number,state'];
+            } catch { /* detached HEAD -- fall back to no branch arg */ }
 
-            // Try --head first (GH-191), fall back to branch arg if gh doesn't support --head
-            let pr;
-            try {
-              pr = JSON.parse(execFileSync('gh', ghArgs, opts).trim());
-            } catch {
-              // Some gh versions don't support --head on `pr view`; fall back to positional branch
-              if (branch) {
-                pr = JSON.parse(
-                  execFileSync(
-                    'gh',
-                    ['pr', 'view', branch, '--json', 'number,state'],
-                    opts
-                  ).trim()
-                );
-              } else {
-                pr = JSON.parse(execFileSync('gh', ['pr', 'view', '--json', 'number,state'], opts).trim());
-              }
-            }
+            const pr = JSON.parse(execFileSync('gh', ghArgs, opts).trim());
             return pr.number > 0 && pr.state === 'OPEN';
           } catch {
             return false;
@@ -407,15 +388,12 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             const { execFileSync } = require('child_process');
             const opts = { encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] };
 
-            // Resolve branch once for --head flag to support worktree contexts (GH-191)
+            // Resolve branch to support worktree contexts (GH-191, GH-203)
             let prViewArgs = ['pr', 'view', '--json', 'number', '-q', '.number'];
             try {
               const branch = execFileSync('git', ['branch', '--show-current'], opts).trim();
-              if (branch)
-                prViewArgs = ['pr', 'view', '--head', branch, '--json', 'number', '-q', '.number'];
-            } catch {
-              /* detached HEAD -- fall back to no --head */
-            }
+              if (branch) prViewArgs = ['pr', 'view', branch, '--json', 'number', '-q', '.number'];
+            } catch { /* detached HEAD -- fall back to no branch arg */ }
 
             // 1. Get PR number
             const prNum = execFileSync('gh', prViewArgs, opts).trim();

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -370,7 +370,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             try {
               const branch = execFileSync('git', ['branch', '--show-current'], opts).trim();
               if (branch) ghArgs = ['pr', 'view', branch, '--json', 'number,state'];
-            } catch { /* detached HEAD -- fall back to no branch arg */ }
+            } catch { /* branch detection failed -- fall back to no branch arg */ }
 
             const pr = JSON.parse(execFileSync('gh', ghArgs, opts).trim());
             return pr.number > 0 && pr.state === 'OPEN';
@@ -393,7 +393,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             try {
               const branch = execFileSync('git', ['branch', '--show-current'], opts).trim();
               if (branch) prViewArgs = ['pr', 'view', branch, '--json', 'number', '-q', '.number'];
-            } catch { /* detached HEAD -- fall back to no branch arg */ }
+            } catch { /* branch detection failed -- fall back to no branch arg */ }
 
             // 1. Get PR number
             const prNum = execFileSync('gh', prViewArgs, opts).trim();

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -372,7 +372,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
               if (branch) ghArgs = ['pr', 'view', branch, '--json', 'number,state'];
             } catch { /* branch detection failed -- fall back to no branch arg */ }
 
-            const pr = JSON.parse(execFileSync('gh', ghArgs, opts).trim());
+            const pr = JSON.parse(execFileSync('gh', ghArgs, opts).trim()); // GH-203: positional arg, not --head
             return pr.number > 0 && pr.state === 'OPEN';
           } catch {
             return false;


### PR DESCRIPTION
## Existing Behavior

- The `code-architect` agent had no explicit read-only boundary declaration, leaving ambiguity about whether it could write or scaffold files.
- Working Principle #1 required reading code before proposing but did not mandate listing inspected files by path and line range; blueprints could omit codebase evidence entirely.
- Working Principle #4 (previously "Consider Dependencies") required mapping dependencies but did not enforce before/after data flow descriptions or explicit identification of breaking changes.
- The Output Format had 8 items with no structural slot for codebase evidence.
- No guard existed against vague language ("handle logic", "manage state", "consider", "might") or against introducing unnecessary new abstractions without justification.
- `gh pr view` was called with the `--head` flag to resolve PRs by branch name. This flag is not supported by all `gh` versions and caused failures in some environments; the code fell back to the positional branch argument only on error.
- Directory resolution for tasks, worktrees, and screenshots was duplicated across `work-pr.workflow.js`, `check.workflow.js`, `enforce-screenshot-requirement.js`, and `unstick-complete.js`, each building paths independently instead of delegating to `lib/config`.
- Test discovery in `scripts/run-tests.sh` only searched `workflows/` and `skills/`, missing test files placed under `agents/`.
- `work-code-review-status.js` and `unstick-complete.js` used raw ticket IDs when constructing task folder paths, bypassing the `safeTicketId` sanitization step.

## Intended New Behavior

- A `## Role Boundary` section explicitly declares `code-architect` as read-only: it produces blueprints only and never writes, edits, or scaffolds code files.
- Working Principle #1 now requires the blueprint to list all inspected files by path and line range; a blueprint with a missing or empty **Existing Patterns** section is invalid.
- Working Principle #4 is renamed "Map Dependencies" and requires explicit before/after data flow descriptions and identification of breaking changes for every impacted module.
- A `### Pattern Anchoring` section requires every proposed component to reference an existing equivalent by file path; introducing a new pattern requires written justification.
- A `### Simplicity Constraint` section mandates preferring extensions of existing modules over new abstractions, with explicit justification required for any new layer.
- A `### Strict Specificity Rule` section bans vague terms and hedge words, requiring exact function names, signatures, props, parameters, and data transformation shapes.
- The Output Format expands to 9 items with **Existing Patterns** as item 2, providing a mandatory structural slot for codebase evidence.
- `gh pr view` now uses the branch name as a positional argument (`gh pr view <branch>`) instead of `--head <branch>`, removing the two-call fallback path and ensuring compatibility across all supported `gh` versions.
- Tasks directory, worktree directory, and screenshot directory resolution is now centralized through `config.tasksDir()` and `config.worktreeDir()`, with the previous path-join logic kept as a fallback. `work-pr.workflow.js`, `check.workflow.js`, `enforce-screenshot-requirement.js`, `unstick-complete.js`, and `work-code-review-status.js` all delegate to `lib/config` instead of building paths independently.
- `scripts/run-tests.sh` now includes `agents/` in the test discovery search path so test files under `agents/__tests__/` are picked up automatically.
- 22 structural tests in `agents/__tests__/code-architect.test.js` validate all prompt hardening changes using the Node.js built-in test runner.

## Dev Checks

- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**code-architect prompt hardening**

1. Run the structural test suite: `node --test agents/__tests__/code-architect.test.js`
2. Confirm all 22 tests pass with zero failures.
3. Open `agents/code-architect.md` and verify sections appear in order: `## Role Boundary` → `### Pattern Anchoring` → `### Simplicity Constraint` → `### Strict Specificity Rule`.
4. In `### Output Format`, confirm item 2 is `**Existing Patterns**` and the total item count is 9.

**gh pr view positional branch arg fix**

5. On a branch that has an open PR, run: `gh pr view <branch-name> --json number,state` and confirm it returns the PR without error.
6. Confirm the two-call fallback path in `workflow-definition.js` no longer exists — only a single `execFileSync('gh', ghArgs, opts)` call remains.

**config centralization**

7. Set `TASKS_BASE` in the environment and confirm `work-pr.workflow.js` calls `config.tasksDir(ticketId)` to resolve the task folder path.
8. Verify `check.workflow.js` and `enforce-screenshot-requirement.js` use `config.tasksDir()` rather than constructing the path with `path.join(TASKS_BASE, instanceId)` or `path.join(repoRoot, 'tasks', ticketId)`.

**test discovery**

9. Place a `.test.js` file under `agents/__tests__/` and run `scripts/run-tests.sh`; confirm it is discovered and executed.

### Test Results

22 tests defined across 10 describe blocks covering: frontmatter preservation, Pattern Anchoring placement and content, Simplicity Constraint presence and content, Strict Specificity Rule banned terms, Role Boundary placement, Working Principles #1 and #4 enhancements, and Output Format item count and item 2 identity.

Closes #203