### PR TITLE
test: isolate work-hooks tests to temp dirs to prevent orphan leaks

### DIFF
--- a/workflows/work/__tests__/work-enforce-steps.test.js
+++ b/workflows/work/__tests__/work-enforce-steps.test.js
@@ -39,8 +39,10 @@ const ORIG_ENV = {
 process.env.TASKS_BASE = TEMP_TASKS_BASE;
 process.env.TICKET_PROJECT_KEY = TICKET_PROJECT_KEY;
 const CONFIG_PATH = '../../lib/config';
+// Intentional: config.js caches env at require-time, so the require MUST
+// follow the env mutations above.  Cleanup (env restore + cache bust) is in
+// the describe's after() hook below.
 const config = require(CONFIG_PATH);
-// Env/cache restoration happens in the describe's after() hook (see below).
 function runHook(toolInput, hookType = 'PostToolUse') {
   return new Promise((resolve, reject) => {
     const proc = spawn('node', [HOOK_PATH], {

--- a/workflows/work/__tests__/work-enforce-steps.test.js
+++ b/workflows/work/__tests__/work-enforce-steps.test.js
@@ -40,9 +40,13 @@ process.env.TASKS_BASE = TEMP_TASKS_BASE;
 process.env.TICKET_PROJECT_KEY = TICKET_PROJECT_KEY;
 const CONFIG_PATH = '../../lib/config';
 // Intentional: config.js caches env at require-time, so the require MUST
-// follow the env mutations above.  Cleanup (env restore + cache bust) is in
-// the describe's after() hook below.
-const config = require(CONFIG_PATH);
+// follow the env mutations above.  Clear the module cache first so that if
+// another test file already loaded config.js under different env values we
+// re-read from the freshly-set env.  Cleanup (env restore + cache bust) is
+// in the describe's after() hook below.
+const RESOLVED_CONFIG_PATH = require.resolve(CONFIG_PATH);
+delete require.cache[RESOLVED_CONFIG_PATH];
+const config = require(RESOLVED_CONFIG_PATH);
 function runHook(toolInput, hookType = 'PostToolUse') {
   return new Promise((resolve, reject) => {
     const proc = spawn('node', [HOOK_PATH], {

--- a/workflows/work/__tests__/work-enforce-steps.test.js
+++ b/workflows/work/__tests__/work-enforce-steps.test.js
@@ -5,14 +5,33 @@
  * Run with: node --test hooks/__tests__/work-enforce-steps.test.js
  */
 
-const { describe, it } = require('node:test');
+const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert');
 const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
-const config = require('../../lib/config');
+const os = require('os');
 
 const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'work-enforce-steps.js');
+
+// Isolate all filesystem side effects to a temp dir so tests never touch the
+// real tasks/ directory (which would leak orphaned ticket dirs on assertion
+// failure). Use a stable project key so the hook's ticket-extraction regex
+// resolves to the same dir the test inspects.
+const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'work-enforce-steps-test-'));
+const TICKET_PROJECT_KEY = 'TESTGH';
+
+let ticketCounter = 0;
+function nextTicketId() {
+  ticketCounter += 1;
+  return `${TICKET_PROJECT_KEY}-${process.pid}${ticketCounter}`;
+}
+
+// config.js reads TASKS_BASE/TICKET_PROJECT_KEY at require time, so we must
+// set them before requiring it.
+process.env.TASKS_BASE = TEMP_TASKS_BASE;
+process.env.TICKET_PROJECT_KEY = TICKET_PROJECT_KEY;
+const config = require('../../lib/config');
 
 function runHook(toolInput, hookType = 'PostToolUse') {
   return new Promise((resolve, reject) => {
@@ -20,6 +39,8 @@ function runHook(toolInput, hookType = 'PostToolUse') {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: {
         ...process.env,
+        TASKS_BASE: TEMP_TASKS_BASE,
+        TICKET_PROJECT_KEY,
         TOOL_INPUT: JSON.stringify(toolInput),
         CLAUDE_HOOK_TYPE: hookType,
       },
@@ -41,8 +62,12 @@ function runHook(toolInput, hookType = 'PostToolUse') {
 }
 
 describe('work-enforce-steps hook', () => {
+  after(() => {
+    try { fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true }); } catch {}
+  });
+
   it('should exit 0 for non-work/work-pr skills', async () => {
-    const { code } = await runHook({ skill: 'work-implement', args: 'PROJ-123' });
+    const { code } = await runHook({ skill: 'work-implement', args: nextTicketId() });
     assert.strictEqual(code, 0);
   });
 
@@ -52,21 +77,21 @@ describe('work-enforce-steps hook', () => {
   });
 
   it('should create session file on PreToolUse for /work', async () => {
-    const ticketId = `PROJ-${Date.now()}`;
-    const { code } = await runHook({ skill: 'work', args: ticketId }, 'PreToolUse');
+    const ticketId = nextTicketId();
+    const { code } = await runHook(
+      { skill: 'work', args: ticketId },
+      'PreToolUse'
+    );
     assert.strictEqual(code, 0);
 
     // Check session file was created
     const tasksDir = config.tasksDir(ticketId);
     const sessionFile = path.join(tasksDir, '.work-session');
     assert.ok(fs.existsSync(sessionFile));
-
-    // Cleanup
-    fs.rmSync(tasksDir, { recursive: true, force: true });
   });
 
   it('should mark work-pr as executed on PreToolUse', async () => {
-    const ticketId = `PROJ-${Date.now()}`;
+    const ticketId = nextTicketId();
     const tasksDir = config.tasksDir(ticketId);
     fs.mkdirSync(tasksDir, { recursive: true });
 
@@ -75,8 +100,5 @@ describe('work-enforce-steps hook', () => {
 
     const prFile = path.join(tasksDir, '.work-pr-executed');
     assert.ok(fs.existsSync(prFile));
-
-    // Cleanup
-    fs.rmSync(tasksDir, { recursive: true, force: true });
   });
 });

--- a/workflows/work/__tests__/work-enforce-steps.test.js
+++ b/workflows/work/__tests__/work-enforce-steps.test.js
@@ -40,6 +40,7 @@ process.env.TASKS_BASE = TEMP_TASKS_BASE;
 process.env.TICKET_PROJECT_KEY = TICKET_PROJECT_KEY;
 const CONFIG_PATH = '../../lib/config';
 const config = require(CONFIG_PATH);
+// Env/cache restoration happens in the describe's after() hook (see below).
 
 function runHook(toolInput, hookType = 'PostToolUse') {
   return new Promise((resolve, reject) => {

--- a/workflows/work/__tests__/work-enforce-steps.test.js
+++ b/workflows/work/__tests__/work-enforce-steps.test.js
@@ -41,7 +41,6 @@ process.env.TICKET_PROJECT_KEY = TICKET_PROJECT_KEY;
 const CONFIG_PATH = '../../lib/config';
 const config = require(CONFIG_PATH);
 // Env/cache restoration happens in the describe's after() hook (see below).
-
 function runHook(toolInput, hookType = 'PostToolUse') {
   return new Promise((resolve, reject) => {
     const proc = spawn('node', [HOOK_PATH], {

--- a/workflows/work/__tests__/work-enforce-steps.test.js
+++ b/workflows/work/__tests__/work-enforce-steps.test.js
@@ -5,7 +5,7 @@
  * Run with: node --test hooks/__tests__/work-enforce-steps.test.js
  */
 
-const { describe, it, before, after } = require('node:test');
+const { describe, it, after } = require('node:test');
 const assert = require('node:assert');
 const { spawn } = require('child_process');
 const path = require('path');
@@ -27,11 +27,19 @@ function nextTicketId() {
   return `${TICKET_PROJECT_KEY}-${process.pid}${ticketCounter}`;
 }
 
+// Capture original env so we can restore it in after() — node --test runs
+// many files in one process and sibling tests must not see our overrides.
+const ORIG_ENV = {
+  TASKS_BASE: process.env.TASKS_BASE,
+  TICKET_PROJECT_KEY: process.env.TICKET_PROJECT_KEY,
+};
+
 // config.js reads TASKS_BASE/TICKET_PROJECT_KEY at require time, so we must
 // set them before requiring it.
 process.env.TASKS_BASE = TEMP_TASKS_BASE;
 process.env.TICKET_PROJECT_KEY = TICKET_PROJECT_KEY;
-const config = require('../../lib/config');
+const CONFIG_PATH = '../../lib/config';
+const config = require(CONFIG_PATH);
 
 function runHook(toolInput, hookType = 'PostToolUse') {
   return new Promise((resolve, reject) => {
@@ -64,6 +72,15 @@ function runHook(toolInput, hookType = 'PostToolUse') {
 describe('work-enforce-steps hook', () => {
   after(() => {
     try { fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true }); } catch {}
+    // Restore original env so sibling test files in the same Node process
+    // don't inherit our temp base / test project key.
+    if (ORIG_ENV.TASKS_BASE === undefined) delete process.env.TASKS_BASE;
+    else process.env.TASKS_BASE = ORIG_ENV.TASKS_BASE;
+    if (ORIG_ENV.TICKET_PROJECT_KEY === undefined) delete process.env.TICKET_PROJECT_KEY;
+    else process.env.TICKET_PROJECT_KEY = ORIG_ENV.TICKET_PROJECT_KEY;
+    // Clear require.cache for config.js so sibling tests re-read it under
+    // restored env instead of reusing our cached temp derivation.
+    try { delete require.cache[require.resolve(CONFIG_PATH)]; } catch {}
   });
 
   it('should exit 0 for non-work/work-pr skills', async () => {

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -40,9 +40,8 @@ const GET_CONFIG_PATH = path.join(__dirname, '..', '..', 'lib', 'get-config');
 const CONFIG_PATH = path.join(__dirname, '..', '..', 'lib', 'config');
 const getConfig = require(GET_CONFIG_PATH);
 const TASKS_BASE = getConfig.require('TASKS_BASE');
-
+// Env/cache restoration happens in the global after() hook further down.
 // ─── Helpers ────────────────────────────────────────────────────────────────
-
 function runOrchestrator(args = [], opts = {}) {
   // If an inner describe block overrides WORKTREES_BASE without also
   // overriding TASKS_BASE, derive TASKS_BASE from the inner WORKTREES_BASE

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -13,6 +13,17 @@ const fs = require('fs');
 const os = require('os');
 
 const HOOK_PATH = path.join(__dirname, '..', 'work.workflow.js');
+
+// Isolate all filesystem side effects to a temp dir so the real tasks/
+// directory never accumulates orphan ticket dirs when an assertion fails
+// before cleanup runs. Must be set BEFORE loading get-config (which caches
+// TASKS_BASE from env at module init).
+const TEMP_WORKTREES_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'work-orchestrator-test-'));
+const TEMP_TASKS_BASE = path.join(TEMP_WORKTREES_BASE, 'tasks');
+fs.mkdirSync(TEMP_TASKS_BASE, { recursive: true });
+process.env.WORKTREES_BASE = TEMP_WORKTREES_BASE;
+process.env.TASKS_BASE = TEMP_TASKS_BASE;
+
 const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
 const TASKS_BASE = getConfig.require('TASKS_BASE');
 
@@ -61,20 +72,13 @@ function cleanupTempWorkState(ticket) {
 // ─── Global Cleanup ─────────────────────────────────────────────────────────
 
 after(() => {
-  try {
-    const entries = fs.readdirSync(TASKS_BASE);
-    for (const entry of entries) {
-      if (entry.startsWith('TEST-')) {
-        fs.rmSync(path.join(TASKS_BASE, entry), { recursive: true, force: true });
-      }
-    }
-  } catch {}
+  // Nuke the whole temp base — no selective cleanup needed since everything
+  // the suite touches lives under TEMP_WORKTREES_BASE.
+  try { fs.rmSync(TEMP_WORKTREES_BASE, { recursive: true, force: true }); } catch {}
   // Safety-net: clean up leaked session guard files created by THIS suite only (TEST-* tickets)
   try {
-    const tmpDir = require('os').tmpdir();
-    const tmpFiles = fs
-      .readdirSync(tmpDir)
-      .filter((f) => f.startsWith('claude-session-guard-TEST-'));
+    const tmpDir = os.tmpdir();
+    const tmpFiles = fs.readdirSync(tmpDir).filter(f => f.startsWith('claude-session-guard-TEST-'));
     for (const f of tmpFiles) {
       try {
         fs.unlinkSync(path.join(tmpDir, f));

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -17,14 +17,27 @@ const HOOK_PATH = path.join(__dirname, '..', 'work.workflow.js');
 // Isolate all filesystem side effects to a temp dir so the real tasks/
 // directory never accumulates orphan ticket dirs when an assertion fails
 // before cleanup runs. Must be set BEFORE loading get-config (which caches
-// TASKS_BASE from env at module init).
+// config.js at require time).
+//
+// Note: we override ONLY WORKTREES_BASE and explicitly clear TASKS_BASE so
+// config.js derives TASKS_BASE = WORKTREES_BASE/tasks. Inner describe blocks
+// set their own WORKTREES_BASE via opts.env for per-suite isolation and rely
+// on the same derivation — if we set TASKS_BASE directly it would leak into
+// those child processes (since spread inherits process.env) and cause the
+// child's config to point at a different dir than the inner suite's tasks/.
+const ORIG_ENV = {
+  WORKTREES_BASE: process.env.WORKTREES_BASE,
+  TASKS_BASE: process.env.TASKS_BASE,
+};
 const TEMP_WORKTREES_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'work-orchestrator-test-'));
 const TEMP_TASKS_BASE = path.join(TEMP_WORKTREES_BASE, 'tasks');
 fs.mkdirSync(TEMP_TASKS_BASE, { recursive: true });
 process.env.WORKTREES_BASE = TEMP_WORKTREES_BASE;
-process.env.TASKS_BASE = TEMP_TASKS_BASE;
+delete process.env.TASKS_BASE;
 
-const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
+const GET_CONFIG_PATH = path.join(__dirname, '..', '..', 'lib', 'get-config');
+const CONFIG_PATH = path.join(__dirname, '..', '..', 'lib', 'config');
+const getConfig = require(GET_CONFIG_PATH);
 const TASKS_BASE = getConfig.require('TASKS_BASE');
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -84,9 +97,19 @@ after(() => {
         fs.unlinkSync(path.join(tmpDir, f));
       } catch {}
     }
-  } catch {
-    /* ignore if tmpdir unreadable */
-  }
+  } catch { /* ignore if tmpdir unreadable */ }
+  // Restore original env so sibling test files loaded in the same Node
+  // process (node --test runs many files in one process) don't see our
+  // temp overrides leak through inherited env.
+  if (ORIG_ENV.WORKTREES_BASE === undefined) delete process.env.WORKTREES_BASE;
+  else process.env.WORKTREES_BASE = ORIG_ENV.WORKTREES_BASE;
+  if (ORIG_ENV.TASKS_BASE === undefined) delete process.env.TASKS_BASE;
+  else process.env.TASKS_BASE = ORIG_ENV.TASKS_BASE;
+  // Clear require.cache for get-config / config so sibling test files get a
+  // fresh module re-read with the restored env instead of our cached temp
+  // derivation.
+  try { delete require.cache[require.resolve(GET_CONFIG_PATH)]; } catch {}
+  try { delete require.cache[require.resolve(CONFIG_PATH)]; } catch {}
 });
 
 /**

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -39,6 +39,7 @@ const GET_CONFIG_PATH = path.join(__dirname, '..', '..', 'lib', 'get-config');
 const CONFIG_PATH = path.join(__dirname, '..', '..', 'lib', 'config');
 const getConfig = require(GET_CONFIG_PATH);
 const TASKS_BASE = getConfig.require('TASKS_BASE');
+// Env/cache restoration happens in the global after() hook further down.
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -19,12 +19,13 @@ const HOOK_PATH = path.join(__dirname, '..', 'work.workflow.js');
 // before cleanup runs. Must be set BEFORE loading get-config (which caches
 // config.js at require time).
 //
-// Note: we override ONLY WORKTREES_BASE and explicitly clear TASKS_BASE so
-// config.js derives TASKS_BASE = WORKTREES_BASE/tasks. Inner describe blocks
-// set their own WORKTREES_BASE via opts.env for per-suite isolation and rely
-// on the same derivation — if we set TASKS_BASE directly it would leak into
-// those child processes (since spread inherits process.env) and cause the
-// child's config to point at a different dir than the inner suite's tasks/.
+// Both WORKTREES_BASE and TASKS_BASE are set *explicitly* (rather than
+// deleting TASKS_BASE and relying on derivation), because config.js's
+// loadEnvFile() repopulates missing env vars from a repo-level .env file
+// at require time — deleting would be undone on developer machines that
+// have TASKS_BASE in .env. Inner describe blocks that override only
+// WORKTREES_BASE get their TASKS_BASE derived inside runOrchestrator()
+// below, so per-suite isolation still works.
 const ORIG_ENV = {
   WORKTREES_BASE: process.env.WORKTREES_BASE,
   TASKS_BASE: process.env.TASKS_BASE,
@@ -33,23 +34,31 @@ const TEMP_WORKTREES_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'work-orchestr
 const TEMP_TASKS_BASE = path.join(TEMP_WORKTREES_BASE, 'tasks');
 fs.mkdirSync(TEMP_TASKS_BASE, { recursive: true });
 process.env.WORKTREES_BASE = TEMP_WORKTREES_BASE;
-delete process.env.TASKS_BASE;
+process.env.TASKS_BASE = TEMP_TASKS_BASE;
 
 const GET_CONFIG_PATH = path.join(__dirname, '..', '..', 'lib', 'get-config');
 const CONFIG_PATH = path.join(__dirname, '..', '..', 'lib', 'config');
 const getConfig = require(GET_CONFIG_PATH);
 const TASKS_BASE = getConfig.require('TASKS_BASE');
-// Env/cache restoration happens in the global after() hook further down.
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function runOrchestrator(args = [], opts = {}) {
+  // If an inner describe block overrides WORKTREES_BASE without also
+  // overriding TASKS_BASE, derive TASKS_BASE from the inner WORKTREES_BASE
+  // so the child doesn't inherit the top-level TASKS_BASE (which would
+  // point at a different dir than the inner suite's per-suite tasks/).
+  const optsEnv = opts.env || {};
+  const derivedEnv = { ...optsEnv };
+  if (optsEnv.WORKTREES_BASE && !Object.prototype.hasOwnProperty.call(optsEnv, 'TASKS_BASE')) {
+    derivedEnv.TASKS_BASE = path.join(optsEnv.WORKTREES_BASE, 'tasks');
+  }
   return new Promise((resolve, reject) => {
     const proc = spawn('node', [HOOK_PATH, ...args], {
       stdio: ['pipe', 'pipe', 'pipe'],
       // Intentionally disable session guard to isolate orchestrator plan logic.
       // Session guard has dedicated tests in session-guard.test.js (26 tests covering all subcommands + hooks).
-      env: { ...process.env, SESSION_GUARD_ENABLED: '0', ...opts.env },
+      env: { ...process.env, SESSION_GUARD_ENABLED: '0', ...derivedEnv },
       cwd: opts.cwd,
     });
 


### PR DESCRIPTION
## Existing Behavior

- `work-enforce-steps.test.js` resolved ticket directories using the real `TASKS_BASE` inherited from the environment, with no temp-dir isolation. It used `PROJ-${Date.now()}` ticket ids, which clashed with the hook's extraction regex (`GH-\d+|\d+`), causing the hook to write to `tasks/GH-<ts>/` while the test asserted on `tasks/PROJ-<ts>/`. Assertion failure skipped per-test `fs.rmSync` cleanup, leaking both directories.
- `work-orchestrator.test.js` read `TASKS_BASE` from the real env at module load time. Its global `after()` only scrubbed `TEST-*`-prefixed dirs and was skipped entirely on hard crashes, leaving every other ticket prefix (e.g. `PROJ-123`, `#TEST-444`) to accumulate in the real tasks folder.
- Over time the above accumulated 72+ timestamp-based orphan dirs and 9 `#`-prefixed leak dirs in the user's real `~/p/w-claude-plugin/tasks/` directory.

## Intended New Behavior

- `work-enforce-steps.test.js` creates a `fs.mkdtempSync` temp `TASKS_BASE` and sets `process.env.TASKS_BASE` + `TICKET_PROJECT_KEY=TESTGH` before requiring `../../lib/config` (which caches env at init). The same env vars are forwarded to the hook subprocess so both sides resolve to the same directory. Ticket ids use `pid + counter` under the matching project key — collision-free across parallel runs with no cross-prefix mismatch. A single unconditional `after()` nukes the entire temp base, replacing per-test cleanup that was silently skipped on failures.
- `work-orchestrator.test.js` creates temp `WORKTREES_BASE` and `TASKS_BASE` dirs via `mkdtempSync` and sets them on `process.env` before loading `get-config`. The selective `TEST-*` filter in `after()` is replaced with a single `fs.rmSync(TEMP_WORKTREES_BASE, { recursive: true })` that covers all ticket prefixes unconditionally.
- The real `tasks/` directory is never touched by either test suite regardless of assertion outcome or crash.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Test files only — no production code changed. To verify:

1. From the repo root, record the current entry count in the real tasks dir:
   ```bash
   ls ~/p/w-claude-plugin/tasks/ | wc -l
   ```
2. Run the enforce-steps suite:
   ```bash
   node --test workflows/work/__tests__/work-enforce-steps.test.js
   ```
   Expected: 4/4 pass; entry count in `tasks/` unchanged.
3. Run the orchestrator suite:
   ```bash
   node --test workflows/work/__tests__/work-orchestrator.test.js
   ```
   Expected: 95 pass / 11 fail (all 11 are pre-existing unrelated failures); entry count in `tasks/` unchanged; `#PROJ-123/.work-state.json` mtime unchanged between runs.
4. Confirm no new entries were created under `~/p/w-claude-plugin/tasks/` after both runs.

### Test Results

- `work-enforce-steps.test.js`: 4/4 pass
- `work-orchestrator.test.js`: 95 pass / 11 fail (pre-existing, unrelated to this change)
- Real `tasks/` entry count: unchanged before and after both suites