### PR TITLE
feat(work): gate brief->spec on unresolved open questions (GH-215)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env
 .envrc
 node_modules/
+node_modules
 
 # Runtime-generated hook artifacts
 .claude-code-check-request.json

--- a/agents/brief-writer.md
+++ b/agents/brief-writer.md
@@ -80,8 +80,22 @@ Generate a markdown document with this structure:
 - {How do we measure success?}
 
 ## Open Questions
-- {Anything that needs clarification}
+
+- **Question:** {question text}
+  - `scope: local | cross-ticket | architectural`
+  - `rationale: {why this classification}`
+  - `resolved: false`
 ```
+
+### Open Questions — Classification Guidance
+
+Every open question MUST be emitted as a structured bullet with an explicit `scope` classification. Use these definitions to choose the correct category at emission time:
+
+- **`local`** — Implementation detail contained within this ticket; the answer does not change sibling work and has zero blast radius outside this brief.
+- **`cross-ticket`** — Blast radius extends beyond this ticket; the decision affects siblings (parallel tickets, shared modules, or downstream consumers) and must be resolved before those siblings can safely proceed.
+- **`architectural`** — Systemic or foundational choice whose blast radius affects siblings, platform conventions, or long-lived contracts (data models, public APIs, auth, infra shape); requires explicit sign-off, not just a default.
+
+Always emit `resolved: false` on creation. Only `local` questions may remain unresolved when handing off; `cross-ticket` and `architectural` questions block the downstream gate and must be resolved (or explicitly downgraded to `local` with a justification) before the spec step runs.
 
 ## Workflow
 

--- a/skills/brief/SKILL.md
+++ b/skills/brief/SKILL.md
@@ -76,3 +76,22 @@ After the agent completes:
 - Confirm the file was saved
 - Show the path
 - Suggest next step: "Run `/spec ${FOLDER_NAME}` to generate a technical specification from this brief."
+
+## Open Questions: Scope Classification and the Brief Gate
+
+Every entry under `## Open Questions` in the generated brief is emitted as a structured bullet with an explicit `scope:` classification. The scope tells downstream tooling whether the question is safe to defer or whether it must be answered before the spec step runs.
+
+### Scope categories
+
+- **`local`** — Implementation detail contained within this ticket; the answer does not change sibling work and has zero blast radius outside this brief.
+- **`cross-ticket`** — Decision affects siblings (parallel tickets, shared modules, or downstream consumers) and must be resolved before those siblings can safely proceed.
+- **`architectural`** — Systemic or foundational choice affecting siblings, platform conventions, or long-lived contracts (data models, public APIs, auth, infra shape); requires explicit sign-off, not a default.
+
+### Brief gate behavior
+
+Between the `brief` step and the `spec` step, the workflow runs a `brief_gate` check over the brief's Open Questions:
+
+- Unresolved questions with `scope: cross-ticket` or `scope: architectural` **block** the transition from brief to spec. The planner emits a `RUN` action that prompts you interactively via `AskUserQuestion`; your answer is written back into the brief as a `Resolution:` line and the question is flipped to `resolved: true`. The gate re-runs until no blocking questions remain.
+- Unresolved questions with `scope: local` **do not block** the gate. They are clarifications that do not affect sibling tickets or architecture, so they can carry forward into spec and be resolved in context.
+
+If a question was mis-classified at emission time, you can downgrade it to `local` with a written justification (or upgrade it) by editing the brief directly before re-running the gate.

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -3588,6 +3588,31 @@ describe('enforce-step-workflow', () => {
       );
     });
 
+    it('blocks brief_gate -> spec when brief has unresolved cross-ticket question', async () => {
+      // Scenario 2 (cross-ticket counterpart): the gate must also block on
+      // scope: cross-ticket unresolved questions. This locks in that BOTH
+      // blocking scopes (architectural + cross-ticket) are handled at the
+      // integration level, not just architectural.
+      writeWorkState(makeStepStatus('brief_gate', WORK_STEPS));
+      writeBrief(buildBrief({ scope: 'cross-ticket', resolved: false }));
+
+      const { code, stderr } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: `node ${ORCHESTRATOR_PATH} transition ${TEST_TICKET} spec` },
+      });
+      assert.equal(
+        code,
+        2,
+        'Should block brief_gate -> spec when cross-ticket question is unresolved'
+      );
+      assert.ok(stderr.includes('BLOCKED'), 'stderr should contain BLOCKED marker');
+      assert.match(
+        stderr,
+        /brief[_-]gate|open questions|unresolved/i,
+        `stderr should mention brief_gate / open questions / unresolved. stderr: ${stderr}`
+      );
+    });
+
     it('allows brief_gate -> spec when architectural question is resolved', async () => {
       // Scenario 4 (first half): architectural question with resolved: true
       // and a Resolution: subfield must pass cleanly.

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -115,6 +115,12 @@ const WORK_STEPS = [
   'ticket',
   'bootstrap',
   'brief',
+  // GH-215: brief_gate sits between `brief` and `spec` so the hook can block
+  // the transition into `spec` until every cross-ticket/architectural open
+  // question in brief.md has been resolved. The ordering here must mirror
+  // workflows/work/step-registry.js:ALL_STEPS so tests that rely on
+  // makeStepStatus() see an authentic in-progress/pending split.
+  'brief_gate',
   'spec',
   'implement',
   'commit',
@@ -3489,6 +3495,154 @@ describe('enforce-step-workflow', () => {
       });
       assert.equal(code, 2, 'Should block when tdd-phase.json is absent');
       assert.ok(stderr.includes('BLOCKED'));
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // GH-215: brief_gate transition (brief_gate -> spec)
+  // ═══════════════════════════════════════════════════════════════════════════
+  //
+  // These tests exercise the end-to-end enforce-step-workflow hook against the
+  // verify entry wired up in workflow-definition.js for STEPS.brief_gate. They
+  // simulate a planner asking the orchestrator to advance the workflow from
+  // `brief_gate` to `spec`. The hook must:
+  //   - allow the transition when brief.md has no blocking open questions
+  //     (only-local questions, or architectural questions already resolved),
+  //   - block the transition with a BLOCKED message when one or more
+  //     architectural / cross-ticket questions remain unresolved, and
+  //   - behave idempotently: running two consecutive transitions against an
+  //     already-resolved brief must leave brief.md byte-equal and succeed both
+  //     times.
+  //
+  // Shared helpers for building fixture briefs live at the top of this block
+  // so all four scenarios use identical framing (same heading placement, same
+  // subfield indentation, same trailing newline) — that isolates the gate's
+  // behavior from any whitespace noise in the fixtures.
+  describe('brief_gate -> spec transition (GH-215)', () => {
+    const ORCHESTRATOR_PATH = path.join(__dirname, '..', '..', 'work', 'work.workflow.js');
+    const BRIEF_PATH = () => path.join(TASKS_DIR, 'brief.md');
+
+    // Minimal brief.md containing a single structured Open Question of the
+    // requested scope + resolved state. Kept deliberately small so a diff of a
+    // failing byte-equality assertion is readable.
+    function buildBrief({ scope, resolved, withResolution = false }) {
+      const lines = [
+        '# Brief',
+        '',
+        '## Open Questions',
+        '',
+        '- **Question:** Does this change affect the shared auth layer?',
+        '  - `scope: ' + scope + '`',
+        '  - `resolved: ' + (resolved ? 'true' : 'false') + '`',
+        '  - `rationale: gate-scenario fixture`',
+      ];
+      if (withResolution) {
+        lines.push('  - **Resolution:** No — stays confined to this module.');
+      }
+      lines.push(''); // trailing newline for POSIX-friendly files
+      return lines.join('\n');
+    }
+
+    function writeBrief(markdown) {
+      if (!fs.existsSync(TASKS_DIR)) fs.mkdirSync(TASKS_DIR, { recursive: true });
+      fs.writeFileSync(BRIEF_PATH(), markdown);
+    }
+
+    it('allows brief_gate -> spec when brief has only scope: local questions', async () => {
+      // Scenario 1 (spec §Test Scenarios): only-local questions never block.
+      writeWorkState(makeStepStatus('brief_gate', WORK_STEPS));
+      writeBrief(buildBrief({ scope: 'local', resolved: false }));
+
+      const { code, stderr } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: `node ${ORCHESTRATOR_PATH} transition ${TEST_TICKET} spec` },
+      });
+      assert.equal(
+        code,
+        0,
+        `Should allow brief_gate -> spec for only-local brief. stderr: ${stderr}`
+      );
+    });
+
+    it('blocks brief_gate -> spec when brief has unresolved architectural question', async () => {
+      // Scenario 2: unresolved architectural must block with a reason.
+      writeWorkState(makeStepStatus('brief_gate', WORK_STEPS));
+      writeBrief(buildBrief({ scope: 'architectural', resolved: false }));
+
+      const { code, stderr } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: `node ${ORCHESTRATOR_PATH} transition ${TEST_TICKET} spec` },
+      });
+      assert.equal(
+        code,
+        2,
+        'Should block brief_gate -> spec when architectural question is unresolved'
+      );
+      assert.ok(stderr.includes('BLOCKED'), 'stderr should contain BLOCKED marker');
+      // Tightened assertion: the block reason must reference the gate or the
+      // open questions it guards so the user understands what to fix.
+      assert.match(
+        stderr,
+        /brief[_-]gate|open questions|unresolved/i,
+        `stderr should mention brief_gate / open questions / unresolved. stderr: ${stderr}`
+      );
+    });
+
+    it('allows brief_gate -> spec when architectural question is resolved', async () => {
+      // Scenario 4 (first half): architectural question with resolved: true
+      // and a Resolution: subfield must pass cleanly.
+      writeWorkState(makeStepStatus('brief_gate', WORK_STEPS));
+      writeBrief(buildBrief({ scope: 'architectural', resolved: true, withResolution: true }));
+
+      const { code, stderr } = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: `node ${ORCHESTRATOR_PATH} transition ${TEST_TICKET} spec` },
+      });
+      assert.equal(
+        code,
+        0,
+        `Should allow brief_gate -> spec for resolved architectural brief. stderr: ${stderr}`
+      );
+    });
+
+    it('is idempotent: two consecutive runs leave brief.md byte-equal and both pass', async () => {
+      // Scenario 6: re-running the gate on an already-resolved brief must not
+      // mutate the file (byte-equal) and must not re-prompt — both transitions
+      // succeed. This guards against accidental rewriter side-effects in the
+      // verify path and against duplicate Resolution lines.
+      writeWorkState(makeStepStatus('brief_gate', WORK_STEPS));
+      const initial = buildBrief({
+        scope: 'architectural',
+        resolved: true,
+        withResolution: true,
+      });
+      writeBrief(initial);
+
+      const first = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: `node ${ORCHESTRATOR_PATH} transition ${TEST_TICKET} spec` },
+      });
+      assert.equal(first.code, 0, `First run should pass. stderr: ${first.stderr}`);
+      const afterFirst = fs.readFileSync(BRIEF_PATH(), 'utf-8');
+      assert.equal(
+        afterFirst,
+        initial,
+        'brief.md must be byte-equal after the first gate run (verify is read-only)'
+      );
+
+      // Re-arm the state as the orchestrator would on a subsequent /work pass.
+      writeWorkState(makeStepStatus('brief_gate', WORK_STEPS));
+      const second = await runHook({
+        tool_name: 'Bash',
+        tool_input: { command: `node ${ORCHESTRATOR_PATH} transition ${TEST_TICKET} spec` },
+      });
+      assert.equal(second.code, 0, `Second run should also pass. stderr: ${second.stderr}`);
+      const afterSecond = fs.readFileSync(BRIEF_PATH(), 'utf-8');
+      assert.equal(
+        afterSecond,
+        initial,
+        'brief.md must remain byte-equal after the second gate run (idempotent)'
+      );
     });
   });
 

--- a/workflows/work/__tests__/plan-generator-brief-gate.test.js
+++ b/workflows/work/__tests__/plan-generator-brief-gate.test.js
@@ -1,0 +1,188 @@
+/**
+ * Tests for workflows/work/plan-generator.js — GH-215 Task 6.2
+ *
+ * Verifies that the plan generator emits `brief_gate` between `brief` and
+ * `spec` entries. This closes the loop between:
+ *   - Task 3 (STEPS.brief_gate constant + ALL_STEPS ordering), and
+ *   - Task 4 (briefGateStep implementation)
+ * by proving the gate is actually observable in generatePlan() output.
+ *
+ * Strategy: call generatePlan() directly with mocked deps and state rather
+ * than spawning the CLI — this keeps the assertion fast, deterministic, and
+ * focused purely on step ordering in the returned plan array.
+ *
+ * Run: node --test workflows/work/__tests__/plan-generator-brief-gate.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { generatePlan } = require(path.join(__dirname, '..', 'plan-generator'));
+const { STEPS } = require(path.join(__dirname, '..', 'step-registry'));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal deps object for generatePlan(). None of the step modules
+ * under test (brief, brief_gate, spec) need the heavier dependencies for the
+ * ordering assertion — we only care that each emits a plan entry with the
+ * correct `step` name, in the correct order.
+ */
+function makeDeps(overrides = {}) {
+  return {
+    tp: {
+      sanitizeTicketIdForPath: (t) => t,
+      getProviderConfig: () => ({}),
+      getCreateTicketAgentType: () => 'general-purpose',
+      getCreateTicketPrompt: () => null,
+      getFetchTicketPrompt: () => 'Fetch ticket TEST-100 details.',
+      getTransitionPrompt: () => 'Move ticket to In Development',
+    },
+    TDD_PROTOCOL: '',
+    TDD_GATED_STEPS: [],
+    STEPS,
+    parseTasks: () => [],
+    buildTaskPrompt: () => '',
+    fileExists: () => false,
+    run: () => '',
+    WORKTREES_BASE: '/tmp/worktrees',
+    TASKS_BASE: '/tmp/tasks',
+    MAIN_WORKTREE_FOLDER: 'my-project',
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal inspected state — enough for every step module to make a SKIP
+ * decision without reading real files. The key flag under test is hasBrief,
+ * which controls whether brief_gate emits SKIP ("No brief.md present") or
+ * attempts to read brief.md.
+ */
+function makeState(overrides = {}) {
+  return {
+    worktreeExists: true,
+    tasksDirExists: true,
+    hasStateFile: false,
+    currentStep: 'brief',
+    worktreeDir: '/tmp/worktrees/my-project-TEST-100',
+    tasksDir: '/tmp/tasks/TEST-100',
+    branch: null,
+    headSha: null,
+    hasDiffVsMain: false,
+    diffSummary: '',
+    hasCommitWithTicket: false,
+    hasUncommitted: false,
+    uncommittedCount: 0,
+    hasUnpushed: false,
+    lastCommitMsg: '',
+    pr: { number: 1 },
+    reports: {},
+    allReportsPass: true,
+    missingReports: [],
+    failedReports: [],
+    prUpdateSha: null,
+    postPrUpdateSha: null,
+    prEverUpdated: false,
+    prShaMatch: false,
+    hasBrief: false,
+    hasSpec: false,
+    hasTasks: false,
+    hasDevSession: false,
+    workState: null,
+    stepIs: () => 'unknown',
+    ...overrides,
+  };
+}
+
+function stepIndex(plan, stepName) {
+  return plan.findIndex((entry) => entry.step === stepName);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('plan-generator brief_gate ordering (GH-215 Task 6.2)', () => {
+  it('emits brief_gate when brief is not yet present (SKIP path)', () => {
+    const state = makeState({ hasBrief: false });
+    const { plan } = generatePlan(
+      'TEST-100',
+      null,
+      state,
+      /* rework */ false,
+      /* callerProviderCfg */ null,
+      /* suffix */ null,
+      makeDeps()
+    );
+
+    const briefIdx = stepIndex(plan, STEPS.brief);
+    const gateIdx = stepIndex(plan, STEPS.brief_gate);
+    const specIdx = stepIndex(plan, STEPS.spec);
+
+    assert.ok(briefIdx >= 0, 'plan should contain a brief entry');
+    assert.ok(gateIdx >= 0, 'plan should contain a brief_gate entry');
+    assert.ok(specIdx >= 0, 'plan should contain a spec entry');
+    assert.equal(gateIdx, briefIdx + 1, 'brief_gate must come directly after brief');
+    assert.equal(specIdx, gateIdx + 1, 'spec must come directly after brief_gate');
+  });
+
+  it('emits brief_gate when hasBrief is true (gate evaluates brief.md)', () => {
+    // With hasBrief=true, the gate will try to read brief.md via fs and
+    // fail-open to a SKIP ("brief.md unreadable") because we use a bogus path.
+    // That is fine for the ordering assertion — we only care that a
+    // brief_gate entry appears between brief and spec.
+    const state = makeState({ hasBrief: true });
+    const { plan } = generatePlan(
+      'TEST-100',
+      null,
+      state,
+      false,
+      null,
+      null,
+      makeDeps()
+    );
+
+    const briefIdx = stepIndex(plan, STEPS.brief);
+    const gateIdx = stepIndex(plan, STEPS.brief_gate);
+    const specIdx = stepIndex(plan, STEPS.spec);
+
+    assert.ok(briefIdx >= 0, 'plan should contain a brief entry');
+    assert.ok(gateIdx >= 0, 'plan should contain a brief_gate entry when hasBrief is true');
+    assert.ok(specIdx >= 0, 'plan should contain a spec entry');
+    assert.equal(gateIdx, briefIdx + 1);
+    assert.equal(specIdx, gateIdx + 1);
+  });
+
+  it('keeps brief_gate in the plan even when brief step is disabled', () => {
+    // WORK_BRIEF_ENABLED=0 makes brief step SKIP; the gate also SKIPs for
+    // the same reason, but both entries must still appear in order so the
+    // workflow state machine can advance through brief_gate.
+    const prev = process.env.WORK_BRIEF_ENABLED;
+    process.env.WORK_BRIEF_ENABLED = '0';
+    try {
+      const { plan } = generatePlan(
+        'TEST-100',
+        null,
+        makeState(),
+        false,
+        null,
+        null,
+        makeDeps()
+      );
+
+      const briefIdx = stepIndex(plan, STEPS.brief);
+      const gateIdx = stepIndex(plan, STEPS.brief_gate);
+      const specIdx = stepIndex(plan, STEPS.spec);
+
+      assert.ok(briefIdx >= 0);
+      assert.ok(gateIdx >= 0);
+      assert.ok(specIdx >= 0);
+      assert.equal(gateIdx, briefIdx + 1);
+      assert.equal(specIdx, gateIdx + 1);
+    } finally {
+      if (prev === undefined) delete process.env.WORK_BRIEF_ENABLED;
+      else process.env.WORK_BRIEF_ENABLED = prev;
+    }
+  });
+});

--- a/workflows/work/__tests__/step-registry.test.js
+++ b/workflows/work/__tests__/step-registry.test.js
@@ -1,0 +1,57 @@
+/**
+ * Tests for workflows/work/step-registry.js
+ *
+ * GH-215: Verifies that the `brief_gate` step constant is declared and
+ * inserted into ALL_STEPS immediately between `brief` and `spec`. The gate
+ * step must sit between brief and spec so the orchestrator can evaluate
+ * unresolved cross-ticket / architectural questions before spec planning.
+ *
+ * Run: node --test workflows/work/__tests__/step-registry.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { STEPS, ALL_STEPS, STEP_ORDER } = require(path.join(__dirname, '..', 'step-registry'));
+
+describe('step-registry', () => {
+  describe('STEPS constant map', () => {
+    it('declares brief_gate identifier', () => {
+      assert.equal(STEPS.brief_gate, 'brief_gate');
+    });
+
+    it('still declares the surrounding brief and spec identifiers', () => {
+      assert.equal(STEPS.brief, 'brief');
+      assert.equal(STEPS.spec, 'spec');
+    });
+  });
+
+  describe('ALL_STEPS ordering', () => {
+    it('includes brief_gate', () => {
+      assert.ok(ALL_STEPS.includes('brief_gate'), 'ALL_STEPS should contain brief_gate');
+    });
+
+    it('inserts brief_gate immediately after brief', () => {
+      const briefIdx = ALL_STEPS.indexOf('brief');
+      const gateIdx = ALL_STEPS.indexOf('brief_gate');
+      assert.ok(briefIdx >= 0, 'brief must exist in ALL_STEPS');
+      assert.equal(gateIdx, briefIdx + 1);
+    });
+
+    it('inserts brief_gate immediately before spec', () => {
+      const specIdx = ALL_STEPS.indexOf('spec');
+      const gateIdx = ALL_STEPS.indexOf('brief_gate');
+      assert.ok(specIdx >= 0, 'spec must exist in ALL_STEPS');
+      assert.equal(gateIdx, specIdx - 1);
+    });
+
+    it('STEP_ORDER reflects the same brief -> brief_gate -> spec sequence', () => {
+      const briefIdx = STEP_ORDER.indexOf('brief');
+      const gateIdx = STEP_ORDER.indexOf('brief_gate');
+      const specIdx = STEP_ORDER.indexOf('spec');
+      assert.equal(gateIdx, briefIdx + 1);
+      assert.equal(specIdx, gateIdx + 1);
+    });
+  });
+});

--- a/workflows/work/__tests__/tdd-enforcement.test.js
+++ b/workflows/work/__tests__/tdd-enforcement.test.js
@@ -105,6 +105,7 @@ async function transitionTo(ticket, targetStep, envExtra = {}) {
   const steps = [
     'bootstrap',
     'brief',
+    'brief_gate', // GH-215
     'spec',
     'tasks',
     'implement',
@@ -388,6 +389,7 @@ describe('TDD enforcement', () => {
       // Walk to implement linearly
       await runOrchestrator(['transition', TICKET, 'bootstrap'], { env: baseEnv() });
       await runOrchestrator(['transition', TICKET, 'brief'], { env: baseEnv() });
+      await runOrchestrator(['transition', TICKET, 'brief_gate'], { env: baseEnv() });
       await runOrchestrator(['transition', TICKET, 'spec'], { env: baseEnv() });
       await runOrchestrator(['transition', TICKET, 'tasks'], { env: baseEnv() });
       await runOrchestrator(['transition', TICKET, 'implement'], { env: baseEnv() });
@@ -422,6 +424,7 @@ describe('TDD enforcement', () => {
     it('transition INTO 3_implement with no prior tdd-phase.json does not error (ENOENT handled)', async () => {
       await runOrchestrator(['transition', TICKET, 'bootstrap'], { env: baseEnv() });
       await runOrchestrator(['transition', TICKET, 'brief'], { env: baseEnv() });
+      await runOrchestrator(['transition', TICKET, 'brief_gate'], { env: baseEnv() });
       await runOrchestrator(['transition', TICKET, 'spec'], { env: baseEnv() });
       await runOrchestrator(['transition', TICKET, 'tasks'], { env: baseEnv() });
       // Make sure no phase state file exists

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -145,7 +145,8 @@ describe('work-orchestrator.js', () => {
       assert.ok(result.transitions);
       assert.ok(result.steps.includes('ticket'));
       assert.ok(result.steps.includes('complete'));
-      assert.equal(result.steps.length, 15);
+      // GH-215: added brief_gate between brief and spec.
+      assert.equal(result.steps.length, 16);
     });
 
     it('should include follow_up in steps', async () => {
@@ -390,6 +391,7 @@ describe('work-orchestrator.js', () => {
     it('should block invalid transition', async () => {
       await runOrchestrator(['transition', TEST_TICKET, 'bootstrap'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'brief'], transOpts);
+      await runOrchestrator(['transition', TEST_TICKET, 'brief_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'spec'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'tasks'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'implement'], transOpts);
@@ -403,6 +405,7 @@ describe('work-orchestrator.js', () => {
     it('should allow retry loop (backward transition)', async () => {
       await runOrchestrator(['transition', TEST_TICKET, 'bootstrap'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'brief'], transOpts);
+      await runOrchestrator(['transition', TEST_TICKET, 'brief_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'spec'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'tasks'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'implement'], transOpts);
@@ -426,6 +429,7 @@ describe('work-orchestrator.js', () => {
     it('should persist state after transition', async () => {
       await runOrchestrator(['transition', TEST_TICKET, 'bootstrap'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'brief'], transOpts);
+      await runOrchestrator(['transition', TEST_TICKET, 'brief_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'spec'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'tasks'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'implement'], transOpts);
@@ -439,6 +443,7 @@ describe('work-orchestrator.js', () => {
     it('should reset intermediate steps on backward transition', async () => {
       await runOrchestrator(['transition', TEST_TICKET, 'bootstrap']);
       await runOrchestrator(['transition', TEST_TICKET, 'brief']);
+      await runOrchestrator(['transition', TEST_TICKET, 'brief_gate']);
       await runOrchestrator(['transition', TEST_TICKET, 'spec']);
       await runOrchestrator(['transition', TEST_TICKET, 'tasks']);
       await runOrchestrator(['transition', TEST_TICKET, 'implement']);
@@ -453,9 +458,10 @@ describe('work-orchestrator.js', () => {
   });
 
   describe('state machine logic', () => {
-    it('should have 14 steps total', async () => {
+    it('should have 16 steps total', async () => {
       const { result } = await runOrchestrator(['graph']);
-      assert.equal(result.steps.length, 15);
+      // GH-215: added brief_gate between brief and spec.
+      assert.equal(result.steps.length, 16);
     });
 
     it('should not allow self-transitions (except complete)', async () => {
@@ -676,6 +682,7 @@ describe('work-orchestrator.js', () => {
       try {
         await runOrchestrator(['transition', T, 'bootstrap'], o);
         await runOrchestrator(['transition', T, 'brief'], o);
+        await runOrchestrator(['transition', T, 'brief_gate'], o);
         await runOrchestrator(['transition', T, 'spec'], o);
         await runOrchestrator(['transition', T, 'tasks'], o);
         await runOrchestrator(['transition', T, 'implement'], o);
@@ -698,6 +705,7 @@ describe('work-orchestrator.js', () => {
       try {
         await runOrchestrator(['transition', TEST_TICKET, 'bootstrap'], o);
         await runOrchestrator(['transition', TEST_TICKET, 'brief'], o);
+        await runOrchestrator(['transition', TEST_TICKET, 'brief_gate'], o);
         await runOrchestrator(['transition', TEST_TICKET, 'spec'], o);
         await runOrchestrator(['transition', TEST_TICKET, 'tasks'], o);
         await runOrchestrator(['transition', TEST_TICKET, 'implement'], o);
@@ -720,6 +728,7 @@ describe('work-orchestrator.js', () => {
       try {
         await runOrchestrator(['transition', TEST_TICKET, 'bootstrap'], o);
         await runOrchestrator(['transition', TEST_TICKET, 'brief'], o);
+        await runOrchestrator(['transition', TEST_TICKET, 'brief_gate'], o);
         await runOrchestrator(['transition', TEST_TICKET, 'spec'], o);
         await runOrchestrator(['transition', TEST_TICKET, 'tasks'], o);
         await runOrchestrator(['transition', TEST_TICKET, 'implement'], o);
@@ -837,6 +846,7 @@ describe('work-orchestrator.js', () => {
     it('should allow transition follow_up → ci (forward)', async () => {
       await runOrchestrator(['transition', T, 'bootstrap'], o);
       await runOrchestrator(['transition', T, 'brief'], o);
+      await runOrchestrator(['transition', T, 'brief_gate'], o);
       await runOrchestrator(['transition', T, 'spec'], o);
       await runOrchestrator(['transition', T, 'tasks'], o);
       await runOrchestrator(['transition', T, 'implement'], o);
@@ -859,6 +869,7 @@ describe('work-orchestrator.js', () => {
       try {
         await runOrchestrator(['transition', T2, 'bootstrap'], o);
         await runOrchestrator(['transition', T2, 'brief'], o);
+        await runOrchestrator(['transition', T2, 'brief_gate'], o);
         await runOrchestrator(['transition', T2, 'spec'], o);
         await runOrchestrator(['transition', T2, 'tasks'], o);
         await runOrchestrator(['transition', T2, 'implement'], o);
@@ -886,6 +897,7 @@ describe('work-orchestrator.js', () => {
       try {
         await runOrchestrator(['transition', T3, 'bootstrap'], o);
         await runOrchestrator(['transition', T3, 'brief'], o);
+        await runOrchestrator(['transition', T3, 'brief_gate'], o);
         await runOrchestrator(['transition', T3, 'spec'], o);
         await runOrchestrator(['transition', T3, 'tasks'], o);
         await runOrchestrator(['transition', T3, 'implement'], o);
@@ -914,6 +926,7 @@ describe('work-orchestrator.js', () => {
       try {
         await runOrchestrator(['transition', T_ARCHIVE, 'bootstrap'], o);
         await runOrchestrator(['transition', T_ARCHIVE, 'brief'], o);
+        await runOrchestrator(['transition', T_ARCHIVE, 'brief_gate'], o);
         await runOrchestrator(['transition', T_ARCHIVE, 'spec'], o);
         await runOrchestrator(['transition', T_ARCHIVE, 'tasks'], o);
         await runOrchestrator(['transition', T_ARCHIVE, 'implement'], o);
@@ -957,6 +970,7 @@ describe('work-orchestrator.js', () => {
         // First pass: bootstrap → ... → check, write reports, check → implement (backward)
         await runOrchestrator(['transition', T_RUNS, 'bootstrap'], o);
         await runOrchestrator(['transition', T_RUNS, 'brief'], o);
+        await runOrchestrator(['transition', T_RUNS, 'brief_gate'], o);
         await runOrchestrator(['transition', T_RUNS, 'spec'], o);
         await runOrchestrator(['transition', T_RUNS, 'tasks'], o);
         await runOrchestrator(['transition', T_RUNS, 'implement'], o);
@@ -988,6 +1002,7 @@ describe('work-orchestrator.js', () => {
       try {
         await runOrchestrator(['transition', T4, 'bootstrap'], o);
         await runOrchestrator(['transition', T4, 'brief'], o);
+        await runOrchestrator(['transition', T4, 'brief_gate'], o);
         await runOrchestrator(['transition', T4, 'spec'], o);
         await runOrchestrator(['transition', T4, 'tasks'], o);
         await runOrchestrator(['transition', T4, 'implement'], o);
@@ -1053,6 +1068,7 @@ describe('work-orchestrator.js', () => {
       // Build up to check linearly
       await runOrchestrator(['transition', TICKET, 'bootstrap'], envOpts);
       await runOrchestrator(['transition', TICKET, 'brief'], envOpts);
+      await runOrchestrator(['transition', TICKET, 'brief_gate'], envOpts);
       await runOrchestrator(['transition', TICKET, 'spec'], envOpts);
       await runOrchestrator(['transition', TICKET, 'tasks'], envOpts);
       await runOrchestrator(['transition', TICKET, 'implement'], envOpts);
@@ -1077,6 +1093,7 @@ describe('work-orchestrator.js', () => {
       // Build state up to check linearly
       await runOrchestrator(['transition', TICKET, 'bootstrap'], envOpts);
       await runOrchestrator(['transition', TICKET, 'brief'], envOpts);
+      await runOrchestrator(['transition', TICKET, 'brief_gate'], envOpts);
       await runOrchestrator(['transition', TICKET, 'spec'], envOpts);
       await runOrchestrator(['transition', TICKET, 'tasks'], envOpts);
       await runOrchestrator(['transition', TICKET, 'implement'], envOpts);
@@ -1310,6 +1327,7 @@ describe('work-orchestrator.js', () => {
     async function advanceToCheck() {
       await runOrchestrator(['transition', TICKET, 'bootstrap'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'brief'], gateOpts);
+      await runOrchestrator(['transition', TICKET, 'brief_gate'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'spec'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'tasks'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'implement'], gateOpts);
@@ -1367,6 +1385,7 @@ describe('work-orchestrator.js', () => {
     it('should NOT evaluate check gate on implement → commit transition', async () => {
       await runOrchestrator(['transition', TICKET, 'bootstrap'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'brief'], gateOpts);
+      await runOrchestrator(['transition', TICKET, 'brief_gate'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'spec'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'tasks'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'implement'], gateOpts);

--- a/workflows/work/__tests__/work-state.test.js
+++ b/workflows/work/__tests__/work-state.test.js
@@ -72,7 +72,7 @@ describe('work-state.js', () => {
       cleanupTempWorkState(TICKET);
     });
 
-    it('should create state with all 15 steps as pending', async () => {
+    it('should create state with all 16 steps as pending', async () => {
       const { result, code } = await runWorkState(['init', TICKET]);
       assert.equal(code, 0);
       assert.equal(result.ticketId, TICKET);
@@ -83,7 +83,8 @@ describe('work-state.js', () => {
       assert.equal(result.errors.length, 0);
 
       const steps = Object.keys(result.stepStatus);
-      assert.equal(steps.length, 15);
+      // GH-215: 16 steps — added brief_gate between brief and spec.
+      assert.equal(steps.length, 16);
       for (const step of steps) {
         assert.equal(result.stepStatus[step], 'pending', `Step ${step} should be pending`);
       }
@@ -93,6 +94,7 @@ describe('work-state.js', () => {
         'ticket',
         'bootstrap',
         'brief',
+        'brief_gate', // GH-215
         'spec',
         'tasks',
         'implement',
@@ -144,7 +146,8 @@ describe('work-state.js', () => {
       assert.equal(code, 0);
       assert.equal(result.ticketId, TICKET_EXISTS);
       assert.equal(result.status, 'in_progress');
-      assert.equal(Object.keys(result.stepStatus).length, 15);
+      // GH-215: 16 steps — added brief_gate between brief and spec.
+      assert.equal(Object.keys(result.stepStatus).length, 16);
       for (const step of Object.keys(result.stepStatus)) {
         assert.equal(result.stepStatus[step], 'pending');
       }
@@ -174,8 +177,9 @@ describe('work-state.js', () => {
       // Verify persistence
       const { result: getResult } = await runWorkState(['get', TICKET]);
       assert.equal(getResult.stepStatus['implement'], 'in_progress');
-      // currentStep should be updated to 6 (index 5 + 1, after ticket/bootstrap/brief/spec/tasks)
-      assert.equal(getResult.currentStep, 6);
+      // currentStep should be updated to 7 (index 6 + 1, after ticket/bootstrap/brief/brief_gate/spec/tasks)
+      // GH-215: brief_gate inserted between brief and spec shifts implement from index 5 to 6.
+      assert.equal(getResult.currentStep, 7);
     });
 
     it('should reject invalid step name with exit code 1', async () => {

--- a/workflows/work/__tests__/workflow-definition.test.js
+++ b/workflows/work/__tests__/workflow-definition.test.js
@@ -9,9 +9,11 @@
  * GH-206 Task 12: Extract declarative workflow policy config.
  */
 
-const { describe, it } = require('node:test');
+const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert');
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
 
 const createWorkflowDefinition = require(path.join(__dirname, '..', 'workflow-definition'));
 const { STEPS } = require(path.join(__dirname, '..', 'step-registry'));
@@ -133,5 +135,116 @@ describe('workflow-definition: agentGatedScripts', () => {
     assert.ok(entry.agents.includes('developer-react-senior'));
     assert.ok(entry.agents.includes('developer-devops'));
     assert.equal(entry.step, STEPS.implement);
+  });
+});
+
+// ─── GH-215 Task 7: brief_gate verify entry ─────────────────────────────────
+//
+// The verify function for STEPS.brief_gate must return true iff:
+//   (1) brief.md exists under the ticket's tasks dir, AND
+//   (2) openQuestions.findBlocking(parse(brief)) returns an empty array.
+// It must never throw — any read/parse failure is a fail-closed `false`.
+describe('workflow-definition: verify[STEPS.brief_gate]', () => {
+  // Create a throwaway tasks base so each test can stage its own brief.md
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'workflow-def-briefgate-'));
+  const ticketId = 'GH-215';
+  const ticketDir = path.join(tmpRoot, ticketId);
+  fs.mkdirSync(ticketDir, { recursive: true });
+
+  const deps = {
+    TASKS_BASE: tmpRoot,
+    safeTicketPath: (id) => id,
+    resolveGitHead: () => 'ref: refs/heads/stub',
+  };
+  const { workflow: briefGateWf } = createWorkflowDefinition(deps);
+
+  // Locate the verify function on the commandMap.
+  function getBriefGateVerify() {
+    const entries = briefGateWf.commandMap.filter(
+      (e) => e.step === STEPS.brief_gate && typeof e.verify === 'function'
+    );
+    return entries.length > 0 ? entries[0].verify : undefined;
+  }
+
+  function writeBrief(contents) {
+    fs.writeFileSync(path.join(ticketDir, 'brief.md'), contents, 'utf-8');
+  }
+  function removeBrief() {
+    const p = path.join(ticketDir, 'brief.md');
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+
+  after(() => {
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+
+  it('registers a verify function for STEPS.brief_gate on the commandMap', () => {
+    const verify = getBriefGateVerify();
+    assert.equal(typeof verify, 'function', 'expected verify[STEPS.brief_gate] to be a function');
+  });
+
+  it('returns false when brief.md is missing (fail-closed)', () => {
+    removeBrief();
+    const verify = getBriefGateVerify();
+    assert.equal(verify(ticketId), false);
+  });
+
+  it('returns false when brief has an unresolved architectural question', () => {
+    writeBrief(
+      [
+        '# Brief',
+        '',
+        '## Open Questions',
+        '',
+        '- **Question:** Should we change the auth model?',
+        '  - `scope: architectural`',
+        '  - `rationale: touches session handling`',
+        '  - `resolved: false`',
+        '',
+      ].join('\n')
+    );
+    const verify = getBriefGateVerify();
+    assert.equal(verify(ticketId), false);
+  });
+
+  it('returns true when all questions are local or resolved', () => {
+    writeBrief(
+      [
+        '# Brief',
+        '',
+        '## Open Questions',
+        '',
+        '- **Question:** What name should this helper use?',
+        '  - `scope: local`',
+        '  - `rationale: naming only, no cross-cutting impact`',
+        '  - `resolved: false`',
+        '',
+        '- **Question:** Should we change the auth model?',
+        '  - `scope: architectural`',
+        '  - `rationale: resolved during planning`',
+        '  - `resolved: true`',
+        '  - **Resolution:** Keep existing model.',
+        '',
+      ].join('\n')
+    );
+    const verify = getBriefGateVerify();
+    assert.equal(verify(ticketId), true);
+  });
+
+  it('returns false for a malformed brief read error (fail-closed)', () => {
+    // Remove the brief and place a directory at its path so read/parse fails.
+    removeBrief();
+    const briefPath = path.join(ticketDir, 'brief.md');
+    fs.mkdirSync(briefPath);
+    try {
+      const verify = getBriefGateVerify();
+      assert.equal(verify(ticketId), false);
+    } finally {
+      fs.rmdirSync(briefPath);
+    }
   });
 });

--- a/workflows/work/lib/__tests__/open-questions.test.js
+++ b/workflows/work/lib/__tests__/open-questions.test.js
@@ -10,7 +10,13 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { parse, findBlocking, classify, SCOPES } = require('../open-questions');
+const {
+  parse,
+  findBlocking,
+  classify,
+  SCOPES,
+  downgradeToLocal,
+} = require('../open-questions');
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
 
@@ -83,6 +89,44 @@ Nothing to question here.
 
 ## Out of Scope
 - Done.
+`;
+
+const FIXTURE_H1_AFTER_SECTION = `# Brief
+
+## Open Questions
+
+- **Question:** A real question
+  - \`scope: architectural\`
+  - \`rationale: r\`
+  - \`resolved: false\`
+
+# Second H1 Heading
+
+- Not a question, should not be parsed
+- Another stray bullet
+`;
+
+const FIXTURE_H3_AFTER_SECTION = `# Brief
+
+## Open Questions
+
+- **Question:** A real question
+  - \`scope: architectural\`
+  - \`rationale: r\`
+  - \`resolved: false\`
+
+### Sub Heading Inside Doc
+
+- Not a question
+`;
+
+const FIXTURE_MISSING_RESOLVED = `# Brief
+
+## Open Questions
+
+- **Question:** Structured block without resolved field
+  - \`scope: architectural\`
+  - \`rationale: author forgot resolved\`
 `;
 
 // ─── parse() ────────────────────────────────────────────────────────────────
@@ -161,6 +205,47 @@ describe('open-questions: parse', () => {
   it('does not crash on null/undefined input', () => {
     assert.deepEqual(parse(null), []);
     assert.deepEqual(parse(undefined), []);
+  });
+
+  it('does not bleed past an h1 heading that follows the section', () => {
+    const result = parse(FIXTURE_H1_AFTER_SECTION);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].questionText, 'A real question');
+  });
+
+  it('does not bleed past an h3 heading that follows the section', () => {
+    const result = parse(FIXTURE_H3_AFTER_SECTION);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].questionText, 'A real question');
+  });
+
+  it('endLine points to the last non-blank content line of each block', () => {
+    const result = parse(FIXTURE_MULTIPLE_MIXED);
+    const lines = FIXTURE_MULTIPLE_MIXED.split('\n');
+    for (const q of result) {
+      assert.notEqual(
+        lines[q.endLine].trim(),
+        '',
+        `endLine ${q.endLine} is blank: "${lines[q.endLine]}"`
+      );
+    }
+  });
+
+  it('endLine for a block with trailing blank before next block lands on last subfield', () => {
+    // FIXTURE_MULTIPLE_MIXED has three structured blocks. The first block's
+    // last non-blank content line is `  - \`resolved: false\``. We assert
+    // that the first question's endLine matches that line, not a blank.
+    const result = parse(FIXTURE_MULTIPLE_MIXED);
+    const lines = FIXTURE_MULTIPLE_MIXED.split('\n');
+    assert.ok(lines[result[0].endLine].includes('resolved: false'));
+  });
+
+  it('treats a missing resolved: field as resolved: false on a valid structured block', () => {
+    const result = parse(FIXTURE_MISSING_RESOLVED);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].scope, 'architectural');
+    assert.equal(result[0].resolved, false);
+    assert.equal(result[0].rationale, 'author forgot resolved');
   });
 });
 
@@ -245,5 +330,20 @@ describe('open-questions: classify', () => {
     assert.ok(Array.isArray(SCOPES));
     assert.ok(Object.isFrozen(SCOPES));
     assert.deepEqual([...SCOPES].sort(), ['architectural', 'cross-ticket', 'local']);
+  });
+});
+
+// ─── downgradeToLocal() P1 extension point ──────────────────────────────────
+
+describe('open-questions: downgradeToLocal (P1 extension point)', () => {
+  it('is exported as a function', () => {
+    assert.equal(typeof downgradeToLocal, 'function');
+  });
+
+  it('throws a "not implemented" error indicating P1 status', () => {
+    assert.throws(
+      () => downgradeToLocal('some question', 'some justification'),
+      /not implemented|P1/i
+    );
   });
 });

--- a/workflows/work/lib/__tests__/open-questions.test.js
+++ b/workflows/work/lib/__tests__/open-questions.test.js
@@ -543,6 +543,18 @@ describe('open-questions: applyResolutions', () => {
       'Resolved by inserting the subfield.',
       'resolution text must be set'
     );
+
+    // GH-215: Verify raw line ordering — `resolved: true` must appear
+    // BEFORE the `**Resolution:**` line, not after it.
+    const lines = result.split('\n');
+    const resolvedIdx = lines.findIndex((l) => l.includes('`resolved: true`'));
+    const resolutionIdx = lines.findIndex((l) => l.includes('**Resolution:**'));
+    assert.ok(resolvedIdx !== -1, 'resolved: true line must exist');
+    assert.ok(resolutionIdx !== -1, 'Resolution line must exist');
+    assert.ok(
+      resolvedIdx < resolutionIdx,
+      `resolved: true (line ${resolvedIdx}) must come before **Resolution:** (line ${resolutionIdx})`
+    );
   });
 
   it('is a no-op when the answer is pure whitespace that collapses to empty', () => {

--- a/workflows/work/lib/__tests__/open-questions.test.js
+++ b/workflows/work/lib/__tests__/open-questions.test.js
@@ -16,6 +16,8 @@ const {
   classify,
   SCOPES,
   downgradeToLocal,
+  applyResolutions,
+  escapeResolution,
 } = require('../open-questions');
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
@@ -345,5 +347,202 @@ describe('open-questions: downgradeToLocal (P1 extension point)', () => {
       () => downgradeToLocal('some question', 'some justification'),
       /not implemented|P1/i
     );
+  });
+});
+
+// ─── applyResolutions() ─────────────────────────────────────────────────────
+
+describe('open-questions: applyResolutions', () => {
+  it('is exported as a function', () => {
+    assert.equal(typeof applyResolutions, 'function');
+  });
+
+  it('rewrites a single unresolved architectural block with resolved: true and a Resolution line', () => {
+    const resolutions = new Map([
+      ['Should the gate be a hook or a step?', 'It should be a step.'],
+    ]);
+    const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
+
+    // The result is still a string containing the original heading and summary.
+    assert.equal(typeof result, 'string');
+    assert.ok(result.includes('# Product Brief'));
+    assert.ok(result.includes('## Summary'));
+
+    // Re-parse to verify the block is now resolved with the new resolution.
+    const parsed = parse(result);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].resolved, true);
+    assert.equal(parsed[0].resolution, 'It should be a step.');
+  });
+
+  it('rewrites only answered blocks in a multi-block brief', () => {
+    const resolutions = new Map([
+      ['How do siblings coordinate router ownership?', 'Via a shared registry.'],
+    ]);
+    const result = applyResolutions(FIXTURE_MULTIPLE_MIXED, resolutions);
+    const parsed = parse(result);
+
+    // Still 3 blocks, and only the cross-ticket one was updated.
+    assert.equal(parsed.length, 3);
+
+    // Block 0: local, unresolved, untouched
+    assert.equal(parsed[0].scope, 'local');
+    assert.equal(parsed[0].resolved, false);
+    assert.equal(parsed[0].resolution, undefined);
+
+    // Block 1: cross-ticket, now resolved
+    assert.equal(parsed[1].scope, 'cross-ticket');
+    assert.equal(parsed[1].resolved, true);
+    assert.equal(parsed[1].resolution, 'Via a shared registry.');
+
+    // Block 2: architectural, already resolved, untouched
+    assert.equal(parsed[2].scope, 'architectural');
+    assert.equal(parsed[2].resolved, true);
+    assert.equal(parsed[2].resolution, 'No, defer to Q3 planning.');
+  });
+
+  it('accepts a plain object (not just a Map) for resolutions', () => {
+    const resolutions = {
+      'Should the gate be a hook or a step?': 'It should be a step.',
+    };
+    const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
+    const parsed = parse(result);
+    assert.equal(parsed[0].resolved, true);
+    assert.equal(parsed[0].resolution, 'It should be a step.');
+  });
+
+  it('is a no-op when the question text is not found', () => {
+    const resolutions = new Map([['Nonexistent question?', 'unused']]);
+    const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
+    assert.equal(result, FIXTURE_SINGLE_STRUCTURED);
+  });
+
+  it('is a no-op when resolutions is empty', () => {
+    assert.equal(applyResolutions(FIXTURE_SINGLE_STRUCTURED, new Map()), FIXTURE_SINGLE_STRUCTURED);
+    assert.equal(applyResolutions(FIXTURE_SINGLE_STRUCTURED, {}), FIXTURE_SINGLE_STRUCTURED);
+  });
+
+  it('does not touch blocks that are already resolved (guard)', () => {
+    // Run once to resolve the single block.
+    const first = applyResolutions(
+      FIXTURE_SINGLE_STRUCTURED,
+      new Map([['Should the gate be a hook or a step?', 'First answer.']])
+    );
+    // Attempt to re-resolve with a different answer — should be a no-op
+    // because the block is already resolved.
+    const second = applyResolutions(
+      first,
+      new Map([['Should the gate be a hook or a step?', 'Second answer.']])
+    );
+    assert.equal(second, first);
+    const parsed = parse(second);
+    assert.equal(parsed[0].resolution, 'First answer.');
+  });
+
+  it('is idempotent: running twice with the same resolutions produces byte-equal output', () => {
+    const resolutions = new Map([
+      ['How do siblings coordinate router ownership?', 'Via a shared registry.'],
+      ['Where should the gate live?', 'In the work steps directory.'],
+    ]);
+    const once = applyResolutions(FIXTURE_MULTIPLE_MIXED, resolutions);
+    const twice = applyResolutions(once, resolutions);
+    assert.equal(twice, once);
+  });
+
+  it('preserves the Question[] count after a rewrite (no block corruption)', () => {
+    const before = parse(FIXTURE_MULTIPLE_MIXED).length;
+    const resolutions = new Map([
+      ['How do siblings coordinate router ownership?', 'answer'],
+    ]);
+    const after = parse(applyResolutions(FIXTURE_MULTIPLE_MIXED, resolutions)).length;
+    assert.equal(after, before);
+  });
+
+  it('preserves surrounding markdown byte-for-byte outside the changed block', () => {
+    const resolutions = new Map([
+      ['Should the gate be a hook or a step?', 'A step.'],
+    ]);
+    const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
+    // Heading, summary, and section header are unchanged verbatim.
+    assert.ok(result.startsWith('# Product Brief\n\n## Summary\nExample brief.\n\n## Open Questions\n'));
+  });
+
+  it('escapes injection: leading "##" heading in answer does not create a new section', () => {
+    const malicious = '## Injected Heading\nmore stuff';
+    const resolutions = new Map([
+      ['Should the gate be a hook or a step?', malicious],
+    ]);
+    const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
+
+    // Re-parse: still exactly one question, resolved.
+    const parsed = parse(result);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].resolved, true);
+
+    // The leading '#' characters must have been stripped so no new heading
+    // is introduced into the document.
+    assert.ok(!/^##\s+Injected Heading/m.test(result));
+  });
+
+  it('collapses multi-line answers to a single line', () => {
+    const multi = 'line one\nline two\nline three';
+    const resolutions = new Map([
+      ['Should the gate be a hook or a step?', multi],
+    ]);
+    const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
+    const parsed = parse(result);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].resolved, true);
+    // The stored resolution must not contain a literal newline.
+    assert.ok(parsed[0].resolution && !parsed[0].resolution.includes('\n'));
+    assert.ok(parsed[0].resolution.includes('line one'));
+    assert.ok(parsed[0].resolution.includes('line two'));
+  });
+
+  it('returns the input unchanged when markdown has no Open Questions section', () => {
+    const resolutions = new Map([['x', 'y']]);
+    assert.equal(applyResolutions(FIXTURE_NO_SECTION, resolutions), FIXTURE_NO_SECTION);
+  });
+});
+
+// ─── escapeResolution() ─────────────────────────────────────────────────────
+
+describe('open-questions: escapeResolution', () => {
+  it('is exported as a function', () => {
+    assert.equal(typeof escapeResolution, 'function');
+  });
+
+  it('returns an empty string for empty/nullish input', () => {
+    assert.equal(escapeResolution(''), '');
+    assert.equal(escapeResolution(null), '');
+    assert.equal(escapeResolution(undefined), '');
+  });
+
+  it('strips leading "#" characters so answers cannot start a new heading', () => {
+    assert.ok(!escapeResolution('## Heading').startsWith('#'));
+    assert.ok(!escapeResolution('# Top Heading').startsWith('#'));
+    assert.ok(!escapeResolution('#### Deep Heading').startsWith('#'));
+  });
+
+  it('collapses embedded newlines to spaces', () => {
+    const out = escapeResolution('line one\nline two\r\nline three');
+    assert.ok(!out.includes('\n'));
+    assert.ok(!out.includes('\r'));
+    assert.ok(out.includes('line one'));
+    assert.ok(out.includes('line two'));
+    assert.ok(out.includes('line three'));
+  });
+
+  it('leaves a clean single-line answer untouched', () => {
+    assert.equal(escapeResolution('A simple answer.'), 'A simple answer.');
+  });
+
+  it('neutralizes inline triple-backticks so they cannot terminate a fence', () => {
+    const out = escapeResolution('```js\nconst x = 1;\n```');
+    assert.ok(!out.includes('```'));
+  });
+
+  it('trims surrounding whitespace', () => {
+    assert.equal(escapeResolution('   hello   '), 'hello');
   });
 });

--- a/workflows/work/lib/__tests__/open-questions.test.js
+++ b/workflows/work/lib/__tests__/open-questions.test.js
@@ -503,6 +503,36 @@ describe('open-questions: applyResolutions', () => {
     const resolutions = new Map([['x', 'y']]);
     assert.equal(applyResolutions(FIXTURE_NO_SECTION, resolutions), FIXTURE_NO_SECTION);
   });
+
+  it('is a no-op when the answer collapses to empty after escaping (e.g. pure-hash input)', () => {
+    // `escapeResolution('###')` strips all leading `#` characters and
+    // returns `''`. An empty-after-escape answer must not produce a
+    // dangling `- **Resolution:** ` line with empty content — the block
+    // should remain unresolved so the gate re-prompts on the next pass.
+    const resolutions = new Map([
+      ['Should the gate be a hook or a step?', '###'],
+    ]);
+    const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
+
+    // Byte-equal to the input: no rewrite occurred.
+    assert.equal(result, FIXTURE_SINGLE_STRUCTURED);
+
+    // And re-parsing confirms the block is still unresolved with no
+    // `resolution` field (i.e., `undefined`, not an empty string).
+    const parsed = parse(result);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].resolved, false);
+    assert.equal(parsed[0].resolution, undefined);
+  });
+
+  it('is a no-op when the answer is pure whitespace that collapses to empty', () => {
+    // `escapeResolution('## ')` also returns `''`; same contract applies.
+    const resolutions = new Map([
+      ['Should the gate be a hook or a step?', '## '],
+    ]);
+    const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
+    assert.equal(result, FIXTURE_SINGLE_STRUCTURED);
+  });
 });
 
 // ─── escapeResolution() ─────────────────────────────────────────────────────
@@ -544,5 +574,15 @@ describe('open-questions: escapeResolution', () => {
 
   it('trims surrounding whitespace', () => {
     assert.equal(escapeResolution('   hello   '), 'hello');
+  });
+
+  it('returns an empty string for pure-hash / markdown-control-only input', () => {
+    // An answer consisting only of heading markers has no content left
+    // after leading-# stripping and whitespace trim. This is the input
+    // shape that motivates the `applyResolutions` no-op guard.
+    assert.equal(escapeResolution('###'), '');
+    assert.equal(escapeResolution('## '), '');
+    assert.equal(escapeResolution('#'), '');
+    assert.equal(escapeResolution('   ##   '), '');
   });
 });

--- a/workflows/work/lib/__tests__/open-questions.test.js
+++ b/workflows/work/lib/__tests__/open-questions.test.js
@@ -1,0 +1,249 @@
+/**
+ * Tests for workflows/work/lib/open-questions.js
+ *
+ * Pure-logic parser module that reads brief.md Open Questions and extracts
+ * structured blocks (scope, rationale, resolved).
+ *
+ * Run: node --test workflows/work/lib/__tests__/open-questions.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parse, findBlocking, classify, SCOPES } = require('../open-questions');
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const FIXTURE_SINGLE_STRUCTURED = `# Product Brief
+
+## Summary
+Example brief.
+
+## Open Questions
+
+- **Question:** Should the gate be a hook or a step?
+  - \`scope: architectural\`
+  - \`rationale: affects workflow shape\`
+  - \`resolved: false\`
+`;
+
+const FIXTURE_MULTIPLE_MIXED = `# Brief
+
+## Open Questions
+
+- **Question:** Where should the gate live?
+  - \`scope: local\`
+  - \`rationale: implementation detail\`
+  - \`resolved: false\`
+- **Question:** How do siblings coordinate router ownership?
+  - \`scope: cross-ticket\`
+  - \`rationale: affects multiple tickets\`
+  - \`resolved: false\`
+- **Question:** Should we migrate to a new framework?
+  - \`scope: architectural\`
+  - \`rationale: structural change\`
+  - \`resolved: true\`
+  - **Resolution:** No, defer to Q3 planning.
+
+## Success Metrics
+- Some metric.
+`;
+
+const FIXTURE_LEGACY_FREE_TEXT = `# Brief
+
+## Open Questions
+- Is the API rate limit 100 or 1000?
+- Should we use Redis or Memcached?
+
+## Out of Scope
+- Nothing here.
+`;
+
+const FIXTURE_MALFORMED = `# Brief
+
+## Open Questions
+
+- **Question:** Broken question with no scope
+  - \`rationale: missing scope field\`
+  - \`resolved: false\`
+`;
+
+const FIXTURE_EMPTY_SECTION = `# Brief
+
+## Open Questions
+
+## Out of Scope
+- Done.
+`;
+
+const FIXTURE_NO_SECTION = `# Brief
+
+## Summary
+Nothing to question here.
+
+## Out of Scope
+- Done.
+`;
+
+// ─── parse() ────────────────────────────────────────────────────────────────
+
+describe('open-questions: parse', () => {
+  it('parses a single well-formed structured block', () => {
+    const result = parse(FIXTURE_SINGLE_STRUCTURED);
+    assert.equal(result.length, 1);
+    const q = result[0];
+    assert.equal(q.questionText, 'Should the gate be a hook or a step?');
+    assert.equal(q.scope, 'architectural');
+    assert.equal(q.rationale, 'affects workflow shape');
+    assert.equal(q.resolved, false);
+    assert.equal(typeof q.startLine, 'number');
+    assert.equal(typeof q.endLine, 'number');
+    assert.ok(q.endLine >= q.startLine);
+  });
+
+  it('parses multiple structured blocks with mixed scopes and resolutions', () => {
+    const result = parse(FIXTURE_MULTIPLE_MIXED);
+    assert.equal(result.length, 3);
+
+    assert.equal(result[0].scope, 'local');
+    assert.equal(result[0].resolved, false);
+    assert.equal(result[0].questionText, 'Where should the gate live?');
+
+    assert.equal(result[1].scope, 'cross-ticket');
+    assert.equal(result[1].resolved, false);
+
+    assert.equal(result[2].scope, 'architectural');
+    assert.equal(result[2].resolved, true);
+    assert.equal(result[2].resolution, 'No, defer to Q3 planning.');
+  });
+
+  it('does not bleed past the Open Questions section into the next heading', () => {
+    const result = parse(FIXTURE_MULTIPLE_MIXED);
+    // All blocks must end before the "## Success Metrics" line
+    const sectionEndLine = FIXTURE_MULTIPLE_MIXED.split('\n').findIndex((l) =>
+      l.startsWith('## Success Metrics')
+    );
+    for (const q of result) {
+      assert.ok(q.endLine < sectionEndLine, `question ending at ${q.endLine} bled past section`);
+    }
+  });
+
+  it('coerces legacy free-text bullets to { scope: local, resolved: true }', () => {
+    const result = parse(FIXTURE_LEGACY_FREE_TEXT);
+    assert.equal(result.length, 2);
+    for (const q of result) {
+      assert.equal(q.scope, 'local');
+      assert.equal(q.resolved, true);
+    }
+    assert.equal(result[0].questionText, 'Is the API rate limit 100 or 1000?');
+    assert.equal(result[1].questionText, 'Should we use Redis or Memcached?');
+  });
+
+  it('coerces malformed structured blocks (missing scope:) to { scope: local, resolved: true }', () => {
+    const result = parse(FIXTURE_MALFORMED);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].scope, 'local');
+    assert.equal(result[0].resolved, true);
+  });
+
+  it('returns [] for a brief with no Open Questions section', () => {
+    assert.deepEqual(parse(FIXTURE_NO_SECTION), []);
+  });
+
+  it('returns [] for an empty Open Questions section', () => {
+    assert.deepEqual(parse(FIXTURE_EMPTY_SECTION), []);
+  });
+
+  it('returns [] for empty string input', () => {
+    assert.deepEqual(parse(''), []);
+  });
+
+  it('does not crash on null/undefined input', () => {
+    assert.deepEqual(parse(null), []);
+    assert.deepEqual(parse(undefined), []);
+  });
+});
+
+// ─── findBlocking() ─────────────────────────────────────────────────────────
+
+describe('open-questions: findBlocking', () => {
+  it('returns an empty array for empty input', () => {
+    assert.deepEqual(findBlocking([]), []);
+  });
+
+  it('returns an empty array when all questions are local', () => {
+    const qs = [
+      { scope: 'local', resolved: false },
+      { scope: 'local', resolved: false },
+    ];
+    assert.deepEqual(findBlocking(qs), []);
+  });
+
+  it('filters out resolved architectural questions', () => {
+    const qs = [
+      { scope: 'architectural', resolved: true, questionText: 'a' },
+      { scope: 'architectural', resolved: false, questionText: 'b' },
+    ];
+    const result = findBlocking(qs);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].questionText, 'b');
+  });
+
+  it('returns both unresolved cross-ticket and architectural questions', () => {
+    const qs = [
+      { scope: 'local', resolved: false, questionText: 'a' },
+      { scope: 'cross-ticket', resolved: false, questionText: 'b' },
+      { scope: 'architectural', resolved: false, questionText: 'c' },
+      { scope: 'architectural', resolved: true, questionText: 'd' },
+    ];
+    const result = findBlocking(qs);
+    assert.equal(result.length, 2);
+    assert.deepEqual(
+      result.map((q) => q.questionText),
+      ['b', 'c']
+    );
+  });
+
+  it('returns empty when all architectural questions are resolved', () => {
+    const qs = [
+      { scope: 'architectural', resolved: true },
+      { scope: 'architectural', resolved: true },
+    ];
+    assert.deepEqual(findBlocking(qs), []);
+  });
+});
+
+// ─── classify() ─────────────────────────────────────────────────────────────
+
+describe('open-questions: classify', () => {
+  it('passes through valid scopes', () => {
+    assert.equal(classify('local'), 'local');
+    assert.equal(classify('cross-ticket'), 'cross-ticket');
+    assert.equal(classify('architectural'), 'architectural');
+  });
+
+  it('normalizes whitespace and case', () => {
+    assert.equal(classify('  local  '), 'local');
+    assert.equal(classify('LOCAL'), 'local');
+    assert.equal(classify('Cross-Ticket'), 'cross-ticket');
+    assert.equal(classify('ARCHITECTURAL'), 'architectural');
+  });
+
+  it('returns unknown for invalid scope strings', () => {
+    assert.equal(classify('global'), 'unknown');
+    assert.equal(classify('system-wide'), 'unknown');
+  });
+
+  it('returns unknown for empty or missing input', () => {
+    assert.equal(classify(''), 'unknown');
+    assert.equal(classify('   '), 'unknown');
+    assert.equal(classify(undefined), 'unknown');
+    assert.equal(classify(null), 'unknown');
+  });
+
+  it('exports a frozen SCOPES allowlist', () => {
+    assert.ok(Array.isArray(SCOPES));
+    assert.ok(Object.isFrozen(SCOPES));
+    assert.deepEqual([...SCOPES].sort(), ['architectural', 'cross-ticket', 'local']);
+  });
+});

--- a/workflows/work/lib/__tests__/open-questions.test.js
+++ b/workflows/work/lib/__tests__/open-questions.test.js
@@ -525,6 +525,26 @@ describe('open-questions: applyResolutions', () => {
     assert.equal(parsed[0].resolution, undefined);
   });
 
+  it('inserts resolved: true when the block has no resolved: subfield', () => {
+    // FIXTURE_MISSING_RESOLVED has `scope: architectural` and `rationale:`
+    // but NO `resolved:` subfield. The parser defaults to resolved: false.
+    // applyResolutions must insert a `resolved: true` line (not just flip
+    // an existing one) AND append the Resolution line.
+    const resolutions = new Map([
+      ['Structured block without resolved field', 'Resolved by inserting the subfield.'],
+    ]);
+    const result = applyResolutions(FIXTURE_MISSING_RESOLVED, resolutions);
+    const parsed = parse(result);
+
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].resolved, true, 'block must be resolved after applyResolutions');
+    assert.equal(
+      parsed[0].resolution,
+      'Resolved by inserting the subfield.',
+      'resolution text must be set'
+    );
+  });
+
   it('is a no-op when the answer is pure whitespace that collapses to empty', () => {
     // `escapeResolution('## ')` also returns `''`; same contract applies.
     const resolutions = new Map([

--- a/workflows/work/lib/open-questions.js
+++ b/workflows/work/lib/open-questions.js
@@ -1,0 +1,223 @@
+/**
+ * workflows/work/lib/open-questions.js
+ *
+ * Pure-logic parser/classifier for the `## Open Questions` section of a
+ * brief.md document. No I/O, no side effects, no external dependencies.
+ *
+ * Public API:
+ *   - parse(markdown): Question[]
+ *   - findBlocking(questions): Question[]
+ *   - classify(scope): 'local' | 'cross-ticket' | 'architectural' | 'unknown'
+ *   - SCOPES: readonly frozen allowlist of valid scope strings
+ *
+ * A Question is:
+ *   {
+ *     questionText: string,
+ *     scope: 'local' | 'cross-ticket' | 'architectural',
+ *     rationale: string,
+ *     resolved: boolean,
+ *     resolution?: string,
+ *     startLine: number,   // 0-indexed, inclusive
+ *     endLine: number      // 0-indexed, inclusive
+ *   }
+ *
+ * Fallback behavior (fail-open):
+ *   - Legacy free-text bullets (no `scope:` subfield) coerce to
+ *     { scope: 'local', resolved: true } so pre-existing briefs do not
+ *     retroactively block the workflow.
+ *   - Malformed structured blocks that look structured (indented subfields)
+ *     but are missing `scope:` also coerce to { scope: 'local', resolved: true }.
+ *   - Any parse failure returns [] rather than throwing.
+ */
+
+'use strict';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/**
+ * Allowlist of valid scope classifications. Frozen so downstream modules can
+ * safely import and reference without fear of mutation.
+ */
+const SCOPES = Object.freeze(['local', 'cross-ticket', 'architectural']);
+
+const OPEN_QUESTIONS_HEADING = /^##\s+Open Questions\s*$/;
+const ANY_HEADING = /^##\s+/;
+const TOP_LEVEL_BULLET = /^-\s+/;
+const QUESTION_BULLET = /^-\s+\*\*Question:\*\*\s*(.*)$/;
+const LEGACY_BULLET = /^-\s+(.*)$/;
+const SUBFIELD_LINE = /^\s{2,}-\s+`([^:`]+):\s*([^`]*)`\s*$/;
+const RESOLUTION_LINE = /^\s{2,}-\s+\*\*Resolution:\*\*\s*(.*)$/;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Locate the line range (inclusive start, exclusive end) of the
+ * `## Open Questions` section. Returns null if there is no such section.
+ */
+function findSectionRange(lines) {
+  const startIdx = lines.findIndex((line) => OPEN_QUESTIONS_HEADING.test(line));
+  if (startIdx === -1) return null;
+
+  // Scan from the line after the heading for the next `## ` heading.
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (ANY_HEADING.test(lines[i])) {
+      endIdx = i;
+      break;
+    }
+  }
+  return { start: startIdx + 1, end: endIdx };
+}
+
+/**
+ * Scan forward from `startIdx` inside a section and return the exclusive end
+ * index of the current block. A block ends at:
+ *   - the next top-level bullet (`- ` at column 0),
+ *   - the section end, or
+ *   - a blank line followed by anything that isn't a continuation indent.
+ * For simplicity and robustness, we stop at the next top-level bullet or
+ * section end; blank lines within a block are tolerated but contribute
+ * nothing.
+ */
+function findBlockEnd(lines, startIdx, sectionEnd) {
+  for (let i = startIdx + 1; i < sectionEnd; i++) {
+    if (TOP_LEVEL_BULLET.test(lines[i])) return i; // next top-level bullet
+  }
+  return sectionEnd;
+}
+
+/**
+ * Extract key/value subfields and an optional resolution from a block's
+ * interior lines. Returns `{ fields: Map, resolution?: string }`.
+ * Keys are lowercased; values are trimmed.
+ */
+function readSubfields(blockLines) {
+  const fields = new Map();
+  let resolution;
+  for (const line of blockLines) {
+    const resMatch = line.match(RESOLUTION_LINE);
+    if (resMatch) {
+      resolution = resMatch[1].trim();
+      continue;
+    }
+    const subMatch = line.match(SUBFIELD_LINE);
+    if (subMatch) {
+      fields.set(subMatch[1].trim().toLowerCase(), subMatch[2].trim());
+    }
+  }
+  return { fields, resolution };
+}
+
+/**
+ * Build a Question object from a range of lines. Applies fallback coercion
+ * for legacy / malformed blocks.
+ */
+function buildQuestion(lines, blockStart, blockEnd) {
+  const header = lines[blockStart];
+  const questionMatch = header.match(QUESTION_BULLET);
+
+  let questionText;
+  if (questionMatch) {
+    questionText = questionMatch[1].trim();
+  } else {
+    // Legacy-style bullet: `- <free text>` or `- **Label:** text`.
+    // We still scan interior subfields — if the author supplied structured
+    // metadata under a non-canonical header, we should honor it.
+    const legacyMatch = header.match(LEGACY_BULLET);
+    if (!legacyMatch) return null;
+    questionText = legacyMatch[1].trim();
+  }
+  const interiorLines = lines.slice(blockStart + 1, blockEnd);
+
+  const { fields, resolution } = readSubfields(interiorLines);
+  const rawScope = fields.get('scope');
+  const scopeClass = classify(rawScope);
+
+  // Fallback: missing or invalid scope → legacy/malformed coercion.
+  if (!fields.has('scope') || scopeClass === 'unknown') {
+    return {
+      questionText,
+      scope: 'local',
+      rationale: fields.get('rationale') || '',
+      resolved: true,
+      startLine: blockStart,
+      endLine: blockEnd - 1,
+    };
+  }
+
+  const rawResolved = (fields.get('resolved') || '').toLowerCase();
+  const resolved = rawResolved === 'true';
+
+  const question = {
+    questionText,
+    scope: scopeClass,
+    rationale: fields.get('rationale') || '',
+    resolved,
+    startLine: blockStart,
+    endLine: blockEnd - 1,
+  };
+
+  if (resolution !== undefined) {
+    question.resolution = resolution;
+  }
+  return question;
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse the `## Open Questions` section of a brief markdown document into
+ * an array of Question objects. Never throws: malformed input produces
+ * fallback entries or an empty array.
+ */
+function parse(markdown) {
+  if (typeof markdown !== 'string' || markdown.length === 0) return [];
+
+  const lines = markdown.split('\n');
+  const range = findSectionRange(lines);
+  if (!range) return [];
+
+  const questions = [];
+  let i = range.start;
+  while (i < range.end) {
+    if (TOP_LEVEL_BULLET.test(lines[i])) {
+      const blockEnd = findBlockEnd(lines, i, range.end);
+      const q = buildQuestion(lines, i, blockEnd);
+      if (q) questions.push(q);
+      i = blockEnd;
+    } else {
+      i += 1;
+    }
+  }
+  return questions;
+}
+
+/**
+ * Return the subset of questions that block the workflow: unresolved
+ * `cross-ticket` or `architectural` scope.
+ */
+function findBlocking(questions) {
+  if (!Array.isArray(questions)) return [];
+  return questions.filter(
+    (q) => q && !q.resolved && (q.scope === 'cross-ticket' || q.scope === 'architectural')
+  );
+}
+
+/**
+ * Normalize and validate a scope string. Unknown / empty / non-string input
+ * maps to 'unknown'. All other valid scopes are returned in their canonical
+ * lowercase form.
+ */
+function classify(scope) {
+  if (typeof scope !== 'string') return 'unknown';
+  const normalized = scope.trim().toLowerCase();
+  if (!normalized) return 'unknown';
+  return SCOPES.includes(normalized) ? normalized : 'unknown';
+}
+
+module.exports = {
+  parse,
+  findBlocking,
+  classify,
+  SCOPES,
+};

--- a/workflows/work/lib/open-questions.js
+++ b/workflows/work/lib/open-questions.js
@@ -453,6 +453,7 @@ function applyResolutions(markdown, resolutions) {
     // If the block had no `resolved:` subfield at all (the parser defaults
     // to resolved: false), we must insert one so re-parsing yields
     // `resolved: true`. Use the same indentation as sibling subfields.
+    let insertionPoint = q.endLine + 1;
     if (!resolvedLineFlipped) {
       const blockLines = lines.slice(q.startLine, q.endLine + 1);
       let indent = '  ';
@@ -460,15 +461,17 @@ function applyResolutions(markdown, resolutions) {
         const m = bl.match(/^(\s{2,})-\s+/);
         if (m) { indent = m[1]; break; }
       }
-      lines.splice(q.endLine + 1, 0, `${indent}- \`resolved: true\``);
+      lines.splice(insertionPoint, 0, `${indent}- \`resolved: true\``);
+      insertionPoint++; // Resolution line goes AFTER resolved: true
     }
 
     // Append a `- **Resolution:** ...` line right after the block's last
-    // content line. We splice rather than concatenate so interior blocks
-    // don't disturb downstream content.
+    // content line (or after the newly-inserted resolved: true line).
+    // We splice rather than concatenate so interior blocks don't disturb
+    // downstream content.
     const blockLines = lines.slice(q.startLine, q.endLine + 1);
     const resolutionLine = buildResolutionLine(blockLines, escaped);
-    lines.splice(q.endLine + 1, 0, resolutionLine); // append after resolved:true insertion (if any)
+    lines.splice(insertionPoint, 0, resolutionLine);
   }
 
   return lines.join('\n');

--- a/workflows/work/lib/open-questions.js
+++ b/workflows/work/lib/open-questions.js
@@ -421,12 +421,22 @@ function applyResolutions(markdown, resolutions) {
     if (!resMap.has(q.questionText)) continue;
     // Idempotency guard: never touch already-resolved blocks. The guard
     // intentionally uses the parser's definition of `resolved` (the boolean
-    // on the Question object), which is derived from `resolved: true` in
-    // the subfield line and/or presence of a `Resolution:` sub-bullet.
+    // on the Question object), which is derived solely from `resolved: true`
+    // in the `resolved:` subfield line (see `buildQuestion`). A block that
+    // carries a `**Resolution:**` sub-bullet but still has `resolved: false`
+    // (an inconsistent manual-edit state) is treated as unresolved here.
     if (q.resolved === true) continue;
 
     const rawAnswer = resMap.get(q.questionText);
     const escaped = escapeResolution(rawAnswer);
+    // Guard: if the sanitized answer collapses to empty (e.g. the user
+    // supplied a pure-hash `"###"` or a whitespace-only string), skip the
+    // rewrite entirely. Writing a dangling `- **Resolution:** ` line would
+    // leave `resolution === ''` in the parsed block — a shape that differs
+    // from both "unresolved" (`resolution === undefined`) and
+    // "resolved with answer" and could confuse downstream consumers.
+    // Leaving the block untouched means the gate re-prompts next pass.
+    if (escaped === '') continue;
 
     // Flip the block's `resolved: false` line (if any) to `resolved: true`,
     // modifying the original `lines` array in place.

--- a/workflows/work/lib/open-questions.js
+++ b/workflows/work/lib/open-questions.js
@@ -17,8 +17,13 @@
  *     rationale: string,
  *     resolved: boolean,
  *     resolution?: string,
- *     startLine: number,   // 0-indexed, inclusive
- *     endLine: number      // 0-indexed, inclusive
+ *     startLine: number,   // 0-indexed, inclusive — the `- **Question:**` line
+ *     endLine: number      // 0-indexed, inclusive — the LAST non-blank
+ *                          //   content line of the block (never a trailing
+ *                          //   blank separator). Consumers can safely use
+ *                          //   `lines.slice(startLine, endLine + 1)` to
+ *                          //   extract the block without picking up a
+ *                          //   trailing blank or `split('\n')` artifact.
  *   }
  *
  * Fallback behavior (fail-open):
@@ -41,7 +46,11 @@
 const SCOPES = Object.freeze(['local', 'cross-ticket', 'architectural']);
 
 const OPEN_QUESTIONS_HEADING = /^##\s+Open Questions\s*$/;
-const ANY_HEADING = /^##\s+/;
+// Match any ATX heading (h1..h6). A heading at any level after the
+// `## Open Questions` line terminates the section — without this, an h1
+// (e.g. a second top-level title later in a multi-document markdown) or
+// an h3+ subheading would let the parser bleed into unrelated content.
+const ANY_HEADING = /^#{1,6}\s+/;
 const TOP_LEVEL_BULLET = /^-\s+/;
 const QUESTION_BULLET = /^-\s+\*\*Question:\*\*\s*(.*)$/;
 const LEGACY_BULLET = /^-\s+(.*)$/;
@@ -84,6 +93,23 @@ function findBlockEnd(lines, startIdx, sectionEnd) {
     if (TOP_LEVEL_BULLET.test(lines[i])) return i; // next top-level bullet
   }
   return sectionEnd;
+}
+
+/**
+ * Given the exclusive end of a block, walk backward to find the index of the
+ * last non-blank line that actually belongs to this block. Returns a value
+ * `>= blockStart` so the block is always at least one line wide (the header).
+ * This tightens the `endLine` contract: consumers (e.g. Task 2's rewriter)
+ * can slice `lines.slice(startLine, endLine + 1)` without picking up the
+ * blank separator between blocks or the trailing empty element produced by
+ * `split('\n')` on a trailing-newline string.
+ */
+function findLastContentLine(lines, blockStart, blockEnd) {
+  let last = blockEnd - 1;
+  while (last > blockStart && (lines[last] === undefined || lines[last].trim() === '')) {
+    last -= 1;
+  }
+  return last;
 }
 
 /**
@@ -132,6 +158,7 @@ function buildQuestion(lines, blockStart, blockEnd) {
   const { fields, resolution } = readSubfields(interiorLines);
   const rawScope = fields.get('scope');
   const scopeClass = classify(rawScope);
+  const endLine = findLastContentLine(lines, blockStart, blockEnd);
 
   // Fallback: missing or invalid scope → legacy/malformed coercion.
   if (!fields.has('scope') || scopeClass === 'unknown') {
@@ -141,7 +168,7 @@ function buildQuestion(lines, blockStart, blockEnd) {
       rationale: fields.get('rationale') || '',
       resolved: true,
       startLine: blockStart,
-      endLine: blockEnd - 1,
+      endLine,
     };
   }
 
@@ -154,7 +181,7 @@ function buildQuestion(lines, blockStart, blockEnd) {
     rationale: fields.get('rationale') || '',
     resolved,
     startLine: blockStart,
-    endLine: blockEnd - 1,
+    endLine,
   };
 
   if (resolution !== undefined) {
@@ -215,9 +242,46 @@ function classify(scope) {
   return SCOPES.includes(normalized) ? normalized : 'unknown';
 }
 
+/**
+ * (P1 extension point — Task 11)
+ *
+ * Downgrade a specific open question's scope to `'local'`, with a required
+ * human-authored justification. This is the escape hatch referenced in
+ * spec.md §Open Questions & Decisions and tasks.md R21: a way for authors
+ * to acknowledge a cross-ticket or architectural question that would
+ * otherwise block the workflow, and explicitly accept the risk of treating
+ * it as local scope.
+ *
+ * P0 scope (this file): this stub exists as the designated anchor point so
+ * Task 11's P1 implementation has an explicit contract to extend. It is
+ * exported (throwing) so that any accidental caller fails loudly rather
+ * than silently coercing behavior.
+ *
+ * P1 plan (Task 11):
+ *   1. Accept `(questionText, justification)` where both are non-empty
+ *      strings; reject empty justifications with a validation error.
+ *   2. Return a mutation descriptor `{ questionText, newScope: 'local',
+ *      justification, timestamp }` that Task 2's `applyResolutions`
+ *      rewriter can consume to rewrite the block in-place, appending a
+ *      `- \`downgrade-justification: <text>\`` subfield and setting the
+ *      scope to `local`.
+ *   3. The gate (Task 3) will then treat the downgraded question as
+ *      non-blocking, preserving the author's decision in the brief file
+ *      for audit.
+ *
+ * @param {string} _questionText  The exact text of the question to downgrade.
+ * @param {string} _justification A non-empty human-authored justification.
+ * @returns {never} Always throws until Task 11 implements it.
+ * @throws {Error} with message containing "not implemented" and "P1".
+ */
+function downgradeToLocal(_questionText, _justification) {
+  throw new Error('downgradeToLocal is not implemented — P1 escape hatch (Task 11)');
+}
+
 module.exports = {
   parse,
   findBlocking,
   classify,
+  downgradeToLocal,
   SCOPES,
 };

--- a/workflows/work/lib/open-questions.js
+++ b/workflows/work/lib/open-questions.js
@@ -8,6 +8,8 @@
  *   - parse(markdown): Question[]
  *   - findBlocking(questions): Question[]
  *   - classify(scope): 'local' | 'cross-ticket' | 'architectural' | 'unknown'
+ *   - applyResolutions(markdown, resolutions): string  — idempotent rewriter
+ *   - escapeResolution(answer): string                 — injection-safe escape
  *   - SCOPES: readonly frozen allowlist of valid scope strings
  *
  * A Question is:
@@ -278,10 +280,181 @@ function downgradeToLocal(_questionText, _justification) {
   throw new Error('downgradeToLocal is not implemented — P1 escape hatch (Task 11)');
 }
 
+// ─── applyResolutions() + escapeResolution() ────────────────────────────────
+
+/**
+ * Sanitize a user-supplied answer before persisting it into brief.md.
+ *
+ * Threat model: the answer is written verbatim into a markdown file that is
+ * later re-parsed by `parse()` and read by downstream agents (spec-writer,
+ * split-in-tasks). A malicious or careless answer could:
+ *   - start a new heading (`## Injected Heading`) and split the Open
+ *     Questions section;
+ *   - terminate or open a fenced code block (```); or
+ *   - contain embedded newlines that would break the block's single-line
+ *     bullet structure.
+ *
+ * Rules (all fail-closed — any questionable content is neutralized rather
+ * than preserved):
+ *   1. Non-string / empty / nullish input → return `''`.
+ *   2. Collapse all embedded newlines (`\r\n`, `\n`, `\r`) to single spaces.
+ *   3. Strip triple-backtick sequences anywhere in the string.
+ *   4. Strip all leading `#` characters and the whitespace that follows so
+ *      the answer cannot start a heading at the beginning of its line.
+ *   5. Trim surrounding whitespace.
+ *
+ * The result is safe to splice into a `- **Resolution:** <answer>` line
+ * without altering the surrounding parser-observable structure.
+ */
+function escapeResolution(answer) {
+  if (typeof answer !== 'string' || answer.length === 0) return '';
+  let out = answer;
+  // Collapse newlines (handle CRLF before LF so we don't double-space).
+  out = out.replace(/\r\n/g, ' ').replace(/[\r\n]+/g, ' ');
+  // Remove triple-backtick sequences entirely — they have no legitimate
+  // place in a single-line bullet, and they're the single biggest risk for
+  // markdown fence injection.
+  out = out.replace(/```/g, '');
+  // Strip any leading `#` block (repeatedly, in case the input begins with
+  // `## ## ...`), along with the whitespace immediately following it.
+  out = out.replace(/^\s*(?:#+\s*)+/, '');
+  // Final whitespace cleanup.
+  out = out.trim();
+  return out;
+}
+
+/**
+ * Normalize a `resolutions` argument into a plain `Map<string, string>` so
+ * callers can pass either a real Map or a plain object for ergonomics.
+ * Non-string keys/values are dropped.
+ */
+function normalizeResolutions(resolutions) {
+  const out = new Map();
+  if (!resolutions) return out;
+  if (resolutions instanceof Map) {
+    for (const [k, v] of resolutions.entries()) {
+      if (typeof k === 'string' && typeof v === 'string') out.set(k, v);
+    }
+    return out;
+  }
+  if (typeof resolutions === 'object') {
+    for (const [k, v] of Object.entries(resolutions)) {
+      if (typeof k === 'string' && typeof v === 'string') out.set(k, v);
+    }
+  }
+  return out;
+}
+
+/**
+ * Rewrite a `resolved: false` subfield line to `resolved: true`, preserving
+ * the original indentation and surrounding formatting. If the line already
+ * says `resolved: true`, return it unchanged.
+ */
+function flipResolvedLine(line) {
+  return line.replace(/(`resolved:\s*)(false)(\s*`)/i, (_m, pre, _val, post) => `${pre}true${post}`);
+}
+
+/**
+ * Build the `- **Resolution:** ...` line for a block, matching the
+ * indentation of the block's existing subfield lines so the parser can
+ * recognize it on re-read.
+ */
+function buildResolutionLine(blockLines, escaped) {
+  // Find the indentation of an existing subfield line (they all start with
+  // at least two spaces). Default to two spaces if we can't find one.
+  let indent = '  ';
+  for (const line of blockLines) {
+    const match = line.match(/^(\s{2,})-\s+/);
+    if (match) {
+      indent = match[1];
+      break;
+    }
+  }
+  return `${indent}- **Resolution:** ${escaped}`;
+}
+
+/**
+ * Rewrite `brief.md` markdown so that every question in `resolutions` is
+ * marked resolved and gets a `Resolution:` subfield appended to its block.
+ *
+ * Guarantees:
+ *   - **Idempotency.** A block whose parsed `resolved === true` is never
+ *     touched, even if the caller passes a new answer for it. Running
+ *     `applyResolutions` twice with the same resolutions produces byte-equal
+ *     output.
+ *   - **Injection safety.** User answers pass through `escapeResolution` so
+ *     they cannot introduce new headings, fences, or block-boundary-breaking
+ *     newlines. Re-parsing the rewritten markdown MUST yield the same
+ *     `Question[]` count as the input.
+ *   - **Minimal rewrite.** Lines outside the changed block are preserved
+ *     byte-for-byte.
+ *   - **No I/O.** Pure function. Invalid / empty / unknown-question
+ *     resolutions are silent no-ops.
+ *
+ * The rewriter operates by:
+ *   1. Parsing the input to locate each question block (with `startLine`
+ *      and `endLine` ranges).
+ *   2. Walking the question list from LAST to FIRST so that line indices
+ *      computed by `parse()` remain valid as we splice new lines in.
+ *   3. For each match: flipping an in-block `resolved: false` subfield to
+ *      `resolved: true` and inserting an escaped `- **Resolution:** …` line
+ *      immediately after the block's last content line.
+ *
+ * @param {string} markdown
+ * @param {Map<string,string>|Record<string,string>} resolutions
+ * @returns {string}
+ */
+function applyResolutions(markdown, resolutions) {
+  if (typeof markdown !== 'string' || markdown.length === 0) return markdown;
+
+  const resMap = normalizeResolutions(resolutions);
+  if (resMap.size === 0) return markdown;
+
+  const questions = parse(markdown);
+  if (questions.length === 0) return markdown;
+
+  const lines = markdown.split('\n');
+
+  // Walk LAST → FIRST so earlier indices stay stable as we splice.
+  for (let i = questions.length - 1; i >= 0; i--) {
+    const q = questions[i];
+    if (!resMap.has(q.questionText)) continue;
+    // Idempotency guard: never touch already-resolved blocks. The guard
+    // intentionally uses the parser's definition of `resolved` (the boolean
+    // on the Question object), which is derived from `resolved: true` in
+    // the subfield line and/or presence of a `Resolution:` sub-bullet.
+    if (q.resolved === true) continue;
+
+    const rawAnswer = resMap.get(q.questionText);
+    const escaped = escapeResolution(rawAnswer);
+
+    // Flip the block's `resolved: false` line (if any) to `resolved: true`,
+    // modifying the original `lines` array in place.
+    for (let j = q.startLine; j <= q.endLine; j++) {
+      const flipped = flipResolvedLine(lines[j]);
+      if (flipped !== lines[j]) {
+        lines[j] = flipped;
+        break;
+      }
+    }
+
+    // Append a `- **Resolution:** ...` line right after the block's last
+    // content line. We splice rather than concatenate so interior blocks
+    // don't disturb downstream content.
+    const blockLines = lines.slice(q.startLine, q.endLine + 1);
+    const resolutionLine = buildResolutionLine(blockLines, escaped);
+    lines.splice(q.endLine + 1, 0, resolutionLine);
+  }
+
+  return lines.join('\n');
+}
+
 module.exports = {
   parse,
   findBlocking,
   classify,
   downgradeToLocal,
+  applyResolutions,
+  escapeResolution,
   SCOPES,
 };

--- a/workflows/work/lib/open-questions.js
+++ b/workflows/work/lib/open-questions.js
@@ -440,12 +440,27 @@ function applyResolutions(markdown, resolutions) {
 
     // Flip the block's `resolved: false` line (if any) to `resolved: true`,
     // modifying the original `lines` array in place.
+    let resolvedLineFlipped = false;
     for (let j = q.startLine; j <= q.endLine; j++) {
       const flipped = flipResolvedLine(lines[j]);
       if (flipped !== lines[j]) {
         lines[j] = flipped;
+        resolvedLineFlipped = true;
         break;
       }
+    }
+
+    // If the block had no `resolved:` subfield at all (the parser defaults
+    // to resolved: false), we must insert one so re-parsing yields
+    // `resolved: true`. Use the same indentation as sibling subfields.
+    if (!resolvedLineFlipped) {
+      const blockLines = lines.slice(q.startLine, q.endLine + 1);
+      let indent = '  ';
+      for (const bl of blockLines) {
+        const m = bl.match(/^(\s{2,})-\s+/);
+        if (m) { indent = m[1]; break; }
+      }
+      lines.splice(q.endLine + 1, 0, `${indent}- \`resolved: true\``);
     }
 
     // Append a `- **Resolution:** ...` line right after the block's last

--- a/workflows/work/lib/open-questions.js
+++ b/workflows/work/lib/open-questions.js
@@ -468,7 +468,7 @@ function applyResolutions(markdown, resolutions) {
     // don't disturb downstream content.
     const blockLines = lines.slice(q.startLine, q.endLine + 1);
     const resolutionLine = buildResolutionLine(blockLines, escaped);
-    lines.splice(q.endLine + 1, 0, resolutionLine);
+    lines.splice(q.endLine + 1, 0, resolutionLine); // append after resolved:true insertion (if any)
   }
 
   return lines.join('\n');

--- a/workflows/work/plan-generator.js
+++ b/workflows/work/plan-generator.js
@@ -142,7 +142,10 @@ function generatePlan(ticket, description, s, rework, callerProviderCfg, suffix,
     workStatePath: path.join(__dirname, 'work-state.js'),
   };
 
-  // Execute step pipeline — each handler may call add() and/or mutate ctx/plan
+  // Execute step pipeline — each handler may call add() and/or mutate ctx/plan.
+  // GH-215: briefGateStep sits between briefStep and specStep in STEP_PIPELINE,
+  // emitting a `brief_gate` plan entry that gates the brief → spec transition on
+  // unresolved cross-ticket / architectural open questions in brief.md.
   for (const stepHandler of STEP_PIPELINE) {
     stepHandler(add, s, ctx);
   }

--- a/workflows/work/skills/brief.md
+++ b/workflows/work/skills/brief.md
@@ -20,8 +20,10 @@ Generate a structured product brief from a ticket or feature description. The br
 ## What It Does
 
 1. **Resolve input** — If a ticket ID is provided, fetch ticket details (title, description, acceptance criteria). If a description is provided, use it directly.
-2. **Delegate to brief-writer agent** — The agent structures the information into a product brief.
+2. **Delegate to brief-writer agent** — The agent structures the information into a product brief, classifying every Open Question with `scope: local | cross-ticket | architectural`.
 3. **Save output** — Brief is saved to `${TASKS_BASE}/${FOLDER_NAME}/brief.md`.
+
+After the brief is written, the workflow runs a `brief_gate` step between `brief` and `spec`. This gate scans the brief's Open Questions and interactively prompts (via `AskUserQuestion`) for any unresolved `cross-ticket` or `architectural` questions before allowing the `spec` step to run; `local` questions are allowed to pass through the gate unanswered.
 
 ## Execution
 

--- a/workflows/work/step-registry.js
+++ b/workflows/work/step-registry.js
@@ -15,6 +15,9 @@ const STEPS = Object.freeze({
   ticket: 'ticket',
   bootstrap: 'bootstrap',
   brief: 'brief',
+  // GH-215: gate step that blocks spec until unresolved cross-ticket /
+  // architectural open questions in brief.md have been answered.
+  brief_gate: 'brief_gate',
   spec: 'spec',
   tasks: 'tasks',
   implement: 'implement',
@@ -36,6 +39,7 @@ const STEP_ORDER = Object.freeze([
   STEPS.ticket,
   STEPS.bootstrap,
   STEPS.brief,
+  STEPS.brief_gate, // GH-215: must sit between brief and spec
   STEPS.spec,
   STEPS.tasks,
   STEPS.implement,

--- a/workflows/work/steps/__tests__/brief-gate.test.js
+++ b/workflows/work/steps/__tests__/brief-gate.test.js
@@ -225,5 +225,62 @@ describe('brief-gate step', () => {
       const after = fs.readFileSync(briefPath, 'utf8');
       assert.equal(after, before, 'brief.md must be byte-identical on empty map');
     });
+
+    it('returns false without touching brief.md for non-object resolutions (number/string/boolean)', () => {
+      const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+      createdDirs.push(dir);
+      const briefPath = path.join(dir, 'brief.md');
+      const before = fs.readFileSync(briefPath, 'utf8');
+
+      // Monkey-patch fs.readFileSync to detect if brief-gate reads the file
+      // while handling a stray non-object. A type guard at the top of
+      // applyBriefResolutions must bail out BEFORE any I/O.
+      const originalReadFileSync = fs.readFileSync;
+      let readCallsForBrief = 0;
+      fs.readFileSync = function patchedReadFileSync(p, ...rest) {
+        if (typeof p === 'string' && p === briefPath) {
+          readCallsForBrief += 1;
+        }
+        return originalReadFileSync.call(fs, p, ...rest);
+      };
+
+      try {
+        // number
+        assert.equal(
+          applyBriefResolutions(briefPath, 42),
+          false,
+          'number resolutions must return false'
+        );
+        // string
+        assert.equal(
+          applyBriefResolutions(briefPath, 'not a map'),
+          false,
+          'string resolutions must return false'
+        );
+        // boolean
+        assert.equal(
+          applyBriefResolutions(briefPath, true),
+          false,
+          'boolean resolutions must return false'
+        );
+        // symbol (another non-object primitive)
+        assert.equal(
+          applyBriefResolutions(briefPath, Symbol('x')),
+          false,
+          'symbol resolutions must return false'
+        );
+
+        assert.equal(
+          readCallsForBrief,
+          0,
+          'brief.md must not be read when resolutions is a non-object primitive'
+        );
+      } finally {
+        fs.readFileSync = originalReadFileSync;
+      }
+
+      const after = originalReadFileSync.call(fs, briefPath, 'utf8');
+      assert.equal(after, before, 'brief.md must be byte-identical after non-object inputs');
+    });
   });
 });

--- a/workflows/work/steps/__tests__/brief-gate.test.js
+++ b/workflows/work/steps/__tests__/brief-gate.test.js
@@ -226,6 +226,44 @@ describe('brief-gate step', () => {
       assert.equal(after, before, 'brief.md must be byte-identical on empty map');
     });
 
+    it('returns false when fs.writeFileSync throws (EACCES/ENOSPC/etc)', () => {
+      // The read path already returns false on failure (fail-closed). The
+      // write path must mirror that no-throw contract: an EACCES/ENOSPC
+      // during writeFileSync must not propagate as an uncaught exception to
+      // the orchestrator — applyBriefResolutions must simply return false.
+      const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+      createdDirs.push(dir);
+      const briefPath = path.join(dir, 'brief.md');
+      const before = fs.readFileSync(briefPath, 'utf8');
+
+      const originalWriteFileSync = fs.writeFileSync;
+      fs.writeFileSync = function patchedWriteFileSync(p, ...rest) {
+        if (typeof p === 'string' && p === briefPath) {
+          const err = new Error('EACCES: permission denied');
+          err.code = 'EACCES';
+          throw err;
+        }
+        return originalWriteFileSync.call(fs, p, ...rest);
+      };
+
+      try {
+        const resolutions = new Map([
+          [
+            'Which queue backend should we adopt for cross-service jobs?',
+            'Use SQS for all cross-service jobs.',
+          ],
+        ]);
+        const result = applyBriefResolutions(briefPath, resolutions);
+        assert.equal(result, false, 'applyBriefResolutions must return false on write failure');
+      } finally {
+        fs.writeFileSync = originalWriteFileSync;
+      }
+
+      // brief.md must be byte-equal — no partial write, no crash.
+      const after = fs.readFileSync(briefPath, 'utf8');
+      assert.equal(after, before, 'brief.md must remain byte-identical after write failure');
+    });
+
     it('returns false without touching brief.md for non-object resolutions (number/string/boolean)', () => {
       const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
       createdDirs.push(dir);

--- a/workflows/work/steps/__tests__/brief-gate.test.js
+++ b/workflows/work/steps/__tests__/brief-gate.test.js
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for the brief-gate step module (GH-215, Task 4).
+ *
+ * Covers the four SKIP/RUN decision paths plus the post-resolve handler
+ * behavior (rewrite-on-answer, no-op-on-cancel).
+ *
+ * Run: node --test workflows/work/steps/__tests__/brief-gate.test.js
+ */
+
+'use strict';
+
+const { describe, it, before, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { STEPS } = require('../../step-registry');
+
+// ─── Test doubles matching bootstrap.test.js ────────────────────────────────
+
+function makeCtx(overrides = {}) {
+  return {
+    STEPS,
+    ticket: 'TEST-100',
+    description: null,
+    rework: false,
+    safeName: 'TEST-100',
+    worktreeDir: '/tmp/worktrees/my-project-TEST-100',
+    tasksDir: '/tmp/tasks/TEST-100',
+    t: 'TEST-100',
+    path,
+    fileExists: (p) => fs.existsSync(p),
+    ...overrides,
+  };
+}
+
+function makeState(overrides = {}) {
+  return {
+    worktreeExists: true,
+    hasBrief: true,
+    pr: null,
+    ...overrides,
+  };
+}
+
+function makeAdd() {
+  const entries = [];
+  const add = (step, action, command, reason, extra) => {
+    entries.push({ step, action, command, reason, ...(extra || {}) });
+  };
+  return { add, entries };
+}
+
+// ─── Fixture helpers ────────────────────────────────────────────────────────
+
+const BRIEF_ALL_LOCAL = [
+  '# Brief',
+  '',
+  '## Open Questions',
+  '',
+  '- **Question:** How should we name the local helper?',
+  '  - `scope: local`',
+  '  - `rationale: scoped to this ticket only`',
+  '  - `resolved: false`',
+  '',
+].join('\n');
+
+const BRIEF_ONE_BLOCKING_ARCH = [
+  '# Brief',
+  '',
+  '## Open Questions',
+  '',
+  '- **Question:** Which queue backend should we adopt for cross-service jobs?',
+  '  - `scope: architectural`',
+  '  - `rationale: affects all downstream services`',
+  '  - `resolved: false`',
+  '',
+].join('\n');
+
+function makeTmpTasksDir(briefContent) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'brief-gate-test-'));
+  if (briefContent !== null) {
+    fs.writeFileSync(path.join(dir, 'brief.md'), briefContent, 'utf8');
+  }
+  return dir;
+}
+
+function rmrf(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (_e) {
+    /* ignore */
+  }
+}
+
+// ─── Suite ──────────────────────────────────────────────────────────────────
+
+describe('brief-gate step', () => {
+  let briefGateStep;
+  let applyBriefResolutions;
+  const createdDirs = [];
+  const originalEnv = process.env.WORK_BRIEF_ENABLED;
+
+  before(() => {
+    const mod = require(path.join(__dirname, '..', 'brief-gate.js'));
+    briefGateStep = typeof mod === 'function' ? mod : mod.briefGateStep;
+    applyBriefResolutions = mod.applyBriefResolutions;
+  });
+
+  beforeEach(() => {
+    delete process.env.WORK_BRIEF_ENABLED;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.WORK_BRIEF_ENABLED;
+    else process.env.WORK_BRIEF_ENABLED = originalEnv;
+    while (createdDirs.length) rmrf(createdDirs.pop());
+  });
+
+  it('exports a function', () => {
+    assert.equal(typeof briefGateStep, 'function');
+  });
+
+  it('SKIPs when WORK_BRIEF_ENABLED=0', () => {
+    process.env.WORK_BRIEF_ENABLED = '0';
+    const { add, entries } = makeAdd();
+    briefGateStep(add, makeState(), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.brief_gate);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /disabled/i);
+  });
+
+  it('SKIPs when no brief.md is present', () => {
+    const { add, entries } = makeAdd();
+    briefGateStep(add, makeState({ hasBrief: false }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.brief_gate);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /no brief/i);
+  });
+
+  it('SKIPs when all questions are resolved (only-local brief)', () => {
+    const dir = makeTmpTasksDir(BRIEF_ALL_LOCAL);
+    createdDirs.push(dir);
+    const { add, entries } = makeAdd();
+    briefGateStep(add, makeState(), makeCtx({ tasksDir: dir }));
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.brief_gate);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /resolved|no open/i);
+  });
+
+  it('RUNs with AskUserQuestion payload when a blocking architectural question exists', () => {
+    const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+    createdDirs.push(dir);
+    const { add, entries } = makeAdd();
+    briefGateStep(add, makeState(), makeCtx({ tasksDir: dir }));
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.brief_gate);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.command, 'AskUserQuestion');
+    assert.match(entry.reason, /1 .*unresolved/i);
+    assert.ok(entry.askUserQuestionPayload, 'RUN entry must carry askUserQuestionPayload');
+    assert.ok(
+      Array.isArray(entry.askUserQuestionPayload.questions) ||
+        entry.askUserQuestionPayload.question,
+      'payload must carry questions[] or a question field'
+    );
+    assert.equal(entry.onResolve, 'rewrite brief.md');
+  });
+
+  it('SKIPs (fail-open) when brief.md is unreadable', () => {
+    const dir = makeTmpTasksDir(null); // no brief.md file
+    createdDirs.push(dir);
+    // But s.hasBrief is true — simulates stale state where brief vanished.
+    const { add, entries } = makeAdd();
+    briefGateStep(add, makeState({ hasBrief: true }), makeCtx({ tasksDir: dir }));
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'SKIP');
+  });
+
+  describe('applyBriefResolutions (post-resolve handler)', () => {
+    it('rewrites brief.md when resolutions are provided', () => {
+      const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+      createdDirs.push(dir);
+      const briefPath = path.join(dir, 'brief.md');
+
+      const resolutions = new Map([
+        [
+          'Which queue backend should we adopt for cross-service jobs?',
+          'Use SQS for all cross-service jobs.',
+        ],
+      ]);
+
+      applyBriefResolutions(briefPath, resolutions);
+
+      const updated = fs.readFileSync(briefPath, 'utf8');
+      assert.match(updated, /resolved:\s*true/);
+      assert.match(updated, /\*\*Resolution:\*\*\s*Use SQS/);
+    });
+
+    it('is a no-op when resolutions are undefined (user cancellation)', () => {
+      const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+      createdDirs.push(dir);
+      const briefPath = path.join(dir, 'brief.md');
+      const before = fs.readFileSync(briefPath, 'utf8');
+
+      applyBriefResolutions(briefPath, undefined);
+
+      const after = fs.readFileSync(briefPath, 'utf8');
+      assert.equal(after, before, 'brief.md must be byte-identical on cancel');
+    });
+
+    it('is a no-op when resolutions map is empty', () => {
+      const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+      createdDirs.push(dir);
+      const briefPath = path.join(dir, 'brief.md');
+      const before = fs.readFileSync(briefPath, 'utf8');
+
+      applyBriefResolutions(briefPath, new Map());
+
+      const after = fs.readFileSync(briefPath, 'utf8');
+      assert.equal(after, before, 'brief.md must be byte-identical on empty map');
+    });
+  });
+});

--- a/workflows/work/steps/__tests__/brief-gate.test.js
+++ b/workflows/work/steps/__tests__/brief-gate.test.js
@@ -170,6 +170,10 @@ describe('brief-gate step', () => {
       'payload must carry questions[] or a question field'
     );
     assert.equal(entry.onResolve, 'rewrite brief.md');
+    assert.equal(entry.agentType, 'general-purpose', 'AskUserQuestion RUN must specify agentType');
+    assert.equal(typeof entry.agentPrompt, 'string', 'AskUserQuestion RUN must carry agentPrompt string');
+    assert.match(entry.agentPrompt, /AskUserQuestion/, 'agentPrompt must mention AskUserQuestion');
+    assert.match(entry.agentPrompt, /applyBriefResolutions/, 'agentPrompt must mention applyBriefResolutions');
   });
 
   it('emits RUN (not SKIP) when brief.md is unreadable so planner shows gate needs attention', () => {
@@ -181,6 +185,9 @@ describe('brief-gate step', () => {
     assert.equal(entries.length, 1);
     assert.equal(entries[0].action, 'RUN', 'unreadable brief must emit RUN, not SKIP');
     assert.match(entries[0].reason, /unreadable|regenerate/i);
+    assert.equal(entries[0].command, '/brief', 'unreadable RUN must carry /brief command');
+    assert.equal(entries[0].agentType, 'skill', 'unreadable RUN must specify agentType: skill');
+    assert.equal(entries[0].agentPrompt, '/brief', 'unreadable RUN must specify agentPrompt: /brief');
   });
 
   describe('applyBriefResolutions (post-resolve handler)', () => {

--- a/workflows/work/steps/__tests__/brief-gate.test.js
+++ b/workflows/work/steps/__tests__/brief-gate.test.js
@@ -172,14 +172,15 @@ describe('brief-gate step', () => {
     assert.equal(entry.onResolve, 'rewrite brief.md');
   });
 
-  it('SKIPs (fail-open) when brief.md is unreadable', () => {
+  it('emits RUN (not SKIP) when brief.md is unreadable so planner shows gate needs attention', () => {
     const dir = makeTmpTasksDir(null); // no brief.md file
     createdDirs.push(dir);
     // But s.hasBrief is true — simulates stale state where brief vanished.
     const { add, entries } = makeAdd();
     briefGateStep(add, makeState({ hasBrief: true }), makeCtx({ tasksDir: dir }));
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].action, 'SKIP');
+    assert.equal(entries[0].action, 'RUN', 'unreadable brief must emit RUN, not SKIP');
+    assert.match(entries[0].reason, /unreadable|regenerate/i);
   });
 
   describe('applyBriefResolutions (post-resolve handler)', () => {

--- a/workflows/work/steps/__tests__/step-modules.test.js
+++ b/workflows/work/steps/__tests__/step-modules.test.js
@@ -81,6 +81,7 @@ describe('step modules', () => {
       'bootstrap',
       'transition',
       'brief',
+      'brief-gate',
       'spec',
       'tasks',
       'implement',
@@ -102,6 +103,36 @@ describe('step modules', () => {
         assert.equal(typeof stepModule, 'function', `${mod}.js should export a function`);
       });
     }
+  });
+
+  // GH-215 Task 6.1: briefGateStep must be exposed as a named export on
+  // workflows/work/steps/index.js so the pipeline (and any external consumer
+  // that imports the steps barrel) can pick it up alongside briefStep/specStep.
+  describe('steps/index.js barrel (GH-215)', () => {
+    it('exports briefGateStep as a function', () => {
+      const barrel = require(path.join(__dirname, '..', 'index.js'));
+      assert.equal(
+        typeof barrel.briefGateStep,
+        'function',
+        'steps/index.js should re-export briefGateStep'
+      );
+    });
+
+    it('includes briefGateStep in STEP_PIPELINE between briefStep and specStep', () => {
+      const barrel = require(path.join(__dirname, '..', 'index.js'));
+      assert.ok(Array.isArray(barrel.STEP_PIPELINE), 'STEP_PIPELINE should be an array');
+      const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+      const specStep = require(path.join(__dirname, '..', 'spec.js'));
+      const briefGateStep = require(path.join(__dirname, '..', 'brief-gate.js'));
+      const briefIdx = barrel.STEP_PIPELINE.indexOf(briefStep);
+      const gateIdx = barrel.STEP_PIPELINE.indexOf(briefGateStep);
+      const specIdx = barrel.STEP_PIPELINE.indexOf(specStep);
+      assert.ok(briefIdx >= 0, 'briefStep must be in STEP_PIPELINE');
+      assert.ok(gateIdx >= 0, 'briefGateStep must be in STEP_PIPELINE');
+      assert.ok(specIdx >= 0, 'specStep must be in STEP_PIPELINE');
+      assert.equal(gateIdx, briefIdx + 1, 'briefGateStep must come directly after briefStep');
+      assert.equal(specIdx, gateIdx + 1, 'specStep must come directly after briefGateStep');
+    });
   });
 
   describe('ticket step', () => {

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -77,7 +77,10 @@ function briefGateStep(add, s, ctx) {
     // returns false on read errors (fail-closed), so emitting SKIP here
     // would create a confusing mismatch ("gate skipped" yet transition
     // blocked). RUN with a helpful message signals the issue clearly.
-    add(STEPS.brief_gate, 'RUN', null, 'brief.md unreadable — regenerate brief before proceeding');
+    add(STEPS.brief_gate, 'RUN', '/brief', 'brief.md unreadable — regenerate brief before proceeding', {
+      agentType: 'skill',
+      agentPrompt: '/brief',
+    });
     return; // fail-closed: verify() also returns false on read errors — aligned
   }
 
@@ -95,6 +98,8 @@ function briefGateStep(add, s, ctx) {
     'AskUserQuestion',
     `Resolve ${blocking.length} unresolved cross-ticket/architectural question(s)`,
     {
+      agentType: 'general-purpose',
+      agentPrompt: `Use AskUserQuestion to resolve ${blocking.length} unresolved open question(s) in brief.md, then call applyBriefResolutions() to persist the answers.`,
       askUserQuestionPayload: buildAskUserQuestionPayload(blocking),
       onResolve: 'rewrite brief.md',
     }

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -1,0 +1,143 @@
+/**
+ * Step: brief-gate (GH-215)
+ *
+ * Gates the `brief → spec` transition on unresolved cross-ticket or
+ * architectural open questions in `brief.md`. Mirrors the sibling step
+ * contract `(add, s, ctx) => void` from `./brief.js` and `./spec.js`, and
+ * reuses the pure parser/rewriter in `../lib/open-questions.js`.
+ *
+ * Decision matrix:
+ *   1. `WORK_BRIEF_ENABLED=0`                  → SKIP "Brief disabled"
+ *   2. `!s.hasBrief`                           → SKIP "No brief.md present"
+ *   3. `brief.md` unreadable (fail-open)       → SKIP "brief.md unreadable"
+ *   4. Parser returns zero blocking questions  → SKIP "All blocking questions resolved"
+ *   5. Otherwise                               → RUN with an AskUserQuestion
+ *                                                payload + `onResolve: 'rewrite brief.md'`
+ *
+ * The RUN payload instructs the orchestrator to invoke AskUserQuestion
+ * inline (hooks are non-interactive — the gate step is a planning-time
+ * declaration, not a runtime prompt). Once the orchestrator has collected
+ * answers, it calls the exported `applyBriefResolutions(briefPath, resolutions)`
+ * post-resolve handler, which delegates to `openQuestions.applyResolutions`
+ * and writes the result back to `brief.md`. Cancellations (undefined/empty
+ * resolutions) are no-ops so the next planner pass re-prompts.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const openQuestions = require('../lib/open-questions');
+
+/**
+ * Build the `AskUserQuestion` payload for the RUN action. Kept local so the
+ * public surface of this module is just the step function and the
+ * post-resolve handler.
+ *
+ * @param {Array<{questionText: string, rationale: string, scope: string}>} blocking
+ * @returns {{questions: Array<object>}}
+ */
+function buildAskUserQuestionPayload(blocking) {
+  return {
+    questions: blocking.map((q) => ({
+      questionText: q.questionText,
+      scope: q.scope,
+      rationale: q.rationale,
+      // Orchestrator-facing hint: the answer must be persisted back into
+      // the brief.md block identified by `questionText`.
+      persistTo: 'brief.md',
+    })),
+  };
+}
+
+/**
+ * @param {Function} add
+ * @param {object} s
+ * @param {object} ctx
+ */
+function briefGateStep(add, s, ctx) {
+  const { STEPS, tasksDir, path } = ctx;
+  const briefEnabled = process.env.WORK_BRIEF_ENABLED !== '0';
+
+  if (!briefEnabled) {
+    add(STEPS.brief_gate, 'SKIP', null, 'Brief disabled (WORK_BRIEF_ENABLED=0)');
+    return;
+  }
+
+  if (!s || !s.hasBrief) {
+    add(STEPS.brief_gate, 'SKIP', null, 'No brief.md present');
+    return;
+  }
+
+  const briefPath = path.join(tasksDir, 'brief.md');
+  let markdown;
+  try {
+    markdown = fs.readFileSync(briefPath, 'utf8');
+  } catch (_e) {
+    // Fail-open: do not crash the planner on unreadable brief — upstream
+    // verify already covers missing/corrupt brief cases.
+    add(STEPS.brief_gate, 'SKIP', null, 'brief.md unreadable');
+    return;
+  }
+
+  const questions = openQuestions.parse(markdown);
+  const blocking = openQuestions.findBlocking(questions);
+
+  if (blocking.length === 0) {
+    add(STEPS.brief_gate, 'SKIP', null, 'All blocking questions resolved');
+    return;
+  }
+
+  add(
+    STEPS.brief_gate,
+    'RUN',
+    'AskUserQuestion',
+    `Resolve ${blocking.length} unresolved cross-ticket/architectural question(s)`,
+    {
+      askUserQuestionPayload: buildAskUserQuestionPayload(blocking),
+      onResolve: 'rewrite brief.md',
+    }
+  );
+}
+
+/**
+ * Post-resolve handler — invoked by the orchestrator after AskUserQuestion
+ * returns. Rewrites `brief.md` in place with the user-supplied resolutions,
+ * delegating all parsing/idempotency/injection-escape invariants to
+ * `openQuestions.applyResolutions`.
+ *
+ * Cancellation path: if the caller passes `undefined`, `null`, or an empty
+ * map/object, the handler is a no-op — brief.md is unchanged and the next
+ * planner pass will re-prompt for the same questions.
+ *
+ * @param {string} briefPath
+ * @param {Map<string,string>|Record<string,string>|null|undefined} resolutions
+ * @returns {boolean} true if brief.md was rewritten, false if skipped.
+ */
+function applyBriefResolutions(briefPath, resolutions) {
+  if (resolutions === undefined || resolutions === null) return false;
+  if (resolutions instanceof Map && resolutions.size === 0) return false;
+  if (
+    !(resolutions instanceof Map) &&
+    typeof resolutions === 'object' &&
+    Object.keys(resolutions).length === 0
+  ) {
+    return false;
+  }
+
+  let markdown;
+  try {
+    markdown = fs.readFileSync(briefPath, 'utf8');
+  } catch (_e) {
+    return false;
+  }
+
+  const rewritten = openQuestions.applyResolutions(markdown, resolutions);
+  if (rewritten === markdown) return false;
+
+  fs.writeFileSync(briefPath, rewritten, 'utf8');
+  return true;
+}
+
+module.exports = briefGateStep;
+module.exports.briefGateStep = briefGateStep;
+module.exports.applyBriefResolutions = applyBriefResolutions;

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -115,6 +115,11 @@ function briefGateStep(add, s, ctx) {
  */
 function applyBriefResolutions(briefPath, resolutions) {
   if (resolutions === undefined || resolutions === null) return false;
+  // Defensive type guard: reject stray primitives (number, string, boolean,
+  // symbol, bigint) before doing any I/O. Only Map or plain-object payloads
+  // can carry resolution data; anything else is a caller bug and must be a
+  // silent no-op — the next planner pass will re-prompt.
+  if (typeof resolutions !== 'object') return false;
   if (resolutions instanceof Map && resolutions.size === 0) return false;
   if (
     !(resolutions instanceof Map) &&

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -139,7 +139,13 @@ function applyBriefResolutions(briefPath, resolutions) {
   const rewritten = openQuestions.applyResolutions(markdown, resolutions);
   if (rewritten === markdown) return false;
 
-  fs.writeFileSync(briefPath, rewritten, 'utf8');
+  try {
+    fs.writeFileSync(briefPath, rewritten, 'utf8');
+  } catch (_e) {
+    // Fail-closed: mirror the read-failure contract so EACCES/ENOSPC/etc
+    // never propagate as an uncaught exception to the orchestrator.
+    return false;
+  }
   return true;
 }
 

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -9,7 +9,7 @@
  * Decision matrix:
  *   1. `WORK_BRIEF_ENABLED=0`                  → SKIP "Brief disabled"
  *   2. `!s.hasBrief`                           → SKIP "No brief.md present"
- *   3. `brief.md` unreadable (fail-open)       → SKIP "brief.md unreadable"
+ *   3. `brief.md` unreadable (fail-closed)      → RUN  "brief.md unreadable — regenerate brief"
  *   4. Parser returns zero blocking questions  → SKIP "All blocking questions resolved"
  *   5. Otherwise                               → RUN with an AskUserQuestion
  *                                                payload + `onResolve: 'rewrite brief.md'`
@@ -73,9 +73,11 @@ function briefGateStep(add, s, ctx) {
   try {
     markdown = fs.readFileSync(briefPath, 'utf8');
   } catch (_e) {
-    // Fail-open: do not crash the planner on unreadable brief — upstream
-    // verify already covers missing/corrupt brief cases.
-    add(STEPS.brief_gate, 'SKIP', null, 'brief.md unreadable');
+    // Emit RUN so the planner shows the gate needs attention — verify
+    // returns false on read errors (fail-closed), so emitting SKIP here
+    // would create a confusing mismatch ("gate skipped" yet transition
+    // blocked). RUN with a helpful message signals the issue clearly.
+    add(STEPS.brief_gate, 'RUN', null, 'brief.md unreadable — regenerate brief before proceeding');
     return;
   }
 

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -78,7 +78,7 @@ function briefGateStep(add, s, ctx) {
     // would create a confusing mismatch ("gate skipped" yet transition
     // blocked). RUN with a helpful message signals the issue clearly.
     add(STEPS.brief_gate, 'RUN', null, 'brief.md unreadable — regenerate brief before proceeding');
-    return;
+    return; // fail-closed: verify() also returns false on read errors — aligned
   }
 
   const questions = openQuestions.parse(markdown);

--- a/workflows/work/steps/index.js
+++ b/workflows/work/steps/index.js
@@ -10,6 +10,7 @@ const ticketStep = require('./ticket');
 const bootstrapStep = require('./bootstrap');
 const transitionStep = require('./transition');
 const briefStep = require('./brief');
+const briefGateStep = require('./brief-gate');
 const specStep = require('./spec');
 const tasksStep = require('./tasks');
 const implementStep = require('./implement');
@@ -36,6 +37,7 @@ const STEP_PIPELINE = [
   bootstrapStep,
   transitionStep,
   briefStep,
+  briefGateStep,
   specStep,
   tasksStep,
   implementStep,
@@ -51,4 +53,12 @@ const STEP_PIPELINE = [
   completeStep,
 ];
 
-module.exports = { STEP_PIPELINE };
+module.exports = {
+  STEP_PIPELINE,
+  // GH-215 Task 6.1: export briefGateStep as a named handle so external
+  // consumers (and tests) can reference the gate without knowing its
+  // position in STEP_PIPELINE. The gate runs immediately after briefStep
+  // and before specStep to block the brief → spec transition on unresolved
+  // cross-ticket / architectural open questions.
+  briefGateStep,
+};

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -36,6 +36,25 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
     }
   }
 
+  // GH-215: Helper for STEPS.brief_gate verify. Returns true iff brief.md
+  // exists for `ticketId` AND openQuestions.findBlocking(parse(brief)) is
+  // empty. Fail-closed on any read/parse error — we never claim verified
+  // unless we can prove it. Extracted out of the commandMap entry so the
+  // verify declaration reads as a single expression (parallel to
+  // `verifyBootstrap` above).
+  function verifyBriefGate(ticketId) {
+    try {
+      const briefPath = path.join(TASKS_BASE, safeTicketPath(ticketId), 'brief.md');
+      if (!fs.existsSync(briefPath)) return false;
+      const openQuestions = require(path.join(__dirname, 'lib', 'open-questions'));
+      const markdown = fs.readFileSync(briefPath, 'utf-8');
+      const blocking = openQuestions.findBlocking(openQuestions.parse(markdown));
+      return Array.isArray(blocking) && blocking.length === 0;
+    } catch {
+      return false;
+    }
+  }
+
   // ─── Declarative policy config (GH-206 Task 12) ───────────────────────────
   //
   // Artifact patterns per step — consumed by artifact-archival.js on backward
@@ -131,6 +150,13 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             return false;
           }
         },
+      },
+      {
+        // GH-215: Gate between `brief` and `spec`. Verified iff brief.md exists
+        // AND every blocking open question (cross-ticket / architectural scope,
+        // resolved: false) has been answered.
+        step: STEPS.brief_gate,
+        verify: verifyBriefGate,
       },
       {
         step: STEPS.spec,


### PR DESCRIPTION
## Existing Behavior

- The brief step could surface architectural ambiguities and cross-ticket concerns in prose, but the workflow had no mechanism to pause and collect answers before spec began.
- Open Questions in brief.md were free-form text with no structured format, making them unparseable by automation.
- The brief→spec transition was unconditional — the workflow would proceed to spec even with unresolved blockers.
- There was no idempotency guarantee: re-running the workflow after partial answers could re-ask already-resolved questions.

## Intended New Behavior

- A new `brief_gate` step sits between `brief` and `spec` in the step registry and pipeline.
- The gate parses structured Open Question blocks from brief.md (with `scope`, `rationale`, and `resolved` fields) and classifies each as `local`, `cross_ticket`, or `architectural`.
- Any unresolved cross-ticket or architectural question blocks the workflow; the gate collects answers interactively via AskUserQuestion and persists them back into brief.md.
- The gate is fully idempotent — if all questions are already resolved (or only local-scope questions remain), it emits SKIP and is a no-op.
- The `brief-writer` agent now emits a canonical structured Open Questions template so new briefs are parseable from the start.

## Dev Checks

- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## What Changed

### New modules
- `workflows/work/lib/open-questions.js` — pure parser/rewriter: parse, findBlocking, classify, applyResolutions, escapeResolution, downgradeToLocal
- `workflows/work/steps/brief-gate.js` — step module that emits SKIP or RUN(AskUserQuestion) based on blocking question state

### Pipeline wiring
- `workflows/work/step-registry.js` — inserted STEPS.brief_gate between brief and spec
- `workflows/work/steps/index.js` — exports briefGateStep
- `workflows/work/plan-generator.js` — plugs briefGateStep into the execution pipeline
- `workflows/work/workflow-definition.js` — adds verify entry for brief_gate

### Tests (356 total, 7 suites)
- `workflows/work/lib/__tests__/open-questions.test.js` — 49 parser/rewriter unit tests
- `workflows/work/steps/__tests__/brief-gate.test.js` — 11 step-level tests (SKIP paths, RUN paths, write errors)
- `workflows/work/__tests__/step-registry.test.js` — 6 registry ordering tests
- `workflows/work/__tests__/plan-generator-brief-gate.test.js` — 3 pipeline integration tests
- `workflows/work/__tests__/workflow-definition.test.js` — 19 definition tests (incl. brief_gate verify entry)
- `workflows/lib/__tests__/enforce-step-workflow.test.js` — 5 transition integration tests (only-local / unresolved-arch / resolved-arch / idempotent / cross-ticket)
- `workflows/work/steps/__tests__/step-modules.test.js` — 27 step module shape tests

### Documentation
- `agents/brief-writer.md` — structured Open Questions template with scope/rationale/resolved fields
- `skills/brief/SKILL.md` — scope classification table and brief_gate step description
- `workflows/work/skills/brief.md` — updated to reference the gate

### Misc
- `.gitignore` — added node_modules without trailing slash to cover symlink case in dev container

## Testing Plan / Demo

**Backend / workflow gate**

1. Run the work orchestrator on a ticket whose brief.md contains an unresolved architectural question (scope: architectural, resolved: false).
2. Confirm the workflow pauses at brief_gate and prompts via AskUserQuestion with the question text.
3. Provide an answer; confirm the answer is written back into brief.md under the corresponding question block.
4. Re-run the orchestrator; confirm brief_gate emits SKIP (idempotent) and spec proceeds.
5. Run the orchestrator on a brief with only local-scope questions; confirm brief_gate emits SKIP immediately without prompting.

**Unit/integration tests**

Run each suite with node --test:
- workflows/work/lib/__tests__/open-questions.test.js
- workflows/work/steps/__tests__/brief-gate.test.js
- workflows/work/__tests__/step-registry.test.js
- workflows/work/__tests__/plan-generator-brief-gate.test.js
- workflows/lib/__tests__/enforce-step-workflow.test.js

All 356 tests across 7 suites pass.

### Test Results

356 tests pass across 7 suites: 49 parser + 11 brief-gate + 6 step-registry + 3 plan-generator + 19 workflow-definition + 241 enforce-step-workflow + 27 step-modules.

## References

Closes #215