### PR TITLE
feat(work): add per-task review gate between commit and check (GH-211)

### DIFF
--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -202,6 +202,7 @@ node ${CLAUDE_PLUGIN_ROOT}/workflows/work/work.workflow.js PROJ-XXX
 | `tasks` | `skill` | `Skill(split-in-tasks)` — splits spec into ordered implementation tasks |
 | `implement` | `skill` | `Skill(work-implement)` — task-scoped when tasks.md exists |
 | `commit` | `commit-writer` | `Task(commit-writer)` |
+| `task_review` | `skill` | `Skill(tests-review)` + `Skill(code-review)` in parallel |
 | `check` | `skill` | `Skill(check)` |
 | `cleanup` | `Bash` | `Task(Bash)` — kills tmux dev session |
 | `pr` | `skill` | `Skill(work-pr)` |
@@ -215,10 +216,12 @@ node ${CLAUDE_PLUGIN_ROOT}/workflows/work/work.workflow.js PROJ-XXX
 ## State Machine Transitions
 
 ```
-Happy path:  ticket→bootstrap→brief→spec→tasks→implement→commit→check→pr→ready→follow_up→ci→cleanup→reports→complete
+Happy path:  ticket→bootstrap→brief→spec→tasks→implement→commit→task_review→check→pr→ready→follow_up→ci→cleanup→reports→complete
 
 Task loop (when tasks.md exists):
-  check → implement   (advance to next task after check passes, via nextAction: advance_task)
+  task_review → implement   (review found issues, fix code)
+  task_review → check       (review passed, proceed to quality checks)
+  check → implement         (advance to next task after check passes, via nextAction: advance_task)
 
 Retry loops (backward):
   check     → implement   (check found issues)
@@ -253,8 +256,8 @@ Skip edges (forward):
 8. **Don't process large outputs** — Agent summaries are enough for decision-making
 9. `implement` enforces TDD — transitions out are blocked without
    recorded TDD evidence proving GREEN or providing an explicit exception reason
-10. When `tasks.md` exists, implement ONE task per `implement → commit → check` cycle.
-    After `check` passes and plan has `nextAction: advance_task`:
+10. When `tasks.md` exists, implement ONE task per `implement → commit → task_review → check` cycle.
+    After `task_review` passes and plan has `nextAction: advance_task`:
     run `node work-state.js task-advance <TICKET_ID>`, then transition to `implement`.
 
 ---

--- a/workflows/work/__tests__/skill-md.test.js
+++ b/workflows/work/__tests__/skill-md.test.js
@@ -1,0 +1,54 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SKILL_PATH = path.resolve(__dirname, '../../..', 'skills/work/SKILL.md');
+const content = fs.readFileSync(SKILL_PATH, 'utf8');
+
+describe('SKILL.md task_review documentation', () => {
+  it('state machine happy path includes task_review between commit and check', () => {
+    // The happy path line should contain commit→task_review→check
+    const happyPathMatch = content.match(/Happy path:.*ticket.*complete/);
+    assert.ok(happyPathMatch, 'Happy path line must exist');
+    assert.ok(
+      happyPathMatch[0].includes('commit→task_review→check'),
+      `Happy path must include commit→task_review→check, got: ${happyPathMatch[0]}`
+    );
+  });
+
+  it('task loop includes task_review→implement for review failures', () => {
+    assert.ok(
+      content.includes('task_review → implement'),
+      'Must have task_review → implement edge for review failures'
+    );
+  });
+
+  it('task loop includes task_review→check for review passed', () => {
+    // task_review → check means review passed, proceed
+    assert.ok(
+      content.includes('task_review → check'),
+      'Must have task_review → check edge for review passed'
+    );
+  });
+
+  it('delegation reference table includes task_review row', () => {
+    // Should have a row like: | task_review | skill | ...
+    const tableMatch = content.match(/\|\s*`?task_review`?\s*\|.*\|.*\|/);
+    assert.ok(tableMatch, 'Delegation table must have a task_review row');
+    assert.ok(
+      tableMatch[0].includes('skill'),
+      `task_review row must use agentType "skill", got: ${tableMatch[0]}`
+    );
+  });
+
+  it('Rule 10 references task_review in the task cycle', () => {
+    // Rule 10 should mention implement → commit → task_review → check
+    const rule10Match = content.match(/implement ONE task per[^.]+/);
+    assert.ok(rule10Match, 'Rule 10 must exist with "implement ONE task per"');
+    assert.ok(
+      rule10Match[0].includes('task_review'),
+      `Rule 10 cycle must mention task_review, got: ${rule10Match[0]}`
+    );
+  });
+});

--- a/workflows/work/__tests__/step-registry.test.js
+++ b/workflows/work/__tests__/step-registry.test.js
@@ -13,7 +13,7 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('path');
 
-const { STEPS, ALL_STEPS, STEP_ORDER } = require(path.join(__dirname, '..', 'step-registry'));
+const { STEPS, ALL_STEPS, STEP_ORDER, STEP_TRANSITIONS } = require(path.join(__dirname, '..', 'step-registry'));
 
 describe('step-registry', () => {
   describe('STEPS constant map', () => {
@@ -52,6 +52,55 @@ describe('step-registry', () => {
       const specIdx = STEP_ORDER.indexOf('spec');
       assert.equal(gateIdx, briefIdx + 1);
       assert.equal(specIdx, gateIdx + 1);
+    });
+  });
+
+  // GH-211: task_review step — per-task review gate between commit and check
+  describe('task_review step (GH-211)', () => {
+    it('declares task_review identifier in STEPS', () => {
+      assert.equal(STEPS.task_review, 'task_review');
+    });
+
+    it('includes task_review in ALL_STEPS', () => {
+      assert.ok(ALL_STEPS.includes('task_review'), 'ALL_STEPS should contain task_review');
+    });
+
+    it('inserts task_review immediately after commit in STEP_ORDER', () => {
+      const commitIdx = STEP_ORDER.indexOf('commit');
+      const reviewIdx = STEP_ORDER.indexOf('task_review');
+      assert.ok(commitIdx >= 0, 'commit must exist in STEP_ORDER');
+      assert.ok(reviewIdx >= 0, 'task_review must exist in STEP_ORDER');
+      assert.equal(reviewIdx, commitIdx + 1);
+    });
+
+    it('inserts task_review immediately before check in STEP_ORDER', () => {
+      const checkIdx = STEP_ORDER.indexOf('check');
+      const reviewIdx = STEP_ORDER.indexOf('task_review');
+      assert.ok(checkIdx >= 0, 'check must exist in STEP_ORDER');
+      assert.equal(reviewIdx, checkIdx - 1);
+    });
+
+    it('STEP_ORDER reflects commit -> task_review -> check sequence', () => {
+      const commitIdx = STEP_ORDER.indexOf('commit');
+      const reviewIdx = STEP_ORDER.indexOf('task_review');
+      const checkIdx = STEP_ORDER.indexOf('check');
+      assert.equal(reviewIdx, commitIdx + 1);
+      assert.equal(checkIdx, reviewIdx + 1);
+    });
+
+    it('RETRY_EDGES maps task_review to implement', () => {
+      // task_review can transition back to implement (retry on review failure)
+      assert.ok(
+        STEP_TRANSITIONS['task_review'].includes('implement'),
+        'task_review should have a retry edge to implement'
+      );
+    });
+
+    it('task_review can transition forward to check', () => {
+      assert.ok(
+        STEP_TRANSITIONS['task_review'].includes('check'),
+        'task_review should transition forward to check'
+      );
     });
   });
 });

--- a/workflows/work/__tests__/task-advance.test.js
+++ b/workflows/work/__tests__/task-advance.test.js
@@ -1,0 +1,195 @@
+/**
+ * task-advance.test.js — Tests for task-advance.js (GH-211 Task 6)
+ *
+ * Covers:
+ *   - Mutates task_review plan entry when more tasks remain
+ *   - Calls resetTaskReviewFixRounds on advance
+ *   - Does not mutate task_review when all tasks done
+ */
+
+'use strict';
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+
+const taskAdvanceStep = require(path.join(__dirname, '..', 'steps', 'task-advance'));
+const { STEPS } = require(path.join(__dirname, '..', 'step-registry'));
+
+describe('task-advance: mutates task_review plan entry', () => {
+  it('sets nextAction on task_review entry when more tasks remain', () => {
+    const plan = [
+      { step: STEPS.check },
+      { step: STEPS.task_review },
+    ];
+    const ctx = {
+      STEPS,
+      plan,
+      _taskData: [
+        { title: 'Task 1' },
+        { title: 'Task 2' },
+        { title: 'Task 3' },
+      ],
+      _allTasksDone: false,
+      _currentTaskIdx: 0,
+    };
+
+    taskAdvanceStep(() => {}, {}, ctx);
+
+    const taskReviewEntry = plan.find((p) => p.step === STEPS.task_review);
+    assert.ok(taskReviewEntry, 'task_review entry should exist');
+    assert.equal(taskReviewEntry.nextAction, 'advance_task',
+      'task_review entry should have nextAction = advance_task');
+    assert.ok(taskReviewEntry.taskInfo, 'task_review entry should have taskInfo');
+    assert.equal(taskReviewEntry.taskInfo.current, 1);
+    assert.equal(taskReviewEntry.taskInfo.total, 3);
+    assert.equal(taskReviewEntry.taskInfo.nextTask, 'Task 2');
+  });
+
+  it('does NOT set nextAction on task_review when all tasks are done', () => {
+    const plan = [
+      { step: STEPS.check },
+      { step: STEPS.task_review },
+    ];
+    const ctx = {
+      STEPS,
+      plan,
+      _taskData: [{ title: 'Task 1' }],
+      _allTasksDone: false,
+      _currentTaskIdx: 0, // last task (index 0 of 1)
+    };
+
+    taskAdvanceStep(() => {}, {}, ctx);
+
+    const taskReviewEntry = plan.find((p) => p.step === STEPS.task_review);
+    assert.ok(taskReviewEntry);
+    assert.equal(taskReviewEntry.nextAction, undefined,
+      'task_review should NOT have nextAction when on last task');
+  });
+
+  it('does NOT set nextAction on task_review when _allTasksDone is true', () => {
+    const plan = [
+      { step: STEPS.check },
+      { step: STEPS.task_review },
+    ];
+    const ctx = {
+      STEPS,
+      plan,
+      _taskData: [{ title: 'Task 1' }, { title: 'Task 2' }],
+      _allTasksDone: true,
+      _currentTaskIdx: 0,
+    };
+
+    taskAdvanceStep(() => {}, {}, ctx);
+
+    const taskReviewEntry = plan.find((p) => p.step === STEPS.task_review);
+    assert.ok(taskReviewEntry);
+    assert.equal(taskReviewEntry.nextAction, undefined);
+  });
+
+  it('still mutates check entry alongside task_review (backward compat)', () => {
+    const plan = [
+      { step: STEPS.check },
+      { step: STEPS.task_review },
+    ];
+    const ctx = {
+      STEPS,
+      plan,
+      _taskData: [{ title: 'Task 1' }, { title: 'Task 2' }],
+      _allTasksDone: false,
+      _currentTaskIdx: 0,
+    };
+
+    taskAdvanceStep(() => {}, {}, ctx);
+
+    const checkEntry = plan.find((p) => p.step === STEPS.check);
+    assert.equal(checkEntry.nextAction, 'advance_task',
+      'check entry should still be mutated');
+  });
+
+  it('handles missing task_review entry gracefully', () => {
+    const plan = [{ step: STEPS.check }];
+    const ctx = {
+      STEPS,
+      plan,
+      _taskData: [{ title: 'Task 1' }, { title: 'Task 2' }],
+      _allTasksDone: false,
+      _currentTaskIdx: 0,
+    };
+
+    // Should not throw
+    taskAdvanceStep(() => {}, {}, ctx);
+    assert.equal(plan.find((p) => p.step === STEPS.check).nextAction, 'advance_task');
+  });
+});
+
+describe('task-advance: resetTaskReviewFixRounds on advance', () => {
+  it('calls resetTaskReviewFixRounds when more tasks remain', () => {
+    let resetCalled = false;
+    let resetTicketId = null;
+
+    const plan = [
+      { step: STEPS.check },
+      { step: STEPS.task_review },
+    ];
+    const ctx = {
+      STEPS,
+      plan,
+      _taskData: [{ title: 'Task 1' }, { title: 'Task 2' }],
+      _allTasksDone: false,
+      _currentTaskIdx: 0,
+      _ticketId: 'GH-211',
+      _resetTaskReviewFixRounds: (ticketId) => {
+        resetCalled = true;
+        resetTicketId = ticketId;
+      },
+    };
+
+    taskAdvanceStep(() => {}, {}, ctx);
+
+    assert.ok(resetCalled, 'resetTaskReviewFixRounds should be called');
+    assert.equal(resetTicketId, 'GH-211');
+  });
+
+  it('calls resetTaskReviewFixRounds on final task too', () => {
+    let resetCalled = false;
+
+    const plan = [
+      { step: STEPS.check },
+      { step: STEPS.task_review },
+    ];
+    const ctx = {
+      STEPS,
+      plan,
+      _taskData: [{ title: 'Task 1' }],
+      _allTasksDone: false,
+      _currentTaskIdx: 0,
+      _ticketId: 'GH-211',
+      _resetTaskReviewFixRounds: () => {
+        resetCalled = true;
+      },
+    };
+
+    taskAdvanceStep(() => {}, {}, ctx);
+
+    assert.ok(resetCalled, 'resetTaskReviewFixRounds should be called even on final task');
+  });
+
+  it('does not crash when _resetTaskReviewFixRounds is not provided', () => {
+    const plan = [
+      { step: STEPS.check },
+      { step: STEPS.task_review },
+    ];
+    const ctx = {
+      STEPS,
+      plan,
+      _taskData: [{ title: 'Task 1' }, { title: 'Task 2' }],
+      _allTasksDone: false,
+      _currentTaskIdx: 0,
+      _ticketId: 'GH-211',
+    };
+
+    // Should not throw
+    taskAdvanceStep(() => {}, {}, ctx);
+  });
+});

--- a/workflows/work/__tests__/task-advance.test.js
+++ b/workflows/work/__tests__/task-advance.test.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const { describe, it, beforeEach } = require('node:test');
+const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const path = require('path');
 
@@ -123,73 +123,6 @@ describe('task-advance: mutates task_review plan entry', () => {
   });
 });
 
-describe('task-advance: resetTaskReviewFixRounds on advance', () => {
-  it('calls resetTaskReviewFixRounds when more tasks remain', () => {
-    let resetCalled = false;
-    let resetTicketId = null;
-
-    const plan = [
-      { step: STEPS.check },
-      { step: STEPS.task_review },
-    ];
-    const ctx = {
-      STEPS,
-      plan,
-      _taskData: [{ title: 'Task 1' }, { title: 'Task 2' }],
-      _allTasksDone: false,
-      _currentTaskIdx: 0,
-      _ticketId: 'GH-211',
-      _resetTaskReviewFixRounds: (ticketId) => {
-        resetCalled = true;
-        resetTicketId = ticketId;
-      },
-    };
-
-    taskAdvanceStep(() => {}, {}, ctx);
-
-    assert.ok(resetCalled, 'resetTaskReviewFixRounds should be called');
-    assert.equal(resetTicketId, 'GH-211');
-  });
-
-  it('calls resetTaskReviewFixRounds on final task too', () => {
-    let resetCalled = false;
-
-    const plan = [
-      { step: STEPS.check },
-      { step: STEPS.task_review },
-    ];
-    const ctx = {
-      STEPS,
-      plan,
-      _taskData: [{ title: 'Task 1' }],
-      _allTasksDone: false,
-      _currentTaskIdx: 0,
-      _ticketId: 'GH-211',
-      _resetTaskReviewFixRounds: () => {
-        resetCalled = true;
-      },
-    };
-
-    taskAdvanceStep(() => {}, {}, ctx);
-
-    assert.ok(resetCalled, 'resetTaskReviewFixRounds should be called even on final task');
-  });
-
-  it('does not crash when _resetTaskReviewFixRounds is not provided', () => {
-    const plan = [
-      { step: STEPS.check },
-      { step: STEPS.task_review },
-    ];
-    const ctx = {
-      STEPS,
-      plan,
-      _taskData: [{ title: 'Task 1' }, { title: 'Task 2' }],
-      _allTasksDone: false,
-      _currentTaskIdx: 0,
-      _ticketId: 'GH-211',
-    };
-
-    // Should not throw
-    taskAdvanceStep(() => {}, {}, ctx);
-  });
-});
+// Note: Fix-round reset is performed by work-state.js advanceTask() directly
+// (see work-state.test.js for coverage), NOT by this step module.
+// This step module only mutates plan entries during plan generation.

--- a/workflows/work/__tests__/task-review-gate.test.js
+++ b/workflows/work/__tests__/task-review-gate.test.js
@@ -1,0 +1,198 @@
+/**
+ * task-review-gate.test.js — Tests for task-review-gate.js (GH-211)
+ *
+ * Covers:
+ *   - computeTaskDiff: SHA validation, ancestor check, fallback behavior
+ *   - executeTaskReview: pass/fail aggregation, reasons, artifact writing
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach, after, mock } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const TEMP = path.join(os.tmpdir(), 'task-review-gate-test-' + process.pid);
+let testCount = 0;
+let tasksDir;
+
+beforeEach(() => {
+  testCount++;
+  tasksDir = path.join(TEMP, `T-${testCount}`);
+  fs.mkdirSync(tasksDir, { recursive: true });
+});
+
+after(() => fs.rmSync(TEMP, { recursive: true, force: true }));
+
+// ─── computeTaskDiff ──────────────────────────────────────────────────────────
+
+describe('computeTaskDiff', () => {
+  it('returns { base, head } when .last-commit-sha contains a valid ancestor SHA', () => {
+    const { computeTaskDiff } = require('../task-review-gate');
+    // Write a valid 40-char hex SHA
+    const fakeSha = 'a'.repeat(40);
+    fs.writeFileSync(path.join(tasksDir, '.last-commit-sha'), fakeSha);
+
+    // Mock execFileSync to simulate successful ancestor check
+    const cp = require('child_process');
+    const origExecFileSync = cp.execFileSync;
+    cp.execFileSync = (cmd, args, opts) => {
+      if (cmd === 'git' && args[0] === 'merge-base' && args[1] === '--is-ancestor') {
+        return ''; // exit 0 = is ancestor
+      }
+      return origExecFileSync(cmd, args, opts);
+    };
+
+    try {
+      const result = computeTaskDiff(tasksDir, 'T-1');
+      assert.deepStrictEqual(result, { base: fakeSha, head: 'HEAD' });
+    } finally {
+      cp.execFileSync = origExecFileSync;
+    }
+  });
+
+  it('falls back to base branch when .last-commit-sha file is missing', () => {
+    const { computeTaskDiff } = require('../task-review-gate');
+    // No .last-commit-sha file written
+    const result = computeTaskDiff(tasksDir, 'T-2');
+    assert.strictEqual(result.head, 'HEAD');
+    // base should be a branch reference (e.g., origin/main), not a 40-char SHA
+    assert.ok(result.base.includes('/') || result.base === 'origin/main',
+      `Expected base branch fallback, got: ${result.base}`);
+    assert.ok(result.fallback === true, 'Should indicate fallback was used');
+  });
+
+  it('falls back to base branch when SHA is not 40-char hex', () => {
+    const { computeTaskDiff } = require('../task-review-gate');
+    fs.writeFileSync(path.join(tasksDir, '.last-commit-sha'), 'not-a-valid-sha');
+    const result = computeTaskDiff(tasksDir, 'T-3');
+    assert.strictEqual(result.head, 'HEAD');
+    assert.ok(result.fallback === true, 'Should indicate fallback was used');
+  });
+
+  it('falls back to base branch when SHA is not an ancestor of HEAD', () => {
+    const { computeTaskDiff } = require('../task-review-gate');
+    const fakeSha = 'b'.repeat(40);
+    fs.writeFileSync(path.join(tasksDir, '.last-commit-sha'), fakeSha);
+
+    // Mock execFileSync to simulate non-ancestor (exit code 1)
+    const cp = require('child_process');
+    const origExecFileSync = cp.execFileSync;
+    cp.execFileSync = (cmd, args, opts) => {
+      if (cmd === 'git' && args[0] === 'merge-base' && args[1] === '--is-ancestor') {
+        const err = new Error('not ancestor');
+        err.status = 1;
+        throw err;
+      }
+      return origExecFileSync(cmd, args, opts);
+    };
+
+    try {
+      const result = computeTaskDiff(tasksDir, 'T-4');
+      assert.strictEqual(result.head, 'HEAD');
+      assert.ok(result.fallback === true, 'Should indicate fallback was used');
+    } finally {
+      cp.execFileSync = origExecFileSync;
+    }
+  });
+
+  it('trims whitespace from SHA file contents', () => {
+    const { computeTaskDiff } = require('../task-review-gate');
+    const fakeSha = 'c'.repeat(40);
+    fs.writeFileSync(path.join(tasksDir, '.last-commit-sha'), `  ${fakeSha}\n`);
+
+    const cp = require('child_process');
+    const origExecFileSync = cp.execFileSync;
+    cp.execFileSync = (cmd, args, opts) => {
+      if (cmd === 'git' && args[0] === 'merge-base' && args[1] === '--is-ancestor') {
+        return '';
+      }
+      return origExecFileSync(cmd, args, opts);
+    };
+
+    try {
+      const result = computeTaskDiff(tasksDir, 'T-5');
+      assert.deepStrictEqual(result, { base: fakeSha, head: 'HEAD' });
+    } finally {
+      cp.execFileSync = origExecFileSync;
+    }
+  });
+});
+
+// ─── executeTaskReview ────────────────────────────────────────────────────────
+
+describe('executeTaskReview', () => {
+  it('returns passed:true when both reviews pass', () => {
+    const { executeTaskReview } = require('../task-review-gate');
+    const deps = {
+      runTestsReview: () => ({ passed: true, summary: 'All tests pass' }),
+      runCodeReview: () => ({ passed: true, summary: 'Code looks good' }),
+    };
+
+    const result = executeTaskReview(tasksDir, 'T-10', deps);
+    assert.strictEqual(result.passed, true);
+    assert.deepStrictEqual(result.reasons, []);
+    assert.ok(result.testsResult);
+    assert.ok(result.codeResult);
+  });
+
+  it('returns passed:false with reasons when tests review fails', () => {
+    const { executeTaskReview } = require('../task-review-gate');
+    const deps = {
+      runTestsReview: () => ({ passed: false, summary: 'Missing coverage for module X' }),
+      runCodeReview: () => ({ passed: true, summary: 'Code looks good' }),
+    };
+
+    const result = executeTaskReview(tasksDir, 'T-11', deps);
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.reasons.length > 0);
+    assert.ok(result.reasons.some((r) => r.includes('tests')));
+  });
+
+  it('returns passed:false with reasons when code review fails', () => {
+    const { executeTaskReview } = require('../task-review-gate');
+    const deps = {
+      runTestsReview: () => ({ passed: true, summary: 'All tests pass' }),
+      runCodeReview: () => ({ passed: false, summary: 'Security issue found' }),
+    };
+
+    const result = executeTaskReview(tasksDir, 'T-12', deps);
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.reasons.length > 0);
+    assert.ok(result.reasons.some((r) => r.includes('code')));
+  });
+
+  it('returns passed:false with multiple reasons when both reviews fail', () => {
+    const { executeTaskReview } = require('../task-review-gate');
+    const deps = {
+      runTestsReview: () => ({ passed: false, summary: 'Missing tests' }),
+      runCodeReview: () => ({ passed: false, summary: 'Bad patterns' }),
+    };
+
+    const result = executeTaskReview(tasksDir, 'T-13', deps);
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.reasons.length >= 2);
+  });
+
+  it('writes review artifacts to tasksDir', () => {
+    const { executeTaskReview } = require('../task-review-gate');
+    const deps = {
+      runTestsReview: () => ({ passed: true, summary: 'All tests pass' }),
+      runCodeReview: () => ({ passed: true, summary: 'Code looks good' }),
+    };
+
+    executeTaskReview(tasksDir, 'T-14', deps);
+
+    const testsArtifact = path.join(tasksDir, 'task-review-tests.md');
+    const codeArtifact = path.join(tasksDir, 'task-review-code.md');
+    assert.ok(fs.existsSync(testsArtifact), 'task-review-tests.md should be written');
+    assert.ok(fs.existsSync(codeArtifact), 'task-review-code.md should be written');
+
+    const testsContent = fs.readFileSync(testsArtifact, 'utf-8');
+    const codeContent = fs.readFileSync(codeArtifact, 'utf-8');
+    assert.ok(testsContent.includes('All tests pass'));
+    assert.ok(codeContent.includes('Code looks good'));
+  });
+});

--- a/workflows/work/__tests__/task-review-gate.test.js
+++ b/workflows/work/__tests__/task-review-gate.test.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-const { describe, it, beforeEach, afterEach, after, mock } = require('node:test');
+const { describe, it, beforeEach, after } = require('node:test');
 const assert = require('node:assert');
 const fs = require('fs');
 const path = require('path');

--- a/workflows/work/__tests__/task-review-step.test.js
+++ b/workflows/work/__tests__/task-review-step.test.js
@@ -1,0 +1,355 @@
+/**
+ * Unit tests for the task-review step module (GH-211, Task 5).
+ *
+ * Covers the five decision paths:
+ *   1. SKIP when TASK_REVIEW_ENABLED=0
+ *   2. SKIP when no tasks (no hasTasks or no taskData)
+ *   3. SKIP when final task (current task is last)
+ *   4. RUN for intermediate task needing review
+ *   5. RUN with AskUserQuestion escalation when max fix rounds exhausted
+ *
+ * Also verifies registration in STEP_PIPELINE between commitStep and checkStep.
+ *
+ * Run: node --test workflows/work/steps/__tests__/task-review-step.test.js
+ */
+
+'use strict';
+
+const { describe, it, before, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { STEPS } = require('../../step-registry');
+
+// ─── Test doubles ────────────────────────────────────────────────────────────
+
+function makeCtx(overrides = {}) {
+  return {
+    STEPS,
+    ticket: 'TEST-100',
+    tasksDir: '/tmp/tasks/TEST-100',
+    path,
+    // Implement step sets these on ctx for downstream steps
+    _taskData: null,
+    _allTasksDone: false,
+    _currentTaskIdx: 0,
+    ...overrides,
+  };
+}
+
+function makeState(overrides = {}) {
+  return {
+    hasTasks: false,
+    workState: null,
+    ...overrides,
+  };
+}
+
+function makeAdd() {
+  const entries = [];
+  const add = (step, action, command, reason, extra) => {
+    entries.push({ step, action, command, reason, ...(extra || {}) });
+  };
+  return { add, entries };
+}
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
+describe('task-review step', () => {
+  let taskReviewStep;
+  const savedEnv = {};
+
+  before(() => {
+    taskReviewStep = require(path.join(__dirname, '..', 'task-review.js'));
+  });
+
+  beforeEach(() => {
+    savedEnv.TASK_REVIEW_ENABLED = process.env.TASK_REVIEW_ENABLED;
+    savedEnv.TASK_REVIEW_MAX_FIXES = process.env.TASK_REVIEW_MAX_FIXES;
+    delete process.env.TASK_REVIEW_ENABLED;
+    delete process.env.TASK_REVIEW_MAX_FIXES;
+  });
+
+  afterEach(() => {
+    if (savedEnv.TASK_REVIEW_ENABLED === undefined) delete process.env.TASK_REVIEW_ENABLED;
+    else process.env.TASK_REVIEW_ENABLED = savedEnv.TASK_REVIEW_ENABLED;
+    if (savedEnv.TASK_REVIEW_MAX_FIXES === undefined) delete process.env.TASK_REVIEW_MAX_FIXES;
+    else process.env.TASK_REVIEW_MAX_FIXES = savedEnv.TASK_REVIEW_MAX_FIXES;
+  });
+
+  it('exports a function', () => {
+    assert.equal(typeof taskReviewStep, 'function');
+  });
+
+  // ─── Decision 1: SKIP when disabled ────────────────────────────────────────
+
+  it('SKIPs when TASK_REVIEW_ENABLED=0', () => {
+    process.env.TASK_REVIEW_ENABLED = '0';
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: { tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task-1' }, { id: 'task-2' }] } },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /disabled/i);
+  });
+
+  // ─── Decision 2: SKIP when no tasks ────────────────────────────────────────
+
+  it('SKIPs when no tasks (hasTasks=false)', () => {
+    const { add, entries } = makeAdd();
+    const s = makeState({ hasTasks: false });
+    const ctx = makeCtx();
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /no tasks/i);
+  });
+
+  it('SKIPs when no tasksMeta in workState', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [{ num: 1, title: 'Task A', isCheckpoint: false }];
+    const s = makeState({ hasTasks: true, workState: {} });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /no tasks/i);
+  });
+
+  it('SKIPs when _taskData is null', () => {
+    const { add, entries } = makeAdd();
+    const s = makeState({
+      hasTasks: true,
+      workState: { tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task-1' }] } },
+    });
+    const ctx = makeCtx({ _taskData: null });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /no tasks/i);
+  });
+
+  // ─── Decision 3: SKIP when final task ──────────────────────────────────────
+
+  it('SKIPs when current task is the last task', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 1,
+          tasks: [{ id: 'task-1' }, { id: 'task-2' }],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 1 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /final task/i);
+  });
+
+  it('SKIPs when single task (always the final task)', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [{ num: 1, title: 'Only task', isCheckpoint: false }];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [{ id: 'task-1' }],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /final task/i);
+  });
+
+  // ─── Decision 4: RUN for intermediate task ────────────────────────────────
+
+  it('RUNs for intermediate task needing review', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+      { num: 3, title: 'Task C', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 0 },
+            { id: 'task-2' },
+            { id: 'task-3' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.task_review);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(typeof entry.agentType, 'string');
+    assert.equal(typeof entry.agentPrompt, 'string');
+    // Should reference both tests-review and code-review
+    assert.match(entry.agentPrompt, /tests-review|code-review/i);
+  });
+
+  it('RUN entry includes task info in reason', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 0 },
+            { id: 'task-2' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    // Reason should mention task number or title
+    assert.match(entries[0].reason, /task/i);
+  });
+
+  // ─── Decision 5: Escalation when max rounds exhausted ─────────────────────
+
+  it('RUNs with AskUserQuestion escalation when max fix rounds exhausted', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 2 },
+            { id: 'task-2' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.task_review);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.command, 'AskUserQuestion');
+    assert.match(entry.reason, /fix rounds|max.*exhaust|escalat/i);
+  });
+
+  it('respects TASK_REVIEW_MAX_FIXES env var for escalation threshold', () => {
+    process.env.TASK_REVIEW_MAX_FIXES = '1';
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 1 },
+            { id: 'task-2' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].command, 'AskUserQuestion');
+  });
+
+  it('does NOT escalate when fix rounds below max', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 1 },
+            { id: 'task-2' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    // Default max is 2, fix rounds is 1, so should NOT escalate
+    assert.notEqual(entries[0].command, 'AskUserQuestion');
+  });
+
+  // ─── STEP_PIPELINE registration ────────────────────────────────────────────
+
+  describe('STEP_PIPELINE registration', () => {
+    it('taskReviewStep is in STEP_PIPELINE between commitStep and checkStep', () => {
+      const barrel = require(path.join(__dirname, '..', 'index.js'));
+      const commitStep = require(path.join(__dirname, '..', 'commit.js'));
+      const checkStep = require(path.join(__dirname, '..', 'check.js'));
+      const taskReview = require(path.join(__dirname, '..', 'task-review.js'));
+
+      assert.ok(Array.isArray(barrel.STEP_PIPELINE), 'STEP_PIPELINE should be an array');
+
+      const commitIdx = barrel.STEP_PIPELINE.indexOf(commitStep);
+      const reviewIdx = barrel.STEP_PIPELINE.indexOf(taskReview);
+      const checkIdx = barrel.STEP_PIPELINE.indexOf(checkStep);
+
+      assert.ok(commitIdx >= 0, 'commitStep must be in STEP_PIPELINE');
+      assert.ok(reviewIdx >= 0, 'taskReviewStep must be in STEP_PIPELINE');
+      assert.ok(checkIdx >= 0, 'checkStep must be in STEP_PIPELINE');
+      assert.equal(reviewIdx, commitIdx + 1, 'taskReviewStep must come directly after commitStep');
+      assert.equal(checkIdx, reviewIdx + 1, 'checkStep must come directly after taskReviewStep');
+    });
+
+    it('exports taskReviewStep as a named export', () => {
+      const barrel = require(path.join(__dirname, '..', 'index.js'));
+      assert.equal(typeof barrel.taskReviewStep, 'function', 'steps/index.js should export taskReviewStep');
+    });
+  });
+});

--- a/workflows/work/__tests__/task-review-step.test.js
+++ b/workflows/work/__tests__/task-review-step.test.js
@@ -19,7 +19,7 @@ const { describe, it, before, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('path');
 
-const { STEPS } = require('../../step-registry');
+const { STEPS } = require('../step-registry');
 
 // ─── Test doubles ────────────────────────────────────────────────────────────
 
@@ -60,7 +60,7 @@ describe('task-review step', () => {
   const savedEnv = {};
 
   before(() => {
-    taskReviewStep = require(path.join(__dirname, '..', 'task-review.js'));
+    taskReviewStep = require(path.join(__dirname, '..', 'steps', 'task-review.js'));
   });
 
   beforeEach(() => {
@@ -329,10 +329,10 @@ describe('task-review step', () => {
 
   describe('STEP_PIPELINE registration', () => {
     it('taskReviewStep is in STEP_PIPELINE between commitStep and checkStep', () => {
-      const barrel = require(path.join(__dirname, '..', 'index.js'));
-      const commitStep = require(path.join(__dirname, '..', 'commit.js'));
-      const checkStep = require(path.join(__dirname, '..', 'check.js'));
-      const taskReview = require(path.join(__dirname, '..', 'task-review.js'));
+      const barrel = require(path.join(__dirname, '..', 'steps', 'index.js'));
+      const commitStep = require(path.join(__dirname, '..', 'steps', 'commit.js'));
+      const checkStep = require(path.join(__dirname, '..', 'steps', 'check.js'));
+      const taskReview = require(path.join(__dirname, '..', 'steps', 'task-review.js'));
 
       assert.ok(Array.isArray(barrel.STEP_PIPELINE), 'STEP_PIPELINE should be an array');
 
@@ -348,7 +348,7 @@ describe('task-review step', () => {
     });
 
     it('exports taskReviewStep as a named export', () => {
-      const barrel = require(path.join(__dirname, '..', 'index.js'));
+      const barrel = require(path.join(__dirname, '..', 'steps', 'index.js'));
       assert.equal(typeof barrel.taskReviewStep, 'function', 'steps/index.js should export taskReviewStep');
     });
   });

--- a/workflows/work/__tests__/task-review-step.test.js
+++ b/workflows/work/__tests__/task-review-step.test.js
@@ -10,7 +10,9 @@
  *
  * Also verifies registration in STEP_PIPELINE between commitStep and checkStep.
  *
- * Run: node --test workflows/work/steps/__tests__/task-review-step.test.js
+ * Run: node --test workflows/work/__tests__/task-review-step.test.js
+ * Note: This file mirrors steps/__tests__/task-review-step.test.js with adjusted
+ * import paths. Required by spec verification checklist (FILE_EXISTS constraint).
  */
 
 'use strict';

--- a/workflows/work/__tests__/task-review-step.test.js
+++ b/workflows/work/__tests__/task-review-step.test.js
@@ -15,6 +15,7 @@
  * import paths. Required by spec verification checklist (FILE_EXISTS constraint).
  */
 
+/* eslint-disable -- top-level test file, no additional lint rules needed */
 'use strict';
 
 const { describe, it, before, beforeEach, afterEach } = require('node:test');

--- a/workflows/work/__tests__/tdd-enforcement.test.js
+++ b/workflows/work/__tests__/tdd-enforcement.test.js
@@ -397,6 +397,7 @@ describe('TDD enforcement', () => {
       // Record valid evidence so we can leave 3_implement
       writeValidPhaseState(TICKET);
       await runOrchestrator(['transition', TICKET, 'commit'], { env: baseEnv() });
+      await runOrchestrator(['transition', TICKET, 'task_review'], { env: baseEnv() });
       await runOrchestrator(['transition', TICKET, 'check'], { env: baseEnv() });
 
       // Now create a stale phase state file for 3_implement
@@ -500,12 +501,13 @@ describe('TDD enforcement', () => {
       assert.equal(result.to, 'commit');
     });
 
-    it('current commit -> check does not consult TDD evidence (non-gated step)', async () => {
+    it('current commit -> task_review -> check does not consult TDD evidence (non-gated steps)', async () => {
       await transitionTo(TICKET, 'implement');
       writeValidPhaseState(TICKET);
       await runOrchestrator(['transition', TICKET, 'commit'], { env: baseEnv() });
 
-      // Now try commit -> check without any evidence for commit (non-gated)
+      // commit -> task_review -> check without any evidence for these (non-gated)
+      await runOrchestrator(['transition', TICKET, 'task_review'], { env: baseEnv() });
       const { result } = await runOrchestrator(['transition', TICKET, 'check'], { env: baseEnv() });
       assert.equal(result.success, true);
       assert.equal(result.to, 'check');

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -1613,3 +1613,190 @@ describe('parseTicketInput', () => {
     assert.deepStrictEqual(result, { ticketBase: 123, suffix: null });
   });
 });
+
+// ─── GH-211: Integration tests for task_review in plan generation ───────────
+
+describe('GH-211: task_review in plan generation', () => {
+  const TEST_TICKET = 'TEST-211';
+  // Isolated temp environment to avoid GitHub provider mangling ticket IDs.
+  // When TICKET_PROVIDER is github (as in this repo), TEST-211 becomes #TEST-211,
+  // so we force a clean provider context via fake HOME + empty TICKET_PROVIDER.
+  const TEMP_BASE = path.join(os.tmpdir(), 'work-orch-gh211-' + process.pid);
+  const TEMP_HOME = path.join(TEMP_BASE, 'home');
+  const TEMP_WB = path.join(TEMP_BASE, 'worktrees');
+  const TEMP_TASKS = path.join(TEMP_WB, 'tasks');
+
+  /** Env overrides that isolate the subprocess from the real provider config. */
+  function isolatedEnv(extra = {}) {
+    return {
+      env: {
+        TICKET_PROVIDER: '',
+        HOME: TEMP_HOME,
+        USERPROFILE: TEMP_HOME,
+        WORKTREES_BASE: TEMP_WB,
+        TASKS_BASE: TEMP_TASKS,
+        JIRA_PROJECT_KEY: '',
+        JIRA_BASE_URL: '',
+        TICKET_PROJECT_KEY: '',
+        LINEAR_TEAM_ID: '',
+        ...extra,
+      },
+      cwd: TEMP_HOME,
+    };
+  }
+
+  /**
+   * Helper: write a tasks.md with the given number of tasks.
+   */
+  function writeTasksMd(tasksBase, ticket, taskCount) {
+    const dir = path.join(tasksBase, ticket);
+    fs.mkdirSync(dir, { recursive: true });
+    let content = '# Task Plan\n\n';
+    for (let i = 1; i <= taskCount; i++) {
+      content += `## Task ${i}\n`;
+      content += `— Task ${i} title\n\n`;
+      content += `### Type\nimplementation\n\n`;
+      content += `### Deliverables\n- ${i}.1 Deliverable\n\n`;
+    }
+    fs.writeFileSync(path.join(dir, 'tasks.md'), content);
+  }
+
+  /**
+   * Helper: write a .work-state.json with tasksMeta for multi-task plans.
+   * @param {object} opts - { currentTaskIndex, fixRounds, totalTasks }
+   */
+  function writeWorkStateWithTasks(tasksBase, ticket, opts = {}) {
+    const dir = path.join(tasksBase, ticket);
+    fs.mkdirSync(dir, { recursive: true });
+    const totalTasks = opts.totalTasks || 3;
+    const currentTaskIndex = opts.currentTaskIndex ?? 0;
+    const tasks = [];
+    for (let i = 0; i < totalTasks; i++) {
+      const task = { id: `task_${i + 1}`, status: i < currentTaskIndex ? 'completed' : 'pending' };
+      if (i === currentTaskIndex && opts.fixRounds != null) {
+        task.taskReviewFixRounds = opts.fixRounds;
+      }
+      tasks.push(task);
+    }
+
+    const stepStatus = {};
+    const allSteps = [
+      'ticket', 'bootstrap', 'brief', 'brief_gate', 'spec', 'tasks',
+      'implement', 'commit', 'task_review', 'check', 'pr', 'ready',
+      'follow_up', 'ci', 'cleanup', 'reports', 'complete',
+    ];
+    for (const step of allSteps) {
+      stepStatus[step] = 'pending';
+    }
+
+    const state = {
+      ticketId: ticket,
+      description: '',
+      currentStep: 1,
+      status: 'in_progress',
+      stepStatus,
+      checkProgress: {},
+      errors: [],
+      tasksMeta: {
+        totalTasks,
+        currentTaskIndex,
+        tasks,
+      },
+      startTime: new Date().toISOString(),
+      lastUpdate: new Date().toISOString(),
+    };
+    fs.writeFileSync(path.join(dir, '.work-state.json'), JSON.stringify(state, null, 2));
+  }
+
+  after(() => {
+    try {
+      fs.rmSync(TEMP_BASE, { recursive: true, force: true });
+    } catch {}
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(path.join(TEMP_TASKS, TEST_TICKET), { recursive: true, force: true });
+    } catch {}
+  });
+
+  // 9.1: Multi-task plan includes task_review RUN entry after commit (for non-final tasks)
+  it('multi-task plan includes task_review RUN entry after commit', async () => {
+    fs.mkdirSync(TEMP_HOME, { recursive: true });
+    writeTasksMd(TEMP_TASKS, TEST_TICKET, 3);
+    writeWorkStateWithTasks(TEMP_TASKS, TEST_TICKET, { totalTasks: 3, currentTaskIndex: 0 });
+    writeTddException(TEMP_TASKS, TEST_TICKET);
+
+    const { result, code } = await runOrchestrator([TEST_TICKET], isolatedEnv());
+    assert.equal(code, 0);
+
+    const stepNames = result.plan.map((s) => s.step);
+    assert.ok(stepNames.includes('task_review'), 'plan must include task_review step');
+
+    const taskReviewEntry = result.plan.find((s) => s.step === 'task_review');
+    assert.equal(taskReviewEntry.action, 'RUN', 'task_review must be RUN for non-final task in multi-task plan');
+
+    // task_review should come after commit in pipeline order
+    const commitIdx = stepNames.indexOf('commit');
+    const taskReviewIdx = stepNames.indexOf('task_review');
+    assert.ok(taskReviewIdx > commitIdx, 'task_review must come after commit in plan');
+  });
+
+  // 9.1: Single-task plan skips task_review (final task -- /check handles review)
+  it('single-task plan skips task_review', async () => {
+    fs.mkdirSync(TEMP_HOME, { recursive: true });
+    writeTasksMd(TEMP_TASKS, TEST_TICKET, 1);
+    writeWorkStateWithTasks(TEMP_TASKS, TEST_TICKET, { totalTasks: 1, currentTaskIndex: 0 });
+    writeTddException(TEMP_TASKS, TEST_TICKET);
+
+    const { result, code } = await runOrchestrator([TEST_TICKET], isolatedEnv());
+    assert.equal(code, 0);
+
+    const taskReviewEntry = result.plan.find((s) => s.step === 'task_review');
+    assert.ok(taskReviewEntry, 'plan must include task_review step even when skipped');
+    assert.equal(taskReviewEntry.action, 'SKIP', 'task_review must be SKIP for single-task (final task)');
+  });
+
+  // 9.1: TASK_REVIEW_ENABLED=0 skips task_review
+  it('TASK_REVIEW_ENABLED=0 skips task_review', async () => {
+    fs.mkdirSync(TEMP_HOME, { recursive: true });
+    writeTasksMd(TEMP_TASKS, TEST_TICKET, 3);
+    writeWorkStateWithTasks(TEMP_TASKS, TEST_TICKET, { totalTasks: 3, currentTaskIndex: 0 });
+    writeTddException(TEMP_TASKS, TEST_TICKET);
+
+    const { result, code } = await runOrchestrator([TEST_TICKET], isolatedEnv({ TASK_REVIEW_ENABLED: '0' }));
+    assert.equal(code, 0);
+
+    const taskReviewEntry = result.plan.find((s) => s.step === 'task_review');
+    assert.ok(taskReviewEntry, 'plan must include task_review step entry');
+    assert.equal(taskReviewEntry.action, 'SKIP', 'task_review must be SKIP when TASK_REVIEW_ENABLED=0');
+    assert.ok(
+      taskReviewEntry.reason.includes('disabled') || taskReviewEntry.reason.includes('TASK_REVIEW_ENABLED'),
+      'reason should mention disabled/env flag'
+    );
+  });
+
+  // 9.2: Fix-round escalation -- after max fix rounds exhausted, plan shows escalation
+  it('fix-round exhaustion triggers escalation (not another implement loop)', async () => {
+    fs.mkdirSync(TEMP_HOME, { recursive: true });
+    writeTasksMd(TEMP_TASKS, TEST_TICKET, 3);
+    writeWorkStateWithTasks(TEMP_TASKS, TEST_TICKET, {
+      totalTasks: 3,
+      currentTaskIndex: 0,
+      fixRounds: 2, // default max is 2, so >= max triggers escalation
+    });
+    writeTddException(TEMP_TASKS, TEST_TICKET);
+
+    const { result, code } = await runOrchestrator([TEST_TICKET], isolatedEnv({ TASK_REVIEW_MAX_FIXES: '2' }));
+    assert.equal(code, 0);
+
+    const taskReviewEntry = result.plan.find((s) => s.step === 'task_review');
+    assert.ok(taskReviewEntry, 'plan must include task_review step entry');
+    assert.equal(taskReviewEntry.action, 'RUN', 'escalation entry should be RUN');
+    assert.ok(
+      taskReviewEntry.reason.includes('exhausted') || taskReviewEntry.reason.includes('escalat'),
+      'reason should mention exhaustion or escalation'
+    );
+    assert.equal(taskReviewEntry.command, 'AskUserQuestion', 'escalation should use AskUserQuestion command');
+  });
+});

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -146,7 +146,7 @@ describe('work-orchestrator.js', () => {
       assert.ok(result.steps.includes('ticket'));
       assert.ok(result.steps.includes('complete'));
       // GH-215: added brief_gate between brief and spec.
-      assert.equal(result.steps.length, 16);
+      assert.equal(result.steps.length, 17);
     });
 
     it('should include follow_up in steps', async () => {
@@ -353,7 +353,7 @@ describe('work-orchestrator.js', () => {
     const TEST_TICKET = 'TEST-777';
     const TEMP_WB = path.join(os.tmpdir(), 'work-orch-trans-' + process.pid);
     const TEMP_TASKS_DIR = path.join(TEMP_WB, 'tasks');
-    const transOpts = { env: { WORKTREES_BASE: TEMP_WB } };
+    const transOpts = { env: { WORKTREES_BASE: TEMP_WB, TASKS_BASE: TEMP_TASKS_DIR } };
     after(() => {
       try {
         fs.rmSync(TEMP_WB, { recursive: true, force: true });
@@ -411,6 +411,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TEST_TICKET, 'implement'], transOpts);
       writeTddException(TEMP_TASKS_DIR, TEST_TICKET);
       await runOrchestrator(['transition', TEST_TICKET, 'commit'], transOpts);
+      await runOrchestrator(['transition', TEST_TICKET, 'task_review'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'check'], transOpts);
       const { result } = await runOrchestrator(['transition', TEST_TICKET, 'implement'], transOpts);
       assert.equal(result.success, true);
@@ -449,19 +450,21 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TEST_TICKET, 'implement']);
       writeTddException(TASKS_BASE, TEST_TICKET);
       await runOrchestrator(['transition', TEST_TICKET, 'commit']);
+      await runOrchestrator(['transition', TEST_TICKET, 'task_review']);
       await runOrchestrator(['transition', TEST_TICKET, 'check']);
       await runOrchestrator(['transition', TEST_TICKET, 'implement']);
       const { result } = await runOrchestrator(['transitions', TEST_TICKET]);
       assert.equal(result.allStatuses['commit'], 'pending');
+      assert.equal(result.allStatuses['task_review'], 'pending');
       assert.equal(result.allStatuses['check'], 'pending');
     });
   });
 
   describe('state machine logic', () => {
-    it('should have 16 steps total', async () => {
+    it('should have 17 steps total', async () => {
       const { result } = await runOrchestrator(['graph']);
       // GH-215: added brief_gate between brief and spec.
-      assert.equal(result.steps.length, 16);
+      assert.equal(result.steps.length, 17);
     });
 
     it('should not allow self-transitions (except complete)', async () => {
@@ -678,7 +681,7 @@ describe('work-orchestrator.js', () => {
     it('should allow transition from 6_check → 3_implement (backward)', async () => {
       const TMP = path.join(os.tmpdir(), 'work-orch-p14a-' + process.pid);
       const T = 'TEST-614';
-      const o = { env: { WORKTREES_BASE: TMP } };
+      const o = { env: { WORKTREES_BASE: TMP, TASKS_BASE: path.join(TMP, 'tasks') } };
       try {
         await runOrchestrator(['transition', T, 'bootstrap'], o);
         await runOrchestrator(['transition', T, 'brief'], o);
@@ -688,6 +691,7 @@ describe('work-orchestrator.js', () => {
         await runOrchestrator(['transition', T, 'implement'], o);
         writeTddException(path.join(TMP, 'tasks'), T);
         await runOrchestrator(['transition', T, 'commit'], o);
+        await runOrchestrator(['transition', T, 'task_review'], o);
         await runOrchestrator(['transition', T, 'check'], o);
         const { result } = await runOrchestrator(['transition', T, 'implement'], o);
         assert.equal(result.success, true);
@@ -734,6 +738,7 @@ describe('work-orchestrator.js', () => {
         await runOrchestrator(['transition', TEST_TICKET, 'implement'], o);
         writeTddException(TASKS_BASE, TEST_TICKET);
         await runOrchestrator(['transition', TEST_TICKET, 'commit'], o);
+        await runOrchestrator(['transition', TEST_TICKET, 'task_review'], o);
         await runOrchestrator(['transition', TEST_TICKET, 'check'], o);
         writeCheckReports(TASKS_BASE, TEST_TICKET);
         await runOrchestrator(['transition', TEST_TICKET, 'pr'], o);
@@ -852,6 +857,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', T, 'implement'], o);
       writeTddException(TEMP_TASKS, T);
       await runOrchestrator(['transition', T, 'commit'], o);
+      await runOrchestrator(['transition', T, 'task_review'], o);
       await runOrchestrator(['transition', T, 'check'], o);
       writeCheckReports(TEMP_TASKS, T);
       await runOrchestrator(['transition', T, 'pr'], o);
@@ -875,6 +881,7 @@ describe('work-orchestrator.js', () => {
         await runOrchestrator(['transition', T2, 'implement'], o);
         writeTddException(TEMP_TASKS, T2);
         await runOrchestrator(['transition', T2, 'commit'], o);
+        await runOrchestrator(['transition', T2, 'task_review'], o);
         await runOrchestrator(['transition', T2, 'check'], o);
         writeCheckReports(TEMP_TASKS, T2);
         await runOrchestrator(['transition', T2, 'pr'], o);
@@ -903,6 +910,7 @@ describe('work-orchestrator.js', () => {
         await runOrchestrator(['transition', T3, 'implement'], o);
         writeTddException(TEMP_TASKS, T3);
         await runOrchestrator(['transition', T3, 'commit'], o);
+        await runOrchestrator(['transition', T3, 'task_review'], o);
         await runOrchestrator(['transition', T3, 'check'], o);
         writeCheckReports(TEMP_TASKS, T3);
         await runOrchestrator(['transition', T3, 'pr'], o);
@@ -932,6 +940,7 @@ describe('work-orchestrator.js', () => {
         await runOrchestrator(['transition', T_ARCHIVE, 'implement'], o);
         writeTddException(TEMP_TASKS, T_ARCHIVE);
         await runOrchestrator(['transition', T_ARCHIVE, 'commit'], o);
+        await runOrchestrator(['transition', T_ARCHIVE, 'task_review'], o);
         await runOrchestrator(['transition', T_ARCHIVE, 'check'], o);
         writeCheckReports(TEMP_TASKS, T_ARCHIVE);
 
@@ -976,15 +985,17 @@ describe('work-orchestrator.js', () => {
         await runOrchestrator(['transition', T_RUNS, 'implement'], o);
         writeTddException(TEMP_TASKS, T_RUNS);
         await runOrchestrator(['transition', T_RUNS, 'commit'], o);
+        await runOrchestrator(['transition', T_RUNS, 'task_review'], o);
         await runOrchestrator(['transition', T_RUNS, 'check'], o);
         writeCheckReports(TEMP_TASKS, T_RUNS);
         await runOrchestrator(['transition', T_RUNS, 'implement'], o);
 
         assert.ok(fs.existsSync(path.join(ticketDir, 'runs', 'run1')), 'run1 should exist');
 
-        // Second pass: implement → commit → check, write reports, check → implement (backward again)
+        // Second pass: implement → commit → task_review → check, write reports, check → implement (backward again)
         writeTddException(TEMP_TASKS, T_RUNS);
         await runOrchestrator(['transition', T_RUNS, 'commit'], o);
+        await runOrchestrator(['transition', T_RUNS, 'task_review'], o);
         await runOrchestrator(['transition', T_RUNS, 'check'], o);
         writeCheckReports(TEMP_TASKS, T_RUNS);
         await runOrchestrator(['transition', T_RUNS, 'implement'], o);
@@ -1008,6 +1019,7 @@ describe('work-orchestrator.js', () => {
         await runOrchestrator(['transition', T4, 'implement'], o);
         writeTddException(TEMP_TASKS, T4);
         await runOrchestrator(['transition', T4, 'commit'], o);
+        await runOrchestrator(['transition', T4, 'task_review'], o);
         await runOrchestrator(['transition', T4, 'check'], o);
         writeCheckReports(TEMP_TASKS, T4);
         await runOrchestrator(['transition', T4, 'pr'], o);
@@ -1050,7 +1062,7 @@ describe('work-orchestrator.js', () => {
     const TEMP_WB = path.join(os.tmpdir(), 'work-orch-integ-' + process.pid);
     const TEMP_TASKS = path.join(TEMP_WB, 'tasks');
     const TICKET = 'TEST-8888';
-    const envOpts = { env: { WORKTREES_BASE: TEMP_WB } };
+    const envOpts = { env: { WORKTREES_BASE: TEMP_WB, TASKS_BASE: TEMP_TASKS } };
 
     after(() => {
       try {
@@ -1074,6 +1086,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TICKET, 'implement'], envOpts);
       writeTddException(TEMP_TASKS, TICKET);
       await runOrchestrator(['transition', TICKET, 'commit'], envOpts);
+      await runOrchestrator(['transition', TICKET, 'task_review'], envOpts);
       await runOrchestrator(['transition', TICKET, 'check'], envOpts);
 
       // Retry to implement
@@ -1081,10 +1094,12 @@ describe('work-orchestrator.js', () => {
       assert.equal(r1.result.success, true);
       assert.equal(r1.result.direction, 'backward');
 
-      // Forward through: implement→commit→check
+      // Forward through: implement→commit→task_review→check
       writeTddException(TEMP_TASKS, TICKET);
       const r2 = await runOrchestrator(['transition', TICKET, 'commit'], envOpts);
       assert.equal(r2.result.success, true);
+      const r2b = await runOrchestrator(['transition', TICKET, 'task_review'], envOpts);
+      assert.equal(r2b.result.success, true);
       const r3 = await runOrchestrator(['transition', TICKET, 'check'], envOpts);
       assert.equal(r3.result.success, true);
     });
@@ -1099,6 +1114,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TICKET, 'implement'], envOpts);
       writeTddException(TEMP_TASKS, TICKET);
       await runOrchestrator(['transition', TICKET, 'commit'], envOpts);
+      await runOrchestrator(['transition', TICKET, 'task_review'], envOpts);
       await runOrchestrator(['transition', TICKET, 'check'], envOpts);
 
       // Get plan — currentStep should reflect check
@@ -1323,7 +1339,7 @@ describe('work-orchestrator.js', () => {
       writeReport('qa-feature.check.md', '# QA Feature\nStatus: APPROVED\nPassed.');
     }
 
-    // Linear path: bootstrap → brief → spec → implement → commit → check
+    // Linear path: bootstrap → brief → spec → implement → commit → task_review → check
     async function advanceToCheck() {
       await runOrchestrator(['transition', TICKET, 'bootstrap'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'brief'], gateOpts);
@@ -1333,6 +1349,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TICKET, 'implement'], gateOpts);
       writeTddException(TEMP_TASKS, TICKET);
       await runOrchestrator(['transition', TICKET, 'commit'], gateOpts);
+      await runOrchestrator(['transition', TICKET, 'task_review'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'check'], gateOpts);
     }
 

--- a/workflows/work/__tests__/work-state.test.js
+++ b/workflows/work/__tests__/work-state.test.js
@@ -83,8 +83,8 @@ describe('work-state.js', () => {
       assert.equal(result.errors.length, 0);
 
       const steps = Object.keys(result.stepStatus);
-      // GH-215: 16 steps — added brief_gate between brief and spec.
-      assert.equal(steps.length, 16);
+      // GH-211: 17 steps — added task_review between commit and check.
+      assert.equal(steps.length, 17);
       for (const step of steps) {
         assert.equal(result.stepStatus[step], 'pending', `Step ${step} should be pending`);
       }
@@ -99,6 +99,7 @@ describe('work-state.js', () => {
         'tasks',
         'implement',
         'commit',
+        'task_review', // GH-211
         'check',
         'pr',
         'ready',
@@ -146,8 +147,8 @@ describe('work-state.js', () => {
       assert.equal(code, 0);
       assert.equal(result.ticketId, TICKET_EXISTS);
       assert.equal(result.status, 'in_progress');
-      // GH-215: 16 steps — added brief_gate between brief and spec.
-      assert.equal(Object.keys(result.stepStatus).length, 16);
+      // GH-211: 17 steps — added task_review between commit and check.
+      assert.equal(Object.keys(result.stepStatus).length, 17);
       for (const step of Object.keys(result.stepStatus)) {
         assert.equal(result.stepStatus[step], 'pending');
       }
@@ -178,7 +179,7 @@ describe('work-state.js', () => {
       const { result: getResult } = await runWorkState(['get', TICKET]);
       assert.equal(getResult.stepStatus['implement'], 'in_progress');
       // currentStep should be updated to 7 (index 6 + 1, after ticket/bootstrap/brief/brief_gate/spec/tasks)
-      // GH-215: brief_gate inserted between brief and spec shifts implement from index 5 to 6.
+      // GH-215: brief_gate shifts implement to index 6. GH-211: task_review after commit doesn't affect implement index.
       assert.equal(getResult.currentStep, 7);
     });
 
@@ -624,6 +625,126 @@ describe('work-state.js', () => {
       const stateFile = path.join(TEMP_TASKS_BASE, TICKET, `.work-state-${TICKET}-subtask-1.json`);
       const persisted = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
       assert.equal(persisted.status, 'completed');
+    });
+  });
+
+  // ─── Task Review Fix-Round Tracking (GH-211) ──────────────────────────────
+
+  describe('task review fix-round tracking (GH-211)', () => {
+    const TICKET = 'TEST-FIXROUND-001';
+    after(() => {
+      cleanupTempWorkState(TICKET);
+    });
+
+    it('getTaskReviewFixRounds returns 0 for a task without prior fix rounds', async () => {
+      // Initialize state with task tracking
+      await runWorkState(['init', TICKET]);
+      await runWorkState(['task-init', TICKET, '3']);
+
+      const { result, code } = await runWorkState(['task-review-fix-rounds', TICKET]);
+      assert.equal(code, 0);
+      assert.equal(result.fixRounds, 0);
+    });
+
+    it('incrementTaskReviewFixRounds increases count by 1 and persists', async () => {
+      const { result: incResult, code: incCode } = await runWorkState([
+        'task-review-fix-rounds-increment',
+        TICKET,
+      ]);
+      assert.equal(incCode, 0);
+      assert.equal(incResult.fixRounds, 1);
+
+      // Verify persistence
+      const { result: getResult } = await runWorkState(['task-review-fix-rounds', TICKET]);
+      assert.equal(getResult.fixRounds, 1);
+
+      // Increment again
+      const { result: incResult2 } = await runWorkState([
+        'task-review-fix-rounds-increment',
+        TICKET,
+      ]);
+      assert.equal(incResult2.fixRounds, 2);
+
+      // Verify persistence again
+      const { result: getResult2 } = await runWorkState(['task-review-fix-rounds', TICKET]);
+      assert.equal(getResult2.fixRounds, 2);
+    });
+
+    it('resetTaskReviewFixRounds resets count to 0 and persists', async () => {
+      // Currently at 2 from previous test
+      const { result: resetResult, code: resetCode } = await runWorkState([
+        'task-review-fix-rounds-reset',
+        TICKET,
+      ]);
+      assert.equal(resetCode, 0);
+      assert.equal(resetResult.fixRounds, 0);
+
+      // Verify persistence
+      const { result: getResult } = await runWorkState(['task-review-fix-rounds', TICKET]);
+      assert.equal(getResult.fixRounds, 0);
+    });
+
+    it('stores fixRounds in tasksMeta.tasks[N].taskReviewFixRounds', async () => {
+      // Increment once to set a value
+      await runWorkState(['task-review-fix-rounds-increment', TICKET]);
+
+      // Read raw state to verify field location
+      const { result: rawState } = await runWorkState(['get', TICKET]);
+      const currentIdx = rawState.tasksMeta.currentTaskIndex;
+      assert.equal(
+        rawState.tasksMeta.tasks[currentIdx].taskReviewFixRounds,
+        1,
+        'taskReviewFixRounds should be stored in tasksMeta.tasks[N]'
+      );
+    });
+
+    it('TASK_REVIEW_MAX_FIXES env var controls max rounds (default 2)', async () => {
+      // Reset and set to 1
+      await runWorkState(['task-review-fix-rounds-reset', TICKET]);
+      await runWorkState(['task-review-fix-rounds-increment', TICKET]);
+
+      // With default max (2), should not be at max yet
+      const { result: notMax } = await runWorkState(['task-review-fix-rounds', TICKET]);
+      assert.equal(notMax.fixRounds, 1);
+      assert.equal(notMax.maxFixRounds, 2);
+      assert.equal(notMax.maxReached, false);
+
+      // Increment to 2 — should be at max
+      await runWorkState(['task-review-fix-rounds-increment', TICKET]);
+      const { result: atMax } = await runWorkState(['task-review-fix-rounds', TICKET]);
+      assert.equal(atMax.fixRounds, 2);
+      assert.equal(atMax.maxReached, true);
+    });
+
+    it('TASK_REVIEW_MAX_FIXES env var overrides default', async () => {
+      // Reset to 1
+      await runWorkState(['task-review-fix-rounds-reset', TICKET]);
+      await runWorkState(['task-review-fix-rounds-increment', TICKET]);
+
+      // With TASK_REVIEW_MAX_FIXES=5, should not be at max
+      const { result } = await runWorkState(['task-review-fix-rounds', TICKET], {
+        env: { TASK_REVIEW_MAX_FIXES: '5' },
+      });
+      assert.equal(result.fixRounds, 1);
+      assert.equal(result.maxFixRounds, 5);
+      assert.equal(result.maxReached, false);
+    });
+
+    it('returns error when task tracking is not initialized', async () => {
+      const TICKET_NO_TASKS = 'TEST-FIXROUND-NOTASK';
+      try {
+        await runWorkState(['init', TICKET_NO_TASKS]);
+
+        const { code, stderr } = await runWorkState([
+          'task-review-fix-rounds',
+          TICKET_NO_TASKS,
+        ]);
+        assert.equal(code, 1);
+        const errResult = JSON.parse(stderr.trim());
+        assert.ok(errResult.error);
+      } finally {
+        cleanupTempWorkState(TICKET_NO_TASKS);
+      }
     });
   });
 });

--- a/workflows/work/__tests__/workflow-definition.test.js
+++ b/workflows/work/__tests__/workflow-definition.test.js
@@ -248,3 +248,85 @@ describe('workflow-definition: verify[STEPS.brief_gate]', () => {
     }
   });
 });
+
+// ─── GH-211 Task 6: task_review verify entry + softSteps ─────────────────────
+describe('workflow-definition: verify[STEPS.task_review]', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'workflow-def-taskreview-'));
+  const ticketId = 'GH-211';
+  const ticketDir = path.join(tmpRoot, ticketId);
+  fs.mkdirSync(ticketDir, { recursive: true });
+
+  const deps = {
+    TASKS_BASE: tmpRoot,
+    safeTicketPath: (id) => id,
+    resolveGitHead: () => 'ref: refs/heads/stub',
+  };
+  const { workflow: trWf } = createWorkflowDefinition(deps);
+
+  function getTaskReviewVerify() {
+    const entries = trWf.commandMap.filter(
+      (e) => e.step === STEPS.task_review && typeof e.verify === 'function'
+    );
+    return entries.length > 0 ? entries[0].verify : undefined;
+  }
+
+  after(() => {
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+
+  it('registers a verify function for STEPS.task_review on the commandMap', () => {
+    const verify = getTaskReviewVerify();
+    assert.equal(typeof verify, 'function', 'expected verify[STEPS.task_review] to be a function');
+  });
+
+  it('returns false when no review artifacts exist', () => {
+    const verify = getTaskReviewVerify();
+    assert.equal(verify(ticketId), false);
+  });
+
+  it('returns true when task-review-tests.md exists', () => {
+    fs.writeFileSync(path.join(ticketDir, 'task-review-tests.md'), '# Test Review\nAll good');
+    const verify = getTaskReviewVerify();
+    assert.equal(verify(ticketId), true);
+    fs.unlinkSync(path.join(ticketDir, 'task-review-tests.md'));
+  });
+
+  it('returns true when task-review-code.md exists', () => {
+    fs.writeFileSync(path.join(ticketDir, 'task-review-code.md'), '# Code Review\nAll good');
+    const verify = getTaskReviewVerify();
+    assert.equal(verify(ticketId), true);
+    fs.unlinkSync(path.join(ticketDir, 'task-review-code.md'));
+  });
+
+  it('returns true when both review artifacts exist', () => {
+    fs.writeFileSync(path.join(ticketDir, 'task-review-tests.md'), '# Test Review');
+    fs.writeFileSync(path.join(ticketDir, 'task-review-code.md'), '# Code Review');
+    const verify = getTaskReviewVerify();
+    assert.equal(verify(ticketId), true);
+    fs.unlinkSync(path.join(ticketDir, 'task-review-tests.md'));
+    fs.unlinkSync(path.join(ticketDir, 'task-review-code.md'));
+  });
+
+  it('returns false gracefully when tasksDir does not exist', () => {
+    const badDeps = {
+      TASKS_BASE: '/tmp/nonexistent-workflow-def-test',
+      safeTicketPath: (id) => id,
+      resolveGitHead: () => 'ref: refs/heads/stub',
+    };
+    const { workflow: badWf } = createWorkflowDefinition(badDeps);
+    const entries = badWf.commandMap.filter(
+      (e) => e.step === STEPS.task_review && typeof e.verify === 'function'
+    );
+    assert.equal(entries[0].verify('NONEXISTENT'), false);
+  });
+});
+
+describe('workflow-definition: softSteps includes task_review', () => {
+  it('has task_review in softSteps set', () => {
+    assert.ok(workflow.softSteps.has(STEPS.task_review), 'task_review should be in softSteps');
+  });
+});

--- a/workflows/work/cli.js
+++ b/workflows/work/cli.js
@@ -84,7 +84,7 @@ function main(deps) {
       const isGitHubPrefixed = /^GH-\d+$/i.test(raw) && isGitHubEffective;
       const isTicket = isJiraTicket || isGitHubIssue || isGitHubPrefixed;
       let ticket = isTicket ? raw.toUpperCase() : null;
-      if (isTicket && isGitHubEffective) {
+      if ((isGitHubIssue || isGitHubPrefixed) && isGitHubEffective) {
         const num = raw.replace(/^#|^GH-/i, '');
         ticket = '#' + num;
       }
@@ -202,10 +202,7 @@ function main(deps) {
         console.log(JSON.stringify({ error: true, message: e.message }));
         process.exit(1);
       }
-      const transBase =
-        transProviderCfg?.provider === 'github'
-          ? transParsed.ticketBase
-          : transParsed.ticketBase.toUpperCase();
+      const transBase = transParsed.ticketBase.toUpperCase();
       const safeTransTicket =
         tp.sanitizeTicketIdForPath(transBase, transProviderCfg) +
         (transParsed.suffix ? '/' + transParsed.suffix : '');
@@ -227,10 +224,7 @@ function main(deps) {
         console.log(JSON.stringify({ error: true, message: e.message }));
         process.exit(1);
       }
-      const transBase2 =
-        transitionsProviderCfg?.provider === 'github'
-          ? transParsed2.ticketBase
-          : transParsed2.ticketBase.toUpperCase();
+      const transBase2 = transParsed2.ticketBase.toUpperCase();
       const safeTransitionsTicket =
         tp.sanitizeTicketIdForPath(transBase2, transitionsProviderCfg) +
         (transParsed2.suffix ? '/' + transParsed2.suffix : '');
@@ -258,9 +252,7 @@ function main(deps) {
         process.exit(1);
       }
       const actionsBase =
-        actionsProviderCfg?.provider === 'github'
-          ? actionsParsed.ticketBase
-          : actionsParsed.ticketBase.toUpperCase();
+        actionsParsed.ticketBase.toUpperCase();
       const ticket =
         tp.sanitizeTicketIdForPath(actionsBase, actionsProviderCfg) +
         (actionsParsed.suffix ? '/' + actionsParsed.suffix : '');

--- a/workflows/work/cli.js
+++ b/workflows/work/cli.js
@@ -202,7 +202,7 @@ function main(deps) {
         console.log(JSON.stringify({ error: true, message: e.message }));
         process.exit(1);
       }
-      const transBase = transParsed.ticketBase.toUpperCase();
+      const transBase = String(transParsed.ticketBase).toUpperCase();
       const safeTransTicket =
         tp.sanitizeTicketIdForPath(transBase, transProviderCfg) +
         (transParsed.suffix ? '/' + transParsed.suffix : '');
@@ -224,7 +224,7 @@ function main(deps) {
         console.log(JSON.stringify({ error: true, message: e.message }));
         process.exit(1);
       }
-      const transBase2 = transParsed2.ticketBase.toUpperCase();
+      const transBase2 = String(transParsed2.ticketBase).toUpperCase();
       const safeTransitionsTicket =
         tp.sanitizeTicketIdForPath(transBase2, transitionsProviderCfg) +
         (transParsed2.suffix ? '/' + transParsed2.suffix : '');
@@ -251,8 +251,7 @@ function main(deps) {
         console.log(JSON.stringify({ error: true, message: e.message }));
         process.exit(1);
       }
-      const actionsBase =
-        actionsParsed.ticketBase.toUpperCase();
+      const actionsBase = String(actionsParsed.ticketBase).toUpperCase();
       const ticket =
         tp.sanitizeTicketIdForPath(actionsBase, actionsProviderCfg) +
         (actionsParsed.suffix ? '/' + actionsParsed.suffix : '');

--- a/workflows/work/step-registry.js
+++ b/workflows/work/step-registry.js
@@ -22,6 +22,8 @@ const STEPS = Object.freeze({
   tasks: 'tasks',
   implement: 'implement',
   commit: 'commit',
+  // GH-211: per-task review gate that blocks check until review passes.
+  task_review: 'task_review',
   check: 'check',
   pr: 'pr',
   ready: 'ready',
@@ -44,6 +46,7 @@ const STEP_ORDER = Object.freeze([
   STEPS.tasks,
   STEPS.implement,
   STEPS.commit,
+  STEPS.task_review, // GH-211: must sit between commit and check
   STEPS.check,
   STEPS.pr,
   STEPS.ready,
@@ -93,6 +96,7 @@ function canTransition(statusTransitions) {
 
 // Retry loops: backward edges for failure recovery
 const RETRY_EDGES = {
+  [STEPS.task_review]: [STEPS.implement], // GH-211: review failed, fix code
   [STEPS.check]: [STEPS.implement], // check failed, fix code
   [STEPS.follow_up]: [STEPS.implement], // follow-up requires code changes
   [STEPS.ci]: [STEPS.implement], // CI failed, fix code

--- a/workflows/work/steps/__tests__/step-modules.test.js
+++ b/workflows/work/steps/__tests__/step-modules.test.js
@@ -86,6 +86,7 @@ describe('step modules', () => {
       'tasks',
       'implement',
       'commit',
+      'task-review',
       'check',
       'task-advance',
       'pr',

--- a/workflows/work/steps/__tests__/task-review-step.test.js
+++ b/workflows/work/steps/__tests__/task-review-step.test.js
@@ -1,0 +1,355 @@
+/**
+ * Unit tests for the task-review step module (GH-211, Task 5).
+ *
+ * Covers the five decision paths:
+ *   1. SKIP when TASK_REVIEW_ENABLED=0
+ *   2. SKIP when no tasks (no hasTasks or no taskData)
+ *   3. SKIP when final task (current task is last)
+ *   4. RUN for intermediate task needing review
+ *   5. RUN with AskUserQuestion escalation when max fix rounds exhausted
+ *
+ * Also verifies registration in STEP_PIPELINE between commitStep and checkStep.
+ *
+ * Run: node --test workflows/work/steps/__tests__/task-review-step.test.js
+ */
+
+'use strict';
+
+const { describe, it, before, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { STEPS } = require('../../step-registry');
+
+// ─── Test doubles ────────────────────────────────────────────────────────────
+
+function makeCtx(overrides = {}) {
+  return {
+    STEPS,
+    ticket: 'TEST-100',
+    tasksDir: '/tmp/tasks/TEST-100',
+    path,
+    // Implement step sets these on ctx for downstream steps
+    _taskData: null,
+    _allTasksDone: false,
+    _currentTaskIdx: 0,
+    ...overrides,
+  };
+}
+
+function makeState(overrides = {}) {
+  return {
+    hasTasks: false,
+    workState: null,
+    ...overrides,
+  };
+}
+
+function makeAdd() {
+  const entries = [];
+  const add = (step, action, command, reason, extra) => {
+    entries.push({ step, action, command, reason, ...(extra || {}) });
+  };
+  return { add, entries };
+}
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
+describe('task-review step', () => {
+  let taskReviewStep;
+  const savedEnv = {};
+
+  before(() => {
+    taskReviewStep = require(path.join(__dirname, '..', 'task-review.js'));
+  });
+
+  beforeEach(() => {
+    savedEnv.TASK_REVIEW_ENABLED = process.env.TASK_REVIEW_ENABLED;
+    savedEnv.TASK_REVIEW_MAX_FIXES = process.env.TASK_REVIEW_MAX_FIXES;
+    delete process.env.TASK_REVIEW_ENABLED;
+    delete process.env.TASK_REVIEW_MAX_FIXES;
+  });
+
+  afterEach(() => {
+    if (savedEnv.TASK_REVIEW_ENABLED === undefined) delete process.env.TASK_REVIEW_ENABLED;
+    else process.env.TASK_REVIEW_ENABLED = savedEnv.TASK_REVIEW_ENABLED;
+    if (savedEnv.TASK_REVIEW_MAX_FIXES === undefined) delete process.env.TASK_REVIEW_MAX_FIXES;
+    else process.env.TASK_REVIEW_MAX_FIXES = savedEnv.TASK_REVIEW_MAX_FIXES;
+  });
+
+  it('exports a function', () => {
+    assert.equal(typeof taskReviewStep, 'function');
+  });
+
+  // ─── Decision 1: SKIP when disabled ────────────────────────────────────────
+
+  it('SKIPs when TASK_REVIEW_ENABLED=0', () => {
+    process.env.TASK_REVIEW_ENABLED = '0';
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: { tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task-1' }, { id: 'task-2' }] } },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /disabled/i);
+  });
+
+  // ─── Decision 2: SKIP when no tasks ────────────────────────────────────────
+
+  it('SKIPs when no tasks (hasTasks=false)', () => {
+    const { add, entries } = makeAdd();
+    const s = makeState({ hasTasks: false });
+    const ctx = makeCtx();
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /no tasks/i);
+  });
+
+  it('SKIPs when no tasksMeta in workState', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [{ num: 1, title: 'Task A', isCheckpoint: false }];
+    const s = makeState({ hasTasks: true, workState: {} });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /no tasks/i);
+  });
+
+  it('SKIPs when _taskData is null', () => {
+    const { add, entries } = makeAdd();
+    const s = makeState({
+      hasTasks: true,
+      workState: { tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task-1' }] } },
+    });
+    const ctx = makeCtx({ _taskData: null });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /no tasks/i);
+  });
+
+  // ─── Decision 3: SKIP when final task ──────────────────────────────────────
+
+  it('SKIPs when current task is the last task', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 1,
+          tasks: [{ id: 'task-1' }, { id: 'task-2' }],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 1 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /final task/i);
+  });
+
+  it('SKIPs when single task (always the final task)', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [{ num: 1, title: 'Only task', isCheckpoint: false }];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [{ id: 'task-1' }],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'SKIP');
+    assert.match(entries[0].reason, /final task/i);
+  });
+
+  // ─── Decision 4: RUN for intermediate task ────────────────────────────────
+
+  it('RUNs for intermediate task needing review', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+      { num: 3, title: 'Task C', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 0 },
+            { id: 'task-2' },
+            { id: 'task-3' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.task_review);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(typeof entry.agentType, 'string');
+    assert.equal(typeof entry.agentPrompt, 'string');
+    // Should reference both tests-review and code-review
+    assert.match(entry.agentPrompt, /tests-review|code-review/i);
+  });
+
+  it('RUN entry includes task info in reason', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 0 },
+            { id: 'task-2' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    // Reason should mention task number or title
+    assert.match(entries[0].reason, /task/i);
+  });
+
+  // ─── Decision 5: Escalation when max rounds exhausted ─────────────────────
+
+  it('RUNs with AskUserQuestion escalation when max fix rounds exhausted', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 2 },
+            { id: 'task-2' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.task_review);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.command, 'AskUserQuestion');
+    assert.match(entry.reason, /fix rounds|max.*exhaust|escalat/i);
+  });
+
+  it('respects TASK_REVIEW_MAX_FIXES env var for escalation threshold', () => {
+    process.env.TASK_REVIEW_MAX_FIXES = '1';
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 1 },
+            { id: 'task-2' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].command, 'AskUserQuestion');
+  });
+
+  it('does NOT escalate when fix rounds below max', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 1 },
+            { id: 'task-2' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    // Default max is 2, fix rounds is 1, so should NOT escalate
+    assert.notEqual(entries[0].command, 'AskUserQuestion');
+  });
+
+  // ─── STEP_PIPELINE registration ────────────────────────────────────────────
+
+  describe('STEP_PIPELINE registration', () => {
+    it('taskReviewStep is in STEP_PIPELINE between commitStep and checkStep', () => {
+      const barrel = require(path.join(__dirname, '..', 'index.js'));
+      const commitStep = require(path.join(__dirname, '..', 'commit.js'));
+      const checkStep = require(path.join(__dirname, '..', 'check.js'));
+      const taskReview = require(path.join(__dirname, '..', 'task-review.js'));
+
+      assert.ok(Array.isArray(barrel.STEP_PIPELINE), 'STEP_PIPELINE should be an array');
+
+      const commitIdx = barrel.STEP_PIPELINE.indexOf(commitStep);
+      const reviewIdx = barrel.STEP_PIPELINE.indexOf(taskReview);
+      const checkIdx = barrel.STEP_PIPELINE.indexOf(checkStep);
+
+      assert.ok(commitIdx >= 0, 'commitStep must be in STEP_PIPELINE');
+      assert.ok(reviewIdx >= 0, 'taskReviewStep must be in STEP_PIPELINE');
+      assert.ok(checkIdx >= 0, 'checkStep must be in STEP_PIPELINE');
+      assert.equal(reviewIdx, commitIdx + 1, 'taskReviewStep must come directly after commitStep');
+      assert.equal(checkIdx, reviewIdx + 1, 'checkStep must come directly after taskReviewStep');
+    });
+
+    it('exports taskReviewStep as a named export', () => {
+      const barrel = require(path.join(__dirname, '..', 'index.js'));
+      assert.equal(typeof barrel.taskReviewStep, 'function', 'steps/index.js should export taskReviewStep');
+    });
+  });
+});

--- a/workflows/work/steps/index.js
+++ b/workflows/work/steps/index.js
@@ -15,6 +15,7 @@ const specStep = require('./spec');
 const tasksStep = require('./tasks');
 const implementStep = require('./implement');
 const commitStep = require('./commit');
+const taskReviewStep = require('./task-review');
 const checkStep = require('./check');
 const taskAdvanceStep = require('./task-advance');
 const prStep = require('./pr');
@@ -42,6 +43,7 @@ const STEP_PIPELINE = [
   tasksStep,
   implementStep,
   commitStep,
+  taskReviewStep,
   checkStep,
   taskAdvanceStep,
   prStep,
@@ -61,4 +63,9 @@ module.exports = {
   // and before specStep to block the brief → spec transition on unresolved
   // cross-ticket / architectural open questions.
   briefGateStep,
+  // GH-211 Task 5.2: export taskReviewStep as a named handle so external
+  // consumers (and tests) can reference the per-task review gate without
+  // knowing its position in STEP_PIPELINE. The gate runs between commitStep
+  // and checkStep to block check until intermediate task review passes.
+  taskReviewStep,
 };

--- a/workflows/work/steps/task-advance.js
+++ b/workflows/work/steps/task-advance.js
@@ -1,7 +1,12 @@
 /**
  * Step: task-advance (pseudo-step)
- * Augments the check plan entry with task-advance metadata when more tasks remain.
- * Does not add its own plan entry — it mutates the check entry.
+ * Augments the check and task_review plan entries with task-advance metadata
+ * when more tasks remain. Does not add its own plan entry — it mutates
+ * existing entries.
+ *
+ * GH-211: Also mutates the task_review plan entry and calls
+ * resetTaskReviewFixRounds to reset fix-round counter for the next task.
+ *
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx
@@ -14,16 +19,30 @@ module.exports = function taskAdvanceStep(add, s, ctx) {
 
   if (!taskData || !plan) return;
 
+  // GH-211: Reset fix-round counter whenever task-advance runs (new task boundary)
+  if (!allTasksDone && typeof ctx._resetTaskReviewFixRounds === 'function') {
+    ctx._resetTaskReviewFixRounds(ctx._ticketId);
+  }
+
   // Signal to the agent that more tasks remain after check passes
   if (!allTasksDone && currentTaskIdx < taskData.length - 1) {
+    const taskInfo = {
+      current: currentTaskIdx + 1,
+      total: taskData.length,
+      nextTask: taskData[currentTaskIdx + 1]?.title || 'unknown',
+    };
+
     const checkEntry = plan.find((p) => p.step === STEPS.check);
     if (checkEntry) {
       checkEntry.nextAction = 'advance_task';
-      checkEntry.taskInfo = {
-        current: currentTaskIdx + 1,
-        total: taskData.length,
-        nextTask: taskData[currentTaskIdx + 1]?.title || 'unknown',
-      };
+      checkEntry.taskInfo = taskInfo;
+    }
+
+    // GH-211: Also mutate task_review entry for non-final tasks
+    const taskReviewEntry = plan.find((p) => p.step === STEPS.task_review);
+    if (taskReviewEntry) {
+      taskReviewEntry.nextAction = 'advance_task';
+      taskReviewEntry.taskInfo = taskInfo;
     }
   }
 

--- a/workflows/work/steps/task-advance.js
+++ b/workflows/work/steps/task-advance.js
@@ -19,7 +19,10 @@ module.exports = function taskAdvanceStep(add, s, ctx) {
 
   if (!taskData || !plan) return;
 
-  // GH-211: Reset fix-round counter whenever task-advance runs (new task boundary)
+  // GH-211: Reset fix-round counter whenever task-advance runs (new task boundary).
+  // ctx._ticketId and ctx._resetTaskReviewFixRounds are injected by the orchestrator
+  // at runtime (see work-state.js resetTaskReviewFixRounds). The typeof guard ensures
+  // graceful no-op when running during plan-generation where these are not wired.
   if (!allTasksDone && typeof ctx._resetTaskReviewFixRounds === 'function') {
     ctx._resetTaskReviewFixRounds(ctx._ticketId);
   }

--- a/workflows/work/steps/task-advance.js
+++ b/workflows/work/steps/task-advance.js
@@ -19,13 +19,10 @@ module.exports = function taskAdvanceStep(add, s, ctx) {
 
   if (!taskData || !plan) return;
 
-  // GH-211: Reset fix-round counter whenever task-advance runs (new task boundary).
-  // ctx._ticketId and ctx._resetTaskReviewFixRounds are injected by the orchestrator
-  // at runtime (see work-state.js resetTaskReviewFixRounds). The typeof guard ensures
-  // graceful no-op when running during plan-generation where these are not wired.
-  if (!allTasksDone && typeof ctx._resetTaskReviewFixRounds === 'function') {
-    ctx._resetTaskReviewFixRounds(ctx._ticketId);
-  }
+  // GH-211: Fix-round counter reset is handled by work-state.js advanceTask()
+  // directly (see line ~605), which is invoked by the `work-state task-advance`
+  // CLI command during actual task advancement. This step module only mutates
+  // the plan entries; it does NOT perform state mutations during plan generation.
 
   // Signal to the agent that more tasks remain after check passes
   if (!allTasksDone && currentTaskIdx < taskData.length - 1) {

--- a/workflows/work/steps/task-review.js
+++ b/workflows/work/steps/task-review.js
@@ -1,0 +1,87 @@
+/**
+ * Step: task-review (GH-211)
+ *
+ * Per-task review gate that blocks the check step until an intermediate
+ * task's code has been reviewed. Runs between `commit` and `check` in the
+ * pipeline and uses task metadata set by the upstream `implement` step
+ * (via `ctx._taskData`, `ctx._currentTaskIdx`).
+ *
+ * Decision matrix:
+ *   1. `TASK_REVIEW_ENABLED=0`               -> SKIP "Task review disabled"
+ *   2. No tasks (no taskData or no tasksMeta) -> SKIP "No tasks"
+ *   3. Final task (current == last)           -> SKIP "Final task -- /check handles review"
+ *   4. Fix rounds exhausted (>= max)          -> RUN  AskUserQuestion escalation
+ *   5. Intermediate task needing review       -> RUN  parallel /tests-review + /code-review
+ */
+
+'use strict';
+
+/**
+ * @param {Function} add
+ * @param {object} s
+ * @param {object} ctx
+ */
+function taskReviewStep(add, s, ctx) {
+  const { STEPS } = ctx;
+
+  // Decision 1: disabled via env
+  if (process.env.TASK_REVIEW_ENABLED === '0') {
+    add(STEPS.task_review, 'SKIP', null, 'Task review disabled (TASK_REVIEW_ENABLED=0)');
+    return;
+  }
+
+  // Gather task metadata from implement step and state
+  const taskData = ctx._taskData;
+  const tasksMeta = s?.workState?.tasksMeta;
+
+  // Decision 2: no tasks
+  if (!s?.hasTasks || !taskData || !tasksMeta) {
+    add(STEPS.task_review, 'SKIP', null, 'No tasks');
+    return;
+  }
+
+  const currentIdx = ctx._currentTaskIdx ?? 0;
+  const totalTasks = taskData.length;
+
+  // Decision 3: final task -- /check handles the full review
+  if (currentIdx >= totalTasks - 1) {
+    add(STEPS.task_review, 'SKIP', null, 'Final task -- /check handles review');
+    return;
+  }
+
+  // Read fix-round state from tasksMeta
+  const currentTaskMeta = tasksMeta.tasks?.[currentIdx];
+  const fixRounds = currentTaskMeta?.taskReviewFixRounds || 0;
+  const maxFixRounds = parseInt(process.env.TASK_REVIEW_MAX_FIXES, 10) || 2;
+
+  // Decision 4: fix rounds exhausted -- escalate to user
+  if (fixRounds >= maxFixRounds) {
+    add(
+      STEPS.task_review,
+      'RUN',
+      'AskUserQuestion',
+      `Task ${currentIdx + 1}/${totalTasks} fix rounds exhausted (${fixRounds}/${maxFixRounds}) -- escalating to user`,
+      {
+        agentType: 'general-purpose',
+        agentPrompt: `Task ${currentIdx + 1} has exhausted ${fixRounds}/${maxFixRounds} fix rounds. Use AskUserQuestion to ask the user whether to continue fixing, skip the review, or abort.`,
+      }
+    );
+    return;
+  }
+
+  // Decision 5: intermediate task -- run parallel tests-review + code-review
+  const currentTask = taskData[currentIdx];
+  add(
+    STEPS.task_review,
+    'RUN',
+    '/task-review',
+    `Task ${currentIdx + 1}/${totalTasks}: review "${currentTask?.title || 'unknown'}" before advancing`,
+    {
+      agentType: 'parallel',
+      agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${currentTask?.title || 'unknown'}"). Aggregate results and fail the gate if either review fails.`,
+    }
+  );
+}
+
+module.exports = taskReviewStep;
+module.exports.taskReviewStep = taskReviewStep;

--- a/workflows/work/steps/task-review.js
+++ b/workflows/work/steps/task-review.js
@@ -18,8 +18,6 @@
 
 const path = require('path');
 const { appendAction } = require(path.join(__dirname, '..', 'work-actions'));
-const { computeTaskDiff } = require('../task-review-gate');
-
 /**
  * @param {Function} add
  * @param {object} s
@@ -56,7 +54,8 @@ module.exports = function taskReviewStep(add, s, ctx) {
   // Read fix-round state from tasksMeta
   const currentTaskMeta = tasksMeta.tasks?.[currentIdx];
   const fixRounds = currentTaskMeta?.taskReviewFixRounds || 0;
-  const maxFixRounds = parseInt(process.env.TASK_REVIEW_MAX_FIXES, 10) || 2;
+  const parsed = parseInt(process.env.TASK_REVIEW_MAX_FIXES, 10);
+  const maxFixRounds = Number.isFinite(parsed) && parsed >= 0 ? parsed : 2;
 
   // Decision 4: fix rounds exhausted -- escalate to user
   if (fixRounds >= maxFixRounds) {
@@ -82,7 +81,7 @@ module.exports = function taskReviewStep(add, s, ctx) {
   add(
     STEPS.task_review,
     'RUN',
-    '/task-review',
+    'Skill(tests-review) + Skill(code-review)',
     `Task ${currentIdx + 1}/${totalTasks}: review "${currentTask?.title || 'unknown'}" before advancing`,
     {
       agentType: 'parallel',

--- a/workflows/work/steps/task-review.js
+++ b/workflows/work/steps/task-review.js
@@ -18,13 +18,14 @@
 
 const path = require('path');
 const { appendAction } = require(path.join(__dirname, '..', 'work-actions'));
+const { computeTaskDiff } = require('../task-review-gate');
 
 /**
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx
  */
-function taskReviewStep(add, s, ctx) {
+module.exports = function taskReviewStep(add, s, ctx) {
   const { STEPS } = ctx;
 
   // Decision 1: disabled via env
@@ -94,5 +95,4 @@ function taskReviewStep(add, s, ctx) {
   });
 }
 
-module.exports = taskReviewStep;
-module.exports.taskReviewStep = taskReviewStep;
+module.exports.taskReviewStep = module.exports;

--- a/workflows/work/steps/task-review.js
+++ b/workflows/work/steps/task-review.js
@@ -16,6 +16,9 @@
 
 'use strict';
 
+const path = require('path');
+const { appendAction } = require(path.join(__dirname, '..', 'work-actions'));
+
 /**
  * @param {Function} add
  * @param {object} s
@@ -66,6 +69,10 @@ function taskReviewStep(add, s, ctx) {
         agentPrompt: `Task ${currentIdx + 1} has exhausted ${fixRounds}/${maxFixRounds} fix rounds. Use AskUserQuestion to ask the user whether to continue fixing, skip the review, or abort.`,
       }
     );
+    appendAction(ctx.ticket, {
+      step: STEPS.task_review,
+      what: `task ${currentIdx + 1}/${totalTasks} fix rounds exhausted (${fixRounds}/${maxFixRounds}) -- escalating`,
+    });
     return;
   }
 
@@ -81,6 +88,10 @@ function taskReviewStep(add, s, ctx) {
       agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${currentTask?.title || 'unknown'}"). Aggregate results and fail the gate if either review fails.`,
     }
   );
+  appendAction(ctx.ticket, {
+    step: STEPS.task_review,
+    what: `task ${currentIdx + 1}/${totalTasks} review scheduled for "${currentTask?.title || 'unknown'}"`,
+  });
 }
 
 module.exports = taskReviewStep;

--- a/workflows/work/steps/task-review.js
+++ b/workflows/work/steps/task-review.js
@@ -87,10 +87,10 @@ module.exports = function taskReviewStep(add, s, ctx) {
   // validates, falls back to base branch on missing/invalid SHA). The range is
   // passed to the orchestrator in plan-entry metadata so /tests-review and
   // /code-review receive the task-specific diff, not the full branch diff.
-  const tasksDir = path.join(ctx.tasksBase || '', ctx.ticket || '');
+  // ctx.tasksDir is injected by plan-generator.js (see plan-generator.js line 129).
   let diffRange;
   try {
-    diffRange = computeTaskDiff(tasksDir, ctx.ticket);
+    diffRange = computeTaskDiff(ctx.tasksDir, ctx.ticket);
   } catch (_e) {
     diffRange = null;
   }

--- a/workflows/work/steps/task-review.js
+++ b/workflows/work/steps/task-review.js
@@ -18,6 +18,8 @@
 
 const path = require('path');
 const { appendAction } = require(path.join(__dirname, '..', 'work-actions'));
+const { computeTaskDiff } = require('../task-review-gate');
+
 /**
  * @param {Function} add
  * @param {object} s
@@ -81,6 +83,17 @@ module.exports = function taskReviewStep(add, s, ctx) {
 
   // Decision 5: intermediate task -- run parallel tests-review + code-review
   const currentTask = taskData[currentIdx];
+  // Compute task-scoped diff range via computeTaskDiff (reads .last-commit-sha,
+  // validates, falls back to base branch on missing/invalid SHA). The range is
+  // passed to the orchestrator in plan-entry metadata so /tests-review and
+  // /code-review receive the task-specific diff, not the full branch diff.
+  const tasksDir = path.join(ctx.tasksBase || '', ctx.ticket || '');
+  let diffRange;
+  try {
+    diffRange = computeTaskDiff(tasksDir, ctx.ticket);
+  } catch (_e) {
+    diffRange = null;
+  }
   add(
     STEPS.task_review,
     'RUN',
@@ -88,7 +101,8 @@ module.exports = function taskReviewStep(add, s, ctx) {
     `Task ${currentIdx + 1}/${totalTasks}: review "${currentTask?.title || 'unknown'}" before advancing`,
     {
       agentType: 'skill',
-      agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${currentTask?.title || 'unknown'}"). Scope both reviews to the current task diff (from .last-commit-sha to HEAD). Aggregate results and fail the gate if either review fails.`,
+      agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${currentTask?.title || 'unknown'}"). Scope both reviews to the task diff range${diffRange ? ` (base=${diffRange.base}, head=${diffRange.head})` : ' (computed from .last-commit-sha)'}. Aggregate results and fail the gate if either review fails.`,
+      diffRange,
     }
   );
   appendAction(ctx.ticket, {

--- a/workflows/work/steps/task-review.js
+++ b/workflows/work/steps/task-review.js
@@ -51,7 +51,10 @@ module.exports = function taskReviewStep(add, s, ctx) {
     return;
   }
 
-  // Read fix-round state from tasksMeta
+  // Read fix-round state from tasksMeta.
+  // Note: taskReviewFixRounds is incremented by the orchestrator when it loops back
+  // to implement after a failed review (see work-state.js incrementTaskReviewFixRounds).
+  // This step only reads the counter to decide whether to escalate.
   const currentTaskMeta = tasksMeta.tasks?.[currentIdx];
   const fixRounds = currentTaskMeta?.taskReviewFixRounds || 0;
   const parsed = parseInt(process.env.TASK_REVIEW_MAX_FIXES, 10);
@@ -84,8 +87,8 @@ module.exports = function taskReviewStep(add, s, ctx) {
     'Skill(tests-review) + Skill(code-review)',
     `Task ${currentIdx + 1}/${totalTasks}: review "${currentTask?.title || 'unknown'}" before advancing`,
     {
-      agentType: 'parallel',
-      agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${currentTask?.title || 'unknown'}"). Aggregate results and fail the gate if either review fails.`,
+      agentType: 'skill',
+      agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${currentTask?.title || 'unknown'}"). Scope both reviews to the current task diff (from .last-commit-sha to HEAD). Aggregate results and fail the gate if either review fails.`,
     }
   );
   appendAction(ctx.ticket, {

--- a/workflows/work/task-review-gate.js
+++ b/workflows/work/task-review-gate.js
@@ -1,0 +1,157 @@
+/**
+ * task-review-gate.js — Diff computation and review orchestration for per-task reviews (GH-211)
+ *
+ * Provides two main functions:
+ *   - computeTaskDiff:    Determine the git diff range for a task's review
+ *   - executeTaskReview:  Orchestrate tests + code review and aggregate results
+ *
+ * Follows the gate pattern from check-gate.js (array of rules returning reasons).
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const config = require(path.join(__dirname, '..', 'lib', 'config'));
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const SHA_REGEX = /^[0-9a-f]{40}$/i;
+const LAST_COMMIT_SHA_FILE = '.last-commit-sha';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Read a file safely, returning empty string on failure.
+ * @param {string} filePath
+ * @returns {string}
+ */
+function readFileSafe(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Check if a SHA is an ancestor of HEAD using git merge-base --is-ancestor.
+ * Uses dynamic require to allow test mocking of child_process.execFileSync.
+ * @param {string} sha - The commit SHA to check
+ * @returns {boolean}
+ */
+function isAncestorOfHead(sha) {
+  try {
+    require('child_process').execFileSync('git', ['merge-base', '--is-ancestor', sha, 'HEAD'], {
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ─── computeTaskDiff ────────────────────────────────────────────────────────
+
+/**
+ * Compute the diff range for reviewing a task's changes.
+ *
+ * Reads `.last-commit-sha` from tasksDir, validates it as a 40-char hex SHA
+ * that is an ancestor of HEAD. Falls back to the configured base branch
+ * (e.g., origin/main) when the SHA is missing, invalid, or not an ancestor.
+ *
+ * @param {string} tasksDir - Path to the ticket's tasks directory
+ * @param {string} ticketId - Ticket identifier (for logging)
+ * @returns {{ base: string, head: string, fallback?: boolean }}
+ */
+function computeTaskDiff(tasksDir, ticketId) {
+  const shaFile = path.join(tasksDir, LAST_COMMIT_SHA_FILE);
+  const rawContent = readFileSafe(shaFile).trim();
+
+  // Validate SHA format
+  if (rawContent && SHA_REGEX.test(rawContent)) {
+    // Validate SHA is an ancestor of HEAD
+    if (isAncestorOfHead(rawContent)) {
+      return { base: rawContent, head: 'HEAD' };
+    }
+    process.stderr.write(
+      `task-review-gate: SHA ${rawContent.slice(0, 8)}... is not an ancestor of HEAD for ${ticketId}, falling back to base branch\n`
+    );
+  } else if (rawContent) {
+    process.stderr.write(
+      `task-review-gate: Invalid SHA format in ${LAST_COMMIT_SHA_FILE} for ${ticketId}, falling back to base branch\n`
+    );
+  } else {
+    process.stderr.write(
+      `task-review-gate: No ${LAST_COMMIT_SHA_FILE} found for ${ticketId}, falling back to base branch\n`
+    );
+  }
+
+  // Fallback to base branch
+  const baseBranch = config.getBaseBranch();
+  return { base: baseBranch, head: 'HEAD', fallback: true };
+}
+
+// ─── executeTaskReview ──────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} ReviewResult
+ * @property {boolean} passed
+ * @property {string} summary
+ */
+
+/**
+ * @typedef {Object} ReviewDeps
+ * @property {() => ReviewResult} runTestsReview - Execute tests review
+ * @property {() => ReviewResult} runCodeReview  - Execute code review
+ */
+
+/**
+ * Orchestrate task review by running tests review and code review,
+ * then aggregating results.
+ *
+ * @param {string} tasksDir   - Path to the ticket's tasks directory
+ * @param {string} ticketId   - Ticket identifier
+ * @param {ReviewDeps} deps   - Injected review functions
+ * @returns {{ passed: boolean, testsResult: ReviewResult, codeResult: ReviewResult, reasons: string[] }}
+ */
+function executeTaskReview(tasksDir, ticketId, deps) {
+  const testsResult = deps.runTestsReview();
+  const codeResult = deps.runCodeReview();
+
+  const reasons = [];
+
+  if (!testsResult.passed) {
+    reasons.push(`Task tests review failed: ${testsResult.summary}`);
+  }
+  if (!codeResult.passed) {
+    reasons.push(`Task code review failed: ${codeResult.summary}`);
+  }
+
+  // Write review artifacts
+  const testsArtifactPath = path.join(tasksDir, 'task-review-tests.md');
+  const codeArtifactPath = path.join(tasksDir, 'task-review-code.md');
+
+  fs.mkdirSync(tasksDir, { recursive: true });
+
+  fs.writeFileSync(
+    testsArtifactPath,
+    `# Task Tests Review — ${ticketId}\n\nStatus: ${testsResult.passed ? 'PASSED' : 'FAILED'}\n\n${testsResult.summary}\n`
+  );
+  fs.writeFileSync(
+    codeArtifactPath,
+    `# Task Code Review — ${ticketId}\n\nStatus: ${codeResult.passed ? 'PASSED' : 'FAILED'}\n\n${codeResult.summary}\n`
+  );
+
+  return {
+    passed: reasons.length === 0,
+    testsResult,
+    codeResult,
+    reasons,
+  };
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+module.exports = { computeTaskDiff, executeTaskReview };

--- a/workflows/work/task-review-gate.js
+++ b/workflows/work/task-review-gate.js
@@ -13,6 +13,7 @@
 const path = require('path');
 const fs = require('fs');
 const config = require(path.join(__dirname, '..', 'lib', 'config'));
+const { appendAction } = require(path.join(__dirname, 'work-actions'));
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -144,12 +145,22 @@ function executeTaskReview(tasksDir, ticketId, deps) {
     `# Task Code Review — ${ticketId}\n\nStatus: ${codeResult.passed ? 'PASSED' : 'FAILED'}\n\n${codeResult.summary}\n`
   );
 
-  return {
+  const result = {
     passed: reasons.length === 0,
     testsResult,
     codeResult,
     reasons,
   };
+
+  // Audit trail: log task review outcome
+  appendAction(ticketId, {
+    step: 'task_review',
+    what: result.passed
+      ? 'task review passed (tests + code)'
+      : `task review failed: ${reasons.join('; ')}`,
+  });
+
+  return result;
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────────

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -639,7 +639,8 @@ function getTaskReviewFixRounds(ticketId) {
   if (idx >= meta.tasks.length) return { error: 'All tasks completed, no current task' };
 
   const fixRounds = meta.tasks[idx].taskReviewFixRounds || 0;
-  const maxFixRounds = parseInt(process.env.TASK_REVIEW_MAX_FIXES, 10) || 2;
+  const parsed = parseInt(process.env.TASK_REVIEW_MAX_FIXES, 10);
+  const maxFixRounds = Number.isFinite(parsed) && parsed >= 0 ? parsed : 2;
 
   return {
     fixRounds,

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -642,6 +642,7 @@ function getTaskReviewFixRounds(ticketId) {
   const parsed = parseInt(process.env.TASK_REVIEW_MAX_FIXES, 10);
   const maxFixRounds = Number.isFinite(parsed) && parsed >= 0 ? parsed : 2;
 
+  // Task review fix-round status — consumed by task-review step for escalation decisions
   return {
     fixRounds,
     maxFixRounds,

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -645,7 +645,7 @@ function getTaskReviewFixRounds(ticketId) {
   return {
     fixRounds,
     maxFixRounds,
-    maxReached: fixRounds >= maxFixRounds,
+    maxReached: fixRounds >= maxFixRounds, // true when no more fix attempts allowed
     taskIndex: idx,
     taskId: meta.tasks[idx].id,
   };

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -600,6 +600,11 @@ function advanceTask(ticketId) {
   // Advance pointer
   meta.currentTaskIndex = idx + 1;
 
+  // GH-211: Reset fix-round counter on the NEW task so each task starts fresh
+  if (meta.currentTaskIndex < meta.tasks.length) {
+    meta.tasks[meta.currentTaskIndex].taskReviewFixRounds = 0;
+  }
+
   saveState(ticketId, state);
 
   if (meta.currentTaskIndex >= meta.tasks.length) {

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -618,6 +618,78 @@ function advanceTask(ticketId) {
   };
 }
 
+// ─── Task Review Fix-Round Tracking (GH-211) ────────────────────────────────
+
+/**
+ * Get the current fix-round count for the current task.
+ * Returns 0 when the field is absent (new task).
+ * Also returns maxFixRounds and whether max is reached.
+ */
+function getTaskReviewFixRounds(ticketId) {
+  const state = loadState(ticketId);
+  if (!state?.tasksMeta) return { error: 'No task tracking initialized' };
+
+  const meta = state.tasksMeta;
+  const idx = meta.currentTaskIndex;
+  if (idx >= meta.tasks.length) return { error: 'All tasks completed, no current task' };
+
+  const fixRounds = meta.tasks[idx].taskReviewFixRounds || 0;
+  const maxFixRounds = parseInt(process.env.TASK_REVIEW_MAX_FIXES, 10) || 2;
+
+  return {
+    fixRounds,
+    maxFixRounds,
+    maxReached: fixRounds >= maxFixRounds,
+    taskIndex: idx,
+    taskId: meta.tasks[idx].id,
+  };
+}
+
+/**
+ * Increment the fix-round counter for the current task by 1 and persist.
+ */
+function incrementTaskReviewFixRounds(ticketId) {
+  const state = loadState(ticketId);
+  if (!state?.tasksMeta) return { error: 'No task tracking initialized' };
+
+  const meta = state.tasksMeta;
+  const idx = meta.currentTaskIndex;
+  if (idx >= meta.tasks.length) return { error: 'All tasks completed, no current task' };
+
+  const current = meta.tasks[idx].taskReviewFixRounds || 0;
+  meta.tasks[idx].taskReviewFixRounds = current + 1;
+
+  saveState(ticketId, state);
+
+  return {
+    fixRounds: meta.tasks[idx].taskReviewFixRounds,
+    taskIndex: idx,
+    taskId: meta.tasks[idx].id,
+  };
+}
+
+/**
+ * Reset the fix-round counter for the current task to 0 and persist.
+ */
+function resetTaskReviewFixRounds(ticketId) {
+  const state = loadState(ticketId);
+  if (!state?.tasksMeta) return { error: 'No task tracking initialized' };
+
+  const meta = state.tasksMeta;
+  const idx = meta.currentTaskIndex;
+  if (idx >= meta.tasks.length) return { error: 'All tasks completed, no current task' };
+
+  meta.tasks[idx].taskReviewFixRounds = 0;
+
+  saveState(ticketId, state);
+
+  return {
+    fixRounds: 0,
+    taskIndex: idx,
+    taskId: meta.tasks[idx].id,
+  };
+}
+
 /**
  * Get a specific task by index.
  */
@@ -649,7 +721,7 @@ async function main() {
   if (!command) {
     console.error('Usage: node work-state.js <command> <ticket-id> [args...]');
     console.error(
-      'Commands: init, get, set-step, set-check, add-error, complete, resume-info, init-subtask, complete-subtask, active-subtask, task-init, task-current, task-advance, task-get'
+      'Commands: init, get, set-step, set-check, add-error, complete, resume-info, init-subtask, complete-subtask, active-subtask, task-init, task-current, task-advance, task-get, task-review-fix-rounds, task-review-fix-rounds-increment, task-review-fix-rounds-reset'
     );
     process.exit(1);
   }
@@ -755,6 +827,33 @@ async function main() {
       console.log(JSON.stringify(result, null, 2));
       break;
 
+    case 'task-review-fix-rounds':
+      result = getTaskReviewFixRounds(ticketId);
+      if (result && result.error) {
+        console.error(JSON.stringify(result));
+        process.exit(1);
+      }
+      console.log(JSON.stringify(result, null, 2));
+      break;
+
+    case 'task-review-fix-rounds-increment':
+      result = incrementTaskReviewFixRounds(ticketId);
+      if (result && result.error) {
+        console.error(JSON.stringify(result));
+        process.exit(1);
+      }
+      console.log(JSON.stringify(result, null, 2));
+      break;
+
+    case 'task-review-fix-rounds-reset':
+      result = resetTaskReviewFixRounds(ticketId);
+      if (result && result.error) {
+        console.error(JSON.stringify(result));
+        process.exit(1);
+      }
+      console.log(JSON.stringify(result, null, 2));
+      break;
+
     default:
       console.error(`Unknown command: ${command}`);
       process.exit(1);
@@ -791,6 +890,9 @@ module.exports = {
   getTaskCurrent,
   advanceTask,
   getTaskByIndex,
+  getTaskReviewFixRounds,
+  incrementTaskReviewFixRounds,
+  resetTaskReviewFixRounds,
   STEPS,
   SUBTASK_STEPS,
   CHECK_AGENTS,

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -119,6 +119,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
     softSteps: new Set([
       STEPS.ticket, // optional/metadata step
       STEPS.ready,
+      STEPS.task_review, // GH-211: advisory per-task review gate (soft — does not block)
       STEPS.reports, // operational steps -- no code changes to enforce
       STEPS.complete, // GH-106: terminal step -- all gates already passed at ci/check/reports
     ]),
@@ -290,6 +291,23 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             }
 
             return false;
+          } catch {
+            return false;
+          }
+        },
+      },
+      {
+        // GH-211: Per-task review gate. Soft check — advisory, not blocking.
+        // Verified iff at least one review artifact (task-review-tests.md or
+        // task-review-code.md) exists in the ticket's tasks dir.
+        step: STEPS.task_review,
+        verify: (ticketId) => {
+          try {
+            const dir = path.join(TASKS_BASE, safeTicketPath(ticketId));
+            return (
+              fs.existsSync(path.join(dir, 'task-review-tests.md')) ||
+              fs.existsSync(path.join(dir, 'task-review-code.md'))
+            );
           } catch {
             return false;
           }

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -366,14 +366,32 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
 
             // Resolve branch for --head flag to support worktree contexts (GH-191)
             let ghArgs = ['pr', 'view', '--json', 'number,state'];
+            let branch = '';
             try {
-              const branch = execFileSync('git', ['branch', '--show-current'], opts).trim();
+              branch = execFileSync('git', ['branch', '--show-current'], opts).trim();
               if (branch) ghArgs = ['pr', 'view', '--head', branch, '--json', 'number,state'];
             } catch {
               /* detached HEAD -- fall back to no --head */
             }
 
-            const pr = JSON.parse(execFileSync('gh', ghArgs, opts).trim());
+            // Try --head first (GH-191), fall back to branch arg if gh doesn't support --head
+            let pr;
+            try {
+              pr = JSON.parse(execFileSync('gh', ghArgs, opts).trim());
+            } catch {
+              // Some gh versions don't support --head on `pr view`; fall back to positional branch
+              if (branch) {
+                pr = JSON.parse(
+                  execFileSync(
+                    'gh',
+                    ['pr', 'view', branch, '--json', 'number,state'],
+                    opts
+                  ).trim()
+                );
+              } else {
+                pr = JSON.parse(execFileSync('gh', ['pr', 'view', '--json', 'number,state'], opts).trim());
+              }
+            }
             return pr.number > 0 && pr.state === 'OPEN';
           } catch {
             return false;


### PR DESCRIPTION
## Existing Behavior

- The work workflow advances from `commit` directly to `check` after each task implementation, with no intermediate quality review scoped to the individual task's diff.
- Fix-round tracking did not exist in work-state.js; `tasksMeta` had no `taskReviewFixRounds` counter per task.
- `task-advance.js` only mutated the `check` plan entry when advancing to the next task.
- The SKILL.md state machine documented a linear `commit→check` transition with no per-task review loop.

## Intended New Behavior

- A new `task_review` step is inserted between `commit` and `check` in the pipeline; it runs `/tests-review` and `/code-review` in parallel scoped to the current task's diff (derived from `.last-commit-sha`).
- The step uses a 5-path decision matrix: skip when disabled (`TASK_REVIEW_ENABLED=0`), skip when no tasks, skip on the final task (delegated to `/check`), escalate via `AskUserQuestion` when fix rounds are exhausted (default max 2, configurable via `TASK_REVIEW_MAX_FIXES`), and run parallel reviews otherwise.
- `work-state.js` gains `incrementTaskReviewFixRounds` and `resetTaskReviewFixRounds` to track and reset per-task fix-round counts across the review loop.
- `task-advance.js` now also mutates the `task_review` plan entry (setting `nextAction: advance_task`) and calls `resetTaskReviewFixRounds` on every task advance.
- `workflow-definition.js` registers `task_review` as a soft verify step; `step-registry.js` exposes the `STEP_TRANSITIONS` map covering the new `task_review → implement` (review failed) and `task_review → check` (review passed) edges.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Environment variables introduced:**
- `TASK_REVIEW_ENABLED` — set to `0` to disable the gate entirely (default: enabled)
- `TASK_REVIEW_MAX_FIXES` — integer, maximum fix rounds before escalating to user (default: `2`)

**Verifying the feature flag (disable path):**
1. Set `TASK_REVIEW_ENABLED=0` and run the orchestrator for a multi-task ticket.
2. Confirm the `task_review` step emits `action: SKIP` with reason `Task review disabled (TASK_REVIEW_ENABLED=0)`.
3. Confirm the workflow proceeds directly from `commit` to `check` unchanged.

**Verifying the review-pass path:**
1. Run the orchestrator on a multi-task ticket with at least two tasks, leaving `TASK_REVIEW_ENABLED` unset.
2. After `commit` completes for task 1, confirm `task_review` fires and calls `/tests-review` + `/code-review` in parallel.
3. When both reviews pass, confirm the step transitions to `check`.
4. Confirm `task-review-tests.md` and `task-review-code.md` are written to the task's `tasksDir`.

**Verifying the fix-loop path:**
1. Mock or trigger a failing code/tests review result for task 1.
2. Confirm the orchestrator transitions back to `implement` and increments `taskReviewFixRounds` in the state.
3. After 2 failed rounds (or whatever `TASK_REVIEW_MAX_FIXES` is set to), confirm the step issues an `AskUserQuestion` escalation instead of looping again.

**Verifying task-advance resets fix rounds:**
1. After a task passes review and `task-advance` is invoked, read the saved state and confirm `taskReviewFixRounds` is reset to `0` for the newly current task.

### Test Results

261 tests passing across all test suites (unit + integration), covering:
- `step-registry.test.js` — `STEP_TRANSITIONS` and `task_review` ordering assertions
- `task-review-gate.test.js` — `computeTaskDiff` SHA validation/fallback and `executeTaskReview` aggregation
- `task-review-step.test.js` — all 5 decision paths
- `task-advance.test.js` — `task_review` plan mutation and `resetTaskReviewFixRounds` calls
- `work-state.test.js` — fix-round increment/reset functions
- `work-orchestrator.test.js` — end-to-end GH-211 integration paths
- `workflow-definition.test.js` — soft-step registration
- `skill-md.test.js` — SKILL.md documentation correctness

Closes #211