### PR TITLE
docs(work-implement): clarify REFACTOR phase vs review gate separation (GH-212)

### DIFF
--- a/agents/developer-devops.md
+++ b/agents/developer-devops.md
@@ -16,6 +16,8 @@ You are an **Infrastructure Deployment Expert** with senior-level expertise in c
 
 ### Core Capabilities
 
+> **Scope boundary — reviews run separately.** TDD REFACTOR is developer self-cleanup — `/tests-review` and `/code-review` run as a separate post-commit gate (`workflows/work/steps/task-review.js`, GH-211) against the committed diff and are NOT this agent's responsibility. Do not invoke reviewer commands from inside your implementation loop; the orchestrator handles the post-commit review gate.
+
 * **Requirements Analysis:** Understand business and technical needs, asking clarifying questions about scale, budget, security, compliance, and constraints.
 * **Cloud Provisioning:** Design and configure infrastructure across AWS, Azure, GCP, and other platforms.
 * **Infrastructure as Code:** Implement reproducible, version-controlled deployments with Terraform, CloudFormation, Pulumi, or ARM templates.

--- a/agents/developer-nodejs-tdd.md
+++ b/agents/developer-nodejs-tdd.md
@@ -122,7 +122,7 @@ From these documents, extract:
 2. Design the test suite that captures all requirements
 3. Write integration tests first (red phase)
 4. Implement the feature with proper TypeScript types (green phase)
-5. Refactor for optimization and cleanliness (refactor phase)
+5. Refactor for optimization and cleanliness (refactor phase) — REFACTOR is developer self-cleanup; do NOT run `/tests-review` or `/code-review` here. Those reviewer commands are explicitly excluded from the refactor phase and run as a separate post-commit review gate (`workflows/work/steps/task-review.js`, GH-211) against the committed diff.
 6. Verify all tests still pass
 7. Document any complex logic or architectural decisions
 

--- a/agents/developer-react-senior.md
+++ b/agents/developer-react-senior.md
@@ -92,6 +92,8 @@ You follow a systematic approach for every React development task:
    * Document component APIs and architectural decisions
    * Create visual regression tests with Storybook
 
+> **Scope boundary — reviews run separately.** TDD REFACTOR is developer self-cleanup — `/tests-review` and `/code-review` run as a separate post-commit gate (`workflows/work/steps/task-review.js`, GH-211) against the committed diff and are NOT this agent's responsibility. Do not invoke reviewer commands from inside your implementation loop; the orchestrator handles the post-commit review gate.
+
 ## Technical Expertise
 
 * **React Core:** Hooks, Context, Suspense, Concurrent Features, Server Components

--- a/agents/developer-react-ui-architect.md
+++ b/agents/developer-react-ui-architect.md
@@ -88,6 +88,7 @@ You follow a strict three-phase approach for every UI task:
    * Refactor to achieve peak performance and maintainability.
    * Apply React.memo, useMemo, and useCallback strategically.
    * Introduce lazy-loading, code splitting, and reusable patterns.
+   * This cleanup phase is developer self-cleanup and does NOT include running `/tests-review` or `/code-review`. Reviewer responsibilities are explicitly excluded from this phase — they are owned by a separate post-commit review gate (`workflows/work/steps/task-review.js`, GH-211) that runs after the commit step against the committed diff.
 
 ## Technical Expertise
 

--- a/skills/work-implement/SKILL.md
+++ b/skills/work-implement/SKILL.md
@@ -162,6 +162,15 @@ node ${CLAUDE_PLUGIN_ROOT}/workflows/work-implement/tdd-phase-state.js transitio
 # If done with all behaviors: proceed to Step 3
 ```
 
+**REFACTOR is developer-owned self-cleanup only.** `/tests-review` and `/code-review` are NOT run during REFACTOR — they run as a separate post-commit gate via `workflows/work/steps/task-review.js` (GH-211). The developer agent's responsibility in REFACTOR ends at producing clean, still-green code; reviewer agents take over afterwards against the committed diff.
+
+**REFACTOR exit checklist (advisory):**
+- tests still green
+- no dead code
+- naming consistent
+
+_Why this split?_ Reviews run as a different agent against a committed artifact, which keeps the TDD state machine simple (exactly 3 phases: RED/GREEN/REFACTOR) and ensures reviewers never see half-refactored work. See `workflows/work/steps/task-review.js` (GH-211) for the post-commit review gate.
+
 **Important:**
 - Evidence is recorded by the SCRIPT, not by agents — the script runs `git diff` and test commands itself
 - Do NOT make local git commits during the TDD loop — the commit step handles that

--- a/skills/work-implement/SKILL.md
+++ b/skills/work-implement/SKILL.md
@@ -169,7 +169,7 @@ node ${CLAUDE_PLUGIN_ROOT}/workflows/work-implement/tdd-phase-state.js transitio
 - no dead code
 - naming consistent
 
-_Why this split?_ Reviews run as a different agent against a committed artifact, which keeps the TDD state machine simple (exactly 3 phases: RED/GREEN/REFACTOR) and ensures reviewers never see half-refactored work. See `workflows/work/steps/task-review.js` (GH-211) for the post-commit review gate.
+_Why this split?_ Reviews run as a different agent against a committed artifact, which keeps the core workflow aligned to the three-phase TDD loop (RED/GREEN/REFACTOR) and ensures reviewers never see half-refactored work. See `workflows/work/steps/task-review.js` (GH-211) for the post-commit review gate.
 
 **Important:**
 - Evidence is recorded by the SCRIPT, not by agents — the script runs `git diff` and test commands itself

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -12,8 +12,9 @@
  *   REFACTOR and is NOT invoked by this CLI. The post-commit review gate
  *   lives in workflows/work/steps/task-review.js (GH-211) and runs after
  *   the commit step, against the committed diff. Keeping reviews out of
- *   the TDD phase state machine preserves a clean 3-phase invariant
- *   (RED / GREEN / REFACTOR) and ensures reviewers never see
+ *   the TDD phase state machine means the normal TDD loop preserves the
+ *   clean RED / GREEN / REFACTOR flow, while exception handling remains
+ *   an out-of-band state, and ensures reviewers never see
  *   half-refactored work.
  *
  * Usage:

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -6,6 +6,16 @@
  * CLI script for managing TDD phase state.
  * This is the ONLY way evidence gets recorded — agents never self-report.
  *
+ * Scope boundary (GH-212):
+ *   REFACTOR evidence recorded here is developer self-cleanup only. The
+ *   external review gate (/tests-review + /code-review) is NOT part of
+ *   REFACTOR and is NOT invoked by this CLI. The post-commit review gate
+ *   lives in workflows/work/steps/task-review.js (GH-211) and runs after
+ *   the commit step, against the committed diff. Keeping reviews out of
+ *   the TDD phase state machine preserves a clean 3-phase invariant
+ *   (RED / GREEN / REFACTOR) and ensures reviewers never see
+ *   half-refactored work.
+ *
  * Usage:
  *   node tdd-phase-state.js init <TICKET_ID>
  *   node tdd-phase-state.js current <TICKET_ID>
@@ -288,6 +298,10 @@ function cmdRecordGreen(ticketId, args) {
   successOut({ ok: true, phase: 'green', cycle: state.currentCycle, testExitCode: exitCode });
 }
 
+// cmdRecordRefactor: records re-run evidence only; does NOT invoke
+// /tests-review or /code-review. Those reviewer commands run as a separate
+// post-commit gate owned by workflows/work/steps/task-review.js (GH-211),
+// not by this CLI and not by the developer agent driving the TDD loop.
 function cmdRecordRefactor(ticketId, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
   const cmd = parseCmd(args);


### PR DESCRIPTION
## Existing Behavior

- TDD REFACTOR phase had no explicit scope boundary documented; agents could conflate self-cleanup work with reviewer responsibilities
- No P1 exit checklist guided developers on when REFACTOR was done (tests green, no dead code, consistent naming)
- No cross-reference between the SKILL docs and GH-211's post-commit review gate machinery

## Intended New Behavior

- REFACTOR phase is explicitly scoped to developer self-cleanup only; post-commit reviews run as a separate gate via GH-211's task-review step
- SKILL.md gains a P1 exit checklist (tests green / no dead code / naming consistent) as advisory prose, plus a GH-211 cross-link and rationale note
- All four developer-* agents (`developer-nodejs-tdd.md`, `developer-react-ui-architect.md`, `developer-react-senior.md`, `developer-devops.md`) carry explicit scope-boundary notes excluding /tests-review and /code-review from the REFACTOR/optimization phase
- `tdd-phase-state.js` gains inline docstring comments only — zero code-line changes, all 84 phase-state tests continue to pass

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [Y] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Summary
- Documents that TDD REFACTOR is developer self-cleanup and reviews run as a separate post-commit gate (GH-211's task-review step)
- Adds P1 REFACTOR exit checklist as advisory prose
- Cross-links to GH-211 from the SKILL docs and tdd-phase-state.js inline comments
- Pairs with GH-211 to ship the two halves of one design

## Related
- Closes #212
- Pairs with GH-211 (per-task review gate, already merged)

## Testing Plan / Demo

This is a docs/prompt/comment-only change. Verify by:

1. Confirm `tdd-phase-state.js` has zero code-line changes: `git diff origin/main...HEAD -- workflows/work-implement/tdd-phase-state.js` should show only comment additions (lines starting with `+//` or `+/*`)
2. Confirm the SKILL.md mirror invariant: `diff skills/work-implement/SKILL.md workflows/work-implement/skills/work-implement.md` should produce no output
3. Run phase-state tests: `node --test workflows/work-implement/tests/tdd-phase-state.test.js` — expect 84/84 pass
4. Confirm ALLOWED_AGENTS still lists exactly 4 developer-* agents and CLI exposes exactly 7 gated subcommands
5. Review the scope-boundary prose in each updated agent file to confirm it excludes /tests-review and /code-review from the REFACTOR phase

### Test Results
- All 84 tdd-phase-state tests pass (primary scope)
- `diff skills/work-implement/SKILL.md workflows/work-implement/skills/work-implement.md` produces no output (mirror invariant holds)
- `tdd-phase-state.js` has 0 code-line changes (only comment additions)
- ALLOWED_AGENTS still lists exactly 4 developer-* agents; CLI exposes exactly 7 gated subcommands
- All 9 spec verification grep markers pass