### PR TITLE
feat(enforcement): foundation — audit records + context adapter (#219 PR 1/5)

### DIFF
--- a/workflows/work/__tests__/work-actions.test.js
+++ b/workflows/work/__tests__/work-actions.test.js
@@ -14,7 +14,7 @@ const os = require('os');
 const TEST_TASKS_BASE = path.join(os.tmpdir(), 'work-actions-test-' + process.pid);
 const FAKE_HOME = path.join(TEST_TASKS_BASE, 'fakehome');
 
-let appendAction, loadActions, analyzeActions;
+let appendAction, loadActions, analyzeActions, appendEnforcementAudit;
 
 describe('work-actions', () => {
   const TEST_TICKET = 'TEST-ACTIONS-001';
@@ -34,6 +34,7 @@ describe('work-actions', () => {
     appendAction = mod.appendAction;
     loadActions = mod.loadActions;
     analyzeActions = mod.analyzeActions;
+    appendEnforcementAudit = mod.appendEnforcementAudit;
   });
 
   after(() => {
@@ -178,6 +179,207 @@ describe('work-actions', () => {
       const result = analyzeActions(actions);
       assert.strictEqual(result.totalDuration, '2640s');
       assert.strictEqual(result.actionCount, 2);
+    });
+  });
+
+  // ─── IDEA2 / GH-219: Enforcement audit records ──────────────────────────────
+  // Task 1 — R13 (shape) + R16 (schema evolution without breaking readers).
+  // Enforcement records share the same `.work-actions.json` as legacy step rows
+  // and are separated by an explicit `kind: 'enforcement'` discriminator.
+  describe('appendEnforcementAudit', () => {
+    it('should expose appendEnforcementAudit as a module export', () => {
+      assert.strictEqual(
+        typeof appendEnforcementAudit,
+        'function',
+        'work-actions must export appendEnforcementAudit for enforcement hooks to audit decisions'
+      );
+    });
+
+    it('should write a record with all brief-required fields and kind discriminator', () => {
+      appendEnforcementAudit(TEST_TICKET, {
+        origin: 'workflow',
+        task: 1,
+        phase: 'red',
+        action: 'Write',
+        allow: true,
+        reason: 'write allowed: path matches claimed task artifact root',
+        outputPath: '/tmp/fake/tasks/GH-219/task1/implement.md',
+      });
+
+      const actions = loadActions(TEST_TICKET);
+      assert.strictEqual(actions.length, 1, 'one record should be appended');
+      const row = actions[0];
+
+      assert.strictEqual(row.kind, 'enforcement', 'discriminator must be kind: "enforcement"');
+      assert.ok(row.timestamp, 'must include timestamp');
+      assert.match(
+        row.timestamp,
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+        'timestamp must be ISO 8601'
+      );
+      assert.strictEqual(row.origin, 'workflow', 'must record origin');
+      assert.strictEqual(row.task, 1, 'must record task');
+      assert.strictEqual(row.phase, 'red', 'must record phase');
+      assert.strictEqual(row.action, 'Write', 'must record action (tool name)');
+      assert.strictEqual(row.allow, true, 'must record allow/deny as a boolean');
+      assert.strictEqual(
+        row.reason,
+        'write allowed: path matches claimed task artifact root',
+        'must record reason'
+      );
+      assert.strictEqual(
+        row.outputPath,
+        '/tmp/fake/tasks/GH-219/task1/implement.md',
+        'must record outputPath'
+      );
+    });
+
+    it('should record deny decisions with allow=false and preserve reason/outputPath', () => {
+      appendEnforcementAudit(TEST_TICKET, {
+        origin: 'user',
+        task: null,
+        phase: null,
+        action: 'Edit',
+        allow: false,
+        reason: 'deny: unclaimed task write attempted by user origin',
+        outputPath: '/tmp/fake/repo/src/index.ts',
+      });
+
+      const actions = loadActions(TEST_TICKET);
+      assert.strictEqual(actions[0].kind, 'enforcement');
+      assert.strictEqual(actions[0].allow, false);
+      assert.strictEqual(actions[0].origin, 'user');
+      assert.strictEqual(actions[0].task, null);
+      assert.strictEqual(actions[0].phase, null);
+      assert.strictEqual(actions[0].action, 'Edit');
+      assert.match(actions[0].reason, /deny/);
+    });
+
+    it('should pass through optional meta without dropping required fields', () => {
+      appendEnforcementAudit(TEST_TICKET, {
+        origin: 'ai-subtask',
+        task: 2,
+        phase: 'green',
+        action: 'Bash',
+        allow: true,
+        reason: 'allow: command inside PR1 worker root',
+        outputPath: null,
+        meta: { ruleId: 'path-allowed', prSlot: 'PR1' },
+      });
+
+      const row = loadActions(TEST_TICKET)[0];
+      assert.strictEqual(row.kind, 'enforcement');
+      assert.deepStrictEqual(row.meta, { ruleId: 'path-allowed', prSlot: 'PR1' });
+      assert.strictEqual(row.outputPath, null);
+    });
+
+    it('should coexist with legacy appendAction rows in the same .work-actions.json', () => {
+      appendAction(TEST_TICKET, { step: 'implement', what: 'step started' });
+      appendEnforcementAudit(TEST_TICKET, {
+        origin: 'workflow',
+        task: 1,
+        phase: 'red',
+        action: 'Write',
+        allow: true,
+        reason: 'allow: claimed task write',
+        outputPath: '/tmp/fake/tasks/GH-219/task1/implement.md',
+      });
+      appendAction(TEST_TICKET, { step: 'implement', what: 'step completed' });
+
+      const rows = loadActions(TEST_TICKET);
+      assert.strictEqual(rows.length, 3);
+
+      const legacyRows = rows.filter((r) => r.kind !== 'enforcement');
+      const enforcementRows = rows.filter((r) => r.kind === 'enforcement');
+      assert.strictEqual(legacyRows.length, 2, 'legacy rows are not enforcement rows');
+      assert.strictEqual(enforcementRows.length, 1, 'enforcement rows are discriminated');
+      assert.strictEqual(legacyRows[0].step, 'implement');
+      assert.strictEqual(legacyRows[0].what, 'step started');
+      assert.strictEqual(legacyRows[1].what, 'step completed');
+    });
+  });
+
+  describe('loadActions / analyzeActions backward compatibility (R16)', () => {
+    // Fixture mirrors a pre-IDEA2 .work-actions.json: only legacy rows, no `kind` field.
+    const preIdea2Fixture = [
+      { step: 'ticket', timestamp: '2026-01-05T10:00:00.000Z', what: 'workflow started' },
+      { step: 'ticket', timestamp: '2026-01-05T10:00:00.500Z', what: 'step started' },
+      {
+        step: 'ticket',
+        timestamp: '2026-01-05T10:00:30.000Z',
+        what: 'mcp__atlassian__jira_get_issue',
+      },
+      { step: 'ticket', timestamp: '2026-01-05T10:01:00.000Z', what: 'step completed' },
+      { step: 'bootstrap', timestamp: '2026-01-05T10:01:00.000Z', what: 'step started' },
+      {
+        step: 'bootstrap',
+        timestamp: '2026-01-05T10:01:30.000Z',
+        what: 'BLOCKED: Skill(bootstrap)',
+      },
+      { step: 'bootstrap', timestamp: '2026-01-05T10:02:30.000Z', what: 'step reset' },
+      { step: 'bootstrap', timestamp: '2026-01-05T10:03:00.000Z', what: 'step completed' },
+    ];
+
+    it('loadActions parses a pre-IDEA2 .work-actions.json without throwing', () => {
+      const dir = path.join(FAKE_HOME, 'worktrees', 'tasks', TEST_TICKET);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, '.work-actions.json'),
+        JSON.stringify(preIdea2Fixture, null, 2)
+      );
+
+      const loaded = loadActions(TEST_TICKET);
+      assert.strictEqual(loaded.length, preIdea2Fixture.length);
+      assert.strictEqual(loaded[0].what, 'workflow started');
+      for (const row of loaded) {
+        assert.ok(!('kind' in row), 'legacy rows must not gain a kind field on read');
+      }
+    });
+
+    it('analyzeActions handles a pre-IDEA2 fixture without throwing and still computes steps', () => {
+      const result = analyzeActions(preIdea2Fixture);
+      assert.strictEqual(result.actionCount, preIdea2Fixture.length);
+      const ticketStep = result.steps.find((s) => s.step === 'ticket');
+      const bootstrapStep = result.steps.find((s) => s.step === 'bootstrap');
+      assert.ok(ticketStep, 'ticket step analysed');
+      assert.ok(bootstrapStep, 'bootstrap step analysed');
+      assert.strictEqual(ticketStep.duration, '60s');
+      assert.strictEqual(bootstrapStep.duration, '120s');
+      assert.strictEqual(bootstrapStep.blockCount, 1);
+      assert.strictEqual(bootstrapStep.retryCount, 1);
+    });
+
+    it('analyzeActions does not throw when enforcement rows are mixed with legacy rows', () => {
+      const mixed = [
+        ...preIdea2Fixture,
+        {
+          kind: 'enforcement',
+          timestamp: '2026-01-05T10:03:30.000Z',
+          origin: 'workflow',
+          task: 1,
+          phase: 'red',
+          action: 'Write',
+          allow: true,
+          reason: 'allow: claim matches',
+          outputPath: '/tmp/fake/tasks/GH-219/task1/implement.md',
+        },
+      ];
+
+      let result;
+      assert.doesNotThrow(() => {
+        result = analyzeActions(mixed);
+      });
+      assert.strictEqual(
+        result.actionCount,
+        mixed.length,
+        'enforcement rows counted but do not corrupt step analysis'
+      );
+      const ticketStep = result.steps.find((s) => s.step === 'ticket');
+      assert.strictEqual(
+        ticketStep && ticketStep.duration,
+        '60s',
+        'ticket step duration unchanged by enforcement row'
+      );
     });
   });
 });

--- a/workflows/work/__tests__/work-enforcement-context.test.js
+++ b/workflows/work/__tests__/work-enforcement-context.test.js
@@ -330,6 +330,21 @@ describe('loadEnforcementContext — R15 ticket id validation', () => {
     assert.match(ctx.error.code, /ticket/i);
   });
 
+  it('rejects normalized IDs that still contain a forward slash (normalization failure)', () => {
+    // safeTicketId mock fails to fully normalize — result still has a slash
+    installMocks({
+      state: null,
+      safeId: (id) => (id === 'bad/input' ? 'still/bad' : id),
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('bad/input');
+
+    assert.ok(ctx.error, 'normalized ID containing "/" must be rejected');
+    assert.match(ctx.error.code, /ticket/i);
+    assert.equal(ctx.origin, null, 'invalid ticket id yields no origin');
+  });
+
   it('rejects non-string ticket ids (number, null, undefined, object)', () => {
     installMocks({ state: null });
 

--- a/workflows/work/__tests__/work-enforcement-context.test.js
+++ b/workflows/work/__tests__/work-enforcement-context.test.js
@@ -1,0 +1,421 @@
+/**
+ * Tests for work-enforcement-context.js
+ *
+ * IDEA2 / GH-219 — Task 2: Enforcement context adapter.
+ *
+ * Requirements covered:
+ *   R1  — gates read `.work-state.json` and parsed `tasks.md` via one shared
+ *         adapter; no transcript grep.
+ *   R2  — origin ∈ {workflow, ai-subtask, user} derived from observable
+ *         signals only; ambiguous `--subtask` does NOT throw — it returns a
+ *         structured error descriptor consumable by preflight (Task 3).
+ *   R15 — bad ticket id (empty, path-traversal, non-string) is rejected
+ *         fail-closed without any filesystem I/O.
+ *
+ * Uses node:test + node:assert/strict with require.cache injection to stub
+ * `loadState` / `loadActiveSubtaskState` / `parseTasks` without touching disk.
+ *
+ * Run: node --test workflows/work/__tests__/work-enforcement-context.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const Module = require('module'); // module resolution helpers
+
+// Resolve target + dependency paths ONCE to match what the adapter will
+// receive from its own `require('./work-state')` / `require('./task-parser')`
+// / `require('../lib/config')` calls — same absolute paths are cached.
+const MODULE_PATH = path.join(__dirname, '..', 'work-enforcement-context');
+const WORK_STATE_PATH = require.resolve(path.join(__dirname, '..', 'work-state'));
+const TASK_PARSER_PATH = require.resolve(path.join(__dirname, '..', 'task-parser'));
+const CONFIG_PATH = require.resolve(path.join(__dirname, '..', '..', 'lib', 'config'));
+
+// ─── Mock infrastructure ────────────────────────────────────────────────────
+
+/**
+ * Install mocks for work-state, task-parser, and config in require.cache.
+ * Each mock records every call it receives so individual tests can assert
+ * that only the expected functions were hit (e.g. no transcript reads).
+ */
+function installMocks({ state = null, tasks = null, subtaskState = null, safeId } = {}) {
+  const loadStateCalls = [];
+  const loadActiveSubtaskStateCalls = [];
+  const parseTasksCalls = [];
+  const safeTicketIdCalls = [];
+
+  require.cache[WORK_STATE_PATH] = {
+    id: WORK_STATE_PATH,
+    filename: WORK_STATE_PATH,
+    loaded: true,
+    exports: {
+      loadState: (ticketId) => {
+        loadStateCalls.push(ticketId);
+        return typeof state === 'function' ? state(ticketId) : state;
+      },
+      loadActiveSubtaskState: (ticketId) => {
+        loadActiveSubtaskStateCalls.push(ticketId);
+        return typeof subtaskState === 'function' ? subtaskState(ticketId) : subtaskState;
+      },
+    },
+  };
+
+  require.cache[TASK_PARSER_PATH] = {
+    id: TASK_PARSER_PATH,
+    filename: TASK_PARSER_PATH,
+    loaded: true,
+    exports: {
+      parseTasks: (tasksDir) => {
+        parseTasksCalls.push(tasksDir);
+        return typeof tasks === 'function' ? tasks(tasksDir) : tasks;
+      },
+    },
+  };
+
+  require.cache[CONFIG_PATH] = {
+    id: CONFIG_PATH,
+    filename: CONFIG_PATH,
+    loaded: true,
+    exports: {
+      TASKS_BASE: '/fake/tasks',
+      safeTicketId: (id) => {
+        safeTicketIdCalls.push(id);
+        return typeof safeId === 'function' ? safeId(id) : id;
+      },
+      tasksDir: (id) => path.join('/fake/tasks', id),
+    },
+  };
+
+  delete require.cache[require.resolve(MODULE_PATH)];
+
+  return { loadStateCalls, loadActiveSubtaskStateCalls, parseTasksCalls, safeTicketIdCalls };
+}
+
+function uninstallMocks() {
+  delete require.cache[WORK_STATE_PATH];
+  delete require.cache[TASK_PARSER_PATH];
+  delete require.cache[CONFIG_PATH];
+  delete require.cache[require.resolve(MODULE_PATH)];
+}
+
+/**
+ * Wrap `fs.readFileSync` and `child_process.execSync` so tests can assert
+ * the adapter never reads transcript files and never calls grep. Returns a
+ * restore() function that reinstates the originals and a `calls` object
+ * with the recorded arguments.
+ */
+function spyOnIO() {
+  const fs = require('fs');
+  const cp = require('child_process');
+  const origRead = fs.readFileSync;
+  const origExec = cp.execSync;
+  const calls = { reads: [], execs: [] };
+
+  fs.readFileSync = function (...args) {
+    calls.reads.push(String(args[0] ?? ''));
+    return origRead.apply(this, args);
+  };
+  cp.execSync = function (...args) {
+    calls.execs.push(String(args[0] ?? ''));
+    return origExec.apply(this, args);
+  };
+
+  return {
+    calls,
+    restore() {
+      fs.readFileSync = origRead;
+      cp.execSync = origExec;
+    },
+  };
+}
+
+// ─── R1 / R2 — Origin derivation ────────────────────────────────────────────
+
+describe('loadEnforcementContext — origin derivation (R1, R2)', () => {
+  afterEach(uninstallMocks);
+
+  it('returns origin "workflow" when state.status === "in_progress"', () => {
+    installMocks({
+      state: { ticketId: 'GH-219', status: 'in_progress', currentStep: 4 },
+      tasks: null,
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219');
+
+    assert.equal(ctx.origin, 'workflow', 'active workflow state => origin=workflow');
+    assert.equal(ctx.hasWorkflow, true, 'hasWorkflow is a boolean signal for hooks');
+    assert.equal(ctx.error, null, 'no error for a valid active workflow');
+    assert.equal(ctx.state.status, 'in_progress', 'raw state is included for hook consumers');
+  });
+
+  it('returns origin "ai-subtask" when --subtask flag AND a resolvable subtask state exists', () => {
+    installMocks({
+      state: { ticketId: 'GH-219', status: 'completed' },
+      subtaskState: {
+        ticketId: 'GH-219',
+        isSubtask: true,
+        parentTicketId: 'GH-219',
+        subtaskIndex: 2,
+        status: 'in_progress',
+      },
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219', { subtask: true });
+
+    assert.equal(ctx.origin, 'ai-subtask', '--subtask + resolvable state => origin=ai-subtask');
+    assert.equal(ctx.error, null, 'no error when subtask state resolves');
+    assert.equal(ctx.subtaskState.subtaskIndex, 2, 'resolved subtask state is exposed for hooks');
+    assert.equal(ctx.hasWorkflow, false, 'completed main workflow does not imply workflow origin');
+  });
+
+  it('returns origin "user" when there is no active workflow and no subtask flag', () => {
+    installMocks({ state: null, tasks: null });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219');
+
+    assert.equal(ctx.origin, 'user', 'default origin is user');
+    assert.equal(ctx.hasWorkflow, false);
+    assert.equal(ctx.error, null);
+  });
+
+  it('treats main state with status !== "in_progress" as non-workflow', () => {
+    installMocks({ state: { ticketId: 'GH-219', status: 'completed' } });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219');
+
+    assert.equal(ctx.origin, 'user', 'completed workflow should not produce workflow origin');
+  });
+
+  it('never derives origin from caller-supplied fields on options (R15 trust boundary)', () => {
+    installMocks({ state: null });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219', {
+      // Hostile payload trying to force an origin — adapter must ignore these.
+      origin: 'workflow',
+      _origin: 'ai-subtask',
+    });
+
+    assert.equal(ctx.origin, 'user', 'caller-supplied origin field must not influence derivation');
+  });
+});
+
+// ─── Ambiguous --subtask (R2 fail-closed, no throw) ─────────────────────────
+
+describe('loadEnforcementContext — ambiguous --subtask (R2)', () => {
+  afterEach(uninstallMocks);
+
+  it('returns a structured error descriptor (NOT a throw) when --subtask is set but no subtask state resolves', () => {
+    installMocks({
+      state: { status: 'in_progress' }, // main workflow active, but flag says subtask
+      subtaskState: null, // <-- no resolvable subtask
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+
+    let ctx;
+    assert.doesNotThrow(() => {
+      ctx = loadEnforcementContext('GH-219', { subtask: true });
+    }, 'ambiguous subtask must not throw — preflight must see a structured payload');
+
+    assert.ok(ctx.error, 'error descriptor is present on ambiguous subtask');
+    assert.equal(
+      typeof ctx.error.code,
+      'string',
+      'error.code is a stable string for rule-id routing'
+    );
+    assert.match(
+      ctx.error.code,
+      /subtask/i,
+      'error.code identifies the ambiguous-subtask rule (consumable by preflight)'
+    );
+    assert.equal(typeof ctx.error.message, 'string', 'error.message is human-readable');
+    assert.ok(Array.isArray(ctx.error.remediation), 'remediation is an array of fix steps');
+    assert.ok(
+      ctx.error.remediation.length > 0,
+      'at least one remediation step is provided (R18 quality)'
+    );
+  });
+
+  it('does not claim ai-subtask origin when ambiguous — origin is null or user, never ai-subtask', () => {
+    installMocks({ state: null, subtaskState: null });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219', { subtask: true });
+
+    assert.notEqual(
+      ctx.origin,
+      'ai-subtask',
+      'ambiguous subtask must NOT be treated as ai-subtask origin'
+    );
+    assert.ok(ctx.error, 'error descriptor is still present');
+  });
+});
+
+// ─── R15 — Bad ticket id (fail-closed, no filesystem I/O) ───────────────────
+
+describe('loadEnforcementContext — R15 ticket id validation', () => {
+  afterEach(uninstallMocks);
+
+  it('returns a deterministic error for an empty string ticket id', () => {
+    installMocks({ state: null });
+    const spy = spyOnIO();
+
+    try {
+      const { loadEnforcementContext } = require(MODULE_PATH);
+      const ctx = loadEnforcementContext('');
+
+      assert.ok(ctx.error, 'empty ticket id yields an error descriptor');
+      assert.match(ctx.error.code, /ticket/i, 'error code points at ticket id problem');
+      assert.equal(ctx.origin, null, 'no origin derivation for invalid ticket id');
+      assert.ok(
+        Array.isArray(ctx.error.remediation) && ctx.error.remediation.length > 0,
+        'remediation provided for R18 quality bar'
+      );
+
+      for (const execCall of spy.calls.execs) {
+        assert.ok(
+          !/grep/i.test(execCall),
+          `no grep calls allowed — saw: ${execCall.slice(0, 120)}`
+        );
+      }
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it('rejects path-traversal characters (.. / \\ null bytes)', () => {
+    installMocks({ state: null });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+
+    for (const bad of ['../../etc', 'GH-219/../secret', 'GH\\219', 'GH-219\u0000x']) {
+      const ctx = loadEnforcementContext(bad);
+      assert.ok(ctx.error, `path-traversal candidate "${bad}" must be rejected`);
+      assert.match(ctx.error.code, /ticket/i);
+      assert.equal(ctx.origin, null, 'invalid ticket id yields no origin');
+    }
+  });
+
+  it('rejects non-string ticket ids (number, null, undefined, object)', () => {
+    installMocks({ state: null });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+
+    for (const bad of [null, undefined, 42, {}, []]) {
+      const ctx = loadEnforcementContext(bad);
+      assert.ok(ctx.error, `non-string ticket id must be rejected: ${JSON.stringify(bad)}`);
+      assert.equal(ctx.origin, null);
+    }
+  });
+
+  it('does not perform any filesystem I/O for an invalid ticket id (fail-closed)', () => {
+    const mocks = installMocks({ state: null });
+    const spy = spyOnIO();
+
+    try {
+      const { loadEnforcementContext } = require(MODULE_PATH);
+      const ctx = loadEnforcementContext('../traversal');
+
+      assert.ok(ctx.error, 'invalid id yields error');
+      assert.equal(
+        mocks.loadStateCalls.length,
+        0,
+        'loadState MUST NOT be called for invalid ticket id'
+      );
+      assert.equal(
+        mocks.parseTasksCalls.length,
+        0,
+        'parseTasks MUST NOT be called for invalid ticket id'
+      );
+      assert.equal(
+        mocks.loadActiveSubtaskStateCalls.length,
+        0,
+        'loadActiveSubtaskState MUST NOT be called for invalid ticket id'
+      );
+    } finally {
+      spy.restore();
+    }
+  });
+});
+
+// ─── R1 — No transcript reads, no grep calls ────────────────────────────────
+
+describe('loadEnforcementContext — no transcript / no grep (R1)', () => {
+  afterEach(uninstallMocks);
+
+  it('does not read transcript files and does not invoke grep when resolving origin', () => {
+    installMocks({ state: { status: 'in_progress' }, tasks: [], subtaskState: null });
+    const spy = spyOnIO();
+
+    try {
+      const { loadEnforcementContext } = require(MODULE_PATH);
+      const ctx = loadEnforcementContext('GH-219', { subtask: false });
+
+      assert.equal(ctx.origin, 'workflow');
+
+      for (const p of spy.calls.reads) {
+        assert.ok(
+          !/\.jsonl$/i.test(p),
+          `adapter must not read transcript jsonl files — saw: ${p}`
+        );
+        assert.ok(!/transcript/i.test(p), `adapter must not read transcript files — saw: ${p}`);
+      }
+      for (const e of spy.calls.execs) {
+        assert.ok(!/\bgrep\b/.test(e), `adapter must not call grep — saw: ${e}`);
+      }
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it('delegates state + tasks reads exclusively through loadState / parseTasks stubs', () => {
+    const mocks = installMocks({
+      state: { status: 'in_progress' },
+      tasks: [{ id: 'task_1', num: 1, dependencies: [] }],
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219');
+
+    assert.ok(mocks.loadStateCalls.length > 0, 'adapter must call loadState via work-state.js');
+    assert.ok(mocks.parseTasksCalls.length > 0, 'adapter must call parseTasks via task-parser.js');
+    assert.ok(Array.isArray(ctx.tasks) && ctx.tasks[0].id === 'task_1', 'tasks are exposed on context');
+  });
+});
+
+// ─── EnforcementContext shape (Task 3 consumer contract) ────────────────────
+
+describe('loadEnforcementContext — context shape (Task 3 contract)', () => {
+  afterEach(uninstallMocks);
+
+  it('exposes a stable shape: { ticketId, origin, state, tasks, subtaskState, hasWorkflow, error, options }', () => {
+    installMocks({
+      state: { status: 'in_progress', tasksMeta: { totalTasks: 2 } },
+      tasks: [{ id: 'task_1', num: 1 }],
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219');
+
+    // Keys that Task 3 (preflight) will read
+    for (const key of [
+      'ticketId',
+      'origin',
+      'state',
+      'tasks',
+      'subtaskState',
+      'hasWorkflow',
+      'error',
+      'options',
+    ]) {
+      assert.ok(key in ctx, `EnforcementContext must expose "${key}" for preflight consumer`);
+    }
+    assert.equal(ctx.ticketId, 'GH-219', 'ticketId is the sanitized id');
+    assert.equal(ctx.options.subtask, undefined, 'options are echoed for caller traceability');
+  });
+});

--- a/workflows/work/__tests__/work-enforcement-context.test.js
+++ b/workflows/work/__tests__/work-enforcement-context.test.js
@@ -18,10 +18,9 @@
  * Run: node --test workflows/work/__tests__/work-enforcement-context.test.js
  */
 
-const { describe, it, beforeEach, afterEach } = require('node:test');
+const { describe, it, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('path');
-const Module = require('module'); // module resolution helpers
 
 // Resolve target + dependency paths ONCE to match what the adapter will
 // receive from its own `require('./work-state')` / `require('./task-parser')`
@@ -293,7 +292,7 @@ describe('loadEnforcementContext — R15 ticket id validation', () => {
 
     const { loadEnforcementContext } = require(MODULE_PATH);
 
-    for (const bad of ['../../etc', 'GH-219/../secret', 'GH\\219', 'GH-219\u0000x']) {
+    for (const bad of ['../../etc', 'GH-219/../secret', 'GH\\219', 'GH-219\u0000x', '/etc/passwd']) {
       const ctx = loadEnforcementContext(bad);
       assert.ok(ctx.error, `path-traversal candidate "${bad}" must be rejected`);
       assert.match(ctx.error.code, /ticket/i);

--- a/workflows/work/__tests__/work-enforcement-context.test.js
+++ b/workflows/work/__tests__/work-enforcement-context.test.js
@@ -287,17 +287,47 @@ describe('loadEnforcementContext — R15 ticket id validation', () => {
     }
   });
 
-  it('rejects path-traversal characters (.. / \\ null bytes)', () => {
+  it('rejects path-traversal characters (.. \\ null bytes) after normalization', () => {
     installMocks({ state: null });
 
     const { loadEnforcementContext } = require(MODULE_PATH);
 
-    for (const bad of ['../../etc', 'GH-219/../secret', 'GH\\219', 'GH-219\u0000x', '/etc/passwd']) {
+    // These contain "..", backslash, or null bytes — rejected after normalization
+    for (const bad of ['../../etc', 'GH-219/../secret', 'GH\\219', 'GH-219\u0000x']) {
       const ctx = loadEnforcementContext(bad);
       assert.ok(ctx.error, `path-traversal candidate "${bad}" must be rejected`);
       assert.match(ctx.error.code, /ticket/i);
       assert.equal(ctx.origin, null, 'invalid ticket id yields no origin');
     }
+  });
+
+  it('allows slash-containing inputs (e.g. URLs) that normalize to safe IDs', () => {
+    // safeTicketId mock normalizes URL-like input to a safe ID
+    installMocks({
+      state: null,
+      safeId: (id) => (id === '/etc/passwd' ? 'etc-passwd' : id),
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('/etc/passwd');
+
+    // After normalization to "etc-passwd", the ID is safe — no error
+    assert.equal(ctx.error, null, 'slash-containing input that normalizes safely should not be rejected');
+    assert.equal(ctx.ticketId, 'etc-passwd');
+  });
+
+  it('rejects slash-containing inputs whose normalized form is still unsafe', () => {
+    // safeTicketId mock returns an unsafe normalized form
+    installMocks({
+      state: null,
+      safeId: (id) => (id === 'foo/../../bar' ? '../bar' : id),
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('foo/../../bar');
+
+    assert.ok(ctx.error, 'normalized ID with ".." must still be rejected');
+    assert.match(ctx.error.code, /ticket/i);
   });
 
   it('rejects non-string ticket ids (number, null, undefined, object)', () => {

--- a/workflows/work/__tests__/work-enforcement-context.test.js
+++ b/workflows/work/__tests__/work-enforcement-context.test.js
@@ -415,6 +415,6 @@ describe('loadEnforcementContext — context shape (Task 3 contract)', () => {
       assert.ok(key in ctx, `EnforcementContext must expose "${key}" for preflight consumer`);
     }
     assert.equal(ctx.ticketId, 'GH-219', 'ticketId is the sanitized id');
-    assert.equal(ctx.options.subtask, undefined, 'options are echoed for caller traceability');
+    assert.equal(ctx.options.subtask, false, 'options.subtask is coerced to boolean (undefined → false)');
   });
 });

--- a/workflows/work/work-actions.js
+++ b/workflows/work/work-actions.js
@@ -1,12 +1,32 @@
 /**
  * work-actions.js
  *
- * Shared helper for appending timestamped actions to .work-actions.json.
- * Actions are append-only and stored separately from .work-state.json
+ * Shared helper for appending timestamped actions to `.work-actions.json`.
+ * Actions are append-only and stored separately from `.work-state.json`
  * to keep the state file small and avoid conflicts with backward transitions.
  *
+ * Record types (IDEA2 / GH-219 R13 + R16):
+ *   - Legacy step-transition rows: `{ step, timestamp, what, meta? }`.
+ *     Written by `appendAction()`. No `kind` field (pre-IDEA2 compatible).
+ *   - Enforcement audit rows:
+ *     `{ kind: 'enforcement', timestamp, origin, task, phase, action,
+ *        allow, reason, outputPath, meta? }`.
+ *     Written by `appendEnforcementAudit()`.
+ *
+ * Both record types coexist in one file. Consumers discriminate with the
+ * `kind` field: enforcement rows carry `kind === ENFORCEMENT_KIND`; legacy
+ * rows carry no `kind` at all. `loadActions()` returns every row verbatim;
+ * `analyzeActions()` ignores enforcement rows when computing per-step
+ * metrics (they are still counted in `actionCount`).
+ *
  * Usage:
- *   const { appendAction, loadActions, analyzeActions } = require('./work-actions');
+ *   const {
+ *     appendAction,
+ *     appendEnforcementAudit,
+ *     loadActions,
+ *     analyzeActions,
+ *     ENFORCEMENT_KIND,
+ *   } = require('./work-actions');
  *   appendAction('PROJ-881', { step: 'ticket', what: 'step started' });
  */
 
@@ -14,6 +34,14 @@ const fs = require('fs');
 const path = require('path');
 
 const getConfig = require('../lib/get-config');
+
+/**
+ * Discriminator value for enforcement audit rows (IDEA2 spec §Pattern — audit).
+ * Legacy `appendAction` rows never carry this field.
+ * @type {'enforcement'}
+ */
+const ENFORCEMENT_KIND = 'enforcement';
+
 let _tasksBase;
 function getTasksBase() {
   if (!_tasksBase) _tasksBase = getConfig.require('TASKS_BASE');
@@ -29,43 +57,106 @@ function safeId(ticketId) {
   }
 }
 
+function actionsFilePath(ticketId) {
+  return path.join(getTasksBase(), safeId(ticketId), '.work-actions.json');
+}
+
 /**
- * Load actions from .work-actions.json for a given ticket.
+ * Load actions from `.work-actions.json` for a given ticket.
+ *
+ * Returns rows verbatim, including both legacy step rows (no `kind`) and
+ * enforcement audit rows (`kind === ENFORCEMENT_KIND`). Missing or unreadable
+ * files yield `[]` — callers should never see a throw.
+ *
  * @param {string} ticketId
- * @returns {Array<{step: string, timestamp: string, what: string, meta?: object}>}
+ * @returns {Array<object>}
  */
 function loadActions(ticketId) {
   try {
-    const filePath = path.join(getTasksBase(), safeId(ticketId), '.work-actions.json');
-    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    return JSON.parse(fs.readFileSync(actionsFilePath(ticketId), 'utf-8'));
   } catch {
     return [];
   }
 }
 
 /**
- * Append a single action to .work-actions.json.
+ * Shared serialize-and-append helper used by `appendAction` and
+ * `appendEnforcementAudit`. Ensures the ticket directory exists, loads the
+ * current rows, appends `row`, and rewrites the file. Fail-open: errors are
+ * swallowed so logging never breaks the workflow.
+ *
  * @param {string} ticketId
- * @param {{step: string, what: string, meta?: object}} action
+ * @param {object} row — fully-built record; caller stamps its own timestamp.
  */
-function appendAction(ticketId, action) {
+function appendRow(ticketId, row) {
   try {
-    const dir = path.join(getTasksBase(), safeId(ticketId));
-    const filePath = path.join(dir, '.work-actions.json');
+    const filePath = actionsFilePath(ticketId);
+    const dir = path.dirname(filePath);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
     const actions = loadActions(ticketId);
-    actions.push({
-      step: action.step,
-      timestamp: new Date().toISOString(),
-      what: action.what,
-      ...(action.meta ? { meta: action.meta } : {}),
-    });
-
+    actions.push(row);
     fs.writeFileSync(filePath, JSON.stringify(actions, null, 2));
   } catch {
     // Fail-open: never break the workflow for logging
   }
+}
+
+/**
+ * Append a single legacy step-transition action to `.work-actions.json`.
+ * Legacy rows are written WITHOUT a `kind` field — consumers treat any row
+ * whose `kind !== ENFORCEMENT_KIND` (including absent) as a legacy row.
+ *
+ * @param {string} ticketId
+ * @param {{step: string, what: string, meta?: object}} action
+ */
+function appendAction(ticketId, action) {
+  appendRow(ticketId, {
+    step: action.step,
+    timestamp: new Date().toISOString(),
+    what: action.what,
+    ...(action.meta ? { meta: action.meta } : {}),
+  });
+}
+
+/**
+ * Append an enforcement audit record to `.work-actions.json`.
+ *
+ * IDEA2 / GH-219 — Task 1, requirements R13 (shape) + R16 (compatibility).
+ *
+ * Enforcement audit records share the same `.work-actions.json` file as
+ * legacy step rows written by `appendAction()`. They are distinguished by
+ * `kind: ENFORCEMENT_KIND` so `loadActions()` / `analyzeActions()` and
+ * downstream consumers can filter one from the other without introducing a
+ * second on-disk log (spec §Pattern — audit: "No `actions.jsonl`"). Legacy
+ * rows never acquire a `kind` field — a pre-IDEA2 `.work-actions.json` with
+ * only legacy rows parses via `loadActions` / `analyzeActions` unchanged.
+ *
+ * @param {string} ticketId
+ * @param {{
+ *   origin: 'workflow' | 'ai-subtask' | 'user',
+ *   task: number | string | null,
+ *   phase: 'red' | 'green' | 'refactor' | null,
+ *   action: string,
+ *   allow: boolean,
+ *   reason: string,
+ *   outputPath: string | null,
+ *   meta?: object
+ * }} entry
+ */
+function appendEnforcementAudit(ticketId, entry) {
+  appendRow(ticketId, {
+    kind: ENFORCEMENT_KIND,
+    timestamp: new Date().toISOString(),
+    origin: entry.origin,
+    task: entry.task ?? null,
+    phase: entry.phase ?? null,
+    action: entry.action,
+    allow: entry.allow,
+    reason: entry.reason,
+    outputPath: entry.outputPath ?? null,
+    ...(entry.meta ? { meta: entry.meta } : {}),
+  });
 }
 
 /**
@@ -87,6 +178,11 @@ function analyzeActions(actions) {
   const stepMap = new Map();
 
   for (const action of actions) {
+    // IDEA2 / GH-219: skip enforcement audit rows — they do not carry `step` /
+    // `what` fields and would corrupt step-duration accounting. Their record
+    // count still feeds `actionCount` below.
+    if (action && action.kind === ENFORCEMENT_KIND) continue;
+
     if (!stepMap.has(action.step)) {
       stepMap.set(action.step, {
         startTime: null,
@@ -150,8 +246,10 @@ function analyzeActions(actions) {
 
 module.exports = {
   appendAction,
+  appendEnforcementAudit,
   loadActions,
   analyzeActions,
+  ENFORCEMENT_KIND,
   get TASKS_BASE() {
     return getTasksBase();
   },

--- a/workflows/work/work-actions.js
+++ b/workflows/work/work-actions.js
@@ -180,7 +180,8 @@ function analyzeActions(actions) {
   for (const action of actions) {
     // IDEA2 / GH-219: skip enforcement audit rows — they do not carry `step` /
     // `what` fields and would corrupt step-duration accounting. Their record
-    // count still feeds `actionCount` below.
+    // count still feeds `actionCount` below. Boundary timestamps for
+    // totalDuration are also filtered to legacy rows only (see below).
     if (action && action.kind === ENFORCEMENT_KIND) continue;
 
     if (!stepMap.has(action.step)) {

--- a/workflows/work/work-actions.js
+++ b/workflows/work/work-actions.js
@@ -180,8 +180,8 @@ function analyzeActions(actions) {
   for (const action of actions) {
     // IDEA2 / GH-219: skip enforcement audit rows — they do not carry `step` /
     // `what` fields and would corrupt step-duration accounting. Their record
-    // count still feeds `actionCount` below. Boundary timestamps for
-    // totalDuration are also filtered to legacy rows only (see below).
+    // count still feeds `actionCount` below. Enforcement rows are also
+    // excluded from totalDuration boundary computation (see legacyActions filter ~line 236).
     if (action && action.kind === ENFORCEMENT_KIND) continue;
 
     if (!stepMap.has(action.step)) {
@@ -233,7 +233,7 @@ function analyzeActions(actions) {
 
   // Total duration: first legacy action to last legacy action.
   // Enforcement rows are excluded so they do not skew boundary timestamps.
-  const legacyActions = actions.filter(a => !(a && a.kind === ENFORCEMENT_KIND));
+  const legacyActions = actions.filter((a) => !(a && a.kind === ENFORCEMENT_KIND));
   let totalDuration = 0;
   if (legacyActions.length > 0) {
     const firstTs = new Date(legacyActions[0].timestamp).getTime();

--- a/workflows/work/work-actions.js
+++ b/workflows/work/work-actions.js
@@ -230,10 +230,15 @@ function analyzeActions(actions) {
     }
   }
 
-  // Total duration: first action to last action
-  const firstTs = new Date(actions[0].timestamp).getTime();
-  const lastTs = new Date(actions[actions.length - 1].timestamp).getTime();
-  const totalDuration = Math.round((lastTs - firstTs) / 1000);
+  // Total duration: first legacy action to last legacy action.
+  // Enforcement rows are excluded so they do not skew boundary timestamps.
+  const legacyActions = actions.filter(a => !(a && a.kind === ENFORCEMENT_KIND));
+  let totalDuration = 0;
+  if (legacyActions.length > 0) {
+    const firstTs = new Date(legacyActions[0].timestamp).getTime();
+    const lastTs = new Date(legacyActions[legacyActions.length - 1].timestamp).getTime();
+    totalDuration = Math.round((lastTs - firstTs) / 1000);
+  }
 
   return {
     steps,

--- a/workflows/work/work-enforcement-context.js
+++ b/workflows/work/work-enforcement-context.js
@@ -67,9 +67,9 @@ function validateTicketId(ticketId) {
         'Use a simple alphanumeric-with-hyphens format (e.g., "GH-219").',
       ],
     };
-  }
+  } // fail-closed: reject before any I/O
 
-  return null;
+  return null; // valid ticket ID
 }
 
 // ─── EnforcementContext builder ──────────────────────────────────────────────

--- a/workflows/work/work-enforcement-context.js
+++ b/workflows/work/work-enforcement-context.js
@@ -1,0 +1,177 @@
+/**
+ * work-enforcement-context.js
+ *
+ * IDEA2 / GH-219 — Task 2: Enforcement context adapter.
+ *
+ * Composes work-state.js (loadState, loadActiveSubtaskState) and
+ * task-parser.js (parseTasks) into a single unified EnforcementContext
+ * object consumed by preflight hooks (Task 3) and enforcement gates.
+ *
+ * Origin derivation rules (observable signals only — no transcript reads):
+ *   workflow    — .work-state.json exists AND status === 'in_progress'
+ *   ai-subtask  — options.subtask is set AND loadActiveSubtaskState resolves
+ *   user        — default when neither of the above applies
+ *
+ * Fail-closed on ambiguity: --subtask set but no matching subtask state
+ * returns a structured error/remediation payload (never throws).
+ *
+ * @module work-enforcement-context
+ */
+
+const path = require('path');
+
+let config;
+try {
+  config = require('../lib/config');
+} catch {
+  config = null;
+}
+
+const { loadState, loadActiveSubtaskState } = require('./work-state');
+const { parseTasks } = require('./task-parser');
+
+// ─── Ticket ID validation (R15) ─────────────────────────────────────────────
+
+/** @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes */
+const UNSAFE_TICKET_RE = /\.\.|[\\]|\x00/;
+
+/**
+ * Validate a ticket ID. Returns null if valid, or an error descriptor if invalid.
+ * Fail-closed: invalid IDs produce no filesystem I/O.
+ *
+ * @param {unknown} ticketId
+ * @returns {{ code: string, message: string, remediation: string[] } | null}
+ */
+function validateTicketId(ticketId) {
+  if (typeof ticketId !== 'string' || ticketId.length === 0) {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `Ticket ID must be a non-empty string, received: ${typeof ticketId === 'string' ? '""' : typeof ticketId}`,
+      remediation: [
+        'Pass a valid ticket ID string (e.g., "GH-219", "PROJ-42").',
+        'Ensure the --ticket flag is set when invoking the command.',
+      ],
+    };
+  }
+
+  if (UNSAFE_TICKET_RE.test(ticketId)) {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `Ticket ID contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`,
+      remediation: [
+        'Remove "..", backslashes, and null bytes from the ticket ID.',
+        'Use a simple alphanumeric-with-hyphens format (e.g., "GH-219").',
+      ],
+    };
+  }
+
+  return null;
+}
+
+// ─── EnforcementContext builder ──────────────────────────────────────────────
+
+/**
+ * @typedef {Object} EnforcementContextError
+ * @property {string} code    - Stable string for rule-id routing (e.g., 'AMBIGUOUS_SUBTASK')
+ * @property {string} message - Human-readable description
+ * @property {string[]} remediation - Array of actionable fix steps
+ */
+
+/**
+ * @typedef {Object} EnforcementContext
+ * @property {string|null}  ticketId     - Sanitized ticket ID (null on validation error)
+ * @property {'workflow'|'ai-subtask'|'user'|null} origin - Derived origin (null on validation error)
+ * @property {object|null}  state        - Result from loadState(ticketId) or null
+ * @property {object[]|null} tasks       - Result from parseTasks(tasksDir) or null
+ * @property {object|null}  subtaskState - Active subtask state or null
+ * @property {boolean}      hasWorkflow  - Whether an active workflow exists (state.status === 'in_progress')
+ * @property {EnforcementContextError|null} error - null on success, structured error on ambiguity/validation failure
+ * @property {object}       options      - Echo of caller-supplied options (for traceability)
+ */
+
+/**
+ * Load a unified enforcement context for a ticket.
+ *
+ * Composes loadState, loadActiveSubtaskState, and parseTasks into a single
+ * context object. Derives `origin` from observable signals only — never reads
+ * transcripts.
+ *
+ * @param {unknown} ticketId - Raw ticket ID (will be validated and sanitized)
+ * @param {object} [options={}] - Caller options
+ * @param {boolean} [options.subtask] - Whether the --subtask flag was set
+ * @returns {EnforcementContext}
+ */
+function loadEnforcementContext(ticketId, options = {}) {
+  // Strip any caller-injected origin fields — origin is derived, never trusted
+  const safeOptions = { subtask: options?.subtask };
+
+  // ─── R15: Validate ticket ID (fail-closed, no I/O) ─────────────────────
+  const idError = validateTicketId(ticketId);
+  if (idError) {
+    return {
+      ticketId: null,
+      origin: null,
+      state: null,
+      tasks: null,
+      subtaskState: null,
+      hasWorkflow: false,
+      error: idError,
+      options: safeOptions,
+    };
+  }
+
+  // Sanitize via config.safeTicketId (R15)
+  const safeId = config && config.safeTicketId ? config.safeTicketId(ticketId) : ticketId;
+
+  // ─── Load state and tasks ──────────────────────────────────────────────
+  const state = loadState(safeId);
+  const tasksBase = config && config.TASKS_BASE ? config.TASKS_BASE : null;
+  const tasksDir = tasksBase ? path.join(tasksBase, safeId) : null;
+  const tasks = tasksDir ? parseTasks(tasksDir) : null;
+
+  // ─── Derive hasWorkflow ────────────────────────────────────────────────
+  const hasWorkflow = !!(state && state.status === 'in_progress');
+
+  // ─── Derive origin ─────────────────────────────────────────────────────
+  let origin = 'user';
+  let subtaskState = null;
+  let error = null;
+
+  if (safeOptions.subtask) {
+    // --subtask flag is set: attempt to resolve active subtask state
+    subtaskState = loadActiveSubtaskState(safeId);
+
+    if (subtaskState) {
+      origin = 'ai-subtask';
+    } else {
+      // Fail-closed: --subtask set but no resolvable subtask state
+      origin = 'user';
+      error = {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: `--subtask flag is set but no active subtask state found for ticket "${safeId}". ` +
+          'Cannot determine ai-subtask origin without a resolvable .work-state-*-subtask-*.json file.',
+        remediation: [
+          'Initialize a subtask first: node work-state.js init-subtask ' + safeId,
+          'Verify the subtask state file exists and has status "in_progress".',
+          'Remove the --subtask flag if this is not an AI-driven subtask.',
+        ],
+      };
+    }
+  } else if (hasWorkflow) {
+    origin = 'workflow';
+  }
+  // else: origin stays 'user'
+
+  return {
+    ticketId: safeId,
+    origin,
+    state,
+    tasks,
+    subtaskState,
+    hasWorkflow,
+    error,
+    options: safeOptions,
+  };
+}
+
+module.exports = { loadEnforcementContext };

--- a/workflows/work/work-enforcement-context.js
+++ b/workflows/work/work-enforcement-context.js
@@ -35,12 +35,12 @@ const { parseTasks } = require('./task-parser');
 // ─── Ticket ID validation (R15) ─────────────────────────────────────────────
 
 /**
- * @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes
- * in the NORMALIZED ticket ID. Slashes are not checked here because
- * normalization (safeTicketId) handles URL-style inputs like
- * "https://github.com/.../issues/123" → "GH-123" before this runs.
+ * @type {RegExp} Reject path-traversal sequences, slashes, backslashes, and
+ * null bytes in the NORMALIZED ticket ID. Slashes are checked because
+ * normalization (safeTicketId) should have already stripped them — a `/` in
+ * the normalized result means normalization failed to clean the input.
  */
-const UNSAFE_NORMALIZED_RE = /\.\.|[\\]|\x00/;
+const UNSAFE_NORMALIZED_RE = /\.\.|[\\\/]|\x00/;
 
 /**
  * Validate a raw ticket ID for basic type/emptiness.

--- a/workflows/work/work-enforcement-context.js
+++ b/workflows/work/work-enforcement-context.js
@@ -23,8 +23,12 @@ const path = require('path');
 let config;
 try {
   config = require('../lib/config');
-} catch {
-  config = null;
+} catch (err) {
+  if (err && err.code === 'MODULE_NOT_FOUND') {
+    config = null;
+  } else {
+    throw err;
+  }
 }
 
 const { loadState, loadActiveSubtaskState } = require('./work-state');
@@ -33,7 +37,7 @@ const { parseTasks } = require('./task-parser');
 // ─── Ticket ID validation (R15) ─────────────────────────────────────────────
 
 /** @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes */
-const UNSAFE_TICKET_RE = /\.\.|[\\]|\x00/;
+const UNSAFE_TICKET_RE = /\.\.|[\\\/]|\x00/;
 
 /**
  * Validate a ticket ID. Returns null if valid, or an error descriptor if invalid.
@@ -57,9 +61,9 @@ function validateTicketId(ticketId) {
   if (UNSAFE_TICKET_RE.test(ticketId)) {
     return {
       code: 'INVALID_TICKET_ID',
-      message: `Ticket ID contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`,
+      message: `Ticket ID contains unsafe characters (path traversal, slash, backslash, or null byte): "${ticketId}"`,
       remediation: [
-        'Remove "..", backslashes, and null bytes from the ticket ID.',
+        'Remove "..", slashes, backslashes, and null bytes from the ticket ID.',
         'Use a simple alphanumeric-with-hyphens format (e.g., "GH-219").',
       ],
     };

--- a/workflows/work/work-enforcement-context.js
+++ b/workflows/work/work-enforcement-context.js
@@ -18,8 +18,6 @@
  * @module work-enforcement-context
  */
 
-const path = require('path');
-
 let config;
 try {
   config = require('../lib/config');
@@ -36,17 +34,23 @@ const { parseTasks } = require('./task-parser');
 
 // ─── Ticket ID validation (R15) ─────────────────────────────────────────────
 
-/** @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes */
-const UNSAFE_TICKET_RE = /\.\.|[\\\/]|\x00/;
+/**
+ * @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes
+ * in the NORMALIZED ticket ID. Slashes are not checked here because
+ * normalization (safeTicketId) handles URL-style inputs like
+ * "https://github.com/.../issues/123" → "GH-123" before this runs.
+ */
+const UNSAFE_NORMALIZED_RE = /\.\.|[\\]|\x00/;
 
 /**
- * Validate a ticket ID. Returns null if valid, or an error descriptor if invalid.
+ * Validate a raw ticket ID for basic type/emptiness.
+ * Returns null if the basic checks pass, or an error descriptor if invalid.
  * Fail-closed: invalid IDs produce no filesystem I/O.
  *
  * @param {unknown} ticketId
  * @returns {{ code: string, message: string, remediation: string[] } | null}
  */
-function validateTicketId(ticketId) {
+function validateTicketIdBasic(ticketId) {
   if (typeof ticketId !== 'string' || ticketId.length === 0) {
     return {
       code: 'INVALID_TICKET_ID',
@@ -58,18 +62,30 @@ function validateTicketId(ticketId) {
     };
   }
 
-  if (UNSAFE_TICKET_RE.test(ticketId)) {
+  return null; // basic checks passed
+}
+
+/**
+ * Validate a NORMALIZED ticket ID for path-traversal attacks.
+ * Called AFTER safeTicketId normalization so that URL-style inputs
+ * (containing slashes) have already been transformed to safe IDs.
+ *
+ * @param {string} normalizedId
+ * @returns {{ code: string, message: string, remediation: string[] } | null}
+ */
+function validateNormalizedId(normalizedId) {
+  if (UNSAFE_NORMALIZED_RE.test(normalizedId)) {
     return {
       code: 'INVALID_TICKET_ID',
-      message: `Ticket ID contains unsafe characters (path traversal, slash, backslash, or null byte): "${ticketId}"`,
+      message: `Ticket ID contains unsafe characters (path traversal, backslash, or null byte): "${normalizedId}"`,
       remediation: [
-        'Remove "..", slashes, backslashes, and null bytes from the ticket ID.',
+        'Remove "..", backslashes, and null bytes from the ticket ID.',
         'Use a simple alphanumeric-with-hyphens format (e.g., "GH-219").',
       ],
     };
   } // fail-closed: reject before any I/O
 
-  return null; // valid ticket ID
+  return null; // valid normalized ticket ID
 }
 
 // ─── EnforcementContext builder ──────────────────────────────────────────────
@@ -109,9 +125,9 @@ function loadEnforcementContext(ticketId, options = {}) {
   // Strip any caller-injected origin fields — origin is derived, never trusted
   const safeOptions = { subtask: Boolean(options?.subtask) };
 
-  // ─── R15: Validate ticket ID (fail-closed, no I/O) ─────────────────────
-  const idError = validateTicketId(ticketId);
-  if (idError) {
+  // ─── R15 Step 1: Basic type/emptiness check (fail-closed, no I/O) ─────
+  const basicError = validateTicketIdBasic(ticketId);
+  if (basicError) {
     return {
       ticketId: null,
       origin: null,
@@ -119,19 +135,33 @@ function loadEnforcementContext(ticketId, options = {}) {
       tasks: null,
       subtaskState: null,
       hasWorkflow: false,
-      error: idError,
+      error: basicError,
       options: safeOptions,
     };
   }
 
-  // safeTicketId transforms provider-specific IDs (e.g. #N → GH-N) — never introduces path separators
+  // ─── R15 Step 2: Normalize via provider-specific sanitizer ─────────────
+  // safeTicketId transforms provider-specific IDs (e.g. #N → GH-N, URLs → GH-N)
   const safeId = config && config.safeTicketId ? config.safeTicketId(ticketId) : ticketId;
+
+  // ─── R15 Step 3: Validate NORMALIZED result for traversal attacks ──────
+  const normalizedError = validateNormalizedId(safeId);
+  if (normalizedError) {
+    return {
+      ticketId: null,
+      origin: null,
+      state: null,
+      tasks: null,
+      subtaskState: null,
+      hasWorkflow: false,
+      error: normalizedError,
+      options: safeOptions,
+    };
+  }
 
   // ─── Load state and tasks ──────────────────────────────────────────────
   const state = loadState(safeId);
-  const tasksBase = config && config.TASKS_BASE ? config.TASKS_BASE : null;
-  // Derive tasksDir here (config.tasksDir not available — would require config.js changes in a separate PR)
-  const tasksDir = tasksBase ? path.join(tasksBase, safeId) : null;
+  const tasksDir = config && typeof config.tasksDir === 'function' ? config.tasksDir(safeId) : null;
   const tasks = tasksDir ? parseTasks(tasksDir) : null;
 
   // ─── Derive hasWorkflow ────────────────────────────────────────────────

--- a/workflows/work/work-enforcement-context.js
+++ b/workflows/work/work-enforcement-context.js
@@ -107,7 +107,7 @@ function validateTicketId(ticketId) {
  */
 function loadEnforcementContext(ticketId, options = {}) {
   // Strip any caller-injected origin fields — origin is derived, never trusted
-  const safeOptions = { subtask: options?.subtask };
+  const safeOptions = { subtask: Boolean(options?.subtask) };
 
   // ─── R15: Validate ticket ID (fail-closed, no I/O) ─────────────────────
   const idError = validateTicketId(ticketId);
@@ -124,12 +124,13 @@ function loadEnforcementContext(ticketId, options = {}) {
     };
   }
 
-  // Sanitize via config.safeTicketId (R15)
+  // safeTicketId transforms provider-specific IDs (e.g. #N → GH-N) — never introduces path separators
   const safeId = config && config.safeTicketId ? config.safeTicketId(ticketId) : ticketId;
 
   // ─── Load state and tasks ──────────────────────────────────────────────
   const state = loadState(safeId);
   const tasksBase = config && config.TASKS_BASE ? config.TASKS_BASE : null;
+  // Derive tasksDir here (config.tasksDir not available — would require config.js changes in a separate PR)
   const tasksDir = tasksBase ? path.join(tasksBase, safeId) : null;
   const tasks = tasksDir ? parseTasks(tasksDir) : null;
 


### PR DESCRIPTION
## Existing Behavior

- `work-actions.js` writes only legacy step-transition rows (`{ step, timestamp, what, meta? }`) to `.work-actions.json` with no type discriminator, making it impossible for consumers to distinguish enforcement decisions from workflow step events.
- `analyzeActions()` assumes every row has `step` / `what` fields; mixed non-step rows would corrupt per-step duration accounting.
- No unified adapter exists to compose `loadState`, `loadActiveSubtaskState`, and `parseTasks` into a single enforcement context — hooks and gates call each dependency directly, with origin derived ad-hoc (or from transcript grep).

## Intended New Behavior

- `appendEnforcementAudit(ticketId, entry)` appends enforcement audit records to the same `.work-actions.json` with a `kind: 'enforcement'` discriminator, keeping a single on-disk log (no separate `actions.jsonl`). Legacy rows remain unchanged — a pre-GH-219 file parses without modification.
- `analyzeActions()` skips enforcement rows during per-step metrics computation; they still contribute to `actionCount`. `ENFORCEMENT_KIND` is exported for consumers to filter by type.
- `loadEnforcementContext(ticketId, options)` in the new `work-enforcement-context.js` composes `loadState` + `loadActiveSubtaskState` + `parseTasks` into a stable `EnforcementContext` shape, deriving `origin` from observable state signals only (no transcript reads, no grep). Invalid ticket IDs and ambiguous `--subtask` states return structured error descriptors (never throw) for fail-closed preflight handling in Task 3.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

These are pure-JS modules with no external service dependencies. Verify locally with:

1. Run the enforcement audit tests:
   ```
   node --test workflows/work/__tests__/work-actions.test.js
   ```
   Expected: all `appendEnforcementAudit` and backward-compatibility suites pass.

2. Run the enforcement context tests:
   ```
   node --test workflows/work/__tests__/work-enforcement-context.test.js
   ```
   Expected: all origin-derivation, ambiguous-subtask, R15 ticket-id validation, and no-transcript suites pass.

3. Confirm schema backward compatibility by inspecting a pre-GH-219 `.work-actions.json` (only legacy rows): `loadActions` and `analyzeActions` must return the same results as before — no `kind` field is added on read, and step durations are unaffected.

Part of #219

### Test Results

Tests will be populated after PR creation with actual run output.