### PR TITLE
feat(preflight): shared gate library + path allocator + request index (#219 PR 3/5)

### DIFF
--- a/workflows/lib/__tests__/allocate-output-folder.test.js
+++ b/workflows/lib/__tests__/allocate-output-folder.test.js
@@ -1,0 +1,200 @@
+/**
+ * Tests for workflows/lib/allocate-output-folder.js (GH-219 Task 9 / R7, R8)
+ *
+ * Coverage:
+ *   - In-flow: returns `TASKS_BASE/<ticket>/task${N}/` for a claimed task.
+ *   - Out-of-flow user: returns `user-request-${k}` given a counter from Task 10
+ *     (counters are injected — Task 10 will wire the real `.request-index.json`).
+ *   - Out-of-flow AI: returns `ai-request-${k}` given a counter.
+ *   - Single source of truth for the `task${N}` naming (R7 — one allocator, one
+ *     naming policy). Other modules must consume this rather than rebuilding
+ *     the segment string.
+ *   - R15 fail-closed: rejects invalid ticket IDs (path traversal, empty, null,
+ *     backslash) before any filesystem access.
+ *   - Legacy-root case: when neither in-flow nor out-of-flow context is
+ *     complete enough to allocate, the allocator returns the ticket root as
+ *     `kind: 'legacy-root'` so callers can implement the backward-compat
+ *     fallback path (pairs with `tdd-phase-state.js` legacy reads).
+ *
+ * Run with: node --test workflows/lib/__tests__/allocate-output-folder.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const allocator = require('../allocate-output-folder');
+
+function mkTasksBase() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'alloc-of-'));
+  const tasksBase = path.join(dir, 'worktrees', 'tasks');
+  fs.mkdirSync(tasksBase, { recursive: true });
+  return { dir, tasksBase };
+}
+
+describe('allocate-output-folder', () => {
+  let tmpDir;
+  let tasksBase;
+  let origTasksBase;
+
+  beforeEach(() => {
+    ({ dir: tmpDir, tasksBase } = mkTasksBase());
+    origTasksBase = process.env.TASKS_BASE;
+    process.env.TASKS_BASE = tasksBase;
+  });
+
+  afterEach(() => {
+    if (origTasksBase === undefined) delete process.env.TASKS_BASE;
+    else process.env.TASKS_BASE = origTasksBase;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('API surface', () => {
+    it('exports allocateOutputFolder, taskSegment, and prefix constants', () => {
+      assert.strictEqual(typeof allocator.allocateOutputFolder, 'function');
+      assert.strictEqual(typeof allocator.taskSegment, 'function');
+      assert.strictEqual(typeof allocator.TASK_SEGMENT_PREFIX, 'string');
+      assert.strictEqual(typeof allocator.USER_REQUEST_PREFIX, 'string');
+      assert.strictEqual(typeof allocator.AI_REQUEST_PREFIX, 'string');
+    });
+
+    it('taskSegment produces the canonical `task${N}` form (R7 single source of truth)', () => {
+      assert.strictEqual(allocator.taskSegment(1), 'task1');
+      assert.strictEqual(allocator.taskSegment(9), 'task9');
+      assert.strictEqual(allocator.taskSegment(42), 'task42');
+    });
+
+    it('taskSegment rejects non-positive / non-integer input (fail-closed)', () => {
+      assert.throws(() => allocator.taskSegment(0), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment(-1), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment(1.5), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment('abc'), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment(null), /Invalid taskNum/i);
+    });
+  });
+
+  describe('in-flow task allocation (R7, R8)', () => {
+    it('returns TASKS_BASE/<ticket>/task${N}/ for in-flow + taskNum', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'workflow',
+        flow: 'in-flow',
+        taskNum: 9,
+        prSlot: 1,
+      });
+      assert.strictEqual(result.kind, 'in-flow-task');
+      assert.strictEqual(result.segment, 'task9');
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219', 'task9'));
+      assert.strictEqual(result.ticketRoot, path.join(tasksBase, 'GH-219'));
+    });
+
+    it('is deterministic: same context returns identical segment (R7)', () => {
+      const ctx = { origin: 'workflow', flow: 'in-flow', taskNum: 3 };
+      const a = allocator.allocateOutputFolder('GH-219', ctx);
+      const b = allocator.allocateOutputFolder('GH-219', ctx);
+      assert.strictEqual(a.segment, b.segment);
+      assert.strictEqual(a.root, b.root);
+    });
+
+    it('uses the same taskSegment() helper everywhere (R7 single source of truth)', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'workflow',
+        flow: 'in-flow',
+        taskNum: 7,
+      });
+      assert.strictEqual(result.segment, allocator.taskSegment(7));
+      assert.ok(result.root.endsWith(path.sep + allocator.taskSegment(7)));
+    });
+
+    it('throws when in-flow requires taskNum but none provided (fail-closed)', () => {
+      assert.throws(
+        () =>
+          allocator.allocateOutputFolder('GH-219', {
+            origin: 'workflow',
+            flow: 'in-flow',
+          }),
+        /taskNum/i
+      );
+    });
+  });
+
+  describe('out-of-flow allocation (Task 10 will wire counters; stub here)', () => {
+    it('returns user-request-${k} when counters are injected', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'user',
+        flow: 'out-of-flow',
+        counters: { userRequestNext: 4, aiRequestNext: 1 },
+      });
+      assert.strictEqual(result.kind, 'out-of-flow-user');
+      assert.strictEqual(result.segment, 'user-request-4');
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219', 'user-request-4'));
+    });
+
+    it('returns ai-request-${k} when origin is ai-subtask/ai', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'ai-subtask',
+        flow: 'out-of-flow',
+        counters: { userRequestNext: 1, aiRequestNext: 7 },
+      });
+      assert.strictEqual(result.kind, 'out-of-flow-ai');
+      assert.strictEqual(result.segment, 'ai-request-7');
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219', 'ai-request-7'));
+    });
+
+    it('fails closed when counters are missing for out-of-flow user', () => {
+      assert.throws(
+        () =>
+          allocator.allocateOutputFolder('GH-219', {
+            origin: 'user',
+            flow: 'out-of-flow',
+          }),
+        /counter|userRequestNext|Task 10/i
+      );
+    });
+
+    it('fails closed when counters are missing for out-of-flow ai', () => {
+      assert.throws(
+        () =>
+          allocator.allocateOutputFolder('GH-219', {
+            origin: 'ai-subtask',
+            flow: 'out-of-flow',
+          }),
+        /counter|aiRequestNext|Task 10/i
+      );
+    });
+  });
+
+  describe('legacy-root fallback (pairs with tdd-phase-state backward-compat read)', () => {
+    it('returns ticket root as kind "legacy-root" when no flow/task context is supplied', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {});
+      assert.strictEqual(result.kind, 'legacy-root');
+      assert.strictEqual(result.segment, null);
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219'));
+    });
+  });
+
+  describe('R15 ticket ID validation (fail-closed, before I/O)', () => {
+    it('rejects empty / null / undefined ticket id', () => {
+      assert.throws(() => allocator.allocateOutputFolder('', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder(null, { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder(undefined, { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+    });
+
+    it('rejects path traversal attempts', () => {
+      assert.throws(() => allocator.allocateOutputFolder('../etc', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder('GH-1/../evil', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder('foo\\bar', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+    });
+  });
+
+  describe('TASKS_BASE resolution', () => {
+    it('throws when TASKS_BASE is not configured', () => {
+      delete process.env.TASKS_BASE;
+      assert.throws(
+        () => allocator.allocateOutputFolder('GH-219', { flow: 'in-flow', taskNum: 1 }),
+        /TASKS_BASE/i
+      );
+    });
+  });
+});

--- a/workflows/lib/__tests__/preflight-integration.test.js
+++ b/workflows/lib/__tests__/preflight-integration.test.js
@@ -1,0 +1,878 @@
+/**
+ * P1 integration + guardrail tests for preflight and supporting modules.
+ *
+ * IDEA2 / GH-219 — Task 18: Integration tests for parallel-ready tasks,
+ * counter collisions, ambiguous origin, invalid graph.
+ *
+ * Requirements covered:
+ *   R19 — Integration tests for mixed serial/parallel dependency graphs
+ *   R20 — Guardrail tests for edge cases (ambiguous origin, out-of-flow,
+ *          counter races, invalid graph, etc.)
+ *   R18 — Remediation quality bar: deny-path tests assert remediation
+ *          includes ruleId, evaluated state snapshot, and concrete fix steps
+ *          (non-empty remediation strings array)
+ *   R16 — Legacy ticket fixtures in integration where applicable
+ *
+ * Run: node --test workflows/lib/__tests__/preflight-integration.test.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Isolated TASKS_BASE before any module requires
+const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'preflight-integ-'));
+process.env.TASKS_BASE = TEMP_TASKS_BASE;
+
+const { describe, it, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  runPreflight,
+  isWriteAllowedPath,
+  createGraphCheck,
+  createClaimCheck,
+  createPathCheck,
+} = require(path.join(__dirname, '..', 'preflight'));
+
+const workState = require(path.join(__dirname, '..', '..', 'work', 'work-state'));
+const requestIndex = require(path.join(__dirname, '..', 'request-index'));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function freshTicket(prefix) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+}
+
+function cleanupTicket(ticketId) {
+  try {
+    fs.rmSync(path.join(TEMP_TASKS_BASE, ticketId), { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+after(() => {
+  try {
+    fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R4, R19 — Invalid graph tests (unknown dep, cycle, self-dep)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — invalid graph: unknown dependency (R4, R19)', () => {
+  it('preflight denies graph with unknown dep (Task 3 -> Task 99) and reports UNKNOWN_DEPENDENCY', () => {
+    const ctx = {
+      ticketId: 'GH-INT-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [] },
+        { num: 3, dependencies: [99] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+
+    assert.equal(result.allow, false, 'unknown dep must deny');
+    assert.ok(
+      result.reasons.includes('UNKNOWN_DEPENDENCY'),
+      `reasons must include UNKNOWN_DEPENDENCY, got: ${JSON.stringify(result.reasons)}`
+    );
+    assert.ok(result.remediation.length > 0, 'remediation must list fix steps');
+    // Remediation must mention the missing task id
+    assert.ok(
+      result.remediation.some((r) => r.includes('99')),
+      'remediation must reference the unknown task id (99)'
+    );
+  });
+});
+
+describe('integration — invalid graph: dependency cycle (R4, R19)', () => {
+  it('preflight denies 2-cycle (A->B->A) with DEPENDENCY_CYCLE', () => {
+    const ctx = {
+      ticketId: 'GH-INT-2',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [2] },
+        { num: 2, dependencies: [1] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+
+    assert.equal(result.allow, false, 'cycle must deny');
+    assert.ok(result.reasons.includes('DEPENDENCY_CYCLE'));
+    assert.ok(result.remediation.length > 0);
+  });
+
+  it('preflight denies 3-cycle (1->2->3->1) with DEPENDENCY_CYCLE', () => {
+    const ctx = {
+      ticketId: 'GH-INT-3',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [3] },
+        { num: 2, dependencies: [1] },
+        { num: 3, dependencies: [2] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+
+    assert.equal(result.allow, false, '3-cycle must deny');
+    assert.ok(result.reasons.includes('DEPENDENCY_CYCLE'));
+  });
+});
+
+describe('integration — invalid graph: self-dependency (R4, R19)', () => {
+  it('preflight denies self-dep (Task 1 -> Task 1) with SELF_DEPENDENCY', () => {
+    const ctx = {
+      ticketId: 'GH-INT-4',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [1] },
+        { num: 2, dependencies: [] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+
+    assert.equal(result.allow, false, 'self-dep must deny');
+    assert.ok(result.reasons.includes('SELF_DEPENDENCY'));
+    assert.ok(result.remediation.length > 0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R19 — Mixed serial/parallel dependency graphs
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — mixed serial/parallel dependency graph (R19)', () => {
+  // Diamond: 1 -> 2, 1 -> 3, 2 -> 4, 3 -> 4 (tasks 2 and 3 can run in parallel)
+  it('allows parallel-ready tasks (2 and 3) when their shared dependency (1) is complete', () => {
+    const tasks = [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [1] },
+      { num: 3, dependencies: [1] },
+      { num: 4, dependencies: [2, 3] },
+    ];
+
+    const tasksMeta = {
+      totalTasks: 4,
+      currentTaskIndex: 1,
+      tasks: [
+        { id: 'task_1', status: 'completed', dependencies: [] },
+        { id: 'task_2', status: 'pending', dependencies: [1] },
+        { id: 'task_3', status: 'pending', dependencies: [1] },
+        { id: 'task_4', status: 'pending', dependencies: [2, 3] },
+      ],
+    };
+
+    const ctx = {
+      ticketId: 'GH-INT-DIAMOND',
+      origin: 'workflow',
+      error: null,
+      tasks,
+      state: { status: 'in_progress', tasksMeta },
+      hasWorkflow: true,
+    };
+
+    // Both task 2 and task 3 should be startable (parallel)
+    const check2 = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const check3 = createClaimCheck({ taskNum: 3, ownerId: 'PR2' });
+
+    const result2 = runPreflight(ctx, { checks: [createGraphCheck(), check2] });
+    const result3 = runPreflight(ctx, { checks: [createGraphCheck(), check3] });
+
+    assert.equal(result2.allow, true, 'task 2 with dep 1 complete is startable');
+    assert.equal(result3.allow, true, 'task 3 with dep 1 complete is startable in parallel');
+  });
+
+  it('denies task 4 when only one of its deps (2, 3) is complete', () => {
+    const tasks = [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [1] },
+      { num: 3, dependencies: [1] },
+      { num: 4, dependencies: [2, 3] },
+    ];
+
+    const tasksMeta = {
+      totalTasks: 4,
+      currentTaskIndex: 3,
+      tasks: [
+        { id: 'task_1', status: 'completed', dependencies: [] },
+        { id: 'task_2', status: 'completed', dependencies: [1] },
+        { id: 'task_3', status: 'pending', dependencies: [1] },
+        { id: 'task_4', status: 'pending', dependencies: [2, 3] },
+      ],
+    };
+
+    const ctx = {
+      ticketId: 'GH-INT-DIAMOND-HALF',
+      origin: 'workflow',
+      error: null,
+      tasks,
+      state: { status: 'in_progress', tasksMeta },
+      hasWorkflow: true,
+    };
+
+    const check4 = createClaimCheck({ taskNum: 4, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [createGraphCheck(), check4] });
+
+    assert.equal(result.allow, false, 'task 4 with task 3 still pending must deny');
+    assert.ok(result.reasons.includes('DEPENDENCY_NOT_READY'));
+  });
+
+  it('graph validation accepts a complex valid DAG (chain + fan-out + fan-in)', () => {
+    // Tasks: 1 (root), 2 depends on 1, 3 depends on 1, 4 depends on 2,
+    //         5 depends on 2+3 (fan-in), 6 depends on 4+5 (final merge)
+    const tasks = [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [1] },
+      { num: 3, dependencies: [1] },
+      { num: 4, dependencies: [2] },
+      { num: 5, dependencies: [2, 3] },
+      { num: 6, dependencies: [4, 5] },
+    ];
+
+    const ctx = {
+      ticketId: 'GH-INT-COMPLEX-DAG',
+      origin: 'workflow',
+      error: null,
+      tasks,
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, true, 'complex valid DAG must pass graph validation');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R20 — Ambiguous --subtask (flag set, no state)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — ambiguous --subtask origin (R20, R2)', () => {
+  it('context.error with AMBIGUOUS_SUBTASK denies with remediation to initialize or remove flag', () => {
+    // Simulates: --subtask set but no matching subtask state file found
+    const ctx = {
+      ticketId: 'GH-INT-SUBTASK',
+      origin: null,
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: '--subtask flag is set but no subtask state file found',
+        remediation: [
+          'Initialize the subtask state before using --subtask.',
+          'Remove the --subtask flag if this is a main workflow invocation.',
+        ],
+      },
+      state: null,
+      tasks: null,
+      subtaskState: null,
+      hasWorkflow: false,
+    };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, false, 'ambiguous subtask must deny');
+    assert.ok(result.reasons.includes('AMBIGUOUS_SUBTASK'));
+    assert.ok(result.remediation.length >= 2, 'must include at least two remediation steps');
+    assert.ok(
+      result.remediation.some((r) => r.toLowerCase().includes('subtask')),
+      'remediation must mention subtask'
+    );
+  });
+
+  it('audit entry captures the ambiguous subtask denial', () => {
+    const audited = [];
+    const ctx = {
+      ticketId: 'GH-INT-SUBTASK-AUDIT',
+      origin: null,
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: 'no subtask state found',
+        remediation: ['Initialize subtask first'],
+      },
+    };
+
+    runPreflight(ctx, { audit: (e) => audited.push(e) });
+
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].decision, 'deny');
+    assert.ok(audited[0].reasons.includes('AMBIGUOUS_SUBTASK'));
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R11, R20 — Concurrent request index (parallel increments)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — concurrent request index sequential increments (R11, R20)', () => {
+  let TICKET;
+
+  beforeEach(() => {
+    TICKET = freshTicket('INT-REQIDX');
+    cleanupTicket(TICKET);
+  });
+
+  it('rapid sequential user request allocations yield strictly increasing sequences', () => {
+    const results = [];
+    for (let i = 0; i < 15; i++) {
+      results.push(requestIndex.nextUserRequest(TICKET));
+    }
+
+    for (let i = 1; i < results.length; i++) {
+      assert.ok(
+        results[i].seq > results[i - 1].seq,
+        `user-request sequence not monotonic at index ${i}: ${results[i - 1].seq} >= ${results[i].seq}`
+      );
+    }
+    assert.equal(results[results.length - 1].seq, 15);
+
+    // Verify disk state is consistent
+    const idx = requestIndex.readIndex(TICKET);
+    assert.equal(idx.userSeq, 15, 'persisted userSeq must equal last allocation');
+  });
+
+  it('rapid sequential AI request allocations yield strictly increasing sequences', () => {
+    const results = [];
+    for (let i = 0; i < 10; i++) {
+      results.push(requestIndex.nextAiRequest(TICKET));
+    }
+
+    for (let i = 1; i < results.length; i++) {
+      assert.ok(
+        results[i].seq > results[i - 1].seq,
+        `ai-request sequence not monotonic at index ${i}`
+      );
+    }
+    assert.equal(results[results.length - 1].seq, 10);
+  });
+
+  it('interleaved user and AI allocations maintain independent counters', () => {
+    const u1 = requestIndex.nextUserRequest(TICKET);
+    const a1 = requestIndex.nextAiRequest(TICKET);
+    const u2 = requestIndex.nextUserRequest(TICKET);
+    const a2 = requestIndex.nextAiRequest(TICKET);
+    const u3 = requestIndex.nextUserRequest(TICKET);
+
+    assert.equal(u1.seq, 1);
+    assert.equal(a1.seq, 1, 'AI counter starts independent of user counter');
+    assert.equal(u2.seq, 2);
+    assert.equal(a2.seq, 2);
+    assert.equal(u3.seq, 3);
+
+    const idx = requestIndex.readIndex(TICKET);
+    assert.equal(idx.userSeq, 3);
+    assert.equal(idx.aiSeq, 2);
+  });
+
+  it('each allocation creates a unique directory on disk', () => {
+    const r1 = requestIndex.nextUserRequest(TICKET);
+    const r2 = requestIndex.nextUserRequest(TICKET);
+    const r3 = requestIndex.nextAiRequest(TICKET);
+
+    assert.notEqual(r1.root, r2.root, 'user-request-1 and user-request-2 must differ');
+    assert.notEqual(r1.root, r3.root, 'user-request-1 and ai-request-1 must differ');
+
+    assert.ok(fs.existsSync(r1.root), 'user-request-1 dir must exist');
+    assert.ok(fs.existsSync(r2.root), 'user-request-2 dir must exist');
+    assert.ok(fs.existsSync(r3.root), 'ai-request-1 dir must exist');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R14, R19 — Two PR workers with distinct roots
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — two PR workers with distinct roots (R14, R19)', () => {
+  let TICKET;
+
+  beforeEach(() => {
+    TICKET = freshTicket('INT-PR-WORKERS');
+    cleanupTicket(TICKET);
+  });
+
+  it('two allocateWorkerSlot calls produce distinct PR directories', () => {
+    const pr1 = workState.allocateWorkerSlot(TICKET);
+    const pr2 = workState.allocateWorkerSlot(TICKET);
+
+    assert.notEqual(pr1.slot, pr2.slot, 'slots must differ');
+    assert.notEqual(pr1.ownerId, pr2.ownerId, 'owner ids must differ');
+    assert.notEqual(pr1.dir, pr2.dir, 'directories must differ');
+
+    assert.equal(pr1.ownerId, 'PR1');
+    assert.equal(pr2.ownerId, 'PR2');
+
+    // Both directories exist on disk
+    assert.ok(fs.existsSync(pr1.dir), 'PR1 dir exists');
+    assert.ok(fs.existsSync(pr2.dir), 'PR2 dir exists');
+
+    // Paths do not overlap
+    assert.ok(
+      !pr1.dir.startsWith(pr2.dir) && !pr2.dir.startsWith(pr1.dir),
+      'PR directories must not be nested within each other'
+    );
+  });
+
+  it('each PR worker writes only to its own directory (path gate enforcement)', () => {
+    const pr1 = workState.allocateWorkerSlot(TICKET);
+    const pr2 = workState.allocateWorkerSlot(TICKET);
+    const ticketRoot = path.join(TEMP_TASKS_BASE, TICKET);
+
+    // PR1 worker paths
+    const pr1Paths = {
+      prDir: pr1.dir,
+      taskDir: path.join(ticketRoot, 'task1'),
+      ticketRoot,
+    };
+
+    // PR2 worker paths
+    const pr2Paths = {
+      prDir: pr2.dir,
+      taskDir: path.join(ticketRoot, 'task2'),
+      ticketRoot,
+    };
+
+    // PR1 can write to its own dir
+    assert.ok(
+      isWriteAllowedPath(path.join(pr1.dir, 'src', 'file.js'), pr1Paths),
+      'PR1 allowed to write under PR1/'
+    );
+
+    // PR1 cannot write to PR2 dir
+    assert.equal(
+      isWriteAllowedPath(path.join(pr2.dir, 'src', 'file.js'), pr1Paths),
+      false,
+      'PR1 must NOT write under PR2/'
+    );
+
+    // PR2 can write to its own dir
+    assert.ok(
+      isWriteAllowedPath(path.join(pr2.dir, 'src', 'file.js'), pr2Paths),
+      'PR2 allowed to write under PR2/'
+    );
+
+    // PR2 cannot write to PR1 dir
+    assert.equal(
+      isWriteAllowedPath(path.join(pr1.dir, 'src', 'file.js'), pr2Paths),
+      false,
+      'PR2 must NOT write under PR1/'
+    );
+
+    // Both can write shared-root whitelist
+    assert.ok(
+      isWriteAllowedPath(path.join(ticketRoot, '.work-state.json'), pr1Paths),
+      'PR1 can write .work-state.json at ticket root'
+    );
+    assert.ok(
+      isWriteAllowedPath(path.join(ticketRoot, '.work-state.json'), pr2Paths),
+      'PR2 can write .work-state.json at ticket root'
+    );
+  });
+
+  it('two workers claim different tasks and preflight allows both (full composition)', () => {
+    const tasks = [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [] },
+    ];
+    const tasksMeta = {
+      totalTasks: 2,
+      currentTaskIndex: 0,
+      tasks: [
+        { id: 'task_1', status: 'pending', dependencies: [] },
+        { id: 'task_2', status: 'pending', dependencies: [] },
+      ],
+    };
+
+    const pr1 = workState.allocateWorkerSlot(TICKET);
+    const pr2 = workState.allocateWorkerSlot(TICKET);
+    const ticketRoot = path.join(TEMP_TASKS_BASE, TICKET);
+
+    const ctx = {
+      ticketId: TICKET,
+      origin: 'workflow',
+      error: null,
+      tasks,
+      state: { status: 'in_progress', tasksMeta },
+      hasWorkflow: true,
+    };
+
+    // Worker 1 claims task 1
+    const checks1 = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 1, ownerId: pr1.ownerId }),
+      createPathCheck({
+        filePath: path.join(pr1.dir, 'src', 'main.js'),
+        allowedPaths: {
+          prDir: pr1.dir,
+          taskDir: path.join(ticketRoot, 'task1'),
+          ticketRoot,
+        },
+      }),
+    ];
+
+    // Worker 2 claims task 2
+    const checks2 = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 2, ownerId: pr2.ownerId }),
+      createPathCheck({
+        filePath: path.join(pr2.dir, 'src', 'other.js'),
+        allowedPaths: {
+          prDir: pr2.dir,
+          taskDir: path.join(ticketRoot, 'task2'),
+          ticketRoot,
+        },
+      }),
+    ];
+
+    const result1 = runPreflight(ctx, { checks: checks1 });
+    const result2 = runPreflight(ctx, { checks: checks2 });
+
+    assert.equal(result1.allow, true, 'worker 1 on task 1 allowed');
+    assert.equal(result2.allow, true, 'worker 2 on task 2 allowed in parallel');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R18 — Remediation quality bar (ruleId, evaluated state, fix steps)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — R18 remediation quality bar', () => {
+  it('UNKNOWN_DEPENDENCY deny includes ruleId, evaluated state reference, and non-empty remediation', () => {
+    const ctx = {
+      ticketId: 'GH-R18-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [99] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const audited = [];
+    const result = runPreflight(ctx, {
+      checks: [createGraphCheck()],
+      audit: (e) => audited.push(e),
+    });
+
+    // 1. ruleId assertion: each reason IS the stable ruleId
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.length > 0, 'at least one ruleId present');
+    for (const ruleId of result.reasons) {
+      assert.equal(typeof ruleId, 'string', 'ruleId is a string');
+      assert.ok(ruleId.length > 0, 'ruleId is non-empty');
+      assert.match(ruleId, /^[A-Z][A-Z0-9_]+$/, `ruleId "${ruleId}" must be SCREAMING_SNAKE_CASE`);
+    }
+
+    // 2. Evaluated state snapshot: the audit entry captures origin and ticketId
+    //    which represents the evaluated state at decision time
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].decision, 'deny');
+    assert.equal(audited[0].ticketId, 'GH-R18-1', 'audit captures ticketId (state snapshot)');
+    assert.equal(audited[0].origin, 'workflow', 'audit captures origin (state snapshot)');
+    assert.ok(
+      Array.isArray(audited[0].reasons) && audited[0].reasons.length > 0,
+      'audit reasons populated for state snapshot'
+    );
+
+    // 3. Concrete fix steps: remediation array with actionable strings
+    assert.ok(Array.isArray(result.remediation), 'remediation is an array');
+    assert.ok(result.remediation.length > 0, 'remediation has at least one step');
+    for (const step of result.remediation) {
+      assert.equal(typeof step, 'string', 'each remediation step is a string');
+      assert.ok(step.length > 0, 'remediation step is non-empty');
+    }
+    // Remediation must mention the offending task and the missing dependency
+    const allRemediation = result.remediation.join(' ');
+    assert.ok(
+      allRemediation.includes('99') || allRemediation.includes('Task 99'),
+      'remediation must reference the missing dependency (99)'
+    );
+  });
+
+  it('DEPENDENCY_NOT_READY deny includes ruleId, state snapshot, and concrete remediation', () => {
+    const ctx = {
+      ticketId: 'GH-R18-2',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      hasWorkflow: true,
+    };
+
+    const audited = [];
+    const result = runPreflight(ctx, {
+      checks: [createClaimCheck({ taskNum: 2, ownerId: 'PR1' })],
+      audit: (e) => audited.push(e),
+    });
+
+    // ruleId
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('DEPENDENCY_NOT_READY'));
+
+    // State snapshot in audit
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].ticketId, 'GH-R18-2');
+    assert.equal(audited[0].origin, 'workflow');
+
+    // Concrete remediation
+    assert.ok(result.remediation.length >= 2, 'at least 2 remediation steps for dependency issue');
+    const allRemediation = result.remediation.join(' ');
+    assert.ok(
+      allRemediation.includes('Task 1') || allRemediation.includes('task 1'),
+      'remediation must reference the blocking dependency (Task 1)'
+    );
+    assert.ok(
+      allRemediation.toLowerCase().includes('complete') || allRemediation.toLowerCase().includes('canstart'),
+      'remediation must suggest completing the dependency or checking canStart'
+    );
+  });
+
+  it('UNCLAIMED_TASK_WRITE deny includes ruleId, and remediation mentions claimTask', () => {
+    const ctx = {
+      ticketId: 'GH-R18-3',
+      origin: 'workflow',
+      error: null,
+      tasks: [{ num: 1, dependencies: [] }],
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 1,
+          currentTaskIndex: 0,
+          tasks: [{ id: 'task_1', status: 'pending', dependencies: [] }],
+        },
+      },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, {
+      checks: [createClaimCheck({ taskNum: 1 })], // no ownerId = unclaimed
+    });
+
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('UNCLAIMED_TASK_WRITE'));
+    assert.ok(result.remediation.length > 0);
+    assert.ok(
+      result.remediation.some((r) => r.toLowerCase().includes('claim')),
+      'remediation must mention claiming the task'
+    );
+  });
+
+  it('PATH_NOT_ALLOWED deny includes ruleId and remediation with allowed path guidance', () => {
+    const ctx = {
+      ticketId: 'GH-R18-4',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, {
+      checks: [
+        createPathCheck({
+          filePath: '/unauthorized/path/file.js',
+          allowedPaths: {
+            prDir: '/tasks/GH-R18-4/PR1',
+            taskDir: '/tasks/GH-R18-4/task1',
+            ticketRoot: '/tasks/GH-R18-4',
+          },
+        }),
+      ],
+    });
+
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('PATH_NOT_ALLOWED'));
+    assert.ok(result.remediation.length >= 2, 'path denial needs multiple remediation steps');
+    const allRemediation = result.remediation.join(' ');
+    assert.ok(
+      allRemediation.includes('PR{N}') || allRemediation.includes('task${N}'),
+      'remediation must describe the allowed path patterns'
+    );
+  });
+
+  it('DEPENDENCY_CYCLE deny includes ruleId and remediation mentioning how to break the cycle', () => {
+    const ctx = {
+      ticketId: 'GH-R18-5',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [2] },
+        { num: 2, dependencies: [1] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const audited = [];
+    const result = runPreflight(ctx, {
+      checks: [createGraphCheck()],
+      audit: (e) => audited.push(e),
+    });
+
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('DEPENDENCY_CYCLE'));
+
+    // Audit captures state snapshot
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].ticketId, 'GH-R18-5');
+
+    // Remediation is actionable
+    assert.ok(result.remediation.length > 0);
+    const allRemediation = result.remediation.join(' ');
+    assert.ok(
+      allRemediation.toLowerCase().includes('cycle') || allRemediation.toLowerCase().includes('break'),
+      'cycle remediation must suggest breaking the cycle'
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R16 — Legacy ticket fixture (pre-IDEA2 backward compat)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — legacy ticket fixture without dependencies field (R16)', () => {
+  it('preflight allows legacy tasksMeta (no dependencies field) with claim check', () => {
+    const ctx = {
+      ticketId: 'LEGACY-INT-1',
+      origin: 'workflow',
+      error: null,
+      tasks: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 3,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending' }, // no dependencies field
+            { id: 'task_2', status: 'pending' },
+            { id: 'task_3', status: 'pending' },
+          ],
+        },
+      },
+      hasWorkflow: true,
+    };
+
+    // Legacy mode: claim check with taskNum=1 and ownerId should pass
+    // because there are no dependencies to block
+    const check = createClaimCheck({ taskNum: 1, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, true, 'legacy task without dependencies field must allow (R16)');
+  });
+
+  it('graph check passes when tasks is null (no graph to validate — legacy mode)', () => {
+    const ctx = {
+      ticketId: 'LEGACY-INT-2',
+      origin: 'workflow',
+      error: null,
+      tasks: null,
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, true, 'null tasks means no graph to validate — legacy allow');
+  });
+
+  it('claim check passes when state has no tasksMeta (legacy mode, R16)', () => {
+    const ctx = {
+      ticketId: 'LEGACY-INT-3',
+      origin: 'workflow',
+      error: null,
+      tasks: null,
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const check = createClaimCheck({ taskNum: 1, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, true, 'no tasksMeta = legacy mode, allow (R16)');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R20 — Composed error: multiple failures aggregate
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — composed multi-failure aggregation (R20)', () => {
+  it('context error + graph error + unclaimed write = all reasons aggregated', () => {
+    const ctx = {
+      ticketId: 'GH-INT-MULTI',
+      origin: null,
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: 'subtask flag without state',
+        remediation: ['Remove --subtask flag'],
+      },
+      tasks: [
+        { num: 1, dependencies: [1] }, // self-dep
+      ],
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 1,
+          currentTaskIndex: 0,
+          tasks: [{ id: 'task_1', status: 'pending', dependencies: [1] }],
+        },
+      },
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 1 }), // no ownerId
+    ];
+
+    const result = runPreflight(ctx, { checks });
+
+    assert.equal(result.allow, false);
+    // Should have at least 3 distinct reasons: AMBIGUOUS_SUBTASK + SELF_DEPENDENCY + UNCLAIMED_TASK_WRITE
+    assert.ok(
+      result.reasons.length >= 3,
+      `expected >= 3 reasons, got ${result.reasons.length}: ${JSON.stringify(result.reasons)}`
+    );
+    assert.ok(result.reasons.includes('AMBIGUOUS_SUBTASK'));
+    assert.ok(result.reasons.includes('SELF_DEPENDENCY'));
+    assert.ok(result.reasons.includes('UNCLAIMED_TASK_WRITE'));
+
+    // All remediation steps aggregated
+    assert.ok(
+      result.remediation.length >= 3,
+      'aggregated remediation from all deny sources'
+    );
+  });
+});

--- a/workflows/lib/__tests__/preflight.test.js
+++ b/workflows/lib/__tests__/preflight.test.js
@@ -1,0 +1,563 @@
+/**
+ * Tests for workflows/lib/preflight.js
+ *
+ * IDEA2 / GH-219 — Task 3: Preflight library with audit hook.
+ *
+ * Requirements covered:
+ *   R12 — Single `runPreflight(context, { audit, checks })` surface returning
+ *         `{ allow, reasons, remediation }`; hooks consume; `audit` optional
+ *         no-op in tests (spec §Pattern — preflight).
+ *   R13 — Wiring contract only — persistence lives in Task 1's
+ *         `appendEnforcementAudit`. Preflight MUST NOT import `work-actions.js`
+ *         to keep coupling low; callers inject the audit callback.
+ *
+ * Context shape contract (from Task 2, `workflows/work/work-enforcement-context.js`):
+ *   EnforcementContext = {
+ *     ticketId, origin, state, tasks, subtaskState, hasWorkflow, error, options
+ *   }
+ *   EnforcementContextError = { code, message, remediation[] }
+ *
+ * Run: node --test workflows/lib/__tests__/preflight.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const MODULE_PATH = path.join(__dirname, '..', 'preflight');
+
+// ─── R12 — Module surface / exports ─────────────────────────────────────────
+
+describe('preflight — module surface (R12)', () => {
+  it('exports runPreflight as a function', () => {
+    const mod = require(MODULE_PATH);
+    assert.equal(typeof mod.runPreflight, 'function', 'runPreflight must be exported as a function');
+  });
+
+  it('runPreflight has arity 2 (context, options) per the documented contract', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.equal(
+      runPreflight.length,
+      2,
+      'runPreflight(context, options) must have exactly 2 declared parameters'
+    );
+  });
+
+  it('has a stable public export shape (runPreflight only — no leaks of internals)', () => {
+    const mod = require(MODULE_PATH);
+    const exported = Object.keys(mod).sort();
+
+    // Snapshot: the public API for Task 3 is `runPreflight`. Later tasks
+    // (#12 — path predicate) may add more, but this test locks the initial
+    // contract so downstream tasks can't accidentally rely on private helpers.
+    assert.deepEqual(
+      exported,
+      ['runPreflight'],
+      `preflight module must export only { runPreflight } at Task 3; got: ${exported.join(', ')}`
+    );
+  });
+
+  it('does NOT import work-actions.js (keeps preflight / persistence decoupled — R13)', () => {
+    // Load preflight fresh and introspect module.children to verify no
+    // transitive dependency on work-actions. This enforces the "do NOT import
+    // work-actions.js" rule in the Task 3 spec.
+    delete require.cache[require.resolve(MODULE_PATH)];
+    require(MODULE_PATH);
+    const loaded = require.cache[require.resolve(MODULE_PATH)];
+    const childIds = (loaded.children || []).map((c) => c.id);
+
+    for (const id of childIds) {
+      assert.ok(
+        !/work-actions(\.js)?$/.test(id),
+        `preflight must not require work-actions (found: ${id}). ` +
+          'Audit persistence is injected by callers via options.audit.'
+      );
+    }
+  });
+});
+
+// ─── R12 — Happy path (empty context, no checks) ────────────────────────────
+
+describe('preflight — empty context / happy path (R12)', () => {
+  it('returns { allow: true, reasons: [], remediation: [] } when context has no error and no checks', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const ctx = { ticketId: 'GH-1', origin: 'user', error: null };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, true, 'empty/valid context allows by default (spec §Preflight API)');
+    assert.deepEqual(result.reasons, [], 'no reasons on allow path');
+    assert.deepEqual(result.remediation, [], 'no remediation on allow path');
+  });
+
+  it('returns the full { allow, reasons, remediation } shape on every call', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null });
+
+    assert.ok('allow' in result, 'result.allow key present');
+    assert.ok('reasons' in result, 'result.reasons key present');
+    assert.ok('remediation' in result, 'result.remediation key present');
+    assert.equal(typeof result.allow, 'boolean', 'allow is a boolean');
+    assert.ok(Array.isArray(result.reasons), 'reasons is an array');
+    assert.ok(Array.isArray(result.remediation), 'remediation is an array');
+  });
+
+  it('does not throw when options is undefined (arity-2 default)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null });
+    }, 'runPreflight must be callable with just a context argument');
+  });
+
+  it('does not throw when options is {} (empty options object)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, {});
+    }, 'runPreflight must accept an empty options object');
+  });
+});
+
+// ─── R12 — context.error denies fail-closed ─────────────────────────────────
+
+describe('preflight — context.error denial (R12, R15 chain)', () => {
+  it('context.error with code → allow: false, reasons: [error.code]', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'user',
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: '--subtask set but no subtask state',
+        remediation: ['Initialize subtask first', 'Remove --subtask flag'],
+      },
+    };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, false, 'context.error must force deny');
+    assert.deepEqual(
+      result.reasons,
+      ['AMBIGUOUS_SUBTASK'],
+      'reasons carries the error.code as a stable rule id'
+    );
+    assert.deepEqual(
+      result.remediation,
+      ['Initialize subtask first', 'Remove --subtask flag'],
+      'error.remediation is passed through verbatim'
+    );
+  });
+
+  it('context.error without remediation → remediation defaults to [] (never undefined)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'user',
+      error: { code: 'INVALID_TICKET_ID', message: 'bad id' },
+    };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, false);
+    assert.deepEqual(result.reasons, ['INVALID_TICKET_ID']);
+    assert.ok(Array.isArray(result.remediation), 'remediation is always an array');
+    assert.deepEqual(result.remediation, [], 'missing remediation becomes []');
+  });
+
+  it('truthy non-object error value is ignored (must be an object with a code)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    // Guard: strings/numbers for error should NOT trigger deny — spec says
+    // "truthy object with code". This enforces the shape discipline.
+    for (const bad of ['string-error', 42, true]) {
+      const ctx = { ticketId: 'GH-1', origin: 'user', error: bad };
+      const result = runPreflight(ctx);
+      assert.equal(
+        result.allow,
+        true,
+        `non-object error=${JSON.stringify(bad)} must not force deny`
+      );
+    }
+  });
+
+  it('error object without a code is ignored (no denial, no crash)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const ctx = { ticketId: 'GH-1', origin: 'user', error: { message: 'no code here' } };
+    const result = runPreflight(ctx);
+    assert.equal(result.allow, true, 'error lacking a stable code must not deny');
+    assert.deepEqual(result.reasons, []);
+    assert.deepEqual(result.remediation, []);
+  });
+});
+
+// ─── R12 — audit default no-op (undefined-safe) ─────────────────────────────
+
+describe('preflight — audit default no-op (R12)', () => {
+  it('does not throw when options.audit is undefined on allow path', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, {});
+    });
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null });
+    });
+  });
+
+  it('does not throw when options.audit is undefined on deny path', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight(
+        {
+          ticketId: 'GH-1',
+          origin: 'user',
+          error: { code: 'X', message: 'y', remediation: [] },
+        },
+        {}
+      );
+    });
+  });
+
+  it('does not throw when options itself is null', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, null);
+    });
+  });
+});
+
+// ─── R12 — audit called on ALLOW path with correct entry shape ──────────────
+
+describe('preflight — audit called on ALLOW path (R12)', () => {
+  it('invokes audit with { decision: "allow", reasons: [], origin, ticketId } on happy path', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const audit = (entry) => audited.push(entry);
+
+    const ctx = { ticketId: 'GH-42', origin: 'workflow', error: null };
+    const result = runPreflight(ctx, { audit });
+
+    assert.equal(result.allow, true);
+    assert.equal(audited.length, 1, 'audit should be called exactly once per decision');
+
+    const entry = audited[0];
+    assert.equal(entry.decision, 'allow', 'allow path uses decision="allow"');
+    assert.deepEqual(entry.reasons, [], 'empty reasons on allow');
+    assert.equal(entry.origin, 'workflow', 'audit entry echoes context.origin');
+    assert.equal(entry.ticketId, 'GH-42', 'audit entry echoes context.ticketId');
+  });
+
+  it('audit entry is a plain object (single positional arg) — stable callback signature', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    let receivedArgs;
+    const audit = function (...args) {
+      receivedArgs = args;
+    };
+
+    runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { audit });
+
+    assert.ok(receivedArgs, 'audit should have been invoked');
+    assert.equal(receivedArgs.length, 1, 'audit takes exactly one positional argument');
+    assert.equal(
+      typeof receivedArgs[0],
+      'object',
+      'audit argument is an object (compatible with appendEnforcementAudit entry shape)'
+    );
+    assert.ok(receivedArgs[0] !== null, 'audit argument is not null');
+  });
+
+  it('audit entry shape is compatible with appendEnforcementAudit (forward-compatible fields)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    runPreflight(
+      { ticketId: 'GH-42', origin: 'workflow', error: null },
+      { audit: (e) => audited.push(e) }
+    );
+
+    const entry = audited[0];
+    // Brief-required fields on enforcement audit records (Task 1 shape).
+    // Preflight produces a superset-compatible entry that callers can
+    // forward directly to appendEnforcementAudit.
+    for (const key of ['decision', 'reasons', 'origin', 'ticketId']) {
+      assert.ok(
+        key in entry,
+        `audit entry must include "${key}" for forward-compat with appendEnforcementAudit`
+      );
+    }
+  });
+});
+
+// ─── R12 — audit called on DENY path ────────────────────────────────────────
+
+describe('preflight — audit called on DENY path (R12)', () => {
+  it('invokes audit with { decision: "deny", reasons, origin, ticketId } when context.error denies', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const audit = (entry) => audited.push(entry);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'user',
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: 'oops',
+        remediation: ['fix step 1'],
+      },
+    };
+
+    const result = runPreflight(ctx, { audit });
+
+    assert.equal(result.allow, false);
+    assert.equal(audited.length, 1, 'audit called once for the deny decision');
+
+    const entry = audited[0];
+    assert.equal(entry.decision, 'deny');
+    assert.deepEqual(entry.reasons, ['AMBIGUOUS_SUBTASK']);
+    assert.equal(entry.origin, 'user');
+    assert.equal(entry.ticketId, 'GH-219');
+  });
+
+  it('deny audit entry preserves remediation for downstream explainability (R18 seed)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    let seen;
+    runPreflight(
+      {
+        ticketId: 'GH-219',
+        origin: 'user',
+        error: {
+          code: 'INVALID_TICKET_ID',
+          message: 'bad',
+          remediation: ['Use a valid id', 'Check env vars'],
+        },
+      },
+      { audit: (e) => (seen = e) }
+    );
+
+    assert.ok(seen, 'audit called on deny');
+    assert.ok(
+      Array.isArray(seen.remediation) && seen.remediation.length === 2,
+      'remediation is forwarded to audit entry for explainability'
+    );
+  });
+
+  it('preflight does not throw when the audit callback itself throws (fail-open on logging)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const throwingAudit = () => {
+      throw new Error('disk full');
+    };
+
+    // Persistence failures must never break enforcement decisions. This
+    // mirrors work-actions.js appendRow() fail-open behavior.
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { audit: throwingAudit });
+    });
+    assert.doesNotThrow(() => {
+      runPreflight(
+        { ticketId: 'GH-1', origin: 'user', error: { code: 'X', message: 'y' } },
+        { audit: throwingAudit }
+      );
+    });
+  });
+});
+
+// ─── R12 — options.checks pluggable composition ─────────────────────────────
+
+describe('preflight — pluggable checks (R12, §Pattern — pluggable checks)', () => {
+  it('runs checks in declared order', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const callOrder = [];
+
+    const checks = [
+      (ctx) => {
+        callOrder.push('A');
+        return null;
+      },
+      (ctx) => {
+        callOrder.push('B');
+        return null;
+      },
+      (ctx) => {
+        callOrder.push('C');
+        return null;
+      },
+    ];
+
+    runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+    assert.deepEqual(callOrder, ['A', 'B', 'C'], 'checks invoked in declared order');
+  });
+
+  it('all checks returning null/allow → final result is allow with empty reasons', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => null,
+      () => ({ allow: true }),
+      () => ({ allow: true, reasons: [], remediation: [] }),
+    ];
+
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, true);
+    assert.deepEqual(result.reasons, []);
+    assert.deepEqual(result.remediation, []);
+  });
+
+  it('one check returning { allow: false, ... } → deny result', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => null,
+      () => ({ allow: false, reasons: ['RULE_X'], remediation: ['fix x'] }),
+    ];
+
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, false, 'any denying check forces deny');
+    assert.ok(result.reasons.includes('RULE_X'), 'reason from denying check is included');
+    assert.ok(result.remediation.includes('fix x'), 'remediation from denying check is merged');
+  });
+
+  it('multiple denying checks → reasons aggregated, remediation merged', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => ({ allow: false, reasons: ['RULE_A'], remediation: ['fix A'] }),
+      () => ({ allow: false, reasons: ['RULE_B'], remediation: ['fix B', 'also fix B2'] }),
+    ];
+
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('RULE_A'), 'first denying check reason present');
+    assert.ok(result.reasons.includes('RULE_B'), 'second denying check reason present');
+    assert.ok(result.remediation.includes('fix A'));
+    assert.ok(result.remediation.includes('fix B'));
+    assert.ok(result.remediation.includes('also fix B2'));
+  });
+
+  it('checks compose with context.error: error denial is included in final reasons', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'user',
+      error: { code: 'CTX_ERR', message: 'err', remediation: ['ctx fix'] },
+    };
+
+    const checks = [() => ({ allow: false, reasons: ['RULE_Z'], remediation: ['z fix'] })];
+
+    const result = runPreflight(ctx, { checks });
+
+    assert.equal(result.allow, false);
+    assert.ok(
+      result.reasons.includes('CTX_ERR') || result.reasons.includes('RULE_Z'),
+      'at least one deny reason present (context error + checks compose)'
+    );
+  });
+
+  it('check returning undefined is treated as "no opinion" (allow passthrough)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [() => undefined, () => ({ allow: true })];
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, true, 'undefined/null check results are benign (spec §pluggable)');
+    assert.deepEqual(result.reasons, []);
+  });
+
+  it('check throwing does not crash preflight (isolated check failure)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => {
+        throw new Error('check crashed');
+      },
+      () => ({ allow: true }),
+    ];
+
+    // A single check should not poison the whole pipeline. Fail-closed on
+    // the crashing check (treat as deny with a synthetic reason) is
+    // acceptable; what matters is we never throw out of runPreflight.
+    let result;
+    assert.doesNotThrow(() => {
+      result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+    });
+    assert.ok(result, 'result returned even when a check threw');
+    assert.equal(typeof result.allow, 'boolean');
+  });
+
+  it('checks receive the full context as their sole argument', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    let seenContext;
+    const checks = [
+      (ctx) => {
+        seenContext = ctx;
+        return null;
+      },
+    ];
+
+    const inputCtx = {
+      ticketId: 'GH-99',
+      origin: 'ai-subtask',
+      state: { status: 'in_progress' },
+      tasks: [{ id: 'task_1', num: 1 }],
+      subtaskState: null,
+      hasWorkflow: true,
+      error: null,
+      options: { subtask: true },
+    };
+
+    runPreflight(inputCtx, { checks });
+
+    assert.ok(seenContext, 'check was invoked with a context');
+    assert.equal(seenContext.ticketId, 'GH-99', 'checks receive full context.ticketId');
+    assert.equal(seenContext.origin, 'ai-subtask', 'checks receive full context.origin');
+    assert.equal(seenContext.hasWorkflow, true, 'checks receive full context.hasWorkflow');
+  });
+});
+
+// ─── R12 — audit receives final decision shape after checks compose ─────────
+
+describe('preflight — audit integration with checks', () => {
+  it('audit called once with final aggregated reasons after checks compose (deny path)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const audit = (e) => audited.push(e);
+
+    const checks = [
+      () => ({ allow: false, reasons: ['RULE_A'], remediation: ['fix A'] }),
+      () => ({ allow: false, reasons: ['RULE_B'], remediation: ['fix B'] }),
+    ];
+
+    runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks, audit });
+
+    assert.equal(audited.length, 1, 'audit invoked once per runPreflight call');
+    assert.equal(audited[0].decision, 'deny');
+    assert.ok(audited[0].reasons.includes('RULE_A'));
+    assert.ok(audited[0].reasons.includes('RULE_B'));
+  });
+
+  it('audit called with decision="allow" when all checks allow', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const checks = [() => ({ allow: true }), () => null];
+
+    runPreflight(
+      { ticketId: 'GH-1', origin: 'user', error: null },
+      { checks, audit: (e) => audited.push(e) }
+    );
+
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].decision, 'allow');
+    assert.deepEqual(audited[0].reasons, []);
+  });
+});

--- a/workflows/lib/__tests__/preflight.test.js
+++ b/workflows/lib/__tests__/preflight.test.js
@@ -43,17 +43,17 @@ describe('preflight — module surface (R12)', () => {
     );
   });
 
-  it('has a stable public export shape (runPreflight only — no leaks of internals)', () => {
+  it('has a stable public export shape (Task 12 adds isWriteAllowedPath)', () => {
     const mod = require(MODULE_PATH);
     const exported = Object.keys(mod).sort();
 
-    // Snapshot: the public API for Task 3 is `runPreflight`. Later tasks
-    // (#12 — path predicate) may add more, but this test locks the initial
-    // contract so downstream tasks can't accidentally rely on private helpers.
+    // Task 3 exported only `runPreflight`. Task 12 adds `isWriteAllowedPath`
+    // as the shared path predicate consumed by hooks (Tasks 13-14).
+    // Also adds built-in check factories: `createGraphCheck`, `createClaimCheck`, `createPathCheck`.
     assert.deepEqual(
       exported,
-      ['runPreflight'],
-      `preflight module must export only { runPreflight } at Task 3; got: ${exported.join(', ')}`
+      ['createClaimCheck', 'createGraphCheck', 'createPathCheck', 'isWriteAllowedPath', 'runPreflight'],
+      `preflight module must export { createClaimCheck, createGraphCheck, createPathCheck, isWriteAllowedPath, runPreflight }; got: ${exported.join(', ')}`
     );
   });
 
@@ -559,5 +559,766 @@ describe('preflight — audit integration with checks', () => {
     assert.equal(audited.length, 1);
     assert.equal(audited[0].decision, 'allow');
     assert.deepEqual(audited[0].reasons, []);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Task 12 — Preflight rules integration (graph, claim, paths)
+//
+// Requirements covered:
+//   R3  — Dependency readiness via canStart
+//   R4  — Graph validation (unknown deps, cycles, self-deps)
+//   R6  — Task-readiness edit gate (isWriteAllowedPath)
+//   R12 — Shared preflight library
+//   R13 — Audit on each decision
+//   R15 — Sanitized paths, fail closed
+//   R18 — Remediation text with ruleId
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ─── 12.1 — isWriteAllowedPath export and behavior (R6, R12) ────────────────
+
+describe('preflight — isWriteAllowedPath export (R6, R12)', () => {
+  it('exports isWriteAllowedPath as a function', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    assert.equal(typeof isWriteAllowedPath, 'function', 'isWriteAllowedPath must be exported');
+  });
+
+  it('isWriteAllowedPath has arity 2 (filePath, allowedPaths)', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    assert.equal(isWriteAllowedPath.length, 2, 'isWriteAllowedPath(filePath, allowedPaths) needs 2 params');
+  });
+});
+
+describe('preflight — isWriteAllowedPath: PR{N}/ paths (R6)', () => {
+  it('allows paths under the claiming worker PR{N}/ directory', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/src/index.js', allowed),
+      true,
+      'files under PR{N}/ are allowed'
+    );
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/deep/nested/file.ts', allowed),
+      true,
+      'deeply nested files under PR{N}/ are allowed'
+    );
+  });
+
+  it('denies paths under a different PR slot', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR2/src/file.js', allowed),
+      false,
+      'files under a different PR slot must be denied'
+    );
+  });
+});
+
+describe('preflight — isWriteAllowedPath: task${N}/ paths (R6)', () => {
+  it('allows paths under the claimed task directory', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/task3/implement.md', allowed),
+      true,
+      'task artifact files under task${N}/ are allowed'
+    );
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/task3/tdd-phase.json', allowed),
+      true,
+      'tdd-phase.json under task${N}/ is allowed'
+    );
+  });
+
+  it('denies paths under a different task directory', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/task5/implement.md', allowed),
+      false,
+      'files under a different task directory must be denied'
+    );
+  });
+});
+
+describe('preflight — isWriteAllowedPath: shared-root whitelist (R6)', () => {
+  it('allows brief.md at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/brief.md', allowed),
+      true,
+      'brief.md at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows spec.md at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/spec.md', allowed),
+      true,
+      'spec.md at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows tasks.md at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/tasks.md', allowed),
+      true,
+      'tasks.md at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows .work-state.json at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/.work-state.json', allowed),
+      true,
+      '.work-state.json at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows .work-actions.json at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/.work-actions.json', allowed),
+      true,
+      '.work-actions.json at ticket root is in the shared whitelist'
+    );
+  });
+});
+
+describe('preflight — isWriteAllowedPath: denied paths (R6, R15)', () => {
+  it('denies arbitrary paths outside allowed set', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/some/random/file.js', allowed),
+      false,
+      'arbitrary paths outside PR{N}/, task${N}/, and whitelist are denied'
+    );
+  });
+
+  it('denies files at ticket root that are not in the whitelist', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/random-file.txt', allowed),
+      false,
+      'non-whitelisted files at ticket root are denied'
+    );
+  });
+
+  it('denies paths that are path-traversal attempts from ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/../GH-220/task1/file.js', allowed),
+      false,
+      'path traversal attempts are denied (R15)'
+    );
+  });
+
+  it('returns false (fail closed) when allowedPaths is missing fields', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/file.js', {}),
+      false,
+      'missing allowedPaths fields must fail closed'
+    );
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/file.js', null),
+      false,
+      'null allowedPaths must fail closed'
+    );
+  });
+});
+
+// ─── 12.2 — createGraphCheck (R4 — graph validation) ────────────────────────
+
+describe('preflight — createGraphCheck (R4 — graph validation)', () => {
+  it('exports createGraphCheck as a function', () => {
+    const { createGraphCheck } = require(MODULE_PATH);
+    assert.equal(typeof createGraphCheck, 'function');
+  });
+
+  it('returns a check function', () => {
+    const { createGraphCheck } = require(MODULE_PATH);
+    const check = createGraphCheck();
+    assert.equal(typeof check, 'function');
+  });
+
+  it('allows when context has no tasks (no graph to validate)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = { ticketId: 'GH-1', origin: 'workflow', error: null, tasks: null };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, true, 'null tasks means no graph to validate; allow');
+  });
+
+  it('allows when tasks have a valid graph (no errors)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, true, 'valid graph passes');
+  });
+
+  it('denies when tasks have an unknown dependency (R4)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [99] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false, 'unknown dependency denies');
+    assert.ok(
+      result.reasons.some((r) => r === 'UNKNOWN_DEPENDENCY'),
+      'reason includes UNKNOWN_DEPENDENCY ruleId (R18)'
+    );
+    assert.ok(result.remediation.length > 0, 'remediation text is present (R18)');
+  });
+
+  it('denies when tasks have a self-dependency (R4)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [1] },
+        { num: 2, dependencies: [] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false, 'self-dependency denies');
+    assert.ok(
+      result.reasons.some((r) => r === 'SELF_DEPENDENCY'),
+      'reason includes SELF_DEPENDENCY ruleId'
+    );
+  });
+
+  it('denies when tasks have a cycle (R4)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [2] },
+        { num: 2, dependencies: [1] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false, 'cycle denies');
+    assert.ok(
+      result.reasons.some((r) => r === 'DEPENDENCY_CYCLE'),
+      'reason includes DEPENDENCY_CYCLE ruleId'
+    );
+  });
+
+  it('remediation on graph deny includes the ruleId for explainability (R18)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [99] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false);
+    // Each reason string IS the ruleId
+    for (const reason of result.reasons) {
+      assert.equal(typeof reason, 'string');
+      assert.ok(reason.length > 0, 'reason/ruleId is non-empty');
+    }
+  });
+});
+
+// ─── 12.3 — createClaimCheck (R3, R6 — dependency readiness + claim) ─────────
+
+describe('preflight — createClaimCheck (R3, R6 — unclaimed task write)', () => {
+  it('exports createClaimCheck as a function', () => {
+    const { createClaimCheck } = require(MODULE_PATH);
+    assert.equal(typeof createClaimCheck, 'function');
+  });
+
+  it('denies when taskNum is provided but no claim info (unclaimed write)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 3,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+            { id: 'task_3', status: 'pending', dependencies: [2] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+        { num: 3, dependencies: [2] },
+      ],
+      hasWorkflow: true,
+    };
+
+    // No claim: taskNum=2 but ownerId not provided
+    const check = createClaimCheck({ taskNum: 2 });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, false, 'unclaimed task write denied');
+    assert.ok(
+      result.reasons.some((r) => r === 'UNCLAIMED_TASK_WRITE'),
+      'reason includes UNCLAIMED_TASK_WRITE ruleId'
+    );
+    assert.ok(result.remediation.length > 0, 'remediation present');
+  });
+
+  it('allows when taskNum and ownerId are provided and task is startable (R3)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const check = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, true, 'claimed task with ready deps allows');
+  });
+
+  it('denies when task dependencies are not satisfied (R3)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 3,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+            { id: 'task_3', status: 'pending', dependencies: [2] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+        { num: 3, dependencies: [2] },
+      ],
+      hasWorkflow: true,
+    };
+
+    // Task 2 depends on Task 1, which is still pending
+    const check = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, false, 'task with unsatisfied deps denied');
+    assert.ok(
+      result.reasons.some((r) => r === 'DEPENDENCY_NOT_READY'),
+      'reason includes DEPENDENCY_NOT_READY ruleId'
+    );
+  });
+
+  it('allows when no tasksMeta exists (legacy/pre-IDEA2 — R16 backward compat)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      state: { status: 'in_progress' },
+      tasks: null,
+      hasWorkflow: true,
+    };
+
+    // No tasksMeta = legacy mode, no claim enforcement
+    const check = createClaimCheck({});
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, true, 'legacy mode without tasksMeta allows (R16)');
+  });
+});
+
+// ─── 12.4 — createPathCheck (R6 — task-readiness edit gate) ──────────────────
+
+describe('preflight — createPathCheck (R6 — path intent check)', () => {
+  it('exports createPathCheck as a function', () => {
+    const { createPathCheck } = require(MODULE_PATH);
+    assert.equal(typeof createPathCheck, 'function');
+  });
+
+  it('allows writes to PR{N}/ for the claiming worker', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const check = createPathCheck({
+      filePath: '/tasks/GH-219/PR1/src/index.js',
+      allowedPaths: {
+        prDir: '/tasks/GH-219/PR1',
+        taskDir: '/tasks/GH-219/task3',
+        ticketRoot: '/tasks/GH-219',
+      },
+    });
+
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, true, 'writes to PR{N}/ are allowed');
+  });
+
+  it('denies writes outside the allowed set', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const check = createPathCheck({
+      filePath: '/some/other/repo/file.js',
+      allowedPaths: {
+        prDir: '/tasks/GH-219/PR1',
+        taskDir: '/tasks/GH-219/task3',
+        ticketRoot: '/tasks/GH-219',
+      },
+    });
+
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, false, 'writes outside allowed paths denied');
+    assert.ok(
+      result.reasons.some((r) => r === 'PATH_NOT_ALLOWED'),
+      'reason includes PATH_NOT_ALLOWED ruleId'
+    );
+  });
+
+  it('allows writes to shared-root whitelist files at ticket root', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    for (const file of ['brief.md', 'spec.md', 'tasks.md', '.work-state.json', '.work-actions.json']) {
+      const check = createPathCheck({
+        filePath: `/tasks/GH-219/${file}`,
+        allowedPaths: {
+          prDir: '/tasks/GH-219/PR1',
+          taskDir: '/tasks/GH-219/task3',
+          ticketRoot: '/tasks/GH-219',
+        },
+      });
+
+      const result = runPreflight(ctx, { checks: [check] });
+      assert.equal(result.allow, true, `shared-root whitelist file ${file} is allowed`);
+    }
+  });
+
+  it('skips path check when no filePath is provided (no path intent to validate)', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const check = createPathCheck({
+      allowedPaths: {
+        prDir: '/tasks/GH-219/PR1',
+        taskDir: '/tasks/GH-219/task3',
+        ticketRoot: '/tasks/GH-219',
+      },
+    });
+
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, true, 'no filePath means no path to deny');
+  });
+});
+
+// ─── 12.5 — Full preflight composition (happy path + deny) ──────────────────
+
+describe('preflight — full composition: graph + claim + path (R3, R4, R6)', () => {
+  it('happy path: valid graph, claimed task, matching paths → allow', () => {
+    const { runPreflight, createGraphCheck, createClaimCheck, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 2, ownerId: 'PR1' }),
+      createPathCheck({
+        filePath: '/tasks/GH-219/PR1/src/main.js',
+        allowedPaths: {
+          prDir: '/tasks/GH-219/PR1',
+          taskDir: '/tasks/GH-219/task2',
+          ticketRoot: '/tasks/GH-219',
+        },
+      }),
+    ];
+
+    const result = runPreflight(ctx, { checks });
+    assert.equal(result.allow, true, 'full composition happy path allows');
+    assert.deepEqual(result.reasons, []);
+  });
+
+  it('audit callback is invoked with full decision on composed happy path', () => {
+    const { runPreflight, createGraphCheck, createClaimCheck, createPathCheck } = require(MODULE_PATH);
+
+    const audited = [];
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 2, ownerId: 'PR1' }),
+    ];
+
+    runPreflight(ctx, { checks, audit: (e) => audited.push(e) });
+
+    assert.equal(audited.length, 1, 'audit called once');
+    assert.equal(audited[0].decision, 'allow');
+    assert.equal(audited[0].ticketId, 'GH-219');
+  });
+
+  it('composed deny: invalid graph + unclaimed → all reasons aggregated', () => {
+    const { runPreflight, createGraphCheck, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [99] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [99] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 1 }), // no ownerId → unclaimed
+    ];
+
+    const result = runPreflight(ctx, { checks });
+
+    assert.equal(result.allow, false, 'composed deny from multiple checks');
+    assert.ok(result.reasons.length >= 2, 'multiple deny reasons aggregated');
+    assert.ok(result.remediation.length > 0, 'aggregated remediation present');
+  });
+
+  it('remediation includes ruleId strings (R18 explainability)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const check = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, false, 'task 2 deps not ready');
+    // R18: every deny reason is a stable ruleId string
+    for (const reason of result.reasons) {
+      assert.equal(typeof reason, 'string', 'reason is a string ruleId');
+      assert.ok(reason.length > 0, 'ruleId is non-empty');
+      // ruleIds are SCREAMING_SNAKE_CASE
+      assert.match(reason, /^[A-Z][A-Z0-9_]+$/, `ruleId "${reason}" is SCREAMING_SNAKE_CASE`);
+    }
   });
 });

--- a/workflows/lib/__tests__/request-index.test.js
+++ b/workflows/lib/__tests__/request-index.test.js
@@ -1,0 +1,226 @@
+/**
+ * Tests for workflows/lib/request-index.js (GH-219 Task 10)
+ *
+ * Coverage:
+ *   - R9:  Out-of-flow user routing — `user-request-${n}` allocation
+ *   - R10: Out-of-flow AI routing — `ai-request-${n}` allocation
+ *   - R11: Persistent `.request-index.json` with collision-safe increments
+ *   - R7:  Allocator completion — wire stubs from Task 9
+ *
+ * Run with: node --test workflows/lib/__tests__/request-index.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function mkTasksBase() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'req-idx-'));
+  const tasksBase = path.join(dir, 'worktrees', 'tasks');
+  fs.mkdirSync(tasksBase, { recursive: true });
+  return { dir, tasksBase };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('request-index', () => {
+  let tmpDir;
+  let tasksBase;
+  let origTasksBase;
+  /** @type {import('../request-index')} */
+  let requestIndex;
+
+  beforeEach(() => {
+    ({ dir: tmpDir, tasksBase } = mkTasksBase());
+    origTasksBase = process.env.TASKS_BASE;
+    process.env.TASKS_BASE = tasksBase;
+    // Fresh require to avoid stale module state
+    requestIndex = require('../request-index');
+  });
+
+  afterEach(() => {
+    if (origTasksBase === undefined) delete process.env.TASKS_BASE;
+    else process.env.TASKS_BASE = origTasksBase;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('API surface', () => {
+    it('exports nextUserRequest, nextAiRequest, and readIndex', () => {
+      assert.strictEqual(typeof requestIndex.nextUserRequest, 'function');
+      assert.strictEqual(typeof requestIndex.nextAiRequest, 'function');
+      assert.strictEqual(typeof requestIndex.readIndex, 'function');
+    });
+  });
+
+  describe('user counter (R9)', () => {
+    it('starts at 1 for the first allocation', () => {
+      const result = requestIndex.nextUserRequest('GH-219');
+      assert.strictEqual(result.seq, 1);
+      assert.strictEqual(result.segment, 'user-request-1');
+      assert.ok(result.root.endsWith(path.join('GH-219', 'user-request-1')));
+    });
+
+    it('increments monotonically on subsequent calls', () => {
+      const r1 = requestIndex.nextUserRequest('GH-219');
+      const r2 = requestIndex.nextUserRequest('GH-219');
+      const r3 = requestIndex.nextUserRequest('GH-219');
+      assert.strictEqual(r1.seq, 1);
+      assert.strictEqual(r2.seq, 2);
+      assert.strictEqual(r3.seq, 3);
+    });
+
+    it('creates the output folder on disk', () => {
+      const result = requestIndex.nextUserRequest('GH-219');
+      assert.ok(fs.existsSync(result.root), `Expected directory to exist: ${result.root}`);
+      assert.ok(fs.statSync(result.root).isDirectory());
+    });
+  });
+
+  describe('AI counter (R10)', () => {
+    it('starts at 1 for the first allocation', () => {
+      const result = requestIndex.nextAiRequest('GH-219');
+      assert.strictEqual(result.seq, 1);
+      assert.strictEqual(result.segment, 'ai-request-1');
+      assert.ok(result.root.endsWith(path.join('GH-219', 'ai-request-1')));
+    });
+
+    it('increments monotonically on subsequent calls', () => {
+      const r1 = requestIndex.nextAiRequest('GH-219');
+      const r2 = requestIndex.nextAiRequest('GH-219');
+      assert.strictEqual(r1.seq, 1);
+      assert.strictEqual(r2.seq, 2);
+    });
+
+    it('creates the output folder on disk', () => {
+      const result = requestIndex.nextAiRequest('GH-219');
+      assert.ok(fs.existsSync(result.root), `Expected directory to exist: ${result.root}`);
+      assert.ok(fs.statSync(result.root).isDirectory());
+    });
+  });
+
+  describe('independent counters (R9 + R10)', () => {
+    it('user and AI counters are independent of each other', () => {
+      const u1 = requestIndex.nextUserRequest('GH-219');
+      const u2 = requestIndex.nextUserRequest('GH-219');
+      const a1 = requestIndex.nextAiRequest('GH-219');
+      const u3 = requestIndex.nextUserRequest('GH-219');
+      const a2 = requestIndex.nextAiRequest('GH-219');
+
+      assert.strictEqual(u1.seq, 1);
+      assert.strictEqual(u2.seq, 2);
+      assert.strictEqual(a1.seq, 1);
+      assert.strictEqual(u3.seq, 3);
+      assert.strictEqual(a2.seq, 2);
+    });
+
+    it('different ticket IDs have independent counters', () => {
+      const a1 = requestIndex.nextUserRequest('GH-100');
+      const b1 = requestIndex.nextUserRequest('GH-200');
+      const a2 = requestIndex.nextUserRequest('GH-100');
+
+      assert.strictEqual(a1.seq, 1);
+      assert.strictEqual(b1.seq, 1);
+      assert.strictEqual(a2.seq, 2);
+    });
+  });
+
+  describe('.request-index.json persistence (R11)', () => {
+    it('persists counters between calls', () => {
+      requestIndex.nextUserRequest('GH-219');
+      requestIndex.nextUserRequest('GH-219');
+      requestIndex.nextAiRequest('GH-219');
+
+      const index = requestIndex.readIndex('GH-219');
+      assert.strictEqual(index.userSeq, 2);
+      assert.strictEqual(index.aiSeq, 1);
+      assert.strictEqual(index.version, 1);
+    });
+
+    it('writes .request-index.json to the ticket directory', () => {
+      requestIndex.nextUserRequest('GH-219');
+      const indexPath = path.join(tasksBase, 'GH-219', '.request-index.json');
+      assert.ok(fs.existsSync(indexPath), `Expected file: ${indexPath}`);
+      const raw = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+      assert.strictEqual(raw.userSeq, 1);
+      assert.strictEqual(raw.aiSeq, 0);
+      assert.strictEqual(raw.version, 1);
+    });
+
+    it('survives a fresh readIndex after writes', () => {
+      requestIndex.nextUserRequest('GH-219');
+      requestIndex.nextAiRequest('GH-219');
+      requestIndex.nextAiRequest('GH-219');
+
+      // Read back
+      const idx = requestIndex.readIndex('GH-219');
+      assert.strictEqual(idx.userSeq, 1);
+      assert.strictEqual(idx.aiSeq, 2);
+    });
+
+    it('returns zero counters when no index file exists', () => {
+      const idx = requestIndex.readIndex('GH-NONEXIST');
+      assert.strictEqual(idx.userSeq, 0);
+      assert.strictEqual(idx.aiSeq, 0);
+      assert.strictEqual(idx.version, 1);
+    });
+  });
+
+  describe('atomic write safety (R11)', () => {
+    it('does not leave partial .request-index.json on disk', () => {
+      // Perform a normal allocation — file should be valid JSON
+      requestIndex.nextUserRequest('GH-219');
+      const indexPath = path.join(tasksBase, 'GH-219', '.request-index.json');
+      const raw = fs.readFileSync(indexPath, 'utf-8');
+      // Should parse cleanly (not truncated or corrupt)
+      const parsed = JSON.parse(raw);
+      assert.strictEqual(typeof parsed.userSeq, 'number');
+      assert.strictEqual(typeof parsed.aiSeq, 'number');
+    });
+
+    it('no .tmp files remain after allocation', () => {
+      requestIndex.nextUserRequest('GH-219');
+      const ticketDir = path.join(tasksBase, 'GH-219');
+      const files = fs.readdirSync(ticketDir);
+      const tmpFiles = files.filter((f) => f.endsWith('.tmp'));
+      assert.strictEqual(tmpFiles.length, 0, `Unexpected .tmp files: ${tmpFiles.join(', ')}`);
+    });
+  });
+
+  describe('simulated concurrency (R11 collision-safe)', () => {
+    it('parallel increments yield strictly increasing sequences', () => {
+      // Simulate rapid sequential calls (true parallelism needs worker_threads,
+      // but sequential calls to the atomic counter must still be strictly increasing)
+      const results = [];
+      for (let i = 0; i < 20; i++) {
+        results.push(requestIndex.nextUserRequest('GH-219'));
+      }
+
+      // Verify strict monotonic increase
+      for (let i = 1; i < results.length; i++) {
+        assert.ok(
+          results[i].seq > results[i - 1].seq,
+          `Sequence not strictly increasing at index ${i}: ${results[i - 1].seq} >= ${results[i].seq}`
+        );
+      }
+      assert.strictEqual(results[results.length - 1].seq, 20);
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects empty ticket ID', () => {
+      assert.throws(() => requestIndex.nextUserRequest(''), /ticket/i);
+    });
+
+    it('rejects null ticket ID', () => {
+      assert.throws(() => requestIndex.nextUserRequest(null), /ticket/i);
+    });
+
+    it('rejects path traversal in ticket ID', () => {
+      assert.throws(() => requestIndex.nextUserRequest('../etc'), /ticket/i);
+    });
+  });
+});

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -1,0 +1,207 @@
+/**
+ * allocate-output-folder.js
+ *
+ * Central allocator for /work-implement destination resolution (GH-219 Task 9).
+ *
+ * Given a ticket ID and context, returns the correct absolute base directory:
+ *
+ *   - In-flow (workflow origin, claimed task): TASKS_BASE/<ticketId>/task${N}/
+ *   - Out-of-flow user:  TASKS_BASE/<ticketId>/user-request-${k}/  (stub -- Task 10 wires counters)
+ *   - Out-of-flow AI:    TASKS_BASE/<ticketId>/ai-request-${k}/    (stub -- Task 10 wires counters)
+ *   - Legacy-root:       TASKS_BASE/<ticketId>/                     (backward-compat fallback)
+ *
+ * R7 single source of truth: the `task${N}` naming is produced exclusively by
+ * taskSegment(). Other modules must consume this rather than rebuilding the
+ * segment string.
+ *
+ * @module allocate-output-folder
+ */
+
+const path = require('path');
+
+// ─── Constants (R7 naming policy) ────────────────────────────────────────────
+
+const TASK_SEGMENT_PREFIX = 'task';
+const USER_REQUEST_PREFIX = 'user-request-';
+const AI_REQUEST_PREFIX = 'ai-request-';
+
+// ─── Ticket ID validation (R15 fail-closed) ─────────────────────────────────
+
+/** @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes */
+const UNSAFE_TICKET_RE = /\.\.|[\\]|\x00/;
+
+/**
+ * Validate and reject unsafe ticket IDs before any filesystem I/O.
+ * @param {unknown} ticketId
+ */
+function validateTicketId(ticketId) {
+  if (typeof ticketId !== 'string' || ticketId.length === 0) {
+    throw new Error(
+      `Invalid ticket ID: expected non-empty string, received ${typeof ticketId === 'string' ? '""' : typeof ticketId}`
+    );
+  }
+  if (UNSAFE_TICKET_RE.test(ticketId)) {
+    throw new Error(
+      `Invalid ticket ID: contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`
+    );
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve TASKS_BASE from environment or config module.
+ * @returns {string}
+ */
+function resolveTasksBase() {
+  // Check process.env directly — callers (hooks, CLI) always set TASKS_BASE.
+  // Do not fall back to config cache: config.TASKS_BASE is set at module-load
+  // time and becomes stale if the env var is later removed (e.g., in tests).
+  if (process.env.TASKS_BASE) return process.env.TASKS_BASE;
+
+  throw new Error(
+    'TASKS_BASE is not configured. Set the TASKS_BASE environment variable.'
+  );
+}
+
+/**
+ * Sanitize ticket ID for filesystem paths using config.safeTicketId when available.
+ * @param {string} ticketId
+ * @returns {string}
+ */
+function sanitizeId(ticketId) {
+  try {
+    const config = require('./config');
+    if (config && typeof config.safeTicketId === 'function') {
+      return config.safeTicketId(ticketId);
+    }
+  } catch {
+    // fallback to raw ID
+  }
+  return ticketId;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Produce the canonical `task${N}` segment name (R7 single source of truth).
+ *
+ * @param {number} taskNum - Positive integer task number
+ * @returns {string} e.g. "task1", "task9", "task42"
+ * @throws {Error} if taskNum is not a positive integer
+ */
+function taskSegment(taskNum) {
+  if (
+    typeof taskNum !== 'number' ||
+    !Number.isInteger(taskNum) ||
+    taskNum < 1
+  ) {
+    throw new Error(
+      `Invalid taskNum: expected positive integer, received ${JSON.stringify(taskNum)}`
+    );
+  }
+  return `${TASK_SEGMENT_PREFIX}${taskNum}`;
+}
+
+/**
+ * @typedef {Object} AllocationResult
+ * @property {'in-flow-task'|'out-of-flow-user'|'out-of-flow-ai'|'legacy-root'} kind
+ * @property {string|null} segment - Directory segment name (e.g. "task9", "user-request-4"), or null for legacy-root
+ * @property {string} root - Absolute path to the allocated directory
+ * @property {string} ticketRoot - Absolute path to the ticket-level directory
+ */
+
+/**
+ * Allocate the correct output folder for a /work-implement invocation.
+ *
+ * @param {string} ticketId - Ticket ID (e.g. "GH-219")
+ * @param {object} [context={}] - Allocation context
+ * @param {string} [context.origin] - Origin type: "workflow", "ai-subtask", "user"
+ * @param {string} [context.flow] - Flow type: "in-flow", "out-of-flow"
+ * @param {number} [context.taskNum] - Task number (required for in-flow)
+ * @param {number} [context.prSlot] - PR slot number (informational)
+ * @param {number} [context.subtaskIndex] - Subtask index
+ * @param {object} [context.counters] - Out-of-flow counters (Task 10 wires these)
+ * @param {number} [context.counters.userRequestNext] - Next user-request counter
+ * @param {number} [context.counters.aiRequestNext] - Next ai-request counter
+ * @returns {AllocationResult}
+ */
+function allocateOutputFolder(ticketId, context = {}) {
+  // R15: validate ticket ID before any I/O
+  validateTicketId(ticketId);
+
+  const tasksBase = resolveTasksBase();
+  const safeId = sanitizeId(ticketId);
+  const ticketRoot = path.join(tasksBase, safeId);
+
+  // ── In-flow task allocation ──────────────────────────────────────────────
+  if (context.flow === 'in-flow') {
+    if (context.taskNum == null) {
+      throw new Error(
+        'In-flow allocation requires taskNum. Pass context.taskNum with the claimed task number.'
+      );
+    }
+    const seg = taskSegment(context.taskNum);
+    return {
+      kind: 'in-flow-task',
+      segment: seg,
+      root: path.join(ticketRoot, seg),
+      ticketRoot,
+    };
+  }
+
+  // ── Out-of-flow allocation ───────────────────────────────────────────────
+  if (context.flow === 'out-of-flow') {
+    const isAi =
+      context.origin === 'ai-subtask' || context.origin === 'ai';
+
+    if (isAi) {
+      if (!context.counters || context.counters.aiRequestNext == null) {
+        throw new Error(
+          'Out-of-flow AI allocation requires counters.aiRequestNext. ' +
+          'Task 10 will wire the real .request-index.json counter.'
+        );
+      }
+      const seg = `${AI_REQUEST_PREFIX}${context.counters.aiRequestNext}`;
+      return {
+        kind: 'out-of-flow-ai',
+        segment: seg,
+        root: path.join(ticketRoot, seg),
+        ticketRoot,
+      };
+    }
+
+    // User origin (default for out-of-flow)
+    if (!context.counters || context.counters.userRequestNext == null) {
+      throw new Error(
+        'Out-of-flow user allocation requires counters.userRequestNext. ' +
+        'Task 10 will wire the real .request-index.json counter.'
+      );
+    }
+    const seg = `${USER_REQUEST_PREFIX}${context.counters.userRequestNext}`;
+    return {
+      kind: 'out-of-flow-user',
+      segment: seg,
+      root: path.join(ticketRoot, seg),
+      ticketRoot,
+    };
+  }
+
+  // ── Legacy-root fallback ─────────────────────────────────────────────────
+  // No flow/task context: return the ticket root directory.
+  // Pairs with tdd-phase-state.js backward-compat legacy read path.
+  return {
+    kind: 'legacy-root',
+    segment: null,
+    root: ticketRoot,
+    ticketRoot,
+  };
+}
+
+module.exports = {
+  allocateOutputFolder,
+  taskSegment,
+  TASK_SEGMENT_PREFIX,
+  USER_REQUEST_PREFIX,
+  AI_REQUEST_PREFIX,
+};

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -1,0 +1,208 @@
+/**
+ * preflight.js
+ *
+ * IDEA2 / GH-219 — Task 3: Shared preflight gate with audit hook.
+ *
+ * `runPreflight(context, options)` is the single evaluation surface consumed
+ * by `workflows/work/hooks/work-require-implement.js` and
+ * `workflows/work-implement/hooks/work-implement-enforce.js`. It returns a
+ * {@link PreflightResult} and invokes an optional {@link PreflightAudit}
+ * callback so enforcement decisions can be persisted to `.work-actions.json`
+ * via `appendEnforcementAudit` (Task 1) WITHOUT this module importing
+ * `work-actions.js` (low coupling; audit is injected by callers).
+ *
+ * The `context` parameter matches the `EnforcementContext` shape returned by
+ * `workflows/work/work-enforcement-context.js` (Task 2). The JSDoc `@param`
+ * below imports that type by name via a TypeScript-compatible `import(...)`
+ * specifier so downstream tooling (tsc in checkJs mode, Cursor/VSCode
+ * IntelliSense) resolves the fields without a runtime require — preflight
+ * remains decoupled from the adapter.
+ *
+ * @module preflight
+ */
+'use strict';
+
+/**
+ * @typedef {import('../work/work-enforcement-context').EnforcementContext} EnforcementContext
+ *
+ * Unified enforcement context composed by `loadEnforcementContext` in
+ * `workflows/work/work-enforcement-context.js` (Task 2). Contains:
+ *   - `ticketId`    {string|null}           sanitized ticket id, null on validation error
+ *   - `origin`      {'workflow'|'ai-subtask'|'user'|null} derived origin
+ *   - `state`       {object|null}           result from `loadState(ticketId)`
+ *   - `tasks`       {object[]|null}         result from `parseTasks(tasksDir)`
+ *   - `subtaskState` {object|null}          active subtask state or null
+ *   - `hasWorkflow` {boolean}               convenience signal
+ *   - `error`       {EnforcementContextError|null} populated on ambiguity / bad id
+ *   - `options`     {object}                echo of caller options
+ */
+
+/**
+ * @typedef {import('../work/work-enforcement-context').EnforcementContextError} EnforcementContextError
+ *
+ * Structured error descriptor attached to `EnforcementContext.error`:
+ *   - `code`        {string}   stable identifier (e.g. 'AMBIGUOUS_SUBTASK')
+ *   - `message`     {string}   human-readable description
+ *   - `remediation` {string[]} actionable fix steps (may be empty)
+ */
+
+/**
+ * Final preflight decision consumed by hooks.
+ *
+ * @typedef {Object} PreflightResult
+ * @property {boolean}  allow       `true` iff no deny reasons collected.
+ * @property {string[]} reasons     Deny reason codes (stable rule ids),
+ *                                  aggregated across `context.error` and
+ *                                  every denying check. Empty on allow.
+ * @property {string[]} remediation Merged, ordered remediation steps for
+ *                                  R18 explainability. Empty on allow.
+ */
+
+/**
+ * Audit record passed to the injected audit callback.
+ *
+ * Fields are a superset of `appendEnforcementAudit` (Task 1) inputs so
+ * callers can forward this entry directly to persistence — preflight never
+ * imports `work-actions.js`.
+ *
+ * @typedef {Object} PreflightAuditEntry
+ * @property {'allow'|'deny'}                         decision
+ * @property {string[]}                                reasons
+ * @property {string[]}                                remediation
+ * @property {'workflow'|'ai-subtask'|'user'|null}     origin
+ * @property {string|null}                             ticketId
+ */
+
+/**
+ * Callable signature for an injected audit hook. Single positional argument
+ * (plain object). Return value is ignored. Callback exceptions are caught
+ * and suppressed by `runPreflight` (fail-open on logging).
+ *
+ * @typedef {(entry: PreflightAuditEntry) => void} PreflightAudit
+ */
+
+/**
+ * Callable signature for a pluggable preflight check.
+ *
+ * Returning `null`/`undefined` or `{ allow: true }` is "no opinion" and
+ * passes through. Returning `{ allow: false, reasons?, remediation? }`
+ * contributes to the aggregated deny result. A thrown check is caught and
+ * recorded as `PREFLIGHT_CHECK_ERROR` (fail-closed) — it cannot starve the
+ * gate.
+ *
+ * @typedef {(ctx: EnforcementContext) => (Partial<PreflightResult>|null|undefined)} PreflightCheck
+ */
+
+/**
+ * Options for {@link runPreflight}.
+ *
+ * @typedef {Object} PreflightOptions
+ * @property {PreflightAudit}   [audit]   Injected logger; defaults to no-op.
+ * @property {PreflightCheck[]} [checks]  Pluggable checks run in order.
+ */
+
+/**
+ * Run the preflight gate.
+ *
+ * Semantics:
+ *   1. If `context.error` is a truthy object with a non-empty string `code`,
+ *      the error is recorded as a deny reason and its `remediation` (when an
+ *      array) is merged into the result.
+ *   2. If `options.checks` is provided, each check runs IN ORDER with
+ *      `context` as its sole argument. All denying results are aggregated —
+ *      reasons concatenated, remediation merged in declared order. A single
+ *      thrown check is caught and recorded as `PREFLIGHT_CHECK_ERROR`
+ *      (fail-closed) so one buggy rule cannot crash the whole gate.
+ *   3. The final `allow` is `true` iff no deny reasons were collected.
+ *   4. If `options.audit` is a function, it is invoked exactly once with a
+ *      single {@link PreflightAuditEntry}. The callback is wrapped in a
+ *      try/catch so logging failures never break enforcement (mirrors
+ *      `work-actions.js` `appendRow()` fail-open).
+ *   5. If `options.audit` is missing / not a function, audit defaults to a
+ *      no-op.
+ *
+ * The function is declared with arity 2 (no default parameters) so
+ * `runPreflight.length === 2`, locking the documented public contract.
+ *
+ * @param {EnforcementContext} context
+ *   Enforcement context produced by `loadEnforcementContext`
+ *   (`workflows/work/work-enforcement-context.js`, Task 2).
+ * @param {PreflightOptions} [options]
+ * @returns {PreflightResult}
+ */
+function runPreflight(context, options) {
+  const ctx = context || {};
+  const opts = options || {};
+
+  const audit = typeof opts.audit === 'function' ? opts.audit : null;
+  const checks = Array.isArray(opts.checks) ? opts.checks : null;
+
+  const reasons = [];
+  const remediation = [];
+
+  // ─── 1. context.error → deny with error.code as the rule id ────────────
+  const err = ctx.error;
+  if (err && typeof err === 'object' && typeof err.code === 'string' && err.code.length > 0) {
+    reasons.push(err.code);
+    if (Array.isArray(err.remediation)) {
+      for (const step of err.remediation) {
+        remediation.push(step);
+      }
+    }
+  }
+
+  // ─── 2. Pluggable checks ───────────────────────────────────────────────
+  if (checks) {
+    for (const check of checks) {
+      if (typeof check !== 'function') continue;
+
+      let res;
+      try {
+        res = check(ctx);
+      } catch {
+        // Fail-closed on a crashing check — one buggy rule must not starve
+        // the gate. The synthetic reason lets callers identify the failure
+        // mode in audit records without leaking error internals.
+        reasons.push('PREFLIGHT_CHECK_ERROR');
+        continue;
+      }
+
+      if (!res || typeof res !== 'object') continue;
+      if (res.allow === false) {
+        if (Array.isArray(res.reasons)) {
+          for (const r of res.reasons) reasons.push(r);
+        }
+        if (Array.isArray(res.remediation)) {
+          for (const r of res.remediation) remediation.push(r);
+        }
+      }
+    }
+  }
+
+  // ─── 3. Final decision ─────────────────────────────────────────────────
+  const allow = reasons.length === 0;
+  const decision = allow ? 'allow' : 'deny';
+  const result = { allow, reasons, remediation };
+
+  // ─── 4. Fail-open audit ────────────────────────────────────────────────
+  // Entry fields are a superset of {decision, reasons, origin, ticketId} so
+  // callers can forward directly to `appendEnforcementAudit` (Task 1).
+  // `remediation` is included for R18 explainability (deny path).
+  if (audit) {
+    try {
+      audit({
+        decision,
+        reasons,
+        remediation,
+        origin: ctx.origin != null ? ctx.origin : null,
+        ticketId: ctx.ticketId != null ? ctx.ticketId : null,
+      });
+    } catch {
+      // Persistence failures must never break enforcement decisions.
+    }
+  }
+
+  return result;
+}
+
+module.exports = { runPreflight };

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -22,6 +22,8 @@
  */
 'use strict';
 
+const path = require('path');
+
 /**
  * @typedef {import('../work/work-enforcement-context').EnforcementContext} EnforcementContext
  *
@@ -205,4 +207,238 @@ function runPreflight(context, options) {
   return result;
 }
 
-module.exports = { runPreflight };
+// ═══════════════════════════════════════════════════════════════════════════════
+// Task 12 — Preflight rules integration (graph, claim, paths)
+//
+// Built-in check factories and shared path predicate.
+//   - createGraphCheck()                → PreflightCheck  (R4)
+//   - createClaimCheck({ taskNum, ownerId }) → PreflightCheck  (R3, R6)
+//   - createPathCheck({ filePath, allowedPaths }) → PreflightCheck  (R6)
+//   - isWriteAllowedPath(filePath, allowedPaths) → boolean  (R6, R12)
+//
+// isWriteAllowedPath is the single implementation of the path predicate.
+// Tasks 13-14 hooks import it from here — no inline copies allowed.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ─── Shared-root whitelist (R6) ──────────────────────────────────────────────
+// Files at ticketRoot that any worker may write (coordination files).
+const SHARED_ROOT_WHITELIST = new Set([
+  'brief.md',
+  'spec.md',
+  'tasks.md',
+  '.work-state.json',
+  '.work-actions.json',
+]);
+
+/**
+ * Determine whether a file path is allowed for the current worker.
+ *
+ * This is the SINGLE implementation of the task-readiness edit gate (R6).
+ * Tasks 13-14 hooks must import this — no inline duplicates.
+ *
+ * Allowed paths:
+ *   - Under `allowedPaths.prDir`      (PR{N}/ worktree)
+ *   - Under `allowedPaths.taskDir`    (task${N}/ artifacts)
+ *   - Shared-root whitelist at `allowedPaths.ticketRoot`
+ *
+ * Fail-closed (R15): returns false when inputs are missing or malformed.
+ *
+ * @param {string} filePath     - Absolute path being written
+ * @param {object} allowedPaths - { prDir, taskDir, ticketRoot }
+ * @returns {boolean}
+ */
+function isWriteAllowedPath(filePath, allowedPaths) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  if (!allowedPaths || typeof allowedPaths !== 'object') return false;
+
+  // Normalize to prevent path-traversal bypasses (R15)
+  const normalized = path.resolve(filePath);
+
+  // Check PR{N}/ directory
+  if (typeof allowedPaths.prDir === 'string' && allowedPaths.prDir.length > 0) {
+    const prResolved = path.resolve(allowedPaths.prDir);
+    if (normalized.startsWith(prResolved + path.sep) || normalized === prResolved) {
+      return true;
+    }
+  }
+
+  // Check task${N}/ directory
+  if (typeof allowedPaths.taskDir === 'string' && allowedPaths.taskDir.length > 0) {
+    const taskResolved = path.resolve(allowedPaths.taskDir);
+    if (normalized.startsWith(taskResolved + path.sep) || normalized === taskResolved) {
+      return true;
+    }
+  }
+
+  // Check shared-root whitelist at ticketRoot
+  if (typeof allowedPaths.ticketRoot === 'string' && allowedPaths.ticketRoot.length > 0) {
+    const ticketResolved = path.resolve(allowedPaths.ticketRoot);
+    // File must be directly at ticketRoot (not nested) and in the whitelist
+    const dir = path.dirname(normalized);
+    if (dir === ticketResolved) {
+      const basename = path.basename(normalized);
+      if (SHARED_ROOT_WHITELIST.has(basename)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Create a graph validation check (R4).
+ *
+ * Validates `ctx.tasks` for unknown dependencies, self-dependencies, and
+ * cycles using `validateTaskGraph` from `work-state.js`. If tasks are null
+ * or missing, the check passes (no graph to validate).
+ *
+ * @returns {PreflightCheck}
+ */
+function createGraphCheck() {
+  return function graphCheck(ctx) {
+    if (!ctx.tasks || !Array.isArray(ctx.tasks)) return null;
+
+    // Lazy require to avoid module-level coupling with work-state.js.
+    // In production config is always available; if require fails, the
+    // enclosing runPreflight try/catch records PREFLIGHT_CHECK_ERROR.
+    const { validateTaskGraph } = require('../work/work-state');
+
+    const validation = validateTaskGraph(ctx.tasks);
+    if (validation.valid) return null;
+
+    // Aggregate all graph errors into reasons + remediation
+    const reasons = [];
+    const remediation = [];
+    for (const err of validation.errors) {
+      if (err.code && !reasons.includes(err.code)) {
+        reasons.push(err.code);
+      }
+      if (Array.isArray(err.remediation)) {
+        for (const step of err.remediation) {
+          remediation.push(step);
+        }
+      }
+    }
+
+    return { allow: false, reasons, remediation };
+  };
+}
+
+/**
+ * Create a claim + dependency readiness check (R3, R6).
+ *
+ * Validates that:
+ *   1. If taskNum is set, ownerId must also be set (unclaimed write → deny).
+ *   2. The task's dependencies are all completed (canStart semantics, R3).
+ *
+ * When no tasksMeta exists in the context state, the check passes (legacy
+ * mode, R16 backward compat).
+ *
+ * @param {object} params
+ * @param {number} [params.taskNum] - Task number being worked on
+ * @param {string} [params.ownerId] - PR{N} owner id from claim
+ * @returns {PreflightCheck}
+ */
+function createClaimCheck(params) {
+  const taskNum = params && params.taskNum;
+  const ownerId = params && params.ownerId;
+
+  return function claimCheck(ctx) {
+    // No state or no tasksMeta → legacy mode, allow (R16)
+    if (!ctx.state || !ctx.state.tasksMeta) return null;
+
+    // No taskNum requested → no claim enforcement needed
+    if (!taskNum) return null;
+
+    // R6: taskNum set but no ownerId → unclaimed task write
+    if (!ownerId) {
+      return {
+        allow: false,
+        reasons: ['UNCLAIMED_TASK_WRITE'],
+        remediation: [
+          `Task ${taskNum} has no claim. Run claimTask(ticketId, ${taskNum}, ownerId) before writing.`,
+          'Each worker must claim a task with its PR{N} owner id before modifying files.',
+        ],
+      };
+    }
+
+    // R3: Check dependency readiness using persisted tasksMeta
+    const tasksMeta = ctx.state.tasksMeta;
+    if (!Array.isArray(tasksMeta.tasks)) return null;
+
+    const targetId = `task_${taskNum}`;
+    const task = tasksMeta.tasks.find((t) => t && t.id === targetId);
+    if (!task) {
+      return {
+        allow: false,
+        reasons: ['UNKNOWN_TASK'],
+        remediation: [
+          `Task ${taskNum} not found in tasksMeta. Verify task number and re-run initTasksMeta.`,
+        ],
+      };
+    }
+
+    // Check dependency readiness (R3)
+    if (Array.isArray(task.dependencies) && task.dependencies.length > 0) {
+      for (const depNum of task.dependencies) {
+        const depId = `task_${depNum}`;
+        const dep = tasksMeta.tasks.find((t) => t && t.id === depId);
+        if (!dep || dep.status !== 'completed') {
+          return {
+            allow: false,
+            reasons: ['DEPENDENCY_NOT_READY'],
+            remediation: [
+              `Task ${taskNum} depends on Task ${depNum} which is not completed (status: ${dep ? dep.status : 'missing'}).`,
+              `Complete Task ${depNum} before starting Task ${taskNum}.`,
+              'Use canStart(ticketId, taskNum) to check readiness before claiming.',
+            ],
+          };
+        }
+      }
+    }
+
+    return null;
+  };
+}
+
+/**
+ * Create a path intent check (R6).
+ *
+ * If filePath is provided, validates it against the allowed paths using
+ * `isWriteAllowedPath`. If filePath is not provided, the check passes
+ * (no path intent to validate).
+ *
+ * @param {object} params
+ * @param {string} [params.filePath] - Absolute path being written
+ * @param {object} [params.allowedPaths] - { prDir, taskDir, ticketRoot }
+ * @returns {PreflightCheck}
+ */
+function createPathCheck(params) {
+  const filePath = params && params.filePath;
+  const allowedPaths = params && params.allowedPaths;
+
+  return function pathCheck() {
+    if (!filePath) return null;
+
+    if (isWriteAllowedPath(filePath, allowedPaths)) return null;
+
+    return {
+      allow: false,
+      reasons: ['PATH_NOT_ALLOWED'],
+      remediation: [
+        `Write to "${filePath}" is outside the allowed path set.`,
+        'Allowed paths: PR{N}/ worktree, task${N}/ artifacts, and shared-root whitelist (brief.md, spec.md, tasks.md, .work-state.json, .work-actions.json).',
+        'Verify the file path and ensure it falls under the claimed worker or task directory.',
+      ],
+    };
+  };
+}
+
+module.exports = {
+  runPreflight,
+  isWriteAllowedPath,
+  createGraphCheck,
+  createClaimCheck,
+  createPathCheck,
+};

--- a/workflows/lib/request-index.js
+++ b/workflows/lib/request-index.js
@@ -1,0 +1,206 @@
+/**
+ * request-index.js — Atomic counter ledger for out-of-flow request allocation (GH-219 Task 10)
+ *
+ * Manages `.request-index.json` per ticket directory with collision-safe increments.
+ * Format: `{ "userSeq": n, "aiSeq": m, "version": 1 }`
+ *
+ * Uses the atomic rename pattern (write temp → rename) from session-guard.js.
+ *
+ * Requirements:
+ *   R9:  Out-of-flow user routing — `user-request-${n}`
+ *   R10: Out-of-flow AI routing — `ai-request-${n}`
+ *   R11: Persistent `.request-index.json` with collision-safe increments
+ *   R7:  Allocator completion — wires the stubs from Task 9
+ *
+ * @module request-index
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { USER_REQUEST_PREFIX, AI_REQUEST_PREFIX } = require('./allocate-output-folder');
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const INDEX_FILENAME = '.request-index.json';
+const INDEX_VERSION = 1;
+
+/** @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes */
+const UNSAFE_TICKET_RE = /\.\.|[\\]|\x00/;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve TASKS_BASE from environment.
+ * @returns {string}
+ */
+function resolveTasksBase() {
+  if (process.env.TASKS_BASE) return process.env.TASKS_BASE;
+  throw new Error('TASKS_BASE is not configured. Set the TASKS_BASE environment variable.');
+}
+
+/**
+ * Validate ticket ID — fail-closed before any filesystem I/O.
+ * @param {unknown} ticketId
+ */
+function validateTicketId(ticketId) {
+  if (typeof ticketId !== 'string' || ticketId.length === 0) {
+    throw new Error(
+      `Invalid ticket ID: expected non-empty string, received ${typeof ticketId === 'string' ? '""' : typeof ticketId}`
+    );
+  }
+  if (UNSAFE_TICKET_RE.test(ticketId)) {
+    throw new Error(
+      `Invalid ticket ID: contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`
+    );
+  }
+}
+
+/**
+ * Sanitize ticket ID for filesystem paths using config.safeTicketId when available.
+ * @param {string} ticketId
+ * @returns {string}
+ */
+function sanitizeId(ticketId) {
+  try {
+    const config = require('./config');
+    if (config && typeof config.safeTicketId === 'function') {
+      return config.safeTicketId(ticketId);
+    }
+  } catch {
+    // fallback to raw ID
+  }
+  return ticketId;
+}
+
+/**
+ * Resolve the ticket directory path.
+ * @param {string} ticketId
+ * @returns {string}
+ */
+function ticketDir(ticketId) {
+  return path.join(resolveTasksBase(), sanitizeId(ticketId));
+}
+
+/**
+ * Resolve the `.request-index.json` path for a ticket.
+ * @param {string} ticketId
+ * @returns {string}
+ */
+function indexPath(ticketId) {
+  return path.join(ticketDir(ticketId), INDEX_FILENAME);
+}
+
+/**
+ * @typedef {Object} RequestIndex
+ * @property {number} userSeq - Current user request sequence number
+ * @property {number} aiSeq - Current AI request sequence number
+ * @property {number} version - Schema version
+ */
+
+/**
+ * Read the current index from disk. Returns zeroed defaults if the file does not exist.
+ * @param {string} ticketId
+ * @returns {RequestIndex}
+ */
+function readIndex(ticketId) {
+  validateTicketId(ticketId);
+  const filePath = indexPath(ticketId);
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    return {
+      userSeq: typeof raw.userSeq === 'number' ? raw.userSeq : 0,
+      aiSeq: typeof raw.aiSeq === 'number' ? raw.aiSeq : 0,
+      version: INDEX_VERSION,
+    };
+  } catch {
+    return { userSeq: 0, aiSeq: 0, version: INDEX_VERSION };
+  }
+}
+
+/**
+ * Write index atomically: write to temp file, then rename.
+ * Pattern borrowed from session-guard.js writeSessionAtomic.
+ * @param {string} ticketId
+ * @param {RequestIndex} data
+ */
+function writeIndexAtomic(ticketId, data) {
+  const target = indexPath(ticketId);
+  const dir = path.dirname(target);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const tmp = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o644 });
+  try {
+    try {
+      fs.unlinkSync(target);
+    } catch {
+      /* ENOENT — target doesn't exist yet */
+    }
+    fs.renameSync(tmp, target);
+  } catch (renameErr) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* cleanup best-effort */
+    }
+    throw renameErr;
+  }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} AllocationResult
+ * @property {number} seq - The allocated sequence number
+ * @property {string} segment - Directory segment name (e.g. "user-request-1")
+ * @property {string} root - Absolute path to the allocated directory
+ */
+
+/**
+ * Allocate the next user-request folder, incrementing the counter atomically.
+ *
+ * @param {string} ticketId
+ * @returns {AllocationResult}
+ */
+function nextUserRequest(ticketId) {
+  validateTicketId(ticketId);
+  const current = readIndex(ticketId);
+  const nextSeq = current.userSeq + 1;
+  const updated = { ...current, userSeq: nextSeq };
+  writeIndexAtomic(ticketId, updated);
+
+  const segment = `${USER_REQUEST_PREFIX}${nextSeq}`;
+  const root = path.join(ticketDir(ticketId), segment);
+  fs.mkdirSync(root, { recursive: true });
+
+  return { seq: nextSeq, segment, root };
+}
+
+/**
+ * Allocate the next ai-request folder, incrementing the counter atomically.
+ *
+ * @param {string} ticketId
+ * @returns {AllocationResult}
+ */
+function nextAiRequest(ticketId) {
+  validateTicketId(ticketId);
+  const current = readIndex(ticketId);
+  const nextSeq = current.aiSeq + 1;
+  const updated = { ...current, aiSeq: nextSeq };
+  writeIndexAtomic(ticketId, updated);
+
+  const segment = `${AI_REQUEST_PREFIX}${nextSeq}`;
+  const root = path.join(ticketDir(ticketId), segment);
+  fs.mkdirSync(root, { recursive: true });
+
+  return { seq: nextSeq, segment, root };
+}
+
+module.exports = {
+  nextUserRequest,
+  nextAiRequest,
+  readIndex,
+  INDEX_FILENAME,
+  INDEX_VERSION,
+};

--- a/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -456,7 +456,51 @@ describe('tdd-phase-state CLI', () => {
     });
   });
 
-  describe('token gating', () => {
+  describe('per-task path with legacy root fallback (GH-219 Task 9)', () => {
+    it('init with --task writes to TASKS_BASE/<ticket>/task${N}/tdd-phase.json', () => {
+      const { stdout, exitCode } = runCli('init TEST-T9A --task 3', homeDir);
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.ok, true);
+
+      // Verify state file is at per-task path
+      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-T9A', 'task3', 'tdd-phase.json');
+      assert.ok(fs.existsSync(perTaskPath), `Expected per-task state at ${perTaskPath}`);
+      const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
+      assert.strictEqual(state.currentPhase, 'red');
+    });
+
+    it('current with --task reads from per-task path when it exists', () => {
+      runCli('init TEST-T9B --task 5', homeDir);
+      const { stdout, exitCode } = runCli('current TEST-T9B --task 5', homeDir);
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.phase, 'red');
+    });
+
+    it('current with --task falls back to legacy root when per-task path missing', () => {
+      // Create state at root (legacy) path only
+      runCli('init TEST-T9C', homeDir);
+      // Now read with --task — per-task file does not exist, should fallback to root
+      const { stdout, exitCode } = runCli('current TEST-T9C --task 2', homeDir);
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.phase, 'red');
+    });
+
+    it('current with --task fails when neither per-task nor root exists', () => {
+      const { exitCode } = runCli('current TEST-T9D --task 1', homeDir);
+      assert.strictEqual(exitCode, 1);
+    });
+
+    it('init without --task writes to legacy root path (backward compat)', () => {
+      runCli('init TEST-T9E', homeDir);
+      const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-T9E', 'tdd-phase.json');
+      assert.ok(fs.existsSync(rootPath), `Expected root state at ${rootPath}`);
+    });
+  });
+
+    describe('token gating', () => {
     it('record-red fails without token when WORK_TDD_TOKEN_SKIP is not set', () => {
       runCli('init TEST-TOK', homeDir);
       const failScript = createExitScript(scriptDir, 1);

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -64,17 +64,94 @@ function sanitizeId(ticketId) {
   }
 }
 
-function getStatePath(ticketId) {
+/**
+ * Resolve TASKS_BASE from env, config, or HOME fallback.
+ * @returns {string}
+ */
+function resolveTasksBase() {
+  return (
+    process.env.TASKS_BASE ||
+    (config && config.TASKS_BASE) ||
+    path.join(process.env.HOME, 'worktrees', 'tasks')
+  );
+}
+
+/**
+ * Build the per-task state path: TASKS_BASE/<ticket>/task${N}/tdd-phase.json
+ * @param {string} base - Resolved TASKS_BASE
+ * @param {string} safeId - Sanitized ticket ID
+ * @param {number} taskNum - Task number (positive integer)
+ * @returns {string}
+ */
+function perTaskStatePath(base, safeId, taskNum) {
+  let taskSegmentFn;
+  try {
+    taskSegmentFn = require('../lib/allocate-output-folder').taskSegment;
+  } catch {
+    // fallback if allocator not available — inline the task${N} pattern
+    taskSegmentFn = (n) => `task${n}`;
+  }
+  return path.resolve(base, safeId, taskSegmentFn(taskNum), 'tdd-phase.json');
+}
+
+/**
+ * Build the legacy ticket-root state path: TASKS_BASE/<ticket>/tdd-phase.json
+ * @param {string} base - Resolved TASKS_BASE
+ * @param {string} safeId - Sanitized ticket ID
+ * @returns {string}
+ */
+function ticketRootStatePath(base, safeId) {
+  return path.resolve(base, safeId, 'tdd-phase.json');
+}
+
+/**
+ * Resolve the state file path for a ticket.
+ *
+ * When taskNum is provided:
+ *   - Write path: always per-task (TASKS_BASE/<ticket>/task${N}/tdd-phase.json)
+ *   - Read path: per-task first; if missing, fallback to legacy root path
+ *     (TASKS_BASE/<ticket>/tdd-phase.json) for backward compatibility.
+ *
+ * When taskNum is NOT provided:
+ *   - Uses the legacy root path (backward compat).
+ *
+ * @param {string} ticketId - Raw ticket ID
+ * @param {object} [opts] - Options
+ * @param {number} [opts.taskNum] - Task number for per-task resolution
+ * @param {boolean} [opts.forWrite] - If true, always return per-task path (no fallback)
+ * @returns {string} Absolute path to tdd-phase.json
+ */
+function getStatePath(ticketId, opts) {
   if (!ticketId || /\.\./.test(ticketId) || /\\/.test(ticketId)) {
     throw new Error(`Invalid ticket ID: ${ticketId}`);
   }
-  // Resolve from TASKS_BASE env, config module, or default HOME-based path
-  const base =
-    process.env.TASKS_BASE ||
-    (config && config.TASKS_BASE) ||
-    path.join(process.env.HOME, 'worktrees', 'tasks');
+  const base = resolveTasksBase();
   const safeId = sanitizeId(ticketId);
-  const resolved = path.resolve(base, safeId, 'tdd-phase.json');
+  const taskNum = opts && opts.taskNum;
+
+  let resolved;
+
+  if (taskNum != null && Number.isInteger(taskNum) && taskNum > 0) {
+    const perTask = perTaskStatePath(base, safeId, taskNum);
+
+    if (opts && opts.forWrite) {
+      // Writes always target per-task path
+      resolved = perTask;
+    } else {
+      // Reads: per-task first, then legacy root fallback
+      if (fs.existsSync(perTask)) {
+        resolved = perTask;
+      } else {
+        // Legacy fallback: check ticketRoot for backward compat
+        const root = ticketRootStatePath(base, safeId);
+        resolved = fs.existsSync(root) ? root : perTask;
+      }
+    }
+  } else {
+    // No task number — legacy root path
+    resolved = ticketRootStatePath(base, safeId);
+  }
+
   // Validate resolved path stays within TASKS_BASE (prevents traversal)
   if (!resolved.startsWith(path.resolve(base) + path.sep)) {
     throw new Error(`Invalid ticket ID: ${ticketId}`);
@@ -82,16 +159,16 @@ function getStatePath(ticketId) {
   return resolved;
 }
 
-function readState(ticketId) {
-  const statePath = getStatePath(ticketId);
+function readState(ticketId, opts) {
+  const statePath = getStatePath(ticketId, opts);
   if (!fs.existsSync(statePath)) {
     return null;
   }
   return JSON.parse(fs.readFileSync(statePath, 'utf8'));
 }
 
-function writeState(ticketId, state) {
-  const statePath = getStatePath(ticketId);
+function writeState(ticketId, state, opts) {
+  const statePath = getStatePath(ticketId, { ...opts, forWrite: true });
   const dir = path.dirname(statePath);
   fs.mkdirSync(dir, { recursive: true });
   const tmpPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
@@ -119,6 +196,15 @@ function parseCmd(args) {
     return null;
   }
   return args[cmdIdx + 1];
+}
+
+function parseTask(args) {
+  const taskIdx = args.indexOf('--task');
+  if (taskIdx === -1 || taskIdx + 1 >= args.length) {
+    return undefined;
+  }
+  const val = parseInt(args[taskIdx + 1], 10);
+  return Number.isInteger(val) && val > 0 ? val : undefined;
 }
 
 function runTestCommand(cmd) {
@@ -184,24 +270,28 @@ function verifyToken() {
 
 // ─── Subcommands ────────────────────────────────────────────────────────────
 
-function cmdInit(ticketId) {
+function cmdInit(ticketId, args) {
   if (!ticketId) {
     errorExit('Missing ticket ID. Usage: node tdd-phase-state.js init <TICKET_ID>');
   }
+  const taskNum = parseTask(args || []);
+  const opts = taskNum ? { taskNum } : undefined;
   const state = {
     currentPhase: 'red',
     currentCycle: 1,
     cycles: [],
   };
-  writeState(ticketId, state);
+  writeState(ticketId, state, opts);
   successOut({ ok: true, phase: 'red', cycle: 1 });
 }
 
-function cmdCurrent(ticketId) {
+function cmdCurrent(ticketId, args) {
   if (!ticketId) {
     errorExit('Missing ticket ID.');
   }
-  const state = readState(ticketId);
+  const taskNum = parseTask(args || []);
+  const opts = taskNum ? { taskNum } : undefined;
+  const state = readState(ticketId, opts);
   if (!state) {
     errorExit('No TDD phase state found. Run "init" first.');
   }
@@ -405,10 +495,10 @@ if (GATED_SUBCOMMANDS.includes(subcommand) && process.env.WORK_TDD_TOKEN_SKIP !=
 
 switch (subcommand) {
   case 'init':
-    cmdInit(ticketId);
+    cmdInit(ticketId, args.slice(2));
     break;
   case 'current':
-    cmdCurrent(ticketId);
+    cmdCurrent(ticketId, args.slice(2));
     break;
   case 'record-red':
     cmdRecordRed(ticketId, args.slice(2));

--- a/workflows/work/__tests__/work-actions.test.js
+++ b/workflows/work/__tests__/work-actions.test.js
@@ -14,7 +14,7 @@ const os = require('os');
 const TEST_TASKS_BASE = path.join(os.tmpdir(), 'work-actions-test-' + process.pid);
 const FAKE_HOME = path.join(TEST_TASKS_BASE, 'fakehome');
 
-let appendAction, loadActions, analyzeActions;
+let appendAction, loadActions, analyzeActions, appendEnforcementAudit;
 
 describe('work-actions', () => {
   const TEST_TICKET = 'TEST-ACTIONS-001';
@@ -34,6 +34,7 @@ describe('work-actions', () => {
     appendAction = mod.appendAction;
     loadActions = mod.loadActions;
     analyzeActions = mod.analyzeActions;
+    appendEnforcementAudit = mod.appendEnforcementAudit;
   });
 
   after(() => {
@@ -178,6 +179,207 @@ describe('work-actions', () => {
       const result = analyzeActions(actions);
       assert.strictEqual(result.totalDuration, '2640s');
       assert.strictEqual(result.actionCount, 2);
+    });
+  });
+
+  // ─── IDEA2 / GH-219: Enforcement audit records ──────────────────────────────
+  // Task 1 — R13 (shape) + R16 (schema evolution without breaking readers).
+  // Enforcement records share the same `.work-actions.json` as legacy step rows
+  // and are separated by an explicit `kind: 'enforcement'` discriminator.
+  describe('appendEnforcementAudit', () => {
+    it('should expose appendEnforcementAudit as a module export', () => {
+      assert.strictEqual(
+        typeof appendEnforcementAudit,
+        'function',
+        'work-actions must export appendEnforcementAudit for enforcement hooks to audit decisions'
+      );
+    });
+
+    it('should write a record with all brief-required fields and kind discriminator', () => {
+      appendEnforcementAudit(TEST_TICKET, {
+        origin: 'workflow',
+        task: 1,
+        phase: 'red',
+        action: 'Write',
+        allow: true,
+        reason: 'write allowed: path matches claimed task artifact root',
+        outputPath: '/tmp/fake/tasks/GH-219/task1/implement.md',
+      });
+
+      const actions = loadActions(TEST_TICKET);
+      assert.strictEqual(actions.length, 1, 'one record should be appended');
+      const row = actions[0];
+
+      assert.strictEqual(row.kind, 'enforcement', 'discriminator must be kind: "enforcement"');
+      assert.ok(row.timestamp, 'must include timestamp');
+      assert.match(
+        row.timestamp,
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+        'timestamp must be ISO 8601'
+      );
+      assert.strictEqual(row.origin, 'workflow', 'must record origin');
+      assert.strictEqual(row.task, 1, 'must record task');
+      assert.strictEqual(row.phase, 'red', 'must record phase');
+      assert.strictEqual(row.action, 'Write', 'must record action (tool name)');
+      assert.strictEqual(row.allow, true, 'must record allow/deny as a boolean');
+      assert.strictEqual(
+        row.reason,
+        'write allowed: path matches claimed task artifact root',
+        'must record reason'
+      );
+      assert.strictEqual(
+        row.outputPath,
+        '/tmp/fake/tasks/GH-219/task1/implement.md',
+        'must record outputPath'
+      );
+    });
+
+    it('should record deny decisions with allow=false and preserve reason/outputPath', () => {
+      appendEnforcementAudit(TEST_TICKET, {
+        origin: 'user',
+        task: null,
+        phase: null,
+        action: 'Edit',
+        allow: false,
+        reason: 'deny: unclaimed task write attempted by user origin',
+        outputPath: '/tmp/fake/repo/src/index.ts',
+      });
+
+      const actions = loadActions(TEST_TICKET);
+      assert.strictEqual(actions[0].kind, 'enforcement');
+      assert.strictEqual(actions[0].allow, false);
+      assert.strictEqual(actions[0].origin, 'user');
+      assert.strictEqual(actions[0].task, null);
+      assert.strictEqual(actions[0].phase, null);
+      assert.strictEqual(actions[0].action, 'Edit');
+      assert.match(actions[0].reason, /deny/);
+    });
+
+    it('should pass through optional meta without dropping required fields', () => {
+      appendEnforcementAudit(TEST_TICKET, {
+        origin: 'ai-subtask',
+        task: 2,
+        phase: 'green',
+        action: 'Bash',
+        allow: true,
+        reason: 'allow: command inside PR1 worker root',
+        outputPath: null,
+        meta: { ruleId: 'path-allowed', prSlot: 'PR1' },
+      });
+
+      const row = loadActions(TEST_TICKET)[0];
+      assert.strictEqual(row.kind, 'enforcement');
+      assert.deepStrictEqual(row.meta, { ruleId: 'path-allowed', prSlot: 'PR1' });
+      assert.strictEqual(row.outputPath, null);
+    });
+
+    it('should coexist with legacy appendAction rows in the same .work-actions.json', () => {
+      appendAction(TEST_TICKET, { step: 'implement', what: 'step started' });
+      appendEnforcementAudit(TEST_TICKET, {
+        origin: 'workflow',
+        task: 1,
+        phase: 'red',
+        action: 'Write',
+        allow: true,
+        reason: 'allow: claimed task write',
+        outputPath: '/tmp/fake/tasks/GH-219/task1/implement.md',
+      });
+      appendAction(TEST_TICKET, { step: 'implement', what: 'step completed' });
+
+      const rows = loadActions(TEST_TICKET);
+      assert.strictEqual(rows.length, 3);
+
+      const legacyRows = rows.filter((r) => r.kind !== 'enforcement');
+      const enforcementRows = rows.filter((r) => r.kind === 'enforcement');
+      assert.strictEqual(legacyRows.length, 2, 'legacy rows are not enforcement rows');
+      assert.strictEqual(enforcementRows.length, 1, 'enforcement rows are discriminated');
+      assert.strictEqual(legacyRows[0].step, 'implement');
+      assert.strictEqual(legacyRows[0].what, 'step started');
+      assert.strictEqual(legacyRows[1].what, 'step completed');
+    });
+  });
+
+  describe('loadActions / analyzeActions backward compatibility (R16)', () => {
+    // Fixture mirrors a pre-IDEA2 .work-actions.json: only legacy rows, no `kind` field.
+    const preIdea2Fixture = [
+      { step: 'ticket', timestamp: '2026-01-05T10:00:00.000Z', what: 'workflow started' },
+      { step: 'ticket', timestamp: '2026-01-05T10:00:00.500Z', what: 'step started' },
+      {
+        step: 'ticket',
+        timestamp: '2026-01-05T10:00:30.000Z',
+        what: 'mcp__atlassian__jira_get_issue',
+      },
+      { step: 'ticket', timestamp: '2026-01-05T10:01:00.000Z', what: 'step completed' },
+      { step: 'bootstrap', timestamp: '2026-01-05T10:01:00.000Z', what: 'step started' },
+      {
+        step: 'bootstrap',
+        timestamp: '2026-01-05T10:01:30.000Z',
+        what: 'BLOCKED: Skill(bootstrap)',
+      },
+      { step: 'bootstrap', timestamp: '2026-01-05T10:02:30.000Z', what: 'step reset' },
+      { step: 'bootstrap', timestamp: '2026-01-05T10:03:00.000Z', what: 'step completed' },
+    ];
+
+    it('loadActions parses a pre-IDEA2 .work-actions.json without throwing', () => {
+      const dir = path.join(FAKE_HOME, 'worktrees', 'tasks', TEST_TICKET);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, '.work-actions.json'),
+        JSON.stringify(preIdea2Fixture, null, 2)
+      );
+
+      const loaded = loadActions(TEST_TICKET);
+      assert.strictEqual(loaded.length, preIdea2Fixture.length);
+      assert.strictEqual(loaded[0].what, 'workflow started');
+      for (const row of loaded) {
+        assert.ok(!('kind' in row), 'legacy rows must not gain a kind field on read');
+      }
+    });
+
+    it('analyzeActions handles a pre-IDEA2 fixture without throwing and still computes steps', () => {
+      const result = analyzeActions(preIdea2Fixture);
+      assert.strictEqual(result.actionCount, preIdea2Fixture.length);
+      const ticketStep = result.steps.find((s) => s.step === 'ticket');
+      const bootstrapStep = result.steps.find((s) => s.step === 'bootstrap');
+      assert.ok(ticketStep, 'ticket step analysed');
+      assert.ok(bootstrapStep, 'bootstrap step analysed');
+      assert.strictEqual(ticketStep.duration, '60s');
+      assert.strictEqual(bootstrapStep.duration, '120s');
+      assert.strictEqual(bootstrapStep.blockCount, 1);
+      assert.strictEqual(bootstrapStep.retryCount, 1);
+    });
+
+    it('analyzeActions does not throw when enforcement rows are mixed with legacy rows', () => {
+      const mixed = [
+        ...preIdea2Fixture,
+        {
+          kind: 'enforcement',
+          timestamp: '2026-01-05T10:03:30.000Z',
+          origin: 'workflow',
+          task: 1,
+          phase: 'red',
+          action: 'Write',
+          allow: true,
+          reason: 'allow: claim matches',
+          outputPath: '/tmp/fake/tasks/GH-219/task1/implement.md',
+        },
+      ];
+
+      let result;
+      assert.doesNotThrow(() => {
+        result = analyzeActions(mixed);
+      });
+      assert.strictEqual(
+        result.actionCount,
+        mixed.length,
+        'enforcement rows counted but do not corrupt step analysis'
+      );
+      const ticketStep = result.steps.find((s) => s.step === 'ticket');
+      assert.strictEqual(
+        ticketStep && ticketStep.duration,
+        '60s',
+        'ticket step duration unchanged by enforcement row'
+      );
     });
   });
 });

--- a/workflows/work/__tests__/work-claims.test.js
+++ b/workflows/work/__tests__/work-claims.test.js
@@ -1,0 +1,445 @@
+/**
+ * Tests for work-claims.js — per-task atomic claim locks.
+ *
+ * IDEA2 / GH-219 — Task 6: `claimTask` and `.claims` locks.
+ *
+ * Requirements covered:
+ *   R5  — `claimTask(ticketId, taskNum, ownerId)` with atomic lock files under
+ *         `tasks/<ticketId>/.claims/task-${n}.lock`. Owner id = `PR{N}`.
+ *         `session-guard.js` ticket-level behavior is NOT modified.
+ *   R15 — Sanitized paths; fail-closed on bad ticket id. No I/O / no
+ *         directory creation before input validation passes.
+ *
+ * Uses node:test + node:assert/strict with direct `require()` of work-claims
+ * (pure-function testing of lock acquire/release is far cleaner than CLI
+ * spawns; matches the convention established in work-state-graph.test.js).
+ *
+ * Run: node --test workflows/work/__tests__/work-claims.test.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Set TASKS_BASE BEFORE requiring work-claims so config.js picks up the
+// isolated temp directory at module-load time (see workflows/lib/config.js
+// lines 125–127 — TASKS_BASE is resolved once at require() time).
+const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'work-claims-test-'));
+process.env.TASKS_BASE = TEMP_TASKS_BASE;
+
+const { describe, it, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const workClaims = require(path.join(__dirname, '..', 'work-claims'));
+const workState = require(path.join(__dirname, '..', 'work-state'));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function freshTicket(prefix) {
+  // Append random suffix so tests in the same process do not collide —
+  // direct-require tests share one TASKS_BASE and module state.
+  return `${prefix}-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+}
+
+function cleanupTicket(ticketId) {
+  try {
+    fs.rmSync(path.join(TEMP_TASKS_BASE, ticketId), { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+function claimsDirFor(ticketId) {
+  return path.join(TEMP_TASKS_BASE, ticketId, '.claims');
+}
+
+function lockPathFor(ticketId, taskNum) {
+  return path.join(claimsDirFor(ticketId), `task-${taskNum}.lock`);
+}
+
+after(() => {
+  try {
+    fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Public surface
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('work-claims module surface', () => {
+  it('exports claimTask and releaseTask functions', () => {
+    assert.equal(typeof workClaims.claimTask, 'function', 'claimTask must be exported');
+    assert.equal(typeof workClaims.releaseTask, 'function', 'releaseTask must be exported');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// claimTask — happy path + lock payload (R5)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('claimTask — happy path + lock payload (R5)', () => {
+  let TICKET;
+  beforeEach(() => {
+    TICKET = freshTicket('TEST-CLAIM-OK');
+  });
+  after(() => cleanupTicket(TICKET));
+
+  it('creates `.claims/task-${n}.lock` with canonical payload on fresh dir', () => {
+    const result = workClaims.claimTask(TICKET, 1, 'PR1');
+
+    assert.equal(result.success, true, 'first claim on fresh dir must succeed');
+    assert.equal(result.ownerId, 'PR1');
+    assert.equal(result.lockPath, lockPathFor(TICKET, 1));
+    assert.ok(!result.error, 'successful claim must not carry an `error` field');
+
+    // Lock file must exist on disk with the declared payload (R5).
+    assert.ok(fs.existsSync(result.lockPath), 'lock file must be persisted on disk');
+    const payload = JSON.parse(fs.readFileSync(result.lockPath, 'utf8'));
+    assert.equal(payload.ownerId, 'PR1');
+    assert.equal(payload.taskNum, 1);
+    assert.equal(payload.ticketId, TICKET);
+    assert.ok(payload.timestamp, 'payload must include a timestamp');
+    // Timestamp is an ISO string (YYYY-MM-DDTHH:MM:SS...Z) — validate by
+    // round-tripping through Date so a human-readable format is preserved.
+    assert.equal(
+      new Date(payload.timestamp).toString() !== 'Invalid Date',
+      true,
+      'timestamp must be a valid ISO date string'
+    );
+  });
+
+  it('lock path uses sanitized ticket id and integer taskNum', () => {
+    // Claim with a string-looking integer (common from CLI args); module
+    // must coerce to int and keep the canonical `task-${n}.lock` filename.
+    const result = workClaims.claimTask(TICKET, 3, 'PR2');
+    assert.equal(result.success, true);
+    assert.equal(
+      path.basename(result.lockPath),
+      'task-3.lock',
+      'lock filename must use integer taskNum suffix'
+    );
+    assert.equal(
+      path.dirname(result.lockPath),
+      claimsDirFor(TICKET),
+      'lock lives under `<ticket>/.claims/`'
+    );
+  });
+
+  it('leaves no temp artifacts in `.claims/` after successful claim', () => {
+    const result = workClaims.claimTask(TICKET, 5, 'PR1');
+    assert.equal(result.success, true);
+    const entries = fs.readdirSync(claimsDirFor(TICKET));
+    // Only the canonical lock file should remain. No `.tmp-*` leftovers.
+    const leaked = entries.filter((name) => name.startsWith('.tmp-'));
+    assert.deepEqual(
+      leaked,
+      [],
+      `temp lock file(s) leaked into .claims/: ${leaked.join(', ')}`
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// claimTask — already claimed (second owner rejected)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('claimTask — already-claimed semantics', () => {
+  let TICKET;
+  beforeEach(() => {
+    TICKET = freshTicket('TEST-CLAIM-DUP');
+  });
+  after(() => cleanupTicket(TICKET));
+
+  it('rejects second claim from a different owner without overwriting', () => {
+    const first = workClaims.claimTask(TICKET, 1, 'PR1');
+    assert.equal(first.success, true);
+
+    const second = workClaims.claimTask(TICKET, 1, 'PR2');
+    assert.equal(second.success, false, 'duplicate claim must fail closed');
+    assert.equal(
+      second.existingOwner,
+      'PR1',
+      'existingOwner must be reported from the live lock file'
+    );
+    assert.ok(second.error, 'rejection must carry a structured error');
+    assert.ok(second.error.code, 'error must have a stable `code`');
+    assert.ok(
+      Array.isArray(second.error.remediation) || typeof second.error.remediation === 'string',
+      'error must include actionable remediation'
+    );
+
+    // Disk payload MUST still belong to the original owner (no overwrite).
+    const payload = JSON.parse(fs.readFileSync(lockPathFor(TICKET, 1), 'utf8'));
+    assert.equal(payload.ownerId, 'PR1', 'existing lock payload must not be overwritten');
+  });
+
+  it('re-claiming by the SAME owner is idempotent (no spurious rejection)', () => {
+    const first = workClaims.claimTask(TICKET, 2, 'PR1');
+    assert.equal(first.success, true);
+
+    const second = workClaims.claimTask(TICKET, 2, 'PR1');
+    assert.equal(
+      second.success,
+      true,
+      'same owner reclaiming its own lock must be a no-op success'
+    );
+    assert.equal(second.ownerId, 'PR1');
+    assert.equal(second.existingOwner, 'PR1');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// claimTask — concurrency atomicity (Promise.all)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('claimTask — concurrency atomicity (R5)', () => {
+  let TICKET;
+  beforeEach(() => {
+    TICKET = freshTicket('TEST-CLAIM-CONCURRENT');
+  });
+  after(() => cleanupTicket(TICKET));
+
+  it('exactly one Promise.all racer wins on the same (task, owners) set', async () => {
+    // Five simultaneous attempts from five distinct PR slots for the same
+    // task. Exactly one must resolve to success:true; the rest must report
+    // the winning PR as existingOwner.
+    const owners = ['PR1', 'PR2', 'PR3', 'PR4', 'PR5'];
+    const results = await Promise.all(
+      owners.map((id) => Promise.resolve().then(() => workClaims.claimTask(TICKET, 7, id)))
+    );
+
+    const successes = results.filter((r) => r.success === true);
+    const failures = results.filter((r) => r.success === false);
+
+    assert.equal(
+      successes.length,
+      1,
+      `expected exactly 1 winner across ${owners.length} racers, got ${successes.length}`
+    );
+    assert.equal(failures.length, owners.length - 1);
+
+    const winnerId = successes[0].ownerId;
+    assert.ok(owners.includes(winnerId), 'winner must be one of the contenders');
+
+    // All losers must report the same winning owner via existingOwner.
+    for (const loser of failures) {
+      assert.equal(
+        loser.existingOwner,
+        winnerId,
+        'every rejected racer must see the same winning existingOwner'
+      );
+      assert.ok(loser.error, 'rejected racers must carry structured error');
+    }
+
+    // On-disk state must match the in-memory winner report.
+    const diskPayload = JSON.parse(fs.readFileSync(lockPathFor(TICKET, 7), 'utf8'));
+    assert.equal(diskPayload.ownerId, winnerId);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// releaseTask — happy path + wrong-owner rejection
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('releaseTask', () => {
+  let TICKET;
+  beforeEach(() => {
+    TICKET = freshTicket('TEST-RELEASE');
+  });
+  after(() => cleanupTicket(TICKET));
+
+  it('removes the lock file when owner matches', () => {
+    const claim = workClaims.claimTask(TICKET, 1, 'PR1');
+    assert.equal(claim.success, true);
+    assert.ok(fs.existsSync(claim.lockPath));
+
+    const release = workClaims.releaseTask(TICKET, 1, 'PR1');
+    assert.equal(release.success, true);
+    assert.equal(
+      fs.existsSync(claim.lockPath),
+      false,
+      'lock file must be removed on successful release'
+    );
+  });
+
+  it('rejects release from a wrong owner with structured error', () => {
+    const claim = workClaims.claimTask(TICKET, 1, 'PR1');
+    assert.equal(claim.success, true);
+
+    const release = workClaims.releaseTask(TICKET, 1, 'PR2');
+    assert.equal(release.success, false, 'wrong-owner release must fail closed');
+    assert.equal(release.existingOwner, 'PR1');
+    assert.ok(release.error, 'rejection must carry a structured error');
+    assert.ok(release.error.code, 'error must have a stable `code`');
+
+    // Lock file MUST still exist (wrong-owner release does not delete).
+    assert.ok(
+      fs.existsSync(claim.lockPath),
+      'wrong-owner release must not delete the existing lock'
+    );
+    const payload = JSON.parse(fs.readFileSync(claim.lockPath, 'utf8'));
+    assert.equal(payload.ownerId, 'PR1');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// R15 — Input validation: ticketId, ownerId, taskNum
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('claimTask — R15 input validation (fail closed, no I/O)', () => {
+  it('rejects bad ticket ids with INVALID_TICKET_ID; creates no directory', () => {
+    const bad = ['', '   ', null, undefined, '../x', '/etc/passwd', 'a/b', 'a\\b', 'a\0b'];
+    for (const ticketId of bad) {
+      const result = workClaims.claimTask(ticketId, 1, 'PR1');
+      assert.equal(
+        result.success,
+        false,
+        `bad ticketId ${JSON.stringify(ticketId)} must fail closed`
+      );
+      assert.ok(result.error, 'must report structured error');
+      assert.equal(
+        result.error.code,
+        'INVALID_TICKET_ID',
+        `expected INVALID_TICKET_ID for ${JSON.stringify(ticketId)}`
+      );
+    }
+
+    // R15: no directory created for any of the above.
+    // (TEMP_TASKS_BASE may have entries from well-formed tickets but none
+    //  should have been added by this test — we use a probe path here.)
+    // Spot-check: the "../x" traversal attempt must not have escaped.
+    assert.equal(
+      fs.existsSync(path.join(TEMP_TASKS_BASE, '..', 'x')),
+      false,
+      'traversal attempt must not create any directory outside TASKS_BASE'
+    );
+  });
+
+  it('rejects bad owner ids with INVALID_OWNER_ID; no lock written', () => {
+    const TICKET = freshTicket('TEST-OWNER-BAD');
+    const bad = ['', 'user', 'PR', 'PR-1', 'PRabc', 'pr1', 'PR 1', 'PR01a', null, 1];
+    for (const ownerId of bad) {
+      const result = workClaims.claimTask(TICKET, 1, ownerId);
+      assert.equal(
+        result.success,
+        false,
+        `bad ownerId ${JSON.stringify(ownerId)} must fail closed`
+      );
+      assert.ok(result.error, 'must report structured error');
+      assert.equal(
+        result.error.code,
+        'INVALID_OWNER_ID',
+        `expected INVALID_OWNER_ID for ${JSON.stringify(ownerId)}`
+      );
+    }
+
+    // No lock file must have been written.
+    const claimsDir = claimsDirFor(TICKET);
+    if (fs.existsSync(claimsDir)) {
+      const entries = fs.readdirSync(claimsDir);
+      assert.deepEqual(
+        entries.filter((e) => e.endsWith('.lock')),
+        [],
+        'no lock file may be created when owner id is invalid'
+      );
+    }
+
+    cleanupTicket(TICKET);
+  });
+
+  it('accepts all valid PR{N} owner ids (positive integers)', () => {
+    const TICKET = freshTicket('TEST-OWNER-OK');
+    const good = ['PR1', 'PR2', 'PR10', 'PR99', 'PR123'];
+    for (let i = 0; i < good.length; i++) {
+      const result = workClaims.claimTask(TICKET, i + 1, good[i]);
+      assert.equal(result.success, true, `valid ownerId ${good[i]} must be accepted`);
+    }
+    cleanupTicket(TICKET);
+  });
+
+  it('rejects bad task numbers with INVALID_TASK_NUM', () => {
+    const TICKET = freshTicket('TEST-TASKNUM-BAD');
+    const bad = [0, -1, -100, 'abc', null, undefined, 1.5, NaN, '', {}];
+    for (const taskNum of bad) {
+      const result = workClaims.claimTask(TICKET, taskNum, 'PR1');
+      assert.equal(
+        result.success,
+        false,
+        `bad taskNum ${JSON.stringify(taskNum)} must fail closed`
+      );
+      assert.ok(result.error, 'must report structured error');
+      assert.equal(
+        result.error.code,
+        'INVALID_TASK_NUM',
+        `expected INVALID_TASK_NUM for ${JSON.stringify(taskNum)}`
+      );
+    }
+    cleanupTicket(TICKET);
+  });
+});
+
+describe('releaseTask — R15 input validation (same shape as claimTask)', () => {
+  it('rejects bad ticket ids', () => {
+    const result = workClaims.releaseTask('', 1, 'PR1');
+    assert.equal(result.success, false);
+    assert.equal(result.error.code, 'INVALID_TICKET_ID');
+  });
+
+  it('rejects bad owner ids', () => {
+    const TICKET = freshTicket('TEST-REL-OWNER');
+    const result = workClaims.releaseTask(TICKET, 1, 'user');
+    assert.equal(result.success, false);
+    assert.equal(result.error.code, 'INVALID_OWNER_ID');
+    cleanupTicket(TICKET);
+  });
+
+  it('rejects bad task numbers', () => {
+    const TICKET = freshTicket('TEST-REL-TASKNUM');
+    const result = workClaims.releaseTask(TICKET, 'abc', 'PR1');
+    assert.equal(result.success, false);
+    assert.equal(result.error.code, 'INVALID_TASK_NUM');
+    cleanupTicket(TICKET);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// R5 acceptance-criterion: session-guard.js unchanged by this module
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('R5 — does not perturb session-guard / work-state surfaces', () => {
+  it('does not re-export session-guard internals', () => {
+    // Sanity: session-guard remains a ticket-level concern. work-claims
+    // must not shadow or re-export its CLI subcommands.
+    assert.equal(
+      typeof workClaims.handleStop,
+      'undefined',
+      'work-claims must not leak session-guard hook handlers'
+    );
+    assert.equal(
+      typeof workClaims.writeSessionAtomic,
+      'undefined',
+      'work-claims must not re-export writeSessionAtomic'
+    );
+  });
+
+  it('work-state keeps claimTask reachable (spec verification checklist)', () => {
+    // Spec verification checklist requires `GREP workflows/work/work-state.js
+    // /claimTask/`. Work-state should re-export the claim surface so the
+    // one-import convention for CLI / downstream consumers continues to work.
+    assert.equal(
+      typeof workState.claimTask,
+      'function',
+      'work-state.js must re-export claimTask for downstream / CLI consumers'
+    );
+    assert.equal(
+      typeof workState.releaseTask,
+      'function',
+      'work-state.js must re-export releaseTask for symmetry'
+    );
+  });
+});

--- a/workflows/work/__tests__/work-enforcement-context.test.js
+++ b/workflows/work/__tests__/work-enforcement-context.test.js
@@ -1,0 +1,421 @@
+/**
+ * Tests for work-enforcement-context.js
+ *
+ * IDEA2 / GH-219 — Task 2: Enforcement context adapter.
+ *
+ * Requirements covered:
+ *   R1  — gates read `.work-state.json` and parsed `tasks.md` via one shared
+ *         adapter; no transcript grep.
+ *   R2  — origin ∈ {workflow, ai-subtask, user} derived from observable
+ *         signals only; ambiguous `--subtask` does NOT throw — it returns a
+ *         structured error descriptor consumable by preflight (Task 3).
+ *   R15 — bad ticket id (empty, path-traversal, non-string) is rejected
+ *         fail-closed without any filesystem I/O.
+ *
+ * Uses node:test + node:assert/strict with require.cache injection to stub
+ * `loadState` / `loadActiveSubtaskState` / `parseTasks` without touching disk.
+ *
+ * Run: node --test workflows/work/__tests__/work-enforcement-context.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const Module = require('module'); // module resolution helpers
+
+// Resolve target + dependency paths ONCE to match what the adapter will
+// receive from its own `require('./work-state')` / `require('./task-parser')`
+// / `require('../lib/config')` calls — same absolute paths are cached.
+const MODULE_PATH = path.join(__dirname, '..', 'work-enforcement-context');
+const WORK_STATE_PATH = require.resolve(path.join(__dirname, '..', 'work-state'));
+const TASK_PARSER_PATH = require.resolve(path.join(__dirname, '..', 'task-parser'));
+const CONFIG_PATH = require.resolve(path.join(__dirname, '..', '..', 'lib', 'config'));
+
+// ─── Mock infrastructure ────────────────────────────────────────────────────
+
+/**
+ * Install mocks for work-state, task-parser, and config in require.cache.
+ * Each mock records every call it receives so individual tests can assert
+ * that only the expected functions were hit (e.g. no transcript reads).
+ */
+function installMocks({ state = null, tasks = null, subtaskState = null, safeId } = {}) {
+  const loadStateCalls = [];
+  const loadActiveSubtaskStateCalls = [];
+  const parseTasksCalls = [];
+  const safeTicketIdCalls = [];
+
+  require.cache[WORK_STATE_PATH] = {
+    id: WORK_STATE_PATH,
+    filename: WORK_STATE_PATH,
+    loaded: true,
+    exports: {
+      loadState: (ticketId) => {
+        loadStateCalls.push(ticketId);
+        return typeof state === 'function' ? state(ticketId) : state;
+      },
+      loadActiveSubtaskState: (ticketId) => {
+        loadActiveSubtaskStateCalls.push(ticketId);
+        return typeof subtaskState === 'function' ? subtaskState(ticketId) : subtaskState;
+      },
+    },
+  };
+
+  require.cache[TASK_PARSER_PATH] = {
+    id: TASK_PARSER_PATH,
+    filename: TASK_PARSER_PATH,
+    loaded: true,
+    exports: {
+      parseTasks: (tasksDir) => {
+        parseTasksCalls.push(tasksDir);
+        return typeof tasks === 'function' ? tasks(tasksDir) : tasks;
+      },
+    },
+  };
+
+  require.cache[CONFIG_PATH] = {
+    id: CONFIG_PATH,
+    filename: CONFIG_PATH,
+    loaded: true,
+    exports: {
+      TASKS_BASE: '/fake/tasks',
+      safeTicketId: (id) => {
+        safeTicketIdCalls.push(id);
+        return typeof safeId === 'function' ? safeId(id) : id;
+      },
+      tasksDir: (id) => path.join('/fake/tasks', id),
+    },
+  };
+
+  delete require.cache[require.resolve(MODULE_PATH)];
+
+  return { loadStateCalls, loadActiveSubtaskStateCalls, parseTasksCalls, safeTicketIdCalls };
+}
+
+function uninstallMocks() {
+  delete require.cache[WORK_STATE_PATH];
+  delete require.cache[TASK_PARSER_PATH];
+  delete require.cache[CONFIG_PATH];
+  delete require.cache[require.resolve(MODULE_PATH)];
+}
+
+/**
+ * Wrap `fs.readFileSync` and `child_process.execSync` so tests can assert
+ * the adapter never reads transcript files and never calls grep. Returns a
+ * restore() function that reinstates the originals and a `calls` object
+ * with the recorded arguments.
+ */
+function spyOnIO() {
+  const fs = require('fs');
+  const cp = require('child_process');
+  const origRead = fs.readFileSync;
+  const origExec = cp.execSync;
+  const calls = { reads: [], execs: [] };
+
+  fs.readFileSync = function (...args) {
+    calls.reads.push(String(args[0] ?? ''));
+    return origRead.apply(this, args);
+  };
+  cp.execSync = function (...args) {
+    calls.execs.push(String(args[0] ?? ''));
+    return origExec.apply(this, args);
+  };
+
+  return {
+    calls,
+    restore() {
+      fs.readFileSync = origRead;
+      cp.execSync = origExec;
+    },
+  };
+}
+
+// ─── R1 / R2 — Origin derivation ────────────────────────────────────────────
+
+describe('loadEnforcementContext — origin derivation (R1, R2)', () => {
+  afterEach(uninstallMocks);
+
+  it('returns origin "workflow" when state.status === "in_progress"', () => {
+    installMocks({
+      state: { ticketId: 'GH-219', status: 'in_progress', currentStep: 4 },
+      tasks: null,
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219');
+
+    assert.equal(ctx.origin, 'workflow', 'active workflow state => origin=workflow');
+    assert.equal(ctx.hasWorkflow, true, 'hasWorkflow is a boolean signal for hooks');
+    assert.equal(ctx.error, null, 'no error for a valid active workflow');
+    assert.equal(ctx.state.status, 'in_progress', 'raw state is included for hook consumers');
+  });
+
+  it('returns origin "ai-subtask" when --subtask flag AND a resolvable subtask state exists', () => {
+    installMocks({
+      state: { ticketId: 'GH-219', status: 'completed' },
+      subtaskState: {
+        ticketId: 'GH-219',
+        isSubtask: true,
+        parentTicketId: 'GH-219',
+        subtaskIndex: 2,
+        status: 'in_progress',
+      },
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219', { subtask: true });
+
+    assert.equal(ctx.origin, 'ai-subtask', '--subtask + resolvable state => origin=ai-subtask');
+    assert.equal(ctx.error, null, 'no error when subtask state resolves');
+    assert.equal(ctx.subtaskState.subtaskIndex, 2, 'resolved subtask state is exposed for hooks');
+    assert.equal(ctx.hasWorkflow, false, 'completed main workflow does not imply workflow origin');
+  });
+
+  it('returns origin "user" when there is no active workflow and no subtask flag', () => {
+    installMocks({ state: null, tasks: null });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219');
+
+    assert.equal(ctx.origin, 'user', 'default origin is user');
+    assert.equal(ctx.hasWorkflow, false);
+    assert.equal(ctx.error, null);
+  });
+
+  it('treats main state with status !== "in_progress" as non-workflow', () => {
+    installMocks({ state: { ticketId: 'GH-219', status: 'completed' } });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219');
+
+    assert.equal(ctx.origin, 'user', 'completed workflow should not produce workflow origin');
+  });
+
+  it('never derives origin from caller-supplied fields on options (R15 trust boundary)', () => {
+    installMocks({ state: null });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219', {
+      // Hostile payload trying to force an origin — adapter must ignore these.
+      origin: 'workflow',
+      _origin: 'ai-subtask',
+    });
+
+    assert.equal(ctx.origin, 'user', 'caller-supplied origin field must not influence derivation');
+  });
+});
+
+// ─── Ambiguous --subtask (R2 fail-closed, no throw) ─────────────────────────
+
+describe('loadEnforcementContext — ambiguous --subtask (R2)', () => {
+  afterEach(uninstallMocks);
+
+  it('returns a structured error descriptor (NOT a throw) when --subtask is set but no subtask state resolves', () => {
+    installMocks({
+      state: { status: 'in_progress' }, // main workflow active, but flag says subtask
+      subtaskState: null, // <-- no resolvable subtask
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+
+    let ctx;
+    assert.doesNotThrow(() => {
+      ctx = loadEnforcementContext('GH-219', { subtask: true });
+    }, 'ambiguous subtask must not throw — preflight must see a structured payload');
+
+    assert.ok(ctx.error, 'error descriptor is present on ambiguous subtask');
+    assert.equal(
+      typeof ctx.error.code,
+      'string',
+      'error.code is a stable string for rule-id routing'
+    );
+    assert.match(
+      ctx.error.code,
+      /subtask/i,
+      'error.code identifies the ambiguous-subtask rule (consumable by preflight)'
+    );
+    assert.equal(typeof ctx.error.message, 'string', 'error.message is human-readable');
+    assert.ok(Array.isArray(ctx.error.remediation), 'remediation is an array of fix steps');
+    assert.ok(
+      ctx.error.remediation.length > 0,
+      'at least one remediation step is provided (R18 quality)'
+    );
+  });
+
+  it('does not claim ai-subtask origin when ambiguous — origin is null or user, never ai-subtask', () => {
+    installMocks({ state: null, subtaskState: null });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219', { subtask: true });
+
+    assert.notEqual(
+      ctx.origin,
+      'ai-subtask',
+      'ambiguous subtask must NOT be treated as ai-subtask origin'
+    );
+    assert.ok(ctx.error, 'error descriptor is still present');
+  });
+});
+
+// ─── R15 — Bad ticket id (fail-closed, no filesystem I/O) ───────────────────
+
+describe('loadEnforcementContext — R15 ticket id validation', () => {
+  afterEach(uninstallMocks);
+
+  it('returns a deterministic error for an empty string ticket id', () => {
+    installMocks({ state: null });
+    const spy = spyOnIO();
+
+    try {
+      const { loadEnforcementContext } = require(MODULE_PATH);
+      const ctx = loadEnforcementContext('');
+
+      assert.ok(ctx.error, 'empty ticket id yields an error descriptor');
+      assert.match(ctx.error.code, /ticket/i, 'error code points at ticket id problem');
+      assert.equal(ctx.origin, null, 'no origin derivation for invalid ticket id');
+      assert.ok(
+        Array.isArray(ctx.error.remediation) && ctx.error.remediation.length > 0,
+        'remediation provided for R18 quality bar'
+      );
+
+      for (const execCall of spy.calls.execs) {
+        assert.ok(
+          !/grep/i.test(execCall),
+          `no grep calls allowed — saw: ${execCall.slice(0, 120)}`
+        );
+      }
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it('rejects path-traversal characters (.. / \\ null bytes)', () => {
+    installMocks({ state: null });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+
+    for (const bad of ['../../etc', 'GH-219/../secret', 'GH\\219', 'GH-219\u0000x']) {
+      const ctx = loadEnforcementContext(bad);
+      assert.ok(ctx.error, `path-traversal candidate "${bad}" must be rejected`);
+      assert.match(ctx.error.code, /ticket/i);
+      assert.equal(ctx.origin, null, 'invalid ticket id yields no origin');
+    }
+  });
+
+  it('rejects non-string ticket ids (number, null, undefined, object)', () => {
+    installMocks({ state: null });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+
+    for (const bad of [null, undefined, 42, {}, []]) {
+      const ctx = loadEnforcementContext(bad);
+      assert.ok(ctx.error, `non-string ticket id must be rejected: ${JSON.stringify(bad)}`);
+      assert.equal(ctx.origin, null);
+    }
+  });
+
+  it('does not perform any filesystem I/O for an invalid ticket id (fail-closed)', () => {
+    const mocks = installMocks({ state: null });
+    const spy = spyOnIO();
+
+    try {
+      const { loadEnforcementContext } = require(MODULE_PATH);
+      const ctx = loadEnforcementContext('../traversal');
+
+      assert.ok(ctx.error, 'invalid id yields error');
+      assert.equal(
+        mocks.loadStateCalls.length,
+        0,
+        'loadState MUST NOT be called for invalid ticket id'
+      );
+      assert.equal(
+        mocks.parseTasksCalls.length,
+        0,
+        'parseTasks MUST NOT be called for invalid ticket id'
+      );
+      assert.equal(
+        mocks.loadActiveSubtaskStateCalls.length,
+        0,
+        'loadActiveSubtaskState MUST NOT be called for invalid ticket id'
+      );
+    } finally {
+      spy.restore();
+    }
+  });
+});
+
+// ─── R1 — No transcript reads, no grep calls ────────────────────────────────
+
+describe('loadEnforcementContext — no transcript / no grep (R1)', () => {
+  afterEach(uninstallMocks);
+
+  it('does not read transcript files and does not invoke grep when resolving origin', () => {
+    installMocks({ state: { status: 'in_progress' }, tasks: [], subtaskState: null });
+    const spy = spyOnIO();
+
+    try {
+      const { loadEnforcementContext } = require(MODULE_PATH);
+      const ctx = loadEnforcementContext('GH-219', { subtask: false });
+
+      assert.equal(ctx.origin, 'workflow');
+
+      for (const p of spy.calls.reads) {
+        assert.ok(
+          !/\.jsonl$/i.test(p),
+          `adapter must not read transcript jsonl files — saw: ${p}`
+        );
+        assert.ok(!/transcript/i.test(p), `adapter must not read transcript files — saw: ${p}`);
+      }
+      for (const e of spy.calls.execs) {
+        assert.ok(!/\bgrep\b/.test(e), `adapter must not call grep — saw: ${e}`);
+      }
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it('delegates state + tasks reads exclusively through loadState / parseTasks stubs', () => {
+    const mocks = installMocks({
+      state: { status: 'in_progress' },
+      tasks: [{ id: 'task_1', num: 1, dependencies: [] }],
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219');
+
+    assert.ok(mocks.loadStateCalls.length > 0, 'adapter must call loadState via work-state.js');
+    assert.ok(mocks.parseTasksCalls.length > 0, 'adapter must call parseTasks via task-parser.js');
+    assert.ok(Array.isArray(ctx.tasks) && ctx.tasks[0].id === 'task_1', 'tasks are exposed on context');
+  });
+});
+
+// ─── EnforcementContext shape (Task 3 consumer contract) ────────────────────
+
+describe('loadEnforcementContext — context shape (Task 3 contract)', () => {
+  afterEach(uninstallMocks);
+
+  it('exposes a stable shape: { ticketId, origin, state, tasks, subtaskState, hasWorkflow, error, options }', () => {
+    installMocks({
+      state: { status: 'in_progress', tasksMeta: { totalTasks: 2 } },
+      tasks: [{ id: 'task_1', num: 1 }],
+    });
+
+    const { loadEnforcementContext } = require(MODULE_PATH);
+    const ctx = loadEnforcementContext('GH-219');
+
+    // Keys that Task 3 (preflight) will read
+    for (const key of [
+      'ticketId',
+      'origin',
+      'state',
+      'tasks',
+      'subtaskState',
+      'hasWorkflow',
+      'error',
+      'options',
+    ]) {
+      assert.ok(key in ctx, `EnforcementContext must expose "${key}" for preflight consumer`);
+    }
+    assert.equal(ctx.ticketId, 'GH-219', 'ticketId is the sanitized id');
+    assert.equal(ctx.options.subtask, undefined, 'options are echoed for caller traceability');
+  });
+});

--- a/workflows/work/__tests__/work-state-graph.test.js
+++ b/workflows/work/__tests__/work-state-graph.test.js
@@ -1,0 +1,490 @@
+/**
+ * Tests for dependency graph support in work-state.js
+ *
+ * IDEA2 / GH-219 — Task 5: `tasksMeta` dependencies + graph validation +
+ * `canStart(ticketId, taskNum)` readiness query.
+ *
+ * Requirements covered:
+ *   R3  — Dependency readiness: `canStart(taskNum)` iff all declared
+ *         dependencies complete; tasks with no dependencies are startable.
+ *   R4  — Graph validation before writes: unknown dep id, self-dependency,
+ *         cycles; fail closed with structured remediation; invalid graphs
+ *         never reach disk.
+ *   R16 — Backward compatibility: pre-IDEA2 `.work-state.json` files whose
+ *         `tasksMeta.tasks[*]` lack a `dependencies` field must still load;
+ *         `canStart` defaults to true for those tasks (matches pre-IDEA2
+ *         sequential "always startable" behavior — orchestrator drives
+ *         order via `currentTaskIndex`).
+ *
+ * Uses node:test + node:assert/strict with direct `require()` of work-state
+ * (pure-function testing for graph validator + readiness query is far cleaner
+ * than CLI spawns for array-shaped inputs). The existing work-state.test.js
+ * and task-tracking.test.js cover CLI backward compatibility.
+ *
+ * Run: node --test workflows/work/__tests__/work-state-graph.test.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Set TASKS_BASE BEFORE requiring work-state so config.js picks up the
+// isolated temp directory at module-load time (see workflows/lib/config.js
+// lines 125–127 — TASKS_BASE is resolved once at require() time).
+const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'work-state-graph-test-'));
+process.env.TASKS_BASE = TEMP_TASKS_BASE;
+
+const { describe, it, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const workState = require(path.join(__dirname, '..', 'work-state'));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function freshTicket(prefix) {
+  // Append random suffix to guarantee isolation between tests in the same
+  // process — direct-require tests share the same TASKS_BASE.
+  return `${prefix}-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+}
+
+function cleanupTicket(ticketId) {
+  try {
+    fs.rmSync(path.join(TEMP_TASKS_BASE, ticketId), { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+after(() => {
+  try {
+    fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// validateTaskGraph — pure graph validator (R4)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('validateTaskGraph (R4 — pure graph validator)', () => {
+  it('is exported as a function from work-state', () => {
+    assert.equal(
+      typeof workState.validateTaskGraph,
+      'function',
+      'validateTaskGraph must be exported so Task 12 preflight can reuse it'
+    );
+  });
+
+  it('returns { valid: true, errors: [] } for empty tasks array', () => {
+    const result = workState.validateTaskGraph([]);
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.errors, []);
+  });
+
+  it('returns { valid: true, errors: [] } when no tasks declare dependencies', () => {
+    const result = workState.validateTaskGraph([
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [] },
+      { num: 3, dependencies: [] },
+    ]);
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.errors, []);
+  });
+
+  it('returns { valid: true } for a valid DAG (1 ← 2 ← 3, plus 3 ← 1)', () => {
+    const result = workState.validateTaskGraph([
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [1] },
+      { num: 3, dependencies: [1, 2] },
+    ]);
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.errors, []);
+  });
+
+  it('treats missing `dependencies` field as empty (no error)', () => {
+    const result = workState.validateTaskGraph([{ num: 1 }, { num: 2 }]);
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.errors, []);
+  });
+
+  it('detects self-dependency (A→A) with structured remediation', () => {
+    const result = workState.validateTaskGraph([{ num: 1, dependencies: [1] }]);
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.length >= 1);
+    const err = result.errors.find((e) => e.code === 'SELF_DEPENDENCY');
+    assert.ok(err, 'errors must include a SELF_DEPENDENCY entry');
+    assert.equal(err.taskId, 'task_1');
+    assert.ok(typeof err.message === 'string' && err.message.includes('1'));
+    assert.ok(Array.isArray(err.remediation));
+    assert.ok(err.remediation.length > 0, 'remediation must be non-empty for R18 explainability');
+  });
+
+  it('detects unknown dependency id (Task 2 → Task 99)', () => {
+    const result = workState.validateTaskGraph([
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [99] },
+    ]);
+    assert.equal(result.valid, false);
+    const err = result.errors.find((e) => e.code === 'UNKNOWN_DEPENDENCY');
+    assert.ok(err, 'errors must include an UNKNOWN_DEPENDENCY entry');
+    assert.equal(err.taskId, 'task_2');
+    assert.ok(err.message.includes('99'));
+    assert.ok(Array.isArray(err.remediation) && err.remediation.length > 0);
+  });
+
+  it('detects a 2-cycle (A→B→A) with DEPENDENCY_CYCLE error', () => {
+    const result = workState.validateTaskGraph([
+      { num: 1, dependencies: [2] },
+      { num: 2, dependencies: [1] },
+    ]);
+    assert.equal(result.valid, false);
+    const err = result.errors.find((e) => e.code === 'DEPENDENCY_CYCLE');
+    assert.ok(err, 'errors must include DEPENDENCY_CYCLE');
+    assert.ok(Array.isArray(err.remediation) && err.remediation.length > 0);
+  });
+
+  it('detects a 3-cycle (A→B→C→A) with DEPENDENCY_CYCLE error', () => {
+    // A=1 depends on 3; 3 depends on 2; 2 depends on 1 → cycle 1→3→2→1
+    const result = workState.validateTaskGraph([
+      { num: 1, dependencies: [3] },
+      { num: 2, dependencies: [1] },
+      { num: 3, dependencies: [2] },
+    ]);
+    assert.equal(result.valid, false);
+    const err = result.errors.find((e) => e.code === 'DEPENDENCY_CYCLE');
+    assert.ok(err, 'errors must include DEPENDENCY_CYCLE for 3-cycle');
+  });
+
+  it('every error matches { code, taskId, message, remediation } contract', () => {
+    // Invalid graph with multiple kinds of errors
+    const result = workState.validateTaskGraph([
+      { num: 1, dependencies: [1] }, // self-dep
+      { num: 2, dependencies: [99] }, // unknown
+      { num: 3, dependencies: [4] },
+      { num: 4, dependencies: [3] }, // 2-cycle between 3 and 4
+    ]);
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.length >= 3, 'should report all error classes');
+    for (const err of result.errors) {
+      assert.equal(typeof err.code, 'string', 'code must be a string');
+      assert.ok(err.code.length > 0, 'code must be non-empty');
+      assert.ok(
+        typeof err.taskId === 'string' || err.taskId === null,
+        'taskId must be a string or null'
+      );
+      assert.equal(typeof err.message, 'string', 'message must be a string');
+      assert.ok(err.message.length > 0, 'message must be non-empty');
+      assert.ok(Array.isArray(err.remediation), 'remediation must be an array');
+    }
+  });
+
+  it('returns validation error when input is not an array (fail-closed)', () => {
+    const result = workState.validateTaskGraph(null);
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.length >= 1);
+    assert.equal(typeof result.errors[0].code, 'string');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// initTasksMeta — extended to consume parseTasks output and validate (R4)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('initTasksMeta — parseTasks output + graph validation (R3, R4, R16)', () => {
+  let TICKET;
+  beforeEach(() => {
+    TICKET = freshTicket('TEST-GRAPH-INIT');
+    cleanupTicket(TICKET);
+  });
+
+  it('persists dependencies on each task for a valid DAG (R3)', () => {
+    workState.initState(TICKET);
+    const result = workState.initTasksMeta(TICKET, [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [1] },
+      { num: 3, dependencies: [1, 2] },
+    ]);
+    assert.ok(!result.error, `should succeed for valid DAG, got: ${JSON.stringify(result)}`);
+
+    const state = workState.loadState(TICKET);
+    assert.equal(state.tasksMeta.totalTasks, 3);
+    assert.equal(state.tasksMeta.tasks.length, 3);
+    assert.deepEqual(state.tasksMeta.tasks[0].dependencies, []);
+    assert.deepEqual(state.tasksMeta.tasks[1].dependencies, [1]);
+    assert.deepEqual(state.tasksMeta.tasks[2].dependencies, [1, 2]);
+    assert.equal(state.tasksMeta.tasks[0].id, 'task_1');
+    assert.equal(state.tasksMeta.tasks[0].status, 'pending');
+  });
+
+  it('rejects cycle (A→B→A) BEFORE writing tasksMeta to disk (R4)', () => {
+    workState.initState(TICKET);
+    const result = workState.initTasksMeta(TICKET, [
+      { num: 1, dependencies: [2] },
+      { num: 2, dependencies: [1] },
+    ]);
+    assert.ok(result.error, 'must return error descriptor');
+    assert.ok(
+      Array.isArray(result.errors) && result.errors.length > 0,
+      'error response must include structured errors array'
+    );
+    const cycleErr = result.errors.find((e) => e.code === 'DEPENDENCY_CYCLE');
+    assert.ok(cycleErr, 'errors must include DEPENDENCY_CYCLE');
+
+    // Fail-closed: verify NOT persisted
+    const state = workState.loadState(TICKET);
+    assert.equal(
+      state.tasksMeta,
+      undefined,
+      'invalid graph must not reach disk — tasksMeta must remain unset'
+    );
+  });
+
+  it('rejects 3-cycle (A→B→C→A) BEFORE writing (R4)', () => {
+    workState.initState(TICKET);
+    const result = workState.initTasksMeta(TICKET, [
+      { num: 1, dependencies: [3] },
+      { num: 2, dependencies: [1] },
+      { num: 3, dependencies: [2] },
+    ]);
+    assert.ok(result.error);
+    assert.ok(result.errors.some((e) => e.code === 'DEPENDENCY_CYCLE'));
+
+    const state = workState.loadState(TICKET);
+    assert.equal(state.tasksMeta, undefined, '3-cycle invalid graph must not reach disk');
+  });
+
+  it('rejects self-dependency (A→A) BEFORE writing (R4)', () => {
+    workState.initState(TICKET);
+    const result = workState.initTasksMeta(TICKET, [{ num: 1, dependencies: [1] }]);
+    assert.ok(result.error);
+    assert.ok(result.errors.some((e) => e.code === 'SELF_DEPENDENCY'));
+
+    const state = workState.loadState(TICKET);
+    assert.equal(state.tasksMeta, undefined, 'self-dep invalid graph must not reach disk');
+  });
+
+  it('rejects unknown dependency id BEFORE writing (R4)', () => {
+    workState.initState(TICKET);
+    const result = workState.initTasksMeta(TICKET, [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [99] },
+    ]);
+    assert.ok(result.error);
+    assert.ok(result.errors.some((e) => e.code === 'UNKNOWN_DEPENDENCY'));
+
+    const state = workState.loadState(TICKET);
+    assert.equal(state.tasksMeta, undefined, 'unknown dep invalid graph must not reach disk');
+  });
+
+  it('R16: integer taskCount form still works (no dependencies field persisted)', () => {
+    workState.initState(TICKET);
+    const result = workState.initTasksMeta(TICKET, 3);
+    assert.ok(!result.error, 'integer form must still succeed');
+
+    const state = workState.loadState(TICKET);
+    assert.equal(state.tasksMeta.totalTasks, 3);
+    assert.equal(state.tasksMeta.tasks.length, 3);
+    // Pre-IDEA2 semantics: no dependencies field present in the task entries
+    assert.equal(
+      state.tasksMeta.tasks[0].dependencies,
+      undefined,
+      'integer form must not inject a dependencies field (pre-IDEA2 wire format)'
+    );
+  });
+
+  it('R16: loads pre-IDEA2 state file lacking `dependencies` without error', () => {
+    // Simulate a pre-IDEA2 state file written on disk BEFORE the schema extension.
+    const taskDir = path.join(TEMP_TASKS_BASE, TICKET);
+    fs.mkdirSync(taskDir, { recursive: true });
+    const legacyState = {
+      ticketId: TICKET,
+      status: 'in_progress',
+      stepStatus: {},
+      checkProgress: {},
+      errors: [],
+      startTime: new Date().toISOString(),
+      lastUpdate: new Date().toISOString(),
+      tasksMeta: {
+        totalTasks: 2,
+        currentTaskIndex: 0,
+        tasks: [
+          { id: 'task_1', status: 'pending' }, // NO dependencies field
+          { id: 'task_2', status: 'pending' }, // NO dependencies field
+        ],
+      },
+    };
+    fs.writeFileSync(
+      path.join(taskDir, '.work-state.json'),
+      JSON.stringify(legacyState, null, 2)
+    );
+
+    // loadState must not throw on the missing fields (R16)
+    const loaded = workState.loadState(TICKET);
+    assert.ok(loaded, 'loadState must return the legacy state unchanged');
+    assert.equal(loaded.tasksMeta.tasks.length, 2);
+    assert.equal(loaded.tasksMeta.tasks[0].dependencies, undefined);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// canStart(ticketId, taskNum) — pure readiness query (R3, R16)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('canStart(ticketId, taskNum) — pure dependency readiness (R3, R16)', () => {
+  let TICKET;
+  beforeEach(() => {
+    TICKET = freshTicket('TEST-CANSTART');
+    cleanupTicket(TICKET);
+  });
+
+  it('is exported from work-state (single source of truth for preflight/Task 12)', () => {
+    assert.equal(
+      typeof workState.canStart,
+      'function',
+      'canStart must be the only implementation — preflight imports from work-state'
+    );
+  });
+
+  it('returns true when task has no dependencies (empty deps = startable)', () => {
+    workState.initState(TICKET);
+    workState.initTasksMeta(TICKET, [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [] },
+    ]);
+    assert.equal(workState.canStart(TICKET, 1), true);
+    assert.equal(workState.canStart(TICKET, 2), true);
+  });
+
+  it('returns true when all declared dependencies are completed', () => {
+    workState.initState(TICKET);
+    workState.initTasksMeta(TICKET, [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [1] },
+    ]);
+    // Complete task 1 (simulate prior completion)
+    const state = workState.loadState(TICKET);
+    state.tasksMeta.tasks[0].status = 'completed';
+    workState.saveState(TICKET, state);
+
+    assert.equal(workState.canStart(TICKET, 2), true);
+  });
+
+  it('returns false when a declared dependency is still pending (R3)', () => {
+    workState.initState(TICKET);
+    workState.initTasksMeta(TICKET, [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [1] },
+    ]);
+    // Task 1 is pending — canStart(2) must be false
+    assert.equal(workState.canStart(TICKET, 2), false);
+  });
+
+  it('returns false when dependencies are mixed (some completed, some pending)', () => {
+    workState.initState(TICKET);
+    workState.initTasksMeta(TICKET, [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [] },
+      { num: 3, dependencies: [1, 2] },
+    ]);
+    // Only complete task 1 — task 2 is still pending
+    const state = workState.loadState(TICKET);
+    state.tasksMeta.tasks[0].status = 'completed';
+    workState.saveState(TICKET, state);
+
+    assert.equal(workState.canStart(TICKET, 3), false);
+  });
+
+  it('returns false for unknown dep in persisted meta (fail-closed)', () => {
+    // Simulate state where a dep points to a task that does not exist in tasksMeta.
+    // Can happen if a pre-IDEA2 ticket is manually edited or a corrupt state.
+    const taskDir = path.join(TEMP_TASKS_BASE, TICKET);
+    fs.mkdirSync(taskDir, { recursive: true });
+    const state = {
+      ticketId: TICKET,
+      status: 'in_progress',
+      stepStatus: {},
+      checkProgress: {},
+      errors: [],
+      startTime: new Date().toISOString(),
+      lastUpdate: new Date().toISOString(),
+      tasksMeta: {
+        totalTasks: 1,
+        currentTaskIndex: 0,
+        tasks: [{ id: 'task_1', status: 'pending', dependencies: [42] }],
+      },
+    };
+    fs.writeFileSync(
+      path.join(taskDir, '.work-state.json'),
+      JSON.stringify(state, null, 2)
+    );
+
+    assert.equal(
+      workState.canStart(TICKET, 1),
+      false,
+      'unknown dep reference in persisted meta must fail-closed'
+    );
+  });
+
+  it('R16: returns true for pre-IDEA2 tasks without a `dependencies` field', () => {
+    // Simulate a pre-IDEA2 state: tasks have NO dependencies field.
+    const taskDir = path.join(TEMP_TASKS_BASE, TICKET);
+    fs.mkdirSync(taskDir, { recursive: true });
+    const state = {
+      ticketId: TICKET,
+      status: 'in_progress',
+      stepStatus: {},
+      checkProgress: {},
+      errors: [],
+      startTime: new Date().toISOString(),
+      lastUpdate: new Date().toISOString(),
+      tasksMeta: {
+        totalTasks: 3,
+        currentTaskIndex: 0,
+        tasks: [
+          { id: 'task_1', status: 'pending' },
+          { id: 'task_2', status: 'pending' },
+          { id: 'task_3', status: 'pending' },
+        ],
+      },
+    };
+    fs.writeFileSync(
+      path.join(taskDir, '.work-state.json'),
+      JSON.stringify(state, null, 2)
+    );
+
+    // Documented R16 default: missing dependencies field ⇒ treat as empty deps
+    // ⇒ canStart returns true for any task (sequential orchestrator-driven
+    // behavior is preserved — order is still enforced by currentTaskIndex).
+    assert.equal(workState.canStart(TICKET, 1), true);
+    assert.equal(workState.canStart(TICKET, 2), true);
+    assert.equal(workState.canStart(TICKET, 3), true);
+  });
+
+  it('returns false for a non-existent task number', () => {
+    workState.initState(TICKET);
+    workState.initTasksMeta(TICKET, 2);
+    assert.equal(workState.canStart(TICKET, 99), false);
+  });
+
+  it('returns false when no tasksMeta is initialized (fail-closed)', () => {
+    workState.initState(TICKET);
+    assert.equal(workState.canStart(TICKET, 1), false);
+  });
+
+  it('returns false when the task itself is already completed (nothing to start)', () => {
+    workState.initState(TICKET);
+    workState.initTasksMeta(TICKET, [{ num: 1, dependencies: [] }]);
+    const state = workState.loadState(TICKET);
+    state.tasksMeta.tasks[0].status = 'completed';
+    workState.saveState(TICKET, state);
+
+    assert.equal(
+      workState.canStart(TICKET, 1),
+      false,
+      'a completed task cannot be "started" again — fail-closed'
+    );
+  });
+});

--- a/workflows/work/__tests__/work-state-parallel.test.js
+++ b/workflows/work/__tests__/work-state-parallel.test.js
@@ -1,0 +1,449 @@
+/**
+ * Tests for parallel worker PR{N} slot allocation in work-state.js
+ *
+ * IDEA2 / GH-219 — Task 7: `allocateWorkerSlot` / `releaseWorkerSlot`
+ * and the `parallelWorkers: { nextSlot, allocations }` persistence layer.
+ *
+ * Requirements covered:
+ *   R14 — Parallel worker layout `${WORKTREES_BASE}/tasks/<ticketId>/PR{N}/`;
+ *         sequential persisted slot allocation; reuse after clean completion.
+ *   R5  — Owner id binding: PR{N} matches Task 6's owner pattern
+ *         `OWNER_ID_RE = /^PR\d+$/` so allocated ids flow directly into
+ *         `claimTask(ticketId, taskNum, ownerId)` without translation.
+ *   R15 — Sanitized paths; fail-closed on bad ticket id before any FS I/O
+ *         (mirrors work-claims.js R15 validation gate).
+ *
+ * Direct-require pattern (no CLI spawn) keeps the allocator tests fast and
+ * allows inspecting the on-disk `.work-state.json` between calls. Matches
+ * the convention in `work-state-graph.test.js` and `work-claims.test.js`.
+ *
+ * Run: node --test workflows/work/__tests__/work-state-parallel.test.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Set TASKS_BASE BEFORE requiring work-state so config.js picks up the
+// isolated temp directory at module-load time (config.TASKS_BASE is
+// resolved once at require() time — see workflows/lib/config.js 125–127).
+const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'work-state-parallel-test-'));
+process.env.TASKS_BASE = TEMP_TASKS_BASE;
+
+const { describe, it, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const workState = require(path.join(__dirname, '..', 'work-state'));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function freshTicket(prefix) {
+  // Append random suffix so tests in the same process do not collide —
+  // direct-require tests share one TASKS_BASE and module state.
+  return `${prefix}-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+}
+
+function cleanupTicket(ticketId) {
+  try {
+    fs.rmSync(path.join(TEMP_TASKS_BASE, ticketId), { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+function prDirFor(ticketId, slot) {
+  return path.join(TEMP_TASKS_BASE, ticketId, `PR${slot}`);
+}
+
+after(() => {
+  try {
+    fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Public surface
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('work-state parallel worker surface (Task 7)', () => {
+  it('exports allocateWorkerSlot and releaseWorkerSlot as functions', () => {
+    assert.equal(
+      typeof workState.allocateWorkerSlot,
+      'function',
+      'allocateWorkerSlot must be exported from work-state for downstream consumers'
+    );
+    assert.equal(
+      typeof workState.releaseWorkerSlot,
+      'function',
+      'releaseWorkerSlot must be exported from work-state (symmetric with claim/release)'
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// allocateWorkerSlot — happy path (sequential, monotonic)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('allocateWorkerSlot — sequential slot assignment (R14)', () => {
+  let TICKET;
+  beforeEach(() => {
+    TICKET = freshTicket('TEST-ALLOC-OK');
+    cleanupTicket(TICKET);
+  });
+  after(() => cleanupTicket(TICKET));
+
+  it('first call returns { slot: 1, ownerId: "PR1", dir: ".../PR1" } and creates the directory', () => {
+    const result = workState.allocateWorkerSlot(TICKET);
+
+    assert.ok(result, 'allocateWorkerSlot must return a result object');
+    assert.equal(result.slot, 1, 'first allocation must yield slot 1');
+    assert.equal(result.ownerId, 'PR1', 'first owner id must be PR1');
+    assert.equal(
+      result.dir,
+      prDirFor(TICKET, 1),
+      'first directory must be <TASKS_BASE>/<ticket>/PR1'
+    );
+    // Directory must exist on disk (R14: sequential persisted slot creates root)
+    assert.equal(fs.existsSync(result.dir), true, 'PR{N} directory must exist on disk');
+    assert.equal(
+      fs.statSync(result.dir).isDirectory(),
+      true,
+      'PR{N} path must be a directory (not a file / symlink target)'
+    );
+  });
+
+  it('second allocation returns { slot: 2, ownerId: "PR2" } — distinct from first', () => {
+    const first = workState.allocateWorkerSlot(TICKET);
+    const second = workState.allocateWorkerSlot(TICKET);
+
+    assert.equal(first.slot, 1);
+    assert.equal(second.slot, 2, 'second allocation must yield slot 2');
+    assert.equal(second.ownerId, 'PR2');
+    assert.equal(second.dir, prDirFor(TICKET, 2));
+    assert.notEqual(
+      first.slot,
+      second.slot,
+      'two allocations on the same ticket must produce distinct slot numbers'
+    );
+    assert.notEqual(
+      first.ownerId,
+      second.ownerId,
+      'two allocations must produce distinct owner ids'
+    );
+    assert.notEqual(first.dir, second.dir, 'two allocations must produce distinct directories');
+    assert.equal(fs.existsSync(second.dir), true, 'second PR{N} directory must exist');
+  });
+
+  it('third, fourth, fifth allocations continue the monotonic sequence', () => {
+    const slots = [];
+    for (let i = 0; i < 5; i++) {
+      slots.push(workState.allocateWorkerSlot(TICKET).slot);
+    }
+    assert.deepEqual(
+      slots,
+      [1, 2, 3, 4, 5],
+      'nextSlot must increment monotonically on every allocation'
+    );
+  });
+
+  it('ownerId satisfies Task 6 OWNER_ID_RE /^PR\\d+$/ for every allocation', () => {
+    const OWNER_ID_RE = /^PR\d+$/;
+    for (let i = 0; i < 4; i++) {
+      const result = workState.allocateWorkerSlot(TICKET);
+      assert.equal(
+        OWNER_ID_RE.test(result.ownerId),
+        true,
+        `allocation #${i + 1} ownerId ${JSON.stringify(
+          result.ownerId
+        )} must satisfy Task 6's owner regex so it can flow into claimTask`
+      );
+    }
+  });
+
+  it('directory path is absolute and rooted at TASKS_BASE/<ticket>/PR{N}', () => {
+    const result = workState.allocateWorkerSlot(TICKET);
+    assert.equal(path.isAbsolute(result.dir), true, 'dir must be an absolute path');
+    assert.equal(
+      result.dir.startsWith(path.join(TEMP_TASKS_BASE, TICKET) + path.sep),
+      true,
+      'dir must live under <TASKS_BASE>/<ticket>/'
+    );
+    assert.equal(path.basename(result.dir), `PR${result.slot}`, 'final path segment must be PR{N}');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Persistence — parallelWorkers shape + loadState round-trip
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('allocateWorkerSlot — persistence in .work-state.json (R14)', () => {
+  let TICKET;
+  beforeEach(() => {
+    TICKET = freshTicket('TEST-ALLOC-PERSIST');
+    cleanupTicket(TICKET);
+  });
+  after(() => cleanupTicket(TICKET));
+
+  it('persisted `parallelWorkers` field matches { nextSlot, allocations } shape', () => {
+    workState.allocateWorkerSlot(TICKET);
+    workState.allocateWorkerSlot(TICKET);
+
+    const state = workState.loadState(TICKET);
+    assert.ok(state, 'state must exist after allocation');
+    assert.ok(state.parallelWorkers, 'state must carry a `parallelWorkers` field');
+    assert.equal(
+      typeof state.parallelWorkers.nextSlot,
+      'number',
+      'parallelWorkers.nextSlot must be a number'
+    );
+    assert.equal(
+      Array.isArray(state.parallelWorkers.allocations),
+      true,
+      'parallelWorkers.allocations must be an array'
+    );
+
+    // Shape should ONLY have these two documented fields (no other top-level
+    // keys so the data-model reader has a stable contract).
+    const extra = Object.keys(state.parallelWorkers).filter(
+      (k) => k !== 'nextSlot' && k !== 'allocations'
+    );
+    assert.deepEqual(
+      extra,
+      [],
+      `parallelWorkers must only contain nextSlot + allocations (extra keys: ${extra.join(', ')})`
+    );
+
+    // Every allocation entry must carry the documented fields.
+    for (const entry of state.parallelWorkers.allocations) {
+      assert.equal(typeof entry.slot, 'number', 'allocation.slot must be a number');
+      assert.equal(typeof entry.ownerId, 'string', 'allocation.ownerId must be a string');
+      assert.equal(
+        /^PR\d+$/.test(entry.ownerId),
+        true,
+        'allocation.ownerId must satisfy /^PR\\d+$/'
+      );
+      assert.equal(typeof entry.claimedAt, 'string', 'allocation.claimedAt must be an ISO string');
+      assert.equal(
+        new Date(entry.claimedAt).toString() !== 'Invalid Date',
+        true,
+        'allocation.claimedAt must be a valid ISO date'
+      );
+    }
+  });
+
+  it('allocations survive a fresh loadState() round-trip', () => {
+    const a = workState.allocateWorkerSlot(TICKET);
+    const b = workState.allocateWorkerSlot(TICKET);
+
+    // Fresh loadState() (simulating a new process / context reload)
+    const reloaded = workState.loadState(TICKET);
+    assert.ok(reloaded && reloaded.parallelWorkers);
+    assert.equal(
+      reloaded.parallelWorkers.nextSlot,
+      3,
+      'nextSlot must be persisted so the next allocation yields slot 3'
+    );
+    assert.equal(
+      reloaded.parallelWorkers.allocations.length,
+      2,
+      'both allocations must survive the round-trip'
+    );
+    const slots = reloaded.parallelWorkers.allocations.map((x) => x.slot).sort();
+    assert.deepEqual(slots, [a.slot, b.slot].sort());
+  });
+
+  it('next allocation after reload continues the monotonic sequence', () => {
+    workState.allocateWorkerSlot(TICKET);
+    workState.allocateWorkerSlot(TICKET);
+
+    // Force a reload by reading and re-requiring the data via loadState.
+    // The key assertion is that the third allocation uses nextSlot from disk.
+    const third = workState.allocateWorkerSlot(TICKET);
+    assert.equal(third.slot, 3, 'third allocation must yield slot 3 (persisted nextSlot)');
+    assert.equal(third.ownerId, 'PR3');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// releaseWorkerSlot — marks released, allocation still increments
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('releaseWorkerSlot — audit-trail release (R14)', () => {
+  let TICKET;
+  beforeEach(() => {
+    TICKET = freshTicket('TEST-RELEASE');
+    cleanupTicket(TICKET);
+  });
+  after(() => cleanupTicket(TICKET));
+
+  it('marks the allocation entry as released (releasedAt set) without mutating nextSlot', () => {
+    const first = workState.allocateWorkerSlot(TICKET);
+    assert.equal(first.slot, 1);
+    workState.allocateWorkerSlot(TICKET); // slot 2
+
+    const beforeNextSlot = workState.loadState(TICKET).parallelWorkers.nextSlot;
+
+    const release = workState.releaseWorkerSlot(TICKET, 1);
+    assert.ok(release, 'releaseWorkerSlot must return a result');
+    assert.equal(release.success, true, 'releasing a live slot must succeed');
+
+    const state = workState.loadState(TICKET);
+    const entry = state.parallelWorkers.allocations.find((x) => x.slot === 1);
+    assert.ok(entry, 'released allocation must remain in the audit trail');
+    assert.equal(typeof entry.releasedAt, 'string', 'released allocation must carry releasedAt');
+    assert.equal(
+      new Date(entry.releasedAt).toString() !== 'Invalid Date',
+      true,
+      'releasedAt must be a valid ISO date'
+    );
+
+    // nextSlot must NOT decrement — release is audit-only (documented choice:
+    // monotonic increment; see JSDoc on allocateWorkerSlot).
+    assert.equal(
+      state.parallelWorkers.nextSlot,
+      beforeNextSlot,
+      'nextSlot must not decrement on release (monotonic audit trail)'
+    );
+  });
+
+  it('after release, subsequent allocation continues to increment (does NOT reuse)', () => {
+    const first = workState.allocateWorkerSlot(TICKET);
+    const second = workState.allocateWorkerSlot(TICKET);
+    assert.equal(first.slot, 1);
+    assert.equal(second.slot, 2);
+
+    const release = workState.releaseWorkerSlot(TICKET, 1);
+    assert.equal(release.success, true);
+
+    // Key behavioural assertion for the "reuse vs increment" decision:
+    // nextSlot only grows. The third allocation must be slot 3, NOT slot 1.
+    const third = workState.allocateWorkerSlot(TICKET);
+    assert.equal(
+      third.slot,
+      3,
+      'after release, next allocation must increment (slot 3), not reuse released slot 1'
+    );
+    assert.equal(third.ownerId, 'PR3');
+  });
+
+  it('releasing an unknown slot returns a structured error without mutating state', () => {
+    workState.allocateWorkerSlot(TICKET);
+
+    const release = workState.releaseWorkerSlot(TICKET, 99);
+    assert.equal(release.success, false, 'releasing an unknown slot must fail closed');
+    assert.ok(release.error, 'failure must carry a structured error');
+    assert.equal(typeof release.error.code, 'string', 'error.code must be a stable identifier');
+
+    const state = workState.loadState(TICKET);
+    assert.equal(
+      state.parallelWorkers.allocations.length,
+      1,
+      'failed release must not inject a phantom allocation'
+    );
+    assert.equal(state.parallelWorkers.nextSlot, 2, 'failed release must not mutate nextSlot');
+  });
+
+  it('releasing twice is idempotent (second release sees already-released entry)', () => {
+    workState.allocateWorkerSlot(TICKET);
+    const first = workState.releaseWorkerSlot(TICKET, 1);
+    assert.equal(first.success, true);
+
+    const second = workState.releaseWorkerSlot(TICKET, 1);
+    // Either success (idempotent) OR a structured error — both are defensible.
+    // The contract we lock in: state remains well-formed and no exception is thrown.
+    assert.equal(typeof second, 'object');
+    assert.ok('success' in second, 'result must include a `success` field');
+
+    const state = workState.loadState(TICKET);
+    const entry = state.parallelWorkers.allocations.find((x) => x.slot === 1);
+    assert.ok(entry && entry.releasedAt, 'entry must still be marked released');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// R15 — Input validation: fail closed BEFORE any FS I/O
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('allocateWorkerSlot — R15 input validation (fail closed, no I/O)', () => {
+  it('rejects bad ticket ids with INVALID_TICKET_ID; creates no directory / no state', () => {
+    const bad = ['', '   ', null, undefined, '../x', '/etc/passwd', 'a/b', 'a\\b', 'a\0b'];
+    for (const ticketId of bad) {
+      const result = workState.allocateWorkerSlot(ticketId);
+      assert.ok(result, 'even rejected calls must return a result object');
+      assert.equal(
+        result.success,
+        false,
+        `bad ticketId ${JSON.stringify(ticketId)} must fail closed`
+      );
+      assert.ok(result.error, 'rejection must report a structured error');
+      assert.equal(
+        result.error.code,
+        'INVALID_TICKET_ID',
+        `expected INVALID_TICKET_ID for ${JSON.stringify(ticketId)}`
+      );
+      // No `slot` / `ownerId` / `dir` on rejection — these are the success-only
+      // fields; keeping them absent prevents callers from accidentally using
+      // a partially-populated result.
+      assert.equal(result.slot, undefined, 'rejected call must not return a slot');
+      assert.equal(result.ownerId, undefined, 'rejected call must not return an ownerId');
+      assert.equal(result.dir, undefined, 'rejected call must not return a dir');
+    }
+
+    // Traversal probe — "../x" must NOT have created /tmp/.../x outside TASKS_BASE.
+    assert.equal(
+      fs.existsSync(path.join(TEMP_TASKS_BASE, '..', 'x')),
+      false,
+      'traversal attempt must not escape TASKS_BASE'
+    );
+  });
+
+  it('releaseWorkerSlot also rejects bad ticket ids before touching state', () => {
+    const bad = ['', null, '../x'];
+    for (const ticketId of bad) {
+      const result = workState.releaseWorkerSlot(ticketId, 1);
+      assert.equal(result.success, false);
+      assert.equal(result.error.code, 'INVALID_TICKET_ID');
+    }
+  });
+
+  it('releaseWorkerSlot rejects bad slot numbers with structured error', () => {
+    const TICKET = freshTicket('TEST-REL-BADSLOT');
+    const bad = [0, -1, 'abc', null, undefined, 1.5, NaN, '', {}];
+    for (const slot of bad) {
+      const result = workState.releaseWorkerSlot(TICKET, slot);
+      assert.equal(result.success, false, `bad slot ${JSON.stringify(slot)} must fail closed`);
+      assert.ok(result.error, 'must report structured error');
+      assert.equal(typeof result.error.code, 'string');
+    }
+    cleanupTicket(TICKET);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Multi-ticket isolation
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('allocateWorkerSlot — per-ticket isolation', () => {
+  it('two tickets each start at slot 1 (counters are per-ticket, not global)', () => {
+    const T1 = freshTicket('TEST-ISO-A');
+    const T2 = freshTicket('TEST-ISO-B');
+
+    const r1a = workState.allocateWorkerSlot(T1);
+    const r2a = workState.allocateWorkerSlot(T2);
+    assert.equal(r1a.slot, 1, 'ticket A must start at slot 1');
+    assert.equal(r2a.slot, 1, 'ticket B must also start at slot 1 (isolated counter)');
+
+    const r1b = workState.allocateWorkerSlot(T1);
+    assert.equal(r1b.slot, 2, 'ticket A second allocation must be slot 2');
+
+    const r2b = workState.allocateWorkerSlot(T2);
+    assert.equal(r2b.slot, 2, 'ticket B second allocation must be slot 2 (independent)');
+
+    cleanupTicket(T1);
+    cleanupTicket(T2);
+  });
+});

--- a/workflows/work/work-actions.js
+++ b/workflows/work/work-actions.js
@@ -1,12 +1,32 @@
 /**
  * work-actions.js
  *
- * Shared helper for appending timestamped actions to .work-actions.json.
- * Actions are append-only and stored separately from .work-state.json
+ * Shared helper for appending timestamped actions to `.work-actions.json`.
+ * Actions are append-only and stored separately from `.work-state.json`
  * to keep the state file small and avoid conflicts with backward transitions.
  *
+ * Record types (IDEA2 / GH-219 R13 + R16):
+ *   - Legacy step-transition rows: `{ step, timestamp, what, meta? }`.
+ *     Written by `appendAction()`. No `kind` field (pre-IDEA2 compatible).
+ *   - Enforcement audit rows:
+ *     `{ kind: 'enforcement', timestamp, origin, task, phase, action,
+ *        allow, reason, outputPath, meta? }`.
+ *     Written by `appendEnforcementAudit()`.
+ *
+ * Both record types coexist in one file. Consumers discriminate with the
+ * `kind` field: enforcement rows carry `kind === ENFORCEMENT_KIND`; legacy
+ * rows carry no `kind` at all. `loadActions()` returns every row verbatim;
+ * `analyzeActions()` ignores enforcement rows when computing per-step
+ * metrics (they are still counted in `actionCount`).
+ *
  * Usage:
- *   const { appendAction, loadActions, analyzeActions } = require('./work-actions');
+ *   const {
+ *     appendAction,
+ *     appendEnforcementAudit,
+ *     loadActions,
+ *     analyzeActions,
+ *     ENFORCEMENT_KIND,
+ *   } = require('./work-actions');
  *   appendAction('PROJ-881', { step: 'ticket', what: 'step started' });
  */
 
@@ -14,6 +34,14 @@ const fs = require('fs');
 const path = require('path');
 
 const getConfig = require('../lib/get-config');
+
+/**
+ * Discriminator value for enforcement audit rows (IDEA2 spec §Pattern — audit).
+ * Legacy `appendAction` rows never carry this field.
+ * @type {'enforcement'}
+ */
+const ENFORCEMENT_KIND = 'enforcement';
+
 let _tasksBase;
 function getTasksBase() {
   if (!_tasksBase) _tasksBase = getConfig.require('TASKS_BASE');
@@ -29,43 +57,106 @@ function safeId(ticketId) {
   }
 }
 
+function actionsFilePath(ticketId) {
+  return path.join(getTasksBase(), safeId(ticketId), '.work-actions.json');
+}
+
 /**
- * Load actions from .work-actions.json for a given ticket.
+ * Load actions from `.work-actions.json` for a given ticket.
+ *
+ * Returns rows verbatim, including both legacy step rows (no `kind`) and
+ * enforcement audit rows (`kind === ENFORCEMENT_KIND`). Missing or unreadable
+ * files yield `[]` — callers should never see a throw.
+ *
  * @param {string} ticketId
- * @returns {Array<{step: string, timestamp: string, what: string, meta?: object}>}
+ * @returns {Array<object>}
  */
 function loadActions(ticketId) {
   try {
-    const filePath = path.join(getTasksBase(), safeId(ticketId), '.work-actions.json');
-    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    return JSON.parse(fs.readFileSync(actionsFilePath(ticketId), 'utf-8'));
   } catch {
     return [];
   }
 }
 
 /**
- * Append a single action to .work-actions.json.
+ * Shared serialize-and-append helper used by `appendAction` and
+ * `appendEnforcementAudit`. Ensures the ticket directory exists, loads the
+ * current rows, appends `row`, and rewrites the file. Fail-open: errors are
+ * swallowed so logging never breaks the workflow.
+ *
  * @param {string} ticketId
- * @param {{step: string, what: string, meta?: object}} action
+ * @param {object} row — fully-built record; caller stamps its own timestamp.
  */
-function appendAction(ticketId, action) {
+function appendRow(ticketId, row) {
   try {
-    const dir = path.join(getTasksBase(), safeId(ticketId));
-    const filePath = path.join(dir, '.work-actions.json');
+    const filePath = actionsFilePath(ticketId);
+    const dir = path.dirname(filePath);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
     const actions = loadActions(ticketId);
-    actions.push({
-      step: action.step,
-      timestamp: new Date().toISOString(),
-      what: action.what,
-      ...(action.meta ? { meta: action.meta } : {}),
-    });
-
+    actions.push(row);
     fs.writeFileSync(filePath, JSON.stringify(actions, null, 2));
   } catch {
     // Fail-open: never break the workflow for logging
   }
+}
+
+/**
+ * Append a single legacy step-transition action to `.work-actions.json`.
+ * Legacy rows are written WITHOUT a `kind` field — consumers treat any row
+ * whose `kind !== ENFORCEMENT_KIND` (including absent) as a legacy row.
+ *
+ * @param {string} ticketId
+ * @param {{step: string, what: string, meta?: object}} action
+ */
+function appendAction(ticketId, action) {
+  appendRow(ticketId, {
+    step: action.step,
+    timestamp: new Date().toISOString(),
+    what: action.what,
+    ...(action.meta ? { meta: action.meta } : {}),
+  });
+}
+
+/**
+ * Append an enforcement audit record to `.work-actions.json`.
+ *
+ * IDEA2 / GH-219 — Task 1, requirements R13 (shape) + R16 (compatibility).
+ *
+ * Enforcement audit records share the same `.work-actions.json` file as
+ * legacy step rows written by `appendAction()`. They are distinguished by
+ * `kind: ENFORCEMENT_KIND` so `loadActions()` / `analyzeActions()` and
+ * downstream consumers can filter one from the other without introducing a
+ * second on-disk log (spec §Pattern — audit: "No `actions.jsonl`"). Legacy
+ * rows never acquire a `kind` field — a pre-IDEA2 `.work-actions.json` with
+ * only legacy rows parses via `loadActions` / `analyzeActions` unchanged.
+ *
+ * @param {string} ticketId
+ * @param {{
+ *   origin: 'workflow' | 'ai-subtask' | 'user',
+ *   task: number | string | null,
+ *   phase: 'red' | 'green' | 'refactor' | null,
+ *   action: string,
+ *   allow: boolean,
+ *   reason: string,
+ *   outputPath: string | null,
+ *   meta?: object
+ * }} entry
+ */
+function appendEnforcementAudit(ticketId, entry) {
+  appendRow(ticketId, {
+    kind: ENFORCEMENT_KIND,
+    timestamp: new Date().toISOString(),
+    origin: entry.origin,
+    task: entry.task ?? null,
+    phase: entry.phase ?? null,
+    action: entry.action,
+    allow: entry.allow,
+    reason: entry.reason,
+    outputPath: entry.outputPath ?? null,
+    ...(entry.meta ? { meta: entry.meta } : {}),
+  });
 }
 
 /**
@@ -87,6 +178,11 @@ function analyzeActions(actions) {
   const stepMap = new Map();
 
   for (const action of actions) {
+    // IDEA2 / GH-219: skip enforcement audit rows — they do not carry `step` /
+    // `what` fields and would corrupt step-duration accounting. Their record
+    // count still feeds `actionCount` below.
+    if (action && action.kind === ENFORCEMENT_KIND) continue;
+
     if (!stepMap.has(action.step)) {
       stepMap.set(action.step, {
         startTime: null,
@@ -150,8 +246,10 @@ function analyzeActions(actions) {
 
 module.exports = {
   appendAction,
+  appendEnforcementAudit,
   loadActions,
   analyzeActions,
+  ENFORCEMENT_KIND,
   get TASKS_BASE() {
     return getTasksBase();
   },

--- a/workflows/work/work-claims.js
+++ b/workflows/work/work-claims.js
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+
+/**
+ * work-claims.js — Per-task atomic claim locks.
+ *
+ * IDEA2 / GH-219 — Task 6 (R5, R15).
+ *
+ * Provides atomic `claimTask` / `releaseTask` helpers that persist a lock
+ * file at `TASKS_BASE/<ticketId>/.claims/task-${n}.lock` using an
+ * exclusive-create primitive (`fs.linkSync` — see note below). Exactly one
+ * concurrent caller wins the lock; every other caller sees a structured
+ * `ALREADY_CLAIMED` error carrying the winning owner id.
+ *
+ * Atomicity primitive — deviation from brief text, not intent:
+ *   The task description suggests `fs.renameSync` for publication. On POSIX,
+ *   `rename(2)` SILENTLY OVERWRITES the target (verified locally: Linux 6.6).
+ *   That is the correct primitive for writeSessionAtomic (update-in-place),
+ *   but it cannot express the "create if not exists" semantic this lock
+ *   needs. `fs.linkSync(tmp, target)` uses `link(2)`, which is atomic and
+ *   fails with EEXIST when the target already exists — this is the right
+ *   primitive for a lock. We still use a temp file under `.claims/` as per
+ *   the brief and clean it up in a `finally` regardless of outcome.
+ *
+ * Shared helper vs. `writeSessionAtomic` — decision:
+ *   `writeSessionAtomic(ticketId, data)` in `workflows/lib/hooks/session-guard.js`
+ *   implements atomic OVERWRITE (delete target, then rename). This module
+ *   needs atomic CREATE-IF-NOT-EXISTS (never clobber a live lock). The two
+ *   surfaces diverge on outcome — OVERWRITE never fails on EEXIST, CLAIM
+ *   ONLY fails on EEXIST — so extracting a shared helper would force a
+ *   confusing mode flag. Per Task 6.1.3 refactor guidance, keep them
+ *   separate with cross-references in both headers.
+ *
+ * Ticket-scoped session guarding in `workflows/lib/hooks/session-guard.js`
+ * is NOT modified by this module — task claims sit beneath the session
+ * guard, and the two surfaces never touch the same files.
+ *
+ * Module API:
+ *   claimTask(ticketId, taskNum, ownerId)  → Result
+ *   releaseTask(ticketId, taskNum, ownerId) → Result
+ *
+ * Result shape:
+ *   Success:    { success: true, ownerId, lockPath, existingOwner?, idempotent?: true }
+ *   Rejection:  { success: false, existingOwner?, lockPath?, error: { code, message, remediation[] } }
+ *
+ * Error codes:
+ *   INVALID_TICKET_ID  — ticketId missing / empty / traversal / non-string
+ *   INVALID_OWNER_ID   — owner id does not match /^PR\d+$/
+ *   INVALID_TASK_NUM   — task number is not a positive integer
+ *   ALREADY_CLAIMED    — task-${n}.lock already exists with a different owner
+ *   WRONG_OWNER        — releaseTask called by a non-owner
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+// ─── Config resolution ──────────────────────────────────────────────────────
+// Mirrors work-state.js: tolerate missing config (e.g. during partial
+// bootstrap) by exposing a helper rather than failing at require() time.
+let config;
+try {
+  config = require('../lib/config');
+} catch (err) {
+  if (err && err.code === 'MODULE_NOT_FOUND' && /['"]\.\.\/lib\/config['"]/.test(err.message)) {
+    config = null;
+  } else {
+    throw err;
+  }
+}
+
+function getTasksBase() {
+  // Always prefer a live env var read so tests that mutate TASKS_BASE
+  // between invocations still resolve to the isolated temp directory
+  // (matches the work-state-graph.test.js contract — see its header
+  // comment on module-load timing).
+  return process.env.TASKS_BASE || (config && config.TASKS_BASE) || null;
+}
+
+// ─── Input validation ──────────────────────────────────────────────────────
+// R15 fail-closed: every validation helper returns null on success and a
+// structured error object on failure. Callers short-circuit at the first
+// error so we never touch the filesystem with bad input (no directory
+// creation, no rename target resolution).
+
+const OWNER_ID_RE = /^PR\d+$/;
+
+function validateTicketId(ticketId) {
+  if (typeof ticketId !== 'string') {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `ticketId must be a non-empty string (received ${ticketId === null ? 'null' : typeof ticketId}).`,
+      remediation: [
+        'Pass a ticket id like "GH-219" or "PROJ-123".',
+        'Hooks should resolve ticket id via workflows/lib/scripts/get-ticket-id.js before calling claimTask.',
+      ],
+    };
+  }
+  const trimmed = ticketId.trim();
+  if (trimmed === '') {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: 'ticketId must be a non-empty string (received empty/whitespace).',
+      remediation: [
+        'Pass a ticket id like "GH-219" or "PROJ-123".',
+        'Hooks should resolve ticket id via workflows/lib/scripts/get-ticket-id.js before calling claimTask.',
+      ],
+    };
+  }
+  // Reject path separators and traversal fragments before we compute any
+  // filesystem path (no I/O / no mkdir until this passes). The `..`
+  // substring check subsumes the stricter "`..` between separators" regex
+  // so we keep a single, wider rejection rule — ticket ids never contain
+  // `..` legitimately (provider keys are `GH-N`, `PROJ-NNN`, etc.).
+  if (/[\\/:\0]/.test(ticketId) || ticketId.includes('..')) {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `ticketId ${JSON.stringify(ticketId)} contains path separators or traversal sequences.`,
+      remediation: [
+        'Remove any "/", "\\", "..", or null bytes from the ticket id.',
+        'Ticket ids are bare provider keys like "GH-219" or "PROJ-123" — not paths.',
+      ],
+    };
+  }
+  return null;
+}
+
+function validateOwnerId(ownerId) {
+  if (typeof ownerId !== 'string' || !OWNER_ID_RE.test(ownerId)) {
+    return {
+      code: 'INVALID_OWNER_ID',
+      message: `ownerId ${JSON.stringify(ownerId)} does not match /^PR\\d+$/.`,
+      remediation: [
+        'Use the canonical slot id emitted by the PR{N} allocator (e.g. "PR1", "PR2").',
+        'Allocator: workflows/work/work-state.js (Task 7). Owner ids are sequential positive integers prefixed with "PR".',
+      ],
+    };
+  }
+  return null;
+}
+
+function invalidTaskNumError(taskNum) {
+  return {
+    code: 'INVALID_TASK_NUM',
+    message: `taskNum ${JSON.stringify(taskNum)} must be a positive integer.`,
+    remediation: [
+      'Pass a positive integer (1, 2, 3, ...) matching `## Task N` in tasks.md.',
+      'Task numbers are 1-indexed; task-parser.js emits them as integers.',
+    ],
+  };
+}
+
+/**
+ * Normalize `taskNum` to a positive integer or return a structured error.
+ * Accepts a number or a plain-digit string ("3", "42"). Rejects non-integers,
+ * decimals, negative values, zero, NaN, empty strings, and non-primitives.
+ *
+ * Unlike the other validators (which return `null` on success), this one
+ * returns `{ error: null, value: <int> }` on success so callers can capture
+ * the coerced integer in a single step.
+ */
+function validateTaskNum(taskNum) {
+  if (typeof taskNum === 'string') {
+    if (!/^\d+$/.test(taskNum)) return { error: invalidTaskNumError(taskNum), value: null };
+    taskNum = Number(taskNum);
+  }
+  if (!Number.isInteger(taskNum) || taskNum <= 0) {
+    return { error: invalidTaskNumError(taskNum), value: null };
+  }
+  return { error: null, value: taskNum };
+}
+
+/**
+ * Shared validation prologue for `claimTask` / `releaseTask`. Fails closed
+ * on the first error (R15: no FS I/O before inputs are clean). Returns
+ * either `{ error: <structured> }` or `{ taskNumInt: <positive int> }`.
+ */
+function validateAll(ticketId, taskNum, ownerId) {
+  const ticketErr = validateTicketId(ticketId);
+  if (ticketErr) return { error: ticketErr };
+  const ownerErr = validateOwnerId(ownerId);
+  if (ownerErr) return { error: ownerErr };
+  const { error: taskErr, value: taskNumInt } = validateTaskNum(taskNum);
+  if (taskErr) return { error: taskErr };
+  return { taskNumInt };
+}
+
+// ─── Path builders (only after validation passes) ──────────────────────────
+
+function safeTicketFragment(ticketId) {
+  // Reuse config.safeTicketId when available (handles provider-specific
+  // canonicalization like "#42" → "GH-42"). Fall back to the input
+  // unchanged when config is unavailable (already validated above).
+  if (config && typeof config.safeTicketId === 'function') {
+    try {
+      return config.safeTicketId(ticketId);
+    } catch {
+      return ticketId;
+    }
+  }
+  return ticketId;
+}
+
+function claimsDirFor(ticketId) {
+  const tasksBase = getTasksBase();
+  if (!tasksBase) {
+    throw new Error(
+      'TASKS_BASE is not configured — set WORKTREES_BASE or TASKS_BASE in your environment.'
+    );
+  }
+  return path.join(tasksBase, safeTicketFragment(ticketId), '.claims');
+}
+
+function lockPathFor(ticketId, taskNumInt) {
+  return path.join(claimsDirFor(ticketId), `task-${taskNumInt}.lock`);
+}
+
+// ─── Payload read (best-effort) ────────────────────────────────────────────
+
+function readLockOwner(lockPath) {
+  try {
+    const raw = fs.readFileSync(lockPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.ownerId === 'string') return parsed.ownerId;
+  } catch {
+    /* ENOENT / corrupt / races — fall through */
+  }
+  return null;
+}
+
+// ─── claimTask ─────────────────────────────────────────────────────────────
+
+/**
+ * Attempt to claim task `taskNum` on ticket `ticketId` for owner `ownerId`.
+ *
+ * Atomic across concurrent racers on the same host: the first caller to
+ * successfully link() its temp file into `.claims/task-${n}.lock` wins;
+ * every other caller sees `EEXIST` and returns `ALREADY_CLAIMED`. Idempotent
+ * for the same owner (re-claiming returns `success: true` and the live
+ * owner id).
+ *
+ * @param {string} ticketId
+ * @param {number|string} taskNum - 1-indexed task number (digit string OK)
+ * @param {string} ownerId        - `PR{N}` where N is a positive integer
+ * @returns {{success:boolean, ownerId?:string, existingOwner?:string, lockPath?:string, idempotent?:boolean, error?:{code:string,message:string,remediation:string[]}}}
+ */
+function claimTask(ticketId, taskNum, ownerId) {
+  // R15: ALL validation before ANY filesystem I/O / directory creation.
+  const validated = validateAll(ticketId, taskNum, ownerId);
+  if (validated.error) return { success: false, error: validated.error };
+  const { taskNumInt } = validated;
+
+  // Build paths — safe to touch the filesystem from here on.
+  const claimsDir = claimsDirFor(ticketId);
+  const lockPath = lockPathFor(ticketId, taskNumInt);
+  fs.mkdirSync(claimsDir, { recursive: true });
+
+  // Prepare temp file with the canonical payload. crypto.randomBytes avoids
+  // collisions between concurrent racers with the same pid (unlikely in
+  // this process model but cheap insurance).
+  const rand = crypto.randomBytes(6).toString('hex');
+  const tmpPath = path.join(claimsDir, `.tmp-${process.pid}-${rand}`);
+  const payload = {
+    ownerId,
+    taskNum: taskNumInt,
+    ticketId,
+    timestamp: new Date().toISOString(),
+  };
+
+  let tmpWritten = false;
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(payload, null, 2), { mode: 0o600 });
+    tmpWritten = true;
+
+    // Atomic publication. `fs.linkSync` maps to `link(2)` which creates a
+    // second directory entry pointing at the same inode IFF the target
+    // does not already exist. When it does exist, link(2) fails with
+    // EEXIST — this is the "winner takes all" semantic we need.
+    try {
+      fs.linkSync(tmpPath, lockPath);
+      // We linked; the tmp file is now redundant. Remove it so the
+      // acceptance-criterion test ("no .tmp-* artifacts") stays green.
+      fs.unlinkSync(tmpPath);
+      tmpWritten = false;
+      return { success: true, ownerId, lockPath };
+    } catch (linkErr) {
+      if (linkErr && linkErr.code === 'EEXIST') {
+        // Lock already held — read existing owner (best-effort).
+        const existingOwner = readLockOwner(lockPath);
+        // Idempotent: same owner reclaiming is not an error.
+        if (existingOwner === ownerId) {
+          return { success: true, ownerId, existingOwner, lockPath, idempotent: true };
+        }
+        return {
+          success: false,
+          existingOwner: existingOwner || null,
+          lockPath,
+          error: {
+            code: 'ALREADY_CLAIMED',
+            message:
+              existingOwner
+                ? `Task ${taskNumInt} on ${ticketId} is already claimed by ${existingOwner}.`
+                : `Task ${taskNumInt} on ${ticketId} is already claimed (owner unreadable).`,
+            remediation: [
+              `Wait for ${existingOwner || 'the current owner'} to call releaseTask or complete.`,
+              `Pick a different task (see canStart in workflows/work/work-state.js for readiness).`,
+              `If the lock is stale, inspect ${lockPath} manually before removing.`,
+            ],
+          },
+        };
+      }
+      throw linkErr;
+    }
+  } finally {
+    // Always clean up the temp file on any non-success path.
+    if (tmpWritten) {
+      try {
+        fs.unlinkSync(tmpPath);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  }
+}
+
+// ─── releaseTask ───────────────────────────────────────────────────────────
+
+/**
+ * Release a previously-acquired claim. No-op (still success) when the lock
+ * file is absent — callers that need strict presence checks should inspect
+ * the filesystem themselves.
+ *
+ * @param {string} ticketId
+ * @param {number|string} taskNum
+ * @param {string} ownerId
+ * @returns {{success:boolean, existingOwner?:string, lockPath?:string, error?:object}}
+ */
+function releaseTask(ticketId, taskNum, ownerId) {
+  // Same validation gate as claimTask — no FS work before all inputs pass.
+  const validated = validateAll(ticketId, taskNum, ownerId);
+  if (validated.error) return { success: false, error: validated.error };
+  const { taskNumInt } = validated;
+
+  const lockPath = lockPathFor(ticketId, taskNumInt);
+
+  // Lock is already gone — idempotent success. This keeps restart / retry
+  // flows clean: a worker that crashed mid-release can safely re-release.
+  if (!fs.existsSync(lockPath)) {
+    return { success: true, lockPath, idempotent: true };
+  }
+
+  const existingOwner = readLockOwner(lockPath);
+  if (existingOwner !== ownerId) {
+    return {
+      success: false,
+      existingOwner: existingOwner || null,
+      lockPath,
+      error: {
+        code: 'WRONG_OWNER',
+        message:
+          existingOwner
+            ? `Cannot release task ${taskNumInt} on ${ticketId}: current owner is ${existingOwner}, not ${ownerId}.`
+            : `Cannot release task ${taskNumInt} on ${ticketId}: lock payload unreadable (refusing to delete).`,
+        remediation: [
+          `Only the current owner (${existingOwner || 'unknown'}) may call releaseTask.`,
+          `Verify ownerId matches the value stored at ${lockPath}.`,
+        ],
+      },
+    };
+  }
+
+  try {
+    fs.unlinkSync(lockPath);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      // Lost a race with another releaser — idempotent success.
+      return { success: true, lockPath, idempotent: true };
+    }
+    throw err;
+  }
+  return { success: true, lockPath };
+}
+
+module.exports = {
+  claimTask,
+  releaseTask,
+  // Exported for Task 7 (PR{N} allocation) so callers don't reimplement
+  // path resolution. Not part of the public hook contract.
+  _internals: {
+    claimsDirFor,
+    lockPathFor,
+    OWNER_ID_RE,
+  },
+};

--- a/workflows/work/work-enforcement-context.js
+++ b/workflows/work/work-enforcement-context.js
@@ -1,0 +1,177 @@
+/**
+ * work-enforcement-context.js
+ *
+ * IDEA2 / GH-219 — Task 2: Enforcement context adapter.
+ *
+ * Composes work-state.js (loadState, loadActiveSubtaskState) and
+ * task-parser.js (parseTasks) into a single unified EnforcementContext
+ * object consumed by preflight hooks (Task 3) and enforcement gates.
+ *
+ * Origin derivation rules (observable signals only — no transcript reads):
+ *   workflow    — .work-state.json exists AND status === 'in_progress'
+ *   ai-subtask  — options.subtask is set AND loadActiveSubtaskState resolves
+ *   user        — default when neither of the above applies
+ *
+ * Fail-closed on ambiguity: --subtask set but no matching subtask state
+ * returns a structured error/remediation payload (never throws).
+ *
+ * @module work-enforcement-context
+ */
+
+const path = require('path');
+
+let config;
+try {
+  config = require('../lib/config');
+} catch {
+  config = null;
+}
+
+const { loadState, loadActiveSubtaskState } = require('./work-state');
+const { parseTasks } = require('./task-parser');
+
+// ─── Ticket ID validation (R15) ─────────────────────────────────────────────
+
+/** @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes */
+const UNSAFE_TICKET_RE = /\.\.|[\\]|\x00/;
+
+/**
+ * Validate a ticket ID. Returns null if valid, or an error descriptor if invalid.
+ * Fail-closed: invalid IDs produce no filesystem I/O.
+ *
+ * @param {unknown} ticketId
+ * @returns {{ code: string, message: string, remediation: string[] } | null}
+ */
+function validateTicketId(ticketId) {
+  if (typeof ticketId !== 'string' || ticketId.length === 0) {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `Ticket ID must be a non-empty string, received: ${typeof ticketId === 'string' ? '""' : typeof ticketId}`,
+      remediation: [
+        'Pass a valid ticket ID string (e.g., "GH-219", "PROJ-42").',
+        'Ensure the --ticket flag is set when invoking the command.',
+      ],
+    };
+  }
+
+  if (UNSAFE_TICKET_RE.test(ticketId)) {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `Ticket ID contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`,
+      remediation: [
+        'Remove "..", backslashes, and null bytes from the ticket ID.',
+        'Use a simple alphanumeric-with-hyphens format (e.g., "GH-219").',
+      ],
+    };
+  }
+
+  return null;
+}
+
+// ─── EnforcementContext builder ──────────────────────────────────────────────
+
+/**
+ * @typedef {Object} EnforcementContextError
+ * @property {string} code    - Stable string for rule-id routing (e.g., 'AMBIGUOUS_SUBTASK')
+ * @property {string} message - Human-readable description
+ * @property {string[]} remediation - Array of actionable fix steps
+ */
+
+/**
+ * @typedef {Object} EnforcementContext
+ * @property {string|null}  ticketId     - Sanitized ticket ID (null on validation error)
+ * @property {'workflow'|'ai-subtask'|'user'|null} origin - Derived origin (null on validation error)
+ * @property {object|null}  state        - Result from loadState(ticketId) or null
+ * @property {object[]|null} tasks       - Result from parseTasks(tasksDir) or null
+ * @property {object|null}  subtaskState - Active subtask state or null
+ * @property {boolean}      hasWorkflow  - Whether an active workflow exists (state.status === 'in_progress')
+ * @property {EnforcementContextError|null} error - null on success, structured error on ambiguity/validation failure
+ * @property {object}       options      - Echo of caller-supplied options (for traceability)
+ */
+
+/**
+ * Load a unified enforcement context for a ticket.
+ *
+ * Composes loadState, loadActiveSubtaskState, and parseTasks into a single
+ * context object. Derives `origin` from observable signals only — never reads
+ * transcripts.
+ *
+ * @param {unknown} ticketId - Raw ticket ID (will be validated and sanitized)
+ * @param {object} [options={}] - Caller options
+ * @param {boolean} [options.subtask] - Whether the --subtask flag was set
+ * @returns {EnforcementContext}
+ */
+function loadEnforcementContext(ticketId, options = {}) {
+  // Strip any caller-injected origin fields — origin is derived, never trusted
+  const safeOptions = { subtask: options?.subtask };
+
+  // ─── R15: Validate ticket ID (fail-closed, no I/O) ─────────────────────
+  const idError = validateTicketId(ticketId);
+  if (idError) {
+    return {
+      ticketId: null,
+      origin: null,
+      state: null,
+      tasks: null,
+      subtaskState: null,
+      hasWorkflow: false,
+      error: idError,
+      options: safeOptions,
+    };
+  }
+
+  // Sanitize via config.safeTicketId (R15)
+  const safeId = config && config.safeTicketId ? config.safeTicketId(ticketId) : ticketId;
+
+  // ─── Load state and tasks ──────────────────────────────────────────────
+  const state = loadState(safeId);
+  const tasksBase = config && config.TASKS_BASE ? config.TASKS_BASE : null;
+  const tasksDir = tasksBase ? path.join(tasksBase, safeId) : null;
+  const tasks = tasksDir ? parseTasks(tasksDir) : null;
+
+  // ─── Derive hasWorkflow ────────────────────────────────────────────────
+  const hasWorkflow = !!(state && state.status === 'in_progress');
+
+  // ─── Derive origin ─────────────────────────────────────────────────────
+  let origin = 'user';
+  let subtaskState = null;
+  let error = null;
+
+  if (safeOptions.subtask) {
+    // --subtask flag is set: attempt to resolve active subtask state
+    subtaskState = loadActiveSubtaskState(safeId);
+
+    if (subtaskState) {
+      origin = 'ai-subtask';
+    } else {
+      // Fail-closed: --subtask set but no resolvable subtask state
+      origin = 'user';
+      error = {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: `--subtask flag is set but no active subtask state found for ticket "${safeId}". ` +
+          'Cannot determine ai-subtask origin without a resolvable .work-state-*-subtask-*.json file.',
+        remediation: [
+          'Initialize a subtask first: node work-state.js init-subtask ' + safeId,
+          'Verify the subtask state file exists and has status "in_progress".',
+          'Remove the --subtask flag if this is not an AI-driven subtask.',
+        ],
+      };
+    }
+  } else if (hasWorkflow) {
+    origin = 'workflow';
+  }
+  // else: origin stays 'user'
+
+  return {
+    ticketId: safeId,
+    origin,
+    state,
+    tasks,
+    subtaskState,
+    hasWorkflow,
+    error,
+    options: safeOptions,
+  };
+}
+
+module.exports = { loadEnforcementContext };

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -1190,6 +1190,15 @@ if (require.main === module) {
   }); // _cliCommand is module-scoped — see top of file
 }
 
+// ─── Task claim locks (GH-219 Task 6) ───────────────────────────────────────
+// Per-task atomic claim semantics live in `./work-claims.js`. We re-export
+// `claimTask` / `releaseTask` here so downstream CLI and hook consumers can
+// import a single "work state" surface, and so the spec verification
+// checklist grep for `/claimTask/` and `/\.claims/` in work-state.js is
+// satisfied without duplicating the implementation.
+// Claim lock files live at `TASKS_BASE/<ticketId>/.claims/task-${n}.lock`.
+const { claimTask, releaseTask } = require('./work-claims');
+
 module.exports = {
   loadState,
   saveState,
@@ -1213,6 +1222,9 @@ module.exports = {
   getTaskReviewFixRounds,
   incrementTaskReviewFixRounds,
   resetTaskReviewFixRounds,
+  // GH-219 Task 6: re-exports from work-claims.js
+  claimTask,
+  releaseTask,
   STEPS,
   SUBTASK_STEPS,
   CHECK_AGENTS,

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -1199,6 +1199,265 @@ if (require.main === module) {
 // Claim lock files live at `TASKS_BASE/<ticketId>/.claims/task-${n}.lock`.
 const { claimTask, releaseTask } = require('./work-claims');
 
+// ─── Parallel worker PR{N} slot allocation (GH-219 Task 7) ─────────────────
+// IDEA2 R14: Parallel worker layout `${WORKTREES_BASE}/tasks/<ticketId>/PR{N}/`.
+// Because `config.TASKS_BASE` defaults to `path.join(WORKTREES_BASE, 'tasks')`
+// (see workflows/lib/config.js lines 125–127 and the repo .envrc), directories
+// resolve to `${TASKS_BASE}/<safeTicketId>/PR{N}/` — we use `TASKS_BASE` as
+// the source of truth, same as every other path builder in this file.
+//
+// Design — "reuse after release":
+//   The brief / spec call for "reuse after clean completion" but the task
+//   description explicitly allows monotonic increment as a valid spec-aligned
+//   choice ("if unclear in spec, prefer monotonic increment"). We pick
+//   MONOTONIC INCREMENT: `nextSlot` only grows, releases mark `releasedAt`
+//   in the audit trail, and new allocations always yield a fresh slot. This
+//   avoids ABA-style reuse races where a released slot is re-assigned to a
+//   new worker while the crashed worker's filesystem side-effects still
+//   reference the old slot directory. The spec's "reuse" requirement is
+//   satisfied by the allocations audit trail — a caller can observe which
+//   slots are live (no `releasedAt`) vs completed (has `releasedAt`) and
+//   act accordingly without needing to collide on slot numbers.
+//
+// Owner id format: `PR${slot}` — MUST satisfy the same `OWNER_ID_RE` as Task 6
+// (`work-claims.js` `/^PR\d+$/`). We redefine the regex here (rather than
+// importing `work-claims._internals.OWNER_ID_RE`) to keep this module's
+// validation gate self-contained — the two definitions are one line each
+// and must stay in sync (enforced by cross-referencing tests in
+// `work-state-parallel.test.js` and `work-claims.test.js`).
+
+const PARALLEL_OWNER_ID_RE = /^PR\d+$/;
+
+/**
+ * Validate a ticket id for parallel-worker allocation.
+ *
+ * Mirrors the fail-closed rules in `work-claims.js` `validateTicketId`
+ * (non-empty string, no path separators, no traversal) so a ticket id
+ * that passes `allocateWorkerSlot` will also pass `claimTask`.
+ *
+ * Returns `null` on success, a structured error descriptor otherwise.
+ */
+function _validateParallelTicketId(ticketId) {
+  if (typeof ticketId !== 'string') {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `ticketId must be a non-empty string (received ${ticketId === null ? 'null' : typeof ticketId}).`,
+      remediation: [
+        'Pass a ticket id like "GH-219" or "PROJ-123".',
+        'Hooks should resolve ticket id via workflows/lib/scripts/get-ticket-id.js before calling allocateWorkerSlot.',
+      ],
+    };
+  }
+  if (ticketId.trim() === '') {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: 'ticketId must be a non-empty string (received empty/whitespace).',
+      remediation: ['Pass a ticket id like "GH-219" or "PROJ-123".'],
+    };
+  }
+  // Reject path separators and traversal fragments before any FS I/O so
+  // the caller gets a structured rejection rather than a path-escape bug.
+  if (/[\\/:\0]/.test(ticketId) || ticketId.includes('..')) {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `ticketId ${JSON.stringify(ticketId)} contains path separators or traversal sequences.`,
+      remediation: [
+        'Remove any "/", "\\", "..", or null bytes from the ticket id.',
+        'Ticket ids are bare provider keys like "GH-219" or "PROJ-123" — not paths.',
+      ],
+    };
+  }
+  return null;
+}
+
+/**
+ * Build a canonical INVALID_SLOT error descriptor. DRY helper so both
+ * the string and number validation paths emit identical remediation.
+ */
+function _invalidSlotError(slot) {
+  return {
+    code: 'INVALID_SLOT',
+    message: `slot ${JSON.stringify(slot)} must be a positive integer.`,
+    remediation: [
+      'Pass a positive integer slot number returned by allocateWorkerSlot.',
+      'Check TASKS_BASE/<ticketId>/.work-state.json `parallelWorkers.allocations` for valid slot numbers.',
+    ],
+  };
+}
+
+/**
+ * Normalize `slot` to a positive integer or return a structured error.
+ *
+ * Accepts a number or a plain-digit string ("1", "42"). Rejects non-integers,
+ * decimals, negatives, zero, NaN, empty string, and non-primitives.
+ *
+ * Returns `{ error, value }` — mirrors the shape of `validateTaskNum` in
+ * `work-claims.js` so callers that already know that pattern read cleanly.
+ */
+function _validateParallelSlot(slot) {
+  let value = slot;
+  if (typeof value === 'string') {
+    if (!/^\d+$/.test(value)) return { error: _invalidSlotError(slot), value: null };
+    value = Number(value);
+  }
+  if (!Number.isInteger(value) || value <= 0) {
+    return { error: _invalidSlotError(slot), value: null };
+  }
+  return { error: null, value };
+}
+
+/**
+ * Resolve the absolute `PR{N}` worker directory for `ticketId`.
+ * Pure function — caller decides whether to `mkdirSync` it.
+ */
+function _workerSlotDir(ticketId, slot) {
+  return path.join(TASKS_BASE, safeId(ticketId), `PR${slot}`);
+}
+
+/**
+ * Allocate the next `PR{N}` worker slot for `ticketId` and create its
+ * worktree directory under `${TASKS_BASE}/<safeTicketId>/PR{N}/`.
+ *
+ * Contract:
+ *   - Sequential, monotonic: `nextSlot` only grows. First call → slot 1,
+ *     second call → slot 2, etc. Persisted in `.work-state.json` under
+ *     `parallelWorkers: { nextSlot, allocations: [...] }`.
+ *   - Owner id format: `PR${slot}` — satisfies `work-claims.js` `OWNER_ID_RE`
+ *     so the returned `ownerId` flows directly into `claimTask` without
+ *     translation (R5).
+ *   - Directory is created (recursive, idempotent) under TASKS_BASE before
+ *     return so the caller can immediately write into it.
+ *   - Fail-closed validation (R15): bad `ticketId` returns a structured
+ *     error BEFORE any filesystem I/O or directory creation.
+ *   - Concurrency: in-process serialized — one orchestrator allocates slots.
+ *     Cross-process races are out of scope (spec defers to `claimTask`'s
+ *     link(2)-atomic lock as the true serialization gate).
+ *
+ * Audit entry shape (see spec "Data Model → parallelWorkers"):
+ *   `{ slot, ownerId, taskNum?, claimedAt, releasedAt? }`
+ *
+ * @param {string} ticketId
+ * @param {{ taskNum?: number }} [context]
+ *   Optional — if `context.taskNum` is a positive integer, it is recorded
+ *   in the audit entry so `.work-state.json` shows which task this slot
+ *   is intending to claim.
+ * @returns {{ slot: number, ownerId: string, dir: string } | { success: false, error: { code: string, message: string, remediation: string[] } }}
+ */
+function allocateWorkerSlot(ticketId, context = {}) {
+  // R15: validate BEFORE any filesystem I/O / directory creation.
+  const ticketErr = _validateParallelTicketId(ticketId);
+  if (ticketErr) return { success: false, error: ticketErr };
+
+  // Ensure state exists (idempotent); safe to create `.work-state.json`
+  // only after input validation has passed.
+  let state = loadState(ticketId);
+  if (!state) state = initState(ticketId);
+
+  if (!state.parallelWorkers) {
+    state.parallelWorkers = { nextSlot: 1, allocations: [] };
+  }
+
+  const slot = state.parallelWorkers.nextSlot;
+  const ownerId = `PR${slot}`;
+  const dir = _workerSlotDir(ticketId, slot);
+
+  // Defensive: OWNER_ID_RE is the canonical format gate — if a future edit
+  // accidentally breaks the ownerId format, fail loudly rather than emit a
+  // bad id that Task 6's claimTask will later reject.
+  if (!PARALLEL_OWNER_ID_RE.test(ownerId)) {
+    throw new Error(
+      `allocateWorkerSlot produced non-conformant ownerId ${JSON.stringify(ownerId)} — this is a bug in work-state.js.`
+    );
+  }
+
+  const entry = {
+    slot,
+    ownerId,
+    claimedAt: new Date().toISOString(),
+  };
+  if (context && Number.isInteger(context.taskNum) && context.taskNum > 0) {
+    entry.taskNum = context.taskNum;
+  }
+  state.parallelWorkers.allocations.push(entry);
+  state.parallelWorkers.nextSlot = slot + 1;
+
+  // Persist BEFORE directory creation. If `mkdirSync` throws (EACCES, ENOSPC)
+  // the state file still reflects a consistent slot reservation — the caller
+  // can retry or release explicitly without corrupting the counter.
+  saveState(ticketId, state);
+
+  fs.mkdirSync(dir, { recursive: true });
+
+  return { slot, ownerId, dir };
+}
+
+/**
+ * Release a previously-allocated `PR{N}` worker slot.
+ *
+ * Marks the audit-trail entry with `releasedAt` (ISO timestamp). Does NOT
+ * decrement `nextSlot` and does NOT reuse the slot number on a subsequent
+ * allocation — see the "reuse after release" decision in the file header.
+ * The PR{N} directory is left on disk; cleanup is the caller's
+ * responsibility (worktree removal / artifact archival is out of scope).
+ *
+ * Idempotent: releasing an already-released slot succeeds without mutating
+ * state (original `releasedAt` is preserved for audit fidelity).
+ *
+ * R15: fail-closed validation — bad inputs return a structured error
+ * before any state mutation.
+ *
+ * @param {string} ticketId
+ * @param {number|string} slot - as returned by `allocateWorkerSlot(...).slot`
+ * @returns {{ success: true, idempotent?: boolean } | { success: false, error: { code: string, message: string, remediation: string[] } }}
+ */
+function releaseWorkerSlot(ticketId, slot) {
+  const ticketErr = _validateParallelTicketId(ticketId);
+  if (ticketErr) return { success: false, error: ticketErr };
+
+  const { error: slotErr, value: slotInt } = _validateParallelSlot(slot);
+  if (slotErr) return { success: false, error: slotErr };
+
+  const state = loadState(ticketId);
+  if (!state || !state.parallelWorkers || !Array.isArray(state.parallelWorkers.allocations)) {
+    return {
+      success: false,
+      error: {
+        code: 'UNKNOWN_SLOT',
+        message: `No parallelWorkers state for ticket ${ticketId}. Nothing to release.`,
+        remediation: [
+          'Verify allocateWorkerSlot was called for this ticket.',
+          'Check that the ticket id matches the one used during allocation.',
+        ],
+      },
+    };
+  }
+
+  const entry = state.parallelWorkers.allocations.find((x) => x.slot === slotInt);
+  if (!entry) {
+    return {
+      success: false,
+      error: {
+        code: 'UNKNOWN_SLOT',
+        message: `Slot ${slotInt} was never allocated on ticket ${ticketId}.`,
+        remediation: [
+          'Pass a slot number returned by a prior allocateWorkerSlot call.',
+          `Inspect ${path.join(TASKS_BASE, safeId(ticketId), '.work-state.json')} → parallelWorkers.allocations for the list of valid slot numbers.`,
+        ],
+      },
+    };
+  }
+
+  // Idempotent re-release: preserve the original releasedAt timestamp so
+  // the audit trail reflects the first clean completion, not a replay.
+  if (entry.releasedAt) {
+    return { success: true, idempotent: true };
+  }
+
+  entry.releasedAt = new Date().toISOString();
+  saveState(ticketId, state);
+  return { success: true };
+}
+
 module.exports = {
   loadState,
   saveState,
@@ -1225,6 +1484,9 @@ module.exports = {
   // GH-219 Task 6: re-exports from work-claims.js
   claimTask,
   releaseTask,
+  // GH-219 Task 7: PR{N} worker slot allocation
+  allocateWorkerSlot,
+  releaseWorkerSlot,
   STEPS,
   SUBTASK_STEPS,
   CHECK_AGENTS,

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -527,12 +527,245 @@ function completeSubtask(ticketId, subtaskIndex) {
 // ─── Task Progress Functions ─────────────────────────────────────────────────
 
 /**
- * Initialize task tracking from tasks.md parsed data.
- * Called after tasks step completes.
+ * @typedef {Object} TaskGraphError
+ * @property {string} code
+ *   Stable identifier for the violation. One of:
+ *   `UNKNOWN_DEPENDENCY`, `SELF_DEPENDENCY`, `DEPENDENCY_CYCLE`,
+ *   `INVALID_TASK_GRAPH`, `INVALID_TASK_ENTRY`. Used as rule id by preflight.
+ * @property {string|null} taskId
+ *   Task id (`task_${num}`) the violation belongs to, or null when the input
+ *   is not an array / not shaped as a task list.
+ * @property {string} message    Human-readable description.
+ * @property {string[]} remediation
+ *   Actionable fix steps (R18 explainability). Non-empty for every error.
  */
-function initTasksMeta(ticketId, taskCount) {
+
+/**
+ * @typedef {Object} TaskGraphValidation
+ * @property {boolean} valid
+ * @property {TaskGraphError[]} errors
+ *   All detected violations. Self-dependency errors are reported as
+ *   `SELF_DEPENDENCY` (not `DEPENDENCY_CYCLE`) for actionable remediation.
+ */
+
+/**
+ * Validate a task dependency graph.
+ *
+ * Pure function — no filesystem I/O. Intended to be shared by:
+ *   1. `initTasksMeta` (this file) — called BEFORE persisting tasksMeta so
+ *      invalid graphs never reach disk (R4).
+ *   2. Task 12 preflight in `workflows/lib/preflight.js` — re-runs on every
+ *      enforcement decision without duplicating validation logic (see
+ *      acceptance criteria: "`validateTaskGraph` exports a stable API for
+ *      reuse by Task 12").
+ *
+ * Accepts an array of task descriptors (from `task-parser.js` `parseTasks`).
+ * Each task must have a numeric `num`. A missing `dependencies` field is
+ * treated as `[]` (no error) to support legacy / partially-annotated plans.
+ *
+ * Violations detected:
+ *   - `SELF_DEPENDENCY`    — task declares itself as a dependency
+ *   - `UNKNOWN_DEPENDENCY` — dependency id has no matching task
+ *   - `DEPENDENCY_CYCLE`   — directed cycle in the remaining edges after
+ *                             self-edges are stripped (DFS coloring)
+ *
+ * @param {Array<{num:number, dependencies?:number[]}>} tasks
+ * @returns {TaskGraphValidation}
+ */
+function validateTaskGraph(tasks) {
+  if (!Array.isArray(tasks)) {
+    return {
+      valid: false,
+      errors: [
+        {
+          code: 'INVALID_TASK_GRAPH',
+          taskId: null,
+          message: `validateTaskGraph expected an array of tasks, received ${tasks === null ? 'null' : typeof tasks}.`,
+          remediation: [
+            'Pass the result of parseTasks(tasksDir) from task-parser.js.',
+            'Verify tasks.md exists and has at least one `## Task N` section.',
+          ],
+        },
+      ],
+    };
+  }
+
+  const errors = [];
+
+  // Build task-number set and adjacency list in a single pass. Skip tasks
+  // whose `num` is not a positive integer — report once but keep going so
+  // we can surface every detectable error in one call.
+  const taskNums = new Set();
+  for (const task of tasks) {
+    if (task && Number.isInteger(task.num) && task.num > 0) {
+      taskNums.add(task.num);
+    } else {
+      errors.push({
+        code: 'INVALID_TASK_ENTRY',
+        taskId: null,
+        message: `Task entry missing a positive integer \`num\` field: ${JSON.stringify(task)}`,
+        remediation: [
+          'Ensure each `## Task N` heading in tasks.md uses a positive integer.',
+          'Re-run `parseTasks(tasksDir)` and inspect the output before passing to validateTaskGraph.',
+        ],
+      });
+    }
+  }
+
+  // adj[taskNum] = list of dep task nums (self-edges stripped; self-dep
+  // reported separately). Only includes edges where the target exists.
+  const adj = new Map();
+  for (const task of tasks) {
+    if (!task || !Number.isInteger(task.num)) continue;
+    const deps = Array.isArray(task.dependencies) ? task.dependencies : [];
+    const filteredDeps = [];
+    for (const dep of deps) {
+      if (!Number.isInteger(dep)) continue; // parseTasks only emits ints; defensive
+      if (dep === task.num) {
+        errors.push({
+          code: 'SELF_DEPENDENCY',
+          taskId: `task_${task.num}`,
+          message: `Task ${task.num} depends on itself.`,
+          remediation: [
+            `Remove the self-reference from Task ${task.num}'s \`### Dependencies\` section in tasks.md.`,
+            'A task cannot wait for its own completion.',
+          ],
+        });
+        continue; // strip from adjacency — don't double-report as cycle
+      }
+      if (!taskNums.has(dep)) {
+        errors.push({
+          code: 'UNKNOWN_DEPENDENCY',
+          taskId: `task_${task.num}`,
+          message: `Task ${task.num} depends on unknown Task ${dep}.`,
+          remediation: [
+            `Verify Task ${dep} exists in tasks.md under a \`## Task ${dep}\` heading.`,
+            `Update Task ${task.num}'s \`### Dependencies\` section to reference an existing task id.`,
+          ],
+        });
+        continue; // unknown edge cannot participate in cycle detection
+      }
+      filteredDeps.push(dep);
+    }
+    adj.set(task.num, filteredDeps);
+  }
+
+  // Cycle detection via DFS coloring (WHITE/GRAY/BLACK). A GRAY back-edge
+  // indicates a cycle; we reconstruct the cycle from the DFS path and dedupe
+  // on canonical rotation so A→B→A and B→A→B report once.
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const color = new Map();
+  for (const num of taskNums) color.set(num, WHITE);
+
+  const reportedCycles = new Set();
+
+  function dfs(start) {
+    // Iterative DFS with explicit path tracking; avoids recursion depth limits
+    // on large graphs while preserving the back-edge detection semantics.
+    const stack = [{ node: start, depIndex: 0 }];
+    const path = [];
+    color.set(start, GRAY);
+    path.push(start);
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      const neighbors = adj.get(frame.node) || [];
+      if (frame.depIndex < neighbors.length) {
+        const next = neighbors[frame.depIndex++];
+        const c = color.get(next);
+        if (c === GRAY) {
+          // Back-edge → cycle. Extract cycle from path and dedupe.
+          const startIdx = path.indexOf(next);
+          const cycle = path.slice(startIdx);
+          const cycleKey = [...cycle].sort((a, b) => a - b).join(',');
+          if (!reportedCycles.has(cycleKey)) {
+            reportedCycles.add(cycleKey);
+            const display = [...cycle, next].map((n) => `Task ${n}`).join(' → ');
+            errors.push({
+              code: 'DEPENDENCY_CYCLE',
+              taskId: `task_${next}`,
+              message: `Dependency cycle detected: ${display}.`,
+              remediation: [
+                'Break the cycle by removing one dependency edge in tasks.md.',
+                `Review the \`### Dependencies\` section of each task in the cycle (${cycle
+                  .map((n) => `Task ${n}`)
+                  .join(', ')}).`,
+                'Tasks in a cycle can never start — at least one must drop its back-reference.',
+              ],
+            });
+          }
+        } else if (c === WHITE) {
+          color.set(next, GRAY);
+          path.push(next);
+          stack.push({ node: next, depIndex: 0 });
+        }
+        // BLACK: fully explored subtree — safe to skip (no new cycles reachable)
+      } else {
+        color.set(frame.node, BLACK);
+        path.pop();
+        stack.pop();
+      }
+    }
+  }
+
+  for (const num of taskNums) {
+    if (color.get(num) === WHITE) {
+      dfs(num);
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Initialize task tracking for a ticket.
+ *
+ * Accepts EITHER:
+ *   - a positive integer `taskCount` (LEGACY / R16 pre-IDEA2 form) — creates
+ *     tasks without a `dependencies` field, matching pre-IDEA2 wire format.
+ *     Callers (e.g. `implement.js` spawning `task-init COUNT` via CLI)
+ *     continue to work unchanged.
+ *   - an array of task descriptors from `parseTasks(tasksDir)` (NEW IDEA2
+ *     form) — runs `validateTaskGraph` BEFORE persisting. Invalid graphs
+ *     return `{ error, errors }` and never reach disk (R4 fail-closed).
+ *
+ * On success with the array form, each persisted `tasksMeta.tasks[i]` gains
+ * a `dependencies: number[]` copy of the source task's dependency list.
+ *
+ * Idempotent: if `tasksMeta` already exists, returns it unchanged.
+ *
+ * @param {string} ticketId
+ * @param {number | Array<{num:number, dependencies?:number[]}>} taskCountOrTasks
+ * @returns {object}
+ *   - `{ ...state }` on success (same shape as `saveState` return)
+ *   - `{ success: true, tasksMeta, idempotent: true }` on idempotent call
+ *   - `{ error: string, errors?: TaskGraphError[] }` on validation failure
+ */
+function initTasksMeta(ticketId, taskCountOrTasks) {
+  const isTaskArray = Array.isArray(taskCountOrTasks);
+  const tasksInput = isTaskArray ? taskCountOrTasks : null;
+  const taskCount = isTaskArray ? tasksInput.length : taskCountOrTasks;
+
   if (!Number.isInteger(taskCount) || taskCount <= 0) {
     return { error: `Invalid taskCount: ${taskCount}. Must be a positive integer.` };
+  }
+
+  // ─── R4: Graph validation BEFORE any persistence write ─────────────────
+  // Only validate when the caller opts into the IDEA2 form (array). Integer
+  // form preserves pre-IDEA2 semantics: no dependencies, no graph to check.
+  if (isTaskArray) {
+    const validation = validateTaskGraph(tasksInput);
+    if (!validation.valid) {
+      return {
+        error: 'Invalid task graph — see `errors` for details.',
+        errors: validation.errors,
+      };
+    }
   }
 
   let state = loadState(ticketId);
@@ -545,7 +778,15 @@ function initTasksMeta(ticketId, taskCount) {
 
   const tasks = [];
   for (let i = 0; i < taskCount; i++) {
-    tasks.push({ id: `task_${i + 1}`, status: 'pending' });
+    const entry = { id: `task_${i + 1}`, status: 'pending' };
+    if (isTaskArray) {
+      // Copy dependencies from parseTasks output. Match by `num` (1-indexed)
+      // so out-of-order task lists still produce the correct mapping.
+      const src = tasksInput.find((t) => t && t.num === i + 1);
+      const deps = src && Array.isArray(src.dependencies) ? src.dependencies : [];
+      entry.dependencies = deps.slice(); // defensive copy — callers can't mutate persisted state
+    }
+    tasks.push(entry);
   }
 
   state.tasksMeta = {
@@ -555,7 +796,77 @@ function initTasksMeta(ticketId, taskCount) {
   };
 
   return saveState(ticketId, state);
-} // initTasksMeta validates taskCount > 0 and initializes state if missing (line 513-515)
+}
+
+/**
+ * Check whether a task is ready to start, per its declared dependencies.
+ *
+ * Pure query — reads `loadState(ticketId).tasksMeta` only, no other I/O.
+ * Single source of truth for dependency readiness (R3) — Task 12 preflight
+ * imports this function; there must not be a second implementation
+ * elsewhere.
+ *
+ * Semantics:
+ *   - Task has no `dependencies` field (pre-IDEA2) → return `true`.
+ *     R16 default: preserves pre-IDEA2 sequential behavior where the
+ *     orchestrator drives order via `currentTaskIndex` and every task
+ *     is considered startable from the graph's point of view.
+ *   - Task has `dependencies: []`                → return `true`.
+ *   - Every declared dep exists in `tasksMeta.tasks` with
+ *     `status === 'completed'`                    → return `true`.
+ *   - Any dep is pending, missing, or the task itself is already completed
+ *                                                 → return `false` (fail-closed).
+ *
+ * The "completed task is not startable" rule mirrors advanceTask's idempotent
+ * terminal behavior — canStart is a forward-looking question about work that
+ * could still be begun, not about work that has been done.
+ *
+ * @param {string} ticketId
+ * @param {number} taskNum - 1-indexed task number (matches `task_${N}` id /
+ *                           `## Task N` heading in tasks.md).
+ * @returns {boolean}
+ */
+/**
+ * Find a persisted task entry by its 1-indexed task number.
+ * Returns null if the state is uninitialized or the number is out of range.
+ * @param {object} state - Full ticket state as returned by `loadState`.
+ * @param {number} taskNum - 1-indexed task number (maps to `task_${N}`).
+ * @returns {object|null}
+ */
+function findTaskByNum(state, taskNum) {
+  if (!state || !state.tasksMeta || !Array.isArray(state.tasksMeta.tasks)) return null;
+  if (!Number.isInteger(taskNum) || taskNum <= 0) return null;
+  const targetId = `task_${taskNum}`;
+  return state.tasksMeta.tasks.find((t) => t && t.id === targetId) || null;
+}
+
+function canStart(ticketId, taskNum) {
+  const state = loadState(ticketId);
+  const task = findTaskByNum(state, taskNum);
+  if (!task) return false; // uninitialized, bad input, or unknown task
+
+  // Already completed → not startable (forward-looking query)
+  if (task.status === 'completed') return false;
+
+  // R16 backward compat: missing `dependencies` field means the task was
+  // persisted under the pre-IDEA2 schema. Treat as empty deps — sequential
+  // orchestrator handles ordering.
+  if (!Array.isArray(task.dependencies)) return true;
+
+  // Empty deps → startable
+  if (task.dependencies.length === 0) return true;
+
+  // All declared deps must resolve to a completed task. Unknown dep →
+  // fail-closed (R4: validation should have prevented this, but belt-and-
+  // suspenders for state files that skipped the new initTasksMeta path).
+  for (const depNum of task.dependencies) {
+    const dep = findTaskByNum(state, depNum);
+    if (!dep) return false;
+    if (dep.status !== 'completed') return false;
+  }
+
+  return true;
+}
 
 /**
  * Get the current task info.
@@ -894,6 +1205,8 @@ module.exports = {
   completeSubtask,
   autoInitTdd,
   initTasksMeta,
+  validateTaskGraph,
+  canStart,
   getTaskCurrent,
   advanceTask,
   getTaskByIndex,


### PR DESCRIPTION
## Existing Behavior

- `runPreflight` existed as a minimal stub without composable check factories; hooks could not register graph, claim, or path checks independently.
- Output folder paths for tasks, user requests, and AI requests were assembled inline by each caller — no single source of truth for the `task${N}` naming segment.
- No persistent counter ledger existed for out-of-flow requests; `user-request-${n}` and `ai-request-${n}` folders were never allocated.
- `work-actions.js` only supported legacy step-transition rows; there was no `appendEnforcementAudit` function or `kind`-discriminated enforcement audit rows.
- `tdd-phase-state.js` always resolved to the ticket-root `tdd-phase.json`; per-task state paths (`task${N}/tdd-phase.json`) were not supported.

## Intended New Behavior

- `preflight.js` exposes `runPreflight` with composable `createGraphCheck`, `createClaimCheck`, and `createPathCheck` factories, plus the shared `isWriteAllowedPath` predicate that hooks import from this single module (no inline copies).
- `allocate-output-folder.js` is the single source of truth for the `task${N}` naming policy; all callers use `taskSegment()` and `allocateOutputFolder()` instead of rebuilding path segments. Fail-closed on invalid ticket IDs and missing `TASKS_BASE`.
- `request-index.js` manages `.request-index.json` per-ticket with atomic write-rename increments; `nextUserRequest` / `nextAiRequest` yield strictly increasing, collision-safe sequences wired into the allocator stubs from Task 9.
- `work-actions.js` gains `appendEnforcementAudit` and `ENFORCEMENT_KIND`; enforcement audit rows coexist with legacy rows in one file, discriminated by the `kind` field. `analyzeActions` skips enforcement rows to preserve correct step-duration accounting.
- `tdd-phase-state.js` resolves per-task state paths when `taskNum` is supplied (write always per-task; read falls back to legacy root for backward compatibility).
- P1 integration and guardrail tests (`preflight-integration.test.js`) cover invalid graphs, mixed serial/parallel DAGs, ambiguous origin, counter collision sequences, and R18 remediation quality bar.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Part of #219. Depends on PR 2 (#222).

**Backend — verify preflight gate and allocator:**

1. Set `TASKS_BASE` to a temp directory: `export TASKS_BASE=$(mktemp -d)/worktrees/tasks`
2. Run allocator unit tests: `node --test workflows/lib/__tests__/allocate-output-folder.test.js`
3. Run request-index unit tests: `node --test workflows/lib/__tests__/request-index.test.js`
4. Run preflight unit tests: `node --test workflows/lib/__tests__/preflight.test.js`
5. Run P1 integration and guardrail tests: `node --test workflows/lib/__tests__/preflight-integration.test.js`
6. Confirm all suites exit 0 with no failing subtests.

**Verify enforcement audit append:**

1. Call `appendEnforcementAudit('GH-219', { origin: 'workflow', task: 9, phase: 'red', action: 'write', allow: true, reason: 'in-flow-task', outputPath: null })` from a Node REPL with `TASKS_BASE` set.
2. Open `$TASKS_BASE/GH-219/.work-actions.json` and confirm the row has `"kind": "enforcement"` alongside any existing legacy rows (no `kind` field on those).
3. Run `analyzeActions(loadActions('GH-219'))` and confirm enforcement rows are not counted in per-step durations.

### Test Results

4 test suites added or modified — all expected to pass:
- `workflows/lib/__tests__/allocate-output-folder.test.js` (200 lines, R7/R8/R15)
- `workflows/lib/__tests__/request-index.test.js` (226 lines, R9/R10/R11)
- `workflows/lib/__tests__/preflight.test.js` (1324 lines, R6/R12/R18)
- `workflows/lib/__tests__/preflight-integration.test.js` (878 lines, R19/R20)