### PR TITLE
feat(implement): per-task TDD paths + dependency-aware messaging (#219 PR 5/5)

### DIFF
--- a/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -500,7 +500,7 @@ describe('tdd-phase-state CLI', () => {
     });
   });
 
-    describe('token gating', () => {
+  describe('token gating', () => {
     it('record-red fails without token when WORK_TDD_TOKEN_SKIP is not set', () => {
       runCli('init TEST-TOK', homeDir);
       const failScript = createExitScript(scriptDir, 1);

--- a/workflows/work/__tests__/implement-step.test.js
+++ b/workflows/work/__tests__/implement-step.test.js
@@ -1,0 +1,389 @@
+/**
+ * implement-step.test.js
+ *
+ * GH-219 Task 16: Tests for dependency-aware messaging in implement.js.
+ *
+ * Verifies that implement step output includes:
+ *   - Task id (task_N) when tasksMeta exists
+ *   - Claim owner (PR{N}) when a claim is active
+ *   - Dependency status when tasks have dependencies
+ *
+ * Uses node:test + node:assert/strict with in-memory fixture state.
+ */
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const implementStep = require('../steps/implement');
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal `s` (inspected state) fixture.
+ * Mirrors the shape produced by inspect.js and consumed by step handlers.
+ */
+function makeState(overrides = {}) {
+  return {
+    hasTasks: true,
+    workState: {
+      status: 'in_progress',
+      stepStatus: { implement: 'pending' },
+      tasksMeta: {
+        totalTasks: 3,
+        currentTaskIndex: 0,
+        tasks: [
+          { id: 'task_1', status: 'pending', dependencies: [] },
+          { id: 'task_2', status: 'pending', dependencies: [1] },
+          { id: 'task_3', status: 'pending', dependencies: [1, 2] },
+        ],
+      },
+      ...overrides.workState,
+    },
+    hasDiffVsMain: false,
+    diffSummary: '',
+    stepIs: (step) => overrides.stepStatus?.[step] ?? 'pending',
+    ...overrides,
+  };
+}
+
+/**
+ * Build task data as parseTasks would return.
+ */
+function makeTaskData(tasks) {
+  return tasks.map((t, i) => ({
+    id: `task_${t.num ?? i + 1}`,
+    num: t.num ?? i + 1,
+    title: t.title ?? `Task ${t.num ?? i + 1} title`,
+    type: t.type ?? 'backend',
+    isCheckpoint: t.isCheckpoint ?? false,
+    dependencies: t.dependencies ?? [],
+    requirementsCovered: '',
+    acceptanceCriteria: '',
+    suggestedScope: '',
+    rawContent: `## Task ${t.num ?? i + 1} — ${t.title ?? `Task ${t.num ?? i + 1} title`}`,
+  }));
+}
+
+/**
+ * Build minimal `ctx` with stubs for functions the step calls.
+ */
+function makeCtx(overrides = {}) {
+  const tasksDir = overrides.tasksDir ?? '/tmp/fake-tasks';
+  const taskData = overrides.taskData ?? null;
+  return {
+    STEPS: {
+      implement: 'implement',
+    },
+    safeName: 'GH-219',
+    tasksDir,
+    planningContext: '',
+    getDocsPrompt: () => '',
+    parseTasks: () => taskData,
+    buildTaskPrompt: (task) =>
+      `## Current Task: Task ${task.num} — ${task.title}\n\nYou are implementing ONE task.\n\n### Task Details\n${task.rawContent}`,
+    fileExists: () => false,
+    path,
+    execFileSync: () => '',
+    workStatePath: path.join(__dirname, '..', 'work-state.js'),
+    ...overrides,
+  };
+}
+
+/**
+ * Capture the plan entry emitted by implementStep via the add() callback.
+ */
+function captureStep(s, ctx) {
+  const entries = [];
+  function add(step, action, command, reason, meta) {
+    entries.push({ step, action, command, reason, meta });
+  }
+  implementStep(add, s, ctx);
+  return entries;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('implement step — dependency-aware messaging (GH-219 Task 16)', () => {
+  describe('task id in output', () => {
+    it('includes task id (task_N) in reason when tasksMeta exists', () => {
+      const taskData = makeTaskData([
+        { num: 1, title: 'Enforcement audit records' },
+        { num: 2, title: 'Context adapter' },
+      ]);
+      const s = makeState({
+        workState: {
+          tasksMeta: {
+            totalTasks: 2,
+            currentTaskIndex: 0,
+            tasks: [
+              { id: 'task_1', status: 'pending', dependencies: [] },
+              { id: 'task_2', status: 'pending', dependencies: [1] },
+            ],
+          },
+        },
+      });
+      const ctx = makeCtx({ taskData });
+      const entries = captureStep(s, ctx);
+
+      assert.equal(entries.length, 1);
+      const entry = entries[0];
+      assert.equal(entry.action, 'RUN');
+      // Reason should mention the task id
+      assert.ok(
+        entry.reason.includes('task_1') || entry.reason.includes('Task 1'),
+        `reason should mention task id, got: "${entry.reason}"`
+      );
+    });
+
+    it('includes task id for non-first task', () => {
+      const taskData = makeTaskData([
+        { num: 1, title: 'First task' },
+        { num: 2, title: 'Second task' },
+        { num: 3, title: 'Third task' },
+      ]);
+      const s = makeState({
+        workState: {
+          tasksMeta: {
+            totalTasks: 3,
+            currentTaskIndex: 1,
+            tasks: [
+              { id: 'task_1', status: 'completed', dependencies: [] },
+              { id: 'task_2', status: 'pending', dependencies: [1] },
+              { id: 'task_3', status: 'pending', dependencies: [1, 2] },
+            ],
+          },
+        },
+      });
+      const ctx = makeCtx({ taskData });
+      const entries = captureStep(s, ctx);
+
+      const entry = entries[0];
+      assert.equal(entry.action, 'RUN');
+      // Must reference task_2
+      assert.ok(
+        entry.reason.includes('task_2') || entry.reason.includes('Task 2'),
+        `reason should mention current task id, got: "${entry.reason}"`
+      );
+    });
+  });
+
+  describe('claim and PR slot in output', () => {
+    it('includes claim owner (PR{N}) in reason when claim is present', () => {
+      const taskData = makeTaskData([
+        { num: 1, title: 'First task' },
+      ]);
+      const s = makeState({
+        workState: {
+          tasksMeta: {
+            totalTasks: 1,
+            currentTaskIndex: 0,
+            tasks: [
+              { id: 'task_1', status: 'pending', dependencies: [], claimedBy: 'PR1' },
+            ],
+          },
+        },
+      });
+      const ctx = makeCtx({ taskData });
+      const entries = captureStep(s, ctx);
+
+      const entry = entries[0];
+      assert.equal(entry.action, 'RUN');
+      // Reason or agentPrompt should mention PR1
+      const text = (entry.reason || '') + (entry.meta?.agentPrompt || '');
+      assert.ok(
+        text.includes('PR1'),
+        `output should mention claim owner PR1, got reason: "${entry.reason}", prompt: "${entry.meta?.agentPrompt?.substring(0, 200)}"`
+      );
+    });
+
+    it('includes PR slot in agentPrompt when worker slot is allocated', () => {
+      const taskData = makeTaskData([
+        { num: 1, title: 'First task' },
+      ]);
+      const s = makeState({
+        workState: {
+          tasksMeta: {
+            totalTasks: 1,
+            currentTaskIndex: 0,
+            tasks: [
+              { id: 'task_1', status: 'pending', dependencies: [], claimedBy: 'PR2' },
+            ],
+          },
+          parallelWorkers: {
+            nextSlot: 3,
+            allocations: [
+              { slot: 1, ownerId: 'PR1', releasedAt: '2026-01-01T00:00:00Z' },
+              { slot: 2, ownerId: 'PR2', claimedAt: '2026-01-02T00:00:00Z' },
+            ],
+          },
+        },
+      });
+      const ctx = makeCtx({ taskData });
+      const entries = captureStep(s, ctx);
+
+      const entry = entries[0];
+      const text = (entry.reason || '') + (entry.meta?.agentPrompt || '');
+      assert.ok(
+        text.includes('PR2'),
+        `output should mention PR slot PR2, got reason: "${entry.reason}"`
+      );
+    });
+  });
+
+  describe('dependency status in output', () => {
+    it('includes dependency status phrase when task has dependencies', () => {
+      const taskData = makeTaskData([
+        { num: 1, title: 'First task', dependencies: [] },
+        { num: 2, title: 'Second task', dependencies: [1] },
+      ]);
+      const s = makeState({
+        workState: {
+          tasksMeta: {
+            totalTasks: 2,
+            currentTaskIndex: 1,
+            tasks: [
+              { id: 'task_1', status: 'completed', dependencies: [] },
+              { id: 'task_2', status: 'pending', dependencies: [1] },
+            ],
+          },
+        },
+      });
+      const ctx = makeCtx({ taskData });
+      const entries = captureStep(s, ctx);
+
+      const entry = entries[0];
+      const text = (entry.reason || '') + (entry.meta?.agentPrompt || '');
+      // Should mention dependencies are met / resolved / ready
+      assert.ok(
+        /dependenc/i.test(text) || /deps.*ready/i.test(text) || /deps.*met/i.test(text),
+        `output should mention dependency status, got reason: "${entry.reason}"`
+      );
+    });
+
+    it('does not mention dependencies when task has none', () => {
+      const taskData = makeTaskData([
+        { num: 1, title: 'First task', dependencies: [] },
+      ]);
+      const s = makeState({
+        workState: {
+          tasksMeta: {
+            totalTasks: 1,
+            currentTaskIndex: 0,
+            tasks: [
+              { id: 'task_1', status: 'pending', dependencies: [] },
+            ],
+          },
+        },
+      });
+      const ctx = makeCtx({ taskData });
+      const entries = captureStep(s, ctx);
+
+      const entry = entries[0];
+      // No dependency phrase needed when task has no dependencies
+      assert.equal(entry.action, 'RUN');
+    });
+  });
+
+  describe('existing behaviors preserved', () => {
+    it('SKIPs when all tasks are done', () => {
+      const taskData = makeTaskData([
+        { num: 1, title: 'Only task' },
+      ]);
+      const s = makeState({
+        workState: {
+          tasksMeta: {
+            totalTasks: 1,
+            currentTaskIndex: 1,  // past the end
+            tasks: [
+              { id: 'task_1', status: 'completed', dependencies: [] },
+            ],
+          },
+        },
+      });
+      const ctx = makeCtx({ taskData });
+      const entries = captureStep(s, ctx);
+
+      assert.equal(entries[0].action, 'SKIP');
+      assert.ok(entries[0].reason.includes('All tasks completed'));
+    });
+
+    it('SKIPs checkpoint tasks', () => {
+      const taskData = makeTaskData([
+        { num: 1, title: 'Checkpoint task', isCheckpoint: true, type: 'checkpoint' },
+      ]);
+      const s = makeState({
+        workState: {
+          tasksMeta: {
+            totalTasks: 1,
+            currentTaskIndex: 0,
+            tasks: [
+              { id: 'task_1', status: 'pending', dependencies: [] },
+            ],
+          },
+        },
+      });
+      const ctx = makeCtx({ taskData });
+      const entries = captureStep(s, ctx);
+
+      assert.equal(entries[0].action, 'SKIP');
+      assert.ok(entries[0].reason.includes('checkpoint'));
+    });
+
+    it('DEFERs when implement previously completed with diff', () => {
+      const taskData = makeTaskData([
+        { num: 1, title: 'Task one' },
+      ]);
+      const s = makeState({
+        hasDiffVsMain: true,
+        diffSummary: '3 files changed',
+        stepStatus: { implement: 'completed' },
+        workState: {
+          tasksMeta: {
+            totalTasks: 1,
+            currentTaskIndex: 0,
+            tasks: [
+              { id: 'task_1', status: 'pending', dependencies: [] },
+            ],
+          },
+        },
+      });
+      const ctx = makeCtx({ taskData });
+      const entries = captureStep(s, ctx);
+
+      assert.equal(entries[0].action, 'DEFER');
+    });
+
+    it('emits RUN without tasks when hasTasks is false', () => {
+      const s = makeState({ hasTasks: false });
+      const ctx = makeCtx({ taskData: null });
+      const entries = captureStep(s, ctx);
+
+      assert.equal(entries[0].action, 'RUN');
+      // No task-specific messaging when no tasks exist
+    });
+
+    it('exports task metadata on ctx for task-advance step', () => {
+      const taskData = makeTaskData([
+        { num: 1, title: 'First task' },
+      ]);
+      const s = makeState({
+        workState: {
+          tasksMeta: {
+            totalTasks: 1,
+            currentTaskIndex: 0,
+            tasks: [
+              { id: 'task_1', status: 'pending', dependencies: [] },
+            ],
+          },
+        },
+      });
+      const ctx = makeCtx({ taskData });
+      captureStep(s, ctx);
+
+      assert.ok(ctx._taskData !== undefined, 'ctx._taskData should be set');
+      assert.equal(ctx._allTasksDone, false);
+      assert.equal(ctx._currentTaskIdx, 0);
+    });
+  });
+});

--- a/workflows/work/steps/implement.js
+++ b/workflows/work/steps/implement.js
@@ -12,6 +12,115 @@
 const _taskParser = require('../task-parser');
 void _taskParser;
 
+// ─── GH-219 Task 16: Dependency-aware message builders ─────────────────────
+
+/**
+ * Resolve the PR{N} worker slot for the current claim owner.
+ * Returns the slot string (e.g. "PR1") or null if not applicable.
+ *
+ * @param {object|null} workState - Full work state
+ * @param {string|null} claimOwner - Claim owner id (e.g. "PR1")
+ * @returns {string|null}
+ */
+function _resolveWorkerSlot(workState, claimOwner) {
+  if (!claimOwner || !workState?.parallelWorkers?.allocations) return null;
+  const alloc = workState.parallelWorkers.allocations.find(
+    (a) => a.ownerId === claimOwner && !a.releasedAt
+  );
+  return alloc ? alloc.ownerId : null;
+}
+
+/**
+ * Build a dependency status descriptor for the current task.
+ * Returns null if task has no dependencies, or a status object.
+ *
+ * @param {object|null} currentTask - Parsed task from task-parser
+ * @param {object|null} taskState - tasksMeta from work state
+ * @returns {{ hasDeps: boolean, allMet: boolean, deps: Array<{ num: number, met: boolean }> } | null}
+ */
+function _buildDependencyStatus(currentTask, taskState) {
+  if (!currentTask || !Array.isArray(currentTask.dependencies) || currentTask.dependencies.length === 0) {
+    return null;
+  }
+  const tasks = taskState?.tasks ?? [];
+  const deps = currentTask.dependencies.map((depNum) => {
+    const depTask = tasks.find((t) => t.id === `task_${depNum}`);
+    return { num: depNum, met: depTask?.status === 'completed' };
+  });
+  return { hasDeps: true, allMet: deps.every((d) => d.met), deps };
+}
+
+/**
+ * Build the dependency/claim/slot prompt fragment appended to the agent prompt.
+ *
+ * @param {{ hasDeps: boolean, allMet: boolean, deps: Array<{ num: number, met: boolean }> } | null} depStatus
+ * @param {string|null} claimOwner
+ * @param {string|null} workerSlot
+ * @returns {string}
+ */
+function _buildDependencyPrompt(depStatus, claimOwner, workerSlot) {
+  const parts = [];
+  if (claimOwner) {
+    parts.push(`\n\n### Worker Assignment`);
+    parts.push(`Claimed by: ${claimOwner}`);
+    if (workerSlot) {
+      parts.push(`Worker slot: ${workerSlot}`);
+    }
+  }
+  if (depStatus) {
+    parts.push(`\n\n### Dependencies`);
+    if (depStatus.allMet) {
+      parts.push(`All dependencies met. This task is ready to start.`);
+    }
+    depStatus.deps.forEach((d) => {
+      parts.push(`- Task ${d.num}: ${d.met ? 'completed' : 'pending'}`);
+    });
+  }
+  return parts.length > 0 ? '\n' + parts.join('\n') : '';
+}
+
+/**
+ * Build the human-readable reason string for the implement step.
+ *
+ * @param {object|null} currentTask
+ * @param {number} currentTaskIdx
+ * @param {Array|null} taskData
+ * @param {string|null} claimOwner
+ * @param {string|null} workerSlot
+ * @param {object|null} depStatus
+ * @param {object|null} s
+ * @returns {string}
+ */
+function _buildTaskReason(currentTask, currentTaskIdx, taskData, claimOwner, workerSlot, depStatus, s) {
+  if (!currentTask) {
+    return s?.hasDiffVsMain
+      ? 'Changes exist but implement not yet completed'
+      : 'No changes vs main';
+  }
+
+  const parts = [];
+  // Task id + progress
+  parts.push(`Task ${currentTaskIdx + 1}/${taskData.length} (${currentTask.id}): ${currentTask.title}`);
+
+  // Claim + PR slot
+  if (claimOwner) {
+    const slotInfo = workerSlot ? ` [${workerSlot}]` : '';
+    parts.push(`claimed by ${claimOwner}${slotInfo}`);
+  }
+
+  // Dependency status
+  if (depStatus) {
+    if (depStatus.allMet) {
+      parts.push('dependencies met');
+    } else {
+      const pending = depStatus.deps.filter((d) => !d.met).map((d) => `Task ${d.num}`);
+      parts.push(`dependencies pending: ${pending.join(', ')}`);
+    }
+  }
+
+  return parts.join(' — ');
+}
+
 module.exports = function implementStep(add, s, ctx) {
   const {
     STEPS,
@@ -47,10 +156,16 @@ module.exports = function implementStep(add, s, ctx) {
     }
   }
 
+  // ─── GH-219 Task 16: dependency-aware context extraction ─────────────
+  const currentTaskMeta = taskState?.tasks?.[currentTaskIdx] ?? null;
+  const claimOwner = currentTaskMeta?.claimedBy ?? null;
+  const workerSlot = _resolveWorkerSlot(s?.workState, claimOwner);
+  const depStatus = _buildDependencyStatus(currentTask, taskState);
+
   const implementMeta = {
     agentType: 'skill',
     agentPrompt: currentTask
-      ? `/work-implement ${buildTaskPrompt(currentTask, tasksDir)}${getDocsPrompt('READ_DOCS_ON_DEV')}`
+      ? `/work-implement ${buildTaskPrompt(currentTask, tasksDir)}${_buildDependencyPrompt(depStatus, claimOwner, workerSlot)}${getDocsPrompt('READ_DOCS_ON_DEV')}`
       : `/work-implement <requirements>${planningContext}${getDocsPrompt('READ_DOCS_ON_DEV')}`,
   };
 
@@ -74,11 +189,7 @@ module.exports = function implementStep(add, s, ctx) {
         implementMeta
       );
     } else {
-      const reason = currentTask
-        ? `Task ${currentTaskIdx + 1}/${taskData.length}: ${currentTask.title}`
-        : s?.hasDiffVsMain
-          ? `Changes exist but implement not yet completed`
-          : 'No changes vs main';
+      const reason = _buildTaskReason(currentTask, currentTaskIdx, taskData, claimOwner, workerSlot, depStatus, s);
       add(STEPS.implement, 'RUN', '/work-implement <requirements>', reason, implementMeta);
     }
   }


### PR DESCRIPTION
## Existing Behavior

- The implement step reason string only shows `Task N/M: <title>` with no claim or dependency context.
- The agent prompt passed to `/work-implement` contains no worker slot or dependency information.
- `tdd-phase-state.test.js` had an incorrectly indented `token gating` describe block nested one level too deep.

## Intended New Behavior

- The implement step reason string now includes the task id (`task_N`), claim owner (`PR{N}`), worker slot, and dependency status (met/pending) when available.
- The agent prompt appended to `/work-implement` gains a `### Worker Assignment` section (claim owner + worker slot) and a `### Dependencies` section listing each dependency's completion state.
- Three pure helper functions (`_resolveWorkerSlot`, `_buildDependencyStatus`, `_buildDependencyPrompt`, `_buildTaskReason`) encapsulate all new logic, keeping `implementStep` unchanged in structure.
- The `token gating` describe block indentation is corrected to align with its sibling blocks.

## Dev Checks

- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Backend / CLI changes — verify with node:test runner:

1. Run the new implement-step test suite:
   ```
   node --test workflows/work/__tests__/implement-step.test.js
   ```
   Expected: all 9 tests pass (task id in reason, claim owner in output, dependency status phrase, preserved SKIP/DEFER/RUN behaviours, ctx._taskData exported).

2. Run the corrected tdd-phase-state test suite to confirm indentation fix does not break anything:
   ```
   node --test workflows/work-implement/__tests__/tdd-phase-state.test.js
   ```
   Expected: all tests pass including the `token gating` block.

3. To verify dependency-aware messaging end-to-end, inspect a work state JSON that has a task with `claimedBy: "PR1"` and dependencies `[1]` where task_1 is `completed`. Run the orchestrator against that state and confirm the generated plan entry reason reads:
   ```
   Task 2/N (task_2): <title> — claimed by PR1 [PR1] — dependencies met
   ```

Part of #219. Depends on PR 3 (#223).

### Test Results

Tests covering this PR exist in `workflows/work/__tests__/implement-step.test.js` (new, 389 lines) and `workflows/work-implement/__tests__/tdd-phase-state.test.js` (indentation fix). Results to be confirmed after CI run.