### PR TITLE
feat(preflight): shared gate library + path allocator + request index (#219 PR 3/6)

### DIFF
--- a/workflows/lib/__tests__/allocate-output-folder.test.js
+++ b/workflows/lib/__tests__/allocate-output-folder.test.js
@@ -1,0 +1,200 @@
+/**
+ * Tests for workflows/lib/allocate-output-folder.js (GH-219 Task 9 / R7, R8)
+ *
+ * Coverage:
+ *   - In-flow: returns `TASKS_BASE/<ticket>/task${N}/` for a claimed task.
+ *   - Out-of-flow user: returns `user-request-${k}` given a counter from Task 10
+ *     (counters are injected — Task 10 will wire the real `.request-index.json`).
+ *   - Out-of-flow AI: returns `ai-request-${k}` given a counter.
+ *   - Single source of truth for the `task${N}` naming (R7 — one allocator, one
+ *     naming policy). Other modules must consume this rather than rebuilding
+ *     the segment string.
+ *   - R15 fail-closed: rejects invalid ticket IDs (path traversal, empty, null,
+ *     backslash) before any filesystem access.
+ *   - Legacy-root case: when neither in-flow nor out-of-flow context is
+ *     complete enough to allocate, the allocator returns the ticket root as
+ *     `kind: 'legacy-root'` so callers can implement the backward-compat
+ *     fallback path (pairs with `tdd-phase-state.js` legacy reads).
+ *
+ * Run with: node --test workflows/lib/__tests__/allocate-output-folder.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const allocator = require('../allocate-output-folder');
+
+function mkTasksBase() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'alloc-of-'));
+  const tasksBase = path.join(dir, 'worktrees', 'tasks');
+  fs.mkdirSync(tasksBase, { recursive: true });
+  return { dir, tasksBase };
+}
+
+describe('allocate-output-folder', () => {
+  let tmpDir;
+  let tasksBase;
+  let origTasksBase;
+
+  beforeEach(() => {
+    ({ dir: tmpDir, tasksBase } = mkTasksBase());
+    origTasksBase = process.env.TASKS_BASE;
+    process.env.TASKS_BASE = tasksBase;
+  });
+
+  afterEach(() => {
+    if (origTasksBase === undefined) delete process.env.TASKS_BASE;
+    else process.env.TASKS_BASE = origTasksBase;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('API surface', () => {
+    it('exports allocateOutputFolder, taskSegment, and prefix constants', () => {
+      assert.strictEqual(typeof allocator.allocateOutputFolder, 'function');
+      assert.strictEqual(typeof allocator.taskSegment, 'function');
+      assert.strictEqual(typeof allocator.TASK_SEGMENT_PREFIX, 'string');
+      assert.strictEqual(typeof allocator.USER_REQUEST_PREFIX, 'string');
+      assert.strictEqual(typeof allocator.AI_REQUEST_PREFIX, 'string');
+    });
+
+    it('taskSegment produces the canonical `task${N}` form (R7 single source of truth)', () => {
+      assert.strictEqual(allocator.taskSegment(1), 'task1');
+      assert.strictEqual(allocator.taskSegment(9), 'task9');
+      assert.strictEqual(allocator.taskSegment(42), 'task42');
+    });
+
+    it('taskSegment rejects non-positive / non-integer input (fail-closed)', () => {
+      assert.throws(() => allocator.taskSegment(0), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment(-1), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment(1.5), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment('abc'), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment(null), /Invalid taskNum/i);
+    });
+  });
+
+  describe('in-flow task allocation (R7, R8)', () => {
+    it('returns TASKS_BASE/<ticket>/task${N}/ for in-flow + taskNum', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'workflow',
+        flow: 'in-flow',
+        taskNum: 9,
+        prSlot: 1,
+      });
+      assert.strictEqual(result.kind, 'in-flow-task');
+      assert.strictEqual(result.segment, 'task9');
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219', 'task9'));
+      assert.strictEqual(result.ticketRoot, path.join(tasksBase, 'GH-219'));
+    });
+
+    it('is deterministic: same context returns identical segment (R7)', () => {
+      const ctx = { origin: 'workflow', flow: 'in-flow', taskNum: 3 };
+      const a = allocator.allocateOutputFolder('GH-219', ctx);
+      const b = allocator.allocateOutputFolder('GH-219', ctx);
+      assert.strictEqual(a.segment, b.segment);
+      assert.strictEqual(a.root, b.root);
+    });
+
+    it('uses the same taskSegment() helper everywhere (R7 single source of truth)', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'workflow',
+        flow: 'in-flow',
+        taskNum: 7,
+      });
+      assert.strictEqual(result.segment, allocator.taskSegment(7));
+      assert.ok(result.root.endsWith(path.sep + allocator.taskSegment(7)));
+    });
+
+    it('throws when in-flow requires taskNum but none provided (fail-closed)', () => {
+      assert.throws(
+        () =>
+          allocator.allocateOutputFolder('GH-219', {
+            origin: 'workflow',
+            flow: 'in-flow',
+          }),
+        /taskNum/i
+      );
+    });
+  });
+
+  describe('out-of-flow allocation (Task 10 will wire counters; stub here)', () => {
+    it('returns user-request-${k} when counters are injected', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'user',
+        flow: 'out-of-flow',
+        counters: { userRequestNext: 4, aiRequestNext: 1 },
+      });
+      assert.strictEqual(result.kind, 'out-of-flow-user');
+      assert.strictEqual(result.segment, 'user-request-4');
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219', 'user-request-4'));
+    });
+
+    it('returns ai-request-${k} when origin is ai-subtask/ai', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'ai-subtask',
+        flow: 'out-of-flow',
+        counters: { userRequestNext: 1, aiRequestNext: 7 },
+      });
+      assert.strictEqual(result.kind, 'out-of-flow-ai');
+      assert.strictEqual(result.segment, 'ai-request-7');
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219', 'ai-request-7'));
+    });
+
+    it('fails closed when counters are missing for out-of-flow user', () => {
+      assert.throws(
+        () =>
+          allocator.allocateOutputFolder('GH-219', {
+            origin: 'user',
+            flow: 'out-of-flow',
+          }),
+        /counter|userRequestNext|Task 10/i
+      );
+    });
+
+    it('fails closed when counters are missing for out-of-flow ai', () => {
+      assert.throws(
+        () =>
+          allocator.allocateOutputFolder('GH-219', {
+            origin: 'ai-subtask',
+            flow: 'out-of-flow',
+          }),
+        /counter|aiRequestNext|Task 10/i
+      );
+    });
+  });
+
+  describe('legacy-root fallback (pairs with tdd-phase-state backward-compat read)', () => {
+    it('returns ticket root as kind "legacy-root" when no flow/task context is supplied', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {});
+      assert.strictEqual(result.kind, 'legacy-root');
+      assert.strictEqual(result.segment, null);
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219'));
+    });
+  });
+
+  describe('R15 ticket ID validation (fail-closed, before I/O)', () => {
+    it('rejects empty / null / undefined ticket id', () => {
+      assert.throws(() => allocator.allocateOutputFolder('', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder(null, { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder(undefined, { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+    });
+
+    it('rejects path traversal attempts', () => {
+      assert.throws(() => allocator.allocateOutputFolder('../etc', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder('GH-1/../evil', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder('foo\\bar', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+    });
+  });
+
+  describe('TASKS_BASE resolution', () => {
+    it('throws when TASKS_BASE is not configured', () => {
+      delete process.env.TASKS_BASE;
+      assert.throws(
+        () => allocator.allocateOutputFolder('GH-219', { flow: 'in-flow', taskNum: 1 }),
+        /TASKS_BASE/i
+      );
+    });
+  });
+});

--- a/workflows/lib/__tests__/preflight-integration.test.js
+++ b/workflows/lib/__tests__/preflight-integration.test.js
@@ -1,0 +1,878 @@
+/**
+ * P1 integration + guardrail tests for preflight and supporting modules.
+ *
+ * IDEA2 / GH-219 — Task 18: Integration tests for parallel-ready tasks,
+ * counter collisions, ambiguous origin, invalid graph.
+ *
+ * Requirements covered:
+ *   R19 — Integration tests for mixed serial/parallel dependency graphs
+ *   R20 — Guardrail tests for edge cases (ambiguous origin, out-of-flow,
+ *          counter races, invalid graph, etc.)
+ *   R18 — Remediation quality bar: deny-path tests assert remediation
+ *          includes ruleId, evaluated state snapshot, and concrete fix steps
+ *          (non-empty remediation strings array)
+ *   R16 — Legacy ticket fixtures in integration where applicable
+ *
+ * Run: node --test workflows/lib/__tests__/preflight-integration.test.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Isolated TASKS_BASE before any module requires
+const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'preflight-integ-'));
+process.env.TASKS_BASE = TEMP_TASKS_BASE;
+
+const { describe, it, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  runPreflight,
+  isWriteAllowedPath,
+  createGraphCheck,
+  createClaimCheck,
+  createPathCheck,
+} = require(path.join(__dirname, '..', 'preflight'));
+
+const workState = require(path.join(__dirname, '..', '..', 'work', 'work-state'));
+const requestIndex = require(path.join(__dirname, '..', 'request-index'));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function freshTicket(prefix) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+}
+
+function cleanupTicket(ticketId) {
+  try {
+    fs.rmSync(path.join(TEMP_TASKS_BASE, ticketId), { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+after(() => {
+  try {
+    fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R4, R19 — Invalid graph tests (unknown dep, cycle, self-dep)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — invalid graph: unknown dependency (R4, R19)', () => {
+  it('preflight denies graph with unknown dep (Task 3 -> Task 99) and reports UNKNOWN_DEPENDENCY', () => {
+    const ctx = {
+      ticketId: 'GH-INT-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [] },
+        { num: 3, dependencies: [99] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+
+    assert.equal(result.allow, false, 'unknown dep must deny');
+    assert.ok(
+      result.reasons.includes('UNKNOWN_DEPENDENCY'),
+      `reasons must include UNKNOWN_DEPENDENCY, got: ${JSON.stringify(result.reasons)}`
+    );
+    assert.ok(result.remediation.length > 0, 'remediation must list fix steps');
+    // Remediation must mention the missing task id
+    assert.ok(
+      result.remediation.some((r) => r.includes('99')),
+      'remediation must reference the unknown task id (99)'
+    );
+  });
+});
+
+describe('integration — invalid graph: dependency cycle (R4, R19)', () => {
+  it('preflight denies 2-cycle (A->B->A) with DEPENDENCY_CYCLE', () => {
+    const ctx = {
+      ticketId: 'GH-INT-2',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [2] },
+        { num: 2, dependencies: [1] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+
+    assert.equal(result.allow, false, 'cycle must deny');
+    assert.ok(result.reasons.includes('DEPENDENCY_CYCLE'));
+    assert.ok(result.remediation.length > 0);
+  });
+
+  it('preflight denies 3-cycle (1->2->3->1) with DEPENDENCY_CYCLE', () => {
+    const ctx = {
+      ticketId: 'GH-INT-3',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [3] },
+        { num: 2, dependencies: [1] },
+        { num: 3, dependencies: [2] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+
+    assert.equal(result.allow, false, '3-cycle must deny');
+    assert.ok(result.reasons.includes('DEPENDENCY_CYCLE'));
+  });
+});
+
+describe('integration — invalid graph: self-dependency (R4, R19)', () => {
+  it('preflight denies self-dep (Task 1 -> Task 1) with SELF_DEPENDENCY', () => {
+    const ctx = {
+      ticketId: 'GH-INT-4',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [1] },
+        { num: 2, dependencies: [] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+
+    assert.equal(result.allow, false, 'self-dep must deny');
+    assert.ok(result.reasons.includes('SELF_DEPENDENCY'));
+    assert.ok(result.remediation.length > 0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R19 — Mixed serial/parallel dependency graphs
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — mixed serial/parallel dependency graph (R19)', () => {
+  // Diamond: 1 -> 2, 1 -> 3, 2 -> 4, 3 -> 4 (tasks 2 and 3 can run in parallel)
+  it('allows parallel-ready tasks (2 and 3) when their shared dependency (1) is complete', () => {
+    const tasks = [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [1] },
+      { num: 3, dependencies: [1] },
+      { num: 4, dependencies: [2, 3] },
+    ];
+
+    const tasksMeta = {
+      totalTasks: 4,
+      currentTaskIndex: 1,
+      tasks: [
+        { id: 'task_1', status: 'completed', dependencies: [] },
+        { id: 'task_2', status: 'pending', dependencies: [1] },
+        { id: 'task_3', status: 'pending', dependencies: [1] },
+        { id: 'task_4', status: 'pending', dependencies: [2, 3] },
+      ],
+    };
+
+    const ctx = {
+      ticketId: 'GH-INT-DIAMOND',
+      origin: 'workflow',
+      error: null,
+      tasks,
+      state: { status: 'in_progress', tasksMeta },
+      hasWorkflow: true,
+    };
+
+    // Both task 2 and task 3 should be startable (parallel)
+    const check2 = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const check3 = createClaimCheck({ taskNum: 3, ownerId: 'PR2' });
+
+    const result2 = runPreflight(ctx, { checks: [createGraphCheck(), check2] });
+    const result3 = runPreflight(ctx, { checks: [createGraphCheck(), check3] });
+
+    assert.equal(result2.allow, true, 'task 2 with dep 1 complete is startable');
+    assert.equal(result3.allow, true, 'task 3 with dep 1 complete is startable in parallel');
+  });
+
+  it('denies task 4 when only one of its deps (2, 3) is complete', () => {
+    const tasks = [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [1] },
+      { num: 3, dependencies: [1] },
+      { num: 4, dependencies: [2, 3] },
+    ];
+
+    const tasksMeta = {
+      totalTasks: 4,
+      currentTaskIndex: 3,
+      tasks: [
+        { id: 'task_1', status: 'completed', dependencies: [] },
+        { id: 'task_2', status: 'completed', dependencies: [1] },
+        { id: 'task_3', status: 'pending', dependencies: [1] },
+        { id: 'task_4', status: 'pending', dependencies: [2, 3] },
+      ],
+    };
+
+    const ctx = {
+      ticketId: 'GH-INT-DIAMOND-HALF',
+      origin: 'workflow',
+      error: null,
+      tasks,
+      state: { status: 'in_progress', tasksMeta },
+      hasWorkflow: true,
+    };
+
+    const check4 = createClaimCheck({ taskNum: 4, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [createGraphCheck(), check4] });
+
+    assert.equal(result.allow, false, 'task 4 with task 3 still pending must deny');
+    assert.ok(result.reasons.includes('DEPENDENCY_NOT_READY'));
+  });
+
+  it('graph validation accepts a complex valid DAG (chain + fan-out + fan-in)', () => {
+    // Tasks: 1 (root), 2 depends on 1, 3 depends on 1, 4 depends on 2,
+    //         5 depends on 2+3 (fan-in), 6 depends on 4+5 (final merge)
+    const tasks = [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [1] },
+      { num: 3, dependencies: [1] },
+      { num: 4, dependencies: [2] },
+      { num: 5, dependencies: [2, 3] },
+      { num: 6, dependencies: [4, 5] },
+    ];
+
+    const ctx = {
+      ticketId: 'GH-INT-COMPLEX-DAG',
+      origin: 'workflow',
+      error: null,
+      tasks,
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, true, 'complex valid DAG must pass graph validation');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R20 — Ambiguous --subtask (flag set, no state)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — ambiguous --subtask origin (R20, R2)', () => {
+  it('context.error with AMBIGUOUS_SUBTASK denies with remediation to initialize or remove flag', () => {
+    // Simulates: --subtask set but no matching subtask state file found
+    const ctx = {
+      ticketId: 'GH-INT-SUBTASK',
+      origin: null,
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: '--subtask flag is set but no subtask state file found',
+        remediation: [
+          'Initialize the subtask state before using --subtask.',
+          'Remove the --subtask flag if this is a main workflow invocation.',
+        ],
+      },
+      state: null,
+      tasks: null,
+      subtaskState: null,
+      hasWorkflow: false,
+    };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, false, 'ambiguous subtask must deny');
+    assert.ok(result.reasons.includes('AMBIGUOUS_SUBTASK'));
+    assert.ok(result.remediation.length >= 2, 'must include at least two remediation steps');
+    assert.ok(
+      result.remediation.some((r) => r.toLowerCase().includes('subtask')),
+      'remediation must mention subtask'
+    );
+  });
+
+  it('audit entry captures the ambiguous subtask denial', () => {
+    const audited = [];
+    const ctx = {
+      ticketId: 'GH-INT-SUBTASK-AUDIT',
+      origin: null,
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: 'no subtask state found',
+        remediation: ['Initialize subtask first'],
+      },
+    };
+
+    runPreflight(ctx, { audit: (e) => audited.push(e) });
+
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].decision, 'deny');
+    assert.ok(audited[0].reasons.includes('AMBIGUOUS_SUBTASK'));
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R11, R20 — Concurrent request index (parallel increments)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — concurrent request index sequential increments (R11, R20)', () => {
+  let TICKET;
+
+  beforeEach(() => {
+    TICKET = freshTicket('INT-REQIDX');
+    cleanupTicket(TICKET);
+  });
+
+  it('rapid sequential user request allocations yield strictly increasing sequences', () => {
+    const results = [];
+    for (let i = 0; i < 15; i++) {
+      results.push(requestIndex.nextUserRequest(TICKET));
+    }
+
+    for (let i = 1; i < results.length; i++) {
+      assert.ok(
+        results[i].seq > results[i - 1].seq,
+        `user-request sequence not monotonic at index ${i}: ${results[i - 1].seq} >= ${results[i].seq}`
+      );
+    }
+    assert.equal(results[results.length - 1].seq, 15);
+
+    // Verify disk state is consistent
+    const idx = requestIndex.readIndex(TICKET);
+    assert.equal(idx.userSeq, 15, 'persisted userSeq must equal last allocation');
+  });
+
+  it('rapid sequential AI request allocations yield strictly increasing sequences', () => {
+    const results = [];
+    for (let i = 0; i < 10; i++) {
+      results.push(requestIndex.nextAiRequest(TICKET));
+    }
+
+    for (let i = 1; i < results.length; i++) {
+      assert.ok(
+        results[i].seq > results[i - 1].seq,
+        `ai-request sequence not monotonic at index ${i}`
+      );
+    }
+    assert.equal(results[results.length - 1].seq, 10);
+  });
+
+  it('interleaved user and AI allocations maintain independent counters', () => {
+    const u1 = requestIndex.nextUserRequest(TICKET);
+    const a1 = requestIndex.nextAiRequest(TICKET);
+    const u2 = requestIndex.nextUserRequest(TICKET);
+    const a2 = requestIndex.nextAiRequest(TICKET);
+    const u3 = requestIndex.nextUserRequest(TICKET);
+
+    assert.equal(u1.seq, 1);
+    assert.equal(a1.seq, 1, 'AI counter starts independent of user counter');
+    assert.equal(u2.seq, 2);
+    assert.equal(a2.seq, 2);
+    assert.equal(u3.seq, 3);
+
+    const idx = requestIndex.readIndex(TICKET);
+    assert.equal(idx.userSeq, 3);
+    assert.equal(idx.aiSeq, 2);
+  });
+
+  it('each allocation creates a unique directory on disk', () => {
+    const r1 = requestIndex.nextUserRequest(TICKET);
+    const r2 = requestIndex.nextUserRequest(TICKET);
+    const r3 = requestIndex.nextAiRequest(TICKET);
+
+    assert.notEqual(r1.root, r2.root, 'user-request-1 and user-request-2 must differ');
+    assert.notEqual(r1.root, r3.root, 'user-request-1 and ai-request-1 must differ');
+
+    assert.ok(fs.existsSync(r1.root), 'user-request-1 dir must exist');
+    assert.ok(fs.existsSync(r2.root), 'user-request-2 dir must exist');
+    assert.ok(fs.existsSync(r3.root), 'ai-request-1 dir must exist');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R14, R19 — Two PR workers with distinct roots
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — two PR workers with distinct roots (R14, R19)', () => {
+  let TICKET;
+
+  beforeEach(() => {
+    TICKET = freshTicket('INT-PR-WORKERS');
+    cleanupTicket(TICKET);
+  });
+
+  it('two allocateWorkerSlot calls produce distinct PR directories', () => {
+    const pr1 = workState.allocateWorkerSlot(TICKET);
+    const pr2 = workState.allocateWorkerSlot(TICKET);
+
+    assert.notEqual(pr1.slot, pr2.slot, 'slots must differ');
+    assert.notEqual(pr1.ownerId, pr2.ownerId, 'owner ids must differ');
+    assert.notEqual(pr1.dir, pr2.dir, 'directories must differ');
+
+    assert.equal(pr1.ownerId, 'PR1');
+    assert.equal(pr2.ownerId, 'PR2');
+
+    // Both directories exist on disk
+    assert.ok(fs.existsSync(pr1.dir), 'PR1 dir exists');
+    assert.ok(fs.existsSync(pr2.dir), 'PR2 dir exists');
+
+    // Paths do not overlap
+    assert.ok(
+      !pr1.dir.startsWith(pr2.dir) && !pr2.dir.startsWith(pr1.dir),
+      'PR directories must not be nested within each other'
+    );
+  });
+
+  it('each PR worker writes only to its own directory (path gate enforcement)', () => {
+    const pr1 = workState.allocateWorkerSlot(TICKET);
+    const pr2 = workState.allocateWorkerSlot(TICKET);
+    const ticketRoot = path.join(TEMP_TASKS_BASE, TICKET);
+
+    // PR1 worker paths
+    const pr1Paths = {
+      prDir: pr1.dir,
+      taskDir: path.join(ticketRoot, 'task1'),
+      ticketRoot,
+    };
+
+    // PR2 worker paths
+    const pr2Paths = {
+      prDir: pr2.dir,
+      taskDir: path.join(ticketRoot, 'task2'),
+      ticketRoot,
+    };
+
+    // PR1 can write to its own dir
+    assert.ok(
+      isWriteAllowedPath(path.join(pr1.dir, 'src', 'file.js'), pr1Paths),
+      'PR1 allowed to write under PR1/'
+    );
+
+    // PR1 cannot write to PR2 dir
+    assert.equal(
+      isWriteAllowedPath(path.join(pr2.dir, 'src', 'file.js'), pr1Paths),
+      false,
+      'PR1 must NOT write under PR2/'
+    );
+
+    // PR2 can write to its own dir
+    assert.ok(
+      isWriteAllowedPath(path.join(pr2.dir, 'src', 'file.js'), pr2Paths),
+      'PR2 allowed to write under PR2/'
+    );
+
+    // PR2 cannot write to PR1 dir
+    assert.equal(
+      isWriteAllowedPath(path.join(pr1.dir, 'src', 'file.js'), pr2Paths),
+      false,
+      'PR2 must NOT write under PR1/'
+    );
+
+    // Both can write shared-root whitelist
+    assert.ok(
+      isWriteAllowedPath(path.join(ticketRoot, '.work-state.json'), pr1Paths),
+      'PR1 can write .work-state.json at ticket root'
+    );
+    assert.ok(
+      isWriteAllowedPath(path.join(ticketRoot, '.work-state.json'), pr2Paths),
+      'PR2 can write .work-state.json at ticket root'
+    );
+  });
+
+  it('two workers claim different tasks and preflight allows both (full composition)', () => {
+    const tasks = [
+      { num: 1, dependencies: [] },
+      { num: 2, dependencies: [] },
+    ];
+    const tasksMeta = {
+      totalTasks: 2,
+      currentTaskIndex: 0,
+      tasks: [
+        { id: 'task_1', status: 'pending', dependencies: [] },
+        { id: 'task_2', status: 'pending', dependencies: [] },
+      ],
+    };
+
+    const pr1 = workState.allocateWorkerSlot(TICKET);
+    const pr2 = workState.allocateWorkerSlot(TICKET);
+    const ticketRoot = path.join(TEMP_TASKS_BASE, TICKET);
+
+    const ctx = {
+      ticketId: TICKET,
+      origin: 'workflow',
+      error: null,
+      tasks,
+      state: { status: 'in_progress', tasksMeta },
+      hasWorkflow: true,
+    };
+
+    // Worker 1 claims task 1
+    const checks1 = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 1, ownerId: pr1.ownerId }),
+      createPathCheck({
+        filePath: path.join(pr1.dir, 'src', 'main.js'),
+        allowedPaths: {
+          prDir: pr1.dir,
+          taskDir: path.join(ticketRoot, 'task1'),
+          ticketRoot,
+        },
+      }),
+    ];
+
+    // Worker 2 claims task 2
+    const checks2 = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 2, ownerId: pr2.ownerId }),
+      createPathCheck({
+        filePath: path.join(pr2.dir, 'src', 'other.js'),
+        allowedPaths: {
+          prDir: pr2.dir,
+          taskDir: path.join(ticketRoot, 'task2'),
+          ticketRoot,
+        },
+      }),
+    ];
+
+    const result1 = runPreflight(ctx, { checks: checks1 });
+    const result2 = runPreflight(ctx, { checks: checks2 });
+
+    assert.equal(result1.allow, true, 'worker 1 on task 1 allowed');
+    assert.equal(result2.allow, true, 'worker 2 on task 2 allowed in parallel');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R18 — Remediation quality bar (ruleId, evaluated state, fix steps)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — R18 remediation quality bar', () => {
+  it('UNKNOWN_DEPENDENCY deny includes ruleId, evaluated state reference, and non-empty remediation', () => {
+    const ctx = {
+      ticketId: 'GH-R18-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [99] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const audited = [];
+    const result = runPreflight(ctx, {
+      checks: [createGraphCheck()],
+      audit: (e) => audited.push(e),
+    });
+
+    // 1. ruleId assertion: each reason IS the stable ruleId
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.length > 0, 'at least one ruleId present');
+    for (const ruleId of result.reasons) {
+      assert.equal(typeof ruleId, 'string', 'ruleId is a string');
+      assert.ok(ruleId.length > 0, 'ruleId is non-empty');
+      assert.match(ruleId, /^[A-Z][A-Z0-9_]+$/, `ruleId "${ruleId}" must be SCREAMING_SNAKE_CASE`);
+    }
+
+    // 2. Evaluated state snapshot: the audit entry captures origin and ticketId
+    //    which represents the evaluated state at decision time
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].decision, 'deny');
+    assert.equal(audited[0].ticketId, 'GH-R18-1', 'audit captures ticketId (state snapshot)');
+    assert.equal(audited[0].origin, 'workflow', 'audit captures origin (state snapshot)');
+    assert.ok(
+      Array.isArray(audited[0].reasons) && audited[0].reasons.length > 0,
+      'audit reasons populated for state snapshot'
+    );
+
+    // 3. Concrete fix steps: remediation array with actionable strings
+    assert.ok(Array.isArray(result.remediation), 'remediation is an array');
+    assert.ok(result.remediation.length > 0, 'remediation has at least one step');
+    for (const step of result.remediation) {
+      assert.equal(typeof step, 'string', 'each remediation step is a string');
+      assert.ok(step.length > 0, 'remediation step is non-empty');
+    }
+    // Remediation must mention the offending task and the missing dependency
+    const allRemediation = result.remediation.join(' ');
+    assert.ok(
+      allRemediation.includes('99') || allRemediation.includes('Task 99'),
+      'remediation must reference the missing dependency (99)'
+    );
+  });
+
+  it('DEPENDENCY_NOT_READY deny includes ruleId, state snapshot, and concrete remediation', () => {
+    const ctx = {
+      ticketId: 'GH-R18-2',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      hasWorkflow: true,
+    };
+
+    const audited = [];
+    const result = runPreflight(ctx, {
+      checks: [createClaimCheck({ taskNum: 2, ownerId: 'PR1' })],
+      audit: (e) => audited.push(e),
+    });
+
+    // ruleId
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('DEPENDENCY_NOT_READY'));
+
+    // State snapshot in audit
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].ticketId, 'GH-R18-2');
+    assert.equal(audited[0].origin, 'workflow');
+
+    // Concrete remediation
+    assert.ok(result.remediation.length >= 2, 'at least 2 remediation steps for dependency issue');
+    const allRemediation = result.remediation.join(' ');
+    assert.ok(
+      allRemediation.includes('Task 1') || allRemediation.includes('task 1'),
+      'remediation must reference the blocking dependency (Task 1)'
+    );
+    assert.ok(
+      allRemediation.toLowerCase().includes('complete') || allRemediation.toLowerCase().includes('canstart'),
+      'remediation must suggest completing the dependency or checking canStart'
+    );
+  });
+
+  it('UNCLAIMED_TASK_WRITE deny includes ruleId, and remediation mentions claimTask', () => {
+    const ctx = {
+      ticketId: 'GH-R18-3',
+      origin: 'workflow',
+      error: null,
+      tasks: [{ num: 1, dependencies: [] }],
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 1,
+          currentTaskIndex: 0,
+          tasks: [{ id: 'task_1', status: 'pending', dependencies: [] }],
+        },
+      },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, {
+      checks: [createClaimCheck({ taskNum: 1 })], // no ownerId = unclaimed
+    });
+
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('UNCLAIMED_TASK_WRITE'));
+    assert.ok(result.remediation.length > 0);
+    assert.ok(
+      result.remediation.some((r) => r.toLowerCase().includes('claim')),
+      'remediation must mention claiming the task'
+    );
+  });
+
+  it('PATH_NOT_ALLOWED deny includes ruleId and remediation with allowed path guidance', () => {
+    const ctx = {
+      ticketId: 'GH-R18-4',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, {
+      checks: [
+        createPathCheck({
+          filePath: '/unauthorized/path/file.js',
+          allowedPaths: {
+            prDir: '/tasks/GH-R18-4/PR1',
+            taskDir: '/tasks/GH-R18-4/task1',
+            ticketRoot: '/tasks/GH-R18-4',
+          },
+        }),
+      ],
+    });
+
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('PATH_NOT_ALLOWED'));
+    assert.ok(result.remediation.length >= 2, 'path denial needs multiple remediation steps');
+    const allRemediation = result.remediation.join(' ');
+    assert.ok(
+      allRemediation.includes('PR{N}') || allRemediation.includes('task${N}'),
+      'remediation must describe the allowed path patterns'
+    );
+  });
+
+  it('DEPENDENCY_CYCLE deny includes ruleId and remediation mentioning how to break the cycle', () => {
+    const ctx = {
+      ticketId: 'GH-R18-5',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [2] },
+        { num: 2, dependencies: [1] },
+      ],
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const audited = [];
+    const result = runPreflight(ctx, {
+      checks: [createGraphCheck()],
+      audit: (e) => audited.push(e),
+    });
+
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('DEPENDENCY_CYCLE'));
+
+    // Audit captures state snapshot
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].ticketId, 'GH-R18-5');
+
+    // Remediation is actionable
+    assert.ok(result.remediation.length > 0);
+    const allRemediation = result.remediation.join(' ');
+    assert.ok(
+      allRemediation.toLowerCase().includes('cycle') || allRemediation.toLowerCase().includes('break'),
+      'cycle remediation must suggest breaking the cycle'
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R16 — Legacy ticket fixture (pre-IDEA2 backward compat)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — legacy ticket fixture without dependencies field (R16)', () => {
+  it('preflight allows legacy tasksMeta (no dependencies field) with claim check', () => {
+    const ctx = {
+      ticketId: 'LEGACY-INT-1',
+      origin: 'workflow',
+      error: null,
+      tasks: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 3,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending' }, // no dependencies field
+            { id: 'task_2', status: 'pending' },
+            { id: 'task_3', status: 'pending' },
+          ],
+        },
+      },
+      hasWorkflow: true,
+    };
+
+    // Legacy mode: claim check with taskNum=1 and ownerId should pass
+    // because there are no dependencies to block
+    const check = createClaimCheck({ taskNum: 1, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, true, 'legacy task without dependencies field must allow (R16)');
+  });
+
+  it('graph check passes when tasks is null (no graph to validate — legacy mode)', () => {
+    const ctx = {
+      ticketId: 'LEGACY-INT-2',
+      origin: 'workflow',
+      error: null,
+      tasks: null,
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, true, 'null tasks means no graph to validate — legacy allow');
+  });
+
+  it('claim check passes when state has no tasksMeta (legacy mode, R16)', () => {
+    const ctx = {
+      ticketId: 'LEGACY-INT-3',
+      origin: 'workflow',
+      error: null,
+      tasks: null,
+      state: { status: 'in_progress' },
+      hasWorkflow: true,
+    };
+
+    const check = createClaimCheck({ taskNum: 1, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, true, 'no tasksMeta = legacy mode, allow (R16)');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R20 — Composed error: multiple failures aggregate
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('integration — composed multi-failure aggregation (R20)', () => {
+  it('context error + graph error + unclaimed write = all reasons aggregated', () => {
+    const ctx = {
+      ticketId: 'GH-INT-MULTI',
+      origin: null,
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: 'subtask flag without state',
+        remediation: ['Remove --subtask flag'],
+      },
+      tasks: [
+        { num: 1, dependencies: [1] }, // self-dep
+      ],
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 1,
+          currentTaskIndex: 0,
+          tasks: [{ id: 'task_1', status: 'pending', dependencies: [1] }],
+        },
+      },
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 1 }), // no ownerId
+    ];
+
+    const result = runPreflight(ctx, { checks });
+
+    assert.equal(result.allow, false);
+    // Should have at least 3 distinct reasons: AMBIGUOUS_SUBTASK + SELF_DEPENDENCY + UNCLAIMED_TASK_WRITE
+    assert.ok(
+      result.reasons.length >= 3,
+      `expected >= 3 reasons, got ${result.reasons.length}: ${JSON.stringify(result.reasons)}`
+    );
+    assert.ok(result.reasons.includes('AMBIGUOUS_SUBTASK'));
+    assert.ok(result.reasons.includes('SELF_DEPENDENCY'));
+    assert.ok(result.reasons.includes('UNCLAIMED_TASK_WRITE'));
+
+    // All remediation steps aggregated
+    assert.ok(
+      result.remediation.length >= 3,
+      'aggregated remediation from all deny sources'
+    );
+  });
+});

--- a/workflows/lib/__tests__/preflight.test.js
+++ b/workflows/lib/__tests__/preflight.test.js
@@ -1,0 +1,1324 @@
+/**
+ * Tests for workflows/lib/preflight.js
+ *
+ * IDEA2 / GH-219 — Task 3: Preflight library with audit hook.
+ *
+ * Requirements covered:
+ *   R12 — Single `runPreflight(context, { audit, checks })` surface returning
+ *         `{ allow, reasons, remediation }`; hooks consume; `audit` optional
+ *         no-op in tests (spec §Pattern — preflight).
+ *   R13 — Wiring contract only — persistence lives in Task 1's
+ *         `appendEnforcementAudit`. Preflight MUST NOT import `work-actions.js`
+ *         to keep coupling low; callers inject the audit callback.
+ *
+ * Context shape contract (from Task 2, `workflows/work/work-enforcement-context.js`):
+ *   EnforcementContext = {
+ *     ticketId, origin, state, tasks, subtaskState, hasWorkflow, error, options
+ *   }
+ *   EnforcementContextError = { code, message, remediation[] }
+ *
+ * Run: node --test workflows/lib/__tests__/preflight.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const MODULE_PATH = path.join(__dirname, '..', 'preflight');
+
+// ─── R12 — Module surface / exports ─────────────────────────────────────────
+
+describe('preflight — module surface (R12)', () => {
+  it('exports runPreflight as a function', () => {
+    const mod = require(MODULE_PATH);
+    assert.equal(typeof mod.runPreflight, 'function', 'runPreflight must be exported as a function');
+  });
+
+  it('runPreflight has arity 2 (context, options) per the documented contract', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.equal(
+      runPreflight.length,
+      2,
+      'runPreflight(context, options) must have exactly 2 declared parameters'
+    );
+  });
+
+  it('has a stable public export shape (Task 12 adds isWriteAllowedPath)', () => {
+    const mod = require(MODULE_PATH);
+    const exported = Object.keys(mod).sort();
+
+    // Task 3 exported only `runPreflight`. Task 12 adds `isWriteAllowedPath`
+    // as the shared path predicate consumed by hooks (Tasks 13-14).
+    // Also adds built-in check factories: `createGraphCheck`, `createClaimCheck`, `createPathCheck`.
+    assert.deepEqual(
+      exported,
+      ['createClaimCheck', 'createGraphCheck', 'createPathCheck', 'isWriteAllowedPath', 'runPreflight'],
+      `preflight module must export { createClaimCheck, createGraphCheck, createPathCheck, isWriteAllowedPath, runPreflight }; got: ${exported.join(', ')}`
+    );
+  });
+
+  it('does NOT import work-actions.js (keeps preflight / persistence decoupled — R13)', () => {
+    // Load preflight fresh and introspect module.children to verify no
+    // transitive dependency on work-actions. This enforces the "do NOT import
+    // work-actions.js" rule in the Task 3 spec.
+    delete require.cache[require.resolve(MODULE_PATH)];
+    require(MODULE_PATH);
+    const loaded = require.cache[require.resolve(MODULE_PATH)];
+    const childIds = (loaded.children || []).map((c) => c.id);
+
+    for (const id of childIds) {
+      assert.ok(
+        !/work-actions(\.js)?$/.test(id),
+        `preflight must not require work-actions (found: ${id}). ` +
+          'Audit persistence is injected by callers via options.audit.'
+      );
+    }
+  });
+});
+
+// ─── R12 — Happy path (empty context, no checks) ────────────────────────────
+
+describe('preflight — empty context / happy path (R12)', () => {
+  it('returns { allow: true, reasons: [], remediation: [] } when context has no error and no checks', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const ctx = { ticketId: 'GH-1', origin: 'user', error: null };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, true, 'empty/valid context allows by default (spec §Preflight API)');
+    assert.deepEqual(result.reasons, [], 'no reasons on allow path');
+    assert.deepEqual(result.remediation, [], 'no remediation on allow path');
+  });
+
+  it('returns the full { allow, reasons, remediation } shape on every call', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null });
+
+    assert.ok('allow' in result, 'result.allow key present');
+    assert.ok('reasons' in result, 'result.reasons key present');
+    assert.ok('remediation' in result, 'result.remediation key present');
+    assert.equal(typeof result.allow, 'boolean', 'allow is a boolean');
+    assert.ok(Array.isArray(result.reasons), 'reasons is an array');
+    assert.ok(Array.isArray(result.remediation), 'remediation is an array');
+  });
+
+  it('does not throw when options is undefined (arity-2 default)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null });
+    }, 'runPreflight must be callable with just a context argument');
+  });
+
+  it('does not throw when options is {} (empty options object)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, {});
+    }, 'runPreflight must accept an empty options object');
+  });
+});
+
+// ─── R12 — context.error denies fail-closed ─────────────────────────────────
+
+describe('preflight — context.error denial (R12, R15 chain)', () => {
+  it('context.error with code → allow: false, reasons: [error.code]', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'user',
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: '--subtask set but no subtask state',
+        remediation: ['Initialize subtask first', 'Remove --subtask flag'],
+      },
+    };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, false, 'context.error must force deny');
+    assert.deepEqual(
+      result.reasons,
+      ['AMBIGUOUS_SUBTASK'],
+      'reasons carries the error.code as a stable rule id'
+    );
+    assert.deepEqual(
+      result.remediation,
+      ['Initialize subtask first', 'Remove --subtask flag'],
+      'error.remediation is passed through verbatim'
+    );
+  });
+
+  it('context.error without remediation → remediation defaults to [] (never undefined)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'user',
+      error: { code: 'INVALID_TICKET_ID', message: 'bad id' },
+    };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, false);
+    assert.deepEqual(result.reasons, ['INVALID_TICKET_ID']);
+    assert.ok(Array.isArray(result.remediation), 'remediation is always an array');
+    assert.deepEqual(result.remediation, [], 'missing remediation becomes []');
+  });
+
+  it('truthy non-object error value is ignored (must be an object with a code)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    // Guard: strings/numbers for error should NOT trigger deny — spec says
+    // "truthy object with code". This enforces the shape discipline.
+    for (const bad of ['string-error', 42, true]) {
+      const ctx = { ticketId: 'GH-1', origin: 'user', error: bad };
+      const result = runPreflight(ctx);
+      assert.equal(
+        result.allow,
+        true,
+        `non-object error=${JSON.stringify(bad)} must not force deny`
+      );
+    }
+  });
+
+  it('error object without a code is ignored (no denial, no crash)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const ctx = { ticketId: 'GH-1', origin: 'user', error: { message: 'no code here' } };
+    const result = runPreflight(ctx);
+    assert.equal(result.allow, true, 'error lacking a stable code must not deny');
+    assert.deepEqual(result.reasons, []);
+    assert.deepEqual(result.remediation, []);
+  });
+});
+
+// ─── R12 — audit default no-op (undefined-safe) ─────────────────────────────
+
+describe('preflight — audit default no-op (R12)', () => {
+  it('does not throw when options.audit is undefined on allow path', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, {});
+    });
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null });
+    });
+  });
+
+  it('does not throw when options.audit is undefined on deny path', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight(
+        {
+          ticketId: 'GH-1',
+          origin: 'user',
+          error: { code: 'X', message: 'y', remediation: [] },
+        },
+        {}
+      );
+    });
+  });
+
+  it('does not throw when options itself is null', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, null);
+    });
+  });
+});
+
+// ─── R12 — audit called on ALLOW path with correct entry shape ──────────────
+
+describe('preflight — audit called on ALLOW path (R12)', () => {
+  it('invokes audit with { decision: "allow", reasons: [], origin, ticketId } on happy path', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const audit = (entry) => audited.push(entry);
+
+    const ctx = { ticketId: 'GH-42', origin: 'workflow', error: null };
+    const result = runPreflight(ctx, { audit });
+
+    assert.equal(result.allow, true);
+    assert.equal(audited.length, 1, 'audit should be called exactly once per decision');
+
+    const entry = audited[0];
+    assert.equal(entry.decision, 'allow', 'allow path uses decision="allow"');
+    assert.deepEqual(entry.reasons, [], 'empty reasons on allow');
+    assert.equal(entry.origin, 'workflow', 'audit entry echoes context.origin');
+    assert.equal(entry.ticketId, 'GH-42', 'audit entry echoes context.ticketId');
+  });
+
+  it('audit entry is a plain object (single positional arg) — stable callback signature', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    let receivedArgs;
+    const audit = function (...args) {
+      receivedArgs = args;
+    };
+
+    runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { audit });
+
+    assert.ok(receivedArgs, 'audit should have been invoked');
+    assert.equal(receivedArgs.length, 1, 'audit takes exactly one positional argument');
+    assert.equal(
+      typeof receivedArgs[0],
+      'object',
+      'audit argument is an object (compatible with appendEnforcementAudit entry shape)'
+    );
+    assert.ok(receivedArgs[0] !== null, 'audit argument is not null');
+  });
+
+  it('audit entry shape is compatible with appendEnforcementAudit (forward-compatible fields)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    runPreflight(
+      { ticketId: 'GH-42', origin: 'workflow', error: null },
+      { audit: (e) => audited.push(e) }
+    );
+
+    const entry = audited[0];
+    // Brief-required fields on enforcement audit records (Task 1 shape).
+    // Preflight produces a superset-compatible entry that callers can
+    // forward directly to appendEnforcementAudit.
+    for (const key of ['decision', 'reasons', 'origin', 'ticketId']) {
+      assert.ok(
+        key in entry,
+        `audit entry must include "${key}" for forward-compat with appendEnforcementAudit`
+      );
+    }
+  });
+});
+
+// ─── R12 — audit called on DENY path ────────────────────────────────────────
+
+describe('preflight — audit called on DENY path (R12)', () => {
+  it('invokes audit with { decision: "deny", reasons, origin, ticketId } when context.error denies', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const audit = (entry) => audited.push(entry);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'user',
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: 'oops',
+        remediation: ['fix step 1'],
+      },
+    };
+
+    const result = runPreflight(ctx, { audit });
+
+    assert.equal(result.allow, false);
+    assert.equal(audited.length, 1, 'audit called once for the deny decision');
+
+    const entry = audited[0];
+    assert.equal(entry.decision, 'deny');
+    assert.deepEqual(entry.reasons, ['AMBIGUOUS_SUBTASK']);
+    assert.equal(entry.origin, 'user');
+    assert.equal(entry.ticketId, 'GH-219');
+  });
+
+  it('deny audit entry preserves remediation for downstream explainability (R18 seed)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    let seen;
+    runPreflight(
+      {
+        ticketId: 'GH-219',
+        origin: 'user',
+        error: {
+          code: 'INVALID_TICKET_ID',
+          message: 'bad',
+          remediation: ['Use a valid id', 'Check env vars'],
+        },
+      },
+      { audit: (e) => (seen = e) }
+    );
+
+    assert.ok(seen, 'audit called on deny');
+    assert.ok(
+      Array.isArray(seen.remediation) && seen.remediation.length === 2,
+      'remediation is forwarded to audit entry for explainability'
+    );
+  });
+
+  it('preflight does not throw when the audit callback itself throws (fail-open on logging)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const throwingAudit = () => {
+      throw new Error('disk full');
+    };
+
+    // Persistence failures must never break enforcement decisions. This
+    // mirrors work-actions.js appendRow() fail-open behavior.
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { audit: throwingAudit });
+    });
+    assert.doesNotThrow(() => {
+      runPreflight(
+        { ticketId: 'GH-1', origin: 'user', error: { code: 'X', message: 'y' } },
+        { audit: throwingAudit }
+      );
+    });
+  });
+});
+
+// ─── R12 — options.checks pluggable composition ─────────────────────────────
+
+describe('preflight — pluggable checks (R12, §Pattern — pluggable checks)', () => {
+  it('runs checks in declared order', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const callOrder = [];
+
+    const checks = [
+      (ctx) => {
+        callOrder.push('A');
+        return null;
+      },
+      (ctx) => {
+        callOrder.push('B');
+        return null;
+      },
+      (ctx) => {
+        callOrder.push('C');
+        return null;
+      },
+    ];
+
+    runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+    assert.deepEqual(callOrder, ['A', 'B', 'C'], 'checks invoked in declared order');
+  });
+
+  it('all checks returning null/allow → final result is allow with empty reasons', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => null,
+      () => ({ allow: true }),
+      () => ({ allow: true, reasons: [], remediation: [] }),
+    ];
+
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, true);
+    assert.deepEqual(result.reasons, []);
+    assert.deepEqual(result.remediation, []);
+  });
+
+  it('one check returning { allow: false, ... } → deny result', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => null,
+      () => ({ allow: false, reasons: ['RULE_X'], remediation: ['fix x'] }),
+    ];
+
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, false, 'any denying check forces deny');
+    assert.ok(result.reasons.includes('RULE_X'), 'reason from denying check is included');
+    assert.ok(result.remediation.includes('fix x'), 'remediation from denying check is merged');
+  });
+
+  it('multiple denying checks → reasons aggregated, remediation merged', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => ({ allow: false, reasons: ['RULE_A'], remediation: ['fix A'] }),
+      () => ({ allow: false, reasons: ['RULE_B'], remediation: ['fix B', 'also fix B2'] }),
+    ];
+
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('RULE_A'), 'first denying check reason present');
+    assert.ok(result.reasons.includes('RULE_B'), 'second denying check reason present');
+    assert.ok(result.remediation.includes('fix A'));
+    assert.ok(result.remediation.includes('fix B'));
+    assert.ok(result.remediation.includes('also fix B2'));
+  });
+
+  it('checks compose with context.error: error denial is included in final reasons', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'user',
+      error: { code: 'CTX_ERR', message: 'err', remediation: ['ctx fix'] },
+    };
+
+    const checks = [() => ({ allow: false, reasons: ['RULE_Z'], remediation: ['z fix'] })];
+
+    const result = runPreflight(ctx, { checks });
+
+    assert.equal(result.allow, false);
+    assert.ok(
+      result.reasons.includes('CTX_ERR') || result.reasons.includes('RULE_Z'),
+      'at least one deny reason present (context error + checks compose)'
+    );
+  });
+
+  it('check returning undefined is treated as "no opinion" (allow passthrough)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [() => undefined, () => ({ allow: true })];
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, true, 'undefined/null check results are benign (spec §pluggable)');
+    assert.deepEqual(result.reasons, []);
+  });
+
+  it('check throwing does not crash preflight (isolated check failure)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => {
+        throw new Error('check crashed');
+      },
+      () => ({ allow: true }),
+    ];
+
+    // A single check should not poison the whole pipeline. Fail-closed on
+    // the crashing check (treat as deny with a synthetic reason) is
+    // acceptable; what matters is we never throw out of runPreflight.
+    let result;
+    assert.doesNotThrow(() => {
+      result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+    });
+    assert.ok(result, 'result returned even when a check threw');
+    assert.equal(typeof result.allow, 'boolean');
+  });
+
+  it('checks receive the full context as their sole argument', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    let seenContext;
+    const checks = [
+      (ctx) => {
+        seenContext = ctx;
+        return null;
+      },
+    ];
+
+    const inputCtx = {
+      ticketId: 'GH-99',
+      origin: 'ai-subtask',
+      state: { status: 'in_progress' },
+      tasks: [{ id: 'task_1', num: 1 }],
+      subtaskState: null,
+      hasWorkflow: true,
+      error: null,
+      options: { subtask: true },
+    };
+
+    runPreflight(inputCtx, { checks });
+
+    assert.ok(seenContext, 'check was invoked with a context');
+    assert.equal(seenContext.ticketId, 'GH-99', 'checks receive full context.ticketId');
+    assert.equal(seenContext.origin, 'ai-subtask', 'checks receive full context.origin');
+    assert.equal(seenContext.hasWorkflow, true, 'checks receive full context.hasWorkflow');
+  });
+});
+
+// ─── R12 — audit receives final decision shape after checks compose ─────────
+
+describe('preflight — audit integration with checks', () => {
+  it('audit called once with final aggregated reasons after checks compose (deny path)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const audit = (e) => audited.push(e);
+
+    const checks = [
+      () => ({ allow: false, reasons: ['RULE_A'], remediation: ['fix A'] }),
+      () => ({ allow: false, reasons: ['RULE_B'], remediation: ['fix B'] }),
+    ];
+
+    runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks, audit });
+
+    assert.equal(audited.length, 1, 'audit invoked once per runPreflight call');
+    assert.equal(audited[0].decision, 'deny');
+    assert.ok(audited[0].reasons.includes('RULE_A'));
+    assert.ok(audited[0].reasons.includes('RULE_B'));
+  });
+
+  it('audit called with decision="allow" when all checks allow', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const checks = [() => ({ allow: true }), () => null];
+
+    runPreflight(
+      { ticketId: 'GH-1', origin: 'user', error: null },
+      { checks, audit: (e) => audited.push(e) }
+    );
+
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].decision, 'allow');
+    assert.deepEqual(audited[0].reasons, []);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Task 12 — Preflight rules integration (graph, claim, paths)
+//
+// Requirements covered:
+//   R3  — Dependency readiness via canStart
+//   R4  — Graph validation (unknown deps, cycles, self-deps)
+//   R6  — Task-readiness edit gate (isWriteAllowedPath)
+//   R12 — Shared preflight library
+//   R13 — Audit on each decision
+//   R15 — Sanitized paths, fail closed
+//   R18 — Remediation text with ruleId
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ─── 12.1 — isWriteAllowedPath export and behavior (R6, R12) ────────────────
+
+describe('preflight — isWriteAllowedPath export (R6, R12)', () => {
+  it('exports isWriteAllowedPath as a function', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    assert.equal(typeof isWriteAllowedPath, 'function', 'isWriteAllowedPath must be exported');
+  });
+
+  it('isWriteAllowedPath has arity 2 (filePath, allowedPaths)', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    assert.equal(isWriteAllowedPath.length, 2, 'isWriteAllowedPath(filePath, allowedPaths) needs 2 params');
+  });
+});
+
+describe('preflight — isWriteAllowedPath: PR{N}/ paths (R6)', () => {
+  it('allows paths under the claiming worker PR{N}/ directory', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/src/index.js', allowed),
+      true,
+      'files under PR{N}/ are allowed'
+    );
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/deep/nested/file.ts', allowed),
+      true,
+      'deeply nested files under PR{N}/ are allowed'
+    );
+  });
+
+  it('denies paths under a different PR slot', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR2/src/file.js', allowed),
+      false,
+      'files under a different PR slot must be denied'
+    );
+  });
+});
+
+describe('preflight — isWriteAllowedPath: task${N}/ paths (R6)', () => {
+  it('allows paths under the claimed task directory', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/task3/implement.md', allowed),
+      true,
+      'task artifact files under task${N}/ are allowed'
+    );
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/task3/tdd-phase.json', allowed),
+      true,
+      'tdd-phase.json under task${N}/ is allowed'
+    );
+  });
+
+  it('denies paths under a different task directory', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/task5/implement.md', allowed),
+      false,
+      'files under a different task directory must be denied'
+    );
+  });
+});
+
+describe('preflight — isWriteAllowedPath: shared-root whitelist (R6)', () => {
+  it('allows brief.md at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/brief.md', allowed),
+      true,
+      'brief.md at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows spec.md at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/spec.md', allowed),
+      true,
+      'spec.md at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows tasks.md at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/tasks.md', allowed),
+      true,
+      'tasks.md at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows .work-state.json at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/.work-state.json', allowed),
+      true,
+      '.work-state.json at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows .work-actions.json at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/.work-actions.json', allowed),
+      true,
+      '.work-actions.json at ticket root is in the shared whitelist'
+    );
+  });
+});
+
+describe('preflight — isWriteAllowedPath: denied paths (R6, R15)', () => {
+  it('denies arbitrary paths outside allowed set', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/some/random/file.js', allowed),
+      false,
+      'arbitrary paths outside PR{N}/, task${N}/, and whitelist are denied'
+    );
+  });
+
+  it('denies files at ticket root that are not in the whitelist', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/random-file.txt', allowed),
+      false,
+      'non-whitelisted files at ticket root are denied'
+    );
+  });
+
+  it('denies paths that are path-traversal attempts from ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/../GH-220/task1/file.js', allowed),
+      false,
+      'path traversal attempts are denied (R15)'
+    );
+  });
+
+  it('returns false (fail closed) when allowedPaths is missing fields', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/file.js', {}),
+      false,
+      'missing allowedPaths fields must fail closed'
+    );
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/file.js', null),
+      false,
+      'null allowedPaths must fail closed'
+    );
+  });
+});
+
+// ─── 12.2 — createGraphCheck (R4 — graph validation) ────────────────────────
+
+describe('preflight — createGraphCheck (R4 — graph validation)', () => {
+  it('exports createGraphCheck as a function', () => {
+    const { createGraphCheck } = require(MODULE_PATH);
+    assert.equal(typeof createGraphCheck, 'function');
+  });
+
+  it('returns a check function', () => {
+    const { createGraphCheck } = require(MODULE_PATH);
+    const check = createGraphCheck();
+    assert.equal(typeof check, 'function');
+  });
+
+  it('allows when context has no tasks (no graph to validate)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = { ticketId: 'GH-1', origin: 'workflow', error: null, tasks: null };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, true, 'null tasks means no graph to validate; allow');
+  });
+
+  it('allows when tasks have a valid graph (no errors)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, true, 'valid graph passes');
+  });
+
+  it('denies when tasks have an unknown dependency (R4)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [99] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false, 'unknown dependency denies');
+    assert.ok(
+      result.reasons.some((r) => r === 'UNKNOWN_DEPENDENCY'),
+      'reason includes UNKNOWN_DEPENDENCY ruleId (R18)'
+    );
+    assert.ok(result.remediation.length > 0, 'remediation text is present (R18)');
+  });
+
+  it('denies when tasks have a self-dependency (R4)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [1] },
+        { num: 2, dependencies: [] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false, 'self-dependency denies');
+    assert.ok(
+      result.reasons.some((r) => r === 'SELF_DEPENDENCY'),
+      'reason includes SELF_DEPENDENCY ruleId'
+    );
+  });
+
+  it('denies when tasks have a cycle (R4)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [2] },
+        { num: 2, dependencies: [1] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false, 'cycle denies');
+    assert.ok(
+      result.reasons.some((r) => r === 'DEPENDENCY_CYCLE'),
+      'reason includes DEPENDENCY_CYCLE ruleId'
+    );
+  });
+
+  it('remediation on graph deny includes the ruleId for explainability (R18)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [99] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false);
+    // Each reason string IS the ruleId
+    for (const reason of result.reasons) {
+      assert.equal(typeof reason, 'string');
+      assert.ok(reason.length > 0, 'reason/ruleId is non-empty');
+    }
+  });
+});
+
+// ─── 12.3 — createClaimCheck (R3, R6 — dependency readiness + claim) ─────────
+
+describe('preflight — createClaimCheck (R3, R6 — unclaimed task write)', () => {
+  it('exports createClaimCheck as a function', () => {
+    const { createClaimCheck } = require(MODULE_PATH);
+    assert.equal(typeof createClaimCheck, 'function');
+  });
+
+  it('denies when taskNum is provided but no claim info (unclaimed write)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 3,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+            { id: 'task_3', status: 'pending', dependencies: [2] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+        { num: 3, dependencies: [2] },
+      ],
+      hasWorkflow: true,
+    };
+
+    // No claim: taskNum=2 but ownerId not provided
+    const check = createClaimCheck({ taskNum: 2 });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, false, 'unclaimed task write denied');
+    assert.ok(
+      result.reasons.some((r) => r === 'UNCLAIMED_TASK_WRITE'),
+      'reason includes UNCLAIMED_TASK_WRITE ruleId'
+    );
+    assert.ok(result.remediation.length > 0, 'remediation present');
+  });
+
+  it('allows when taskNum and ownerId are provided and task is startable (R3)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const check = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, true, 'claimed task with ready deps allows');
+  });
+
+  it('denies when task dependencies are not satisfied (R3)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 3,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+            { id: 'task_3', status: 'pending', dependencies: [2] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+        { num: 3, dependencies: [2] },
+      ],
+      hasWorkflow: true,
+    };
+
+    // Task 2 depends on Task 1, which is still pending
+    const check = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, false, 'task with unsatisfied deps denied');
+    assert.ok(
+      result.reasons.some((r) => r === 'DEPENDENCY_NOT_READY'),
+      'reason includes DEPENDENCY_NOT_READY ruleId'
+    );
+  });
+
+  it('allows when no tasksMeta exists (legacy/pre-IDEA2 — R16 backward compat)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      state: { status: 'in_progress' },
+      tasks: null,
+      hasWorkflow: true,
+    };
+
+    // No tasksMeta = legacy mode, no claim enforcement
+    const check = createClaimCheck({});
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, true, 'legacy mode without tasksMeta allows (R16)');
+  });
+});
+
+// ─── 12.4 — createPathCheck (R6 — task-readiness edit gate) ──────────────────
+
+describe('preflight — createPathCheck (R6 — path intent check)', () => {
+  it('exports createPathCheck as a function', () => {
+    const { createPathCheck } = require(MODULE_PATH);
+    assert.equal(typeof createPathCheck, 'function');
+  });
+
+  it('allows writes to PR{N}/ for the claiming worker', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const check = createPathCheck({
+      filePath: '/tasks/GH-219/PR1/src/index.js',
+      allowedPaths: {
+        prDir: '/tasks/GH-219/PR1',
+        taskDir: '/tasks/GH-219/task3',
+        ticketRoot: '/tasks/GH-219',
+      },
+    });
+
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, true, 'writes to PR{N}/ are allowed');
+  });
+
+  it('denies writes outside the allowed set', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const check = createPathCheck({
+      filePath: '/some/other/repo/file.js',
+      allowedPaths: {
+        prDir: '/tasks/GH-219/PR1',
+        taskDir: '/tasks/GH-219/task3',
+        ticketRoot: '/tasks/GH-219',
+      },
+    });
+
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, false, 'writes outside allowed paths denied');
+    assert.ok(
+      result.reasons.some((r) => r === 'PATH_NOT_ALLOWED'),
+      'reason includes PATH_NOT_ALLOWED ruleId'
+    );
+  });
+
+  it('allows writes to shared-root whitelist files at ticket root', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    for (const file of ['brief.md', 'spec.md', 'tasks.md', '.work-state.json', '.work-actions.json']) {
+      const check = createPathCheck({
+        filePath: `/tasks/GH-219/${file}`,
+        allowedPaths: {
+          prDir: '/tasks/GH-219/PR1',
+          taskDir: '/tasks/GH-219/task3',
+          ticketRoot: '/tasks/GH-219',
+        },
+      });
+
+      const result = runPreflight(ctx, { checks: [check] });
+      assert.equal(result.allow, true, `shared-root whitelist file ${file} is allowed`);
+    }
+  });
+
+  it('skips path check when no filePath is provided (no path intent to validate)', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const check = createPathCheck({
+      allowedPaths: {
+        prDir: '/tasks/GH-219/PR1',
+        taskDir: '/tasks/GH-219/task3',
+        ticketRoot: '/tasks/GH-219',
+      },
+    });
+
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, true, 'no filePath means no path to deny');
+  });
+});
+
+// ─── 12.5 — Full preflight composition (happy path + deny) ──────────────────
+
+describe('preflight — full composition: graph + claim + path (R3, R4, R6)', () => {
+  it('happy path: valid graph, claimed task, matching paths → allow', () => {
+    const { runPreflight, createGraphCheck, createClaimCheck, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 2, ownerId: 'PR1' }),
+      createPathCheck({
+        filePath: '/tasks/GH-219/PR1/src/main.js',
+        allowedPaths: {
+          prDir: '/tasks/GH-219/PR1',
+          taskDir: '/tasks/GH-219/task2',
+          ticketRoot: '/tasks/GH-219',
+        },
+      }),
+    ];
+
+    const result = runPreflight(ctx, { checks });
+    assert.equal(result.allow, true, 'full composition happy path allows');
+    assert.deepEqual(result.reasons, []);
+  });
+
+  it('audit callback is invoked with full decision on composed happy path', () => {
+    const { runPreflight, createGraphCheck, createClaimCheck, createPathCheck } = require(MODULE_PATH);
+
+    const audited = [];
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 2, ownerId: 'PR1' }),
+    ];
+
+    runPreflight(ctx, { checks, audit: (e) => audited.push(e) });
+
+    assert.equal(audited.length, 1, 'audit called once');
+    assert.equal(audited[0].decision, 'allow');
+    assert.equal(audited[0].ticketId, 'GH-219');
+  });
+
+  it('composed deny: invalid graph + unclaimed → all reasons aggregated', () => {
+    const { runPreflight, createGraphCheck, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [99] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [99] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 1 }), // no ownerId → unclaimed
+    ];
+
+    const result = runPreflight(ctx, { checks });
+
+    assert.equal(result.allow, false, 'composed deny from multiple checks');
+    assert.ok(result.reasons.length >= 2, 'multiple deny reasons aggregated');
+    assert.ok(result.remediation.length > 0, 'aggregated remediation present');
+  });
+
+  it('remediation includes ruleId strings (R18 explainability)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const check = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, false, 'task 2 deps not ready');
+    // R18: every deny reason is a stable ruleId string
+    for (const reason of result.reasons) {
+      assert.equal(typeof reason, 'string', 'reason is a string ruleId');
+      assert.ok(reason.length > 0, 'ruleId is non-empty');
+      // ruleIds are SCREAMING_SNAKE_CASE
+      assert.match(reason, /^[A-Z][A-Z0-9_]+$/, `ruleId "${reason}" is SCREAMING_SNAKE_CASE`);
+    }
+  });
+});

--- a/workflows/lib/__tests__/request-index.test.js
+++ b/workflows/lib/__tests__/request-index.test.js
@@ -1,0 +1,226 @@
+/**
+ * Tests for workflows/lib/request-index.js (GH-219 Task 10)
+ *
+ * Coverage:
+ *   - R9:  Out-of-flow user routing — `user-request-${n}` allocation
+ *   - R10: Out-of-flow AI routing — `ai-request-${n}` allocation
+ *   - R11: Persistent `.request-index.json` with collision-safe increments
+ *   - R7:  Allocator completion — wire stubs from Task 9
+ *
+ * Run with: node --test workflows/lib/__tests__/request-index.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function mkTasksBase() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'req-idx-'));
+  const tasksBase = path.join(dir, 'worktrees', 'tasks');
+  fs.mkdirSync(tasksBase, { recursive: true });
+  return { dir, tasksBase };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('request-index', () => {
+  let tmpDir;
+  let tasksBase;
+  let origTasksBase;
+  /** @type {import('../request-index')} */
+  let requestIndex;
+
+  beforeEach(() => {
+    ({ dir: tmpDir, tasksBase } = mkTasksBase());
+    origTasksBase = process.env.TASKS_BASE;
+    process.env.TASKS_BASE = tasksBase;
+    // Fresh require to avoid stale module state
+    requestIndex = require('../request-index');
+  });
+
+  afterEach(() => {
+    if (origTasksBase === undefined) delete process.env.TASKS_BASE;
+    else process.env.TASKS_BASE = origTasksBase;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('API surface', () => {
+    it('exports nextUserRequest, nextAiRequest, and readIndex', () => {
+      assert.strictEqual(typeof requestIndex.nextUserRequest, 'function');
+      assert.strictEqual(typeof requestIndex.nextAiRequest, 'function');
+      assert.strictEqual(typeof requestIndex.readIndex, 'function');
+    });
+  });
+
+  describe('user counter (R9)', () => {
+    it('starts at 1 for the first allocation', () => {
+      const result = requestIndex.nextUserRequest('GH-219');
+      assert.strictEqual(result.seq, 1);
+      assert.strictEqual(result.segment, 'user-request-1');
+      assert.ok(result.root.endsWith(path.join('GH-219', 'user-request-1')));
+    });
+
+    it('increments monotonically on subsequent calls', () => {
+      const r1 = requestIndex.nextUserRequest('GH-219');
+      const r2 = requestIndex.nextUserRequest('GH-219');
+      const r3 = requestIndex.nextUserRequest('GH-219');
+      assert.strictEqual(r1.seq, 1);
+      assert.strictEqual(r2.seq, 2);
+      assert.strictEqual(r3.seq, 3);
+    });
+
+    it('creates the output folder on disk', () => {
+      const result = requestIndex.nextUserRequest('GH-219');
+      assert.ok(fs.existsSync(result.root), `Expected directory to exist: ${result.root}`);
+      assert.ok(fs.statSync(result.root).isDirectory());
+    });
+  });
+
+  describe('AI counter (R10)', () => {
+    it('starts at 1 for the first allocation', () => {
+      const result = requestIndex.nextAiRequest('GH-219');
+      assert.strictEqual(result.seq, 1);
+      assert.strictEqual(result.segment, 'ai-request-1');
+      assert.ok(result.root.endsWith(path.join('GH-219', 'ai-request-1')));
+    });
+
+    it('increments monotonically on subsequent calls', () => {
+      const r1 = requestIndex.nextAiRequest('GH-219');
+      const r2 = requestIndex.nextAiRequest('GH-219');
+      assert.strictEqual(r1.seq, 1);
+      assert.strictEqual(r2.seq, 2);
+    });
+
+    it('creates the output folder on disk', () => {
+      const result = requestIndex.nextAiRequest('GH-219');
+      assert.ok(fs.existsSync(result.root), `Expected directory to exist: ${result.root}`);
+      assert.ok(fs.statSync(result.root).isDirectory());
+    });
+  });
+
+  describe('independent counters (R9 + R10)', () => {
+    it('user and AI counters are independent of each other', () => {
+      const u1 = requestIndex.nextUserRequest('GH-219');
+      const u2 = requestIndex.nextUserRequest('GH-219');
+      const a1 = requestIndex.nextAiRequest('GH-219');
+      const u3 = requestIndex.nextUserRequest('GH-219');
+      const a2 = requestIndex.nextAiRequest('GH-219');
+
+      assert.strictEqual(u1.seq, 1);
+      assert.strictEqual(u2.seq, 2);
+      assert.strictEqual(a1.seq, 1);
+      assert.strictEqual(u3.seq, 3);
+      assert.strictEqual(a2.seq, 2);
+    });
+
+    it('different ticket IDs have independent counters', () => {
+      const a1 = requestIndex.nextUserRequest('GH-100');
+      const b1 = requestIndex.nextUserRequest('GH-200');
+      const a2 = requestIndex.nextUserRequest('GH-100');
+
+      assert.strictEqual(a1.seq, 1);
+      assert.strictEqual(b1.seq, 1);
+      assert.strictEqual(a2.seq, 2);
+    });
+  });
+
+  describe('.request-index.json persistence (R11)', () => {
+    it('persists counters between calls', () => {
+      requestIndex.nextUserRequest('GH-219');
+      requestIndex.nextUserRequest('GH-219');
+      requestIndex.nextAiRequest('GH-219');
+
+      const index = requestIndex.readIndex('GH-219');
+      assert.strictEqual(index.userSeq, 2);
+      assert.strictEqual(index.aiSeq, 1);
+      assert.strictEqual(index.version, 1);
+    });
+
+    it('writes .request-index.json to the ticket directory', () => {
+      requestIndex.nextUserRequest('GH-219');
+      const indexPath = path.join(tasksBase, 'GH-219', '.request-index.json');
+      assert.ok(fs.existsSync(indexPath), `Expected file: ${indexPath}`);
+      const raw = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+      assert.strictEqual(raw.userSeq, 1);
+      assert.strictEqual(raw.aiSeq, 0);
+      assert.strictEqual(raw.version, 1);
+    });
+
+    it('survives a fresh readIndex after writes', () => {
+      requestIndex.nextUserRequest('GH-219');
+      requestIndex.nextAiRequest('GH-219');
+      requestIndex.nextAiRequest('GH-219');
+
+      // Read back
+      const idx = requestIndex.readIndex('GH-219');
+      assert.strictEqual(idx.userSeq, 1);
+      assert.strictEqual(idx.aiSeq, 2);
+    });
+
+    it('returns zero counters when no index file exists', () => {
+      const idx = requestIndex.readIndex('GH-NONEXIST');
+      assert.strictEqual(idx.userSeq, 0);
+      assert.strictEqual(idx.aiSeq, 0);
+      assert.strictEqual(idx.version, 1);
+    });
+  });
+
+  describe('atomic write safety (R11)', () => {
+    it('does not leave partial .request-index.json on disk', () => {
+      // Perform a normal allocation — file should be valid JSON
+      requestIndex.nextUserRequest('GH-219');
+      const indexPath = path.join(tasksBase, 'GH-219', '.request-index.json');
+      const raw = fs.readFileSync(indexPath, 'utf-8');
+      // Should parse cleanly (not truncated or corrupt)
+      const parsed = JSON.parse(raw);
+      assert.strictEqual(typeof parsed.userSeq, 'number');
+      assert.strictEqual(typeof parsed.aiSeq, 'number');
+    });
+
+    it('no .tmp files remain after allocation', () => {
+      requestIndex.nextUserRequest('GH-219');
+      const ticketDir = path.join(tasksBase, 'GH-219');
+      const files = fs.readdirSync(ticketDir);
+      const tmpFiles = files.filter((f) => f.endsWith('.tmp'));
+      assert.strictEqual(tmpFiles.length, 0, `Unexpected .tmp files: ${tmpFiles.join(', ')}`);
+    });
+  });
+
+  describe('simulated concurrency (R11 collision-safe)', () => {
+    it('parallel increments yield strictly increasing sequences', () => {
+      // Simulate rapid sequential calls (true parallelism needs worker_threads,
+      // but sequential calls to the atomic counter must still be strictly increasing)
+      const results = [];
+      for (let i = 0; i < 20; i++) {
+        results.push(requestIndex.nextUserRequest('GH-219'));
+      }
+
+      // Verify strict monotonic increase
+      for (let i = 1; i < results.length; i++) {
+        assert.ok(
+          results[i].seq > results[i - 1].seq,
+          `Sequence not strictly increasing at index ${i}: ${results[i - 1].seq} >= ${results[i].seq}`
+        );
+      }
+      assert.strictEqual(results[results.length - 1].seq, 20);
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects empty ticket ID', () => {
+      assert.throws(() => requestIndex.nextUserRequest(''), /ticket/i);
+    });
+
+    it('rejects null ticket ID', () => {
+      assert.throws(() => requestIndex.nextUserRequest(null), /ticket/i);
+    });
+
+    it('rejects path traversal in ticket ID', () => {
+      assert.throws(() => requestIndex.nextUserRequest('../etc'), /ticket/i);
+    });
+  });
+});

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -133,6 +133,12 @@ function allocateOutputFolder(ticketId, context = {}) {
   const tasksBase = resolveTasksBase();
   const safeId = sanitizeId(ticketId);
   const ticketRoot = path.join(tasksBase, safeId);
+  // Defense-in-depth: ensure ticket root stays under TASKS_BASE
+  const resolvedRoot = path.resolve(ticketRoot);
+  const resolvedBase = path.resolve(tasksBase);
+  if (resolvedRoot !== resolvedBase && !resolvedRoot.startsWith(resolvedBase + path.sep)) {
+    throw new Error(`allocateOutputFolder: resolved path escapes TASKS_BASE: ${ticketRoot}`);
+  }
 
   // ── In-flow task allocation ──────────────────────────────────────────────
   if (context.flow === 'in-flow') {
@@ -162,7 +168,11 @@ function allocateOutputFolder(ticketId, context = {}) {
           'Task 10 will wire the real .request-index.json counter.'
         );
       }
-      const seg = `${AI_REQUEST_PREFIX}${context.counters.aiRequestNext}`;
+      const n = context.counters.aiRequestNext;
+      if (!Number.isInteger(n) || n < 1) {
+        throw new Error(`Invalid aiRequestNext counter: expected positive integer, got ${JSON.stringify(n)}`);
+      }
+      const seg = `${AI_REQUEST_PREFIX}${n}`;
       return {
         kind: 'out-of-flow-ai',
         segment: seg,
@@ -178,7 +188,11 @@ function allocateOutputFolder(ticketId, context = {}) {
         'Task 10 will wire the real .request-index.json counter.'
       );
     }
-    const seg = `${USER_REQUEST_PREFIX}${context.counters.userRequestNext}`;
+    const n = context.counters.userRequestNext;
+    if (!Number.isInteger(n) || n < 1) {
+      throw new Error(`Invalid userRequestNext counter: expected positive integer, got ${JSON.stringify(n)}`);
+    }
+    const seg = `${USER_REQUEST_PREFIX}${n}`;
     return {
       kind: 'out-of-flow-user',
       segment: seg,

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -1,0 +1,207 @@
+/**
+ * allocate-output-folder.js
+ *
+ * Central allocator for /work-implement destination resolution (GH-219 Task 9).
+ *
+ * Given a ticket ID and context, returns the correct absolute base directory:
+ *
+ *   - In-flow (workflow origin, claimed task): TASKS_BASE/<ticketId>/task${N}/
+ *   - Out-of-flow user:  TASKS_BASE/<ticketId>/user-request-${k}/  (stub -- Task 10 wires counters)
+ *   - Out-of-flow AI:    TASKS_BASE/<ticketId>/ai-request-${k}/    (stub -- Task 10 wires counters)
+ *   - Legacy-root:       TASKS_BASE/<ticketId>/                     (backward-compat fallback)
+ *
+ * R7 single source of truth: the `task${N}` naming is produced exclusively by
+ * taskSegment(). Other modules must consume this rather than rebuilding the
+ * segment string.
+ *
+ * @module allocate-output-folder
+ */
+
+const path = require('path');
+
+// ─── Constants (R7 naming policy) ────────────────────────────────────────────
+
+const TASK_SEGMENT_PREFIX = 'task';
+const USER_REQUEST_PREFIX = 'user-request-';
+const AI_REQUEST_PREFIX = 'ai-request-';
+
+// ─── Ticket ID validation (R15 fail-closed) ─────────────────────────────────
+
+/** @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes */
+const UNSAFE_TICKET_RE = /\.\.|[\\]|\x00/;
+
+/**
+ * Validate and reject unsafe ticket IDs before any filesystem I/O.
+ * @param {unknown} ticketId
+ */
+function validateTicketId(ticketId) {
+  if (typeof ticketId !== 'string' || ticketId.length === 0) {
+    throw new Error(
+      `Invalid ticket ID: expected non-empty string, received ${typeof ticketId === 'string' ? '""' : typeof ticketId}`
+    );
+  }
+  if (UNSAFE_TICKET_RE.test(ticketId)) {
+    throw new Error(
+      `Invalid ticket ID: contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`
+    );
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve TASKS_BASE from environment or config module.
+ * @returns {string}
+ */
+function resolveTasksBase() {
+  // Check process.env directly — callers (hooks, CLI) always set TASKS_BASE.
+  // Do not fall back to config cache: config.TASKS_BASE is set at module-load
+  // time and becomes stale if the env var is later removed (e.g., in tests).
+  if (process.env.TASKS_BASE) return process.env.TASKS_BASE;
+
+  throw new Error(
+    'TASKS_BASE is not configured. Set the TASKS_BASE environment variable.'
+  );
+}
+
+/**
+ * Sanitize ticket ID for filesystem paths using config.safeTicketId when available.
+ * @param {string} ticketId
+ * @returns {string}
+ */
+function sanitizeId(ticketId) {
+  try {
+    const config = require('./config');
+    if (config && typeof config.safeTicketId === 'function') {
+      return config.safeTicketId(ticketId);
+    }
+  } catch {
+    // fallback to raw ID
+  }
+  return ticketId;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Produce the canonical `task${N}` segment name (R7 single source of truth).
+ *
+ * @param {number} taskNum - Positive integer task number
+ * @returns {string} e.g. "task1", "task9", "task42"
+ * @throws {Error} if taskNum is not a positive integer
+ */
+function taskSegment(taskNum) {
+  if (
+    typeof taskNum !== 'number' ||
+    !Number.isInteger(taskNum) ||
+    taskNum < 1
+  ) {
+    throw new Error(
+      `Invalid taskNum: expected positive integer, received ${JSON.stringify(taskNum)}`
+    );
+  }
+  return `${TASK_SEGMENT_PREFIX}${taskNum}`;
+}
+
+/**
+ * @typedef {Object} AllocationResult
+ * @property {'in-flow-task'|'out-of-flow-user'|'out-of-flow-ai'|'legacy-root'} kind
+ * @property {string|null} segment - Directory segment name (e.g. "task9", "user-request-4"), or null for legacy-root
+ * @property {string} root - Absolute path to the allocated directory
+ * @property {string} ticketRoot - Absolute path to the ticket-level directory
+ */
+
+/**
+ * Allocate the correct output folder for a /work-implement invocation.
+ *
+ * @param {string} ticketId - Ticket ID (e.g. "GH-219")
+ * @param {object} [context={}] - Allocation context
+ * @param {string} [context.origin] - Origin type: "workflow", "ai-subtask", "user"
+ * @param {string} [context.flow] - Flow type: "in-flow", "out-of-flow"
+ * @param {number} [context.taskNum] - Task number (required for in-flow)
+ * @param {number} [context.prSlot] - PR slot number (informational)
+ * @param {number} [context.subtaskIndex] - Subtask index
+ * @param {object} [context.counters] - Out-of-flow counters (Task 10 wires these)
+ * @param {number} [context.counters.userRequestNext] - Next user-request counter
+ * @param {number} [context.counters.aiRequestNext] - Next ai-request counter
+ * @returns {AllocationResult}
+ */
+function allocateOutputFolder(ticketId, context = {}) {
+  // R15: validate ticket ID before any I/O
+  validateTicketId(ticketId);
+
+  const tasksBase = resolveTasksBase();
+  const safeId = sanitizeId(ticketId);
+  const ticketRoot = path.join(tasksBase, safeId);
+
+  // ── In-flow task allocation ──────────────────────────────────────────────
+  if (context.flow === 'in-flow') {
+    if (context.taskNum == null) {
+      throw new Error(
+        'In-flow allocation requires taskNum. Pass context.taskNum with the claimed task number.'
+      );
+    }
+    const seg = taskSegment(context.taskNum);
+    return {
+      kind: 'in-flow-task',
+      segment: seg,
+      root: path.join(ticketRoot, seg),
+      ticketRoot,
+    };
+  }
+
+  // ── Out-of-flow allocation ───────────────────────────────────────────────
+  if (context.flow === 'out-of-flow') {
+    const isAi =
+      context.origin === 'ai-subtask' || context.origin === 'ai';
+
+    if (isAi) {
+      if (!context.counters || context.counters.aiRequestNext == null) {
+        throw new Error(
+          'Out-of-flow AI allocation requires counters.aiRequestNext. ' +
+          'Task 10 will wire the real .request-index.json counter.'
+        );
+      }
+      const seg = `${AI_REQUEST_PREFIX}${context.counters.aiRequestNext}`;
+      return {
+        kind: 'out-of-flow-ai',
+        segment: seg,
+        root: path.join(ticketRoot, seg),
+        ticketRoot,
+      };
+    }
+
+    // User origin (default for out-of-flow)
+    if (!context.counters || context.counters.userRequestNext == null) {
+      throw new Error(
+        'Out-of-flow user allocation requires counters.userRequestNext. ' +
+        'Task 10 will wire the real .request-index.json counter.'
+      );
+    }
+    const seg = `${USER_REQUEST_PREFIX}${context.counters.userRequestNext}`;
+    return {
+      kind: 'out-of-flow-user',
+      segment: seg,
+      root: path.join(ticketRoot, seg),
+      ticketRoot,
+    };
+  }
+
+  // ── Legacy-root fallback ─────────────────────────────────────────────────
+  // No flow/task context: return the ticket root directory.
+  // Pairs with tdd-phase-state.js backward-compat legacy read path.
+  return {
+    kind: 'legacy-root',
+    segment: null,
+    root: ticketRoot,
+    ticketRoot,
+  };
+}
+
+module.exports = {
+  allocateOutputFolder,
+  taskSegment,
+  TASK_SEGMENT_PREFIX,
+  USER_REQUEST_PREFIX,
+  AI_REQUEST_PREFIX,
+};

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -138,8 +138,7 @@ function allocateOutputFolder(ticketId, context = {}) {
   const resolvedBase = path.resolve(tasksBase);
   if (resolvedRoot !== resolvedBase && !resolvedRoot.startsWith(resolvedBase + path.sep)) {
     throw new Error(`allocateOutputFolder: resolved path escapes TASKS_BASE: ${ticketRoot}`);
-  }
-
+  } // path-containment verified
   // ── In-flow task allocation ──────────────────────────────────────────────
   if (context.flow === 'in-flow') {
     if (context.taskNum == null) {
@@ -172,7 +171,7 @@ function allocateOutputFolder(ticketId, context = {}) {
       if (!Number.isInteger(n) || n < 1) {
         throw new Error(`Invalid aiRequestNext counter: expected positive integer, got ${JSON.stringify(n)}`);
       }
-      const seg = `${AI_REQUEST_PREFIX}${n}`;
+      const seg = `${AI_REQUEST_PREFIX}${n}`; // counter validated above
       return {
         kind: 'out-of-flow-ai',
         segment: seg,

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -194,8 +194,8 @@ function runPreflight(context, options) {
     try {
       audit({
         decision,
-        reasons,
-        remediation,
+        reasons: reasons.slice(),
+        remediation: remediation.slice(),
         origin: ctx.origin != null ? ctx.origin : null,
         ticketId: ctx.ticketId != null ? ctx.ticketId : null,
       });

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -1,0 +1,444 @@
+/**
+ * preflight.js
+ *
+ * IDEA2 / GH-219 — Task 3: Shared preflight gate with audit hook.
+ *
+ * `runPreflight(context, options)` is the single evaluation surface consumed
+ * by `workflows/work/hooks/work-require-implement.js` and
+ * `workflows/work-implement/hooks/work-implement-enforce.js`. It returns a
+ * {@link PreflightResult} and invokes an optional {@link PreflightAudit}
+ * callback so enforcement decisions can be persisted to `.work-actions.json`
+ * via `appendEnforcementAudit` (Task 1) WITHOUT this module importing
+ * `work-actions.js` (low coupling; audit is injected by callers).
+ *
+ * The `context` parameter matches the `EnforcementContext` shape returned by
+ * `workflows/work/work-enforcement-context.js` (Task 2). The JSDoc `@param`
+ * below imports that type by name via a TypeScript-compatible `import(...)`
+ * specifier so downstream tooling (tsc in checkJs mode, Cursor/VSCode
+ * IntelliSense) resolves the fields without a runtime require — preflight
+ * remains decoupled from the adapter.
+ *
+ * @module preflight
+ */
+'use strict';
+
+const path = require('path');
+
+/**
+ * @typedef {import('../work/work-enforcement-context').EnforcementContext} EnforcementContext
+ *
+ * Unified enforcement context composed by `loadEnforcementContext` in
+ * `workflows/work/work-enforcement-context.js` (Task 2). Contains:
+ *   - `ticketId`    {string|null}           sanitized ticket id, null on validation error
+ *   - `origin`      {'workflow'|'ai-subtask'|'user'|null} derived origin
+ *   - `state`       {object|null}           result from `loadState(ticketId)`
+ *   - `tasks`       {object[]|null}         result from `parseTasks(tasksDir)`
+ *   - `subtaskState` {object|null}          active subtask state or null
+ *   - `hasWorkflow` {boolean}               convenience signal
+ *   - `error`       {EnforcementContextError|null} populated on ambiguity / bad id
+ *   - `options`     {object}                echo of caller options
+ */
+
+/**
+ * @typedef {import('../work/work-enforcement-context').EnforcementContextError} EnforcementContextError
+ *
+ * Structured error descriptor attached to `EnforcementContext.error`:
+ *   - `code`        {string}   stable identifier (e.g. 'AMBIGUOUS_SUBTASK')
+ *   - `message`     {string}   human-readable description
+ *   - `remediation` {string[]} actionable fix steps (may be empty)
+ */
+
+/**
+ * Final preflight decision consumed by hooks.
+ *
+ * @typedef {Object} PreflightResult
+ * @property {boolean}  allow       `true` iff no deny reasons collected.
+ * @property {string[]} reasons     Deny reason codes (stable rule ids),
+ *                                  aggregated across `context.error` and
+ *                                  every denying check. Empty on allow.
+ * @property {string[]} remediation Merged, ordered remediation steps for
+ *                                  R18 explainability. Empty on allow.
+ */
+
+/**
+ * Audit record passed to the injected audit callback.
+ *
+ * Fields are a superset of `appendEnforcementAudit` (Task 1) inputs so
+ * callers can forward this entry directly to persistence — preflight never
+ * imports `work-actions.js`.
+ *
+ * @typedef {Object} PreflightAuditEntry
+ * @property {'allow'|'deny'}                         decision
+ * @property {string[]}                                reasons
+ * @property {string[]}                                remediation
+ * @property {'workflow'|'ai-subtask'|'user'|null}     origin
+ * @property {string|null}                             ticketId
+ */
+
+/**
+ * Callable signature for an injected audit hook. Single positional argument
+ * (plain object). Return value is ignored. Callback exceptions are caught
+ * and suppressed by `runPreflight` (fail-open on logging).
+ *
+ * @typedef {(entry: PreflightAuditEntry) => void} PreflightAudit
+ */
+
+/**
+ * Callable signature for a pluggable preflight check.
+ *
+ * Returning `null`/`undefined` or `{ allow: true }` is "no opinion" and
+ * passes through. Returning `{ allow: false, reasons?, remediation? }`
+ * contributes to the aggregated deny result. A thrown check is caught and
+ * recorded as `PREFLIGHT_CHECK_ERROR` (fail-closed) — it cannot starve the
+ * gate.
+ *
+ * @typedef {(ctx: EnforcementContext) => (Partial<PreflightResult>|null|undefined)} PreflightCheck
+ */
+
+/**
+ * Options for {@link runPreflight}.
+ *
+ * @typedef {Object} PreflightOptions
+ * @property {PreflightAudit}   [audit]   Injected logger; defaults to no-op.
+ * @property {PreflightCheck[]} [checks]  Pluggable checks run in order.
+ */
+
+/**
+ * Run the preflight gate.
+ *
+ * Semantics:
+ *   1. If `context.error` is a truthy object with a non-empty string `code`,
+ *      the error is recorded as a deny reason and its `remediation` (when an
+ *      array) is merged into the result.
+ *   2. If `options.checks` is provided, each check runs IN ORDER with
+ *      `context` as its sole argument. All denying results are aggregated —
+ *      reasons concatenated, remediation merged in declared order. A single
+ *      thrown check is caught and recorded as `PREFLIGHT_CHECK_ERROR`
+ *      (fail-closed) so one buggy rule cannot crash the whole gate.
+ *   3. The final `allow` is `true` iff no deny reasons were collected.
+ *   4. If `options.audit` is a function, it is invoked exactly once with a
+ *      single {@link PreflightAuditEntry}. The callback is wrapped in a
+ *      try/catch so logging failures never break enforcement (mirrors
+ *      `work-actions.js` `appendRow()` fail-open).
+ *   5. If `options.audit` is missing / not a function, audit defaults to a
+ *      no-op.
+ *
+ * The function is declared with arity 2 (no default parameters) so
+ * `runPreflight.length === 2`, locking the documented public contract.
+ *
+ * @param {EnforcementContext} context
+ *   Enforcement context produced by `loadEnforcementContext`
+ *   (`workflows/work/work-enforcement-context.js`, Task 2).
+ * @param {PreflightOptions} [options]
+ * @returns {PreflightResult}
+ */
+function runPreflight(context, options) {
+  const ctx = context || {};
+  const opts = options || {};
+
+  const audit = typeof opts.audit === 'function' ? opts.audit : null;
+  const checks = Array.isArray(opts.checks) ? opts.checks : null;
+
+  const reasons = [];
+  const remediation = [];
+
+  // ─── 1. context.error → deny with error.code as the rule id ────────────
+  const err = ctx.error;
+  if (err && typeof err === 'object' && typeof err.code === 'string' && err.code.length > 0) {
+    reasons.push(err.code);
+    if (Array.isArray(err.remediation)) {
+      for (const step of err.remediation) {
+        remediation.push(step);
+      }
+    }
+  }
+
+  // ─── 2. Pluggable checks ───────────────────────────────────────────────
+  if (checks) {
+    for (const check of checks) {
+      if (typeof check !== 'function') continue;
+
+      let res;
+      try {
+        res = check(ctx);
+      } catch {
+        // Fail-closed on a crashing check — one buggy rule must not starve
+        // the gate. The synthetic reason lets callers identify the failure
+        // mode in audit records without leaking error internals.
+        reasons.push('PREFLIGHT_CHECK_ERROR');
+        continue;
+      }
+
+      if (!res || typeof res !== 'object') continue;
+      if (res.allow === false) {
+        if (Array.isArray(res.reasons)) {
+          for (const r of res.reasons) reasons.push(r);
+        }
+        if (Array.isArray(res.remediation)) {
+          for (const r of res.remediation) remediation.push(r);
+        }
+      }
+    }
+  }
+
+  // ─── 3. Final decision ─────────────────────────────────────────────────
+  const allow = reasons.length === 0;
+  const decision = allow ? 'allow' : 'deny';
+  const result = { allow, reasons, remediation };
+
+  // ─── 4. Fail-open audit ────────────────────────────────────────────────
+  // Entry fields are a superset of {decision, reasons, origin, ticketId} so
+  // callers can forward directly to `appendEnforcementAudit` (Task 1).
+  // `remediation` is included for R18 explainability (deny path).
+  if (audit) {
+    try {
+      audit({
+        decision,
+        reasons,
+        remediation,
+        origin: ctx.origin != null ? ctx.origin : null,
+        ticketId: ctx.ticketId != null ? ctx.ticketId : null,
+      });
+    } catch {
+      // Persistence failures must never break enforcement decisions.
+    }
+  }
+
+  return result;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Task 12 — Preflight rules integration (graph, claim, paths)
+//
+// Built-in check factories and shared path predicate.
+//   - createGraphCheck()                → PreflightCheck  (R4)
+//   - createClaimCheck({ taskNum, ownerId }) → PreflightCheck  (R3, R6)
+//   - createPathCheck({ filePath, allowedPaths }) → PreflightCheck  (R6)
+//   - isWriteAllowedPath(filePath, allowedPaths) → boolean  (R6, R12)
+//
+// isWriteAllowedPath is the single implementation of the path predicate.
+// Tasks 13-14 hooks import it from here — no inline copies allowed.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ─── Shared-root whitelist (R6) ──────────────────────────────────────────────
+// Files at ticketRoot that any worker may write (coordination files).
+const SHARED_ROOT_WHITELIST = new Set([
+  'brief.md',
+  'spec.md',
+  'tasks.md',
+  '.work-state.json',
+  '.work-actions.json',
+]);
+
+/**
+ * Determine whether a file path is allowed for the current worker.
+ *
+ * This is the SINGLE implementation of the task-readiness edit gate (R6).
+ * Tasks 13-14 hooks must import this — no inline duplicates.
+ *
+ * Allowed paths:
+ *   - Under `allowedPaths.prDir`      (PR{N}/ worktree)
+ *   - Under `allowedPaths.taskDir`    (task${N}/ artifacts)
+ *   - Shared-root whitelist at `allowedPaths.ticketRoot`
+ *
+ * Fail-closed (R15): returns false when inputs are missing or malformed.
+ *
+ * @param {string} filePath     - Absolute path being written
+ * @param {object} allowedPaths - { prDir, taskDir, ticketRoot }
+ * @returns {boolean}
+ */
+function isWriteAllowedPath(filePath, allowedPaths) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  if (!allowedPaths || typeof allowedPaths !== 'object') return false;
+
+  // Normalize to prevent path-traversal bypasses (R15)
+  const normalized = path.resolve(filePath);
+
+  // Check PR{N}/ directory
+  if (typeof allowedPaths.prDir === 'string' && allowedPaths.prDir.length > 0) {
+    const prResolved = path.resolve(allowedPaths.prDir);
+    if (normalized.startsWith(prResolved + path.sep) || normalized === prResolved) {
+      return true;
+    }
+  }
+
+  // Check task${N}/ directory
+  if (typeof allowedPaths.taskDir === 'string' && allowedPaths.taskDir.length > 0) {
+    const taskResolved = path.resolve(allowedPaths.taskDir);
+    if (normalized.startsWith(taskResolved + path.sep) || normalized === taskResolved) {
+      return true;
+    }
+  }
+
+  // Check shared-root whitelist at ticketRoot
+  if (typeof allowedPaths.ticketRoot === 'string' && allowedPaths.ticketRoot.length > 0) {
+    const ticketResolved = path.resolve(allowedPaths.ticketRoot);
+    // File must be directly at ticketRoot (not nested) and in the whitelist
+    const dir = path.dirname(normalized);
+    if (dir === ticketResolved) {
+      const basename = path.basename(normalized);
+      if (SHARED_ROOT_WHITELIST.has(basename)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Create a graph validation check (R4).
+ *
+ * Validates `ctx.tasks` for unknown dependencies, self-dependencies, and
+ * cycles using `validateTaskGraph` from `work-state.js`. If tasks are null
+ * or missing, the check passes (no graph to validate).
+ *
+ * @returns {PreflightCheck}
+ */
+function createGraphCheck() {
+  return function graphCheck(ctx) {
+    if (!ctx.tasks || !Array.isArray(ctx.tasks)) return null;
+
+    // Lazy require to avoid module-level coupling with work-state.js.
+    // In production config is always available; if require fails, the
+    // enclosing runPreflight try/catch records PREFLIGHT_CHECK_ERROR.
+    const { validateTaskGraph } = require('../work/work-state');
+
+    const validation = validateTaskGraph(ctx.tasks);
+    if (validation.valid) return null;
+
+    // Aggregate all graph errors into reasons + remediation
+    const reasons = [];
+    const remediation = [];
+    for (const err of validation.errors) {
+      if (err.code && !reasons.includes(err.code)) {
+        reasons.push(err.code);
+      }
+      if (Array.isArray(err.remediation)) {
+        for (const step of err.remediation) {
+          remediation.push(step);
+        }
+      }
+    }
+
+    return { allow: false, reasons, remediation };
+  };
+}
+
+/**
+ * Create a claim + dependency readiness check (R3, R6).
+ *
+ * Validates that:
+ *   1. If taskNum is set, ownerId must also be set (unclaimed write → deny).
+ *   2. The task's dependencies are all completed (canStart semantics, R3).
+ *
+ * When no tasksMeta exists in the context state, the check passes (legacy
+ * mode, R16 backward compat).
+ *
+ * @param {object} params
+ * @param {number} [params.taskNum] - Task number being worked on
+ * @param {string} [params.ownerId] - PR{N} owner id from claim
+ * @returns {PreflightCheck}
+ */
+function createClaimCheck(params) {
+  const taskNum = params && params.taskNum;
+  const ownerId = params && params.ownerId;
+
+  return function claimCheck(ctx) {
+    // No state or no tasksMeta → legacy mode, allow (R16)
+    if (!ctx.state || !ctx.state.tasksMeta) return null;
+
+    // No taskNum requested → no claim enforcement needed
+    if (!taskNum) return null;
+
+    // R6: taskNum set but no ownerId → unclaimed task write
+    if (!ownerId) {
+      return {
+        allow: false,
+        reasons: ['UNCLAIMED_TASK_WRITE'],
+        remediation: [
+          `Task ${taskNum} has no claim. Run claimTask(ticketId, ${taskNum}, ownerId) before writing.`,
+          'Each worker must claim a task with its PR{N} owner id before modifying files.',
+        ],
+      };
+    }
+
+    // R3: Check dependency readiness using persisted tasksMeta
+    const tasksMeta = ctx.state.tasksMeta;
+    if (!Array.isArray(tasksMeta.tasks)) return null;
+
+    const targetId = `task_${taskNum}`;
+    const task = tasksMeta.tasks.find((t) => t && t.id === targetId);
+    if (!task) {
+      return {
+        allow: false,
+        reasons: ['UNKNOWN_TASK'],
+        remediation: [
+          `Task ${taskNum} not found in tasksMeta. Verify task number and re-run initTasksMeta.`,
+        ],
+      };
+    }
+
+    // Check dependency readiness (R3)
+    if (Array.isArray(task.dependencies) && task.dependencies.length > 0) {
+      for (const depNum of task.dependencies) {
+        const depId = `task_${depNum}`;
+        const dep = tasksMeta.tasks.find((t) => t && t.id === depId);
+        if (!dep || dep.status !== 'completed') {
+          return {
+            allow: false,
+            reasons: ['DEPENDENCY_NOT_READY'],
+            remediation: [
+              `Task ${taskNum} depends on Task ${depNum} which is not completed (status: ${dep ? dep.status : 'missing'}).`,
+              `Complete Task ${depNum} before starting Task ${taskNum}.`,
+              'Use canStart(ticketId, taskNum) to check readiness before claiming.',
+            ],
+          };
+        }
+      }
+    }
+
+    return null;
+  };
+}
+
+/**
+ * Create a path intent check (R6).
+ *
+ * If filePath is provided, validates it against the allowed paths using
+ * `isWriteAllowedPath`. If filePath is not provided, the check passes
+ * (no path intent to validate).
+ *
+ * @param {object} params
+ * @param {string} [params.filePath] - Absolute path being written
+ * @param {object} [params.allowedPaths] - { prDir, taskDir, ticketRoot }
+ * @returns {PreflightCheck}
+ */
+function createPathCheck(params) {
+  const filePath = params && params.filePath;
+  const allowedPaths = params && params.allowedPaths;
+
+  return function pathCheck() {
+    if (!filePath) return null;
+
+    if (isWriteAllowedPath(filePath, allowedPaths)) return null;
+
+    return {
+      allow: false,
+      reasons: ['PATH_NOT_ALLOWED'],
+      remediation: [
+        `Write to "${filePath}" is outside the allowed path set.`,
+        'Allowed paths: PR{N}/ worktree, task${N}/ artifacts, and shared-root whitelist (brief.md, spec.md, tasks.md, .work-state.json, .work-actions.json).',
+        'Verify the file path and ensure it falls under the claimed worker or task directory.',
+      ],
+    };
+  };
+}
+
+module.exports = {
+  runPreflight,
+  isWriteAllowedPath,
+  createGraphCheck,
+  createClaimCheck,
+  createPathCheck,
+};

--- a/workflows/lib/request-index.js
+++ b/workflows/lib/request-index.js
@@ -79,7 +79,15 @@ function sanitizeId(ticketId) {
  * @returns {string}
  */
 function ticketDir(ticketId) {
-  return path.join(resolveTasksBase(), sanitizeId(ticketId));
+  const base = resolveTasksBase();
+  const dir = path.join(base, sanitizeId(ticketId));
+  // Defense-in-depth: ensure path stays under TASKS_BASE
+  const resolved = path.resolve(dir);
+  const resolvedBase = path.resolve(base);
+  if (resolved !== resolvedBase && !resolved.startsWith(resolvedBase + path.sep)) {
+    throw new Error(`ticketDir: resolved path escapes TASKS_BASE: ${dir}`);
+  }
+  return dir;
 }
 
 /**
@@ -113,8 +121,12 @@ function readIndex(ticketId) {
       aiSeq: typeof raw.aiSeq === 'number' ? raw.aiSeq : 0,
       version: INDEX_VERSION,
     };
-  } catch {
-    return { userSeq: 0, aiSeq: 0, version: INDEX_VERSION };
+  } catch (err) {
+    // Only default to zeros on missing file; fail closed on other errors
+    if (err && err.code === 'ENOENT') {
+      return { userSeq: 0, aiSeq: 0, version: INDEX_VERSION };
+    }
+    throw err;
   }
 }
 
@@ -132,11 +144,8 @@ function writeIndexAtomic(ticketId, data) {
   const tmp = `${target}.${process.pid}.tmp`;
   fs.writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o644 });
   try {
-    try {
-      fs.unlinkSync(target);
-    } catch {
-      /* ENOENT — target doesn't exist yet */
-    }
+    // rename(2) is atomic on POSIX — no need to unlink first.
+    // This avoids a window where the target doesn't exist.
     fs.renameSync(tmp, target);
   } catch (renameErr) {
     try {
@@ -146,6 +155,51 @@ function writeIndexAtomic(ticketId, data) {
     }
     throw renameErr;
   }
+}
+
+/**
+ * Acquire a simple lock file for the read-modify-write cycle.
+ * Uses O_EXCL (wx) for atomic create — fails if lock already exists.
+ * Retries a few times with brief delay to handle contention.
+ * @param {string} lockPath
+ * @returns {boolean} true if lock acquired
+ */
+function acquireLock(lockPath) {
+  const MAX_RETRIES = 5;
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  for (let i = 0; i < MAX_RETRIES; i++) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx');
+      fs.writeSync(fd, String(process.pid));
+      fs.closeSync(fd);
+      return true;
+    } catch (err) {
+      if (err && err.code === 'EEXIST') {
+        // Check if lock is stale (older than 30s)
+        try {
+          const stat = fs.statSync(lockPath);
+          if (Date.now() - stat.mtimeMs > 30000) {
+            fs.unlinkSync(lockPath);
+            continue; // retry after removing stale lock
+          }
+        } catch { /* lock disappeared — retry */ }
+        // Brief busy-wait for contention (not using sleep)
+        const start = Date.now();
+        while (Date.now() - start < 50) { /* spin */ }
+        continue;
+      }
+      throw err;
+    }
+  }
+  return false;
+}
+
+/**
+ * Release the lock file.
+ * @param {string} lockPath
+ */
+function releaseLock(lockPath) {
+  try { fs.unlinkSync(lockPath); } catch { /* best-effort */ }
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────
@@ -165,16 +219,24 @@ function writeIndexAtomic(ticketId, data) {
  */
 function nextUserRequest(ticketId) {
   validateTicketId(ticketId);
-  const current = readIndex(ticketId);
-  const nextSeq = current.userSeq + 1;
-  const updated = { ...current, userSeq: nextSeq };
-  writeIndexAtomic(ticketId, updated);
+  const lockPath = indexPath(ticketId) + '.lock';
+  if (!acquireLock(lockPath)) {
+    throw new Error(`Failed to acquire index lock for ${ticketId} — concurrent contention`);
+  }
+  try {
+    const current = readIndex(ticketId);
+    const nextSeq = current.userSeq + 1;
+    const updated = { ...current, userSeq: nextSeq };
+    writeIndexAtomic(ticketId, updated);
 
-  const segment = `${USER_REQUEST_PREFIX}${nextSeq}`;
-  const root = path.join(ticketDir(ticketId), segment);
-  fs.mkdirSync(root, { recursive: true });
+    const segment = `${USER_REQUEST_PREFIX}${nextSeq}`;
+    const root = path.join(ticketDir(ticketId), segment);
+    fs.mkdirSync(root, { recursive: true });
 
-  return { seq: nextSeq, segment, root };
+    return { seq: nextSeq, segment, root };
+  } finally {
+    releaseLock(lockPath);
+  }
 }
 
 /**
@@ -185,16 +247,24 @@ function nextUserRequest(ticketId) {
  */
 function nextAiRequest(ticketId) {
   validateTicketId(ticketId);
-  const current = readIndex(ticketId);
-  const nextSeq = current.aiSeq + 1;
-  const updated = { ...current, aiSeq: nextSeq };
-  writeIndexAtomic(ticketId, updated);
+  const lockPath = indexPath(ticketId) + '.lock';
+  if (!acquireLock(lockPath)) {
+    throw new Error(`Failed to acquire index lock for ${ticketId} — concurrent contention`);
+  }
+  try {
+    const current = readIndex(ticketId);
+    const nextSeq = current.aiSeq + 1;
+    const updated = { ...current, aiSeq: nextSeq };
+    writeIndexAtomic(ticketId, updated);
 
-  const segment = `${AI_REQUEST_PREFIX}${nextSeq}`;
-  const root = path.join(ticketDir(ticketId), segment);
-  fs.mkdirSync(root, { recursive: true });
+    const segment = `${AI_REQUEST_PREFIX}${nextSeq}`;
+    const root = path.join(ticketDir(ticketId), segment);
+    fs.mkdirSync(root, { recursive: true });
 
-  return { seq: nextSeq, segment, root };
+    return { seq: nextSeq, segment, root };
+  } finally {
+    releaseLock(lockPath);
+  }
 }
 
 module.exports = {

--- a/workflows/lib/request-index.js
+++ b/workflows/lib/request-index.js
@@ -1,0 +1,206 @@
+/**
+ * request-index.js — Atomic counter ledger for out-of-flow request allocation (GH-219 Task 10)
+ *
+ * Manages `.request-index.json` per ticket directory with collision-safe increments.
+ * Format: `{ "userSeq": n, "aiSeq": m, "version": 1 }`
+ *
+ * Uses the atomic rename pattern (write temp → rename) from session-guard.js.
+ *
+ * Requirements:
+ *   R9:  Out-of-flow user routing — `user-request-${n}`
+ *   R10: Out-of-flow AI routing — `ai-request-${n}`
+ *   R11: Persistent `.request-index.json` with collision-safe increments
+ *   R7:  Allocator completion — wires the stubs from Task 9
+ *
+ * @module request-index
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { USER_REQUEST_PREFIX, AI_REQUEST_PREFIX } = require('./allocate-output-folder');
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const INDEX_FILENAME = '.request-index.json';
+const INDEX_VERSION = 1;
+
+/** @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes */
+const UNSAFE_TICKET_RE = /\.\.|[\\]|\x00/;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve TASKS_BASE from environment.
+ * @returns {string}
+ */
+function resolveTasksBase() {
+  if (process.env.TASKS_BASE) return process.env.TASKS_BASE;
+  throw new Error('TASKS_BASE is not configured. Set the TASKS_BASE environment variable.');
+}
+
+/**
+ * Validate ticket ID — fail-closed before any filesystem I/O.
+ * @param {unknown} ticketId
+ */
+function validateTicketId(ticketId) {
+  if (typeof ticketId !== 'string' || ticketId.length === 0) {
+    throw new Error(
+      `Invalid ticket ID: expected non-empty string, received ${typeof ticketId === 'string' ? '""' : typeof ticketId}`
+    );
+  }
+  if (UNSAFE_TICKET_RE.test(ticketId)) {
+    throw new Error(
+      `Invalid ticket ID: contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`
+    );
+  }
+}
+
+/**
+ * Sanitize ticket ID for filesystem paths using config.safeTicketId when available.
+ * @param {string} ticketId
+ * @returns {string}
+ */
+function sanitizeId(ticketId) {
+  try {
+    const config = require('./config');
+    if (config && typeof config.safeTicketId === 'function') {
+      return config.safeTicketId(ticketId);
+    }
+  } catch {
+    // fallback to raw ID
+  }
+  return ticketId;
+}
+
+/**
+ * Resolve the ticket directory path.
+ * @param {string} ticketId
+ * @returns {string}
+ */
+function ticketDir(ticketId) {
+  return path.join(resolveTasksBase(), sanitizeId(ticketId));
+}
+
+/**
+ * Resolve the `.request-index.json` path for a ticket.
+ * @param {string} ticketId
+ * @returns {string}
+ */
+function indexPath(ticketId) {
+  return path.join(ticketDir(ticketId), INDEX_FILENAME);
+}
+
+/**
+ * @typedef {Object} RequestIndex
+ * @property {number} userSeq - Current user request sequence number
+ * @property {number} aiSeq - Current AI request sequence number
+ * @property {number} version - Schema version
+ */
+
+/**
+ * Read the current index from disk. Returns zeroed defaults if the file does not exist.
+ * @param {string} ticketId
+ * @returns {RequestIndex}
+ */
+function readIndex(ticketId) {
+  validateTicketId(ticketId);
+  const filePath = indexPath(ticketId);
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    return {
+      userSeq: typeof raw.userSeq === 'number' ? raw.userSeq : 0,
+      aiSeq: typeof raw.aiSeq === 'number' ? raw.aiSeq : 0,
+      version: INDEX_VERSION,
+    };
+  } catch {
+    return { userSeq: 0, aiSeq: 0, version: INDEX_VERSION };
+  }
+}
+
+/**
+ * Write index atomically: write to temp file, then rename.
+ * Pattern borrowed from session-guard.js writeSessionAtomic.
+ * @param {string} ticketId
+ * @param {RequestIndex} data
+ */
+function writeIndexAtomic(ticketId, data) {
+  const target = indexPath(ticketId);
+  const dir = path.dirname(target);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const tmp = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o644 });
+  try {
+    try {
+      fs.unlinkSync(target);
+    } catch {
+      /* ENOENT — target doesn't exist yet */
+    }
+    fs.renameSync(tmp, target);
+  } catch (renameErr) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* cleanup best-effort */
+    }
+    throw renameErr;
+  }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} AllocationResult
+ * @property {number} seq - The allocated sequence number
+ * @property {string} segment - Directory segment name (e.g. "user-request-1")
+ * @property {string} root - Absolute path to the allocated directory
+ */
+
+/**
+ * Allocate the next user-request folder, incrementing the counter atomically.
+ *
+ * @param {string} ticketId
+ * @returns {AllocationResult}
+ */
+function nextUserRequest(ticketId) {
+  validateTicketId(ticketId);
+  const current = readIndex(ticketId);
+  const nextSeq = current.userSeq + 1;
+  const updated = { ...current, userSeq: nextSeq };
+  writeIndexAtomic(ticketId, updated);
+
+  const segment = `${USER_REQUEST_PREFIX}${nextSeq}`;
+  const root = path.join(ticketDir(ticketId), segment);
+  fs.mkdirSync(root, { recursive: true });
+
+  return { seq: nextSeq, segment, root };
+}
+
+/**
+ * Allocate the next ai-request folder, incrementing the counter atomically.
+ *
+ * @param {string} ticketId
+ * @returns {AllocationResult}
+ */
+function nextAiRequest(ticketId) {
+  validateTicketId(ticketId);
+  const current = readIndex(ticketId);
+  const nextSeq = current.aiSeq + 1;
+  const updated = { ...current, aiSeq: nextSeq };
+  writeIndexAtomic(ticketId, updated);
+
+  const segment = `${AI_REQUEST_PREFIX}${nextSeq}`;
+  const root = path.join(ticketDir(ticketId), segment);
+  fs.mkdirSync(root, { recursive: true });
+
+  return { seq: nextSeq, segment, root };
+}
+
+module.exports = {
+  nextUserRequest,
+  nextAiRequest,
+  readIndex,
+  INDEX_FILENAME,
+  INDEX_VERSION,
+};

--- a/workflows/lib/request-index.js
+++ b/workflows/lib/request-index.js
@@ -87,7 +87,7 @@ function ticketDir(ticketId) {
   if (resolved !== resolvedBase && !resolved.startsWith(resolvedBase + path.sep)) {
     throw new Error(`ticketDir: resolved path escapes TASKS_BASE: ${dir}`);
   }
-  return dir;
+  return dir; // path-containment verified
 }
 
 /**
@@ -228,11 +228,9 @@ function nextUserRequest(ticketId) {
     const nextSeq = current.userSeq + 1;
     const updated = { ...current, userSeq: nextSeq };
     writeIndexAtomic(ticketId, updated);
-
     const segment = `${USER_REQUEST_PREFIX}${nextSeq}`;
     const root = path.join(ticketDir(ticketId), segment);
     fs.mkdirSync(root, { recursive: true });
-
     return { seq: nextSeq, segment, root };
   } finally {
     releaseLock(lockPath);

--- a/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -456,6 +456,50 @@ describe('tdd-phase-state CLI', () => {
     });
   });
 
+  describe('per-task path with legacy root fallback (GH-219 Task 9)', () => {
+    it('init with --task writes to TASKS_BASE/<ticket>/task${N}/tdd-phase.json', () => {
+      const { stdout, exitCode } = runCli('init TEST-T9A --task 3', homeDir);
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.ok, true);
+
+      // Verify state file is at per-task path
+      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-T9A', 'task3', 'tdd-phase.json');
+      assert.ok(fs.existsSync(perTaskPath), `Expected per-task state at ${perTaskPath}`);
+      const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
+      assert.strictEqual(state.currentPhase, 'red');
+    });
+
+    it('current with --task reads from per-task path when it exists', () => {
+      runCli('init TEST-T9B --task 5', homeDir);
+      const { stdout, exitCode } = runCli('current TEST-T9B --task 5', homeDir);
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.phase, 'red');
+    });
+
+    it('current with --task falls back to legacy root when per-task path missing', () => {
+      // Create state at root (legacy) path only
+      runCli('init TEST-T9C', homeDir);
+      // Now read with --task — per-task file does not exist, should fallback to root
+      const { stdout, exitCode } = runCli('current TEST-T9C --task 2', homeDir);
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.phase, 'red');
+    });
+
+    it('current with --task fails when neither per-task nor root exists', () => {
+      const { exitCode } = runCli('current TEST-T9D --task 1', homeDir);
+      assert.strictEqual(exitCode, 1);
+    });
+
+    it('init without --task writes to legacy root path (backward compat)', () => {
+      runCli('init TEST-T9E', homeDir);
+      const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-T9E', 'tdd-phase.json');
+      assert.ok(fs.existsSync(rootPath), `Expected root state at ${rootPath}`);
+    });
+  });
+
   describe('token gating', () => {
     it('record-red fails without token when WORK_TDD_TOKEN_SKIP is not set', () => {
       runCli('init TEST-TOK', homeDir);

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -64,17 +64,94 @@ function sanitizeId(ticketId) {
   }
 }
 
-function getStatePath(ticketId) {
+/**
+ * Resolve TASKS_BASE from env, config, or HOME fallback.
+ * @returns {string}
+ */
+function resolveTasksBase() {
+  return (
+    process.env.TASKS_BASE ||
+    (config && config.TASKS_BASE) ||
+    path.join(process.env.HOME, 'worktrees', 'tasks')
+  );
+}
+
+/**
+ * Build the per-task state path: TASKS_BASE/<ticket>/task${N}/tdd-phase.json
+ * @param {string} base - Resolved TASKS_BASE
+ * @param {string} safeId - Sanitized ticket ID
+ * @param {number} taskNum - Task number (positive integer)
+ * @returns {string}
+ */
+function perTaskStatePath(base, safeId, taskNum) {
+  let taskSegmentFn;
+  try {
+    taskSegmentFn = require('../lib/allocate-output-folder').taskSegment;
+  } catch {
+    // fallback if allocator not available — inline the task${N} pattern
+    taskSegmentFn = (n) => `task${n}`;
+  }
+  return path.resolve(base, safeId, taskSegmentFn(taskNum), 'tdd-phase.json');
+}
+
+/**
+ * Build the legacy ticket-root state path: TASKS_BASE/<ticket>/tdd-phase.json
+ * @param {string} base - Resolved TASKS_BASE
+ * @param {string} safeId - Sanitized ticket ID
+ * @returns {string}
+ */
+function ticketRootStatePath(base, safeId) {
+  return path.resolve(base, safeId, 'tdd-phase.json');
+}
+
+/**
+ * Resolve the state file path for a ticket.
+ *
+ * When taskNum is provided:
+ *   - Write path: always per-task (TASKS_BASE/<ticket>/task${N}/tdd-phase.json)
+ *   - Read path: per-task first; if missing, fallback to legacy root path
+ *     (TASKS_BASE/<ticket>/tdd-phase.json) for backward compatibility.
+ *
+ * When taskNum is NOT provided:
+ *   - Uses the legacy root path (backward compat).
+ *
+ * @param {string} ticketId - Raw ticket ID
+ * @param {object} [opts] - Options
+ * @param {number} [opts.taskNum] - Task number for per-task resolution
+ * @param {boolean} [opts.forWrite] - If true, always return per-task path (no fallback)
+ * @returns {string} Absolute path to tdd-phase.json
+ */
+function getStatePath(ticketId, opts) {
   if (!ticketId || /\.\./.test(ticketId) || /\\/.test(ticketId)) {
     throw new Error(`Invalid ticket ID: ${ticketId}`);
   }
-  // Resolve from TASKS_BASE env, config module, or default HOME-based path
-  const base =
-    process.env.TASKS_BASE ||
-    (config && config.TASKS_BASE) ||
-    path.join(process.env.HOME, 'worktrees', 'tasks');
+  const base = resolveTasksBase();
   const safeId = sanitizeId(ticketId);
-  const resolved = path.resolve(base, safeId, 'tdd-phase.json');
+  const taskNum = opts && opts.taskNum;
+
+  let resolved;
+
+  if (taskNum != null && Number.isInteger(taskNum) && taskNum > 0) {
+    const perTask = perTaskStatePath(base, safeId, taskNum);
+
+    if (opts && opts.forWrite) {
+      // Writes always target per-task path
+      resolved = perTask;
+    } else {
+      // Reads: per-task first, then legacy root fallback
+      if (fs.existsSync(perTask)) {
+        resolved = perTask;
+      } else {
+        // Legacy fallback: check ticketRoot for backward compat
+        const root = ticketRootStatePath(base, safeId);
+        resolved = fs.existsSync(root) ? root : perTask;
+      }
+    }
+  } else {
+    // No task number — legacy root path
+    resolved = ticketRootStatePath(base, safeId);
+  }
+
   // Validate resolved path stays within TASKS_BASE (prevents traversal)
   if (!resolved.startsWith(path.resolve(base) + path.sep)) {
     throw new Error(`Invalid ticket ID: ${ticketId}`);
@@ -82,16 +159,16 @@ function getStatePath(ticketId) {
   return resolved;
 }
 
-function readState(ticketId) {
-  const statePath = getStatePath(ticketId);
+function readState(ticketId, opts) {
+  const statePath = getStatePath(ticketId, opts);
   if (!fs.existsSync(statePath)) {
     return null;
   }
   return JSON.parse(fs.readFileSync(statePath, 'utf8'));
 }
 
-function writeState(ticketId, state) {
-  const statePath = getStatePath(ticketId);
+function writeState(ticketId, state, opts) {
+  const statePath = getStatePath(ticketId, { ...opts, forWrite: true });
   const dir = path.dirname(statePath);
   fs.mkdirSync(dir, { recursive: true });
   const tmpPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
@@ -119,6 +196,15 @@ function parseCmd(args) {
     return null;
   }
   return args[cmdIdx + 1];
+}
+
+function parseTask(args) {
+  const taskIdx = args.indexOf('--task');
+  if (taskIdx === -1 || taskIdx + 1 >= args.length) {
+    return undefined;
+  }
+  const val = parseInt(args[taskIdx + 1], 10);
+  return Number.isInteger(val) && val > 0 ? val : undefined;
 }
 
 function runTestCommand(cmd) {
@@ -184,24 +270,28 @@ function verifyToken() {
 
 // ─── Subcommands ────────────────────────────────────────────────────────────
 
-function cmdInit(ticketId) {
+function cmdInit(ticketId, args) {
   if (!ticketId) {
     errorExit('Missing ticket ID. Usage: node tdd-phase-state.js init <TICKET_ID>');
   }
+  const taskNum = parseTask(args || []);
+  const opts = taskNum ? { taskNum } : undefined;
   const state = {
     currentPhase: 'red',
     currentCycle: 1,
     cycles: [],
   };
-  writeState(ticketId, state);
+  writeState(ticketId, state, opts);
   successOut({ ok: true, phase: 'red', cycle: 1 });
 }
 
-function cmdCurrent(ticketId) {
+function cmdCurrent(ticketId, args) {
   if (!ticketId) {
     errorExit('Missing ticket ID.');
   }
-  const state = readState(ticketId);
+  const taskNum = parseTask(args || []);
+  const opts = taskNum ? { taskNum } : undefined;
+  const state = readState(ticketId, opts);
   if (!state) {
     errorExit('No TDD phase state found. Run "init" first.');
   }
@@ -405,10 +495,10 @@ if (GATED_SUBCOMMANDS.includes(subcommand) && process.env.WORK_TDD_TOKEN_SKIP !=
 
 switch (subcommand) {
   case 'init':
-    cmdInit(ticketId);
+    cmdInit(ticketId, args.slice(2));
     break;
   case 'current':
-    cmdCurrent(ticketId);
+    cmdCurrent(ticketId, args.slice(2));
     break;
   case 'record-red':
     cmdRecordRed(ticketId, args.slice(2));

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -72,7 +72,7 @@ function resolveTasksBase() {
   return (
     process.env.TASKS_BASE ||
     (config && config.TASKS_BASE) ||
-    path.join(process.env.HOME, 'worktrees', 'tasks')
+    path.join(require('os').homedir(), 'worktrees', 'tasks')
   );
 }
 

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -73,7 +73,7 @@ function resolveTasksBase() {
     process.env.TASKS_BASE ||
     (config && config.TASKS_BASE) ||
     path.join(require('os').homedir(), 'worktrees', 'tasks')
-  );
+  ); // os.homedir() — safe on all platforms
 }
 
 /**
@@ -237,7 +237,7 @@ function verifyToken() {
   if (!token) {
     errorExit(
       "No valid write token found. This script can only be called through Claude Code's agent system."
-    );
+    ); // os.homedir() — safe on all platforms
   }
 
   if (typeof token.timestamp !== 'number' || !Number.isFinite(token.timestamp)) {
@@ -259,12 +259,12 @@ function verifyToken() {
 
   const agentMatch = ALLOWED_AGENTS.some(
     (a) => normalizeAgentName(a) === normalizeAgentName(token.agent)
-  );
+  ); // os.homedir() — safe on all platforms
 
   if (!agentMatch) {
     errorExit(
       `Token agent "${token.agent}" is not authorized. Allowed: ${ALLOWED_AGENTS.join(', ')}`
-    );
+    ); // os.homedir() — safe on all platforms
   }
 }
 
@@ -311,7 +311,7 @@ function cmdRecordRed(ticketId, args) {
       'Cannot record RED evidence: current phase is "' +
         state.currentPhase +
         '". Transition to red first.'
-    );
+    ); // os.homedir() — safe on all platforms
 
   // Detect changed test files via git diff
   let allChanged = [];
@@ -372,7 +372,7 @@ function cmdRecordGreen(ticketId, args) {
       'Cannot record GREEN evidence: current phase is "' +
         state.currentPhase +
         '". Transition to green first.'
-    );
+    ); // os.homedir() — safe on all platforms
 
   const exitCode = runTestCommand(cmd);
   if (exitCode !== 0) {
@@ -406,7 +406,7 @@ function cmdRecordRefactor(ticketId, args) {
       'Cannot record REFACTOR evidence: current phase is "' +
         state.currentPhase +
         '". Transition to refactor first.'
-    );
+    ); // os.homedir() — safe on all platforms
 
   const exitCode = runTestCommand(cmd);
   if (exitCode !== 0) {
@@ -435,7 +435,7 @@ function cmdTransition(ticketId, targetPhase) {
     errorExit(
       `Invalid transition: ${state.currentPhase} -> ${targetPhase}. ` +
         `Valid transitions: red->green, green->refactor, refactor->red.`
-    );
+    ); // os.homedir() — safe on all platforms
   }
 
   // Validate evidence exists for current phase
@@ -444,7 +444,7 @@ function cmdTransition(ticketId, targetPhase) {
     errorExit(
       `No evidence recorded for ${state.currentPhase} phase. ` +
         `Run "record-${state.currentPhase}" first.`
-    );
+    ); // os.homedir() — safe on all platforms
   }
 
   // Update phase
@@ -465,7 +465,7 @@ function cmdException(ticketId, args) {
   if (reasonIdx === -1 || reasonIdx + 1 >= args.length) {
     errorExit(
       'Missing --reason argument. Usage: node tdd-phase-state.js exception <TICKET_ID> --reason "<reason>"'
-    );
+    ); // os.homedir() — safe on all platforms
   }
   const reason = args[reasonIdx + 1];
   if (!reason || !reason.trim()) {
@@ -519,5 +519,5 @@ switch (subcommand) {
     errorExit(
       `Unknown subcommand: ${subcommand}. ` +
         'Valid: init, current, record-red, record-green, record-refactor, transition, exception'
-    );
+    ); // os.homedir() — safe on all platforms
 }


### PR DESCRIPTION
## Existing Behavior

- No shared preflight evaluation surface existed; enforcement hooks in `work-require-implement` and `work-implement-enforce` each applied their own ad-hoc allow/deny logic with no common contract.
- Output folder paths (in-flow task dirs, out-of-flow user/AI request dirs) were reconstructed independently by callers with no single naming authority, making the `task${N}` segment string easy to diverge.
- No persistent counter ledger existed for out-of-flow requests, so `user-request-${n}` and `ai-request-${n}` allocations had no collision protection across parallel workers.
- TDD phase state reads used a hardcoded ticket-root path with no awareness of per-task subdirectories introduced by the Task 9 allocator.

## Intended New Behavior

- `workflows/lib/preflight.js` provides a single `runPreflight(context, { checks, audit })` surface returning `{ allow, reasons, remediation }`. Hooks inject an audit callback; preflight never imports `work-actions.js`, keeping persistence decoupled (R12, R13).
- `workflows/lib/allocate-output-folder.js` is the single source of truth for path naming (R7): `taskSegment(N)` produces the canonical `task${N}` form; in-flow, out-of-flow user/AI, and legacy-root cases are all resolved here with R15 fail-closed ticket ID validation before any filesystem I/O.
- `workflows/lib/request-index.js` implements an atomic counter ledger (`.request-index.json`) using the write-temp-then-rename pattern for collision-safe `userSeq` / `aiSeq` increments (R9, R10, R11).
- `tdd-phase-state.js` is updated to resolve its state file path via the allocator, gaining awareness of per-task output roots and the legacy-root fallback for pre-IDEA2 tickets (R16).

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

All three modules ship with `node --test` suites runnable without any external setup:

1. **Preflight unit tests** (R12, R13, R15):
   ```
   node --test workflows/lib/__tests__/preflight.test.js
   ```
   Verifies the `runPreflight` API surface, context-error denial, audit no-op, built-in check factories (`createGraphCheck`, `createClaimCheck`, `createPathCheck`), and the `isWriteAllowedPath` predicate.

2. **Allocator unit tests** (R7, R8, R15):
   ```
   TASKS_BASE=/tmp/test-tasks node --test workflows/lib/__tests__/allocate-output-folder.test.js
   ```
   Verifies in-flow (`task${N}`), out-of-flow user/AI, legacy-root, ticket ID validation, and `taskSegment` single-source-of-truth.

3. **Request index unit tests** (R9, R10, R11):
   ```
   node --test workflows/lib/__tests__/request-index.test.js
   ```
   Verifies `nextUserRequest`, `nextAiRequest`, monotonic counter sequences, independent user/AI counters, atomic rename pattern, and fail-closed validation.

4. **Preflight integration tests** (R18, R19, R20):
   ```
   node --test workflows/lib/__tests__/preflight-integration.test.js
   ```
   Covers mixed serial/parallel diamond dependency graphs, invalid graphs (unknown dep, cycle, self-dep), ambiguous `--subtask` origin, concurrent request-index sequential increments, two PR workers with distinct roots and path isolation, R18 remediation quality bar (ruleId, state snapshot, concrete fix steps), legacy ticket fixtures, and composed multi-failure aggregation.

5. **TDD phase state tests**:
   ```
   node --test workflows/work-implement/__tests__/tdd-phase-state.test.js
   ```
   Verifies allocator-aware path resolution and legacy-root fallback for pre-IDEA2 tickets.

### Test Results
[Will be populated after PR creation with actual test results]