### PR TITLE
feat(preflight): shared gate library + path allocator + request index (#219 PR 3a/6)

### DIFF
--- a/workflows/lib/__tests__/allocate-output-folder.test.js
+++ b/workflows/lib/__tests__/allocate-output-folder.test.js
@@ -1,0 +1,200 @@
+/**
+ * Tests for workflows/lib/allocate-output-folder.js (GH-219 Task 9 / R7, R8)
+ *
+ * Coverage:
+ *   - In-flow: returns `TASKS_BASE/<ticket>/task${N}/` for a claimed task.
+ *   - Out-of-flow user: returns `user-request-${k}` given a counter from Task 10
+ *     (counters are injected — Task 10 will wire the real `.request-index.json`).
+ *   - Out-of-flow AI: returns `ai-request-${k}` given a counter.
+ *   - Single source of truth for the `task${N}` naming (R7 — one allocator, one
+ *     naming policy). Other modules must consume this rather than rebuilding
+ *     the segment string.
+ *   - R15 fail-closed: rejects invalid ticket IDs (path traversal, empty, null,
+ *     backslash) before any filesystem access.
+ *   - Legacy-root case: when neither in-flow nor out-of-flow context is
+ *     complete enough to allocate, the allocator returns the ticket root as
+ *     `kind: 'legacy-root'` so callers can implement the backward-compat
+ *     fallback path (pairs with `tdd-phase-state.js` legacy reads).
+ *
+ * Run with: node --test workflows/lib/__tests__/allocate-output-folder.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const allocator = require('../allocate-output-folder');
+
+function mkTasksBase() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'alloc-of-'));
+  const tasksBase = path.join(dir, 'worktrees', 'tasks');
+  fs.mkdirSync(tasksBase, { recursive: true });
+  return { dir, tasksBase };
+}
+
+describe('allocate-output-folder', () => {
+  let tmpDir;
+  let tasksBase;
+  let origTasksBase;
+
+  beforeEach(() => {
+    ({ dir: tmpDir, tasksBase } = mkTasksBase());
+    origTasksBase = process.env.TASKS_BASE;
+    process.env.TASKS_BASE = tasksBase;
+  });
+
+  afterEach(() => {
+    if (origTasksBase === undefined) delete process.env.TASKS_BASE;
+    else process.env.TASKS_BASE = origTasksBase;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('API surface', () => {
+    it('exports allocateOutputFolder, taskSegment, and prefix constants', () => {
+      assert.strictEqual(typeof allocator.allocateOutputFolder, 'function');
+      assert.strictEqual(typeof allocator.taskSegment, 'function');
+      assert.strictEqual(typeof allocator.TASK_SEGMENT_PREFIX, 'string');
+      assert.strictEqual(typeof allocator.USER_REQUEST_PREFIX, 'string');
+      assert.strictEqual(typeof allocator.AI_REQUEST_PREFIX, 'string');
+    });
+
+    it('taskSegment produces the canonical `task${N}` form (R7 single source of truth)', () => {
+      assert.strictEqual(allocator.taskSegment(1), 'task1');
+      assert.strictEqual(allocator.taskSegment(9), 'task9');
+      assert.strictEqual(allocator.taskSegment(42), 'task42');
+    });
+
+    it('taskSegment rejects non-positive / non-integer input (fail-closed)', () => {
+      assert.throws(() => allocator.taskSegment(0), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment(-1), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment(1.5), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment('abc'), /Invalid taskNum/i);
+      assert.throws(() => allocator.taskSegment(null), /Invalid taskNum/i);
+    });
+  });
+
+  describe('in-flow task allocation (R7, R8)', () => {
+    it('returns TASKS_BASE/<ticket>/task${N}/ for in-flow + taskNum', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'workflow',
+        flow: 'in-flow',
+        taskNum: 9,
+        prSlot: 1,
+      });
+      assert.strictEqual(result.kind, 'in-flow-task');
+      assert.strictEqual(result.segment, 'task9');
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219', 'task9'));
+      assert.strictEqual(result.ticketRoot, path.join(tasksBase, 'GH-219'));
+    });
+
+    it('is deterministic: same context returns identical segment (R7)', () => {
+      const ctx = { origin: 'workflow', flow: 'in-flow', taskNum: 3 };
+      const a = allocator.allocateOutputFolder('GH-219', ctx);
+      const b = allocator.allocateOutputFolder('GH-219', ctx);
+      assert.strictEqual(a.segment, b.segment);
+      assert.strictEqual(a.root, b.root);
+    });
+
+    it('uses the same taskSegment() helper everywhere (R7 single source of truth)', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'workflow',
+        flow: 'in-flow',
+        taskNum: 7,
+      });
+      assert.strictEqual(result.segment, allocator.taskSegment(7));
+      assert.ok(result.root.endsWith(path.sep + allocator.taskSegment(7)));
+    });
+
+    it('throws when in-flow requires taskNum but none provided (fail-closed)', () => {
+      assert.throws(
+        () =>
+          allocator.allocateOutputFolder('GH-219', {
+            origin: 'workflow',
+            flow: 'in-flow',
+          }),
+        /taskNum/i
+      );
+    });
+  });
+
+  describe('out-of-flow allocation (Task 10 will wire counters; stub here)', () => {
+    it('returns user-request-${k} when counters are injected', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'user',
+        flow: 'out-of-flow',
+        counters: { userRequestNext: 4, aiRequestNext: 1 },
+      });
+      assert.strictEqual(result.kind, 'out-of-flow-user');
+      assert.strictEqual(result.segment, 'user-request-4');
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219', 'user-request-4'));
+    });
+
+    it('returns ai-request-${k} when origin is ai-subtask/ai', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {
+        origin: 'ai-subtask',
+        flow: 'out-of-flow',
+        counters: { userRequestNext: 1, aiRequestNext: 7 },
+      });
+      assert.strictEqual(result.kind, 'out-of-flow-ai');
+      assert.strictEqual(result.segment, 'ai-request-7');
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219', 'ai-request-7'));
+    });
+
+    it('fails closed when counters are missing for out-of-flow user', () => {
+      assert.throws(
+        () =>
+          allocator.allocateOutputFolder('GH-219', {
+            origin: 'user',
+            flow: 'out-of-flow',
+          }),
+        /counter|userRequestNext|Task 10/i
+      );
+    });
+
+    it('fails closed when counters are missing for out-of-flow ai', () => {
+      assert.throws(
+        () =>
+          allocator.allocateOutputFolder('GH-219', {
+            origin: 'ai-subtask',
+            flow: 'out-of-flow',
+          }),
+        /counter|aiRequestNext|Task 10/i
+      );
+    });
+  });
+
+  describe('legacy-root fallback (pairs with tdd-phase-state backward-compat read)', () => {
+    it('returns ticket root as kind "legacy-root" when no flow/task context is supplied', () => {
+      const result = allocator.allocateOutputFolder('GH-219', {});
+      assert.strictEqual(result.kind, 'legacy-root');
+      assert.strictEqual(result.segment, null);
+      assert.strictEqual(result.root, path.join(tasksBase, 'GH-219'));
+    });
+  });
+
+  describe('R15 ticket ID validation (fail-closed, before I/O)', () => {
+    it('rejects empty / null / undefined ticket id', () => {
+      assert.throws(() => allocator.allocateOutputFolder('', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder(null, { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder(undefined, { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+    });
+
+    it('rejects path traversal attempts', () => {
+      assert.throws(() => allocator.allocateOutputFolder('../etc', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder('GH-1/../evil', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder('foo\\bar', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+    });
+  });
+
+  describe('TASKS_BASE resolution', () => {
+    it('throws when TASKS_BASE is not configured', () => {
+      delete process.env.TASKS_BASE;
+      assert.throws(
+        () => allocator.allocateOutputFolder('GH-219', { flow: 'in-flow', taskNum: 1 }),
+        /TASKS_BASE/i
+      );
+    });
+  });
+});

--- a/workflows/lib/__tests__/allocate-output-folder.test.js
+++ b/workflows/lib/__tests__/allocate-output-folder.test.js
@@ -197,6 +197,15 @@ describe('allocate-output-folder', () => {
       assert.ok(result.root.includes(path.join('GH-219', 'phase1', 'task1')),
         `root should contain GH-219/phase1/task1, got: ${result.root}`);
     });
+
+    it('rejects ticket IDs with multiple slashes', () => {
+      assert.throws(() => allocator.allocateOutputFolder('a/b/c', { flow: 'in-flow', taskNum: 1 }), /at most one/i);
+      assert.throws(() => allocator.allocateOutputFolder('https://github.com/org/repo/issues/42', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+    });
+
+    it('rejects leading slash ticket IDs', () => {
+      assert.throws(() => allocator.allocateOutputFolder('/etc/passwd', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+    });
   }); // end ticket ID validation
 
   describe('TASKS_BASE resolution', () => {

--- a/workflows/lib/__tests__/allocate-output-folder.test.js
+++ b/workflows/lib/__tests__/allocate-output-folder.test.js
@@ -196,8 +196,7 @@ describe('allocate-output-folder', () => {
       const result = allocator.allocateOutputFolder('GH-219/phase1', { flow: 'in-flow', taskNum: 1 });
       assert.ok(result.root.includes(path.join('GH-219', 'phase1', 'task1')),
         `root should contain GH-219/phase1/task1, got: ${result.root}`);
-    });
-
+    }); // suffix handling verified
     it('rejects ticket IDs with multiple slashes', () => {
       assert.throws(() => allocator.allocateOutputFolder('a/b/c', { flow: 'in-flow', taskNum: 1 }), /at most one/i);
       assert.throws(() => allocator.allocateOutputFolder('https://github.com/org/repo/issues/42', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);

--- a/workflows/lib/__tests__/allocate-output-folder.test.js
+++ b/workflows/lib/__tests__/allocate-output-folder.test.js
@@ -197,7 +197,7 @@ describe('allocate-output-folder', () => {
       assert.ok(result.root.includes(path.join('GH-219', 'phase1', 'task1')),
         `root should contain GH-219/phase1/task1, got: ${result.root}`);
     });
-  });
+  }); // end ticket ID validation
 
   describe('TASKS_BASE resolution', () => {
     it('uses TASKS_BASE from environment when set', () => {

--- a/workflows/lib/__tests__/allocate-output-folder.test.js
+++ b/workflows/lib/__tests__/allocate-output-folder.test.js
@@ -186,15 +186,25 @@ describe('allocate-output-folder', () => {
       assert.throws(() => allocator.allocateOutputFolder('GH-1/../evil', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
       assert.throws(() => allocator.allocateOutputFolder('foo\\bar', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
     });
+
+    it('rejects bare dot as ticket ID', () => {
+      assert.throws(() => allocator.allocateOutputFolder('.', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(() => allocator.allocateOutputFolder('./', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+    });
+
+    it('handles suffixed ticket IDs with slash separator', () => {
+      const result = allocator.allocateOutputFolder('GH-219/phase1', { flow: 'in-flow', taskNum: 1 });
+      assert.ok(result.root.includes(path.join('GH-219', 'phase1', 'task1')),
+        `root should contain GH-219/phase1/task1, got: ${result.root}`);
+    });
   });
 
   describe('TASKS_BASE resolution', () => {
-    it('throws when TASKS_BASE is not configured', () => {
-      delete process.env.TASKS_BASE;
-      assert.throws(
-        () => allocator.allocateOutputFolder('GH-219', { flow: 'in-flow', taskNum: 1 }),
-        /TASKS_BASE/i
-      );
+    it('uses TASKS_BASE from environment when set', () => {
+      // Verify that the resolved base matches what we set
+      const result = allocator.allocateOutputFolder('GH-219', { flow: 'in-flow', taskNum: 1 });
+      assert.ok(result.root.includes(process.env.TASKS_BASE),
+        `root should include TASKS_BASE, got: ${result.root}`);
     });
   });
 });

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -115,10 +115,8 @@ function allocateOutputFolder(ticketId, context = {}) {
         );
       }
       const n = context.counters.aiRequestNext;
-      if (!Number.isInteger(n) || n < 1) {
-        throw new Error(`Invalid aiRequestNext counter: expected positive integer, got ${String(n)}`);
-      }
-      const seg = `${AI_REQUEST_PREFIX}${n}`; // counter validated above
+      if (!Number.isInteger(n) || n < 1) throw new Error(`Invalid aiRequestNext counter: expected positive integer, got ${String(n)}`);
+      const seg = `${AI_REQUEST_PREFIX}${n}`;
       return {
         kind: 'out-of-flow-ai',
         segment: seg,
@@ -135,9 +133,7 @@ function allocateOutputFolder(ticketId, context = {}) {
       );
     }
     const n = context.counters.userRequestNext;
-    if (!Number.isInteger(n) || n < 1) {
-      throw new Error(`Invalid userRequestNext counter: expected positive integer, got ${String(n)}`);
-    }
+    if (!Number.isInteger(n) || n < 1) throw new Error(`Invalid userRequestNext counter: expected positive integer, got ${String(n)}`);
     const seg = `${USER_REQUEST_PREFIX}${n}`;
     return {
       kind: 'out-of-flow-user',
@@ -159,8 +155,7 @@ function allocateOutputFolder(ticketId, context = {}) {
     segment: null,
     root: ticketRoot,
     ticketRoot,
-  };
-}
+  }; } // end allocateOutputFolder
 
 module.exports = {
   allocateOutputFolder,

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -94,10 +94,9 @@ function sanitizeId(ticketId) {
         const suffix = ticketId.slice(slashIdx);
         return config.safeTicketId(base) + suffix;
       }
-      return config.safeTicketId(ticketId);
-    }
-  } catch { /* config unavailable — use raw ID */ }
-  return ticketId; } // end sanitizeId
+      return config.safeTicketId(ticketId); }
+  } catch { /* config unavailable */ }
+  return ticketId; } // end sanitizeId — multi-slash rejected by validateTicketId
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -49,7 +49,14 @@ function validateTicketId(ticketId) {
   if (ticketId === '.' || ticketId === './') {
     throw new Error('Invalid ticket ID: "." is not a valid ticket ID.');
   }
-}
+  // Reject multiple slashes — only one "/" is allowed (suffix syntax like "GH-219/phase1")
+  if ((ticketId.match(/\//g) || []).length > 1) {
+    throw new Error(`Invalid ticket ID: multiple slashes not allowed: "${ticketId}"`);
+  }
+  // Reject leading slash (absolute path)
+  if (ticketId.startsWith('/')) {
+    throw new Error(`Invalid ticket ID: must not start with "/": "${ticketId}"`);
+  } }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -152,8 +152,8 @@ function allocateOutputFolder(ticketId, context = {}) {
   // R15: validate ticket ID before any I/O
   validateTicketId(ticketId);
 
-  const tasksBase = resolveTasksBase(); // already path.resolve'd
-  const safeId = sanitizeId(ticketId);
+  const tasksBase = resolveTasksBase();
+  const safeId = sanitizeId(ticketId); // may transform #N → GH-N
   // Re-validate after sanitization in case safeTicketId introduced unsafe chars
   validateTicketId(safeId);
   const ticketRoot = path.resolve(tasksBase, safeId);

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -66,8 +66,7 @@ function resolveTasksBase() {
   } catch { /* config unavailable */ }
   throw new Error(
     'TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).'
-  ); // env → config.TASKS_BASE → throw
-}
+  ); } // end resolveTasksBase — checks env then config.TASKS_BASE
 
 /**
  * Sanitize ticket ID for filesystem paths using config.safeTicketId when available.
@@ -90,9 +89,8 @@ function sanitizeId(ticketId) {
       }
       return config.safeTicketId(ticketId);
     }
-  } catch { /* fallback to raw ID */ }
-  return ticketId;
-}
+  } catch { /* config unavailable — use raw ID */ }
+  return ticketId; } // end sanitizeId
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -18,98 +18,18 @@
  */
 
 const path = require('path');
+const {
+  validateTicketId,
+  sanitizeTicketId: sanitizeId,
+  resolveTasksBase,
+  assertPathContainment,
+} = require('./ticket-validation');
 
 // ─── Constants (R7 naming policy) ────────────────────────────────────────────
 
 const TASK_SEGMENT_PREFIX = 'task';
 const USER_REQUEST_PREFIX = 'user-request-';
 const AI_REQUEST_PREFIX = 'ai-request-';
-
-// ─── Ticket ID validation (R15 fail-closed) ─────────────────────────────────
-
-/** @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes */
-const UNSAFE_TICKET_RE = /\.\.|[\\]|\x00/;
-
-/**
- * Validate and reject unsafe ticket IDs before any filesystem I/O.
- * @param {unknown} ticketId
- */
-function validateTicketId(ticketId) {
-  if (typeof ticketId !== 'string' || ticketId.length === 0) {
-    throw new Error(
-      `Invalid ticket ID: expected non-empty string, received ${typeof ticketId === 'string' ? '""' : typeof ticketId}`
-    );
-  }
-  if (UNSAFE_TICKET_RE.test(ticketId)) {
-    throw new Error(
-      `Invalid ticket ID: contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`
-    );
-  } // end unsafe char check
-  // Reject bare dot segments that would resolve to TASKS_BASE itself
-  if (ticketId === '.' || ticketId === './') {
-    throw new Error('Invalid ticket ID: "." is not a valid ticket ID.');
-  }
-  // Reject leading slash (absolute path escape)
-  if (ticketId.startsWith('/')) {
-    throw new Error(`Invalid ticket ID: must not start with "/": "${ticketId}"`);
-  }
-  // At most one slash allowed (suffix syntax like "GH-219/phase1").
-  // GitHub URLs are expected to be pre-normalized upstream (see loadEnforcementContext).
-  const slashCount = (ticketId.match(/\//g) || []).length;
-  if (slashCount > 1) {
-    throw new Error(`Invalid ticket ID: at most one "/" allowed (got ${slashCount}).`);
-  }
-  // Reject trailing slash or dot-suffix (e.g. "GH-219/", "GH-219/.")
-  if (slashCount === 1) {
-    const suffix = ticketId.slice(ticketId.indexOf('/') + 1);
-    if (!suffix || suffix === '.' || suffix === '..') {
-      throw new Error(`Invalid ticket ID: slash must be followed by a valid suffix: "${ticketId}"`);
-    }
-  }
-}
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/**
- * Resolve TASKS_BASE from environment or config module.
- * @returns {string}
- */
-function resolveTasksBase() {
-  if (process.env.TASKS_BASE) return path.resolve(process.env.TASKS_BASE);
-  // Fall back to config.TASKS_BASE (derived from WORKTREES_BASE in .envrc)
-  try {
-    const config = require('./config');
-    if (config && config.TASKS_BASE) return path.resolve(config.TASKS_BASE);
-  } catch {
-    /* config unavailable */
-  }
-  throw new Error(
-    'TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).'
-  );
-}
-
-/**
- * Sanitize ticket ID for filesystem paths using config.safeTicketId when available.
- * validateTicketId guarantees at most one slash before this runs.
- * @param {string} ticketId
- * @returns {string}
- */
-function sanitizeId(ticketId) {
-  try {
-    const config = require('./config');
-    if (config && typeof config.safeTicketId === 'function') {
-      // Split to sanitize the base independently so "#123/phase1" → "GH-123/phase1".
-      const slashIdx = ticketId.indexOf('/');
-      if (slashIdx !== -1) {
-        return config.safeTicketId(ticketId.slice(0, slashIdx)) + ticketId.slice(slashIdx);
-      }
-      return config.safeTicketId(ticketId);
-    }
-  } catch {
-    /* config unavailable */
-  }
-  return ticketId;
-}
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
@@ -165,10 +85,7 @@ function allocateOutputFolder(ticketId, context = {}) {
   // Re-validate after sanitization in case safeTicketId introduced unsafe chars
   validateTicketId(safeId);
   const ticketRoot = path.resolve(tasksBase, safeId);
-  // Defense-in-depth: ticket root must be a strict child of TASKS_BASE
-  if (!ticketRoot.startsWith(tasksBase + path.sep)) {
-    throw new Error(`allocateOutputFolder: resolved path escapes TASKS_BASE: ${ticketRoot}`);
-  }
+  assertPathContainment(ticketRoot, tasksBase, 'allocateOutputFolder');
   // ── In-flow task allocation ──────────────────────────────────────────────
   if (context.flow === 'in-flow') {
     if (context.taskNum == null) {

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -49,13 +49,18 @@ function validateTicketId(ticketId) {
   if (ticketId === '.' || ticketId === './') {
     throw new Error('Invalid ticket ID: "." is not a valid ticket ID.');
   }
-  // Reject multiple slashes — only one "/" is allowed (suffix syntax like "GH-219/phase1")
-  if ((ticketId.match(/\//g) || []).length > 1) {
-    throw new Error(`Invalid ticket ID: multiple slashes not allowed: "${ticketId}"`);
-  }
-  // Reject leading slash (absolute path)
+  // Reject leading slash (absolute path escape)
   if (ticketId.startsWith('/')) {
     throw new Error(`Invalid ticket ID: must not start with "/": "${ticketId}"`);
+  }
+  // At most one slash allowed (suffix syntax like "GH-219/phase1").
+  // GitHub URLs are expected to be pre-normalized upstream (see loadEnforcementContext).
+  const slashCount = (ticketId.match(/\//g) || []).length;
+  if (slashCount > 1) {
+    throw new Error(
+      `Invalid ticket ID: at most one "/" allowed (got ${slashCount}). ` +
+      'URLs must be normalized to ticket IDs before calling the allocator.'
+    );
   } }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -149,6 +154,8 @@ function allocateOutputFolder(ticketId, context = {}) {
 
   const tasksBase = resolveTasksBase(); // already path.resolve'd
   const safeId = sanitizeId(ticketId);
+  // Re-validate after sanitization in case safeTicketId introduced unsafe chars
+  validateTicketId(safeId);
   const ticketRoot = path.resolve(tasksBase, safeId);
   // Defense-in-depth: ensure ticket root stays under TASKS_BASE
   if (ticketRoot !== tasksBase && !ticketRoot.startsWith(tasksBase + path.sep)) {

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -65,7 +65,8 @@ function validateTicketId(ticketId) {
     if (!suffix || suffix === '.' || suffix === '..') {
       throw new Error(`Invalid ticket ID: slash must be followed by a valid suffix: "${ticketId}"`);
     }
-  } }
+  }
+}
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -79,13 +80,17 @@ function resolveTasksBase() {
   try {
     const config = require('./config');
     if (config && config.TASKS_BASE) return path.resolve(config.TASKS_BASE);
-  } catch { /* config unavailable */ }
+  } catch {
+    /* config unavailable */
+  }
   throw new Error(
     'TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).'
-  ); } // end resolveTasksBase — checks env then config.TASKS_BASE
+  );
+}
 
 /**
  * Sanitize ticket ID for filesystem paths using config.safeTicketId when available.
+ * validateTicketId guarantees at most one slash before this runs.
  * @param {string} ticketId
  * @returns {string}
  */
@@ -93,15 +98,18 @@ function sanitizeId(ticketId) {
   try {
     const config = require('./config');
     if (config && typeof config.safeTicketId === 'function') {
-      // validateTicketId guarantees at most one slash. Split to sanitize
-      // the base independently so "#123/phase1" → "GH-123/phase1".
+      // Split to sanitize the base independently so "#123/phase1" → "GH-123/phase1".
       const slashIdx = ticketId.indexOf('/');
       if (slashIdx !== -1) {
         return config.safeTicketId(ticketId.slice(0, slashIdx)) + ticketId.slice(slashIdx);
       }
-      return config.safeTicketId(ticketId); }
-  } catch { /* config unavailable */ }
-  return ticketId; } // end sanitizeId — multi-slash rejected by validateTicketId
+      return config.safeTicketId(ticketId);
+    }
+  } catch {
+    /* config unavailable */
+  }
+  return ticketId;
+}
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
@@ -157,10 +165,10 @@ function allocateOutputFolder(ticketId, context = {}) {
   // Re-validate after sanitization in case safeTicketId introduced unsafe chars
   validateTicketId(safeId);
   const ticketRoot = path.resolve(tasksBase, safeId);
-  // Defense-in-depth: ensure ticket root stays under TASKS_BASE
-  if (ticketRoot !== tasksBase && !ticketRoot.startsWith(tasksBase + path.sep)) {
+  // Defense-in-depth: ticket root must be a strict child of TASKS_BASE
+  if (!ticketRoot.startsWith(tasksBase + path.sep)) {
     throw new Error(`allocateOutputFolder: resolved path escapes TASKS_BASE: ${ticketRoot}`);
-  } // path-containment verified
+  }
   // ── In-flow task allocation ──────────────────────────────────────────────
   if (context.flow === 'in-flow') {
     if (context.taskNum == null) {

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -116,7 +116,7 @@ function allocateOutputFolder(ticketId, context = {}) {
       }
       const n = context.counters.aiRequestNext;
       if (!Number.isInteger(n) || n < 1) {
-        throw new Error(`Invalid aiRequestNext counter: expected positive integer, got ${JSON.stringify(n)}`);
+        throw new Error(`Invalid aiRequestNext counter: expected positive integer, got ${String(n)}`);
       }
       const seg = `${AI_REQUEST_PREFIX}${n}`; // counter validated above
       return {
@@ -136,7 +136,7 @@ function allocateOutputFolder(ticketId, context = {}) {
     }
     const n = context.counters.userRequestNext;
     if (!Number.isInteger(n) || n < 1) {
-      throw new Error(`Invalid userRequestNext counter: expected positive integer, got ${JSON.stringify(n)}`);
+      throw new Error(`Invalid userRequestNext counter: expected positive integer, got ${String(n)}`);
     }
     const seg = `${USER_REQUEST_PREFIX}${n}`;
     return {
@@ -147,9 +147,13 @@ function allocateOutputFolder(ticketId, context = {}) {
     };
   }
 
+  // ── Reject unknown flow values ───────────────────────────────────────────
+  if (context.flow != null && context.flow !== 'in-flow' && context.flow !== 'out-of-flow') {
+    throw new Error(`Unknown flow type: ${String(context.flow)}. Expected "in-flow", "out-of-flow", or undefined.`);
+  }
+
   // ── Legacy-root fallback ─────────────────────────────────────────────────
   // No flow/task context: return the ticket root directory.
-  // Pairs with tdd-phase-state.js backward-compat legacy read path.
   return {
     kind: 'legacy-root',
     segment: null,

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -1,0 +1,220 @@
+/**
+ * allocate-output-folder.js
+ *
+ * Central allocator for /work-implement destination resolution (GH-219 Task 9).
+ *
+ * Given a ticket ID and context, returns the correct absolute base directory:
+ *
+ *   - In-flow (workflow origin, claimed task): TASKS_BASE/<ticketId>/task${N}/
+ *   - Out-of-flow user:  TASKS_BASE/<ticketId>/user-request-${k}/  (stub -- Task 10 wires counters)
+ *   - Out-of-flow AI:    TASKS_BASE/<ticketId>/ai-request-${k}/    (stub -- Task 10 wires counters)
+ *   - Legacy-root:       TASKS_BASE/<ticketId>/                     (backward-compat fallback)
+ *
+ * R7 single source of truth: the `task${N}` naming is produced exclusively by
+ * taskSegment(). Other modules must consume this rather than rebuilding the
+ * segment string.
+ *
+ * @module allocate-output-folder
+ */
+
+const path = require('path');
+
+// ─── Constants (R7 naming policy) ────────────────────────────────────────────
+
+const TASK_SEGMENT_PREFIX = 'task';
+const USER_REQUEST_PREFIX = 'user-request-';
+const AI_REQUEST_PREFIX = 'ai-request-';
+
+// ─── Ticket ID validation (R15 fail-closed) ─────────────────────────────────
+
+/** @type {RegExp} Reject path-traversal sequences, backslashes, and null bytes */
+const UNSAFE_TICKET_RE = /\.\.|[\\]|\x00/;
+
+/**
+ * Validate and reject unsafe ticket IDs before any filesystem I/O.
+ * @param {unknown} ticketId
+ */
+function validateTicketId(ticketId) {
+  if (typeof ticketId !== 'string' || ticketId.length === 0) {
+    throw new Error(
+      `Invalid ticket ID: expected non-empty string, received ${typeof ticketId === 'string' ? '""' : typeof ticketId}`
+    );
+  }
+  if (UNSAFE_TICKET_RE.test(ticketId)) {
+    throw new Error(
+      `Invalid ticket ID: contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`
+    );
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve TASKS_BASE from environment or config module.
+ * @returns {string}
+ */
+function resolveTasksBase() {
+  // Check process.env directly — callers (hooks, CLI) always set TASKS_BASE.
+  // Do not fall back to config cache: config.TASKS_BASE is set at module-load
+  // time and becomes stale if the env var is later removed (e.g., in tests).
+  if (process.env.TASKS_BASE) return process.env.TASKS_BASE;
+
+  throw new Error(
+    'TASKS_BASE is not configured. Set the TASKS_BASE environment variable.'
+  );
+}
+
+/**
+ * Sanitize ticket ID for filesystem paths using config.safeTicketId when available.
+ * @param {string} ticketId
+ * @returns {string}
+ */
+function sanitizeId(ticketId) {
+  try {
+    const config = require('./config');
+    if (config && typeof config.safeTicketId === 'function') {
+      return config.safeTicketId(ticketId);
+    }
+  } catch {
+    // fallback to raw ID
+  }
+  return ticketId;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Produce the canonical `task${N}` segment name (R7 single source of truth).
+ *
+ * @param {number} taskNum - Positive integer task number
+ * @returns {string} e.g. "task1", "task9", "task42"
+ * @throws {Error} if taskNum is not a positive integer
+ */
+function taskSegment(taskNum) {
+  if (
+    typeof taskNum !== 'number' ||
+    !Number.isInteger(taskNum) ||
+    taskNum < 1
+  ) {
+    throw new Error(
+      `Invalid taskNum: expected positive integer, received ${JSON.stringify(taskNum)}`
+    );
+  }
+  return `${TASK_SEGMENT_PREFIX}${taskNum}`;
+}
+
+/**
+ * @typedef {Object} AllocationResult
+ * @property {'in-flow-task'|'out-of-flow-user'|'out-of-flow-ai'|'legacy-root'} kind
+ * @property {string|null} segment - Directory segment name (e.g. "task9", "user-request-4"), or null for legacy-root
+ * @property {string} root - Absolute path to the allocated directory
+ * @property {string} ticketRoot - Absolute path to the ticket-level directory
+ */
+
+/**
+ * Allocate the correct output folder for a /work-implement invocation.
+ *
+ * @param {string} ticketId - Ticket ID (e.g. "GH-219")
+ * @param {object} [context={}] - Allocation context
+ * @param {string} [context.origin] - Origin type: "workflow", "ai-subtask", "user"
+ * @param {string} [context.flow] - Flow type: "in-flow", "out-of-flow"
+ * @param {number} [context.taskNum] - Task number (required for in-flow)
+ * @param {number} [context.prSlot] - PR slot number (informational)
+ * @param {number} [context.subtaskIndex] - Subtask index
+ * @param {object} [context.counters] - Out-of-flow counters (Task 10 wires these)
+ * @param {number} [context.counters.userRequestNext] - Next user-request counter
+ * @param {number} [context.counters.aiRequestNext] - Next ai-request counter
+ * @returns {AllocationResult}
+ */
+function allocateOutputFolder(ticketId, context = {}) {
+  // R15: validate ticket ID before any I/O
+  validateTicketId(ticketId);
+
+  const tasksBase = resolveTasksBase();
+  const safeId = sanitizeId(ticketId);
+  const ticketRoot = path.join(tasksBase, safeId);
+  // Defense-in-depth: ensure ticket root stays under TASKS_BASE
+  const resolvedRoot = path.resolve(ticketRoot);
+  const resolvedBase = path.resolve(tasksBase);
+  if (resolvedRoot !== resolvedBase && !resolvedRoot.startsWith(resolvedBase + path.sep)) {
+    throw new Error(`allocateOutputFolder: resolved path escapes TASKS_BASE: ${ticketRoot}`);
+  } // path-containment verified
+  // ── In-flow task allocation ──────────────────────────────────────────────
+  if (context.flow === 'in-flow') {
+    if (context.taskNum == null) {
+      throw new Error(
+        'In-flow allocation requires taskNum. Pass context.taskNum with the claimed task number.'
+      );
+    }
+    const seg = taskSegment(context.taskNum);
+    return {
+      kind: 'in-flow-task',
+      segment: seg,
+      root: path.join(ticketRoot, seg),
+      ticketRoot,
+    };
+  }
+
+  // ── Out-of-flow allocation ───────────────────────────────────────────────
+  if (context.flow === 'out-of-flow') {
+    const isAi =
+      context.origin === 'ai-subtask' || context.origin === 'ai';
+
+    if (isAi) {
+      if (!context.counters || context.counters.aiRequestNext == null) {
+        throw new Error(
+          'Out-of-flow AI allocation requires counters.aiRequestNext. ' +
+          'Task 10 will wire the real .request-index.json counter.'
+        );
+      }
+      const n = context.counters.aiRequestNext;
+      if (!Number.isInteger(n) || n < 1) {
+        throw new Error(`Invalid aiRequestNext counter: expected positive integer, got ${JSON.stringify(n)}`);
+      }
+      const seg = `${AI_REQUEST_PREFIX}${n}`; // counter validated above
+      return {
+        kind: 'out-of-flow-ai',
+        segment: seg,
+        root: path.join(ticketRoot, seg),
+        ticketRoot,
+      };
+    }
+
+    // User origin (default for out-of-flow)
+    if (!context.counters || context.counters.userRequestNext == null) {
+      throw new Error(
+        'Out-of-flow user allocation requires counters.userRequestNext. ' +
+        'Task 10 will wire the real .request-index.json counter.'
+      );
+    }
+    const n = context.counters.userRequestNext;
+    if (!Number.isInteger(n) || n < 1) {
+      throw new Error(`Invalid userRequestNext counter: expected positive integer, got ${JSON.stringify(n)}`);
+    }
+    const seg = `${USER_REQUEST_PREFIX}${n}`;
+    return {
+      kind: 'out-of-flow-user',
+      segment: seg,
+      root: path.join(ticketRoot, seg),
+      ticketRoot,
+    };
+  }
+
+  // ── Legacy-root fallback ─────────────────────────────────────────────────
+  // No flow/task context: return the ticket root directory.
+  // Pairs with tdd-phase-state.js backward-compat legacy read path.
+  return {
+    kind: 'legacy-root',
+    segment: null,
+    root: ticketRoot,
+    ticketRoot,
+  };
+}
+
+module.exports = {
+  allocateOutputFolder,
+  taskSegment,
+  TASK_SEGMENT_PREFIX,
+  USER_REQUEST_PREFIX,
+  AI_REQUEST_PREFIX,
+};

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -57,10 +57,14 @@ function validateTicketId(ticketId) {
   // GitHub URLs are expected to be pre-normalized upstream (see loadEnforcementContext).
   const slashCount = (ticketId.match(/\//g) || []).length;
   if (slashCount > 1) {
-    throw new Error(
-      `Invalid ticket ID: at most one "/" allowed (got ${slashCount}). ` +
-      'URLs must be normalized to ticket IDs before calling the allocator.'
-    );
+    throw new Error(`Invalid ticket ID: at most one "/" allowed (got ${slashCount}).`);
+  }
+  // Reject trailing slash or dot-suffix (e.g. "GH-219/", "GH-219/.")
+  if (slashCount === 1) {
+    const suffix = ticketId.slice(ticketId.indexOf('/') + 1);
+    if (!suffix || suffix === '.' || suffix === '..') {
+      throw new Error(`Invalid ticket ID: slash must be followed by a valid suffix: "${ticketId}"`);
+    }
   } }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -89,15 +93,11 @@ function sanitizeId(ticketId) {
   try {
     const config = require('./config');
     if (config && typeof config.safeTicketId === 'function') {
-      // Only split on "/" when there's exactly one slash (suffix syntax).
-      // Multiple slashes indicate a URL or invalid input — pass through
-      // to safeTicketId which handles URL parsing internally.
-      const slashes = (ticketId.match(/\//g) || []).length;
-      if (slashes === 1) {
-        const slashIdx = ticketId.indexOf('/');
-        const base = ticketId.slice(0, slashIdx);
-        const suffix = ticketId.slice(slashIdx);
-        return config.safeTicketId(base) + suffix;
+      // validateTicketId guarantees at most one slash. Split to sanitize
+      // the base independently so "#123/phase1" → "GH-123/phase1".
+      const slashIdx = ticketId.indexOf('/');
+      if (slashIdx !== -1) {
+        return config.safeTicketId(ticketId.slice(0, slashIdx)) + ticketId.slice(slashIdx);
       }
       return config.safeTicketId(ticketId); }
   } catch { /* config unavailable */ }

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -66,7 +66,7 @@ function resolveTasksBase() {
   } catch { /* config unavailable */ }
   throw new Error(
     'TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).'
-  ); // also checks config.TASKS_BASE as fallback above
+  ); // env → config.TASKS_BASE → throw
 }
 
 /**
@@ -78,20 +78,20 @@ function sanitizeId(ticketId) {
   try {
     const config = require('./config');
     if (config && typeof config.safeTicketId === 'function') {
-      // Split on "/" to sanitize base separately from suffix,
-      // so "#123/phase1" → "GH-123/phase1" (not left as-is).
-      const slashIdx = ticketId.indexOf('/');
-      if (slashIdx !== -1) {
+      // Only split on "/" when there's exactly one slash (suffix syntax).
+      // Multiple slashes indicate a URL or invalid input — pass through
+      // to safeTicketId which handles URL parsing internally.
+      const slashes = (ticketId.match(/\//g) || []).length;
+      if (slashes === 1) {
+        const slashIdx = ticketId.indexOf('/');
         const base = ticketId.slice(0, slashIdx);
         const suffix = ticketId.slice(slashIdx);
         return config.safeTicketId(base) + suffix;
       }
       return config.safeTicketId(ticketId);
     }
-  } catch {
-    // fallback to raw ID
-  }
-  return ticketId; // raw fallback when config unavailable
+  } catch { /* fallback to raw ID */ }
+  return ticketId;
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────
@@ -161,9 +161,9 @@ function allocateOutputFolder(ticketId, context = {}) {
     return {
       kind: 'in-flow-task',
       segment: seg,
-      root: path.join(ticketRoot, seg), // absolute — tasksBase is resolved
+      root: path.resolve(ticketRoot, seg),
       ticketRoot,
-    };
+    }; // in-flow result — paths are absolute (tasksBase resolved)
   }
 
   // ── Out-of-flow allocation ───────────────────────────────────────────────

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -45,6 +45,10 @@ function validateTicketId(ticketId) {
       `Invalid ticket ID: contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`
     );
   }
+  // Reject bare dot segments that would resolve to TASKS_BASE itself
+  if (ticketId === '.' || ticketId === './') {
+    throw new Error('Invalid ticket ID: "." is not a valid ticket ID.');
+  }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -54,13 +58,14 @@ function validateTicketId(ticketId) {
  * @returns {string}
  */
 function resolveTasksBase() {
-  // Check process.env directly — callers (hooks, CLI) always set TASKS_BASE.
-  // Do not fall back to config cache: config.TASKS_BASE is set at module-load
-  // time and becomes stale if the env var is later removed (e.g., in tests).
-  if (process.env.TASKS_BASE) return process.env.TASKS_BASE;
-
+  if (process.env.TASKS_BASE) return path.resolve(process.env.TASKS_BASE);
+  // Fall back to config.TASKS_BASE (derived from WORKTREES_BASE in .envrc)
+  try {
+    const config = require('./config');
+    if (config && config.TASKS_BASE) return path.resolve(config.TASKS_BASE);
+  } catch { /* config unavailable */ }
   throw new Error(
-    'TASKS_BASE is not configured. Set the TASKS_BASE environment variable.'
+    'TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).'
   );
 }
 
@@ -73,6 +78,14 @@ function sanitizeId(ticketId) {
   try {
     const config = require('./config');
     if (config && typeof config.safeTicketId === 'function') {
+      // Split on "/" to sanitize base separately from suffix,
+      // so "#123/phase1" → "GH-123/phase1" (not left as-is).
+      const slashIdx = ticketId.indexOf('/');
+      if (slashIdx !== -1) {
+        const base = ticketId.slice(0, slashIdx);
+        const suffix = ticketId.slice(slashIdx);
+        return config.safeTicketId(base) + suffix;
+      }
       return config.safeTicketId(ticketId);
     }
   } catch {
@@ -130,13 +143,11 @@ function allocateOutputFolder(ticketId, context = {}) {
   // R15: validate ticket ID before any I/O
   validateTicketId(ticketId);
 
-  const tasksBase = resolveTasksBase();
+  const tasksBase = resolveTasksBase(); // already path.resolve'd
   const safeId = sanitizeId(ticketId);
-  const ticketRoot = path.join(tasksBase, safeId);
+  const ticketRoot = path.resolve(tasksBase, safeId);
   // Defense-in-depth: ensure ticket root stays under TASKS_BASE
-  const resolvedRoot = path.resolve(ticketRoot);
-  const resolvedBase = path.resolve(tasksBase);
-  if (resolvedRoot !== resolvedBase && !resolvedRoot.startsWith(resolvedBase + path.sep)) {
+  if (ticketRoot !== tasksBase && !ticketRoot.startsWith(tasksBase + path.sep)) {
     throw new Error(`allocateOutputFolder: resolved path escapes TASKS_BASE: ${ticketRoot}`);
   } // path-containment verified
   // ── In-flow task allocation ──────────────────────────────────────────────

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -44,7 +44,7 @@ function validateTicketId(ticketId) {
     throw new Error(
       `Invalid ticket ID: contains unsafe characters (path traversal, backslash, or null byte): "${ticketId}"`
     );
-  }
+  } // end unsafe char check
   // Reject bare dot segments that would resolve to TASKS_BASE itself
   if (ticketId === '.' || ticketId === './') {
     throw new Error('Invalid ticket ID: "." is not a valid ticket ID.');
@@ -66,7 +66,7 @@ function resolveTasksBase() {
   } catch { /* config unavailable */ }
   throw new Error(
     'TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).'
-  );
+  ); // also checks config.TASKS_BASE as fallback above
 }
 
 /**
@@ -91,7 +91,7 @@ function sanitizeId(ticketId) {
   } catch {
     // fallback to raw ID
   }
-  return ticketId;
+  return ticketId; // raw fallback when config unavailable
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────
@@ -161,7 +161,7 @@ function allocateOutputFolder(ticketId, context = {}) {
     return {
       kind: 'in-flow-task',
       segment: seg,
-      root: path.join(ticketRoot, seg),
+      root: path.join(ticketRoot, seg), // absolute — tasksBase is resolved
       ticketRoot,
     };
   }


### PR DESCRIPTION
## Existing Behavior

- No single canonical allocator exists for resolving /work-implement output destinations; each hook or workflow step rebuilds the `task${N}` segment string independently, violating R7 (single source of truth).
- Path containment against `TASKS_BASE` is unenforced at the allocation layer, allowing path-traversal ticket IDs to escape the worktrees directory.
- Out-of-flow (user/AI sub-task) allocations have no defined naming policy or counter injection contract, making Task 10 wiring undefined.

## Intended New Behavior

- `workflows/lib/allocate-output-folder.js` is the single allocator for /work-implement destination resolution: in-flow tasks resolve to `TASKS_BASE/<ticket>/task${N}/`, out-of-flow user to `user-request-${k}/`, out-of-flow AI to `ai-request-${k}/`, and uncontextualized calls fall back to `legacy-root` (R7 single source of truth).
- `taskSegment(N)` is the one canonical producer of the `task${N}` name; all other modules must consume it rather than rebuilding the segment string.
- R15 fail-closed validation rejects path-traversal sequences, backslashes, null bytes, leading slashes, bare dots, and multi-slash ticket IDs before any filesystem I/O.
- Defense-in-depth path containment ensures the resolved ticket root cannot escape `TASKS_BASE` after sanitization via `config.safeTicketId`.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Run the test suite directly with Node's built-in test runner:

```
node --test workflows/lib/__tests__/allocate-output-folder.test.js
```

Expected: all test cases pass covering:
1. API surface — `allocateOutputFolder`, `taskSegment`, and prefix constants exported correctly
2. `taskSegment` — canonical `task${N}` form, rejects non-positive/non-integer input
3. In-flow task allocation — returns `TASKS_BASE/<ticket>/task${N}/`, deterministic across identical contexts, shares `taskSegment()` for naming
4. Out-of-flow allocation — user gets `user-request-${k}/`, AI gets `ai-request-${k}/`, fails closed when counters are missing
5. Legacy-root fallback — returns ticket root with `kind: 'legacy-root'` when no flow context is supplied
6. R15 ticket ID validation — rejects empty/null/undefined, path traversal, bare dots, leading slash, multi-slash, and URLs
7. `TASKS_BASE` resolution — resolved root includes the env-var path

Closes #219 (PR 3a/6)

### Test Results

Run: `node --test workflows/lib/__tests__/allocate-output-folder.test.js`