### PR TITLE
feat(preflight): shared gate library with audit support (#219 PR 3b/6)

### DIFF
--- a/workflows/lib/__tests__/preflight.test.js
+++ b/workflows/lib/__tests__/preflight.test.js
@@ -1,0 +1,1324 @@
+/**
+ * Tests for workflows/lib/preflight.js
+ *
+ * IDEA2 / GH-219 — Task 3: Preflight library with audit hook.
+ *
+ * Requirements covered:
+ *   R12 — Single `runPreflight(context, { audit, checks })` surface returning
+ *         `{ allow, reasons, remediation }`; hooks consume; `audit` optional
+ *         no-op in tests (spec §Pattern — preflight).
+ *   R13 — Wiring contract only — persistence lives in Task 1's
+ *         `appendEnforcementAudit`. Preflight MUST NOT import `work-actions.js`
+ *         to keep coupling low; callers inject the audit callback.
+ *
+ * Context shape contract (from Task 2, `workflows/work/work-enforcement-context.js`):
+ *   EnforcementContext = {
+ *     ticketId, origin, state, tasks, subtaskState, hasWorkflow, error, options
+ *   }
+ *   EnforcementContextError = { code, message, remediation[] }
+ *
+ * Run: node --test workflows/lib/__tests__/preflight.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const MODULE_PATH = path.join(__dirname, '..', 'preflight');
+
+// ─── R12 — Module surface / exports ─────────────────────────────────────────
+
+describe('preflight — module surface (R12)', () => {
+  it('exports runPreflight as a function', () => {
+    const mod = require(MODULE_PATH);
+    assert.equal(typeof mod.runPreflight, 'function', 'runPreflight must be exported as a function');
+  });
+
+  it('runPreflight has arity 2 (context, options) per the documented contract', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.equal(
+      runPreflight.length,
+      2,
+      'runPreflight(context, options) must have exactly 2 declared parameters'
+    );
+  });
+
+  it('has a stable public export shape (Task 12 adds isWriteAllowedPath)', () => {
+    const mod = require(MODULE_PATH);
+    const exported = Object.keys(mod).sort();
+
+    // Task 3 exported only `runPreflight`. Task 12 adds `isWriteAllowedPath`
+    // as the shared path predicate consumed by hooks (Tasks 13-14).
+    // Also adds built-in check factories: `createGraphCheck`, `createClaimCheck`, `createPathCheck`.
+    assert.deepEqual(
+      exported,
+      ['createClaimCheck', 'createGraphCheck', 'createPathCheck', 'isWriteAllowedPath', 'runPreflight'],
+      `preflight module must export { createClaimCheck, createGraphCheck, createPathCheck, isWriteAllowedPath, runPreflight }; got: ${exported.join(', ')}`
+    );
+  });
+
+  it('does NOT import work-actions.js (keeps preflight / persistence decoupled — R13)', () => {
+    // Load preflight fresh and introspect module.children to verify no
+    // transitive dependency on work-actions. This enforces the "do NOT import
+    // work-actions.js" rule in the Task 3 spec.
+    delete require.cache[require.resolve(MODULE_PATH)];
+    require(MODULE_PATH);
+    const loaded = require.cache[require.resolve(MODULE_PATH)];
+    const childIds = (loaded.children || []).map((c) => c.id);
+
+    for (const id of childIds) {
+      assert.ok(
+        !/work-actions(\.js)?$/.test(id),
+        `preflight must not require work-actions (found: ${id}). ` +
+          'Audit persistence is injected by callers via options.audit.'
+      );
+    }
+  });
+});
+
+// ─── R12 — Happy path (empty context, no checks) ────────────────────────────
+
+describe('preflight — empty context / happy path (R12)', () => {
+  it('returns { allow: true, reasons: [], remediation: [] } when context has no error and no checks', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const ctx = { ticketId: 'GH-1', origin: 'user', error: null };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, true, 'empty/valid context allows by default (spec §Preflight API)');
+    assert.deepEqual(result.reasons, [], 'no reasons on allow path');
+    assert.deepEqual(result.remediation, [], 'no remediation on allow path');
+  });
+
+  it('returns the full { allow, reasons, remediation } shape on every call', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null });
+
+    assert.ok('allow' in result, 'result.allow key present');
+    assert.ok('reasons' in result, 'result.reasons key present');
+    assert.ok('remediation' in result, 'result.remediation key present');
+    assert.equal(typeof result.allow, 'boolean', 'allow is a boolean');
+    assert.ok(Array.isArray(result.reasons), 'reasons is an array');
+    assert.ok(Array.isArray(result.remediation), 'remediation is an array');
+  });
+
+  it('does not throw when options is undefined (arity-2 default)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null });
+    }, 'runPreflight must be callable with just a context argument');
+  });
+
+  it('does not throw when options is {} (empty options object)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, {});
+    }, 'runPreflight must accept an empty options object');
+  });
+});
+
+// ─── R12 — context.error denies fail-closed ─────────────────────────────────
+
+describe('preflight — context.error denial (R12, R15 chain)', () => {
+  it('context.error with code → allow: false, reasons: [error.code]', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'user',
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: '--subtask set but no subtask state',
+        remediation: ['Initialize subtask first', 'Remove --subtask flag'],
+      },
+    };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, false, 'context.error must force deny');
+    assert.deepEqual(
+      result.reasons,
+      ['AMBIGUOUS_SUBTASK'],
+      'reasons carries the error.code as a stable rule id'
+    );
+    assert.deepEqual(
+      result.remediation,
+      ['Initialize subtask first', 'Remove --subtask flag'],
+      'error.remediation is passed through verbatim'
+    );
+  });
+
+  it('context.error without remediation → remediation defaults to [] (never undefined)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'user',
+      error: { code: 'INVALID_TICKET_ID', message: 'bad id' },
+    };
+
+    const result = runPreflight(ctx);
+
+    assert.equal(result.allow, false);
+    assert.deepEqual(result.reasons, ['INVALID_TICKET_ID']);
+    assert.ok(Array.isArray(result.remediation), 'remediation is always an array');
+    assert.deepEqual(result.remediation, [], 'missing remediation becomes []');
+  });
+
+  it('truthy non-object error value is ignored (must be an object with a code)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    // Guard: strings/numbers for error should NOT trigger deny — spec says
+    // "truthy object with code". This enforces the shape discipline.
+    for (const bad of ['string-error', 42, true]) {
+      const ctx = { ticketId: 'GH-1', origin: 'user', error: bad };
+      const result = runPreflight(ctx);
+      assert.equal(
+        result.allow,
+        true,
+        `non-object error=${JSON.stringify(bad)} must not force deny`
+      );
+    }
+  });
+
+  it('error object without a code is ignored (no denial, no crash)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const ctx = { ticketId: 'GH-1', origin: 'user', error: { message: 'no code here' } };
+    const result = runPreflight(ctx);
+    assert.equal(result.allow, true, 'error lacking a stable code must not deny');
+    assert.deepEqual(result.reasons, []);
+    assert.deepEqual(result.remediation, []);
+  });
+});
+
+// ─── R12 — audit default no-op (undefined-safe) ─────────────────────────────
+
+describe('preflight — audit default no-op (R12)', () => {
+  it('does not throw when options.audit is undefined on allow path', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, {});
+    });
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null });
+    });
+  });
+
+  it('does not throw when options.audit is undefined on deny path', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight(
+        {
+          ticketId: 'GH-1',
+          origin: 'user',
+          error: { code: 'X', message: 'y', remediation: [] },
+        },
+        {}
+      );
+    });
+  });
+
+  it('does not throw when options itself is null', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, null);
+    });
+  });
+});
+
+// ─── R12 — audit called on ALLOW path with correct entry shape ──────────────
+
+describe('preflight — audit called on ALLOW path (R12)', () => {
+  it('invokes audit with { decision: "allow", reasons: [], origin, ticketId } on happy path', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const audit = (entry) => audited.push(entry);
+
+    const ctx = { ticketId: 'GH-42', origin: 'workflow', error: null };
+    const result = runPreflight(ctx, { audit });
+
+    assert.equal(result.allow, true);
+    assert.equal(audited.length, 1, 'audit should be called exactly once per decision');
+
+    const entry = audited[0];
+    assert.equal(entry.decision, 'allow', 'allow path uses decision="allow"');
+    assert.deepEqual(entry.reasons, [], 'empty reasons on allow');
+    assert.equal(entry.origin, 'workflow', 'audit entry echoes context.origin');
+    assert.equal(entry.ticketId, 'GH-42', 'audit entry echoes context.ticketId');
+  });
+
+  it('audit entry is a plain object (single positional arg) — stable callback signature', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    let receivedArgs;
+    const audit = function (...args) {
+      receivedArgs = args;
+    };
+
+    runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { audit });
+
+    assert.ok(receivedArgs, 'audit should have been invoked');
+    assert.equal(receivedArgs.length, 1, 'audit takes exactly one positional argument');
+    assert.equal(
+      typeof receivedArgs[0],
+      'object',
+      'audit argument is an object (compatible with appendEnforcementAudit entry shape)'
+    );
+    assert.ok(receivedArgs[0] !== null, 'audit argument is not null');
+  });
+
+  it('audit entry shape is compatible with appendEnforcementAudit (forward-compatible fields)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    runPreflight(
+      { ticketId: 'GH-42', origin: 'workflow', error: null },
+      { audit: (e) => audited.push(e) }
+    );
+
+    const entry = audited[0];
+    // Brief-required fields on enforcement audit records (Task 1 shape).
+    // Preflight produces a superset-compatible entry that callers can
+    // forward directly to appendEnforcementAudit.
+    for (const key of ['decision', 'reasons', 'origin', 'ticketId']) {
+      assert.ok(
+        key in entry,
+        `audit entry must include "${key}" for forward-compat with appendEnforcementAudit`
+      );
+    }
+  });
+});
+
+// ─── R12 — audit called on DENY path ────────────────────────────────────────
+
+describe('preflight — audit called on DENY path (R12)', () => {
+  it('invokes audit with { decision: "deny", reasons, origin, ticketId } when context.error denies', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const audit = (entry) => audited.push(entry);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'user',
+      error: {
+        code: 'AMBIGUOUS_SUBTASK',
+        message: 'oops',
+        remediation: ['fix step 1'],
+      },
+    };
+
+    const result = runPreflight(ctx, { audit });
+
+    assert.equal(result.allow, false);
+    assert.equal(audited.length, 1, 'audit called once for the deny decision');
+
+    const entry = audited[0];
+    assert.equal(entry.decision, 'deny');
+    assert.deepEqual(entry.reasons, ['AMBIGUOUS_SUBTASK']);
+    assert.equal(entry.origin, 'user');
+    assert.equal(entry.ticketId, 'GH-219');
+  });
+
+  it('deny audit entry preserves remediation for downstream explainability (R18 seed)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    let seen;
+    runPreflight(
+      {
+        ticketId: 'GH-219',
+        origin: 'user',
+        error: {
+          code: 'INVALID_TICKET_ID',
+          message: 'bad',
+          remediation: ['Use a valid id', 'Check env vars'],
+        },
+      },
+      { audit: (e) => (seen = e) }
+    );
+
+    assert.ok(seen, 'audit called on deny');
+    assert.ok(
+      Array.isArray(seen.remediation) && seen.remediation.length === 2,
+      'remediation is forwarded to audit entry for explainability'
+    );
+  });
+
+  it('preflight does not throw when the audit callback itself throws (fail-open on logging)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const throwingAudit = () => {
+      throw new Error('disk full');
+    };
+
+    // Persistence failures must never break enforcement decisions. This
+    // mirrors work-actions.js appendRow() fail-open behavior.
+    assert.doesNotThrow(() => {
+      runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { audit: throwingAudit });
+    });
+    assert.doesNotThrow(() => {
+      runPreflight(
+        { ticketId: 'GH-1', origin: 'user', error: { code: 'X', message: 'y' } },
+        { audit: throwingAudit }
+      );
+    });
+  });
+});
+
+// ─── R12 — options.checks pluggable composition ─────────────────────────────
+
+describe('preflight — pluggable checks (R12, §Pattern — pluggable checks)', () => {
+  it('runs checks in declared order', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const callOrder = [];
+
+    const checks = [
+      (ctx) => {
+        callOrder.push('A');
+        return null;
+      },
+      (ctx) => {
+        callOrder.push('B');
+        return null;
+      },
+      (ctx) => {
+        callOrder.push('C');
+        return null;
+      },
+    ];
+
+    runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+    assert.deepEqual(callOrder, ['A', 'B', 'C'], 'checks invoked in declared order');
+  });
+
+  it('all checks returning null/allow → final result is allow with empty reasons', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => null,
+      () => ({ allow: true }),
+      () => ({ allow: true, reasons: [], remediation: [] }),
+    ];
+
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, true);
+    assert.deepEqual(result.reasons, []);
+    assert.deepEqual(result.remediation, []);
+  });
+
+  it('one check returning { allow: false, ... } → deny result', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => null,
+      () => ({ allow: false, reasons: ['RULE_X'], remediation: ['fix x'] }),
+    ];
+
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, false, 'any denying check forces deny');
+    assert.ok(result.reasons.includes('RULE_X'), 'reason from denying check is included');
+    assert.ok(result.remediation.includes('fix x'), 'remediation from denying check is merged');
+  });
+
+  it('multiple denying checks → reasons aggregated, remediation merged', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => ({ allow: false, reasons: ['RULE_A'], remediation: ['fix A'] }),
+      () => ({ allow: false, reasons: ['RULE_B'], remediation: ['fix B', 'also fix B2'] }),
+    ];
+
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, false);
+    assert.ok(result.reasons.includes('RULE_A'), 'first denying check reason present');
+    assert.ok(result.reasons.includes('RULE_B'), 'second denying check reason present');
+    assert.ok(result.remediation.includes('fix A'));
+    assert.ok(result.remediation.includes('fix B'));
+    assert.ok(result.remediation.includes('also fix B2'));
+  });
+
+  it('checks compose with context.error: error denial is included in final reasons', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'user',
+      error: { code: 'CTX_ERR', message: 'err', remediation: ['ctx fix'] },
+    };
+
+    const checks = [() => ({ allow: false, reasons: ['RULE_Z'], remediation: ['z fix'] })];
+
+    const result = runPreflight(ctx, { checks });
+
+    assert.equal(result.allow, false);
+    assert.ok(
+      result.reasons.includes('CTX_ERR') || result.reasons.includes('RULE_Z'),
+      'at least one deny reason present (context error + checks compose)'
+    );
+  });
+
+  it('check returning undefined is treated as "no opinion" (allow passthrough)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [() => undefined, () => ({ allow: true })];
+    const result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+
+    assert.equal(result.allow, true, 'undefined/null check results are benign (spec §pluggable)');
+    assert.deepEqual(result.reasons, []);
+  });
+
+  it('check throwing does not crash preflight (isolated check failure)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const checks = [
+      () => {
+        throw new Error('check crashed');
+      },
+      () => ({ allow: true }),
+    ];
+
+    // A single check should not poison the whole pipeline. Fail-closed on
+    // the crashing check (treat as deny with a synthetic reason) is
+    // acceptable; what matters is we never throw out of runPreflight.
+    let result;
+    assert.doesNotThrow(() => {
+      result = runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks });
+    });
+    assert.ok(result, 'result returned even when a check threw');
+    assert.equal(typeof result.allow, 'boolean');
+  });
+
+  it('checks receive the full context as their sole argument', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    let seenContext;
+    const checks = [
+      (ctx) => {
+        seenContext = ctx;
+        return null;
+      },
+    ];
+
+    const inputCtx = {
+      ticketId: 'GH-99',
+      origin: 'ai-subtask',
+      state: { status: 'in_progress' },
+      tasks: [{ id: 'task_1', num: 1 }],
+      subtaskState: null,
+      hasWorkflow: true,
+      error: null,
+      options: { subtask: true },
+    };
+
+    runPreflight(inputCtx, { checks });
+
+    assert.ok(seenContext, 'check was invoked with a context');
+    assert.equal(seenContext.ticketId, 'GH-99', 'checks receive full context.ticketId');
+    assert.equal(seenContext.origin, 'ai-subtask', 'checks receive full context.origin');
+    assert.equal(seenContext.hasWorkflow, true, 'checks receive full context.hasWorkflow');
+  });
+});
+
+// ─── R12 — audit receives final decision shape after checks compose ─────────
+
+describe('preflight — audit integration with checks', () => {
+  it('audit called once with final aggregated reasons after checks compose (deny path)', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const audit = (e) => audited.push(e);
+
+    const checks = [
+      () => ({ allow: false, reasons: ['RULE_A'], remediation: ['fix A'] }),
+      () => ({ allow: false, reasons: ['RULE_B'], remediation: ['fix B'] }),
+    ];
+
+    runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }, { checks, audit });
+
+    assert.equal(audited.length, 1, 'audit invoked once per runPreflight call');
+    assert.equal(audited[0].decision, 'deny');
+    assert.ok(audited[0].reasons.includes('RULE_A'));
+    assert.ok(audited[0].reasons.includes('RULE_B'));
+  });
+
+  it('audit called with decision="allow" when all checks allow', () => {
+    const { runPreflight } = require(MODULE_PATH);
+
+    const audited = [];
+    const checks = [() => ({ allow: true }), () => null];
+
+    runPreflight(
+      { ticketId: 'GH-1', origin: 'user', error: null },
+      { checks, audit: (e) => audited.push(e) }
+    );
+
+    assert.equal(audited.length, 1);
+    assert.equal(audited[0].decision, 'allow');
+    assert.deepEqual(audited[0].reasons, []);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Task 12 — Preflight rules integration (graph, claim, paths)
+//
+// Requirements covered:
+//   R3  — Dependency readiness via canStart
+//   R4  — Graph validation (unknown deps, cycles, self-deps)
+//   R6  — Task-readiness edit gate (isWriteAllowedPath)
+//   R12 — Shared preflight library
+//   R13 — Audit on each decision
+//   R15 — Sanitized paths, fail closed
+//   R18 — Remediation text with ruleId
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ─── 12.1 — isWriteAllowedPath export and behavior (R6, R12) ────────────────
+
+describe('preflight — isWriteAllowedPath export (R6, R12)', () => {
+  it('exports isWriteAllowedPath as a function', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    assert.equal(typeof isWriteAllowedPath, 'function', 'isWriteAllowedPath must be exported');
+  });
+
+  it('isWriteAllowedPath has arity 2 (filePath, allowedPaths)', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    assert.equal(isWriteAllowedPath.length, 2, 'isWriteAllowedPath(filePath, allowedPaths) needs 2 params');
+  });
+});
+
+describe('preflight — isWriteAllowedPath: PR{N}/ paths (R6)', () => {
+  it('allows paths under the claiming worker PR{N}/ directory', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/src/index.js', allowed),
+      true,
+      'files under PR{N}/ are allowed'
+    );
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/deep/nested/file.ts', allowed),
+      true,
+      'deeply nested files under PR{N}/ are allowed'
+    );
+  });
+
+  it('denies paths under a different PR slot', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR2/src/file.js', allowed),
+      false,
+      'files under a different PR slot must be denied'
+    );
+  });
+});
+
+describe('preflight — isWriteAllowedPath: task${N}/ paths (R6)', () => {
+  it('allows paths under the claimed task directory', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/task3/implement.md', allowed),
+      true,
+      'task artifact files under task${N}/ are allowed'
+    );
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/task3/tdd-phase.json', allowed),
+      true,
+      'tdd-phase.json under task${N}/ is allowed'
+    );
+  });
+
+  it('denies paths under a different task directory', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/task5/implement.md', allowed),
+      false,
+      'files under a different task directory must be denied'
+    );
+  });
+});
+
+describe('preflight — isWriteAllowedPath: shared-root whitelist (R6)', () => {
+  it('allows brief.md at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/brief.md', allowed),
+      true,
+      'brief.md at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows spec.md at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/spec.md', allowed),
+      true,
+      'spec.md at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows tasks.md at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/tasks.md', allowed),
+      true,
+      'tasks.md at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows .work-state.json at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/.work-state.json', allowed),
+      true,
+      '.work-state.json at ticket root is in the shared whitelist'
+    );
+  });
+
+  it('allows .work-actions.json at ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/.work-actions.json', allowed),
+      true,
+      '.work-actions.json at ticket root is in the shared whitelist'
+    );
+  });
+});
+
+describe('preflight — isWriteAllowedPath: denied paths (R6, R15)', () => {
+  it('denies arbitrary paths outside allowed set', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/some/random/file.js', allowed),
+      false,
+      'arbitrary paths outside PR{N}/, task${N}/, and whitelist are denied'
+    );
+  });
+
+  it('denies files at ticket root that are not in the whitelist', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/random-file.txt', allowed),
+      false,
+      'non-whitelisted files at ticket root are denied'
+    );
+  });
+
+  it('denies paths that are path-traversal attempts from ticket root', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+    const allowed = {
+      prDir: '/tasks/GH-219/PR1',
+      taskDir: '/tasks/GH-219/task3',
+      ticketRoot: '/tasks/GH-219',
+    };
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/../GH-220/task1/file.js', allowed),
+      false,
+      'path traversal attempts are denied (R15)'
+    );
+  });
+
+  it('returns false (fail closed) when allowedPaths is missing fields', () => {
+    const { isWriteAllowedPath } = require(MODULE_PATH);
+
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/file.js', {}),
+      false,
+      'missing allowedPaths fields must fail closed'
+    );
+    assert.equal(
+      isWriteAllowedPath('/tasks/GH-219/PR1/file.js', null),
+      false,
+      'null allowedPaths must fail closed'
+    );
+  });
+});
+
+// ─── 12.2 — createGraphCheck (R4 — graph validation) ────────────────────────
+
+describe('preflight — createGraphCheck (R4 — graph validation)', () => {
+  it('exports createGraphCheck as a function', () => {
+    const { createGraphCheck } = require(MODULE_PATH);
+    assert.equal(typeof createGraphCheck, 'function');
+  });
+
+  it('returns a check function', () => {
+    const { createGraphCheck } = require(MODULE_PATH);
+    const check = createGraphCheck();
+    assert.equal(typeof check, 'function');
+  });
+
+  it('allows when context has no tasks (no graph to validate)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = { ticketId: 'GH-1', origin: 'workflow', error: null, tasks: null };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, true, 'null tasks means no graph to validate; allow');
+  });
+
+  it('allows when tasks have a valid graph (no errors)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, true, 'valid graph passes');
+  });
+
+  it('denies when tasks have an unknown dependency (R4)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [99] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false, 'unknown dependency denies');
+    assert.ok(
+      result.reasons.some((r) => r === 'UNKNOWN_DEPENDENCY'),
+      'reason includes UNKNOWN_DEPENDENCY ruleId (R18)'
+    );
+    assert.ok(result.remediation.length > 0, 'remediation text is present (R18)');
+  });
+
+  it('denies when tasks have a self-dependency (R4)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [1] },
+        { num: 2, dependencies: [] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false, 'self-dependency denies');
+    assert.ok(
+      result.reasons.some((r) => r === 'SELF_DEPENDENCY'),
+      'reason includes SELF_DEPENDENCY ruleId'
+    );
+  });
+
+  it('denies when tasks have a cycle (R4)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [2] },
+        { num: 2, dependencies: [1] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false, 'cycle denies');
+    assert.ok(
+      result.reasons.some((r) => r === 'DEPENDENCY_CYCLE'),
+      'reason includes DEPENDENCY_CYCLE ruleId'
+    );
+  });
+
+  it('remediation on graph deny includes the ruleId for explainability (R18)', () => {
+    const { runPreflight, createGraphCheck } = require(MODULE_PATH);
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [99] },
+      ],
+    };
+    const result = runPreflight(ctx, { checks: [createGraphCheck()] });
+    assert.equal(result.allow, false);
+    // Each reason string IS the ruleId
+    for (const reason of result.reasons) {
+      assert.equal(typeof reason, 'string');
+      assert.ok(reason.length > 0, 'reason/ruleId is non-empty');
+    }
+  });
+});
+
+// ─── 12.3 — createClaimCheck (R3, R6 — dependency readiness + claim) ─────────
+
+describe('preflight — createClaimCheck (R3, R6 — unclaimed task write)', () => {
+  it('exports createClaimCheck as a function', () => {
+    const { createClaimCheck } = require(MODULE_PATH);
+    assert.equal(typeof createClaimCheck, 'function');
+  });
+
+  it('denies when taskNum is provided but no claim info (unclaimed write)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 3,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+            { id: 'task_3', status: 'pending', dependencies: [2] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+        { num: 3, dependencies: [2] },
+      ],
+      hasWorkflow: true,
+    };
+
+    // No claim: taskNum=2 but ownerId not provided
+    const check = createClaimCheck({ taskNum: 2 });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, false, 'unclaimed task write denied');
+    assert.ok(
+      result.reasons.some((r) => r === 'UNCLAIMED_TASK_WRITE'),
+      'reason includes UNCLAIMED_TASK_WRITE ruleId'
+    );
+    assert.ok(result.remediation.length > 0, 'remediation present');
+  });
+
+  it('allows when taskNum and ownerId are provided and task is startable (R3)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const check = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, true, 'claimed task with ready deps allows');
+  });
+
+  it('denies when task dependencies are not satisfied (R3)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 3,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+            { id: 'task_3', status: 'pending', dependencies: [2] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+        { num: 3, dependencies: [2] },
+      ],
+      hasWorkflow: true,
+    };
+
+    // Task 2 depends on Task 1, which is still pending
+    const check = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, false, 'task with unsatisfied deps denied');
+    assert.ok(
+      result.reasons.some((r) => r === 'DEPENDENCY_NOT_READY'),
+      'reason includes DEPENDENCY_NOT_READY ruleId'
+    );
+  });
+
+  it('allows when no tasksMeta exists (legacy/pre-IDEA2 — R16 backward compat)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-1',
+      origin: 'workflow',
+      error: null,
+      state: { status: 'in_progress' },
+      tasks: null,
+      hasWorkflow: true,
+    };
+
+    // No tasksMeta = legacy mode, no claim enforcement
+    const check = createClaimCheck({});
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, true, 'legacy mode without tasksMeta allows (R16)');
+  });
+});
+
+// ─── 12.4 — createPathCheck (R6 — task-readiness edit gate) ──────────────────
+
+describe('preflight — createPathCheck (R6 — path intent check)', () => {
+  it('exports createPathCheck as a function', () => {
+    const { createPathCheck } = require(MODULE_PATH);
+    assert.equal(typeof createPathCheck, 'function');
+  });
+
+  it('allows writes to PR{N}/ for the claiming worker', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const check = createPathCheck({
+      filePath: '/tasks/GH-219/PR1/src/index.js',
+      allowedPaths: {
+        prDir: '/tasks/GH-219/PR1',
+        taskDir: '/tasks/GH-219/task3',
+        ticketRoot: '/tasks/GH-219',
+      },
+    });
+
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, true, 'writes to PR{N}/ are allowed');
+  });
+
+  it('denies writes outside the allowed set', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const check = createPathCheck({
+      filePath: '/some/other/repo/file.js',
+      allowedPaths: {
+        prDir: '/tasks/GH-219/PR1',
+        taskDir: '/tasks/GH-219/task3',
+        ticketRoot: '/tasks/GH-219',
+      },
+    });
+
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, false, 'writes outside allowed paths denied');
+    assert.ok(
+      result.reasons.some((r) => r === 'PATH_NOT_ALLOWED'),
+      'reason includes PATH_NOT_ALLOWED ruleId'
+    );
+  });
+
+  it('allows writes to shared-root whitelist files at ticket root', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    for (const file of ['brief.md', 'spec.md', 'tasks.md', '.work-state.json', '.work-actions.json']) {
+      const check = createPathCheck({
+        filePath: `/tasks/GH-219/${file}`,
+        allowedPaths: {
+          prDir: '/tasks/GH-219/PR1',
+          taskDir: '/tasks/GH-219/task3',
+          ticketRoot: '/tasks/GH-219',
+        },
+      });
+
+      const result = runPreflight(ctx, { checks: [check] });
+      assert.equal(result.allow, true, `shared-root whitelist file ${file} is allowed`);
+    }
+  });
+
+  it('skips path check when no filePath is provided (no path intent to validate)', () => {
+    const { runPreflight, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      hasWorkflow: true,
+    };
+
+    const check = createPathCheck({
+      allowedPaths: {
+        prDir: '/tasks/GH-219/PR1',
+        taskDir: '/tasks/GH-219/task3',
+        ticketRoot: '/tasks/GH-219',
+      },
+    });
+
+    const result = runPreflight(ctx, { checks: [check] });
+    assert.equal(result.allow, true, 'no filePath means no path to deny');
+  });
+});
+
+// ─── 12.5 — Full preflight composition (happy path + deny) ──────────────────
+
+describe('preflight — full composition: graph + claim + path (R3, R4, R6)', () => {
+  it('happy path: valid graph, claimed task, matching paths → allow', () => {
+    const { runPreflight, createGraphCheck, createClaimCheck, createPathCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 2, ownerId: 'PR1' }),
+      createPathCheck({
+        filePath: '/tasks/GH-219/PR1/src/main.js',
+        allowedPaths: {
+          prDir: '/tasks/GH-219/PR1',
+          taskDir: '/tasks/GH-219/task2',
+          ticketRoot: '/tasks/GH-219',
+        },
+      }),
+    ];
+
+    const result = runPreflight(ctx, { checks });
+    assert.equal(result.allow, true, 'full composition happy path allows');
+    assert.deepEqual(result.reasons, []);
+  });
+
+  it('audit callback is invoked with full decision on composed happy path', () => {
+    const { runPreflight, createGraphCheck, createClaimCheck, createPathCheck } = require(MODULE_PATH);
+
+    const audited = [];
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 2, ownerId: 'PR1' }),
+    ];
+
+    runPreflight(ctx, { checks, audit: (e) => audited.push(e) });
+
+    assert.equal(audited.length, 1, 'audit called once');
+    assert.equal(audited[0].decision, 'allow');
+    assert.equal(audited[0].ticketId, 'GH-219');
+  });
+
+  it('composed deny: invalid graph + unclaimed → all reasons aggregated', () => {
+    const { runPreflight, createGraphCheck, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [99] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [99] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const checks = [
+      createGraphCheck(),
+      createClaimCheck({ taskNum: 1 }), // no ownerId → unclaimed
+    ];
+
+    const result = runPreflight(ctx, { checks });
+
+    assert.equal(result.allow, false, 'composed deny from multiple checks');
+    assert.ok(result.reasons.length >= 2, 'multiple deny reasons aggregated');
+    assert.ok(result.remediation.length > 0, 'aggregated remediation present');
+  });
+
+  it('remediation includes ruleId strings (R18 explainability)', () => {
+    const { runPreflight, createClaimCheck } = require(MODULE_PATH);
+
+    const ctx = {
+      ticketId: 'GH-219',
+      origin: 'workflow',
+      error: null,
+      state: {
+        status: 'in_progress',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task_1', status: 'pending', dependencies: [] },
+            { id: 'task_2', status: 'pending', dependencies: [1] },
+          ],
+        },
+      },
+      tasks: [
+        { num: 1, dependencies: [] },
+        { num: 2, dependencies: [1] },
+      ],
+      hasWorkflow: true,
+    };
+
+    const check = createClaimCheck({ taskNum: 2, ownerId: 'PR1' });
+    const result = runPreflight(ctx, { checks: [check] });
+
+    assert.equal(result.allow, false, 'task 2 deps not ready');
+    // R18: every deny reason is a stable ruleId string
+    for (const reason of result.reasons) {
+      assert.equal(typeof reason, 'string', 'reason is a string ruleId');
+      assert.ok(reason.length > 0, 'ruleId is non-empty');
+      // ruleIds are SCREAMING_SNAKE_CASE
+      assert.match(reason, /^[A-Z][A-Z0-9_]+$/, `ruleId "${reason}" is SCREAMING_SNAKE_CASE`);
+    }
+  });
+});

--- a/workflows/lib/__tests__/preflight.test.js
+++ b/workflows/lib/__tests__/preflight.test.js
@@ -468,10 +468,8 @@ describe('preflight — pluggable checks (R12, §Pattern — pluggable checks)',
     const result = runPreflight(ctx, { checks });
 
     assert.equal(result.allow, false);
-    assert.ok(
-      result.reasons.includes('CTX_ERR') || result.reasons.includes('RULE_Z'),
-      'at least one deny reason present (context error + checks compose)'
-    );
+    assert.ok(result.reasons.includes('CTX_ERR'), 'context error reason must be present');
+    assert.ok(result.reasons.includes('RULE_Z'), 'check deny reason must be present');
   });
 
   it('check returning undefined is treated as "no opinion" (allow passthrough)', () => {

--- a/workflows/lib/__tests__/preflight.test.js
+++ b/workflows/lib/__tests__/preflight.test.js
@@ -423,6 +423,22 @@ describe('preflight — pluggable checks (R12, §Pattern — pluggable checks)',
     assert.ok(result.remediation.includes('fix x'), 'remediation from denying check is merged');
   });
 
+  it('deny without reasons array still forces allow:false with synthetic reason', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const checks = [() => ({ allow: false })];
+    const result = runPreflight({}, { checks });
+    assert.equal(result.allow, false, 'must deny even without reasons');
+    assert.ok(result.reasons.length > 0, 'must have at least one synthetic reason');
+    assert.ok(result.reasons.includes('PREFLIGHT_DENIED'), 'synthetic reason should be PREFLIGHT_DENIED');
+  });
+
+  it('deny with empty reasons array still forces allow:false', () => {
+    const { runPreflight } = require(MODULE_PATH);
+    const checks = [() => ({ allow: false, reasons: [] })];
+    const result = runPreflight({}, { checks });
+    assert.equal(result.allow, false, 'must deny even with empty reasons');
+  });
+
   it('multiple denying checks → reasons aggregated, remediation merged', () => {
     const { runPreflight } = require(MODULE_PATH);
 

--- a/workflows/lib/__tests__/preflight.test.js
+++ b/workflows/lib/__tests__/preflight.test.js
@@ -72,9 +72,7 @@ describe('preflight — module surface (R12)', () => {
         `preflight must not require work-actions (found: ${id}). ` +
           'Audit persistence is injected by callers via options.audit.'
       );
-    }
-  });
-});
+    } }); }); // end coupling test
 
 // ─── R12 — Happy path (empty context, no checks) ────────────────────────────
 
@@ -421,8 +419,7 @@ describe('preflight — pluggable checks (R12, §Pattern — pluggable checks)',
     assert.equal(result.allow, false, 'any denying check forces deny');
     assert.ok(result.reasons.includes('RULE_X'), 'reason from denying check is included');
     assert.ok(result.remediation.includes('fix x'), 'remediation from denying check is merged');
-  });
-
+  }); // single deny check verified
   it('deny without reasons array still forces allow:false with synthetic reason', () => {
     const { runPreflight } = require(MODULE_PATH);
     const checks = [() => ({ allow: false })];

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -353,8 +353,7 @@ function createClaimCheck(params) {
     if (!ctx.state || !ctx.state.tasksMeta) return null;
 
     // No taskNum requested → no claim enforcement needed
-    if (taskNum == null) return null;
-
+    if (taskNum == null) return null; // no task context → skip claim check
     // R6: taskNum set but no ownerId → unclaimed task write
     if (!ownerId) {
       return {

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -260,6 +260,7 @@ function isWriteAllowedPath(filePath, allowedPaths) {
 
   // Check PR{N}/ directory
   if (typeof allowedPaths.prDir === 'string' && allowedPaths.prDir.length > 0) {
+    if (!path.isAbsolute(allowedPaths.prDir)) return false;
     const prResolved = path.resolve(allowedPaths.prDir);
     if (normalized.startsWith(prResolved + path.sep) || normalized === prResolved) {
       return true;
@@ -268,6 +269,7 @@ function isWriteAllowedPath(filePath, allowedPaths) {
 
   // Check task${N}/ directory
   if (typeof allowedPaths.taskDir === 'string' && allowedPaths.taskDir.length > 0) {
+    if (!path.isAbsolute(allowedPaths.taskDir)) return false;
     const taskResolved = path.resolve(allowedPaths.taskDir);
     if (normalized.startsWith(taskResolved + path.sep) || normalized === taskResolved) {
       return true;
@@ -276,6 +278,7 @@ function isWriteAllowedPath(filePath, allowedPaths) {
 
   // Check shared-root whitelist at ticketRoot
   if (typeof allowedPaths.ticketRoot === 'string' && allowedPaths.ticketRoot.length > 0) {
+    if (!path.isAbsolute(allowedPaths.ticketRoot)) return false;
     const ticketResolved = path.resolve(allowedPaths.ticketRoot);
     // File must be directly at ticketRoot (not nested) and in the whitelist
     const dir = path.dirname(normalized);
@@ -353,8 +356,8 @@ function createClaimCheck(params) {
     if (!ctx.state || !ctx.state.tasksMeta) return null;
 
     // No taskNum requested → no claim enforcement needed
-    if (taskNum == null) return null; // no task context → skip claim check
-    // R6: taskNum set but no ownerId → unclaimed task write
+    if (taskNum == null) return null; // no task context → skip
+    // R6: taskNum present but no ownerId → unclaimed task write
     if (!ownerId) {
       return {
         allow: false,

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -1,0 +1,444 @@
+/**
+ * preflight.js
+ *
+ * IDEA2 / GH-219 — Task 3: Shared preflight gate with audit hook.
+ *
+ * `runPreflight(context, options)` is the single evaluation surface consumed
+ * by `workflows/work/hooks/work-require-implement.js` and
+ * `workflows/work-implement/hooks/work-implement-enforce.js`. It returns a
+ * {@link PreflightResult} and invokes an optional {@link PreflightAudit}
+ * callback so enforcement decisions can be persisted to `.work-actions.json`
+ * via `appendEnforcementAudit` (Task 1) WITHOUT this module importing
+ * `work-actions.js` (low coupling; audit is injected by callers).
+ *
+ * The `context` parameter matches the `EnforcementContext` shape returned by
+ * `workflows/work/work-enforcement-context.js` (Task 2). The JSDoc `@param`
+ * below imports that type by name via a TypeScript-compatible `import(...)`
+ * specifier so downstream tooling (tsc in checkJs mode, Cursor/VSCode
+ * IntelliSense) resolves the fields without a runtime require — preflight
+ * remains decoupled from the adapter.
+ *
+ * @module preflight
+ */
+'use strict';
+
+const path = require('path');
+
+/**
+ * @typedef {import('../work/work-enforcement-context').EnforcementContext} EnforcementContext
+ *
+ * Unified enforcement context composed by `loadEnforcementContext` in
+ * `workflows/work/work-enforcement-context.js` (Task 2). Contains:
+ *   - `ticketId`    {string|null}           sanitized ticket id, null on validation error
+ *   - `origin`      {'workflow'|'ai-subtask'|'user'|null} derived origin
+ *   - `state`       {object|null}           result from `loadState(ticketId)`
+ *   - `tasks`       {object[]|null}         result from `parseTasks(tasksDir)`
+ *   - `subtaskState` {object|null}          active subtask state or null
+ *   - `hasWorkflow` {boolean}               convenience signal
+ *   - `error`       {EnforcementContextError|null} populated on ambiguity / bad id
+ *   - `options`     {object}                echo of caller options
+ */
+
+/**
+ * @typedef {import('../work/work-enforcement-context').EnforcementContextError} EnforcementContextError
+ *
+ * Structured error descriptor attached to `EnforcementContext.error`:
+ *   - `code`        {string}   stable identifier (e.g. 'AMBIGUOUS_SUBTASK')
+ *   - `message`     {string}   human-readable description
+ *   - `remediation` {string[]} actionable fix steps (may be empty)
+ */
+
+/**
+ * Final preflight decision consumed by hooks.
+ *
+ * @typedef {Object} PreflightResult
+ * @property {boolean}  allow       `true` iff no deny reasons collected.
+ * @property {string[]} reasons     Deny reason codes (stable rule ids),
+ *                                  aggregated across `context.error` and
+ *                                  every denying check. Empty on allow.
+ * @property {string[]} remediation Merged, ordered remediation steps for
+ *                                  R18 explainability. Empty on allow.
+ */
+
+/**
+ * Audit record passed to the injected audit callback.
+ *
+ * Fields are a superset of `appendEnforcementAudit` (Task 1) inputs so
+ * callers can forward this entry directly to persistence — preflight never
+ * imports `work-actions.js`.
+ *
+ * @typedef {Object} PreflightAuditEntry
+ * @property {'allow'|'deny'}                         decision
+ * @property {string[]}                                reasons
+ * @property {string[]}                                remediation
+ * @property {'workflow'|'ai-subtask'|'user'|null}     origin
+ * @property {string|null}                             ticketId
+ */
+
+/**
+ * Callable signature for an injected audit hook. Single positional argument
+ * (plain object). Return value is ignored. Callback exceptions are caught
+ * and suppressed by `runPreflight` (fail-open on logging).
+ *
+ * @typedef {(entry: PreflightAuditEntry) => void} PreflightAudit
+ */
+
+/**
+ * Callable signature for a pluggable preflight check.
+ *
+ * Returning `null`/`undefined` or `{ allow: true }` is "no opinion" and
+ * passes through. Returning `{ allow: false, reasons?, remediation? }`
+ * contributes to the aggregated deny result. A thrown check is caught and
+ * recorded as `PREFLIGHT_CHECK_ERROR` (fail-closed) — it cannot starve the
+ * gate.
+ *
+ * @typedef {(ctx: EnforcementContext) => (Partial<PreflightResult>|null|undefined)} PreflightCheck
+ */
+
+/**
+ * Options for {@link runPreflight}.
+ *
+ * @typedef {Object} PreflightOptions
+ * @property {PreflightAudit}   [audit]   Injected logger; defaults to no-op.
+ * @property {PreflightCheck[]} [checks]  Pluggable checks run in order.
+ */
+
+/**
+ * Run the preflight gate.
+ *
+ * Semantics:
+ *   1. If `context.error` is a truthy object with a non-empty string `code`,
+ *      the error is recorded as a deny reason and its `remediation` (when an
+ *      array) is merged into the result.
+ *   2. If `options.checks` is provided, each check runs IN ORDER with
+ *      `context` as its sole argument. All denying results are aggregated —
+ *      reasons concatenated, remediation merged in declared order. A single
+ *      thrown check is caught and recorded as `PREFLIGHT_CHECK_ERROR`
+ *      (fail-closed) so one buggy rule cannot crash the whole gate.
+ *   3. The final `allow` is `true` iff no deny reasons were collected.
+ *   4. If `options.audit` is a function, it is invoked exactly once with a
+ *      single {@link PreflightAuditEntry}. The callback is wrapped in a
+ *      try/catch so logging failures never break enforcement (mirrors
+ *      `work-actions.js` `appendRow()` fail-open).
+ *   5. If `options.audit` is missing / not a function, audit defaults to a
+ *      no-op.
+ *
+ * The function is declared with arity 2 (no default parameters) so
+ * `runPreflight.length === 2`, locking the documented public contract.
+ *
+ * @param {EnforcementContext} context
+ *   Enforcement context produced by `loadEnforcementContext`
+ *   (`workflows/work/work-enforcement-context.js`, Task 2).
+ * @param {PreflightOptions} [options]
+ * @returns {PreflightResult}
+ */
+function runPreflight(context, options) {
+  const ctx = context || {};
+  const opts = options || {};
+
+  const audit = typeof opts.audit === 'function' ? opts.audit : null;
+  const checks = Array.isArray(opts.checks) ? opts.checks : null;
+
+  const reasons = [];
+  const remediation = [];
+
+  // ─── 1. context.error → deny with error.code as the rule id ────────────
+  const err = ctx.error;
+  if (err && typeof err === 'object' && typeof err.code === 'string' && err.code.length > 0) {
+    reasons.push(err.code);
+    if (Array.isArray(err.remediation)) {
+      for (const step of err.remediation) {
+        remediation.push(step);
+      }
+    }
+  }
+
+  // ─── 2. Pluggable checks ───────────────────────────────────────────────
+  if (checks) {
+    for (const check of checks) {
+      if (typeof check !== 'function') continue;
+
+      let res;
+      try {
+        res = check(ctx);
+      } catch {
+        // Fail-closed on a crashing check — one buggy rule must not starve
+        // the gate. The synthetic reason lets callers identify the failure
+        // mode in audit records without leaking error internals.
+        reasons.push('PREFLIGHT_CHECK_ERROR');
+        continue;
+      }
+
+      if (!res || typeof res !== 'object') continue;
+      if (res.allow === false) {
+        if (Array.isArray(res.reasons)) {
+          for (const r of res.reasons) reasons.push(r);
+        }
+        if (Array.isArray(res.remediation)) {
+          for (const r of res.remediation) remediation.push(r);
+        }
+      }
+    }
+  }
+
+  // ─── 3. Final decision ─────────────────────────────────────────────────
+  const allow = reasons.length === 0;
+  const decision = allow ? 'allow' : 'deny';
+  const result = { allow, reasons, remediation };
+
+  // ─── 4. Fail-open audit ────────────────────────────────────────────────
+  // Entry fields are a superset of {decision, reasons, origin, ticketId} so
+  // callers can forward directly to `appendEnforcementAudit` (Task 1).
+  // `remediation` is included for R18 explainability (deny path).
+  if (audit) {
+    try {
+      audit({
+        decision,
+        reasons: reasons.slice(),
+        remediation: remediation.slice(),
+        origin: ctx.origin != null ? ctx.origin : null,
+        ticketId: ctx.ticketId != null ? ctx.ticketId : null,
+      });
+    } catch {
+      // Persistence failures must never break enforcement decisions.
+    }
+  }
+
+  return result;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Task 12 — Preflight rules integration (graph, claim, paths)
+//
+// Built-in check factories and shared path predicate.
+//   - createGraphCheck()                → PreflightCheck  (R4)
+//   - createClaimCheck({ taskNum, ownerId }) → PreflightCheck  (R3, R6)
+//   - createPathCheck({ filePath, allowedPaths }) → PreflightCheck  (R6)
+//   - isWriteAllowedPath(filePath, allowedPaths) → boolean  (R6, R12)
+//
+// isWriteAllowedPath is the single implementation of the path predicate.
+// Tasks 13-14 hooks import it from here — no inline copies allowed.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ─── Shared-root whitelist (R6) ──────────────────────────────────────────────
+// Files at ticketRoot that any worker may write (coordination files).
+const SHARED_ROOT_WHITELIST = new Set([
+  'brief.md',
+  'spec.md',
+  'tasks.md',
+  '.work-state.json',
+  '.work-actions.json',
+]);
+
+/**
+ * Determine whether a file path is allowed for the current worker.
+ *
+ * This is the SINGLE implementation of the task-readiness edit gate (R6).
+ * Tasks 13-14 hooks must import this — no inline duplicates.
+ *
+ * Allowed paths:
+ *   - Under `allowedPaths.prDir`      (PR{N}/ worktree)
+ *   - Under `allowedPaths.taskDir`    (task${N}/ artifacts)
+ *   - Shared-root whitelist at `allowedPaths.ticketRoot`
+ *
+ * Fail-closed (R15): returns false when inputs are missing or malformed.
+ *
+ * @param {string} filePath     - Absolute path being written
+ * @param {object} allowedPaths - { prDir, taskDir, ticketRoot }
+ * @returns {boolean}
+ */
+function isWriteAllowedPath(filePath, allowedPaths) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  if (!allowedPaths || typeof allowedPaths !== 'object') return false;
+
+  // Normalize to prevent path-traversal bypasses (R15)
+  const normalized = path.resolve(filePath);
+
+  // Check PR{N}/ directory
+  if (typeof allowedPaths.prDir === 'string' && allowedPaths.prDir.length > 0) {
+    const prResolved = path.resolve(allowedPaths.prDir);
+    if (normalized.startsWith(prResolved + path.sep) || normalized === prResolved) {
+      return true;
+    }
+  }
+
+  // Check task${N}/ directory
+  if (typeof allowedPaths.taskDir === 'string' && allowedPaths.taskDir.length > 0) {
+    const taskResolved = path.resolve(allowedPaths.taskDir);
+    if (normalized.startsWith(taskResolved + path.sep) || normalized === taskResolved) {
+      return true;
+    }
+  }
+
+  // Check shared-root whitelist at ticketRoot
+  if (typeof allowedPaths.ticketRoot === 'string' && allowedPaths.ticketRoot.length > 0) {
+    const ticketResolved = path.resolve(allowedPaths.ticketRoot);
+    // File must be directly at ticketRoot (not nested) and in the whitelist
+    const dir = path.dirname(normalized);
+    if (dir === ticketResolved) {
+      const basename = path.basename(normalized);
+      if (SHARED_ROOT_WHITELIST.has(basename)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Create a graph validation check (R4).
+ *
+ * Validates `ctx.tasks` for unknown dependencies, self-dependencies, and
+ * cycles using `validateTaskGraph` from `work-state.js`. If tasks are null
+ * or missing, the check passes (no graph to validate).
+ *
+ * @returns {PreflightCheck}
+ */
+function createGraphCheck() {
+  return function graphCheck(ctx) {
+    if (!ctx.tasks || !Array.isArray(ctx.tasks)) return null;
+
+    // Lazy require to avoid module-level coupling with work-state.js.
+    // In production config is always available; if require fails, the
+    // enclosing runPreflight try/catch records PREFLIGHT_CHECK_ERROR.
+    const { validateTaskGraph } = require('../work/work-state');
+
+    const validation = validateTaskGraph(ctx.tasks);
+    if (validation.valid) return null;
+
+    // Aggregate all graph errors into reasons + remediation
+    const reasons = [];
+    const remediation = [];
+    for (const err of validation.errors) {
+      if (err.code && !reasons.includes(err.code)) {
+        reasons.push(err.code);
+      }
+      if (Array.isArray(err.remediation)) {
+        for (const step of err.remediation) {
+          remediation.push(step);
+        }
+      }
+    }
+
+    return { allow: false, reasons, remediation };
+  };
+}
+
+/**
+ * Create a claim + dependency readiness check (R3, R6).
+ *
+ * Validates that:
+ *   1. If taskNum is set, ownerId must also be set (unclaimed write → deny).
+ *   2. The task's dependencies are all completed (canStart semantics, R3).
+ *
+ * When no tasksMeta exists in the context state, the check passes (legacy
+ * mode, R16 backward compat).
+ *
+ * @param {object} params
+ * @param {number} [params.taskNum] - Task number being worked on
+ * @param {string} [params.ownerId] - PR{N} owner id from claim
+ * @returns {PreflightCheck}
+ */
+function createClaimCheck(params) {
+  const taskNum = params && params.taskNum;
+  const ownerId = params && params.ownerId;
+
+  return function claimCheck(ctx) {
+    // No state or no tasksMeta → legacy mode, allow (R16)
+    if (!ctx.state || !ctx.state.tasksMeta) return null;
+
+    // No taskNum requested → no claim enforcement needed
+    if (!taskNum) return null;
+
+    // R6: taskNum set but no ownerId → unclaimed task write
+    if (!ownerId) {
+      return {
+        allow: false,
+        reasons: ['UNCLAIMED_TASK_WRITE'],
+        remediation: [
+          `Task ${taskNum} has no claim. Run claimTask(ticketId, ${taskNum}, ownerId) before writing.`,
+          'Each worker must claim a task with its PR{N} owner id before modifying files.',
+        ],
+      };
+    }
+
+    // R3: Check dependency readiness using persisted tasksMeta
+    const tasksMeta = ctx.state.tasksMeta;
+    if (!Array.isArray(tasksMeta.tasks)) return null;
+
+    const targetId = `task_${taskNum}`;
+    const task = tasksMeta.tasks.find((t) => t && t.id === targetId);
+    if (!task) {
+      return {
+        allow: false,
+        reasons: ['UNKNOWN_TASK'],
+        remediation: [
+          `Task ${taskNum} not found in tasksMeta. Verify task number and re-run initTasksMeta.`,
+        ],
+      };
+    }
+
+    // Check dependency readiness (R3)
+    if (Array.isArray(task.dependencies) && task.dependencies.length > 0) {
+      for (const depNum of task.dependencies) {
+        const depId = `task_${depNum}`;
+        const dep = tasksMeta.tasks.find((t) => t && t.id === depId);
+        if (!dep || dep.status !== 'completed') {
+          return {
+            allow: false,
+            reasons: ['DEPENDENCY_NOT_READY'],
+            remediation: [
+              `Task ${taskNum} depends on Task ${depNum} which is not completed (status: ${dep ? dep.status : 'missing'}).`,
+              `Complete Task ${depNum} before starting Task ${taskNum}.`,
+              'Use canStart(ticketId, taskNum) to check readiness before claiming.',
+            ],
+          };
+        }
+      }
+    }
+
+    return null;
+  };
+}
+
+/**
+ * Create a path intent check (R6).
+ *
+ * If filePath is provided, validates it against the allowed paths using
+ * `isWriteAllowedPath`. If filePath is not provided, the check passes
+ * (no path intent to validate).
+ *
+ * @param {object} params
+ * @param {string} [params.filePath] - Absolute path being written
+ * @param {object} [params.allowedPaths] - { prDir, taskDir, ticketRoot }
+ * @returns {PreflightCheck}
+ */
+function createPathCheck(params) {
+  const filePath = params && params.filePath;
+  const allowedPaths = params && params.allowedPaths;
+
+  return function pathCheck() {
+    if (!filePath) return null;
+
+    if (isWriteAllowedPath(filePath, allowedPaths)) return null;
+
+    return {
+      allow: false,
+      reasons: ['PATH_NOT_ALLOWED'],
+      remediation: [
+        `Write to "${filePath}" is outside the allowed path set.`,
+        'Allowed paths: PR{N}/ worktree, task${N}/ artifacts, and shared-root whitelist (brief.md, spec.md, tasks.md, .work-state.json, .work-actions.json).',
+        'Verify the file path and ensure it falls under the claimed worker or task directory.',
+      ],
+    };
+  };
+}
+
+module.exports = {
+  runPreflight,
+  isWriteAllowedPath,
+  createGraphCheck,
+  createClaimCheck,
+  createPathCheck,
+};

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -177,9 +177,7 @@ function runPreflight(context, options) {
         denied = true;
         if (Array.isArray(res.reasons) && res.reasons.length > 0) {
           for (const r of res.reasons) reasons.push(r);
-        } else {
-          reasons.push('PREFLIGHT_DENIED');
-        }
+        } else { reasons.push('PREFLIGHT_DENIED'); } // synthetic reason when check provides none
         if (Array.isArray(res.remediation)) {
           for (const r of res.remediation) remediation.push(r);
         }
@@ -258,8 +256,7 @@ function isWriteAllowedPath(filePath, allowedPaths) {
   if (!path.isAbsolute(filePath)) return false; // require absolute paths — fail-closed
   if (!allowedPaths || typeof allowedPaths !== 'object') return false;
 
-  // Normalize to prevent path-traversal bypasses (R15)
-  const normalized = path.resolve(filePath);
+  const normalized = path.resolve(filePath); // normalize for path-traversal defense (R15)
 
   // Check PR{N}/ directory
   if (typeof allowedPaths.prDir === 'string' && allowedPaths.prDir.length > 0) {
@@ -304,7 +301,7 @@ function isWriteAllowedPath(filePath, allowedPaths) {
  */
 function createGraphCheck() {
   return function graphCheck(ctx) {
-    if (!ctx.tasks || !Array.isArray(ctx.tasks)) return null;
+    if (!ctx.tasks || !Array.isArray(ctx.tasks)) return null; // no tasks → no graph to validate
 
     // Lazy require to avoid module-level coupling with work-state.js.
     // In production config is always available; if require fails, the
@@ -356,7 +353,7 @@ function createClaimCheck(params) {
     if (!ctx.state || !ctx.state.tasksMeta) return null;
 
     // No taskNum requested → no claim enforcement needed
-    if (!taskNum) return null;
+    if (taskNum == null) return null;
 
     // R6: taskNum set but no ownerId → unclaimed task write
     if (!ownerId) {
@@ -375,7 +372,7 @@ function createClaimCheck(params) {
     if (!Array.isArray(tasksMeta.tasks)) return null;
 
     const targetId = `task_${taskNum}`;
-    const task = tasksMeta.tasks.find((t) => t && t.id === targetId);
+    const task = tasksMeta.tasks.find((t) => t && t.id === targetId); // R3 lookup
     if (!task) {
       return {
         allow: false,

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -278,8 +278,8 @@ function isWriteAllowedPath(filePath, allowedPaths) {
 
   // Check shared-root whitelist at ticketRoot
   if (typeof allowedPaths.ticketRoot === 'string' && allowedPaths.ticketRoot.length > 0) {
-    if (!path.isAbsolute(allowedPaths.ticketRoot)) return false;
-    const ticketResolved = path.resolve(allowedPaths.ticketRoot);
+    if (!path.isAbsolute(allowedPaths.ticketRoot)) return false; // require absolute
+    const ticketResolved = path.resolve(allowedPaths.ticketRoot); // normalize
     // File must be directly at ticketRoot (not nested) and in the whitelist
     const dir = path.dirname(normalized);
     if (dir === ticketResolved) {

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -141,10 +141,12 @@ function runPreflight(context, options) {
 
   const reasons = [];
   const remediation = [];
+  let denied = false;
 
   // ─── 1. context.error → deny with error.code as the rule id ────────────
   const err = ctx.error;
   if (err && typeof err === 'object' && typeof err.code === 'string' && err.code.length > 0) {
+    denied = true;
     reasons.push(err.code);
     if (Array.isArray(err.remediation)) {
       for (const step of err.remediation) {
@@ -165,14 +167,18 @@ function runPreflight(context, options) {
         // Fail-closed on a crashing check — one buggy rule must not starve
         // the gate. The synthetic reason lets callers identify the failure
         // mode in audit records without leaking error internals.
+        denied = true;
         reasons.push('PREFLIGHT_CHECK_ERROR');
         continue;
       }
 
       if (!res || typeof res !== 'object') continue;
       if (res.allow === false) {
-        if (Array.isArray(res.reasons)) {
+        denied = true;
+        if (Array.isArray(res.reasons) && res.reasons.length > 0) {
           for (const r of res.reasons) reasons.push(r);
+        } else {
+          reasons.push('PREFLIGHT_DENIED');
         }
         if (Array.isArray(res.remediation)) {
           for (const r of res.remediation) remediation.push(r);
@@ -182,7 +188,7 @@ function runPreflight(context, options) {
   }
 
   // ─── 3. Final decision ─────────────────────────────────────────────────
-  const allow = reasons.length === 0;
+  const allow = !denied;
   const decision = allow ? 'allow' : 'deny';
   const result = { allow, reasons, remediation };
 
@@ -249,6 +255,7 @@ const SHARED_ROOT_WHITELIST = new Set([
  */
 function isWriteAllowedPath(filePath, allowedPaths) {
   if (!filePath || typeof filePath !== 'string') return false;
+  if (!path.isAbsolute(filePath)) return false; // require absolute paths — fail-closed
   if (!allowedPaths || typeof allowedPaths !== 'object') return false;
 
   // Normalize to prevent path-traversal bypasses (R15)
@@ -376,6 +383,15 @@ function createClaimCheck(params) {
         remediation: [
           `Task ${taskNum} not found in tasksMeta. Verify task number and re-run initTasksMeta.`,
         ],
+      };
+    }
+
+    // Reject already-completed tasks (matches canStartFromState behavior)
+    if (task.status === 'completed') {
+      return {
+        allow: false,
+        reasons: ['TASK_ALREADY_COMPLETED'],
+        remediation: [`Task ${taskNum} is already completed. Move to the next task.`],
       };
     }
 


### PR DESCRIPTION
## Existing Behavior

- No shared preflight library exists; enforcement hooks duplicate context-error handling and check logic inline.
- There is no standardized contract for pluggable, composable preflight checks that accumulate deny reasons across multiple rules.
- Audit records for enforcement decisions are not produced at the gate layer; callers must manage persistence coupling directly.
- Path write authorization has no single canonical implementation — hooks may maintain separate copies of the predicate.

## Intended New Behavior

- `workflows/lib/preflight.js` exports a single `runPreflight(context, { audit, checks })` surface that returns `{ allow, reasons, remediation }` for every enforcement decision (R12).
- Pluggable `checks` run in declared order; all deny results are aggregated — reasons concatenated, remediation merged — so multi-rule failures surface fully in one pass.
- An injected `audit` callback receives one `PreflightAuditEntry` per `runPreflight` call (fail-open: logging failures never break gate decisions), keeping persistence decoupled from the gate (R13).
- `isWriteAllowedPath(filePath, allowedPaths)` is the single canonical path predicate (R6, R15); Tasks 13–14 hooks import it rather than duplicating the logic. Built-in check factories `createGraphCheck`, `createClaimCheck`, and `createPathCheck` are also exported.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Run the preflight test suite directly with Node's built-in test runner:

```bash
node --test workflows/lib/__tests__/preflight.test.js
```

Expected: all describe/it blocks pass with no failures.

To verify the module surface manually from a Node REPL:

```bash
node -e "
const p = require('./workflows/lib/preflight');
console.log(Object.keys(p).sort());
// Expected: ['createClaimCheck', 'createGraphCheck', 'createPathCheck', 'isWriteAllowedPath', 'runPreflight']

// Happy path
console.log(p.runPreflight({ ticketId: 'GH-1', origin: 'user', error: null }));
// Expected: { allow: true, reasons: [], remediation: [] }

// Deny path via context.error
console.log(p.runPreflight({ ticketId: 'GH-1', origin: 'user', error: { code: 'AMBIGUOUS_SUBTASK', message: 'test', remediation: ['fix it'] } }));
// Expected: { allow: false, reasons: ['AMBIGUOUS_SUBTASK'], remediation: ['fix it'] }

// Path predicate
console.log(p.isWriteAllowedPath('/tasks/GH-219/PR1/src/index.js', { prDir: '/tasks/GH-219/PR1', taskDir: '/tasks/GH-219/task3', ticketRoot: '/tasks/GH-219' }));
// Expected: true
"
```

### Test Results

Test suite: `workflows/lib/__tests__/preflight.test.js` — 1,324 lines covering R12, R13, R3, R4, R6, R15, R18 requirements. Run with `node --test` to verify.