### PR TITLE
feat(lib): shared ticket-validation module (GH-219)

### DIFF
--- a/workflows/lib/__tests__/ticket-validation.test.js
+++ b/workflows/lib/__tests__/ticket-validation.test.js
@@ -112,33 +112,26 @@ describe('sanitizeTicketId', () => {
 });
 
 describe('assertPathContainment', () => {
+  const base = path.resolve('/tmp/test-base');
+  const child = path.resolve('/tmp/test-base/child');
+  const deep = path.resolve('/tmp/test-base/child/deep');
+  const outside = path.resolve('/tmp/other/child');
+  const sibling = path.resolve('/tmp/test-base-extra/child');
+
   it('does not throw for child paths', () => {
-    assert.doesNotThrow(() =>
-      assertPathContainment('/base/child', '/base')
-    );
-    assert.doesNotThrow(() =>
-      assertPathContainment('/base/child/deep', '/base')
-    );
+    assert.doesNotThrow(() => assertPathContainment(child, base));
+    assert.doesNotThrow(() => assertPathContainment(deep, base));
   });
 
   it('throws for paths outside base', () => {
-    assert.throws(() =>
-      assertPathContainment('/other/child', '/base'),
-      /escapes base/
-    );
+    assert.throws(() => assertPathContainment(outside, base), /escapes base/);
   });
 
   it('throws for path equal to base (strict child required)', () => {
-    assert.throws(() =>
-      assertPathContainment('/base', '/base'),
-      /escapes base/
-    );
+    assert.throws(() => assertPathContainment(base, base), /escapes base/);
   });
 
   it('prevents prefix-sibling attacks', () => {
-    assert.throws(() =>
-      assertPathContainment('/base-extra/child', '/base'),
-      /escapes base/
-    );
+    assert.throws(() => assertPathContainment(sibling, base), /escapes base/);
   });
 });

--- a/workflows/lib/__tests__/ticket-validation.test.js
+++ b/workflows/lib/__tests__/ticket-validation.test.js
@@ -109,6 +109,46 @@ describe('sanitizeTicketId', () => {
     const result = sanitizeTicketId('GH-219/phase1');
     assert.ok(result.includes('phase1'), `should preserve suffix, got: ${result}`);
   });
+
+  it('returns canonical form for already-canonical IDs', () => {
+    const result = sanitizeTicketId('GH-219');
+    assert.ok(result.includes('GH-219'), `should contain GH-219, got: ${result}`);
+  });
+});
+
+describe('resolveTasksBase', () => {
+  const { resolveTasksBase, resolveTasksBaseOrNull } = require('../ticket-validation');
+
+  it('returns TASKS_BASE from environment', () => {
+    const saved = process.env.TASKS_BASE;
+    process.env.TASKS_BASE = '/tmp/test-resolve-base';
+    try {
+      const result = resolveTasksBase();
+      assert.equal(result, path.resolve('/tmp/test-resolve-base'));
+    } finally {
+      if (saved) process.env.TASKS_BASE = saved;
+      else delete process.env.TASKS_BASE;
+    }
+  });
+
+  it('resolveTasksBaseOrNull returns null when unavailable', () => {
+    const saved = process.env.TASKS_BASE;
+    const savedW = process.env.WORKTREES_BASE;
+    delete process.env.TASKS_BASE;
+    delete process.env.WORKTREES_BASE;
+    const configPath = require.resolve('../../lib/config');
+    const cached = require.cache[configPath];
+    delete require.cache[configPath];
+    try {
+      const result = resolveTasksBaseOrNull();
+      // May return null or a derived value depending on config
+      assert.ok(result === null || typeof result === 'string');
+    } finally {
+      if (saved) process.env.TASKS_BASE = saved;
+      if (savedW) process.env.WORKTREES_BASE = savedW;
+      if (cached) require.cache[configPath] = cached;
+    }
+  });
 });
 
 describe('assertPathContainment', () => {

--- a/workflows/lib/__tests__/ticket-validation.test.js
+++ b/workflows/lib/__tests__/ticket-validation.test.js
@@ -108,8 +108,7 @@ describe('sanitizeTicketId', () => {
   it('handles suffix syntax', () => {
     const result = sanitizeTicketId('GH-219/phase1');
     assert.ok(result.includes('phase1'), `should preserve suffix, got: ${result}`);
-  });
-
+  }); // suffix preserved through sanitization
   it('returns canonical form for already-canonical IDs', () => {
     const result = sanitizeTicketId('GH-219');
     assert.ok(result.includes('GH-219'), `should contain GH-219, got: ${result}`);
@@ -173,5 +172,4 @@ describe('assertPathContainment', () => {
 
   it('prevents prefix-sibling attacks', () => {
     assert.throws(() => assertPathContainment(sibling, base), /escapes base/);
-  });
-});
+  }); }); // end assertPathContainment

--- a/workflows/lib/__tests__/ticket-validation.test.js
+++ b/workflows/lib/__tests__/ticket-validation.test.js
@@ -1,0 +1,144 @@
+/**
+ * Tests for workflows/lib/ticket-validation.js — shared ticket ID validation.
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const {
+  validateTicketId,
+  validateTicketIdStructured,
+  sanitizeTicketId,
+  assertPathContainment,
+} = require('../ticket-validation');
+
+describe('validateTicketIdStructured', () => {
+  it('returns null for valid ticket IDs', () => {
+    const valid = ['GH-219', 'PROJ-123', 'AB-1', 'GH-219/phase1', 'PROJ-1/task_2'];
+    for (const id of valid) {
+      assert.equal(validateTicketIdStructured(id), null, `"${id}" should be valid`);
+    }
+  });
+
+  it('rejects non-string inputs', () => {
+    for (const bad of [null, undefined, 42, true, {}]) {
+      const err = validateTicketIdStructured(bad);
+      assert.ok(err, `${JSON.stringify(bad)} should be rejected`);
+      assert.equal(err.code, 'INVALID_TICKET_ID');
+    }
+  });
+
+  it('rejects empty and whitespace-only strings', () => {
+    for (const bad of ['', '   ', '\t', '\n']) {
+      const err = validateTicketIdStructured(bad);
+      assert.ok(err, `${JSON.stringify(bad)} should be rejected`);
+      assert.equal(err.code, 'INVALID_TICKET_ID');
+    }
+  });
+
+  it('rejects whitespace-padded inputs', () => {
+    for (const bad of [' GH-219', 'GH-219 ', ' GH-219 ']) {
+      const err = validateTicketIdStructured(bad);
+      assert.ok(err, `${JSON.stringify(bad)} should be rejected`);
+      assert.match(err.message, /whitespace/i);
+    }
+  });
+
+  it('rejects dot segments', () => {
+    assert.ok(validateTicketIdStructured('.'));
+    assert.ok(validateTicketIdStructured('./'));
+  });
+
+  it('rejects path traversal', () => {
+    assert.ok(validateTicketIdStructured('../x'));
+    assert.ok(validateTicketIdStructured('GH-1/../evil'));
+  });
+
+  it('rejects backslash, colon, null byte', () => {
+    assert.ok(validateTicketIdStructured('a\\b'));
+    assert.ok(validateTicketIdStructured('a:b'));
+    assert.ok(validateTicketIdStructured('a\0b'));
+  });
+
+  it('rejects leading slash', () => {
+    assert.ok(validateTicketIdStructured('/etc/passwd'));
+  });
+
+  it('rejects multiple slashes', () => {
+    assert.ok(validateTicketIdStructured('a/b/c'));
+    assert.ok(validateTicketIdStructured('https://github.com'));
+  });
+
+  it('rejects trailing slash and dot suffix', () => {
+    assert.ok(validateTicketIdStructured('GH-219/'));
+    assert.ok(validateTicketIdStructured('GH-219/.'));
+    assert.ok(validateTicketIdStructured('GH-219/..'));
+  });
+
+  it('accepts single-slash suffix tickets', () => {
+    assert.equal(validateTicketIdStructured('GH-219/phase1'), null);
+    assert.equal(validateTicketIdStructured('PROJ-1/my-suffix'), null);
+  });
+});
+
+describe('validateTicketId (throwing)', () => {
+  it('does not throw for valid IDs', () => {
+    assert.doesNotThrow(() => validateTicketId('GH-219'));
+    assert.doesNotThrow(() => validateTicketId('GH-219/phase1'));
+  });
+
+  it('throws for invalid IDs', () => {
+    assert.throws(() => validateTicketId(''), /Invalid ticket ID/);
+    assert.throws(() => validateTicketId('../x'), /Invalid ticket ID/);
+    assert.throws(() => validateTicketId(null), /Invalid ticket ID/);
+  });
+});
+
+describe('sanitizeTicketId', () => {
+  it('returns ticketId as-is when config is unavailable', () => {
+    // In test env, config may or may not be available
+    const result = sanitizeTicketId('GH-219');
+    assert.equal(typeof result, 'string');
+    assert.ok(result.length > 0);
+  });
+
+  it('handles suffix syntax', () => {
+    const result = sanitizeTicketId('GH-219/phase1');
+    assert.ok(result.includes('phase1'), `should preserve suffix, got: ${result}`);
+  });
+});
+
+describe('assertPathContainment', () => {
+  it('does not throw for child paths', () => {
+    assert.doesNotThrow(() =>
+      assertPathContainment('/base/child', '/base')
+    );
+    assert.doesNotThrow(() =>
+      assertPathContainment('/base/child/deep', '/base')
+    );
+  });
+
+  it('throws for paths outside base', () => {
+    assert.throws(() =>
+      assertPathContainment('/other/child', '/base'),
+      /escapes base/
+    );
+  });
+
+  it('throws for path equal to base (strict child required)', () => {
+    assert.throws(() =>
+      assertPathContainment('/base', '/base'),
+      /escapes base/
+    );
+  });
+
+  it('prevents prefix-sibling attacks', () => {
+    assert.throws(() =>
+      assertPathContainment('/base-extra/child', '/base'),
+      /escapes base/
+    );
+  });
+});

--- a/workflows/lib/ticket-validation.js
+++ b/workflows/lib/ticket-validation.js
@@ -153,8 +153,8 @@ function sanitizeTicketId(ticketId) {
       }
       return config.safeTicketId(ticketId);
     }
-  } catch {
-    /* config unavailable — return raw */
+  } catch (err) {
+    if (!err || err.code !== 'MODULE_NOT_FOUND') throw err;
   }
   return ticketId;
 }
@@ -173,8 +173,8 @@ function resolveTasksBase() {
   try {
     const config = require('./config');
     if (config && config.TASKS_BASE) return path.resolve(config.TASKS_BASE);
-  } catch {
-    /* config unavailable */
+  } catch (err) {
+    if (!err || err.code !== 'MODULE_NOT_FOUND') throw err;
   }
   throw new Error(
     'TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).'
@@ -206,7 +206,10 @@ function resolveTasksBaseOrNull() {
  * @throws {Error} if path escapes base
  */
 function assertPathContainment(resolvedPath, resolvedBase, label = 'path') {
-  if (!resolvedPath.startsWith(resolvedBase + path.sep)) {
+  // Use path.sep-terminated prefix to prevent sibling attacks (/base vs /base-extra).
+  // Handle root directory edge case where base already ends with separator.
+  const prefix = resolvedBase.endsWith(path.sep) ? resolvedBase : resolvedBase + path.sep;
+  if (!resolvedPath.startsWith(prefix)) {
     throw new Error(`${label}: resolved path escapes base directory: ${resolvedPath}`);
   }
 }

--- a/workflows/lib/ticket-validation.js
+++ b/workflows/lib/ticket-validation.js
@@ -69,7 +69,7 @@ function validateTicketIdStructured(ticketId) {
   if (ticketId === '.' || ticketId === './') {
     return {
       code: 'INVALID_TICKET_ID',
-      message: 'Invalid ticket ID: "." is not a valid ticket ID.',
+      message: '"." is not a valid ticket ID.',
       remediation: ['Use a proper ticket id like "GH-219" or "PROJ-123".'],
     };
   }
@@ -108,7 +108,7 @@ function validateTicketIdStructured(ticketId) {
   // Reject trailing slash or dot-suffix
   if (slashCount === 1) {
     const suffix = ticketId.slice(ticketId.indexOf('/') + 1);
-    if (!suffix || suffix === '.' || suffix === '..') {
+    if (!suffix || suffix === '.' || suffix === '..' || UNSAFE_TICKET_RE.test(suffix)) {
       return {
         code: 'INVALID_TICKET_ID',
         message: `ticketId ${JSON.stringify(ticketId)} has invalid suffix after "/".`,

--- a/workflows/lib/ticket-validation.js
+++ b/workflows/lib/ticket-validation.js
@@ -154,10 +154,9 @@ function sanitizeTicketId(ticketId) {
       return config.safeTicketId(ticketId);
     }
   } catch (err) {
-    if (!err || err.code !== 'MODULE_NOT_FOUND') throw err;
+    if (!err || err.code !== 'MODULE_NOT_FOUND') throw err; // only swallow missing config
   }
-  return ticketId;
-}
+  return ticketId; }
 
 // ─── TASKS_BASE resolution ───────────────────────────────────────────────────
 
@@ -174,7 +173,7 @@ function resolveTasksBase() {
     const config = require('./config');
     if (config && config.TASKS_BASE) return path.resolve(config.TASKS_BASE);
   } catch (err) {
-    if (!err || err.code !== 'MODULE_NOT_FOUND') throw err;
+    if (!err || err.code !== 'MODULE_NOT_FOUND') throw err; // only swallow missing config
   }
   throw new Error(
     'TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).'

--- a/workflows/lib/ticket-validation.js
+++ b/workflows/lib/ticket-validation.js
@@ -114,8 +114,7 @@ function validateTicketIdStructured(ticketId) {
         message: `ticketId ${JSON.stringify(ticketId)} has invalid suffix after "/".`,
         remediation: ['Either remove the trailing "/" or add a valid suffix like "PROJ-123/phase1".'],
       };
-    }
-  }
+    } } // end suffix validation — rejects empty, dot, and unsafe-char suffixes
 
   return null;
 }

--- a/workflows/lib/ticket-validation.js
+++ b/workflows/lib/ticket-validation.js
@@ -1,0 +1,223 @@
+/**
+ * ticket-validation.js — Shared ticket ID validation and sanitization (GH-219)
+ *
+ * Single source of truth for ticket ID safety checks used across:
+ *   - allocate-output-folder.js
+ *   - work-claims.js
+ *   - work-enforcement-context.js
+ *   - parallel-workers.js
+ *   - request-index.js
+ *
+ * Two error models:
+ *   - validateTicketId(id)        → throws on invalid (for allocator/request-index)
+ *   - validateTicketIdStructured(id) → returns { code, message, remediation } or null
+ *
+ * @module ticket-validation
+ */
+
+'use strict';
+
+const path = require('path');
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Reject path traversal, backslash, colon, and null bytes */
+const UNSAFE_TICKET_RE = /\.\.|[\\:\0]/;
+
+// ─── Core validation logic ───────────────────────────────────────────────────
+
+/**
+ * Validate a ticket ID. Returns null on success, structured error on failure.
+ * This is the canonical validation — all other validators delegate here.
+ *
+ * @param {unknown} ticketId
+ * @returns {{ code: string, message: string, remediation: string[] } | null}
+ */
+function validateTicketIdStructured(ticketId) {
+  if (typeof ticketId !== 'string') {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `ticketId must be a non-empty string (received ${ticketId === null ? 'null' : typeof ticketId}).`,
+      remediation: [
+        'Pass a ticket id like "GH-219" or "PROJ-123".',
+        'Hooks should resolve ticket id via workflows/lib/scripts/get-ticket-id.js before calling.',
+      ],
+    };
+  }
+
+  const trimmed = ticketId.trim();
+  if (trimmed === '') {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: 'ticketId must be a non-empty string (received empty/whitespace).',
+      remediation: [
+        'Pass a ticket id like "GH-219" or "PROJ-123".',
+      ],
+    };
+  }
+
+  // Reject whitespace-padded inputs
+  if (ticketId !== trimmed) {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `ticketId ${JSON.stringify(ticketId)} contains leading/trailing whitespace.`,
+      remediation: ['Trim the ticket id before passing it.'],
+    };
+  }
+
+  // Reject bare dot segments
+  if (ticketId === '.' || ticketId === './') {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: 'Invalid ticket ID: "." is not a valid ticket ID.',
+      remediation: ['Use a proper ticket id like "GH-219" or "PROJ-123".'],
+    };
+  }
+
+  // Reject unsafe characters (traversal, backslash, colon, null byte)
+  if (UNSAFE_TICKET_RE.test(ticketId)) {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `ticketId ${JSON.stringify(ticketId)} contains unsafe characters (path traversal, backslash, colon, or null byte).`,
+      remediation: [
+        'Remove any "\\", "..", colon, or null bytes from the ticket id.',
+        'Ticket ids are bare provider keys like "GH-219" or "PROJ-123" — not paths.',
+      ],
+    };
+  }
+
+  // Reject leading slash (absolute path)
+  if (ticketId.startsWith('/')) {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `ticketId ${JSON.stringify(ticketId)} must not start with "/".`,
+      remediation: ['Ticket ids must not start with "/".'],
+    };
+  }
+
+  // Reject multiple slashes
+  const slashCount = (ticketId.match(/\//g) || []).length;
+  if (slashCount > 1) {
+    return {
+      code: 'INVALID_TICKET_ID',
+      message: `ticketId has ${slashCount} slashes — at most one "/" is allowed.`,
+      remediation: ['Use format like "PROJ-123/phase1" — at most one "/".'],
+    };
+  }
+
+  // Reject trailing slash or dot-suffix
+  if (slashCount === 1) {
+    const suffix = ticketId.slice(ticketId.indexOf('/') + 1);
+    if (!suffix || suffix === '.' || suffix === '..') {
+      return {
+        code: 'INVALID_TICKET_ID',
+        message: `ticketId ${JSON.stringify(ticketId)} has invalid suffix after "/".`,
+        remediation: ['Either remove the trailing "/" or add a valid suffix like "PROJ-123/phase1".'],
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Validate a ticket ID, throwing on failure.
+ * Use this in modules that throw (allocator, request-index).
+ *
+ * @param {unknown} ticketId
+ * @throws {Error} if ticketId is invalid
+ */
+function validateTicketId(ticketId) {
+  const err = validateTicketIdStructured(ticketId);
+  if (err) {
+    throw new Error(`Invalid ticket ID: ${err.message}`);
+  }
+}
+
+// ─── Sanitization ─────────────────────────────────────────────────────────────
+
+/**
+ * Sanitize ticket ID for filesystem paths using config.safeTicketId.
+ * Handles suffix syntax: splits on "/" to sanitize base independently
+ * so "#123/phase1" → "GH-123/phase1".
+ *
+ * @param {string} ticketId - Pre-validated ticket ID
+ * @returns {string}
+ */
+function sanitizeTicketId(ticketId) {
+  try {
+    const config = require('./config');
+    if (config && typeof config.safeTicketId === 'function') {
+      const slashIdx = ticketId.indexOf('/');
+      if (slashIdx !== -1) {
+        return config.safeTicketId(ticketId.slice(0, slashIdx)) + ticketId.slice(slashIdx);
+      }
+      return config.safeTicketId(ticketId);
+    }
+  } catch {
+    /* config unavailable — return raw */
+  }
+  return ticketId;
+}
+
+// ─── TASKS_BASE resolution ───────────────────────────────────────────────────
+
+/**
+ * Resolve TASKS_BASE from environment or config module.
+ * Returns an absolute path (always path.resolve'd).
+ *
+ * @returns {string} Absolute path to TASKS_BASE
+ * @throws {Error} if TASKS_BASE cannot be resolved
+ */
+function resolveTasksBase() {
+  if (process.env.TASKS_BASE) return path.resolve(process.env.TASKS_BASE);
+  try {
+    const config = require('./config');
+    if (config && config.TASKS_BASE) return path.resolve(config.TASKS_BASE);
+  } catch {
+    /* config unavailable */
+  }
+  throw new Error(
+    'TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).'
+  );
+}
+
+/**
+ * Resolve TASKS_BASE, returning null instead of throwing.
+ * Use this in modules that return structured errors (work-claims).
+ *
+ * @returns {string|null}
+ */
+function resolveTasksBaseOrNull() {
+  try {
+    return resolveTasksBase();
+  } catch {
+    return null;
+  }
+}
+
+// ─── Path containment ─────────────────────────────────────────────────────────
+
+/**
+ * Verify that a resolved path is a strict child of a base directory.
+ *
+ * @param {string} resolvedPath - Absolute resolved path
+ * @param {string} resolvedBase - Absolute resolved base
+ * @param {string} [label='path'] - Label for error message
+ * @throws {Error} if path escapes base
+ */
+function assertPathContainment(resolvedPath, resolvedBase, label = 'path') {
+  if (!resolvedPath.startsWith(resolvedBase + path.sep)) {
+    throw new Error(`${label}: resolved path escapes base directory: ${resolvedPath}`);
+  }
+}
+
+module.exports = {
+  validateTicketId,
+  validateTicketIdStructured,
+  sanitizeTicketId,
+  resolveTasksBase,
+  resolveTasksBaseOrNull,
+  assertPathContainment,
+  UNSAFE_TICKET_RE,
+};


### PR DESCRIPTION
## Existing Behavior

- Ticket ID validation logic (format checks, path traversal guards, unsafe character rejection, path containment) is duplicated independently across `allocate-output-folder.js`, `work-claims.js`, `work-enforcement-context.js`, `parallel-workers.js`, and `request-index.js`.
- Each consumer implements its own subset of safety rules, creating inconsistency in what is rejected and how errors are reported.
- TASKS_BASE resolution logic is also scattered, with each module resolving it differently (throw vs. null vs. silent fallback).

## Intended New Behavior

- A single `workflows/lib/ticket-validation.js` module is the canonical source of truth for all ticket ID safety rules.
- Two error models are exported: `validateTicketId()` (throws) for modules that propagate exceptions, and `validateTicketIdStructured()` (returns structured `{ code, message, remediation }`) for modules that return error objects — no consumer needs to duplicate logic to choose a style.
- `sanitizeTicketId()` centralizes filesystem-safe ID sanitization including suffix (`PROJ-123/phase1`) handling via `config.safeTicketId`.
- `resolveTasksBase()` / `resolveTasksBaseOrNull()` and `assertPathContainment()` consolidate TASKS_BASE resolution and path escape prevention into one place.
- This PR adds the shared module only; wiring existing consumers is deferred to follow-up PRs to keep this diff small and reviewable.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The shared module has a dedicated test file. To verify:

1. From the repo root, run the test suite directly:
   ```bash
   node --test workflows/lib/__tests__/ticket-validation.test.js
   ```
2. Confirm all 4 describe blocks pass: `validateTicketIdStructured`, `validateTicketId (throwing)`, `sanitizeTicketId`, `assertPathContainment`.
3. To verify path traversal is blocked, node REPL:
   ```js
   const { validateTicketId } = require('./workflows/lib/ticket-validation');
   validateTicketId('../evil'); // must throw
   validateTicketId('GH-219');  // must not throw
   validateTicketId('GH-219/phase1'); // must not throw
   ```
4. Existing consumers (`work-claims.js`, `allocate-output-folder.js`, etc.) are unchanged in this PR — no regression risk on existing behavior.

### Test Results

144-line test file covering:
- Valid ticket IDs accepted (`GH-219`, `PROJ-123`, `AB-1`, `GH-219/phase1`)
- Non-string, empty, and whitespace-padded inputs rejected with `INVALID_TICKET_ID` code
- Path traversal (`../x`, `GH-1/../evil`), backslash, colon, null byte all rejected
- Leading slash and multiple-slash formats rejected
- Trailing slash and dot-suffix rejected
- `assertPathContainment` guards against prefix-sibling attacks (`/base-extra/child` vs `/base`)

Closes #219