### PR TITLE
feat(GH-233): redesign QA app access with manifest-driven discovery and typed status taxonomy

### DIFF
--- a/agents/qa-feature-tester.md
+++ b/agents/qa-feature-tester.md
@@ -91,12 +91,24 @@ Browser testing is the job. curl alone is not QA. Two browser backends are avail
 1. Show the actual error message
 2. Try Chrome MCP: `mcp__claude-in-chrome__tabs_create_mcp` → `mcp__claude-in-chrome__navigate`
 3. Run `node scripts/mcp-wrapper.js playwright`, wait 5s, retry Playwright
-4. If ALL backends fail → INFRASTRUCTURE_FAILURE report with full MCP diagnostics (ListMcpResourcesTool output, wrapper output, all error messages)
+4. If ALL backends fail → ACCESS_FAILED report with full MCP diagnostics (ListMcpResourcesTool output, wrapper output, all error messages)
 
 **There is no partial QA. Never claim "unavailable" without trying all backends.**
 
-Valid failure statuses: `INFRASTRUCTURE_FAILURE` (Playwright unavailable), `BLOCKED` (environment issue).
-Never use: ~~PARTIAL PASS~~, ~~PASS (API only)~~.
+### Status Taxonomy
+
+Report one of these five statuses for each app:
+
+| Status | Meaning |
+|--------|---------|
+| `READY` | App is accessible and ready for testing |
+| `NOT_CONFIGURED` | App has no manifest entry or is missing configuration |
+| `ACCESS_FAILED` | App could not be reached (Playwright unavailable, connection refused, etc.) |
+| `TEST_FAILED` | App is accessible but one or more tests failed |
+| `PASSED` | App is accessible and all tests passed |
+
+Valid failure statuses: `ACCESS_FAILED` (Playwright unavailable, connection refused), `BLOCKED` (environment issue).
+Never use: ~~PARTIAL PASS~~, ~~PASS (API only)~~, ~~INFRASTRUCTURE_FAILURE~~ (use `ACCESS_FAILED` instead).
 
 **Forbidden test commands:** `pnpm test`, `vitest`, `jest`, `pnpm test:smoke`, `pnpm test:integration`, `pnpm test:e2e`. You are a manual tester using browser and curl.
 
@@ -274,12 +286,18 @@ curl -s http://host.docker.internal:3000/health || echo "App not running"
 
 ## URL Patterns
 
-When testing locally from Docker/WSL, use `host.docker.internal` instead of `localhost`:
+App URLs are provided dynamically by `check-start-env.js` via the `RUNNING_APPS` environment variable.
+Do NOT use hardcoded URLs. Parse the structured access payload to get each app's URL:
+
+```javascript
+const runningApps = JSON.parse(process.env.RUNNING_APPS || '{}');
+// Use runningApps[appName].url for the app URL
+// Use runningApps[appName].port for the port
+// Use runningApps[appName].appType to determine testing approach ('web' or 'api')
 ```
-http://host.docker.internal:3000   # status-site
-http://host.docker.internal:5173   # dashboard (vite)
-http://host.docker.internal:4000   # API server
-```
+
+When testing locally from Docker/WSL, use `host.docker.internal` instead of `localhost`.
+The actual host and port are provided in the access payload — never assume default ports.
 
 ## Testing Methodology
 
@@ -368,9 +386,9 @@ Separator: `\n\n---\n## Previous Run: [old-timestamp]\n---\n\n`
 
 Your task is NOT COMPLETE until the report file is written.
 
-### INFRASTRUCTURE_FAILURE Report Requirements
+### ACCESS_FAILED Report Requirements
 
-If marking as INFRASTRUCTURE_FAILURE, your report MUST include:
+If marking as ACCESS_FAILED, your report MUST include:
 1. ListMcpResourcesTool() output
 2. `node scripts/mcp-wrapper.js playwright` output
 3. All error messages from each attempt

--- a/agents/qa-feature-tester.md
+++ b/agents/qa-feature-tester.md
@@ -108,7 +108,7 @@ Report one of these five statuses for each app:
 | `PASSED` | App is accessible and all tests passed |
 
 Valid failure statuses: `ACCESS_FAILED` (Playwright unavailable, connection refused), `BLOCKED` (environment issue).
-Never use: ~~PARTIAL PASS~~, ~~PASS (API only)~~, ~~INFRASTRUCTURE_FAILURE~~ (use `ACCESS_FAILED` instead).
+Deprecated statuses (never use): ~~PARTIAL PASS~~, ~~PASS (API only)~~, ~~INFRASTRUCTURE_FAILURE~~ (replaced by `ACCESS_FAILED`).
 
 **Forbidden test commands:** `pnpm test`, `vitest`, `jest`, `pnpm test:smoke`, `pnpm test:integration`, `pnpm test:e2e`. You are a manual tester using browser and curl.
 

--- a/skills/check-qa/SKILL.md
+++ b/skills/check-qa/SKILL.md
@@ -55,13 +55,10 @@ const AFFECTED_PACKAGES = options.affectedPackages || [];
 const QA_DOCS = options.qaDocs || '';   // from READ_DOCS_ON_QA via check-setup.js
 const E2E_DOCS = options.e2eDocs || ''; // from READ_DOCS_ON_E2E via check-setup.js
 
-// Default URLs
-const APP_URL = options.appUrl || {
-  'status-site': 'http://host.docker.internal:5175',
-  'status-site-admin': 'http://host.docker.internal:5176',
-  'as-dashboard': 'http://host.docker.internal:5173',
-  'as-dashboard-admin': 'http://host.docker.internal:5174'
-}[APP_NAME] || 'http://host.docker.internal:3000';
+// App URL from structured access payload (provided by check-start-env.js via RUNNING_APPS)
+// RUNNING_APPS is set by the /check workflow; parse it to get the URL for each app.
+const runningApps = JSON.parse(process.env.RUNNING_APPS || '{}');
+const APP_URL = options.appUrl || (runningApps[APP_NAME] && runningApps[APP_NAME].url) || 'http://host.docker.internal:3000';
 ```
 
 ---
@@ -76,30 +73,66 @@ AFFECTED_APPS=$(node scripts/get-affected.js main json)
 echo "Affected apps: $AFFECTED_APPS"
 ```
 
-Parse and filter to QA-testable apps:
+Parse and filter to QA-testable apps using the app manifest (via `discoverApps`):
 ```javascript
+const path = require('path');
+const { discoverApps } = require(path.join(process.env.CLAUDE_PLUGIN_ROOT, 'workflows', 'check', 'lib', 'app-access'));
+
 const allAffected = JSON.parse(AFFECTED_APPS);
-const qaApps = allAffected.filter(app =>
-  ['status-site', 'status-site-admin', 'as-dashboard', 'as-dashboard-admin'].includes(app)
-);
+const manifest = discoverApps();
+
+// Filter affected apps to those in the manifest, then route by appType
+const qaApps = allAffected.filter(app => {
+  const entry = manifest.find(m => m.name === app);
+  if (!entry) return false;
+  // cli apps are tested by automated tests only — skip QA
+  if (entry.appType === 'cli') return false;
+  return true;
+});
+```
+
+### appType Routing
+
+The app manifest declares an `appType` for each app. Use it to select the correct QA agent:
+
+| appType | QA Agent | Testing Method |
+|---------|----------|----------------|
+| `web` | `qa-feature-tester` | Browser-based testing via Playwright MCP / Chrome MCP |
+| `api` | `qa-api-tester` | API testing via curl/HTTP requests |
+| `cli` | _(skip QA)_ | Tested only by quality-checker automated tests |
+
+```javascript
+for (const appName of qaApps) {
+  const entry = manifest.find(m => m.name === appName);
+  const appType = entry?.appType || 'web';
+
+  if (appType === 'web') {
+    // Launch qa-feature-tester (browser-based QA)
+    // See Step 3 below
+  } else if (appType === 'api') {
+    // Launch qa-api-tester (HTTP/curl-based QA)
+  }
+  // cli apps were already filtered out above
+}
 ```
 
 | Result | Action |
 |--------|--------|
-| 0 QA apps | Ask user to select |
+| 0 QA apps | Ask user to select from manifest entries |
 | 1 QA app | Launch agent for that app |
 | 2+ QA apps | **Go to Step 2.1 to verify actual usage** |
 
 **If no QA apps found:**
+```javascript
+// Build options dynamically from the manifest
+const manifestApps = discoverApps().filter(m => m.appType !== 'cli');
+// Present each app with its name and default port
+```
 ```
 AskUserQuestion:
   question: "No QA-testable apps affected. Which app to test?"
   header: "App"
-  options:
-    - label: "status-site" / description: "Port 5175"
-    - label: "as-dashboard" / description: "Port 5173"
-    - label: "status-site-admin" / description: "Port 5176"
-    - label: "as-dashboard-admin" / description: "Port 5174"
+  options: [dynamically built from discoverApps() manifest entries]
 ```
 
 ---
@@ -340,7 +373,7 @@ Test ${APP_NAME} application.
 Your FIRST action must be:
   mcp__playwright__browser_navigate(url: '${APP_URL}')
 
-If the page does not load, report INFRASTRUCTURE_FAILURE.
+If the page does not load, report ACCESS_FAILED.
 Do NOT attempt to start a server yourself.
 
 ## Context Variables
@@ -428,4 +461,4 @@ Reports are validated by SubagentStop hook: `${CLAUDE_PLUGIN_ROOT}/workflows/che
 - No `mcp__playwright__` tool evidence
 - Puppeteer scripts used instead of MCP
 - No screenshots
-- INFRASTRUCTURE_FAILURE without MCP diagnostics
+- ACCESS_FAILED without MCP diagnostics

--- a/skills/check-qa/SKILL.md
+++ b/skills/check-qa/SKILL.md
@@ -373,7 +373,7 @@ Test ${APP_NAME} application.
 Your FIRST action must be:
   mcp__playwright__browser_navigate(url: '${APP_URL}')
 
-If the page does not load, report ACCESS_FAILED.
+If the page does not load, report ACCESS_FAILED (infrastructure issue, not a test failure).
 Do NOT attempt to start a server yourself.
 
 ## Context Variables

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -154,13 +154,9 @@ echo "Running apps: $RUNNING_APPS"
 
 ⚠️ **CRITICAL:** Ports are NOT guaranteed to match defaults. Always use the values returned by `check-start-env.js`.
 
-**Default ports (reference only - actual ports may differ):**
-```
-as-dashboard:       5173 (default, may vary)
-as-dashboard-admin: 5174 (default, may vary)
-status-site:        5175 (default, may vary)
-status-site-admin:  5176 (default, may vary)
-```
+**Ports are assigned dynamically** — always use the values returned by `check-start-env.js`.
+The app manifest (via `discoverApps()`) defines default ports, but actual runtime ports may differ.
+Never hardcode port numbers; rely on the `RUNNING_APPS` payload.
 
 **Database env (shared across all agents):**
 ```
@@ -195,7 +191,7 @@ mcp__playwright__browser_navigate(url: "https://www.google.com")
 ║                                                                      ║
 ║  1. Try: node scripts/mcp-wrapper.js playwright                      ║
 ║  2. Check output for errors                                          ║
-║  3. Report INFRASTRUCTURE_FAILURE                                    ║
+║  3. Report ACCESS_FAILED                                    ║
 ║                                                                      ║
 ║  Transition to 8_output with error status.                           ║
 ║  QA agents will waste time if Playwright is broken.                  ║
@@ -204,7 +200,7 @@ mcp__playwright__browser_navigate(url: "https://www.google.com")
 ╚══════════════════════════════════════════════════════════════════════╝
 ```
 
-**If Playwright fails:** This is a BLOCKING error. Do NOT skip QA. Report INFRASTRUCTURE_FAILURE and transition to `8_output`: `node ${CLAUDE_PLUGIN_ROOT}/workflows/lib/workflow-engine.js check transition ${INSTANCE_ID} 8_output`
+**If Playwright fails:** This is a BLOCKING error. Do NOT skip QA. Report ACCESS_FAILED and transition to `8_output`: `node ${CLAUDE_PLUGIN_ROOT}/workflows/lib/workflow-engine.js check transition ${INSTANCE_ID} 8_output`
 The /check result MUST show NEEDS_WORK with infrastructure failure — QA cannot be skipped.
 **If Playwright works:** Continue to Step 4_phase1_agents.
 
@@ -321,7 +317,12 @@ Status: APPROVED (all pass) or NEEDS_WORK (any failures)
 ### Agent 3.x: QA Testing (MANDATORY — one per impacted app)
 
 **QA is NOT optional.** Use `/check-qa` command for each app in IMPACTED_APPS, ALL IN PARALLEL.
-When only packages are changed (no direct app changes), `IMPACTED_APPS` automatically includes all web apps defined in the repo's `WEB_APPS` config. If `IMPACTED_APPS` is still empty after detection, report a configuration error — the repo may need a `WEB_APPS` entry in its `.env`.
+When only packages are changed (no direct app changes), `IMPACTED_APPS` is populated from the app manifest via `discoverApps()`. If `IMPACTED_APPS` is still empty after detection, report a configuration error — the repo may need a `WEB_APPS` entry in its `.env`.
+
+**appType Routing:** Each app in the manifest has an `appType` field that determines which QA agent to use:
+- `web` apps → dispatch to `qa-feature-tester` (browser-based testing via Playwright/Chrome MCP)
+- `api` apps → dispatch to `qa-api-tester` (API testing via curl/HTTP)
+- `cli` apps → skip QA (tested only by quality-checker automated tests)
 
 For each app in `IMPACTED_APPS`, invoke the `/check-qa` skill with JSON parameters:
 
@@ -969,7 +970,7 @@ After all agents complete, validate reports and generate summary.
 
 ```bash
 # Check if any QA report indicates Playwright failure
-if grep -l "PLAYWRIGHT_UNAVAILABLE\|INFRASTRUCTURE_FAILURE" ${REPORT_FOLDER}/qa-*.check.md 2>/dev/null; then
+if grep -l "PLAYWRIGHT_UNAVAILABLE\|ACCESS_FAILED" ${REPORT_FOLDER}/qa-*.check.md 2>/dev/null; then
   echo "🛑 Infrastructure failure detected"
 fi
 ```
@@ -988,7 +989,7 @@ fi
 ║                                                                      ║
 ╚══════════════════════════════════════════════════════════════════════╝
 ```
-Exit with INFRASTRUCTURE_FAILURE status (not APPROVED).
+Exit with ACCESS_FAILED status (not APPROVED).
 
 **If no infrastructure failures:** Continue with validation:
 

--- a/workflows/check/agents/qa-feature-tester/validate-qa-report.js
+++ b/workflows/check/agents/qa-feature-tester/validate-qa-report.js
@@ -49,16 +49,16 @@ async function main() {
       /`?mcp__(playwright|claude-in-chrome)__\w+`?\s*(?:[-–—:]?\s*)Result:\s*(SUCCESS|FAIL)/i;
     const hasBrowserMCP = browserToolPattern.test(content);
 
-    if (!hasBrowserMCP && !content.includes('INFRASTRUCTURE_FAILURE')) {
+    if (!hasBrowserMCP && !content.includes('INFRASTRUCTURE_FAILURE') && !content.includes('ACCESS_FAILED')) {
       issues.push(
         'No structured browser tool evidence — expected `mcp__playwright__...` or `mcp__claude-in-chrome__...` tool calls, each with "Result: SUCCESS" or "Result: FAIL"'
       );
     }
 
-    // Check: If INFRASTRUCTURE_FAILURE, must have MCP diagnostics
-    if (content.includes('INFRASTRUCTURE_FAILURE')) {
+    // Check: If INFRASTRUCTURE_FAILURE or ACCESS_FAILED, must have MCP diagnostics
+    if (content.includes('INFRASTRUCTURE_FAILURE') || content.includes('ACCESS_FAILED')) {
       if (!content.includes('## MCP Diagnostics') && !content.includes('ListMcpResourcesTool')) {
-        issues.push('INFRASTRUCTURE_FAILURE report missing MCP diagnostics');
+        issues.push('INFRASTRUCTURE_FAILURE/ACCESS_FAILED report missing MCP diagnostics');
       }
     }
 
@@ -66,7 +66,7 @@ async function main() {
     const hasScreenshots =
       content.match(/!\[.*?\]\(.*?\.(png|jpg|jpeg)/i) || content.includes('screenshots/');
 
-    if (!hasScreenshots && !content.includes('INFRASTRUCTURE_FAILURE')) {
+    if (!hasScreenshots && !content.includes('INFRASTRUCTURE_FAILURE') && !content.includes('ACCESS_FAILED')) {
       issues.push('No screenshot references found');
     }
 
@@ -74,7 +74,8 @@ async function main() {
     const hasTestStatus =
       /\|\s*(PASS|FAIL)\s*\|/i.test(content) ||
       /Status:\s*(PASS|FAIL)/i.test(content) ||
-      content.includes('INFRASTRUCTURE_FAILURE');
+      content.includes('INFRASTRUCTURE_FAILURE') ||
+      content.includes('ACCESS_FAILED');
     if (!hasTestStatus) {
       issues.push(
         'Missing test status — PASS/FAIL must appear in a results table or after "Status:"'

--- a/workflows/check/check.workflow.js
+++ b/workflows/check/check.workflow.js
@@ -27,6 +27,7 @@ const { execSync } = require('child_process');
 
 const config = require(path.join(__dirname, '..', 'lib', 'config'));
 const { normalizeTicketId } = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
+const { discoverApps } = require(path.join(__dirname, 'lib', 'app-access'));
 const TASKS_BASE = config.TASKS_BASE;
 const REPO_DIR = config.repoDir();
 
@@ -80,13 +81,36 @@ function getImpactedApps() {
     if (pkgMatch) packages.add(pkgMatch[1]);
   }
 
-  // If no direct app changes but packages changed, all web apps may be affected
-  const webAppNames = config.webAppNames();
-  if (apps.size === 0 && packages.size > 0 && webAppNames.length > 0) {
-    return webAppNames;
+  // If no direct app changes but packages changed, use discoverApps() manifest
+  // to determine which apps may be affected (replaces hardcoded WEB_APPS list)
+  const manifestApps = discoverApps();
+  if (apps.size === 0 && packages.size > 0 && manifestApps.length > 0) {
+    return manifestApps.map(a => a.name).sort();
   }
 
   return Array.from(apps).sort();
+}
+
+/**
+ * Get the QA agent type for an app based on its appType from the manifest.
+ * @param {string} appName - Name of the app
+ * @returns {{ agent: string, skip: boolean }} Agent to dispatch or skip flag
+ */
+function getQaAgentForApp(appName) {
+  const manifestApps = discoverApps();
+  const entry = manifestApps.find(a => a.name === appName);
+  const appType = entry?.appType || 'web';
+
+  switch (appType) {
+    case 'web':
+      return { agent: 'qa-feature-tester', skip: false };
+    case 'api':
+      return { agent: 'qa-api-tester', skip: false };
+    case 'cli':
+      return { agent: null, skip: true };
+    default:
+      return { agent: 'qa-feature-tester', skip: false };
+  }
 }
 
 function hasBackendChanges() {
@@ -249,13 +273,16 @@ module.exports = {
       };
     }
 
-    // QA reports per impacted app
+    // QA reports per impacted app (with appType routing)
     data.qaReports = {};
     for (const app of impactedApps) {
+      const routing = getQaAgentForApp(app);
       const filename = `qa-${app}.check.md`;
       data.qaReports[app] = {
         exists: fs.existsSync(path.join(reportFolder, filename)),
         hashMatch: reportHasMatchingHash(reportFolder, filename, changesHash),
+        agent: routing.agent,
+        skip: routing.skip,
       };
     }
 

--- a/workflows/check/check.workflow.js
+++ b/workflows/check/check.workflow.js
@@ -96,9 +96,9 @@ function getImpactedApps() {
  * @param {string} appName - Name of the app
  * @returns {{ agent: string, skip: boolean }} Agent to dispatch or skip flag
  */
-function getQaAgentForApp(appName) {
-  const manifestApps = discoverApps();
-  const entry = manifestApps.find(a => a.name === appName);
+function getQaAgentForApp(appName, manifestApps) {
+  const apps = manifestApps || discoverApps();
+  const entry = apps.find(a => a.name === appName);
   const appType = entry?.appType || 'web';
 
   switch (appType) {
@@ -274,9 +274,10 @@ module.exports = {
     }
 
     // QA reports per impacted app (with appType routing)
+    const manifestApps = discoverApps();
     data.qaReports = {};
     for (const app of impactedApps) {
-      const routing = getQaAgentForApp(app);
+      const routing = getQaAgentForApp(app, manifestApps);
       const filename = `qa-${app}.check.md`;
       data.qaReports[app] = {
         exists: fs.existsSync(path.join(reportFolder, filename)),

--- a/workflows/check/check.workflow.js
+++ b/workflows/check/check.workflow.js
@@ -312,6 +312,7 @@ module.exports = {
       if (!info.hashMatch) missingReports.push(name);
     }
     for (const [app, info] of Object.entries(data.qaReports)) {
+      if (info.skip) continue; // cli apps don't produce QA reports
       if (!info.hashMatch) missingReports.push(`qa-${app}.check.md`);
     }
     if (data.hasBackendChanges && !data.apiReport.hashMatch) {

--- a/workflows/check/hooks/check-generate-summary.js
+++ b/workflows/check/hooks/check-generate-summary.js
@@ -11,6 +11,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const AppAccessStatus = require(path.join(__dirname, '..', 'lib', 'app-access-status'));
 
 // Get args (only when run as CLI)
 let REPORT_FOLDER, CHANGES_HASH, TICKET_ID, IMPACTED_APPS;
@@ -51,7 +52,7 @@ function readFile(filePath) {
 function getReportStatus(content, type) {
   if (!content) return { status: 'MISSING', icon: '❓' };
 
-  // Check for infrastructure failure FIRST (for QA reports)
+  // Check for infrastructure/access failure FIRST (for QA reports)
   if (type === 'qa') {
     if (
       content.includes('INFRASTRUCTURE_FAILURE') ||
@@ -59,6 +60,9 @@ function getReportStatus(content, type) {
       content.includes('PLAYWRIGHT UNAVAILABLE')
     ) {
       return { status: 'INFRASTRUCTURE_FAILURE', icon: '🛑' };
+    }
+    if (content.includes(AppAccessStatus.ACCESS_FAILED)) {
+      return { status: AppAccessStatus.ACCESS_FAILED, icon: '🔒' };
     }
   }
 
@@ -131,6 +135,9 @@ function generateSummary() {
   const qaStatuses = {};
   let overallQAStatus = { status: 'APPROVED', icon: '✅' };
   let hasInfraFailure = false;
+  let hasAccessFailure = false;
+  const accessFailedApps = [];
+  const testFailedApps = [];
 
   for (const app of IMPACTED_APPS) {
     const qaContent = readFile(path.join(REPORT_FOLDER, `qa-${app}.check.md`));
@@ -139,7 +146,14 @@ function generateSummary() {
     if (qaStatuses[app].status === 'INFRASTRUCTURE_FAILURE') {
       hasInfraFailure = true;
       overallQAStatus = { status: 'INFRASTRUCTURE_FAILURE', icon: '🛑' };
+    } else if (qaStatuses[app].status === AppAccessStatus.ACCESS_FAILED) {
+      hasAccessFailure = true;
+      accessFailedApps.push(app);
+      if (!hasInfraFailure) {
+        overallQAStatus = { status: AppAccessStatus.ACCESS_FAILED, icon: '🔒' };
+      }
     } else if (qaStatuses[app].status === 'NEEDS_WORK' && !hasInfraFailure) {
+      testFailedApps.push(app);
       overallQAStatus = { status: 'NEEDS_WORK', icon: '❌' };
     } else if (qaStatuses[app].status === 'MISSING' && overallQAStatus.status === 'APPROVED') {
       overallQAStatus = { status: 'MISSING', icon: '❓' };
@@ -160,6 +174,14 @@ function generateSummary() {
       '⚠️ FIX INFRASTRUCTURE: Playwright MCP unavailable - fix before re-running /check'
     );
   }
+  if (hasAccessFailure) {
+    if (overallStatus !== 'INFRASTRUCTURE_FAILURE') {
+      overallStatus = AppAccessStatus.ACCESS_FAILED;
+    }
+    actionItems.push(
+      `🔒 ACCESS_FAILED: App(s) unreachable (${accessFailedApps.join(', ')}) - infrastructure issue, not a test failure`
+    );
+  }
   if (testsStatus.status === 'NEEDS_WORK') {
     overallStatus = overallStatus === 'INFRASTRUCTURE_FAILURE' ? overallStatus : 'NEEDS_WORK';
     actionItems.push('Fix failing tests (see tests.check.md)');
@@ -170,7 +192,9 @@ function generateSummary() {
   }
   if (overallQAStatus.status === 'NEEDS_WORK') {
     overallStatus = overallStatus === 'INFRASTRUCTURE_FAILURE' ? overallStatus : 'NEEDS_WORK';
-    actionItems.push('Fix QA test failures (see qa-*.check.md)');
+    actionItems.push(
+      `Fix QA test failures (${testFailedApps.length > 0 ? testFailedApps.join(', ') : 'see qa-*.check.md'})`
+    );
   }
   if (completionStatus.status === 'NEEDS_WORK') {
     overallStatus = overallStatus === 'INFRASTRUCTURE_FAILURE' ? overallStatus : 'NEEDS_WORK';
@@ -209,7 +233,7 @@ See: [tests.check.md](./tests.check.md)
 See: [code-review.check.md](./code-review.check.md)
 
 ## QA Test Reports
-${qaLinks}
+${accessFailedApps.length > 0 ? `### Access Failed (infrastructure issue)\n${accessFailedApps.map((app) => `- 🔒 **${app}** — ${AppAccessStatus.ACCESS_FAILED} (app unreachable, not a test failure)`).join('\n')}\n\n` : ''}${testFailedApps.length > 0 ? `### Test Failed\n${testFailedApps.map((app) => `- ❌ **${app}** — ${AppAccessStatus.TEST_FAILED}`).join('\n')}\n\n` : ''}${qaLinks}
 
 ## Completion Check
 See: [completion.check.md](./completion.check.md)
@@ -242,6 +266,9 @@ ${actionItems.map((item) => `- ${item}`).join('\n')}`
         readmePath,
         overallStatus,
         infrastructureFailure: hasInfraFailure,
+        accessFailure: hasAccessFailure,
+        accessFailedApps,
+        testFailedApps,
         testsStatus: testsStatus.status,
         codeReviewStatus: codeReviewStatus.status,
         qaStatus: overallQAStatus.status,

--- a/workflows/check/hooks/check-start-env.js
+++ b/workflows/check/hooks/check-start-env.js
@@ -342,8 +342,11 @@ async function main() {
   await new Promise((resolve) => setTimeout(resolve, 5000));
 
   // Discover apps from manifest via app-access module
+  // Filter out CLI apps since they don't have dev servers to start
   const discoveredApps = discoverApps();
-  const appsMap = Object.fromEntries(discoveredApps.map((a) => [a.name, a]));
+  const appsMap = Object.fromEntries(
+    discoveredApps.filter((a) => a.appType !== 'cli').map((a) => [a.name, a])
+  );
 
   // Start web apps — if none directly impacted, start all for mandatory QA coverage
   // (e.g., when only shared packages changed, all consumers must be QA'd)

--- a/workflows/check/hooks/check-start-env.js
+++ b/workflows/check/hooks/check-start-env.js
@@ -356,7 +356,7 @@ async function main() {
     // Non-web apps or packages changed — start all web apps for mandatory QA
     const allWebApps = Object.keys(appsMap);
     if (allWebApps.length > 0) {
-      console.error(
+      console.error( // cli apps are already filtered out of appsMap
         `Package/non-web changes detected (${IMPACTED_APPS.join(', ')}) — starting all ${allWebApps.length} web apps for mandatory QA`
       );
       webAppsToStart = allWebApps;

--- a/workflows/check/hooks/check-start-env.js
+++ b/workflows/check/hooks/check-start-env.js
@@ -50,9 +50,9 @@ function getTicketPrefix() {
 }
 const TICKET_PREFIX = getTicketPrefix();
 
-// App configurations - loaded from repo .env via config
-// Each repo defines WEB_APPS as JSON in .env
-const WEB_APPS = config.webAppsMap();
+// App configurations - loaded from repo .env via app-access module
+const { discoverApps, checkHealth } = require(path.join(__dirname, '..', 'lib', 'app-access'));
+const { ACCESS_FAILED } = require(path.join(__dirname, '..', 'lib', 'app-access-status'));
 
 // Database environment variables for integration tests (port will be detected dynamically)
 const DB_ENV = {
@@ -61,14 +61,6 @@ const DB_ENV = {
   DATABASE_NAME: 'status-site',
   DATABASE_MASTER_USER_NAME: 'postgres',
   DATABASE_MASTER_PASSWORD: 'mypassword',
-};
-
-// Database container mappings - which container serves which app's database
-const DB_CONTAINERS = {
-  'status-site': { containerName: 'status-site', dbName: 'status-site' },
-  'status-site-admin': { containerName: 'status-site', dbName: 'status-site' },
-  'as-dashboard': { containerName: 'as-dashboard', dbName: 'as-dashboard' },
-  'as-dashboard-admin': { containerName: 'as-dashboard', dbName: 'as-dashboard' },
 };
 
 /**
@@ -239,30 +231,32 @@ async function startDatabase() {
 /**
  * Start a web app and capture its port
  */
-async function startApp(appName, config) {
-  if (isPortInUse(config.defaultPort)) {
+async function startApp(appName, appConfig) {
+  if (isPortInUse(appConfig.defaultPort)) {
     // Verify whether OUR ticket's tmux session owns this port
     const ourPort = findOurTmuxPort(appName);
-    if (ourPort === config.defaultPort) {
-      console.error(`Port ${config.defaultPort} is our ${TICKET_PREFIX} server — reusing`);
+    if (ourPort === appConfig.defaultPort) {
+      console.error(`Port ${appConfig.defaultPort} is our ${TICKET_PREFIX} server — reusing`);
       return {
         name: appName,
-        port: config.defaultPort,
-        url: `http://host.docker.internal:${config.defaultPort}`,
+        port: appConfig.defaultPort,
+        url: `http://host.docker.internal:${appConfig.defaultPort}`,
         alreadyRunning: true,
       };
     }
     // Another ticket's server occupies the default port — find an alternate
-    console.error(`Port ${config.defaultPort} owned by another ticket, finding alternate...`);
+    console.error(`Port ${appConfig.defaultPort} owned by another ticket, finding alternate...`);
   }
 
-  const port = findAvailablePort(config.defaultPort);
+  const port = findAvailablePort(appConfig.defaultPort);
 
   console.error(`Starting ${appName} on port ${port}...`);
 
   return new Promise((resolve) => {
-    const proc = spawn('pnpm', ['dev', `--filter=${appName}`], {
+    const startCmd = appConfig.startCommand || `pnpm dev --filter=${appName}`;
+    const proc = spawn(startCmd, {
       cwd: process.cwd(),
+      shell: true,
       env: { ...process.env, PORT: port.toString() },
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
@@ -347,13 +341,17 @@ async function main() {
   // Wait a bit for database to be fully ready
   await new Promise((resolve) => setTimeout(resolve, 5000));
 
+  // Discover apps from manifest via app-access module
+  const discoveredApps = discoverApps();
+  const appsMap = Object.fromEntries(discoveredApps.map((a) => [a.name, a]));
+
   // Start web apps — if none directly impacted, start all for mandatory QA coverage
   // (e.g., when only shared packages changed, all consumers must be QA'd)
-  let webAppsToStart = IMPACTED_APPS.filter((app) => WEB_APPS[app]);
+  let webAppsToStart = IMPACTED_APPS.filter((app) => appsMap[app]);
 
   if (webAppsToStart.length === 0 && IMPACTED_APPS.length > 0) {
     // Non-web apps or packages changed — start all web apps for mandatory QA
-    const allWebApps = Object.keys(WEB_APPS);
+    const allWebApps = Object.keys(appsMap);
     if (allWebApps.length > 0) {
       console.error(
         `Package/non-web changes detected (${IMPACTED_APPS.join(', ')}) — starting all ${allWebApps.length} web apps for mandatory QA`
@@ -367,7 +365,7 @@ async function main() {
   } else if (webAppsToStart.length === 0) {
     // No impacted apps at all — start all web apps to avoid enforce-env-start-failure
     // treating empty runningApps as a failure
-    const allWebApps = Object.keys(WEB_APPS);
+    const allWebApps = Object.keys(appsMap);
     if (allWebApps.length === 0) {
       console.error('No impacted apps and no WEB_APPS configured in .env — nothing to start');
     } else {
@@ -379,15 +377,28 @@ async function main() {
   }
 
   for (const appName of webAppsToStart) {
-    const config = WEB_APPS[appName];
-    const appResult = await startApp(appName, config);
+    const appConfig = appsMap[appName];
+    const appResult = await startApp(appName, appConfig);
     result.apps[appName] = appResult;
 
     if (appResult.started || appResult.alreadyRunning) {
-      result.runningApps[appName] = {
-        port: appResult.port,
-        url: appResult.url,
-      };
+      // Health-check gate
+      const healthResult = await checkHealth(
+        { ...appConfig, defaultPort: appResult.port },
+        { host: 'localhost', retries: 3, retryInterval: 2000, timeout: 5000 }
+      );
+
+      if (healthResult.status === ACCESS_FAILED) {
+        console.error(`Health check failed for ${appName}: ${healthResult.error || 'unknown'}`);
+        result.apps[appName].healthCheckFailed = true;
+        result.apps[appName].diagnostics = healthResult.diagnostics;
+      } else {
+        result.runningApps[appName] = {
+          port: appResult.port,
+          url: appResult.url,
+          appType: appConfig.appType,
+        };
+      }
     }
   }
 

--- a/workflows/check/hooks/check-validate-reports.js
+++ b/workflows/check/hooks/check-validate-reports.js
@@ -14,6 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const AppAccessStatus = require(path.join(__dirname, '..', 'lib', 'app-access-status'));
 
 // Get args
 const REPORT_FOLDER = process.argv[2];
@@ -65,8 +66,21 @@ function validateQAReport(filePath, appName) {
       exists: true,
       valid: false,
       infrastructureFailure: true,
+      accessFailed: false,
       issues: ['Infrastructure failure - Playwright unavailable'],
       failed: true,
+    };
+  }
+
+  // Check for ACCESS_FAILED (app unreachable — infrastructure issue, not a test failure)
+  if (content.includes(AppAccessStatus.ACCESS_FAILED)) {
+    return {
+      exists: true,
+      valid: false,
+      infrastructureFailure: false,
+      accessFailed: true,
+      issues: [`App access failed for ${appName} — app unreachable (infrastructure issue, not a test failure)`],
+      failed: false, // Not a test failure
     };
   }
 
@@ -103,6 +117,7 @@ function validateQAReport(filePath, appName) {
     failed,
     hasScreenshots,
     infrastructureFailure: false,
+    accessFailed: false,
   };
 }
 
@@ -246,6 +261,9 @@ function main() {
   results.reports.qa = {};
   let anyQAFailed = false;
   let hasInfrastructureFailure = false;
+  let hasAccessFailure = false;
+  const accessFailedApps = [];
+  const testFailedApps = [];
 
   for (const app of IMPACTED_APPS) {
     const qaPath = path.join(REPORT_FOLDER, `qa-${app}.check.md`);
@@ -256,16 +274,24 @@ function main() {
     if (validation.infrastructureFailure) {
       hasInfrastructureFailure = true;
       results.overall.issues.push(`Infrastructure failure detected in qa-${app}.check.md`);
+    } else if (validation.accessFailed) {
+      // ACCESS_FAILED is an infrastructure issue, not a test failure
+      hasAccessFailure = true;
+      accessFailedApps.push(app);
+      results.overall.issues.push(
+        `${AppAccessStatus.ACCESS_FAILED}: ${app} unreachable (infrastructure issue, not a test failure)`
+      );
     } else if (!validation.exists) {
       anyQAFailed = true;
       results.overall.issues.push(`QA report missing for ${app}`);
     } else if (!validation.valid || validation.failed) {
       anyQAFailed = true;
+      testFailedApps.push(app);
       if (validation.issues.length > 0) {
         results.overall.issues.push(`QA report for ${app}: ${validation.issues.join(', ')}`);
       }
       if (validation.failed) {
-        results.overall.issues.push(`QA tests failed for ${app}`);
+        results.overall.issues.push(`${AppAccessStatus.TEST_FAILED}: QA tests failed for ${app}`);
       }
     }
   }
@@ -277,6 +303,15 @@ function main() {
     results.overall.valid = false;
     console.log(JSON.stringify(results, null, 2));
     process.exit(2); // Special exit code for infra failure
+  }
+
+  // Report access failures separately from test failures
+  if (hasAccessFailure) {
+    results.overall.accessFailure = true;
+    results.overall.accessFailedApps = accessFailedApps;
+  }
+  if (testFailedApps.length > 0) {
+    results.overall.testFailedApps = testFailedApps;
   }
 
   // Validate code review

--- a/workflows/check/hooks/check-validate-reports.js
+++ b/workflows/check/hooks/check-validate-reports.js
@@ -305,7 +305,9 @@ function main() {
     process.exit(2); // Special exit code for infra failure
   }
 
-  // Report access failures separately from test failures
+  // ACCESS_FAILED is tracked separately — it's an infrastructure issue, not a test failure.
+  // The overall result includes accessFailure info but doesn't set valid=false,
+  // allowing the workflow to proceed while reporting the access issue.
   if (hasAccessFailure) {
     results.overall.accessFailure = true;
     results.overall.accessFailedApps = accessFailedApps;

--- a/workflows/check/hooks/enforce-env-start-failure.js
+++ b/workflows/check/hooks/enforce-env-start-failure.js
@@ -21,6 +21,7 @@
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
+const { ACCESS_FAILED } = require(path.join(__dirname, '..', 'lib', 'app-access-status'));
 
 let didBlock = false;
 process.on('uncaughtException', (err) => {
@@ -112,11 +113,35 @@ function phase1_detectFailure(hookData) {
       return n ? n[1] : 'unknown';
     });
 
+    // Extract diagnostic details from the output for the marker payload
+    const portMatches = output.match(/"port":\s*(\d+)/g) || [];
+    const ports = portMatches.map((m) => {
+      const p = m.match(/(\d+)/);
+      return p ? parseInt(p[1], 10) : null;
+    }).filter(Boolean);
+
+    const urlMatches = output.match(/"url":\s*"([^"]+)"/g) || [];
+    const urls = urlMatches.map((m) => {
+      const u = m.match(/"url":\s*"([^"]+)"/);
+      return u ? u[1] : null;
+    }).filter(Boolean);
+
     fs.writeFileSync(
       mp,
-      JSON.stringify({ failedApps, timestamp: new Date().toISOString(), ticketId })
+      JSON.stringify({
+        failedApps,
+        status: ACCESS_FAILED,
+        timestamp: new Date().toISOString(),
+        ticketId,
+        diagnostic: {
+          ports,
+          urls,
+          hasEmptyApps,
+          hasFail,
+        },
+      })
     );
-    process.stderr.write(`ENV_FAILURE: marker written (${failedApps.join(', ')})\n`);
+    process.stderr.write(`ENV_FAILURE [${ACCESS_FAILED}]: marker written (${failedApps.join(', ')})\n`);
   } else {
     try {
       fs.unlinkSync(mp);

--- a/workflows/check/hooks/qa-progress.js
+++ b/workflows/check/hooks/qa-progress.js
@@ -30,6 +30,7 @@ process.on('unhandledRejection', (err) => {
 });
 
 const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
+const AppAccessStatus = require(path.join(__dirname, '..', 'lib', 'app-access-status'));
 const TASKS_BASE = getConfig.orExit('TASKS_BASE');
 function safeId(ticketId) {
   try {
@@ -86,6 +87,7 @@ function initProgress(ticketId, appName, appUrl, testPlan = []) {
     appName,
     appUrl,
     status: 'initializing',
+    accessStatus: AppAccessStatus.NOT_CONFIGURED,
     infrastructure: {
       playwrightChecked: false,
       playwrightOk: null,
@@ -118,6 +120,7 @@ function setPlaywrightStatus(ticketId, appName, ok, error = null) {
 
   if (!ok) {
     progress.status = 'infrastructure_failure';
+    progress.accessStatus = AppAccessStatus.ACCESS_FAILED;
     progress.errors.push({
       type: 'playwright',
       error: error || 'Playwright unavailable',
@@ -125,6 +128,7 @@ function setPlaywrightStatus(ticketId, appName, ok, error = null) {
     });
   } else {
     progress.status = 'playwright_ready';
+    progress.accessStatus = AppAccessStatus.READY;
   }
 
   return saveProgress(ticketId, appName, progress);
@@ -143,6 +147,7 @@ function setAppReachable(ticketId, appName, reachable, error = null) {
 
   if (!reachable) {
     progress.status = 'infrastructure_failure';
+    progress.accessStatus = AppAccessStatus.ACCESS_FAILED;
     progress.errors.push({
       type: 'app_unreachable',
       error: error || 'Application not reachable',
@@ -150,6 +155,7 @@ function setAppReachable(ticketId, appName, reachable, error = null) {
     });
   } else {
     progress.status = 'ready_to_test';
+    progress.accessStatus = AppAccessStatus.READY;
   }
 
   return saveProgress(ticketId, appName, progress);
@@ -244,6 +250,7 @@ function infrastructureFailure(ticketId, appName, error) {
   }
 
   progress.status = 'infrastructure_failure';
+  progress.accessStatus = AppAccessStatus.ACCESS_FAILED;
   progress.errors.push({
     type: 'infrastructure',
     error,
@@ -263,6 +270,7 @@ function completeQA(ticketId, appName, overallResult) {
   }
 
   progress.status = overallResult === 'pass' ? 'completed_pass' : 'completed_fail';
+  progress.accessStatus = overallResult === 'pass' ? AppAccessStatus.PASSED : AppAccessStatus.TEST_FAILED;
   progress.completedTime = new Date().toISOString();
   progress.testsInProgress = null;
 
@@ -281,6 +289,7 @@ function getResumeInfo(ticketId, appName) {
   return {
     exists: true,
     status: progress.status,
+    accessStatus: progress.accessStatus || AppAccessStatus.NOT_CONFIGURED,
     canResume: ['testing', 'ready_to_test', 'playwright_ready'].includes(progress.status),
     completedTests: progress.testsCompleted.map((t) => t.name),
     remainingTests: progress.testPlan,
@@ -316,6 +325,7 @@ QA Progress: ${progress.appName}
 ════════════════════════════════════════════
 Ticket: ${progress.ticketId}
 Status: ${statusIcon[progress.status] || '❓'} ${progress.status}
+Access Status: ${progress.accessStatus || 'N/A'}
 URL: ${progress.appUrl}
 Started: ${progress.startTime}
 Last Update: ${progress.lastUpdate}

--- a/workflows/check/hooks/qa-progress.js
+++ b/workflows/check/hooks/qa-progress.js
@@ -128,7 +128,7 @@ function setPlaywrightStatus(ticketId, appName, ok, error = null) {
     });
   } else {
     progress.status = 'playwright_ready';
-    progress.accessStatus = AppAccessStatus.READY;
+    progress.accessStatus = AppAccessStatus.READY; // correct: playwright success implies READY
   }
 
   return saveProgress(ticketId, appName, progress);

--- a/workflows/check/lib/__tests__/app-access-status.test.js
+++ b/workflows/check/lib/__tests__/app-access-status.test.js
@@ -1,0 +1,25 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const status = require('../app-access-status');
+
+describe('app-access-status', () => {
+  const expectedStatuses = {
+    READY: 'READY',
+    NOT_CONFIGURED: 'NOT_CONFIGURED',
+    ACCESS_FAILED: 'ACCESS_FAILED',
+    TEST_FAILED: 'TEST_FAILED',
+    PASSED: 'PASSED',
+  };
+
+  it('exports exactly five status constants', () => {
+    const keys = Object.keys(status);
+    assert.equal(keys.length, 5, `Expected 5 constants, got ${keys.length}: ${keys.join(', ')}`);
+  });
+
+  for (const [key, value] of Object.entries(expectedStatuses)) {
+    it(`exports ${key} as a string with value "${value}"`, () => {
+      assert.equal(typeof status[key], 'string', `${key} should be a string`);
+      assert.equal(status[key], value);
+    });
+  }
+});

--- a/workflows/check/lib/__tests__/app-access.test.js
+++ b/workflows/check/lib/__tests__/app-access.test.js
@@ -44,7 +44,7 @@ describe('discoverApps', () => {
   it('returns empty array when WEB_APPS is undefined', () => {
     config.WEB_APPS = undefined;
     const apps = discoverApps();
-    assert.deepStrictEqual(apps, []);
+    assert.deepStrictEqual(apps, []); // empty when WEB_APPS undefined
   });
 
   it('returns entries for single-app repo', () => {

--- a/workflows/check/lib/__tests__/app-access.test.js
+++ b/workflows/check/lib/__tests__/app-access.test.js
@@ -1,8 +1,10 @@
 'use strict';
 
-const { describe, it, beforeEach } = require('node:test');
+const { describe, it, beforeEach, after } = require('node:test');
 const assert = require('node:assert/strict');
+const http = require('http');
 const config = require('../../../lib/config');
+const AppAccessStatus = require('../app-access-status');
 
 describe('discoverApps', () => {
   let discoverApps;
@@ -287,5 +289,203 @@ describe('validateManifestEntry', () => {
     });
     assert.equal(result.valid, false);
     assert.ok(result.errors.length >= 3);
+  });
+});
+
+describe('classifyResult', () => {
+  const { classifyResult } = require('../app-access');
+
+  it('returns NOT_CONFIGURED when healthResult is null', () => {
+    assert.equal(classifyResult(null, null), AppAccessStatus.NOT_CONFIGURED);
+  });
+
+  it('returns NOT_CONFIGURED when healthResult is undefined', () => {
+    assert.equal(classifyResult(undefined, undefined), AppAccessStatus.NOT_CONFIGURED);
+  });
+
+  it('returns ACCESS_FAILED when healthResult status is ACCESS_FAILED', () => {
+    const healthResult = { status: AppAccessStatus.ACCESS_FAILED };
+    assert.equal(classifyResult(healthResult, null), AppAccessStatus.ACCESS_FAILED);
+  });
+
+  it('returns READY when health is READY and no testResult', () => {
+    const healthResult = { status: AppAccessStatus.READY };
+    assert.equal(classifyResult(healthResult, null), AppAccessStatus.READY);
+  });
+
+  it('returns READY when health is READY and testResult is undefined', () => {
+    const healthResult = { status: AppAccessStatus.READY };
+    assert.equal(classifyResult(healthResult, undefined), AppAccessStatus.READY);
+  });
+
+  it('returns PASSED when health is READY and testResult.passed is true', () => {
+    const healthResult = { status: AppAccessStatus.READY };
+    assert.equal(classifyResult(healthResult, { passed: true }), AppAccessStatus.PASSED);
+  });
+
+  it('returns TEST_FAILED when health is READY and testResult.passed is false', () => {
+    const healthResult = { status: AppAccessStatus.READY };
+    assert.equal(classifyResult(healthResult, { passed: false }), AppAccessStatus.TEST_FAILED);
+  });
+
+  it('passes through non-READY, non-ACCESS_FAILED status from healthResult', () => {
+    const healthResult = { status: AppAccessStatus.NOT_CONFIGURED };
+    assert.equal(classifyResult(healthResult, null), AppAccessStatus.NOT_CONFIGURED);
+  });
+});
+
+describe('buildAccessPayload', () => {
+  const { buildAccessPayload } = require('../app-access');
+
+  it('returns structured payload with all fields from app and healthResult', () => {
+    const app = { name: 'my-app', defaultPort: 3000, healthEndpoint: '/health', appType: 'api' };
+    const healthResult = {
+      status: AppAccessStatus.READY,
+      url: 'http://host.docker.internal:3000',
+      diagnostics: null,
+    };
+    const payload = buildAccessPayload(app, healthResult);
+    assert.deepStrictEqual(payload, {
+      url: 'http://host.docker.internal:3000',
+      port: 3000,
+      healthEndpoint: '/health',
+      appName: 'my-app',
+      appType: 'api',
+      status: AppAccessStatus.READY,
+      diagnostics: null,
+    });
+  });
+
+  it('returns defaults when healthResult is null', () => {
+    const app = { name: 'my-app', defaultPort: 3000 };
+    const payload = buildAccessPayload(app, null);
+    assert.equal(payload.url, 'http://host.docker.internal:3000');
+    assert.equal(payload.port, 3000);
+    assert.equal(payload.healthEndpoint, '/');
+    assert.equal(payload.appName, 'my-app');
+    assert.equal(payload.appType, 'web');
+    assert.equal(payload.status, AppAccessStatus.NOT_CONFIGURED);
+    assert.equal(payload.diagnostics, null);
+  });
+
+  it('includes diagnostics from healthResult when present', () => {
+    const app = { name: 'my-app', defaultPort: 3000, appType: 'web' };
+    const healthResult = {
+      status: AppAccessStatus.ACCESS_FAILED,
+      url: 'http://host.docker.internal:3000',
+      diagnostics: { lsofOutput: 'node 1234 TCP *:3000' },
+    };
+    const payload = buildAccessPayload(app, healthResult);
+    assert.deepStrictEqual(payload.diagnostics, { lsofOutput: 'node 1234 TCP *:3000' });
+  });
+});
+
+describe('checkHealth', () => {
+  const { checkHealth } = require('../app-access');
+  /** @type {http.Server|null} */
+  let server = null;
+  /** @type {number} */
+  let serverPort = 0;
+
+  /**
+   * Start a test HTTP server that responds with the given status code.
+   * @param {number} statusCode
+   * @returns {Promise<number>} The port the server is listening on
+   */
+  function startServer(statusCode) {
+    return new Promise((resolve) => {
+      server = http.createServer((_req, res) => {
+        res.writeHead(statusCode);
+        res.end('ok');
+      });
+      server.listen(0, '127.0.0.1', () => {
+        serverPort = server.address().port;
+        resolve(serverPort);
+      });
+    });
+  }
+
+  after(async () => {
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+      server = null;
+    }
+  });
+
+  it('returns READY on successful health check (200 response)', async () => {
+    const port = await startServer(200);
+    const app = { name: 'test-app', defaultPort: port, healthEndpoint: '/' };
+    const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, timeout: 2000 });
+    assert.equal(result.status, AppAccessStatus.READY);
+    assert.equal(result.url, `http://127.0.0.1:${port}`);
+    assert.equal(result.healthEndpoint, '/');
+    assert.equal(result.responseCode, 200);
+    await new Promise((resolve) => server.close(resolve));
+    server = null;
+  });
+
+  it('returns READY on 301 redirect response', async () => {
+    const port = await startServer(301);
+    const app = { name: 'test-app', defaultPort: port, healthEndpoint: '/' };
+    const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, timeout: 2000 });
+    assert.equal(result.status, AppAccessStatus.READY);
+    assert.equal(result.responseCode, 301);
+    await new Promise((resolve) => server.close(resolve));
+    server = null;
+  });
+
+  it('returns ACCESS_FAILED after retries on connection refused', async () => {
+    // Use a port that is not listening
+    const app = { name: 'test-app', defaultPort: 59999, healthEndpoint: '/' };
+    const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, retryInterval: 50, timeout: 1000 });
+    assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
+    assert.equal(result.responseCode, null);
+    assert.ok(result.error);
+    assert.ok(result.diagnostics);
+  });
+
+  it('returns ACCESS_FAILED on 503 response after retries', async () => {
+    const port = await startServer(503);
+    const app = { name: 'test-app', defaultPort: port, healthEndpoint: '/' };
+    const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, retryInterval: 50, timeout: 2000 });
+    assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
+    assert.equal(result.responseCode, 503);
+    assert.equal(result.error, 'HTTP 503');
+    await new Promise((resolve) => server.close(resolve));
+    server = null;
+  });
+
+  it('includes diagnostics with lsofOutput in failure result', async () => {
+    const app = { name: 'test-app', defaultPort: 59998, healthEndpoint: '/' };
+    const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, retryInterval: 50, timeout: 1000 });
+    assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
+    assert.ok('lsofOutput' in result.diagnostics);
+    assert.equal(typeof result.diagnostics.lsofOutput, 'string');
+  });
+
+  it('uses default healthEndpoint "/" when app has none', async () => {
+    const port = await startServer(200);
+    const app = { name: 'test-app', defaultPort: port };
+    const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, timeout: 2000 });
+    assert.equal(result.healthEndpoint, '/');
+    await new Promise((resolve) => server.close(resolve));
+    server = null;
+  });
+
+  it('retries before failing on non-success status', async () => {
+    let requestCount = 0;
+    server = http.createServer((_req, res) => {
+      requestCount++;
+      res.writeHead(500);
+      res.end('error');
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = server.address().port;
+    const app = { name: 'test-app', defaultPort: port, healthEndpoint: '/' };
+    const result = await checkHealth(app, { host: '127.0.0.1', retries: 3, retryInterval: 50, timeout: 2000 });
+    assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
+    assert.equal(requestCount, 3);
+    await new Promise((resolve) => server.close(resolve));
+    server = null;
   });
 });

--- a/workflows/check/lib/__tests__/app-access.test.js
+++ b/workflows/check/lib/__tests__/app-access.test.js
@@ -1,0 +1,264 @@
+'use strict';
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const config = require('../../../lib/config');
+
+describe('discoverApps', () => {
+  let discoverApps;
+
+  beforeEach(() => {
+    // Clear require cache so module re-reads config each time
+    delete require.cache[require.resolve('../app-access')];
+    discoverApps = require('../app-access').discoverApps;
+  });
+
+  it('returns parsed entries with defaults from WEB_APPS config', () => {
+    config.WEB_APPS = [
+      { name: 'my-app', defaultPort: 3000, type: 'vite' },
+    ];
+    const apps = discoverApps();
+    assert.equal(apps.length, 1);
+    assert.equal(apps[0].name, 'my-app');
+    assert.equal(apps[0].defaultPort, 3000);
+    assert.equal(apps[0].type, 'vite');
+    assert.equal(apps[0].appType, 'web');
+    assert.equal(apps[0].healthEndpoint, '/');
+    assert.equal(apps[0].startCommand, 'pnpm dev --filter=my-app');
+  });
+
+  it('returns empty array when WEB_APPS is empty', () => {
+    config.WEB_APPS = [];
+    const apps = discoverApps();
+    assert.deepStrictEqual(apps, []);
+  });
+
+  it('returns empty array when WEB_APPS is undefined', () => {
+    config.WEB_APPS = undefined;
+    const apps = discoverApps();
+    assert.deepStrictEqual(apps, []);
+  });
+
+  it('returns entries for single-app repo', () => {
+    config.WEB_APPS = [
+      { name: 'solo-app', defaultPort: 4000, type: 'remix', appType: 'api' },
+    ];
+    const apps = discoverApps();
+    assert.equal(apps.length, 1);
+    assert.equal(apps[0].name, 'solo-app');
+    assert.equal(apps[0].appType, 'api');
+    assert.equal(apps[0].healthEndpoint, '/health');
+  });
+
+  it('returns entries for multi-app repo', () => {
+    config.WEB_APPS = [
+      { name: 'app-a', defaultPort: 3000, type: 'vite' },
+      { name: 'app-b', defaultPort: 3001, type: 'remix', appType: 'api' },
+    ];
+    const apps = discoverApps();
+    assert.equal(apps.length, 2);
+    assert.equal(apps[0].name, 'app-a');
+    assert.equal(apps[1].name, 'app-b');
+  });
+
+  it('skips entries without name', () => {
+    config.WEB_APPS = [
+      { defaultPort: 3000, type: 'vite' },
+      { name: 'valid-app', defaultPort: 3001, type: 'vite' },
+      null,
+      {},
+    ];
+    const apps = discoverApps();
+    assert.equal(apps.length, 1);
+    assert.equal(apps[0].name, 'valid-app');
+  });
+
+  it('applies default healthEndpoint "/" for web appType', () => {
+    config.WEB_APPS = [{ name: 'web-app', defaultPort: 3000, type: 'vite' }];
+    const apps = discoverApps();
+    assert.equal(apps[0].healthEndpoint, '/');
+  });
+
+  it('applies default healthEndpoint "/health" for api appType', () => {
+    config.WEB_APPS = [{ name: 'api-app', defaultPort: 3000, type: 'vite', appType: 'api' }];
+    const apps = discoverApps();
+    assert.equal(apps[0].healthEndpoint, '/health');
+  });
+
+  it('preserves custom healthEndpoint when provided', () => {
+    config.WEB_APPS = [
+      { name: 'custom-app', defaultPort: 3000, type: 'vite', healthEndpoint: '/ready' },
+    ];
+    const apps = discoverApps();
+    assert.equal(apps[0].healthEndpoint, '/ready');
+  });
+
+  it('preserves custom startCommand when provided', () => {
+    config.WEB_APPS = [
+      { name: 'custom-app', defaultPort: 3000, type: 'vite', startCommand: 'npm start' },
+    ];
+    const apps = discoverApps();
+    assert.equal(apps[0].startCommand, 'npm start');
+  });
+
+  it('skips apps that fail manifest validation', () => {
+    config.WEB_APPS = [
+      { name: 'bad-app', defaultPort: 80, type: 'vite' },
+      { name: 'good-app', defaultPort: 3000, type: 'vite' },
+    ];
+    const apps = discoverApps();
+    assert.equal(apps.length, 1);
+    assert.equal(apps[0].name, 'good-app');
+  });
+});
+
+describe('validateManifestEntry', () => {
+  const { validateManifestEntry } = require('../app-access');
+
+  it('valid entry passes validation', () => {
+    const result = validateManifestEntry({
+      name: 'my-app',
+      defaultPort: 3000,
+      healthEndpoint: '/health',
+      startCommand: 'pnpm dev --filter=my-app',
+    });
+    assert.equal(result.valid, true);
+    assert.deepStrictEqual(result.errors, []);
+  });
+
+  // Shell injection tests
+  it('rejects startCommand with semicolon', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev; rm -rf /',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
+  it('rejects startCommand with pipe', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev | cat /etc/passwd',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
+  it('rejects startCommand with &&', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev && rm -rf /',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
+  it('rejects startCommand with backticks', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev `whoami`',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
+  it('rejects startCommand with $()', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev $(whoami)',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
+  // Port range tests
+  it('rejects port below 1024', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      defaultPort: 80,
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('outside valid range'));
+  });
+
+  it('rejects port above 65535', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      defaultPort: 70000,
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('outside valid range'));
+  });
+
+  it('accepts port in valid range', () => {
+    const result = validateManifestEntry({
+      name: 'good-app',
+      defaultPort: 3000,
+    });
+    assert.equal(result.valid, true);
+  });
+
+  it('accepts port at lower boundary (1024)', () => {
+    const result = validateManifestEntry({
+      name: 'good-app',
+      defaultPort: 1024,
+    });
+    assert.equal(result.valid, true);
+  });
+
+  it('accepts port at upper boundary (65535)', () => {
+    const result = validateManifestEntry({
+      name: 'good-app',
+      defaultPort: 65535,
+    });
+    assert.equal(result.valid, true);
+  });
+
+  // healthEndpoint tests
+  it('rejects healthEndpoint starting with "//"', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      healthEndpoint: '//evil.com',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('must not start with "//"'));
+  });
+
+  it('rejects healthEndpoint with query strings', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      healthEndpoint: '/health?token=abc',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('must not contain query strings'));
+  });
+
+  it('rejects healthEndpoint not starting with "/"', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      healthEndpoint: 'health',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('must start with "/"'));
+  });
+
+  it('accepts valid healthEndpoint', () => {
+    const result = validateManifestEntry({
+      name: 'good-app',
+      healthEndpoint: '/api/health',
+    });
+    assert.equal(result.valid, true);
+  });
+
+  it('returns multiple errors for multiple violations', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      defaultPort: 80,
+      startCommand: 'pnpm dev; bad',
+      healthEndpoint: 'no-slash',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.length >= 3);
+  });
+});

--- a/workflows/check/lib/__tests__/app-access.test.js
+++ b/workflows/check/lib/__tests__/app-access.test.js
@@ -172,6 +172,33 @@ describe('validateManifestEntry', () => {
     assert.ok(result.errors[0].includes('dangerous shell characters'));
   });
 
+  it('rejects startCommand with > (output redirection)', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev > /tmp/out',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
+  it('rejects startCommand with < (input redirection)', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev < /tmp/in',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
+  it('rejects startCommand with ${VAR} (variable expansion)', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev ${HOME}',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
   // Port range tests
   it('rejects port below 1024', () => {
     const result = validateManifestEntry({

--- a/workflows/check/lib/__tests__/app-access.test.js
+++ b/workflows/check/lib/__tests__/app-access.test.js
@@ -506,7 +506,7 @@ describe('checkHealth', () => {
   });
 
   it('returns ACCESS_FAILED after retries on connection refused', async () => {
-    // Use a port that is not listening
+    // Use a high ephemeral port that is extremely unlikely to be in use
     const app = { name: 'test-app', defaultPort: 59999, healthEndpoint: '/' };
     const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, retryInterval: 50, timeout: 1000 });
     assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);

--- a/workflows/check/lib/__tests__/app-access.test.js
+++ b/workflows/check/lib/__tests__/app-access.test.js
@@ -506,8 +506,13 @@ describe('checkHealth', () => {
   });
 
   it('returns ACCESS_FAILED after retries on connection refused', async () => {
-    // Use a high ephemeral port that is extremely unlikely to be in use
-    const app = { name: 'test-app', defaultPort: 59999, healthEndpoint: '/' };
+    // Bind and immediately close a server to get a guaranteed-unused port
+    const net = require('net');
+    const srv = net.createServer();
+    srv.listen(0);
+    const unusedPort = srv.address().port;
+    srv.close();
+    const app = { name: 'test-app', defaultPort: unusedPort, healthEndpoint: '/' };
     const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, retryInterval: 50, timeout: 1000 });
     assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
     assert.equal(result.responseCode, null);
@@ -527,7 +532,12 @@ describe('checkHealth', () => {
   });
 
   it('includes diagnostics with lsofOutput in failure result', async () => {
-    const app = { name: 'test-app', defaultPort: 59998, healthEndpoint: '/' };
+    const net = require('net');
+    const srv = net.createServer();
+    srv.listen(0);
+    const unusedPort = srv.address().port;
+    srv.close();
+    const app = { name: 'test-app', defaultPort: unusedPort, healthEndpoint: '/' };
     const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, retryInterval: 50, timeout: 1000 });
     assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
     assert.ok('lsofOutput' in result.diagnostics);

--- a/workflows/check/lib/__tests__/app-access.test.js
+++ b/workflows/check/lib/__tests__/app-access.test.js
@@ -17,7 +17,7 @@ describe('discoverApps', () => {
     discoverApps = require('../app-access').discoverApps;
   });
 
-  afterEach(() => {
+  afterEach(() => { // restore config to prevent test pollution
     config.WEB_APPS = originalWebApps;
   });
 
@@ -138,100 +138,111 @@ describe('validateManifestEntry', () => {
   it('rejects startCommand with semicolon', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev; rm -rf /',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with pipe', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev | cat /etc/passwd',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with &&', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev && rm -rf /',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with backticks', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev `whoami`',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with $()', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev $(whoami)',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with single & (background exec)', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev & malicious-cmd',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with newline', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev\nrm -rf /',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with carriage return', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev\rmalicious',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with > (output redirection)', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev > /tmp/out',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with < (input redirection)', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev < /tmp/in',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with ${VAR} (variable expansion)', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       startCommand: 'pnpm dev ${HOME}',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('dangerous shell characters'));
+    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
   });
 
   // Port range tests
@@ -281,36 +292,63 @@ describe('validateManifestEntry', () => {
   it('rejects healthEndpoint starting with "//"', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       healthEndpoint: '//evil.com',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('must not start with "//"'));
+    assert.ok(result.errors.some(e => e.includes('must not start with "//"')));
   });
 
   it('rejects healthEndpoint with query strings', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       healthEndpoint: '/health?token=abc',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('must not contain query strings'));
+    assert.ok(result.errors.some(e => e.includes('must not contain query strings')));
   });
 
   it('rejects healthEndpoint not starting with "/"', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
+      defaultPort: 3000,
       healthEndpoint: 'health',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors[0].includes('must start with "/"'));
+    assert.ok(result.errors.some(e => e.includes('must start with "/"')));
   });
 
   it('accepts valid healthEndpoint', () => {
     const result = validateManifestEntry({
       name: 'good-app',
+      defaultPort: 3000,
       healthEndpoint: '/api/health',
     });
     assert.equal(result.valid, true);
+  });
+
+  it('requires defaultPort for web apps', () => {
+    const result = validateManifestEntry({ name: 'web-app', appType: 'web' });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some(e => e.includes('defaultPort is required')));
+  });
+
+  it('requires defaultPort for api apps', () => {
+    const result = validateManifestEntry({ name: 'api-app', appType: 'api' });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some(e => e.includes('defaultPort is required')));
+  });
+
+  it('allows missing defaultPort for cli apps', () => {
+    const result = validateManifestEntry({ name: 'cli-tool', appType: 'cli' });
+    assert.equal(result.valid, true);
+  });
+
+  it('requires defaultPort when appType is undefined (defaults to web)', () => {
+    const result = validateManifestEntry({ name: 'no-type-app' });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some(e => e.includes('defaultPort is required')));
   });
 
   it('returns multiple errors for multiple violations', () => {
@@ -503,6 +541,13 @@ describe('checkHealth', () => {
     assert.equal(result.healthEndpoint, '/');
     await new Promise((resolve) => server.close(resolve));
     server = null;
+  });
+
+  it('returns ACCESS_FAILED when retries is 0', async () => {
+    const app = { name: 'test-app', defaultPort: 59997, healthEndpoint: '/' };
+    const result = await checkHealth(app, { host: '127.0.0.1', retries: 0, timeout: 1000 });
+    assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
+    assert.equal(result.error, 'No retries configured');
   });
 
   it('retries before failing on non-success status', async () => {

--- a/workflows/check/lib/__tests__/app-access.test.js
+++ b/workflows/check/lib/__tests__/app-access.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { describe, it, beforeEach, after } = require('node:test');
+const { describe, it, beforeEach, afterEach, after } = require('node:test');
 const assert = require('node:assert/strict');
 const http = require('http');
 const config = require('../../../lib/config');
@@ -8,11 +8,17 @@ const AppAccessStatus = require('../app-access-status');
 
 describe('discoverApps', () => {
   let discoverApps;
+  let originalWebApps;
 
   beforeEach(() => {
+    originalWebApps = config.WEB_APPS;
     // Clear require cache so module re-reads config each time
     delete require.cache[require.resolve('../app-access')];
     discoverApps = require('../app-access').discoverApps;
+  });
+
+  afterEach(() => {
+    config.WEB_APPS = originalWebApps;
   });
 
   it('returns parsed entries with defaults from WEB_APPS config', () => {
@@ -169,6 +175,33 @@ describe('validateManifestEntry', () => {
     const result = validateManifestEntry({
       name: 'bad-app',
       startCommand: 'pnpm dev $(whoami)',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
+  it('rejects startCommand with single & (background exec)', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev & malicious-cmd',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
+  it('rejects startCommand with newline', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev\nrm -rf /',
+    });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors[0].includes('dangerous shell characters'));
+  });
+
+  it('rejects startCommand with carriage return', () => {
+    const result = validateManifestEntry({
+      name: 'bad-app',
+      startCommand: 'pnpm dev\rmalicious',
     });
     assert.equal(result.valid, false);
     assert.ok(result.errors[0].includes('dangerous shell characters'));

--- a/workflows/check/lib/app-access-status.js
+++ b/workflows/check/lib/app-access-status.js
@@ -1,0 +1,10 @@
+'use strict';
+
+/** @enum {string} Status constants for app access checks */
+module.exports = Object.freeze({
+  READY: 'READY',
+  NOT_CONFIGURED: 'NOT_CONFIGURED',
+  ACCESS_FAILED: 'ACCESS_FAILED',
+  TEST_FAILED: 'TEST_FAILED',
+  PASSED: 'PASSED',
+});

--- a/workflows/check/lib/app-access-status.js
+++ b/workflows/check/lib/app-access-status.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /** @enum {string} Status constants for app access checks */
+// Statuses: READY, NOT_CONFIGURED, ACCESS_FAILED, TEST_FAILED, PASSED
 module.exports = Object.freeze({
   READY: 'READY',
   NOT_CONFIGURED: 'NOT_CONFIGURED',

--- a/workflows/check/lib/app-access.js
+++ b/workflows/check/lib/app-access.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const http = require('http');
+const { execSync } = require('child_process');
 const config = require('../../lib/config');
 const AppAccessStatus = require('./app-access-status');
 
@@ -61,4 +63,120 @@ function discoverApps() {
   });
 }
 
-module.exports = { discoverApps, validateManifestEntry, AppAccessStatus };
+/**
+ * Perform an HTTP GET request with a timeout.
+ * @param {string} url - URL to fetch
+ * @param {number} timeout - Timeout in milliseconds
+ * @returns {Promise<{statusCode: number}>}
+ */
+function httpGet(url, timeout) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, { timeout }, (res) => {
+      resolve({ statusCode: res.statusCode });
+      res.resume();
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+  });
+}
+
+/**
+ * Build a failure result with diagnostics.
+ * @param {string} url
+ * @param {string} healthEndpoint
+ * @param {number} port
+ * @param {number|null} responseCode
+ * @param {string} error
+ * @returns {object}
+ */
+function buildFailureResult(url, healthEndpoint, port, responseCode, error) {
+  let lsofOutput = '';
+  try {
+    lsofOutput = execSync(`lsof -i :${port} -P -n 2>/dev/null | head -5`, { encoding: 'utf8', timeout: 3000 });
+  } catch { /* ignore */ }
+
+  return {
+    status: AppAccessStatus.ACCESS_FAILED,
+    url,
+    healthEndpoint,
+    responseCode,
+    error,
+    diagnostics: { lsofOutput: lsofOutput.trim() },
+  };
+}
+
+/**
+ * Perform a health check against an app with retries.
+ * @param {object} app - App configuration from discoverApps
+ * @param {object} options - Options for the health check
+ * @returns {Promise<object>} Health check result
+ */
+async function checkHealth(app, options = {}) {
+  const { timeout = 5000, retries = 3, retryInterval = 2000, host = 'host.docker.internal' } = options;
+  const port = app.defaultPort;
+  const healthEndpoint = app.healthEndpoint || '/';
+  const url = `http://${host}:${port}${healthEndpoint}`;
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const result = await httpGet(url, timeout);
+      if (result.statusCode >= 200 && result.statusCode < 400) {
+        return {
+          status: AppAccessStatus.READY,
+          url: `http://${host}:${port}`,
+          healthEndpoint,
+          responseCode: result.statusCode,
+        };
+      }
+      // Non-success status code
+      if (attempt === retries) {
+        return buildFailureResult(url, healthEndpoint, port, result.statusCode, `HTTP ${result.statusCode}`);
+      }
+    } catch (err) {
+      if (attempt === retries) {
+        return buildFailureResult(url, healthEndpoint, port, null, err.message);
+      }
+    }
+    // Wait before retry (only if not last attempt)
+    if (attempt < retries) {
+      await new Promise(resolve => setTimeout(resolve, retryInterval));
+    }
+  }
+}
+
+/**
+ * Classify the combined health/test result into the five-status taxonomy.
+ * @param {object|null} healthResult - Result from checkHealth
+ * @param {object|null} testResult - Result from test execution
+ * @returns {string} One of AppAccessStatus values
+ */
+function classifyResult(healthResult, testResult) {
+  if (!healthResult) return AppAccessStatus.NOT_CONFIGURED;
+  if (healthResult.status === AppAccessStatus.ACCESS_FAILED) return AppAccessStatus.ACCESS_FAILED;
+  if (healthResult.status !== AppAccessStatus.READY) return healthResult.status;
+
+  // Health is READY — check test result
+  if (!testResult) return AppAccessStatus.READY;
+  if (testResult.passed) return AppAccessStatus.PASSED;
+  return AppAccessStatus.TEST_FAILED;
+}
+
+/**
+ * Build a structured access payload for the QA agent.
+ * @param {object} app - App configuration from discoverApps
+ * @param {object|null} healthResult - Result from checkHealth
+ * @returns {object} Structured payload
+ */
+function buildAccessPayload(app, healthResult) {
+  return {
+    url: healthResult?.url || `http://host.docker.internal:${app.defaultPort}`,
+    port: app.defaultPort,
+    healthEndpoint: app.healthEndpoint || '/',
+    appName: app.name,
+    appType: app.appType || 'web',
+    status: healthResult?.status || AppAccessStatus.NOT_CONFIGURED,
+    diagnostics: healthResult?.diagnostics || null,
+  };
+}
+
+module.exports = { discoverApps, validateManifestEntry, checkHealth, classifyResult, buildAccessPayload, AppAccessStatus };

--- a/workflows/check/lib/app-access.js
+++ b/workflows/check/lib/app-access.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const config = require('../../lib/config');
+const AppAccessStatus = require('./app-access-status');
 
 /**
  * Validate a manifest entry for security and correctness.
@@ -19,7 +20,7 @@ function validateManifestEntry(entry) {
 
   // Shell injection prevention for startCommand
   if (entry.startCommand) {
-    const dangerousChars = /[;|`]|\$\(|&&/;
+    const dangerousChars = /[;|<>`]|\$[\({]|&&|>>/;
     if (dangerousChars.test(entry.startCommand)) {
       errors.push(`startCommand contains dangerous shell characters: ${entry.startCommand}`);
     }
@@ -47,30 +48,17 @@ function validateManifestEntry(entry) {
  * @returns {Array<object>} Array of validated app configurations
  */
 function discoverApps() {
-  const apps = config.WEB_APPS;
-  if (!apps || !Array.isArray(apps) || apps.length === 0) return [];
-
-  return apps
-    .filter(app => app && app.name)
-    .map(app => {
-      const appType = app.appType || 'web';
-      return {
-        name: app.name,
-        defaultPort: app.defaultPort,
-        type: app.type,
-        appType,
-        healthEndpoint: app.healthEndpoint || (appType === 'api' ? '/health' : '/'),
-        startCommand: app.startCommand || `pnpm dev --filter=${app.name}`,
-      };
-    })
-    .filter(app => {
-      const validation = validateManifestEntry(app);
-      if (!validation.valid) {
-        console.error(`[app-access] Skipping invalid app "${app.name}": ${validation.errors.join(', ')}`);
-        return false;
-      }
-      return true;
-    });
+  if (!config.WEB_APPS || !Array.isArray(config.WEB_APPS) || config.WEB_APPS.length === 0) return [];
+  const map = config.webAppsMap();
+  const entries = Object.entries(map).map(([name, fields]) => ({ name, ...fields }));
+  return entries.filter(app => {
+    const validation = validateManifestEntry(app);
+    if (!validation.valid) {
+      console.error(`[app-access] Skipping invalid app "${app.name}": ${validation.errors.join(', ')}`);
+      return false;
+    }
+    return true;
+  });
 }
 
-module.exports = { discoverApps, validateManifestEntry };
+module.exports = { discoverApps, validateManifestEntry, AppAccessStatus };

--- a/workflows/check/lib/app-access.js
+++ b/workflows/check/lib/app-access.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const config = require('../../lib/config');
+
+/**
+ * Validate a manifest entry for security and correctness.
+ * @param {object} entry - App manifest entry
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateManifestEntry(entry) {
+  const errors = [];
+
+  // Port range validation (1024-65535)
+  if (entry.defaultPort !== undefined) {
+    if (typeof entry.defaultPort !== 'number' || entry.defaultPort < 1024 || entry.defaultPort > 65535) {
+      errors.push(`Port ${entry.defaultPort} is outside valid range (1024-65535)`);
+    }
+  }
+
+  // Shell injection prevention for startCommand
+  if (entry.startCommand) {
+    const dangerousChars = /[;|`]|\$\(|&&/;
+    if (dangerousChars.test(entry.startCommand)) {
+      errors.push(`startCommand contains dangerous shell characters: ${entry.startCommand}`);
+    }
+  }
+
+  // healthEndpoint path validation
+  if (entry.healthEndpoint) {
+    if (entry.healthEndpoint.startsWith('//')) {
+      errors.push(`healthEndpoint must not start with "//": ${entry.healthEndpoint}`);
+    }
+    if (entry.healthEndpoint.includes('?')) {
+      errors.push(`healthEndpoint must not contain query strings: ${entry.healthEndpoint}`);
+    }
+    if (!entry.healthEndpoint.startsWith('/')) {
+      errors.push(`healthEndpoint must start with "/": ${entry.healthEndpoint}`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Discover apps from WEB_APPS config with defaults applied.
+ * Filters out invalid entries based on manifest validation.
+ * @returns {Array<object>} Array of validated app configurations
+ */
+function discoverApps() {
+  const apps = config.WEB_APPS;
+  if (!apps || !Array.isArray(apps) || apps.length === 0) return [];
+
+  return apps
+    .filter(app => app && app.name)
+    .map(app => {
+      const appType = app.appType || 'web';
+      return {
+        name: app.name,
+        defaultPort: app.defaultPort,
+        type: app.type,
+        appType,
+        healthEndpoint: app.healthEndpoint || (appType === 'api' ? '/health' : '/'),
+        startCommand: app.startCommand || `pnpm dev --filter=${app.name}`,
+      };
+    })
+    .filter(app => {
+      const validation = validateManifestEntry(app);
+      if (!validation.valid) {
+        console.error(`[app-access] Skipping invalid app "${app.name}": ${validation.errors.join(', ')}`);
+        return false;
+      }
+      return true;
+    });
+}
+
+module.exports = { discoverApps, validateManifestEntry };

--- a/workflows/check/lib/app-access.js
+++ b/workflows/check/lib/app-access.js
@@ -22,7 +22,7 @@ function validateManifestEntry(entry) {
 
   // Shell injection prevention for startCommand
   if (entry.startCommand) {
-    const dangerousChars = /[;|<>`]|\$[\({]|&&|>>/;
+    const dangerousChars = /[;|<>`&\n\r]|\$[\({]/;
     if (dangerousChars.test(entry.startCommand)) {
       errors.push(`startCommand contains dangerous shell characters: ${entry.startCommand}`);
     }

--- a/workflows/check/lib/app-access.js
+++ b/workflows/check/lib/app-access.js
@@ -13,16 +13,18 @@ const AppAccessStatus = require('./app-access-status');
 function validateManifestEntry(entry) {
   const errors = [];
 
-  // Port range validation (1024-65535)
-  if (entry.defaultPort !== undefined) {
-    if (typeof entry.defaultPort !== 'number' || entry.defaultPort < 1024 || entry.defaultPort > 65535) {
-      errors.push(`Port ${entry.defaultPort} is outside valid range (1024-65535)`);
+  // Port validation — required for web/api apps, optional for cli
+  if (entry.defaultPort === undefined || entry.defaultPort === null) {
+    if (entry.appType !== 'cli') {
+      errors.push('defaultPort is required for web and api apps');
     }
+  } else if (typeof entry.defaultPort !== 'number' || entry.defaultPort < 1024 || entry.defaultPort > 65535) {
+    errors.push(`Port ${entry.defaultPort} is outside valid range (1024-65535)`);
   }
 
   // Shell injection prevention for startCommand
   if (entry.startCommand) {
-    const dangerousChars = /[;|<>`&\n\r]|\$[\({]/;
+    const dangerousChars = /[;|<>`&\n\r]|\$[\({]/; // hardened regex — covers shell metacharacters
     if (dangerousChars.test(entry.startCommand)) {
       errors.push(`startCommand contains dangerous shell characters: ${entry.startCommand}`);
     }
@@ -142,6 +144,9 @@ async function checkHealth(app, options = {}) {
       await new Promise(resolve => setTimeout(resolve, retryInterval));
     }
   }
+
+  // Guard: handle edge case where retries=0 (no iterations executed)
+  return buildFailureResult(url, healthEndpoint, port, null, 'No retries configured');
 }
 
 /**

--- a/workflows/check/scripts/write-qa-report.js
+++ b/workflows/check/scripts/write-qa-report.js
@@ -28,7 +28,7 @@
 
 const { createReportWriter } = require('../../lib/scripts/write-report');
 
-const ALLOWED_STATUSES = ['PASS', 'FAIL', 'INFRASTRUCTURE_FAILURE', 'BLOCKED'];
+const ALLOWED_STATUSES = ['PASS', 'FAIL', 'INFRASTRUCTURE_FAILURE', 'ACCESS_FAILED', 'BLOCKED'];
 
 const writer = createReportWriter({
   name: 'QA Report Writer',
@@ -86,15 +86,15 @@ const writer = createReportWriter({
     }
 
     // Screenshots: must have at least one (unless INFRASTRUCTURE_FAILURE)
-    if (input.status !== 'INFRASTRUCTURE_FAILURE' && input.status !== 'BLOCKED') {
+    if (input.status !== 'INFRASTRUCTURE_FAILURE' && input.status !== 'ACCESS_FAILED' && input.status !== 'BLOCKED') {
       if (!Array.isArray(input.screenshots) || input.screenshots.length === 0) {
         errors.push('At least one screenshot is required for PASS/FAIL reports');
       }
     }
 
-    // INFRASTRUCTURE_FAILURE requires MCP diagnostics
-    if (input.status === 'INFRASTRUCTURE_FAILURE' && !input.mcpDiagnostics) {
-      errors.push('mcpDiagnostics is required when status is INFRASTRUCTURE_FAILURE');
+    // INFRASTRUCTURE_FAILURE / ACCESS_FAILED requires MCP diagnostics
+    if ((input.status === 'INFRASTRUCTURE_FAILURE' || input.status === 'ACCESS_FAILED') && !input.mcpDiagnostics) {
+      errors.push('mcpDiagnostics is required when status is INFRASTRUCTURE_FAILURE or ACCESS_FAILED');
     }
 
     // Report path must match qa-*.check.md pattern

--- a/workflows/lib/__tests__/config.test.js
+++ b/workflows/lib/__tests__/config.test.js
@@ -151,12 +151,18 @@ describe('config', () => {
   // ─── webAppsMap ─────────────────────────────────────────────────────────
 
   describe('webAppsMap', () => {
-    it('builds map from valid entries', () => {
+    it('builds map from valid entries with default manifest fields', () => {
       const config = freshRequire({
         WEB_APPS: JSON.stringify([{ name: 'app-a', defaultPort: 3000, type: 'vite' }]),
       });
       const map = config.webAppsMap();
-      assert.deepEqual(map['app-a'], { defaultPort: 3000, type: 'vite' });
+      assert.deepEqual(map['app-a'], {
+        defaultPort: 3000,
+        type: 'vite',
+        appType: 'web',
+        healthEndpoint: '/',
+        startCommand: 'pnpm dev --filter=app-a',
+      });
     });
 
     it('skips malformed entries (null, missing name)', () => {
@@ -169,13 +175,72 @@ describe('config', () => {
       });
       const map = config.webAppsMap();
       assert.equal(Object.keys(map).length, 1);
-      assert.deepEqual(map['valid'], { defaultPort: 5000, type: 'remix' });
+      assert.deepEqual(map['valid'], {
+        defaultPort: 5000,
+        type: 'remix',
+        appType: 'web',
+        healthEndpoint: '/',
+        startCommand: 'pnpm dev --filter=valid',
+      });
     });
 
     it('returns prototype-free object', () => {
       const config = freshRequire();
       const map = config.webAppsMap();
       assert.equal(Object.getPrototypeOf(map), null);
+    });
+
+    it('defaults appType to "web"', () => {
+      const config = freshRequire({
+        WEB_APPS: JSON.stringify([{ name: 'my-app', defaultPort: 3000, type: 'vite' }]),
+      });
+      const map = config.webAppsMap();
+      assert.equal(map['my-app'].appType, 'web');
+    });
+
+    it('defaults healthEndpoint to "/" for web apps', () => {
+      const config = freshRequire({
+        WEB_APPS: JSON.stringify([{ name: 'web-app', defaultPort: 3000, type: 'vite' }]),
+      });
+      const map = config.webAppsMap();
+      assert.equal(map['web-app'].healthEndpoint, '/');
+    });
+
+    it('defaults healthEndpoint to "/health" for api apps', () => {
+      const config = freshRequire({
+        WEB_APPS: JSON.stringify([
+          { name: 'api-svc', defaultPort: 4000, type: 'node', appType: 'api' },
+        ]),
+      });
+      const map = config.webAppsMap();
+      assert.equal(map['api-svc'].healthEndpoint, '/health');
+    });
+
+    it('defaults startCommand to "pnpm dev --filter={name}"', () => {
+      const config = freshRequire({
+        WEB_APPS: JSON.stringify([{ name: 'dashboard', defaultPort: 3000, type: 'vite' }]),
+      });
+      const map = config.webAppsMap();
+      assert.equal(map['dashboard'].startCommand, 'pnpm dev --filter=dashboard');
+    });
+
+    it('preserves explicit healthEndpoint, startCommand, appType', () => {
+      const config = freshRequire({
+        WEB_APPS: JSON.stringify([
+          {
+            name: 'custom',
+            defaultPort: 8080,
+            type: 'express',
+            appType: 'cli',
+            healthEndpoint: '/status',
+            startCommand: 'node index.js',
+          },
+        ]),
+      });
+      const map = config.webAppsMap();
+      assert.equal(map['custom'].appType, 'cli');
+      assert.equal(map['custom'].healthEndpoint, '/status');
+      assert.equal(map['custom'].startCommand, 'node index.js');
     });
   });
 

--- a/workflows/lib/config.js
+++ b/workflows/lib/config.js
@@ -174,7 +174,14 @@ config.webAppsMap = () => {
   const map = Object.create(null);
   for (const app of config.WEB_APPS) {
     if (!app || !app.name) continue;
-    map[app.name] = { defaultPort: app.defaultPort, type: app.type };
+    const appType = app.appType || 'web';
+    map[app.name] = {
+      defaultPort: app.defaultPort,
+      type: app.type,
+      appType,
+      healthEndpoint: app.healthEndpoint || (appType === 'api' ? '/health' : '/'),
+      startCommand: app.startCommand || `pnpm dev --filter=${app.name}`,
+    };
   }
   return map;
 };


### PR DESCRIPTION
## Existing Behavior

- App URLs and ports for QA are hardcoded in `check-start-env.js` and agent skill files (e.g., `status-site` on port 5175, `as-dashboard` on port 5173), making the system brittle and repo-specific.
- The `WEB_APPS` config map produces bare `{ defaultPort, type }` objects with no `appType`, `healthEndpoint`, or `startCommand` — consumers must assume defaults or hardcode them.
- QA failure reporting uses a single `INFRASTRUCTURE_FAILURE` status for all unreachable-app scenarios, conflating Playwright-level failures with app-level access failures.
- Impacted app detection for package-only changes falls back to a hardcoded `WEB_APPS` list from config rather than a live manifest.
- App start commands are always `pnpm dev --filter=<appName>` with no way to override per-app.

## Intended New Behavior

- A new `app-access.js` module introduces `discoverApps()`, which reads `WEB_APPS` from config, applies manifest defaults (`appType`, `healthEndpoint`, `startCommand`), validates each entry for security (port range, shell injection, endpoint path), and returns a structured manifest array.
- `config.webAppsMap()` now enriches each entry with `appType` (default `web`), `healthEndpoint` (default `/` for web, `/health` for api), and `startCommand` (default `pnpm dev --filter=<name>`), preserving any explicit overrides.
- A new five-status taxonomy is introduced via `app-access-status.js`: `READY`, `NOT_CONFIGURED`, `ACCESS_FAILED`, `TEST_FAILED`, `PASSED`. `ACCESS_FAILED` replaces `INFRASTRUCTURE_FAILURE` for app-level unreachability (distinguished from Playwright-level failures).
- `check-start-env.js` now uses `discoverApps()` to start apps and runs a `checkHealth()` HTTP gate after each app starts — apps that fail the health check are excluded from `RUNNING_APPS` with diagnostics attached.
- QA agent routing in `check.workflow.js` and `check-qa/SKILL.md` dispatches to `qa-feature-tester` (web), `qa-api-tester` (api), or skips (cli) based on `appType` from the manifest.
- Summary and report-validation hooks (`check-generate-summary.js`, `check-validate-reports.js`) now distinguish `ACCESS_FAILED` apps (infrastructure issue, not a test failure) from `TEST_FAILED` apps, reporting them separately in the summary output.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

### Backend / Workflow Logic

1. Add a `WEB_APPS` entry to a repo's `.env` with `appType: "api"` and verify `discoverApps()` returns `healthEndpoint: "/health"` and the correct `startCommand`.
2. Add an entry with `startCommand: "pnpm dev; rm -rf /"` and confirm `discoverApps()` skips it with a logged error (shell injection rejection).
3. Run `/check` on a branch with package-only changes and confirm `IMPACTED_APPS` is populated from the manifest rather than a hardcoded list.
4. Simulate a failing app (e.g., kill the dev server after start) and confirm `check-start-env.js` marks the app `healthCheckFailed` and excludes it from `RUNNING_APPS`.
5. Confirm the summary report lists the unreachable app under "Access Failed (infrastructure issue)" with a `🔒 ACCESS_FAILED` badge, not as a test failure.
6. Add a `cli`-type app to the manifest and confirm it is excluded from QA dispatch in `check.workflow.js`.

### Test Results

Tests added in `workflows/check/lib/__tests__/app-access.test.js` and `workflows/check/lib/__tests__/app-access-status.test.js` cover:
- `discoverApps()`: empty/undefined `WEB_APPS`, single/multi-app repos, default field injection, validation filtering
- `validateManifestEntry()`: all shell injection patterns, port range boundaries, healthEndpoint format rules
- `classifyResult()`: all five status transitions
- `buildAccessPayload()`: field mapping with and without healthResult
- `checkHealth()`: 200/301 READY, connection-refused ACCESS_FAILED, 503 ACCESS_FAILED, retry count, lsof diagnostics presence
- `config.webAppsMap()`: default field injection for `appType`, `healthEndpoint`, `startCommand`; explicit override preservation