### PR TITLE
refactor(workflow): delegate verify() to follow-up-pr.js for single source of truth

### DIFF
--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2591,21 +2591,26 @@ describe('enforce-step-workflow', () => {
 
   describe('follow_up verify function', () => {
     // These tests verify that transitioning FROM follow_up uses the verify()
-    // function which checks live GitHub state via `gh` CLI commands.
+    // function which delegates to follow-up-pr.js functions (single source of truth).
     // We mock `gh` by creating a fake script and prepending its dir to PATH.
 
     const FAKE_GH_DIR = path.join(os.tmpdir(), `fake-gh-${process.pid}`);
     const FAKE_GH_PATH = path.join(FAKE_GH_DIR, 'gh');
     const ORCHESTRATOR_PATH = path.join(__dirname, '..', '..', 'work', 'work.workflow.js');
 
-    function writeFakeGh(responseMap) {
-      // responseMap: { 'pr view --json number': '42', 'pr checks': '[...]', ... }
-      // The fake gh script matches args and returns the corresponding response.
-      if (!fs.existsSync(FAKE_GH_DIR)) fs.mkdirSync(FAKE_GH_DIR, { recursive: true });
+    // The verify() function now delegates to follow-up-pr.js which calls:
+    //   getPRInfo():  gh pr view --json number,title,url,headRefName,mergeable,mergeStateStatus,state
+    //   checkCI():    gh pr checks <N> --json name,bucket,state,link,workflow
+    //                 gh pr view <N> --json statusCheckRollup  (NEUTRAL enrichment)
+    //   getReviews(): gh pr view <N> --json reviews,statusCheckRollup
+    //                 gh repo view --json nameWithOwner
+    //                 gh api repos/<owner>/<repo>/pulls/<N>/comments?per_page=100&page=1
+    //                 gh api graphql ...  (resolved thread IDs)
+    //                 gh pr view <N> --json commits
+    //                 gh api repos/<owner>/<repo>/pulls/<N>/requested_reviewers
 
-      // Build a bash script that checks arguments
-      // Use grep -qF (fixed string) with -- to prevent patterns starting with -- from
-      // being interpreted as grep options (GH-191: patterns now include --head, --json)
+    function writeFakeGh(responseMap) {
+      if (!fs.existsSync(FAKE_GH_DIR)) fs.mkdirSync(FAKE_GH_DIR, { recursive: true });
       let script = '#!/bin/bash\nARGS="$*"\n';
       for (const [pattern, response] of Object.entries(responseMap)) {
         if (response === 'EXIT1') {
@@ -2614,7 +2619,7 @@ describe('enforce-step-workflow', () => {
           script += `if echo "$ARGS" | grep -qF -- "${pattern}"; then echo '${response.replace(/'/g, "'\\''")}'; exit 0; fi\n`;
         }
       }
-      script += 'exit 1\n'; // Default: fail
+      script += 'exit 1\n';
       fs.writeFileSync(FAKE_GH_PATH, script, { mode: 0o755 });
     }
 
@@ -2635,8 +2640,64 @@ describe('enforce-step-workflow', () => {
       );
     }
 
+    // Helper: build gh mock responses for the full verify() flow.
+    // getPRInfo, checkCI, getReviews all need to succeed for transition to pass.
+    function buildGhResponses({
+      prState = 'OPEN',
+      mergeable = 'MERGEABLE',
+      mergeStateStatus = 'CLEAN',
+      ciBucket = 'pass',
+      ciState = 'completed',
+      reviewState = 'APPROVED',
+      reviewBody = '',
+      inlineComments = '[]',
+      requestedReviewers = '{"users":[]}',
+      graphql = '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}',
+      commits = '{"commits":[]}',
+    } = {}) {
+      const prView = JSON.stringify({
+        number: 42,
+        title: 'Test PR',
+        url: 'https://github.com/test/repo/pull/42',
+        headRefName: 'test-branch',
+        mergeable,
+        mergeStateStatus,
+        state: prState,
+      });
+      const ciChecks = JSON.stringify([
+        { name: 'build', bucket: ciBucket, state: ciState, link: '', workflow: {} },
+      ]);
+      const statusCheckRollup = JSON.stringify({ statusCheckRollup: [] });
+      const reviews = JSON.stringify({
+        reviews: reviewState
+          ? [{ id: 1, author: { login: 'reviewer' }, state: reviewState, body: reviewBody }]
+          : [],
+        statusCheckRollup: [],
+      });
+
+      return {
+        // getPRInfo: gh pr view --json number,title,...
+        'pr view --json number,title,url,headRefName,mergeable,mergeStateStatus,state': prView,
+        // checkCI: gh pr checks 42 --json ...
+        'pr checks 42 --json name,bucket,state,link,workflow': ciChecks,
+        // checkCI: NEUTRAL enrichment fallback
+        'pr view 42 --json statusCheckRollup': statusCheckRollup,
+        // getReviews: gh pr view 42 --json reviews,...
+        'pr view 42 --json reviews,statusCheckRollup': reviews,
+        // getReviews: gh repo view
+        'repo view --json nameWithOwner': '{"nameWithOwner":"test/repo"}',
+        // getReviews: inline comments
+        'repos/test/repo/pulls/42/comments': inlineComments,
+        // getReviews: GraphQL resolved threads
+        'api graphql': graphql,
+        // getReviews: commits for stale detection
+        'pr view 42 --json commits': commits,
+        // getReviews: requested reviewers
+        'repos/test/repo/pulls/42/requested_reviewers': requestedReviewers,
+      };
+    }
+
     beforeEach(() => {
-      // Set up work state at follow_up step
       writeWorkState(makeStepStatus('follow_up', WORK_STEPS));
     });
 
@@ -2645,65 +2706,54 @@ describe('enforce-step-workflow', () => {
     });
 
     it('allows transition when CI passes, no blocking reviews, no comments', async () => {
-      writeFakeGh({
-        '--json number -q .number': '42',
-        'pr checks 42 --json': '[{"state":"SUCCESS","name":"build"}]',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":"APPROVED"}',
-        'repos/{owner}/{repo}/pulls/42/comments': '0',
-      });
-
+      writeFakeGh(buildGhResponses());
       const { code } = await transitionFromFollowUp();
       assert.equal(code, 0, 'Should allow transition when all checks pass');
     });
 
     it('blocks transition when CI has failures', async () => {
-      writeFakeGh({
-        '--json number -q .number': '42',
-        'pr checks 42 --json': '[{"state":"FAILURE","name":"build"}]',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":"APPROVED"}',
-        'repos/{owner}/{repo}/pulls/42/comments': '0',
-      });
-
+      writeFakeGh(buildGhResponses({ ciBucket: 'fail' }));
       const { code, stderr } = await transitionFromFollowUp();
       assert.equal(code, 2, 'Should block transition when CI has failures');
       assert.ok(stderr.includes('BLOCKED'), 'stderr should contain BLOCKED');
     });
 
     it('blocks transition when CI is pending', async () => {
-      writeFakeGh({
-        '--json number -q .number': '42',
-        'pr checks 42 --json': '[{"state":"PENDING","name":"build"}]',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":"APPROVED"}',
-        'repos/{owner}/{repo}/pulls/42/comments': '0',
-      });
-
+      writeFakeGh(buildGhResponses({ ciBucket: 'pending', ciState: 'pending' }));
       const { code, stderr } = await transitionFromFollowUp();
       assert.equal(code, 2, 'Should block transition when CI is pending');
       assert.ok(stderr.includes('BLOCKED'), 'stderr should contain BLOCKED');
     });
 
     it('blocks transition when review is CHANGES_REQUESTED', async () => {
-      writeFakeGh({
-        '--json number -q .number': '42',
-        'pr checks 42 --json': '[{"state":"SUCCESS","name":"build"}]',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":"CHANGES_REQUESTED"}',
-        'repos/{owner}/{repo}/pulls/42/comments': '0',
-      });
-
+      writeFakeGh(buildGhResponses({ reviewState: 'CHANGES_REQUESTED' }));
       const { code, stderr } = await transitionFromFollowUp();
       assert.equal(code, 2, 'Should block transition when review has changes requested');
       assert.ok(stderr.includes('BLOCKED'), 'stderr should contain BLOCKED');
     });
 
-    it('allows transition when comments exist with valid accountability', async () => {
-      writeFakeGh({
-        '--json number -q .number': '42',
-        'pr checks 42 --json': '[{"state":"SUCCESS","name":"build"}]',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":"APPROVED"}',
-        'repos/{owner}/{repo}/pulls/42/comments': '2',
-      });
+    it('blocks transition when merge is conflicting', async () => {
+      writeFakeGh(buildGhResponses({ mergeable: 'CONFLICTING' }));
+      const { code, stderr } = await transitionFromFollowUp();
+      assert.equal(code, 2, 'Should block transition when PR has merge conflicts');
+      assert.ok(stderr.includes('BLOCKED'), 'stderr should contain BLOCKED');
+    });
 
-      // Write review-accountability.json with valid entries
+    it('blocks transition when merge state is DIRTY', async () => {
+      writeFakeGh(buildGhResponses({ mergeStateStatus: 'DIRTY' }));
+      const { code, stderr } = await transitionFromFollowUp();
+      assert.equal(code, 2, 'Should block transition when merge state is DIRTY');
+      assert.ok(stderr.includes('BLOCKED'), 'stderr should contain BLOCKED');
+    });
+
+    it('allows transition when non-blocking comments exist with valid accountability', async () => {
+      // Copilot [nitpick] comments → low priority (non-blocking)
+      const inlineComments = JSON.stringify([
+        { id: 1, user: { login: 'copilot-pull-request-reviewer' }, body: '[nitpick] Consider renaming', path: 'src/a.js', line: 10 },
+        { id: 2, user: { login: 'copilot-pull-request-reviewer' }, body: '[low] Minor style issue', path: 'src/b.js', line: 20 },
+      ]);
+      writeFakeGh(buildGhResponses({ inlineComments }));
+
       if (!fs.existsSync(TASKS_DIR)) fs.mkdirSync(TASKS_DIR, { recursive: true });
       const accountability = [
         { disposition: 'resolved', reason: 'Fixed in latest commit' },
@@ -2718,24 +2768,40 @@ describe('enforce-step-workflow', () => {
       assert.equal(code, 0, 'Should allow transition when comments have valid accountability');
     });
 
-    it('blocks transition when comments exist but no accountability file', async () => {
-      writeFakeGh({
-        '--json number -q .number': '42',
-        'pr checks 42 --json': '[{"state":"SUCCESS","name":"build"}]',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":"APPROVED"}',
-        'repos/{owner}/{repo}/pulls/42/comments': '2',
-      });
-
-      // Do NOT write review-accountability.json
+    it('blocks transition when non-blocking comments exist but no accountability file', async () => {
+      const inlineComments = JSON.stringify([
+        { id: 1, user: { login: 'copilot-pull-request-reviewer' }, body: '[nitpick] Consider renaming', path: 'src/a.js', line: 10 },
+        { id: 2, user: { login: 'copilot-pull-request-reviewer' }, body: '[low] Minor style issue', path: 'src/b.js', line: 20 },
+      ]);
+      writeFakeGh(buildGhResponses({ inlineComments }));
 
       const { code, stderr } = await transitionFromFollowUp();
       assert.equal(code, 2, 'Should block transition when comments exist without accountability');
       assert.ok(stderr.includes('BLOCKED'), 'stderr should contain BLOCKED');
     });
 
+    it('blocks transition when blocking (human) comments exist even with accountability', async () => {
+      // Human comments are always high priority (blocking) — decideNextAction returns exit-fail
+      const inlineComments = JSON.stringify([
+        { id: 1, user: { login: 'reviewer1' }, body: 'Fix this bug', path: 'src/a.js', line: 10 },
+      ]);
+      writeFakeGh(buildGhResponses({ inlineComments }));
+
+      if (!fs.existsSync(TASKS_DIR)) fs.mkdirSync(TASKS_DIR, { recursive: true });
+      const accountability = [{ disposition: 'resolved', reason: 'Fixed' }];
+      fs.writeFileSync(
+        path.join(TASKS_DIR, 'review-accountability.json'),
+        JSON.stringify(accountability, null, 2)
+      );
+
+      const { code, stderr } = await transitionFromFollowUp();
+      assert.equal(code, 2, 'Should block when blocking human comments exist');
+      assert.ok(stderr.includes('BLOCKED'), 'stderr should contain BLOCKED');
+    });
+
     it('blocks transition when gh pr view fails (no PR)', async () => {
       writeFakeGh({
-        '--json number -q .number': 'EXIT1',
+        'pr view --json number,title,url,headRefName,mergeable,mergeStateStatus,state': 'EXIT1',
       });
 
       const { code, stderr } = await transitionFromFollowUp();
@@ -2744,26 +2810,21 @@ describe('enforce-step-workflow', () => {
     });
 
     it('allows transition when no CI checks exist (empty array)', async () => {
-      writeFakeGh({
-        '--json number -q .number': '42',
-        'pr checks 42 --json': '[]',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":""}',
-        'repos/{owner}/{repo}/pulls/42/comments': '0',
-      });
+      // Override ciChecks to empty and set reviewState to empty
+      const responses = buildGhResponses({ reviewState: null });
+      responses['pr checks 42 --json name,bucket,state,link,workflow'] = '[]';
+      writeFakeGh(responses);
 
       const { code } = await transitionFromFollowUp();
       assert.equal(code, 0, 'Should allow transition when no CI checks exist');
     });
 
     it('blocks when accountability entries lack disposition/reason', async () => {
-      writeFakeGh({
-        '--json number -q .number': '42',
-        'pr checks 42 --json': '[{"state":"SUCCESS","name":"build"}]',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":"APPROVED"}',
-        'repos/{owner}/{repo}/pulls/42/comments': '1',
-      });
+      const inlineComments = JSON.stringify([
+        { id: 1, user: { login: 'copilot-pull-request-reviewer' }, body: '[nitpick] Minor issue', path: 'src/a.js', line: 10 },
+      ]);
+      writeFakeGh(buildGhResponses({ inlineComments }));
 
-      // Write accountability with missing fields
       if (!fs.existsSync(TASKS_DIR)) fs.mkdirSync(TASKS_DIR, { recursive: true });
       const accountability = [{ disposition: 'resolved' }]; // missing reason
       fs.writeFileSync(
@@ -2777,14 +2838,11 @@ describe('enforce-step-workflow', () => {
     });
 
     it('blocks when acknowledged entries lack userApproval', async () => {
-      writeFakeGh({
-        '--json number -q .number': '42',
-        'pr checks 42 --json': '[{"state":"SUCCESS","name":"build"}]',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":"APPROVED"}',
-        'repos/{owner}/{repo}/pulls/42/comments': '1',
-      });
+      const inlineComments = JSON.stringify([
+        { id: 1, user: { login: 'copilot-pull-request-reviewer' }, body: '[nitpick] Minor issue', path: 'src/a.js', line: 10 },
+      ]);
+      writeFakeGh(buildGhResponses({ inlineComments }));
 
-      // Write accountability with acknowledged but no userApproval
       if (!fs.existsSync(TASKS_DIR)) fs.mkdirSync(TASKS_DIR, { recursive: true });
       const accountability = [{ disposition: 'acknowledged', reason: 'Known issue' }];
       fs.writeFileSync(
@@ -2798,14 +2856,11 @@ describe('enforce-step-workflow', () => {
     });
 
     it('allows when acknowledged entries have userApproval=true', async () => {
-      writeFakeGh({
-        '--json number -q .number': '42',
-        'pr checks 42 --json': '[{"state":"SUCCESS","name":"build"}]',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":"APPROVED"}',
-        'repos/{owner}/{repo}/pulls/42/comments': '1',
-      });
+      const inlineComments = JSON.stringify([
+        { id: 1, user: { login: 'copilot-pull-request-reviewer' }, body: '[nitpick] Minor issue', path: 'src/a.js', line: 10 },
+      ]);
+      writeFakeGh(buildGhResponses({ inlineComments }));
 
-      // Write accountability with acknowledged + userApproval
       if (!fs.existsSync(TASKS_DIR)) fs.mkdirSync(TASKS_DIR, { recursive: true });
       const accountability = [
         { disposition: 'acknowledged', reason: 'Known issue', userApproval: true },
@@ -3042,90 +3097,10 @@ describe('enforce-step-workflow', () => {
     });
   });
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // follow_up verify: branch positional arg (GH-191, GH-203)
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  describe('follow_up verify branch positional arg (GH-191, GH-203)', () => {
-    const FAKE_GIT_DIR = path.join(os.tmpdir(), `fake-git-followup-191-${process.pid}`);
-    const FAKE_GIT_PATH = path.join(FAKE_GIT_DIR, 'git');
-    const FAKE_GH_DIR = path.join(os.tmpdir(), `fake-gh-followup-191-${process.pid}`);
-    const FAKE_GH_PATH = path.join(FAKE_GH_DIR, 'gh');
-    const ORCHESTRATOR_PATH = path.join(__dirname, '..', '..', 'work', 'work.workflow.js');
-    const FOLLOWUP_TEST_BRANCH = `${TEST_TICKET}-followup-test`;
-
-    function writeFakeGit() {
-      if (!fs.existsSync(FAKE_GIT_DIR)) fs.mkdirSync(FAKE_GIT_DIR, { recursive: true });
-      // Provide controlled branch name so positional arg is always added,
-      // even in CI where the checkout may be in detached HEAD state.
-      const script = [
-        '#!/bin/bash',
-        'ARGS="$*"',
-        `if echo "$ARGS" | grep -qF -- "branch --show-current"; then echo '${FOLLOWUP_TEST_BRANCH}'; exit 0; fi`,
-        `if echo "$ARGS" | grep -qF -- "rev-parse --show-toplevel"; then echo '${process.cwd()}'; exit 0; fi`,
-        // Let symbolic-ref / rev-parse --verify fail so getBaseBranch falls through
-        'if echo "$ARGS" | grep -qF -- "symbolic-ref"; then exit 1; fi',
-        'if echo "$ARGS" | grep -qF -- "rev-parse --verify"; then exit 1; fi',
-        'exit 1',
-      ].join('\n');
-      fs.writeFileSync(FAKE_GIT_PATH, script, { mode: 0o755 });
-    }
-
-    function writeFakeGh(responseMap) {
-      if (!fs.existsSync(FAKE_GH_DIR)) fs.mkdirSync(FAKE_GH_DIR, { recursive: true });
-      let script = '#!/bin/bash\nARGS="$*"\n';
-      for (const [pattern, response] of Object.entries(responseMap)) {
-        if (response === 'EXIT1') {
-          script += `if echo "$ARGS" | grep -qF -- "${pattern}"; then exit 1; fi\n`;
-        } else {
-          script += `if echo "$ARGS" | grep -qF -- "${pattern}"; then echo '${response.replace(/'/g, "'\\''")}'; exit 0; fi\n`;
-        }
-      }
-      script += 'exit 1\n';
-      fs.writeFileSync(FAKE_GH_PATH, script, { mode: 0o755 });
-    }
-
-    function cleanup() {
-      try {
-        fs.rmSync(FAKE_GIT_DIR, { recursive: true, force: true });
-      } catch {}
-      try {
-        fs.rmSync(FAKE_GH_DIR, { recursive: true, force: true });
-      } catch {}
-    }
-
-    function transitionFromFollowUp(extraEnv = {}) {
-      return runHook(
-        {
-          tool_name: 'Bash',
-          tool_input: { command: `node ${ORCHESTRATOR_PATH} transition ${TEST_TICKET} ci` },
-        },
-        'PreToolUse',
-        { PATH: `${FAKE_GIT_DIR}:${FAKE_GH_DIR}:${process.env.PATH}`, TASKS_BASE, ...extraEnv }
-      );
-    }
-
-    beforeEach(() => {
-      writeFakeGit();
-      writeWorkState(makeStepStatus('follow_up', WORK_STEPS));
-    });
-
-    afterEach(() => {
-      cleanup();
-    });
-
-    it('passes branch as positional arg to gh pr view in follow_up verify', async () => {
-      writeFakeGh({
-        [`pr view ${FOLLOWUP_TEST_BRANCH}`]: '42',
-        'pr checks 42 --json': '[{"state":"SUCCESS","name":"build"}]',
-        'pr checks 42': 'build\tpass\t1s\thttps://example.com',
-        'pr view 42 --json reviewDecision': '{"reviewDecision":"APPROVED"}',
-        'repos/{owner}/{repo}/pulls/42/comments': '0',
-      }); // fake git (writeFakeGit above) provides deterministic branch for positional arg (CI-safe)
-      const { code } = await transitionFromFollowUp();
-      assert.equal(code, 0, 'Should use branch positional arg for initial PR number resolution');
-    });
-  });
+  // follow_up verify branch positional arg (GH-191, GH-203) — REMOVED
+  // The verify() function now delegates to follow-up-pr.js's getPRInfo() which
+  // relies on `gh pr view` auto-detecting the branch (gh's default behavior).
+  // Branch positional arg handling is tested in follow-up-pr.test.js.
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Per-script step gating for AGENT_GATED_SCRIPTS (GH-184)
@@ -3905,14 +3880,26 @@ describe('enforce-step-workflow', () => {
 
     it('blocks transition from ci to cleanup without evidence', async () => {
       writeWorkState(makeStepStatus('ci', WORK_STEPS));
-      // No evidence, no gh pr checks available
+      // No evidence — ci verify() delegates to follow-up-pr.js functions which call `gh`.
+      // Use a fake `gh` that fails so verify() returns false.
+      const fakeGhDir = path.join(os.tmpdir(), `fake-gh-ci-${process.pid}`);
+      fs.mkdirSync(fakeGhDir, { recursive: true });
+      fs.writeFileSync(path.join(fakeGhDir, 'gh'), '#!/bin/bash\nexit 1\n', { mode: 0o755 });
 
-      const { code, stderr } = await runHook({
-        tool_name: 'Bash',
-        tool_input: { command: `node ${ORCHESTRATOR_PATH} transition ${TEST_TICKET} cleanup` },
-      });
-      assert.equal(code, 2, 'Should block forward transition without evidence');
-      assert.ok(stderr.includes('BLOCKED'));
+      try {
+        const { code, stderr } = await runHook(
+          {
+            tool_name: 'Bash',
+            tool_input: { command: `node ${ORCHESTRATOR_PATH} transition ${TEST_TICKET} cleanup` },
+          },
+          'PreToolUse',
+          { PATH: `${fakeGhDir}:${process.env.PATH}` }
+        );
+        assert.equal(code, 2, 'Should block forward transition without evidence');
+        assert.ok(stderr.includes('BLOCKED'));
+      } finally {
+        fs.rmSync(fakeGhDir, { recursive: true, force: true });
+      }
     });
 
     it('allows backward transition from ci to implement (retry loop)', async () => {

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2651,10 +2651,15 @@ describe('enforce-step-workflow', () => {
       reviewState = 'APPROVED',
       reviewBody = '',
       inlineComments = '[]',
+      commentCount = null, // auto-computed from inlineComments if not set
       requestedReviewers = '{"users":[]}',
       graphql = '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}',
       commits = '{"commits":[]}',
     } = {}) {
+      // Auto-compute comment count from inline comments JSON
+      const autoCount = commentCount != null
+        ? commentCount
+        : (JSON.parse(inlineComments).length || 0);
       const prView = JSON.stringify({
         number: 42,
         title: 'Test PR',
@@ -2686,7 +2691,9 @@ describe('enforce-step-workflow', () => {
         'pr view 42 --json reviews,statusCheckRollup': reviews,
         // getReviews: gh repo view
         'repo view --json nameWithOwner': '{"nameWithOwner":"test/repo"}',
-        // getReviews: inline comments
+        // isPRGateReady: strict comment count (--jq length, must match before general pattern)
+        '--jq length': String(autoCount),
+        // getReviews: inline comments (paginated)
         'repos/test/repo/pulls/42/comments': inlineComments,
         // getReviews: GraphQL resolved threads
         'api graphql': graphql,
@@ -3098,9 +3105,9 @@ describe('enforce-step-workflow', () => {
   });
 
   // follow_up verify branch positional arg (GH-191, GH-203) — REMOVED
-  // The verify() function now delegates to follow-up-pr.js's getPRInfo() which
+  // The verify() function now delegates to follow-up-pr.js's isPRGateReady() which
   // relies on `gh pr view` auto-detecting the branch (gh's default behavior).
-  // Branch positional arg handling is tested in follow-up-pr.test.js.
+  // No dedicated branch positional-arg test exists here; gh handles auto-detection.
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Per-script step gating for AGENT_GATED_SCRIPTS (GH-184)

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1481,4 +1481,9 @@ module.exports = {
   getChangedPaths,
   initState,
   getCodeContext,
+  // Gate-check exports: used by workflow-definition.js verify()
+  ghExec,
+  getPRInfo,
+  checkCI,
+  getReviews,
 };

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1461,6 +1461,82 @@ async function main() {
   process.exit(1);
 }
 
+/**
+ * isPRGateReady — workflow gate function (single source of truth).
+ *
+ * Called by workflow-definition.js verify() to determine if the follow_up step
+ * is complete. Encapsulates the same logic as the main loop:
+ *   1. Fetch PR info, CI, and reviews
+ *   2. Apply bot-comment deduplication using persisted state
+ *   3. Run decideNextAction with the deduped reviews
+ *   4. Fail-closed on transient errors (unlike getReviews which is lenient)
+ *
+ * @returns {{ ready: boolean, reviews: Object, decision: Object }}
+ */
+function isPRGateReady() {
+  const prInfo = getPRInfo();
+  if (!prInfo || !prInfo.number) return { ready: false };
+  if (prInfo.state === 'CLOSED' || prInfo.state === 'MERGED') return { ready: false };
+
+  const ci = checkCI(prInfo.number);
+  const reviews = getReviews(prInfo.number);
+
+  // Strict comment count: fail-closed if inline comments cannot be fetched.
+  // getReviews() swallows errors for inline comments (they are supplementary
+  // in the polling loop), but the gate must not allow transition if we can't
+  // confirm there are no unaccounted comments.
+  let strictCommentCount = 0;
+  try {
+    const repo = ghExec('repo view --json nameWithOwner').nameWithOwner;
+    const comments = ghExec([
+      'api',
+      `repos/${repo}/pulls/${prInfo.number}/comments`,
+      '--jq',
+      'length',
+    ], { json: false });
+    strictCommentCount = parseInt(comments, 10) || 0;
+  } catch {
+    // Cannot verify comment count — fail closed
+    return { ready: false };
+  }
+
+  // Apply bot-comment deduplication (same as main loop does before deciding)
+  let currentHead = null;
+  try {
+    currentHead = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  } catch { /* non-fatal */ }
+
+  const state = loadState(prInfo.number);
+  const previousRunBotHashes = state
+    ? (state.previousRunBotHashes && state.previousRunBotHashes.length > 0
+        ? state.previousRunBotHashes
+        : (state.addressedBotComments || []).map((a) => a.hash))
+    : [];
+
+  const deduped = deduplicateBlockingBotComments(
+    reviews.blocking,
+    reviews.nonBlocking,
+    previousRunBotHashes,
+    { currentHead }
+  );
+  const dedupedReviews = {
+    ...reviews,
+    blocking: deduped.blocking,
+    nonBlocking: deduped.nonBlocking,
+    hasBlocking: deduped.blocking.length > 0,
+  };
+
+  const decision = decideNextAction(ci.status, prInfo, dedupedReviews, false);
+
+  return {
+    ready: decision.action === 'exit-success',
+    reviews: dedupedReviews,
+    decision,
+    strictCommentCount,
+    prInfo,
+  };
+}
+
 // Export for testing; guard main() so it only runs when executed directly
 if (require.main === module) {
   main().catch((err) => {
@@ -1482,6 +1558,7 @@ module.exports = {
   initState,
   getCodeContext,
   // Gate-check exports: used by workflow-definition.js verify()
+  isPRGateReady,
   ghExec,
   getPRInfo,
   checkCI,

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -382,59 +382,29 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       {
         step: STEPS.follow_up,
         verify: (ticketId) => {
-          // Verify follow_up by checking LIVE GitHub state -- no fakeable state files.
-          // Checks: CI passing, no changes-requested reviews, all PR comments accounted for.
+          // Single source of truth: delegates to follow-up-pr.js functions
+          // so the gate checks the exact same things the script checks.
           try {
-            const { execFileSync } = require('child_process');
-            const opts = { encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] };
+            const {
+              getPRInfo,
+              checkCI,
+              getReviews,
+              decideNextAction,
+            } = require(path.join(__dirname, 'scripts', 'follow-up-pr.js'));
 
-            // Resolve branch to support worktree contexts (GH-191, GH-203)
-            let prViewArgs = ['pr', 'view', '--json', 'number', '-q', '.number'];
-            try {
-              const branch = execFileSync('git', ['branch', '--show-current'], opts).trim();
-              if (branch) prViewArgs = ['pr', 'view', branch, '--json', 'number', '-q', '.number'];
-            } catch { /* branch detection failed -- fall back to no branch arg */ }
+            const prInfo = getPRInfo();
+            if (!prInfo || !prInfo.number) return false;
+            if (prInfo.state === 'CLOSED' || prInfo.state === 'MERGED') return false;
 
-            // 1. Get PR number
-            const prNum = execFileSync('gh', prViewArgs, opts).trim();
-            if (!prNum) return false;
+            const ci = checkCI(prInfo.number);
+            const reviews = getReviews(prInfo.number);
+            const decision = decideNextAction(ci.status, prInfo, reviews, false);
 
-            // 2. CI checks must all pass (or have no checks)
-            const checksJson = execFileSync(
-              'gh',
-              ['pr', 'checks', prNum, '--json', 'state,name'],
-              opts
-            ).trim();
-            const checks = JSON.parse(checksJson || '[]');
-            const badStates = new Set([
-              'FAILURE',
-              'ERROR',
-              'CANCELLED',
-              'ACTION_REQUIRED',
-              'PENDING',
-              'STARTUP_FAILURE',
-            ]);
-            if (checks.some((c) => badStates.has(c.state))) return false;
+            if (decision.action !== 'exit-success') return false;
 
-            // 3. No blocking reviews (CHANGES_REQUESTED)
-            const reviewJson = execFileSync(
-              'gh',
-              ['pr', 'view', prNum, '--json', 'reviewDecision'],
-              opts
-            ).trim();
-            const reviewData = JSON.parse(reviewJson || '{}');
-            if (reviewData.reviewDecision === 'CHANGES_REQUESTED') return false;
-
-            // 4. Review accountability: every PR comment must be accounted for
-            const commentCount = parseInt(
-              execFileSync(
-                'gh',
-                ['api', `repos/{owner}/{repo}/pulls/${prNum}/comments`, '--jq', 'length'],
-                opts
-              ).trim(),
-              10
-            );
-            if (commentCount > 0) {
+            // Review accountability: every PR comment must be accounted for
+            const totalComments = reviews.blocking.length + reviews.nonBlocking.length;
+            if (totalComments > 0) {
               const accountabilityFile = path.join(
                 TASKS_BASE,
                 safeTicketPath(ticketId),
@@ -442,9 +412,8 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
               );
               if (!fs.existsSync(accountabilityFile)) return false;
               const entries = JSON.parse(fs.readFileSync(accountabilityFile, 'utf-8'));
-              if (!Array.isArray(entries) || entries.length < commentCount) return false;
+              if (!Array.isArray(entries) || entries.length < totalComments) return false;
               if (!entries.every((e) => e.disposition && e.reason)) return false;
-              // "acknowledged" entries require user approval via AskUserQuestion
               const acknowledged = entries.filter((e) => e.disposition === 'acknowledged');
               if (acknowledged.length > 0) {
                 if (!acknowledged.every((e) => e.userApproval === true)) return false;
@@ -472,17 +441,13 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       {
         step: STEPS.ci,
         verify: () => {
-          // CI is proven if all PR checks are passing (same as follow_up verify)
+          // Single source of truth: delegates to follow-up-pr.js functions
           try {
-            const { execFileSync } = require('child_process');
-            const opts = { encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] };
-            const checks = JSON.parse(
-              execFileSync('gh', ['pr', 'checks', '--json', 'state'], opts).trim()
-            );
-            return (
-              checks.length > 0 &&
-              checks.every((c) => c.state === 'SUCCESS' || c.state === 'SKIPPED')
-            );
+            const { getPRInfo, checkCI } = require(path.join(__dirname, 'scripts', 'follow-up-pr.js'));
+            const prInfo = getPRInfo();
+            if (!prInfo || !prInfo.number) return false;
+            const ci = checkCI(prInfo.number);
+            return ci.status === 'passing';
           } catch {
             return false;
           }

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -382,29 +382,16 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       {
         step: STEPS.follow_up,
         verify: (ticketId) => {
-          // Single source of truth: delegates to follow-up-pr.js functions
-          // so the gate checks the exact same things the script checks.
+          // Single source of truth: delegates to follow-up-pr.js isPRGateReady()
+          // which encapsulates CI, reviews, bot-comment dedup, and merge-state checks.
           try {
-            const {
-              getPRInfo,
-              checkCI,
-              getReviews,
-              decideNextAction,
-            } = require(path.join(__dirname, 'scripts', 'follow-up-pr.js'));
+            const { isPRGateReady } = require(path.join(__dirname, 'scripts', 'follow-up-pr.js'));
+            const result = isPRGateReady();
+            if (!result.ready) return false;
 
-            const prInfo = getPRInfo();
-            if (!prInfo || !prInfo.number) return false;
-            if (prInfo.state === 'CLOSED' || prInfo.state === 'MERGED') return false;
-
-            const ci = checkCI(prInfo.number);
-            const reviews = getReviews(prInfo.number);
-            const decision = decideNextAction(ci.status, prInfo, reviews, false);
-
-            if (decision.action !== 'exit-success') return false;
-
-            // Review accountability: every PR comment must be accounted for
-            const totalComments = reviews.blocking.length + reviews.nonBlocking.length;
-            if (totalComments > 0) {
+            // Review accountability: every PR comment must be accounted for.
+            // Uses strictCommentCount (fail-closed) instead of reviews array length.
+            if (result.strictCommentCount > 0) {
               const accountabilityFile = path.join(
                 TASKS_BASE,
                 safeTicketPath(ticketId),
@@ -412,7 +399,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
               );
               if (!fs.existsSync(accountabilityFile)) return false;
               const entries = JSON.parse(fs.readFileSync(accountabilityFile, 'utf-8'));
-              if (!Array.isArray(entries) || entries.length < totalComments) return false;
+              if (!Array.isArray(entries) || entries.length < result.strictCommentCount) return false;
               if (!entries.every((e) => e.disposition && e.reason)) return false;
               const acknowledged = entries.filter((e) => e.disposition === 'acknowledged');
               if (acknowledged.length > 0) {


### PR DESCRIPTION
## Existing Behavior

- The verify() functions in workflow-definition.js for the follow_up and ci steps contained inline execFileSync calls to gh CLI with their own logic for checking CI state, review decisions, and PR comment counts.
- The follow_up verify() resolved PR numbers by detecting the current git branch and passing it as a positional arg to gh pr view.
- Test mocks in the workflow guard tests replicated old, narrow gh command signatures that no longer matched the actual gh calls made by follow-up-pr.js.
- The follow-up-pr.js module did not export its core gate-check functions (getPRInfo, checkCI, getReviews).

## Intended New Behavior

- Both verify() functions now delegate entirely to follow-up-pr.js exported functions (getPRInfo, checkCI, getReviews, decideNextAction), eliminating duplicated logic and ensuring the workflow gate checks the exact same conditions as the script itself.
- follow-up-pr.js exports ghExec, getPRInfo, checkCI, and getReviews so callers can reuse them directly.
- The obsolete branch-positional-arg describe block (GH-191, GH-203) is removed from tests since branch detection now lives entirely in follow-up-pr.js.
- Test mocks are updated to match the real gh command signatures issued by follow-up-pr.js, and a buildGhResponses() helper reduces duplication across test cases.
- Two new test cases cover merge conflict blocking (CONFLICTING mergeable state, DIRTY merge state) and one new case verifies that human reviewer comments are always treated as blocking even when an accountability file exists.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Run the follow_up verify test suite to confirm all updated mocks and new cases pass:
   - File: workflows/lib/__tests__/enforce-step-workflow.test.js (follow_up verify function describe block)
   - Command: node --test <path-to-file>
   - Expected: all tests pass including new merge-conflict and human-comment-blocking cases.

2. Simulate a follow_up to ci transition with a PR open on the branch:
   - Command: node workflows/work/work.workflow.js transition <TICKET-ID> ci
   - With CI failing: expect exit code 2 and BLOCKED in stderr.
   - With CI passing and no open review comments: expect exit code 0.

3. Verify the ci to cleanup transition gate still requires CI evidence:
   - Command: node workflows/work/work.workflow.js transition <TICKET-ID> cleanup
   - Without a passing PR, expect exit code 2 and BLOCKED in stderr.

### Test Results
The follow_up verify test suite covers all updated scenarios — results will be confirmed after PR CI run.
