### PR TITLE
fix(GH-219): wire --task N through TDD enforcement to fix per-task state regressions

### DIFF
--- a/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -456,7 +456,7 @@ describe('tdd-phase-state CLI', () => {
     });
   });
 
-  describe('per-task path with legacy root fallback (GH-219 Task 9)', () => {
+  describe('per-task path resolution (GH-219 Task 9 + Task 1)', () => {
     it('init with --task writes to TASKS_BASE/<ticket>/task${N}/tdd-phase.json', () => {
       const { stdout, exitCode } = runCli('init TEST-T9A --task 3', homeDir);
       assert.strictEqual(exitCode, 0);
@@ -478,17 +478,15 @@ describe('tdd-phase-state CLI', () => {
       assert.strictEqual(result.phase, 'red');
     });
 
-    it('current with --task falls back to legacy root when per-task path missing', () => {
+    it('current with --task does NOT fall back to legacy root (GH-219 Task 1)', () => {
       // Create state at root (legacy) path only
       runCli('init TEST-T9C', homeDir);
-      // Now read with --task — per-task file does not exist, should fallback to root
-      const { stdout, exitCode } = runCli('current TEST-T9C --task 2', homeDir);
-      assert.strictEqual(exitCode, 0);
-      const result = JSON.parse(stdout);
-      assert.strictEqual(result.phase, 'red');
+      // Now read with --task — per-task file does not exist, should NOT fallback to root
+      const { exitCode } = runCli('current TEST-T9C --task 2', homeDir);
+      assert.strictEqual(exitCode, 1, 'Should fail when per-task state does not exist, no root fallback');
     });
 
-    it('current with --task fails when neither per-task nor root exists', () => {
+    it('current with --task fails when per-task path does not exist', () => {
       const { exitCode } = runCli('current TEST-T9D --task 1', homeDir);
       assert.strictEqual(exitCode, 1);
     });
@@ -497,6 +495,176 @@ describe('tdd-phase-state CLI', () => {
       runCli('init TEST-T9E', homeDir);
       const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-T9E', 'tdd-phase.json');
       assert.ok(fs.existsSync(rootPath), `Expected root state at ${rootPath}`);
+    });
+  });
+
+
+  describe('no-fallback guard (GH-219 Task 1)', () => {
+    it('getStatePath with taskNum always returns per-task path, never root', () => {
+      // Init at root, then verify --task read does NOT find root state
+      runCli('init TEST-NOFALL', homeDir);
+      const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-NOFALL', 'tdd-phase.json');
+      assert.ok(fs.existsSync(rootPath), 'Root state should exist');
+
+      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-NOFALL', 'task1', 'tdd-phase.json');
+      assert.ok(!fs.existsSync(perTaskPath), 'Per-task state should NOT exist yet');
+
+      // Reading with --task 1 should fail (no per-task state), NOT fall back to root
+      const { exitCode } = runCli('current TEST-NOFALL --task 1', homeDir);
+      assert.strictEqual(exitCode, 1, 'Should not fall back to root path');
+    });
+  });
+
+  describe('record commands with --task (GH-219 Task 1)', () => {
+    it('record-green with --task reads/writes per-task path', () => {
+      // Init per-task state
+      runCli('init TEST-RG1 --task 2', homeDir);
+      // Set up state for green phase
+      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-RG1', 'task2', 'tdd-phase.json');
+      const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
+      state.currentPhase = 'green';
+      state.cycles = [
+        {
+          cycle: 1,
+          red: {
+            testFiles: ['foo.test.ts'],
+            testCommand: 'echo test',
+            testExitCode: 1,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      ];
+      fs.writeFileSync(perTaskPath, JSON.stringify(state, null, 2));
+
+      const passScript = createExitScript(scriptDir, 0);
+      const { stdout, exitCode } = runCli(
+        `record-green TEST-RG1 --task 2 --cmd "${passScript}"`,
+        homeDir
+      );
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.ok, true);
+
+      // Verify it wrote to per-task path, not root
+      const updatedState = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
+      assert.strictEqual(updatedState.cycles[0].green.testExitCode, 0);
+      // Root path should NOT exist
+      const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-RG1', 'tdd-phase.json');
+      assert.ok(!fs.existsSync(rootPath), 'Root state should NOT be created');
+    });
+
+    it('record-refactor with --task reads/writes per-task path', () => {
+      runCli('init TEST-RR1 --task 4', homeDir);
+      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-RR1', 'task4', 'tdd-phase.json');
+      const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
+      state.currentPhase = 'refactor';
+      state.cycles = [
+        {
+          cycle: 1,
+          red: {
+            testFiles: ['foo.test.ts'],
+            testCommand: 'echo test',
+            testExitCode: 1,
+            timestamp: new Date().toISOString(),
+          },
+          green: { testCommand: 'echo test', testExitCode: 0, timestamp: new Date().toISOString() },
+        },
+      ];
+      fs.writeFileSync(perTaskPath, JSON.stringify(state, null, 2));
+
+      const passScript = createExitScript(scriptDir, 0);
+      const { stdout, exitCode } = runCli(
+        `record-refactor TEST-RR1 --task 4 --cmd "${passScript}"`,
+        homeDir
+      );
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.ok, true);
+
+      const updatedState = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
+      assert.strictEqual(updatedState.cycles[0].refactor.testExitCode, 0);
+    });
+
+    it('record-green without --task still uses root path (backward compat)', () => {
+      runCli('init TEST-RG2', homeDir);
+      const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-RG2', 'tdd-phase.json');
+      const state = JSON.parse(fs.readFileSync(rootPath, 'utf8'));
+      state.currentPhase = 'green';
+      state.cycles = [
+        {
+          cycle: 1,
+          red: {
+            testFiles: ['foo.test.ts'],
+            testCommand: 'echo test',
+            testExitCode: 1,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      ];
+      fs.writeFileSync(rootPath, JSON.stringify(state, null, 2));
+
+      const passScript = createExitScript(scriptDir, 0);
+      const { stdout, exitCode } = runCli(
+        `record-green TEST-RG2 --cmd "${passScript}"`,
+        homeDir
+      );
+      assert.strictEqual(exitCode, 0);
+      const updatedState = JSON.parse(fs.readFileSync(rootPath, 'utf8'));
+      assert.strictEqual(updatedState.cycles[0].green.testExitCode, 0);
+    });
+  });
+
+  describe('transition with --task (GH-219 Task 1)', () => {
+    it('transition with --task reads/writes per-task path', () => {
+      runCli('init TEST-TR1 --task 3', homeDir);
+      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-TR1', 'task3', 'tdd-phase.json');
+      const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
+      state.cycles = [
+        {
+          cycle: 1,
+          red: {
+            testFiles: ['foo.test.ts'],
+            testCommand: 'echo test',
+            testExitCode: 1,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      ];
+      fs.writeFileSync(perTaskPath, JSON.stringify(state, null, 2));
+
+      const { stdout, exitCode } = runCli('transition TEST-TR1 green --task 3', homeDir);
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.phase, 'green');
+
+      const updatedState = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
+      assert.strictEqual(updatedState.currentPhase, 'green');
+      // Root path should NOT exist
+      const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-TR1', 'tdd-phase.json');
+      assert.ok(!fs.existsSync(rootPath), 'Root state should NOT be created');
+    });
+
+    it('transition without --task still uses root path (backward compat)', () => {
+      runCli('init TEST-TR2', homeDir);
+      const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-TR2', 'tdd-phase.json');
+      const state = JSON.parse(fs.readFileSync(rootPath, 'utf8'));
+      state.cycles = [
+        {
+          cycle: 1,
+          red: {
+            testFiles: ['foo.test.ts'],
+            testCommand: 'echo test',
+            testExitCode: 1,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      ];
+      fs.writeFileSync(rootPath, JSON.stringify(state, null, 2));
+
+      const { stdout, exitCode } = runCli('transition TEST-TR2 green', homeDir);
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.phase, 'green');
     });
   });
 

--- a/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -330,6 +330,40 @@ describe('tdd-phase-state CLI', () => {
         `Expected error about empty reason, got: ${stderr}`
       );
     });
+
+    it('with --task writes to per-task path (GH-219 PR6)', () => {
+      const { stdout, exitCode } = runCli(
+        'exception TEST-EXC4 --task 2 --reason "config-only change"',
+        homeDir
+      );
+      assert.strictEqual(exitCode, 0);
+      const result = JSON.parse(stdout);
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.phase, 'exception');
+
+      // Verify state file is at per-task path
+      const perTaskPath = path.join(
+        homeDir, 'worktrees', 'tasks', 'TEST-EXC4', 'task2', 'tdd-phase.json'
+      );
+      assert.ok(fs.existsSync(perTaskPath), `Expected per-task state at ${perTaskPath}`);
+      const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
+      assert.strictEqual(state.currentPhase, 'exception');
+      assert.strictEqual(state.exception, 'config-only change');
+
+      // Root path should NOT exist
+      const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-EXC4', 'tdd-phase.json');
+      assert.ok(!fs.existsSync(rootPath), 'Root state should NOT be created when --task is used');
+    });
+
+    it('without --task writes to root path (backward compat)', () => {
+      const { exitCode } = runCli(
+        'exception TEST-EXC5 --reason "no task context"',
+        homeDir
+      );
+      assert.strictEqual(exitCode, 0);
+      const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-EXC5', 'tdd-phase.json');
+      assert.ok(fs.existsSync(rootPath), `Expected root state at ${rootPath}`);
+    });
   });
 
   describe('phase validation in record commands', () => {

--- a/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -718,4 +718,151 @@ describe('tdd-phase-state CLI', () => {
       assert.strictEqual(exitCode, 0);
     });
   });
+  describe('multi-task TDD accumulation (GH-219 Task 5)', () => {
+    it('5.1: accumulates independent per-task state across full TDD lifecycle', () => {
+      const ticketId = 'TEST-MT1';
+      const tasksBase = path.join(homeDir, 'worktrees', 'tasks');
+      const failScript = createExitScript(scriptDir, 1);
+      const passScript = createExitScript(scriptDir, 0);
+
+      // 1. Init task 1
+      const initResult1 = runCli(`init ${ticketId} --task 1`, homeDir);
+      assert.strictEqual(initResult1.exitCode, 0);
+
+      // 2. Verify task1/tdd-phase.json exists with currentPhase: 'red', cycles: []
+      const task1Path = path.join(tasksBase, ticketId, 'task1', 'tdd-phase.json');
+      assert.ok(fs.existsSync(task1Path), 'task1/tdd-phase.json should exist after init');
+      const task1StateAfterInit = JSON.parse(fs.readFileSync(task1Path, 'utf8'));
+      assert.strictEqual(task1StateAfterInit.currentPhase, 'red');
+      assert.deepStrictEqual(task1StateAfterInit.cycles, []);
+
+      // 3. Record red for task 1 — requires a git repo with changed test files
+      const gitRepo = createTempGitRepo();
+      fs.writeFileSync(path.join(gitRepo, 'feature.test.ts'), 'describe("feature", () => {});');
+      execSync('git add feature.test.ts', { cwd: gitRepo, stdio: 'pipe' });
+      const redResult = runCli(
+        `record-red ${ticketId} --task 1 --cmd "${failScript}"`,
+        homeDir,
+        gitRepo
+      );
+      assert.strictEqual(redResult.exitCode, 0, `record-red should succeed, got: ${redResult.stderr || ''}`);
+
+      // 4. Transition task 1 to green
+      const transResult = runCli(`transition ${ticketId} green --task 1`, homeDir);
+      assert.strictEqual(transResult.exitCode, 0);
+
+      // 5. Record green for task 1
+      const greenResult = runCli(
+        `record-green ${ticketId} --task 1 --cmd "${passScript}"`,
+        homeDir
+      );
+      assert.strictEqual(greenResult.exitCode, 0, `record-green should succeed, got: ${greenResult.stderr || ''}`);
+
+      // 6. Verify task1/tdd-phase.json has non-empty cycles with red AND green evidence
+      const task1Final = JSON.parse(fs.readFileSync(task1Path, 'utf8'));
+      assert.ok(task1Final.cycles.length > 0, 'cycles should be non-empty');
+      assert.ok(task1Final.cycles[0].red, 'cycle should have red evidence');
+      assert.ok(task1Final.cycles[0].green, 'cycle should have green evidence');
+      assert.strictEqual(task1Final.cycles[0].red.testExitCode, 1);
+      assert.strictEqual(task1Final.cycles[0].green.testExitCode, 0);
+
+      // Snapshot task1 state for later comparison
+      const task1Snapshot = fs.readFileSync(task1Path, 'utf8');
+
+      // 7. Init task 2
+      const initResult2 = runCli(`init ${ticketId} --task 2`, homeDir);
+      assert.strictEqual(initResult2.exitCode, 0);
+
+      // 8. Verify task1/tdd-phase.json is UNMODIFIED
+      const task1AfterTask2Init = fs.readFileSync(task1Path, 'utf8');
+      assert.strictEqual(
+        task1AfterTask2Init,
+        task1Snapshot,
+        'task1/tdd-phase.json must not be modified by task 2 init'
+      );
+
+      // 9. Record red for task 2
+      const gitRepo2 = createTempGitRepo();
+      fs.writeFileSync(path.join(gitRepo2, 'other.test.ts'), 'describe("other", () => {});');
+      execSync('git add other.test.ts', { cwd: gitRepo2, stdio: 'pipe' });
+      const redResult2 = runCli(
+        `record-red ${ticketId} --task 2 --cmd "${failScript}"`,
+        homeDir,
+        gitRepo2
+      );
+      assert.strictEqual(redResult2.exitCode, 0, `record-red task 2 should succeed, got: ${redResult2.stderr || ''}`);
+
+      // 10. Verify both state files exist independently
+      const task2Path = path.join(tasksBase, ticketId, 'task2', 'tdd-phase.json');
+      assert.ok(fs.existsSync(task1Path), 'task1/tdd-phase.json should still exist');
+      assert.ok(fs.existsSync(task2Path), 'task2/tdd-phase.json should exist');
+
+      // Verify task2 has its own red evidence
+      const task2State = JSON.parse(fs.readFileSync(task2Path, 'utf8'));
+      assert.ok(task2State.cycles.length > 0, 'task2 cycles should be non-empty');
+      assert.ok(task2State.cycles[0].red, 'task2 cycle should have red evidence');
+      assert.strictEqual(task2State.cycles[0].red.testExitCode, 1);
+
+      // Clean up git repos
+      fs.rmSync(gitRepo, { recursive: true, force: true });
+      fs.rmSync(gitRepo2, { recursive: true, force: true });
+    });
+
+    it('5.2: no root tdd-phase.json created when using per-task paths', () => {
+      const ticketId = 'TEST-MT2';
+      const tasksBase = path.join(homeDir, 'worktrees', 'tasks');
+
+      // Init and record for task 1
+      runCli(`init ${ticketId} --task 1`, homeDir);
+      const task1Path = path.join(tasksBase, ticketId, 'task1', 'tdd-phase.json');
+      const state1 = JSON.parse(fs.readFileSync(task1Path, 'utf8'));
+      state1.currentPhase = 'green';
+      state1.cycles = [
+        {
+          cycle: 1,
+          red: {
+            testFiles: ['a.test.ts'],
+            testCommand: 'echo test',
+            testExitCode: 1,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      ];
+      fs.writeFileSync(task1Path, JSON.stringify(state1, null, 2));
+
+      const passScript = createExitScript(scriptDir, 0);
+      runCli(`record-green ${ticketId} --task 1 --cmd "${passScript}"`, homeDir);
+
+      // Init and record for task 2
+      runCli(`init ${ticketId} --task 2`, homeDir);
+      const task2Path = path.join(tasksBase, ticketId, 'task2', 'tdd-phase.json');
+      const state2 = JSON.parse(fs.readFileSync(task2Path, 'utf8'));
+      state2.currentPhase = 'green';
+      state2.cycles = [
+        {
+          cycle: 1,
+          red: {
+            testFiles: ['b.test.ts'],
+            testCommand: 'echo test',
+            testExitCode: 1,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      ];
+      fs.writeFileSync(task2Path, JSON.stringify(state2, null, 2));
+      runCli(`record-green ${ticketId} --task 2 --cmd "${passScript}"`, homeDir);
+
+      // Assert NO root tdd-phase.json exists
+      const rootPath = path.join(tasksBase, ticketId, 'tdd-phase.json');
+      assert.ok(
+        !fs.existsSync(rootPath),
+        'Root tdd-phase.json must NOT exist when using per-task paths'
+      );
+
+      // Confirm per-task files DO exist
+      assert.ok(fs.existsSync(task1Path), 'task1/tdd-phase.json should exist');
+      assert.ok(fs.existsSync(task2Path), 'task2/tdd-phase.json should exist');
+    });
+  });
+
 });

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -466,12 +466,14 @@ function cmdException(ticketId, args) {
   if (!reason || !reason.trim()) {
     errorExit('Reason cannot be empty.');
   }
+  const taskNum = parseTask(args);
+  const opts = taskNum ? { taskNum } : undefined;
   const state = {
     currentPhase: 'exception',
     exception: reason,
     cycles: [],
   };
-  writeState(ticketId, state);
+  writeState(ticketId, state, opts);
   successOut({ ok: true, phase: 'exception', exception: reason });
 }
 

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -108,9 +108,8 @@ function ticketRootStatePath(base, safeId) {
  * Resolve the state file path for a ticket.
  *
  * When taskNum is provided:
- *   - Write path: always per-task (TASKS_BASE/<ticket>/task${N}/tdd-phase.json)
- *   - Read path: per-task first; if missing, fallback to legacy root path
- *     (TASKS_BASE/<ticket>/tdd-phase.json) for backward compatibility.
+ *   - Always uses per-task path (TASKS_BASE/<ticket>/task${N}/tdd-phase.json).
+ *   - No fallback to legacy root (GH-219 Task 1).
  *
  * When taskNum is NOT provided:
  *   - Uses the legacy root path (backward compat).
@@ -118,7 +117,6 @@ function ticketRootStatePath(base, safeId) {
  * @param {string} ticketId - Raw ticket ID
  * @param {object} [opts] - Options
  * @param {number} [opts.taskNum] - Task number for per-task resolution
- * @param {boolean} [opts.forWrite] - If true, always return per-task path (no fallback)
  * @returns {string} Absolute path to tdd-phase.json
  */
 function getStatePath(ticketId, opts) {
@@ -134,19 +132,8 @@ function getStatePath(ticketId, opts) {
   if (taskNum != null && Number.isInteger(taskNum) && taskNum > 0) {
     const perTask = perTaskStatePath(base, safeId, taskNum);
 
-    if (opts && opts.forWrite) {
-      // Writes always target per-task path
-      resolved = perTask;
-    } else {
-      // Reads: per-task first, then legacy root fallback
-      if (fs.existsSync(perTask)) {
-        resolved = perTask;
-      } else {
-        // Legacy fallback: check ticketRoot for backward compat
-        const root = ticketRootStatePath(base, safeId);
-        resolved = fs.existsSync(root) ? root : perTask;
-      }
-    }
+    // Per-task path — always use it, no legacy root fallback (GH-219 Task 1)
+    resolved = perTask;
   } else {
     // No task number — legacy root path
     resolved = ticketRootStatePath(base, safeId);
@@ -302,8 +289,10 @@ function cmdRecordRed(ticketId, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
   const cmd = parseCmd(args);
   if (!cmd) errorExit('Missing --cmd argument.');
+  const taskNum = parseTask(args);
+  const opts = taskNum ? { taskNum } : undefined;
 
-  const state = readState(ticketId);
+  const state = readState(ticketId, opts);
   if (!state) errorExit('No TDD phase state found. Run "init" first.');
   // Enforce phase consistency: record-red only allowed during red phase
   if (state.currentPhase !== 'red')
@@ -349,7 +338,7 @@ function cmdRecordRed(ticketId, args) {
     testExitCode: exitCode,
     timestamp: new Date().toISOString(),
   };
-  writeState(ticketId, state);
+  writeState(ticketId, state, opts);
   successOut({
     ok: true,
     phase: 'red',
@@ -363,8 +352,10 @@ function cmdRecordGreen(ticketId, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
   const cmd = parseCmd(args);
   if (!cmd) errorExit('Missing --cmd argument.');
+  const taskNum = parseTask(args);
+  const opts = taskNum ? { taskNum } : undefined;
 
-  const state = readState(ticketId);
+  const state = readState(ticketId, opts);
   if (!state) errorExit('No TDD phase state found. Run "init" first.');
   // Enforce phase consistency: record-green only allowed during green phase
   if (state.currentPhase !== 'green')
@@ -385,7 +376,7 @@ function cmdRecordGreen(ticketId, args) {
     testExitCode: exitCode,
     timestamp: new Date().toISOString(),
   };
-  writeState(ticketId, state);
+  writeState(ticketId, state, opts);
   successOut({ ok: true, phase: 'green', cycle: state.currentCycle, testExitCode: exitCode });
 }
 
@@ -397,8 +388,10 @@ function cmdRecordRefactor(ticketId, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
   const cmd = parseCmd(args);
   if (!cmd) errorExit('Missing --cmd argument.');
+  const taskNum = parseTask(args);
+  const opts = taskNum ? { taskNum } : undefined;
 
-  const state = readState(ticketId);
+  const state = readState(ticketId, opts);
   if (!state) errorExit('No TDD phase state found. Run "init" first.');
   // Enforce phase consistency: record-refactor only allowed during refactor phase
   if (state.currentPhase !== 'refactor')
@@ -419,15 +412,17 @@ function cmdRecordRefactor(ticketId, args) {
     testExitCode: exitCode,
     timestamp: new Date().toISOString(),
   };
-  writeState(ticketId, state);
+  writeState(ticketId, state, opts);
   successOut({ ok: true, phase: 'refactor', cycle: state.currentCycle, testExitCode: exitCode });
 }
 
-function cmdTransition(ticketId, targetPhase) {
+function cmdTransition(ticketId, targetPhase, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
   if (!targetPhase) errorExit('Missing target phase.');
+  const taskNum = parseTask(args || []);
+  const opts = taskNum ? { taskNum } : undefined;
 
-  const state = readState(ticketId);
+  const state = readState(ticketId, opts);
   if (!state) errorExit('No TDD phase state found. Run "init" first.');
 
   // Validate transition
@@ -455,7 +450,7 @@ function cmdTransition(ticketId, targetPhase) {
     state.currentCycle += 1;
   }
 
-  writeState(ticketId, state);
+  writeState(ticketId, state, opts);
   successOut({ phase: state.currentPhase, cycle: state.currentCycle });
 }
 
@@ -510,7 +505,7 @@ switch (subcommand) {
     cmdRecordRefactor(ticketId, args.slice(2));
     break;
   case 'transition':
-    cmdTransition(ticketId, args[2]);
+    cmdTransition(ticketId, args[2], args.slice(2));
     break;
   case 'exception':
     cmdException(ticketId, args.slice(2));

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -292,7 +292,7 @@ function cmdRecordRed(ticketId, args) {
   const taskNum = parseTask(args);
   const opts = taskNum ? { taskNum } : undefined;
 
-  const state = readState(ticketId, opts);
+  const state = readState(ticketId, opts); // reads per-task path when taskNum provided
   if (!state) errorExit('No TDD phase state found. Run "init" first.');
   // Enforce phase consistency: record-red only allowed during red phase
   if (state.currentPhase !== 'red')

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -194,6 +194,10 @@ function parseTask(args) {
   if (!Number.isInteger(val) || val < 1) throw new Error("Invalid --task value: " + args[taskIdx + 1]); return val;
 }
 
+function safeParseTask(args) {
+  try { return parseTask(args); } catch (e) { errorExit(e.message); }
+}
+
 function runTestCommand(cmd) {
   try {
     execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 300000 });
@@ -261,7 +265,7 @@ function cmdInit(ticketId, args) {
   if (!ticketId) {
     errorExit('Missing ticket ID. Usage: node tdd-phase-state.js init <TICKET_ID>');
   }
-  const taskNum = parseTask(args || []);
+  const taskNum = safeParseTask(args || []);
   const opts = taskNum ? { taskNum } : undefined;
   const state = {
     currentPhase: 'red',
@@ -276,7 +280,7 @@ function cmdCurrent(ticketId, args) {
   if (!ticketId) {
     errorExit('Missing ticket ID.');
   }
-  const taskNum = parseTask(args || []);
+  const taskNum = safeParseTask(args || []);
   const opts = taskNum ? { taskNum } : undefined;
   const state = readState(ticketId, opts);
   if (!state) {
@@ -289,7 +293,7 @@ function cmdRecordRed(ticketId, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
   const cmd = parseCmd(args);
   if (!cmd) errorExit('Missing --cmd argument.');
-  const taskNum = parseTask(args);
+  const taskNum = safeParseTask(args);
   const opts = taskNum ? { taskNum } : undefined;
 
   const state = readState(ticketId, opts); // reads per-task path when taskNum provided
@@ -352,7 +356,7 @@ function cmdRecordGreen(ticketId, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
   const cmd = parseCmd(args);
   if (!cmd) errorExit('Missing --cmd argument.');
-  const taskNum = parseTask(args);
+  const taskNum = safeParseTask(args);
   const opts = taskNum ? { taskNum } : undefined;
 
   const state = readState(ticketId, opts);
@@ -388,7 +392,7 @@ function cmdRecordRefactor(ticketId, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
   const cmd = parseCmd(args);
   if (!cmd) errorExit('Missing --cmd argument.');
-  const taskNum = parseTask(args);
+  const taskNum = safeParseTask(args);
   const opts = taskNum ? { taskNum } : undefined;
 
   const state = readState(ticketId, opts);
@@ -419,7 +423,7 @@ function cmdRecordRefactor(ticketId, args) {
 function cmdTransition(ticketId, targetPhase, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
   if (!targetPhase) errorExit('Missing target phase.');
-  const taskNum = parseTask(args || []);
+  const taskNum = safeParseTask(args || []);
   const opts = taskNum ? { taskNum } : undefined;
 
   const state = readState(ticketId, opts);
@@ -466,7 +470,7 @@ function cmdException(ticketId, args) {
   if (!reason || !reason.trim()) {
     errorExit('Reason cannot be empty.');
   }
-  const taskNum = parseTask(args);
+  const taskNum = safeParseTask(args);
   const opts = taskNum ? { taskNum } : undefined;
   const state = {
     currentPhase: 'exception',

--- a/workflows/work/__tests__/tdd-enforcement.test.js
+++ b/workflows/work/__tests__/tdd-enforcement.test.js
@@ -515,6 +515,124 @@ describe('TDD enforcement', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
+  // Per-task TDD evidence (GH-219 Task 2)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('readTddEvidence with taskNum (per-task paths)', () => {
+    const { readTddEvidence } = require('../tdd-enforcement');
+
+    it('reads from per-task path when taskNum is provided', () => {
+      const ticket = 'TDDT2-100';
+      const taskDir = path.join(tempTasksBase, ticket, 'task3');
+      fs.mkdirSync(taskDir, { recursive: true });
+      const state = {
+        currentPhase: 'red',
+        currentCycle: 2,
+        cycles: [{ cycle: 1, red: { testFiles: ['a.test.ts'] }, green: { testCommand: 'test' }, refactor: { testCommand: 'test' } }],
+      };
+      fs.writeFileSync(path.join(taskDir, 'tdd-phase.json'), JSON.stringify(state));
+
+      const result = readTddEvidence(tempTasksBase, ticket, 'implement', 3);
+      assert.equal(result.exists, true);
+      assert.equal(result.parseError, false);
+      assert.deepEqual(result.evidence.cycles.length, 1);
+
+      // Cleanup
+      fs.rmSync(path.join(tempTasksBase, ticket), { recursive: true, force: true });
+    });
+
+    it('returns exists:false when per-task file is missing (no fallback to ticket root)', () => {
+      const ticket = 'TDDT2-101';
+      const ticketDir = path.join(tempTasksBase, ticket);
+      fs.mkdirSync(ticketDir, { recursive: true });
+      // Write evidence at ticket root — should NOT be found when taskNum is given
+      fs.writeFileSync(
+        path.join(ticketDir, 'tdd-phase.json'),
+        JSON.stringify({ currentPhase: 'red', cycles: [] })
+      );
+
+      const result = readTddEvidence(tempTasksBase, ticket, 'implement', 2);
+      assert.equal(result.exists, false, 'Must not fall back to ticket root when taskNum is provided');
+
+      // Cleanup
+      fs.rmSync(ticketDir, { recursive: true, force: true });
+    });
+
+    it('still reads from ticket root when taskNum is NOT provided (backward compat)', () => {
+      const ticket = 'TDDT2-102';
+      const ticketDir = path.join(tempTasksBase, ticket);
+      fs.mkdirSync(ticketDir, { recursive: true });
+      const state = { currentPhase: 'red', cycles: [{ cycle: 1, red: {}, green: {}, refactor: {} }] };
+      fs.writeFileSync(path.join(ticketDir, 'tdd-phase.json'), JSON.stringify(state));
+
+      const result = readTddEvidence(tempTasksBase, ticket, 'implement');
+      assert.equal(result.exists, true, 'Should read from ticket root when no taskNum');
+
+      // Cleanup
+      fs.rmSync(ticketDir, { recursive: true, force: true });
+    });
+
+    it('returns parseError:true for corrupt JSON in per-task path', () => {
+      const ticket = 'TDDT2-103';
+      const taskDir = path.join(tempTasksBase, ticket, 'task1');
+      fs.mkdirSync(taskDir, { recursive: true });
+      fs.writeFileSync(path.join(taskDir, 'tdd-phase.json'), '{corrupt!!!');
+
+      const result = readTddEvidence(tempTasksBase, ticket, 'implement', 1);
+      assert.equal(result.exists, true);
+      assert.equal(result.parseError, true);
+
+      // Cleanup
+      fs.rmSync(path.join(tempTasksBase, ticket), { recursive: true, force: true });
+    });
+
+    it('uses taskSegment() for path construction (task5, not task-5)', () => {
+      const ticket = 'TDDT2-104';
+      // Create task5/ directory with evidence
+      const taskDir = path.join(tempTasksBase, ticket, 'task5');
+      fs.mkdirSync(taskDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(taskDir, 'tdd-phase.json'),
+        JSON.stringify({ currentPhase: 'red', cycles: [] })
+      );
+
+      const result = readTddEvidence(tempTasksBase, ticket, 'implement', 5);
+      assert.equal(result.exists, true, 'Should find file via taskSegment("task5")');
+
+      // Cleanup
+      fs.rmSync(path.join(tempTasksBase, ticket), { recursive: true, force: true });
+    });
+  });
+
+  describe('autoInitTdd with taskNum (per-task paths)', () => {
+    // autoInitTdd requires the config module, so we test via the work-state module
+    // which has TASKS_BASE wired. We'll test the function directly by requiring it.
+    // However, autoInitTdd uses config.TASKS_BASE internally, so we need to test
+    // through the CLI or mock. For unit tests, we'll verify the file is created
+    // at the correct per-task path.
+
+    it('creates tdd-phase.json in per-task directory when taskNum is provided', () => {
+      const ticket = 'TDDT2-200';
+      const taskDir = path.join(tempTasksBase, ticket, 'task2');
+
+      // We test autoInitTdd indirectly: the function writes to TASKS_BASE which
+      // is set from config. Since we can't easily override config in unit tests,
+      // we test readTddEvidence + the transition gate integration tests below.
+      // The unit-level validation of path construction is covered by readTddEvidence tests.
+      fs.mkdirSync(taskDir, { recursive: true });
+      // Verify taskSegment produces correct path
+      const { taskSegment } = require('../../lib/allocate-output-folder');
+      assert.equal(taskSegment(2), 'task2');
+      assert.equal(taskSegment(10), 'task10');
+      assert.throws(() => taskSegment(0), /positive integer/);
+      assert.throws(() => taskSegment(-1), /positive integer/);
+
+      // Cleanup
+      fs.rmSync(path.join(tempTasksBase, ticket), { recursive: true, force: true });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
   // GitHub ticket ID sanitization in transitionStep
   // ═══════════════════════════════════════════════════════════════════════════
 

--- a/workflows/work/__tests__/tdd-enforcement.test.js
+++ b/workflows/work/__tests__/tdd-enforcement.test.js
@@ -612,7 +612,7 @@ describe('TDD enforcement', () => {
       if (origTasksBase !== undefined) {
         process.env.TASKS_BASE = origTasksBase;
       }
-      delete require.cache[require.resolve('../work-state')];
+      delete require.cache[require.resolve('../work-state')]; // restore module cache
     });
 
     it('creates tdd-phase.json at per-task path with red phase and empty cycles', () => {

--- a/workflows/work/__tests__/tdd-enforcement.test.js
+++ b/workflows/work/__tests__/tdd-enforcement.test.js
@@ -608,11 +608,14 @@ describe('TDD enforcement', () => {
     let origTasksBase;
 
     afterEach(() => {
-      // Restore original TASKS_BASE and clear module cache
+      // Restore original TASKS_BASE (or delete if not originally set) and clear module cache
       if (origTasksBase !== undefined) {
         process.env.TASKS_BASE = origTasksBase;
+      } else {
+        delete process.env.TASKS_BASE;
       }
-      delete require.cache[require.resolve('../work-state')]; // restore module cache
+      delete require.cache[require.resolve('../work-state')];
+      delete require.cache[require.resolve('../../lib/config')];
     });
 
     it('creates tdd-phase.json at per-task path with red phase and empty cycles', () => {

--- a/workflows/work/__tests__/tdd-enforcement.test.js
+++ b/workflows/work/__tests__/tdd-enforcement.test.js
@@ -723,4 +723,175 @@ describe('TDD enforcement', () => {
       assert.ok(result.allowed.length > 0, 'Should have available transitions');
     });
   });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // TDD_PROTOCOL text includes --task <N> in CLI examples (GH-219 Task 3)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('TDD_PROTOCOL includes --task <N> in CLI examples', () => {
+    const { TDD_PROTOCOL } = require('../tdd-enforcement');
+
+    it('init command includes --task <N>', () => {
+      assert.match(TDD_PROTOCOL, /init <TICKET_ID> --task <N>/);
+    });
+
+    it('record-red command includes --task <N>', () => {
+      assert.match(TDD_PROTOCOL, /record-red <TICKET_ID> --task <N>/);
+    });
+
+    it('record-green command includes --task <N>', () => {
+      assert.match(TDD_PROTOCOL, /record-green <TICKET_ID> --task <N>/);
+    });
+
+    it('record-refactor command includes --task <N>', () => {
+      assert.match(TDD_PROTOCOL, /record-refactor <TICKET_ID> --task <N>/);
+    });
+
+    it('transition to green includes --task <N>', () => {
+      assert.match(TDD_PROTOCOL, /transition <TICKET_ID> green --task <N>/);
+    });
+
+    it('transition to refactor includes --task <N>', () => {
+      assert.match(TDD_PROTOCOL, /transition <TICKET_ID> refactor --task <N>/);
+    });
+
+    it('transition to red includes --task <N>', () => {
+      assert.match(TDD_PROTOCOL, /transition <TICKET_ID> red --task <N>/);
+    });
+
+    it('exception command includes --task <N>', () => {
+      assert.match(TDD_PROTOCOL, /exception <TICKET_ID> --task <N>/);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // task-review uses per-task path when task context is available (GH-219 Task 3)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('task-review uses per-task tasksDir', () => {
+    const taskReviewStep = require('../steps/task-review');
+    const { STEPS } = require('../step-registry');
+    const { taskSegment } = require('../../lib/allocate-output-folder');
+
+    function makeAdd() {
+      const entries = [];
+      const add = (step, action, command, reason, extra) => {
+        entries.push({ step, action, command, reason, ...(extra || {}) });
+      };
+      return { add, entries };
+    }
+
+    function makeCtx(overrides = {}) {
+      return {
+        STEPS,
+        ticket: 'TEST-TR-100',
+        tasksDir: '/tmp/tasks/TEST-TR-100',
+        path,
+        _taskData: null,
+        _allTasksDone: false,
+        _currentTaskIdx: 0,
+        ...overrides,
+      };
+    }
+
+    function makeState(overrides = {}) {
+      return {
+        hasTasks: false,
+        workState: null,
+        ...overrides,
+      };
+    }
+
+    it('overrides tasksDir to per-task path when _currentTaskIdx is set', () => {
+      const ticketTasksDir = path.join(tempTasksBase, 'TEST-TR-101');
+      const taskData = [
+        { num: 1, title: 'Task A' },
+        { num: 2, title: 'Task B' },
+        { num: 3, title: 'Task C' },
+      ];
+      const s = makeState({
+        hasTasks: true,
+        workState: {
+          tasksMeta: {
+            currentTaskIndex: 0,
+            tasks: [
+              { id: 'task-1', taskReviewFixRounds: 0 },
+              { id: 'task-2' },
+              { id: 'task-3' },
+            ],
+          },
+        },
+      });
+      // _currentTaskIdx is 0-indexed, task num is 1-indexed
+      const ctx = makeCtx({
+        _taskData: taskData,
+        _currentTaskIdx: 0,
+        tasksDir: ticketTasksDir,
+        ticket: 'TEST-TR-101',
+      });
+
+      // Create the per-task directory with .last-commit-sha so computeTaskDiff can find it
+      const perTaskDir = path.join(ticketTasksDir, taskSegment(1));
+      fs.mkdirSync(perTaskDir, { recursive: true });
+      fs.writeFileSync(path.join(perTaskDir, '.last-commit-sha'), 'a'.repeat(40));
+
+      const { add, entries } = makeAdd();
+      taskReviewStep(add, s, ctx);
+
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].action, 'RUN');
+      // The diffRange should have been computed from the per-task dir
+      // (not the ticket root). If it used the ticket root, .last-commit-sha
+      // would not be found and diffRange would be null.
+      assert.ok(entries[0].diffRange !== null, 'diffRange should be computed from per-task path');
+
+      // Cleanup
+      fs.rmSync(ticketTasksDir, { recursive: true, force: true });
+    });
+
+    it('falls back to ticket-level tasksDir when _currentTaskIdx is not set', () => {
+      const ticketTasksDir = path.join(tempTasksBase, 'TEST-TR-102');
+      const taskData = [
+        { num: 1, title: 'Task A' },
+        { num: 2, title: 'Task B' },
+      ];
+      const s = makeState({
+        hasTasks: true,
+        workState: {
+          tasksMeta: {
+            currentTaskIndex: 0,
+            tasks: [
+              { id: 'task-1', taskReviewFixRounds: 0 },
+              { id: 'task-2' },
+            ],
+          },
+        },
+      });
+      // _currentTaskIdx is explicitly undefined (not set by implement step)
+      const ctx = makeCtx({
+        _taskData: taskData,
+        _currentTaskIdx: undefined,
+        tasksDir: ticketTasksDir,
+        ticket: 'TEST-TR-102',
+      });
+
+      // Create .last-commit-sha at ticket root level (not per-task)
+      fs.mkdirSync(ticketTasksDir, { recursive: true });
+      fs.writeFileSync(path.join(ticketTasksDir, '.last-commit-sha'), 'b'.repeat(40));
+
+      const { add, entries } = makeAdd();
+      taskReviewStep(add, s, ctx);
+
+      // _currentTaskIdx is undefined, defaults to 0 in the step
+      // With default 0, it's still an intermediate task (0 < 2-1),
+      // but tasksDir should NOT be overridden to per-task path
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].action, 'RUN');
+      // diffRange should come from ticket root (where .last-commit-sha exists)
+      assert.ok(entries[0].diffRange !== null, 'diffRange should be computed from ticket root');
+
+      // Cleanup
+      fs.rmSync(ticketTasksDir, { recursive: true, force: true });
+    });
+  });
 });

--- a/workflows/work/__tests__/tdd-enforcement.test.js
+++ b/workflows/work/__tests__/tdd-enforcement.test.js
@@ -605,27 +605,45 @@ describe('TDD enforcement', () => {
   });
 
   describe('autoInitTdd with taskNum (per-task paths)', () => {
-    // autoInitTdd requires the config module, so we test via the work-state module
-    // which has TASKS_BASE wired. We'll test the function directly by requiring it.
-    // However, autoInitTdd uses config.TASKS_BASE internally, so we need to test
-    // through the CLI or mock. For unit tests, we'll verify the file is created
-    // at the correct per-task path.
+    let origTasksBase;
 
-    it('creates tdd-phase.json in per-task directory when taskNum is provided', () => {
-      const ticket = 'TDDT2-200';
-      const taskDir = path.join(tempTasksBase, ticket, 'task2');
+    afterEach(() => {
+      // Restore original TASKS_BASE and clear module cache
+      if (origTasksBase !== undefined) {
+        process.env.TASKS_BASE = origTasksBase;
+      }
+      delete require.cache[require.resolve('../work-state')];
+    });
 
-      // We test autoInitTdd indirectly: the function writes to TASKS_BASE which
-      // is set from config. Since we can't easily override config in unit tests,
-      // we test readTddEvidence + the transition gate integration tests below.
-      // The unit-level validation of path construction is covered by readTddEvidence tests.
-      fs.mkdirSync(taskDir, { recursive: true });
-      // Verify taskSegment produces correct path
-      const { taskSegment } = require('../../lib/allocate-output-folder');
-      assert.equal(taskSegment(2), 'task2');
-      assert.equal(taskSegment(10), 'task10');
-      assert.throws(() => taskSegment(0), /positive integer/);
-      assert.throws(() => taskSegment(-1), /positive integer/);
+    it('creates tdd-phase.json at per-task path with red phase and empty cycles', () => {
+      const ticket = 'TEST-200';
+      const expectedDir = path.join(tempTasksBase, ticket, 'task2');
+      const expectedFile = path.join(expectedDir, 'tdd-phase.json');
+
+      // Point TASKS_BASE at our temp dir and reload config + work-state to pick it up
+      origTasksBase = process.env.TASKS_BASE;
+      process.env.TASKS_BASE = tempTasksBase;
+      delete require.cache[require.resolve('../../lib/config')];
+      delete require.cache[require.resolve('../work-state')];
+      // Also clear submodules that work-state requires (they cache parent fns)
+      try { delete require.cache[require.resolve('../work-state/task-readiness')]; } catch {}
+      try { delete require.cache[require.resolve('../work-state/parallel-workers')]; } catch {}
+      try { delete require.cache[require.resolve('../work-state/graph-validation')]; } catch {}
+      const { autoInitTdd } = require('../work-state');
+
+      // Call autoInitTdd with taskNum
+      autoInitTdd(ticket, 2);
+
+      // Assert file exists at per-task path
+      assert.ok(
+        fs.existsSync(expectedFile),
+        `Expected tdd-phase.json at ${expectedFile}`
+      );
+
+      // Assert file contents
+      const state = JSON.parse(fs.readFileSync(expectedFile, 'utf8'));
+      assert.equal(state.currentPhase, 'red', 'currentPhase should be red');
+      assert.deepEqual(state.cycles, [], 'cycles should be empty array');
 
       // Cleanup
       fs.rmSync(path.join(tempTasksBase, ticket), { recursive: true, force: true });

--- a/workflows/work/steps/task-review.js
+++ b/workflows/work/steps/task-review.js
@@ -19,6 +19,7 @@
 const path = require('path');
 const { appendAction } = require(path.join(__dirname, '..', 'work-actions'));
 const { computeTaskDiff } = require('../task-review-gate');
+const { taskSegment } = require('../../lib/allocate-output-folder');
 
 /**
  * @param {Function} add
@@ -83,14 +84,19 @@ module.exports = function taskReviewStep(add, s, ctx) {
 
   // Decision 5: intermediate task -- run parallel tests-review + code-review
   const currentTask = taskData[currentIdx];
+  // Override tasksDir to per-task subfolder when task context is available.
+  // ctx._currentTaskIdx is set by the implement step; when present (not undefined/null),
+  // use taskSegment() to construct the per-task path for artifact resolution.
+  const reviewTasksDir = ctx._currentTaskIdx != null
+    ? path.join(ctx.tasksDir, taskSegment(currentIdx + 1))
+    : ctx.tasksDir;
   // Compute task-scoped diff range via computeTaskDiff (reads .last-commit-sha,
   // validates, falls back to base branch on missing/invalid SHA). The range is
   // passed to the orchestrator in plan-entry metadata so /tests-review and
   // /code-review receive the task-specific diff, not the full branch diff.
-  // ctx.tasksDir is injected by plan-generator.js (see plan-generator.js line 129).
   let diffRange;
   try {
-    diffRange = computeTaskDiff(ctx.tasksDir, ctx.ticket);
+    diffRange = computeTaskDiff(reviewTasksDir, ctx.ticket);
   } catch (_e) {
     diffRange = null;
   }

--- a/workflows/work/tdd-enforcement.js
+++ b/workflows/work/tdd-enforcement.js
@@ -20,6 +20,7 @@ Initialize TDD state:
 
 Note: --task <N> is required when working inside a task-scoped workflow (tasks.md exists).
 Omit --task when running standalone /work-implement without task context.
+All subcommands (init, record-*, transition, exception) support --task.
 
 For each behavior change, cycle through RED → GREEN → REFACTOR:
 
@@ -49,7 +50,7 @@ Rules:
 - Evidence is recorded by the SCRIPT — it runs git diff and test commands itself.
 - Do NOT make local git commits during the cycle — the commit step handles that.
 - If the change is purely mechanical (config-only, no behavior change):
-  node <TDD_STATE_PATH> exception <TICKET_ID> --task <N> --reason "config-only change, no testable behavior"
+  node <TDD_STATE_PATH> exception <TICKET_ID> --task <N> --reason "config-only change, no testable behavior"  # --task supported
 `.trim();
 
 /**

--- a/workflows/work/tdd-enforcement.js
+++ b/workflows/work/tdd-enforcement.js
@@ -22,7 +22,8 @@ Note: --task <N> is required when working inside a task-scoped workflow (tasks.m
 Omit --task when running standalone /work-implement without task context.
 All subcommands (init, record-*, transition, exception) support --task when task context exists.
 
-For each behavior change, cycle through RED → GREEN → REFACTOR:
+For each behavior change, cycle through RED → GREEN → REFACTOR.
+Each phase has hook-enforced file restrictions:
 
 RED Phase (write failing tests — hook enforced):
 - Hook BLOCKS Write/Edit to any non .test/.spec file

--- a/workflows/work/tdd-enforcement.js
+++ b/workflows/work/tdd-enforcement.js
@@ -23,8 +23,7 @@ Omit --task when running standalone /work-implement without task context.
 All subcommands (init, record-*, transition, exception) support --task when task context exists.
 
 For each behavior change, cycle through RED → GREEN → REFACTOR.
-Each phase has hook-enforced file restrictions:
-
+Each phase has hook-enforced file restrictions.
 RED Phase (write failing tests — hook enforced):
 - Hook BLOCKS Write/Edit to any non .test/.spec file
 - Write focused tests (1-3) that express expected behavior

--- a/workflows/work/tdd-enforcement.js
+++ b/workflows/work/tdd-enforcement.js
@@ -62,9 +62,10 @@ Rules:
  * @returns {{exists: boolean, parseError: boolean, evidence: object|null}}
  */
 function readTddEvidence(tasksBase, ticketId, stepId, taskNum) {
+  // taskSegment() validates taskNum internally (throws on non-positive-integer)
   const phasePath = taskNum != null
     ? path.join(tasksBase, ticketId, taskSegment(taskNum), 'tdd-phase.json')
-    : path.join(tasksBase, ticketId, 'tdd-phase.json');
+    : path.join(tasksBase, ticketId, 'tdd-phase.json'); // root fallback for non-task flows
   try {
     if (!fs.existsSync(phasePath)) return { exists: false, parseError: false, evidence: null };
   } catch {

--- a/workflows/work/tdd-enforcement.js
+++ b/workflows/work/tdd-enforcement.js
@@ -16,7 +16,7 @@ The TDD loop is enforced by hooks — file restrictions are automatic per phase.
 Use tdd-phase-state.js CLI for evidence recording and phase transitions.
 
 Initialize TDD state:
-  node <TDD_STATE_PATH> init <TICKET_ID>
+  node <TDD_STATE_PATH> init <TICKET_ID> --task <N>
 
 For each behavior change, cycle through RED → GREEN → REFACTOR:
 
@@ -24,29 +24,29 @@ RED Phase (write failing tests):
 - Hook BLOCKS Write/Edit to any non .test/.spec file
 - Write focused tests (1-3) that express expected behavior
 - Record evidence and transition:
-  node <TDD_STATE_PATH> record-red <TICKET_ID> --cmd "<targeted test command>"
-  node <TDD_STATE_PATH> transition <TICKET_ID> green
+  node <TDD_STATE_PATH> record-red <TICKET_ID> --task <N> --cmd "<targeted test command>"
+  node <TDD_STATE_PATH> transition <TICKET_ID> green --task <N>
 
 GREEN Phase (make tests pass):
 - Hook BLOCKS Write/Edit to .test/.spec files (prevents cheating)
 - Test helpers allowed: __mocks__/, __fixtures__/, test-utils, *.mock.*, *.fixture.*
 - Write minimum production code to make tests pass
 - Record evidence and transition:
-  node <TDD_STATE_PATH> record-green <TICKET_ID> --cmd "<same test command>"
-  node <TDD_STATE_PATH> transition <TICKET_ID> refactor
+  node <TDD_STATE_PATH> record-green <TICKET_ID> --task <N> --cmd "<same test command>"
+  node <TDD_STATE_PATH> transition <TICKET_ID> refactor --task <N>
 
 REFACTOR Phase (clean up):
 - No file restrictions
 - Refactor both test and production code
 - Record evidence:
-  node <TDD_STATE_PATH> record-refactor <TICKET_ID> --cmd "<broader test command>"
-  node <TDD_STATE_PATH> transition <TICKET_ID> red  (if more behaviors)
+  node <TDD_STATE_PATH> record-refactor <TICKET_ID> --task <N> --cmd "<broader test command>"
+  node <TDD_STATE_PATH> transition <TICKET_ID> red --task <N>  (if more behaviors)
 
 Rules:
 - Evidence is recorded by the SCRIPT — it runs git diff and test commands itself.
 - Do NOT make local git commits during the cycle — the commit step handles that.
 - If the change is purely mechanical (config-only, no behavior change):
-  node <TDD_STATE_PATH> exception <TICKET_ID> --reason "config-only change, no testable behavior"
+  node <TDD_STATE_PATH> exception <TICKET_ID> --task <N> --reason "config-only change, no testable behavior"
 `.trim();
 
 /**

--- a/workflows/work/tdd-enforcement.js
+++ b/workflows/work/tdd-enforcement.js
@@ -7,6 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { taskSegment } = require('../lib/allocate-output-folder');
 
 const TDD_PROTOCOL = `
 TDD protocol (hook-enforced for this step):
@@ -53,10 +54,13 @@ Rules:
  * @param {string} tasksBase - TASKS_BASE root directory
  * @param {string} ticketId
  * @param {string} stepId - unused (reserved for multi-step enforcement)
+ * @param {number} [taskNum] - 1-indexed task number; when provided, reads from per-task path
  * @returns {{exists: boolean, parseError: boolean, evidence: object|null}}
  */
-function readTddEvidence(tasksBase, ticketId, stepId) {
-  const phasePath = path.join(tasksBase, ticketId, 'tdd-phase.json');
+function readTddEvidence(tasksBase, ticketId, stepId, taskNum) {
+  const phasePath = taskNum != null
+    ? path.join(tasksBase, ticketId, taskSegment(taskNum), 'tdd-phase.json')
+    : path.join(tasksBase, ticketId, 'tdd-phase.json');
   try {
     if (!fs.existsSync(phasePath)) return { exists: false, parseError: false, evidence: null };
   } catch {

--- a/workflows/work/tdd-enforcement.js
+++ b/workflows/work/tdd-enforcement.js
@@ -18,6 +18,9 @@ Use tdd-phase-state.js CLI for evidence recording and phase transitions.
 Initialize TDD state:
   node <TDD_STATE_PATH> init <TICKET_ID> --task <N>
 
+Note: --task <N> is required when working inside a task-scoped workflow (tasks.md exists).
+Omit --task when running standalone /work-implement without task context.
+
 For each behavior change, cycle through RED → GREEN → REFACTOR:
 
 RED Phase (write failing tests):

--- a/workflows/work/tdd-enforcement.js
+++ b/workflows/work/tdd-enforcement.js
@@ -20,11 +20,11 @@ Initialize TDD state:
 
 Note: --task <N> is required when working inside a task-scoped workflow (tasks.md exists).
 Omit --task when running standalone /work-implement without task context.
-All subcommands (init, record-*, transition, exception) support --task.
+All subcommands (init, record-*, transition, exception) support --task when task context exists.
 
 For each behavior change, cycle through RED → GREEN → REFACTOR:
 
-RED Phase (write failing tests):
+RED Phase (write failing tests — hook enforced):
 - Hook BLOCKS Write/Edit to any non .test/.spec file
 - Write focused tests (1-3) that express expected behavior
 - Record evidence and transition:

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -58,9 +58,14 @@ function transitionStep(ticket, targetStep, deps) {
     };
   }
 
+  // Extract 1-indexed task number from work state for per-task TDD paths (GH-219 Task 2)
+  const taskNum = ws?.tasksMeta?.currentTaskIndex != null
+    ? ws.tasksMeta.currentTaskIndex + 1
+    : undefined;
+
   // TDD gate: require evidence before leaving gated steps (always enforced)
   if (TDD_GATED_STEPS.includes(currentStep) && currentStep !== targetStep) {
-    const { exists, parseError, evidence } = readTddEvidence(safeTicket, currentStep);
+    const { exists, parseError, evidence } = readTddEvidence(safeTicket, currentStep, taskNum);
     if (!exists || parseError) {
       const tddStatePath = path.resolve(__dirname, '..', 'work-implement', 'tdd-phase-state.js');
       const msg = `Cannot leave ${currentStep} without TDD evidence. Use the TDD phase system:\n  node ${tddStatePath} init ${safeTicket}\n  node ${tddStatePath} record-red ${safeTicket} --cmd "<test command>"\n  node ${tddStatePath} record-green ${safeTicket} --cmd "<test command>"\n  node ${tddStatePath} record-refactor ${safeTicket} --cmd "<test command>"`;
@@ -116,7 +121,13 @@ function transitionStep(ticket, targetStep, deps) {
   // Stale evidence cleanup when transitioning INTO a gated step
   if (TDD_GATED_STEPS.includes(targetStep)) {
     try {
-      const phasePath = path.join(TASKS_BASE, safeTicket, 'tdd-phase.json');
+      let phasePath;
+      if (taskNum != null) {
+        const { taskSegment } = require(path.join(__dirname, '..', 'lib', 'allocate-output-folder'));
+        phasePath = path.join(TASKS_BASE, safeTicket, taskSegment(taskNum), 'tdd-phase.json');
+      } else {
+        phasePath = path.join(TASKS_BASE, safeTicket, 'tdd-phase.json');
+      }
       fs.unlinkSync(phasePath);
     } catch (e) {
       if (e && e.code !== 'ENOENT') {
@@ -125,7 +136,7 @@ function transitionStep(ticket, targetStep, deps) {
     }
     try {
       const { autoInitTdd } = require(path.join(__dirname, 'work-state'));
-      autoInitTdd(safeTicket);
+      autoInitTdd(safeTicket, taskNum);
     } catch {
       /* fail-open */
     }

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -69,7 +69,8 @@ function transitionStep(ticket, targetStep, deps) {
     const { exists, parseError, evidence } = readTddEvidence(safeTicket, currentStep, taskNum);
     if (!exists || parseError) {
       const tddStatePath = path.resolve(__dirname, '..', 'work-implement', 'tdd-phase-state.js');
-      const msg = `Cannot leave ${currentStep} without TDD evidence. Use the TDD phase system:\n  node ${tddStatePath} init ${safeTicket}\n  node ${tddStatePath} record-red ${safeTicket} --cmd "<test command>"\n  node ${tddStatePath} record-green ${safeTicket} --cmd "<test command>"\n  node ${tddStatePath} record-refactor ${safeTicket} --cmd "<test command>"`;
+      const taskFlag = taskNum ? ` --task ${taskNum}` : '';
+      const msg = `Cannot leave ${currentStep} without TDD evidence. Use the TDD phase system:\n  node ${tddStatePath} init ${safeTicket}${taskFlag}\n  node ${tddStatePath} record-red ${safeTicket}${taskFlag} --cmd "<test command>"\n  node ${tddStatePath} record-green ${safeTicket}${taskFlag} --cmd "<test command>"\n  node ${tddStatePath} record-refactor ${safeTicket}${taskFlag} --cmd "<test command>"`;
       return { error: true, message: msg };
     }
     const validation = validateTddEvidence(evidence);

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -12,6 +12,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { taskSegment } = require(path.join(__dirname, '..', 'lib', 'allocate-output-folder'));
 
 /**
  * @param {string} ticket
@@ -123,7 +124,6 @@ function transitionStep(ticket, targetStep, deps) {
     try {
       let phasePath;
       if (taskNum != null) {
-        const { taskSegment } = require(path.join(__dirname, '..', 'lib', 'allocate-output-folder'));
         phasePath = path.join(TASKS_BASE, safeTicket, taskSegment(taskNum), 'tdd-phase.json');
       } else {
         phasePath = path.join(TASKS_BASE, safeTicket, 'tdd-phase.json');

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -142,14 +142,22 @@ function initState(ticketId, description = '') {
  * Auto-initialize TDD phase state when entering the implement step.
  * Creates tdd-phase.json with RED phase so the developer agent is forced
  * to write tests first. Idempotent — skips if state already exists.
+ * @param {string} ticketId
+ * @param {number} [taskNum] - 1-indexed task number; when provided, writes to per-task path
  */
-function autoInitTdd(ticketId) {
+function autoInitTdd(ticketId, taskNum) {
   let fd;
   let created = false;
+  let tddStatePath;
   try {
     // Validate ticketId — reject traversal chars and verify resolved path stays within TASKS_BASE
     if (!ticketId || /\.\./.test(ticketId) || /\\/.test(ticketId)) return;
-    const tddStatePath = path.join(TASKS_BASE, safeId(ticketId), 'tdd-phase.json');
+    if (taskNum != null) {
+      const { taskSegment } = require('../lib/allocate-output-folder');
+      tddStatePath = path.join(TASKS_BASE, safeId(ticketId), taskSegment(taskNum), 'tdd-phase.json');
+    } else {
+      tddStatePath = path.join(TASKS_BASE, safeId(ticketId), 'tdd-phase.json');
+    }
     if (!path.resolve(tddStatePath).startsWith(path.resolve(TASKS_BASE) + path.sep)) return;
     // Create directory and write initial RED phase state
     fs.mkdirSync(path.dirname(tddStatePath), { recursive: true });
@@ -161,9 +169,9 @@ function autoInitTdd(ticketId) {
   } catch (err) {
     if (err && err.code === 'EEXIST') return; // already initialized
     // fail-open: TDD init failure must not block step transition
-    if (created) {
+    if (created && tddStatePath) {
       try {
-        fs.unlinkSync(path.join(TASKS_BASE, safeId(ticketId), 'tdd-phase.json'));
+        fs.unlinkSync(tddStatePath);
       } catch {}
     }
   } finally {

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -59,6 +59,7 @@ if (!config) process.exit(0);
 const TASKS_BASE = config.TASKS_BASE;
 
 const { ALL_STEPS: STEPS } = require(path.join(__dirname, 'step-registry'));
+const { taskSegment } = require('../lib/allocate-output-folder');
 
 const SUBTASK_STEPS = ['implement', 'commit'];
 
@@ -153,7 +154,6 @@ function autoInitTdd(ticketId, taskNum) {
     // Validate ticketId — reject traversal chars and verify resolved path stays within TASKS_BASE
     if (!ticketId || /\.\./.test(ticketId) || /\\/.test(ticketId)) return;
     if (taskNum != null) {
-      const { taskSegment } = require('../lib/allocate-output-folder');
       tddStatePath = path.join(TASKS_BASE, safeId(ticketId), taskSegment(taskNum), 'tdd-phase.json');
     } else {
       tddStatePath = path.join(TASKS_BASE, safeId(ticketId), 'tdd-phase.json');

--- a/workflows/work/work.workflow.js
+++ b/workflows/work/work.workflow.js
@@ -106,8 +106,8 @@ function saveWorkState(ticket, state) {
 function getCurrentStep(workState) {
   return helpers.getCurrentStep(workState, STEPS, ALL_STEPS);
 }
-function readTddEvidence(ticketId, stepId) {
-  return _readTddEvidence(TASKS_BASE, ticketId, stepId);
+function readTddEvidence(ticketId, stepId, taskNum) {
+  return _readTddEvidence(TASKS_BASE, ticketId, stepId, taskNum);
 }
 function validateCheckGate(ticket) {
   return _validateCheckGate(TASKS_BASE, ticket);


### PR DESCRIPTION
## Existing Behavior

- `tdd-phase-state.js` CLI commands (`record-red`, `record-green`, `record-refactor`, `transition`) ignored the `--task N` flag: reads and writes always targeted the ticket-root `tdd-phase.json`, causing per-task state files to be overwritten rather than accumulating independently.
- `getStatePath()` applied a legacy root fallback for read operations when a per-task file was missing, silently masking the missing-state error.
- `readTddEvidence()` in `tdd-enforcement.js` always resolved to the ticket-root path regardless of task context; `autoInitTdd()` likewise wrote only to the ticket root.
- `task-review.js` used `ctx.tasksDir` (ticket-level) for artifact resolution, so `.last-commit-sha` and diff ranges were computed from the wrong directory when running per-task reviews.
- `TDD_PROTOCOL` instruction text omitted `--task <N>` from every CLI example.

## Intended New Behavior

- `record-red`, `record-green`, `record-refactor`, and `transition` all parse `--task N` and pass it through to `readState`/`writeState`, so per-task `tdd-phase.json` files accumulate correctly without touching sibling tasks.
- `getStatePath()` removes the legacy root fallback: when `--task N` is supplied, the per-task path is used exclusively; a missing file returns a hard failure instead of silently falling back.
- `readTddEvidence()` accepts an optional `taskNum` parameter and resolves to `<tasksBase>/<ticket>/task<N>/tdd-phase.json`; `autoInitTdd()` accepts `taskNum` and writes to the same per-task path. `transition-step.js` and `work.workflow.js` extract `currentTaskIndex` from work state and forward `taskNum` accordingly.
- `task-review.js` overrides `tasksDir` to `path.join(ctx.tasksDir, taskSegment(currentIdx + 1))` when `ctx._currentTaskIdx` is set, directing `computeTaskDiff` to the correct per-task folder.
- `TDD_PROTOCOL` text is updated so every CLI example includes `--task <N>`.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

These are regression fixes in the TDD enforcement pipeline. Verify with the existing test suite:

1. Run the tdd-phase-state CLI tests:
   ```
   node --test workflows/work-implement/__tests__/tdd-phase-state.test.js
   ```
   Confirm the `record commands with --task` and `transition with --task` describe blocks pass, and the `no-fallback guard` test confirms exit code 1 when per-task state is absent.

2. Run the TDD enforcement tests:
   ```
   node --test workflows/work/__tests__/tdd-enforcement.test.js
   ```
   Confirm `readTddEvidence with taskNum`, `autoInitTdd with taskNum`, `TDD_PROTOCOL includes --task <N>`, and `task-review uses per-task tasksDir` describe blocks all pass.

3. Manual smoke test for the path-isolation regression:
   - Init two tasks: `node tdd-phase-state.js init TICKET-1 --task 1` and `node tdd-phase-state.js init TICKET-1 --task 2`
   - Run `record-red` for task 1 only: `node tdd-phase-state.js record-red TICKET-1 --task 1 --cmd "..."`
   - Verify `task1/tdd-phase.json` has a populated cycle and `task2/tdd-phase.json` still has `cycles: []`.
   - Verify no `tdd-phase.json` exists at the ticket root.

Closes #219

### Test Results
[Will be populated after PR creation with actual test run output]