### PR TITLE
feat(GH-219): add contentGuard to brief artifact preventing pre-resolution of blocking questions

### DIFF
--- a/workflows/lib/__tests__/protect-artifact-files.test.js
+++ b/workflows/lib/__tests__/protect-artifact-files.test.js
@@ -297,3 +297,130 @@ describe('createArtifactProtector', () => {
     assert.equal(result.blocked, false);
   });
 });
+
+// ─── contentGuard ─────────────────────────────────────────────────────────────
+
+describe('contentGuard', () => {
+  const TICKET = 'TEST-123';
+
+  function makeProtectorWithGuard(guardFn, overrides = {}) {
+    return createArtifactProtector({
+      artifacts: [
+        {
+          basename: 'brief.md',
+          step: 'brief',
+          agents: ['brief-writer'],
+          contentGuard: guardFn,
+        },
+        { basename: 'spec.md', step: 'spec', agents: ['spec-writer'] },
+      ],
+      getStepInProgress: () => overrides.currentStep || 'brief',
+      isRunningInAgent: () => true,
+      getTicketId: () => TICKET,
+      ...overrides,
+    });
+  }
+
+  it('blocks when contentGuard returns blocked: true (Write)', () => {
+    const guard = () => ({ blocked: true, message: 'Content not allowed' });
+    const p = makeProtectorWithGuard(guard);
+    const result = p.check('Write', {
+      file_path: `/tasks/${TICKET}/brief.md`,
+      content: 'some content',
+    });
+    assert.equal(result.blocked, true);
+    assert.equal(result.rule, 'content');
+    assert.equal(result.message, 'Content not allowed');
+  });
+
+  it('allows when contentGuard returns blocked: false (Write)', () => {
+    const guard = () => ({ blocked: false });
+    const p = makeProtectorWithGuard(guard);
+    const result = p.check('Write', {
+      file_path: `/tasks/${TICKET}/brief.md`,
+      content: 'some content',
+    });
+    assert.equal(result.blocked, false);
+  });
+
+  it('blocks when contentGuard returns blocked: true (Edit)', () => {
+    const guard = (content) => {
+      if (content.includes('bad')) return { blocked: true, message: 'Bad content in edit' };
+      return { blocked: false };
+    };
+    const p = makeProtectorWithGuard(guard);
+    const result = p.check('Edit', {
+      file_path: `/tasks/${TICKET}/brief.md`,
+      new_string: 'this is bad content',
+    });
+    assert.equal(result.blocked, true);
+    assert.equal(result.rule, 'content');
+    assert.ok(result.message.includes('Bad content'));
+  });
+
+  it('blocks when contentGuard returns blocked: true (MultiEdit)', () => {
+    const guard = () => ({ blocked: true, message: 'Blocked by guard' });
+    const p = makeProtectorWithGuard(guard);
+    const result = p.check('MultiEdit', {
+      file_path: `/tasks/${TICKET}/brief.md`,
+      new_string: 'multi edit content',
+    });
+    assert.equal(result.blocked, true);
+    assert.equal(result.rule, 'content');
+  });
+
+  it('does NOT call contentGuard for Bash tool', () => {
+    let called = false;
+    const guard = () => {
+      called = true;
+      return { blocked: true, message: 'Should not reach here' };
+    };
+    const p = makeProtectorWithGuard(guard);
+    // Bash that writes to brief.md — should be checked for step/agent but NOT contentGuard
+    const result = p.check('Bash', { command: `cat > /tasks/${TICKET}/brief.md` });
+    assert.equal(called, false);
+    assert.equal(result.blocked, false);
+  });
+
+  it('does NOT call contentGuard when rule has no contentGuard defined', () => {
+    // spec.md has no contentGuard in our setup
+    const p = makeProtectorWithGuard(null, { currentStep: 'spec' });
+    const result = p.check('Write', {
+      file_path: `/tasks/${TICKET}/spec.md`,
+      content: 'spec content',
+    });
+    assert.equal(result.blocked, false);
+  });
+
+  it('passes content and currentStep to contentGuard', () => {
+    let capturedContent = null;
+    let capturedStep = null;
+    const guard = (content, step) => {
+      capturedContent = content;
+      capturedStep = step;
+      return { blocked: false };
+    };
+    const p = makeProtectorWithGuard(guard, { currentStep: 'brief' });
+    p.check('Write', {
+      file_path: `/tasks/${TICKET}/brief.md`,
+      content: 'hello world',
+    });
+    assert.equal(capturedContent, 'hello world');
+    assert.equal(capturedStep, 'brief');
+  });
+
+  it('does not call contentGuard when content is empty', () => {
+    let called = false;
+    const guard = () => {
+      called = true;
+      return { blocked: true, message: 'Should not reach' };
+    };
+    const p = makeProtectorWithGuard(guard);
+    const result = p.check('Write', {
+      file_path: `/tasks/${TICKET}/brief.md`,
+      content: '',
+    });
+    assert.equal(called, false);
+    assert.equal(result.blocked, false);
+  });
+});

--- a/workflows/lib/__tests__/protect-artifact-files.test.js
+++ b/workflows/lib/__tests__/protect-artifact-files.test.js
@@ -424,3 +424,158 @@ describe('contentGuard', () => {
     assert.equal(result.blocked, false);
   });
 });
+
+// ─── contentGuard Edit bypass fix (GH-219) ──────────────────────────────────
+
+describe('contentGuard with Edit tool (file-read simulation)', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const os = require('os');
+  const TICKET = 'TEST-123';
+
+  let tmpDir;
+
+  function makeProtectorWithGuard(guardFn, overrides = {}) {
+    return createArtifactProtector({
+      artifacts: [
+        {
+          basename: 'brief.md',
+          step: 'brief',
+          agents: ['brief-writer'],
+          contentGuard: guardFn,
+        },
+      ],
+      getStepInProgress: () => overrides.currentStep || 'brief',
+      isRunningInAgent: () => true,
+      getTicketId: () => TICKET,
+      ...overrides,
+    });
+  }
+
+  it('contentGuard blocks Edit that resolves a blocking question', () => {
+    // Create a temp file with unresolved question
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'paf-test-'));
+    const filePath = path.join(tmpDir, 'tasks', TICKET, 'brief.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const fileContent = [
+      '# Brief',
+      '',
+      '## Open Questions',
+      '- question: What DB to use?',
+      '  resolved: false',
+      '  category: architectural',
+    ].join('\n');
+    fs.writeFileSync(filePath, fileContent);
+
+    // Guard that blocks if all questions are resolved
+    const guard = (content) => {
+      if (content.includes('resolved: false')) return { blocked: false };
+      return { blocked: true, message: 'Cannot resolve blocking questions via edit' };
+    };
+
+    const p = makeProtectorWithGuard(guard);
+    // Edit changes resolved: false → resolved: true (the bypass vector)
+    const result = p.check('Edit', {
+      file_path: filePath,
+      old_string: 'resolved: false',
+      new_string: 'resolved: true',
+    });
+
+    assert.equal(result.blocked, true);
+    assert.equal(result.rule, 'content');
+    assert.ok(result.message.includes('Cannot resolve'));
+
+    // Cleanup
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('contentGuard allows Edit that does not resolve blocking questions', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'paf-test-'));
+    const filePath = path.join(tmpDir, 'tasks', TICKET, 'brief.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const fileContent = [
+      '# Brief',
+      '',
+      '## Open Questions',
+      '- question: What DB to use?',
+      '  resolved: false',
+      '  category: architectural',
+    ].join('\n');
+    fs.writeFileSync(filePath, fileContent);
+
+    // Guard that blocks if all questions are resolved
+    const guard = (content) => {
+      if (content.includes('resolved: false')) return { blocked: false };
+      return { blocked: true, message: 'Cannot resolve blocking questions via edit' };
+    };
+
+    const p = makeProtectorWithGuard(guard);
+    // Edit fixes a typo — does NOT resolve the question
+    const result = p.check('Edit', {
+      file_path: filePath,
+      old_string: 'What DB to use?',
+      new_string: 'Which database to use?',
+    });
+
+    assert.equal(result.blocked, false);
+
+    // Cleanup
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('contentGuard falls back to new_string when file does not exist', () => {
+    // Guard that blocks content with "resolved: true"
+    const guard = (content) => {
+      if (content.includes('resolved: true'))
+        return { blocked: true, message: 'Blocked resolved' };
+      return { blocked: false };
+    };
+
+    const p = makeProtectorWithGuard(guard);
+    // File doesn't exist — falls back to checking new_string only
+    const result = p.check('Edit', {
+      file_path: '/nonexistent/tasks/TEST-123/brief.md',
+      old_string: 'resolved: false',
+      new_string: 'resolved: true',
+    });
+
+    // Falls back to new_string which contains "resolved: true" → blocked
+    assert.equal(result.blocked, true);
+    assert.equal(result.rule, 'content');
+  });
+
+  it('contentGuard falls back to new_string when file does not exist (allowed case)', () => {
+    // Guard that only blocks full resolved content
+    const guard = (content) => {
+      if (content.includes('resolved: false'))
+        return { blocked: true, message: 'Unresolved' };
+      return { blocked: false };
+    };
+
+    const p = makeProtectorWithGuard(guard);
+    const result = p.check('Edit', {
+      file_path: '/nonexistent/tasks/TEST-123/brief.md',
+      old_string: 'old text',
+      new_string: 'new text without trigger',
+    });
+
+    assert.equal(result.blocked, false);
+  });
+
+  it('Write tool contentGuard still works unchanged', () => {
+    const guard = (content) => {
+      if (content.includes('resolved: false'))
+        return { blocked: true, message: 'Has unresolved' };
+      return { blocked: false };
+    };
+
+    const p = makeProtectorWithGuard(guard);
+    const result = p.check('Write', {
+      file_path: `/tasks/${TICKET}/brief.md`,
+      content: '# Brief\nresolved: false\n',
+    });
+
+    assert.equal(result.blocked, true);
+    assert.equal(result.rule, 'content');
+  });
+});

--- a/workflows/lib/protect-artifact-files.js
+++ b/workflows/lib/protect-artifact-files.js
@@ -163,6 +163,22 @@ function createArtifactProtector(opts) {
       }
     }
 
+    // Check 3: Content guard (if specified on the rule)
+    if (rule.contentGuard && ['Write', 'Edit', 'MultiEdit'].includes(toolName)) {
+      const newContent = toolInput?.content || toolInput?.new_string || '';
+      if (newContent) {
+        const guardResult = rule.contentGuard(newContent, currentStep);
+        if (guardResult.blocked) {
+          return {
+            blocked: true,
+            file: bn,
+            rule: 'content',
+            message: guardResult.message,
+          };
+        }
+      }
+    }
+
     return { blocked: false };
   }
 

--- a/workflows/lib/protect-artifact-files.js
+++ b/workflows/lib/protect-artifact-files.js
@@ -165,9 +165,27 @@ function createArtifactProtector(opts) {
 
     // Check 3: Content guard (if specified on the rule)
     if (rule.contentGuard && ['Write', 'Edit', 'MultiEdit'].includes(toolName)) {
-      const newContent = toolInput?.content || toolInput?.new_string || '';
-      if (newContent) {
-        const guardResult = rule.contentGuard(newContent, currentStep);
+      let guardContent = '';
+      if (toolName === 'Write') {
+        guardContent = toolInput?.content || '';
+      } else if (toolName === 'Edit' || toolName === 'MultiEdit') {
+        // Read existing file and apply edit in memory to get resulting content
+        try {
+          const fs = require('fs');
+          const existing = fs.readFileSync(toolInput?.file_path, 'utf-8');
+          const oldStr = toolInput?.old_string || '';
+          const newStr = toolInput?.new_string || '';
+          if (oldStr && newStr) {
+            guardContent = existing.replace(oldStr, newStr);
+          } else {
+            guardContent = existing; // Can't simulate edit, check existing
+          }
+        } catch {
+          guardContent = toolInput?.new_string || ''; // File doesn't exist yet, fall back
+        }
+      }
+      if (guardContent) {
+        const guardResult = rule.contentGuard(guardContent, currentStep);
         if (guardResult.blocked) {
           return {
             blocked: true,

--- a/workflows/work/__tests__/workflow-definition.test.js
+++ b/workflows/work/__tests__/workflow-definition.test.js
@@ -330,3 +330,108 @@ describe('workflow-definition: softSteps includes task_review', () => {
     assert.ok(workflow.softSteps.has(STEPS.task_review), 'task_review should be in softSteps');
   });
 });
+
+// ─── GH-219: brief.md contentGuard ───────────────────────────────────────────
+
+describe('workflow-definition: brief.md contentGuard', () => {
+  const { artifactRules } = createWorkflowDefinition(stubDeps);
+
+  function getBriefRule() {
+    return artifactRules.find((r) => r.basename === 'brief.md');
+  }
+
+  const BRIEF_WITH_RESOLVED_ARCHITECTURAL = [
+    '# Brief',
+    '',
+    '## Open Questions',
+    '',
+    '- **Question:** Should we change the auth model?',
+    '  - `scope: architectural`',
+    '  - `rationale: touches session handling`',
+    '  - `resolved: true`',
+    '  - **Resolution:** Yes, use OAuth.',
+    '',
+  ].join('\n');
+
+  const BRIEF_WITH_RESOLVED_CROSS_TICKET = [
+    '# Brief',
+    '',
+    '## Open Questions',
+    '',
+    '- **Question:** Does team X need to update their service?',
+    '  - `scope: cross-ticket`',
+    '  - `rationale: depends on external team`',
+    '  - `resolved: true`',
+    '  - **Resolution:** They will update independently.',
+    '',
+  ].join('\n');
+
+  const BRIEF_WITH_UNRESOLVED_ARCHITECTURAL = [
+    '# Brief',
+    '',
+    '## Open Questions',
+    '',
+    '- **Question:** Should we change the auth model?',
+    '  - `scope: architectural`',
+    '  - `rationale: touches session handling`',
+    '  - `resolved: false`',
+    '',
+  ].join('\n');
+
+  const BRIEF_WITH_RESOLVED_LOCAL = [
+    '# Brief',
+    '',
+    '## Open Questions',
+    '',
+    '- **Question:** What name should this helper use?',
+    '  - `scope: local`',
+    '  - `rationale: naming only`',
+    '  - `resolved: true`',
+    '  - **Resolution:** Use parseQuestions.',
+    '',
+  ].join('\n');
+
+  it('has a contentGuard on the brief.md artifact rule', () => {
+    const rule = getBriefRule();
+    assert.equal(typeof rule.contentGuard, 'function');
+  });
+
+  it('blocks resolved architectural questions during brief step', () => {
+    const rule = getBriefRule();
+    const result = rule.contentGuard(BRIEF_WITH_RESOLVED_ARCHITECTURAL, STEPS.brief);
+    assert.equal(result.blocked, true);
+    assert.ok(result.message.includes('BLOCKED'));
+    assert.ok(result.message.includes('1'));
+  });
+
+  it('blocks resolved cross-ticket questions during brief step', () => {
+    const rule = getBriefRule();
+    const result = rule.contentGuard(BRIEF_WITH_RESOLVED_CROSS_TICKET, STEPS.brief);
+    assert.equal(result.blocked, true);
+    assert.ok(result.message.includes('BLOCKED'));
+  });
+
+  it('allows resolved architectural questions during brief_gate step', () => {
+    const rule = getBriefRule();
+    const result = rule.contentGuard(BRIEF_WITH_RESOLVED_ARCHITECTURAL, STEPS.brief_gate);
+    assert.equal(result.blocked, false);
+  });
+
+  it('allows unresolved architectural questions during brief step', () => {
+    const rule = getBriefRule();
+    const result = rule.contentGuard(BRIEF_WITH_UNRESOLVED_ARCHITECTURAL, STEPS.brief);
+    assert.equal(result.blocked, false);
+  });
+
+  it('allows resolved local questions during brief step', () => {
+    const rule = getBriefRule();
+    const result = rule.contentGuard(BRIEF_WITH_RESOLVED_LOCAL, STEPS.brief);
+    assert.equal(result.blocked, false);
+  });
+
+  it('fails open when content has no open questions section', () => {
+    const rule = getBriefRule();
+    const result = rule.contentGuard('# Brief\n\nJust a normal brief.', STEPS.brief);
+    assert.equal(result.blocked, false);
+  });
+});

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -494,7 +494,35 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
   };
 
   const artifactRules = [
-    { basename: 'brief.md', step: STEPS.brief, agents: ['brief-writer'] },
+    {
+      basename: 'brief.md',
+      step: STEPS.brief,
+      agents: ['brief-writer'],
+      contentGuard: (content, currentStep) => {
+        // Only enforce during the 'brief' step — brief_gate is allowed to resolve questions
+        if (currentStep !== STEPS.brief) return { blocked: false };
+        try {
+          const openQuestions = require(path.join(__dirname, 'lib', 'open-questions'));
+          const questions = openQuestions.parse(content);
+          const resolvedBlocking = questions.filter(
+            (q) => q.resolved && (q.scope === 'cross-ticket' || q.scope === 'architectural')
+          );
+          if (resolvedBlocking.length > 0) {
+            return {
+              blocked: true,
+              message:
+                `BLOCKED: Cannot resolve blocking open questions during the brief step.\n` +
+                `Found ${resolvedBlocking.length} resolved architectural/cross-ticket question(s).\n` +
+                `Only the brief_gate step (via AskUserQuestion) can resolve blocking questions.\n` +
+                `Write the questions with resolved: false and let the brief_gate handle resolution.\n`,
+            };
+          }
+        } catch {
+          // fail-open on parse errors
+        }
+        return { blocked: false };
+      },
+    },
     { basename: 'spec.md', step: STEPS.spec, agents: ['spec-writer'] },
     { basename: 'tasks.md', step: STEPS.tasks, agents: [] },
     { basename: '.last-commit-sha', step: STEPS.commit },


### PR DESCRIPTION
## Existing Behavior

- `protect-artifact-files.js` enforced write access to artifact files (e.g., `brief.md`) only via step and agent checks — no inspection of the content being written.
- The `brief-writer` agent could write `brief.md` with resolved architectural or cross-ticket open questions during the `brief` step, bypassing the intended gate flow.
- Blocking open questions (scope: `architectural` or `cross-ticket`) were supposed to be resolved exclusively via `AskUserQuestion` in the `brief_gate` step, but nothing enforced this at write time.

## Intended New Behavior

- `createArtifactProtector` now accepts an optional `contentGuard` function on each artifact rule, which is invoked for `Write`, `Edit`, and `MultiEdit` tool calls when the content is non-empty.
- The `brief.md` artifact rule ships a `contentGuard` that scans the content for open questions with `resolved: true` and scope `architectural` or `cross-ticket` during the `brief` step, and returns a blocked result if any are found.
- Attempts to pre-resolve blocking questions during the `brief` step are rejected with a clear message directing the agent to leave them as `resolved: false` for the `brief_gate` step to handle.
- The guard fails open: parse errors and steps other than `brief` (e.g., `brief_gate`) are always allowed through.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**To verify the contentGuard blocks pre-resolved blocking questions:**

1. Set the workflow to the `brief` step for a ticket.
2. Have `brief-writer` attempt to write a `brief.md` containing an open question with `scope: architectural` and `resolved: true`.
3. Confirm the write is blocked with a message containing `BLOCKED: Cannot resolve blocking open questions during the brief step.`

**To verify the guard allows resolution at the correct step:**

1. Advance the workflow to the `brief_gate` step.
2. Have `AskUserQuestion` write `brief.md` with the same resolved architectural question.
3. Confirm the write succeeds (not blocked).

**To verify unresolved or local-scope questions are always allowed:**

1. During the `brief` step, write a `brief.md` with `scope: architectural` and `resolved: false` — confirm not blocked.
2. During the `brief` step, write a `brief.md` with `scope: local` and `resolved: true` — confirm not blocked.

**Run the full test suite to confirm 74/74 pass:**
```bash
node --test workflows/lib/__tests__/protect-artifact-files.test.js
node --test workflows/work/__tests__/workflow-definition.test.js
```

### Test Results

15 new tests added across `protect-artifact-files.test.js` and `workflow-definition.test.js`. All 74 tests pass.

Closes #251