### PR TITLE
docs: add comprehensive architecture documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,7 @@
 # Copilot Code Review Instructions
 
+**Architecture Reference:** See [`docs/README.md`](../docs/README.md) for full codebase documentation — architecture, workflows, state machine, hooks, TDD enforcement, agents, skills, and configuration.
+
 ## Stale Comment Resolution
 
 - Before flagging an issue, check if it was already fixed in a later commit in the same PR.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,70 @@
+# Claude Plugin Work — Documentation
+
+Comprehensive documentation for the `claude-plugin-work` plugin, a deterministic workflow engine for Claude Code that orchestrates ticket-to-PR delivery through specialized agents, TDD enforcement, and evidence-based quality gates.
+
+## Documentation Index
+
+### Architecture & Design
+
+- **[Architecture Overview](./architecture.md)** — High-level system design, directory structure, and how components interact
+- **[State Machine](./state-machine.md)** — Step registry, transitions, state persistence, and resume-on-context-loss
+
+### Core Workflows
+
+- **[/work Workflow](./workflow-work.md)** — The main orchestrator: 17-step ticket-to-PR pipeline
+- **[/check Workflow](./workflow-check.md)** — Parallel quality verification: code review, tests, QA, completion
+- **[/work-implement Workflow](./workflow-work-implement.md)** — Quick TDD-gated implementation (skip brief/spec/tasks)
+- **[/work-pr Workflow](./workflow-work-pr.md)** — PR description generation and visual documentation
+
+### Enforcement & Gating
+
+- **[Hook System](./hooks.md)** — PreToolUse/PostToolUse enforcement, fail-open policy, hook lifecycle
+- **[TDD Enforcement](./tdd-enforcement.md)** — RED/GREEN/REFACTOR cycle, phase gating, evidence recording, exception mode
+- **[Artifact Management](./artifacts.md)** — Output folder allocation, per-task scoping, archival on backward transitions
+
+### Agents & Skills
+
+- **[Agents](./agents.md)** — All 18 specialized agents: roles, dispatch rules, and authorization
+- **[Skills](./skills.md)** — All slash commands: purpose, allowed tools, and invocation patterns
+
+### Configuration & Setup
+
+- **[Configuration](./configuration.md)** — Environment variables, .envrc, config.js resolution, ticket providers
+
+---
+
+## Quick Reference
+
+### Workflow Step Order (/work)
+
+```
+ticket → bootstrap → brief → brief_gate → spec → tasks →
+implement → commit → task_review → check → pr → ready →
+follow_up → ci → cleanup → reports → complete
+```
+
+### Key Directories
+
+| Directory | Purpose |
+|---|---|
+| `workflows/work/` | Main /work orchestrator |
+| `workflows/check/` | Quality verification |
+| `workflows/work-implement/` | TDD phase management |
+| `workflows/work-pr/` | PR generation |
+| `workflows/lib/` | Shared utilities, hooks, policies |
+| `agents/` | 18 agent definitions (markdown) |
+| `skills/` | 25 slash command definitions |
+| `hooks/` | Top-level hook registration |
+
+### State Files
+
+| File | Location | Purpose |
+|---|---|---|
+| `.work-state.json` | `TASKS_BASE/<ticket>/` | /work step progress |
+| `.work-actions.json` | `TASKS_BASE/<ticket>/` | Audit trail of all actions |
+| `tdd-phase.json` | `TASKS_BASE/<ticket>/taskN/` | TDD cycle evidence |
+| `.check.workflow-state.json` | `TASKS_BASE/<ticket>/` | /check step progress |
+| `brief.md` | `TASKS_BASE/<ticket>/` | Product brief |
+| `spec.md` | `TASKS_BASE/<ticket>/` | Technical specification |
+| `tasks.md` | `TASKS_BASE/<ticket>/` | Task decomposition |
+| `*.check.md` | `TASKS_BASE/<ticket>/` | Quality reports |

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ Comprehensive documentation for the `claude-plugin-work` plugin, a deterministic
 
 ### Agents & Skills
 
-- **[Agents](./agents.md)** — All 18 specialized agents: roles, dispatch rules, and authorization
+- **[Agents](./agents.md)** — All 19 specialized agents: roles, dispatch rules, and authorization
 - **[Skills](./skills.md)** — All slash commands: purpose, allowed tools, and invocation patterns
 
 ### Configuration & Setup

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ Comprehensive documentation for the `claude-plugin-work` plugin, a deterministic
 ### Workflow Step Order (/work)
 
 ```
-ticket → bootstrap → brief → brief_gate → spec → tasks →
+ticket → bootstrap → brief → brief_gate → spec → spec_gate → tasks →
 implement → commit → task_review → check → pr → ready →
 follow_up → ci → cleanup → reports → complete
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Comprehensive documentation for the `claude-plugin-work` plugin, a deterministic
 
 ### Core Workflows
 
-- **[/work Workflow](./workflow-work.md)** — The main orchestrator: 17-step ticket-to-PR pipeline
+- **[/work Workflow](./workflow-work.md)** — The main orchestrator: 18-step ticket-to-PR pipeline
 - **[/check Workflow](./workflow-check.md)** — Parallel quality verification: code review, tests, QA, completion
 - **[/work-implement Workflow](./workflow-work-implement.md)** — Quick TDD-gated implementation (skip brief/spec/tasks)
 - **[/work-pr Workflow](./workflow-work-pr.md)** — PR description generation and visual documentation
@@ -52,8 +52,8 @@ follow_up → ci → cleanup → reports → complete
 | `workflows/work-implement/` | TDD phase management |
 | `workflows/work-pr/` | PR generation |
 | `workflows/lib/` | Shared utilities, hooks, policies |
-| `agents/` | 18 agent definitions (markdown) |
-| `skills/` | 25 slash command definitions |
+| `agents/` | 19 agent definitions (markdown) |
+| `skills/` | 23 slash command definitions |
 | `hooks/` | Top-level hook registration |
 
 ### State Files

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,122 @@
+# Agents
+
+The plugin uses 18 specialized agents, each defined as a markdown file in `agents/`. Agents are dispatched via `Task()` tool calls — they never self-invoke or call other agents recursively.
+
+## Agent Catalog
+
+### Planning Agents
+
+| Agent | File | Role |
+|---|---|---|
+| **brief-writer** | `agents/brief-writer.md` | Generate product briefs from ticket requirements |
+| **spec-writer** | `agents/spec-writer.md` | Generate technical specs from briefs + codebase analysis |
+| **code-architect** | `agents/code-architect.md` | Architecture review and design guidance |
+
+### Developer Agents
+
+| Agent | File | Domain |
+|---|---|---|
+| **developer-nodejs-tdd** | `agents/developer-nodejs-tdd.md` | Node.js/Express/NestJS backend, strict TDD |
+| **developer-react-senior** | `agents/developer-react-senior.md` | React frontend, complex architecture |
+| **developer-react-ui-architect** | `agents/developer-react-ui-architect.md` | UI components, visual design, animations |
+| **developer-devops** | `agents/developer-devops.md` | Infrastructure, CI/CD, deployment |
+
+### Quality Agents
+
+| Agent | File | Role |
+|---|---|---|
+| **code-checker** | `agents/code-checker.md` | Static code review, compliance checking |
+| **quality-checker** | `agents/quality-checker.md` | Lint, typecheck, unit/integration tests |
+| **completion-checker** | `agents/completion-checker.md` | Requirement coverage verification |
+| **qa-feature-tester** | `agents/qa-feature-tester.md` | UI testing via Playwright MCP |
+| **qa-api-tester** | `agents/qa-api-tester.md` | API/backend testing via curl/HTTP |
+| **pr-reviewer** | `agents/pr-reviewer.md` | Pull request code review |
+
+### PR & Commit Agents
+
+| Agent | File | Role |
+|---|---|---|
+| **pr-generator** | `agents/pr-generator.md` | Generate PR titles and descriptions from diffs |
+| **pr-post-generator** | `agents/pr-post-generator.md` | Add visual documentation to PRs |
+| **commit-writer** | `agents/commit-writer.md` | Generate semantic commit messages |
+
+### Coordination Agents
+
+| Agent | File | Role |
+|---|---|---|
+| **project-coordinator** | `agents/project-coordinator.md` | Cross-agent task orchestration |
+| **jira-task-creator** | `agents/jira-task-creator.md` | Ticket creation with template validation |
+
+## Dispatch Rules
+
+### Automatic dispatch by step
+
+The `/work` orchestrator selects agents based on the current step:
+
+| Step | Agent(s) dispatched |
+|---|---|
+| brief | brief-writer |
+| spec | spec-writer |
+| tasks | (skill: split-in-tasks) |
+| implement | developer-* (auto-selected) |
+| commit | commit-writer |
+| check | code-checker, quality-checker, qa-*, completion-checker (parallel) |
+| pr | pr-generator |
+
+### Developer agent selection
+
+During the `implement` step, the developer agent is selected based on changed file types and project context:
+
+- **React/TypeScript frontend** → `developer-react-senior`
+- **Node.js backend** → `developer-nodejs-tdd`
+- **Infrastructure/config** → `developer-devops`
+- **UI-heavy with design focus** → `developer-react-ui-architect`
+
+### QA agent routing
+
+During the `check` step, QA agents are dispatched based on the `WEB_APPS` manifest:
+
+- Apps with `appType: "web"` → `qa-feature-tester` (browser automation)
+- Apps with `appType: "api"` → `qa-api-tester` (HTTP testing)
+- Apps with `appType: "cli"` → No QA agent
+- No `WEB_APPS` configured → QA skipped
+
+## Agent Authorization
+
+Certain scripts are gated to specific agents (defined in `workflow-definition.js`):
+
+| Script | Authorized Agents | Step |
+|---|---|---|
+| `write-qa-report.js` | qa-feature-tester, qa-api-tester | check |
+| `write-tests-report.js` | quality-checker | check |
+| `write-code-review.js` | code-checker | check |
+| `write-completion-report.js` | completion-checker | check |
+| `tdd-phase-state.js` | developer-nodejs-tdd, developer-react-senior, developer-react-ui-architect, developer-devops | implement |
+
+If an unauthorized agent attempts to call a gated script, the hook blocks it with an error message identifying the expected agent.
+
+## Agent Identity Detection
+
+**File:** `workflows/lib/agent-detection.js`
+
+Agent identity is determined from the Claude Code transcript:
+
+- `isRunningInAgent(transcriptPath, agentNames)` — Scans transcript for agent dispatch context
+- `normalizeAgentName()` — Standardizes names (e.g., `developer_nodejs_tdd` → `developer-nodejs-tdd`)
+
+## Consensus Loop (Phase 2 of /check)
+
+When the code-checker reports IMPORTANT or SUGGESTION findings:
+
+1. A developer agent evaluates each finding:
+   - `IMPLEMENTED` — Code was changed to address the finding
+   - `DEFERRED` — Valid finding but out of scope
+   - `NOT_APPLICABLE` — Disagrees with the finding
+
+2. The code-checker validates the developer's decisions:
+   - `AGREE` — Accepts the resolution
+   - `DISAGREE` — Requests re-evaluation
+
+3. Loop continues until consensus or max iterations
+
+The developer agent for phase 2 is auto-selected based on changed file types (same rules as implement step).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agents
 
-The plugin uses 18 specialized agents, each defined as a markdown file in `agents/`. Agents are dispatched via `Task()` tool calls — they never self-invoke or call other agents recursively.
+The plugin uses 19 specialized agents, each defined as a markdown file in `agents/`. Agents are dispatched via `Task()` tool calls — they never self-invoke or call other agents recursively.
 
 ## Agent Catalog
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,165 @@
+# Architecture Overview
+
+## System Design
+
+`claude-plugin-work` is a Claude Code plugin that provides deterministic, state-machine-driven workflows for software development. It transforms ticket requirements into merged PRs through a pipeline of specialized agents, enforced by hooks that gate tool usage based on workflow state.
+
+### Design Principles
+
+1. **Deterministic orchestration** — A state machine guarantees exact step execution order. No step is skipped unless explicitly planned (SKIP/DEFER).
+2. **Evidence-based gates** — Steps must produce verifiable evidence (files, git state, test results) before the workflow can progress.
+3. **Fail-open hooks** — All enforcement hooks exit 0 on internal errors (allow tool use). Only intentional blocks return exit code 2.
+4. **Agent specialization** — 18 domain-specific agents handle different concerns. No agent self-reports evidence; external scripts record it.
+5. **Resume on context loss** — Persistent state files allow the workflow to resume from the last completed step after a crash or context window rotation.
+
+## Directory Structure
+
+```
+claude-plugin-work/
+├── workflows/                  # Core workflow engine & definitions
+│   ├── lib/                    # Shared utilities
+│   │   ├── workflow-engine.js  # Reusable state machine engine
+│   │   ├── workflow-state.js   # Generic state persistence
+│   │   ├── config.js           # Centralized config loader
+│   │   ├── ticket-provider.js  # Provider abstraction (Jira/Linear/GitHub)
+│   │   ├── allocate-output-folder.js  # Output directory routing
+│   │   ├── agent-detection.js  # Identify running agent context
+│   │   ├── hook-error-log.js   # Error logging (not stderr)
+│   │   ├── ticket-validation.js # Path traversal protection
+│   │   ├── hooks/              # Shared enforcement hooks
+│   │   │   ├── enforce-step-workflow.js  # Master step gating
+│   │   │   └── policies/       # Pure decision functions
+│   │   │       ├── command-matching.js
+│   │   │       ├── agent-authorization.js
+│   │   │       ├── state-protection.js
+│   │   │       ├── evidence-recorder.js
+│   │   │       ├── step-gate.js
+│   │   │       └── transition-gate.js
+│   │   └── scripts/            # Utility scripts
+│   ├── work/                   # /work orchestrator
+│   │   ├── work.workflow.js    # Main dispatcher
+│   │   ├── workflow-definition.js  # Declarative config
+│   │   ├── step-registry.js    # Step ID + ordering registry
+│   │   ├── steps/              # Per-step handlers
+│   │   ├── hooks/              # /work-specific hooks
+│   │   ├── scripts/            # /work scripts
+│   │   ├── work-state.js       # /work state extensions
+│   │   ├── plan-generator.js   # RUN/SKIP/DEFER planner
+│   │   ├── inspect.js          # Filesystem state inspector
+│   │   ├── check-gate.js       # Quality verification gate
+│   │   ├── artifact-archival.js # Backward transition cleanup
+│   │   └── tdd-enforcement.js  # TDD evidence validation
+│   ├── work-implement/         # TDD phase management
+│   │   ├── tdd-phase-state.js  # TDD CLI (record-red, record-green, etc.)
+│   │   ├── tdd-phase-registry.js  # Phase definitions & transitions
+│   │   └── hooks/              # TDD file gating
+│   ├── work-pr/                # PR generation workflow
+│   └── check/                  # Quality verification workflow
+│       ├── check.workflow.js   # Check dispatcher
+│       ├── hooks/              # Check-specific hooks
+│       └── scripts/            # Report writers
+├── agents/                     # 18 specialized agent definitions (markdown)
+├── skills/                     # 25 slash command definitions (SKILL.md)
+├── hooks/                      # Hook registration (hooks.json)
+├── scripts/                    # Root-level scripts
+└── package.json                # Dependencies (biome only)
+```
+
+## Data Flow
+
+```
+User invokes /work TICKET-123
+         │
+         ▼
+┌─────────────────────────────────────┐
+│  work.workflow.js (orchestrator)    │
+│  Reads .work-state.json            │
+│  Runs plan-generator.js            │
+│  Outputs: RUN / SKIP / DEFER       │
+└──────────┬──────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────┐
+│  Per-step handler (steps/*.js)      │
+│  Dispatches agent via Task()        │
+│  Agent produces artifacts           │
+└──────────┬──────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────┐
+│  enforce-step-workflow.js (hooks)   │
+│  PreToolUse: gate tool usage        │
+│  PostToolUse: record evidence       │
+│  Blocks unauthorized tool calls     │
+└──────────┬──────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────┐
+│  workflow-definition.js (verify)    │
+│  Checks file existence, git state   │
+│  Evaluates evidence requirements    │
+│  Returns: verified / not verified   │
+└──────────┬──────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────┐
+│  transition-step.js                 │
+│  Advances to next step              │
+│  Triggers artifact archival         │
+│  Updates .work-state.json           │
+└─────────────────────────────────────┘
+```
+
+## Component Interactions
+
+### Orchestrator → Agents
+
+The orchestrator dispatches agents via `Task()` tool calls. Each step maps to one or more agents:
+
+| Step | Agent(s) |
+|---|---|
+| brief | brief-writer |
+| spec | spec-writer |
+| implement | developer-nodejs-tdd, developer-react-senior, developer-devops |
+| check | code-checker, quality-checker, qa-feature-tester, completion-checker |
+| pr | pr-generator |
+| commit | commit-writer |
+
+### Hooks → Workflows
+
+Hooks intercept tool calls and delegate to workflow-specific logic:
+
+1. `workflow-router-hook.js` identifies which workflow is active
+2. `enforce-step-workflow.js` applies step gating rules
+3. Workflow-specific hooks add domain logic (TDD phase gating, screenshot requirements)
+
+### State → Filesystem
+
+All state persists to the filesystem under `TASKS_BASE/<ticket>/`:
+
+```
+tasks/TICKET-123/
+├── .work-state.json           # Step progress
+├── .work-actions.json         # Audit trail
+├── brief.md                   # Brief artifact
+├── spec.md                    # Spec artifact
+├── tasks.md                   # Task decomposition
+├── tdd-phase.json             # Root TDD state (legacy)
+├── task1/                     # Per-task artifacts (GH-219)
+│   └── tdd-phase.json
+├── task2/
+│   └── tdd-phase.json
+├── code-review.check.md       # Check reports
+├── tests.check.md
+├── completion.check.md
+├── qa-myapp.check.md
+├── README.md                  # Check summary with hash
+├── screenshots/               # QA screenshots
+└── runs/                      # Archived reports from prior check runs
+    ├── run1/
+    └── run2/
+```
+
+## Zero Runtime Dependencies
+
+The plugin has no runtime npm dependencies. Only `@biomejs/biome` is listed as a devDependency for code formatting. All logic is pure Node.js using built-in modules (`fs`, `path`, `child_process`, `crypto`).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@
 1. **Deterministic orchestration** — A state machine guarantees exact step execution order. No step is skipped unless explicitly planned (SKIP/DEFER).
 2. **Evidence-based gates** — Steps must produce verifiable evidence (files, git state, test results) before the workflow can progress.
 3. **Fail-open hooks** — All enforcement hooks exit 0 on internal errors (allow tool use). Only intentional blocks return exit code 2.
-4. **Agent specialization** — 18 domain-specific agents handle different concerns. No agent self-reports evidence; external scripts record it.
+4. **Agent specialization** — 19 domain-specific agents handle different concerns. No agent self-reports evidence; external scripts record it.
 5. **Resume on context loss** — Persistent state files allow the workflow to resume from the last completed step after a crash or context window rotation.
 
 ## Directory Structure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,10 +127,10 @@ The orchestrator dispatches agents via `Task()` tool calls. Each step maps to on
 
 ### Hooks → Workflows
 
-Hooks intercept tool calls and delegate to workflow-specific logic:
+Hooks intercept prompt and tool events and delegate to workflow-specific logic:
 
-1. `workflow-router-hook.js` identifies which workflow is active
-2. `enforce-step-workflow.js` applies step gating rules
+1. `workflow-router-hook.js` routes `UserPromptSubmit` events to workflow-specific prompt logic
+2. `enforce-step-workflow.js` identifies which workflow is active for tool gating (by loading each workflow's state file and evaluating `isActive(state)`), then applies step gating rules
 3. Workflow-specific hooks add domain logic (TDD phase gating, screenshot requirements)
 
 ### State → Filesystem

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,8 +58,8 @@ claude-plugin-work/
 │       ├── check.workflow.js   # Check dispatcher
 │       ├── hooks/              # Check-specific hooks
 │       └── scripts/            # Report writers
-├── agents/                     # 18 specialized agent definitions (markdown)
-├── skills/                     # 25 slash command definitions (SKILL.md)
+├── agents/                     # 19 specialized agent definitions (markdown)
+├── skills/                     # 23 slash command definitions (SKILL.md)
 ├── hooks/                      # Hook registration (hooks.json)
 ├── scripts/                    # Root-level scripts
 └── package.json                # Dependencies (biome only)

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,0 +1,168 @@
+# Artifact Management
+
+The artifact system controls where files are created, who can write them, and how they're cleaned up on workflow retries.
+
+## Output Folder Allocation
+
+**File:** `workflows/lib/allocate-output-folder.js`
+
+### Allocation Rules (GH-219)
+
+| Context | Directory Pattern | Example |
+|---|---|---|
+| In-flow task | `TASKS_BASE/<ticket>/taskN/` | `tasks/PROJ-123/task3/` |
+| Out-of-flow user | `TASKS_BASE/<ticket>/user-request-N/` | `tasks/PROJ-123/user-request-1/` |
+| Out-of-flow AI | `TASKS_BASE/<ticket>/ai-request-N/` | `tasks/PROJ-123/ai-request-1/` |
+| Legacy root | `TASKS_BASE/<ticket>/` | `tasks/PROJ-123/` |
+
+### taskSegment() — Single Source of Truth (R7)
+
+The `taskSegment(taskNum)` function is the canonical way to produce task directory names:
+
+```javascript
+taskSegment(1)  // → "task1"
+taskSegment(9)  // → "task9"
+taskSegment(42) // → "task42"
+```
+
+All modules must use this function — never construct `task${N}` strings directly.
+
+### allocateOutputFolder()
+
+```javascript
+const result = allocateOutputFolder('PROJ-123', {
+  flow: 'in-flow',
+  taskNum: 3,
+});
+// → { kind: 'in-flow-task', segment: 'task3', root: '/abs/path/tasks/PROJ-123/task3/', ticketRoot: '/abs/path/tasks/PROJ-123/' }
+```
+
+## Artifact Rules
+
+**File:** `workflows/work/workflow-definition.js`
+
+Each artifact is bound to a step and authorized agents:
+
+| File | Step | Authorized Agents |
+|---|---|---|
+| `brief.md` | brief | brief-writer |
+| `spec.md` | spec | spec-writer |
+| `tasks.md` | tasks | (any) |
+| `.last-commit-sha` | commit | (any) |
+| `code-review.check.md` | check | code-checker |
+| `tests.check.md` | check | quality-checker |
+| `completion.check.md` | check | completion-checker |
+| `qa-*.check.md` | check | qa-feature-tester, qa-api-tester |
+| `code-review-reply.check.md` | check | developer-nodejs-tdd, developer-react-senior, developer-devops |
+| `review-accountability.json` | follow_up | follow-up-pr |
+
+### Agent-Gated Scripts
+
+Certain scripts require both the correct agent AND the correct step:
+
+| Script | Authorized Agents | Required Step |
+|---|---|---|
+| `write-qa-report.js` | qa-feature-tester, qa-api-tester | check |
+| `write-tests-report.js` | quality-checker | check |
+| `write-code-review.js` | code-checker | check |
+| `write-completion-report.js` | completion-checker | check |
+| `tdd-phase-state.js` | developer-* agents | implement |
+
+## Artifact Protection
+
+**File:** `workflows/lib/protect-artifact-files.js`
+
+The artifact protector blocks unauthorized writes:
+
+1. **Step check:** Is the file's step currently `in_progress`?
+2. **Agent check:** Is the calling agent in the authorized list?
+3. **Vector detection:** Catches direct Write/Edit, Bash redirects (`>`, `>>`, `tee`), and Node.js `fs` calls.
+
+If blocked, returns a message like:
+```
+BLOCKED: code-review.check.md can only be written during the 'check' step by agent 'code-checker'.
+Current step: implement. Current agent: developer-nodejs-tdd.
+```
+
+## State File Protection
+
+**File:** `workflows/lib/protect-state-files.js`
+
+Protected files:
+- `.work-state.json`
+- `.work-actions.json`
+- `.workflow-state.json`
+- `.check.workflow-state.json`
+- `tdd-phase.json`
+
+Only designated management scripts (work-state.js, tdd-phase-state.js, workflow-engine.js) can write these files.
+
+## Artifact Archival
+
+**File:** `workflows/work/artifact-archival.js`
+
+When the workflow transitions backward (e.g., `check → implement`), stale artifacts must be cleaned to prevent false verification.
+
+### Archival Process
+
+1. Detect backward transition (target step index < current step index)
+2. Look up `archivalPatterns` for each step between target and current
+3. Move matching files to `runs/runN/` (next sequential run number)
+4. Plan generator re-evaluates from clean state
+
+### Archival Patterns
+
+```javascript
+archivalPatterns: {
+  check: [/^.*\.check\.md$/],           // All check reports
+  pr:    [/^\.pr-update-sha$/, /^\.post-pr-update-sha$/],  // PR metadata
+}
+```
+
+### Example
+
+Before backward transition (`check → implement`):
+```
+tasks/PROJ-123/
+├── code-review.check.md    ← stale (from previous check)
+├── tests.check.md          ← stale
+├── completion.check.md     ← stale
+└── runs/
+    └── run1/               ← from even earlier check
+```
+
+After archival:
+```
+tasks/PROJ-123/
+└── runs/
+    ├── run1/               ← earliest check
+    └── run2/               ← just archived
+        ├── code-review.check.md
+        ├── tests.check.md
+        └── completion.check.md
+```
+
+## Ticket-Root vs Per-Task Scoping
+
+### Currently per-task (in `taskN/` directories)
+- `tdd-phase.json` — TDD cycle evidence per task
+
+### Currently ticket-root (at `tasks/<ticket>/`)
+- `brief.md`, `spec.md`, `tasks.md` — Planning artifacts
+- `*.check.md` — Quality check reports
+- `README.md` — Check summary
+- `.work-state.json` — Workflow state
+- `.work-actions.json` — Audit trail
+- `screenshots/` — QA screenshots
+- `runs/` — Archived check reports
+
+See [GH-259](https://github.com/tigredonorte/claude-plugin-work/issues/259) for discussion on scoping check reports per-task.
+
+## Path Security
+
+**File:** `workflows/lib/ticket-validation.js`
+
+All path construction validates:
+1. Ticket ID doesn't contain `..`, `\`, or null bytes
+2. Resolved path stays within `TASKS_BASE` (prevents directory traversal)
+3. Sanitized ID is re-validated after transformation (e.g., `#123` → `GH-123`)

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -93,9 +93,8 @@ Protected files:
 - `.work-actions.json`
 - `.workflow-state.json`
 - `.check.workflow-state.json`
-- `tdd-phase.json`
 
-Only designated management scripts (work-state.js, tdd-phase-state.js, workflow-engine.js) can write these files.
+Only designated management scripts (such as `work-state.js` and `workflow-engine.js`) can write these workflow state files. Note: `tdd-phase.json` is protected via the TDD phase hook gating system (`work-implement-enforce.js`), not by `protect-state-files.js`.
 
 ## Artifact Archival
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,164 @@
+# Configuration
+
+The plugin uses environment variables for configuration, loaded via `.envrc` files and resolved through `workflows/lib/config.js`.
+
+## Environment Variables
+
+### Required
+
+| Variable | Example | Purpose |
+|---|---|---|
+| `TICKET_PROJECT_KEY` | `PROJ` | Ticket ID prefix (e.g., PROJ-123) |
+| `REPO_NAME` | `my-app` | Repository name (used for worktree folder naming) |
+| `TASKS_BASE` | `../tasks` | Root directory for task state and artifacts |
+
+### Recommended
+
+| Variable | Example | Purpose |
+|---|---|---|
+| `WORKTREES_BASE` | `..` | Parent directory for git worktrees |
+| `BASE_BRANCH` | `main` | Git base branch (auto-detected: main/dev/master) |
+| `TICKET_PROVIDER` | `jira` | Ticket provider: `jira`, `linear`, `github`, `none` |
+| `WEB_APPS` | `[{"name":"web","appType":"web"}]` | JSON array of app configs for QA routing |
+
+### Ticket Provider Configuration
+
+#### Jira
+| Variable | Example |
+|---|---|
+| `JIRA_PROJECT_KEY` | `PROJ` |
+| `JIRA_BASE_URL` | `your-org.atlassian.net` |
+
+#### Linear
+| Variable | Example |
+|---|---|
+| `LINEAR_TEAM_KEY` | `ENG` |
+
+#### GitHub
+| Variable | Example |
+|---|---|
+| `GITHUB_ORG` | `my-org` |
+
+### Optional
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DEV_COMMAND` | (auto-detect) | Custom dev server start command |
+| `TEST_COMMAND` | (auto-detect) | Custom test runner command |
+| `LINT_COMMAND` | (auto-detect) | Custom linter command |
+| `TYPECHECK_COMMAND` | (auto-detect) | Custom typecheck command |
+| `SESSION_GUARD_ENABLED` | `1` | Prevent concurrent /work sessions |
+| `TASK_REVIEW_MAX_FIXES` | `2` | Max fix rounds per task review |
+| `READ_DOCS_ON_BRIEF` | | Paths to docs the brief-writer should read |
+| `READ_DOCS_ON_SPEC` | | Paths to docs the spec-writer should read |
+
+### Debug Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ENFORCE_HOOK_DEBUG` | `0` | Verbose hook logging to stderr |
+| `WORK_TDD_TOKEN_SKIP` | `0` | Skip TDD token verification |
+| `HOOK_ERROR_LOG` | `/tmp/claude-hook-errors.log` | Hook error log path |
+
+## Config Resolution
+
+**File:** `workflows/lib/config.js`
+
+Resolution order (first wins):
+1. `process.env` (command line / shell environment)
+2. `.envrc` file (parent directory — check `../` first)
+3. `.env` file (plugin root or cwd)
+4. Defaults in `config.js`
+
+### Key Functions
+
+```javascript
+const config = require('./config');
+
+config.TASKS_BASE           // Resolved tasks directory
+config.WORKTREES_BASE       // Resolved worktrees directory
+config.safeTicketId(id)     // Sanitize ticket ID for filesystem
+config.getBaseBranch()      // Detect base branch
+config.tasksDir(ticketId)   // Full path to ticket's tasks dir
+config.repoDir()            // Current repo root
+config.worktreeDir(ticket)  // Worktree path for a ticket
+config.prefixTicketId(id)   // Add project key prefix if missing
+```
+
+## Ticket Provider
+
+**File:** `workflows/lib/ticket-provider.js`
+
+The provider abstraction handles differences between Jira, Linear, and GitHub:
+
+| Provider | ID Format | Path Sanitization | URL Format |
+|---|---|---|---|
+| `jira` | `PROJ-123` | (none) | `https://org.atlassian.net/browse/PROJ-123` |
+| `linear` | `ENG-123` | (none) | `https://linear.app/team/ENG-123` |
+| `github` | `#123` | `#123` → `GH-123` | `https://github.com/org/repo/issues/123` |
+| `none` | any | (none) | (none) |
+
+### Auto-detection
+
+If `TICKET_PROVIDER` is not set, the provider is auto-detected:
+1. If `JIRA_BASE_URL` is set → `jira`
+2. If `LINEAR_TEAM_KEY` is set → `linear`
+3. If `GITHUB_ORG` is set → `github`
+4. Otherwise → `none`
+
+## WEB_APPS Configuration
+
+The `WEB_APPS` variable controls QA agent routing during `/check`:
+
+```json
+[
+  {
+    "name": "web",
+    "appType": "web",
+    "port": 3000,
+    "startCommand": "pnpm dev",
+    "paths": ["src/app", "src/components"]
+  },
+  {
+    "name": "api",
+    "appType": "api",
+    "paths": ["src/server", "src/routes"]
+  }
+]
+```
+
+| Field | Required | Purpose |
+|---|---|---|
+| `name` | Yes | App identifier (used in report filenames) |
+| `appType` | Yes | `web` (Playwright), `api` (HTTP), `cli` (skip QA) |
+| `port` | No | Dev server port |
+| `startCommand` | No | Custom start command |
+| `paths` | No | Source paths to match against git diff for impact detection |
+
+## .envrc Location
+
+The `.envrc` file is typically in the **parent directory** relative to the worktree, not inside the worktree itself. The config loader checks `../` first when looking for environment configuration.
+
+```
+parent-dir/
+├── .envrc                    ← Config lives here
+├── tasks/                    ← TASKS_BASE
+├── my-repo/                  ← Main repo
+└── my-repo-TICKET-123/       ← Worktree
+```
+
+## Path Security
+
+**File:** `workflows/lib/ticket-validation.js`
+
+All ticket-ID-to-path conversions are validated:
+
+1. **Traversal prevention:** Rejects `..`, `\`, null bytes
+2. **Containment check:** Resolved path must stay within `TASKS_BASE`
+3. **Post-sanitization validation:** Re-validates after `#123 → GH-123` transform
+
+```javascript
+validateTicketId(ticketId)              // Throws on invalid
+sanitizeTicketId(ticketId)              // Transform for filesystem
+assertPathContainment(path, base, ctx)  // Verify path stays within base
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-The plugin uses environment variables for configuration, loaded via `.envrc` files and resolved through `workflows/lib/config.js`.
+The plugin uses environment variables for configuration, resolved through `workflows/lib/config.js` from the repo `.env` file or the current process environment (e.g., populated by `direnv` from `.envrc`).
 
 ## Environment Variables
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,12 +97,12 @@ The provider abstraction handles differences between Jira, Linear, and GitHub:
 | `github` | `#123` | `#123` → `GH-123` | `https://github.com/org/repo/issues/123` |
 | `none` | any | (none) | (none) |
 
-### Auto-detection
+### Provider Resolution
 
-If `TICKET_PROVIDER` is not set, the provider is auto-detected:
-1. If `JIRA_BASE_URL` is set → `jira`
-2. If `LINEAR_TEAM_KEY` is set → `linear`
-3. If `GITHUB_ORG` is set → `github`
+Provider resolution uses this precedence:
+1. If `TICKET_PROVIDER` env var is set → use it directly
+2. Per-repo config in `~/.claude/ticket-providers.json` (if exists)
+3. Fallback based on available env vars (e.g., `JIRA_PROJECT_KEY`)
 4. Otherwise → `none`
 
 ## WEB_APPS Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,10 +65,9 @@ The plugin uses environment variables for configuration, loaded via `.envrc` fil
 **File:** `workflows/lib/config.js`
 
 Resolution order (first wins):
-1. `process.env` (command line / shell environment)
-2. `.envrc` file (parent directory — check `../` first)
-3. `.env` file (plugin root or cwd)
-4. Defaults in `config.js`
+1. `process.env` (command line / shell environment — includes variables loaded by `direnv` from `.envrc`)
+2. `.env` file (repo root or cwd — loaded by `config.js`)
+3. Defaults in `config.js`
 
 ### Key Functions
 
@@ -137,7 +136,7 @@ The `WEB_APPS` variable controls QA agent routing during `/check`:
 
 ## .envrc Location
 
-The `.envrc` file is typically in the **parent directory** relative to the worktree, not inside the worktree itself. The config loader checks `../` first when looking for environment configuration.
+In many setups, especially when using `direnv`, the `.envrc` file lives in the **parent directory** relative to the worktree rather than inside the worktree itself. This is a shell/environment convention (direnv loads `.envrc` into `process.env`), not a special `../` lookup implemented by `config.js`.
 
 ```
 parent-dir/

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,186 @@
+# Hook System
+
+The enforcement system uses Claude Code hooks (PreToolUse, PostToolUse, PreCompact, Stop) to gate tool usage, record evidence, and protect state files.
+
+## Hook Lifecycle
+
+```
+User message / Agent action
+         │
+         ▼
+┌─────────────────────────┐
+│   PreToolUse hooks       │  ← Can BLOCK tool execution
+│   (before tool runs)     │
+└──────────┬──────────────┘
+           │ (allowed)
+           ▼
+┌─────────────────────────┐
+│   Tool executes          │
+│   (Bash, Edit, Write,   │
+│    Task, Skill, etc.)    │
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────────────────┐
+│   PostToolUse hooks      │  ← Can record evidence
+│   (after tool completes) │
+└─────────────────────────┘
+```
+
+## Hook Registration
+
+**File:** `hooks/hooks.json`
+
+Hooks are registered as shell commands that receive tool context via stdin (JSON):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "command": "node workflows/lib/hooks/enforce-step-workflow.js" }
+    ],
+    "PostToolUse": [
+      { "command": "node workflows/lib/hooks/enforce-step-workflow.js" }
+    ]
+  }
+}
+```
+
+## Hook Input/Output Protocol
+
+### Input (stdin)
+
+```json
+{
+  "tool_name": "Edit",
+  "tool_input": {
+    "file_path": "/path/to/file.ts",
+    "old_string": "...",
+    "new_string": "..."
+  },
+  "session_id": "abc123",
+  "transcript_path": "/path/to/transcript"
+}
+```
+
+### Output (exit codes)
+
+| Exit Code | Meaning |
+|---|---|
+| 0 | Allow tool use (no message) |
+| 0 + stdout | Allow, show message to user |
+| 2 | Block tool use (stdout = block reason) |
+
+## Master Enforcement Hook
+
+**File:** `workflows/lib/hooks/enforce-step-workflow.js`
+
+This is the primary enforcement hook, handling both PreToolUse and PostToolUse for all workflows.
+
+### PreToolUse Rules
+
+**Rule 1 — Step gating:** Block tool commands unless the matching workflow step is `in_progress`.
+
+Example: If the current step is `brief`, attempting to run a `commit` command is blocked.
+
+**Rule 2 — Transition gating:** Block step transitions unless the step's expected command has been executed.
+
+Example: Cannot transition `brief → spec` unless `brief.md` was actually generated.
+
+**Rule 3 — State protection:** Block direct edits to state files (`.work-state.json`, etc.).
+
+**Rule 4 — Artifact protection:** Block writes to step artifacts by unauthorized agents.
+
+**Rule 5 — Agent-gated scripts:** Verify the calling agent is authorized for specific scripts (e.g., only `developer-*` agents can call `tdd-phase-state.js`).
+
+### PostToolUse Rules
+
+**Evidence recording:** After a tool executes, record what happened in `.step-evidence.json`.
+
+**Evidence clearing:** On backward transitions, clear evidence for all steps between the target and current.
+
+### Policy Decomposition (GH-206)
+
+Enforcement logic is decomposed into pure decision functions:
+
+| Policy Module | Responsibility |
+|---|---|
+| `command-matching.js` | Match tool call to workflow step |
+| `agent-authorization.js` | Verify agent identity and permissions |
+| `state-protection.js` | Protect state file writes |
+| `evidence-recorder.js` | Load/save/clear evidence |
+| `step-gate.js` | Decide if step command should be allowed |
+| `transition-gate.js` | Decide if transition should be allowed |
+
+## Fail-Open Policy
+
+All hooks follow a strict fail-open policy:
+
+1. If any error occurs inside the hook → exit 0 (allow)
+2. Errors are logged to `hook-error-log.js` (file-based, not stderr)
+3. Only intentional blocks use exit 2
+4. `didBlock` flag preserves block decisions even during cleanup errors
+
+**Rationale:** A hook crash should never prevent the user from working. False negatives (allowing when should block) are preferable to false positives (blocking valid work).
+
+## Workflow-Specific Hooks
+
+### /work hooks (`workflows/work/hooks/`)
+
+| Hook | Purpose |
+|---|---|
+| `enforce-work-command.js` | Ensure /work is the active command |
+| `enforce-coverage-fix.js` | Post-check coverage improvement |
+| `work-require-implement.js` | Block code changes outside implement step |
+| `work-code-review-status.js` | Track code review consensus |
+
+### /work-implement hooks (`workflows/work-implement/hooks/`)
+
+| Hook | Purpose |
+|---|---|
+| `work-implement-enforce.js` | TDD phase file gating (RED/GREEN/REFACTOR) |
+
+### /check hooks (`workflows/check/hooks/`)
+
+| Hook | Purpose |
+|---|---|
+| `check-setup.js` | Initialize check context, discover impacted apps |
+| `check-start-env.js` | Start dev servers |
+| `check-validate-reports.js` | Validate report format and status |
+| `enforce-screenshot-requirement.js` | Block QA without screenshots (GH-207) |
+
+## Session Guard
+
+**File:** `workflows/lib/hooks/session-guard.js`
+
+Prevents concurrent `/work` sessions:
+- Creates a lock file on workflow start
+- Blocks if lock exists from another session
+- Cleans up on PreCompact/Stop events
+- Controlled by `SESSION_GUARD_ENABLED` env var
+
+## Error Logging
+
+**File:** `workflows/lib/hook-error-log.js`
+
+Hook errors go to a log file instead of stderr:
+- Path: `/tmp/claude-hook-errors.log` (or `HOOK_ERROR_LOG` env)
+- Auto-rotation at 1MB
+- Format: `[timestamp] [pid] [context] message`
+- Verbose stderr: Set `ENFORCE_HOOK_DEBUG=1`
+
+## Debugging Hooks
+
+```bash
+# Enable verbose hook logging
+export ENFORCE_HOOK_DEBUG=1
+
+# View hook error log
+cat /tmp/claude-hook-errors.log
+
+# Skip TDD token verification (standalone testing)
+export WORK_TDD_TOKEN_SKIP=1
+
+# Disable session guard
+export SESSION_GUARD_ENABLED=0
+```

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -171,7 +171,11 @@ All hooks follow a strict fail-open policy:
 | `check-start-env.js` | Start dev servers |
 | `check-validate-reports.js` | Validate report format and status |
 
-Note: `enforce-screenshot-requirement.js` lives in `workflows/lib/hooks/` (shared hooks), not in the check-specific hooks directory. It is consumed by the check workflow but is architecturally a shared enforcement hook.
+### Shared hooks used by /check (`workflows/lib/hooks/`)
+
+| Hook | Purpose |
+|---|---|
+| `enforce-screenshot-requirement.js` | Block QA without screenshots (GH-207) |
 
 ## Session Guard
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -33,28 +33,33 @@ User message / Agent action
 
 Hooks are registered as shell commands that receive tool context via stdin (JSON):
 
+The actual `hooks.json` uses `matcher` regex patterns, `CLAUDE_HOOK_TYPE` env vars, and `${CLAUDE_PLUGIN_ROOT}` paths. Different tool types trigger different hook sets:
+
 ```json
 {
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit|Bash",
+        "matcher": "Task|Skill",
         "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/workflows/lib/hooks/enforce-step-workflow.js"
-          }
+          { "type": "command", "command": "CLAUDE_HOOK_TYPE=PreToolUse node ${CLAUDE_PLUGIN_ROOT}/workflows/lib/hooks/enforce-step-workflow.js" }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "CLAUDE_HOOK_TYPE=PreToolUse node ${CLAUDE_PLUGIN_ROOT}/workflows/lib/hooks/enforce-step-workflow.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/workflows/work/hooks/enforce-work-command.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/workflows/work-implement/hooks/work-implement-enforce.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/workflows/work/hooks/work-require-implement.js" }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit|Bash",
+        "matcher": "Task|Skill|Bash",
         "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/workflows/lib/hooks/enforce-step-workflow.js"
-          }
+          { "type": "command", "command": "CLAUDE_HOOK_TYPE=PostToolUse node ${CLAUDE_PLUGIN_ROOT}/workflows/lib/hooks/enforce-step-workflow.js" }
         ]
       }
     ]
@@ -62,7 +67,7 @@ Hooks are registered as shell commands that receive tool context via stdin (JSON
 }
 ```
 
-Note: The actual `hooks.json` uses `matcher` patterns and `${CLAUDE_PLUGIN_ROOT}` paths. Only matching tool types trigger the hooks.
+Note: This is a simplified excerpt. The full `hooks.json` includes additional matchers for `Bash`, MCP tools, `AskUserQuestion`, `PreCompact`, and `Stop` events. `CLAUDE_HOOK_TYPE` is set as an env var prefix so the same script can distinguish Pre vs Post invocation.
 
 ## Hook Input/Output Protocol
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -37,14 +37,32 @@ Hooks are registered as shell commands that receive tool context via stdin (JSON
 {
   "hooks": {
     "PreToolUse": [
-      { "command": "node workflows/lib/hooks/enforce-step-workflow.js" }
+      {
+        "matcher": "Edit|Write|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/workflows/lib/hooks/enforce-step-workflow.js"
+          }
+        ]
+      }
     ],
     "PostToolUse": [
-      { "command": "node workflows/lib/hooks/enforce-step-workflow.js" }
+      {
+        "matcher": "Edit|Write|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/workflows/lib/hooks/enforce-step-workflow.js"
+          }
+        ]
+      }
     ]
   }
 }
 ```
+
+Note: The actual `hooks.json` uses `matcher` patterns and `${CLAUDE_PLUGIN_ROOT}` paths. Only matching tool types trigger the hooks.
 
 ## Hook Input/Output Protocol
 
@@ -147,7 +165,8 @@ All hooks follow a strict fail-open policy:
 | `check-setup.js` | Initialize check context, discover impacted apps |
 | `check-start-env.js` | Start dev servers |
 | `check-validate-reports.js` | Validate report format and status |
-| `enforce-screenshot-requirement.js` | Block QA without screenshots (GH-207) |
+
+Note: `enforce-screenshot-requirement.js` lives in `workflows/lib/hooks/` (shared hooks), not in the check-specific hooks directory. It is consumed by the check workflow but is architecturally a shared enforcement hook.
 
 ## Session Guard
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -169,9 +169,9 @@ All hooks follow a strict fail-open policy:
 |---|---|
 | `check-setup.js` | Initialize check context, discover impacted apps |
 | `check-start-env.js` | Start dev servers |
-| `check-validate-reports.js` | Validate report format and status |
+| `check-validate-reports.js` | Validate report format and status lines |
 
-### Shared hooks used by /check (`workflows/lib/hooks/`)
+### Shared hooks consumed by /check (`workflows/lib/hooks/`)
 
 | Hook | Purpose |
 |---|---|

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,109 @@
+# Skills (Slash Commands)
+
+Skills are user-invocable slash commands defined in `skills/*/SKILL.md`. Each skill specifies its allowed tools, argument patterns, and behavior.
+
+## Skill Catalog
+
+### Core Workflow Skills
+
+| Command | Skill Directory | Purpose |
+|---|---|---|
+| `/work <TICKET>` | `skills/work/` | Full orchestrated ticket-to-PR workflow |
+| `/work-implement <TICKET>` | `skills/work-implement/` | Quick TDD-gated implementation |
+| `/work-pr <TICKET>` | `skills/work-pr/` | Update PR description and visual docs |
+| `/check <TICKET>` | `skills/check/` | Full quality verification (parallel agents) |
+| `/check-qa <app>` | `skills/check-qa/` | Test specific app via Playwright |
+| `/check-browser` | `skills/check-browser/` | Verify browser/UI state |
+
+### Planning Skills
+
+| Command | Skill Directory | Purpose |
+|---|---|---|
+| `/brief <description>` | `skills/brief/` | Generate product brief |
+| `/spec` | `skills/spec/` | Generate technical spec from brief |
+| `/split-in-tasks` | `skills/split-in-tasks/` | Decompose spec into ordered tasks |
+
+### Testing Skills
+
+| Command | Skill Directory | Purpose |
+|---|---|---|
+| `/tests-review` | `skills/tests-review/` | Analyze test coverage gaps |
+| `/tests-create` | `skills/tests-create/` | Create missing test cases |
+| `/test-coordination` | `skills/test-coordination/` | Run review + create in parallel |
+| `/code-review` | `skills/code-review/` | Static code review |
+
+### PR & Git Skills
+
+| Command | Skill Directory | Purpose |
+|---|---|---|
+| `/follow-up-pr` | `skills/follow-up-pr/` | Monitor CI, address review comments |
+| `/bootstrap <TICKET...>` | `skills/bootstrap/` | Setup worktrees for multiple tickets |
+| `/orchestrate <TICKET...>` | `skills/orchestrate/` | Run /work sequentially for multiple tickets |
+| `/cleanup-worktrees` | `skills/cleanup-worktrees/` | Verify merge & remove worktrees |
+
+### Jira Skills
+
+| Command | Skill Directory | Purpose |
+|---|---|---|
+| `/create-jira` | `skills/create-jira/` | Multi-agent consensus ticket creation |
+| `/create-jira-consensus` | `skills/create-jira-consensus/` | Agent consultation for Jira |
+| `/create-jira-agents` | `skills/create-jira-agents/` | Agent consultation prompts |
+| `/create-jira-design-doc` | `skills/create-jira-design-doc/` | Design doc evaluation |
+| `/create-jira-wiki` | `skills/create-jira-wiki/` | Publish design docs to wiki |
+| `/create-design-doc` | `skills/create-design-doc/` | Guide for writing design docs |
+
+## Skill Definition Format
+
+Each skill is defined in `SKILL.md` with frontmatter:
+
+```markdown
+---
+name: work
+description: Orchestrated workflow for ticket tasks
+allowed-tools: Task, Bash, Skill, Read, Glob, Grep, Edit, Write, AskUserQuestion
+argument-hint: <TICKET_ID> [description]
+---
+
+[Skill prompt content — instructions for Claude when this skill is invoked]
+```
+
+### Key Fields
+
+| Field | Purpose |
+|---|---|
+| `name` | Slash command name (e.g., `work` → `/work`) |
+| `description` | One-line description shown in help |
+| `allowed-tools` | Tools the skill can use (whitelist) |
+| `argument-hint` | Usage hint shown to user |
+
+## Skill vs Agent
+
+| | Skill | Agent |
+|---|---|---|
+| Invocation | User types `/command` | Dispatched via `Task()` |
+| Definition | `SKILL.md` (instructions) | `agent.md` (personality + capabilities) |
+| Scope | Orchestration, coordination | Domain-specific execution |
+| Tool access | Configurable whitelist | Inherited from parent |
+| State | May manage workflow state | Stateless (produces artifacts) |
+
+## Skill Interactions
+
+Skills can invoke other skills and agents:
+
+```
+/work TICKET-123
+  ├─ /brief (skill)
+  │   └─ Task(brief-writer)
+  ├─ /spec (skill)
+  │   └─ Task(spec-writer)
+  ├─ /split-in-tasks (skill)
+  ├─ Task(developer-react-senior)  ← implement step
+  ├─ Task(commit-writer)           ← commit step
+  ├─ /check (skill)
+  │   ├─ Task(code-checker)
+  │   ├─ Task(quality-checker)
+  │   ├─ Task(qa-feature-tester)
+  │   └─ Task(completion-checker)
+  ├─ Task(pr-generator)            ← pr step
+  └─ /follow-up-pr (skill)        ← follow_up step
+```

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1,0 +1,219 @@
+# State Machine
+
+The workflow engine is built on a deterministic state machine that tracks step progress, enforces transitions, and enables resume-on-context-loss.
+
+## Step Registry
+
+**File:** `workflows/work/step-registry.js`
+
+The step registry is the single source of truth for step identifiers and ordering. Step IDs are decoupled from their position — reordering only requires changing `STEP_ORDER`.
+
+### Step Identifiers
+
+```javascript
+const STEPS = Object.freeze({
+  ticket:      'ticket',
+  bootstrap:   'bootstrap',
+  brief:       'brief',
+  brief_gate:  'brief_gate',
+  spec:        'spec',
+  tasks:       'tasks',
+  implement:   'implement',
+  commit:      'commit',
+  task_review: 'task_review',
+  check:       'check',
+  pr:          'pr',
+  ready:       'ready',
+  follow_up:   'follow_up',
+  ci:          'ci',
+  cleanup:     'cleanup',
+  reports:     'reports',
+  complete:    'complete',
+});
+```
+
+### Step Ordering
+
+```
+1. ticket        — Initialize work state
+2. bootstrap     — Create worktree & branch
+3. brief         — Generate product brief
+4. brief_gate    — Verify no blocking open questions (GH-215)
+5. spec          — Generate technical spec
+6. tasks         — Split spec into tasks (tasks.md)
+7. implement     — TDD-gated code implementation
+8. commit        — Commit changes
+9. task_review   — Per-task code review gate (GH-211)
+10. check        — Full quality verification
+11. pr           — Create/update pull request
+12. ready        — Mark PR ready for review
+13. follow_up    — Monitor CI & address review comments
+14. ci           — Verify CI passes
+15. cleanup      — Remove dev server sessions
+16. reports      — Generate approval summary
+17. complete     — Terminal step
+```
+
+## Transition Graph
+
+### Forward Edges
+
+Each step transitions to the next step in order: `ticket → bootstrap → brief → ... → complete`.
+
+### Backward Edges (Retry Loops)
+
+When quality gates fail, the workflow loops back to `implement` to fix issues:
+
+```
+task_review → implement    (review found issues)
+check       → implement    (check found issues)
+follow_up   → implement    (PR review requires code changes)
+ci          → implement    (CI failed, fix code)
+```
+
+### Self-Loop
+
+```
+complete → complete        (retry terminal step on partial failure, GH-106)
+```
+
+### Visual Graph
+
+```
+ticket → bootstrap → brief → brief_gate → spec → tasks
+                                                    │
+    ┌───────────────────────────────────────────────┘
+    ▼
+implement ←──────────────────────────────────────┐
+    │                                             │
+    ▼                                             │
+commit → task_review ─── (issues found) ──────────┤
+    │         │                                   │
+    │         ▼ (pass)                            │
+    │    check ─────────── (issues found) ────────┤
+    │         │                                   │
+    │         ▼ (pass)                            │
+    │    pr → ready → follow_up ── (changes) ─────┤
+    │                     │                       │
+    │                     ▼ (pass)                │
+    │                ci ──────── (failed) ────────┘
+    │                     │
+    │                     ▼ (pass)
+    │              cleanup → reports → complete
+    │                                     │
+    └─────────────────────────────────────┘
+                  (self-loop for retries)
+```
+
+## State Persistence
+
+### .work-state.json
+
+The primary state file tracks step progress:
+
+```json
+{
+  "ticketId": "PROJ-123",
+  "description": "",
+  "currentStep": 10,
+  "status": "in_progress",
+  "stepStatus": {
+    "ticket": "completed",
+    "bootstrap": "completed",
+    "brief": "completed",
+    "brief_gate": "completed",
+    "spec": "completed",
+    "tasks": "completed",
+    "implement": "completed",
+    "commit": "completed",
+    "task_review": "completed",
+    "check": "in_progress",
+    "pr": "pending",
+    "...": "pending"
+  },
+  "checkProgress": {},
+  "errors": [],
+  "startTime": "2026-04-22T11:00:36.726Z",
+  "lastUpdate": "2026-04-22T14:33:38.502Z",
+  "tasksMeta": {
+    "totalTasks": 6,
+    "currentTaskIndex": 3,
+    "tasks": [
+      { "id": "task_1", "status": "completed" },
+      { "id": "task_2", "status": "completed" },
+      { "id": "task_3", "status": "completed" },
+      { "id": "task_4", "status": "in_progress" },
+      { "id": "task_5", "status": "pending" },
+      { "id": "task_6", "status": "pending" }
+    ]
+  },
+  "deferredSteps": ["bootstrap", "brief", "brief_gate", "spec"]
+}
+```
+
+### Step Statuses
+
+| Status | Meaning |
+|---|---|
+| `pending` | Not yet started |
+| `in_progress` | Currently active |
+| `completed` | Successfully finished |
+| `failed` | Failed (triggers retry) |
+
+### Task Meta
+
+When `tasks.md` exists, the workflow tracks per-task progress:
+
+- `totalTasks` — Number of tasks parsed from tasks.md
+- `currentTaskIndex` — 0-indexed pointer to current task
+- `tasks[]` — Per-task status with `taskReviewFixRounds` counter
+
+The implement/commit/task_review cycle repeats for each task before proceeding to check.
+
+## Plan Generator
+
+**File:** `workflows/work/plan-generator.js`
+
+Before each orchestrator iteration, the plan generator inspects current state and computes actions:
+
+| Action | Meaning |
+|---|---|
+| `RUN` | Execute this step now |
+| `SKIP` | Step already verified, move to next |
+| `DEFER` | Step needs prerequisites first |
+
+The plan generator calls each step's `verify()` function (from `workflow-definition.js`) to determine if evidence already exists. This enables:
+
+- **Resume** — After context loss, already-completed steps are SKIPped
+- **Idempotency** — Re-running the orchestrator produces the same plan
+- **Backward transitions** — After a retry loop, intermediate steps may need re-verification
+
+## Resume on Context Loss
+
+When Claude's context window rotates or the conversation crashes:
+
+1. User re-invokes `/work TICKET-123`
+2. Orchestrator loads `.work-state.json`
+3. Plan generator runs `verify()` for each step
+4. Steps with evidence → SKIP
+5. First step without evidence → RUN
+6. Work resumes from that point
+
+## Workflow Engine (Generic)
+
+**File:** `workflows/lib/workflow-engine.js`
+
+The generic workflow engine supports any workflow (not just /work). It provides:
+
+- `discoverWorkflows()` — Scan `workflows/` for `*.workflow.js` files
+- `loadWorkflow(name)` — Load workflow definition
+- `transitionStep(ticketId, step)` — Advance state machine
+- `detectStepState(workflow, ticketId)` — Inspect which steps are verified
+
+Each workflow provides a `workflow-definition.js` that returns:
+- `steps` — Ordered step array
+- `commandMap` — Step-to-tool-pattern mappings
+- `verify()` functions — Evidence checks
+- `archivalPatterns` — Cleanup rules for backward transitions
+- `evidenceRequirements` — Required files per step
+- `softSteps` — Steps that don't require evidence

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -20,8 +20,8 @@ const STEPS = Object.freeze({
   spec_gate:   'spec_gate',
   tasks:       'tasks',
   implement:   'implement',
-  commit:      'commit',
-  task_review: 'task_review',
+  commit:      'commit',      // step 9
+  task_review: 'task_review', // step 10 (GH-211)
   check:       'check',
   pr:          'pr',
   ready:       'ready',

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -120,7 +120,7 @@ The primary state file tracks step progress:
 {
   "ticketId": "PROJ-123",
   "description": "",
-  "currentStep": 10,
+  "currentStep": 11,
   "status": "in_progress",
   "stepStatus": {
     "ticket": "completed",
@@ -128,6 +128,7 @@ The primary state file tracks step progress:
     "brief": "completed",
     "brief_gate": "completed",
     "spec": "completed",
+    "spec_gate": "completed",
     "tasks": "completed",
     "implement": "completed",
     "commit": "completed",
@@ -147,7 +148,7 @@ The primary state file tracks step progress:
       { "id": "task_1", "status": "completed" },
       { "id": "task_2", "status": "completed" },
       { "id": "task_3", "status": "completed" },
-      { "id": "task_4", "status": "in_progress" },
+      { "id": "task_4", "status": "pending" },
       { "id": "task_5", "status": "pending" },
       { "id": "task_6", "status": "pending" }
     ]

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -17,6 +17,7 @@ const STEPS = Object.freeze({
   brief:       'brief',
   brief_gate:  'brief_gate',
   spec:        'spec',
+  spec_gate:   'spec_gate',
   tasks:       'tasks',
   implement:   'implement',
   commit:      'commit',
@@ -40,18 +41,19 @@ const STEPS = Object.freeze({
 3. brief         — Generate product brief
 4. brief_gate    — Verify no blocking open questions (GH-215)
 5. spec          — Generate technical spec
-6. tasks         — Split spec into tasks (tasks.md)
-7. implement     — TDD-gated code implementation
-8. commit        — Commit changes
-9. task_review   — Per-task code review gate (GH-211)
-10. check        — Full quality verification
-11. pr           — Create/update pull request
-12. ready        — Mark PR ready for review
-13. follow_up    — Monitor CI & address review comments
-14. ci           — Verify CI passes
-15. cleanup      — Remove dev server sessions
-16. reports      — Generate approval summary
-17. complete     — Terminal step
+6. spec_gate     — Validate Gherkin test scenarios in spec (GH-244)
+7. tasks         — Split spec into tasks (tasks.md)
+8. implement     — TDD-gated code implementation
+9. commit        — Commit changes
+10. task_review  — Per-task code review gate (GH-211)
+11. check        — Full quality verification
+12. pr           — Create/update pull request
+13. ready        — Mark PR ready for review
+14. follow_up   — Monitor CI & address review comments
+15. ci           — Verify CI passes
+16. cleanup      — Remove dev server sessions
+17. reports      — Generate approval summary
+18. complete     — Terminal step
 ```
 
 ## Transition Graph
@@ -62,9 +64,10 @@ Each step transitions to the next step in order: `ticket → bootstrap → brief
 
 ### Backward Edges (Retry Loops)
 
-When quality gates fail, the workflow loops back to `implement` to fix issues:
+When quality gates fail, the workflow loops back to fix issues:
 
 ```
+spec_gate   → spec         (Gherkin validation failed, regenerate spec)
 task_review → implement    (review found issues)
 check       → implement    (check found issues)
 follow_up   → implement    (PR review requires code changes)
@@ -80,9 +83,11 @@ complete → complete        (retry terminal step on partial failure, GH-106)
 ### Visual Graph
 
 ```
-ticket → bootstrap → brief → brief_gate → spec → tasks
-                                                    │
-    ┌───────────────────────────────────────────────┘
+ticket → bootstrap → brief → brief_gate → spec → spec_gate → tasks
+                                            ▲        │
+                                            └────────┘ (Gherkin invalid)
+                                                               │
+    ┌──────────────────────────────────────────────────────────┘
     ▼
 implement ←──────────────────────────────────────┐
     │                                             │

--- a/docs/tdd-enforcement.md
+++ b/docs/tdd-enforcement.md
@@ -1,0 +1,207 @@
+# TDD Enforcement
+
+The TDD enforcement system ensures that all code changes follow the RED → GREEN → REFACTOR discipline. It operates through three layers: phase gating (hooks), evidence recording (CLI), and evidence validation (orchestrator).
+
+## Three Layers
+
+### Layer 1: Phase Gating (Hook)
+
+**File:** `workflows/work-implement/hooks/work-implement-enforce.js`
+
+A PreToolUse hook that blocks file edits based on the current TDD phase:
+
+| Current Phase | Edit test file | Edit source file | Edit helper |
+|---|---|---|---|
+| RED | ALLOW | BLOCK | ALLOW |
+| GREEN | BLOCK | ALLOW | ALLOW |
+| REFACTOR | ALLOW | ALLOW | ALLOW |
+| exception | ALLOW | ALLOW | ALLOW |
+
+**File classification** (`tdd-phase-registry.js`):
+
+- **Test files:** `*.test.ts`, `*.test.tsx`, `*.spec.ts`, `*.spec.tsx`, `*.test.js`, `*.spec.js`
+- **Test helpers:** `__mocks__/*`, `__fixtures__/*`, `test-utils.*`, `testing-library.*`
+- **Source files:** Everything else
+
+### Layer 2: Evidence Recording (CLI)
+
+**File:** `workflows/work-implement/tdd-phase-state.js`
+
+Only this CLI can record TDD evidence — agents cannot self-report. Evidence includes:
+
+| Phase | What's recorded |
+|---|---|
+| RED | Test files changed, test command, exit code (must be non-zero), timestamp |
+| GREEN | Test command, exit code (must be 0), timestamp |
+| REFACTOR | Test command, exit code (must be 0), timestamp |
+
+**Token gating:** Gated subcommands (`record-red`, `record-green`, `record-refactor`, `transition`) require a token issued by `enforce-step-workflow.js` Rule 5. This prevents unauthorized evidence injection.
+
+**Authorized agents:** `developer-nodejs-tdd`, `developer-react-senior`, `developer-react-ui-architect`, `developer-devops`
+
+### Layer 3: Evidence Validation (Orchestrator)
+
+**File:** `workflows/work/tdd-enforcement.js`
+
+The `/work` orchestrator validates TDD evidence before allowing transition out of `implement`:
+
+```javascript
+function validateTddEvidence(evidence) {
+  // Exception: valid if reason is non-empty
+  if (typeof evidence.exception === 'string' && evidence.exception.trim() !== '') {
+    return { valid: true, reason: '' };
+  }
+  // Normal: at least one cycle with red + green
+  if (!Array.isArray(evidence.cycles) || evidence.cycles.length === 0) {
+    return { valid: false, reason: 'No TDD cycles recorded' };
+  }
+  return evidence.cycles.some(c => c.red && c.green)
+    ? { valid: true, reason: '' }
+    : { valid: false, reason: 'No complete RED→GREEN cycle' };
+}
+```
+
+## Phase Transitions
+
+**File:** `workflows/work-implement/tdd-phase-registry.js`
+
+Valid transitions:
+
+```
+red → green → refactor → red (cyclic)
+```
+
+Any phase can transition to `exception` (one-way, terminal).
+
+The `tddCanTransition(from, to)` function enforces this graph.
+
+## State File
+
+**Per-task:** `TASKS_BASE/<ticket>/taskN/tdd-phase.json`
+**Legacy root:** `TASKS_BASE/<ticket>/tdd-phase.json`
+
+### Normal cycle
+
+```json
+{
+  "currentPhase": "refactor",
+  "currentCycle": 1,
+  "cycles": [
+    {
+      "cycle": 1,
+      "red": {
+        "testFiles": ["src/feature.test.ts"],
+        "testCommand": "npm test -- --filter feature",
+        "testExitCode": 1,
+        "timestamp": "2026-04-22T13:29:32.249Z"
+      },
+      "green": {
+        "testCommand": "npm test -- --filter feature",
+        "testExitCode": 0,
+        "timestamp": "2026-04-22T13:38:20.418Z"
+      },
+      "refactor": {
+        "testCommand": "npm test -- --filter feature",
+        "testExitCode": 0,
+        "timestamp": "2026-04-22T13:38:46.873Z"
+      }
+    }
+  ]
+}
+```
+
+### Multiple cycles
+
+When refactoring reveals need for more behavior:
+
+```json
+{
+  "currentPhase": "green",
+  "currentCycle": 2,
+  "cycles": [
+    { "cycle": 1, "red": {...}, "green": {...}, "refactor": {...} },
+    { "cycle": 2, "red": {...} }
+  ]
+}
+```
+
+### Exception mode
+
+```json
+{
+  "currentPhase": "exception",
+  "exception": "config-only change, no testable behavior",
+  "cycles": []
+}
+```
+
+## Exception Mode
+
+**Valid reasons** (documented, not yet enforced programmatically):
+- Config-only changes (vite.config, tsconfig, package.json)
+- File moves/renames with no behavior change
+- Non-testable infrastructure changes (CI/CD, Dockerfiles)
+
+**Known gap:** Any non-empty string is accepted. See [GH-258](https://github.com/tigredonorte/claude-plugin-work/issues/258).
+
+## Per-Task vs Root State
+
+When `tasks.md` exists (multi-task mode):
+- Each task gets its own `taskN/tdd-phase.json`
+- The `--task N` flag routes to the per-task path
+- No fallback to root (GH-219 Task 1)
+
+When no `tasks.md` (single-task mode):
+- Root `tdd-phase.json` is used
+- `--task` flag is omitted
+
+**Path resolution** (`tdd-phase-state.js:getStatePath()`):
+```
+With --task 3:  TASKS_BASE/<ticket>/task3/tdd-phase.json
+Without --task: TASKS_BASE/<ticket>/tdd-phase.json
+```
+
+## Auto-Initialization
+
+When the `/work` orchestrator transitions to the `implement` step, it automatically initializes `tdd-phase.json` with RED phase:
+
+```javascript
+// work-state.js:autoInitTdd()
+function autoInitTdd(ticketId, taskNum) {
+  const state = { currentPhase: 'red', currentCycle: 1, cycles: [] };
+  // Atomic exclusive create (wx flag) — idempotent
+  fs.openSync(tddStatePath, 'wx');
+  fs.writeFileSync(fd, JSON.stringify(state, null, 2));
+}
+```
+
+This forces the developer agent to write tests first before any implementation.
+
+## CLI Reference
+
+```bash
+# Initialize
+node tdd-phase-state.js init TICKET-123 [--task N]
+
+# Check current phase
+node tdd-phase-state.js current TICKET-123 [--task N]
+
+# Record phases (runs test command internally)
+node tdd-phase-state.js record-red TICKET-123 --cmd "npm test" [--task N]
+node tdd-phase-state.js record-green TICKET-123 --cmd "npm test" [--task N]
+node tdd-phase-state.js record-refactor TICKET-123 --cmd "npm test" [--task N]
+
+# Manual transition
+node tdd-phase-state.js transition TICKET-123 green [--task N]
+
+# Exception mode
+node tdd-phase-state.js exception TICKET-123 --reason "reason" [--task N]
+```
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WORK_TDD_TOKEN_SKIP` | `0` | Skip token verification (debugging) |
+| `TASKS_BASE` | from config | State file root |
+| `ENFORCE_HOOK_DEBUG` | `0` | Verbose hook logging |

--- a/docs/tdd-enforcement.md
+++ b/docs/tdd-enforcement.md
@@ -12,16 +12,20 @@ A PreToolUse hook that blocks file edits based on the current TDD phase:
 
 | Current Phase | Edit test file | Edit source file | Edit helper |
 |---|---|---|---|
-| RED | ALLOW | BLOCK | ALLOW |
+| RED | ALLOW | BLOCK | BLOCK |
 | GREEN | BLOCK | ALLOW | ALLOW |
 | REFACTOR | ALLOW | ALLOW | ALLOW |
 | exception | ALLOW | ALLOW | ALLOW |
 
+Note: In RED phase, only files matching `.test.*` or `.spec.*` patterns are allowed. Helpers (`__mocks__/`, `__fixtures__/`, `test-utils/`) are classified separately and blocked in RED. In GREEN phase, test files are blocked but helpers are explicitly allowed (`isTestFile && !isTestHelper`).
+
 **File classification** (`tdd-phase-registry.js`):
 
-- **Test files:** `*.test.ts`, `*.test.tsx`, `*.spec.ts`, `*.spec.tsx`, `*.test.js`, `*.spec.js`
-- **Test helpers:** `__mocks__/*`, `__fixtures__/*`, `test-utils.*`, `testing-library.*`
+- **Test files:** Matches `TEST_FILE_PATTERNS`: `/\.test\.[jt]sx?$/`, `/\.spec\.[jt]sx?$/`
+- **Test helpers:** Matches `TEST_HELPER_PATTERNS`: `__mocks__/`, `__fixtures__/`, `test-utils/`, `test-utils.[jt]sx?`, `test-helper/`
 - **Source files:** Everything else
+
+Note: `isTestHelper()` returns false if the file also matches `isTestFile()` — a file named `test-utils.test.ts` is a test file, not a helper.
 
 ### Layer 2: Evidence Recording (CLI)
 
@@ -71,9 +75,9 @@ Valid transitions:
 red → green → refactor → red (cyclic)
 ```
 
-Any phase can transition to `exception` (one-way, terminal).
+`exception` is not part of the transition graph — it is set directly by the `cmdException()` function, bypassing `tddCanTransition()`. It overwrites the entire state file with `{ currentPhase: 'exception', exception: reason, cycles: [] }`.
 
-The `tddCanTransition(from, to)` function enforces this graph.
+The `tddCanTransition(from, to)` function only enforces the `red → green → refactor → red` cycle.
 
 ## State File
 

--- a/docs/workflow-check.md
+++ b/docs/workflow-check.md
@@ -1,0 +1,216 @@
+# /check Workflow
+
+Parallel quality verification that runs code review, tests, QA, and completion checks.
+
+## Invocation
+
+```
+/check TICKET-123
+```
+
+Also invoked automatically as part of `/work` at the `check` step.
+
+## Steps
+
+| # | Step | Purpose |
+|---|---|---|
+| 1 | `1_setup` | Initialize, compute changes hash, check cache |
+| 2 | `2_start_env` | Start dev servers for Playwright |
+| 3 | `3_verify_playwright` | Verify Playwright MCP connectivity |
+| 4 | `4_phase1_agents` | Run all check agents in parallel |
+| 5 | `5_phase2_consensus` | Developers evaluate code review suggestions |
+| 6 | `6_quality_recheck` | Re-validate if code review was implemented |
+| 7 | `7_validate_summary` | Verify all reports, generate README.md |
+| 8 | `8_output` | Display final results |
+| 9 | `9_cleanup` | Kill dev servers |
+
+## Changes Hash Cache
+
+The check workflow computes a hash of code changes to avoid redundant re-checks:
+
+```bash
+git diff ${baseBranch}...HEAD -w | sha256sum
+```
+
+- Each report includes: `**Changes Hash:** abc123def456`
+- `README.md` (summary) includes the hash
+- On re-run: if hash matches all existing reports → SKIP all steps
+- On re-run: if hash differs → re-run from step 2
+
+## Phase 1: Parallel Agents
+
+All agents run concurrently during phase 1:
+
+### code-checker
+
+**Report:** `code-review.check.md`
+
+**Checks:**
+- Task-doc compliance (brief.md, spec.md, tasks.md alignment)
+- Code reuse (spec's reuse audit)
+- TDD / test discipline
+- TypeScript safety
+- Code smells
+- SOLID / design quality
+- Dependency hygiene
+
+**Verdicts:** APPROVED, NEEDS_WORK (with severity: CRITICAL, IMPORTANT, SUGGESTION)
+
+### quality-checker
+
+**Report:** `tests.check.md`
+
+**Checks:**
+- Lint (project lint command)
+- Typecheck (project typecheck command)
+- Unit tests (project test command)
+- Integration tests (if applicable)
+- Smoke tests (if applicable)
+
+**Verdicts:** APPROVED, NEEDS_WORK (with failing test details)
+
+### qa-feature-tester
+
+**Report:** `qa-<app>.check.md` (one per impacted web app)
+
+**Checks:**
+- Start application
+- Navigate to affected pages
+- Test user flows
+- Capture screenshots
+- Verify against Gherkin scenarios from spec.md
+
+**Tools:** Playwright MCP (browser automation)
+
+**Dispatch:** Only for apps listed in `WEB_APPS` env var with `appType: "web"`
+
+### qa-api-tester
+
+**Report:** `qa-api.check.md`
+
+**Checks:**
+- Call API endpoints
+- Verify responses
+- Check database state
+- Validate service behavior
+
+**Dispatch:** For apps with `appType: "api"` or backend-only changes
+
+### completion-checker
+
+**Report:** `completion.check.md`
+
+**Checks:**
+- Every requirement in brief.md/spec.md/tasks.md has been delivered
+- Requirement-to-evidence mapping (R1 → Task 2 → file changes)
+- Gap identification
+
+**Verdicts:** COMPLETE, INCOMPLETE (with gap details)
+
+## Phase 2: Consensus Loop
+
+If code-checker reports issues (IMPORTANT or SUGGESTION severity), phase 2 runs:
+
+1. **Developer agent evaluates** each issue:
+   - `IMPLEMENTED` — Fixed the code
+   - `DEFERRED` — Valid but out of scope
+   - `NOT_APPLICABLE` — Disagrees with finding
+
+2. **Code-checker validates** developer decisions:
+   - `AGREE` — Accepts the resolution
+   - `DISAGREE` — Requests re-evaluation
+
+3. **Loop** until consensus or max iterations reached
+
+Developer agent selection is based on changed file types:
+- `.ts`, `.tsx` (React) → `developer-react-senior`
+- `.ts`, `.js` (Node.js) → `developer-nodejs-tdd`
+- Infrastructure files → `developer-devops`
+
+## Phase 3: Quality Re-check
+
+If phase 2 resulted in code changes (IMPLEMENTED), the quality-checker re-runs on affected files to ensure no regressions.
+
+## Report Structure
+
+All reports follow this format:
+
+```markdown
+**Changes Hash:** abc123def456
+
+## [Report Title]
+
+[Content]
+
+## Status: APPROVED
+```
+
+The `Status:` line is required by the quality gate. Valid values:
+- `APPROVED` — Passed all checks
+- `NEEDS_WORK` — Issues found, must be fixed
+- `COMPLETE` / `INCOMPLETE` — For completion-checker
+
+## Evidence Requirements
+
+Defined in `workflow-definition.js`:
+
+```javascript
+evidenceRequirements: {
+  check: {
+    requiredFiles: ['code-review.check.md', 'tests.check.md',
+                    'completion.check.md', 'README.md'],
+    qaReportPattern: /^qa-.*\.check\.md$/,
+  },
+  reports: {
+    requiredApprovals: [
+      { file: 'tests.check.md', pattern: /Status:\s*APPROVED/i },
+      { file: 'code-review.check.md', pattern: /Status:\s*APPROVED/i },
+      { file: 'completion.check.md', pattern: /Status:\s*(COMPLETE|APPROVED)/i },
+    ],
+    qaReportPattern: /^qa-.*\.check\.md$/,
+    qaApprovalPattern: /Status:\s*APPROVED/i,
+  },
+}
+```
+
+## QA Agent Routing
+
+The check setup script (`check-setup.js`) determines which QA agents to dispatch:
+
+1. Compute git diff to find changed files
+2. Match changed files against `WEB_APPS` manifest
+3. For each impacted app:
+   - `appType: "web"` → `qa-feature-tester` (Playwright)
+   - `appType: "api"` → `qa-api-tester` (curl/HTTP)
+   - `appType: "cli"` → Skip QA
+4. If no `WEB_APPS` configured → Skip QA (generates skip report)
+
+## State File
+
+`TASKS_BASE/<ticket>/.check.workflow-state.json`
+
+```json
+{
+  "workflow": "check",
+  "instanceId": "TICKET-123",
+  "status": "in_progress",
+  "currentStep": 4,
+  "stepStatus": {
+    "1_setup": "completed",
+    "2_start_env": "completed",
+    "3_verify_playwright": "completed",
+    "4_phase1_agents": "in_progress",
+    "5_phase2_consensus": "pending",
+    "...": "pending"
+  }
+}
+```
+
+## Artifact Archival
+
+When `/check` re-runs (e.g., after backward transition from `follow_up → implement → check`):
+
+1. Existing `*.check.md` files are moved to `runs/runN/`
+2. `README.md` is deleted
+3. Fresh reports are generated
+4. `runs/` preserves history of all prior check runs

--- a/docs/workflow-check.md
+++ b/docs/workflow-check.md
@@ -28,8 +28,10 @@ Also invoked automatically as part of `/work` at the `check` step.
 
 The check workflow computes a hash of code changes to avoid redundant re-checks:
 
-```bash
-git diff ${baseBranch}...HEAD -w | sha256sum
+```javascript
+// check.workflow.js — computeChangesHash()
+const diff = execSync(`git diff ${baseBranch}...HEAD -w`);
+return crypto.createHash('sha256').update(diff).digest('hex').substring(0, 12);
 ```
 
 - Each report includes: `**Changes Hash:** abc123def456`

--- a/docs/workflow-work-implement.md
+++ b/docs/workflow-work-implement.md
@@ -1,0 +1,182 @@
+# /work-implement Workflow
+
+Quick TDD-gated implementation that skips brief/spec/tasks generation. Used for standalone implementation tasks or within `/work` at the implement step.
+
+## Invocation
+
+```
+/work-implement TICKET-123
+/work-implement TICKET-123 --task 3
+```
+
+## TDD Phase Cycle
+
+Every implementation follows the RED → GREEN → REFACTOR cycle:
+
+```
+RED ──────────► GREEN ──────────► REFACTOR
+(write tests)   (make pass)       (clean up)
+     │                                │
+     └────────────────────────────────┘
+              (next cycle)
+```
+
+### RED Phase
+
+**Goal:** Write failing tests that define the expected behavior.
+
+**Hook enforcement:** Blocks Write/Edit to non-test files.
+
+**Allowed files:** `*.test.ts`, `*.test.tsx`, `*.spec.ts`, `*.spec.tsx`, `__mocks__/*`, `__fixtures__/*`, `test-utils/*`
+
+**Evidence required:** Test files changed + test command exits with non-zero code.
+
+### GREEN Phase
+
+**Goal:** Write minimal production code to make tests pass.
+
+**Hook enforcement:** Blocks Write/Edit to test files (except helpers).
+
+**Allowed files:** All non-test source files.
+
+**Evidence required:** Test command exits with code 0.
+
+### REFACTOR Phase
+
+**Goal:** Clean up code while keeping tests green.
+
+**Hook enforcement:** None — all file edits allowed.
+
+**Evidence required:** Test command still exits with code 0.
+
+## TDD Phase State CLI
+
+**File:** `workflows/work-implement/tdd-phase-state.js`
+
+All subcommands support `--task N` for per-task scoping.
+
+### Commands
+
+```bash
+# Initialize TDD state
+node tdd-phase-state.js init TICKET-123 --task 1
+
+# Check current phase
+node tdd-phase-state.js current TICKET-123 --task 1
+
+# Record RED phase (runs tests, expects failure)
+node tdd-phase-state.js record-red TICKET-123 --task 1 --cmd "npm test"
+
+# Record GREEN phase (runs tests, expects success)
+node tdd-phase-state.js record-green TICKET-123 --task 1 --cmd "npm test"
+
+# Record REFACTOR phase (runs tests, expects success)
+node tdd-phase-state.js record-refactor TICKET-123 --task 1 --cmd "npm test"
+
+# Transition to next phase
+node tdd-phase-state.js transition TICKET-123 --task 1 green
+
+# Exception mode (skip TDD for mechanical changes)
+node tdd-phase-state.js exception TICKET-123 --task 1 --reason "config-only change"
+```
+
+### Token Gating
+
+Gated subcommands (`record-red`, `record-green`, `record-refactor`, `transition`) require a valid token. Tokens are issued by `enforce-step-workflow.js` Rule 5 and consumed by the CLI. This prevents agents from self-reporting evidence.
+
+Set `WORK_TDD_TOKEN_SKIP=1` for standalone/debugging use.
+
+## State File
+
+**Location:** `TASKS_BASE/<ticket>/taskN/tdd-phase.json` (per-task) or `TASKS_BASE/<ticket>/tdd-phase.json` (legacy root)
+
+```json
+{
+  "currentPhase": "refactor",
+  "currentCycle": 1,
+  "cycles": [
+    {
+      "cycle": 1,
+      "red": {
+        "testFiles": ["src/foo.test.ts"],
+        "testCommand": "npm test",
+        "testExitCode": 1,
+        "timestamp": "2026-04-22T13:29:32.249Z"
+      },
+      "green": {
+        "testCommand": "npm test",
+        "testExitCode": 0,
+        "timestamp": "2026-04-22T13:38:20.418Z"
+      },
+      "refactor": {
+        "testCommand": "npm test",
+        "testExitCode": 0,
+        "timestamp": "2026-04-22T13:38:46.873Z"
+      }
+    }
+  ]
+}
+```
+
+## Exception Mode
+
+For purely mechanical changes (config-only, file moves, no testable behavior), the exception subcommand bypasses TDD:
+
+```json
+{
+  "currentPhase": "exception",
+  "exception": "config-only change, no testable behavior",
+  "cycles": []
+}
+```
+
+**Documented valid reasons:**
+- Config-only changes (vite.config, tsconfig, etc.)
+- File moves/renames with no behavior change
+- Non-testable infrastructure changes
+
+**Validation:** Currently accepts any non-empty string. See [GH-258](https://github.com/tigredonorte/claude-plugin-work/issues/258) for planned hardening.
+
+## File Gating Hook
+
+**File:** `workflows/work-implement/hooks/work-implement-enforce.js`
+
+This PreToolUse hook blocks file edits based on the current TDD phase:
+
+| Phase | Write/Edit to test file | Write/Edit to source file |
+|---|---|---|
+| RED | ALLOW | BLOCK |
+| GREEN | BLOCK (except helpers) | ALLOW |
+| REFACTOR | ALLOW | ALLOW |
+| exception | ALLOW | ALLOW |
+
+**Test file detection** (`tdd-phase-registry.js`):
+- `.test.ts`, `.test.tsx`, `.test.js`, `.test.jsx`
+- `.spec.ts`, `.spec.tsx`, `.spec.js`, `.spec.jsx`
+
+**Test helper detection:**
+- `__mocks__/*`, `__fixtures__/*`
+- `test-utils.*`, `testing-library.*`
+- Files matching helper patterns are always writable
+
+## Evidence Validation
+
+**File:** `workflows/work/tdd-enforcement.js`
+
+The `/work` orchestrator validates TDD evidence before allowing transition out of `implement`:
+
+```javascript
+function validateTddEvidence(evidence) {
+  // Exception mode: valid if reason is non-empty
+  if (typeof evidence.exception === 'string' && evidence.exception.trim() !== '') {
+    return { valid: true, reason: '' };
+  }
+  // Normal mode: at least one cycle with red + green evidence
+  if (!Array.isArray(evidence.cycles) || evidence.cycles.length === 0) {
+    return { valid: false, reason: 'No TDD cycles recorded' };
+  }
+  return evidence.cycles.some(c => c.red && c.green)
+    ? { valid: true, reason: '' }
+    : { valid: false, reason: 'No complete RED→GREEN cycle' };
+}
+```

--- a/docs/workflow-work-implement.md
+++ b/docs/workflow-work-implement.md
@@ -27,7 +27,7 @@ RED ──────────► GREEN ──────────► RE
 
 **Hook enforcement:** Blocks Write/Edit to non-test files.
 
-**Allowed files:** `*.test.ts`, `*.test.tsx`, `*.spec.ts`, `*.spec.tsx` (only files matching `.test.*` or `.spec.*` patterns — helpers like `__mocks__/` are blocked in RED)
+**Allowed files:** Files matching `/\.test\.[jt]sx?$/` or `/\.spec\.[jt]sx?$/` — i.e., `*.test.ts`, `*.test.tsx`, `*.test.js`, `*.test.jsx`, `*.spec.ts`, `*.spec.tsx`, `*.spec.js`, `*.spec.jsx`. Helpers (`__mocks__/`, `__fixtures__/`, `test-utils/`) are blocked in RED.
 
 **Evidence required:** Test files changed + test command exits with non-zero code.
 
@@ -154,10 +154,10 @@ This PreToolUse hook blocks file edits based on the current TDD phase:
 - `.test.ts`, `.test.tsx`, `.test.js`, `.test.jsx`
 - `.spec.ts`, `.spec.tsx`, `.spec.js`, `.spec.jsx`
 
-**Test helper detection:**
+**Test helper detection** (from `TEST_HELPER_PATTERNS`):
 - `__mocks__/*`, `__fixtures__/*`
-- `test-utils.*`, `testing-library.*`
-- Files matching helper patterns are always writable
+- `test-utils/`, `test-utils.[jt]sx?`, `test-helper/`
+- Helpers are writable in GREEN and REFACTOR, but blocked in RED
 
 ## Evidence Validation
 

--- a/docs/workflow-work-implement.md
+++ b/docs/workflow-work-implement.md
@@ -27,7 +27,7 @@ RED ──────────► GREEN ──────────► RE
 
 **Hook enforcement:** Blocks Write/Edit to non-test files.
 
-**Allowed files:** `*.test.ts`, `*.test.tsx`, `*.spec.ts`, `*.spec.tsx`, `__mocks__/*`, `__fixtures__/*`, `test-utils/*`
+**Allowed files:** `*.test.ts`, `*.test.tsx`, `*.spec.ts`, `*.spec.tsx` (only files matching `.test.*` or `.spec.*` patterns — helpers like `__mocks__/` are blocked in RED)
 
 **Evidence required:** Test files changed + test command exits with non-zero code.
 
@@ -37,7 +37,7 @@ RED ──────────► GREEN ──────────► RE
 
 **Hook enforcement:** Blocks Write/Edit to test files (except helpers).
 
-**Allowed files:** All non-test source files.
+**Allowed files:** All non-test source files, plus test helpers (`__mocks__/*`, `__fixtures__/*`, `test-utils/*`).
 
 **Evidence required:** Test command exits with code 0.
 

--- a/docs/workflow-work-implement.md
+++ b/docs/workflow-work-implement.md
@@ -74,7 +74,7 @@ node tdd-phase-state.js record-green TICKET-123 --task 1 --cmd "npm test"
 node tdd-phase-state.js record-refactor TICKET-123 --task 1 --cmd "npm test"
 
 # Transition to next phase
-node tdd-phase-state.js transition TICKET-123 --task 1 green
+node tdd-phase-state.js transition TICKET-123 green --task 1
 
 # Exception mode (skip TDD for mechanical changes)
 node tdd-phase-state.js exception TICKET-123 --task 1 --reason "config-only change"

--- a/docs/workflow-work-pr.md
+++ b/docs/workflow-work-pr.md
@@ -45,9 +45,9 @@ Generates a well-structured PR description from git diffs and adds visual docume
 
 `TASKS_BASE/<ticket>/.work-pr.workflow-state.json`
 
-## Workflow Steps
+## Agent-Executed Steps
 
-The full workflow includes orchestration steps (preflight, setup, screenshot gating, summary). The two agent-executed steps are:
+The full `/work-pr` workflow also includes orchestration steps (preflight, setup, screenshot gating, summary). The two agent-executed steps are:
 
 1. **pr-generator** — Create/update PR description
 2. **pr-post-generator** — Add visual documentation (screenshots, recordings)

--- a/docs/workflow-work-pr.md
+++ b/docs/workflow-work-pr.md
@@ -1,0 +1,51 @@
+# /work-pr Workflow
+
+PR description generation and visual documentation workflow.
+
+## Invocation
+
+```
+/work-pr TICKET-123
+```
+
+Also invoked automatically as part of `/work` at the `pr` step.
+
+## Purpose
+
+Generates a well-structured PR description from git diffs and adds visual documentation (screenshots, GIFs) to the PR.
+
+## Agents
+
+### pr-generator
+
+**Role:** Generate PR title and description from git diffs.
+
+**Actions:**
+1. Check if branch is in sync with main, rebase if needed
+2. Analyze code changes (entire branch diff or last commit)
+3. Create PR via `gh pr create` with structured description:
+   - Summary (1-3 bullet points)
+   - Test plan (checklist)
+   - Ticket reference
+
+**Diff selection:**
+- Last commit only → `git show HEAD`
+- Entire branch → `git diff origin/main...HEAD`
+
+### pr-post-generator
+
+**Role:** Add visual documentation to PR.
+
+**Actions:**
+1. Read QA reports and screenshots from tasks folder
+2. Upload images to wiki
+3. Update PR description with wiki link
+
+## State File
+
+`TASKS_BASE/<ticket>/.work-pr-state.json`
+
+## Workflow Steps
+
+1. **pr-generator** — Create/update PR description
+2. **pr-post-generator** — Add visual documentation (screenshots, recordings)

--- a/docs/workflow-work-pr.md
+++ b/docs/workflow-work-pr.md
@@ -43,9 +43,11 @@ Generates a well-structured PR description from git diffs and adds visual docume
 
 ## State File
 
-`TASKS_BASE/<ticket>/.work-pr-state.json`
+`TASKS_BASE/<ticket>/.work-pr.workflow-state.json`
 
 ## Workflow Steps
+
+The full workflow includes orchestration steps (preflight, setup, screenshot gating, summary). The two agent-executed steps are:
 
 1. **pr-generator** — Create/update PR description
 2. **pr-post-generator** — Add visual documentation (screenshots, recordings)

--- a/docs/workflow-work.md
+++ b/docs/workflow-work.md
@@ -1,0 +1,268 @@
+# /work Workflow
+
+The main orchestrator workflow that drives ticket-to-PR delivery through 17 deterministic steps.
+
+## Invocation
+
+```
+/work TICKET-123
+/work TICKET-123 "Optional description"
+```
+
+## Step Details
+
+### 1. ticket
+
+**Purpose:** Initialize work state and read ticket information.
+
+**Actions:**
+- Create `.work-state.json` with all steps set to `pending`
+- Read ticket details from provider (Jira, Linear, GitHub)
+- Store ticket description in state
+
+**Verification:** `.work-state.json` exists and `status === 'in_progress'`
+
+### 2. bootstrap
+
+**Purpose:** Create git worktree and feature branch.
+
+**Actions:**
+- Create worktree at `WORKTREES_BASE/<repo>-<ticket>/`
+- Create branch containing ticket ID
+- Copy credentials, symlink configs
+- Initialize codegraph if applicable
+- Optionally open draft PR
+
+**Verification:** Current git branch name contains ticket ID
+
+**Deferrable:** Yes — if already on the correct branch, this step is skipped
+
+### 3. brief
+
+**Purpose:** Generate a structured product brief from ticket requirements.
+
+**Agent:** `brief-writer`
+
+**Actions:**
+- Read ticket details
+- Analyze requirements, constraints, dependencies
+- Generate `brief.md` with sections: Problem, Goal, Requirements (P0/P1/P2), Constraints, Scope, Success Metrics, Open Questions
+
+**Verification:** `brief.md` exists in tasks directory
+
+**Output:** `tasks/<ticket>/brief.md`
+
+### 4. brief_gate (GH-215)
+
+**Purpose:** Block spec generation until all blocking open questions in the brief are resolved.
+
+**Actions:**
+- Parse `brief.md` for open questions
+- Check each question: scope (cross-ticket vs local) and resolved status
+- Block if any cross-ticket/architectural questions are unresolved
+
+**Verification:** `brief.md` exists AND no blocking open questions remain
+
+**Blocking behavior:** Uses `AskUserQuestion` to present unresolved questions to the user
+
+### 5. spec
+
+**Purpose:** Generate a technical specification from the brief and codebase analysis.
+
+**Agent:** `spec-writer`
+
+**Actions:**
+- Read brief.md
+- Explore codebase (architecture, patterns, existing code)
+- Generate `spec.md` with: Architecture decisions, API changes, Security considerations, Gherkin test scenarios, Reuse audit, Verification checklist
+
+**Verification:** `spec.md` exists
+
+**Output:** `tasks/<ticket>/spec.md`
+
+### 6. tasks
+
+**Purpose:** Split the spec into ordered, deliverable tasks with requirement traceability.
+
+**Skill:** `/split-in-tasks`
+
+**Actions:**
+- Parse spec.md
+- Generate `tasks.md` with numbered tasks, dependencies, deliverables
+- Each task follows RED → GREEN → REFACTOR TDD ordering
+- Initialize `tasksMeta` in state with task count
+
+**Verification:** `tasks.md` exists
+
+**Output:** `tasks/<ticket>/tasks.md`
+
+### 7. implement
+
+**Purpose:** Code implementation following TDD discipline.
+
+**Agents:** `developer-nodejs-tdd`, `developer-react-senior`, `developer-react-ui-architect`, `developer-devops` (auto-selected based on file types)
+
+**TDD Cycle per task:**
+1. **RED:** Write failing tests (hook blocks non-test file edits)
+2. **GREEN:** Implement code to pass tests (hook blocks test file edits)
+3. **REFACTOR:** Clean up (all edits allowed)
+
+**Evidence:** `tdd-phase.json` with at least one cycle containing `red` + `green` evidence
+
+**Per-task loop:** When `tasks.md` exists, implement runs for each task sequentially:
+```
+task 1: implement → commit → task_review → advance
+task 2: implement → commit → task_review → advance
+...
+task N: implement → commit → task_review → check
+```
+
+**Exception mode:** For config-only/mechanical changes, `tdd-phase-state.js exception` records a reason and bypasses TDD. See [TDD Enforcement](./tdd-enforcement.md).
+
+### 8. commit
+
+**Purpose:** Commit implemented changes.
+
+**Agent:** `commit-writer`
+
+**Actions:**
+- Stage relevant files
+- Generate semantic commit message
+- Create commit (with autonomous flag — no confirmation prompt)
+
+**Verification:** HEAD has new non-empty commits compared to base branch
+
+### 9. task_review (GH-211)
+
+**Purpose:** Per-task code review after each commit.
+
+**Soft step** — advisory, does not hard-block progression.
+
+**Actions:**
+- Run lightweight tests review on the task's diff
+- Run code review on the task's diff
+- Generate task-review artifacts
+
+**Fix rounds:** If issues found, loop back to implement (max `TASK_REVIEW_MAX_FIXES` rounds, default 2)
+
+**Verification:** Review artifacts exist (`task-review-tests.md` or `task-review-code.md`)
+
+### 10. check
+
+**Purpose:** Full quality verification across all tasks.
+
+**Delegates to:** `/check` workflow (see [/check Workflow](./workflow-check.md))
+
+**Reports required:**
+- `code-review.check.md` (APPROVED)
+- `tests.check.md` (APPROVED)
+- `completion.check.md` (APPROVED/COMPLETE)
+- At least one `qa-*.check.md` (APPROVED)
+- `README.md` (summary with changes hash)
+
+**Verification:** All required report files exist
+
+### 11. pr
+
+**Purpose:** Create or update the pull request.
+
+**Agent:** `pr-generator`
+
+**Actions:**
+- Analyze full branch diff
+- Generate PR title and description
+- Create PR via `gh pr create` or update via `gh pr edit`
+
+**Verification:** Open PR exists for current branch (`gh pr view`)
+
+### 12. ready
+
+**Purpose:** Mark PR as ready for review.
+
+**Soft step** — user/agent signals readiness.
+
+### 13. follow_up
+
+**Purpose:** Monitor PR for CI status and review comments.
+
+**Actions:**
+- Check PR comments (Copilot, human reviewers)
+- Build `review-accountability.json` — every comment must be accounted for
+- Dispositions: `fixed`, `acknowledged` (requires user approval), `not_applicable`
+- If code changes needed: loop back to implement
+
+**Verification:** `isPRGateReady()` returns true AND all comments accounted for
+
+### 14. ci
+
+**Purpose:** Verify CI checks pass.
+
+**Verification:** `gh pr checks` shows all checks passing
+
+**Retry:** If CI fails, loop back to implement to fix
+
+### 15. cleanup
+
+**Purpose:** Remove development server sessions.
+
+**Actions:**
+- Kill tmux session `<ticket>-dev`
+- Clean up any running processes
+
+**Verification:** No tmux session exists for this ticket
+
+### 16. reports
+
+**Purpose:** Validate final approval status.
+
+**Verification:** All check reports contain `Status: APPROVED` or `Status: COMPLETE`. At least one QA report exists and passes.
+
+### 17. complete
+
+**Purpose:** Terminal step.
+
+**Soft step** — marks state as `completed`. Self-loop allows retry on partial failure (GH-106).
+
+## Multi-Task Mode
+
+When `tasks.md` exists with multiple tasks, the implement/commit/task_review cycle runs per-task:
+
+```
+                  ┌────────────────────────┐
+                  ▼                        │
+Task N: implement → commit → task_review ──┘ (if fix needed)
+                                    │
+                                    ▼ (pass)
+                            task-advance
+                                    │
+                                    ▼
+                            Next task or → check
+```
+
+State tracking:
+- `tasksMeta.currentTaskIndex` — 0-indexed pointer
+- `tasksMeta.tasks[i].status` — `pending`, `in_progress`, `completed`
+- `tasksMeta.tasks[i].taskReviewFixRounds` — Fix round counter (resets per task)
+
+## Plan Actions
+
+The orchestrator generates a plan before each iteration:
+
+| Action | Meaning | When |
+|---|---|---|
+| `RUN` | Execute this step | Step not yet verified |
+| `SKIP` | Already done | Step verified (file exists, git state correct) |
+| `DEFER` | Wait for prerequisites | Step depends on unfinished work |
+
+## Deferred Steps
+
+Steps may be deferred when:
+- They were already completed in a previous context (e.g., bootstrap on resume)
+- The orchestrator marks them as not needing re-execution
+- Listed in `state.deferredSteps[]`
+
+## Error Handling
+
+- Errors are recorded in `state.errors[]` with `{step, error, timestamp}`
+- The orchestrator surfaces errors and may retry or escalate
+- Maximum retry attempts are step-specific (e.g., `TASK_REVIEW_MAX_FIXES=2`)

--- a/docs/workflow-work.md
+++ b/docs/workflow-work.md
@@ -4,7 +4,7 @@ The main orchestrator workflow that drives ticket-to-PR delivery through 18 dete
 
 ## Invocation
 
-```
+```bash
 /work TICKET-123
 /work TICKET-123 "Optional description"
 ```

--- a/docs/workflow-work.md
+++ b/docs/workflow-work.md
@@ -115,7 +115,7 @@ The main orchestrator workflow that drives ticket-to-PR delivery through 18 dete
 
 ### 8. implement
 
-**Purpose:** Code implementation following TDD discipline.
+**Purpose:** TDD-gated code implementation.
 
 **Agents:** `developer-nodejs-tdd`, `developer-react-senior`, `developer-react-ui-architect`, `developer-devops` (auto-selected based on file types)
 

--- a/docs/workflow-work.md
+++ b/docs/workflow-work.md
@@ -1,6 +1,6 @@
 # /work Workflow
 
-The main orchestrator workflow that drives ticket-to-PR delivery through 17 deterministic steps.
+The main orchestrator workflow that drives ticket-to-PR delivery through 18 deterministic steps.
 
 ## Invocation
 
@@ -80,7 +80,24 @@ The main orchestrator workflow that drives ticket-to-PR delivery through 17 dete
 
 **Output:** `tasks/<ticket>/spec.md`
 
-### 6. tasks
+### 6. spec_gate (GH-244)
+
+**Purpose:** Validate Gherkin test scenarios in the spec before task decomposition.
+
+**Actions:**
+- Parse `spec.md` for Gherkin test scenario blocks
+- Validate syntax and structure via `parse-gherkin.js`
+- Check for skip override (specs can declare Gherkin validation not applicable)
+
+**Verification:** One of:
+- Spec is disabled (`WORK_SPEC_ENABLED=0`)
+- `spec.md` doesn't exist (step SKIPs)
+- Skip override is present in spec
+- `parse()` + `validate()` passes with no errors
+
+**Retry:** On failure, loops back to `spec` to regenerate (`spec_gate → spec`)
+
+### 7. tasks
 
 **Purpose:** Split the spec into ordered, deliverable tasks with requirement traceability.
 
@@ -96,7 +113,7 @@ The main orchestrator workflow that drives ticket-to-PR delivery through 17 dete
 
 **Output:** `tasks/<ticket>/tasks.md`
 
-### 7. implement
+### 8. implement
 
 **Purpose:** Code implementation following TDD discipline.
 
@@ -119,7 +136,7 @@ task N: implement → commit → task_review → check
 
 **Exception mode:** For config-only/mechanical changes, `tdd-phase-state.js exception` records a reason and bypasses TDD. See [TDD Enforcement](./tdd-enforcement.md).
 
-### 8. commit
+### 9. commit
 
 **Purpose:** Commit implemented changes.
 
@@ -132,7 +149,7 @@ task N: implement → commit → task_review → check
 
 **Verification:** HEAD has new non-empty commits compared to base branch
 
-### 9. task_review (GH-211)
+### 10. task_review (GH-211)
 
 **Purpose:** Per-task code review after each commit.
 
@@ -147,7 +164,7 @@ task N: implement → commit → task_review → check
 
 **Verification:** Review artifacts exist (`task-review-tests.md` or `task-review-code.md`)
 
-### 10. check
+### 11. check
 
 **Purpose:** Full quality verification across all tasks.
 
@@ -162,7 +179,7 @@ task N: implement → commit → task_review → check
 
 **Verification:** All required report files exist
 
-### 11. pr
+### 12. pr
 
 **Purpose:** Create or update the pull request.
 
@@ -175,13 +192,13 @@ task N: implement → commit → task_review → check
 
 **Verification:** Open PR exists for current branch (`gh pr view`)
 
-### 12. ready
+### 13. ready
 
 **Purpose:** Mark PR as ready for review.
 
 **Soft step** — user/agent signals readiness.
 
-### 13. follow_up
+### 14. follow_up
 
 **Purpose:** Monitor PR for CI status and review comments.
 
@@ -193,7 +210,7 @@ task N: implement → commit → task_review → check
 
 **Verification:** `isPRGateReady()` returns true AND all comments accounted for
 
-### 14. ci
+### 15. ci
 
 **Purpose:** Verify CI checks pass.
 
@@ -201,7 +218,7 @@ task N: implement → commit → task_review → check
 
 **Retry:** If CI fails, loop back to implement to fix
 
-### 15. cleanup
+### 16. cleanup
 
 **Purpose:** Remove development server sessions.
 
@@ -211,13 +228,13 @@ task N: implement → commit → task_review → check
 
 **Verification:** No tmux session exists for this ticket
 
-### 16. reports
+### 17. reports
 
 **Purpose:** Validate final approval status.
 
 **Verification:** All check reports contain `Status: APPROVED` or `Status: COMPLETE`. At least one QA report exists and passes.
 
-### 17. complete
+### 18. complete
 
 **Purpose:** Terminal step.
 

--- a/docs/workflow-work.md
+++ b/docs/workflow-work.md
@@ -258,7 +258,7 @@ Task N: implement → commit → task_review ──┘ (if fix needed)
 
 State tracking:
 - `tasksMeta.currentTaskIndex` — 0-indexed pointer
-- `tasksMeta.tasks[i].status` — `pending`, `in_progress`, `completed`
+- `tasksMeta.tasks[i].status` — `pending` or `completed` (active task is identified by `currentTaskIndex`, not a separate status)
 - `tasksMeta.tasks[i].taskReviewFixRounds` — Fix round counter (resets per task)
 
 ## Plan Actions


### PR DESCRIPTION
## Existing Behavior

- The plugin has no developer-facing documentation beyond code comments and inline markdown in agent/skill files.
- Copilot code review instructions had no reference to codebase structure or design principles.
- Contributors and reviewers had no single entry point to understand the system's architecture, state machine, hook lifecycle, or agent dispatch logic.

## Intended New Behavior

- A new `docs/` directory provides 11 structured reference documents covering the full plugin surface area: architecture, state machine, hooks, TDD enforcement, artifact management, configuration, workflows, agents, and skills.
- `docs/README.md` serves as a documentation index with a quick-reference step order, key directory map, and state file inventory.
- `.github/copilot-instructions.md` now links to `docs/README.md` so Copilot has structural context during code review.
- All documents cross-reference each other and link to related GitHub issues (GH-106, GH-206, GH-207, GH-211, GH-215, GH-219, GH-258, GH-259) for traceability.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a docs-only change. To verify:

1. Browse to `docs/README.md` in the repository — confirm all 11 linked documents render correctly with working relative links.
2. Open any individual doc (e.g., `docs/architecture.md`) — confirm the ASCII diagrams, tables, and code blocks render as expected in GitHub Markdown.
3. Check `.github/copilot-instructions.md` — confirm the Architecture Reference line with the link to `docs/README.md` is present at the top of the file.
4. Verify no source code, test files, or configuration files were modified by this PR (`git diff origin/main...HEAD --name-only` should list only `docs/` and `.github/copilot-instructions.md`).