### PR TITLE
feat(GH-253): make brief, spec, and tasks generation mandatory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,12 +46,6 @@ GITHUB_ORG=
 
 # ─── Workflow Control ─────────────────────────────────────────────────────
 
-# Enable product brief generation before implementation (default: enabled)
-# WORK_BRIEF_ENABLED=1
-
-# Enable technical spec generation before implementation (default: enabled)
-# WORK_SPEC_ENABLED=1
-
 # Enable code-architect routing in /work-implement (default: disabled)
 # WORK_ARCHITECT_ENABLED=0
 

--- a/workflows/work/__tests__/plan-generator-brief-gate.test.js
+++ b/workflows/work/__tests__/plan-generator-brief-gate.test.js
@@ -154,10 +154,10 @@ describe('plan-generator brief_gate ordering (GH-215 Task 6.2)', () => {
     assert.equal(specIdx, gateIdx + 1);
   });
 
-  it('keeps brief_gate in the plan even when brief step is disabled', () => {
-    // WORK_BRIEF_ENABLED=0 makes brief step DEFER; the gate also DEFERs for
-    // the same reason, but both entries must still appear in order so the
-    // workflow state machine can advance through brief_gate.
+  it('keeps brief_gate in the plan even when WORK_BRIEF_ENABLED=0 (toggle is ignored)', () => {
+    // GH-253 Task 4: WORK_BRIEF_ENABLED toggle removed — setting it to '0'
+    // has no effect. Both entries must still appear in order so the workflow
+    // state machine can advance through brief_gate.
     const prev = process.env.WORK_BRIEF_ENABLED;
     process.env.WORK_BRIEF_ENABLED = '0';
     try {

--- a/workflows/work/__tests__/plan-generator-no-toggles.test.js
+++ b/workflows/work/__tests__/plan-generator-no-toggles.test.js
@@ -1,0 +1,217 @@
+/**
+ * Tests for GH-253 Task 4: Remove toggle variables from plan-generator.js
+ *
+ * Verifies:
+ * 1. plan-generator.js source does not reference WORK_BRIEF_ENABLED,
+ *    WORK_SPEC_ENABLED, or WORK_TASKS_ENABLED
+ * 2. planningDocs always includes brief/spec/tasks paths when artifacts
+ *    are missing (no "disabled" conditional)
+ * 3. No plan entry ever has a reason containing "disabled"
+ *
+ * Run: node --test workflows/work/__tests__/plan-generator-no-toggles.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+
+const { generatePlan } = require(path.join(__dirname, '..', 'plan-generator'));
+const { STEPS } = require(path.join(__dirname, '..', 'step-registry'));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeDeps(overrides = {}) {
+  return {
+    tp: {
+      sanitizeTicketIdForPath: (t) => t,
+      getProviderConfig: () => ({}),
+      getCreateTicketAgentType: () => 'general-purpose',
+      getCreateTicketPrompt: () => null,
+      getFetchTicketPrompt: () => 'Fetch ticket TEST-100 details.',
+      getTransitionPrompt: () => 'Move ticket to In Development',
+    },
+    TDD_PROTOCOL: '',
+    TDD_GATED_STEPS: [],
+    STEPS,
+    parseTasks: () => [],
+    buildTaskPrompt: () => '',
+    fileExists: () => false,
+    run: () => '',
+    WORKTREES_BASE: '/tmp/worktrees',
+    TASKS_BASE: '/tmp/tasks',
+    MAIN_WORKTREE_FOLDER: 'my-project',
+    ...overrides,
+  };
+}
+
+function makeState(overrides = {}) {
+  return {
+    worktreeExists: true,
+    tasksDirExists: true,
+    hasStateFile: false,
+    currentStep: 'brief',
+    worktreeDir: '/tmp/worktrees/my-project-TEST-100',
+    tasksDir: '/tmp/tasks/TEST-100',
+    branch: null,
+    headSha: null,
+    hasDiffVsMain: false,
+    diffSummary: '',
+    hasCommitWithTicket: false,
+    hasUncommitted: false,
+    uncommittedCount: 0,
+    hasUnpushed: false,
+    lastCommitMsg: '',
+    pr: { number: 1 },
+    reports: {},
+    allReportsPass: true,
+    missingReports: [],
+    failedReports: [],
+    prUpdateSha: null,
+    postPrUpdateSha: null,
+    prEverUpdated: false,
+    prShaMatch: false,
+    hasBrief: false,
+    hasSpec: false,
+    hasTasks: false,
+    hasDevSession: false,
+    workState: null,
+    stepIs: () => 'unknown',
+    ...overrides,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('GH-253 Task 4: plan-generator.js toggle removal', () => {
+  const planGenSource = fs.readFileSync(
+    path.join(__dirname, '..', 'plan-generator.js'),
+    'utf8'
+  );
+
+  it('does not reference WORK_BRIEF_ENABLED in source code', () => {
+    assert.ok(
+      !planGenSource.includes('WORK_BRIEF_ENABLED'),
+      'plan-generator.js must not contain WORK_BRIEF_ENABLED'
+    );
+  });
+
+  it('does not reference WORK_SPEC_ENABLED in source code', () => {
+    assert.ok(
+      !planGenSource.includes('WORK_SPEC_ENABLED'),
+      'plan-generator.js must not contain WORK_SPEC_ENABLED'
+    );
+  });
+
+  it('does not reference WORK_TASKS_ENABLED in source code', () => {
+    assert.ok(
+      !planGenSource.includes('WORK_TASKS_ENABLED'),
+      'plan-generator.js must not contain WORK_TASKS_ENABLED'
+    );
+  });
+
+  it('does not declare briefEnabled, specEnabled, or tasksEnabled variables', () => {
+    assert.ok(
+      !planGenSource.includes('briefEnabled'),
+      'plan-generator.js must not declare briefEnabled'
+    );
+    assert.ok(
+      !planGenSource.includes('specEnabled'),
+      'plan-generator.js must not declare specEnabled'
+    );
+    assert.ok(
+      !planGenSource.includes('tasksEnabled'),
+      'plan-generator.js must not declare tasksEnabled'
+    );
+  });
+});
+
+describe('GH-253 Task 4: plan never contains "disabled" reason', () => {
+  const savedEnv = {};
+
+  beforeEach(() => {
+    savedEnv.WORK_BRIEF_ENABLED = process.env.WORK_BRIEF_ENABLED;
+    savedEnv.WORK_SPEC_ENABLED = process.env.WORK_SPEC_ENABLED;
+    savedEnv.WORK_TASKS_ENABLED = process.env.WORK_TASKS_ENABLED;
+    // Even if someone sets these to '0', the plan should NOT contain "disabled"
+    process.env.WORK_BRIEF_ENABLED = '0';
+    process.env.WORK_SPEC_ENABLED = '0';
+    process.env.WORK_TASKS_ENABLED = '0';
+  });
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  it('no plan entry has a reason containing "disabled" when artifacts missing', () => {
+    const state = makeState({ hasBrief: false, hasSpec: false, hasTasks: false });
+    const { plan } = generatePlan('TEST-100', null, state, false, null, null, makeDeps());
+
+    const disabledEntries = plan.filter(
+      (e) => typeof e.reason === 'string' && e.reason.toLowerCase().includes('disabled')
+    );
+    assert.equal(
+      disabledEntries.length,
+      0,
+      `No plan entry should have "disabled" in reason, but found: ${JSON.stringify(disabledEntries)}`
+    );
+  });
+
+  it('always includes RUN entries for brief and spec when artifacts are missing', () => {
+    const state = makeState({ hasBrief: false, hasSpec: false, hasTasks: false });
+    const { plan } = generatePlan('TEST-100', null, state, false, null, null, makeDeps());
+
+    const briefEntry = plan.find((e) => e.step === STEPS.brief);
+    const specEntry = plan.find((e) => e.step === STEPS.spec);
+    const tasksEntry = plan.find((e) => e.step === STEPS.tasks);
+
+    assert.ok(briefEntry, 'plan must contain a brief entry');
+    assert.ok(specEntry, 'plan must contain a spec entry');
+    assert.ok(tasksEntry, 'plan must contain a tasks entry');
+
+    // brief/spec should be RUN when artifacts are missing
+    assert.equal(briefEntry.action, 'RUN', 'brief should be RUN when artifact missing');
+    assert.equal(specEntry.action, 'RUN', 'spec should be RUN when artifact missing');
+    // tasks DEFERs when spec.md is absent (dependency not met) — that is correct behavior
+    assert.equal(tasksEntry.action, 'DEFER', 'tasks should DEFER when spec.md dependency is absent');
+  });
+
+  it('includes RUN for tasks when spec exists but tasks.md is missing', () => {
+    const state = makeState({ hasBrief: true, hasSpec: true, hasTasks: false });
+    // fileExists returns true for spec.md path so tasks step can RUN
+    const specPath = '/tmp/tasks/TEST-100/spec.md';
+    const { plan } = generatePlan('TEST-100', null, state, false, null, null, makeDeps({
+      fileExists: (p) => p === specPath || p === '/tmp/tasks/TEST-100',
+    }));
+
+    const tasksEntry = plan.find((e) => e.step === STEPS.tasks);
+    assert.ok(tasksEntry, 'plan must contain a tasks entry');
+    assert.equal(tasksEntry.action, 'RUN', 'tasks should be RUN when spec exists but tasks.md missing');
+  });
+});
+
+describe('GH-253 Task 4: .env.example toggle removal', () => {
+  const envExampleSource = fs.readFileSync(
+    path.join(__dirname, '..', '..', '..', '.env.example'),
+    'utf8'
+  );
+
+  it('does not contain WORK_BRIEF_ENABLED', () => {
+    assert.ok(
+      !envExampleSource.includes('WORK_BRIEF_ENABLED'),
+      '.env.example must not contain WORK_BRIEF_ENABLED'
+    );
+  });
+
+  it('does not contain WORK_SPEC_ENABLED', () => {
+    assert.ok(
+      !envExampleSource.includes('WORK_SPEC_ENABLED'),
+      '.env.example must not contain WORK_SPEC_ENABLED'
+    );
+  });
+});

--- a/workflows/work/__tests__/workflow-definition.test.js
+++ b/workflows/work/__tests__/workflow-definition.test.js
@@ -478,11 +478,16 @@ describe('workflow-definition: verify[STEPS.spec] (no toggle)', () => {
   });
 
   it('does not auto-verify when WORK_SPEC_ENABLED=0 (toggle removed)', () => {
-    process.env.WORK_SPEC_ENABLED = '0';
-    const verify = getSpecVerify();
-    // spec.md does not exist, so verify should return false regardless of env
-    assert.equal(verify(ticketId), false);
-    delete process.env.WORK_SPEC_ENABLED;
+    const saved = process.env.WORK_SPEC_ENABLED;
+    try {
+      process.env.WORK_SPEC_ENABLED = '0';
+      const verify = getSpecVerify();
+      // spec.md does not exist, so verify should return false regardless of env
+      assert.equal(verify(ticketId), false);
+    } finally {
+      if (saved === undefined) delete process.env.WORK_SPEC_ENABLED;
+      else process.env.WORK_SPEC_ENABLED = saved;
+    }
   });
 });
 

--- a/workflows/work/__tests__/workflow-definition.test.js
+++ b/workflows/work/__tests__/workflow-definition.test.js
@@ -436,6 +436,56 @@ describe('workflow-definition: brief.md contentGuard', () => {
   });
 });
 
+// ─── GH-253 Task 3: spec step verify (toggle removed) ────────────────────────
+describe('workflow-definition: verify[STEPS.spec] (no toggle)', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'workflow-def-spec-notoggle-'));
+  const ticketId = 'GH-253';
+  const ticketDir = path.join(tmpRoot, ticketId);
+  fs.mkdirSync(ticketDir, { recursive: true });
+
+  const deps = {
+    TASKS_BASE: tmpRoot,
+    safeTicketPath: (id) => id,
+    resolveGitHead: () => 'ref: refs/heads/stub',
+  };
+  const { workflow: specWf } = createWorkflowDefinition(deps);
+
+  function getSpecVerify() {
+    const entries = specWf.commandMap.filter(
+      (e) => e.step === STEPS.spec && typeof e.verify === 'function'
+    );
+    return entries.length > 0 ? entries[0].verify : undefined;
+  }
+
+  after(() => {
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+
+  it('returns false when spec.md does not exist', () => {
+    const verify = getSpecVerify();
+    assert.equal(verify(ticketId), false);
+  });
+
+  it('returns true when spec.md exists', () => {
+    fs.writeFileSync(path.join(ticketDir, 'spec.md'), '# Spec\nContent');
+    const verify = getSpecVerify();
+    assert.equal(verify(ticketId), true);
+    fs.unlinkSync(path.join(ticketDir, 'spec.md'));
+  });
+
+  it('does not auto-verify when WORK_SPEC_ENABLED=0 (toggle removed)', () => {
+    process.env.WORK_SPEC_ENABLED = '0';
+    const verify = getSpecVerify();
+    // spec.md does not exist, so verify should return false regardless of env
+    assert.equal(verify(ticketId), false);
+    delete process.env.WORK_SPEC_ENABLED;
+  });
+});
+
 // ─── GH-244: spec_gate verify entry ──────────────────────────────────────────
 describe('workflow-definition: verify[STEPS.spec_gate]', () => {
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'workflow-def-specgate-'));
@@ -471,21 +521,15 @@ describe('workflow-definition: verify[STEPS.spec_gate]', () => {
     } catch {
       /* best-effort cleanup */
     }
-    // Restore env
-    delete process.env.WORK_SPEC_ENABLED;
   });
 
-  it('returns true when WORK_SPEC_ENABLED=0 (gate auto-verified)', () => {
-    process.env.WORK_SPEC_ENABLED = '0';
-    const verify = getSpecGateVerify();
-    assert.equal(verify(ticketId), true);
-    delete process.env.WORK_SPEC_ENABLED;
-  });
+  // GH-253 Task 3: WORK_SPEC_ENABLED toggle removed — spec is always mandatory.
+  // verifySpecGate no longer checks process.env.WORK_SPEC_ENABLED.
 
-  it('returns true when spec.md does not exist (nothing to validate)', () => {
+  it('returns false when spec.md does not exist (fail-closed)', () => {
     removeSpec();
     const verify = getSpecGateVerify();
-    assert.equal(verify(ticketId), true);
+    assert.equal(verify(ticketId), false);
   });
 
   it('returns true when skip override <!-- gherkin-skip: reason --> is present', () => {
@@ -542,6 +586,15 @@ describe('workflow-definition: verify[STEPS.spec_gate]', () => {
     );
     const verify = getSpecGateVerify();
     assert.equal(verify(ticketId), false);
+  });
+
+  // GH-253 Task 3: verify WORK_SPEC_ENABLED is not referenced anywhere in workflow-definition.js
+  it('does not reference WORK_SPEC_ENABLED in the module source', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'workflow-definition.js'), 'utf-8');
+    assert.ok(
+      !src.includes('WORK_SPEC_ENABLED'),
+      'workflow-definition.js should not reference WORK_SPEC_ENABLED'
+    );
   });
 
   it('returns false when parse has errors but validation would pass (malformed Gherkin)', () => {

--- a/workflows/work/plan-generator.js
+++ b/workflows/work/plan-generator.js
@@ -88,9 +88,6 @@ function generatePlan(ticket, description, s, rework, callerProviderCfg, suffix,
 
   // Planning docs discovery
   const providerConfig = tp.getProviderConfig({ skipPrompt: true });
-  const briefEnabled = process.env.WORK_BRIEF_ENABLED !== '0';
-  const specEnabled = process.env.WORK_SPEC_ENABLED !== '0';
-  const tasksEnabled = process.env.WORK_TASKS_ENABLED !== '0';
   const briefPath = path.join(tasksDir, 'brief.md');
   const specPath = path.join(tasksDir, 'spec.md');
   const tasksPath = path.join(tasksDir, 'tasks.md');
@@ -105,11 +102,11 @@ function generatePlan(ticket, description, s, rework, callerProviderCfg, suffix,
   }
   const planningDocs = [];
   if (fileExists(briefPath)) planningDocs.push(`- Brief: ${briefPath}`);
-  else if (briefEnabled) planningDocs.push(`- Brief (if present after brief step): ${briefPath}`);
+  else planningDocs.push(`- Brief (if present after brief step): ${briefPath}`);
   if (fileExists(specPath)) planningDocs.push(`- Spec: ${specPath}`);
-  else if (specEnabled) planningDocs.push(`- Spec (if present after spec step): ${specPath}`);
+  else planningDocs.push(`- Spec (if present after spec step): ${specPath}`);
   if (fileExists(tasksPath)) planningDocs.push(`- Tasks: ${tasksPath}`);
-  else if (tasksEnabled) planningDocs.push(`- Tasks (if present after tasks step): ${tasksPath}`);
+  else planningDocs.push(`- Tasks (if present after tasks step): ${tasksPath}`);
   prePlanningFiles.forEach((f) => planningDocs.push(`- Pre-planning: ${f}`));
   const planningContext =
     planningDocs.length > 0

--- a/workflows/work/steps/__tests__/brief-gate.test.js
+++ b/workflows/work/steps/__tests__/brief-gate.test.js
@@ -185,6 +185,27 @@ describe('brief-gate step', () => {
     assert.match(entry.agentPrompt, /applyBriefResolutions/, 'agentPrompt must mention applyBriefResolutions');
   });
 
+  it('RUN entry includes postResolveCommand referencing applyBriefResolutions', () => {
+    const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+    createdDirs.push(dir);
+    const { add, entries } = makeAdd();
+    briefGateStep(add, makeState(), makeCtx({ tasksDir: dir }));
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.action, 'RUN');
+    assert.equal(typeof entry.postResolveCommand, 'string', 'RUN entry must carry postResolveCommand string');
+    assert.match(entry.postResolveCommand, /applyBriefResolutions/, 'postResolveCommand must reference applyBriefResolutions');
+    assert.match(entry.postResolveCommand, /brief-gate\.js/, 'postResolveCommand must require brief-gate.js');
+    assert.match(entry.postResolveCommand, /\$RESOLUTIONS_JSON/, 'postResolveCommand must reference $RESOLUTIONS_JSON placeholder');
+    assert.match(entry.postResolveCommand, /node -e/, 'postResolveCommand must be a node -e one-liner');
+    // Verify the path includes the actual briefPath (tasks dir + brief.md)
+    const expectedBriefPath = path.join(dir, 'brief.md');
+    assert.ok(
+      entry.postResolveCommand.includes(expectedBriefPath),
+      `postResolveCommand must include briefPath: ${expectedBriefPath}`
+    );
+  });
+
   it('emits RUN (not SKIP) when brief.md is unreadable so planner shows gate needs attention', () => {
     const dir = makeTmpTasksDir(null); // no brief.md file
     createdDirs.push(dir);

--- a/workflows/work/steps/__tests__/brief-gate.test.js
+++ b/workflows/work/steps/__tests__/brief-gate.test.js
@@ -100,21 +100,13 @@ describe('brief-gate step', () => {
   let briefGateStep;
   let applyBriefResolutions;
   const createdDirs = [];
-  const originalEnv = process.env.WORK_BRIEF_ENABLED;
-
   before(() => {
     const mod = require(path.join(__dirname, '..', 'brief-gate.js'));
     briefGateStep = typeof mod === 'function' ? mod : mod.briefGateStep;
     applyBriefResolutions = mod.applyBriefResolutions;
   });
 
-  beforeEach(() => {
-    delete process.env.WORK_BRIEF_ENABLED;
-  });
-
   afterEach(() => {
-    if (originalEnv === undefined) delete process.env.WORK_BRIEF_ENABLED;
-    else process.env.WORK_BRIEF_ENABLED = originalEnv;
     while (createdDirs.length) rmrf(createdDirs.pop());
   });
 
@@ -122,14 +114,31 @@ describe('brief-gate step', () => {
     assert.equal(typeof briefGateStep, 'function');
   });
 
-  it('DEFERs when WORK_BRIEF_ENABLED=0', () => {
+  // GH-253 Task 4: WORK_BRIEF_ENABLED toggle removed — brief-gate no longer
+  // checks process.env.WORK_BRIEF_ENABLED.
+  it('does not reference WORK_BRIEF_ENABLED in source code', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'brief-gate.js'), 'utf8');
+    assert.ok(
+      !src.includes('WORK_BRIEF_ENABLED'),
+      'brief-gate.js must not contain WORK_BRIEF_ENABLED'
+    );
+  });
+
+  it('ignores WORK_BRIEF_ENABLED=0 and still evaluates brief.md normally', () => {
+    const prev = process.env.WORK_BRIEF_ENABLED;
     process.env.WORK_BRIEF_ENABLED = '0';
-    const { add, entries } = makeAdd();
-    briefGateStep(add, makeState(), makeCtx());
-    assert.equal(entries.length, 1);
-    assert.equal(entries[0].step, STEPS.brief_gate);
-    assert.equal(entries[0].action, 'DEFER');
-    assert.match(entries[0].reason, /disabled/i);
+    try {
+      const { add, entries } = makeAdd();
+      // hasBrief=false should DEFER with "No brief.md present", NOT "disabled"
+      briefGateStep(add, makeState({ hasBrief: false }), makeCtx());
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].step, STEPS.brief_gate);
+      assert.equal(entries[0].action, 'DEFER');
+      assert.match(entries[0].reason, /no brief/i);
+    } finally {
+      if (prev === undefined) delete process.env.WORK_BRIEF_ENABLED;
+      else process.env.WORK_BRIEF_ENABLED = prev;
+    }
   });
 
   it('DEFERs when no brief.md is present', () => {

--- a/workflows/work/steps/__tests__/brief.test.js
+++ b/workflows/work/steps/__tests__/brief.test.js
@@ -7,7 +7,7 @@
  * - Step DEFERs when brief.md already exists
  * - Step RUNs when brief.md is missing
  *
- * Run: npx vitest run workflows/work/steps/__tests__/brief.test.js
+ * Run: node --test workflows/work/steps/__tests__/brief.test.js
  */
 
 'use strict';

--- a/workflows/work/steps/__tests__/brief.test.js
+++ b/workflows/work/steps/__tests__/brief.test.js
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the brief step module (GH-253, Task 1).
+ *
+ * Verifies that:
+ * - The brief step never DEFERs with a "disabled" reason (toggle removed)
+ * - Setting WORK_BRIEF_ENABLED=0 has no effect (step still behaves normally)
+ * - Step DEFERs when brief.md already exists
+ * - Step RUNs when brief.md is missing
+ *
+ * Run: npx vitest run workflows/work/steps/__tests__/brief.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { STEPS } = require('../../step-registry');
+
+// ─── Test doubles ────────────────────────────────────────────────────────────
+
+function makeCtx(overrides = {}) {
+  return {
+    STEPS,
+    ticket: 'TEST-100',
+    description: null,
+    rework: false,
+    safeName: 'TEST-100',
+    worktreeDir: '/tmp/worktrees/my-project-TEST-100',
+    tasksDir: '/tmp/tasks/TEST-100',
+    t: 'TEST-100',
+    path,
+    fileExists: () => false,
+    getDocsPrompt: () => '',
+    ...overrides,
+  };
+}
+
+function makeState(overrides = {}) {
+  return {
+    worktreeExists: true,
+    hasBrief: false,
+    pr: null,
+    ...overrides,
+  };
+}
+
+function makeAdd() {
+  const entries = [];
+  const add = (step, action, command, reason, extra) => {
+    entries.push({ step, action, command, reason, ...(extra || {}) });
+  };
+  return { add, entries };
+}
+
+// ─── Suite ──────────────────────────────────────────────────────────────────
+
+describe('brief step (GH-253)', () => {
+  const originalEnv = process.env.WORK_BRIEF_ENABLED;
+
+  beforeEach(() => {
+    delete process.env.WORK_BRIEF_ENABLED;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.WORK_BRIEF_ENABLED;
+    else process.env.WORK_BRIEF_ENABLED = originalEnv;
+  });
+
+  it('never DEFERs with a "disabled" reason even when WORK_BRIEF_ENABLED=0', () => {
+    process.env.WORK_BRIEF_ENABLED = '0';
+    const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+    const { add, entries } = makeAdd();
+    briefStep(add, makeState(), makeCtx());
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    if (entry.action === 'DEFER') {
+      assert.ok(
+        !entry.reason.toLowerCase().includes('disabled'),
+        `brief step must not DEFER with "disabled" reason, got: "${entry.reason}"`
+      );
+    }
+  });
+
+  it('does not reference WORK_BRIEF_ENABLED in source code', () => {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'brief.js'), 'utf8');
+    assert.ok(
+      !source.includes('WORK_BRIEF_ENABLED'),
+      'brief.js must not contain WORK_BRIEF_ENABLED'
+    );
+  });
+
+  it('RUNs when brief.md is missing (hasBrief=false)', () => {
+    const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+    const { add, entries } = makeAdd();
+    briefStep(add, makeState({ hasBrief: false }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.brief);
+    assert.equal(entries[0].action, 'RUN');
+  });
+
+  it('DEFERs when brief.md already exists (hasBrief=true)', () => {
+    const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+    const { add, entries } = makeAdd();
+    briefStep(add, makeState({ hasBrief: true }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.brief);
+    assert.equal(entries[0].action, 'DEFER');
+    assert.match(entries[0].reason.toLowerCase(), /already exists/);
+  });
+
+  it('RUNs with correct agent type and prompt when brief is missing', () => {
+    const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+    const { add, entries } = makeAdd();
+    briefStep(add, makeState({ hasBrief: false }), makeCtx());
+    const entry = entries[0];
+    assert.equal(entry.agentType, 'brief-writer');
+    assert.match(entry.agentPrompt, /TEST-100/);
+    assert.match(entry.agentPrompt, /brief\.md/);
+  });
+
+  it('still RUNs when WORK_BRIEF_ENABLED=0 and brief is missing', () => {
+    process.env.WORK_BRIEF_ENABLED = '0';
+    const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+    const { add, entries } = makeAdd();
+    briefStep(add, makeState({ hasBrief: false }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'RUN');
+  });
+});

--- a/workflows/work/steps/__tests__/brief.test.js
+++ b/workflows/work/steps/__tests__/brief.test.js
@@ -17,6 +17,7 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const { STEPS } = require('../../step-registry');
+const briefStep = require('../brief.js');
 
 // ─── Test doubles ────────────────────────────────────────────────────────────
 
@@ -70,7 +71,7 @@ describe('brief step (GH-253)', () => {
 
   it('never DEFERs with a "disabled" reason even when WORK_BRIEF_ENABLED=0', () => {
     process.env.WORK_BRIEF_ENABLED = '0';
-    const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+
     const { add, entries } = makeAdd();
     briefStep(add, makeState(), makeCtx());
     assert.equal(entries.length, 1);
@@ -92,7 +93,7 @@ describe('brief step (GH-253)', () => {
   });
 
   it('RUNs when brief.md is missing (hasBrief=false)', () => {
-    const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+
     const { add, entries } = makeAdd();
     briefStep(add, makeState({ hasBrief: false }), makeCtx());
     assert.equal(entries.length, 1);
@@ -101,7 +102,7 @@ describe('brief step (GH-253)', () => {
   });
 
   it('DEFERs when brief.md already exists (hasBrief=true)', () => {
-    const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+
     const { add, entries } = makeAdd();
     briefStep(add, makeState({ hasBrief: true }), makeCtx());
     assert.equal(entries.length, 1);
@@ -111,7 +112,7 @@ describe('brief step (GH-253)', () => {
   });
 
   it('RUNs with correct agent type and prompt when brief is missing', () => {
-    const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+
     const { add, entries } = makeAdd();
     briefStep(add, makeState({ hasBrief: false }), makeCtx());
     const entry = entries[0];
@@ -122,7 +123,7 @@ describe('brief step (GH-253)', () => {
 
   it('still RUNs when WORK_BRIEF_ENABLED=0 and brief is missing', () => {
     process.env.WORK_BRIEF_ENABLED = '0';
-    const briefStep = require(path.join(__dirname, '..', 'brief.js'));
+
     const { add, entries } = makeAdd();
     briefStep(add, makeState({ hasBrief: false }), makeCtx());
     assert.equal(entries.length, 1);

--- a/workflows/work/steps/__tests__/spec-gate.test.js
+++ b/workflows/work/steps/__tests__/spec-gate.test.js
@@ -1,13 +1,12 @@
 /**
  * Unit tests for the spec-gate step module (GH-244, Task 4).
  *
- * Covers the six DEFER/RUN decision paths:
- *   1. WORK_SPEC_ENABLED=0 → DEFER
- *   2. !s.hasSpec → DEFER
- *   3. spec.md unreadable → RUN /spec
- *   4. gherkin-skip override → DEFER with reason
- *   5. Validation passes → DEFER with scenario count
- *   6. Validation fails → RUN with error messages
+ * Covers the five DEFER/RUN decision paths:
+ *   1. !s.hasSpec → DEFER
+ *   2. spec.md unreadable → RUN /spec
+ *   3. gherkin-skip override → DEFER with reason
+ *   4. Validation passes → DEFER with scenario count
+ *   5. Validation fails → RUN with error messages
  *
  * Run: node --test workflows/work/steps/__tests__/spec-gate.test.js
  */
@@ -133,20 +132,13 @@ function rmrf(dir) {
 describe('spec-gate step', () => {
   let specGateStep;
   const createdDirs = [];
-  const originalEnv = process.env.WORK_SPEC_ENABLED;
 
   before(() => {
     const mod = require(path.join(__dirname, '..', 'spec-gate.js'));
     specGateStep = typeof mod === 'function' ? mod : mod.specGateStep;
   });
 
-  beforeEach(() => {
-    delete process.env.WORK_SPEC_ENABLED;
-  });
-
   afterEach(() => {
-    if (originalEnv === undefined) delete process.env.WORK_SPEC_ENABLED;
-    else process.env.WORK_SPEC_ENABLED = originalEnv;
     while (createdDirs.length) rmrf(createdDirs.pop());
   });
 
@@ -154,18 +146,34 @@ describe('spec-gate step', () => {
     assert.equal(typeof specGateStep, 'function');
   });
 
-  // Case 1: WORK_SPEC_ENABLED=0
-  it('DEFERs when WORK_SPEC_ENABLED=0', () => {
-    process.env.WORK_SPEC_ENABLED = '0';
-    const { add, entries } = makeAdd();
-    specGateStep(add, makeState(), makeCtx());
-    assert.equal(entries.length, 1);
-    assert.equal(entries[0].step, STEPS.spec_gate);
-    assert.equal(entries[0].action, 'DEFER');
-    assert.match(entries[0].reason, /disabled/i);
+  // GH-253 Task 4: WORK_SPEC_ENABLED toggle removed — spec-gate no longer
+  // checks process.env.WORK_SPEC_ENABLED.
+  it('does not reference WORK_SPEC_ENABLED in source code', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'spec-gate.js'), 'utf8');
+    assert.ok(
+      !src.includes('WORK_SPEC_ENABLED'),
+      'spec-gate.js must not contain WORK_SPEC_ENABLED'
+    );
   });
 
-  // Case 2: No spec.md present
+  it('ignores WORK_SPEC_ENABLED=0 and still evaluates spec.md normally', () => {
+    const prev = process.env.WORK_SPEC_ENABLED;
+    process.env.WORK_SPEC_ENABLED = '0';
+    try {
+      const { add, entries } = makeAdd();
+      // hasSpec=false should DEFER with "No spec.md present", NOT "disabled"
+      specGateStep(add, makeState({ hasSpec: false }), makeCtx());
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].step, STEPS.spec_gate);
+      assert.equal(entries[0].action, 'DEFER');
+      assert.match(entries[0].reason, /no spec/i);
+    } finally {
+      if (prev === undefined) delete process.env.WORK_SPEC_ENABLED;
+      else process.env.WORK_SPEC_ENABLED = prev;
+    }
+  });
+
+  // Case 1: No spec.md present
   it('DEFERs when !s.hasSpec', () => {
     const { add, entries } = makeAdd();
     specGateStep(add, makeState({ hasSpec: false }), makeCtx());

--- a/workflows/work/steps/__tests__/spec.test.js
+++ b/workflows/work/steps/__tests__/spec.test.js
@@ -8,7 +8,7 @@
  * - Step DEFERs when spec.md already exists
  * - Step RUNs when spec.md is missing
  *
- * Run: npx vitest run workflows/work/steps/__tests__/spec.test.js
+ * Run: node --test workflows/work/steps/__tests__/spec.test.js
  */
 
 'use strict';

--- a/workflows/work/steps/__tests__/spec.test.js
+++ b/workflows/work/steps/__tests__/spec.test.js
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the spec step module (GH-253, Task 1).
+ *
+ * Verifies that:
+ * - The spec step never DEFERs with a "disabled" reason (toggle removed)
+ * - Setting WORK_SPEC_ENABLED=0 has no effect
+ * - The briefRef logic no longer depends on WORK_BRIEF_ENABLED
+ * - Step DEFERs when spec.md already exists
+ * - Step RUNs when spec.md is missing
+ *
+ * Run: npx vitest run workflows/work/steps/__tests__/spec.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { STEPS } = require('../../step-registry');
+
+// ─── Test doubles ────────────────────────────────────────────────────────────
+
+function makeCtx(overrides = {}) {
+  return {
+    STEPS,
+    ticket: 'TEST-100',
+    description: null,
+    rework: false,
+    safeName: 'TEST-100',
+    worktreeDir: '/tmp/worktrees/my-project-TEST-100',
+    tasksDir: '/tmp/tasks/TEST-100',
+    t: 'TEST-100',
+    path,
+    fileExists: () => false,
+    getDocsPrompt: () => '',
+    ...overrides,
+  };
+}
+
+function makeState(overrides = {}) {
+  return {
+    worktreeExists: true,
+    hasBrief: false,
+    hasSpec: false,
+    pr: null,
+    ...overrides,
+  };
+}
+
+function makeAdd() {
+  const entries = [];
+  const add = (step, action, command, reason, extra) => {
+    entries.push({ step, action, command, reason, ...(extra || {}) });
+  };
+  return { add, entries };
+}
+
+// ─── Suite ──────────────────────────────────────────────────────────────────
+
+describe('spec step (GH-253)', () => {
+  const originalSpecEnv = process.env.WORK_SPEC_ENABLED;
+  const originalBriefEnv = process.env.WORK_BRIEF_ENABLED;
+
+  beforeEach(() => {
+    delete process.env.WORK_SPEC_ENABLED;
+    delete process.env.WORK_BRIEF_ENABLED;
+  });
+
+  afterEach(() => {
+    if (originalSpecEnv === undefined) delete process.env.WORK_SPEC_ENABLED;
+    else process.env.WORK_SPEC_ENABLED = originalSpecEnv;
+    if (originalBriefEnv === undefined) delete process.env.WORK_BRIEF_ENABLED;
+    else process.env.WORK_BRIEF_ENABLED = originalBriefEnv;
+  });
+
+  it('never DEFERs with a "disabled" reason even when WORK_SPEC_ENABLED=0', () => {
+    process.env.WORK_SPEC_ENABLED = '0';
+    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+    const { add, entries } = makeAdd();
+    specStep(add, makeState(), makeCtx());
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    if (entry.action === 'DEFER') {
+      assert.ok(
+        !entry.reason.toLowerCase().includes('disabled'),
+        `spec step must not DEFER with "disabled" reason, got: "${entry.reason}"`
+      );
+    }
+  });
+
+  it('does not reference WORK_SPEC_ENABLED in source code', () => {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'spec.js'), 'utf8');
+    assert.ok(
+      !source.includes('WORK_SPEC_ENABLED'),
+      'spec.js must not contain WORK_SPEC_ENABLED'
+    );
+  });
+
+  it('does not reference WORK_BRIEF_ENABLED in source code', () => {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'spec.js'), 'utf8');
+    assert.ok(
+      !source.includes('WORK_BRIEF_ENABLED'),
+      'spec.js must not contain WORK_BRIEF_ENABLED'
+    );
+  });
+
+  it('RUNs when spec.md is missing (hasSpec=false)', () => {
+    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+    const { add, entries } = makeAdd();
+    specStep(add, makeState({ hasSpec: false }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.spec);
+    assert.equal(entries[0].action, 'RUN');
+  });
+
+  it('DEFERs when spec.md already exists (hasSpec=true)', () => {
+    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+    const { add, entries } = makeAdd();
+    specStep(add, makeState({ hasSpec: true }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.spec);
+    assert.equal(entries[0].action, 'DEFER');
+    assert.match(entries[0].reason.toLowerCase(), /already exists/);
+  });
+
+  it('includes briefRef when brief.md file exists on disk', () => {
+    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    specStep(add, makeState({ hasSpec: false }), ctx);
+    assert.match(entries[0].agentPrompt, /Read the product brief/);
+  });
+
+  it('includes briefRef when brief.md does not exist but hasBrief is false (will be generated)', () => {
+    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => false });
+    specStep(add, makeState({ hasSpec: false, hasBrief: false }), ctx);
+    assert.match(entries[0].agentPrompt, /brief\.md/);
+  });
+
+  it('still RUNs when WORK_SPEC_ENABLED=0 and spec is missing', () => {
+    process.env.WORK_SPEC_ENABLED = '0';
+    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+    const { add, entries } = makeAdd();
+    specStep(add, makeState({ hasSpec: false }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'RUN');
+  });
+
+  it('RUNs with correct agent type', () => {
+    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+    const { add, entries } = makeAdd();
+    specStep(add, makeState({ hasSpec: false }), makeCtx());
+    assert.equal(entries[0].agentType, 'spec-writer');
+  });
+});

--- a/workflows/work/steps/__tests__/spec.test.js
+++ b/workflows/work/steps/__tests__/spec.test.js
@@ -18,6 +18,7 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const { STEPS } = require('../../step-registry');
+const specStep = require('../spec.js');
 
 // ─── Test doubles ────────────────────────────────────────────────────────────
 
@@ -76,7 +77,7 @@ describe('spec step (GH-253)', () => {
 
   it('never DEFERs with a "disabled" reason even when WORK_SPEC_ENABLED=0', () => {
     process.env.WORK_SPEC_ENABLED = '0';
-    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+
     const { add, entries } = makeAdd();
     specStep(add, makeState(), makeCtx());
     assert.equal(entries.length, 1);
@@ -106,7 +107,7 @@ describe('spec step (GH-253)', () => {
   });
 
   it('RUNs when spec.md is missing (hasSpec=false)', () => {
-    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+
     const { add, entries } = makeAdd();
     specStep(add, makeState({ hasSpec: false }), makeCtx());
     assert.equal(entries.length, 1);
@@ -115,7 +116,7 @@ describe('spec step (GH-253)', () => {
   });
 
   it('DEFERs when spec.md already exists (hasSpec=true)', () => {
-    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+
     const { add, entries } = makeAdd();
     specStep(add, makeState({ hasSpec: true }), makeCtx());
     assert.equal(entries.length, 1);
@@ -125,7 +126,7 @@ describe('spec step (GH-253)', () => {
   });
 
   it('includes briefRef when brief.md file exists on disk', () => {
-    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => true });
     specStep(add, makeState({ hasSpec: false }), ctx);
@@ -133,16 +134,23 @@ describe('spec step (GH-253)', () => {
   });
 
   it('includes briefRef when brief.md does not exist but hasBrief is false (will be generated)', () => {
-    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => false });
     specStep(add, makeState({ hasSpec: false, hasBrief: false }), ctx);
     assert.match(entries[0].agentPrompt, /brief\.md/);
   });
 
+  it('omits briefRef when hasBrief=true and brief.md does not exist on disk', () => {
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => false });
+    specStep(add, makeState({ hasSpec: false, hasBrief: true }), ctx);
+    assert.doesNotMatch(entries[0].agentPrompt, /Read the product brief/);
+  });
+
   it('still RUNs when WORK_SPEC_ENABLED=0 and spec is missing', () => {
     process.env.WORK_SPEC_ENABLED = '0';
-    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+
     const { add, entries } = makeAdd();
     specStep(add, makeState({ hasSpec: false }), makeCtx());
     assert.equal(entries.length, 1);
@@ -150,7 +158,7 @@ describe('spec step (GH-253)', () => {
   });
 
   it('RUNs with correct agent type', () => {
-    const specStep = require(path.join(__dirname, '..', 'spec.js'));
+
     const { add, entries } = makeAdd();
     specStep(add, makeState({ hasSpec: false }), makeCtx());
     assert.equal(entries[0].agentType, 'spec-writer');

--- a/workflows/work/steps/__tests__/tasks.test.js
+++ b/workflows/work/steps/__tests__/tasks.test.js
@@ -8,7 +8,7 @@
  * - Step RUNs when spec.md exists and tasks.md is missing
  * - Step DEFERs when spec.md is missing (cannot generate tasks)
  *
- * Run: npx vitest run workflows/work/steps/__tests__/tasks.test.js
+ * Run: node --test workflows/work/steps/__tests__/tasks.test.js
  */
 
 'use strict';

--- a/workflows/work/steps/__tests__/tasks.test.js
+++ b/workflows/work/steps/__tests__/tasks.test.js
@@ -18,6 +18,7 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const { STEPS } = require('../../step-registry');
+const tasksStep = require('../tasks.js');
 
 // ─── Test doubles ────────────────────────────────────────────────────────────
 
@@ -71,7 +72,7 @@ describe('tasks step (GH-253)', () => {
 
   it('never DEFERs with a "disabled" reason even when WORK_TASKS_ENABLED=0', () => {
     process.env.WORK_TASKS_ENABLED = '0';
-    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => true });
     tasksStep(add, makeState(), ctx);
@@ -94,7 +95,7 @@ describe('tasks step (GH-253)', () => {
   });
 
   it('DEFERs when tasks.md already exists (hasTasks=true)', () => {
-    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+
     const { add, entries } = makeAdd();
     tasksStep(add, makeState({ hasTasks: true }), makeCtx());
     assert.equal(entries.length, 1);
@@ -104,7 +105,7 @@ describe('tasks step (GH-253)', () => {
   });
 
   it('RUNs when spec.md exists and tasks.md is missing', () => {
-    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => true });
     tasksStep(add, makeState({ hasTasks: false }), ctx);
@@ -114,7 +115,7 @@ describe('tasks step (GH-253)', () => {
   });
 
   it('DEFERs when spec.md is missing (cannot generate tasks)', () => {
-    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => false });
     tasksStep(add, makeState({ hasTasks: false }), ctx);
@@ -126,7 +127,7 @@ describe('tasks step (GH-253)', () => {
 
   it('still RUNs when WORK_TASKS_ENABLED=0 and spec exists', () => {
     process.env.WORK_TASKS_ENABLED = '0';
-    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => true });
     tasksStep(add, makeState({ hasTasks: false }), ctx);
@@ -135,7 +136,7 @@ describe('tasks step (GH-253)', () => {
   });
 
   it('RUNs with correct agent type and prompt', () => {
-    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => true });
     tasksStep(add, makeState({ hasTasks: false }), ctx);

--- a/workflows/work/steps/__tests__/tasks.test.js
+++ b/workflows/work/steps/__tests__/tasks.test.js
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the tasks step module (GH-253, Task 1).
+ *
+ * Verifies that:
+ * - The tasks step never DEFERs with a "disabled" reason (toggle removed)
+ * - Setting WORK_TASKS_ENABLED=0 has no effect
+ * - Step DEFERs when tasks.md already exists
+ * - Step RUNs when spec.md exists and tasks.md is missing
+ * - Step DEFERs when spec.md is missing (cannot generate tasks)
+ *
+ * Run: npx vitest run workflows/work/steps/__tests__/tasks.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { STEPS } = require('../../step-registry');
+
+// ─── Test doubles ────────────────────────────────────────────────────────────
+
+function makeCtx(overrides = {}) {
+  return {
+    STEPS,
+    ticket: 'TEST-100',
+    description: null,
+    rework: false,
+    safeName: 'TEST-100',
+    worktreeDir: '/tmp/worktrees/my-project-TEST-100',
+    tasksDir: '/tmp/tasks/TEST-100',
+    t: 'TEST-100',
+    path,
+    fileExists: () => false,
+    getDocsPrompt: () => '',
+    ...overrides,
+  };
+}
+
+function makeState(overrides = {}) {
+  return {
+    worktreeExists: true,
+    hasTasks: false,
+    pr: null,
+    ...overrides,
+  };
+}
+
+function makeAdd() {
+  const entries = [];
+  const add = (step, action, command, reason, extra) => {
+    entries.push({ step, action, command, reason, ...(extra || {}) });
+  };
+  return { add, entries };
+}
+
+// ─── Suite ──────────────────────────────────────────────────────────────────
+
+describe('tasks step (GH-253)', () => {
+  const originalEnv = process.env.WORK_TASKS_ENABLED;
+
+  beforeEach(() => {
+    delete process.env.WORK_TASKS_ENABLED;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.WORK_TASKS_ENABLED;
+    else process.env.WORK_TASKS_ENABLED = originalEnv;
+  });
+
+  it('never DEFERs with a "disabled" reason even when WORK_TASKS_ENABLED=0', () => {
+    process.env.WORK_TASKS_ENABLED = '0';
+    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    tasksStep(add, makeState(), ctx);
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    if (entry.action === 'DEFER') {
+      assert.ok(
+        !entry.reason.toLowerCase().includes('disabled'),
+        `tasks step must not DEFER with "disabled" reason, got: "${entry.reason}"`
+      );
+    }
+  });
+
+  it('does not reference WORK_TASKS_ENABLED in source code', () => {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'tasks.js'), 'utf8');
+    assert.ok(
+      !source.includes('WORK_TASKS_ENABLED'),
+      'tasks.js must not contain WORK_TASKS_ENABLED'
+    );
+  });
+
+  it('DEFERs when tasks.md already exists (hasTasks=true)', () => {
+    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+    const { add, entries } = makeAdd();
+    tasksStep(add, makeState({ hasTasks: true }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.tasks);
+    assert.equal(entries[0].action, 'DEFER');
+    assert.match(entries[0].reason.toLowerCase(), /already exists/);
+  });
+
+  it('RUNs when spec.md exists and tasks.md is missing', () => {
+    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    tasksStep(add, makeState({ hasTasks: false }), ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.tasks);
+    assert.equal(entries[0].action, 'RUN');
+  });
+
+  it('DEFERs when spec.md is missing (cannot generate tasks)', () => {
+    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => false });
+    tasksStep(add, makeState({ hasTasks: false }), ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.tasks);
+    assert.equal(entries[0].action, 'DEFER');
+    assert.match(entries[0].reason.toLowerCase(), /spec/);
+  });
+
+  it('still RUNs when WORK_TASKS_ENABLED=0 and spec exists', () => {
+    process.env.WORK_TASKS_ENABLED = '0';
+    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    tasksStep(add, makeState({ hasTasks: false }), ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'RUN');
+  });
+
+  it('RUNs with correct agent type and prompt', () => {
+    const tasksStep = require(path.join(__dirname, '..', 'tasks.js'));
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    tasksStep(add, makeState({ hasTasks: false }), ctx);
+    assert.equal(entries[0].agentType, 'skill');
+    assert.match(entries[0].agentPrompt, /split-in-tasks/);
+  });
+});

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -95,6 +95,7 @@ function briefGateStep(add, s, ctx) {
       agentPrompt: `Use AskUserQuestion to resolve ${blocking.length} unresolved open question(s) in brief.md, then call applyBriefResolutions() to persist the answers.`,
       askUserQuestionPayload: buildAskUserQuestionPayload(blocking),
       onResolve: 'rewrite brief.md',
+      postResolveCommand: `node -e "require('${path.join(__dirname, 'brief-gate.js')}').applyBriefResolutions('${briefPath}', JSON.parse(process.argv[1]))" "$RESOLUTIONS_JSON"`,
     }
   );
 }

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -95,7 +95,7 @@ function briefGateStep(add, s, ctx) {
       agentPrompt: `Use AskUserQuestion to resolve ${blocking.length} unresolved open question(s) in brief.md, then call applyBriefResolutions() to persist the answers.`,
       askUserQuestionPayload: buildAskUserQuestionPayload(blocking),
       onResolve: 'rewrite brief.md',
-      postResolveCommand: `node -e "require('${path.join(__dirname, 'brief-gate.js')}').applyBriefResolutions('${briefPath}', JSON.parse(process.argv[1]))" "$RESOLUTIONS_JSON"`,
+      postResolveCommand: `node -e "require(process.argv[1]).applyBriefResolutions(process.argv[2], JSON.parse(process.argv[3]))" "${path.join(__dirname, 'brief-gate.js')}" "${briefPath}" "$RESOLUTIONS_JSON"`,
     }
   );
 }

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -95,7 +95,7 @@ function briefGateStep(add, s, ctx) {
       agentPrompt: `Use AskUserQuestion to resolve ${blocking.length} unresolved open question(s) in brief.md, then call applyBriefResolutions() to persist the answers.`,
       askUserQuestionPayload: buildAskUserQuestionPayload(blocking),
       onResolve: 'rewrite brief.md',
-      postResolveCommand: `node -e "require(process.argv[1]).applyBriefResolutions(process.argv[2], JSON.parse(process.argv[3]))" "${path.join(__dirname, 'brief-gate.js')}" "${briefPath}" "$RESOLUTIONS_JSON"`,
+      postResolveCommand: `node -e "var r=process.argv[3];if(!r)process.exit(0);require(process.argv[1]).applyBriefResolutions(process.argv[2],JSON.parse(r))" "${path.join(__dirname, 'brief-gate.js')}" "${briefPath}" "$RESOLUTIONS_JSON"`,
     }
   );
 }

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -7,11 +7,10 @@
  * reuses the pure parser/rewriter in `../lib/open-questions.js`.
  *
  * Decision matrix:
- *   1. `WORK_BRIEF_ENABLED=0`                  → DEFER "Brief disabled"
- *   2. `!s.hasBrief`                           → DEFER "No brief.md present"
- *   3. `brief.md` unreadable (fail-closed)      → RUN   "brief.md unreadable — regenerate brief"
- *   4. Parser returns zero blocking questions  → DEFER "All blocking questions resolved"
- *   5. Otherwise                               → RUN with an AskUserQuestion
+ *   1. `!s.hasBrief`                           → DEFER "No brief.md present"
+ *   2. `brief.md` unreadable (fail-closed)      → RUN   "brief.md unreadable — regenerate brief"
+ *   3. Parser returns zero blocking questions  → DEFER "All blocking questions resolved"
+ *   4. Otherwise                               → RUN with an AskUserQuestion
  *                                                payload + `onResolve: 'rewrite brief.md'`
  *
  * The RUN payload instructs the orchestrator to invoke AskUserQuestion
@@ -56,12 +55,6 @@ function buildAskUserQuestionPayload(blocking) {
  */
 function briefGateStep(add, s, ctx) {
   const { STEPS, tasksDir, path } = ctx;
-  const briefEnabled = process.env.WORK_BRIEF_ENABLED !== '0';
-
-  if (!briefEnabled) {
-    add(STEPS.brief_gate, 'DEFER', null, 'Brief disabled (WORK_BRIEF_ENABLED=0)');
-    return;
-  }
 
   if (!s || !s.hasBrief) {
     add(STEPS.brief_gate, 'DEFER', null, 'No brief.md present');

--- a/workflows/work/steps/brief.js
+++ b/workflows/work/steps/brief.js
@@ -7,11 +7,8 @@
  */
 module.exports = function briefStep(add, s, ctx) {
   const { STEPS, t, tasksDir, getDocsPrompt, fileExists, path } = ctx;
-  const briefEnabled = process.env.WORK_BRIEF_ENABLED !== '0';
 
-  if (!briefEnabled) {
-    add(STEPS.brief, 'DEFER', null, 'Brief generation disabled (WORK_BRIEF_ENABLED=0)');
-  } else if (s?.hasBrief) {
+  if (s?.hasBrief) {
     add(STEPS.brief, 'DEFER', null, 'brief.md already exists');
   } else {
     add(

--- a/workflows/work/steps/brief.js
+++ b/workflows/work/steps/brief.js
@@ -1,6 +1,11 @@
 /**
  * Step: brief
  * Generates the product brief from ticket requirements.
+ *
+ * Decision matrix:
+ *   1. hasBrief=true  → DEFER (artifact already present)
+ *   2. hasBrief=false → RUN  (generate the brief)
+ *
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx

--- a/workflows/work/steps/spec-gate.js
+++ b/workflows/work/steps/spec-gate.js
@@ -6,12 +6,11 @@
  * `./brief-gate.js`, and reuses the pure parser in `../lib/parse-gherkin.js`.
  *
  * Decision matrix:
- *   1. `WORK_SPEC_ENABLED=0`                  → DEFER "Spec disabled"
- *   2. `!s.hasSpec`                           → DEFER "No spec.md present"
- *   3. `spec.md` unreadable (fail-closed)      → RUN  "/spec" regenerate spec
- *   4. gherkin-skip override present           → DEFER with override reason
- *   5. parse() + validate() passes             → DEFER with scenario count
- *   6. Validation fails                        → RUN  "/spec" with error messages
+ *   1. `!s.hasSpec`                           → DEFER "No spec.md present"
+ *   2. `spec.md` unreadable (fail-closed)      → RUN  "/spec" regenerate spec
+ *   3. gherkin-skip override present           → DEFER with override reason
+ *   4. parse() + validate() passes             → DEFER with scenario count
+ *   5. Validation fails                        → RUN  "/spec" with error messages
  */
 
 'use strict';
@@ -26,21 +25,14 @@ const parseGherkin = require('../lib/parse-gherkin');
  */
 function specGateStep(add, s, ctx) {
   const { STEPS, tasksDir, path } = ctx;
-  const specEnabled = process.env.WORK_SPEC_ENABLED !== '0';
 
-  // Case 1: Spec disabled
-  if (!specEnabled) {
-    add(STEPS.spec_gate, 'DEFER', null, 'Spec disabled (WORK_SPEC_ENABLED=0)');
-    return;
-  }
-
-  // Case 2: No spec.md
+  // Case 1: No spec.md
   if (!s || !s.hasSpec) {
     add(STEPS.spec_gate, 'DEFER', null, 'No spec.md present');
     return;
   }
 
-  // Case 3: spec.md unreadable
+  // Case 2: spec.md unreadable
   const specPath = path.join(tasksDir, 'spec.md');
   let markdown;
   try {
@@ -53,14 +45,14 @@ function specGateStep(add, s, ctx) {
     return;
   }
 
-  // Case 4: Skip override
+  // Case 3: Skip override
   const skipResult = parseGherkin.hasSkipOverride(markdown);
   if (skipResult.skip) {
     add(STEPS.spec_gate, 'DEFER', null, `Gherkin skip override: ${skipResult.reason}`);
     return;
   }
 
-  // Case 5+6: Parse and validate
+  // Case 4+5: Parse and validate
   const parsed = parseGherkin.parse(markdown);
   // If parse found errors and no features, report parse errors in the RUN reason
   const validation = parseGherkin.validate(parsed);
@@ -76,7 +68,7 @@ function specGateStep(add, s, ctx) {
     return;
   }
 
-  // Case 6: Validation or parse fails → RUN with retry to spec
+  // Case 5: Validation or parse fails → RUN with retry to spec
   add(STEPS.spec_gate, 'RUN', '/spec', allErrors.join('; '), {
     agentType: 'skill',
     agentPrompt: '/spec',

--- a/workflows/work/steps/spec.js
+++ b/workflows/work/steps/spec.js
@@ -1,6 +1,12 @@
 /**
  * Step: spec
  * Generates the technical specification from the brief and codebase analysis.
+ *
+ * Decision matrix:
+ *   1. hasSpec=true                          → DEFER (artifact already present)
+ *   2. hasSpec=false, brief exists or pending → RUN with briefRef in prompt
+ *   3. hasSpec=false, brief complete on disk  → RUN without briefRef
+ *
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx

--- a/workflows/work/steps/spec.js
+++ b/workflows/work/steps/spec.js
@@ -7,18 +7,14 @@
  */
 module.exports = function specStep(add, s, ctx) {
   const { STEPS, t, worktreeDir, tasksDir, getDocsPrompt, fileExists, path } = ctx;
-  const specEnabled = process.env.WORK_SPEC_ENABLED !== '0';
-  const briefEnabled = process.env.WORK_BRIEF_ENABLED !== '0';
   const briefPath = path.join(tasksDir, 'brief.md');
   const specPath = path.join(tasksDir, 'spec.md');
 
-  if (!specEnabled) {
-    add(STEPS.spec, 'DEFER', null, 'Spec generation disabled (WORK_SPEC_ENABLED=0)');
-  } else if (s?.hasSpec) {
+  if (s?.hasSpec) {
     add(STEPS.spec, 'DEFER', null, 'spec.md already exists');
   } else {
     const briefRef =
-      fileExists(briefPath) || (briefEnabled && !s?.hasBrief)
+      fileExists(briefPath) || !s?.hasBrief
         ? `\n\nRead the product brief at: ${briefPath}`
         : '';
     add(STEPS.spec, 'RUN', 'Task(spec-writer)', 'Generate technical specification', {

--- a/workflows/work/steps/spec.js
+++ b/workflows/work/steps/spec.js
@@ -3,9 +3,9 @@
  * Generates the technical specification from the brief and codebase analysis.
  *
  * Decision matrix:
- *   1. hasSpec=true                          → DEFER (artifact already present)
- *   2. hasSpec=false, brief exists or pending → RUN with briefRef in prompt
- *   3. hasSpec=false, brief complete on disk  → RUN without briefRef
+ *   1. hasSpec=true                                        → DEFER (artifact already present)
+ *   2. hasSpec=false, brief.md on disk OR hasBrief=false   → RUN with briefRef path in prompt
+ *   3. hasSpec=false, brief.md NOT on disk AND hasBrief=true → RUN without briefRef
  *
  * @param {Function} add
  * @param {object} s

--- a/workflows/work/steps/tasks.js
+++ b/workflows/work/steps/tasks.js
@@ -1,6 +1,12 @@
 /**
  * Step: tasks
  * Generates tasks from the technical specification.
+ *
+ * Decision matrix:
+ *   1. hasTasks=true     → DEFER (artifact already present)
+ *   2. spec.md missing   → DEFER (dependency not met)
+ *   3. spec.md exists    → RUN  (generate tasks from spec)
+ *
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx

--- a/workflows/work/steps/tasks.js
+++ b/workflows/work/steps/tasks.js
@@ -7,12 +7,9 @@
  */
 module.exports = function tasksStep(add, s, ctx) {
   const { STEPS, safeName, tasksDir, fileExists, path } = ctx;
-  const tasksEnabled = process.env.WORK_TASKS_ENABLED !== '0';
   const specPath = path.join(tasksDir, 'spec.md');
 
-  if (!tasksEnabled) {
-    add(STEPS.tasks, 'DEFER', null, 'Task splitting disabled (WORK_TASKS_ENABLED=0)');
-  } else if (s?.hasTasks) {
+  if (s?.hasTasks) {
     add(STEPS.tasks, 'DEFER', null, 'tasks.md already exists');
   } else if (!fileExists(specPath)) {
     add(STEPS.tasks, 'DEFER', null, 'No spec.md — cannot generate tasks', {

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -61,7 +61,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
   function verifySpecGate(ticketId) {
     try {
       const specPath = path.join(TASKS_BASE, safeTicketPath(ticketId), 'spec.md');
-      if (!fs.existsSync(specPath)) return false; // No spec.md = fail-closed
+      if (!fs.existsSync(specPath)) return false; // GH-253: fail-closed — missing spec blocks the gate
       const parseGherkin = require(path.join(__dirname, 'lib', 'parse-gherkin'));
       const markdown = fs.readFileSync(specPath, 'utf-8');
       const skipResult = parseGherkin.hasSkipOverride(markdown);

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -55,15 +55,13 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
     }
   }
 
-  // GH-244: Helper for STEPS.spec_gate verify. Returns true if spec is
-  // disabled, spec.md is missing (step SKIPs), skip override is present,
-  // or parse() + validate() passes. Fail-closed on any read/parse error.
+  // GH-253: Helper for STEPS.spec_gate verify. Returns true iff spec.md
+  // exists AND (skip override is present OR parse() + validate() passes).
+  // Fail-closed: returns false when spec.md is missing or on any error.
   function verifySpecGate(ticketId) {
-    // If spec is disabled, gate is auto-verified (nothing to validate)
-    if (process.env.WORK_SPEC_ENABLED === '0') return true;
     try {
       const specPath = path.join(TASKS_BASE, safeTicketPath(ticketId), 'spec.md');
-      if (!fs.existsSync(specPath)) return true; // No spec.md = gate trivially passes (step emits SKIP)
+      if (!fs.existsSync(specPath)) return false; // No spec.md = fail-closed
       const parseGherkin = require(path.join(__dirname, 'lib', 'parse-gherkin'));
       const markdown = fs.readFileSync(specPath, 'utf-8');
       const skipResult = parseGherkin.hasSkipOverride(markdown);
@@ -184,8 +182,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       {
         step: STEPS.spec,
         verify: (ticketId) => {
-          // GH-244: When spec is disabled, verify trivially passes (step emits SKIP)
-          if (process.env.WORK_SPEC_ENABLED === '0') return true;
+          // GH-253: spec is always mandatory — no env toggle bypass.
           // safeTicketPath() converts #N -> GH-N via cached config.safeTicketId()
           try {
             return fs.existsSync(path.join(TASKS_BASE, safeTicketPath(ticketId), 'spec.md'));
@@ -195,8 +192,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
         },
       },
       {
-        // GH-244: Gate between `spec` and `tasks`. Verified iff spec is disabled,
-        // spec.md is missing, gherkin-skip override is present, or parse() + validate() passes.
+        // GH-253: Gate between `spec` and `tasks`. Verified iff spec.md exists
+        // AND (gherkin-skip override is present OR parse() + validate() passes).
+        // Fail-closed when spec.md is missing or on any read/parse error.
         step: STEPS.spec_gate,
         verify: verifySpecGate,
       },


### PR DESCRIPTION
## Existing Behavior

- `WORK_BRIEF_ENABLED`, `WORK_SPEC_ENABLED`, and `WORK_TASKS_ENABLED` env vars could be set to `0` to skip the corresponding workflow step, allowing teams to bypass brief/spec/tasks generation entirely.
- `verifySpecGate` in `workflow-definition.js` returned `true` (auto-pass) when `WORK_SPEC_ENABLED=0` or when `spec.md` was absent — a fail-open bug that let the gate pass without a valid spec.
- The `brief_gate` RUN entry did not carry a `postResolveCommand`, so the orchestrator had no automated path to apply resolutions after user answers.

## Intended New Behavior

- `brief.js`, `spec.js`, `tasks.js`, `brief-gate.js`, and `spec-gate.js` no longer read `WORK_BRIEF_ENABLED`, `WORK_SPEC_ENABLED`, or `WORK_TASKS_ENABLED` — brief, spec, and task generation are always mandatory.
- `verifySpecGate` is now fail-closed: returns `false` when `spec.md` is absent, ensuring the gate cannot be trivially bypassed.
- The `brief_gate` RUN entry includes a `postResolveCommand` that calls `applyBriefResolutions()` after user answers are collected, enabling automated resolution persistence.
- `plan-generator.js` unconditionally includes brief/spec/tasks path hints in planning context regardless of env vars.
- `.env.example` is cleaned of the removed toggle entries.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / CLI workflow verification:**

1. Confirm `WORK_BRIEF_ENABLED=0`, `WORK_SPEC_ENABLED=0`, and `WORK_TASKS_ENABLED=0` have no effect on step execution:
   ```bash
   WORK_BRIEF_ENABLED=0 WORK_SPEC_ENABLED=0 WORK_TASKS_ENABLED=0 node --test workflows/work/steps/__tests__/brief.test.js
   WORK_BRIEF_ENABLED=0 WORK_SPEC_ENABLED=0 WORK_TASKS_ENABLED=0 node --test workflows/work/steps/__tests__/spec.test.js
   WORK_BRIEF_ENABLED=0 WORK_SPEC_ENABLED=0 WORK_TASKS_ENABLED=0 node --test workflows/work/steps/__tests__/tasks.test.js
   ```
   Expected: all tests pass; no entry has action=DEFER with reason containing "disabled".

2. Verify `spec_gate` verify returns `false` when `spec.md` is absent (fail-closed):
   ```bash
   node --test workflows/work/__tests__/workflow-definition.test.js
   ```
   Expected: the test "returns false when spec.md does not exist" passes.

3. Verify `brief_gate` RUN entry carries `postResolveCommand`:
   ```bash
   node --test workflows/work/steps/__tests__/brief-gate.test.js
   ```
   Expected: the test "RUN entry includes postResolveCommand referencing applyBriefResolutions" passes.

4. Confirm `.env.example` no longer documents the removed toggles:
   ```bash
   grep -c 'WORK_BRIEF_ENABLED\|WORK_SPEC_ENABLED' .env.example
   ```
   Expected output: `0`

### Test Results

32+ new tests added across:
- `workflows/work/steps/__tests__/brief.test.js` (new file)
- `workflows/work/steps/__tests__/spec.test.js` (new file)
- `workflows/work/steps/__tests__/tasks.test.js` (new file)
- `workflows/work/__tests__/plan-generator-no-toggles.test.js` (new file)
- `workflows/work/__tests__/workflow-definition.test.js` (extended)
- `workflows/work/steps/__tests__/brief-gate.test.js` (extended)
- `workflows/work/steps/__tests__/spec-gate.test.js` (extended)