### PR TITLE
GH-264 - docs: add root-level AGENTS.md and project overview

### DIFF
--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -279,7 +279,7 @@ function checkCI(prNumber) {
 
 // ── Reviews ─────────────────────────────────────────────────────────────────
 
-const DEFAULT_BOT_REVIEWERS = 'copilot-pull-request-reviewer,cursor-ai[bot]';
+const DEFAULT_BOT_REVIEWERS = 'copilot-pull-request-reviewer,cursor-ai[bot],chatgpt-codex-connector[bot]';
 
 function getBotReviewers() {
   const env = process.env.FOLLOW_UP_PR_BOT_REVIEWERS;
@@ -305,7 +305,7 @@ function isBotAuthorLogin(author, botReviewers) {
   // Exact match against configured bot reviewers (case-insensitive)
   if (reviewers.includes(lower)) return true;
   // Match known aliases used by classifyCommentPriority
-  if (lower === 'copilot' || lower === 'cursor-ai[bot]') return true;
+  if (lower === 'copilot' || lower === 'cursor-ai[bot]' || lower === 'chatgpt-codex-connector[bot]' || lower === 'chatgpt-codex-connector') return true;
   // Fuzzy match: strip [bot] suffix from configured names
   return reviewers.some((bot) => bot.includes('[bot]') && lower === bot.replace('[bot]', ''));
 }
@@ -509,6 +509,18 @@ function classifyCommentPriority(author, body) {
     }
     // No severity marker found — default to medium (blocking)
     return 'medium';
+  }
+
+  // Codex (chatgpt-codex-connector[bot]): parse P-level badges or treat non-inline as low
+  if (author === 'chatgpt-codex-connector[bot]' || author === 'chatgpt-codex-connector') {
+    const badgeMatch = (body || '').match(/!\[P(\d)/);
+    if (badgeMatch) {
+      const level = parseInt(badgeMatch[1], 10);
+      if (level <= 1) return 'high';
+      if (level <= 2) return 'medium';
+      return 'low';
+    }
+    return 'low';
   }
 
   // Human reviewers: always blocking


### PR DESCRIPTION
## Existing Behavior

- `follow-up-pr.js` only recognized `copilot-pull-request-reviewer` and `cursor-ai[bot]` as bot reviewers in the default reviewer list.
- The `isBotAuthorLogin` function did not match `chatgpt-codex-connector[bot]` or its alias, so Codex comments were treated as human reviewer comments.
- `classifyCommentPriority` had no Codex-specific logic, so Codex PR comments defaulted to `high` priority (the human-reviewer fallback).

## Intended New Behavior

- `chatgpt-codex-connector[bot]` is added to the `DEFAULT_BOT_REVIEWERS` list so it is auto-requested on new PRs alongside Copilot and Cursor.
- `isBotAuthorLogin` now matches both `chatgpt-codex-connector[bot]` and the bare alias `chatgpt-codex-connector` to correctly identify the bot as a non-blocking reviewer.
- `classifyCommentPriority` parses P-level badge markers (e.g. `![P1`) from Codex comment bodies: P0-P1 → `high`, P2 → `medium`, P3+ → `low`; comments without a badge default to `low`.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Open a PR in a repo where `follow-up-pr.js` is active.
2. Confirm `chatgpt-codex-connector[bot]` is added as a reviewer automatically alongside Copilot.
3. Have the Codex bot post a review comment containing a badge such as `![P1` or `![P3`.
4. Run the follow-up workflow and verify the comment is classified as `high` for P1 or `low` for P3.
5. Post a Codex comment with no badge and confirm it is classified as `low` (non-blocking).
6. Confirm a human reviewer comment still classifies as `high`.