### PR TITLE
fix(GH-253): recognize chatgpt-codex-connector as bot reviewer in follow-up-pr

### DIFF
--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -163,7 +163,7 @@ describe('classifyCommentPriority', () => {
     });
 
     it('returns medium for comments without P-badge', () => {
-      assert.equal(classifyCommentPriority(author, 'no badge comment'), 'medium');
+      assert.equal(classifyCommentPriority(author, 'no badge comment'), 'low');
     });
   });
 

--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -2,6 +2,7 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const {
   classifyCommentPriority,
+  isBotAuthorLogin,
   isBlockingPriority,
   getResolvedCommentIds,
   resolveOutdatedThreads,
@@ -146,6 +147,34 @@ describe('classifyCommentPriority', () => {
     });
   });
 
+  describe('Codex (chatgpt-codex-connector[bot])', () => {
+    const author = 'chatgpt-codex-connector[bot]';
+
+    it('returns high for P1 badge', () => {
+      assert.equal(classifyCommentPriority(author, '![P1 Badge] Critical issue found'), 'high');
+    });
+
+    it('returns medium for P2 badge', () => {
+      assert.equal(classifyCommentPriority(author, '![P2 Badge] Consider fixing'), 'medium');
+    });
+
+    it('returns low for P3 badge', () => {
+      assert.equal(classifyCommentPriority(author, '![P3 Badge] Minor suggestion'), 'low');
+    });
+
+    it('returns medium for comments without P-badge', () => {
+      assert.equal(classifyCommentPriority(author, 'no badge comment'), 'medium');
+    });
+  });
+
+  describe('Codex (chatgpt-codex-connector alias)', () => {
+    const author = 'chatgpt-codex-connector';
+
+    it('returns high for P1 badge (alias)', () => {
+      assert.equal(classifyCommentPriority(author, '![P1 Badge] Critical issue found'), 'high');
+    });
+  });
+
   describe('Human reviewers', () => {
     it('returns high for any human reviewer', () => {
       assert.equal(classifyCommentPriority('octocat', 'Please fix this'), 'high');
@@ -161,6 +190,18 @@ describe('classifyCommentPriority', () => {
         'high'
       );
     });
+  });
+});
+
+describe('isBotAuthorLogin', () => {
+  const defaultBots = ['copilot-pull-request-reviewer', 'cursor-ai[bot]', 'chatgpt-codex-connector[bot]'];
+
+  it('returns true for chatgpt-codex-connector[bot]', () => {
+    assert.equal(isBotAuthorLogin('chatgpt-codex-connector[bot]', defaultBots), true);
+  });
+
+  it('returns true for chatgpt-codex-connector (fuzzy match strips [bot])', () => {
+    assert.equal(isBotAuthorLogin('chatgpt-codex-connector', defaultBots), true);
   });
 });
 

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -279,7 +279,7 @@ function checkCI(prNumber) {
 
 // ── Reviews ─────────────────────────────────────────────────────────────────
 
-const DEFAULT_BOT_REVIEWERS = 'copilot-pull-request-reviewer,cursor-ai[bot]';
+const DEFAULT_BOT_REVIEWERS = 'copilot-pull-request-reviewer,cursor-ai[bot],chatgpt-codex-connector[bot]';
 
 function getBotReviewers() {
   const env = process.env.FOLLOW_UP_PR_BOT_REVIEWERS;
@@ -305,7 +305,7 @@ function isBotAuthorLogin(author, botReviewers) {
   // Exact match against configured bot reviewers (case-insensitive)
   if (reviewers.includes(lower)) return true;
   // Match known aliases used by classifyCommentPriority
-  if (lower === 'copilot' || lower === 'cursor-ai[bot]') return true;
+  if (lower === 'copilot' || lower === 'cursor-ai[bot]' || lower === 'chatgpt-codex-connector[bot]' || lower === 'chatgpt-codex-connector') return true;
   // Fuzzy match: strip [bot] suffix from configured names
   return reviewers.some((bot) => bot.includes('[bot]') && lower === bot.replace('[bot]', ''));
 }
@@ -509,6 +509,18 @@ function classifyCommentPriority(author, body) {
     }
     // No severity marker found — default to medium (blocking)
     return 'medium';
+  }
+
+  // Codex (chatgpt-codex-connector[bot]): parse P-level badges or treat non-inline as low
+  if (author === 'chatgpt-codex-connector[bot]' || author === 'chatgpt-codex-connector') {
+    const badgeMatch = (body || '').match(/!\[P(\d)/);
+    if (badgeMatch) {
+      const level = parseInt(badgeMatch[1], 10);
+      if (level <= 1) return 'high';
+      if (level <= 2) return 'medium';
+      return 'low';
+    }
+    return 'low';
   }
 
   // Human reviewers: always blocking

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -305,7 +305,7 @@ function isBotAuthorLogin(author, botReviewers) {
   // Exact match against configured bot reviewers (case-insensitive)
   if (reviewers.includes(lower)) return true;
   // Match known aliases used by classifyCommentPriority
-  if (lower === 'copilot' || lower === 'cursor-ai[bot]' || lower === 'chatgpt-codex-connector[bot]' || lower === 'chatgpt-codex-connector') return true;
+  if (lower === 'copilot' || lower === 'cursor-ai[bot]') return true;
   // Fuzzy match: strip [bot] suffix from configured names
   return reviewers.some((bot) => bot.includes('[bot]') && lower === bot.replace('[bot]', ''));
 }
@@ -511,16 +511,19 @@ function classifyCommentPriority(author, body) {
     return 'medium';
   }
 
-  // Codex (chatgpt-codex-connector[bot]): parse P-level badges or treat non-inline as low
+  // Codex (chatgpt-codex-connector[bot]): parse P-level badges
   if (author === 'chatgpt-codex-connector[bot]' || author === 'chatgpt-codex-connector') {
-    const badgeMatch = (body || '').match(/!\[P(\d)/);
+    const badgeMatch = (body || '').match(/!\[P(\d+)/);
     if (badgeMatch) {
       const level = parseInt(badgeMatch[1], 10);
       if (level <= 1) return 'high';
       if (level <= 2) return 'medium';
       return 'low';
     }
-    return 'low';
+    // No P-badge: default to medium (blocking). Header/announcement comments
+    // are filtered out by isBotReview() at the review level; inline comments
+    // without badges should be treated as actionable.
+    return 'medium';
   }
 
   // Human reviewers: always blocking
@@ -714,6 +717,8 @@ function getReviews(prNumber) {
     const botLoginAliases = {
       'copilot-pull-request-reviewer': ['copilot', 'copilot-pull-request-reviewer'],
       'cursor-ai[bot]': ['cursor-ai[bot]', 'cursor-ai'],
+      'chatgpt-codex-connector[bot]': ['chatgpt-codex-connector'],
+      'chatgpt-codex-connector': ['chatgpt-codex-connector[bot]'],
     };
     for (const bot of botReviewers) {
       const aliases = botLoginAliases[bot] || [bot.toLowerCase()];
@@ -1589,6 +1594,7 @@ if (require.main === module) {
 
 module.exports = {
   classifyCommentPriority,
+  isBotAuthorLogin,
   isBlockingPriority,
   getResolvedCommentIds,
   resolveOutdatedThreads,

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -521,10 +521,10 @@ function classifyCommentPriority(author, body) {
       if (level <= 2) return 'medium';
       return 'low';
     }
-    // No P-badge: default to medium (blocking). Header/announcement comments
-    // are filtered out by isBotReview() at the review level; inline comments
-    // without badges should be treated as actionable.
-    return 'medium';
+    // No P-badge: default to low (non-blocking). Codex header/announcement comments
+    // and unbadged inline suggestions are treated as non-blocking.
+    // Inline comments WITH P-badges are classified by badge level.
+    return 'low';
   }
 
   // Human reviewers: always blocking

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -279,6 +279,7 @@ function checkCI(prNumber) {
 
 // ── Reviews ─────────────────────────────────────────────────────────────────
 
+// Aliases for each bot are in botLoginAliases (see getReviews)
 const DEFAULT_BOT_REVIEWERS = 'copilot-pull-request-reviewer,cursor-ai[bot],chatgpt-codex-connector[bot]';
 
 function getBotReviewers() {


### PR DESCRIPTION
## Existing Behavior

- `DEFAULT_BOT_REVIEWERS` only includes `copilot-pull-request-reviewer` and `cursor-ai[bot]`
- `isBotAuthorLogin` does not recognize `chatgpt-codex-connector[bot]` as a bot, causing its COMMENTED reviews to be treated as human (blocking)
- `classifyCommentPriority` has no Codex-specific logic, so all Codex comments default to `high` (blocking)

## Intended New Behavior

- `chatgpt-codex-connector[bot]` is added to `DEFAULT_BOT_REVIEWERS` so it is auto-included in follow-up PR review requests
- `isBotAuthorLogin` recognizes both `chatgpt-codex-connector[bot]` and `chatgpt-codex-connector` aliases, correctly filtering COMMENTED reviews as non-blocking
- `classifyCommentPriority` parses Codex P-level badge images (P1→high, P2→medium, P3+→low); header/announcement comments without a P-badge default to low (non-blocking)

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Open a PR that has `chatgpt-codex-connector[bot]` as a reviewer
2. Run the follow-up-pr script against that PR number
3. Verify the bot is listed under configured bot reviewers (check `getBotReviewers()` output)
4. Confirm COMMENTED reviews from `chatgpt-codex-connector[bot]` are not surfaced as blocking action items
5. Add a Codex comment containing a `![P1` badge and verify it is classified as `high`
6. Add a Codex comment containing a `![P3` badge and verify it is classified as `low`
7. Add a Codex header/announcement comment with no P-badge and verify it is classified as `low`