### PR TITLE
GH-264 - docs: add root-level AGENTS.md and project overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 19 specialized agents in `agents/`. Dispatched via `Task()` — never self-invoke recursively.
 
-For project overview and development rules see **[CLAUDE.md](./CLAUDE.md)**. For detailed documentation see **[docs/README.md](./docs/README.md)**.
+For project overview and development rules see **[CLAUDE.md](./CLAUDE.md)**.
+For detailed documentation see **[docs/README.md](./docs/README.md)**.
 
 ## Review guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 19 specialized agents in `agents/`. Dispatched via `Task()` — never self-invoke recursively.
 
-For detailed documentation see **[docs/README.md](./docs/README.md)**.
+For project overview and development rules see **[CLAUDE.md](./CLAUDE.md)**. For detailed documentation see **[docs/README.md](./docs/README.md)**.
 
 ## Review guidelines
 
@@ -68,7 +68,7 @@ For detailed documentation see **[docs/README.md](./docs/README.md)**.
 | implement | developer-* (by file type) |
 | commit | commit-writer |
 | check | code-checker, quality-checker, qa-*, completion-checker |
-| pr | pr-generator |
+| pr | pr-generator, pr-post-generator |
 
 ## Authorization
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# Agents
+
+19 specialized agents in `agents/`. Dispatched via `Task()` — never self-invoke recursively.
+
+For detailed documentation see **[docs/README.md](./docs/README.md)**.
+
+## Review guidelines
+
+- This is a Claude Code plugin — **CommonJS only** (`require`/`module.exports`). Do not suggest ES modules.
+- **No TypeScript** — plain JavaScript. Do not suggest adding types or `.d.ts` files.
+- Tests use **`node:test`** + **`node:assert/strict`**. Do not suggest Jest, Vitest, or Mocha.
+- Hooks use `process.exit(0/1/2)` intentionally — 0=allow, 2=block. Do not suggest throwing errors instead.
+- **Fail-open is intentional** — hooks catch errors and exit 0. Do not suggest fail-closed alternatives.
+- `logHookError(__filename, err)` is the logging convention. Do not suggest `console.error`.
+- Config lives in `workflows/lib/config.js` — do not duplicate its logic elsewhere.
+- `Object.create(null)` prevents prototype pollution — intentional, do not flag.
+- Content inside `skills/**/SKILL.md` and `agents/*.md` are AI instruction documents, not executable code. Do not flag code fences inside them.
+- `protect-state-files.js` four-vector design is intentional. Do not simplify regex patterns.
+- Shell command interpolation from git commands (not user input) is safe — do not flag as injection.
+
+## Catalog
+
+### Planning
+| Agent | Role |
+|---|---|
+| `brief-writer` | Product briefs from ticket requirements |
+| `spec-writer` | Technical specs from briefs + codebase analysis |
+| `code-architect` | Architecture review and design guidance |
+
+### Development
+| Agent | Domain |
+|---|---|
+| `developer-nodejs-tdd` | Node.js/Express/NestJS, strict TDD |
+| `developer-react-senior` | React frontend, complex architecture |
+| `developer-react-ui-architect` | UI components, visual design |
+| `developer-devops` | Infrastructure, CI/CD, deployment |
+
+### Quality
+| Agent | Role |
+|---|---|
+| `code-checker` | Static code review, compliance |
+| `quality-checker` | Lint, typecheck, unit/integration tests |
+| `completion-checker` | Requirement coverage verification |
+| `qa-feature-tester` | UI testing via Playwright MCP |
+| `qa-api-tester` | API/backend testing via curl |
+| `pr-reviewer` | Pull request code review |
+
+### PR & Commit
+| Agent | Role |
+|---|---|
+| `pr-generator` | PR titles and descriptions from diffs |
+| `pr-post-generator` | Visual documentation for PRs |
+| `commit-writer` | Semantic commit messages |
+
+### Coordination
+| Agent | Role |
+|---|---|
+| `project-coordinator` | Cross-agent task orchestration |
+| `jira-task-creator` | Ticket creation with template validation |
+| `jira-transitioner` | Verify merged PRs, transition tickets to Done |
+
+## Auto-Dispatch
+
+| /work Step | Agent(s) |
+|---|---|
+| brief | brief-writer |
+| spec | spec-writer |
+| implement | developer-* (by file type) |
+| commit | commit-writer |
+| check | code-checker, quality-checker, qa-*, completion-checker |
+| pr | pr-generator |
+
+## Authorization
+
+Scripts gated to specific agents:
+
+| Script | Agents |
+|---|---|
+| `tdd-phase-state.js` | developer-* |
+| `write-qa-report.js` | qa-feature-tester, qa-api-tester |
+| `write-tests-report.js` | quality-checker |
+| `write-code-review.js` | code-checker |
+| `write-completion-report.js` | completion-checker |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# Claude Plugin Work
+
+## Project Overview
+
+This is a Claude Code plugin (Node.js, CommonJS only). It provides deterministic workflows for ticket-to-PR delivery via `/work`, `/check`, `/work-implement`, and `/work-pr` commands.
+
+See **[AGENTS.md](./AGENTS.md)** for the agent catalog. See **[docs/README.md](./docs/README.md)** for full architecture documentation.
+
+## Development Rules
+
+### Language & Runtime
+- **CommonJS only** — `require`/`module.exports`. No ES modules, no `.mjs`, no bundlers.
+- **Plain JavaScript** — No TypeScript. No transpilation. Runs directly under Node.js.
+- **Node built-in test runner** — `node:test` + `node:assert/strict`. No Jest, Vitest, or Mocha.
+- **Zero runtime dependencies** — Only `@biomejs/biome` as devDependency for formatting.
+
+### Testing
+- Run tests: `pnpm test`
+- Run specific test: `node --test workflows/work/__tests__/transition-step.test.js`
+- Tests spawn hook scripts with `child_process.spawn` to test exit codes — this is the established pattern.
+- Temp directories use `fs.mkdtempSync` + `rmSync({ recursive: true, force: true })` in `after`/`afterEach`.
+
+### Code Conventions
+- `process.exit(0/1/2)` in hooks is intentional — 0=allow, 2=block.
+- Fail-open: hooks `catch` errors and exit 0 (allow). Only intentional blocks use exit 2.
+- `logHookError(__filename, err)` is the logging convention. Not `console.error`.
+- `Object.create(null)` prevents prototype pollution — intentional.
+- Config via `workflows/lib/config.js` — never duplicate its logic elsewhere.
+- `getConfig('TASKS_BASE')` / `getConfig.orExit(...)` are the canonical config accessors.
+
+### File Organization
+- `workflows/` — Core engine, per-workflow definitions, hooks, scripts
+- `workflows/lib/` — Shared utilities (config, enforcement, validation, policies)
+- `workflows/lib/hooks/policies/` — Pure decision functions (testable, no side effects)
+- `agents/` — Agent definitions (markdown instruction files)
+- `skills/` — Slash command definitions (SKILL.md per command)
+- `hooks/hooks.json` — Hook registration (matchers, commands, timeouts)
+
+### State Machine
+- 18 steps: `ticket → bootstrap → brief → brief_gate → spec → spec_gate → tasks → implement → commit → task_review → check → pr → ready → follow_up → ci → cleanup → reports → complete`
+- Step IDs are in `workflows/work/step-registry.js` — decoupled from ordering.
+- Transitions validated by `workflowCanTransition()` — only declared edges are allowed.
+- `transition-step.js` handles state persistence, artifact archival, and TDD gates.
+
+### TDD Enforcement
+- `implement` step is TDD-gated: must record RED → GREEN cycle before transitioning out.
+- `tdd-phase-state.js` is the ONLY way to record evidence — agents cannot self-report.
+- Phase gating hook (`work-implement-enforce.js`) blocks file edits by phase:
+  - RED: only `.test.*`/`.spec.*` files
+  - GREEN: only source files + test helpers
+  - REFACTOR: all files
+- `exception` mode for config-only changes — overwrites state directly, not via transition graph.
+
+### Security
+- All ticket-ID-to-path conversions validated against directory traversal.
+- `protect-state-files.js` guards `.work-state.json` etc. from direct edits.
+- `protect-artifact-files.js` enforces step+agent authorization for report files.
+- Agent-gated scripts require both correct agent identity AND correct workflow step.
+
+### Ticket Providers
+- Configured via `TICKET_PROVIDER` env var: `jira`, `linear`, `github`, `none`.
+- GitHub issues use `#N` IDs, sanitized to `GH-N` for filesystem paths.
+- `ticket-provider.js` handles all provider-specific logic.
+
+### Formatting
+- `pnpm format` — biome formatter
+- `pnpm format:check` — check only


### PR DESCRIPTION
## Existing Behavior

- No root-level orientation files exist for contributors or reviewers discovering the repository
- Agent catalog, authorization rules, and project conventions are only documented in `docs/README.md`, which is not surfaced automatically by tools that inspect the repo root
- Review guidelines specific to this codebase (CommonJS-only, no TypeScript, `node:test`, fail-open hooks) are not present at the root level

## Intended New Behavior

- `CLAUDE.md` at the root provides an operational project overview: language/runtime rules, testing commands, code conventions, file organization, state machine summary, TDD enforcement model, and security model — all linking to `docs/README.md` for deeper reference
- `AGENTS.md` at the root provides a structured agent catalog grouped by role (Planning, Development, Quality, PR & Commit, Coordination), auto-dispatch mapping for `/work` steps, agent-gated script authorization table, and review guidelines that prevent incorrect suggestions specific to this codebase
- Both files cross-link each other and `docs/README.md` so any entry point leads to the full documentation tree

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Documentation-only change. Verify by inspecting the two new root files:

1. `cat CLAUDE.md` — confirm project overview, dev rules, state machine, and TDD enforcement sections are present and accurate
2. `cat AGENTS.md` — confirm agent catalog tables, review guidelines, auto-dispatch map, and authorization table are present
3. Confirm all cross-links resolve: `CLAUDE.md` links to `AGENTS.md` and `docs/README.md`; `AGENTS.md` links to `docs/README.md`
4. Open the repo root on GitHub and verify both files render correctly as markdown