### PR TITLE
feat(check): scope check reports per-task when tasks.md exists

### DIFF
--- a/workflows/lib/__tests__/tests-common-report-folder.test.js
+++ b/workflows/lib/__tests__/tests-common-report-folder.test.js
@@ -1,0 +1,78 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const TESTS_COMMON = path.resolve(
+  __dirname,
+  '..',
+  'tests-common.sh',
+);
+
+describe('tests-common.sh REPORT_FOLDER handling', () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-folder-test-'));
+    // Initialise a tiny git repo so tests_lib_init can detect GIT_ROOT
+    execSync('git init && git config user.email "test@test.com" && git config user.name "Test" && git commit --allow-empty -m init', {
+      cwd: tmpDir,
+      stdio: 'pipe',
+    });
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('preserves a pre-set REPORT_FOLDER', () => {
+    const customFolder = path.join(tmpDir, 'custom-reports');
+    // Source tests-common.sh with REPORT_FOLDER already set, then print it
+    const script = [
+      `export REPORT_FOLDER="${customFolder}"`,
+      `source "${TESTS_COMMON}"`,
+      `tests_lib_init`,
+      `echo "$REPORT_FOLDER"`,
+    ].join('\n');
+
+    const result = execSync(`bash -c '${script.replace(/'/g, "'\\''")}'`, {
+      cwd: tmpDir,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    assert.equal(result, customFolder, 'REPORT_FOLDER should be the pre-set value');
+    assert.ok(
+      fs.existsSync(customFolder),
+      'mkdir -p should have created the custom folder',
+    );
+  });
+
+  it('computes default REPORT_FOLDER when not pre-set', () => {
+    // Source tests-common.sh without setting REPORT_FOLDER
+    const script = [
+      'unset REPORT_FOLDER',
+      `source "${TESTS_COMMON}"`,
+      'tests_lib_init',
+      'echo "$REPORT_FOLDER"',
+    ].join('\n');
+
+    const result = execSync(`bash -c '${script.replace(/'/g, "'\\''")}'`, {
+      cwd: tmpDir,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    // Default pattern: $HOME/worktrees/tasks/${TASK_FOLDER}
+    assert.ok(
+      result.includes('/worktrees/tasks/'),
+      `Expected default path to contain /worktrees/tasks/, got: ${result}`,
+    );
+    assert.ok(
+      !result.includes('custom-reports'),
+      'Should not contain the custom folder name',
+    );
+  });
+});

--- a/workflows/work/__tests__/artifact-archival.test.js
+++ b/workflows/work/__tests__/artifact-archival.test.js
@@ -151,6 +151,8 @@ describe('archiveStepArtifacts', () => {
   // ─── Per-task archival (GH-259 Task 6) ──────────────────────────────────
 
   it('archives per-task files to runs/runN/taskM/', () => {
+    // tasks.md must exist for per-task archival (GH-259)
+    fs.writeFileSync(path.join(tmpDir, 'tasks.md'), '# Tasks\n', 'utf-8');
     // Create task subdirectories with artifact files
     fs.mkdirSync(path.join(tmpDir, 'task1'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, 'task2'), { recursive: true });
@@ -171,6 +173,8 @@ describe('archiveStepArtifacts', () => {
   });
 
   it('archives root and per-task files together', () => {
+    // tasks.md must exist for per-task archival (GH-259)
+    fs.writeFileSync(path.join(tmpDir, 'tasks.md'), '# Tasks\n', 'utf-8');
     // Root-level artifact
     touch('dev-quality.check.md');
 

--- a/workflows/work/__tests__/artifact-archival.test.js
+++ b/workflows/work/__tests__/artifact-archival.test.js
@@ -147,4 +147,65 @@ describe('archiveStepArtifacts', () => {
     // Artifact moved
     assert.ok(!fs.existsSync(path.join(tmpDir, 'dev-quality.check.md')));
   });
+
+  // ─── Per-task archival (GH-259 Task 6) ──────────────────────────────────
+
+  it('archives per-task files to runs/runN/taskM/', () => {
+    // Create task subdirectories with artifact files
+    fs.mkdirSync(path.join(tmpDir, 'task1'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'task2'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'task1', 'code-review.check.md'), 'review1', 'utf-8');
+    fs.writeFileSync(path.join(tmpDir, 'task2', 'tests.check.md'), 'review2', 'utf-8');
+
+    const result = archiveStepArtifacts(tmpDir, [STEPS.check]);
+    assert.equal(result, 'runs/run1');
+
+    // Per-task files archived to per-task run dirs
+    const runDir = path.join(tmpDir, 'runs', 'run1');
+    assert.ok(fs.existsSync(path.join(runDir, 'task1', 'code-review.check.md')));
+    assert.ok(fs.existsSync(path.join(runDir, 'task2', 'tests.check.md')));
+
+    // Original files removed
+    assert.ok(!fs.existsSync(path.join(tmpDir, 'task1', 'code-review.check.md')));
+    assert.ok(!fs.existsSync(path.join(tmpDir, 'task2', 'tests.check.md')));
+  });
+
+  it('archives root and per-task files together', () => {
+    // Root-level artifact
+    touch('dev-quality.check.md');
+
+    // Per-task artifacts
+    fs.mkdirSync(path.join(tmpDir, 'task1'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'task1', 'lint.check.md'), 'task1-lint', 'utf-8');
+
+    const result = archiveStepArtifacts(tmpDir, [STEPS.check]);
+    assert.equal(result, 'runs/run1');
+
+    const runDir = path.join(tmpDir, 'runs', 'run1');
+    // Root file at run root
+    assert.ok(fs.existsSync(path.join(runDir, 'dev-quality.check.md')));
+    // Per-task file in task subdir
+    assert.ok(fs.existsSync(path.join(runDir, 'task1', 'lint.check.md')));
+
+    // Originals removed
+    assert.ok(!fs.existsSync(path.join(tmpDir, 'dev-quality.check.md')));
+    assert.ok(!fs.existsSync(path.join(tmpDir, 'task1', 'lint.check.md')));
+  });
+
+  it('handles single-task mode (no task dirs) unchanged', () => {
+    // Only root-level files, no taskN/ directories
+    touch('dev-quality.check.md');
+
+    const result = archiveStepArtifacts(tmpDir, [STEPS.check]);
+    assert.equal(result, 'runs/run1');
+
+    const runDir = path.join(tmpDir, 'runs', 'run1');
+    assert.ok(fs.existsSync(path.join(runDir, 'dev-quality.check.md')));
+    assert.ok(!fs.existsSync(path.join(tmpDir, 'dev-quality.check.md')));
+
+    // No taskN/ dirs should exist in run dir
+    const runContents = fs.readdirSync(runDir);
+    const taskDirs = runContents.filter(d => /^task\d+$/.test(d));
+    assert.equal(taskDirs.length, 0);
+  });
 });

--- a/workflows/work/__tests__/check-gate.test.js
+++ b/workflows/work/__tests__/check-gate.test.js
@@ -350,11 +350,53 @@ describe('check-gate (unit)', () => {
     assert.ok(reasons[0].toLowerCase().includes('json'));
   });
 
-  it('per-task-tdd-evidence rule skips when tasks.md exists but no taskN dirs yet', () => {
+  it('per-task-tdd-evidence rule fails when tasks.md declares tasks but no taskN dirs exist', () => {
     const dir = path.join(TEMP, testTicket);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1\n');
-    // No task directories created yet
+    // No task directories created yet — gate must catch this
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'per-task-tdd-evidence');
+    const reasons = rule.check(dir, testTicket);
+    assert.equal(reasons.length, 1);
+    assert.ok(reasons[0].includes('task1'));
+    assert.ok(reasons[0].toLowerCase().includes('tdd'));
+  });
+
+  it('per-task-tdd-evidence rule fails when tasks.md declares 3 tasks but only 2 dirs exist', () => {
+    const dir = path.join(TEMP, testTicket);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1\n## Task 2\n## Task 3\n');
+    writeTaskFile(
+      'task1',
+      'tdd-phase.json',
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+    writeTaskFile(
+      'task2',
+      'tdd-phase.json',
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+    // task3 directory does not exist at all
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'per-task-tdd-evidence');
+    const reasons = rule.check(dir, testTicket);
+    assert.equal(reasons.length, 1);
+    assert.ok(reasons[0].includes('task3'));
+    assert.ok(reasons[0].toLowerCase().includes('tdd'));
+  });
+
+  it('per-task-tdd-evidence rule skips checkpoint tasks from tasks.md', () => {
+    const dir = path.join(TEMP, testTicket);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'tasks.md'),
+      '# Tasks\n\n## Task 1\n— Implement feature\n### Type\nimplementation\n\n## Task 2\n— Checkpoint\n### Type\ncheckpoint\n'
+    );
+    writeTaskFile(
+      'task1',
+      'tdd-phase.json',
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+    // task2 is a checkpoint — no dir needed
     const rule = CHECK_GATE_RULES.find((r) => r.name === 'per-task-tdd-evidence');
     const reasons = rule.check(dir, testTicket);
     assert.deepStrictEqual(reasons, []);

--- a/workflows/work/__tests__/check-gate.test.js
+++ b/workflows/work/__tests__/check-gate.test.js
@@ -22,8 +22,8 @@ beforeEach(() => {
 });
 
 describe('check-gate (unit)', () => {
-  it('CHECK_GATE_RULES has 4 rules with required shape', () => {
-    assert.equal(CHECK_GATE_RULES.length, 4);
+  it('CHECK_GATE_RULES has 5 rules with required shape', () => {
+    assert.equal(CHECK_GATE_RULES.length, 5);
     for (const rule of CHECK_GATE_RULES) {
       assert.ok(rule.name, 'rule must have a name');
       assert.ok(rule.description, 'rule must have a description');
@@ -240,6 +240,170 @@ describe('check-gate (unit)', () => {
       delete require.cache[configPath];
       delete require.cache[gatePath];
     }
+  });
+
+  // ─── GH-259: per-task TDD evidence gate ──────────────────────────────────
+
+  function writeTaskFile(taskDir, name, content) {
+    const dir = path.join(TEMP, testTicket, taskDir);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, name), content);
+  }
+
+  it('per-task-tdd-evidence rule passes when tasks.md exists and all tasks have TDD evidence', () => {
+    const dir = path.join(TEMP, testTicket);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1\n## Task 2\n');
+    writeTaskFile(
+      'task1',
+      'tdd-phase.json',
+      JSON.stringify({
+        cycles: [{ red: { ts: 1 }, green: { ts: 2 } }],
+      })
+    );
+    writeTaskFile(
+      'task2',
+      'tdd-phase.json',
+      JSON.stringify({
+        cycles: [{ red: { ts: 1 }, green: { ts: 2 } }],
+      })
+    );
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'per-task-tdd-evidence');
+    assert.ok(rule, 'per-task-tdd-evidence rule must exist');
+    const reasons = rule.check(dir, testTicket);
+    assert.deepStrictEqual(reasons, []);
+  });
+
+  it('per-task-tdd-evidence rule fails when a task dir is missing tdd-phase.json', () => {
+    const dir = path.join(TEMP, testTicket);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1\n## Task 2\n');
+    writeTaskFile(
+      'task1',
+      'tdd-phase.json',
+      JSON.stringify({
+        cycles: [{ red: { ts: 1 }, green: { ts: 2 } }],
+      })
+    );
+    // task2 exists but no tdd-phase.json
+    fs.mkdirSync(path.join(dir, 'task2'), { recursive: true });
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'per-task-tdd-evidence');
+    const reasons = rule.check(dir, testTicket);
+    assert.equal(reasons.length, 1);
+    assert.ok(reasons[0].includes('task2'));
+    assert.ok(reasons[0].toLowerCase().includes('tdd'));
+  });
+
+  it('per-task-tdd-evidence rule fails when tdd-phase.json has no complete cycle', () => {
+    const dir = path.join(TEMP, testTicket);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1\n');
+    writeTaskFile(
+      'task1',
+      'tdd-phase.json',
+      JSON.stringify({
+        cycles: [{ red: { ts: 1 } }], // no green
+      })
+    );
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'per-task-tdd-evidence');
+    const reasons = rule.check(dir, testTicket);
+    assert.equal(reasons.length, 1);
+    assert.ok(reasons[0].includes('task1'));
+    assert.ok(reasons[0].includes('RED'));
+  });
+
+  it('per-task-tdd-evidence rule passes when tdd-phase.json has exception mode', () => {
+    const dir = path.join(TEMP, testTicket);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1\n');
+    writeTaskFile(
+      'task1',
+      'tdd-phase.json',
+      JSON.stringify({
+        exception: 'config-only change',
+        cycles: [],
+      })
+    );
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'per-task-tdd-evidence');
+    const reasons = rule.check(dir, testTicket);
+    assert.deepStrictEqual(reasons, []);
+  });
+
+  it('per-task-tdd-evidence rule skips when no tasks.md (single-task mode)', () => {
+    const dir = path.join(TEMP, testTicket);
+    fs.mkdirSync(dir, { recursive: true });
+    // No tasks.md
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'per-task-tdd-evidence');
+    const reasons = rule.check(dir, testTicket);
+    assert.deepStrictEqual(reasons, []);
+  });
+
+  it('per-task-tdd-evidence rule fails when tdd-phase.json is invalid JSON', () => {
+    const dir = path.join(TEMP, testTicket);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1\n');
+    writeTaskFile('task1', 'tdd-phase.json', 'not valid json{{{');
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'per-task-tdd-evidence');
+    const reasons = rule.check(dir, testTicket);
+    assert.equal(reasons.length, 1);
+    assert.ok(reasons[0].includes('task1'));
+    assert.ok(reasons[0].toLowerCase().includes('json'));
+  });
+
+  it('per-task-tdd-evidence rule skips when tasks.md exists but no taskN dirs yet', () => {
+    const dir = path.join(TEMP, testTicket);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1\n');
+    // No task directories created yet
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'per-task-tdd-evidence');
+    const reasons = rule.check(dir, testTicket);
+    assert.deepStrictEqual(reasons, []);
+  });
+
+  it('validateCheckGate multi-task: passes when all reports + TDD evidence present', () => {
+    const dir = path.join(TEMP, testTicket);
+    writeReport('tests.check.md', 'Status: APPROVED');
+    writeReport('code-review.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1\n## Task 2\n');
+    writeTaskFile(
+      'task1',
+      'tdd-phase.json',
+      JSON.stringify({
+        cycles: [{ red: { ts: 1 }, green: { ts: 2 } }],
+      })
+    );
+    writeTaskFile(
+      'task2',
+      'tdd-phase.json',
+      JSON.stringify({
+        cycles: [{ red: { ts: 1 }, green: { ts: 2 } }],
+      })
+    );
+    const result = validateCheckGate(TEMP, testTicket);
+    // Filter out running-agents and spec-verification (env-dependent)
+    const tddReasons = result.reasons.filter((r) => r.toLowerCase().includes('tdd'));
+    assert.deepStrictEqual(tddReasons, []);
+  });
+
+  it('validateCheckGate multi-task: fails when task2 missing TDD evidence', () => {
+    const dir = path.join(TEMP, testTicket);
+    writeReport('tests.check.md', 'Status: APPROVED');
+    writeReport('code-review.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1\n## Task 2\n');
+    writeTaskFile(
+      'task1',
+      'tdd-phase.json',
+      JSON.stringify({
+        cycles: [{ red: { ts: 1 }, green: { ts: 2 } }],
+      })
+    );
+    fs.mkdirSync(path.join(dir, 'task2'), { recursive: true });
+    // task2 has no tdd-phase.json
+    const result = validateCheckGate(TEMP, testTicket);
+    assert.equal(result.valid, false);
+    assert.ok(result.reasons.some((r) => r.includes('task2') && r.toLowerCase().includes('tdd')));
   });
 
   it('spec-verification rule passes when spec has no checklist (scenario 12)', () => {

--- a/workflows/work/__tests__/check-step-rework.test.js
+++ b/workflows/work/__tests__/check-step-rework.test.js
@@ -45,10 +45,10 @@ describe('check step: rework preCommands (GH-259 Task 7.3)', () => {
       'should still clean ticket-root *.check.md'
     );
 
-    // New cleanup: per-task *.check.md (e.g. rm -f "${tasksDir}"/task*/*.check.md)
+    // New cleanup: per-task *.check.md (e.g. rm -f "${tasksDir}"/task[0-9]*/*.check.md)
     assert.ok(
-      preCommands.some((cmd) => /task\*/.test(cmd) && /\*\.check\.md/.test(cmd)),
-      'should clean per-task *.check.md files (task*/*.check.md)'
+      preCommands.some((cmd) => /task\[0-9\]\*/.test(cmd) && /\*\.check\.md/.test(cmd)),
+      'should clean per-task *.check.md files (task[0-9]*/*.check.md)'
     );
   });
 

--- a/workflows/work/__tests__/check-step-rework.test.js
+++ b/workflows/work/__tests__/check-step-rework.test.js
@@ -1,0 +1,88 @@
+/**
+ * check-step-rework.test.js
+ *
+ * GH-259 Task 7.3: Tests that check step rework preCommands include
+ * per-task *.check.md cleanup pattern.
+ *
+ * Uses node:test + node:assert/strict.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const checkStep = require('../steps/check');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function collectActions(s, ctx) {
+  const actions = [];
+  const add = (step, action, tool, reason, opts) => {
+    actions.push({ step, action, tool, reason, opts });
+  };
+  checkStep(add, s, ctx);
+  return actions;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('check step: rework preCommands (GH-259 Task 7.3)', () => {
+  it('includes per-task *.check.md cleanup in rework preCommands', () => {
+    const tasksDir = '/tmp/test-tasks/GH-259';
+    const ctx = {
+      STEPS: { check: 'check' },
+      rework: true,
+      tasksDir,
+    };
+    const actions = collectActions(null, ctx);
+
+    assert.equal(actions.length, 1, 'rework should produce one action');
+    const preCommands = actions[0].opts.preCommands;
+    assert.ok(Array.isArray(preCommands), 'preCommands should be an array');
+
+    // Existing cleanup: ticket-root *.check.md (e.g. rm -f "${tasksDir}"/*.check.md)
+    assert.ok(
+      preCommands.some((cmd) => /\*\.check\.md/.test(cmd) && !/task\*/.test(cmd)),
+      'should still clean ticket-root *.check.md'
+    );
+
+    // New cleanup: per-task *.check.md (e.g. rm -f "${tasksDir}"/task*/*.check.md)
+    assert.ok(
+      preCommands.some((cmd) => /task\*/.test(cmd) && /\*\.check\.md/.test(cmd)),
+      'should clean per-task *.check.md files (task*/*.check.md)'
+    );
+  });
+
+  it('preserves existing pr-update-sha cleanup in rework preCommands', () => {
+    const tasksDir = '/tmp/test-tasks/GH-259';
+    const ctx = {
+      STEPS: { check: 'check' },
+      rework: true,
+      tasksDir,
+    };
+    const actions = collectActions(null, ctx);
+    const preCommands = actions[0].opts.preCommands;
+
+    assert.ok(
+      preCommands.some((cmd) => cmd.includes('.pr-update-sha')),
+      'should still clean .pr-update-sha'
+    );
+    assert.ok(
+      preCommands.some((cmd) => cmd.includes('.post-pr-update-sha')),
+      'should still clean .post-pr-update-sha'
+    );
+  });
+
+  it('non-rework mode does not have per-task cleanup', () => {
+    const tasksDir = '/tmp/test-tasks/GH-259';
+    const ctx = {
+      STEPS: { check: 'check' },
+      rework: false,
+      tasksDir,
+    };
+    const s = { allReportsPass: false, missingReports: ['tests.check.md'], failedReports: [] };
+    const actions = collectActions(s, ctx);
+
+    assert.equal(actions.length, 1);
+    assert.equal(actions[0].opts.preCommands, undefined, 'non-rework should have no preCommands');
+  });
+});

--- a/workflows/work/__tests__/inspect-per-task-reports.test.js
+++ b/workflows/work/__tests__/inspect-per-task-reports.test.js
@@ -1,0 +1,179 @@
+/**
+ * inspect-per-task-reports.test.js
+ *
+ * GH-259 Task 7.1: Tests that inspect.js populates s.perTaskReports
+ * when tasks.md and taskN/ directories exist in the ticket's tasksDir.
+ *
+ * Uses node:test + node:assert/strict with temp filesystem fixtures.
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const { inspect } = require('../inspect');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'inspect-per-task-'));
+}
+
+/**
+ * Build minimal deps for inspect(). All side-effecting ops are faked
+ * to avoid real git/tmux calls.
+ */
+function makeDeps(tasksBase) {
+  return {
+    tp: { sanitizeTicketIdForPath: (id) => id },
+    run: () => '',
+    fileExists: (p) => fs.existsSync(p),
+    readFile: (p) => fs.readFileSync(p, 'utf-8'),
+    listFiles: (dir, pattern) => {
+      try {
+        return fs
+          .readdirSync(dir)
+          .filter((f) => pattern.test(f))
+          .map((f) => path.join(dir, f));
+      } catch {
+        return [];
+      }
+    },
+    loadWorkState: () => null,
+    getCurrentStep: () => null,
+    REQUIRED_REPORTS: [],
+    WORKTREES_BASE: '/tmp/nonexistent-worktrees',
+    TASKS_BASE: tasksBase,
+    MAIN_WORKTREE_FOLDER: 'repo',
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('inspect: perTaskReports aggregation (GH-259 Task 7.1)', () => {
+  const tmpDirs = [];
+  after(() => {
+    for (const d of tmpDirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  it('populates s.perTaskReports when tasks.md and taskN/ dirs exist', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketDir = path.join(tmp, 'GH-259');
+    fs.mkdirSync(ticketDir, { recursive: true });
+    fs.writeFileSync(path.join(ticketDir, 'tasks.md'), '# Tasks\n## Task 1\n## Task 2\n');
+
+    // Create task1 with check reports and tdd-phase.json
+    const task1Dir = path.join(ticketDir, 'task1');
+    fs.mkdirSync(task1Dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(task1Dir, 'tdd-phase.json'),
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+    fs.writeFileSync(path.join(task1Dir, 'code-review.check.md'), 'Status: APPROVED');
+
+    // Create task2 with only tdd-phase.json
+    const task2Dir = path.join(ticketDir, 'task2');
+    fs.mkdirSync(task2Dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(task2Dir, 'tdd-phase.json'),
+      JSON.stringify({ cycles: [{ red: { ts: 1 } }] })
+    );
+
+    const deps = makeDeps(tmp);
+    const s = inspect('GH-259', {}, null, deps);
+
+    assert.ok(s.perTaskReports, 'perTaskReports should be defined');
+    assert.ok(s.perTaskReports.task1, 'task1 entry should exist');
+    assert.ok(s.perTaskReports.task2, 'task2 entry should exist');
+
+    // task1 has tdd-phase.json and a check.md file
+    assert.ok(s.perTaskReports.task1.tddPhase, 'task1 should have tddPhase');
+    assert.ok(
+      Array.isArray(s.perTaskReports.task1.checkReports),
+      'task1 checkReports should be array'
+    );
+    assert.equal(s.perTaskReports.task1.checkReports.length, 1);
+
+    // task2 has tdd-phase.json but no check.md files
+    assert.ok(s.perTaskReports.task2.tddPhase, 'task2 should have tddPhase');
+    assert.equal(s.perTaskReports.task2.checkReports.length, 0);
+  });
+
+  it('does NOT set s.perTaskReports when no tasks.md exists', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketDir = path.join(tmp, 'GH-100');
+    fs.mkdirSync(ticketDir, { recursive: true });
+
+    const deps = makeDeps(tmp);
+    const s = inspect('GH-100', {}, null, deps);
+
+    assert.equal(
+      s.perTaskReports,
+      undefined,
+      'perTaskReports should be undefined without tasks.md'
+    );
+  });
+
+  it('handles tasks.md present but no taskN/ directories', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketDir = path.join(tmp, 'GH-101');
+    fs.mkdirSync(ticketDir, { recursive: true });
+    fs.writeFileSync(path.join(ticketDir, 'tasks.md'), '# Tasks\n## Task 1\n');
+
+    const deps = makeDeps(tmp);
+    const s = inspect('GH-101', {}, null, deps);
+
+    assert.ok(s.perTaskReports, 'perTaskReports should still be defined');
+    assert.deepStrictEqual(s.perTaskReports, {}, 'but should be empty object');
+  });
+
+  it('includes tddPhase status from tdd-phase.json content', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketDir = path.join(tmp, 'GH-102');
+    fs.mkdirSync(ticketDir, { recursive: true });
+    fs.writeFileSync(path.join(ticketDir, 'tasks.md'), '# Tasks\n## Task 1\n');
+
+    const task1Dir = path.join(ticketDir, 'task1');
+    fs.mkdirSync(task1Dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(task1Dir, 'tdd-phase.json'),
+      JSON.stringify({ exception: 'config-only', cycles: [] })
+    );
+
+    const deps = makeDeps(tmp);
+    const s = inspect('GH-102', {}, null, deps);
+
+    assert.ok(s.perTaskReports.task1.tddPhase, 'tddPhase should exist');
+    assert.equal(
+      s.perTaskReports.task1.tddPhase.exception,
+      true,
+      'exception mode should be flagged'
+    );
+  });
+
+  it('preserves s.reports for backward compatibility', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketDir = path.join(tmp, 'GH-103');
+    fs.mkdirSync(ticketDir, { recursive: true });
+    fs.writeFileSync(path.join(ticketDir, 'tasks.md'), '# Tasks\n## Task 1\n');
+
+    const deps = makeDeps(tmp);
+    const s = inspect('GH-103', {}, null, deps);
+
+    assert.ok(s.reports !== undefined, 's.reports should still exist');
+    assert.equal(typeof s.reports, 'object');
+  });
+});

--- a/workflows/work/__tests__/verify-per-task.test.js
+++ b/workflows/work/__tests__/verify-per-task.test.js
@@ -135,6 +135,69 @@ describe('workflow-definition: check verify with per-task TDD (GH-259 Task 7.2)'
     assert.equal(verify(ticketId), true);
   });
 
+  it('check verify fails when tasks.md declares 3 tasks but only 2 dirs exist', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketId = 'GH-280';
+    const dir = path.join(tmp, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), '# README');
+    fs.writeFileSync(path.join(dir, 'qa-feature.check.md'), 'Status: APPROVED');
+
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n## Task 1\n## Task 2\n## Task 3\n');
+    const task1 = path.join(dir, 'task1');
+    const task2 = path.join(dir, 'task2');
+    fs.mkdirSync(task1, { recursive: true });
+    fs.mkdirSync(task2, { recursive: true });
+    fs.writeFileSync(
+      path.join(task1, 'tdd-phase.json'),
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+    fs.writeFileSync(
+      path.join(task2, 'tdd-phase.json'),
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+    // task3 dir does not exist — gate must catch this
+
+    const { workflow } = createWorkflowDefinition(makeDeps(tmp));
+    const verify = getVerify(workflow, STEPS.check);
+    assert.equal(verify(ticketId), false);
+  });
+
+  it('check verify skips checkpoint tasks from tasks.md', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketId = 'GH-281';
+    const dir = path.join(tmp, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), '# README');
+    fs.writeFileSync(path.join(dir, 'qa-feature.check.md'), 'Status: APPROVED');
+
+    fs.writeFileSync(
+      path.join(dir, 'tasks.md'),
+      '# Tasks\n## Task 1\n— Implement feature\n### Type\nimplementation\n\n## Task 2\n— Checkpoint\n### Type\ncheckpoint\n'
+    );
+    const task1 = path.join(dir, 'task1');
+    fs.mkdirSync(task1, { recursive: true });
+    fs.writeFileSync(
+      path.join(task1, 'tdd-phase.json'),
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+    // task2 is checkpoint — no dir needed
+
+    const { workflow } = createWorkflowDefinition(makeDeps(tmp));
+    const verify = getVerify(workflow, STEPS.check);
+    assert.equal(verify(ticketId), true);
+  });
+
   it('check verify passes when taskN/ has exception mode in tdd-phase.json', () => {
     const tmp = makeTmpDir();
     tmpDirs.push(tmp);

--- a/workflows/work/__tests__/verify-per-task.test.js
+++ b/workflows/work/__tests__/verify-per-task.test.js
@@ -1,0 +1,242 @@
+/**
+ * verify-per-task.test.js
+ *
+ * GH-259 Task 7.2: Tests that workflow-definition.js verify functions
+ * for `check` and `reports` steps account for per-task directories
+ * when tasks.md exists.
+ *
+ * Uses node:test + node:assert/strict with temp filesystem fixtures.
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const createWorkflowDefinition = require(path.join(__dirname, '..', 'workflow-definition'));
+const { STEPS } = require(path.join(__dirname, '..', 'step-registry'));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'verify-per-task-'));
+}
+
+function makeDeps(tasksBase) {
+  return {
+    TASKS_BASE: tasksBase,
+    safeTicketPath: (id) => id,
+    resolveGitHead: () => 'ref: refs/heads/stub',
+  };
+}
+
+function getVerify(workflow, stepId) {
+  const entries = workflow.commandMap.filter(
+    (e) => e.step === stepId && typeof e.verify === 'function'
+  );
+  return entries.length > 0 ? entries[0].verify : undefined;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('workflow-definition: check verify with per-task TDD (GH-259 Task 7.2)', () => {
+  const tmpDirs = [];
+  after(() => {
+    for (const d of tmpDirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  it('check verify passes when tasks.md exists and all taskN/ have valid tdd-phase.json', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketId = 'GH-259';
+    const dir = path.join(tmp, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Required check report files at ticket root
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), '# README');
+    fs.writeFileSync(path.join(dir, 'qa-feature.check.md'), 'Status: APPROVED');
+
+    // tasks.md and per-task TDD evidence
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n## Task 1\n## Task 2\n');
+    const task1 = path.join(dir, 'task1');
+    const task2 = path.join(dir, 'task2');
+    fs.mkdirSync(task1, { recursive: true });
+    fs.mkdirSync(task2, { recursive: true });
+    fs.writeFileSync(
+      path.join(task1, 'tdd-phase.json'),
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+    fs.writeFileSync(
+      path.join(task2, 'tdd-phase.json'),
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+
+    const { workflow } = createWorkflowDefinition(makeDeps(tmp));
+    const verify = getVerify(workflow, STEPS.check);
+    assert.equal(verify(ticketId), true);
+  });
+
+  it('check verify fails when tasks.md exists and a taskN/ lacks tdd-phase.json', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketId = 'GH-260';
+    const dir = path.join(tmp, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Required files at ticket root
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), '# README');
+    fs.writeFileSync(path.join(dir, 'qa-feature.check.md'), 'Status: APPROVED');
+
+    // tasks.md with task dirs but task2 missing tdd-phase.json
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n## Task 1\n## Task 2\n');
+    const task1 = path.join(dir, 'task1');
+    const task2 = path.join(dir, 'task2');
+    fs.mkdirSync(task1, { recursive: true });
+    fs.mkdirSync(task2, { recursive: true });
+    fs.writeFileSync(
+      path.join(task1, 'tdd-phase.json'),
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+
+    const { workflow } = createWorkflowDefinition(makeDeps(tmp));
+    const verify = getVerify(workflow, STEPS.check);
+    assert.equal(verify(ticketId), false);
+  });
+
+  it('check verify still passes in single-task mode (no tasks.md)', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketId = 'GH-261';
+    const dir = path.join(tmp, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Required check files only
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), '# README');
+    fs.writeFileSync(path.join(dir, 'qa-feature.check.md'), 'Status: APPROVED');
+
+    const { workflow } = createWorkflowDefinition(makeDeps(tmp));
+    const verify = getVerify(workflow, STEPS.check);
+    assert.equal(verify(ticketId), true);
+  });
+
+  it('check verify passes when taskN/ has exception mode in tdd-phase.json', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketId = 'GH-262';
+    const dir = path.join(tmp, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), '# README');
+    fs.writeFileSync(path.join(dir, 'qa-feature.check.md'), 'Status: APPROVED');
+
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n## Task 1\n');
+    const task1 = path.join(dir, 'task1');
+    fs.mkdirSync(task1, { recursive: true });
+    fs.writeFileSync(
+      path.join(task1, 'tdd-phase.json'),
+      JSON.stringify({ exception: 'config-only', cycles: [] })
+    );
+
+    const { workflow } = createWorkflowDefinition(makeDeps(tmp));
+    const verify = getVerify(workflow, STEPS.check);
+    assert.equal(verify(ticketId), true);
+  });
+});
+
+describe('workflow-definition: reports verify with per-task dirs (GH-259 Task 7.2)', () => {
+  const tmpDirs = [];
+  after(() => {
+    for (const d of tmpDirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  it('reports verify passes when tasks.md exists and all taskN/ have valid tdd-phase.json', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketId = 'GH-270';
+    const dir = path.join(tmp, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Required approved files at ticket root
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'qa-feature.check.md'), 'Status: APPROVED');
+
+    // tasks.md with per-task evidence
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n## Task 1\n');
+    const task1 = path.join(dir, 'task1');
+    fs.mkdirSync(task1, { recursive: true });
+    fs.writeFileSync(
+      path.join(task1, 'tdd-phase.json'),
+      JSON.stringify({ cycles: [{ red: { ts: 1 }, green: { ts: 2 } }] })
+    );
+
+    const { workflow } = createWorkflowDefinition(makeDeps(tmp));
+    const verify = getVerify(workflow, STEPS.reports);
+    assert.equal(verify(ticketId), true);
+  });
+
+  it('reports verify fails when tasks.md exists and a taskN/ lacks valid tdd evidence', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketId = 'GH-271';
+    const dir = path.join(tmp, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'qa-feature.check.md'), 'Status: APPROVED');
+
+    fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n## Task 1\n');
+    const task1 = path.join(dir, 'task1');
+    fs.mkdirSync(task1, { recursive: true });
+    // no tdd-phase.json in task1
+
+    const { workflow } = createWorkflowDefinition(makeDeps(tmp));
+    const verify = getVerify(workflow, STEPS.reports);
+    assert.equal(verify(ticketId), false);
+  });
+
+  it('reports verify passes in single-task mode (no tasks.md)', () => {
+    const tmp = makeTmpDir();
+    tmpDirs.push(tmp);
+    const ticketId = 'GH-272';
+    const dir = path.join(tmp, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), 'Status: APPROVED');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), 'Status: COMPLETE');
+    fs.writeFileSync(path.join(dir, 'qa-feature.check.md'), 'Status: APPROVED');
+
+    const { workflow } = createWorkflowDefinition(makeDeps(tmp));
+    const verify = getVerify(workflow, STEPS.reports);
+    assert.equal(verify(ticketId), true);
+  });
+});

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -146,6 +146,24 @@ function writeCheckReports(tasksBase, ticket) {
 function writeTddException(tasksBase, ticket) {
   const dir = path.join(tasksBase, ticket);
   fs.mkdirSync(dir, { recursive: true });
+  // Also write per-task TDD evidence when tasks.md declares tasks (GH-259)
+  const tasksPath = path.join(dir, 'tasks.md');
+  if (fs.existsSync(tasksPath)) {
+    try {
+      const tp = require(path.join(__dirname, '..', 'task-parser'));
+      const tasks = tp.parseTasks(dir);
+      if (tasks && tasks.length > 0) {
+        for (const t of tasks.filter((x) => !x.isCheckpoint)) {
+          const taskDir = path.join(dir, `task${t.num}`);
+          fs.mkdirSync(taskDir, { recursive: true });
+          fs.writeFileSync(
+            path.join(taskDir, 'tdd-phase.json'),
+            JSON.stringify({ exception: 'test artifact — orchestrator test', cycles: [] })
+          );
+        }
+      }
+    } catch { /* parseTasks may not be available in all test contexts */ }
+  }
   fs.writeFileSync(
     path.join(dir, 'tdd-phase.json'),
     JSON.stringify({
@@ -190,7 +208,7 @@ function writeTaskArtifacts(tasksBase, ticket) {
     path.join(dir, 'spec.md'),
     '# Spec\n\n<!-- gherkin-skip: test artifact -->\n\n## Summary\nTest spec.\n'
   );
-  fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n- [ ] Task 1\n');
+  fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1 — Test task\n\n### Type\nbackend\n\n### Deliverables\n- [ ] 1.1 Test deliverable\n');
 }
 
 /**

--- a/workflows/work/artifact-archival.js
+++ b/workflows/work/artifact-archival.js
@@ -107,7 +107,8 @@ function archiveStepArtifacts(tasksDir, stepsToArchive) {
   }
 
   // Scan taskN/ subdirectories for matching artifacts (GH-259)
-  try {
+  // Only recurse when tasks.md exists (multi-task mode)
+  if (fileExists(path.join(tasksDir, 'tasks.md'))) try {
     const taskDirs = fs
       .readdirSync(tasksDir)
       .filter((d) => /^task\d+$/.test(d))

--- a/workflows/work/artifact-archival.js
+++ b/workflows/work/artifact-archival.js
@@ -119,7 +119,7 @@ function archiveStepArtifacts(tasksDir, stepsToArchive) {
           return false;
         }
       });
-
+    // GH-259: only recurse when tasks.md exists (multi-task mode)
     for (const taskDir of taskDirs) {
       const taskPath = path.join(tasksDir, taskDir);
       for (const step of stepsToArchive) {

--- a/workflows/work/artifact-archival.js
+++ b/workflows/work/artifact-archival.js
@@ -106,6 +106,51 @@ function archiveStepArtifacts(tasksDir, stepsToArchive) {
     }
   }
 
+  // Scan taskN/ subdirectories for matching artifacts (GH-259)
+  try {
+    const taskDirs = fs
+      .readdirSync(tasksDir)
+      .filter((d) => /^task\d+$/.test(d))
+      .filter((d) => {
+        try {
+          return fs.statSync(path.join(tasksDir, d)).isDirectory();
+        } catch {
+          return false;
+        }
+      });
+
+    for (const taskDir of taskDirs) {
+      const taskPath = path.join(tasksDir, taskDir);
+      for (const step of stepsToArchive) {
+        const patterns = STEP_ARTIFACTS[step];
+        if (!patterns) continue;
+
+        const files = [...new Set(patterns.flatMap((p) => listFiles(taskPath, p)))];
+        if (files.length === 0) continue;
+
+        if (!archived) {
+          fs.mkdirSync(runDir, { recursive: true });
+          archived = true;
+        }
+        const taskRunDir = path.join(runDir, taskDir);
+        fs.mkdirSync(taskRunDir, { recursive: true });
+
+        for (const filePath of files) {
+          const dest = path.join(taskRunDir, path.basename(filePath));
+          try {
+            fs.renameSync(filePath, dest);
+          } catch (e) {
+            process.stderr.write(
+              `work-orchestrator: failed to archive ${taskDir}/${path.basename(filePath)}: ${e?.message || e}\n`
+            );
+          }
+        }
+      }
+    }
+  } catch {
+    /* ignore readdir failures */
+  }
+
   return archived ? `runs/run${runNum}` : null;
 }
 

--- a/workflows/work/check-gate.js
+++ b/workflows/work/check-gate.js
@@ -169,28 +169,7 @@ const CHECK_GATE_RULES = [
       const { validateTddEvidence } = require(path.join(__dirname, 'tdd-enforcement'));
       const taskParser = require(path.join(__dirname, 'task-parser'));
       const tasks = taskParser.parseTasks(dir);
-      if (!tasks || tasks.length === 0) {
-        // Fallback: scan for existing taskN/ dirs when tasks.md is unparseable
-        const fallbackDirs = listFiles(dir, /^task\d+$/).filter((d) => {
-          try { return fs.statSync(d).isDirectory(); } catch { return false; }
-        });
-        if (fallbackDirs.length === 0) return []; // no tasks declared or created yet
-        // Validate discovered dirs
-        const fallbackReasons = [];
-        for (const taskDirPath of fallbackDirs) {
-          const taskName = path.basename(taskDirPath);
-          const tddPath = path.join(taskDirPath, 'tdd-phase.json');
-          if (!fileExists(tddPath)) { fallbackReasons.push(`Missing TDD evidence: ${taskName}/tdd-phase.json`); continue; }
-          try {
-            const state = JSON.parse(readFile(tddPath));
-            const validation = validateTddEvidence(state);
-            if (!validation.valid) fallbackReasons.push(`${taskName}/tdd-phase.json: ${validation.reason}`);
-          } catch (e) {
-            fallbackReasons.push(`${taskName}/tdd-phase.json: ${e instanceof SyntaxError ? 'invalid JSON' : e?.message || 'read error'}`);
-          }
-        }
-        return fallbackReasons;
-      }
+      if (!tasks || tasks.length === 0) return ['Unable to parse tasks.md — cannot verify per-task TDD evidence'];
       const expectedTasks = tasks.filter((t) => !t.isCheckpoint);
       if (expectedTasks.length === 0) return []; // all checkpoint tasks
       const reasons = [];

--- a/workflows/work/check-gate.js
+++ b/workflows/work/check-gate.js
@@ -167,17 +167,15 @@ const CHECK_GATE_RULES = [
       const tasksPath = path.join(dir, 'tasks.md');
       if (!fileExists(tasksPath)) return []; // single-task mode, skip
       const { validateTddEvidence } = require(path.join(__dirname, 'tdd-enforcement'));
-      const taskDirs = listFiles(dir, /^task\d+$/).filter((d) => {
-        try {
-          return fs.statSync(d).isDirectory();
-        } catch {
-          return false;
-        }
-      });
-      if (taskDirs.length === 0) return []; // no task dirs yet
+      const taskParser = require(path.join(__dirname, 'task-parser'));
+      const tasks = taskParser.parseTasks(dir);
+      if (!tasks || tasks.length === 0) return []; // unparseable tasks.md
+      const expectedTasks = tasks.filter((t) => !t.isCheckpoint);
+      if (expectedTasks.length === 0) return []; // all checkpoint tasks
       const reasons = [];
-      for (const taskDirPath of taskDirs) {
-        const taskName = path.basename(taskDirPath);
+      for (const task of expectedTasks) {
+        const taskName = `task${task.num}`;
+        const taskDirPath = path.join(dir, taskName);
         const tddPath = path.join(taskDirPath, 'tdd-phase.json');
         if (!fileExists(tddPath)) {
           reasons.push(`Missing TDD evidence: ${taskName}/tdd-phase.json`);
@@ -190,7 +188,9 @@ const CHECK_GATE_RULES = [
             reasons.push(`${taskName}/tdd-phase.json: ${validation.reason}`);
           }
         } catch (e) {
-          reasons.push(`${taskName}/tdd-phase.json: ${e instanceof SyntaxError ? 'invalid JSON' : e?.message || 'read error'}`);
+          reasons.push(
+            `${taskName}/tdd-phase.json: ${e instanceof SyntaxError ? 'invalid JSON' : e?.message || 'read error'}`
+          );
         }
       }
       return reasons;

--- a/workflows/work/check-gate.js
+++ b/workflows/work/check-gate.js
@@ -169,7 +169,7 @@ const CHECK_GATE_RULES = [
       const { validateTddEvidence } = require(path.join(__dirname, 'tdd-enforcement'));
       const taskParser = require(path.join(__dirname, 'task-parser'));
       const tasks = taskParser.parseTasks(dir);
-      if (!tasks || tasks.length === 0) return []; // unparseable tasks.md
+      if (!tasks || tasks.length === 0) return ['Unable to parse tasks.md — cannot verify per-task TDD evidence'];
       const expectedTasks = tasks.filter((t) => !t.isCheckpoint);
       if (expectedTasks.length === 0) return []; // all checkpoint tasks
       const reasons = [];

--- a/workflows/work/check-gate.js
+++ b/workflows/work/check-gate.js
@@ -166,6 +166,7 @@ const CHECK_GATE_RULES = [
     check(dir) {
       const tasksPath = path.join(dir, 'tasks.md');
       if (!fileExists(tasksPath)) return []; // single-task mode, skip
+      const { validateTddEvidence } = require(path.join(__dirname, 'tdd-enforcement'));
       const taskDirs = listFiles(dir, /^task\d+$/).filter((d) => {
         try {
           return fs.statSync(d).isDirectory();
@@ -183,14 +184,10 @@ const CHECK_GATE_RULES = [
           continue;
         }
         try {
-          const state = JSON.parse(fs.readFileSync(tddPath, 'utf8'));
-          if (typeof state.exception === 'string' && state.exception.trim() !== '') continue;
-          if (!Array.isArray(state.cycles) || state.cycles.length === 0) {
-            reasons.push(`${taskName}/tdd-phase.json has no TDD cycles or exception`);
-            continue;
-          }
-          if (!state.cycles.some((c) => c.red && c.green)) {
-            reasons.push(`${taskName}/tdd-phase.json has no complete RED→GREEN cycle`);
+          const state = JSON.parse(readFile(tddPath));
+          const validation = validateTddEvidence(state);
+          if (!validation.valid) {
+            reasons.push(`${taskName}/tdd-phase.json: ${validation.reason}`);
           }
         } catch {
           reasons.push(`${taskName}/tdd-phase.json is not valid JSON`);

--- a/workflows/work/check-gate.js
+++ b/workflows/work/check-gate.js
@@ -189,8 +189,8 @@ const CHECK_GATE_RULES = [
           if (!validation.valid) {
             reasons.push(`${taskName}/tdd-phase.json: ${validation.reason}`);
           }
-        } catch {
-          reasons.push(`${taskName}/tdd-phase.json is not valid JSON`);
+        } catch (e) {
+          reasons.push(`${taskName}/tdd-phase.json: ${e instanceof SyntaxError ? 'invalid JSON' : e?.message || 'read error'}`);
         }
       }
       return reasons;

--- a/workflows/work/check-gate.js
+++ b/workflows/work/check-gate.js
@@ -161,6 +161,45 @@ const CHECK_GATE_RULES = [
     },
   },
   {
+    name: 'per-task-tdd-evidence',
+    description: 'All tasks must have TDD evidence when tasks.md exists (GH-259)',
+    check(dir) {
+      const tasksPath = path.join(dir, 'tasks.md');
+      if (!fileExists(tasksPath)) return []; // single-task mode, skip
+      const taskDirs = listFiles(dir, /^task\d+$/).filter((d) => {
+        try {
+          return fs.statSync(d).isDirectory();
+        } catch {
+          return false;
+        }
+      });
+      if (taskDirs.length === 0) return []; // no task dirs yet
+      const reasons = [];
+      for (const taskDirPath of taskDirs) {
+        const taskName = path.basename(taskDirPath);
+        const tddPath = path.join(taskDirPath, 'tdd-phase.json');
+        if (!fileExists(tddPath)) {
+          reasons.push(`Missing TDD evidence: ${taskName}/tdd-phase.json`);
+          continue;
+        }
+        try {
+          const state = JSON.parse(fs.readFileSync(tddPath, 'utf8'));
+          if (typeof state.exception === 'string' && state.exception.trim() !== '') continue;
+          if (!Array.isArray(state.cycles) || state.cycles.length === 0) {
+            reasons.push(`${taskName}/tdd-phase.json has no TDD cycles or exception`);
+            continue;
+          }
+          if (!state.cycles.some((c) => c.red && c.green)) {
+            reasons.push(`${taskName}/tdd-phase.json has no complete RED→GREEN cycle`);
+          }
+        } catch {
+          reasons.push(`${taskName}/tdd-phase.json is not valid JSON`);
+        }
+      }
+      return reasons;
+    },
+  },
+  {
     name: 'spec-verification',
     description: 'Spec Verification Checklist markers must all pass (fail-open for legacy specs)',
     check(dir) {

--- a/workflows/work/check-gate.js
+++ b/workflows/work/check-gate.js
@@ -169,7 +169,28 @@ const CHECK_GATE_RULES = [
       const { validateTddEvidence } = require(path.join(__dirname, 'tdd-enforcement'));
       const taskParser = require(path.join(__dirname, 'task-parser'));
       const tasks = taskParser.parseTasks(dir);
-      if (!tasks || tasks.length === 0) return ['Unable to parse tasks.md — cannot verify per-task TDD evidence'];
+      if (!tasks || tasks.length === 0) {
+        // Fallback: scan for existing taskN/ dirs when tasks.md is unparseable
+        const fallbackDirs = listFiles(dir, /^task\d+$/).filter((d) => {
+          try { return fs.statSync(d).isDirectory(); } catch { return false; }
+        });
+        if (fallbackDirs.length === 0) return []; // no tasks declared or created yet
+        // Validate discovered dirs
+        const fallbackReasons = [];
+        for (const taskDirPath of fallbackDirs) {
+          const taskName = path.basename(taskDirPath);
+          const tddPath = path.join(taskDirPath, 'tdd-phase.json');
+          if (!fileExists(tddPath)) { fallbackReasons.push(`Missing TDD evidence: ${taskName}/tdd-phase.json`); continue; }
+          try {
+            const state = JSON.parse(readFile(tddPath));
+            const validation = validateTddEvidence(state);
+            if (!validation.valid) fallbackReasons.push(`${taskName}/tdd-phase.json: ${validation.reason}`);
+          } catch (e) {
+            fallbackReasons.push(`${taskName}/tdd-phase.json: ${e instanceof SyntaxError ? 'invalid JSON' : e?.message || 'read error'}`);
+          }
+        }
+        return fallbackReasons;
+      }
       const expectedTasks = tasks.filter((t) => !t.isCheckpoint);
       if (expectedTasks.length === 0) return []; // all checkpoint tasks
       const reasons = [];

--- a/workflows/work/inspect.js
+++ b/workflows/work/inspect.js
@@ -136,7 +136,9 @@ function inspect(ticket, providerConfig, suffix, deps) {
   // Uses deps.fileExists/readFile/listFiles for testability (consistent with the rest of inspect).
   if (fileExists(path.join(s.tasksDir, 'tasks.md'))) {
     s.perTaskReports = {};
-    const taskDirNames = listFiles(s.tasksDir, /^task\d+$/).map((fp) => path.basename(fp));
+    const taskDirNames = listFiles(s.tasksDir, /^task\d+$/)
+      .filter((fp) => { try { return fs.statSync(fp).isDirectory(); } catch { return false; } })
+      .map((fp) => path.basename(fp));
     for (const taskDirName of taskDirNames) {
       const taskDir = path.join(s.tasksDir, taskDirName);
       const taskReport = { tddPhase: null, checkReports: [] };

--- a/workflows/work/inspect.js
+++ b/workflows/work/inspect.js
@@ -133,8 +133,10 @@ function inspect(ticket, providerConfig, suffix, deps) {
 
   // Per-task reports (GH-259 Task 7.1)
   // When tasks.md exists, scan taskN/ subdirectories for check reports and TDD evidence.
-  // Uses deps.fileExists/readFile/listFiles for testability (consistent with the rest of inspect).
+  // Uses deps.listFiles/fileExists/readFile for most I/O; fs.statSync for directory detection
+  // (no deps.isDirectory exists — acceptable since listFiles already filters by regex).
   if (fileExists(path.join(s.tasksDir, 'tasks.md'))) {
+    const { validateTddEvidence } = require(path.join(__dirname, 'tdd-enforcement'));
     s.perTaskReports = {};
     const taskDirNames = listFiles(s.tasksDir, /^task\d+$/)
       .filter((fp) => { try { return fs.statSync(fp).isDirectory(); } catch { return false; } })
@@ -143,18 +145,17 @@ function inspect(ticket, providerConfig, suffix, deps) {
       const taskDir = path.join(s.tasksDir, taskDirName);
       const taskReport = { tddPhase: null, checkReports: [] };
 
-      // Read tdd-phase.json if present
+      // Read tdd-phase.json if present — uses shared validateTddEvidence for consistency
       const tddPath = path.join(taskDir, 'tdd-phase.json');
       if (fileExists(tddPath)) {
         try {
           const tddData = JSON.parse(readFile(tddPath));
+          const validation = validateTddEvidence(tddData);
           const hasException =
             typeof tddData.exception === 'string' && tddData.exception.trim() !== '';
-          const hasCompleteCycle =
-            Array.isArray(tddData.cycles) && tddData.cycles.some((c) => c.red && c.green);
           taskReport.tddPhase = {
             exists: true,
-            valid: hasException || hasCompleteCycle,
+            valid: validation.valid,
             exception: hasException,
             cycleCount: Array.isArray(tddData.cycles) ? tddData.cycles.length : 0,
           };

--- a/workflows/work/inspect.js
+++ b/workflows/work/inspect.js
@@ -157,9 +157,9 @@ function inspect(ticket, providerConfig, suffix, deps) {
             cycleCount: Array.isArray(tddData.cycles) ? tddData.cycles.length : 0,
           };
         } catch {
-          taskReport.tddPhase = { exists: true, valid: false, parseError: true }; // GH-259: uses deps.listFiles
+          taskReport.tddPhase = { exists: true, valid: false, parseError: true };
         }
-      } // end tdd-phase check
+      }
 
       // Scan for *.check.md files in the task dir
       taskReport.checkReports = listFiles(taskDir, /\.check\.md$/).map((fp) => path.basename(fp));

--- a/workflows/work/inspect.js
+++ b/workflows/work/inspect.js
@@ -157,9 +157,9 @@ function inspect(ticket, providerConfig, suffix, deps) {
             cycleCount: Array.isArray(tddData.cycles) ? tddData.cycles.length : 0,
           };
         } catch {
-          taskReport.tddPhase = { exists: true, valid: false, parseError: true };
+          taskReport.tddPhase = { exists: true, valid: false, parseError: true }; // GH-259: uses deps.listFiles
         }
-      }
+      } // end tdd-phase check
 
       // Scan for *.check.md files in the task dir
       taskReport.checkReports = listFiles(taskDir, /\.check\.md$/).map((fp) => path.basename(fp));

--- a/workflows/work/inspect.js
+++ b/workflows/work/inspect.js
@@ -131,6 +131,43 @@ function inspect(ticket, providerConfig, suffix, deps) {
     }
   }
 
+  // Per-task reports (GH-259 Task 7.1)
+  // When tasks.md exists, scan taskN/ subdirectories for check reports and TDD evidence.
+  // Uses deps.fileExists/readFile/listFiles for testability (consistent with the rest of inspect).
+  if (fileExists(path.join(s.tasksDir, 'tasks.md'))) {
+    s.perTaskReports = {};
+    const taskDirNames = listFiles(s.tasksDir, /^task\d+$/).map((fp) => path.basename(fp));
+    for (const taskDirName of taskDirNames) {
+      const taskDir = path.join(s.tasksDir, taskDirName);
+      const taskReport = { tddPhase: null, checkReports: [] };
+
+      // Read tdd-phase.json if present
+      const tddPath = path.join(taskDir, 'tdd-phase.json');
+      if (fileExists(tddPath)) {
+        try {
+          const tddData = JSON.parse(readFile(tddPath));
+          const hasException =
+            typeof tddData.exception === 'string' && tddData.exception.trim() !== '';
+          const hasCompleteCycle =
+            Array.isArray(tddData.cycles) && tddData.cycles.some((c) => c.red && c.green);
+          taskReport.tddPhase = {
+            exists: true,
+            valid: hasException || hasCompleteCycle,
+            exception: hasException,
+            cycleCount: Array.isArray(tddData.cycles) ? tddData.cycles.length : 0,
+          };
+        } catch {
+          taskReport.tddPhase = { exists: true, valid: false, parseError: true };
+        }
+      }
+
+      // Scan for *.check.md files in the task dir
+      taskReport.checkReports = listFiles(taskDir, /\.check\.md$/).map((fp) => path.basename(fp));
+
+      s.perTaskReports[taskDirName] = taskReport;
+    }
+  }
+
   // SHA tracking
   s.prUpdateSha = fileExists(path.join(s.tasksDir, '.pr-update-sha'))
     ? readFile(path.join(s.tasksDir, '.pr-update-sha')).trim()

--- a/workflows/work/steps/__tests__/check.test.js
+++ b/workflows/work/steps/__tests__/check.test.js
@@ -58,7 +58,7 @@ describe('check step', () => {
     assert.ok(Array.isArray(entries[0].preCommands));
     assert.equal(entries[0].preCommands.length, 4);
     assert.match(entries[0].preCommands[0], /rm -f.*\.check\.md/);
-    assert.match(entries[0].preCommands[1], /rm -f.*task\*.*\.check\.md/);
+    assert.match(entries[0].preCommands[1], /rm -f.*task\[0-9\]\*.*\.check\.md/);
     assert.match(entries[0].preCommands[2], /\.pr-update-sha/);
     assert.match(entries[0].preCommands[3], /\.post-pr-update-sha/);
   });

--- a/workflows/work/steps/__tests__/check.test.js
+++ b/workflows/work/steps/__tests__/check.test.js
@@ -56,10 +56,11 @@ describe('check step', () => {
     assert.equal(entries[0].action, 'RUN');
     assert.match(entries[0].reason, /REWORK/);
     assert.ok(Array.isArray(entries[0].preCommands));
-    assert.equal(entries[0].preCommands.length, 3);
+    assert.equal(entries[0].preCommands.length, 4);
     assert.match(entries[0].preCommands[0], /rm -f.*\.check\.md/);
-    assert.match(entries[0].preCommands[1], /\.pr-update-sha/);
-    assert.match(entries[0].preCommands[2], /\.post-pr-update-sha/);
+    assert.match(entries[0].preCommands[1], /rm -f.*task\*.*\.check\.md/);
+    assert.match(entries[0].preCommands[2], /\.pr-update-sha/);
+    assert.match(entries[0].preCommands[3], /\.post-pr-update-sha/);
   });
 
   it('DEFERs when all three or more reports pass', () => {

--- a/workflows/work/steps/__tests__/task-review-step.test.js
+++ b/workflows/work/steps/__tests__/task-review-step.test.js
@@ -325,6 +325,93 @@ describe('task-review step', () => {
     assert.notEqual(entries[0].command, 'AskUserQuestion');
   });
 
+  // ─── GH-259: reportFolder in plan entry metadata ─────────────────────────
+
+  it('RUN entry includes reportFolder with per-task path when task context exists', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+      { num: 3, title: 'Task C', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 0 },
+            { id: 'task-2' },
+            { id: 'task-3' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].reportFolder, '/tmp/tasks/TEST-100/task1');
+  });
+
+  it('RUN entry includes reportFolder as tasksDir when _currentTaskIdx is undefined', () => {
+    const { add, entries } = makeAdd();
+    // _currentTaskIdx undefined means reviewTasksDir falls back to ctx.tasksDir
+    // But currentIdx defaults to 0 via ?? 0, so with 3 tasks it's intermediate
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+      { num: 3, title: 'Task C', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 0 },
+            { id: 'task-2' },
+            { id: 'task-3' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({
+      _taskData: taskData,
+      _currentTaskIdx: undefined,
+    });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].reportFolder, '/tmp/tasks/TEST-100');
+  });
+
+  it('agentPrompt mentions reportFolder path for downstream skills', () => {
+    const { add, entries } = makeAdd();
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+      { num: 3, title: 'Task C', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [
+            { id: 'task-1', taskReviewFixRounds: 0 },
+            { id: 'task-2' },
+            { id: 'task-3' },
+          ],
+        },
+      },
+    });
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    // agentPrompt should reference the per-task report folder path
+    assert.match(entries[0].agentPrompt, /\/tmp\/tasks\/TEST-100\/task1/);
+    assert.match(entries[0].agentPrompt, /REPORT_FOLDER/i);
+  });
+
   // ─── STEP_PIPELINE registration ────────────────────────────────────────────
 
   describe('STEP_PIPELINE registration', () => {

--- a/workflows/work/steps/check.js
+++ b/workflows/work/steps/check.js
@@ -14,7 +14,7 @@ module.exports = function checkStep(add, s, ctx) {
       agentPrompt: '/check',
       preCommands: [
         `rm -f "${tasksDir}"/*.check.md`,
-        `rm -f "${tasksDir}"/task*/*.check.md`,
+        `rm -f "${tasksDir}"/task[0-9]*/*.check.md`,
         `rm -f "${tasksDir}"/.pr-update-sha`,
         `rm -f "${tasksDir}"/.post-pr-update-sha`,
       ],

--- a/workflows/work/steps/check.js
+++ b/workflows/work/steps/check.js
@@ -14,6 +14,7 @@ module.exports = function checkStep(add, s, ctx) {
       agentPrompt: '/check',
       preCommands: [
         `rm -f "${tasksDir}"/*.check.md`,
+        `rm -f "${tasksDir}"/task*/*.check.md`,
         `rm -f "${tasksDir}"/.pr-update-sha`,
         `rm -f "${tasksDir}"/.post-pr-update-sha`,
       ],

--- a/workflows/work/steps/task-review.js
+++ b/workflows/work/steps/task-review.js
@@ -107,8 +107,9 @@ module.exports = function taskReviewStep(add, s, ctx) {
     `Task ${currentIdx + 1}/${totalTasks}: review "${currentTask?.title || 'unknown'}" before advancing`,
     {
       agentType: 'skill',
-      agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${currentTask?.title || 'unknown'}"). Scope both reviews to the task diff range${diffRange ? ` (base=${diffRange.base}, head=${diffRange.head})` : ' (computed from .last-commit-sha)'}. Aggregate results and fail the gate if either review fails.`,
+      agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${currentTask?.title || 'unknown'}"). Scope both reviews to the task diff range${diffRange ? ` (base=${diffRange.base}, head=${diffRange.head})` : ' (computed from .last-commit-sha)'}. Set REPORT_FOLDER=${reviewTasksDir} for both skills. Aggregate results and fail the gate if either review fails.`,
       diffRange,
+      reportFolder: reviewTasksDir,
     }
   );
   appendAction(ctx.ticket, {

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -92,9 +92,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
         if (!fs.existsSync(tddPath)) return false;
         const state = JSON.parse(fs.readFileSync(tddPath, 'utf-8'));
         const validation = validateTddEvidence(state);
-        if (!validation.valid) return false; // uses shared validateTddEvidence
-      }
-      return true; // all tasks have valid TDD evidence
+        if (!validation.valid) return false;
+      } // validated via shared validateTddEvidence (tdd-enforcement.js)
+      return true;
     } catch {
       return false;
     }

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -86,7 +86,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       const tasksPath = path.join(dir, 'tasks.md');
       if (!fs.existsSync(tasksPath)) return true; // single-task mode — no per-task check
       const tasks = taskParser.parseTasks(dir);
-      if (!tasks || tasks.length === 0) return true; // unparseable tasks.md
+      if (!tasks || tasks.length === 0) return false; // fail-closed: unparseable tasks.md blocks gate
       const expectedTasks = tasks.filter((t) => !t.isCheckpoint);
       if (expectedTasks.length === 0) return true; // all checkpoint tasks
       for (const task of expectedTasks) {

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -86,21 +86,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       const tasksPath = path.join(dir, 'tasks.md');
       if (!fs.existsSync(tasksPath)) return true; // single-task mode — no per-task check
       const tasks = taskParser.parseTasks(dir);
-      if (!tasks || tasks.length === 0) {
-        // Fallback: scan for existing taskN/ dirs when tasks.md is unparseable
-        const entries = fs.readdirSync(dir, { withFileTypes: true });
-        const taskDirs = entries.filter((e) => e.isDirectory() && /^task\d+$/.test(e.name));
-        if (taskDirs.length === 0) return true; // no tasks declared or created yet
-        // Validate discovered dirs
-        for (const taskEntry of taskDirs) {
-          const tddPath = path.join(dir, taskEntry.name, 'tdd-phase.json');
-          if (!fs.existsSync(tddPath)) return false;
-          const state = JSON.parse(fs.readFileSync(tddPath, 'utf-8'));
-          const validation = validateTddEvidence(state);
-          if (!validation.valid) return false;
-        }
-        return true;
-      }
+      if (!tasks || tasks.length === 0) return false; // fail-closed: unparseable tasks.md blocks gate
       const expectedTasks = tasks.filter((t) => !t.isCheckpoint);
       if (expectedTasks.length === 0) return true; // all checkpoint tasks
       for (const task of expectedTasks) {

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -81,16 +81,16 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
   function verifyPerTaskTDD(ticketId) {
     try {
       const { validateTddEvidence } = require(path.join(__dirname, 'tdd-enforcement'));
+      const taskParser = require(path.join(__dirname, 'task-parser'));
       const dir = path.join(TASKS_BASE, safeTicketPath(ticketId));
       const tasksPath = path.join(dir, 'tasks.md');
       if (!fs.existsSync(tasksPath)) return true; // single-task mode — no per-task check
-      const entries = fs.readdirSync(dir, { withFileTypes: true });
-      const taskDirs = entries.filter((e) => e.isDirectory() && /^task\d+$/.test(e.name));
-      // Intentional: no task dirs yet means implementation hasn't started creating
-      // per-task artifacts. Return true to avoid blocking pre-implementation steps.
-      if (taskDirs.length === 0) return true;
-      for (const taskEntry of taskDirs) {
-        const tddPath = path.join(dir, taskEntry.name, 'tdd-phase.json');
+      const tasks = taskParser.parseTasks(dir);
+      if (!tasks || tasks.length === 0) return true; // unparseable tasks.md
+      const expectedTasks = tasks.filter((t) => !t.isCheckpoint);
+      if (expectedTasks.length === 0) return true; // all checkpoint tasks
+      for (const task of expectedTasks) {
+        const tddPath = path.join(dir, `task${task.num}`, 'tdd-phase.json');
         if (!fs.existsSync(tddPath)) return false;
         const state = JSON.parse(fs.readFileSync(tddPath, 'utf-8'));
         const validation = validateTddEvidence(state);

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -77,8 +77,10 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
 
   // GH-259 Task 7.2: Helper to verify per-task TDD evidence when tasks.md exists.
   // Returns true if no tasks.md, or if every taskN/ dir has valid tdd-phase.json.
+  // Uses validateTddEvidence from tdd-enforcement.js (single source of truth).
   function verifyPerTaskTDD(ticketId) {
     try {
+      const { validateTddEvidence } = require(path.join(__dirname, 'tdd-enforcement'));
       const dir = path.join(TASKS_BASE, safeTicketPath(ticketId));
       const tasksPath = path.join(dir, 'tasks.md');
       if (!fs.existsSync(tasksPath)) return true; // single-task mode — no per-task check
@@ -89,9 +91,8 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
         const tddPath = path.join(dir, taskEntry.name, 'tdd-phase.json');
         if (!fs.existsSync(tddPath)) return false;
         const state = JSON.parse(fs.readFileSync(tddPath, 'utf-8'));
-        if (typeof state.exception === 'string' && state.exception.trim() !== '') continue;
-        if (!Array.isArray(state.cycles) || state.cycles.length === 0) return false;
-        if (!state.cycles.some((c) => c.red && c.green)) return false;
+        const validation = validateTddEvidence(state);
+        if (!validation.valid) return false;
       }
       return true;
     } catch {

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -86,7 +86,21 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       const tasksPath = path.join(dir, 'tasks.md');
       if (!fs.existsSync(tasksPath)) return true; // single-task mode — no per-task check
       const tasks = taskParser.parseTasks(dir);
-      if (!tasks || tasks.length === 0) return false; // fail-closed: unparseable tasks.md blocks gate
+      if (!tasks || tasks.length === 0) {
+        // Fallback: scan for existing taskN/ dirs when tasks.md is unparseable
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        const taskDirs = entries.filter((e) => e.isDirectory() && /^task\d+$/.test(e.name));
+        if (taskDirs.length === 0) return true; // no tasks declared or created yet
+        // Validate discovered dirs
+        for (const taskEntry of taskDirs) {
+          const tddPath = path.join(dir, taskEntry.name, 'tdd-phase.json');
+          if (!fs.existsSync(tddPath)) return false;
+          const state = JSON.parse(fs.readFileSync(tddPath, 'utf-8'));
+          const validation = validateTddEvidence(state);
+          if (!validation.valid) return false;
+        }
+        return true;
+      }
       const expectedTasks = tasks.filter((t) => !t.isCheckpoint);
       if (expectedTasks.length === 0) return true; // all checkpoint tasks
       for (const task of expectedTasks) {

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -75,6 +75,30 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
   }
   // GH-244: verifySpecGate tests added in workflow-definition.test.js
 
+  // GH-259 Task 7.2: Helper to verify per-task TDD evidence when tasks.md exists.
+  // Returns true if no tasks.md, or if every taskN/ dir has valid tdd-phase.json.
+  function verifyPerTaskTDD(ticketId) {
+    try {
+      const dir = path.join(TASKS_BASE, safeTicketPath(ticketId));
+      const tasksPath = path.join(dir, 'tasks.md');
+      if (!fs.existsSync(tasksPath)) return true; // single-task mode — no per-task check
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      const taskDirs = entries.filter((e) => e.isDirectory() && /^task\d+$/.test(e.name));
+      if (taskDirs.length === 0) return true; // no task dirs yet — skip
+      for (const taskEntry of taskDirs) {
+        const tddPath = path.join(dir, taskEntry.name, 'tdd-phase.json');
+        if (!fs.existsSync(tddPath)) return false;
+        const state = JSON.parse(fs.readFileSync(tddPath, 'utf-8'));
+        if (typeof state.exception === 'string' && state.exception.trim() !== '') continue;
+        if (!Array.isArray(state.cycles) || state.cycles.length === 0) return false;
+        if (!state.cycles.some((c) => c.red && c.green)) return false;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   // ─── Declarative policy config (GH-206 Task 12) ───────────────────────────
   //
   // Artifact patterns per step — consumed by artifact-archival.js on backward
@@ -354,7 +378,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             // At least one QA report must exist (matches qaReportPattern)
             const files = fs.readdirSync(dir);
             const qaPattern = reqs?.qaReportPattern;
-            return qaPattern ? files.some((f) => qaPattern.test(f)) : true;
+            if (qaPattern && !files.some((f) => qaPattern.test(f))) return false;
+            // GH-259: When tasks.md exists, verify per-task TDD evidence
+            return verifyPerTaskTDD(ticketId);
           } catch {
             return false;
           }
@@ -398,7 +424,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             try {
               const branch = execFileSync('git', ['branch', '--show-current'], opts).trim();
               if (branch) ghArgs = ['pr', 'view', branch, '--json', 'number,state'];
-            } catch { /* branch detection failed -- fall back to no branch arg */ }
+            } catch {
+              /* branch detection failed -- fall back to no branch arg */
+            }
 
             const pr = JSON.parse(execFileSync('gh', ghArgs, opts).trim()); // GH-203: positional arg, not --head
             return pr.number > 0 && pr.state === 'OPEN';
@@ -427,7 +455,8 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
               );
               if (!fs.existsSync(accountabilityFile)) return false;
               const entries = JSON.parse(fs.readFileSync(accountabilityFile, 'utf-8'));
-              if (!Array.isArray(entries) || entries.length < result.strictCommentCount) return false;
+              if (!Array.isArray(entries) || entries.length < result.strictCommentCount)
+                return false;
               if (!entries.every((e) => e.disposition && e.reason)) return false;
               const acknowledged = entries.filter((e) => e.disposition === 'acknowledged');
               if (acknowledged.length > 0) {
@@ -458,7 +487,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
         verify: () => {
           // Single source of truth: delegates to follow-up-pr.js functions
           try {
-            const { getPRInfo, checkCI } = require(path.join(__dirname, 'scripts', 'follow-up-pr.js'));
+            const { getPRInfo, checkCI } = require(
+              path.join(__dirname, 'scripts', 'follow-up-pr.js')
+            );
             const prInfo = getPRInfo();
             if (!prInfo || !prInfo.number) return false;
             const ci = checkCI(prInfo.number);
@@ -491,12 +522,15 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             // At least one QA report must exist and pass
             const qaPattern = reqs?.qaReportPattern;
             const approvalPattern = reqs?.qaApprovalPattern;
-            if (!qaPattern || !approvalPattern) return true;
+            if (!qaPattern || !approvalPattern) return verifyPerTaskTDD(ticketId);
             const files = fs.readdirSync(dir).filter((f) => qaPattern.test(f));
             if (files.length === 0) return false;
-            return files.every((f) =>
-              approvalPattern.test(fs.readFileSync(path.join(dir, f), 'utf-8'))
-            );
+            if (
+              !files.every((f) => approvalPattern.test(fs.readFileSync(path.join(dir, f), 'utf-8')))
+            )
+              return false;
+            // GH-259: When tasks.md exists, verify per-task TDD evidence
+            return verifyPerTaskTDD(ticketId);
           } catch {
             return false;
           }

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -92,9 +92,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
         if (!fs.existsSync(tddPath)) return false;
         const state = JSON.parse(fs.readFileSync(tddPath, 'utf-8'));
         const validation = validateTddEvidence(state);
-        if (!validation.valid) return false;
+        if (!validation.valid) return false; // uses shared validateTddEvidence
       }
-      return true;
+      return true; // all tasks have valid TDD evidence
     } catch {
       return false;
     }

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -88,7 +88,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       const tasks = taskParser.parseTasks(dir);
       if (!tasks || tasks.length === 0) return false; // fail-closed: unparseable tasks.md blocks gate
       const expectedTasks = tasks.filter((t) => !t.isCheckpoint);
-      if (expectedTasks.length === 0) return true; // all checkpoint tasks
+      if (expectedTasks.length === 0) return true; // only checkpoint tasks — no TDD evidence needed
       for (const task of expectedTasks) {
         const tddPath = path.join(dir, `task${task.num}`, 'tdd-phase.json');
         if (!fs.existsSync(tddPath)) return false;

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -86,7 +86,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       if (!fs.existsSync(tasksPath)) return true; // single-task mode — no per-task check
       const entries = fs.readdirSync(dir, { withFileTypes: true });
       const taskDirs = entries.filter((e) => e.isDirectory() && /^task\d+$/.test(e.name));
-      if (taskDirs.length === 0) return true; // no task dirs yet — skip
+      // Intentional: no task dirs yet means implementation hasn't started creating
+      // per-task artifacts. Return true to avoid blocking pre-implementation steps.
+      if (taskDirs.length === 0) return true;
       for (const taskEntry of taskDirs) {
         const tddPath = path.join(dir, taskEntry.name, 'tdd-phase.json');
         if (!fs.existsSync(tddPath)) return false;


### PR DESCRIPTION
## Existing Behavior

- Check-gate validates reports only against the top-level ticket directory, with no awareness of per-task subdirectories.
- `artifact-archival.js` only scans the root task directory and ignores `taskN/` subdirectories when archiving reports.
- `inspect.js` does not expose per-task report state — callers have no visibility into which tasks have passing or missing check reports.
- The `task-review` step plan entry does not carry a `reportFolder` field or a `REPORT_FOLDER` instruction in `agentPrompt`, so downstream skills (`/tests-review`, `/code-review`) write reports to an unscoped location.
- The `workflow-definition.js` `verify` functions for the `check` and `reports` steps do not validate per-task TDD evidence when a `tasks.md` file is present.

## Intended New Behavior

- `check-gate.js` adds a `per-task-tdd-evidence` rule: when `tasks.md` exists, every `taskN/` subdirectory must contain a `tdd-phase.json` with a complete RED→GREEN cycle (or a non-empty `exception` field); single-task tickets are unaffected.
- `artifact-archival.js` recurses into `taskN/` subdirectories to collect and archive check reports alongside root-level artifacts.
- `inspect.js` populates `s.perTaskReports` — a keyed map of per-task report state — when `tasks.md` is present, so plan logic can read task-scoped report status.
- `task-review.js` now attaches `reportFolder` metadata and a `REPORT_FOLDER=<per-task-path>` instruction to each intermediate-task plan entry so `/tests-review` and `/code-review` write reports into the correct `taskN/` folder.
- `workflow-definition.js` adds a `verifyPerTaskTDD` helper called by both the `check` and `reports` verify functions, blocking the transition to `pr` until TDD evidence is confirmed for every task.
- `steps/check.js` extends the rework `preCommands` to also delete `task*/*.check.md` files so stale per-task reports are cleared on rework.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend changes — verification steps:**

1. Create a multi-task ticket with `tasks.md` present. Advance the workflow to the `check` step.
2. Verify `check-gate.js` blocks the `check → pr` transition when any `taskN/tdd-phase.json` is missing by inspecting the gate failure output — it should report `Missing TDD evidence: taskN/tdd-phase.json`.
3. Add a valid `tdd-phase.json` with at least one `{red: true, green: true}` cycle entry to each `taskN/` directory, then re-run the gate — it should pass.
4. Confirm `artifact-archival.js` includes files from `task1/`, `task2/`, etc. in its archive output when tasks subdirectories are present.
5. Call `inspect.js` on a multi-task ticket and verify the returned state includes a populated `perTaskReports` object keyed by task directory name.
6. For a single-task ticket (no `tasks.md`), confirm the gate rule is skipped and the workflow behaves identically to the previous version.
7. During a rework cycle on a multi-task ticket, confirm `task*/*.check.md` files are deleted by the `preCommands` before `/check` is re-run.
8. Trigger the `task-review` step on an intermediate task and confirm the generated plan entry has both a `reportFolder` property and a `REPORT_FOLDER=` clause in `agentPrompt`.

### Test Results
Tests covering this feature are located in:
- `workflows/lib/__tests__/tests-common-report-folder.test.js`
- `workflows/work/__tests__/artifact-archival.test.js`
- `workflows/work/__tests__/check-gate.test.js`
- `workflows/work/__tests__/inspect-per-task-reports.test.js`
- `workflows/work/__tests__/verify-per-task.test.js`
- `workflows/work/steps/__tests__/task-review-step.test.js`

Closes #259