### PR TITLE
GH-289 - chore: apply biome formatting and add pre-commit hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,13 +14,7 @@
       "source": "./",
       "description": "Orchestrated /work command with pre-computed action plans",
       "category": "workflow",
-      "tags": [
-        "workflow",
-        "jira",
-        "orchestrator",
-        "state-machine",
-        "automation"
-      ]
+      "tags": ["workflow", "jira", "orchestrator", "state-machine", "automation"]
     }
   ]
 }

--- a/agents/__tests__/code-architect.test.js
+++ b/agents/__tests__/code-architect.test.js
@@ -192,13 +192,9 @@ describe('Output Format item 2', () => {
     // Find numbered items only within the "### Output Format" section
     const ofIdx = lines.findIndex((l) => l.includes('### Output Format'));
     assert.ok(ofIdx > -1);
-    const nextHeadingOffset = lines
-      .slice(ofIdx + 1)
-      .findIndex((l) => l.match(/^###\s+/));
+    const nextHeadingOffset = lines.slice(ofIdx + 1).findIndex((l) => l.match(/^###\s+/));
     const sectionEnd = nextHeadingOffset === -1 ? lines.length : ofIdx + 1 + nextHeadingOffset;
-    const ofItems = lines
-      .slice(ofIdx, sectionEnd)
-      .filter((l) => l.match(/^\d+\.\s+\*\*/));
+    const ofItems = lines.slice(ofIdx, sectionEnd).filter((l) => l.match(/^\d+\.\s+\*\*/));
     assert.equal(ofItems.length, 9, 'Output Format should have 9 items');
   });
 });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev:test:main": "./workflows/lib/scripts/dev-check/dev-test.sh --main",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "prepare": "git config core.hooksPath scripts/hooks"
+    "prepare": "command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath scripts/hooks || true"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.11"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dev:check": "pnpm dev:lint && pnpm dev:typecheck && pnpm dev:test",
     "dev:test:main": "./workflows/lib/scripts/dev-check/dev-test.sh --main",
     "format": "biome format --write .",
-    "format:check": "biome format ."
+    "format:check": "biome format .",
+    "prepare": "git config core.hooksPath scripts/hooks"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.11"

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,12 +1,25 @@
 #!/bin/sh
-# Pre-commit hook: format staged JS files with biome
+# Pre-commit hook: format staged JS/JSON files with biome
 # Install: git config core.hooksPath scripts/hooks
 
 STAGED=$(git diff --cached --name-only --diff-filter=ACM -- '*.js' '*.json')
 [ -z "$STAGED" ] && exit 0
 
+# Warn about partially-staged files (unstaged hunks would get auto-staged)
+PARTIAL=$(echo "$STAGED" | while read -r f; do
+  [ -f "$f" ] && git diff --name-only -- "$f" 2>/dev/null
+done)
+if [ -n "$PARTIAL" ]; then
+  echo "pre-commit: WARNING — partially staged files detected:"
+  echo "$PARTIAL" | sed 's/^/  /'
+  echo "Formatting will stage all changes in these files."
+fi
+
 # Format staged files in place
-echo "$STAGED" | xargs npx biome format --write 2>/dev/null
+if ! echo "$STAGED" | xargs npx biome format --write; then
+  echo "pre-commit: biome format failed — commit blocked"
+  exit 1
+fi
 
 # Re-stage any reformatted files
 echo "$STAGED" | xargs git add

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -2,26 +2,31 @@
 # Pre-commit hook: format staged JS/JSON files with biome
 # Install: git config core.hooksPath scripts/hooks
 
-STAGED=$(git diff --cached --name-only --diff-filter=ACM -- '*.js' '*.json')
+# Use NUL-delimited output for safe filename handling (spaces, special chars)
+STAGED=$(git diff --cached --name-only -z --diff-filter=ACM -- '*.js' '*.json' | tr '\0' '\n')
 [ -z "$STAGED" ] && exit 0
 
-# Warn about partially-staged files (unstaged hunks would get auto-staged)
-PARTIAL=$(echo "$STAGED" | while read -r f; do
-  [ -f "$f" ] && git diff --name-only -- "$f" 2>/dev/null
-done)
-if [ -n "$PARTIAL" ]; then
-  echo "pre-commit: WARNING — partially staged files detected:"
-  echo "$PARTIAL" | sed 's/^/  /'
-  echo "Formatting will stage all changes in these files."
-fi
+# Abort if any staged file is partially staged (has unstaged changes too)
+# This prevents the hook from accidentally staging unintended hunks
+PARTIAL=""
+echo "$STAGED" | while IFS= read -r f; do
+  if [ -f "$f" ] && git diff --quiet -- "$f" 2>/dev/null; [ $? -ne 0 ]; then
+    PARTIAL="$PARTIAL $f"
+  fi
+done
 
 # Format staged files in place
-if ! echo "$STAGED" | xargs npx biome format --write; then
+if ! echo "$STAGED" | xargs -I{} npx biome format --write "{}"; then
   echo "pre-commit: biome format failed — commit blocked"
   exit 1
 fi
 
-# Re-stage any reformatted files
-echo "$STAGED" | xargs git add
+# Re-stage only the files that were already fully staged
+echo "$STAGED" | while IFS= read -r f; do
+  # Skip partially-staged files — only re-add fully staged ones
+  if git diff --quiet -- "$f" 2>/dev/null; then
+    git add "$f"
+  fi
+done
 
 exit 0

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -2,31 +2,34 @@
 # Pre-commit hook: format staged JS/JSON files with biome
 # Install: git config core.hooksPath scripts/hooks
 
-# Use NUL-delimited output for safe filename handling (spaces, special chars)
-STAGED=$(git diff --cached --name-only -z --diff-filter=ACM -- '*.js' '*.json' | tr '\0' '\n')
-[ -z "$STAGED" ] && exit 0
+# Collect staged JS/JSON files (NUL-delimited for safe filename handling)
+STAGED_FILE=$(mktemp)
+trap 'rm -f "$STAGED_FILE"' EXIT
+git diff --cached --name-only -z --diff-filter=ACM -- '*.js' '*.json' >"$STAGED_FILE"
+[ ! -s "$STAGED_FILE" ] && exit 0
 
-# Abort if any staged file is partially staged (has unstaged changes too)
+# Block if any staged file is partially staged (has unstaged changes too)
 # This prevents the hook from accidentally staging unintended hunks
 PARTIAL=""
-echo "$STAGED" | while IFS= read -r f; do
-  if [ -f "$f" ] && git diff --quiet -- "$f" 2>/dev/null; [ $? -ne 0 ]; then
+while IFS= read -r -d '' f; do
+  if [ -f "$f" ] && ! git diff --quiet -- "$f" 2>/dev/null; then
     PARTIAL="$PARTIAL $f"
   fi
-done
+done <"$STAGED_FILE"
 
-# Format staged files in place
-if ! echo "$STAGED" | xargs -I{} npx biome format --write "{}"; then
+if [ -n "$PARTIAL" ]; then
+  echo "pre-commit: partially staged files detected; commit blocked:$PARTIAL"
+  echo "Stage all changes in these files or stash unstaged changes first."
+  exit 1
+fi
+
+# Format staged files in place (NUL-delimited)
+if ! xargs -0 npx biome format --write <"$STAGED_FILE"; then
   echo "pre-commit: biome format failed — commit blocked"
   exit 1
 fi
 
-# Re-stage only the files that were already fully staged
-echo "$STAGED" | while IFS= read -r f; do
-  # Skip partially-staged files — only re-add fully staged ones
-  if git diff --quiet -- "$f" 2>/dev/null; then
-    git add "$f"
-  fi
-done
+# Re-stage formatted files (NUL-delimited)
+xargs -0 git add <"$STAGED_FILE"
 
 exit 0

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Pre-commit hook: format staged JS files with biome
+# Install: git config core.hooksPath scripts/hooks
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACM -- '*.js' '*.json')
+[ -z "$STAGED" ] && exit 0
+
+# Format staged files in place
+echo "$STAGED" | xargs npx biome format --write 2>/dev/null
+
+# Re-stage any reformatted files
+echo "$STAGED" | xargs git add
+
+exit 0

--- a/workflows/check/agents/qa-feature-tester/validate-qa-report.js
+++ b/workflows/check/agents/qa-feature-tester/validate-qa-report.js
@@ -49,7 +49,11 @@ async function main() {
       /`?mcp__(playwright|claude-in-chrome)__\w+`?\s*(?:[-–—:]?\s*)Result:\s*(SUCCESS|FAIL)/i;
     const hasBrowserMCP = browserToolPattern.test(content);
 
-    if (!hasBrowserMCP && !content.includes('INFRASTRUCTURE_FAILURE') && !content.includes('ACCESS_FAILED')) {
+    if (
+      !hasBrowserMCP &&
+      !content.includes('INFRASTRUCTURE_FAILURE') &&
+      !content.includes('ACCESS_FAILED')
+    ) {
       issues.push(
         'No structured browser tool evidence — expected `mcp__playwright__...` or `mcp__claude-in-chrome__...` tool calls, each with "Result: SUCCESS" or "Result: FAIL"'
       );
@@ -66,7 +70,11 @@ async function main() {
     const hasScreenshots =
       content.match(/!\[.*?\]\(.*?\.(png|jpg|jpeg)/i) || content.includes('screenshots/');
 
-    if (!hasScreenshots && !content.includes('INFRASTRUCTURE_FAILURE') && !content.includes('ACCESS_FAILED')) {
+    if (
+      !hasScreenshots &&
+      !content.includes('INFRASTRUCTURE_FAILURE') &&
+      !content.includes('ACCESS_FAILED')
+    ) {
       issues.push('No screenshot references found');
     }
 

--- a/workflows/check/check.workflow.js
+++ b/workflows/check/check.workflow.js
@@ -85,7 +85,7 @@ function getImpactedApps() {
   // to determine which apps may be affected (replaces hardcoded WEB_APPS list)
   const manifestApps = discoverApps();
   if (apps.size === 0 && packages.size > 0 && manifestApps.length > 0) {
-    return manifestApps.map(a => a.name).sort();
+    return manifestApps.map((a) => a.name).sort();
   }
 
   return Array.from(apps).sort();
@@ -98,7 +98,7 @@ function getImpactedApps() {
  */
 function getQaAgentForApp(appName, manifestApps) {
   const apps = manifestApps || discoverApps();
-  const entry = apps.find(a => a.name === appName);
+  const entry = apps.find((a) => a.name === appName);
   const appType = entry?.appType || 'web';
 
   switch (appType) {

--- a/workflows/check/hooks/check-start-env.js
+++ b/workflows/check/hooks/check-start-env.js
@@ -356,7 +356,8 @@ async function main() {
     // Non-web apps or packages changed — start all web apps for mandatory QA
     const allWebApps = Object.keys(appsMap);
     if (allWebApps.length > 0) {
-      console.error( // cli apps are already filtered out of appsMap
+      console.error(
+        // cli apps are already filtered out of appsMap
         `Package/non-web changes detected (${IMPACTED_APPS.join(', ')}) — starting all ${allWebApps.length} web apps for mandatory QA`
       );
       webAppsToStart = allWebApps;

--- a/workflows/check/hooks/check-validate-reports.js
+++ b/workflows/check/hooks/check-validate-reports.js
@@ -79,7 +79,9 @@ function validateQAReport(filePath, appName) {
       valid: false,
       infrastructureFailure: false,
       accessFailed: true,
-      issues: [`App access failed for ${appName} — app unreachable (infrastructure issue, not a test failure)`],
+      issues: [
+        `App access failed for ${appName} — app unreachable (infrastructure issue, not a test failure)`,
+      ],
       failed: false, // Not a test failure
     };
   }

--- a/workflows/check/hooks/enforce-env-start-failure.js
+++ b/workflows/check/hooks/enforce-env-start-failure.js
@@ -115,16 +115,20 @@ function phase1_detectFailure(hookData) {
 
     // Extract diagnostic details from the output for the marker payload
     const portMatches = output.match(/"port":\s*(\d+)/g) || [];
-    const ports = portMatches.map((m) => {
-      const p = m.match(/(\d+)/);
-      return p ? parseInt(p[1], 10) : null;
-    }).filter(Boolean);
+    const ports = portMatches
+      .map((m) => {
+        const p = m.match(/(\d+)/);
+        return p ? parseInt(p[1], 10) : null;
+      })
+      .filter(Boolean);
 
     const urlMatches = output.match(/"url":\s*"([^"]+)"/g) || [];
-    const urls = urlMatches.map((m) => {
-      const u = m.match(/"url":\s*"([^"]+)"/);
-      return u ? u[1] : null;
-    }).filter(Boolean);
+    const urls = urlMatches
+      .map((m) => {
+        const u = m.match(/"url":\s*"([^"]+)"/);
+        return u ? u[1] : null;
+      })
+      .filter(Boolean);
 
     fs.writeFileSync(
       mp,
@@ -141,7 +145,9 @@ function phase1_detectFailure(hookData) {
         },
       })
     );
-    process.stderr.write(`ENV_FAILURE [${ACCESS_FAILED}]: marker written (${failedApps.join(', ')})\n`);
+    process.stderr.write(
+      `ENV_FAILURE [${ACCESS_FAILED}]: marker written (${failedApps.join(', ')})\n`
+    );
   } else {
     try {
       fs.unlinkSync(mp);

--- a/workflows/check/hooks/qa-progress.js
+++ b/workflows/check/hooks/qa-progress.js
@@ -270,7 +270,8 @@ function completeQA(ticketId, appName, overallResult) {
   }
 
   progress.status = overallResult === 'pass' ? 'completed_pass' : 'completed_fail';
-  progress.accessStatus = overallResult === 'pass' ? AppAccessStatus.PASSED : AppAccessStatus.TEST_FAILED;
+  progress.accessStatus =
+    overallResult === 'pass' ? AppAccessStatus.PASSED : AppAccessStatus.TEST_FAILED;
   progress.completedTime = new Date().toISOString();
   progress.testsInProgress = null;
 

--- a/workflows/check/lib/__tests__/app-access.test.js
+++ b/workflows/check/lib/__tests__/app-access.test.js
@@ -17,14 +17,13 @@ describe('discoverApps', () => {
     discoverApps = require('../app-access').discoverApps;
   });
 
-  afterEach(() => { // restore config to prevent test pollution
+  afterEach(() => {
+    // restore config to prevent test pollution
     config.WEB_APPS = originalWebApps;
   });
 
   it('returns parsed entries with defaults from WEB_APPS config', () => {
-    config.WEB_APPS = [
-      { name: 'my-app', defaultPort: 3000, type: 'vite' },
-    ];
+    config.WEB_APPS = [{ name: 'my-app', defaultPort: 3000, type: 'vite' }];
     const apps = discoverApps();
     assert.equal(apps.length, 1);
     assert.equal(apps[0].name, 'my-app');
@@ -48,9 +47,7 @@ describe('discoverApps', () => {
   });
 
   it('returns entries for single-app repo', () => {
-    config.WEB_APPS = [
-      { name: 'solo-app', defaultPort: 4000, type: 'remix', appType: 'api' },
-    ];
+    config.WEB_APPS = [{ name: 'solo-app', defaultPort: 4000, type: 'remix', appType: 'api' }];
     const apps = discoverApps();
     assert.equal(apps.length, 1);
     assert.equal(apps[0].name, 'solo-app');
@@ -142,7 +139,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev; rm -rf /',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with pipe', () => {
@@ -152,7 +149,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev | cat /etc/passwd',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with &&', () => {
@@ -162,7 +159,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev && rm -rf /',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with backticks', () => {
@@ -172,7 +169,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev `whoami`',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with $()', () => {
@@ -182,7 +179,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev $(whoami)',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with single & (background exec)', () => {
@@ -192,7 +189,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev & malicious-cmd',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with newline', () => {
@@ -202,7 +199,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev\nrm -rf /',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with carriage return', () => {
@@ -212,7 +209,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev\rmalicious',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with > (output redirection)', () => {
@@ -222,7 +219,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev > /tmp/out',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with < (input redirection)', () => {
@@ -232,7 +229,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev < /tmp/in',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   it('rejects startCommand with ${VAR} (variable expansion)', () => {
@@ -242,7 +239,7 @@ describe('validateManifestEntry', () => {
       startCommand: 'pnpm dev ${HOME}',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('dangerous shell characters')));
+    assert.ok(result.errors.some((e) => e.includes('dangerous shell characters')));
   });
 
   // Port range tests
@@ -296,7 +293,7 @@ describe('validateManifestEntry', () => {
       healthEndpoint: '//evil.com',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('must not start with "//"')));
+    assert.ok(result.errors.some((e) => e.includes('must not start with "//"')));
   });
 
   it('rejects healthEndpoint with query strings', () => {
@@ -306,7 +303,7 @@ describe('validateManifestEntry', () => {
       healthEndpoint: '/health?token=abc',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('must not contain query strings')));
+    assert.ok(result.errors.some((e) => e.includes('must not contain query strings')));
   });
 
   it('rejects healthEndpoint not starting with "/"', () => {
@@ -316,7 +313,7 @@ describe('validateManifestEntry', () => {
       healthEndpoint: 'health',
     });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('must start with "/"')));
+    assert.ok(result.errors.some((e) => e.includes('must start with "/"')));
   });
 
   it('accepts valid healthEndpoint', () => {
@@ -331,13 +328,13 @@ describe('validateManifestEntry', () => {
   it('requires defaultPort for web apps', () => {
     const result = validateManifestEntry({ name: 'web-app', appType: 'web' });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('defaultPort is required')));
+    assert.ok(result.errors.some((e) => e.includes('defaultPort is required')));
   });
 
   it('requires defaultPort for api apps', () => {
     const result = validateManifestEntry({ name: 'api-app', appType: 'api' });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('defaultPort is required')));
+    assert.ok(result.errors.some((e) => e.includes('defaultPort is required')));
   });
 
   it('allows missing defaultPort for cli apps', () => {
@@ -348,7 +345,7 @@ describe('validateManifestEntry', () => {
   it('requires defaultPort when appType is undefined (defaults to web)', () => {
     const result = validateManifestEntry({ name: 'no-type-app' });
     assert.equal(result.valid, false);
-    assert.ok(result.errors.some(e => e.includes('defaultPort is required')));
+    assert.ok(result.errors.some((e) => e.includes('defaultPort is required')));
   });
 
   it('returns multiple errors for multiple violations', () => {
@@ -513,7 +510,12 @@ describe('checkHealth', () => {
     const unusedPort = srv.address().port;
     srv.close();
     const app = { name: 'test-app', defaultPort: unusedPort, healthEndpoint: '/' };
-    const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, retryInterval: 50, timeout: 1000 });
+    const result = await checkHealth(app, {
+      host: '127.0.0.1',
+      retries: 1,
+      retryInterval: 50,
+      timeout: 1000,
+    });
     assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
     assert.equal(result.responseCode, null);
     assert.ok(result.error);
@@ -523,7 +525,12 @@ describe('checkHealth', () => {
   it('returns ACCESS_FAILED on 503 response after retries', async () => {
     const port = await startServer(503);
     const app = { name: 'test-app', defaultPort: port, healthEndpoint: '/' };
-    const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, retryInterval: 50, timeout: 2000 });
+    const result = await checkHealth(app, {
+      host: '127.0.0.1',
+      retries: 1,
+      retryInterval: 50,
+      timeout: 2000,
+    });
     assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
     assert.equal(result.responseCode, 503);
     assert.equal(result.error, 'HTTP 503');
@@ -538,7 +545,12 @@ describe('checkHealth', () => {
     const unusedPort = srv.address().port;
     srv.close();
     const app = { name: 'test-app', defaultPort: unusedPort, healthEndpoint: '/' };
-    const result = await checkHealth(app, { host: '127.0.0.1', retries: 1, retryInterval: 50, timeout: 1000 });
+    const result = await checkHealth(app, {
+      host: '127.0.0.1',
+      retries: 1,
+      retryInterval: 50,
+      timeout: 1000,
+    });
     assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
     assert.ok('lsofOutput' in result.diagnostics);
     assert.equal(typeof result.diagnostics.lsofOutput, 'string');
@@ -570,7 +582,12 @@ describe('checkHealth', () => {
     await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
     const port = server.address().port;
     const app = { name: 'test-app', defaultPort: port, healthEndpoint: '/' };
-    const result = await checkHealth(app, { host: '127.0.0.1', retries: 3, retryInterval: 50, timeout: 2000 });
+    const result = await checkHealth(app, {
+      host: '127.0.0.1',
+      retries: 3,
+      retryInterval: 50,
+      timeout: 2000,
+    });
     assert.equal(result.status, AppAccessStatus.ACCESS_FAILED);
     assert.equal(requestCount, 3);
     await new Promise((resolve) => server.close(resolve));

--- a/workflows/check/lib/app-access.js
+++ b/workflows/check/lib/app-access.js
@@ -18,7 +18,11 @@ function validateManifestEntry(entry) {
     if (entry.appType !== 'cli') {
       errors.push('defaultPort is required for web and api apps');
     }
-  } else if (typeof entry.defaultPort !== 'number' || entry.defaultPort < 1024 || entry.defaultPort > 65535) {
+  } else if (
+    typeof entry.defaultPort !== 'number' ||
+    entry.defaultPort < 1024 ||
+    entry.defaultPort > 65535
+  ) {
     errors.push(`Port ${entry.defaultPort} is outside valid range (1024-65535)`);
   }
 
@@ -52,13 +56,16 @@ function validateManifestEntry(entry) {
  * @returns {Array<object>} Array of validated app configurations
  */
 function discoverApps() {
-  if (!config.WEB_APPS || !Array.isArray(config.WEB_APPS) || config.WEB_APPS.length === 0) return [];
+  if (!config.WEB_APPS || !Array.isArray(config.WEB_APPS) || config.WEB_APPS.length === 0)
+    return [];
   const map = config.webAppsMap();
   const entries = Object.entries(map).map(([name, fields]) => ({ name, ...fields }));
-  return entries.filter(app => {
+  return entries.filter((app) => {
     const validation = validateManifestEntry(app);
     if (!validation.valid) {
-      console.error(`[app-access] Skipping invalid app "${app.name}": ${validation.errors.join(', ')}`);
+      console.error(
+        `[app-access] Skipping invalid app "${app.name}": ${validation.errors.join(', ')}`
+      );
       return false;
     }
     return true;
@@ -78,7 +85,10 @@ function httpGet(url, timeout) {
       res.resume();
     });
     req.on('error', reject);
-    req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('timeout'));
+    });
   });
 }
 
@@ -94,8 +104,13 @@ function httpGet(url, timeout) {
 function buildFailureResult(url, healthEndpoint, port, responseCode, error) {
   let lsofOutput = '';
   try {
-    lsofOutput = execSync(`lsof -i :${port} -P -n 2>/dev/null | head -5`, { encoding: 'utf8', timeout: 3000 });
-  } catch { /* ignore */ }
+    lsofOutput = execSync(`lsof -i :${port} -P -n 2>/dev/null | head -5`, {
+      encoding: 'utf8',
+      timeout: 3000,
+    });
+  } catch {
+    /* ignore */
+  }
 
   return {
     status: AppAccessStatus.ACCESS_FAILED,
@@ -114,7 +129,12 @@ function buildFailureResult(url, healthEndpoint, port, responseCode, error) {
  * @returns {Promise<object>} Health check result
  */
 async function checkHealth(app, options = {}) {
-  const { timeout = 5000, retries = 3, retryInterval = 2000, host = 'host.docker.internal' } = options;
+  const {
+    timeout = 5000,
+    retries = 3,
+    retryInterval = 2000,
+    host = 'host.docker.internal',
+  } = options;
   const port = app.defaultPort;
   const healthEndpoint = app.healthEndpoint || '/';
   const url = `http://${host}:${port}${healthEndpoint}`;
@@ -132,7 +152,13 @@ async function checkHealth(app, options = {}) {
       }
       // Non-success status code
       if (attempt === retries) {
-        return buildFailureResult(url, healthEndpoint, port, result.statusCode, `HTTP ${result.statusCode}`);
+        return buildFailureResult(
+          url,
+          healthEndpoint,
+          port,
+          result.statusCode,
+          `HTTP ${result.statusCode}`
+        );
       }
     } catch (err) {
       if (attempt === retries) {
@@ -141,7 +167,7 @@ async function checkHealth(app, options = {}) {
     }
     // Wait before retry (only if not last attempt)
     if (attempt < retries) {
-      await new Promise(resolve => setTimeout(resolve, retryInterval));
+      await new Promise((resolve) => setTimeout(resolve, retryInterval));
     }
   }
 
@@ -184,4 +210,11 @@ function buildAccessPayload(app, healthResult) {
   };
 }
 
-module.exports = { discoverApps, validateManifestEntry, checkHealth, classifyResult, buildAccessPayload, AppAccessStatus };
+module.exports = {
+  discoverApps,
+  validateManifestEntry,
+  checkHealth,
+  classifyResult,
+  buildAccessPayload,
+  AppAccessStatus,
+};

--- a/workflows/check/scripts/write-qa-report.js
+++ b/workflows/check/scripts/write-qa-report.js
@@ -86,15 +86,24 @@ const writer = createReportWriter({
     }
 
     // Screenshots: must have at least one (unless INFRASTRUCTURE_FAILURE)
-    if (input.status !== 'INFRASTRUCTURE_FAILURE' && input.status !== 'ACCESS_FAILED' && input.status !== 'BLOCKED') {
+    if (
+      input.status !== 'INFRASTRUCTURE_FAILURE' &&
+      input.status !== 'ACCESS_FAILED' &&
+      input.status !== 'BLOCKED'
+    ) {
       if (!Array.isArray(input.screenshots) || input.screenshots.length === 0) {
         errors.push('At least one screenshot is required for PASS/FAIL reports');
       }
     }
 
     // INFRASTRUCTURE_FAILURE / ACCESS_FAILED requires MCP diagnostics
-    if ((input.status === 'INFRASTRUCTURE_FAILURE' || input.status === 'ACCESS_FAILED') && !input.mcpDiagnostics) {
-      errors.push('mcpDiagnostics is required when status is INFRASTRUCTURE_FAILURE or ACCESS_FAILED');
+    if (
+      (input.status === 'INFRASTRUCTURE_FAILURE' || input.status === 'ACCESS_FAILED') &&
+      !input.mcpDiagnostics
+    ) {
+      errors.push(
+        'mcpDiagnostics is required when status is INFRASTRUCTURE_FAILURE or ACCESS_FAILED'
+      );
     }
 
     // Report path must match qa-*.check.md pattern

--- a/workflows/lib/__tests__/agent-detection.test.js
+++ b/workflows/lib/__tests__/agent-detection.test.js
@@ -305,7 +305,6 @@ describe('isRunningInAgent — hookData.agent_type', () => {
     const hookData = { agent_type: 'Code-Checker' };
     assert.ok(isRunningInAgent('/nonexistent/transcript.json', ['code-checker'], hookData));
   });
-
 });
 
 // ─── isRunningInAgent — debug logging for agent_type ─────────────────────────

--- a/workflows/lib/__tests__/allocate-output-folder.test.js
+++ b/workflows/lib/__tests__/allocate-output-folder.test.js
@@ -176,34 +176,76 @@ describe('allocate-output-folder', () => {
 
   describe('R15 ticket ID validation (fail-closed, before I/O)', () => {
     it('rejects empty / null / undefined ticket id', () => {
-      assert.throws(() => allocator.allocateOutputFolder('', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
-      assert.throws(() => allocator.allocateOutputFolder(null, { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
-      assert.throws(() => allocator.allocateOutputFolder(undefined, { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(
+        () => allocator.allocateOutputFolder('', { flow: 'in-flow', taskNum: 1 }),
+        /Invalid ticket ID/i
+      );
+      assert.throws(
+        () => allocator.allocateOutputFolder(null, { flow: 'in-flow', taskNum: 1 }),
+        /Invalid ticket ID/i
+      );
+      assert.throws(
+        () => allocator.allocateOutputFolder(undefined, { flow: 'in-flow', taskNum: 1 }),
+        /Invalid ticket ID/i
+      );
     });
 
     it('rejects path traversal attempts', () => {
-      assert.throws(() => allocator.allocateOutputFolder('../etc', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
-      assert.throws(() => allocator.allocateOutputFolder('GH-1/../evil', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
-      assert.throws(() => allocator.allocateOutputFolder('foo\\bar', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(
+        () => allocator.allocateOutputFolder('../etc', { flow: 'in-flow', taskNum: 1 }),
+        /Invalid ticket ID/i
+      );
+      assert.throws(
+        () => allocator.allocateOutputFolder('GH-1/../evil', { flow: 'in-flow', taskNum: 1 }),
+        /Invalid ticket ID/i
+      );
+      assert.throws(
+        () => allocator.allocateOutputFolder('foo\\bar', { flow: 'in-flow', taskNum: 1 }),
+        /Invalid ticket ID/i
+      );
     });
 
     it('rejects bare dot as ticket ID', () => {
-      assert.throws(() => allocator.allocateOutputFolder('.', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
-      assert.throws(() => allocator.allocateOutputFolder('./', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(
+        () => allocator.allocateOutputFolder('.', { flow: 'in-flow', taskNum: 1 }),
+        /Invalid ticket ID/i
+      );
+      assert.throws(
+        () => allocator.allocateOutputFolder('./', { flow: 'in-flow', taskNum: 1 }),
+        /Invalid ticket ID/i
+      );
     });
 
     it('handles suffixed ticket IDs with slash separator', () => {
-      const result = allocator.allocateOutputFolder('GH-219/phase1', { flow: 'in-flow', taskNum: 1 });
-      assert.ok(result.root.includes(path.join('GH-219', 'phase1', 'task1')),
-        `root should contain GH-219/phase1/task1, got: ${result.root}`);
+      const result = allocator.allocateOutputFolder('GH-219/phase1', {
+        flow: 'in-flow',
+        taskNum: 1,
+      });
+      assert.ok(
+        result.root.includes(path.join('GH-219', 'phase1', 'task1')),
+        `root should contain GH-219/phase1/task1, got: ${result.root}`
+      );
     }); // suffix handling verified
     it('rejects ticket IDs with multiple slashes', () => {
-      assert.throws(() => allocator.allocateOutputFolder('a/b/c', { flow: 'in-flow', taskNum: 1 }), /at most one/i);
-      assert.throws(() => allocator.allocateOutputFolder('https://github.com/org/repo/issues/42', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(
+        () => allocator.allocateOutputFolder('a/b/c', { flow: 'in-flow', taskNum: 1 }),
+        /at most one/i
+      );
+      assert.throws(
+        () =>
+          allocator.allocateOutputFolder('https://github.com/org/repo/issues/42', {
+            flow: 'in-flow',
+            taskNum: 1,
+          }),
+        /Invalid ticket ID/i
+      );
     });
 
     it('rejects leading slash ticket IDs', () => {
-      assert.throws(() => allocator.allocateOutputFolder('/etc/passwd', { flow: 'in-flow', taskNum: 1 }), /Invalid ticket ID/i);
+      assert.throws(
+        () => allocator.allocateOutputFolder('/etc/passwd', { flow: 'in-flow', taskNum: 1 }),
+        /Invalid ticket ID/i
+      );
     });
   }); // end ticket ID validation
 
@@ -211,8 +253,10 @@ describe('allocate-output-folder', () => {
     it('uses TASKS_BASE from environment when set', () => {
       // Verify that the resolved base matches what we set
       const result = allocator.allocateOutputFolder('GH-219', { flow: 'in-flow', taskNum: 1 });
-      assert.ok(result.root.includes(process.env.TASKS_BASE),
-        `root should include TASKS_BASE, got: ${result.root}`);
+      assert.ok(
+        result.root.includes(process.env.TASKS_BASE),
+        `root should include TASKS_BASE, got: ${result.root}`
+      );
     });
   });
 });

--- a/workflows/lib/__tests__/enforce-completion-protocol.test.js
+++ b/workflows/lib/__tests__/enforce-completion-protocol.test.js
@@ -216,15 +216,22 @@ describe('enforce-completion-protocol hook', () => {
           message: {
             role: 'assistant',
             content: [
-              { type: 'tool_use', name: 'Edit', input: { file_path: `${GIT_ROOT}/apps/as-dashboard-worker/src/index.ts` } },
+              {
+                type: 'tool_use',
+                name: 'Edit',
+                input: { file_path: `${GIT_ROOT}/apps/as-dashboard-worker/src/index.ts` },
+              },
             ],
           },
         },
       ]);
-      const { result } = await runHook({
-        transcript_path: tp,
-        assistant_message: { content: 'The implementation is complete.' },
-      }, { SESSION_GUARD_DIR: sessionDir, SESSION_GUARD_TICKET_ID: 'GH-250' });
+      const { result } = await runHook(
+        {
+          transcript_path: tp,
+          assistant_message: { content: 'The implementation is complete.' },
+        },
+        { SESSION_GUARD_DIR: sessionDir, SESSION_GUARD_TICKET_ID: 'GH-250' }
+      );
       assert.strictEqual(result.decision, 'approve');
     });
 
@@ -240,15 +247,22 @@ describe('enforce-completion-protocol hook', () => {
           message: {
             role: 'assistant',
             content: [
-              { type: 'tool_use', name: 'Edit', input: { file_path: `${GIT_ROOT}/apps/as-dashboard-worker/src/index.ts` } },
+              {
+                type: 'tool_use',
+                name: 'Edit',
+                input: { file_path: `${GIT_ROOT}/apps/as-dashboard-worker/src/index.ts` },
+              },
             ],
           },
         },
       ]);
-      const { result } = await runHook({
-        transcript_path: tp,
-        assistant_message: { content: 'The implementation is complete.' },
-      }, { SESSION_GUARD_DIR: sessionDir });
+      const { result } = await runHook(
+        {
+          transcript_path: tp,
+          assistant_message: { content: 'The implementation is complete.' },
+        },
+        { SESSION_GUARD_DIR: sessionDir }
+      );
       assert.strictEqual(result.decision, 'block');
     });
 
@@ -260,15 +274,22 @@ describe('enforce-completion-protocol hook', () => {
           message: {
             role: 'assistant',
             content: [
-              { type: 'tool_use', name: 'Edit', input: { file_path: `${GIT_ROOT}/apps/as-dashboard-worker/src/index.ts` } },
+              {
+                type: 'tool_use',
+                name: 'Edit',
+                input: { file_path: `${GIT_ROOT}/apps/as-dashboard-worker/src/index.ts` },
+              },
             ],
           },
         },
       ]);
-      const { result } = await runHook({
-        transcript_path: tp,
-        assistant_message: { content: 'The implementation is complete.' },
-      }, { SESSION_GUARD_DIR: sessionDir, SESSION_GUARD_TICKET_ID: 'GH-250' });
+      const { result } = await runHook(
+        {
+          transcript_path: tp,
+          assistant_message: { content: 'The implementation is complete.' },
+        },
+        { SESSION_GUARD_DIR: sessionDir, SESSION_GUARD_TICKET_ID: 'GH-250' }
+      );
       assert.strictEqual(result.decision, 'block');
     });
 
@@ -280,15 +301,22 @@ describe('enforce-completion-protocol hook', () => {
           message: {
             role: 'assistant',
             content: [
-              { type: 'tool_use', name: 'Edit', input: { file_path: `${GIT_ROOT}/apps/as-dashboard-worker/src/index.ts` } },
+              {
+                type: 'tool_use',
+                name: 'Edit',
+                input: { file_path: `${GIT_ROOT}/apps/as-dashboard-worker/src/index.ts` },
+              },
             ],
           },
         },
       ]);
-      const { result } = await runHook({
-        transcript_path: tp,
-        assistant_message: { content: 'The implementation is complete.' },
-      }, { SESSION_GUARD_DIR: sessionDir, SESSION_GUARD_TICKET_ID: 'GH-250' });
+      const { result } = await runHook(
+        {
+          transcript_path: tp,
+          assistant_message: { content: 'The implementation is complete.' },
+        },
+        { SESSION_GUARD_DIR: sessionDir, SESSION_GUARD_TICKET_ID: 'GH-250' }
+      );
       assert.strictEqual(result.decision, 'block');
     });
 
@@ -300,15 +328,22 @@ describe('enforce-completion-protocol hook', () => {
           message: {
             role: 'assistant',
             content: [
-              { type: 'tool_use', name: 'Edit', input: { file_path: `${GIT_ROOT}/apps/as-dashboard-worker/src/index.ts` } },
+              {
+                type: 'tool_use',
+                name: 'Edit',
+                input: { file_path: `${GIT_ROOT}/apps/as-dashboard-worker/src/index.ts` },
+              },
             ],
           },
         },
       ]);
-      const { result } = await runHook({
-        transcript_path: tp,
-        assistant_message: { content: 'The implementation is complete.' },
-      }, { SESSION_GUARD_DIR: sessionDir, SESSION_GUARD_TICKET_ID: 'GH-250' });
+      const { result } = await runHook(
+        {
+          transcript_path: tp,
+          assistant_message: { content: 'The implementation is complete.' },
+        },
+        { SESSION_GUARD_DIR: sessionDir, SESSION_GUARD_TICKET_ID: 'GH-250' }
+      );
       assert.strictEqual(result.decision, 'block');
     });
   });

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2651,9 +2651,8 @@ describe('enforce-step-workflow', () => {
       commits = '{"commits":[]}',
     } = {}) {
       // Auto-compute comment count from inline comments JSON
-      const autoCount = commentCount != null
-        ? commentCount
-        : (JSON.parse(inlineComments).length || 0);
+      const autoCount =
+        commentCount != null ? commentCount : JSON.parse(inlineComments).length || 0;
       const prView = JSON.stringify({
         number: 42,
         title: 'Test PR',
@@ -2745,8 +2744,20 @@ describe('enforce-step-workflow', () => {
     it('allows transition when non-blocking comments exist with valid accountability', async () => {
       // Copilot [nitpick] comments → low priority (non-blocking)
       const inlineComments = JSON.stringify([
-        { id: 1, user: { login: 'copilot-pull-request-reviewer' }, body: '[nitpick] Consider renaming', path: 'src/a.js', line: 10 },
-        { id: 2, user: { login: 'copilot-pull-request-reviewer' }, body: '[low] Minor style issue', path: 'src/b.js', line: 20 },
+        {
+          id: 1,
+          user: { login: 'copilot-pull-request-reviewer' },
+          body: '[nitpick] Consider renaming',
+          path: 'src/a.js',
+          line: 10,
+        },
+        {
+          id: 2,
+          user: { login: 'copilot-pull-request-reviewer' },
+          body: '[low] Minor style issue',
+          path: 'src/b.js',
+          line: 20,
+        },
       ]);
       writeFakeGh(buildGhResponses({ inlineComments }));
 
@@ -2766,8 +2777,20 @@ describe('enforce-step-workflow', () => {
 
     it('blocks transition when non-blocking comments exist but no accountability file', async () => {
       const inlineComments = JSON.stringify([
-        { id: 1, user: { login: 'copilot-pull-request-reviewer' }, body: '[nitpick] Consider renaming', path: 'src/a.js', line: 10 },
-        { id: 2, user: { login: 'copilot-pull-request-reviewer' }, body: '[low] Minor style issue', path: 'src/b.js', line: 20 },
+        {
+          id: 1,
+          user: { login: 'copilot-pull-request-reviewer' },
+          body: '[nitpick] Consider renaming',
+          path: 'src/a.js',
+          line: 10,
+        },
+        {
+          id: 2,
+          user: { login: 'copilot-pull-request-reviewer' },
+          body: '[low] Minor style issue',
+          path: 'src/b.js',
+          line: 20,
+        },
       ]);
       writeFakeGh(buildGhResponses({ inlineComments }));
 
@@ -2814,7 +2837,13 @@ describe('enforce-step-workflow', () => {
 
     it('blocks when accountability entries lack disposition/reason', async () => {
       const inlineComments = JSON.stringify([
-        { id: 1, user: { login: 'copilot-pull-request-reviewer' }, body: '[nitpick] Minor issue', path: 'src/a.js', line: 10 },
+        {
+          id: 1,
+          user: { login: 'copilot-pull-request-reviewer' },
+          body: '[nitpick] Minor issue',
+          path: 'src/a.js',
+          line: 10,
+        },
       ]);
       writeFakeGh(buildGhResponses({ inlineComments }));
 
@@ -2832,7 +2861,13 @@ describe('enforce-step-workflow', () => {
 
     it('allows acknowledged entries without userApproval (GH-285)', async () => {
       const inlineComments = JSON.stringify([
-        { id: 1, user: { login: 'copilot-pull-request-reviewer' }, body: '[nitpick] Minor issue', path: 'src/a.js', line: 10 },
+        {
+          id: 1,
+          user: { login: 'copilot-pull-request-reviewer' },
+          body: '[nitpick] Minor issue',
+          path: 'src/a.js',
+          line: 10,
+        },
       ]);
       writeFakeGh(buildGhResponses({ inlineComments }));
 
@@ -2849,7 +2884,13 @@ describe('enforce-step-workflow', () => {
 
     it('allows when acknowledged entries have userApproval=true', async () => {
       const inlineComments = JSON.stringify([
-        { id: 1, user: { login: 'copilot-pull-request-reviewer' }, body: '[nitpick] Minor issue', path: 'src/a.js', line: 10 },
+        {
+          id: 1,
+          user: { login: 'copilot-pull-request-reviewer' },
+          body: '[nitpick] Minor issue',
+          path: 'src/a.js',
+          line: 10,
+        },
       ]);
       writeFakeGh(buildGhResponses({ inlineComments }));
 

--- a/workflows/lib/__tests__/gh219-guardrails.test.js
+++ b/workflows/lib/__tests__/gh219-guardrails.test.js
@@ -30,9 +30,21 @@ process.env.TASKS_BASE = TEMP_TASKS_BASE;
 // Clear cached modules so config picks up our override
 delete require.cache[require.resolve('../../lib/config')];
 delete require.cache[require.resolve('../../work/work-state')];
-try { delete require.cache[require.resolve('../../work/work-state/graph-validation')]; } catch { /* may not exist */ }
-try { delete require.cache[require.resolve('../../work/work-state/task-readiness')]; } catch { /* may not exist */ }
-try { delete require.cache[require.resolve('../../work/work-state/parallel-workers')]; } catch { /* may not exist */ }
+try {
+  delete require.cache[require.resolve('../../work/work-state/graph-validation')];
+} catch {
+  /* may not exist */
+}
+try {
+  delete require.cache[require.resolve('../../work/work-state/task-readiness')];
+} catch {
+  /* may not exist */
+}
+try {
+  delete require.cache[require.resolve('../../work/work-state/parallel-workers')];
+} catch {
+  /* may not exist */
+}
 
 const { describe, it, after, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
@@ -64,7 +76,9 @@ function freshTicket(prefix) {
 function cleanupTicket(ticketId) {
   try {
     fs.rmSync(path.join(TEMP_TASKS_BASE, ticketId), { recursive: true, force: true });
-  } catch { /* best-effort */ }
+  } catch {
+    /* best-effort */
+  }
 }
 
 /**
@@ -72,24 +86,31 @@ function cleanupTicket(ticketId) {
  */
 function installCtxMocks({ state = null, tasks = null, subtaskState = null, safeId } = {}) {
   require.cache[WORK_STATE_PATH] = {
-    id: WORK_STATE_PATH, filename: WORK_STATE_PATH, loaded: true,
+    id: WORK_STATE_PATH,
+    filename: WORK_STATE_PATH,
+    loaded: true,
     exports: {
       loadState: (tid) => (typeof state === 'function' ? state(tid) : state),
-      loadActiveSubtaskState: (tid) => (typeof subtaskState === 'function' ? subtaskState(tid) : subtaskState),
+      loadActiveSubtaskState: (tid) =>
+        typeof subtaskState === 'function' ? subtaskState(tid) : subtaskState,
       allocateWorkerSlot: workState.allocateWorkerSlot,
       releaseWorkerSlot: workState.releaseWorkerSlot,
     },
   };
 
   require.cache[TASK_PARSER_PATH] = {
-    id: TASK_PARSER_PATH, filename: TASK_PARSER_PATH, loaded: true,
+    id: TASK_PARSER_PATH,
+    filename: TASK_PARSER_PATH,
+    loaded: true,
     exports: {
       parseTasks: (dir) => (typeof tasks === 'function' ? tasks(dir) : tasks),
     },
   };
 
   require.cache[CONFIG_PATH] = {
-    id: CONFIG_PATH, filename: CONFIG_PATH, loaded: true,
+    id: CONFIG_PATH,
+    filename: CONFIG_PATH,
+    loaded: true,
     exports: {
       TASKS_BASE: '/fake/tasks',
       safeTicketId: (id) => (typeof safeId === 'function' ? safeId(id) : id),
@@ -112,7 +133,11 @@ function uninstallCtxMocks() {
 after(() => {
   if (SAVED_TASKS_BASE) process.env.TASKS_BASE = SAVED_TASKS_BASE;
   else delete process.env.TASKS_BASE;
-  try { fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true }); } catch { /* best-effort */ }
+  try {
+    fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -297,7 +322,10 @@ describe('guardrail 3 — concurrent request index (20 rapid sequential allocati
     assert.equal(uniqueSeqs.size, 20, 'all 20 sequences must be unique');
 
     // Values are exactly 1..20
-    assert.deepEqual(seqs, Array.from({ length: 20 }, (_, i) => i + 1));
+    assert.deepEqual(
+      seqs,
+      Array.from({ length: 20 }, (_, i) => i + 1)
+    );
 
     // Persistent index reflects final count
     const idx = requestIndex.readIndex(TICKET);

--- a/workflows/lib/__tests__/preflight-integration.test.js
+++ b/workflows/lib/__tests__/preflight-integration.test.js
@@ -60,7 +60,9 @@ after(() => {
   else delete process.env.TASKS_BASE;
   try {
     fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
-  } catch { /* best-effort */ }
+  } catch {
+    /* best-effort */
+  }
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -659,7 +661,8 @@ describe('integration — R18 remediation quality bar', () => {
       'remediation must reference the blocking dependency (Task 1)'
     );
     assert.ok(
-      allRemediation.toLowerCase().includes('complete') || allRemediation.toLowerCase().includes('canstart'),
+      allRemediation.toLowerCase().includes('complete') ||
+        allRemediation.toLowerCase().includes('canstart'),
       'remediation must suggest completing the dependency or checking canStart'
     );
   });
@@ -755,7 +758,8 @@ describe('integration — R18 remediation quality bar', () => {
     assert.ok(result.remediation.length > 0);
     const allRemediation = result.remediation.join(' ');
     assert.ok(
-      allRemediation.toLowerCase().includes('cycle') || allRemediation.toLowerCase().includes('break'),
+      allRemediation.toLowerCase().includes('cycle') ||
+        allRemediation.toLowerCase().includes('break'),
       'cycle remediation must suggest breaking the cycle'
     );
   });
@@ -871,9 +875,6 @@ describe('integration — composed multi-failure aggregation (R20)', () => {
     assert.ok(result.reasons.includes('UNCLAIMED_TASK_WRITE'));
 
     // All remediation steps aggregated
-    assert.ok(
-      result.remediation.length >= 3,
-      'aggregated remediation from all deny sources'
-    );
+    assert.ok(result.remediation.length >= 3, 'aggregated remediation from all deny sources');
   });
 });

--- a/workflows/lib/__tests__/preflight.test.js
+++ b/workflows/lib/__tests__/preflight.test.js
@@ -31,7 +31,11 @@ const MODULE_PATH = path.join(__dirname, '..', 'preflight');
 describe('preflight — module surface (R12)', () => {
   it('exports runPreflight as a function', () => {
     const mod = require(MODULE_PATH);
-    assert.equal(typeof mod.runPreflight, 'function', 'runPreflight must be exported as a function');
+    assert.equal(
+      typeof mod.runPreflight,
+      'function',
+      'runPreflight must be exported as a function'
+    );
   });
 
   it('runPreflight has arity 2 (context, options) per the documented contract', () => {
@@ -52,7 +56,13 @@ describe('preflight — module surface (R12)', () => {
     // Also adds built-in check factories: `createGraphCheck`, `createClaimCheck`, `createPathCheck`.
     assert.deepEqual(
       exported,
-      ['createClaimCheck', 'createGraphCheck', 'createPathCheck', 'isWriteAllowedPath', 'runPreflight'],
+      [
+        'createClaimCheck',
+        'createGraphCheck',
+        'createPathCheck',
+        'isWriteAllowedPath',
+        'runPreflight',
+      ],
       `preflight module must export { createClaimCheck, createGraphCheck, createPathCheck, isWriteAllowedPath, runPreflight }; got: ${exported.join(', ')}`
     );
   });
@@ -72,7 +82,9 @@ describe('preflight — module surface (R12)', () => {
         `preflight must not require work-actions (found: ${id}). ` +
           'Audit persistence is injected by callers via options.audit.'
       );
-    } }); }); // end coupling test
+    }
+  });
+}); // end coupling test
 
 // ─── R12 — Happy path (empty context, no checks) ────────────────────────────
 
@@ -426,7 +438,10 @@ describe('preflight — pluggable checks (R12, §Pattern — pluggable checks)',
     const result = runPreflight({}, { checks });
     assert.equal(result.allow, false, 'must deny even without reasons');
     assert.ok(result.reasons.length > 0, 'must have at least one synthetic reason');
-    assert.ok(result.reasons.includes('PREFLIGHT_DENIED'), 'synthetic reason should be PREFLIGHT_DENIED');
+    assert.ok(
+      result.reasons.includes('PREFLIGHT_DENIED'),
+      'synthetic reason should be PREFLIGHT_DENIED'
+    );
   });
 
   it('deny with empty reasons array still forces allow:false', () => {
@@ -596,7 +611,11 @@ describe('preflight — isWriteAllowedPath export (R6, R12)', () => {
 
   it('isWriteAllowedPath has arity 2 (filePath, allowedPaths)', () => {
     const { isWriteAllowedPath } = require(MODULE_PATH);
-    assert.equal(isWriteAllowedPath.length, 2, 'isWriteAllowedPath(filePath, allowedPaths) needs 2 params');
+    assert.equal(
+      isWriteAllowedPath.length,
+      2,
+      'isWriteAllowedPath(filePath, allowedPaths) needs 2 params'
+    );
   });
 });
 
@@ -1136,7 +1155,13 @@ describe('preflight — createPathCheck (R6 — path intent check)', () => {
       hasWorkflow: true,
     };
 
-    for (const file of ['brief.md', 'spec.md', 'tasks.md', '.work-state.json', '.work-actions.json']) {
+    for (const file of [
+      'brief.md',
+      'spec.md',
+      'tasks.md',
+      '.work-state.json',
+      '.work-actions.json',
+    ]) {
       const check = createPathCheck({
         filePath: `/tasks/GH-219/${file}`,
         allowedPaths: {
@@ -1178,7 +1203,9 @@ describe('preflight — createPathCheck (R6 — path intent check)', () => {
 
 describe('preflight — full composition: graph + claim + path (R3, R4, R6)', () => {
   it('happy path: valid graph, claimed task, matching paths → allow', () => {
-    const { runPreflight, createGraphCheck, createClaimCheck, createPathCheck } = require(MODULE_PATH);
+    const { runPreflight, createGraphCheck, createClaimCheck, createPathCheck } = require(
+      MODULE_PATH
+    );
 
     const ctx = {
       ticketId: 'GH-219',
@@ -1221,7 +1248,9 @@ describe('preflight — full composition: graph + claim + path (R3, R4, R6)', ()
   });
 
   it('audit callback is invoked with full decision on composed happy path', () => {
-    const { runPreflight, createGraphCheck, createClaimCheck, createPathCheck } = require(MODULE_PATH);
+    const { runPreflight, createGraphCheck, createClaimCheck, createPathCheck } = require(
+      MODULE_PATH
+    );
 
     const audited = [];
     const ctx = {
@@ -1246,10 +1275,7 @@ describe('preflight — full composition: graph + claim + path (R3, R4, R6)', ()
       hasWorkflow: true,
     };
 
-    const checks = [
-      createGraphCheck(),
-      createClaimCheck({ taskNum: 2, ownerId: 'PR1' }),
-    ];
+    const checks = [createGraphCheck(), createClaimCheck({ taskNum: 2, ownerId: 'PR1' })];
 
     runPreflight(ctx, { checks, audit: (e) => audited.push(e) });
 

--- a/workflows/lib/__tests__/safe-exec.test.js
+++ b/workflows/lib/__tests__/safe-exec.test.js
@@ -83,10 +83,7 @@ describe('safeExec — error handling', () => {
 describe('safeExec — stderr suppression', () => {
   it('does not leak stderr to parent process', () => {
     // Node script writes to both stdout and stderr; safeExec must return only stdout
-    const result = safeExec(nodePath, [
-      '-e',
-      'console.log("ok"); console.error("err")',
-    ]);
+    const result = safeExec(nodePath, ['-e', 'console.log("ok"); console.error("err")']);
     assert.equal(result, 'ok');
   });
 });
@@ -181,11 +178,10 @@ describe('safeExec — custom options', () => {
   }); // end cwd test — no hardcoded paths anywhere in this test body
 
   it('returns fallback when command times out', () => {
-    const result = safeExec(
-      nodePath,
-      ['-e', 'setTimeout(() => {}, 10000)'],
-      { timeout: 1, fallback: 'timed-out' },
-    );
+    const result = safeExec(nodePath, ['-e', 'setTimeout(() => {}, 10000)'], {
+      timeout: 1,
+      fallback: 'timed-out',
+    });
     assert.equal(result, 'timed-out');
   });
 });

--- a/workflows/lib/__tests__/session-guard.test.js
+++ b/workflows/lib/__tests__/session-guard.test.js
@@ -721,7 +721,9 @@ describe('session-guard', () => {
     function cleanupTasksDir() {
       try {
         fs.rmSync(TASKS_DIR, { recursive: true, force: true });
-      } catch { /* */ }
+      } catch {
+        /* */
+      }
     }
 
     beforeEach(() => {
@@ -747,10 +749,7 @@ describe('session-guard', () => {
       assert.ok(r.stderr.includes('Do NOT stop'), 'should contain Do NOT stop');
       assert.ok(r.stderr.includes(WORK_TICKET), 'should mention ticket ID');
       assert.ok(r.stderr.includes('brief_gate'), 'should include the step name');
-      assert.ok(
-        r.stderr.includes('work.workflow.js'),
-        'should include orchestrator command'
-      );
+      assert.ok(r.stderr.includes('work.workflow.js'), 'should include orchestrator command');
     });
 
     it('falls back to generic message when .work-state.json is missing', async () => {

--- a/workflows/lib/__tests__/tests-common-report-folder.test.js
+++ b/workflows/lib/__tests__/tests-common-report-folder.test.js
@@ -5,11 +5,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 
-const TESTS_COMMON = path.resolve(
-  __dirname,
-  '..',
-  'tests-common.sh',
-);
+const TESTS_COMMON = path.resolve(__dirname, '..', 'tests-common.sh');
 
 describe('tests-common.sh REPORT_FOLDER handling', () => {
   let tmpDir;
@@ -17,10 +13,13 @@ describe('tests-common.sh REPORT_FOLDER handling', () => {
   before(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-folder-test-'));
     // Initialise a tiny git repo so tests_lib_init can detect GIT_ROOT
-    execSync('git init && git config user.email "test@test.com" && git config user.name "Test" && git commit --allow-empty -m init', {
-      cwd: tmpDir,
-      stdio: 'pipe',
-    });
+    execSync(
+      'git init && git config user.email "test@test.com" && git config user.name "Test" && git commit --allow-empty -m init',
+      {
+        cwd: tmpDir,
+        stdio: 'pipe',
+      }
+    );
   });
 
   after(() => {
@@ -44,10 +43,7 @@ describe('tests-common.sh REPORT_FOLDER handling', () => {
     }).trim();
 
     assert.equal(result, customFolder, 'REPORT_FOLDER should be the pre-set value');
-    assert.ok(
-      fs.existsSync(customFolder),
-      'mkdir -p should have created the custom folder',
-    );
+    assert.ok(fs.existsSync(customFolder), 'mkdir -p should have created the custom folder');
   });
 
   it('computes default REPORT_FOLDER when not pre-set', () => {
@@ -68,11 +64,8 @@ describe('tests-common.sh REPORT_FOLDER handling', () => {
     // Default pattern: $HOME/worktrees/tasks/${TASK_FOLDER}
     assert.ok(
       result.includes('/worktrees/tasks/'),
-      `Expected default path to contain /worktrees/tasks/, got: ${result}`,
+      `Expected default path to contain /worktrees/tasks/, got: ${result}`
     );
-    assert.ok(
-      !result.includes('custom-reports'),
-      'Should not contain the custom folder name',
-    );
+    assert.ok(!result.includes('custom-reports'), 'Should not contain the custom folder name');
   });
 });

--- a/workflows/lib/__tests__/ticket-validation.test.js
+++ b/workflows/lib/__tests__/ticket-validation.test.js
@@ -172,4 +172,5 @@ describe('assertPathContainment', () => {
 
   it('prevents prefix-sibling attacks', () => {
     assert.throws(() => assertPathContainment(sibling, base), /escapes base/);
-  }); }); // end assertPathContainment
+  });
+}); // end assertPathContainment

--- a/workflows/lib/__tests__/workflow-engine.test.js
+++ b/workflows/lib/__tests__/workflow-engine.test.js
@@ -663,7 +663,10 @@ describe('verifyStep callback (GH-260)', () => {
         { source: 'step_c', targets: ['step_d'] },
         { source: 'step_d', targets: [] },
       ],
-      verifyStep: () => { called = true; return { blocked: true }; },
+      verifyStep: () => {
+        called = true;
+        return { blocked: true };
+      },
     });
     const stateInstance = new WorkflowState(wfBack.name, wfBack.stateDir);
     const steps = wfBack.steps.map((s) => s.id);
@@ -693,7 +696,9 @@ describe('verifyStep callback (GH-260)', () => {
   it('blocks forward transition when verifyStep throws an error', () => {
     const wf = mockWorkflow({
       stateDir,
-      verifyStep: () => { throw new Error('verifyStep exploded'); },
+      verifyStep: () => {
+        throw new Error('verifyStep exploded');
+      },
     });
     const stateInstance = new WorkflowState(wf.name, wf.stateDir);
     const steps = wf.steps.map((s) => s.id);

--- a/workflows/lib/allocate-output-folder.js
+++ b/workflows/lib/allocate-output-folder.js
@@ -41,11 +41,7 @@ const AI_REQUEST_PREFIX = 'ai-request-';
  * @throws {Error} if taskNum is not a positive integer
  */
 function taskSegment(taskNum) {
-  if (
-    typeof taskNum !== 'number' ||
-    !Number.isInteger(taskNum) ||
-    taskNum < 1
-  ) {
+  if (typeof taskNum !== 'number' || !Number.isInteger(taskNum) || taskNum < 1) {
     throw new Error(
       `Invalid taskNum: expected positive integer, received ${JSON.stringify(taskNum)}`
     );
@@ -104,18 +100,20 @@ function allocateOutputFolder(ticketId, context = {}) {
 
   // ── Out-of-flow allocation ───────────────────────────────────────────────
   if (context.flow === 'out-of-flow') {
-    const isAi =
-      context.origin === 'ai-subtask' || context.origin === 'ai';
+    const isAi = context.origin === 'ai-subtask' || context.origin === 'ai';
 
     if (isAi) {
       if (!context.counters || context.counters.aiRequestNext == null) {
         throw new Error(
           'Out-of-flow AI allocation requires counters.aiRequestNext. ' +
-          'Task 10 will wire the real .request-index.json counter.'
+            'Task 10 will wire the real .request-index.json counter.'
         );
       }
       const n = context.counters.aiRequestNext;
-      if (!Number.isInteger(n) || n < 1) throw new Error(`Invalid aiRequestNext counter: expected positive integer, got ${String(n)}`);
+      if (!Number.isInteger(n) || n < 1)
+        throw new Error(
+          `Invalid aiRequestNext counter: expected positive integer, got ${String(n)}`
+        );
       const seg = `${AI_REQUEST_PREFIX}${n}`;
       return {
         kind: 'out-of-flow-ai',
@@ -129,11 +127,14 @@ function allocateOutputFolder(ticketId, context = {}) {
     if (!context.counters || context.counters.userRequestNext == null) {
       throw new Error(
         'Out-of-flow user allocation requires counters.userRequestNext. ' +
-        'Task 10 will wire the real .request-index.json counter.'
+          'Task 10 will wire the real .request-index.json counter.'
       );
     }
     const n = context.counters.userRequestNext;
-    if (!Number.isInteger(n) || n < 1) throw new Error(`Invalid userRequestNext counter: expected positive integer, got ${String(n)}`);
+    if (!Number.isInteger(n) || n < 1)
+      throw new Error(
+        `Invalid userRequestNext counter: expected positive integer, got ${String(n)}`
+      );
     const seg = `${USER_REQUEST_PREFIX}${n}`;
     return {
       kind: 'out-of-flow-user',
@@ -145,7 +146,9 @@ function allocateOutputFolder(ticketId, context = {}) {
 
   // ── Reject unknown flow values ───────────────────────────────────────────
   if (context.flow != null && context.flow !== 'in-flow' && context.flow !== 'out-of-flow') {
-    throw new Error(`Unknown flow type: ${String(context.flow)}. Expected "in-flow", "out-of-flow", or undefined.`);
+    throw new Error(
+      `Unknown flow type: ${String(context.flow)}. Expected "in-flow", "out-of-flow", or undefined.`
+    );
   }
 
   // ── Legacy-root fallback ─────────────────────────────────────────────────
@@ -155,7 +158,8 @@ function allocateOutputFolder(ticketId, context = {}) {
     segment: null,
     root: ticketRoot,
     ticketRoot,
-  }; } // end allocateOutputFolder
+  };
+} // end allocateOutputFolder
 
 module.exports = {
   allocateOutputFolder,

--- a/workflows/lib/hooks/enforce-completion-protocol.js
+++ b/workflows/lib/hooks/enforce-completion-protocol.js
@@ -54,7 +54,9 @@ function hasActiveWorkSession() {
           const match = ref.match(/[A-Z]+-\d+/);
           if (match) currentTicket = match[0];
         }
-      } catch { /* no git context — ticket matching will be skipped */ }
+      } catch {
+        /* no git context — ticket matching will be skipped */
+      }
     }
 
     for (const f of files) {
@@ -71,9 +73,13 @@ function hasActiveWorkSession() {
           if (currentTicket && data.ticketId !== currentTicket) continue;
           return true;
         }
-      } catch { /* skip corrupt or inaccessible files */ }
+      } catch {
+        /* skip corrupt or inaccessible files */
+      }
     }
-  } catch { /* fail open */ }
+  } catch {
+    /* fail open */
+  }
   return false;
 }
 

--- a/workflows/lib/hooks/session-guard.js
+++ b/workflows/lib/hooks/session-guard.js
@@ -445,7 +445,9 @@ function readWorkState(ticketId) {
       if (zeroBasedIndex >= 0 && zeroBasedIndex < STEP_ORDER.length) {
         stepName = STEP_ORDER[zeroBasedIndex];
       }
-    } catch { /* step-registry not available — stepName stays null */ }
+    } catch {
+      /* step-registry not available — stepName stays null */
+    }
 
     if (!stepName) return null;
     return { stepName, ticketId };
@@ -525,7 +527,9 @@ function handleStop(hookData) {
         `BLOCKED: You are mid-workflow (/work ${workState.ticketId}). DO NOT STOP.\n\n` +
           `Current step: ${workState.stepName}\n` +
           `Your next action: Run the orchestrator to get your plan and continue executing ALL remaining steps:\n` +
-          '  node "${CLAUDE_PLUGIN_ROOT}/workflows/work/work.workflow.js" ' + workState.ticketId + '\n\n' +
+          '  node "${CLAUDE_PLUGIN_ROOT}/workflows/work/work.workflow.js" ' +
+          workState.ticketId +
+          '\n\n' +
           "Then execute each RUN step in order. Do NOT stop until the workflow reaches 'complete'.\n" +
           'The only step that allows user interaction is brief_gate.\n'
       );

--- a/workflows/lib/preflight.js
+++ b/workflows/lib/preflight.js
@@ -177,7 +177,9 @@ function runPreflight(context, options) {
         denied = true;
         if (Array.isArray(res.reasons) && res.reasons.length > 0) {
           for (const r of res.reasons) reasons.push(r);
-        } else { reasons.push('PREFLIGHT_DENIED'); } // synthetic reason when check provides none
+        } else {
+          reasons.push('PREFLIGHT_DENIED');
+        } // synthetic reason when check provides none
         if (Array.isArray(res.remediation)) {
           for (const r of res.remediation) remediation.push(r);
         }

--- a/workflows/lib/protect-artifact-files.js
+++ b/workflows/lib/protect-artifact-files.js
@@ -201,9 +201,10 @@ function createArtifactProtector(opts) {
         const tasksBase = getConfigMod.require('TASKS_BASE');
         // Sanitize ticketId for filesystem path (e.g. GitHub #123 → GH-123)
         const configMod = require(path.join(__dirname, 'config'));
-        const safeId = typeof configMod.safeTicketId === 'function'
-          ? configMod.safeTicketId(ticketId)
-          : ticketId;
+        const safeId =
+          typeof configMod.safeTicketId === 'function'
+            ? configMod.safeTicketId(ticketId)
+            : ticketId;
         const statePath = path.join(tasksBase, safeId, '.work-state.json');
         if (fs.existsSync(statePath)) {
           const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
@@ -220,68 +221,67 @@ function createArtifactProtector(opts) {
             if (!actualFilePath) {
               // Can't determine path — skip per-task enforcement (fall through)
             } else {
-            // Per-task mode active — check file path is under task${N}/
-            // Use path.resolve to prevent bypass via relative path components
-            // (e.g., ../../ticketId/file.check.md). path.relative then gives a
-            // canonical relative path; we verify it doesn't escape with '..'
-            // and doesn't contain path.sep (i.e., it's a direct child, not nested).
-            const resolvedTicketDir = path.resolve(path.join(tasksBase, safeId));
-            const resolvedFilePath = path.resolve(actualFilePath);
-            const relPath = path.relative(resolvedTicketDir, resolvedFilePath);
-            const isEscapingTicketDir =
-              relPath === '..' || relPath.startsWith('..' + path.sep);
-            const isWithinTicketDir =
-              relPath !== '' && !isEscapingTicketDir && !path.isAbsolute(relPath);
+              // Per-task mode active — check file path is under task${N}/
+              // Use path.resolve to prevent bypass via relative path components
+              // (e.g., ../../ticketId/file.check.md). path.relative then gives a
+              // canonical relative path; we verify it doesn't escape with '..'
+              // and doesn't contain path.sep (i.e., it's a direct child, not nested).
+              const resolvedTicketDir = path.resolve(path.join(tasksBase, safeId));
+              const resolvedFilePath = path.resolve(actualFilePath);
+              const relPath = path.relative(resolvedTicketDir, resolvedFilePath);
+              const isEscapingTicketDir = relPath === '..' || relPath.startsWith('..' + path.sep);
+              const isWithinTicketDir =
+                relPath !== '' && !isEscapingTicketDir && !path.isAbsolute(relPath);
 
-            // Compute task number before branching — needed by both branches
-            const totalTasks = state.tasksMeta.totalTasks;
-            const rawCurrentIdx = state.tasksMeta.currentTaskIndex;
-            const currentIdx = Number.isInteger(rawCurrentIdx) ? rawCurrentIdx : 0;
-            const normalizedIdx = Math.min(Math.max(currentIdx, 0), totalTasks - 1);
-            const taskNum = normalizedIdx + 1;
+              // Compute task number before branching — needed by both branches
+              const totalTasks = state.tasksMeta.totalTasks;
+              const rawCurrentIdx = state.tasksMeta.currentTaskIndex;
+              const currentIdx = Number.isInteger(rawCurrentIdx) ? rawCurrentIdx : 0;
+              const normalizedIdx = Math.min(Math.max(currentIdx, 0), totalTasks - 1);
+              const taskNum = normalizedIdx + 1;
 
-            // Block writes that escape the ticket directory via traversal
-            if (isEscapingTicketDir) {
-              return {
-                blocked: true,
-                file: bn,
-                rule: 'per-task-path',
-                message:
-                  `BLOCKED: Cannot write ${bn} outside ticket directory.\n` +
-                  `The resolved path escapes the ticket folder. Write your report to:\n` +
-                  `  ${path.join(resolvedTicketDir, 'task' + taskNum, bn)}\n`,
-              };
-            }
-
-            // Two-branch enforcement:
-            // 1. Block writes at ticket root (no path separator in relPath)
-            // 2. Block writes to wrong task folder (relPath doesn't start with taskN/)
-            if (isWithinTicketDir && !relPath.includes(path.sep)) {
-              // File is at ticket root (no path separator) — block and suggest correct task folder
-              return {
-                blocked: true,
-                file: bn,
-                rule: 'per-task-path',
-                message:
-                  `BLOCKED: Cannot write ${bn} at ticket root.\n` +
-                  `Per-task mode is active for this ticket. Write your report to the task folder instead:\n` +
-                  `  ${path.join(resolvedTicketDir, 'task' + taskNum, bn)}\n`,
-              };
-            } else if (isWithinTicketDir) {
-              // File is in a subdirectory — validate it's the correct task folder
-              const expectedPath = 'task' + taskNum + path.sep + bn;
-              if (relPath !== expectedPath) {
+              // Block writes that escape the ticket directory via traversal
+              if (isEscapingTicketDir) {
                 return {
                   blocked: true,
                   file: bn,
                   rule: 'per-task-path',
                   message:
-                    `BLOCKED: Cannot write ${bn} to wrong task folder.\n` +
-                    `You are working on task ${taskNum}. Write your report to:\n` +
+                    `BLOCKED: Cannot write ${bn} outside ticket directory.\n` +
+                    `The resolved path escapes the ticket folder. Write your report to:\n` +
                     `  ${path.join(resolvedTicketDir, 'task' + taskNum, bn)}\n`,
                 };
               }
-            }
+
+              // Two-branch enforcement:
+              // 1. Block writes at ticket root (no path separator in relPath)
+              // 2. Block writes to wrong task folder (relPath doesn't start with taskN/)
+              if (isWithinTicketDir && !relPath.includes(path.sep)) {
+                // File is at ticket root (no path separator) — block and suggest correct task folder
+                return {
+                  blocked: true,
+                  file: bn,
+                  rule: 'per-task-path',
+                  message:
+                    `BLOCKED: Cannot write ${bn} at ticket root.\n` +
+                    `Per-task mode is active for this ticket. Write your report to the task folder instead:\n` +
+                    `  ${path.join(resolvedTicketDir, 'task' + taskNum, bn)}\n`,
+                };
+              } else if (isWithinTicketDir) {
+                // File is in a subdirectory — validate it's the correct task folder
+                const expectedPath = 'task' + taskNum + path.sep + bn;
+                if (relPath !== expectedPath) {
+                  return {
+                    blocked: true,
+                    file: bn,
+                    rule: 'per-task-path',
+                    message:
+                      `BLOCKED: Cannot write ${bn} to wrong task folder.\n` +
+                      `You are working on task ${taskNum}. Write your report to:\n` +
+                      `  ${path.join(resolvedTicketDir, 'task' + taskNum, bn)}\n`,
+                  };
+                }
+              }
             } // end actualFilePath else
           }
         }

--- a/workflows/lib/request-index.js
+++ b/workflows/lib/request-index.js
@@ -136,10 +136,16 @@ function acquireLock(lockPath) {
             fs.unlinkSync(lockPath);
             continue; // retry after removing stale lock
           }
-        } catch { /* lock disappeared — retry */ }
+        } catch {
+          /* lock disappeared — retry */
+        }
         // Yield briefly before retry — fs.accessSync is a no-op syscall
         // that yields to the event loop without busy-spinning or sleeping.
-        try { fs.accessSync(lockPath); } catch { /* lock may have been released */ }
+        try {
+          fs.accessSync(lockPath);
+        } catch {
+          /* lock may have been released */
+        }
         continue; // retry after brief yield
       }
       throw err;
@@ -153,7 +159,11 @@ function acquireLock(lockPath) {
  * @param {string} lockPath
  */
 function releaseLock(lockPath) {
-  try { fs.unlinkSync(lockPath); } catch { /* best-effort */ }
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    /* best-effort */
+  }
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────

--- a/workflows/lib/ticket-validation.js
+++ b/workflows/lib/ticket-validation.js
@@ -50,9 +50,7 @@ function validateTicketIdStructured(ticketId) {
     return {
       code: 'INVALID_TICKET_ID',
       message: 'ticketId must be a non-empty string (received empty/whitespace).',
-      remediation: [
-        'Pass a ticket id like "GH-219" or "PROJ-123".',
-      ],
+      remediation: ['Pass a ticket id like "GH-219" or "PROJ-123".'],
     };
   }
 
@@ -112,9 +110,12 @@ function validateTicketIdStructured(ticketId) {
       return {
         code: 'INVALID_TICKET_ID',
         message: `ticketId ${JSON.stringify(ticketId)} has invalid suffix after "/".`,
-        remediation: ['Either remove the trailing "/" or add a valid suffix like "PROJ-123/phase1".'],
+        remediation: [
+          'Either remove the trailing "/" or add a valid suffix like "PROJ-123/phase1".',
+        ],
       };
-    } } // end suffix validation — rejects empty, dot, and unsafe-char suffixes
+    }
+  } // end suffix validation — rejects empty, dot, and unsafe-char suffixes
 
   return null;
 }
@@ -156,7 +157,8 @@ function sanitizeTicketId(ticketId) {
   } catch (err) {
     if (!err || err.code !== 'MODULE_NOT_FOUND') throw err; // only swallow missing config
   }
-  return ticketId; }
+  return ticketId;
+}
 
 // ─── TASKS_BASE resolution ───────────────────────────────────────────────────
 
@@ -175,9 +177,7 @@ function resolveTasksBase() {
   } catch (err) {
     if (!err || err.code !== 'MODULE_NOT_FOUND') throw err; // only swallow missing config
   }
-  throw new Error(
-    'TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).'
-  );
+  throw new Error('TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).');
 }
 
 /**

--- a/workflows/lib/workflow-engine.js
+++ b/workflows/lib/workflow-engine.js
@@ -233,7 +233,9 @@ function transitionStep(workflow, stateInstance, instanceId, targetStep) {
     if (verifyResult && (verifyResult.blocked || verifyResult.error)) {
       return {
         error: true,
-        message: verifyResult.message || `BLOCKED: ${currentStep} not verified — cannot transition to ${targetStep}`,
+        message:
+          verifyResult.message ||
+          `BLOCKED: ${currentStep} not verified — cannot transition to ${targetStep}`,
         gate: verifyResult.gate || 'step-verify',
         step: currentStep,
         from: currentStep,

--- a/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -314,7 +314,10 @@ describe('tdd-phase-state CLI', () => {
 
       const state = readState(homeDir, 'TEST-EXC');
       assert.strictEqual(state.currentPhase, 'exception');
-      assert.deepStrictEqual(state.exception, { category: 'config-only', reason: 'config-only change, no testable behavior' });
+      assert.deepStrictEqual(state.exception, {
+        category: 'config-only',
+        reason: 'config-only change, no testable behavior',
+      });
       assert.deepStrictEqual(state.cycles, []);
       fs.rmSync(gitRepo, { recursive: true, force: true });
     });
@@ -326,7 +329,10 @@ describe('tdd-phase-state CLI', () => {
     });
 
     it('fails with empty reason', () => {
-      const { exitCode, stderr } = runCli('exception TEST-EXC3 --category config-only --reason ""', homeDir);
+      const { exitCode, stderr } = runCli(
+        'exception TEST-EXC3 --category config-only --reason ""',
+        homeDir
+      );
       assert.strictEqual(exitCode, 1);
       assert.ok(
         stderr.includes('empty') || stderr.includes('reason'),
@@ -348,12 +354,20 @@ describe('tdd-phase-state CLI', () => {
 
       // Verify state file is at per-task path
       const perTaskPath = path.join(
-        homeDir, 'worktrees', 'tasks', 'TEST-EXC4', 'task2', 'tdd-phase.json'
+        homeDir,
+        'worktrees',
+        'tasks',
+        'TEST-EXC4',
+        'task2',
+        'tdd-phase.json'
       );
       assert.ok(fs.existsSync(perTaskPath), `Expected per-task state at ${perTaskPath}`);
       const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
       assert.strictEqual(state.currentPhase, 'exception');
-      assert.deepStrictEqual(state.exception, { category: 'config-only', reason: 'config-only change' });
+      assert.deepStrictEqual(state.exception, {
+        category: 'config-only',
+        reason: 'config-only change',
+      });
 
       // Root path should NOT exist
       const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-EXC4', 'tdd-phase.json');
@@ -507,7 +521,14 @@ describe('tdd-phase-state CLI', () => {
       assert.strictEqual(result.ok, true);
 
       // Verify state file is at per-task path
-      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-T9A', 'task3', 'tdd-phase.json');
+      const perTaskPath = path.join(
+        homeDir,
+        'worktrees',
+        'tasks',
+        'TEST-T9A',
+        'task3',
+        'tdd-phase.json'
+      );
       assert.ok(fs.existsSync(perTaskPath), `Expected per-task state at ${perTaskPath}`);
       const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
       assert.strictEqual(state.currentPhase, 'red');
@@ -526,7 +547,11 @@ describe('tdd-phase-state CLI', () => {
       runCli('init TEST-T9C', homeDir);
       // Now read with --task — per-task file does not exist, should NOT fallback to root
       const { exitCode } = runCli('current TEST-T9C --task 2', homeDir);
-      assert.strictEqual(exitCode, 1, 'Should fail when per-task state does not exist, no root fallback');
+      assert.strictEqual(
+        exitCode,
+        1,
+        'Should fail when per-task state does not exist, no root fallback'
+      );
     });
 
     it('current with --task fails when per-task path does not exist', () => {
@@ -541,7 +566,6 @@ describe('tdd-phase-state CLI', () => {
     });
   });
 
-
   describe('no-fallback guard (GH-219 Task 1)', () => {
     it('getStatePath with taskNum always returns per-task path, never root', () => {
       // Init at root, then verify --task read does NOT find root state
@@ -549,7 +573,14 @@ describe('tdd-phase-state CLI', () => {
       const rootPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-NOFALL', 'tdd-phase.json');
       assert.ok(fs.existsSync(rootPath), 'Root state should exist');
 
-      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-NOFALL', 'task1', 'tdd-phase.json');
+      const perTaskPath = path.join(
+        homeDir,
+        'worktrees',
+        'tasks',
+        'TEST-NOFALL',
+        'task1',
+        'tdd-phase.json'
+      );
       assert.ok(!fs.existsSync(perTaskPath), 'Per-task state should NOT exist yet');
 
       // Reading with --task 1 should fail (no per-task state), NOT fall back to root
@@ -563,7 +594,14 @@ describe('tdd-phase-state CLI', () => {
       // Init per-task state
       runCli('init TEST-RG1 --task 2', homeDir);
       // Set up state for green phase
-      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-RG1', 'task2', 'tdd-phase.json');
+      const perTaskPath = path.join(
+        homeDir,
+        'worktrees',
+        'tasks',
+        'TEST-RG1',
+        'task2',
+        'tdd-phase.json'
+      );
       const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
       state.currentPhase = 'green';
       state.cycles = [
@@ -598,7 +636,14 @@ describe('tdd-phase-state CLI', () => {
 
     it('record-refactor with --task reads/writes per-task path', () => {
       runCli('init TEST-RR1 --task 4', homeDir);
-      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-RR1', 'task4', 'tdd-phase.json');
+      const perTaskPath = path.join(
+        homeDir,
+        'worktrees',
+        'tasks',
+        'TEST-RR1',
+        'task4',
+        'tdd-phase.json'
+      );
       const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
       state.currentPhase = 'refactor';
       state.cycles = [
@@ -647,10 +692,7 @@ describe('tdd-phase-state CLI', () => {
       fs.writeFileSync(rootPath, JSON.stringify(state, null, 2));
 
       const passScript = createExitScript(scriptDir, 0);
-      const { stdout, exitCode } = runCli(
-        `record-green TEST-RG2 --cmd "${passScript}"`,
-        homeDir
-      );
+      const { stdout, exitCode } = runCli(`record-green TEST-RG2 --cmd "${passScript}"`, homeDir);
       assert.strictEqual(exitCode, 0);
       const updatedState = JSON.parse(fs.readFileSync(rootPath, 'utf8'));
       assert.strictEqual(updatedState.cycles[0].green.testExitCode, 0);
@@ -660,7 +702,14 @@ describe('tdd-phase-state CLI', () => {
   describe('transition with --task (GH-219 Task 1)', () => {
     it('transition with --task reads/writes per-task path', () => {
       runCli('init TEST-TR1 --task 3', homeDir);
-      const perTaskPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-TR1', 'task3', 'tdd-phase.json');
+      const perTaskPath = path.join(
+        homeDir,
+        'worktrees',
+        'tasks',
+        'TEST-TR1',
+        'task3',
+        'tdd-phase.json'
+      );
       const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
       state.cycles = [
         {
@@ -778,7 +827,12 @@ describe('tdd-phase-state CLI', () => {
 
       // Verify structured format in state file
       const perTaskPath = path.join(
-        homeDir, 'worktrees', 'tasks', 'TEST-CAT1', 'task2', 'tdd-phase.json'
+        homeDir,
+        'worktrees',
+        'tasks',
+        'TEST-CAT1',
+        'task2',
+        'tdd-phase.json'
       );
       const state = JSON.parse(fs.readFileSync(perTaskPath, 'utf8'));
       assert.strictEqual(state.currentPhase, 'exception');
@@ -806,10 +860,7 @@ describe('tdd-phase-state CLI', () => {
         homeDir
       );
       assert.strictEqual(exitCode, 1);
-      assert.ok(
-        stderr.includes('--category'),
-        `Expected missing category error, got: ${stderr}`
-      );
+      assert.ok(stderr.includes('--category'), `Expected missing category error, got: ${stderr}`);
     });
 
     it('new exported code with --category config-only exits 1 (heuristic blocks)', () => {
@@ -910,7 +961,11 @@ describe('tdd-phase-state CLI', () => {
           homeDir,
           nonGitDir
         );
-        assert.strictEqual(exitCode, 1, `Expected exit 1 when git repo detection fails, got ${exitCode}`);
+        assert.strictEqual(
+          exitCode,
+          1,
+          `Expected exit 1 when git repo detection fails, got ${exitCode}`
+        );
         assert.ok(
           stderr.includes('git') || stderr.includes('repository'),
           `Expected git/repository error message, got: ${stderr}`
@@ -928,19 +983,23 @@ describe('tdd-phase-state CLI', () => {
       assert.strictEqual(exitCode, 1);
 
       // Check audit file for audit record
-      const actionsPath = path.join(homeDir, 'worktrees', 'tasks', 'TEST-AUD1', '.work-actions.json');
+      const actionsPath = path.join(
+        homeDir,
+        'worktrees',
+        'tasks',
+        'TEST-AUD1',
+        '.work-actions.json'
+      );
       assert.ok(fs.existsSync(actionsPath), `Expected audit file at ${actionsPath}`);
       const actions = JSON.parse(fs.readFileSync(actionsPath, 'utf8'));
-      const auditRecord = actions.find(
-        (a) => a.action === 'tdd-exception' && a.allow === false
-      );
+      const auditRecord = actions.find((a) => a.action === 'tdd-exception' && a.allow === false);
       assert.ok(auditRecord, 'Expected audit record with allow: false');
       assert.strictEqual(auditRecord.allow, false);
       assert.ok(auditRecord.reason.includes('bogus'), 'Expected reason to contain category');
     });
   });
 
-    describe('multi-task TDD accumulation (GH-219 Task 5)', () => {
+  describe('multi-task TDD accumulation (GH-219 Task 5)', () => {
     it('5.1: accumulates independent per-task state across full TDD lifecycle', () => {
       const ticketId = 'TEST-MT1';
       const tasksBase = path.join(homeDir, 'worktrees', 'tasks');
@@ -967,7 +1026,11 @@ describe('tdd-phase-state CLI', () => {
         homeDir,
         gitRepo
       );
-      assert.strictEqual(redResult.exitCode, 0, `record-red should succeed, got: ${redResult.stderr || ''}`);
+      assert.strictEqual(
+        redResult.exitCode,
+        0,
+        `record-red should succeed, got: ${redResult.stderr || ''}`
+      );
 
       // 4. Transition task 1 to green
       const transResult = runCli(`transition ${ticketId} green --task 1`, homeDir);
@@ -978,7 +1041,11 @@ describe('tdd-phase-state CLI', () => {
         `record-green ${ticketId} --task 1 --cmd "${passScript}"`,
         homeDir
       );
-      assert.strictEqual(greenResult.exitCode, 0, `record-green should succeed, got: ${greenResult.stderr || ''}`);
+      assert.strictEqual(
+        greenResult.exitCode,
+        0,
+        `record-green should succeed, got: ${greenResult.stderr || ''}`
+      );
 
       // 6. Verify task1/tdd-phase.json has non-empty cycles with red AND green evidence
       const task1Final = JSON.parse(fs.readFileSync(task1Path, 'utf8'));
@@ -1012,7 +1079,11 @@ describe('tdd-phase-state CLI', () => {
         homeDir,
         gitRepo2
       );
-      assert.strictEqual(redResult2.exitCode, 0, `record-red task 2 should succeed, got: ${redResult2.stderr || ''}`);
+      assert.strictEqual(
+        redResult2.exitCode,
+        0,
+        `record-red task 2 should succeed, got: ${redResult2.stderr || ''}`
+      );
 
       // 10. Verify both state files exist independently
       const task2Path = path.join(tasksBase, ticketId, 'task2', 'tdd-phase.json');
@@ -1086,5 +1157,4 @@ describe('tdd-phase-state CLI', () => {
       assert.ok(fs.existsSync(task2Path), 'task2/tdd-phase.json should exist');
     });
   });
-
 });

--- a/workflows/work-implement/__tests__/work-implement-enforce.test.js
+++ b/workflows/work-implement/__tests__/work-implement-enforce.test.js
@@ -66,10 +66,7 @@ function createWorkState(ticketDir, overrides = {}) {
 
 function createTddPhaseState(ticketDir, phase) {
   const statePath = path.join(ticketDir, 'tdd-phase.json');
-  fs.writeFileSync(
-    statePath,
-    JSON.stringify({ currentPhase: phase, currentCycle: 1, cycles: [] })
-  );
+  fs.writeFileSync(statePath, JSON.stringify({ currentPhase: phase, currentCycle: 1, cycles: [] }));
   return statePath;
 }
 
@@ -77,10 +74,7 @@ function createPerTaskTddPhaseState(ticketDir, taskNum, phase) {
   const taskDir = path.join(ticketDir, 'task' + taskNum);
   fs.mkdirSync(taskDir, { recursive: true });
   const statePath = path.join(taskDir, 'tdd-phase.json');
-  fs.writeFileSync(
-    statePath,
-    JSON.stringify({ currentPhase: phase, currentCycle: 1, cycles: [] })
-  );
+  fs.writeFileSync(statePath, JSON.stringify({ currentPhase: phase, currentCycle: 1, cycles: [] }));
   return statePath;
 }
 
@@ -104,10 +98,19 @@ function makeTranscript(content = '') {
     os.tmpdir(),
     'test-wie-' + Date.now() + '-' + Math.random().toString(36).slice(2) + '.jsonl'
   );
-  fs.writeFileSync(tp, content); _transcriptPaths.push(tp);
+  fs.writeFileSync(tp, content);
+  _transcriptPaths.push(tp);
   return tp;
 }
-afterEach(() => { while (_transcriptPaths.length) { try { fs.unlinkSync(_transcriptPaths.pop()); } catch { /* already cleaned */ } } });
+afterEach(() => {
+  while (_transcriptPaths.length) {
+    try {
+      fs.unlinkSync(_transcriptPaths.pop());
+    } catch {
+      /* already cleaned */
+    }
+  }
+});
 describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
   it('should APPROVE non-blocked tools (Read, Bash)', async () => {
     const { result } = await runHook({ tool_name: 'Read', tool_input: {} });
@@ -155,7 +158,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
     const env = createTestEnv('TEST-MD');
     const tp = makeTranscript();
     const { result } = await runHookWithEnv(
-      { tool_name: 'Write', tool_input: { file_path: '/home/node/project/README.md' }, transcript_path: tp },
+      {
+        tool_name: 'Write',
+        tool_input: { file_path: '/home/node/project/README.md' },
+        transcript_path: tp,
+      },
       env.env
     );
     env.cleanup();
@@ -166,7 +173,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
     const env = createTestEnv('TEST-CLAUDE');
     const tp = makeTranscript();
     const { result } = await runHookWithEnv(
-      { tool_name: 'Write', tool_input: { file_path: '/tmp/project/.claude/hooks/test.js' }, transcript_path: tp },
+      {
+        tool_name: 'Write',
+        tool_input: { file_path: '/tmp/project/.claude/hooks/test.js' },
+        transcript_path: tp,
+      },
       env.env
     );
     env.cleanup();
@@ -177,7 +188,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
     const env = createTestEnv('TEST-NOAGENT');
     const tp = makeTranscript('');
     const { result } = await runHookWithEnv(
-      { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+      {
+        tool_name: 'Edit',
+        tool_input: { file_path: '/home/node/project/src/app.ts' },
+        transcript_path: tp,
+      },
       env.env
     );
     env.cleanup();
@@ -190,7 +205,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
     createTddPhaseState(env.ticketDir, 'green');
     const tp = makeTranscript('"subagent_type": "developer-nodejs-tdd"\n');
     const { result } = await runHookWithEnv(
-      { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+      {
+        tool_name: 'Edit',
+        tool_input: { file_path: '/home/node/project/src/app.ts' },
+        transcript_path: tp,
+      },
       env.env
     );
     env.cleanup();
@@ -202,7 +221,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
     createTddPhaseState(env.ticketDir, 'green');
     const tp = makeTranscript('"subagent_type": "work-workflow:developer-nodejs-tdd"\n');
     const { result } = await runHookWithEnv(
-      { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+      {
+        tool_name: 'Edit',
+        tool_input: { file_path: '/home/node/project/src/app.ts' },
+        transcript_path: tp,
+      },
       env.env
     );
     env.cleanup();
@@ -214,7 +237,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
     createTddPhaseState(env.ticketDir, 'green');
     const tp = makeTranscript('"subagent_type": "code-architect"\n');
     const { result } = await runHookWithEnv(
-      { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+      {
+        tool_name: 'Edit',
+        tool_input: { file_path: '/home/node/project/src/app.ts' },
+        transcript_path: tp,
+      },
       { ...env.env, WORK_ARCHITECT_ENABLED: '1' }
     );
     env.cleanup();
@@ -226,7 +253,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
     createTddPhaseState(env.ticketDir, 'green');
     const tp = makeTranscript('"subagent_type": "work-workflow:code-architect"\n');
     const { result } = await runHookWithEnv(
-      { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+      {
+        tool_name: 'Edit',
+        tool_input: { file_path: '/home/node/project/src/app.ts' },
+        transcript_path: tp,
+      },
       { ...env.env, WORK_ARCHITECT_ENABLED: '1' }
     );
     env.cleanup();
@@ -237,12 +268,19 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
     const env = createTestEnv('TEST-CA-BLOCK');
     const tp = makeTranscript('');
     const { result } = await runHookWithEnv(
-      { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+      {
+        tool_name: 'Edit',
+        tool_input: { file_path: '/home/node/project/src/app.ts' },
+        transcript_path: tp,
+      },
       { ...env.env, WORK_ARCHITECT_ENABLED: '1' }
     );
     env.cleanup();
     assert.strictEqual(result.decision, 'block');
-    assert.ok(result.reason.includes('code-architect'), 'error message should mention code-architect');
+    assert.ok(
+      result.reason.includes('code-architect'),
+      'error message should mention code-architect'
+    );
   });
 
   describe('WORK_ARCHITECT_ENABLED gate', () => {
@@ -250,7 +288,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       const env = createTestEnv('TEST-CA-GATE1');
       const tp = makeTranscript('"subagent_type": "code-architect"\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Edit',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         { ...env.env, WORK_ARCHITECT_ENABLED: '' }
       );
       env.cleanup();
@@ -262,7 +304,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       createTddPhaseState(env.ticketDir, 'green');
       const tp = makeTranscript('"subagent_type": "code-architect"\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Edit',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         { ...env.env, WORK_ARCHITECT_ENABLED: '1' }
       );
       env.cleanup();
@@ -273,24 +319,38 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       const env = createTestEnv('TEST-CA-GATE3');
       const tp = makeTranscript('');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Edit',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         { ...env.env, WORK_ARCHITECT_ENABLED: '' }
       );
       env.cleanup();
       assert.strictEqual(result.decision, 'block');
-      assert.ok(!result.reason.includes('code-architect'), 'should NOT mention code-architect when disabled');
+      assert.ok(
+        !result.reason.includes('code-architect'),
+        'should NOT mention code-architect when disabled'
+      );
     });
 
     it('should include code-architect in error message when WORK_ARCHITECT_ENABLED=1', async () => {
       const env = createTestEnv('TEST-CA-GATE4');
       const tp = makeTranscript('');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Edit',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         { ...env.env, WORK_ARCHITECT_ENABLED: '1' }
       );
       env.cleanup();
       assert.strictEqual(result.decision, 'block');
-      assert.ok(result.reason.includes('code-architect'), 'should mention code-architect when enabled');
+      assert.ok(
+        result.reason.includes('code-architect'),
+        'should mention code-architect when enabled'
+      );
     });
   });
 
@@ -298,7 +358,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
     const env = createTestEnv('TEST-TDD-PROTECT');
     const tp = makeTranscript();
     const { result } = await runHookWithEnv(
-      { tool_name: 'Write', tool_input: { file_path: '/home/node/project/tasks/TEST-123/tdd-phase.json' }, transcript_path: tp },
+      {
+        tool_name: 'Write',
+        tool_input: { file_path: '/home/node/project/tasks/TEST-123/tdd-phase.json' },
+        transcript_path: tp,
+      },
       env.env
     );
     env.cleanup();
@@ -322,7 +386,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       createTddPhaseState(env.ticketDir, 'red');
       const tp = makeTranscript('"subagent_type": "developer-nodejs-tdd"\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Write', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         env.env
       );
       env.cleanup();
@@ -335,7 +403,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       createTddPhaseState(env.ticketDir, 'red');
       const tp = makeTranscript('"subagent_type": "developer-nodejs-tdd"\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Write', tool_input: { file_path: '/home/node/project/src/app.test.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: '/home/node/project/src/app.test.ts' },
+          transcript_path: tp,
+        },
         env.env
       );
       env.cleanup();
@@ -347,7 +419,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       createTddPhaseState(env.ticketDir, 'green');
       const tp = makeTranscript('"subagent_type": "developer-nodejs-tdd"\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Write', tool_input: { file_path: '/home/node/project/src/app.test.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: '/home/node/project/src/app.test.ts' },
+          transcript_path: tp,
+        },
         env.env
       );
       env.cleanup();
@@ -360,7 +436,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       createTddPhaseState(env.ticketDir, 'green');
       const tp = makeTranscript('"subagent_type": "developer-nodejs-tdd"\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Write', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         env.env
       );
       env.cleanup();
@@ -372,7 +452,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       createTddPhaseState(env.ticketDir, 'green');
       const tp = makeTranscript('"subagent_type": "developer-nodejs-tdd"\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Write', tool_input: { file_path: '/home/node/project/__mocks__/foo.js' }, transcript_path: tp },
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: '/home/node/project/__mocks__/foo.js' },
+          transcript_path: tp,
+        },
         env.env
       );
       env.cleanup();
@@ -383,7 +467,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       const env = createTestEnv('TDD-NOINIT');
       const tp = makeTranscript('"subagent_type": "developer-nodejs-tdd"\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Write', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         env.env
       );
       env.cleanup();
@@ -395,7 +483,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       const env = createTestEnv('TDD-NOFILE-MD');
       const tp = makeTranscript('"subagent_type": "developer-nodejs-tdd"\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Write', tool_input: { file_path: '/home/node/project/README.md' }, transcript_path: tp },
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: '/home/node/project/README.md' },
+          transcript_path: tp,
+        },
         env.env
       );
       env.cleanup();
@@ -406,7 +498,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       const env = createTestEnv('TDD-NOFILE-NOAGENT');
       const tp = makeTranscript('');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Write', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         env.env
       );
       env.cleanup();
@@ -419,7 +515,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       createPerTaskTddPhaseState(env.ticketDir, 14, 'red');
       const tp = makeTranscript('"subagent_type": "developer-nodejs-tdd"\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Write', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         { ...env.env, WORK_TASK_NUM: '14' }
       );
       env.cleanup();
@@ -447,7 +547,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
       const env = createTestEnv('TEST-AUDIT');
       const tp = makeTranscript('');
       await runHookWithEnv(
-        { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Edit',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         env.env
       );
       const actionsFile = '.work-actions' + '.json';
@@ -466,7 +570,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
     it('should NOT activate based on transcript content alone (no state)', async () => {
       const tp = makeTranscript('# Implement Command\n');
       const { result } = await runHookWithEnv(
-        { tool_name: 'Edit', tool_input: { file_path: '/home/node/project/src/app.ts' }, transcript_path: tp },
+        {
+          tool_name: 'Edit',
+          tool_input: { file_path: '/home/node/project/src/app.ts' },
+          transcript_path: tp,
+        },
         { TICKET_ID: '' }
       );
       assert.strictEqual(result.decision, 'approve', 'Should not activate from transcript alone');
@@ -486,7 +594,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
         { ...env.env, WORK_TASK_NUM: '5', WORK_PR_SLOT: '1' }
       );
       env.cleanup();
-      assert.strictEqual(result.decision, 'approve', 'Writes to PR{N}/ should be allowed in task-aware mode');
+      assert.strictEqual(
+        result.decision,
+        'approve',
+        'Writes to PR{N}/ should be allowed in task-aware mode'
+      );
     });
 
     it('should APPROVE writes to task{N}/ dir when task-aware mode active', async () => {
@@ -513,7 +625,11 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
         { ...env.env, WORK_TASK_NUM: '5' }
       );
       env.cleanup();
-      assert.strictEqual(result.decision, 'approve', 'Writes to shared whitelist files should be allowed');
+      assert.strictEqual(
+        result.decision,
+        'approve',
+        'Writes to shared whitelist files should be allowed'
+      );
     });
 
     it('should BLOCK writes outside allow list when task-aware and developer agent present', async () => {
@@ -526,9 +642,14 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
         { ...env.env, WORK_TASK_NUM: '5', WORK_PR_SLOT: '1' }
       );
       env.cleanup();
-      assert.strictEqual(result.decision, 'block', 'Writes outside allow list should be blocked in task-aware mode');
+      assert.strictEqual(
+        result.decision,
+        'block',
+        'Writes outside allow list should be blocked in task-aware mode'
+      );
       assert.ok(
-        result.reason.includes('outside the allowed path set') || result.reason.includes('PATH_NOT_ALLOWED'),
+        result.reason.includes('outside the allowed path set') ||
+          result.reason.includes('PATH_NOT_ALLOWED'),
         'Should mention path not allowed'
       );
     });
@@ -543,17 +664,26 @@ describe('work-implement-enforce hook (GH-219 Task 14 — state-based)', () => {
         env.env
       );
       env.cleanup();
-      assert.strictEqual(result.decision, 'approve', 'Legacy mode (no WORK_TASK_NUM) should not apply path gate');
+      assert.strictEqual(
+        result.decision,
+        'approve',
+        'Legacy mode (no WORK_TASK_NUM) should not apply path gate'
+      );
     });
 
     it('should use isWriteAllowedPath from preflight (not duplicate)', async () => {
       const { isWriteAllowedPath } = require(path.join(__dirname, '..', '..', 'lib', 'preflight'));
-      assert.strictEqual(typeof isWriteAllowedPath, 'function', 'isWriteAllowedPath should be exported from preflight');
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wp-test-'));
-      const result = isWriteAllowedPath(
-        path.join(tempDir, 'PR1', 'src', 'file.ts'),
-        { prDir: path.join(tempDir, 'PR1'), taskDir: null, ticketRoot: tempDir }
+      assert.strictEqual(
+        typeof isWriteAllowedPath,
+        'function',
+        'isWriteAllowedPath should be exported from preflight'
       );
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wp-test-'));
+      const result = isWriteAllowedPath(path.join(tempDir, 'PR1', 'src', 'file.ts'), {
+        prDir: path.join(tempDir, 'PR1'),
+        taskDir: null,
+        ticketRoot: tempDir,
+      });
       assert.strictEqual(result, true, 'isWriteAllowedPath should allow PR dir files');
       fs.rmSync(tempDir, { recursive: true, force: true });
     });

--- a/workflows/work-implement/hooks/work-implement-enforce.js
+++ b/workflows/work-implement/hooks/work-implement-enforce.js
@@ -129,7 +129,10 @@ function resolveTaskBase() {
     taskBase = process.env.TASKS_BASE || null;
   }
   if (!taskBase) {
-    taskBase = (process.env.HOME || process.env.USERPROFILE) ? path.join(process.env.HOME || process.env.USERPROFILE, 'worktrees', 'tasks') : null;
+    taskBase =
+      process.env.HOME || process.env.USERPROFILE
+        ? path.join(process.env.HOME || process.env.USERPROFILE, 'worktrees', 'tasks')
+        : null;
   }
   return taskBase;
 }
@@ -161,9 +164,7 @@ function resolveSafeTicketId(ticketId) {
  * @returns {string|null} Path to tdd-phase.json, or null if not found
  */
 function resolveTddStatePath(taskBase, safeTicketId) {
-  const taskNum = process.env.WORK_TASK_NUM
-    ? parseInt(process.env.WORK_TASK_NUM, 10)
-    : null;
+  const taskNum = process.env.WORK_TASK_NUM ? parseInt(process.env.WORK_TASK_NUM, 10) : null;
 
   if (taskNum && Number.isInteger(taskNum) && taskNum > 0) {
     // Try per-task path first
@@ -230,12 +231,12 @@ function checkTddPhase(filePath, ticketId) {
  * @returns {{ prDir: string|null, taskDir: string|null, ticketRoot: string }|null}
  */
 function buildAllowedPaths(taskBase, safeTicketId) {
-  const taskNum = process.env.WORK_TASK_NUM
-    ? parseInt(process.env.WORK_TASK_NUM, 10)
-    : null;
+  const taskNum = process.env.WORK_TASK_NUM ? parseInt(process.env.WORK_TASK_NUM, 10) : null;
 
   // No task num = legacy mode; invalid taskNum = fail-closed
-  if (taskNum == null) return null; if (!Number.isInteger(taskNum) || taskNum < 1) return { prDir: null, taskDir: null, ticketRoot: null };
+  if (taskNum == null) return null;
+  if (!Number.isInteger(taskNum) || taskNum < 1)
+    return { prDir: null, taskDir: null, ticketRoot: null };
 
   const ticketRoot = path.join(taskBase, safeTicketId);
   let taskDir = null;
@@ -246,12 +247,9 @@ function buildAllowedPaths(taskBase, safeTicketId) {
   }
 
   // PR slot for worktree dir
-  const prSlot = process.env.WORK_PR_SLOT
-    ? parseInt(process.env.WORK_PR_SLOT, 10)
-    : null;
-  const prDir = prSlot && Number.isInteger(prSlot) && prSlot > 0
-    ? path.join(ticketRoot, 'PR' + prSlot)
-    : null;
+  const prSlot = process.env.WORK_PR_SLOT ? parseInt(process.env.WORK_PR_SLOT, 10) : null;
+  const prDir =
+    prSlot && Number.isInteger(prSlot) && prSlot > 0 ? path.join(ticketRoot, 'PR' + prSlot) : null;
 
   return { prDir, taskDir, ticketRoot };
 }
@@ -263,14 +261,17 @@ function buildAllowedPaths(taskBase, safeTicketId) {
 function createAuditCallback(ticketId, toolName, filePath, ctx) {
   return (entry) => {
     try {
-      const { appendEnforcementAudit } = require(path.join(__dirname, '..', '..', 'work', 'work-actions'));
+      const { appendEnforcementAudit } = require(
+        path.join(__dirname, '..', '..', 'work', 'work-actions')
+      );
       appendEnforcementAudit(ticketId, {
         origin: entry.origin || (ctx && ctx.origin) || 'user',
         task: null,
         phase: null,
         action: `${toolName}:${filePath || 'unknown'}`,
         allow: entry.decision === 'allow',
-        reason: (entry.reasons || []).join('; ') || (entry.decision === 'allow' ? 'allowed' : 'denied'),
+        reason:
+          (entry.reasons || []).join('; ') || (entry.decision === 'allow' ? 'allowed' : 'denied'),
         outputPath: filePath || null,
       });
     } catch {
@@ -298,26 +299,27 @@ async function main() {
   // ── State-based activation (R1): load enforcement context ──────────────
   // If TICKET_ID is explicitly set (even to empty), honor it; otherwise derive
   const ticketId =
-    ('TICKET_ID' in process.env) ? (process.env.TICKET_ID || null) :
-    (() => {
-      try {
-        const { getCurrentTaskId } = require(
-          path.join(__dirname, '..', '..', 'lib', 'scripts', 'get-ticket-id.js')
-        );
-        const id = getCurrentTaskId();
-        return id || null;
-      } catch {
-        try {
-          const branch = require('child_process')
-            .execSync('git branch --show-current', { encoding: 'utf8' })
-            .trim();
-          const match = branch.match(/[A-Za-z]+-[0-9]+/i);
-          return match ? match[0] : null;
-        } catch {
-          return null;
-        }
-      }
-    })();
+    'TICKET_ID' in process.env
+      ? process.env.TICKET_ID || null
+      : (() => {
+          try {
+            const { getCurrentTaskId } = require(
+              path.join(__dirname, '..', '..', 'lib', 'scripts', 'get-ticket-id.js')
+            );
+            const id = getCurrentTaskId();
+            return id || null;
+          } catch {
+            try {
+              const branch = require('child_process')
+                .execSync('git branch --show-current', { encoding: 'utf8' })
+                .trim();
+              const match = branch.match(/[A-Za-z]+-[0-9]+/i);
+              return match ? match[0] : null;
+            } catch {
+              return null;
+            }
+          }
+        })();
 
   // No ticket ID => no workflow to enforce
   if (!ticketId) {
@@ -395,9 +397,11 @@ async function main() {
     const allowedPaths = buildAllowedPaths(resolveTaskBase(), resolveSafeTicketId(ticketId));
     if (allowedPaths && filePath && !isWriteAllowedPath(filePath, allowedPaths)) {
       process.stderr.write(
-        'Write to "' + filePath + '" is outside the allowed path set.\n' +
-        'Allowed: PR{N}/, task{N}/, shared whitelist at ticket root.\n' +
-        'Verify the file path falls under the claimed worker or task directory.\n'
+        'Write to "' +
+          filePath +
+          '" is outside the allowed path set.\n' +
+          'Allowed: PR{N}/, task{N}/, shared whitelist at ticket root.\n' +
+          'Verify the file path falls under the claimed worker or task directory.\n'
       );
       const auditCb = createAuditCallback(ticketId, toolName, filePath, ctx);
       auditCb({ decision: 'deny', reasons: ['PATH_NOT_ALLOWED'], origin: ctx.origin });

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -37,7 +37,8 @@ const { normalizeAgentName } = require('../lib/agent-detection');
 let config;
 try {
   config = require('../lib/config');
-} catch (e) { if (e && e.code !== "MODULE_NOT_FOUND") throw e;
+} catch (e) {
+  if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
   config = null;
 }
 
@@ -50,7 +51,13 @@ const ALLOWED_AGENTS = [
 ];
 
 // Subcommands that require token verification
-const GATED_SUBCOMMANDS = ['record-red', 'record-green', 'record-refactor', 'transition', 'exception'];
+const GATED_SUBCOMMANDS = [
+  'record-red',
+  'record-green',
+  'record-refactor',
+  'transition',
+  'exception',
+];
 
 const TOKEN_MAX_AGE_MS = 10_000; // 10 seconds
 
@@ -59,7 +66,8 @@ const TOKEN_MAX_AGE_MS = 10_000; // 10 seconds
 function sanitizeId(ticketId) {
   try {
     return require('../lib/config').safeTicketId(ticketId);
-  } catch (e) { if (e && e.code !== "MODULE_NOT_FOUND") throw e;
+  } catch (e) {
+    if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
     return ticketId;
   }
 }
@@ -87,7 +95,8 @@ function perTaskStatePath(base, safeId, taskNum) {
   let taskSegmentFn;
   try {
     taskSegmentFn = require('../lib/allocate-output-folder').taskSegment;
-  } catch (e) { if (e && e.code !== "MODULE_NOT_FOUND") throw e;
+  } catch (e) {
+    if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
     // fallback if allocator not available — inline the task${N} pattern
     taskSegmentFn = (n) => `task${n}`;
   }
@@ -191,13 +200,18 @@ function parseTask(args) {
     return undefined;
   }
   const val = parseInt(args[taskIdx + 1], 10);
-  if (!Number.isInteger(val) || val < 1) throw new Error("Invalid --task value: " + args[taskIdx + 1]); return val;
+  if (!Number.isInteger(val) || val < 1)
+    throw new Error('Invalid --task value: ' + args[taskIdx + 1]);
+  return val;
 }
 
 function safeParseTask(args) {
-  try { return parseTask(args); } catch (e) { errorExit(e.message); }
+  try {
+    return parseTask(args);
+  } catch (e) {
+    errorExit(e.message);
+  }
 }
-
 
 function parseCategory(args) {
   const idx = args.indexOf('--category');
@@ -478,7 +492,9 @@ function auditException(ticketId, taskNum, category, reason, allow) {
       outputPath: null,
       meta: { category },
     });
-  } catch { /* fail-open */ }
+  } catch {
+    /* fail-open */
+  }
 }
 
 function cmdException(ticketId, args) {
@@ -489,7 +505,9 @@ function cmdException(ticketId, args) {
   const taskNum = safeParseTask(args);
   if (!category) {
     auditException(ticketId, taskNum, null, null, false);
-    errorExit('Missing --category argument. Usage: node tdd-phase-state.js exception <TICKET_ID> --category <category> --reason "<reason>"');
+    errorExit(
+      'Missing --category argument. Usage: node tdd-phase-state.js exception <TICKET_ID> --category <category> --reason "<reason>"'
+    );
   }
 
   // Validate category
@@ -504,14 +522,20 @@ function cmdException(ticketId, args) {
   if (category === 'checkpoint') {
     if (!taskNum) {
       auditException(ticketId, null, category, null, false);
-      errorExit('Category "checkpoint" requires --task <N> to identify which task is a checkpoint.');
+      errorExit(
+        'Category "checkpoint" requires --task <N> to identify which task is a checkpoint.'
+      );
     }
     const { isCheckpointTask } = require('./exception-validator');
     const resolvedTasksBase = resolveTasksBase();
     const safeId = sanitizeId(ticketId);
     if (!isCheckpointTask(safeId, taskNum, resolvedTasksBase)) {
       auditException(ticketId, taskNum, category, null, false);
-      errorExit('Category "checkpoint" is only allowed for checkpoint tasks. Task ' + taskNum + ' is not a checkpoint task.');
+      errorExit(
+        'Category "checkpoint" is only allowed for checkpoint tasks. Task ' +
+          taskNum +
+          ' is not a checkpoint task.'
+      );
     }
   }
 
@@ -538,17 +562,27 @@ function cmdException(ticketId, args) {
       const diff = execSync('git diff --diff-filter=A --name-only', gitOpts).trim();
       const staged = execSync('git diff --cached --diff-filter=A --name-only', gitOpts).trim();
       const untracked = execSync('git ls-files --others --exclude-standard', gitOpts).trim();
-      const relFiles = [...new Set([...diff.split('\n'), ...staged.split('\n'), ...untracked.split('\n')].filter(Boolean))];
-      allChanged = relFiles.map(f => path.resolve(repoRoot, f));
+      const relFiles = [
+        ...new Set(
+          [...diff.split('\n'), ...staged.split('\n'), ...untracked.split('\n')].filter(Boolean)
+        ),
+      ];
+      allChanged = relFiles.map((f) => path.resolve(repoRoot, f));
     } catch {
       auditException(ticketId, taskNum, category, reason, false);
-      errorExit('Unable to verify exception eligibility: git repository detection failed. Run this command from within the repository so new-export checks can be enforced.');
+      errorExit(
+        'Unable to verify exception eligibility: git repository detection failed. Run this command from within the repository so new-export checks can be enforced.'
+      );
     }
 
     const exportCheck = checkNewExportedCode(allChanged);
     if (exportCheck.hasNewExports) {
       auditException(ticketId, taskNum, category, reason, false);
-      errorExit('New exported code detected in: ' + exportCheck.files.join(', ') + '. TDD is required for new code with exports. Use the RED-GREEN-REFACTOR cycle instead of exception mode.');
+      errorExit(
+        'New exported code detected in: ' +
+          exportCheck.files.join(', ') +
+          '. TDD is required for new code with exports. Use the RED-GREEN-REFACTOR cycle instead of exception mode.'
+      );
     }
   }
 

--- a/workflows/work/__tests__/artifact-archival.test.js
+++ b/workflows/work/__tests__/artifact-archival.test.js
@@ -209,7 +209,7 @@ describe('archiveStepArtifacts', () => {
 
     // No taskN/ dirs should exist in run dir
     const runContents = fs.readdirSync(runDir);
-    const taskDirs = runContents.filter(d => /^task\d+$/.test(d));
+    const taskDirs = runContents.filter((d) => /^task\d+$/.test(d));
     assert.equal(taskDirs.length, 0);
   });
 });

--- a/workflows/work/__tests__/cli-summary-skip.test.js
+++ b/workflows/work/__tests__/cli-summary-skip.test.js
@@ -17,10 +17,7 @@ describe('CLI summary cleanup (GH-245 Task 7)', () => {
   describe('cli.js summary object', () => {
     it('should not include "skip" key in summary', () => {
       // Read cli.js source and check the summary object construction
-      const cliSource = fs.readFileSync(
-        path.join(__dirname, '..', 'cli.js'),
-        'utf-8'
-      );
+      const cliSource = fs.readFileSync(path.join(__dirname, '..', 'cli.js'), 'utf-8');
 
       // The summary object should not have a skip counter
       // Check for `skip:` in the summary construction block (lines ~169-179)
@@ -28,17 +25,11 @@ describe('CLI summary cleanup (GH-245 Task 7)', () => {
       assert.ok(summaryBlock, 'Should find summary assignment block');
 
       // Should not contain skip key
-      assert.ok(
-        !summaryBlock[0].includes("skip:"),
-        'Summary should not contain "skip:" counter'
-      );
+      assert.ok(!summaryBlock[0].includes('skip:'), 'Summary should not contain "skip:" counter');
     });
 
     it('should not include "stepsSkipped" key in summary', () => {
-      const cliSource = fs.readFileSync(
-        path.join(__dirname, '..', 'cli.js'),
-        'utf-8'
-      );
+      const cliSource = fs.readFileSync(path.join(__dirname, '..', 'cli.js'), 'utf-8');
 
       const summaryBlock = cliSource.match(/result\.summary\s*=\s*\{[\s\S]*?\};/);
       assert.ok(summaryBlock, 'Should find summary assignment block');
@@ -50,10 +41,7 @@ describe('CLI summary cleanup (GH-245 Task 7)', () => {
     });
 
     it('summary should still contain run, defer, and pending counters', () => {
-      const cliSource = fs.readFileSync(
-        path.join(__dirname, '..', 'cli.js'),
-        'utf-8'
-      );
+      const cliSource = fs.readFileSync(path.join(__dirname, '..', 'cli.js'), 'utf-8');
 
       const summaryBlock = cliSource.match(/result\.summary\s*=\s*\{[\s\S]*?\};/);
       assert.ok(summaryBlock, 'Should find summary assignment block');
@@ -66,10 +54,7 @@ describe('CLI summary cleanup (GH-245 Task 7)', () => {
 
   describe('comment references to SKIP', () => {
     it('workflow-definition.js should not reference "SKIP/RUN" in comments', () => {
-      const source = fs.readFileSync(
-        path.join(__dirname, '..', 'workflow-definition.js'),
-        'utf-8'
-      );
+      const source = fs.readFileSync(path.join(__dirname, '..', 'workflow-definition.js'), 'utf-8');
 
       // Line 193 originally has "SKIP/RUN" -- should be changed to "DEFER/RUN"
       assert.ok(
@@ -79,10 +64,7 @@ describe('CLI summary cleanup (GH-245 Task 7)', () => {
     });
 
     it('step-registry.js should not reference "SKIP/RUN/DEFER" in comments', () => {
-      const source = fs.readFileSync(
-        path.join(__dirname, '..', 'step-registry.js'),
-        'utf-8'
-      );
+      const source = fs.readFileSync(path.join(__dirname, '..', 'step-registry.js'), 'utf-8');
 
       // Line 94 originally has "SKIP/RUN/DEFER" -- should be changed to "RUN/DEFER"
       assert.ok(

--- a/workflows/work/__tests__/complete-deadlock.test.js
+++ b/workflows/work/__tests__/complete-deadlock.test.js
@@ -190,10 +190,7 @@ describe('GH-106: complete step deadlock fix', () => {
 
   describe('6. workflows/work/steps/complete.js: complete step prompt includes archival', () => {
     it('complete step agentPrompt mentions archiving artifacts', () => {
-      const src = fs.readFileSync(
-        path.join(__dirname, '..', 'steps', 'complete.js'),
-        'utf-8'
-      );
+      const src = fs.readFileSync(path.join(__dirname, '..', 'steps', 'complete.js'), 'utf-8');
       assert.match(
         src,
         /archive|archiv/i,

--- a/workflows/work/__tests__/follow-up-verify-gate.test.js
+++ b/workflows/work/__tests__/follow-up-verify-gate.test.js
@@ -31,12 +31,7 @@ describe('follow_up verify gate: acknowledged entries without userApproval', () 
     fs.mkdirSync(ticketDir, { recursive: true });
 
     // Stub isPRGateReady via module cache override
-    const followUpPrPath = path.resolve(
-      __dirname,
-      '..',
-      'scripts',
-      'follow-up-pr.js'
-    );
+    const followUpPrPath = path.resolve(__dirname, '..', 'scripts', 'follow-up-pr.js');
 
     // Cache a stub module for follow-up-pr.js
     const stubModule = new Module(followUpPrPath);
@@ -48,11 +43,7 @@ describe('follow_up verify gate: acknowledged entries without userApproval', () 
     require.cache[followUpPrPath] = stubModule;
 
     // Create the workflow definition with our temp TASKS_BASE
-    const createWorkflowDefinition = require(path.join(
-      __dirname,
-      '..',
-      'workflow-definition'
-    ));
+    const createWorkflowDefinition = require(path.join(__dirname, '..', 'workflow-definition'));
     const { STEPS } = require(path.join(__dirname, '..', 'step-registry'));
 
     const result = createWorkflowDefinition({
@@ -76,12 +67,7 @@ describe('follow_up verify gate: acknowledged entries without userApproval', () 
     fs.rmSync(tmpDir, { recursive: true, force: true });
 
     // Remove the stubbed module from cache
-    const followUpPrPath = path.resolve(
-      __dirname,
-      '..',
-      'scripts',
-      'follow-up-pr.js'
-    );
+    const followUpPrPath = path.resolve(__dirname, '..', 'scripts', 'follow-up-pr.js');
     delete require.cache[followUpPrPath];
   });
 
@@ -114,7 +100,11 @@ describe('follow_up verify gate: acknowledged entries without userApproval', () 
     fs.writeFileSync(accountabilityFile, JSON.stringify(entries));
 
     const result = followUpGate.verify(ticketId);
-    assert.equal(result, true, 'Gate should pass for acknowledged entries even with userApproval: false');
+    assert.equal(
+      result,
+      true,
+      'Gate should pass for acknowledged entries even with userApproval: false'
+    );
   });
 
   it('still returns true for acknowledged entries with userApproval: true', () => {

--- a/workflows/work/__tests__/implement-step.test.js
+++ b/workflows/work/__tests__/implement-step.test.js
@@ -32,7 +32,9 @@ function writeClaim(tasksDir, taskNum, ownerId) {
 }
 function cleanupClaims() {
   for (const dir of _claimCleanupDirs) {
-    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {}
   }
   _claimCleanupDirs = [];
 }
@@ -151,8 +153,10 @@ describe('implement step — dependency-aware messaging (GH-219 Task 16)', () =>
       assert.equal(entry.action, 'RUN');
       // Reason should mention the task id
       // Strict: must include exact task_1 id, not just "Task 1"
-      assert.ok(entry.reason.includes('task_1'),
-        `reason should mention task id "task_1", got: "${entry.reason}"`);
+      assert.ok(
+        entry.reason.includes('task_1'),
+        `reason should mention task id "task_1", got: "${entry.reason}"`
+      );
     });
 
     it('includes task id for non-first task', () => {
@@ -194,15 +198,14 @@ describe('implement step — dependency-aware messaging (GH-219 Task 16)', () =>
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'impl-test-'));
       _claimCleanupDirs.push(tmpDir);
       writeClaim(tmpDir, 1, 'PR1'); // claim via lock file, not tasksMeta.claimedBy
-      const taskData = makeTaskData([
-        { num: 1, title: 'First task' },
-      ]);
+      const taskData = makeTaskData([{ num: 1, title: 'First task' }]);
       const s = makeState({
         workState: {
           tasksMeta: {
             totalTasks: 1,
             currentTaskIndex: 0,
-            tasks: [ // no claimedBy — claim lives in lock file
+            tasks: [
+              // no claimedBy — claim lives in lock file
               { id: 'task_1', status: 'pending', dependencies: [] },
             ], // claim ownership read from .claims/task-1.lock, not here
           },
@@ -225,15 +228,14 @@ describe('implement step — dependency-aware messaging (GH-219 Task 16)', () =>
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'impl-test-'));
       _claimCleanupDirs.push(tmpDir);
       writeClaim(tmpDir, 1, 'PR2'); // claim via lock file, not tasksMeta.claimedBy
-      const taskData = makeTaskData([
-        { num: 1, title: 'First task' },
-      ]);
+      const taskData = makeTaskData([{ num: 1, title: 'First task' }]);
       const s = makeState({
         workState: {
           tasksMeta: {
             totalTasks: 1,
             currentTaskIndex: 0,
-            tasks: [ // no claimedBy — claim lives in lock file
+            tasks: [
+              // no claimedBy — claim lives in lock file
               { id: 'task_1', status: 'pending', dependencies: [] },
             ], // claim ownership read from .claims/task-1.lock, not here
           },
@@ -293,17 +295,13 @@ describe('implement step — dependency-aware messaging (GH-219 Task 16)', () =>
     });
 
     it('does not mention dependencies when task has none', () => {
-      const taskData = makeTaskData([
-        { num: 1, title: 'First task', dependencies: [] },
-      ]);
+      const taskData = makeTaskData([{ num: 1, title: 'First task', dependencies: [] }]);
       const s = makeState({
         workState: {
           tasksMeta: {
             totalTasks: 1,
             currentTaskIndex: 0,
-            tasks: [
-              { id: 'task_1', status: 'pending', dependencies: [] },
-            ],
+            tasks: [{ id: 'task_1', status: 'pending', dependencies: [] }],
           },
         },
       });
@@ -326,17 +324,13 @@ describe('implement step — dependency-aware messaging (GH-219 Task 16)', () =>
 
   describe('existing behaviors preserved', () => {
     it('DEFERs when all tasks are done', () => {
-      const taskData = makeTaskData([
-        { num: 1, title: 'Only task' },
-      ]);
+      const taskData = makeTaskData([{ num: 1, title: 'Only task' }]);
       const s = makeState({
         workState: {
           tasksMeta: {
             totalTasks: 1,
-            currentTaskIndex: 1,  // past the end
-            tasks: [
-              { id: 'task_1', status: 'completed', dependencies: [] },
-            ],
+            currentTaskIndex: 1, // past the end
+            tasks: [{ id: 'task_1', status: 'completed', dependencies: [] }],
           },
         },
       });
@@ -356,9 +350,7 @@ describe('implement step — dependency-aware messaging (GH-219 Task 16)', () =>
           tasksMeta: {
             totalTasks: 1,
             currentTaskIndex: 0,
-            tasks: [
-              { id: 'task_1', status: 'pending', dependencies: [] },
-            ],
+            tasks: [{ id: 'task_1', status: 'pending', dependencies: [] }],
           },
         },
       });
@@ -370,9 +362,7 @@ describe('implement step — dependency-aware messaging (GH-219 Task 16)', () =>
     });
 
     it('DEFERs when implement previously completed with diff', () => {
-      const taskData = makeTaskData([
-        { num: 1, title: 'Task one' },
-      ]);
+      const taskData = makeTaskData([{ num: 1, title: 'Task one' }]);
       const s = makeState({
         hasDiffVsMain: true,
         diffSummary: '3 files changed',
@@ -381,9 +371,7 @@ describe('implement step — dependency-aware messaging (GH-219 Task 16)', () =>
           tasksMeta: {
             totalTasks: 1,
             currentTaskIndex: 0,
-            tasks: [
-              { id: 'task_1', status: 'pending', dependencies: [] },
-            ],
+            tasks: [{ id: 'task_1', status: 'pending', dependencies: [] }],
           },
         },
       });
@@ -403,17 +391,13 @@ describe('implement step — dependency-aware messaging (GH-219 Task 16)', () =>
     });
 
     it('exports task metadata on ctx for task-advance step', () => {
-      const taskData = makeTaskData([
-        { num: 1, title: 'First task' },
-      ]);
+      const taskData = makeTaskData([{ num: 1, title: 'First task' }]);
       const s = makeState({
         workState: {
           tasksMeta: {
             totalTasks: 1,
             currentTaskIndex: 0,
-            tasks: [
-              { id: 'task_1', status: 'pending', dependencies: [] },
-            ],
+            tasks: [{ id: 'task_1', status: 'pending', dependencies: [] }],
           },
         },
       });

--- a/workflows/work/__tests__/plan-generator-brief-gate.test.js
+++ b/workflows/work/__tests__/plan-generator-brief-gate.test.js
@@ -133,15 +133,7 @@ describe('plan-generator brief_gate ordering (GH-215 Task 6.2)', () => {
     // That is fine for the ordering assertion — we only care that a
     // brief_gate entry appears between brief and spec.
     const state = makeState({ hasBrief: true });
-    const { plan } = generatePlan(
-      'TEST-100',
-      null,
-      state,
-      false,
-      null,
-      null,
-      makeDeps()
-    );
+    const { plan } = generatePlan('TEST-100', null, state, false, null, null, makeDeps());
 
     const briefIdx = stepIndex(plan, STEPS.brief);
     const gateIdx = stepIndex(plan, STEPS.brief_gate);
@@ -161,15 +153,7 @@ describe('plan-generator brief_gate ordering (GH-215 Task 6.2)', () => {
     const prev = process.env.WORK_BRIEF_ENABLED;
     process.env.WORK_BRIEF_ENABLED = '0';
     try {
-      const { plan } = generatePlan(
-        'TEST-100',
-        null,
-        makeState(),
-        false,
-        null,
-        null,
-        makeDeps()
-      );
+      const { plan } = generatePlan('TEST-100', null, makeState(), false, null, null, makeDeps());
 
       const briefIdx = stepIndex(plan, STEPS.brief);
       const gateIdx = stepIndex(plan, STEPS.brief_gate);

--- a/workflows/work/__tests__/plan-generator-no-toggles.test.js
+++ b/workflows/work/__tests__/plan-generator-no-toggles.test.js
@@ -86,10 +86,7 @@ function makeState(overrides = {}) {
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe('GH-253 Task 4: plan-generator.js toggle removal', () => {
-  const planGenSource = fs.readFileSync(
-    path.join(__dirname, '..', 'plan-generator.js'),
-    'utf8'
-  );
+  const planGenSource = fs.readFileSync(path.join(__dirname, '..', 'plan-generator.js'), 'utf8');
 
   it('does not reference WORK_BRIEF_ENABLED in source code', () => {
     assert.ok(
@@ -178,20 +175,36 @@ describe('GH-253 Task 4: plan never contains "disabled" reason', () => {
     assert.equal(briefEntry.action, 'RUN', 'brief should be RUN when artifact missing');
     assert.equal(specEntry.action, 'RUN', 'spec should be RUN when artifact missing');
     // tasks DEFERs when spec.md is absent (dependency not met) — that is correct behavior
-    assert.equal(tasksEntry.action, 'DEFER', 'tasks should DEFER when spec.md dependency is absent');
+    assert.equal(
+      tasksEntry.action,
+      'DEFER',
+      'tasks should DEFER when spec.md dependency is absent'
+    );
   });
 
   it('includes RUN for tasks when spec exists but tasks.md is missing', () => {
     const state = makeState({ hasBrief: true, hasSpec: true, hasTasks: false });
     // fileExists returns true for spec.md path so tasks step can RUN
     const specPath = '/tmp/tasks/TEST-100/spec.md';
-    const { plan } = generatePlan('TEST-100', null, state, false, null, null, makeDeps({
-      fileExists: (p) => p === specPath || p === '/tmp/tasks/TEST-100',
-    }));
+    const { plan } = generatePlan(
+      'TEST-100',
+      null,
+      state,
+      false,
+      null,
+      null,
+      makeDeps({
+        fileExists: (p) => p === specPath || p === '/tmp/tasks/TEST-100',
+      })
+    );
 
     const tasksEntry = plan.find((e) => e.step === STEPS.tasks);
     assert.ok(tasksEntry, 'plan must contain a tasks entry');
-    assert.equal(tasksEntry.action, 'RUN', 'tasks should be RUN when spec exists but tasks.md missing');
+    assert.equal(
+      tasksEntry.action,
+      'RUN',
+      'tasks should be RUN when spec exists but tasks.md missing'
+    );
   });
 });
 

--- a/workflows/work/__tests__/plan-validation.test.js
+++ b/workflows/work/__tests__/plan-validation.test.js
@@ -33,10 +33,7 @@ describe('validatePlan (GH-245 Task 8)', () => {
           err.message.includes('bootstrap'),
           'Error message should include the step name "bootstrap"'
         );
-        assert.ok(
-          err.message.includes('SKIP'),
-          'Error message should mention SKIP'
-        );
+        assert.ok(err.message.includes('SKIP'), 'Error message should mention SKIP');
         return true;
       },
       'validatePlan should throw for plan with SKIP action'
@@ -61,18 +58,13 @@ describe('validatePlan (GH-245 Task 8)', () => {
   it('should not throw for an empty plan', () => {
     const { validatePlan } = require('../plan-generator');
 
-    assert.doesNotThrow(
-      () => validatePlan([]),
-      'validatePlan should pass silently for empty plan'
-    );
+    assert.doesNotThrow(() => validatePlan([]), 'validatePlan should pass silently for empty plan');
   });
 
   it('should throw with descriptive error including step name for SKIP entries', () => {
     const { validatePlan } = require('../plan-generator');
 
-    const plan = [
-      { step: 'implement', action: 'SKIP', reason: 'skipped' },
-    ];
+    const plan = [{ step: 'implement', action: 'SKIP', reason: 'skipped' }];
 
     assert.throws(
       () => validatePlan(plan),

--- a/workflows/work/__tests__/step-registry.test.js
+++ b/workflows/work/__tests__/step-registry.test.js
@@ -13,7 +13,9 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('path');
 
-const { STEPS, ALL_STEPS, STEP_ORDER, STEP_TRANSITIONS } = require(path.join(__dirname, '..', 'step-registry'));
+const { STEPS, ALL_STEPS, STEP_ORDER, STEP_TRANSITIONS } = require(
+  path.join(__dirname, '..', 'step-registry')
+);
 
 describe('step-registry', () => {
   describe('STEPS constant map', () => {

--- a/workflows/work/__tests__/task-advance.test.js
+++ b/workflows/work/__tests__/task-advance.test.js
@@ -18,18 +18,11 @@ const { STEPS } = require(path.join(__dirname, '..', 'step-registry'));
 
 describe('task-advance: mutates task_review plan entry', () => {
   it('sets nextAction on task_review entry when more tasks remain', () => {
-    const plan = [
-      { step: STEPS.check },
-      { step: STEPS.task_review },
-    ];
+    const plan = [{ step: STEPS.check }, { step: STEPS.task_review }];
     const ctx = {
       STEPS,
       plan,
-      _taskData: [
-        { title: 'Task 1' },
-        { title: 'Task 2' },
-        { title: 'Task 3' },
-      ],
+      _taskData: [{ title: 'Task 1' }, { title: 'Task 2' }, { title: 'Task 3' }],
       _allTasksDone: false,
       _currentTaskIdx: 0,
     };
@@ -38,8 +31,11 @@ describe('task-advance: mutates task_review plan entry', () => {
 
     const taskReviewEntry = plan.find((p) => p.step === STEPS.task_review);
     assert.ok(taskReviewEntry, 'task_review entry should exist');
-    assert.equal(taskReviewEntry.nextAction, 'advance_task',
-      'task_review entry should have nextAction = advance_task');
+    assert.equal(
+      taskReviewEntry.nextAction,
+      'advance_task',
+      'task_review entry should have nextAction = advance_task'
+    );
     assert.ok(taskReviewEntry.taskInfo, 'task_review entry should have taskInfo');
     assert.equal(taskReviewEntry.taskInfo.current, 1);
     assert.equal(taskReviewEntry.taskInfo.total, 3);
@@ -47,10 +43,7 @@ describe('task-advance: mutates task_review plan entry', () => {
   });
 
   it('does NOT set nextAction on task_review when all tasks are done', () => {
-    const plan = [
-      { step: STEPS.check },
-      { step: STEPS.task_review },
-    ];
+    const plan = [{ step: STEPS.check }, { step: STEPS.task_review }];
     const ctx = {
       STEPS,
       plan,
@@ -63,15 +56,15 @@ describe('task-advance: mutates task_review plan entry', () => {
 
     const taskReviewEntry = plan.find((p) => p.step === STEPS.task_review);
     assert.ok(taskReviewEntry);
-    assert.equal(taskReviewEntry.nextAction, undefined,
-      'task_review should NOT have nextAction when on last task');
+    assert.equal(
+      taskReviewEntry.nextAction,
+      undefined,
+      'task_review should NOT have nextAction when on last task'
+    );
   });
 
   it('does NOT set nextAction on task_review when _allTasksDone is true', () => {
-    const plan = [
-      { step: STEPS.check },
-      { step: STEPS.task_review },
-    ];
+    const plan = [{ step: STEPS.check }, { step: STEPS.task_review }];
     const ctx = {
       STEPS,
       plan,
@@ -88,10 +81,7 @@ describe('task-advance: mutates task_review plan entry', () => {
   });
 
   it('still mutates check entry alongside task_review (backward compat)', () => {
-    const plan = [
-      { step: STEPS.check },
-      { step: STEPS.task_review },
-    ];
+    const plan = [{ step: STEPS.check }, { step: STEPS.task_review }];
     const ctx = {
       STEPS,
       plan,
@@ -103,8 +93,7 @@ describe('task-advance: mutates task_review plan entry', () => {
     taskAdvanceStep(() => {}, {}, ctx);
 
     const checkEntry = plan.find((p) => p.step === STEPS.check);
-    assert.equal(checkEntry.nextAction, 'advance_task',
-      'check entry should still be mutated');
+    assert.equal(checkEntry.nextAction, 'advance_task', 'check entry should still be mutated');
   });
 
   it('handles missing task_review entry gracefully', () => {

--- a/workflows/work/__tests__/task-review-gate.test.js
+++ b/workflows/work/__tests__/task-review-gate.test.js
@@ -59,8 +59,10 @@ describe('computeTaskDiff', () => {
     const result = computeTaskDiff(tasksDir, 'T-2');
     assert.strictEqual(result.head, 'HEAD');
     // base should be a branch reference (e.g., origin/main), not a 40-char SHA
-    assert.ok(result.base.includes('/') || result.base === 'origin/main',
-      `Expected base branch fallback, got: ${result.base}`);
+    assert.ok(
+      result.base.includes('/') || result.base === 'origin/main',
+      `Expected base branch fallback, got: ${result.base}`
+    );
     assert.ok(result.fallback === true, 'Should indicate fallback was used');
   });
 

--- a/workflows/work/__tests__/task-review-step.test.js
+++ b/workflows/work/__tests__/task-review-step.test.js
@@ -95,7 +95,9 @@ describe('task-review step', () => {
     ];
     const s = makeState({
       hasTasks: true,
-      workState: { tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task-1' }, { id: 'task-2' }] } },
+      workState: {
+        tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task-1' }, { id: 'task-2' }] },
+      },
     });
     const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
     taskReviewStep(add, s, ctx);
@@ -203,11 +205,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 0 },
-            { id: 'task-2' },
-            { id: 'task-3' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 0 }, { id: 'task-2' }, { id: 'task-3' }],
         },
       },
     });
@@ -234,10 +232,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 0 },
-            { id: 'task-2' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 0 }, { id: 'task-2' }],
         },
       },
     });
@@ -261,10 +256,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 2 },
-            { id: 'task-2' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 2 }, { id: 'task-2' }],
         },
       },
     });
@@ -290,10 +282,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 1 },
-            { id: 'task-2' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 1 }, { id: 'task-2' }],
         },
       },
     });
@@ -314,10 +303,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 1 },
-            { id: 'task-2' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 1 }, { id: 'task-2' }],
         },
       },
     });
@@ -352,7 +338,11 @@ describe('task-review step', () => {
 
     it('exports taskReviewStep as a named export', () => {
       const barrel = require(path.join(__dirname, '..', 'steps', 'index.js'));
-      assert.equal(typeof barrel.taskReviewStep, 'function', 'steps/index.js should export taskReviewStep');
+      assert.equal(
+        typeof barrel.taskReviewStep,
+        'function',
+        'steps/index.js should export taskReviewStep'
+      );
     });
   });
 });

--- a/workflows/work/__tests__/tdd-enforcement.test.js
+++ b/workflows/work/__tests__/tdd-enforcement.test.js
@@ -149,7 +149,11 @@ function prepareTicketEnv(ticket, envExtra = {}) {
     gitDir,
     opts: { env: baseEnv(envExtra), cwd: gitDir },
     safeTicket,
-    cleanup: () => { try { fs.rmSync(gitDir, { recursive: true, force: true }); } catch {} },
+    cleanup: () => {
+      try {
+        fs.rmSync(gitDir, { recursive: true, force: true });
+      } catch {}
+    },
   };
 }
 
@@ -579,7 +583,15 @@ describe('TDD enforcement', () => {
       const { opts, cleanup } = prepareTicketEnv(TICKET);
       try {
         // Walk to implement
-        const steps = ['bootstrap', 'brief', 'brief_gate', 'spec', 'spec_gate', 'tasks', 'implement'];
+        const steps = [
+          'bootstrap',
+          'brief',
+          'brief_gate',
+          'spec',
+          'spec_gate',
+          'tasks',
+          'implement',
+        ];
         for (const s of steps) {
           await runOrchestrator(['transition', TICKET, s], opts);
         }
@@ -611,7 +623,14 @@ describe('TDD enforcement', () => {
       const state = {
         currentPhase: 'red',
         currentCycle: 2,
-        cycles: [{ cycle: 1, red: { testFiles: ['a.test.ts'] }, green: { testCommand: 'test' }, refactor: { testCommand: 'test' } }],
+        cycles: [
+          {
+            cycle: 1,
+            red: { testFiles: ['a.test.ts'] },
+            green: { testCommand: 'test' },
+            refactor: { testCommand: 'test' },
+          },
+        ],
       };
       fs.writeFileSync(path.join(taskDir, 'tdd-phase.json'), JSON.stringify(state));
 
@@ -635,7 +654,11 @@ describe('TDD enforcement', () => {
       );
 
       const result = readTddEvidence(tempTasksBase, ticket, 'implement', 2);
-      assert.equal(result.exists, false, 'Must not fall back to ticket root when taskNum is provided');
+      assert.equal(
+        result.exists,
+        false,
+        'Must not fall back to ticket root when taskNum is provided'
+      );
 
       // Cleanup
       fs.rmSync(ticketDir, { recursive: true, force: true });
@@ -645,7 +668,10 @@ describe('TDD enforcement', () => {
       const ticket = 'TDDT2-102';
       const ticketDir = path.join(tempTasksBase, ticket);
       fs.mkdirSync(ticketDir, { recursive: true });
-      const state = { currentPhase: 'red', cycles: [{ cycle: 1, red: {}, green: {}, refactor: {} }] };
+      const state = {
+        currentPhase: 'red',
+        cycles: [{ cycle: 1, red: {}, green: {}, refactor: {} }],
+      };
       fs.writeFileSync(path.join(ticketDir, 'tdd-phase.json'), JSON.stringify(state));
 
       const result = readTddEvidence(tempTasksBase, ticket, 'implement');
@@ -712,19 +738,22 @@ describe('TDD enforcement', () => {
       delete require.cache[require.resolve('../../lib/config')];
       delete require.cache[require.resolve('../work-state')];
       // Also clear submodules that work-state requires (they cache parent fns)
-      try { delete require.cache[require.resolve('../work-state/task-readiness')]; } catch {}
-      try { delete require.cache[require.resolve('../work-state/parallel-workers')]; } catch {}
-      try { delete require.cache[require.resolve('../work-state/graph-validation')]; } catch {}
+      try {
+        delete require.cache[require.resolve('../work-state/task-readiness')];
+      } catch {}
+      try {
+        delete require.cache[require.resolve('../work-state/parallel-workers')];
+      } catch {}
+      try {
+        delete require.cache[require.resolve('../work-state/graph-validation')];
+      } catch {}
       const { autoInitTdd } = require('../work-state');
 
       // Call autoInitTdd with taskNum
       autoInitTdd(ticket, 2);
 
       // Assert file exists at per-task path
-      assert.ok(
-        fs.existsSync(expectedFile),
-        `Expected tdd-phase.json at ${expectedFile}`
-      );
+      assert.ok(fs.existsSync(expectedFile), `Expected tdd-phase.json at ${expectedFile}`);
 
       // Assert file contents
       const state = JSON.parse(fs.readFileSync(expectedFile, 'utf8'));
@@ -885,19 +914,31 @@ describe('TDD enforcement', () => {
     });
 
     it('structured exception with valid category config-only', () => {
-      const result = validateTddEvidence({ exception: { category: 'config-only', reason: 'tsconfig' }, cycles: [] });
+      const result = validateTddEvidence({
+        exception: { category: 'config-only', reason: 'tsconfig' },
+        cycles: [],
+      });
       assert.equal(result.valid, true);
     });
 
     it('structured exception with valid category file-move', () => {
-      const result = validateTddEvidence({ exception: { category: 'file-move', reason: 'renamed' }, cycles: [] });
+      const result = validateTddEvidence({
+        exception: { category: 'file-move', reason: 'renamed' },
+        cycles: [],
+      });
       assert.equal(result.valid, true);
     });
 
     it('structured exception with invalid category rejects', () => {
-      const result = validateTddEvidence({ exception: { category: 'whatever', reason: 'x' }, cycles: [] });
+      const result = validateTddEvidence({
+        exception: { category: 'whatever', reason: 'x' },
+        cycles: [],
+      });
       assert.equal(result.valid, false);
-      assert.ok(result.reason.includes('Invalid exception category'), `Expected reason to contain "Invalid exception category", got: ${result.reason}`);
+      assert.ok(
+        result.reason.includes('Invalid exception category'),
+        `Expected reason to contain "Invalid exception category", got: ${result.reason}`
+      );
     });
 
     it('structured exception with missing category rejects', () => {
@@ -913,13 +954,22 @@ describe('TDD enforcement', () => {
     it('structured exception with missing reason rejects', () => {
       const result = validateTddEvidence({ exception: { category: 'config-only' }, cycles: [] });
       assert.equal(result.valid, false);
-      assert.ok(result.reason.includes('Exception reason is required'), `Expected reason message, got: ${result.reason}`);
+      assert.ok(
+        result.reason.includes('Exception reason is required'),
+        `Expected reason message, got: ${result.reason}`
+      );
     });
 
     it('structured exception with empty reason rejects', () => {
-      const result = validateTddEvidence({ exception: { category: 'config-only', reason: '  ' }, cycles: [] });
+      const result = validateTddEvidence({
+        exception: { category: 'config-only', reason: '  ' },
+        cycles: [],
+      });
       assert.equal(result.valid, false);
-      assert.ok(result.reason.includes('Exception reason is required'), `Expected reason message, got: ${result.reason}`);
+      assert.ok(
+        result.reason.includes('Exception reason is required'),
+        `Expected reason message, got: ${result.reason}`
+      );
     });
   });
 
@@ -969,11 +1019,7 @@ describe('TDD enforcement', () => {
         workState: {
           tasksMeta: {
             currentTaskIndex: 0,
-            tasks: [
-              { id: 'task-1', taskReviewFixRounds: 0 },
-              { id: 'task-2' },
-              { id: 'task-3' },
-            ],
+            tasks: [{ id: 'task-1', taskReviewFixRounds: 0 }, { id: 'task-2' }, { id: 'task-3' }],
           },
         },
       });
@@ -1015,10 +1061,7 @@ describe('TDD enforcement', () => {
         workState: {
           tasksMeta: {
             currentTaskIndex: 0,
-            tasks: [
-              { id: 'task-1', taskReviewFixRounds: 0 },
-              { id: 'task-2' },
-            ],
+            tasks: [{ id: 'task-1', taskReviewFixRounds: 0 }, { id: 'task-2' }],
           },
         },
       });

--- a/workflows/work/__tests__/transition-step.test.js
+++ b/workflows/work/__tests__/transition-step.test.js
@@ -42,7 +42,9 @@ function createDeps(overrides = {}) {
       if (savedStates[ticket]) return savedStates[ticket];
       // Return a basic in_progress state at the given step
       const stepStatus = {};
-      ALL_STEPS.forEach((s) => { stepStatus[s] = 'pending'; });
+      ALL_STEPS.forEach((s) => {
+        stepStatus[s] = 'pending';
+      });
       stepStatus[ALL_STEPS[0]] = 'in_progress';
       return {
         ticketId: ticket,
@@ -131,14 +133,8 @@ describe('transition-step.js (GH-245 Task 4)', () => {
       );
 
       // Should NOT have "step skipped" actions
-      const skippedActions = deps._actions.filter(
-        (a) => a.what === 'step skipped'
-      );
-      assert.equal(
-        skippedActions.length,
-        0,
-        'Should NOT log any "step skipped" actions'
-      );
+      const skippedActions = deps._actions.filter((a) => a.what === 'step skipped');
+      assert.equal(skippedActions.length, 0, 'Should NOT log any "step skipped" actions');
     });
 
     it('should mark multiple intermediate steps as "completed" and log "step deferred" when jumping', () => {
@@ -193,7 +189,13 @@ describe('transition-step.js (GH-260): generic step-verify gate', () => {
     const followUpIdx = ALL_STEPS.indexOf(STEPS.follow_up);
     const deps = createDeps({
       workflowCanTransition: () => true,
-      softSteps: new Set([STEPS.ticket, STEPS.ready, STEPS.task_review, STEPS.reports, STEPS.complete]),
+      softSteps: new Set([
+        STEPS.ticket,
+        STEPS.ready,
+        STEPS.task_review,
+        STEPS.reports,
+        STEPS.complete,
+      ]),
       commandMap: [
         { step: STEPS.follow_up, verify: () => false }, // verify fails
       ],
@@ -217,7 +219,13 @@ describe('transition-step.js (GH-260): generic step-verify gate', () => {
     const followUpIdx = ALL_STEPS.indexOf(STEPS.follow_up);
     const deps = createDeps({
       workflowCanTransition: () => true,
-      softSteps: new Set([STEPS.ticket, STEPS.ready, STEPS.task_review, STEPS.reports, STEPS.complete]),
+      softSteps: new Set([
+        STEPS.ticket,
+        STEPS.ready,
+        STEPS.task_review,
+        STEPS.reports,
+        STEPS.complete,
+      ]),
       commandMap: [
         { step: STEPS.follow_up, verify: () => true }, // verify passes
       ],
@@ -239,7 +247,13 @@ describe('transition-step.js (GH-260): generic step-verify gate', () => {
     const reportsIdx = ALL_STEPS.indexOf(STEPS.reports);
     const deps = createDeps({
       workflowCanTransition: () => true,
-      softSteps: new Set([STEPS.ticket, STEPS.ready, STEPS.task_review, STEPS.reports, STEPS.complete]),
+      softSteps: new Set([
+        STEPS.ticket,
+        STEPS.ready,
+        STEPS.task_review,
+        STEPS.reports,
+        STEPS.complete,
+      ]),
       commandMap: [
         { step: STEPS.reports, verify: () => false }, // verify would fail, but reports is soft
       ],
@@ -261,7 +275,13 @@ describe('transition-step.js (GH-260): generic step-verify gate', () => {
     const ciIdx = ALL_STEPS.indexOf(STEPS.ci);
     const deps = createDeps({
       workflowCanTransition: () => true,
-      softSteps: new Set([STEPS.ticket, STEPS.ready, STEPS.task_review, STEPS.reports, STEPS.complete]),
+      softSteps: new Set([
+        STEPS.ticket,
+        STEPS.ready,
+        STEPS.task_review,
+        STEPS.reports,
+        STEPS.complete,
+      ]),
       commandMap: [
         { step: STEPS.ci, verify: () => false }, // verify fails but backward should be allowed
       ],
@@ -283,7 +303,13 @@ describe('transition-step.js (GH-260): generic step-verify gate', () => {
     const cleanupIdx = ALL_STEPS.indexOf(STEPS.cleanup);
     const deps = createDeps({
       workflowCanTransition: () => true,
-      softSteps: new Set([STEPS.ticket, STEPS.ready, STEPS.task_review, STEPS.reports, STEPS.complete]),
+      softSteps: new Set([
+        STEPS.ticket,
+        STEPS.ready,
+        STEPS.task_review,
+        STEPS.reports,
+        STEPS.complete,
+      ]),
       commandMap: [], // no verify for cleanup
     });
 
@@ -326,7 +352,13 @@ describe('transition-step.js (GH-260): generic step-verify gate', () => {
     const ciIdx = ALL_STEPS.indexOf(STEPS.ci);
     const deps = createDeps({
       workflowCanTransition: () => true,
-      softSteps: new Set([STEPS.ticket, STEPS.ready, STEPS.task_review, STEPS.reports, STEPS.complete]),
+      softSteps: new Set([
+        STEPS.ticket,
+        STEPS.ready,
+        STEPS.task_review,
+        STEPS.reports,
+        STEPS.complete,
+      ]),
       commandMap: [
         { step: STEPS.ci, verify: () => false }, // CI not passing
       ],
@@ -350,9 +382,20 @@ describe('transition-step.js (GH-260): generic step-verify gate', () => {
     const followUpIdx = ALL_STEPS.indexOf(STEPS.follow_up);
     const deps = createDeps({
       workflowCanTransition: () => true,
-      softSteps: new Set([STEPS.ticket, STEPS.ready, STEPS.task_review, STEPS.reports, STEPS.complete]),
+      softSteps: new Set([
+        STEPS.ticket,
+        STEPS.ready,
+        STEPS.task_review,
+        STEPS.reports,
+        STEPS.complete,
+      ]),
       commandMap: [
-        { step: STEPS.follow_up, verify: () => { throw new Error('isPRGateReady exploded'); } },
+        {
+          step: STEPS.follow_up,
+          verify: () => {
+            throw new Error('isPRGateReady exploded');
+          },
+        },
       ],
     });
 
@@ -366,5 +409,4 @@ describe('transition-step.js (GH-260): generic step-verify gate', () => {
     assert.equal(result.gate, 'step-verify', 'Gate should be step-verify');
     assert.ok(result.message.includes('verify threw'), 'Message should indicate verify threw');
   });
-
 });

--- a/workflows/work/__tests__/work-claims.test.js
+++ b/workflows/work/__tests__/work-claims.test.js
@@ -154,11 +154,7 @@ describe('claimTask — happy path + lock payload (R5)', () => {
     const entries = fs.readdirSync(claimsDirFor(TICKET));
     // Only the canonical lock file should remain. No `.tmp-*` leftovers.
     const leaked = entries.filter((name) => name.startsWith('.tmp-'));
-    assert.deepEqual(
-      leaked,
-      [],
-      `temp lock file(s) leaked into .claims/: ${leaked.join(', ')}`
-    );
+    assert.deepEqual(leaked, [], `temp lock file(s) leaked into .claims/: ${leaked.join(', ')}`);
   });
 });
 
@@ -308,7 +304,19 @@ describe('releaseTask', () => {
 
 describe('claimTask — R15 input validation (fail closed, no I/O)', () => {
   it('rejects bad ticket ids with INVALID_TICKET_ID; creates no directory', () => {
-    const bad = ['', '   ', null, undefined, '../x', '/etc/passwd', 'a\\b', 'a\0b', 'a//b', 'a:b', 'GH-219/'];
+    const bad = [
+      '',
+      '   ',
+      null,
+      undefined,
+      '../x',
+      '/etc/passwd',
+      'a\\b',
+      'a\0b',
+      'a//b',
+      'a:b',
+      'GH-219/',
+    ];
     for (const ticketId of bad) {
       const result = workClaims.claimTask(ticketId, 1, 'PR1');
       assert.equal(
@@ -371,7 +379,11 @@ describe('claimTask — R15 input validation (fail closed, no I/O)', () => {
     const bad = [' GH-219', 'GH-219 ', ' GH-219 ', '\tGH-219', 'GH-219\n'];
     for (const ticketId of bad) {
       const result = workClaims.claimTask(ticketId, 1, 'PR1');
-      assert.equal(result.success, false, `whitespace-padded ${JSON.stringify(ticketId)} must fail`);
+      assert.equal(
+        result.success,
+        false,
+        `whitespace-padded ${JSON.stringify(ticketId)} must fail`
+      );
       assert.equal(result.error.code, 'INVALID_TICKET_ID');
     }
   });
@@ -503,10 +515,7 @@ describe('R5 — does not perturb session-guard / work-state surfaces', () => {
     const result = workClaims.claimTask('A/B/C', 1, 'PR1');
     assert.equal(result.success, false, 'must reject A/B/C');
     assert.equal(result.error.code, 'INVALID_TICKET_ID');
-    assert.ok(
-      result.error.message.includes('/'),
-      'error message must mention the slash issue'
-    );
+    assert.ok(result.error.message.includes('/'), 'error message must mention the slash issue');
   });
 
   it('releaseTask returns idempotent success when lock disappears between existsSync and readLockOwner (TOCTOU)', () => {

--- a/workflows/work/__tests__/work-enforce-steps.test.js
+++ b/workflows/work/__tests__/work-enforce-steps.test.js
@@ -77,7 +77,9 @@ function runHook(toolInput, hookType = 'PostToolUse') {
 
 describe('work-enforce-steps hook', () => {
   after(() => {
-    try { fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true }); } catch {}
+    try {
+      fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
+    } catch {}
     // Restore original env so sibling test files in the same Node process
     // don't inherit our temp base / test project key.
     if (ORIG_ENV.TASKS_BASE === undefined) delete process.env.TASKS_BASE;
@@ -86,7 +88,9 @@ describe('work-enforce-steps hook', () => {
     else process.env.TICKET_PROJECT_KEY = ORIG_ENV.TICKET_PROJECT_KEY;
     // Clear require.cache for config.js so sibling tests re-read it under
     // restored env instead of reusing our cached temp derivation.
-    try { delete require.cache[require.resolve(CONFIG_PATH)]; } catch {}
+    try {
+      delete require.cache[require.resolve(CONFIG_PATH)];
+    } catch {}
   });
 
   it('should exit 0 for non-work/work-pr skills', async () => {
@@ -101,10 +105,7 @@ describe('work-enforce-steps hook', () => {
 
   it('should create session file on PreToolUse for /work', async () => {
     const ticketId = nextTicketId();
-    const { code } = await runHook(
-      { skill: 'work', args: ticketId },
-      'PreToolUse'
-    );
+    const { code } = await runHook({ skill: 'work', args: ticketId }, 'PreToolUse');
     assert.strictEqual(code, 0);
 
     // Check session file was created

--- a/workflows/work/__tests__/work-enforcement-context.test.js
+++ b/workflows/work/__tests__/work-enforcement-context.test.js
@@ -312,7 +312,11 @@ describe('loadEnforcementContext — R15 ticket id validation', () => {
     const ctx = loadEnforcementContext('/etc/passwd');
 
     // After normalization to "etc-passwd", the ID is safe — no error
-    assert.equal(ctx.error, null, 'slash-containing input that normalizes safely should not be rejected');
+    assert.equal(
+      ctx.error,
+      null,
+      'slash-containing input that normalizes safely should not be rejected'
+    );
     assert.equal(ctx.ticketId, 'etc-passwd');
   });
 
@@ -403,10 +407,7 @@ describe('loadEnforcementContext — no transcript / no grep (R1)', () => {
       assert.equal(ctx.origin, 'workflow');
 
       for (const p of spy.calls.reads) {
-        assert.ok(
-          !/\.jsonl$/i.test(p),
-          `adapter must not read transcript jsonl files — saw: ${p}`
-        );
+        assert.ok(!/\.jsonl$/i.test(p), `adapter must not read transcript jsonl files — saw: ${p}`);
         assert.ok(!/transcript/i.test(p), `adapter must not read transcript files — saw: ${p}`);
       }
       for (const e of spy.calls.execs) {
@@ -428,7 +429,10 @@ describe('loadEnforcementContext — no transcript / no grep (R1)', () => {
 
     assert.ok(mocks.loadStateCalls.length > 0, 'adapter must call loadState via work-state.js');
     assert.ok(mocks.parseTasksCalls.length > 0, 'adapter must call parseTasks via task-parser.js');
-    assert.ok(Array.isArray(ctx.tasks) && ctx.tasks[0].id === 'task_1', 'tasks are exposed on context');
+    assert.ok(
+      Array.isArray(ctx.tasks) && ctx.tasks[0].id === 'task_1',
+      'tasks are exposed on context'
+    );
   });
 });
 
@@ -460,6 +464,10 @@ describe('loadEnforcementContext — context shape (Task 3 contract)', () => {
       assert.ok(key in ctx, `EnforcementContext must expose "${key}" for preflight consumer`);
     }
     assert.equal(ctx.ticketId, 'GH-219', 'ticketId is the sanitized id');
-    assert.equal(ctx.options.subtask, false, 'options.subtask is coerced to boolean (undefined → false)');
+    assert.equal(
+      ctx.options.subtask,
+      false,
+      'options.subtask is coerced to boolean (undefined → false)'
+    );
   });
 });

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -96,17 +96,23 @@ function cleanupTempWorkState(ticket) {
 after(() => {
   // Nuke the whole temp base — no selective cleanup needed since everything
   // the suite touches lives under TEMP_WORKTREES_BASE.
-  try { fs.rmSync(TEMP_WORKTREES_BASE, { recursive: true, force: true }); } catch {}
+  try {
+    fs.rmSync(TEMP_WORKTREES_BASE, { recursive: true, force: true });
+  } catch {}
   // Safety-net: clean up leaked session guard files created by THIS suite only (TEST-* tickets)
   try {
     const tmpDir = os.tmpdir();
-    const tmpFiles = fs.readdirSync(tmpDir).filter(f => f.startsWith('claude-session-guard-TEST-'));
+    const tmpFiles = fs
+      .readdirSync(tmpDir)
+      .filter((f) => f.startsWith('claude-session-guard-TEST-'));
     for (const f of tmpFiles) {
       try {
         fs.unlinkSync(path.join(tmpDir, f));
       } catch {}
     }
-  } catch { /* ignore if tmpdir unreadable */ }
+  } catch {
+    /* ignore if tmpdir unreadable */
+  }
   // Restore original env so sibling test files loaded in the same Node
   // process (node --test runs many files in one process) don't see our
   // temp overrides leak through inherited env.
@@ -117,8 +123,12 @@ after(() => {
   // Clear require.cache for get-config / config so sibling test files get a
   // fresh module re-read with the restored env instead of our cached temp
   // derivation.
-  try { delete require.cache[require.resolve(GET_CONFIG_PATH)]; } catch {}
-  try { delete require.cache[require.resolve(CONFIG_PATH)]; } catch {}
+  try {
+    delete require.cache[require.resolve(GET_CONFIG_PATH)];
+  } catch {}
+  try {
+    delete require.cache[require.resolve(CONFIG_PATH)];
+  } catch {}
 });
 
 /**
@@ -162,7 +172,9 @@ function writeTddException(tasksBase, ticket) {
           );
         }
       }
-    } catch { /* parseTasks may not be available in all test contexts */ }
+    } catch {
+      /* parseTasks may not be available in all test contexts */
+    }
   }
   fs.writeFileSync(
     path.join(dir, 'tdd-phase.json'),
@@ -208,7 +220,10 @@ function writeTaskArtifacts(tasksBase, ticket) {
     path.join(dir, 'spec.md'),
     '# Spec\n\n<!-- gherkin-skip: test artifact -->\n\n## Summary\nTest spec.\n'
   );
-  fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n## Task 1 — Test task\n\n### Type\nbackend\n\n### Deliverables\n- [ ] 1.1 Test deliverable\n');
+  fs.writeFileSync(
+    path.join(dir, 'tasks.md'),
+    '# Tasks\n\n## Task 1 — Test task\n\n### Type\nbackend\n\n### Deliverables\n- [ ] 1.1 Test deliverable\n'
+  );
 }
 
 /**
@@ -222,7 +237,11 @@ function prepareVerifyEnv(ticket, tasksBase) {
   writeTaskArtifacts(tasksBase, ticket);
   return {
     gitDir,
-    cleanup: () => { try { fs.rmSync(gitDir, { recursive: true, force: true }); } catch {} },
+    cleanup: () => {
+      try {
+        fs.rmSync(gitDir, { recursive: true, force: true });
+      } catch {}
+    },
   };
 }
 
@@ -463,8 +482,12 @@ describe('work-orchestrator.js', () => {
     let transGitDir;
     const transOpts = {};
     after(() => {
-      try { fs.rmSync(TEMP_WB, { recursive: true, force: true }); } catch {}
-      try { if (transGitDir) fs.rmSync(transGitDir, { recursive: true, force: true }); } catch {}
+      try {
+        fs.rmSync(TEMP_WB, { recursive: true, force: true });
+      } catch {}
+      try {
+        if (transGitDir) fs.rmSync(transGitDir, { recursive: true, force: true });
+      } catch {}
     });
     afterEach(() => {
       try {
@@ -692,7 +715,11 @@ describe('work-orchestrator.js', () => {
     it('should not emit any SKIP steps (GH-245)', async () => {
       const { result } = await runOrchestrator([TEST_TICKET]);
       const skipSteps = result.plan.filter((s) => s.action === 'SKIP');
-      assert.equal(skipSteps.length, 0, `Found ${skipSteps.length} SKIP step(s): ${skipSteps.map(s => s.step).join(', ')}`);
+      assert.equal(
+        skipSteps.length,
+        0,
+        `Found ${skipSteps.length} SKIP step(s): ${skipSteps.map((s) => s.step).join(', ')}`
+      );
     });
 
     it('should include agentType for DEFER steps with commands as fallback (GH-130)', async () => {
@@ -822,7 +849,9 @@ describe('work-orchestrator.js', () => {
         assert.equal(result.success, true);
         assert.equal(result.direction, 'backward');
       } finally {
-        try { fs.rmSync(TMP, { recursive: true, force: true }); } catch {}
+        try {
+          fs.rmSync(TMP, { recursive: true, force: true });
+        } catch {}
         cleanupGit();
       }
     });
@@ -838,14 +867,25 @@ describe('work-orchestrator.js', () => {
       const stepStatus = {};
       let foundPr = false;
       for (const s of ALL_STEPS) {
-        if (s === 'pr') { stepStatus[s] = 'in_progress'; foundPr = true; }
-        else if (!foundPr) { stepStatus[s] = 'completed'; }
-        else { stepStatus[s] = 'pending'; }
+        if (s === 'pr') {
+          stepStatus[s] = 'in_progress';
+          foundPr = true;
+        } else if (!foundPr) {
+          stepStatus[s] = 'completed';
+        } else {
+          stepStatus[s] = 'pending';
+        }
       }
-      fs.writeFileSync(path.join(dir, STATE_BASENAME), JSON.stringify({
-        ticketId: TEST_TICKET, status: 'in_progress', stepStatus,
-        startTime: '2026-01-01T00:00:00.000Z', lastUpdate: '2026-01-01T00:00:00.000Z',
-      }));
+      fs.writeFileSync(
+        path.join(dir, STATE_BASENAME),
+        JSON.stringify({
+          ticketId: TEST_TICKET,
+          status: 'in_progress',
+          stepStatus,
+          startTime: '2026-01-01T00:00:00.000Z',
+          lastUpdate: '2026-01-01T00:00:00.000Z',
+        })
+      );
       try {
         // pr → ci is invalid (must go through ready + follow_up) — graph block fires before verify
         const { result } = await runOrchestrator(['transition', TEST_TICKET, 'ci']);
@@ -869,14 +909,25 @@ describe('work-orchestrator.js', () => {
       const stepStatus = {};
       let foundReady = false;
       for (const s of ALL_STEPS) {
-        if (s === 'ready') { stepStatus[s] = 'in_progress'; foundReady = true; }
-        else if (!foundReady) { stepStatus[s] = 'completed'; }
-        else { stepStatus[s] = 'pending'; }
+        if (s === 'ready') {
+          stepStatus[s] = 'in_progress';
+          foundReady = true;
+        } else if (!foundReady) {
+          stepStatus[s] = 'completed';
+        } else {
+          stepStatus[s] = 'pending';
+        }
       }
-      fs.writeFileSync(path.join(dir, STATE_BASENAME), JSON.stringify({
-        ticketId: TEST_TICKET, status: 'in_progress', stepStatus,
-        startTime: '2026-01-01T00:00:00.000Z', lastUpdate: '2026-01-01T00:00:00.000Z',
-      }));
+      fs.writeFileSync(
+        path.join(dir, STATE_BASENAME),
+        JSON.stringify({
+          ticketId: TEST_TICKET,
+          status: 'in_progress',
+          stepStatus,
+          startTime: '2026-01-01T00:00:00.000Z',
+          lastUpdate: '2026-01-01T00:00:00.000Z',
+        })
+      );
       try {
         // ready → follow_up (ready is soft — no verify)
         const { result: r1 } = await runOrchestrator(['transition', TEST_TICKET, 'follow_up']);
@@ -993,8 +1044,12 @@ describe('work-orchestrator.js', () => {
       o.cwd = fuGitDir;
     });
     after(() => {
-      try { fs.rmSync(TEMP_WB, { recursive: true, force: true }); } catch {}
-      try { if (fuGitDir) fs.rmSync(fuGitDir, { recursive: true, force: true }); } catch {}
+      try {
+        fs.rmSync(TEMP_WB, { recursive: true, force: true });
+      } catch {}
+      try {
+        if (fuGitDir) fs.rmSync(fuGitDir, { recursive: true, force: true });
+      } catch {}
     });
 
     it('should allow transition follow_up → ci (forward)', async () => {
@@ -1009,14 +1064,25 @@ describe('work-orchestrator.js', () => {
       const stepStatus = {};
       let found = false;
       for (const s of ALL_STEPS) {
-        if (s === 'follow_up') { stepStatus[s] = 'in_progress'; found = true; }
-        else if (!found) { stepStatus[s] = 'completed'; }
-        else { stepStatus[s] = 'pending'; }
+        if (s === 'follow_up') {
+          stepStatus[s] = 'in_progress';
+          found = true;
+        } else if (!found) {
+          stepStatus[s] = 'completed';
+        } else {
+          stepStatus[s] = 'pending';
+        }
       }
-      fs.writeFileSync(path.join(dir, STATE_BASENAME), JSON.stringify({
-        ticketId: T, status: 'in_progress', stepStatus,
-        startTime: '2026-01-01T00:00:00.000Z', lastUpdate: '2026-01-01T00:00:00.000Z',
-      }));
+      fs.writeFileSync(
+        path.join(dir, STATE_BASENAME),
+        JSON.stringify({
+          ticketId: T,
+          status: 'in_progress',
+          stepStatus,
+          startTime: '2026-01-01T00:00:00.000Z',
+          lastUpdate: '2026-01-01T00:00:00.000Z',
+        })
+      );
       // follow_up → ci is valid in graph; verify gate blocks without real PR.
       // Test the graph validity via transitions query.
       const { result } = await runOrchestrator(['transitions', T], o);
@@ -1035,14 +1101,25 @@ describe('work-orchestrator.js', () => {
       const stepStatus = {};
       let found = false;
       for (const s of ALL_STEPS) {
-        if (s === 'follow_up') { stepStatus[s] = 'in_progress'; found = true; }
-        else if (!found) { stepStatus[s] = 'completed'; }
-        else { stepStatus[s] = 'pending'; }
+        if (s === 'follow_up') {
+          stepStatus[s] = 'in_progress';
+          found = true;
+        } else if (!found) {
+          stepStatus[s] = 'completed';
+        } else {
+          stepStatus[s] = 'pending';
+        }
       }
-      fs.writeFileSync(path.join(dir, STATE_BASENAME), JSON.stringify({
-        ticketId: T2, status: 'in_progress', stepStatus,
-        startTime: '2026-01-01T00:00:00.000Z', lastUpdate: '2026-01-01T00:00:00.000Z',
-      }));
+      fs.writeFileSync(
+        path.join(dir, STATE_BASENAME),
+        JSON.stringify({
+          ticketId: T2,
+          status: 'in_progress',
+          stepStatus,
+          startTime: '2026-01-01T00:00:00.000Z',
+          lastUpdate: '2026-01-01T00:00:00.000Z',
+        })
+      );
       try {
         const { result } = await runOrchestrator(['transition', T2, 'implement'], o);
         assert.equal(result.success, true);
@@ -1050,7 +1127,9 @@ describe('work-orchestrator.js', () => {
         assert.equal(result.to, 'implement');
         assert.equal(result.direction, 'backward');
       } finally {
-        try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+        try {
+          fs.rmSync(dir, { recursive: true, force: true });
+        } catch {}
       }
     });
 
@@ -1064,14 +1143,25 @@ describe('work-orchestrator.js', () => {
       const stepStatus = {};
       let found = false;
       for (const s of ALL_STEPS) {
-        if (s === 'follow_up') { stepStatus[s] = 'in_progress'; found = true; }
-        else if (!found) { stepStatus[s] = 'completed'; }
-        else { stepStatus[s] = 'pending'; }
+        if (s === 'follow_up') {
+          stepStatus[s] = 'in_progress';
+          found = true;
+        } else if (!found) {
+          stepStatus[s] = 'completed';
+        } else {
+          stepStatus[s] = 'pending';
+        }
       }
-      fs.writeFileSync(path.join(dir, STATE_BASENAME), JSON.stringify({
-        ticketId: T3, status: 'in_progress', stepStatus,
-        startTime: '2026-01-01T00:00:00.000Z', lastUpdate: '2026-01-01T00:00:00.000Z',
-      }));
+      fs.writeFileSync(
+        path.join(dir, STATE_BASENAME),
+        JSON.stringify({
+          ticketId: T3,
+          status: 'in_progress',
+          stepStatus,
+          startTime: '2026-01-01T00:00:00.000Z',
+          lastUpdate: '2026-01-01T00:00:00.000Z',
+        })
+      );
       try {
         const { result } = await runOrchestrator(['transition', T3, 'implement'], o);
         assert.equal(result.success, true);
@@ -1079,7 +1169,9 @@ describe('work-orchestrator.js', () => {
         assert.equal(result.to, 'implement');
         assert.equal(result.direction, 'backward');
       } finally {
-        try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+        try {
+          fs.rmSync(dir, { recursive: true, force: true });
+        } catch {}
       }
     });
 
@@ -1094,14 +1186,25 @@ describe('work-orchestrator.js', () => {
         const stepStatus = {};
         let found = false;
         for (const s of ALL_STEPS) {
-          if (s === 'check') { stepStatus[s] = 'in_progress'; found = true; }
-          else if (!found) { stepStatus[s] = 'completed'; }
-          else { stepStatus[s] = 'pending'; }
+          if (s === 'check') {
+            stepStatus[s] = 'in_progress';
+            found = true;
+          } else if (!found) {
+            stepStatus[s] = 'completed';
+          } else {
+            stepStatus[s] = 'pending';
+          }
         }
-        fs.writeFileSync(path.join(ticketDir, STATE_BASENAME), JSON.stringify({
-          ticketId: T_ARCHIVE, status: 'in_progress', stepStatus,
-          startTime: '2026-01-01T00:00:00.000Z', lastUpdate: '2026-01-01T00:00:00.000Z',
-        }));
+        fs.writeFileSync(
+          path.join(ticketDir, STATE_BASENAME),
+          JSON.stringify({
+            ticketId: T_ARCHIVE,
+            status: 'in_progress',
+            stepStatus,
+            startTime: '2026-01-01T00:00:00.000Z',
+            lastUpdate: '2026-01-01T00:00:00.000Z',
+          })
+        );
         writeCheckReports(TEMP_TASKS, T_ARCHIVE);
 
         // Verify reports exist before backward transition
@@ -1126,7 +1229,9 @@ describe('work-orchestrator.js', () => {
         assert.ok(fs.existsSync(path.join(ticketDir, 'runs', 'run1', 'completion.check.md')));
         assert.ok(fs.existsSync(path.join(ticketDir, 'runs', 'run1', 'qa-feature.check.md')));
       } finally {
-        try { fs.rmSync(ticketDir, { recursive: true, force: true }); } catch {}
+        try {
+          fs.rmSync(ticketDir, { recursive: true, force: true });
+        } catch {}
       }
     });
 
@@ -1141,14 +1246,25 @@ describe('work-orchestrator.js', () => {
         const stepStatus = {};
         let found = false;
         for (const s of ALL_STEPS) {
-          if (s === 'check') { stepStatus[s] = 'in_progress'; found = true; }
-          else if (!found) { stepStatus[s] = 'completed'; }
-          else { stepStatus[s] = 'pending'; }
+          if (s === 'check') {
+            stepStatus[s] = 'in_progress';
+            found = true;
+          } else if (!found) {
+            stepStatus[s] = 'completed';
+          } else {
+            stepStatus[s] = 'pending';
+          }
         }
-        fs.writeFileSync(path.join(ticketDir, STATE_BASENAME), JSON.stringify({
-          ticketId: T_RUNS, status: 'in_progress', stepStatus,
-          startTime: '2026-01-01T00:00:00.000Z', lastUpdate: '2026-01-01T00:00:00.000Z',
-        }));
+        fs.writeFileSync(
+          path.join(ticketDir, STATE_BASENAME),
+          JSON.stringify({
+            ticketId: T_RUNS,
+            status: 'in_progress',
+            stepStatus,
+            startTime: '2026-01-01T00:00:00.000Z',
+            lastUpdate: '2026-01-01T00:00:00.000Z',
+          })
+        );
         writeCheckReports(TEMP_TASKS, T_RUNS);
         // First backward: check → implement
         await runOrchestrator(['transition', T_RUNS, 'implement'], o);
@@ -1164,7 +1280,9 @@ describe('work-orchestrator.js', () => {
 
         assert.ok(fs.existsSync(path.join(ticketDir, 'runs', 'run2')), 'run2 should exist');
       } finally {
-        try { fs.rmSync(ticketDir, { recursive: true, force: true }); } catch {}
+        try {
+          fs.rmSync(ticketDir, { recursive: true, force: true });
+        } catch {}
       }
     });
 
@@ -1234,8 +1352,12 @@ describe('work-orchestrator.js', () => {
       envOpts.cwd = integGitDir;
     });
     after(() => {
-      try { fs.rmSync(TEMP_WB, { recursive: true, force: true }); } catch {}
-      try { if (integGitDir) fs.rmSync(integGitDir, { recursive: true, force: true }); } catch {}
+      try {
+        fs.rmSync(TEMP_WB, { recursive: true, force: true });
+      } catch {}
+      try {
+        if (integGitDir) fs.rmSync(integGitDir, { recursive: true, force: true });
+      } catch {}
     });
 
     afterEach(() => {
@@ -1535,8 +1657,12 @@ describe('work-orchestrator.js', () => {
       gateOpts.cwd = gateGitDir;
     });
     after(() => {
-      try { fs.rmSync(TEMP_WB, { recursive: true, force: true }); } catch {}
-      try { if (gateGitDir) fs.rmSync(gateGitDir, { recursive: true, force: true }); } catch {}
+      try {
+        fs.rmSync(TEMP_WB, { recursive: true, force: true });
+      } catch {}
+      try {
+        if (gateGitDir) fs.rmSync(gateGitDir, { recursive: true, force: true });
+      } catch {}
     });
     afterEach(() => {
       try {
@@ -1883,9 +2009,24 @@ describe('GH-211: task_review in plan generation', () => {
 
     const stepStatus = {};
     const allSteps = [
-      'ticket', 'bootstrap', 'brief', 'brief_gate', 'spec', 'spec_gate', 'tasks',
-      'implement', 'commit', 'task_review', 'check', 'pr', 'ready',
-      'follow_up', 'ci', 'cleanup', 'reports', 'complete',
+      'ticket',
+      'bootstrap',
+      'brief',
+      'brief_gate',
+      'spec',
+      'spec_gate',
+      'tasks',
+      'implement',
+      'commit',
+      'task_review',
+      'check',
+      'pr',
+      'ready',
+      'follow_up',
+      'ci',
+      'cleanup',
+      'reports',
+      'complete',
     ];
     for (const step of allSteps) {
       stepStatus[step] = 'pending';
@@ -1936,7 +2077,11 @@ describe('GH-211: task_review in plan generation', () => {
     assert.ok(stepNames.includes('task_review'), 'plan must include task_review step');
 
     const taskReviewEntry = result.plan.find((s) => s.step === 'task_review');
-    assert.equal(taskReviewEntry.action, 'RUN', 'task_review must be RUN for non-final task in multi-task plan');
+    assert.equal(
+      taskReviewEntry.action,
+      'RUN',
+      'task_review must be RUN for non-final task in multi-task plan'
+    );
 
     // task_review should come after commit in pipeline order
     const commitIdx = stepNames.indexOf('commit');
@@ -1956,7 +2101,11 @@ describe('GH-211: task_review in plan generation', () => {
 
     const taskReviewEntry = result.plan.find((s) => s.step === 'task_review');
     assert.ok(taskReviewEntry, 'plan must include task_review step even when skipped');
-    assert.equal(taskReviewEntry.action, 'DEFER', 'task_review must be DEFER for single-task (final task)');
+    assert.equal(
+      taskReviewEntry.action,
+      'DEFER',
+      'task_review must be DEFER for single-task (final task)'
+    );
   });
 
   // 9.1: TASK_REVIEW_ENABLED=0 skips task_review
@@ -1966,14 +2115,22 @@ describe('GH-211: task_review in plan generation', () => {
     writeWorkStateWithTasks(TEMP_TASKS, TEST_TICKET, { totalTasks: 3, currentTaskIndex: 0 });
     writeTddException(TEMP_TASKS, TEST_TICKET);
 
-    const { result, code } = await runOrchestrator([TEST_TICKET], isolatedEnv({ TASK_REVIEW_ENABLED: '0' }));
+    const { result, code } = await runOrchestrator(
+      [TEST_TICKET],
+      isolatedEnv({ TASK_REVIEW_ENABLED: '0' })
+    );
     assert.equal(code, 0);
 
     const taskReviewEntry = result.plan.find((s) => s.step === 'task_review');
     assert.ok(taskReviewEntry, 'plan must include task_review step entry');
-    assert.equal(taskReviewEntry.action, 'DEFER', 'task_review must be DEFER when TASK_REVIEW_ENABLED=0');
+    assert.equal(
+      taskReviewEntry.action,
+      'DEFER',
+      'task_review must be DEFER when TASK_REVIEW_ENABLED=0'
+    );
     assert.ok(
-      taskReviewEntry.reason.includes('disabled') || taskReviewEntry.reason.includes('TASK_REVIEW_ENABLED'),
+      taskReviewEntry.reason.includes('disabled') ||
+        taskReviewEntry.reason.includes('TASK_REVIEW_ENABLED'),
       'reason should mention disabled/env flag'
     );
   });
@@ -1989,7 +2146,10 @@ describe('GH-211: task_review in plan generation', () => {
     });
     writeTddException(TEMP_TASKS, TEST_TICKET);
 
-    const { result, code } = await runOrchestrator([TEST_TICKET], isolatedEnv({ TASK_REVIEW_MAX_FIXES: '2' }));
+    const { result, code } = await runOrchestrator(
+      [TEST_TICKET],
+      isolatedEnv({ TASK_REVIEW_MAX_FIXES: '2' })
+    );
     assert.equal(code, 0);
 
     const taskReviewEntry = result.plan.find((s) => s.step === 'task_review');
@@ -1999,6 +2159,10 @@ describe('GH-211: task_review in plan generation', () => {
       taskReviewEntry.reason.includes('exhausted') || taskReviewEntry.reason.includes('escalat'),
       'reason should mention exhaustion or escalation'
     );
-    assert.equal(taskReviewEntry.command, 'AskUserQuestion', 'escalation should use AskUserQuestion command');
+    assert.equal(
+      taskReviewEntry.command,
+      'AskUserQuestion',
+      'escalation should use AskUserQuestion command'
+    );
   });
 });

--- a/workflows/work/__tests__/work-require-implement.test.js
+++ b/workflows/work/__tests__/work-require-implement.test.js
@@ -52,10 +52,7 @@ function createStateFixture(ticketId, stateOverrides = {}) {
     ...restOverrides,
   };
 
-  fs.writeFileSync(
-    path.join(ticketDir, '.work-state.json'),
-    JSON.stringify(defaultState, null, 2)
-  );
+  fs.writeFileSync(path.join(ticketDir, '.work-state.json'), JSON.stringify(defaultState, null, 2));
 
   return {
     tasksBase,
@@ -253,7 +250,11 @@ describe('work-require-implement hook', () => {
           tool_name: 'Write',
           tool_input: { file_path: taskFile },
         },
-        { TASKS_BASE: fixture.tasksBase, WORKTREES_BASE: path.dirname(fixture.tasksBase), TICKET_ID: 'GH-219' }
+        {
+          TASKS_BASE: fixture.tasksBase,
+          WORKTREES_BASE: path.dirname(fixture.tasksBase),
+          TICKET_ID: 'GH-219',
+        }
       );
       assert.strictEqual(result.decision, 'approve');
     } finally {
@@ -265,10 +266,7 @@ describe('work-require-implement hook', () => {
 
   it('should APPROVE when inside developer agent', async () => {
     const tp = path.join(os.tmpdir(), `test-wri4-${Date.now()}.jsonl`);
-    fs.writeFileSync(
-      tp,
-      ['"subagent_type": "developer-nodejs-tdd"'].join('\n')
-    );
+    fs.writeFileSync(tp, ['"subagent_type": "developer-nodejs-tdd"'].join('\n'));
     try {
       const { result } = await runHookWithState(
         {
@@ -291,10 +289,7 @@ describe('work-require-implement hook', () => {
 
   it('should APPROVE when inside developer agent with work-workflow: prefix', async () => {
     const tp = path.join(os.tmpdir(), `test-wri-prefix-${Date.now()}.jsonl`);
-    fs.writeFileSync(
-      tp,
-      ['"subagent_type": "work-workflow:developer-nodejs-tdd"'].join('\n')
-    );
+    fs.writeFileSync(tp, ['"subagent_type": "work-workflow:developer-nodejs-tdd"'].join('\n'));
     try {
       const { result } = await runHookWithState(
         {
@@ -317,10 +312,7 @@ describe('work-require-implement hook', () => {
 
   it('should APPROVE when inside code-architect agent with WORK_ARCHITECT_ENABLED=1', async () => {
     const tp = path.join(os.tmpdir(), `test-wri-ca-prefix-${Date.now()}.jsonl`);
-    fs.writeFileSync(
-      tp,
-      ['"subagent_type": "work-workflow:code-architect"'].join('\n')
-    );
+    fs.writeFileSync(tp, ['"subagent_type": "work-workflow:code-architect"'].join('\n'));
     try {
       const { result } = await runHookWithState(
         {
@@ -345,10 +337,7 @@ describe('work-require-implement hook', () => {
   describe('WORK_ARCHITECT_ENABLED gate', () => {
     it('should BLOCK code-architect when WORK_ARCHITECT_ENABLED is not set', async () => {
       const tp = path.join(os.tmpdir(), `test-wri-ca-gate-${Date.now()}.jsonl`);
-      fs.writeFileSync(
-        tp,
-        ['"subagent_type": "code-architect"'].join('\n')
-      );
+      fs.writeFileSync(tp, ['"subagent_type": "code-architect"'].join('\n'));
       try {
         const { result } = await runHookWithState(
           {
@@ -372,10 +361,7 @@ describe('work-require-implement hook', () => {
 
     it('should APPROVE code-architect when WORK_ARCHITECT_ENABLED=1', async () => {
       const tp = path.join(os.tmpdir(), `test-wri-ca-gate2-${Date.now()}.jsonl`);
-      fs.writeFileSync(
-        tp,
-        ['"subagent_type": "code-architect"'].join('\n')
-      );
+      fs.writeFileSync(tp, ['"subagent_type": "code-architect"'].join('\n'));
       try {
         const { result } = await runHookWithState(
           {
@@ -448,7 +434,11 @@ describe('work-require-implement hook', () => {
           tool_name: 'Edit',
           tool_input: { file_path: '/home/node/project/src/app.ts' },
         },
-        { TASKS_BASE: fixture.tasksBase, WORKTREES_BASE: path.dirname(fixture.tasksBase), TICKET_ID: 'GH-219' }
+        {
+          TASKS_BASE: fixture.tasksBase,
+          WORKTREES_BASE: path.dirname(fixture.tasksBase),
+          TICKET_ID: 'GH-219',
+        }
       );
 
       // Check that .work-actions.json was written with an enforcement audit record
@@ -477,7 +467,11 @@ describe('work-require-implement hook', () => {
           tool_name: 'Edit',
           tool_input: { file_path: '/home/node/project/src/app.ts' },
         },
-        { TASKS_BASE: fixture.tasksBase, WORKTREES_BASE: path.dirname(fixture.tasksBase), TICKET_ID: 'GH-219' }
+        {
+          TASKS_BASE: fixture.tasksBase,
+          WORKTREES_BASE: path.dirname(fixture.tasksBase),
+          TICKET_ID: 'GH-219',
+        }
       );
 
       // Check that audit was written on allow path too

--- a/workflows/work/__tests__/work-state-graph.test.js
+++ b/workflows/work/__tests__/work-state-graph.test.js
@@ -233,7 +233,11 @@ describe('validateTaskGraph (R4 — pure graph validator)', () => {
     ]);
     assert.equal(result.valid, false);
     const dupErrors = result.errors.filter((e) => e.code === 'DUPLICATE_TASK_NUM');
-    assert.equal(dupErrors.length, 2, 'should report one DUPLICATE_TASK_NUM per duplicate occurrence');
+    assert.equal(
+      dupErrors.length,
+      2,
+      'should report one DUPLICATE_TASK_NUM per duplicate occurrence'
+    );
   });
 });
 
@@ -350,7 +354,10 @@ describe('initTasksMeta — parseTasks output + graph validation (R3, R4, R16)',
       { num: 1, dependencies: [] },
     ]);
     assert.ok(result.error, 'must return error for duplicate task numbers');
-    assert.ok(result.error.includes('Duplicate'), `error message must mention duplicates: ${result.error}`);
+    assert.ok(
+      result.error.includes('Duplicate'),
+      `error message must mention duplicates: ${result.error}`
+    );
 
     const state = workState.loadState(TICKET);
     assert.equal(state.tasksMeta, undefined, 'duplicate nums must not reach disk');
@@ -402,10 +409,7 @@ describe('initTasksMeta — parseTasks output + graph validation (R3, R4, R16)',
         ],
       },
     };
-    fs.writeFileSync(
-      path.join(taskDir, '.work-state.json'),
-      JSON.stringify(legacyState, null, 2)
-    );
+    fs.writeFileSync(path.join(taskDir, '.work-state.json'), JSON.stringify(legacyState, null, 2));
 
     // loadState must not throw on the missing fields (R16)
     const loaded = workState.loadState(TICKET);
@@ -502,10 +506,7 @@ describe('canStart(ticketId, taskNum) — pure dependency readiness (R3, R16)', 
         tasks: [{ id: 'task_1', status: 'pending', dependencies: [42] }],
       },
     };
-    fs.writeFileSync(
-      path.join(taskDir, '.work-state.json'),
-      JSON.stringify(state, null, 2)
-    );
+    fs.writeFileSync(path.join(taskDir, '.work-state.json'), JSON.stringify(state, null, 2));
 
     assert.equal(
       workState.canStart(TICKET, 1),
@@ -536,10 +537,7 @@ describe('canStart(ticketId, taskNum) — pure dependency readiness (R3, R16)', 
         ],
       },
     };
-    fs.writeFileSync(
-      path.join(taskDir, '.work-state.json'),
-      JSON.stringify(state, null, 2)
-    );
+    fs.writeFileSync(path.join(taskDir, '.work-state.json'), JSON.stringify(state, null, 2));
 
     // Documented R16 default: missing dependencies field ⇒ treat as empty deps
     // ⇒ canStart returns true for any task (sequential orchestrator-driven
@@ -591,9 +589,7 @@ describe('canStartFromState(state, taskNum) — pure readiness from loaded state
   it('returns true when task has no dependencies', () => {
     const state = {
       tasksMeta: {
-        tasks: [
-          { id: 'task_1', status: 'pending', dependencies: [] },
-        ],
+        tasks: [{ id: 'task_1', status: 'pending', dependencies: [] }],
       },
     };
     assert.equal(workState.canStartFromState(state, 1), true);
@@ -630,9 +626,7 @@ describe('canStartFromState(state, taskNum) — pure readiness from loaded state
   it('returns false for completed task', () => {
     const state = {
       tasksMeta: {
-        tasks: [
-          { id: 'task_1', status: 'completed', dependencies: [] },
-        ],
+        tasks: [{ id: 'task_1', status: 'completed', dependencies: [] }],
       },
     };
     assert.equal(workState.canStartFromState(state, 1), false);
@@ -641,9 +635,7 @@ describe('canStartFromState(state, taskNum) — pure readiness from loaded state
   it('returns true for pre-IDEA2 tasks without dependencies field (R16)', () => {
     const state = {
       tasksMeta: {
-        tasks: [
-          { id: 'task_1', status: 'pending' },
-        ],
+        tasks: [{ id: 'task_1', status: 'pending' }],
       },
     };
     assert.equal(workState.canStartFromState(state, 1), true);

--- a/workflows/work/__tests__/work-state-parallel.test.js
+++ b/workflows/work/__tests__/work-state-parallel.test.js
@@ -493,9 +493,6 @@ describe('allocateWorkerSlot — per-ticket isolation', () => {
     const result = workState.allocateWorkerSlot('A/B/C');
     assert.ok(result.error, 'must return an error for multiple slashes');
     assert.equal(result.error.code, 'INVALID_TICKET_ID');
-    assert.ok(
-      result.error.message.includes('/'),
-      'error message must mention the slash issue'
-    );
+    assert.ok(result.error.message.includes('/'), 'error message must mention the slash issue');
   });
 });

--- a/workflows/work/__tests__/work-state.test.js
+++ b/workflows/work/__tests__/work-state.test.js
@@ -736,10 +736,7 @@ describe('work-state.js', () => {
       try {
         await runWorkState(['init', TICKET_NO_TASKS]);
 
-        const { code, stderr } = await runWorkState([
-          'task-review-fix-rounds',
-          TICKET_NO_TASKS,
-        ]);
+        const { code, stderr } = await runWorkState(['task-review-fix-rounds', TICKET_NO_TASKS]);
         assert.equal(code, 1);
         const errResult = JSON.parse(stderr.trim());
         assert.ok(errResult.error);

--- a/workflows/work/artifact-archival.js
+++ b/workflows/work/artifact-archival.js
@@ -108,49 +108,50 @@ function archiveStepArtifacts(tasksDir, stepsToArchive) {
 
   // Scan taskN/ subdirectories for matching artifacts (GH-259)
   // Only recurse when tasks.md exists (multi-task mode)
-  if (fileExists(path.join(tasksDir, 'tasks.md'))) try {
-    const taskDirs = fs
-      .readdirSync(tasksDir)
-      .filter((d) => /^task\d+$/.test(d))
-      .filter((d) => {
-        try {
-          return fs.statSync(path.join(tasksDir, d)).isDirectory();
-        } catch {
-          return false;
-        }
-      });
-    // GH-259: only recurse when tasks.md exists (multi-task mode)
-    for (const taskDir of taskDirs) {
-      const taskPath = path.join(tasksDir, taskDir);
-      for (const step of stepsToArchive) {
-        const patterns = STEP_ARTIFACTS[step];
-        if (!patterns) continue;
-
-        const files = [...new Set(patterns.flatMap((p) => listFiles(taskPath, p)))];
-        if (files.length === 0) continue;
-
-        if (!archived) {
-          fs.mkdirSync(runDir, { recursive: true });
-          archived = true;
-        }
-        const taskRunDir = path.join(runDir, taskDir);
-        fs.mkdirSync(taskRunDir, { recursive: true });
-
-        for (const filePath of files) {
-          const dest = path.join(taskRunDir, path.basename(filePath));
+  if (fileExists(path.join(tasksDir, 'tasks.md')))
+    try {
+      const taskDirs = fs
+        .readdirSync(tasksDir)
+        .filter((d) => /^task\d+$/.test(d))
+        .filter((d) => {
           try {
-            fs.renameSync(filePath, dest);
-          } catch (e) {
-            process.stderr.write(
-              `work-orchestrator: failed to archive ${taskDir}/${path.basename(filePath)}: ${e?.message || e}\n`
-            );
+            return fs.statSync(path.join(tasksDir, d)).isDirectory();
+          } catch {
+            return false;
+          }
+        });
+      // GH-259: only recurse when tasks.md exists (multi-task mode)
+      for (const taskDir of taskDirs) {
+        const taskPath = path.join(tasksDir, taskDir);
+        for (const step of stepsToArchive) {
+          const patterns = STEP_ARTIFACTS[step];
+          if (!patterns) continue;
+
+          const files = [...new Set(patterns.flatMap((p) => listFiles(taskPath, p)))];
+          if (files.length === 0) continue;
+
+          if (!archived) {
+            fs.mkdirSync(runDir, { recursive: true });
+            archived = true;
+          }
+          const taskRunDir = path.join(runDir, taskDir);
+          fs.mkdirSync(taskRunDir, { recursive: true });
+
+          for (const filePath of files) {
+            const dest = path.join(taskRunDir, path.basename(filePath));
+            try {
+              fs.renameSync(filePath, dest);
+            } catch (e) {
+              process.stderr.write(
+                `work-orchestrator: failed to archive ${taskDir}/${path.basename(filePath)}: ${e?.message || e}\n`
+              );
+            }
           }
         }
       }
+    } catch {
+      /* ignore readdir failures */
     }
-  } catch {
-    /* ignore readdir failures */
-  }
 
   return archived ? `runs/run${runNum}` : null;
 }

--- a/workflows/work/check-gate.js
+++ b/workflows/work/check-gate.js
@@ -169,7 +169,8 @@ const CHECK_GATE_RULES = [
       const { validateTddEvidence } = require(path.join(__dirname, 'tdd-enforcement'));
       const taskParser = require(path.join(__dirname, 'task-parser'));
       const tasks = taskParser.parseTasks(dir);
-      if (!tasks || tasks.length === 0) return ['Unable to parse tasks.md — cannot verify per-task TDD evidence'];
+      if (!tasks || tasks.length === 0)
+        return ['Unable to parse tasks.md — cannot verify per-task TDD evidence'];
       const expectedTasks = tasks.filter((t) => !t.isCheckpoint);
       if (expectedTasks.length === 0) return []; // all checkpoint tasks
       const reasons = [];

--- a/workflows/work/cli.js
+++ b/workflows/work/cli.js
@@ -95,14 +95,7 @@ function main(deps) {
       const state = ticket ? inspect(ticket, providerConfig, suffix) : null;
       let result;
       try {
-        result = generatePlan(
-          ticket,
-          isTicket ? null : raw,
-          state,
-          rework,
-          providerConfig,
-          suffix
-        );
+        result = generatePlan(ticket, isTicket ? null : raw, state, rework, providerConfig, suffix);
       } catch (err) {
         console.log(JSON.stringify({ error: true, message: err?.message || String(err) }));
         process.exit(1);

--- a/workflows/work/hooks/__tests__/enforce-review-accountability.test.js
+++ b/workflows/work/hooks/__tests__/enforce-review-accountability.test.js
@@ -31,10 +31,7 @@ function createFixture(ticketId, { commentCount = 1, accountability = null } = {
   // Fake .git/HEAD
   const gitDir = path.join(base, '.git');
   fs.mkdirSync(gitDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(gitDir, 'HEAD'),
-    `ref: refs/heads/${ticketId}-fix-something\n`
-  );
+  fs.writeFileSync(path.join(gitDir, 'HEAD'), `ref: refs/heads/${ticketId}-fix-something\n`);
 
   // Fake gh script that returns PR number and comment count
   const binDir = path.join(base, 'bin');
@@ -92,8 +89,12 @@ function runHook(input, { cwd, envOverrides = {} } = {}) {
     });
     let stdout = '';
     let stderr = '';
-    proc.stdout.on('data', (d) => { stdout += d.toString(); });
-    proc.stderr.on('data', (d) => { stderr += d.toString(); });
+    proc.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    proc.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
     proc.on('close', (code) => resolve({ code, stderr, stdout }));
     proc.on('error', reject);
     proc.stdin.write(JSON.stringify(input));
@@ -113,9 +114,7 @@ describe('enforce-review-accountability: file field not required', () => {
   it('should ALLOW entries with disposition+reason but no file field (exit 0)', async () => {
     const fixture = createFixture('GH-285', {
       commentCount: 1,
-      accountability: [
-        { disposition: 'addressed', reason: 'Fixed in commit abc123' },
-      ],
+      accountability: [{ disposition: 'addressed', reason: 'Fixed in commit abc123' }],
     });
     cleanups.push(fixture.cleanup);
 
@@ -128,7 +127,8 @@ describe('enforce-review-accountability: file field not required', () => {
     });
 
     assert.strictEqual(
-      code, 0,
+      code,
+      0,
       `Expected exit 0 (allow) for entry without file field, got ${code}. stderr: ${stderr}`
     );
   });
@@ -136,9 +136,7 @@ describe('enforce-review-accountability: file field not required', () => {
   it('should still BLOCK entries missing disposition (exit 2)', async () => {
     const fixture = createFixture('GH-285', {
       commentCount: 1,
-      accountability: [
-        { reason: 'some reason but no disposition' },
-      ],
+      accountability: [{ reason: 'some reason but no disposition' }],
     });
     cleanups.push(fixture.cleanup);
 
@@ -157,9 +155,7 @@ describe('enforce-review-accountability: file field not required', () => {
   it('should still BLOCK entries missing reason (exit 2)', async () => {
     const fixture = createFixture('GH-285', {
       commentCount: 1,
-      accountability: [
-        { disposition: 'addressed' },
-      ],
+      accountability: [{ disposition: 'addressed' }],
     });
     cleanups.push(fixture.cleanup);
 
@@ -178,9 +174,7 @@ describe('enforce-review-accountability: file field not required', () => {
   it('should ALLOW entries that include file field alongside disposition+reason (exit 0)', async () => {
     const fixture = createFixture('GH-285', {
       commentCount: 1,
-      accountability: [
-        { file: 'src/index.js', disposition: 'outdated', reason: 'Code removed' },
-      ],
+      accountability: [{ file: 'src/index.js', disposition: 'outdated', reason: 'Code removed' }],
     });
     cleanups.push(fixture.cleanup);
 
@@ -193,7 +187,8 @@ describe('enforce-review-accountability: file field not required', () => {
     });
 
     assert.strictEqual(
-      code, 0,
+      code,
+      0,
       `Expected exit 0 (allow) for entry with file field present, got ${code}. stderr: ${stderr}`
     );
   });
@@ -202,7 +197,7 @@ describe('enforce-review-accountability: file field not required', () => {
     const fixture = createFixture('GH-285', {
       commentCount: 1,
       accountability: [
-        { file: 'src/index.js' },  // has file but missing disposition + reason
+        { file: 'src/index.js' }, // has file but missing disposition + reason
       ],
     });
     cleanups.push(fixture.cleanup);
@@ -229,7 +224,7 @@ describe('enforce-review-accountability: file field not required', () => {
   it('should not show file or line fields in schema documentation', async () => {
     const fixture = createFixture('GH-285', {
       commentCount: 1,
-      accountability: null,  // no file → triggers schema docs output
+      accountability: null, // no file → triggers schema docs output
     });
     cleanups.push(fixture.cleanup);
 

--- a/workflows/work/hooks/__tests__/protect-tasks-md.test.js
+++ b/workflows/work/hooks/__tests__/protect-tasks-md.test.js
@@ -45,10 +45,7 @@ function createStateFixture(ticketId, stepStatus = {}) {
     lastUpdate: new Date().toISOString(),
   };
 
-  fs.writeFileSync(
-    path.join(ticketDir, '.work-state.json'),
-    JSON.stringify(state, null, 2)
-  );
+  fs.writeFileSync(path.join(ticketDir, '.work-state.json'), JSON.stringify(state, null, 2));
 
   return {
     tasksBase,
@@ -209,7 +206,11 @@ describe('protect-tasks-md hook', () => {
       'GH-258',
       { implement: 'in_progress', tasks: 'completed', task_review: 'pending' }
     );
-    assert.strictEqual(code, 2, `Expected exit 2 (block) for GH-258, got ${code}. stderr: ${stderr}`);
+    assert.strictEqual(
+      code,
+      2,
+      `Expected exit 2 (block) for GH-258, got ${code}. stderr: ${stderr}`
+    );
     assert.ok(stderr.length > 0, 'Expected stderr message explaining block');
   });
 
@@ -242,7 +243,11 @@ describe('protect-tasks-md hook', () => {
         },
         { TASKS_BASE: fixture.tasksBase, TICKET_ID: 'GH-99' }
       );
-      assert.strictEqual(code, 2, `Expected exit 2 (block) for Bash redirect to tasks.md, got ${code}. stderr: ${stderr}`);
+      assert.strictEqual(
+        code,
+        2,
+        `Expected exit 2 (block) for Bash redirect to tasks.md, got ${code}. stderr: ${stderr}`
+      );
     } finally {
       fixture.cleanup();
     }
@@ -267,7 +272,11 @@ describe('protect-tasks-md hook', () => {
           TICKET_PROVIDER: 'github', // Required for #N → GH-N normalization
         }
       );
-      assert.strictEqual(code, 2, `Should block even when TICKET_ID needs normalization (#99 → GH-99), got ${code}. stderr: ${stderr}`);
+      assert.strictEqual(
+        code,
+        2,
+        `Should block even when TICKET_ID needs normalization (#99 → GH-99), got ${code}. stderr: ${stderr}`
+      );
     } finally {
       fixture.cleanup();
     }

--- a/workflows/work/hooks/protect-tasks-md.js
+++ b/workflows/work/hooks/protect-tasks-md.js
@@ -16,7 +16,9 @@
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
-const { createArtifactProtector } = require(path.join(__dirname, '..', '..', 'lib', 'protect-artifact-files'));
+const { createArtifactProtector } = require(
+  path.join(__dirname, '..', '..', 'lib', 'protect-artifact-files')
+);
 
 const ALLOWED_STEPS = new Set(['tasks', 'task_review']);
 
@@ -28,25 +30,35 @@ const ALLOWED_STEPS = new Set(['tasks', 'task_review']);
  */
 function getTicketId(hookData) {
   // Use TICKET_ID env var if set, otherwise derive from branch/cwd
-  const raw = process.env.TICKET_ID || (() => {
-    try {
-      const { getCurrentTaskId } = require(path.join(__dirname, '..', '..', 'lib', 'scripts', 'get-ticket-id'));
-      return getCurrentTaskId() || null;
-    } catch { return null; }
-  })();
+  const raw =
+    process.env.TICKET_ID ||
+    (() => {
+      try {
+        const { getCurrentTaskId } = require(
+          path.join(__dirname, '..', '..', 'lib', 'scripts', 'get-ticket-id')
+        );
+        return getCurrentTaskId() || null;
+      } catch {
+        return null;
+      }
+    })();
   if (!raw) return null;
   // Normalize (e.g., #99 → GH-99)
   let ticketId;
   try {
     ticketId = require(path.join(__dirname, '..', '..', 'lib', 'config')).safeTicketId(raw);
-  } catch { ticketId = raw; }
+  } catch {
+    ticketId = raw;
+  }
   // Fail-open: if work state doesn't exist, return null (no ticket context → allow)
   try {
     const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
     const tasksBase = getConfig.require('TASKS_BASE');
     const statePath = path.join(tasksBase, ticketId, '.work-state.json');
     if (!fs.existsSync(statePath)) return null;
-  } catch { return null; }
+  } catch {
+    return null;
+  }
   return ticketId;
 }
 
@@ -97,11 +109,16 @@ async function main() {
   const hookData = JSON.parse(input);
   const toolName = hookData.tool_name;
   const toolInput = hookData.tool_input || {};
-  const cmd = (toolInput.command || '');
+  const cmd = toolInput.command || '';
 
   // Additional Bash vector: resolve relative paths against cwd
   const ticketId = getTicketId(hookData);
-  if (toolName === 'Bash' && cmd.includes('tasks.md') && ticketId && !cmd.includes('/' + ticketId + '/')) {
+  if (
+    toolName === 'Bash' &&
+    cmd.includes('tasks.md') &&
+    ticketId &&
+    !cmd.includes('/' + ticketId + '/')
+  ) {
     try {
       const cwd = process.cwd();
       const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
@@ -110,11 +127,17 @@ async function main() {
         // We're inside the ticket directory — relative tasks.md is ticket-scoped
         const step = getStepInProgress(ticketId);
         if (!ALLOWED_STEPS.has(step)) {
-          process.stderr.write('BLOCKED: Bash write to tasks.md via relative path during ' + (step || 'unknown') + ' step.\n');
+          process.stderr.write(
+            'BLOCKED: Bash write to tasks.md via relative path during ' +
+              (step || 'unknown') +
+              ' step.\n'
+          );
           process.exit(2);
         }
       }
-    } catch { /* fail-open */ }
+    } catch {
+      /* fail-open */
+    }
   }
 
   const result = protector.check(toolName, toolInput, hookData);

--- a/workflows/work/hooks/work-require-implement.js
+++ b/workflows/work/hooks/work-require-implement.js
@@ -75,7 +75,11 @@ const ALLOWED_PATTERNS = [
   /\.prettierrc/, // Prettier config
   /package\.json$/, // Package files
   /tsconfig/, // TypeScript config
-  new RegExp(config.TASKS_BASE ? config.TASKS_BASE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : '__NO_TASKS_BASE__'), // Global task tracking files
+  new RegExp(
+    config.TASKS_BASE
+      ? config.TASKS_BASE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      : '__NO_TASKS_BASE__'
+  ), // Global task tracking files
   /\.task-/, // Task files
   /\/__tests__\//, // Test directories
   /\.test\.[jt]sx?$/, // .test.js, .test.ts, .test.tsx
@@ -208,7 +212,8 @@ function createAuditCallback(ticketId, toolName, filePath, ctx) {
       phase: null,
       action: `${toolName}:${filePath || 'unknown'}`,
       allow: entry.decision === 'allow',
-      reason: (entry.reasons || []).join('; ') || (entry.decision === 'allow' ? 'allowed' : 'denied'),
+      reason:
+        (entry.reasons || []).join('; ') || (entry.decision === 'allow' ? 'allowed' : 'denied'),
       outputPath: filePath || null,
     });
   };
@@ -296,7 +301,14 @@ async function main() {
   // ── Block with audit (R13) ───────────────────────────────────────────
   const auditCb = createAuditCallback(ticketId, toolName, filePath, ctx);
   runPreflight(
-    { ...ctx, error: { code: 'IMPLEMENT_REQUIRED', message: '/work-implement not invoked', remediation: ['Invoke /work-implement first'] } },
+    {
+      ...ctx,
+      error: {
+        code: 'IMPLEMENT_REQUIRED',
+        message: '/work-implement not invoked',
+        remediation: ['Invoke /work-implement first'],
+      },
+    },
     { audit: auditCb }
   );
 

--- a/workflows/work/inspect.js
+++ b/workflows/work/inspect.js
@@ -139,7 +139,13 @@ function inspect(ticket, providerConfig, suffix, deps) {
     const { validateTddEvidence } = require(path.join(__dirname, 'tdd-enforcement'));
     s.perTaskReports = {};
     const taskDirNames = listFiles(s.tasksDir, /^task\d+$/)
-      .filter((fp) => { try { return fs.statSync(fp).isDirectory(); } catch { return false; } })
+      .filter((fp) => {
+        try {
+          return fs.statSync(fp).isDirectory();
+        } catch {
+          return false;
+        }
+      })
       .map((fp) => path.basename(fp));
     for (const taskDirName of taskDirNames) {
       const taskDir = path.join(s.tasksDir, taskDirName);
@@ -153,7 +159,9 @@ function inspect(ticket, providerConfig, suffix, deps) {
           const validation = validateTddEvidence(tddData);
           const hasException =
             (typeof tddData.exception === 'string' && tddData.exception.trim() !== '') ||
-            (typeof tddData.exception === 'object' && tddData.exception !== null && typeof tddData.exception.category === 'string');
+            (typeof tddData.exception === 'object' &&
+              tddData.exception !== null &&
+              typeof tddData.exception.category === 'string');
           taskReport.tddPhase = {
             exists: true,
             valid: validation.valid,

--- a/workflows/work/lib/__tests__/open-questions.test.js
+++ b/workflows/work/lib/__tests__/open-questions.test.js
@@ -358,9 +358,7 @@ describe('open-questions: applyResolutions', () => {
   });
 
   it('rewrites a single unresolved architectural block with resolved: true and a Resolution line', () => {
-    const resolutions = new Map([
-      ['Should the gate be a hook or a step?', 'It should be a step.'],
-    ]);
+    const resolutions = new Map([['Should the gate be a hook or a step?', 'It should be a step.']]);
     const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
 
     // The result is still a string containing the original heading and summary.
@@ -451,27 +449,23 @@ describe('open-questions: applyResolutions', () => {
 
   it('preserves the Question[] count after a rewrite (no block corruption)', () => {
     const before = parse(FIXTURE_MULTIPLE_MIXED).length;
-    const resolutions = new Map([
-      ['How do siblings coordinate router ownership?', 'answer'],
-    ]);
+    const resolutions = new Map([['How do siblings coordinate router ownership?', 'answer']]);
     const after = parse(applyResolutions(FIXTURE_MULTIPLE_MIXED, resolutions)).length;
     assert.equal(after, before);
   });
 
   it('preserves surrounding markdown byte-for-byte outside the changed block', () => {
-    const resolutions = new Map([
-      ['Should the gate be a hook or a step?', 'A step.'],
-    ]);
+    const resolutions = new Map([['Should the gate be a hook or a step?', 'A step.']]);
     const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
     // Heading, summary, and section header are unchanged verbatim.
-    assert.ok(result.startsWith('# Product Brief\n\n## Summary\nExample brief.\n\n## Open Questions\n'));
+    assert.ok(
+      result.startsWith('# Product Brief\n\n## Summary\nExample brief.\n\n## Open Questions\n')
+    );
   });
 
   it('escapes injection: leading "##" heading in answer does not create a new section', () => {
     const malicious = '## Injected Heading\nmore stuff';
-    const resolutions = new Map([
-      ['Should the gate be a hook or a step?', malicious],
-    ]);
+    const resolutions = new Map([['Should the gate be a hook or a step?', malicious]]);
     const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
 
     // Re-parse: still exactly one question, resolved.
@@ -486,9 +480,7 @@ describe('open-questions: applyResolutions', () => {
 
   it('collapses multi-line answers to a single line', () => {
     const multi = 'line one\nline two\nline three';
-    const resolutions = new Map([
-      ['Should the gate be a hook or a step?', multi],
-    ]);
+    const resolutions = new Map([['Should the gate be a hook or a step?', multi]]);
     const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
     const parsed = parse(result);
     assert.equal(parsed.length, 1);
@@ -509,9 +501,7 @@ describe('open-questions: applyResolutions', () => {
     // returns `''`. An empty-after-escape answer must not produce a
     // dangling `- **Resolution:** ` line with empty content — the block
     // should remain unresolved so the gate re-prompts on the next pass.
-    const resolutions = new Map([
-      ['Should the gate be a hook or a step?', '###'],
-    ]);
+    const resolutions = new Map([['Should the gate be a hook or a step?', '###']]);
     const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
 
     // Byte-equal to the input: no rewrite occurred.
@@ -559,9 +549,7 @@ describe('open-questions: applyResolutions', () => {
 
   it('is a no-op when the answer is pure whitespace that collapses to empty', () => {
     // `escapeResolution('## ')` also returns `''`; same contract applies.
-    const resolutions = new Map([
-      ['Should the gate be a hook or a step?', '## '],
-    ]);
+    const resolutions = new Map([['Should the gate be a hook or a step?', '## ']]);
     const result = applyResolutions(FIXTURE_SINGLE_STRUCTURED, resolutions);
     assert.equal(result, FIXTURE_SINGLE_STRUCTURED);
   });

--- a/workflows/work/lib/__tests__/parse-gherkin.test.js
+++ b/workflows/work/lib/__tests__/parse-gherkin.test.js
@@ -296,7 +296,22 @@ describe('parse-gherkin: validate', () => {
 
   it('fails when scenario count is below threshold', () => {
     const parseResult = {
-      features: [{ name: 'F', scenarios: [{ name: 'S', tags: ['@integration'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] }] }],
+      features: [
+        {
+          name: 'F',
+          scenarios: [
+            {
+              name: 'S',
+              tags: ['@integration'],
+              steps: [
+                { keyword: 'Given', text: 'x' },
+                { keyword: 'When', text: 'y' },
+                { keyword: 'Then', text: 'z' },
+              ],
+            },
+          ],
+        },
+      ],
       errors: [],
     };
     const result = validate(parseResult, { minScenarios: 2 });
@@ -308,13 +323,31 @@ describe('parse-gherkin: validate', () => {
 
   it('passes when scenario count is exactly at threshold', () => {
     const parseResult = {
-      features: [{
-        name: 'F',
-        scenarios: [
-          { name: 'S1', tags: ['@integration'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] },
-          { name: 'S2', tags: [], steps: [{ keyword: 'Given', text: 'a' }, { keyword: 'When', text: 'b' }, { keyword: 'Then', text: 'c' }] },
-        ],
-      }],
+      features: [
+        {
+          name: 'F',
+          scenarios: [
+            {
+              name: 'S1',
+              tags: ['@integration'],
+              steps: [
+                { keyword: 'Given', text: 'x' },
+                { keyword: 'When', text: 'y' },
+                { keyword: 'Then', text: 'z' },
+              ],
+            },
+            {
+              name: 'S2',
+              tags: [],
+              steps: [
+                { keyword: 'Given', text: 'a' },
+                { keyword: 'When', text: 'b' },
+                { keyword: 'Then', text: 'c' },
+              ],
+            },
+          ],
+        },
+      ],
       errors: [],
     };
     const result = validate(parseResult, { minScenarios: 2, requireTags: ['@integration'] });
@@ -329,13 +362,31 @@ describe('parse-gherkin: validate', () => {
 
   it('fails when neither @integration nor @e2e tag is present (default OR semantics)', () => {
     const parseResult = {
-      features: [{
-        name: 'F',
-        scenarios: [
-          { name: 'S1', tags: ['@unit'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] },
-          { name: 'S2', tags: ['@unit'], steps: [{ keyword: 'Given', text: 'a' }, { keyword: 'When', text: 'b' }, { keyword: 'Then', text: 'c' }] },
-        ],
-      }],
+      features: [
+        {
+          name: 'F',
+          scenarios: [
+            {
+              name: 'S1',
+              tags: ['@unit'],
+              steps: [
+                { keyword: 'Given', text: 'x' },
+                { keyword: 'When', text: 'y' },
+                { keyword: 'Then', text: 'z' },
+              ],
+            },
+            {
+              name: 'S2',
+              tags: ['@unit'],
+              steps: [
+                { keyword: 'Given', text: 'a' },
+                { keyword: 'When', text: 'b' },
+                { keyword: 'Then', text: 'c' },
+              ],
+            },
+          ],
+        },
+      ],
       errors: [],
     };
     const result = validate(parseResult);
@@ -345,13 +396,31 @@ describe('parse-gherkin: validate', () => {
 
   it('passes when only @integration is present (OR semantics)', () => {
     const parseResult = {
-      features: [{
-        name: 'F',
-        scenarios: [
-          { name: 'S1', tags: ['@integration'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] },
-          { name: 'S2', tags: [], steps: [{ keyword: 'Given', text: 'a' }, { keyword: 'When', text: 'b' }, { keyword: 'Then', text: 'c' }] },
-        ],
-      }],
+      features: [
+        {
+          name: 'F',
+          scenarios: [
+            {
+              name: 'S1',
+              tags: ['@integration'],
+              steps: [
+                { keyword: 'Given', text: 'x' },
+                { keyword: 'When', text: 'y' },
+                { keyword: 'Then', text: 'z' },
+              ],
+            },
+            {
+              name: 'S2',
+              tags: [],
+              steps: [
+                { keyword: 'Given', text: 'a' },
+                { keyword: 'When', text: 'b' },
+                { keyword: 'Then', text: 'c' },
+              ],
+            },
+          ],
+        },
+      ],
       errors: [],
     };
     const result = validate(parseResult);
@@ -360,13 +429,31 @@ describe('parse-gherkin: validate', () => {
 
   it('passes when only @e2e is present (OR semantics)', () => {
     const parseResult = {
-      features: [{
-        name: 'F',
-        scenarios: [
-          { name: 'S1', tags: ['@e2e'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] },
-          { name: 'S2', tags: [], steps: [{ keyword: 'Given', text: 'a' }, { keyword: 'When', text: 'b' }, { keyword: 'Then', text: 'c' }] },
-        ],
-      }],
+      features: [
+        {
+          name: 'F',
+          scenarios: [
+            {
+              name: 'S1',
+              tags: ['@e2e'],
+              steps: [
+                { keyword: 'Given', text: 'x' },
+                { keyword: 'When', text: 'y' },
+                { keyword: 'Then', text: 'z' },
+              ],
+            },
+            {
+              name: 'S2',
+              tags: [],
+              steps: [
+                { keyword: 'Given', text: 'a' },
+                { keyword: 'When', text: 'b' },
+                { keyword: 'Then', text: 'c' },
+              ],
+            },
+          ],
+        },
+      ],
       errors: [],
     };
     const result = validate(parseResult);
@@ -375,12 +462,22 @@ describe('parse-gherkin: validate', () => {
 
   it('supports custom options override', () => {
     const parseResult = {
-      features: [{
-        name: 'F',
-        scenarios: [
-          { name: 'S1', tags: ['@e2e'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] },
-        ],
-      }],
+      features: [
+        {
+          name: 'F',
+          scenarios: [
+            {
+              name: 'S1',
+              tags: ['@e2e'],
+              steps: [
+                { keyword: 'Given', text: 'x' },
+                { keyword: 'When', text: 'y' },
+                { keyword: 'Then', text: 'z' },
+              ],
+            },
+          ],
+        },
+      ],
       errors: [],
     };
     const result = validate(parseResult, { minScenarios: 1, requireTags: ['@e2e'] });
@@ -398,10 +495,28 @@ describe('parse-gherkin: validate', () => {
 
   it('reports single error when none of the required tags are present (OR semantics)', () => {
     const parseResult = {
-      features: [{ name: 'F', scenarios: [{ name: 'S', tags: ['@unit'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] }] }],
+      features: [
+        {
+          name: 'F',
+          scenarios: [
+            {
+              name: 'S',
+              tags: ['@unit'],
+              steps: [
+                { keyword: 'Given', text: 'x' },
+                { keyword: 'When', text: 'y' },
+                { keyword: 'Then', text: 'z' },
+              ],
+            },
+          ],
+        },
+      ],
       errors: [],
     };
-    const result = validate(parseResult, { minScenarios: 1, requireTags: ['@integration', '@e2e'] });
+    const result = validate(parseResult, {
+      minScenarios: 1,
+      requireTags: ['@integration', '@e2e'],
+    });
     assert.equal(result.valid, false);
     assert.equal(result.errors.length, 1);
     assert.ok(result.errors[0].includes('@integration'));
@@ -421,13 +536,30 @@ describe('parse-gherkin: validate', () => {
 
   it('fails when scenario is missing When step', () => {
     const parseResult = {
-      features: [{
-        name: 'F',
-        scenarios: [
-          { name: 'Missing When', tags: ['@integration'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'Then', text: 'z' }] },
-          { name: 'Complete', tags: [], steps: [{ keyword: 'Given', text: 'a' }, { keyword: 'When', text: 'b' }, { keyword: 'Then', text: 'c' }] },
-        ],
-      }],
+      features: [
+        {
+          name: 'F',
+          scenarios: [
+            {
+              name: 'Missing When',
+              tags: ['@integration'],
+              steps: [
+                { keyword: 'Given', text: 'x' },
+                { keyword: 'Then', text: 'z' },
+              ],
+            },
+            {
+              name: 'Complete',
+              tags: [],
+              steps: [
+                { keyword: 'Given', text: 'a' },
+                { keyword: 'When', text: 'b' },
+                { keyword: 'Then', text: 'c' },
+              ],
+            },
+          ],
+        },
+      ],
       errors: [],
     };
     const result = validate(parseResult, { minScenarios: 1, requireTags: ['@integration'] });
@@ -437,13 +569,30 @@ describe('parse-gherkin: validate', () => {
 
   it('fails when scenario has only Given and Then (missing When mentioned)', () => {
     const parseResult = {
-      features: [{
-        name: 'F',
-        scenarios: [
-          { name: 'Incomplete scenario', tags: ['@e2e'], steps: [{ keyword: 'Given', text: 'setup' }, { keyword: 'Then', text: 'result' }] },
-          { name: 'Full', tags: [], steps: [{ keyword: 'Given', text: 'a' }, { keyword: 'When', text: 'b' }, { keyword: 'Then', text: 'c' }] },
-        ],
-      }],
+      features: [
+        {
+          name: 'F',
+          scenarios: [
+            {
+              name: 'Incomplete scenario',
+              tags: ['@e2e'],
+              steps: [
+                { keyword: 'Given', text: 'setup' },
+                { keyword: 'Then', text: 'result' },
+              ],
+            },
+            {
+              name: 'Full',
+              tags: [],
+              steps: [
+                { keyword: 'Given', text: 'a' },
+                { keyword: 'When', text: 'b' },
+                { keyword: 'Then', text: 'c' },
+              ],
+            },
+          ],
+        },
+      ],
       errors: [],
     };
     const result = validate(parseResult, { minScenarios: 1, requireTags: ['@e2e'] });
@@ -458,19 +607,33 @@ describe('parse-gherkin: validate', () => {
 
   it('passes when scenario has Given/When/Then plus And (And extends previous)', () => {
     const parseResult = {
-      features: [{
-        name: 'F',
-        scenarios: [
-          { name: 'With And', tags: ['@integration'], steps: [
-            { keyword: 'Given', text: 'setup' },
-            { keyword: 'And', text: 'more setup' },
-            { keyword: 'When', text: 'action' },
-            { keyword: 'Then', text: 'result' },
-            { keyword: 'And', text: 'another result' },
-          ]},
-          { name: 'Simple', tags: [], steps: [{ keyword: 'Given', text: 'a' }, { keyword: 'When', text: 'b' }, { keyword: 'Then', text: 'c' }] },
-        ],
-      }],
+      features: [
+        {
+          name: 'F',
+          scenarios: [
+            {
+              name: 'With And',
+              tags: ['@integration'],
+              steps: [
+                { keyword: 'Given', text: 'setup' },
+                { keyword: 'And', text: 'more setup' },
+                { keyword: 'When', text: 'action' },
+                { keyword: 'Then', text: 'result' },
+                { keyword: 'And', text: 'another result' },
+              ],
+            },
+            {
+              name: 'Simple',
+              tags: [],
+              steps: [
+                { keyword: 'Given', text: 'a' },
+                { keyword: 'When', text: 'b' },
+                { keyword: 'Then', text: 'c' },
+              ],
+            },
+          ],
+        },
+      ],
       errors: [],
     };
     const result = validate(parseResult, { minScenarios: 1, requireTags: ['@integration'] });

--- a/workflows/work/lib/open-questions.js
+++ b/workflows/work/lib/open-questions.js
@@ -351,7 +351,10 @@ function normalizeResolutions(resolutions) {
  * says `resolved: true`, return it unchanged.
  */
 function flipResolvedLine(line) {
-  return line.replace(/(`resolved:\s*)(false)(\s*`)/i, (_m, pre, _val, post) => `${pre}true${post}`);
+  return line.replace(
+    /(`resolved:\s*)(false)(\s*`)/i,
+    (_m, pre, _val, post) => `${pre}true${post}`
+  );
 }
 
 /**
@@ -459,7 +462,10 @@ function applyResolutions(markdown, resolutions) {
       let indent = '  ';
       for (const bl of blockLines) {
         const m = bl.match(/^(\s{2,})-\s+/);
-        if (m) { indent = m[1]; break; }
+        if (m) {
+          indent = m[1];
+          break;
+        }
       }
       lines.splice(insertionPoint, 0, `${indent}- \`resolved: true\``);
       insertionPoint++; // Resolution line goes AFTER resolved: true

--- a/workflows/work/lib/parse-gherkin.js
+++ b/workflows/work/lib/parse-gherkin.js
@@ -183,20 +183,15 @@ function parse(markdown) {
  * @returns {{ valid: boolean, errors: string[] }}
  */
 function validate(parseResult, options) {
-  const minScenarios = (options && options.minScenarios !== undefined)
-    ? options.minScenarios
-    : DEFAULT_MIN_SCENARIOS;
-  const requireTags = (options && options.requireTags !== undefined)
-    ? options.requireTags
-    : DEFAULT_REQUIRED_TAGS;
+  const minScenarios =
+    options && options.minScenarios !== undefined ? options.minScenarios : DEFAULT_MIN_SCENARIOS;
+  const requireTags =
+    options && options.requireTags !== undefined ? options.requireTags : DEFAULT_REQUIRED_TAGS;
 
   const validationErrors = [];
 
   // Count total scenarios across all features
-  const totalScenarios = parseResult.features.reduce(
-    (sum, f) => sum + f.scenarios.length,
-    0
-  );
+  const totalScenarios = parseResult.features.reduce((sum, f) => sum + f.scenarios.length, 0);
 
   if (totalScenarios < minScenarios) {
     validationErrors.push(

--- a/workflows/work/plan-generator.js
+++ b/workflows/work/plan-generator.js
@@ -171,7 +171,7 @@ function validatePlan(plan) {
     if (entry.action === 'SKIP') {
       throw new Error(
         `Plan validation failed: step "${entry.step}" has forbidden action "SKIP". ` +
-        `All steps must use RUN or DEFER.`
+          `All steps must use RUN or DEFER.`
       );
     }
   }

--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -194,7 +194,11 @@ describe('classifyCommentPriority', () => {
 });
 
 describe('isBotAuthorLogin', () => {
-  const defaultBots = ['copilot-pull-request-reviewer', 'cursor-ai[bot]', 'chatgpt-codex-connector[bot]'];
+  const defaultBots = [
+    'copilot-pull-request-reviewer',
+    'cursor-ai[bot]',
+    'chatgpt-codex-connector[bot]',
+  ];
 
   it('returns true for chatgpt-codex-connector[bot]', () => {
     assert.equal(isBotAuthorLogin('chatgpt-codex-connector[bot]', defaultBots), true);

--- a/workflows/work/scripts/__tests__/review-accountability.test.js
+++ b/workflows/work/scripts/__tests__/review-accountability.test.js
@@ -3,9 +3,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const {
-  buildAccountabilityEntries,
-} = require('../follow-up-pr.js');
+const { buildAccountabilityEntries } = require('../follow-up-pr.js');
 
 describe('buildAccountabilityEntries', () => {
   it('marks blocking comments as addressed', () => {
@@ -20,9 +18,7 @@ describe('buildAccountabilityEntries', () => {
 
   it('marks deduplicated comments as addressed', () => {
     const blocking = [];
-    const nonBlocking = [
-      { id: 2, author: 'bob', body: 'Nit: rename var', deduplicated: true },
-    ];
+    const nonBlocking = [{ id: 2, author: 'bob', body: 'Nit: rename var', deduplicated: true }];
     const entries = buildAccountabilityEntries(blocking, nonBlocking);
 
     assert.equal(entries.length, 1);
@@ -32,9 +28,7 @@ describe('buildAccountabilityEntries', () => {
 
   it('marks non-blocking non-deduplicated comments as acknowledged (not deferred)', () => {
     const blocking = [];
-    const nonBlocking = [
-      { id: 3, author: 'carol', body: 'Consider renaming' },
-    ];
+    const nonBlocking = [{ id: 3, author: 'carol', body: 'Consider renaming' }];
     const entries = buildAccountabilityEntries(blocking, nonBlocking);
 
     assert.equal(entries.length, 1);
@@ -79,7 +73,10 @@ describe('review-accountability error handling', () => {
     // Capture stderr output
     const stderrChunks = [];
     const origWrite = process.stderr.write;
-    process.stderr.write = (chunk) => { stderrChunks.push(String(chunk)); return true; };
+    process.stderr.write = (chunk) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    };
 
     try {
       // Simulate the catch block behavior from follow-up-pr.js
@@ -87,7 +84,7 @@ describe('review-accountability error handling', () => {
       // This mirrors the exact catch block at lines 1476-1480
       process.stderr.write(
         `WARNING: Failed to write review-accountability.json: ${err.message}\n` +
-        `The follow_up → ci transition gate will block until this file exists.\n`
+          `The follow_up → ci transition gate will block until this file exists.\n`
       );
 
       const output = stderrChunks.join('');

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -280,7 +280,8 @@ function checkCI(prNumber) {
 // ── Reviews ─────────────────────────────────────────────────────────────────
 
 // Aliases for each bot are in botLoginAliases (see getReviews)
-const DEFAULT_BOT_REVIEWERS = 'copilot-pull-request-reviewer,cursor-ai[bot],chatgpt-codex-connector[bot]';
+const DEFAULT_BOT_REVIEWERS =
+  'copilot-pull-request-reviewer,cursor-ai[bot],chatgpt-codex-connector[bot]';
 
 function getBotReviewers() {
   const env = process.env.FOLLOW_UP_PR_BOT_REVIEWERS;
@@ -1382,7 +1383,9 @@ async function main() {
           const staleTag = item.stale ? c.dim(' (stale)') : '';
           const dedupTag = item.deduplicated ? c.dim(' (deduped)') : '';
           console.log('');
-          console.log(`  ${c.cyan(`Comment ${i + 1}:`)} @${item.author} [${priority}]${staleTag}${dedupTag} ${loc}`);
+          console.log(
+            `  ${c.cyan(`Comment ${i + 1}:`)} @${item.author} [${priority}]${staleTag}${dedupTag} ${loc}`
+          );
           console.log(`  ${c.dim('─'.repeat(60))}`);
           console.log(`  ${(item.body || '').trim()}`);
           console.log(`  ${c.dim('─'.repeat(60))}`);
@@ -1476,7 +1479,7 @@ async function main() {
         const errMsg = String(err && err.message ? err.message : err);
         process.stderr.write(
           `WARNING: Failed to write review-accountability.json: ${errMsg}\n` +
-          `The follow_up → ci transition gate will block until this file exists.\n`
+            `The follow_up → ci transition gate will block until this file exists.\n`
         );
       }
 
@@ -1528,12 +1531,10 @@ function isPRGateReady() {
   let strictCommentCount = 0;
   try {
     const repo = ghExec('repo view --json nameWithOwner').nameWithOwner;
-    const comments = ghExec([
-      'api',
-      `repos/${repo}/pulls/${prInfo.number}/comments`,
-      '--jq',
-      'length',
-    ], { json: false });
+    const comments = ghExec(
+      ['api', `repos/${repo}/pulls/${prInfo.number}/comments`, '--jq', 'length'],
+      { json: false }
+    );
     strictCommentCount = parseInt(comments, 10) || 0;
   } catch {
     // Cannot verify comment count — fail closed
@@ -1544,13 +1545,15 @@ function isPRGateReady() {
   let currentHead = null;
   try {
     currentHead = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
-  } catch { /* non-fatal */ }
+  } catch {
+    /* non-fatal */
+  }
 
   const state = loadState(prInfo.number);
   const previousRunBotHashes = state
-    ? (state.previousRunBotHashes && state.previousRunBotHashes.length > 0
-        ? state.previousRunBotHashes
-        : (state.addressedBotComments || []).map((a) => a.hash))
+    ? state.previousRunBotHashes && state.previousRunBotHashes.length > 0
+      ? state.previousRunBotHashes
+      : (state.addressedBotComments || []).map((a) => a.hash)
     : [];
 
   const deduped = deduplicateBlockingBotComments(

--- a/workflows/work/steps/__tests__/brief-gate.test.js
+++ b/workflows/work/steps/__tests__/brief-gate.test.js
@@ -180,9 +180,17 @@ describe('brief-gate step', () => {
     );
     assert.equal(entry.onResolve, 'rewrite brief.md');
     assert.equal(entry.agentType, 'general-purpose', 'AskUserQuestion RUN must specify agentType');
-    assert.equal(typeof entry.agentPrompt, 'string', 'AskUserQuestion RUN must carry agentPrompt string');
+    assert.equal(
+      typeof entry.agentPrompt,
+      'string',
+      'AskUserQuestion RUN must carry agentPrompt string'
+    );
     assert.match(entry.agentPrompt, /AskUserQuestion/, 'agentPrompt must mention AskUserQuestion');
-    assert.match(entry.agentPrompt, /applyBriefResolutions/, 'agentPrompt must mention applyBriefResolutions');
+    assert.match(
+      entry.agentPrompt,
+      /applyBriefResolutions/,
+      'agentPrompt must mention applyBriefResolutions'
+    );
   });
 
   it('RUN entry includes postResolveCommand referencing applyBriefResolutions', () => {
@@ -193,11 +201,31 @@ describe('brief-gate step', () => {
     assert.equal(entries.length, 1);
     const entry = entries[0];
     assert.equal(entry.action, 'RUN');
-    assert.equal(typeof entry.postResolveCommand, 'string', 'RUN entry must carry postResolveCommand string');
-    assert.match(entry.postResolveCommand, /applyBriefResolutions/, 'postResolveCommand must reference applyBriefResolutions');
-    assert.match(entry.postResolveCommand, /brief-gate\.js/, 'postResolveCommand must require brief-gate.js');
-    assert.match(entry.postResolveCommand, /\$RESOLUTIONS_JSON/, 'postResolveCommand must reference $RESOLUTIONS_JSON placeholder');
-    assert.match(entry.postResolveCommand, /node -e/, 'postResolveCommand must be a node -e one-liner');
+    assert.equal(
+      typeof entry.postResolveCommand,
+      'string',
+      'RUN entry must carry postResolveCommand string'
+    );
+    assert.match(
+      entry.postResolveCommand,
+      /applyBriefResolutions/,
+      'postResolveCommand must reference applyBriefResolutions'
+    );
+    assert.match(
+      entry.postResolveCommand,
+      /brief-gate\.js/,
+      'postResolveCommand must require brief-gate.js'
+    );
+    assert.match(
+      entry.postResolveCommand,
+      /\$RESOLUTIONS_JSON/,
+      'postResolveCommand must reference $RESOLUTIONS_JSON placeholder'
+    );
+    assert.match(
+      entry.postResolveCommand,
+      /node -e/,
+      'postResolveCommand must be a node -e one-liner'
+    );
     // Verify the path includes the actual briefPath (tasks dir + brief.md)
     const expectedBriefPath = path.join(dir, 'brief.md');
     assert.ok(
@@ -217,7 +245,11 @@ describe('brief-gate step', () => {
     assert.match(entries[0].reason, /unreadable|regenerate/i);
     assert.equal(entries[0].command, '/brief', 'unreadable RUN must carry /brief command');
     assert.equal(entries[0].agentType, 'skill', 'unreadable RUN must specify agentType: skill');
-    assert.equal(entries[0].agentPrompt, '/brief', 'unreadable RUN must specify agentPrompt: /brief');
+    assert.equal(
+      entries[0].agentPrompt,
+      '/brief',
+      'unreadable RUN must specify agentPrompt: /brief'
+    );
   });
 
   describe('applyBriefResolutions (post-resolve handler)', () => {

--- a/workflows/work/steps/__tests__/brief.test.js
+++ b/workflows/work/steps/__tests__/brief.test.js
@@ -93,7 +93,6 @@ describe('brief step (GH-253)', () => {
   });
 
   it('RUNs when brief.md is missing (hasBrief=false)', () => {
-
     const { add, entries } = makeAdd();
     briefStep(add, makeState({ hasBrief: false }), makeCtx());
     assert.equal(entries.length, 1);
@@ -102,7 +101,6 @@ describe('brief step (GH-253)', () => {
   });
 
   it('DEFERs when brief.md already exists (hasBrief=true)', () => {
-
     const { add, entries } = makeAdd();
     briefStep(add, makeState({ hasBrief: true }), makeCtx());
     assert.equal(entries.length, 1);
@@ -112,7 +110,6 @@ describe('brief step (GH-253)', () => {
   });
 
   it('RUNs with correct agent type and prompt when brief is missing', () => {
-
     const { add, entries } = makeAdd();
     briefStep(add, makeState({ hasBrief: false }), makeCtx());
     const entry = entries[0];

--- a/workflows/work/steps/__tests__/spec.test.js
+++ b/workflows/work/steps/__tests__/spec.test.js
@@ -92,10 +92,7 @@ describe('spec step (GH-253)', () => {
 
   it('does not reference WORK_SPEC_ENABLED in source code', () => {
     const source = fs.readFileSync(path.join(__dirname, '..', 'spec.js'), 'utf8');
-    assert.ok(
-      !source.includes('WORK_SPEC_ENABLED'),
-      'spec.js must not contain WORK_SPEC_ENABLED'
-    );
+    assert.ok(!source.includes('WORK_SPEC_ENABLED'), 'spec.js must not contain WORK_SPEC_ENABLED');
   });
 
   it('does not reference WORK_BRIEF_ENABLED in source code', () => {
@@ -107,7 +104,6 @@ describe('spec step (GH-253)', () => {
   });
 
   it('RUNs when spec.md is missing (hasSpec=false)', () => {
-
     const { add, entries } = makeAdd();
     specStep(add, makeState({ hasSpec: false }), makeCtx());
     assert.equal(entries.length, 1);
@@ -116,7 +112,6 @@ describe('spec step (GH-253)', () => {
   });
 
   it('DEFERs when spec.md already exists (hasSpec=true)', () => {
-
     const { add, entries } = makeAdd();
     specStep(add, makeState({ hasSpec: true }), makeCtx());
     assert.equal(entries.length, 1);
@@ -126,7 +121,6 @@ describe('spec step (GH-253)', () => {
   });
 
   it('includes briefRef when brief.md file exists on disk', () => {
-
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => true });
     specStep(add, makeState({ hasSpec: false }), ctx);
@@ -134,7 +128,6 @@ describe('spec step (GH-253)', () => {
   });
 
   it('includes briefRef when brief.md does not exist but hasBrief is false (will be generated)', () => {
-
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => false });
     specStep(add, makeState({ hasSpec: false, hasBrief: false }), ctx);
@@ -158,7 +151,6 @@ describe('spec step (GH-253)', () => {
   });
 
   it('RUNs with correct agent type', () => {
-
     const { add, entries } = makeAdd();
     specStep(add, makeState({ hasSpec: false }), makeCtx());
     assert.equal(entries[0].agentType, 'spec-writer');

--- a/workflows/work/steps/__tests__/task-review-step.test.js
+++ b/workflows/work/steps/__tests__/task-review-step.test.js
@@ -92,7 +92,9 @@ describe('task-review step', () => {
     ];
     const s = makeState({
       hasTasks: true,
-      workState: { tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task-1' }, { id: 'task-2' }] } },
+      workState: {
+        tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task-1' }, { id: 'task-2' }] },
+      },
     });
     const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
     taskReviewStep(add, s, ctx);
@@ -200,11 +202,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 0 },
-            { id: 'task-2' },
-            { id: 'task-3' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 0 }, { id: 'task-2' }, { id: 'task-3' }],
         },
       },
     });
@@ -231,10 +229,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 0 },
-            { id: 'task-2' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 0 }, { id: 'task-2' }],
         },
       },
     });
@@ -258,10 +253,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 2 },
-            { id: 'task-2' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 2 }, { id: 'task-2' }],
         },
       },
     });
@@ -287,10 +279,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 1 },
-            { id: 'task-2' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 1 }, { id: 'task-2' }],
         },
       },
     });
@@ -311,10 +300,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 1 },
-            { id: 'task-2' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 1 }, { id: 'task-2' }],
         },
       },
     });
@@ -339,11 +325,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 0 },
-            { id: 'task-2' },
-            { id: 'task-3' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 0 }, { id: 'task-2' }, { id: 'task-3' }],
         },
       },
     });
@@ -367,11 +349,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 0 },
-            { id: 'task-2' },
-            { id: 'task-3' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 0 }, { id: 'task-2' }, { id: 'task-3' }],
         },
       },
     });
@@ -396,11 +374,7 @@ describe('task-review step', () => {
       workState: {
         tasksMeta: {
           currentTaskIndex: 0,
-          tasks: [
-            { id: 'task-1', taskReviewFixRounds: 0 },
-            { id: 'task-2' },
-            { id: 'task-3' },
-          ],
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 0 }, { id: 'task-2' }, { id: 'task-3' }],
         },
       },
     });
@@ -436,7 +410,11 @@ describe('task-review step', () => {
 
     it('exports taskReviewStep as a named export', () => {
       const barrel = require(path.join(__dirname, '..', 'index.js'));
-      assert.equal(typeof barrel.taskReviewStep, 'function', 'steps/index.js should export taskReviewStep');
+      assert.equal(
+        typeof barrel.taskReviewStep,
+        'function',
+        'steps/index.js should export taskReviewStep'
+      );
     });
   });
 });

--- a/workflows/work/steps/__tests__/tasks.test.js
+++ b/workflows/work/steps/__tests__/tasks.test.js
@@ -95,7 +95,6 @@ describe('tasks step (GH-253)', () => {
   });
 
   it('DEFERs when tasks.md already exists (hasTasks=true)', () => {
-
     const { add, entries } = makeAdd();
     tasksStep(add, makeState({ hasTasks: true }), makeCtx());
     assert.equal(entries.length, 1);
@@ -105,7 +104,6 @@ describe('tasks step (GH-253)', () => {
   });
 
   it('RUNs when spec.md exists and tasks.md is missing', () => {
-
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => true });
     tasksStep(add, makeState({ hasTasks: false }), ctx);
@@ -115,7 +113,6 @@ describe('tasks step (GH-253)', () => {
   });
 
   it('DEFERs when spec.md is missing (cannot generate tasks)', () => {
-
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => false });
     tasksStep(add, makeState({ hasTasks: false }), ctx);
@@ -136,7 +133,6 @@ describe('tasks step (GH-253)', () => {
   });
 
   it('RUNs with correct agent type and prompt', () => {
-
     const { add, entries } = makeAdd();
     const ctx = makeCtx({ fileExists: () => true });
     tasksStep(add, makeState({ hasTasks: false }), ctx);

--- a/workflows/work/steps/brief-gate.js
+++ b/workflows/work/steps/brief-gate.js
@@ -70,10 +70,16 @@ function briefGateStep(add, s, ctx) {
     // returns false on read errors (fail-closed), so emitting DEFER here
     // would create a confusing mismatch ("gate deferred" yet transition
     // blocked). RUN with a helpful message signals the issue clearly.
-    add(STEPS.brief_gate, 'RUN', '/brief', 'brief.md unreadable — regenerate brief before proceeding', {
-      agentType: 'skill',
-      agentPrompt: '/brief',
-    });
+    add(
+      STEPS.brief_gate,
+      'RUN',
+      '/brief',
+      'brief.md unreadable — regenerate brief before proceeding',
+      {
+        agentType: 'skill',
+        agentPrompt: '/brief',
+      }
+    );
     return; // fail-closed: verify() also returns false on read errors — aligned
   }
 

--- a/workflows/work/steps/implement.js
+++ b/workflows/work/steps/implement.js
@@ -25,7 +25,9 @@ function _readClaimOwner(tasksDir, taskNum) {
     const raw = fs.readFileSync(lockPath, 'utf8');
     const parsed = JSON.parse(raw);
     return parsed?.ownerId ?? null;
-  } catch { return null; }
+  } catch {
+    return null;
+  }
 }
 
 // ─── GH-219 Task 16: Dependency-aware message builders ─────────────────────
@@ -61,7 +63,11 @@ function _buildDependencyStatus(currentTask, taskState) {
   const tasks = taskState?.tasks ?? [];
   const currentTaskMeta = tasks.find((t) => t.id === `task_${currentTask.num}`);
   // Backward compat: missing dependencies field → no deps (matches R16 in task-readiness.js)
-  if (!currentTaskMeta || !Array.isArray(currentTaskMeta.dependencies) || currentTaskMeta.dependencies.length === 0) {
+  if (
+    !currentTaskMeta ||
+    !Array.isArray(currentTaskMeta.dependencies) ||
+    currentTaskMeta.dependencies.length === 0
+  ) {
     return null;
   }
   // Build dependency list from persisted tasksMeta (aligned with canStartFromState).
@@ -117,7 +123,15 @@ function _buildDependencyPrompt(depStatus, claimOwner, workerSlot) {
  * @param {object|null} s
  * @returns {string}
  */
-function _buildTaskReason(currentTask, currentTaskIdx, taskData, claimOwner, workerSlot, depStatus, s) {
+function _buildTaskReason(
+  currentTask,
+  currentTaskIdx,
+  taskData,
+  claimOwner,
+  workerSlot,
+  depStatus,
+  s
+) {
   if (!currentTask) {
     return s?.hasDiffVsMain
       ? 'Changes exist but implement not yet completed'
@@ -126,7 +140,9 @@ function _buildTaskReason(currentTask, currentTaskIdx, taskData, claimOwner, wor
 
   const parts = [];
   // Task id + progress
-  parts.push(`Task ${currentTaskIdx + 1}/${taskData.length} (task_${currentTask.num}): ${currentTask.title}`);
+  parts.push(
+    `Task ${currentTaskIdx + 1}/${taskData.length} (task_${currentTask.num}): ${currentTask.title}`
+  );
 
   // Claim + PR slot
   if (claimOwner) {
@@ -215,7 +231,15 @@ module.exports = function implementStep(add, s, ctx) {
         implementMeta
       );
     } else {
-      const reason = _buildTaskReason(currentTask, currentTaskIdx, taskData, claimOwner, workerSlot, depStatus, s);
+      const reason = _buildTaskReason(
+        currentTask,
+        currentTaskIdx,
+        taskData,
+        claimOwner,
+        workerSlot,
+        depStatus,
+        s
+      );
       add(STEPS.implement, 'RUN', '/work-implement <requirements>', reason, implementMeta);
     }
   }

--- a/workflows/work/steps/spec-gate.js
+++ b/workflows/work/steps/spec-gate.js
@@ -59,12 +59,20 @@ function specGateStep(add, s, ctx) {
   const allErrors = [...parsed.errors, ...validation.errors];
   if (validation.valid && parsed.errors.length === 0) {
     const totalScenarios = parsed.features.reduce((sum, f) => sum + f.scenarios.length, 0);
-    const integrationCount = parsed.features.reduce((sum, f) =>
-      sum + f.scenarios.filter((sc) => sc.tags.includes('@integration')).length, 0);
-    const e2eCount = parsed.features.reduce((sum, f) =>
-      sum + f.scenarios.filter((sc) => sc.tags.includes('@e2e')).length, 0);
-    add(STEPS.spec_gate, 'DEFER', null,
-      `Gherkin validation passed (${totalScenarios} scenarios, ${integrationCount} @integration, ${e2eCount} @e2e)`);
+    const integrationCount = parsed.features.reduce(
+      (sum, f) => sum + f.scenarios.filter((sc) => sc.tags.includes('@integration')).length,
+      0
+    );
+    const e2eCount = parsed.features.reduce(
+      (sum, f) => sum + f.scenarios.filter((sc) => sc.tags.includes('@e2e')).length,
+      0
+    );
+    add(
+      STEPS.spec_gate,
+      'DEFER',
+      null,
+      `Gherkin validation passed (${totalScenarios} scenarios, ${integrationCount} @integration, ${e2eCount} @e2e)`
+    );
     return;
   }
 

--- a/workflows/work/steps/spec.js
+++ b/workflows/work/steps/spec.js
@@ -20,9 +20,7 @@ module.exports = function specStep(add, s, ctx) {
     add(STEPS.spec, 'DEFER', null, 'spec.md already exists');
   } else {
     const briefRef =
-      fileExists(briefPath) || !s?.hasBrief
-        ? `\n\nRead the product brief at: ${briefPath}`
-        : '';
+      fileExists(briefPath) || !s?.hasBrief ? `\n\nRead the product brief at: ${briefPath}` : '';
     add(STEPS.spec, 'RUN', 'Task(spec-writer)', 'Generate technical specification', {
       agentType: 'spec-writer',
       agentPrompt: `Analyze the codebase in ${worktreeDir} and generate a technical specification for ticket ${t}.${briefRef}\n\nSave the spec to: ${specPath}\n\nThe spec MUST include:\n1. Summary\n2. Architecture decisions (reference specific files)\n3. Data model changes\n4. API/interface changes\n5. Security considerations\n6. Test Scenarios (Gherkin) — structured Feature/Scenario/Given/When/Then with @integration or @e2e tags (min 2 scenarios, at least 1 @integration or @e2e). Use <!-- gherkin-skip: reason --> for non-testable changes\n7. Reuse Audit — grep/glob for existing patterns, components, utilities that can be reused\n8. Implementation Order — numbered steps with explicit dependency notation\n9. Files to create/modify\n10. Out of Scope — explicitly list what is NOT being implemented\n11. Open Questions & Decisions — surface ambiguity with default assumptions\n12. Dependencies — external libs, services, or internal modules needed\n13. Verification Checklist — machine-checkable markers (FILE_EXISTS, GREP, TEST_COUNT, REUSES)${getDocsPrompt('READ_DOCS_ON_SPEC')}`,

--- a/workflows/work/steps/task-review.js
+++ b/workflows/work/steps/task-review.js
@@ -87,9 +87,10 @@ module.exports = function taskReviewStep(add, s, ctx) {
   // Override tasksDir to per-task subfolder when task context is available.
   // ctx._currentTaskIdx is set by the implement step; when present (not undefined/null),
   // use taskSegment() to construct the per-task path for artifact resolution.
-  const reviewTasksDir = ctx._currentTaskIdx != null
-    ? path.join(ctx.tasksDir, taskSegment(currentIdx + 1))
-    : ctx.tasksDir;
+  const reviewTasksDir =
+    ctx._currentTaskIdx != null
+      ? path.join(ctx.tasksDir, taskSegment(currentIdx + 1))
+      : ctx.tasksDir;
   // Compute task-scoped diff range via computeTaskDiff (reads .last-commit-sha,
   // validates, falls back to base branch on missing/invalid SHA). The range is
   // passed to the orchestrator in plan-entry metadata so /tests-review and
@@ -116,6 +117,6 @@ module.exports = function taskReviewStep(add, s, ctx) {
     step: STEPS.task_review,
     what: `task ${currentIdx + 1}/${totalTasks} review scheduled for "${currentTask?.title || 'unknown'}"`,
   });
-}
+};
 
 module.exports.taskReviewStep = module.exports;

--- a/workflows/work/tdd-enforcement.js
+++ b/workflows/work/tdd-enforcement.js
@@ -65,9 +65,10 @@ Rules:
  */
 function readTddEvidence(tasksBase, ticketId, stepId, taskNum) {
   // taskSegment() validates taskNum internally (throws on non-positive-integer)
-  const phasePath = taskNum != null
-    ? path.join(tasksBase, ticketId, taskSegment(taskNum), 'tdd-phase.json')
-    : path.join(tasksBase, ticketId, 'tdd-phase.json'); // root fallback for non-task flows
+  const phasePath =
+    taskNum != null
+      ? path.join(tasksBase, ticketId, taskSegment(taskNum), 'tdd-phase.json')
+      : path.join(tasksBase, ticketId, 'tdd-phase.json'); // root fallback for non-task flows
   try {
     if (!fs.existsSync(phasePath)) return { exists: false, parseError: false, evidence: null };
   } catch {
@@ -102,14 +103,26 @@ function validateTddEvidence(evidence) {
     if (typeof evidence.exception === 'object' && evidence.exception !== null) {
       const { ALLOWED_CATEGORIES } = require('../work-implement/exception-validator');
       const cat = evidence.exception.category;
-      if (typeof cat === 'string' && ALLOWED_CATEGORIES.includes(cat)) { // GH-258: validated against exception-validator.ALLOWED_CATEGORIES
+      if (typeof cat === 'string' && ALLOWED_CATEGORIES.includes(cat)) {
+        // GH-258: validated against exception-validator.ALLOWED_CATEGORIES
         const reason = evidence.exception.reason;
         if (typeof reason !== 'string' || !reason.trim()) {
-          return { valid: false, reason: 'Exception reason is required and must be a non-empty string.' };
+          return {
+            valid: false,
+            reason: 'Exception reason is required and must be a non-empty string.',
+          };
         }
         return { valid: true, reason: '' };
       }
-      return { valid: false, reason: 'Invalid exception category: "' + cat + '". Allowed: ' + ALLOWED_CATEGORIES.join(', ') + '.' };
+      return {
+        valid: false,
+        reason:
+          'Invalid exception category: "' +
+          cat +
+          '". Allowed: ' +
+          ALLOWED_CATEGORIES.join(', ') +
+          '.',
+      };
     }
     // exception exists but is neither string nor valid object
     return { valid: false, reason: 'Exception field has invalid format' };

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -64,9 +64,8 @@ function transitionStep(ticket, targetStep, deps) {
   }
 
   // Extract 1-indexed task number from work state for per-task TDD paths (GH-219 Task 2)
-  const taskNum = ws?.tasksMeta?.currentTaskIndex != null
-    ? ws.tasksMeta.currentTaskIndex + 1
-    : undefined;
+  const taskNum =
+    ws?.tasksMeta?.currentTaskIndex != null ? ws.tasksMeta.currentTaskIndex + 1 : undefined;
 
   // TDD gate: require evidence before leaving gated steps (always enforced)
   if (TDD_GATED_STEPS.includes(currentStep) && currentStep !== targetStep) {

--- a/workflows/work/work-claims.js
+++ b/workflows/work/work-claims.js
@@ -114,9 +114,7 @@ function validateTicketId(ticketId) {
     return {
       code: 'INVALID_TICKET_ID',
       message: `ticketId ${JSON.stringify(ticketId)} contains leading/trailing whitespace.`,
-      remediation: [
-        'Trim the ticket id before passing it to claimTask/releaseTask.',
-      ],
+      remediation: ['Trim the ticket id before passing it to claimTask/releaseTask.'],
     };
   }
   // Expects pre-normalized ticket ID (e.g. "GH-219", not a URL).
@@ -155,7 +153,8 @@ function validateTicketId(ticketId) {
   const slashCount = (ticketId.match(/\//g) || []).length;
   if (slashCount > 1) {
     // "A/B/C" — only one "/" allowed
-    return { code: 'INVALID_TICKET_ID',
+    return {
+      code: 'INVALID_TICKET_ID',
       message: 'Only one "/" suffix separator is allowed.',
       remediation: ['Use format like "PROJ-123/phase1" — at most one "/".'],
     };
@@ -343,7 +342,9 @@ function claimTask(ticketId, taskNum, ownerId) {
       try {
         fs.unlinkSync(tmpPath);
         tmpWritten = false;
-      } catch { /* best-effort cleanup; finally will retry while tmpWritten remains true */ }
+      } catch {
+        /* best-effort cleanup; finally will retry while tmpWritten remains true */
+      }
       return { success: true, ownerId, lockPath };
     } catch (linkErr) {
       if (linkErr && linkErr.code === 'EEXIST') {
@@ -359,10 +360,9 @@ function claimTask(ticketId, taskNum, ownerId) {
           lockPath,
           error: {
             code: 'ALREADY_CLAIMED',
-            message:
-              existingOwner
-                ? `Task ${taskNumInt} on ${ticketId} is already claimed by ${existingOwner}.`
-                : `Task ${taskNumInt} on ${ticketId} is already claimed (owner unreadable).`,
+            message: existingOwner
+              ? `Task ${taskNumInt} on ${ticketId} is already claimed by ${existingOwner}.`
+              : `Task ${taskNumInt} on ${ticketId} is already claimed (owner unreadable).`,
             remediation: [
               `Wait for ${existingOwner || 'the current owner'} to call releaseTask or complete.`,
               `Pick a different task (see canStart in workflows/work/work-state.js for readiness).`,
@@ -428,10 +428,9 @@ function releaseTask(ticketId, taskNum, ownerId) {
       lockPath,
       error: {
         code: 'WRONG_OWNER',
-        message:
-          existingOwner
-            ? `Cannot release task ${taskNumInt} on ${ticketId}: current owner is ${existingOwner}, not ${ownerId}.`
-            : `Cannot release task ${taskNumInt} on ${ticketId}: lock payload unreadable (refusing to delete).`,
+        message: existingOwner
+          ? `Cannot release task ${taskNumInt} on ${ticketId}: current owner is ${existingOwner}, not ${ownerId}.`
+          : `Cannot release task ${taskNumInt} on ${ticketId}: lock payload unreadable (refusing to delete).`,
         remediation: [
           `Only the current owner (${existingOwner || 'unknown'}) may call releaseTask.`,
           `Verify ownerId matches the value stored at ${lockPath}.`,

--- a/workflows/work/work-enforcement-context.js
+++ b/workflows/work/work-enforcement-context.js
@@ -183,7 +183,8 @@ function loadEnforcementContext(ticketId, options = {}) {
       origin = 'user';
       error = {
         code: 'AMBIGUOUS_SUBTASK',
-        message: `--subtask flag is set but no active subtask state found for ticket "${safeId}". ` +
+        message:
+          `--subtask flag is set but no active subtask state found for ticket "${safeId}". ` +
           'Cannot determine ai-subtask origin without a resolvable .work-state-*-subtask-*.json file.',
         remediation: [
           'Initialize a subtask first: node work-state.js init-subtask ' + safeId,

--- a/workflows/work/work-state.js
+++ b/workflows/work/work-state.js
@@ -154,7 +154,12 @@ function autoInitTdd(ticketId, taskNum) {
     // Validate ticketId — reject traversal chars and verify resolved path stays within TASKS_BASE
     if (!ticketId || /\.\./.test(ticketId) || /\\/.test(ticketId)) return;
     if (taskNum != null) {
-      tddStatePath = path.join(TASKS_BASE, safeId(ticketId), taskSegment(taskNum), 'tdd-phase.json');
+      tddStatePath = path.join(
+        TASKS_BASE,
+        safeId(ticketId),
+        taskSegment(taskNum),
+        'tdd-phase.json'
+      );
     } else {
       tddStatePath = path.join(TASKS_BASE, safeId(ticketId), 'tdd-phase.json');
     }
@@ -270,7 +275,7 @@ function completeWork(ticketId) {
   // Terminal guard: block completion if tasks are still pending (GH-245)
   // Array.isArray guards against corrupted state files where tasksMeta.tasks is not an array
   if (state.tasksMeta && Array.isArray(state.tasksMeta.tasks)) {
-    const pendingTasks = state.tasksMeta.tasks.filter(t => t.status !== 'completed');
+    const pendingTasks = state.tasksMeta.tasks.filter((t) => t.status !== 'completed');
     if (pendingTasks.length > 0) {
       return { error: `Cannot complete workflow: ${pendingTasks.length} tasks still pending` };
     }
@@ -886,10 +891,7 @@ try {
 // Extracted to work-state/parallel-workers.js. Re-imported here so all
 // existing consumers of work-state.js are unaffected.
 const _parallelWorkers = require('./work-state/parallel-workers');
-const {
-  allocateWorkerSlot,
-  releaseWorkerSlot,
-} = _parallelWorkers;
+const { allocateWorkerSlot, releaseWorkerSlot } = _parallelWorkers;
 
 // Inject parent functions into submodules to break the circular dependency.
 // MUST run before the CLI `main()` block below — `main()` is async but its

--- a/workflows/work/work-state/parallel-workers.js
+++ b/workflows/work/work-state/parallel-workers.js
@@ -42,7 +42,11 @@ let config;
 try {
   config = require('../../lib/config');
 } catch (err) {
-  if (err && err.code === 'MODULE_NOT_FOUND' && /['"]\.\.\/\.\.\/lib\/config['"]|['"]\.\.\/lib\/config['"]/.test(err.message)) {
+  if (
+    err &&
+    err.code === 'MODULE_NOT_FOUND' &&
+    /['"]\.\.\/\.\.\/lib\/config['"]|['"]\.\.\/lib\/config['"]/.test(err.message)
+  ) {
     config = null;
   } else {
     throw err;

--- a/workflows/work/work-state/task-readiness.js
+++ b/workflows/work/work-state/task-readiness.js
@@ -144,29 +144,33 @@ function initTasksMeta(ticketId, taskCountOrTasks) {
 
   // ─── Non-contiguous / duplicate task number validation ─────────────────
   if (isTaskArray) {
-    const nums = tasksInput.map(t => t.num);
+    const nums = tasksInput.map((t) => t.num);
     const uniqueNums = new Set(nums);
     if (uniqueNums.size !== nums.length) {
       return {
         error: 'Duplicate task numbers detected in tasksInput.',
-        errors: [{
-          code: 'DUPLICATE_TASK_NUMS',
-          taskId: null,
-          message: 'Duplicate task numbers detected.',
-          remediation: ['Each task must have a unique num field.'],
-        }],
+        errors: [
+          {
+            code: 'DUPLICATE_TASK_NUMS',
+            taskId: null,
+            message: 'Duplicate task numbers detected.',
+            remediation: ['Each task must have a unique num field.'],
+          },
+        ],
       };
     }
     const maxNum = Math.max(...nums);
-    if (maxNum !== taskCount || !nums.every(n => n >= 1 && n <= taskCount)) {
+    if (maxNum !== taskCount || !nums.every((n) => n >= 1 && n <= taskCount)) {
       return {
         error: `Task numbers must be contiguous 1..${taskCount}. Found: ${nums.sort((a, b) => a - b).join(', ')}`,
-        errors: [{
-          code: 'NON_CONTIGUOUS_TASK_NUMS',
-          taskId: null,
-          message: `Task numbers must be contiguous 1..${taskCount}. Found: ${nums.sort((a, b) => a - b).join(', ')}`,
-          remediation: ['Ensure tasks are numbered 1 through N with no gaps.'],
-        }],
+        errors: [
+          {
+            code: 'NON_CONTIGUOUS_TASK_NUMS',
+            taskId: null,
+            message: `Task numbers must be contiguous 1..${taskCount}. Found: ${nums.sort((a, b) => a - b).join(', ')}`,
+            remediation: ['Ensure tasks are numbered 1 through N with no gaps.'],
+          },
+        ],
       };
     }
   }
@@ -198,7 +202,10 @@ function initTasksMeta(ticketId, taskCountOrTasks) {
     const entry = { id: `task_${i + 1}`, status: 'pending' };
     if (isTaskArray) {
       const src = taskMap.get(i + 1);
-      const deps = src && Array.isArray(src.dependencies) ? src.dependencies.filter(d => Number.isInteger(d)) : [];
+      const deps =
+        src && Array.isArray(src.dependencies)
+          ? src.dependencies.filter((d) => Number.isInteger(d))
+          : [];
       entry.dependencies = deps.slice(); // defensive copy
     }
     tasks.push(entry);

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -257,16 +257,19 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             // Exception mode: config-only or mechanical changes that skip TDD
             // Accept both legacy string format and structured { category, reason } format
             if (typeof state.exception === 'string' && state.exception.trim() !== '') return true;
-            if (
-              typeof state.exception === 'object' &&
-              state.exception !== null
-            ) {
+            if (typeof state.exception === 'object' && state.exception !== null) {
               // If exception-validator fails to load, the outer catch returns false (fail-closed)
-              const { ALLOWED_CATEGORIES } = require(path.join(__dirname, '..', 'work-implement', 'exception-validator'));
+              const { ALLOWED_CATEGORIES } = require(
+                path.join(__dirname, '..', 'work-implement', 'exception-validator')
+              );
               const cat = state.exception.category;
               const reason = state.exception.reason;
-              return typeof cat === 'string' && ALLOWED_CATEGORIES.includes(cat) &&
-                typeof reason === 'string' && reason.trim() !== '';
+              return (
+                typeof cat === 'string' &&
+                ALLOWED_CATEGORIES.includes(cat) &&
+                typeof reason === 'string' &&
+                reason.trim() !== ''
+              );
             }
             if (!Array.isArray(state.cycles) || state.cycles.length === 0) return false;
             // At least one cycle must have both red and green evidence
@@ -475,7 +478,8 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
               // GH-285: userApproval requirement removed per brief resolution —
               // disposition + reason fields are sufficient proof of comment triage.
               const validDispositions = ['addressed', 'acknowledged', 'outdated'];
-              if (!entries.every((e) => validDispositions.includes(e.disposition) && e.reason)) return false;
+              if (!entries.every((e) => validDispositions.includes(e.disposition) && e.reason))
+                return false;
             }
 
             return true;


### PR DESCRIPTION
## Existing Behavior

- 91 source and test files have inconsistent formatting not aligned with the biome configuration already present in the repo.
- No automated enforcement exists to prevent formatting drift on future commits.
- The `scripts/hooks/` directory exists but `core.hooksPath` is not configured automatically on install.

## Intended New Behavior

- All 91 JS and JSON files are reformatted to be consistent with the project's biome configuration — no logic changes.
- A new `scripts/hooks/pre-commit` hook auto-formats staged `.js` and `.json` files with biome before each commit and re-stages any reformatted files.
- A `prepare` script in `package.json` runs `git config core.hooksPath scripts/hooks` on install, activating the hook for all contributors automatically.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a formatting-only change with no logic modifications. Verification steps:

1. Run `pnpm format:check` — should exit 0 with no files reported as needing formatting.
2. Run `pnpm run verify` to confirm all existing functionality is unaffected.
3. Stage a change to any `.js` file and run `git commit` — the pre-commit hook should reformat the file in place and re-stage it before the commit is recorded.
4. On a fresh clone, run `pnpm install` — confirm the hooks path is configured via `git config --get core.hooksPath` returning `scripts/hooks`.
