### PR TITLE
fix(follow-up-pr): treat MERGED PRs as passing follow_up gate

### DIFF
--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1538,7 +1538,9 @@ async function main() {
 function isPRGateReady() {
   const prInfo = getPRInfo();
   if (!prInfo || !prInfo.number) return { ready: false };
-  if (prInfo.state === 'CLOSED' || prInfo.state === 'MERGED') return { ready: false };
+  if (prInfo.state === 'CLOSED') return { ready: false };
+  // Merged PRs have passed all gates — allow transition (GH-276)
+  if (prInfo.state === 'MERGED') return { ready: true, reviews: {}, decision: { action: 'exit-success', finalStatus: 'merged' }, strictCommentCount: 0, prInfo };
 
   const ci = checkCI(prInfo.number);
   const reviews = getReviews(prInfo.number);


### PR DESCRIPTION
## Existing Behavior

- `isPRGateReady()` treated `MERGED` PRs the same as `CLOSED` PRs, returning `{ ready: false }` for both states.
- When a PR was merged before the `/work` workflow reached the `complete` step, the `follow_up` gate would return `ready: false`, blocking all further transitions.
- This created a deadlock: a successfully merged PR could not advance the workflow to `complete`.

## Intended New Behavior

- `CLOSED` PRs continue to return `{ ready: false }`, preserving existing blocked-PR behavior.
- `MERGED` PRs now return `{ ready: true }` with a synthetic gate result (`action: 'exit-success'`, `finalStatus: 'merged'`, zero strict comment count), allowing the workflow to transition past the `follow_up` gate and reach `complete`.
- The fix is annotated with `(GH-276)` for traceability.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Reproduce the deadlock and verify it is resolved:

1. Run the `/work` workflow on a ticket through to the `follow_up` step.
2. Merge the associated PR on GitHub before the workflow reaches `complete`.
3. Resume the workflow — previously it would stall at the `follow_up` gate indefinitely.
4. Confirm the workflow now transitions through `follow_up` and advances to `complete` without manual intervention.

To verify the gate logic directly, inspect `isPRGateReady()` in `workflows/work/scripts/follow-up-pr.js` and confirm that a `prInfo.state === 'MERGED'` object returns `ready: true` with `finalStatus: 'merged'`.