### PR TITLE
GH-232 - fix(check-gate): unify report status parsing and fix false-negative scenarios

### DIFF
--- a/workflows/check/__tests__/check-generate-summary.test.js
+++ b/workflows/check/__tests__/check-generate-summary.test.js
@@ -11,6 +11,8 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { getReportStatus } = require('../hooks/check-generate-summary.js');
 
@@ -152,6 +154,20 @@ describe('getReportStatus', () => {
       result.status,
       'NEEDS_WORK',
       'Fail markers should take precedence over pass markers to avoid false negatives'
+    );
+  });
+
+  // ── Shared utility delegation (R5, R8) ──────────────────────────────────
+
+  it('delegates to shared parseReportStatus from parse-report-status.js (R5)', () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'hooks', 'check-generate-summary.js'),
+      'utf8'
+    );
+    assert.ok(
+      source.includes("require('../../lib/parse-report-status") ||
+        source.includes('require("../../lib/parse-report-status'),
+      'check-generate-summary.js must import from shared parse-report-status module'
     );
   });
 });

--- a/workflows/check/hooks/check-generate-summary.js
+++ b/workflows/check/hooks/check-generate-summary.js
@@ -12,6 +12,7 @@
 const fs = require('fs');
 const path = require('path');
 const AppAccessStatus = require(path.join(__dirname, '..', 'lib', 'app-access-status'));
+const { parseReportStatus } = require('../../lib/parse-report-status');
 
 // Get args (only when run as CLI)
 let REPORT_FOLDER, CHANGES_HASH, TICKET_ID, IMPACTED_APPS;
@@ -47,69 +48,11 @@ function readFile(filePath) {
 }
 
 /**
- * Check report status from content
+ * Check report status from content.
+ * Delegates to shared parseReportStatus (R5) while preserving export name (R8).
  */
 function getReportStatus(content, type) {
-  if (!content) return { status: 'MISSING', icon: '❓' };
-
-  // Check for infrastructure/access failure FIRST (for QA reports)
-  if (type === 'qa') {
-    if (
-      content.includes('INFRASTRUCTURE_FAILURE') ||
-      content.includes('PLAYWRIGHT_UNAVAILABLE') ||
-      content.includes('PLAYWRIGHT UNAVAILABLE')
-    ) {
-      return { status: 'INFRASTRUCTURE_FAILURE', icon: '🛑' };
-    }
-    if (content.includes(AppAccessStatus.ACCESS_FAILED)) {
-      return { status: AppAccessStatus.ACCESS_FAILED, icon: '🔒' };
-    }
-  }
-
-  const statusChecks = {
-    tests: {
-      pass: ['✅ PASS', 'APPROVED', 'All.*pass'],
-      fail: ['❌ FAIL', 'NEEDS_WORK', 'fail [1-9]\\d*'],
-    },
-    codeReview: {
-      pass: ['APPROVED', 'No critical', 'No issues'],
-      fail: ['CRITICAL', 'NEEDS_WORK'],
-    },
-    qa: {
-      pass: ['✅ PASS', 'All tests passed', 'SUCCESS', 'Status:\\s*APPROVED'],
-      fail: [
-        '❌ FAIL',
-        'FAILED:\\s*[1-9]',
-        'failures:\\s*[1-9]',
-        'Status:\\s*FAIL',
-        'Status:\\s*NEEDS_WORK',
-      ],
-    },
-    completion: {
-      pass: ['COMPLETE', 'DELIVERED'],
-      fail: ['INCOMPLETE', 'PENDING'],
-    },
-  };
-
-  const checks = statusChecks[type];
-  if (!checks) return { status: 'UNKNOWN', icon: '❓' };
-
-  // Check for failures first — fail markers take precedence to avoid false negatives
-  // (pass-first ordering would silence explicit NEEDS_WORK when a pass pattern also matches)
-  for (const pattern of checks.fail) {
-    if (new RegExp(pattern, 'i').test(content)) {
-      return { status: 'NEEDS_WORK', icon: '❌' };
-    }
-  }
-
-  // Check for pass
-  for (const pattern of checks.pass) {
-    if (new RegExp(pattern, 'i').test(content)) {
-      return { status: 'APPROVED', icon: '✅' };
-    }
-  }
-
-  return { status: 'UNKNOWN', icon: '❓' };
+  return parseReportStatus(content, type);
 }
 
 /**

--- a/workflows/lib/__tests__/parse-report-status.test.js
+++ b/workflows/lib/__tests__/parse-report-status.test.js
@@ -76,6 +76,20 @@ describe('parseReportStatus — Status: line format', () => {
     assert.equal(result.status, 'UNKNOWN', 'unrecognized Status line must block heuristic fallback');
   });
 
+  it('stops at first Status line even when later Status lines are valid', () => {
+    // Status: COMPLETE (invalid for tests) followed by Status: APPROVED
+    // The first Status: line is authoritative — don't scan further.
+    const content = 'Status: COMPLETE\n\nStatus: APPROVED';
+    const result = parseReportStatus(content, 'tests');
+    assert.equal(result.status, 'UNKNOWN', 'first invalid Status line must be authoritative');
+  });
+
+  it('returns UNKNOWN for summary table with type-invalid status', () => {
+    const content = '| Status | COMPLETE |\n\n✅ PASS';
+    const result = parseReportStatus(content, 'tests');
+    assert.equal(result.status, 'UNKNOWN', 'type-invalid table status must block heuristic fallback');
+  });
+
   it('recognizes Status: NEEDS_WORK', () => {
     const result = parseReportStatus('Status: NEEDS_WORK', 'codeReview');
     assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
@@ -749,6 +763,18 @@ describe('isCodeReviewResolved — spurious title filtering (GH-232)', () => {
       true,
       'CRITICAL keyword alone must not be treated as issue title'
     );
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+
+  it('does not treat "**CRITICAL:**" (with trailing colon) as an issue title', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**CRITICAL:** this describes the section, not an issue.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, true, 'CRITICAL: with colon must be filtered by SPURIOUS_TITLE_RE');
     assert.deepStrictEqual(result.unaddressed, []);
   });
 

--- a/workflows/lib/__tests__/parse-report-status.test.js
+++ b/workflows/lib/__tests__/parse-report-status.test.js
@@ -350,6 +350,16 @@ describe('parseReportStatus — anchored markers prevent false positives', () =>
     assert.equal(result.status, 'UNKNOWN', 'SUCCESS is only valid for QA type');
   });
 
+  it('recognizes "Status: INFRASTRUCTURE_FAILURE" for QA type', () => {
+    const result = parseReportStatus('Status: INFRASTRUCTURE_FAILURE', 'qa');
+    assert.deepStrictEqual(result, { status: 'INFRASTRUCTURE_FAILURE', icon: '🛑' });
+  });
+
+  it('recognizes "Status: ACCESS_FAILED" for QA type', () => {
+    const result = parseReportStatus('Status: ACCESS_FAILED', 'qa');
+    assert.deepStrictEqual(result, { status: 'ACCESS_FAILED', icon: '🔒' });
+  });
+
   it('Status: APPROVED at top overrides later Status: FAIL in embedded output', () => {
     const content = [
       'Status: APPROVED',

--- a/workflows/lib/__tests__/parse-report-status.test.js
+++ b/workflows/lib/__tests__/parse-report-status.test.js
@@ -68,6 +68,14 @@ describe('parseReportStatus — Status: line format', () => {
     assert.notEqual(result.status, 'APPROVED');
   });
 
+  it('does NOT fall through to heuristics when Status line has unrecognized value', () => {
+    // Status: COMPLETE is invalid for tests type. Even though ✅ PASS marker
+    // exists in the body, the explicit Status: line should prevent heuristic fallback.
+    const content = 'Status: COMPLETE\n\n✅ PASS\nAll tests passed';
+    const result = parseReportStatus(content, 'tests');
+    assert.equal(result.status, 'UNKNOWN', 'unrecognized Status line must block heuristic fallback');
+  });
+
   it('recognizes Status: NEEDS_WORK', () => {
     const result = parseReportStatus('Status: NEEDS_WORK', 'codeReview');
     assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });

--- a/workflows/lib/__tests__/parse-report-status.test.js
+++ b/workflows/lib/__tests__/parse-report-status.test.js
@@ -1,0 +1,976 @@
+/**
+ * Tests for workflows/lib/parse-report-status.js — shared report status parsing.
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  parseReportStatus,
+  parseReplyDecisions,
+  isCodeReviewResolved,
+} = require('../parse-report-status');
+
+// ---------------------------------------------------------------------------
+// R9: null / undefined / empty content -> MISSING
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — null safety (R9)', () => {
+  it('returns MISSING for null content', () => {
+    const result = parseReportStatus(null, 'tests');
+    assert.deepStrictEqual(result, { status: 'MISSING', icon: '❓' });
+  });
+
+  it('returns MISSING for undefined content', () => {
+    const result = parseReportStatus(undefined, 'tests');
+    assert.deepStrictEqual(result, { status: 'MISSING', icon: '❓' });
+  });
+
+  it('returns MISSING for empty string', () => {
+    const result = parseReportStatus('', 'tests');
+    assert.deepStrictEqual(result, { status: 'MISSING', icon: '❓' });
+  });
+
+  it('returns MISSING for whitespace-only string', () => {
+    const result = parseReportStatus('   \n\t  ', 'tests');
+    assert.deepStrictEqual(result, { status: 'MISSING', icon: '❓' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R3: Status: line format (plain)
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — Status: line format', () => {
+  it('recognizes plain Status: APPROVED for tests', () => {
+    const result = parseReportStatus('Status: APPROVED', 'tests');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('recognizes Status: APPROVED with leading whitespace', () => {
+    const result = parseReportStatus('  Status:   APPROVED  ', 'tests');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('recognizes Status: COMPLETE for completion type', () => {
+    const result = parseReportStatus('Status: COMPLETE', 'completion');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('does NOT accept Status: COMPLETE for tests type (type-scoped aliases)', () => {
+    const result = parseReportStatus('Status: COMPLETE', 'tests');
+    // COMPLETE is not a valid alias for tests — should fall through to UNKNOWN
+    assert.notEqual(result.status, 'APPROVED');
+  });
+
+  it('does NOT accept Status: COMPLETE for codeReview type', () => {
+    const result = parseReportStatus('Status: COMPLETE', 'codeReview');
+    assert.notEqual(result.status, 'APPROVED');
+  });
+
+  it('recognizes Status: NEEDS_WORK', () => {
+    const result = parseReportStatus('Status: NEEDS_WORK', 'codeReview');
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+  });
+
+  it('recognizes Status: NOT_APPLICABLE', () => {
+    const result = parseReportStatus('Status: NOT_APPLICABLE', 'qa');
+    assert.deepStrictEqual(result, { status: 'NOT_APPLICABLE', icon: '➖' });
+  });
+
+  it('recognizes Status: FAIL as NEEDS_WORK', () => {
+    const result = parseReportStatus('Status: FAIL', 'tests');
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R3: Bold markdown format
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — bold markdown format', () => {
+  it('recognizes **Status:** **APPROVED**', () => {
+    const result = parseReportStatus('**Status:** **APPROVED**', 'tests');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('recognizes **Status:** **COMPLETE** for completion', () => {
+    const result = parseReportStatus('**Status:** **COMPLETE**', 'completion');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('recognizes **Status:** APPROVED (partial bold)', () => {
+    const result = parseReportStatus('**Status:** APPROVED', 'tests');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R3: Summary table format
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — summary table format', () => {
+  it('recognizes | Status | APPROVED | in a table', () => {
+    const content = ['| Field | Value |', '|-------|-------|', '| Status | APPROVED |'].join('\n');
+    const result = parseReportStatus(content, 'tests');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('recognizes | Status | COMPLETE | for completion', () => {
+    const content = '| Status | COMPLETE |';
+    const result = parseReportStatus(content, 'completion');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('recognizes | Status | NEEDS_WORK | in a table', () => {
+    const content = '| Status | NEEDS_WORK |';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R10: Fail-first precedence
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — Status line priority', () => {
+  it('explicit Status: APPROVED overrides CRITICAL markers in body', () => {
+    const content = [
+      'Status: APPROVED',
+      '',
+      '## Issues',
+      '### CRITICAL: Memory leak in handler',
+    ].join('\n');
+    const result = parseReportStatus(content, 'codeReview');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('explicit Status: NEEDS_WORK is respected even with APPROVED in body', () => {
+    const content = ['Status: NEEDS_WORK', '', 'Previously APPROVED items remain valid.'].join(
+      '\n'
+    );
+    const result = parseReportStatus(content, 'codeReview');
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+  });
+
+  it('fail markers win when no explicit Status line exists', () => {
+    const content = ['✅ PASS: 10 tests', '❌ FAIL: 2 tests'].join('\n');
+    const result = parseReportStatus(content, 'tests');
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+  });
+
+  it('Status: APPROVED overrides fail patterns in raw test output', () => {
+    const content = ['```', 'ℹ fail 16', '```', '', 'Status: APPROVED'].join('\n');
+    const result = parseReportStatus(content, 'tests');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Infrastructure failure detection (QA type)
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — infrastructure failures', () => {
+  it('detects INFRASTRUCTURE_FAILURE for QA reports', () => {
+    const result = parseReportStatus('INFRASTRUCTURE_FAILURE: playwright not available', 'qa');
+    assert.deepStrictEqual(result, { status: 'INFRASTRUCTURE_FAILURE', icon: '🛑' });
+  });
+
+  it('detects PLAYWRIGHT_UNAVAILABLE for QA reports', () => {
+    const result = parseReportStatus('PLAYWRIGHT_UNAVAILABLE', 'qa');
+    assert.deepStrictEqual(result, { status: 'INFRASTRUCTURE_FAILURE', icon: '🛑' });
+  });
+
+  it('detects ACCESS_FAILED for QA reports', () => {
+    const result = parseReportStatus('ACCESS_FAILED: could not reach app', 'qa');
+    assert.deepStrictEqual(result, { status: 'ACCESS_FAILED', icon: '🔒' });
+  });
+
+  it('honors explicit Status: NOT_APPLICABLE over PLAYWRIGHT_UNAVAILABLE in prose', () => {
+    const content = [
+      'Status: NOT_APPLICABLE',
+      '',
+      'QA was skipped because PLAYWRIGHT_UNAVAILABLE in this environment.',
+    ].join('\n');
+    const result = parseReportStatus(content, 'qa');
+    assert.deepStrictEqual(result, { status: 'NOT_APPLICABLE', icon: '➖' });
+  });
+
+  it('honors explicit Status: APPROVED over INFRASTRUCTURE_FAILURE in prose', () => {
+    const content = [
+      'Status: APPROVED',
+      '',
+      'Previously saw INFRASTRUCTURE_FAILURE but retried successfully.',
+    ].join('\n');
+    const result = parseReportStatus(content, 'qa');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('still detects INFRASTRUCTURE_FAILURE when no explicit Status line', () => {
+    const result = parseReportStatus('PLAYWRIGHT_UNAVAILABLE — cannot run tests', 'qa');
+    assert.deepStrictEqual(result, { status: 'INFRASTRUCTURE_FAILURE', icon: '🛑' });
+  });
+
+  it('does NOT detect INFRASTRUCTURE_FAILURE for non-QA types', () => {
+    const result = parseReportStatus('INFRASTRUCTURE_FAILURE mentioned somewhere', 'tests');
+    // For tests type, INFRASTRUCTURE_FAILURE is not a recognized fail pattern
+    assert.notEqual(result.status, 'INFRASTRUCTURE_FAILURE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pass marker patterns (per type)
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — pass markers', () => {
+  it('recognizes "✅ PASS" for tests type', () => {
+    const result = parseReportStatus('✅ PASS: All 42 tests passed', 'tests');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('recognizes "All tests passed" for QA type', () => {
+    const result = parseReportStatus('All tests passed successfully', 'qa');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('recognizes "COMPLETE" for completion type', () => {
+    const result = parseReportStatus('All tasks are COMPLETE', 'completion');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('recognizes "No critical issues" for codeReview type', () => {
+    const result = parseReportStatus('No critical issues found', 'codeReview');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('recognizes "No issues found" for codeReview type', () => {
+    const result = parseReportStatus('No issues found in this review', 'codeReview');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH-232: CRITICAL section headers must not trigger fail marker
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — CRITICAL section header false-negative (GH-232)', () => {
+  it('returns APPROVED when Status: APPROVED with ## CRITICAL ISSUES header + None found', () => {
+    const content = 'Status: APPROVED\n\n## CRITICAL ISSUES\nNone found.';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('returns APPROVED when Status: APPROVED with ### CRITICAL ISSUES header + None found', () => {
+    const content = 'Status: APPROVED\n\n### CRITICAL ISSUES\nNone found.';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('returns APPROVED when Status: APPROVED with emoji CRITICAL header + None found', () => {
+    const content = 'Status: APPROVED\n\n### 🔴 CRITICAL ISSUES\nNone found.';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('explicit Status: APPROVED overrides CRITICAL in body', () => {
+    const content = 'Status: APPROVED\n\n## Issues\n### CRITICAL: Memory leak in handler';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('CRITICAL in prose triggers NEEDS_WORK when no explicit Status line', () => {
+    const content = 'Found a CRITICAL bug in the parser.';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH-232: Anchored markers prevent substring false positives
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — anchored markers prevent false positives', () => {
+  it('does not treat "unsuccessful" as SUCCESS for QA type', () => {
+    const result = parseReportStatus('execution was unsuccessful', 'qa');
+    assert.notEqual(result.status, 'APPROVED', '"unsuccessful" must not match SUCCESS');
+  });
+
+  it('does not treat "unapproved" as APPROVED for tests type', () => {
+    const result = parseReportStatus('this run is unapproved pending rerun', 'tests');
+    assert.notEqual(result.status, 'APPROVED', '"unapproved" must not match APPROVED');
+  });
+
+  it('does not treat "should fail 3 times" prose as fail marker for tests type', () => {
+    const content = 'Status: APPROVED\n\nTest description: should fail 3 times before succeeding';
+    const result = parseReportStatus(content, 'tests');
+    assert.equal(result.status, 'APPROVED', 'inline prose "fail 3" must not override Status line');
+  });
+
+  it('does not treat "No issues were fixed yet" as pass for codeReview', () => {
+    const result = parseReportStatus('No issues were fixed yet', 'codeReview');
+    assert.notEqual(
+      result.status,
+      'APPROVED',
+      '"No issues were fixed yet" must not match pass marker'
+    );
+  });
+
+  it('does not treat "no success was achieved" as pass for QA', () => {
+    const result = parseReportStatus('no success was achieved in testing', 'qa');
+    assert.notEqual(result.status, 'APPROVED', '"no success" must not match SUCCESS pass marker');
+  });
+
+  it('recognizes "Status: SUCCESS" for QA type', () => {
+    const result = parseReportStatus('Status: SUCCESS', 'qa');
+    assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
+  });
+
+  it('Status: APPROVED at top overrides later Status: FAIL in embedded output', () => {
+    const content = [
+      'Status: APPROVED',
+      '',
+      '```',
+      'Status: FAIL',
+      'Some embedded output',
+      '```',
+    ].join('\n');
+    const result = parseReportStatus(content, 'tests');
+    assert.equal(result.status, 'APPROVED', 'first Status line should be authoritative');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown type / unknown content -> UNKNOWN
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — fallback to UNKNOWN', () => {
+  it('returns UNKNOWN for unrecognized type', () => {
+    const result = parseReportStatus('Some content', 'unknownType');
+    assert.deepStrictEqual(result, { status: 'UNKNOWN', icon: '❓' });
+  });
+
+  it('returns UNKNOWN when no patterns match', () => {
+    const result = parseReportStatus('Just some random text with no status indicators', 'tests');
+    assert.deepStrictEqual(result, { status: 'UNKNOWN', icon: '❓' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance criteria from tasks.md
+// ---------------------------------------------------------------------------
+describe('parseReportStatus — acceptance criteria', () => {
+  it('parseReportStatus(null, "tests") returns MISSING with "?" icon', () => {
+    const result = parseReportStatus(null, 'tests');
+    assert.equal(result.status, 'MISSING');
+    assert.equal(result.icon, '❓');
+  });
+
+  it('parseReportStatus("Status: APPROVED", "tests") returns APPROVED', () => {
+    const result = parseReportStatus('Status: APPROVED', 'tests');
+    assert.equal(result.status, 'APPROVED');
+    assert.equal(result.icon, '✅');
+  });
+
+  it('parseReportStatus("**Status:** **COMPLETE**", "completion") returns APPROVED', () => {
+    const result = parseReportStatus('**Status:** **COMPLETE**', 'completion');
+    assert.equal(result.status, 'APPROVED');
+    assert.equal(result.icon, '✅');
+  });
+
+  it('explicit Status: APPROVED takes priority over CRITICAL in body for codeReview', () => {
+    const content =
+      'Status: APPROVED\n\n## Issues\n### CRITICAL: Unhandled error\nSome detail here.';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.equal(result.status, 'APPROVED');
+    assert.equal(result.icon, '✅');
+  });
+
+  it('exports parseReportStatus as a function', () => {
+    assert.equal(typeof parseReportStatus, 'function');
+  });
+});
+
+// ===========================================================================
+// parseReplyDecisions — Task 2 (R1)
+// ===========================================================================
+describe('parseReplyDecisions — empty/null input', () => {
+  it('returns empty array for null content', () => {
+    assert.deepStrictEqual(parseReplyDecisions(null), []);
+  });
+
+  it('returns empty array for undefined content', () => {
+    assert.deepStrictEqual(parseReplyDecisions(undefined), []);
+  });
+
+  it('returns empty array for empty string', () => {
+    assert.deepStrictEqual(parseReplyDecisions(''), []);
+  });
+
+  it('returns empty array for content with no Issue sections', () => {
+    assert.deepStrictEqual(parseReplyDecisions('Some random text\nNo issues here'), []);
+  });
+});
+
+describe('parseReplyDecisions — single issue', () => {
+  it('parses a single FIXED issue', () => {
+    const content = [
+      '## Issue: Memory leak in handler',
+      '**Decision:** FIXED',
+      '**Reason:** Refactored the handler to properly close connections.',
+    ].join('\n');
+
+    const result = parseReplyDecisions(content);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].title, 'Memory leak in handler');
+    assert.equal(result[0].decision, 'FIXED');
+    assert.equal(result[0].reason, 'Refactored the handler to properly close connections.');
+  });
+
+  it('parses a single DEFERRED issue with reason', () => {
+    const content = [
+      '## Issue: Performance optimization',
+      '**Decision:** DEFERRED',
+      '**Reason:** Will address in follow-up ticket GH-300.',
+    ].join('\n');
+
+    const result = parseReplyDecisions(content);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].title, 'Performance optimization');
+    assert.equal(result[0].decision, 'DEFERRED');
+    assert.equal(result[0].reason, 'Will address in follow-up ticket GH-300.');
+  });
+
+  it('parses a single NOT_APPLICABLE issue', () => {
+    const content = [
+      '## Issue: Missing validation on input',
+      '**Decision:** NOT_APPLICABLE',
+      '**Reason:** Input is already validated upstream.',
+    ].join('\n');
+
+    const result = parseReplyDecisions(content);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].title, 'Missing validation on input');
+    assert.equal(result[0].decision, 'NOT_APPLICABLE');
+    assert.equal(result[0].reason, 'Input is already validated upstream.');
+  });
+});
+
+describe('parseReplyDecisions — multiple issues', () => {
+  it('parses multiple issues with mixed decisions', () => {
+    const content = [
+      '## Issue: SQL injection risk',
+      '**Decision:** FIXED',
+      '**Reason:** Added parameterized queries.',
+      '',
+      '## Issue: Missing error handling',
+      '**Decision:** DEFERRED',
+      '**Reason:** Tracked in GH-301.',
+      '',
+      '## Issue: Unused import',
+      '**Decision:** NOT_APPLICABLE',
+      '**Reason:** Import is used in conditional block.',
+    ].join('\n');
+
+    const result = parseReplyDecisions(content);
+    assert.equal(result.length, 3);
+    assert.equal(result[0].title, 'SQL injection risk');
+    assert.equal(result[0].decision, 'FIXED');
+    assert.equal(result[1].title, 'Missing error handling');
+    assert.equal(result[1].decision, 'DEFERRED');
+    assert.equal(result[2].title, 'Unused import');
+    assert.equal(result[2].decision, 'NOT_APPLICABLE');
+  });
+});
+
+describe('parseReplyDecisions — missing fields', () => {
+  it('sets empty reason when Reason field is missing', () => {
+    const content = ['## Issue: Some issue', '**Decision:** FIXED'].join('\n');
+
+    const result = parseReplyDecisions(content);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].title, 'Some issue');
+    assert.equal(result[0].decision, 'FIXED');
+    assert.equal(result[0].reason, '');
+  });
+
+  it('sets UNKNOWN decision when Decision field is missing', () => {
+    const content = ['## Issue: Orphaned issue', '**Reason:** Something happened.'].join('\n');
+
+    const result = parseReplyDecisions(content);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].title, 'Orphaned issue');
+    assert.equal(result[0].decision, 'UNKNOWN');
+    assert.equal(result[0].reason, 'Something happened.');
+  });
+
+  it('handles DEFERRED with empty reason (blank after Reason:)', () => {
+    const content = [
+      '## Issue: Deferred without justification',
+      '**Decision:** DEFERRED',
+      '**Reason:**',
+    ].join('\n');
+
+    const result = parseReplyDecisions(content);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].decision, 'DEFERRED');
+    assert.equal(result[0].reason, '');
+  });
+});
+
+describe('parseReplyDecisions — exports', () => {
+  it('exports parseReplyDecisions as a function', () => {
+    assert.equal(typeof parseReplyDecisions, 'function');
+  });
+});
+
+// ===========================================================================
+// isCodeReviewResolved — Task 2 (R1)
+// ===========================================================================
+describe('isCodeReviewResolved — all issues addressed', () => {
+  it('returns resolved:true when all CRITICAL issues have FIXED replies', () => {
+    const report = [
+      '## Code Review',
+      '### 🔴 CRITICAL ISSUES',
+      '**Memory leak in handler**',
+      'Details about the memory leak.',
+      '**Unvalidated input**',
+      'Details about unvalidated input.',
+      '### 🟢 NICE-TO-HAVE',
+      'Some suggestion.',
+    ].join('\n');
+
+    const reply = [
+      '## Issue: Memory leak in handler',
+      '**Decision:** FIXED',
+      '**Reason:** Refactored handler.',
+      '',
+      '## Issue: Unvalidated input',
+      '**Decision:** FIXED',
+      '**Reason:** Added validation.',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, true);
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+
+  it('returns resolved:true when DEFERRED has a reason', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**Security vulnerability**',
+      'Details.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const reply = [
+      '## Issue: Security vulnerability',
+      '**Decision:** DEFERRED',
+      '**Reason:** Tracked in GH-500 for next sprint.',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, true);
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+
+  it('returns resolved:true when NOT_APPLICABLE decision given', () => {
+    const report = [
+      '### 🟡 IMPORTANT ISSUES',
+      '**Missing test coverage**',
+      'Needs tests.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const reply = [
+      '## Issue: Missing test coverage',
+      '**Decision:** NOT_APPLICABLE',
+      '**Reason:** Tests exist in separate integration suite.',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, true);
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+});
+
+describe('isCodeReviewResolved — unaddressed issues', () => {
+  it('returns resolved:false when a CRITICAL issue has no reply', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**Memory leak in handler**',
+      'Details.',
+      '**Unvalidated input**',
+      'Details.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const reply = [
+      '## Issue: Memory leak in handler',
+      '**Decision:** FIXED',
+      '**Reason:** Fixed it.',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, false);
+    assert.equal(result.unaddressed.length, 1);
+    assert.ok(result.unaddressed[0].includes('Unvalidated input'));
+  });
+
+  it('returns resolved:false when DEFERRED has no reason', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**Security vulnerability**',
+      'Details.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const reply = [
+      '## Issue: Security vulnerability',
+      '**Decision:** DEFERRED',
+      '**Reason:**',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, false);
+    assert.equal(result.unaddressed.length, 1);
+    assert.ok(result.unaddressed[0].includes('Security vulnerability'));
+  });
+
+  it('returns resolved:false when IMPORTANT issue has no reply', () => {
+    const report = [
+      '### 🟡 IMPORTANT ISSUES',
+      '**Error handling missing**',
+      'Details.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const reply = ''; // empty reply
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, false);
+    assert.equal(result.unaddressed.length, 1);
+    assert.ok(result.unaddressed[0].includes('Error handling missing'));
+  });
+});
+
+describe('isCodeReviewResolved — no blocking issues', () => {
+  it('returns resolved:true when report has no CRITICAL or IMPORTANT issues', () => {
+    const report = [
+      '## Code Review',
+      '### 🟢 NICE-TO-HAVE IMPROVEMENTS',
+      '**Consider renaming variable**',
+      'Minor style suggestion.',
+    ].join('\n');
+
+    const reply = ''; // no reply needed
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, true);
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+
+  it('returns resolved:true when report has "No critical issues" text', () => {
+    const report = ['## Code Review', 'Status: APPROVED', 'No critical issues found.'].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, true);
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+});
+
+describe('isCodeReviewResolved — null safety', () => {
+  it('returns resolved:false for null report (cannot verify empty content)', () => {
+    const result = isCodeReviewResolved(null, null);
+    assert.equal(result.resolved, false);
+    assert.ok(result.unaddressed.length > 0, 'empty report should have unaddressed marker');
+  });
+
+  it('returns resolved:false for empty report (cannot verify empty content)', () => {
+    const result = isCodeReviewResolved('', '');
+    assert.equal(result.resolved, false);
+    assert.ok(result.unaddressed.length > 0, 'empty report should have unaddressed marker');
+  });
+});
+
+describe('isCodeReviewResolved — exports', () => {
+  it('exports isCodeReviewResolved as a function', () => {
+    assert.equal(typeof isCodeReviewResolved, 'function');
+  });
+});
+
+describe('isCodeReviewResolved — inline CRITICAL/IMPORTANT heading format', () => {
+  it('extracts issues from ### CRITICAL: Title format', () => {
+    const report = [
+      '# Code Review',
+      '',
+      '### CRITICAL: Memory leak in handler',
+      'Details about the leak.',
+      '',
+      '### CRITICAL: SQL injection risk',
+      'Details about the risk.',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, false);
+    assert.equal(result.unaddressed.length, 2);
+    assert.ok(result.unaddressed.some((t) => t.includes('Memory leak in handler')));
+    assert.ok(result.unaddressed.some((t) => t.includes('SQL injection risk')));
+  });
+
+  it('resolves inline CRITICAL heading issues via reply', () => {
+    const report = ['### CRITICAL: Memory leak in handler', 'Details.'].join('\n');
+
+    const reply = [
+      '## Issue: Memory leak in handler',
+      '**Decision:** FIXED',
+      '**Reason:** Fixed the leak.',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, true);
+  });
+});
+
+// ===========================================================================
+// GH-232 Task 4: extractIssueTitles spurious title filtering
+// ===========================================================================
+describe('isCodeReviewResolved — spurious title filtering (GH-232)', () => {
+  it('does not treat bold CRITICAL keyword in body as an issue title', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**CRITICAL** mention in body text should not be an issue.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    // "CRITICAL" alone should be filtered out as a spurious title
+    assert.equal(
+      result.resolved,
+      true,
+      'CRITICAL keyword alone must not be treated as issue title'
+    );
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+
+  it('does not treat bold IMPORTANT keyword in body as an issue title', () => {
+    const report = [
+      '### 🟡 IMPORTANT ISSUES',
+      '**IMPORTANT** this is emphasized text, not an issue title.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(
+      result.resolved,
+      true,
+      'IMPORTANT keyword alone must not be treated as issue title'
+    );
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+
+  it('does not treat bold field labels with colon like "**File:**" as issue titles', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**Memory leak in handler**',
+      '**File:** src/handler.js',
+      '**Description:** Resource not freed',
+      '**Status:** open',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const reply = [
+      '## Issue: Memory leak in handler',
+      '**Decision:** FIXED',
+      '**Reason:** Fixed it.',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, true, 'Field labels with colon must not be issue titles');
+  });
+
+  it('does not treat "**Note:**" as an issue title', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**Unsafe input handling**',
+      '**Note:** This affects all endpoints',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const reply = [
+      '## Issue: Unsafe input handling',
+      '**Decision:** FIXED',
+      '**Reason:** Added validation.',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, true, '"Note:" should be filtered as a field label');
+  });
+
+  it('treats "No error handling in foo()" as a real issue title (not filtered by SPURIOUS_TITLE_RE)', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**No error handling in foo()**',
+      'Details.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, false, '"No error handling in foo()" is a real issue');
+    assert.ok(result.unaddressed[0].includes('No error handling'));
+  });
+
+  it('does not treat short bold words (<=2 chars) as issue titles', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**No** issues found here. **It** is confirmed.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, true, 'Short bold words must not be treated as issue titles');
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+
+  it('treats 3-char titles like XSS or SQL as real issue titles', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**XSS** vulnerability found in input handler.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, false, '3-char titles like XSS should be treated as real issues');
+    assert.equal(result.unaddressed.length, 1);
+    assert.ok(result.unaddressed[0].includes('XSS'));
+  });
+
+  it('does not treat field labels like Decision/Status/Reason as issue titles', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**Decision** was made to defer. **Status** is pending. **Reason** is unclear.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, true, 'Field labels must not be treated as issue titles');
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+
+  it('does not treat NICE-TO-HAVE or SUGGESTIONS as issue titles', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**NICE-TO-HAVE** improvements listed below. **SUGGESTIONS** for improvement.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, true, 'Category keywords must not be treated as issue titles');
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+
+  it('still extracts real issue titles that are descriptive', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**Memory leak in event handler**',
+      'Details about the leak.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const reply = [
+      '## Issue: Memory leak in event handler',
+      '**Decision:** FIXED',
+      '**Reason:** Fixed the leak.',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, true);
+    assert.deepStrictEqual(result.unaddressed, []);
+  });
+
+  it('still flags real issues as unaddressed even with spurious titles filtered', () => {
+    const report = [
+      '### 🔴 CRITICAL ISSUES',
+      '**CRITICAL** emphasis in text.',
+      '**SQL injection vulnerability**',
+      'Details about the vulnerability.',
+      '### 🟢 NICE-TO-HAVE',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, false);
+    assert.equal(result.unaddressed.length, 1);
+    assert.ok(result.unaddressed[0].includes('SQL injection vulnerability'));
+  });
+});
+
+// isCodeReviewResolved — write-code-review.js "Issues Found" format
+describe('isCodeReviewResolved — Issues Found list format (write-code-review.js)', () => {
+  it('extracts critical issues from **[🔴 Critical] title** format', () => {
+    const report = [
+      '## Issues Found',
+      '',
+      '**[🔴 Critical] SQL injection in user input**',
+      '- File: `src/api.js:42`',
+      '- Description: User input not sanitized',
+      '',
+      '**[🟡 Important] Missing error handling**',
+      '- File: `src/handler.js:10`',
+      '- Description: No try-catch around async call',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, false);
+    assert.equal(result.blockingCount, 2);
+    assert.ok(result.unaddressed.some((t) => t.includes('SQL injection')));
+    assert.ok(result.unaddressed.some((t) => t.includes('Missing error handling')));
+  });
+
+  it('resolves Issues Found format when reply addresses all issues', () => {
+    const report = [
+      '## Issues Found',
+      '',
+      '**[🔴 Critical] SQL injection in user input**',
+      '- Description: User input not sanitized',
+    ].join('\n');
+
+    const reply = [
+      '## Issue: SQL injection in user input',
+      '**Decision:** FIXED',
+      '**Reason:** Added parameterized queries',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, true);
+    assert.equal(result.blockingCount, 1);
+    assert.equal(result.unaddressed.length, 0);
+  });
+
+  it('marks Issues Found format unresolved when reply is missing', () => {
+    const report = [
+      '## Issues Found',
+      '',
+      '**[🔴 Critical] XSS vulnerability**',
+      '- Description: Unescaped HTML output',
+      '',
+      '**[🟡 Important] Hardcoded credentials**',
+      '- Description: API key in source',
+    ].join('\n');
+
+    const reply = [
+      '## Issue: XSS vulnerability',
+      '**Decision:** FIXED',
+      '**Reason:** Added HTML escaping',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, reply);
+    assert.equal(result.resolved, false);
+    assert.equal(result.blockingCount, 2);
+    assert.equal(result.unaddressed.length, 1);
+    assert.ok(result.unaddressed[0].includes('Hardcoded credentials'));
+  });
+
+  it('ignores nice-to-have issues in Issues Found format', () => {
+    const report = [
+      '## Issues Found',
+      '',
+      '**[🔵 Nice-to-have] Consider adding docs**',
+      '- Description: Function lacks JSDoc',
+    ].join('\n');
+
+    const result = isCodeReviewResolved(report, '');
+    assert.equal(result.resolved, true);
+    assert.equal(result.blockingCount, 0);
+  });
+});

--- a/workflows/lib/__tests__/parse-report-status.test.js
+++ b/workflows/lib/__tests__/parse-report-status.test.js
@@ -340,6 +340,16 @@ describe('parseReportStatus — anchored markers prevent false positives', () =>
     assert.deepStrictEqual(result, { status: 'APPROVED', icon: '✅' });
   });
 
+  it('does NOT accept "Status: SUCCESS" for tests type', () => {
+    const result = parseReportStatus('Status: SUCCESS', 'tests');
+    assert.equal(result.status, 'UNKNOWN', 'SUCCESS is only valid for QA type');
+  });
+
+  it('does NOT accept "Status: SUCCESS" for codeReview type', () => {
+    const result = parseReportStatus('Status: SUCCESS', 'codeReview');
+    assert.equal(result.status, 'UNKNOWN', 'SUCCESS is only valid for QA type');
+  });
+
   it('Status: APPROVED at top overrides later Status: FAIL in embedded output', () => {
     const content = [
       'Status: APPROVED',

--- a/workflows/lib/__tests__/parse-report-status.test.js
+++ b/workflows/lib/__tests__/parse-report-status.test.js
@@ -92,7 +92,7 @@ describe('parseReportStatus — Status: line format', () => {
 
   it('recognizes Status: NEEDS_WORK', () => {
     const result = parseReportStatus('Status: NEEDS_WORK', 'codeReview');
-    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '❌' });
   });
 
   it('recognizes Status: NOT_APPLICABLE', () => {
@@ -102,7 +102,7 @@ describe('parseReportStatus — Status: line format', () => {
 
   it('recognizes Status: FAIL as NEEDS_WORK', () => {
     const result = parseReportStatus('Status: FAIL', 'tests');
-    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '❌' });
   });
 });
 
@@ -145,7 +145,7 @@ describe('parseReportStatus — summary table format', () => {
   it('recognizes | Status | NEEDS_WORK | in a table', () => {
     const content = '| Status | NEEDS_WORK |';
     const result = parseReportStatus(content, 'codeReview');
-    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '❌' });
   });
 });
 
@@ -169,13 +169,13 @@ describe('parseReportStatus — Status line priority', () => {
       '\n'
     );
     const result = parseReportStatus(content, 'codeReview');
-    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '❌' });
   });
 
   it('fail markers win when no explicit Status line exists', () => {
     const content = ['✅ PASS: 10 tests', '❌ FAIL: 2 tests'].join('\n');
     const result = parseReportStatus(content, 'tests');
-    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '❌' });
   });
 
   it('Status: APPROVED overrides fail patterns in raw test output', () => {
@@ -297,7 +297,7 @@ describe('parseReportStatus — CRITICAL section header false-negative (GH-232)'
   it('CRITICAL in prose triggers NEEDS_WORK when no explicit Status line', () => {
     const content = 'Found a CRITICAL bug in the parser.';
     const result = parseReportStatus(content, 'codeReview');
-    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '⚠️' });
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '❌' });
   });
 });
 

--- a/workflows/lib/parse-report-status.js
+++ b/workflows/lib/parse-report-status.js
@@ -7,7 +7,7 @@ const AppAccessStatus = require('../check/lib/app-access-status');
 // ---------------------------------------------------------------------------
 const ICONS = Object.create(null);
 ICONS['APPROVED'] = '✅';
-ICONS['NEEDS_WORK'] = '⚠️';
+ICONS['NEEDS_WORK'] = '❌';
 ICONS['MISSING'] = '❓';
 ICONS['NOT_APPLICABLE'] = '➖';
 ICONS['UNKNOWN'] = '❓';

--- a/workflows/lib/parse-report-status.js
+++ b/workflows/lib/parse-report-status.js
@@ -36,9 +36,12 @@ TYPE_ALIASES['completion'] = Object.assign(Object.create(null), BASE_ALIASES, {
   COMPLETE: 'APPROVED',
   DELIVERED: 'APPROVED',
 });
-// QA accepts SUCCESS as APPROVED (used by QA report generators).
+// QA accepts SUCCESS as APPROVED (used by QA report generators),
+// and recognizes infrastructure/access failure statuses from write-qa-report.js.
 TYPE_ALIASES['qa'] = Object.assign(Object.create(null), BASE_ALIASES, {
   SUCCESS: 'APPROVED',
+  INFRASTRUCTURE_FAILURE: 'INFRASTRUCTURE_FAILURE',
+  ACCESS_FAILED: 'ACCESS_FAILED',
 });
 // Fallback for types without overrides
 const STATUS_ALIASES = BASE_ALIASES;

--- a/workflows/lib/parse-report-status.js
+++ b/workflows/lib/parse-report-status.js
@@ -152,11 +152,18 @@ function checkStatusLine(content, type) {
   // later Status: tokens in embedded output should not override it.
   const re = /^\s*\*{0,2}Status:\*{0,2}\s*\*{0,2}\s*([A-Z_]+)\s*\*{0,2}/gim;
   let match;
+  let hasStatusLine = false;
   while ((match = re.exec(content)) !== null) {
+    hasStatusLine = true;
     const raw = match[1].toUpperCase();
     const resolved = resolveAlias(raw, type);
     if (resolved) return resolved;
   }
+  // If a Status: line exists but its value is not recognized for this type,
+  // return UNKNOWN to prevent heuristic fallback from overriding an explicit
+  // (but type-invalid) declaration. E.g., Status: COMPLETE in tests.check.md
+  // should NOT fall through to pass markers like ✅ PASS.
+  if (hasStatusLine) return 'UNKNOWN';
   return null;
 }
 

--- a/workflows/lib/parse-report-status.js
+++ b/workflows/lib/parse-report-status.js
@@ -1,0 +1,500 @@
+'use strict';
+
+const AppAccessStatus = require('../check/lib/app-access-status');
+
+// ---------------------------------------------------------------------------
+// Icons — keyed by normalized status (Object.create(null) per convention)
+// ---------------------------------------------------------------------------
+const ICONS = Object.create(null);
+ICONS['APPROVED'] = '✅';
+ICONS['NEEDS_WORK'] = '⚠️';
+ICONS['MISSING'] = '❓';
+ICONS['NOT_APPLICABLE'] = '➖';
+ICONS['UNKNOWN'] = '❓';
+ICONS['INFRASTRUCTURE_FAILURE'] = '🛑';
+ICONS['ACCESS_FAILED'] = '🔒';
+
+// ---------------------------------------------------------------------------
+// Status normalization — maps raw values to canonical statuses.
+// Base aliases apply to all types; type-specific overrides extend them.
+// ---------------------------------------------------------------------------
+const BASE_ALIASES = Object.create(null);
+BASE_ALIASES['APPROVED'] = 'APPROVED';
+BASE_ALIASES['PASS'] = 'APPROVED';
+BASE_ALIASES['PASSED'] = 'APPROVED';
+BASE_ALIASES['SUCCESS'] = 'APPROVED';
+BASE_ALIASES['NEEDS_WORK'] = 'NEEDS_WORK';
+BASE_ALIASES['FAIL'] = 'NEEDS_WORK';
+BASE_ALIASES['FAILED'] = 'NEEDS_WORK';
+BASE_ALIASES['INCOMPLETE'] = 'NEEDS_WORK';
+BASE_ALIASES['PENDING'] = 'NEEDS_WORK';
+BASE_ALIASES['NOT_APPLICABLE'] = 'NOT_APPLICABLE';
+
+// Per-type alias maps — only 'completion' accepts COMPLETE/DELIVERED as APPROVED.
+// tests and codeReview must use explicit APPROVED.
+const TYPE_ALIASES = Object.create(null);
+TYPE_ALIASES['completion'] = Object.assign(Object.create(null), BASE_ALIASES, {
+  COMPLETE: 'APPROVED',
+  DELIVERED: 'APPROVED',
+});
+// Fallback for types without overrides
+const STATUS_ALIASES = BASE_ALIASES;
+
+/**
+ * Resolve a raw status string to a canonical status, scoped by report type.
+ * @param {string} raw - uppercase raw status value
+ * @param {string} [type] - report type for type-specific aliases
+ * @returns {string|undefined}
+ */
+function resolveAlias(raw, type) {
+  const typeMap = type && TYPE_ALIASES[type];
+  if (typeMap && typeMap[raw] !== undefined) return typeMap[raw];
+  return STATUS_ALIASES[raw];
+}
+
+// ---------------------------------------------------------------------------
+// Per-type marker patterns (migrated from check-generate-summary.js)
+// Uses Object.create(null) for all lookup maps per project convention.
+// ---------------------------------------------------------------------------
+const TYPE_CHECKS = Object.create(null);
+
+TYPE_CHECKS['tests'] = Object.create(null);
+TYPE_CHECKS['tests'].fail = [
+  '❌ FAIL',
+  'NEEDS_WORK',
+  '(?:^|\\n)(?:ℹ\\s*)?fail(?:ed)?\\s+[1-9]\\d*',
+];
+TYPE_CHECKS['tests'].pass = ['✅ PASS', '\\bAPPROVED\\b', '\\bAll\\b.*\\bpass'];
+
+TYPE_CHECKS['codeReview'] = Object.create(null);
+TYPE_CHECKS['codeReview'].fail = ['(?<!No )CRITICAL(?!\\s*ISSUES\\b)', 'NEEDS_WORK'];
+TYPE_CHECKS['codeReview'].pass = [
+  '\\bAPPROVED\\b',
+  '\\bNo critical issues\\b',
+  '\\bNo issues found\\b',
+];
+
+TYPE_CHECKS['qa'] = Object.create(null);
+TYPE_CHECKS['qa'].fail = [
+  '❌ FAIL',
+  'FAILED:\\s*[1-9]',
+  'failures:\\s*[1-9]',
+  'Status:\\s*FAIL',
+  'Status:\\s*NEEDS_WORK',
+];
+TYPE_CHECKS['qa'].pass = [
+  '✅ PASS',
+  '\\bAll tests passed\\b',
+  '(?:^|\\n)\\s*SUCCESS\\s*(?:\\n|$)',
+  'Status:\\s*SUCCESS',
+  'Status:\\s*APPROVED',
+];
+
+TYPE_CHECKS['completion'] = Object.create(null);
+TYPE_CHECKS['completion'].fail = ['\\bINCOMPLETE\\b', '\\bPENDING\\b'];
+TYPE_CHECKS['completion'].pass = ['\\bCOMPLETE\\b', '\\bDELIVERED\\b'];
+
+// ---------------------------------------------------------------------------
+// Format checkers — each returns a normalized status string or null
+// ---------------------------------------------------------------------------
+
+/**
+ * Check for QA-specific infrastructure/access failures.
+ * Only applies to 'qa' type reports.
+ * @param {string} content
+ * @param {string} type
+ * @returns {string|null}
+ */
+function checkInfrastructureFailure(content, type) {
+  if (type !== 'qa') return null;
+  if (
+    content.includes('INFRASTRUCTURE_FAILURE') ||
+    content.includes('PLAYWRIGHT_UNAVAILABLE') ||
+    content.includes('PLAYWRIGHT UNAVAILABLE')
+  ) {
+    return 'INFRASTRUCTURE_FAILURE';
+  }
+  if (content.includes(AppAccessStatus.ACCESS_FAILED)) {
+    return 'ACCESS_FAILED';
+  }
+  return null;
+}
+
+/**
+ * Check for type-specific fail markers.
+ * Fail markers are checked first to enforce fail-first precedence (R10).
+ * @param {string} content
+ * @param {string} type
+ * @returns {string|null}
+ */
+function checkFailMarkers(content, type) {
+  const checks = TYPE_CHECKS[type];
+  if (!checks) return null;
+  for (const pattern of checks.fail) {
+    if (new RegExp(pattern, 'i').test(content)) {
+      return 'NEEDS_WORK';
+    }
+  }
+  return null;
+}
+
+/**
+ * Check for explicit Status: line (with optional bold markdown).
+ * Matches: Status: APPROVED, **Status:** **APPROVED**, **Status:** APPROVED
+ * @param {string} content
+ * @param {string} [type] - report type for type-scoped alias resolution
+ * @returns {string|null}
+ */
+function checkStatusLine(content, type) {
+  // Match Status: at start of line (^ with multiline) to avoid matching
+  // Status: mentions inside prose or bullet points. Return the FIRST
+  // recognized match — the top-level declaration is authoritative, and
+  // later Status: tokens in embedded output should not override it.
+  const re = /^\s*\*{0,2}Status:\*{0,2}\s*\*{0,2}\s*([A-Z_]+)\s*\*{0,2}/gim;
+  let match;
+  while ((match = re.exec(content)) !== null) {
+    const raw = match[1].toUpperCase();
+    const resolved = resolveAlias(raw, type);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
+/**
+ * Check for status in a markdown summary table.
+ * Matches: | Status | APPROVED |
+ * @param {string} content
+ * @param {string} [type] - report type for type-scoped alias resolution
+ * @returns {string|null}
+ */
+function checkSummaryTable(content, type) {
+  const match = content.match(/\|\s*Status\s*\|\s*\*{0,2}([A-Z_]+)\*{0,2}\s*\|/i);
+  if (!match) return null;
+  const raw = match[1].toUpperCase();
+  return resolveAlias(raw, type) || null;
+}
+
+/**
+ * Check for type-specific pass markers.
+ * @param {string} content
+ * @param {string} type
+ * @returns {string|null}
+ */
+function checkPassMarkers(content, type) {
+  const checks = TYPE_CHECKS[type];
+  if (!checks) return null;
+  for (const pattern of checks.pass) {
+    if (new RegExp(pattern, 'i').test(content)) {
+      return 'APPROVED';
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the status from report file content.
+ *
+ * Resolution priority (matches implementation order):
+ *   1. Explicit Status: line (first match, authoritative when present)
+ *   2. Summary table with status column
+ *   3. Infrastructure failures (QA only — after Status line so declared status wins)
+ *   4. Fail markers (type-specific heuristics, only when no explicit status)
+ *   5. Pass markers (type-specific heuristics)
+ *   6. Fallback: UNKNOWN
+ *
+ * @param {string|null|undefined} content - report file content
+ * @param {string} type - one of 'tests', 'codeReview', 'qa', 'completion'
+ * @returns {{ status: string, icon: string }}
+ */
+function parseReportStatus(content, type) {
+  // R9: null / undefined / empty -> MISSING
+  if (!content || !content.trim()) {
+    return { status: 'MISSING', icon: ICONS['MISSING'] };
+  }
+
+  // 1. Explicit Status: line — authoritative when present (overrides raw content patterns)
+  const lineStatus = checkStatusLine(content, type);
+  if (lineStatus) {
+    return { status: lineStatus, icon: ICONS[lineStatus] || ICONS['UNKNOWN'] };
+  }
+
+  // 2. Summary table
+  const tableStatus = checkSummaryTable(content, type);
+  if (tableStatus) {
+    return { status: tableStatus, icon: ICONS[tableStatus] || ICONS['UNKNOWN'] };
+  }
+
+  // 3. Infrastructure failures (QA only) — checked AFTER explicit Status/table so that
+  //    a declared Status: NOT_APPLICABLE or Status: APPROVED is honored even when the
+  //    report body mentions infrastructure tokens like PLAYWRIGHT_UNAVAILABLE in prose.
+  const infraStatus = checkInfrastructureFailure(content, type);
+  if (infraStatus) {
+    return { status: infraStatus, icon: ICONS[infraStatus] };
+  }
+
+  // 4. Fail markers (only when no explicit Status line — raw content heuristic)
+  const failStatus = checkFailMarkers(content, type);
+  if (failStatus) {
+    return { status: failStatus, icon: ICONS[failStatus] };
+  }
+
+  // 5. Pass markers
+  const passStatus = checkPassMarkers(content, type);
+  if (passStatus) {
+    return { status: passStatus, icon: ICONS[passStatus] };
+  }
+
+  // 6. Unknown type or no match
+  return { status: 'UNKNOWN', icon: ICONS['UNKNOWN'] };
+}
+
+// ---------------------------------------------------------------------------
+// Reply decision parsing — extracts Decision/Reason from code-review reply
+// ---------------------------------------------------------------------------
+
+// Regex for splitting on reply ## Issue: headers (used by parseReplyDecisions)
+const REPLY_ISSUE_HEADER_RE = /^##\s+Issue:\s*(.+)$/gm;
+
+/**
+ * Parse reply file content into an array of decision objects.
+ *
+ * Expected format (enforced by work-suggestion-replies.js):
+ *   ## Issue: [title]
+ *   **Decision:** FIXED | DEFERRED | NOT_APPLICABLE
+ *   **Reason:** [justification]
+ *
+ * @param {string|null|undefined} replyContent
+ * @returns {Array<{ title: string, decision: string, reason: string }>}
+ */
+function parseReplyDecisions(replyContent) {
+  if (!replyContent || !replyContent.trim()) return [];
+
+  const decisions = [];
+  const sectionStarts = [];
+
+  // Collect all ## Issue: header positions
+  let match;
+  const re = new RegExp(REPLY_ISSUE_HEADER_RE.source, 'gm');
+  while ((match = re.exec(replyContent)) !== null) {
+    sectionStarts.push({ index: match.index, title: match[1].trim() });
+  }
+
+  if (sectionStarts.length === 0) return [];
+
+  for (let i = 0; i < sectionStarts.length; i++) {
+    const start = sectionStarts[i].index;
+    const end = i + 1 < sectionStarts.length ? sectionStarts[i + 1].index : replyContent.length;
+    const sectionBody = replyContent.slice(start, end);
+
+    // Extract Decision field
+    const decisionMatch = sectionBody.match(
+      /\*\*Decision:\*\*\s*(FIXED|DEFERRED|NOT_APPLICABLE)\b/i
+    );
+    const decision = decisionMatch ? decisionMatch[1].toUpperCase() : 'UNKNOWN';
+
+    // Extract Reason field
+    const reasonMatch = sectionBody.match(/\*\*Reason:\*\*\s*(.*)/i);
+    const reason = reasonMatch ? reasonMatch[1].trim() : '';
+
+    decisions.push({
+      title: sectionStarts[i].title,
+      decision,
+      reason,
+    });
+  }
+
+  return decisions;
+}
+
+// ---------------------------------------------------------------------------
+// Code-review resolution check — cross-references report issues with replies
+// ---------------------------------------------------------------------------
+
+// Patterns for extracting CRITICAL/IMPORTANT issue titles from code-review reports.
+// Reuses the patterns from check-validate-reports.js (lines 149-156) and
+// work-suggestion-replies.js extractAllIssues().
+const CRITICAL_SECTION_RE =
+  /###?\s*(?:🔴\s*)?CRITICAL\s*ISSUES?[^\n]*\n([\s\S]*?)(?=###?\s*(?:🟡|IMPORTANT|🟢|NICE-TO-HAVE|SUGGESTIONS?|---)|$)/i;
+const IMPORTANT_SECTION_RE =
+  /###?\s*(?:🟡\s*)?IMPORTANT\s*ISSUES?[^\n]*\n([\s\S]*?)(?=###?\s*(?:🟢|NICE-TO-HAVE|SUGGESTIONS?|---)|$)/i;
+
+// Early-exit pattern: section says "none found" / "no issues" / "0 issues"
+const NO_ISSUES_RE = /none\s*found|no\s*(critical|important|issues?)|0\s*issues/i;
+
+// Patterns for extracting individual issue titles within a section.
+// Matches: **Title**, **🔴 Title**, - **Title**: desc, 1. **Title**: desc
+const ISSUE_TITLE_PATTERNS = [
+  /\*\*(?:🔴|🟡|🟢)?\s*([^*\n]+)\*\*/g,
+  /[-*]\s*\*\*([^*:]+)\*\*\s*:/g,
+  /\d+\.\s*\*\*([^*:]+)\*\*\s*:/g,
+];
+
+// Guard filter: reject spurious bold words that are not real issue titles.
+// Intentionally diverges from work-suggestion-replies.js (lines 109-115):
+//   - work-suggestion-replies filters any title starting with "no " and requires length > 3
+//   - Here we only filter specific "no issues/no critical" template phrases and allow
+//     titles starting with "No" when they describe real issues (e.g., "No error handling
+//     in foo()"). We also allow 3-char titles like "XSS" / "NPE" that are legitimate
+//     blocking findings.
+const SPURIOUS_TITLE_RE =
+  /^(none|n\/a|no\s+issues?\s*$|no\s+issues?\s+found|no\s+critical\s+issues?|no\s+important\s+issues?|none\s+found|issues?\s*found|CRITICAL\s*$|IMPORTANT\s*$|NICE-TO-HAVE|SUGGESTIONS?\s*$)/i;
+// Matches common field labels with optional trailing colon (e.g., "File", "File:")
+// Also includes "Note" to avoid treating "**Note:** something" as an issue title.
+const FIELD_LABEL_RE =
+  /^(File|Description|Impact|Recommendation|Decision|Reason|Status|Summary|Details|Category|Severity|Priority|Suggestion|Evidence|Location|Context|Resolution|Type|Source|Line|Path|Note|Example|Output|Result|Action|Fix|Cause|Root Cause):?$/i;
+
+/**
+ * Extract issue titles from a section of the code-review report.
+ * @param {string} sectionContent
+ * @returns {string[]}
+ */
+function extractIssueTitles(sectionContent) {
+  if (!sectionContent) return [];
+
+  // Check for "none found" / "no issues" early exit
+  if (NO_ISSUES_RE.test(sectionContent.substring(0, 200))) {
+    return [];
+  }
+
+  const titles = [];
+  for (const pattern of ISSUE_TITLE_PATTERNS) {
+    const re = new RegExp(pattern.source, pattern.flags);
+    let m;
+    while ((m = re.exec(sectionContent)) !== null) {
+      const title = m[1].trim();
+      // Strip trailing colon before guard checks so "File:" matches FIELD_LABEL_RE
+      const normalizedTitle = title.replace(/:$/, '');
+      if (
+        title &&
+        title.length > 2 &&
+        !SPURIOUS_TITLE_RE.test(title) &&
+        !FIELD_LABEL_RE.test(normalizedTitle) &&
+        !titles.includes(title)
+      ) {
+        titles.push(title);
+      }
+    }
+  }
+  return titles;
+}
+
+/**
+ * Determine whether all CRITICAL/IMPORTANT issues in a code-review report
+ * have been addressed in the reply file.
+ *
+ * An issue is addressed if its reply decision is:
+ *   - FIXED
+ *   - DEFERRED (with a non-empty reason)
+ *   - NOT_APPLICABLE
+ *
+ * DEFERRED without a reason is treated as unaddressed (blocks).
+ *
+ * @param {string|null|undefined} reportContent - code-review.check.md content
+ * @param {string|null|undefined} replyContent  - code-review-reply.check.md content
+ * @returns {{ resolved: boolean, unaddressed: string[], blockingCount: number }}
+ */
+function isCodeReviewResolved(reportContent, replyContent) {
+  // Empty/missing report cannot be considered resolved — callers should not
+  // bypass the gate on an empty code-review.check.md just because a reply exists.
+  if (!reportContent || !reportContent.trim()) {
+    return { resolved: false, unaddressed: ['(empty report content)'], blockingCount: 0 };
+  }
+
+  // Extract CRITICAL and IMPORTANT issue titles from the report.
+  // Supports three formats:
+  //   1. Section-based: "## CRITICAL ISSUES" with bold issue titles inside
+  //   2. Heading-based: "### CRITICAL: Title" / "### IMPORTANT: Title" (inline titles)
+  //   3. Issues Found list: "**[🔴 Critical] Title**" / "**[🟡 Important] Title**"
+  //      (canonical output of write-code-review.js under "## Issues Found")
+  const criticalMatch = reportContent.match(CRITICAL_SECTION_RE);
+  const importantMatch = reportContent.match(IMPORTANT_SECTION_RE);
+
+  const criticalTitles = extractIssueTitles(criticalMatch ? criticalMatch[1] : '');
+  const importantTitles = extractIssueTitles(importantMatch ? importantMatch[1] : '');
+
+  // Also extract inline heading-based issues (### CRITICAL: Title / ### IMPORTANT: Title)
+  const INLINE_CRITICAL_RE = /###?\s*(?:🔴\s*)?CRITICAL:\s*(.+)/gi;
+  const INLINE_IMPORTANT_RE = /###?\s*(?:🟡\s*)?IMPORTANT:\s*(.+)/gi;
+  let inlineMatch;
+  while ((inlineMatch = INLINE_CRITICAL_RE.exec(reportContent)) !== null) {
+    const title = inlineMatch[1].trim();
+    if (title && !criticalTitles.includes(title)) criticalTitles.push(title);
+  }
+  while ((inlineMatch = INLINE_IMPORTANT_RE.exec(reportContent)) !== null) {
+    const title = inlineMatch[1].trim();
+    if (title && !importantTitles.includes(title)) importantTitles.push(title);
+  }
+
+  // Extract from "## Issues Found" list format (write-code-review.js output):
+  //   **[🔴 Critical] Title** or **[🟡 Important] Title**
+  const ISSUES_FOUND_CRITICAL_RE = /\*\*\[🔴\s*Critical\]\s*([^*\n]+)\*\*/gi;
+  const ISSUES_FOUND_IMPORTANT_RE = /\*\*\[🟡\s*Important\]\s*([^*\n]+)\*\*/gi;
+  let issuesMatch;
+  while ((issuesMatch = ISSUES_FOUND_CRITICAL_RE.exec(reportContent)) !== null) {
+    const title = issuesMatch[1].trim();
+    if (title && !criticalTitles.includes(title)) criticalTitles.push(title);
+  }
+  while ((issuesMatch = ISSUES_FOUND_IMPORTANT_RE.exec(reportContent)) !== null) {
+    const title = issuesMatch[1].trim();
+    if (title && !importantTitles.includes(title)) importantTitles.push(title);
+  }
+
+  const allBlockingTitles = [...criticalTitles, ...importantTitles];
+
+  // No blocking issues -> resolved
+  if (allBlockingTitles.length === 0) {
+    return { resolved: true, unaddressed: [], blockingCount: 0 };
+  }
+
+  // Parse reply decisions
+  const decisions = parseReplyDecisions(replyContent);
+
+  // Build a lookup of reply decisions by normalized title
+  const decisionByTitle = Object.create(null);
+  for (const d of decisions) {
+    decisionByTitle[
+      d.title
+        .toLowerCase()
+        .replace(/[^\w\s]/g, '')
+        .trim()
+    ] = d;
+  }
+
+  // Check each blocking issue
+  const unaddressed = [];
+  for (const title of allBlockingTitles) {
+    const normalized = title
+      .toLowerCase()
+      .replace(/[^\w\s]/g, '')
+      .trim();
+    const reply = decisionByTitle[normalized];
+
+    if (!reply) {
+      unaddressed.push(title);
+      continue;
+    }
+
+    const { decision, reason } = reply;
+    if (decision === 'FIXED' || decision === 'NOT_APPLICABLE') {
+      continue; // addressed
+    }
+    if (decision === 'DEFERRED' && reason && reason.trim()) {
+      continue; // addressed with justification
+    }
+
+    // DEFERRED without reason, UNKNOWN, or invalid decision -> unaddressed
+    unaddressed.push(title);
+  }
+
+  return {
+    resolved: unaddressed.length === 0,
+    unaddressed,
+    blockingCount: allBlockingTitles.length,
+  };
+}
+
+module.exports = { parseReportStatus, parseReplyDecisions, isCodeReviewResolved };

--- a/workflows/lib/parse-report-status.js
+++ b/workflows/lib/parse-report-status.js
@@ -22,7 +22,6 @@ const BASE_ALIASES = Object.create(null);
 BASE_ALIASES['APPROVED'] = 'APPROVED';
 BASE_ALIASES['PASS'] = 'APPROVED';
 BASE_ALIASES['PASSED'] = 'APPROVED';
-BASE_ALIASES['SUCCESS'] = 'APPROVED';
 BASE_ALIASES['NEEDS_WORK'] = 'NEEDS_WORK';
 BASE_ALIASES['FAIL'] = 'NEEDS_WORK';
 BASE_ALIASES['FAILED'] = 'NEEDS_WORK';
@@ -30,12 +29,16 @@ BASE_ALIASES['INCOMPLETE'] = 'NEEDS_WORK';
 BASE_ALIASES['PENDING'] = 'NEEDS_WORK';
 BASE_ALIASES['NOT_APPLICABLE'] = 'NOT_APPLICABLE';
 
-// Per-type alias maps — only 'completion' accepts COMPLETE/DELIVERED as APPROVED.
-// tests and codeReview must use explicit APPROVED.
+// Per-type alias maps extend BASE_ALIASES with type-specific keywords.
+// tests and codeReview must use explicit APPROVED/PASS/PASSED.
 const TYPE_ALIASES = Object.create(null);
 TYPE_ALIASES['completion'] = Object.assign(Object.create(null), BASE_ALIASES, {
   COMPLETE: 'APPROVED',
   DELIVERED: 'APPROVED',
+});
+// QA accepts SUCCESS as APPROVED (used by QA report generators).
+TYPE_ALIASES['qa'] = Object.assign(Object.create(null), BASE_ALIASES, {
+  SUCCESS: 'APPROVED',
 });
 // Fallback for types without overrides
 const STATUS_ALIASES = BASE_ALIASES;
@@ -67,7 +70,7 @@ TYPE_CHECKS['tests'].fail = [
 TYPE_CHECKS['tests'].pass = ['✅ PASS', '\\bAPPROVED\\b', '\\bAll\\b.*\\bpass'];
 
 TYPE_CHECKS['codeReview'] = Object.create(null);
-TYPE_CHECKS['codeReview'].fail = ['(?<!No )CRITICAL(?!\\s*ISSUES\\b)', 'NEEDS_WORK'];
+TYPE_CHECKS['codeReview'].fail = ['(?<!No )CRITICAL(?!\\s*ISSUES?\\b)', 'NEEDS_WORK'];
 TYPE_CHECKS['codeReview'].pass = [
   '\\bAPPROVED\\b',
   '\\bNo critical issues\\b',

--- a/workflows/lib/parse-report-status.js
+++ b/workflows/lib/parse-report-status.js
@@ -146,25 +146,17 @@ function checkFailMarkers(content, type) {
  * @returns {string|null}
  */
 function checkStatusLine(content, type) {
-  // Match Status: at start of line (^ with multiline) to avoid matching
-  // Status: mentions inside prose or bullet points. Return the FIRST
-  // recognized match — the top-level declaration is authoritative, and
-  // later Status: tokens in embedded output should not override it.
-  const re = /^\s*\*{0,2}Status:\*{0,2}\s*\*{0,2}\s*([A-Z_]+)\s*\*{0,2}/gim;
-  let match;
-  let hasStatusLine = false;
-  while ((match = re.exec(content)) !== null) {
-    hasStatusLine = true;
-    const raw = match[1].toUpperCase();
-    const resolved = resolveAlias(raw, type);
-    if (resolved) return resolved;
-  }
-  // If a Status: line exists but its value is not recognized for this type,
-  // return UNKNOWN to prevent heuristic fallback from overriding an explicit
-  // (but type-invalid) declaration. E.g., Status: COMPLETE in tests.check.md
-  // should NOT fall through to pass markers like ✅ PASS.
-  if (hasStatusLine) return 'UNKNOWN';
-  return null;
+  // Match the FIRST Status: at start of line (^ with multiline). The top-level
+  // declaration is authoritative — later Status: tokens in embedded output must
+  // not override it. If the first Status: line's value is not recognized for this
+  // type, return UNKNOWN to prevent heuristic fallback from overriding an explicit
+  // (but type-invalid) declaration.
+  const re = /^\s*\*{0,2}Status:\*{0,2}\s*\*{0,2}\s*([A-Z_]+)\s*\*{0,2}/im;
+  const match = content.match(re);
+  if (!match) return null;
+  const raw = match[1].toUpperCase();
+  const resolved = resolveAlias(raw, type);
+  return resolved || 'UNKNOWN';
 }
 
 /**
@@ -178,7 +170,8 @@ function checkSummaryTable(content, type) {
   const match = content.match(/\|\s*Status\s*\|\s*\*{0,2}([A-Z_]+)\*{0,2}\s*\|/i);
   if (!match) return null;
   const raw = match[1].toUpperCase();
-  return resolveAlias(raw, type) || null;
+  // Return UNKNOWN for type-invalid values to prevent heuristic fallback.
+  return resolveAlias(raw, type) || 'UNKNOWN';
 }
 
 /**
@@ -378,7 +371,7 @@ function extractIssueTitles(sectionContent) {
       if (
         title &&
         title.length > 2 &&
-        !SPURIOUS_TITLE_RE.test(title) &&
+        !SPURIOUS_TITLE_RE.test(normalizedTitle) &&
         !FIELD_LABEL_RE.test(normalizedTitle) &&
         !titles.includes(title)
       ) {

--- a/workflows/work/__tests__/check-gate.test.js
+++ b/workflows/work/__tests__/check-gate.test.js
@@ -93,7 +93,11 @@ describe('check-gate (unit)', () => {
       const rule = freshRules.find((r) => r.name === 'qa-reports');
       const reasons = rule.check(path.join(TEMP, testTicket));
       assert.equal(reasons.length, 1);
-      assert.ok(reasons[0].includes('qa-feature.check.md'));
+      assert.ok(reasons[0].includes('qa-feature.check.md'), 'reason should mention file');
+      assert.ok(
+        reasons[0].includes('APPROVED or NOT_APPLICABLE'),
+        'reason should mention accepted statuses'
+      );
     } finally {
       if (savedWebApps === undefined) delete process.env.WEB_APPS;
       else process.env.WEB_APPS = savedWebApps;
@@ -463,5 +467,345 @@ describe('check-gate (unit)', () => {
     const specRule = CHECK_GATE_RULES.find((r) => r.name === 'spec-verification');
     const reasons = specRule.check(ticketDir, testTicket);
     assert.equal(reasons.length, 0);
+  });
+
+  // ─── GH-232: code-review reply reconciliation ──────────────────────────
+
+  it('required-reports rule passes when code-review has complete reply file', () => {
+    writeReport('tests.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    // code-review has CRITICAL issues (would normally fail)
+    writeReport(
+      'code-review.check.md',
+      '# Code Review\n\n## CRITICAL ISSUES\n\n**Missing error handling**\n\nStatus: NEEDS_WORK'
+    );
+    // But the reply file resolves all issues
+    writeReport(
+      'code-review-reply.check.md',
+      '## Issue: Missing error handling\n\n**Decision:** FIXED\n**Reason:** Added try/catch blocks\n'
+    );
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'required-reports');
+    const reasons = rule.check(path.join(TEMP, testTicket));
+    assert.deepStrictEqual(reasons, [], 'code-review with complete reply should pass');
+  });
+
+  it('required-reports rule blocks when code-review reply is incomplete', () => {
+    writeReport('tests.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    writeReport(
+      'code-review.check.md',
+      '# Code Review\n\n## CRITICAL ISSUES\n\n**Missing error handling**\n\n**SQL injection risk**\n\nStatus: NEEDS_WORK'
+    );
+    // Reply only addresses one of two issues
+    writeReport(
+      'code-review-reply.check.md',
+      '## Issue: Missing error handling\n\n**Decision:** FIXED\n**Reason:** Added try/catch blocks\n'
+    );
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'required-reports');
+    const reasons = rule.check(path.join(TEMP, testTicket));
+    assert.ok(reasons.length > 0, 'incomplete reply should block');
+    assert.ok(
+      reasons.some((r) => r.includes('code-review')),
+      'reason should mention code-review'
+    );
+  });
+
+  it('required-reports rule blocks when no reply file and CRITICAL issues present', () => {
+    writeReport('tests.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    writeReport(
+      'code-review.check.md',
+      '# Code Review\n\n## CRITICAL ISSUES\n\n**Missing error handling**\n\nStatus: NEEDS_WORK'
+    );
+    // No reply file exists
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'required-reports');
+    const reasons = rule.check(path.join(TEMP, testTicket));
+    assert.ok(reasons.length > 0, 'no reply with CRITICAL issues should block');
+    assert.ok(reasons.some((r) => r.includes('code-review')));
+  });
+
+  it('required-reports rule passes APPROVED code-review even with incomplete reply file', () => {
+    writeReport('tests.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    // code-review is APPROVED — reply should not block it
+    writeReport('code-review.check.md', 'Status: APPROVED\n\n## CRITICAL ISSUES\nNone found.');
+    // Incomplete reply file exists
+    writeReport(
+      'code-review-reply.check.md',
+      '## Issue: Some other issue\n\n**Decision:** FIXED\n**Reason:** Done\n'
+    );
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'required-reports');
+    const reasons = rule.check(path.join(TEMP, testTicket));
+    assert.deepStrictEqual(
+      reasons,
+      [],
+      'APPROVED code-review should pass regardless of reply state'
+    );
+  });
+
+  it('required-reports rule blocks empty code-review even with reply file', () => {
+    writeReport('tests.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    writeReport('code-review.check.md', '   '); // empty/whitespace
+    writeReport(
+      'code-review-reply.check.md',
+      '## Issue: X\n**Decision:** FIXED\n**Reason:** Done\n'
+    );
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'required-reports');
+    const reasons = rule.check(path.join(TEMP, testTicket));
+    assert.ok(reasons.length > 0, 'empty code-review must not pass');
+    assert.ok(reasons[0].includes('empty'), 'reason should mention empty');
+  });
+
+  it('required-reports rule passes with bold Status format', () => {
+    writeReport('tests.check.md', '**Status:** **APPROVED**');
+    writeReport('code-review.check.md', '**Status:** **APPROVED**');
+    writeReport('completion.check.md', '**Status:** **COMPLETE**');
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'required-reports');
+    const reasons = rule.check(path.join(TEMP, testTicket));
+    assert.deepStrictEqual(reasons, [], 'bold Status format should be recognized');
+  });
+
+  it('required-reports rule passes with summary table format', () => {
+    writeReport('tests.check.md', '| Status | APPROVED |');
+    writeReport('code-review.check.md', '| Status | APPROVED |');
+    writeReport('completion.check.md', '| Status | COMPLETE |');
+    const rule = CHECK_GATE_RULES.find((r) => r.name === 'required-reports');
+    const reasons = rule.check(path.join(TEMP, testTicket));
+    assert.deepStrictEqual(reasons, [], 'summary table format should be recognized');
+  });
+
+  // ─── GH-232: QA NOT_APPLICABLE ─────────────────────────────────────────
+
+  it('qa-reports rule passes when report has Status: NOT_APPLICABLE', () => {
+    const savedWebApps = process.env.WEB_APPS;
+    try {
+      process.env.WEB_APPS = '[{"name":"test-app","defaultPort":3000,"type":"vite"}]';
+      const configPath = require.resolve('../../lib/config');
+      const gatePath = require.resolve('../check-gate');
+      delete require.cache[configPath];
+      delete require.cache[gatePath];
+      const { CHECK_GATE_RULES: freshRules } = require('../check-gate');
+      writeReport(
+        'qa-feature.check.md',
+        'QA skipped because no WEB_APPS configured\n\nStatus: NOT_APPLICABLE'
+      );
+      const rule = freshRules.find((r) => r.name === 'qa-reports');
+      const reasons = rule.check(path.join(TEMP, testTicket));
+      assert.deepStrictEqual(reasons, [], 'NOT_APPLICABLE QA report should pass');
+    } finally {
+      if (savedWebApps === undefined) delete process.env.WEB_APPS;
+      else process.env.WEB_APPS = savedWebApps;
+      delete require.cache[require.resolve('../../lib/config')];
+      delete require.cache[require.resolve('../check-gate')];
+    }
+  });
+
+  // ─── GH-232: structured per-rule results ────────────────────────────────
+
+  it('validateCheckGate returns structured rules array', () => {
+    writeReport('tests.check.md', 'Status: APPROVED');
+    writeReport('code-review.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    const result = validateCheckGate(TEMP, testTicket);
+    // Result must have rules array
+    assert.ok(Array.isArray(result.rules), 'result must have rules array');
+    assert.equal(
+      result.rules.length,
+      CHECK_GATE_RULES.length,
+      'rules array must have one entry per gate rule'
+    );
+    for (const rule of result.rules) {
+      assert.ok(typeof rule.name === 'string', 'each rule must have a name');
+      assert.ok(typeof rule.passed === 'boolean', 'each rule must have a passed boolean');
+      assert.ok(Array.isArray(rule.reasons), 'each rule must have a reasons array');
+    }
+    // Backward compatibility: valid and reasons still present
+    assert.ok(typeof result.valid === 'boolean', 'valid must still exist');
+    assert.ok(Array.isArray(result.reasons), 'reasons must still exist');
+  });
+
+  // ─── GH-232 Task 8: False-negative scenario integration tests ───────────
+  // These exercise the full validateCheckGate() path, not individual rules.
+
+  it('integration: code-review with reply resolution passes full gate', () => {
+    // Scenario: code-review.check.md has CRITICAL issues but
+    // code-review-reply.check.md resolves all of them.
+    // The full validateCheckGate() must return valid: true.
+    writeReport('tests.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    writeReport(
+      'code-review.check.md',
+      '# Code Review\n\n## CRITICAL ISSUES\n\n**Unsafe input handling**\n\n**Memory leak in event listener**\n\nStatus: NEEDS_WORK'
+    );
+    writeReport(
+      'code-review-reply.check.md',
+      '## Issue: Unsafe input handling\n\n**Decision:** FIXED\n**Reason:** Added input validation\n\n## Issue: Memory leak in event listener\n\n**Decision:** FIXED\n**Reason:** Added cleanup in dispose()\n'
+    );
+    const result = validateCheckGate(TEMP, testTicket);
+    // Filter to only required-reports and qa-reports reasons (ignore running-agents, spec-verification, tdd which are env-dependent)
+    const reportReasons = result.reasons.filter(
+      (r) => r.includes('report') || r.includes('Report') || r.includes('code-review')
+    );
+    assert.deepStrictEqual(
+      reportReasons,
+      [],
+      'gate should pass for code-review when reply resolves all CRITICAL issues'
+    );
+    // Verify the required-reports rule specifically passed
+    const requiredRule = result.rules.find((r) => r.name === 'required-reports');
+    assert.ok(requiredRule, 'required-reports rule must be in results');
+    assert.equal(requiredRule.passed, true, 'required-reports rule must pass');
+    assert.deepStrictEqual(requiredRule.reasons, []);
+  });
+
+  it('integration: QA skipped with NOT_APPLICABLE passes full gate', () => {
+    // Scenario: WEB_APPS is configured with entries, but the QA report
+    // has Status: NOT_APPLICABLE. The full gate must pass.
+    const savedWebApps = process.env.WEB_APPS;
+    try {
+      process.env.WEB_APPS = '[{"name":"my-app","defaultPort":3000,"type":"vite"}]';
+      const configPath = require.resolve('../../lib/config');
+      const gatePath = require.resolve('../check-gate');
+      delete require.cache[configPath];
+      delete require.cache[gatePath];
+      const { validateCheckGate: freshValidate } = require('../check-gate');
+      writeReport('tests.check.md', 'Status: APPROVED');
+      writeReport('code-review.check.md', 'Status: APPROVED');
+      writeReport('completion.check.md', 'Status: COMPLETE');
+      writeReport(
+        'qa-feature.check.md',
+        'QA skipped because no WEB_APPS configured\n\nStatus: NOT_APPLICABLE'
+      );
+      const result = freshValidate(TEMP, testTicket);
+      // No QA-related failures
+      const qaReasons = result.reasons.filter((r) => r.toLowerCase().includes('qa'));
+      assert.deepStrictEqual(
+        qaReasons,
+        [],
+        'gate should pass when QA report has NOT_APPLICABLE status'
+      );
+      // Verify the qa-reports rule specifically passed
+      const qaRule = result.rules.find((r) => r.name === 'qa-reports');
+      assert.ok(qaRule, 'qa-reports rule must be in results');
+      assert.equal(qaRule.passed, true, 'qa-reports rule must pass with NOT_APPLICABLE');
+    } finally {
+      if (savedWebApps === undefined) delete process.env.WEB_APPS;
+      else process.env.WEB_APPS = savedWebApps;
+      delete require.cache[require.resolve('../../lib/config')];
+      delete require.cache[require.resolve('../check-gate')];
+    }
+  });
+
+  it('integration: report with summary table (no Status line) passes full gate', () => {
+    // Scenario: tests.check.md has ONLY a summary table format
+    // "| Status | APPROVED |" with no explicit "Status: APPROVED" line.
+    // The full validateCheckGate() must pass the required-reports rule.
+    writeReport(
+      'tests.check.md',
+      '# Test Results\n\n| Field | Value |\n|-------|-------|\n| Status | APPROVED |\n| Tests | 42 |'
+    );
+    writeReport('code-review.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    const result = validateCheckGate(TEMP, testTicket);
+    // Verify required-reports rule passes (tests.check.md recognized via table)
+    const requiredRule = result.rules.find((r) => r.name === 'required-reports');
+    assert.ok(requiredRule, 'required-reports rule must be in results');
+    assert.deepStrictEqual(
+      requiredRule.reasons,
+      [],
+      'required-reports must pass when tests.check.md uses summary table format'
+    );
+    assert.equal(requiredRule.passed, true);
+  });
+
+  it('integration: APPROVED code-review with CRITICAL ISSUES header (no reply file) passes gate (GH-232)', () => {
+    // Scenario: code-review.check.md has Status: APPROVED with standard
+    // template headers like "### CRITICAL ISSUES\nNone found." but no reply file.
+    // The CRITICAL in the section header must NOT trigger a false-negative.
+    writeReport('tests.check.md', 'Status: APPROVED');
+    writeReport('completion.check.md', 'Status: COMPLETE');
+    writeReport(
+      'code-review.check.md',
+      [
+        '# Code Review Report',
+        '',
+        'Status: APPROVED',
+        '',
+        '## Summary',
+        'Code looks good overall.',
+        '',
+        '### CRITICAL ISSUES',
+        'None found.',
+        '',
+        '### IMPORTANT ISSUES',
+        'None found.',
+        '',
+        '### 🟢 NICE-TO-HAVE',
+        '**Consider adding JSDoc** for public API.',
+      ].join('\n')
+    );
+    // No reply file — should still pass because report is APPROVED
+    const result = validateCheckGate(TEMP, testTicket);
+    const requiredRule = result.rules.find((r) => r.name === 'required-reports');
+    assert.ok(requiredRule, 'required-reports rule must be in results');
+    assert.equal(
+      requiredRule.passed,
+      true,
+      'required-reports must pass when code-review is APPROVED with CRITICAL section headers'
+    );
+    assert.deepStrictEqual(requiredRule.reasons, []);
+  });
+
+  it('integration: validateCheckGate structured rules have name, passed, reasons per rule', () => {
+    // Scenario: Call validateCheckGate() with some reports missing to
+    // exercise both passing and failing rules. Verify every rule entry
+    // has the correct shape AND that the rules array reflects actual pass/fail.
+    writeReport('tests.check.md', 'Status: APPROVED');
+    // Missing code-review and completion — required-reports should fail
+    const result = validateCheckGate(TEMP, testTicket);
+    // Shape validation
+    assert.ok(Array.isArray(result.rules), 'result must have rules array');
+    assert.equal(
+      result.rules.length,
+      CHECK_GATE_RULES.length,
+      'rules array must have one entry per CHECK_GATE_RULE'
+    );
+    for (const rule of result.rules) {
+      assert.ok(
+        typeof rule.name === 'string' && rule.name.length > 0,
+        `rule must have a non-empty name`
+      );
+      assert.ok(typeof rule.passed === 'boolean', `rule "${rule.name}" must have a passed boolean`);
+      assert.ok(Array.isArray(rule.reasons), `rule "${rule.name}" must have a reasons array`);
+      // passed must be consistent with reasons
+      if (rule.passed) {
+        assert.equal(
+          rule.reasons.length,
+          0,
+          `rule "${rule.name}" marked passed must have empty reasons`
+        );
+      } else {
+        assert.ok(
+          rule.reasons.length > 0,
+          `rule "${rule.name}" marked failed must have non-empty reasons`
+        );
+      }
+    }
+    // required-reports specifically should fail (missing code-review and completion)
+    const requiredRule = result.rules.find((r) => r.name === 'required-reports');
+    assert.ok(requiredRule, 'required-reports rule must exist');
+    assert.equal(requiredRule.passed, false, 'required-reports must fail with missing reports');
+    assert.ok(
+      requiredRule.reasons.some((r) => r.includes('code-review.check.md')),
+      'reasons must mention missing code-review'
+    );
+    assert.ok(
+      requiredRule.reasons.some((r) => r.includes('completion.check.md')),
+      'reasons must mention missing completion'
+    );
+    // Backward compat: top-level valid and reasons
+    assert.equal(result.valid, false);
+    assert.ok(result.reasons.length > 0);
   });
 });

--- a/workflows/work/check-gate.js
+++ b/workflows/work/check-gate.js
@@ -14,6 +14,7 @@ const path = require('path');
 const fs = require('fs');
 const { execFileSync } = require('child_process');
 const config = require(path.join(__dirname, '..', 'lib', 'config'));
+const { parseReportStatus, isCodeReviewResolved } = require('../lib/parse-report-status');
 
 // ─── Helpers (local, no external deps) ──────────────────────────────────────
 
@@ -89,9 +90,9 @@ const CHECK_GATE_RULES = [
       'All required .check.md reports must exist with accepted status (APPROVED or COMPLETE)',
     check(dir) {
       const required = [
-        { file: 'tests.check.md', pattern: /Status:\s*\*{0,2}\s*APPROVED/i },
-        { file: 'code-review.check.md', pattern: /Status:\s*\*{0,2}\s*APPROVED/i },
-        { file: 'completion.check.md', pattern: /Status:\s*\*{0,2}\s*(COMPLETE|APPROVED)/i },
+        { file: 'tests.check.md', type: 'tests' },
+        { file: 'code-review.check.md', type: 'codeReview' },
+        { file: 'completion.check.md', type: 'completion' },
       ];
       const reasons = [];
       for (const req of required) {
@@ -100,8 +101,47 @@ const CHECK_GATE_RULES = [
           reasons.push(`Missing report: ${req.file}`);
           continue;
         }
-        if (!req.pattern.test(readFile(fp))) {
-          reasons.push(`Report ${req.file} does not contain the required Status: line`);
+        const content = readFile(fp);
+
+        // Guard: empty/whitespace content cannot pass any gate
+        if (!content || !content.trim()) {
+          reasons.push(`Report ${req.file} is empty`);
+          continue;
+        }
+
+        const { status } = parseReportStatus(content, req.type);
+
+        // Code-review: short-circuit on APPROVED (no need to check replies),
+        // then check reply reconciliation for non-APPROVED statuses.
+        if (req.type === 'codeReview') {
+          // If already APPROVED, accept regardless of reply file state
+          if (status === 'APPROVED') {
+            continue;
+          }
+
+          const replyPath = path.join(dir, 'code-review-reply.check.md');
+          if (fileExists(replyPath)) {
+            const replyContent = readFile(replyPath);
+            const resolution = isCodeReviewResolved(content, replyContent);
+            if (resolution.blockingCount > 0) {
+              // Report has CRITICAL/IMPORTANT issues — reply reconciliation decides
+              if (resolution.resolved) {
+                continue; // blockingCount > 0 but all addressed — skip this report
+              }
+              reasons.push(
+                `Report ${req.file} has unresolved issues: ${resolution.unaddressed.join(', ')}`
+              );
+              continue;
+            } // blockingCount === 0: no CRITICAL/IMPORTANT issues found in report
+            // No blocking issues extracted — reply file cannot bypass a non-APPROVED
+            // status; fall through to the standard status check below.
+          }
+          // No reply file — fall through to status check
+        }
+
+        if (status !== 'APPROVED') {
+          // Status line is the authoritative gate when no blocking issues exist
+          reasons.push(`Report ${req.file} status is ${status} (expected APPROVED)`);
         }
       }
       return reasons;
@@ -110,7 +150,7 @@ const CHECK_GATE_RULES = [
   {
     name: 'qa-reports',
     description:
-      'At least one qa-*.check.md must exist when web apps are configured; all must have Status: APPROVED',
+      'At least one qa-*.check.md must exist when web apps are configured; all must have Status: APPROVED or NOT_APPLICABLE',
     check(dir) {
       // Skip QA requirement when no web apps are configured (GH-181)
       if (config.webAppNames().length === 0) {
@@ -118,9 +158,16 @@ const CHECK_GATE_RULES = [
       }
       const qaFiles = listFiles(dir, /^qa-.*\.check\.md$/);
       if (qaFiles.length === 0) return ['No QA reports found (need at least one qa-*.check.md)'];
-      return qaFiles
-        .filter((f) => !/Status:\s*\*{0,2}\s*APPROVED/i.test(readFile(f)))
-        .map((f) => `QA report ${path.basename(f)} does not have Status: APPROVED`); // regex on line above handles bold markdown
+      const reasons = [];
+      for (const f of qaFiles) {
+        const { status } = parseReportStatus(readFile(f), 'qa');
+        if (status !== 'APPROVED' && status !== 'NOT_APPLICABLE') {
+          reasons.push(
+            `QA report ${path.basename(f)} has status ${status} (expected APPROVED or NOT_APPLICABLE)`
+          );
+        }
+      }
+      return reasons;
     },
   },
   {
@@ -250,12 +297,16 @@ const CHECK_GATE_RULES = [
  * Validate all check-gate rules for a ticket.
  * @param {string} tasksBase - Root tasks directory
  * @param {string} ticket    - Ticket ID (e.g. "PROJ-123")
- * @returns {{ valid: boolean, reasons: string[] }}
+ * @returns {{ valid: boolean, reasons: string[], rules: Array<{ name: string, passed: boolean, reasons: string[] }> }}
  */
 function validateCheckGate(tasksBase, ticket) {
   const dir = path.join(tasksBase, ticket);
-  const reasons = CHECK_GATE_RULES.flatMap((rule) => rule.check(dir, ticket));
-  return { valid: reasons.length === 0, reasons };
+  const rules = CHECK_GATE_RULES.map((rule) => {
+    const ruleReasons = rule.check(dir, ticket);
+    return { name: rule.name, passed: ruleReasons.length === 0, reasons: ruleReasons };
+  });
+  const reasons = rules.flatMap((r) => r.reasons);
+  return { valid: reasons.length === 0, reasons, rules };
 }
 
 module.exports = { CHECK_GATE_RULES, validateCheckGate };


### PR DESCRIPTION
## Existing Behavior

- `getReportStatus()` in `check-generate-summary.js` contains its own inline status-detection logic (regex patterns, fail/pass maps, QA infra checks), duplicated nowhere else and untestable in isolation.
- A code-review report with a `## CRITICAL ISSUES` section header triggers the `CRITICAL` fail marker even when the section body says "None found" and the status line reads `APPROVED`.
- `Status: APPROVED` on a top-level line cannot override explicit fail patterns found later in embedded output (e.g., raw test runner output containing `ℹ fail 16`), producing a false negative.
- `isCodeReviewResolved()` does not exist; there is no structured way to cross-reference code-review report issues with developer reply decisions, and `QA: NOT_APPLICABLE` has no non-blocking path through the gate.

## Intended New Behavior

- A shared `parseReportStatus(content, type)` function in `workflows/lib/parse-report-status.js` centralizes all status-detection logic with a strict resolution priority: explicit `Status:` line > summary table > infra failures (QA) > fail markers > pass markers.
- `Status:` line is authoritative: when present, it short-circuits all body-level heuristics, so `## CRITICAL ISSUES` section headers and embedded raw output can no longer produce false negatives.
- Type-scoped aliases prevent cross-type `Status:` leakage (e.g., `Status: COMPLETE` is only valid for `completion` type, not `tests` or `codeReview`).
- `isCodeReviewResolved(reportContent, replyContent)` and `parseReplyDecisions(replyContent)` are exported from the shared module, enabling per-issue reconciliation (FIXED / DEFERRED with reason / NOT_APPLICABLE) and treating `QA: NOT_APPLICABLE` as non-blocking.
- A title-filter guard (`SPURIOUS_TITLE_RE` + `FIELD_LABEL_RE`) in `extractIssueTitles()` prevents bold keyword noise (e.g., `**CRITICAL**` in prose, `**File:**` field labels) from being registered as unaddressed blocking issues.
- `check-generate-summary.js` delegates entirely to `parseReportStatus` (R8), removing ~70 lines of duplicated logic and preserving the `getReportStatus` export name for backward compatibility.

## Dev Checks

- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

105 tests cover the new module (89 in `parse-report-status.test.js`, 16 in `check-generate-summary.test.js`).

To verify the core false-negative fix manually:

1. Create a file `test-report.check.md` with this content:
   ```
   Status: APPROVED

   ## CRITICAL ISSUES
   None found.
   ```
2. Run the gate logic against it with type `codeReview` — result must be `{ status: 'APPROVED', icon: '✅' }`.
3. Add a `## CRITICAL ISSUES` section with an actual issue title (no "None found") and no `Status:` line — result must be `{ status: 'NEEDS_WORK', icon: '⚠️' }`.
4. Verify `QA` report with `Status: NOT_APPLICABLE` passes the gate without blocking.

To run the full test suite for this module:
```bash
node --test workflows/lib/__tests__/parse-report-status.test.js
node --test workflows/check/__tests__/check-generate-summary.test.js
```

### Test Results

89 pass, 0 fail — `workflows/lib/__tests__/parse-report-status.test.js`
16 pass, 0 fail — `workflows/check/__tests__/check-generate-summary.test.js`

Closes #232