### PR TITLE
GH-232 - fix(spec-verify): handle multiline require() in REUSES verification

### DIFF
--- a/workflows/check/scripts/__tests__/spec-verify.test.js
+++ b/workflows/check/scripts/__tests__/spec-verify.test.js
@@ -286,6 +286,24 @@ describe('spec-verify.js', () => {
     assert.equal(json.checks[0].passed, false);
   });
 
+  it('REUSES handles regex with quote char before require on same line', () => {
+    writeFile('src/app.js', "const re = /\\'/; const { useAuth } = require('./hooks');");
+    const specPath = writeSpec(['- REUSES src/app.js hooks']);
+    const result = runScript(specPath, { json: true });
+    assert.equal(result.exitCode, 0);
+    const json = JSON.parse(result.stdout);
+    assert.equal(json.checks[0].passed, true);
+  });
+
+  it('REUSES detects require() inside template literal interpolation', () => {
+    writeFile('src/app.js', "const x = `${require('./hooks')}`;");
+    const specPath = writeSpec(['- REUSES src/app.js hooks']);
+    const result = runScript(specPath, { json: true });
+    assert.equal(result.exitCode, 0);
+    const json = JSON.parse(result.stdout);
+    assert.equal(json.checks[0].passed, true);
+  });
+
   it('REUSES ignores require() inside regular string literals', () => {
     writeFile('src/app.js', 'const s = "require(\'./hooks\')";');
     const specPath = writeSpec(['- REUSES src/app.js hooks']);

--- a/workflows/check/scripts/__tests__/spec-verify.test.js
+++ b/workflows/check/scripts/__tests__/spec-verify.test.js
@@ -276,4 +276,22 @@ describe('spec-verify.js', () => {
     const json = JSON.parse(result.stdout);
     assert.equal(json.checks[0].passed, true);
   });
+
+  it('REUSES ignores require() inside template literals', () => {
+    writeFile('src/app.js', "const example = `require(\n  './hooks'\n)`;");
+    const specPath = writeSpec(['- REUSES src/app.js hooks']);
+    const result = runScript(specPath, { json: true });
+    assert.equal(result.exitCode, 1);
+    const json = JSON.parse(result.stdout);
+    assert.equal(json.checks[0].passed, false);
+  });
+
+  it('REUSES ignores require() inside regular string literals', () => {
+    writeFile('src/app.js', 'const s = "require(\'./hooks\')";');
+    const specPath = writeSpec(['- REUSES src/app.js hooks']);
+    const result = runScript(specPath, { json: true });
+    assert.equal(result.exitCode, 1);
+    const json = JSON.parse(result.stdout);
+    assert.equal(json.checks[0].passed, false);
+  });
 });

--- a/workflows/check/scripts/__tests__/spec-verify.test.js
+++ b/workflows/check/scripts/__tests__/spec-verify.test.js
@@ -231,4 +231,31 @@ describe('spec-verify.js', () => {
     const json = JSON.parse(result.stdout);
     assert.equal(json.checks[0].passed, true);
   });
+
+  it('REUSES detects multiline require() split across lines', () => {
+    writeFile('src/app.js', "const { useAuth } = require(\n  './hooks'\n);");
+    const specPath = writeSpec(['- REUSES src/app.js hooks']);
+    const result = runScript(specPath, { json: true });
+    assert.equal(result.exitCode, 0);
+    const json = JSON.parse(result.stdout);
+    assert.equal(json.checks[0].passed, true);
+  });
+
+  it('REUSES ignores require() inside single-line comments', () => {
+    writeFile('src/app.js', "// const { useAuth } = require('./hooks');");
+    const specPath = writeSpec(['- REUSES src/app.js hooks']);
+    const result = runScript(specPath, { json: true });
+    assert.equal(result.exitCode, 1);
+    const json = JSON.parse(result.stdout);
+    assert.equal(json.checks[0].passed, false);
+  });
+
+  it('REUSES ignores require() inside block comments', () => {
+    writeFile('src/app.js', "/* require('./hooks') */\nconst x = 1;");
+    const specPath = writeSpec(['- REUSES src/app.js hooks']);
+    const result = runScript(specPath, { json: true });
+    assert.equal(result.exitCode, 1);
+    const json = JSON.parse(result.stdout);
+    assert.equal(json.checks[0].passed, false);
+  });
 });

--- a/workflows/check/scripts/__tests__/spec-verify.test.js
+++ b/workflows/check/scripts/__tests__/spec-verify.test.js
@@ -267,4 +267,13 @@ describe('spec-verify.js', () => {
     const json = JSON.parse(result.stdout);
     assert.equal(json.checks[0].passed, true);
   });
+
+  it('REUSES preserves // inside regex literals when stripping comments', () => {
+    writeFile('src/app.js', 'const re = /https?:\\/\\//; const { useAuth } = require(\'./hooks\');');
+    const specPath = writeSpec(['- REUSES src/app.js hooks']);
+    const result = runScript(specPath, { json: true });
+    assert.equal(result.exitCode, 0);
+    const json = JSON.parse(result.stdout);
+    assert.equal(json.checks[0].passed, true);
+  });
 });

--- a/workflows/check/scripts/__tests__/spec-verify.test.js
+++ b/workflows/check/scripts/__tests__/spec-verify.test.js
@@ -258,4 +258,13 @@ describe('spec-verify.js', () => {
     const json = JSON.parse(result.stdout);
     assert.equal(json.checks[0].passed, false);
   });
+
+  it('REUSES preserves // inside string literals when stripping comments', () => {
+    writeFile('src/app.js', 'const url = "https://api"; const { useAuth } = require(\'./hooks\');');
+    const specPath = writeSpec(['- REUSES src/app.js hooks']);
+    const result = runScript(specPath, { json: true });
+    assert.equal(result.exitCode, 0);
+    const json = JSON.parse(result.stdout);
+    assert.equal(json.checks[0].passed, true);
+  });
 });

--- a/workflows/check/scripts/spec-verify.js
+++ b/workflows/check/scripts/spec-verify.js
@@ -445,6 +445,42 @@ function stripComments(src) {
         out += src[i]; // closing quote
         i++;
       }
+    // Regex literal — a / after certain tokens starts a regex, not a comment.
+    // Heuristic: / preceded by =, (, [, !, &, |, ?, :, ,, ;, {, }, newline, or line start.
+    } else if (ch === '/' && src[i + 1] !== '/' && src[i + 1] !== '*' && isRegexContext(out)) {
+      out += ch;
+      i++;
+      while (i < src.length && src[i] !== '/' && src[i] !== '\n') {
+        if (src[i] === '\\') {
+          out += src[i] + (src[i + 1] || '');
+          i += 2;
+        } else if (src[i] === '[') {
+          // Character class — skip to ]
+          out += src[i];
+          i++;
+          while (i < src.length && src[i] !== ']' && src[i] !== '\n') {
+            if (src[i] === '\\') {
+              out += src[i] + (src[i + 1] || '');
+              i += 2;
+            } else {
+              out += src[i];
+              i++;
+            }
+          }
+        } else {
+          out += src[i];
+          i++;
+        }
+      }
+      if (i < src.length && src[i] === '/') {
+        out += src[i]; // closing /
+        i++;
+        // Skip regex flags
+        while (i < src.length && /[gimsuy]/.test(src[i])) {
+          out += src[i];
+          i++;
+        }
+      }
     // Single-line comment — skip to end of line
     } else if (ch === '/' && src[i + 1] === '/') {
       while (i < src.length && src[i] !== '\n') i++;
@@ -462,6 +498,20 @@ function stripComments(src) {
     }
   }
   return out;
+}
+
+/**
+ * Check if the last non-whitespace character in output suggests a regex follows.
+ * A / is a regex start after: = ( [ ! & | ? : , ; { } ~ ^ + - * % < > newline or start of string.
+ * A / is division after: ) ] identifier digit.
+ * @param {string} output - text emitted so far
+ * @returns {boolean}
+ */
+function isRegexContext(output) {
+  const trimmed = output.replace(/\s+$/, '');
+  if (trimmed.length === 0) return true;
+  const last = trimmed[trimmed.length - 1];
+  return '=([!&|?:,;{}~^+-*%<>\n'.includes(last);
 }
 
 function escapeRegex(str) {

--- a/workflows/check/scripts/spec-verify.js
+++ b/workflows/check/scripts/spec-verify.js
@@ -390,7 +390,8 @@ function checkReuses(args, root) {
   const importRegex = new RegExp(
     `(import\\s.*${escaped}|${escaped}.*require\\s*\\(|require\\s*\\(.*${escaped})`
   );
-  // Strip comments to avoid false positives from commented-out imports/requires.
+  // Strip single-line (//) and block (/* */) comments before matching to avoid
+  // false positives from commented-out import/require statements.
   const stripped = content
     .replace(/\/\/[^\n]*/g, '')
     .replace(/\/\*[\s\S]*?\*\//g, '');

--- a/workflows/check/scripts/spec-verify.js
+++ b/workflows/check/scripts/spec-verify.js
@@ -394,13 +394,19 @@ function checkReuses(args, root) {
   // machine avoids false stripping of // inside strings (e.g. URLs).
   const stripped = stripComments(content);
   const lines = stripped.split(/\r?\n/);
-  if (lines.some((line) => importRegex.test(line))) {
+  if (lines.some((line) => {
+    const m = importRegex.exec(line);
+    return m && !isInsideString(line, m.index);
+  })) {
     return { type: 'REUSES', args, passed: true };
   }
   // Fallback: check full content for require('...pattern...') split across lines by formatters.
-  const multilineRegex = new RegExp(`require\\s*\\(\\s*['"][^'"]*${escaped}[^'"]*['"]`, 's');
-  if (multilineRegex.test(stripped)) {
-    return { type: 'REUSES', args, passed: true };
+  const multilineRegex = new RegExp(`require\\s*\\(\\s*['"][^'"]*${escaped}[^'"]*['"]`, 'sg');
+  let match;
+  while ((match = multilineRegex.exec(stripped)) !== null) {
+    if (!isInsideString(stripped, match.index)) {
+      return { type: 'REUSES', args, passed: true };
+    }
   }
   return {
     type: 'REUSES',
@@ -427,7 +433,7 @@ function stripComments(src) {
   let i = 0;
   while (i < src.length) {
     const ch = src[i];
-    // String literals — skip to closing quote, respecting escapes
+    // String literals — preserve content (needed for require() arguments)
     if (ch === "'" || ch === '"' || ch === '`') {
       const quote = ch;
       out += ch;
@@ -507,6 +513,32 @@ function stripComments(src) {
  * @param {string} output - text emitted so far
  * @returns {boolean}
  */
+/**
+ * Check if a position in source text is inside a string literal.
+ * Walks from the start tracking quote state.
+ * @param {string} src - source text (already comment-stripped)
+ * @param {number} pos - character index to check
+ * @returns {boolean}
+ */
+function isInsideString(src, pos) {
+  let inString = false;
+  let quote = '';
+  for (let i = 0; i < pos && i < src.length; i++) {
+    const ch = src[i];
+    if (inString) {
+      if (ch === '\\') {
+        i++; // skip escaped char
+      } else if (ch === quote) {
+        inString = false;
+      }
+    } else if (ch === "'" || ch === '"' || ch === '`') {
+      inString = true;
+      quote = ch;
+    }
+  }
+  return inString;
+}
+
 function isRegexContext(output) {
   const trimmed = output.replace(/\s+$/, '');
   if (trimmed.length === 0) return true;

--- a/workflows/check/scripts/spec-verify.js
+++ b/workflows/check/scripts/spec-verify.js
@@ -383,13 +383,24 @@ function checkReuses(args, root) {
     return { type: 'REUSES', args, passed: false, reason: `File ${filePath} not found` };
   }
 
-  // Check for import or require containing the pattern (line-by-line to avoid cross-line false positives)
+  // Check for import or require containing the pattern.
+  // First try line-by-line (avoids cross-line false positives), then fall back
+  // to full-content matching for formatters that split require() across lines.
   const escaped = escapeRegex(importPattern);
   const importRegex = new RegExp(
     `(import\\s.*${escaped}|${escaped}.*require\\s*\\(|require\\s*\\(.*${escaped})`
   );
-  const lines = content.split(/\r?\n/);
+  // Strip comments to avoid false positives from commented-out imports/requires.
+  const stripped = content
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const lines = stripped.split(/\r?\n/);
   if (lines.some((line) => importRegex.test(line))) {
+    return { type: 'REUSES', args, passed: true };
+  }
+  // Fallback: check full content for require('...pattern...') split across lines by formatters.
+  const multilineRegex = new RegExp(`require\\s*\\(\\s*['"][^'"]*${escaped}[^'"]*['"]`, 's');
+  if (multilineRegex.test(stripped)) {
     return { type: 'REUSES', args, passed: true };
   }
   return {

--- a/workflows/check/scripts/spec-verify.js
+++ b/workflows/check/scripts/spec-verify.js
@@ -392,9 +392,10 @@ function checkReuses(args, root) {
   );
   // Strip single-line (//) and block (/* */) comments before matching to avoid
   // false positives from commented-out import/require statements.
+  // Block comments preserve newlines to prevent line concatenation.
   const stripped = content
     .replace(/\/\/[^\n]*/g, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '');
+    .replace(/\/\*[\s\S]*?\*\//g, (match) => match.replace(/[^\n]/g, ''));
   const lines = stripped.split(/\r?\n/);
   if (lines.some((line) => importRegex.test(line))) {
     return { type: 'REUSES', args, passed: true };

--- a/workflows/check/scripts/spec-verify.js
+++ b/workflows/check/scripts/spec-verify.js
@@ -417,13 +417,8 @@ function checkReuses(args, root) {
 }
 
 /**
- * Escape special regex characters in a string.
- * @param {string} str
- * @returns {string}
- */
-/**
- * Strip JS comments while respecting string literals.
- * Tracks quote state so // and /* inside strings are preserved.
+ * Strip JS comments while respecting string and regex literals.
+ * Tracks quote/regex state so // and /* inside strings/regex are preserved.
  * Block comments are replaced with equivalent newlines to prevent line concatenation.
  * @param {string} src
  * @returns {string}
@@ -490,13 +485,19 @@ function stripComments(src) {
     // Single-line comment — skip to end of line
     } else if (ch === '/' && src[i + 1] === '/') {
       while (i < src.length && src[i] !== '\n') i++;
-    // Block comment — replace with newlines to preserve line structure
+    // Block comment — replace with newlines to preserve line structure.
+    // If no newline was emitted, insert a space to prevent token concatenation.
     } else if (ch === '/' && src[i + 1] === '*') {
+      let emittedNewline = false;
       i += 2;
       while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) {
-        if (src[i] === '\n') out += '\n';
+        if (src[i] === '\n') {
+          out += '\n';
+          emittedNewline = true;
+        }
         i++;
       }
+      if (!emittedNewline) out += ' ';
       if (i < src.length) i += 2; // skip */
     } else {
       out += ch;
@@ -507,13 +508,6 @@ function stripComments(src) {
 }
 
 /**
- * Check if the last non-whitespace character in output suggests a regex follows.
- * A / is a regex start after: = ( [ ! & | ? : , ; { } ~ ^ + - * % < > newline or start of string.
- * A / is division after: ) ] identifier digit.
- * @param {string} output - text emitted so far
- * @returns {boolean}
- */
-/**
  * Check if a position in source text is inside a string literal.
  * Walks from the start tracking quote state.
  * @param {string} src - source text (already comment-stripped)
@@ -523,29 +517,68 @@ function stripComments(src) {
 function isInsideString(src, pos) {
   let inString = false;
   let quote = '';
+  let braceDepth = 0; // tracks ${...} nesting in template literals
   for (let i = 0; i < pos && i < src.length; i++) {
     const ch = src[i];
-    if (inString) {
+    if (inString && quote === '`' && braceDepth > 0) {
+      // Inside ${...} interpolation — treat as code
+      if (ch === '{') {
+        braceDepth++;
+      } else if (ch === '}') {
+        braceDepth--;
+      } else if (ch === "'" || ch === '"') {
+        // Skip strings inside interpolation
+        const q = ch;
+        i++;
+        while (i < src.length && src[i] !== q) {
+          if (src[i] === '\\') i++;
+          i++;
+        }
+      }
+    } else if (inString) {
       if (ch === '\\') {
         i++; // skip escaped char
+      } else if (quote === '`' && ch === '$' && src[i + 1] === '{') {
+        braceDepth = 1;
+        i++; // skip {
       } else if (ch === quote) {
         inString = false;
       }
     } else if (ch === "'" || ch === '"' || ch === '`') {
       inString = true;
       quote = ch;
+    } else if (ch === '/' && isRegexContext(src.slice(0, i))) {
+      // Skip regex literal to avoid treating quotes inside regex as string starts
+      i++;
+      while (i < src.length && src[i] !== '/' && src[i] !== '\n') {
+        if (src[i] === '\\') i++;
+        i++;
+      }
     }
   }
-  return inString;
+  return inString && !(quote === '`' && braceDepth > 0);
 }
 
+/**
+ * Check if the last non-whitespace character in output suggests a regex follows.
+ * A / is a regex start after: = ( [ ! & | ? : , ; { } ~ ^ + - * % < > newline or start of string.
+ * A / is division after: ) ] identifier digit.
+ * @param {string} output - text emitted so far
+ * @returns {boolean}
+ */
 function isRegexContext(output) {
   const trimmed = output.replace(/\s+$/, '');
   if (trimmed.length === 0) return true;
   const last = trimmed[trimmed.length - 1];
-  return '=([!&|?:,;{}~^+-*%<>\n'.includes(last);
+  // Include ) for keyword contexts like if(x)/regex/ and return(x)/regex/
+  return '=([)!&|?:,;{}~^+-*%<>\n'.includes(last);
 }
 
+/**
+ * Escape special regex characters in a string.
+ * @param {string} str
+ * @returns {string}
+ */
 function escapeRegex(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/workflows/check/scripts/spec-verify.js
+++ b/workflows/check/scripts/spec-verify.js
@@ -390,12 +390,9 @@ function checkReuses(args, root) {
   const importRegex = new RegExp(
     `(import\\s.*${escaped}|${escaped}.*require\\s*\\(|require\\s*\\(.*${escaped})`
   );
-  // Strip single-line (//) and block (/* */) comments before matching to avoid
-  // false positives from commented-out import/require statements.
-  // Block comments preserve newlines to prevent line concatenation.
-  const stripped = content
-    .replace(/\/\/[^\n]*/g, '')
-    .replace(/\/\*[\s\S]*?\*\//g, (match) => match.replace(/[^\n]/g, ''));
+  // Strip comments while preserving string literal content. A simple state
+  // machine avoids false stripping of // inside strings (e.g. URLs).
+  const stripped = stripComments(content);
   const lines = stripped.split(/\r?\n/);
   if (lines.some((line) => importRegex.test(line))) {
     return { type: 'REUSES', args, passed: true };
@@ -418,6 +415,55 @@ function checkReuses(args, root) {
  * @param {string} str
  * @returns {string}
  */
+/**
+ * Strip JS comments while respecting string literals.
+ * Tracks quote state so // and /* inside strings are preserved.
+ * Block comments are replaced with equivalent newlines to prevent line concatenation.
+ * @param {string} src
+ * @returns {string}
+ */
+function stripComments(src) {
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    // String literals — skip to closing quote, respecting escapes
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const quote = ch;
+      out += ch;
+      i++;
+      while (i < src.length && src[i] !== quote) {
+        if (src[i] === '\\') {
+          out += src[i] + (src[i + 1] || '');
+          i += 2;
+        } else {
+          out += src[i];
+          i++;
+        }
+      }
+      if (i < src.length) {
+        out += src[i]; // closing quote
+        i++;
+      }
+    // Single-line comment — skip to end of line
+    } else if (ch === '/' && src[i + 1] === '/') {
+      while (i < src.length && src[i] !== '\n') i++;
+    // Block comment — replace with newlines to preserve line structure
+    } else if (ch === '/' && src[i + 1] === '*') {
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) {
+        if (src[i] === '\n') out += '\n';
+        i++;
+      }
+      if (i < src.length) i += 2; // skip */
+    } else {
+      out += ch;
+      i++;
+    }
+  }
+  return out;
+}
+
 function escapeRegex(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }


### PR DESCRIPTION
## Existing Behavior

The `checkReuses` function in `spec-verify.js` verifies that a file imports a required module using a line-by-line regex scan. When a code formatter (e.g., Biome, Prettier) splits a `require()` call across multiple lines, no single line matches the pattern, causing the REUSES check to report a false negative and incorrectly block the workflow.

## Intended New Behavior

After the line-by-line scan fails to find a match, a fallback regex is applied against the full file content. The fallback pattern is constrained to match only within string arguments of `require()` calls (using quoted boundaries), preventing false positives from comments or unrelated expressions that happen to contain the import pattern.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a backend/script change. To verify the fix:

1. Create a file where a formatter has split a `require()` across lines, for example:
   ```js
   const mod = require(
     '../some/module'
   );
   ```
2. Add a `REUSES` assertion in a spec that references `../some/module`.
3. Run `spec-verify.js` against that file — previously this would report a false negative; with the fix it should pass.
4. Confirm the fallback does NOT match when the pattern appears only inside a comment or in an unrelated string expression (no quotes wrapping the pattern inside `require()`).

Closes #232