### PR TITLE
GH-232 - feat(follow-up-pr): brief output and sequential comment resolution

### DIFF
--- a/skills/follow-up-pr/SKILL.md
+++ b/skills/follow-up-pr/SKILL.md
@@ -162,55 +162,84 @@ node "$SCRIPT_PATH" $REVIEW_FLAG 2>&1
 
 ---
 
-## Step 5: Address Review Feedback
+## Step 5: Address Review Feedback (Sequential Comment Resolution)
 
-### Review Priority System
+```
+╔══════════════════════════════════════════════════════════════════════╗
+║  CRITICAL: Process comments ONE AT A TIME using the sequential CLI  ║
+║                                                                      ║
+║  DO NOT try to read or fix all comments at once.                    ║
+║  Get ONE comment → fix it → mark solved → get NEXT comment.        ║
+╚══════════════════════════════════════════════════════════════════════╝
+```
 
-The script automatically classifies review comments by priority:
+### 5.0 Snapshot PR Comments
 
-| Reviewer | Blocking (must fix) | Non-blocking (ignore) |
-|----------|--------------------|-----------------------|
-| **Cursor** (`cursor-ai[bot]`) | severity: critical/high/major/medium/moderate | severity: minor/low/nitpick/trivial/suggestion |
-| **Copilot** (`copilot-pull-request-reviewer`) | `[critical]`, `[high]`, `[medium]`, or no tag | `[low]` or `[nitpick]` tags |
-| **Human reviewers** | Always blocking | — |
+First, detect the PR number and take a snapshot of all comments:
 
-- **Blocking reviews** (medium/high priority) → you MUST fix these
-- **Non-blocking reviews** (low/nitpick) → shown as informational, do NOT block "PR READY TO REVIEW"
+```bash
+COMMENTS_SCRIPT="$PLUGIN_ROOT/workflows/work/scripts/follow-up-pr-comments.js"
+PR_NUMBER=$(gh pr view --json number -q '.number')
+node "$COMMENTS_SCRIPT" --snapshot --pr "$PR_NUMBER"
+```
 
-### 5.1 Read and Understand Feedback
+Then check how many blocking comments exist:
 
-For each **blocking** review comment:
+```bash
+node "$COMMENTS_SCRIPT" --status
+```
 
-1. Read the comment body and understand what change is requested
-2. If it's an inline comment, read the referenced file and line(s)
-3. Group related comments (e.g., multiple comments about the same pattern)
+This shows a brief summary like: `Blocking: 8, Non-blocking: 5, Solved: 0, Skipped: 0`
 
-### 5.2 Apply Review Fixes
+### 5.1 Sequential Comment Loop
 
-For each group of related feedback:
+Process each blocking comment ONE AT A TIME:
 
-1. Determine `<TICKET_ID>` from the current branch: `git branch --show-current | grep -oE '[A-Z]+-[0-9]+|GH-[0-9]+' || echo "unknown"`
-2. Formulate a review-fix description: reviewer name, comment text, file path, line number, and what change is requested
-3. Invoke: `Skill(work-implement): --subtask <TICKET_ID> fix(review): <description with full comment context, file path, and line number>`
-4. After /work-implement completes, run: `Skill(check)`
-5. Record in `summary.reviewsAddressed`:
-   ```javascript
-   { author: "<reviewer>", comment: "<summary>", fix: "<what was changed>" }
-   ```
+```
+WHILE there are unsolved blocking comments:
+  1. Get the next unsolved comment:
+     node "$COMMENTS_SCRIPT" --next-comment
+     → Returns: comment ID, file, line, author, priority, body
 
-If /work-implement fails, use AskUserQuestion to ask the user for guidance before retrying.
+  2. Read the referenced file at the indicated line
+  3. Understand what the reviewer is asking for
+  4. Fix the code (directly — no need for /work-implement for small fixes)
+  5. Run tests to verify: node --test <affected-test-file>
+  6. Mark the comment as solved:
+     node "$COMMENTS_SCRIPT" --solve-comment <ID> $(git rev-parse HEAD) "<brief description of fix>"
 
-### 5.3 Push and Re-enter Loop
+  7. OR skip the comment if it conflicts with user intent:
+     node "$COMMENTS_SCRIPT" --skip-comment <ID> "<reason why skipped>"
 
-1. Push: `git push`
-2. Log the review fixes in `summary.fixes`
-3. Return to Step 1 (re-run monitor script to re-check CI and reviews)
+  REPEAT until --next-comment returns no more blocking comments
+```
 
-**Important notes for review handling:**
-- **If a review comment is ambiguous or you're unsure how to address it**, use AskUserQuestion to ask the user for guidance
-- **Never dismiss or resolve review threads** — let the reviewer verify your fix
-- **If the same reviewer keeps requesting changes**, consider asking the user if they want to continue or discuss directly with the reviewer
-- **After addressing reviews**, the reviewer may add new comments — that's why we re-enter the loop
+### 5.2 Commit and Push After All Comments
+
+After ALL blocking comments are solved/skipped:
+
+```bash
+git add -A
+# Use commit-writer agent
+git push
+```
+
+### 5.3 Re-enter Monitor Loop
+
+Return to Step 1 (re-run follow-up-pr.js) — the reviewer may post new comments after your push.
+
+### 5.4 Skip AI Comments That Conflict With User Intent
+
+When an AI reviewer suggests reverting or undoing changes the user explicitly requested:
+
+1. **Do NOT implement** — skip it
+2. Use: `node "$COMMENTS_SCRIPT" --skip-comment <ID> "Conflicts with user intent: <reason>"`
+3. Report skipped comments in the summary
+
+**Important notes:**
+- **If a comment is ambiguous**, use AskUserQuestion to ask the user
+- **Never dismiss or resolve review threads on GitHub** — let the reviewer verify
+- **Process ONE comment at a time** — fix, verify, mark solved, then get next
 
 ### 5.4 Skip AI Comments That Conflict With User Intent
 

--- a/skills/follow-up-pr/SKILL.md
+++ b/skills/follow-up-pr/SKILL.md
@@ -189,7 +189,7 @@ Then check how many blocking comments exist:
 node "$COMMENTS_SCRIPT" --status
 ```
 
-This shows a brief summary like: `Blocking: 8, Non-blocking: 5, Solved: 0, Skipped: 0`
+This shows a JSON summary like: `{"total":13,"solved":0,"skipped":0,"remaining":13,"strictCommentCount":8}`
 
 ### 5.1 Sequential Comment Loop
 
@@ -211,7 +211,7 @@ WHILE there are unsolved blocking comments:
   7. OR skip the comment if it conflicts with user intent:
      node "$COMMENTS_SCRIPT" --skip-comment <ID> "<reason why skipped>"
 
-  REPEAT until --next-comment returns no more blocking comments
+  REPEAT until --next-comment returns {"done": true}
 ```
 
 ### 5.2 Commit and Push After All Comments
@@ -220,7 +220,7 @@ After ALL blocking comments are solved/skipped:
 
 ```bash
 git add -A
-# Use commit-writer agent
+# → Invoke commit-writer agent here to create the commit
 git push
 ```
 
@@ -241,7 +241,7 @@ When an AI reviewer suggests reverting or undoing changes the user explicitly re
 - **Never dismiss or resolve review threads on GitHub** — let the reviewer verify
 - **Process ONE comment at a time** — fix, verify, mark solved, then get next
 
-### 5.4 Skip AI Comments That Conflict With User Intent
+### 5.5 Skip AI Comments — Detailed Template
 
 Sometimes AI reviewers (Cursor, Copilot) suggest reverting or undoing changes that the user explicitly requested. When you identify such comments:
 

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1365,8 +1365,8 @@ async function main() {
       state.finalStatus = decision.finalStatus;
       saveState(state);
 
-      // GH-248: Show full comment bodies for ALL comments on exit so the agent
-      // has complete context. Non-blocking comments must be evaluated too.
+      // GH-248: Show brief comment previews (80 chars) for ALL comments on exit
+      // so the agent has context. Non-blocking comments must be evaluated too.
       const allExitComments = [
         ...(reviews.blocking || []).map((item) => ({ ...item, _section: 'BLOCKING' })),
         ...(reviews.nonBlocking || []).map((item) => ({ ...item, _section: 'NON-BLOCKING' })),

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -988,7 +988,7 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
       lines.push('');
       lines.push(
         c.yellow(
-          '  → Use follow-up-pr-comments.js --snapshot --pr <N> then --next-comment to process each comment ONE AT A TIME'
+          '  → Use node follow-up-pr-comments.js --snapshot --pr <N> then --next-comment to process each comment ONE AT A TIME'
         )
       );
       lines.push(

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -991,6 +991,26 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
           '  → Use follow-up-pr-comments.js --snapshot --pr <N> then --next-comment to process each comment ONE AT A TIME'
         )
       );
+      lines.push(
+        c.yellow(
+          '  → SOLVE ALL COMMENTS BEFORE PUSHING. Do NOT push after each comment. Do NOT use gh api to read'
+        )
+      );
+      lines.push(
+        c.yellow(
+          '    comments directly. The --next-comment loop is the ONLY way to process comments — it tracks'
+        )
+      );
+      lines.push(
+        c.yellow(
+          '    state so nothing is missed or duplicated. Pushing mid-loop causes snapshot invalidation,'
+        )
+      );
+      lines.push(
+        c.yellow(
+          '    line-number drift, and dedup confusion.'
+        )
+      );
       if (reviews.nonBlocking.length > 0) {
         lines.push(
           `  + ${reviews.nonBlocking.length} non-blocking (nitpick/low — assess whether to address):`

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -983,22 +983,14 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
           const preview = normalized.length > 80 ? normalized.slice(0, 77) + '...' : normalized;
           lines.push(`    ${c.dim('"' + preview + '"')}`);
         }
-        if (item.path && item.line) {
-          lines.push(
-            `    ${c.yellow('→ Alter line ' + item.line + ' in ' + item.path + ' to address this comment (touch the exact line to invalidate stale review)')}`
-          );
-          // Show actual code at the referenced line so the agent can verify if already fixed
-          const codeCtx = getCodeContext(item.path, item.line);
-          if (codeCtx) {
-            lines.push(`    ${c.dim('Current code at ' + item.path + ':' + item.line + ':')}`);
-            for (const ctxLine of codeCtx.split('\n')) {
-              lines.push(`    ${c.dim(ctxLine)}`);
-            }
-          }
-        } else if (item.path) {
-          lines.push(`    ${c.yellow('→ Alter ' + item.path + ' to address this comment')}`);
-        }
+        // Code context omitted — use follow-up-pr-comments.js --next-comment for full details
       }
+      lines.push('');
+      lines.push(
+        c.yellow(
+          '  → Use follow-up-pr-comments.js --snapshot --pr <N> then --next-comment to process each comment ONE AT A TIME'
+        )
+      );
       if (reviews.nonBlocking.length > 0) {
         lines.push(
           `  + ${reviews.nonBlocking.length} non-blocking (nitpick/low — assess whether to address):`
@@ -1047,19 +1039,10 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
       lines.push('');
       lines.push(c.bold('--- Non-Blocking Comments Report ---'));
       reviews.nonBlocking.forEach((item, i) => {
-        const loc = item.path ? `${item.path}${item.line ? ':' + item.line : ''}` : '';
-        const fullText = item.body ? item.body.trim() : '';
-        lines.push('');
-        lines.push(`  Comment ${i + 1}: ${fullText}`);
-        lines.push(`  File: ${loc || 'N/A'}`);
-        lines.push(`  Author: @${item.author}`);
-        if (item.deduplicated) {
-          lines.push(
-            `  Status: ${c.cyan('DEDUPED')} — previously addressed, re-posted after force-push`
-          );
-        } else {
-          lines.push(`  Status: ${c.dim('NOT ADDRESSED')} — low priority`);
-        }
+        const loc = item.path ? `${item.path}${item.line ? ':' + item.line : ''}` : 'N/A';
+        const briefBody = (item.body || '').trim().replace(/\n/g, ' ').substring(0, 80);
+        const status = item.deduplicated ? c.cyan('DEDUPED') : c.dim('NOT ADDRESSED');
+        lines.push(`  Comment ${i + 1}: [${status}] @${item.author} ${loc} — ${briefBody}`);
       });
       lines.push('');
       lines.push(c.dim('---'));
@@ -1370,7 +1353,7 @@ async function main() {
       ];
       if (allExitComments.length > 0) {
         console.log('');
-        console.log(c.bold('--- Full Comment Bodies (All Reviews) ---'));
+        console.log(c.bold('--- Brief Comment Bodies (All Reviews) ---'));
         let currentSection = '';
         allExitComments.forEach((item, i) => {
           if (item._section !== currentSection) {
@@ -1382,13 +1365,10 @@ async function main() {
           const priority = (item.priority || 'unknown').toUpperCase();
           const staleTag = item.stale ? c.dim(' (stale)') : '';
           const dedupTag = item.deduplicated ? c.dim(' (deduped)') : '';
-          console.log('');
+          const briefBody = (item.body || '').trim().replace(/\n/g, ' ').substring(0, 80);
           console.log(
-            `  ${c.cyan(`Comment ${i + 1}:`)} @${item.author} [${priority}]${staleTag}${dedupTag} ${loc}`
+            `  ${c.cyan(`Comment ${i + 1}:`)} [${priority}] @${item.author}${staleTag}${dedupTag} ${loc} — ${briefBody}`
           );
-          console.log(`  ${c.dim('─'.repeat(60))}`);
-          console.log(`  ${(item.body || '').trim()}`);
-          console.log(`  ${c.dim('─'.repeat(60))}`);
         });
         console.log('');
       }
@@ -1462,7 +1442,13 @@ async function main() {
           try {
             const repo = ghExec('repo view --json nameWithOwner').nameWithOwner;
             const ids = ghExec(
-              ['api', '--paginate', `repos/${repo}/pulls/${prInfo.number}/comments?per_page=100`, '--jq', '.[].id'],
+              [
+                'api',
+                '--paginate',
+                `repos/${repo}/pulls/${prInfo.number}/comments?per_page=100`,
+                '--jq',
+                '.[].id',
+              ],
               { json: false }
             );
             const inlineIds = new Set((ids || '').split('\n').filter(Boolean));
@@ -1474,7 +1460,9 @@ async function main() {
                 inlineComments.push({ id: Number(id) || id, author: 'inline', body: '' });
             }
           } catch (inlineErr) {
-            process.stderr.write(`WARNING: Failed to fetch inline comment IDs: ${inlineErr.message}\n`);
+            process.stderr.write(
+              `WARNING: Failed to fetch inline comment IDs: ${inlineErr.message}\n`
+            );
           }
           const entries = buildAccountabilityEntries(reviews.blocking || [], [
             ...(reviews.nonBlocking || []),
@@ -1540,7 +1528,14 @@ function isPRGateReady() {
   if (!prInfo || !prInfo.number) return { ready: false };
   if (prInfo.state === 'CLOSED') return { ready: false };
   // Merged PRs have passed all gates — allow transition (GH-276)
-  if (prInfo.state === 'MERGED') return { ready: true, reviews: {}, decision: { action: 'exit-success', finalStatus: 'merged' }, strictCommentCount: 0, prInfo };
+  if (prInfo.state === 'MERGED')
+    return {
+      ready: true,
+      reviews: {},
+      decision: { action: 'exit-success', finalStatus: 'merged' },
+      strictCommentCount: 0,
+      prInfo,
+    };
 
   const ci = checkCI(prInfo.number);
   const reviews = getReviews(prInfo.number);
@@ -1554,11 +1549,20 @@ function isPRGateReady() {
     const repo = ghExec('repo view --json nameWithOwner').nameWithOwner;
     // Use --paginate to count ALL inline comments, not just the first page (default 30)
     const comments = ghExec(
-      ['api', '--paginate', `repos/${repo}/pulls/${prInfo.number}/comments?per_page=100`, '--jq', 'length'],
+      [
+        'api',
+        '--paginate',
+        `repos/${repo}/pulls/${prInfo.number}/comments?per_page=100`,
+        '--jq',
+        'length',
+      ],
       { json: false }
     );
     // --paginate with --jq length returns one number per page; sum them
-    strictCommentCount = (comments || '').split('\n').filter(Boolean).reduce((sum, n) => sum + (parseInt(n, 10) || 0), 0);
+    strictCommentCount = (comments || '')
+      .split('\n')
+      .filter(Boolean)
+      .reduce((sum, n) => sum + (parseInt(n, 10) || 0), 0);
   } catch {
     // Cannot verify comment count — fail closed
     return { ready: false };


### PR DESCRIPTION
## Existing Behavior

- `follow-up-pr.js` outputs full comment bodies with code context blocks, separator lines, and verbose inline code snippets for each blocking review comment, making the report output large and hard to scan.
- Non-blocking comments are rendered with multi-line detail blocks (full body, file, author, status on separate lines).
- The exit summary section prints full comment bodies surrounded by separator lines (`─`.repeat(60)).
- `SKILL.md` Step 5 describes a manual review priority table and instructs the agent to group comments and invoke `/work-implement` per group, with no sequential comment-by-comment workflow.

## Intended New Behavior

- Blocking comment output drops inline code context and the `→ Alter line N in file` hint; a single line now directs the agent to use `follow-up-pr-comments.js --next-comment` for full details.
- Non-blocking and exit-summary comments are collapsed to a single one-liner each: `[STATUS] @author file:line — <first 80 chars of body>`.
- `SKILL.md` Step 5 is rewritten to enforce a strict sequential loop: snapshot PR comments → `--next-comment` → fix → `--solve-comment` (or `--skip-comment`) → repeat until no blocking comments remain, then commit and push.
- Formatting-only refactors improve readability of multi-argument `ghExec` calls and the `isPRGateReady` MERGED early-return object.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / CLI verification:**

1. Check out the branch and run `follow-up-pr.js` against a PR that has blocking review comments:
   ```bash
   node workflows/work/scripts/follow-up-pr.js
   ```
2. Confirm blocking comment entries no longer include code context blocks or `→ Alter line N` hints — each comment should show only the preview line plus the single `follow-up-pr-comments.js` instruction.
3. Confirm non-blocking comment entries are collapsed to a single one-liner per comment.
4. Confirm the exit summary section prints one line per comment (no separator lines, no multi-line bodies).
5. Verify the sequential comment CLI works end-to-end:
   ```bash
   PR_NUMBER=$(gh pr view --json number -q '.number')
   node workflows/work/scripts/follow-up-pr-comments.js --snapshot --pr "$PR_NUMBER"
   node workflows/work/scripts/follow-up-pr-comments.js --status
   node workflows/work/scripts/follow-up-pr-comments.js --next-comment
   ```

Closes #232 (partial — output trimming follow-up)