### PR TITLE
GH-232 - fix(protect-artifact): skip per-task routing during check step

### DIFF
--- a/workflows/lib/__tests__/protect-artifact-files.test.js
+++ b/workflows/lib/__tests__/protect-artifact-files.test.js
@@ -635,8 +635,15 @@ describe('per-task path enforcement for .check.md', () => {
 
   function makeProtector(overrides = {}) {
     return createArtifactProtector({
-      artifacts: [{ pattern: /\.check\.md$/, step: 'check', agents: ['code-checker'] }],
-      getStepInProgress: () => overrides.currentStep || 'check',
+      artifacts: [
+        {
+          pattern: /\.check\.md$/,
+          step: 'check',
+          allowedSteps: ['task_review'],
+          agents: ['code-checker'],
+        },
+      ],
+      getStepInProgress: () => overrides.currentStep || 'task_review',
       isRunningInAgent: overrides.isRunningInAgent || (() => true),
       getTicketId: () => overrides.ticketId || TICKET,
       ...overrides,

--- a/workflows/lib/__tests__/protect-artifact-files.test.js
+++ b/workflows/lib/__tests__/protect-artifact-files.test.js
@@ -1069,6 +1069,69 @@ describe('per-task path enforcement for .check.md', () => {
     assert.ok(result.message.includes('outside ticket directory'));
   });
 
+  it('allows .check.md at ticket root during check step (per-task routing skipped)', () => {
+    const ticketDir = path.join(tmpDir, TICKET);
+    fs.mkdirSync(ticketDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(ticketDir, '.work-state.json'),
+      JSON.stringify({ tasksMeta: { totalTasks: 3, currentTaskIndex: 1 } })
+    );
+
+    const p = makeProtector({ currentStep: 'check' });
+    const filePath = path.join(ticketDir, 'tests.check.md');
+    const result = p.check('Write', { file_path: filePath });
+    assert.equal(result.blocked, false);
+  });
+
+  it('blocks .check.md escaping ticket dir during check step (traversal guard still active)', () => {
+    const ticketDir = path.join(tmpDir, TICKET);
+    fs.mkdirSync(path.join(ticketDir, 'task1'), { recursive: true });
+    fs.writeFileSync(
+      path.join(ticketDir, '.work-state.json'),
+      JSON.stringify({ tasksMeta: { totalTasks: 3, currentTaskIndex: 0 } })
+    );
+
+    const p = makeProtector({ currentStep: 'check' });
+    const filePath = ticketDir + '/task1/../../other/tests.check.md';
+    const result = p.check('Write', { file_path: filePath });
+    assert.equal(result.blocked, true);
+    assert.equal(result.rule, 'per-task-path');
+    assert.ok(result.message.includes('outside ticket directory'));
+  });
+
+  it('traversal block message suggests ticket root path during check step', () => {
+    const ticketDir = path.join(tmpDir, TICKET);
+    fs.mkdirSync(path.join(ticketDir, 'task1'), { recursive: true });
+    fs.writeFileSync(
+      path.join(ticketDir, '.work-state.json'),
+      JSON.stringify({ tasksMeta: { totalTasks: 3, currentTaskIndex: 0 } })
+    );
+
+    const p = makeProtector({ currentStep: 'check' });
+    const filePath = ticketDir + '/task1/../../other/tests.check.md';
+    const result = p.check('Write', { file_path: filePath });
+    assert.equal(result.blocked, true);
+    // During check step, suggested path should be ticket root, not per-task
+    assert.ok(result.message.includes(path.join(ticketDir, 'tests.check.md')));
+    assert.ok(!result.message.includes('task1'));
+  });
+
+  it('traversal block message suggests per-task path during non-check step', () => {
+    const ticketDir = path.join(tmpDir, TICKET);
+    fs.mkdirSync(path.join(ticketDir, 'task1'), { recursive: true });
+    fs.writeFileSync(
+      path.join(ticketDir, '.work-state.json'),
+      JSON.stringify({ tasksMeta: { totalTasks: 3, currentTaskIndex: 0 } })
+    );
+
+    const p = makeProtector({ currentStep: 'task_review' });
+    const filePath = ticketDir + '/task1/../../other/tests.check.md';
+    const result = p.check('Write', { file_path: filePath });
+    assert.equal(result.blocked, true);
+    // During non-check step, suggested path should be per-task
+    assert.ok(result.message.includes(path.join(ticketDir, 'task1', 'tests.check.md')));
+  });
+
   it('fails open when ticketId contains ../ (path traversal)', () => {
     // Create a state file at the traversal target to prove it is NOT read
     const outsideDir = path.join(tmpDir, 'secret');

--- a/workflows/lib/protect-artifact-files.js
+++ b/workflows/lib/protect-artifact-files.js
@@ -193,7 +193,9 @@ function createArtifactProtector(opts) {
     }
 
     // Check 3: Per-task path enforcement — when tasks.md exists, .check.md reports
-    // must go to tasks/ticketId/task${N}/ not tasks/ticketId/ root
+    // must go to tasks/ticketId/task${N}/ not tasks/ticketId/ root.
+    // Exception: during the final /check step, per-task routing is skipped
+    // (reports belong at ticket root), but the path-escape guard still applies.
     if (bn.endsWith('.check.md')) {
       try {
         const fs = require('fs');
@@ -240,7 +242,9 @@ function createArtifactProtector(opts) {
               const normalizedIdx = Math.min(Math.max(currentIdx, 0), totalTasks - 1);
               const taskNum = normalizedIdx + 1;
 
-              // Block writes that escape the ticket directory via traversal
+              // Block writes that escape the ticket directory via path traversal.
+              // This guard runs unconditionally — including during the 'check' step —
+              // so that writes like "/<ticket>/../outside/file.check.md" are always blocked.
               if (isEscapingTicketDir) {
                 return {
                   blocked: true,
@@ -253,33 +257,37 @@ function createArtifactProtector(opts) {
                 };
               }
 
-              // Two-branch enforcement:
-              // 1. Block writes at ticket root (no path separator in relPath)
-              // 2. Block writes to wrong task folder (relPath doesn't start with taskN/)
-              if (isWithinTicketDir && !relPath.includes(path.sep)) {
-                // File is at ticket root (no path separator) — block and suggest correct task folder
-                return {
-                  blocked: true,
-                  file: bn,
-                  rule: 'per-task-path',
-                  message:
-                    `BLOCKED: Cannot write ${bn} at ticket root.\n` +
-                    `Per-task mode is active for this ticket. Write your report to the task folder instead:\n` +
-                    `  ${path.join(resolvedTicketDir, 'task' + taskNum, bn)}\n`,
-                };
-              } else if (isWithinTicketDir) {
-                // File is in a subdirectory — validate it's the correct task folder
-                const expectedPath = 'task' + taskNum + path.sep + bn;
-                if (relPath !== expectedPath) {
+              // Per-task routing enforcement — skip during 'check' step
+              // (final /check step writes reports at ticket root, not per-task)
+              if (currentStep !== 'check') {
+                // Two-branch enforcement:
+                // 1. Block writes at ticket root (no path separator in relPath)
+                // 2. Block writes to wrong task folder (relPath doesn't start with taskN/)
+                if (isWithinTicketDir && !relPath.includes(path.sep)) {
+                  // File is at ticket root (no path separator) — block and suggest correct task folder
                   return {
                     blocked: true,
                     file: bn,
                     rule: 'per-task-path',
                     message:
-                      `BLOCKED: Cannot write ${bn} to wrong task folder.\n` +
-                      `You are working on task ${taskNum}. Write your report to:\n` +
+                      `BLOCKED: Cannot write ${bn} at ticket root.\n` +
+                      `Per-task mode is active for this ticket. Write your report to the task folder instead:\n` +
                       `  ${path.join(resolvedTicketDir, 'task' + taskNum, bn)}\n`,
                   };
+                } else if (isWithinTicketDir) {
+                  // File is in a subdirectory — validate it's the correct task folder
+                  const expectedPath = 'task' + taskNum + path.sep + bn;
+                  if (relPath !== expectedPath) {
+                    return {
+                      blocked: true,
+                      file: bn,
+                      rule: 'per-task-path',
+                      message:
+                        `BLOCKED: Cannot write ${bn} to wrong task folder.\n` +
+                        `You are working on task ${taskNum}. Write your report to:\n` +
+                        `  ${path.join(resolvedTicketDir, 'task' + taskNum, bn)}\n`,
+                    };
+                  }
                 }
               }
             } // end actualFilePath else

--- a/workflows/lib/protect-artifact-files.js
+++ b/workflows/lib/protect-artifact-files.js
@@ -246,6 +246,9 @@ function createArtifactProtector(opts) {
               // This guard runs unconditionally — including during the 'check' step —
               // so that writes like "/<ticket>/../outside/file.check.md" are always blocked.
               if (isEscapingTicketDir) {
+                const suggestedPath = currentStep === 'check'
+                  ? path.join(resolvedTicketDir, bn)
+                  : path.join(resolvedTicketDir, 'task' + taskNum, bn);
                 return {
                   blocked: true,
                   file: bn,
@@ -253,7 +256,7 @@ function createArtifactProtector(opts) {
                   message:
                     `BLOCKED: Cannot write ${bn} outside ticket directory.\n` +
                     `The resolved path escapes the ticket folder. Write your report to:\n` +
-                    `  ${path.join(resolvedTicketDir, 'task' + taskNum, bn)}\n`,
+                    `  ${suggestedPath}\n`,
                 };
               }
 

--- a/workflows/work/__tests__/workflow-definition.test.js
+++ b/workflows/work/__tests__/workflow-definition.test.js
@@ -18,6 +18,8 @@ const os = require('os');
 const createWorkflowDefinition = require(path.join(__dirname, '..', 'workflow-definition'));
 const { STEPS } = require(path.join(__dirname, '..', 'step-registry'));
 
+const configPath = path.resolve(__dirname, '..', '..', 'lib', 'config.js');
+
 // Minimal deps stub — we only read static config, not call verify fns.
 const stubDeps = {
   TASKS_BASE: '/tmp/tasks-base',
@@ -616,5 +618,95 @@ describe('workflow-definition: verify[STEPS.spec_gate]', () => {
     );
     const verify = getSpecGateVerify();
     assert.equal(verify(ticketId), false);
+  });
+});
+
+describe('workflow-definition: verify[STEPS.check] QA report gating', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'workflow-def-check-'));
+  const ticketId = 'GH-232';
+  const ticketDir = path.join(tmpRoot, ticketId);
+
+  const deps = {
+    TASKS_BASE: tmpRoot,
+    safeTicketPath: (id) => id,
+    resolveGitHead: () => 'ref: refs/heads/stub',
+  };
+  const { workflow: checkWf } = createWorkflowDefinition(deps);
+
+  function getCheckVerify() {
+    const entries = checkWf.commandMap.filter(
+      (e) => e.step === STEPS.check && typeof e.verify === 'function'
+    );
+    return entries.length > 0 ? entries[0].verify : undefined;
+  }
+
+  after(() => {
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  function setupTicketDir(files) {
+    fs.rmSync(ticketDir, { recursive: true, force: true });
+    fs.mkdirSync(ticketDir, { recursive: true });
+    for (const f of files) {
+      fs.writeFileSync(path.join(ticketDir, f), 'placeholder');
+    }
+  }
+
+  function callVerifyWithWebApps(webApps) {
+    const savedWebApps = process.env.WEB_APPS;
+    delete require.cache[configPath];
+    process.env.WEB_APPS = JSON.stringify(webApps);
+    try {
+      const verify = getCheckVerify();
+      return verify(ticketId);
+    } finally {
+      if (savedWebApps !== undefined) {
+        process.env.WEB_APPS = savedWebApps;
+      } else {
+        delete process.env.WEB_APPS;
+      }
+      delete require.cache[configPath];
+    }
+  }
+
+  it('passes without QA report when no web apps configured', () => {
+    setupTicketDir([
+      'code-review.check.md',
+      'tests.check.md',
+      'completion.check.md',
+      'README.md',
+    ]);
+    assert.equal(callVerifyWithWebApps([]), true);
+  });
+
+  it('fails without QA report when web apps are configured', () => {
+    setupTicketDir([
+      'code-review.check.md',
+      'tests.check.md',
+      'completion.check.md',
+      'README.md',
+    ]);
+    assert.equal(
+      callVerifyWithWebApps([{ name: 'my-app', defaultPort: 3000, type: 'vite' }]),
+      false
+    );
+  });
+
+  it('passes with QA report when web apps are configured', () => {
+    setupTicketDir([
+      'code-review.check.md',
+      'tests.check.md',
+      'completion.check.md',
+      'README.md',
+      'qa-feature-tester.check.md',
+    ]);
+    assert.equal(
+      callVerifyWithWebApps([{ name: 'my-app', defaultPort: 3000, type: 'vite' }]),
+      true
+    );
   });
 });

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -393,10 +393,13 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             const reqs = evidenceRequirements[STEPS.check];
             const required = reqs?.requiredFiles || [];
             if (!required.every((f) => fs.existsSync(path.join(dir, f)))) return false;
-            // At least one QA report must exist (matches qaReportPattern)
-            const files = fs.readdirSync(dir);
-            const qaPattern = reqs?.qaReportPattern;
-            if (qaPattern && !files.some((f) => qaPattern.test(f))) return false;
+            // At least one QA report must exist when web apps are configured
+            const config = require(path.join(__dirname, '..', 'lib', 'config'));
+            if (config.webAppNames().length > 0) {
+              const files = fs.readdirSync(dir);
+              const qaPattern = reqs?.qaReportPattern;
+              if (qaPattern && !files.some((f) => qaPattern.test(f))) return false;
+            }
             // GH-259: When tasks.md exists, verify per-task TDD evidence
             return verifyPerTaskTDD(ticketId);
           } catch {


### PR DESCRIPTION
## Existing Behavior

- Per-task path enforcement for `.check.md` files was applied unconditionally across all workflow steps, including the final `/check` step where reports are written at the ticket root (not inside task subfolders), causing false-negative blocks.
- The QA report presence check in the `check` step gate ran regardless of whether any web applications were configured, blocking tickets that legitimately have no web app QA surface.
- The path-traversal escape guard and per-task routing were coupled, so disabling one required restructuring both.

## Intended New Behavior

- Per-task path enforcement (ticket-root block and wrong-task-folder block) is now skipped when `currentStep === 'check'`, allowing the code-checker agent to write `.check.md` at the ticket root during the final check step.
- The path-traversal escape guard is preserved unconditionally — it runs even during the `check` step — so directory traversal attacks are still blocked.
- The QA report presence check is now conditional: it only runs when `config.webAppNames()` returns at least one configured web app, preventing false gate failures on backend-only or config-only tickets.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend logic changes — verify via test suite and manual workflow run:**

1. Run the test suite to confirm per-task routing tests pass: `node --test workflows/lib/__tests__/protect-artifact-files.test.js`
2. To verify the `/check` step fix: create a ticket with `tasks.md` present, run `/check`, and confirm the code-checker agent can write a `.check.md` at the ticket root (e.g., `tasks/GH-XXX/GH-XXX.check.md`) without being blocked.
3. To verify the path-traversal guard still works during `/check`: attempt to write a `.check.md` with a path like `tasks/GH-XXX/../outside.check.md` — it must still be blocked.
4. To verify the QA report gate fix: run a ticket with no web apps configured (empty `WEB_APPS`) through the `check → ready` transition — it must pass without requiring a QA report file.
5. To confirm QA report is still required when web apps are configured: set `WEB_APPS` to a non-empty value and run the same transition without a QA report — it must block.

### Test Results
[Will be populated after PR creation with actual test run output]

Closes #232