### PR TITLE
feat(work): re-run /check step when new commits detected after check passes (GH-299)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,13 +14,7 @@
       "source": "./",
       "description": "Orchestrated /work command with pre-computed action plans",
       "category": "workflow",
-      "tags": [
-        "workflow",
-        "jira",
-        "orchestrator",
-        "state-machine",
-        "automation"
-      ]
+      "tags": ["workflow", "jira", "orchestrator", "state-machine", "automation"]
     }
   ]
 }

--- a/workflows/check/scripts/__tests__/spec-verify.test.js
+++ b/workflows/check/scripts/__tests__/spec-verify.test.js
@@ -269,7 +269,7 @@ describe('spec-verify.js', () => {
   });
 
   it('REUSES preserves // inside regex literals when stripping comments', () => {
-    writeFile('src/app.js', 'const re = /https?:\\/\\//; const { useAuth } = require(\'./hooks\');');
+    writeFile('src/app.js', "const re = /https?:\\/\\//; const { useAuth } = require('./hooks');");
     const specPath = writeSpec(['- REUSES src/app.js hooks']);
     const result = runScript(specPath, { json: true });
     assert.equal(result.exitCode, 0);

--- a/workflows/check/scripts/spec-verify.js
+++ b/workflows/check/scripts/spec-verify.js
@@ -394,10 +394,12 @@ function checkReuses(args, root) {
   // machine avoids false stripping of // inside strings (e.g. URLs).
   const stripped = stripComments(content);
   const lines = stripped.split(/\r?\n/);
-  if (lines.some((line) => {
-    const m = importRegex.exec(line);
-    return m && !isInsideString(line, m.index);
-  })) {
+  if (
+    lines.some((line) => {
+      const m = importRegex.exec(line);
+      return m && !isInsideString(line, m.index);
+    })
+  ) {
     return { type: 'REUSES', args, passed: true };
   }
   // Fallback: check full content for require('...pattern...') split across lines by formatters.
@@ -446,8 +448,8 @@ function stripComments(src) {
         out += src[i]; // closing quote
         i++;
       }
-    // Regex literal — a / after certain tokens starts a regex, not a comment.
-    // Heuristic: / preceded by =, (, [, !, &, |, ?, :, ,, ;, {, }, newline, or line start.
+      // Regex literal — a / after certain tokens starts a regex, not a comment.
+      // Heuristic: / preceded by =, (, [, !, &, |, ?, :, ,, ;, {, }, newline, or line start.
     } else if (ch === '/' && src[i + 1] !== '/' && src[i + 1] !== '*' && isRegexContext(out)) {
       out += ch;
       i++;
@@ -482,11 +484,11 @@ function stripComments(src) {
           i++;
         }
       }
-    // Single-line comment — skip to end of line
+      // Single-line comment — skip to end of line
     } else if (ch === '/' && src[i + 1] === '/') {
       while (i < src.length && src[i] !== '\n') i++;
-    // Block comment — replace with newlines to preserve line structure.
-    // If no newline was emitted, insert a space to prevent token concatenation.
+      // Block comment — replace with newlines to preserve line structure.
+      // If no newline was emitted, insert a space to prevent token concatenation.
     } else if (ch === '/' && src[i + 1] === '*') {
       let emittedNewline = false;
       i += 2;

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2135,7 +2135,10 @@ describe('enforce-step-workflow', () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
       const { code, stderr } = await runHook(
-        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} complete $(echo ${TEST_TICKET})` } },
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} complete $(echo ${TEST_TICKET})` },
+        },
         'PreToolUse'
       );
       assert.equal(code, 2, 'command substitution should be blocked');
@@ -2146,7 +2149,10 @@ describe('enforce-step-workflow', () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
       const { code, stderr } = await runHook(
-        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} complete \`echo ${TEST_TICKET}\`` } },
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} complete \`echo ${TEST_TICKET}\`` },
+        },
         'PreToolUse'
       );
       assert.equal(code, 2, 'backtick substitution should be blocked');
@@ -2157,7 +2163,10 @@ describe('enforce-step-workflow', () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
       const { code, stderr } = await runHook(
-        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET} || echo pwned` } },
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET} || echo pwned` },
+        },
         'PreToolUse'
       );
       assert.equal(code, 2, 'chained || should be blocked');
@@ -2168,7 +2177,10 @@ describe('enforce-step-workflow', () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
       const { code, stderr } = await runHook(
-        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET} | tee /tmp/out` } },
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET} | tee /tmp/out` },
+        },
         'PreToolUse'
       );
       assert.equal(code, 2, 'pipe should be blocked');
@@ -2179,7 +2191,10 @@ describe('enforce-step-workflow', () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
       const { code, stderr } = await runHook(
-        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET} > /tmp/out` } },
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET} > /tmp/out` },
+        },
         'PreToolUse'
       );
       assert.equal(code, 2, 'redirect should be blocked');
@@ -2190,7 +2205,10 @@ describe('enforce-step-workflow', () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
       const { code, stderr } = await runHook(
-        { tool_name: 'Bash', tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET} --force` } },
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET} --force` },
+        },
         'PreToolUse'
       );
       assert.equal(code, 2, 'extra args should be blocked');

--- a/workflows/lib/__tests__/parse-report-status.test.js
+++ b/workflows/lib/__tests__/parse-report-status.test.js
@@ -73,7 +73,11 @@ describe('parseReportStatus — Status: line format', () => {
     // exists in the body, the explicit Status: line should prevent heuristic fallback.
     const content = 'Status: COMPLETE\n\n✅ PASS\nAll tests passed';
     const result = parseReportStatus(content, 'tests');
-    assert.equal(result.status, 'UNKNOWN', 'unrecognized Status line must block heuristic fallback');
+    assert.equal(
+      result.status,
+      'UNKNOWN',
+      'unrecognized Status line must block heuristic fallback'
+    );
   });
 
   it('stops at first Status line even when later Status lines are valid', () => {
@@ -87,7 +91,11 @@ describe('parseReportStatus — Status: line format', () => {
   it('returns UNKNOWN for summary table with type-invalid status', () => {
     const content = '| Status | COMPLETE |\n\n✅ PASS';
     const result = parseReportStatus(content, 'tests');
-    assert.equal(result.status, 'UNKNOWN', 'type-invalid table status must block heuristic fallback');
+    assert.equal(
+      result.status,
+      'UNKNOWN',
+      'type-invalid table status must block heuristic fallback'
+    );
   });
 
   it('recognizes Status: NEEDS_WORK', () => {
@@ -794,7 +802,11 @@ describe('isCodeReviewResolved — spurious title filtering (GH-232)', () => {
     ].join('\n');
 
     const result = isCodeReviewResolved(report, '');
-    assert.equal(result.resolved, true, 'CRITICAL: with colon must be filtered by SPURIOUS_TITLE_RE');
+    assert.equal(
+      result.resolved,
+      true,
+      'CRITICAL: with colon must be filtered by SPURIOUS_TITLE_RE'
+    );
     assert.deepStrictEqual(result.unaddressed, []);
   });
 

--- a/workflows/lib/hooks/enforce-step-workflow.js
+++ b/workflows/lib/hooks/enforce-step-workflow.js
@@ -425,7 +425,8 @@ function isTerminalCompleteBypass(cmd, ticketId) {
   // Strict format: only "node <path>/work-state.js complete <ticketId>"
   // Accepts quoted paths: node "path/work-state.js" or node 'path/work-state.js'
   // Reject anything with shell operators, substitutions, or extra arguments
-  const strictPattern = /^node\s+(?:"([^"]+[\\/]work-state\.js)"|'([^']+[\\/]work-state\.js)'|(\S+[\\/]work-state\.js))\s+complete\s+(\S+)\s*$/;
+  const strictPattern =
+    /^node\s+(?:"([^"]+[\\/]work-state\.js)"|'([^']+[\\/]work-state\.js)'|(\S+[\\/]work-state\.js))\s+complete\s+(\S+)\s*$/;
   const match = strictPattern.exec(cmd);
   if (!match) return false;
 

--- a/workflows/lib/protect-artifact-files.js
+++ b/workflows/lib/protect-artifact-files.js
@@ -246,9 +246,10 @@ function createArtifactProtector(opts) {
               // This guard runs unconditionally — including during the 'check' step —
               // so that writes like "/<ticket>/../outside/file.check.md" are always blocked.
               if (isEscapingTicketDir) {
-                const suggestedPath = currentStep === 'check'
-                  ? path.join(resolvedTicketDir, bn)
-                  : path.join(resolvedTicketDir, 'task' + taskNum, bn);
+                const suggestedPath =
+                  currentStep === 'check'
+                    ? path.join(resolvedTicketDir, bn)
+                    : path.join(resolvedTicketDir, 'task' + taskNum, bn);
                 return {
                   blocked: true,
                   file: bn,

--- a/workflows/work/__tests__/resolve-git-head.test.js
+++ b/workflows/work/__tests__/resolve-git-head.test.js
@@ -88,14 +88,13 @@ describe('getHeadSha (GH-299 Task 1)', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh299-git-'));
     try {
       // Create a self-contained git repo so test doesn't depend on outer checkout
-      execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
-      execFileSync('git', ['-C', tmpDir, 'config', 'user.email', 'test@test.com'], {
-        stdio: 'ignore',
-      });
-      execFileSync('git', ['-C', tmpDir, 'config', 'user.name', 'Test'], { stdio: 'ignore' });
+      const gitOpts = { cwd: tmpDir, stdio: 'ignore', timeout: 5000 };
+      execFileSync('git', ['init'], gitOpts);
+      execFileSync('git', ['config', 'user.email', 'test@test.com'], gitOpts);
+      execFileSync('git', ['config', 'user.name', 'Test'], gitOpts);
       fs.writeFileSync(path.join(tmpDir, 'file.txt'), 'test');
-      execFileSync('git', ['add', '.'], { cwd: tmpDir, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'init'], { cwd: tmpDir, stdio: 'ignore' });
+      execFileSync('git', ['add', '.'], gitOpts);
+      execFileSync('git', ['commit', '-m', 'init'], gitOpts);
 
       const sha = getHeadSha(tmpDir);
       assert.notEqual(sha, null, 'Should not be null in a git repo');

--- a/workflows/work/__tests__/resolve-git-head.test.js
+++ b/workflows/work/__tests__/resolve-git-head.test.js
@@ -82,23 +82,34 @@ describe('resolveGitHead (GH-260 Issue 1)', () => {
 });
 
 describe('getHeadSha (GH-299 Task 1)', () => {
-  it('should return a 40-char hex string in a real git repo', () => {
-    const sha = getHeadSha();
-    assert.notEqual(sha, null, 'Should not be null in a git repo');
-    assert.match(sha, /^[0-9a-f]{40}$/, 'Should be a 40-char hex SHA');
+  const { execFileSync } = require('child_process');
+
+  it('should return a 40-char hex string in a self-contained temp git repo', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh299-git-'));
+    try {
+      // Create a self-contained git repo so test doesn't depend on outer checkout
+      execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
+      execFileSync('git', ['-C', tmpDir, 'config', 'user.email', 'test@test.com'], {
+        stdio: 'ignore',
+      });
+      execFileSync('git', ['-C', tmpDir, 'config', 'user.name', 'Test'], { stdio: 'ignore' });
+      fs.writeFileSync(path.join(tmpDir, 'file.txt'), 'test');
+      execFileSync('git', ['add', '.'], { cwd: tmpDir, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd: tmpDir, stdio: 'ignore' });
+
+      const sha = getHeadSha(tmpDir);
+      assert.notEqual(sha, null, 'Should not be null in a git repo');
+      assert.match(sha, /^[0-9a-f]{40}$/, 'Should be a 40-char hex SHA');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it('should return null when git fails (non-git directory)', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh299-'));
     try {
-      const origCwd = process.cwd();
-      process.chdir(tmpDir);
-      try {
-        const sha = getHeadSha();
-        assert.equal(sha, null, 'Should return null in a non-git directory');
-      } finally {
-        process.chdir(origCwd);
-      }
+      const sha = getHeadSha(tmpDir);
+      assert.equal(sha, null, 'Should return null in a non-git directory');
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/workflows/work/__tests__/resolve-git-head.test.js
+++ b/workflows/work/__tests__/resolve-git-head.test.js
@@ -12,7 +12,7 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { resolveGitHead } = require('../git-utils');
+const { resolveGitHead, getHeadSha } = require('../git-utils');
 
 describe('resolveGitHead (GH-260 Issue 1)', () => {
   const tmpDirs = [];
@@ -78,5 +78,29 @@ describe('resolveGitHead (GH-260 Issue 1)', () => {
       /unexpected \.git content/,
       'Should throw for non-gitdir content'
     );
+  });
+});
+
+describe('getHeadSha (GH-299 Task 1)', () => {
+  it('should return a 40-char hex string in a real git repo', () => {
+    const sha = getHeadSha();
+    assert.notEqual(sha, null, 'Should not be null in a git repo');
+    assert.match(sha, /^[0-9a-f]{40}$/, 'Should be a 40-char hex SHA');
+  });
+
+  it('should return null when git fails (non-git directory)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh299-'));
+    try {
+      const origCwd = process.cwd();
+      process.chdir(tmpDir);
+      try {
+        const sha = getHeadSha();
+        assert.equal(sha, null, 'Should return null in a non-git directory');
+      } finally {
+        process.chdir(origCwd);
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/workflows/work/__tests__/step-registry.test.js
+++ b/workflows/work/__tests__/step-registry.test.js
@@ -153,4 +153,18 @@ describe('step-registry', () => {
       );
     });
   });
+
+  // GH-299: post-check steps can retry back to check
+  describe('post-check retry edges to check (GH-299)', () => {
+    const postCheckSteps = ['pr', 'ready', 'follow_up', 'ci', 'cleanup', 'reports'];
+
+    for (const step of postCheckSteps) {
+      it(`RETRY_EDGES maps ${step} to check`, () => {
+        assert.ok(
+          STEP_TRANSITIONS[step].includes('check'),
+          `${step} should have a retry edge to check`
+        );
+      });
+    }
+  });
 });

--- a/workflows/work/__tests__/task-parser.test.js
+++ b/workflows/work/__tests__/task-parser.test.js
@@ -270,10 +270,7 @@ describe('buildTaskPrompt', () => {
 
   it('marks current task with YOU ARE IMPLEMENTING THIS', () => {
     const task = { num: 2, title: 'Current', rawContent: 'content', suggestedScope: '' };
-    const allTasks = [
-      { num: 1, title: 'Previous', suggestedScope: '' },
-      task,
-    ];
+    const allTasks = [{ num: 1, title: 'Previous', suggestedScope: '' }, task];
     const prompt = buildTaskPrompt(task, tmpDir, allTasks);
     assert.ok(prompt.includes('YOU ARE IMPLEMENTING THIS'));
     assert.ok(prompt.match(/Task 2.*YOU ARE IMPLEMENTING THIS/));
@@ -281,20 +278,14 @@ describe('buildTaskPrompt', () => {
 
   it('marks pending tasks as do NOT implement yet', () => {
     const task = { num: 1, title: 'Current', rawContent: 'content', suggestedScope: '' };
-    const allTasks = [
-      task,
-      { num: 2, title: 'Upcoming', suggestedScope: '' },
-    ];
+    const allTasks = [task, { num: 2, title: 'Upcoming', suggestedScope: '' }];
     const prompt = buildTaskPrompt(task, tmpDir, allTasks);
     assert.ok(prompt.includes('pending — do NOT implement yet'));
   });
 
   it('marks completed tasks as do NOT re-implement', () => {
     const task = { num: 2, title: 'Current', rawContent: 'content', suggestedScope: '' };
-    const allTasks = [
-      { num: 1, title: 'Done task', suggestedScope: '' },
-      task,
-    ];
+    const allTasks = [{ num: 1, title: 'Done task', suggestedScope: '' }, task];
     const taskState = {
       tasks: [{ id: 'task_1', status: 'completed' }],
     };
@@ -316,20 +307,14 @@ describe('buildTaskPrompt', () => {
 
   it('does not include reserved files for pending tasks with no suggestedScope', () => {
     const task = { num: 1, title: 'Current', rawContent: 'content', suggestedScope: '' };
-    const allTasks = [
-      task,
-      { num: 2, title: 'No scope', suggestedScope: '' },
-    ];
+    const allTasks = [task, { num: 2, title: 'No scope', suggestedScope: '' }];
     const prompt = buildTaskPrompt(task, tmpDir, allTasks);
     assert.ok(!prompt.includes('Reserved files:'));
   });
 
   it('falls back gracefully when taskState has no tasks array', () => {
     const task = { num: 2, title: 'Current', rawContent: 'content', suggestedScope: '' };
-    const allTasks = [
-      { num: 1, title: 'Previous', suggestedScope: '' },
-      task,
-    ];
+    const allTasks = [{ num: 1, title: 'Previous', suggestedScope: '' }, task];
     // taskState with no tasks array — should not throw
     const prompt = buildTaskPrompt(task, tmpDir, allTasks, {});
     assert.ok(prompt.includes('### Task Context'));
@@ -340,10 +325,7 @@ describe('buildTaskPrompt', () => {
   it('shows all reserved files when scope exceeds the old 5-line cap', () => {
     const task = { num: 1, title: 'Current', rawContent: 'content', suggestedScope: '' };
     const manyFiles = Array.from({ length: 8 }, (_, i) => `- src/file${i + 1}.ts`).join('\n');
-    const allTasks = [
-      task,
-      { num: 2, title: 'Big scope', suggestedScope: manyFiles },
-    ];
+    const allTasks = [task, { num: 2, title: 'Big scope', suggestedScope: manyFiles }];
     const prompt = buildTaskPrompt(task, tmpDir, allTasks);
     // All 8 files must appear, not just 5
     for (let i = 1; i <= 8; i++) {
@@ -426,10 +408,7 @@ describe('buildTaskPrompt', () => {
 
   it('labels a claimed (in-flight) task as in progress, not pending', () => {
     const task = { num: 1, title: 'Current', rawContent: 'content', suggestedScope: '' };
-    const allTasks = [
-      task,
-      { num: 2, title: 'In-flight', suggestedScope: '' },
-    ];
+    const allTasks = [task, { num: 2, title: 'In-flight', suggestedScope: '' }];
     // Write a claim lock for task 2
     const claimsDir = path.join(tmpDir, '.claims');
     fs.mkdirSync(claimsDir, { recursive: true });

--- a/workflows/work/__tests__/transition-step.test.js
+++ b/workflows/work/__tests__/transition-step.test.js
@@ -68,6 +68,8 @@ function createDeps(overrides = {}) {
     // GH-260: generic step-verify gate deps (default: no soft steps, no commandMap)
     softSteps: new Set(),
     commandMap: [],
+    // GH-299: getHeadSha dep (default: returns a fixed SHA)
+    getHeadSha: () => 'a'.repeat(40),
     // expose for assertions
     _actions: actions,
     _savedStates: savedStates,
@@ -408,5 +410,192 @@ describe('transition-step.js (GH-260): generic step-verify gate', () => {
     assert.equal(result.error, true, 'Should block transition when verify throws');
     assert.equal(result.gate, 'step-verify', 'Gate should be step-verify');
     assert.ok(result.message.includes('verify threw'), 'Message should indicate verify threw');
+  });
+});
+
+// ─── GH-299: check-drift gate tests ─────────────────────────────────────────
+describe('transition-step.js (GH-299): check-drift gate', () => {
+  /** Helper: create deps with state at a given step, with checkPassedSha set */
+  function depsAtStep(stepName, opts = {}) {
+    const { STEPS, ALL_STEPS } = require('../step-registry');
+    const stepIdx = ALL_STEPS.indexOf(stepName);
+    const sha = opts.checkPassedSha !== undefined ? opts.checkPassedSha : 'a'.repeat(40);
+    const headSha = opts.headSha !== undefined ? opts.headSha : 'a'.repeat(40);
+
+    const deps = createDeps({
+      workflowCanTransition: () => true,
+      getHeadSha: () => headSha,
+      ...opts.extraDeps,
+    });
+
+    const ws = deps.loadWorkState(opts.ticket || 'TEST-DRIFT');
+    ws.currentStep = stepIdx + 1;
+    ws.stepStatus[stepName] = 'in_progress';
+    if (sha !== undefined) {
+      ws.checkPassedSha = sha;
+    }
+    if (opts.checkInterruptedStep !== undefined) {
+      ws.checkInterruptedStep = opts.checkInterruptedStep;
+    }
+    deps._savedStates[opts.ticket || 'TEST-DRIFT'] = ws;
+
+    return { deps, STEPS, ALL_STEPS };
+  }
+
+  it('should proceed normally when SHA matches on forward transition from post-check step', () => {
+    const { transitionStep } = require('../transition-step');
+    const matchingSha = 'b'.repeat(40);
+    const { deps } = depsAtStep('pr', {
+      ticket: 'TEST-DRIFT-MATCH',
+      checkPassedSha: matchingSha,
+      headSha: matchingSha,
+    });
+
+    const result = transitionStep('TEST-DRIFT-MATCH', 'ready', deps);
+    assert.equal(result.success, true, 'Should proceed when SHA matches');
+    assert.equal(result.from, 'pr');
+    assert.equal(result.to, 'ready');
+  });
+
+  it('should redirect to check when SHA differs on forward transition from post-check step', () => {
+    const { transitionStep } = require('../transition-step');
+    const { deps, STEPS } = depsAtStep('pr', {
+      ticket: 'TEST-DRIFT-DIFF',
+      checkPassedSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40),
+    });
+
+    const result = transitionStep('TEST-DRIFT-DIFF', 'ready', deps);
+    assert.equal(result.success, true, 'Should succeed (redirected)');
+    assert.equal(result.to, STEPS.check, 'Should redirect to check');
+    assert.equal(result.gate, 'check-drift', 'Gate should be check-drift');
+    assert.ok(
+      result.message.includes('New commits detected'),
+      'Message should mention new commits'
+    );
+  });
+
+  it('should skip gate on backward transitions', () => {
+    const { transitionStep } = require('../transition-step');
+    const { deps, STEPS } = depsAtStep('pr', {
+      ticket: 'TEST-DRIFT-BACK',
+      checkPassedSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40), // SHA differs but backward should skip gate
+    });
+
+    const result = transitionStep('TEST-DRIFT-BACK', STEPS.check, deps);
+    assert.equal(result.success, true, 'Backward transition should succeed');
+    assert.equal(result.to, STEPS.check);
+    // Should NOT have gate='check-drift' — backward transitions skip the gate
+    assert.notEqual(result.gate, 'check-drift', 'Backward should not trigger drift gate');
+  });
+
+  it('should skip gate when checkPassedSha is missing from work state', () => {
+    const { transitionStep } = require('../transition-step');
+    const { deps } = depsAtStep('pr', {
+      ticket: 'TEST-DRIFT-NOSHA',
+      checkPassedSha: undefined,
+      headSha: 'b'.repeat(40),
+    });
+    // Remove checkPassedSha explicitly
+    delete deps._savedStates['TEST-DRIFT-NOSHA'].checkPassedSha;
+
+    const result = transitionStep('TEST-DRIFT-NOSHA', 'ready', deps);
+    assert.equal(result.success, true, 'Should proceed without checkPassedSha');
+  });
+
+  it('should skip gate (fail-open) when getHeadSha returns null', () => {
+    const { transitionStep } = require('../transition-step');
+    const { deps } = depsAtStep('pr', {
+      ticket: 'TEST-DRIFT-NULL',
+      checkPassedSha: 'a'.repeat(40),
+      headSha: null,
+    });
+
+    const result = transitionStep('TEST-DRIFT-NULL', 'ready', deps);
+    assert.equal(result.success, true, 'Should fail-open when getHeadSha returns null');
+  });
+
+  it('should record checkPassedSha on check → pr transition', () => {
+    const { transitionStep } = require('../transition-step');
+    const { STEPS, ALL_STEPS } = require('../step-registry');
+    const expectedSha = 'c'.repeat(40);
+
+    const checkIdx = ALL_STEPS.indexOf(STEPS.check);
+    const deps = createDeps({
+      workflowCanTransition: () => true,
+      getHeadSha: () => expectedSha,
+    });
+
+    const ws = deps.loadWorkState('TEST-DRIFT-RECORD');
+    ws.currentStep = checkIdx + 1;
+    ws.stepStatus[STEPS.check] = 'in_progress';
+    deps._savedStates['TEST-DRIFT-RECORD'] = ws;
+
+    const result = transitionStep('TEST-DRIFT-RECORD', STEPS.pr, deps);
+    assert.equal(result.success, true, 'check -> pr should succeed');
+
+    const saved = deps._savedStates['TEST-DRIFT-RECORD'];
+    assert.equal(saved.checkPassedSha, expectedSha, 'checkPassedSha should be recorded');
+  });
+
+  it('should clear checkInterruptedStep on check → pr transition', () => {
+    const { transitionStep } = require('../transition-step');
+    const { STEPS, ALL_STEPS } = require('../step-registry');
+
+    const checkIdx = ALL_STEPS.indexOf(STEPS.check);
+    const deps = createDeps({
+      workflowCanTransition: () => true,
+      getHeadSha: () => 'd'.repeat(40),
+    });
+
+    const ws = deps.loadWorkState('TEST-DRIFT-CLEAR');
+    ws.currentStep = checkIdx + 1;
+    ws.stepStatus[STEPS.check] = 'in_progress';
+    ws.checkInterruptedStep = 'pr'; // was previously interrupted
+    deps._savedStates['TEST-DRIFT-CLEAR'] = ws;
+
+    const result = transitionStep('TEST-DRIFT-CLEAR', STEPS.pr, deps);
+    assert.equal(result.success, true);
+
+    const saved = deps._savedStates['TEST-DRIFT-CLEAR'];
+    assert.equal(saved.checkInterruptedStep, null, 'checkInterruptedStep should be cleared');
+  });
+
+  it('should set checkInterruptedStep on drift detection', () => {
+    const { transitionStep } = require('../transition-step');
+    const { deps, STEPS } = depsAtStep('follow_up', {
+      ticket: 'TEST-DRIFT-INTERRUPT',
+      checkPassedSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40),
+    });
+
+    const result = transitionStep('TEST-DRIFT-INTERRUPT', STEPS.ci, deps);
+    assert.equal(result.gate, 'check-drift');
+
+    const saved = deps._savedStates['TEST-DRIFT-INTERRUPT'];
+    assert.equal(
+      saved.checkInterruptedStep,
+      'follow_up',
+      'checkInterruptedStep should be set to current step'
+    );
+    assert.equal(saved.checkPassedSha, null, 'checkPassedSha should be cleared on drift');
+  });
+
+  it('should call appendAction with re-check message on drift', () => {
+    const { transitionStep } = require('../transition-step');
+    const { deps, STEPS } = depsAtStep('ci', {
+      ticket: 'TEST-DRIFT-ACTION',
+      checkPassedSha: 'a'.repeat(40),
+      headSha: 'b'.repeat(40),
+    });
+
+    transitionStep('TEST-DRIFT-ACTION', STEPS.cleanup, deps);
+
+    const recheckActions = deps._actions.filter(
+      (a) => a.what === 'check re-triggered: new commits detected'
+    );
+    assert.equal(recheckActions.length, 1, 'Should log re-check action');
+    assert.equal(recheckActions[0].step, 'ci', 'Action step should be current step');
   });
 });

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -821,14 +821,12 @@ describe('work-orchestrator.js', () => {
       assert.ok(result.transitions['check'].includes('pr'));
     });
 
-    it('should NOT include pr → ci (no skip edges)', async () => {
+    it('should have exactly [ready, check] transitions for pr', async () => {
       const { result } = await runOrchestrator(['graph']);
-      assert.ok(!result.transitions['pr'].includes('ci'), 'pr should NOT skip to ci');
-      assert.ok(result.transitions['pr'].includes('ready'), 'pr should include ready');
-      // GH-299: pr can also retry back to check via RETRY_EDGES
-      assert.ok(
-        result.transitions['pr'].includes('check'),
-        'pr should include check (GH-299 retry edge)'
+      assert.deepEqual(
+        result.transitions['pr'].slice().sort(),
+        ['check', 'ready'],
+        'pr should transition to ready (forward) and check (GH-299 retry edge) only'
       );
     });
 

--- a/workflows/work/__tests__/work-orchestrator.test.js
+++ b/workflows/work/__tests__/work-orchestrator.test.js
@@ -824,7 +824,12 @@ describe('work-orchestrator.js', () => {
     it('should NOT include pr → ci (no skip edges)', async () => {
       const { result } = await runOrchestrator(['graph']);
       assert.ok(!result.transitions['pr'].includes('ci'), 'pr should NOT skip to ci');
-      assert.deepEqual(result.transitions['pr'], ['ready'], 'pr should only go to ready');
+      assert.ok(result.transitions['pr'].includes('ready'), 'pr should include ready');
+      // GH-299: pr can also retry back to check via RETRY_EDGES
+      assert.ok(
+        result.transitions['pr'].includes('check'),
+        'pr should include check (GH-299 retry edge)'
+      );
     });
 
     it('should allow transition from 6_check → 3_implement (backward)', async () => {

--- a/workflows/work/__tests__/work-workflow-deps-wiring.test.js
+++ b/workflows/work/__tests__/work-workflow-deps-wiring.test.js
@@ -47,9 +47,10 @@ describe('work.workflow.js dependency wiring', () => {
       }
 
       const fnBody = source.slice(fnBodyStart, fnBodyEnd + 1);
+      // Match getHeadSha as a property in the return object (not just a comment reference)
       assert.ok(
-        /\bgetHeadSha\b/.test(fnBody),
-        `buildTransitionDeps should include getHeadSha in its return object.\nFunction body: ${fnBody}`
+        /\bgetHeadSha[,\s}]/.test(fnBody),
+        `buildTransitionDeps should include getHeadSha as a property in its return object.\nFunction body: ${fnBody}`
       );
     });
   });

--- a/workflows/work/__tests__/work-workflow-deps-wiring.test.js
+++ b/workflows/work/__tests__/work-workflow-deps-wiring.test.js
@@ -1,0 +1,56 @@
+/**
+ * Tests for dependency wiring in work.workflow.js
+ *
+ * Verifies that required dependencies are properly wired into
+ * buildTransitionDeps() for transitionStep calls.
+ *
+ * Run: node --test workflows/work/__tests__/work-workflow-deps-wiring.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_PATH = path.join(__dirname, '..', 'work.workflow.js');
+const source = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+
+describe('work.workflow.js dependency wiring', () => {
+  describe('buildTransitionDeps includes getHeadSha (GH-299 Task 5)', () => {
+    it('should import getHeadSha from git-utils', () => {
+      // Verify the require statement pulls getHeadSha from git-utils
+      const importPattern = /require\([^)]*git-utils[^)]*\)/;
+      assert.ok(importPattern.test(source), 'git-utils should be required');
+
+      const getHeadShaImport = /getHeadSha\b/;
+      assert.ok(getHeadShaImport.test(source), 'getHeadSha should be imported from git-utils');
+    });
+
+    it('should include getHeadSha in buildTransitionDeps return object', () => {
+      // Extract the buildTransitionDeps function body by finding its boundaries
+      const fnStart = source.indexOf('function buildTransitionDeps()');
+      assert.ok(fnStart !== -1, 'buildTransitionDeps function should exist');
+
+      // Find the function's opening brace
+      const fnBodyStart = source.indexOf('{', fnStart);
+
+      // Walk to the matching closing brace for the function body
+      let braceCount = 0;
+      let fnBodyEnd = fnBodyStart;
+      for (let i = fnBodyStart; i < source.length; i++) {
+        if (source[i] === '{') braceCount++;
+        if (source[i] === '}') braceCount--;
+        if (braceCount === 0) {
+          fnBodyEnd = i;
+          break;
+        }
+      }
+
+      const fnBody = source.slice(fnBodyStart, fnBodyEnd + 1);
+      assert.ok(
+        /\bgetHeadSha\b/.test(fnBody),
+        `buildTransitionDeps should include getHeadSha in its return object.\nFunction body: ${fnBody}`
+      );
+    });
+  });
+});

--- a/workflows/work/__tests__/workflow-definition.test.js
+++ b/workflows/work/__tests__/workflow-definition.test.js
@@ -674,22 +674,12 @@ describe('workflow-definition: verify[STEPS.check] QA report gating', () => {
   }
 
   it('passes without QA report when no web apps configured', () => {
-    setupTicketDir([
-      'code-review.check.md',
-      'tests.check.md',
-      'completion.check.md',
-      'README.md',
-    ]);
+    setupTicketDir(['code-review.check.md', 'tests.check.md', 'completion.check.md', 'README.md']);
     assert.equal(callVerifyWithWebApps([]), true);
   });
 
   it('fails without QA report when web apps are configured', () => {
-    setupTicketDir([
-      'code-review.check.md',
-      'tests.check.md',
-      'completion.check.md',
-      'README.md',
-    ]);
+    setupTicketDir(['code-review.check.md', 'tests.check.md', 'completion.check.md', 'README.md']);
     assert.equal(
       callVerifyWithWebApps([{ name: 'my-app', defaultPort: 3000, type: 'vite' }]),
       false

--- a/workflows/work/git-utils.js
+++ b/workflows/work/git-utils.js
@@ -50,7 +50,7 @@ function resolveGitHead(cwd) {
  */
 function getHeadSha(cwd) {
   try {
-    const opts = { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] };
+    const opts = { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000 };
     if (cwd) opts.cwd = cwd;
     return execFileSync('git', ['rev-parse', 'HEAD'], opts).trim();
   } catch {

--- a/workflows/work/git-utils.js
+++ b/workflows/work/git-utils.js
@@ -45,14 +45,14 @@ function resolveGitHead(cwd) {
  * Uses `git rev-parse HEAD` to retrieve the 40-char hex SHA.
  * Returns null on any failure (fail-open).
  *
+ * @param {string} [cwd] - Optional working directory (defaults to process.cwd())
  * @returns {string|null} 40-char hex SHA, or null on error
  */
-function getHeadSha() {
+function getHeadSha(cwd) {
   try {
-    return execFileSync('git', ['rev-parse', 'HEAD'], {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
+    const opts = { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] };
+    if (cwd) opts.cwd = cwd;
+    return execFileSync('git', ['rev-parse', 'HEAD'], opts).trim();
   } catch {
     return null;
   }

--- a/workflows/work/git-utils.js
+++ b/workflows/work/git-utils.js
@@ -52,7 +52,8 @@ function getHeadSha(cwd) {
   try {
     const opts = { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000 };
     if (cwd) opts.cwd = cwd;
-    return execFileSync('git', ['rev-parse', 'HEAD'], opts).trim();
+    const sha = execFileSync('git', ['rev-parse', 'HEAD'], opts).trim();
+    return /^[0-9a-f]{40}$/i.test(sha) ? sha : null;
   } catch {
     return null;
   }

--- a/workflows/work/git-utils.js
+++ b/workflows/work/git-utils.js
@@ -9,6 +9,9 @@ const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+/** Validates a 40-char hex SHA. Shared across workflow modules. */
+const SHA_REGEX = /^[0-9a-f]{40}$/i;
+
 /**
  * Resolve the HEAD ref for a git repository or worktree.
  *
@@ -53,10 +56,10 @@ function getHeadSha(cwd) {
     const opts = { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000 };
     if (cwd) opts.cwd = cwd;
     const sha = execFileSync('git', ['rev-parse', 'HEAD'], opts).trim();
-    return /^[0-9a-f]{40}$/i.test(sha) ? sha : null;
+    return SHA_REGEX.test(sha) ? sha : null;
   } catch {
     return null;
   }
 }
 
-module.exports = { resolveGitHead, getHeadSha };
+module.exports = { resolveGitHead, getHeadSha, SHA_REGEX };

--- a/workflows/work/git-utils.js
+++ b/workflows/work/git-utils.js
@@ -5,6 +5,7 @@
  * and reuse across modules.
  */
 
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -38,4 +39,23 @@ function resolveGitHead(cwd) {
   throw new Error(`unexpected .git content in ${dotgitPath}`);
 }
 
-module.exports = { resolveGitHead };
+/**
+ * Get the current HEAD commit SHA.
+ *
+ * Uses `git rev-parse HEAD` to retrieve the 40-char hex SHA.
+ * Returns null on any failure (fail-open).
+ *
+ * @returns {string|null} 40-char hex SHA, or null on error
+ */
+function getHeadSha() {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { resolveGitHead, getHeadSha };

--- a/workflows/work/scripts/__tests__/follow-up-pr-comments.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr-comments.test.js
@@ -238,7 +238,9 @@ describe('follow-up-pr-comments CLI', () => {
     it('exits 1 for unknown comment ID', () => {
       const comments = [makeComment({ id: 100 })];
       ctx = createTempState(makeState(comments));
-      const result = run(['--solve-comment', '999', 'abc1234', 'Fix'], envFor(ctx.tmpDir), { cwd: cwdFor(ctx) });
+      const result = run(['--solve-comment', '999', 'abc1234', 'Fix'], envFor(ctx.tmpDir), {
+        cwd: cwdFor(ctx),
+      });
       assert.equal(result.status, 1);
       assert.match(result.stderr, /not found/i);
     });
@@ -246,7 +248,9 @@ describe('follow-up-pr-comments CLI', () => {
     it('validates commitSha format (hex 7-40 chars)', () => {
       const comments = [makeComment({ id: 100 })];
       ctx = createTempState(makeState(comments));
-      const result = run(['--solve-comment', '100', 'short', 'Fix'], envFor(ctx.tmpDir), { cwd: cwdFor(ctx) });
+      const result = run(['--solve-comment', '100', 'short', 'Fix'], envFor(ctx.tmpDir), {
+        cwd: cwdFor(ctx),
+      });
       assert.equal(result.status, 1);
       assert.match(result.stderr, /commit/i);
     });
@@ -255,7 +259,9 @@ describe('follow-up-pr-comments CLI', () => {
       const comments = [makeComment({ id: 100 })];
       ctx = createTempState(makeState(comments));
       const longDesc = 'x'.repeat(600);
-      const result = run(['--solve-comment', '100', 'abc1234def0', longDesc], envFor(ctx.tmpDir), { cwd: cwdFor(ctx) });
+      const result = run(['--solve-comment', '100', 'abc1234def0', longDesc], envFor(ctx.tmpDir), {
+        cwd: cwdFor(ctx),
+      });
       assert.equal(result.status, 0);
 
       const state = JSON.parse(fs.readFileSync(ctx.stateFile, 'utf8'));
@@ -274,7 +280,9 @@ describe('follow-up-pr-comments CLI', () => {
         makeComment({ id: 200, author: 'reviewer', body: 'Nitpick', path: 'src/b.js' }),
       ];
       ctx = createTempState(makeState(comments));
-      const result = run(['--skip-comment', '200', 'Non-blocking nitpick'], envFor(ctx.tmpDir), { cwd: cwdFor(ctx) });
+      const result = run(['--skip-comment', '200', 'Non-blocking nitpick'], envFor(ctx.tmpDir), {
+        cwd: cwdFor(ctx),
+      });
       assert.equal(result.status, 0);
 
       const state = JSON.parse(fs.readFileSync(ctx.stateFile, 'utf8'));
@@ -291,7 +299,9 @@ describe('follow-up-pr-comments CLI', () => {
     it('exits 1 for unknown comment ID', () => {
       const comments = [makeComment({ id: 200 })];
       ctx = createTempState(makeState(comments));
-      const result = run(['--skip-comment', '999', 'Reason'], envFor(ctx.tmpDir), { cwd: cwdFor(ctx) });
+      const result = run(['--skip-comment', '999', 'Reason'], envFor(ctx.tmpDir), {
+        cwd: cwdFor(ctx),
+      });
       assert.equal(result.status, 1);
       assert.match(result.stderr, /not found/i);
     });
@@ -300,7 +310,9 @@ describe('follow-up-pr-comments CLI', () => {
       const comments = [makeComment({ id: 200 })];
       ctx = createTempState(makeState(comments));
       const longReason = 'y'.repeat(600);
-      const result = run(['--skip-comment', '200', longReason], envFor(ctx.tmpDir), { cwd: cwdFor(ctx) });
+      const result = run(['--skip-comment', '200', longReason], envFor(ctx.tmpDir), {
+        cwd: cwdFor(ctx),
+      });
       assert.equal(result.status, 0);
 
       const state = JSON.parse(fs.readFileSync(ctx.stateFile, 'utf8'));
@@ -457,21 +469,29 @@ describe('follow-up-pr-comments CLI', () => {
     it('accepts string review IDs (e.g. PRR_kwDO...) for --solve-comment', () => {
       const comments = [makeComment({ id: 'PRR_kwDO123' })];
       ctx = createTempState(makeState(comments));
-      const result = run(['--solve-comment', 'PRR_kwDO123', 'abc1234def0', 'Fix'], envFor(ctx.tmpDir), { cwd: cwdFor(ctx) });
+      const result = run(
+        ['--solve-comment', 'PRR_kwDO123', 'abc1234def0', 'Fix'],
+        envFor(ctx.tmpDir),
+        { cwd: cwdFor(ctx) }
+      );
       assert.equal(result.status, 0);
     });
 
     it('accepts string review IDs for --skip-comment', () => {
       const comments = [makeComment({ id: 'PRR_kwDO456' })];
       ctx = createTempState(makeState(comments));
-      const result = run(['--skip-comment', 'PRR_kwDO456', 'Low priority'], envFor(ctx.tmpDir), { cwd: cwdFor(ctx) });
+      const result = run(['--skip-comment', 'PRR_kwDO456', 'Low priority'], envFor(ctx.tmpDir), {
+        cwd: cwdFor(ctx),
+      });
       assert.equal(result.status, 0);
     });
 
     it('rejects empty commentId for --solve-comment', () => {
       const comments = [makeComment({ id: 100 })];
       ctx = createTempState(makeState(comments));
-      const result = run(['--solve-comment', '', 'abc1234', 'Fix'], envFor(ctx.tmpDir), { cwd: cwdFor(ctx) });
+      const result = run(['--solve-comment', '', 'abc1234', 'Fix'], envFor(ctx.tmpDir), {
+        cwd: cwdFor(ctx),
+      });
       assert.equal(result.status, 1);
     });
 

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1006,11 +1006,7 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
           '    state so nothing is missed or duplicated. Pushing mid-loop causes snapshot invalidation,'
         )
       );
-      lines.push(
-        c.yellow(
-          '    line-number drift, and dedup confusion.'
-        )
-      );
+      lines.push(c.yellow('    line-number drift, and dedup confusion.'));
       if (reviews.nonBlocking.length > 0) {
         lines.push(
           `  + ${reviews.nonBlocking.length} non-blocking (nitpick/low — assess whether to address):`

--- a/workflows/work/step-registry.js
+++ b/workflows/work/step-registry.js
@@ -101,8 +101,12 @@ const RETRY_EDGES = {
   [STEPS.spec_gate]: [STEPS.spec], // GH-244: gate failed, regenerate spec
   [STEPS.task_review]: [STEPS.implement], // GH-211: review failed, fix code
   [STEPS.check]: [STEPS.implement], // check failed, fix code
-  [STEPS.follow_up]: [STEPS.implement], // follow-up requires code changes
-  [STEPS.ci]: [STEPS.implement], // CI failed, fix code
+  [STEPS.pr]: [STEPS.check], // GH-299: recheck on new commits
+  [STEPS.ready]: [STEPS.check], // GH-299: recheck on new commits
+  [STEPS.follow_up]: [STEPS.implement, STEPS.check], // follow-up requires code changes; GH-299: recheck
+  [STEPS.ci]: [STEPS.implement, STEPS.check], // CI failed, fix code; GH-299: recheck
+  [STEPS.cleanup]: [STEPS.check], // GH-299: recheck on new commits
+  [STEPS.reports]: [STEPS.check], // GH-299: recheck on new commits
 };
 
 // Generate linear forward edges from STEP_ORDER, merge retry edges

--- a/workflows/work/task-parser.js
+++ b/workflows/work/task-parser.js
@@ -69,7 +69,10 @@ function _readClaimOwner(tasksDir, taskNum) {
  * @returns {string}
  */
 function _normalizeScope(line) {
-  return line.trim().replace(/^[-*+]\s+/, '').trim();
+  return line
+    .trim()
+    .replace(/^[-*+]\s+/, '')
+    .trim();
 }
 
 // ─── Task Parsing ────────────────────────────────────────────────────────────

--- a/workflows/work/task-review-gate.js
+++ b/workflows/work/task-review-gate.js
@@ -165,4 +165,4 @@ function executeTaskReview(tasksDir, ticketId, deps) {
 
 // ─── Public API ─────────────────────────────────────────────────────────────
 
-module.exports = { computeTaskDiff, executeTaskReview };
+module.exports = { computeTaskDiff, executeTaskReview, SHA_REGEX };

--- a/workflows/work/task-review-gate.js
+++ b/workflows/work/task-review-gate.js
@@ -14,10 +14,9 @@ const path = require('path');
 const fs = require('fs');
 const config = require(path.join(__dirname, '..', 'lib', 'config'));
 const { appendAction } = require(path.join(__dirname, 'work-actions'));
+const { SHA_REGEX } = require(path.join(__dirname, 'git-utils'));
 
 // ─── Constants ──────────────────────────────────────────────────────────────
-
-const SHA_REGEX = /^[0-9a-f]{40}$/i;
 const LAST_COMMIT_SHA_FILE = '.last-commit-sha';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -165,4 +164,4 @@ function executeTaskReview(tasksDir, ticketId, deps) {
 
 // ─── Public API ─────────────────────────────────────────────────────────────
 
-module.exports = { computeTaskDiff, executeTaskReview, SHA_REGEX };
+module.exports = { computeTaskDiff, executeTaskReview };

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -15,6 +15,11 @@ const fs = require('fs');
 const path = require('path');
 const { taskSegment } = require(path.join(__dirname, '..', 'lib', 'allocate-output-folder'));
 
+const SHA_REGEX = /^[0-9a-f]{40}$/i;
+
+/** Steps that come after `check` — used by the check-drift gate (GH-299). */
+const POST_CHECK_STEPS = new Set(['pr', 'ready', 'follow_up', 'ci', 'cleanup', 'reports']);
+
 /**
  * @param {string} ticket
  * @param {string} targetStep
@@ -167,15 +172,12 @@ function transitionStep(ticket, targetStep, deps) {
   // GH-299: Check-drift gate — detect HEAD drift on forward transitions from post-check steps.
   // If new commits landed since check passed, redirect back to check.
   let checkDriftDetected = false;
-  const POST_CHECK_STEPS = [
-    STEPS.pr,
-    STEPS.ready,
-    STEPS.follow_up,
-    STEPS.ci,
-    STEPS.cleanup,
-    STEPS.reports,
-  ];
-  if (isForward && POST_CHECK_STEPS.includes(currentStep) && ws?.checkPassedSha) {
+  if (
+    isForward &&
+    POST_CHECK_STEPS.has(currentStep) &&
+    ws?.checkPassedSha &&
+    SHA_REGEX.test(ws.checkPassedSha)
+  ) {
     const headSha = getHeadSha();
     if (headSha != null && headSha !== ws.checkPassedSha) {
       ws.checkInterruptedStep = currentStep;
@@ -184,7 +186,6 @@ function transitionStep(ticket, targetStep, deps) {
         step: currentStep,
         what: 'check re-triggered: new commits detected',
       });
-      saveWorkState(safeTicket, ws);
       // Redirect transition to check (backward)
       targetStep = STEPS.check;
       checkDriftDetected = true;

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -136,41 +136,10 @@ function transitionStep(ticket, targetStep, deps) {
     ws.checkInterruptedStep = null;
   }
 
-  // GH-260: Generic step-verify gate — run the step's verify() function before
-  // allowing forward transitions out of non-soft steps. This catches bypasses
-  // for follow_up, ci, and any other step with a verify() in workflow-definition.js.
-  // The TDD and check-to-PR gates above remain as explicit fast-path checks with
-  // better error messages; this gate acts as a universal catch-all.
-  if (isForward && !softSteps.has(currentStep) && !TDD_GATED_STEPS.includes(currentStep)) {
-    const entry = commandMap.find((c) => c.step === currentStep && typeof c.verify === 'function');
-    if (entry) {
-      let verified;
-      try {
-        verified = entry.verify(safeTicket);
-      } catch (err) {
-        const detail = err && typeof err.message === 'string' ? err.message : String(err);
-        return {
-          error: true,
-          message: `BLOCKED: ${currentStep} verify threw — cannot transition to ${targetStep}: ${detail}`,
-          gate: 'step-verify',
-          step: currentStep,
-          hint: `The ${currentStep} step verification encountered an error: ${detail}. Resolve the issue before transitioning.`,
-        };
-      }
-      if (!verified) {
-        return {
-          error: true,
-          message: `BLOCKED: ${currentStep} not verified — cannot transition to ${targetStep}`,
-          gate: 'step-verify',
-          step: currentStep,
-          hint: `The ${currentStep} step has not passed its verification check. Complete the step requirements before transitioning.`,
-        };
-      }
-    }
-  }
-
   // GH-299: Check-drift gate — detect HEAD drift on forward transitions from post-check steps.
   // If new commits landed since check passed, redirect back to check.
+  // Runs BEFORE step-verify so that drift detection fires even when the current step's
+  // verify() would fail (e.g., follow_up verify returns false but HEAD drifted).
   let checkDriftDetected = false;
   if (
     isForward &&
@@ -196,6 +165,45 @@ function transitionStep(ticket, targetStep, deps) {
         };
       }
       checkDriftDetected = true;
+    }
+  }
+
+  // GH-260: Generic step-verify gate — run the step's verify() function before
+  // allowing forward transitions out of non-soft steps. This catches bypasses
+  // for follow_up, ci, and any other step with a verify() in workflow-definition.js.
+  // The TDD and check-to-PR gates above remain as explicit fast-path checks with
+  // better error messages; this gate acts as a universal catch-all.
+  // Skipped when check-drift redirected targetStep (backward transition to check).
+  if (
+    isForward &&
+    !checkDriftDetected &&
+    !softSteps.has(currentStep) &&
+    !TDD_GATED_STEPS.includes(currentStep)
+  ) {
+    const entry = commandMap.find((c) => c.step === currentStep && typeof c.verify === 'function');
+    if (entry) {
+      let verified;
+      try {
+        verified = entry.verify(safeTicket);
+      } catch (err) {
+        const detail = err && typeof err.message === 'string' ? err.message : String(err);
+        return {
+          error: true,
+          message: `BLOCKED: ${currentStep} verify threw — cannot transition to ${targetStep}: ${detail}`,
+          gate: 'step-verify',
+          step: currentStep,
+          hint: `The ${currentStep} step verification encountered an error: ${detail}. Resolve the issue before transitioning.`,
+        };
+      }
+      if (!verified) {
+        return {
+          error: true,
+          message: `BLOCKED: ${currentStep} not verified — cannot transition to ${targetStep}`,
+          gate: 'step-verify',
+          step: currentStep,
+          hint: `The ${currentStep} step has not passed its verification check. Complete the step requirements before transitioning.`,
+        };
+      }
     }
   }
 

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -14,7 +14,7 @@
 const fs = require('fs');
 const path = require('path');
 const { taskSegment } = require(path.join(__dirname, '..', 'lib', 'allocate-output-folder'));
-const { SHA_REGEX } = require(path.join(__dirname, 'task-review-gate'));
+const { SHA_REGEX } = require(path.join(__dirname, 'git-utils'));
 
 /**
  * Derive the set of steps that come after `check` in the workflow.

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -14,8 +14,7 @@
 const fs = require('fs');
 const path = require('path');
 const { taskSegment } = require(path.join(__dirname, '..', 'lib', 'allocate-output-folder'));
-
-const SHA_REGEX = /^[0-9a-f]{40}$/i;
+const { SHA_REGEX } = require(path.join(__dirname, 'task-review-gate'));
 
 /**
  * Derive the set of steps that come after `check` in the workflow.

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -186,8 +186,15 @@ function transitionStep(ticket, targetStep, deps) {
         step: currentStep,
         what: 'check re-triggered: new commits detected',
       });
-      // Redirect transition to check (backward)
+      // Redirect transition to check (backward) and re-validate the redirected edge
       targetStep = STEPS.check;
+      if (!workflowCanTransition(currentStep, targetStep)) {
+        return {
+          error: true,
+          message: `BLOCKED: cannot transition from ${currentStep} to ${targetStep}`,
+          allowed: STEP_TRANSITIONS[currentStep] || [],
+        };
+      }
       checkDriftDetected = true;
     }
   }

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -17,8 +17,23 @@ const { taskSegment } = require(path.join(__dirname, '..', 'lib', 'allocate-outp
 
 const SHA_REGEX = /^[0-9a-f]{40}$/i;
 
-/** Steps that come after `check` — used by the check-drift gate (GH-299). */
-const POST_CHECK_STEPS = new Set(['pr', 'ready', 'follow_up', 'ci', 'cleanup', 'reports']);
+/**
+ * Derive the set of steps that come after `check` in the workflow.
+ * Computed from the step registry rather than hardcoded, so it stays
+ * in sync if steps are renamed or added (GH-299).
+ * @param {string[]} allSteps - ALL_STEPS from the step registry
+ * @param {object} STEPS - STEPS constants from the step registry
+ * @returns {Set<string>}
+ */
+let _postCheckSteps = null;
+function getPostCheckSteps(allSteps, STEPS) {
+  if (!_postCheckSteps) {
+    const checkIdx = allSteps.indexOf(STEPS.check);
+    // Steps after check, excluding 'complete' (terminal step)
+    _postCheckSteps = new Set(allSteps.slice(checkIdx + 1).filter((s) => s !== STEPS.complete));
+  }
+  return _postCheckSteps;
+}
 
 /**
  * @param {string} ticket
@@ -132,7 +147,7 @@ function transitionStep(ticket, targetStep, deps) {
 
   // GH-299: Record checkPassedSha on successful check → pr forward transition
   if (isCheckToPr && isForward) {
-    ws.checkPassedSha = getHeadSha();
+    ws.checkPassedSha = getHeadSha(process.cwd());
     ws.checkInterruptedStep = null;
   }
 
@@ -143,11 +158,11 @@ function transitionStep(ticket, targetStep, deps) {
   let checkDriftDetected = false;
   if (
     isForward &&
-    POST_CHECK_STEPS.has(currentStep) &&
+    getPostCheckSteps(ALL_STEPS, STEPS).has(currentStep) &&
     ws?.checkPassedSha &&
     SHA_REGEX.test(ws.checkPassedSha)
   ) {
-    const headSha = getHeadSha();
+    const headSha = getHeadSha(process.cwd());
     if (headSha != null && headSha !== ws.checkPassedSha) {
       // Validate redirected edge before mutating state
       if (!workflowCanTransition(currentStep, STEPS.check)) {

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -149,21 +149,22 @@ function transitionStep(ticket, targetStep, deps) {
   ) {
     const headSha = getHeadSha();
     if (headSha != null && headSha !== ws.checkPassedSha) {
+      // Validate redirected edge before mutating state
+      if (!workflowCanTransition(currentStep, STEPS.check)) {
+        return {
+          error: true,
+          message: `BLOCKED: cannot transition from ${currentStep} to ${STEPS.check}`,
+          allowed: STEP_TRANSITIONS[currentStep] || [],
+        };
+      }
+      // Edge validated — now mutate state and redirect
       ws.checkInterruptedStep = currentStep;
       ws.checkPassedSha = null;
       appendAction(safeTicket, {
         step: currentStep,
         what: 'check re-triggered: new commits detected',
       });
-      // Redirect transition to check (backward) and re-validate the redirected edge
       targetStep = STEPS.check;
-      if (!workflowCanTransition(currentStep, targetStep)) {
-        return {
-          error: true,
-          message: `BLOCKED: cannot transition from ${currentStep} to ${targetStep}`,
-          allowed: STEP_TRANSITIONS[currentStep] || [],
-        };
-      }
       checkDriftDetected = true;
     }
   }

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -40,6 +40,8 @@ function transitionStep(ticket, targetStep, deps) {
     // GH-260: generic step-verify gate deps
     softSteps,
     commandMap,
+    // GH-299: check-drift gate dep
+    getHeadSha,
   } = deps;
 
   if (!ALL_STEPS.includes(targetStep)) {
@@ -123,6 +125,12 @@ function transitionStep(ticket, targetStep, deps) {
     }
   }
 
+  // GH-299: Record checkPassedSha on successful check → pr forward transition
+  if (isCheckToPr && isForward) {
+    ws.checkPassedSha = getHeadSha();
+    ws.checkInterruptedStep = null;
+  }
+
   // GH-260: Generic step-verify gate — run the step's verify() function before
   // allowing forward transitions out of non-soft steps. This catches bypasses
   // for follow_up, ci, and any other step with a verify() in workflow-definition.js.
@@ -153,6 +161,33 @@ function transitionStep(ticket, targetStep, deps) {
           hint: `The ${currentStep} step has not passed its verification check. Complete the step requirements before transitioning.`,
         };
       }
+    }
+  }
+
+  // GH-299: Check-drift gate — detect HEAD drift on forward transitions from post-check steps.
+  // If new commits landed since check passed, redirect back to check.
+  let checkDriftDetected = false;
+  const POST_CHECK_STEPS = [
+    STEPS.pr,
+    STEPS.ready,
+    STEPS.follow_up,
+    STEPS.ci,
+    STEPS.cleanup,
+    STEPS.reports,
+  ];
+  if (isForward && POST_CHECK_STEPS.includes(currentStep) && ws?.checkPassedSha) {
+    const headSha = getHeadSha();
+    if (headSha != null && headSha !== ws.checkPassedSha) {
+      ws.checkInterruptedStep = currentStep;
+      ws.checkPassedSha = null;
+      appendAction(safeTicket, {
+        step: currentStep,
+        what: 'check re-triggered: new commits detected',
+      });
+      saveWorkState(safeTicket, ws);
+      // Redirect transition to check (backward)
+      targetStep = STEPS.check;
+      checkDriftDetected = true;
     }
   }
 
@@ -240,13 +275,21 @@ function transitionStep(ticket, targetStep, deps) {
   ws.lastTransitionTimestamp = new Date().toISOString();
   saveWorkState(safeTicket, ws);
 
-  return {
+  const result = {
     success: true,
     from: currentStep,
     to: targetStep,
     direction: targetIdx > currentIdx ? 'forward' : 'backward',
     message: `${currentStep} → ${targetStep}`,
   };
+
+  // GH-299: Annotate result when check-drift redirected the transition
+  if (checkDriftDetected) {
+    result.gate = 'check-drift';
+    result.message = `New commits detected since check passed. Re-running check.`;
+  }
+
+  return result;
 }
 
 function getAvailableTransitions(ticket, deps) {

--- a/workflows/work/transition-step.js
+++ b/workflows/work/transition-step.js
@@ -145,9 +145,12 @@ function transitionStep(ticket, targetStep, deps) {
     }
   }
 
-  // GH-299: Record checkPassedSha on successful check → pr forward transition
+  // GH-299: Record checkPassedSha on successful check → pr forward transition.
+  // Only update if getHeadSha returns a valid SHA; otherwise preserve any existing value
+  // to avoid disabling drift detection when git is temporarily unavailable.
   if (isCheckToPr && isForward) {
-    ws.checkPassedSha = getHeadSha(process.cwd());
+    const sha = getHeadSha(process.cwd());
+    if (sha) ws.checkPassedSha = sha;
     ws.checkInterruptedStep = null;
   }
 

--- a/workflows/work/work.workflow.js
+++ b/workflows/work/work.workflow.js
@@ -74,6 +74,7 @@ const { run, fileExists, readFile, listFiles, ...helpers } = require(
 const { parseTicketInput } = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
 const { parseTasks, buildTaskPrompt } = require(path.join(__dirname, 'task-parser'));
 const { archiveStepArtifacts } = require(path.join(__dirname, 'artifact-archival'));
+const { getHeadSha } = require(path.join(__dirname, 'git-utils'));
 const { TDD_PROTOCOL, readTddEvidence: _readTddEvidence, validateTddEvidence } = require(
   path.join(__dirname, 'tdd-enforcement')
 );
@@ -183,6 +184,8 @@ function buildTransitionDeps() {
     // Tests must provide the necessary filesystem/git state for verify to pass.
     softSteps: workflow.softSteps,
     commandMap: workflow.commandMap,
+    // GH-299: check-drift gate dep
+    getHeadSha,
   };
 }
 function transitionStep(ticket, targetStep) {


### PR DESCRIPTION
## Existing Behavior

- The `/check` step is a one-time gate: once a ticket passes check and advances to `pr`, `ready`, `follow_up`, `ci`, `cleanup`, or `reports`, no mechanism exists to detect that new commits have landed since check passed.
- Forward transitions from any post-check step proceed unconditionally regardless of whether HEAD has moved since the check gate was cleared.
- `git-utils.js` exports only `resolveGitHead` (reads `.git` refs via the filesystem), with no function to resolve the current HEAD SHA via the git CLI.
- `RETRY_EDGES` in `step-registry.js` does not include retry paths from post-check steps back to `check`.

## Intended New Behavior

- A **check-drift gate** is evaluated on every forward transition out of any post-check step (`pr`, `ready`, `follow_up`, `ci`, `cleanup`, `reports`). When the current HEAD SHA differs from the SHA recorded when check last passed, the transition is transparently redirected to `check` instead of the intended target step.
- `git-utils.js` now exports `getHeadSha()` which calls `git rev-parse HEAD` via `execFileSync`; it fails-open (returns `null`) on any error so the gate never blocks a transition it cannot verify.
- `transition-step.js` records `checkPassedSha` in the work state on a successful `check → pr` forward transition and clears it on drift detection, also storing `checkInterruptedStep` so the workflow knows which step was interrupted.
- `step-registry.js` adds explicit `check` retry edges for all post-check steps so `workflowCanTransition()` accepts the redirected transition.
- `buildTransitionDeps()` in `work.workflow.js` now wires `getHeadSha` into the deps object passed to `transitionStep`.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Simulating drift detection (backend logic):**

1. Start a ticket that has reached a post-check step (e.g. `pr`) with `checkPassedSha` set in its `.work-state.json`.
2. Make a new commit in the repo (so HEAD moves).
3. Attempt a forward transition (e.g. `pr` → `ready`) via the `/work` orchestrator.
4. Expected: the transition is redirected to `check`, `result.gate === 'check-drift'`, and `result.message` contains `"New commits detected since check passed. Re-running check."`.
5. Verify `.work-state.json` has `checkPassedSha: null` and `checkInterruptedStep: "pr"`.

**Verifying fail-open behavior:**

1. Set `checkPassedSha` in the work state but run from a directory where `git rev-parse HEAD` fails (e.g. a non-git directory or by stubbing `getHeadSha` to return `null`).
2. Attempt a forward transition — expected: transition proceeds normally (no redirect).

**Verifying SHA is recorded on check → pr:**

1. Run the `/check` step to completion so it transitions forward to `pr`.
2. Inspect `.work-state.json` — expected: `checkPassedSha` is set to a 40-char hex string matching the HEAD SHA at the time of transition.

### Test Results
New and updated test files covering the check-drift gate:
- `workflows/work/__tests__/transition-step.test.js` — 9 new GH-299 scenarios (SHA match, SHA diff/redirect, backward skip, missing SHA, null SHA, record on check→pr, clear `checkInterruptedStep`, set `checkInterruptedStep` on drift, appendAction call)
- `workflows/work/__tests__/resolve-git-head.test.js` — 2 new tests for `getHeadSha()` (real repo, non-git dir)
- `workflows/work/__tests__/step-registry.test.js` — 6 new tests confirming all post-check steps have a retry edge to `check`
- `workflows/work/__tests__/work-workflow-deps-wiring.test.js` — new file; 2 tests verifying `getHeadSha` is imported and wired into `buildTransitionDeps()`