### PR TITLE
feat(split-in-tasks): enforce bookend tasks — first test, last verification checkpoint

### DIFF
--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -299,7 +299,7 @@ This task is checkpoint type (auto-TDD-exception) and should be the second-to-la
 **Rule 12 — Bookend Tasks (First/Last Enforcement):**
 The first task in `tasks.md` must be of type `test` and must implement the Gherkin/Given-When-Then scenarios from `spec.md` as automated tests. This ensures tests exist before any implementation begins. If `spec.md` contains no Gherkin scenarios, the first task should still be type `test` but focused on scaffolding the test harness based on acceptance criteria from the brief or spec.
 
-The last task must be a verification checkpoint of type `checkpoint` titled "Checkpoint: Verify all tests pass" that runs all tests created during the ticket's tasks and confirms they pass. This task must depend on all preceding tasks.
+The last task must be of type `checkpoint` and serves as the final verification step, titled "Checkpoint: Verify all tests pass", that runs all tests created during the ticket's tasks and confirms they pass. This task must depend on all preceding tasks.
 
 All intermediate tasks (implementation, infrastructure, refactoring, other checkpoints) must be ordered between the first test task and the last verification checkpoint task.
 

--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -299,7 +299,7 @@ This task is checkpoint type (auto-TDD-exception) and should be the second-to-la
 **Rule 12 — Bookend Tasks (First/Last Enforcement):**
 The first task in `tasks.md` must be of type `test` and must implement the Gherkin/Given-When-Then scenarios from `spec.md` as automated tests. This ensures tests exist before any implementation begins. If `spec.md` contains no Gherkin scenarios, the first task should still be type `test` but focused on scaffolding the test harness based on acceptance criteria from the brief or spec.
 
-The last task must be of type `checkpoint` titled "Checkpoint: Verify all tests pass" that runs all tests created during the ticket's tasks and confirms they pass. This task must depend on all preceding tasks.
+The last task must be a verification checkpoint of type `checkpoint` titled "Checkpoint: Verify all tests pass" that runs all tests created during the ticket's tasks and confirms they pass. This task must depend on all preceding tasks.
 
 All intermediate tasks (implementation, infrastructure, refactoring, other checkpoints) must be ordered between the first test task and the last verification checkpoint task.
 

--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -153,6 +153,7 @@ Review all generated tasks and check:
 - Parallelization is maximized safely (any task marked `No` that could be `Yes`?)
 - Checkpoint tasks are present after every 3 implementation tasks or subsystem boundary
 - TDD ordering is correct (RED before GREEN before REFACTOR in every non-exempt implementation task — see Rule 10 for exemptions)
+- Bookend enforcement: first task is a Gherkin-to-test task (type `test`) and last task is a verification checkpoint (type `checkpoint`) per Rule 12
 - Anti-patterns are absent
 
 Refactor tasks if any issues are found. Re-validate coverage after any refactoring.
@@ -293,4 +294,17 @@ If the spec references user-facing behavior changes, API changes, configuration 
 - Affected `.md` files are updated (README, architecture docs, API docs)
 - New features are documented if user-facing
 - Configuration changes are documented
-This task is checkpoint type (auto-TDD-exception) and should be the last task.
+This task is checkpoint type (auto-TDD-exception) and should be the second-to-last task (before the final verification checkpoint).
+
+**Rule 12 — Bookend Tasks (First/Last Enforcement):**
+The first task in `tasks.md` must be of type `test` and must implement the Gherkin/Given-When-Then scenarios from `spec.md` as automated tests. This ensures tests exist before any implementation begins. If `spec.md` contains no Gherkin scenarios, the first task should still be type `test` but focused on scaffolding the test harness based on acceptance criteria from the brief or spec.
+
+The last task must be of type `checkpoint` titled "Checkpoint: Verify all tests pass" that runs all tests created during the ticket's tasks and confirms they pass. This task must depend on all preceding tasks.
+
+All intermediate tasks (implementation, infrastructure, refactoring, other checkpoints) must be ordered between the first test task and the last verification checkpoint task.
+
+**Anti-patterns for bookend enforcement:**
+- Do not place implementation tasks before the first test task
+- Do not place any task after the final verification checkpoint
+- Do not omit the first test task even if the spec has no Gherkin scenarios
+- Do not omit the final verification checkpoint task

--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -153,7 +153,7 @@ Review all generated tasks and check:
 - Parallelization is maximized safely (any task marked `No` that could be `Yes`?)
 - Checkpoint tasks are present after every 3 implementation tasks or subsystem boundary
 - TDD ordering is correct (RED before GREEN before REFACTOR in every non-exempt implementation task — see Rule 10 for exemptions)
-- Bookend enforcement: first task is a Gherkin-to-test task (type `test`) and last task is a verification checkpoint (type `checkpoint`) per Rule 12
+- Bookend enforcement: first task is type `test` (Gherkin-based or acceptance-criteria-based per Rule 12) and last task is a verification checkpoint (type `checkpoint`) per Rule 12
 - Anti-patterns are absent
 
 Refactor tasks if any issues are found. Re-validate coverage after any refactoring.

--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -290,7 +290,7 @@ _TDD Protocol: Every non-exempt implementation task follows RED -> GREEN -> REFA
 - The file ends with the Requirement Coverage table
 
 **Rule 11 — Documentation Task:**
-If the spec references user-facing behavior changes, API changes, configuration changes, or existing `.md` documentation files are related to the changes, add a final task of type `checkpoint` titled "Documentation Review" that verifies:
+If the spec references user-facing behavior changes, API changes, configuration changes, or existing `.md` documentation files are related to the changes, add a task of type `checkpoint` titled "Documentation Review" that verifies:
 - Affected `.md` files are updated (README, architecture docs, API docs)
 - New features are documented if user-facing
 - Configuration changes are documented

--- a/skills/split-in-tasks/__tests__/split-in-tasks-bookend-tasks.test.js
+++ b/skills/split-in-tasks/__tests__/split-in-tasks-bookend-tasks.test.js
@@ -13,8 +13,11 @@ describe('split-in-tasks SKILL.md — bookend task enforcement (Rule 12)', () =>
     assert.ok(rule11Idx > -1, 'SKILL.md must contain Rule 11');
     assert.ok(rule12Idx > -1, 'SKILL.md must contain Rule 12');
     assert.ok(rule11Idx < rule12Idx, 'Rule 12 must appear after Rule 11');
-    assert.match(content.slice(rule12Idx), /first task/i, 'Rule 12 must reference "first task"');
-    assert.match(content.slice(rule12Idx), /last task/i, 'Rule 12 must reference "last task"');
+    const rule12Section = content.match(/\*\*Rule 12[\s\S]*?(?=\*\*(?:Rule|Anti-patterns))/);
+    assert.ok(rule12Section, 'Rule 12 section must exist');
+    const section = rule12Section[0];
+    assert.match(section, /first task/i, 'Rule 12 must reference "first task"');
+    assert.match(section, /last task/i, 'Rule 12 must reference "last task"');
   });
 
   it('Rule 12 requires first task to be type test with Gherkin reference', () => {
@@ -23,7 +26,7 @@ describe('split-in-tasks SKILL.md — bookend task enforcement (Rule 12)', () =>
     const section = rule12Section[0];
     assert.match(
       section,
-      /first task[\s\S]*?type.*test|type.*test[\s\S]*?first task/i,
+      /first task[\s\S]*?\btype\s+`test`|type\s+`test`[\s\S]*?first task/i,
       'Rule 12 must specify the first task is type "test"'
     );
     assert.match(
@@ -39,7 +42,7 @@ describe('split-in-tasks SKILL.md — bookend task enforcement (Rule 12)', () =>
     const section = rule12Section[0];
     assert.match(
       section,
-      /last task[\s\S]*?checkpoint|checkpoint[\s\S]*?last task/i,
+      /last task[\s\S]*?type[\s\S]*?[`"]?checkpoint[`"]?|type[\s\S]*?[`"]?checkpoint[`"]?[\s\S]*?last task/i,
       'Rule 12 must specify the last task is type "checkpoint"'
     );
     assert.match(
@@ -81,9 +84,10 @@ describe('split-in-tasks SKILL.md — bookend task enforcement (Rule 12)', () =>
     );
     assert.match(
       section,
-      /Rule 12|bookend/i,
-      'Step 5 bookend check must reference Rule 12 or the bookend requirement'
+      /first task[\s\S]*?last task|last task[\s\S]*?first task/i,
+      'Step 5 must explicitly include checks for both first-task and last-task constraints'
     );
+    assert.match(section, /Rule 12/i, 'Step 5 first/last task check must reference Rule 12');
   });
 
   it('Rule 11 specifies second-to-last instead of last', () => {

--- a/skills/split-in-tasks/__tests__/split-in-tasks-bookend-tasks.test.js
+++ b/skills/split-in-tasks/__tests__/split-in-tasks-bookend-tasks.test.js
@@ -1,0 +1,111 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SKILL_PATH = path.resolve(__dirname, '..', 'SKILL.md');
+const content = fs.readFileSync(SKILL_PATH, 'utf-8');
+
+describe('split-in-tasks SKILL.md — bookend task enforcement (Rule 12)', () => {
+  it('Rule 12 exists and appears after Rule 11', () => {
+    const rule11Idx = content.indexOf('**Rule 11');
+    const rule12Idx = content.indexOf('**Rule 12');
+    assert.ok(rule11Idx > -1, 'SKILL.md must contain Rule 11');
+    assert.ok(rule12Idx > -1, 'SKILL.md must contain Rule 12');
+    assert.ok(rule11Idx < rule12Idx, 'Rule 12 must appear after Rule 11');
+    assert.match(content.slice(rule12Idx), /first task/i, 'Rule 12 must reference "first task"');
+    assert.match(content.slice(rule12Idx), /last task/i, 'Rule 12 must reference "last task"');
+  });
+
+  it('Rule 12 requires first task to be type test with Gherkin reference', () => {
+    const rule12Section = content.match(/\*\*Rule 12[\s\S]*?(?=\*\*(?:Rule|Anti-patterns))/);
+    assert.ok(rule12Section, 'Rule 12 section must exist');
+    const section = rule12Section[0];
+    assert.match(
+      section,
+      /first task[\s\S]*?type.*test|type.*test[\s\S]*?first task/i,
+      'Rule 12 must specify the first task is type "test"'
+    );
+    assert.match(
+      section,
+      /[Gg]herkin|[Gg]iven.*[Ww]hen.*[Tt]hen/,
+      'Rule 12 must reference Gherkin or Given-When-Then scenarios from spec.md'
+    );
+  });
+
+  it('Rule 12 requires last task to be verification checkpoint', () => {
+    const rule12Section = content.match(/\*\*Rule 12[\s\S]*?(?=\*\*(?:Rule|Anti-patterns))/);
+    assert.ok(rule12Section, 'Rule 12 section must exist');
+    const section = rule12Section[0];
+    assert.match(
+      section,
+      /last task[\s\S]*?checkpoint|checkpoint[\s\S]*?last task/i,
+      'Rule 12 must specify the last task is type "checkpoint"'
+    );
+    assert.match(
+      section,
+      /run all tests|run.*tests|verify.*tests/i,
+      'Rule 12 must specify the last task runs all tests'
+    );
+    assert.match(
+      section,
+      /depends on all|depend.*all.*preceding|depend.*prior/i,
+      'Rule 12 must specify the last task depends on all preceding tasks'
+    );
+  });
+
+  it('Rule 12 addresses edge case when spec has no Gherkin scenarios', () => {
+    const rule12Section = content.match(/\*\*Rule 12[\s\S]*?(?=\*\*(?:Rule|Anti-patterns))/);
+    assert.ok(rule12Section, 'Rule 12 section must exist');
+    const section = rule12Section[0];
+    assert.match(
+      section,
+      /no [Gg]herkin|without [Gg]herkin|[Gg]herkin.*not.*present|no.*scenarios/i,
+      'Rule 12 must include fallback guidance for specs without Gherkin scenarios'
+    );
+    assert.match(
+      section,
+      /test scaffolding|acceptance criteria|test harness/i,
+      'Fallback must mention test scaffolding or acceptance criteria'
+    );
+  });
+
+  it('Step 5 quality review includes first/last task bookend check', () => {
+    const step5Match = content.match(/### Step 5[\s\S]*?(?=### Step 6|$)/);
+    assert.ok(step5Match, 'Step 5 section must exist');
+    const section = step5Match[0];
+    assert.match(
+      section,
+      /first.task[\s\S]*?last.task|last.task[\s\S]*?first.task|bookend/i,
+      'Step 5 must include a check for first-task and last-task constraints'
+    );
+    assert.match(
+      section,
+      /Rule 12|bookend/i,
+      'Step 5 bookend check must reference Rule 12 or the bookend requirement'
+    );
+  });
+
+  it('Rule 11 specifies second-to-last instead of last', () => {
+    const rule11Section = content.match(/\*\*Rule 11[\s\S]*?(?=\*\*(?:Rule 12|Anti-patterns))/);
+    assert.ok(rule11Section, 'Rule 11 section must exist');
+    const section = rule11Section[0];
+    assert.match(section, /second-to-last/i, 'Rule 11 must say "second-to-last"');
+    assert.doesNotMatch(
+      section,
+      /should be the last task/i,
+      'Rule 11 must NOT say "should be the last task"'
+    );
+  });
+
+  it('Rule 12 specifies intermediate tasks ordered between bookend tasks', () => {
+    const rule12Section = content.match(/\*\*Rule 12[\s\S]*?(?=\*\*(?:Rule|Anti-patterns))/);
+    assert.ok(rule12Section, 'Rule 12 section must exist');
+    const section = rule12Section[0];
+    assert.match(
+      section,
+      /intermediate|implementation.*between|between.*first.*last|ordered between/i,
+      'Rule 12 must mention intermediate/implementation tasks between first and last'
+    );
+  });
+});


### PR DESCRIPTION
## Existing Behavior

- Rule 11 designated the documentation update task as "the last task" in any generated `tasks.md`.
- The `split-in-tasks` skill had no requirement for a first task that converts Gherkin/Given-When-Then scenarios from `spec.md` into automated tests.
- The Step 5 quality review checklist did not verify first/last task placement.
- No safeguard prevented implementation tasks from being placed before any test scaffolding task.

## Intended New Behavior

- Rule 12 (Bookend Tasks) is introduced: the first task in `tasks.md` must be of type `test` and must implement the Gherkin/Given-When-Then scenarios from `spec.md` as automated tests; if no Gherkin scenarios exist, it scaffolds the test harness from acceptance criteria.
- The last task must be a `checkpoint` titled "Checkpoint: Verify all tests pass" that depends on all preceding tasks, enforcing a TDD sandwich (tests first, implementation in the middle, verification last).
- Rule 11 is amended from "last task" to "second-to-last task" to correctly position the documentation update before the final verification checkpoint.
- Step 5 quality review now includes an explicit bookend check referencing Rule 12.
- 7 new unit tests in `split-in-tasks-bookend-tasks.test.js` verify all Rule 12 constraints and the Rule 11 amendment.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

These are documentation/skill changes validated by test assertions against the SKILL.md file itself. To verify:

1. Run the bookend task tests directly:
   ```bash
   node --test skills/split-in-tasks/__tests__/split-in-tasks-bookend-tasks.test.js
   ```
   Expected: all 7 tests pass.

2. Review `skills/split-in-tasks/SKILL.md` and confirm:
   - Rule 12 appears after Rule 11 and defines first task as type `test` with Gherkin reference
   - Rule 12 defines last task as type `checkpoint` depending on all preceding tasks
   - Rule 11 now reads "second-to-last task" (not "last task")
   - Step 5 checklist includes a line referencing bookend enforcement and Rule 12

3. To manually exercise the skill, run `/split-in-tasks` on any ticket with a spec containing Gherkin scenarios and confirm `tasks.md` begins with a `test` task and ends with a verification `checkpoint` task.

## Test Results

| Test File | Status | Count |
|-----------|--------|-------|
| `split-in-tasks-bookend-tasks.test.js` | PASS | 7/7 |
| `split-in-tasks-tdd-ordering.test.js` | PASS | 7/7 |
| **Total** | **PASS** | **14/14** |

<details>
<summary>Full test output</summary>

```
▶ split-in-tasks SKILL.md — bookend task enforcement (Rule 12)
  ✔ Rule 12 exists and appears after Rule 11 (1.054308ms)
  ✔ Rule 12 requires first task to be type test with Gherkin reference (0.690024ms)
  ✔ Rule 12 requires last task to be verification checkpoint (0.369264ms)
  ✔ Rule 12 addresses edge case when spec has no Gherkin scenarios (0.47576ms)
  ✔ Step 5 quality review includes first/last task bookend check (0.494322ms)
  ✔ Rule 11 specifies second-to-last instead of last (1.273238ms)
  ✔ Rule 12 specifies intermediate tasks ordered between bookend tasks (0.334217ms)
✔ split-in-tasks SKILL.md — bookend task enforcement (Rule 12) (5.977789ms)
ℹ tests 7 | pass 7 | fail 0 | duration_ms 67.137088

▶ split-in-tasks SKILL.md — TDD ordering enforcement
  ✔ contains Rule 10 with TDD ordering requirement after Rule 9 (0.896061ms)
  ✔ contains phase-labeled deliverables template with RED, GREEN, REFACTOR prefixes (0.336279ms)
  ✔ contains TDD protocol metadata line in file header template (0.203ms)
  ✔ contains TDD ordering check in Step 5 quality review (0.223561ms)
  ✔ contains format rules documenting phase prefix convention (0.203122ms)
  ✔ contains exception for checkpoint/config-only tasks (0.924284ms)
  ✔ contains multi-behavior triplet guidance (0.722403ms)
✔ split-in-tasks SKILL.md — TDD ordering enforcement (5.067338ms)
ℹ tests 7 | pass 7 | fail 0 | duration_ms 67.681830
```

</details>

Closes #298