### PR TITLE
fix(work-implement): prevent agent halt on IMPLEMENT_COMPLETE signal in orchestrator mode

### DIFF
--- a/skills/work-implement/SKILL.md
+++ b/skills/work-implement/SKILL.md
@@ -272,7 +272,7 @@ Fix any issues before completing.
 
 Still update `$HOME/worktrees/tasks/${TICKET_ID}/implement.md` with results (same as normal mode).
 
-After updating implement.md, finish and return control to the orchestrator immediately. Do NOT output any structured completion block, do NOT display "Next steps", and do NOT prompt the user. The orchestrator handles all subsequent steps automatically.
+After updating implement.md, finish and return control to the orchestrator immediately. Do NOT output any structured completion block, do NOT display "Next steps", and Do NOT prompt the user. The orchestrator handles all subsequent steps automatically.
 
 **When in normal mode (standalone invocation, no `--subtask`, not called from `/work`):**
 

--- a/skills/work-implement/SKILL.md
+++ b/skills/work-implement/SKILL.md
@@ -262,12 +262,6 @@ Fix any issues before completing.
    (where `<N>` is the subtask index from the init-subtask output)
 3. Report completion briefly and return control to the parent workflow
 
-<!-- GH-231: The orchestrator-mode section is deliberately terse. The /work orchestrator
-     handles all subsequent steps (commit, check, PR) automatically after Skill() returns.
-     Outputting a structured block here caused agents to halt and display it to the user
-     instead of returning control. Keep this section free of fenced code blocks or signal
-     formats that could be mistaken for a stopping point. -->
-
 **When called from `/work` orchestrator (orchestrator plan exists with subsequent steps):**
 
 Still update `$HOME/worktrees/tasks/${TICKET_ID}/implement.md` with results (same as normal mode).

--- a/skills/work-implement/SKILL.md
+++ b/skills/work-implement/SKILL.md
@@ -272,7 +272,7 @@ Fix any issues before completing.
 
 Still update `$HOME/worktrees/tasks/${TICKET_ID}/implement.md` with results (same as normal mode).
 
-After updating implement.md, finish and return control to the orchestrator immediately. Do NOT output any structured completion block, do NOT display "Next steps", and Do NOT prompt the user. The orchestrator handles all subsequent steps automatically.
+After updating implement.md, finish and return control to the orchestrator immediately. Do NOT output any structured completion block, Do NOT display "Next steps", and Do NOT prompt the user. The orchestrator handles all subsequent steps automatically.
 
 **When in normal mode (standalone invocation, no `--subtask`, not called from `/work`):**
 

--- a/skills/work-implement/SKILL.md
+++ b/skills/work-implement/SKILL.md
@@ -262,20 +262,17 @@ Fix any issues before completing.
    (where `<N>` is the subtask index from the init-subtask output)
 3. Report completion briefly and return control to the parent workflow
 
+<!-- GH-231: The orchestrator-mode section is deliberately terse. The /work orchestrator
+     handles all subsequent steps (commit, check, PR) automatically after Skill() returns.
+     Outputting a structured block here caused agents to halt and display it to the user
+     instead of returning control. Keep this section free of fenced code blocks or signal
+     formats that could be mistaken for a stopping point. -->
+
 **When called from `/work` orchestrator (orchestrator plan exists with subsequent steps):**
 
 Still update `$HOME/worktrees/tasks/${TICKET_ID}/implement.md` with results (same as normal mode).
 
-Then return a brief completion signal and hand control back to the orchestrator. Do NOT prompt the user for next steps or display a "Next steps" list.
-
-```
-IMPLEMENT_COMPLETE
-
-Agent used: <agent-name>
-Changes: <brief summary>
-Files modified: <count> files
-Quality: <quality checks run and results>
-```
+After updating implement.md, finish and return control to the orchestrator immediately. Do NOT output any structured completion block, do NOT display "Next steps", and do NOT prompt the user. The orchestrator handles all subsequent steps automatically.
 
 **When in normal mode (standalone invocation, no `--subtask`, not called from `/work`):**
 
@@ -339,4 +336,4 @@ Next steps:
 - For complex multi-step features, consider using `/work` instead
 - **Agent delegation is MANDATORY** - direct Write/Edit is blocked
 - **Subtask mode** (`--subtask <TICKET_ID>`): Skips branch/worktree creation, uses subtask state tracking, commits on completion, and returns control to parent workflow
-- **Orchestrator mode**: When invoked by `/work`, returns a brief completion signal instead of prompting the user — the orchestrator handles subsequent steps (commit, check, PR)
+- **Orchestrator mode**: When invoked by `/work`, returns control to the orchestrator without prompting — the orchestrator handles subsequent steps (commit, check, PR) automatically

--- a/skills/work-implement/__tests__/skill-md-content.test.js
+++ b/skills/work-implement/__tests__/skill-md-content.test.js
@@ -171,8 +171,7 @@ describe('work-implement SKILL.md — orchestrator completion (GH-231)', () => {
     });
   });
 
-  // Scenario 5 is an @e2e scenario (runtime orchestrator behavior) — not testable as a file-content check
-  describe('Scenario 6: Notes section orchestrator-mode bullet', () => {
+  describe('Scenario 5: Notes section orchestrator-mode bullet', () => {
     it('the Notes section has an orchestrator-mode bullet', () => {
       const section = getNotesSection();
       assert.ok(section, 'Notes section must exist');

--- a/skills/work-implement/__tests__/skill-md-content.test.js
+++ b/skills/work-implement/__tests__/skill-md-content.test.js
@@ -175,6 +175,7 @@ describe('work-implement SKILL.md — orchestrator completion (GH-231)', () => {
     });
   });
 
+  // Scenario 5 is an @e2e scenario (runtime orchestrator behavior) — not testable as a file-content check
   describe('Scenario 6: Notes section orchestrator-mode bullet', () => {
     it('the Notes section has an orchestrator-mode bullet', () => {
       const section = getNotesSection();

--- a/skills/work-implement/__tests__/skill-md-content.test.js
+++ b/skills/work-implement/__tests__/skill-md-content.test.js
@@ -1,0 +1,224 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SKILL_PATH = path.resolve(__dirname, '..', 'SKILL.md');
+const content = fs.readFileSync(SKILL_PATH, 'utf-8');
+
+/**
+ * Extract the orchestrator-mode section from Step 5.
+ * Starts at "When called from `/work` orchestrator" and ends at the next
+ * bold-prefixed mode header ("**When in ").
+ */
+function getOrchestratorSection() {
+  const start = content.search(
+    /\*\*When called from [`/]*(?:\/)?work[`]* orchestrator/
+  );
+  if (start === -1) return null;
+  const rest = content.slice(start);
+  const nextHeader = rest.slice(1).search(/\n\*\*When in /);
+  if (nextHeader === -1) return rest;
+  return rest.slice(0, nextHeader + 1);
+}
+
+/**
+ * Extract the normal-mode section from Step 5.
+ */
+function getNormalModeSection() {
+  const start = content.search(/\*\*When in normal mode/);
+  if (start === -1) return null;
+  const rest = content.slice(start);
+  const nextHeader = rest.slice(1).search(/\n##[^#]/);
+  if (nextHeader === -1) return rest;
+  return rest.slice(0, nextHeader + 1);
+}
+
+/**
+ * Extract the subtask-mode section from Step 5.
+ */
+function getSubtaskModeSection() {
+  const start = content.search(/\*\*When in subtask mode/);
+  if (start === -1) return null;
+  const rest = content.slice(start);
+  const nextHeader = rest.slice(1).search(/\n\*\*When /);
+  if (nextHeader === -1) return rest;
+  return rest.slice(0, nextHeader + 1);
+}
+
+/**
+ * Extract the Notes section (from ## Notes to end of file).
+ */
+function getNotesSection() {
+  const idx = content.search(/^## Notes/m);
+  if (idx === -1) return null;
+  return content.slice(idx);
+}
+
+describe('work-implement SKILL.md — orchestrator completion (GH-231)', () => {
+  describe('Scenario 1: orchestrator section contains no structured signal block', () => {
+    it('the orchestrator-mode section exists', () => {
+      const section = getOrchestratorSection();
+      assert.ok(
+        section,
+        'SKILL.md must contain a "When called from /work orchestrator" section'
+      );
+    });
+
+    it('the orchestrator section does NOT contain "IMPLEMENT_COMPLETE" text', () => {
+      const section = getOrchestratorSection();
+      assert.ok(section, 'orchestrator section must exist');
+      assert.doesNotMatch(
+        section,
+        /IMPLEMENT_COMPLETE/,
+        'Orchestrator section must NOT contain "IMPLEMENT_COMPLETE" — use prose instructions instead'
+      );
+    });
+
+    it('the orchestrator section contains prose instructing the agent to finish and return control', () => {
+      const section = getOrchestratorSection();
+      assert.ok(section, 'orchestrator section must exist');
+      assert.match(
+        section,
+        /return.*control|hand.*control.*back|return.*orchestrator/i,
+        'Orchestrator section must contain prose about returning control to the orchestrator'
+      );
+    });
+
+    it('the orchestrator section does NOT contain a fenced code block with a signal format', () => {
+      const section = getOrchestratorSection();
+      assert.ok(section, 'orchestrator section must exist');
+      const fencedBlocks = section.match(/```[\s\S]*?```/g) || [];
+      for (const block of fencedBlocks) {
+        assert.doesNotMatch(
+          block,
+          /IMPLEMENT_COMPLETE|Agent used:|Changes:|Files modified:|Quality:/,
+          'Orchestrator section must NOT contain a fenced code block with structured signal fields'
+        );
+      }
+    });
+  });
+
+  describe('Scenario 2: standalone mode completion instructions are preserved', () => {
+    it('the normal-mode section exists', () => {
+      const section = getNormalModeSection();
+      assert.ok(section, 'SKILL.md must contain a "When in normal mode" section');
+    });
+
+    it('contains "Implementation Complete"', () => {
+      const section = getNormalModeSection();
+      assert.ok(section, 'normal-mode section must exist');
+      assert.match(
+        section,
+        /Implementation Complete/,
+        'Normal-mode section must contain "Implementation Complete"'
+      );
+    });
+
+    it('contains "Next steps"', () => {
+      const section = getNormalModeSection();
+      assert.ok(section, 'normal-mode section must exist');
+      assert.match(
+        section,
+        /Next steps/,
+        'Normal-mode section must contain "Next steps"'
+      );
+    });
+  });
+
+  describe('Scenario 3: subtask mode completion instructions are preserved', () => {
+    it('the subtask-mode section exists', () => {
+      const section = getSubtaskModeSection();
+      assert.ok(section, 'SKILL.md must contain a "When in subtask mode" section');
+    });
+
+    it('instructs the agent to commit changes', () => {
+      const section = getSubtaskModeSection();
+      assert.ok(section, 'subtask-mode section must exist');
+      assert.match(
+        section,
+        /[Cc]ommit/,
+        'Subtask-mode section must instruct committing changes'
+      );
+    });
+
+    it('instructs the agent to mark the subtask as completed', () => {
+      const section = getSubtaskModeSection();
+      assert.ok(section, 'subtask-mode section must exist');
+      assert.match(
+        section,
+        /complete[d\-]?.*subtask|mark.*subtask.*complete|subtask.*complet/i,
+        'Subtask-mode section must instruct marking the subtask as completed'
+      );
+    });
+
+    it('instructs the agent to return control to the parent workflow', () => {
+      const section = getSubtaskModeSection();
+      assert.ok(section, 'subtask-mode section must exist');
+      assert.match(
+        section,
+        /return.*control|parent.*workflow/i,
+        'Subtask-mode section must instruct returning control to the parent workflow'
+      );
+    });
+  });
+
+  describe('Scenario 4: orchestrator-mode section still requires updating implement.md', () => {
+    it('the orchestrator section instructs updating implement.md with results', () => {
+      const section = getOrchestratorSection();
+      assert.ok(section, 'orchestrator section must exist');
+      assert.match(
+        section,
+        /implement\.md/,
+        'Orchestrator section must reference updating implement.md'
+      );
+    });
+
+    it('the implement.md instruction appears before the return-control instruction', () => {
+      const section = getOrchestratorSection();
+      assert.ok(section, 'orchestrator section must exist');
+      const implementIdx = section.search(/implement\.md/);
+      const returnIdx = section.search(
+        /return.*control|hand.*control.*back|return.*orchestrator/i
+      );
+      assert.ok(implementIdx > -1, 'implement.md reference must exist');
+      assert.ok(returnIdx > -1, 'return-control instruction must exist');
+      assert.ok(
+        implementIdx < returnIdx,
+        'implement.md instruction must appear before the return-control instruction'
+      );
+    });
+  });
+
+  describe('Scenario 6: Notes section orchestrator-mode bullet', () => {
+    it('the Notes section has an orchestrator-mode bullet', () => {
+      const section = getNotesSection();
+      assert.ok(section, 'Notes section must exist');
+      assert.match(
+        section,
+        /[Oo]rchestrator/,
+        'Notes section must have an orchestrator-mode bullet'
+      );
+    });
+
+    it('the orchestrator-mode bullet does NOT reference "completion signal" or "structured block"', () => {
+      const section = getNotesSection();
+      assert.ok(section, 'Notes section must exist');
+      const lines = section.split('\n');
+      const orchestratorLines = lines.filter((l) => /[Oo]rchestrator/.test(l));
+      assert.ok(orchestratorLines.length > 0, 'Must have orchestrator line in Notes');
+      for (const line of orchestratorLines) {
+        assert.doesNotMatch(
+          line,
+          /completion signal/i,
+          'Orchestrator bullet in Notes must NOT reference "completion signal"'
+        );
+        assert.doesNotMatch(
+          line,
+          /structured block/i,
+          'Orchestrator bullet in Notes must NOT reference "structured block"'
+        );
+      }
+    });
+  });
+});

--- a/skills/work-implement/__tests__/skill-md-content.test.js
+++ b/skills/work-implement/__tests__/skill-md-content.test.js
@@ -83,14 +83,10 @@ describe('work-implement SKILL.md — orchestrator completion (GH-231)', () => {
     it('the orchestrator section does NOT contain a fenced code block with a signal format', () => {
       const section = getOrchestratorSection();
       assert.ok(section, 'orchestrator section must exist');
-      const fencedBlocks = section.match(/```[\s\S]*?```/g) || [];
-      for (const block of fencedBlocks) {
-        assert.doesNotMatch(
-          block,
-          /IMPLEMENT_COMPLETE|Agent used:|Changes:|Files modified:|Quality:/,
-          'Orchestrator section must NOT contain a fenced code block with structured signal fields'
-        );
-      }
+      assert.ok(
+        !section.includes('```'),
+        'Orchestrator section must NOT contain any fenced code blocks (triple backticks)'
+      );
     });
   });
 

--- a/skills/work-implement/__tests__/skill-md-content.test.js
+++ b/skills/work-implement/__tests__/skill-md-content.test.js
@@ -12,9 +12,7 @@ const content = fs.readFileSync(SKILL_PATH, 'utf-8');
  * bold-prefixed mode header ("**When in ").
  */
 function getOrchestratorSection() {
-  const start = content.search(
-    /\*\*When called from [`/]*(?:\/)?work[`]* orchestrator/
-  );
+  const start = content.search(/\*\*When called from [`/]*(?:\/)?work[`]* orchestrator/);
   if (start === -1) return null;
   const rest = content.slice(start);
   const nextHeader = rest.slice(1).search(/\n\*\*When in /);
@@ -59,10 +57,7 @@ describe('work-implement SKILL.md — orchestrator completion (GH-231)', () => {
   describe('Scenario 1: orchestrator section contains no structured signal block', () => {
     it('the orchestrator-mode section exists', () => {
       const section = getOrchestratorSection();
-      assert.ok(
-        section,
-        'SKILL.md must contain a "When called from /work orchestrator" section'
-      );
+      assert.ok(section, 'SKILL.md must contain a "When called from /work orchestrator" section');
     });
 
     it('the orchestrator section does NOT contain "IMPLEMENT_COMPLETE" text', () => {
@@ -118,11 +113,7 @@ describe('work-implement SKILL.md — orchestrator completion (GH-231)', () => {
     it('contains "Next steps"', () => {
       const section = getNormalModeSection();
       assert.ok(section, 'normal-mode section must exist');
-      assert.match(
-        section,
-        /Next steps/,
-        'Normal-mode section must contain "Next steps"'
-      );
+      assert.match(section, /Next steps/, 'Normal-mode section must contain "Next steps"');
     });
   });
 
@@ -135,11 +126,7 @@ describe('work-implement SKILL.md — orchestrator completion (GH-231)', () => {
     it('instructs the agent to commit changes', () => {
       const section = getSubtaskModeSection();
       assert.ok(section, 'subtask-mode section must exist');
-      assert.match(
-        section,
-        /[Cc]ommit/,
-        'Subtask-mode section must instruct committing changes'
-      );
+      assert.match(section, /[Cc]ommit/, 'Subtask-mode section must instruct committing changes');
     });
 
     it('instructs the agent to mark the subtask as completed', () => {
@@ -178,9 +165,7 @@ describe('work-implement SKILL.md — orchestrator completion (GH-231)', () => {
       const section = getOrchestratorSection();
       assert.ok(section, 'orchestrator section must exist');
       const implementIdx = section.search(/implement\.md/);
-      const returnIdx = section.search(
-        /return.*control|hand.*control.*back|return.*orchestrator/i
-      );
+      const returnIdx = section.search(/return.*control|hand.*control.*back|return.*orchestrator/i);
       assert.ok(implementIdx > -1, 'implement.md reference must exist');
       assert.ok(returnIdx > -1, 'return-control instruction must exist');
       assert.ok(


### PR DESCRIPTION
## Existing Behavior

The `/work-implement` skill's SKILL.md orchestrator-mode section contained a verbose HTML comment (added in a prior fix) explaining the rationale for keeping the section terse. Additionally, the test suite had a test scenario numbered as "Scenario 6" that was incorrectly numbered — the prior Scenario 5 was removed, creating a gap that Copilot flagged in review.

## Intended New Behavior

- The verbose HTML comment explaining the GH-231 fix rationale is removed from SKILL.md, keeping the orchestrator-mode section clean and readable without inline developer notes.
- The test scenario previously numbered "Scenario 6" (Notes section orchestrator-mode bullet) is renamed to "Scenario 5" to close the numbering gap, addressing the Copilot review comment.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

These are documentation and test cleanup changes with no runtime behavior impact. To verify:

1. Run the skill-md-content test suite and confirm all 5 scenarios pass:
   ```
   node --test skills/work-implement/__tests__/skill-md-content.test.js
   ```
2. Confirm the test output shows `Scenario 5: Notes section orchestrator-mode bullet` (not Scenario 6).
3. Open `skills/work-implement/SKILL.md` and confirm no HTML comment block appears between the subtask-mode section and the `**When called from /work orchestrator**` heading.

### Test Results

All 5 scenarios in `skills/work-implement/__tests__/skill-md-content.test.js` pass after these changes.