### PR TITLE
fix(follow-up-pr): handle BLOCKED merge status and non-required CI correctly

### DIFF
--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -867,3 +867,10 @@ describe('formatReport', () => {
     assert.match(output, /FAILING/, 'should show FAILING status');
   });
 });
+
+describe('ghExec shared module', () => {
+  it('is importable from shared gh-exec module', () => {
+    const { ghExec } = require('../gh-exec.js');
+    assert.equal(typeof ghExec, 'function');
+  });
+});

--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -815,7 +815,7 @@ describe('formatReport', () => {
 
   it('displays optional CI failures as warnings (not errors) when optionalFailed has items', () => {
     const ci = makeCi({
-      status: 'failing',
+      status: 'passing',
       failed: [{ name: 'lint', category: 'lint' }],
       optionalFailed: [{ name: 'lint', category: 'lint' }],
       requiredFailed: [],
@@ -961,7 +961,7 @@ describe('formatReport — review output clarity (GH-324)', () => {
     );
   });
 
-  it('shows "Merge BLOCKED by N unresolved comment threads" when BLOCKED + unresolved comments', () => {
+  it('shows "Merge BLOCKED by N unresolved review comments" when BLOCKED + unresolved comments', () => {
     const ci = makeCi({ status: 'passing' });
     const blockedPrInfo = {
       ...basePrInfo,
@@ -979,7 +979,7 @@ describe('formatReport — review output clarity (GH-324)', () => {
     const output = formatReport(blockedPrInfo, ci, reviews, 1, 10, baseOpts);
     assert.match(
       output,
-      /Merge BLOCKED by 2 unresolved comment/,
+      /Merge BLOCKED by 2 unresolved review comment/,
       'should link BLOCKED merge status to unresolved comments count'
     );
   });

--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -586,6 +586,22 @@ describe('decideNextAction', () => {
     assert.ok(result.message, 'should include a message');
     assert.match(result.message, /blocked.*approval/i);
   });
+
+  // checkCI returns 'passing' when only optional (non-required) checks fail.
+  // These tests verify that decideNextAction correctly exits success in that
+  // scenario, confirming the full checkCI → decideNextAction pipeline handles
+  // optional-only failures as non-blocking.
+  it('returns exit-success when ciStatus is passing (optional-only failures) and merge ready', () => {
+    const result = decideNextAction('passing', mergeReady, noReviews, false);
+    assert.equal(result.action, 'exit-success');
+    assert.equal(result.finalStatus, 'ready');
+  });
+
+  it('returns exit-success when ciStatus is passing (optional-only failures) and blocked-by-approval', () => {
+    const result = decideNextAction('passing', blockedByApproval, noReviews, false);
+    assert.equal(result.action, 'exit-success');
+    assert.equal(result.finalStatus, 'blocked-by-approval');
+  });
 });
 
 describe('getAdaptiveInterval', () => {
@@ -797,6 +813,24 @@ describe('formatReport', () => {
       output,
       /merge blocked by required approvals only/i,
       'should show blocked-by-approval message'
+    );
+  });
+
+  it('shows "awaiting required approvals" (not "not yet mergeable") when blocked by approval', () => {
+    const ci = makeCi({ status: 'passing' });
+    const blockedPrInfo = {
+      ...basePrInfo,
+      mergeStateStatus: 'BLOCKED',
+    };
+    const output = formatReport(blockedPrInfo, ci, baseReviews, 1, 10, baseOpts);
+    assert.match(
+      output,
+      /BLOCKED \(awaiting required approvals\)/,
+      'should show blocked awaiting approvals message'
+    );
+    assert.ok(
+      !output.includes('not yet mergeable'),
+      'should not show generic "not yet mergeable" for blocked-by-approval'
     );
   });
 

--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -438,6 +438,7 @@ describe('decideNextAction', () => {
   const notReady = { mergeable: 'UNKNOWN', mergeStateStatus: 'BEHIND' };
   const noReviews = { hasBlocking: false, pendingBots: [], nonBlocking: [] };
   const blockingReviews = { hasBlocking: true, pendingBots: [], blocking: [{ author: 'user' }] };
+  const blockedByApproval = { mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED' };
   const pendingBots = { hasBlocking: false, pendingBots: ['copilot-pull-request-reviewer'] };
 
   it('returns exit-fail with ci-failing when CI fails', () => {
@@ -527,6 +528,61 @@ describe('decideNextAction', () => {
     const result = decideNextAction('passing', notReady, noReviews, false);
     assert.equal(result.action, 'poll');
     assert.match(result.waitReason, /merge status: BEHIND/);
+  });
+
+  // ── BLOCKED merge status tests ──────────────────────────────────────────────
+  it('returns exit-success with blocked-by-approval when BLOCKED, CI passing, reviews clear', () => {
+    const result = decideNextAction('passing', blockedByApproval, noReviews, false);
+    assert.equal(result.action, 'exit-success');
+    assert.equal(result.finalStatus, 'blocked-by-approval');
+  });
+
+  it('returns exit-fail with ci-failing when BLOCKED and CI fails', () => {
+    const result = decideNextAction('failing', blockedByApproval, noReviews, false);
+    assert.equal(result.action, 'exit-fail');
+    assert.equal(result.finalStatus, 'ci-failing');
+  });
+
+  it('returns exit-fail with conflicting when BLOCKED but has conflicts', () => {
+    const blockedConflicting = { mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' };
+    const result = decideNextAction('passing', blockedConflicting, noReviews, false);
+    assert.equal(result.action, 'exit-fail');
+    assert.equal(result.finalStatus, 'conflicting');
+  });
+
+  it('returns poll when BLOCKED and CI is pending', () => {
+    const result = decideNextAction('pending', blockedByApproval, noReviews, false);
+    assert.equal(result.action, 'poll');
+  });
+
+  it('returns exit-success with blocked-by-approval when BLOCKED, no-checks CI, reviews clear', () => {
+    const result = decideNextAction('no-checks', blockedByApproval, noReviews, false);
+    assert.equal(result.action, 'exit-success');
+    assert.equal(result.finalStatus, 'blocked-by-approval');
+  });
+
+  it('returns exit-fail with reviews-blocking when BLOCKED and reviews are blocking', () => {
+    const result = decideNextAction('passing', blockedByApproval, blockingReviews, false);
+    assert.equal(result.action, 'exit-fail');
+    assert.equal(result.finalStatus, 'reviews-blocking');
+  });
+
+  it('returns exit-success when BLOCKED, CI passing, noReviews is true', () => {
+    const result = decideNextAction('passing', blockedByApproval, blockingReviews, true);
+    assert.equal(result.action, 'exit-success');
+    assert.equal(result.finalStatus, 'blocked-by-approval');
+  });
+
+  it('returns exit-fail with ci-cancelled when BLOCKED and CI is cancelled', () => {
+    const result = decideNextAction('cancelled', blockedByApproval, noReviews, false);
+    assert.equal(result.action, 'exit-fail');
+    assert.equal(result.finalStatus, 'ci-cancelled');
+  });
+
+  it('includes human-readable message when exiting success due to blocked-by-approval', () => {
+    const result = decideNextAction('passing', blockedByApproval, noReviews, false);
+    assert.ok(result.message, 'should include a message');
+    assert.match(result.message, /blocked.*approval/i);
   });
 });
 

--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -10,6 +10,7 @@ const {
   getAdaptiveInterval,
   getCodeContext,
   partitionByRequired,
+  formatReport,
 } = require('../follow-up-pr.js');
 
 describe('classifyCommentPriority', () => {
@@ -735,5 +736,100 @@ describe('getCodeContext', () => {
     assert.ok(result.includes('>>>'), 'should have marker');
     // Should not have negative line numbers
     assert.ok(!result.includes('-1:'), 'no negative line numbers');
+  });
+});
+
+// ── formatReport ──────────────────────────────────────────────────────────────
+describe('formatReport', () => {
+  // Minimal fixtures for formatReport parameters
+  const basePrInfo = {
+    number: 42,
+    title: 'Test PR',
+    branch: 'feature-branch',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+  };
+  const baseReviews = { hasBlocking: false, pendingBots: [], nonBlocking: [], blocking: [] };
+  const baseOpts = { noReviews: false, interval: 30 };
+
+  function makeCi(overrides) {
+    return {
+      status: 'passing',
+      total: 2,
+      passed: [{ name: 'build' }, { name: 'test' }],
+      running: [],
+      failed: [],
+      neutral: [],
+      cancelled: [],
+      optionalFailed: [],
+      requiredFailed: [],
+      hasRequiredInfo: false,
+      ...overrides,
+    };
+  }
+
+  it('displays optional CI failures as warnings (not errors) when optionalFailed has items', () => {
+    const ci = makeCi({
+      status: 'failing',
+      failed: [{ name: 'lint', category: 'lint' }],
+      optionalFailed: [{ name: 'lint', category: 'lint' }],
+      requiredFailed: [],
+      hasRequiredInfo: true,
+    });
+    const output = formatReport(basePrInfo, ci, baseReviews, 1, 10, baseOpts);
+    assert.match(
+      output,
+      /Optional CI failures \(non-blocking\)/,
+      'should show optional failures warning section'
+    );
+    assert.match(output, /lint/, 'should list the optional failure name');
+  });
+
+  it('includes blocked-by-approval message when decision has that status', () => {
+    const ci = makeCi({ status: 'passing' });
+    const blockedPrInfo = {
+      ...basePrInfo,
+      mergeStateStatus: 'BLOCKED',
+    };
+    const decision = { action: 'exit-success', finalStatus: 'blocked-by-approval' };
+    const output = formatReport(blockedPrInfo, ci, baseReviews, 1, 10, baseOpts, decision);
+    assert.match(
+      output,
+      /merge blocked by required approvals only/i,
+      'should show blocked-by-approval message'
+    );
+  });
+
+  it('does not show optional failures section when optionalFailed is empty', () => {
+    const ci = makeCi({ status: 'passing', optionalFailed: [] });
+    const output = formatReport(basePrInfo, ci, baseReviews, 1, 10, baseOpts);
+    assert.ok(
+      !output.includes('Optional CI failures'),
+      'should not show optional failures section'
+    );
+  });
+
+  it('does not show optional failures section when optionalFailed is undefined', () => {
+    const ci = makeCi({ status: 'passing' });
+    delete ci.optionalFailed;
+    const output = formatReport(basePrInfo, ci, baseReviews, 1, 10, baseOpts);
+    assert.ok(
+      !output.includes('Optional CI failures'),
+      'should not show optional failures section'
+    );
+  });
+
+  it('backward compat: still shows failed checks normally when no optionalFailed info', () => {
+    const ci = makeCi({
+      status: 'failing',
+      failed: [{ name: 'build', category: 'build' }],
+      hasRequiredInfo: false,
+    });
+    delete ci.optionalFailed;
+    delete ci.requiredFailed;
+    const output = formatReport(basePrInfo, ci, baseReviews, 1, 10, baseOpts);
+    // Should still show the failure with the standard format
+    assert.match(output, /build/, 'should display failed check name');
+    assert.match(output, /FAILING/, 'should show FAILING status');
   });
 });

--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -602,6 +602,35 @@ describe('decideNextAction', () => {
     assert.equal(result.action, 'exit-success');
     assert.equal(result.finalStatus, 'blocked-by-approval');
   });
+
+  // ── BLOCKED + unresolved conversations (non-blocking comments) ──────────
+  it('returns exit-fail with unresolved-conversations when BLOCKED, CI passing, non-blocking comments exist', () => {
+    const nonBlockingComments = {
+      hasBlocking: false,
+      pendingBots: [],
+      nonBlocking: [{ author: 'copilot', body: '[low] suggestion' }],
+    };
+    const result = decideNextAction('passing', blockedByApproval, nonBlockingComments, false);
+    assert.equal(result.action, 'exit-fail');
+    assert.equal(result.finalStatus, 'unresolved-conversations');
+  });
+
+  it('returns exit-success when BLOCKED, CI passing, truly no comments at all', () => {
+    const result = decideNextAction('passing', blockedByApproval, noReviews, false);
+    assert.equal(result.action, 'exit-success');
+    assert.equal(result.finalStatus, 'blocked-by-approval');
+  });
+
+  it('includes unresolved thread count in message when BLOCKED by conversations', () => {
+    const twoComments = {
+      hasBlocking: false,
+      pendingBots: [],
+      nonBlocking: [{ author: 'a' }, { author: 'b' }],
+    };
+    const result = decideNextAction('passing', blockedByApproval, twoComments, false);
+    assert.ok(result.message);
+    assert.match(result.message, /2.*unresolved/i);
+  });
 });
 
 describe('getAdaptiveInterval', () => {

--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -868,6 +868,138 @@ describe('formatReport', () => {
   });
 });
 
+// ── formatReport review output with BLOCKED merge + non-blocking comments (GH-324 Task 6) ──
+describe('formatReport — review output clarity (GH-324)', () => {
+  const basePrInfo = {
+    number: 42,
+    title: 'Test PR',
+    branch: 'feature-branch',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+  };
+  const baseOpts = { noReviews: false, interval: 30 };
+
+  function makeCi(overrides) {
+    return {
+      status: 'passing',
+      total: 2,
+      passed: [{ name: 'build' }, { name: 'test' }],
+      running: [],
+      failed: [],
+      neutral: [],
+      cancelled: [],
+      optionalFailed: [],
+      requiredFailed: [],
+      hasRequiredInfo: false,
+      ...overrides,
+    };
+  }
+
+  it('shows UNRESOLVED (not CLEAR) when non-blocking comments exist', () => {
+    const ci = makeCi({ status: 'passing' });
+    const reviews = {
+      hasBlocking: false,
+      pendingBots: [],
+      blocking: [],
+      nonBlocking: [
+        { author: 'Copilot', priority: 'low', path: 'file.js', line: 10, body: 'nitpick' },
+      ],
+    };
+    const output = formatReport(basePrInfo, ci, reviews, 1, 10, baseOpts);
+    assert.match(output, /UNRESOLVED/, 'should show UNRESOLVED instead of CLEAR');
+    assert.ok(!output.match(/Reviews: CLEAR/), 'should NOT say CLEAR when comments exist');
+  });
+
+  it('says "address these to unblock merge" instead of "assess whether to address"', () => {
+    const ci = makeCi({ status: 'passing' });
+    const reviews = {
+      hasBlocking: false,
+      pendingBots: [],
+      blocking: [],
+      nonBlocking: [
+        { author: 'Copilot', priority: 'low', path: 'file.js', line: 10, body: 'nitpick' },
+      ],
+    };
+    const output = formatReport(basePrInfo, ci, reviews, 1, 10, baseOpts);
+    assert.match(
+      output,
+      /address these to unblock merge/,
+      'should say address these to unblock merge'
+    );
+    assert.ok(
+      !output.includes('assess whether to address'),
+      'should NOT say assess whether to address'
+    );
+  });
+
+  it('shows "Merge BLOCKED by N unresolved comment threads" when BLOCKED + unresolved comments', () => {
+    const ci = makeCi({ status: 'passing' });
+    const blockedPrInfo = {
+      ...basePrInfo,
+      mergeStateStatus: 'BLOCKED',
+    };
+    const reviews = {
+      hasBlocking: false,
+      pendingBots: [],
+      blocking: [],
+      nonBlocking: [
+        { author: 'Copilot', priority: 'low', path: 'file.js', line: 10, body: 'nitpick' },
+        { author: 'Copilot', priority: 'low', path: 'other.js', line: 5, body: 'style' },
+      ],
+    };
+    const output = formatReport(blockedPrInfo, ci, reviews, 1, 10, baseOpts);
+    assert.match(
+      output,
+      /Merge BLOCKED by 2 unresolved comment/,
+      'should link BLOCKED merge status to unresolved comments count'
+    );
+  });
+
+  it('still says "awaiting required approvals" when BLOCKED but no unresolved comments', () => {
+    const ci = makeCi({ status: 'passing' });
+    const blockedPrInfo = {
+      ...basePrInfo,
+      mergeStateStatus: 'BLOCKED',
+    };
+    const reviews = {
+      hasBlocking: false,
+      pendingBots: [],
+      blocking: [],
+      nonBlocking: [],
+    };
+    const output = formatReport(blockedPrInfo, ci, reviews, 1, 10, baseOpts);
+    assert.match(output, /awaiting required approvals/, 'should show awaiting required approvals');
+    assert.ok(
+      !output.includes('unresolved comment'),
+      'should NOT mention unresolved comments when there are none'
+    );
+  });
+
+  it('uses "unresolved" wording in blocking reviews non-blocking sub-section too', () => {
+    const ci = makeCi({ status: 'passing' });
+    const reviews = {
+      hasBlocking: true,
+      pendingBots: [],
+      blocking: [
+        { author: 'Copilot', priority: 'medium', path: 'main.js', line: 20, body: 'bug here' },
+      ],
+      nonBlocking: [
+        { author: 'Copilot', priority: 'low', path: 'file.js', line: 10, body: 'nitpick' },
+      ],
+    };
+    const output = formatReport(basePrInfo, ci, reviews, 1, 10, baseOpts);
+    assert.match(
+      output,
+      /unresolved/,
+      'should use "unresolved" wording for non-blocking sub-section'
+    );
+    assert.ok(
+      !output.includes('assess whether to address'),
+      'should NOT use "assess whether to address" in blocking section either'
+    );
+  });
+});
+
 describe('ghExec shared module', () => {
   it('is importable from shared gh-exec module', () => {
     const { ghExec } = require('../gh-exec.js');

--- a/workflows/work/scripts/__tests__/follow-up-pr.test.js
+++ b/workflows/work/scripts/__tests__/follow-up-pr.test.js
@@ -9,6 +9,7 @@ const {
   decideNextAction,
   getAdaptiveInterval,
   getCodeContext,
+  partitionByRequired,
 } = require('../follow-up-pr.js');
 
 describe('classifyCommentPriority', () => {
@@ -629,6 +630,58 @@ describe('getAdaptiveInterval', () => {
   it('returns 30s when no checks exist (total=0, attempt>1)', () => {
     const ci = makeCi([], []);
     assert.equal(getAdaptiveInterval(2, ci), 30);
+  });
+});
+
+// ── partitionByRequired ──────────────────────────────────────────────────────
+describe('partitionByRequired', () => {
+  const makeCheck = (name) => ({ name, bucket: 'fail', category: 'unknown' });
+
+  it('treats all failed as required when requiredChecks is null', () => {
+    const failed = [makeCheck('lint'), makeCheck('test')];
+    const result = partitionByRequired(failed, null);
+    assert.equal(result.hasRequiredInfo, false);
+    assert.deepStrictEqual(result.requiredFailed, failed);
+    assert.deepStrictEqual(result.optionalFailed, []);
+  });
+
+  it('treats all failed as required when requiredChecks is empty array', () => {
+    const failed = [makeCheck('lint')];
+    const result = partitionByRequired(failed, []);
+    assert.equal(result.hasRequiredInfo, false);
+    assert.deepStrictEqual(result.requiredFailed, failed);
+    assert.deepStrictEqual(result.optionalFailed, []);
+  });
+
+  it('returns only optional failures when all required checks pass', () => {
+    const failed = [makeCheck('optional-lint'), makeCheck('optional-docs')];
+    const requiredChecks = ['build', 'test'];
+    const result = partitionByRequired(failed, requiredChecks);
+    assert.equal(result.hasRequiredInfo, true);
+    assert.deepStrictEqual(result.requiredFailed, []);
+    assert.deepStrictEqual(result.optionalFailed, failed);
+  });
+
+  it('returns required failure when a required check fails', () => {
+    const failedBuild = makeCheck('build');
+    const failed = [failedBuild];
+    const requiredChecks = ['build', 'test'];
+    const result = partitionByRequired(failed, requiredChecks);
+    assert.equal(result.hasRequiredInfo, true);
+    assert.deepStrictEqual(result.requiredFailed, [failedBuild]);
+    assert.deepStrictEqual(result.optionalFailed, []);
+  });
+
+  it('partitions mixed required and optional failures correctly', () => {
+    const failedBuild = makeCheck('build');
+    const failedLint = makeCheck('lint');
+    const failedDocs = makeCheck('docs');
+    const failed = [failedBuild, failedLint, failedDocs];
+    const requiredChecks = ['build', 'docs'];
+    const result = partitionByRequired(failed, requiredChecks);
+    assert.equal(result.hasRequiredInfo, true);
+    assert.deepStrictEqual(result.requiredFailed, [failedBuild, failedDocs]);
+    assert.deepStrictEqual(result.optionalFailed, [failedLint]);
   });
 });
 

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -100,31 +100,7 @@ Options:
 
 // ── gh CLI Wrapper ──────────────────────────────────────────────────────────
 
-function ghExec(ghArgs, { json = true, allowNonZero = false } = {}) {
-  const args = typeof ghArgs === 'string' ? ghArgs.split(/\s+/) : ghArgs;
-  try {
-    const result = execFileSync('gh', args, {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 30000,
-    });
-    return json ? JSON.parse(result) : result.trim();
-  } catch (err) {
-    if (allowNonZero && err.stdout) {
-      const stdout = err.stdout.toString().trim();
-      if (json && stdout) {
-        try {
-          return JSON.parse(stdout);
-        } catch {
-          /* fall through */
-        }
-      }
-      if (!json && stdout) return stdout;
-    }
-    const stderr = err.stderr ? err.stderr.toString().trim() : '';
-    throw new Error(`gh command failed: gh ${args.join(' ')}\n${stderr}`);
-  }
-}
+const { ghExec } = require('./gh-exec.js');
 
 // ── PR Info ─────────────────────────────────────────────────────────────────
 

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -923,7 +923,7 @@ function formatNonBlockingItems(items, lines) {
   }
 }
 
-function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
+function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts, decision) {
   const lines = [];
 
   lines.push(c.bold('=== Follow-up PR Monitor ==='));
@@ -998,6 +998,17 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
     }
   } else {
     lines.push(c.dim('CI: No checks found'));
+  }
+
+  // Optional (non-required) CI failures — shown as warnings, not errors
+  if (ci.optionalFailed && ci.optionalFailed.length > 0 && ci.hasRequiredInfo) {
+    lines.push('');
+    lines.push(c.yellow('\u26A0 Optional CI failures (non-blocking):'));
+    for (const ck of ci.optionalFailed) {
+      lines.push(
+        `  ${c.yellow('\u26A0')} ${ck.name} ${c.dim(`[${ck.category || 'unknown'}]`)} — failed (optional)`
+      );
+    }
   }
 
   // Merge status
@@ -1083,6 +1094,8 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
   // Action hint — order matches fail-fast exit priority
   lines.push('');
   const ciAcceptable = ci.status === 'passing' || ci.status === 'no-checks';
+  const isBlockedByApproval =
+    prInfo.mergeable === 'MERGEABLE' && prInfo.mergeStateStatus === 'BLOCKED' && !isConflicting;
   if (ci.status === 'failing') {
     lines.push(`→ Fix the failure, push, then re-run: ${c.dim('node scripts/follow-up-pr.js')}`);
   } else if (isConflicting) {
@@ -1104,7 +1117,7 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
     ciAcceptable &&
     (!reviews.hasBlocking || opts.noReviews) &&
     reviews.pendingBots.length === 0 &&
-    isMergeReady
+    (isMergeReady || isBlockedByApproval)
   ) {
     // Non-blocking comments report (before the banner)
     if (reviews.nonBlocking && reviews.nonBlocking.length > 0) {
@@ -1128,6 +1141,9 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts) {
     lines.push(
       c.green(`CI: ${ciLabel} | Reviews: ${opts.noReviews ? 'SKIPPED' : 'CLEAR'} | Conflicts: NONE`)
     );
+    if (decision && decision.finalStatus === 'blocked-by-approval') {
+      lines.push(c.yellow('PR ready \u2014 merge blocked by required approvals only'));
+    }
     lines.push(c.green(`PR #${prInfo.number} is ready for review/merge!`));
   } else if (ci.status === 'pending') {
     lines.push(`→ Waiting ${opts.interval}s for checks... (attempt ${attempt}/${maxAttempts})`);
@@ -1737,6 +1753,7 @@ module.exports = {
   initState,
   getCodeContext,
   buildAccountabilityEntries,
+  formatReport,
   partitionByRequired,
   // Gate-check exports: used by workflow-definition.js verify()
   isPRGateReady,

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1023,12 +1023,18 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts, decision)
     lines.push('');
     lines.push(c.red('CONFLICTS: Merge conflicts detected — rebase required'));
   } else if (!isMergeReady) {
+    const isBlockedByApprovalStatus =
+      prInfo.mergeable === 'MERGEABLE' && prInfo.mergeStateStatus === 'BLOCKED';
     lines.push('');
-    lines.push(
-      c.yellow(
-        `MERGE STATUS: ${prInfo.mergeable || 'UNKNOWN'} (${prInfo.mergeStateStatus || 'UNKNOWN'}) — not yet mergeable`
-      )
-    );
+    if (isBlockedByApprovalStatus) {
+      lines.push(c.yellow('MERGE STATUS: BLOCKED (awaiting required approvals)'));
+    } else {
+      lines.push(
+        c.yellow(
+          `MERGE STATUS: ${prInfo.mergeable || 'UNKNOWN'} (${prInfo.mergeStateStatus || 'UNKNOWN'}) — not yet mergeable`
+        )
+      );
+    }
   }
 
   // Reviews

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1192,6 +1192,22 @@ function decideNextAction(ciStatus, prInfo, reviews, noReviews) {
     return { action: 'exit-fail', finalStatus: 'reviews-blocking' };
   }
 
+  // BLOCKED by unresolved conversations — non-blocking comments that still block merge via branch protection
+  if (
+    isBlockedByApproval &&
+    ciAcceptable &&
+    !noReviews &&
+    reviews.nonBlocking &&
+    reviews.nonBlocking.length > 0
+  ) {
+    const count = reviews.nonBlocking.length;
+    return {
+      action: 'exit-fail',
+      finalStatus: 'unresolved-conversations',
+      message: `Merge blocked by ${count} unresolved comment thread(s) — address them to unblock merge.`,
+    };
+  }
+
   // Success — CI acceptable (passing or no-checks), reviews clear, merge ready
   if (ciAcceptable && reviewsClear && (isMergeReady || isBlockedByApproval)) {
     return {

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1103,6 +1103,8 @@ function decideNextAction(ciStatus, prInfo, reviews, noReviews) {
       prInfo.mergeStateStatus === 'CLEAN' ||
       prInfo.mergeStateStatus === 'HAS_HOOKS' ||
       prInfo.mergeStateStatus === 'UNSTABLE');
+  const isBlockedByApproval =
+    prInfo.mergeable === 'MERGEABLE' && prInfo.mergeStateStatus === 'BLOCKED' && !isConflicting;
   const ciAcceptable = ciStatus === 'passing' || ciStatus === 'no-checks';
   const ciFinished = ciAcceptable || ciStatus === 'cancelled';
   const reviewsClear = noReviews || (!reviews.hasBlocking && reviews.pendingBots.length === 0);
@@ -1128,8 +1130,14 @@ function decideNextAction(ciStatus, prInfo, reviews, noReviews) {
   }
 
   // Success — CI acceptable (passing or no-checks), reviews clear, merge ready
-  if (ciAcceptable && reviewsClear && isMergeReady) {
-    return { action: 'exit-success', finalStatus: 'ready' };
+  if (ciAcceptable && reviewsClear && (isMergeReady || isBlockedByApproval)) {
+    return {
+      action: 'exit-success',
+      finalStatus: isBlockedByApproval ? 'blocked-by-approval' : 'ready',
+      message: isBlockedByApproval
+        ? 'PR ready — merge blocked by required approvals only'
+        : undefined,
+    };
   }
 
   // Still polling — build list of reasons (tested in follow-up-pr.test.js)

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -977,7 +977,13 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts, decision)
   }
 
   // Optional (non-required) CI failures — shown as warnings, not errors
-  if (ci.optionalFailed && ci.optionalFailed.length > 0 && ci.hasRequiredInfo) {
+  // Only show when CI is not already failing (avoids duplicating checks shown in CI FAILING section)
+  if (
+    ci.optionalFailed &&
+    ci.optionalFailed.length > 0 &&
+    ci.hasRequiredInfo &&
+    ci.status !== 'failing'
+  ) {
     lines.push('');
     lines.push(c.yellow('\u26A0 Optional CI failures (non-blocking):'));
     for (const ck of ci.optionalFailed) {
@@ -1002,13 +1008,11 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts, decision)
     const isBlockedByApprovalStatus =
       prInfo.mergeable === 'MERGEABLE' && prInfo.mergeStateStatus === 'BLOCKED';
     lines.push('');
-    const unresolvedCount =
-      (reviews.nonBlocking ? reviews.nonBlocking.length : 0) +
-      (reviews.blocking ? reviews.blocking.length : 0);
+    const unresolvedCount = reviews.nonBlocking ? reviews.nonBlocking.length : 0;
     if (isBlockedByApprovalStatus && unresolvedCount > 0) {
       lines.push(
         c.yellow(
-          `MERGE STATUS: Merge BLOCKED by ${unresolvedCount} unresolved comment thread${unresolvedCount !== 1 ? 's' : ''}`
+          `MERGE STATUS: Merge BLOCKED by ${unresolvedCount} unresolved review comment${unresolvedCount !== 1 ? 's' : ''}`
         )
       );
     } else if (isBlockedByApprovalStatus) {
@@ -1108,7 +1112,8 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts, decision)
     ciAcceptable &&
     (!reviews.hasBlocking || opts.noReviews) &&
     reviews.pendingBots.length === 0 &&
-    (isMergeReady || isBlockedByApproval)
+    (isMergeReady ||
+      (isBlockedByApproval && !(reviews.nonBlocking && reviews.nonBlocking.length > 0)))
   ) {
     // Non-blocking comments report (before the banner)
     if (reviews.nonBlocking && reviews.nonBlocking.length > 0) {
@@ -1193,10 +1198,12 @@ function decideNextAction(ciStatus, prInfo, reviews, noReviews) {
   }
 
   // BLOCKED by unresolved conversations — non-blocking comments that still block merge via branch protection
+  // Wait for bot reviews to finish first (consistent with blocking-review guard above)
   if (
     isBlockedByApproval &&
     ciAcceptable &&
     !noReviews &&
+    reviews.pendingBots.length === 0 &&
     reviews.nonBlocking &&
     reviews.nonBlocking.length > 0
   ) {
@@ -1204,7 +1211,7 @@ function decideNextAction(ciStatus, prInfo, reviews, noReviews) {
     return {
       action: 'exit-fail',
       finalStatus: 'unresolved-conversations',
-      message: `Merge blocked by ${count} unresolved comment thread(s) — address them to unblock merge.`,
+      message: `Merge blocked by ${count} unresolved review comment(s) — analyse each comment, address those that make sense. Do NOT blindly solve comments that conflict with user/ticket intent or request large out-of-scope refactors (minor improvements are ok). Skip with reason when appropriate, e.g. Skipped "<title>" — conflicts with user intent: <reason>, or Skipped "<title>" — out of scope: <reason>.`,
     };
   }
 

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -1002,7 +1002,16 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts, decision)
     const isBlockedByApprovalStatus =
       prInfo.mergeable === 'MERGEABLE' && prInfo.mergeStateStatus === 'BLOCKED';
     lines.push('');
-    if (isBlockedByApprovalStatus) {
+    const unresolvedCount =
+      (reviews.nonBlocking ? reviews.nonBlocking.length : 0) +
+      (reviews.blocking ? reviews.blocking.length : 0);
+    if (isBlockedByApprovalStatus && unresolvedCount > 0) {
+      lines.push(
+        c.yellow(
+          `MERGE STATUS: Merge BLOCKED by ${unresolvedCount} unresolved comment thread${unresolvedCount !== 1 ? 's' : ''}`
+        )
+      );
+    } else if (isBlockedByApprovalStatus) {
       lines.push(c.yellow('MERGE STATUS: BLOCKED (awaiting required approvals)'));
     } else {
       lines.push(
@@ -1058,14 +1067,14 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts, decision)
       lines.push(c.yellow('    line-number drift, and dedup confusion.'));
       if (reviews.nonBlocking.length > 0) {
         lines.push(
-          `  + ${reviews.nonBlocking.length} non-blocking (nitpick/low — assess whether to address):`
+          `  + ${reviews.nonBlocking.length} unresolved (nitpick/low — address these to unblock merge):`
         );
         formatNonBlockingItems(reviews.nonBlocking, lines);
       }
     } else if (reviews.nonBlocking.length > 0) {
       lines.push(
-        c.green(`Reviews: CLEAR`) +
-          ` (${reviews.nonBlocking.length} non-blocking — assess whether to address):`
+        c.yellow(`Reviews: UNRESOLVED`) +
+          ` (${reviews.nonBlocking.length} unresolved — address these to unblock merge):`
       );
       formatNonBlockingItems(reviews.nonBlocking, lines);
     } else {
@@ -1120,9 +1129,9 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts, decision)
     lines.push(c.green('═══════════════════════════════════════'));
     lines.push('');
     const ciLabel = ci.status === 'no-checks' ? 'NO CHECKS' : 'PASSED';
-    lines.push(
-      c.green(`CI: ${ciLabel} | Reviews: ${opts.noReviews ? 'SKIPPED' : 'CLEAR'} | Conflicts: NONE`)
-    );
+    const hasUnresolved = reviews.nonBlocking && reviews.nonBlocking.length > 0;
+    const reviewLabel = opts.noReviews ? 'SKIPPED' : hasUnresolved ? 'UNRESOLVED' : 'CLEAR';
+    lines.push(c.green(`CI: ${ciLabel} | Reviews: ${reviewLabel} | Conflicts: NONE`));
     if (decision && decision.finalStatus === 'blocked-by-approval') {
       lines.push(c.yellow('PR ready \u2014 merge blocked by required approvals only'));
     }

--- a/workflows/work/scripts/follow-up-pr.js
+++ b/workflows/work/scripts/follow-up-pr.js
@@ -162,6 +162,24 @@ function categorizeCheck(checkName) {
   return 'unknown';
 }
 
+// ── Required/Optional CI Check Partitioning ─────────────────────────────────
+
+/**
+ * Partition failed checks into required and optional.
+ * @param {Array} allFailed - All failed check objects
+ * @param {Array|null} requiredChecks - Required check names (null = unavailable)
+ * @returns {{ requiredFailed: Array, optionalFailed: Array, hasRequiredInfo: boolean }}
+ */
+function partitionByRequired(allFailed, requiredChecks) {
+  if (!requiredChecks || requiredChecks.length === 0) {
+    return { requiredFailed: allFailed, optionalFailed: [], hasRequiredInfo: false };
+  }
+  const requiredNames = new Set(requiredChecks.map((n) => (typeof n === 'string' ? n : n.name)));
+  const requiredFailed = allFailed.filter((ck) => requiredNames.has(ck.name));
+  const optionalFailed = allFailed.filter((ck) => !requiredNames.has(ck.name));
+  return { requiredFailed, optionalFailed, hasRequiredInfo: true };
+}
+
 // ── CI Status ───────────────────────────────────────────────────────────────
 
 function checkCI(prNumber) {
@@ -267,14 +285,52 @@ function checkCI(prNumber) {
   const neutral = checks.filter((ck) => ck.bucket === 'neutral');
   const cancelled = checks.filter((ck) => ck.bucket === 'cancel');
 
-  let status;
-  if (failed.length > 0) status = 'failing';
-  else if (running.length > 0) status = 'pending';
-  else if (checks.length === 0) status = 'no-checks';
-  else if (cancelled.length > 0) status = 'cancelled';
-  else status = 'passing';
+  // Fetch required checks (gh pr checks --required)
+  let requiredCheckNames = null;
+  try {
+    const requiredRaw = ghExec(`pr checks ${prArg} --required --json name`, { allowNonZero: true });
+    if (Array.isArray(requiredRaw) && requiredRaw.length > 0) {
+      requiredCheckNames = requiredRaw.map((c) => c.name);
+    }
+  } catch {
+    // --required flag unavailable or failed — fall back to all-as-required
+  }
 
-  return { status, checks, failed, running, passed, neutral, cancelled, total: checks.length };
+  const { requiredFailed, optionalFailed, hasRequiredInfo } = partitionByRequired(
+    failed,
+    requiredCheckNames
+  );
+
+  let status;
+  if (hasRequiredInfo) {
+    // When we know which checks are required, only required failures matter
+    if (requiredFailed.length > 0) status = 'failing';
+    else if (running.length > 0) status = 'pending';
+    else if (checks.length === 0) status = 'no-checks';
+    else if (cancelled.length > 0) status = 'cancelled';
+    else status = 'passing';
+  } else {
+    // Fallback: all checks treated as required (current behavior)
+    if (failed.length > 0) status = 'failing';
+    else if (running.length > 0) status = 'pending';
+    else if (checks.length === 0) status = 'no-checks';
+    else if (cancelled.length > 0) status = 'cancelled';
+    else status = 'passing';
+  }
+
+  return {
+    status,
+    checks,
+    failed,
+    running,
+    passed,
+    neutral,
+    cancelled,
+    total: checks.length,
+    requiredFailed,
+    optionalFailed,
+    hasRequiredInfo,
+  };
 }
 
 // ── Reviews ─────────────────────────────────────────────────────────────────
@@ -1681,6 +1737,7 @@ module.exports = {
   initState,
   getCodeContext,
   buildAccountabilityEntries,
+  partitionByRequired,
   // Gate-check exports: used by workflow-definition.js verify()
   isPRGateReady,
   ghExec,

--- a/workflows/work/scripts/gh-exec.js
+++ b/workflows/work/scripts/gh-exec.js
@@ -1,0 +1,43 @@
+/**
+ * gh-exec.js — Shared gh CLI wrapper
+ *
+ * Executes `gh` commands via execFileSync with JSON parsing,
+ * error handling, and optional non-zero exit tolerance.
+ */
+const { execFileSync } = require('child_process');
+
+/**
+ * Execute a gh CLI command synchronously.
+ * @param {string|string[]} ghArgs - Command arguments (string is split on whitespace)
+ * @param {object} [opts]
+ * @param {boolean} [opts.json=true] - Parse stdout as JSON
+ * @param {boolean} [opts.allowNonZero=false] - Tolerate non-zero exit codes
+ * @returns {*} Parsed JSON or trimmed string
+ */
+function ghExec(ghArgs, { json = true, allowNonZero = false } = {}) {
+  const args = typeof ghArgs === 'string' ? ghArgs.split(/\s+/) : ghArgs;
+  try {
+    const result = execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 30000,
+    });
+    return json ? JSON.parse(result) : result.trim();
+  } catch (err) {
+    if (allowNonZero && err.stdout) {
+      const stdout = err.stdout.toString().trim();
+      if (json && stdout) {
+        try {
+          return JSON.parse(stdout);
+        } catch {
+          /* fall through */
+        }
+      }
+      if (!json && stdout) return stdout;
+    }
+    const stderr = err.stderr ? err.stderr.toString().trim() : '';
+    throw new Error(`gh command failed: gh ${args.join(' ')}\n${stderr}`);
+  }
+}
+
+module.exports = { ghExec };


### PR DESCRIPTION
## Existing Behavior

- When a PR's merge state is `BLOCKED` and CI is passing with no blocking reviews, `decideNextAction` falls through to the success path and exits with `exit-success`, causing the follow-up loop to terminate prematurely instead of surfacing the real block reason.
- Non-required CI check failures are treated as blocking, preventing the loop from advancing even when only optional checks fail.
- `ghExec` is defined inline inside `follow-up-pr.js`, duplicating logic that other scripts cannot share.
- When non-blocking review comments exist, the report displays `Reviews: CLEAR` (green), misleading developers into thinking nothing needs attention.

## Intended New Behavior

- `BLOCKED` merge status with unresolved comment threads now exits `unresolved-conversations` (fail path) with an explicit count, instead of looping forever or silently exiting success.
- `BLOCKED` with no unresolved comments still exits `blocked-by-approval` (success path — awaiting required approvals).
- Non-required CI failures are correctly classified as non-blocking; only `requiredFailed` checks gate the loop.
- `ghExec` is extracted into `workflows/work/scripts/gh-exec.js` and imported by `follow-up-pr.js` for reuse.
- Report output now shows `Reviews: UNRESOLVED` (yellow) with "address these to unblock merge" wording, and links a `BLOCKED` merge status to the exact unresolved comment thread count.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

All changes are covered by the test suite in `workflows/work/scripts/__tests__/follow-up-pr.test.js`. To verify locally:

1. Run the full test suite:
   ```
   node --test workflows/work/scripts/__tests__/follow-up-pr.test.js
   ```
2. Confirm the new test groups pass:
   - `decideNextAction` — BLOCKED + CI passing + non-blocking comments → `exit-fail / unresolved-conversations`
   - `decideNextAction` — BLOCKED + CI passing + no comments → `exit-success / blocked-by-approval`
   - `decideNextAction` — message includes unresolved thread count
   - `formatReport — review output clarity (GH-324)` — UNRESOLVED label, correct wording, comment count in BLOCKED message
3. For a live smoke test: point a repository PR at a branch-protection rule requiring resolved conversations, then invoke `follow-up-pr.js` against that PR number. Expect the script to exit with status `unresolved-conversations` rather than looping or exiting success.

### Test Results

New test cases added in this PR (all passing):
- `decideNextAction` — returns `exit-fail / unresolved-conversations` when BLOCKED, CI passing, non-blocking comments present
- `decideNextAction` — returns `exit-success / blocked-by-approval` when BLOCKED, CI passing, no comments
- `decideNextAction` — message matches `/2.*unresolved/i` for 2 non-blocking comment threads
- `formatReport` — shows UNRESOLVED (not CLEAR) when non-blocking comments exist
- `formatReport` — says "address these to unblock merge" instead of "assess whether to address"
- `formatReport` — shows "Merge BLOCKED by N unresolved comment threads" when BLOCKED + comments
- `formatReport` — shows "awaiting required approvals" when BLOCKED but no unresolved comments

---
Fixes #324
Refs #305, #306