### PR TITLE
fix(check): enforce Status: line in check reports to prevent gate failures

### DIFF
--- a/workflows/check/scripts/write-code-review.js
+++ b/workflows/check/scripts/write-code-review.js
@@ -36,6 +36,8 @@ const VALID_PRIORITIES = ['critical', 'important', 'nice-to-have'];
 const writer = createReportWriter({
   name: 'Code Review Writer',
 
+  reportType: 'codeReview',
+
   allowedAgents: ['code-checker'],
 
   requiredFields: ['reportPath', 'changesHash', 'verdict', 'strengths', 'issues'],

--- a/workflows/check/scripts/write-completion-report.js
+++ b/workflows/check/scripts/write-completion-report.js
@@ -27,6 +27,8 @@ const { createReportWriter } = require('../../lib/scripts/write-report');
 const writer = createReportWriter({
   name: 'Completion Report Writer',
 
+  reportType: 'completion',
+
   allowedAgents: ['completion-checker'],
 
   requiredFields: ['reportPath', 'changesHash', 'originalRequest', 'deliverables', 'finalStatus'],

--- a/workflows/check/scripts/write-tests-report.js
+++ b/workflows/check/scripts/write-tests-report.js
@@ -26,6 +26,8 @@ const { createReportWriter } = require('../../lib/scripts/write-report');
 const writer = createReportWriter({
   name: 'Tests Report Writer',
 
+  reportType: 'tests',
+
   allowedAgents: ['quality-checker'],
 
   requiredFields: ['reportPath', 'changesHash', 'qualityGate', 'unitTests'],

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2558,7 +2558,7 @@ describe('enforce-step-workflow', () => {
       const { code } = await runHook(
         {
           tool_name: 'Write',
-          tool_input: { file_path: `${TASKS_DIR}/tests.check.md`, content: '# Check report' },
+          tool_input: { file_path: `${TASKS_DIR}/tests.check.md`, content: 'Status: APPROVED\n# Check report' },
         },
         'PreToolUse',
         { CLAUDE_CURRENT_AGENT: 'quality-checker' }
@@ -2572,7 +2572,7 @@ describe('enforce-step-workflow', () => {
       const { code } = await runHook(
         {
           tool_name: 'Write',
-          tool_input: { file_path: `${TASKS_DIR}/tests.check.md`, content: '# Check report' },
+          tool_input: { file_path: `${TASKS_DIR}/tests.check.md`, content: 'Status: APPROVED\n# Check report' },
         },
         'PreToolUse',
         { CLAUDE_CURRENT_AGENT: 'work-workflow:quality-checker' }

--- a/workflows/lib/__tests__/parse-report-status.test.js
+++ b/workflows/lib/__tests__/parse-report-status.test.js
@@ -1040,3 +1040,60 @@ describe('isCodeReviewResolved — Issues Found list format (write-code-review.j
     assert.equal(result.blockingCount, 0);
   });
 });
+
+// ===========================================================================
+// GH-326 Task 1.3: Freeform fallback patterns
+// ===========================================================================
+describe('parseReportStatus — freeform fallback patterns (GH-326)', () => {
+  it('resolves standalone "**APPROVED**" on own line to APPROVED for codeReview', () => {
+    const content = '# Code Review\n\n**APPROVED**\n\nAll good';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.equal(result.status, 'APPROVED');
+  });
+
+  it('resolves "Overall Assessment: Approved" to APPROVED for codeReview', () => {
+    const content = 'Overall Assessment: Approved\n\nDetails...';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.equal(result.status, 'APPROVED');
+  });
+
+  it('resolves "Result: COMPLETE" to APPROVED for completion type', () => {
+    const content = 'Result: COMPLETE\n\nAll requirements delivered';
+    const result = parseReportStatus(content, 'completion');
+    assert.equal(result.status, 'APPROVED');
+  });
+
+  it('resolves "COMPLETE -- All requirements delivered" to APPROVED for completion', () => {
+    const content = 'COMPLETE \u2014 All requirements delivered';
+    const result = parseReportStatus(content, 'completion');
+    assert.equal(result.status, 'APPROVED');
+  });
+
+  it('resolves standalone "**NEEDS_WORK**" on own line to NEEDS_WORK for codeReview', () => {
+    const content = '# Code Review\n\n**NEEDS_WORK**\n\nSee issues below';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.equal(result.status, 'NEEDS_WORK');
+  });
+
+  it('does NOT let freeform pattern override explicit Status: line', () => {
+    // Explicit Status: NEEDS_WORK should win even if freeform **APPROVED** appears
+    const content = 'Status: NEEDS_WORK\n\n**APPROVED**\nAll good';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.equal(result.status, 'NEEDS_WORK', 'explicit Status: line must take priority');
+  });
+
+  it('does NOT let freeform pattern override summary table', () => {
+    // Summary table should win over freeform
+    const content = '| Status | NEEDS_WORK |\n\n**APPROVED**\nAll good';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.equal(result.status, 'NEEDS_WORK', 'summary table must take priority over freeform');
+  });
+
+  it('freeform pattern takes priority over fail/pass markers', () => {
+    // Freeform "**APPROVED**" should win over a fail marker in the body
+    // (freeform is inserted between summary table and infrastructure failure)
+    const content = '# Code Review\n\n**APPROVED**\n\nSome CRITICAL mention in passing';
+    const result = parseReportStatus(content, 'codeReview');
+    assert.equal(result.status, 'APPROVED', 'freeform should take priority over fail markers');
+  });
+});

--- a/workflows/lib/__tests__/validate-check-report-status.test.js
+++ b/workflows/lib/__tests__/validate-check-report-status.test.js
@@ -1,0 +1,215 @@
+/**
+ * Tests for workflows/lib/validate-check-report-status.js
+ *
+ * GH-326 Task 1.1: Validator that checks Status: line presence in check reports.
+ * These tests are written BEFORE the production code (RED phase).
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { validateCheckReportStatus } = require('../validate-check-report-status');
+
+// ---------------------------------------------------------------------------
+// Valid Status lines per report type
+// ---------------------------------------------------------------------------
+describe('validateCheckReportStatus — valid Status lines', () => {
+  it('accepts "Status: APPROVED" for tests type', () => {
+    const result = validateCheckReportStatus('Status: APPROVED\n# Test Report', 'tests');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts "Status: NEEDS_WORK" for tests type', () => {
+    const result = validateCheckReportStatus('Status: NEEDS_WORK\n# Test Report', 'tests');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts "Status: APPROVED" for codeReview type', () => {
+    const result = validateCheckReportStatus('Status: APPROVED\n# Code Review', 'codeReview');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts "Status: NEEDS_WORK" for codeReview type', () => {
+    const result = validateCheckReportStatus('Status: NEEDS_WORK\n# Code Review', 'codeReview');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts "Status: COMPLETE" for completion type', () => {
+    const result = validateCheckReportStatus('Status: COMPLETE\n# Completion Report', 'completion');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts "Status: INCOMPLETE" for completion type', () => {
+    const result = validateCheckReportStatus(
+      'Status: INCOMPLETE\n# Completion Report',
+      'completion'
+    );
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts "Status: APPROVED" for completion type (base alias)', () => {
+    const result = validateCheckReportStatus(
+      'Status: APPROVED\n# Completion Report',
+      'completion'
+    );
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts "Status: PASS" as alias for APPROVED for tests type', () => {
+    const result = validateCheckReportStatus('Status: PASS\n# Test Report', 'tests');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts "Status: FAIL" as alias for NEEDS_WORK for tests type', () => {
+    const result = validateCheckReportStatus('Status: FAIL\n# Test Report', 'tests');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing Status line
+// ---------------------------------------------------------------------------
+describe('validateCheckReportStatus — missing Status line', () => {
+  it('returns valid: false when no Status line exists', () => {
+    const result = validateCheckReportStatus('# Test Report\nAll tests pass', 'tests');
+    assert.equal(result.valid, false);
+    assert.ok(result.message, 'should include an error message');
+    assert.ok(result.message.includes('Status:'), 'message should mention Status:');
+  });
+
+  it('returns valid: false for content with only prose', () => {
+    const result = validateCheckReportStatus(
+      '# Code Review\n\nLooks good to me.\n\nNo issues found.',
+      'codeReview'
+    );
+    assert.equal(result.valid, false);
+    assert.ok(result.message);
+  });
+
+  it('error message lists valid statuses for the report type', () => {
+    const result = validateCheckReportStatus('# Test Report\nAll tests pass', 'tests');
+    assert.equal(result.valid, false);
+    assert.ok(result.message.includes('APPROVED'), 'should list APPROVED as valid');
+  });
+
+  it('error message lists COMPLETE for completion type', () => {
+    const result = validateCheckReportStatus('# Completion Report', 'completion');
+    assert.equal(result.valid, false);
+    assert.ok(result.message.includes('COMPLETE'), 'should list COMPLETE as valid for completion');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid status for type
+// ---------------------------------------------------------------------------
+describe('validateCheckReportStatus — invalid status for type', () => {
+  it('returns valid: false for Status: COMPLETE on tests type', () => {
+    const result = validateCheckReportStatus('Status: COMPLETE\n# Test Report', 'tests');
+    assert.equal(result.valid, false);
+    assert.ok(result.message, 'should include error message');
+  });
+
+  it('returns valid: false for Status: COMPLETE on codeReview type', () => {
+    const result = validateCheckReportStatus('Status: COMPLETE\n# Code Review', 'codeReview');
+    assert.equal(result.valid, false);
+  });
+
+  it('returns valid: false for Status: SUCCESS on tests type', () => {
+    const result = validateCheckReportStatus('Status: SUCCESS\n# Test Report', 'tests');
+    assert.equal(result.valid, false);
+  });
+
+  it('returns valid: false for Status: GIBBERISH on any type', () => {
+    const result = validateCheckReportStatus('Status: GIBBERISH\n# Report', 'tests');
+    assert.equal(result.valid, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Freeform status words without "Status:" prefix
+// ---------------------------------------------------------------------------
+describe('validateCheckReportStatus — freeform status words (no Status: prefix)', () => {
+  it('returns valid: false for standalone "APPROVED" without Status: prefix', () => {
+    const result = validateCheckReportStatus('# Code Review\n\nAPPROVED\nLooks good', 'codeReview');
+    assert.equal(result.valid, false);
+  });
+
+  it('returns valid: false for standalone "**APPROVED**" without Status: prefix', () => {
+    const result = validateCheckReportStatus(
+      '# Code Review\n\n**APPROVED**\nLooks good',
+      'codeReview'
+    );
+    assert.equal(result.valid, false);
+  });
+
+  it('returns valid: false for "Overall Assessment: Approved" without Status: prefix', () => {
+    const result = validateCheckReportStatus(
+      '# Code Review\n\nOverall Assessment: Approved\nDetails...',
+      'codeReview'
+    );
+    assert.equal(result.valid, false);
+  });
+
+  it('returns valid: false for "Result: COMPLETE" without Status: prefix', () => {
+    const result = validateCheckReportStatus(
+      '# Completion Report\n\nResult: COMPLETE\nAll done.',
+      'completion'
+    );
+    assert.equal(result.valid, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bold markdown variants with Status: prefix
+// ---------------------------------------------------------------------------
+describe('validateCheckReportStatus — bold markdown variants', () => {
+  it('accepts "**Status:** APPROVED"', () => {
+    const result = validateCheckReportStatus('**Status:** APPROVED\n# Report', 'tests');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts "**Status:** **APPROVED**"', () => {
+    const result = validateCheckReportStatus('**Status:** **APPROVED**\n# Report', 'tests');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts "**Status:** **COMPLETE**" for completion type', () => {
+    const result = validateCheckReportStatus(
+      '**Status:** **COMPLETE**\n# Report',
+      'completion'
+    );
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('accepts Status: line with leading whitespace', () => {
+    const result = validateCheckReportStatus('  Status: APPROVED\n# Report', 'tests');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-open on errors (null/undefined input)
+// ---------------------------------------------------------------------------
+describe('validateCheckReportStatus — fail-open on errors', () => {
+  it('returns valid: true for null content', () => {
+    const result = validateCheckReportStatus(null, 'tests');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('returns valid: true for undefined content', () => {
+    const result = validateCheckReportStatus(undefined, 'tests');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('returns valid: true for non-string content', () => {
+    const result = validateCheckReportStatus(42, 'tests');
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('returns valid: true for null reportType', () => {
+    const result = validateCheckReportStatus('Status: APPROVED', null);
+    assert.deepStrictEqual(result, { valid: true });
+  });
+});

--- a/workflows/lib/parse-report-status.js
+++ b/workflows/lib/parse-report-status.js
@@ -101,6 +101,11 @@ TYPE_CHECKS['completion'].fail = ['\\bINCOMPLETE\\b', '\\bPENDING\\b'];
 TYPE_CHECKS['completion'].pass = ['\\bCOMPLETE\\b', '\\bDELIVERED\\b'];
 
 // ---------------------------------------------------------------------------
+// Status line regex — shared with validate-check-report-status.js
+// ---------------------------------------------------------------------------
+const STATUS_LINE_RE = /^\s*\*{0,2}Status:\*{0,2}\s*\*{0,2}\s*([A-Z_]+)\s*\*{0,2}/im;
+
+// ---------------------------------------------------------------------------
 // Format checkers — each returns a normalized status string or null
 // ---------------------------------------------------------------------------
 
@@ -157,8 +162,7 @@ function checkStatusLine(content, type) {
   // not override it. If the first Status: line's value is not recognized for this
   // type, return UNKNOWN to prevent heuristic fallback from overriding an explicit
   // (but type-invalid) declaration.
-  const re = /^\s*\*{0,2}Status:\*{0,2}\s*\*{0,2}\s*([A-Z_]+)\s*\*{0,2}/im;
-  const match = content.match(re);
+  const match = content.match(STATUS_LINE_RE);
   if (!match) return null;
   const raw = match[1].toUpperCase();
   const resolved = resolveAlias(raw, type);
@@ -197,6 +201,65 @@ function checkPassMarkers(content, type) {
   return null;
 }
 
+/**
+ * Check for freeform status patterns in report content.
+ * This is a P1 fallback that catches status declarations agents emit outside
+ * of the canonical "Status: <VALUE>" line or summary table.
+ *
+ * Patterns (checked in order):
+ *   1. Standalone bold status on own line: **APPROVED**, **NEEDS_WORK**, etc.
+ *   2. "Overall Assessment: <status>" pattern
+ *   3. "Result: <status>" pattern
+ *   4. Standalone status at line start followed by dash: COMPLETE — ...
+ *
+ * Only returns a value when the raw match resolves via resolveAlias for the
+ * given type. Returns null otherwise (lets other checks handle it).
+ *
+ * @param {string} content
+ * @param {string} [type] - report type for type-scoped alias resolution
+ * @returns {string|null}
+ */
+function checkFreeformStatus(content, type) {
+  // 1. Standalone bold status on own line
+  const boldMatch = content.match(
+    /^\s*\*{2}(APPROVED|NEEDS_WORK|COMPLETE|INCOMPLETE|PASS|PASSED|FAIL|FAILED)\*{2}\s*$/im
+  );
+  if (boldMatch) {
+    const resolved = resolveAlias(boldMatch[1].toUpperCase(), type);
+    if (resolved) return resolved;
+  }
+
+  // 2. "Overall Assessment: <status>"
+  const assessmentMatch = content.match(
+    /Overall\s+Assessment:\s*(?:✅|❌)?\s*(Approved|Needs[_ ]Work|Pass|Fail)/im
+  );
+  if (assessmentMatch) {
+    const raw = assessmentMatch[1].replace(/[_ ]/g, '_').toUpperCase();
+    const resolved = resolveAlias(raw, type);
+    if (resolved) return resolved;
+  }
+
+  // 3. "Result: <status>"
+  const resultMatch = content.match(
+    /Result:\s*(APPROVED|NEEDS_WORK|COMPLETE|INCOMPLETE|PASS|FAIL)/im
+  );
+  if (resultMatch) {
+    const resolved = resolveAlias(resultMatch[1].toUpperCase(), type);
+    if (resolved) return resolved;
+  }
+
+  // 4. Standalone status at line start followed by dash
+  const dashMatch = content.match(
+    /^(COMPLETE|APPROVED|NEEDS_WORK|INCOMPLETE)\s*[—–-]/m
+  );
+  if (dashMatch) {
+    const resolved = resolveAlias(dashMatch[1].toUpperCase(), type);
+    if (resolved) return resolved;
+  }
+
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -207,6 +270,7 @@ function checkPassMarkers(content, type) {
  * Resolution priority (matches implementation order):
  *   1. Explicit Status: line (first match, authoritative when present)
  *   2. Summary table with status column
+ *   2.5. Freeform fallback patterns (GH-326)
  *   3. Infrastructure failures (QA only — after Status line so declared status wins)
  *   4. Fail markers (type-specific heuristics, only when no explicit status)
  *   5. Pass markers (type-specific heuristics)
@@ -232,6 +296,12 @@ function parseReportStatus(content, type) {
   const tableStatus = checkSummaryTable(content, type);
   if (tableStatus) {
     return { status: tableStatus, icon: ICONS[tableStatus] || ICONS['UNKNOWN'] };
+  }
+
+  // 2.5 Freeform fallback (GH-326)
+  const freeformStatus = checkFreeformStatus(content, type);
+  if (freeformStatus) {
+    return { status: freeformStatus, icon: ICONS[freeformStatus] || ICONS['UNKNOWN'] };
   }
 
   // 3. Infrastructure failures (QA only) — checked AFTER explicit Status/table so that
@@ -503,4 +573,4 @@ function isCodeReviewResolved(reportContent, replyContent) {
   };
 }
 
-module.exports = { parseReportStatus, parseReplyDecisions, isCodeReviewResolved };
+module.exports = { parseReportStatus, parseReplyDecisions, isCodeReviewResolved, resolveAlias, STATUS_LINE_RE };

--- a/workflows/lib/scripts/__tests__/write-report.test.js
+++ b/workflows/lib/scripts/__tests__/write-report.test.js
@@ -250,4 +250,113 @@ describe('write-report', () => {
       assert.ok(result.output.includes('not authorized'));
     });
   });
+
+  // ─── GH-326 Task 1.4: Post-write validation ──────────────────────────────
+  describe('post-write validation (GH-326)', () => {
+    it('rejects formatted output without Status line when reportType is set', () => {
+      // createReportWriter with reportType should validate formatReport output.
+      // A formatReport that returns content without a Status: line should cause
+      // the writer to exit with error.
+      const { createReportWriter } = require(WRITE_REPORT);
+
+      // We test by creating a writer with a reportType and a formatReport that
+      // omits the Status line, then running it via the script pattern.
+      // Since createReportWriter reads from stdin, we need a helper script.
+      const helperScript = path.join('/tmp', 'test-write-report-validation-no-status.js');
+      fs.writeFileSync(
+        helperScript,
+        `
+        const { createReportWriter } = require('${WRITE_REPORT.replace(/\\/g, '\\\\')}');
+        createReportWriter({
+          name: 'Test Writer',
+          allowedAgents: ['test-agent'],
+          requiredFields: ['reportPath'],
+          reportType: 'tests',
+          formatReport: () => '# Test Report\\nAll tests pass\\nNo Status line here',
+        }).run();
+        `,
+        'utf8'
+      );
+
+      writeToken(path.basename(helperScript), 'test-agent', Date.now());
+      const result = runScript(helperScript, { reportPath: REPORT_PATH });
+      // Should fail because formatted output has no valid Status line
+      assert.notEqual(result.exitCode, 0, 'should reject output without Status line');
+      assert.ok(
+        result.output.includes('Status') || result.output.includes('status'),
+        'error should mention Status'
+      );
+
+      try {
+        fs.unlinkSync(helperScript);
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('accepts formatted output with valid Status line when reportType is set', () => {
+      const helperScript = path.join('/tmp', 'test-write-report-validation-with-status.js');
+      fs.writeFileSync(
+        helperScript,
+        `
+        const { createReportWriter } = require('${WRITE_REPORT.replace(/\\/g, '\\\\')}');
+        createReportWriter({
+          name: 'Test Writer',
+          allowedAgents: ['test-agent'],
+          requiredFields: ['reportPath'],
+          reportType: 'tests',
+          formatReport: () => 'Status: APPROVED\\n# Test Report\\nAll tests pass',
+        }).run();
+        `,
+        'utf8'
+      );
+
+      writeToken(path.basename(helperScript), 'test-agent', Date.now());
+      const result = runScript(helperScript, { reportPath: REPORT_PATH });
+      assert.equal(result.exitCode, 0, 'should accept output with valid Status line');
+
+      try {
+        fs.unlinkSync(helperScript);
+      } catch {
+        /* ignore */
+      }
+      try {
+        fs.unlinkSync(REPORT_PATH);
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('skips validation when reportType is not set (backward compat)', () => {
+      const helperScript = path.join('/tmp', 'test-write-report-validation-no-type.js');
+      fs.writeFileSync(
+        helperScript,
+        `
+        const { createReportWriter } = require('${WRITE_REPORT.replace(/\\/g, '\\\\')}');
+        createReportWriter({
+          name: 'Test Writer',
+          allowedAgents: ['test-agent'],
+          requiredFields: ['reportPath'],
+          formatReport: () => '# Report\\nNo Status line but no reportType either',
+        }).run();
+        `,
+        'utf8'
+      );
+
+      writeToken(path.basename(helperScript), 'test-agent', Date.now());
+      const result = runScript(helperScript, { reportPath: REPORT_PATH });
+      assert.equal(result.exitCode, 0, 'should skip validation when no reportType');
+
+      try {
+        fs.unlinkSync(helperScript);
+      } catch {
+        /* ignore */
+      }
+      try {
+        fs.unlinkSync(REPORT_PATH);
+      } catch {
+        /* ignore */
+      }
+    });
+  });
 });

--- a/workflows/lib/scripts/write-report.js
+++ b/workflows/lib/scripts/write-report.js
@@ -111,6 +111,7 @@ function consumeToken(scriptBasename) {
  * @property {string[]} requiredFields — Field names that must be present in input
  * @property {(input: object) => string} formatReport — Function that formats input into markdown
  * @property {(input: object) => string[]} [validate] — Optional extra validation (returns error messages)
+ * @property {string} [reportType] — Report type for post-write status validation (e.g. 'tests', 'codeReview', 'completion')
  */
 
 /**
@@ -120,7 +121,7 @@ function consumeToken(scriptBasename) {
  * @returns {{ run: () => Promise<void> }}
  */
 function createReportWriter(config) {
-  const { name, allowedAgents, requiredFields, formatReport, validate } = config;
+  const { name, allowedAgents, requiredFields, formatReport, validate, reportType } = config;
 
   async function run() {
     // Parse input from stdin (JSON)
@@ -243,6 +244,22 @@ function createReportWriter(config) {
     }
 
     const newContent = formatReport(input);
+
+    // Post-write validation: verify formatted output has a parseable Status line (GH-326)
+    if (reportType) {
+      const { STATUS_LINE_RE, resolveAlias } = require('../parse-report-status');
+      const statusMatch = newContent.match(STATUS_LINE_RE);
+      const hasValidStatus = statusMatch && resolveAlias(statusMatch[1].toUpperCase(), reportType);
+      if (!hasValidStatus) {
+        process.stderr.write(
+          `[${name}] VALIDATION FAILED: Formatted report has no parseable Status line.\n` +
+          `  parseReportStatus returned: ${hasValidStatus ? 'valid' : 'UNKNOWN'}\n` +
+          `  The formatReport() function must include a "Status: <VALUE>" line.\n` +
+          `  This is a bug in the report writer, not in the agent input.\n`
+        );
+        process.exit(1);
+      }
+    }
 
     // Prepend strategy: if file exists, preserve old content with separator
     let finalContent = newContent;

--- a/workflows/lib/validate-check-report-status.js
+++ b/workflows/lib/validate-check-report-status.js
@@ -35,7 +35,8 @@ function getValidStatusValues(reportType) {
  */
 function validateCheckReportStatus(content, reportType) {
   try {
-    if (!content || typeof content !== 'string') return { valid: true }; // fail-open
+    if (content === null || content === undefined || typeof content !== 'string') return { valid: true }; // fail-open for null/undefined/non-string
+    // Empty string is treated as missing Status (not fail-open) — check-gate blocks empty reports
 
     const match = content.match(STATUS_LINE_RE);
     if (!match) {

--- a/workflows/lib/validate-check-report-status.js
+++ b/workflows/lib/validate-check-report-status.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { resolveAlias, STATUS_LINE_RE } = require('./parse-report-status');
+
+// Valid statuses per report type (Object.create(null) per project convention)
+const VALID_STATUSES = Object.create(null);
+VALID_STATUSES['tests'] = ['APPROVED', 'NEEDS_WORK', 'NOT_APPLICABLE'];
+VALID_STATUSES['codeReview'] = ['APPROVED', 'NEEDS_WORK', 'NOT_APPLICABLE'];
+VALID_STATUSES['completion'] = ['APPROVED', 'NEEDS_WORK', 'NOT_APPLICABLE']; // COMPLETE/INCOMPLETE resolve via aliases
+
+// Human-readable valid values per type (includes aliases for user guidance)
+const VALID_VALUES = Object.create(null);
+VALID_VALUES['completion'] = ['APPROVED', 'NEEDS_WORK', 'COMPLETE', 'INCOMPLETE', 'NOT_APPLICABLE'];
+VALID_VALUES['tests'] = ['APPROVED', 'NEEDS_WORK', 'PASS', 'PASSED', 'FAIL', 'FAILED', 'NOT_APPLICABLE'];
+VALID_VALUES['codeReview'] = ['APPROVED', 'NEEDS_WORK', 'PASS', 'PASSED', 'FAIL', 'FAILED', 'NOT_APPLICABLE'];
+
+/**
+ * Get human-readable valid status values for a report type.
+ * @param {string} reportType
+ * @returns {string[]}
+ */
+function getValidStatusValues(reportType) {
+  return VALID_VALUES[reportType] || ['APPROVED', 'NEEDS_WORK', 'NOT_APPLICABLE'];
+}
+
+/**
+ * Validate that check report content contains a valid Status: line.
+ *
+ * Fail-open: returns { valid: true } for null/undefined/non-string content
+ * or when an internal error occurs.
+ *
+ * @param {string|null|undefined} content - Report file content
+ * @param {string} reportType - One of 'tests', 'codeReview', 'completion'
+ * @returns {{ valid: boolean, message?: string }}
+ */
+function validateCheckReportStatus(content, reportType) {
+  try {
+    if (!content || typeof content !== 'string') return { valid: true }; // fail-open
+
+    const match = content.match(STATUS_LINE_RE);
+    if (!match) {
+      const validValues = getValidStatusValues(reportType);
+      return {
+        valid: false,
+        message: `BLOCKED: Report content must contain a Status: line.\n` +
+          `Expected format: Status: <VALUE> or **Status:** <VALUE>\n` +
+          `Valid values for ${reportType} reports: ${validValues.join(', ')}\n` +
+          `Example: Status: APPROVED`,
+      };
+    }
+
+    const raw = match[1].toUpperCase();
+    const resolved = resolveAlias(raw, reportType);
+    if (!resolved) {
+      const validValues = getValidStatusValues(reportType);
+      return {
+        valid: false,
+        message: `BLOCKED: Status value "${raw}" is not valid for ${reportType} reports.\n` +
+          `Valid values: ${validValues.join(', ')}`,
+      };
+    }
+
+    return { valid: true };
+  } catch {
+    return { valid: true }; // fail-open on errors
+  }
+}
+
+module.exports = { validateCheckReportStatus };

--- a/workflows/work/__tests__/workflow-definition.test.js
+++ b/workflows/work/__tests__/workflow-definition.test.js
@@ -700,3 +700,96 @@ describe('workflow-definition: verify[STEPS.check] QA report gating', () => {
     );
   });
 });
+
+// ─── GH-326 Task 1.2: .check.md contentGuard ─────────────────────────────────
+describe('workflow-definition: .check.md contentGuard', () => {
+  const { artifactRules } = createWorkflowDefinition(stubDeps);
+
+  function getRule(basename) {
+    return artifactRules.find((r) => r.basename === basename);
+  }
+
+  // --- contentGuard presence ---
+  it('has a contentGuard on tests.check.md artifact rule', () => {
+    const rule = getRule('tests.check.md');
+    assert.equal(typeof rule.contentGuard, 'function');
+  });
+
+  it('has a contentGuard on code-review.check.md artifact rule', () => {
+    const rule = getRule('code-review.check.md');
+    assert.equal(typeof rule.contentGuard, 'function');
+  });
+
+  it('has a contentGuard on completion.check.md artifact rule', () => {
+    const rule = getRule('completion.check.md');
+    assert.equal(typeof rule.contentGuard, 'function');
+  });
+
+  // --- contentGuard blocks missing Status line ---
+  it('blocks tests.check.md without Status line', () => {
+    const rule = getRule('tests.check.md');
+    const result = rule.contentGuard('# Test Report\nAll tests pass', STEPS.check);
+    assert.equal(result.blocked, true);
+    assert.ok(result.message.includes('Status:'), 'message should mention Status:');
+  });
+
+  it('blocks code-review.check.md without Status line', () => {
+    const rule = getRule('code-review.check.md');
+    const result = rule.contentGuard('# Code Review\nLooks good', STEPS.check);
+    assert.equal(result.blocked, true);
+    assert.ok(result.message);
+  });
+
+  it('blocks completion.check.md without Status line', () => {
+    const rule = getRule('completion.check.md');
+    const result = rule.contentGuard('# Completion Report\nAll done', STEPS.check);
+    assert.equal(result.blocked, true);
+    assert.ok(result.message);
+  });
+
+  // --- contentGuard allows valid Status line ---
+  it('allows tests.check.md with "Status: APPROVED"', () => {
+    const rule = getRule('tests.check.md');
+    const result = rule.contentGuard('Status: APPROVED\n# Test Report', STEPS.check);
+    assert.equal(result.blocked, false);
+  });
+
+  it('allows code-review.check.md with "Status: NEEDS_WORK"', () => {
+    const rule = getRule('code-review.check.md');
+    const result = rule.contentGuard('Status: NEEDS_WORK\n# Code Review', STEPS.check);
+    assert.equal(result.blocked, false);
+  });
+
+  it('allows completion.check.md with "Status: COMPLETE"', () => {
+    const rule = getRule('completion.check.md');
+    const result = rule.contentGuard('Status: COMPLETE\n# Completion Report', STEPS.check);
+    assert.equal(result.blocked, false);
+  });
+
+  // --- contentGuard blocks invalid status for type ---
+  it('blocks tests.check.md with Status: COMPLETE (invalid for tests)', () => {
+    const rule = getRule('tests.check.md');
+    const result = rule.contentGuard('Status: COMPLETE\n# Test Report', STEPS.check);
+    assert.equal(result.blocked, true);
+  });
+
+  it('blocks code-review.check.md with Status: COMPLETE (invalid for codeReview)', () => {
+    const rule = getRule('code-review.check.md');
+    const result = rule.contentGuard('Status: COMPLETE\n# Code Review', STEPS.check);
+    assert.equal(result.blocked, true);
+  });
+
+  // --- contentGuard allows bold markdown variants ---
+  it('allows tests.check.md with "**Status:** **APPROVED**"', () => {
+    const rule = getRule('tests.check.md');
+    const result = rule.contentGuard('**Status:** **APPROVED**\n# Report', STEPS.check);
+    assert.equal(result.blocked, false);
+  });
+
+  // --- contentGuard blocks freeform status without Status: prefix ---
+  it('blocks code-review.check.md with standalone "**APPROVED**" (no Status: prefix)', () => {
+    const rule = getRule('code-review.check.md');
+    const result = rule.contentGuard('# Code Review\n\n**APPROVED**\nLooks good', STEPS.check);
+    assert.equal(result.blocked, true);
+  });
+});

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -609,9 +609,36 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
     { basename: 'spec.md', step: STEPS.spec, agents: ['spec-writer'] },
     { basename: 'tasks.md', step: STEPS.tasks, allowedSteps: [STEPS.task_review], agents: [] },
     { basename: '.last-commit-sha', step: STEPS.commit },
-    { basename: 'code-review.check.md', step: STEPS.check, agents: ['code-checker'] },
-    { basename: 'tests.check.md', step: STEPS.check, agents: ['quality-checker'] },
-    { basename: 'completion.check.md', step: STEPS.check, agents: ['completion-checker'] },
+    {
+      basename: 'code-review.check.md',
+      step: STEPS.check,
+      agents: ['code-checker'],
+      contentGuard: (content) => {
+        const { validateCheckReportStatus } = require(path.join(__dirname, '..', 'lib', 'validate-check-report-status'));
+        const result = validateCheckReportStatus(content, 'codeReview');
+        return result.valid ? { blocked: false } : { blocked: true, message: result.message };
+      },
+    },
+    {
+      basename: 'tests.check.md',
+      step: STEPS.check,
+      agents: ['quality-checker'],
+      contentGuard: (content) => {
+        const { validateCheckReportStatus } = require(path.join(__dirname, '..', 'lib', 'validate-check-report-status'));
+        const result = validateCheckReportStatus(content, 'tests');
+        return result.valid ? { blocked: false } : { blocked: true, message: result.message };
+      },
+    },
+    {
+      basename: 'completion.check.md',
+      step: STEPS.check,
+      agents: ['completion-checker'],
+      contentGuard: (content) => {
+        const { validateCheckReportStatus } = require(path.join(__dirname, '..', 'lib', 'validate-check-report-status'));
+        const result = validateCheckReportStatus(content, 'completion');
+        return result.valid ? { blocked: false } : { blocked: true, message: result.message };
+      },
+    },
     {
       pattern: /^qa-.*\.check\.md$/,
       step: STEPS.check,


### PR DESCRIPTION
## Existing Behavior

- `parseReportStatus()` requires a canonical `Status: <VALUE>` line in `.check.md` reports to determine pass/fail state, returning `UNKNOWN` when the line is absent.
- Check agents (`code-checker`, `quality-checker`, `completion-checker`) can write `.check.md` files containing only freeform prose or bold status markers (e.g. `**APPROVED**`) without a `Status:` prefix, causing `parseReportStatus` to return `UNKNOWN`.
- When `parseReportStatus` returns `UNKNOWN` for any check report, the check-to-pr gate treats the report as unresolved and blocks the workflow permanently.
- `createReportWriter` performs no post-write validation of the formatted content it writes to disk, so `formatReport` regressions producing Status-less output go undetected at write time.

## Intended New Behavior

- The artifact rules for `code-review.check.md`, `tests.check.md`, and `completion.check.md` in `workflow-definition.js` now carry a `contentGuard` that calls `validateCheckReportStatus` before any Write/Edit is allowed, blocking direct file writes that lack a valid `Status:` line.
- A new `validateCheckReportStatus` module (`workflows/lib/validate-check-report-status.js`) validates that report content contains a `Status: <VALUE>` line with a type-valid value, returning a structured `{ valid, message }` result; it fails open on null/undefined input to avoid blocking unrelated writes.
- `parseReportStatus` gains a `checkFreeformStatus` fallback (priority 2.5) that recognises standalone bold status markers (`**APPROVED**`), `Overall Assessment:`, `Result:`, and dash-prefixed status lines as defense-in-depth for legacy report formats, inserted after the summary table check but before infrastructure failure markers.
- `createReportWriter` now accepts a `reportType` option and validates the `formatReport()` output against `STATUS_LINE_RE` before writing to disk, exiting with a clear error message when the formatted content lacks a parseable Status line.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify contentGuard blocks Status-less writes:**
1. Trigger a check step that produces a report without a `Status:` line (e.g. patch `write-code-review.js` `formatReport` to omit the Status line temporarily).
2. Observe that the write is blocked with a message containing `Status:` and valid values.
3. Add `Status: APPROVED` to the content and confirm the write succeeds.

**Verify freeform fallback in parseReportStatus:**
1. Call `parseReportStatus('# Code Review\n\n**APPROVED**\nAll good', 'codeReview')`.
2. Confirm the returned status is `APPROVED` rather than `UNKNOWN`.
3. Confirm that a content containing both `Status: NEEDS_WORK` and `**APPROVED**` returns `NEEDS_WORK` (explicit Status: line wins).

**Verify post-write validation in createReportWriter:**
1. Create a writer with `reportType: 'tests'` and a `formatReport` that returns content without a `Status:` line.
2. Run the writer — confirm it exits non-zero with an error referencing `Status`.
3. Update `formatReport` to return `Status: APPROVED\n...` and confirm exit code 0.

### Test Results
New and updated test files:
- `workflows/lib/__tests__/parse-report-status.test.js` — 7 new freeform fallback cases
- `workflows/lib/__tests__/validate-check-report-status.test.js` — 215-line new test suite (valid lines, missing line, invalid type, freeform rejection, bold markdown variants, fail-open)
- `workflows/lib/scripts/__tests__/write-report.test.js` — 3 new post-write validation cases
- `workflows/work/__tests__/workflow-definition.test.js` — 18 new contentGuard cases