### PR TITLE
fix(spec-verify): match local symbol definitions in REUSES check

### DIFF
--- a/workflows/check/scripts/__tests__/spec-verify.test.js
+++ b/workflows/check/scripts/__tests__/spec-verify.test.js
@@ -312,4 +312,104 @@ describe('spec-verify.js', () => {
     const json = JSON.parse(result.stdout);
     assert.equal(json.checks[0].passed, false);
   });
+
+  // ── REUSES local definitions (GH-327) ──────────────────────────────────
+
+  describe('REUSES local definitions (GH-327)', () => {
+    // --- Local definitions (RED — production code does not support yet) ---
+
+    it('REUSES detects local function declaration', () => {
+      writeFile('src/utils.js', 'function ghExec(args) { return args; }');
+      const specPath = writeSpec(['- REUSES src/utils.js ghExec']);
+      const result = runScript(specPath, { json: true });
+      assert.equal(result.exitCode, 0);
+      const json = JSON.parse(result.stdout);
+      assert.equal(json.checks[0].passed, true);
+    });
+
+    it('REUSES detects local const assignment', () => {
+      writeFile('src/utils.js', 'const ghExec = (args) => args;');
+      const specPath = writeSpec(['- REUSES src/utils.js ghExec']);
+      const result = runScript(specPath, { json: true });
+      assert.equal(result.exitCode, 0);
+      const json = JSON.parse(result.stdout);
+      assert.equal(json.checks[0].passed, true);
+    });
+
+    it('REUSES detects local let assignment', () => {
+      writeFile('src/utils.js', 'let counter = 0;');
+      const specPath = writeSpec(['- REUSES src/utils.js counter']);
+      const result = runScript(specPath, { json: true });
+      assert.equal(result.exitCode, 0);
+      const json = JSON.parse(result.stdout);
+      assert.equal(json.checks[0].passed, true);
+    });
+
+    it('REUSES detects local var assignment', () => {
+      writeFile('src/utils.js', 'var oldStyle = true;');
+      const specPath = writeSpec(['- REUSES src/utils.js oldStyle']);
+      const result = runScript(specPath, { json: true });
+      assert.equal(result.exitCode, 0);
+      const json = JSON.parse(result.stdout);
+      assert.equal(json.checks[0].passed, true);
+    });
+
+    // --- Regression tests (should PASS with current code) ---
+
+    it('REUSES regression: ES import still passes', () => {
+      writeFile('src/app.js', 'import { useAuth } from "./hooks";');
+      const specPath = writeSpec(['- REUSES src/app.js useAuth']);
+      const result = runScript(specPath, { json: true });
+      assert.equal(result.exitCode, 0);
+      const json = JSON.parse(result.stdout);
+      assert.equal(json.checks[0].passed, true);
+    });
+
+    it('REUSES regression: require import still passes', () => {
+      writeFile('src/app.js', "const { useAuth } = require('./hooks');");
+      const specPath = writeSpec(['- REUSES src/app.js useAuth']);
+      const result = runScript(specPath, { json: true });
+      assert.equal(result.exitCode, 0);
+      const json = JSON.parse(result.stdout);
+      assert.equal(json.checks[0].passed, true);
+    });
+
+    // --- Negative tests (should correctly FAIL) ---
+
+    it('REUSES fails when symbol is not present in file', () => {
+      writeFile('src/app.js', 'const x = 1;');
+      const specPath = writeSpec(['- REUSES src/app.js nonExistent']);
+      const result = runScript(specPath, { json: true });
+      assert.equal(result.exitCode, 1);
+      const json = JSON.parse(result.stdout);
+      assert.equal(json.checks[0].passed, false);
+    });
+
+    it('REUSES fails for commented-out function definition', () => {
+      writeFile('src/app.js', '// function ghExec(args) {}');
+      const specPath = writeSpec(['- REUSES src/app.js ghExec']);
+      const result = runScript(specPath, { json: true });
+      assert.equal(result.exitCode, 1);
+      const json = JSON.parse(result.stdout);
+      assert.equal(json.checks[0].passed, false);
+    });
+
+    it('REUSES fails for block-commented definition', () => {
+      writeFile('src/app.js', '/* const ghExec = 1; */\nconst x = 2;');
+      const specPath = writeSpec(['- REUSES src/app.js ghExec']);
+      const result = runScript(specPath, { json: true });
+      assert.equal(result.exitCode, 1);
+      const json = JSON.parse(result.stdout);
+      assert.equal(json.checks[0].passed, false);
+    });
+
+    it('REUSES fails for partial name match (word boundary)', () => {
+      writeFile('src/app.js', 'function ghExecHelper(args) {}');
+      const specPath = writeSpec(['- REUSES src/app.js ghExec']);
+      const result = runScript(specPath, { json: true });
+      assert.equal(result.exitCode, 1);
+      const json = JSON.parse(result.stdout);
+      assert.equal(json.checks[0].passed, false);
+    });
+  });
 });

--- a/workflows/check/scripts/__tests__/spec-verify.test.js
+++ b/workflows/check/scripts/__tests__/spec-verify.test.js
@@ -383,6 +383,7 @@ describe('spec-verify.js', () => {
       assert.equal(result.exitCode, 1);
       const json = JSON.parse(result.stdout);
       assert.equal(json.checks[0].passed, false);
+      assert.ok(json.checks[0].reason.includes('definition'), 'reason should mention definition');
     });
 
     it('REUSES fails for commented-out function definition', () => {

--- a/workflows/check/scripts/spec-verify.js
+++ b/workflows/check/scripts/spec-verify.js
@@ -426,7 +426,7 @@ function checkReuses(args, root) {
     type: 'REUSES',
     args,
     passed: false,
-    reason: `Expected import matching "${importPattern}" in ${filePath} — not found`,
+    reason: `Expected import or definition matching "${importPattern}" in ${filePath} — not found`,
   };
 }
 

--- a/workflows/check/scripts/spec-verify.js
+++ b/workflows/check/scripts/spec-verify.js
@@ -410,6 +410,18 @@ function checkReuses(args, root) {
       return { type: 'REUSES', args, passed: true };
     }
   }
+  // Check for local definitions: function SYMBOL(, const/let/var SYMBOL =
+  const defRegex = new RegExp(
+    `(?:function\\s+${escaped}(?![a-zA-Z0-9_$])\\s*\\(|(?:const|let|var)\\s+${escaped}(?![a-zA-Z0-9_$])\\s*[=,;)])`
+  );
+  if (
+    lines.some((line) => {
+      const m = defRegex.exec(line);
+      return m && !isInsideString(line, m.index);
+    })
+  ) {
+    return { type: 'REUSES', args, passed: true };
+  }
   return {
     type: 'REUSES',
     args,


### PR DESCRIPTION
## Existing Behavior

- The `REUSES` check in `spec-verify.js` only searched for import/require patterns (`import ... from`, `require(...)`) to verify that a symbol is reused in a given file.
- When a spec used `REUSES` to assert a symbol that was defined locally (e.g., `function myHelper()` or `const myHelper = ...`), the check would fail with a false positive gate failure even though the symbol was present and in use.
- The failure reason message referenced only "import matching" which was misleading for the actual scope of the check.

## Intended New Behavior

- The `REUSES` check now also matches locally-defined symbols: `function SYMBOL(` declarations and `const/let/var SYMBOL =` assignments in the target file.
- Specs that require locally-defined helpers, utilities, or factory functions pass the gate without needing an import statement, eliminating false positive failures.
- The failure reason message is updated to "Expected import or definition matching" to accurately reflect both matching strategies.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Create a spec.md with a `## Verification Checklist` section containing a `REUSES` marker targeting a symbol that is defined locally in a file (not imported):
   ```
   - REUSES src/utils.js myHelperFn
   ```
2. In `src/utils.js`, define the symbol locally:
   ```js
   function myHelperFn() { ... }
   ```
3. Run `node workflows/check/scripts/spec-verify.js spec.md --root .`
4. Confirm the check now reports `[PASS] REUSES src/utils.js myHelperFn` instead of a false positive `[FAIL]`.
5. Verify a missing symbol still fails: remove `myHelperFn` from the file and rerun — confirm `[FAIL]` with the updated message "Expected import or definition matching".

Closes #327

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the `REUSES` gate’s matching logic, which could change pass/fail outcomes for spec checks if the new regex misidentifies symbols; coverage is improved with targeted tests to reduce this risk.
> 
> **Overview**
> Fixes `spec-verify`’s `REUSES` check to treat *local symbol definitions* as valid reuse, not just `import`/`require` usage (adds detection for `function NAME(` and `const`/`let`/`var NAME =`-style declarations with basic word-boundary protection).
> 
> Extends the unit tests to cover these new definition cases plus negative/regression scenarios (commented-out definitions, partial matches, missing symbols), and updates the failure message to say **"import or definition"** when no match is found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b7579e418aa6695f826967ec374636bc0d20949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Test Results

| Test | Status | Notes |
|------|--------|-------|
| REUSES detects local function declaration | PASS | New regex matches function SYMBOL( pattern |
| REUSES detects local const/let/var assignment | PASS | New regex matches const/let/var SYMBOL = pattern |
| REUSES regression: ES import still passes | PASS | Existing import behavior preserved |
| REUSES regression: require import still passes | PASS | Existing require behavior preserved |
| REUSES negative: commented-out definition | PASS | Correctly rejects |
| REUSES negative: partial name match | PASS | Correctly rejects |
| All spec-verify unit tests (GH-327 scope) | PASS | 35/35 pass, 0 failures |

> 16 pre-existing failures in enforce-screenshot-requirement.test.js (15) and session-guard.test.js (1) exist on main independent of this branch and are out of scope for GH-327.