### PR TITLE
fix(cleanup-worktrees): force fresh analysis on every invocation

### DIFF
--- a/skills/cleanup-worktrees/SKILL.md
+++ b/skills/cleanup-worktrees/SKILL.md
@@ -4,6 +4,16 @@ description: Safely clean up git worktrees by verifying code has been merged to 
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion, mcp__atlassian__jira_search, mcp__atlassian__jira_get_issue, mcp__atlassian__jira_get_transitions, mcp__atlassian__jira_transition_issue, mcp__linear__get_issue
 ---
+
+**CRITICAL**: Every invocation of this command MUST discard all prior analysis results, cached data, and previous conclusions — and start from scratch. Re-analyze every worktree fresh, regardless of any earlier runs.
+
+Before any analysis, you MUST:
+1. Run `git fetch --prune origin` to get the latest remote state and remove stale tracking branches
+2. Re-check PR status via `gh pr view` for every worktree branch — never rely on cached PR data
+3. Re-check every worktree for uncommitted changes and unpushed commits — previous results are invalid
+
+Begin output with: "Fresh analysis started — all prior results discarded."
+
 # Cleanup Worktrees Command
 
 Safely clean up git worktrees by thoroughly verifying code has been merged to main.
@@ -18,7 +28,7 @@ Safely clean up git worktrees by thoroughly verifying code has been merged to ma
 
 ```bash
 cd ~/$REPO_NAME
-git fetch origin main
+git fetch --prune origin
 git worktree list
 ```
 

--- a/skills/cleanup-worktrees/SKILL.md
+++ b/skills/cleanup-worktrees/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion, mcp__atlassian__jira_sea
 
 Before any analysis, you MUST:
 1. Run `git fetch --prune origin` to get the latest remote state and remove stale tracking branches
-2. Re-check PR status via `gh pr view` for every worktree branch — never rely on cached PR data
+2. Re-check PR status for every worktree branch — never rely on cached PR data
 3. Re-check every worktree for uncommitted changes and unpushed commits — previous results are invalid
 
 Begin output with: "Fresh analysis started — all prior results discarded."

--- a/skills/cleanup-worktrees/__tests__/skill-md-content.test.js
+++ b/skills/cleanup-worktrees/__tests__/skill-md-content.test.js
@@ -53,8 +53,8 @@ describe('cleanup-worktrees SKILL.md — fresh-data preamble (GH-90)', () => {
       assert.ok(preamble, 'preamble must exist');
       assert.match(
         preamble,
-        /discard|re-analy[sz]e|from scratch/i,
-        'Preamble must instruct to discard cached data or re-analyze from scratch'
+        /discard.*prior|re-analy[sz]e.*from scratch|from scratch.*re-analy[sz]e/i,
+        'Preamble must instruct to discard prior results or re-analyze from scratch'
       );
     });
 
@@ -93,8 +93,8 @@ describe('cleanup-worktrees SKILL.md — fresh-data preamble (GH-90)', () => {
       assert.ok(preamble, 'preamble must exist');
       assert.match(
         preamble,
-        /fresh analysis/i,
-        'Preamble must include a "Fresh analysis" instruction'
+        /fresh analysis.*discarded|fresh analysis.*started/i,
+        'Preamble must include a "Fresh analysis started" output instruction'
       );
     });
   });

--- a/skills/cleanup-worktrees/__tests__/skill-md-content.test.js
+++ b/skills/cleanup-worktrees/__tests__/skill-md-content.test.js
@@ -1,0 +1,139 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SKILL_PATH = path.resolve(__dirname, '..', 'SKILL.md');
+const content = fs.readFileSync(SKILL_PATH, 'utf-8');
+
+/**
+ * Extract the preamble: content between the closing `---` of frontmatter
+ * and the `# Cleanup Worktrees Command` heading.
+ */
+function getPreamble() {
+  // Find the second `---` (end of frontmatter)
+  const firstIdx = content.indexOf('---');
+  if (firstIdx === -1) return null;
+  const secondIdx = content.indexOf('---', firstIdx + 3);
+  if (secondIdx === -1) return null;
+  const afterFrontmatter = content.slice(secondIdx + 3);
+
+  // Find the heading
+  const headingIdx = afterFrontmatter.indexOf('# Cleanup Worktrees Command');
+  if (headingIdx === -1) return null;
+
+  const preamble = afterFrontmatter.slice(0, headingIdx).trim();
+  return preamble.length > 0 ? preamble : null;
+}
+
+/**
+ * Extract the Step 1 section content.
+ */
+function getStep1Section() {
+  const start = content.search(/^### Step 1:/m);
+  if (start === -1) return null;
+  const rest = content.slice(start);
+  const nextStep = rest.slice(1).search(/\n### Step [0-9]/);
+  if (nextStep === -1) return rest;
+  return rest.slice(0, nextStep + 1);
+}
+
+describe('cleanup-worktrees SKILL.md — fresh-data preamble (GH-90)', () => {
+  describe('Preamble exists and enforces fresh analysis', () => {
+    it('preamble exists between frontmatter and heading', () => {
+      const preamble = getPreamble();
+      assert.ok(
+        preamble,
+        'SKILL.md must have content between the closing --- of frontmatter and # Cleanup Worktrees Command'
+      );
+    });
+
+    it('preamble contains discard/re-analyze directive', () => {
+      const preamble = getPreamble();
+      assert.ok(preamble, 'preamble must exist');
+      assert.match(
+        preamble,
+        /discard|re-analy[sz]e|from scratch/i,
+        'Preamble must instruct to discard cached data or re-analyze from scratch'
+      );
+    });
+
+    it('preamble mandates git fetch --prune origin', () => {
+      const preamble = getPreamble();
+      assert.ok(preamble, 'preamble must exist');
+      assert.match(
+        preamble,
+        /git fetch --prune origin/,
+        'Preamble must mandate running git fetch --prune origin'
+      );
+    });
+
+    it('preamble mandates re-checking PR status', () => {
+      const preamble = getPreamble();
+      assert.ok(preamble, 'preamble must exist');
+      assert.match(
+        preamble,
+        /PR status|gh pr view|pull request.*status/i,
+        'Preamble must mandate re-checking PR status'
+      );
+    });
+
+    it('preamble mandates re-checking uncommitted/unpushed work', () => {
+      const preamble = getPreamble();
+      assert.ok(preamble, 'preamble must exist');
+      assert.match(
+        preamble,
+        /uncommitted|unpushed/i,
+        'Preamble must mandate checking for uncommitted or unpushed work'
+      );
+    });
+
+    it('preamble includes Fresh analysis output instruction', () => {
+      const preamble = getPreamble();
+      assert.ok(preamble, 'preamble must exist');
+      assert.match(
+        preamble,
+        /fresh analysis/i,
+        'Preamble must include a "Fresh analysis" instruction'
+      );
+    });
+  });
+
+  describe('Step 1 uses correct fetch command', () => {
+    it('Step 1 uses git fetch --prune origin', () => {
+      const step1 = getStep1Section();
+      assert.ok(step1, 'Step 1 section must exist');
+      assert.match(
+        step1,
+        /git fetch --prune origin/,
+        'Step 1 must use "git fetch --prune origin" not "git fetch origin main"'
+      );
+    });
+  });
+
+  describe('Existing structure preserved', () => {
+    it('contains # Cleanup Worktrees Command heading', () => {
+      assert.match(
+        content,
+        /^# Cleanup Worktrees Command$/m,
+        'SKILL.md must contain the "# Cleanup Worktrees Command" heading'
+      );
+    });
+
+    it('contains ## Philosophy section', () => {
+      assert.match(
+        content,
+        /^## Philosophy/m,
+        'SKILL.md must contain the "## Philosophy" section'
+      );
+    });
+
+    it('contains ## Instructions section', () => {
+      assert.match(
+        content,
+        /^## Instructions$/m,
+        'SKILL.md must contain the "## Instructions" section'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Existing Behavior

- The `/cleanup-worktrees` skill analyzed worktrees and cached those results in conversation context across subsequent invocations.
- The `git fetch` command in Step 1 used `git fetch origin main`, which fetched the main branch but did not prune stale remote-tracking branches.
- No explicit instruction existed to discard prior results, so the agent could silently reuse stale PR merge status, uncommitted-change checks, and worktree state from an earlier run in the same conversation.

## Intended New Behavior

- A mandatory CRITICAL preamble is added at the top of `SKILL.md` (before the `# Cleanup Worktrees Command` heading) instructing the agent to discard all prior analysis results and re-analyze every worktree from scratch on every invocation.
- The Step 1 fetch command is updated to `git fetch --prune origin`, ensuring stale remote-tracking branches are removed and the full latest remote state is retrieved.
- The preamble requires re-checking PR status via `gh pr view`, uncommitted changes, and unpushed commits on every invocation — never relying on cached data.
- A new test file (`skills/cleanup-worktrees/__tests__/skill-md-content.test.js`) verifies the preamble and Step 1 command are structurally correct and contain all required directives.

Closes #90

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a documentation/skill-instruction change. Verify the fix as follows:

1. Run the new test suite to confirm structural requirements are enforced:
   ```bash
   node --test skills/cleanup-worktrees/__tests__/skill-md-content.test.js
   ```
   Expected: all 9 tests pass.

2. Open `skills/cleanup-worktrees/SKILL.md` and confirm the preamble block appears immediately after the closing `---` of the frontmatter and before `# Cleanup Worktrees Command`.

3. Invoke `/cleanup-worktrees` in a session, let it analyze some worktrees, then invoke it again without clearing context. Confirm the agent outputs "Fresh analysis started — all prior results discarded." and re-runs `git fetch --prune origin` before any analysis.

4. Verify Step 1 in the skill now reads `git fetch --prune origin` (not `git fetch origin main`).

### Test Results

All tests in `skills/cleanup-worktrees/__tests__/skill-md-content.test.js` cover:
- Preamble existence between frontmatter and heading
- Discard/re-analyze directive present
- `git fetch --prune origin` mandate in preamble
- PR status re-check mandate
- Uncommitted/unpushed work re-check mandate
- "Fresh analysis" output instruction
- Step 1 uses correct fetch command
- Existing structural headings preserved (Philosophy, Instructions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/skill-instruction updates plus a small Node test that validates required text/structure; no runtime product logic changes.
> 
> **Overview**
> Updates `cleanup-worktrees` instructions to **force a fresh, non-cached analysis on every invocation**, including a required `git fetch --prune origin`, explicit re-checks for PR status and uncommitted/unpushed work, and a mandated "Fresh analysis started" banner.
> 
> Adds a new Node test (`skill-md-content.test.js`) that enforces the presence/placement of this preamble and verifies Step 1 uses `git fetch --prune origin` while preserving key document headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a015e2a0f4bed3a4168514fe7e5dcd702d9f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->