### PR TITLE
feat(agents): harden agent prompts with red flags, iron law, and anti-patterns

### DIFF
--- a/agents/__tests__/agent-prompt-hardening.test.js
+++ b/agents/__tests__/agent-prompt-hardening.test.js
@@ -1,0 +1,253 @@
+// Tests for GH-323 — agent prompt hardening: red flags tables in developer
+// agents, Verification Iron Law in quality agents, and testing anti-patterns
+// reference file.
+//
+// Discovered by scripts/run-tests.sh which searches: workflows/, agents/, skills/
+// Manual: node --test agents/__tests__/agent-prompt-hardening.test.js
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const AGENTS_DIR = path.resolve(__dirname, '..');
+const ROOT_DIR = path.resolve(__dirname, '..', '..');
+
+// ─── Agent file loaders ──────────────────────────────────────────────────────
+
+/** Read agent file content by name. */
+function readAgent(name) {
+  return fs.readFileSync(path.join(AGENTS_DIR, `${name}.md`), 'utf-8');
+}
+
+/** Extract YAML frontmatter key-value pairs from markdown text. */
+function parseFrontmatter(text) {
+  const match = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const fm = {};
+  for (const line of match[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx > 0) {
+      fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+    }
+  }
+  return fm;
+}
+
+/**
+ * Extract markdown table rows (excluding header row and separator row).
+ * Returns an array of arrays, one per data row, with cell text trimmed.
+ */
+function extractTableRows(text, headerPattern) {
+  const lines = text.split('\n');
+  const headerIdx = lines.findIndex((l) => l.includes(headerPattern));
+  if (headerIdx === -1) return [];
+
+  const rows = [];
+  // Skip header row (headerIdx) and separator row (headerIdx + 1)
+  for (let i = headerIdx + 2; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line.startsWith('|')) break;
+    const cells = line
+      .split('|')
+      .slice(1, -1)
+      .map((c) => c.trim());
+    if (cells.length > 0) rows.push(cells);
+  }
+  return rows;
+}
+
+// ─── Agent groups ────────────────────────────────────────────────────────────
+
+const DEVELOPER_AGENTS = [
+  'developer-nodejs-tdd',
+  'developer-react-senior',
+  'developer-react-ui-architect',
+  'commit-writer',
+];
+
+// Only the three developer-* agents must cross-reference testing-anti-patterns.md (R10).
+// commit-writer is a developer agent for red-flags purposes but not for cross-ref.
+const CROSS_REF_AGENTS = [
+  'developer-nodejs-tdd',
+  'developer-react-senior',
+  'developer-react-ui-architect',
+];
+
+const QUALITY_AGENTS = ['completion-checker', 'quality-checker', 'code-checker', 'pr-reviewer'];
+
+const ALL_MODIFIED_AGENTS = [...DEVELOPER_AGENTS, ...QUALITY_AGENTS];
+
+// Pre-load content and frontmatter for all agents under test.
+const agentContent = Object.create(null);
+const agentFrontmatter = Object.create(null);
+for (const name of ALL_MODIFIED_AGENTS) {
+  agentContent[name] = readAgent(name);
+  agentFrontmatter[name] = parseFrontmatter(agentContent[name]);
+}
+
+// ─── 1. Red flags tables in developer agents ────────────────────────────────
+
+describe('Red flags tables in developer agents', () => {
+  const RED_FLAGS_HEADER = '| Red Flag';
+
+  for (const agent of DEVELOPER_AGENTS) {
+    it(`${agent} contains a red flags table`, () => {
+      assert.ok(
+        agentContent[agent].includes(RED_FLAGS_HEADER),
+        `${agent}.md must contain a red flags table with header starting "| Red Flag"`
+      );
+    });
+
+    it(`${agent} red flags table has at least 3 data rows`, () => {
+      const rows = extractTableRows(agentContent[agent], RED_FLAGS_HEADER);
+      assert.ok(
+        rows.length >= 3,
+        `${agent}.md red flags table must have >= 3 rows, found ${rows.length}`
+      );
+    });
+  }
+
+  it('all developer agents use consistent column headings', () => {
+    const headingSets = [];
+    for (const agent of DEVELOPER_AGENTS) {
+      const lines = agentContent[agent].split('\n');
+      const headerLine = lines.find((l) => l.includes(RED_FLAGS_HEADER));
+      if (headerLine) headingSets.push(headerLine.trim());
+    }
+    // All agents that have the table should share the same header row
+    assert.ok(headingSets.length > 0, 'At least one agent must have a red flags table');
+    const unique = new Set(headingSets);
+    assert.equal(
+      unique.size,
+      1,
+      `All developer agents must use the same red flags column headings. Found: ${[...unique].join(' vs ')}`
+    );
+  });
+});
+
+// ─── 2. Verification Iron Law in quality agents ─────────────────────────────
+
+describe('Verification Iron Law in quality agents', () => {
+  const IRON_LAW_STEPS = ['IDENTIFY', 'RUN', 'READ', 'VERIFY', 'ONLY THEN'];
+
+  for (const agent of QUALITY_AGENTS) {
+    it(`${agent} contains Verification Iron Law section`, () => {
+      assert.ok(
+        agentContent[agent].includes('Verification Iron Law'),
+        `${agent}.md must contain "Verification Iron Law"`
+      );
+    });
+
+    it(`${agent} contains all 5 Iron Law steps`, () => {
+      for (const step of IRON_LAW_STEPS) {
+        assert.ok(
+          agentContent[agent].includes(step),
+          `${agent}.md must contain Iron Law step "${step}"`
+        );
+      }
+    });
+  }
+
+  it('all quality agents use consistent Iron Law text', () => {
+    // Extract the Iron Law section from each agent and compare
+    const sections = [];
+    for (const agent of QUALITY_AGENTS) {
+      const content = agentContent[agent];
+      const startIdx = content.indexOf('Verification Iron Law');
+      if (startIdx === -1) continue;
+
+      // Extract from the Iron Law heading to the next heading of same or higher level
+      const afterStart = content.slice(startIdx);
+      const nextHeading = afterStart.slice(1).search(/\n#{1,3}\s/);
+      const section = nextHeading === -1 ? afterStart : afterStart.slice(0, nextHeading + 1);
+      sections.push(section.trim());
+    }
+
+    assert.ok(sections.length > 0, 'At least one quality agent must have Iron Law section');
+    const unique = new Set(sections);
+    assert.equal(
+      unique.size,
+      1,
+      'All quality agents must use identical Verification Iron Law text'
+    );
+  });
+});
+
+// ─── 3. Testing anti-patterns reference file ────────────────────────────────
+
+describe('Testing anti-patterns reference file', () => {
+  const ANTI_PATTERNS_PATH = path.join(ROOT_DIR, 'references', 'testing-anti-patterns.md');
+
+  it('references/testing-anti-patterns.md exists', () => {
+    assert.ok(fs.existsSync(ANTI_PATTERNS_PATH), 'references/testing-anti-patterns.md must exist');
+  });
+
+  it('contains at least 5 anti-pattern sections', () => {
+    const exists = fs.existsSync(ANTI_PATTERNS_PATH);
+    if (!exists) {
+      assert.fail('Cannot check sections — file does not exist');
+      return;
+    }
+    const text = fs.readFileSync(ANTI_PATTERNS_PATH, 'utf-8');
+    // Count second-level headings (## Anti-pattern: ... or ## N. ...)
+    const sectionHeadings = text.split('\n').filter((l) => l.match(/^##\s+/));
+    assert.ok(
+      sectionHeadings.length >= 5,
+      `Must have >= 5 anti-pattern sections (## headings), found ${sectionHeadings.length}`
+    );
+  });
+
+  it('contains gate functions', () => {
+    const exists = fs.existsSync(ANTI_PATTERNS_PATH);
+    if (!exists) {
+      assert.fail('Cannot check gate functions — file does not exist');
+      return;
+    }
+    const text = fs.readFileSync(ANTI_PATTERNS_PATH, 'utf-8');
+    assert.ok(
+      text.includes('gate') || text.includes('Gate'),
+      'testing-anti-patterns.md must reference gate functions'
+    );
+  });
+});
+
+// ─── 4. Developer agents cross-reference anti-patterns ──────────────────────
+
+describe('Developer agents cross-reference testing-anti-patterns.md', () => {
+  for (const agent of CROSS_REF_AGENTS) {
+    it(`${agent} references testing-anti-patterns.md`, () => {
+      assert.ok(
+        agentContent[agent].includes('testing-anti-patterns.md'),
+        `${agent}.md must cross-reference references/testing-anti-patterns.md`
+      );
+    });
+  }
+});
+
+// ─── 5. Frontmatter preservation ────────────────────────────────────────────
+
+describe('YAML frontmatter is preserved on all agent files', () => {
+  for (const agent of ALL_MODIFIED_AGENTS) {
+    it(`${agent} has valid frontmatter with name field`, () => {
+      const fm = agentFrontmatter[agent];
+      assert.ok(fm.name, `${agent}.md must have a "name" field in frontmatter`);
+      assert.equal(
+        fm.name,
+        agent,
+        `${agent}.md frontmatter name must be "${agent}", got "${fm.name}"`
+      );
+    });
+
+    it(`${agent} has description in frontmatter`, () => {
+      const content = agentContent[agent];
+      // Check raw frontmatter block for description key (handles multi-line YAML values)
+      const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+      assert.ok(fmMatch, `${agent}.md must have YAML frontmatter`);
+      assert.ok(
+        fmMatch[1].includes('description:'),
+        `${agent}.md frontmatter must contain "description:" key`
+      );
+    });
+  }
+});

--- a/agents/__tests__/agent-prompt-hardening.test.js
+++ b/agents/__tests__/agent-prompt-hardening.test.js
@@ -154,12 +154,16 @@ describe('Verification Iron Law in quality agents', () => {
     const sections = [];
     for (const agent of QUALITY_AGENTS) {
       const content = agentContent[agent];
-      const startIdx = content.indexOf('Verification Iron Law');
-      if (startIdx === -1) continue;
+      // Find the full heading line (e.g., "## Verification Iron Law")
+      const headingMatch = content.match(/^(#{1,3})\s+Verification Iron Law/m);
+      if (!headingMatch) continue;
+      const headingLevel = headingMatch[1].length;
+      const startIdx = content.indexOf(headingMatch[0]);
 
-      // Extract from the Iron Law heading to the next heading of same or higher level
+      // Extract from the heading to the next heading of same or higher level (or EOF)
       const afterStart = content.slice(startIdx);
-      const nextHeading = afterStart.slice(1).search(/\n#{1,3}\s/);
+      const sameOrHigherRe = new RegExp(`\\n#{1,${headingLevel}}\\s`);
+      const nextHeading = afterStart.slice(1).search(sameOrHigherRe);
       const section = nextHeading === -1 ? afterStart : afterStart.slice(0, nextHeading + 1);
       sections.push(section.trim());
     }
@@ -198,17 +202,22 @@ describe('Testing anti-patterns reference file', () => {
     );
   });
 
-  it('contains gate functions', () => {
+  it('each anti-pattern section contains a gate function', () => {
     const exists = fs.existsSync(ANTI_PATTERNS_PATH);
     if (!exists) {
       assert.fail('Cannot check gate functions — file does not exist');
       return;
     }
     const text = fs.readFileSync(ANTI_PATTERNS_PATH, 'utf-8');
-    assert.ok(
-      text.includes('gate') || text.includes('Gate'),
-      'testing-anti-patterns.md must reference gate functions'
-    );
+    const sections = text.split(/^## /m).filter((s) => s.trim());
+    const antiPatternSections = sections.filter((s) => !s.startsWith('Testing Anti-Patterns'));
+    for (const section of antiPatternSections) {
+      const title = section.split('\n')[0].trim();
+      assert.ok(
+        /gate/i.test(section),
+        `Anti-pattern section "${title}" must contain a gate function`
+      );
+    }
   });
 });
 

--- a/agents/__tests__/agent-prompt-hardening.test.js
+++ b/agents/__tests__/agent-prompt-hardening.test.js
@@ -160,12 +160,17 @@ describe('Verification Iron Law in quality agents', () => {
       const headingLevel = headingMatch[1].length;
       const startIdx = content.indexOf(headingMatch[0]);
 
-      // Extract from the heading to the next heading of same or higher level (or EOF)
+      // Extract the core Iron Law text (heading through "Violations:" paragraph)
+      // Agent-specific addenda after the core section are allowed to differ
       const afterStart = content.slice(startIdx);
-      const sameOrHigherRe = new RegExp(`\\n#{1,${headingLevel}}\\s`);
-      const nextHeading = afterStart.slice(1).search(sameOrHigherRe);
-      const section = nextHeading === -1 ? afterStart : afterStart.slice(0, nextHeading + 1);
-      sections.push(section.trim());
+      const violationsEnd = afterStart.search(/\*\*Violations:\*\*[^\n]*\n/);
+      if (violationsEnd === -1) {
+        sections.push(afterStart.trim());
+      } else {
+        const endOfViolations = afterStart.indexOf('\n', violationsEnd + 1);
+        const core = endOfViolations === -1 ? afterStart : afterStart.slice(0, endOfViolations);
+        sections.push(core.trim());
+      }
     }
 
     assert.ok(sections.length > 0, 'At least one quality agent must have Iron Law section');

--- a/agents/__tests__/agent-prompt-hardening.test.js
+++ b/agents/__tests__/agent-prompt-hardening.test.js
@@ -214,8 +214,9 @@ describe('Testing anti-patterns reference file', () => {
       return;
     }
     const text = fs.readFileSync(ANTI_PATTERNS_PATH, 'utf-8');
+    // Split on ## headings; first element is the preamble (before any ##), skip it
     const sections = text.split(/^## /m).filter((s) => s.trim());
-    const antiPatternSections = sections.filter((s) => !s.startsWith('Testing Anti-Patterns'));
+    const antiPatternSections = sections.slice(1);
     for (const section of antiPatternSections) {
       const title = section.split('\n')[0].trim();
       assert.ok(

--- a/agents/code-checker.md
+++ b/agents/code-checker.md
@@ -533,3 +533,15 @@ Observations that could not be verified from available code. These do not affect
 - **Prioritize Substance**: Never let cosmetic findings overshadow structural issues
 - **Minimize Noise**: Do not list trivial style issues when higher-severity issues exist. Prefer fewer, high-signal findings over exhaustive low-value commentary. A review with 5 precise findings is better than one with 25 that includes padding.
 - **No Redundant Findings**: If the same root cause manifests in multiple places, report it once with all affected locations listed — do not create separate issues for each instance.
+
+## Verification Iron Law
+
+Every claim must be backed by fresh evidence. Follow these 5 steps in order:
+
+1. **IDENTIFY** — What specific claim needs verification?
+2. **RUN** — Execute the command that produces evidence (test, lint, build, grep).
+3. **READ** — Read the actual output. Do not assume or summarize from memory.
+4. **VERIFY** — Compare the output against the claim. Does it actually prove what you're asserting?
+5. **ONLY THEN** — Report the result. Never report a result without completing steps 1-4.
+
+**Violations:** Skipping any step is a verification failure. "I already checked" is not evidence. "It should work" is not evidence. Only fresh command output is evidence.

--- a/agents/commit-writer.md
+++ b/agents/commit-writer.md
@@ -71,3 +71,12 @@ feat(auth): add JWT refresh token rotation
 fix(api): handle null response in user endpoint
 chore(deps): bump axios to 1.7.2
 ```
+
+## Red Flags
+
+| Red Flag | Required Action |
+|----------|-----------------|
+| "This change is too small to need a separate commit" | Commit what's staged, no matter the size. |
+| "I'll just amend the previous commit" | Never amend unless explicitly asked. |
+| "The push failed so I'll force push" | Never force push. Report the error. |
+| "I should stage some unstaged files first" | Never run git add. Only commit what's already staged. |

--- a/agents/commit-writer.md
+++ b/agents/commit-writer.md
@@ -77,6 +77,6 @@ chore(deps): bump axios to 1.7.2
 | Red Flag | Required Action |
 |----------|-----------------|
 | "This change is too small to need a separate commit" | Commit what's staged, no matter the size. |
-| "I'll just amend the previous commit" | Never amend unless explicitly asked. |
+| "I'll just amend the previous commit" | Never amend. Create a new commit instead. Report if the user needs to amend manually. |
 | "The push failed so I'll force push" | Never force push. Report the error. |
 | "I should stage some unstaged files first" | Never run git add. Only commit what's already staged. |

--- a/agents/completion-checker.md
+++ b/agents/completion-checker.md
@@ -132,3 +132,15 @@ If a spec-verify output exists for this ticket, read it. Spec-verify failures ar
 ### Final Guidelines
 6. If assistant provided the requested information/action → COMPLETE
 8. If assistant said "ready", "done", "delivered", "implemented", "here is", "completed" → COMPLETE
+
+## Verification Iron Law
+
+Every claim must be backed by fresh evidence. Follow these 5 steps in order:
+
+1. **IDENTIFY** — What specific claim needs verification?
+2. **RUN** — Execute the command that produces evidence (test, lint, build, grep).
+3. **READ** — Read the actual output. Do not assume or summarize from memory.
+4. **VERIFY** — Compare the output against the claim. Does it actually prove what you're asserting?
+5. **ONLY THEN** — Report the result. Never report a result without completing steps 1-4.
+
+**Violations:** Skipping any step is a verification failure. "I already checked" is not evidence. "It should work" is not evidence. Only fresh command output is evidence.

--- a/agents/completion-checker.md
+++ b/agents/completion-checker.md
@@ -2,7 +2,7 @@
 name: completion-checker
 tools: Bash, Read, Grep, Glob
 description: Checks that all user requirements have been met before finalizing the conversation.
-model: sonnet
+model: opus
 color: cyan
 ---
 

--- a/agents/completion-checker.md
+++ b/agents/completion-checker.md
@@ -144,3 +144,5 @@ Every claim must be backed by fresh evidence. Follow these 5 steps in order:
 5. **ONLY THEN** — Report the result. Never report a result without completing steps 1-4.
 
 **Violations:** Skipping any step is a verification failure. "I already checked" is not evidence. "It should work" is not evidence. Only fresh command output is evidence.
+
+**For this agent:** Before declaring any requirement DELIVERED, you must have run a command (grep, gh pr diff, git diff) whose output you can cite as evidence. A requirement is not DELIVERED just because the file exists — you must verify the specific content matches the acceptance criteria.

--- a/agents/completion-checker.md
+++ b/agents/completion-checker.md
@@ -145,4 +145,4 @@ Every claim must be backed by fresh evidence. Follow these 5 steps in order:
 
 **Violations:** Skipping any step is a verification failure. "I already checked" is not evidence. "It should work" is not evidence. Only fresh command output is evidence.
 
-**For this agent:** Before declaring any requirement DELIVERED, you must have run a command (grep, gh pr diff, git diff) whose output you can cite as evidence. A requirement is not DELIVERED just because the file exists — you must verify the specific content matches the acceptance criteria.
+**For this agent:** Before declaring any code-related requirement DELIVERED, you must have run a command (grep, gh pr diff, git diff) whose output you can cite as evidence. A requirement is not DELIVERED just because the file exists — you must verify the specific content matches the acceptance criteria.

--- a/agents/developer-nodejs-tdd.md
+++ b/agents/developer-nodejs-tdd.md
@@ -134,3 +134,15 @@ When presenting code, you:
 - Suggest potential improvements or extensions
 
 You communicate technical decisions clearly, explaining why certain approaches were chosen and how they align with TDD principles and TypeScript best practices.
+
+## Red Flags
+
+| Red Flag | Required Action |
+|----------|-----------------|
+| "This is too simple to need tests" | Simple changes break builds. Write the test. |
+| "I'll add tests later" | Later never comes. Write tests first. |
+| "The existing tests cover this" | Verify by running them. If they don't fail without your change, they don't cover it. |
+| "I'll just mock everything" | Mocks must match real behavior. Verify each mock's contract against the real dependency. |
+| "The types are too complex to get right" | Complex types prevent complex bugs. Define the type correctly or simplify the design. |
+
+> See also: [Testing Anti-Patterns](../references/testing-anti-patterns.md)

--- a/agents/developer-react-senior.md
+++ b/agents/developer-react-senior.md
@@ -249,3 +249,15 @@ You follow a systematic approach for every React development task:
 **User:** "Implement our design system in React with full documentation and interactive examples."
 **Assistant:** "I'll use the developer-react-senior agent to build the design system components with Storybook as the living style guide, including interaction tests through play functions."
 **Commentary:** Perfect use case for Storybook-driven development with comprehensive component testing.
+
+## Red Flags
+
+| Red Flag | Required Action |
+|----------|-----------------|
+| "This is too simple to need tests" | Simple changes break builds. Write the test. |
+| "I'll add tests later" | Later never comes. Write tests first. |
+| "The existing tests cover this" | Verify by running them. If they don't fail without your change, they don't cover it. |
+| "This component is just presentational, no tests needed" | Presentational components break too. Write a Storybook story with interaction tests. |
+| "I'll skip the accessibility check for now" | Accessibility is not optional. Run the a11y audit before marking complete. |
+
+> See also: [Testing Anti-Patterns](../references/testing-anti-patterns.md)

--- a/agents/developer-react-ui-architect.md
+++ b/agents/developer-react-ui-architect.md
@@ -151,3 +151,15 @@ You follow a strict three-phase approach for every UI task:
 **Assistant:** "I'll engage the developer-react-ui-architect agent to refactor these components, improve aesthetics, and strengthen test coverage."
 **Commentary:** Optimizing and maintaining a UI library fits directly into this agent’s expertise.
 
+
+## Red Flags
+
+| Red Flag | Required Action |
+|----------|-----------------|
+| "This is too simple to need tests" | Simple changes break builds. Write the test. |
+| "I'll add tests later" | Later never comes. Write tests first. |
+| "The existing tests cover this" | Verify by running them. If they don't fail without your change, they don't cover it. |
+| "The design looks fine, no visual regression test needed" | Visual regressions are invisible without automated checks. Add a Chromatic or screenshot test. |
+| "Performance optimization can wait" | Measure first. Run Lighthouse and profile renders before deferring. |
+
+> See also: [Testing Anti-Patterns](../references/testing-anti-patterns.md)

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -495,3 +495,15 @@ Use these exact labels for clarity:
 ✅ **Ensure recommendation matches severity of findings**
 
 **Consistent, constructive code reviews improve code quality and team knowledge sharing!**
+
+## Verification Iron Law
+
+Every claim must be backed by fresh evidence. Follow these 5 steps in order:
+
+1. **IDENTIFY** — What specific claim needs verification?
+2. **RUN** — Execute the command that produces evidence (test, lint, build, grep).
+3. **READ** — Read the actual output. Do not assume or summarize from memory.
+4. **VERIFY** — Compare the output against the claim. Does it actually prove what you're asserting?
+5. **ONLY THEN** — Report the result. Never report a result without completing steps 1-4.
+
+**Violations:** Skipping any step is a verification failure. "I already checked" is not evidence. "It should work" is not evidence. Only fresh command output is evidence.

--- a/agents/quality-checker.md
+++ b/agents/quality-checker.md
@@ -184,3 +184,15 @@ OR
 - ❌ Run lint or typecheck as standalone full-workspace commands when dev:check is available
 - ❌ Summarize without actual output
 - ❌ Skip any test type that exists
+
+## Verification Iron Law
+
+Every claim must be backed by fresh evidence. Follow these 5 steps in order:
+
+1. **IDENTIFY** — What specific claim needs verification?
+2. **RUN** — Execute the command that produces evidence (test, lint, build, grep).
+3. **READ** — Read the actual output. Do not assume or summarize from memory.
+4. **VERIFY** — Compare the output against the claim. Does it actually prove what you're asserting?
+5. **ONLY THEN** — Report the result. Never report a result without completing steps 1-4.
+
+**Violations:** Skipping any step is a verification failure. "I already checked" is not evidence. "It should work" is not evidence. Only fresh command output is evidence.

--- a/references/testing-anti-patterns.md
+++ b/references/testing-anti-patterns.md
@@ -1,0 +1,43 @@
+# Testing Anti-Patterns
+
+This reference catalogs common testing anti-patterns that undermine code quality. Each anti-pattern includes a gate function describing how to detect and prevent it during development and review.
+
+## Testing mock behavior instead of real behavior
+
+When tests verify that mocks were called correctly rather than verifying actual system behavior, the tests become tautological. They pass by definition because they only confirm the test setup, not the production code. A test suite full of mock-verification assertions can achieve 100% coverage while catching zero real bugs.
+
+### Gate function
+
+Before approving a test, ask: "If I delete the production code this test covers and replace it with a stub that satisfies the mocks, does the test still pass?" If yes, the test is testing mock behavior, not real behavior. Require at least one assertion on an observable output (return value, side effect, state change) that would fail if the production logic were removed.
+
+## Adding test-only methods to production code
+
+When production classes or modules expose methods, properties, or flags solely to make testing easier (e.g., `_getInternalState()`, `testMode` flags, `resetForTesting()`), the production code becomes coupled to test infrastructure. This leaks test concerns into production, increases surface area for bugs, and creates maintenance burden.
+
+### Gate function
+
+Search production source files for symbols containing "test", "mock", "stub", or "spec" in their names. If any exist and are not part of a legitimate public API, flag them. Production code should be testable through its public interface. If it is not, the design needs refactoring (dependency injection, strategy pattern, or interface extraction), not test-only backdoors.
+
+## Mocking without understanding what is being mocked
+
+When developers mock a dependency without understanding its contract, the mock becomes a fiction. It returns values the real dependency would never return, omits error cases the real dependency raises, and silently diverges from the real behavior over time. Tests pass against the fiction while the real integration is broken.
+
+### Gate function
+
+For every mock in a test file, verify: (1) the mock's return values match the real dependency's documented or observed behavior, (2) the mock covers at least one error/failure case from the real dependency, and (3) the mock is updated when the real dependency's interface changes. If a mock was copy-pasted from another test without verification, flag it.
+
+## Incomplete mocks that hide real failures
+
+When a mock replaces a dependency but only implements the happy path, the test suite becomes blind to failure modes. The real dependency may throw, return null, timeout, or return malformed data, but the mock always returns a perfect response. Production code that lacks error handling passes all tests and fails in production.
+
+### Gate function
+
+For each mocked dependency, list the failure modes of the real dependency (throws, returns null, returns error codes, times out). Verify that at least one test exercises each failure mode through the mock. If the mock has no failure-mode tests, the test suite has a coverage gap that must be addressed before merge.
+
+## Integration tests treated as an afterthought
+
+When integration tests are deferred, skipped, or written as shallow wrappers around unit tests, the system's actual wiring is never verified. Components that pass all unit tests individually can fail catastrophically when composed. Database queries, HTTP calls, message queues, and file I/O must be tested with real (or realistic) infrastructure.
+
+### Gate function
+
+For any feature that crosses a system boundary (database, HTTP, file system, message queue), verify that at least one integration test exercises the real boundary. If all tests for a boundary-crossing feature use mocks exclusively, flag the gap. The integration test does not need to cover every case, but it must prove that the real wiring works for at least the primary happy path and one failure path.

--- a/references/testing-anti-patterns.md
+++ b/references/testing-anti-patterns.md
@@ -41,3 +41,4 @@ When integration tests are deferred, skipped, or written as shallow wrappers aro
 ### Gate function
 
 For any feature that crosses a system boundary (database, HTTP, file system, message queue), verify that at least one integration test exercises the real boundary. If all tests for a boundary-crossing feature use mocks exclusively, flag the gap. The integration test does not need to cover every case, but it must prove that the real wiring works for at least the primary happy path and one failure path.
+


### PR DESCRIPTION
## Existing Behavior

- Developer agents (nodejs-tdd, react-senior, react-ui-architect, commit-writer) had no structured guardrails against common rationalization patterns that lead to skipping tests, force-pushing, or deferring quality work.
- Quality agents (completion-checker, quality-checker, code-checker, pr-reviewer) lacked a mandatory evidence protocol, leaving room for unverified claims in review outputs.
- No shared reference document existed for testing anti-patterns; each agent relied on implicit knowledge.
- No automated tests verified that agent prompt files contained the required sections.

## Intended New Behavior

- Four developer agents now include a Red Flags Rationalization-Prevention Table listing specific "danger phrase → required counter-action" mappings to block rationalization before it occurs.
- Four quality agents now include an identical Verification Iron Law section enforcing a 5-step evidence protocol: IDENTIFY → RUN → READ → VERIFY → ONLY THEN, with explicit statement that "I already checked" is not evidence.
- `references/testing-anti-patterns.md` documents 5 anti-patterns (mock behavior testing, test-only production methods, mocking without contract understanding, incomplete mocks, integration test afterthought), each with a concrete gate function reviewers can apply.
- `agents/__tests__/agent-prompt-hardening.test.js` adds 40 tests across 5 suites that enforce structural correctness of all modified agent files and the new reference document, preventing future regressions.

## Dev Checks

- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Run the new test suite directly:
   ```
   node --test agents/__tests__/agent-prompt-hardening.test.js
   ```
   Expected: 40 tests pass, 0 fail across 5 suites.

2. Open any modified developer agent (e.g., `agents/developer-nodejs-tdd.md`) and verify the `## Red Flags` table is present at the end with columns `| Red Flag | Required Action |`.

3. Open any modified quality agent (e.g., `agents/code-checker.md`) and verify the `## Verification Iron Law` section is present with all 5 numbered steps (IDENTIFY, RUN, READ, VERIFY, ONLY THEN).

4. Confirm `references/testing-anti-patterns.md` exists and contains at least 5 `##` headings and the word "gate" in each anti-pattern section.

5. Verify developer agents reference the new file by searching for `testing-anti-patterns.md` in `developer-nodejs-tdd.md`, `developer-react-senior.md`, and `developer-react-ui-architect.md`.

### Test Results

40 pass, 0 fail — `node --test agents/__tests__/agent-prompt-hardening.test.js`

Closes #323

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes multiple agent prompts (including a `model` switch for `completion-checker`) and adds strict content-enforcement tests, which can alter agent behavior and CI outcomes despite no application runtime code changes.
> 
> **Overview**
> Adds **prompt-hardening guardrails** across several agent markdowns: developer agents now include a standardized `## Red Flags` rationalization-prevention table (and developer-* agents link to the new anti-patterns doc), while quality/review agents now include a shared `## Verification Iron Law` evidence protocol.
> 
> Introduces `references/testing-anti-patterns.md` with five anti-pattern “gate functions”, and adds `agents/__tests__/agent-prompt-hardening.test.js` to enforce required sections, consistent wording, cross-references, and preserved YAML frontmatter to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad3a9eadc17db1a48467933ca6b9b548c29f8d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->