### PR TITLE
fix(pr-generator): block git merge and git rebase in readonly guard

### DIFF
--- a/workflows/work-pr/agents/pr-generator/pr-generator-readonly-guard.js
+++ b/workflows/work-pr/agents/pr-generator/pr-generator-readonly-guard.js
@@ -34,6 +34,13 @@ const FILE_MODIFY_PATTERNS = [
   /[^|]>\s*[^&|]/,
 ];
 
+// Destructive git subcommand arguments
+const DESTRUCTIVE_GIT_PATTERNS = [
+  /^\s*git\s+branch\s+(-[dD]|--delete)\b/,
+  /^\s*git\s+push\s+.*--force\b/,
+  /^\s*git\s+push\s+.*--delete\b/,
+];
+
 // Commands that indicate attempting to fix code
 const FIX_ATTEMPT_PATTERNS = [
   /\bpnpm\s+(test|lint|typecheck|dev:lint|dev:typecheck|dev:test)\b/,
@@ -46,7 +53,7 @@ const FIX_ATTEMPT_PATTERNS = [
 ];
 
 // Allowed git subcommands — read-only + commit + push (no merge, rebase, reset, etc.)
-const ALLOWED_GIT_SUBCOMMANDS = /^\s*git\s+(diff|log|show|status|branch|rev-parse|ls-files|fetch|remote|describe|config|shortlog|name-rev|for-each-ref|cat-file|tag|commit|push)\b/;
+const ALLOWED_GIT_SUBCOMMANDS = /^\s*git\s+(diff|log|show|status|branch|rev-parse|ls-files|fetch|commit|push)\b/;
 
 // Explicitly allowed commands (quality gate + git/gh)
 const ALLOWED_COMMANDS = [
@@ -68,10 +75,20 @@ function isAllowedCommand(command) {
   if (/^\s*gh\b/.test(command)) {
     return true;
   }
+  // Allowed git subcommands with pipes (e.g., git log | head)
+  if (ALLOWED_GIT_SUBCOMMANDS.test(command)) {
+    return true;
+  }
   return false;
 }
 
 function isBlockedCommand(command) {
+  // Check for destructive git arguments
+  for (const pattern of DESTRUCTIVE_GIT_PATTERNS) {
+    if (pattern.test(command)) {
+      return `Destructive git command detected: ${pattern}`;
+    }
+  }
   // Check for file modification patterns
   for (const pattern of FILE_MODIFY_PATTERNS) {
     if (pattern.test(command)) {

--- a/workflows/work-pr/agents/pr-generator/pr-generator-readonly-guard.js
+++ b/workflows/work-pr/agents/pr-generator/pr-generator-readonly-guard.js
@@ -45,11 +45,14 @@ const FIX_ATTEMPT_PATTERNS = [
   /\bpatch\b/,
 ];
 
+// Allowed git subcommands — read-only + commit + push (no merge, rebase, reset, etc.)
+const ALLOWED_GIT_SUBCOMMANDS = /^\s*git\s+(diff|log|show|status|branch|rev-parse|ls-files|fetch|remote|describe|config|shortlog|name-rev|for-each-ref|cat-file|tag|commit|push)\b/;
+
 // Explicitly allowed commands (quality gate + git/gh)
 const ALLOWED_COMMANDS = [
   /^\s*pnpm\s+dev:check\b/, // Quality gate — read-only verification
   /^\s*(\w+=\S+\s+)*([\w./-]*\/)?dev-check\.sh(\s+[-\w=./]+)*\s*$/, // Bundled dev-check scripts — plugin fallback (anchored, no shell chaining)
-  /^\s*git\b/,
+  ALLOWED_GIT_SUBCOMMANDS,
   /^\s*gh\b/,
   /^\s*DEFAULT_BRANCH=/,
   /^\s*echo\s+"/, // echo for display only (no redirect)
@@ -61,8 +64,8 @@ function isAllowedCommand(command) {
       return true;
     }
   }
-  // git and gh commands are always allowed, even with pipes
-  if (/^\s*(git|gh)\b/.test(command)) {
+  // gh commands are always allowed, even with pipes
+  if (/^\s*gh\b/.test(command)) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Existing Behavior

- The pr-generator readonly guard allowlisted all `git` commands via a blanket `/^\s*git\b/` pattern at line 52 and a fallback in `isAllowedCommand`.
- This permitted `git merge` and `git rebase` to pass through unchecked, allowing the pr-generator agent to create merge commits or rebase the branch, which can pollute the PR diff and trigger check-drift gates.

## Intended New Behavior

- Git commands are now validated against an explicit allowlist of safe subcommands: `diff`, `log`, `show`, `status`, `branch`, `rev-parse`, `ls-files`, `fetch`, `remote`, `describe`, `config`, `shortlog`, `name-rev`, `for-each-ref`, `cat-file`, `tag`, `commit`, `push`.
- `git merge`, `git rebase`, `git reset`, and any other non-allowlisted git subcommands are now blocked by the readonly guard.
- The `isAllowedCommand` fallback is updated to only pass through `gh` commands unconditionally; git commands must match the allowlist pattern.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Verify the readonly guard blocks dangerous git subcommands:

1. Open `workflows/work-pr/agents/pr-generator/pr-generator-readonly-guard.js` and confirm `ALLOWED_GIT_SUBCOMMANDS` does not include `merge` or `rebase`.
2. Run the guard logic against a `git merge origin/main` command and confirm it returns `false` (blocked).
3. Run the guard logic against `git diff origin/main...HEAD` and confirm it returns `true` (allowed).
4. Run the guard logic against `git push` and confirm it returns `true` (allowed).
5. Confirm `isAllowedCommand` no longer has a broad `/^\s*(git|gh)\b/` fallback — only `gh` is unconditionally allowed.

Closes #341

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the command-allowlisting gate for the pr-generator agent; misclassification could either block legitimate `git` usage or accidentally allow unsafe operations.
> 
> **Overview**
> PreToolUse read-only guard for `pr-generator` now **restricts `git` usage to an explicit allowlist** (`diff`, `log`, `show`, `status`, `branch`, `rev-parse`, `ls-files`, `fetch`, `commit`, `push`) instead of allowing all `git` commands, preventing operations like `git merge`/`git rebase` from slipping through.
> 
> Adds **explicit detection of destructive git flags** (e.g., `git branch -d/--delete`, `git push --force`, `git push --delete`) and updates `isAllowedCommand` so only `gh` is unconditionally allowed while `git` must match the allowlist (including when piped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e371d96ad586f57167a2c07de8bb86a2bcd02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->