### PR TITLE
feat(split-in-tasks): reject vague task descriptions with no-placeholder validation

### DIFF
--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -134,6 +134,17 @@ Checkpoint tasks and config-only infrastructure tasks are exempt from the RED/GR
 - Tasks without requirement mapping
 - "Refactor and clean up" as a standalone task (cleanup belongs inside the task that creates the code)
 
+**Anti-patterns are enforced by `workflows/lib/hooks/policies/task-description-quality.js` — the canonical blocked-pattern list. The following patterns will cause `tasks.md` writes to be blocked:**
+- **TBD** — Replace the TBD placeholder with a concrete description of what this task delivers.
+- **TODO** — Replace the TODO placeholder with specific implementation details.
+- **implement later** — Remove the deferral phrase and describe what should be implemented now, or move to a separate task. (Blocked unless followed by 20+ chars of qualifying detail.)
+- **to be determined** — Replace with a concrete decision or escalate to the spec phase. (Always blocked, no qualification possible.)
+- **Handle edge cases** — Specify which edge cases to handle (e.g. null input, empty array, overflow). (Blocked unless followed by 20+ chars of qualifying detail.)
+- **Add appropriate error handling** — Specify which error types to handle and the handling strategy (retry, fallback, abort). (Blocked unless followed by 20+ chars of qualifying detail.)
+- **Add tests** — List specific test scenarios (e.g. "test that invalid input returns 400"). (Blocked unless followed by 20+ chars of qualifying detail. Lines with TDD phase prefixes like `**RED:**` are exempt.)
+- **Similar/Same as Task N** — Repeat the actual steps instead of cross-referencing another task.
+
+
 #### Step 4.2 — Coverage Validation (MANDATORY — do this AFTER creating all tasks)
 
 After generating all tasks, verify coverage:

--- a/workflows/lib/hooks/policies/__tests__/task-description-quality.test.js
+++ b/workflows/lib/hooks/policies/__tests__/task-description-quality.test.js
@@ -380,3 +380,30 @@ describe('getBlockedPatterns', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// SKILL.md consolidation
+// ---------------------------------------------------------------------------
+
+describe('SKILL.md consolidation', () => {
+  it('references task-description-quality as canonical source', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const skillPath = path.resolve(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      '..',
+      'skills',
+      'split-in-tasks',
+      'SKILL.md'
+    );
+    const content = fs.readFileSync(skillPath, 'utf8');
+    assert.ok(
+      content.includes('task-description-quality'),
+      'SKILL.md should reference task-description-quality policy'
+    );
+  });
+});

--- a/workflows/lib/hooks/policies/__tests__/task-description-quality.test.js
+++ b/workflows/lib/hooks/policies/__tests__/task-description-quality.test.js
@@ -1,0 +1,382 @@
+/**
+ * Tests for policies/task-description-quality.js
+ *
+ * Run: node --test workflows/lib/hooks/policies/__tests__/task-description-quality.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { validateTaskDescriptions, getBlockedPatterns } = require('../task-description-quality');
+
+/**
+ * Build a minimal tasks.md content wrapping test content in proper Task sections.
+ * @param {number} taskNum
+ * @param {string} description
+ * @param {string} [deliverables]
+ * @returns {string}
+ */
+function buildTaskContent(taskNum, description, deliverables) {
+  let content = `## Task ${taskNum} — Test Task\n\n### Description\n${description}\n`;
+  if (deliverables) {
+    content += `\n### Deliverables\n${deliverables}\n`;
+  }
+  return content;
+}
+
+// ---------------------------------------------------------------------------
+// validateTaskDescriptions — blocking patterns
+// ---------------------------------------------------------------------------
+
+describe('validateTaskDescriptions: blocking patterns', () => {
+  it('blocks literal placeholder "TBD" in task description', () => {
+    const content = '## Task 1 — TBD\n### Description\nTBD';
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    assert.ok(result.violations.length >= 1);
+
+    const v = result.violations.find((v) => v.task.includes('1'));
+    assert.ok(v, 'violation should identify Task 1');
+    assert.ok(v.pattern.includes('TBD'), 'pattern should mention TBD');
+    assert.ok(v.hint.length > 0, 'hint should suggest expanding the placeholder');
+  });
+
+  it('blocks "TODO" case-insensitively', () => {
+    const content = buildTaskContent(1, 'todo: figure this out later');
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    assert.ok(result.violations.length >= 1);
+
+    const v = result.violations[0];
+    assert.ok(v.pattern.toUpperCase().includes('TODO'), 'pattern label should match TODO');
+  });
+
+  it('blocks unqualified "Handle edge cases"', () => {
+    const content = buildTaskContent(1, 'Core implementation', '- Handle edge cases');
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    assert.ok(result.violations.length >= 1);
+
+    const v = result.violations[0];
+    assert.ok(
+      v.hint.toLowerCase().includes('edge case'),
+      'hint should suggest specifying which edge cases'
+    );
+  });
+
+  it('blocks "Similar to Task N" cross-references', () => {
+    const content = buildTaskContent(2, 'Implement feature', '- Similar to Task 2');
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    assert.ok(result.violations.length >= 1);
+
+    const v = result.violations[0];
+    assert.ok(
+      v.hint.toLowerCase().includes('repeat') || v.hint.toLowerCase().includes('actual'),
+      'hint should suggest repeating the actual steps'
+    );
+  });
+
+  it('blocks "Same as Task N" cross-references', () => {
+    const content = buildTaskContent(2, 'Implement feature', '- Same as Task 1');
+    const result = validateTaskDescriptions(content);
+    assert.equal(result.blocked, true);
+    assert.ok(result.violations.length >= 1);
+    const v = result.violations[0];
+    assert.ok(
+      v.hint.toLowerCase().includes('repeat') || v.hint.toLowerCase().includes('actual'),
+      'hint should suggest repeating the actual steps'
+    );
+  });
+
+  it('blocks "tbd" lowercase variant (case-insensitive)', () => {
+    const content = buildTaskContent(1, 'tbd');
+    const result = validateTaskDescriptions(content);
+    assert.equal(result.blocked, true);
+  });
+
+  it('blocks "Add appropriate error handling" without specifics', () => {
+    const content = buildTaskContent(1, 'Build parser', '- Add appropriate error handling');
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    assert.ok(result.violations.length >= 1);
+
+    const v = result.violations[0];
+    assert.ok(
+      v.hint.toLowerCase().includes('error') || v.hint.toLowerCase().includes('specif'),
+      'hint should suggest specifying error types and handling strategy'
+    );
+  });
+
+  it('blocks "Add tests" without specifying scenarios', () => {
+    const content = buildTaskContent(1, 'Implement module', '- Add tests');
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    assert.ok(result.violations.length >= 1);
+
+    const v = result.violations[0];
+    assert.ok(
+      v.hint.toLowerCase().includes('scenario') || v.hint.toLowerCase().includes('test'),
+      'hint should suggest listing specific test scenarios'
+    );
+  });
+
+  it('blocks standalone "implement later"', () => {
+    const content = buildTaskContent(1, 'implement later');
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    assert.ok(result.violations.length >= 1);
+  });
+
+  it('blocks "to be determined"', () => {
+    const content = buildTaskContent(1, 'to be determined');
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    assert.ok(result.violations.length >= 1);
+  });
+
+  it('blocks "to be determined" even with qualifying detail after it (non-qualifiable)', () => {
+    const content = buildTaskContent(
+      1,
+      'to be determined once the spec is reviewed and the architecture is finalized'
+    );
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(
+      result.blocked,
+      true,
+      '"to be determined" is a pure deferral and must always block'
+    );
+    assert.ok(result.violations.length >= 1);
+    const v = result.violations[0];
+    assert.equal(v.pattern, 'to be determined');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateTaskDescriptions — false-positive avoidance
+// ---------------------------------------------------------------------------
+
+describe('validateTaskDescriptions: false-positive avoidance', () => {
+  it('allows qualified edge case description', () => {
+    const content = buildTaskContent(
+      1,
+      'Handle the edge case where user ID is null by returning a 400 error'
+    );
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, false);
+  });
+
+  it('allows specific error handling description', () => {
+    const content = buildTaskContent(
+      1,
+      'Implementation details',
+      '- Add error handling for network timeouts by retrying with exponential backoff, max 3 retries'
+    );
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, false);
+  });
+
+  it('allows "implement later" as substring in a qualified sentence', () => {
+    const content = buildTaskContent(
+      1,
+      'Do not implement later phases in this task; only implement the parser'
+    );
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, false);
+  });
+
+  it('does not flag TDD prefix "**RED:** Add tests for validation edge cases"', () => {
+    const content = buildTaskContent(
+      1,
+      'Implement parser',
+      '- **RED:** Add tests for validation edge cases'
+    );
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, false);
+  });
+
+  it('does not flag TDD prefix with checkbox and task number "- [ ] 1.1.1 **RED:** Add tests"', () => {
+    const content = buildTaskContent(1, 'Implement auth module', '- [ ] 1.1.1 **RED:** Add tests');
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, false, 'checkbox-prefixed TDD lines should be exempt');
+  });
+
+  it('does not flag TDD prefix with checked checkbox "- [x] 2.3 **GREEN:** Add error handling"', () => {
+    const content = buildTaskContent(
+      1,
+      'Implement timeout handler',
+      '- [x] 2.3 **GREEN:** Add error handling'
+    );
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, false, 'checked checkbox TDD lines should be exempt');
+  });
+
+  it('does not scan Requirement Coverage table', () => {
+    const taskContent = buildTaskContent(1, 'Implement the parser with full error handling');
+    const coverageTable =
+      '\n## Requirement Coverage\n\n| Requirement | Covered By |\n|---|---|\n| R1 | Task 1, Task 2 |\n| R2 | Task 3 |\n';
+    const content = taskContent + coverageTable;
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateTaskDescriptions — multi-violation reporting
+// ---------------------------------------------------------------------------
+
+describe('validateTaskDescriptions: deduplication', () => {
+  it('emits only one violation per (task, pattern) pair even when pattern appears on multiple lines', () => {
+    // TBD appears in both the header line and the description body
+    const content = '## Task 1 — TBD\n### Description\nTBD\n';
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    // Count how many TBD violations exist for Task 1
+    const tbdViolations = result.violations.filter(
+      (v) => v.task === 'Task 1' && v.pattern === 'TBD'
+    );
+    assert.equal(
+      tbdViolations.length,
+      1,
+      `expected exactly 1 TBD violation for Task 1, got ${tbdViolations.length}`
+    );
+  });
+
+  it('still reports distinct patterns in the same task', () => {
+    // Task has both TBD and TODO — these are different patterns, both should be reported
+    const content = '## Task 1 — TBD\n### Description\ntodo: figure it out\n';
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    assert.equal(result.violations.length, 2, 'should report TBD and TODO as separate violations');
+    const labels = result.violations.map((v) => v.pattern);
+    assert.ok(labels.includes('TBD'), 'should include TBD');
+    assert.ok(labels.includes('TODO'), 'should include TODO');
+  });
+
+  it('deduplicates across header and body for same pattern', () => {
+    // "implement later" in header and body
+    const content = '## Task 1 — implement later\n### Description\nWe will implement later\n';
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    const implLaterViolations = result.violations.filter(
+      (v) => v.task === 'Task 1' && v.pattern === 'implement later'
+    );
+    assert.equal(
+      implLaterViolations.length,
+      1,
+      `expected exactly 1 "implement later" violation for Task 1, got ${implLaterViolations.length}`
+    );
+  });
+});
+
+describe('validateTaskDescriptions: multi-violation reporting', () => {
+  it('reports multiple violations with task numbers', () => {
+    const content =
+      '## Task 1 — TBD\n### Description\nTBD\n\n## Task 2 — Good Task\n### Description\nFully specified implementation with details\n\n## Task 3 — Edge Cases\n### Description\nCore work\n### Deliverables\n- Handle edge cases\n';
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(result.blocked, true);
+    assert.ok(result.violations.length >= 2, 'should report at least 2 violations');
+
+    const taskNums = result.violations.map((v) => v.task);
+    assert.ok(
+      taskNums.some((t) => t.includes('1')),
+      'should identify Task 1'
+    );
+    assert.ok(
+      taskNums.some((t) => t.includes('3')),
+      'should identify Task 3'
+    );
+
+    for (const v of result.violations) {
+      assert.ok(v.task, 'each violation must have task');
+      assert.ok(v.pattern, 'each violation must have pattern');
+      assert.ok(v.hint, 'each violation must have hint');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractTaskSections — Extracted Requirements before Task sections
+// ---------------------------------------------------------------------------
+
+describe('validateTaskDescriptions: Extracted Requirements precedes tasks', () => {
+  it('scans task sections even when preceded by Extracted Requirements', () => {
+    const content = [
+      '# Tasks',
+      '',
+      '## Extracted Requirements',
+      '- R1 — some requirement',
+      '',
+      '---',
+      '',
+      '## Task 1 — Test Task',
+      '',
+      '### Description',
+      'TBD',
+      '',
+    ].join('\n');
+    const result = validateTaskDescriptions(content);
+    assert.equal(result.blocked, true, 'Should detect TBD in task after Extracted Requirements');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contentGuard integration placeholder
+// ---------------------------------------------------------------------------
+
+describe('validateTaskDescriptions: contentGuard integration', () => {
+  it('policy function is callable from protect-artifact-files context', () => {
+    // This is a placeholder verifying the policy function can be called
+    // with the same signature the contentGuard adapter would use.
+    const content = buildTaskContent(1, 'Fully specified task with concrete details');
+    const result = validateTaskDescriptions(content);
+
+    assert.equal(typeof result.blocked, 'boolean');
+    assert.equal(result.blocked, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getBlockedPatterns
+// ---------------------------------------------------------------------------
+
+describe('getBlockedPatterns', () => {
+  it('returns at least 6 patterns, each with RegExp, label, and hint', () => {
+    const patterns = getBlockedPatterns();
+
+    assert.ok(Array.isArray(patterns), 'should return an array');
+    assert.ok(patterns.length >= 6, `should have at least 6 patterns, got ${patterns.length}`);
+
+    for (const p of patterns) {
+      assert.ok(p.pattern instanceof RegExp, `pattern should be a RegExp, got ${typeof p.pattern}`);
+      assert.ok(
+        typeof p.label === 'string' && p.label.length > 0,
+        'label should be a non-empty string'
+      );
+      assert.ok(
+        typeof p.hint === 'string' && p.hint.length > 0,
+        'hint should be a non-empty string'
+      );
+    }
+  });
+});

--- a/workflows/lib/hooks/policies/task-description-quality.js
+++ b/workflows/lib/hooks/policies/task-description-quality.js
@@ -1,0 +1,237 @@
+/**
+ * policies/task-description-quality.js
+ *
+ * Pure policy function that validates tasks.md content for vague or
+ * placeholder task descriptions. Returns a structured result indicating
+ * whether any tasks contain blocked patterns.
+ *
+ * Design constraints:
+ *   - CommonJS, zero dependencies
+ *   - Pure functions, no I/O or side effects
+ *   - Object.create(null) for any internal maps
+ *   - Case-insensitive matching (R5)
+ *   - No false positives for qualified descriptions (R8)
+ *   - Only scans within ## Task N sections (R12)
+ *   - TDD phase prefixes (**RED:**) exempt from "Add tests" pattern (R13)
+ */
+
+/** Minimum chars of qualifying detail after a trigger phrase (R8). */
+const QUALIFY_THRESHOLD = 20;
+
+/**
+ * Patterns that are always blocked (no qualification possible).
+ * @type {Array<{pattern: RegExp, label: string, hint: string, qualifiable: boolean}>}
+ */
+const BLOCKED_PATTERNS = Object.freeze([
+  {
+    pattern: /\btbd\b/i,
+    label: 'TBD',
+    hint: 'Replace the TBD placeholder with a concrete description of what this task delivers.',
+    qualifiable: false,
+  },
+  {
+    pattern: /\btodo\b/i,
+    label: 'TODO',
+    hint: 'Replace the TODO placeholder with specific implementation details.',
+    qualifiable: false,
+  },
+  {
+    pattern: /\bimplement later\b/i,
+    label: 'implement later',
+    hint: 'Remove the deferral phrase and describe what should be implemented now, or move to a separate task.',
+    qualifiable: true,
+  },
+  {
+    pattern: /\bto be determined\b/i,
+    label: 'to be determined',
+    hint: 'Replace with a concrete decision or escalate to the spec phase.',
+    qualifiable: false,
+  },
+  {
+    pattern: /\bhandle\s+(?:the\s+)?edge\s+cases?\b/i,
+    label: 'Handle edge cases',
+    hint: 'Specify which edge cases to handle (e.g. null input, empty array, overflow).',
+    qualifiable: true,
+  },
+  {
+    pattern: /\badd\s+(?:appropriate\s+)?error\s+handling\b/i,
+    label: 'Add appropriate error handling',
+    hint: 'Specify which error types to handle and the handling strategy (retry, fallback, abort).',
+    qualifiable: true,
+  },
+  {
+    pattern: /\badd\s+tests?\b/i,
+    label: 'Add tests',
+    hint: 'List specific test scenarios (e.g. "test that invalid input returns 400").',
+    qualifiable: true,
+  },
+  {
+    pattern: /\b(?:similar|same)\s+(?:as|to)\s+task\s+\d+/i,
+    label: 'Similar/Same as Task N',
+    hint: 'Repeat the actual steps instead of cross-referencing another task.',
+    qualifiable: false,
+  },
+]);
+
+/**
+ * Check whether a line has enough qualifying detail after the trigger phrase.
+ * @param {string} line
+ * @param {RegExp} pattern
+ * @returns {boolean} true if the line is sufficiently qualified
+ */
+function isQualified(line, pattern) {
+  const match = pattern.exec(line);
+  if (!match) return false;
+  const afterMatch = line.slice(match.index + match[0].length);
+  return afterMatch.length >= QUALIFY_THRESHOLD;
+}
+
+/**
+ * Check whether a line starts with a TDD phase prefix like **RED:** or **GREEN:**.
+ * @param {string} line — trimmed line
+ * @returns {boolean}
+ */
+function hasTddPrefix(line) {
+  return /\*\*(?:RED|GREEN|REFACTOR):\*\*/i.test(line);
+}
+
+/**
+ * Extract task sections from tasks.md content.
+ * Only returns content within ## Task N sections; stops at
+ * ## Requirement Coverage or similar trailing sections.
+ *
+ * @param {string} content
+ * @returns {Array<{taskId: string, body: string}>}
+ */
+function extractTaskSections(content) {
+  const sections = [];
+  const lines = content.split('\n');
+  let currentTask = null;
+  let bodyLines = [];
+
+  for (const line of lines) {
+    // Stop scanning at trailing non-task sections
+    if (/^##\s+Requirement\s+Coverage\b/i.test(line)) {
+      // Flush current task
+      if (currentTask) {
+        sections.push({ taskId: currentTask, body: bodyLines.join('\n') });
+        currentTask = null;
+        bodyLines = [];
+      }
+      break;
+    }
+
+    const taskMatch = line.match(/^##\s+Task\s+(\d+)\b/);
+    if (taskMatch) {
+      // Flush previous task
+      if (currentTask) {
+        sections.push({ taskId: currentTask, body: bodyLines.join('\n') });
+      }
+      currentTask = `Task ${taskMatch[1]}`;
+      bodyLines = [line]; // include the header line itself for patterns in title
+      continue;
+    }
+
+    if (currentTask) {
+      bodyLines.push(line);
+    }
+  }
+
+  // Flush last task
+  if (currentTask) {
+    sections.push({ taskId: currentTask, body: bodyLines.join('\n') });
+  }
+
+  return sections;
+}
+
+/**
+ * Validate tasks.md content for vague or placeholder descriptions.
+ *
+ * @param {string} content — full text of tasks.md
+ * @returns {{ blocked: boolean, message?: string, violations?: Array<{task: string, pattern: string, hint: string}> }}
+ */
+function validateTaskDescriptions(content) {
+  if (!content || typeof content !== 'string') {
+    return { blocked: false };
+  }
+
+  const sections = extractTaskSections(content);
+  const violations = [];
+
+  for (const section of sections) {
+    const sectionLines = section.body.split('\n');
+
+    for (const rawLine of sectionLines) {
+      const line = rawLine.trim();
+      if (!line) continue;
+
+      for (const entry of BLOCKED_PATTERNS) {
+        if (!entry.pattern.test(line)) continue;
+
+        // TDD prefix exemption (R13): lines like "**RED:** Add tests for ..."
+        if (hasTddPrefix(line)) continue;
+
+        // Qualification check (R8): if the pattern is qualifiable and the
+        // line has enough detail after the trigger phrase, skip it.
+        if (
+          entry.qualifiable &&
+          isQualified(line, new RegExp(entry.pattern.source, entry.pattern.flags))
+        ) {
+          continue;
+        }
+
+        violations.push({
+          task: section.taskId,
+          pattern: entry.label,
+          hint: entry.hint,
+        });
+
+        // One violation per pattern per line is enough
+        break;
+      }
+    }
+  }
+
+  // Deduplicate by (task, pattern) key — a pattern appearing on multiple
+  // lines within the same task section should only emit one violation.
+  const seen = Object.create(null);
+  const deduped = [];
+  for (const v of violations) {
+    const key = `${v.task}\0${v.pattern}`;
+    if (!seen[key]) {
+      seen[key] = true;
+      deduped.push(v);
+    }
+  }
+
+  if (deduped.length === 0) {
+    return { blocked: false };
+  }
+
+  const summary = deduped.map((v) => `  - ${v.task}: "${v.pattern}" — ${v.hint}`).join('\n');
+
+  return {
+    blocked: true,
+    message: `Vague task descriptions detected:\n${summary}`,
+    violations: deduped,
+  };
+}
+
+/**
+ * Returns the canonical list of blocked patterns.
+ *
+ * @returns {Array<{pattern: RegExp, label: string, hint: string}>}
+ */
+function getBlockedPatterns() {
+  return BLOCKED_PATTERNS.map((p) => ({
+    pattern: p.pattern,
+    label: p.label,
+    hint: p.hint,
+  }));
+}
+
+module.exports = {
+  validateTaskDescriptions,
+  getBlockedPatterns,
+};

--- a/workflows/lib/hooks/policies/task-description-quality.js
+++ b/workflows/lib/hooks/policies/task-description-quality.js
@@ -170,7 +170,9 @@ function validateTaskDescriptions(content) {
         if (!entry.pattern.test(line)) continue;
 
         // TDD prefix exemption (R13): lines like "**RED:** Add tests for ..."
-        if (hasTddPrefix(line)) continue;
+        // Only applies to qualifiable patterns — non-qualifiable patterns like
+        // TBD/TODO must still be blocked even on TDD-prefixed lines.
+        if (entry.qualifiable && hasTddPrefix(line)) continue;
 
         // Qualification check (R8): if the pattern is qualifiable and the
         // line has enough detail after the trigger phrase, skip it.

--- a/workflows/lib/hooks/policies/task-description-quality.js
+++ b/workflows/lib/hooks/policies/task-description-quality.js
@@ -174,10 +174,7 @@ function validateTaskDescriptions(content) {
 
         // Qualification check (R8): if the pattern is qualifiable and the
         // line has enough detail after the trigger phrase, skip it.
-        if (
-          entry.qualifiable &&
-          isQualified(line, new RegExp(entry.pattern.source, entry.pattern.flags))
-        ) {
+        if (entry.qualifiable && isQualified(line, entry.pattern)) {
           continue;
         }
 

--- a/workflows/work/__tests__/workflow-definition.test.js
+++ b/workflows/work/__tests__/workflow-definition.test.js
@@ -701,6 +701,38 @@ describe('workflow-definition: verify[STEPS.check] QA report gating', () => {
   });
 });
 
+// ─── GH-321 Task 4: tasks.md contentGuard ─────────────────────────────────────
+
+describe('workflow-definition: tasks.md contentGuard', () => {
+  const { artifactRules } = createWorkflowDefinition(stubDeps);
+
+  function getTasksRule() {
+    return artifactRules.find((r) => r.basename === 'tasks.md');
+  }
+
+  it('has a contentGuard on the tasks.md artifact rule', () => {
+    const rule = getTasksRule();
+    assert.ok(rule, 'tasks.md rule should exist in artifactRules');
+    assert.equal(typeof rule.contentGuard, 'function', 'tasks.md should have a contentGuard');
+  });
+
+  it('tasks.md contentGuard blocks vague descriptions', () => {
+    const rule = getTasksRule();
+    const result = rule.contentGuard('## Task 1 — Test\n\n### Description\nTBD\n');
+    assert.equal(result.blocked, true);
+    assert.ok(result.message, 'blocked result should include a message');
+  });
+
+  it('tasks.md contentGuard allows valid descriptions', () => {
+    const rule = getTasksRule();
+    const result = rule.contentGuard(
+      '## Task 1 — Test\n\n### Description\nImplement the user authentication flow with JWT tokens\n'
+    );
+    assert.equal(result.blocked, false);
+  });
+});
+
+
 // ─── GH-326 Task 1.2: .check.md contentGuard ─────────────────────────────────
 describe('workflow-definition: .check.md contentGuard', () => {
   const { artifactRules } = createWorkflowDefinition(stubDeps);

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -607,14 +607,32 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       },
     },
     { basename: 'spec.md', step: STEPS.spec, agents: ['spec-writer'] },
-    { basename: 'tasks.md', step: STEPS.tasks, allowedSteps: [STEPS.task_review], agents: [] },
+    {
+      basename: 'tasks.md',
+      step: STEPS.tasks,
+      allowedSteps: [STEPS.task_review],
+      agents: [],
+      contentGuard: (content) => {
+        try {
+          const { validateTaskDescriptions } = require(
+            path.join(__dirname, '..', 'lib', 'hooks', 'policies', 'task-description-quality')
+          );
+          const result = validateTaskDescriptions(content);
+          return result.blocked ? { blocked: true, message: result.message } : { blocked: false };
+        } catch {
+          return { blocked: false }; // fail-open
+        }
+      },
+    },
     { basename: '.last-commit-sha', step: STEPS.commit },
     {
       basename: 'code-review.check.md',
       step: STEPS.check,
       agents: ['code-checker'],
       contentGuard: (content) => {
-        const { validateCheckReportStatus } = require(path.join(__dirname, '..', 'lib', 'validate-check-report-status'));
+        const { validateCheckReportStatus } = require(
+          path.join(__dirname, '..', 'lib', 'validate-check-report-status')
+        );
         const result = validateCheckReportStatus(content, 'codeReview');
         return result.valid ? { blocked: false } : { blocked: true, message: result.message };
       },
@@ -624,7 +642,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       step: STEPS.check,
       agents: ['quality-checker'],
       contentGuard: (content) => {
-        const { validateCheckReportStatus } = require(path.join(__dirname, '..', 'lib', 'validate-check-report-status'));
+        const { validateCheckReportStatus } = require(
+          path.join(__dirname, '..', 'lib', 'validate-check-report-status')
+        );
         const result = validateCheckReportStatus(content, 'tests');
         return result.valid ? { blocked: false } : { blocked: true, message: result.message };
       },
@@ -634,7 +654,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       step: STEPS.check,
       agents: ['completion-checker'],
       contentGuard: (content) => {
-        const { validateCheckReportStatus } = require(path.join(__dirname, '..', 'lib', 'validate-check-report-status'));
+        const { validateCheckReportStatus } = require(
+          path.join(__dirname, '..', 'lib', 'validate-check-report-status')
+        );
         const result = validateCheckReportStatus(content, 'completion');
         return result.valid ? { blocked: false } : { blocked: true, message: result.message };
       },


### PR DESCRIPTION
## Existing Behavior

- `tasks.md` writes were accepted by the artifact guard with no validation of task description quality.
- Placeholder text such as `TBD`, `TODO`, `implement later`, `to be determined`, `Handle edge cases`, `Add appropriate error handling`, `Add tests`, and `Similar/Same as Task N` could be committed to `tasks.md` without any enforcement.
- `SKILL.md` listed anti-patterns for split-in-tasks only as prose guidelines with no machine-enforced equivalent.
- The `workflow-definition.js` `require` call formatting for other `contentGuard` blocks was inconsistent with the project style.

## Intended New Behavior

- A new pure policy module `workflows/lib/hooks/policies/task-description-quality.js` defines the canonical blocked-pattern list and exports `validateTaskDescriptions` / `getBlockedPatterns`.
- `tasks.md` now has a `contentGuard` wired into the artifact rule in `workflow-definition.js`; writes containing vague descriptions are blocked (fail-open on unexpected errors).
- Qualifiable patterns (e.g. `Handle edge cases`, `Add tests`) are allowed when followed by 20+ characters of specific detail; non-qualifiable patterns (`TBD`, `TODO`, `to be determined`, `Similar/Same as Task N`) are always blocked.
- TDD phase-prefixed lines (`**RED:** Add tests …`, including checkbox variants) are exempt from the `Add tests` block.
- `SKILL.md` now references `task-description-quality.js` as the canonical source of blocked patterns, keeping documentation and enforcement in sync.

## Dev Checks

- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Policy unit tests** (`workflows/lib/hooks/policies/__tests__/task-description-quality.test.js`):

1. Run `node --test workflows/lib/hooks/policies/__tests__/task-description-quality.test.js`
2. All 409 lines of test assertions should pass, covering: blocking patterns, false-positive avoidance (qualified descriptions pass), deduplication, multi-task reporting, Extracted Requirements section skip, TDD prefix exemption, and `getBlockedPatterns` shape.

**Workflow-definition integration tests** (`workflows/work/__tests__/workflow-definition.test.js`):

1. Run `node --test workflows/work/__tests__/workflow-definition.test.js`
2. The three new tests under `workflow-definition: tasks.md contentGuard` should pass: existence of `contentGuard`, blocking on a TBD description, and allowing a valid description.

**Manual end-to-end verification:**

1. Start a `/work` session and progress to the `tasks` step.
2. Write a `tasks.md` containing `## Task 1 — TBD\n### Description\nTBD`.
3. Confirm the write is rejected with a message listing the violation and a remediation hint.
4. Rewrite the description with a concrete sentence (20+ chars of qualifying detail); confirm the write is accepted.

Closes #321

### Test Results
Tests cover `validateTaskDescriptions` (blocking patterns, false-positive avoidance, deduplication, multi-violation reporting, Extracted Requirements handling, contentGuard integration) and `getBlockedPatterns` shape — 409-line test file with node:test runner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new enforcement that can block `tasks.md` writes based on pattern matching; although it fails open on unexpected errors, it may still disrupt workflow if the rules are too strict or produce false positives.
> 
> **Overview**
> Introduces a new `task-description-quality` policy and wires it into the `tasks.md` artifact `contentGuard`, rejecting placeholder/vague task text (e.g. `TBD`, `TODO`, unqualified “Handle edge cases”, “Add tests”, and “Similar/Same as Task N”), with exemptions for sufficiently qualified lines and TDD-prefixed deliverables.
> 
> Adds comprehensive unit tests for the policy plus workflow-definition integration tests, and updates `split-in-tasks` `SKILL.md` to reference the policy as the canonical blocked-pattern list (keeping docs aligned with enforcement).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a99b0cc4ddc934e9c50a0043df65e58c74f3a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->