### PR TITLE
feat(check): unify QA report status language with other report types

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,13 +14,7 @@
       "source": "./",
       "description": "Orchestrated /work command with pre-computed action plans",
       "category": "workflow",
-      "tags": [
-        "workflow",
-        "jira",
-        "orchestrator",
-        "state-machine",
-        "automation"
-      ]
+      "tags": ["workflow", "jira", "orchestrator", "state-machine", "automation"]
     }
   ]
 }

--- a/agents/qa-api-tester.md
+++ b/agents/qa-api-tester.md
@@ -458,9 +458,9 @@ The report `Status:` line uses a canonical vocabulary for downstream gate compat
 | Agent Input | Report Output |
 |-------------|---------------|
 | `PASS` | `APPROVED` |
-| `FAIL`, `BLOCKED` | `NEEDS_WORK` |
+| `FAIL`, `ACCESS_FAILED`, `BLOCKED` | `NEEDS_WORK` |
 
-You still use PASS, FAIL, and BLOCKED as your per-test verdicts. The `write-qa-report.js` script translates the overall result to APPROVED or NEEDS_WORK on the report `Status:` line.
+You still use PASS, FAIL, ACCESS_FAILED, and BLOCKED as your per-test verdicts. The `write-qa-report.js` script translates the overall result to APPROVED or NEEDS_WORK on the report `Status:` line.
 
 ## MANDATORY REPORT FILE - YOU MUST SAVE THIS
 

--- a/agents/qa-api-tester.md
+++ b/agents/qa-api-tester.md
@@ -451,6 +451,17 @@ Testing: User CRUD API
 - Database has correct data after operation
 - Service behaves as expected
 
+### Report Output Status
+
+The report `Status:` line uses a canonical vocabulary for downstream gate compatibility:
+
+| Agent Input | Report Output |
+|-------------|---------------|
+| `PASS` | `APPROVED` |
+| `FAIL`, `BLOCKED` | `NEEDS_WORK` |
+
+You still use PASS, FAIL, and BLOCKED as your per-test verdicts. The `write-qa-report.js` script translates the overall result to APPROVED or NEEDS_WORK on the report `Status:` line.
+
 ## MANDATORY REPORT FILE - YOU MUST SAVE THIS
 
 ```

--- a/agents/qa-feature-tester.md
+++ b/agents/qa-feature-tester.md
@@ -110,6 +110,17 @@ Report one of these five statuses for each app:
 Valid failure statuses: `ACCESS_FAILED` (Playwright unavailable, connection refused), `BLOCKED` (environment issue).
 Deprecated statuses (never use): ~~PARTIAL PASS~~, ~~PASS (API only)~~, ~~INFRASTRUCTURE_FAILURE~~ (replaced by `ACCESS_FAILED`).
 
+### Report Output Status
+
+The `write-qa-report.js` script generates the final report `Status:` line using a canonical vocabulary:
+
+| Agent Input | Report Output |
+|-------------|---------------|
+| `PASS` | `APPROVED` |
+| `FAIL`, `ACCESS_FAILED`, `BLOCKED` | `NEEDS_WORK` |
+
+You still pass the input statuses above (PASS, FAIL, ACCESS_FAILED, BLOCKED) to the report script. The script translates them to APPROVED or NEEDS_WORK on the `Status:` line for downstream gate compatibility.
+
 **Forbidden test commands:** `pnpm test`, `vitest`, `jest`, `pnpm test:smoke`, `pnpm test:integration`, `pnpm test:e2e`. You are a manual tester using browser and curl.
 
 ## 3. Source Code Policy

--- a/skills/check-qa/SKILL.md
+++ b/skills/check-qa/SKILL.md
@@ -454,6 +454,8 @@ ${E2E_DOCS}
 
 Reports are validated by SubagentStop hook: `${CLAUDE_PLUGIN_ROOT}/workflows/check/agents/qa-feature-tester/validate-qa-report.js`
 
+**Report output status:** The `write-qa-report.js` script sets the report `Status:` line to `APPROVED` (when agent passes PASS) or `NEEDS_WORK` (when agent passes FAIL, ACCESS_FAILED, or BLOCKED). Agents still use the input vocabulary (PASS/FAIL/ACCESS_FAILED/BLOCKED) — the script handles the translation.
+
 **Blocked if:**
 - Missing report file
 - Missing `**Changes Hash:**` header

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -989,7 +989,7 @@ fi
 ║                                                                      ║
 ╚══════════════════════════════════════════════════════════════════════╝
 ```
-Exit with ACCESS_FAILED status (not APPROVED).
+Exit with NEEDS_WORK status (infrastructure failure prevents APPROVED).
 
 **If no infrastructure failures:** Continue with validation:
 

--- a/workflows/check/agents/qa-feature-tester/__tests__/validate-qa-report.test.js
+++ b/workflows/check/agents/qa-feature-tester/__tests__/validate-qa-report.test.js
@@ -17,8 +17,12 @@ function buildQAReport(statusToken, opts = {}) {
   const browserEvidence = opts.noBrowserEvidence
     ? ''
     : '`mcp__playwright__navigate` Result: SUCCESS\n';
-  const infraLine = opts.infraFailure ? 'INFRASTRUCTURE_FAILURE\n## MCP Diagnostics\nListMcpResourcesTool\n' : '';
-  const accessLine = opts.accessFailed ? 'ACCESS_FAILED\n## MCP Diagnostics\nListMcpResourcesTool\n' : '';
+  const infraLine = opts.infraFailure
+    ? 'INFRASTRUCTURE_FAILURE\n## MCP Diagnostics\nListMcpResourcesTool\n'
+    : '';
+  const accessLine = opts.accessFailed
+    ? 'ACCESS_FAILED\n## MCP Diagnostics\nListMcpResourcesTool\n'
+    : '';
 
   return [
     '# QA Report',
@@ -47,8 +51,12 @@ function runScript(reportPath) {
     let stderr = '';
     let stdout = '';
 
-    child.stderr.on('data', (d) => { stderr += d; });
-    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => {
+      stderr += d;
+    });
+    child.stdout.on('data', (d) => {
+      stdout += d;
+    });
 
     const stdinData = JSON.stringify({
       task_prompt: `REPORT_PATH: ${reportPath}`,

--- a/workflows/check/agents/qa-feature-tester/__tests__/validate-qa-report.test.js
+++ b/workflows/check/agents/qa-feature-tester/__tests__/validate-qa-report.test.js
@@ -1,0 +1,151 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawn } = require('child_process');
+
+const SCRIPT = path.resolve(__dirname, '..', 'validate-qa-report.js');
+const TEMP = path.join(os.tmpdir(), 'validate-qa-report-test-' + process.pid);
+
+/**
+ * Build a minimal valid QA report with the given status in a table row
+ * and a Status: line. Includes all required sections.
+ */
+function buildQAReport(statusToken, opts = {}) {
+  const screenshotLine = opts.noScreenshots ? '' : '![screenshot](./screenshots/test.png)\n';
+  const browserEvidence = opts.noBrowserEvidence
+    ? ''
+    : '`mcp__playwright__navigate` Result: SUCCESS\n';
+  const infraLine = opts.infraFailure ? 'INFRASTRUCTURE_FAILURE\n## MCP Diagnostics\nListMcpResourcesTool\n' : '';
+  const accessLine = opts.accessFailed ? 'ACCESS_FAILED\n## MCP Diagnostics\nListMcpResourcesTool\n' : '';
+
+  return [
+    '# QA Report',
+    '',
+    '## Playwright Verification',
+    '',
+    browserEvidence,
+    screenshotLine,
+    '| Test | Status |',
+    '|------|--------|',
+    `| Login | ${statusToken} |`,
+    '',
+    `Status: ${statusToken}`,
+    '',
+    infraLine,
+    accessLine,
+  ].join('\n');
+}
+
+/**
+ * Run the validate-qa-report.js script by piping stdin, return exit code and stderr.
+ */
+function runScript(reportPath) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [SCRIPT], { timeout: 10000 });
+    let stderr = '';
+    let stdout = '';
+
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.stdout.on('data', (d) => { stdout += d; });
+
+    const stdinData = JSON.stringify({
+      task_prompt: `REPORT_PATH: ${reportPath}`,
+    });
+    child.stdin.write(stdinData);
+    child.stdin.end();
+
+    child.on('close', (code) => {
+      resolve({ exitCode: code, stderr, stdout });
+    });
+    child.on('error', reject);
+  });
+}
+
+before(() => {
+  fs.mkdirSync(TEMP, { recursive: true });
+});
+
+after(() => {
+  fs.rmSync(TEMP, { recursive: true, force: true });
+});
+
+describe('validate-qa-report.js — hasTestStatus canonical status matching', () => {
+  // --- Backward compat: legacy statuses ---
+
+  it('accepts a QA report with legacy PASS status in table', async () => {
+    const reportPath = path.join(TEMP, 'qa-legacy-pass.check.md');
+    fs.writeFileSync(reportPath, buildQAReport('PASS'));
+
+    const { exitCode, stderr } = await runScript(reportPath);
+    assert.equal(exitCode, 0, `Should pass validation, stderr: ${stderr}`);
+  });
+
+  it('accepts a QA report with legacy FAIL status in table', async () => {
+    const reportPath = path.join(TEMP, 'qa-legacy-fail.check.md');
+    fs.writeFileSync(reportPath, buildQAReport('FAIL'));
+
+    const { exitCode, stderr } = await runScript(reportPath);
+    assert.equal(exitCode, 0, `Should pass validation, stderr: ${stderr}`);
+  });
+
+  // --- Canonical statuses ---
+
+  it('accepts a QA report with canonical APPROVED status in table', async () => {
+    const reportPath = path.join(TEMP, 'qa-canonical-approved.check.md');
+    fs.writeFileSync(reportPath, buildQAReport('APPROVED'));
+
+    const { exitCode, stderr } = await runScript(reportPath);
+    assert.equal(exitCode, 0, `APPROVED should be accepted, stderr: ${stderr}`);
+  });
+
+  it('accepts a QA report with canonical NEEDS_WORK status in table', async () => {
+    const reportPath = path.join(TEMP, 'qa-canonical-needs-work.check.md');
+    fs.writeFileSync(reportPath, buildQAReport('NEEDS_WORK'));
+
+    const { exitCode, stderr } = await runScript(reportPath);
+    assert.equal(exitCode, 0, `NEEDS_WORK should be accepted, stderr: ${stderr}`);
+  });
+
+  it('accepts a QA report with APPROVED in Status: line only', async () => {
+    const reportPath = path.join(TEMP, 'qa-status-line-approved.check.md');
+    // Report with APPROVED only in the Status: line (not in table)
+    const content = [
+      '# QA Report',
+      '',
+      '## Playwright Verification',
+      '',
+      '`mcp__playwright__navigate` Result: SUCCESS',
+      '',
+      '![screenshot](./screenshots/test.png)',
+      '',
+      'Status: APPROVED',
+      '',
+    ].join('\n');
+    fs.writeFileSync(reportPath, content);
+
+    const { exitCode, stderr } = await runScript(reportPath);
+    assert.equal(exitCode, 0, `APPROVED in Status: line should be accepted, stderr: ${stderr}`);
+  });
+
+  it('accepts a QA report with NEEDS_WORK in Status: line only', async () => {
+    const reportPath = path.join(TEMP, 'qa-status-line-needs-work.check.md');
+    const content = [
+      '# QA Report',
+      '',
+      '## Playwright Verification',
+      '',
+      '`mcp__playwright__navigate` Result: SUCCESS',
+      '',
+      '![screenshot](./screenshots/test.png)',
+      '',
+      'Status: NEEDS_WORK',
+      '',
+    ].join('\n');
+    fs.writeFileSync(reportPath, content);
+
+    const { exitCode, stderr } = await runScript(reportPath);
+    assert.equal(exitCode, 0, `NEEDS_WORK in Status: line should be accepted, stderr: ${stderr}`);
+  });
+});

--- a/workflows/check/agents/qa-feature-tester/validate-qa-report.js
+++ b/workflows/check/agents/qa-feature-tester/validate-qa-report.js
@@ -79,9 +79,10 @@ async function main() {
     }
 
     // Check: Has structured test results (in table rows or after "Status:" labels)
+    // Matches canonical statuses (APPROVED/NEEDS_WORK) alongside legacy ones (PASS/FAIL)
     const hasTestStatus =
-      /\|\s*(PASS|FAIL)\s*\|/i.test(content) ||
-      /Status:\s*(PASS|FAIL)/i.test(content) ||
+      /\|\s*(PASS|FAIL|APPROVED|NEEDS_WORK)\s*\|/i.test(content) ||
+      /Status:\s*(PASS|FAIL|APPROVED|NEEDS_WORK)/i.test(content) ||
       content.includes('INFRASTRUCTURE_FAILURE') ||
       content.includes('ACCESS_FAILED');
     if (!hasTestStatus) {

--- a/workflows/check/hooks/__tests__/check-validate-reports.test.js
+++ b/workflows/check/hooks/__tests__/check-validate-reports.test.js
@@ -1,0 +1,152 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync } = require('child_process');
+
+const SCRIPT = path.resolve(__dirname, '..', 'check-validate-reports.js');
+const TEMP = path.join(os.tmpdir(), 'check-validate-reports-test-' + process.pid);
+
+/**
+ * Build a minimal QA report with the given status token.
+ * Includes all required sections so only the status line varies.
+ */
+function buildQAReport(statusToken, opts = {}) {
+  const lines = [
+    '**Changes Hash:** abc123',
+    '',
+    `Status: ${statusToken}`,
+    '',
+    '## Playwright Verification',
+    '',
+    '![screenshot](./screenshots/test.png)',
+    '',
+  ];
+  if (opts.infraFailure) {
+    lines.push('INFRASTRUCTURE_FAILURE');
+  }
+  if (opts.accessFailed) {
+    lines.push('ACCESS_FAILED');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Run the validate-reports script and return parsed JSON + exit code.
+ */
+function runScript(reportFolder, impactedApps) {
+  try {
+    const stdout = execFileSync('node', [SCRIPT, reportFolder, JSON.stringify(impactedApps)], {
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+    return { exitCode: 0, result: JSON.parse(stdout) };
+  } catch (err) {
+    const stdout = (err.stdout || '').toString();
+    let result = null;
+    try {
+      result = JSON.parse(stdout);
+    } catch (_) {
+      /* script may not output valid JSON on some failures */
+    }
+    return { exitCode: err.status, result };
+  }
+}
+
+function setupDir(name) {
+  const dir = path.join(TEMP, name);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+before(() => {
+  fs.mkdirSync(TEMP, { recursive: true });
+});
+
+after(() => {
+  fs.rmSync(TEMP, { recursive: true, force: true });
+});
+
+describe('check-validate-reports.js — validateQAReport canonical status matching', () => {
+  // --- Backward compat: legacy statuses still work ---
+
+  it('accepts a QA report with legacy PASS status', () => {
+    const dir = setupDir('legacy-pass');
+    // Write required non-QA reports so the script doesn't fail on missing files
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), '**Changes Hash:** x\n✅ PASS');
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), '**Changes Hash:** x\nNo issues');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), '**Changes Hash:** x\nCOMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), 'readme');
+    fs.writeFileSync(path.join(dir, 'qa-myapp.check.md'), buildQAReport('PASS'));
+
+    const { result } = runScript(dir, ['myapp']);
+    assert.ok(result.reports.qa.myapp.exists, 'report should exist');
+    assert.ok(!result.reports.qa.myapp.failed, 'PASS should not be marked failed');
+    // hasStatus must have detected PASS
+    assert.deepEqual(result.reports.qa.myapp.issues.filter(i => i.includes('Missing PASS/FAIL')), []);
+  });
+
+  it('detects a QA report with legacy FAIL status as failed', () => {
+    const dir = setupDir('legacy-fail');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), '**Changes Hash:** x\n✅ PASS');
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), '**Changes Hash:** x\nNo issues');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), '**Changes Hash:** x\nCOMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), 'readme');
+    fs.writeFileSync(
+      path.join(dir, 'qa-myapp.check.md'),
+      buildQAReport('FAIL').replace('Status: FAIL', '❌ FAIL\nStatus: FAIL')
+    );
+
+    const { result } = runScript(dir, ['myapp']);
+    assert.ok(result.reports.qa.myapp.failed, 'FAIL should be detected as failed');
+  });
+
+  // --- Canonical statuses: APPROVED / NEEDS_WORK ---
+
+  it('accepts a QA report with canonical APPROVED status (no missing-status issue)', () => {
+    const dir = setupDir('canonical-approved');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), '**Changes Hash:** x\n✅ PASS');
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), '**Changes Hash:** x\nNo issues');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), '**Changes Hash:** x\nCOMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), 'readme');
+    fs.writeFileSync(path.join(dir, 'qa-myapp.check.md'), buildQAReport('APPROVED'));
+
+    const { result } = runScript(dir, ['myapp']);
+    assert.ok(result.reports.qa.myapp.exists, 'report should exist');
+    // The key assertion: APPROVED must be recognized as a valid status
+    const statusIssues = result.reports.qa.myapp.issues.filter(i => i.includes('Missing'));
+    assert.deepEqual(statusIssues, [], 'APPROVED should be recognized as a valid status');
+    assert.ok(!result.reports.qa.myapp.failed, 'APPROVED should not be marked failed');
+  });
+
+  it('detects a QA report with canonical NEEDS_WORK status as failed', () => {
+    const dir = setupDir('canonical-needs-work');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), '**Changes Hash:** x\n✅ PASS');
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), '**Changes Hash:** x\nNo issues');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), '**Changes Hash:** x\nCOMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), 'readme');
+    fs.writeFileSync(
+      path.join(dir, 'qa-myapp.check.md'),
+      buildQAReport('NEEDS_WORK').replace('Status: NEEDS_WORK', '❌ NEEDS_WORK\nStatus: NEEDS_WORK')
+    );
+
+    const { result } = runScript(dir, ['myapp']);
+    assert.ok(result.reports.qa.myapp.exists, 'report should exist');
+    // The key assertion: NEEDS_WORK must be detected as failed
+    assert.ok(result.reports.qa.myapp.failed, 'NEEDS_WORK should be detected as failed');
+  });
+
+  it('recognizes NEEDS_WORK in Status: line as a valid status (no missing-status issue)', () => {
+    const dir = setupDir('canonical-needs-work-status');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), '**Changes Hash:** x\n✅ PASS');
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), '**Changes Hash:** x\nNo issues');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), '**Changes Hash:** x\nCOMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), 'readme');
+    fs.writeFileSync(path.join(dir, 'qa-myapp.check.md'), buildQAReport('NEEDS_WORK'));
+
+    const { result } = runScript(dir, ['myapp']);
+    const statusIssues = result.reports.qa.myapp.issues.filter(i => i.includes('Missing'));
+    assert.deepEqual(statusIssues, [], 'NEEDS_WORK should be recognized as a valid status');
+  });
+});

--- a/workflows/check/hooks/__tests__/check-validate-reports.test.js
+++ b/workflows/check/hooks/__tests__/check-validate-reports.test.js
@@ -84,7 +84,10 @@ describe('check-validate-reports.js — validateQAReport canonical status matchi
     assert.ok(result.reports.qa.myapp.exists, 'report should exist');
     assert.ok(!result.reports.qa.myapp.failed, 'PASS should not be marked failed');
     // hasStatus must have detected PASS
-    assert.deepEqual(result.reports.qa.myapp.issues.filter(i => i.includes('Missing PASS/FAIL')), []);
+    assert.deepEqual(
+      result.reports.qa.myapp.issues.filter((i) => i.includes('Missing PASS/FAIL')),
+      []
+    );
   });
 
   it('detects a QA report with legacy FAIL status as failed', () => {
@@ -115,7 +118,7 @@ describe('check-validate-reports.js — validateQAReport canonical status matchi
     const { result } = runScript(dir, ['myapp']);
     assert.ok(result.reports.qa.myapp.exists, 'report should exist');
     // The key assertion: APPROVED must be recognized as a valid status
-    const statusIssues = result.reports.qa.myapp.issues.filter(i => i.includes('Missing'));
+    const statusIssues = result.reports.qa.myapp.issues.filter((i) => i.includes('Missing'));
     assert.deepEqual(statusIssues, [], 'APPROVED should be recognized as a valid status');
     assert.ok(!result.reports.qa.myapp.failed, 'APPROVED should not be marked failed');
   });
@@ -146,7 +149,7 @@ describe('check-validate-reports.js — validateQAReport canonical status matchi
     fs.writeFileSync(path.join(dir, 'qa-myapp.check.md'), buildQAReport('NEEDS_WORK'));
 
     const { result } = runScript(dir, ['myapp']);
-    const statusIssues = result.reports.qa.myapp.issues.filter(i => i.includes('Missing'));
+    const statusIssues = result.reports.qa.myapp.issues.filter((i) => i.includes('Missing'));
     assert.deepEqual(statusIssues, [], 'NEEDS_WORK should be recognized as a valid status');
   });
 });

--- a/workflows/check/hooks/__tests__/check-validate-reports.test.js
+++ b/workflows/check/hooks/__tests__/check-validate-reports.test.js
@@ -140,6 +140,24 @@ describe('check-validate-reports.js — validateQAReport canonical status matchi
     assert.ok(result.reports.qa.myapp.failed, 'NEEDS_WORK should be detected as failed');
   });
 
+  it('does not false-positive when stale NEEDS_WORK appears in Previous Run section', () => {
+    const dir = setupDir('stale-previous-run');
+    fs.writeFileSync(path.join(dir, 'tests.check.md'), '**Changes Hash:** x\n✅ PASS');
+    fs.writeFileSync(path.join(dir, 'code-review.check.md'), '**Changes Hash:** x\nNo issues');
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), '**Changes Hash:** x\nCOMPLETE');
+    fs.writeFileSync(path.join(dir, 'README.md'), 'readme');
+    // Current run is APPROVED, but Previous Run section has NEEDS_WORK
+    const report =
+      buildQAReport('APPROVED') + '\n---\n# Previous Run\n---\nStatus: NEEDS_WORK\n❌ NEEDS_WORK\n';
+    fs.writeFileSync(path.join(dir, 'qa-myapp.check.md'), report);
+
+    const { result } = runScript(dir, ['myapp']);
+    assert.ok(
+      !result.reports.qa.myapp.failed,
+      'stale NEEDS_WORK in Previous Run should not mark current run as failed'
+    );
+  });
+
   it('recognizes NEEDS_WORK in Status: line as a valid status (no missing-status issue)', () => {
     const dir = setupDir('canonical-needs-work-status');
     fs.writeFileSync(path.join(dir, 'tests.check.md'), '**Changes Hash:** x\n✅ PASS');

--- a/workflows/check/hooks/check-generate-summary.js
+++ b/workflows/check/hooks/check-generate-summary.js
@@ -96,8 +96,17 @@ function generateSummary() {
         overallQAStatus = { status: AppAccessStatus.ACCESS_FAILED, icon: '🔒' };
       }
     } else if (qaStatuses[app].status === 'NEEDS_WORK' && !hasInfraFailure) {
-      testFailedApps.push(app);
-      overallQAStatus = { status: 'NEEDS_WORK', icon: '❌' };
+      // GH-331: canonical NEEDS_WORK may mask ACCESS_FAILED — check content body
+      if (qaContent && qaContent.includes(AppAccessStatus.ACCESS_FAILED)) {
+        hasAccessFailure = true;
+        accessFailedApps.push(app);
+        if (!hasInfraFailure) {
+          overallQAStatus = { status: AppAccessStatus.ACCESS_FAILED, icon: '🔒' };
+        }
+      } else {
+        testFailedApps.push(app);
+        overallQAStatus = { status: 'NEEDS_WORK', icon: '❌' };
+      }
     } else if (qaStatuses[app].status === 'MISSING' && overallQAStatus.status === 'APPROVED') {
       overallQAStatus = { status: 'MISSING', icon: '❓' };
     }

--- a/workflows/check/hooks/check-generate-summary.js
+++ b/workflows/check/hooks/check-generate-summary.js
@@ -96,13 +96,14 @@ function generateSummary() {
         overallQAStatus = { status: AppAccessStatus.ACCESS_FAILED, icon: '🔒' };
       }
     } else if (qaStatuses[app].status === 'NEEDS_WORK' && !hasInfraFailure) {
-      // GH-331: canonical NEEDS_WORK may mask ACCESS_FAILED — check content body
-      if (qaContent && qaContent.includes(AppAccessStatus.ACCESS_FAILED)) {
+      // GH-331: canonical NEEDS_WORK may mask infra statuses — check content body
+      if (qaContent && qaContent.includes('INFRASTRUCTURE_FAILURE')) {
+        hasInfraFailure = true;
+        overallQAStatus = { status: 'INFRASTRUCTURE_FAILURE', icon: '🛑' };
+      } else if (qaContent && qaContent.includes(AppAccessStatus.ACCESS_FAILED)) {
         hasAccessFailure = true;
         accessFailedApps.push(app);
-        if (!hasInfraFailure) {
-          overallQAStatus = { status: AppAccessStatus.ACCESS_FAILED, icon: '🔒' };
-        }
+        overallQAStatus = { status: AppAccessStatus.ACCESS_FAILED, icon: '🔒' };
       } else {
         testFailedApps.push(app);
         overallQAStatus = { status: 'NEEDS_WORK', icon: '❌' };

--- a/workflows/check/hooks/check-validate-reports.js
+++ b/workflows/check/hooks/check-validate-reports.js
@@ -103,14 +103,22 @@ function validateQAReport(filePath, appName) {
     issues.push('No screenshots found - QA reports must include visual evidence');
   }
 
-  // Check for pass/fail status
-  const hasStatus = content.includes('PASS') || content.includes('FAIL');
+  // Check for pass/fail status (canonical: APPROVED/NEEDS_WORK, legacy: PASS/FAIL)
+  const hasStatus =
+    content.includes('PASS') ||
+    content.includes('FAIL') ||
+    content.includes('APPROVED') ||
+    content.includes('NEEDS_WORK');
   if (!hasStatus) {
     issues.push('Missing PASS/FAIL status');
   }
 
-  // Check if marked as failed
-  const failed = content.includes('❌ FAIL') || content.includes('Status: FAIL');
+  // Check if marked as failed (canonical: NEEDS_WORK, legacy: FAIL)
+  const failed =
+    content.includes('❌ FAIL') ||
+    content.includes('Status: FAIL') ||
+    content.includes('❌ NEEDS_WORK') ||
+    content.includes('Status: NEEDS_WORK');
 
   return {
     exists: true,

--- a/workflows/check/hooks/check-validate-reports.js
+++ b/workflows/check/hooks/check-validate-reports.js
@@ -113,15 +113,18 @@ function validateQAReport(filePath, appName) {
     issues.push('Missing PASS/FAIL/APPROVED/NEEDS_WORK status');
   }
 
-  // Check if marked as failed using only the FIRST Status: line (not full content).
-  // Reports may contain "Previous Run" sections with stale statuses — scanning
-  // the entire content would false-positive a current APPROVED run as failed.
-  // Fallback: if no Status: line exists (legacy reports), check for ❌ FAIL/NEEDS_WORK markers.
+  // Check if marked as failed using the FIRST Status: line + body markers in current run.
+  // Reports may contain "Previous Run" sections with stale statuses — limit body scan
+  // to content before the first "# Previous Run" delimiter.
   const statusLineMatch = content.match(/^Status:\s*(\S+)/m);
   const firstStatus = statusLineMatch ? statusLineMatch[1] : '';
+  const prevRunIdx = content.indexOf('# Previous Run');
+  const currentRunContent = prevRunIdx > -1 ? content.slice(0, prevRunIdx) : content;
+  const bodyHasFailMarker =
+    currentRunContent.includes('❌ FAIL') || currentRunContent.includes('❌ NEEDS_WORK');
   const failed = statusLineMatch
-    ? firstStatus === 'FAIL' || firstStatus === 'NEEDS_WORK'
-    : content.includes('❌ FAIL') || content.includes('❌ NEEDS_WORK');
+    ? firstStatus === 'FAIL' || firstStatus === 'NEEDS_WORK' || bodyHasFailMarker
+    : bodyHasFailMarker;
 
   return {
     exists: true,

--- a/workflows/check/hooks/check-validate-reports.js
+++ b/workflows/check/hooks/check-validate-reports.js
@@ -116,9 +116,12 @@ function validateQAReport(filePath, appName) {
   // Check if marked as failed using only the FIRST Status: line (not full content).
   // Reports may contain "Previous Run" sections with stale statuses — scanning
   // the entire content would false-positive a current APPROVED run as failed.
+  // Fallback: if no Status: line exists (legacy reports), check for ❌ FAIL/NEEDS_WORK markers.
   const statusLineMatch = content.match(/^Status:\s*(\S+)/m);
   const firstStatus = statusLineMatch ? statusLineMatch[1] : '';
-  const failed = firstStatus === 'FAIL' || firstStatus === 'NEEDS_WORK';
+  const failed = statusLineMatch
+    ? firstStatus === 'FAIL' || firstStatus === 'NEEDS_WORK'
+    : content.includes('❌ FAIL') || content.includes('❌ NEEDS_WORK');
 
   return {
     exists: true,

--- a/workflows/check/hooks/check-validate-reports.js
+++ b/workflows/check/hooks/check-validate-reports.js
@@ -113,12 +113,12 @@ function validateQAReport(filePath, appName) {
     issues.push('Missing PASS/FAIL/APPROVED/NEEDS_WORK status');
   }
 
-  // Check if marked as failed (canonical: NEEDS_WORK, legacy: FAIL)
-  const failed =
-    content.includes('❌ FAIL') ||
-    content.includes('Status: FAIL') ||
-    content.includes('❌ NEEDS_WORK') ||
-    content.includes('Status: NEEDS_WORK');
+  // Check if marked as failed using only the FIRST Status: line (not full content).
+  // Reports may contain "Previous Run" sections with stale statuses — scanning
+  // the entire content would false-positive a current APPROVED run as failed.
+  const statusLineMatch = content.match(/^Status:\s*(\S+)/m);
+  const firstStatus = statusLineMatch ? statusLineMatch[1] : '';
+  const failed = firstStatus === 'FAIL' || firstStatus === 'NEEDS_WORK';
 
   return {
     exists: true,

--- a/workflows/check/hooks/check-validate-reports.js
+++ b/workflows/check/hooks/check-validate-reports.js
@@ -110,7 +110,7 @@ function validateQAReport(filePath, appName) {
     content.includes('APPROVED') ||
     content.includes('NEEDS_WORK');
   if (!hasStatus) {
-    issues.push('Missing PASS/FAIL status');
+    issues.push('Missing PASS/FAIL/APPROVED/NEEDS_WORK status');
   }
 
   // Check if marked as failed (canonical: NEEDS_WORK, legacy: FAIL)

--- a/workflows/check/scripts/write-qa-report.js
+++ b/workflows/check/scripts/write-qa-report.js
@@ -122,7 +122,9 @@ const writer = createReportWriter({
     const timestamp = new Date().toISOString();
 
     // Header with changes hash (required for cache validation)
-    // Status line for downstream gate compatibility (check-generate-summary.js)
+    // Map QA statuses to canonical gate statuses:
+    //   PASS → APPROVED
+    //   FAIL, INFRASTRUCTURE_FAILURE, ACCESS_FAILED, BLOCKED → NEEDS_WORK
     const gateStatus = input.status === 'PASS' ? 'APPROVED' : 'NEEDS_WORK';
     lines.push(`**Changes Hash:** ${input.changesHash}`);
     lines.push(`Status: ${gateStatus}`);

--- a/workflows/check/scripts/write-qa-report.js
+++ b/workflows/check/scripts/write-qa-report.js
@@ -33,6 +33,8 @@ const ALLOWED_STATUSES = ['PASS', 'FAIL', 'INFRASTRUCTURE_FAILURE', 'ACCESS_FAIL
 const writer = createReportWriter({
   name: 'QA Report Writer',
 
+  reportType: 'qa',
+
   allowedAgents: ['qa-feature-tester', 'qa-api-tester'],
 
   requiredFields: [
@@ -121,8 +123,7 @@ const writer = createReportWriter({
 
     // Header with changes hash (required for cache validation)
     // Status line for downstream gate compatibility (check-generate-summary.js)
-    const gateStatus =
-      input.status === 'PASS' ? 'APPROVED' : input.status === 'FAIL' ? 'NEEDS_WORK' : input.status;
+    const gateStatus = input.status === 'PASS' ? 'APPROVED' : 'NEEDS_WORK';
     lines.push(`**Changes Hash:** ${input.changesHash}`);
     lines.push(`Status: ${gateStatus}`);
     lines.push('');

--- a/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2558,7 +2558,10 @@ describe('enforce-step-workflow', () => {
       const { code } = await runHook(
         {
           tool_name: 'Write',
-          tool_input: { file_path: `${TASKS_DIR}/tests.check.md`, content: 'Status: APPROVED\n# Check report' },
+          tool_input: {
+            file_path: `${TASKS_DIR}/tests.check.md`,
+            content: 'Status: APPROVED\n# Check report',
+          },
         },
         'PreToolUse',
         { CLAUDE_CURRENT_AGENT: 'quality-checker' }
@@ -2572,7 +2575,10 @@ describe('enforce-step-workflow', () => {
       const { code } = await runHook(
         {
           tool_name: 'Write',
-          tool_input: { file_path: `${TASKS_DIR}/tests.check.md`, content: 'Status: APPROVED\n# Check report' },
+          tool_input: {
+            file_path: `${TASKS_DIR}/tests.check.md`,
+            content: 'Status: APPROVED\n# Check report',
+          },
         },
         'PreToolUse',
         { CLAUDE_CURRENT_AGENT: 'work-workflow:quality-checker' }

--- a/workflows/lib/__tests__/parse-report-status.test.js
+++ b/workflows/lib/__tests__/parse-report-status.test.js
@@ -1132,11 +1132,7 @@ describe('parseReportStatus — GH-331 QA alias unification', () => {
   it('resolves ACCESS_FAILED in summary table to NEEDS_WORK for QA type', () => {
     const content = '| Status | ACCESS_FAILED |';
     const result = parseReportStatus(content, 'qa');
-    assert.equal(
-      result.status,
-      'NEEDS_WORK',
-      'ACCESS_FAILED in table must resolve to NEEDS_WORK'
-    );
+    assert.equal(result.status, 'NEEDS_WORK', 'ACCESS_FAILED in table must resolve to NEEDS_WORK');
   });
 
   it('still resolves "Status: SUCCESS" to APPROVED for QA type (backward compat)', () => {

--- a/workflows/lib/__tests__/parse-report-status.test.js
+++ b/workflows/lib/__tests__/parse-report-status.test.js
@@ -358,14 +358,14 @@ describe('parseReportStatus — anchored markers prevent false positives', () =>
     assert.equal(result.status, 'UNKNOWN', 'SUCCESS is only valid for QA type');
   });
 
-  it('recognizes "Status: INFRASTRUCTURE_FAILURE" for QA type', () => {
+  it('resolves "Status: INFRASTRUCTURE_FAILURE" to NEEDS_WORK for QA type (GH-331)', () => {
     const result = parseReportStatus('Status: INFRASTRUCTURE_FAILURE', 'qa');
-    assert.deepStrictEqual(result, { status: 'INFRASTRUCTURE_FAILURE', icon: '🛑' });
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '❌' });
   });
 
-  it('recognizes "Status: ACCESS_FAILED" for QA type', () => {
+  it('resolves "Status: ACCESS_FAILED" to NEEDS_WORK for QA type (GH-331)', () => {
     const result = parseReportStatus('Status: ACCESS_FAILED', 'qa');
-    assert.deepStrictEqual(result, { status: 'ACCESS_FAILED', icon: '🔒' });
+    assert.deepStrictEqual(result, { status: 'NEEDS_WORK', icon: '❌' });
   });
 
   it('Status: APPROVED at top overrides later Status: FAIL in embedded output', () => {
@@ -1095,5 +1095,62 @@ describe('parseReportStatus — freeform fallback patterns (GH-326)', () => {
     const content = '# Code Review\n\n**APPROVED**\n\nSome CRITICAL mention in passing';
     const result = parseReportStatus(content, 'codeReview');
     assert.equal(result.status, 'APPROVED', 'freeform should take priority over fail markers');
+  });
+});
+
+// ===========================================================================
+// GH-331 Task 1.1: QA alias unification — INFRASTRUCTURE_FAILURE and
+// ACCESS_FAILED should resolve to NEEDS_WORK via Status: line
+// ===========================================================================
+describe('parseReportStatus — GH-331 QA alias unification', () => {
+  it('resolves "Status: INFRASTRUCTURE_FAILURE" to NEEDS_WORK for QA type', () => {
+    const result = parseReportStatus('Status: INFRASTRUCTURE_FAILURE', 'qa');
+    assert.equal(
+      result.status,
+      'NEEDS_WORK',
+      'INFRASTRUCTURE_FAILURE alias must resolve to NEEDS_WORK'
+    );
+    assert.equal(result.icon, '❌');
+  });
+
+  it('resolves "Status: ACCESS_FAILED" to NEEDS_WORK for QA type', () => {
+    const result = parseReportStatus('Status: ACCESS_FAILED', 'qa');
+    assert.equal(result.status, 'NEEDS_WORK', 'ACCESS_FAILED alias must resolve to NEEDS_WORK');
+    assert.equal(result.icon, '❌');
+  });
+
+  it('resolves INFRASTRUCTURE_FAILURE in summary table to NEEDS_WORK for QA type', () => {
+    const content = '| Status | INFRASTRUCTURE_FAILURE |';
+    const result = parseReportStatus(content, 'qa');
+    assert.equal(
+      result.status,
+      'NEEDS_WORK',
+      'INFRASTRUCTURE_FAILURE in table must resolve to NEEDS_WORK'
+    );
+  });
+
+  it('resolves ACCESS_FAILED in summary table to NEEDS_WORK for QA type', () => {
+    const content = '| Status | ACCESS_FAILED |';
+    const result = parseReportStatus(content, 'qa');
+    assert.equal(
+      result.status,
+      'NEEDS_WORK',
+      'ACCESS_FAILED in table must resolve to NEEDS_WORK'
+    );
+  });
+
+  it('still resolves "Status: SUCCESS" to APPROVED for QA type (backward compat)', () => {
+    const result = parseReportStatus('Status: SUCCESS', 'qa');
+    assert.equal(result.status, 'APPROVED', 'SUCCESS alias must still resolve to APPROVED');
+  });
+
+  it('still resolves "Status: PASS" to APPROVED for QA type', () => {
+    const result = parseReportStatus('Status: PASS', 'qa');
+    assert.equal(result.status, 'APPROVED', 'PASS alias must resolve to APPROVED');
+  });
+
+  it('still resolves "Status: FAIL" to NEEDS_WORK for QA type', () => {
+    const result = parseReportStatus('Status: FAIL', 'qa');
+    assert.equal(result.status, 'NEEDS_WORK', 'FAIL alias must resolve to NEEDS_WORK');
   });
 });

--- a/workflows/lib/__tests__/validate-check-report-status.test.js
+++ b/workflows/lib/__tests__/validate-check-report-status.test.js
@@ -50,10 +50,7 @@ describe('validateCheckReportStatus — valid Status lines', () => {
   });
 
   it('accepts "Status: APPROVED" for completion type (base alias)', () => {
-    const result = validateCheckReportStatus(
-      'Status: APPROVED\n# Completion Report',
-      'completion'
-    );
+    const result = validateCheckReportStatus('Status: APPROVED\n# Completion Report', 'completion');
     assert.deepStrictEqual(result, { valid: true });
   });
 
@@ -176,10 +173,7 @@ describe('validateCheckReportStatus — bold markdown variants', () => {
   });
 
   it('accepts "**Status:** **COMPLETE**" for completion type', () => {
-    const result = validateCheckReportStatus(
-      '**Status:** **COMPLETE**\n# Report',
-      'completion'
-    );
+    const result = validateCheckReportStatus('**Status:** **COMPLETE**\n# Report', 'completion');
     assert.deepStrictEqual(result, { valid: true });
   });
 

--- a/workflows/lib/parse-report-status.js
+++ b/workflows/lib/parse-report-status.js
@@ -249,9 +249,7 @@ function checkFreeformStatus(content, type) {
   }
 
   // 4. Standalone status at line start followed by dash
-  const dashMatch = content.match(
-    /^(COMPLETE|APPROVED|NEEDS_WORK|INCOMPLETE)\s*[—–-]/m
-  );
+  const dashMatch = content.match(/^(COMPLETE|APPROVED|NEEDS_WORK|INCOMPLETE)\s*[—–-]/m);
   if (dashMatch) {
     const resolved = resolveAlias(dashMatch[1].toUpperCase(), type);
     if (resolved) return resolved;
@@ -573,4 +571,10 @@ function isCodeReviewResolved(reportContent, replyContent) {
   };
 }
 
-module.exports = { parseReportStatus, parseReplyDecisions, isCodeReviewResolved, resolveAlias, STATUS_LINE_RE };
+module.exports = {
+  parseReportStatus,
+  parseReplyDecisions,
+  isCodeReviewResolved,
+  resolveAlias,
+  STATUS_LINE_RE,
+};

--- a/workflows/lib/parse-report-status.js
+++ b/workflows/lib/parse-report-status.js
@@ -40,8 +40,8 @@ TYPE_ALIASES['completion'] = Object.assign(Object.create(null), BASE_ALIASES, {
 // and recognizes infrastructure/access failure statuses from write-qa-report.js.
 TYPE_ALIASES['qa'] = Object.assign(Object.create(null), BASE_ALIASES, {
   SUCCESS: 'APPROVED',
-  INFRASTRUCTURE_FAILURE: 'INFRASTRUCTURE_FAILURE',
-  ACCESS_FAILED: 'ACCESS_FAILED',
+  INFRASTRUCTURE_FAILURE: 'NEEDS_WORK',
+  ACCESS_FAILED: 'NEEDS_WORK',
 });
 // Fallback for types without overrides
 const STATUS_ALIASES = BASE_ALIASES;

--- a/workflows/lib/scripts/__tests__/write-report.test.js
+++ b/workflows/lib/scripts/__tests__/write-report.test.js
@@ -380,11 +380,7 @@ describe('write-report', () => {
       const content = fs.readFileSync('/tmp/qa-test-runner.check.md', 'utf8');
       const statusLine = content.match(/^Status:\s*(\S+)/m);
       assert.ok(statusLine, 'report must contain a Status: line');
-      assert.equal(
-        statusLine[1],
-        'APPROVED',
-        'PASS input must produce Status: APPROVED'
-      );
+      assert.equal(statusLine[1], 'APPROVED', 'PASS input must produce Status: APPROVED');
     });
 
     it('outputs "Status: NEEDS_WORK" when input status is FAIL', () => {
@@ -400,11 +396,7 @@ describe('write-report', () => {
       const content = fs.readFileSync('/tmp/qa-test-runner.check.md', 'utf8');
       const statusLine = content.match(/^Status:\s*(\S+)/m);
       assert.ok(statusLine, 'report must contain a Status: line');
-      assert.equal(
-        statusLine[1],
-        'NEEDS_WORK',
-        'FAIL input must produce Status: NEEDS_WORK'
-      );
+      assert.equal(statusLine[1], 'NEEDS_WORK', 'FAIL input must produce Status: NEEDS_WORK');
     });
 
     it('outputs "Status: NEEDS_WORK" when input status is INFRASTRUCTURE_FAILURE', () => {
@@ -462,11 +454,7 @@ describe('write-report', () => {
       const content = fs.readFileSync('/tmp/qa-test-runner.check.md', 'utf8');
       const statusLine = content.match(/^Status:\s*(\S+)/m);
       assert.ok(statusLine, 'report must contain a Status: line');
-      assert.equal(
-        statusLine[1],
-        'NEEDS_WORK',
-        'BLOCKED input must produce Status: NEEDS_WORK'
-      );
+      assert.equal(statusLine[1], 'NEEDS_WORK', 'BLOCKED input must produce Status: NEEDS_WORK');
     });
   });
 

--- a/workflows/lib/scripts/__tests__/write-report.test.js
+++ b/workflows/lib/scripts/__tests__/write-report.test.js
@@ -359,4 +359,146 @@ describe('write-report', () => {
       }
     });
   });
+
+  // ─── GH-331 Task 1.2: write-qa-report formatReport status mapping ─────────
+  describe('write-qa-report formatReport status mapping (GH-331)', () => {
+    afterEach(() => {
+      cleanupToken('write-qa-report.js');
+      try {
+        fs.unlinkSync('/tmp/qa-test-runner.check.md');
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('outputs "Status: APPROVED" when input status is PASS', () => {
+      writeToken('write-qa-report.js', 'qa-feature-tester', Date.now());
+      const input = { ...validQAInput, status: 'PASS' };
+      const result = runScript(QA_SCRIPT, input);
+      assert.equal(result.exitCode, 0, `script failed: ${result.output}`);
+
+      const content = fs.readFileSync('/tmp/qa-test-runner.check.md', 'utf8');
+      const statusLine = content.match(/^Status:\s*(\S+)/m);
+      assert.ok(statusLine, 'report must contain a Status: line');
+      assert.equal(
+        statusLine[1],
+        'APPROVED',
+        'PASS input must produce Status: APPROVED'
+      );
+    });
+
+    it('outputs "Status: NEEDS_WORK" when input status is FAIL', () => {
+      writeToken('write-qa-report.js', 'qa-feature-tester', Date.now());
+      const input = {
+        ...validQAInput,
+        status: 'FAIL',
+        tests: [{ name: 'test1', status: 'fail' }],
+      };
+      const result = runScript(QA_SCRIPT, input);
+      assert.equal(result.exitCode, 0, `script failed: ${result.output}`);
+
+      const content = fs.readFileSync('/tmp/qa-test-runner.check.md', 'utf8');
+      const statusLine = content.match(/^Status:\s*(\S+)/m);
+      assert.ok(statusLine, 'report must contain a Status: line');
+      assert.equal(
+        statusLine[1],
+        'NEEDS_WORK',
+        'FAIL input must produce Status: NEEDS_WORK'
+      );
+    });
+
+    it('outputs "Status: NEEDS_WORK" when input status is INFRASTRUCTURE_FAILURE', () => {
+      writeToken('write-qa-report.js', 'qa-feature-tester', Date.now());
+      const input = {
+        ...validQAInput,
+        status: 'INFRASTRUCTURE_FAILURE',
+        screenshots: [],
+        mcpDiagnostics: 'Playwright not available',
+      };
+      const result = runScript(QA_SCRIPT, input);
+      assert.equal(result.exitCode, 0, `script failed: ${result.output}`);
+
+      const content = fs.readFileSync('/tmp/qa-test-runner.check.md', 'utf8');
+      const statusLine = content.match(/^Status:\s*(\S+)/m);
+      assert.ok(statusLine, 'report must contain a Status: line');
+      assert.equal(
+        statusLine[1],
+        'NEEDS_WORK',
+        'INFRASTRUCTURE_FAILURE input must produce Status: NEEDS_WORK'
+      );
+    });
+
+    it('outputs "Status: NEEDS_WORK" when input status is ACCESS_FAILED', () => {
+      writeToken('write-qa-report.js', 'qa-feature-tester', Date.now());
+      const input = {
+        ...validQAInput,
+        status: 'ACCESS_FAILED',
+        screenshots: [],
+        mcpDiagnostics: 'Could not reach app',
+      };
+      const result = runScript(QA_SCRIPT, input);
+      assert.equal(result.exitCode, 0, `script failed: ${result.output}`);
+
+      const content = fs.readFileSync('/tmp/qa-test-runner.check.md', 'utf8');
+      const statusLine = content.match(/^Status:\s*(\S+)/m);
+      assert.ok(statusLine, 'report must contain a Status: line');
+      assert.equal(
+        statusLine[1],
+        'NEEDS_WORK',
+        'ACCESS_FAILED input must produce Status: NEEDS_WORK'
+      );
+    });
+
+    it('outputs "Status: NEEDS_WORK" when input status is BLOCKED', () => {
+      writeToken('write-qa-report.js', 'qa-feature-tester', Date.now());
+      const input = {
+        ...validQAInput,
+        status: 'BLOCKED',
+        screenshots: [],
+      };
+      const result = runScript(QA_SCRIPT, input);
+      assert.equal(result.exitCode, 0, `script failed: ${result.output}`);
+
+      const content = fs.readFileSync('/tmp/qa-test-runner.check.md', 'utf8');
+      const statusLine = content.match(/^Status:\s*(\S+)/m);
+      assert.ok(statusLine, 'report must contain a Status: line');
+      assert.equal(
+        statusLine[1],
+        'NEEDS_WORK',
+        'BLOCKED input must produce Status: NEEDS_WORK'
+      );
+    });
+  });
+
+  // ─── GH-331 Task 1.3: write-qa-report reportType validation ───────────────
+  describe('write-qa-report reportType: qa validation (GH-331)', () => {
+    afterEach(() => {
+      cleanupToken('write-qa-report.js');
+      try {
+        fs.unlinkSync('/tmp/qa-test-runner.check.md');
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('has reportType set to qa in createReportWriter config', () => {
+      // Verify by reading the source file and checking for reportType: 'qa'
+      const qaSource = fs.readFileSync(QA_SCRIPT, 'utf8');
+      assert.ok(
+        /reportType:\s*['"]qa['"]/.test(qaSource),
+        'write-qa-report.js must configure reportType: "qa" in createReportWriter config'
+      );
+    });
+
+    it('post-write validation succeeds for PASS status (reportType fires)', () => {
+      // When reportType: 'qa' is set, the post-write validation in write-report.js
+      // will verify that the formatted output has a parseable Status line.
+      // This test verifies the full pipeline works with reportType active.
+      writeToken('write-qa-report.js', 'qa-feature-tester', Date.now());
+      const input = { ...validQAInput, status: 'PASS' };
+      const result = runScript(QA_SCRIPT, input);
+      assert.equal(result.exitCode, 0, `post-write validation should pass: ${result.output}`);
+      assert.ok(result.output.includes('"success": true'));
+    });
+  });
 });

--- a/workflows/lib/scripts/write-report.js
+++ b/workflows/lib/scripts/write-report.js
@@ -253,9 +253,9 @@ function createReportWriter(config) {
       if (!hasValidStatus) {
         process.stderr.write(
           `[${name}] VALIDATION FAILED: Formatted report has no parseable Status line.\n` +
-          `  parseReportStatus returned: ${hasValidStatus ? 'valid' : 'UNKNOWN'}\n` +
-          `  The formatReport() function must include a "Status: <VALUE>" line.\n` +
-          `  This is a bug in the report writer, not in the agent input.\n`
+            `  parseReportStatus returned: ${hasValidStatus ? 'valid' : 'UNKNOWN'}\n` +
+            `  The formatReport() function must include a "Status: <VALUE>" line.\n` +
+            `  This is a bug in the report writer, not in the agent input.\n`
         );
         process.exit(1);
       }

--- a/workflows/lib/validate-check-report-status.js
+++ b/workflows/lib/validate-check-report-status.js
@@ -11,8 +11,24 @@ VALID_STATUSES['completion'] = ['APPROVED', 'NEEDS_WORK', 'NOT_APPLICABLE']; // 
 // Human-readable valid values per type (includes aliases for user guidance)
 const VALID_VALUES = Object.create(null);
 VALID_VALUES['completion'] = ['APPROVED', 'NEEDS_WORK', 'COMPLETE', 'INCOMPLETE', 'NOT_APPLICABLE'];
-VALID_VALUES['tests'] = ['APPROVED', 'NEEDS_WORK', 'PASS', 'PASSED', 'FAIL', 'FAILED', 'NOT_APPLICABLE'];
-VALID_VALUES['codeReview'] = ['APPROVED', 'NEEDS_WORK', 'PASS', 'PASSED', 'FAIL', 'FAILED', 'NOT_APPLICABLE'];
+VALID_VALUES['tests'] = [
+  'APPROVED',
+  'NEEDS_WORK',
+  'PASS',
+  'PASSED',
+  'FAIL',
+  'FAILED',
+  'NOT_APPLICABLE',
+];
+VALID_VALUES['codeReview'] = [
+  'APPROVED',
+  'NEEDS_WORK',
+  'PASS',
+  'PASSED',
+  'FAIL',
+  'FAILED',
+  'NOT_APPLICABLE',
+];
 
 /**
  * Get human-readable valid status values for a report type.
@@ -35,7 +51,8 @@ function getValidStatusValues(reportType) {
  */
 function validateCheckReportStatus(content, reportType) {
   try {
-    if (content === null || content === undefined || typeof content !== 'string') return { valid: true }; // fail-open for null/undefined/non-string
+    if (content === null || content === undefined || typeof content !== 'string')
+      return { valid: true }; // fail-open for null/undefined/non-string
     // Empty string is treated as missing Status (not fail-open) — check-gate blocks empty reports
 
     const match = content.match(STATUS_LINE_RE);
@@ -43,7 +60,8 @@ function validateCheckReportStatus(content, reportType) {
       const validValues = getValidStatusValues(reportType);
       return {
         valid: false,
-        message: `BLOCKED: Report content must contain a Status: line.\n` +
+        message:
+          `BLOCKED: Report content must contain a Status: line.\n` +
           `Expected format: Status: <VALUE> or **Status:** <VALUE>\n` +
           `Valid values for ${reportType} reports: ${validValues.join(', ')}\n` +
           `Example: Status: APPROVED`,
@@ -56,7 +74,8 @@ function validateCheckReportStatus(content, reportType) {
       const validValues = getValidStatusValues(reportType);
       return {
         valid: false,
-        message: `BLOCKED: Status value "${raw}" is not valid for ${reportType} reports.\n` +
+        message:
+          `BLOCKED: Status value "${raw}" is not valid for ${reportType} reports.\n` +
           `Valid values: ${validValues.join(', ')}`,
       };
     }

--- a/workflows/work/workflow-definition.js
+++ b/workflows/work/workflow-definition.js
@@ -614,7 +614,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       step: STEPS.check,
       agents: ['code-checker'],
       contentGuard: (content) => {
-        const { validateCheckReportStatus } = require(path.join(__dirname, '..', 'lib', 'validate-check-report-status'));
+        const { validateCheckReportStatus } = require(
+          path.join(__dirname, '..', 'lib', 'validate-check-report-status')
+        );
         const result = validateCheckReportStatus(content, 'codeReview');
         return result.valid ? { blocked: false } : { blocked: true, message: result.message };
       },
@@ -624,7 +626,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       step: STEPS.check,
       agents: ['quality-checker'],
       contentGuard: (content) => {
-        const { validateCheckReportStatus } = require(path.join(__dirname, '..', 'lib', 'validate-check-report-status'));
+        const { validateCheckReportStatus } = require(
+          path.join(__dirname, '..', 'lib', 'validate-check-report-status')
+        );
         const result = validateCheckReportStatus(content, 'tests');
         return result.valid ? { blocked: false } : { blocked: true, message: result.message };
       },
@@ -634,7 +638,9 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       step: STEPS.check,
       agents: ['completion-checker'],
       contentGuard: (content) => {
-        const { validateCheckReportStatus } = require(path.join(__dirname, '..', 'lib', 'validate-check-report-status'));
+        const { validateCheckReportStatus } = require(
+          path.join(__dirname, '..', 'lib', 'validate-check-report-status')
+        );
         const result = validateCheckReportStatus(content, 'completion');
         return result.valid ? { blocked: false } : { blocked: true, message: result.message };
       },


### PR DESCRIPTION
## Existing Behavior

- QA reports could emit raw agent input statuses (PASS, FAIL, INFRASTRUCTURE_FAILURE, ACCESS_FAILED, BLOCKED) on the Status line, diverging from the canonical APPROVED/NEEDS_WORK vocabulary used by all other report types.
- parse-report-status.js did not include INFRASTRUCTURE_FAILURE and ACCESS_FAILED in the TYPE_ALIASES qa mapping, so those statuses were not resolved to canonical values.
- Downstream hooks (check-validate-reports.js, validate-qa-report.js) accepted only legacy PASS/FAIL vocabulary in their status presence checks.
- Agent and skill documentation (qa-api-tester.md, qa-feature-tester.md, check/SKILL.md, check-qa/SKILL.md) did not explain the translation between agent input statuses and canonical report output statuses.

## Intended New Behavior

- write-qa-report.js maps all non-PASS QA statuses (FAIL, INFRASTRUCTURE_FAILURE, ACCESS_FAILED, BLOCKED) to NEEDS_WORK on the report Status line, with an explicit comment enumerating all mappings for grep-based spec verification.
- parse-report-status.js TYPE_ALIASES qa now includes INFRASTRUCTURE_FAILURE and ACCESS_FAILED resolving to NEEDS_WORK, making QA alias resolution consistent with other report types.
- check-validate-reports.js error message updated to include canonical statuses (PASS/FAIL/APPROVED/NEEDS_WORK) for clearer diagnostics.
- Agent docs (qa-api-tester.md) and skill docs (check/SKILL.md, check-qa/SKILL.md) include a "Report Output Status" section explaining the input-to-output translation, with ACCESS_FAILED added to the status mapping table.
- createReportWriter config for the QA report writer now includes reportType: 'qa' to enable post-write canonical validation.
- 25+ new tests added covering alias resolution, formatReport mapping, and hook validation logic.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / script validation:**

1. Run quality checks to confirm all tests pass:
   ```
   pnpm dev:check
   ```
   Expected: all new tests in parse-report-status.test.js and write-report.test.js pass.

2. Simulate a QA agent writing a FAIL report via write-qa-report.js and verify the Status line in the output file reads `Status: NEEDS_WORK`.

3. Repeat with status ACCESS_FAILED and INFRASTRUCTURE_FAILURE — both should produce `Status: NEEDS_WORK`.

4. Repeat with status PASS — should produce `Status: APPROVED`.

5. Verify check-validate-reports.js accepts APPROVED/NEEDS_WORK by running its test file:
   ```
   node --test workflows/check/hooks/__tests__/check-validate-reports.test.js
   ```

Closes #331

## Test Results

| Test Type | Status | Details |
|-----------|--------|---------|
| Unit (GH-331 scope) | PASS | 153/153 tests pass across all changed files |
| Unit (full suite) | 2969/2985 | 16 pre-existing failures unrelated to this branch |
| Integration | N/A | No integration tests in this project |
| Smoke | N/A | No smoke tests in this project |

**GH-331 test coverage:** `parse-report-status.test.js` (116 pass), `write-report.test.js` (26 pass), `check-validate-reports.test.js` (5 pass), `validate-qa-report.test.js` (6 pass).

**Pre-existing failures (not introduced by this branch):**
- `enforce-screenshot-requirement.test.js` — 15 failures (QA agent blocking / skip marker suites)
- `session-guard.test.js` — 1 failure (`/check` workflow stop suppression)

## Code Review

**Verdict: APPROVED** (with minor fixes applied)

| Area | Status |
|------|--------|
| Task-Doc Compliance | Pass (fixed) |
| Code Reuse | Pass |
| TDD / Test Discipline | Pass |
| Code Smells | Pass (fixed) |
| SOLID / Design Quality | Pass |
| Dependency Hygiene | Pass |

**Issues resolved before merge:**
1. `qa-api-tester.md` "Report Output Status" table now includes `ACCESS_FAILED -> NEEDS_WORK` (was omitted in initial commit; added in 735b1744).
2. Stale error string in `check-validate-reports.js` updated from `"Missing PASS/FAIL status"` to reflect all four accepted tokens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes QA report status parsing/validation and summary generation to treat `APPROVED`/`NEEDS_WORK` as the canonical output, which can affect CI gating and failure classification if any edge-case report formats aren’t handled.
> 
> **Overview**
> QA report output is normalized to the same canonical status vocabulary as other `/check` reports: `write-qa-report.js` now always writes `Status: APPROVED` for PASS and `Status: NEEDS_WORK` for all other QA outcomes, and enables post-write validation via `reportType: 'qa'`.
> 
> Status parsing/validation is updated to recognize canonical tokens (and keep legacy PASS/FAIL compatibility), including mapping QA `INFRASTRUCTURE_FAILURE`/`ACCESS_FAILED` to `NEEDS_WORK`, avoiding false failures from stale "Previous Run" sections, and improving `/check` summary logic to still surface infra/access failures even when the status line is canonical.
> 
> Adds unit tests covering the new status aliasing/mapping behavior for `parse-report-status`, QA report validation hooks, report writer output, and the `/check` report validator; also updates QA agent/skill docs to document the input-to-output status translation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a60a928111a2db6f31e081560ce23d308951efe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->