### PR TITLE
fix(protect-tasks-md): only protect root-level tasks.md, allow subfolder writes

### DIFF
--- a/workflows/work/hooks/__tests__/protect-tasks-md.test.js
+++ b/workflows/work/hooks/__tests__/protect-tasks-md.test.js
@@ -56,14 +56,19 @@ function createStateFixture(ticketId, stepStatus = {}) {
 
 /**
  * Run the hook with given stdin input and env overrides.
+ * @param {object} input — JSON payload to pipe to stdin
+ * @param {object} [envOverrides] — environment variable overrides
+ * @param {object} [options] — additional spawn options (e.g. { cwd: '/some/dir' })
  * Returns { code, stderr, stdout }.
  */
-function runHook(input, envOverrides = {}) {
+function runHook(input, envOverrides = {}, options = {}) {
   return new Promise((resolve, reject) => {
-    const proc = spawn('node', [HOOK_PATH], {
+    const spawnOpts = {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, ...envOverrides },
-    });
+    };
+    if (options.cwd) spawnOpts.cwd = options.cwd;
+    const proc = spawn('node', [HOOK_PATH], spawnOpts);
     let stdout = '';
     let stderr = '';
     proc.stdout.on('data', (d) => {
@@ -251,6 +256,173 @@ describe('protect-tasks-md hook', () => {
     } finally {
       fixture.cleanup();
     }
+  });
+
+  describe('subfolder tasks.md — GH-309', () => {
+    it('should ALLOW Edit to subfolder tasks.md when step is implement (exit 0)', async () => {
+      const fixture = createStateFixture('GH-309', {
+        implement: 'in_progress',
+        tasks: 'completed',
+        task_review: 'pending',
+      });
+      try {
+        const subfolderPath = path.join(fixture.tasksBase, 'GH-309', 'flaky-tests', 'tasks.md');
+        fs.mkdirSync(path.dirname(subfolderPath), { recursive: true });
+        const { code } = await runHook(
+          {
+            tool_name: 'Edit',
+            tool_input: { file_path: subfolderPath },
+          },
+          { TASKS_BASE: fixture.tasksBase, TICKET_ID: 'GH-309' }
+        );
+        assert.strictEqual(
+          code,
+          0,
+          'Expected exit 0 (allow) for subfolder tasks.md during implement'
+        );
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    it('should ALLOW Write to deeply nested subfolder tasks.md (exit 0)', async () => {
+      const fixture = createStateFixture('GH-309', {
+        implement: 'in_progress',
+        tasks: 'completed',
+        task_review: 'pending',
+      });
+      try {
+        const deepPath = path.join(fixture.tasksBase, 'GH-309', 'sub', 'deep', 'tasks.md');
+        fs.mkdirSync(path.dirname(deepPath), { recursive: true });
+        const { code } = await runHook(
+          {
+            tool_name: 'Write',
+            tool_input: { file_path: deepPath },
+          },
+          { TASKS_BASE: fixture.tasksBase, TICKET_ID: 'GH-309' }
+        );
+        assert.strictEqual(
+          code,
+          0,
+          'Expected exit 0 (allow) for deeply nested tasks.md during implement'
+        );
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    it('should ALLOW Bash redirect to subfolder tasks.md (exit 0)', async () => {
+      const fixture = createStateFixture('GH-309', {
+        implement: 'in_progress',
+        tasks: 'completed',
+        task_review: 'pending',
+      });
+      try {
+        const subfolderPath = path.join(fixture.tasksBase, 'GH-309', 'flaky-tests', 'tasks.md');
+        fs.mkdirSync(path.dirname(subfolderPath), { recursive: true });
+        const { code } = await runHook(
+          {
+            tool_name: 'Bash',
+            tool_input: {
+              command: `echo "data" >> ${subfolderPath}`,
+            },
+          },
+          { TASKS_BASE: fixture.tasksBase, TICKET_ID: 'GH-309' }
+        );
+        assert.strictEqual(
+          code,
+          0,
+          'Expected exit 0 (allow) for Bash redirect to subfolder tasks.md'
+        );
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    it('should ALLOW Bash relative-path write to tasks.md from subfolder cwd (exit 0)', async () => {
+      const fixture = createStateFixture('GH-309', {
+        implement: 'in_progress',
+        tasks: 'completed',
+        task_review: 'pending',
+      });
+      try {
+        // Create a subfolder inside the ticket dir
+        const subfolderDir = path.join(fixture.tasksBase, 'GH-309', 'flaky-tests');
+        fs.mkdirSync(subfolderDir, { recursive: true });
+        const { code } = await runHook(
+          {
+            tool_name: 'Bash',
+            tool_input: {
+              command: 'echo "data" >> tasks.md',
+            },
+          },
+          { TASKS_BASE: fixture.tasksBase, TICKET_ID: 'GH-309' },
+          { cwd: subfolderDir }
+        );
+        assert.strictEqual(
+          code,
+          0,
+          'Expected exit 0 (allow) for relative tasks.md from subfolder cwd'
+        );
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    it('should BLOCK Bash command that references subfolder AND root-level tasks.md (exit 2)', async () => {
+      const fixture = createStateFixture('GH-309', {
+        implement: 'in_progress',
+        tasks: 'completed',
+        task_review: 'pending',
+      });
+      try {
+        const subfolderPath = path.join(fixture.tasksBase, 'GH-309', 'flaky-tests', 'tasks.md');
+        const rootPath = path.join(fixture.tasksBase, 'GH-309', 'tasks.md');
+        fs.mkdirSync(path.dirname(subfolderPath), { recursive: true });
+        const { code, stderr } = await runHook(
+          {
+            tool_name: 'Bash',
+            tool_input: {
+              command: `cat ${subfolderPath} >> ${rootPath}`,
+            },
+          },
+          { TASKS_BASE: fixture.tasksBase, TICKET_ID: 'GH-309' }
+        );
+        assert.strictEqual(
+          code,
+          2,
+          `Expected exit 2 (block) when Bash references both subfolder and root tasks.md, got ${code}. stderr: ${stderr}`
+        );
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    it('should still BLOCK Edit to root-level tasks.md when step is implement (exit 2) — regression', async () => {
+      const fixture = createStateFixture('GH-309', {
+        implement: 'in_progress',
+        tasks: 'completed',
+        task_review: 'pending',
+      });
+      try {
+        const rootPath = path.join(fixture.tasksBase, 'GH-309', 'tasks.md');
+        const { code, stderr } = await runHook(
+          {
+            tool_name: 'Edit',
+            tool_input: { file_path: rootPath },
+          },
+          { TASKS_BASE: fixture.tasksBase, TICKET_ID: 'GH-309' }
+        );
+        assert.strictEqual(
+          code,
+          2,
+          `Expected exit 2 (block) for root-level tasks.md, got ${code}. stderr: ${stderr}`
+        );
+        assert.ok(stderr.length > 0, 'Expected stderr message explaining block');
+      } finally {
+        fixture.cleanup();
+      }
+    });
   });
 
   it('should normalize #N ticket IDs to GH-N for path matching', async () => {

--- a/workflows/work/hooks/protect-tasks-md.js
+++ b/workflows/work/hooks/protect-tasks-md.js
@@ -16,11 +16,39 @@
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
-const { createArtifactProtector } = require(
-  path.join(__dirname, '..', '..', 'lib', 'protect-artifact-files')
-);
+const { createArtifactProtector } = require('../../lib/protect-artifact-files');
 
 const ALLOWED_STEPS = new Set(['tasks', 'task_review']);
+
+/**
+ * Check whether a file named tasks.md is the root-level workflow artifact
+ * (i.e. <tasksBase>/<ticketId>/tasks.md). Returns a three-state result:
+ *
+ *   true  — the file IS the root-level tasks.md (should be protected)
+ *   false — the file is a subfolder tasks.md at depth 2+ (should be allowed)
+ *   null  — the file is outside TASKS_BASE entirely (let protector.check handle it)
+ *
+ * GH-309: Only root-level tasks.md should be protected. Subfolder tasks.md
+ * files are user-created artifacts that agents must be free to edit.
+ *
+ * @param {string} filePath — absolute path to the file being written
+ * @param {string} ticketId — sanitized ticket ID (e.g. 'GH-309')
+ * @param {string} tasksBase — absolute path to TASKS_BASE directory
+ * @returns {boolean|null} true if root-level, false if subfolder, null if outside
+ */
+function isRootLevelTasksMd(filePath, ticketId, tasksBase) {
+  const ticketDir = path.resolve(path.join(tasksBase, ticketId));
+  const resolved = path.resolve(filePath);
+  const rel = path.relative(ticketDir, resolved);
+  // If the relative path escapes the ticket dir, the file is not under TASKS_BASE
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  // Root-level tasks.md has rel === 'tasks.md' (no separators) — IS root level
+  if (rel === 'tasks.md') return true;
+  // Any deeper path whose basename is tasks.md is a subfolder tasks.md (NOT root level)
+  if (path.basename(rel) === 'tasks.md') return false;
+  // Not a tasks.md file at all
+  return null;
+}
 
 /**
  * Get the ticket ID from TICKET_ID env var or derive from branch/cwd.
@@ -111,8 +139,52 @@ async function main() {
   const toolInput = hookData.tool_input || {};
   const cmd = toolInput.command || '';
 
-  // Additional Bash vector: resolve relative paths against cwd
+  // GH-309: Early exit for subfolder tasks.md files.
+  // Only the root-level <ticketId>/tasks.md is the workflow artifact that needs
+  // step-gated protection. Subfolder tasks.md files (e.g. flaky-tests/tasks.md)
+  // are user-created and should not be blocked.
   const ticketId = getTicketId(hookData);
+  const targetBasename = toolInput.file_path ? path.basename(toolInput.file_path) : '';
+  const hasTasksMdReference =
+    targetBasename === 'tasks.md' || (toolName === 'Bash' && cmd.includes('tasks.md'));
+  if (ticketId && hasTasksMdReference) {
+    try {
+      const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
+      const tasksBase = getConfig.require('TASKS_BASE');
+
+      // For Write/Edit/MultiEdit: check file_path directly
+      if (['Write', 'Edit', 'MultiEdit'].includes(toolName)) {
+        if (isRootLevelTasksMd(toolInput.file_path, ticketId, tasksBase) === false) {
+          process.exit(0); // Subfolder tasks.md — allow unconditionally
+        }
+      }
+
+      // For Bash: extract all target paths from the command and check depth.
+      // We must scan ALL tokens — a command may reference both subfolder and
+      // root-level tasks.md (e.g. `cat subfolder/tasks.md >> root/tasks.md`).
+      // Only exit 0 if subfolder references exist AND no root-level reference exists.
+      if (toolName === 'Bash' && cmd.includes('tasks.md')) {
+        let hasSubfolderRef = false;
+        let hasRootLevelRef = false;
+        const tokens = cmd.split(/\s+/);
+        for (const token of tokens) {
+          const cleaned = token.replace(/^[>]+/, '').replace(/['"]/g, '');
+          if (cleaned.includes('tasks.md') && cleaned.includes('/')) {
+            const depth = isRootLevelTasksMd(cleaned, ticketId, tasksBase);
+            if (depth === false) hasSubfolderRef = true;
+            if (depth === true) hasRootLevelRef = true;
+          }
+        }
+        if (hasSubfolderRef && !hasRootLevelRef) {
+          process.exit(0); // Only subfolder tasks.md refs — allow unconditionally
+        }
+      }
+    } catch {
+      /* fail-open: if config is unavailable, fall through to protector.check */
+    }
+  }
+
+  // Additional Bash vector: resolve relative paths against cwd
   if (
     toolName === 'Bash' &&
     cmd.includes('tasks.md') &&
@@ -124,6 +196,11 @@ async function main() {
       const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
       const tasksBase = getConfig.require('TASKS_BASE');
       if (cwd.startsWith(path.join(tasksBase, ticketId))) {
+        // GH-309: Only block if the relative path resolves to root-level tasks.md.
+        const resolvedTarget = path.join(cwd, 'tasks.md');
+        if (isRootLevelTasksMd(resolvedTarget, ticketId, tasksBase) === false) {
+          process.exit(0);
+        }
         // We're inside the ticket directory — relative tasks.md is ticket-scoped
         const step = getStepInProgress(ticketId);
         if (!ALLOWED_STEPS.has(step)) {

--- a/workflows/work/hooks/protect-tasks-md.js
+++ b/workflows/work/hooks/protect-tasks-md.js
@@ -196,8 +196,13 @@ async function main() {
       const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
       const tasksBase = getConfig.require('TASKS_BASE');
       if (cwd.startsWith(path.join(tasksBase, ticketId))) {
-        // GH-309: Only block if the relative path resolves to root-level tasks.md.
-        const resolvedTarget = path.join(cwd, 'tasks.md');
+        // GH-309: Extract the actual relative path referencing tasks.md from the command,
+        // then resolve it against cwd. This handles ../tasks.md, ./sub/tasks.md, etc.
+        const relRef =
+          cmd.match(/(?:>>?|>)\s*([^\s;|&]*tasks\.md)/)?.[1] ||
+          cmd.match(/\b([^\s;|&]*tasks\.md)\b/)?.[1] ||
+          'tasks.md';
+        const resolvedTarget = path.resolve(cwd, relRef);
         if (isRootLevelTasksMd(resolvedTarget, ticketId, tasksBase) === false) {
           process.exit(0);
         }

--- a/workflows/work/hooks/protect-tasks-md.js
+++ b/workflows/work/hooks/protect-tasks-md.js
@@ -163,17 +163,20 @@ async function main() {
       // We must scan ALL tokens — a command may reference both subfolder and
       // root-level tasks.md (e.g. `cat subfolder/tasks.md >> root/tasks.md`).
       // Only exit 0 if subfolder references exist AND no root-level reference exists.
+      // Bare tokens (no '/') are resolved against cwd to handle relative paths.
       if (toolName === 'Bash' && cmd.includes('tasks.md')) {
         let hasSubfolderRef = false;
         let hasRootLevelRef = false;
+        const cwd = process.cwd();
         const tokens = cmd.split(/\s+/);
         for (const token of tokens) {
           const cleaned = token.replace(/^[>]+/, '').replace(/['"]/g, '');
-          if (cleaned.includes('tasks.md') && cleaned.includes('/')) {
-            const depth = isRootLevelTasksMd(cleaned, ticketId, tasksBase);
-            if (depth === false) hasSubfolderRef = true;
-            if (depth === true) hasRootLevelRef = true;
-          }
+          if (!cleaned.includes('tasks.md')) continue;
+          // Resolve: absolute paths stay absolute, relative paths resolve against cwd
+          const resolved = cleaned.includes('/') ? cleaned : path.resolve(cwd, cleaned);
+          const depth = isRootLevelTasksMd(resolved, ticketId, tasksBase);
+          if (depth === false) hasSubfolderRef = true;
+          if (depth === true) hasRootLevelRef = true;
         }
         if (hasSubfolderRef && !hasRootLevelRef) {
           process.exit(0); // Only subfolder tasks.md refs — allow unconditionally
@@ -196,14 +199,21 @@ async function main() {
       const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
       const tasksBase = getConfig.require('TASKS_BASE');
       if (cwd.startsWith(path.join(tasksBase, ticketId))) {
-        // GH-309: Extract the actual relative path referencing tasks.md from the command,
-        // then resolve it against cwd. This handles ../tasks.md, ./sub/tasks.md, etc.
-        const relRef =
-          cmd.match(/(?:>>?|>)\s*([^\s;|&]*tasks\.md)/)?.[1] ||
-          cmd.match(/\b([^\s;|&]*tasks\.md)\b/)?.[1] ||
-          'tasks.md';
-        const resolvedTarget = path.resolve(cwd, relRef);
-        if (isRootLevelTasksMd(resolvedTarget, ticketId, tasksBase) === false) {
+        // GH-309: Extract ALL relative paths referencing tasks.md from the command,
+        // resolve each against cwd. Only allow if ALL resolve to subfolder (not root).
+        // This handles ../tasks.md, ./sub/tasks.md, cp tasks.md ../tasks.md, etc.
+        const refPattern = /[^\s;|&]*tasks\.md/g;
+        const refs = cmd.match(refPattern) || ['tasks.md'];
+        let anyRoot = false;
+        let anySub = false;
+        for (const ref of refs) {
+          const cleaned = ref.replace(/^[>]+/, '').replace(/['"]/g, '');
+          const resolved = path.resolve(cwd, cleaned);
+          const depth = isRootLevelTasksMd(resolved, ticketId, tasksBase);
+          if (depth === true) anyRoot = true;
+          if (depth === false) anySub = true;
+        }
+        if (anySub && !anyRoot) {
           process.exit(0);
         }
         // We're inside the ticket directory — relative tasks.md is ticket-scoped


### PR DESCRIPTION
## Existing Behavior

The `protect-tasks-md.js` hook used `path.basename()` matching to detect writes to `tasks.md`. This meant **any** file named `tasks.md` at any directory depth — including user-created artifacts in subfolders like `flaky-tests/tasks.md` — would be caught by the hook and blocked during non-allowed workflow steps.

The Bash command scanner also only detected relative `tasks.md` references when the process cwd was inside the ticket directory, without distinguishing root-level from subfolder targets.

## Intended New Behavior

- A new `isRootLevelTasksMd(filePath, ticketId, tasksBase)` helper uses `path.resolve` + `path.relative` depth-checking to distinguish the root-level workflow artifact (`<TASKS_BASE>/<ticketId>/tasks.md`) from any subfolder `tasks.md` (depth 2+).
- Write/Edit/MultiEdit hooks early-exit with code 0 when the target resolves to a subfolder `tasks.md`.
- The Bash scanner now checks all path tokens in the command; it only early-exits (allows) when subfolder references exist and **no** root-level reference is present, so mixed commands like `cat subfolder/tasks.md >> root/tasks.md` are still blocked.
- The relative-path Bash resolver also applies the depth check before blocking.
- Root-level `tasks.md` protection is unchanged (regression tested).

Closes #309

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Run the hook test suite directly:

```bash
node --test workflows/work/hooks/__tests__/protect-tasks-md.test.js
```

Expected: 18 tests pass, 0 failures.

To verify the fix manually, trigger a Write to a subfolder path while in the `implement` step — the hook should exit 0 (allow). A write to the root-level `<TASKS_BASE>/<ticketId>/tasks.md` during `implement` should exit 2 (block).

### Test Results

18 tests pass across the full `protect-tasks-md` suite, including 6 new cases added for GH-309:

- ALLOW Edit to subfolder tasks.md during implement
- ALLOW Write to deeply nested subfolder tasks.md
- ALLOW Bash absolute-path redirect to subfolder tasks.md
- ALLOW Bash relative-path write from subfolder cwd
- BLOCK Bash command referencing both subfolder and root-level tasks.md
- BLOCK Edit to root-level tasks.md during implement (regression)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts enforcement logic in the `protect-tasks-md` pre-tool hook, so misclassification could unintentionally allow edits to the protected artifact or block legitimate writes. Risk is mitigated by added regression/unit coverage across Write/Edit/Bash scenarios and mixed-path commands.
> 
> **Overview**
> Updates `protect-tasks-md.js` to **only protect the root-level** workflow artifact ` `<TASKS_BASE>/<ticketId>/tasks.md` , while **allowing** edits to any subfolder `tasks.md` (GH-309) via a new path-depth check.
> 
> Extends Bash handling to scan all `tasks.md` references (including relative-path writes from subfolder `cwd`) and only auto-allow when *all* references resolve to subfolder targets; mixed commands that touch both subfolder and root-level `tasks.md` remain blocked.
> 
> Adds test coverage for subfolder allow-cases, relative-path Bash from subdirectories, and regression checks ensuring root-level protection is unchanged; test harness now supports spawning the hook with a custom `cwd`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e245b2318f358448a14124db992ace87a7acfd57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->