### PR TITLE
fix(check): prevent severity marker false positives in code-review validator

### DIFF
--- a/workflows/check/hooks/check-validate-reports.js
+++ b/workflows/check/hooks/check-validate-reports.js
@@ -15,15 +15,7 @@
 const fs = require('fs');
 const path = require('path');
 const AppAccessStatus = require(path.join(__dirname, '..', 'lib', 'app-access-status'));
-
-// Get args
-const REPORT_FOLDER = process.argv[2];
-const IMPACTED_APPS = JSON.parse(process.argv[3] || '[]');
-
-if (!REPORT_FOLDER) {
-  console.error('Usage: node check-validate-reports.js <REPORT_FOLDER> <IMPACTED_APPS_JSON>');
-  process.exit(1);
-}
+const { detectSeverityMarkers } = require(path.join(__dirname, '..', 'lib', 'severity-detection'));
 
 /**
  * Check if a file exists
@@ -159,15 +151,10 @@ function validateCodeReview(reportFolder) {
     issues.push('Missing "**Changes Hash:**" at top of report');
   }
 
-  // Check for CRITICAL issues
-  const criticalMatches = content.match(/🔴\s*CRITICAL|CRITICAL.*must fix|severity.*critical/gi);
-  const hasCritical = criticalMatches && criticalMatches.length > 0;
-
-  // Check for IMPORTANT issues
-  const importantMatches = content.match(
-    /🟡\s*IMPORTANT|IMPORTANT.*should fix|severity.*important/gi
-  );
-  const hasImportant = importantMatches && importantMatches.length > 0;
+  // Detect severity markers using line-based analysis with negation filtering
+  const markers = detectSeverityMarkers(content);
+  const hasCritical = markers.critical.length > 0;
+  const hasImportant = markers.important.length > 0;
 
   // Check if there's a reply file addressing the issues
   const replyPath = path.join(reportFolder, 'code-review-reply.check.md');
@@ -261,6 +248,15 @@ function validateCompletionReport(reportFolder) {
  * Main validation
  */
 function main() {
+  // Get args
+  const REPORT_FOLDER = process.argv[2];
+  const IMPACTED_APPS = JSON.parse(process.argv[3] || '[]');
+
+  if (!REPORT_FOLDER) {
+    console.error('Usage: node check-validate-reports.js <REPORT_FOLDER> <IMPACTED_APPS_JSON>');
+    process.exit(1);
+  }
+
   const results = {
     reportFolder: REPORT_FOLDER,
     impactedApps: IMPACTED_APPS,
@@ -390,4 +386,8 @@ function main() {
   process.exit(results.overall.valid ? 0 : 1);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { validateCodeReview };

--- a/workflows/check/lib/__tests__/severity-detection.test.js
+++ b/workflows/check/lib/__tests__/severity-detection.test.js
@@ -70,6 +70,46 @@ describe('severity-detection', () => {
         'mid-line negation phrase must not suppress genuine finding'
       );
     });
+
+    it('does not suppress genuine finding with "no remaining" in description', () => {
+      const report = '🔴 CRITICAL: No remaining input validation after auth refactor';
+      const result = detectSeverityMarkers(report);
+      assert.equal(
+        result.critical.length,
+        1,
+        '"no remaining" in description must not suppress genuine finding'
+      );
+    });
+
+    it('does not suppress genuine finding with "none found" in description', () => {
+      const report = '🔴 CRITICAL: Security headers - none found in response';
+      const result = detectSeverityMarkers(report);
+      assert.equal(
+        result.critical.length,
+        1,
+        '"none found" in description must not suppress genuine finding'
+      );
+    });
+
+    it('does not suppress genuine finding with "all resolved" in description', () => {
+      const report = '🔴 CRITICAL: All user sessions resolved to wrong tenant';
+      const result = detectSeverityMarkers(report);
+      assert.equal(
+        result.critical.length,
+        1,
+        '"all...resolved" in description must not suppress genuine finding'
+      );
+    });
+
+    it('does not suppress genuine finding with "0 critical" in description', () => {
+      const report = '🔴 CRITICAL: Returns 0 critical errors instead of raising exception';
+      const result = detectSeverityMarkers(report);
+      assert.equal(
+        result.critical.length,
+        1,
+        '"0...critical" in description must not suppress genuine finding'
+      );
+    });
   });
 
   describe('inline code — false positive prevention', () => {

--- a/workflows/check/lib/__tests__/severity-detection.test.js
+++ b/workflows/check/lib/__tests__/severity-detection.test.js
@@ -100,18 +100,18 @@ describe('severity-detection', () => {
     });
   });
 
-  describe('severity label formatting — false positive prevention', () => {
-    it('does not detect review severity label **[🟡 Important]**', () => {
+  describe('severity label formatting — real findings in bracket format', () => {
+    it('detects real finding in **[🟡 Important]** format', () => {
       const report =
         '**[🟡 Important] Backward-compatibility regression: text-only severity patterns silently dropped**';
       const result = detectSeverityMarkers(report);
-      assert.equal(result.important.length, 0);
+      assert.equal(result.important.length, 1);
     });
 
-    it('does not detect review severity label **[🔴 CRITICAL]**', () => {
+    it('detects real finding in **[🔴 CRITICAL]** format', () => {
       const report = '**[🔴 CRITICAL] Missing input validation**';
       const result = detectSeverityMarkers(report);
-      assert.equal(result.critical.length, 0);
+      assert.equal(result.critical.length, 1);
     });
 
     it('does not detect severity justification lines with emoji', () => {

--- a/workflows/check/lib/__tests__/severity-detection.test.js
+++ b/workflows/check/lib/__tests__/severity-detection.test.js
@@ -1,0 +1,257 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { detectSeverityMarkers } = require('../severity-detection');
+
+describe('severity-detection', () => {
+  describe('genuine issue detection', () => {
+    it('detects a genuine CRITICAL issue', () => {
+      const report = '🔴 CRITICAL: Missing input validation in auth handler';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 1);
+      assert.equal(result.important.length, 0);
+    });
+
+    it('detects a genuine IMPORTANT issue', () => {
+      const report = '🟡 IMPORTANT: Should add rate limiting';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.important.length, 1);
+      assert.equal(result.critical.length, 0);
+    });
+
+    it('does not detect text-only CRITICAL without emoji marker (emoji convention is enforced standard)', () => {
+      const report = 'CRITICAL must fix: do this now';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+      assert.equal(result.important.length, 0);
+    });
+
+    it('detects multiple severity markers on different lines', () => {
+      const report = [
+        'Review findings:',
+        '🔴 CRITICAL: SQL injection in query builder',
+        '🔴 CRITICAL: Hardcoded credentials in config',
+        '🟡 IMPORTANT: Missing error handling in API route',
+      ].join('\n');
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 2);
+      assert.equal(result.important.length, 1);
+    });
+  });
+
+  describe('negation context — false positive prevention', () => {
+    it('"No remaining" negation does not trigger false positive', () => {
+      const report = 'No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+      assert.equal(result.important.length, 0);
+    });
+
+    it('"0 CRITICAL" does not trigger false positive', () => {
+      const report = '0 🔴 CRITICAL issues found';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+    });
+
+    it('"No CRITICAL issues" does not trigger false positive', () => {
+      const report = 'No 🔴 CRITICAL issues found';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+    });
+
+    it('does not suppress genuine finding when "no...issues" appears mid-line', () => {
+      const report = 'there are no blocking issues with 🔴 CRITICAL: the session token expiry';
+      const result = detectSeverityMarkers(report);
+      assert.equal(
+        result.critical.length,
+        1,
+        'mid-line negation phrase must not suppress genuine finding'
+      );
+    });
+  });
+
+  describe('inline code — false positive prevention', () => {
+    it('does not detect severity marker inside backtick-quoted code', () => {
+      const report =
+        "- Evidence: Running `detectSeverityMarkers('no blocking issues with 🔴 CRITICAL: the session token expiry')` returns empty";
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+    });
+
+    it('still detects marker when it appears outside backticks on the same line', () => {
+      const report = '`some code` then 🔴 CRITICAL: real issue here';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 1);
+    });
+
+    it('does not detect severity marker inside double-quoted string', () => {
+      const report =
+        'The helper correctly handles "### 🔴 CRITICAL ISSUES" by stripping the prefix.';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+    });
+
+    it('still detects marker when it appears outside double quotes on the same line', () => {
+      const report = '"some quoted text" then 🔴 CRITICAL: real issue here';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 1);
+    });
+  });
+
+  describe('severity label formatting — false positive prevention', () => {
+    it('does not detect review severity label **[🟡 Important]**', () => {
+      const report =
+        '**[🟡 Important] Backward-compatibility regression: text-only severity patterns silently dropped**';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.important.length, 0);
+    });
+
+    it('does not detect review severity label **[🔴 CRITICAL]**', () => {
+      const report = '**[🔴 CRITICAL] Missing input validation**';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+    });
+
+    it('does not detect severity justification lines with emoji', () => {
+      const report =
+        '- Severity justification: 🟡 Important because the emoji convention is the enforced standard';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.important.length, 0);
+    });
+  });
+
+  describe('mixed content — real issues with negation summary', () => {
+    it('counts only real issues, not negation summary lines', () => {
+      const lines = [];
+      // Pad lines 1-9
+      for (let i = 1; i <= 9; i++) lines.push(`Line ${i} normal text`);
+      // Line 10: real CRITICAL issue
+      lines.push('🔴 CRITICAL: Buffer overflow in parser');
+      // Pad lines 11-49
+      for (let i = 11; i <= 49; i++) lines.push(`Line ${i} normal text`);
+      // Line 50: negation summary
+      lines.push('No remaining 🔴 CRITICAL issues');
+
+      const report = lines.join('\n');
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 1);
+      // The match should come from line 10, not line 50
+      assert.ok(
+        result.critical[0].includes('Buffer overflow'),
+        'Match should be the real issue from line 10'
+      );
+    });
+  });
+
+  describe('section headings with severity keywords', () => {
+    it('does not count heading when content says "None found"', () => {
+      const report = [
+        '### 🔴 CRITICAL ISSUES',
+        'None found',
+        '',
+        '### 🟡 IMPORTANT ISSUES',
+        'None found',
+      ].join('\n');
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+      assert.equal(result.important.length, 0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: validateCodeReview uses detectSeverityMarkers (Task 3)
+// ---------------------------------------------------------------------------
+describe('validateCodeReview integration', () => {
+  /** @type {string} */
+  let tmpDir;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'severity-int-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Helper: write a code-review.check.md and call validateCodeReview.
+   * @param {string} content
+   */
+  function runValidation(content) {
+    const { validateCodeReview } = require('../../hooks/check-validate-reports');
+    fs.writeFileSync(path.join(tmpDir, 'code-review.check.md'), content, 'utf8');
+    return validateCodeReview(tmpDir);
+  }
+
+  it('returns hasCritical false for negation-only content', () => {
+    const content = [
+      '**Changes Hash:** abc123',
+      '',
+      '## Summary',
+      'No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.',
+      '0 🔴 CRITICAL issues found.',
+    ].join('\n');
+
+    const result = runValidation(content);
+
+    assert.equal(result.exists, true);
+    assert.equal(result.hasCritical, false, 'negation-only content must not flag critical');
+    assert.equal(result.hasImportant, false, 'negation-only content must not flag important');
+    assert.equal(result.valid, true);
+  });
+
+  it('returns hasCritical true for genuine critical issues', () => {
+    const content = [
+      '**Changes Hash:** abc123',
+      '',
+      '🔴 CRITICAL: SQL injection vulnerability in query builder',
+    ].join('\n');
+
+    const result = runValidation(content);
+
+    assert.equal(result.exists, true);
+    assert.equal(result.hasCritical, true);
+    assert.equal(result.valid, false);
+  });
+
+  it('returns hasImportant true for genuine important issues', () => {
+    const content = [
+      '**Changes Hash:** abc123',
+      '',
+      '🟡 IMPORTANT: Should add rate limiting to API',
+    ].join('\n');
+
+    const result = runValidation(content);
+
+    assert.equal(result.exists, true);
+    assert.equal(result.hasImportant, true);
+    assert.equal(result.hasCritical, false);
+    assert.equal(result.valid, true);
+  });
+
+  it('does not count section heading labels as findings', () => {
+    const content = [
+      '**Changes Hash:** abc123',
+      '',
+      '### 🔴 CRITICAL ISSUES',
+      'None found',
+      '',
+      '### 🟡 IMPORTANT ISSUES',
+      'None found',
+    ].join('\n');
+
+    const result = runValidation(content);
+
+    assert.equal(result.hasCritical, false, 'heading label must not count as critical');
+    assert.equal(result.hasImportant, false, 'heading label must not count as important');
+    assert.equal(result.valid, true);
+  });
+
+  it('is exported via module.exports', () => {
+    const mod = require('../../hooks/check-validate-reports');
+    assert.equal(typeof mod.validateCodeReview, 'function');
+  });
+});

--- a/workflows/check/lib/__tests__/severity-detection.test.js
+++ b/workflows/check/lib/__tests__/severity-detection.test.js
@@ -112,6 +112,38 @@ describe('severity-detection', () => {
     });
   });
 
+  describe('Markdown list-prefixed negation — false positive prevention', () => {
+    it('suppresses "- No remaining" bullet-list negation', () => {
+      const report = '- No remaining 🔴 CRITICAL issues';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'bullet-list negation must be suppressed');
+    });
+
+    it('suppresses "* No CRITICAL issues" bullet-list negation', () => {
+      const report = '* No 🔴 CRITICAL issues found';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'asterisk-list negation must be suppressed');
+    });
+
+    it('suppresses "> All resolved" blockquote negation', () => {
+      const report = '> All 🔴 CRITICAL issues resolved';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'blockquote negation must be suppressed');
+    });
+
+    it('suppresses indented bullet-list negation', () => {
+      const report = '  - 0 🔴 CRITICAL issues found';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'indented bullet negation must be suppressed');
+    });
+
+    it('suppresses nested list negation ("> - No...")', () => {
+      const report = '> - No 🔴 CRITICAL issues found';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'nested list negation must be suppressed');
+    });
+  });
+
   describe('inline code — false positive prevention', () => {
     it('does not detect severity marker inside backtick-quoted code', () => {
       const report =

--- a/workflows/check/lib/severity-detection.js
+++ b/workflows/check/lib/severity-detection.js
@@ -31,12 +31,12 @@ const IMPORTANT_RE = /🟡\s*IMPORTANT/i;
  * negation keyword and the anchor word (e.g., "No 🔴 CRITICAL issues").
  */
 const NEGATION_PATTERNS = [
-  /\bno\s+remaining\b/i,
+  /^\s*no\s+remaining\b/i,
   /^\s*\bno\b.*\bissues\b/i,
-  /\b0\s+.*(?:critical|important)\b/i,
-  /\bnone\s+found\b/i,
-  /\ball\b.*\bresolved\b/i,
-  /\ball\b.*\baddressed\b/i,
+  /^\s*0\s+.*(?:critical|important)\b/i,
+  /^\s*none\s+found\b/i,
+  /^\s*\ball\b.*\bresolved\b/i,
+  /^\s*\ball\b.*\baddressed\b/i,
   /^\s*\bno\b.*\bfound\b/i,
 ];
 

--- a/workflows/check/lib/severity-detection.js
+++ b/workflows/check/lib/severity-detection.js
@@ -1,0 +1,147 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Severity marker detection — pure function for line-based analysis
+//
+// Vocabulary aligns with parse-report-status.js (NO_ISSUES_RE, SPURIOUS_TITLE_RE)
+// but operates at the line level rather than section level.
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex matching any severity emoji marker on a line.
+ * Used as an early-exit filter before classification.
+ *
+ * Emoji prefix is required — text-only patterns (e.g., "CRITICAL must fix",
+ * "severity critical") are intentionally out of scope. The emoji-based
+ * convention is the enforced standard for this plugin's code review reports.
+ */
+const SEVERITY_RE = /(?:🔴\s*CRITICAL|🟡\s*IMPORTANT)/i;
+
+/** Matches a line containing a 🔴 CRITICAL marker. */
+const CRITICAL_RE = /🔴\s*CRITICAL/i;
+
+/** Matches a line containing a 🟡 IMPORTANT marker. */
+const IMPORTANT_RE = /🟡\s*IMPORTANT/i;
+
+/**
+ * Negation patterns — lines matching any of these report the *absence* of
+ * issues and must not be counted as genuine findings.
+ *
+ * Uses `.*` to bridge emoji/severity tokens that may appear between the
+ * negation keyword and the anchor word (e.g., "No 🔴 CRITICAL issues").
+ */
+const NEGATION_PATTERNS = [
+  /\bno\s+remaining\b/i,
+  /^\s*\bno\b.*\bissues\b/i,
+  /\b0\s+.*(?:critical|important)\b/i,
+  /\bnone\s+found\b/i,
+  /\ball\b.*\bresolved\b/i,
+  /\ball\b.*\baddressed\b/i,
+  /^\s*\bno\b.*\bfound\b/i,
+];
+
+/**
+ * Severity label pattern — the review's own categorization markers.
+ * E.g., `**[🟡 Important]**` or `**[🔴 CRITICAL]**` used to label suggestions.
+ * Also matches severity justification lines like "Severity justification: 🟡 Important".
+ * These are metadata, not genuine findings.
+ */
+const SEVERITY_LABEL_RE = /\*\*\[(?:🔴\s*CRITICAL|🟡\s*IMPORTANT)\]|severity\s+justification[:\s]/i;
+
+/** Markdown heading prefix (e.g., `###`). */
+const HEADING_RE = /^\s*#{1,6}\s+/;
+
+/**
+ * Content pattern for headings that are section labels only — no issue text.
+ * Matches after stripping the `#` prefix, e.g., "🔴 CRITICAL ISSUES".
+ */
+const HEADING_LABEL_RE = /^(?:🔴\s*)?(?:🟡\s*)?(?:CRITICAL|IMPORTANT)\s*(?:ISSUES?)?$/i;
+
+/**
+ * Determine whether a line is a section heading with no issue description.
+ * E.g., "### 🔴 CRITICAL ISSUES" is a heading label, not a genuine finding.
+ *
+ * @param {string} line
+ * @returns {boolean}
+ */
+function isSectionHeading(line) {
+  if (!HEADING_RE.test(line)) return false;
+  const content = line.replace(HEADING_RE, '').trim();
+  return HEADING_LABEL_RE.test(content);
+}
+
+/**
+ * Check whether all severity markers on a line appear inside inline code spans
+ * or double-quoted strings. Strips backtick-delimited and double-quoted content
+ * and re-tests — if no marker remains, the line is considered a code example
+ * or quoted reference, not a genuine finding.
+ *
+ * @param {string} line
+ * @returns {boolean}
+ */
+function isInsideInlineCode(line) {
+  // Remove inline code spans (backtick-delimited) and quoted strings (double-quoted)
+  const stripped = line.replace(/`[^`]+`/g, '').replace(/"[^"]+"/g, '');
+  // If no severity marker remains after stripping, the marker was inside code/quotes
+  return !SEVERITY_RE.test(stripped);
+}
+
+/**
+ * Check whether a line matches any negation pattern.
+ *
+ * @param {string} line
+ * @returns {boolean}
+ */
+function isNegated(line) {
+  for (const pattern of NEGATION_PATTERNS) {
+    if (pattern.test(line)) return true;
+  }
+  return false;
+}
+
+/**
+ * Detect genuine severity markers in report content.
+ *
+ * Splits content into lines, matches severity emoji markers per line,
+ * and filters out lines matching negation patterns or section headings
+ * without issue descriptions.
+ *
+ * @param {string} content - The report content to analyze
+ * @returns {{ critical: string[], important: string[] }} Arrays of matching lines
+ */
+function detectSeverityMarkers(content) {
+  const result = { critical: [], important: [] };
+
+  if (!content) return result;
+
+  const lines = content.split('\n');
+
+  for (const line of lines) {
+    // Early exit: skip lines without any severity marker
+    if (!SEVERITY_RE.test(line)) continue;
+
+    // Filter false positives: severity marker inside inline code (backticks)
+    if (isInsideInlineCode(line)) continue;
+
+    // Filter false positives: severity label formatting (e.g., **[🟡 Important]**)
+    if (SEVERITY_LABEL_RE.test(line)) continue;
+
+    // Filter false positives: negation context
+    if (isNegated(line)) continue;
+
+    // Filter false positives: section headings without issue text
+    if (isSectionHeading(line)) continue;
+
+    // Classify by severity level
+    if (CRITICAL_RE.test(line)) {
+      result.critical.push(line);
+    }
+    if (IMPORTANT_RE.test(line)) {
+      result.important.push(line);
+    }
+  }
+
+  return result;
+}
+
+module.exports = { detectSeverityMarkers };

--- a/workflows/check/lib/severity-detection.js
+++ b/workflows/check/lib/severity-detection.js
@@ -41,12 +41,14 @@ const NEGATION_PATTERNS = [
 ];
 
 /**
- * Severity label pattern — the review's own categorization markers.
- * E.g., `**[🟡 Important]**` or `**[🔴 CRITICAL]**` used to label suggestions.
- * Also matches severity justification lines like "Severity justification: 🟡 Important".
- * These are metadata, not genuine findings.
+ * Severity justification pattern — metadata lines that explain *why* a severity
+ * level was assigned, not actual findings.
+ * E.g., "Severity justification: 🟡 Important because ..."
+ *
+ * NOTE: `**[🔴 CRITICAL] Issue Title**` is the code-checker agent's actual finding
+ * format and must NOT be suppressed here — those are genuine findings.
  */
-const SEVERITY_LABEL_RE = /\*\*\[(?:🔴\s*CRITICAL|🟡\s*IMPORTANT)\]|severity\s+justification[:\s]/i;
+const SEVERITY_JUSTIFICATION_RE = /severity\s+justification[:\s]/i;
 
 /** Markdown heading prefix (e.g., `###`). */
 const HEADING_RE = /^\s*#{1,6}\s+/;
@@ -123,8 +125,8 @@ function detectSeverityMarkers(content) {
     // Filter false positives: severity marker inside inline code (backticks)
     if (isInsideInlineCode(line)) continue;
 
-    // Filter false positives: severity label formatting (e.g., **[🟡 Important]**)
-    if (SEVERITY_LABEL_RE.test(line)) continue;
+    // Filter false positives: severity justification metadata lines
+    if (SEVERITY_JUSTIFICATION_RE.test(line)) continue;
 
     // Filter false positives: negation context
     if (isNegated(line)) continue;

--- a/workflows/check/lib/severity-detection.js
+++ b/workflows/check/lib/severity-detection.js
@@ -29,15 +29,20 @@ const IMPORTANT_RE = /🟡\s*IMPORTANT/i;
  *
  * Uses `.*` to bridge emoji/severity tokens that may appear between the
  * negation keyword and the anchor word (e.g., "No 🔴 CRITICAL issues").
+ *
+ * The `LINE_START` prefix handles optional Markdown list markers (`- `, `* `, `> `)
+ * and blockquote prefixes that commonly appear in code review report summaries.
  */
+const LINE_START = /^\s*(?:[-*>]+\s+)*/.source;
+
 const NEGATION_PATTERNS = [
-  /^\s*no\s+remaining\b/i,
-  /^\s*\bno\b.*\bissues\b/i,
-  /^\s*0\s+.*(?:critical|important)\b/i,
-  /^\s*none\s+found\b/i,
-  /^\s*\ball\b.*\bresolved\b/i,
-  /^\s*\ball\b.*\baddressed\b/i,
-  /^\s*\bno\b.*\bfound\b/i,
+  new RegExp(`${LINE_START}no\\s+remaining\\b`, 'i'),
+  new RegExp(`${LINE_START}\\bno\\b.*\\bissues\\b`, 'i'),
+  new RegExp(`${LINE_START}0\\s+.*(?:critical|important)\\b`, 'i'),
+  new RegExp(`${LINE_START}none\\s+found\\b`, 'i'),
+  new RegExp(`${LINE_START}\\ball\\b.*\\bresolved\\b`, 'i'),
+  new RegExp(`${LINE_START}\\ball\\b.*\\baddressed\\b`, 'i'),
+  new RegExp(`${LINE_START}\\bno\\b.*\\bfound\\b`, 'i'),
 ];
 
 /**


### PR DESCRIPTION
## Existing Behavior

- The code-review validator in `check-validate-reports.js` detected CRITICAL and IMPORTANT severity markers using broad regex patterns (`/🔴\s*CRITICAL|CRITICAL.*must fix|severity.*critical/gi`) applied to the entire report content as a single string.
- Negation phrases like "No remaining 🔴 CRITICAL issues" or "0 🔴 CRITICAL issues found" were matched as genuine findings, causing false positives that incorrectly blocked check gates.
- Severity markers inside inline code spans (backtick-delimited) and double-quoted strings were treated as real issues.
- Section headings like `### 🔴 CRITICAL ISSUES` followed by "None found" were counted as findings.
- The `validateCodeReview` function was not exported or testable in isolation (no `module.exports`, `main()` called at module load time).

## Intended New Behavior

- Severity detection is extracted into a dedicated pure function `detectSeverityMarkers(content)` in `workflows/check/lib/severity-detection.js`, enabling isolated unit testing.
- Detection operates line-by-line with layered false positive filters: negation patterns (`no remaining`, `0 CRITICAL`, `none found`, `all resolved`), inline code spans (backtick-delimited), double-quoted strings, section heading labels, and severity justification metadata lines.
- `check-validate-reports.js` delegates to `detectSeverityMarkers` and exports `validateCodeReview` via `module.exports` for integration testing; `main()` is guarded by `require.main === module`.
- 257-line test suite in `severity-detection.test.js` covers genuine detections, negation contexts, inline code suppression, bracket format findings, mixed content, and section headings.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Run the unit tests directly: `node --test workflows/check/lib/__tests__/severity-detection.test.js`
2. Verify a report with only negation phrases (e.g., "No remaining 🔴 CRITICAL issues") exits the check gate with no blocking errors.
3. Verify a report containing a genuine `🔴 CRITICAL: <description>` line still triggers a block.
4. Verify a report with inline code containing severity markers (e.g., `` `detectSeverityMarkers('🔴 CRITICAL...')` ``) does not trigger a block.
5. Verify a report with `### 🔴 CRITICAL ISSUES\nNone found` heading section does not trigger a block.

### Test Results
`workflows/check/lib/__tests__/severity-detection.test.js` — 257-line test file covering:
- Genuine issue detection (4 cases)
- Negation context false positive prevention (4 cases)
- Inline code false positive prevention (4 cases)
- Severity label bracket format detection (3 cases)
- Mixed content with negation summary (1 case)
- Section headings with "None found" (1 case)
- Integration: `validateCodeReview` via `check-validate-reports.js` (5 cases)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the gatekeeping logic for `/check` by tightening how CRITICAL/IMPORTANT findings are detected; mis-detection could incorrectly pass or block CI approvals. Added tests reduce regression risk but detection heuristics may miss edge-case report formats.
> 
> **Overview**
> Updates the code-review report validator to stop flagging **false-positive** CRITICAL/IMPORTANT findings by replacing broad whole-document regexes with a new line-based `detectSeverityMarkers()` helper.
> 
> Adds `workflows/check/lib/severity-detection.js`, which detects emoji-based severity markers while filtering out negation summaries (e.g., “no issues”, “0 critical”), section headings, severity-justification metadata, and markers appearing only inside inline code/quoted strings.
> 
> Makes `check-validate-reports.js` more testable by guarding `main()` behind `require.main === module` and exporting `validateCodeReview`, and introduces a comprehensive unit+integration test suite covering the new detection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1468a6a7d94eff7f57fcb79c42e465293cf4a19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->