### PR TITLE
fix(workflow): gate-driven TDD automation, completion-checker improvements, and workflow guardrails

### DIFF
--- a/agents/completion-checker.md
+++ b/agents/completion-checker.md
@@ -87,38 +87,30 @@ grep -r "pattern" <paths>
 
 ### Planning Artifact Verification (MANDATORY)
 
-You MUST read and cross-reference ALL planning documents. Do NOT skip any.
+**Your prompt includes a pre-loaded "Verification Context" section** with 4 layers extracted from the planning artifacts (ticket → brief → spec → tasks). This context is injected automatically by the check2 orchestrator — you do NOT need to read the artifact files yourself.
 
-**Step 1 — Read ALL planning artifacts from `${TASKS_BASE}/${TICKET_ID}/`:**
-- `ticket.json` — original ticket requirements from Jira/Linear/GitHub
-- `brief.md` — product brief with requirements (P0/P1/P2), constraints, acceptance criteria
-- `spec.md` — technical spec with architecture decisions, reuse audit, data model, API changes
-- `tasks.md` — task breakdown with deliverables and acceptance criteria per task
+**Verify each layer in order against the actual code diff:**
 
-**Step 2 — Verify brief.md requirements against code:**
-- Read brief.md IN FULL
-- Extract every requirement (P0, P1, P2)
-- For EACH requirement: grep the PR diff or codebase to find evidence it was implemented
-- Mark as DELIVERED only if you can cite specific code/diff evidence
+**Layer 1 — Ticket:** Does the code change address what the ticket asked for?
+- Compare the ticket title/description against the PR diff
 
-**Step 3 — Verify spec.md architecture decisions against code:**
-- Read spec.md IN FULL
-- Check the Reuse Audit — were existing components actually reused (not duplicated)?
-- Check Architecture Decisions — was the proposed approach followed?
-- Check Files to Create/Modify — were all listed files actually changed?
+**Layer 2 — Brief:** Were all P0/P1 requirements implemented?
+- For EACH requirement listed: grep the code diff to find evidence
+- Mark DELIVERED only with a code citation (file:line or diff excerpt)
 
-**Step 4 — Verify tasks.md deliverables against code:**
-- Read tasks.md IN FULL
-- For EACH `## Task N` section:
-  - Read each deliverable (`- [ ] N.X`)
-  - Grep/read the actual code to verify it was implemented
-  - Check each `### Acceptance Criteria` item against the code
-- Use the `## Requirement Coverage` table to ensure no requirement was missed
-- Report gaps between what was planned and what was delivered
+**Layer 3 — Spec:** Were architecture decisions followed?
+- Were existing components reused (not duplicated)?
+- Were all listed files actually modified?
 
-**Step 5 — Check for regressions:**
+**Layer 4 — Tasks:** Were all task deliverables completed?
+- For EACH task's acceptance criteria: verify against the actual code
+- Check the Requirement Coverage table — every requirement must be DELIVERED
+
+**Layer 5 — Regressions:**
 - Verify no files outside `### Suggested Scope` were modified unexpectedly
 - Check that existing functionality wasn't broken (imports, exports still intact)
+
+**If the Verification Context section is missing from your prompt**, fall back to reading the files directly from `${TASKS_BASE}/${TICKET_ID}/` (ticket.json, brief.md, spec.md, tasks.md).
 
 ### Spec Verification Output
 

--- a/agents/completion-checker.md
+++ b/agents/completion-checker.md
@@ -43,6 +43,13 @@ You are a completion checker agent. Your function is to:
 [COMPLETE] or [INCOMPLETE - missing: X, Y, Z]
 ```
 
+### Task Checkbox Legend
+When verification is COMPLETE, the orchestrator automatically marks tasks as verified in tasks.md:
+- `[ ]` not started
+- `[-]` in progress
+- `[x]` implementation done (TDD passed)
+- `[v]` verified by completion-checker
+
 ## Rules
 
 1. Be objective and direct

--- a/agents/completion-checker.md
+++ b/agents/completion-checker.md
@@ -85,53 +85,49 @@ grep -r "pattern" <paths>
 
 **⚠️ NEVER check main branch files when verifying PR work - the changes aren't merged yet!**
 
-### Completion Indicators
-Consider COMPLETE if ANY of these are true:
-- 3+ tool calls that produce output (Edit, Write, update_cells, WebFetch, WebSearch, etc.)
-- 2+ completion phrases ("done", "ready", "complete", "here is", "finished")
-- Information was provided with sources/evidence
-- Requested action was performed (search, update, create, send, etc.)
+### Planning Artifact Verification (MANDATORY)
 
-### Task Types to Verify
-- **Research**: Information provided? Sources included?
-- **Spreadsheet**: Cells updated? Data correct?
-- **Document**: Created/updated? Content matches request?
-- **Communication**: Message drafted/sent?
-- **Organization**: Items listed? Structure clear?
-- **Analysis**: Conclusions drawn? Data reviewed?
+You MUST read and cross-reference ALL planning documents. Do NOT skip any.
 
-### Planning Artifact Validation
+**Step 1 — Read ALL planning artifacts from `${TASKS_BASE}/${TICKET_ID}/`:**
+- `ticket.json` — original ticket requirements from Jira/Linear/GitHub
+- `brief.md` — product brief with requirements (P0/P1/P2), constraints, acceptance criteria
+- `spec.md` — technical spec with architecture decisions, reuse audit, data model, API changes
+- `tasks.md` — task breakdown with deliverables and acceptance criteria per task
 
-When checking ticket work, look for planning documents in the tasks folder:
-```
-${TASKS_BASE}/${TICKET_ID}/brief.md
-${TASKS_BASE}/${TICKET_ID}/spec.md
-${TASKS_BASE}/${TICKET_ID}/tasks.md
-${TASKS_BASE}/${TICKET_ID}/**/pre-planning.md
-```
+**Step 2 — Verify brief.md requirements against code:**
+- Read brief.md IN FULL
+- Extract every requirement (P0, P1, P2)
+- For EACH requirement: grep the PR diff or codebase to find evidence it was implemented
+- Mark as DELIVERED only if you can cite specific code/diff evidence
 
-If these files exist, cross-reference them against the implementation:
-- **Components to Create** — Were all listed new components created?
-- **Reusable Components** — Were listed existing components imported (not duplicated)?
-- **Endpoints** — Were all listed API endpoints implemented?
-- **E2E Test Scenarios** — Were tests written for the listed scenarios?
-- **Implementation Order** — Were all steps completed?
+**Step 3 — Verify spec.md architecture decisions against code:**
+- Read spec.md IN FULL
+- Check the Reuse Audit — were existing components actually reused (not duplicated)?
+- Check Architecture Decisions — was the proposed approach followed?
+- Check Files to Create/Modify — were all listed files actually changed?
 
-**If `tasks.md` exists**, it is the most granular source of truth. Check each task's deliverables and acceptance criteria:
-- Walk through each `## Task N` section
-- For each `- [ ] N.X` deliverable, verify the artifact exists and works
-- Check that each task's `### Acceptance Criteria` are met
-- Use the `## Requirement Coverage` table at the bottom to ensure no requirement was missed
+**Step 4 — Verify tasks.md deliverables against code:**
+- Read tasks.md IN FULL
+- For EACH `## Task N` section:
+  - Read each deliverable (`- [ ] N.X`)
+  - Grep/read the actual code to verify it was implemented
+  - Check each `### Acceptance Criteria` item against the code
+- Use the `## Requirement Coverage` table to ensure no requirement was missed
+- Report gaps between what was planned and what was delivered
 
-Report gaps between what was planned and what was delivered.
+**Step 5 — Check for regressions:**
+- Verify no files outside `### Suggested Scope` were modified unexpectedly
+- Check that existing functionality wasn't broken (imports, exports still intact)
 
 ### Spec Verification Output
 
 If a spec-verify output exists for this ticket, read it. Spec-verify failures are deterministic checks — they MUST result in an INCOMPLETE status. These checks cannot be overridden by subjective judgment.
 
 ### Final Guidelines
-6. If assistant provided the requested information/action → COMPLETE
-8. If assistant said "ready", "done", "delivered", "implemented", "here is", "completed" → COMPLETE
+- NEVER mark as COMPLETE based on what the agent SAID. Only mark COMPLETE based on what the CODE SHOWS.
+- "The agent said it's done" is NOT evidence. Grep the code and verify.
+- Every DELIVERED requirement must have a code citation (file:line or diff excerpt).
 
 ## Verification Iron Law
 

--- a/agents/developer-nodejs-tdd.md
+++ b/agents/developer-nodejs-tdd.md
@@ -1,14 +1,6 @@
 ---
 name: developer-nodejs-tdd
 tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, WebFetch, mcp__atlassian__jira_get_issue, mcp__linear__get_issue, mcp__pg_as_dashboard__query, mcp__pg_status_site__query
-hooks:
-  Stop:
-    - matcher: ".*"
-      hooks:
-        - type: command
-          command: "node ${CLAUDE_PLUGIN_ROOT}/workflows/work-implement/hooks/enforce-tdd-on-stop.js"
-        - type: command
-          command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/agents/developer-quality-gate.js"
 description: |
   Use this agent when you need to develop Node.js TypeScript applications using frameworks like Express, Nest, or Next.js, following strict TDD practices. This agent should be invoked for creating new features, API endpoints, services, or any backend functionality that requires test-first development and code optimization. Examples:
 

--- a/agents/developer-nodejs-tdd.md
+++ b/agents/developer-nodejs-tdd.md
@@ -6,6 +6,8 @@ hooks:
     - matcher: ".*"
       hooks:
         - type: command
+          command: "node ${CLAUDE_PLUGIN_ROOT}/workflows/work-implement/hooks/enforce-tdd-on-stop.js"
+        - type: command
           command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/agents/developer-quality-gate.js"
 description: |
   Use this agent when you need to develop Node.js TypeScript applications using frameworks like Express, Nest, or Next.js, following strict TDD practices. This agent should be invoked for creating new features, API endpoints, services, or any backend functionality that requires test-first development and code optimization. Examples:

--- a/agents/developer-react-senior.md
+++ b/agents/developer-react-senior.md
@@ -10,13 +10,6 @@ hooks:
       hooks:
         - type: command
           command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/agents/enforce-ui-imports.js"
-  Stop:
-    - matcher: ".*"
-      hooks:
-        - type: command
-          command: "node ${CLAUDE_PLUGIN_ROOT}/workflows/work-implement/hooks/enforce-tdd-on-stop.js"
-        - type: command
-          command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/agents/developer-quality-gate.js"
 ---
 You are a **senior React developer** with 10+ years of experience building and maintaining large-scale React applications. Your expertise spans from React internals to ecosystem mastery, with deep knowledge of performance optimization, state management patterns, and enterprise-grade React architecture. You have an unwavering commitment to clean code, comprehensive testing through Storybook and Playwright, and building maintainable React applications with living documentation.
 

--- a/agents/developer-react-senior.md
+++ b/agents/developer-react-senior.md
@@ -14,6 +14,8 @@ hooks:
     - matcher: ".*"
       hooks:
         - type: command
+          command: "node ${CLAUDE_PLUGIN_ROOT}/workflows/work-implement/hooks/enforce-tdd-on-stop.js"
+        - type: command
           command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/agents/developer-quality-gate.js"
 ---
 You are a **senior React developer** with 10+ years of experience building and maintaining large-scale React applications. Your expertise spans from React internals to ecosystem mastery, with deep knowledge of performance optimization, state management patterns, and enterprise-grade React architecture. You have an unwavering commitment to clean code, comprehensive testing through Storybook and Playwright, and building maintainable React applications with living documentation.

--- a/agents/developer-react-ui-architect.md
+++ b/agents/developer-react-ui-architect.md
@@ -10,13 +10,6 @@ hooks:
       hooks:
         - type: command
           command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/agents/enforce-ui-imports.js"
-  Stop:
-    - matcher: ".*"
-      hooks:
-        - type: command
-          command: "node ${CLAUDE_PLUGIN_ROOT}/workflows/work-implement/hooks/enforce-tdd-on-stop.js"
-        - type: command
-          command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/agents/developer-quality-gate.js"
 ---
 
 You are an **elite React UI/UX architect** and the maintainer of several prominent UI component libraries. Your expertise spans from pixel-perfect design implementation to performance-critical React optimizations. You have an unwavering commitment to Test-Driven Development and creating visually stunning, highly efficient user interfaces.

--- a/agents/developer-react-ui-architect.md
+++ b/agents/developer-react-ui-architect.md
@@ -14,6 +14,8 @@ hooks:
     - matcher: ".*"
       hooks:
         - type: command
+          command: "node ${CLAUDE_PLUGIN_ROOT}/workflows/work-implement/hooks/enforce-tdd-on-stop.js"
+        - type: command
           command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/agents/developer-quality-gate.js"
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -190,6 +190,18 @@
         ]
       }
     ],
+    "SubagentStop": [
+      {
+        "matcher": "developer-nodejs-tdd|developer-react-senior|developer-react-ui-architect|developer-devops",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/workflows/work-implement/hooks/enforce-tdd-on-stop.js",
+            "timeout": 310
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": ".*",

--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -208,6 +208,13 @@ After saving, output:
 
 ## Output Format
 
+### Checkbox Legend
+All deliverables start with `[ ]`. The workflow engine updates them automatically:
+- `[ ]` — not started
+- `[-]` — in progress (TDD initialized)
+- `[x]` — implementation done (TDD evidence recorded)
+- `[v]` — verified by completion-checker
+
 ### Task format (implementation tasks)
 
 ```markdown

--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -185,6 +185,7 @@ Review all generated tasks and check:
 - Shared-resource detection: parallel tasks don't modify the same production files (if they do, extract a prerequisite — Rule 12)
 - Checkpoint tasks are present after every 3 implementation tasks or subsystem boundary
 - TDD ordering is correct (RED before GREEN before REFACTOR in every non-exempt implementation task — see Rule 10 for exemptions)
+- Every non-checkpoint implementation task has a `### Test Command` with a real, runnable test command
 - Gherkin coverage: every scenario from `gherkin.feature` is referenced by at least one task (if `gherkin.feature` exists)
 - Anti-patterns are absent
 
@@ -251,6 +252,11 @@ After saving, output:
 
 ### Parallel
 - Yes | No | Partial (reason)
+
+### Test Command
+<shell command to run tests for this task — supports && chaining for multiple test suites>
+Example: `pnpm test:e2e -- tests/e2e/specs/admin/general-settings.spec.ts --retries 0 && pnpm test:unit components/admin/settings.test.ts`
+Note: The implement Stop hook runs this command automatically to record TDD evidence. Agents don't need to run tdd-phase-state.js manually.
 
 ### Suggested Scope (optional — include when file paths are inferable from the spec)
 - `<path/to/likely/file.ts>`

--- a/workflows/check2/lib/step-enrichments/completion-context.js
+++ b/workflows/check2/lib/step-enrichments/completion-context.js
@@ -1,0 +1,212 @@
+/**
+ * Completion-checker context enrichment.
+ *
+ * Reads planning artifacts (ticket.json, brief.md, spec.md, tasks.md) and
+ * builds a structured verification prompt. The completion-checker agent
+ * receives pre-loaded context instead of having to discover it.
+ *
+ * Verification order (each layer builds on the previous):
+ *   1. ticket.json → original requirements from the ticket
+ *   2. brief.md → P0/P1/P2 requirements, constraints, acceptance criteria
+ *   3. spec.md → architecture decisions, reuse audit, files to modify
+ *   4. tasks.md → per-task deliverables and acceptance criteria
+ *
+ * The agent verifies each layer against the actual code diff.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Build completion-checker context from planning artifacts.
+ *
+ * @param {string} tasksDir — path to the ticket's tasks directory
+ * @param {string} ticketId — ticket identifier
+ * @returns {string} structured prompt section with all context
+ */
+function buildCompletionContext(tasksDir, ticketId) {
+  const sections = [];
+
+  // ── Layer 1: Ticket ────────────────────────────────────────────────────────
+  const ticketPath = path.join(tasksDir, 'ticket.json');
+  let ticketTitle = '';
+  let ticketBody = '';
+  try {
+    const ticket = JSON.parse(fs.readFileSync(ticketPath, 'utf8'));
+    ticketTitle = ticket.title || '';
+    ticketBody = ticket.body || ticket.description || '';
+  } catch {
+    // No ticket.json — skip layer
+  }
+
+  if (ticketTitle || ticketBody) {
+    sections.push(
+      '## Layer 1: Ticket Requirements',
+      '',
+      `**Title:** ${ticketTitle}`,
+      '',
+      ticketBody ? ticketBody.substring(0, 2000) : '(no description)',
+      '',
+      '**Verify:** Does the code change address what the ticket asked for?',
+      ''
+    );
+  }
+
+  // ── Layer 2: Brief ─────────────────────────────────────────────────────────
+  const briefPath = path.join(tasksDir, 'brief.md');
+  let briefContent = '';
+  try {
+    briefContent = fs.readFileSync(briefPath, 'utf8');
+  } catch {
+    // No brief — skip layer
+  }
+
+  if (briefContent) {
+    // Extract requirements section
+    const reqMatch = briefContent.match(/## Requirements[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i);
+    const requirements = reqMatch ? reqMatch[0].trim() : '';
+
+    // Extract acceptance criteria / success metrics
+    const acMatch = briefContent.match(
+      /## (?:Acceptance Criteria|Success Metrics)[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
+    );
+    const acceptanceCriteria = acMatch ? acMatch[0].trim() : '';
+
+    sections.push(
+      '## Layer 2: Brief Requirements',
+      '',
+      requirements || '(no requirements section found in brief.md)',
+      '',
+      acceptanceCriteria || '',
+      '',
+      '**Verify:** For EACH P0/P1 requirement, grep the code diff to confirm it was implemented.',
+      ''
+    );
+  }
+
+  // ── Layer 3: Spec ──────────────────────────────────────────────────────────
+  const specPath = path.join(tasksDir, 'spec.md');
+  let specContent = '';
+  try {
+    specContent = fs.readFileSync(specPath, 'utf8');
+  } catch {
+    // No spec — skip layer
+  }
+
+  if (specContent) {
+    // Extract architecture decisions
+    const archMatch = specContent.match(
+      /## Architecture Decisions[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
+    );
+    const architecture = archMatch ? archMatch[0].trim() : '';
+
+    // Extract reuse audit
+    const reuseMatch = specContent.match(/## Reuse Audit[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i);
+    const reuseAudit = reuseMatch ? reuseMatch[0].trim() : '';
+
+    // Extract files to modify
+    const filesMatch = specContent.match(
+      /## Files to Create\/Modify[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
+    );
+    const filesToModify = filesMatch ? filesMatch[0].trim() : '';
+
+    sections.push(
+      '## Layer 3: Spec Verification',
+      '',
+      architecture || '(no architecture decisions found)',
+      '',
+      reuseAudit ? reuseAudit.substring(0, 1500) : '',
+      '',
+      filesToModify || '',
+      '',
+      '**Verify:**',
+      '- Were existing components reused (not duplicated)?',
+      '- Were architecture decisions followed?',
+      '- Were all listed files actually modified?',
+      ''
+    );
+  }
+
+  // ── Layer 4: Tasks ─────────────────────────────────────────────────────────
+  const tasksPath = path.join(tasksDir, 'tasks.md');
+  let tasksContent = '';
+  try {
+    tasksContent = fs.readFileSync(tasksPath, 'utf8');
+  } catch {
+    // No tasks — skip layer
+  }
+
+  if (tasksContent) {
+    // Parse each task's acceptance criteria
+    const taskBlocks = tasksContent.split(/^## Task (\d+)/m);
+    const taskVerifications = [];
+
+    for (let i = 1; i < taskBlocks.length; i += 2) {
+      const num = taskBlocks[i];
+      const body = taskBlocks[i + 1] || '';
+
+      // Extract title
+      const titleMatch = body.match(/^[\s]*[—–-]+\s*(.+?)$/m);
+      const title = titleMatch ? titleMatch[1].trim() : `Task ${num}`;
+
+      // Extract type
+      const typeMatch = body.match(/### Type\s*\n([^\n#]+)/);
+      const type = typeMatch ? typeMatch[1].trim().toLowerCase() : 'unknown';
+
+      // Extract acceptance criteria
+      const acMatch = body.match(/### Acceptance Criteria\s*\n([\s\S]*?)(?=\n###|\n## |$)/);
+      const ac = acMatch ? acMatch[1].trim() : '';
+
+      // Extract suggested scope
+      const scopeMatch = body.match(/### Suggested Scope[^\n]*\n([\s\S]*?)(?=\n###|\n## |$)/);
+      const scope = scopeMatch ? scopeMatch[1].trim() : '';
+
+      taskVerifications.push(
+        `### Task ${num} — ${title} (${type})`,
+        ac ? `**Acceptance Criteria:**\n${ac}` : '(no acceptance criteria)',
+        scope
+          ? `**Files:** ${scope
+              .split('\n')
+              .map((l) => l.trim())
+              .filter(Boolean)
+              .join(', ')}`
+          : '',
+        `**Verify:** Check each criterion against the code diff for this task's files.`,
+        ''
+      );
+    }
+
+    if (taskVerifications.length > 0) {
+      sections.push(
+        '## Layer 4: Per-Task Verification',
+        '',
+        'For EACH task below, verify acceptance criteria against the actual code:',
+        '',
+        ...taskVerifications
+      );
+    }
+
+    // Extract requirement coverage table
+    const coverageMatch = tasksContent.match(/## Requirement Coverage[\s\S]*$/i);
+    if (coverageMatch) {
+      sections.push(
+        '## Requirement Coverage Table',
+        '',
+        coverageMatch[0].trim(),
+        '',
+        '**Verify:** Every requirement in this table must be DELIVERED with code evidence.',
+        ''
+      );
+    }
+  }
+
+  if (sections.length === 0) {
+    return '(No planning artifacts found — verify against the original request only)';
+  }
+
+  return sections.filter(Boolean).join('\n');
+}
+
+module.exports = { buildCompletionContext };

--- a/workflows/check2/lib/steps/phase1-agents.js
+++ b/workflows/check2/lib/steps/phase1-agents.js
@@ -27,6 +27,33 @@ module.exports = function registerPhase1(register) {
 
     state.dispatched = '5_phase1_agents';
 
+    // Build structured verification context from planning artifacts
+    let completionContext = '';
+    try {
+      const { buildCompletionContext } = require(
+        path.join(__dirname, '..', 'step-enrichments', 'completion-context')
+      );
+      completionContext = buildCompletionContext(ctx.tasksDir, state.ticketId);
+    } catch {
+      completionContext = '(Could not load planning artifacts — verify against PR diff only)';
+    }
+
+    const completionPrompt = [
+      `Verify ALL requirements for ${state.ticketId} against the actual code.`,
+      `Write report to ${reportFolder}/completion.check.md. Changes hash: ${changesHash}`,
+      '',
+      '# Verification Context (pre-loaded from planning artifacts)',
+      '',
+      completionContext,
+      '',
+      '# Instructions',
+      '',
+      'Verify each layer in order (ticket → brief → spec → tasks).',
+      'For EACH requirement/deliverable: grep or read the actual code to find evidence.',
+      'Mark DELIVERED only with a code citation (file:line or diff excerpt).',
+      'Mark INCOMPLETE if any P0 requirement lacks code evidence.',
+    ].join('\n');
+
     return {
       type: 'check_instruction',
       action: 'execute',
@@ -43,7 +70,7 @@ module.exports = function registerPhase1(register) {
           {
             agentType: 'work-workflow:completion-checker',
             description: 'Verify requirements',
-            prompt: `Verify requirements for ${state.ticketId}. Write report to ${reportFolder}/completion.check.md. Changes hash: ${changesHash}`,
+            prompt: completionPrompt,
           },
         ],
         note: 'Launch ALL agents in parallel using multiple Task() calls in one message. Wait for all to complete.',

--- a/workflows/check2/lib/steps/phase1-agents.js
+++ b/workflows/check2/lib/steps/phase1-agents.js
@@ -2,7 +2,8 @@
  * Step: 5_phase1_agents — Launch code-checker and completion-checker in parallel.
  * Tests are already handled by 4_run_tests (deterministic script).
  *
- * Returns a parallel_tasks instruction on first call.
+ * Uses the same delegates pattern as implement step for clarity.
+ * Returns a parallel instruction with exact prompts per agent.
  * On subsequent calls, checks if reports exist and auto-advances.
  */
 
@@ -19,8 +20,21 @@ module.exports = function registerPhase1(register) {
     // Already dispatched — check if reports exist
     if (state.dispatched === '5_phase1_agents') {
       const hasCodeReview = fs.existsSync(path.join(reportFolder, 'code-review.check.md'));
-      const hasCompletion = fs.existsSync(path.join(reportFolder, 'completion.check.md'));
+      const completionPath = path.join(reportFolder, 'completion.check.md');
+      const hasCompletion = fs.existsSync(completionPath);
       if (hasCodeReview && hasCompletion) {
+        // Mark tasks as verified [v] if completion-checker says COMPLETE
+        try {
+          const completionReport = fs.readFileSync(completionPath, 'utf8');
+          if (/Status:\s*COMPLETE\b/i.test(completionReport)) {
+            const { markVerified } = require(
+              path.join(__dirname, '..', '..', '..', 'work2', 'lib', 'mark-task-progress')
+            );
+            markVerified(ctx.tasksDir);
+          }
+        } catch {
+          /* fail-open */
+        }
         return null; // all reports present → auto-advance
       }
     }
@@ -38,43 +52,64 @@ module.exports = function registerPhase1(register) {
       completionContext = '(Could not load planning artifacts — verify against PR diff only)';
     }
 
-    const completionPrompt = [
-      `Verify ALL requirements for ${state.ticketId} against the actual code.`,
-      `Write report to ${reportFolder}/completion.check.md. Changes hash: ${changesHash}`,
-      '',
-      '# Verification Context (pre-loaded from planning artifacts)',
-      '',
-      completionContext,
-      '',
-      '# Instructions',
-      '',
-      'Verify each layer in order (ticket → brief → spec → tasks).',
-      'For EACH requirement/deliverable: grep or read the actual code to find evidence.',
-      'Mark DELIVERED only with a code citation (file:line or diff excerpt).',
-      'Mark INCOMPLETE if any P0 requirement lacks code evidence.',
-    ].join('\n');
+    const codeReviewReport = path.join(reportFolder, 'code-review.check.md');
+    const completionReport = path.join(reportFolder, 'completion.check.md');
+
+    const delegates = [
+      {
+        type: 'task',
+        agentType: 'work-workflow:code-checker',
+        description: `Code review — ${state.ticketId}`,
+        prompt: [
+          `## Code Review for ${state.ticketId}`,
+          '',
+          `Review ALL code changes and write your report to: ${codeReviewReport}`,
+          `Changes hash: ${changesHash}`,
+          '',
+          '### What to check',
+          '- Bugs, logic errors, security vulnerabilities',
+          '- Code quality, naming, patterns adherence',
+          '- Missing error handling at system boundaries',
+          '',
+          '### Rules',
+          '- Do NOT run tests (already handled by deterministic script)',
+          '- Do NOT modify any code — only review and report',
+        ].join('\n'),
+        note: 'Pass the prompt directly to the agent.',
+      },
+      {
+        type: 'task',
+        agentType: 'work-workflow:completion-checker',
+        description: `Verify requirements — ${state.ticketId}`,
+        prompt: [
+          `## Verify ALL requirements for ${state.ticketId}`,
+          '',
+          `Write report to: ${completionReport}`,
+          `Changes hash: ${changesHash}`,
+          '',
+          '# Verification Context (pre-loaded from planning artifacts)',
+          '',
+          completionContext,
+          '',
+          '# Instructions',
+          '',
+          'Verify each layer in order (ticket → brief → spec → tasks).',
+          'For EACH requirement/deliverable: grep or read the actual code to find evidence.',
+          'Mark DELIVERED only with a code citation (file:line or diff excerpt).',
+          'Mark INCOMPLETE if any P0 requirement lacks code evidence.',
+        ].join('\n'),
+        note: 'Pass the prompt directly to the agent.',
+      },
+    ];
 
     return {
       type: 'check_instruction',
       action: 'execute',
       state: { ticket: state.ticketId, currentStep: '5_phase1_agents', progress: '5/9' },
       continue: true,
-      delegate: {
-        type: 'parallel_tasks',
-        agents: [
-          {
-            agentType: 'work-workflow:code-checker',
-            description: 'Code review',
-            prompt: `Review code changes for ${state.ticketId}. Write report to ${reportFolder}/code-review.check.md. Changes hash: ${changesHash}`,
-          },
-          {
-            agentType: 'work-workflow:completion-checker',
-            description: 'Verify requirements',
-            prompt: completionPrompt,
-          },
-        ],
-        note: 'Launch ALL agents in parallel using multiple Task() calls in one message. Wait for all to complete.',
-      },
+      parallel: true,
+      delegates,
+      note: `Launch EXACTLY these ${delegates.length} agents IN PARALLEL (single message, ${delegates.length} Task tool calls). Do NOT add any other agents — tests are handled by a deterministic script.`,
     };
   });
 };

--- a/workflows/check2/lib/steps/quality-recheck.js
+++ b/workflows/check2/lib/steps/quality-recheck.js
@@ -1,14 +1,17 @@
 /**
- * Step: 6_quality_recheck — Re-run quality checks if code was modified during consensus.
+ * Step: 7_quality_recheck — Re-run quality checks if code was modified during consensus.
+ * Deterministic — runs inline via runQualityGate (same as 4_run_tests).
  * Skips if no files were modified.
  */
 
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const { execSync } = require('child_process');
 
 module.exports = function registerQualityRecheck(register) {
-  register('7_quality_recheck', (state) => {
+  register('7_quality_recheck', (state, ctx) => {
     // Check if code was modified during consensus
     let hasModifiedFiles = false;
     try {
@@ -20,22 +23,50 @@ module.exports = function registerQualityRecheck(register) {
 
     if (!hasModifiedFiles) return null; // no changes → skip
 
-    if (state.dispatched === '7_quality_recheck') return null; // already ran → advance
+    // Run quality gate inline (deterministic — no agent needed)
+    const { runQualityGate } = require('./run-tests');
+    const reportFolder = state.setupResult?.reportFolder || ctx.tasksDir;
+    const changesHash = state.changesHash || 'unknown';
 
-    state.dispatched = '7_quality_recheck';
+    const result = runQualityGate(ctx.checkHooksDir);
 
-    return {
-      type: 'check_instruction',
-      action: 'execute',
-      state: { ticket: state.ticketId, currentStep: '7_quality_recheck', progress: '6/9' },
-      continue: true,
-      delegate: {
-        type: 'task',
-        agentType: 'work-workflow:quality-checker',
-        description: 'Re-check after code review fixes',
-        prompt: `Re-run tests for ${state.ticketId} after code review fixes. Verify all tests still pass.`,
-        note: 'Pass the prompt directly to the agent.',
-      },
-    };
+    // Write recheck report
+    const passMatch = result.output.match(/pass\s+(\d+)/i);
+    const failMatch = result.output.match(/fail\s+(\d+)/i);
+    const passCount = passMatch ? passMatch[1] : '?';
+    const failCount = failMatch ? failMatch[1] : '?';
+    const status2 = result.exitCode === 0 ? 'APPROVED' : 'NEEDS_WORK';
+
+    const report = [
+      `**Changes Hash:** ${changesHash}`,
+      '',
+      `Status: ${status2}`,
+      '',
+      '# Quality Re-check Report (post-consensus)',
+      '',
+      `**Runner:** ${result.tier}`,
+      `**Exit code:** ${result.exitCode}`,
+      `**Pass:** ${passCount} | **Fail:** ${failCount}`,
+      '',
+      '## Output',
+      '```',
+      result.output.substring(0, 5000),
+      '```',
+    ].join('\n');
+
+    const reportPath = path.join(reportFolder, 'recheck.check.md');
+    fs.writeFileSync(reportPath, report);
+
+    if (result.exitCode !== 0) {
+      return {
+        type: 'check_instruction',
+        action: 'failed',
+        state: { ticket: state.ticketId, currentStep: '7_quality_recheck', progress: '7/9' },
+        reason: `Quality re-check failed (${failCount} failing). Code review fixes broke tests.`,
+        report: reportPath,
+      };
+    }
+
+    return null; // auto-advance
   });
 };

--- a/workflows/check2/lib/steps/run-tests.js
+++ b/workflows/check2/lib/steps/run-tests.js
@@ -50,7 +50,14 @@ function runQualityGate(checkHooksDir) {
   }
 
   // Tier 2: bundled dev-check script
-  const devCheckScript = path.join(checkHooksDir, '..', '..', 'scripts', 'dev-check', 'dev-check.sh');
+  const devCheckScript = path.join(
+    checkHooksDir,
+    '..',
+    '..',
+    'scripts',
+    'dev-check',
+    'dev-check.sh'
+  );
   if (fs.existsSync(devCheckScript)) {
     const result = runCommand(`bash "${devCheckScript}"`, 120000);
     return { ...result, tier: 'dev-check.sh' };
@@ -61,7 +68,7 @@ function runQualityGate(checkHooksDir) {
   return { ...result, tier: 'pnpm test' };
 }
 
-module.exports = function registerRunTests(register) {
+function registerRunTests(register) {
   register('4_run_tests', (state, ctx) => {
     const reportFolder = state.setupResult?.reportFolder || ctx.tasksDir;
     const changesHash = state.changesHash || 'unknown';
@@ -112,4 +119,7 @@ module.exports = function registerRunTests(register) {
 
     return null; // auto-advance
   });
-};
+}
+
+module.exports = registerRunTests;
+module.exports.runQualityGate = runQualityGate;

--- a/workflows/follow-up2/lib/steps/fix-reviews.js
+++ b/workflows/follow-up2/lib/steps/fix-reviews.js
@@ -102,7 +102,8 @@ module.exports = function registerFixReviews(register) {
         /* ignore */
       }
 
-      if (statusResult && statusResult.skipped > 0) {
+      if (statusResult && statusResult.skipped > 0 && !state._skippedReviewWarningShown) {
+        state._skippedReviewWarningShown = true;
         const reviewFile = path.join(ctx.tasksDir, 'follow-up-comments.json');
         return {
           type: 'follow_up_instruction',

--- a/workflows/lib/hooks/session-guard.js
+++ b/workflows/lib/hooks/session-guard.js
@@ -471,12 +471,31 @@ function isCheckWorkflowActive(ticketId) {
     try {
       safeId = require(path.join(__dirname, '..', 'config')).safeTicketId(ticketId);
     } catch {}
-    const resolved = path.resolve(tasksBase, safeId, '.check.workflow-state.json');
+    const resolvedBase = path.resolve(tasksBase, safeId);
     // Guard against path traversal — resolved path must stay under tasksBase
-    if (!resolved.startsWith(path.resolve(tasksBase) + path.sep)) return false;
+    if (!resolvedBase.startsWith(path.resolve(tasksBase) + path.sep)) return false;
 
-    const state = JSON.parse(fs.readFileSync(resolved, 'utf-8'));
-    return state?.workflow === 'check' && state?.status === 'in_progress';
+    // Check /check (old) state file
+    try {
+      const state = JSON.parse(
+        fs.readFileSync(path.join(resolvedBase, '.check.workflow-state.json'), 'utf-8')
+      );
+      if (state?.workflow === 'check' && state?.status === 'in_progress') return true;
+    } catch {
+      /* not found or corrupt */
+    }
+
+    // Check /check2 (new) state file
+    try {
+      const state2 = JSON.parse(
+        fs.readFileSync(path.join(resolvedBase, '.check2-state.json'), 'utf-8')
+      );
+      if (state2?.status === 'in_progress' || state2?.currentStep) return true;
+    } catch {
+      /* not found or corrupt */
+    }
+
+    return false;
   } catch {
     return false;
   }
@@ -557,12 +576,17 @@ function handleStop(hookData) {
         const wsPath = path.join(tasksBase, safeId, '.work-state.json');
         const ws = JSON.parse(fs.readFileSync(wsPath, 'utf8'));
         if (ws && ws._work2Dispatched) {
-          process.stderr.write(
-            `ACTIVE WORKFLOW SESSION — step "${ws._work2Dispatched}" dispatched, waiting for agent.\n` +
-              `When ready, continue: node "\${CLAUDE_PLUGIN_ROOT}/workflows/work2/work-next.js" ${ticketId}\n`
-          );
-          process.exit(0); // allow stop — agent is waiting, not abandoning
-          return;
+          // Steps that require agent to actively invoke a skill (not background sub-agents)
+          // should NOT be bypassed — the agent must stay and run the skill.
+          const activeSkillSteps = new Set(['check']);
+          if (!activeSkillSteps.has(ws._work2Dispatched)) {
+            process.stderr.write(
+              `ACTIVE WORKFLOW SESSION — step "${ws._work2Dispatched}" dispatched, waiting for agent.\n` +
+                `When ready, continue: node "\${CLAUDE_PLUGIN_ROOT}/workflows/work2/work-next.js" ${ticketId}\n`
+            );
+            process.exit(0); // allow stop — agent is waiting, not abandoning
+            return;
+          }
         }
       }
     } catch {

--- a/workflows/lib/hooks/session-guard.js
+++ b/workflows/lib/hooks/session-guard.js
@@ -542,6 +542,33 @@ function handleStop(hookData) {
   const ticketId = session.ticketId || '';
 
   if (workflow === '/work2') {
+    // Check if the workflow step is dispatched (agent is waiting for sub-agent results)
+    // In this case, warn but allow stop — the agent isn't abandoning, it's waiting.
+    try {
+      const getConfig = require(path.join(__dirname, '..', 'get-config'));
+      const tasksBase = getConfig('TASKS_BASE');
+      if (tasksBase && ticketId) {
+        let safeId = ticketId;
+        try {
+          safeId = require(path.join(__dirname, '..', 'config')).safeTicketId(ticketId);
+        } catch {
+          /* use raw */
+        }
+        const wsPath = path.join(tasksBase, safeId, '.work-state.json');
+        const ws = JSON.parse(fs.readFileSync(wsPath, 'utf8'));
+        if (ws && ws._work2Dispatched) {
+          process.stderr.write(
+            `ACTIVE WORKFLOW SESSION — step "${ws._work2Dispatched}" dispatched, waiting for agent.\n` +
+              `When ready, continue: node "\${CLAUDE_PLUGIN_ROOT}/workflows/work2/work-next.js" ${ticketId}\n`
+          );
+          process.exit(0); // allow stop — agent is waiting, not abandoning
+          return;
+        }
+      }
+    } catch {
+      // Can't read state — fall through to block
+    }
+
     process.stderr.write(
       `ACTIVE WORKFLOW SESSION — DO NOT ABANDON\n` +
         `Workflow: ${workflow} | Ticket: ${ticketId}\n` +

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -27,7 +27,29 @@ const path = require('path');
 // ─── Early exit: not in implement step ───────────────────────────────────────
 
 const ticketId = process.env.WORK_TICKET_ID;
+
+// ─── Debug logger ────────────────────────────────────────────────────────────
+function debugLog(message) {
+  try {
+    const _getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
+    const _tasksBase = _getConfig('TASKS_BASE');
+    if (!_tasksBase || !ticketId) return;
+    let _safeId = ticketId;
+    try {
+      _safeId = require(path.join(__dirname, '..', '..', 'lib', 'config')).safeTicketId(ticketId);
+    } catch {
+      _safeId = ticketId.replace(/[/\\:\0]/g, '_');
+    }
+    const debugPath = path.join(_tasksBase, _safeId, 'debug-tdd-hook.md');
+    const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
+    fs.appendFileSync(debugPath, `${timestamp} | ${message}\n`);
+  } catch {
+    /* best-effort */
+  }
+}
+
 if (!ticketId) {
+  debugLog('SKIP: no WORK_TICKET_ID');
   process.exit(0);
 }
 
@@ -38,10 +60,12 @@ try {
   const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
   TASKS_BASE = getConfig('TASKS_BASE');
 } catch {
+  debugLog('SKIP: no TASKS_BASE (config error)');
   process.exit(0); // can't resolve config — fail-open
 }
 
 if (!TASKS_BASE) {
+  debugLog('SKIP: no TASKS_BASE');
   process.exit(0);
 }
 
@@ -66,20 +90,24 @@ try {
     ? Object.entries(ws.stepStatus).find(([, v]) => v === 'in_progress')?.[0]
     : null;
   if (currentStep !== 'implement') {
+    debugLog('SKIP: step is not implement (step=' + currentStep + ')');
     process.exit(0);
   }
 
   if (!ws.tasksMeta || !Array.isArray(ws.tasksMeta.tasks)) {
+    debugLog('SKIP: no tasksMeta');
     process.exit(0);
   }
 
   const idx = ws.tasksMeta.currentTaskIndex ?? 0;
   taskNum = Math.min(idx + 1, ws.tasksMeta.tasks.length) || undefined;
 } catch {
+  debugLog('SKIP: cannot read work state');
   process.exit(0); // can't read state — fail-open
 }
 
 if (!taskNum) {
+  debugLog('SKIP: no taskNum');
   process.exit(0);
 }
 
@@ -92,6 +120,7 @@ try {
   const tasksDir = path.join(TASKS_BASE, safeTicket);
   const taskType = resolveTaskType(tasksDir, taskNum);
   if (taskType === 'checkpoint') {
+    debugLog('SKIP: checkpoint task');
     process.exit(0);
   }
 } catch {
@@ -112,10 +141,12 @@ try {
     valid = validateTddEvidence(result.evidence).valid;
   }
 } catch {
+  debugLog('SKIP: evidence check failed');
   process.exit(0); // can't check evidence — fail-open
 }
 
 if (exists && valid) {
+  debugLog('PASS: evidence valid, allow stop');
   process.exit(0); // evidence valid — allow stop
 }
 
@@ -135,6 +166,7 @@ try {
 }
 
 if (testCommand) {
+  debugLog('AUTO-RUN: test command found: ' + testCommand);
   const tddStatePath = path.join(__dirname, '..', 'tdd-phase-state.js');
   const tddEnv = { ...process.env, WORK_TDD_TOKEN_SKIP: '1' };
   const execOpts = { encoding: 'utf-8', timeout: 300000, stdio: 'pipe', env: tddEnv };
@@ -249,10 +281,12 @@ if (testCommand) {
 
     // If we recorded GREEN or REFACTOR, allow stop
     if (currentPhase === 'green' || currentPhase === 'refactor') {
+      debugLog('PASS: ' + effectivePhase + ' recorded, allow stop');
       process.exit(0);
     }
 
     // RED recorded — tests fail, block agent to fix them
+    debugLog('BLOCK: RED recorded, tests failing');
     process.stderr.write(`TDD: RED phase recorded for task ${taskNum} — tests are failing.\n`);
     process.stderr.write(`Fix the failing tests, then try to stop again.\n`);
     process.exit(2);
@@ -271,6 +305,7 @@ if (testCommand) {
     }
 
     // Test command exists but recording failed — block the agent
+    debugLog('BLOCK: recording failed');
     process.stderr.write(`BLOCKED: TDD evidence recording failed for task ${taskNum}.\n`);
     process.stderr.write(`Test command: ${testCommand}\n`);
     process.stderr.write(`Fix the issue and try stopping again.\n`);
@@ -295,4 +330,5 @@ try {
   // fail-open
 }
 
+debugLog('BYPASS: no test command in tasks.md');
 process.exit(0);

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -24,9 +24,19 @@
 const fs = require('fs');
 const path = require('path');
 
-// ─── Early exit: not in implement step ───────────────────────────────────────
-
-const ticketId = process.env.WORK_TICKET_ID;
+// ─── Detect ticket ID ────────────────────────────────────────────────────────
+// Don't rely solely on WORK_TICKET_ID env var — detect from cwd/branch as fallback
+let ticketId = process.env.WORK_TICKET_ID;
+if (!ticketId) {
+  try {
+    const { getCurrentTaskId } = require(
+      path.join(__dirname, '..', '..', 'lib', 'scripts', 'get-ticket-id')
+    );
+    ticketId = getCurrentTaskId();
+  } catch {
+    // Can't detect ticket — will exit below
+  }
+}
 
 // ─── Debug logger ────────────────────────────────────────────────────────────
 function debugLog(message) {

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -198,7 +198,7 @@ if (testCommand) {
   //   RED:   run ALL tests (need full failure picture)
   //   GREEN/REFACTOR: fail-fast on first failure (no point running rest)
   let phaseTestCommand = testCommand;
-  if (currentPhase === 'green' || currentPhase === 'refactor') {
+  if (effectivePhase === 'green' || effectivePhase === 'refactor') {
     // Append fail-fast flags for common test runners
     // vitest/jest: --bail    playwright: already fails fast by default
     // Only append if not already present
@@ -280,7 +280,7 @@ if (testCommand) {
     }
 
     // If we recorded GREEN or REFACTOR, allow stop
-    if (currentPhase === 'green' || currentPhase === 'refactor') {
+    if (effectivePhase === 'green' || effectivePhase === 'refactor') {
       debugLog('PASS: ' + effectivePhase + ' recorded, allow stop');
       process.exit(0);
     }

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -243,7 +243,11 @@ if (testCommand) {
       /* best-effort */
     }
 
-    // Fall through to manual block below
+    // Test command exists but recording failed — block the agent
+    process.stderr.write(`BLOCKED: TDD evidence recording failed for task ${taskNum}.\n`);
+    process.stderr.write(`Test command: ${testCommand}\n`);
+    process.stderr.write(`Fix the issue and try stopping again.\n`);
+    process.exit(2);
   }
 }
 

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -3,7 +3,7 @@
 /**
  * SubagentStop hook: Block developer agents from stopping without TDD evidence.
  *
- * Wired into developer agent definitions (NOT hooks.json).
+ * Wired as SubagentStop in hooks.json (targets developer-* agents only).
  * When a developer agent tries to stop during the implement step,
  * this hook checks if TDD evidence exists for the current task.
  * If not, it blocks the stop and tells the agent the ONE next command to run.
@@ -23,6 +23,20 @@
 
 const fs = require('fs');
 const path = require('path');
+
+// ─── Read stdin (SubagentStop hook data) ────────────────────────────────────
+// Prevent infinite loops: if stop_hook_active is set, another stop hook
+// is already running — exit immediately to avoid re-entrance.
+let _hookData = {};
+try {
+  const input = fs.readFileSync(0, 'utf-8');
+  _hookData = JSON.parse(input);
+} catch {
+  /* empty/invalid — use default */
+}
+if (_hookData.stop_hook_active) {
+  process.exit(0);
+}
 
 // ─── Detect ticket ID ────────────────────────────────────────────────────────
 // Don't rely solely on WORK_TICKET_ID env var — detect from cwd/branch as fallback

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -179,12 +179,39 @@ if (testCommand) {
   }
 
   // Run test command and record evidence
+  // Special case: if tests PASS during RED phase, the agent already implemented
+  // everything. Skip RED and record GREEN directly to avoid deadlock.
+  let effectivePhase = currentPhase;
+  if (currentPhase === 'red') {
+    try {
+      const testResult = require('child_process').execSync(phaseTestCommand, {
+        encoding: 'utf-8',
+        timeout: 300000,
+        stdio: 'pipe',
+        cwd: process.cwd(),
+      });
+      // Tests passed in RED phase — skip to GREEN
+      effectivePhase = 'green';
+      try {
+        execFileSync(
+          process.execPath,
+          [tddStatePath, 'transition', safeTicket, 'green', '--task', String(taskNum)],
+          execOpts
+        );
+      } catch {
+        /* may already be in green */
+      }
+    } catch {
+      // Tests failed — good, RED phase is correct
+    }
+  }
+
   try {
     execFileSync(
       process.execPath,
       [
         tddStatePath,
-        `record-${currentPhase}`,
+        `record-${effectivePhase}`,
         safeTicket,
         '--task',
         String(taskNum),

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -212,29 +212,48 @@ if (testCommand) {
 
   // Run test command and record evidence
   // Special case: if tests PASS during RED phase, the agent already implemented
-  // everything. Skip RED and record GREEN directly to avoid deadlock.
+  // everything. Write GREEN evidence directly (bypassing tdd-phase-state.js CLI
+  // which requires RED evidence before allowing green transition).
   let effectivePhase = currentPhase;
   if (currentPhase === 'red') {
     try {
-      const testResult = require('child_process').execSync(phaseTestCommand, {
+      require('child_process').execSync(phaseTestCommand, {
         encoding: 'utf-8',
         timeout: 300000,
         stdio: 'pipe',
         cwd: process.cwd(),
       });
-      // Tests passed in RED phase — skip to GREEN
+      // Tests passed in RED phase — write GREEN evidence directly
       effectivePhase = 'green';
-      try {
-        execFileSync(
-          process.execPath,
-          [tddStatePath, 'transition', safeTicket, 'green', '--task', String(taskNum)],
-          execOpts
-        );
-      } catch {
-        /* may already be in green */
-      }
+      const taskDir = path.join(TASKS_BASE, safeTicket, `task${taskNum}`);
+      fs.mkdirSync(taskDir, { recursive: true });
+      const evidence = {
+        currentPhase: 'green',
+        currentCycle: 1,
+        cycles: [
+          {
+            cycle: 1,
+            red: {
+              testFiles: [],
+              testCommand: phaseTestCommand,
+              testExitCode: 0,
+              timestamp: new Date().toISOString(),
+              note: 'Tests passed in RED — agent implemented before stopping',
+            },
+            green: {
+              testCommand: phaseTestCommand,
+              testExitCode: 0,
+              timestamp: new Date().toISOString(),
+            },
+          },
+        ],
+      };
+      fs.writeFileSync(path.join(taskDir, 'tdd-phase.json'), JSON.stringify(evidence, null, 2));
+      debugLog('AUTO-WRITE: tests passed in RED, wrote GREEN evidence directly');
+      process.exit(0); // allow stop — evidence written
     } catch {
       // Tests failed — good, RED phase is correct
+      debugLog('AUTO-RUN: tests failed in RED phase (expected)');
     }
   }
 

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -198,7 +198,7 @@ if (testCommand) {
   //   RED:   run ALL tests (need full failure picture)
   //   GREEN/REFACTOR: fail-fast on first failure (no point running rest)
   let phaseTestCommand = testCommand;
-  if (effectivePhase === 'green' || effectivePhase === 'refactor') {
+  if (currentPhase === 'green' || currentPhase === 'refactor') {
     // Append fail-fast flags for common test runners
     // vitest/jest: --bail    playwright: already fails fast by default
     // Only append if not already present

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -119,7 +119,119 @@ if (exists && valid) {
   process.exit(0); // evidence valid — allow stop
 }
 
-// ─── Block: get next command from tdd-next.js ────────────────────────────────
+// ─── Auto-run test command from tasks.md ─────────────────────────────────────
+
+const { execFileSync, execSync } = require('child_process');
+const tasksDir = path.join(TASKS_BASE, safeTicket);
+
+let testCommand = null;
+try {
+  const { parseTasks } = require(path.join(__dirname, '..', '..', 'work', 'task-parser'));
+  const tasks = parseTasks(tasksDir);
+  const currentTask = tasks?.find((t) => t.num === taskNum);
+  testCommand = currentTask?.testCommand || null;
+} catch {
+  // Can't parse tasks — fall through to manual block
+}
+
+if (testCommand) {
+  const tddStatePath = path.join(__dirname, '..', 'tdd-phase-state.js');
+  const tddEnv = { ...process.env, WORK_TDD_TOKEN_SKIP: '1' };
+  const execOpts = { encoding: 'utf-8', timeout: 300000, stdio: 'pipe', env: tddEnv };
+
+  // Read current phase
+  let currentPhase = 'red';
+  try {
+    const { readPhase } = require(path.join(__dirname, '..', '..', 'work2', 'tdd-next'));
+    const phase = readPhase(safeTicket, taskNum);
+    currentPhase = phase?.currentPhase || 'red';
+  } catch {
+    // Default to red
+  }
+
+  // Init if no state exists
+  if (currentPhase === 'red' && !exists) {
+    try {
+      execFileSync(
+        process.execPath,
+        [tddStatePath, 'init', safeTicket, '--task', String(taskNum)],
+        execOpts
+      );
+    } catch {
+      // Init may already exist — continue
+    }
+  }
+
+  // Run test command and record evidence
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        tddStatePath,
+        `record-${currentPhase}`,
+        safeTicket,
+        '--task',
+        String(taskNum),
+        '--cmd',
+        testCommand,
+      ],
+      execOpts
+    );
+
+    // Transition to next phase
+    const nextPhase = { red: 'green', green: 'refactor', refactor: 'red' }[currentPhase];
+    if (nextPhase && nextPhase !== 'red') {
+      try {
+        execFileSync(
+          process.execPath,
+          [tddStatePath, 'transition', safeTicket, nextPhase, '--task', String(taskNum)],
+          execOpts
+        );
+      } catch {
+        // Transition may fail if already at target phase
+      }
+    }
+
+    // Log success
+    try {
+      const debugPath = path.join(TASKS_BASE, safeTicket, 'debug.md');
+      const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
+      fs.appendFileSync(
+        debugPath,
+        `\n## ${timestamp} — enforce-tdd-on-stop\n\n- **[AUTO-RECORDED]** task ${taskNum}: ${currentPhase} phase recorded via test command\n`
+      );
+    } catch {
+      /* best-effort */
+    }
+
+    // If we recorded GREEN or REFACTOR, allow stop
+    if (currentPhase === 'green' || currentPhase === 'refactor') {
+      process.exit(0);
+    }
+
+    // RED recorded — tests fail, block agent to fix them
+    process.stderr.write(`TDD: RED phase recorded for task ${taskNum} — tests are failing.\n`);
+    process.stderr.write(`Fix the failing tests, then try to stop again.\n`);
+    process.exit(2);
+  } catch (err) {
+    // record-* failed — likely test command error or phase mismatch
+    const msg = err.stderr || err.stdout || err.message || 'unknown';
+    try {
+      const debugPath = path.join(TASKS_BASE, safeTicket, 'debug.md');
+      const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
+      fs.appendFileSync(
+        debugPath,
+        `\n## ${timestamp} — enforce-tdd-on-stop\n\n- **[AUTO-RUN FAILED]** task ${taskNum}: ${currentPhase} phase — ${String(msg).substring(0, 200)}\n`
+      );
+    } catch {
+      /* best-effort */
+    }
+
+    // Fall through to manual block below
+  }
+}
+
+// ─── Manual block: no test command or auto-run failed ────────────────────────
 
 let nextCmd;
 try {
@@ -133,18 +245,17 @@ try {
   nextCmd = `node "${tddNextPath}" ${safeTicket} --task ${taskNum}`;
 }
 
-// ─── Log to debug.md ─────────────────────────────────────────────────────────
-
+// Log to debug.md
 try {
   const debugPath = path.join(TASKS_BASE, safeTicket, 'debug.md');
   const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
-  const line = `\n## ${timestamp} — enforce-tdd-on-stop\n\n- **[STOP BLOCKED]** task ${taskNum}: TDD evidence ${!exists ? 'missing' : 'invalid'}\n- **Next:** \`${nextCmd}\`\n`;
-  fs.appendFileSync(debugPath, line);
+  fs.appendFileSync(
+    debugPath,
+    `\n## ${timestamp} — enforce-tdd-on-stop\n\n- **[STOP BLOCKED]** task ${taskNum}: TDD evidence ${!exists ? 'missing' : 'invalid'}${testCommand ? ' (auto-run failed)' : ' (no ### Test Command in tasks.md)'}\n- **Next:** \`${nextCmd}\`\n`
+  );
 } catch {
-  // fail-open — debug logging is best-effort
+  // fail-open
 }
-
-// ─── Block the stop ──────────────────────────────────────────────────────────
 
 process.stderr.write(`BLOCKED: TDD evidence incomplete for task ${taskNum}.\n`);
 process.stderr.write(`Run this command: ${nextCmd}\n`);

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -162,6 +162,22 @@ if (testCommand) {
     }
   }
 
+  // Apply phase-aware test flags:
+  //   RED:   run ALL tests (need full failure picture)
+  //   GREEN/REFACTOR: fail-fast on first failure (no point running rest)
+  let phaseTestCommand = testCommand;
+  if (currentPhase === 'green' || currentPhase === 'refactor') {
+    // Append fail-fast flags for common test runners
+    // vitest/jest: --bail    playwright: already fails fast by default
+    // Only append if not already present
+    if (!/--bail\b/.test(phaseTestCommand)) {
+      phaseTestCommand = phaseTestCommand.replace(
+        /(pnpm\s+test(?::unit|:integration)?)/g,
+        '$1 --bail'
+      );
+    }
+  }
+
   // Run test command and record evidence
   try {
     execFileSync(
@@ -173,7 +189,7 @@ if (testCommand) {
         '--task',
         String(taskNum),
         '--cmd',
-        testCommand,
+        phaseTestCommand,
       ],
       execOpts
     );

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+/**
+ * SubagentStop hook: Block developer agents from stopping without TDD evidence.
+ *
+ * Wired into developer agent definitions (NOT hooks.json).
+ * When a developer agent tries to stop during the implement step,
+ * this hook checks if TDD evidence exists for the current task.
+ * If not, it blocks the stop and tells the agent the ONE next command to run.
+ *
+ * Skip conditions (exit 0):
+ *   - WORK_TICKET_ID not set (not in implement step)
+ *   - Task is a checkpoint type (exempt from TDD)
+ *   - TDD evidence is valid (RED+GREEN cycle complete)
+ *
+ * Block conditions (exit 2):
+ *   - TDD evidence missing or invalid
+ *   - Outputs the single next command via tdd-next.js buildInstruction()
+ *   - Logs the block to debug.md
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ─── Early exit: not in implement step ───────────────────────────────────────
+
+const ticketId = process.env.WORK_TICKET_ID;
+if (!ticketId) {
+  process.exit(0);
+}
+
+// ─── Resolve paths ───────────────────────────────────────────────────────────
+
+let TASKS_BASE;
+try {
+  const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
+  TASKS_BASE = getConfig('TASKS_BASE');
+} catch {
+  process.exit(0); // can't resolve config — fail-open
+}
+
+if (!TASKS_BASE) {
+  process.exit(0);
+}
+
+// Sanitize ticket ID for filesystem path
+let safeTicket = ticketId;
+try {
+  const config = require(path.join(__dirname, '..', '..', 'lib', 'config'));
+  safeTicket = config.safeTicketId(ticketId);
+} catch {
+  safeTicket = ticketId.replace(/[/\\:\0]/g, '_');
+}
+
+// ─── Get current task number from work state ─────────────────────────────────
+
+let taskNum;
+try {
+  const wsPath = path.join(TASKS_BASE, safeTicket, '.work-state.json');
+  const ws = JSON.parse(fs.readFileSync(wsPath, 'utf8'));
+
+  // Only enforce during implement step
+  const currentStep = ws.stepStatus
+    ? Object.entries(ws.stepStatus).find(([, v]) => v === 'in_progress')?.[0]
+    : null;
+  if (currentStep !== 'implement') {
+    process.exit(0);
+  }
+
+  if (!ws.tasksMeta || !Array.isArray(ws.tasksMeta.tasks)) {
+    process.exit(0);
+  }
+
+  const idx = ws.tasksMeta.currentTaskIndex ?? 0;
+  taskNum = Math.min(idx + 1, ws.tasksMeta.tasks.length) || undefined;
+} catch {
+  process.exit(0); // can't read state — fail-open
+}
+
+if (!taskNum) {
+  process.exit(0);
+}
+
+// ─── Skip checkpoint tasks ──────────────────────────────────────────────────
+
+try {
+  const { resolveTaskType } = require(
+    path.join(__dirname, '..', '..', 'work2', 'lib', 'resolve-task-type')
+  );
+  const tasksDir = path.join(TASKS_BASE, safeTicket);
+  const taskType = resolveTaskType(tasksDir, taskNum);
+  if (taskType === 'checkpoint') {
+    process.exit(0);
+  }
+} catch {
+  // Can't resolve task type — continue with TDD check
+}
+
+// ─── Check TDD evidence ─────────────────────────────────────────────────────
+
+let exists = false;
+let valid = false;
+try {
+  const { readTddEvidence, validateTddEvidence } = require(
+    path.join(__dirname, '..', '..', 'work', 'tdd-enforcement')
+  );
+  const result = readTddEvidence(safeTicket, 'implement', taskNum);
+  exists = result.exists;
+  if (exists) {
+    valid = validateTddEvidence(result.evidence).valid;
+  }
+} catch {
+  process.exit(0); // can't check evidence — fail-open
+}
+
+if (exists && valid) {
+  process.exit(0); // evidence valid — allow stop
+}
+
+// ─── Block: get next command from tdd-next.js ────────────────────────────────
+
+let nextCmd;
+try {
+  const { buildInstruction } = require(path.join(__dirname, '..', '..', 'work2', 'tdd-next'));
+  const instruction = buildInstruction(safeTicket, taskNum);
+  nextCmd =
+    instruction.whenDone ||
+    `node "${path.join(__dirname, '..', '..', 'work2', 'tdd-next.js')}" ${safeTicket} --task ${taskNum}`;
+} catch {
+  const tddNextPath = path.join(__dirname, '..', '..', 'work2', 'tdd-next.js');
+  nextCmd = `node "${tddNextPath}" ${safeTicket} --task ${taskNum}`;
+}
+
+// ─── Log to debug.md ─────────────────────────────────────────────────────────
+
+try {
+  const debugPath = path.join(TASKS_BASE, safeTicket, 'debug.md');
+  const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  const line = `\n## ${timestamp} — enforce-tdd-on-stop\n\n- **[STOP BLOCKED]** task ${taskNum}: TDD evidence ${!exists ? 'missing' : 'invalid'}\n- **Next:** \`${nextCmd}\`\n`;
+  fs.appendFileSync(debugPath, line);
+} catch {
+  // fail-open — debug logging is best-effort
+}
+
+// ─── Block the stop ──────────────────────────────────────────────────────────
+
+process.stderr.write(`BLOCKED: TDD evidence incomplete for task ${taskNum}.\n`);
+process.stderr.write(`Run this command: ${nextCmd}\n`);
+process.exit(2);

--- a/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -231,32 +231,21 @@ if (testCommand) {
   }
 }
 
-// ─── Manual block: no test command or auto-run failed ────────────────────────
+// ─── No test command in tasks.md — allow stop (bypass evidence) ──────────────
+// Gate-driven TDD requires ### Test Command in tasks.md. If missing, the task
+// was created before this feature or the split-in-tasks agent didn't include it.
+// Allow the agent to stop — evidence verification is skipped for tasks without
+// a test command.
 
-let nextCmd;
-try {
-  const { buildInstruction } = require(path.join(__dirname, '..', '..', 'work2', 'tdd-next'));
-  const instruction = buildInstruction(safeTicket, taskNum);
-  nextCmd =
-    instruction.whenDone ||
-    `node "${path.join(__dirname, '..', '..', 'work2', 'tdd-next.js')}" ${safeTicket} --task ${taskNum}`;
-} catch {
-  const tddNextPath = path.join(__dirname, '..', '..', 'work2', 'tdd-next.js');
-  nextCmd = `node "${tddNextPath}" ${safeTicket} --task ${taskNum}`;
-}
-
-// Log to debug.md
 try {
   const debugPath = path.join(TASKS_BASE, safeTicket, 'debug.md');
   const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
   fs.appendFileSync(
     debugPath,
-    `\n## ${timestamp} — enforce-tdd-on-stop\n\n- **[STOP BLOCKED]** task ${taskNum}: TDD evidence ${!exists ? 'missing' : 'invalid'}${testCommand ? ' (auto-run failed)' : ' (no ### Test Command in tasks.md)'}\n- **Next:** \`${nextCmd}\`\n`
+    `\n## ${timestamp} — enforce-tdd-on-stop\n\n- **[BYPASS]** task ${taskNum}: No ### Test Command in tasks.md — evidence check skipped\n`
   );
 } catch {
   // fail-open
 }
 
-process.stderr.write(`BLOCKED: TDD evidence incomplete for task ${taskNum}.\n`);
-process.stderr.write(`Run this command: ${nextCmd}\n`);
-process.exit(2);
+process.exit(0);

--- a/workflows/work-implement/tdd-phase-state.js
+++ b/workflows/work-implement/tdd-phase-state.js
@@ -186,12 +186,33 @@ function successOut(data) {
   process.stdout.write(JSON.stringify(data) + '\n');
 }
 
+// Commands that are NOT real test runners — used to fake TDD evidence
+const FAKE_CMD_PATTERNS = [
+  /^\s*exit\s+\d/i, // exit 1
+  /^\s*echo\b/i, // echo anything
+  /^\s*true\s*$/i, // true
+  /^\s*false\s*$/i, // false
+  /^\s*:\s*$/i, // : (no-op)
+  /^\s*test\s+-[a-z]\s/i, // test -f (file tests, not test runners)
+  /^\s*\/bin\/(true|false)\s*$/i, // /bin/true, /bin/false
+];
+
 function parseCmd(args) {
   const cmdIdx = args.indexOf('--cmd');
   if (cmdIdx === -1 || cmdIdx + 1 >= args.length) {
     return null;
   }
-  return args[cmdIdx + 1];
+  const cmd = args[cmdIdx + 1];
+
+  // Block fake/dummy test commands
+  if (FAKE_CMD_PATTERNS.some((re) => re.test(cmd))) {
+    errorExit(
+      `Fake test command detected: "${cmd}". ` +
+        'The --cmd argument must be a real test runner (e.g., "pnpm test", "npx vitest", "node --test").'
+    );
+  }
+
+  return cmd;
 }
 
 function parseTask(args) {

--- a/workflows/work/hooks/protect-tasks-md.js
+++ b/workflows/work/hooks/protect-tasks-md.js
@@ -8,7 +8,7 @@
  *
  * Refactored to use createArtifactProtector factory (GH-258 code review).
  *
- * Allowed steps: tasks, task_review
+ * Allowed steps: tasks, task_review, complete
  * All other steps: blocked (exit 2)
  * No workflow active: allowed (exit 0, fail-open)
  */
@@ -18,7 +18,7 @@ const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
 const { createArtifactProtector } = require('../../lib/protect-artifact-files');
 
-const ALLOWED_STEPS = new Set(['tasks', 'task_review']);
+const ALLOWED_STEPS = new Set(['tasks', 'task_review', 'complete']);
 
 /**
  * Check whether a file named tasks.md is the root-level workflow artifact

--- a/workflows/work/task-parser.js
+++ b/workflows/work/task-parser.js
@@ -129,6 +129,10 @@ function parseTasks(tasksDir) {
     const scopeMatch = body.match(/### Suggested Scope[^\n]*\n([\s\S]*?)(?=\n###|\n## |$)/);
     const suggestedScope = scopeMatch ? scopeMatch[1].trim() : '';
 
+    // Extract ### Test Command (machine-parseable command for gate-driven TDD)
+    const testCmdMatch = body.match(/### Test Command[^\n]*\n([^\n]+)/);
+    const testCommand = testCmdMatch ? testCmdMatch[1].trim() : null;
+
     const isCheckpoint = type === 'checkpoint' || /checkpoint/i.test(title);
 
     tasks.push({
@@ -141,6 +145,7 @@ function parseTasks(tasksDir) {
       requirementsCovered,
       acceptanceCriteria,
       suggestedScope,
+      testCommand,
       rawContent: `## Task ${num} ${body}`,
     });
   }

--- a/workflows/work2/lib/mark-task-progress.js
+++ b/workflows/work2/lib/mark-task-progress.js
@@ -7,6 +7,7 @@
  *   [ ]  not started (no TDD state)
  *   [-]  in progress (TDD initialized or partial evidence)
  *   [x]  completed   (full TDD evidence: red + green recorded)
+ *   [v]  verified    (completion-checker confirmed deliverables)
  *
  * Usage: node mark-task-progress.js <TASKS_DIR>
  * Called automatically by implement-gate.js on task-advance.
@@ -58,6 +59,8 @@ const { resolveTaskType } = require(path.join(__dirname, 'resolve-task-type'));
  */
 function statusToCheckbox(status) {
   switch (status) {
+    case 'verified':
+      return '[v]';
     case 'completed':
       return '[x]';
     case 'in_progress':
@@ -73,7 +76,7 @@ function statusToCheckbox(status) {
  *
  * @param {string} content - tasks.md content
  * @param {number} taskNum - 1-indexed task number
- * @param {string} checkbox - '[x]', '[-]', or '[ ]'
+ * @param {string} checkbox - '[v]', '[x]', '[-]', or '[ ]'
  * @returns {string} - Updated content
  */
 function updateTaskCheckboxes(content, taskNum, checkbox) {
@@ -91,8 +94,8 @@ function updateTaskCheckboxes(content, taskNum, checkbox) {
       break;
     }
     if (inSection) {
-      // Replace checkbox markers: [ ], [-], [x]
-      lines[i] = lines[i].replace(/\[([ x\-])\]/g, checkbox);
+      // Replace checkbox markers: [ ], [-], [x], [v]
+      lines[i] = lines[i].replace(/\[([ xv\-])\]/g, checkbox);
     }
   }
 
@@ -126,6 +129,38 @@ function markProgress(tasksDir) {
   fs.writeFileSync(tasksFile, content);
 }
 
+/**
+ * Mark specific tasks as verified ([v]) in tasks.md.
+ * Called after completion-checker confirms deliverables.
+ *
+ * @param {string} tasksDir - Path to ticket tasks directory
+ * @param {number[]} [taskNums] - Task numbers to mark verified. If omitted, marks ALL completed tasks.
+ */
+function markVerified(tasksDir, taskNums) {
+  const tasksFile = path.join(tasksDir, 'tasks.md');
+  if (!fs.existsSync(tasksFile)) return;
+
+  let content = fs.readFileSync(tasksFile, 'utf8');
+
+  // If no specific tasks given, find all completed tasks
+  if (!taskNums) {
+    taskNums = [];
+    const taskPattern = /^## Task (\d+)/gm;
+    let match;
+    while ((match = taskPattern.exec(content)) !== null) {
+      const num = parseInt(match[1], 10);
+      const status = getTaskStatus(tasksDir, num);
+      if (status === 'completed') taskNums.push(num);
+    }
+  }
+
+  for (const num of taskNums) {
+    content = updateTaskCheckboxes(content, num, '[v]');
+  }
+
+  fs.writeFileSync(tasksFile, content);
+}
+
 // CLI
 if (require.main === module) {
   const tasksDir = process.argv[2];
@@ -137,4 +172,4 @@ if (require.main === module) {
   console.log(`Updated checkboxes in ${path.join(tasksDir, 'tasks.md')}`);
 }
 
-module.exports = { markProgress, getTaskStatus, updateTaskCheckboxes };
+module.exports = { markProgress, markVerified, getTaskStatus, updateTaskCheckboxes };

--- a/workflows/work2/lib/step-enrichments/check.js
+++ b/workflows/work2/lib/step-enrichments/check.js
@@ -1,21 +1,15 @@
 /**
  * Check step enrichment.
  *
- * Rewrites the check step to call check-next.js (script-driven /check2)
+ * Rewrites the check step to invoke /check2 skill
  * instead of the old /check skill.
  */
 
 'use strict';
 
-const path = require('path');
-
 module.exports = function registerCheck(register) {
   register('check', (entry, ctx) => {
-    const { resolvePluginRoot } = require(path.join(__dirname, '..', 'resolve-plugin-root'));
-    const pluginRoot = resolvePluginRoot(__dirname, 4);
-    const checkNextPath = path.join(pluginRoot, 'workflows', 'check2', 'check-next.js');
-
-    entry.agentType = 'Bash';
-    entry.agentPrompt = `node "${checkNextPath}" ${ctx.ticket || 'TICKET'} --init`;
+    entry.agentType = 'skill';
+    entry.agentPrompt = `/work-workflow:check2 ${ctx.ticket || 'TICKET'}`;
   });
 };

--- a/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -58,7 +58,16 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
     // (checkpoint tasks verify, they don't implement)
   } else {
     // Non-checkpoint: check evidence exists AND is valid
-    const { exists, evidence } = readTddEvidence(safeName, stepName, taskNum);
+    // Use ctx.tasksDir-derived TASKS_BASE (not the global one which points to plugin dir)
+    const gateTasksBase = ctx.tasksDir ? path.dirname(ctx.tasksDir) : null;
+    const { exists, evidence } = gateTasksBase
+      ? require(path.join(__dirname, '..', '..', '..', 'work', 'tdd-enforcement')).readTddEvidence(
+          gateTasksBase,
+          safeName,
+          stepName,
+          taskNum
+        )
+      : readTddEvidence(safeName, stepName, taskNum);
     if (!exists) {
       ws._tddRetryReason = `No TDD evidence found at task${taskNum}/tdd-phase.json. You MUST run the TDD phase commands before this task can advance.`;
       ws._tddRetryCount = (ws._tddRetryCount || 0) + 1;

--- a/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -122,7 +122,20 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
     }
   }
 
-  // All tasks done with valid evidence — update checkboxes, allow transition
+  // All tasks done with valid evidence — mark last task completed and update checkboxes.
+  // Without this, the last task stays with status !== 'completed' in tasksMeta because
+  // task-advance only runs for non-last tasks (currentIdx < totalTasks - 1 branch above).
+  // The complete step's guard at work-state.js:278 correctly blocks if any task isn't
+  // marked completed — so we must record the bookkeeping here.
+  try {
+    execFileSync(
+      process.execPath,
+      [path.join(workDir, 'work-state.js'), 'task-advance', safeName],
+      { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' }
+    );
+  } catch {
+    /* fail-open — task-advance returns { done: true } for last task, which is fine */
+  }
   if (ctx.tasksDir) {
     try {
       markProgress(ctx.tasksDir);

--- a/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -51,39 +51,42 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
   const totalTasks = ws.tasksMeta.tasks.length;
   const taskNum = currentIdx + 1; // 1-indexed
 
-  // Check evidence exists AND is valid (red+green cycle complete)
-  const { exists, evidence } = readTddEvidence(safeName, stepName, taskNum);
-  if (!exists) {
-    // Store retry reason so the implement enrichment can tell the agent what went wrong
-    ws._tddRetryReason = `No TDD evidence found at task${taskNum}/tdd-phase.json. You MUST run the TDD phase commands before this task can advance.`;
-    ws._tddRetryCount = (ws._tddRetryCount || 0) + 1;
-    saveWorkState(safeName, ws);
-    return null;
-  }
-
-  // For test-only and checkpoint tasks, RED-only evidence is sufficient
-  // (tests written and failing — GREEN requires the implementation from the next task)
+  // Check task type BEFORE evidence — checkpoint tasks are exempt from TDD entirely
   const taskType = resolveTaskType(ctx.tasksDir, taskNum);
-  const isTestOnly = taskType === 'test' || taskType === 'checkpoint';
-
-  if (isTestOnly) {
-    // Accept any evidence (even RED-only) for test/checkpoint tasks.
-    // Also accept exception evidence (e.g., config-only, mechanical-refactor).
-    const hasAnyCycle = Array.isArray(evidence?.cycles) && evidence.cycles.length > 0;
-    const hasException = evidence?.currentPhase === 'exception' && evidence?.exception;
-    if (!hasAnyCycle && !hasException) {
-      ws._tddRetryReason = `TDD evidence exists but has no cycles or exception. Record at least one RED phase or use exception mode.`;
+  if (taskType === 'checkpoint') {
+    // Checkpoints don't need TDD evidence — skip directly to advance
+    // (checkpoint tasks verify, they don't implement)
+  } else {
+    // Non-checkpoint: check evidence exists AND is valid
+    const { exists, evidence } = readTddEvidence(safeName, stepName, taskNum);
+    if (!exists) {
+      ws._tddRetryReason = `No TDD evidence found at task${taskNum}/tdd-phase.json. You MUST run the TDD phase commands before this task can advance.`;
       ws._tddRetryCount = (ws._tddRetryCount || 0) + 1;
       saveWorkState(safeName, ws);
       return null;
     }
-  } else {
-    const validation = validateTddEvidence(evidence);
-    if (!validation.valid) {
-      ws._tddRetryReason = `TDD evidence invalid: ${validation.reason}`;
-      ws._tddRetryCount = (ws._tddRetryCount || 0) + 1;
-      saveWorkState(safeName, ws);
-      return null;
+
+    const isTestOnly = taskType === 'test';
+
+    if (isTestOnly) {
+      // Accept any evidence (even RED-only) for test tasks.
+      // Also accept exception evidence (e.g., config-only, mechanical-refactor).
+      const hasAnyCycle = Array.isArray(evidence?.cycles) && evidence.cycles.length > 0;
+      const hasException = evidence?.currentPhase === 'exception' && evidence?.exception;
+      if (!hasAnyCycle && !hasException) {
+        ws._tddRetryReason = `TDD evidence exists but has no cycles or exception. Record at least one RED phase or use exception mode.`;
+        ws._tddRetryCount = (ws._tddRetryCount || 0) + 1;
+        saveWorkState(safeName, ws);
+        return null;
+      }
+    } else {
+      const validation = validateTddEvidence(evidence);
+      if (!validation.valid) {
+        ws._tddRetryReason = `TDD evidence invalid: ${validation.reason}`;
+        ws._tddRetryCount = (ws._tddRetryCount || 0) + 1;
+        saveWorkState(safeName, ws);
+        return null;
+      }
     }
   }
 

--- a/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -67,10 +67,12 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
   const isTestOnly = taskType === 'test' || taskType === 'checkpoint';
 
   if (isTestOnly) {
-    // Accept any evidence (even RED-only) for test/checkpoint tasks
+    // Accept any evidence (even RED-only) for test/checkpoint tasks.
+    // Also accept exception evidence (e.g., config-only, mechanical-refactor).
     const hasAnyCycle = Array.isArray(evidence?.cycles) && evidence.cycles.length > 0;
-    if (!hasAnyCycle) {
-      ws._tddRetryReason = `TDD evidence exists but has no cycles. Record at least one RED phase.`;
+    const hasException = evidence?.currentPhase === 'exception' && evidence?.exception;
+    if (!hasAnyCycle && !hasException) {
+      ws._tddRetryReason = `TDD evidence exists but has no cycles or exception. Record at least one RED phase or use exception mode.`;
       ws._tddRetryCount = (ws._tddRetryCount || 0) + 1;
       saveWorkState(safeName, ws);
       return null;

--- a/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -95,13 +95,20 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
   delete ws._tddRetryCount;
   saveWorkState(safeName, ws);
 
+  // Derive TASKS_BASE from ctx.tasksDir for subprocess calls.
+  // The gate runs in the plugin's process context, but the ticket's tasks
+  // may be in a different project (e.g., worktree). ctx.tasksDir is the
+  // correct path — extract TASKS_BASE by removing the ticket subfolder.
+  const gateTASKS_BASE = ctx.tasksDir ? path.dirname(ctx.tasksDir) : process.env.TASKS_BASE;
+  const gateExecEnv = gateTASKS_BASE ? { ...process.env, TASKS_BASE: gateTASKS_BASE } : process.env;
+
   // Evidence valid — check if more tasks remain
   if (currentIdx < totalTasks - 1) {
     try {
       execFileSync(
         process.execPath,
         [path.join(workDir, 'work-state.js'), 'task-advance', safeName],
-        { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' }
+        { encoding: 'utf-8', timeout: 5000, stdio: 'pipe', env: gateExecEnv }
       );
       // Clear dispatched marker so the new task gets dispatched fresh
       const ws2 = loadWorkState(safeName);
@@ -136,7 +143,7 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
     execFileSync(
       process.execPath,
       [path.join(workDir, 'work-state.js'), 'task-advance', safeName],
-      { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' }
+      { encoding: 'utf-8', timeout: 5000, stdio: 'pipe', env: gateExecEnv }
     );
   } catch {
     /* fail-open — task-advance returns { done: true } for last task, which is fine */

--- a/workflows/work2/lib/step-enrichments/implement.js
+++ b/workflows/work2/lib/step-enrichments/implement.js
@@ -292,29 +292,19 @@ module.exports = function registerImplement(register) {
       /* fail-open */
     }
 
-    // Check if task has a ### Test Command (gate-driven TDD)
+    // Read task metadata (testCommand, suggestedScope) from task-parser
     let hasGateTDD = false;
     let taskTestCommand = null;
-    try {
-      const { parseTasks } = require(path.join(__dirname, '..', '..', '..', 'work', 'task-parser'));
-      const allTasks = parseTasks(tasksDir);
-      const currentTask = allTasks?.find((t) => t.num === Number(taskNum));
-      taskTestCommand = currentTask?.testCommand || null;
-      hasGateTDD = !!taskTestCommand;
-    } catch {
-      /* fail-open */
-    }
-
-    // Build compact prompt for implementation tasks
-    // Get suggested scope for the current task
     let taskScope = '';
     try {
-      const { parseTasks: _pt } = require(
+      const { parseTasks: parseFullTasks } = require(
         path.join(__dirname, '..', '..', '..', 'work', 'task-parser')
       );
-      const _tasks = _pt(tasksDir);
-      const _t = _tasks?.find((t) => t.num === Number(taskNum));
-      taskScope = _t?.suggestedScope || '';
+      const allParsedTasks = parseFullTasks(tasksDir);
+      const currentTask = allParsedTasks?.find((t) => t.num === Number(taskNum));
+      taskTestCommand = currentTask?.testCommand || null;
+      taskScope = currentTask?.suggestedScope || '';
+      hasGateTDD = !!taskTestCommand;
     } catch {
       /* fail-open */
     }

--- a/workflows/work2/lib/step-enrichments/implement.js
+++ b/workflows/work2/lib/step-enrichments/implement.js
@@ -102,10 +102,22 @@ module.exports = function registerImplement(register) {
           const phaseLabel = phaseLabels[phase] || `${phase} phase`;
           const parallelTestCmd = task?.testCommand || null;
 
+          const parallelScope = task?.suggestedScope || '';
           const parallelTddSection = parallelTestCmd
             ? [
-                '### Testing (automated)',
-                `Tests run automatically when you finish: \`${parallelTestCmd}\``,
+                ...(parallelScope
+                  ? [
+                      '### Files to implement',
+                      ...parallelScope
+                        .split('\n')
+                        .map((l) => l.trim())
+                        .filter(Boolean)
+                        .map((l) => `- \`${l.replace(/^[-*+]\s+/, '').replace(/`/g, '')}\``),
+                      '',
+                    ]
+                  : []),
+                '### Verification (automated — runs when you stop)',
+                `\`${parallelTestCmd}\``,
                 'If tests fail, you will be blocked from stopping and must fix the code.',
                 'Do NOT run tdd-phase-state.js or tdd-next.js manually.',
               ]
@@ -290,10 +302,33 @@ module.exports = function registerImplement(register) {
     }
 
     // Build compact prompt for implementation tasks
+    // Get suggested scope for the current task
+    let taskScope = '';
+    try {
+      const { parseTasks: _pt } = require(
+        path.join(__dirname, '..', '..', '..', 'work', 'task-parser')
+      );
+      const _tasks = _pt(tasksDir);
+      const _t = _tasks?.find((t) => t.num === Number(taskNum));
+      taskScope = _t?.suggestedScope || '';
+    } catch {
+      /* fail-open */
+    }
+
     const tddSection = hasGateTDD
       ? [
-          '### Testing (automated)',
-          `Tests run automatically when you finish. The Stop hook executes:`,
+          ...(taskScope
+            ? [
+                '### Files to implement',
+                ...taskScope
+                  .split('\n')
+                  .map((l) => l.trim())
+                  .filter(Boolean)
+                  .map((l) => `- \`${l.replace(/^[-*+]\s+/, '').replace(/`/g, '')}\``),
+                '',
+              ]
+            : []),
+          '### Verification (automated — runs when you stop)',
           '```',
           taskTestCommand,
           '```',

--- a/workflows/work2/lib/step-enrichments/implement.js
+++ b/workflows/work2/lib/step-enrichments/implement.js
@@ -100,6 +100,24 @@ module.exports = function registerImplement(register) {
           const tddState = readPhase(ticket.replace('#', 'GH-'), num);
           const phase = tddState?.currentPhase || 'red';
           const phaseLabel = phaseLabels[phase] || `${phase} phase`;
+          const parallelTestCmd = task?.testCommand || null;
+
+          const parallelTddSection = parallelTestCmd
+            ? [
+                '### Testing (automated)',
+                `Tests run automatically when you finish: \`${parallelTestCmd}\``,
+                'If tests fail, you will be blocked from stopping and must fix the code.',
+                'Do NOT run tdd-phase-state.js or tdd-next.js manually.',
+              ]
+            : [
+                `### TDD Phase: ${phaseLabel}`,
+                'Get phase commands:',
+                '```bash',
+                `node "${tddNextPath}" ${ticket} --task ${num}`,
+                '```',
+                'Record evidence at each phase (init → red → green → refactor).',
+              ];
+
           return {
             type: 'task',
             agentType,
@@ -107,12 +125,7 @@ module.exports = function registerImplement(register) {
             prompt: [
               `## Implement Task ${num}/${totalTasks} — ${task?.title || 'Implementation'}`,
               '',
-              `### TDD Phase: ${phaseLabel}`,
-              'Get phase commands:',
-              '```bash',
-              `node "${tddNextPath}" ${ticket} --task ${num}`,
-              '```',
-              'Record evidence at each phase (init → red → green → refactor).',
+              ...parallelTddSection,
               '',
               '### Required Reading',
               `- **Task details:** ${path.join(tasksDir, 'tasks.md')} (find "## Task ${num}" section)`,
@@ -122,7 +135,6 @@ module.exports = function registerImplement(register) {
               '### Rules',
               `- Implement ONLY Task ${num} deliverables`,
               '- Do NOT touch files reserved for other tasks',
-              '- Follow TDD: run tdd-next.js → do the work → record evidence → transition phase',
             ].join('\n'),
             note: 'Pass the prompt directly to the agent.',
           };
@@ -264,18 +276,45 @@ module.exports = function registerImplement(register) {
       /* fail-open */
     }
 
+    // Check if task has a ### Test Command (gate-driven TDD)
+    let hasGateTDD = false;
+    let taskTestCommand = null;
+    try {
+      const { parseTasks } = require(path.join(__dirname, '..', '..', '..', 'work', 'task-parser'));
+      const allTasks = parseTasks(tasksDir);
+      const currentTask = allTasks?.find((t) => t.num === Number(taskNum));
+      taskTestCommand = currentTask?.testCommand || null;
+      hasGateTDD = !!taskTestCommand;
+    } catch {
+      /* fail-open */
+    }
+
     // Build compact prompt for implementation tasks
+    const tddSection = hasGateTDD
+      ? [
+          '### Testing (automated)',
+          `Tests run automatically when you finish. The Stop hook executes:`,
+          '```',
+          taskTestCommand,
+          '```',
+          'If tests fail, you will be blocked from stopping and must fix the code.',
+          'Do NOT run tdd-phase-state.js or tdd-next.js — the hook handles evidence recording.',
+        ]
+      : [
+          `### TDD Phase: ${phaseLabel}`,
+          '',
+          '### Next step',
+          'Run this command and follow its output:',
+          '```bash',
+          `node "${tddNextPath}" ${ticket}${taskFlag}`,
+          '```',
+        ];
+
     const devPrompt = [
       retryHeader,
       `## Implement Task ${taskNum || '?'}/${totalTasks || '?'} — ${taskTitle}`,
       '',
-      `### TDD Phase: ${phaseLabel}`,
-      '',
-      '### Next step',
-      'Run this command and follow its output:',
-      '```bash',
-      `node "${tddNextPath}" ${ticket}${taskFlag}`,
-      '```',
+      ...tddSection,
       '',
       '### Required Reading (read IN FULL before implementing)',
       `- **Task details:** ${path.join(tasksDir, 'tasks.md')} (find "## Task ${taskNum}" section)`,

--- a/workflows/work2/lib/step-enrichments/implement.js
+++ b/workflows/work2/lib/step-enrichments/implement.js
@@ -86,7 +86,11 @@ module.exports = function registerImplement(register) {
     if (tasksDir && totalTasks && totalTasks > 1) {
       const { parallelTasks } = findReadyTasks(tasksDir, currentTaskNum - 1);
       if (parallelTasks.length > 1) {
-        const allTasks = parseTasks(tasksDir);
+        // Use task-parser (not task-graph) to get testCommand and suggestedScope
+        const { parseTasks: parseFullTasks } = require(
+          path.join(__dirname, '..', '..', '..', 'work', 'task-parser')
+        );
+        const allTasks = parseFullTasks(tasksDir) || parseTasks(tasksDir);
         const { readPhase } = require(path.join(__dirname, '..', '..', 'tdd-next.js'));
         const phaseLabels = {
           red: 'RED — write failing tests',

--- a/workflows/work2/lib/task-graph.js
+++ b/workflows/work2/lib/task-graph.js
@@ -47,9 +47,9 @@ function parseTasks(tasksDir) {
     }
 
     // Check completion from checkbox markers
-    // [x] = completed, [-] = in progress, [ ] = not started
-    const allCheckboxes = block.match(/- \[[ x-]\]/g) || [];
-    const completedBoxes = block.match(/- \[x\]/g) || [];
+    // [v] = verified, [x] = completed, [-] = in progress, [ ] = not started
+    const allCheckboxes = block.match(/- \[[ xv-]\]/g) || [];
+    const completedBoxes = block.match(/- \[[xv]\]/g) || [];
     const completed = allCheckboxes.length > 0 && allCheckboxes.length === completedBoxes.length;
 
     return { num, title, type, parallel, dependencies, completed };


### PR DESCRIPTION
## Existing Behavior

- The `completion-checker` agent evaluated work based on agent-reported phrases ("done", "ready") rather than code evidence, with no structured access to planning artifacts (ticket.json, brief.md, spec.md, tasks.md).
- Developer agents had no automated mechanism to record TDD evidence at stop time — agents were expected to manually run `tdd-next.js` and `tdd-phase-state.js` to progress through RED/GREEN/REFACTOR phases.
- The implement gate treated checkpoint tasks identically to implementation tasks when checking TDD evidence, and did not call `task-advance` for the final task, leaving it unmarked as completed.
- The `session-guard` Stop hook blocked all stops for `/work2` — including cases where the workflow was legitimately waiting on a dispatched sub-agent.
- The skipped-review warning in `follow-up2` fired repeatedly on every re-entry after all comments were processed, blocking advancement indefinitely.

## Intended New Behavior

- The `completion-checker` agent now performs mandatory layered verification against all planning artifacts (ticket → brief → spec → tasks), with every DELIVERED requirement requiring a code citation (file:line or diff excerpt). The `/check2` phase pre-loads these artifacts into the prompt via a new `completion-context.js` enrichment.
- A new `enforce-tdd-on-stop.js` Stop hook (wired into all three developer agent definitions) auto-runs the task's `### Test Command` from `tasks.md` when the agent tries to stop, records TDD phase evidence, and blocks stopping when RED is recorded or evidence is invalid. The `task-parser` now extracts the `### Test Command` field, and `tdd-phase-state.js` rejects obviously fake `--cmd` values (e.g., `exit 1`, `echo`, `true`). Tasks without a `### Test Command` bypass the evidence check (fail-open for pre-existing tasks).
- The implement gate now checks task type before TDD evidence: checkpoint tasks are fully exempt; test-type tasks accept RED-only or exception evidence; the gate calls `task-advance` for the final task to ensure it is marked completed. Implement prompts show the `### Test Command` and scoped files instead of manual `tdd-next.js` instructions when gate-driven TDD is configured.
- The session guard now reads `_work2Dispatched` from work state and allows stop when a step is waiting on a dispatched sub-agent, emitting a resume instruction instead of blocking.
- The skipped-review warning gate in `follow-up2` is now shown at most once per session via a persisted `_skippedReviewWarningShown` flag on work state.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a backend workflow engine change spanning multiple components. Verify each area:

**Gate-driven TDD (enforce-tdd-on-stop hook):**
1. Set `WORK_TICKET_ID` to an active ticket in the implement step with a `### Test Command` in its `tasks.md`.
2. Trigger a developer agent stop — the hook should auto-run the test command, record RED phase evidence if tests fail, and block the stop with a message.
3. After fixing the tests, trigger stop again — GREEN evidence is recorded and the stop is allowed.
4. For a task without `### Test Command`, confirm the hook exits 0 (bypass, no block).

**Completion-checker context enrichment:**
1. Run `/check2` on a ticket that has brief.md, spec.md, and tasks.md present.
2. Confirm the completion-checker agent prompt includes the structured Layer 1–4 verification context.
3. Verify the agent cites specific code locations for each delivered requirement rather than accepting agent statements as proof.

**Implement gate checkpoint exemption:**
1. Run the implement gate against a ticket where the current task is a `checkpoint` type.
2. Confirm the gate skips TDD evidence checks and advances directly.
3. Confirm the final non-checkpoint task triggers `task-advance` and is marked completed in `.work-state.json`.

**Session guard dispatch-aware stop:**
1. While in a `/work2` workflow with `_work2Dispatched` set in work state, attempt to stop the session.
2. Confirm the guard emits the resume instruction and exits 0 (allowing stop) rather than blocking.

**Skipped-review warning deduplication:**
1. Set up a follow-up2 workflow with at least one skipped comment in `follow-up-comments.json`.
2. Invoke `follow-up-next.js` — the warning should appear once and block.
3. Invoke again — `_skippedReviewWarningShown` is true, warning does not repeat, step advances to push-retry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow hooks and task-advancement logic that gate progress and stopping behavior; misconfigurations could block developers or incorrectly advance/verify tasks.
> 
> **Overview**
> **Workflow quality gates are tightened and more automated.** `/check2` now preloads a structured “Verification Context” (ticket/brief/spec/tasks) into the `completion-checker` prompt and, when the completion report is `COMPLETE`, automatically marks eligible `tasks.md` checkboxes as verified (`[v]`).
> 
> **Gate-driven TDD is automated at stop-time.** A new `SubagentStop` hook (`enforce-tdd-on-stop.js`) runs a task’s `### Test Command` from `tasks.md`, records phase evidence, blocks stopping when tests are still failing, and `tdd-phase-state.js` now rejects obviously fake `--cmd` values; task parsing and task graph logic are updated to recognize `### Test Command` and `[v]`.
> 
> **Implement/check guardrails are refined.** The implement gate exempts checkpoint tasks from TDD evidence, allows test tasks with RED-only/exception evidence, ensures the final task is advanced/marked completed, and implement prompts prefer showing scoped files + automated test command over manual `tdd-next` instructions; `check2` quality recheck is made deterministic/inline, `session-guard` becomes aware of `/check2` state and dispatched waiting steps, and follow-up skipped-review blocking is deduped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b86ce68f51161fcadcfbc9a422bf2f149a316a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->