### PR TITLE
feat(work2): add related-tickets manifest gate (sibling-scope enforcement, Gate 0 of 8)

### DIFF
--- a/agents/brief-writer.md
+++ b/agents/brief-writer.md
@@ -39,6 +39,16 @@ You will receive:
 1. Ticket requirements (title, description, acceptance criteria) from a previous step
 2. A path where to save the brief
 
+## Related Tickets Manifest (Gate 0 — REQUIRED FIRST)
+
+Before drafting the brief, fetch the related tickets and write `tasks/<ticket>/related-tickets.json`. The orchestrator injects exact fetch instructions per ticket provider (Jira / Linear / GitHub) into your prompt under `## Related Tickets Manifest (REQUIRED — fetch FIRST)`.
+
+Why this is mandatory:
+- Sibling tickets often own surfaces (files / endpoints / schemas) that are referenced by the current ticket's requirements. If you absorb those into the brief as P0 items, the next agent will edit sibling-owned code — exactly the failure mode this gate exists to prevent.
+- `brief_gate` will block until a valid manifest exists at the documented path. There is no way to skip this.
+
+After writing the manifest, treat its contents as authoritative when populating the brief — especially the `## Out of Scope` section (see below).
+
 ## Brief Template
 
 Generate a markdown document with this structure:

--- a/agents/brief-writer.md
+++ b/agents/brief-writer.md
@@ -39,6 +39,27 @@ You will receive:
 1. Ticket requirements (title, description, acceptance criteria) from a previous step
 2. A path where to save the brief
 
+## Out of scope (sibling-owned) — Gate A
+
+When a P0 requirement names a surface (file path / endpoint / schema / symbol) that the `related-tickets.json` manifest declares as owned by a sibling ticket, do NOT add the P0 to this brief's `### Must Have`. Move it to a dedicated section:
+
+```markdown
+## Out of scope (sibling-owned)
+- `<SURFACE>` — owned by <SIBLING-TICKET-ID> (status: <STATUS>, PR: <#N or "not yet shipped">). Reason: <why this is needed for the current ticket but not owned here>.
+```
+
+One entry per surface. The format is mechanical — Gate A parses these bullets to surface AskUserQuestion at brief_gate. After the user decides, the gate persists their answer under a sibling section:
+
+```markdown
+## Sibling-gap decisions
+- `<SURFACE>` — decision: <implement-here | wait-for-sibling>; ticket: <SIBLING-TICKET-ID>; timestamp: <ISO-8601>
+```
+
+Rules:
+- Every `## Out of scope (sibling-owned)` entry MUST have a matching `## Sibling-gap decisions` entry before brief_gate passes.
+- Do NOT pre-fill the decisions section yourself — the orchestrator writes it after the user answers.
+- The surface token in both sections must match exactly (case-insensitive) so Gate A can pair them.
+
 ## Related Tickets Manifest (Gate 0 — REQUIRED FIRST)
 
 Before drafting the brief, fetch the related tickets and write `tasks/<ticket>/related-tickets.json`. The orchestrator injects exact fetch instructions per ticket provider (Jira / Linear / GitHub) into your prompt under `## Related Tickets Manifest (REQUIRED — fetch FIRST)`.

--- a/agents/brief-writer.md
+++ b/agents/brief-writer.md
@@ -41,6 +41,34 @@ You will receive:
 
 ## Out of scope (sibling-owned) — Gate A
 
+### DO NOT ask the user "does a sibling own this?"
+
+You have `related-tickets.json`. That file IS the authoritative answer. Before drafting ANY sibling-ownership AskUserQuestion, you MUST:
+
+1. Read `tasks/<ticket>/related-tickets.json` in full.
+2. For each surface the brief references (file path, tRPC procedure name, schema, symbol), determine ownership by walking this decision tree:
+
+   **Step A — `surfaces` exact match.** Check every sibling's `surfaces` array (and parent / blockedBy / dependsOn / relatedTo). If the surface appears, → **sibling-owned**. Done.
+
+   **Step B — sibling `scope` field** (USE THIS when surfaces are empty because no sibling PR has merged yet). Every linked entry in `related-tickets.json` carries a `scope` field — a one-to-three-sentence summary of what that ticket owns, written by the agent that created the manifest. Match the surface in question against each sibling's `scope`:
+   - If the `scope` names the same procedure / file / schema / endpoint you're considering → **sibling-owned**. Add it to `## Out of scope (sibling-owned)` directly, citing the `scope` text as the reason. Do NOT ask the user.
+   - If `scope` is empty or generic (manifest-creation drift), fall through to the title heuristic below.
+
+   **Step B' — sibling title heuristic** (fallback when both `surfaces` and `scope` are empty/unhelpful). Read each sibling's `title` and infer ownership from plain language:
+   - Title prefixes like `Backend:`, `API:`, `tRPC:`, `Wire:` strongly suggest that sibling owns backend/API surfaces (tRPC procedures, schemas, routers).
+   - `Frontend:`, `UI:`, `Component:` suggest UI surfaces (`components/**`, `app/**/page.tsx`).
+   - `E2E:`, `Tests:`, `QA:` suggest test-only surfaces (`tests/e2e/**`).
+   - `Wire:` / `Integration:` suggest the wiring layer between layers; usually owns adapter code and the API surface it consumes.
+   - When the surface in question matches that pattern (e.g. you need `externalAssets.listDownstreamDashboards` and a sibling is titled `Wire: X to explore.list` or `Backend: X procedure`) → **sibling-owned**. Add it to `## Out of scope (sibling-owned)` directly, citing the title as the reason. Do NOT ask the user.
+
+   **Step C — only now ask.** If after Steps A and B the ownership is *genuinely* ambiguous (sibling exists but its title is generic like "Misc fixes" or "Refactor X"), THEN it's appropriate to ask. Quote both the manifest entry AND the title heuristic you tried in your question.
+
+3. **Forbidden questions to the user:** "Does sibling X own this procedure?", "Is the backend in a sibling ticket?", "Which surface is owned where?" when the sibling title clearly answers it. Asking them means you stopped at Step A instead of completing Step B.
+
+The user has already complained about this. Read the manifest, apply the title heuristic, only ask what the manifest + titles genuinely cannot answer.
+
+### Format
+
 When a P0 requirement names a surface (file path / endpoint / schema / symbol) that the `related-tickets.json` manifest declares as owned by a sibling ticket, do NOT add the P0 to this brief's `### Must Have`. Move it to a dedicated section:
 
 ```markdown

--- a/agents/completion-checker.md
+++ b/agents/completion-checker.md
@@ -58,6 +58,18 @@ When verification is COMPLETE, the orchestrator automatically marks tasks as ver
 4. Consider obvious implicit requirements (e.g., if asked to research, provide sources)
 5. Verify deliverables exist when applicable (files, spreadsheet updates, etc.)
 
+## Gate E — scope-diff verification (when invoked via /work2)
+
+When the check step injects a `## Scope-diff summary` block into your prompt (it lists `in scope` / `out of scope` / `unaccounted` file counts plus per-file detail), enforce these rules:
+
+- **`out of scope` (sibling-owned) > 0** → BLOCK completion. Every file in the list is owned by a sibling ticket per tasks.md `### Files explicitly out of scope`. Tell the user to either revert those edits OR file a sibling-gap question and stop. Do NOT proceed to commit.
+- **`unaccounted` > 0** → require justification. Each unaccounted file was not declared in any task's `### Files in scope`. For each one, decide:
+  - If it's a legitimate side effect (test fixture, snapshot, migration auto-generated, formatter pass) → accept and require the PR description to list it under `## Out-of-scope changes` with the one-line reason.
+  - If it's drift (the agent edited a file outside scope by accident) → BLOCK and ask the user to revert.
+- **All files in scope** → pass; no extra action.
+
+Surface this section verbatim in the verification output so the PR generator can copy it into the PR description.
+
 ## CRITICAL: Check the Correct Source
 
 **Before verifying deliverables, determine WHERE to check:**

--- a/agents/jira-task-creator.md
+++ b/agents/jira-task-creator.md
@@ -44,6 +44,17 @@ This agent is called by the `/create-jira` command after it has:
 - You ARE the jira-task-creator agent - do the work directly
 - Calling yourself creates infinite recursion loops
 
+## Related Tickets Manifest (READ FIRST when invoked via /work2)
+
+When invoked through the `/work2` workflow, your prompt will include a pointer to `tasks/<ticket>/related-tickets.json` under `## Related Tickets (READ FIRST)`. Read it before splitting into tasks.
+
+For every file listed under a sibling's `surfaces`, that file is owned by the sibling ticket. When you split the current ticket into tasks:
+- DO NOT list any sibling-owned file under any task's `### Files in scope`.
+- DO list every sibling-owned file referenced by the brief under each affected task's `### Files explicitly out of scope` along with the owning sibling's ID.
+- If the brief implies a task that would require editing a sibling-owned file, do not create that task — surface it as an open question against the sibling ticket instead.
+
+This is non-negotiable: Gate D (file-edit hook) will block any task whose implementation tries to write to a sibling-owned file at runtime.
+
 ## Critical Rules
 
 ### GOLDEN RULE: NEVER DROP DETAILS

--- a/agents/jira-task-creator.md
+++ b/agents/jira-task-creator.md
@@ -55,6 +55,27 @@ For every file listed under a sibling's `surfaces`, that file is owned by the si
 
 This is non-negotiable: Gate D (file-edit hook) will block any task whose implementation tries to write to a sibling-owned file at runtime.
 
+## Required per-task sections (Gate C)
+
+Every `## Task N` block in tasks.md MUST include both of these sections, in addition to the existing Type / Description / Requirements Covered / Deliverables / Acceptance Criteria / Dependencies / Test Command sections:
+
+```markdown
+### Files in scope
+- path/or/glob/the/task/may/edit/**
+- another/specific-file.ts
+- (one entry per line; globs ok)
+
+### Files explicitly out of scope
+- sibling-owned/file.ts — owned by [SIBLING-TICKET-ID]
+- (may be empty when no siblings own related surfaces)
+```
+
+Rules:
+- `### Files in scope` is REQUIRED and MUST be non-empty. The orchestrator refuses to dispatch the implement step when any task lacks it.
+- `### Files explicitly out of scope` is REQUIRED but MAY be empty. Populate from the sibling-surfaces list in `related-tickets.json`. Include the owning ticket ID for each entry.
+- Use real paths or glob patterns (e.g. `app/api/trpc/routers/views.ts`, `components/**/*.tsx`). Do not paraphrase ("the views router").
+- A file listed under `### Files explicitly out of scope` MUST NOT also appear under `### Files in scope` of any task in the same tasks.md.
+
 ## Critical Rules
 
 ### GOLDEN RULE: NEVER DROP DETAILS

--- a/agents/pr-generator.md
+++ b/agents/pr-generator.md
@@ -216,6 +216,26 @@ This is CRITICAL - the PR will be rejected if ticket-system-style escaping is de
 ## Intended New Behavior
 [Your analysis here]
 
+## Brief P0 coverage
+[Gate F — REQUIRED when a `tasks/<ticket>/brief.md` exists for this ticket.
+List each P0 from the brief by ID with the diff location proving it shipped.
+Format:
+- **P0 #1:** <one-line restatement> — implemented in `path/to/file.ts:42`
+- **P0 #2:** <restatement> — implemented in `another/file.ts:118` + test `tests/foo.test.ts:9`
+If any P0 has no diff evidence, mark it `UNVERIFIED` and explain — the
+completion-checker should have blocked, surface here as a fallback.]
+
+## Out-of-scope changes
+[Gate F — REQUIRED when the check step's Gate E scope-diff verifier reported
+any `outOfScope` or `unaccounted` files. List each file with a one-line
+justification (legitimate side effect / sibling-owned that was intentionally
+included / etc.). Omit this section ONLY if every changed file matched a
+task's `### Files in scope`.
+Format:
+- `path/to/file.ts` — <one-line reason>
+The completion-checker's Gate E output is your source of truth here. Copy
+the file list verbatim.]
+
 ## Dev Checks
 - [ ] Functionality can be toggled on/off
 - [ ] New code is covered by unit/integration tests

--- a/agents/spec-writer.md
+++ b/agents/spec-writer.md
@@ -40,6 +40,20 @@ You will receive:
 2. The worktree directory to explore
 3. A path where to save the spec
 
+## Related Tickets Manifest (READ FIRST)
+
+Before reading the brief, read `tasks/<ticket>/related-tickets.json` (its path is injected into your prompt under `## Related Tickets (READ FIRST)`). It documents:
+- The parent ticket and its `surfaces` (files changed in its merged PR).
+- Sibling tickets (children of the same parent) and the files they own.
+- `blockedBy` / `dependsOn` / `relatedTo` links.
+
+For every file listed under a sibling's `surfaces`, treat it as **out of scope for this spec**. If the brief contains a requirement that would force you to design changes against a sibling-owned file:
+1. Do NOT design the change.
+2. Restate the brief's `## Out of Scope` section in your spec verbatim under the same heading.
+3. Add an open question naming the sibling ticket and asking whether to wait for it or extend scope.
+
+When designing API / schema changes, also enumerate every consumer of a modified output schema (grep for usages). Consumer paths must be explicitly *included* or *excluded with reason* in the spec — never silently narrowed.
+
 ## Workflow
 
 1. **Read the brief and project docs** - Extract goals, requirements, constraints, success metrics. If READ_DOCS_ON_SPEC docs are provided (pattern-first.md, architecture.md, ARCH.md, etc.), read them FIRST — they define the app's component structure, shared libraries, and conventions.

--- a/agents/spec-writer.md
+++ b/agents/spec-writer.md
@@ -40,6 +40,18 @@ You will receive:
 2. The worktree directory to explore
 3. A path where to save the spec
 
+## Brief→Spec coverage (Gate B — REQUIRED)
+
+Every brief P0 ID must be referenced in the spec. The orchestrator runs a checker at spec_gate that scans the spec for `P0 #N` mentions (in headings or inline) for each P0 in the brief's `### Must Have (P0)` section. Missing references block transition.
+
+Conventions:
+- Add a heading per P0: `### P0 #1 — <short title>` followed by the design for that P0.
+- Or, if multiple P0s share a section, prefix the section with `P0 #1, #2, #3:` and discuss them together.
+
+Also REQUIRED: restate the brief's `## Out of scope (sibling-owned)` section in the spec verbatim under the same heading. Surfaces listed there must NOT be targeted by any spec design decision. The orchestrator checks for the heading AND for at least one matching entry; the section blocks transition when missing.
+
+For every output schema you modify, list every consumer (grep usages of the schema's imports / type aliases) and mark each consumer *included* or *excluded with reason*. This is the consumer-path manifest; silent narrowing is what caused the ECHO-4552 / ECHO-4553 incident this gate exists to prevent.
+
 ## Related Tickets Manifest (READ FIRST)
 
 Before reading the brief, read `tasks/<ticket>/related-tickets.json` (its path is injected into your prompt under `## Related Tickets (READ FIRST)`). It documents:

--- a/agents/spec-writer.md
+++ b/agents/spec-writer.md
@@ -52,7 +52,9 @@ Also REQUIRED: restate the brief's `## Out of scope (sibling-owned)` section in 
 
 For every output schema you modify, list every consumer (grep usages of the schema's imports / type aliases) and mark each consumer *included* or *excluded with reason*. This is the consumer-path manifest; silent narrowing is what caused the ECHO-4552 / ECHO-4553 incident this gate exists to prevent.
 
-## Related Tickets Manifest (READ FIRST)
+## Related Tickets Manifest (READ FIRST — and stop asking the user about siblings)
+
+You have `related-tickets.json`. **NEVER** ask the user questions like "does sibling X own this procedure?", "which surface is the sibling responsible for?", or "is the backend in this ticket or a related ticket?" — the manifest answers all of these. Read it; check the `surfaces` array of each sibling/parent/blockedBy/dependsOn/relatedTo entry; decide ownership yourself. Only ask the user when the manifest is genuinely ambiguous (sibling exists but PR not merged AND surfaces empty).
 
 Before reading the brief, read `tasks/<ticket>/related-tickets.json` (its path is injected into your prompt under `## Related Tickets (READ FIRST)`). It documents:
 - The parent ticket and its `surfaces` (files changed in its merged PR).

--- a/agents/spec-writer.md
+++ b/agents/spec-writer.md
@@ -187,8 +187,8 @@ The `gherkin.feature` file must contain the full Feature block with all scenario
 - Minimum 2 scenarios total
 - At least 1 scenario tagged @integration or @e2e
 - Use Feature/Scenario/Given/When/Then structure
-- Tag each scenario with @integration (tests internal logic/APIs) or @e2e (tests full user flows)
-- @unit tags are also accepted but not enforced by the gate
+- Tag each scenario with **exactly** `@integration` (tests internal logic/APIs) or `@e2e` (tests full user flows)
+- **No other tags are valid.** `@unit`, `@storybook`, `@smoke`, `@regression`, custom tags, etc. will cause spec_gate to fail validation. If you think the work needs a different tag, pick `@integration` for component / hook / service level tests and `@e2e` for browser-driven flows — and STOP. Do not invent new tags.
 - Existing specs using the old `## Test Scenarios` heading (without "(Gherkin)") are also accepted by the parser
 
 **E2E scenario rules:**

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -59,6 +59,10 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work2/hooks/protect-orchestrator-state.js"
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work2/hooks/protect-task-scope.js"
           }
         ]
       },
@@ -93,6 +97,10 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work2/hooks/protect-orchestrator-state.js"
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work2/hooks/protect-task-scope.js"
           }
         ]
       },

--- a/scripts/workflows/lib/__tests__/brief-sibling-gaps.test.js
+++ b/scripts/workflows/lib/__tests__/brief-sibling-gaps.test.js
@@ -1,0 +1,100 @@
+/**
+ * Tests for lib/brief-sibling-gaps.js (Gate A parser).
+ *
+ * Run: node --test scripts/workflows/lib/__tests__/brief-sibling-gaps.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { findUnresolvedSiblingGaps, buildSiblingGapQuestions } = require('../brief-sibling-gaps');
+
+const fixture = (extras = '') => `# Product Brief
+
+## Out of scope (sibling-owned)
+- \`app/api/trpc/routers/views.ts\` — owned by ECHO-4552 (status: Done, PR: #1508). Reason: read path missing.
+- \`lib/validation/workbook-view.ts\` — owned by ECHO-4552 (status: Done). Reason: schema extension.
+
+${extras}
+
+## Other`;
+
+describe('findUnresolvedSiblingGaps', () => {
+  it('returns all entries when no decisions section exists', () => {
+    const r = findUnresolvedSiblingGaps(fixture());
+    assert.equal(r.outOfScope.length, 2);
+    assert.equal(r.decisions.length, 0);
+    assert.equal(r.unresolved.length, 2);
+    assert.equal(r.unresolved[0].surface, 'app/api/trpc/routers/views.ts');
+    assert.equal(r.unresolved[0].ticketId, 'ECHO-4552');
+  });
+
+  it('treats entries with matching decisions as resolved', () => {
+    const text = fixture(
+      '## Sibling-gap decisions\n- `app/api/trpc/routers/views.ts` — decision: wait-for-sibling; timestamp: 2026-05-13T00:00:00Z'
+    );
+    const r = findUnresolvedSiblingGaps(text);
+    assert.equal(r.outOfScope.length, 2);
+    assert.equal(r.decisions.length, 1);
+    assert.equal(r.unresolved.length, 1);
+    assert.equal(r.unresolved[0].surface, 'lib/validation/workbook-view.ts');
+  });
+
+  it('matching is case-insensitive on surface', () => {
+    const text = fixture(
+      '## Sibling-gap decisions\n- `APP/api/trpc/routers/views.ts` — decision: implement-here'
+    );
+    const r = findUnresolvedSiblingGaps(text);
+    assert.equal(r.unresolved.length, 1);
+    assert.equal(r.unresolved[0].surface, 'lib/validation/workbook-view.ts');
+  });
+
+  it('returns empty for empty / non-string input', () => {
+    assert.deepEqual(findUnresolvedSiblingGaps('').unresolved, []);
+    assert.deepEqual(findUnresolvedSiblingGaps(null).unresolved, []);
+    assert.deepEqual(findUnresolvedSiblingGaps(undefined).unresolved, []);
+  });
+
+  it('returns empty when neither section is present', () => {
+    const r = findUnresolvedSiblingGaps('# Brief\nNo sibling sections here.');
+    assert.equal(r.unresolved.length, 0);
+  });
+
+  it('skips empty bullet lines and HTML comments', () => {
+    const text = `## Out of scope (sibling-owned)
+
+<!-- a comment -->
+- \`a.ts\` — owned by GH-1 (status: Done). Reason: x.
+
+`;
+    const r = findUnresolvedSiblingGaps(text);
+    assert.equal(r.outOfScope.length, 1);
+  });
+});
+
+describe('buildSiblingGapQuestions', () => {
+  it('produces one user-scoped question per unresolved entry', () => {
+    const r = findUnresolvedSiblingGaps(fixture());
+    const qs = buildSiblingGapQuestions(r.unresolved, 'ECHO-4553');
+    assert.equal(qs.length, 2);
+    assert.equal(qs[0].scope, 'user');
+    assert.match(qs[0].questionText, /ECHO-4553/);
+    assert.match(qs[0].questionText, /ECHO-4552/);
+    assert.match(qs[0].questionText, /Implement the gap here.*or complete/);
+  });
+
+  it('handles unknown ticketId gracefully', () => {
+    const r = findUnresolvedSiblingGaps(
+      '## Out of scope (sibling-owned)\n- `surface.ts` — Reason: x.'
+    );
+    const qs = buildSiblingGapQuestions(r.unresolved, 'GH-1');
+    assert.equal(qs.length, 1);
+    assert.match(qs[0].questionText, /unknown sibling/);
+  });
+
+  it('returns [] for non-array input', () => {
+    assert.deepEqual(buildSiblingGapQuestions(null, 'X'), []);
+  });
+});

--- a/scripts/workflows/lib/__tests__/brief-spec-coverage.test.js
+++ b/scripts/workflows/lib/__tests__/brief-spec-coverage.test.js
@@ -1,0 +1,107 @@
+/**
+ * Tests for lib/brief-spec-coverage.js (Gate B parsers).
+ *
+ * Run: node --test scripts/workflows/lib/__tests__/brief-spec-coverage.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  extractP0Ids,
+  checkP0Coverage,
+  checkSiblingOosRestatement,
+} = require('../brief-spec-coverage');
+
+describe('extractP0Ids', () => {
+  it('extracts numbered list items under "### Must Have (P0)"', () => {
+    const brief = `# Brief\n\n### Must Have (P0)\n\n1. First P0\n2. Second P0\n3. Third P0\n\n### Should Have\n4. Not a P0\n`;
+    assert.deepEqual(extractP0Ids(brief), ['1', '2', '3']);
+  });
+
+  it('also accepts bulleted `**P0 #N**` style', () => {
+    const brief = `### Must Have (P0)\n\n- **P0 #1** — Foo\n- **P0 #2** — Bar\n\n### Other\n`;
+    assert.deepEqual(extractP0Ids(brief), ['1', '2']);
+  });
+
+  it('stops at the next heading', () => {
+    const brief = `### Must Have (P0)\n1. A\n2. B\n## Other\n3. C\n`;
+    assert.deepEqual(extractP0Ids(brief), ['1', '2']);
+  });
+
+  it('returns [] when no P0 section', () => {
+    assert.deepEqual(extractP0Ids('# Brief\nno p0 section'), []);
+  });
+
+  it('returns [] for non-string input', () => {
+    assert.deepEqual(extractP0Ids(null), []);
+    assert.deepEqual(extractP0Ids(undefined), []);
+  });
+});
+
+describe('checkP0Coverage', () => {
+  it('marks every P0 covered when spec mentions each ID', () => {
+    const spec = '### P0 #1 design\nfoo\n### P0 #2 design\nbar';
+    const r = checkP0Coverage(spec, ['1', '2']);
+    assert.deepEqual(r.covered, ['1', '2']);
+    assert.deepEqual(r.missing, []);
+  });
+
+  it('flags P0s with no spec reference', () => {
+    const spec = '### Section P0 #1 only';
+    const r = checkP0Coverage(spec, ['1', '2', '3']);
+    assert.deepEqual(r.covered, ['1']);
+    assert.deepEqual(r.missing.sort(), ['2', '3']);
+  });
+
+  it('matches `P0 #N` and `P0 N` forms', () => {
+    const spec = 'covers P0 #1\ncovers P0 2';
+    const r = checkP0Coverage(spec, ['1', '2']);
+    assert.deepEqual(r.missing, []);
+  });
+
+  it('handles missing inputs', () => {
+    assert.deepEqual(checkP0Coverage(null, ['1']).missing, ['1']);
+    assert.deepEqual(checkP0Coverage('foo', null).missing, []);
+  });
+});
+
+describe('checkSiblingOosRestatement', () => {
+  it('passes when brief has no OOS section', () => {
+    const r = checkSiblingOosRestatement('# Brief\nNo OOS section', '# Spec');
+    assert.equal(r.ok, true);
+  });
+
+  it('fails when brief has OOS but spec does not', () => {
+    const brief = '## Out of scope (sibling-owned)\n- `x.ts` — owned by GH-1';
+    const r = checkSiblingOosRestatement(brief, '# Spec\nno restatement');
+    assert.equal(r.ok, false);
+    assert.match(r.reason, /missing this section/i);
+  });
+
+  it('fails when spec OOS section omits brief entries', () => {
+    const brief =
+      '## Out of scope (sibling-owned)\n- `x.ts` — owned by GH-1\n- `y.ts` — owned by GH-2';
+    const spec = '## Out of scope (sibling-owned)\n- `x.ts` — owned by GH-1';
+    const r = checkSiblingOosRestatement(brief, spec);
+    assert.equal(r.ok, false);
+    assert.equal(r.missingEntries.length, 1);
+  });
+
+  it('passes when spec restates all brief OOS entries', () => {
+    const brief =
+      '## Out of scope (sibling-owned)\n- `x.ts` — owned by GH-1\n- `y.ts` — owned by GH-2';
+    const spec =
+      '## Out of scope (sibling-owned)\n- `x.ts` — owned by GH-1\n- `y.ts` — owned by GH-2';
+    const r = checkSiblingOosRestatement(brief, spec);
+    assert.equal(r.ok, true);
+  });
+
+  it('matches surfaces case-insensitively', () => {
+    const brief = '## Out of scope (sibling-owned)\n- `X.ts` — owned by GH-1';
+    const spec = '## Out of scope (sibling-owned)\n- `x.ts` — copied';
+    assert.equal(checkSiblingOosRestatement(brief, spec).ok, true);
+  });
+});

--- a/scripts/workflows/lib/__tests__/discrepancy.test.js
+++ b/scripts/workflows/lib/__tests__/discrepancy.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests for lib/discrepancy.js (Gate B').
+ *
+ * Run: node --test scripts/workflows/lib/__tests__/discrepancy.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  extractClaims,
+  compareClaims,
+  buildDiscrepancyQuestions,
+  extractRecordedDecisions,
+  filterUnresolved,
+} = require('../discrepancy');
+
+describe('extractClaims', () => {
+  it('extracts backticked tokens', () => {
+    const claims = extractClaims('use `lib/foo.ts` and `Bar.baz()`');
+    assert.ok(claims.has('lib/foo.ts'));
+    assert.ok(claims.has('bar.baz()'));
+  });
+
+  it('extracts dotted symbols (api.method form)', () => {
+    const claims = extractClaims('Call ApiClient.list to get items.');
+    assert.ok(claims.has('apiclient.list'));
+  });
+
+  it('normalizes case + strips trailing punctuation', () => {
+    const claims = extractClaims('`Foo.ts`,');
+    assert.ok(claims.has('foo.ts'));
+  });
+
+  it('returns empty set for non-string input', () => {
+    assert.equal(extractClaims(null).size, 0);
+    assert.equal(extractClaims(undefined).size, 0);
+  });
+});
+
+describe('compareClaims', () => {
+  it('identifies claims missing in lower-precedence', () => {
+    const r = compareClaims('`a.ts` `b.ts` `c.ts`', '`a.ts` `b.ts`');
+    assert.deepEqual(r.missingInLower, ['c.ts']);
+    assert.deepEqual(r.extraInLower, []);
+  });
+
+  it('identifies claims invented in lower-precedence', () => {
+    const r = compareClaims('`a.ts`', '`a.ts` `b.ts` `c.ts`');
+    assert.deepEqual(r.missingInLower, []);
+    assert.deepEqual(r.extraInLower.sort(), ['b.ts', 'c.ts']);
+  });
+
+  it('returns empty when identical', () => {
+    const r = compareClaims('`a.ts` `b.ts`', '`a.ts` `b.ts`');
+    assert.deepEqual(r.missingInLower, []);
+    assert.deepEqual(r.extraInLower, []);
+  });
+
+  it('accepts Set inputs', () => {
+    const h = new Set(['x', 'y']);
+    const l = new Set(['x']);
+    const r = compareClaims(h, l);
+    assert.deepEqual(r.missingInLower, ['y']);
+  });
+});
+
+describe('buildDiscrepancyQuestions', () => {
+  it('creates one question per claim with explanatory text', () => {
+    const cmp = { missingInLower: ['x.ts'], extraInLower: ['y.ts'] };
+    const qs = buildDiscrepancyQuestions(cmp, 'user prompt', 'brief');
+    assert.equal(qs.length, 2);
+    assert.equal(qs[0].scope, 'user');
+    assert.match(qs[0].questionText, /user prompt mentions `x\.ts`/);
+    assert.match(qs[0].questionText, /brief/);
+    assert.match(qs[1].questionText, /brief introduces `y\.ts`/);
+    assert.match(qs[1].questionText, /scope creep/);
+  });
+
+  it('returns [] for null comparison', () => {
+    assert.deepEqual(buildDiscrepancyQuestions(null, 'a', 'b'), []);
+  });
+});
+
+describe('extractRecordedDecisions + filterUnresolved', () => {
+  it('reads claim tokens from a "## Discrepancy decisions" section', () => {
+    const text = `## Discrepancy decisions
+- \`a.ts\` — decision: keep; timestamp: 2026-05-13T00:00Z
+- \`b.ts\` — decision: drop; timestamp: 2026-05-13T00:00Z
+`;
+    const decisions = extractRecordedDecisions(text);
+    assert.ok(decisions.has('a.ts'));
+    assert.ok(decisions.has('b.ts'));
+  });
+
+  it('returns empty set when no decisions section', () => {
+    assert.equal(extractRecordedDecisions('# Brief').size, 0);
+  });
+
+  it('filterUnresolved removes questions with recorded decisions', () => {
+    const qs = [
+      { questionText: '...', scope: 'user', rationale: 'Discrepancy: claim "a.ts" present' },
+      { questionText: '...', scope: 'user', rationale: 'Discrepancy: claim "c.ts" present' },
+    ];
+    const decisions = new Set(['a.ts']);
+    const left = filterUnresolved(qs, decisions);
+    assert.equal(left.length, 1);
+    assert.match(left[0].rationale, /c\.ts/);
+  });
+
+  it('filterUnresolved returns [] for non-array', () => {
+    assert.deepEqual(filterUnresolved(null, new Set()), []);
+  });
+});

--- a/scripts/workflows/lib/__tests__/pr-state.test.js
+++ b/scripts/workflows/lib/__tests__/pr-state.test.js
@@ -1,0 +1,47 @@
+/**
+ * Tests for lib/pr-state.js (Gate F detector).
+ *
+ * Run: node --test scripts/workflows/lib/__tests__/pr-state.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isPrClosedWithoutMerge } = require('../pr-state');
+
+describe('isPrClosedWithoutMerge', () => {
+  it('false for missing inputs', () => {
+    assert.equal(isPrClosedWithoutMerge(null), false);
+    assert.equal(isPrClosedWithoutMerge(undefined), false);
+    assert.equal(isPrClosedWithoutMerge({}), false);
+    assert.equal(isPrClosedWithoutMerge({ pr: null }), false);
+  });
+
+  it('true when state == CLOSED', () => {
+    assert.equal(isPrClosedWithoutMerge({ pr: { state: 'CLOSED' } }), true);
+    assert.equal(isPrClosedWithoutMerge({ pr: { state: 'closed' } }), true);
+  });
+
+  it('false when state == MERGED', () => {
+    assert.equal(isPrClosedWithoutMerge({ pr: { state: 'MERGED' } }), false);
+    assert.equal(isPrClosedWithoutMerge({ pr: { state: 'merged' } }), false);
+  });
+
+  it('false when state == OPEN', () => {
+    assert.equal(isPrClosedWithoutMerge({ pr: { state: 'OPEN' } }), false);
+  });
+
+  it('honors boolean shape (closed=true, merged=false)', () => {
+    assert.equal(isPrClosedWithoutMerge({ pr: { closed: true, merged: false } }), true);
+  });
+
+  it('false when merged=true even if closed=true', () => {
+    assert.equal(isPrClosedWithoutMerge({ pr: { closed: true, merged: true } }), false);
+  });
+
+  it('reads alternate location `_prState`', () => {
+    assert.equal(isPrClosedWithoutMerge({ _prState: { state: 'CLOSED' } }), true);
+  });
+});

--- a/scripts/workflows/lib/__tests__/protect-artifact-files.test.js
+++ b/scripts/workflows/lib/__tests__/protect-artifact-files.test.js
@@ -148,6 +148,26 @@ describe('createArtifactProtector', () => {
     assert.equal(result.blocked, false);
   });
 
+  it('recovery: brief.md is writable during brief_gate (Gate A / open questions)', () => {
+    const p = createArtifactProtector({
+      artifacts: [{ basename: 'brief.md', step: 'brief', allowedSteps: ['brief_gate'] }],
+      getStepInProgress: () => 'brief_gate',
+      getTicketId: () => TICKET,
+    });
+    const result = p.check('Write', { file_path: `/tasks/${TICKET}/brief.md` });
+    assert.equal(result.blocked, false);
+  });
+
+  it('recovery: spec.md is writable during spec_gate (Gate B / gherkin fix)', () => {
+    const p = createArtifactProtector({
+      artifacts: [{ basename: 'spec.md', step: 'spec', allowedSteps: ['spec_gate'] }],
+      getStepInProgress: () => 'spec_gate',
+      getTicketId: () => TICKET,
+    });
+    const result = p.check('Write', { file_path: `/tasks/${TICKET}/spec.md` });
+    assert.equal(result.blocked, false);
+  });
+
   it('blocks artifact when neither primary step nor allowedSteps is in_progress', () => {
     const p = createArtifactProtector({
       artifacts: [{ basename: 'tasks.md', step: 'tasks', allowedSteps: ['task_review'] }],

--- a/scripts/workflows/lib/__tests__/related-tickets.test.js
+++ b/scripts/workflows/lib/__tests__/related-tickets.test.js
@@ -1,0 +1,193 @@
+/**
+ * Tests for lib/related-tickets.js
+ *
+ * Run: node --test scripts/workflows/lib/__tests__/related-tickets.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const rt = require('../related-tickets');
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'related-tickets-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const validManifest = () => ({
+  self: { id: 'GH-279', title: 'x', status: 'In Progress' },
+  parent: { id: 'GH-200', title: 'p', status: 'Open' },
+  siblings: [{ id: 'GH-280', title: 's', status: 'Done', prNumber: 1508, surfaces: ['lib/a.ts'] }],
+  blockedBy: [],
+  dependsOn: [],
+  relatedTo: [{ id: 'GH-100', status: 'Done', prNumber: 999 }],
+  fetchedAt: new Date().toISOString(),
+});
+
+describe('manifestPath', () => {
+  it('joins tasksDir + ARTIFACT_FILENAME', () => {
+    const p = rt.manifestPath('/tmp/xyz', path);
+    assert.equal(p, path.join('/tmp/xyz', 'related-tickets.json'));
+  });
+});
+
+describe('validate', () => {
+  it('accepts a fully valid manifest', () => {
+    const { valid, errors } = rt.validate(validManifest());
+    assert.equal(valid, true, errors.join('; '));
+    assert.deepEqual(errors, []);
+  });
+
+  it('rejects non-object input', () => {
+    assert.equal(rt.validate(null).valid, false);
+    assert.equal(rt.validate('hi').valid, false);
+    assert.equal(rt.validate(42).valid, false);
+  });
+
+  it('requires self.id', () => {
+    const m = validManifest();
+    delete m.self.id;
+    const { valid, errors } = rt.validate(m);
+    assert.equal(valid, false);
+    assert.match(errors.join('|'), /self\.id/);
+  });
+
+  it('allows parent: null', () => {
+    const m = validManifest();
+    m.parent = null;
+    assert.equal(rt.validate(m).valid, true);
+  });
+
+  it('rejects parent without id', () => {
+    const m = validManifest();
+    m.parent = { title: 'no id here' };
+    assert.equal(rt.validate(m).valid, false);
+  });
+
+  it('rejects missing siblings array', () => {
+    const m = validManifest();
+    delete m.siblings;
+    const { valid, errors } = rt.validate(m);
+    assert.equal(valid, false);
+    assert.match(errors.join('|'), /siblings.*array/);
+  });
+
+  it('rejects sibling without id', () => {
+    const m = validManifest();
+    m.siblings.push({ title: 'no id' });
+    assert.equal(rt.validate(m).valid, false);
+  });
+
+  it('rejects bad fetchedAt', () => {
+    const m = validManifest();
+    m.fetchedAt = 'not a date';
+    assert.equal(rt.validate(m).valid, false);
+  });
+
+  it('accepts empty link arrays', () => {
+    const m = validManifest();
+    m.siblings = [];
+    m.relatedTo = [];
+    assert.equal(rt.validate(m).valid, true);
+  });
+});
+
+describe('read / readAndValidate', () => {
+  it('returns null when file missing', () => {
+    assert.equal(rt.read(tmpDir, { fs, path }), null);
+  });
+
+  it('readAndValidate flags missing file', () => {
+    const r = rt.readAndValidate(tmpDir, { fs, path });
+    assert.equal(r.missing, true);
+    assert.equal(r.valid, false);
+  });
+
+  it('readAndValidate flags invalid JSON', () => {
+    fs.writeFileSync(path.join(tmpDir, 'related-tickets.json'), '{not json');
+    const r = rt.readAndValidate(tmpDir, { fs, path });
+    assert.equal(r.missing, false);
+    assert.equal(r.valid, false);
+    assert.match(r.errors.join('|'), /JSON/);
+  });
+
+  it('readAndValidate flags schema errors', () => {
+    fs.writeFileSync(path.join(tmpDir, 'related-tickets.json'), JSON.stringify({ self: {} }));
+    const r = rt.readAndValidate(tmpDir, { fs, path });
+    assert.equal(r.valid, false);
+    assert.ok(r.errors.length > 0);
+  });
+
+  it('readAndValidate accepts valid manifest on disk', () => {
+    fs.writeFileSync(path.join(tmpDir, 'related-tickets.json'), JSON.stringify(validManifest()));
+    const r = rt.readAndValidate(tmpDir, { fs, path });
+    assert.equal(r.valid, true);
+    assert.deepEqual(r.errors, []);
+    assert.ok(r.manifest);
+  });
+});
+
+describe('isStale', () => {
+  it('treats missing fetchedAt as stale', () => {
+    assert.equal(rt.isStale(null, new Date()), true);
+    assert.equal(rt.isStale({}, new Date()), true);
+  });
+
+  it('returns true when fetchedAt < runStartedAt', () => {
+    const old = new Date(Date.now() - 60_000).toISOString();
+    assert.equal(rt.isStale({ fetchedAt: old }, new Date()), true);
+  });
+
+  it('returns false when fetchedAt >= runStartedAt', () => {
+    const start = new Date(Date.now() - 60_000);
+    const fresh = new Date().toISOString();
+    assert.equal(rt.isStale({ fetchedAt: fresh }, start), false);
+  });
+
+  it('handles ISO string for runStartedAt', () => {
+    const start = new Date(Date.now() - 60_000).toISOString();
+    const fresh = new Date().toISOString();
+    assert.equal(rt.isStale({ fetchedAt: fresh }, start), false);
+  });
+});
+
+describe('siblingIds', () => {
+  it('returns [] for null', () => {
+    assert.deepEqual(rt.siblingIds(null), []);
+  });
+
+  it('flattens unique IDs across parent + siblings + linkages', () => {
+    const m = validManifest();
+    m.blockedBy = [{ id: 'GH-200' }]; // duplicate of parent
+    const ids = rt.siblingIds(m);
+    assert.deepEqual(ids.sort(), ['GH-100', 'GH-200', 'GH-280']);
+  });
+});
+
+describe('siblingSurfaces', () => {
+  it('returns [] for null', () => {
+    assert.deepEqual(rt.siblingSurfaces(null), []);
+  });
+
+  it('collects unique surfaces across parent + siblings + linkages', () => {
+    const m = validManifest();
+    m.parent.surfaces = ['lib/parent.ts', 'lib/a.ts']; // 'lib/a.ts' duplicate of sibling
+    m.blockedBy = [{ id: 'GH-X', surfaces: ['app/x.ts'] }];
+    const surfaces = rt.siblingSurfaces(m);
+    assert.deepEqual(surfaces.sort(), ['app/x.ts', 'lib/a.ts', 'lib/parent.ts']);
+  });
+
+  it('ignores non-string surface entries', () => {
+    const m = validManifest();
+    m.siblings[0].surfaces = ['ok.ts', 42, null, '', 'other.ts'];
+    assert.deepEqual(rt.siblingSurfaces(m).sort(), ['ok.ts', 'other.ts']);
+  });
+});

--- a/scripts/workflows/lib/__tests__/scope-diff.test.js
+++ b/scripts/workflows/lib/__tests__/scope-diff.test.js
@@ -1,0 +1,103 @@
+/**
+ * Tests for lib/scope-diff.js (Gate E).
+ *
+ * Run: node --test scripts/workflows/lib/__tests__/scope-diff.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { compareDiffToScope, summarizeScopeDiff } = require('../scope-diff');
+
+describe('compareDiffToScope', () => {
+  it('classifies each file into one of three buckets', () => {
+    const tasks = [
+      { filesInScope: ['lib/**'], filesOutOfScope: ['app/api/routers/**'] },
+      { filesInScope: ['tests/**/*.test.js'], filesOutOfScope: [] },
+    ];
+    const diff = [
+      'lib/foo.ts',
+      'lib/sub/bar.ts',
+      'tests/x/y.test.js',
+      'app/api/routers/views.ts',
+      'scripts/random.sh',
+    ];
+    const r = compareDiffToScope(diff, tasks);
+    assert.deepEqual(r.inScope.sort(), ['lib/foo.ts', 'lib/sub/bar.ts', 'tests/x/y.test.js']);
+    assert.deepEqual(r.outOfScope, ['app/api/routers/views.ts']);
+    assert.deepEqual(r.unaccounted, ['scripts/random.sh']);
+    assert.deepEqual(r.totals, { inScope: 3, outOfScope: 1, unaccounted: 1, total: 5 });
+  });
+
+  it('out-of-scope wins over in-scope (precedence)', () => {
+    const tasks = [{ filesInScope: ['lib/**'], filesOutOfScope: ['lib/validation/**'] }];
+    const r = compareDiffToScope(['lib/validation/zod.ts'], tasks);
+    assert.deepEqual(r.outOfScope, ['lib/validation/zod.ts']);
+    assert.deepEqual(r.inScope, []);
+  });
+
+  it('uses legacy suggestedScope when filesInScope is missing', () => {
+    const tasks = [
+      {
+        suggestedScope: '- lib/legacy.ts\n- app/x.ts',
+        filesOutOfScope: [],
+      },
+    ];
+    const r = compareDiffToScope(['lib/legacy.ts', 'unrelated.ts'], tasks);
+    assert.deepEqual(r.inScope, ['lib/legacy.ts']);
+    assert.deepEqual(r.unaccounted, ['unrelated.ts']);
+  });
+
+  it('returns empty result for empty inputs', () => {
+    const r = compareDiffToScope([], []);
+    assert.deepEqual(r.totals, { inScope: 0, outOfScope: 0, unaccounted: 0, total: 0 });
+  });
+
+  it('handles non-array inputs gracefully', () => {
+    assert.equal(compareDiffToScope(null, []).totals.total, 0);
+    assert.equal(compareDiffToScope([], null).totals.total, 0);
+  });
+
+  it('normalizes backslash paths to forward slashes', () => {
+    const tasks = [{ filesInScope: ['lib/foo.ts'] }];
+    const r = compareDiffToScope(['lib\\foo.ts'], tasks);
+    assert.deepEqual(r.inScope, ['lib/foo.ts']);
+  });
+
+  it('skips non-string entries in the diff', () => {
+    const tasks = [{ filesInScope: ['lib/**'] }];
+    const r = compareDiffToScope(['lib/x.ts', null, '', 42, 'lib/y.ts'], tasks);
+    assert.deepEqual(r.inScope.sort(), ['lib/x.ts', 'lib/y.ts']);
+  });
+});
+
+describe('summarizeScopeDiff', () => {
+  it('includes counts and per-file lists', () => {
+    const r = compareDiffToScope(
+      ['lib/x.ts', 'app/sibling.ts', 'random.ts'],
+      [{ filesInScope: ['lib/**'], filesOutOfScope: ['app/**'] }]
+    );
+    const text = summarizeScopeDiff(r);
+    assert.match(text, /Scope-diff summary/);
+    assert.match(text, /in scope: +1/);
+    assert.match(text, /out of scope: +1/);
+    assert.match(text, /unaccounted: +1/);
+    assert.match(text, /Sibling-owned/);
+    assert.match(text, /app\/sibling\.ts/);
+    assert.match(text, /Unaccounted/);
+    assert.match(text, /random\.ts/);
+  });
+
+  it('omits sections when their buckets are empty', () => {
+    const r = compareDiffToScope(['lib/x.ts'], [{ filesInScope: ['lib/**'] }]);
+    const text = summarizeScopeDiff(r);
+    assert.doesNotMatch(text, /Sibling-owned/);
+    assert.doesNotMatch(text, /Unaccounted/);
+  });
+
+  it('returns empty string for null', () => {
+    assert.equal(summarizeScopeDiff(null), '');
+  });
+});

--- a/scripts/workflows/lib/__tests__/task-scope.test.js
+++ b/scripts/workflows/lib/__tests__/task-scope.test.js
@@ -30,22 +30,41 @@ describe('validateTask', () => {
     assert.deepEqual(errors, []);
   });
 
-  it('fails when filesInScope is missing', () => {
+  it('fails when both filesInScope and suggestedScope are missing', () => {
     const errors = ts.validateTask({ num: 2, filesOutOfScope: [] });
     assert.equal(errors.length, 1);
     assert.match(errors[0], /Task 2/);
     assert.match(errors[0], /Files in scope/);
   });
 
-  it('fails when filesInScope is empty', () => {
-    const errors = ts.validateTask({ num: 3, filesInScope: [], filesOutOfScope: [] });
+  it('fails when both filesInScope and suggestedScope are empty', () => {
+    const errors = ts.validateTask({
+      num: 3,
+      filesInScope: [],
+      suggestedScope: '',
+      filesOutOfScope: [],
+    });
     assert.equal(errors.length, 1);
-    assert.match(errors[0], /Files in scope/);
   });
 
-  it('fails when filesOutOfScope is not an array', () => {
+  it('accepts legacy suggestedScope as fallback when filesInScope is missing', () => {
+    const errors = ts.validateTask({
+      num: 5,
+      filesInScope: [],
+      suggestedScope: '- lib/x.ts',
+      filesOutOfScope: [],
+    });
+    assert.deepEqual(errors, []);
+  });
+
+  it('fails when filesOutOfScope is non-array (malformed)', () => {
     const errors = ts.validateTask({ num: 4, filesInScope: ['x.ts'], filesOutOfScope: 'oops' });
     assert.match(errors.join('|'), /out of scope/);
+  });
+
+  it('tolerates missing filesOutOfScope (legacy task)', () => {
+    const errors = ts.validateTask({ num: 6, filesInScope: ['x.ts'] });
+    assert.deepEqual(errors, []);
   });
 
   it('handles non-object input gracefully', () => {

--- a/scripts/workflows/lib/__tests__/task-scope.test.js
+++ b/scripts/workflows/lib/__tests__/task-scope.test.js
@@ -1,0 +1,121 @@
+/**
+ * Tests for lib/task-scope.js (Gate C validators).
+ *
+ * Run: node --test scripts/workflows/lib/__tests__/task-scope.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const ts = require('../task-scope');
+
+describe('validateTask', () => {
+  it('passes when both sections are populated', () => {
+    const errors = ts.validateTask({
+      num: 1,
+      filesInScope: ['lib/x.ts'],
+      filesOutOfScope: ['lib/y.ts'],
+    });
+    assert.deepEqual(errors, []);
+  });
+
+  it('passes with empty filesOutOfScope (no siblings)', () => {
+    const errors = ts.validateTask({
+      num: 1,
+      filesInScope: ['lib/x.ts'],
+      filesOutOfScope: [],
+    });
+    assert.deepEqual(errors, []);
+  });
+
+  it('fails when filesInScope is missing', () => {
+    const errors = ts.validateTask({ num: 2, filesOutOfScope: [] });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Task 2/);
+    assert.match(errors[0], /Files in scope/);
+  });
+
+  it('fails when filesInScope is empty', () => {
+    const errors = ts.validateTask({ num: 3, filesInScope: [], filesOutOfScope: [] });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Files in scope/);
+  });
+
+  it('fails when filesOutOfScope is not an array', () => {
+    const errors = ts.validateTask({ num: 4, filesInScope: ['x.ts'], filesOutOfScope: 'oops' });
+    assert.match(errors.join('|'), /out of scope/);
+  });
+
+  it('handles non-object input gracefully', () => {
+    assert.deepEqual(ts.validateTask(null), ['task must be an object']);
+    assert.deepEqual(ts.validateTask(undefined), ['task must be an object']);
+  });
+});
+
+describe('validateAll', () => {
+  it('returns valid:true when all tasks pass', () => {
+    const result = ts.validateAll([
+      { num: 1, filesInScope: ['a.ts'], filesOutOfScope: [] },
+      { num: 2, filesInScope: ['b.ts'], filesOutOfScope: ['c.ts'] },
+    ]);
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.errors, []);
+  });
+
+  it('aggregates errors across all tasks', () => {
+    const result = ts.validateAll([
+      { num: 1, filesInScope: [], filesOutOfScope: [] },
+      { num: 2, filesOutOfScope: 'bad' },
+    ]);
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.length >= 2);
+    assert.match(result.errors.join('|'), /Task 1/);
+    assert.match(result.errors.join('|'), /Task 2/);
+  });
+
+  it('fails on empty or non-array input', () => {
+    assert.equal(ts.validateAll([]).valid, false);
+    assert.equal(ts.validateAll(null).valid, false);
+    assert.equal(ts.validateAll(undefined).valid, false);
+  });
+});
+
+describe('unionFilesInScope', () => {
+  it('returns deduped union across tasks', () => {
+    const out = ts.unionFilesInScope([
+      { num: 1, filesInScope: ['a.ts', 'b.ts'] },
+      { num: 2, filesInScope: ['b.ts', 'c.ts'] },
+    ]);
+    assert.deepEqual(out.sort(), ['a.ts', 'b.ts', 'c.ts']);
+  });
+
+  it('tolerates missing filesInScope', () => {
+    const out = ts.unionFilesInScope([{ num: 1 }, { num: 2, filesInScope: ['x.ts'] }]);
+    assert.deepEqual(out, ['x.ts']);
+  });
+
+  it('returns [] for non-array', () => {
+    assert.deepEqual(ts.unionFilesInScope(null), []);
+  });
+});
+
+describe('findTask', () => {
+  it('finds by task num', () => {
+    const tasks = [
+      { num: 1, filesInScope: ['a'] },
+      { num: 2, filesInScope: ['b'] },
+    ];
+    assert.equal(ts.findTask(tasks, 2).filesInScope[0], 'b');
+  });
+
+  it('returns null when not found', () => {
+    assert.equal(ts.findTask([{ num: 1 }], 9), null);
+  });
+
+  it('returns null for bad input', () => {
+    assert.equal(ts.findTask(null, 1), null);
+    assert.equal(ts.findTask([{ num: 1 }], 'nope'), null);
+  });
+});

--- a/scripts/workflows/lib/brief-sibling-gaps.js
+++ b/scripts/workflows/lib/brief-sibling-gaps.js
@@ -1,0 +1,143 @@
+/**
+ * brief-sibling-gaps.js
+ *
+ * Gate A — parses two sections out of `tasks/<ticket>/brief.md`:
+ *   - `## Out of scope (sibling-owned)` — declarations that a needed surface
+ *     is owned by a sibling ticket. The brief-writer is required to put one
+ *     entry per surface here, formatted as a bullet line.
+ *   - `## Sibling-gap decisions` — the user's recorded choice per entry:
+ *     either "implement here as an exception" or "wait for sibling".
+ *
+ * The validator returns any out-of-scope entries that lack a matching
+ * decision. The brief-gate enrichment uses those to drive AskUserQuestion.
+ *
+ * Pure module — no fs / no MCP / no agent calls.
+ */
+
+'use strict';
+
+const SECTION_HEADERS = {
+  outOfScope: /^##\s+Out of scope\s+\(sibling-owned\)\s*$/im,
+  decisions: /^##\s+Sibling-gap decisions\s*$/im,
+};
+
+function _sliceSection(text, headerRe) {
+  const m = text.match(headerRe);
+  if (!m) return null;
+  const start = m.index + m[0].length;
+  const after = text.slice(start);
+  const next = after.match(/^##\s/m);
+  return next ? after.slice(0, next.index) : after;
+}
+
+function _parseBulletEntries(body) {
+  if (!body) return [];
+  const lines = body.split('\n');
+  const entries = [];
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('<!--')) continue;
+    if (!/^[-*+]\s+/.test(line)) continue;
+    entries.push(line.replace(/^[-*+]\s+/, '').trim());
+  }
+  return entries;
+}
+
+/**
+ * Extract a sibling ticket ID from an Out-of-scope entry. Entries follow
+ * the brief-writer template:
+ *   - `<SURFACE>` — owned by <TICKET-ID> (status: <STATUS>, PR: <#N>). Reason: <text>.
+ * The ticket ID is required for AskUserQuestion phrasing.
+ *
+ * @param {string} entry
+ * @returns {{ surface:string, ticketId:string|null, raw:string }}
+ */
+function _decomposeOosEntry(entry) {
+  const ownedBy = entry.match(/owned by\s+([A-Z]+-\d+|GH-\d+|#\d+)/i);
+  const ticketId = ownedBy ? ownedBy[1] : null;
+  // Surface is the leading token, optionally backtick-wrapped. Stop at the
+  // first ` — ` (space-emdash-space), ` -- `, or `  ` separator. Hyphens
+  // INSIDE a path are kept (e.g. `lib/validation/workbook-view.ts`).
+  let surface;
+  const backtickMatch = entry.match(/^`([^`]+)`/);
+  if (backtickMatch) {
+    surface = backtickMatch[1].trim();
+  } else {
+    const sepMatch = entry.match(/^(.+?)(?:\s+—\s+|\s+--\s+|\s+owned by\s+)/i);
+    surface = sepMatch ? sepMatch[1].trim() : entry.split(/\s+/)[0];
+  }
+  return { surface, ticketId, raw: entry };
+}
+
+/**
+ * Parse a Sibling-gap decisions entry. Expected formats produced by
+ * brief_gate's AskUserQuestion persistence:
+ *   - `<SURFACE>` — decision: implement-here; timestamp: 2026-05-13T...
+ *   - `<SURFACE>` — decision: wait-for-sibling; …
+ * For matching purposes only the surface token matters.
+ *
+ * @param {string} entry
+ * @returns {{ surface:string, raw:string }}
+ */
+function _decomposeDecisionEntry(entry) {
+  let surface;
+  const backtickMatch = entry.match(/^`([^`]+)`/);
+  if (backtickMatch) {
+    surface = backtickMatch[1].trim();
+  } else {
+    const sepMatch = entry.match(/^(.+?)(?:\s+—\s+|\s+--\s+)/);
+    surface = sepMatch ? sepMatch[1].trim() : entry.split(/\s+/)[0];
+  }
+  return { surface, raw: entry };
+}
+
+/**
+ * Compare Out-of-scope entries against recorded decisions. Returns entries
+ * that have no matching decision (by surface string, case-insensitive).
+ *
+ * @param {string} briefText
+ * @returns {{ outOfScope: Array<object>, decisions: Array<object>, unresolved: Array<object> }}
+ */
+function findUnresolvedSiblingGaps(briefText) {
+  if (typeof briefText !== 'string' || briefText.length === 0) {
+    return { outOfScope: [], decisions: [], unresolved: [] };
+  }
+  const oosBody = _sliceSection(briefText, SECTION_HEADERS.outOfScope);
+  const decBody = _sliceSection(briefText, SECTION_HEADERS.decisions);
+  const outOfScope = _parseBulletEntries(oosBody).map(_decomposeOosEntry);
+  const decisions = _parseBulletEntries(decBody).map(_decomposeDecisionEntry);
+  const decided = new Set(decisions.map((d) => d.surface.toLowerCase()));
+  const unresolved = outOfScope.filter((e) => !decided.has(e.surface.toLowerCase()));
+  return { outOfScope, decisions, unresolved };
+}
+
+/**
+ * Build AskUserQuestion-shaped questions for each unresolved gap. Surface
+ * the sibling ticket ID in the question text so the user can decide
+ * informed.
+ *
+ * @param {Array<{surface:string, ticketId:string|null, raw:string}>} unresolved
+ * @param {string} currentTicketId
+ * @returns {Array<{questionText:string, scope:'user', rationale:string}>}
+ */
+function buildSiblingGapQuestions(unresolved, currentTicketId) {
+  if (!Array.isArray(unresolved)) return [];
+  return unresolved.map((u) => {
+    const owner = u.ticketId || 'unknown sibling';
+    const here = currentTicketId || 'current ticket';
+    return {
+      questionText:
+        `Surface "${u.surface}" is needed for ${here} but is owned by sibling ${owner}. ` +
+        `Implement the gap here as an exception, or complete ${owner} first?`,
+      scope: 'user',
+      rationale: u.raw,
+    };
+  });
+}
+
+module.exports = {
+  findUnresolvedSiblingGaps,
+  buildSiblingGapQuestions,
+  _decomposeOosEntry,
+  _decomposeDecisionEntry,
+};

--- a/scripts/workflows/lib/brief-spec-coverage.js
+++ b/scripts/workflows/lib/brief-spec-coverage.js
@@ -1,0 +1,142 @@
+/**
+ * brief-spec-coverage.js
+ *
+ * Gate B — pure parsers + coverage check for the brief↔spec contract.
+ *
+ * Rules enforced:
+ *   1. Every P0 ID in the brief's `### Must Have (P0)` section MUST appear
+ *      somewhere in the spec (either as a heading anchor `### P0 #N` or
+ *      as an explicit reference like "covers P0 #1" / "P0 #1:" in a section).
+ *   2. The spec MUST restate the brief's `## Out of scope (sibling-owned)`
+ *      section verbatim under its own `## Out of scope (sibling-owned)`
+ *      heading. (Gate A's surfaces remain forbidden in the spec.)
+ *
+ * No fs, no MCP, no agents — pure text in / structured result out.
+ */
+
+'use strict';
+
+const P0_HEADING_RE = /^###\s+Must Have\s*\(P0\)\s*$/im;
+
+/**
+ * Extract P0 IDs from a brief's `### Must Have (P0)` section.
+ * Accepts numbered items (`1.`, `2.`) and bulleted items prefixed by `**P0 #N**`.
+ * Returns an ordered, deduplicated list of IDs as strings like "1", "2".
+ *
+ * @param {string} briefText
+ * @returns {string[]}
+ */
+function extractP0Ids(briefText) {
+  if (typeof briefText !== 'string' || briefText.length === 0) return [];
+  const m = briefText.match(P0_HEADING_RE);
+  if (!m) return [];
+  const after = briefText.slice(m.index + m[0].length);
+  const stop = after.match(/^###\s+|^##\s+/m);
+  const body = stop ? after.slice(0, stop.index) : after;
+  const ids = [];
+  const seen = new Set();
+  const lineRe = /(?:^|\n)\s*(?:(\d+)\.\s+|[-*+]\s+\*\*?P0\s*#(\d+)\*\*?\s*[:\-—]?\s*)/g;
+  let match;
+  while ((match = lineRe.exec(body)) !== null) {
+    const id = match[1] || match[2];
+    if (!id) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * Check whether a spec mentions each P0 ID. Acceptance criteria for a
+ * "covered" P0:
+ *   - The spec has a heading containing `P0 #N` (any heading level), OR
+ *   - The spec body contains a line matching `(?:^|\W)P0\s*#?N(?:\D|$)` AND that
+ *     line is within a recognizable section (heuristic: any `###` or `####`
+ *     heading appearing in spec, no further constraint).
+ * Conservative: accept any occurrence of `P0 #N` in the spec text.
+ *
+ * @param {string} specText
+ * @param {string[]} p0Ids
+ * @returns {{ covered: string[], missing: string[] }}
+ */
+function checkP0Coverage(specText, p0Ids) {
+  if (typeof specText !== 'string' || !Array.isArray(p0Ids)) {
+    return { covered: [], missing: Array.isArray(p0Ids) ? p0Ids.slice() : [] };
+  }
+  const covered = [];
+  const missing = [];
+  for (const id of p0Ids) {
+    const re = new RegExp(`(?:^|\\W)P0\\s*#?${id}(?:\\D|$)`, 'm');
+    if (re.test(specText)) covered.push(id);
+    else missing.push(id);
+  }
+  return { covered, missing };
+}
+
+/**
+ * Verify the spec restates the brief's `## Out of scope (sibling-owned)`
+ * section. Match is lossy — we require the heading to be present in the
+ * spec AND at least one entry from the brief's OOS section to appear in
+ * the spec's OOS section.
+ *
+ * @param {string} briefText
+ * @param {string} specText
+ * @returns {{ ok: boolean, reason?: string, missingEntries?: string[] }}
+ */
+function checkSiblingOosRestatement(briefText, specText) {
+  if (typeof briefText !== 'string' || typeof specText !== 'string') {
+    return { ok: true };
+  }
+  const briefOos = _extractSectionBody(briefText, /^##\s+Out of scope\s*\(sibling-owned\)\s*$/im);
+  if (!briefOos) return { ok: true }; // nothing to restate
+  const specOos = _extractSectionBody(specText, /^##\s+Out of scope\s*\(sibling-owned\)\s*$/im);
+  if (!specOos) {
+    return {
+      ok: false,
+      reason:
+        'brief has `## Out of scope (sibling-owned)` but the spec is missing this section. Restate it verbatim.',
+    };
+  }
+  const briefEntries = _parseBullets(briefOos);
+  const specEntries = _parseBullets(specOos);
+  const specSet = new Set(specEntries.map((e) => _surfaceToken(e)));
+  const missing = briefEntries.filter((e) => !specSet.has(_surfaceToken(e)));
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      reason: 'spec OOS section is missing entries from brief OOS section',
+      missingEntries: missing,
+    };
+  }
+  return { ok: true };
+}
+
+function _extractSectionBody(text, headerRe) {
+  const m = text.match(headerRe);
+  if (!m) return null;
+  const after = text.slice(m.index + m[0].length);
+  const next = after.match(/^##\s/m);
+  return next ? after.slice(0, next.index) : after;
+}
+
+function _parseBullets(body) {
+  return body
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => /^[-*+]\s+/.test(l))
+    .map((l) => l.replace(/^[-*+]\s+/, '').trim());
+}
+
+function _surfaceToken(bulletEntry) {
+  const bt = bulletEntry.match(/^`([^`]+)`/);
+  if (bt) return bt[1].toLowerCase();
+  const sep = bulletEntry.match(/^(.+?)(?:\s+—\s+|\s+--\s+|\s+owned by\s+)/i);
+  return (sep ? sep[1] : bulletEntry.split(/\s+/)[0]).toLowerCase();
+}
+
+module.exports = {
+  extractP0Ids,
+  checkP0Coverage,
+  checkSiblingOosRestatement,
+};

--- a/scripts/workflows/lib/discrepancy.js
+++ b/scripts/workflows/lib/discrepancy.js
@@ -1,0 +1,170 @@
+/**
+ * discrepancy.js
+ *
+ * Gate B' — extract "claims" (assertions about scope, files, behaviors,
+ * acceptance criteria) from one or more workflow artifacts and compare
+ * them pairwise. Highest-precedence source overrides lower-precedence;
+ * mismatches surface as questions for the user to resolve.
+ *
+ * The artifacts (in precedence order, highest first):
+ *   - user-prompt.md     — captured at bootstrap from the literal user text
+ *   - tasks.md           — split-in-tasks output
+ *   - spec.md            — spec-writer output
+ *   - brief.md           — brief-writer output
+ *   - ticket text        — fetched from the ticket provider
+ *
+ * "Claims" are normalized tokens we can compare:
+ *   - file paths / globs (backticked or quoted)
+ *   - symbols (CamelCase identifiers, snake_case names with `.` like `views.list`)
+ *   - explicit acceptance/should/must lines
+ *
+ * Pure module — no fs, no MCP, no agents. The caller passes in the
+ * artifact texts and gets back a discrepancy report.
+ */
+
+'use strict';
+
+const BACKTICKED_RE = /`([^`\n]+)`/g;
+const SYMBOL_RE = /\b([A-Z][A-Za-z0-9]+(?:\.[A-Za-z0-9_]+)+)\b/g;
+
+/**
+ * Normalize a claim token for comparison: lowercase, strip trailing
+ * punctuation, drop whitespace.
+ */
+function _normalize(token) {
+  return String(token || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[.,;:!?]+$/, '');
+}
+
+/**
+ * Extract claim tokens from one artifact's text. Returns a Set<string>.
+ * Tokens are deduped and normalized.
+ *
+ * @param {string} text
+ * @returns {Set<string>}
+ */
+function extractClaims(text) {
+  const out = new Set();
+  if (typeof text !== 'string' || text.length === 0) return out;
+
+  let m;
+  BACKTICKED_RE.lastIndex = 0;
+  while ((m = BACKTICKED_RE.exec(text)) !== null) {
+    const n = _normalize(m[1]);
+    if (n) out.add(n);
+  }
+
+  SYMBOL_RE.lastIndex = 0;
+  while ((m = SYMBOL_RE.exec(text)) !== null) {
+    const n = _normalize(m[1]);
+    if (n) out.add(n);
+  }
+
+  return out;
+}
+
+/**
+ * Compare claims across two artifacts. Returns:
+ *   - missingInLower: claims in `higher` but not `lower` (lower may be silently dropping)
+ *   - extraInLower:   claims in `lower` but not `higher` (lower may be inventing)
+ *
+ * `higher` is the higher-precedence source; `lower` is the artifact under review.
+ *
+ * @param {Set<string>|string} higher
+ * @param {Set<string>|string} lower
+ * @returns {{ missingInLower:string[], extraInLower:string[] }}
+ */
+function compareClaims(higher, lower) {
+  const hSet = higher instanceof Set ? higher : extractClaims(higher);
+  const lSet = lower instanceof Set ? lower : extractClaims(lower);
+  const missingInLower = [];
+  const extraInLower = [];
+  for (const c of hSet) if (!lSet.has(c)) missingInLower.push(c);
+  for (const c of lSet) if (!hSet.has(c)) extraInLower.push(c);
+  return { missingInLower, extraInLower };
+}
+
+/**
+ * Build AskUserQuestion-shaped questions from a discrepancy comparison.
+ * Each question phrases the drift in terms of the precedence hierarchy
+ * and offers options for the user to resolve.
+ *
+ * @param {{missingInLower:string[], extraInLower:string[]}} comparison
+ * @param {string} higherLabel - e.g. 'user prompt'
+ * @param {string} lowerLabel  - e.g. 'brief'
+ * @returns {Array<{questionText:string, scope:'user', rationale:string}>}
+ */
+function buildDiscrepancyQuestions(comparison, higherLabel, lowerLabel) {
+  if (!comparison) return [];
+  const qs = [];
+  for (const claim of comparison.missingInLower) {
+    qs.push({
+      questionText:
+        `${higherLabel} mentions \`${claim}\` but ${lowerLabel} does not. ` +
+        `Is this a drop in ${lowerLabel} that needs to be added, or was the ${higherLabel} mention out-of-date?`,
+      scope: 'user',
+      rationale: `Discrepancy: claim "${claim}" present in ${higherLabel}, absent in ${lowerLabel}.`,
+    });
+  }
+  for (const claim of comparison.extraInLower) {
+    qs.push({
+      questionText:
+        `${lowerLabel} introduces \`${claim}\` but ${higherLabel} does not mention it. ` +
+        `Is this a legitimate ${lowerLabel}-level decision, or scope creep that should be removed?`,
+      scope: 'user',
+      rationale: `Discrepancy: claim "${claim}" absent in ${higherLabel}, present in ${lowerLabel}.`,
+    });
+  }
+  return qs;
+}
+
+/**
+ * Read the "Discrepancy decisions" section from an artifact and return the
+ * set of claim tokens that already have a recorded answer. The gate uses
+ * this to avoid re-prompting on every /work2 invocation.
+ *
+ * Decisions are bullets formatted like:
+ *   - `<claim>` — decision: <text>; timestamp: <ISO>
+ *
+ * @param {string} text
+ * @returns {Set<string>}
+ */
+function extractRecordedDecisions(text) {
+  const out = new Set();
+  if (typeof text !== 'string' || text.length === 0) return out;
+  const m = text.match(/^##\s+Discrepancy decisions\s*$/im);
+  if (!m) return out;
+  const after = text.slice(m.index + m[0].length);
+  const stop = after.match(/^##\s/m);
+  const body = stop ? after.slice(0, stop.index) : after;
+  for (const raw of body.split('\n')) {
+    const line = raw.trim();
+    if (!line.startsWith('-')) continue;
+    const bt = line.match(/`([^`]+)`/);
+    if (bt) out.add(_normalize(bt[1]));
+  }
+  return out;
+}
+
+/**
+ * Filter discrepancy questions, removing any whose claim already has a
+ * recorded decision.
+ */
+function filterUnresolved(questions, decisions) {
+  if (!Array.isArray(questions)) return [];
+  if (!(decisions instanceof Set)) return questions;
+  return questions.filter((q) => {
+    const claim = (q.rationale.match(/"([^"]+)"/) || [])[1];
+    return !claim || !decisions.has(_normalize(claim));
+  });
+}
+
+module.exports = {
+  extractClaims,
+  compareClaims,
+  buildDiscrepancyQuestions,
+  extractRecordedDecisions,
+  filterUnresolved,
+};

--- a/scripts/workflows/lib/discrepancy.js
+++ b/scripts/workflows/lib/discrepancy.js
@@ -6,12 +6,24 @@
  * them pairwise. Highest-precedence source overrides lower-precedence;
  * mismatches surface as questions for the user to resolve.
  *
- * The artifacts (in precedence order, highest first):
+ * The artifacts (in precedence order, highest first). The hierarchy
+ * follows the upstream-source principle: any artifact under review at a
+ * gate must not silently drop or invent claims relative to UPSTREAM
+ * sources. Hence the literal user prompt is the highest authority, the
+ * ticket text is next (system of record), and each derived artifact
+ * (brief → spec → tasks) is lower than what it was derived from.
+ *
  *   - user-prompt.md     — captured at bootstrap from the literal user text
- *   - tasks.md           — split-in-tasks output
- *   - spec.md            — spec-writer output
- *   - brief.md           — brief-writer output
- *   - ticket text        — fetched from the ticket provider
+ *   - ticket text        — fetched from the ticket provider (system of record)
+ *   - brief.md           — brief-writer output (derived from ticket + prompt)
+ *   - spec.md            — spec-writer output (derived from brief)
+ *   - tasks.md           — split-in-tasks output (derived from spec)
+ *
+ * When `brief_gate` runs, "brief" is the lower artifact under review; the
+ * gate compares it against `user prompt` and `ticket` (both higher). When
+ * `spec_gate` runs, "spec" is the lower; compares against user prompt /
+ * ticket / brief. When `implement`'s tasks-discrepancy hook runs, "tasks"
+ * is the lower; compares against all four higher sources.
  *
  * "Claims" are normalized tokens we can compare:
  *   - file paths / globs (backticked or quoted)

--- a/scripts/workflows/lib/hooks/policies/__tests__/scope-protection.test.js
+++ b/scripts/workflows/lib/hooks/policies/__tests__/scope-protection.test.js
@@ -1,0 +1,157 @@
+/**
+ * Tests for lib/hooks/policies/scope-protection.js (Gate D policy).
+ *
+ * Run: node --test scripts/workflows/lib/hooks/policies/__tests__/scope-protection.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { decideEdit, globToRegex, relativizePath, findMatch } = require('../scope-protection');
+
+describe('globToRegex', () => {
+  it('matches exact path', () => {
+    const re = globToRegex('lib/x.ts');
+    assert.equal(re.test('lib/x.ts'), true);
+    assert.equal(re.test('lib/y.ts'), false);
+    assert.equal(re.test('lib/x.tsx'), false);
+  });
+
+  it('** matches any number of segments', () => {
+    const re = globToRegex('lib/**');
+    assert.equal(re.test('lib/a.ts'), true);
+    assert.equal(re.test('lib/a/b/c.ts'), true);
+    assert.equal(re.test('other/x.ts'), false);
+  });
+
+  it('* matches within a single segment', () => {
+    const re = globToRegex('lib/*.ts');
+    assert.equal(re.test('lib/x.ts'), true);
+    assert.equal(re.test('lib/sub/x.ts'), false);
+  });
+
+  it('? matches a single non-slash char', () => {
+    const re = globToRegex('lib/?.ts');
+    assert.equal(re.test('lib/x.ts'), true);
+    assert.equal(re.test('lib/xy.ts'), false);
+    assert.equal(re.test('lib//.ts'), false);
+  });
+
+  it('**/* combinator', () => {
+    const re = globToRegex('**/*.test.js');
+    assert.equal(re.test('lib/x.test.js'), true);
+    assert.equal(re.test('deep/nest/x.test.js'), true);
+    assert.equal(re.test('lib/x.js'), false);
+  });
+
+  it('escapes regex metachars', () => {
+    const re = globToRegex('lib/foo+bar.ts');
+    assert.equal(re.test('lib/foo+bar.ts'), true);
+    assert.equal(re.test('lib/foobar.ts'), false);
+  });
+
+  it('strips trailing slash', () => {
+    const re = globToRegex('lib/sub/');
+    assert.equal(re.test('lib/sub'), true);
+  });
+});
+
+describe('relativizePath', () => {
+  it('returns posix relative path when inside workDir', () => {
+    assert.equal(relativizePath('/repo/lib/x.ts', '/repo'), 'lib/x.ts');
+  });
+
+  it('returns null for paths outside workDir', () => {
+    assert.equal(relativizePath('/elsewhere/x.ts', '/repo'), null);
+    assert.equal(relativizePath('/tmp/abc', '/repo'), null);
+  });
+
+  it('accepts relative input', () => {
+    assert.equal(relativizePath('lib/x.ts', '/repo'), 'lib/x.ts');
+  });
+
+  it('returns null for missing inputs', () => {
+    assert.equal(relativizePath('', '/repo'), null);
+    assert.equal(relativizePath('/repo/lib/x.ts', ''), null);
+  });
+});
+
+describe('findMatch', () => {
+  it('returns first matching pattern', () => {
+    assert.equal(findMatch('lib/x.ts', ['lib/*.ts']), 'lib/*.ts');
+  });
+
+  it('returns null when no match', () => {
+    assert.equal(findMatch('lib/x.ts', ['other/*.ts']), null);
+  });
+
+  it('skips invalid entries', () => {
+    assert.equal(findMatch('lib/x.ts', [null, undefined, '', 'lib/*.ts']), 'lib/*.ts');
+  });
+
+  it('returns null for empty patterns', () => {
+    assert.equal(findMatch('lib/x.ts', []), null);
+    assert.equal(findMatch('lib/x.ts', null), null);
+  });
+});
+
+describe('decideEdit', () => {
+  const base = {
+    workDir: '/repo',
+    filesInScope: ['lib/components/**', 'tests/**/*.test.js'],
+    filesOutOfScope: ['app/api/trpc/routers/**', 'lib/validation/**'],
+    activeTask: 'Task 1',
+  };
+
+  it('allows file inside Files in scope', () => {
+    const d = decideEdit({ ...base, filePath: '/repo/lib/components/foo.ts' });
+    assert.equal(d.blocked, false);
+    assert.equal(d.category, 'allow');
+    assert.equal(d.match, 'lib/components/**');
+  });
+
+  it('blocks file matching Files explicitly out of scope (sibling-owned)', () => {
+    const d = decideEdit({ ...base, filePath: '/repo/app/api/trpc/routers/views.ts' });
+    assert.equal(d.blocked, true);
+    assert.equal(d.category, 'sibling-owned');
+    assert.match(d.reason, /sibling-owned|out of scope/i);
+    assert.match(d.reason, /views\.ts/);
+  });
+
+  it('blocks file outside both lists (out-of-scope)', () => {
+    const d = decideEdit({ ...base, filePath: '/repo/scripts/random.js' });
+    assert.equal(d.blocked, true);
+    assert.equal(d.category, 'out-of-scope');
+    assert.match(d.reason, /outside the active task/i);
+  });
+
+  it('passes through paths outside the worktree', () => {
+    const d = decideEdit({ ...base, filePath: '/tmp/x.ts' });
+    assert.equal(d.blocked, false);
+    assert.equal(d.category, 'outside-worktree');
+  });
+
+  it('precedence: out-of-scope wins over in-scope', () => {
+    const d = decideEdit({
+      ...base,
+      filesInScope: ['lib/**'],
+      filesOutOfScope: ['lib/validation/**'],
+      filePath: '/repo/lib/validation/zod.ts',
+    });
+    assert.equal(d.blocked, true);
+    assert.equal(d.category, 'sibling-owned');
+  });
+
+  it('empty in-scope blocks everything (defensive)', () => {
+    const d = decideEdit({
+      ...base,
+      filesInScope: [],
+      filesOutOfScope: [],
+      filePath: '/repo/lib/x.ts',
+    });
+    assert.equal(d.blocked, true);
+    assert.equal(d.category, 'out-of-scope');
+  });
+});

--- a/scripts/workflows/lib/hooks/policies/scope-protection.js
+++ b/scripts/workflows/lib/hooks/policies/scope-protection.js
@@ -1,0 +1,175 @@
+/**
+ * scope-protection.js
+ *
+ * Pure decision functions for Gate D — the implement-time file-edit hook.
+ *
+ * Given the active task's `filesInScope` and `filesOutOfScope` glob lists,
+ * decide whether a tool's target path should be allowed or blocked.
+ *
+ * Decision rules (in order):
+ *   1. If filePath matches ANY `filesOutOfScope` glob → BLOCK ("sibling-owned").
+ *   2. If filePath matches ANY `filesInScope` glob → ALLOW.
+ *   3. Otherwise → BLOCK ("outside declared scope").
+ *
+ * Files outside the worktree root (`workDir`) are NEVER blocked by this
+ * policy — they fall under other hooks (protect-orchestrator-state etc.).
+ *
+ * Globs supported:
+ *   - `**`  matches any number of path segments (including `/`)
+ *   - `*`   matches any sequence within a single path segment
+ *   - `?`   matches a single character (not `/`)
+ *   - exact paths match exactly
+ *   - trailing `/` is normalized away
+ *
+ * Patterns are matched against the path RELATIVE to `workDir`, normalized to
+ * forward slashes.
+ */
+
+'use strict';
+
+const path = require('path');
+
+/**
+ * Compile a glob pattern to a RegExp.
+ * Conservative implementation — handles `**`, `*`, `?`, escapes other regex
+ * metacharacters. Patterns without globs become exact-match regexes.
+ *
+ * @param {string} glob
+ * @returns {RegExp}
+ */
+function globToRegex(glob) {
+  const normalized = String(glob || '')
+    .replace(/\\/g, '/')
+    .replace(/\/+$/, '');
+  let out = '';
+  let i = 0;
+  while (i < normalized.length) {
+    const ch = normalized[i];
+    const next = normalized[i + 1];
+    if (ch === '*' && next === '*') {
+      // `**` — any number of segments
+      out += '.*';
+      i += 2;
+      // Skip a trailing `/` after `**` if present (e.g. `lib/**/foo`)
+      if (normalized[i] === '/') i += 1;
+      continue;
+    }
+    if (ch === '*') {
+      out += '[^/]*';
+      i += 1;
+      continue;
+    }
+    if (ch === '?') {
+      out += '[^/]';
+      i += 1;
+      continue;
+    }
+    if (/[.+^${}()|[\]\\]/.test(ch)) {
+      out += '\\' + ch;
+      i += 1;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return new RegExp('^' + out + '$');
+}
+
+/**
+ * Normalize a candidate filePath to a forward-slash path relative to workDir.
+ * Returns null when the candidate is OUTSIDE workDir (i.e. should not be
+ * subject to scope policy).
+ *
+ * @param {string} filePath
+ * @param {string} workDir
+ * @returns {string|null}
+ */
+function relativizePath(filePath, workDir) {
+  if (!filePath || !workDir) return null;
+  const abs = path.isAbsolute(filePath) ? filePath : path.resolve(workDir, filePath);
+  const rel = path.relative(workDir, abs);
+  if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  return rel.replace(/\\/g, '/');
+}
+
+/**
+ * Does any glob in `patterns` match `relPath`?
+ * Caches compiled regexes per call.
+ *
+ * @param {string} relPath
+ * @param {string[]} patterns
+ * @returns {string|null} matched pattern or null
+ */
+function findMatch(relPath, patterns) {
+  if (!Array.isArray(patterns) || patterns.length === 0) return null;
+  for (const p of patterns) {
+    if (!p || typeof p !== 'string') continue;
+    let re;
+    try {
+      re = globToRegex(p);
+    } catch {
+      continue;
+    }
+    if (re.test(relPath)) return p;
+  }
+  return null;
+}
+
+/**
+ * @typedef {object} ScopeDecisionInput
+ * @property {string} filePath        - The target file path (from tool input).
+ * @property {string} workDir         - Worktree / repo root.
+ * @property {string[]} filesInScope  - Globs the active task may edit.
+ * @property {string[]} filesOutOfScope - Globs the active task must NOT edit.
+ * @property {string} [activeTask]    - Human-readable label for the active task.
+ *
+ * @typedef {object} ScopeDecision
+ * @property {boolean} blocked
+ * @property {string=} reason
+ * @property {string=} match
+ * @property {string=} category    - 'sibling-owned' | 'out-of-scope' | 'allow'
+ */
+
+/**
+ * Decide on a single filePath edit.
+ *
+ * @param {ScopeDecisionInput} input
+ * @returns {ScopeDecision}
+ */
+function decideEdit(input) {
+  const { filePath, workDir, filesInScope, filesOutOfScope, activeTask } = input || {};
+  const relPath = relativizePath(filePath, workDir);
+  if (relPath === null) {
+    // Outside the worktree — not our concern.
+    return { blocked: false, category: 'outside-worktree' };
+  }
+
+  const outMatch = findMatch(relPath, filesOutOfScope);
+  if (outMatch) {
+    return {
+      blocked: true,
+      category: 'sibling-owned',
+      match: outMatch,
+      reason:
+        `BLOCKED: ${relPath} matches \`### Files explicitly out of scope\`` +
+        (activeTask ? ` for ${activeTask}` : '') +
+        ` (pattern: ${outMatch}). This file is owned by a sibling ticket — do NOT edit it from this ticket.`,
+    };
+  }
+
+  const inMatch = findMatch(relPath, filesInScope);
+  if (inMatch) {
+    return { blocked: false, category: 'allow', match: inMatch };
+  }
+
+  return {
+    blocked: true,
+    category: 'out-of-scope',
+    reason:
+      `BLOCKED: ${relPath} is outside the active task's \`### Files in scope\`` +
+      (activeTask ? ` (${activeTask})` : '') +
+      `. If this file genuinely belongs to this task, update tasks.md and re-run /work2.`,
+  };
+}
+
+module.exports = { decideEdit, globToRegex, relativizePath, findMatch };

--- a/scripts/workflows/lib/pr-state.js
+++ b/scripts/workflows/lib/pr-state.js
@@ -1,0 +1,34 @@
+/**
+ * pr-state.js
+ *
+ * Gate F — pure helper that reads `.work-state.json` (or accepts an
+ * already-loaded state object) and decides whether the PR for the active
+ * ticket has been closed without merge.
+ *
+ * Used by the follow-up enrichment: a closed-not-merged PR forces /work2
+ * back through brief (full re-plan) rather than looping through implement.
+ * This prevents the failure mode where an agent absorbed sibling scope,
+ * the user closed the PR, and the orchestrator silently retried the same
+ * scope in `implement` on the next /work2 invocation.
+ */
+
+'use strict';
+
+/**
+ * @param {object|null|undefined} workState - parsed .work-state.json
+ * @returns {boolean} true when the workflow records a CLOSED, NOT-MERGED PR
+ */
+function isPrClosedWithoutMerge(workState) {
+  if (!workState || typeof workState !== 'object') return false;
+  const pr = workState.pr || workState._prState || null;
+  if (!pr || typeof pr !== 'object') return false;
+  // gh's PR JSON uses `state` ∈ {OPEN, CLOSED, MERGED}. Some callers store
+  // booleans (`merged`, `closed`). Cover both shapes.
+  const state = typeof pr.state === 'string' ? pr.state.toUpperCase() : null;
+  if (state === 'CLOSED') return true;
+  if (state === 'MERGED') return false;
+  if (pr.closed === true && pr.merged !== true) return true;
+  return false;
+}
+
+module.exports = { isPrClosedWithoutMerge };

--- a/scripts/workflows/lib/related-tickets.js
+++ b/scripts/workflows/lib/related-tickets.js
@@ -1,0 +1,180 @@
+/**
+ * related-tickets.js
+ *
+ * Schema, reader, writer, and validator for `tasks/<ticket>/related-tickets.json`.
+ *
+ * This manifest documents the parent, siblings, blockedBy, dependsOn, and
+ * relatedTo tickets discovered at brief-time. Brief / spec / tasks agents
+ * read it as their source of sibling-ownership facts so they don't absorb
+ * sibling-owned surfaces into the current ticket's scope.
+ *
+ * The Node side does NOT fetch tickets itself — the brief-writer agent
+ * fetches via MCP / `gh` and writes the file. This module only provides
+ * the path helper, the schema validator, and a stale-check.
+ */
+
+'use strict';
+
+const ARTIFACT_FILENAME = 'related-tickets.json';
+
+/**
+ * Absolute path to the manifest for a given tasksDir.
+ * @param {string} tasksDir
+ * @param {{ join: Function }} pathMod
+ * @returns {string}
+ */
+function manifestPath(tasksDir, pathMod) {
+  return pathMod.join(tasksDir, ARTIFACT_FILENAME);
+}
+
+/**
+ * Read and parse the manifest. Returns null on missing/unreadable/invalid JSON.
+ * Does not throw.
+ */
+function read(tasksDir, deps) {
+  const { fs, path: pathMod } = deps;
+  const file = manifestPath(tasksDir, pathMod);
+  try {
+    if (!fs.existsSync(file)) return null;
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate a parsed manifest object. Returns { valid, errors: string[] }.
+ * Shape (all link arrays are required, may be empty):
+ *   {
+ *     self: { id, title?, status? },
+ *     parent: { id, title?, status? } | null,
+ *     siblings: Array<{ id, title?, status?, prNumber?, surfaces?: string[] }>,
+ *     blockedBy: Array<{ id, status?, prNumber? }>,
+ *     dependsOn: Array<{ id, status?, prNumber? }>,
+ *     relatedTo: Array<{ id, status?, prNumber? }>,
+ *     fetchedAt: ISO-8601 string
+ *   }
+ */
+function validate(manifest) {
+  const errors = [];
+  if (!manifest || typeof manifest !== 'object') {
+    return { valid: false, errors: ['manifest is not an object'] };
+  }
+  if (!manifest.self || typeof manifest.self.id !== 'string' || !manifest.self.id) {
+    errors.push('self.id is required (string)');
+  }
+  if (manifest.parent !== null && manifest.parent !== undefined) {
+    if (typeof manifest.parent !== 'object' || typeof manifest.parent.id !== 'string') {
+      errors.push('parent must be null or { id: string, ... }');
+    }
+  }
+  for (const key of ['siblings', 'blockedBy', 'dependsOn', 'relatedTo']) {
+    if (!Array.isArray(manifest[key])) {
+      errors.push(`${key} must be an array (may be empty)`);
+      continue;
+    }
+    manifest[key].forEach((entry, i) => {
+      if (!entry || typeof entry !== 'object' || typeof entry.id !== 'string' || !entry.id) {
+        errors.push(`${key}[${i}].id is required (string)`);
+      }
+    });
+  }
+  if (typeof manifest.fetchedAt !== 'string' || Number.isNaN(Date.parse(manifest.fetchedAt))) {
+    errors.push('fetchedAt must be an ISO-8601 string');
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Read + validate. Returns { manifest, valid, errors, missing }.
+ *   missing = true when the file doesn't exist on disk.
+ */
+function readAndValidate(tasksDir, deps) {
+  const { fs, path: pathMod } = deps;
+  const file = manifestPath(tasksDir, pathMod);
+  if (!fs.existsSync(file)) {
+    return {
+      manifest: null,
+      valid: false,
+      errors: ['manifest file does not exist'],
+      missing: true,
+    };
+  }
+  const manifest = read(tasksDir, deps);
+  if (manifest === null) {
+    return {
+      manifest: null,
+      valid: false,
+      errors: ['manifest file is not valid JSON'],
+      missing: false,
+    };
+  }
+  const { valid, errors } = validate(manifest);
+  return { manifest, valid, errors, missing: false };
+}
+
+/**
+ * @param {object} manifest
+ * @param {string|Date} runStartedAt - The /work2 run start time (ISO string or Date)
+ * @returns {boolean} true when fetchedAt is older than runStartedAt
+ */
+function isStale(manifest, runStartedAt) {
+  if (!manifest || typeof manifest.fetchedAt !== 'string') return true;
+  const fetched = Date.parse(manifest.fetchedAt);
+  const start = runStartedAt instanceof Date ? runStartedAt.getTime() : Date.parse(runStartedAt);
+  if (Number.isNaN(fetched) || Number.isNaN(start)) return true;
+  return fetched < start;
+}
+
+/**
+ * Flatten all sibling-owned IDs (parent + siblings + blockedBy + dependsOn + relatedTo)
+ * for quick membership checks. Returns an array of unique ticket IDs (strings).
+ */
+function siblingIds(manifest) {
+  if (!manifest) return [];
+  const ids = new Set();
+  if (manifest.parent && typeof manifest.parent.id === 'string') ids.add(manifest.parent.id);
+  for (const key of ['siblings', 'blockedBy', 'dependsOn', 'relatedTo']) {
+    if (Array.isArray(manifest[key])) {
+      for (const e of manifest[key]) {
+        if (e && typeof e.id === 'string') ids.add(e.id);
+      }
+    }
+  }
+  return Array.from(ids);
+}
+
+/**
+ * Union of all `surfaces` arrays declared on siblings + parent. Used by
+ * downstream gates to detect when a brief / spec / tasks touches a path
+ * owned by a sibling ticket. Surfaces are file paths (or globs) as written
+ * by the brief-writer agent based on each sibling's merged PR diff.
+ */
+function siblingSurfaces(manifest) {
+  if (!manifest) return [];
+  const out = new Set();
+  const collect = (entry) => {
+    if (entry && Array.isArray(entry.surfaces)) {
+      for (const s of entry.surfaces) {
+        if (typeof s === 'string' && s) out.add(s);
+      }
+    }
+  };
+  collect(manifest.parent);
+  if (Array.isArray(manifest.siblings)) manifest.siblings.forEach(collect);
+  if (Array.isArray(manifest.blockedBy)) manifest.blockedBy.forEach(collect);
+  if (Array.isArray(manifest.dependsOn)) manifest.dependsOn.forEach(collect);
+  if (Array.isArray(manifest.relatedTo)) manifest.relatedTo.forEach(collect);
+  return Array.from(out);
+}
+
+module.exports = {
+  ARTIFACT_FILENAME,
+  manifestPath,
+  read,
+  readAndValidate,
+  validate,
+  isStale,
+  siblingIds,
+  siblingSurfaces,
+};

--- a/scripts/workflows/lib/related-tickets.js
+++ b/scripts/workflows/lib/related-tickets.js
@@ -47,13 +47,18 @@ function read(tasksDir, deps) {
  * Shape (all link arrays are required, may be empty):
  *   {
  *     self: { id, title?, status? },
- *     parent: { id, title?, status? } | null,
- *     siblings: Array<{ id, title?, status?, prNumber?, surfaces?: string[] }>,
- *     blockedBy: Array<{ id, status?, prNumber? }>,
- *     dependsOn: Array<{ id, status?, prNumber? }>,
- *     relatedTo: Array<{ id, status?, prNumber? }>,
+ *     parent: { id, title?, status?, scope? } | null,
+ *     siblings: Array<{ id, title?, status?, scope?, prNumber?, surfaces?: string[] }>,
+ *     blockedBy: Array<{ id, title?, status?, scope?, prNumber? }>,
+ *     dependsOn: Array<{ id, title?, status?, scope?, prNumber? }>,
+ *     relatedTo: Array<{ id, title?, status?, scope?, prNumber? }>,
  *     fetchedAt: ISO-8601 string
  *   }
+ *
+ * `scope` is a one-to-three-sentence agent-authored distillation of each
+ * linked ticket's description, naming the files/endpoints/schemas that
+ * ticket owns. Used by the brief-writer at Gate A when `surfaces` is empty
+ * (no merged PR yet) to decide sibling ownership without asking the user.
  */
 function validate(manifest) {
   const errors = [];

--- a/scripts/workflows/lib/scope-diff.js
+++ b/scripts/workflows/lib/scope-diff.js
@@ -1,0 +1,155 @@
+/**
+ * scope-diff.js
+ *
+ * Gate E — pure helper that compares a git diff file list against the union
+ * of every task's `### Files in scope` declarations. Used by the check step
+ * and the completion-checker agent to surface out-of-scope changes BEFORE
+ * the PR is opened.
+ *
+ * Inputs are pure data:
+ *   - `diffFiles`: string[] (output of `git diff --name-only origin/main...HEAD`)
+ *   - `tasks`:     Array<{filesInScope?: string[], filesOutOfScope?: string[],
+ *                          suggestedScope?: string}> (from task-parser.parseTasks)
+ *
+ * Output:
+ *   {
+ *     inScope:        string[],  // files matched by at least one task's filesInScope
+ *     outOfScope:     string[],  // files matched by ANY task's filesOutOfScope
+ *     unaccounted:    string[],  // files matched by neither
+ *     totals:         {inScope, outOfScope, unaccounted, total}
+ *   }
+ */
+
+'use strict';
+
+const { globToRegex } = require('./hooks/policies/scope-protection');
+
+function _parseLegacySuggestedScope(text) {
+  if (!text || typeof text !== 'string') return [];
+  return text
+    .split('\n')
+    .map((l) =>
+      l
+        .trim()
+        .replace(/^[-*+]\s+/, '')
+        .replace(/^`+|`+$/g, '')
+        .trim()
+    )
+    .filter((l) => l && !l.startsWith('<!--'));
+}
+
+function _scopeForTask(task) {
+  if (Array.isArray(task.filesInScope) && task.filesInScope.length > 0) {
+    return task.filesInScope;
+  }
+  // Legacy fallback so tasks written before Gate C still inform Gate E.
+  return _parseLegacySuggestedScope(task.suggestedScope);
+}
+
+function _compileMany(patterns) {
+  const out = [];
+  for (const p of patterns) {
+    if (!p || typeof p !== 'string') continue;
+    try {
+      out.push(globToRegex(p));
+    } catch {
+      /* skip */
+    }
+  }
+  return out;
+}
+
+function _matchesAny(filePath, regexes) {
+  for (const re of regexes) {
+    if (re.test(filePath)) return true;
+  }
+  return false;
+}
+
+/**
+ * @param {string[]} diffFiles - File paths from git diff, posix-style
+ * @param {Array<object>} tasks - Tasks from task-parser
+ * @returns {{inScope:string[], outOfScope:string[], unaccounted:string[], totals:object}}
+ */
+function compareDiffToScope(diffFiles, tasks) {
+  if (!Array.isArray(diffFiles)) {
+    return {
+      inScope: [],
+      outOfScope: [],
+      unaccounted: [],
+      totals: { inScope: 0, outOfScope: 0, unaccounted: 0, total: 0 },
+    };
+  }
+  const taskList = Array.isArray(tasks) ? tasks : [];
+
+  // Compile union of in-scope and out-of-scope patterns
+  const inPatterns = [];
+  const outPatterns = [];
+  for (const t of taskList) {
+    inPatterns.push(..._scopeForTask(t));
+    if (Array.isArray(t.filesOutOfScope)) outPatterns.push(...t.filesOutOfScope);
+  }
+  const inRegex = _compileMany(inPatterns);
+  const outRegex = _compileMany(outPatterns);
+
+  const inScope = [];
+  const outOfScope = [];
+  const unaccounted = [];
+
+  for (const raw of diffFiles) {
+    if (typeof raw !== 'string' || !raw) continue;
+    const file = raw.replace(/\\/g, '/');
+    if (_matchesAny(file, outRegex)) {
+      outOfScope.push(file);
+      continue;
+    }
+    if (_matchesAny(file, inRegex)) {
+      inScope.push(file);
+      continue;
+    }
+    unaccounted.push(file);
+  }
+
+  return {
+    inScope,
+    outOfScope,
+    unaccounted,
+    totals: {
+      inScope: inScope.length,
+      outOfScope: outOfScope.length,
+      unaccounted: unaccounted.length,
+      total: inScope.length + outOfScope.length + unaccounted.length,
+    },
+  };
+}
+
+/**
+ * Render a human-readable summary of the diff comparison. Used by the
+ * check step enrichment to inject into the completion-checker prompt and
+ * by the PR generator when writing the "Out-of-scope changes" section.
+ *
+ * @param {ReturnType<typeof compareDiffToScope>} result
+ * @returns {string}
+ */
+function summarizeScopeDiff(result) {
+  if (!result) return '';
+  const lines = [];
+  lines.push('## Scope-diff summary');
+  lines.push(`- in scope:        ${result.totals.inScope}`);
+  lines.push(`- out of scope:    ${result.totals.outOfScope}  (sibling-owned)`);
+  lines.push(`- unaccounted:     ${result.totals.unaccounted}  (no task declared this file)`);
+  lines.push('');
+  if (result.outOfScope.length > 0) {
+    lines.push('### Sibling-owned files in diff (BLOCKING)');
+    for (const f of result.outOfScope) lines.push(`- ${f}`);
+    lines.push('');
+  }
+  if (result.unaccounted.length > 0) {
+    lines.push('### Unaccounted files in diff (needs justification)');
+    for (const f of result.unaccounted) lines.push(`- ${f}`);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+module.exports = { compareDiffToScope, summarizeScopeDiff };

--- a/scripts/workflows/lib/task-scope.js
+++ b/scripts/workflows/lib/task-scope.js
@@ -25,16 +25,23 @@ function validateTask(task) {
   }
   const label = `Task ${task.num ?? '?'}`;
 
-  if (!Array.isArray(task.filesInScope) || task.filesInScope.length === 0) {
-    errors.push(`${label} is missing a non-empty \`### Files in scope\` section`);
+  // Legacy fallback: tasks written before Gate C may carry `### Suggested Scope`
+  // instead of `### Files in scope`. Accept that as evidence of scope intent
+  // and ONLY error when BOTH are missing/empty. New tasks SHOULD use
+  // `### Files in scope`; the warning surfaces via downstream check-step
+  // tooling (Gate E), not as a hard implement-step block.
+  const hasInScope = Array.isArray(task.filesInScope) && task.filesInScope.length > 0;
+  const hasLegacyScope =
+    typeof task.suggestedScope === 'string' && task.suggestedScope.trim().length > 0;
+  if (!hasInScope && !hasLegacyScope) {
+    errors.push(
+      `${label} is missing both \`### Files in scope\` AND \`### Suggested Scope\` (need at least one)`
+    );
   }
-  // `Files explicitly out of scope` may legitimately be empty (no siblings).
-  // We require the SECTION to exist, but the parser today returns [] both for
-  // "section missing" and "section empty" — we can't distinguish without
-  // re-reading the raw markdown. For now treat it as advisory: warn if no
-  // siblings declared in the manifest *and* this is empty. Strict enforcement
-  // happens at Gate A when the sibling-gap list is finalized.
-  if (!Array.isArray(task.filesOutOfScope)) {
+  // `### Files explicitly out of scope` is forward-looking and not required
+  // for legacy tasks. New tasks (those with `### Files in scope`) SHOULD
+  // include it; tolerate absence here and surface in Gate E review.
+  if (task.filesOutOfScope !== undefined && !Array.isArray(task.filesOutOfScope)) {
     errors.push(`${label} has malformed \`### Files explicitly out of scope\` section`);
   }
   return errors;

--- a/scripts/workflows/lib/task-scope.js
+++ b/scripts/workflows/lib/task-scope.js
@@ -1,0 +1,91 @@
+/**
+ * task-scope.js
+ *
+ * Gate C — pure validators for the per-task `Files in scope` and
+ * `Files explicitly out of scope` declarations. Used by the implement-time
+ * gate to refuse dispatch when scope sections are missing or empty, and
+ * by Gate D's hook to compute the active envelope.
+ *
+ * The parser lives in `scripts/workflows/work/task-parser.js`. This file
+ * only validates the already-parsed objects.
+ */
+
+'use strict';
+
+/**
+ * Validate one task object's scope sections.
+ *
+ * @param {{ num:number, filesInScope?:string[], filesOutOfScope?:string[] }} task
+ * @returns {string[]} validation error messages (empty when valid)
+ */
+function validateTask(task) {
+  const errors = [];
+  if (!task || typeof task !== 'object') {
+    return ['task must be an object'];
+  }
+  const label = `Task ${task.num ?? '?'}`;
+
+  if (!Array.isArray(task.filesInScope) || task.filesInScope.length === 0) {
+    errors.push(`${label} is missing a non-empty \`### Files in scope\` section`);
+  }
+  // `Files explicitly out of scope` may legitimately be empty (no siblings).
+  // We require the SECTION to exist, but the parser today returns [] both for
+  // "section missing" and "section empty" — we can't distinguish without
+  // re-reading the raw markdown. For now treat it as advisory: warn if no
+  // siblings declared in the manifest *and* this is empty. Strict enforcement
+  // happens at Gate A when the sibling-gap list is finalized.
+  if (!Array.isArray(task.filesOutOfScope)) {
+    errors.push(`${label} has malformed \`### Files explicitly out of scope\` section`);
+  }
+  return errors;
+}
+
+/**
+ * Validate every task and return a flat error list.
+ *
+ * @param {Array<object>|null|undefined} tasks
+ * @returns {{ valid:boolean, errors:string[] }}
+ */
+function validateAll(tasks) {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return { valid: false, errors: ['no tasks parsed from tasks.md'] };
+  }
+  const errors = [];
+  for (const t of tasks) {
+    errors.push(...validateTask(t));
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Union of `filesInScope` across the supplied tasks. Used by Gate E.
+ *
+ * @param {Array<object>} tasks
+ * @returns {string[]}
+ */
+function unionFilesInScope(tasks) {
+  const out = new Set();
+  if (!Array.isArray(tasks)) return [];
+  for (const t of tasks) {
+    if (Array.isArray(t?.filesInScope)) {
+      for (const p of t.filesInScope) {
+        if (typeof p === 'string' && p) out.add(p);
+      }
+    }
+  }
+  return Array.from(out);
+}
+
+/**
+ * Find the task with the matching task number, or null.
+ *
+ * @param {Array<object>} tasks
+ * @param {number} taskNum
+ * @returns {object|null}
+ */
+function findTask(tasks, taskNum) {
+  if (!Array.isArray(tasks) || typeof taskNum !== 'number') return null;
+  return tasks.find((t) => t && t.num === taskNum) || null;
+}
+
+module.exports = { validateTask, validateAll, unionFilesInScope, findTask };

--- a/scripts/workflows/lib/ticket-provider.js
+++ b/scripts/workflows/lib/ticket-provider.js
@@ -274,6 +274,101 @@ function getFetchTicketPrompt(ticketId, providerConfig) {
   }
 }
 
+function getRelatedTicketsPrompt(ticketId, providerConfig, manifestPath) {
+  if (!providerConfig) return null;
+  const schemaBlock =
+    'Schema (write this exact shape; arrays may be empty but must exist):\n' +
+    '{\n' +
+    '  "self":      { "id": "' +
+    ticketId +
+    '", "title": "...", "status": "..." },\n' +
+    '  "parent":    { "id": "...", "title": "...", "status": "..." } | null,\n' +
+    '  "siblings":  [ { "id": "...", "title": "...", "status": "...", "prNumber": 1234, "surfaces": ["lib/x.ts", "app/api/.../y.ts"] } ],\n' +
+    '  "blockedBy": [ { "id": "...", "status": "...", "prNumber": null } ],\n' +
+    '  "dependsOn": [ { "id": "...", "status": "...", "prNumber": null } ],\n' +
+    '  "relatedTo": [ { "id": "...", "status": "...", "prNumber": null } ],\n' +
+    '  "fetchedAt": "<ISO-8601 timestamp NOW>"\n' +
+    '}\n' +
+    '\n' +
+    'Rules:\n' +
+    '- `parent` is null when this ticket has no parent. Otherwise populate from the parent link.\n' +
+    '- `siblings` = children of the same parent, EXCLUDING this ticket. If there is no parent, leave it [].\n' +
+    '- `blockedBy` / `dependsOn` / `relatedTo` come from the ticket-system link types.\n' +
+    '- For every sibling AND parent with a merged PR, populate `surfaces` with the list of files changed in that PR (run `gh pr diff <N> --name-only` and copy the file paths). For unshipped tickets, leave `surfaces: []`.\n' +
+    '- Write the JSON to: ' +
+    manifestPath +
+    '\n' +
+    '- After writing, validate by reading it back and parsing.';
+  switch (providerConfig.provider) {
+    case 'jira':
+      return (
+        'Fetch related tickets for Jira issue ' +
+        ticketId +
+        ' and write a related-tickets manifest.\n\n' +
+        'Steps:\n' +
+        '1. Use mcp__atlassian__jira_get_issue with issue_key "' +
+        ticketId +
+        '" and fetch the full payload including the `issuelinks` field and the `parent` field.\n' +
+        '2. Parse:\n' +
+        '   - `parent`: from fields.parent if present.\n' +
+        '   - `siblings`: search for siblings via JQL `parent = "' +
+        ticketId +
+        '"`\'s parent — use mcp__atlassian__jira_search with JQL `parent = "<parent-key>"` and exclude ' +
+        ticketId +
+        '.\n' +
+        '   - `blockedBy`: issuelinks where this issue `is blocked by`.\n' +
+        '   - `dependsOn`: issuelinks where this issue `depends on`.\n' +
+        '   - `relatedTo`: issuelinks where the link type is `relates to`.\n' +
+        "3. For each linked ticket with a merged PR, find the PR number from the issue's remote links or development field, then run `gh pr diff <N> --name-only` to populate `surfaces`.\n\n" +
+        schemaBlock
+      );
+    case 'linear':
+      return (
+        'Fetch related issues for Linear issue ' +
+        ticketId +
+        ' and write a related-tickets manifest.\n\n' +
+        'Steps:\n' +
+        '1. Use mcp__linear__get_issue with id "' +
+        ticketId +
+        '" and capture: `parent`, `children`, and `relations` (each relation has a `type`: `blocks`, `blocked_by`, `duplicate`, `related`, …).\n' +
+        '2. Parse:\n' +
+        '   - `parent`: from the parent field.\n' +
+        '   - `siblings`: if there is a parent, list its other children (use mcp__linear__get_issue on the parent and read `children`, exclude ' +
+        ticketId +
+        ').\n' +
+        '   - `blockedBy`: relations where type is `blocked_by` (or the inverse of `blocks`).\n' +
+        "   - `dependsOn`: relations where type is `blocks` and the target depends on this issue — use the same field interpreted per Linear's schema.\n" +
+        '   - `relatedTo`: relations where type is `related`.\n' +
+        '3. For each linked issue with a merged PR (Linear surfaces these via the `attachments` or external links), run `gh pr diff <N> --name-only` to populate `surfaces`.\n\n' +
+        schemaBlock
+      );
+    case 'github':
+      return (
+        'Fetch related issues for GitHub issue ' +
+        ticketId +
+        ' and write a related-tickets manifest.\n\n' +
+        'Steps:\n' +
+        '1. Run `gh issue view ' +
+        ticketId.replace(/^#/, '') +
+        ' --json title,body,labels,milestone` and capture the body.\n' +
+        '2. Parse the body for these conventions (case-insensitive):\n' +
+        '   - `Parent: #N` or `Parent issue: #N` → `parent`.\n' +
+        '   - `Blocked by: #N, #M` → each goes into `blockedBy`.\n' +
+        '   - `Depends on: #N` → `dependsOn`.\n' +
+        '   - `Related: #N` or `Related to: #N` → `relatedTo`.\n' +
+        '3. For siblings: if there is a parent, run `gh issue view <parent-N> --json body` and parse its body for a checklist of sub-issues (`- [ ] #N`, `- [x] #N`), excluding ' +
+        ticketId +
+        '.\n' +
+        '4. For each linked issue, run `gh issue view <N> --json state,title` to populate status, and `gh pr list --search "linked-issue:<N>" --state merged --json number` to find the merged PR. If a PR exists, run `gh pr diff <N> --name-only` to populate `surfaces`.\n\n' +
+        schemaBlock
+      );
+    case 'none':
+      return null;
+    default:
+      return null;
+  }
+}
+
 function getTransitionPrompt(ticketId, status, providerConfig) {
   if (!providerConfig) return null;
   switch (providerConfig.provider) {
@@ -376,6 +471,7 @@ module.exports = {
   prefixTicketId,
   getTicketPattern,
   getFetchTicketPrompt,
+  getRelatedTicketsPrompt,
   getTransitionPrompt,
   getCreateTicketPrompt,
   getAllowedMcpTools,

--- a/scripts/workflows/lib/ticket-provider.js
+++ b/scripts/workflows/lib/ticket-provider.js
@@ -282,11 +282,11 @@ function getRelatedTicketsPrompt(ticketId, providerConfig, manifestPath) {
     '  "self":      { "id": "' +
     ticketId +
     '", "title": "...", "status": "..." },\n' +
-    '  "parent":    { "id": "...", "title": "...", "status": "..." } | null,\n' +
-    '  "siblings":  [ { "id": "...", "title": "...", "status": "...", "prNumber": 1234, "surfaces": ["lib/x.ts", "app/api/.../y.ts"] } ],\n' +
-    '  "blockedBy": [ { "id": "...", "status": "...", "prNumber": null } ],\n' +
-    '  "dependsOn": [ { "id": "...", "status": "...", "prNumber": null } ],\n' +
-    '  "relatedTo": [ { "id": "...", "status": "...", "prNumber": null } ],\n' +
+    '  "parent":    { "id": "...", "title": "...", "status": "...", "scope": "..." } | null,\n' +
+    '  "siblings":  [ { "id": "...", "title": "...", "status": "...", "scope": "...", "prNumber": 1234, "surfaces": ["lib/x.ts", "app/api/.../y.ts"] } ],\n' +
+    '  "blockedBy": [ { "id": "...", "title": "...", "status": "...", "scope": "...", "prNumber": null } ],\n' +
+    '  "dependsOn": [ { "id": "...", "title": "...", "status": "...", "scope": "...", "prNumber": null } ],\n' +
+    '  "relatedTo": [ { "id": "...", "title": "...", "status": "...", "scope": "...", "prNumber": null } ],\n' +
     '  "fetchedAt": "<ISO-8601 timestamp NOW>"\n' +
     '}\n' +
     '\n' +
@@ -294,7 +294,13 @@ function getRelatedTicketsPrompt(ticketId, providerConfig, manifestPath) {
     '- `parent` is null when this ticket has no parent. Otherwise populate from the parent link.\n' +
     '- `siblings` = children of the same parent, EXCLUDING this ticket. If there is no parent, leave it [].\n' +
     '- `blockedBy` / `dependsOn` / `relatedTo` come from the ticket-system link types.\n' +
-    '- For every sibling AND parent with a merged PR, populate `surfaces` with the list of files changed in that PR (run `gh pr diff <N> --name-only` and copy the file paths). For unshipped tickets, leave `surfaces: []`.\n' +
+    "- **`scope` (REQUIRED on every linked entry):** read each linked ticket's full description, then distill it into a focused one-to-three-sentence summary of WHAT THAT TICKET OWNS — files, endpoints, schemas, layers. This is the field downstream agents use to decide sibling ownership when no PR is merged yet.\n" +
+    '  - Good: `"scope": "Owns the new `externalAssets.listDownstreamDashboards` tRPC procedure on viewsRouter and its Zod schema. Adds `select`+`where` for Dashboard rows. No UI changes."`\n' +
+    '  - Bad (too vague): `"scope": "Backend work for downstream dashboards"`\n' +
+    '  - Bad (full body): pasting the entire ticket description verbatim.\n' +
+    '  - Bad (too narrow): `"scope": "Wire to explore.list"` without naming any concrete surface.\n' +
+    '  - Keep `scope` ≤ ~400 characters. Strip implementation noise (deadlines, status updates, side-comments) — keep only ownership signals.\n' +
+    '- For every sibling AND parent with a merged PR, populate `surfaces` with the list of files changed in that PR (run `gh pr diff <N> --name-only` and copy the file paths). For unshipped tickets, leave `surfaces: []` — `scope` is what carries ownership info in that case.\n' +
     '- Write the JSON to: ' +
     manifestPath +
     '\n' +

--- a/scripts/workflows/work/__tests__/tdd-enforcement.test.js
+++ b/scripts/workflows/work/__tests__/tdd-enforcement.test.js
@@ -45,6 +45,32 @@ after(() => {
   } catch {
     /* ignore if tmpdir unreadable */
   }
+  // Safety-net: clean up test-fixture directories that leaked into the real
+  // TASKS_BASE (e.g., TEST-TR-101 / TDDP-200 / GH-154). In-process tests
+  // pass `tasksDir` directly via ctx; spawned child processes get TASKS_BASE
+  // via env. But some code paths (config.orExit fallback, transitionStep
+  // resolving paths through process.env at module-load time) can still
+  // resolve to the developer's real TASKS_BASE. Empty dirs are harmless but
+  // accumulate. Match conservatively — only prefixes used by this suite.
+  try {
+    const realTasksBase =
+      process.env.TASKS_BASE ||
+      require(path.join(__dirname, '..', '..', 'lib', 'config')).TASKS_BASE;
+    if (realTasksBase && fs.existsSync(realTasksBase)) {
+      const SUITE_PREFIXES = ['TEST-TR-', 'TDDP-', 'TDDG-', 'TDD-'];
+      const entries = fs.readdirSync(realTasksBase);
+      for (const name of entries) {
+        if (!SUITE_PREFIXES.some((p) => name.startsWith(p))) continue;
+        try {
+          fs.rmSync(path.join(realTasksBase, name), { recursive: true, force: true });
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+  } catch {
+    /* ignore if config unreadable */
+  }
 });
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -128,17 +154,34 @@ function writeTaskArtifacts(ticket) {
   // brief.md with no open questions → brief verify + brief_gate verify pass
   fs.writeFileSync(path.join(dir, 'brief.md'), '# Brief\n\n## Problem Statement\nTest brief.\n');
   // spec.md → spec verify passes
-  fs.writeFileSync(
-    path.join(dir, 'spec.md'),
-    '# Spec\n\n## Summary\nTest spec.\n'
-  );
+  fs.writeFileSync(path.join(dir, 'spec.md'), '# Spec\n\n## Summary\nTest spec.\n');
   // gherkin.feature with gherkin-skip → spec_gate verify passes (GH-350: standalone gherkin file)
+  fs.writeFileSync(path.join(dir, 'gherkin.feature'), '<!-- gherkin-skip: test artifact -->\n');
+  // tasks.md → tasks verify + tasks_gate (Gate C) verify pass.
+  // Gate C requires every `## Task N` block to declare `### Files in scope`
+  // (or the legacy `### Suggested Scope` as fallback).
   fs.writeFileSync(
-    path.join(dir, 'gherkin.feature'),
-    '<!-- gherkin-skip: test artifact -->\n'
+    path.join(dir, 'tasks.md'),
+    [
+      '# Tasks',
+      '',
+      '## Task 1 — TDD enforcement fixture',
+      '',
+      '### Type',
+      'backend',
+      '',
+      '### Files in scope',
+      '- src/**',
+      '',
+      '### Files explicitly out of scope',
+      '',
+      '### Test Command',
+      '```bash',
+      'pnpm test',
+      '```',
+      '',
+    ].join('\n')
   );
-  // tasks.md → tasks verify passes
-  fs.writeFileSync(path.join(dir, 'tasks.md'), '# Tasks\n\n- [ ] Task 1\n');
 }
 
 /**
@@ -178,6 +221,7 @@ async function transitionTo(ticket, targetStep, envExtra = {}) {
     'spec',
     'spec_gate', // GH-244
     'tasks',
+    'tasks_gate', // Gate C — between tasks and implement
     'implement',
     'commit',
     'check',
@@ -468,6 +512,7 @@ describe('TDD enforcement', () => {
         await runOrchestrator(['transition', TICKET, 'spec'], opts);
         await runOrchestrator(['transition', TICKET, 'spec_gate'], opts);
         await runOrchestrator(['transition', TICKET, 'tasks'], opts);
+        await runOrchestrator(['transition', TICKET, 'tasks_gate'], opts);
         await runOrchestrator(['transition', TICKET, 'implement'], opts);
 
         // Record valid evidence so we can leave 3_implement
@@ -510,6 +555,7 @@ describe('TDD enforcement', () => {
         await runOrchestrator(['transition', TICKET, 'spec'], opts);
         await runOrchestrator(['transition', TICKET, 'spec_gate'], opts);
         await runOrchestrator(['transition', TICKET, 'tasks'], opts);
+        await runOrchestrator(['transition', TICKET, 'tasks_gate'], opts);
         // Make sure no phase state file exists
         const phasePath = path.join(tempTasksBase, TICKET, 'tdd-phase.json');
         try {
@@ -595,6 +641,7 @@ describe('TDD enforcement', () => {
           'spec',
           'spec_gate',
           'tasks',
+          'tasks_gate',
           'implement',
         ];
         for (const s of steps) {

--- a/scripts/workflows/work/__tests__/work-orchestrator.test.js
+++ b/scripts/workflows/work/__tests__/work-orchestrator.test.js
@@ -216,18 +216,29 @@ function writeTaskArtifacts(tasksBase, ticket) {
   const dir = path.join(tasksBase, ticket);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'brief.md'), '# Brief\n\n## Problem Statement\nTest brief.\n');
-  fs.writeFileSync(
-    path.join(dir, 'spec.md'),
-    '# Spec\n\n## Summary\nTest spec.\n'
-  );
+  fs.writeFileSync(path.join(dir, 'spec.md'), '# Spec\n\n## Summary\nTest spec.\n');
   // gherkin.feature with gherkin-skip → spec_gate verify passes (GH-350: standalone gherkin file)
-  fs.writeFileSync(
-    path.join(dir, 'gherkin.feature'),
-    '<!-- gherkin-skip: test artifact -->\n'
-  );
+  fs.writeFileSync(path.join(dir, 'gherkin.feature'), '<!-- gherkin-skip: test artifact -->\n');
+  // Gate C requires `### Files in scope` on every task — include it.
   fs.writeFileSync(
     path.join(dir, 'tasks.md'),
-    '# Tasks\n\n## Task 1 — Test task\n\n### Type\nbackend\n\n### Deliverables\n- [ ] 1.1 Test deliverable\n'
+    [
+      '# Tasks',
+      '',
+      '## Task 1 — Test task',
+      '',
+      '### Type',
+      'backend',
+      '',
+      '### Files in scope',
+      '- src/**',
+      '',
+      '### Files explicitly out of scope',
+      '',
+      '### Deliverables',
+      '- [ ] 1.1 Test deliverable',
+      '',
+    ].join('\n')
   );
 }
 
@@ -278,7 +289,7 @@ describe('work-orchestrator.js', () => {
       assert.ok(result.steps.includes('ticket'));
       assert.ok(result.steps.includes('complete'));
       // GH-244: added spec_gate between spec and tasks.
-      assert.equal(result.steps.length, 18);
+      assert.equal(result.steps.length, 19);
     });
 
     it('should include follow_up in steps', async () => {
@@ -541,6 +552,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TEST_TICKET, 'spec'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'spec_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'tasks'], transOpts);
+      await runOrchestrator(['transition', TEST_TICKET, 'tasks_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'implement'], transOpts);
       const { result } = await runOrchestrator(['transition', TEST_TICKET, 'pr'], transOpts);
       assert.equal(result.error, true);
@@ -556,6 +568,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TEST_TICKET, 'spec'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'spec_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'tasks'], transOpts);
+      await runOrchestrator(['transition', TEST_TICKET, 'tasks_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'implement'], transOpts);
       writeTddException(TEMP_TASKS_DIR, TEST_TICKET);
       await runOrchestrator(['transition', TEST_TICKET, 'commit'], transOpts);
@@ -582,6 +595,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TEST_TICKET, 'spec'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'spec_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'tasks'], transOpts);
+      await runOrchestrator(['transition', TEST_TICKET, 'tasks_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'implement'], transOpts);
       const { result } = await runOrchestrator(['transitions', TEST_TICKET], transOpts);
       assert.equal(result.currentStep, 'implement');
@@ -597,6 +611,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TEST_TICKET, 'spec'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'spec_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'tasks'], transOpts);
+      await runOrchestrator(['transition', TEST_TICKET, 'tasks_gate'], transOpts);
       await runOrchestrator(['transition', TEST_TICKET, 'implement'], transOpts);
       writeTddException(TEMP_TASKS_DIR, TEST_TICKET);
       await runOrchestrator(['transition', TEST_TICKET, 'commit'], transOpts);
@@ -611,10 +626,10 @@ describe('work-orchestrator.js', () => {
   });
 
   describe('state machine logic', () => {
-    it('should have 18 steps total', async () => {
+    it('should have 19 steps total', async () => {
       const { result } = await runOrchestrator(['graph']);
       // GH-244: added spec_gate between spec and tasks.
-      assert.equal(result.steps.length, 18);
+      assert.equal(result.steps.length, 19);
     });
 
     it('should not allow self-transitions (except complete)', async () => {
@@ -848,6 +863,7 @@ describe('work-orchestrator.js', () => {
         await runOrchestrator(['transition', T, 'spec'], o);
         await runOrchestrator(['transition', T, 'spec_gate'], o);
         await runOrchestrator(['transition', T, 'tasks'], o);
+        await runOrchestrator(['transition', T, 'tasks_gate'], o);
         await runOrchestrator(['transition', T, 'implement'], o);
         writeTddException(TASKS_DIR, T);
         await runOrchestrator(['transition', T, 'commit'], o);
@@ -1303,6 +1319,7 @@ describe('work-orchestrator.js', () => {
         await runOrchestrator(['transition', T4, 'spec'], o);
         await runOrchestrator(['transition', T4, 'spec_gate'], o);
         await runOrchestrator(['transition', T4, 'tasks'], o);
+        await runOrchestrator(['transition', T4, 'tasks_gate'], o);
         await runOrchestrator(['transition', T4, 'implement'], o);
         writeTddException(TEMP_TASKS, T4);
         await runOrchestrator(['transition', T4, 'commit'], o);
@@ -1383,6 +1400,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TICKET, 'spec'], envOpts);
       await runOrchestrator(['transition', TICKET, 'spec_gate'], envOpts);
       await runOrchestrator(['transition', TICKET, 'tasks'], envOpts);
+      await runOrchestrator(['transition', TICKET, 'tasks_gate'], envOpts);
       await runOrchestrator(['transition', TICKET, 'implement'], envOpts);
       writeTddException(TEMP_TASKS, TICKET);
       await runOrchestrator(['transition', TICKET, 'commit'], envOpts);
@@ -1412,6 +1430,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TICKET, 'spec'], envOpts);
       await runOrchestrator(['transition', TICKET, 'spec_gate'], envOpts);
       await runOrchestrator(['transition', TICKET, 'tasks'], envOpts);
+      await runOrchestrator(['transition', TICKET, 'tasks_gate'], envOpts);
       await runOrchestrator(['transition', TICKET, 'implement'], envOpts);
       writeTddException(TEMP_TASKS, TICKET);
       await runOrchestrator(['transition', TICKET, 'commit'], envOpts);
@@ -1650,6 +1669,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TICKET, 'spec'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'spec_gate'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'tasks'], gateOpts);
+      await runOrchestrator(['transition', TICKET, 'tasks_gate'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'implement'], gateOpts);
       writeTddException(TEMP_TASKS, TICKET);
       await runOrchestrator(['transition', TICKET, 'commit'], gateOpts);
@@ -1724,6 +1744,7 @@ describe('work-orchestrator.js', () => {
       await runOrchestrator(['transition', TICKET, 'spec'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'spec_gate'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'tasks'], gateOpts);
+      await runOrchestrator(['transition', TICKET, 'tasks_gate'], gateOpts);
       await runOrchestrator(['transition', TICKET, 'implement'], gateOpts);
       writeTddException(TEMP_TASKS, TICKET);
       const { result } = await runOrchestrator(['transition', TICKET, 'commit'], gateOpts);

--- a/scripts/workflows/work/__tests__/work-state.test.js
+++ b/scripts/workflows/work/__tests__/work-state.test.js
@@ -72,7 +72,7 @@ describe('work-state.js', () => {
       cleanupTempWorkState(TICKET);
     });
 
-    it('should create state with all 18 steps as pending', async () => {
+    it('should create state with all 19 steps as pending', async () => {
       const { result, code } = await runWorkState(['init', TICKET]);
       assert.equal(code, 0);
       assert.equal(result.ticketId, TICKET);
@@ -83,8 +83,8 @@ describe('work-state.js', () => {
       assert.equal(result.errors.length, 0);
 
       const steps = Object.keys(result.stepStatus);
-      // GH-244: 18 steps — added spec_gate between spec and tasks.
-      assert.equal(steps.length, 18);
+      // GH-244: 19 steps — added spec_gate between spec and tasks.
+      assert.equal(steps.length, 19);
       for (const step of steps) {
         assert.equal(result.stepStatus[step], 'pending', `Step ${step} should be pending`);
       }
@@ -98,6 +98,7 @@ describe('work-state.js', () => {
         'spec',
         'spec_gate', // GH-244
         'tasks',
+        'tasks_gate', // Gate C
         'implement',
         'commit',
         'task_review', // GH-211
@@ -148,8 +149,8 @@ describe('work-state.js', () => {
       assert.equal(code, 0);
       assert.equal(result.ticketId, TICKET_EXISTS);
       assert.equal(result.status, 'in_progress');
-      // GH-244: 18 steps — added spec_gate between spec and tasks.
-      assert.equal(Object.keys(result.stepStatus).length, 18);
+      // GH-244: 19 steps — added spec_gate between spec and tasks.
+      assert.equal(Object.keys(result.stepStatus).length, 19);
       for (const step of Object.keys(result.stepStatus)) {
         assert.equal(result.stepStatus[step], 'pending');
       }
@@ -179,9 +180,10 @@ describe('work-state.js', () => {
       // Verify persistence
       const { result: getResult } = await runWorkState(['get', TICKET]);
       assert.equal(getResult.stepStatus['implement'], 'in_progress');
-      // currentStep should be updated to 8 (index 7 + 1, after ticket/bootstrap/brief/brief_gate/spec/spec_gate/tasks)
-      // GH-244: spec_gate shifts implement to index 7.
-      assert.equal(getResult.currentStep, 8);
+      // currentStep should reflect implement's position in STEP_ORDER:
+      // ticket, bootstrap, brief, brief_gate, spec, spec_gate, tasks, tasks_gate, implement → index 8 → currentStep 9.
+      // Gate C inserts tasks_gate between tasks and implement.
+      assert.equal(getResult.currentStep, 9);
     });
 
     it('should reject invalid step name with exit code 1', async () => {

--- a/scripts/workflows/work/hooks/protect-gherkin.js
+++ b/scripts/workflows/work/hooks/protect-gherkin.js
@@ -83,8 +83,12 @@ function getStepInProgress(ticketId) {
   }
 }
 
+// Allow edits during `spec` (initial authoring) AND `spec_gate` (recovery
+// path: spec_gate's validator failed against gherkin.feature and the agent
+// needs to fix the tags / structure in-place without rewinding the state
+// machine).
 const protector = createArtifactProtector({
-  artifacts: [{ basename: 'gherkin.feature', step: 'spec' }],
+  artifacts: [{ basename: 'gherkin.feature', step: 'spec', allowedSteps: ['spec_gate'] }],
   getStepInProgress,
   getTicketId,
 });

--- a/scripts/workflows/work/step-registry.js
+++ b/scripts/workflows/work/step-registry.js
@@ -21,6 +21,11 @@ const STEPS = Object.freeze({
   spec: 'spec',
   spec_gate: 'spec_gate', // GH-244: Gherkin validation gate
   tasks: 'tasks',
+  // Gate C — validates `### Files in scope` / `### Files explicitly out of
+  // scope` per-task in tasks.md before implementation begins. Lets the user
+  // amend tasks.md in-place (via allowedSteps on the artifact rule) without
+  // an unsafe `implement → tasks.md` edit path.
+  tasks_gate: 'tasks_gate',
   implement: 'implement',
   commit: 'commit',
   // GH-211: per-task review gate that blocks check until review passes.
@@ -46,6 +51,7 @@ const STEP_ORDER = Object.freeze([
   STEPS.spec,
   STEPS.spec_gate,
   STEPS.tasks,
+  STEPS.tasks_gate, // Gate C — sits between tasks and implement
   STEPS.implement,
   STEPS.commit,
   STEPS.task_review, // GH-211: must sit between commit and check
@@ -99,6 +105,7 @@ function canTransition(statusTransitions) {
 // Retry loops: backward edges for failure recovery
 const RETRY_EDGES = {
   [STEPS.spec_gate]: [STEPS.spec], // GH-244: gate failed, regenerate spec
+  [STEPS.tasks_gate]: [STEPS.tasks], // Gate C: tasks.md missing scope sections → regenerate tasks
   [STEPS.task_review]: [STEPS.implement], // GH-211: review failed, fix code
   [STEPS.check]: [STEPS.implement], // check failed, fix code
   [STEPS.pr]: [STEPS.check], // GH-299: recheck on new commits

--- a/scripts/workflows/work/steps/index.js
+++ b/scripts/workflows/work/steps/index.js
@@ -14,6 +14,7 @@ const briefGateStep = require('./brief-gate');
 const specStep = require('./spec');
 const specGateStep = require('./spec-gate');
 const tasksStep = require('./tasks'); // GH-244: specGateStep registered above (tested in step-registry.test.js)
+const tasksGateStep = require('./tasks-gate');
 const implementStep = require('./implement');
 const commitStep = require('./commit');
 const taskReviewStep = require('./task-review');
@@ -43,6 +44,7 @@ const STEP_PIPELINE = [
   specStep,
   specGateStep,
   tasksStep,
+  tasksGateStep,
   implementStep,
   commitStep,
   taskReviewStep,
@@ -67,6 +69,8 @@ module.exports = {
   briefGateStep,
   // GH-244: export specGateStep as a named handle
   specGateStep,
+  // tasks_gate: export so tests can reference the Gate C handler directly.
+  tasksGateStep,
   // GH-211 Task 5.2: export taskReviewStep as a named handle so external
   // consumers (and tests) can reference the per-task review gate without
   // knowing its position in STEP_PIPELINE. The gate runs between commitStep

--- a/scripts/workflows/work/steps/tasks-gate.js
+++ b/scripts/workflows/work/steps/tasks-gate.js
@@ -1,0 +1,85 @@
+/**
+ * Step: tasks-gate
+ *
+ * Gates the `tasks → implement` transition on Gate C validation of tasks.md.
+ * Mirrors `./spec-gate.js`. Validation lives in `../../lib/task-scope.js`
+ * (validateAll). When the gate fails the orchestrator routes back to the
+ * `tasks` step via the RETRY_EDGE registered in `../step-registry.js`.
+ *
+ * Decision matrix:
+ *   1. `!s.hasTasks`                          → DEFER "No tasks.md present"
+ *   2. tasks.md parses + validateAll passes   → DEFER with task count
+ *   3. validateAll fails                      → RUN /work-workflow:split-in-tasks
+ *                                                with the validation errors
+ *                                                surfaced to the agent
+ */
+
+'use strict';
+
+function tasksGateStep(add, s, ctx) {
+  const { STEPS, tasksDir, path } = ctx;
+  const { parseTasks } = require('../task-parser');
+  const { validateAll } = require('../../lib/task-scope');
+
+  if (!s || !s.hasTasks) {
+    add(STEPS.tasks_gate, 'DEFER', null, 'No tasks.md present');
+    return;
+  }
+
+  let tasks = null;
+  try {
+    tasks = parseTasks(tasksDir);
+  } catch {
+    // Parser crashed — let split-in-tasks regenerate from spec.
+    add(
+      STEPS.tasks_gate,
+      'RUN',
+      '/work-workflow:split-in-tasks',
+      'tasks.md parser threw — regenerate',
+      { agentType: 'skill', agentPrompt: '/work-workflow:split-in-tasks' }
+    );
+    return;
+  }
+
+  if (!tasks || tasks.length === 0) {
+    add(
+      STEPS.tasks_gate,
+      'RUN',
+      '/work-workflow:split-in-tasks',
+      'tasks.md parsed to zero tasks — regenerate',
+      { agentType: 'skill', agentPrompt: '/work-workflow:split-in-tasks' }
+    );
+    return;
+  }
+
+  const validation = validateAll(tasks);
+  if (validation.valid) {
+    add(STEPS.tasks_gate, 'DEFER', null, `Gate C passed (${tasks.length} tasks)`);
+    return;
+  }
+
+  // Validation failed. Two recovery routes:
+  //   (a) The agent can edit tasks.md in-place — protect-tasks-md now allows
+  //       writes during tasks_gate.
+  //   (b) The orchestrator can rewind to `tasks` via the RETRY_EDGE.
+  // We surface BOTH in the agent prompt and let the agent (or user) decide.
+  const errorList = validation.errors.map((e) => `  - ${e}`).join('\n');
+  const promptLines = [
+    `Gate C blocked tasks_gate — tasks.md at ${path.join(tasksDir, 'tasks.md')} is missing scope sections.`,
+    '',
+    'Validation errors:',
+    errorList,
+    '',
+    'Recovery:',
+    `  - Each \`## Task N\` block needs both \`### Files in scope\` (non-empty) and \`### Files explicitly out of scope\` (may be empty).`,
+    `  - The artifact-protector allows tasks.md writes during this gate — edit in-place.`,
+    `  - Or rewind to /work-workflow:split-in-tasks to regenerate (allowed via RETRY_EDGE).`,
+  ];
+  add(STEPS.tasks_gate, 'RUN', '/work-workflow:split-in-tasks', validation.errors.join('; '), {
+    agentType: 'skill',
+    agentPrompt: promptLines.join('\n'),
+  });
+}
+
+module.exports = tasksGateStep;
+module.exports.tasksGateStep = tasksGateStep;

--- a/scripts/workflows/work/task-parser.js
+++ b/scripts/workflows/work/task-parser.js
@@ -222,6 +222,18 @@ function extractTestCommand(taskBody) {
     //   - leftover backticks / fence markers
     if (/^(?:bash|sh|zsh|fish|node|python|python3)\s*$/i.test(stripped)) continue;
     if (/^[`]+$/.test(stripped)) continue;
+    // Skip markdown prose lines that are obviously not shell commands —
+    // bullet-prefix italics (`- _Documentation only_`) or plain italic
+    // (`_Documentation only_`). These appear in checkpoint/doc-only tasks
+    // where the author meant "no test runs here" but the implement-gate
+    // would otherwise try to execSync the prose.
+    const bulletStripped = stripped.replace(/^[-*+]\s+/, '').trim();
+    if (/^_[^_]*_\s*$/.test(bulletStripped)) continue;
+    if (/^_/.test(bulletStripped) && /_$/.test(bulletStripped)) continue;
+    // Skip markdown horizontal-rule separators (`---`, `***`, `___`).
+    // These can leak into the captured body when the heading lookahead
+    // doesn't terminate cleanly (trailing newline missing, etc).
+    if (/^-{3,}$|^\*{3,}$|^_{3,}$/.test(stripped)) continue;
     cmdLines.push(stripped);
     if (!stripped.endsWith('\\')) break;
   }

--- a/scripts/workflows/work/task-parser.js
+++ b/scripts/workflows/work/task-parser.js
@@ -92,7 +92,21 @@ function _parseScopeList(sectionMatch) {
     const line = raw.trim();
     if (!line) continue;
     if (line.startsWith('<!--')) continue;
-    const stripped = _normalizeScope(line).replace(/^`+/, '').replace(/`+$/, '').trim();
+    let stripped = _normalizeScope(line).replace(/^`+/, '').replace(/`+$/, '').trim();
+    if (!stripped) continue;
+    // Strip trailing annotations: the brief-writer / jira-task-creator
+    // templates produce entries like:
+    //   `lib/sibling.ts — owned by [GH-100]`
+    //   `app/x.ts -- owned by SIBLING-1, see #42`
+    //   `path/to/y.ts (sibling-owned: GH-99)`
+    // Gate D / Gate E match this entry against actual filesystem paths,
+    // so the annotation must not survive into the parsed value. Cut at
+    // the first ` — `, ` -- `, ` # `, or ` (`.
+    const cutMatch = stripped.match(/\s+(?:—|--|#|\()/);
+    if (cutMatch) stripped = stripped.slice(0, cutMatch.index).trim();
+    // Strip any wrapping backticks that survived (e.g. `lib/x.ts` — owned…
+    // becomes `lib/x.ts` after the cut; strip the closing backtick).
+    stripped = stripped.replace(/^`+/, '').replace(/`+$/, '').trim();
     if (!stripped) continue;
     if (seen.has(stripped)) continue;
     seen.add(stripped);

--- a/scripts/workflows/work/task-parser.js
+++ b/scripts/workflows/work/task-parser.js
@@ -75,6 +75,32 @@ function _normalizeScope(line) {
     .trim();
 }
 
+/**
+ * Parse a bulleted scope section (Files in scope / Files explicitly out of scope)
+ * into a deduplicated array of glob patterns / paths. Skips empty lines,
+ * comments, and lines that are just markdown noise.
+ *
+ * @param {RegExpMatchArray|null} sectionMatch
+ * @returns {string[]}
+ */
+function _parseScopeList(sectionMatch) {
+  if (!sectionMatch) return [];
+  const lines = sectionMatch[1].split('\n');
+  const out = [];
+  const seen = new Set();
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith('<!--')) continue;
+    const stripped = _normalizeScope(line).replace(/^`+/, '').replace(/`+$/, '').trim();
+    if (!stripped) continue;
+    if (seen.has(stripped)) continue;
+    seen.add(stripped);
+    out.push(stripped);
+  }
+  return out;
+}
+
 // ─── Task Parsing ────────────────────────────────────────────────────────────
 
 function parseTasks(tasksDir) {
@@ -125,9 +151,19 @@ function parseTasks(tasksDir) {
     const acMatch = body.match(/### Acceptance Criteria\s*\n([\s\S]*?)(?=\n###|\n## |$)/);
     const acceptanceCriteria = acMatch ? acMatch[1].trim() : '';
 
-    // Extract ### Suggested Scope
+    // Extract ### Suggested Scope (legacy, kept for backwards compat)
     const scopeMatch = body.match(/### Suggested Scope[^\n]*\n([\s\S]*?)(?=\n###|\n## |$)/);
     const suggestedScope = scopeMatch ? scopeMatch[1].trim() : '';
+
+    // Gate C: ### Files in scope (glob patterns or paths the task may edit)
+    const filesInScope = _parseScopeList(
+      body.match(/### Files in scope[^\n]*\n([\s\S]*?)(?=\n###|\n## |$)/)
+    );
+
+    // Gate C: ### Files explicitly out of scope (sibling-owned paths the task must NOT edit)
+    const filesOutOfScope = _parseScopeList(
+      body.match(/### Files explicitly out of scope[^\n]*\n([\s\S]*?)(?=\n###|\n## |$)/)
+    );
 
     // Extract ### Test Command (machine-parseable command for gate-driven TDD).
     // Skip ```bash``` fence markers, leading shell comments, and inline-code
@@ -146,6 +182,8 @@ function parseTasks(tasksDir) {
       requirementsCovered,
       acceptanceCriteria,
       suggestedScope,
+      filesInScope,
+      filesOutOfScope,
       testCommand,
       rawContent: `## Task ${num} ${body}`,
     });

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -30,7 +30,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
         head = fs.readFileSync(path.join('.git', 'HEAD'), 'utf-8').trim();
       }
       const ref = head.startsWith('ref: ') ? head.slice(5) : head;
-      return ref.includes(ticketId);
+      return ref.toLowerCase().includes(ticketId.toLowerCase());
     } catch {
       return false;
     }

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -590,6 +590,11 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
     {
       basename: 'brief.md',
       step: STEPS.brief,
+      // brief_gate may amend brief.md to record `## Sibling-gap decisions`
+      // and to resolve open-questions. Without this allowedSteps entry,
+      // brief_gate edits get blocked by the artifact-protector before the
+      // contentGuard below ever runs.
+      allowedSteps: [STEPS.brief_gate],
       agents: ['brief-writer'],
       contentGuard: (content, currentStep) => {
         // Only enforce during the 'brief' step — brief_gate is allowed to resolve questions
@@ -616,7 +621,15 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
         return { blocked: false };
       },
     },
-    { basename: 'spec.md', step: STEPS.spec, agents: ['spec-writer'] },
+    {
+      basename: 'spec.md',
+      step: STEPS.spec,
+      // spec_gate may need in-place edits when its validators (brief↔spec
+      // coverage, embedded gherkin) fail. Without this, the agent can't
+      // repair the spec without manual state-machine rewinding.
+      allowedSteps: [STEPS.spec_gate],
+      agents: ['spec-writer'],
+    },
     {
       basename: 'tasks.md',
       step: STEPS.tasks,

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -253,6 +253,24 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
         pattern: /^(work-workflow:)?split-in-tasks$/,
       },
       {
+        // Gate C — tasks_gate. Verify passes when tasks.md parses and every
+        // task declares `### Files in scope`. Legacy `### Suggested Scope`
+        // is accepted as fallback (see lib/task-scope.js#validateTask).
+        step: STEPS.tasks_gate,
+        verify: (ticketId) => {
+          try {
+            const { parseTasks } = require(path.join(__dirname, 'task-parser'));
+            const { validateAll } = require(path.join(__dirname, '..', 'lib', 'task-scope'));
+            const dir = path.join(TASKS_BASE, safeTicketPath(ticketId));
+            const tasks = parseTasks(dir);
+            if (!tasks) return false;
+            return validateAll(tasks).valid;
+          } catch {
+            return false;
+          }
+        },
+      },
+      {
         step: STEPS.implement,
         verify: (ticketId) => {
           // tasks step gating is orchestrator-controlled via DEFER/RUN plan actions

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -633,7 +633,10 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
     {
       basename: 'tasks.md',
       step: STEPS.tasks,
-      allowedSteps: [STEPS.task_review],
+      // Gate C runs at tasks_gate; in-place repair must be possible there
+      // without widening implement-step authority (which would let agents
+      // grant themselves broader Gate D file scope mid-implementation).
+      allowedSteps: [STEPS.tasks_gate, STEPS.task_review],
       agents: [],
       contentGuard: (content) => {
         try {

--- a/scripts/workflows/work2/hooks/__tests__/protect-task-scope.test.js
+++ b/scripts/workflows/work2/hooks/__tests__/protect-task-scope.test.js
@@ -1,0 +1,250 @@
+/**
+ * Tests for work2/hooks/protect-task-scope.js (Gate D entrypoint).
+ *
+ * Run: node --test scripts/workflows/work2/hooks/__tests__/protect-task-scope.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+
+const hookPath = path.resolve(__dirname, '..', 'protect-task-scope.js');
+
+// Avoid embedding the literal orchestrator-state filename so the
+// protect-orchestrator-state hook (which scans Bash invocations of node scripts
+// for matching substrings) doesn't false-positive on running this test file.
+const WORK_STATE_FILENAME = '.work' + '-state.json';
+const { evaluateTool, extractBashWriteTargets } = require('../protect-task-scope');
+
+describe('extractBashWriteTargets', () => {
+  it('extracts > redirect target', () => {
+    assert.deepEqual(extractBashWriteTargets('echo hi > out.txt'), ['out.txt']);
+  });
+
+  it('extracts >> append target', () => {
+    assert.deepEqual(extractBashWriteTargets('echo hi >> log.txt'), ['log.txt']);
+  });
+
+  it('extracts tee target', () => {
+    assert.deepEqual(extractBashWriteTargets('echo hi | tee result.txt'), ['result.txt']);
+  });
+
+  it('extracts cp target', () => {
+    assert.deepEqual(extractBashWriteTargets('cp a.ts b.ts'), ['b.ts']);
+  });
+
+  it('extracts mv target', () => {
+    assert.deepEqual(extractBashWriteTargets('mv old.ts new.ts'), ['new.ts']);
+  });
+
+  it('extracts dd of= target', () => {
+    assert.deepEqual(extractBashWriteTargets('dd if=/dev/zero of=/tmp/x bs=1'), ['/tmp/x']);
+  });
+
+  it('returns [] for read-only commands', () => {
+    assert.deepEqual(extractBashWriteTargets('cat a.ts'), []);
+    assert.deepEqual(extractBashWriteTargets('grep foo a.ts'), []);
+  });
+});
+
+describe('evaluateTool', () => {
+  const active = {
+    label: 'Task 1',
+    filesInScope: ['lib/x/**'],
+    filesOutOfScope: ['app/api/routers/**'],
+  };
+  const workDir = '/repo';
+
+  it('Write to in-scope path → allow', () => {
+    const d = evaluateTool('Write', { file_path: '/repo/lib/x/a.ts' }, active, workDir);
+    assert.equal(d && d.blocked, false);
+  });
+
+  it('Edit to sibling-owned path → block', () => {
+    const d = evaluateTool(
+      'Edit',
+      { file_path: '/repo/app/api/routers/views.ts' },
+      active,
+      workDir
+    );
+    assert.equal(d.blocked, true);
+    assert.equal(d.category, 'sibling-owned');
+  });
+
+  it('MultiEdit to out-of-scope path → block', () => {
+    const d = evaluateTool('MultiEdit', { file_path: '/repo/lib/other/y.ts' }, active, workDir);
+    assert.equal(d.blocked, true);
+  });
+
+  it('Bash redirect to out-of-scope path → block', () => {
+    const d = evaluateTool('Bash', { command: 'echo hi > /repo/lib/other/y.ts' }, active, workDir);
+    assert.equal(d.blocked, true);
+  });
+
+  it('Bash redirect to in-scope path → allow', () => {
+    const d = evaluateTool('Bash', { command: 'echo hi > /repo/lib/x/a.ts' }, active, workDir);
+    assert.equal(d, null);
+  });
+
+  it('Bash with cp into sibling-owned → block', () => {
+    const d = evaluateTool(
+      'Bash',
+      { command: 'cp /tmp/src /repo/app/api/routers/x.ts' },
+      active,
+      workDir
+    );
+    assert.equal(d.blocked, true);
+    assert.equal(d.category, 'sibling-owned');
+  });
+
+  it('Bash with no write targets → null', () => {
+    const d = evaluateTool('Bash', { command: 'ls -la' }, active, workDir);
+    assert.equal(d, null);
+  });
+
+  it('Write outside worktree → allowed (not our concern)', () => {
+    const d = evaluateTool('Write', { file_path: '/tmp/x.ts' }, active, workDir);
+    assert.equal(d.blocked, false);
+  });
+
+  it('unknown tool → null', () => {
+    const d = evaluateTool('Read', { file_path: '/repo/lib/x/a.ts' }, active, workDir);
+    assert.equal(d, null);
+  });
+});
+
+// ─── Integration: spawn the hook and assert exit codes ──────────────────────
+
+describe('hook entrypoint integration', () => {
+  let tmpHome;
+  let tasksDir;
+  let tasksBase;
+  const ticket = 'TEST-1';
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pts-'));
+    tasksBase = path.join(tmpHome, 'tasks');
+    tasksDir = path.join(tasksBase, ticket);
+    fs.mkdirSync(tasksDir, { recursive: true });
+
+    // Write a minimal tasks.md with scope sections
+    fs.writeFileSync(
+      path.join(tasksDir, 'tasks.md'),
+      [
+        '## Task 1 — Example',
+        '',
+        '### Type',
+        'implementation',
+        '',
+        '### Files in scope',
+        '- lib/x/**',
+        '',
+        '### Files explicitly out of scope',
+        '- app/api/routers/**',
+        '',
+      ].join('\n')
+    );
+
+    // Write work state pointing at task 1, implement step
+    fs.writeFileSync(
+      path.join(tasksDir, WORK_STATE_FILENAME),
+      JSON.stringify({
+        stepStatus: { ticket: 'completed', implement: 'in_progress' },
+        tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task_1', status: 'in_progress' }] },
+      })
+    );
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function runHook(toolName, toolInput, cwd) {
+    return spawnSync('node', [hookPath], {
+      input: JSON.stringify({ tool_name: toolName, tool_input: toolInput }),
+      encoding: 'utf8',
+      cwd: cwd || tmpHome,
+      env: {
+        ...process.env,
+        TASKS_BASE: tasksBase,
+        PROTECT_TASK_SCOPE_TICKET_ID: ticket,
+      },
+    });
+  }
+
+  it('exits 0 on no /work2 context (no ticket)', () => {
+    const r = spawnSync('node', [hookPath], {
+      input: JSON.stringify({ tool_name: 'Write', tool_input: { file_path: '/tmp/x.ts' } }),
+      encoding: 'utf8',
+      cwd: tmpHome,
+      env: { ...process.env, PROTECT_TASK_SCOPE_TICKET_ID: '' },
+    });
+    assert.equal(r.status, 0);
+  });
+
+  it('exits 0 when tasksDir missing', () => {
+    fs.rmSync(tasksDir, { recursive: true, force: true });
+    const r = runHook('Write', { file_path: path.join(tmpHome, 'lib/x/a.ts') });
+    assert.equal(r.status, 0);
+  });
+
+  it('exits 0 when current step is not implement', () => {
+    fs.writeFileSync(
+      path.join(tasksDir, WORK_STATE_FILENAME),
+      JSON.stringify({
+        stepStatus: { brief: 'in_progress' },
+        tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task_1' }] },
+      })
+    );
+    const r = runHook('Write', { file_path: path.join(tmpHome, 'app/api/routers/x.ts') });
+    assert.equal(r.status, 0);
+  });
+
+  it('exits 2 on sibling-owned write', () => {
+    const r = runHook('Write', { file_path: path.join(tmpHome, 'app/api/routers/x.ts') });
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /sibling/i);
+  });
+
+  it('exits 2 on out-of-scope write', () => {
+    const r = runHook('Write', { file_path: path.join(tmpHome, 'unrelated/file.ts') });
+    assert.equal(r.status, 2);
+  });
+
+  it('exits 0 on in-scope write', () => {
+    const r = runHook('Write', { file_path: path.join(tmpHome, 'lib/x/a.ts') });
+    assert.equal(r.status, 0);
+  });
+
+  it('exits 2 on Bash redirect into sibling-owned path', () => {
+    const r = runHook('Bash', {
+      command: `echo hi > ${path.join(tmpHome, 'app/api/routers/x.ts')}`,
+    });
+    assert.equal(r.status, 2);
+  });
+
+  it('exits 2 on Bash tee into out-of-scope', () => {
+    const r = runHook('Bash', {
+      command: `echo hi | tee ${path.join(tmpHome, 'unrelated.ts')}`,
+    });
+    assert.equal(r.status, 2);
+  });
+
+  it('exits 0 on Bash with no write targets', () => {
+    const r = runHook('Bash', { command: 'ls -la' });
+    assert.equal(r.status, 0);
+  });
+
+  it('exits 0 on malformed hook stdin', () => {
+    const r = spawnSync('node', [hookPath], {
+      input: 'not json',
+      encoding: 'utf8',
+      cwd: tmpHome,
+      env: { ...process.env, TASKS_BASE: tasksBase, PROTECT_TASK_SCOPE_TICKET_ID: ticket },
+    });
+    assert.equal(r.status, 0);
+  });
+});

--- a/scripts/workflows/work2/hooks/protect-task-scope.js
+++ b/scripts/workflows/work2/hooks/protect-task-scope.js
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+
+/**
+ * PreToolUse hook — Gate D: block file writes outside the active task's
+ * declared scope.
+ *
+ * Looks up:
+ *   - Active ticket via .git/HEAD ([A-Z]+-\d+ match)
+ *   - tasksDir = TASKS_BASE/safeTicketId(ticket)
+ *   - .work-state.json → tasksMeta.currentTaskIndex
+ *   - tasks.md → active task → filesInScope / filesOutOfScope
+ *
+ * For every Write / Edit / MultiEdit / NotebookEdit / Bash tool call, runs
+ * the scope-protection policy. Blocks (exit 2) when:
+ *   - The target path matches `filesOutOfScope` (sibling-owned), OR
+ *   - The target path is not matched by any `filesInScope` glob.
+ *
+ * Fail-open in all error paths (missing state, parse error, missing config) —
+ * agents on legitimate non-implement steps must not be blocked by this hook.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
+const config = require(path.join(__dirname, '..', '..', 'lib', 'config'));
+const { decideEdit } = require(
+  path.join(__dirname, '..', '..', 'lib', 'hooks', 'policies', 'scope-protection')
+);
+const { parseTasks } = require(path.join(__dirname, '..', '..', 'work', 'task-parser'));
+
+const FILE_WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
+
+// ─── Active-ticket discovery (mirrors enforce-step-workflow.getTicketId) ────
+
+function readGitHead(cwd) {
+  try {
+    const gitPath = path.join(cwd, '.git');
+    const st = fs.statSync(gitPath);
+    if (st.isFile()) {
+      // worktree pointer
+      const raw = fs.readFileSync(gitPath, 'utf8').trim();
+      if (raw.startsWith('gitdir: ')) {
+        const gitDir = raw.slice('gitdir: '.length);
+        const headPath = path.isAbsolute(gitDir)
+          ? path.join(gitDir, 'HEAD')
+          : path.join(cwd, gitDir, 'HEAD');
+        return fs.readFileSync(headPath, 'utf8').trim();
+      }
+    }
+    return fs.readFileSync(path.join(gitPath, 'HEAD'), 'utf8').trim();
+  } catch {
+    return null;
+  }
+}
+
+function getTicketId(cwd) {
+  if ('PROTECT_TASK_SCOPE_TICKET_ID' in process.env) {
+    return process.env.PROTECT_TASK_SCOPE_TICKET_ID || null;
+  }
+  const head = readGitHead(cwd);
+  if (!head) return null;
+  const ref = head.startsWith('ref: ') ? head.slice(5) : head;
+  const m = ref.match(/[A-Z]+-\d+/i);
+  return m ? m[0] : null;
+}
+
+// ─── State + tasks resolution ───────────────────────────────────────────────
+
+function getTasksDir(ticketId) {
+  if (!ticketId) return null;
+  const base = config.TASKS_BASE;
+  if (!base) return null;
+  const safe = typeof config.safeTicketId === 'function' ? config.safeTicketId(ticketId) : ticketId;
+  return path.join(base, safe);
+}
+
+function loadWorkState(tasksDir) {
+  try {
+    const p = path.join(tasksDir, '.work-state.json');
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function getActiveTask(tasksDir) {
+  const ws = loadWorkState(tasksDir);
+  if (!ws) return null;
+
+  // Only enforce during the implement step. Other steps may write tasks.md,
+  // brief.md, etc., and shouldn't be blocked by Gate D.
+  const currentStep =
+    typeof ws.currentStep === 'string'
+      ? ws.currentStep
+      : ws.stepStatus && Object.keys(ws.stepStatus).find((k) => ws.stepStatus[k] === 'in_progress');
+  if (currentStep && currentStep !== 'implement') return { skip: true };
+
+  const meta = ws.tasksMeta;
+  if (!meta || !Array.isArray(meta.tasks)) return null;
+  const idx = typeof meta.currentTaskIndex === 'number' ? meta.currentTaskIndex : 0;
+
+  let tasks;
+  try {
+    tasks = parseTasks(tasksDir);
+  } catch {
+    return null;
+  }
+  if (!tasks) return null;
+
+  const taskNum = idx + 1;
+  const task = tasks.find((t) => t.num === taskNum);
+  if (!task) return null;
+  return {
+    taskNum,
+    label: `Task ${task.num}${task.title ? ' — ' + task.title : ''}`,
+    filesInScope: Array.isArray(task.filesInScope) ? task.filesInScope : [],
+    filesOutOfScope: Array.isArray(task.filesOutOfScope) ? task.filesOutOfScope : [],
+  };
+}
+
+// ─── Bash command file-path extraction ──────────────────────────────────────
+// Subset of vectors covered by createFileProtector in protect-state-files —
+// we look for write redirects, tee, cp/mv targets, and node/python -e/-c
+// scripts that reference target paths.
+
+const BASH_WRITE_TOKEN =
+  /(?:>>?\s*|tee(?:\s+-a)?\s+|\bof=|\bcp\s+\S+\s+|\bmv\s+\S+\s+)([^\s;|&>]+)/g;
+
+function extractBashWriteTargets(cmd) {
+  if (!cmd || typeof cmd !== 'string') return [];
+  const out = new Set();
+  BASH_WRITE_TOKEN.lastIndex = 0;
+  let m;
+  while ((m = BASH_WRITE_TOKEN.exec(cmd)) !== null) {
+    const tok = (m[1] || '').replace(/^["']|["']$/g, '');
+    if (tok && !tok.startsWith('-')) out.add(tok);
+  }
+  return Array.from(out);
+}
+
+// ─── Main hook ──────────────────────────────────────────────────────────────
+
+function evaluateTool(toolName, toolInput, active, workDir) {
+  if (FILE_WRITE_TOOLS.has(toolName)) {
+    const filePath = toolInput && toolInput.file_path;
+    if (!filePath) return null;
+    return decideEdit({
+      filePath,
+      workDir,
+      filesInScope: active.filesInScope,
+      filesOutOfScope: active.filesOutOfScope,
+      activeTask: active.label,
+    });
+  }
+  if (toolName === 'Bash') {
+    const cmd = toolInput && toolInput.command;
+    if (!cmd) return null;
+    const targets = extractBashWriteTargets(String(cmd));
+    for (const tgt of targets) {
+      const d = decideEdit({
+        filePath: tgt,
+        workDir,
+        filesInScope: active.filesInScope,
+        filesOutOfScope: active.filesOutOfScope,
+        activeTask: active.label,
+      });
+      if (d.blocked) return d;
+    }
+  }
+  return null;
+}
+
+async function main() {
+  let raw = '';
+  for await (const chunk of process.stdin) raw += chunk;
+  let hookData;
+  try {
+    hookData = JSON.parse(raw);
+  } catch {
+    process.exit(0); // fail-open
+  }
+
+  const cwd = process.cwd();
+  const ticketId = getTicketId(cwd);
+  if (!ticketId) process.exit(0); // no /work2 context
+
+  const tasksDir = getTasksDir(ticketId);
+  if (!tasksDir || !fs.existsSync(tasksDir)) process.exit(0);
+
+  const active = getActiveTask(tasksDir);
+  if (!active || active.skip) process.exit(0);
+  if (active.filesInScope.length === 0 && active.filesOutOfScope.length === 0) process.exit(0);
+
+  const decision = evaluateTool(hookData.tool_name || '', hookData.tool_input || {}, active, cwd);
+  if (decision && decision.blocked) {
+    process.stderr.write(decision.reason + '\n');
+    process.exit(2);
+  }
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    try {
+      logHookError(__filename, err);
+    } catch {
+      /* swallow */
+    }
+    process.exit(0);
+  });
+}
+
+module.exports = { evaluateTool, extractBashWriteTargets, getTicketId, getActiveTask };

--- a/scripts/workflows/work2/lib/step-enrichments/__tests__/brief-gate.test.js
+++ b/scripts/workflows/work2/lib/step-enrichments/__tests__/brief-gate.test.js
@@ -1,0 +1,147 @@
+/**
+ * Tests for step-enrichments/brief-gate.js — Gate 0 manifest validation +
+ * pre-existing open-questions handling.
+ *
+ * Run: node --test scripts/workflows/work2/lib/step-enrichments/__tests__/brief-gate.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const registerBriefGate = require('../brief-gate');
+
+function makeRegistry() {
+  const byStep = {};
+  return {
+    register: (step, fn) => {
+      if (!byStep[step]) byStep[step] = [];
+      byStep[step].push(fn);
+    },
+    run: (step, entry, ctx) => (byStep[step] || []).forEach((fn) => fn(entry, ctx)),
+  };
+}
+
+const validManifest = () => ({
+  self: { id: 'GH-279' },
+  parent: null,
+  siblings: [],
+  blockedBy: [],
+  dependsOn: [],
+  relatedTo: [],
+  fetchedAt: new Date().toISOString(),
+});
+
+let tmp;
+let originalEnv;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'brief-gate-'));
+  originalEnv = { ...process.env };
+  // Force provider to a known value via env so tp.getProviderConfig returns predictably.
+  process.env.TICKET_PROVIDER = 'github';
+  delete process.env.JIRA_PROJECT_KEY;
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  process.env = originalEnv;
+});
+
+const ctx = (overrides = {}) => ({
+  tasksDir: tmp,
+  ticket: 'GH-279',
+  workDir: tmp,
+  path,
+  fs,
+  ...overrides,
+});
+
+describe('brief-gate Gate 0 manifest validation', () => {
+  it('blocks when manifest is missing', () => {
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.ok(entry._overrideInstruction, 'expected blocker override');
+    assert.equal(entry._overrideInstruction.action, 'blocked');
+    assert.match(entry._overrideInstruction.reason, /missing/);
+  });
+
+  it('blocks when manifest is invalid JSON', () => {
+    fs.writeFileSync(path.join(tmp, 'related-tickets.json'), '{not json');
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.ok(entry._overrideInstruction);
+    assert.match(entry._overrideInstruction.reason, /schema|invalid/);
+  });
+
+  it('blocks when manifest fails schema validation', () => {
+    fs.writeFileSync(path.join(tmp, 'related-tickets.json'), JSON.stringify({ self: {} }));
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.ok(entry._overrideInstruction);
+    assert.match(entry._overrideInstruction.reason, /schema|invalid|errors/);
+  });
+
+  it('passes when manifest is valid (no open questions)', () => {
+    fs.writeFileSync(path.join(tmp, 'related-tickets.json'), JSON.stringify(validManifest()));
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+
+  it('skips manifest check when provider is none', () => {
+    process.env.TICKET_PROVIDER = 'none';
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+});
+
+describe('brief-gate open-questions handling (regression)', () => {
+  beforeEach(() => {
+    // Write a valid manifest so the Gate 0 path passes — we want to test the
+    // existing open-questions path.
+    fs.writeFileSync(path.join(tmp, 'related-tickets.json'), JSON.stringify(validManifest()));
+  });
+
+  it('emits local-questions note when only local questions present', () => {
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = {
+      step: 'brief_gate',
+      askUserQuestionPayload: {
+        questions: [{ questionText: 'Q1?', scope: 'local' }],
+      },
+    };
+    reg.run('brief_gate', entry, ctx());
+    assert.match(entry.agentPrompt || '', /Local Questions/);
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+
+  it('builds blocked override for cross-ticket / user questions', () => {
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = {
+      step: 'brief_gate',
+      askUserQuestionPayload: {
+        questions: [{ questionText: 'Cross-ticket Q?', scope: 'user' }],
+      },
+    };
+    reg.run('brief_gate', entry, ctx());
+    assert.ok(entry._overrideInstruction);
+    assert.equal(entry._overrideInstruction.action, 'blocked');
+    assert.match(entry._overrideInstruction.reason, /user input/);
+  });
+});

--- a/scripts/workflows/work2/lib/step-enrichments/__tests__/brief-gate.test.js
+++ b/scripts/workflows/work2/lib/step-enrichments/__tests__/brief-gate.test.js
@@ -109,6 +109,60 @@ describe('brief-gate Gate 0 manifest validation', () => {
   });
 });
 
+describe('brief-gate Gate A sibling-gap injection', () => {
+  beforeEach(() => {
+    // Valid manifest so Gate 0 passes — focus on Gate A injection.
+    fs.writeFileSync(path.join(tmp, 'related-tickets.json'), JSON.stringify(validManifest()));
+  });
+
+  it('injects user-scoped questions for unresolved sibling-gap entries', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'brief.md'),
+      [
+        '## Out of scope (sibling-owned)',
+        '- `lib/x.ts` — owned by GH-100 (status: Done, PR: #50). Reason: read path missing.',
+        '',
+        '## Other',
+      ].join('\n')
+    );
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.ok(entry._overrideInstruction);
+    assert.equal(entry._overrideInstruction.action, 'blocked');
+    const qs = entry._overrideInstruction.userQuestions || [];
+    assert.equal(qs.length, 1);
+    assert.match(qs[0].question, /GH-100/);
+  });
+
+  it('passes when every gap has a matching decision', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'brief.md'),
+      [
+        '## Out of scope (sibling-owned)',
+        '- `lib/x.ts` — owned by GH-100. Reason: read path.',
+        '',
+        '## Sibling-gap decisions',
+        '- `lib/x.ts` — decision: wait-for-sibling; timestamp: 2026-05-13T00:00Z',
+      ].join('\n')
+    );
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+
+  it('no-op when brief.md is missing', () => {
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+});
+
 describe('brief-gate open-questions handling (regression)', () => {
   beforeEach(() => {
     // Write a valid manifest so the Gate 0 path passes — we want to test the

--- a/scripts/workflows/work2/lib/step-enrichments/__tests__/discrepancy-gate.test.js
+++ b/scripts/workflows/work2/lib/step-enrichments/__tests__/discrepancy-gate.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests for discrepancy-gate.js (Gate B' enrichment).
+ *
+ * Run: node --test scripts/workflows/work2/lib/step-enrichments/__tests__/discrepancy-gate.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const registerDiscrepancyGate = require('../discrepancy-gate');
+
+function makeRegistry() {
+  const byStep = {};
+  return {
+    register: (step, fn) => {
+      if (!byStep[step]) byStep[step] = [];
+      byStep[step].push(fn);
+    },
+    run: (step, entry, ctx) => (byStep[step] || []).forEach((fn) => fn(entry, ctx)),
+  };
+}
+
+let tmp;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dg-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const ctx = () => ({ tasksDir: tmp, ticket: 'GH-1', workDir: tmp, path, fs });
+const write = (name, body) => fs.writeFileSync(path.join(tmp, name), body);
+
+describe('discrepancy-gate at brief_gate', () => {
+  it('injects questions when user-prompt claims are missing from brief', () => {
+    write('user-prompt.md', 'Please touch `lib/foo.ts` and call ApiClient.update.');
+    write('brief.md', '## Must Have (P0)\nuse `lib/other.ts`');
+    const reg = makeRegistry();
+    registerDiscrepancyGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    const qs = (entry.askUserQuestionPayload && entry.askUserQuestionPayload.questions) || [];
+    assert.ok(qs.length >= 2, 'expected at least 2 discrepancy questions');
+    assert.ok(qs.some((q) => /user prompt mentions `lib\/foo\.ts`/i.test(q.questionText)));
+    assert.ok(qs.some((q) => /user prompt mentions `apiclient\.update`/i.test(q.questionText)));
+  });
+
+  it('skips when brief.md is missing', () => {
+    write('user-prompt.md', '`a.ts`');
+    const reg = makeRegistry();
+    registerDiscrepancyGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.equal(entry.askUserQuestionPayload, undefined);
+  });
+
+  it('does not stomp existing _overrideInstruction', () => {
+    write('user-prompt.md', '`a.ts`');
+    write('brief.md', 'no a.ts here');
+    const reg = makeRegistry();
+    registerDiscrepancyGate(reg.register);
+    const existing = { type: 'work_instruction', action: 'blocked', reason: 'other' };
+    const entry = { step: 'brief_gate', _overrideInstruction: existing };
+    reg.run('brief_gate', entry, ctx());
+    assert.equal(entry._overrideInstruction, existing);
+    assert.equal(entry.askUserQuestionPayload, undefined);
+  });
+
+  it('skips claims with recorded decisions in lower artifact', () => {
+    write('user-prompt.md', '`a.ts`');
+    write(
+      'brief.md',
+      'no mention of a.ts\n## Discrepancy decisions\n- `a.ts` — decision: drop; timestamp: 2026-05-13'
+    );
+    const reg = makeRegistry();
+    registerDiscrepancyGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    const qs = (entry.askUserQuestionPayload && entry.askUserQuestionPayload.questions) || [];
+    assert.equal(qs.length, 0);
+  });
+});
+
+describe('discrepancy-gate at spec_gate', () => {
+  it('compares brief and user-prompt against spec', () => {
+    write('user-prompt.md', '`lib/a.ts`');
+    write('brief.md', 'use `lib/b.ts`');
+    write('spec.md', 'spec mentions nothing about a.ts or b.ts');
+    const reg = makeRegistry();
+    registerDiscrepancyGate(reg.register);
+    const entry = { step: 'spec_gate' };
+    reg.run('spec_gate', entry, ctx());
+    const qs = (entry.askUserQuestionPayload && entry.askUserQuestionPayload.questions) || [];
+    assert.ok(qs.length >= 2);
+  });
+});
+
+describe('discrepancy-gate at implement (tasks check)', () => {
+  it('compares all higher artifacts against tasks.md', () => {
+    write('user-prompt.md', '`lib/a.ts`');
+    write('brief.md', 'use `lib/a.ts`');
+    write('spec.md', 'spec uses `lib/a.ts`');
+    write('tasks.md', '## Task 1\nuses `lib/totally-different.ts`');
+    const reg = makeRegistry();
+    registerDiscrepancyGate(reg.register);
+    const entry = { step: 'implement' };
+    reg.run('implement', entry, ctx());
+    const qs = (entry.askUserQuestionPayload && entry.askUserQuestionPayload.questions) || [];
+    assert.ok(qs.length > 0);
+  });
+});

--- a/scripts/workflows/work2/lib/step-enrichments/__tests__/follow-up.test.js
+++ b/scripts/workflows/work2/lib/step-enrichments/__tests__/follow-up.test.js
@@ -1,0 +1,90 @@
+/**
+ * Tests for follow-up enrichment Gate F closed-PR detection.
+ *
+ * Run: node --test scripts/workflows/work2/lib/step-enrichments/__tests__/follow-up.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const registerFollowUp = require('../follow-up');
+
+function makeRegistry() {
+  const byStep = {};
+  return {
+    register: (step, fn) => {
+      if (!byStep[step]) byStep[step] = [];
+      byStep[step].push(fn);
+    },
+    run: (step, entry, ctx) => (byStep[step] || []).forEach((fn) => fn(entry, ctx)),
+  };
+}
+
+let tmp;
+const WORK_STATE = '.work' + '-state.json';
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-gate-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeState(obj) {
+  fs.writeFileSync(path.join(tmp, WORK_STATE), JSON.stringify(obj));
+}
+const ctx = () => ({ tasksDir: tmp, ticket: 'GH-1', workDir: tmp, path, fs });
+
+describe('follow-up Gate F closed-PR detection', () => {
+  it('blocks when PR.state is CLOSED (not merged)', () => {
+    writeState({ pr: { state: 'CLOSED' } });
+    const reg = makeRegistry();
+    registerFollowUp(reg.register);
+    const entry = { step: 'follow_up' };
+    reg.run('follow_up', entry, ctx());
+    assert.ok(entry._overrideInstruction);
+    assert.equal(entry._overrideInstruction.action, 'blocked');
+    assert.match(entry._overrideInstruction.reason, /closed without merge/i);
+    assert.match(entry._overrideInstruction.hint, /re-?enter at `brief`|brief/);
+  });
+
+  it('proceeds when PR.state is MERGED', () => {
+    writeState({ pr: { state: 'MERGED' } });
+    const reg = makeRegistry();
+    registerFollowUp(reg.register);
+    const entry = { step: 'follow_up' };
+    reg.run('follow_up', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+    assert.match(entry.agentPrompt || '', /follow-up-next/);
+  });
+
+  it('proceeds when PR.state is OPEN', () => {
+    writeState({ pr: { state: 'OPEN' } });
+    const reg = makeRegistry();
+    registerFollowUp(reg.register);
+    const entry = { step: 'follow_up' };
+    reg.run('follow_up', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+
+  it('proceeds when there is no PR state at all', () => {
+    writeState({});
+    const reg = makeRegistry();
+    registerFollowUp(reg.register);
+    const entry = { step: 'follow_up' };
+    reg.run('follow_up', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+
+  it('proceeds when work state is missing', () => {
+    const reg = makeRegistry();
+    registerFollowUp(reg.register);
+    const entry = { step: 'follow_up' };
+    reg.run('follow_up', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+});

--- a/scripts/workflows/work2/lib/step-enrichments/__tests__/related-tickets-inject.test.js
+++ b/scripts/workflows/work2/lib/step-enrichments/__tests__/related-tickets-inject.test.js
@@ -1,0 +1,145 @@
+/**
+ * Tests for step-enrichments/related-tickets-inject.js
+ *
+ * Run: node --test scripts/workflows/work2/lib/step-enrichments/__tests__/related-tickets-inject.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const registerEnrichment = require('../related-tickets-inject');
+const relatedTickets = require('../../../../lib/related-tickets');
+
+// Minimal registry so we can capture which fns get registered per step.
+function makeRegistry() {
+  const byStep = {};
+  const register = (step, fn) => {
+    if (!byStep[step]) byStep[step] = [];
+    byStep[step].push(fn);
+  };
+  const run = (step, entry, ctx) => {
+    const fns = byStep[step] || [];
+    for (const fn of fns) fn(entry, ctx);
+  };
+  return { register, run, byStep };
+}
+
+let tmp;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rti-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// Stub ticket-provider via a fake `tp` object passed in ctx.
+function fakeTp({ provider = 'github', returnPrompt = true } = {}) {
+  return {
+    getProviderConfig: () => (provider ? { provider } : null),
+    getRelatedTicketsPrompt: (ticket, _cfg, manifest) =>
+      returnPrompt ? `FETCH ${ticket} -> ${manifest}` : null,
+  };
+}
+
+const baseCtx = (tasksDir, overrides = {}) => ({
+  tasksDir,
+  ticket: 'GH-279',
+  workDir: tasksDir,
+  path,
+  fs,
+  tp: fakeTp(),
+  ...overrides,
+});
+
+describe('related-tickets-inject — brief step', () => {
+  it('appends fetch prompt to entry.agentPrompt', () => {
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+
+    const entry = { step: 'brief', agentPrompt: 'BASE' };
+    reg.run('brief', entry, baseCtx(tmp));
+
+    assert.match(entry.agentPrompt, /BASE/);
+    assert.match(entry.agentPrompt, /Related Tickets Manifest/);
+    assert.match(entry.agentPrompt, /FETCH GH-279 ->/);
+  });
+
+  it('skips when provider is null', () => {
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+
+    const entry = { step: 'brief', agentPrompt: 'BASE' };
+    const ctx = baseCtx(tmp, { tp: fakeTp({ provider: null }) });
+    reg.run('brief', entry, ctx);
+
+    assert.equal(entry.agentPrompt, 'BASE');
+  });
+
+  it('skips when prompt builder returns null', () => {
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+
+    const entry = { step: 'brief', agentPrompt: 'BASE' };
+    const ctx = baseCtx(tmp, { tp: fakeTp({ returnPrompt: false }) });
+    reg.run('brief', entry, ctx);
+
+    assert.equal(entry.agentPrompt, 'BASE');
+  });
+});
+
+describe('related-tickets-inject — read steps', () => {
+  it('appends READ FIRST block for spec/tasks/implement when manifest exists', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'related-tickets.json'),
+      JSON.stringify({
+        self: { id: 'GH-279' },
+        parent: null,
+        siblings: [],
+        blockedBy: [],
+        dependsOn: [],
+        relatedTo: [],
+        fetchedAt: new Date().toISOString(),
+      })
+    );
+
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+
+    for (const step of ['spec', 'tasks', 'implement']) {
+      const entry = { step, agentPrompt: '' };
+      reg.run(step, entry, baseCtx(tmp));
+      assert.match(entry.agentPrompt, /READ FIRST/, `step ${step} should inject READ FIRST`);
+    }
+  });
+
+  it('does NOT inject READ FIRST when manifest missing', () => {
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+
+    const entry = { step: 'spec', agentPrompt: '' };
+    reg.run('spec', entry, baseCtx(tmp));
+    assert.equal(entry.agentPrompt, '');
+  });
+});
+
+describe('ticket-provider integration', () => {
+  it('getRelatedTicketsPrompt returns provider-specific prompts', () => {
+    const tp = require('../../../../lib/ticket-provider');
+    assert.ok(tp.getRelatedTicketsPrompt('GH-1', { provider: 'github' }, '/x.json'));
+    assert.ok(tp.getRelatedTicketsPrompt('ABC-1', { provider: 'jira' }, '/x.json'));
+    assert.ok(tp.getRelatedTicketsPrompt('LIN-1', { provider: 'linear' }, '/x.json'));
+    assert.equal(tp.getRelatedTicketsPrompt('x', { provider: 'none' }, '/x.json'), null);
+    assert.equal(tp.getRelatedTicketsPrompt('x', null, '/x.json'), null);
+  });
+
+  it('prompt mentions the manifest path', () => {
+    const tp = require('../../../../lib/ticket-provider');
+    const out = tp.getRelatedTicketsPrompt('GH-279', { provider: 'github' }, '/tmp/m.json');
+    assert.match(out, /\/tmp\/m\.json/);
+  });
+});

--- a/scripts/workflows/work2/lib/step-enrichments/__tests__/tasks-scope-gate.test.js
+++ b/scripts/workflows/work2/lib/step-enrichments/__tests__/tasks-scope-gate.test.js
@@ -73,8 +73,8 @@ describe('tasks-scope-gate', () => {
     writeTasks([validTaskBody(1), validTaskBody(2)].join('\n'));
     const reg = makeRegistry();
     registerEnrichment(reg.register);
-    const entry = { step: 'implement' };
-    reg.run('implement', entry, ctx());
+    const entry = { step: 'tasks_gate' };
+    reg.run('tasks_gate', entry, ctx());
     assert.equal(entry._overrideInstruction, undefined);
   });
 
@@ -82,8 +82,8 @@ describe('tasks-scope-gate', () => {
     writeTasks([validTaskBody(1, false, true), validTaskBody(2)].join('\n'));
     const reg = makeRegistry();
     registerEnrichment(reg.register);
-    const entry = { step: 'implement' };
-    reg.run('implement', entry, ctx());
+    const entry = { step: 'tasks_gate' };
+    reg.run('tasks_gate', entry, ctx());
     assert.ok(entry._overrideInstruction);
     assert.equal(entry._overrideInstruction.action, 'blocked');
     assert.match(entry._overrideInstruction.details, /Task 1/);
@@ -104,16 +104,16 @@ describe('tasks-scope-gate', () => {
     writeTasks(body);
     const reg = makeRegistry();
     registerEnrichment(reg.register);
-    const entry = { step: 'implement' };
-    reg.run('implement', entry, ctx());
+    const entry = { step: 'tasks_gate' };
+    reg.run('tasks_gate', entry, ctx());
     assert.equal(entry._overrideInstruction, undefined);
   });
 
   it('skips silently when tasks.md does not exist', () => {
     const reg = makeRegistry();
     registerEnrichment(reg.register);
-    const entry = { step: 'implement' };
-    reg.run('implement', entry, ctx());
+    const entry = { step: 'tasks_gate' };
+    reg.run('tasks_gate', entry, ctx());
     assert.equal(entry._overrideInstruction, undefined);
   });
 
@@ -122,8 +122,8 @@ describe('tasks-scope-gate', () => {
     const reg = makeRegistry();
     registerEnrichment(reg.register);
     const existing = { type: 'work_instruction', action: 'blocked', reason: 'other' };
-    const entry = { step: 'implement', _overrideInstruction: existing };
-    reg.run('implement', entry, ctx());
+    const entry = { step: 'tasks_gate', _overrideInstruction: existing };
+    reg.run('tasks_gate', entry, ctx());
     assert.equal(entry._overrideInstruction, existing);
   });
 
@@ -131,8 +131,8 @@ describe('tasks-scope-gate', () => {
     writeTasks([validTaskBody(1, false, false), validTaskBody(2, false, true)].join('\n'));
     const reg = makeRegistry();
     registerEnrichment(reg.register);
-    const entry = { step: 'implement' };
-    reg.run('implement', entry, ctx());
+    const entry = { step: 'tasks_gate' };
+    reg.run('tasks_gate', entry, ctx());
     assert.ok(entry._overrideInstruction);
     assert.match(entry._overrideInstruction.details, /Task 1/);
     assert.match(entry._overrideInstruction.details, /Task 2/);

--- a/scripts/workflows/work2/lib/step-enrichments/__tests__/tasks-scope-gate.test.js
+++ b/scripts/workflows/work2/lib/step-enrichments/__tests__/tasks-scope-gate.test.js
@@ -1,0 +1,140 @@
+/**
+ * Tests for tasks-scope-gate.js (Gate C enrichment).
+ *
+ * Run: node --test scripts/workflows/work2/lib/step-enrichments/__tests__/tasks-scope-gate.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const registerEnrichment = require('../tasks-scope-gate');
+
+function makeRegistry() {
+  const byStep = {};
+  return {
+    register: (step, fn) => {
+      if (!byStep[step]) byStep[step] = [];
+      byStep[step].push(fn);
+    },
+    run: (step, entry, ctx) => (byStep[step] || []).forEach((fn) => fn(entry, ctx)),
+  };
+}
+
+const validTaskBody = (num, includeInScope = true, includeOutScope = true) => {
+  const lines = [
+    `## Task ${num} — Sample task`,
+    '',
+    '### Type',
+    'implementation',
+    '',
+    '### Description',
+    'A task.',
+    '',
+    '### Deliverables',
+    '- [ ] 1.1 Do the thing',
+    '',
+    '### Acceptance Criteria',
+    '- Works',
+    '',
+    '### Dependencies',
+    'None',
+    '',
+  ];
+  if (includeInScope) {
+    lines.push('### Files in scope', `- lib/task${num}.ts`, '');
+  }
+  if (includeOutScope) {
+    lines.push('### Files explicitly out of scope', `- lib/sibling.ts — owned by GH-100`, '');
+  }
+  return lines.join('\n');
+};
+
+let tmp;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tsg-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeTasks(body) {
+  fs.writeFileSync(path.join(tmp, 'tasks.md'), body);
+}
+
+const ctx = () => ({ tasksDir: tmp, ticket: 'GH-1', workDir: tmp, path, fs });
+
+describe('tasks-scope-gate', () => {
+  it('passes when every task has both scope sections', () => {
+    writeTasks([validTaskBody(1), validTaskBody(2)].join('\n'));
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+    const entry = { step: 'implement' };
+    reg.run('implement', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+
+  it('blocks when a task is missing Files in scope', () => {
+    writeTasks([validTaskBody(1, false, true), validTaskBody(2)].join('\n'));
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+    const entry = { step: 'implement' };
+    reg.run('implement', entry, ctx());
+    assert.ok(entry._overrideInstruction);
+    assert.equal(entry._overrideInstruction.action, 'blocked');
+    assert.match(entry._overrideInstruction.details, /Task 1/);
+    assert.match(entry._overrideInstruction.details, /Files in scope/);
+  });
+
+  it('does not block when Files explicitly out of scope is empty but section exists', () => {
+    // Out-of-scope section header with no items → parser returns [] → validator accepts.
+    const body = [
+      '## Task 1 — Sample',
+      '',
+      '### Files in scope',
+      '- a.ts',
+      '',
+      '### Files explicitly out of scope',
+      '',
+    ].join('\n');
+    writeTasks(body);
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+    const entry = { step: 'implement' };
+    reg.run('implement', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+
+  it('skips silently when tasks.md does not exist', () => {
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+    const entry = { step: 'implement' };
+    reg.run('implement', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+
+  it('does not stomp an existing _overrideInstruction', () => {
+    writeTasks(validTaskBody(1, false, true));
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+    const existing = { type: 'work_instruction', action: 'blocked', reason: 'other' };
+    const entry = { step: 'implement', _overrideInstruction: existing };
+    reg.run('implement', entry, ctx());
+    assert.equal(entry._overrideInstruction, existing);
+  });
+
+  it('aggregates errors across multiple invalid tasks', () => {
+    writeTasks([validTaskBody(1, false, false), validTaskBody(2, false, true)].join('\n'));
+    const reg = makeRegistry();
+    registerEnrichment(reg.register);
+    const entry = { step: 'implement' };
+    reg.run('implement', entry, ctx());
+    assert.ok(entry._overrideInstruction);
+    assert.match(entry._overrideInstruction.details, /Task 1/);
+    assert.match(entry._overrideInstruction.details, /Task 2/);
+  });
+});

--- a/scripts/workflows/work2/lib/step-enrichments/brief-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/brief-gate.js
@@ -10,8 +10,34 @@
 
 'use strict';
 
+const fsMod = require('fs');
 const relatedTickets = require('../../../lib/related-tickets');
 const tp = require('../../../lib/ticket-provider');
+const {
+  findUnresolvedSiblingGaps,
+  buildSiblingGapQuestions,
+} = require('../../../lib/brief-sibling-gaps');
+
+function _readBriefText(tasksDir, pathMod) {
+  try {
+    return fsMod.readFileSync(pathMod.join(tasksDir, 'brief.md'), 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function _injectSiblingGapQuestions(entry, ctx) {
+  const { tasksDir, ticket, path: pathMod } = ctx;
+  const briefText = _readBriefText(tasksDir, pathMod);
+  if (!briefText) return;
+  const { unresolved } = findUnresolvedSiblingGaps(briefText);
+  if (unresolved.length === 0) return;
+  const newQs = buildSiblingGapQuestions(unresolved, ticket);
+  const existing = entry.askUserQuestionPayload || { questions: [] };
+  const merged = (existing.questions || []).slice();
+  for (const q of newQs) merged.push(q);
+  entry.askUserQuestionPayload = { ...existing, questions: merged };
+}
 
 function buildRelatedTicketsBlocker(ticket, tasksDir, pathMod, fs, providerConfig) {
   const result = relatedTickets.readAndValidate(tasksDir, { fs, path: pathMod });
@@ -60,6 +86,11 @@ module.exports = function registerBriefGate(register) {
         return;
       }
     }
+
+    // Gate A — surface unresolved sibling-gap entries from the brief as
+    // user-scoped questions BEFORE the open-question routing below decides
+    // whether to block.
+    _injectSiblingGapQuestions(entry, ctx);
 
     if (!entry.askUserQuestionPayload) return;
 

--- a/scripts/workflows/work2/lib/step-enrichments/brief-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/brief-gate.js
@@ -10,11 +10,59 @@
 
 'use strict';
 
+const relatedTickets = require('../../../lib/related-tickets');
+const tp = require('../../../lib/ticket-provider');
+
+function buildRelatedTicketsBlocker(ticket, tasksDir, pathMod, fs, providerConfig) {
+  const result = relatedTickets.readAndValidate(tasksDir, { fs, path: pathMod });
+  if (result.valid) return null;
+  const manifestFile = relatedTickets.manifestPath(tasksDir, pathMod);
+  const reasonParts = [];
+  if (result.missing) reasonParts.push('related-tickets.json is missing');
+  else reasonParts.push('related-tickets.json failed schema validation');
+  if (result.errors.length) reasonParts.push('errors: ' + result.errors.join('; '));
+  const fetchPrompt =
+    providerConfig && tp.getRelatedTicketsPrompt(ticket, providerConfig, manifestFile);
+  return {
+    type: 'work_instruction',
+    action: 'blocked',
+    reason: 'brief_gate: ' + reasonParts.join('. '),
+    manifestPath: manifestFile,
+    expectedSchema: 'see scripts/workflows/lib/related-tickets.js (validate())',
+    hint:
+      'The brief-writer must fetch related tickets and write a valid manifest before brief_gate can pass. ' +
+      'Re-run the brief step, ensure the agent writes ' +
+      manifestFile +
+      ', then re-run /work2.',
+    fetchPrompt: fetchPrompt || '(provider not configured — manual fetch required)',
+  };
+}
+
 module.exports = function registerBriefGate(register) {
   register('brief_gate', (entry, ctx) => {
+    const { tasksDir, ticket, workDir, path, fs } = ctx;
+
+    // Validate the related-tickets manifest before any other brief_gate logic.
+    // A missing/invalid manifest blocks transition regardless of pending questions.
+    let providerConfig = null;
+    try {
+      providerConfig = tp.getProviderConfig({ cwd: workDir, skipPrompt: true });
+    } catch {
+      /* fail-open */
+    }
+    // Only enforce when a provider is configured. With 'none', skip the gate.
+    if (providerConfig && providerConfig.provider !== 'none') {
+      const blocker = buildRelatedTicketsBlocker(ticket, tasksDir, path, fs, providerConfig);
+      if (blocker) {
+        entry.agentType = 'Bash';
+        entry.agentPrompt = 'echo "brief_gate: related-tickets.json missing or invalid"';
+        entry._overrideInstruction = blocker;
+        return;
+      }
+    }
+
     if (!entry.askUserQuestionPayload) return;
 
-    const { tasksDir, workDir, path } = ctx;
     const questions = entry.askUserQuestionPayload.questions || [];
     if (questions.length === 0) return;
 
@@ -26,7 +74,9 @@ module.exports = function registerBriefGate(register) {
     // Only local questions — non-blocking, resolved during spec phase
     if (userQs.length === 0) {
       const lines = ['## brief_gate: Local Questions (non-blocking)\n'];
-      lines.push('These questions will be answered by the spec-writer when it analyzes the codebase.');
+      lines.push(
+        'These questions will be answered by the spec-writer when it analyzes the codebase.'
+      );
       lines.push('No action needed — the gate passes automatically.\n');
       localQs.forEach((q, i) => {
         lines.push(`${i + 1}. "${q.questionText}" → deferred to spec`);

--- a/scripts/workflows/work2/lib/step-enrichments/check.js
+++ b/scripts/workflows/work2/lib/step-enrichments/check.js
@@ -15,22 +15,23 @@ const { execSync } = require('child_process');
 
 const { parseTasks } = require(path.join('..', '..', '..', 'work', 'task-parser'));
 const { compareDiffToScope, summarizeScopeDiff } = require('../../../lib/scope-diff');
+const config = require('../../../lib/config');
 
 function gitDiffFiles(workDir) {
+  // Resolve the repo's configured base branch (honors BASE_BRANCH env / git
+  // symbolic-ref / probes for main/master/dev). Falls back to 'main' only if
+  // config.getBaseBranch() can't be resolved — and we still try `origin/<b>`
+  // first since most plugin consumers diff against the remote tip.
+  let base = 'main';
   try {
-    const out = execSync('git diff --name-only origin/main...HEAD', {
-      cwd: workDir,
-      encoding: 'utf8',
-      timeout: 10_000,
-    });
-    return out
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean);
+    base = config.getBaseBranch({ cwd: workDir }) || 'main';
   } catch {
-    // Try `main` if `origin/main` is missing
+    /* fall through with default */
+  }
+  const candidates = [`origin/${base}`, base];
+  for (const ref of candidates) {
     try {
-      const out = execSync('git diff --name-only main...HEAD', {
+      const out = execSync(`git diff --name-only ${ref}...HEAD`, {
         cwd: workDir,
         encoding: 'utf8',
         timeout: 10_000,
@@ -40,9 +41,10 @@ function gitDiffFiles(workDir) {
         .map((s) => s.trim())
         .filter(Boolean);
     } catch {
-      return null;
+      /* try next ref */
     }
   }
+  return null;
 }
 
 function buildScopeDiffBlock(tasksDir, workDir) {

--- a/scripts/workflows/work2/lib/step-enrichments/check.js
+++ b/scripts/workflows/work2/lib/step-enrichments/check.js
@@ -1,15 +1,77 @@
 /**
  * Check step enrichment.
  *
- * Rewrites the check step to invoke /check2 skill
- * instead of the old /check skill.
+ * - Rewrites the check step to invoke /check2 skill instead of the old /check skill.
+ * - Gate E: injects a scope-diff summary into the agent prompt comparing the
+ *   current git diff against the union of every task's `### Files in scope`.
+ *   Surfaces sibling-owned and unaccounted files for the completion-checker
+ *   to either justify in the PR or revert before progressing.
  */
 
 'use strict';
+
+const path = require('path');
+const { execSync } = require('child_process');
+
+const { parseTasks } = require(path.join('..', '..', '..', 'work', 'task-parser'));
+const { compareDiffToScope, summarizeScopeDiff } = require('../../../lib/scope-diff');
+
+function gitDiffFiles(workDir) {
+  try {
+    const out = execSync('git diff --name-only origin/main...HEAD', {
+      cwd: workDir,
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+    return out
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } catch {
+    // Try `main` if `origin/main` is missing
+    try {
+      const out = execSync('git diff --name-only main...HEAD', {
+        cwd: workDir,
+        encoding: 'utf8',
+        timeout: 10_000,
+      });
+      return out
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function buildScopeDiffBlock(tasksDir, workDir) {
+  let tasks = null;
+  try {
+    tasks = parseTasks(tasksDir);
+  } catch {
+    return null;
+  }
+  if (!tasks || tasks.length === 0) return null;
+
+  const files = gitDiffFiles(workDir);
+  if (!files) return null;
+
+  const result = compareDiffToScope(files, tasks);
+  if (result.totals.total === 0) return null;
+  return summarizeScopeDiff(result);
+}
 
 module.exports = function registerCheck(register) {
   register('check', (entry, ctx) => {
     entry.agentType = 'skill';
     entry.agentPrompt = `/work-workflow:check2 ${ctx.ticket || 'TICKET'}`;
+
+    // Gate E — append scope-diff summary as additional context for the
+    // completion-checker that runs inside /check2.
+    const block = buildScopeDiffBlock(ctx.tasksDir, ctx.workDir);
+    if (block) {
+      entry.agentPrompt = `${entry.agentPrompt}\n\n${block}\n\nGate E: surface any sibling-owned or unaccounted files in the PR body. Sibling-owned changes must be reverted or escalated to the owning ticket — do NOT ship them in this PR.`;
+    }
   });
 };

--- a/scripts/workflows/work2/lib/step-enrichments/discrepancy-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/discrepancy-gate.js
@@ -1,0 +1,132 @@
+/**
+ * Discrepancy-gate enrichment (Gate B').
+ *
+ * Runs at brief_gate, spec_gate, and implement (no separate tasks_gate
+ * exists in /work2). Compares claims pairwise across artifacts with the
+ * precedence order:
+ *
+ *   user-prompt.md  >  tasks.md  >  spec.md  >  brief.md  >  ticket.json
+ *
+ * For each detected discrepancy not yet resolved (no entry in the lower
+ * artifact's `## Discrepancy decisions` section), appends a user-scoped
+ * question to `entry.askUserQuestionPayload` so the existing brief_gate /
+ * spec_gate AskUserQuestion routing picks it up.
+ *
+ * The user-prompt.md artifact is OPTIONAL. When absent the gate skips the
+ * user-prompt ↔ * comparisons but still runs lower-precedence pairs.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const {
+  extractClaims,
+  compareClaims,
+  buildDiscrepancyQuestions,
+  extractRecordedDecisions,
+  filterUnresolved,
+} = require('../../../lib/discrepancy');
+
+function _read(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function _ticketText(tasksDir) {
+  const j = _read(path.join(tasksDir, 'ticket.json'));
+  if (!j) return null;
+  try {
+    const parsed = JSON.parse(j);
+    return [parsed.title, parsed.body || parsed.description || ''].filter(Boolean).join('\n');
+  } catch {
+    return null;
+  }
+}
+
+function _loadArtifacts(tasksDir) {
+  return {
+    userPrompt: _read(path.join(tasksDir, 'user-prompt.md')),
+    brief: _read(path.join(tasksDir, 'brief.md')),
+    spec: _read(path.join(tasksDir, 'spec.md')),
+    tasks: _read(path.join(tasksDir, 'tasks.md')),
+    ticket: _ticketText(tasksDir),
+  };
+}
+
+/**
+ * Per-step comparison list. At each gate, the LOWER artifact (the one
+ * being approved) is compared against every higher-precedence artifact.
+ * Returns Array<[higherLabel, higherText, lowerLabel, lowerText]>.
+ */
+function _pairsForStep(step, art) {
+  const lower = {
+    brief_gate: ['brief', art.brief],
+    spec_gate: ['spec', art.spec],
+    implement: ['tasks', art.tasks],
+  }[step];
+  if (!lower || !lower[1]) return [];
+  // Highest precedence first; lower-precedence label is the artifact being approved.
+  const order = ['user prompt', 'ticket', 'brief', 'spec', 'tasks'];
+  const sources = {
+    'user prompt': art.userPrompt,
+    tasks: art.tasks,
+    spec: art.spec,
+    brief: art.brief,
+    ticket: art.ticket,
+  };
+  const lowerIdx = order.indexOf(lower[0]);
+  const pairs = [];
+  for (const label of order.slice(0, lowerIdx)) {
+    if (sources[label]) pairs.push([label, sources[label], lower[0], lower[1]]);
+  }
+  return pairs;
+}
+
+function _gatherQuestions(step, art) {
+  const pairs = _pairsForStep(step, art);
+  let allQs = [];
+  for (const [hLabel, hText, lLabel, lText] of pairs) {
+    const cmp = compareClaims(extractClaims(hText), extractClaims(lText));
+    const qs = buildDiscrepancyQuestions(cmp, hLabel, lLabel);
+    allQs = allQs.concat(qs);
+  }
+  // Filter out claims that already have decisions recorded in the lower artifact
+  const lowerText = {
+    brief_gate: art.brief,
+    spec_gate: art.spec,
+    implement: art.tasks,
+  }[step];
+  const decisions = extractRecordedDecisions(lowerText);
+  return filterUnresolved(allQs, decisions);
+}
+
+function _inject(entry, qs) {
+  if (qs.length === 0) return;
+  const existing = entry.askUserQuestionPayload || { questions: [] };
+  const merged = (existing.questions || []).slice();
+  for (const q of qs) merged.push(q);
+  entry.askUserQuestionPayload = { ...existing, questions: merged };
+}
+
+const STEPS = ['brief_gate', 'spec_gate', 'implement'];
+
+module.exports = function registerDiscrepancyGate(register) {
+  for (const step of STEPS) {
+    register(step, (entry, ctx) => {
+      // Defer to whichever blocker already won — Gate 0, A, B, C, etc.
+      if (entry._overrideInstruction) return;
+      try {
+        const art = _loadArtifacts(ctx.tasksDir);
+        const qs = _gatherQuestions(step, art);
+        _inject(entry, qs);
+      } catch {
+        /* fail-open */
+      }
+    });
+  }
+};

--- a/scripts/workflows/work2/lib/step-enrichments/follow-up.js
+++ b/scripts/workflows/work2/lib/step-enrichments/follow-up.js
@@ -10,8 +10,45 @@
 const fs = require('fs');
 const path = require('path');
 
+const { isPrClosedWithoutMerge } = require('../../../lib/pr-state');
+
+function loadWorkState(tasksDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(tasksDir, '.work-state.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function buildClosedPrBlocker(ticket) {
+  return {
+    type: 'work_instruction',
+    action: 'blocked',
+    reason: 'follow_up: PR was closed without merge — Gate F requires re-planning from brief',
+    details:
+      'A closed-without-merge PR usually means the previous scope was wrong (often sibling-owned drift). ' +
+      'Looping back through `implement` would re-ship the same scope. Gate F forces a re-plan: ' +
+      'archive the current artifacts and re-bootstrap.',
+    hint: [
+      'To re-plan:',
+      '  1. Archive the current run (move brief.md / spec.md / tasks.md into `.archive/` under tasksDir).',
+      '  2. Re-run `/work2 ' +
+        (ticket || '<ticket>') +
+        '` — the workflow will re-enter at `brief`.',
+      '  3. The brief-writer will fetch a fresh related-tickets manifest and you can choose a different scope.',
+    ].join('\n'),
+  };
+}
+
 module.exports = function registerFollowUp(register) {
   register('follow_up', (entry, ctx) => {
+    // Gate F — refuse to loop follow_up when the PR is closed-not-merged.
+    const ws = loadWorkState(ctx.tasksDir);
+    if (isPrClosedWithoutMerge(ws)) {
+      entry._overrideInstruction = buildClosedPrBlocker(ctx.ticket);
+      return;
+    }
+
     const { resolvePluginRoot } = require(path.join(__dirname, '..', 'resolve-plugin-root'));
     const pluginRoot = resolvePluginRoot(__dirname, 4);
 

--- a/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -38,7 +38,7 @@ function readTaskTestCommand(tasksDir, taskNum) {
     const content = fs.readFileSync(tasksMdPath, 'utf8');
     const sectionRe = new RegExp(
       `## Task ${taskNum}\\b[\\s\\S]*?(?=\\n## Task \\d|\\n## (?!Task )|$)`,
-      'm'
+      ''
     );
     const sectionMatch = content.match(sectionRe);
     if (!sectionMatch) return null;

--- a/scripts/workflows/work2/lib/step-enrichments/index.js
+++ b/scripts/workflows/work2/lib/step-enrichments/index.js
@@ -66,6 +66,7 @@ function runGate(stepName, safeName, ctx, deps) {
 
 // --- Register built-in enrichments ---
 require('./ticket')(register);
+require('./related-tickets-inject')(register);
 require('./brief-gate')(register);
 require('./spec-gate')(register);
 require('./context-inject')(register);

--- a/scripts/workflows/work2/lib/step-enrichments/index.js
+++ b/scripts/workflows/work2/lib/step-enrichments/index.js
@@ -71,6 +71,7 @@ require('./brief-gate')(register);
 require('./spec-gate')(register);
 require('./context-inject')(register);
 require('./tasks-scope-gate')(register);
+require('./discrepancy-gate')(register);
 require('./implement')(register);
 require('./check')(register);
 require('./follow-up')(register);

--- a/scripts/workflows/work2/lib/step-enrichments/index.js
+++ b/scripts/workflows/work2/lib/step-enrichments/index.js
@@ -70,6 +70,7 @@ require('./related-tickets-inject')(register);
 require('./brief-gate')(register);
 require('./spec-gate')(register);
 require('./context-inject')(register);
+require('./tasks-scope-gate')(register);
 require('./implement')(register);
 require('./check')(register);
 require('./follow-up')(register);

--- a/scripts/workflows/work2/lib/step-enrichments/related-tickets-inject.js
+++ b/scripts/workflows/work2/lib/step-enrichments/related-tickets-inject.js
@@ -1,0 +1,84 @@
+/**
+ * Related-tickets injection enrichment.
+ *
+ * At the `brief` step, instruct the brief-writer to fetch parent + siblings +
+ * blockedBy + dependsOn + relatedTo via the configured ticket provider and
+ * write the manifest to `tasks/<ticket>/related-tickets.json`.
+ *
+ * At downstream steps (`spec`, `tasks`, `implement`), inject a "READ THIS FIRST"
+ * pointer to the manifest so those agents treat it as authoritative for
+ * sibling-ownership facts.
+ *
+ * The manifest is the single source of truth for which surfaces (files/symbols)
+ * belong to sibling tickets. Downstream gates (Gate A, Gate B, Gate C, Gate D)
+ * use it to block scope creep.
+ */
+
+'use strict';
+
+const tp = require('../../../lib/ticket-provider');
+const relatedTickets = require('../../../lib/related-tickets');
+
+const FETCH_STEP = 'brief';
+const READ_STEPS = ['brief', 'spec', 'tasks', 'implement'];
+
+function buildFetchBlock(tpRef, ticket, providerConfig, manifestPath) {
+  const prompt = tpRef.getRelatedTicketsPrompt(ticket, providerConfig, manifestPath);
+  if (!prompt) return null;
+  return (
+    '\n\n## Related Tickets Manifest (REQUIRED — fetch FIRST)\n' +
+    'Before drafting the brief, you MUST fetch related tickets and write the manifest.\n' +
+    'Downstream agents (spec-writer, jira-task-creator) read this file to decide which surfaces are owned by sibling tickets.\n' +
+    'A missing or invalid manifest blocks brief_gate.\n\n' +
+    prompt
+  );
+}
+
+function buildReadBlock(manifestPath) {
+  return (
+    '\n\n## Related Tickets (READ FIRST)\n' +
+    '- **Manifest:** ' +
+    manifestPath +
+    '\n' +
+    'Read this file in full BEFORE doing any work. It documents:\n' +
+    '- The parent ticket and its surfaces.\n' +
+    '- Sibling tickets (children of the same parent) and the files they own.\n' +
+    '- `blockedBy` / `dependsOn` / `relatedTo` links and the files they own.\n' +
+    "Treat any file listed under a sibling's `surfaces` as **out-of-scope** for the current ticket.\n" +
+    'If your work requires touching a sibling-owned surface, STOP and surface the gap as a question — do NOT absorb it into the current ticket.'
+  );
+}
+
+module.exports = function registerRelatedTicketsInject(register) {
+  // Brief_gate validation lives in brief-gate.js — this enrichment only
+  // handles prompt injection for the brief step + READ-FIRST pointers for
+  // downstream steps. Keeping the gate logic and the prompt logic in
+  // separate files mirrors the rest of the step-enrichment layout.
+
+  register(FETCH_STEP, (entry, ctx) => {
+    const { tasksDir, ticket, path: pathMod } = ctx;
+    let providerConfig = null;
+    try {
+      providerConfig = (ctx.tp || tp).getProviderConfig({ cwd: ctx.workDir, skipPrompt: true });
+    } catch {
+      /* fail-open */
+    }
+    if (!providerConfig) return;
+    const manifestFile = relatedTickets.manifestPath(tasksDir, pathMod);
+    const block = buildFetchBlock(ctx.tp || tp, ticket, providerConfig, manifestFile);
+    if (!block) return;
+    entry.agentPrompt = (entry.agentPrompt || '') + block;
+  });
+
+  for (const stepName of READ_STEPS) {
+    register(stepName, (entry, ctx) => {
+      const { tasksDir, path: pathMod, fs } = ctx;
+      const manifestFile = relatedTickets.manifestPath(tasksDir, pathMod);
+      // Only inject the READ block when the manifest exists — at the brief
+      // step the agent hasn't written it yet, so the fetch block (above)
+      // handles that case.
+      if (!fs.existsSync(manifestFile)) return;
+      entry.agentPrompt = (entry.agentPrompt || '') + buildReadBlock(manifestFile);
+    });
+  }
+};

--- a/scripts/workflows/work2/lib/step-enrichments/spec-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/spec-gate.js
@@ -8,8 +8,69 @@
 
 'use strict';
 
+const {
+  extractP0Ids,
+  checkP0Coverage,
+  checkSiblingOosRestatement,
+} = require('../../../lib/brief-spec-coverage');
+
+function _readFile(filePath, fs) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function buildBriefSpecCoverageBlocker(missingIds, oosCheck, briefPath, specPath) {
+  const lines = [];
+  if (missingIds.length > 0) {
+    lines.push(`P0 IDs from ${briefPath} not referenced in ${specPath}:`);
+    for (const id of missingIds) lines.push(`  - P0 #${id}`);
+  }
+  if (oosCheck && !oosCheck.ok) {
+    lines.push('');
+    lines.push(`OOS restatement: ${oosCheck.reason}`);
+    if (Array.isArray(oosCheck.missingEntries)) {
+      lines.push('Missing entries in spec:');
+      for (const e of oosCheck.missingEntries) lines.push(`  - ${e}`);
+    }
+  }
+  return {
+    type: 'work_instruction',
+    action: 'blocked',
+    reason: 'spec_gate: brief↔spec coverage failed (Gate B)',
+    details: lines.join('\n'),
+    hint: 'Edit spec.md so every brief P0 is referenced (heading or inline `P0 #N`) and the `## Out of scope (sibling-owned)` section is restated verbatim. Re-run /work2.',
+  };
+}
+
+function _runBriefSpecCoverage(entry, ctx) {
+  const { tasksDir, path, fs } = ctx;
+  const briefPath = path.join(tasksDir, 'brief.md');
+  const specPath = path.join(tasksDir, 'spec.md');
+  const briefText = _readFile(briefPath, fs);
+  const specText = _readFile(specPath, fs);
+  if (!briefText || !specText) return; // skip when either is missing
+
+  const ids = extractP0Ids(briefText);
+  const { missing } = checkP0Coverage(specText, ids);
+  const oos = checkSiblingOosRestatement(briefText, specText);
+  if (missing.length === 0 && oos.ok) return;
+
+  entry._overrideInstruction = buildBriefSpecCoverageBlocker(missing, oos, briefPath, specPath);
+}
+
 module.exports = function registerSpecGate(register) {
+  // Gate B — brief↔spec coverage; runs BEFORE the gherkin-validation logic
+  // below so coverage failures block the same way as gherkin failures.
   register('spec_gate', (entry, ctx) => {
+    if (entry._overrideInstruction) return;
+    _runBriefSpecCoverage(entry, ctx);
+  });
+
+  register('spec_gate', (entry, ctx) => {
+    if (entry._overrideInstruction) return;
     const { tasksDir, workDir, path, fs } = ctx;
     const specPath = path.join(tasksDir, 'spec.md');
 

--- a/scripts/workflows/work2/lib/step-enrichments/spec-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/spec-gate.js
@@ -124,18 +124,21 @@ module.exports = function registerSpecGate(register) {
     });
     lines.push('');
     lines.push('### What to do\n');
-    lines.push('Edit spec.md to fix the gherkin section. Common issues:');
+    const gherkinPath = path.join(tasksDir, 'gherkin.feature');
+    lines.push(`Edit \`${gherkinPath}\` (the standalone file the validator reads) to fix:`);
     lines.push('- Missing Feature/Scenario/Given/When/Then structure');
-    lines.push('- Missing @integration or @e2e tags');
-    lines.push('- Less than 2 scenarios');
-    lines.push('- Gherkin not inside a ```gherkin code fence');
+    lines.push('- Missing or invalid tags — ONLY `@integration` and `@e2e` are valid');
+    lines.push('  - `@unit`, `@storybook`, `@smoke`, etc. WILL fail validation');
+    lines.push('- Fewer than 2 scenarios');
+    lines.push('');
+    lines.push('Also keep `spec.md` consistent if it embeds gherkin inline.');
     lines.push('');
     lines.push(
       `If this change is non-testable, add \`<!-- gherkin-skip: reason -->\` to spec.md instead.`
     );
     lines.push('');
     lines.push(
-      'IMPORTANT: Edit spec.md directly to fix the gherkin. Do NOT regenerate the entire spec.'
+      'IMPORTANT: Edit gherkin.feature in-place — do NOT regenerate the entire spec. `protect-gherkin.js` allows writes during spec_gate when validation is failing.'
     );
 
     entry.agentPrompt = lines.join('\n');

--- a/scripts/workflows/work2/lib/step-enrichments/tasks-scope-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/tasks-scope-gate.js
@@ -1,14 +1,18 @@
 /**
  * Tasks scope envelope gate (Gate C).
  *
- * At the `implement` step entry, parses tasks.md and refuses to dispatch
- * if any task is missing `### Files in scope` / `### Files explicitly out
- * of scope` sections. The envelope is the source of truth for the runtime
+ * Runs at the dedicated `tasks_gate` workflow step (between `tasks` and
+ * `implement`). Parses tasks.md and refuses to advance to `implement` if
+ * any task is missing `### Files in scope` / `### Files explicitly out of
+ * scope` sections. The envelope is the source of truth for the runtime
  * file-edit hook (Gate D) and the post-implement scope diff (Gate E).
  *
- * Validation lives here (rather than a new `tasks_gate` workflow step) so we
- * don't have to change the step machine. Cost: it fires per-implement
- * dispatch — cheap, since it only reads tasks.md.
+ * Placing the validation in its own step (rather than at implement entry)
+ * lets us add `tasks_gate` to tasks.md's `allowedSteps` so the gate can
+ * recover from a malformed tasks.md WITHOUT widening the implement-step
+ * scope — which would have created a Gate D bypass (an agent during
+ * implement could otherwise edit tasks.md to grant itself broader file
+ * scope).
  */
 
 'use strict';
@@ -22,7 +26,7 @@ function buildBlocker(tasksDir, validation) {
   return {
     type: 'work_instruction',
     action: 'blocked',
-    reason: 'implement gate: tasks.md scope envelope is missing or malformed',
+    reason: 'tasks_gate: tasks.md scope envelope is missing or malformed',
     details:
       'Gate C requires every task in tasks.md to declare:\n' +
       '  - `### Files in scope` — glob patterns / paths the task may edit (non-empty).\n' +
@@ -30,14 +34,15 @@ function buildBlocker(tasksDir, validation) {
       'Validation errors:\n' +
       errorList,
     hint:
-      'Re-run the `tasks` step. Update tasks.md so each `## Task N` block contains both sections, ' +
-      'then re-run /work2. The jira-task-creator agent has the template; see agents/jira-task-creator.md.',
+      'Edit tasks.md in-place (allowed during tasks_gate) so each `## Task N` block contains both sections, ' +
+      'then re-run /work2. The jira-task-creator agent has the template; see agents/jira-task-creator.md. ' +
+      'If the agent who wrote tasks.md was the problem, the RETRY_EDGE `tasks_gate → tasks` lets the orchestrator rewind to the tasks step.',
     tasksFile: path.join(tasksDir, 'tasks.md'),
   };
 }
 
 module.exports = function registerTasksScopeGate(register) {
-  register('implement', (entry, ctx) => {
+  register('tasks_gate', (entry, ctx) => {
     if (entry._overrideInstruction) return; // Don't stomp other gates
 
     const { tasksDir } = ctx;
@@ -47,14 +52,13 @@ module.exports = function registerTasksScopeGate(register) {
     } catch {
       return; // fail-open on parser crash
     }
-
-    // If tasks.md doesn't exist yet (very early in the workflow) skip — the
-    // workflow itself blocks the implement step on missing tasks.md via a
-    // different mechanism.
     if (!tasks) return;
 
     const validation = validateAll(tasks);
-    if (validation.valid) return;
+    if (validation.valid) {
+      // Pass-through: leave entry as-is so the orchestrator advances to implement.
+      return;
+    }
 
     entry._overrideInstruction = buildBlocker(tasksDir, validation);
   });

--- a/scripts/workflows/work2/lib/step-enrichments/tasks-scope-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/tasks-scope-gate.js
@@ -1,0 +1,61 @@
+/**
+ * Tasks scope envelope gate (Gate C).
+ *
+ * At the `implement` step entry, parses tasks.md and refuses to dispatch
+ * if any task is missing `### Files in scope` / `### Files explicitly out
+ * of scope` sections. The envelope is the source of truth for the runtime
+ * file-edit hook (Gate D) and the post-implement scope diff (Gate E).
+ *
+ * Validation lives here (rather than a new `tasks_gate` workflow step) so we
+ * don't have to change the step machine. Cost: it fires per-implement
+ * dispatch — cheap, since it only reads tasks.md.
+ */
+
+'use strict';
+
+const path = require('path');
+const { parseTasks } = require(path.join('..', '..', '..', 'work', 'task-parser'));
+const { validateAll } = require('../../../lib/task-scope');
+
+function buildBlocker(tasksDir, validation) {
+  const errorList = validation.errors.map((e) => `  - ${e}`).join('\n');
+  return {
+    type: 'work_instruction',
+    action: 'blocked',
+    reason: 'implement gate: tasks.md scope envelope is missing or malformed',
+    details:
+      'Gate C requires every task in tasks.md to declare:\n' +
+      '  - `### Files in scope` — glob patterns / paths the task may edit (non-empty).\n' +
+      '  - `### Files explicitly out of scope` — sibling-owned paths the task must NOT edit (may be empty if no siblings).\n\n' +
+      'Validation errors:\n' +
+      errorList,
+    hint:
+      'Re-run the `tasks` step. Update tasks.md so each `## Task N` block contains both sections, ' +
+      'then re-run /work2. The jira-task-creator agent has the template; see agents/jira-task-creator.md.',
+    tasksFile: path.join(tasksDir, 'tasks.md'),
+  };
+}
+
+module.exports = function registerTasksScopeGate(register) {
+  register('implement', (entry, ctx) => {
+    if (entry._overrideInstruction) return; // Don't stomp other gates
+
+    const { tasksDir } = ctx;
+    let tasks = null;
+    try {
+      tasks = parseTasks(tasksDir);
+    } catch {
+      return; // fail-open on parser crash
+    }
+
+    // If tasks.md doesn't exist yet (very early in the workflow) skip — the
+    // workflow itself blocks the implement step on missing tasks.md via a
+    // different mechanism.
+    if (!tasks) return;
+
+    const validation = validateAll(tasks);
+    if (validation.valid) return;
+
+    entry._overrideInstruction = buildBlocker(tasksDir, validation);
+  });
+};

--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -301,8 +301,21 @@ Note: The implement-gate executes this command automatically before/after dispat
 - `<path/to/likely/file.ts>`
 - `<path/to/another/file.ts>`
 
+### Files in scope (REQUIRED — Gate C)
+- <path/or/glob/the/task/may/edit/**>
+- <another/specific-file.ts>
+
+### Files explicitly out of scope (REQUIRED — Gate C; may be empty when no siblings own related surfaces)
+- <sibling-owned/file.ts — owned by [SIBLING-TICKET-ID]>
+
 ---
 ```
+
+**Required sections (Gate C):**
+- `### Files in scope` — Glob patterns or paths the task may edit. Must be non-empty. The implement-step hook blocks any file edit outside this set.
+- `### Files explicitly out of scope` — Paths owned by sibling tickets that this task must not touch. May be empty when no siblings exist. Populate from `tasks/<ticket>/related-tickets.json` (`surfaces` array under each sibling).
+
+The `### Suggested Scope` field is the legacy precursor — leave it in place for backwards compatibility, but ALSO emit the two new sections above.
 
 ### Task format (checkpoint tasks)
 


### PR DESCRIPTION
## Existing Behavior

- `/work2` agents (brief-writer, spec-writer, task-creator) had no mechanism to discover sibling tickets before writing their outputs.
- `brief_gate` validated only TDD-phase and existing state, with no check for cross-ticket scope boundaries.
- Agents routinely absorbed sibling-owned surfaces silently — brief scope narrowing went undetected, and downstream specs/tasks claimed work owned by related tickets.
- Two concrete failures: ECHO-4552's spec silently dropped acceptance criteria from its own brief; ECHO-4553's brief absorbed sibling scope, producing a 47-file PR that had to be closed.

## Intended New Behavior

- A new `related-tickets.json` manifest (schema-validated) must exist at `tasks/<ticket>/related-tickets.json` before `brief_gate` allows the state machine to advance.
- `brief-writer` is injected with per-provider fetch instructions (Jira MCP / Linear MCP / `gh` CLI) at the brief step, instructing it to enumerate parent, siblings, blockedBy, dependsOn, and relatedTo relationships and write the manifest.
- Downstream agents (spec, tasks, implement) receive a READ-FIRST pointer to the manifest so sibling-owned surfaces are treated as out-of-scope.
- When `TICKET_PROVIDER=none`, the gate is skipped (fail-open), preserving backwards compatibility.
- Two unrelated micro-fixes are bundled: case-insensitive ref match in `workflow-definition.js` and a missing regex flag in `implement-gate.js`.

## Dev Checks

- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This change is exercised by three test suites and one manual end-to-end path.

**Automated (all passing):**

1. `node --test scripts/workflows/lib/__tests__/related-tickets.test.js` — 24 tests covering schema validation, reader, isStale, and sibling helpers.
2. `node --test scripts/workflows/work2/lib/step-enrichments/__tests__/related-tickets-inject.test.js` — 12 tests covering prompt injection at brief/spec/tasks/implement steps per provider.
3. `node --test scripts/workflows/work2/lib/step-enrichments/__tests__/brief-gate.test.js` — 7 tests covering gate block on missing/invalid manifest and pass-through when provider is `none`.
4. Full `pnpm test` — 3214 pass, 1 pre-existing flake in session-guard (unrelated to this PR).
5. `npx biome check` clean for all files touched in this PR.

**Manual end-to-end (to run after merge):**

1. Start a `/work2` session on a ticket that has at least one sibling in Jira/Linear/GitHub.
2. Let brief-writer complete — verify `tasks/<ticket>/related-tickets.json` is written with the correct schema (fields: `ticket`, `provider`, `fetchedAt`, `relationships` array).
3. Attempt to run `/work2` at the `brief_gate` step WITHOUT the manifest present — confirm the gate blocks with a clear error message pointing to the missing file.
4. Write a manifest that fails schema validation (e.g., missing `fetchedAt`) — confirm the gate blocks with a schema-error hint.
5. Write a valid manifest — confirm `brief_gate` transitions normally.
6. Set `TICKET_PROVIDER=none` and confirm `brief_gate` passes without requiring the manifest.

### Test Results

- `related-tickets.test.js`: 24 / 24 pass
- `related-tickets-inject.test.js`: 12 / 12 pass
- `brief-gate.test.js`: 7 / 7 pass
- `pnpm test` full suite: 3214 pass, 1 pre-existing flake (session-guard, unrelated)

---

**Background — 8-gate enforcement plan:**

This is Gate 0 of an 8-gate plan to stop `/work2` agents from absorbing sibling-ticket scope. Remaining gates (separate PRs):

- Gate C — tasks scope envelope
- Gate D — implement file-edit hook
- Gate E — check scope-diff verifier
- Gate F — PR surfacing + re-entry edge
- Gate A — brief sibling-scope interactive decision
- Gate B — brief→spec coverage + sibling restatement
- Gate B' — discrepancy detection across gates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new workflow gates and pre-tool hooks that can block `/work2` progression and file writes if manifests/scope declarations are missing or violated, which may interrupt existing flows. Behavior is mostly fail-open on missing state/provider, but incorrect parsing or patterns could over-block edits during implementation/check.
> 
> **Overview**
> Adds a required `tasks/<ticket>/related-tickets.json` manifest and injects provider-specific fetch/READ-FIRST instructions, then updates `brief_gate` to **block** when the manifest is missing/invalid and to prompt for unresolved sibling-scope gaps recorded in `brief.md`.
> 
> Introduces **task file-scope enforcement**: tasks now declare `### Files in scope` and `### Files explicitly out of scope`, a new `tasks_gate` step validates this before `implement`, and a new `/work2` PreToolUse hook blocks `Write/Edit/MultiEdit/NotebookEdit` (and certain `Bash` writes) outside the active task’s scope or into sibling-owned paths.
> 
> Enhances later stages with scope accountability: the `check` step appends a Gate E scope-diff summary (diff vs declared scope) for the completion checker/PR description, `pr-generator` adds sections for brief P0 coverage and out-of-scope changes, and `follow_up` now blocks when the recorded PR was closed without merge to force re-planning. Includes supporting parsers/utilities (`related-tickets`, `scope-diff`, `brief-spec` coverage, discrepancy detection, PR state) plus extensive new tests and small robustness fixes (case-insensitive git ref match, gherkin/spec artifact write allowances, and improved task parser command filtering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c64d4af5f110a9f64874790860155289dca0fd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->