### PR TITLE
fix(work2): unblock orchestrator self-invoke, guard sibling sessions, clean test locks

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -16,8 +16,21 @@ cleanup_test_artifacts() {
   node -e "require('./scripts/workflows/lib/__tests__/test-cleanup').cleanupTestArtifacts()" 2>/dev/null || true
 }
 
+# On signal: clean up, then re-raise the signal so the script exits with the
+# correct conventional code (130 for SIGINT, 143 for SIGTERM). Without
+# re-raising, cleanup's `|| true` would mask `$?` to 0 and CI would falsely
+# report success on an interrupted run.
+on_signal() {
+  local signal="$1"
+  cleanup_test_artifacts
+  trap - EXIT INT TERM
+  kill -s "$signal" "$$"
+}
+
 # Fire on ANY exit path — clean shutdown, SIGINT (Ctrl+C), SIGTERM, error.
-trap cleanup_test_artifacts EXIT INT TERM
+trap cleanup_test_artifacts EXIT
+trap 'on_signal INT' INT
+trap 'on_signal TERM' TERM
 
 # Build space-separated file list (node --test expects positional args, not newlines)
 mapfile -t FILES < <(find scripts/workflows agents skills -type f \( -name '*.test.js' -o -name '*.spec.js' \) | sort)

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,9 +3,21 @@
 # Works on Node 20+ without glob support in `node --test`
 #
 # To skip a broken test, add its path to .test-skip (one per line).
-set -euo pipefail
+#
+# IMPORTANT: cleanup runs via `trap` on EXIT/INT/TERM so leftover dirs and
+# /tmp/claude-session-guard-*.json lock files NEVER survive an interrupted
+# run. Leaked locks block real agents from starting their workflows.
+set -u
+set -o pipefail
 
 SKIP_FILE=".test-skip"
+
+cleanup_test_artifacts() {
+  node -e "require('./scripts/workflows/lib/__tests__/test-cleanup').cleanupTestArtifacts()" 2>/dev/null || true
+}
+
+# Fire on ANY exit path — clean shutdown, SIGINT (Ctrl+C), SIGTERM, error.
+trap cleanup_test_artifacts EXIT INT TERM
 
 # Build space-separated file list (node --test expects positional args, not newlines)
 mapfile -t FILES < <(find scripts/workflows agents skills -type f \( -name '*.test.js' -o -name '*.spec.js' \) | sort)
@@ -28,14 +40,8 @@ if [ ${#FILES[@]} -eq 0 ]; then
   exit 0
 fi
 
-# Clean up leftover TEST-* dirs from previous interrupted test runs
-node -e "require('./scripts/workflows/lib/__tests__/test-cleanup').cleanupTestDirs()" 2>/dev/null || true
+# Pre-clean (in case a prior run died before its trap could fire)
+cleanup_test_artifacts
 
-# Run tests, capture exit code, then clean up
+# Run tests; trap will fire cleanup on exit (clean or interrupted)
 node --test "${FILES[@]}"
-EXIT_CODE=$?
-
-# Clean up TEST-* dirs created during this run
-node -e "require('./scripts/workflows/lib/__tests__/test-cleanup').cleanupTestDirs()" 2>/dev/null || true
-
-exit $EXIT_CODE

--- a/scripts/workflows/follow-up2/__tests__/conflict-guard.test.js
+++ b/scripts/workflows/follow-up2/__tests__/conflict-guard.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+// Skip delays in tests
+process.env.FOLLOW_UP2_NO_DELAY = '1';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+/**
+ * Regression: follow-up2 must NOT declare a PR "complete" while merge
+ * conflicts remain. ECHO-4611 ended with status=complete despite the
+ * monitor output containing "CONFLICTS: Merge conflicts detected".
+ *
+ * Two safety nets exercised here:
+ *   1. monitor.js — exitCode 0 only when mergeable is not CONFLICTING/DIRTY
+ *      (covered indirectly via the report.js test below; direct unit test of
+ *      monitor.js would need to stub gh/git which is out of scope here).
+ *   2. report.js — must route back to fix-ci when lastMonitorResult.output
+ *      still contains a "merge conflict" marker, even on entry to report.
+ */
+
+const handlers = Object.create(null);
+function registerStep(name, fn) {
+  handlers[name] = fn;
+}
+require('../lib/steps/report')(registerStep);
+const report = handlers['report'];
+
+function makeCtx() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'followup-report-'));
+  return { tmp, ctx: { tasksDir: tmp } };
+}
+
+describe('report step: conflict safety net', () => {
+  it('refuses to complete when monitor output still shows a merge conflict', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = {
+        ticketId: 'ECHO-CONF',
+        prNumber: 1586,
+        currentStep: 'report',
+        attempt: 1,
+        lastMonitorResult: {
+          exitCode: 0,
+          output:
+            'CI: PASSED (all 31 checks)\nCONFLICTS: Merge conflicts detected — rebase required\nReviews: CLEAR',
+        },
+      };
+      const result = report(state, ctx);
+      assert.equal(
+        result,
+        null,
+        'report must not return complete-instruction when conflict still present'
+      );
+      assert.equal(state.currentStep, 'fix-ci');
+      assert.equal(state.failureCategory, 'conflict');
+      // review-accountability.json must NOT have been written
+      assert.equal(fs.existsSync(path.join(tmp, 'review-accountability.json')), false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('completes normally when monitor output is clear of conflicts', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = {
+        ticketId: 'ECHO-OK',
+        prNumber: 1234,
+        currentStep: 'report',
+        attempt: 1,
+        lastMonitorResult: {
+          exitCode: 0,
+          output: 'CI: PASSED (all 31 checks)\nReviews: CLEAR',
+        },
+      };
+      const result = report(state, ctx);
+      assert.ok(result, 'report must return a complete-instruction in the happy path');
+      assert.equal(result.action, 'complete');
+      assert.equal(state.status, 'complete');
+      assert.equal(fs.existsSync(path.join(tmp, 'review-accountability.json')), true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('also catches "cannot be merged" phrasing', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = {
+        ticketId: 'ECHO-CONF2',
+        prNumber: 4242,
+        currentStep: 'report',
+        attempt: 1,
+        lastMonitorResult: {
+          exitCode: 0,
+          output: 'PR cannot be merged. Branch is out of date with the base branch.',
+        },
+      };
+      const result = report(state, ctx);
+      assert.equal(result, null);
+      assert.equal(state.currentStep, 'fix-ci');
+      assert.equal(state.failureCategory, 'conflict');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/workflows/follow-up2/__tests__/conflict-local-detection.test.js
+++ b/scripts/workflows/follow-up2/__tests__/conflict-local-detection.test.js
@@ -1,0 +1,134 @@
+'use strict';
+
+// Integration test: build a real two-branch git fixture that conflicts,
+// then run the monitor.js local-conflict-detection logic against it and
+// assert _isConflicting becomes true.
+//
+// This catches the bugs in the original 888dd5e4 implementation:
+//   1. execFileSync throws on `git merge-tree` exit 1 → exception swallowed
+//      → conflict invisible. Switched to spawnSync.
+//   2. The default merge-tree output uses `CONFLICT (...)` lines, NOT
+//      `<<<<<<<` separator markers (those only appear with --write-tree
+//      against an actual workdir). The detection regex now matches the
+//      real output format.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync, spawnSync } = require('node:child_process');
+
+function git(cwd, ...args) {
+  return execFileSync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=t', '-c', 'commit.gpgsign=false', ...args],
+    { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+  );
+}
+
+function buildConflictingFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fu2-conflict-fixture-'));
+  const seed = path.join(root, 'seed');
+  fs.mkdirSync(seed);
+  git(seed, 'init', '-q', '-b', 'main');
+  fs.writeFileSync(path.join(seed, 'file.txt'), 'alpha\n');
+  git(seed, 'add', 'file.txt');
+  git(seed, 'commit', '-q', '-m', 'init');
+  const originBare = path.join(root, 'origin.git');
+  git(seed, 'clone', '-q', '--bare', '.', originBare);
+  const worktree = path.join(root, 'worktree');
+  git(root, 'clone', '-q', originBare, worktree);
+
+  // feature branch with one change
+  git(worktree, 'checkout', '-q', '-b', 'feature');
+  fs.writeFileSync(path.join(worktree, 'file.txt'), 'from-feature\n');
+  git(worktree, 'commit', '-qam', 'feature change');
+  git(worktree, 'push', '-q', 'origin', 'feature');
+
+  // main moves with a conflicting change
+  git(worktree, 'checkout', '-q', 'main');
+  fs.writeFileSync(path.join(worktree, 'file.txt'), 'from-main\n');
+  git(worktree, 'commit', '-qam', 'main update');
+  git(worktree, 'push', '-q', 'origin', 'main');
+
+  git(worktree, 'checkout', '-q', 'feature');
+  return { root, worktree };
+}
+
+// Reach into monitor.js's logic by running the same git commands it runs.
+// This proves the detection works end-to-end without mocking. If we ever
+// change the detection strategy in monitor.js, update both here and there.
+function detectLocalConflict(worktree, baseBranch) {
+  let mb;
+  try {
+    mb = execFileSync('git', ['merge-base', 'HEAD', `origin/${baseBranch}`], {
+      cwd: worktree,
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return { conflicting: false, files: [] };
+  }
+  const res = spawnSync(
+    'git',
+    ['merge-tree', `--merge-base=${mb}`, 'HEAD', `origin/${baseBranch}`],
+    { cwd: worktree, encoding: 'utf8' }
+  );
+  const tree = (res.stdout || '') + (res.stderr || '');
+  const hasConflictExit = res.status !== 0 && res.status !== null;
+  const hasConflictMarker = /^CONFLICT \(/m.test(tree);
+  if (!hasConflictExit && !hasConflictMarker) return { conflicting: false, files: [] };
+  const files = [];
+  for (const line of tree.split('\n')) {
+    const m =
+      line.match(/^CONFLICT \([^)]+\):.*?(?:in|on) (.+?)$/) || line.match(/^Auto-merging (.+?)$/);
+    if (m && !files.includes(m[1])) files.push(m[1]);
+    if (files.length >= 3) break;
+  }
+  return { conflicting: true, files };
+}
+
+describe('monitor.js local conflict detection — integration', () => {
+  it('detects a real two-branch conflict via merge-tree', () => {
+    const { root, worktree } = buildConflictingFixture();
+    try {
+      const result = detectLocalConflict(worktree, 'main');
+      assert.equal(result.conflicting, true, 'must detect the conflict');
+      assert.ok(result.files.length > 0, 'must extract at least one conflicting file');
+      assert.ok(
+        result.files.includes('file.txt'),
+        `expected file.txt in conflict list, got ${JSON.stringify(result.files)}`
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports no conflict when branches do not diverge on shared content', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fu2-clean-fixture-'));
+    try {
+      const seed = path.join(root, 'seed');
+      fs.mkdirSync(seed);
+      git(seed, 'init', '-q', '-b', 'main');
+      fs.writeFileSync(path.join(seed, 'file.txt'), 'alpha\n');
+      git(seed, 'add', 'file.txt');
+      git(seed, 'commit', '-q', '-m', 'init');
+      const originBare = path.join(root, 'origin.git');
+      git(seed, 'clone', '-q', '--bare', '.', originBare);
+      const worktree = path.join(root, 'worktree');
+      git(root, 'clone', '-q', originBare, worktree);
+      git(worktree, 'checkout', '-q', '-b', 'feature');
+      // Non-conflicting change to a different file
+      fs.writeFileSync(path.join(worktree, 'other.txt'), 'new\n');
+      git(worktree, 'add', 'other.txt');
+      git(worktree, 'commit', '-qam', 'add other');
+      git(worktree, 'push', '-q', 'origin', 'feature');
+
+      const result = detectLocalConflict(worktree, 'main');
+      assert.equal(result.conflicting, false);
+      assert.deepEqual(result.files, []);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/workflows/follow-up2/__tests__/conflict-precedence.test.js
+++ b/scripts/workflows/follow-up2/__tests__/conflict-precedence.test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// Skip delays in tests
+process.env.FOLLOW_UP2_NO_DELAY = '1';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+/**
+ * Regression: a merge conflict on the PR must preempt EVERYTHING else in
+ * /follow-up2. The structured signal `state._isConflicting` (set by
+ * monitor.js with a bounded UNKNOWN retry) carries the truth across all
+ * steps, so triage, fix-reviews, and report all route to fix-ci when it
+ * is true — independent of whether `lastMonitorResult.output` happens to
+ * contain a literal "merge conflict" string.
+ *
+ * Observed failure mode (ECHO-4577): monitor's first cycle saw
+ * `mergeable: UNKNOWN` (GitHub mid-recompute after a sibling merge),
+ * formatReport didn't emit the CONFLICTS line, triage routed to
+ * fix-reviews, agent paused on a blocked "review skipped" instruction
+ * while the real blocker was a conflict in app/api/trpc/routers/explore.ts.
+ */
+
+const handlers = Object.create(null);
+function registerStep(name, fn) {
+  handlers[name] = fn;
+}
+require('../lib/steps/triage')(registerStep);
+require('../lib/steps/fix-reviews')(registerStep);
+require('../lib/steps/report')(registerStep);
+const triage = handlers['triage'];
+const fixReviews = handlers['fix-reviews'];
+const report = handlers['report'];
+
+function makeCtx() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-conflict-'));
+  return {
+    tmp,
+    ctx: {
+      tasksDir: tmp,
+      worktreeDir: tmp,
+      workScriptsDir: '/no/such/path',
+    },
+  };
+}
+
+describe('follow-up2: merge conflict has absolute precedence', () => {
+  it('triage routes to fix-ci on _isConflicting EVEN WHEN output has no conflict text', () => {
+    const state = {
+      ticketId: 'ECHO-CONF',
+      prNumber: 1611,
+      currentStep: 'triage',
+      attempt: 0,
+      _isConflicting: true,
+      lastMonitorResult: {
+        exitCode: 1,
+        output: 'CI: PASSED (all 5 checks)\nReviews: 1 BLOCKING\n  ✗ @cursor[bot] some comment',
+      },
+      failureCategory: null,
+    };
+    const result = triage(state, {});
+    assert.equal(result, null);
+    assert.equal(state.failureCategory, 'conflict');
+    assert.equal(state.currentStep, 'fix-ci');
+  });
+
+  it('triage prefers conflict over blocking reviews when both signaled', () => {
+    const state = {
+      ticketId: 'ECHO-CONF',
+      prNumber: 1611,
+      currentStep: 'triage',
+      attempt: 0,
+      _isConflicting: true,
+      lastMonitorResult: {
+        exitCode: 1,
+        output:
+          'CI: PASSED\nCONFLICTS: Merge conflicts detected\nReviews: 1 BLOCKING\n  ✗ @cursor[bot]',
+      },
+      failureCategory: null,
+    };
+    triage(state, {});
+    assert.equal(state.currentStep, 'fix-ci');
+    assert.equal(state.failureCategory, 'conflict');
+  });
+
+  it('fix-reviews refuses to dispatch when _isConflicting; reroutes to fix-ci', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = {
+        ticketId: 'ECHO-CONF',
+        prNumber: 1611,
+        currentStep: 'fix-reviews',
+        _isConflicting: true,
+      };
+      const result = fixReviews(state, ctx);
+      // null = no instruction emitted, currentStep was redirected
+      assert.equal(result, null);
+      assert.equal(state.currentStep, 'fix-ci');
+      assert.equal(state.failureCategory, 'conflict');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('fix-reviews proceeds normally when _isConflicting is false (would dispatch snapshot)', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = {
+        ticketId: 'ECHO-OK',
+        prNumber: 1234,
+        currentStep: 'fix-reviews',
+        _isConflicting: false,
+      };
+      // The snapshot subprocess will fail (workScriptsDir doesn't exist),
+      // but the important assertion is that we got PAST the conflict guard.
+      const result = fixReviews(state, ctx);
+      // Expect either a blocked snapshot-failure instruction or a comment-fetch attempt,
+      // but never the conflict re-route.
+      assert.notEqual(state.currentStep, 'fix-ci');
+      assert.notEqual(state.failureCategory, 'conflict');
+      // result is whatever fix-reviews dispatched; either an instruction or null,
+      // not the conflict-reroute (which would return null + currentStep='fix-ci').
+      if (result && result.reason) {
+        assert.ok(typeof result.reason === 'string');
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('report routes to fix-ci on _isConflicting even when output is clear', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = {
+        ticketId: 'ECHO-CONF',
+        prNumber: 1611,
+        currentStep: 'report',
+        _isConflicting: true,
+        lastMonitorResult: {
+          exitCode: 0,
+          output: 'CI: PASSED (all 31 checks)\nReviews: CLEAR',
+        },
+      };
+      const result = report(state, ctx);
+      assert.equal(result, null);
+      assert.equal(state.currentStep, 'fix-ci');
+      assert.equal(state.failureCategory, 'conflict');
+      // No accountability report when we bail back to fix-ci
+      assert.equal(fs.existsSync(path.join(tmp, 'review-accountability.json')), false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/workflows/follow-up2/__tests__/conflict-precedence.test.js
+++ b/scripts/workflows/follow-up2/__tests__/conflict-precedence.test.js
@@ -31,9 +31,11 @@ function registerStep(name, fn) {
 require('../lib/steps/triage')(registerStep);
 require('../lib/steps/fix-reviews')(registerStep);
 require('../lib/steps/report')(registerStep);
+require('../lib/steps/fix-ci')(registerStep);
 const triage = handlers['triage'];
 const fixReviews = handlers['fix-reviews'];
 const report = handlers['report'];
+const fixCi = handlers['fix-ci'];
 
 function makeCtx() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-conflict-'));
@@ -126,6 +128,30 @@ describe('follow-up2: merge conflict has absolute precedence', () => {
       if (result && result.reason) {
         assert.ok(typeof result.reason === 'string');
       }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('fix-ci HARD STOPS with a blocked instruction when conflicted (no auto-rebase dispatch)', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = {
+        ticketId: 'ECHO-CONF',
+        prNumber: 1611,
+        currentStep: 'fix-ci',
+        attempt: 0,
+        _isConflicting: true,
+        failureCategory: 'conflict',
+      };
+      const result = fixCi(state, ctx);
+      assert.ok(result, 'fix-ci must return an instruction when conflicted');
+      assert.equal(result.action, 'blocked');
+      assert.match(result.reason, /Merge conflicts found/i);
+      assert.match(result.reason, /sync your branch/i);
+      assert.match(result.reason, /#1611/);
+      // Crucially: no delegate. The agent does NOT get an auto-rebase dispatch.
+      assert.equal(result.delegate, undefined);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/scripts/workflows/follow-up2/lib/steps/fix-ci.js
+++ b/scripts/workflows/follow-up2/lib/steps/fix-ci.js
@@ -19,10 +19,18 @@ module.exports = function registerFixCi(register) {
     // schema migrations, etc).
     if (state._isConflicting || state.failureCategory === 'conflict') {
       const prNum = state.prNumber || 'unknown';
+      const files = Array.isArray(state._mergeStatus && state._mergeStatus.localConflictFiles)
+        ? state._mergeStatus.localConflictFiles
+        : [];
+      const baseBranch = state._mergeStatus && state._mergeStatus.baseBranch;
+      const fileSuffix = files.length
+        ? ` Conflicting file${files.length > 1 ? 's' : ''}: ${files.join(', ')}.`
+        : '';
+      const baseSuffix = baseBranch ? ` (target: ${baseBranch})` : '';
       return {
         type: 'follow_up_instruction',
         action: 'blocked',
-        reason: `Merge conflicts found on PR #${prNum} — sync your branch with the target branch before proceeding. Then re-run /follow-up2 ${state.ticketId || ''}.`,
+        reason: `Merge conflicts found on PR #${prNum}${baseSuffix} — sync your branch with the target branch before proceeding.${fileSuffix} Then re-run /follow-up2 ${state.ticketId || ''}.`,
         state: { ticket: state.ticketId, currentStep: 'fix-ci', attempt: state.attempt || 0 },
       };
     }

--- a/scripts/workflows/follow-up2/lib/steps/fix-ci.js
+++ b/scripts/workflows/follow-up2/lib/steps/fix-ci.js
@@ -11,6 +11,22 @@ const { execFileSync } = require('child_process');
 
 module.exports = function registerFixCi(register) {
   register('fix-ci', (state, ctx) => {
+    // ── HARD STOP on merge conflict ─────────────────────────────────────
+    // Conflicts are NOT auto-resolved. Halt the workflow and tell the
+    // agent (and the user) to sync the branch before continuing. This
+    // prevents auto-rebase delegates from silently dropping upstream
+    // changes that need human judgement (big sibling-PR merges, conflicting
+    // schema migrations, etc).
+    if (state._isConflicting || state.failureCategory === 'conflict') {
+      const prNum = state.prNumber || 'unknown';
+      return {
+        type: 'follow_up_instruction',
+        action: 'blocked',
+        reason: `Merge conflicts found on PR #${prNum} — sync your branch with the target branch before proceeding. Then re-run /follow-up2 ${state.ticketId || ''}.`,
+        state: { ticket: state.ticketId, currentStep: 'fix-ci', attempt: state.attempt || 0 },
+      };
+    }
+
     if (state.dispatched === 'fix-ci') return null; // already ran → advance to push-retry
 
     state.dispatched = 'fix-ci';

--- a/scripts/workflows/follow-up2/lib/steps/fix-reviews.js
+++ b/scripts/workflows/follow-up2/lib/steps/fix-reviews.js
@@ -22,6 +22,19 @@ const { execFileSync } = require('child_process');
 
 module.exports = function registerFixReviews(register) {
   register('fix-reviews', (state, ctx) => {
+    // ── PRIORITY 0 guard: never process reviews against a conflicted branch.
+    // Conflict was either detected on the current monitor cycle (state
+    // ._isConflicting set by monitor.js) or persisted from a prior cycle.
+    // Sending the agent to fix reviews against a branch that won't merge
+    // wastes a round-trip and risks the "blocked: review skipped, ask
+    // user" instruction when the real issue is "rebase first". Re-route
+    // to fix-ci so the agent resolves the conflict before any review work.
+    if (state._isConflicting) {
+      state.failureCategory = 'conflict';
+      state.currentStep = 'fix-ci';
+      return null;
+    }
+
     const commentsScript = path.join(ctx.workScriptsDir, 'follow-up-pr-comments.js');
     const prNum = String(state.prNumber || '');
     const scriptEnv = { ...process.env, WORK_TICKET_ID: state.ticketId };

--- a/scripts/workflows/follow-up2/lib/steps/fix-reviews.js
+++ b/scripts/workflows/follow-up2/lib/steps/fix-reviews.js
@@ -115,18 +115,23 @@ module.exports = function registerFixReviews(register) {
         /* ignore */
       }
 
-      if (statusResult && statusResult.skipped > 0 && !state._skippedReviewWarningShown) {
-        state._skippedReviewWarningShown = true;
-        const reviewFile = path.join(ctx.tasksDir, 'follow-up-comments.json');
-        return {
-          type: 'follow_up_instruction',
-          action: 'blocked',
-          reason: [
-            `Review comments: ${statusResult.solved} fixed, ${statusResult.skipped} skipped.`,
-            `Skipped comments need your review: ${reviewFile}`,
-            `After reviewing, re-run follow-up-next.js to continue.`,
-          ].join('\n'),
-        };
+      // When all remaining comments are terminal (solved or skipped),
+      // advance directly to `report` and let the workflow finish. The
+      // rationale for each skipped comment is preserved in
+      // follow-up-comments.json for later review. Previously this returned
+      // `action: 'blocked'` which forced a manual "I have reviewed, re-run"
+      // ack-loop every time — even when the user had already approved the
+      // skips. The reason for each skip is the agent's responsibility to
+      // make defensible (per `feedback_review_comments_judgment`).
+      //
+      // Loop-break invariant: routing to `report` marks the workflow
+      // `status: complete`, so re-running /follow-up2 without --init
+      // returns "Already complete" instead of cycling back here.
+      if (statusResult && statusResult.skipped > 0) {
+        state._skippedReviewsCount = statusResult.skipped;
+        state._solvedReviewsCount = statusResult.solved || 0;
+        state.currentStep = 'report';
+        return null;
       }
 
       return null; // all solved → advance to push-retry

--- a/scripts/workflows/follow-up2/lib/steps/monitor.js
+++ b/scripts/workflows/follow-up2/lib/steps/monitor.js
@@ -68,6 +68,42 @@ module.exports = function registerMonitor(register) {
       return null;
     }
 
+    // GitHub returns `mergeable: UNKNOWN` for up to ~30s after a push or a
+    // sibling-PR merge, while it recomputes mergeability. If we accept that
+    // value we declare the PR conflict-free when in fact a conflict is about
+    // to be reported. Retry a few times before trusting UNKNOWN.
+    // Bounded retry (3 * 3s = 9s max latency) — better than letting a
+    // conflict slip past the gate for an entire cycle.
+    let mergeableRetries = 0;
+    while (prInfo && prInfo.mergeable === 'UNKNOWN' && mergeableRetries < 3) {
+      try {
+        execFileSync('node', ['-e', 'setTimeout(()=>{}, 3000)'], {
+          stdio: 'ignore',
+          timeout: 5000,
+        });
+      } catch {
+        /* sleep best-effort */
+      }
+      try {
+        prInfo = getPRInfo(prArg);
+      } catch {
+        break;
+      }
+      mergeableRetries++;
+    }
+
+    // First-class conflict signal. Any later step (triage, fix-reviews,
+    // report) can check `state._isConflicting` without re-parsing the
+    // formatted output. This makes merge-conflict detection authoritative:
+    // it preempts CI status, review state, and pending bot reviews.
+    state._mergeStatus = {
+      mergeable: prInfo.mergeable || 'UNKNOWN',
+      mergeStateStatus: prInfo.mergeStateStatus || 'UNKNOWN',
+      isConflicting: prInfo.mergeable === 'CONFLICTING' || prInfo.mergeStateStatus === 'DIRTY',
+      retries: mergeableRetries,
+    };
+    state._isConflicting = state._mergeStatus.isConflicting;
+
     if (prInfo.state === 'MERGED') {
       state.lastMonitorResult = { exitCode: 0, output: `PR #${prInfo.number} is merged.` };
       state.currentStep = 'report';

--- a/scripts/workflows/follow-up2/lib/steps/monitor.js
+++ b/scripts/workflows/follow-up2/lib/steps/monitor.js
@@ -122,20 +122,36 @@ module.exports = function registerMonitor(register) {
           stdio: ['pipe', 'pipe', 'pipe'],
         }).trim();
         if (mb) {
-          const tree = execFileSync(
+          // `git merge-tree` exits with code 1 when conflicts are present —
+          // execFileSync THROWS on non-zero, so we use spawnSync to capture
+          // both stdout and exit code without throwing. Conflict markers in
+          // the default output format are `CONFLICT (content): ...` lines
+          // (NOT `<<<<<<<` separator markers — those only appear with
+          // --write-tree mode against an actual workdir, not against bare
+          // refs like origin/<base>). Each conflicting file gets one
+          // `Auto-merging <path>` and one `CONFLICT (...) <path>` line.
+          const { spawnSync } = require('child_process');
+          const res = spawnSync(
             'git',
             ['merge-tree', `--merge-base=${mb}`, 'HEAD', `origin/${baseBranch}`],
             {
               encoding: 'utf8',
               cwd: ctx.worktreeDir,
               timeout: 30000,
-              stdio: ['pipe', 'pipe', 'pipe'],
             }
           );
-          if (/^<{7} |^={7}$|^>{7} /m.test(tree)) {
+          const tree = (res && (res.stdout || '')) + (res && res.stderr ? res.stderr : '');
+          // Conflict is signaled by EITHER non-zero exit code OR a CONFLICT line.
+          const hasConflictExitCode = res && res.status !== 0 && res.status !== null;
+          const hasConflictMarker = /^CONFLICT \(/m.test(tree);
+          if (hasConflictExitCode || hasConflictMarker) {
             localConflicting = true;
+            // Extract conflicting file paths from `CONFLICT (...): Merge conflict in <path>`
+            // and `Auto-merging <path>` lines.
             for (const line of tree.split('\n')) {
-              const m = line.match(/^\+\+\+ b\/(.+)$/);
+              const m =
+                line.match(/^CONFLICT \([^)]+\):.*?(?:in|on) (.+?)$/) ||
+                line.match(/^Auto-merging (.+?)$/);
               if (m && !localConflictFiles.includes(m[1])) {
                 localConflictFiles.push(m[1]);
               }

--- a/scripts/workflows/follow-up2/lib/steps/monitor.js
+++ b/scripts/workflows/follow-up2/lib/steps/monitor.js
@@ -96,10 +96,66 @@ module.exports = function registerMonitor(register) {
     // report) can check `state._isConflicting` without re-parsing the
     // formatted output. This makes merge-conflict detection authoritative:
     // it preempts CI status, review state, and pending bot reviews.
+    const apiConflicting =
+      prInfo.mergeable === 'CONFLICTING' || prInfo.mergeStateStatus === 'DIRTY';
+
+    // Cross-check via local `git merge-tree` against the PR's base branch.
+    // GitHub's `mergeable` API has known false-clean cases:
+    //   - stacked PRs (base is a sibling branch — clean to base, conflicts vs main)
+    //   - stale cached mergeability after a sibling PR merged into the base
+    // Local check is authoritative because it operates on actual tree content.
+    // Best-effort: if `git fetch` / `git merge-tree` fail, trust the API answer.
+    let localConflicting = false;
+    let localConflictFiles = [];
+    const baseBranch = prInfo.baseBranch;
+    if (baseBranch && ctx && ctx.worktreeDir) {
+      try {
+        execFileSync('git', ['fetch', 'origin', baseBranch], {
+          stdio: 'ignore',
+          cwd: ctx.worktreeDir,
+          timeout: 30000,
+        });
+        const mb = execFileSync('git', ['merge-base', 'HEAD', `origin/${baseBranch}`], {
+          encoding: 'utf8',
+          cwd: ctx.worktreeDir,
+          timeout: 10000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }).trim();
+        if (mb) {
+          const tree = execFileSync(
+            'git',
+            ['merge-tree', `--merge-base=${mb}`, 'HEAD', `origin/${baseBranch}`],
+            {
+              encoding: 'utf8',
+              cwd: ctx.worktreeDir,
+              timeout: 30000,
+              stdio: ['pipe', 'pipe', 'pipe'],
+            }
+          );
+          if (/^<{7} |^={7}$|^>{7} /m.test(tree)) {
+            localConflicting = true;
+            for (const line of tree.split('\n')) {
+              const m = line.match(/^\+\+\+ b\/(.+)$/);
+              if (m && !localConflictFiles.includes(m[1])) {
+                localConflictFiles.push(m[1]);
+              }
+              if (localConflictFiles.length >= 3) break;
+            }
+          }
+        }
+      } catch {
+        /* network/auth failure → trust API */
+      }
+    }
+
     state._mergeStatus = {
       mergeable: prInfo.mergeable || 'UNKNOWN',
       mergeStateStatus: prInfo.mergeStateStatus || 'UNKNOWN',
-      isConflicting: prInfo.mergeable === 'CONFLICTING' || prInfo.mergeStateStatus === 'DIRTY',
+      baseBranch: baseBranch || null,
+      apiConflicting,
+      localConflicting,
+      localConflictFiles,
+      isConflicting: apiConflicting || localConflicting,
       retries: mergeableRetries,
     };
     state._isConflicting = state._mergeStatus.isConflicting;

--- a/scripts/workflows/follow-up2/lib/steps/monitor.js
+++ b/scripts/workflows/follow-up2/lib/steps/monitor.js
@@ -74,22 +74,27 @@ module.exports = function registerMonitor(register) {
     // to be reported. Retry a few times before trusting UNKNOWN.
     // Bounded retry (3 * 3s = 9s max latency) — better than letting a
     // conflict slip past the gate for an entire cycle.
-    let mergeableRetries = 0;
-    while (prInfo && prInfo.mergeable === 'UNKNOWN' && mergeableRetries < 3) {
+    // Synchronous sleep via Atomics.wait — no subprocess, no event-loop
+    // dependency. Uses a private SharedArrayBuffer so the wait can never be
+    // notified externally; it always times out after `ms` milliseconds.
+    const sleepSync = (ms) => {
       try {
-        execFileSync('node', ['-e', 'setTimeout(()=>{}, 3000)'], {
-          stdio: 'ignore',
-          timeout: 5000,
-        });
+        const sab = new SharedArrayBuffer(4);
+        Atomics.wait(new Int32Array(sab), 0, 0, ms);
       } catch {
         /* sleep best-effort */
       }
+    };
+
+    let mergeableRetries = 0;
+    while (prInfo && prInfo.mergeable === 'UNKNOWN' && mergeableRetries < 3) {
+      mergeableRetries++;
+      sleepSync(3000);
       try {
         prInfo = getPRInfo(prArg);
       } catch {
         break;
       }
-      mergeableRetries++;
     }
 
     // First-class conflict signal. Any later step (triage, fix-reviews,

--- a/scripts/workflows/follow-up2/lib/steps/monitor.js
+++ b/scripts/workflows/follow-up2/lib/steps/monitor.js
@@ -124,11 +124,16 @@ module.exports = function registerMonitor(register) {
       output = lines.join('\n');
     }
 
-    // Determine exit code: 0 = all clear, 1 = issues remain
+    // Determine exit code: 0 = all clear, 1 = issues remain.
+    // Merge state matters: a PR with green CI + clear reviews but
+    // `mergeable: CONFLICTING` is NOT all-clear — it needs a rebase before
+    // it can merge. Previously this returned 0 and `report.js` declared the
+    // workflow complete while conflicts existed on the PR.
     const ciOk = ci.status === 'passing' || ci.status === 'no-checks';
     const reviewsOk =
       !reviews.hasBlocking && (!reviews.pendingBots || reviews.pendingBots.length === 0);
-    const exitCode = ciOk && reviewsOk ? 0 : 1;
+    const mergeOk = prInfo.mergeable !== 'CONFLICTING' && prInfo.mergeStateStatus !== 'DIRTY';
+    const exitCode = ciOk && reviewsOk && mergeOk ? 0 : 1;
 
     state.lastMonitorResult = { exitCode, output: output.substring(0, 3000) };
     state._ciRunningCount = ci.running ? ci.running.length : 0;

--- a/scripts/workflows/follow-up2/lib/steps/report.js
+++ b/scripts/workflows/follow-up2/lib/steps/report.js
@@ -15,7 +15,7 @@ module.exports = function registerReport(register) {
     // fix-ci falling through when there were no failing CI jobs to dispatch
     // a fix for. Send the workflow back to fix-ci instead.
     const lastOutput = (state.lastMonitorResult && state.lastMonitorResult.output) || '';
-    if (/merge conflict|cannot be merged/i.test(lastOutput)) {
+    if (state._isConflicting || /merge conflict|cannot be merged/i.test(lastOutput)) {
       state.failureCategory = 'conflict';
       state.currentStep = 'fix-ci';
       return null;

--- a/scripts/workflows/follow-up2/lib/steps/report.js
+++ b/scripts/workflows/follow-up2/lib/steps/report.js
@@ -23,6 +23,8 @@ module.exports = function registerReport(register) {
 
     // Write accountability report if it doesn't exist
     const reportPath = path.join(ctx.tasksDir, 'review-accountability.json');
+    const skippedReviews = state._skippedReviewsCount || 0;
+    const solvedReviews = state._solvedReviewsCount || 0;
     if (!fs.existsSync(reportPath)) {
       try {
         fs.writeFileSync(
@@ -34,6 +36,7 @@ module.exports = function registerReport(register) {
               attempts: state.attempt || 1,
               completedAt: new Date().toISOString(),
               status: 'success',
+              reviewComments: { solved: solvedReviews, skipped: skippedReviews },
             },
             null,
             2
@@ -46,11 +49,15 @@ module.exports = function registerReport(register) {
 
     state.status = 'complete';
 
+    const skipSuffix = skippedReviews
+      ? ` — ${solvedReviews} review${solvedReviews !== 1 ? 's' : ''} fixed, ${skippedReviews} skipped (see follow-up-comments.json for rationale).`
+      : '';
+
     return {
       type: 'follow_up_instruction',
       action: 'complete',
       state: { ticket: state.ticketId, currentStep: 'report', attempt: state.attempt },
-      summary: `Follow-up complete for ${state.ticketId} PR #${state.prNumber || '?'} after ${state.attempt || 1} attempt(s).`,
+      summary: `Follow-up complete for ${state.ticketId} PR #${state.prNumber || '?'} after ${state.attempt || 1} attempt(s)${skipSuffix}`,
     };
   });
 };

--- a/scripts/workflows/follow-up2/lib/steps/report.js
+++ b/scripts/workflows/follow-up2/lib/steps/report.js
@@ -9,6 +9,18 @@ const path = require('path');
 
 module.exports = function registerReport(register) {
   register('report', (state, ctx) => {
+    // Final safety net: never mark complete while the latest monitor cycle
+    // still shows merge conflicts. Catches the case where an earlier step
+    // (triage/fix-ci) routed past a conflict without resolving it — e.g.
+    // fix-ci falling through when there were no failing CI jobs to dispatch
+    // a fix for. Send the workflow back to fix-ci instead.
+    const lastOutput = (state.lastMonitorResult && state.lastMonitorResult.output) || '';
+    if (/merge conflict|cannot be merged/i.test(lastOutput)) {
+      state.failureCategory = 'conflict';
+      state.currentStep = 'fix-ci';
+      return null;
+    }
+
     // Write accountability report if it doesn't exist
     const reportPath = path.join(ctx.tasksDir, 'review-accountability.json');
     if (!fs.existsSync(reportPath)) {

--- a/scripts/workflows/follow-up2/lib/steps/triage.js
+++ b/scripts/workflows/follow-up2/lib/steps/triage.js
@@ -48,19 +48,27 @@ module.exports = function registerTriage(register) {
       };
     }
 
-    const hasConflict = /merge conflict|cannot be merged/i.test(output);
+    // ── PRIORITY 0: merge conflict ──────────────────────────────────────
+    // Conflict ALWAYS preempts everything else (CI status, reviews, etc).
+    // Structured signal `state._isConflicting` is set by monitor.js after
+    // a bounded retry on `mergeable: UNKNOWN`, so it survives the case
+    // where formatReport didn't emit a "CONFLICTS:" line yet (e.g. when
+    // GitHub was mid-recompute). Regex fallback covers older state files
+    // written before this field existed.
+    const structuredConflict = !!state._isConflicting;
+    const hasConflict = structuredConflict || /merge conflict|cannot be merged/i.test(output);
+    if (hasConflict) {
+      state.failureCategory = 'conflict';
+      state.currentStep = 'fix-ci';
+      return null;
+    }
+
     const hasCiFailure = /CI:\s*FAILING/i.test(output);
     const hasCiPending = /CI:\s*PENDING/i.test(output);
     const hasCiCancelled = /CI:\s*CANCELLED/i.test(output);
     const isMergeBlocked = /MERGE STATUS:\s*BLOCKED/i.test(output);
     const hasBlockingReviews = /Reviews:.*BLOCKING/i.test(output);
     const hasOngoingReview = /awaiting bot reviews/i.test(output);
-
-    if (hasConflict) {
-      state.failureCategory = 'conflict';
-      state.currentStep = 'fix-ci';
-      return null;
-    }
 
     if (hasCiFailure) {
       state.failureCategory = 'ci_failure';

--- a/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2749,7 +2749,7 @@ describe('enforce-step-workflow', () => {
     const ORCHESTRATOR_PATH = path.join(__dirname, '..', '..', 'work', 'work.workflow.js');
 
     // The verify() function now delegates to follow-up-pr.js which calls:
-    //   getPRInfo():  gh pr view --json number,title,url,headRefName,mergeable,mergeStateStatus,state
+    //   getPRInfo():  gh pr view --json number,title,url,headRefName,baseRefName,mergeable,mergeStateStatus,state
     //   checkCI():    gh pr checks <N> --json name,bucket,state,link,workflow
     //                 gh pr view <N> --json statusCheckRollup  (NEUTRAL enrichment)
     //   getReviews(): gh pr view <N> --json reviews,statusCheckRollup
@@ -2814,6 +2814,7 @@ describe('enforce-step-workflow', () => {
         title: 'Test PR',
         url: 'https://github.com/test/repo/pull/42',
         headRefName: 'test-branch',
+        baseRefName: 'main',
         mergeable,
         mergeStateStatus,
         state: prState,
@@ -2831,7 +2832,8 @@ describe('enforce-step-workflow', () => {
 
       return {
         // getPRInfo: gh pr view --json number,title,...
-        'pr view --json number,title,url,headRefName,mergeable,mergeStateStatus,state': prView,
+        'pr view --json number,title,url,headRefName,baseRefName,mergeable,mergeStateStatus,state':
+          prView,
         // checkCI: gh pr checks 42 --json ...
         'pr checks 42 --json name,bucket,state,link,workflow': ciChecks,
         // checkCI: NEUTRAL enrichment fallback

--- a/scripts/workflows/lib/__tests__/protect-state-files.test.js
+++ b/scripts/workflows/lib/__tests__/protect-state-files.test.js
@@ -703,6 +703,14 @@ describe('exported constants', () => {
     assert.ok(BASH_WRITE_OPS.test('dd if=/dev/zero of=file'));
     assert.ok(!BASH_WRITE_OPS.test('cat file'));
     assert.ok(!BASH_WRITE_OPS.test('echo hello'));
+    // fd-number redirects must NOT match (they don't write to a user-named target)
+    assert.ok(!BASH_WRITE_OPS.test('cat foo 2>/dev/null'));
+    assert.ok(!BASH_WRITE_OPS.test('cat foo 2>>/dev/null'));
+    assert.ok(!BASH_WRITE_OPS.test('cat foo 1>>log'));
+    assert.ok(!BASH_WRITE_OPS.test('cat foo 1>/dev/null'));
+    // but &>> and &> still match (these DO write to a user-named target)
+    assert.ok(BASH_WRITE_OPS.test('cmd &> out'));
+    assert.ok(BASH_WRITE_OPS.test('cmd &>> out'));
   });
 
   it('NODE_FS_WRITES matches fs write calls', () => {

--- a/scripts/workflows/lib/__tests__/task-scope.test.js
+++ b/scripts/workflows/lib/__tests__/task-scope.test.js
@@ -183,8 +183,8 @@ describe('validateTaskTestScope (regression: ECHO-4637-class deadlock)', () => {
     const tasks = [
       {
         num: 1,
-        filesInScope: ['lib/foo.ts'],
-        testCommand: 'CHANGED_FILES="lib/bar.ts" eval "$TEST_UNIT_COMMAND"',
+        filesInScope: ['lib/foo/**'],
+        testCommand: 'CHANGED_FILES="lib/bar/bar.test.ts" eval "$TEST_UNIT_COMMAND"',
       },
     ];
     const r = ts.validateAll(tasks);
@@ -207,6 +207,86 @@ describe('extractChangedFilesFromTestCommand', () => {
       assert.deepEqual(ts.extractChangedFilesFromTestCommand(input), expected);
     });
   }
+});
+
+describe('Rule 4b: testable surface enforcement', () => {
+  it('blocks Test Command that is `pnpm typecheck`', () => {
+    const task = {
+      num: 6,
+      filesInScope: ['lib/foo.ts'],
+      testCommand: 'pnpm typecheck',
+    };
+    const errors = ts.validateTaskTestScope(task);
+    assert.ok(errors.length >= 1);
+    assert.match(errors[0], /typecheck-only/);
+    assert.match(errors[0], /Rule 4b/);
+  });
+
+  it('blocks Test Command that is `pnpm lint`', () => {
+    const task = { num: 7, filesInScope: ['lib/foo.ts'], testCommand: 'pnpm lint --fix' };
+    const errors = ts.validateTaskTestScope(task);
+    assert.ok(errors.length >= 1);
+    assert.match(errors[0], /lint-only/);
+  });
+
+  it('blocks Test Command that is `pnpm build`', () => {
+    const task = { num: 8, filesInScope: ['lib/foo.ts'], testCommand: 'pnpm build' };
+    const errors = ts.validateTaskTestScope(task);
+    assert.ok(errors.length >= 1);
+    assert.match(errors[0], /build-only/);
+  });
+
+  it('blocks Test Command that is `true` (noop)', () => {
+    const task = { num: 9, filesInScope: ['lib/foo.ts'], testCommand: 'true' };
+    const errors = ts.validateTaskTestScope(task);
+    assert.ok(errors.length >= 1);
+    assert.match(errors[0], /noop/);
+  });
+
+  it('blocks helper-only task: CHANGED_FILES has zero test files', () => {
+    // ECHO-4637 Task 6 shape: ships a helper, no test file, integration runner.
+    const task = {
+      num: 6,
+      filesInScope: ['tests/e2e/helpers/external-assets-filter-seed.ts'],
+      testCommand:
+        'CHANGED_FILES="tests/e2e/helpers/external-assets-filter-seed.ts" eval "$TEST_INTEGRATION_COMMAND"',
+    };
+    const errors = ts.validateTaskTestScope(task);
+    assert.ok(errors.length >= 1);
+    assert.match(errors[0], /no test files/i);
+    assert.match(errors[0], /Rule 4b/);
+  });
+
+  it('exempts checkpoint tasks (type=checkpoint)', () => {
+    const task = {
+      num: 9,
+      type: 'checkpoint',
+      filesInScope: ['*.md'],
+      testCommand: 'pnpm typecheck',
+    };
+    assert.deepEqual(ts.validateTaskTestScope(task), []);
+  });
+
+  it('exempts checkpoint tasks (isCheckpoint=true)', () => {
+    const task = {
+      num: 9,
+      isCheckpoint: true,
+      filesInScope: ['*.md'],
+      testCommand: 'true',
+    };
+    assert.deepEqual(ts.validateTaskTestScope(task), []);
+  });
+
+  it('does NOT block hardcoded runner invocations (pnpm test foo.test.ts)', () => {
+    const task = {
+      num: 1,
+      filesInScope: ['lib/foo/**'],
+      testCommand: 'pnpm test lib/foo/bar.test.ts',
+    };
+    // No CHANGED_FILES envelope to parse, so other checks short-circuit. The
+    // detectNonTestCommand check must NOT flag `pnpm test` as a non-test cmd.
+    assert.deepEqual(ts.validateTaskTestScope(task), []);
+  });
 });
 
 describe('test-file naming convention (integration / e2e)', () => {

--- a/scripts/workflows/lib/__tests__/task-scope.test.js
+++ b/scripts/workflows/lib/__tests__/task-scope.test.js
@@ -71,6 +71,12 @@ describe('validateTask', () => {
     assert.deepEqual(ts.validateTask(null), ['task must be an object']);
     assert.deepEqual(ts.validateTask(undefined), ['task must be an object']);
   });
+
+  it('exempts checkpoint tasks from the Files-in-scope requirement', () => {
+    // Checkpoint tasks don't ship code, so they don't need a scope envelope.
+    assert.deepEqual(ts.validateTask({ num: 9, type: 'checkpoint' }), []);
+    assert.deepEqual(ts.validateTask({ num: 10, isCheckpoint: true }), []);
+  });
 });
 
 describe('validateAll', () => {
@@ -335,7 +341,7 @@ describe('test-file naming convention (integration / e2e)', () => {
       };
       const errors = ts.validateTaskTestScope(task);
       assert.equal(errors.length, 1);
-      assert.match(errors[0], /not named as integration tests/i);
+      assert.match(errors[0], /no declared runner will pick up/i);
       assert.match(errors[0], /bar\.test\.ts/);
     });
 
@@ -347,7 +353,7 @@ describe('test-file naming convention (integration / e2e)', () => {
       };
       const errors = ts.validateTaskTestScope(task);
       assert.equal(errors.length, 1);
-      assert.match(errors[0], /not named as e2e tests/i);
+      assert.match(errors[0], /no declared runner will pick up/i);
     });
 
     it('blocks $TEST_UNIT_COMMAND when test file IS an integration test', () => {
@@ -359,7 +365,7 @@ describe('test-file naming convention (integration / e2e)', () => {
       };
       const errors = ts.validateTaskTestScope(task);
       assert.equal(errors.length, 1);
-      assert.match(errors[0], /integration- or e2e-named/);
+      assert.match(errors[0], /no declared runner will pick up/i);
     });
 
     it('blocks $TEST_UNIT_COMMAND when test file IS an e2e test', () => {
@@ -370,7 +376,7 @@ describe('test-file naming convention (integration / e2e)', () => {
       };
       const errors = ts.validateTaskTestScope(task);
       assert.equal(errors.length, 1);
-      assert.match(errors[0], /integration- or e2e-named/);
+      assert.match(errors[0], /no declared runner will pick up/i);
     });
 
     it('passes correctly named integration test with the integration runner', () => {
@@ -390,6 +396,33 @@ describe('test-file naming convention (integration / e2e)', () => {
         testCommand: 'CHANGED_FILES="tests/e2e/foo.spec.ts" eval "$TEST_E2E_COMMAND"',
       };
       assert.deepEqual(ts.validateTaskTestScope(task), []);
+    });
+
+    it('passes multi-suite chained command (unit + integration)', () => {
+      // The legitimate pattern: each runner self-filters CHANGED_FILES.
+      // Unit runner picks up `foo.test.ts`; integration runner picks up
+      // `bar.integration.test.ts`. No file is orphaned.
+      const task = {
+        num: 7,
+        filesInScope: ['lib/foo/**', 'app/api/**'],
+        testCommand:
+          'CHANGED_FILES="app/api/bar.integration.test.ts lib/foo/foo.test.ts" eval "$TEST_UNIT_COMMAND" && eval "$TEST_INTEGRATION_COMMAND"',
+      };
+      assert.deepEqual(ts.validateTaskTestScope(task), []);
+    });
+
+    it('still blocks when a file matches NO declared runner', () => {
+      // Only `$TEST_UNIT_COMMAND` declared, but an integration file is in
+      // CHANGED_FILES — unit runner's include pattern won't match it.
+      const task = {
+        num: 8,
+        filesInScope: ['lib/foo/**', 'app/api/**'],
+        testCommand:
+          'CHANGED_FILES="app/api/bar.integration.test.ts lib/foo/foo.test.ts" eval "$TEST_UNIT_COMMAND"',
+      };
+      const errors = ts.validateTaskTestScope(task);
+      assert.ok(errors.length >= 1);
+      assert.match(errors[0], /bar\.integration\.test\.ts/);
     });
   });
 });

--- a/scripts/workflows/lib/__tests__/task-scope.test.js
+++ b/scripts/workflows/lib/__tests__/task-scope.test.js
@@ -148,11 +148,12 @@ describe('validateTaskTestScope (regression: ECHO-4637-class deadlock)', () => {
         'eval "$TEST_INTEGRATION_COMMAND"',
     };
     const errors = ts.validateTaskTestScope(task);
-    assert.equal(errors.length, 1);
-    assert.match(errors[0], /Task 2/);
-    assert.match(errors[0], /external-assets-tags\.integration\.test\.ts/);
-    assert.match(errors[0], /lib\/validation\/__tests__\/external-asset-update-tags\.test\.ts/);
-    assert.match(errors[0], /deadlock/i);
+    assert.ok(errors.length >= 1, `expected at least one error, got ${errors.length}`);
+    const deadlock = errors.find((e) => /deadlock/i.test(e));
+    assert.ok(deadlock, 'expected a deadlock error');
+    assert.match(deadlock, /Task 2/);
+    assert.match(deadlock, /external-assets-tags\.integration\.test\.ts/);
+    assert.match(deadlock, /lib\/validation\/__tests__\/external-asset-update-tags\.test\.ts/);
   });
 
   it('honours glob patterns in Files in scope', () => {
@@ -206,6 +207,111 @@ describe('extractChangedFilesFromTestCommand', () => {
       assert.deepEqual(ts.extractChangedFilesFromTestCommand(input), expected);
     });
   }
+});
+
+describe('test-file naming convention (integration / e2e)', () => {
+  describe('isIntegrationTestPath', () => {
+    const cases = [
+      ['lib/foo/__tests__/bar.integration.test.ts', true],
+      ['lib/foo/bar.integration.spec.tsx', true],
+      ['tests/integration/handler.test.ts', true],
+      ['app/integration/foo.spec.js', true],
+      ['lib/foo/bar.test.ts', false], // plain unit
+      ['lib/foo/bar.spec.ts', false], // plain unit
+      ['tests/e2e/bar.test.ts', false], // e2e, not integration
+      ['lib/foo/bar.integration.ts', false], // not a test file
+      ['lib/integrationhelpers/foo.test.ts', false], // word boundary
+    ];
+    for (const [p, expected] of cases) {
+      it(`${JSON.stringify(p)} → ${expected}`, () => {
+        assert.equal(ts.isIntegrationTestPath(p), expected);
+      });
+    }
+  });
+
+  describe('isE2eTestPath', () => {
+    const cases = [
+      ['tests/e2e/specs/login.e2e.spec.ts', true],
+      ['app/e2e/foo.spec.ts', true],
+      ['lib/foo/bar.e2e.test.ts', true],
+      ['lib/foo/bar.test.ts', false],
+      ['lib/foo/bar.integration.test.ts', false],
+      ['lib/e2ehelper/foo.test.ts', false], // word boundary
+    ];
+    for (const [p, expected] of cases) {
+      it(`${JSON.stringify(p)} → ${expected}`, () => {
+        assert.equal(ts.isE2eTestPath(p), expected);
+      });
+    }
+  });
+
+  describe('validateTaskTestScope: runner-vs-naming consistency', () => {
+    it('blocks $TEST_INTEGRATION_COMMAND with a non-integration test file', () => {
+      const task = {
+        num: 1,
+        filesInScope: ['lib/foo/**', 'tests/**'],
+        testCommand:
+          'CHANGED_FILES="lib/foo/bar.ts tests/foo/bar.test.ts" eval "$TEST_INTEGRATION_COMMAND"',
+      };
+      const errors = ts.validateTaskTestScope(task);
+      assert.equal(errors.length, 1);
+      assert.match(errors[0], /not named as integration tests/i);
+      assert.match(errors[0], /bar\.test\.ts/);
+    });
+
+    it('blocks $TEST_E2E_COMMAND with a non-e2e test file', () => {
+      const task = {
+        num: 2,
+        filesInScope: ['tests/**'],
+        testCommand: 'CHANGED_FILES="tests/foo.test.ts" eval "$TEST_E2E_COMMAND"',
+      };
+      const errors = ts.validateTaskTestScope(task);
+      assert.equal(errors.length, 1);
+      assert.match(errors[0], /not named as e2e tests/i);
+    });
+
+    it('blocks $TEST_UNIT_COMMAND when test file IS an integration test', () => {
+      const task = {
+        num: 3,
+        filesInScope: ['lib/foo/**'],
+        testCommand:
+          'CHANGED_FILES="lib/foo/__tests__/bar.integration.test.ts" eval "$TEST_UNIT_COMMAND"',
+      };
+      const errors = ts.validateTaskTestScope(task);
+      assert.equal(errors.length, 1);
+      assert.match(errors[0], /integration- or e2e-named/);
+    });
+
+    it('blocks $TEST_UNIT_COMMAND when test file IS an e2e test', () => {
+      const task = {
+        num: 4,
+        filesInScope: ['tests/**'],
+        testCommand: 'CHANGED_FILES="tests/e2e/foo.spec.ts" eval "$TEST_UNIT_COMMAND"',
+      };
+      const errors = ts.validateTaskTestScope(task);
+      assert.equal(errors.length, 1);
+      assert.match(errors[0], /integration- or e2e-named/);
+    });
+
+    it('passes correctly named integration test with the integration runner', () => {
+      const task = {
+        num: 5,
+        filesInScope: ['lib/foo/**'],
+        testCommand:
+          'CHANGED_FILES="lib/foo/bar.integration.test.ts" eval "$TEST_INTEGRATION_COMMAND"',
+      };
+      assert.deepEqual(ts.validateTaskTestScope(task), []);
+    });
+
+    it('passes correctly named e2e test with the e2e runner', () => {
+      const task = {
+        num: 6,
+        filesInScope: ['tests/**'],
+        testCommand: 'CHANGED_FILES="tests/e2e/foo.spec.ts" eval "$TEST_E2E_COMMAND"',
+      };
+      assert.deepEqual(ts.validateTaskTestScope(task), []);
+    });
+  });
 });
 
 describe('fileMatchesScope', () => {

--- a/scripts/workflows/lib/__tests__/task-scope.test.js
+++ b/scripts/workflows/lib/__tests__/task-scope.test.js
@@ -120,6 +120,109 @@ describe('unionFilesInScope', () => {
   });
 });
 
+describe('validateTaskTestScope (regression: ECHO-4637-class deadlock)', () => {
+  it('passes when CHANGED_FILES is a strict subset of Files in scope', () => {
+    const task = {
+      num: 2,
+      filesInScope: [
+        'lib/external-assets/update-tags.ts',
+        'lib/external-assets/__tests__/update-tags.test.ts',
+      ],
+      testCommand:
+        'CHANGED_FILES="lib/external-assets/__tests__/update-tags.test.ts" eval "$TEST_UNIT_COMMAND"',
+    };
+    assert.deepEqual(ts.validateTaskTestScope(task), []);
+  });
+
+  it('blocks when CHANGED_FILES references a sibling-owned integration test', () => {
+    // The exact ECHO-4637 shape: Task 2 ships only the helper but its test
+    // command runs through tRPC integration tests, traversing code owned by
+    // Task 4 (schema narrowing).
+    const task = {
+      num: 2,
+      filesInScope: ['lib/external-assets/update-tags.ts'],
+      testCommand:
+        'CHANGED_FILES="lib/external-assets/update-tags.ts ' +
+        'app/api/trpc/routers/__tests__/external-assets-tags.integration.test.ts ' +
+        'lib/validation/__tests__/external-asset-update-tags.test.ts" ' +
+        'eval "$TEST_INTEGRATION_COMMAND"',
+    };
+    const errors = ts.validateTaskTestScope(task);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Task 2/);
+    assert.match(errors[0], /external-assets-tags\.integration\.test\.ts/);
+    assert.match(errors[0], /lib\/validation\/__tests__\/external-asset-update-tags\.test\.ts/);
+    assert.match(errors[0], /deadlock/i);
+  });
+
+  it('honours glob patterns in Files in scope', () => {
+    const task = {
+      num: 1,
+      filesInScope: ['lib/foo/**', 'tests/foo/**'],
+      testCommand: 'CHANGED_FILES="lib/foo/bar.ts tests/foo/bar.test.ts" eval "$TEST_UNIT_COMMAND"',
+    };
+    assert.deepEqual(ts.validateTaskTestScope(task), []);
+  });
+
+  it('skips check when testCommand is absent (legacy tasks)', () => {
+    const task = { num: 3, filesInScope: ['lib/foo.ts'], testCommand: null };
+    assert.deepEqual(ts.validateTaskTestScope(task), []);
+  });
+
+  it('skips check when Test Command does not use the canonical CHANGED_FILES envelope', () => {
+    const task = {
+      num: 4,
+      filesInScope: ['lib/foo.ts'],
+      testCommand: 'pnpm test lib/other/something.test.ts',
+    };
+    assert.deepEqual(ts.validateTaskTestScope(task), []);
+  });
+
+  it('validateAll surfaces test-scope errors alongside scope-envelope errors', () => {
+    const tasks = [
+      {
+        num: 1,
+        filesInScope: ['lib/foo.ts'],
+        testCommand: 'CHANGED_FILES="lib/bar.ts" eval "$TEST_UNIT_COMMAND"',
+      },
+    ];
+    const r = ts.validateAll(tasks);
+    assert.equal(r.valid, false);
+    assert.ok(r.errors.some((e) => /references files not in its/.test(e)));
+  });
+});
+
+describe('extractChangedFilesFromTestCommand', () => {
+  const cases = [
+    ['CHANGED_FILES="a.ts b.ts" eval "$X"', ['a.ts', 'b.ts']],
+    [`CHANGED_FILES='a.ts b.ts' eval "$X"`, ['a.ts', 'b.ts']],
+    ['CHANGED_FILES="a.ts" eval "$X" && CHANGED_FILES="b.ts" eval "$Y"', ['a.ts']],
+    ['pnpm test foo.ts', []],
+    [null, []],
+    ['', []],
+  ];
+  for (const [input, expected] of cases) {
+    it(`parses: ${JSON.stringify(input)}`, () => {
+      assert.deepEqual(ts.extractChangedFilesFromTestCommand(input), expected);
+    });
+  }
+});
+
+describe('fileMatchesScope', () => {
+  it('exact match', () => {
+    assert.equal(ts.fileMatchesScope('lib/foo.ts', ['lib/foo.ts']), true);
+  });
+  it('glob with **', () => {
+    assert.equal(ts.fileMatchesScope('lib/foo/bar/baz.ts', ['lib/foo/**']), true);
+  });
+  it('no match across siblings', () => {
+    assert.equal(ts.fileMatchesScope('lib/bar.ts', ['lib/foo.ts']), false);
+  });
+  it('handles ./ prefix on both sides', () => {
+    assert.equal(ts.fileMatchesScope('./lib/foo.ts', ['./lib/foo.ts']), true);
+  });
+});
+
 describe('findTask', () => {
   it('finds by task num', () => {
     const tasks = [

--- a/scripts/workflows/lib/__tests__/test-cleanup.js
+++ b/scripts/workflows/lib/__tests__/test-cleanup.js
@@ -1,22 +1,25 @@
 /**
  * Shared test cleanup utility.
  *
- * Removes TEST-* directories from TASKS_BASE to prevent leftover
- * test artifacts from accumulating across interrupted test runs.
+ * Removes TEST-* directories from TASKS_BASE AND leaked session-guard
+ * lock files from /tmp. Test runs that abort (SIGINT, hook rejection,
+ * crash) would otherwise leave these around and block future agents.
  *
  * Convention: ALL test ticket IDs MUST start with "TEST-" so this
  * cleanup can safely target them without touching real ticket data.
  *
- * Usage in test files:
- *   const { cleanupTestDirs } = require('../../lib/__tests__/test-cleanup');
- *   before(() => cleanupTestDirs());
- *   after(() => cleanupTestDirs());
+ * Usage in test files (defense in depth — also called from run-tests.sh
+ * trap so interrupted runs clean up):
+ *   const { cleanupTestArtifacts } = require('../../lib/__tests__/test-cleanup');
+ *   before(() => cleanupTestArtifacts());
+ *   after(() => cleanupTestArtifacts());
  */
 
 'use strict';
 
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
 const TEST_DIR_PREFIX = 'TEST-';
 // Additional test-only patterns that leak into TASKS_BASE because some
@@ -28,9 +31,30 @@ const EXTRA_TEST_PATTERNS = [
   /^ARCHIVE-TEST-\d+$/, // complete-deadlock.test.js
 ];
 
+// Session-guard lock files in /tmp. The hook creates these whenever a real
+// ticket workflow starts; tests that don't override SESSION_GUARD_DIR will
+// leak them. A leaked lock file = a real ticket cannot start its workflow
+// until manually rm'd. The patterns below are conservative — they only
+// match obvious test-only or garbage-ID lock names; real-ticket locks like
+// claude-session-guard-ECHO-4446.json are NEVER deleted by this helper.
+const SESSION_GUARD_LOCK_PREFIX = 'claude-session-guard-';
+const SESSION_GUARD_TEST_PATTERNS = [
+  /^TEST-/, // test-only ticket prefix
+  /^T-\d+(?:\.json)?$/, // task-review-gate.test.js series
+  /^ARCHIVE-TEST-/, // archive deadlock tests
+  /[ =]/, // garbage IDs (real ticket IDs have no spaces/'=')
+  /TASKS|SPEC|REWORK/, // belt-and-braces for known leaked names
+];
+
 function isTestDir(name) {
   if (name.startsWith(TEST_DIR_PREFIX)) return true;
   return EXTRA_TEST_PATTERNS.some((re) => re.test(name));
+}
+
+function isTestSessionGuardLock(filename) {
+  if (!filename.startsWith(SESSION_GUARD_LOCK_PREFIX)) return false;
+  const tail = filename.slice(SESSION_GUARD_LOCK_PREFIX.length);
+  return SESSION_GUARD_TEST_PATTERNS.some((re) => re.test(tail));
 }
 
 function cleanupTestDirs() {
@@ -55,4 +79,40 @@ function cleanupTestDirs() {
   }
 }
 
-module.exports = { cleanupTestDirs, isTestDir, TEST_DIR_PREFIX, EXTRA_TEST_PATTERNS };
+function cleanupSessionGuardLocks() {
+  const tmpDir = os.tmpdir() || '/tmp';
+  let entries;
+  try {
+    entries = fs.readdirSync(tmpDir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (isTestSessionGuardLock(entry)) {
+      try {
+        fs.rmSync(path.join(tmpDir, entry), { force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  }
+}
+
+/**
+ * Run all cleanup tasks (dirs + session-guard locks). Prefer this over
+ * cleanupTestDirs alone — it covers every leak vector this helper knows.
+ */
+function cleanupTestArtifacts() {
+  cleanupTestDirs();
+  cleanupSessionGuardLocks();
+}
+
+module.exports = {
+  cleanupTestDirs,
+  cleanupSessionGuardLocks,
+  cleanupTestArtifacts,
+  isTestDir,
+  isTestSessionGuardLock,
+  TEST_DIR_PREFIX,
+  EXTRA_TEST_PATTERNS,
+};

--- a/scripts/workflows/lib/__tests__/test-cleanup.js
+++ b/scripts/workflows/lib/__tests__/test-cleanup.js
@@ -42,8 +42,11 @@ const SESSION_GUARD_TEST_PATTERNS = [
   /^TEST-/, // test-only ticket prefix
   /^T-\d+(?:\.json)?$/, // task-review-gate.test.js series
   /^ARCHIVE-TEST-/, // archive deadlock tests
-  /[ =]/, // garbage IDs (real ticket IDs have no spaces/'=')
-  /TASKS|SPEC|REWORK/, // belt-and-braces for known leaked names
+  // Garbage IDs from pre-validation bug runs always contained a space or '='
+  // (real ticket IDs are alphanumeric+hyphen only). This pattern catches them
+  // without risking real tickets — INSPECT-123, PAPERWORK-42, etc. are safe
+  // because they don't contain either character.
+  /[ =]/,
 ];
 
 function isTestDir(name) {

--- a/scripts/workflows/lib/__tests__/test-cleanup.test.js
+++ b/scripts/workflows/lib/__tests__/test-cleanup.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  isTestDir,
+  isTestSessionGuardLock,
+  cleanupSessionGuardLocks,
+  cleanupTestArtifacts,
+} = require('./test-cleanup');
+
+describe('test-cleanup: dir classification', () => {
+  const cases = [
+    ['TEST-100', true],
+    ['TEST-abc', true],
+    ['T-10', true],
+    ['T-14', true],
+    ['ARCHIVE-TEST-1', true],
+    ['ECHO-4446', false], // real ticket — must not match
+    ['APPSUPEN-1234', false],
+    ['PR-1547', false],
+  ];
+  for (const [name, expected] of cases) {
+    it(`isTestDir(${JSON.stringify(name)}) === ${expected}`, () => {
+      assert.equal(isTestDir(name), expected);
+    });
+  }
+});
+
+describe('test-cleanup: session-guard lock classification', () => {
+  const cases = [
+    // Test-only patterns → should be cleaned
+    ['claude-session-guard-TEST-100.json', true],
+    ['claude-session-guard-TEST-abc.json', true],
+    ['claude-session-guard-T-14.json', true],
+    ['claude-session-guard-ARCHIVE-TEST-1.json', true],
+    // Garbage patterns from pre-validation bug runs → should be cleaned
+    ['claude-session-guard-ECHO-4446 TASKS.json', true],
+    ['claude-session-guard-ECHO-4452 SPEC.json', true],
+    ['claude-session-guard-ECHO-4452 REWORK=SPEC.json', true],
+    // Real ticket lock files → MUST NOT be cleaned
+    ['claude-session-guard-ECHO-4446.json', false],
+    ['claude-session-guard-APPSUPEN-1234.json', false],
+    ['claude-session-guard-PR-1547.json', false],
+    // Unrelated files → not touched
+    ['some-other-file.json', false],
+    ['claude-session-guard-', false], // empty tail
+  ];
+  for (const [filename, expected] of cases) {
+    it(`isTestSessionGuardLock(${JSON.stringify(filename)}) === ${expected}`, () => {
+      assert.equal(isTestSessionGuardLock(filename), expected);
+    });
+  }
+});
+
+describe('test-cleanup: cleanupSessionGuardLocks removes only test locks', () => {
+  it('removes test-only locks but preserves real-ticket locks', () => {
+    // Isolated tmpdir so we don't touch real /tmp content
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-test-'));
+    const origTmpdir = os.tmpdir;
+    os.tmpdir = () => tmpDir;
+    try {
+      const filesToCreate = {
+        'claude-session-guard-TEST-100.json': 'should-delete',
+        'claude-session-guard-T-14.json': 'should-delete',
+        'claude-session-guard-ECHO-4452 SPEC.json': 'should-delete',
+        'claude-session-guard-ECHO-4446.json': 'should-keep',
+        'claude-session-guard-APPSUPEN-1.json': 'should-keep',
+        'unrelated.txt': 'should-keep',
+      };
+      for (const [name, body] of Object.entries(filesToCreate)) {
+        fs.writeFileSync(path.join(tmpDir, name), body);
+      }
+      cleanupSessionGuardLocks();
+      const remaining = fs.readdirSync(tmpDir).sort();
+      assert.deepEqual(remaining, [
+        'claude-session-guard-APPSUPEN-1.json',
+        'claude-session-guard-ECHO-4446.json',
+        'unrelated.txt',
+      ]);
+    } finally {
+      os.tmpdir = origTmpdir;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('test-cleanup: cleanupTestArtifacts is the union', () => {
+  it('does not throw and exposes both leak vectors', () => {
+    // Smoke test — both paths are best-effort and tolerant of missing config.
+    assert.doesNotThrow(() => cleanupTestArtifacts());
+  });
+});

--- a/scripts/workflows/lib/__tests__/test-cleanup.test.js
+++ b/scripts/workflows/lib/__tests__/test-cleanup.test.js
@@ -46,6 +46,11 @@ describe('test-cleanup: session-guard lock classification', () => {
     ['claude-session-guard-ECHO-4446.json', false],
     ['claude-session-guard-APPSUPEN-1234.json', false],
     ['claude-session-guard-PR-1547.json', false],
+    // Regression: real tickets whose names contain SPEC/REWORK/TASKS as a
+    // substring (INSPECT, PAPERWORK, TASKS-RELATED) must NEVER be matched.
+    ['claude-session-guard-INSPECT-123.json', false],
+    ['claude-session-guard-PAPERWORK-42.json', false],
+    ['claude-session-guard-MULTITASKS-7.json', false],
     // Unrelated files → not touched
     ['some-other-file.json', false],
     ['claude-session-guard-', false], // empty tail

--- a/scripts/workflows/lib/__tests__/ticket-provider.test.js
+++ b/scripts/workflows/lib/__tests__/ticket-provider.test.js
@@ -502,4 +502,98 @@ describe('ticket-provider', () => {
       assert.equal(tp.normalizeTicketId('PROJ-123-bugfix'), 'PROJ-123-bugfix');
     });
   });
+
+  // ─── validateRawTicketInput ─────────────────────────────────────────
+
+  describe('validateRawTicketInput', () => {
+    it('accepts a plain ticket ID', () => {
+      const tp = freshRequire('../ticket-provider');
+      const r = tp.validateRawTicketInput('ECHO-4446', { provider: 'linear' });
+      assert.deepStrictEqual(r, {
+        ticketBase: 'ECHO-4446',
+        suffix: null,
+        separator: null,
+        canonical: 'ECHO-4446',
+      });
+    });
+
+    it('accepts hyphenated suffix and returns canonical', () => {
+      const tp = freshRequire('../ticket-provider');
+      const r = tp.validateRawTicketInput('APP-1234-foo', { provider: 'jira' });
+      assert.deepStrictEqual(r, {
+        ticketBase: 'APP-1234',
+        suffix: 'foo',
+        separator: '-',
+        canonical: 'APP-1234-foo',
+      });
+    });
+
+    it('accepts slash suffix', () => {
+      const tp = freshRequire('../ticket-provider');
+      const r = tp.validateRawTicketInput('APP-1234/phase1', { provider: 'jira' });
+      assert.deepStrictEqual(r, {
+        ticketBase: 'APP-1234',
+        suffix: 'phase1',
+        separator: '/',
+        canonical: 'APP-1234/phase1',
+      });
+    });
+
+    it('uppercases the base on a lowercase input', () => {
+      const tp = freshRequire('../ticket-provider');
+      const r = tp.validateRawTicketInput('app-1234-foo', { provider: 'jira' });
+      assert.equal(r.ticketBase, 'APP-1234');
+      assert.equal(r.canonical, 'APP-1234-foo');
+    });
+
+    it('rejects internal whitespace (the ECHO-4446 TASKS bug)', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.throws(
+        () => tp.validateRawTicketInput('ECHO-4446 TASKS', { provider: 'linear' }),
+        /whitespace/
+      );
+    });
+
+    it('rejects path traversal', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.throws(
+        () => tp.validateRawTicketInput('../../etc/passwd', { provider: 'jira' }),
+        /unsafe|traversal|backslash/i
+      );
+    });
+
+    it('rejects empty input', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.throws(() => tp.validateRawTicketInput('', { provider: 'jira' }), /required/);
+      assert.throws(() => tp.validateRawTicketInput(null, { provider: 'jira' }), /required/);
+    });
+
+    it('rejects bases that do not match canonical format', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.throws(
+        () => tp.validateRawTicketInput('notaticket', { provider: 'jira' }),
+        /Invalid ticket ID base/
+      );
+    });
+
+    it('accepts GitHub URL form', () => {
+      const tp = freshRequire('../ticket-provider');
+      const r = tp.validateRawTicketInput('https://github.com/org/repo/issues/56', {
+        provider: 'github',
+      });
+      assert.equal(r.canonical, 'GH-56');
+      assert.equal(r.ticketBase, 'GH-56');
+    });
+
+    it('accepts #N for github provider', () => {
+      const tp = freshRequire('../ticket-provider');
+      const r = tp.validateRawTicketInput('#56', { provider: 'github' });
+      assert.equal(r.ticketBase, '#56');
+    });
+
+    it('rejects #N for non-github provider', () => {
+      const tp = freshRequire('../ticket-provider');
+      assert.throws(() => tp.validateRawTicketInput('#56', { provider: 'jira' }), /Invalid/);
+    });
+  });
 });

--- a/scripts/workflows/lib/protect-state-files.js
+++ b/scripts/workflows/lib/protect-state-files.js
@@ -34,11 +34,14 @@ const path = require('path');
 const FILE_WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit']);
 
 /** Shell write operators — redirects, tee, cp, mv, dd.
- *  The negative-lookbehind `(?<!\d)` on `>` excludes fd-number redirects
- *  like `2>/dev/null`, `1>>log`, which never write to a user-named target.
- *  Real file writes (`> out`, `>> out`, `cmd &> out`) still match because
- *  they're preceded by whitespace or `&`, not a digit. */
-const BASH_WRITE_OPS = /(?:(?<!\d)>{1,2}|\btee\b|\bcp\b|\bmv\b|\bdd\b.*\bof=)/;
+ *  The negative-lookbehind `(?<![\d>])` on the leading `>` excludes fd-number
+ *  redirects like `2>/dev/null`, `2>>/dev/null`, `1>>log`, which never write
+ *  to a user-named target. The `>` exclusion handles the second `>` in `>>`
+ *  cases like `2>>` (the second `>` is preceded by `>`, but the first `>` is
+ *  preceded by a digit, so the whole operator is rejected). Real file writes
+ *  (`> out`, `>> out`, `cmd &> out`) still match because they're preceded by
+ *  whitespace or `&`, not a digit or `>`. */
+const BASH_WRITE_OPS = /(?:(?<![\d>])>{1,2}|\btee\b|\bcp\b|\bmv\b|\bdd\b.*\bof=)/;
 
 /** Node.js fs write calls executed via Bash (node -e, inline scripts) */
 const NODE_FS_WRITES = /\b(?:writeFileSync|appendFileSync|writeFile|createWriteStream)\b/;

--- a/scripts/workflows/lib/protect-state-files.js
+++ b/scripts/workflows/lib/protect-state-files.js
@@ -117,7 +117,22 @@ function basenameProtector(basenames) {
  * @property {boolean} skipRemainingChecks — true for file tools (Edit/Write/MultiEdit) whether blocked or not
  */
 function createFileProtector(opts) {
-  const { isProtected, isExempt = () => false, formatMessage } = opts;
+  const { isProtected, isExempt = () => false, formatMessage, trustedScriptRoots = [] } = opts;
+  // Resolve trusted script roots once. Scripts whose realpath is inside any of
+  // these roots skip Vector 3 (script-content bypass detection). This is how a
+  // hook tells the protector "these scripts are mine — they're the legitimate
+  // writers of the protected files." Without this, the hook deadlocks: it
+  // can't run its own orchestrator because the orchestrator's source mentions
+  // the protected basenames and contains write ops.
+  const resolvedTrustedRoots = trustedScriptRoots
+    .map((r) => {
+      try {
+        return fs.realpathSync(r);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
 
   const defaultMessage = (match, vector) =>
     `BLOCKED: Direct ${vector} to ${match} is not allowed.\n` +
@@ -258,6 +273,21 @@ function createFileProtector(opts) {
     }
   }
 
+  function isUnderTrustedRoot(scriptPath) {
+    if (resolvedTrustedRoots.length === 0) return false;
+    let resolved;
+    try {
+      resolved = fs.realpathSync(scriptPath);
+    } catch {
+      return false;
+    }
+    for (const root of resolvedTrustedRoots) {
+      const rel = path.relative(root, resolved);
+      if (!rel.startsWith('..') && !path.isAbsolute(rel)) return true;
+    }
+    return false;
+  }
+
   function checkScriptBypass(cmd, toolInput, hookData) {
     const scripts = extractScriptPaths(cmd);
     for (const scriptPath of scripts) {
@@ -266,6 +296,11 @@ function createFileProtector(opts) {
       // Resolves the GH-141 false positive: `node --test workflow-state.test.js` is no longer
       // blocked because the test file is in __tests__/, within the repo root, and git-tracked.
       if (isTrustedTestScript(scriptPath)) continue;
+      // Skip Vector 3 for scripts inside an explicitly trusted root (e.g. the
+      // plugin's own orchestrator scripts). The hook that owns the protected
+      // basenames declares its own scripts trusted; otherwise the orchestrator
+      // can't run itself.
+      if (isUnderTrustedRoot(scriptPath)) continue;
 
       let content;
       try {

--- a/scripts/workflows/lib/protect-state-files.js
+++ b/scripts/workflows/lib/protect-state-files.js
@@ -33,8 +33,12 @@ const path = require('path');
 /** Tools that write via file_path */
 const FILE_WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit']);
 
-/** Shell write operators — redirects, tee, cp, mv, dd */
-const BASH_WRITE_OPS = /(?:>{1,2}|\btee\b|\bcp\b|\bmv\b|\bdd\b.*\bof=)/;
+/** Shell write operators — redirects, tee, cp, mv, dd.
+ *  The negative-lookbehind `(?<!\d)` on `>` excludes fd-number redirects
+ *  like `2>/dev/null`, `1>>log`, which never write to a user-named target.
+ *  Real file writes (`> out`, `>> out`, `cmd &> out`) still match because
+ *  they're preceded by whitespace or `&`, not a digit. */
+const BASH_WRITE_OPS = /(?:(?<!\d)>{1,2}|\btee\b|\bcp\b|\bmv\b|\bdd\b.*\bof=)/;
 
 /** Node.js fs write calls executed via Bash (node -e, inline scripts) */
 const NODE_FS_WRITES = /\b(?:writeFileSync|appendFileSync|writeFile|createWriteStream)\b/;

--- a/scripts/workflows/lib/task-scope.js
+++ b/scripts/workflows/lib/task-scope.js
@@ -163,6 +163,58 @@ function usesE2eRunner(testCommand) {
 }
 
 /**
+ * Decide whether the Test Command is a recognised test-runner invocation
+ * (unit / integration / e2e) — i.e. it would actually execute tests.
+ * Plain typecheck/lint/build commands are NOT test invocations, so they
+ * cannot serve as a task's behavior gate.
+ */
+function usesRecognisedRunner(testCommand) {
+  return (
+    usesUnitRunner(testCommand) || usesIntegrationRunner(testCommand) || usesE2eRunner(testCommand)
+  );
+}
+
+/**
+ * Detect Test Commands that pretend to be a test gate but actually run
+ * something that never asserts behavior — typecheck, lint, build, format,
+ * a bare `true`, etc. Returns a short category name when matched, null
+ * otherwise.
+ *
+ * The check is conservative: it only flags commands that are CLEARLY
+ * non-test (no test runner referenced; primary verb is a compile/lint
+ * tool). Hardcoded runner invocations like `pnpm test foo.ts` aren't
+ * touched here (handled by the opt-out clause in SKILL.md).
+ */
+function detectNonTestCommand(testCommand) {
+  if (typeof testCommand !== 'string' || !testCommand.trim()) return null;
+  if (usesRecognisedRunner(testCommand)) return null;
+  const lower = testCommand.toLowerCase();
+  // Hardcoded test-runner invocations still count as tests, even without env vars
+  if (
+    /\b(?:pnpm|npm|yarn|bun)\s+(?:run\s+)?(?:test|vitest|jest|playwright|cypress|pw\s+test)\b/.test(
+      lower
+    )
+  ) {
+    return null;
+  }
+  if (
+    /\b(?:pnpm|npm|yarn|bun)\s+(?:run\s+)?typecheck\b|\btsc\b(?!.*-p\s+tsconfig\.test)/.test(lower)
+  ) {
+    return 'typecheck-only';
+  }
+  if (/\b(?:pnpm|npm|yarn|bun)\s+(?:run\s+)?(?:lint|format|prettier|biome|eslint)\b/.test(lower)) {
+    return 'lint-only';
+  }
+  if (/\b(?:pnpm|npm|yarn|bun)\s+(?:run\s+)?build\b/.test(lower)) {
+    return 'build-only';
+  }
+  if (/^\s*(?:true|:|exit\s+0)\s*;?\s*$/.test(testCommand)) {
+    return 'noop';
+  }
+  return null;
+}
+
+/**
  * Verify the task's Test Command CHANGED_FILES list is fully covered by
  * this task's `### Files in scope`. When a CHANGED_FILES path is owned
  * by another task, the test will execute through that other task's code
@@ -181,7 +233,49 @@ function usesE2eRunner(testCommand) {
 function validateTaskTestScope(task) {
   const errors = [];
   if (!task || typeof task !== 'object') return errors;
+
+  // Skip checks for checkpoint tasks — they're explicit "verify integration"
+  // markers and the implement-gate exempts them from TDD evidence entirely.
+  const taskType = typeof task.type === 'string' ? task.type.toLowerCase().trim() : null;
+  if (taskType === 'checkpoint' || task.isCheckpoint === true) {
+    return errors;
+  }
+
+  // Rule 4b: Test Command must actually run tests. Typecheck / lint / build /
+  // `true` are not behavior gates. If a task has no behavior to verify, it
+  // should be merged with its consumer (SKILL.md Rule 4b).
+  const nonTest = detectNonTestCommand(task.testCommand);
+  if (nonTest) {
+    errors.push(
+      `Task ${task.num ?? '?'} \`### Test Command\` is a ${nonTest} command, not a test runner: ` +
+        `${JSON.stringify(String(task.testCommand || '').slice(0, 120))}. ` +
+        "A task's gate must execute tests that assert behavior. Use $TEST_UNIT_COMMAND / " +
+        '$TEST_INTEGRATION_COMMAND / $TEST_E2E_COMMAND with a real test file in CHANGED_FILES. ' +
+        'If this task has no testable behavior in isolation (e.g. a helper consumed only by ' +
+        'another task), MERGE IT INTO THE CONSUMING TASK — see split-in-tasks SKILL.md Rule 4b.'
+    );
+    return errors;
+  }
+
   const changed = extractChangedFilesFromTestCommand(task.testCommand);
+  // Rule 4b (helper-only): A task that uses a recognised runner but lists ZERO
+  // test files in CHANGED_FILES will never have a test to execute — the gate
+  // gets "No test files found" forever. This is the helper-only pattern.
+  if (
+    usesRecognisedRunner(task.testCommand) &&
+    changed.length > 0 &&
+    !changed.some((p) => TEST_FILE_EXT_RE.test(p))
+  ) {
+    errors.push(
+      `Task ${task.num ?? '?'} \`### Test Command\` lists CHANGED_FILES with NO test files ` +
+        `(no .test.* / .spec.* path). The runner will report "No test files found" and the ` +
+        'gate will loop forever. This is the helper-only task pattern — the task ships code ' +
+        "used by another task's tests but has no test of its own. MERGE IT INTO THE CONSUMING " +
+        "TASK (split-in-tasks SKILL.md Rule 4b), or add this task's own test file to CHANGED_FILES."
+    );
+    return errors;
+  }
+
   if (changed.length === 0) return errors;
 
   const scope =
@@ -306,5 +400,7 @@ module.exports = {
   usesIntegrationRunner,
   usesUnitRunner,
   usesE2eRunner,
+  usesRecognisedRunner,
+  detectNonTestCommand,
   TEST_FILE_EXT_RE,
 };

--- a/scripts/workflows/lib/task-scope.js
+++ b/scripts/workflows/lib/task-scope.js
@@ -25,6 +25,15 @@ function validateTask(task) {
   }
   const label = `Task ${task.num ?? '?'}`;
 
+  // Checkpoint tasks don't ship code, so the `Files in scope` envelope is
+  // not meaningful for them. The implement-gate already exempts them from
+  // TDD evidence; this matches that behavior at Gate C.
+  const taskType = typeof task.type === 'string' ? task.type.toLowerCase().trim() : null;
+  const isCheckpoint = taskType === 'checkpoint' || task.isCheckpoint === true;
+  if (isCheckpoint) {
+    return errors;
+  }
+
   // Legacy fallback: tasks written before Gate C may carry `### Suggested Scope`
   // instead of `### Files in scope`. Accept that as evidence of scope intent
   // and ONLY error when BOTH are missing/empty. New tasks SHOULD use
@@ -294,44 +303,39 @@ function validateTaskTestScope(task) {
     }
   }
 
-  // Test-runner / file-naming consistency
+  // Test-runner / file-naming consistency.
+  //
+  // Multi-suite chained commands (`$TEST_UNIT_COMMAND && $TEST_INTEGRATION_COMMAND`)
+  // are valid — each runner self-filters CHANGED_FILES by its include pattern.
+  // We only flag a file when NO chained runner's naming convention matches it.
   const testFiles = changed.filter((p) => TEST_FILE_EXT_RE.test(p));
   if (testFiles.length > 0) {
-    if (usesIntegrationRunner(task.testCommand)) {
-      const wrong = testFiles.filter((p) => !isIntegrationTestPath(p));
-      if (wrong.length > 0) {
-        errors.push(
-          `Task ${task.num ?? '?'} \`### Test Command\` uses \`$TEST_INTEGRATION_COMMAND\` but ` +
-            `CHANGED_FILES includes test files that are NOT named as integration tests: ` +
-            wrong.map((p) => `"${p}"`).join(', ') +
-            '. Integration tests MUST match `**/*.integration.(test|spec).(ts|tsx|js|jsx|mjs|cjs)` ' +
-            'OR live under a `**/integration/**/` directory. Either rename the test file (recommended) ' +
-            'or switch the Test Command to `$TEST_UNIT_COMMAND` if it is actually a unit test.'
-        );
-      }
-    } else if (usesE2eRunner(task.testCommand)) {
-      const wrong = testFiles.filter((p) => !isE2eTestPath(p));
-      if (wrong.length > 0) {
-        errors.push(
-          `Task ${task.num ?? '?'} \`### Test Command\` uses \`$TEST_E2E_COMMAND\` but ` +
-            `CHANGED_FILES includes test files that are NOT named as e2e tests: ` +
-            wrong.map((p) => `"${p}"`).join(', ') +
-            '. E2E tests MUST match `**/*.e2e.(test|spec).(ts|tsx|js|jsx|mjs|cjs)` ' +
-            'OR live under a `**/e2e/**/` directory. Either rename the test file (recommended) ' +
-            'or switch the Test Command to `$TEST_UNIT_COMMAND` / `$TEST_INTEGRATION_COMMAND`.'
-        );
-      }
-    } else if (usesUnitRunner(task.testCommand)) {
-      const wrong = testFiles.filter((p) => isIntegrationTestPath(p) || isE2eTestPath(p));
-      if (wrong.length > 0) {
-        errors.push(
-          `Task ${task.num ?? '?'} \`### Test Command\` uses \`$TEST_UNIT_COMMAND\` but ` +
-            `CHANGED_FILES includes integration- or e2e-named test files: ` +
-            wrong.map((p) => `"${p}"`).join(', ') +
-            '. Either rename the file to drop the `.integration.` / `.e2e.` infix and move it out of ' +
-            'any `integration/` or `e2e/` directory, or switch the Test Command to the matching runner.'
-        );
-      }
+    const runners = {
+      unit: usesUnitRunner(task.testCommand),
+      integration: usesIntegrationRunner(task.testCommand),
+      e2e: usesE2eRunner(task.testCommand),
+    };
+    const fileMatchesAnyRunner = (p) => {
+      if (runners.e2e && isE2eTestPath(p)) return true;
+      if (runners.integration && isIntegrationTestPath(p)) return true;
+      if (runners.unit && !isIntegrationTestPath(p) && !isE2eTestPath(p)) return true;
+      return false;
+    };
+    const orphans = testFiles.filter((p) => !fileMatchesAnyRunner(p));
+    if (orphans.length > 0) {
+      const declared = Object.entries(runners)
+        .filter(([, on]) => on)
+        .map(([k]) => `$TEST_${k.toUpperCase()}_COMMAND`)
+        .join(' + ');
+      errors.push(
+        `Task ${task.num ?? '?'} \`### Test Command\` declares ${declared || '(no known runner)'} ` +
+          `but CHANGED_FILES includes test files no declared runner will pick up: ` +
+          orphans.map((p) => `"${p}"`).join(', ') +
+          '. Integration tests MUST match `**/*.integration.(test|spec).<ext>` OR live under ' +
+          '`**/integration/**/`. E2E tests MUST match `**/*.e2e.(test|spec).<ext>` OR live under ' +
+          '`**/e2e/**/`. Unit tests must do NEITHER. Either rename the test file or add the matching ' +
+          'runner to the chain (e.g. append ` && eval "$TEST_INTEGRATION_COMMAND"`).'
+      );
     }
   }
 

--- a/scripts/workflows/lib/task-scope.js
+++ b/scripts/workflows/lib/task-scope.js
@@ -99,11 +99,81 @@ function fileMatchesScope(candidate, scopeGlobs) {
 }
 
 /**
+ * Recognise a test file by extension.
+ */
+const TEST_FILE_EXT_RE = /\.(?:test|spec)\.(?:ts|tsx|js|jsx|mjs|cjs)$/;
+
+/**
+ * Decide whether a test file path follows the project's integration-test
+ * naming convention. Integration tests must be EITHER:
+ *   - filename ends with `.integration.test.<ext>` / `.integration.spec.<ext>`, or
+ *   - path contains an `integration/` directory segment.
+ *
+ * Unit tests must do NEITHER (they live under any directory but never
+ * inside `integration/` and never carry the `.integration.` infix).
+ *
+ * This naming rule is what lets the vitest configs route a test file to
+ * the correct runner; it is also how split-in-tasks declares per-task gate
+ * granularity. Misnamed files silently fall into the wrong runner and the
+ * gate either skips them or runs them against the wrong fixtures.
+ *
+ * @param {string} candidate
+ * @returns {boolean}
+ */
+function isIntegrationTestPath(candidate) {
+  if (typeof candidate !== 'string' || !candidate) return false;
+  if (!TEST_FILE_EXT_RE.test(candidate)) return false;
+  if (/\.integration\.(?:test|spec)\.(?:ts|tsx|js|jsx|mjs|cjs)$/.test(candidate)) return true;
+  if (/(?:^|\/)integration\//.test(candidate)) return true;
+  return false;
+}
+
+/**
+ * Decide whether a test file path follows the project's e2e naming convention.
+ *   - filename ends with `.e2e.test.<ext>` / `.e2e.spec.<ext>`, OR
+ *   - path contains an `e2e/` directory segment.
+ */
+function isE2eTestPath(candidate) {
+  if (typeof candidate !== 'string' || !candidate) return false;
+  if (!TEST_FILE_EXT_RE.test(candidate)) return false;
+  if (/\.e2e\.(?:test|spec)\.(?:ts|tsx|js|jsx|mjs|cjs)$/.test(candidate)) return true;
+  if (/(?:^|\/)e2e\//.test(candidate)) return true;
+  return false;
+}
+
+/**
+ * Decide whether the Test Command targets the integration runner.
+ */
+function usesIntegrationRunner(testCommand) {
+  return typeof testCommand === 'string' && /\$TEST_INTEGRATION_COMMAND\b/.test(testCommand);
+}
+
+/**
+ * Decide whether the Test Command targets the unit runner.
+ */
+function usesUnitRunner(testCommand) {
+  return typeof testCommand === 'string' && /\$TEST_UNIT_COMMAND\b/.test(testCommand);
+}
+
+/**
+ * Decide whether the Test Command targets the e2e runner.
+ */
+function usesE2eRunner(testCommand) {
+  return typeof testCommand === 'string' && /\$TEST_E2E_COMMAND\b/.test(testCommand);
+}
+
+/**
  * Verify the task's Test Command CHANGED_FILES list is fully covered by
  * this task's `### Files in scope`. When a CHANGED_FILES path is owned
  * by another task, the test will execute through that other task's code
  * — and the gate cannot pass until that sibling is also complete. That
  * is the ECHO-4637-class deadlock.
+ *
+ * Also enforces test-file naming conventions:
+ *   - $TEST_INTEGRATION_COMMAND → every test file MUST be an integration
+ *     test (filename `*.integration.test|spec.<ext>` OR under `integration/`).
+ *   - $TEST_UNIT_COMMAND → every test file MUST NOT be an integration test.
+ * Mismatches mean the test file silently lands in the wrong runner.
  *
  * @param {object} task
  * @returns {string[]} validation errors
@@ -113,20 +183,64 @@ function validateTaskTestScope(task) {
   if (!task || typeof task !== 'object') return errors;
   const changed = extractChangedFilesFromTestCommand(task.testCommand);
   if (changed.length === 0) return errors;
+
   const scope =
     Array.isArray(task.filesInScope) && task.filesInScope.length > 0 ? task.filesInScope : null;
-  if (!scope) return errors; // already reported by validateTask
-  const offenders = changed.filter((p) => !fileMatchesScope(p, scope));
-  if (offenders.length > 0) {
-    errors.push(
-      `Task ${task.num ?? '?'} \`### Test Command\` references files not in its \`### Files in scope\`: ` +
-        offenders.map((p) => `"${p}"`).join(', ') +
-        '. The gate will execute the test against code owned by sibling tasks, which cannot pass until ' +
-        'those siblings are also complete (deadlock). Fix by either: (a) narrowing the Test Command to a ' +
-        "unit test of files this task actually ships, or (b) widening this task's Files in scope to include " +
-        'the referenced files (only if this task should own them).'
-    );
+  if (scope) {
+    const offenders = changed.filter((p) => !fileMatchesScope(p, scope));
+    if (offenders.length > 0) {
+      errors.push(
+        `Task ${task.num ?? '?'} \`### Test Command\` references files not in its \`### Files in scope\`: ` +
+          offenders.map((p) => `"${p}"`).join(', ') +
+          '. The gate will execute the test against code owned by sibling tasks, which cannot pass until ' +
+          'those siblings are also complete (deadlock). Fix by either: (a) narrowing the Test Command to a ' +
+          "unit test of files this task actually ships, or (b) widening this task's Files in scope to include " +
+          'the referenced files (only if this task should own them).'
+      );
+    }
   }
+
+  // Test-runner / file-naming consistency
+  const testFiles = changed.filter((p) => TEST_FILE_EXT_RE.test(p));
+  if (testFiles.length > 0) {
+    if (usesIntegrationRunner(task.testCommand)) {
+      const wrong = testFiles.filter((p) => !isIntegrationTestPath(p));
+      if (wrong.length > 0) {
+        errors.push(
+          `Task ${task.num ?? '?'} \`### Test Command\` uses \`$TEST_INTEGRATION_COMMAND\` but ` +
+            `CHANGED_FILES includes test files that are NOT named as integration tests: ` +
+            wrong.map((p) => `"${p}"`).join(', ') +
+            '. Integration tests MUST match `**/*.integration.(test|spec).(ts|tsx|js|jsx|mjs|cjs)` ' +
+            'OR live under a `**/integration/**/` directory. Either rename the test file (recommended) ' +
+            'or switch the Test Command to `$TEST_UNIT_COMMAND` if it is actually a unit test.'
+        );
+      }
+    } else if (usesE2eRunner(task.testCommand)) {
+      const wrong = testFiles.filter((p) => !isE2eTestPath(p));
+      if (wrong.length > 0) {
+        errors.push(
+          `Task ${task.num ?? '?'} \`### Test Command\` uses \`$TEST_E2E_COMMAND\` but ` +
+            `CHANGED_FILES includes test files that are NOT named as e2e tests: ` +
+            wrong.map((p) => `"${p}"`).join(', ') +
+            '. E2E tests MUST match `**/*.e2e.(test|spec).(ts|tsx|js|jsx|mjs|cjs)` ' +
+            'OR live under a `**/e2e/**/` directory. Either rename the test file (recommended) ' +
+            'or switch the Test Command to `$TEST_UNIT_COMMAND` / `$TEST_INTEGRATION_COMMAND`.'
+        );
+      }
+    } else if (usesUnitRunner(task.testCommand)) {
+      const wrong = testFiles.filter((p) => isIntegrationTestPath(p) || isE2eTestPath(p));
+      if (wrong.length > 0) {
+        errors.push(
+          `Task ${task.num ?? '?'} \`### Test Command\` uses \`$TEST_UNIT_COMMAND\` but ` +
+            `CHANGED_FILES includes integration- or e2e-named test files: ` +
+            wrong.map((p) => `"${p}"`).join(', ') +
+            '. Either rename the file to drop the `.integration.` / `.e2e.` infix and move it out of ' +
+            'any `integration/` or `e2e/` directory, or switch the Test Command to the matching runner.'
+        );
+      }
+    }
+  }
+
   return errors;
 }
 
@@ -187,4 +301,10 @@ module.exports = {
   findTask,
   extractChangedFilesFromTestCommand,
   fileMatchesScope,
+  isIntegrationTestPath,
+  isE2eTestPath,
+  usesIntegrationRunner,
+  usesUnitRunner,
+  usesE2eRunner,
+  TEST_FILE_EXT_RE,
 };

--- a/scripts/workflows/lib/task-scope.js
+++ b/scripts/workflows/lib/task-scope.js
@@ -48,6 +48,89 @@ function validateTask(task) {
 }
 
 /**
+ * Extract the CHANGED_FILES list from a task's `### Test Command`. Returns
+ * an empty array if the command doesn't follow the canonical
+ * `CHANGED_FILES="<list>" eval "$TEST_*_COMMAND"` form.
+ *
+ * @param {string|null|undefined} testCommand
+ * @returns {string[]}
+ */
+function extractChangedFilesFromTestCommand(testCommand) {
+  if (typeof testCommand !== 'string' || !testCommand) return [];
+  // Match CHANGED_FILES="..." or CHANGED_FILES='...'. Tolerant of leading
+  // whitespace and `&&`/`;` chains — we only need the FIRST assignment to
+  // judge what the gate will execute against.
+  const m = testCommand.match(/CHANGED_FILES\s*=\s*(['"])([\s\S]*?)\1/);
+  if (!m) return [];
+  return m[2].split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Check whether a candidate file path is covered by any of the task's
+ * `Files in scope` glob patterns. Performs a simple prefix/segment match
+ * sufficient for tasks.md authoring (full glob matching happens at
+ * Gate D runtime via micromatch).
+ *
+ * Returns true when the candidate equals a scope entry, sits under one
+ * (treating `**` as a wildcard), or matches the directory prefix of a
+ * scope entry that ends with a glob.
+ *
+ * @param {string} candidate
+ * @param {string[]} scopeGlobs
+ * @returns {boolean}
+ */
+function fileMatchesScope(candidate, scopeGlobs) {
+  if (!candidate || !Array.isArray(scopeGlobs) || scopeGlobs.length === 0) return false;
+  const norm = String(candidate).replace(/^\.\//, '');
+  for (const raw of scopeGlobs) {
+    if (typeof raw !== 'string' || !raw) continue;
+    const glob = raw.replace(/^\.\//, '');
+    if (glob === norm) return true;
+    // `lib/foo/**` or `lib/foo/**/*.ts` → match anything under lib/foo/
+    const starIdx = glob.indexOf('*');
+    if (starIdx > 0) {
+      const prefix = glob.slice(0, starIdx);
+      if (norm.startsWith(prefix)) return true;
+    } else if (glob.endsWith('/')) {
+      if (norm.startsWith(glob)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Verify the task's Test Command CHANGED_FILES list is fully covered by
+ * this task's `### Files in scope`. When a CHANGED_FILES path is owned
+ * by another task, the test will execute through that other task's code
+ * — and the gate cannot pass until that sibling is also complete. That
+ * is the ECHO-4637-class deadlock.
+ *
+ * @param {object} task
+ * @returns {string[]} validation errors
+ */
+function validateTaskTestScope(task) {
+  const errors = [];
+  if (!task || typeof task !== 'object') return errors;
+  const changed = extractChangedFilesFromTestCommand(task.testCommand);
+  if (changed.length === 0) return errors;
+  const scope =
+    Array.isArray(task.filesInScope) && task.filesInScope.length > 0 ? task.filesInScope : null;
+  if (!scope) return errors; // already reported by validateTask
+  const offenders = changed.filter((p) => !fileMatchesScope(p, scope));
+  if (offenders.length > 0) {
+    errors.push(
+      `Task ${task.num ?? '?'} \`### Test Command\` references files not in its \`### Files in scope\`: ` +
+        offenders.map((p) => `"${p}"`).join(', ') +
+        '. The gate will execute the test against code owned by sibling tasks, which cannot pass until ' +
+        'those siblings are also complete (deadlock). Fix by either: (a) narrowing the Test Command to a ' +
+        "unit test of files this task actually ships, or (b) widening this task's Files in scope to include " +
+        'the referenced files (only if this task should own them).'
+    );
+  }
+  return errors;
+}
+
+/**
  * Validate every task and return a flat error list.
  *
  * @param {Array<object>|null|undefined} tasks
@@ -60,6 +143,7 @@ function validateAll(tasks) {
   const errors = [];
   for (const t of tasks) {
     errors.push(...validateTask(t));
+    errors.push(...validateTaskTestScope(t));
   }
   return { valid: errors.length === 0, errors };
 }
@@ -95,4 +179,12 @@ function findTask(tasks, taskNum) {
   return tasks.find((t) => t && t.num === taskNum) || null;
 }
 
-module.exports = { validateTask, validateAll, unionFilesInScope, findTask };
+module.exports = {
+  validateTask,
+  validateTaskTestScope,
+  validateAll,
+  unionFilesInScope,
+  findTask,
+  extractChangedFilesFromTestCommand,
+  fileMatchesScope,
+};

--- a/scripts/workflows/lib/ticket-provider.js
+++ b/scripts/workflows/lib/ticket-provider.js
@@ -186,6 +186,73 @@ function normalizeTicketId(raw) {
   return base + parsed.separator + parsed.suffix;
 }
 
+/**
+ * Strict validator for raw ticket arguments at the entry points of /work2 and
+ * /work-implement. Rejects malformed input BEFORE any filesystem side effects.
+ *
+ * Returns { ticketBase, suffix, separator, canonical }. Throws Error on invalid.
+ * `canonical` is the post-normalization handle used as the session identity.
+ */
+function validateRawTicketInput(raw, providerConfig) {
+  if (raw === null || raw === undefined || raw === '') {
+    throw new Error('Ticket ID is required.');
+  }
+  if (typeof raw !== 'string') {
+    throw new Error(`Ticket ID must be a string (received ${typeof raw}).`);
+  }
+  // URL form: handle BEFORE the structured validator (URLs contain ':' which would
+  // otherwise trip the unsafe-char check).
+  if (raw.startsWith('http://') || raw.startsWith('https://')) {
+    const parsed = parseGitHubUrl(raw);
+    if (!parsed) {
+      throw new Error(`Unrecognized ticket URL: ${raw}`);
+    }
+    const canonical = 'GH-' + parsed.number;
+    return { ticketBase: canonical, suffix: null, separator: null, canonical };
+  }
+  // Delegate the path-safety subset to the shared structured validator
+  // (covers ../, backslash, colon, NUL, leading slash, multi-slash, leading/trailing
+  // whitespace, bare dot). It does NOT reject internal whitespace, so we check that
+  // explicitly below.
+  let structErr = null;
+  try {
+    const { validateTicketIdStructured } = require('./ticket-validation');
+    structErr = validateTicketIdStructured(raw);
+  } catch (e) {
+    if (!e || e.code !== 'MODULE_NOT_FOUND') throw e;
+  }
+  if (structErr) {
+    const err = new Error(structErr.message);
+    err.code = structErr.code;
+    err.remediation = structErr.remediation;
+    throw err;
+  }
+  if (/\s/.test(raw)) {
+    throw new Error(
+      `Ticket ID ${JSON.stringify(raw)} contains whitespace. Expected format: PROJ-123 or PROJ-123-suffix (no spaces).`
+    );
+  }
+  const parsed = parseTicketInput(raw);
+  const ticketBase = parsed.ticketBase;
+  const isGitHub = providerConfig && providerConfig.provider === 'github';
+  const baseOk = isGitHub
+    ? /^#?\d+$/.test(ticketBase) || /^GH-\d+$/i.test(ticketBase)
+    : /^[A-Z]+-\d+$/i.test(ticketBase);
+  if (!baseOk) {
+    const expected = isGitHub ? '#N, N, or GH-N' : 'PROJ-123';
+    throw new Error(
+      `Invalid ticket ID base ${JSON.stringify(ticketBase)} — expected ${expected} format.`
+    );
+  }
+  const canonical = normalizeTicketId(raw);
+  return {
+    ticketBase: String(ticketBase).toUpperCase(),
+    suffix: parsed.suffix || null,
+    separator: parsed.separator || null,
+    canonical,
+  };
+}
+
 function ticketUrl(ticketId, providerConfig) {
   if (!providerConfig || !ticketId) return null;
   const num = String(ticketId).replace(/^#|^GH-/i, '');
@@ -486,6 +553,7 @@ module.exports = {
   sanitizeTicketIdForPath,
   parseTicketInput,
   normalizeTicketId,
+  validateRawTicketInput,
   VALID_PROVIDERS,
   PROVIDERS_FILE,
 };

--- a/scripts/workflows/work/scripts/follow-up-pr.js
+++ b/scripts/workflows/work/scripts/follow-up-pr.js
@@ -106,13 +106,14 @@ const { ghExec } = require('./gh-exec.js');
 
 function getPRInfo(prNumber) {
   const prArg = prNumber ? `${prNumber}` : '';
-  const fields = 'number,title,url,headRefName,mergeable,mergeStateStatus,state';
+  const fields = 'number,title,url,headRefName,baseRefName,mergeable,mergeStateStatus,state';
   const data = ghExec(`pr view ${prArg} --json ${fields}`);
   return {
     number: data.number,
     title: data.title,
     url: data.url,
     branch: data.headRefName,
+    baseBranch: data.baseRefName,
     mergeable: data.mergeable,
     mergeStateStatus: data.mergeStateStatus,
     state: data.state,

--- a/scripts/workflows/work2/__tests__/work-next.test.js
+++ b/scripts/workflows/work2/__tests__/work-next.test.js
@@ -166,4 +166,73 @@ describe('work-next.js CLI', () => {
     assert.equal(parsed.action, 'blocked');
     assert.ok(parsed.reason.includes('No ticket'));
   });
+
+  it('rejects invalid ticket input (whitespace) WITHOUT creating any folder', () => {
+    const { spawnSync } = require('child_process');
+    const fs = require('fs');
+    const os = require('os');
+    const pathMod = require('path');
+    const tmpBase = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'work-next-validate-'));
+    try {
+      const env = {
+        ...process.env,
+        TASKS_BASE: tmpBase,
+        SESSION_GUARD_ENABLED: '0',
+        TICKET_PROVIDER: 'jira',
+        TICKET_PROJECT_KEY: 'ECHO',
+      };
+      delete env.CLAUDE_PLUGIN_ROOT;
+      const res = spawnSync(
+        process.execPath,
+        [pathMod.join(__dirname, '..', 'work-next.js'), 'ECHO-4446 TASKS'],
+        { encoding: 'utf8', timeout: 10000, env }
+      );
+      const stdout = String(res.stdout || '');
+      // Last JSON blob on stdout (skip any non-JSON noise)
+      const lastBrace = stdout.lastIndexOf('{');
+      const parsed = JSON.parse(stdout.slice(lastBrace > -1 ? lastBrace : 0));
+      assert.equal(parsed.action, 'blocked');
+      assert.ok(
+        /whitespace|Invalid|positional/i.test(parsed.reason),
+        `unexpected reason: ${parsed.reason}`
+      );
+      // Critical: no folder must have been created in TASKS_BASE
+      const entries = fs.readdirSync(tmpBase);
+      assert.deepEqual(entries, [], `expected empty TASKS_BASE, found: ${JSON.stringify(entries)}`);
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects multiple positional args WITHOUT creating any folder', () => {
+    const { spawnSync } = require('child_process');
+    const fs = require('fs');
+    const os = require('os');
+    const pathMod = require('path');
+    const tmpBase = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'work-next-validate-'));
+    try {
+      const env = {
+        ...process.env,
+        TASKS_BASE: tmpBase,
+        SESSION_GUARD_ENABLED: '0',
+        TICKET_PROVIDER: 'jira',
+        TICKET_PROJECT_KEY: 'ECHO',
+      };
+      delete env.CLAUDE_PLUGIN_ROOT;
+      const res = spawnSync(
+        process.execPath,
+        [pathMod.join(__dirname, '..', 'work-next.js'), 'ECHO-4446', 'EXTRA-ARG'],
+        { encoding: 'utf8', timeout: 10000, env }
+      );
+      const stdout = String(res.stdout || '');
+      const lastBrace = stdout.lastIndexOf('{');
+      const parsed = JSON.parse(stdout.slice(lastBrace > -1 ? lastBrace : 0));
+      assert.equal(parsed.action, 'blocked');
+      assert.ok(/positional/i.test(parsed.reason), `unexpected reason: ${parsed.reason}`);
+      const entries = fs.readdirSync(tmpBase);
+      assert.deepEqual(entries, []);
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
 });

--- a/scripts/workflows/work2/__tests__/work-next.test.js
+++ b/scripts/workflows/work2/__tests__/work-next.test.js
@@ -235,4 +235,86 @@ describe('work-next.js CLI', () => {
       fs.rmSync(tmpBase, { recursive: true, force: true });
     }
   });
+
+  it('blocks no-suffix input when a suffix-session is already active', () => {
+    const { spawnSync } = require('child_process');
+    const fs = require('fs');
+    const os = require('os');
+    const pathMod = require('path');
+    const tmpBase = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'work-next-conflict-'));
+    try {
+      // Pre-create an active session at tasks/TEST-1234/foo/.work-state.json
+      const sessionDir = pathMod.join(tmpBase, 'TEST-1234', 'foo');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(
+        pathMod.join(sessionDir, '.work-state.json'),
+        JSON.stringify({
+          ticketId: 'TEST-1234/foo',
+          ticketBase: 'TEST-1234',
+          ticketSuffix: 'foo',
+          ticketSeparator: '/',
+          currentStep: 3,
+          status: 'in_progress',
+          stepStatus: {},
+        })
+      );
+      const env = {
+        ...process.env,
+        TASKS_BASE: tmpBase,
+        SESSION_GUARD_ENABLED: '0',
+        TICKET_PROVIDER: 'jira',
+        TICKET_PROJECT_KEY: 'TEST',
+      };
+      delete env.CLAUDE_PLUGIN_ROOT;
+      // User now passes the bare base — should be blocked
+      const res = spawnSync(
+        process.execPath,
+        [pathMod.join(__dirname, '..', 'work-next.js'), 'TEST-1234'],
+        { encoding: 'utf8', timeout: 10000, env }
+      );
+      const stdout = String(res.stdout || '');
+      const lastBrace = stdout.lastIndexOf('{');
+      const parsed = JSON.parse(stdout.slice(lastBrace > -1 ? lastBrace : 0));
+      assert.equal(parsed.action, 'blocked');
+      assert.ok(/active session/i.test(parsed.reason), `unexpected reason: ${parsed.reason}`);
+      assert.ok(/TEST-1234\/foo|TEST-1234-foo/.test(parsed.suggestion || parsed.reason));
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it('persists canonical identity fields on initial state write', () => {
+    const { spawnSync } = require('child_process');
+    const fs = require('fs');
+    const os = require('os');
+    const pathMod = require('path');
+    const tmpBase = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'work-next-canonical-'));
+    try {
+      const env = {
+        ...process.env,
+        TASKS_BASE: tmpBase,
+        SESSION_GUARD_ENABLED: '0',
+        TICKET_PROVIDER: 'jira',
+        TICKET_PROJECT_KEY: 'TEST',
+      };
+      delete env.CLAUDE_PLUGIN_ROOT;
+      spawnSync(
+        process.execPath,
+        [pathMod.join(__dirname, '..', 'work-next.js'), 'TEST-1234-foo'],
+        { encoding: 'utf8', timeout: 10000, env }
+      );
+      // State file should be at tasks/TEST-1234/foo/.work-state.json with canonical fields
+      const statePath = pathMod.join(tmpBase, 'TEST-1234', 'foo', '.work-state.json');
+      if (fs.existsSync(statePath)) {
+        const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+        assert.equal(state.ticketBase, 'TEST-1234');
+        assert.equal(state.ticketSuffix, 'foo');
+        assert.ok(state.ticketSeparator === '/' || state.ticketSeparator === '-');
+      }
+      // Otherwise: no DEFER plan was emitted, which is fine — the test only
+      // asserts the field shape WHEN state is created.
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
 });

--- a/scripts/workflows/work2/hooks/__tests__/protect-orchestrator-state.test.js
+++ b/scripts/workflows/work2/hooks/__tests__/protect-orchestrator-state.test.js
@@ -109,4 +109,27 @@ describe('protect-orchestrator-state hook', () => {
       assert.equal(r.code, 0);
     });
   });
+
+  describe('does NOT deadlock the orchestrator (regression: GH plugin self-bypass)', () => {
+    // Vector 3 used to block the orchestrator from running itself because
+    // work-next.js (a) contains fs.writeFileSync and (b) mentions the literal
+    // ".work-state.json" in its source. We now exempt scripts living inside
+    // the plugin root.
+    const WORK_NEXT = path.resolve(__dirname, '..', '..', 'work-next.js');
+    const TRANSITION = path.resolve(__dirname, '..', '..', 'transition-step.js');
+    const cases = [
+      ['node work-next.js ECHO-4446', `node ${WORK_NEXT} ECHO-4446`],
+      ['node transition-step.js …', `node ${TRANSITION} ECHO-4446 brief`],
+    ];
+    for (const [label, command] of cases) {
+      it(label, () => {
+        const r = runHook({ tool_name: 'Bash', tool_input: { command } });
+        assert.equal(
+          r.code,
+          0,
+          `orchestrator script must not be blocked by its own protector; stderr=${r.stderr.slice(0, 300)}`
+        );
+      });
+    }
+  });
 });

--- a/scripts/workflows/work2/hooks/__tests__/protect-orchestrator-state.test.js
+++ b/scripts/workflows/work2/hooks/__tests__/protect-orchestrator-state.test.js
@@ -90,6 +90,18 @@ describe('protect-orchestrator-state hook', () => {
       ['grep tdd-phase.json', 'grep -r foo /tmp/t/ECHO-1/task1/tdd-phase.json'],
       ['ls .claims', 'ls -la /tmp/t/ECHO-1/.claims/'],
       ['echo without redirect', 'echo "this mentions .work-state.json but does not write"'],
+      // Regression: `2>/dev/null` (stderr to /dev/null) is a fd-number
+      // redirect, NOT a file write. The hook used to treat the `>` as a
+      // shell write op, tokenize the whole command, and block on the
+      // protected-filename mention.
+      [
+        'cat .work-state.json with stderr suppress',
+        'cat /tmp/t/ECHO-1/.work-state.json 2>/dev/null | grep _tdd',
+      ],
+      [
+        'grep tdd-phase.json with stderr suppress',
+        'grep -r foo /tmp/t/ECHO-1/task1/tdd-phase.json 2>/dev/null',
+      ],
     ];
     for (const [label, command] of cases) {
       it(label, () => {

--- a/scripts/workflows/work2/hooks/__tests__/protect-task-scope.test.js
+++ b/scripts/workflows/work2/hooks/__tests__/protect-task-scope.test.js
@@ -50,6 +50,40 @@ describe('extractBashWriteTargets', () => {
     assert.deepEqual(extractBashWriteTargets('cat a.ts'), []);
     assert.deepEqual(extractBashWriteTargets('grep foo a.ts'), []);
   });
+
+  // Regression: arrow functions / shell expressions inside `node -e "..."`
+  // (and similar quoted code) used to leak through and yield bogus tokens
+  // like `d+=c).on('end',()=` that hit decideEdit and blocked legitimate
+  // diagnostic commands. The scope hook now (a) strips quoted strings before
+  // scanning and (b) validates captured tokens look like real paths.
+  describe('regression: no false positives from quoted code / arrows', () => {
+    const cases = [
+      // The exact pattern that blocked the ECHO-4454 diagnostic
+      [`node -e "let d=''; process.stdin.on('data',c=>d+=c).on('end',()=>{console.log(d)})"`],
+      // Generic arrow function in `node -e`
+      [`node -e "const f = x => x + 1; console.log(f(2))"`],
+      // bash -c with > inside a quoted comparator
+      [`bash -c "if [ 5 > 3 ]; then echo yes; fi"`],
+      // grep with > inside a regex argument
+      [`grep -E "foo>bar" file.txt`],
+      // single-quoted python -c with comparators
+      [`python3 -c 'print(1 > 0)'`],
+    ];
+    for (const [cmd] of cases) {
+      it(`emits no targets for: ${cmd.slice(0, 50)}…`, () => {
+        assert.deepEqual(
+          extractBashWriteTargets(cmd),
+          [],
+          `expected no targets for diagnostic command: ${cmd}`
+        );
+      });
+    }
+  });
+
+  it('still extracts real redirect targets adjacent to quoted code', () => {
+    // The redirect is OUTSIDE the quoted block — must still be caught.
+    assert.deepEqual(extractBashWriteTargets(`node -e "console.log('x')" > out.txt`), ['out.txt']);
+  });
 });
 
 describe('evaluateTool', () => {

--- a/scripts/workflows/work2/hooks/protect-orchestrator-state.js
+++ b/scripts/workflows/work2/hooks/protect-orchestrator-state.js
@@ -105,9 +105,17 @@ function formatMessage(match, vector) {
 
 // ─── Hook entrypoint ────────────────────────────────────────────────────────
 
+// Plugin root contains every legitimate writer of the protected basenames
+// (work-next.js, transition-step.js, tdd-phase-state.js, the gate scripts).
+// Declaring it as a trusted script root prevents Vector 3 from blocking the
+// orchestrator from running itself — it would otherwise scan work-next.js,
+// see "fs.writeFileSync" and ".work-state.json" both present, and block.
+const PLUGIN_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+
 const protector = createFileProtector({
   isProtected: isOrchestratorManaged,
   formatMessage,
+  trustedScriptRoots: [PLUGIN_ROOT],
 });
 
 async function main() {

--- a/scripts/workflows/work2/hooks/protect-orchestrator-state.js
+++ b/scripts/workflows/work2/hooks/protect-orchestrator-state.js
@@ -110,7 +110,14 @@ function formatMessage(match, vector) {
 // Declaring it as a trusted script root prevents Vector 3 from blocking the
 // orchestrator from running itself — it would otherwise scan work-next.js,
 // see "fs.writeFileSync" and ".work-state.json" both present, and block.
-const PLUGIN_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+//
+// Use the project's authoritative resolvePluginRoot so we land on
+// `<repo>/scripts/` (the plugin root that contains `workflows/work`), NOT
+// the entire repo root. Three `..` from `scripts/workflows/work2/hooks/`
+// → `scripts/`. Resolver falls back to that exact traversal when no env
+// var is set, but prefers an env-pinned root when one is present.
+const { resolvePluginRoot } = require(path.join(__dirname, '..', 'lib', 'resolve-plugin-root'));
+const PLUGIN_ROOT = resolvePluginRoot(__dirname, 3) || path.resolve(__dirname, '..', '..', '..');
 
 const protector = createFileProtector({
   isProtected: isOrchestratorManaged,

--- a/scripts/workflows/work2/hooks/protect-task-scope.js
+++ b/scripts/workflows/work2/hooks/protect-task-scope.js
@@ -129,14 +129,52 @@ function getActiveTask(tasksDir) {
 const BASH_WRITE_TOKEN =
   /(?:>>?\s*|tee(?:\s+-a)?\s+|\bof=|\bcp\s+\S+\s+|\bmv\s+\S+\s+)([^\s;|&>]+)/g;
 
+/**
+ * Characters that NEVER appear in a real file path but DO appear in shell
+ * expressions, JS arrow functions, comparison operators, etc. If a captured
+ * "token" contains any of these, it is not a filename — it's syntax bleed-
+ * through from quoted code like `node -e "x=>y"` or `bash -c "test a > b"`.
+ *
+ * This prevents the gate from blocking commands whose inline interpreter
+ * code happens to contain `>` (arrow functions, comparators, redirects
+ * inside quoted strings).
+ */
+const NON_PATH_CHAR = /[()=+{}[\]<>$`!*?]/;
+
+function looksLikePath(token) {
+  if (!token) return false;
+  if (NON_PATH_CHAR.test(token)) return false;
+  // Reject pure-numeric tokens (file descriptors after redirects like `2>&1`
+  // get caught here even though `>` is excluded above) and dot/dotdot.
+  if (/^\d+$/.test(token)) return false;
+  if (token === '.' || token === '..') return false;
+  return true;
+}
+
+/**
+ * Strip the body of single- and double-quoted strings before scanning so
+ * shell operators inside `"..."` or `'...'` don't trigger false positives.
+ * This is intentionally approximate (no shell escape handling, no `$(...)`
+ * nesting) — the hook fails open and the protect-state-files protector
+ * still catches real bypass attempts via Vector 2/3/4.
+ */
+function stripQuotedStrings(cmd) {
+  return String(cmd || '')
+    .replace(/'[^']*'/g, "''")
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""');
+}
+
 function extractBashWriteTargets(cmd) {
   if (!cmd || typeof cmd !== 'string') return [];
   const out = new Set();
+  const scanCmd = stripQuotedStrings(cmd);
   BASH_WRITE_TOKEN.lastIndex = 0;
   let m;
-  while ((m = BASH_WRITE_TOKEN.exec(cmd)) !== null) {
+  while ((m = BASH_WRITE_TOKEN.exec(scanCmd)) !== null) {
     const tok = (m[1] || '').replace(/^["']|["']$/g, '');
-    if (tok && !tok.startsWith('-')) out.add(tok);
+    if (!tok || tok.startsWith('-')) continue;
+    if (!looksLikePath(tok)) continue;
+    out.add(tok);
   }
   return Array.from(out);
 }

--- a/scripts/workflows/work2/lib/step-enrichments/__tests__/implement-gate-cwd.test.js
+++ b/scripts/workflows/work2/lib/step-enrichments/__tests__/implement-gate-cwd.test.js
@@ -1,0 +1,93 @@
+/**
+ * Regression: implement-gate must run test commands inside the TICKET's
+ * worktree, not whichever shell cwd the PostToolUse hook fired from.
+ *
+ * Cross-worktree contamination scenario: two shells, two worktrees. Agent
+ * A invokes /work2 ECHO-A from worktreeA. Later, a PostToolUse hook fires
+ * for ECHO-B from worktreeA's shell. If the gate falls back to
+ * process.cwd(), it runs ECHO-B's test command against worktreeA's source
+ * files and writes the (almost always wrong) result into ECHO-B's evidence.
+ *
+ * This test asserts that runPreImplementTest honors its `workingDir`
+ * argument by running a command that records its own pwd.
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { runPreImplementTest, runTestAndRecord } = require('../implement-gate');
+
+describe('implement-gate: test commands honor workingDir (cross-worktree)', () => {
+  it('runPreImplementTest executes test in `workingDir`, not process.cwd()', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-cwd-'));
+    try {
+      const fakeWorktree = path.join(tmpRoot, 'worktree-A');
+      const fakeTasksBase = path.join(tmpRoot, 'tasks');
+      fs.mkdirSync(fakeWorktree, { recursive: true });
+      fs.mkdirSync(fakeTasksBase, { recursive: true });
+
+      // Probe file: the test command writes its $PWD into it. We assert
+      // afterwards that the recorded pwd matches the fakeWorktree (i.e. the
+      // workingDir passed to the gate), proving the gate did NOT fall back
+      // to process.cwd().
+      const probe = path.join(tmpRoot, 'recorded-pwd.txt');
+      // Force exit 1 so the pre-test is treated as an authentic RED (we only
+      // care about WHERE the command runs, not what it returns).
+      const testCmd = `pwd > ${probe}; exit 1`;
+
+      runPreImplementTest(
+        testCmd,
+        'TEST-1234',
+        1,
+        fakeWorktree, // ← workingDir
+        process.env,
+        fakeTasksBase,
+        'implementation'
+      );
+
+      assert.ok(fs.existsSync(probe), 'probe file should have been written');
+      const recorded = fs.readFileSync(probe, 'utf8').trim();
+      // Use realpathSync on both sides — mkdtempSync paths on macOS go
+      // through /var → /private/var symlink.
+      assert.equal(
+        fs.realpathSync(recorded),
+        fs.realpathSync(fakeWorktree),
+        `expected pwd=${fakeWorktree}, got ${recorded}`
+      );
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('runTestAndRecord executes test in `workingDir`, not process.cwd()', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-cwd-'));
+    try {
+      const fakeWorktree = path.join(tmpRoot, 'worktree-B');
+      const fakeTasksBase = path.join(tmpRoot, 'tasks');
+      fs.mkdirSync(fakeWorktree, { recursive: true });
+      fs.mkdirSync(fakeTasksBase, { recursive: true });
+
+      const probe = path.join(tmpRoot, 'recorded-pwd-2.txt');
+      // Force exit 0 so the gate would record GREEN if it had a tasksDir
+      // (which it does). The cwd-recording side effect runs regardless.
+      const testCmd = `pwd > ${probe}; true`;
+
+      runTestAndRecord(testCmd, 'TEST-5678', 1, fakeWorktree, process.env, fakeTasksBase);
+
+      assert.ok(fs.existsSync(probe), 'probe file should have been written');
+      const recorded = fs.readFileSync(probe, 'utf8').trim();
+      assert.equal(
+        fs.realpathSync(recorded),
+        fs.realpathSync(fakeWorktree),
+        `expected pwd=${fakeWorktree}, got ${recorded}`
+      );
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/workflows/work2/lib/step-enrichments/__tests__/implement-gate-logs.test.js
+++ b/scripts/workflows/work2/lib/step-enrichments/__tests__/implement-gate-logs.test.js
@@ -1,0 +1,128 @@
+/**
+ * Regression: implement-gate must persist full test stdout/stderr to a
+ * per-task `logs/<phase>-<timestamp>.log` file (alongside tdd-phase.json),
+ * with a pointer (`logPath`, `logBytes`) recorded in the evidence JSON.
+ *
+ * Today the JSON only carries a 2–4 KB `outputTail`. ECHO-4573 dropped
+ * meaningful test output (Prisma trigger noise alone filled the tail).
+ * Full logs let later steps (review, follow-up) read the complete run.
+ *
+ * Retention is bounded to LOG_RETENTION_COUNT entries per task.
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { runPreImplementTest, runTestAndRecord } = require('../implement-gate');
+
+function readEvidence(gateTasksBase, safe, taskNum) {
+  const p = path.join(gateTasksBase, safe, `task${taskNum}`, 'tdd-phase.json');
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+describe('implement-gate: persist full test logs', () => {
+  it('runPreImplementTest writes red log file and records logPath', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-logs-'));
+    try {
+      const gateTasksBase = path.join(tmp, 'tasks');
+      const safe = 'ECHO-LOGS';
+      const taskNum = 1;
+      const wd = path.join(tmp, 'wd');
+      fs.mkdirSync(wd, { recursive: true });
+
+      // Failing command that emits a recognizable token to stdout.
+      const cmd = "printf 'PRE_TEST_OUTPUT_MARKER\\n' && exit 1";
+      runPreImplementTest(cmd, safe, taskNum, wd, process.env, gateTasksBase, 'feature');
+
+      const ev = readEvidence(gateTasksBase, safe, taskNum);
+      const red = ev.cycles[0].red;
+      assert.equal(red.testExitCode, 1);
+      assert.ok(red.logPath, 'red.logPath should be set');
+      assert.match(red.logPath, /^logs\/red-.*\.log$/);
+      assert.ok(red.logBytes > 0);
+
+      const taskDir = path.dirname(
+        path.join(gateTasksBase, safe, `task${taskNum}`, 'tdd-phase.json')
+      );
+      const fullLog = fs.readFileSync(path.join(taskDir, red.logPath), 'utf8');
+      assert.match(fullLog, /PRE_TEST_OUTPUT_MARKER/);
+      assert.match(fullLog, /# command:/);
+      assert.match(fullLog, /# exitCode: 1/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('runTestAndRecord writes green log file when appending to existing red', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-logs-'));
+    try {
+      const gateTasksBase = path.join(tmp, 'tasks');
+      const safe = 'ECHO-LOGS';
+      const taskNum = 1;
+      const wd = path.join(tmp, 'wd');
+      fs.mkdirSync(wd, { recursive: true });
+      const taskDir = path.join(gateTasksBase, safe, `task${taskNum}`);
+      fs.mkdirSync(taskDir, { recursive: true });
+
+      // Seed an existing RED so runTestAndRecord takes the "append" branch.
+      fs.writeFileSync(
+        path.join(taskDir, 'tdd-phase.json'),
+        JSON.stringify({
+          currentPhase: 'red',
+          currentCycle: 1,
+          cycles: [{ cycle: 1, red: { testCommand: 'x', testExitCode: 1, timestamp: 'x' } }],
+        })
+      );
+
+      const cmd = "printf 'POST_TEST_GREEN_MARKER\\n' && exit 0";
+      const res = runTestAndRecord(cmd, safe, taskNum, wd, process.env, gateTasksBase);
+      assert.equal(res.passed, true);
+
+      const ev = readEvidence(gateTasksBase, safe, taskNum);
+      const green = ev.cycles[0].green;
+      assert.ok(green.logPath, 'green.logPath should be set');
+      assert.match(green.logPath, /^logs\/green-.*\.log$/);
+      assert.ok(green.logBytes > 0);
+
+      const fullLog = fs.readFileSync(path.join(taskDir, green.logPath), 'utf8');
+      assert.match(fullLog, /POST_TEST_GREEN_MARKER/);
+      assert.match(fullLog, /# phase: green/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('log retention prunes older files (keeps ≤ 6)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-logs-'));
+    try {
+      const gateTasksBase = path.join(tmp, 'tasks');
+      const safe = 'ECHO-LOGS';
+      const taskNum = 1;
+      const wd = path.join(tmp, 'wd');
+      fs.mkdirSync(wd, { recursive: true });
+      const taskDir = path.join(gateTasksBase, safe, `task${taskNum}`);
+      fs.mkdirSync(taskDir, { recursive: true });
+
+      // Run 10 failing pre-tests; only ≤6 logs should survive.
+      const cmd = "printf 'X\\n' && exit 1";
+      for (let i = 0; i < 10; i++) {
+        runPreImplementTest(cmd, safe, taskNum, wd, process.env, gateTasksBase, 'feature');
+        // Sleep is forbidden; rely on ISO timestamp millisecond precision
+        // — these 10 calls are fast enough to collide if same ms, but writeFileSync
+        // is sync and Date.now() advances enough on most runs. If they collide,
+        // we just overwrite and the test asserts <=6 which still holds.
+      }
+
+      const logsDir = path.join(taskDir, 'logs');
+      const entries = fs.readdirSync(logsDir).filter((f) => f.endsWith('.log'));
+      assert.ok(entries.length <= 6, `expected ≤6 log files, got ${entries.length}`);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/workflows/work2/lib/step-enrichments/__tests__/implement-gate-reconcile.test.js
+++ b/scripts/workflows/work2/lib/step-enrichments/__tests__/implement-gate-reconcile.test.js
@@ -1,0 +1,144 @@
+/**
+ * Regression: implement-gate must reconcile `tasksMeta` with tasks.md when
+ * the file has fewer tasks than state (mid-workflow tasks_gate repair).
+ *
+ * Real-world failure mode (ECHO-4617): tasks.md was edited 3→2 tasks during
+ * a tasks_gate repair, but `.work-state.json` kept `task_3: pending`. The
+ * implement-gate then looped asking for TDD evidence of a task that no
+ * longer existed. The gate now truncates pending tail entries when tasks.md
+ * has fewer tasks AND every dropped entry is still pending.
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { dispatchAdvanceGate } = require('../implement-gate');
+
+function mkTasksMd(tasksDir, count) {
+  fs.mkdirSync(tasksDir, { recursive: true });
+  const sections = [];
+  for (let i = 1; i <= count; i++) {
+    sections.push(
+      `## Task ${i} — Sample task ${i}\n\n### Type\nfeature\n\n### Description\nWork item ${i}.\n`
+    );
+  }
+  fs.writeFileSync(path.join(tasksDir, 'tasks.md'), sections.join('\n---\n\n'));
+}
+
+function makeDeps(initialState, capturedSaves) {
+  return {
+    loadWorkState: () => initialState,
+    saveWorkState: (_safe, ws) => {
+      capturedSaves.push(JSON.parse(JSON.stringify(ws)));
+    },
+    readTddEvidence: () => null,
+    validateTddEvidence: () => ({ valid: false, reason: 'no evidence' }),
+    stepName: 'implement',
+    workDir: '/tmp',
+    log: () => {},
+    recursionDepth: 0,
+  };
+}
+
+describe('implement-gate: reconcile tasksMeta with tasks.md', () => {
+  it('drops a pending tail task when tasks.md shrinks 3 → 2', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-reconcile-'));
+    try {
+      const tasksDir = path.join(tmp, 'ECHO-TEST');
+      mkTasksMd(tasksDir, 2); // file has 2 tasks now
+
+      const state = {
+        ticketId: 'ECHO-TEST',
+        tasksMeta: {
+          totalTasks: 3,
+          currentTaskIndex: 2,
+          tasks: [
+            { id: 'task_1', status: 'completed' },
+            { id: 'task_2', status: 'completed' },
+            { id: 'task_3', status: 'pending' },
+          ],
+        },
+        _tddRetryTask: 3,
+        _tddRetryReason: 'stale',
+        _tddRetryCount: 1,
+      };
+      const saves = [];
+      dispatchAdvanceGate('ECHO-TEST', { tasksDir }, makeDeps(state, saves));
+
+      assert.equal(saves.length >= 1, true, 'state should be persisted after reconcile');
+      const final = saves[0];
+      assert.equal(final.tasksMeta.tasks.length, 2);
+      assert.equal(final.tasksMeta.totalTasks, 2);
+      assert.equal(final._tddRetryTask, undefined);
+      assert.equal(final._tddRetryReason, undefined);
+      assert.equal(final._tddRetryCount, undefined);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to drop a completed tail entry (preserves done work)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-reconcile-'));
+    try {
+      const tasksDir = path.join(tmp, 'ECHO-TEST');
+      mkTasksMd(tasksDir, 1); // file has 1 task
+
+      const state = {
+        ticketId: 'ECHO-TEST',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 1,
+          tasks: [
+            { id: 'task_1', status: 'completed' },
+            { id: 'task_2', status: 'completed' }, // already done — must not be silently dropped
+          ],
+        },
+      };
+      const saves = [];
+      dispatchAdvanceGate('ECHO-TEST', { tasksDir }, makeDeps(state, saves));
+
+      // No reconcile save expected because tail entry was completed.
+      // (Other unrelated saves from the rest of dispatchAdvanceGate may
+      // still happen; what matters is tasks.length never shrinks.)
+      for (const s of saves) {
+        assert.equal(s.tasksMeta.tasks.length, 2, 'completed tail must not be dropped');
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('no-op when tasks.md and state agree', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-reconcile-'));
+    try {
+      const tasksDir = path.join(tmp, 'ECHO-TEST');
+      mkTasksMd(tasksDir, 2);
+
+      const state = {
+        ticketId: 'ECHO-TEST',
+        tasksMeta: {
+          totalTasks: 2,
+          currentTaskIndex: 2,
+          tasks: [
+            { id: 'task_1', status: 'completed' },
+            { id: 'task_2', status: 'completed' },
+          ],
+        },
+      };
+      const saves = [];
+      dispatchAdvanceGate('ECHO-TEST', { tasksDir }, makeDeps(state, saves));
+
+      for (const s of saves) {
+        assert.equal(s.tasksMeta.tasks.length, 2);
+        assert.equal(s.tasksMeta.totalTasks, 2);
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -158,7 +158,10 @@ function writeTestLog(taskDir, phase, cmd, exitCode, output, nowIso) {
       /* fail-open */
     }
 
-    return { logPath: path.join('logs', filename), logBytes: Buffer.byteLength(body) };
+    return {
+      logPath: path.join('logs', filename),
+      logBytes: Buffer.byteLength(header) + Buffer.byteLength(body),
+    };
   } catch {
     return null;
   }

--- a/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -74,8 +74,11 @@ function reconcileTasksMetaWithFile(ws, tasksDir, saveWorkState, safeName, log) 
     delete ws._tddRetryOutputTail;
     delete ws._tddRetryTask;
   }
-  if (typeof ws._preTestForTask === 'number' && ws._preTestForTask > fileCount) {
-    delete ws._preTestForTask;
+  if (ws._preTestForTask !== undefined && ws._preTestForTask !== null) {
+    const preTestNum = Number(ws._preTestForTask);
+    if (Number.isFinite(preTestNum) && preTestNum > fileCount) {
+      delete ws._preTestForTask;
+    }
   }
 
   try {

--- a/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -96,6 +96,72 @@ function reconcileTasksMetaWithFile(ws, tasksDir, saveWorkState, safeName, log) 
 }
 
 /**
+ * Persist the full stdout+stderr of a test run alongside its tdd-phase.json.
+ *
+ * Writes `task<N>/logs/<phase>-<timestamp>.log` with a small header (command,
+ * exit code, timestamp) so the file is self-describing if opened directly.
+ * The JSON evidence only carries `outputTail` (small slice) plus a pointer
+ * to this file via `logPath` / `logBytes`, keeping tdd-phase.json compact.
+ *
+ * Retention: keep at most LOG_RETENTION_COUNT files per `logs/` dir. Older
+ * files are deleted on each write — bounded growth even on long retry loops.
+ *
+ * Fail-open: any IO error returns null and the caller proceeds with only
+ * the in-JSON outputTail, matching the rest of this module's policy.
+ *
+ * @param {string} taskDir - Absolute path to `tasks/<TICKET>/task<N>/`
+ * @param {string} phase - 'red' | 'green'
+ * @param {string} cmd - The test command that ran
+ * @param {number|null} exitCode
+ * @param {string} output - Combined stdout+stderr
+ * @param {string} nowIso - ISO timestamp matching evidence timestamp
+ * @returns {{ logPath: string, logBytes: number } | null}
+ *   logPath is relative to taskDir, e.g. `logs/red-2026-05-14T11-22-33-000Z.log`
+ */
+const LOG_RETENTION_COUNT = 6;
+function writeTestLog(taskDir, phase, cmd, exitCode, output, nowIso) {
+  try {
+    if (!taskDir || !phase || output == null) return null;
+    const logsDir = path.join(taskDir, 'logs');
+    fs.mkdirSync(logsDir, { recursive: true });
+    // Filename-safe timestamp (colons break on Windows).
+    const stamp = String(nowIso).replace(/[:.]/g, '-');
+    const filename = `${phase}-${stamp}.log`;
+    const fullPath = path.join(logsDir, filename);
+    const header =
+      `# command: ${cmd}\n` +
+      `# exitCode: ${exitCode == null ? 'null' : exitCode}\n` +
+      `# timestamp: ${nowIso}\n` +
+      `# phase: ${phase}\n` +
+      `${'-'.repeat(72)}\n`;
+    const body = String(output);
+    fs.writeFileSync(fullPath, header + body);
+
+    // Prune oldest entries (by lexicographic name; ISO stamps sort correctly).
+    try {
+      const entries = fs
+        .readdirSync(logsDir)
+        .filter((f) => f.endsWith('.log'))
+        .sort();
+      const excess = entries.length - LOG_RETENTION_COUNT;
+      for (let i = 0; i < excess; i++) {
+        try {
+          fs.unlinkSync(path.join(logsDir, entries[i]));
+        } catch {
+          /* fail-open */
+        }
+      }
+    } catch {
+      /* fail-open */
+    }
+
+    return { logPath: path.join('logs', filename), logBytes: Buffer.byteLength(body) };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Read the `### Test Command` for a specific task from tasks.md.
  *
  * @param {string} tasksDir
@@ -383,6 +449,7 @@ function runPreImplementTest(cmd, safeName, taskNum, workingDir, env, gateTasksB
 
   // Pre-test FAILED — authentic RED. Phase is 'red' until the post-implement
   // test passes and runTestAndRecord transitions it to 'green'.
+  const redLog = writeTestLog(taskDir, 'red', cmd, exitCode, output, now);
   try {
     fs.mkdirSync(taskDir, { recursive: true });
     fs.writeFileSync(
@@ -401,6 +468,7 @@ function runPreImplementTest(cmd, safeName, taskNum, workingDir, env, gateTasksB
                 timestamp: now,
                 capturedByGate: true,
                 outputTail: String(output).slice(-2000),
+                ...(redLog ? { logPath: redLog.logPath, logBytes: redLog.logBytes } : {}),
               },
             },
           ],
@@ -475,6 +543,7 @@ function runTestAndRecord(cmd, safeName, taskNum, workingDir, env, gateTasksBase
     /* no pre-existing evidence */
   }
 
+  const greenLog = writeTestLog(taskDir, 'green', cmd, 0, output, now);
   let evidence;
   if (existing && Array.isArray(existing.cycles) && existing.cycles[0]?.red) {
     evidence = {
@@ -489,6 +558,8 @@ function runTestAndRecord(cmd, safeName, taskNum, workingDir, env, gateTasksBase
                 testExitCode: 0,
                 timestamp: now,
                 capturedByGate: true,
+                outputTail: String(output).slice(-2000),
+                ...(greenLog ? { logPath: greenLog.logPath, logBytes: greenLog.logBytes } : {}),
               },
             }
           : c

--- a/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -22,6 +22,78 @@ const { execFileSync, execSync } = require('child_process');
 const { markProgress } = require(path.join(__dirname, '..', 'mark-task-progress'));
 
 const { resolveTaskType } = require(path.join(__dirname, '..', 'resolve-task-type'));
+const { parseTasks } = require(path.join(__dirname, '..', 'task-graph'));
+
+/**
+ * Reconcile `ws.tasksMeta` against the current tasks.md.
+ *
+ * When tasks.md is edited mid-workflow (e.g. tasks_gate repair drops a task),
+ * `tasksMeta.tasks` keeps the stale entries and the gate then demands TDD
+ * evidence for a task that no longer exists. Truncate the tail to match the
+ * file when — AND ONLY WHEN — all dropped entries are still pending (never
+ * silently drop completed work).
+ *
+ * Returns true when state was mutated and saved.
+ */
+function reconcileTasksMetaWithFile(ws, tasksDir, saveWorkState, safeName, log) {
+  if (!tasksDir) return false;
+  if (!ws?.tasksMeta || !Array.isArray(ws.tasksMeta.tasks)) return false;
+
+  let parsed;
+  try {
+    parsed = parseTasks(tasksDir);
+  } catch {
+    return false;
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) return false;
+
+  const fileCount = parsed.length;
+  const stateCount = ws.tasksMeta.tasks.length;
+  if (fileCount >= stateCount) return false;
+
+  // Only truncate when EVERY tail entry past fileCount is non-completed.
+  // Dropping completed entries would lose evidence of done work.
+  const tail = ws.tasksMeta.tasks.slice(fileCount);
+  const allTailPending = tail.every((t) => t && t.status !== 'completed');
+  if (!allTailPending) return false;
+
+  ws.tasksMeta.tasks = ws.tasksMeta.tasks.slice(0, fileCount);
+  if (typeof ws.tasksMeta.totalTasks === 'number') {
+    ws.tasksMeta.totalTasks = fileCount;
+  }
+  if ((ws.tasksMeta.currentTaskIndex ?? 0) > fileCount) {
+    ws.tasksMeta.currentTaskIndex = fileCount;
+  }
+
+  // Clear stale retry state that pointed at a now-missing task.
+  if (typeof ws._tddRetryTask === 'number' && ws._tddRetryTask > fileCount) {
+    delete ws._tddRetryReason;
+    delete ws._tddRetryCount;
+    delete ws._tddRetryCommand;
+    delete ws._tddRetryExitCode;
+    delete ws._tddRetryOutputTail;
+    delete ws._tddRetryTask;
+  }
+  if (typeof ws._preTestForTask === 'number' && ws._preTestForTask > fileCount) {
+    delete ws._preTestForTask;
+  }
+
+  try {
+    saveWorkState(safeName, ws);
+  } catch {
+    return false;
+  }
+  if (typeof log === 'function') {
+    try {
+      log(
+        `tasksMeta reconciled with tasks.md: ${stateCount} → ${fileCount} (dropped ${stateCount - fileCount} pending tail entr${stateCount - fileCount === 1 ? 'y' : 'ies'})`
+      );
+    } catch {
+      /* fail-open */
+    }
+  }
+  return true;
+}
 
 /**
  * Read the `### Test Command` for a specific task from tasks.md.
@@ -486,6 +558,12 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
   if (!ws?.tasksMeta || !Array.isArray(ws.tasksMeta.tasks)) {
     return null;
   }
+
+  // Reconcile tasksMeta with tasks.md before reading currentIdx/totalTasks.
+  // Mid-workflow tasks.md edits (e.g. tasks_gate repair shrinks the task list)
+  // would otherwise leave stale pending entries and the gate would loop asking
+  // for TDD evidence of a task that no longer exists in tasks.md.
+  reconcileTasksMetaWithFile(ws, ctx && ctx.tasksDir, saveWorkState, safeName, log);
 
   const currentIdx = ws.tasksMeta.currentTaskIndex ?? 0;
   const totalTasks = ws.tasksMeta.tasks.length;

--- a/scripts/workflows/work2/work-next.js
+++ b/scripts/workflows/work2/work-next.js
@@ -557,10 +557,16 @@ function getNextInstruction(ticketRaw, rework) {
           // on verify functions (e.g., isPRGateReady calls checkCI which blocks).
           // Gates like follow-up-gate and check-gate read sub-orchestrator state
           // and advance directly when their sub-workflow completed.
+          // Compute the canonical worktree dir for this ticket so the gate's
+          // test commands run inside the ticket's worktree — NOT whichever
+          // shell cwd the PostToolUse hook happened to fire from. Cross-shell
+          // invocations (one shell per worktree) used to leak: the gate would
+          // run tests from worktree A but write evidence into ticket B.
+          const worktreeDir = path.join(WORKTREES_BASE, `${MAIN_WORKTREE_FOLDER}-${safeBase}`);
           const preGateResult = runGate(
             entry.step,
             safeName,
-            { ticket, stateCtx, tasksDir },
+            { ticket, stateCtx, tasksDir, worktreeDir },
             {
               loadWorkState,
               saveWorkState,

--- a/scripts/workflows/work2/work-next.js
+++ b/scripts/workflows/work2/work-next.js
@@ -218,6 +218,66 @@ function transitionStep(ticket, targetStep) {
   return _transitionStep(ticket, targetStep, buildTransitionDeps());
 }
 
+// ─── Active-session conflict detection ──────────────────────────────────────
+
+/**
+ * Detect whether the user-supplied ticket canonical conflicts with an existing
+ * active session. Returns null on no conflict, or { canonical, reason } when
+ * the caller should be blocked.
+ *
+ * Rules:
+ *   - Input has suffix, no-suffix sibling state exists at tasks/<base>/.work-state.json → conflict
+ *   - Input has no suffix, but a suffix-session exists at tasks/<base>/<suffix>/.work-state.json → conflict
+ *   - Exact-match state (or no state at all) → no conflict
+ */
+function detectSessionConflict(validated, tasksBase, tp) {
+  const fsLocal = require('fs');
+  const pathLocal = require('path');
+  const safeBase = tp.sanitizeTicketIdForPath(
+    validated.ticketBase,
+    tp.getProviderConfig({ skipPrompt: true })
+  );
+  const suffix = validated.suffix;
+  const exactPath = pathLocal.join(
+    tasksBase,
+    suffix ? `${safeBase}/${suffix}` : safeBase,
+    '.work-state.json'
+  );
+  if (fsLocal.existsSync(exactPath)) return null; // exact match — proceed
+  if (suffix) {
+    // Input has suffix; check for a bare-base session
+    const baseStatePath = pathLocal.join(tasksBase, safeBase, '.work-state.json');
+    if (fsLocal.existsSync(baseStatePath)) {
+      return {
+        canonical: safeBase,
+        reason: `An active session exists for ${safeBase} (no suffix). Re-invoke with that exact canonical, or finish/abort it first.`,
+      };
+    }
+  } else {
+    // Input has no suffix; check for any suffix-session under tasks/<base>/
+    const baseDir = pathLocal.join(tasksBase, safeBase);
+    if (fsLocal.existsSync(baseDir)) {
+      let entries;
+      try {
+        entries = fsLocal.readdirSync(baseDir, { withFileTypes: true });
+      } catch {
+        entries = [];
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const stateFile = pathLocal.join(baseDir, entry.name, '.work-state.json');
+        if (fsLocal.existsSync(stateFile)) {
+          return {
+            canonical: `${safeBase}-${entry.name}`,
+            reason: `An active session exists for ${safeBase}/${entry.name}. Re-invoke with: ${safeBase}-${entry.name}`,
+          };
+        }
+      }
+    }
+  }
+  return null;
+}
+
 // ─── Core Orchestration Loop ────────────────────────────────────────────────
 // IMPORTANT: This file is the generic orchestrator. NO step-specific logic here.
 // Step-specific behavior (prompts, gates, delegation overrides) belongs in
@@ -327,18 +387,30 @@ function getNextInstruction(ticketRaw, rework) {
     }
   }
 
-  // Persist DEFER metadata
+  // Persist DEFER metadata. Also persist the canonical ticket identity
+  // (ticketBase / ticketSuffix / ticketSeparator) so future invocations can
+  // verify they're addressing the same session even if the user passes a
+  // shortened or different variant.
   result.timestamp = new Date().toISOString();
   const planState = loadWorkState(safeName);
   if (planState) {
     planState.lastPlanTimestamp = result.timestamp;
     planState.deferredSteps = result.plan.filter((s) => s.action === 'DEFER').map((s) => s.step);
+    // Backfill canonical identity on existing state from pre-this-fix sessions
+    if (planState.ticketBase === undefined) planState.ticketBase = safeBase;
+    if (planState.ticketSuffix === undefined) planState.ticketSuffix = suffix || null;
+    if (planState.ticketSeparator === undefined) {
+      planState.ticketSeparator = suffix ? '/' : null;
+    }
     saveWorkState(safeName, planState);
   } else {
     const deferSteps = result.plan.filter((s) => s.action === 'DEFER').map((s) => s.step);
     if (deferSteps.length > 0) {
       const minimalState = {
         ticketId: safeName,
+        ticketBase: safeBase,
+        ticketSuffix: suffix || null,
+        ticketSeparator: suffix ? '/' : null,
         description: '',
         currentStep: 1,
         status: 'in_progress',
@@ -631,9 +703,10 @@ function main() {
   // Validate BEFORE writeMarkerFile (which creates a tasks/<id>/ folder).
   // We re-validate inside getNextInstruction too, but the marker write happens
   // first under --init, so we must gate it here as well.
+  let validated;
   try {
     const earlyProviderConfig = tp.getProviderConfig({ skipPrompt: true });
-    validateRawTicketInput(ticketRaw, earlyProviderConfig);
+    validated = validateRawTicketInput(ticketRaw, earlyProviderConfig);
   } catch (err) {
     console.log(
       JSON.stringify(
@@ -649,6 +722,28 @@ function main() {
       )
     );
     process.exit(1);
+  }
+
+  // Active-session conflict check: once a session is bootstrapped, future
+  // invocations MUST use the same canonical ID. Pass `APP-1234` when an active
+  // session uses `APP-1234-foo` (or vice versa) → block.
+  {
+    const conflict = detectSessionConflict(validated, TASKS_BASE, tp);
+    if (conflict) {
+      console.log(
+        JSON.stringify(
+          {
+            type: 'work_instruction',
+            action: 'blocked',
+            reason: conflict.reason,
+            suggestion: `Re-invoke with: ${conflict.canonical}`,
+          },
+          null,
+          2
+        )
+      );
+      process.exit(1);
+    }
   }
 
   // On --init, write marker file for auto-advance hook detection

--- a/scripts/workflows/work2/work-next.js
+++ b/scripts/workflows/work2/work-next.js
@@ -233,10 +233,21 @@ function transitionStep(ticket, targetStep) {
 function detectSessionConflict(validated, tasksBase, tp) {
   const fsLocal = require('fs');
   const pathLocal = require('path');
-  const safeBase = tp.sanitizeTicketIdForPath(
-    validated.ticketBase,
-    tp.getProviderConfig({ skipPrompt: true })
-  );
+  const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+  const isGitHub = providerConfig?.provider === 'github';
+  // Normalize ticketBase the same way getNextInstruction does, so the
+  // filesystem path we probe matches the one used by state writers.
+  // For GitHub, `GH-56` / `56` / `#56` all canonicalize to `#56` before
+  // sanitization → `sanitizeTicketIdForPath('#56', ...)` (e.g. `GH-56`).
+  let normalizedBase = validated.ticketBase.toUpperCase();
+  if (
+    isGitHub &&
+    (/^#?\d+$/.test(validated.ticketBase) || /^GH-\d+$/i.test(validated.ticketBase))
+  ) {
+    const num = validated.ticketBase.replace(/^#|^GH-/i, '');
+    normalizedBase = '#' + num;
+  }
+  const safeBase = tp.sanitizeTicketIdForPath(normalizedBase, providerConfig);
   const suffix = validated.suffix;
   const exactPath = pathLocal.join(
     tasksBase,

--- a/scripts/workflows/work2/work-next.js
+++ b/scripts/workflows/work2/work-next.js
@@ -97,7 +97,7 @@ const { STEPS, STEP_TRANSITIONS, ALL_STEPS, workflowCanTransition } = require(
 const { run, fileExists, readFile, listFiles, ...helpers } = require(
   path.join(workDir, 'work-helpers')
 );
-const { parseTicketInput } = require(path.join(libDir, 'ticket-provider'));
+const { parseTicketInput, validateRawTicketInput } = require(path.join(libDir, 'ticket-provider'));
 const { parseTasks, buildTaskPrompt } = require(path.join(workDir, 'task-parser'));
 const { archiveStepArtifacts } = require(path.join(workDir, 'artifact-archival'));
 const { getHeadSha } = require(path.join(workDir, 'git-utils'));
@@ -244,12 +244,15 @@ function getNextInstruction(ticketRaw, rework) {
   }
   _recursionDepth++;
 
-  // Parse ticket input
+  // Parse + STRICT validate ticket input BEFORE any filesystem side effect.
+  // This rejects malformed input like "ECHO-4446 TASKS" (whitespace), traversal,
+  // or non-canonical bases — preventing creation of bogus tasks/ subfolders.
+  const providerConfigEarly = tp.getProviderConfig({ skipPrompt: true });
   let ticketBase, suffix;
   try {
-    const parsed = parseTicketInput(ticketRaw);
-    ticketBase = parsed.ticketBase;
-    suffix = parsed.suffix;
+    const validated = validateRawTicketInput(ticketRaw, providerConfigEarly);
+    ticketBase = validated.ticketBase;
+    suffix = validated.suffix;
   } catch (err) {
     return {
       type: 'work_instruction',
@@ -262,11 +265,12 @@ function getNextInstruction(ticketRaw, rework) {
         remainingSteps: [],
       },
       reason: err.message,
-      suggestion: 'Check ticket ID format',
+      suggestion:
+        'Pass a canonical ticket ID like PROJ-123 (or PROJ-123-suffix). No spaces or path separators.',
     };
   }
 
-  const providerConfig = tp.getProviderConfig({ skipPrompt: true });
+  const providerConfig = providerConfigEarly;
   const isGitHub = providerConfig?.provider === 'github';
 
   // Normalize ticket
@@ -603,10 +607,49 @@ function main() {
 
   const rework = args.includes('--rework');
   const init = args.includes('--init');
-  const ticketRaw = args
-    .filter((a) => !a.startsWith('--'))
-    .join(' ')
-    .trim();
+  // Take only the FIRST positional arg as the ticket. Multiple positionals
+  // (e.g. "ECHO-4446 TASKS ECHO-4446") are an error — they would otherwise be
+  // silently joined into "ECHO-4446 TASKS ECHO-4446" and create a bogus folder.
+  const positionals = args.filter((a) => !a.startsWith('--'));
+  const ticketRaw = (positionals[0] || '').trim();
+  if (positionals.length > 1) {
+    console.log(
+      JSON.stringify(
+        {
+          type: 'work_instruction',
+          action: 'blocked',
+          reason: `Multiple positional arguments received: ${JSON.stringify(positionals)}. Pass exactly ONE ticket ID.`,
+          suggestion: 'Quote suffixes: use APP-1234-foo (one arg), not APP-1234 foo (two args).',
+        },
+        null,
+        2
+      )
+    );
+    process.exit(1);
+  }
+
+  // Validate BEFORE writeMarkerFile (which creates a tasks/<id>/ folder).
+  // We re-validate inside getNextInstruction too, but the marker write happens
+  // first under --init, so we must gate it here as well.
+  try {
+    const earlyProviderConfig = tp.getProviderConfig({ skipPrompt: true });
+    validateRawTicketInput(ticketRaw, earlyProviderConfig);
+  } catch (err) {
+    console.log(
+      JSON.stringify(
+        {
+          type: 'work_instruction',
+          action: 'blocked',
+          reason: err.message,
+          suggestion:
+            'Pass a canonical ticket ID like PROJ-123 (or PROJ-123-suffix). No spaces or path separators.',
+        },
+        null,
+        2
+      )
+    );
+    process.exit(1);
+  }
 
   // On --init, write marker file for auto-advance hook detection
   if (init) {

--- a/scripts/workflows/work2/work-next.js
+++ b/scripts/workflows/work2/work-next.js
@@ -278,9 +278,24 @@ function detectSessionConflict(validated, tasksBase, tp) {
         if (!entry.isDirectory()) continue;
         const stateFile = pathLocal.join(baseDir, entry.name, '.work-state.json');
         if (fsLocal.existsSync(stateFile)) {
+          // Read the existing session's recorded separator (if any) so the
+          // `canonical` and `reason` fields are mutually consistent —
+          // matching the form the session was originally created with.
+          // Falls back to `-` (default re-invocation form).
+          let existingSeparator = '-';
+          try {
+            const raw = fsLocal.readFileSync(stateFile, 'utf8');
+            const parsed = JSON.parse(raw);
+            if (parsed && (parsed.ticketSeparator === '-' || parsed.ticketSeparator === '/')) {
+              existingSeparator = parsed.ticketSeparator;
+            }
+          } catch {
+            // ignore — fall back to '-'
+          }
+          const canonical = `${safeBase}${existingSeparator}${entry.name}`;
           return {
-            canonical: `${safeBase}-${entry.name}`,
-            reason: `An active session exists for ${safeBase}/${entry.name}. Re-invoke with: ${safeBase}-${entry.name}`,
+            canonical,
+            reason: `An active session exists for ${canonical}. Re-invoke with: ${canonical}`,
           };
         }
       }

--- a/scripts/workflows/work2/work-next.js
+++ b/scripts/workflows/work2/work-next.js
@@ -308,11 +308,12 @@ function getNextInstruction(ticketRaw, rework) {
   // This rejects malformed input like "ECHO-4446 TASKS" (whitespace), traversal,
   // or non-canonical bases — preventing creation of bogus tasks/ subfolders.
   const providerConfigEarly = tp.getProviderConfig({ skipPrompt: true });
-  let ticketBase, suffix;
+  let ticketBase, suffix, separator;
   try {
     const validated = validateRawTicketInput(ticketRaw, providerConfigEarly);
     ticketBase = validated.ticketBase;
     suffix = validated.suffix;
+    separator = validated.separator || null;
   } catch (err) {
     return {
       type: 'work_instruction',
@@ -400,7 +401,10 @@ function getNextInstruction(ticketRaw, rework) {
     if (planState.ticketBase === undefined) planState.ticketBase = safeBase;
     if (planState.ticketSuffix === undefined) planState.ticketSuffix = suffix || null;
     if (planState.ticketSeparator === undefined) {
-      planState.ticketSeparator = suffix ? '/' : null;
+      // Use the separator the user actually typed (validateRawTicketInput
+      // returns '-', '/', or null). Falling back to '/' only when a suffix
+      // exists but the parser didn't report a separator — defensive only.
+      planState.ticketSeparator = suffix ? separator || '/' : null;
     }
     saveWorkState(safeName, planState);
   } else {
@@ -410,7 +414,7 @@ function getNextInstruction(ticketRaw, rework) {
         ticketId: safeName,
         ticketBase: safeBase,
         ticketSuffix: suffix || null,
-        ticketSeparator: suffix ? '/' : null,
+        ticketSeparator: suffix ? separator || '/' : null,
         description: '',
         currentStep: 1,
         status: 'in_progress',

--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -100,6 +100,16 @@ Every task must be testable in isolation. If you can't write a test for it, it's
 **Rule 4 — No Overlap:**
 No two tasks should deliver the same code or satisfy the same requirement. If a requirement needs work across multiple tasks, split the requirement's concerns explicitly so each task owns a distinct piece.
 
+**Rule 4b — Every task MUST have a testable surface of its own:**
+A task ships code OR tests that can be verified by THIS task's `### Test Command`, against ONLY files in THIS task's `### Files in scope`. Forbidden patterns (every one of these is a `split-in-tasks` authoring bug — merge with the consumer):
+
+- **Helper-only task:** ships a pure helper or seed used solely by another task's test. There is no test for this helper in isolation. Merge it INTO the consuming task and list both the helper and its consumer's tests in that task's Files in scope.
+- **Schema-narrowing-without-consumer task:** narrows a type/schema that another task's integration test depends on. The narrowing has no behavior change observable in isolation — merge it INTO the task whose test would otherwise fail without the narrowing.
+- **"Run the dependent task's test" task:** a task whose Test Command points at a test file owned by another task. This is the ECHO-4637-class deadlock — caught by the tasks_gate validator.
+- **"Run typecheck only" task:** Test Command is `pnpm typecheck` or any other compile-check that doesn't exercise behavior. Typecheck is not a behavior gate; if your task has no behavior to verify, merge it.
+
+If you cannot write a unit or properly-scoped integration test for the task in isolation, the task should NOT exist as a separate task — merge it with its consumer.
+
 **Rule 5 — Logical Ordering:**
 Tasks are ordered by dependency. Foundational/infrastructure tasks first, then core logic, then integration/UI, then validation/checkpoints.
 

--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -297,6 +297,21 @@ Hardcoded `pnpm test:foo path/to/file` is **only** allowed if a project explicit
 
 Note: The implement-gate executes this command automatically before/after dispatching the developer agent. Agents do NOT call `tdd-phase-state.js` or record any TDD evidence themselves.
 
+**Test scope must equal task scope** (CRITICAL — prevents cross-task gate deadlocks):
+
+A task's Test Command may ONLY exercise code declared in this task's `### Files in scope`. If the test passes through a network boundary (tRPC procedure, REST handler, GraphQL resolver), it ALSO traverses the input/output validators, middleware, and routing for that boundary — and those are owned by OTHER tasks. The gate then can't pass until every co-traversed task is also done, but each of those tasks is gated by its own test that needs THIS task done. Deadlock.
+
+Symptoms when this is violated (don't ship a tasks.md with these):
+- Task A's test executes a tRPC procedure but Task A only ships the inner helper — the procedure's output schema lives in Task B.
+- Task A's Files in scope is one file, but its Test Command's CHANGED_FILES list spans 3 directories.
+- A Zod / type error fires in the test that names a symbol declared by Task B.
+
+Rules:
+1. **Default to unit tests** for per-task gates. A task that ships `lib/foo/helper.ts` should test the helper directly: `CHANGED_FILES="lib/foo/__tests__/helper.test.ts" eval "$TEST_UNIT_COMMAND"`. Do NOT test it through a procedure / handler / resolver unless that procedure is also in this task's Files in scope.
+2. **Use integration tests only when the task owns the entire boundary** — handler + validator + helper all listed under this task's Files in scope. Otherwise the integration test couples this task to its siblings.
+3. **Reserve cross-cutting integration tests for the final `checkpoint` task** — that task's scope is "verify the whole feature works end-to-end" and explicitly depends on every prior task.
+4. **Audit every Test Command before emitting tasks.md**: for each task, walk the file list in CHANGED_FILES and confirm every file appears under this task's Files in scope. If any file is owned by a different task, switch to a narrower unit test or expand the scope.
+
 ### Suggested Scope (optional — include when file paths are inferable from the spec)
 - `<path/to/likely/file.ts>`
 - `<path/to/another/file.ts>`

--- a/skills/split-in-tasks/SKILL.md
+++ b/skills/split-in-tasks/SKILL.md
@@ -297,6 +297,16 @@ Hardcoded `pnpm test:foo path/to/file` is **only** allowed if a project explicit
 
 Note: The implement-gate executes this command automatically before/after dispatching the developer agent. Agents do NOT call `tdd-phase-state.js` or record any TDD evidence themselves.
 
+**Test-file naming MUST match the chosen runner** (CRITICAL — the tasks_gate validator enforces this):
+
+| Runner env var | File name pattern (ANY ONE must match) |
+|---|---|
+| `$TEST_INTEGRATION_COMMAND` | `**/*.integration.(test\|spec).(ts\|tsx\|js\|jsx\|mjs\|cjs)` OR `**/integration/**/*.(test\|spec).<ext>` |
+| `$TEST_E2E_COMMAND` | `**/*.e2e.(test\|spec).(ts\|tsx\|js\|jsx\|mjs\|cjs)` OR `**/e2e/**/*.(test\|spec).<ext>` |
+| `$TEST_UNIT_COMMAND` | Must NOT match either of the above patterns (no `.integration.` / `.e2e.` infix, not under `/integration/` or `/e2e/`) |
+
+If a test file is misnamed for its runner, the vitest config silently routes it to a different runner (or skips it). The gate then can't pass because the test never executes — or it executes against the wrong fixtures. When creating a NEW test file, also name it correctly upfront and include the proposed filename in the task's `### Files in scope`.
+
 **Test scope must equal task scope** (CRITICAL — prevents cross-task gate deadlocks):
 
 A task's Test Command may ONLY exercise code declared in this task's `### Files in scope`. If the test passes through a network boundary (tRPC procedure, REST handler, GraphQL resolver), it ALSO traverses the input/output validators, middleware, and routing for that boundary — and those are owned by OTHER tasks. The gate then can't pass until every co-traversed task is also done, but each of those tasks is gated by its own test that needs THIS task done. Deadlock.


### PR DESCRIPTION
## Existing Behavior

- `protect-orchestrator-state.js` Vector 3 scans every script's source for write ops against protected filenames. Because `work-next.js` itself writes `.work-state.json`, invoking the orchestrator from inside a hook deadlocks — the hook blocks the very script it is trying to run.
- `work-next.js` accepts whitespace-separated ticket strings (e.g. `ECHO-4446 TASKS`) and silently joins them into a single argument, creating bogus `tasks/` subdirectories before any validation occurs.
- A new `/work2` session with a bare ticket base (e.g. `ECHO-4446`) can start alongside an existing suffix-session (`ECHO-4446/foo`), or vice versa, with no conflict detection. The state files diverge silently.
- `run-tests.sh` only cleaned up `TEST-*` directories; it did not remove `/tmp/claude-session-guard-*.json` lock files. Interrupted test runs (Ctrl+C, hook rejection) leaked these locks, blocking real-ticket workflows until manually deleted.

## Intended New Behavior

- `createFileProtector` now accepts a `trustedScriptRoots` option. Scripts whose resolved path lives inside a trusted root bypass Vector 3. `protect-orchestrator-state.js` declares the plugin root as trusted, ending the self-deadlock.
- `validateRawTicketInput` (new export in `ticket-provider.js`) rejects malformed input — internal whitespace, path traversal, non-canonical bases — and is called in `work-next.js` **before** any filesystem write, including the `--init` marker file.
- `detectSessionConflict` cross-checks the incoming canonical ID against existing `tasks/` state files. Mismatched suffix/no-suffix combinations emit a `blocked` action with the correct canonical to use instead.
- `run-tests.sh` traps `EXIT`, `INT`, and `TERM` and calls the new `cleanupTestArtifacts()` helper, which removes both `TEST-*` directories and test-only `/tmp/claude-session-guard-*.json` lock files. A pre-run call handles leftovers from any prior crash.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Orchestrator self-bypass (fix 1)**

1. In a repo with an active work2 session, trigger any hook that calls `work-next.js` (e.g. an auto-advance Bash hook).
2. Previously: hook exits 2 with "BLOCKED: Direct script execution … is not allowed."
3. Now: hook passes through and `work-next.js` runs normally.
4. Unit regression: `node --test scripts/workflows/work2/hooks/__tests__/protect-orchestrator-state.test.js` — verify the "does NOT deadlock the orchestrator" suite passes.

**Strict ticket validation (fix 2)**

1. Run: `TASKS_BASE=/tmp/test-tasks TICKET_PROVIDER=jira node scripts/workflows/work2/work-next.js "ECHO-4446 TASKS"`
2. Expected: JSON output with `action: "blocked"`, reason mentioning whitespace; `/tmp/test-tasks` remains empty.
3. Run: `… work-next.js ECHO-4446 EXTRA-ARG`
4. Expected: JSON output with `action: "blocked"`, reason mentioning "positional".

**Sibling-session conflict detection (fix 2, continued)**

1. Create `$TASKS_BASE/ECHO-4446/foo/.work-state.json` with a minimal state blob.
2. Run: `TASKS_BASE=<above> node scripts/workflows/work2/work-next.js ECHO-4446`
3. Expected: `action: "blocked"`, reason references `ECHO-4446/foo`, suggestion shows the correct canonical.

**Lock-file cleanup (fix 3)**

1. Start `pnpm test` and press Ctrl+C mid-run.
2. Check `/tmp/`: no `claude-session-guard-TEST-*.json` files should remain.
3. Previously: stale lock files required `rm /tmp/claude-session-guard-TEST-*.json` before re-running real-ticket workflows.
4. Verify unit suite: `node --test scripts/workflows/lib/__tests__/test-cleanup.test.js` — all classification and removal cases pass.

### Test Results
Tests added in this PR — run locally with `pnpm test` to verify before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration hooks and workflow gating logic, where regressions could block legitimate workflows or incorrectly mark work complete; changes are mitigated by extensive new regression tests but still affect critical automation paths.
> 
> **Overview**
> **Workflow correctness hardening across `/work2` and `/follow-up2`.** `/follow-up2` now treats merge conflicts as a first-class, cross-step state (`state._isConflicting`): `monitor` retries `mergeable: UNKNOWN`, adds a local `git merge-tree` conflict cross-check, and refuses to report success when mergeable is `CONFLICTING`/`DIRTY`; `triage`, `fix-reviews`, `fix-ci`, and `report` all preempt other outcomes to route to (or block in) `fix-ci`, and `report` records skipped/solved review counts instead of forcing a manual ack loop.
> 
> **Safer `/work2` entry + gate behavior.** `work-next.js` now strictly validates ticket input (`validateRawTicketInput`) and rejects whitespace/multiple positional args *before* any filesystem writes, adds suffix/no-suffix active-session conflict detection, persists canonical ticket identity fields in state, and passes an explicit `worktreeDir` into `implement-gate` so tests run in the correct worktree; `implement-gate` also reconciles `tasksMeta` when `tasks.md` shrinks (dropping only pending tail entries) and persists full test stdout/stderr to bounded per-task log files.
> 
> **Hook/test infrastructure fixes.** `createFileProtector` gains `trustedScriptRoots` to avoid self-deadlocking orchestrator scripts, bash write-op detection no longer flags fd redirects like `2>/dev/null`, task-scope validation is expanded to enforce test-scope vs file-scope (including runner-vs-test-naming consistency and Rule 4b), and `run-tests.sh` adds robust `trap`-based cleanup that also removes leaked session-guard lock files via the expanded `test-cleanup` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e82ae82c47e56e82602471ded43bed40979c3099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->