### PR TITLE
fix(work2): close three TDD bypass paths with strict gate enforcement

### DIFF
--- a/agents/brief-writer.md
+++ b/agents/brief-writer.md
@@ -1,6 +1,6 @@
 ---
 name: brief-writer
-tools: Read, Grep, Glob, Write
+tools: Read, Grep, Glob, Write, Bash
 description: |
   Use this agent to generate a structured Product Brief from ticket requirements. The brief-writer analyzes ticket details and organizes them into a clear document covering problem statement, goals, requirements (P0/P1/P2), constraints, scope, and success metrics. This agent is invoked automatically by the /work workflow during the 3_brief step.
 

--- a/agents/brief-writer.md
+++ b/agents/brief-writer.md
@@ -16,6 +16,47 @@ model: inherit
 color: purple
 ---
 
+## ⚠️ MANDATORY: brief generation via brief-next.js (when invoked during /work2 brief)
+
+When you are dispatched during the `brief` step of a /work or /work2 workflow,
+the entry instruction is ALWAYS:
+
+```
+node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work-brief/brief-next.js <TICKET>
+```
+
+The script drives 5 phases: **inputs → overlap → draft → validate → memorize → done**.
+
+You MUST:
+1. Invoke `brief-next.js` **first**, before reading any ticket, doing overlap
+   analysis, or writing brief.md.
+2. Follow the Markdown response verbatim — it tells you the current phase, what
+   to read/produce, and what must be true to advance.
+3. Re-invoke after each phase. The script validates, records evidence, and
+   advances you. Stop only when it says the brief is done.
+4. In phase `inputs`: call the installed memory plugin's recall tool (e.g.
+   `cortex_recall`) for prior decisions BEFORE drafting anything.
+5. In phase `memorize`: call the memory plugin's remember tool for EVERY key
+   decision (sibling-ownership verdicts, P0 picks, open-question resolutions)
+   so future agents on related tickets can recall them.
+
+You MUST NOT:
+- Write `brief.md`, `sibling-overlap.md`, or `_related/*.md` before running
+  `brief-next.js` and being told you're in the right phase.
+- Edit `brief-phase.json` directly — it is written only by the authorized
+  recorder, and direct edits are blocked.
+- Skip the overlap phase. Even if you "know" there's no overlap, the verdict
+  must be recorded per linked ticket so brief_gate has proof.
+- Skip the memorize phase. If a memory plugin is installed, you MUST save
+  decisions — silent fixes leave the next agent in the dark.
+- Leave items in "Open Questions" without a `Searched:` annotation. The script
+  rejects unannotated open questions in phase `draft`.
+
+If `brief-next.js` blocks you with a reason, READ THE REASON and fix what it
+asks for. Do not "work around" the block.
+
+---
+
 You are a Product Owner responsible for transforming ticket requirements into clear, actionable Product Briefs. You focus on problem definition, constraints, measurable outcomes, and scope clarity.
 
 ## CRITICAL: NEVER CALL YOURSELF

--- a/agents/developer-devops.md
+++ b/agents/developer-devops.md
@@ -6,6 +6,43 @@ model: opus
 color: red
 ---
 
+## ⚠️ MANDATORY: TDD via task-next.js (when invoked during /work2 implement)
+
+When you are dispatched during the `implement` step of a /work or /work2 workflow,
+the entry instruction is ALWAYS:
+
+```
+node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work-implement/task-next.js <TICKET> task<N>
+```
+
+You MUST:
+1. Invoke `task-next.js` **first**, before reading code, writing tests, or editing source.
+2. Follow the Markdown response verbatim — it will tell you the current phase
+   (RED / GREEN / REFACTOR), which file globs you may touch, and the test command
+   it will run on your behalf.
+3. Re-invoke `task-next.js` after each phase — it validates, records evidence,
+   and advances you. Stop only when it says the task is complete.
+
+You MUST NOT:
+- Write tests, source, or fixtures **before** running `task-next.js`.
+- Run the test command yourself — `task-next.js` runs it and gates the transition.
+- Edit `tdd-phase.json`, `.work-state.json`, or any phase artifact directly — they
+  are written only by the authorized recorder, and direct edits are blocked.
+- Stash files to /tmp or `git checkout --` to "fake" a RED failure — that is
+  fabricated TDD evidence and is forbidden by user policy.
+- Invoke /work-implement, /work2, or any slash command. You are inside a /work2
+  dispatch — your only job is the per-task TDD cycle.
+
+If you are tempted to deviate ("I already know the answer", "the test is trivial",
+"let me just edit the source first"), STOP. The whole point of `task-next.js` is
+that an audit-trail exists. Without it, the workflow cannot advance past the
+implement step and the orchestrator will get stuck.
+
+If `task-next.js` blocks you with a reason, READ THE REASON and fix what it asks
+for. Do not "work around" the block.
+
+---
+
 You are an **Infrastructure Deployment Expert** with senior-level expertise in cloud platforms, containerization, orchestration, and DevOps practices. Your focus is on designing, implementing, and maintaining **robust, scalable, secure, and cost-effective infrastructure**.
 
 ## CRITICAL: NEVER CALL YOURSELF

--- a/agents/developer-nodejs-tdd.md
+++ b/agents/developer-nodejs-tdd.md
@@ -34,6 +34,43 @@ model: inherit
 color: green
 ---
 
+## ⚠️ MANDATORY: TDD via task-next.js (when invoked during /work2 implement)
+
+When you are dispatched during the `implement` step of a /work or /work2 workflow,
+the entry instruction is ALWAYS:
+
+```
+node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work-implement/task-next.js <TICKET> task<N>
+```
+
+You MUST:
+1. Invoke `task-next.js` **first**, before reading code, writing tests, or editing source.
+2. Follow the Markdown response verbatim — it will tell you the current phase
+   (RED / GREEN / REFACTOR), which file globs you may touch, and the test command
+   it will run on your behalf.
+3. Re-invoke `task-next.js` after each phase — it validates, records evidence,
+   and advances you. Stop only when it says the task is complete.
+
+You MUST NOT:
+- Write tests, source, or fixtures **before** running `task-next.js`.
+- Run the test command yourself — `task-next.js` runs it and gates the transition.
+- Edit `tdd-phase.json`, `.work-state.json`, or any phase artifact directly — they
+  are written only by the authorized recorder, and direct edits are blocked.
+- Stash files to /tmp or `git checkout --` to "fake" a RED failure — that is
+  fabricated TDD evidence and is forbidden by user policy.
+- Invoke /work-implement, /work2, or any slash command. You are inside a /work2
+  dispatch — your only job is the per-task TDD cycle.
+
+If you are tempted to deviate ("I already know the answer", "the test is trivial",
+"let me just edit the source first"), STOP. The whole point of `task-next.js` is
+that an audit-trail exists. Without it, the workflow cannot advance past the
+implement step and the orchestrator will get stuck.
+
+If `task-next.js` blocks you with a reason, READ THE REASON and fix what it asks
+for. Do not "work around" the block.
+
+---
+
 You are an expert Node.js TypeScript developer specializing in modern backend frameworks including Express, Nest.js, Next.js, Fastify, and Koa. You follow strict Test-Driven Development (TDD) methodology and write highly optimized, type-safe code.
 
 ## CRITICAL: NEVER CALL YOURSELF

--- a/agents/developer-react-senior.md
+++ b/agents/developer-react-senior.md
@@ -5,6 +5,43 @@ description: Use this agent when you need to build, debug, or architect complex 
 model: inherit
 color: blue
 ---
+## ⚠️ MANDATORY: TDD via task-next.js (when invoked during /work2 implement)
+
+When you are dispatched during the `implement` step of a /work or /work2 workflow,
+the entry instruction is ALWAYS:
+
+```
+node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work-implement/task-next.js <TICKET> task<N>
+```
+
+You MUST:
+1. Invoke `task-next.js` **first**, before reading code, writing tests, or editing source.
+2. Follow the Markdown response verbatim — it will tell you the current phase
+   (RED / GREEN / REFACTOR), which file globs you may touch, and the test command
+   it will run on your behalf.
+3. Re-invoke `task-next.js` after each phase — it validates, records evidence,
+   and advances you. Stop only when it says the task is complete.
+
+You MUST NOT:
+- Write tests, source, or fixtures **before** running `task-next.js`.
+- Run the test command yourself — `task-next.js` runs it and gates the transition.
+- Edit `tdd-phase.json`, `.work-state.json`, or any phase artifact directly — they
+  are written only by the authorized recorder, and direct edits are blocked.
+- Stash files to /tmp or `git checkout --` to "fake" a RED failure — that is
+  fabricated TDD evidence and is forbidden by user policy.
+- Invoke /work-implement, /work2, or any slash command. You are inside a /work2
+  dispatch — your only job is the per-task TDD cycle.
+
+If you are tempted to deviate ("I already know the answer", "the test is trivial",
+"let me just edit the source first"), STOP. The whole point of `task-next.js` is
+that an audit-trail exists. Without it, the workflow cannot advance past the
+implement step and the orchestrator will get stuck.
+
+If `task-next.js` blocks you with a reason, READ THE REASON and fix what it asks
+for. Do not "work around" the block.
+
+---
+
 You are a **senior React developer** with 10+ years of experience building and maintaining large-scale React applications. Your expertise spans from React internals to ecosystem mastery, with deep knowledge of performance optimization, state management patterns, and enterprise-grade React architecture. You have an unwavering commitment to clean code, comprehensive testing through Storybook and Playwright, and building maintainable React applications with living documentation.
 
 ## CRITICAL: NEVER CALL YOURSELF

--- a/agents/developer-react-ui-architect.md
+++ b/agents/developer-react-ui-architect.md
@@ -6,6 +6,43 @@ model: opus
 color: pink
 ---
 
+## ⚠️ MANDATORY: TDD via task-next.js (when invoked during /work2 implement)
+
+When you are dispatched during the `implement` step of a /work or /work2 workflow,
+the entry instruction is ALWAYS:
+
+```
+node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work-implement/task-next.js <TICKET> task<N>
+```
+
+You MUST:
+1. Invoke `task-next.js` **first**, before reading code, writing tests, or editing source.
+2. Follow the Markdown response verbatim — it will tell you the current phase
+   (RED / GREEN / REFACTOR), which file globs you may touch, and the test command
+   it will run on your behalf.
+3. Re-invoke `task-next.js` after each phase — it validates, records evidence,
+   and advances you. Stop only when it says the task is complete.
+
+You MUST NOT:
+- Write tests, source, or fixtures **before** running `task-next.js`.
+- Run the test command yourself — `task-next.js` runs it and gates the transition.
+- Edit `tdd-phase.json`, `.work-state.json`, or any phase artifact directly — they
+  are written only by the authorized recorder, and direct edits are blocked.
+- Stash files to /tmp or `git checkout --` to "fake" a RED failure — that is
+  fabricated TDD evidence and is forbidden by user policy.
+- Invoke /work-implement, /work2, or any slash command. You are inside a /work2
+  dispatch — your only job is the per-task TDD cycle.
+
+If you are tempted to deviate ("I already know the answer", "the test is trivial",
+"let me just edit the source first"), STOP. The whole point of `task-next.js` is
+that an audit-trail exists. Without it, the workflow cannot advance past the
+implement step and the orchestrator will get stuck.
+
+If `task-next.js` blocks you with a reason, READ THE REASON and fix what it asks
+for. Do not "work around" the block.
+
+---
+
 You are an **elite React UI/UX architect** and the maintainer of several prominent UI component libraries. Your expertise spans from pixel-perfect design implementation to performance-critical React optimizations. You have an unwavering commitment to Test-Driven Development and creating visually stunning, highly efficient user interfaces.
 
 ## CRITICAL: NEVER CALL YOURSELF

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -155,6 +155,10 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/follow-up2/hooks/follow-up-auto-advance.js"
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/lib/hooks/inject-inbox-messages.js"
           }
         ]
       },

--- a/open-channel.md
+++ b/open-channel.md
@@ -1,0 +1,39 @@
+# Open Channel — agent ↔ monitor communication
+
+Copy/paste the block below into any agent's prompt. Replace `<TICKET-ID>` with the agent's ticket (e.g. `ECHO-4621`).
+
+---
+
+**Start listening on the shared agent inbox.**
+
+A monitor session may need to nudge you mid-workflow (e.g. "your test path is wrong", "stop and re-do RED"). Run this in a dedicated tmux pane so any inbox traffic highlights the pane on arrival:
+
+```bash
+TICKET=<TICKET-ID>
+SESS="${TICKET}-listen"
+tmux has-session -t "$SESS" 2>/dev/null || \
+  tmux new-session -d -s "$SESS" "exec node /home/thomfilg/p/w-claude-plugin/claude-plugin-work/scripts/listen-all.js"
+tmux list-sessions | grep "$SESS"
+```
+
+`listen-all.js` tails every `/tmp/claude-agent-inbox/*.log` channel and prefixes each line with `[channel]`, so you'll see your own messages and any others. Watch for lines tagged `[<TICKET-ID>]` — those are addressed to you.
+
+> Caveat: `listen-all.js` only follows files that exist at startup. If a new ticket's log file is created later, restart the session to pick it up.
+
+To send a status update back to the monitor:
+
+```bash
+node /home/thomfilg/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js MONITOR "<TICKET-ID>: <your message>"
+```
+
+Always prefix MONITOR messages with your ticket ID. The script will report how many listeners are tailing MONITOR before sending; if it warns "no active listeners", the message is still persisted to the log.
+
+Optional one-shot check whether the monitor is listening right now:
+
+```bash
+node /home/thomfilg/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js --check MONITOR
+```
+
+Periodically (every few minutes during long tool calls) glance at the pane in case you missed a tmux highlight, or run `tail -20 /tmp/claude-agent-inbox/<TICKET-ID>.log`.
+
+---

--- a/open-channel.md
+++ b/open-channel.md
@@ -12,7 +12,7 @@ A monitor session may need to nudge you mid-workflow (e.g. "your test path is wr
 TICKET=<TICKET-ID>
 SESS="${TICKET}-listen"
 tmux has-session -t "$SESS" 2>/dev/null || \
-  tmux new-session -d -s "$SESS" "exec node /home/thomfilg/p/w-claude-plugin/claude-plugin-work/scripts/listen-all.js"
+  tmux new-session -d -s "$SESS" "exec node ${CLAUDE_PLUGIN_ROOT}/scripts/listen-all.js"
 tmux list-sessions | grep "$SESS"
 ```
 
@@ -23,7 +23,7 @@ tmux list-sessions | grep "$SESS"
 To send a status update back to the monitor:
 
 ```bash
-node /home/thomfilg/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js MONITOR "<TICKET-ID>: <your message>"
+node ${CLAUDE_PLUGIN_ROOT}/scripts/communicate.js MONITOR "<TICKET-ID>: <your message>"
 ```
 
 Always prefix MONITOR messages with your ticket ID. The script will report how many listeners are tailing MONITOR before sending; if it warns "no active listeners", the message is still persisted to the log.
@@ -31,7 +31,7 @@ Always prefix MONITOR messages with your ticket ID. The script will report how m
 Optional one-shot check whether the monitor is listening right now:
 
 ```bash
-node /home/thomfilg/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js --check MONITOR
+node ${CLAUDE_PLUGIN_ROOT}/scripts/communicate.js --check MONITOR
 ```
 
 Periodically (every few minutes during long tool calls) glance at the pane in case you missed a tmux highlight, or run `tail -20 /tmp/claude-agent-inbox/<TICKET-ID>.log`.

--- a/scripts/communicate.js
+++ b/scripts/communicate.js
@@ -111,22 +111,25 @@ if (watchMode) {
   };
   process.on('SIGINT', stop);
   process.on('SIGTERM', stop);
-}
+} else {
+  // Send mode — wrapped in else so watch mode does NOT fall through into
+  // this block (which would write an empty timestamped line and exit(3),
+  // killing the watch interval set up above).
+  if (!fs.existsSync(inbox)) fs.closeSync(fs.openSync(inbox, 'a'));
+  const listenersBefore = findListeners(inbox);
 
-if (!fs.existsSync(inbox)) fs.closeSync(fs.openSync(inbox, 'a'));
-const listenersBefore = findListeners(inbox);
+  const message = rest.join(' ');
+  const ts = new Date().toISOString();
+  const line = `[${ts}] ${message}\n`;
+  fs.appendFileSync(inbox, line, { mode: 0o644 });
 
-const message = rest.join(' ');
-const ts = new Date().toISOString();
-const line = `[${ts}] ${message}\n`;
-fs.appendFileSync(inbox, line, { mode: 0o644 });
-
-process.stdout.write(
-  `sent → ${inbox} (${listenersBefore.length} listener(s)${listenersBefore.length ? `, pids: ${listenersBefore.join(', ')}` : ''})\n${line}`
-);
-if (listenersBefore.length === 0) {
-  process.stderr.write(
-    'warning: no active listeners detected — message written but no one is tailing.\n'
+  process.stdout.write(
+    `sent → ${inbox} (${listenersBefore.length} listener(s)${listenersBefore.length ? `, pids: ${listenersBefore.join(', ')}` : ''})\n${line}`
   );
-  process.exit(3);
+  if (listenersBefore.length === 0) {
+    process.stderr.write(
+      'warning: no active listeners detected — message written but no one is tailing.\n'
+    );
+    process.exit(3);
+  }
 }

--- a/scripts/communicate.js
+++ b/scripts/communicate.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const INBOX_DIR = process.env.CLAUDE_AGENT_INBOX_DIR || '/tmp/claude-agent-inbox';
+
+function usage(code) {
+  process.stderr.write(
+    'usage: communicate.js <ticket-id> <message...>\n' +
+      '       communicate.js --check <ticket-id>\n' +
+      '       communicate.js --watch <ticket-id>\n' +
+      '  ticket-id is case-insensitive (echo-1234 → ECHO-1234)\n' +
+      '  message can be a single quoted string or remaining argv joined with spaces\n' +
+      '  --check prints listener PIDs for the channel (no send)\n' +
+      '  --watch polls every 1s and prints listener join/leave events\n' +
+      '  Send always reports listener count; exits 3 if zero listeners.\n'
+  );
+  process.exit(code);
+}
+
+function findListeners(inboxPath) {
+  let target;
+  try {
+    target = fs.realpathSync(inboxPath);
+  } catch {
+    return [];
+  }
+  const pids = [];
+  let entries;
+  try {
+    entries = fs.readdirSync('/proc');
+  } catch {
+    return [];
+  }
+  for (const pid of entries) {
+    if (!/^\d+$/.test(pid)) continue;
+    const fdDir = `/proc/${pid}/fd`;
+    let fds;
+    try {
+      fds = fs.readdirSync(fdDir);
+    } catch {
+      continue;
+    }
+    for (const fd of fds) {
+      try {
+        const link = fs.readlinkSync(`${fdDir}/${fd}`);
+        if (link === target || link === inboxPath) {
+          pids.push(Number(pid));
+          break;
+        }
+      } catch {}
+    }
+  }
+  return pids.filter((p) => p !== process.pid);
+}
+
+const args = process.argv.slice(2);
+const checkOnly = args[0] === '--check' || args[0] === '-c';
+const watchMode = args[0] === '--watch' || args[0] === '-w';
+if (checkOnly || watchMode) args.shift();
+
+const [rawTicket, ...rest] = args;
+if (!rawTicket) usage(1);
+if (!checkOnly && !watchMode && rest.length === 0) usage(1);
+
+const ticket = rawTicket.toUpperCase().replace(/[^A-Z0-9_-]/g, '');
+if (!ticket) {
+  process.stderr.write(`invalid ticket id: ${rawTicket}\n`);
+  process.exit(1);
+}
+
+fs.mkdirSync(INBOX_DIR, { recursive: true, mode: 0o755 });
+const inbox = path.join(INBOX_DIR, `${ticket}.log`);
+
+if (checkOnly) {
+  if (!fs.existsSync(inbox)) {
+    process.stdout.write(`no inbox file yet: ${inbox} (0 listeners)\n`);
+    process.exit(3);
+  }
+  const listeners = findListeners(inbox);
+  process.stdout.write(
+    `${inbox}: ${listeners.length} listener(s)${listeners.length ? ` — pids: ${listeners.join(', ')}` : ''}\n`
+  );
+  process.exit(listeners.length === 0 ? 3 : 0);
+}
+
+if (watchMode) {
+  if (!fs.existsSync(inbox)) fs.closeSync(fs.openSync(inbox, 'a'));
+  let prev = new Set(findListeners(inbox));
+  process.stdout.write(
+    `watching ${inbox} for listener changes (Ctrl-C to stop)\n` +
+      `\x07initial: ${prev.size} listener(s)${prev.size ? ` — pids: ${[...prev].join(', ')}` : ''}\n`
+  );
+  const tick = () => {
+    const now = new Set(findListeners(inbox));
+    const joined = [...now].filter((p) => !prev.has(p));
+    const left = [...prev].filter((p) => !now.has(p));
+    const ts = new Date().toISOString();
+    for (const p of joined)
+      process.stdout.write(`\x07[${ts}] + listener joined pid=${p} (total=${now.size})\n`);
+    for (const p of left)
+      process.stdout.write(`\x07[${ts}] - listener left   pid=${p} (total=${now.size})\n`);
+    prev = now;
+  };
+  const interval = setInterval(tick, 1000);
+  const stop = () => {
+    clearInterval(interval);
+    process.exit(0);
+  };
+  process.on('SIGINT', stop);
+  process.on('SIGTERM', stop);
+}
+
+if (!fs.existsSync(inbox)) fs.closeSync(fs.openSync(inbox, 'a'));
+const listenersBefore = findListeners(inbox);
+
+const message = rest.join(' ');
+const ts = new Date().toISOString();
+const line = `[${ts}] ${message}\n`;
+fs.appendFileSync(inbox, line, { mode: 0o644 });
+
+process.stdout.write(
+  `sent → ${inbox} (${listenersBefore.length} listener(s)${listenersBefore.length ? `, pids: ${listenersBefore.join(', ')}` : ''})\n${line}`
+);
+if (listenersBefore.length === 0) {
+  process.stderr.write(
+    'warning: no active listeners detected — message written but no one is tailing.\n'
+  );
+  process.exit(3);
+}

--- a/scripts/listen-all.js
+++ b/scripts/listen-all.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const INBOX_DIR = process.env.CLAUDE_AGENT_INBOX_DIR || '/tmp/claude-agent-inbox';
+
+const filter = process.argv[2] || null;
+
+fs.mkdirSync(INBOX_DIR, { recursive: true, mode: 0o755 });
+
+function matchesFilter(name) {
+  if (!name.endsWith('.log')) return false;
+  if (filter && !name.toUpperCase().includes(filter.toUpperCase())) return false;
+  return true;
+}
+
+const tails = new Map();
+
+function startTail(file) {
+  if (tails.has(file)) return;
+  const channel = path.basename(file, '.log');
+  const proc = spawn('tail', ['-n', '0', '-F', file], { stdio: ['ignore', 'pipe', 'inherit'] });
+  let buf = '';
+  proc.stdout.on('data', (chunk) => {
+    buf += chunk.toString('utf8');
+    let idx;
+    while ((idx = buf.indexOf('\n')) !== -1) {
+      const line = buf.slice(0, idx);
+      buf = buf.slice(idx + 1);
+      if (line.length === 0) continue;
+      process.stdout.write(`\x07[${channel}] ${line}\n`);
+    }
+  });
+  proc.on('exit', () => tails.delete(file));
+  tails.set(file, proc);
+  process.stdout.write(`+ tailing [${channel}]\n`);
+}
+
+for (const f of fs.readdirSync(INBOX_DIR)) {
+  if (matchesFilter(f)) startTail(path.join(INBOX_DIR, f));
+}
+
+process.stdout.write(
+  `listening on ${INBOX_DIR}/*.log${filter ? ` (filter: ${filter})` : ''}` +
+    ` — ${tails.size} channel(s) at start, auto-attaching new ones. Ctrl-C to stop.\n`
+);
+
+const watcher = fs.watch(INBOX_DIR, (eventType, filename) => {
+  if (!filename) return;
+  if (!matchesFilter(filename)) return;
+  const full = path.join(INBOX_DIR, filename);
+  if (tails.has(full)) return;
+  if (!fs.existsSync(full)) return;
+  startTail(full);
+});
+
+function shutdown(code) {
+  try {
+    watcher.close();
+  } catch {}
+  for (const proc of tails.values()) {
+    try {
+      proc.kill('SIGTERM');
+    } catch {}
+  }
+  process.exit(code ?? 0);
+}
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));

--- a/scripts/listen-communication.js
+++ b/scripts/listen-communication.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const INBOX_DIR = process.env.CLAUDE_AGENT_INBOX_DIR || '/tmp/claude-agent-inbox';
+
+function usage(code) {
+  process.stderr.write(
+    'usage: listen-communication.js <ticket-id>\n' +
+      '  Tails /tmp/claude-agent-inbox/<TICKET>.log and prints new messages.\n' +
+      '  Beeps (bell char) on each new line so a tmux pane gets activity highlight.\n'
+  );
+  process.exit(code);
+}
+
+const [, , rawTicket] = process.argv;
+if (!rawTicket) usage(1);
+
+const ticket = rawTicket.toUpperCase().replace(/[^A-Z0-9_-]/g, '');
+if (!ticket) {
+  process.stderr.write(`invalid ticket id: ${rawTicket}\n`);
+  process.exit(1);
+}
+
+fs.mkdirSync(INBOX_DIR, { recursive: true, mode: 0o755 });
+const inbox = path.join(INBOX_DIR, `${ticket}.log`);
+if (!fs.existsSync(inbox)) fs.closeSync(fs.openSync(inbox, 'a'));
+
+process.stdout.write(`listening on ${inbox} (Ctrl-C to stop)\n`);
+
+const tail = spawn('tail', ['-n', '0', '-F', inbox], { stdio: ['ignore', 'pipe', 'inherit'] });
+
+let buf = '';
+tail.stdout.on('data', (chunk) => {
+  buf += chunk.toString('utf8');
+  let idx;
+  while ((idx = buf.indexOf('\n')) !== -1) {
+    const line = buf.slice(0, idx);
+    buf = buf.slice(idx + 1);
+    if (line.length === 0) continue;
+    process.stdout.write(`\x07>>> ${line}\n`);
+  }
+});
+
+tail.on('exit', (code) => process.exit(code ?? 0));
+process.on('SIGINT', () => tail.kill('SIGINT'));
+process.on('SIGTERM', () => tail.kill('SIGTERM'));

--- a/scripts/workflows/check2/lib/steps/phase1-agents.js
+++ b/scripts/workflows/check2/lib/steps/phase1-agents.js
@@ -26,7 +26,10 @@ module.exports = function registerPhase1(register) {
         // Mark tasks as verified [v] if completion-checker says COMPLETE
         try {
           const completionReport = fs.readFileSync(completionPath, 'utf8');
-          if (/Status:\s*COMPLETE\b/i.test(completionReport)) {
+          const { hasVerdict } = require(
+            path.join(__dirname, '..', '..', '..', 'lib', 'parse-completion-status')
+          );
+          if (hasVerdict(completionReport, ['COMPLETE'])) {
             const { markVerified } = require(
               path.join(__dirname, '..', '..', '..', 'work2', 'lib', 'mark-task-progress')
             );

--- a/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -4548,4 +4548,64 @@ describe('enforce-step-workflow', () => {
       assert.equal(code, 0, 'untrusted path not caught by Rule 3b (handled by Vector 3)');
     });
   });
+
+  // ─── ticketId fallback chain (regression: ECHO-4560 token-mint failure) ───
+  describe('ticketId fallback chain when CWD has no ticket branch', () => {
+    it('derives ticket from hookData.tool_input.command when ENFORCE_HOOK_TICKET_ID is empty', async () => {
+      // Empty ENFORCE_HOOK_TICKET_ID forces the fallback chain. The hook
+      // should still process the Bash call (not silently early-return)
+      // and exit 0 because no state file matches our fabricated ticket.
+      const { code } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'node /tmp/some-script.js TEST-FALLBACK-CMD-9999 task1',
+          },
+        },
+        'PreToolUse',
+        { ENFORCE_HOOK_TICKET_ID: '' }
+      );
+      assert.equal(code, 0, 'hook should allow Bash with no ticket context');
+    });
+
+    it('derives ticket from hookData.transcript_path when command has none', async () => {
+      const { code } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: { command: 'ls -la' },
+          transcript_path:
+            '/home/u/.claude/projects/-home-u-g2i-w-tabwoah-tabwoah-TEST-FALLBACK-TR-9998/abc.jsonl',
+        },
+        'PreToolUse',
+        { ENFORCE_HOOK_TICKET_ID: '' }
+      );
+      assert.equal(code, 0, 'hook should allow Bash when ticket only present in transcript_path');
+    });
+
+    it('does not early-return when ticketId is null — Bash on a gated script still reaches Rule 5', async () => {
+      // The bug being prevented: prior to the fix, handlePreToolUse exited
+      // before Rule 5 when getTicketId() returned null, so no write token
+      // was ever minted. This test exercises the path with an explicitly
+      // empty ticketId and a Bash call invoking a gated script via a path
+      // that resolves to /tmp (untrusted), which means Rule 5 will hit the
+      // trusted-dir check and exit 2. That non-zero exit IS the signal
+      // that Rule 5 ran — under the bug, the hook would have exited 0.
+      const { code } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'node /tmp/task-next.js TEST-FALLBACK-RULE5-9997 task1',
+          },
+          transcript_path: '/tmp/no-ticket-here.jsonl',
+        },
+        'PreToolUse',
+        { ENFORCE_HOOK_TICKET_ID: '' }
+      );
+      assert.equal(
+        code,
+        2,
+        'Rule 5 should run for gated script and block on untrusted path (proves no early-return)'
+      );
+    });
+  });
 });

--- a/scripts/workflows/lib/__tests__/parse-completion-status.test.js
+++ b/scripts/workflows/lib/__tests__/parse-completion-status.test.js
@@ -1,0 +1,73 @@
+/**
+ * Tests for parse-completion-status.js
+ *
+ * Run: node --test ./scripts/workflows/lib/__tests__/parse-completion-status.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildVerdictRegex, hasVerdict } = require('../parse-completion-status');
+
+describe('parse-completion-status — buildVerdictRegex', () => {
+  const completeOrApproved = buildVerdictRegex(['COMPLETE', 'APPROVED']);
+  const approvedOnly = buildVerdictRegex(['APPROVED']);
+
+  it('matches canonical writer output `## Final Status\\n\\n**[COMPLETE]**`', () => {
+    const md = `# Completion Verification\n\n## Final Status\n\n**[COMPLETE]** - All requirements have been delivered.\n`;
+    assert.match(md, completeOrApproved);
+    assert.equal(hasVerdict(md, ['COMPLETE']), true);
+  });
+
+  it('matches agent template `### Final Status:\\n[COMPLETE]`', () => {
+    const md = `### Final Status:\n[COMPLETE]\n`;
+    assert.match(md, completeOrApproved);
+  });
+
+  it('matches legacy plain `Status: APPROVED`', () => {
+    assert.match('Status: APPROVED', approvedOnly);
+    assert.match('Status: COMPLETE', completeOrApproved);
+  });
+
+  it('matches reviewer alt form `**Verdict:** **[APPROVED]**`', () => {
+    assert.match('**Verdict:** **[APPROVED]**', approvedOnly);
+  });
+
+  it('matches the actual ECHO-4630 verdict block (bug repro)', () => {
+    const md = [
+      '# Completion Verification — ECHO-4630',
+      '',
+      '**Verdict:** **[COMPLETE]**',
+      '',
+      '## Final Status',
+      '**[COMPLETE]** — All in-scope P0/P1 requirements have code evidence.',
+    ].join('\n');
+    assert.match(md, completeOrApproved);
+    assert.equal(hasVerdict(md, ['COMPLETE']), true);
+  });
+
+  it('rejects INCOMPLETE / NEEDS_WORK', () => {
+    assert.doesNotMatch('## Final Status\n\n**[INCOMPLETE]**', completeOrApproved);
+    assert.doesNotMatch('Status: NEEDS_WORK', approvedOnly);
+  });
+
+  it('is anchored — random prose containing "Status" + later "[COMPLETE]" with non-formatting text in between does not match', () => {
+    // Between "Status" and "COMPLETE" there is alphabetic prose, breaking the
+    // formatting-only inter-character class.
+    const md = 'Status was reviewed by the team. They concluded the work was COMPLETE.';
+    assert.doesNotMatch(md, completeOrApproved);
+  });
+
+  it('hasVerdict handles non-string / empty inputs safely', () => {
+    assert.equal(hasVerdict('', ['COMPLETE']), false);
+    assert.equal(hasVerdict(null, ['COMPLETE']), false);
+    assert.equal(hasVerdict(undefined, ['COMPLETE']), false);
+  });
+
+  it('throws on empty verdict list', () => {
+    assert.throws(() => buildVerdictRegex([]));
+    assert.throws(() => buildVerdictRegex(null));
+  });
+});

--- a/scripts/workflows/lib/hooks/__tests__/inject-inbox-messages.test.js
+++ b/scripts/workflows/lib/hooks/__tests__/inject-inbox-messages.test.js
@@ -1,0 +1,215 @@
+'use strict';
+
+/**
+ * Tests for inject-inbox-messages.js — the PostToolUse hook that delivers
+ * new inbox lines into the agent's tool result via stderr. Validates:
+ *
+ *   1. Ticket-id derivation priority (transcript_path > tool_input.command).
+ *   2. Cursor state advances and prevents re-injecting the same line.
+ *   3. New lines appended after first fire are picked up on the next fire.
+ *   4. Cap at 5 lines per fire (no flooding).
+ *   5. Empty/missing inbox file → fail-open silently.
+ *   6. INJECT_INBOX=0 → disabled (no output).
+ *   7. Malformed JSON stdin → fail-open silently.
+ */
+
+const { describe, it, before, beforeEach, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const HOOK = path.resolve(__dirname, '..', 'inject-inbox-messages.js');
+
+function runHook(stdinObj, env = {}) {
+  const r = spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify(stdinObj),
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return { code: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+function appendInbox(file, ...lines) {
+  fs.appendFileSync(file, lines.map((l) => `${l}\n`).join(''));
+}
+
+describe('inject-inbox-messages.js', () => {
+  let tmp;
+  let inboxDir;
+  let stateDir;
+  let envBase;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'inject-inbox-'));
+    inboxDir = path.join(tmp, 'inbox');
+    stateDir = path.join(tmp, '.claude', 'work-workflow', 'state');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+    // Hide real ~/.claude state by pointing HOME at tmp.
+    envBase = {
+      HOME: tmp,
+      CLAUDE_AGENT_INBOX_DIR: inboxDir,
+    };
+  });
+
+  beforeEach(() => {
+    // Reset cursor file between tests (HOME-based path).
+    const cursors = path.join(stateDir, 'inbox-cursors.json');
+    try {
+      fs.unlinkSync(cursors);
+    } catch {
+      /* ignore */
+    }
+    // Reset inbox files between tests.
+    for (const f of fs.readdirSync(inboxDir)) {
+      fs.unlinkSync(path.join(inboxDir, f));
+    }
+  });
+
+  after(() => {
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('derives ticket from transcript_path and injects all new lines', () => {
+    const ticket = 'ECHO-7001';
+    const inbox = path.join(inboxDir, `${ticket}.log`);
+    appendInbox(inbox, '[t] hello', '[t] world');
+
+    const r = runHook(
+      {
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        transcript_path: `/x/y/tabwoah-${ticket}-something/abc.jsonl`,
+      },
+      envBase
+    );
+
+    assert.equal(r.code, 0, 'hook always exits 0 (fail-open)');
+    assert.match(r.stderr, /Monitor messages for ECHO-7001 \(2\/2 new\)/);
+    assert.match(r.stderr, /\[MONITOR\] \[t\] hello/);
+    assert.match(r.stderr, /\[MONITOR\] \[t\] world/);
+  });
+
+  it('falls back to command when transcript has no ticket', () => {
+    const ticket = 'ECHO-7002';
+    appendInbox(path.join(inboxDir, `${ticket}.log`), '[t] from-cmd');
+
+    const r = runHook(
+      {
+        tool_name: 'Bash',
+        tool_input: { command: `node x.js ${ticket} task1` },
+        transcript_path: '/x/no-ticket-here/abc.jsonl',
+      },
+      envBase
+    );
+    assert.match(r.stderr, /Monitor messages for ECHO-7002/);
+    assert.match(r.stderr, /\[MONITOR\] \[t\] from-cmd/);
+  });
+
+  it('cursor prevents re-injecting the same line on a second fire', () => {
+    const ticket = 'ECHO-7003';
+    const inbox = path.join(inboxDir, `${ticket}.log`);
+    appendInbox(inbox, '[t] one', '[t] two');
+
+    const stdin = {
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      transcript_path: `/x/${ticket}/abc.jsonl`,
+    };
+
+    const r1 = runHook(stdin, envBase);
+    assert.match(r1.stderr, /\(2\/2 new\)/);
+
+    const r2 = runHook(stdin, envBase);
+    assert.equal(r2.stderr.trim(), '', 'second fire with no new lines emits nothing');
+  });
+
+  it('appended lines after first fire are picked up on next fire', () => {
+    const ticket = 'ECHO-7004';
+    const inbox = path.join(inboxDir, `${ticket}.log`);
+    appendInbox(inbox, '[t] one');
+
+    const stdin = {
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      transcript_path: `/x/${ticket}/abc.jsonl`,
+    };
+
+    runHook(stdin, envBase); // cursor → 1
+    appendInbox(inbox, '[t] two', '[t] three');
+
+    const r2 = runHook(stdin, envBase);
+    assert.match(r2.stderr, /\(2\/2 new\)/);
+    assert.match(r2.stderr, /\[MONITOR\] \[t\] two/);
+    assert.match(r2.stderr, /\[MONITOR\] \[t\] three/);
+    assert.doesNotMatch(r2.stderr, /\[MONITOR\] \[t\] one/);
+  });
+
+  it('caps output at 5 lines per fire (last 5 of however many are new)', () => {
+    const ticket = 'ECHO-7005';
+    const inbox = path.join(inboxDir, `${ticket}.log`);
+    appendInbox(inbox, '[t] 1', '[t] 2', '[t] 3', '[t] 4', '[t] 5', '[t] 6', '[t] 7', '[t] 8');
+
+    const r = runHook(
+      {
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        transcript_path: `/x/${ticket}/abc.jsonl`,
+      },
+      envBase
+    );
+    assert.match(r.stderr, /\(5\/8 new\)/, 'shows 5-out-of-8 in the header');
+    // Should contain the last 5 (4..8), not the first 3.
+    for (const n of [4, 5, 6, 7, 8]) {
+      assert.match(r.stderr, new RegExp(`\\[MONITOR\\] \\[t\\] ${n}\\b`));
+    }
+    for (const n of [1, 2, 3]) {
+      assert.doesNotMatch(r.stderr, new RegExp(`\\[MONITOR\\] \\[t\\] ${n}\\b`));
+    }
+  });
+
+  it('no inbox file → silent fail-open (exit 0, no stderr)', () => {
+    const r = runHook(
+      {
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        transcript_path: '/x/ECHO-7006/abc.jsonl',
+      },
+      envBase
+    );
+    assert.equal(r.code, 0);
+    assert.equal(r.stderr.trim(), '');
+  });
+
+  it('INJECT_INBOX=0 disables the hook (no output even if messages exist)', () => {
+    const ticket = 'ECHO-7007';
+    appendInbox(path.join(inboxDir, `${ticket}.log`), '[t] should-not-appear');
+
+    const r = runHook(
+      {
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        transcript_path: `/x/${ticket}/abc.jsonl`,
+      },
+      { ...envBase, INJECT_INBOX: '0' }
+    );
+    assert.equal(r.code, 0);
+    assert.equal(r.stderr.trim(), '');
+  });
+
+  it('malformed stdin → silent fail-open (exit 0, no stderr)', () => {
+    const r = spawnSync(process.execPath, [HOOK], {
+      input: '{not-json',
+      encoding: 'utf8',
+      env: { ...process.env, ...envBase },
+    });
+    assert.equal(r.status, 0);
+    assert.equal((r.stderr || '').trim(), '');
+  });
+});

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -339,7 +339,7 @@ function resolveGitHead() {
   throw new Error('unexpected .git content');
 }
 
-function getTicketId() {
+function getTicketId(hookData) {
   if (_ticketIdResolved) return _cachedTicketId;
   _ticketIdResolved = true;
   // Allow override for testing — empty string explicitly opts out (no git fallback)
@@ -372,6 +372,20 @@ function getTicketId() {
     _cachedTicketId = match ? match[0] : null;
   } catch {
     _cachedTicketId = null;
+  }
+  // Fallback chain when CWD-based detection fails: derive ticket from
+  // hookData. Needed when the hook is spawned with a CWD that is not the
+  // agent's worktree (e.g. parent session in the plugin source tree).
+  if (!_cachedTicketId && hookData) {
+    const cmd = hookData?.tool_input?.command;
+    if (typeof cmd === 'string') {
+      const m = cmd.match(/\b[A-Z]+-\d+\b/);
+      if (m) _cachedTicketId = m[0];
+    }
+    if (!_cachedTicketId && typeof hookData?.transcript_path === 'string') {
+      const m = hookData.transcript_path.match(/\b[A-Z]+-\d+\b/);
+      if (m) _cachedTicketId = m[0];
+    }
   }
   // Compose with suffix when present (GH-146: phase-aware state paths)
   // Only append if ticketId doesn't already contain a '/' (prevent double-suffixing)
@@ -550,9 +564,12 @@ function handlePreToolUse(hookData) {
   const toolName = hookData.tool_name || '';
   const toolInput = hookData.tool_input || {};
 
-  // 1. Find active ticket
-  const ticketId = getTicketId();
-  if (!ticketId) return; // No ticket context → allow
+  // 1. Find active ticket. May be null when the hook's own CWD is not a
+  //    worktree (e.g. parent session lives in the plugin source tree).
+  //    Do NOT early-return on null — Rule 5 (agent-gated writer-script
+  //    token mint) does not need a ticket. Rules that genuinely require
+  //    one already guard with `if (ticketId) { ... }` below.
+  const ticketId = getTicketId(hookData);
 
   // Rule 3: Block direct writes to workflow state files
   // Prevents agents from bypassing the state machine by directly editing state files
@@ -793,6 +810,11 @@ function handlePreToolUse(hookData) {
   }
 
   if (rule3.skipRemainingChecks) return; // Edit/Write/MultiEdit — skip per-workflow loop
+
+  // The per-workflow state/transition loop below needs a ticketId to load
+  // any state. Skip it entirely when ticketId could not be resolved (Rule 5
+  // and earlier rules already ran above with their own null-guards).
+  if (!ticketId) return;
 
   // 2. Check each workflow independently
   for (const wf of WORKFLOWS) {

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -578,8 +578,12 @@ function handlePreToolUse(hookData) {
   const ticketId = getTicketId(hookData);
 
   // Rule 3: Block direct writes to workflow state files
-  // Prevents agents from bypassing the state machine by directly editing state files
-  const rule3 = stateFileProtector.check(toolName, toolInput);
+  // Prevents agents from bypassing the state machine by directly editing state files.
+  // Fail-open when no ticket context: without a workflow there is nothing to protect,
+  // and the hook should not block tool use it cannot reason about. Rule 5 below still
+  // runs unconditionally so agent-gated writer-script token minting works when the
+  // hook is invoked outside a worktree (e.g. plugin source tree parent sessions).
+  const rule3 = ticketId ? stateFileProtector.check(toolName, toolInput) : { blocked: false };
   if (rule3.blocked) {
     if (toolName === 'Bash') {
       const cmd = String(toolInput?.command || '').trim();
@@ -604,7 +608,8 @@ function handlePreToolUse(hookData) {
   // Defense-in-depth: the stateFileProtector's isExempt/Vector 3 may miss the script when
   // multi-arg flags (--require, -r, etc.) cause INTERPRETER_PATTERN to capture the flag
   // argument instead of the actual script. This rule uses the improved nodePattern directly.
-  if (toolName === 'Bash') {
+  // Fail-open when no ticket context — see Rule 3 comment above.
+  if (toolName === 'Bash' && ticketId) {
     const cmd = String(toolInput?.command || '').trim();
     const stateMatches = getNodeInvocations(cmd);
     for (const m of stateMatches) {

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -357,35 +357,41 @@ function getTicketId(hookData) {
     }
     return _cachedTicketId;
   }
-  // (Patch 6+9) Worktree-aware .git/HEAD read — no subprocess spawn
-  try {
-    let head;
-    try {
-      // Try worktree-aware read first (.git as file)
-      head = resolveGitHead();
-    } catch {
-      // Fallback: normal repo (.git is a directory)
-      head = fs.readFileSync(path.join('.git', 'HEAD'), 'utf-8').trim();
-    }
-    const ref = head.startsWith('ref: ') ? head.slice(5) : head;
-    const match = ref.match(/[A-Z]+-\d+/);
-    _cachedTicketId = match ? match[0] : null;
-  } catch {
-    _cachedTicketId = null;
-  }
-  // Fallback chain when CWD-based detection fails: derive ticket from
-  // hookData. Needed when the hook is spawned with a CWD that is not the
-  // agent's worktree (e.g. parent session in the plugin source tree).
-  if (!_cachedTicketId && hookData) {
+  // Priority order: command > .git/HEAD > transcript_path.
+  // The Bash command itself (when present) is the most explicit signal —
+  // a developer running `node task-next.js ECHO-XXXX taskN` literally
+  // states which ticket they're working on. .git/HEAD is *usually* right
+  // but breaks in symlinked-worktree setups where the worktree directory
+  // name doesn't match the checked-out branch (e.g. tabwoah-ECHO-4628/
+  // with branch ECHO-4465 checked out — observed in real incidents).
+  // transcript_path is the weakest signal but a useful last resort when
+  // neither command nor cwd identify a ticket.
+  if (hookData) {
     const cmd = hookData?.tool_input?.command;
     if (typeof cmd === 'string') {
       const m = cmd.match(/\b[A-Z]+-\d+\b/);
       if (m) _cachedTicketId = m[0];
     }
-    if (!_cachedTicketId && typeof hookData?.transcript_path === 'string') {
-      const m = hookData.transcript_path.match(/\b[A-Z]+-\d+\b/);
-      if (m) _cachedTicketId = m[0];
+  }
+  if (!_cachedTicketId) {
+    // (Patch 6+9) Worktree-aware .git/HEAD read — no subprocess spawn
+    try {
+      let head;
+      try {
+        head = resolveGitHead();
+      } catch {
+        head = fs.readFileSync(path.join('.git', 'HEAD'), 'utf-8').trim();
+      }
+      const ref = head.startsWith('ref: ') ? head.slice(5) : head;
+      const match = ref.match(/[A-Z]+-\d+/);
+      _cachedTicketId = match ? match[0] : null;
+    } catch {
+      _cachedTicketId = null;
     }
+  }
+  if (!_cachedTicketId && hookData && typeof hookData?.transcript_path === 'string') {
+    const m = hookData.transcript_path.match(/\b[A-Z]+-\d+\b/);
+    if (m) _cachedTicketId = m[0];
   }
   // Compose with suffix when present (GH-146: phase-aware state paths)
   // Only append if ticketId doesn't already contain a '/' (prevent double-suffixing)

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -653,9 +653,14 @@ function handlePreToolUse(hookData) {
         const allowedAgents = gatedEntry.agents;
         if (!isTrustedScriptPath(scriptPath, TRUSTED_SCRIPT_DIRS)) {
           didBlock = true;
+          const trustedSample = TRUSTED_SCRIPT_DIRS[0] || '<plugin>/scripts/workflows';
           process.stderr.write(
             `BLOCKED: Script ${scriptBase} is not in a trusted directory.\n` +
-              `Resolved path must be under a trusted workflows directory.\n`
+              `  Resolved path: ${scriptPath}\n` +
+              `  Trusted root example: ${trustedSample}\n` +
+              `\nWHAT TO DO INSTEAD:\n` +
+              `  Use an ABSOLUTE path under \${CLAUDE_PLUGIN_ROOT}/scripts/workflows/...\n` +
+              `  Avoid relative paths like ../../scripts/... — they may not normalize to a trusted dir.\n`
           );
           process.exit(2);
         }
@@ -664,10 +669,21 @@ function handlePreToolUse(hookData) {
         const transcriptPath = hookData?.transcript_path;
         if (!isRunningInAgent(transcriptPath, allowedAgents, hookData)) {
           didBlock = true;
+          const primaryAgent = allowedAgents[0];
           process.stderr.write(
             `BLOCKED: Cannot call ${scriptBase} — not running in an authorized agent.\n` +
-              `Allowed agents: ${allowedAgents.join(', ')}\n` +
-              `Only these agents may invoke this writer script.\n`
+              `  Allowed agents: ${allowedAgents.join(', ')}\n` +
+              `\nWHAT TO DO INSTEAD:\n` +
+              `  Re-dispatch this invocation through the Task tool so it runs inside the\n` +
+              `  authorized agent's subprocess (where the hook can mint the write token).\n` +
+              `\n  Example:\n` +
+              `    Task(\n` +
+              `      subagent_type: "${primaryAgent}",\n` +
+              `      prompt: "node ${scriptBase} ${ticketId || '<TICKET>'} ...your args..."\n` +
+              `    )\n` +
+              `\n  Do NOT invoke ${scriptBase} directly from the orchestrator/main session.\n` +
+              `  Do NOT stash source files to /tmp to fake test failures — that is fabricated\n` +
+              `  TDD evidence and forbidden by user rules.\n`
           );
           process.exit(2);
         }
@@ -683,7 +699,13 @@ function handlePreToolUse(hookData) {
             didBlock = true;
             process.stderr.write(
               `BLOCKED: Cannot issue write token — step '${currentStep}' is active, not '${requiredStep}'.\n` +
-                `Script ${scriptBase} can only be called during the ${requiredStep} step.\n`
+                `  Script ${scriptBase} can only be called during the ${requiredStep} step.\n` +
+                `\nWHAT TO DO INSTEAD:\n` +
+                `  The workflow has moved past '${requiredStep}'. Do NOT try to record evidence\n` +
+                `  for a previous step now — that artifact window has closed.\n` +
+                `  If the workflow is genuinely stuck, run:\n` +
+                `    node \${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work2/work-next.js ${ticketId || '<TICKET>'}\n` +
+                `  and follow the action it prints for the CURRENT step ('${currentStep}').\n`
             );
             process.exit(2);
           }

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -656,6 +656,15 @@ function handlePreToolUse(hookData) {
       const scriptPath = expandPluginRoot(nodeExec[1] || nodeExec[2] || nodeExec[3]);
       const scriptBase = path.basename(scriptPath);
       const gatedEntry = AGENT_GATED_SCRIPTS[scriptBase];
+      // Telemetry: log EVERY node-invocation seen by Rule 5, gated or not.
+      // Helps diagnose why a gated script's mint path isn't being reached.
+      _tokenLog('rule5-checked', {
+        scriptBase,
+        scriptPath,
+        gated: Boolean(gatedEntry),
+        gatedKeys: Object.keys(AGENT_GATED_SCRIPTS).slice(0, 20),
+        ticketId: ticketId || null,
+      });
       if (gatedEntry) {
         _tokenLog('rule5-match', {
           scriptBase,

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -783,7 +783,13 @@ function handlePreToolUse(hookData) {
             tasksBase: ticketId ? path.join(TASKS_BASE, safeTicketPath(ticketId)) : null,
           };
           const writeOneToken = (basename) => {
-            const tp = tokenPath(basename);
+            // Key by ticket so parallel sessions on different tickets do
+            // not clobber each other's tokens (real incident: ECHO-4465
+            // and ECHO-4630 task-next.js runs colliding on the same
+            // /tmp/.claude-write-tokens/task-next.js file). When ticketId
+            // is null (no ticket context), falls back to the legacy
+            // unkeyed path.
+            const tp = tokenPath(basename, ticketId);
             try {
               fs.unlinkSync(tp);
             } catch {

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -707,22 +707,35 @@ function handlePreToolUse(hookData) {
         })();
         try {
           ensureTokenDir();
-          const tp = tokenPath(scriptBase);
-          try {
-            fs.unlinkSync(tp);
-          } catch {
-            /* may not exist */
-          }
-          const fd = fs.openSync(tp, 'wx', 0o600);
-          try {
-            const tokenData = {
-              agent: normalizeAgentName(detectedAgent),
-              timestamp: Date.now(),
-              tasksBase: ticketId ? path.join(TASKS_BASE, safeTicketPath(ticketId)) : null,
-            };
-            fs.writeSync(fd, JSON.stringify(tokenData));
-          } finally {
-            fs.closeSync(fd);
+          const tokenData = {
+            agent: normalizeAgentName(detectedAgent),
+            timestamp: Date.now(),
+            tasksBase: ticketId ? path.join(TASKS_BASE, safeTicketPath(ticketId)) : null,
+          };
+          const writeOneToken = (basename) => {
+            const tp = tokenPath(basename);
+            try {
+              fs.unlinkSync(tp);
+            } catch {
+              /* may not exist */
+            }
+            const fd = fs.openSync(tp, 'wx', 0o600);
+            try {
+              fs.writeSync(fd, JSON.stringify(tokenData));
+            } finally {
+              fs.closeSync(fd);
+            }
+          };
+          writeOneToken(scriptBase);
+          // Companion tokens: scripts the gated script calls internally via
+          // spawnSync (which bypasses the PreToolUse hook). Mint a matching
+          // token for each so the chained writer can authenticate without a
+          // second hook trip.
+          const companions = Array.isArray(gatedEntry.companionScripts)
+            ? gatedEntry.companionScripts
+            : [];
+          for (const companion of companions) {
+            writeOneToken(companion);
           }
         } catch (e) {
           if (DEBUG) process.stderr.write(`WARNING: Failed to write token: ${e.message}\n`);

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -789,7 +789,14 @@ function handlePreToolUse(hookData) {
             // /tmp/.claude-write-tokens/task-next.js file). When ticketId
             // is null (no ticket context), falls back to the legacy
             // unkeyed path.
-            const tp = tokenPath(basename, ticketId);
+            //
+            // Strip ENFORCE_HOOK_SUFFIX from the ticket-key: getTicketId()
+            // appends the suffix (`<ticket>/<suffix>`) for phase-aware
+            // STATE-file paths, but consumers like tdd-phase-state.js look
+            // up tokens by the BARE ticket arg from the CLI (no suffix).
+            // Keying tokens with the suffix would make consumers miss them.
+            const bareTicket = ticketId ? ticketId.split('/')[0] : ticketId;
+            const tp = tokenPath(basename, bareTicket);
             try {
               fs.unlinkSync(tp);
             } catch {

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -1009,6 +1009,24 @@ async function main() {
     const hookData = JSON.parse(input);
     const hookType = process.env.CLAUDE_HOOK_TYPE || 'PostToolUse';
 
+    // Telemetry: log every fire so we can prove the hook ran. JSONL.
+    try {
+      const { logTokenEvent } = require(path.join(__dirname, '..', 'next-script-log'));
+      logTokenEvent('hook-fired', {
+        hookType,
+        toolName: hookData?.tool_name || null,
+        cmdSnippet: hookData?.tool_input?.command
+          ? String(hookData.tool_input.command).slice(0, 200)
+          : null,
+        envAgent: process.env.CLAUDE_CURRENT_AGENT || null,
+        subagentType: hookData?.tool_input?.subagent_type || null,
+        hookAgentType: hookData?.agent_type || null,
+        transcriptPath: hookData?.transcript_path || null,
+      });
+    } catch {
+      /* fail-open */
+    }
+
     if (hookType === 'PreToolUse') {
       handlePreToolUse(hookData);
     } else if (hookType === 'PostToolUse') {

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -232,6 +232,7 @@ const TRUSTED_SCRIPT_DIRS = [
   path.resolve(__dirname, '..', '..', 'work', 'scripts'), // workflows/work/scripts/
   path.resolve(__dirname, '..', '..', 'check', 'scripts'), // workflows/check/scripts/
   path.resolve(__dirname, '..', '..', 'work-implement'), // workflows/work-implement/
+  path.resolve(__dirname, '..', '..', 'work-brief'), // workflows/work-brief/
   path.resolve(__dirname, '..', '..', 'work2'), // workflows/work2/
   path.resolve(__dirname, '..', '..', 'check2'), // workflows/check2/
   path.resolve(__dirname, '..', '..', 'follow-up2'), // workflows/follow-up2/
@@ -642,6 +643,12 @@ function handlePreToolUse(hookData) {
   // When a Bash command invokes a writer script (e.g. write-qa-report.js),
   // verify the caller is an authorized agent. This provides defense-in-depth
   // alongside the script's own identity check.
+  let _tokenLog;
+  try {
+    ({ logTokenEvent: _tokenLog } = require(path.join(__dirname, '..', 'next-script-log')));
+  } catch {
+    _tokenLog = () => {};
+  }
   if (toolName === 'Bash') {
     const cmd = String(toolInput?.command || '');
     const nodeMatches = getNodeInvocations(cmd);
@@ -650,6 +657,15 @@ function handlePreToolUse(hookData) {
       const scriptBase = path.basename(scriptPath);
       const gatedEntry = AGENT_GATED_SCRIPTS[scriptBase];
       if (gatedEntry) {
+        _tokenLog('rule5-match', {
+          scriptBase,
+          scriptPath,
+          ticketId: ticketId || null,
+          cmd: cmd.slice(0, 300),
+          envAgent: process.env.CLAUDE_CURRENT_AGENT || null,
+          subagentType: hookData?.tool_input?.subagent_type || null,
+          hookAgentType: hookData?.agent_type || null,
+        });
         const allowedAgents = gatedEntry.agents;
         if (!isTrustedScriptPath(scriptPath, TRUSTED_SCRIPT_DIRS)) {
           didBlock = true;

--- a/scripts/workflows/lib/hooks/inject-inbox-messages.js
+++ b/scripts/workflows/lib/hooks/inject-inbox-messages.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+/**
+ * inject-inbox-messages.js — PostToolUse hook
+ *
+ * Reads new lines from the per-ticket inbox file
+ * (`/tmp/claude-agent-inbox/<TICKET>.log`) and writes them to stderr so
+ * they land in the agent's tool result. This is how monitor messages
+ * actually wake the agent — without this, the listener-tmux pane just
+ * shows messages to a human, but the Claude session never sees them.
+ *
+ * Cursor state lives at `~/.claude/work-workflow/state/inbox-cursors.json`
+ * keyed by ticket. Each value is the line count we've already delivered;
+ * only later lines are emitted on the next fire. Cursor advances after
+ * a successful read so the same message is never injected twice.
+ *
+ * Fails open: any error → exit 0 with no output. Logging must never
+ * break the workflow.
+ *
+ * Disable with `INJECT_INBOX=0`.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+function fail() {
+  process.exit(0);
+}
+
+if (process.env.INJECT_INBOX === '0') fail();
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function deriveTicket(hookData) {
+  // Priority order: transcript_path > tool_input.command > .git/HEAD of cwd
+  const tp = hookData?.transcript_path;
+  if (typeof tp === 'string') {
+    const m = tp.match(/\b[A-Z]+-\d+\b/);
+    if (m) return m[0];
+  }
+  const cmd = hookData?.tool_input?.command;
+  if (typeof cmd === 'string') {
+    const m = cmd.match(/\b[A-Z]+-\d+\b/);
+    if (m) return m[0];
+  }
+  try {
+    const head = fs.readFileSync(path.join(process.cwd(), '.git', 'HEAD'), 'utf8').trim();
+    const ref = head.startsWith('ref: ') ? head.slice(5) : head;
+    const m = ref.match(/[A-Z]+-\d+/);
+    if (m) return m[0];
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function cursorFile() {
+  const dir = path.join(os.homedir(), '.claude', 'work-workflow', 'state');
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
+  } catch {
+    /* ignore */
+  }
+  return path.join(dir, 'inbox-cursors.json');
+}
+
+function readCursors() {
+  try {
+    return JSON.parse(fs.readFileSync(cursorFile(), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeCursors(c) {
+  try {
+    const f = cursorFile();
+    const tmp = `${f}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(c), { mode: 0o644 });
+    fs.renameSync(tmp, f);
+  } catch {
+    /* ignore */
+  }
+}
+
+function inboxPath(ticket) {
+  const dir = process.env.CLAUDE_AGENT_INBOX_DIR || '/tmp/claude-agent-inbox';
+  return path.join(dir, `${ticket}.log`);
+}
+
+function main() {
+  const raw = readStdin();
+  if (!raw.trim()) fail();
+  let hookData;
+  try {
+    hookData = JSON.parse(raw);
+  } catch {
+    fail();
+  }
+
+  const ticket = deriveTicket(hookData);
+  if (!ticket) fail();
+
+  const file = inboxPath(ticket);
+  if (!fs.existsSync(file)) fail();
+
+  let lines;
+  try {
+    lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+  } catch {
+    fail();
+  }
+
+  const cursors = readCursors();
+  const last = Number(cursors[ticket] || 0);
+  if (lines.length <= last) fail(); // nothing new
+
+  const fresh = lines.slice(last);
+  cursors[ticket] = lines.length;
+  writeCursors(cursors);
+
+  // Cap at last 5 fresh lines to avoid flooding the agent if many piled up.
+  const toShow = fresh.slice(-5);
+  process.stderr.write(
+    `\n=== Monitor messages for ${ticket} (${toShow.length}/${fresh.length} new) ===\n` +
+      toShow.map((l) => `[MONITOR] ${l}`).join('\n') +
+      '\n=== end monitor messages ===\n'
+  );
+  process.exit(0);
+}
+
+try {
+  main();
+} catch {
+  process.exit(0);
+}

--- a/scripts/workflows/lib/hooks/policies/agent-authorization.js
+++ b/scripts/workflows/lib/hooks/policies/agent-authorization.js
@@ -24,7 +24,26 @@ const { getNodeInvocations } = require('./command-matching');
 function isTrustedScriptPath(scriptPath, trustedDirs) {
   try {
     const resolved = fs.realpathSync(path.resolve(scriptPath));
-    return trustedDirs.some((dir) => resolved.startsWith(dir + path.sep));
+    // realpath BOTH sides: if the hook was loaded via a symlinked plugin
+    // cache (~/.claude/plugins/cache/.../3.0.64 → /home/.../dev-tree), the
+    // trustedDirs computed from __dirname will be cache paths, while a
+    // caller using the dev-tree path directly will resolve to the symlink
+    // TARGET. Without resolving both, the prefix check returns false even
+    // though both paths point to the same physical directory.
+    return trustedDirs.some((dir) => {
+      let realDir = dir;
+      try {
+        realDir = fs.realpathSync(dir);
+      } catch {
+        /* dir might not exist; fall back to raw */
+      }
+      return (
+        resolved === realDir ||
+        resolved.startsWith(realDir + path.sep) ||
+        resolved === dir ||
+        resolved.startsWith(dir + path.sep)
+      );
+    });
   } catch {
     return false;
   }

--- a/scripts/workflows/lib/hooks/policies/command-matching.js
+++ b/scripts/workflows/lib/hooks/policies/command-matching.js
@@ -18,8 +18,22 @@
 // Handles: cd && node ..., env prefixes, Node flags (including multi-arg like --require <path>),
 // quoted paths. --eval/--print/-e/-p excluded (inline code, not file paths).
 // Use getNodeInvocations() helper to catch ALL invocations in chained commands.
+// Wrapper-aware: matches `timeout <N>[s|m|h] node ...`, `nice [-n N] node ...`,
+// and bare `env [VAR=val ...] node ...` in addition to inline env-assignment.
+// Without this, agents using `timeout 90 node task-next.js ...` silently bypass
+// Rule 5 because the regex didn't recognize the wrapped invocation as a node call.
 const NODE_INVOKE_PATTERN_SRC =
-  '(?:^|&&|;|\\|)\\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|\'[^\']*\'|\\S+)\\s+)*(?:node|nodejs)\\s+(?:(?:--(?:require|loader|experimental-loader|import|input-type|conditions|inspect-brk|inspect|inspect-port)|-[rCi])\\s+\\S+\\s+|(?:-[^\\s]+\\s+))*(?:"([^"]+)"|\'([^\']+)\'|(\\S+))';
+  '(?:^|&&|;|\\|)\\s*' +
+  // Optional wrapper commands (timeout, nice, env). All consume their args.
+  '(?:timeout\\s+\\d+(?:\\.\\d+)?[smhdSMHD]?\\s+|' +
+  'nice(?:\\s+-n\\s+-?\\d+)?\\s+|' +
+  'env(?:\\s+[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|\'[^\']*\'|\\S+))*\\s+' +
+  ')*' +
+  // Inline env-assignments (FOO=bar BAZ=qux node ...).
+  '(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|\'[^\']*\'|\\S+)\\s+)*' +
+  '(?:node|nodejs)\\s+' +
+  '(?:(?:--(?:require|loader|experimental-loader|import|input-type|conditions|inspect-brk|inspect|inspect-port)|-[rCi])\\s+\\S+\\s+|(?:-[^\\s]+\\s+))*' +
+  '(?:"([^"]+)"|\'([^\']+)\'|(\\S+))';
 
 /** Return all node-script invocations from a command string. */
 function getNodeInvocations(cmd) {

--- a/scripts/workflows/lib/next-script-log.js
+++ b/scripts/workflows/lib/next-script-log.js
@@ -1,0 +1,91 @@
+/**
+ * next-script-log.js
+ *
+ * Append-only JSONL invocation log for the self-paced "next" runners
+ * (task-next.js, brief-next.js) and for write-token mint/consume events
+ * in the hook. One line per event, written synchronously so partial
+ * state survives crashes.
+ *
+ * Logs live under `~/.claude/work-workflow/logs/`:
+ *   - next-scripts.jsonl   — every task-next/brief-next invocation
+ *   - write-token.jsonl    — every token mint and consume attempt
+ *
+ * Set `NEXT_SCRIPT_LOG_DIR=/path` to override the directory.
+ * Set `NEXT_SCRIPT_LOG=0` to disable logging entirely.
+ *
+ * Pure module. No deps beyond `node:fs`/`node:path`/`node:os`.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const DEFAULT_DIR = path.join(os.homedir(), '.claude', 'work-workflow', 'logs');
+
+function logsEnabled() {
+  return process.env.NEXT_SCRIPT_LOG !== '0';
+}
+
+function logDir() {
+  return process.env.NEXT_SCRIPT_LOG_DIR || DEFAULT_DIR;
+}
+
+function logPath(basename) {
+  return path.join(logDir(), basename);
+}
+
+function ensureDir(dir) {
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
+  } catch {
+    /* fail-open */
+  }
+}
+
+/**
+ * Append a JSON record as one line. Synchronous, best-effort, never throws.
+ *
+ * @param {string} file - log basename, e.g. 'next-scripts.jsonl'
+ * @param {object} record - serializable object (ts will be auto-added)
+ */
+function append(file, record) {
+  if (!logsEnabled()) return;
+  try {
+    const dir = logDir();
+    ensureDir(dir);
+    const line =
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        pid: process.pid,
+        ppid: process.ppid,
+        ...record,
+      }) + '\n';
+    fs.appendFileSync(path.join(dir, file), line, { mode: 0o644 });
+  } catch {
+    /* fail-open — telemetry must never break the workflow */
+  }
+}
+
+/**
+ * Convenience wrapper for next-script invocations.
+ */
+function logNextScriptEvent(script, payload) {
+  append('next-scripts.jsonl', { script, ...payload });
+}
+
+/**
+ * Convenience wrapper for write-token events.
+ */
+function logTokenEvent(event, payload) {
+  append('write-token.jsonl', { event, ...payload });
+}
+
+module.exports = {
+  append,
+  logNextScriptEvent,
+  logTokenEvent,
+  logPath,
+  logDir,
+};

--- a/scripts/workflows/lib/parse-completion-status.js
+++ b/scripts/workflows/lib/parse-completion-status.js
@@ -1,0 +1,60 @@
+/**
+ * parse-completion-status.js
+ *
+ * Shared helper for detecting an APPROVED/COMPLETE verdict in check reports
+ * (completion.check.md, tests.check.md, code-review.check.md).
+ *
+ * Why: agents (and the canonical writer in check/scripts/write-completion-report.js)
+ * emit the verdict in multiple equivalent forms — `Status: APPROVED`,
+ * `Final Status\n\n**[COMPLETE]**`, `**Verdict:** **[COMPLETE]**`, etc.
+ * Historically each consumer had its own regex (`/Status:\s*COMPLETE/`) which
+ * only matched the simplest form, so a correctly-written report with
+ * `## Final Status\n**[COMPLETE]**` was rejected. This module centralises a
+ * tolerant matcher used by both work-next.js (work2) and phase1-agents.js
+ * (check2).
+ */
+
+'use strict';
+
+/**
+ * Build a regex that matches any of `verdicts` near a `Status`/`Verdict` label.
+ * Accepts the canonical writer output:
+ *   `## Final Status\n\n**[COMPLETE]**`
+ * the agent-template form:
+ *   `### Final Status:\n[COMPLETE]`
+ * the legacy plain form:
+ *   `Status: APPROVED`
+ * and an alternate label commonly used by reviewers:
+ *   `**Verdict:** **[APPROVED]**`
+ *
+ * Between the label and the verdict only formatting characters
+ * (colon, whitespace incl. newline, asterisk, bracket) may appear — any other
+ * character breaks the match, so it stays specific to the verdict region of
+ * the document and won't false-positive on unrelated prose.
+ *
+ * @param {ReadonlyArray<string>} verdicts — values to match (e.g. ['COMPLETE', 'APPROVED'])
+ * @returns {RegExp}
+ */
+function buildVerdictRegex(verdicts) {
+  if (!Array.isArray(verdicts) || verdicts.length === 0) {
+    throw new TypeError('buildVerdictRegex: verdicts must be a non-empty array');
+  }
+  const alt = verdicts.map(escapeRegex).join('|');
+  // [:\s*] is the only allowed inter-character class between label and verdict.
+  // \[? and \]? allow the bracketed form `[COMPLETE]`.
+  return new RegExp(`(?:Status|Verdict)[:\\s*]*\\[?(${alt})\\]?`, 'i');
+}
+
+/**
+ * Convenience: does `content` contain any of the listed verdicts?
+ */
+function hasVerdict(content, verdicts) {
+  if (typeof content !== 'string' || !content) return false;
+  return buildVerdictRegex(verdicts).test(content);
+}
+
+function escapeRegex(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports = { buildVerdictRegex, hasVerdict };

--- a/scripts/workflows/lib/scripts/__tests__/get-ticket-id-symlink.test.js
+++ b/scripts/workflows/lib/scripts/__tests__/get-ticket-id-symlink.test.js
@@ -1,0 +1,98 @@
+/**
+ * Regression test: getCurrentTaskId() must prefer the git branch over the
+ * worktree cwd path when they disagree (symlinked-worktree scenario).
+ *
+ * Repro of the symlinked-worktree bug: dir was named tabwoah-ECHO-4628
+ * but the checked-out branch was feature/echo-4630-..., so the old code
+ * (cwd-first) returned ECHO-4628 and downstream consumers looked up the
+ * wrong tasks/<id>/ snapshot.
+ *
+ * Run: node --test ./scripts/workflows/lib/scripts/__tests__/get-ticket-id-symlink.test.js
+ */
+
+'use strict';
+
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+function freshRequire(mod) {
+  const resolved = require.resolve(mod);
+  delete require.cache[resolved];
+  return require(mod);
+}
+
+function makeRepo(branchName) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'getticketid-'));
+  execSync(`git init -q -b ${branchName}`, { cwd: dir });
+  execSync('git config user.email t@t', { cwd: dir });
+  execSync('git config user.name t', { cwd: dir });
+  fs.writeFileSync(path.join(dir, 'x'), '');
+  execSync('git add x', { cwd: dir });
+  execSync(['git', 'commit', '-q', '-m', 'init'].join(' '), { cwd: dir });
+  return dir;
+}
+
+const tmpDirs = [];
+afterEach(() => {
+  while (tmpDirs.length) {
+    try {
+      fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+describe('getCurrentTaskId — branch wins over cwd when they disagree', () => {
+  it('cwd says ECHO-4628 but branch says ECHO-4630 → returns ECHO-4630 (the ECHO-4630 follow-up bug)', () => {
+    const realDir = makeRepo('feature/echo-4630-wire-component');
+    tmpDirs.push(realDir);
+    // Simulate "tabwoah-ECHO-4628" worktree dir naming. We can't easily
+    // rename the temp dir, so symlink it to a name that contains the
+    // wrong ticket id and pass THAT as cwd.
+    const linkName = path.join(path.dirname(realDir), 'tabwoah-ECHO-4628');
+    fs.symlinkSync(realDir, linkName);
+    tmpDirs.push(linkName);
+
+    const { getCurrentTaskId } = freshRequire('../get-ticket-id');
+    assert.equal(getCurrentTaskId(linkName), 'ECHO-4630');
+  });
+
+  it('cwd has no ticket pattern; branch has ECHO-9999 → returns ECHO-9999', () => {
+    const dir = makeRepo('feature/echo-9999-some-thing');
+    tmpDirs.push(dir);
+    const { getCurrentTaskId } = freshRequire('../get-ticket-id');
+    assert.equal(getCurrentTaskId(dir), 'ECHO-9999');
+  });
+
+  it('cwd has ticket but branch is generic (main) → falls back to cwd ticket', () => {
+    const dir = makeRepo('main');
+    tmpDirs.push(dir);
+    const linkName = path.join(path.dirname(dir), 'work-PROJ-321');
+    fs.symlinkSync(dir, linkName);
+    tmpDirs.push(linkName);
+    const { getCurrentTaskId } = freshRequire('../get-ticket-id');
+    assert.equal(getCurrentTaskId(linkName), 'PROJ-321');
+  });
+
+  it('git lookup fails (non-existent path) → falls back to cwd matching (test compatibility)', () => {
+    const { getCurrentTaskId } = freshRequire('../get-ticket-id');
+    assert.equal(getCurrentTaskId('/tmp/does/not/exist/work-FOO-7'), 'FOO-7');
+  });
+
+  it('WORK_TICKET_ID env var still wins over everything', () => {
+    const dir = makeRepo('feature/echo-1234-x');
+    tmpDirs.push(dir);
+    const prev = process.env.WORK_TICKET_ID;
+    process.env.WORK_TICKET_ID = 'OVERRIDE-1';
+    try {
+      const { getCurrentTaskId } = freshRequire('../get-ticket-id');
+      assert.equal(getCurrentTaskId(dir), 'OVERRIDE-1');
+    } finally {
+      if (prev === undefined) delete process.env.WORK_TICKET_ID;
+      else process.env.WORK_TICKET_ID = prev;
+    }
+  });
+});

--- a/scripts/workflows/lib/scripts/get-ticket-id.js
+++ b/scripts/workflows/lib/scripts/get-ticket-id.js
@@ -15,27 +15,17 @@ function getCurrentTaskId(cwd = process.cwd()) {
   // Explicit override via env var (used by follow-up2 when running outside worktree)
   if (process.env.WORK_TICKET_ID) return process.env.WORK_TICKET_ID;
 
-  // Try GH-XX pattern first (for GitHub Issues worktree paths like my-project-GH-56)
-  // Return GH-N (path-safe) instead of #N to avoid filesystem issues with # in directory names
-  const ghMatch = cwd.match(GH_PATTERN);
-  if (ghMatch) {
-    return 'GH-' + ghMatch[1];
-  }
-
-  // Try to get from worktree folder name (Jira/Linear: PROJ-123)
-  const worktreeMatch = cwd.match(TICKET_PATTERN);
-  if (worktreeMatch) {
-    return worktreeMatch[1].toUpperCase();
-  }
-
-  // Try to get from git branch name
+  // Prefer git branch over cwd path. In symlinked worktrees (e.g.
+  // w-tabwoah/tabwoah-ECHO-4628/ checked out to a feature/echo-4630-...
+  // branch), the cwd-name lies and the branch is authoritative. We still
+  // fall back to cwd-pattern matching if the git lookup fails (e.g. tests
+  // pass a synthetic cwd that doesn't exist on disk).
   try {
     const branch = execSync('git branch --show-current', {
       cwd,
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
-    // Check GH-XX pattern in branch name
     const branchGhMatch = branch.match(GH_PATTERN);
     if (branchGhMatch) {
       return 'GH-' + branchGhMatch[1];
@@ -45,7 +35,20 @@ function getCurrentTaskId(cwd = process.cwd()) {
       return branchMatch[1].toUpperCase();
     }
   } catch {
-    // Ignore git errors
+    // Ignore git errors — fall through to cwd matching.
+  }
+
+  // Fallback: cwd path. Try GH-XX first (for GitHub Issues worktree paths
+  // like my-project-GH-56). Return GH-N (path-safe) instead of #N to avoid
+  // filesystem issues with # in directory names.
+  const ghMatch = cwd.match(GH_PATTERN);
+  if (ghMatch) {
+    return 'GH-' + ghMatch[1];
+  }
+
+  const worktreeMatch = cwd.match(TICKET_PATTERN);
+  if (worktreeMatch) {
+    return worktreeMatch[1].toUpperCase();
   }
 
   // Fallback: try numeric suffix for GitHub Issues provider

--- a/scripts/workflows/lib/scripts/write-report.js
+++ b/scripts/workflows/lib/scripts/write-report.js
@@ -70,38 +70,61 @@ function ensureTokenDir() {
 }
 
 /**
- * Build the token file path for a given script.
+ * Build the token file path for a given script and (optionally) ticket.
+ * When a ticketId is provided, the path is namespaced as
+ * `<TOKEN_DIR>/<scriptBasename>.<safeTicketId>` so parallel sessions for
+ * DIFFERENT tickets do not collide on the same token file (real incident:
+ * two agents running task-next.js concurrently for ECHO-4465 and
+ * ECHO-4630 — last hook-fire's token clobbered the other's).
+ *
  * @param {string} scriptBasename — e.g. "write-qa-report.js"
+ * @param {string} [ticketId] — optional, when present creates per-ticket token
  * @returns {string} — e.g. "/tmp/.claude-write-tokens/write-qa-report.js"
+ *                    OR "/tmp/.claude-write-tokens/write-qa-report.js.ECHO-4630"
  */
-function tokenPath(scriptBasename) {
+function tokenPath(scriptBasename, ticketId) {
+  if (ticketId && typeof ticketId === 'string') {
+    const safe = ticketId.replace(/[^A-Za-z0-9_-]/g, '_');
+    if (safe.length > 0) return path.join(TOKEN_DIR, `${scriptBasename}.${safe}`);
+  }
   return path.join(TOKEN_DIR, scriptBasename);
 }
 
 /**
  * Read and consume a write token (atomic read + delete).
  * Validates that the token file is a regular file (not a symlink).
+ *
+ * Tries the ticket-keyed path first when a ticketId is provided, falling
+ * back to the unkeyed legacy path for backwards compatibility with
+ * pre-keyed hook mints in flight during a deploy.
+ *
  * @param {string} scriptBasename
+ * @param {string} [ticketId]
  * @returns {{ agent: string, timestamp: number } | null}
  */
-function consumeToken(scriptBasename) {
-  const tp = tokenPath(scriptBasename);
-  try {
-    // Verify the token is a regular file (not a symlink to an unsafe target)
-    const stat = fs.lstatSync(tp);
-    if (!stat.isFile()) return null;
-
-    const raw = fs.readFileSync(tp, 'utf8');
-    // Delete immediately to prevent reuse
+function consumeToken(scriptBasename, ticketId) {
+  const candidates = [];
+  if (ticketId) candidates.push(tokenPath(scriptBasename, ticketId));
+  candidates.push(tokenPath(scriptBasename)); // legacy / unkeyed fallback
+  for (const tp of candidates) {
     try {
-      fs.unlinkSync(tp);
+      // Verify the token is a regular file (not a symlink to an unsafe target)
+      const stat = fs.lstatSync(tp);
+      if (!stat.isFile()) continue;
+
+      const raw = fs.readFileSync(tp, 'utf8');
+      // Delete immediately to prevent reuse
+      try {
+        fs.unlinkSync(tp);
+      } catch {
+        /* already deleted — race is fine */
+      }
+      return JSON.parse(raw);
     } catch {
-      /* already deleted — race is fine */
+      /* missing or unparseable — try next candidate */
     }
-    return JSON.parse(raw);
-  } catch {
-    return null;
   }
+  return null;
 }
 
 /**

--- a/scripts/workflows/work-brief/__tests__/brief-next-cycle.test.js
+++ b/scripts/workflows/work-brief/__tests__/brief-next-cycle.test.js
@@ -1,0 +1,223 @@
+'use strict';
+
+/**
+ * End-to-end smoke test for brief-next.js — walks every phase of the
+ * brief workflow (inputs → overlap → draft → validate → memorize → done)
+ * against a temp-dir synthetic ticket. Spawns brief-next.js directly and
+ * pre-mints the agent-gated token so the hook isn't required.
+ *
+ * The test exists to:
+ *   1. Surface bugs in brief-next.js before real /work2 sessions hit them.
+ *   2. Prove that brief-phase-state.js's record/transition chain works
+ *      after the same auto-init pattern used in task-next.js.
+ *   3. Provide a regression anchor so future edits to either script can't
+ *      silently break the full cycle.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const BRIEF_NEXT = path.resolve(__dirname, '..', 'brief-next.js');
+const TOKEN_DIR = '/tmp/.claude-write-tokens';
+
+function mintToken(scriptBasename) {
+  fs.mkdirSync(TOKEN_DIR, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(
+    path.join(TOKEN_DIR, scriptBasename),
+    JSON.stringify({
+      agent: 'brief-writer',
+      timestamp: Date.now(),
+      tasksBase: null,
+    }),
+    { mode: 0o600 }
+  );
+}
+
+function runBriefNext(ticket, env) {
+  mintToken('brief-next.js');
+  mintToken('brief-phase-state.js');
+  return spawnSync(process.execPath, [BRIEF_NEXT, ticket], {
+    cwd: env.cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      TASKS_BASE: env.TASKS_BASE,
+      NEXT_SCRIPT_LOG: '0',
+    },
+  });
+}
+
+describe('brief-next.js full cycle (regression for the brief pipeline)', () => {
+  let tmp;
+  let tasksBase;
+  let worktree;
+  const ticket = 'GH-99981';
+  let tasksDir;
+  let phaseFile;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'brief-next-'));
+    tasksBase = path.join(tmp, 'tasks');
+    worktree = path.join(tmp, 'wt');
+    tasksDir = path.join(tasksBase, ticket);
+    fs.mkdirSync(tasksDir, { recursive: true });
+    fs.mkdirSync(worktree, { recursive: true });
+
+    // Workspace marker.
+    fs.writeFileSync(
+      path.join(tasksDir, 'ticket.json'),
+      JSON.stringify({ id: ticket, title: 'Add LRU cache to user-profile fetcher' })
+    );
+
+    // Minimal related-tickets.json with no siblings — keeps the test
+    // simple but exercises the manifest-read path.
+    fs.writeFileSync(
+      path.join(tasksDir, 'related-tickets.json'),
+      JSON.stringify({
+        self: { id: ticket, title: 'Add LRU cache' },
+        parent: null,
+        siblings: [],
+        blockedBy: [],
+        dependsOn: [],
+        relatedTo: [],
+        fetchedAt: new Date().toISOString(),
+      })
+    );
+
+    spawnSync('git', ['init', '-q', worktree], { stdio: 'ignore' });
+    phaseFile = path.join(tasksDir, 'brief-phase.json');
+  });
+
+  after(() => {
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('phase 1 — INPUTS: with no linked tickets, advances to overlap immediately', () => {
+    const r = runBriefNext(ticket, { cwd: worktree, TASKS_BASE: tasksBase });
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. Output:\n${combined}`);
+    assert.equal(fs.existsSync(phaseFile), true, 'phase state file should be created by init');
+
+    const state = JSON.parse(fs.readFileSync(phaseFile, 'utf8'));
+    assert.equal(
+      state.currentPhase,
+      'overlap',
+      `expected currentPhase=overlap, got ${state.currentPhase}`
+    );
+    assert.ok(state.phases?.inputs, 'inputs phase evidence should be recorded');
+  });
+
+  it('phase 2 — OVERLAP: writing sibling-overlap.md (empty since no siblings) advances to draft', () => {
+    // With zero linked tickets, the overlap analysis still requires the file
+    // to exist (the script validates one section per linked ticket; zero
+    // tickets = no required sections, so an empty file should pass).
+    fs.writeFileSync(
+      path.join(tasksDir, 'sibling-overlap.md'),
+      '# Sibling Overlap Analysis\n\n_No linked tickets._\n'
+    );
+
+    const r = runBriefNext(ticket, { cwd: worktree, TASKS_BASE: tasksBase });
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. Output:\n${combined}`);
+
+    const state = JSON.parse(fs.readFileSync(phaseFile, 'utf8'));
+    assert.equal(
+      state.currentPhase,
+      'draft',
+      `expected currentPhase=draft, got ${state.currentPhase}`
+    );
+    assert.ok(state.phases?.overlap, 'overlap phase evidence should be recorded');
+  });
+
+  it('phase 3 — DRAFT: writing complete brief.md advances to validate', () => {
+    fs.writeFileSync(
+      path.join(tasksDir, 'brief.md'),
+      [
+        '# Brief: Add LRU cache',
+        '',
+        '## Problem Statement',
+        'Repeat fetches of user profiles hammer the upstream service.',
+        '',
+        '## Goal',
+        'Cut downstream traffic ~80% via an in-process LRU cache.',
+        '',
+        '## Target Users',
+        '- Internal services calling fetchUserProfile()',
+        '',
+        '## Requirements',
+        '### Must Have (P0)',
+        '1. LRU cache with 50-entry cap and 60s TTL in front of fetchUserProfile().',
+        '',
+        '## Constraints',
+        '- Per-process, not shared across workers.',
+        '',
+        '## Out of scope (sibling-owned)',
+        '_None._',
+        '',
+        '## Success Metrics',
+        '- 80% reduction in downstream fetch volume in load tests.',
+        '',
+        '## Open Questions',
+        '- _None._',
+        '',
+      ].join('\n')
+    );
+
+    const r = runBriefNext(ticket, { cwd: worktree, TASKS_BASE: tasksBase });
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. Output:\n${combined}`);
+
+    const state = JSON.parse(fs.readFileSync(phaseFile, 'utf8'));
+    assert.equal(
+      state.currentPhase,
+      'validate',
+      `expected currentPhase=validate, got ${state.currentPhase}`
+    );
+    assert.ok(state.phases?.draft, 'draft phase evidence should be recorded');
+  });
+
+  it('phase 4 — VALIDATE: cross-checks pass, advances to memorize', () => {
+    const r = runBriefNext(ticket, { cwd: worktree, TASKS_BASE: tasksBase });
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. Output:\n${combined}`);
+
+    const state = JSON.parse(fs.readFileSync(phaseFile, 'utf8'));
+    assert.equal(
+      state.currentPhase,
+      'memorize',
+      `expected currentPhase=memorize, got ${state.currentPhase}`
+    );
+    assert.ok(state.phases?.validate, 'validate phase evidence should be recorded');
+  });
+
+  it('phase 5 — MEMORIZE: auto-completes when no memory plugin detected', () => {
+    // detectMemoryPlugin() scans ~/.claude/plugins/{marketplaces,cache}
+    // for cortex/mem0. In CI / tmp-only runs there is none, so the script
+    // should record memorize with summary=no-memory-plugin and advance to done.
+    const r = runBriefNext(ticket, { cwd: worktree, TASKS_BASE: tasksBase });
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. Output:\n${combined}`);
+
+    const state = JSON.parse(fs.readFileSync(phaseFile, 'utf8'));
+    // If a real memory plugin is present on the dev box, currentPhase
+    // stays at memorize (agent has to touch .brief-memorized). Accept
+    // either done OR memorize so the test isn't flaky on dev boxes.
+    assert.ok(
+      state.currentPhase === 'done' || state.currentPhase === 'memorize',
+      `expected currentPhase=done|memorize, got ${state.currentPhase}`
+    );
+    assert.ok(
+      state.phases?.memorize || state.currentPhase === 'memorize',
+      'memorize phase should have been recorded OR still be current'
+    );
+  });
+});

--- a/scripts/workflows/work-brief/__tests__/brief-phase-registry.test.js
+++ b/scripts/workflows/work-brief/__tests__/brief-phase-registry.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests for brief-phase-registry.js
+ *
+ * Run with: node --test scripts/workflows/work-brief/__tests__/brief-phase-registry.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  BRIEF_PHASES,
+  BRIEF_PHASE_ORDER,
+  BRIEF_PHASE_TRANSITIONS,
+  BRIEF_INITIAL_PHASE,
+  BRIEF_TERMINAL_PHASE,
+  briefNextPhases,
+  briefCanTransition,
+  isBriefPhase,
+} = require('../brief-phase-registry');
+
+describe('brief-phase-registry', () => {
+  it('exposes all six phases in canonical order', () => {
+    assert.deepEqual(
+      [...BRIEF_PHASE_ORDER],
+      ['inputs', 'overlap', 'draft', 'validate', 'memorize', 'done']
+    );
+    for (const p of BRIEF_PHASE_ORDER) {
+      assert.equal(BRIEF_PHASES[p], p);
+    }
+  });
+
+  it('initial and terminal phases match the linear flow', () => {
+    assert.equal(BRIEF_INITIAL_PHASE, 'inputs');
+    assert.equal(BRIEF_TERMINAL_PHASE, 'done');
+  });
+
+  it('linear single-edge transitions: each phase has exactly one successor (except done)', () => {
+    assert.deepEqual([...BRIEF_PHASE_TRANSITIONS.inputs], ['overlap']);
+    assert.deepEqual([...BRIEF_PHASE_TRANSITIONS.overlap], ['draft']);
+    assert.deepEqual([...BRIEF_PHASE_TRANSITIONS.draft], ['validate']);
+    assert.deepEqual([...BRIEF_PHASE_TRANSITIONS.validate], ['memorize']);
+    assert.deepEqual([...BRIEF_PHASE_TRANSITIONS.memorize], ['done']);
+    assert.deepEqual([...BRIEF_PHASE_TRANSITIONS.done], []);
+  });
+
+  it('briefNextPhases returns successors and [] for terminal', () => {
+    assert.deepEqual([...briefNextPhases('inputs')], ['overlap']);
+    assert.deepEqual([...briefNextPhases('done')], []);
+    assert.deepEqual([...briefNextPhases('unknown')], []);
+  });
+
+  it('briefCanTransition allows only declared edges', () => {
+    assert.equal(briefCanTransition('inputs', 'overlap'), true);
+    assert.equal(briefCanTransition('overlap', 'draft'), true);
+    assert.equal(briefCanTransition('memorize', 'done'), true);
+    // Disallowed: skipping, going backwards, leaving terminal.
+    assert.equal(briefCanTransition('inputs', 'draft'), false);
+    assert.equal(briefCanTransition('draft', 'inputs'), false);
+    assert.equal(briefCanTransition('done', 'inputs'), false);
+    assert.equal(briefCanTransition('done', 'memorize'), false);
+    assert.equal(briefCanTransition('garbage', 'inputs'), false);
+  });
+
+  it('isBriefPhase recognizes only the six phases', () => {
+    for (const p of BRIEF_PHASE_ORDER) assert.equal(isBriefPhase(p), true);
+    assert.equal(isBriefPhase('red'), false);
+    assert.equal(isBriefPhase('inputs '), false);
+    assert.equal(isBriefPhase(''), false);
+    assert.equal(isBriefPhase(undefined), false);
+  });
+
+  it('exports are frozen — no accidental mutation', () => {
+    assert.throws(() => {
+      BRIEF_PHASES.extra = 'oops';
+    });
+    assert.throws(() => {
+      BRIEF_PHASE_ORDER.push('extra');
+    });
+    assert.throws(() => {
+      BRIEF_PHASE_TRANSITIONS.inputs = ['draft'];
+    });
+  });
+});

--- a/scripts/workflows/work-brief/__tests__/memory-plugin-config.test.js
+++ b/scripts/workflows/work-brief/__tests__/memory-plugin-config.test.js
@@ -1,0 +1,153 @@
+/**
+ * Tests for lib/memory-plugin-config.js
+ *
+ * Run: node --test ./scripts/workflows/work-brief/__tests__/memory-plugin-config.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadMemoryPluginCandidates,
+  DEFAULT_CANDIDATES,
+  DEFAULT_MANIFEST_GLOB,
+} = require('../lib/memory-plugin-config');
+
+describe('memory-plugin-config — env-driven detection list', () => {
+  it('default env returns built-in cortex + mem0 candidates', () => {
+    const list = loadMemoryPluginCandidates({});
+    assert.equal(list.length, 2);
+    assert.equal(list[0].name, 'cortex');
+    assert.equal(list[1].name, 'mem0');
+    assert.ok(list[0].probe instanceof RegExp);
+    assert.equal(list[0].recallTool, DEFAULT_CANDIDATES[0].recallTool);
+  });
+
+  it('BRIEF_MEMORY_DISABLED=1 returns []', () => {
+    assert.deepEqual(loadMemoryPluginCandidates({ BRIEF_MEMORY_DISABLED: '1' }), []);
+    assert.deepEqual(loadMemoryPluginCandidates({ BRIEF_MEMORY_DISABLED: 'true' }), []);
+    assert.deepEqual(loadMemoryPluginCandidates({ BRIEF_MEMORY_DISABLED: 'yes' }), []);
+  });
+
+  it('BRIEF_MEMORY_DISABLED falsy values do NOT disable', () => {
+    assert.equal(loadMemoryPluginCandidates({ BRIEF_MEMORY_DISABLED: '' }).length, 2);
+    assert.equal(loadMemoryPluginCandidates({ BRIEF_MEMORY_DISABLED: '0' }).length, 2);
+  });
+
+  it('BRIEF_MEMORY_PLUGIN_DIRS overrides manifest glob for built-in candidates', () => {
+    const list = loadMemoryPluginCandidates({
+      BRIEF_MEMORY_PLUGIN_DIRS: 'custom/dir1:custom/dir2',
+    });
+    assert.deepEqual(list[0].manifestGlob, ['custom/dir1', 'custom/dir2']);
+    assert.deepEqual(list[1].manifestGlob, ['custom/dir1', 'custom/dir2']);
+  });
+
+  it('per-plugin tool overrides apply to recall/remember/save', () => {
+    const list = loadMemoryPluginCandidates({
+      BRIEF_MEMORY_CORTEX_RECALL_TOOL: 'my_recall',
+      BRIEF_MEMORY_CORTEX_REMEMBER_TOOL: 'my_remember',
+      BRIEF_MEMORY_CORTEX_SAVE_TOOL: 'my_save',
+    });
+    const cortex = list.find((c) => c.name === 'cortex');
+    assert.equal(cortex.recallTool, 'my_recall');
+    assert.equal(cortex.rememberTool, 'my_remember');
+    assert.equal(cortex.saveTool, 'my_save');
+    // mem0 untouched
+    const mem0 = list.find((c) => c.name === 'mem0');
+    assert.equal(mem0.rememberTool, DEFAULT_CANDIDATES[1].rememberTool);
+  });
+
+  it('BRIEF_MEMORY_<NAME>_SAVE_TOOL=none clears saveTool', () => {
+    const list = loadMemoryPluginCandidates({
+      BRIEF_MEMORY_CORTEX_SAVE_TOOL: 'none',
+    });
+    assert.equal(list.find((c) => c.name === 'cortex').saveTool, null);
+  });
+
+  it('BRIEF_MEMORY_PLUGINS_JSON fully replaces defaults', () => {
+    const customJson = JSON.stringify([
+      {
+        name: 'mythril',
+        probe: 'mythril|myth',
+        recallTool: 'myth_recall',
+        rememberTool: 'myth_remember',
+        saveTool: 'myth_save',
+      },
+    ]);
+    const list = loadMemoryPluginCandidates({ BRIEF_MEMORY_PLUGINS_JSON: customJson });
+    assert.equal(list.length, 1);
+    assert.equal(list[0].name, 'mythril');
+    assert.ok(list[0].probe instanceof RegExp);
+    assert.ok(list[0].probe.test('mythril-plugin-v1'));
+    assert.equal(list[0].recallTool, 'myth_recall');
+    assert.deepEqual(list[0].manifestGlob, DEFAULT_MANIFEST_GLOB);
+  });
+
+  it('BRIEF_MEMORY_PLUGINS_JSON respects per-entry manifestGlob', () => {
+    const customJson = JSON.stringify([
+      {
+        name: 'x',
+        probe: 'x',
+        recallTool: 'r',
+        rememberTool: 'rm',
+        manifestGlob: ['custom/x'],
+      },
+    ]);
+    const list = loadMemoryPluginCandidates({ BRIEF_MEMORY_PLUGINS_JSON: customJson });
+    assert.deepEqual(list[0].manifestGlob, ['custom/x']);
+  });
+
+  it('invalid BRIEF_MEMORY_PLUGINS_JSON (not array) falls back to defaults', () => {
+    // Suppress stderr in test.
+    const origWrite = process.stderr.write;
+    process.stderr.write = () => true;
+    try {
+      const list = loadMemoryPluginCandidates({ BRIEF_MEMORY_PLUGINS_JSON: '{"name":"oops"}' });
+      assert.equal(list.length, 2);
+      assert.equal(list[0].name, 'cortex');
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it('invalid BRIEF_MEMORY_PLUGINS_JSON (bad JSON) falls back to defaults', () => {
+    const origWrite = process.stderr.write;
+    process.stderr.write = () => true;
+    try {
+      const list = loadMemoryPluginCandidates({ BRIEF_MEMORY_PLUGINS_JSON: 'not json' });
+      assert.equal(list.length, 2);
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it('BRIEF_MEMORY_PLUGINS_JSON entry missing required fields is skipped', () => {
+    const origWrite = process.stderr.write;
+    process.stderr.write = () => true;
+    try {
+      const customJson = JSON.stringify([
+        { name: 'incomplete', probe: 'x' }, // missing recallTool/rememberTool
+        { name: 'good', probe: 'good', recallTool: 'r', rememberTool: 'rm' },
+      ]);
+      const list = loadMemoryPluginCandidates({ BRIEF_MEMORY_PLUGINS_JSON: customJson });
+      assert.equal(list.length, 1);
+      assert.equal(list[0].name, 'good');
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it('default candidates remain frozen — load does not mutate them', () => {
+    const list = loadMemoryPluginCandidates({
+      BRIEF_MEMORY_CORTEX_RECALL_TOOL: 'override',
+      BRIEF_MEMORY_PLUGIN_DIRS: 'x:y',
+    });
+    assert.equal(list[0].recallTool, 'override');
+    // Re-load WITHOUT env overrides: must still be the original defaults.
+    const fresh = loadMemoryPluginCandidates({});
+    assert.equal(fresh[0].recallTool, DEFAULT_CANDIDATES[0].recallTool);
+    assert.deepEqual(fresh[0].manifestGlob, DEFAULT_MANIFEST_GLOB);
+  });
+});

--- a/scripts/workflows/work-brief/__tests__/phase-registry.test.js
+++ b/scripts/workflows/work-brief/__tests__/phase-registry.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tests for the brief phase dispatcher (lib/phase-registry.js).
+ *
+ * Run: node --test ./scripts/workflows/work-brief/__tests__/phase-registry.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { BRIEF_PHASES, BRIEF_PHASE_ORDER } = require('../brief-phase-registry');
+const { getPhase, hasPhase } = require('../lib/phase-registry');
+
+describe('lib/phase-registry — modular brief phase dispatcher', () => {
+  it('registers every phase from BRIEF_PHASES', () => {
+    for (const name of BRIEF_PHASE_ORDER) {
+      assert.equal(hasPhase(name), true, `phase "${name}" must be registered`);
+    }
+  });
+
+  it('every handler exposes validate() and instructions()', () => {
+    for (const name of BRIEF_PHASE_ORDER) {
+      const h = getPhase(name);
+      assert.equal(typeof h.validate, 'function', `${name}.validate must be a function`);
+      assert.equal(typeof h.instructions, 'function', `${name}.instructions must be a function`);
+    }
+  });
+
+  it('handler.next matches the registry transition graph', () => {
+    const expected = {
+      inputs: BRIEF_PHASES.overlap,
+      overlap: BRIEF_PHASES.draft,
+      draft: BRIEF_PHASES.validate,
+      validate: BRIEF_PHASES.memorize,
+      memorize: BRIEF_PHASES.done,
+      done: null,
+    };
+    for (const [name, next] of Object.entries(expected)) {
+      assert.equal(getPhase(name).next, next, `${name}.next must equal ${next}`);
+    }
+  });
+
+  it('getPhase throws for unknown phases', () => {
+    assert.throws(() => getPhase('not-a-phase'));
+    assert.equal(hasPhase('not-a-phase'), false);
+  });
+
+  it('terminal phase (done) returns ok:false with no errors — no advance possible', () => {
+    const v = getPhase(BRIEF_PHASES.done).validate({});
+    assert.equal(v.ok, false);
+    assert.deepEqual(v.errors || [], []);
+  });
+
+  it('memorize: no memory plugin → auto-advance (ok:true with summary)', () => {
+    const v = getPhase(BRIEF_PHASES.memorize).validate({
+      memory: null,
+      tasksDir: '/tmp/nonexistent',
+    });
+    assert.equal(v.ok, true);
+    assert.match(v.summary, /no-memory-plugin/);
+  });
+
+  it('inputs handler returns useful errors when manifest missing', () => {
+    const v = getPhase(BRIEF_PHASES.inputs).validate({
+      tasksDir: '/tmp/nonexistent',
+      manifest: null,
+      linkedIds: [],
+      memory: null,
+    });
+    assert.equal(v.ok, false);
+    assert.ok(Array.isArray(v.errors));
+    assert.match(v.errors[0], /related-tickets\.json missing/);
+  });
+
+  it('inputs handler returns ok:true when manifest exists and no linked tickets', () => {
+    const v = getPhase(BRIEF_PHASES.inputs).validate({
+      tasksDir: '/tmp/nonexistent',
+      manifest: { parent: null, siblings: [] },
+      linkedIds: [],
+      memory: { name: 'cortex' },
+    });
+    assert.equal(v.ok, true);
+    assert.match(v.summary, /linked=0/);
+    assert.match(v.summary, /memory=cortex/);
+  });
+
+  it('instructions() returns a non-empty markdown string for every phase', () => {
+    const ctx = {
+      ticket: 'TEST-1',
+      tasksDir: '/tmp/x',
+      linkedIds: [],
+      manifest: null,
+      memory: null,
+    };
+    for (const name of BRIEF_PHASE_ORDER) {
+      const md = getPhase(name).instructions(ctx);
+      assert.equal(typeof md, 'string');
+      assert.ok(md.length > 20, `${name} instructions must be non-trivial markdown`);
+    }
+  });
+});

--- a/scripts/workflows/work-brief/brief-next.js
+++ b/scripts/workflows/work-brief/brief-next.js
@@ -36,6 +36,8 @@ const { spawnSync } = require('node:child_process');
 
 const BRIEF_PHASE_CLI = path.resolve(__dirname, 'brief-phase-state.js');
 
+const { BRIEF_PHASES, BRIEF_INITIAL_PHASE, briefNextPhases } = require('./brief-phase-registry');
+
 let logNextScriptEvent;
 try {
   ({ logNextScriptEvent } = require('../lib/next-script-log'));
@@ -586,7 +588,7 @@ function main(argv) {
   const worktreeRoot = resolveWorktreeRoot() || path.dirname(tasksBase);
 
   ensureInit(ticket);
-  let phase = getCurrentPhase(ticket) || 'inputs';
+  let phase = getCurrentPhase(ticket) || BRIEF_INITIAL_PHASE;
 
   const ctx = { ticket, tasksDir, tasksBase, manifest, linkedIds, memory, worktreeRoot };
 
@@ -595,108 +597,72 @@ function main(argv) {
   let blockReason = '';
   let advanced = false;
 
-  if (phase === 'inputs') {
+  // advanceAfter(target, summary) — record current phase + transition to target.
+  // Returns true on success; on failure sets blockReason and returns false.
+  const advanceAfter = (target, summary) => {
+    const r = recordPhase(ticket, phase, summary);
+    if (r.code !== 0) {
+      blockReason = `Could not record phase ${phase}:\n${r.out}`;
+      return false;
+    }
+    const t = transitionPhase(ticket, target);
+    if (t.code !== 0) {
+      blockReason = `Could not transition to ${target}:\n${t.out}`;
+      return false;
+    }
+    advanced = true;
+    phase = target;
+    return true;
+  };
+
+  if (phase === BRIEF_PHASES.inputs) {
     if (!manifest) {
       blockReason = `related-tickets.json missing at ${path.join(tasksDir, 'related-tickets.json')}. Cannot proceed without sibling context.`;
     } else {
       const errs = validateInputs(tasksDir, manifest, linkedIds);
-      if (errs.length === 0 && linkedIds.length >= 0) {
-        const r = recordPhase(
-          ticket,
-          'inputs',
+      if (errs.length === 0) {
+        advanceAfter(
+          briefNextPhases(BRIEF_PHASES.inputs)[0],
           `linked=${linkedIds.length} memory=${memory ? memory.name : 'none'}`
         );
-        if (r.code !== 0) blockReason = `Could not record phase inputs:\n${r.out}`;
-        else {
-          const t = transitionPhase(ticket, 'overlap');
-          if (t.code !== 0) blockReason = `Could not transition to overlap:\n${t.out}`;
-          else {
-            advanced = true;
-            phase = 'overlap';
-          }
-        }
-      } else if (errs.length > 0) {
+      } else {
         blockReason = errs.join('\n');
       }
     }
-  } else if (phase === 'overlap') {
+  } else if (phase === BRIEF_PHASES.overlap) {
     const errs = validateOverlap(tasksDir, linkedIds);
     if (errs.length === 0) {
-      const r = recordPhase(ticket, 'overlap', `siblings=${linkedIds.length}`);
-      if (r.code !== 0) blockReason = `Could not record phase overlap:\n${r.out}`;
-      else {
-        const t = transitionPhase(ticket, 'draft');
-        if (t.code !== 0) blockReason = `Could not transition to draft:\n${t.out}`;
-        else {
-          advanced = true;
-          phase = 'draft';
-        }
-      }
+      advanceAfter(briefNextPhases(BRIEF_PHASES.overlap)[0], `siblings=${linkedIds.length}`);
     } else {
       blockReason = errs.join('\n');
     }
-  } else if (phase === 'draft') {
+  } else if (phase === BRIEF_PHASES.draft) {
     const errs = validateDraft(tasksDir);
     if (errs.length === 0) {
-      const r = recordPhase(ticket, 'draft', 'brief.md drafted');
-      if (r.code !== 0) blockReason = `Could not record phase draft:\n${r.out}`;
-      else {
-        const t = transitionPhase(ticket, 'validate');
-        if (t.code !== 0) blockReason = `Could not transition to validate:\n${t.out}`;
-        else {
-          advanced = true;
-          phase = 'validate';
-        }
-      }
+      advanceAfter(briefNextPhases(BRIEF_PHASES.draft)[0], 'brief.md drafted');
     } else {
       blockReason = errs.join('\n');
     }
-  } else if (phase === 'validate') {
+  } else if (phase === BRIEF_PHASES.validate) {
     const errs = validateValidate(tasksDir, linkedIds);
     if (errs.length === 0) {
-      const r = recordPhase(ticket, 'validate', 'cross-checks ok');
-      if (r.code !== 0) blockReason = `Could not record phase validate:\n${r.out}`;
-      else {
-        const t = transitionPhase(ticket, 'memorize');
-        if (t.code !== 0) blockReason = `Could not transition to memorize:\n${t.out}`;
-        else {
-          advanced = true;
-          phase = 'memorize';
-        }
-      }
+      advanceAfter(briefNextPhases(BRIEF_PHASES.validate)[0], 'cross-checks ok');
     } else {
       blockReason = errs.join('\n');
     }
-  } else if (phase === 'memorize') {
+  } else if (phase === BRIEF_PHASES.memorize) {
     // We can't verify memory writes (no introspection across plugins).
     // Record on re-invoke; if no memory plugin, auto-advance.
+    const target = briefNextPhases(BRIEF_PHASES.memorize)[0];
     if (!memory) {
-      const r = recordPhase(ticket, 'memorize', 'no-memory-plugin');
-      if (r.code !== 0) blockReason = `Could not record phase memorize:\n${r.out}`;
-      else {
-        const t = transitionPhase(ticket, 'done');
-        if (t.code !== 0) blockReason = `Could not transition to done:\n${t.out}`;
-        else {
-          advanced = true;
-          phase = 'done';
-        }
-      }
+      advanceAfter(target, 'no-memory-plugin');
     } else {
       // First call in memorize prints instructions. Second call (when agent
       // has finished saving) advances. We detect "second call" by the
       // presence of a sentinel file the agent must touch after persisting.
       const sentinel = path.join(tasksDir, '.brief-memorized');
       if (fs.existsSync(sentinel)) {
-        const r = recordPhase(ticket, 'memorize', `via=${memory.name}`);
-        if (r.code !== 0) blockReason = `Could not record phase memorize:\n${r.out}`;
-        else {
-          const t = transitionPhase(ticket, 'done');
-          if (t.code !== 0) blockReason = `Could not transition to done:\n${t.out}`;
-          else {
-            advanced = true;
-            phase = 'done';
-          }
-        }
+        advanceAfter(target, `via=${memory.name}`);
       }
     }
   }
@@ -712,6 +678,16 @@ function main(argv) {
     '',
   ].join('\n');
 
+  const INSTRUCTORS = {
+    [BRIEF_PHASES.inputs]: instructInputs,
+    [BRIEF_PHASES.overlap]: instructOverlap,
+    [BRIEF_PHASES.draft]: instructDraft,
+    [BRIEF_PHASES.validate]: instructValidate,
+    [BRIEF_PHASES.memorize]: instructMemorize,
+    [BRIEF_PHASES.done]: instructDone,
+  };
+  const instructFor = (p) => (INSTRUCTORS[p] || instructMemorize)(ctx);
+
   let body;
   if (blockReason && !advanced) {
     body = [
@@ -723,29 +699,10 @@ function main(argv) {
       '',
       '---',
       '',
-      phase === 'inputs'
-        ? instructInputs(ctx)
-        : phase === 'overlap'
-          ? instructOverlap(ctx)
-          : phase === 'draft'
-            ? instructDraft(ctx)
-            : phase === 'validate'
-              ? instructValidate(ctx)
-              : instructMemorize(ctx),
+      instructFor(phase),
     ].join('\n');
   } else {
-    body =
-      phase === 'inputs'
-        ? instructInputs(ctx)
-        : phase === 'overlap'
-          ? instructOverlap(ctx)
-          : phase === 'draft'
-            ? instructDraft(ctx)
-            : phase === 'validate'
-              ? instructValidate(ctx)
-              : phase === 'memorize'
-                ? instructMemorize(ctx)
-                : instructDone(ctx);
+    body = instructFor(phase);
   }
 
   process.stdout.write(header + '\n' + body);
@@ -773,4 +730,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { detectMemoryPlugin };
+module.exports = { detectMemoryPlugin, BRIEF_PHASES };

--- a/scripts/workflows/work-brief/brief-next.js
+++ b/scripts/workflows/work-brief/brief-next.js
@@ -31,6 +31,7 @@ const BRIEF_PHASE_CLI = path.resolve(__dirname, 'brief-phase-state.js');
 
 const { BRIEF_INITIAL_PHASE } = require('./brief-phase-registry');
 const { getPhase } = require('./lib/phase-registry');
+const { loadMemoryPluginCandidates } = require('./lib/memory-plugin-config');
 
 let logNextScriptEvent;
 try {
@@ -99,30 +100,15 @@ function mintCompanionToken() {
 // ─── Memory plugin detection ───────────────────────────────────────────────
 
 /**
- * Detect installed memory plugins (cortex, mem0, anything that exposes
- * recall/remember tools). Returns { name, recallTool, rememberTool } or null.
+ * Detect installed memory plugins (cortex, mem0, or any operator-defined
+ * plugin from BRIEF_MEMORY_PLUGINS_JSON). The candidate list comes from
+ * `lib/memory-plugin-config.js` so detection rules are configurable via env.
+ * Returns `{ name, recallTool, rememberTool, saveTool }` or null.
  * Exported for test coverage.
  */
-function detectMemoryPlugin() {
+function detectMemoryPlugin(env = process.env) {
   const home = require('node:os').homedir();
-  const candidates = [
-    {
-      manifestGlob: ['.claude/plugins/marketplaces', '.claude/plugins/cache'],
-      probe: /cortex/i,
-      name: 'cortex',
-      recallTool: 'mcp__plugin_cortex_cortex__cortex_recall',
-      rememberTool: 'mcp__plugin_cortex_cortex__cortex_remember',
-      saveTool: 'mcp__plugin_cortex_cortex__cortex_save',
-    },
-    {
-      manifestGlob: ['.claude/plugins/marketplaces', '.claude/plugins/cache'],
-      probe: /mem0/i,
-      name: 'mem0',
-      recallTool: 'mem0_recall',
-      rememberTool: 'mem0_remember',
-      saveTool: null,
-    },
-  ];
+  const candidates = loadMemoryPluginCandidates(env);
   for (const c of candidates) {
     for (const base of c.manifestGlob) {
       const dir = path.join(home, base);

--- a/scripts/workflows/work-brief/brief-next.js
+++ b/scripts/workflows/work-brief/brief-next.js
@@ -1,0 +1,737 @@
+#!/usr/bin/env node
+
+/**
+ * brief-next.js
+ *
+ * Self-paced runner for the `brief` step, modeled on task-next.js for
+ * `implement`. The agent invokes this script and follows the Markdown
+ * response. Each phase validates artifacts, records evidence, and
+ * advances. Phases (in order):
+ *
+ *   1. inputs    — recall memory, fetch ticket + every linked ticket's
+ *                  FULL content (not just titles), save to _related/.
+ *   2. overlap   — analyze overlaps with each linked ticket, write
+ *                  sibling-overlap.md with one section per linked ticket
+ *                  and a verdict (sibling-owned | shared | no-overlap).
+ *   3. draft     — investigate docs for ambiguities, then write brief.md
+ *                  with required sections. Each Open Question entry MUST
+ *                  carry a `Searched:` annotation listing the paths/queries
+ *                  consulted, OR the section is empty.
+ *   4. validate  — re-check section presence, AC→P0 mapping, and that
+ *                  brief.md's `Out of scope (sibling-owned)` reflects the
+ *                  sibling-owned verdicts from sibling-overlap.md.
+ *   5. memorize  — persist decisions via the installed memory plugin
+ *                  (e.g. cortex). Skipped with a warning if none detected.
+ *
+ * The script is the source of truth for what to do at every phase. The
+ * agent only sees the printed Markdown; it does not need to know the
+ * gate logic.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const BRIEF_PHASE_CLI = path.resolve(__dirname, 'brief-phase-state.js');
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+let config;
+try {
+  config = require('../lib/config');
+} catch {
+  config = null;
+}
+
+function resolveTasksBase() {
+  return (
+    process.env.TASKS_BASE ||
+    (config && config.TASKS_BASE) ||
+    path.join(require('node:os').homedir(), 'worktrees', 'tasks')
+  );
+}
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function die(msg) {
+  process.stderr.write(`brief-next: ${msg}\n`);
+  process.exit(2);
+}
+
+function resolveWorktreeRoot() {
+  const r = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+// ─── Token snapshot/remint (mirrors task-next.js) ──────────────────────────
+
+let _companionTokenSnapshot = null;
+
+function snapshotCompanionToken(scriptBasename) {
+  try {
+    const dir = process.env.CLAUDE_WRITE_TOKEN_DIR || '/tmp/.claude-write-tokens';
+    const file = path.join(dir, scriptBasename);
+    if (!fs.existsSync(file)) return;
+    const raw = fs.readFileSync(file, 'utf8');
+    const data = JSON.parse(raw);
+    _companionTokenSnapshot = { path: file, data };
+  } catch {
+    /* fail-open — phase recording will surface the missing token */
+  }
+}
+
+function mintCompanionToken() {
+  if (!_companionTokenSnapshot) return false;
+  try {
+    fs.mkdirSync(path.dirname(_companionTokenSnapshot.path), { recursive: true, mode: 0o700 });
+    const data = { ..._companionTokenSnapshot.data, timestamp: Date.now() };
+    fs.writeFileSync(_companionTokenSnapshot.path, JSON.stringify(data), { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ─── Memory plugin detection ───────────────────────────────────────────────
+
+/**
+ * Detect installed memory plugins (cortex, mem0, anything that exposes
+ * recall/remember tools). Returns { name, recallTool, rememberTool } or
+ * null. The check looks for known plugin manifest paths under ~/.claude/.
+ */
+function detectMemoryPlugin() {
+  const home = require('node:os').homedir();
+  const candidates = [
+    {
+      manifestGlob: ['.claude/plugins/marketplaces', '.claude/plugins/cache'],
+      probe: /cortex/i,
+      name: 'cortex',
+      recallTool: 'mcp__plugin_cortex_cortex__cortex_recall',
+      rememberTool: 'mcp__plugin_cortex_cortex__cortex_remember',
+      saveTool: 'mcp__plugin_cortex_cortex__cortex_save',
+    },
+    {
+      manifestGlob: ['.claude/plugins/marketplaces', '.claude/plugins/cache'],
+      probe: /mem0/i,
+      name: 'mem0',
+      recallTool: 'mem0_recall',
+      rememberTool: 'mem0_remember',
+      saveTool: null,
+    },
+  ];
+  for (const c of candidates) {
+    for (const base of c.manifestGlob) {
+      const dir = path.join(home, base);
+      if (!fs.existsSync(dir)) continue;
+      let entries;
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      if (entries.some((e) => c.probe.test(e.name))) {
+        return c;
+      }
+    }
+  }
+  return null;
+}
+
+// ─── related-tickets.json reading ──────────────────────────────────────────
+
+function readRelatedManifest(tasksDir) {
+  const p = path.join(tasksDir, 'related-tickets.json');
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function listLinkedIds(manifest) {
+  if (!manifest) return [];
+  const ids = new Set();
+  if (manifest.parent && manifest.parent.id) ids.add(manifest.parent.id);
+  for (const key of ['siblings', 'blockedBy', 'dependsOn', 'relatedTo']) {
+    for (const e of manifest[key] || []) if (e && e.id) ids.add(e.id);
+  }
+  return [...ids];
+}
+
+// ─── Phase state CLI wrappers ──────────────────────────────────────────────
+
+function callPhaseCli(args) {
+  mintCompanionToken();
+  const r = spawnSync(process.execPath, [BRIEF_PHASE_CLI, ...args], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return { code: r.status ?? -1, out: (r.stdout || '') + (r.stderr || '') };
+}
+
+function getCurrentPhase(ticket) {
+  const r = callPhaseCli(['current', ticket]);
+  if (r.code !== 0) return null;
+  try {
+    const j = JSON.parse(r.out.trim().split('\n').pop());
+    return j.currentPhase;
+  } catch {
+    return null;
+  }
+}
+
+function ensureInit(ticket) {
+  const r = callPhaseCli(['init', ticket]);
+  if (r.code !== 0) die(`Could not init brief-phase state:\n${r.out}`);
+}
+
+function recordPhase(ticket, phase, summary) {
+  return callPhaseCli(['record', ticket, phase, '--summary', summary || '']);
+}
+
+function transitionPhase(ticket, target) {
+  return callPhaseCli(['transition', ticket, target]);
+}
+
+// ─── Phase validation logic ────────────────────────────────────────────────
+
+function validateInputs(tasksDir, manifest, linkedIds) {
+  const errors = [];
+  const relDir = path.join(tasksDir, '_related');
+  if (!fs.existsSync(relDir)) {
+    errors.push(
+      `Missing directory ${relDir}. Save each linked ticket's full content as ${relDir}/<TICKET-ID>.md.`
+    );
+    return errors;
+  }
+  for (const id of linkedIds) {
+    const f = path.join(relDir, `${id}.md`);
+    const c = readFile(f);
+    if (!c || c.trim().length < 50) {
+      errors.push(
+        `Missing or too-short ${f} (< 50 chars). Fetch the linked ticket's FULL description (not just title) and save it here.`
+      );
+    }
+  }
+  return errors;
+}
+
+function validateOverlap(tasksDir, linkedIds) {
+  const errors = [];
+  const f = path.join(tasksDir, 'sibling-overlap.md');
+  const c = readFile(f);
+  if (!c) {
+    errors.push(`Missing ${f}.`);
+    return errors;
+  }
+  for (const id of linkedIds) {
+    const headerRe = new RegExp(`^##\\s+${id}\\b`, 'm');
+    if (!headerRe.test(c)) {
+      errors.push(`sibling-overlap.md is missing section for ${id} (expected '## ${id}').`);
+      continue;
+    }
+    const startIdx = c.match(headerRe).index;
+    const after = c.slice(startIdx);
+    const nextHdr = after.slice(2).match(/^##\s/m);
+    const section = nextHdr ? after.slice(0, nextHdr.index + 2) : after;
+    if (!/\*\*Verdict:\*\*\s*(sibling-owned|shared|no-overlap)\b/i.test(section)) {
+      errors.push(
+        `sibling-overlap.md section for ${id} missing '**Verdict:** sibling-owned|shared|no-overlap'.`
+      );
+    }
+  }
+  return errors;
+}
+
+const REQUIRED_BRIEF_SECTIONS = [
+  /^##\s+Problem Statement\b/im,
+  /^##\s+Goal\b/im,
+  /^##\s+Target Users\b/im,
+  /^###\s+Must Have\s*\(P0\)\b/im,
+  /^##\s+Constraints\b/im,
+  /^##\s+Out of scope\s*\(sibling-owned\)\b/im,
+  /^##\s+Success Metrics\b/im,
+  /^##\s+Open Questions\b/im,
+];
+
+function sliceSection(text, headerRe) {
+  const m = text.match(headerRe);
+  if (!m) return null;
+  const after = text.slice(m.index + m[0].length);
+  const next = after.match(/^##\s/m);
+  return next ? after.slice(0, next.index) : after;
+}
+
+function validateDraft(tasksDir) {
+  const errors = [];
+  const f = path.join(tasksDir, 'brief.md');
+  const c = readFile(f);
+  if (!c) {
+    errors.push(`Missing ${f}.`);
+    return errors;
+  }
+  for (const re of REQUIRED_BRIEF_SECTIONS) {
+    if (!re.test(c)) errors.push(`brief.md missing required section: ${re}.`);
+  }
+  // Open Questions: each non-empty entry must carry a `Searched:` line.
+  const oq = sliceSection(c, /^##\s+Open Questions\b/im) || '';
+  const bullets = oq
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => /^[-*+]\s+/.test(l));
+  for (const b of bullets) {
+    // Each bullet must either close with "Searched:" inline or be followed
+    // by an indented sub-bullet starting with "Searched:". Accept either.
+    if (!/Searched:/i.test(b)) {
+      // look for sub-bullet by scanning lines after this one
+      const idx = oq.indexOf(b);
+      const tail = oq.slice(idx + b.length, idx + b.length + 400);
+      if (!/Searched:/i.test(tail)) {
+        errors.push(
+          `Open Question without 'Searched:' annotation: "${b.slice(0, 100)}". Each open question must list what docs/code you searched (paths + patterns) before leaving it open.`
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+function validateValidate(tasksDir, linkedIds) {
+  const errors = [];
+  const briefPath = path.join(tasksDir, 'brief.md');
+  const overlapPath = path.join(tasksDir, 'sibling-overlap.md');
+  const brief = readFile(briefPath);
+  const overlap = readFile(overlapPath);
+  if (!brief) errors.push(`Missing ${briefPath}.`);
+  if (!overlap) errors.push(`Missing ${overlapPath}.`);
+  if (!brief || !overlap) return errors;
+
+  // Every sibling-owned verdict in overlap.md must appear in brief.md's
+  // `Out of scope (sibling-owned)` section.
+  const oos = sliceSection(brief, /^##\s+Out of scope\s*\(sibling-owned\)\b/im) || '';
+  for (const id of linkedIds) {
+    const headerRe = new RegExp(`^##\\s+${id}\\b`, 'm');
+    const m = overlap.match(headerRe);
+    if (!m) continue;
+    const startIdx = m.index;
+    const after = overlap.slice(startIdx);
+    const nextHdr = after.slice(2).match(/^##\s/m);
+    const section = nextHdr ? after.slice(0, nextHdr.index + 2) : after;
+    const verdict = (section.match(/\*\*Verdict:\*\*\s*(sibling-owned|shared|no-overlap)/i) ||
+      [])[1];
+    if (verdict && verdict.toLowerCase() === 'sibling-owned') {
+      if (!oos.includes(id)) {
+        errors.push(
+          `brief.md 'Out of scope (sibling-owned)' is missing ${id}, which sibling-overlap.md marks sibling-owned.`
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+// ─── Phase instructions (Markdown to the agent) ────────────────────────────
+
+function instructInputs(ctx) {
+  const { ticket, tasksDir, linkedIds, manifest, memory } = ctx;
+  const memBlock = memory
+    ? [
+        '',
+        `### 0. Recall prior memory (${memory.name})`,
+        `Before reading anything, call \`${memory.recallTool}\` with each of these queries (one call per query) and read the results:`,
+        `- \`${ticket}\``,
+        `- the ticket title (extract from related-tickets.json self field if present)`,
+        `- "${ticket} brief"`,
+        `- "sibling overlap" + the area of work (e.g. tRPC, schema, component name)`,
+        `- "past decisions" + the area of work`,
+        '',
+        'Treat any hits as authoritative prior context — read them in full before you draft anything. If multiple agents have already decided how to scope this ticket, do not re-litigate; carry the decision forward.',
+      ]
+    : [
+        '',
+        '### 0. Recall prior memory',
+        'No memory plugin detected. Skipping recall step. If you have a memory plugin installed, surface it to the orchestrator so this step can be enabled.',
+      ];
+  return [
+    `# brief-next — Phase 1 of 5: INPUTS`,
+    `Ticket: ${ticket}`,
+    `Tasks dir: ${tasksDir}`,
+    '',
+    ...memBlock,
+    '',
+    '### 1. Read your own ticket',
+    `Open the ticket payload your previous workflow step fetched (typically under \`${path.join(tasksDir, 'ticket')}.{md,json}\` or surfaced in the previous step output). Read every field: title, description, acceptance criteria, comments. Take notes.`,
+    '',
+    '### 2. Read every linked ticket — FULL CONTENT, not just title',
+    manifest
+      ? `\`related-tickets.json\` lists ${linkedIds.length} linked ticket(s): ${linkedIds.join(', ') || '(none)'}. For EACH id, fetch the full description (jira/linear/gh) and save it to \`${path.join(tasksDir, '_related')}/<id>.md\`. Title is not enough — you must read the full body to detect overlaps in phase 2.`
+      : 'No `related-tickets.json` found. Generate it first via the related-tickets-inject step or have the orchestrator regenerate it. This script will block until the manifest is present.',
+    '',
+    '### What I will check before advancing',
+    `- \`${path.join(tasksDir, 'related-tickets.json')}\` exists`,
+    `- For every linked ticket id, \`${path.join(tasksDir, '_related')}/<id>.md\` exists with at least 50 chars of body (title-only files are rejected)`,
+    '',
+    'When done, re-invoke me.',
+    '',
+  ].join('\n');
+}
+
+function instructOverlap(ctx) {
+  const { ticket, tasksDir, linkedIds } = ctx;
+  const overlapPath = path.join(tasksDir, 'sibling-overlap.md');
+  return [
+    `# brief-next — Phase 2 of 5: OVERLAP`,
+    `Ticket: ${ticket}`,
+    '',
+    '### Task',
+    `Read every file in \`${path.join(tasksDir, '_related')}/\`. For each linked ticket (${linkedIds.length}), decide whether your ticket overlaps with theirs in any surface: file paths, tRPC procedures, schemas, components, endpoints, DB tables, environment variables, or product flows.`,
+    '',
+    `Write \`${overlapPath}\` in this exact format:`,
+    '',
+    '```markdown',
+    '# Sibling Overlap Analysis',
+    '',
+    '## <TICKET-ID> — <title>',
+    '**Verdict:** sibling-owned | shared | no-overlap',
+    '**Surfaces:** comma-separated list of overlapping surfaces (file paths, procedures, schemas...)',
+    '**Notes:** one-to-three sentence rationale, citing specific lines/paragraphs from the sibling description that informed the verdict.',
+    '',
+    '## <NEXT-TICKET-ID> — ...',
+    '...',
+    '```',
+    '',
+    '### Verdict semantics',
+    "- **sibling-owned** — the surface is theirs; you must put it in your brief's `## Out of scope (sibling-owned)` and not implement it.",
+    '- **shared** — both tickets touch it; coordination required. Note who owns the change.',
+    '- **no-overlap** — different concerns; no risk of stepping on each other.',
+    '',
+    '### What I will check before advancing',
+    `- \`${overlapPath}\` exists`,
+    `- One \`## <TICKET-ID>\` section per linked ticket (${linkedIds.length} sections)`,
+    `- Each section has a \`**Verdict:**\` line with one of the three values`,
+    '',
+    'When done, re-invoke me.',
+    '',
+  ].join('\n');
+}
+
+function instructDraft(ctx) {
+  const { ticket, tasksDir } = ctx;
+  const briefPath = path.join(tasksDir, 'brief.md');
+  return [
+    `# brief-next — Phase 3 of 5: DRAFT`,
+    `Ticket: ${ticket}`,
+    '',
+    '### Before drafting: investigate docs for ambiguities',
+    "List every ambiguity you would otherwise drop into Open Questions. For EACH ambiguity, search the project docs (README, docs/, ADRs, design notes, this plugin's own AGENTS.md) AND the codebase for prior resolutions BEFORE leaving it open. If a search resolves the ambiguity, fold the answer into the brief proper. If not, leave it open AND record what you searched.",
+    '',
+    '### Required brief structure',
+    `Write \`${briefPath}\` with all of the following sections (exact headings):`,
+    '',
+    '- `## Problem Statement` — one paragraph, user-facing pain.',
+    '- `## Goal` — one paragraph, measurable outcome.',
+    '- `## Target Users` — bulleted list of personas.',
+    '- `## Requirements`',
+    '  - `### Must Have (P0)` — numbered list. Each P0 maps to one or more ticket AC items.',
+    '  - `### Should Have (P1)` — optional, numbered.',
+    '  - `### Could Have (P2)` — optional, numbered.',
+    '- `## Constraints` — bulleted: timelines, tech limits, compliance.',
+    '- `## Out of scope (sibling-owned)` — populated from sibling-overlap.md (every sibling marked `sibling-owned`). One bullet per surface, citing the sibling ID.',
+    '- `## Success Metrics` — bulleted measurable outcomes.',
+    '- `## Open Questions` — bulleted. Each MUST carry a `Searched:` annotation listing what you looked at, e.g.:',
+    '',
+    '  ```',
+    '  - Should the retry use exponential backoff or fixed delay?',
+    '    Searched: docs/architecture/retry.md, ADR-014, grep "backoff" in services/ → no prior decision.',
+    '  ```',
+    '',
+    '  If you have no open questions, write `- _None._` under the heading. Do NOT use the section as a parking lot for unsearched ambiguities.',
+    '',
+    '### What I will check before advancing',
+    `- All required sections present in \`${briefPath}\``,
+    '- Every Open Questions bullet has a `Searched:` annotation OR the section contains `_None._`',
+    '',
+    'When done, re-invoke me.',
+    '',
+  ].join('\n');
+}
+
+function instructValidate(ctx) {
+  const { ticket, tasksDir } = ctx;
+  return [
+    `# brief-next — Phase 4 of 5: VALIDATE`,
+    `Ticket: ${ticket}`,
+    '',
+    '### What I check',
+    `- \`brief.md\` has every required section.`,
+    `- Every linked ticket marked \`sibling-owned\` in sibling-overlap.md is referenced in brief.md's \`Out of scope (sibling-owned)\`.`,
+    '',
+    'If validation passes, I record the phase and advance you to MEMORIZE. If it fails, I print the gaps and you fix them.',
+    '',
+    'Re-invoke me to run the check.',
+    '',
+  ].join('\n');
+}
+
+function instructMemorize(ctx) {
+  const { ticket, memory, linkedIds } = ctx;
+  if (!memory) {
+    return [
+      `# brief-next — Phase 5 of 5: MEMORIZE (skipped)`,
+      '',
+      'No memory plugin detected on this machine. Recording phase as complete with `summary=no-memory-plugin` and advancing to done.',
+      '',
+      'To enable memory persistence, install a plugin like cortex and re-run this workflow.',
+      '',
+    ].join('\n');
+  }
+  return [
+    `# brief-next — Phase 5 of 5: MEMORIZE (${memory.name})`,
+    `Ticket: ${ticket}`,
+    '',
+    '### Task',
+    `Persist your key decisions via \`${memory.rememberTool}\` so future agents can recall them. Save AT LEAST these entries (one tool call each — DO NOT batch into one entry):`,
+    '',
+    `1. **Ticket overview**: tag with the ticket ID and area-of-work keywords. Body = problem statement + goal from brief.md.`,
+    `2. **Sibling ownership map**: for each linked ticket (${linkedIds.length}), save the verdict from sibling-overlap.md with tags ${ticket}, sibling-overlap, and the linked ticket id.`,
+    `3. **P0 requirements**: save the Must Have (P0) list with tags ${ticket}, requirements, P0.`,
+    `4. **Open questions + their searches**: save each unresolved Open Question with the search trail. Tag ${ticket}, open-question, plus the area keyword.`,
+    `5. **Out-of-scope reasoning**: save the sibling-owned out-of-scope list so the next agent working on a related ticket can recall who owns what.`,
+    '',
+    memory.saveTool
+      ? `Finally, archive the session via \`${memory.saveTool}\` so the full conversation context is queryable.`
+      : '',
+    '',
+    '### Why this matters',
+    'When a sibling/follow-up ticket runs `brief-next` later, its INPUTS phase will recall these entries and avoid re-litigating decisions you already made. Skip this and you waste future agent time on questions you already answered.',
+    '',
+    'When done, re-invoke me and I will transition you to done.',
+    '',
+  ].join('\n');
+}
+
+function instructDone(ctx) {
+  return [
+    `# brief-next — DONE`,
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'All five phases recorded. Artifacts:',
+    `- \`brief.md\``,
+    `- \`sibling-overlap.md\``,
+    `- \`_related/<id>.md\` (per linked ticket)`,
+    `- \`brief-phase.json\``,
+    '',
+    'Re-invoke /work2 (or /work) to advance to the brief_gate step.',
+    '',
+  ].join('\n');
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────
+
+function main(argv) {
+  const args = argv.slice(2);
+  const ticket = args[0];
+  if (!ticket || /^-/.test(ticket)) {
+    process.stderr.write('usage: brief-next.js <TICKET>\n  e.g. node brief-next.js ECHO-4560\n');
+    process.exit(2);
+  }
+
+  snapshotCompanionToken('brief-phase-state.js');
+
+  const tasksBase = resolveTasksBase();
+  const tasksDir = path.join(tasksBase, ticket);
+  if (!fs.existsSync(tasksDir)) die(`tasks dir not found: ${tasksDir}`);
+
+  const manifest = readRelatedManifest(tasksDir);
+  const linkedIds = listLinkedIds(manifest);
+  const memory = detectMemoryPlugin();
+  const worktreeRoot = resolveWorktreeRoot() || path.dirname(tasksBase);
+
+  ensureInit(ticket);
+  let phase = getCurrentPhase(ticket) || 'inputs';
+
+  const ctx = { ticket, tasksDir, tasksBase, manifest, linkedIds, memory, worktreeRoot };
+
+  // Validation gates: each phase validates inputs FROM the previous instruction.
+  // If validation fails, print the failures and the current-phase instructions.
+  let blockReason = '';
+  let advanced = false;
+
+  if (phase === 'inputs') {
+    if (!manifest) {
+      blockReason = `related-tickets.json missing at ${path.join(tasksDir, 'related-tickets.json')}. Cannot proceed without sibling context.`;
+    } else {
+      const errs = validateInputs(tasksDir, manifest, linkedIds);
+      if (errs.length === 0 && linkedIds.length >= 0) {
+        const r = recordPhase(
+          ticket,
+          'inputs',
+          `linked=${linkedIds.length} memory=${memory ? memory.name : 'none'}`
+        );
+        if (r.code !== 0) blockReason = `Could not record phase inputs:\n${r.out}`;
+        else {
+          const t = transitionPhase(ticket, 'overlap');
+          if (t.code !== 0) blockReason = `Could not transition to overlap:\n${t.out}`;
+          else {
+            advanced = true;
+            phase = 'overlap';
+          }
+        }
+      } else if (errs.length > 0) {
+        blockReason = errs.join('\n');
+      }
+    }
+  } else if (phase === 'overlap') {
+    const errs = validateOverlap(tasksDir, linkedIds);
+    if (errs.length === 0) {
+      const r = recordPhase(ticket, 'overlap', `siblings=${linkedIds.length}`);
+      if (r.code !== 0) blockReason = `Could not record phase overlap:\n${r.out}`;
+      else {
+        const t = transitionPhase(ticket, 'draft');
+        if (t.code !== 0) blockReason = `Could not transition to draft:\n${t.out}`;
+        else {
+          advanced = true;
+          phase = 'draft';
+        }
+      }
+    } else {
+      blockReason = errs.join('\n');
+    }
+  } else if (phase === 'draft') {
+    const errs = validateDraft(tasksDir);
+    if (errs.length === 0) {
+      const r = recordPhase(ticket, 'draft', 'brief.md drafted');
+      if (r.code !== 0) blockReason = `Could not record phase draft:\n${r.out}`;
+      else {
+        const t = transitionPhase(ticket, 'validate');
+        if (t.code !== 0) blockReason = `Could not transition to validate:\n${t.out}`;
+        else {
+          advanced = true;
+          phase = 'validate';
+        }
+      }
+    } else {
+      blockReason = errs.join('\n');
+    }
+  } else if (phase === 'validate') {
+    const errs = validateValidate(tasksDir, linkedIds);
+    if (errs.length === 0) {
+      const r = recordPhase(ticket, 'validate', 'cross-checks ok');
+      if (r.code !== 0) blockReason = `Could not record phase validate:\n${r.out}`;
+      else {
+        const t = transitionPhase(ticket, 'memorize');
+        if (t.code !== 0) blockReason = `Could not transition to memorize:\n${t.out}`;
+        else {
+          advanced = true;
+          phase = 'memorize';
+        }
+      }
+    } else {
+      blockReason = errs.join('\n');
+    }
+  } else if (phase === 'memorize') {
+    // We can't verify memory writes (no introspection across plugins).
+    // Record on re-invoke; if no memory plugin, auto-advance.
+    if (!memory) {
+      const r = recordPhase(ticket, 'memorize', 'no-memory-plugin');
+      if (r.code !== 0) blockReason = `Could not record phase memorize:\n${r.out}`;
+      else {
+        const t = transitionPhase(ticket, 'done');
+        if (t.code !== 0) blockReason = `Could not transition to done:\n${t.out}`;
+        else {
+          advanced = true;
+          phase = 'done';
+        }
+      }
+    } else {
+      // First call in memorize prints instructions. Second call (when agent
+      // has finished saving) advances. We detect "second call" by the
+      // presence of a sentinel file the agent must touch after persisting.
+      const sentinel = path.join(tasksDir, '.brief-memorized');
+      if (fs.existsSync(sentinel)) {
+        const r = recordPhase(ticket, 'memorize', `via=${memory.name}`);
+        if (r.code !== 0) blockReason = `Could not record phase memorize:\n${r.out}`;
+        else {
+          const t = transitionPhase(ticket, 'done');
+          if (t.code !== 0) blockReason = `Could not transition to done:\n${t.out}`;
+          else {
+            advanced = true;
+            phase = 'done';
+          }
+        }
+      }
+    }
+  }
+
+  // Compose response
+  const header = [
+    `brief-next: ${ticket}`,
+    `  tasks dir: ${tasksDir}`,
+    `  current phase (after this run): ${phase}`,
+    `  memory plugin: ${memory ? memory.name : '(none detected)'}`,
+    `  linked tickets: ${linkedIds.length}${linkedIds.length ? ` (${linkedIds.join(', ')})` : ''}`,
+    advanced ? '  result: PHASE ADVANCED' : blockReason ? '  result: BLOCKED' : '  result: WAITING',
+    '',
+  ].join('\n');
+
+  let body;
+  if (blockReason && !advanced) {
+    body = [
+      `## ❌ Phase ${phase.toUpperCase()} blocked`,
+      '',
+      '```',
+      blockReason,
+      '```',
+      '',
+      '---',
+      '',
+      phase === 'inputs'
+        ? instructInputs(ctx)
+        : phase === 'overlap'
+          ? instructOverlap(ctx)
+          : phase === 'draft'
+            ? instructDraft(ctx)
+            : phase === 'validate'
+              ? instructValidate(ctx)
+              : instructMemorize(ctx),
+    ].join('\n');
+  } else {
+    body =
+      phase === 'inputs'
+        ? instructInputs(ctx)
+        : phase === 'overlap'
+          ? instructOverlap(ctx)
+          : phase === 'draft'
+            ? instructDraft(ctx)
+            : phase === 'validate'
+              ? instructValidate(ctx)
+              : phase === 'memorize'
+                ? instructMemorize(ctx)
+                : instructDone(ctx);
+  }
+
+  process.stdout.write(header + '\n' + body);
+  process.exit(blockReason && !advanced ? 2 : 0);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv);
+  } catch (e) {
+    die(e.message || String(e));
+  }
+}
+
+module.exports = { detectMemoryPlugin };

--- a/scripts/workflows/work-brief/brief-next.js
+++ b/scripts/workflows/work-brief/brief-next.js
@@ -74,11 +74,17 @@ function die(msg) {
 
 let _companionTokenSnapshot = null;
 
-function snapshotCompanionToken(scriptBasename) {
+function snapshotCompanionToken(scriptBasename, ticketId) {
   try {
     const dir = process.env.CLAUDE_WRITE_TOKEN_DIR || '/tmp/.claude-write-tokens';
-    const file = path.join(dir, scriptBasename);
-    if (!fs.existsSync(file)) return;
+    // Per-ticket keyed path first (matches what the PreToolUse hook mints
+    // post commit 2f37f34b). Fall back to the legacy unkeyed path for
+    // backwards-compat (e.g. older hook versions still in transit).
+    const bareTicket = ticketId ? String(ticketId).split('/')[0] : null;
+    const keyed = bareTicket ? path.join(dir, `${scriptBasename}.${bareTicket}`) : null;
+    const legacy = path.join(dir, scriptBasename);
+    const file = keyed && fs.existsSync(keyed) ? keyed : fs.existsSync(legacy) ? legacy : null;
+    if (!file) return;
     _companionTokenSnapshot = { path: file, data: JSON.parse(fs.readFileSync(file, 'utf8')) };
   } catch {
     /* fail-open — phase recording will surface the missing token */
@@ -198,7 +204,7 @@ function main(argv) {
     agent: process.env.CLAUDE_CURRENT_AGENT || null,
   });
 
-  snapshotCompanionToken('brief-phase-state.js');
+  snapshotCompanionToken('brief-phase-state.js', ticket);
 
   const tasksBase = resolveTasksBase();
   const tasksDir = path.join(tasksBase, ticket);

--- a/scripts/workflows/work-brief/brief-next.js
+++ b/scripts/workflows/work-brief/brief-next.js
@@ -216,6 +216,9 @@ function transitionPhase(ticket, target) {
 
 function validateInputs(tasksDir, manifest, linkedIds) {
   const errors = [];
+  // No linked tickets => nothing to put in _related/ => nothing to check.
+  if (linkedIds.length === 0) return errors;
+
   const relDir = path.join(tasksDir, '_related');
   if (!fs.existsSync(relDir)) {
     errors.push(
@@ -262,15 +265,19 @@ function validateOverlap(tasksDir, linkedIds) {
   return errors;
 }
 
+// NOTE: trailing terminator must match a non-word char OR end-of-line.
+// Headings ending in `)` (like `### Must Have (P0)`) followed by `\n` are
+// two non-word chars in a row, where `\b` does NOT match. Using
+// `(?=\s|$)` is correct for both word-ending and paren-ending headings.
 const REQUIRED_BRIEF_SECTIONS = [
-  /^##\s+Problem Statement\b/im,
-  /^##\s+Goal\b/im,
-  /^##\s+Target Users\b/im,
-  /^###\s+Must Have\s*\(P0\)\b/im,
-  /^##\s+Constraints\b/im,
-  /^##\s+Out of scope\s*\(sibling-owned\)\b/im,
-  /^##\s+Success Metrics\b/im,
-  /^##\s+Open Questions\b/im,
+  /^##\s+Problem Statement(?=\s|$)/im,
+  /^##\s+Goal(?=\s|$)/im,
+  /^##\s+Target Users(?=\s|$)/im,
+  /^###\s+Must Have\s*\(P0\)(?=\s|$)/im,
+  /^##\s+Constraints(?=\s|$)/im,
+  /^##\s+Out of scope\s*\(sibling-owned\)(?=\s|$)/im,
+  /^##\s+Success Metrics(?=\s|$)/im,
+  /^##\s+Open Questions(?=\s|$)/im,
 ];
 
 function sliceSection(text, headerRe) {
@@ -293,12 +300,17 @@ function validateDraft(tasksDir) {
     if (!re.test(c)) errors.push(`brief.md missing required section: ${re}.`);
   }
   // Open Questions: each non-empty entry must carry a `Searched:` line.
+  // The "no open questions" placeholder is `- _None._` (or `- None.`,
+  // `- N/A`) — recognised and exempt from the annotation requirement.
   const oq = sliceSection(c, /^##\s+Open Questions\b/im) || '';
+  const EMPTY_PLACEHOLDER_RE = /^[-*+]\s+(?:_?(?:none|n\/a|nothing)\b\.?_?|—|-)\s*$/i;
   const bullets = oq
     .split('\n')
     .map((l) => l.trim())
     .filter((l) => /^[-*+]\s+/.test(l));
   for (const b of bullets) {
+    // Skip the empty-placeholder marker — the section is intentionally empty.
+    if (EMPTY_PLACEHOLDER_RE.test(b)) continue;
     // Each bullet must either close with "Searched:" inline or be followed
     // by an indented sub-bullet starting with "Searched:". Accept either.
     if (!/Searched:/i.test(b)) {
@@ -307,7 +319,7 @@ function validateDraft(tasksDir) {
       const tail = oq.slice(idx + b.length, idx + b.length + 400);
       if (!/Searched:/i.test(tail)) {
         errors.push(
-          `Open Question without 'Searched:' annotation: "${b.slice(0, 100)}". Each open question must list what docs/code you searched (paths + patterns) before leaving it open.`
+          `Open Question without 'Searched:' annotation: "${b.slice(0, 100)}". Each open question must list what docs/code you searched (paths + patterns) before leaving it open. If you have no open questions, write '- _None._' under the heading.`
         );
       }
     }

--- a/scripts/workflows/work-brief/brief-next.js
+++ b/scripts/workflows/work-brief/brief-next.js
@@ -36,6 +36,13 @@ const { spawnSync } = require('node:child_process');
 
 const BRIEF_PHASE_CLI = path.resolve(__dirname, 'brief-phase-state.js');
 
+let logNextScriptEvent;
+try {
+  ({ logNextScriptEvent } = require('../lib/next-script-log'));
+} catch {
+  logNextScriptEvent = () => {};
+}
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 let config;
@@ -541,12 +548,19 @@ function instructDone(ctx) {
 // ─── Main ──────────────────────────────────────────────────────────────────
 
 function main(argv) {
+  const startedAt = Date.now();
   const args = argv.slice(2);
   const ticket = args[0];
   if (!ticket || /^-/.test(ticket)) {
     process.stderr.write('usage: brief-next.js <TICKET>\n  e.g. node brief-next.js ECHO-4560\n');
     process.exit(2);
   }
+  logNextScriptEvent('brief-next', {
+    event: 'invoked',
+    ticket,
+    cwd: process.cwd(),
+    agent: process.env.CLAUDE_CURRENT_AGENT || null,
+  });
 
   snapshotCompanionToken('brief-phase-state.js');
 
@@ -723,7 +737,20 @@ function main(argv) {
   }
 
   process.stdout.write(header + '\n' + body);
-  process.exit(blockReason && !advanced ? 2 : 0);
+  const exitCode = blockReason && !advanced ? 2 : 0;
+  logNextScriptEvent('brief-next', {
+    event: 'completed',
+    ticket,
+    phase,
+    advanced,
+    blocked: Boolean(blockReason),
+    blockReason: blockReason ? blockReason.slice(0, 500) : null,
+    linkedTickets: linkedIds.length,
+    memoryPlugin: memory ? memory.name : null,
+    exitCode,
+    durationMs: Date.now() - startedAt,
+  });
+  process.exit(exitCode);
 }
 
 if (require.main === module) {

--- a/scripts/workflows/work-brief/brief-next.js
+++ b/scripts/workflows/work-brief/brief-next.js
@@ -3,29 +3,22 @@
 /**
  * brief-next.js
  *
- * Self-paced runner for the `brief` step, modeled on task-next.js for
- * `implement`. The agent invokes this script and follows the Markdown
- * response. Each phase validates artifacts, records evidence, and
- * advances. Phases (in order):
+ * Self-paced runner for the `brief` step. Thin orchestrator only — every
+ * phase (inputs / overlap / draft / validate / memorize / done) lives in
+ * its own module under `lib/phases/`, registered via `lib/phase-registry.js`.
+ * The dispatcher pattern mirrors `check2/lib/step-registry.js`.
  *
- *   1. inputs    — recall memory, fetch ticket + every linked ticket's
- *                  FULL content (not just titles), save to _related/.
- *   2. overlap   — analyze overlaps with each linked ticket, write
- *                  sibling-overlap.md with one section per linked ticket
- *                  and a verdict (sibling-owned | shared | no-overlap).
- *   3. draft     — investigate docs for ambiguities, then write brief.md
- *                  with required sections. Each Open Question entry MUST
- *                  carry a `Searched:` annotation listing the paths/queries
- *                  consulted, OR the section is empty.
- *   4. validate  — re-check section presence, AC→P0 mapping, and that
- *                  brief.md's `Out of scope (sibling-owned)` reflects the
- *                  sibling-owned verdicts from sibling-overlap.md.
- *   5. memorize  — persist decisions via the installed memory plugin
- *                  (e.g. cortex). Skipped with a warning if none detected.
+ * Per invocation:
+ *   1. Resolve ticket context (tasks dir, manifest, linked siblings, memory plugin).
+ *   2. Look up the current phase from `brief-phase.json` via `brief-phase-state.js`.
+ *   3. Ask the registered phase handler whether the phase is ready to advance.
+ *        validate(ctx) → { ok, errors?, summary? }
+ *   4. If ok and the phase has a successor: record evidence + transition.
+ *      If errors are present: emit a block prefix on the response.
+ *      Otherwise: just print the current phase's instructions.
+ *   5. Print the header + (possibly blocked) phase instructions.
  *
- * The script is the source of truth for what to do at every phase. The
- * agent only sees the printed Markdown; it does not need to know the
- * gate logic.
+ * Exit codes: 0 = phase progressed or waiting, 2 = phase blocked.
  */
 
 'use strict';
@@ -36,7 +29,8 @@ const { spawnSync } = require('node:child_process');
 
 const BRIEF_PHASE_CLI = path.resolve(__dirname, 'brief-phase-state.js');
 
-const { BRIEF_PHASES, BRIEF_INITIAL_PHASE, briefNextPhases } = require('./brief-phase-registry');
+const { BRIEF_INITIAL_PHASE } = require('./brief-phase-registry');
+const { getPhase } = require('./lib/phase-registry');
 
 let logNextScriptEvent;
 try {
@@ -45,14 +39,14 @@ try {
   logNextScriptEvent = () => {};
 }
 
-// ─── Helpers ────────────────────────────────────────────────────────────────
-
 let config;
 try {
   config = require('../lib/config');
 } catch {
   config = null;
 }
+
+// ─── Path + env helpers ────────────────────────────────────────────────────
 
 function resolveTasksBase() {
   return (
@@ -62,25 +56,17 @@ function resolveTasksBase() {
   );
 }
 
-function readFile(p) {
-  try {
-    return fs.readFileSync(p, 'utf8');
-  } catch {
-    return null;
-  }
-}
-
-function die(msg) {
-  process.stderr.write(`brief-next: ${msg}\n`);
-  process.exit(2);
-}
-
 function resolveWorktreeRoot() {
   const r = spawnSync('git', ['rev-parse', '--show-toplevel'], {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'ignore'],
   });
   return r.status === 0 ? r.stdout.trim() : null;
+}
+
+function die(msg) {
+  process.stderr.write(`brief-next: ${msg}\n`);
+  process.exit(2);
 }
 
 // ─── Token snapshot/remint (mirrors task-next.js) ──────────────────────────
@@ -92,9 +78,7 @@ function snapshotCompanionToken(scriptBasename) {
     const dir = process.env.CLAUDE_WRITE_TOKEN_DIR || '/tmp/.claude-write-tokens';
     const file = path.join(dir, scriptBasename);
     if (!fs.existsSync(file)) return;
-    const raw = fs.readFileSync(file, 'utf8');
-    const data = JSON.parse(raw);
-    _companionTokenSnapshot = { path: file, data };
+    _companionTokenSnapshot = { path: file, data: JSON.parse(fs.readFileSync(file, 'utf8')) };
   } catch {
     /* fail-open — phase recording will surface the missing token */
   }
@@ -116,8 +100,8 @@ function mintCompanionToken() {
 
 /**
  * Detect installed memory plugins (cortex, mem0, anything that exposes
- * recall/remember tools). Returns { name, recallTool, rememberTool } or
- * null. The check looks for known plugin manifest paths under ~/.claude/.
+ * recall/remember tools). Returns { name, recallTool, rememberTool } or null.
+ * Exported for test coverage.
  */
 function detectMemoryPlugin() {
   const home = require('node:os').homedir();
@@ -149,9 +133,7 @@ function detectMemoryPlugin() {
       } catch {
         continue;
       }
-      if (entries.some((e) => c.probe.test(e.name))) {
-        return c;
-      }
+      if (entries.some((e) => c.probe.test(e.name))) return c;
     }
   }
   return null;
@@ -194,8 +176,7 @@ function getCurrentPhase(ticket) {
   const r = callPhaseCli(['current', ticket]);
   if (r.code !== 0) return null;
   try {
-    const j = JSON.parse(r.out.trim().split('\n').pop());
-    return j.currentPhase;
+    return JSON.parse(r.out.trim().split('\n').pop()).currentPhase;
   } catch {
     return null;
   }
@@ -214,352 +195,7 @@ function transitionPhase(ticket, target) {
   return callPhaseCli(['transition', ticket, target]);
 }
 
-// ─── Phase validation logic ────────────────────────────────────────────────
-
-function validateInputs(tasksDir, manifest, linkedIds) {
-  const errors = [];
-  // No linked tickets => nothing to put in _related/ => nothing to check.
-  if (linkedIds.length === 0) return errors;
-
-  const relDir = path.join(tasksDir, '_related');
-  if (!fs.existsSync(relDir)) {
-    errors.push(
-      `Missing directory ${relDir}. Save each linked ticket's full content as ${relDir}/<TICKET-ID>.md.`
-    );
-    return errors;
-  }
-  for (const id of linkedIds) {
-    const f = path.join(relDir, `${id}.md`);
-    const c = readFile(f);
-    if (!c || c.trim().length < 50) {
-      errors.push(
-        `Missing or too-short ${f} (< 50 chars). Fetch the linked ticket's FULL description (not just title) and save it here.`
-      );
-    }
-  }
-  return errors;
-}
-
-function validateOverlap(tasksDir, linkedIds) {
-  const errors = [];
-  const f = path.join(tasksDir, 'sibling-overlap.md');
-  const c = readFile(f);
-  if (!c) {
-    errors.push(`Missing ${f}.`);
-    return errors;
-  }
-  for (const id of linkedIds) {
-    const headerRe = new RegExp(`^##\\s+${id}\\b`, 'm');
-    if (!headerRe.test(c)) {
-      errors.push(`sibling-overlap.md is missing section for ${id} (expected '## ${id}').`);
-      continue;
-    }
-    const startIdx = c.match(headerRe).index;
-    const after = c.slice(startIdx);
-    const nextHdr = after.slice(2).match(/^##\s/m);
-    const section = nextHdr ? after.slice(0, nextHdr.index + 2) : after;
-    if (!/\*\*Verdict:\*\*\s*(sibling-owned|shared|no-overlap)\b/i.test(section)) {
-      errors.push(
-        `sibling-overlap.md section for ${id} missing '**Verdict:** sibling-owned|shared|no-overlap'.`
-      );
-    }
-  }
-  return errors;
-}
-
-// NOTE: trailing terminator must match a non-word char OR end-of-line.
-// Headings ending in `)` (like `### Must Have (P0)`) followed by `\n` are
-// two non-word chars in a row, where `\b` does NOT match. Using
-// `(?=\s|$)` is correct for both word-ending and paren-ending headings.
-const REQUIRED_BRIEF_SECTIONS = [
-  /^##\s+Problem Statement(?=\s|$)/im,
-  /^##\s+Goal(?=\s|$)/im,
-  /^##\s+Target Users(?=\s|$)/im,
-  /^###\s+Must Have\s*\(P0\)(?=\s|$)/im,
-  /^##\s+Constraints(?=\s|$)/im,
-  /^##\s+Out of scope\s*\(sibling-owned\)(?=\s|$)/im,
-  /^##\s+Success Metrics(?=\s|$)/im,
-  /^##\s+Open Questions(?=\s|$)/im,
-];
-
-function sliceSection(text, headerRe) {
-  const m = text.match(headerRe);
-  if (!m) return null;
-  const after = text.slice(m.index + m[0].length);
-  const next = after.match(/^##\s/m);
-  return next ? after.slice(0, next.index) : after;
-}
-
-function validateDraft(tasksDir) {
-  const errors = [];
-  const f = path.join(tasksDir, 'brief.md');
-  const c = readFile(f);
-  if (!c) {
-    errors.push(`Missing ${f}.`);
-    return errors;
-  }
-  for (const re of REQUIRED_BRIEF_SECTIONS) {
-    if (!re.test(c)) errors.push(`brief.md missing required section: ${re}.`);
-  }
-  // Open Questions: each non-empty entry must carry a `Searched:` line.
-  // The "no open questions" placeholder is `- _None._` (or `- None.`,
-  // `- N/A`) — recognised and exempt from the annotation requirement.
-  const oq = sliceSection(c, /^##\s+Open Questions\b/im) || '';
-  const EMPTY_PLACEHOLDER_RE = /^[-*+]\s+(?:_?(?:none|n\/a|nothing)\b\.?_?|—|-)\s*$/i;
-  const bullets = oq
-    .split('\n')
-    .map((l) => l.trim())
-    .filter((l) => /^[-*+]\s+/.test(l));
-  for (const b of bullets) {
-    // Skip the empty-placeholder marker — the section is intentionally empty.
-    if (EMPTY_PLACEHOLDER_RE.test(b)) continue;
-    // Each bullet must either close with "Searched:" inline or be followed
-    // by an indented sub-bullet starting with "Searched:". Accept either.
-    if (!/Searched:/i.test(b)) {
-      // look for sub-bullet by scanning lines after this one
-      const idx = oq.indexOf(b);
-      const tail = oq.slice(idx + b.length, idx + b.length + 400);
-      if (!/Searched:/i.test(tail)) {
-        errors.push(
-          `Open Question without 'Searched:' annotation: "${b.slice(0, 100)}". Each open question must list what docs/code you searched (paths + patterns) before leaving it open. If you have no open questions, write '- _None._' under the heading.`
-        );
-      }
-    }
-  }
-  return errors;
-}
-
-function validateValidate(tasksDir, linkedIds) {
-  const errors = [];
-  const briefPath = path.join(tasksDir, 'brief.md');
-  const overlapPath = path.join(tasksDir, 'sibling-overlap.md');
-  const brief = readFile(briefPath);
-  const overlap = readFile(overlapPath);
-  if (!brief) errors.push(`Missing ${briefPath}.`);
-  if (!overlap) errors.push(`Missing ${overlapPath}.`);
-  if (!brief || !overlap) return errors;
-
-  // Every sibling-owned verdict in overlap.md must appear in brief.md's
-  // `Out of scope (sibling-owned)` section.
-  const oos = sliceSection(brief, /^##\s+Out of scope\s*\(sibling-owned\)\b/im) || '';
-  for (const id of linkedIds) {
-    const headerRe = new RegExp(`^##\\s+${id}\\b`, 'm');
-    const m = overlap.match(headerRe);
-    if (!m) continue;
-    const startIdx = m.index;
-    const after = overlap.slice(startIdx);
-    const nextHdr = after.slice(2).match(/^##\s/m);
-    const section = nextHdr ? after.slice(0, nextHdr.index + 2) : after;
-    const verdict = (section.match(/\*\*Verdict:\*\*\s*(sibling-owned|shared|no-overlap)/i) ||
-      [])[1];
-    if (verdict && verdict.toLowerCase() === 'sibling-owned') {
-      if (!oos.includes(id)) {
-        errors.push(
-          `brief.md 'Out of scope (sibling-owned)' is missing ${id}, which sibling-overlap.md marks sibling-owned.`
-        );
-      }
-    }
-  }
-  return errors;
-}
-
-// ─── Phase instructions (Markdown to the agent) ────────────────────────────
-
-function instructInputs(ctx) {
-  const { ticket, tasksDir, linkedIds, manifest, memory } = ctx;
-  const memBlock = memory
-    ? [
-        '',
-        `### 0. Recall prior memory (${memory.name})`,
-        `Before reading anything, call \`${memory.recallTool}\` with each of these queries (one call per query) and read the results:`,
-        `- \`${ticket}\``,
-        `- the ticket title (extract from related-tickets.json self field if present)`,
-        `- "${ticket} brief"`,
-        `- "sibling overlap" + the area of work (e.g. tRPC, schema, component name)`,
-        `- "past decisions" + the area of work`,
-        '',
-        'Treat any hits as authoritative prior context — read them in full before you draft anything. If multiple agents have already decided how to scope this ticket, do not re-litigate; carry the decision forward.',
-      ]
-    : [
-        '',
-        '### 0. Recall prior memory',
-        'No memory plugin detected. Skipping recall step. If you have a memory plugin installed, surface it to the orchestrator so this step can be enabled.',
-      ];
-  return [
-    `# brief-next — Phase 1 of 5: INPUTS`,
-    `Ticket: ${ticket}`,
-    `Tasks dir: ${tasksDir}`,
-    '',
-    ...memBlock,
-    '',
-    '### 1. Read your own ticket',
-    `Open the ticket payload your previous workflow step fetched (typically under \`${path.join(tasksDir, 'ticket')}.{md,json}\` or surfaced in the previous step output). Read every field: title, description, acceptance criteria, comments. Take notes.`,
-    '',
-    '### 2. Read every linked ticket — FULL CONTENT, not just title',
-    manifest
-      ? `\`related-tickets.json\` lists ${linkedIds.length} linked ticket(s): ${linkedIds.join(', ') || '(none)'}. For EACH id, fetch the full description (jira/linear/gh) and save it to \`${path.join(tasksDir, '_related')}/<id>.md\`. Title is not enough — you must read the full body to detect overlaps in phase 2.`
-      : 'No `related-tickets.json` found. Generate it first via the related-tickets-inject step or have the orchestrator regenerate it. This script will block until the manifest is present.',
-    '',
-    '### What I will check before advancing',
-    `- \`${path.join(tasksDir, 'related-tickets.json')}\` exists`,
-    `- For every linked ticket id, \`${path.join(tasksDir, '_related')}/<id>.md\` exists with at least 50 chars of body (title-only files are rejected)`,
-    '',
-    'When done, re-invoke me.',
-    '',
-  ].join('\n');
-}
-
-function instructOverlap(ctx) {
-  const { ticket, tasksDir, linkedIds } = ctx;
-  const overlapPath = path.join(tasksDir, 'sibling-overlap.md');
-  return [
-    `# brief-next — Phase 2 of 5: OVERLAP`,
-    `Ticket: ${ticket}`,
-    '',
-    '### Task',
-    `Read every file in \`${path.join(tasksDir, '_related')}/\`. For each linked ticket (${linkedIds.length}), decide whether your ticket overlaps with theirs in any surface: file paths, tRPC procedures, schemas, components, endpoints, DB tables, environment variables, or product flows.`,
-    '',
-    `Write \`${overlapPath}\` in this exact format:`,
-    '',
-    '```markdown',
-    '# Sibling Overlap Analysis',
-    '',
-    '## <TICKET-ID> — <title>',
-    '**Verdict:** sibling-owned | shared | no-overlap',
-    '**Surfaces:** comma-separated list of overlapping surfaces (file paths, procedures, schemas...)',
-    '**Notes:** one-to-three sentence rationale, citing specific lines/paragraphs from the sibling description that informed the verdict.',
-    '',
-    '## <NEXT-TICKET-ID> — ...',
-    '...',
-    '```',
-    '',
-    '### Verdict semantics',
-    "- **sibling-owned** — the surface is theirs; you must put it in your brief's `## Out of scope (sibling-owned)` and not implement it.",
-    '- **shared** — both tickets touch it; coordination required. Note who owns the change.',
-    '- **no-overlap** — different concerns; no risk of stepping on each other.',
-    '',
-    '### What I will check before advancing',
-    `- \`${overlapPath}\` exists`,
-    `- One \`## <TICKET-ID>\` section per linked ticket (${linkedIds.length} sections)`,
-    `- Each section has a \`**Verdict:**\` line with one of the three values`,
-    '',
-    'When done, re-invoke me.',
-    '',
-  ].join('\n');
-}
-
-function instructDraft(ctx) {
-  const { ticket, tasksDir } = ctx;
-  const briefPath = path.join(tasksDir, 'brief.md');
-  return [
-    `# brief-next — Phase 3 of 5: DRAFT`,
-    `Ticket: ${ticket}`,
-    '',
-    '### Before drafting: investigate docs for ambiguities',
-    "List every ambiguity you would otherwise drop into Open Questions. For EACH ambiguity, search the project docs (README, docs/, ADRs, design notes, this plugin's own AGENTS.md) AND the codebase for prior resolutions BEFORE leaving it open. If a search resolves the ambiguity, fold the answer into the brief proper. If not, leave it open AND record what you searched.",
-    '',
-    '### Required brief structure',
-    `Write \`${briefPath}\` with all of the following sections (exact headings):`,
-    '',
-    '- `## Problem Statement` — one paragraph, user-facing pain.',
-    '- `## Goal` — one paragraph, measurable outcome.',
-    '- `## Target Users` — bulleted list of personas.',
-    '- `## Requirements`',
-    '  - `### Must Have (P0)` — numbered list. Each P0 maps to one or more ticket AC items.',
-    '  - `### Should Have (P1)` — optional, numbered.',
-    '  - `### Could Have (P2)` — optional, numbered.',
-    '- `## Constraints` — bulleted: timelines, tech limits, compliance.',
-    '- `## Out of scope (sibling-owned)` — populated from sibling-overlap.md (every sibling marked `sibling-owned`). One bullet per surface, citing the sibling ID.',
-    '- `## Success Metrics` — bulleted measurable outcomes.',
-    '- `## Open Questions` — bulleted. Each MUST carry a `Searched:` annotation listing what you looked at, e.g.:',
-    '',
-    '  ```',
-    '  - Should the retry use exponential backoff or fixed delay?',
-    '    Searched: docs/architecture/retry.md, ADR-014, grep "backoff" in services/ → no prior decision.',
-    '  ```',
-    '',
-    '  If you have no open questions, write `- _None._` under the heading. Do NOT use the section as a parking lot for unsearched ambiguities.',
-    '',
-    '### What I will check before advancing',
-    `- All required sections present in \`${briefPath}\``,
-    '- Every Open Questions bullet has a `Searched:` annotation OR the section contains `_None._`',
-    '',
-    'When done, re-invoke me.',
-    '',
-  ].join('\n');
-}
-
-function instructValidate(ctx) {
-  const { ticket, tasksDir } = ctx;
-  return [
-    `# brief-next — Phase 4 of 5: VALIDATE`,
-    `Ticket: ${ticket}`,
-    '',
-    '### What I check',
-    `- \`brief.md\` has every required section.`,
-    `- Every linked ticket marked \`sibling-owned\` in sibling-overlap.md is referenced in brief.md's \`Out of scope (sibling-owned)\`.`,
-    '',
-    'If validation passes, I record the phase and advance you to MEMORIZE. If it fails, I print the gaps and you fix them.',
-    '',
-    'Re-invoke me to run the check.',
-    '',
-  ].join('\n');
-}
-
-function instructMemorize(ctx) {
-  const { ticket, memory, linkedIds } = ctx;
-  if (!memory) {
-    return [
-      `# brief-next — Phase 5 of 5: MEMORIZE (skipped)`,
-      '',
-      'No memory plugin detected on this machine. Recording phase as complete with `summary=no-memory-plugin` and advancing to done.',
-      '',
-      'To enable memory persistence, install a plugin like cortex and re-run this workflow.',
-      '',
-    ].join('\n');
-  }
-  return [
-    `# brief-next — Phase 5 of 5: MEMORIZE (${memory.name})`,
-    `Ticket: ${ticket}`,
-    '',
-    '### Task',
-    `Persist your key decisions via \`${memory.rememberTool}\` so future agents can recall them. Save AT LEAST these entries (one tool call each — DO NOT batch into one entry):`,
-    '',
-    `1. **Ticket overview**: tag with the ticket ID and area-of-work keywords. Body = problem statement + goal from brief.md.`,
-    `2. **Sibling ownership map**: for each linked ticket (${linkedIds.length}), save the verdict from sibling-overlap.md with tags ${ticket}, sibling-overlap, and the linked ticket id.`,
-    `3. **P0 requirements**: save the Must Have (P0) list with tags ${ticket}, requirements, P0.`,
-    `4. **Open questions + their searches**: save each unresolved Open Question with the search trail. Tag ${ticket}, open-question, plus the area keyword.`,
-    `5. **Out-of-scope reasoning**: save the sibling-owned out-of-scope list so the next agent working on a related ticket can recall who owns what.`,
-    '',
-    memory.saveTool
-      ? `Finally, archive the session via \`${memory.saveTool}\` so the full conversation context is queryable.`
-      : '',
-    '',
-    '### Why this matters',
-    'When a sibling/follow-up ticket runs `brief-next` later, its INPUTS phase will recall these entries and avoid re-litigating decisions you already made. Skip this and you waste future agent time on questions you already answered.',
-    '',
-    'When done, re-invoke me and I will transition you to done.',
-    '',
-  ].join('\n');
-}
-
-function instructDone(ctx) {
-  return [
-    `# brief-next — DONE`,
-    `Ticket: ${ctx.ticket}`,
-    '',
-    'All five phases recorded. Artifacts:',
-    `- \`brief.md\``,
-    `- \`sibling-overlap.md\``,
-    `- \`_related/<id>.md\` (per linked ticket)`,
-    `- \`brief-phase.json\``,
-    '',
-    'Re-invoke /work2 (or /work) to advance to the brief_gate step.',
-    '',
-  ].join('\n');
-}
-
-// ─── Main ──────────────────────────────────────────────────────────────────
+// ─── Orchestrator ──────────────────────────────────────────────────────────
 
 function main(argv) {
   const startedAt = Date.now();
@@ -592,82 +228,35 @@ function main(argv) {
 
   const ctx = { ticket, tasksDir, tasksBase, manifest, linkedIds, memory, worktreeRoot };
 
-  // Validation gates: each phase validates inputs FROM the previous instruction.
-  // If validation fails, print the failures and the current-phase instructions.
-  let blockReason = '';
+  // Look up the registered handler for the current phase and ask it whether
+  // the phase is ready to advance. The phase handler does NOT perform the
+  // record/transition itself — that stays here so all state mutations live
+  // in one place.
+  const handler = getPhase(phase);
+  const verdict = handler.validate(ctx);
+
   let advanced = false;
+  let blockReason = '';
 
-  // advanceAfter(target, summary) — record current phase + transition to target.
-  // Returns true on success; on failure sets blockReason and returns false.
-  const advanceAfter = (target, summary) => {
-    const r = recordPhase(ticket, phase, summary);
-    if (r.code !== 0) {
-      blockReason = `Could not record phase ${phase}:\n${r.out}`;
-      return false;
-    }
-    const t = transitionPhase(ticket, target);
-    if (t.code !== 0) {
-      blockReason = `Could not transition to ${target}:\n${t.out}`;
-      return false;
-    }
-    advanced = true;
-    phase = target;
-    return true;
-  };
-
-  if (phase === BRIEF_PHASES.inputs) {
-    if (!manifest) {
-      blockReason = `related-tickets.json missing at ${path.join(tasksDir, 'related-tickets.json')}. Cannot proceed without sibling context.`;
+  if (verdict.ok && handler.next) {
+    const rec = recordPhase(ticket, phase, verdict.summary || '');
+    if (rec.code !== 0) {
+      blockReason = `Could not record phase ${phase}:\n${rec.out}`;
     } else {
-      const errs = validateInputs(tasksDir, manifest, linkedIds);
-      if (errs.length === 0) {
-        advanceAfter(
-          briefNextPhases(BRIEF_PHASES.inputs)[0],
-          `linked=${linkedIds.length} memory=${memory ? memory.name : 'none'}`
-        );
+      const t = transitionPhase(ticket, handler.next);
+      if (t.code !== 0) {
+        blockReason = `Could not transition to ${handler.next}:\n${t.out}`;
       } else {
-        blockReason = errs.join('\n');
+        advanced = true;
+        phase = handler.next;
       }
     }
-  } else if (phase === BRIEF_PHASES.overlap) {
-    const errs = validateOverlap(tasksDir, linkedIds);
-    if (errs.length === 0) {
-      advanceAfter(briefNextPhases(BRIEF_PHASES.overlap)[0], `siblings=${linkedIds.length}`);
-    } else {
-      blockReason = errs.join('\n');
-    }
-  } else if (phase === BRIEF_PHASES.draft) {
-    const errs = validateDraft(tasksDir);
-    if (errs.length === 0) {
-      advanceAfter(briefNextPhases(BRIEF_PHASES.draft)[0], 'brief.md drafted');
-    } else {
-      blockReason = errs.join('\n');
-    }
-  } else if (phase === BRIEF_PHASES.validate) {
-    const errs = validateValidate(tasksDir, linkedIds);
-    if (errs.length === 0) {
-      advanceAfter(briefNextPhases(BRIEF_PHASES.validate)[0], 'cross-checks ok');
-    } else {
-      blockReason = errs.join('\n');
-    }
-  } else if (phase === BRIEF_PHASES.memorize) {
-    // We can't verify memory writes (no introspection across plugins).
-    // Record on re-invoke; if no memory plugin, auto-advance.
-    const target = briefNextPhases(BRIEF_PHASES.memorize)[0];
-    if (!memory) {
-      advanceAfter(target, 'no-memory-plugin');
-    } else {
-      // First call in memorize prints instructions. Second call (when agent
-      // has finished saving) advances. We detect "second call" by the
-      // presence of a sentinel file the agent must touch after persisting.
-      const sentinel = path.join(tasksDir, '.brief-memorized');
-      if (fs.existsSync(sentinel)) {
-        advanceAfter(target, `via=${memory.name}`);
-      }
-    }
+  } else if (Array.isArray(verdict.errors) && verdict.errors.length > 0) {
+    blockReason = verdict.errors.join('\n');
   }
+  // Else: not ok but no errors — waiting (e.g. memorize before sentinel).
 
-  // Compose response
+  // Header + body
   const header = [
     `brief-next: ${ticket}`,
     `  tasks dir: ${tasksDir}`,
@@ -678,34 +267,25 @@ function main(argv) {
     '',
   ].join('\n');
 
-  const INSTRUCTORS = {
-    [BRIEF_PHASES.inputs]: instructInputs,
-    [BRIEF_PHASES.overlap]: instructOverlap,
-    [BRIEF_PHASES.draft]: instructDraft,
-    [BRIEF_PHASES.validate]: instructValidate,
-    [BRIEF_PHASES.memorize]: instructMemorize,
-    [BRIEF_PHASES.done]: instructDone,
-  };
-  const instructFor = (p) => (INSTRUCTORS[p] || instructMemorize)(ctx);
-
-  let body;
-  if (blockReason && !advanced) {
-    body = [
-      `## ❌ Phase ${phase.toUpperCase()} blocked`,
-      '',
-      '```',
-      blockReason,
-      '```',
-      '',
-      '---',
-      '',
-      instructFor(phase),
-    ].join('\n');
-  } else {
-    body = instructFor(phase);
-  }
+  const instructorPhase = getPhase(phase);
+  const instructions = instructorPhase.instructions(ctx);
+  const body =
+    blockReason && !advanced
+      ? [
+          `## ❌ Phase ${phase.toUpperCase()} blocked`,
+          '',
+          '```',
+          blockReason,
+          '```',
+          '',
+          '---',
+          '',
+          instructions,
+        ].join('\n')
+      : instructions;
 
   process.stdout.write(header + '\n' + body);
+
   const exitCode = blockReason && !advanced ? 2 : 0;
   logNextScriptEvent('brief-next', {
     event: 'completed',
@@ -730,4 +310,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { detectMemoryPlugin, BRIEF_PHASES };
+module.exports = { detectMemoryPlugin };

--- a/scripts/workflows/work-brief/brief-phase-registry.js
+++ b/scripts/workflows/work-brief/brief-phase-registry.js
@@ -1,0 +1,83 @@
+/**
+ * brief-phase-registry.js
+ *
+ * Central registry for brief-phase definitions, ordering, and transitions.
+ * Mirrors the shape of tdd-phase-registry.js so brief-phase-state.js and
+ * brief-next.js share one source of truth for phase names + edges.
+ *
+ * Phases (linear): inputs → overlap → draft → validate → memorize → done
+ *
+ * `done` is terminal — it has no outgoing edges.
+ *
+ * Usage:
+ *   const { BRIEF_PHASES, briefCanTransition } = require('./brief-phase-registry');
+ */
+
+'use strict';
+
+const BRIEF_PHASES = Object.freeze({
+  inputs: 'inputs',
+  overlap: 'overlap',
+  draft: 'draft',
+  validate: 'validate',
+  memorize: 'memorize',
+  done: 'done',
+});
+
+const BRIEF_PHASE_ORDER = Object.freeze([
+  BRIEF_PHASES.inputs,
+  BRIEF_PHASES.overlap,
+  BRIEF_PHASES.draft,
+  BRIEF_PHASES.validate,
+  BRIEF_PHASES.memorize,
+  BRIEF_PHASES.done,
+]);
+
+const BRIEF_PHASE_TRANSITIONS = Object.freeze({
+  [BRIEF_PHASES.inputs]: Object.freeze([BRIEF_PHASES.overlap]),
+  [BRIEF_PHASES.overlap]: Object.freeze([BRIEF_PHASES.draft]),
+  [BRIEF_PHASES.draft]: Object.freeze([BRIEF_PHASES.validate]),
+  [BRIEF_PHASES.validate]: Object.freeze([BRIEF_PHASES.memorize]),
+  [BRIEF_PHASES.memorize]: Object.freeze([BRIEF_PHASES.done]),
+  [BRIEF_PHASES.done]: Object.freeze([]),
+});
+
+/**
+ * Returns the list of phases reachable from `current` in one step.
+ * @param {string} current
+ * @returns {readonly string[]}
+ */
+function briefNextPhases(current) {
+  return BRIEF_PHASE_TRANSITIONS[current] || [];
+}
+
+/**
+ * @param {string} current
+ * @param {string} next
+ * @returns {boolean}
+ */
+function briefCanTransition(current, next) {
+  return briefNextPhases(current).includes(next);
+}
+
+/**
+ * @param {string} phase
+ * @returns {boolean}
+ */
+function isBriefPhase(phase) {
+  return Object.hasOwn(BRIEF_PHASES, phase);
+}
+
+const BRIEF_INITIAL_PHASE = BRIEF_PHASES.inputs;
+const BRIEF_TERMINAL_PHASE = BRIEF_PHASES.done;
+
+module.exports = {
+  BRIEF_PHASES,
+  BRIEF_PHASE_ORDER,
+  BRIEF_PHASE_TRANSITIONS,
+  BRIEF_INITIAL_PHASE,
+  BRIEF_TERMINAL_PHASE,
+  briefNextPhases,
+  briefCanTransition,
+  isBriefPhase,
+};

--- a/scripts/workflows/work-brief/brief-phase-state.js
+++ b/scripts/workflows/work-brief/brief-phase-state.js
@@ -31,6 +31,13 @@ const path = require('node:path');
 
 const { consumeToken } = require('../lib/scripts/write-report');
 const { normalizeAgentName } = require('../lib/agent-detection');
+const {
+  BRIEF_PHASE_ORDER,
+  BRIEF_INITIAL_PHASE,
+  briefNextPhases,
+  briefCanTransition,
+  isBriefPhase,
+} = require('./brief-phase-registry');
 
 let config;
 try {
@@ -44,14 +51,8 @@ const ALLOWED_AGENTS = ['brief-writer'];
 const GATED_SUBCOMMANDS = ['init', 'record', 'transition'];
 const TOKEN_MAX_AGE_MS = 10_000;
 
-const PHASES = ['inputs', 'overlap', 'draft', 'validate', 'memorize', 'done'];
-const VALID_TRANSITIONS = new Map([
-  ['inputs', new Set(['overlap'])],
-  ['overlap', new Set(['draft'])],
-  ['draft', new Set(['validate'])],
-  ['validate', new Set(['memorize'])],
-  ['memorize', new Set(['done'])],
-]);
+// Exported for back-compat with existing tests / importers.
+const PHASES = BRIEF_PHASE_ORDER;
 
 function errorExit(message) {
   process.stderr.write(JSON.stringify({ error: true, message }) + '\n');
@@ -155,7 +156,7 @@ function cmdInit(ticket) {
     ticket,
     createdAt: now,
     updatedAt: now,
-    currentPhase: 'inputs',
+    currentPhase: BRIEF_INITIAL_PHASE,
     phases: {},
   };
   writeState(ticket, state);
@@ -172,8 +173,8 @@ function cmdCurrent(ticket) {
 }
 
 function cmdRecord(ticket, phase, args) {
-  if (!PHASES.includes(phase)) {
-    errorExit(`Unknown phase "${phase}". Valid: ${PHASES.join(', ')}.`);
+  if (!isBriefPhase(phase)) {
+    errorExit(`Unknown phase "${phase}". Valid: ${BRIEF_PHASE_ORDER.join(', ')}.`);
   }
   const state = readState(ticket);
   if (!state) errorExit(`No brief-phase state for ${ticket}. Run \`init\` first.`);
@@ -186,16 +187,16 @@ function cmdRecord(ticket, phase, args) {
 }
 
 function cmdTransition(ticket, target) {
-  if (!PHASES.includes(target)) {
-    errorExit(`Unknown target phase "${target}". Valid: ${PHASES.join(', ')}.`);
+  if (!isBriefPhase(target)) {
+    errorExit(`Unknown target phase "${target}". Valid: ${BRIEF_PHASE_ORDER.join(', ')}.`);
   }
   const state = readState(ticket);
   if (!state) errorExit(`No brief-phase state for ${ticket}. Run \`init\` first.`);
-  const allowed = VALID_TRANSITIONS.get(state.currentPhase);
-  if (!allowed || !allowed.has(target)) {
+  if (!briefCanTransition(state.currentPhase, target)) {
+    const allowed = briefNextPhases(state.currentPhase);
     errorExit(
       `Invalid transition ${state.currentPhase} → ${target}. Allowed from ${state.currentPhase}: ${
-        allowed ? [...allowed].join(', ') : '(terminal)'
+        allowed.length ? allowed.join(', ') : '(terminal)'
       }.`
     );
   }
@@ -245,4 +246,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { PHASES, VALID_TRANSITIONS };
+module.exports = { PHASES, briefCanTransition, briefNextPhases };

--- a/scripts/workflows/work-brief/brief-phase-state.js
+++ b/scripts/workflows/work-brief/brief-phase-state.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+
+/**
+ * brief-phase-state.js
+ *
+ * Authorized writer for `tasks/<ticket>/brief-phase.json`. Mirrors the
+ * agent-gated pattern used by tdd-phase-state.js: only callable through
+ * Claude Code's agent system (token-protected), and only by the
+ * brief-writer agent during the `brief` step.
+ *
+ * Subcommands:
+ *   node brief-phase-state.js init       <TICKET>
+ *   node brief-phase-state.js current    <TICKET>
+ *   node brief-phase-state.js record     <TICKET> <phase> [--summary "..."]
+ *   node brief-phase-state.js transition <TICKET> <target>
+ *
+ * Phases (in order): inputs → overlap → draft → validate → memorize → done
+ *
+ * `memorize` is the persist-decisions phase: if a memory plugin like cortex
+ * is installed, the agent must save its key decisions (sibling-ownership
+ * verdicts, P0 picks, open-question resolutions) via the plugin's
+ * `*_remember` / `*_save` tool so future agents can `*_recall` them. The
+ * `inputs` phase is paired: it instructs the agent to `*_recall` first to
+ * surface relevant prior work before drafting.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { consumeToken } = require('../lib/scripts/write-report');
+const { normalizeAgentName } = require('../lib/agent-detection');
+
+let config;
+try {
+  config = require('../lib/config');
+} catch (e) {
+  if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
+  config = null;
+}
+
+const ALLOWED_AGENTS = ['brief-writer'];
+const GATED_SUBCOMMANDS = ['init', 'record', 'transition'];
+const TOKEN_MAX_AGE_MS = 10_000;
+
+const PHASES = ['inputs', 'overlap', 'draft', 'validate', 'memorize', 'done'];
+const VALID_TRANSITIONS = new Map([
+  ['inputs', new Set(['overlap'])],
+  ['overlap', new Set(['draft'])],
+  ['draft', new Set(['validate'])],
+  ['validate', new Set(['memorize'])],
+  ['memorize', new Set(['done'])],
+]);
+
+function errorExit(message) {
+  process.stderr.write(JSON.stringify({ error: true, message }) + '\n');
+  process.exit(1);
+}
+
+function successOut(data) {
+  process.stdout.write(JSON.stringify(data) + '\n');
+}
+
+function sanitizeId(ticketId) {
+  try {
+    return require('../lib/config').safeTicketId(ticketId);
+  } catch (e) {
+    if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
+    return ticketId;
+  }
+}
+
+function resolveTasksBase() {
+  return (
+    process.env.TASKS_BASE ||
+    (config && config.TASKS_BASE) ||
+    path.join(require('node:os').homedir(), 'worktrees', 'tasks')
+  );
+}
+
+function getStatePath(ticketId) {
+  if (!ticketId || /\.\.|[\\:\x00]/.test(ticketId)) {
+    throw new Error(`Invalid ticket ID: ${ticketId}`);
+  }
+  const base = path.resolve(resolveTasksBase());
+  const safeId = sanitizeId(ticketId);
+  const resolved = path.resolve(base, safeId, 'brief-phase.json');
+  if (!resolved.startsWith(base + path.sep)) {
+    throw new Error(`Invalid ticket ID: ${ticketId}`);
+  }
+  return resolved;
+}
+
+function readState(ticketId) {
+  const p = getStatePath(ticketId);
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function writeState(ticketId, state) {
+  const p = getStatePath(ticketId);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+  try {
+    fs.unlinkSync(p);
+  } catch (e) {
+    if (e && e.code !== 'ENOENT') throw e;
+  }
+  fs.renameSync(tmp, p);
+}
+
+function verifyToken() {
+  const scriptBasename = path.basename(__filename);
+  const token = consumeToken(scriptBasename);
+  if (!token) {
+    errorExit(
+      "No valid write token found. This script can only be called through Claude Code's agent system."
+    );
+  }
+  if (typeof token.timestamp !== 'number' || !Number.isFinite(token.timestamp)) {
+    errorExit('Token has invalid or missing timestamp.');
+  }
+  if (typeof token.agent !== 'string' || !token.agent) {
+    errorExit('Token has invalid or missing agent field.');
+  }
+  const age = Date.now() - token.timestamp;
+  if (age < 0) errorExit(`Write token timestamp is in the future (${Math.abs(age)}ms ahead).`);
+  if (age > TOKEN_MAX_AGE_MS)
+    errorExit(`Write token expired (${age}ms old, max ${TOKEN_MAX_AGE_MS}ms).`);
+  const agentNormalized = normalizeAgentName(token.agent);
+  if (!ALLOWED_AGENTS.includes(agentNormalized)) {
+    errorExit(
+      `Agent "${token.agent}" is not authorized. Allowed agents: ${ALLOWED_AGENTS.join(', ')}.`
+    );
+  }
+  return token;
+}
+
+function parseFlag(args, name) {
+  const i = args.indexOf(name);
+  if (i === -1 || i + 1 >= args.length) return null;
+  return args[i + 1];
+}
+
+function cmdInit(ticket) {
+  const existing = readState(ticket);
+  if (existing) {
+    successOut({ ok: true, status: 'exists', state: existing });
+    return;
+  }
+  const now = new Date().toISOString();
+  const state = {
+    ticket,
+    createdAt: now,
+    updatedAt: now,
+    currentPhase: 'inputs',
+    phases: {},
+  };
+  writeState(ticket, state);
+  successOut({ ok: true, status: 'created', state });
+}
+
+function cmdCurrent(ticket) {
+  const state = readState(ticket);
+  if (!state) {
+    successOut({ ok: true, currentPhase: null, state: null });
+    return;
+  }
+  successOut({ ok: true, currentPhase: state.currentPhase, state });
+}
+
+function cmdRecord(ticket, phase, args) {
+  if (!PHASES.includes(phase)) {
+    errorExit(`Unknown phase "${phase}". Valid: ${PHASES.join(', ')}.`);
+  }
+  const state = readState(ticket);
+  if (!state) errorExit(`No brief-phase state for ${ticket}. Run \`init\` first.`);
+  const summary = parseFlag(args, '--summary') || '';
+  const now = new Date().toISOString();
+  state.phases[phase] = { completedAt: now, summary };
+  state.updatedAt = now;
+  writeState(ticket, state);
+  successOut({ ok: true, recordedPhase: phase, state });
+}
+
+function cmdTransition(ticket, target) {
+  if (!PHASES.includes(target)) {
+    errorExit(`Unknown target phase "${target}". Valid: ${PHASES.join(', ')}.`);
+  }
+  const state = readState(ticket);
+  if (!state) errorExit(`No brief-phase state for ${ticket}. Run \`init\` first.`);
+  const allowed = VALID_TRANSITIONS.get(state.currentPhase);
+  if (!allowed || !allowed.has(target)) {
+    errorExit(
+      `Invalid transition ${state.currentPhase} → ${target}. Allowed from ${state.currentPhase}: ${
+        allowed ? [...allowed].join(', ') : '(terminal)'
+      }.`
+    );
+  }
+  if (!state.phases[state.currentPhase]) {
+    errorExit(
+      `Cannot transition: phase "${state.currentPhase}" has no recorded evidence. Run \`record ${ticket} ${state.currentPhase}\` first.`
+    );
+  }
+  const now = new Date().toISOString();
+  state.currentPhase = target;
+  state.updatedAt = now;
+  writeState(ticket, state);
+  successOut({ ok: true, currentPhase: target, state });
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  const sub = args[0];
+  if (!sub) {
+    errorExit('Usage: brief-phase-state.js <init|current|record|transition> <TICKET> [args]');
+  }
+  if (GATED_SUBCOMMANDS.includes(sub)) verifyToken();
+
+  const ticket = args[1];
+  if (!ticket) errorExit('Missing ticket ID.');
+
+  if (sub === 'init') return cmdInit(ticket);
+  if (sub === 'current') return cmdCurrent(ticket);
+  if (sub === 'record') {
+    const phase = args[2];
+    if (!phase) errorExit('Usage: brief-phase-state.js record <TICKET> <phase> [--summary "..."]');
+    return cmdRecord(ticket, phase, args.slice(3));
+  }
+  if (sub === 'transition') {
+    const target = args[2];
+    if (!target) errorExit('Usage: brief-phase-state.js transition <TICKET> <target>');
+    return cmdTransition(ticket, target);
+  }
+  errorExit(`Unknown subcommand: ${sub}`);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv);
+  } catch (e) {
+    errorExit(e.message);
+  }
+}
+
+module.exports = { PHASES, VALID_TRANSITIONS };

--- a/scripts/workflows/work-brief/brief-phase-state.js
+++ b/scripts/workflows/work-brief/brief-phase-state.js
@@ -112,9 +112,14 @@ function writeState(ticketId, state) {
   fs.renameSync(tmp, p);
 }
 
-function verifyToken() {
+function verifyToken(expectedTicketId) {
   const scriptBasename = path.basename(__filename);
-  const token = consumeToken(scriptBasename);
+  // Pass ticket id so consumeToken hits the per-ticket keyed path
+  // (/tmp/.claude-write-tokens/brief-phase-state.js.<TICKET>). The PreToolUse
+  // hook mints ONLY the keyed path post-suffix-strip — checking the
+  // legacy unkeyed path here would fail every time for any agent in a
+  // worktree session.
+  const token = consumeToken(scriptBasename, expectedTicketId);
   if (!token) {
     errorExit(
       "No valid write token found. This script can only be called through Claude Code's agent system."
@@ -218,10 +223,10 @@ function main(argv) {
   if (!sub) {
     errorExit('Usage: brief-phase-state.js <init|current|record|transition> <TICKET> [args]');
   }
-  if (GATED_SUBCOMMANDS.includes(sub)) verifyToken();
-
   const ticket = args[1];
   if (!ticket) errorExit('Missing ticket ID.');
+
+  if (GATED_SUBCOMMANDS.includes(sub)) verifyToken(ticket);
 
   if (sub === 'init') return cmdInit(ticket);
   if (sub === 'current') return cmdCurrent(ticket);

--- a/scripts/workflows/work-brief/lib/memory-plugin-config.js
+++ b/scripts/workflows/work-brief/lib/memory-plugin-config.js
@@ -1,0 +1,186 @@
+/**
+ * Memory-plugin configuration for brief-next.js.
+ *
+ * Detection candidates are normally hardcoded (cortex, mem0). This module
+ * exposes the same defaults but lets operators override them through env
+ * vars without editing source. Useful for: (a) adding a new plugin in
+ * a worktree without forking the codebase, (b) renaming tool identifiers
+ * if a plugin's MCP namespace changes, (c) disabling the memorize phase
+ * outright.
+ *
+ * Env contract (all optional):
+ *
+ *   BRIEF_MEMORY_DISABLED=1
+ *     Hard-disable. `loadMemoryPluginCandidates()` returns [] and
+ *     `detectMemoryPlugin()` returns null regardless of installed plugins.
+ *
+ *   BRIEF_MEMORY_PLUGINS_JSON='[{"name":"X","probe":"X","recallTool":"...","rememberTool":"..."}, ...]'
+ *     Full replacement. Parsed as a JSON array of candidate descriptors.
+ *     `probe` is compiled as a case-insensitive RegExp. `manifestGlob`
+ *     defaults to the standard plugin dirs if omitted. Invalid JSON →
+ *     warn on stderr, fall back to defaults.
+ *
+ *   BRIEF_MEMORY_PLUGIN_DIRS='dirA:dirB'
+ *     Colon-separated list of directories (relative to $HOME) to scan
+ *     instead of `.claude/plugins/marketplaces:.claude/plugins/cache`.
+ *     Applied to every candidate that doesn't specify its own
+ *     `manifestGlob`.
+ *
+ *   BRIEF_MEMORY_<NAME>_RECALL_TOOL=...
+ *   BRIEF_MEMORY_<NAME>_REMEMBER_TOOL=...
+ *   BRIEF_MEMORY_<NAME>_SAVE_TOOL=...
+ *     Per-plugin tool-name overrides. <NAME> is the upper-cased plugin
+ *     name (CORTEX, MEM0). `_SAVE_TOOL=none` clears the save tool.
+ */
+
+'use strict';
+
+const DEFAULT_MANIFEST_GLOB = Object.freeze([
+  '.claude/plugins/marketplaces',
+  '.claude/plugins/cache',
+]);
+
+const DEFAULT_CANDIDATES = Object.freeze([
+  Object.freeze({
+    name: 'cortex',
+    probe: /cortex/i,
+    manifestGlob: DEFAULT_MANIFEST_GLOB,
+    recallTool: 'mcp__plugin_cortex_cortex__cortex_recall',
+    rememberTool: 'mcp__plugin_cortex_cortex__cortex_remember',
+    saveTool: 'mcp__plugin_cortex_cortex__cortex_save',
+  }),
+  Object.freeze({
+    name: 'mem0',
+    probe: /mem0/i,
+    manifestGlob: DEFAULT_MANIFEST_GLOB,
+    recallTool: 'mem0_recall',
+    rememberTool: 'mem0_remember',
+    saveTool: null,
+  }),
+]);
+
+function getEnv(name, env) {
+  const v = env ? env[name] : process.env[name];
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+function isTruthy(v) {
+  return /^(1|true|yes|on)$/i.test(String(v || '').trim());
+}
+
+function parseManifestGlob(envValue) {
+  if (!envValue) return null;
+  const parts = envValue
+    .split(':')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return parts.length > 0 ? parts : null;
+}
+
+function compileProbe(probeSrc) {
+  if (probeSrc instanceof RegExp) return probeSrc;
+  if (typeof probeSrc !== 'string' || !probeSrc) return null;
+  try {
+    return new RegExp(probeSrc, 'i');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Apply per-plugin env overrides (BRIEF_MEMORY_<NAME>_RECALL_TOOL etc.)
+ * Mutates a shallow clone and returns it.
+ */
+function applyEnvOverrides(candidate, env) {
+  const upper = String(candidate.name || '').toUpperCase();
+  if (!upper) return candidate;
+  const recall = getEnv(`BRIEF_MEMORY_${upper}_RECALL_TOOL`, env);
+  const remember = getEnv(`BRIEF_MEMORY_${upper}_REMEMBER_TOOL`, env);
+  const save = getEnv(`BRIEF_MEMORY_${upper}_SAVE_TOOL`, env);
+  const out = { ...candidate };
+  if (recall) out.recallTool = recall;
+  if (remember) out.rememberTool = remember;
+  if (save) out.saveTool = save.toLowerCase() === 'none' ? null : save;
+  return out;
+}
+
+function parseCustomCandidates(jsonSrc, defaultManifestGlob) {
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonSrc);
+  } catch (err) {
+    process.stderr.write(
+      `brief-next: BRIEF_MEMORY_PLUGINS_JSON is not valid JSON (${err.message}); falling back to defaults.\n`
+    );
+    return null;
+  }
+  if (!Array.isArray(parsed)) {
+    process.stderr.write(
+      `brief-next: BRIEF_MEMORY_PLUGINS_JSON must be a JSON array; falling back to defaults.\n`
+    );
+    return null;
+  }
+  const out = [];
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== 'object') continue;
+    const probe = compileProbe(entry.probe);
+    if (!entry.name || !probe || !entry.recallTool || !entry.rememberTool) {
+      process.stderr.write(
+        `brief-next: BRIEF_MEMORY_PLUGINS_JSON entry missing required fields (name/probe/recallTool/rememberTool); skipping.\n`
+      );
+      continue;
+    }
+    out.push({
+      name: String(entry.name),
+      probe,
+      manifestGlob: Array.isArray(entry.manifestGlob) ? entry.manifestGlob : defaultManifestGlob,
+      recallTool: String(entry.recallTool),
+      rememberTool: String(entry.rememberTool),
+      saveTool: entry.saveTool ? String(entry.saveTool) : null,
+    });
+  }
+  return out;
+}
+
+/**
+ * Compute the active candidate list, applying env overrides.
+ *
+ * @param {object} [env] — defaults to process.env; pass an explicit object
+ *   for tests to avoid touching the live environment.
+ * @returns {Array<{name, probe: RegExp, manifestGlob: string[], recallTool, rememberTool, saveTool}>}
+ */
+function loadMemoryPluginCandidates(env = process.env) {
+  if (isTruthy(getEnv('BRIEF_MEMORY_DISABLED', env))) return [];
+
+  const customManifestGlob =
+    parseManifestGlob(getEnv('BRIEF_MEMORY_PLUGIN_DIRS', env)) || DEFAULT_MANIFEST_GLOB;
+
+  const jsonSrc = getEnv('BRIEF_MEMORY_PLUGINS_JSON', env);
+  let base;
+  if (jsonSrc) {
+    const custom = parseCustomCandidates(jsonSrc, customManifestGlob);
+    base = custom !== null ? custom : DEFAULT_CANDIDATES;
+  } else {
+    base = DEFAULT_CANDIDATES;
+  }
+
+  return base.map((c) => {
+    const withGlob = {
+      ...c,
+      manifestGlob:
+        c.manifestGlob && c.manifestGlob !== DEFAULT_MANIFEST_GLOB
+          ? c.manifestGlob
+          : customManifestGlob,
+    };
+    return applyEnvOverrides(withGlob, env);
+  });
+}
+
+module.exports = {
+  loadMemoryPluginCandidates,
+  DEFAULT_CANDIDATES,
+  DEFAULT_MANIFEST_GLOB,
+  // exported for tests
+  parseCustomCandidates,
+  applyEnvOverrides,
+};

--- a/scripts/workflows/work-brief/lib/phase-registry.js
+++ b/scripts/workflows/work-brief/lib/phase-registry.js
@@ -1,0 +1,66 @@
+/**
+ * Brief phase dispatcher.
+ *
+ * Mirrors check2/lib/step-registry.js. Each phase registers a handler shape:
+ *
+ *   {
+ *     next: string|null,                              // next phase to transition to, or null (terminal)
+ *     validate(ctx) => { ok, errors?: string[], summary?: string },
+ *     instructions(ctx) => string                     // markdown printed to agent
+ *   }
+ *
+ * The orchestrator (brief-next.js) has NO phase-specific logic — it looks
+ * up the current phase here, calls validate, advances on ok, and prints
+ * instructions from the (possibly new) phase.
+ *
+ * Add a new phase by creating `phases/<name>.js` and `require`-ing it below.
+ */
+
+'use strict';
+
+const handlers = Object.create(null);
+
+/**
+ * @param {string} phaseName
+ * @param {{
+ *   next: string|null,
+ *   validate: (ctx: object) => { ok: boolean, errors?: string[], summary?: string },
+ *   instructions: (ctx: object) => string,
+ * }} handler
+ */
+function registerPhase(phaseName, handler) {
+  if (
+    !handler ||
+    typeof handler.validate !== 'function' ||
+    typeof handler.instructions !== 'function'
+  ) {
+    throw new Error(
+      `Invalid phase handler for "${phaseName}" — must expose validate() and instructions()`
+    );
+  }
+  handlers[phaseName] = handler;
+}
+
+/**
+ * Look up a phase handler. Throws if the phase is unknown — callers should
+ * only ever pass a phase name from brief-phase-registry.js's BRIEF_PHASES.
+ */
+function getPhase(phaseName) {
+  const h = handlers[phaseName];
+  if (!h) throw new Error(`No brief phase handler registered for "${phaseName}"`);
+  return h;
+}
+
+function hasPhase(phaseName) {
+  return Boolean(handlers[phaseName]);
+}
+
+// ─── Register all phases ────────────────────────────────────────────────────
+require('./phases/inputs')(registerPhase);
+require('./phases/overlap')(registerPhase);
+require('./phases/draft')(registerPhase);
+require('./phases/validate')(registerPhase);
+require('./phases/memorize')(registerPhase);
+require('./phases/done')(registerPhase);
+
+module.exports = { registerPhase, getPhase, hasPhase };

--- a/scripts/workflows/work-brief/lib/phases/done.js
+++ b/scripts/workflows/work-brief/lib/phases/done.js
@@ -1,0 +1,39 @@
+/**
+ * Phase: done — terminal. No advance, no validation, just instructions.
+ */
+
+'use strict';
+
+const { BRIEF_PHASES } = require('../../brief-phase-registry');
+
+function validate() {
+  // done is terminal — never advances.
+  return { ok: false, errors: [] };
+}
+
+function instructions(ctx) {
+  return [
+    `# brief-next — DONE`,
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'All five phases recorded. Artifacts:',
+    `- \`brief.md\``,
+    `- \`sibling-overlap.md\``,
+    `- \`_related/<id>.md\` (per linked ticket)`,
+    `- \`brief-phase.json\``,
+    '',
+    'Re-invoke /work2 (or /work) to advance to the brief_gate step.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(BRIEF_PHASES.done, {
+    next: null,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;

--- a/scripts/workflows/work-brief/lib/phases/draft.js
+++ b/scripts/workflows/work-brief/lib/phases/draft.js
@@ -1,0 +1,140 @@
+/**
+ * Phase: draft — brief.md with required sections + searched Open Questions.
+ *
+ * The agent investigates ambiguities BEFORE drafting (each Open Question
+ * carries a `Searched:` annotation listing the paths/queries consulted),
+ * then writes brief.md. We validate every required section is present and
+ * every Open Question is annotated.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { BRIEF_PHASES } = require('../../brief-phase-registry');
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+// Headings ending in `)` (like `### Must Have (P0)`) followed by `\n` are
+// two non-word chars in a row, where `\b` does NOT match. Using
+// `(?=\s|$)` is correct for both word-ending and paren-ending headings.
+const REQUIRED_BRIEF_SECTIONS = [
+  /^##\s+Problem Statement(?=\s|$)/im,
+  /^##\s+Goal(?=\s|$)/im,
+  /^##\s+Target Users(?=\s|$)/im,
+  /^###\s+Must Have\s*\(P0\)(?=\s|$)/im,
+  /^##\s+Constraints(?=\s|$)/im,
+  /^##\s+Out of scope\s*\(sibling-owned\)(?=\s|$)/im,
+  /^##\s+Success Metrics(?=\s|$)/im,
+  /^##\s+Open Questions(?=\s|$)/im,
+];
+
+function sliceSection(text, headerRe) {
+  const m = text.match(headerRe);
+  if (!m) return null;
+  const after = text.slice(m.index + m[0].length);
+  const next = after.match(/^##\s/m);
+  return next ? after.slice(0, next.index) : after;
+}
+
+function validateArtifacts(tasksDir) {
+  const errors = [];
+  const f = path.join(tasksDir, 'brief.md');
+  const c = readFile(f);
+  if (!c) {
+    errors.push(`Missing ${f}.`);
+    return errors;
+  }
+  for (const re of REQUIRED_BRIEF_SECTIONS) {
+    if (!re.test(c)) errors.push(`brief.md missing required section: ${re}.`);
+  }
+  // Open Questions: each non-empty entry must carry a `Searched:` line.
+  // The "no open questions" placeholder is `- _None._` (or `- None.`,
+  // `- N/A`) — recognised and exempt from the annotation requirement.
+  const oq = sliceSection(c, /^##\s+Open Questions\b/im) || '';
+  const EMPTY_PLACEHOLDER_RE = /^[-*+]\s+(?:_?(?:none|n\/a|nothing)\b\.?_?|—|-)\s*$/i;
+  const bullets = oq
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => /^[-*+]\s+/.test(l));
+  for (const b of bullets) {
+    if (EMPTY_PLACEHOLDER_RE.test(b)) continue;
+    if (!/Searched:/i.test(b)) {
+      const idx = oq.indexOf(b);
+      const tail = oq.slice(idx + b.length, idx + b.length + 400);
+      if (!/Searched:/i.test(tail)) {
+        errors.push(
+          `Open Question without 'Searched:' annotation: "${b.slice(0, 100)}". Each open question must list what docs/code you searched (paths + patterns) before leaving it open. If you have no open questions, write '- _None._' under the heading.`
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+function validate(ctx) {
+  const errors = validateArtifacts(ctx.tasksDir);
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, summary: 'brief.md drafted' };
+}
+
+function instructions(ctx) {
+  const { ticket, tasksDir } = ctx;
+  const briefPath = path.join(tasksDir, 'brief.md');
+  return [
+    `# brief-next — Phase 3 of 5: DRAFT`,
+    `Ticket: ${ticket}`,
+    '',
+    '### Before drafting: investigate docs for ambiguities',
+    "List every ambiguity you would otherwise drop into Open Questions. For EACH ambiguity, search the project docs (README, docs/, ADRs, design notes, this plugin's own AGENTS.md) AND the codebase for prior resolutions BEFORE leaving it open. If a search resolves the ambiguity, fold the answer into the brief proper. If not, leave it open AND record what you searched.",
+    '',
+    '### Required brief structure',
+    `Write \`${briefPath}\` with all of the following sections (exact headings):`,
+    '',
+    '- `## Problem Statement` — one paragraph, user-facing pain.',
+    '- `## Goal` — one paragraph, measurable outcome.',
+    '- `## Target Users` — bulleted list of personas.',
+    '- `## Requirements`',
+    '  - `### Must Have (P0)` — numbered list. Each P0 maps to one or more ticket AC items.',
+    '  - `### Should Have (P1)` — optional, numbered.',
+    '  - `### Could Have (P2)` — optional, numbered.',
+    '- `## Constraints` — bulleted: timelines, tech limits, compliance.',
+    '- `## Out of scope (sibling-owned)` — populated from sibling-overlap.md (every sibling marked `sibling-owned`). One bullet per surface, citing the sibling ID.',
+    '- `## Success Metrics` — bulleted measurable outcomes.',
+    '- `## Open Questions` — bulleted. Each MUST carry a `Searched:` annotation listing what you looked at, e.g.:',
+    '',
+    '  ```',
+    '  - Should the retry use exponential backoff or fixed delay?',
+    '    Searched: docs/architecture/retry.md, ADR-014, grep "backoff" in services/ → no prior decision.',
+    '  ```',
+    '',
+    '  If you have no open questions, write `- _None._` under the heading. Do NOT use the section as a parking lot for unsearched ambiguities.',
+    '',
+    '### What I will check before advancing',
+    `- All required sections present in \`${briefPath}\``,
+    '- Every Open Questions bullet has a `Searched:` annotation OR the section contains `_None._`',
+    '',
+    'When done, re-invoke me.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(BRIEF_PHASES.draft, {
+    next: BRIEF_PHASES.validate,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.validateArtifacts = validateArtifacts;
+module.exports.REQUIRED_BRIEF_SECTIONS = REQUIRED_BRIEF_SECTIONS;

--- a/scripts/workflows/work-brief/lib/phases/inputs.js
+++ b/scripts/workflows/work-brief/lib/phases/inputs.js
@@ -1,0 +1,119 @@
+/**
+ * Phase: inputs — fetch ticket + every linked ticket's full content into _related/.
+ *
+ * The agent must (1) recall prior memory if a plugin is installed and
+ * (2) save each linked ticket's full description to `_related/<id>.md`.
+ * We validate the manifest exists and that every `_related/<id>.md` is
+ * present with at least 50 chars of body.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { BRIEF_PHASES } = require('../../brief-phase-registry');
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function validateArtifacts(tasksDir, manifest, linkedIds) {
+  const errors = [];
+  if (!manifest) {
+    errors.push(
+      `related-tickets.json missing at ${path.join(tasksDir, 'related-tickets.json')}. Cannot proceed without sibling context.`
+    );
+    return errors;
+  }
+  // No linked tickets => nothing to put in _related/ => nothing to check.
+  if (linkedIds.length === 0) return errors;
+
+  const relDir = path.join(tasksDir, '_related');
+  if (!fs.existsSync(relDir)) {
+    errors.push(
+      `Missing directory ${relDir}. Save each linked ticket's full content as ${relDir}/<TICKET-ID>.md.`
+    );
+    return errors;
+  }
+  for (const id of linkedIds) {
+    const f = path.join(relDir, `${id}.md`);
+    const c = readFile(f);
+    if (!c || c.trim().length < 50) {
+      errors.push(
+        `Missing or too-short ${f} (< 50 chars). Fetch the linked ticket's FULL description (not just title) and save it here.`
+      );
+    }
+  }
+  return errors;
+}
+
+function validate(ctx) {
+  const errors = validateArtifacts(ctx.tasksDir, ctx.manifest, ctx.linkedIds);
+  if (errors.length > 0) return { ok: false, errors };
+  return {
+    ok: true,
+    summary: `linked=${ctx.linkedIds.length} memory=${ctx.memory ? ctx.memory.name : 'none'}`,
+  };
+}
+
+function instructions(ctx) {
+  const { ticket, tasksDir, linkedIds, manifest, memory } = ctx;
+  const memBlock = memory
+    ? [
+        '',
+        `### 0. Recall prior memory (${memory.name})`,
+        `Before reading anything, call \`${memory.recallTool}\` with each of these queries (one call per query) and read the results:`,
+        `- \`${ticket}\``,
+        `- the ticket title (extract from related-tickets.json self field if present)`,
+        `- "${ticket} brief"`,
+        `- "sibling overlap" + the area of work (e.g. tRPC, schema, component name)`,
+        `- "past decisions" + the area of work`,
+        '',
+        'Treat any hits as authoritative prior context — read them in full before you draft anything. If multiple agents have already decided how to scope this ticket, do not re-litigate; carry the decision forward.',
+      ]
+    : [
+        '',
+        '### 0. Recall prior memory',
+        'No memory plugin detected. Skipping recall step. If you have a memory plugin installed, surface it to the orchestrator so this step can be enabled.',
+      ];
+  return [
+    `# brief-next — Phase 1 of 5: INPUTS`,
+    `Ticket: ${ticket}`,
+    `Tasks dir: ${tasksDir}`,
+    '',
+    ...memBlock,
+    '',
+    '### 1. Read your own ticket',
+    `Open the ticket payload your previous workflow step fetched (typically under \`${path.join(tasksDir, 'ticket')}.{md,json}\` or surfaced in the previous step output). Read every field: title, description, acceptance criteria, comments. Take notes.`,
+    '',
+    '### 2. Read every linked ticket — FULL CONTENT, not just title',
+    manifest
+      ? `\`related-tickets.json\` lists ${linkedIds.length} linked ticket(s): ${linkedIds.join(', ') || '(none)'}. For EACH id, fetch the full description (jira/linear/gh) and save it to \`${path.join(tasksDir, '_related')}/<id>.md\`. Title is not enough — you must read the full body to detect overlaps in phase 2.`
+      : 'No `related-tickets.json` found. Generate it first via the related-tickets-inject step or have the orchestrator regenerate it. This script will block until the manifest is present.',
+    '',
+    '### What I will check before advancing',
+    `- \`${path.join(tasksDir, 'related-tickets.json')}\` exists`,
+    `- For every linked ticket id, \`${path.join(tasksDir, '_related')}/<id>.md\` exists with at least 50 chars of body (title-only files are rejected)`,
+    '',
+    'When done, re-invoke me.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(BRIEF_PHASES.inputs, {
+    next: BRIEF_PHASES.overlap,
+    validate,
+    instructions,
+  });
+};
+
+// Exposed for tests.
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.validateArtifacts = validateArtifacts;

--- a/scripts/workflows/work-brief/lib/phases/memorize.js
+++ b/scripts/workflows/work-brief/lib/phases/memorize.js
@@ -1,0 +1,86 @@
+/**
+ * Phase: memorize — persist key decisions to an installed memory plugin.
+ *
+ * Three transition modes:
+ *   - No memory plugin → auto-advance with summary `no-memory-plugin`.
+ *   - Memory plugin + `.brief-memorized` sentinel present → advance with
+ *     summary `via=<plugin name>`.
+ *   - Memory plugin + no sentinel → WAIT (not blocked, just no-advance).
+ *     This is signalled by `validate` returning `ok: false, errors: []`.
+ *
+ * The sentinel pattern lets the agent declare "I've persisted my decisions"
+ * via a single file touch — we can't introspect plugin tools to verify
+ * remember calls actually happened.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { BRIEF_PHASES } = require('../../brief-phase-registry');
+
+function validate(ctx) {
+  const { memory, tasksDir } = ctx;
+  if (!memory) {
+    return { ok: true, summary: 'no-memory-plugin' };
+  }
+  const sentinel = path.join(tasksDir, '.brief-memorized');
+  if (fs.existsSync(sentinel)) {
+    return { ok: true, summary: `via=${memory.name}` };
+  }
+  // Waiting (not blocked) — agent hasn't touched sentinel yet.
+  return { ok: false, errors: [] };
+}
+
+function instructions(ctx) {
+  const { ticket, memory, linkedIds, tasksDir } = ctx;
+  if (!memory) {
+    return [
+      `# brief-next — Phase 5 of 5: MEMORIZE (skipped)`,
+      '',
+      'No memory plugin detected on this machine. Recording phase as complete with `summary=no-memory-plugin` and advancing to done.',
+      '',
+      'To enable memory persistence, install a plugin like cortex and re-run this workflow.',
+      '',
+    ].join('\n');
+  }
+  const sentinel = path.join(tasksDir, '.brief-memorized');
+  return [
+    `# brief-next — Phase 5 of 5: MEMORIZE (${memory.name})`,
+    `Ticket: ${ticket}`,
+    '',
+    '### Task',
+    `Persist your key decisions via \`${memory.rememberTool}\` so future agents can recall them. Save AT LEAST these entries (one tool call each — DO NOT batch into one entry):`,
+    '',
+    `1. **Ticket overview**: tag with the ticket ID and area-of-work keywords. Body = problem statement + goal from brief.md.`,
+    `2. **Sibling ownership map**: for each linked ticket (${linkedIds.length}), save the verdict from sibling-overlap.md with tags ${ticket}, sibling-overlap, and the linked ticket id.`,
+    `3. **P0 requirements**: save the Must Have (P0) list with tags ${ticket}, requirements, P0.`,
+    `4. **Open questions + their searches**: save each unresolved Open Question with the search trail. Tag ${ticket}, open-question, plus the area keyword.`,
+    `5. **Out-of-scope reasoning**: save the sibling-owned out-of-scope list so the next agent working on a related ticket can recall who owns what.`,
+    '',
+    memory.saveTool
+      ? `Finally, archive the session via \`${memory.saveTool}\` so the full conversation context is queryable.`
+      : '',
+    '',
+    '### How I detect completion',
+    `After saving every entry above, \`touch ${sentinel}\` so I know to advance. Without that file I will stay on MEMORIZE.`,
+    '',
+    '### Why this matters',
+    'When a sibling/follow-up ticket runs `brief-next` later, its INPUTS phase will recall these entries and avoid re-litigating decisions you already made. Skip this and you waste future agent time on questions you already answered.',
+    '',
+    'When done, re-invoke me and I will transition you to done.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(BRIEF_PHASES.memorize, {
+    next: BRIEF_PHASES.done,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;

--- a/scripts/workflows/work-brief/lib/phases/overlap.js
+++ b/scripts/workflows/work-brief/lib/phases/overlap.js
@@ -1,0 +1,107 @@
+/**
+ * Phase: overlap — sibling-overlap.md with verdicts per linked ticket.
+ *
+ * The agent reads each `_related/<id>.md` and writes a verdict per linked
+ * ticket: `sibling-owned | shared | no-overlap`. We validate the file
+ * exists, has a `## <id>` section per linked ticket, and each section
+ * carries the canonical `**Verdict:** ...` line.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { BRIEF_PHASES } = require('../../brief-phase-registry');
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function validateArtifacts(tasksDir, linkedIds) {
+  const errors = [];
+  const f = path.join(tasksDir, 'sibling-overlap.md');
+  const c = readFile(f);
+  if (!c) {
+    errors.push(`Missing ${f}.`);
+    return errors;
+  }
+  for (const id of linkedIds) {
+    const headerRe = new RegExp(`^##\\s+${id}\\b`, 'm');
+    if (!headerRe.test(c)) {
+      errors.push(`sibling-overlap.md is missing section for ${id} (expected '## ${id}').`);
+      continue;
+    }
+    const startIdx = c.match(headerRe).index;
+    const after = c.slice(startIdx);
+    const nextHdr = after.slice(2).match(/^##\s/m);
+    const section = nextHdr ? after.slice(0, nextHdr.index + 2) : after;
+    if (!/\*\*Verdict:\*\*\s*(sibling-owned|shared|no-overlap)\b/i.test(section)) {
+      errors.push(
+        `sibling-overlap.md section for ${id} missing '**Verdict:** sibling-owned|shared|no-overlap'.`
+      );
+    }
+  }
+  return errors;
+}
+
+function validate(ctx) {
+  const errors = validateArtifacts(ctx.tasksDir, ctx.linkedIds);
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, summary: `siblings=${ctx.linkedIds.length}` };
+}
+
+function instructions(ctx) {
+  const { ticket, tasksDir, linkedIds } = ctx;
+  const overlapPath = path.join(tasksDir, 'sibling-overlap.md');
+  return [
+    `# brief-next — Phase 2 of 5: OVERLAP`,
+    `Ticket: ${ticket}`,
+    '',
+    '### Task',
+    `Read every file in \`${path.join(tasksDir, '_related')}/\`. For each linked ticket (${linkedIds.length}), decide whether your ticket overlaps with theirs in any surface: file paths, tRPC procedures, schemas, components, endpoints, DB tables, environment variables, or product flows.`,
+    '',
+    `Write \`${overlapPath}\` in this exact format:`,
+    '',
+    '```markdown',
+    '# Sibling Overlap Analysis',
+    '',
+    '## <TICKET-ID> — <title>',
+    '**Verdict:** sibling-owned | shared | no-overlap',
+    '**Surfaces:** comma-separated list of overlapping surfaces (file paths, procedures, schemas...)',
+    '**Notes:** one-to-three sentence rationale, citing specific lines/paragraphs from the sibling description that informed the verdict.',
+    '',
+    '## <NEXT-TICKET-ID> — ...',
+    '...',
+    '```',
+    '',
+    '### Verdict semantics',
+    "- **sibling-owned** — the surface is theirs; you must put it in your brief's `## Out of scope (sibling-owned)` and not implement it.",
+    '- **shared** — both tickets touch it; coordination required. Note who owns the change.',
+    '- **no-overlap** — different concerns; no risk of stepping on each other.',
+    '',
+    '### What I will check before advancing',
+    `- \`${overlapPath}\` exists`,
+    `- One \`## <TICKET-ID>\` section per linked ticket (${linkedIds.length} sections)`,
+    `- Each section has a \`**Verdict:**\` line with one of the three values`,
+    '',
+    'When done, re-invoke me.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(BRIEF_PHASES.overlap, {
+    next: BRIEF_PHASES.draft,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.validateArtifacts = validateArtifacts;

--- a/scripts/workflows/work-brief/lib/phases/validate.js
+++ b/scripts/workflows/work-brief/lib/phases/validate.js
@@ -1,0 +1,98 @@
+/**
+ * Phase: validate — cross-check brief.md ↔ sibling-overlap.md.
+ *
+ * Every sibling-overlap.md section marked `sibling-owned` must appear in
+ * brief.md's `Out of scope (sibling-owned)` section. This catches the
+ * agent writing a verdict in one file but forgetting to land it in the
+ * brief.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { BRIEF_PHASES } = require('../../brief-phase-registry');
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function sliceSection(text, headerRe) {
+  const m = text.match(headerRe);
+  if (!m) return null;
+  const after = text.slice(m.index + m[0].length);
+  const next = after.match(/^##\s/m);
+  return next ? after.slice(0, next.index) : after;
+}
+
+function validateArtifacts(tasksDir, linkedIds) {
+  const errors = [];
+  const briefPath = path.join(tasksDir, 'brief.md');
+  const overlapPath = path.join(tasksDir, 'sibling-overlap.md');
+  const brief = readFile(briefPath);
+  const overlap = readFile(overlapPath);
+  if (!brief) errors.push(`Missing ${briefPath}.`);
+  if (!overlap) errors.push(`Missing ${overlapPath}.`);
+  if (!brief || !overlap) return errors;
+
+  const oos = sliceSection(brief, /^##\s+Out of scope\s*\(sibling-owned\)\b/im) || '';
+  for (const id of linkedIds) {
+    const headerRe = new RegExp(`^##\\s+${id}\\b`, 'm');
+    const m = overlap.match(headerRe);
+    if (!m) continue;
+    const startIdx = m.index;
+    const after = overlap.slice(startIdx);
+    const nextHdr = after.slice(2).match(/^##\s/m);
+    const section = nextHdr ? after.slice(0, nextHdr.index + 2) : after;
+    const verdict = (section.match(/\*\*Verdict:\*\*\s*(sibling-owned|shared|no-overlap)/i) ||
+      [])[1];
+    if (verdict && verdict.toLowerCase() === 'sibling-owned') {
+      if (!oos.includes(id)) {
+        errors.push(
+          `brief.md 'Out of scope (sibling-owned)' is missing ${id}, which sibling-overlap.md marks sibling-owned.`
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+function validate(ctx) {
+  const errors = validateArtifacts(ctx.tasksDir, ctx.linkedIds);
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, summary: 'cross-checks ok' };
+}
+
+function instructions(ctx) {
+  const { ticket } = ctx;
+  return [
+    `# brief-next — Phase 4 of 5: VALIDATE`,
+    `Ticket: ${ticket}`,
+    '',
+    '### What I check',
+    `- \`brief.md\` has every required section.`,
+    `- Every linked ticket marked \`sibling-owned\` in sibling-overlap.md is referenced in brief.md's \`Out of scope (sibling-owned)\`.`,
+    '',
+    'If validation passes, I record the phase and advance you to MEMORIZE. If it fails, I print the gaps and you fix them.',
+    '',
+    'Re-invoke me to run the check.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(BRIEF_PHASES.validate, {
+    next: BRIEF_PHASES.memorize,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.validateArtifacts = validateArtifacts;

--- a/scripts/workflows/work-implement/__tests__/auto-init-record.test.js
+++ b/scripts/workflows/work-implement/__tests__/auto-init-record.test.js
@@ -1,0 +1,193 @@
+'use strict';
+
+/**
+ * Regression test for the auto-init-on-record fix in recordEvidence
+ * (task-next.js, commit ea27b7f6).
+ *
+ * Walks the full RED → GREEN → REFACTOR cycle via direct spawn of
+ * task-next.js against a temp-dir synthetic ticket. Proves:
+ *   1. First record (RED) auto-inits the per-task tdd-phase.json
+ *      (no manual `init` needed).
+ *   2. Subsequent records (GREEN, REFACTOR) do NOT re-init (cycle
+ *      history is preserved across phases).
+ *   3. Final tdd-phase.json carries evidence for all three phases.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const TASK_NEXT = path.resolve(__dirname, '..', 'task-next.js');
+const TOKEN_DIR = '/tmp/.claude-write-tokens';
+
+function mintToken(scriptBasename) {
+  fs.mkdirSync(TOKEN_DIR, { recursive: true, mode: 0o700 });
+  const tp = path.join(TOKEN_DIR, scriptBasename);
+  fs.writeFileSync(
+    tp,
+    JSON.stringify({
+      agent: 'developer-nodejs-tdd',
+      timestamp: Date.now(),
+      tasksBase: null,
+    }),
+    { mode: 0o600 }
+  );
+  return tp;
+}
+
+function runTaskNext(ticket, taskArg, env) {
+  // Mint tokens before invoking — task-next.js will consume them via
+  // its companion script chain. The hook normally mints these for us
+  // when an authorized agent invokes the script, but tests spawn it
+  // directly so we pre-mint.
+  mintToken('task-next.js');
+  mintToken('tdd-phase-state.js');
+  return spawnSync(process.execPath, [TASK_NEXT, ticket, taskArg], {
+    cwd: env.cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      TASKS_BASE: env.TASKS_BASE,
+      NEXT_SCRIPT_LOG: '0', // quiet logging
+    },
+  });
+}
+
+describe('task-next.js auto-init in recordEvidence (regression for ea27b7f6)', () => {
+  let tmp;
+  let tasksBase;
+  let worktree;
+  let ticket = 'GH-99991';
+  let phaseFile;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'task-next-autoinit-'));
+    tasksBase = path.join(tmp, 'tasks');
+    worktree = path.join(tmp, 'wt');
+    fs.mkdirSync(path.join(tasksBase, ticket, 'task1'), { recursive: true });
+    fs.mkdirSync(path.join(worktree, 'tmp', 'dbg'), { recursive: true });
+
+    // Workspace marker (so requireTicketWorkspace passes).
+    fs.writeFileSync(path.join(tasksBase, ticket, 'ticket.json'), JSON.stringify({ id: ticket }));
+
+    // tasks.md with a real failing test command.
+    fs.writeFileSync(
+      path.join(tasksBase, ticket, 'tasks.md'),
+      [
+        '# Tasks',
+        '',
+        `_Ticket: ${ticket}_`,
+        '',
+        '## Task 1 — Multiply helper',
+        '',
+        '### Type',
+        'backend',
+        '',
+        '### Test Command',
+        '```bash',
+        'node tmp/dbg/multiply.test.js',
+        '```',
+        '',
+        '### Suggested Scope',
+        '- `tmp/dbg/multiply.test.js`',
+        '- `tmp/dbg/multiply.js`',
+        '',
+      ].join('\n')
+    );
+
+    // Test file:
+    // - Contains a `test()` block so task-next.js's
+    //   countTestBlocksInFiles() counts it (required for unit-only RED
+    //   fallback when there are no @task:N gherkin scenarios).
+    // - Exits non-zero deterministically when multiply.js is missing,
+    //   exits zero when present — so task-next.js sees the correct
+    //   phase signal. Bypasses `node --test`'s quirk of always
+    //   returning 0 in some node versions even when subtests fail.
+    fs.writeFileSync(
+      path.join(worktree, 'tmp', 'dbg', 'multiply.test.js'),
+      `const { test } = require('node:test');
+let mod;
+try { mod = require('./multiply'); } catch { mod = null; }
+test('multiply doubles', () => {});
+const got = mod && mod.multiply ? mod.multiply(3) : null;
+if (got !== 6) {
+  console.error('FAIL: expected 6, got', got);
+  process.exit(1);
+}
+console.log('PASS');
+process.exit(0);
+`
+    );
+
+    // Make worktree a git repo so resolveWorktreeRoot works.
+    spawnSync('git', ['init', '-q', worktree], { stdio: 'ignore' });
+
+    phaseFile = path.join(tasksBase, ticket, 'task1', 'tdd-phase.json');
+  });
+
+  after(() => {
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('phase 1 — RED: auto-init creates tdd-phase.json and records red', () => {
+    assert.equal(fs.existsSync(phaseFile), false, 'precondition: no state yet');
+
+    const r = runTaskNext(ticket, 'task1', { cwd: worktree, TASKS_BASE: tasksBase });
+
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. Output:\n${combined}`);
+    assert.match(combined, /ADVANCED → green|RED accepted/, 'expected RED→GREEN advancement');
+    assert.equal(fs.existsSync(phaseFile), true, 'auto-init should have created tdd-phase.json');
+
+    const state = JSON.parse(fs.readFileSync(phaseFile, 'utf8'));
+    assert.equal(
+      state.currentPhase,
+      'green',
+      `expected currentPhase=green, got ${state.currentPhase}`
+    );
+    assert.ok(
+      Array.isArray(state.cycles) && state.cycles.length >= 1,
+      'cycles[] should have at least 1 entry'
+    );
+    assert.ok(state.cycles[0].red, 'cycle 1 should have red evidence');
+  });
+
+  it('phase 2 — GREEN: writing source advances to refactor and preserves cycle history', () => {
+    fs.writeFileSync(
+      path.join(worktree, 'tmp', 'dbg', 'multiply.js'),
+      'module.exports = { multiply: (n) => n * 2 };\n'
+    );
+
+    const r = runTaskNext(ticket, 'task1', { cwd: worktree, TASKS_BASE: tasksBase });
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. Output:\n${combined}`);
+    assert.match(combined, /ADVANCED → refactor/, 'expected GREEN→REFACTOR advancement');
+
+    const state = JSON.parse(fs.readFileSync(phaseFile, 'utf8'));
+    assert.equal(state.currentPhase, 'refactor');
+    assert.ok(
+      state.cycles[0].red,
+      'red evidence must still be there (init must not have wiped it)'
+    );
+    assert.ok(state.cycles[0].green, 'green evidence must now exist');
+  });
+
+  it('phase 3 — REFACTOR: records refactor evidence; cycle complete', () => {
+    const r = runTaskNext(ticket, 'task1', { cwd: worktree, TASKS_BASE: tasksBase });
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. Output:\n${combined}`);
+
+    const state = JSON.parse(fs.readFileSync(phaseFile, 'utf8'));
+    assert.ok(state.cycles[0].red, 'red evidence preserved');
+    assert.ok(state.cycles[0].green, 'green evidence preserved');
+    assert.ok(state.cycles[0].refactor, 'refactor evidence recorded');
+  });
+});

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -41,6 +41,29 @@ try {
 
 const TDD_CLI = path.join(__dirname, 'tdd-phase-state.js');
 
+const { TDD_PHASES, TDD_PHASE_TRANSITIONS } = require('./tdd-phase-registry');
+
+// `done` is derived in this script (a cycle with red+green+refactor evidence
+// is treated as complete). It is NOT a state-machine target in the registry.
+const TDD_DERIVED_DONE = 'done';
+
+/** record-* subcommand name for a phase. */
+function recordSubcommandFor(phase) {
+  return `record-${phase}`;
+}
+
+/**
+ * Next phase target for task-next's linear walk: red→green→refactor→null.
+ * Sourced from the registry's transition graph, with refactor explicitly
+ * stopping (the registry's refactor→red edge starts a *new* cycle, which
+ * task-next.js doesn't drive — that's external work).
+ */
+function nextPhaseTarget(phase) {
+  if (phase === TDD_PHASES.refactor) return null;
+  const successors = TDD_PHASE_TRANSITIONS[phase] || [];
+  return successors[0] || null;
+}
+
 function die(msg, code = 2) {
   process.stderr.write(`task-next: ${msg}\n`);
   process.exit(code);
@@ -247,15 +270,15 @@ function readPhaseState(ticketsDir, ticket, taskNum) {
 }
 
 function currentPhase(state) {
-  if (!state) return 'red';
+  if (!state) return TDD_PHASES.red;
   // A task is "done" when the latest cycle has red, green, AND refactor
   // evidence recorded. The recorder's transition table has no terminal
   // "done" state — refactor→done isn't valid — so we derive doneness here.
   const cycles = Array.isArray(state.cycles) ? state.cycles : [];
   const latest = cycles[cycles.length - 1];
-  if (latest && latest.red && latest.green && latest.refactor) return 'done';
+  if (latest && latest.red && latest.green && latest.refactor) return TDD_DERIVED_DONE;
   if (state.currentPhase) return state.currentPhase;
-  return 'red';
+  return TDD_PHASES.red;
 }
 
 // Snapshot the companion token once at startup. consumeToken atomically
@@ -312,9 +335,8 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope) {
   // determination, not a state-machine target. So after recording refactor,
   // we stop. currentPhase remains "refactor" on disk, but task-next.js's
   // currentPhase() helper treats a fully-evidenced cycle as `done`.
-  const sub =
-    phase === 'red' ? 'record-red' : phase === 'green' ? 'record-green' : 'record-refactor';
-  const target = phase === 'red' ? 'green' : phase === 'green' ? 'refactor' : null;
+  const sub = recordSubcommandFor(phase);
+  const target = nextPhaseTarget(phase);
 
   // tdd-phase-state.js record-* requires the per-task state file to exist;
   // it does NOT auto-init, and `init` itself overwrites existing state (so
@@ -487,7 +509,7 @@ function scenariosCoveredByTests(scenarios, testFiles) {
 function printPhaseInstructions(phase, ctx) {
   const lines = [];
   const { taskNum, totalScenarios, scenarios, scope, testCmd, testCmdSource } = ctx;
-  if (phase === 'red') {
+  if (phase === TDD_PHASES.red) {
     lines.push(`# RED phase — Task ${taskNum}`);
     lines.push('');
     lines.push('Write failing tests for the scenarios below. **Only test/fixture files.**');
@@ -511,7 +533,7 @@ function printPhaseInstructions(phase, ctx) {
     lines.push(
       'You advance to GREEN when (1) the test command exits non-zero AND (2) every scenario above appears in at least one test file.'
     );
-  } else if (phase === 'green') {
+  } else if (phase === TDD_PHASES.green) {
     lines.push(`# GREEN phase — Task ${taskNum}`);
     lines.push('');
     lines.push('Make the failing tests pass. **Only source files.** No edits to tests/fixtures.');
@@ -524,7 +546,7 @@ function printPhaseInstructions(phase, ctx) {
     lines.push(`Run: \`node ${path.relative(process.cwd(), __filename)} <TICKET> task${taskNum}\``);
     lines.push(`I will run: \`${testCmd}\` (from ${testCmdSource})`);
     lines.push('You advance to REFACTOR when the test command exits 0.');
-  } else if (phase === 'refactor') {
+  } else if (phase === TDD_PHASES.refactor) {
     lines.push(`# REFACTOR phase — Task ${taskNum}`);
     lines.push('');
     lines.push(
@@ -694,7 +716,7 @@ function main() {
         event: 'completed',
         ticket: globalThis.__taskNextCtx?.ticket,
         taskNum: globalThis.__taskNextCtx?.taskNum,
-        phase: 'done',
+        phase: TDD_DERIVED_DONE,
         advanced: false,
         blocked: false,
         exitCode: 0,
@@ -718,7 +740,7 @@ function main() {
   let advanced = false;
   let blockReason = '';
 
-  if (phase === 'red') {
+  if (phase === TDD_PHASES.red) {
     if (passed) {
       blockReason =
         'Your test command exits 0. RED requires a real failing test. Rewrite the assertion so it actually fails before re-invoking me.';
@@ -738,12 +760,12 @@ function main() {
           if (totalBlocks === 0) {
             blockReason = `No gherkin scenarios tagged @task:${taskNum}. Found ${testFiles.length} test file(s) in Suggested Scope but none contain it()/test() blocks. Add at least one failing test, then re-invoke me.`;
           } else {
-            const rec = recordEvidence('red', ticket, taskNum, testCmd, repoRoot, scope);
+            const rec = recordEvidence(TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope);
             if (!rec.ok) {
               blockReason = `Could not record RED evidence:\n${rec.out}`;
             } else {
               advanced = true;
-              phase = 'green';
+              phase = TDD_PHASES.green;
               process.stdout.write(
                 `task-next: RED accepted via unit-only fallback (no @task:${taskNum} gherkin tags; ${filesWithBlocks} test file(s) under Suggested Scope, ${totalBlocks} test block(s)).\n`
               );
@@ -753,37 +775,37 @@ function main() {
       } else if (missing.length > 0) {
         blockReason = `Tests do not yet cover these scenarios (verbatim title match against test files in Suggested Scope):\n  - ${missing.join('\n  - ')}\nAdd a test for each (failing) before re-invoking me.`;
       } else {
-        const rec = recordEvidence('red', ticket, taskNum, testCmd, repoRoot, scope);
+        const rec = recordEvidence(TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope);
         if (!rec.ok) {
           blockReason = `Could not record RED evidence:\n${rec.out}`;
         } else {
           advanced = true;
-          phase = 'green';
+          phase = TDD_PHASES.green;
         }
       }
     }
-  } else if (phase === 'green') {
+  } else if (phase === TDD_PHASES.green) {
     if (!passed) {
       blockReason = `Test command still failing (exit ${run.exitCode}). Last output:\n\n${run.combined}`;
     } else {
-      const rec = recordEvidence('green', ticket, taskNum, testCmd, repoRoot, scope);
+      const rec = recordEvidence(TDD_PHASES.green, ticket, taskNum, testCmd, repoRoot, scope);
       if (!rec.ok) {
         blockReason = `Could not record GREEN evidence:\n${rec.out}`;
       } else {
         advanced = true;
-        phase = 'refactor';
+        phase = TDD_PHASES.refactor;
       }
     }
-  } else if (phase === 'refactor') {
+  } else if (phase === TDD_PHASES.refactor) {
     if (!passed) {
       blockReason = `Regression detected — tests failed during refactor (exit ${run.exitCode}). Revert the breaking change before re-invoking me.\n\n${run.combined}`;
     } else {
-      const rec = recordEvidence('refactor', ticket, taskNum, testCmd, repoRoot, scope);
+      const rec = recordEvidence(TDD_PHASES.refactor, ticket, taskNum, testCmd, repoRoot, scope);
       if (!rec.ok) {
         blockReason = `Could not record REFACTOR evidence:\n${rec.out}`;
       } else {
         advanced = true;
-        phase = 'done';
+        phase = TDD_DERIVED_DONE;
       }
     }
   }

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -208,25 +208,47 @@ function readPhaseState(ticketsDir, ticket, taskNum) {
 
 function currentPhase(state) {
   if (!state) return 'red';
+  // A task is "done" when the latest cycle has red, green, AND refactor
+  // evidence recorded. The recorder's transition table has no terminal
+  // "done" state — refactor→done isn't valid — so we derive doneness here.
+  const cycles = Array.isArray(state.cycles) ? state.cycles : [];
+  const latest = cycles[cycles.length - 1];
+  if (latest && latest.red && latest.green && latest.refactor) return 'done';
   if (state.currentPhase) return state.currentPhase;
   return 'red';
 }
 
-// Refresh the companion token's timestamp so the inner tdd-phase-state.js
-// call has a fresh 10s window. The token was minted by the PreToolUse hook
-// when the agent invoked task-next.js; by the time the test command has
-// finished running (potentially 60s+ for E2E suites), the original timestamp
-// is stale. We are the trusted intermediary — preserving the agent identity
-// from the existing token and bumping only the timestamp keeps the security
-// invariant: "the recorder must be called within 10s of an authorized intent."
-function refreshCompanionToken(scriptBasename) {
+// Snapshot the companion token once at startup. consumeToken atomically
+// deletes the file on read, so after the first child spawn we lose the
+// agent identity unless we cached it. Subsequent spawns will re-mint the
+// token from this snapshot with a fresh timestamp.
+let _companionTokenSnapshot = null;
+function snapshotCompanionToken(scriptBasename) {
   try {
     const { tokenPath } = require('../lib/scripts/write-report');
     const tp = tokenPath(scriptBasename);
     if (!fs.existsSync(tp)) return false;
-    const data = JSON.parse(fs.readFileSync(tp, 'utf8'));
-    data.timestamp = Date.now();
-    fs.writeFileSync(tp, JSON.stringify(data), { mode: 0o600 });
+    _companionTokenSnapshot = {
+      basename: scriptBasename,
+      path: tp,
+      data: JSON.parse(fs.readFileSync(tp, 'utf8')),
+    };
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Re-mint the companion token before each inner spawn. Two reasons it might
+// be missing or stale: (1) the previous spawn consumed (deleted) it; (2) the
+// test command took 60s+ and the original timestamp expired. Re-writing from
+// the snapshot with a current timestamp keeps the security invariant intact
+// — same agent identity, "fresh within 10s of recorder call".
+function mintCompanionToken() {
+  if (!_companionTokenSnapshot) return false;
+  try {
+    const data = { ..._companionTokenSnapshot.data, timestamp: Date.now() };
+    fs.writeFileSync(_companionTokenSnapshot.path, JSON.stringify(data), { mode: 0o600 });
     return true;
   } catch {
     return false;
@@ -235,23 +257,61 @@ function refreshCompanionToken(scriptBasename) {
 
 function recordEvidence(phase, ticket, taskNum, cmd, cwd) {
   // Delegate to tdd-phase-state.js — the only authorized writer. Forward
-  // `--task N` so the recorder resolves the per-task state path
-  // (TASKS_BASE/<ticket>/taskN/tdd-phase.json) rather than the legacy
-  // ticket-root path. Without this the writer errors "No TDD phase state
-  // found, run init first" even though the reader on the same file works.
-  refreshCompanionToken('tdd-phase-state.js');
+  // `--task N` so the recorder resolves the per-task state path. Records
+  // evidence for the just-completed phase, then (for red/green only)
+  // transitions currentPhase to the next phase.
+  //
+  // The TDD model here is cycle-based: valid transitions are red→green,
+  // green→refactor, refactor→red (start a new cycle). There is no
+  // "refactor→done" transition. A task is considered complete when its
+  // latest cycle has evidence for all three phases — that's an in-script
+  // determination, not a state-machine target. So after recording refactor,
+  // we stop. currentPhase remains "refactor" on disk, but task-next.js's
+  // currentPhase() helper treats a fully-evidenced cycle as `done`.
   const sub =
     phase === 'red' ? 'record-red' : phase === 'green' ? 'record-green' : 'record-refactor';
-  const args = [TDD_CLI, sub, ticket, '--task', String(taskNum), '--cmd', cmd];
-  const r = spawnSync(process.execPath, args, {
+  const target = phase === 'red' ? 'green' : phase === 'green' ? 'refactor' : null;
+
+  mintCompanionToken();
+  const recordArgs = [TDD_CLI, sub, ticket, '--task', String(taskNum), '--cmd', cmd];
+  const r = spawnSync(process.execPath, recordArgs, {
     cwd,
     stdio: 'pipe',
     encoding: 'utf8',
   });
+  if (r.status !== 0) {
+    return { ok: false, out: (r.stdout || '') + (r.stderr || ''), exitCode: r.status };
+  }
+
+  if (!target) {
+    // refactor recorded — cycle complete, no transition needed
+    return { ok: true, out: (r.stdout || '') + (r.stderr || ''), exitCode: 0 };
+  }
+
+  mintCompanionToken();
+  const transitionArgs = [TDD_CLI, 'transition', ticket, target, '--task', String(taskNum)];
+  const t = spawnSync(process.execPath, transitionArgs, {
+    cwd,
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+  if (t.status !== 0) {
+    return {
+      ok: false,
+      out:
+        (r.stdout || '') +
+        (r.stderr || '') +
+        `\n--- transition ${phase}→${target} failed ---\n` +
+        (t.stdout || '') +
+        (t.stderr || ''),
+      exitCode: t.status,
+    };
+  }
+
   return {
-    ok: r.status === 0,
-    out: (r.stdout || '') + (r.stderr || ''),
-    exitCode: r.status,
+    ok: true,
+    out: (r.stdout || '') + (r.stderr || '') + (t.stdout || '') + (t.stderr || ''),
+    exitCode: 0,
   };
 }
 
@@ -389,6 +449,12 @@ function main() {
   }
   const ticket = sanitizeTicketId(ticketRaw);
   const taskNum = parseTaskId(taskRaw);
+
+  // Snapshot the companion token NOW, before any child spawn could consume it.
+  // The hook minted this token when the agent invoked `node task-next.js ...`;
+  // we'll re-mint it from this snapshot before every inner tdd-phase-state.js
+  // spawn so consumed/expired tokens don't strand a transition mid-cycle.
+  snapshotCompanionToken('tdd-phase-state.js');
 
   const tasksBase = resolveTasksBase();
   const tasksDir = path.join(tasksBase, ticket);

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -106,9 +106,19 @@ function parseTaskId(raw) {
 }
 
 function extractTaskSection(tasksMd, taskNum) {
-  const re = new RegExp(`(^## *Task ${taskNum}\\b[\\s\\S]*?)(?=^## *Task \\d+\\b|\\Z)`, 'm');
-  const m = tasksMd.match(re);
-  return m ? m[1] : null;
+  // JS regex does NOT support \Z. Previously the pattern used `(?=^## *Task
+  // \d+\b|\Z)` which treated \Z as a literal Z, so the lookahead never
+  // matched the final task in tasks.md and the last task was unextractable.
+  // Slice manually instead: find the start of "## Task N", then the start
+  // of the next "## Task M" (or end-of-string), and slice between them.
+  const startRe = new RegExp(`^## *Task ${taskNum}\\b`, 'm');
+  const startMatch = tasksMd.match(startRe);
+  if (!startMatch) return null;
+  const startIdx = startMatch.index;
+  const after = tasksMd.slice(startIdx + startMatch[0].length);
+  const endMatch = after.match(/^## *Task \d+\b/m);
+  const endIdx = endMatch ? startIdx + startMatch[0].length + endMatch.index : tasksMd.length;
+  return tasksMd.slice(startIdx, endIdx);
 }
 
 function extractField(section, header) {

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -483,17 +483,32 @@ function main() {
   // Checkpoint tasks are verification-only — no source change, no test
   // authorship, no gherkin scenarios. Asking the agent to satisfy a TDD
   // RED gate ("write a failing test for each scenario") is contradictory
-  // when there are 0 scenarios by design. Short-circuit: print the
-  // checkpoint instructions and exit cleanly. No phase, no evidence,
-  // no transition. The orchestrator's implement-gate already routes
-  // checkpoint tasks to the code-checker agent with a verify-only prompt
-  // (see implement.js); this branch is the safety net when the script
-  // is invoked directly.
+  // when there are 0 scenarios by design. We short-circuit the TDD flow
+  // AND advance the task in tasksMeta via the authorized work-state.js
+  // task-advance writer — without that bookkeeping, work-next.js refuses
+  // to complete the workflow ("Cannot complete: 1 tasks still pending").
   if (type === 'checkpoint') {
+    const workStateCli = path.resolve(__dirname, '..', 'work', 'work-state.js');
+    let advanceOut = '';
+    let advanceCode = -1;
+    try {
+      const r = spawnSync(process.execPath, [workStateCli, 'task-advance', ticket], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+      advanceOut = (r.stdout || '') + (r.stderr || '');
+      advanceCode = r.status ?? -1;
+    } catch (e) {
+      advanceOut = `(spawn failed: ${e.message})`;
+    }
     process.stdout.write(
       [
         `task-next: ${ticket} task${taskNum} — ${taskTitle}`,
         '  type: checkpoint (verification only, no TDD cycle)',
+        advanceCode === 0
+          ? `  tasksMeta: task ${taskNum} marked completed`
+          : `  tasksMeta: task-advance failed (exit=${advanceCode}) — workflow may still block on complete step`,
         '',
         `# Checkpoint — Task ${taskNum}`,
         '',
@@ -504,12 +519,14 @@ function main() {
         '2. Run each verification command listed under "### Acceptance" / "### Test Command" exactly as written.',
         '3. Report which commands passed and which (if any) did not.',
         '',
-        'When all verifications pass, the orchestrator will advance the workflow on its next tick.',
-        'No TDD evidence is recorded for checkpoint tasks — that is by design.',
+        advanceCode === 0
+          ? 'tasksMeta has been advanced — re-invoke /work2 to drive the workflow to complete.'
+          : 'tasksMeta advance failed — paste the output below and let the monitor know:',
+        advanceCode === 0 ? '' : '```\n' + advanceOut.slice(-1000) + '\n```',
         '',
       ].join('\n')
     );
-    process.exit(0);
+    process.exit(advanceCode === 0 ? 0 : 2);
   }
 
   const gherkin = readFile(path.join(tasksDir, 'gherkin.feature')) || '';

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -200,11 +200,24 @@ function resolveTestCommand(taskTestCmd, suiteEnvVar) {
   return { cmd: envCmd, source: `$${suiteEnvVar}` };
 }
 
-function runTest(cmd, cwd) {
+function runTest(cmd, cwd, scope) {
   // Bound the test command so a hung subprocess (watch mode, dev server,
   // interactive prompt waiting on stdin, etc.) doesn't strand the whole
   // workflow. Override via TASK_NEXT_TEST_TIMEOUT_MS env var.
   const timeoutMs = Number(process.env.TASK_NEXT_TEST_TIMEOUT_MS) || 5 * 60 * 1000;
+  // Inject CHANGED_FILES into the subprocess env from the task's
+  // Suggested Scope. Many tasks.md test commands use a pattern like
+  // `CHANGED_FILES="..." eval "$TEST_UNIT_COMMAND"` — but in some bash
+  // configurations (login shells, posix mode) the inline env-assignment
+  // does not propagate into the eval's variable scope, so $CHANGED_FILES
+  // inside the eval'd command expands to empty and the test runner
+  // executes the entire suite (timeout). Setting CHANGED_FILES in the
+  // spawned process env makes both patterns work — inline assignment
+  // overrides if present, otherwise this fallback wins. Only test-/spec-
+  // files from scope are included (source files are not test targets).
+  const changedFiles = Array.isArray(scope)
+    ? scope.filter((p) => /\.(test|spec)\.[jt]sx?$/i.test(p)).join(' ')
+    : '';
   const result = spawnSync('bash', ['-lc', cmd], {
     cwd,
     encoding: 'utf8',
@@ -212,6 +225,7 @@ function runTest(cmd, cwd) {
     timeout: timeoutMs,
     killSignal: 'SIGKILL',
     stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, CHANGED_FILES: changedFiles },
   });
   const stdout = result.stdout || '';
   const stderr = result.stderr || '';
@@ -677,7 +691,7 @@ function main() {
   }
 
   // Run the test command.
-  const run = runTest(testCmd, repoRoot);
+  const run = runTest(testCmd, repoRoot, scope);
   const passed = run.exitCode === 0;
 
   // Decide whether we can advance.

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -577,6 +577,18 @@ function main() {
         '',
       ].join('\n')
     );
+    if (globalThis.__taskNextLog) {
+      globalThis.__taskNextLog({
+        event: 'completed',
+        ticket: globalThis.__taskNextCtx?.ticket,
+        taskNum: globalThis.__taskNextCtx?.taskNum,
+        phase: 'checkpoint',
+        advanced: advanceCode === 0,
+        blocked: advanceCode !== 0,
+        exitCode: advanceCode === 0 ? 0 : 2,
+        durationMs: Date.now() - (globalThis.__taskNextStart || Date.now()),
+      });
+    }
     process.exit(advanceCode === 0 ? 0 : 2);
   }
 
@@ -605,6 +617,18 @@ function main() {
         testCmdSource,
       })
     );
+    if (globalThis.__taskNextLog) {
+      globalThis.__taskNextLog({
+        event: 'completed',
+        ticket: globalThis.__taskNextCtx?.ticket,
+        taskNum: globalThis.__taskNextCtx?.taskNum,
+        phase: 'done',
+        advanced: false,
+        blocked: false,
+        exitCode: 0,
+        durationMs: Date.now() - (globalThis.__taskNextStart || Date.now()),
+      });
+    }
     process.exit(0);
   }
 

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -480,6 +480,38 @@ function main() {
   const type = parseTaskType(section);
   const taskTestCmd = parseTaskTestCommand(section);
 
+  // Checkpoint tasks are verification-only — no source change, no test
+  // authorship, no gherkin scenarios. Asking the agent to satisfy a TDD
+  // RED gate ("write a failing test for each scenario") is contradictory
+  // when there are 0 scenarios by design. Short-circuit: print the
+  // checkpoint instructions and exit cleanly. No phase, no evidence,
+  // no transition. The orchestrator's implement-gate already routes
+  // checkpoint tasks to the code-checker agent with a verify-only prompt
+  // (see implement.js); this branch is the safety net when the script
+  // is invoked directly.
+  if (type === 'checkpoint') {
+    process.stdout.write(
+      [
+        `task-next: ${ticket} task${taskNum} — ${taskTitle}`,
+        '  type: checkpoint (verification only, no TDD cycle)',
+        '',
+        `# Checkpoint — Task ${taskNum}`,
+        '',
+        'This task is verification-only. Do NOT write tests, do NOT change source.',
+        '',
+        '## What to do',
+        `1. Read the "## Task ${taskNum}" section in ${path.join(tasksDir, 'tasks.md')}.`,
+        '2. Run each verification command listed under "### Acceptance" / "### Test Command" exactly as written.',
+        '3. Report which commands passed and which (if any) did not.',
+        '',
+        'When all verifications pass, the orchestrator will advance the workflow on its next tick.',
+        'No TDD evidence is recorded for checkpoint tasks — that is by design.',
+        '',
+      ].join('\n')
+    );
+    process.exit(0);
+  }
+
   const gherkin = readFile(path.join(tasksDir, 'gherkin.feature')) || '';
   const scenarios = parseGherkinScenarios(gherkin, taskNum);
 

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -471,7 +471,24 @@ function printPhaseInstructions(phase, ctx) {
   return lines.join('\n') + '\n';
 }
 
+let _log;
+function _logEvent(payload) {
+  if (!_log) {
+    try {
+      _log = require('../lib/next-script-log').logNextScriptEvent;
+    } catch {
+      _log = () => {};
+    }
+  }
+  try {
+    _log('task-next', payload);
+  } catch {
+    /* fail-open */
+  }
+}
+
 function main() {
+  const _startedAt = Date.now();
   const [, , ticketRaw, taskRaw] = process.argv;
   if (!ticketRaw || !taskRaw) {
     process.stderr.write(
@@ -483,6 +500,16 @@ function main() {
   }
   const ticket = sanitizeTicketId(ticketRaw);
   const taskNum = parseTaskId(taskRaw);
+  _logEvent({
+    event: 'invoked',
+    ticket,
+    taskNum,
+    cwd: process.cwd(),
+    agent: process.env.CLAUDE_CURRENT_AGENT || null,
+  });
+  globalThis.__taskNextStart = _startedAt;
+  globalThis.__taskNextLog = _logEvent;
+  globalThis.__taskNextCtx = { ticket, taskNum };
 
   // Snapshot the companion token NOW, before any child spawn could consume it.
   // The hook minted this token when the agent invoked `node task-next.js ...`;
@@ -695,7 +722,21 @@ function main() {
     })
   );
 
-  process.exit(blockReason ? 2 : 0);
+  const _exitCode = blockReason ? 2 : 0;
+  if (globalThis.__taskNextLog) {
+    globalThis.__taskNextLog({
+      event: 'completed',
+      ticket: globalThis.__taskNextCtx?.ticket,
+      taskNum: globalThis.__taskNextCtx?.taskNum,
+      phase,
+      advanced: Boolean(advanced),
+      blocked: Boolean(blockReason),
+      blockReason: blockReason ? String(blockReason).slice(0, 500) : null,
+      exitCode: _exitCode,
+      durationMs: Date.now() - (globalThis.__taskNextStart || Date.now()),
+    });
+  }
+  process.exit(_exitCode);
 }
 
 main();

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -201,17 +201,28 @@ function resolveTestCommand(taskTestCmd, suiteEnvVar) {
 }
 
 function runTest(cmd, cwd) {
+  // Bound the test command so a hung subprocess (watch mode, dev server,
+  // interactive prompt waiting on stdin, etc.) doesn't strand the whole
+  // workflow. Override via TASK_NEXT_TEST_TIMEOUT_MS env var.
+  const timeoutMs = Number(process.env.TASK_NEXT_TEST_TIMEOUT_MS) || 5 * 60 * 1000;
   const result = spawnSync('bash', ['-lc', cmd], {
     cwd,
     encoding: 'utf8',
     maxBuffer: 16 * 1024 * 1024,
+    timeout: timeoutMs,
+    killSignal: 'SIGKILL',
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
   const stdout = result.stdout || '';
   const stderr = result.stderr || '';
+  const timedOut = result.signal === 'SIGKILL' || result.error?.code === 'ETIMEDOUT';
   return {
-    exitCode: result.status ?? -1,
+    exitCode: timedOut ? 124 : (result.status ?? -1),
     stdout,
-    stderr,
+    stderr: timedOut
+      ? `${stderr}\n[task-next] test command exceeded ${timeoutMs}ms — killed.\n`
+      : stderr,
+    timedOut,
     combined: (stdout + stderr).slice(-4000),
   };
 }

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -295,7 +295,7 @@ function mintCompanionToken() {
   }
 }
 
-function recordEvidence(phase, ticket, taskNum, cmd, cwd) {
+function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope) {
   // Delegate to tdd-phase-state.js — the only authorized writer. Forward
   // `--task N` so the recorder resolves the per-task state path. Records
   // evidence for the just-completed phase, then (for red/green only)
@@ -317,10 +317,25 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd) {
   // we cannot just always init). Strategy: try record first; if it fails
   // with "No TDD phase state found", run init ONCE and retry. Existing
   // cycle history is preserved (init only runs when there is no state).
+  //
+  // tdd-phase-state.js re-runs the test command itself (intentional
+  // anti-fake-evidence design) so we must propagate the SAME env we
+  // used in our own runTest, otherwise the recorder's internal run
+  // can disagree with ours (e.g. CHANGED_FILES injection failing in
+  // its subshell would make pnpm test:unit run the whole suite).
+  const changedFiles = Array.isArray(scope)
+    ? scope.filter((p) => /\.(test|spec)\.[jt]sx?$/i.test(p)).join(' ')
+    : '';
+  const childEnv = { ...process.env, CHANGED_FILES: changedFiles };
   function runRecord() {
     mintCompanionToken();
     const recordArgs = [TDD_CLI, sub, ticket, '--task', String(taskNum), '--cmd', cmd];
-    return spawnSync(process.execPath, recordArgs, { cwd, stdio: 'pipe', encoding: 'utf8' });
+    return spawnSync(process.execPath, recordArgs, {
+      cwd,
+      stdio: 'pipe',
+      encoding: 'utf8',
+      env: childEnv,
+    });
   }
   let r = runRecord();
   if (r.status !== 0) {
@@ -330,7 +345,7 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd) {
       const initRes = spawnSync(
         process.execPath,
         [TDD_CLI, 'init', ticket, '--task', String(taskNum)],
-        { cwd, stdio: 'pipe', encoding: 'utf8' }
+        { cwd, stdio: 'pipe', encoding: 'utf8', env: childEnv }
       );
       if (initRes.status !== 0) {
         return {
@@ -361,6 +376,7 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd) {
     cwd,
     stdio: 'pipe',
     encoding: 'utf8',
+    env: childEnv,
   });
   if (t.status !== 0) {
     return {
@@ -718,7 +734,7 @@ function main() {
           if (totalBlocks === 0) {
             blockReason = `No gherkin scenarios tagged @task:${taskNum}. Found ${testFiles.length} test file(s) in Suggested Scope but none contain it()/test() blocks. Add at least one failing test, then re-invoke me.`;
           } else {
-            const rec = recordEvidence('red', ticket, taskNum, testCmd, repoRoot);
+            const rec = recordEvidence('red', ticket, taskNum, testCmd, repoRoot, scope);
             if (!rec.ok) {
               blockReason = `Could not record RED evidence:\n${rec.out}`;
             } else {
@@ -733,7 +749,7 @@ function main() {
       } else if (missing.length > 0) {
         blockReason = `Tests do not yet cover these scenarios (verbatim title match against test files in Suggested Scope):\n  - ${missing.join('\n  - ')}\nAdd a test for each (failing) before re-invoking me.`;
       } else {
-        const rec = recordEvidence('red', ticket, taskNum, testCmd, repoRoot);
+        const rec = recordEvidence('red', ticket, taskNum, testCmd, repoRoot, scope);
         if (!rec.ok) {
           blockReason = `Could not record RED evidence:\n${rec.out}`;
         } else {
@@ -746,7 +762,7 @@ function main() {
     if (!passed) {
       blockReason = `Test command still failing (exit ${run.exitCode}). Last output:\n\n${run.combined}`;
     } else {
-      const rec = recordEvidence('green', ticket, taskNum, testCmd, repoRoot);
+      const rec = recordEvidence('green', ticket, taskNum, testCmd, repoRoot, scope);
       if (!rec.ok) {
         blockReason = `Could not record GREEN evidence:\n${rec.out}`;
       } else {
@@ -758,7 +774,7 @@ function main() {
     if (!passed) {
       blockReason = `Regression detected — tests failed during refactor (exit ${run.exitCode}). Revert the breaking change before re-invoking me.\n\n${run.combined}`;
     } else {
-      const rec = recordEvidence('refactor', ticket, taskNum, testCmd, repoRoot);
+      const rec = recordEvidence('refactor', ticket, taskNum, testCmd, repoRoot, scope);
       if (!rec.ok) {
         blockReason = `Could not record REFACTOR evidence:\n${rec.out}`;
       } else {

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -370,6 +370,25 @@ function findTestFilesInScope(repoRoot, scope) {
 // to substring match if no gherkin() calls are present in the file. The
 // substring fallback handles older test files that haven't adopted the
 // annotation helper.
+// For unit-only tasks (no @task:N gherkin scenarios — e.g. pure Zod schemas
+// with no E2E behavior to tag), the RED gate falls back to verifying that
+// at least one test file in Suggested Scope contains at least one test
+// block. Returns { totalBlocks, filesWithBlocks }.
+function countTestBlocksInFiles(testFiles) {
+  let totalBlocks = 0;
+  let filesWithBlocks = 0;
+  const re = /\b(?:it|test)(?:\.\w+)?\s*\(/g;
+  for (const f of testFiles) {
+    const c = readFile(f) || '';
+    const matches = c.match(re);
+    if (matches && matches.length > 0) {
+      filesWithBlocks += 1;
+      totalBlocks += matches.length;
+    }
+  }
+  return { totalBlocks, filesWithBlocks };
+}
+
 function scenariosCoveredByTests(scenarios, testFiles) {
   const fileContents = testFiles.map((f) => ({ f, c: readFile(f) || '' }));
   const allGherkinCalls = new Set();
@@ -579,7 +598,30 @@ function main() {
       const testFiles = findTestFilesInScope(repoRoot, scope);
       const missing = scenariosCoveredByTests(scenarios, testFiles);
       if (scenarios.length === 0) {
-        blockReason = `No gherkin scenarios are tagged @task:${taskNum}. RED cannot validate scope. Fix gherkin.feature or have an orchestrator regenerate it.`;
+        // Unit-only fallback: tasks with no E2E gherkin coverage (pure Zod
+        // schemas, isolated utilities, etc.) may still validate RED by
+        // proving there is at least one failing test block under Suggested
+        // Scope. The test command already failed (exitCode !== 0) above —
+        // we just need to confirm authorship intent.
+        if (testFiles.length === 0) {
+          blockReason = `No gherkin scenarios tagged @task:${taskNum} AND no *.test.* / *.spec.* files found under Suggested Scope. Add at least one failing test in a file under Suggested Scope, then re-invoke me.`;
+        } else {
+          const { totalBlocks, filesWithBlocks } = countTestBlocksInFiles(testFiles);
+          if (totalBlocks === 0) {
+            blockReason = `No gherkin scenarios tagged @task:${taskNum}. Found ${testFiles.length} test file(s) in Suggested Scope but none contain it()/test() blocks. Add at least one failing test, then re-invoke me.`;
+          } else {
+            const rec = recordEvidence('red', ticket, taskNum, testCmd, repoRoot);
+            if (!rec.ok) {
+              blockReason = `Could not record RED evidence:\n${rec.out}`;
+            } else {
+              advanced = true;
+              phase = 'green';
+              process.stdout.write(
+                `task-next: RED accepted via unit-only fallback (no @task:${taskNum} gherkin tags; ${filesWithBlocks} test file(s) under Suggested Scope, ${totalBlocks} test block(s)).\n`
+              );
+            }
+          }
+        }
       } else if (missing.length > 0) {
         blockReason = `Tests do not yet cover these scenarios (verbatim title match against test files in Suggested Scope):\n  - ${missing.join('\n  - ')}\nAdd a test for each (failing) before re-invoking me.`;
       } else {

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -263,11 +263,15 @@ function currentPhase(state) {
 // agent identity unless we cached it. Subsequent spawns will re-mint the
 // token from this snapshot with a fresh timestamp.
 let _companionTokenSnapshot = null;
-function snapshotCompanionToken(scriptBasename) {
+function snapshotCompanionToken(scriptBasename, ticketId) {
   try {
     const { tokenPath } = require('../lib/scripts/write-report');
-    const tp = tokenPath(scriptBasename);
-    if (!fs.existsSync(tp)) return false;
+    // Prefer the ticket-keyed path (parallel-session-safe); fall back to
+    // the legacy unkeyed path if the keyed one isn't there.
+    const keyed = tokenPath(scriptBasename, ticketId);
+    const unkeyed = tokenPath(scriptBasename);
+    const tp = fs.existsSync(keyed) ? keyed : fs.existsSync(unkeyed) ? unkeyed : null;
+    if (!tp) return false;
     _companionTokenSnapshot = {
       basename: scriptBasename,
       path: tp,
@@ -583,7 +587,7 @@ function main() {
   // The hook minted this token when the agent invoked `node task-next.js ...`;
   // we'll re-mint it from this snapshot before every inner tdd-phase-state.js
   // spawn so consumed/expired tokens don't strand a transition mid-cycle.
-  snapshotCompanionToken('tdd-phase-state.js');
+  snapshotCompanionToken('tdd-phase-state.js', ticket);
 
   const tasksBase = resolveTasksBase();
   const tasksDir = path.join(tasksBase, ticket);

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -1,0 +1,529 @@
+#!/usr/bin/env node
+
+/**
+ * task-next.js
+ *
+ * Self-paced TDD task runner. The implement-step prompt is a one-liner:
+ *   node task-next.js <TICKET> <task_id>
+ *
+ * On each invocation:
+ *   1. Determine the current TDD phase for the task (red | green | refactor | done).
+ *   2. Run the configured test command (### Test Command from tasks.md, or
+ *      $TEST_<SUITE>_COMMAND fallback).
+ *   3. Validate the result against phase rules:
+ *        - red:  command must fail (exit != 0) AND every gherkin scenario tagged
+ *                `@task:N` must appear in at least one test/spec file under the
+ *                task's Suggested Scope.
+ *        - green: command must pass (exit == 0).
+ *        - refactor: command must still pass.
+ *   4. If validation succeeds, record evidence via tdd-phase-state.js (the only
+ *      authorized writer) and advance the phase. If validation fails, print a
+ *      precise diagnosis and the rules for the CURRENT phase so the agent knows
+ *      what to do next.
+ *   5. Print the next-step instructions for the (possibly new) phase.
+ *
+ * Output is structured Markdown so the agent can quote it back if needed.
+ * Exit codes: 0 = phase progressed or already correct, 2 = phase blocked.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+let config;
+try {
+  config = require('../lib/config');
+} catch {
+  config = null;
+}
+
+const TDD_CLI = path.join(__dirname, 'tdd-phase-state.js');
+
+function die(msg, code = 2) {
+  process.stderr.write(`task-next: ${msg}\n`);
+  process.exit(code);
+}
+
+function readJSON(p) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function resolveTasksBase() {
+  const cwd = process.cwd();
+  if (config?.getConfig) {
+    const fromConfig = config.getConfig('TASKS_BASE');
+    if (fromConfig) return path.resolve(cwd, fromConfig);
+  }
+  // Fallback: walk up looking for a `tasks/` dir
+  let dir = cwd;
+  for (let i = 0; i < 8; i++) {
+    const cand = path.join(dir, 'tasks');
+    if (fs.existsSync(cand)) return cand;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.join(cwd, 'tasks');
+}
+
+// Use git's view of the worktree, not tasks/'s parent. In multi-worktree
+// layouts (e.g. w-tabwoah/tabwoah-ECHO-XXXX/), tasks/ lives outside the
+// actual checkout, so dirname(tasksBase) is the wrong cwd to run tests in.
+function resolveWorktreeRoot() {
+  const r = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+  if (r.status === 0 && r.stdout.trim()) return r.stdout.trim();
+  return null;
+}
+
+function sanitizeTicketId(raw) {
+  const s = String(raw || '').trim();
+  if (!s) die('missing TICKET arg');
+  if (!/^[A-Za-z0-9_#-]+$/.test(s)) die(`invalid ticket id: ${raw}`);
+  return s.replace(/^#/, 'GH-');
+}
+
+function parseTaskId(raw) {
+  const m = String(raw || '').match(/^task[_-]?(\d+)$/i);
+  if (!m) die(`task id must look like 'task1' or 'task_1'; got: ${raw}`);
+  return Number(m[1]);
+}
+
+function extractTaskSection(tasksMd, taskNum) {
+  const re = new RegExp(`(^## *Task ${taskNum}\\b[\\s\\S]*?)(?=^## *Task \\d+\\b|\\Z)`, 'm');
+  const m = tasksMd.match(re);
+  return m ? m[1] : null;
+}
+
+function extractField(section, header) {
+  const re = new RegExp(`### *${header}[^\\n]*\\n([\\s\\S]*?)(?=\\n### |\\n## |$)`, 'm');
+  const m = section.match(re);
+  return m ? m[1].trim() : '';
+}
+
+function parseSuggestedScope(section) {
+  const raw = extractField(section, 'Suggested Scope') || extractField(section, 'Files in scope');
+  return raw
+    .split('\n')
+    .map((l) => l.replace(/^[-*+]\s+/, '').trim())
+    .filter((l) => l && !l.startsWith('#'))
+    .map((l) => l.replace(/^[`\s]+|[`\s].*$/g, ''));
+}
+
+function parseTaskType(section) {
+  const t = extractField(section, 'Type');
+  return (t || '').toLowerCase();
+}
+
+function parseTaskTestCommand(section) {
+  const m = section.match(/### *Test Command[^\n]*\n+```(?:[a-zA-Z]+)?\n([\s\S]*?)\n```/);
+  return m ? m[1].trim() : '';
+}
+
+function parseGherkinScenarios(gherkin, taskNum) {
+  if (!gherkin) return [];
+  const lines = gherkin.split('\n');
+  const scenarios = [];
+  let pendingTags = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const t = line.trim();
+    if (t.startsWith('@')) {
+      pendingTags = pendingTags.concat(t.split(/\s+/));
+      continue;
+    }
+    const sc = t.match(/^(Scenario|Scenario Outline):\s*(.+)$/);
+    if (sc) {
+      const tags = pendingTags;
+      pendingTags = [];
+      if (tags.includes(`@task:${taskNum}`)) {
+        scenarios.push({ name: sc[2].trim(), tags });
+      }
+    } else if (t === '') {
+      // blank line resets pending tags only if not directly preceding a scenario
+    } else if (!t.startsWith('@')) {
+      // any non-tag content between tag block and scenario keeps tags
+    }
+  }
+  return scenarios;
+}
+
+function detectSuiteEnvVar(scope, type, title) {
+  const blob = [scope, type, title].join(' ').toLowerCase();
+  if (/\be2e\b|playwright/.test(blob)) return 'TEST_E2E_COMMAND';
+  if (/integration|\.int\./.test(blob)) return 'TEST_INTEGRATION_COMMAND';
+  return 'TEST_UNIT_COMMAND';
+}
+
+function resolveTestCommand(taskTestCmd, suiteEnvVar) {
+  if (taskTestCmd) return { cmd: taskTestCmd, source: '### Test Command (tasks.md)' };
+  let envCmd = '';
+  if (config?.getConfig) {
+    try {
+      envCmd = config.getConfig(suiteEnvVar) || '';
+    } catch {
+      /* empty */
+    }
+  }
+  if (!envCmd && process.env[suiteEnvVar]) envCmd = process.env[suiteEnvVar];
+  return { cmd: envCmd, source: `$${suiteEnvVar}` };
+}
+
+function runTest(cmd, cwd) {
+  const result = spawnSync('bash', ['-lc', cmd], {
+    cwd,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  const stdout = result.stdout || '';
+  const stderr = result.stderr || '';
+  return {
+    exitCode: result.status ?? -1,
+    stdout,
+    stderr,
+    combined: (stdout + stderr).slice(-4000),
+  };
+}
+
+function readPhaseState(ticketsDir, ticket, taskNum) {
+  const tddPath = path.join(ticketsDir, ticket, `task${taskNum}`, 'tdd-phase.json');
+  return { tddPath, state: readJSON(tddPath) };
+}
+
+function currentPhase(state) {
+  if (!state) return 'red';
+  if (state.currentPhase) return state.currentPhase;
+  return 'red';
+}
+
+// Refresh the companion token's timestamp so the inner tdd-phase-state.js
+// call has a fresh 10s window. The token was minted by the PreToolUse hook
+// when the agent invoked task-next.js; by the time the test command has
+// finished running (potentially 60s+ for E2E suites), the original timestamp
+// is stale. We are the trusted intermediary — preserving the agent identity
+// from the existing token and bumping only the timestamp keeps the security
+// invariant: "the recorder must be called within 10s of an authorized intent."
+function refreshCompanionToken(scriptBasename) {
+  try {
+    const { tokenPath } = require('../lib/scripts/write-report');
+    const tp = tokenPath(scriptBasename);
+    if (!fs.existsSync(tp)) return false;
+    const data = JSON.parse(fs.readFileSync(tp, 'utf8'));
+    data.timestamp = Date.now();
+    fs.writeFileSync(tp, JSON.stringify(data), { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function recordEvidence(phase, ticket, taskNum, cmd, cwd) {
+  // Delegate to tdd-phase-state.js — the only authorized writer. Forward
+  // `--task N` so the recorder resolves the per-task state path
+  // (TASKS_BASE/<ticket>/taskN/tdd-phase.json) rather than the legacy
+  // ticket-root path. Without this the writer errors "No TDD phase state
+  // found, run init first" even though the reader on the same file works.
+  refreshCompanionToken('tdd-phase-state.js');
+  const sub =
+    phase === 'red' ? 'record-red' : phase === 'green' ? 'record-green' : 'record-refactor';
+  const args = [TDD_CLI, sub, ticket, '--task', String(taskNum), '--cmd', cmd];
+  const r = spawnSync(process.execPath, args, {
+    cwd,
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+  return {
+    ok: r.status === 0,
+    out: (r.stdout || '') + (r.stderr || ''),
+    exitCode: r.status,
+  };
+}
+
+// Collect every test/spec file referenced by Suggested Scope. Scope entries
+// may name a file directly OR a directory; for directories we walk for
+// *.test.* / *.spec.* up to a small depth.
+function findTestFilesInScope(repoRoot, scope) {
+  const out = new Set();
+  const isTestPath = (p) => /\.(test|spec)\.[jt]sx?$/.test(p);
+  for (const rel of scope) {
+    const p = path.join(repoRoot, rel);
+    if (!fs.existsSync(p)) continue;
+    let stat;
+    try {
+      stat = fs.statSync(p);
+    } catch {
+      continue;
+    }
+    if (stat.isFile() && isTestPath(p)) {
+      out.add(p);
+      continue;
+    }
+    if (stat.isDirectory()) {
+      const walk = (dir, depth) => {
+        if (depth > 4) return;
+        let entries;
+        try {
+          entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+          return;
+        }
+        for (const e of entries) {
+          if (e.name === 'node_modules' || e.name.startsWith('.')) continue;
+          const full = path.join(dir, e.name);
+          if (e.isDirectory()) walk(full, depth + 1);
+          else if (isTestPath(full)) out.add(full);
+        }
+      };
+      walk(p, 0);
+    }
+  }
+  return [...out];
+}
+
+// Look for explicit `gherkin('<scenario name>')` annotation calls; fall back
+// to substring match if no gherkin() calls are present in the file. The
+// substring fallback handles older test files that haven't adopted the
+// annotation helper.
+function scenariosCoveredByTests(scenarios, testFiles) {
+  const fileContents = testFiles.map((f) => ({ f, c: readFile(f) || '' }));
+  const allGherkinCalls = new Set();
+  for (const { c } of fileContents) {
+    const re = /gherkin\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
+    let m;
+    while ((m = re.exec(c)) !== null) allGherkinCalls.add(m[1].trim());
+  }
+  const missing = [];
+  for (const sc of scenarios) {
+    const name = sc.name.trim();
+    if (allGherkinCalls.has(name)) continue;
+    const fuzzy = fileContents.some(({ c }) => c.includes(name));
+    if (!fuzzy) missing.push(name);
+  }
+  return missing;
+}
+
+function printPhaseInstructions(phase, ctx) {
+  const lines = [];
+  const { taskNum, totalScenarios, scenarios, scope, testCmd, testCmdSource } = ctx;
+  if (phase === 'red') {
+    lines.push(`# RED phase — Task ${taskNum}`);
+    lines.push('');
+    lines.push('Write failing tests for the scenarios below. **Only test/fixture files.**');
+    lines.push(
+      "Source files in this task's scope are **off-limits** until you run me again and I advance you to GREEN."
+    );
+    lines.push('');
+    lines.push(`## Scenarios to cover (${totalScenarios})`);
+    for (const sc of scenarios) lines.push(`- ${sc.name}`);
+    lines.push('');
+    lines.push('## Allowed file globs');
+    for (const s of scope.filter((s) => /\.(test|spec)\.|fixtures?|\/__tests__\//.test(s)))
+      lines.push(`- ${s}`);
+    if (!scope.some((s) => /\.(test|spec)\.|fixtures?|\/__tests__\//.test(s))) {
+      lines.push('- (any *.test.* / *.spec.* / fixtures/ files referenced in Suggested Scope)');
+    }
+    lines.push('');
+    lines.push('## How to advance');
+    lines.push(`Run: \`node ${path.relative(process.cwd(), __filename)} <TICKET> task${taskNum}\``);
+    lines.push(`I will run: \`${testCmd}\` (from ${testCmdSource})`);
+    lines.push(
+      'You advance to GREEN when (1) the test command exits non-zero AND (2) every scenario above appears in at least one test file.'
+    );
+  } else if (phase === 'green') {
+    lines.push(`# GREEN phase — Task ${taskNum}`);
+    lines.push('');
+    lines.push('Make the failing tests pass. **Only source files.** No edits to tests/fixtures.');
+    lines.push('');
+    lines.push('## Allowed file globs');
+    for (const s of scope.filter((s) => !/\.(test|spec)\.|fixtures?|\/__tests__\//.test(s)))
+      lines.push(`- ${s}`);
+    lines.push('');
+    lines.push('## How to advance');
+    lines.push(`Run: \`node ${path.relative(process.cwd(), __filename)} <TICKET> task${taskNum}\``);
+    lines.push(`I will run: \`${testCmd}\` (from ${testCmdSource})`);
+    lines.push('You advance to REFACTOR when the test command exits 0.');
+  } else if (phase === 'refactor') {
+    lines.push(`# REFACTOR phase — Task ${taskNum}`);
+    lines.push('');
+    lines.push(
+      'Clean up. Both source AND tests are editable. Tests **must stay green** through every edit.'
+    );
+    lines.push('');
+    lines.push('## How to finish');
+    lines.push(`Run: \`node ${path.relative(process.cwd(), __filename)} <TICKET> task${taskNum}\``);
+    lines.push(`I will run: \`${testCmd}\` (from ${testCmdSource})`);
+    lines.push('Task closes when the test command still exits 0.');
+  } else {
+    lines.push(`# Task ${taskNum} complete`);
+    lines.push('');
+    lines.push('No further work in this task. Move to the next ready task in the plan.');
+  }
+  return lines.join('\n') + '\n';
+}
+
+function main() {
+  const [, , ticketRaw, taskRaw] = process.argv;
+  if (!ticketRaw || !taskRaw) {
+    process.stderr.write(
+      'usage: task-next.js <TICKET> <task_id>\n' +
+        '  TICKET   ticket id, e.g. ECHO-4467 (or #56 → GH-56)\n' +
+        "  task_id  'task1', 'task2', ...\n"
+    );
+    process.exit(2);
+  }
+  const ticket = sanitizeTicketId(ticketRaw);
+  const taskNum = parseTaskId(taskRaw);
+
+  const tasksBase = resolveTasksBase();
+  const tasksDir = path.join(tasksBase, ticket);
+  if (!fs.existsSync(tasksDir)) die(`tasks dir not found: ${tasksDir}`);
+
+  const tasksMd = readFile(path.join(tasksDir, 'tasks.md'));
+  if (!tasksMd) die(`missing tasks.md under ${tasksDir}`);
+  const section = extractTaskSection(tasksMd, taskNum);
+  if (!section) die(`Task ${taskNum} not found in tasks.md`);
+
+  const taskTitle = (section.match(/^## *Task \d+\s*[—-]?\s*(.+)$/m) || [, ''])[1].trim();
+  const scope = parseSuggestedScope(section);
+  const type = parseTaskType(section);
+  const taskTestCmd = parseTaskTestCommand(section);
+
+  const gherkin = readFile(path.join(tasksDir, 'gherkin.feature')) || '';
+  const scenarios = parseGherkinScenarios(gherkin, taskNum);
+
+  const suiteEnvVar = detectSuiteEnvVar(scope.join(' '), type, taskTitle);
+  const { cmd: testCmd, source: testCmdSource } = resolveTestCommand(taskTestCmd, suiteEnvVar);
+
+  // Prefer git's view of the worktree (correct for git-worktree layouts where
+  // tasks/ lives outside the actual checkout). Fall back to dirname(tasksBase)
+  // only when not inside a git repo.
+  const worktreeRoot = resolveWorktreeRoot();
+  const repoRoot = worktreeRoot || path.dirname(tasksBase);
+  const { state, tddPath } = readPhaseState(tasksBase, ticket, taskNum);
+  let phase = currentPhase(state);
+
+  if (phase === 'done') {
+    process.stdout.write(
+      printPhaseInstructions('done', {
+        taskNum,
+        totalScenarios: scenarios.length,
+        scenarios,
+        scope,
+        testCmd,
+        testCmdSource,
+      })
+    );
+    process.exit(0);
+  }
+
+  if (!testCmd) {
+    die(
+      `No test command resolved. Tried '### Test Command' in tasks.md and $${suiteEnvVar}. Cannot validate phase.`
+    );
+  }
+
+  // Run the test command.
+  const run = runTest(testCmd, repoRoot);
+  const passed = run.exitCode === 0;
+
+  // Decide whether we can advance.
+  let advanced = false;
+  let blockReason = '';
+
+  if (phase === 'red') {
+    if (passed) {
+      blockReason =
+        'Your test command exits 0. RED requires a real failing test. Rewrite the assertion so it actually fails before re-invoking me.';
+    } else {
+      const testFiles = findTestFilesInScope(repoRoot, scope);
+      const missing = scenariosCoveredByTests(scenarios, testFiles);
+      if (scenarios.length === 0) {
+        blockReason = `No gherkin scenarios are tagged @task:${taskNum}. RED cannot validate scope. Fix gherkin.feature or have an orchestrator regenerate it.`;
+      } else if (missing.length > 0) {
+        blockReason = `Tests do not yet cover these scenarios (verbatim title match against test files in Suggested Scope):\n  - ${missing.join('\n  - ')}\nAdd a test for each (failing) before re-invoking me.`;
+      } else {
+        const rec = recordEvidence('red', ticket, taskNum, testCmd, repoRoot);
+        if (!rec.ok) {
+          blockReason = `Could not record RED evidence:\n${rec.out}`;
+        } else {
+          advanced = true;
+          phase = 'green';
+        }
+      }
+    }
+  } else if (phase === 'green') {
+    if (!passed) {
+      blockReason = `Test command still failing (exit ${run.exitCode}). Last output:\n\n${run.combined}`;
+    } else {
+      const rec = recordEvidence('green', ticket, taskNum, testCmd, repoRoot);
+      if (!rec.ok) {
+        blockReason = `Could not record GREEN evidence:\n${rec.out}`;
+      } else {
+        advanced = true;
+        phase = 'refactor';
+      }
+    }
+  } else if (phase === 'refactor') {
+    if (!passed) {
+      blockReason = `Regression detected — tests failed during refactor (exit ${run.exitCode}). Revert the breaking change before re-invoking me.\n\n${run.combined}`;
+    } else {
+      const rec = recordEvidence('refactor', ticket, taskNum, testCmd, repoRoot);
+      if (!rec.ok) {
+        blockReason = `Could not record REFACTOR evidence:\n${rec.out}`;
+      } else {
+        advanced = true;
+        phase = 'done';
+      }
+    }
+  }
+
+  // Print summary header, then phase instructions for whatever phase we're now in.
+  const header = [
+    `task-next: ${ticket} task${taskNum} — ${taskTitle}`,
+    `  state file: ${tddPath}`,
+    `  test cmd:   ${testCmd}`,
+    `  ran:        exit=${run.exitCode}`,
+    advanced
+      ? `  result:     ADVANCED → ${phase}`
+      : blockReason
+        ? `  result:     BLOCKED in ${phase}`
+        : `  result:     no change (still ${phase})`,
+    '',
+  ].join('\n');
+  process.stdout.write(header);
+
+  if (blockReason) {
+    process.stdout.write(`## Why you did not advance\n\n${blockReason}\n\n`);
+  }
+
+  process.stdout.write(
+    printPhaseInstructions(phase, {
+      taskNum,
+      totalScenarios: scenarios.length,
+      scenarios,
+      scope,
+      testCmd,
+      testCmdSource,
+    })
+  );
+
+  process.exit(blockReason ? 2 : 0);
+}
+
+main();

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -122,7 +122,12 @@ function extractTaskSection(tasksMd, taskNum) {
 }
 
 function extractField(section, header) {
-  const re = new RegExp(`### *${header}[^\\n]*\\n([\\s\\S]*?)(?=\\n### |\\n## |$)`, 'm');
+  // NOTE: no `m` flag. With `m`, `$` in the lookahead matches end-of-LINE,
+  // so the lazy `[\s\S]*?` terminates at the first newline and we only
+  // capture the first line of the field body (e.g. Suggested Scope returns
+  // only the first path). Without `m`, `$` is end-of-string, and the
+  // lookahead terminates correctly at the next `### ` / `## ` header or EOF.
+  const re = new RegExp(`### *${header}[^\\n]*\\n([\\s\\S]*?)(?=\\n### |\\n## |$)`);
   const m = section.match(re);
   return m ? m[1].trim() : '';
 }

--- a/scripts/workflows/work-implement/task-next.js
+++ b/scripts/workflows/work-implement/task-next.js
@@ -287,15 +287,42 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd) {
     phase === 'red' ? 'record-red' : phase === 'green' ? 'record-green' : 'record-refactor';
   const target = phase === 'red' ? 'green' : phase === 'green' ? 'refactor' : null;
 
-  mintCompanionToken();
-  const recordArgs = [TDD_CLI, sub, ticket, '--task', String(taskNum), '--cmd', cmd];
-  const r = spawnSync(process.execPath, recordArgs, {
-    cwd,
-    stdio: 'pipe',
-    encoding: 'utf8',
-  });
+  // tdd-phase-state.js record-* requires the per-task state file to exist;
+  // it does NOT auto-init, and `init` itself overwrites existing state (so
+  // we cannot just always init). Strategy: try record first; if it fails
+  // with "No TDD phase state found", run init ONCE and retry. Existing
+  // cycle history is preserved (init only runs when there is no state).
+  function runRecord() {
+    mintCompanionToken();
+    const recordArgs = [TDD_CLI, sub, ticket, '--task', String(taskNum), '--cmd', cmd];
+    return spawnSync(process.execPath, recordArgs, { cwd, stdio: 'pipe', encoding: 'utf8' });
+  }
+  let r = runRecord();
   if (r.status !== 0) {
-    return { ok: false, out: (r.stdout || '') + (r.stderr || ''), exitCode: r.status };
+    const combined = (r.stdout || '') + (r.stderr || '');
+    if (/No TDD phase state found/i.test(combined)) {
+      mintCompanionToken();
+      const initRes = spawnSync(
+        process.execPath,
+        [TDD_CLI, 'init', ticket, '--task', String(taskNum)],
+        { cwd, stdio: 'pipe', encoding: 'utf8' }
+      );
+      if (initRes.status !== 0) {
+        return {
+          ok: false,
+          out:
+            combined +
+            `\n--- auto-init ${ticket} task${taskNum} failed ---\n` +
+            (initRes.stdout || '') +
+            (initRes.stderr || ''),
+          exitCode: initRes.status,
+        };
+      }
+      r = runRecord();
+    }
+    if (r.status !== 0) {
+      return { ok: false, out: (r.stdout || '') + (r.stderr || ''), exitCode: r.status };
+    }
   }
 
   if (!target) {

--- a/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/scripts/workflows/work-implement/tdd-phase-state.js
@@ -339,9 +339,13 @@ function getCurrentCycleRecord(state) {
 
 // ─── Token Verification ─────────────────────────────────────────────────────
 
-function verifyToken() {
+function verifyToken(expectedTicketId) {
   const scriptBasename = path.basename(__filename);
-  const token = consumeToken(scriptBasename);
+  // Try the ticket-keyed token first (per write-report.js's per-ticket
+  // namespacing) and fall back to the unkeyed legacy path. The token
+  // file is also tasksBase-validated below to catch any cross-ticket
+  // collisions that slip past the path-level keying.
+  const token = consumeToken(scriptBasename, expectedTicketId);
 
   if (!token) {
     errorExit(
@@ -374,6 +378,26 @@ function verifyToken() {
     errorExit(
       `Token agent "${token.agent}" is not authorized. Allowed: ${ALLOWED_AGENTS.join(', ')}`
     );
+  }
+
+  // Cross-ticket safety: token files are keyed by script basename, so a
+  // parallel session for a DIFFERENT ticket can overwrite our token between
+  // the hook's mint and our consume. The token carries `tasksBase` which
+  // resolves to `<TASKS_BASE>/<safeTicketPath(ticket)>`. Reject if the
+  // ticket arg we received doesn't match the token's tasksBase — that means
+  // a parallel session clobbered us and we should bail rather than write
+  // evidence under the wrong ticket. The caller (task-next.js) will retry.
+  if (expectedTicketId && typeof token.tasksBase === 'string' && token.tasksBase.length > 0) {
+    const safe = sanitizeId(expectedTicketId);
+    const expectedSegment = `${path.sep}${safe}${path.sep}`;
+    const expectedSuffix = `${path.sep}${safe}`;
+    if (!token.tasksBase.includes(expectedSegment) && !token.tasksBase.endsWith(expectedSuffix)) {
+      errorExit(
+        `Write token belongs to a different ticket (token.tasksBase=${token.tasksBase}, expected ticket=${expectedTicketId}). ` +
+          'Likely cause: parallel session for another ticket overwrote /tmp/.claude-write-tokens/' +
+          `${scriptBasename} between the hook's mint and this consume. Re-invoke task-next.js to mint a fresh token.`
+      );
+    }
   }
 }
 
@@ -706,7 +730,7 @@ const ticketId = args[1];
 // where tdd-phase-state.js is registered with developer-* agents authorized.
 // WORK_TDD_TOKEN_SKIP=1 bypasses verification for standalone/debugging use.
 if (GATED_SUBCOMMANDS.includes(subcommand) && process.env.WORK_TDD_TOKEN_SKIP !== '1') {
-  verifyToken();
+  verifyToken(ticketId);
 }
 
 switch (subcommand) {

--- a/scripts/workflows/work/hooks/protect-gherkin.js
+++ b/scripts/workflows/work/hooks/protect-gherkin.js
@@ -83,12 +83,20 @@ function getStepInProgress(ticketId) {
   }
 }
 
-// Allow edits during `spec` (initial authoring) AND `spec_gate` (recovery
-// path: spec_gate's validator failed against gherkin.feature and the agent
-// needs to fix the tags / structure in-place without rewinding the state
-// machine).
+// Allow edits during `spec` (initial authoring), `spec_gate` (recovery
+// path: spec_gate's validator failed against gherkin.feature and the
+// agent needs to fix the tags / structure in-place without rewinding the
+// state machine), AND `tasks` / `tasks_gate` (so the agent can add
+// `@task:N` / `@test:<path>` tags that the tasks_gate cross-validator
+// requires — without these the gate would block forever).
 const protector = createArtifactProtector({
-  artifacts: [{ basename: 'gherkin.feature', step: 'spec', allowedSteps: ['spec_gate'] }],
+  artifacts: [
+    {
+      basename: 'gherkin.feature',
+      step: 'spec',
+      allowedSteps: ['spec_gate', 'tasks', 'tasks_gate'],
+    },
+  ],
   getStepInProgress,
   getTicketId,
 });

--- a/scripts/workflows/work/lib/parse-gherkin.js
+++ b/scripts/workflows/work/lib/parse-gherkin.js
@@ -27,7 +27,7 @@ const DEFAULT_REQUIRED_TAGS = ['@integration', '@e2e'];
 const GHERKIN_SECTION_HEADING = /^##\s+Test Scenarios(?:\s*\(Gherkin\))?\s*$/;
 const ANY_HEADING = /^#{1,6}\s+/;
 const FEATURE_LINE = /^Feature:\s*(.+)$/;
-const SCENARIO_LINE = /^\s*Scenario:\s*(.+)$/;
+const SCENARIO_LINE = /^\s*Scenario(?:\s+Outline)?:\s*(.+)$/;
 const TAG_LINE = /^\s*(@\S+(?:\s+@\S+)*)$/;
 const STEP_LINE = /^\s*(Given|When|Then|And|But)\s+(.+)$/;
 const SKIP_COMMENT = /<!--\s*gherkin-skip:\s*(.+?)\s*-->/;
@@ -291,4 +291,11 @@ function hasSkipOverride(markdown) {
   return { skip: false };
 }
 
-module.exports = { parse, parseRaw, validate, hasSkipOverride, DEFAULT_MIN_SCENARIOS, DEFAULT_REQUIRED_TAGS };
+module.exports = {
+  parse,
+  parseRaw,
+  validate,
+  hasSkipOverride,
+  DEFAULT_MIN_SCENARIOS,
+  DEFAULT_REQUIRED_TAGS,
+};

--- a/scripts/workflows/work/steps/tasks-gate.js
+++ b/scripts/workflows/work/steps/tasks-gate.js
@@ -18,8 +18,12 @@
 
 function tasksGateStep(add, s, ctx) {
   const { STEPS, tasksDir, path } = ctx;
+  const fs = require('fs');
   const { parseTasks } = require('../task-parser');
   const { validateAll } = require('../../lib/task-scope');
+  const {
+    validateConsistency: validateGherkinTaskRefs,
+  } = require('../../work2/lib/gherkin-task-refs');
 
   if (!s || !s.hasTasks) {
     add(STEPS.tasks_gate, 'DEFER', null, 'No tasks.md present');
@@ -54,7 +58,54 @@ function tasksGateStep(add, s, ctx) {
 
   const validation = validateAll(tasks);
   if (validation.valid) {
-    add(STEPS.tasks_gate, 'DEFER', null, `Gate C passed (${tasks.length} tasks)`);
+    // Gate C passed — now run Gate D: gherkin↔tasks consistency.
+    // Every Scenario in gherkin.feature must reference a real task via
+    // @task:N and at least one @test:<path>, and every task that owns
+    // scenarios must list them under `### Scenarios`. This is the
+    // contract the implement-gate later relies on to refuse synthesized
+    // TDD evidence — block here so the bypass can't reach implement.
+    const gherkinPath = path.join(tasksDir, 'gherkin.feature');
+    const tasksMdPath = path.join(tasksDir, 'tasks.md');
+    if (fs.existsSync(gherkinPath) && fs.existsSync(tasksMdPath)) {
+      let gherkinText = '';
+      let tasksMdText = '';
+      try {
+        gherkinText = fs.readFileSync(gherkinPath, 'utf8');
+        tasksMdText = fs.readFileSync(tasksMdPath, 'utf8');
+      } catch {
+        /* fall through — files exist but unreadable, defer */
+      }
+      const refResult = validateGherkinTaskRefs({
+        gherkinText,
+        tasksMdText,
+        knownTaskNums: new Set(tasks.map((t) => t.num)),
+      });
+      if (!refResult.valid) {
+        const errorList = refResult.errors.map((e) => `  - ${e}`).join('\n');
+        const promptLines = [
+          `Gate D blocked tasks_gate — gherkin.feature and tasks.md are not in sync.`,
+          '',
+          'Every Scenario in gherkin.feature MUST:',
+          '  1. Tag itself with `@task:N` pointing at an existing `## Task N` in tasks.md.',
+          '  2. Tag itself with at least one `@test:<path>` whose file will exist once implemented.',
+          'Every task that owns scenarios MUST list each scenario name under `### Scenarios`.',
+          '',
+          'Validation errors:',
+          errorList,
+          '',
+          'Recovery:',
+          `  - Edit ${gherkinPath} to add the missing tags (the artifact protector allows gherkin writes during tasks_gate).`,
+          `  - Edit ${tasksMdPath} to add or correct \`### Scenarios\` bullets (verbatim names, one per line).`,
+          `  - Or rewind to /work-workflow:split-in-tasks to regenerate both files together.`,
+        ];
+        add(STEPS.tasks_gate, 'RUN', '/work-workflow:split-in-tasks', refResult.errors.join('; '), {
+          agentType: 'skill',
+          agentPrompt: promptLines.join('\n'),
+        });
+        return;
+      }
+    }
+    add(STEPS.tasks_gate, 'DEFER', null, `Gate C+D passed (${tasks.length} tasks)`);
     return;
   }
 

--- a/scripts/workflows/work/steps/tasks-gate.js
+++ b/scripts/workflows/work/steps/tasks-gate.js
@@ -69,11 +69,26 @@ function tasksGateStep(add, s, ctx) {
     if (fs.existsSync(gherkinPath) && fs.existsSync(tasksMdPath)) {
       let gherkinText = '';
       let tasksMdText = '';
+      let readOk = true;
       try {
         gherkinText = fs.readFileSync(gherkinPath, 'utf8');
         tasksMdText = fs.readFileSync(tasksMdPath, 'utf8');
       } catch {
-        /* fall through — files exist but unreadable, defer */
+        // Files exist but unreadable (transient I/O error, permission flip,
+        // mid-write). Defer the gate — re-running the orchestrator will
+        // retry the read. Do NOT continue with empty strings, which would
+        // make validateGherkinTaskRefs report a false-positive "invalid"
+        // and trigger needless task regeneration.
+        readOk = false;
+      }
+      if (!readOk) {
+        add(
+          STEPS.tasks_gate,
+          'DEFER',
+          null,
+          'gherkin.feature and tasks.md exist but were unreadable; defer for retry'
+        );
+        return;
       }
       const refResult = validateGherkinTaskRefs({
         gherkinText,

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -177,6 +177,19 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       step: STEPS.implement,
       companionScripts: ['tdd-phase-state.js'],
     },
+    // Self-paced brief runner: same companion pattern as task-next.js —
+    // brief-next.js spawns brief-phase-state.js internally to record/transition
+    // phase evidence. The hook mints tokens for both when the brief-writer
+    // agent invokes brief-next.js during the `brief` step.
+    'brief-next.js': {
+      agents: ['brief-writer'],
+      step: STEPS.brief,
+      companionScripts: ['brief-phase-state.js'],
+    },
+    'brief-phase-state.js': {
+      agents: ['brief-writer'],
+      step: STEPS.brief,
+    },
   };
 
   const workflow = {

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -494,7 +494,11 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
             }
 
             const pr = JSON.parse(execFileSync('gh', ghArgs, opts).trim()); // GH-203: positional arg, not --head
-            return pr.number > 0 && pr.state === 'OPEN';
+            // Accept OPEN or MERGED — a merged PR is even stronger evidence
+            // that the pr step succeeded than an open one. Rejecting MERGED
+            // permanently strands tickets whose PR shipped before the
+            // workflow finished its remaining steps.
+            return pr.number > 0 && (pr.state === 'OPEN' || pr.state === 'MERGED');
           } catch {
             return false;
           }

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -161,6 +161,22 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       ],
       step: STEPS.implement,
     },
+    // task-next.js is the self-paced TDD runner that internally invokes
+    // tdd-phase-state.js via spawnSync. That inner call bypasses the
+    // PreToolUse hook, so we declare tdd-phase-state.js as a companion:
+    // the hook will mint a write token for both scripts when an agent
+    // invokes task-next.js, allowing the inner recorder to consume its
+    // own token without a second hook trip.
+    'task-next.js': {
+      agents: [
+        'developer-nodejs-tdd',
+        'developer-react-senior',
+        'developer-react-ui-architect',
+        'developer-devops',
+      ],
+      step: STEPS.implement,
+      companionScripts: ['tdd-phase-state.js'],
+    },
   };
 
   const workflow = {

--- a/scripts/workflows/work2/lib/__tests__/gherkin-task-refs.test.js
+++ b/scripts/workflows/work2/lib/__tests__/gherkin-task-refs.test.js
@@ -1,0 +1,244 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  parseFeatureFile,
+  parseTaskScenarios,
+  validateConsistency,
+  collectTaskTestPaths,
+  findMissingTestFiles,
+} = require('../gherkin-task-refs.js');
+
+const FEATURE = `Feature: External assets
+
+  @integration
+  @task:1
+  @test:components/foo/foo.integration.test.tsx
+  Scenario: foo bars the baz
+    Given x
+    When y
+    Then z
+
+  @e2e
+  @task:1
+  @test:tests/e2e/foo.spec.ts
+  @test:components/foo/foo.e2e.test.tsx
+  Scenario: foo handles empty input
+    Given a
+    When b
+    Then c
+
+  @integration
+  @task:2
+  @test:components/bar/bar.test.tsx
+  Scenario: bar does the thing
+    Given p
+    When q
+    Then r
+`;
+
+const TASKS_MD = `# tasks
+
+## Task 1 — Foo
+### Type
+frontend
+
+### Scenarios
+- foo bars the baz
+- foo handles empty input
+
+## Task 2 — Bar
+### Type
+backend
+
+### Scenarios
+- bar does the thing
+`;
+
+describe('parseFeatureFile', () => {
+  it('extracts @task and @test tags per scenario', () => {
+    const { scenarios, errors } = parseFeatureFile(FEATURE);
+    assert.equal(errors.length, 0, `unexpected errors: ${errors.join('; ')}`);
+    assert.equal(scenarios.length, 3);
+    assert.equal(scenarios[0].name, 'foo bars the baz');
+    assert.equal(scenarios[0].taskNum, 1);
+    assert.deepEqual(scenarios[0].testPaths, ['components/foo/foo.integration.test.tsx']);
+    assert.equal(scenarios[1].name, 'foo handles empty input');
+    assert.equal(scenarios[1].taskNum, 1);
+    assert.deepEqual(scenarios[1].testPaths, [
+      'tests/e2e/foo.spec.ts',
+      'components/foo/foo.e2e.test.tsx',
+    ]);
+    assert.equal(scenarios[2].taskNum, 2);
+  });
+
+  it('flags scenarios with no @task tag', () => {
+    const broken = `Feature: x
+  @e2e
+  @test:foo.test.ts
+  Scenario: unrooted
+    Given x
+    Then y
+`;
+    const { scenarios, errors } = parseFeatureFile(broken);
+    assert.equal(scenarios[0].taskNum, null);
+    // parseFeatureFile collects errors only for multi-task-tag scenarios;
+    // missing-task is surfaced by validateConsistency.
+    assert.equal(errors.length, 0);
+  });
+
+  it('flags scenarios with multiple @task tags', () => {
+    const broken = `Feature: x
+  @task:1
+  @task:2
+  @test:foo.test.ts
+  Scenario: ambiguous
+    Given x
+    Then y
+`;
+    const { errors } = parseFeatureFile(broken);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /multiple @task: tags/);
+  });
+});
+
+describe('parseTaskScenarios', () => {
+  it('returns a map of taskNum → scenario names', () => {
+    const map = parseTaskScenarios(TASKS_MD);
+    assert.equal(map.size, 2);
+    assert.ok(map.get(1).has('foo bars the baz'));
+    assert.ok(map.get(1).has('foo handles empty input'));
+    assert.ok(map.get(2).has('bar does the thing'));
+  });
+
+  it('omits tasks with no ### Scenarios section', () => {
+    const text = `## Task 1
+### Type
+frontend
+`;
+    const map = parseTaskScenarios(text);
+    assert.equal(map.size, 0);
+  });
+
+  it('strips trailing punctuation and ignores commented bullets', () => {
+    const text = `## Task 1
+### Scenarios
+- scenario one.
+- scenario two:
+<!-- ignored -->
+* scenario three
+`;
+    const map = parseTaskScenarios(text);
+    const names = map.get(1);
+    assert.ok(names.has('scenario one'));
+    assert.ok(names.has('scenario two'));
+    assert.ok(names.has('scenario three'));
+    assert.equal(names.size, 3);
+  });
+});
+
+describe('validateConsistency', () => {
+  it('passes when every scenario is referenced and tagged', () => {
+    const res = validateConsistency({
+      gherkinText: FEATURE,
+      tasksMdText: TASKS_MD,
+      knownTaskNums: new Set([1, 2]),
+    });
+    assert.equal(res.valid, true, `errors: ${res.errors.join('; ')}`);
+  });
+
+  it('fails when a scenario lacks @task', () => {
+    const broken = FEATURE.replace('  @task:2\n', '');
+    const res = validateConsistency({
+      gherkinText: broken,
+      tasksMdText: TASKS_MD,
+      knownTaskNums: new Set([1, 2]),
+    });
+    assert.equal(res.valid, false);
+    assert.ok(res.errors.some((e) => /missing an @task:N tag/.test(e)));
+  });
+
+  it('fails when a scenario lacks @test', () => {
+    const broken = FEATURE.replace('  @test:components/bar/bar.test.tsx\n', '');
+    const res = validateConsistency({
+      gherkinText: broken,
+      tasksMdText: TASKS_MD,
+      knownTaskNums: new Set([1, 2]),
+    });
+    assert.equal(res.valid, false);
+    assert.ok(res.errors.some((e) => /missing an @test:<path> tag/.test(e)));
+  });
+
+  it('fails when tasks.md lists a scenario not present in gherkin', () => {
+    const extra = TASKS_MD.replace(
+      '- bar does the thing\n',
+      '- bar does the thing\n- never authored\n'
+    );
+    const res = validateConsistency({
+      gherkinText: FEATURE,
+      tasksMdText: extra,
+      knownTaskNums: new Set([1, 2]),
+    });
+    assert.equal(res.valid, false);
+    assert.ok(res.errors.some((e) => /never authored/.test(e) && /not present in gherkin/.test(e)));
+  });
+
+  it('fails when gherkin scenario is not listed under its task in tasks.md', () => {
+    const trimmedTasks = TASKS_MD.replace('- foo bars the baz\n', '');
+    const res = validateConsistency({
+      gherkinText: FEATURE,
+      tasksMdText: trimmedTasks,
+      knownTaskNums: new Set([1, 2]),
+    });
+    assert.equal(res.valid, false);
+    assert.ok(res.errors.some((e) => /not listed under `### Scenarios` in Task 1/.test(e)));
+  });
+
+  it('fails when @task points at a task that does not exist', () => {
+    const res = validateConsistency({
+      gherkinText: FEATURE,
+      tasksMdText: TASKS_MD,
+      knownTaskNums: new Set([1]), // task 2 removed
+    });
+    assert.equal(res.valid, false);
+    assert.ok(res.errors.some((e) => /tasks.md has no Task 2/.test(e)));
+  });
+});
+
+describe('collectTaskTestPaths', () => {
+  it('returns sorted unique test paths for a task', () => {
+    const paths = collectTaskTestPaths({ gherkinText: FEATURE }, 1);
+    assert.deepEqual(paths, [
+      'components/foo/foo.e2e.test.tsx',
+      'components/foo/foo.integration.test.tsx',
+      'tests/e2e/foo.spec.ts',
+    ]);
+  });
+
+  it('returns [] for a task with no scenarios', () => {
+    const paths = collectTaskTestPaths({ gherkinText: FEATURE }, 99);
+    assert.deepEqual(paths, []);
+  });
+});
+
+describe('findMissingTestFiles', () => {
+  it('flags only the paths missing from disk', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gherkin-refs-'));
+    try {
+      const present = 'components/foo/foo.integration.test.tsx';
+      const presentAbs = path.join(tmp, present);
+      fs.mkdirSync(path.dirname(presentAbs), { recursive: true });
+      fs.writeFileSync(presentAbs, '// stub');
+      const { missing, all } = findMissingTestFiles({ gherkinText: FEATURE, worktreeDir: tmp }, 1);
+      assert.equal(all.length, 3);
+      assert.deepEqual(missing, ['components/foo/foo.e2e.test.tsx', 'tests/e2e/foo.spec.ts']);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/workflows/work2/lib/__tests__/gherkin-task-refs.test.js
+++ b/scripts/workflows/work2/lib/__tests__/gherkin-task-refs.test.js
@@ -92,6 +92,28 @@ describe('parseFeatureFile', () => {
     assert.equal(errors.length, 0);
   });
 
+  it('extracts tags from Scenario Outline entries (parity with task-next.js)', () => {
+    const withOutline = `Feature: x
+  @integration
+  @task:1
+  @test:components/foo/foo.test.tsx
+  Scenario Outline: foo handles <input>
+    Given <input>
+    When processed
+    Then <output>
+
+    Examples:
+      | input | output |
+      | a     | A      |
+`;
+    const { scenarios, errors } = parseFeatureFile(withOutline);
+    assert.equal(errors.length, 0, `unexpected errors: ${errors.join('; ')}`);
+    assert.equal(scenarios.length, 1);
+    assert.equal(scenarios[0].name, 'foo handles <input>');
+    assert.equal(scenarios[0].taskNum, 1);
+    assert.deepEqual(scenarios[0].testPaths, ['components/foo/foo.test.tsx']);
+  });
+
   it('flags scenarios with multiple @task tags', () => {
     const broken = `Feature: x
   @task:1

--- a/scripts/workflows/work2/lib/gherkin-task-refs.js
+++ b/scripts/workflows/work2/lib/gherkin-task-refs.js
@@ -1,0 +1,283 @@
+/**
+ * gherkin-task-refs.js
+ *
+ * Cross-validates `tasks/<TICKET>/gherkin.feature` against
+ * `tasks/<TICKET>/tasks.md` so every scenario is owned by exactly one task
+ * AND points at a real test file on disk before the implement step runs.
+ *
+ * This module is the contract enforcer for two bypass paths that the gate
+ * previously could not see:
+ *
+ *   1. "Synthesized" TDD evidence — the gate would record red+green at the
+ *      same timestamp when no test files matched the command. With these
+ *      refs in place, the gate refuses to enter implement until every
+ *      scenario's @test file physically exists.
+ *
+ *   2. "Type-skip" — the gate previously waved tasks of certain types past
+ *      RED. Reference enforcement is type-agnostic: every scenario needs an
+ *      @test file, regardless of how the task is labeled in tasks.md.
+ *
+ * Format (per scenario in gherkin.feature):
+ *
+ *     @integration
+ *     @task:3
+ *     @test:components/foo/foo.integration.test.tsx
+ *     Scenario: foo bars the baz
+ *       Given …
+ *
+ *   - `@task:N`            (required) — which `## Task N` in tasks.md owns it
+ *   - `@test:<path>`       (required, may repeat) — test file that MUST exist
+ *
+ * Format (per task in tasks.md):
+ *
+ *     ## Task 3 — Foo
+ *     ...
+ *     ### Scenarios
+ *     - foo bars the baz
+ *     - foo handles empty input
+ *
+ *   Each bullet is the scenario name verbatim (without the trailing colon).
+ *
+ * Public API:
+ *   parseFeatureFile(text)             → { scenarios: [{name, taskNum, testPaths[]}], errors[] }
+ *   parseTaskScenarios(tasksMdText)    → Map<taskNum, Set<scenarioName>>
+ *   validateConsistency(opts)          → { valid, errors[] }
+ *   collectTaskTestPaths(opts, taskNum)→ string[] (absolute paths)
+ *
+ * No I/O is done by the parsing functions — callers pass in text. The
+ * validators that need file-existence checks accept an `fs` injection point
+ * for testability (defaults to node:fs).
+ */
+
+'use strict';
+
+const path = require('node:path');
+const fs = require('node:fs');
+
+const { parseRaw } = require(path.join(__dirname, '..', '..', 'work', 'lib', 'parse-gherkin.js'));
+
+const TASK_TAG_RE = /^@task:(\d+)$/;
+const TEST_TAG_RE = /^@test:(.+)$/;
+
+/**
+ * Parse a gherkin .feature file and extract every scenario's task/test refs.
+ *
+ * @param {string} text - Full file contents
+ * @returns {{
+ *   scenarios: Array<{name: string, taskNum: number|null, testPaths: string[], tags: string[]}>,
+ *   errors: string[]
+ * }}
+ */
+function parseFeatureFile(text) {
+  const { features, errors: parseErrors } = parseRaw(String(text || ''));
+  const errors = [...parseErrors];
+  const scenarios = [];
+
+  for (const feature of features) {
+    for (const scenario of feature.scenarios) {
+      let taskNum = null;
+      const testPaths = [];
+      for (const tag of scenario.tags) {
+        const taskMatch = tag.match(TASK_TAG_RE);
+        if (taskMatch) {
+          if (taskNum !== null) {
+            errors.push(
+              `Scenario "${scenario.name}" has multiple @task: tags — exactly one is required.`
+            );
+          }
+          taskNum = parseInt(taskMatch[1], 10);
+          continue;
+        }
+        const testMatch = tag.match(TEST_TAG_RE);
+        if (testMatch) {
+          testPaths.push(testMatch[1].trim());
+        }
+      }
+      scenarios.push({
+        name: scenario.name,
+        taskNum,
+        testPaths,
+        tags: scenario.tags,
+      });
+    }
+  }
+
+  return { scenarios, errors };
+}
+
+/**
+ * Parse tasks.md and return a map of taskNum → Set of scenario names listed
+ * under that task's `### Scenarios` section.
+ *
+ * Tasks without a `### Scenarios` section produce no entry — callers can
+ * detect that as "task has no scenarios" via .has(num).
+ *
+ * @param {string} tasksMdText
+ * @returns {Map<number, Set<string>>}
+ */
+function parseTaskScenarios(tasksMdText) {
+  const result = new Map();
+  const text = String(tasksMdText || '');
+  if (!text.trim()) return result;
+
+  // Split on ## Task N — same approach as task-parser.js
+  const parts = text.split(/^## Task (\d+)/m);
+  for (let i = 1; i < parts.length; i += 2) {
+    const taskNum = parseInt(parts[i], 10);
+    if (!Number.isFinite(taskNum)) continue;
+    const body = parts[i + 1] || '';
+    // Find ### Scenarios block (any case for the heading word)
+    // Capture the bullet list under `### Scenarios` up to the next ### or ##
+    // heading (or end-of-string). No /m flag — we need `$` to mean
+    // end-of-string, not end-of-line, otherwise the lazy match terminates
+    // after the first bullet.
+    const sectionMatch = body.match(/### +Scenarios\b[^\n]*\n([\s\S]*?)(?=\n###|\n## |$)/);
+    if (!sectionMatch) continue;
+    const sectionBody = sectionMatch[1];
+    const scenarioNames = new Set();
+    for (const rawLine of sectionBody.split('\n')) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('<!--')) continue;
+      // Accept `- name`, `* name`, or `1. name`
+      const m = line.match(/^(?:[-*]|\d+\.)\s+(.+)$/);
+      if (!m) continue;
+      // Strip trailing punctuation that authors may add (`.`, `:`)
+      const name = m[1].replace(/[.:]\s*$/, '').trim();
+      if (name) scenarioNames.add(name);
+    }
+    if (scenarioNames.size > 0) result.set(taskNum, scenarioNames);
+  }
+
+  return result;
+}
+
+/**
+ * Cross-check a gherkin.feature against a tasks.md so the gate can refuse
+ * to transition out of `tasks` until every scenario is reachable.
+ *
+ * Returns `{ valid, errors[] }`. Errors are human-readable and reference
+ * the scenario or task that's at fault. Callers should surface them
+ * verbatim in the gate's RUN instruction so the authoring agent knows
+ * exactly what to fix.
+ *
+ * @param {{
+ *   gherkinText: string,           // contents of gherkin.feature
+ *   tasksMdText: string,           // contents of tasks.md
+ *   knownTaskNums?: Set<number>,   // optional: tasks.md task IDs for cross-check
+ * }} opts
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateConsistency(opts) {
+  const errors = [];
+  const { gherkinText, tasksMdText, knownTaskNums } = opts || {};
+
+  if (!gherkinText || !gherkinText.trim()) {
+    errors.push('gherkin.feature is missing or empty.');
+    return { valid: false, errors };
+  }
+  if (!tasksMdText || !tasksMdText.trim()) {
+    errors.push('tasks.md is missing or empty.');
+    return { valid: false, errors };
+  }
+
+  const { scenarios, errors: parseErrors } = parseFeatureFile(gherkinText);
+  for (const e of parseErrors) errors.push(e);
+
+  if (scenarios.length === 0) {
+    errors.push('gherkin.feature has zero scenarios.');
+    return { valid: false, errors };
+  }
+
+  const taskMap = parseTaskScenarios(tasksMdText);
+
+  // Per-scenario checks: tags present + cross-ref present in tasks.md
+  const referencedByTask = new Map();
+  for (const sc of scenarios) {
+    if (sc.taskNum === null) {
+      errors.push(`Scenario "${sc.name}" is missing an @task:N tag.`);
+      continue;
+    }
+    if (sc.testPaths.length === 0) {
+      errors.push(`Scenario "${sc.name}" (task ${sc.taskNum}) is missing an @test:<path> tag.`);
+    }
+    if (knownTaskNums && !knownTaskNums.has(sc.taskNum)) {
+      errors.push(
+        `Scenario "${sc.name}" references @task:${sc.taskNum} but tasks.md has no Task ${sc.taskNum}.`
+      );
+    }
+    const listed = taskMap.get(sc.taskNum);
+    if (!listed) {
+      errors.push(
+        `Scenario "${sc.name}" claims @task:${sc.taskNum} but Task ${sc.taskNum} in tasks.md has no \`### Scenarios\` list.`
+      );
+    } else if (!listed.has(sc.name)) {
+      errors.push(
+        `Scenario "${sc.name}" is not listed under \`### Scenarios\` in Task ${sc.taskNum} of tasks.md.`
+      );
+    }
+    if (!referencedByTask.has(sc.taskNum)) referencedByTask.set(sc.taskNum, new Set());
+    referencedByTask.get(sc.taskNum).add(sc.name);
+  }
+
+  // Reverse check: every scenario listed in tasks.md must exist in gherkin
+  for (const [taskNum, names] of taskMap.entries()) {
+    const inFeature = referencedByTask.get(taskNum) || new Set();
+    for (const name of names) {
+      if (!inFeature.has(name)) {
+        errors.push(
+          `Task ${taskNum} in tasks.md lists scenario "${name}" but it is not present in gherkin.feature (or its @task tag points elsewhere).`
+        );
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Collect every @test:<path> referenced by scenarios that belong to a given
+ * task, joined with the tasks dir's worktree root so callers can stat()
+ * them. Returned paths are RELATIVE to `worktreeDir` (callers prepend it
+ * before fs.existsSync, or pass it as `cwd`).
+ *
+ * @param {{ gherkinText: string }} opts
+ * @param {number} taskNum
+ * @returns {string[]} unique, sorted test-file paths
+ */
+function collectTaskTestPaths(opts, taskNum) {
+  const { scenarios } = parseFeatureFile(opts.gherkinText);
+  const set = new Set();
+  for (const sc of scenarios) {
+    if (sc.taskNum === taskNum) {
+      for (const p of sc.testPaths) set.add(p);
+    }
+  }
+  return [...set].sort();
+}
+
+/**
+ * Verify every @test:<path> for a task exists on disk. Returns the list of
+ * missing paths (empty array == all present). Pure of side effects.
+ *
+ * @param {{ gherkinText: string, worktreeDir: string, fsImpl?: typeof fs }} opts
+ * @param {number} taskNum
+ * @returns {{ missing: string[], all: string[] }}
+ */
+function findMissingTestFiles(opts, taskNum) {
+  const fsImpl = opts.fsImpl || fs;
+  const all = collectTaskTestPaths(opts, taskNum);
+  const missing = [];
+  for (const rel of all) {
+    const abs = path.isAbsolute(rel) ? rel : path.join(opts.worktreeDir || '.', rel);
+    if (!fsImpl.existsSync(abs)) missing.push(rel);
+  }
+  return { missing, all };
+}
+
+module.exports = {
+  parseFeatureFile,
+  parseTaskScenarios,
+  validateConsistency,
+  collectTaskTestPaths,
+  findMissingTestFiles,
+};

--- a/scripts/workflows/work2/lib/step-enrichments/brief.js
+++ b/scripts/workflows/work2/lib/step-enrichments/brief.js
@@ -1,0 +1,54 @@
+/**
+ * Brief step enrichment.
+ *
+ * Self-paced model: the brief-writer agent receives a minimal prompt that
+ * tells it to invoke `brief-next.js`, which then drives 5 phases (inputs,
+ * overlap, draft, validate, memorize). The script owns all the rules —
+ * which files to read, what overlap analysis to produce, what brief
+ * sections are required, what memory-plugin calls to make.
+ *
+ * Parallel to implement.js's task-next.js wiring.
+ */
+
+'use strict';
+
+const path = require('path');
+
+const BRIEF_NEXT_SCRIPT = path.resolve(__dirname, '..', '..', '..', 'work-brief', 'brief-next.js');
+
+function buildSelfPacedPrompt(ticket) {
+  return [
+    `## Brief generation — ${ticket}`,
+    '',
+    'You are a self-paced brief-writer. Do NOT read tickets, analyze overlap,',
+    'or write the brief until the script tells you the current phase.',
+    '',
+    '### Single instruction',
+    '```bash',
+    `node ${BRIEF_NEXT_SCRIPT} ${ticket}`,
+    '```',
+    '',
+    'Run that command. Follow the Markdown response verbatim:',
+    '- It will tell you the current phase (INPUTS / OVERLAP / DRAFT / VALIDATE / MEMORIZE).',
+    '- It will tell you which files to read or produce.',
+    '- It will tell you what must be true to advance.',
+    '',
+    'When you finish a phase, re-invoke the same command. The script will',
+    'validate, record evidence, and either advance you or tell you precisely',
+    'why it did not. Stop only when the script tells you the brief is done.',
+    '',
+    '### Rules',
+    '- Do NOT touch brief-phase.json — it is written by the authorized recorder.',
+    '- Do NOT invoke /brief, /work2, or any other slash command.',
+    '- Do NOT skip the overlap analysis or the memorize step.',
+  ].join('\n');
+}
+
+module.exports = function registerBrief(register) {
+  register('brief', (entry, ctx) => {
+    if (!entry.agentPrompt) return;
+    const ticket = ctx.ticket || 'TICKET';
+    entry.agentPrompt = buildSelfPacedPrompt(ticket);
+    entry.agentType = 'brief-writer';
+  });
+};

--- a/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/implement-gate.js
@@ -239,14 +239,20 @@ function extractTestCommandFromSection(section) {
 }
 
 /**
- * Task types that REQUIRE authentic RED before dispatch (pre-test must fail).
- * Other types skip RED enforcement and allow dispatch on a passing pre-test.
+ * TDD is required for every task type EXCEPT the exemption list below. The
+ * previous design (`TDD_REQUIRED_TYPES` allowlist) let agents self-exempt
+ * via the `### Type` field in tasks.md — labelling a task "frontend" or
+ * "infrastructure" caused the gate to record a skip stub and let the task
+ * pass without an authentic RED. Inverting the list closes that bypass.
+ *
+ * `checkpoint` is the only legitimate exemption: checkpoint tasks verify
+ * the work of other tasks and have no implementation of their own.
  */
-const TDD_REQUIRED_TYPES = new Set(['implementation', 'feature', 'fix', 'test']);
+const TDD_EXEMPT_TYPES = new Set(['checkpoint']);
 
 function isTddRequired(taskType) {
-  if (!taskType) return true; // default = TDD required
-  return TDD_REQUIRED_TYPES.has(String(taskType).toLowerCase());
+  if (!taskType) return true;
+  return !TDD_EXEMPT_TYPES.has(String(taskType).toLowerCase());
 }
 
 /**
@@ -572,28 +578,18 @@ function runTestAndRecord(cmd, safeName, taskNum, workingDir, env, gateTasksBase
       ),
     };
   } else {
-    // No prior RED — synthesize the full cycle
-    evidence = {
-      currentPhase: 'refactor',
-      currentCycle: 1,
-      cycles: [
-        {
-          cycle: 1,
-          red: {
-            testFiles: [],
-            testCommand: cmd,
-            testExitCode: 1,
-            timestamp: now,
-            synthesizedByGate: true,
-          },
-          green: {
-            testCommand: cmd,
-            testExitCode: 0,
-            timestamp: now,
-            synthesizedByGate: true,
-          },
-        },
-      ],
+    // No prior RED evidence. The pre-implement test path is the ONLY way to
+    // produce authentic RED — synthesizing a fake RED+GREEN at the same
+    // timestamp would let any passing post-test approve a task that was
+    // never test-driven (the bug that produced ECHO-4612/task2,
+    // ECHO-4614/task3, ECHO-4614/task4 evidence). Refuse the GREEN and
+    // surface the gap so the orchestrator routes back through pre-test.
+    return {
+      passed: false,
+      command: cmd,
+      exitCode: 0,
+      outputTail: '',
+      noRedEvidence: true,
     };
   }
 
@@ -713,6 +709,39 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
       const testCmd = readTaskTestCommand(ctx.tasksDir, taskNum);
       if (testCmd) {
         const workingDir = ctx.worktreeDir || (ws.worktreeDir ? ws.worktreeDir : process.cwd());
+        // Gate D' — gherkin @test:<path> existence check.
+        // Before running the test command, verify that every test file
+        // declared in gherkin.feature for this task actually exists on
+        // disk. This catches the "agent renames source out then in" /
+        // "tests/<path>.tsx never existed" patterns that previously
+        // produced testFiles:[] + synthesizedByGate evidence. The check
+        // is opt-in: tickets whose gherkin.feature has no @test tags
+        // (legacy or trivial) skip silently.
+        try {
+          const gherkinPath = path.join(ctx.tasksDir, 'gherkin.feature');
+          if (fs.existsSync(gherkinPath)) {
+            const { findMissingTestFiles, collectTaskTestPaths } = require(
+              path.join(__dirname, '..', 'gherkin-task-refs.js')
+            );
+            const gherkinText = fs.readFileSync(gherkinPath, 'utf8');
+            const allRefs = collectTaskTestPaths({ gherkinText }, taskNum);
+            if (allRefs.length > 0) {
+              const { missing } = findMissingTestFiles(
+                { gherkinText, worktreeDir: workingDir },
+                taskNum
+              );
+              if (missing.length > 0) {
+                recordRetry(
+                  `Task ${taskNum} cannot enter RED — gherkin.feature declares @test files that do not exist on disk: ${missing.join(', ')}. Create the failing test file(s) first, then re-run the gate.`,
+                  { command: testCmd, exitCode: null, outputTail: missing.join('\n') }
+                );
+                return null;
+              }
+            }
+          }
+        } catch {
+          /* fail-open — gherkin parse failure shouldn't deadlock the gate */
+        }
         const runEnv = gateTasksBase ? { ...process.env, TASKS_BASE: gateTasksBase } : process.env;
         const pre = runPreImplementTest(
           testCmd,
@@ -769,6 +798,19 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
             : readTddEvidence(safeName, stepName, taskNum);
           exists = reread.exists;
           evidence = reread.evidence;
+        } else if (result && result.noRedEvidence) {
+          // GREEN ran cleanly but no authentic RED was captured. Clear the
+          // pre-test marker so the next gate pass runs the pre-implement
+          // test again — if the agent already modified source, that pre-test
+          // will pass and the gate will block with "test passed; write a
+          // failing test first," forcing a real RED cycle.
+          delete ws._preTestForTask;
+          saveWorkState(safeName, ws);
+          recordRetry(
+            `No authentic RED evidence for task ${taskNum}. The gate refuses to synthesize a TDD cycle — write a failing test FIRST, commit the failure (gate will capture it), then implement.`,
+            { command: result.command, exitCode: result.exitCode ?? 0, outputTail: '' }
+          );
+          return null;
         } else if (result && result.malformed) {
           recordRetry(
             `Test command for task ${taskNum} is malformed in tasks.md ` +

--- a/scripts/workflows/work2/lib/step-enrichments/implement.js
+++ b/scripts/workflows/work2/lib/step-enrichments/implement.js
@@ -1,9 +1,15 @@
 /**
  * Implement step enrichment.
  *
- * Selects the right developer agent based on task type and file scope.
- * Builds a compact prompt with file references instead of embedding content.
- * The agent reads brief/spec/tasks from disk — no need to duplicate them in the prompt.
+ * Self-paced TDD model: the developer agent receives a minimal prompt that
+ * tells it to invoke `task-next.js`, which then dictates RED → GREEN →
+ * REFACTOR instructions, runs tests, validates phase transitions, and
+ * records evidence via `tdd-phase-state.js`.
+ *
+ * This file selects the right developer agent type per task and builds the
+ * dispatch payload (single or parallel). It no longer embeds TDD rules,
+ * test commands, file-scope lists, or retry summaries into the prompt —
+ * task-next.js owns all of that.
  */
 
 'use strict';
@@ -12,25 +18,24 @@ const fs = require('fs');
 const path = require('path');
 
 const { resolveTaskType } = require(path.join(__dirname, '..', 'resolve-task-type'));
+const { findReadyTasks } = require(path.join(__dirname, '..', 'task-graph'));
+
+const TASK_NEXT_SCRIPT = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'work-implement',
+  'task-next.js'
+);
 
 /**
- * Resolve the developer agent type from task metadata.
- *
- * Priority:
- *   1. IMPLEMENT_AGENT env var (user override)
- *   2. Suggested scope file extensions
- *   3. Task type field
- *   4. Default: developer-nodejs-tdd
- *
- * @param {string} tasksDir - Path to ticket tasks directory
- * @param {number|string} taskNum - 1-indexed task number
- * @returns {string} Agent type identifier
+ * Resolve the developer agent type from task metadata. Same heuristics as
+ * the prior dispatcher — only the prompt body has been simplified.
  */
 function resolveAgentType(tasksDir, taskNum) {
-  // 1. User override via env var
   if (process.env.IMPLEMENT_AGENT) return process.env.IMPLEMENT_AGENT;
 
-  // 2. Read task metadata from tasks.md
   let taskType = null;
   let suggestedScope = '';
   try {
@@ -48,81 +53,52 @@ function resolveAgentType(tasksDir, taskNum) {
     /* no tasks.md */
   }
 
-  // 3. Map from suggested scope file extensions
   const hasReactFiles =
     /\.(tsx|jsx)\b/.test(suggestedScope) || /react|component/i.test(suggestedScope);
   const hasInfraFiles = /dockerfile|\.ya?ml|terraform|\.tf\b|ci\/cd|pipeline/i.test(suggestedScope);
 
   if (hasReactFiles) return 'developer-react-senior';
   if (hasInfraFiles) return 'developer-devops';
-
-  // 4. Map from task type
   if (taskType === 'frontend') return 'developer-react-senior';
   if (taskType === 'devops' || taskType === 'infra') return 'developer-devops';
-
-  // 5. Default
   return 'developer-nodejs-tdd';
 }
 
-const { findReadyTasks, parseTasks } = require(path.join(__dirname, '..', 'task-graph'));
-
 /**
- * Build a "### Previous attempt failed" block from work-state retry fields.
- * Returns an empty array when there is no retry context to surface.
- *
- * The gate persists `_tddRetryReason` / `_tddRetryCommand` / `_tddRetryExitCode`
- * / `_tddRetryOutputTail` whenever the implement-gate decides to re-dispatch.
- * Surfacing them here gives the agent the exact command, exit code, and tail
- * of test output — closing the rationale loop that previously led to TDD
- * evidence fabrication.
+ * Build the minimal agent prompt. The agent invokes task-next.js and follows
+ * the structured Markdown response it prints (current phase, what to touch,
+ * what to verify, how to advance). The script is the source of truth for
+ * everything else.
  */
-function buildRetryFailureBlock(tasksDir, _ticket, targetTaskNum) {
-  if (!tasksDir) return [];
-  let ws;
-  try {
-    // The state file lives at <tasksDir>/.work-state.json directly. Round-tripping
-    // via path.dirname(tasksDir) + ticket would break when the raw ticket
-    // (e.g. "#56") differs from its sanitized directory basename ("GH-56"),
-    // and would double-nest under suffix workflows. Read tasksDir directly.
-    const statePath = path.join(tasksDir, '.work-state.json');
-    ws = JSON.parse(fs.readFileSync(statePath, 'utf8'));
-  } catch {
-    return [];
-  }
-  const reason = ws && ws._tddRetryReason;
-  if (!reason) return [];
-  // Scope retry context to the failing task. Parallel dispatch builds one
-  // delegate per task; surfacing task N's failure to task M's agent would
-  // misdirect effort.
-  const retryTask = ws._tddRetryTask;
-  if (targetTaskNum !== null && targetTaskNum !== undefined && retryTask !== undefined) {
-    if (Number(retryTask) !== Number(targetTaskNum)) return [];
-  }
-  const count = ws._tddRetryCount || 0;
-  const cmd = ws._tddRetryCommand || '';
-  const exitCode = ws._tddRetryExitCode;
-  const tail = ws._tddRetryOutputTail || '';
-  const lines = [`### Previous attempt failed (retry ${count})`, '', `Reason: ${reason}`];
-  if (cmd) {
-    lines.push('', `Test command that ran: \`${cmd}\``);
-  }
-  if (exitCode !== null && exitCode !== undefined) {
-    lines.push(`Exit code: ${exitCode}`);
-  }
-  if (tail) {
-    lines.push('', 'Last lines of test output:', '```', tail, '```');
-  }
-  lines.push(
+function buildSelfPacedPrompt(ticket, taskNum, totalTasks, taskTitle) {
+  return [
+    `## Task ${taskNum}${totalTasks ? `/${totalTasks}` : ''} — ${taskTitle}`,
     '',
-    'What to fix:',
-    '  - If the test failed → fix the source so the command above passes.',
-    '  - If the command itself errored (command-not-found, syntax, missing',
-    '    dependency, malformed parser output) → that is a tasks.md problem.',
-    '    Stop and surface it. Do NOT write `tdd-phase.json` yourself; that',
-    '    file is gate-only and any write will be blocked by the hook.',
-    ''
-  );
-  return lines;
+    'You are a self-paced TDD agent. Do NOT plan ahead, write tests, or change',
+    'source until you are told what phase you are in.',
+    '',
+    '### Single instruction',
+    '```bash',
+    `node ${TASK_NEXT_SCRIPT} ${ticket} task${taskNum}`,
+    '```',
+    '',
+    'Run that command. Follow the Markdown response verbatim:',
+    '- It will tell you the current phase (RED / GREEN / REFACTOR).',
+    '- It will tell you which files you may touch in this phase.',
+    '- It will tell you the test command it will run on your behalf.',
+    '- It will tell you what must be true to advance.',
+    '',
+    'When you finish a phase, re-invoke the same command. The script will run',
+    'the test, validate, record evidence, and either advance you or tell you',
+    'precisely why it did not. Stop only when the script tells you the task',
+    'is complete.',
+    '',
+    '### Rules',
+    `- Implement ONLY Task ${taskNum} deliverables.`,
+    '- Do NOT touch tdd-phase.json or .work-state.json — those are written by',
+    '  the script via the authorized recorder. Direct edits are blocked.',
+    '- Do NOT invoke /work-implement, /work2, or any other slash command.',
+  ].join('\n');
 }
 
 module.exports = function registerImplement(register) {
@@ -130,117 +106,29 @@ module.exports = function registerImplement(register) {
     if (!entry.agentPrompt) return;
 
     const ticket = ctx.ticket || 'TICKET';
-
-    // Check for parallel tasks
     const tasksDir = ctx.tasksDir || '';
     const taskMatch = entry.agentPrompt.match(/Task (\d+) of (\d+)/);
     const currentTaskNum = taskMatch ? parseInt(taskMatch[1], 10) : null;
     const totalTasks = taskMatch ? parseInt(taskMatch[2], 10) : null;
 
+    // Parallel dispatch path: one delegate per ready-to-run task.
     if (tasksDir && totalTasks && totalTasks > 1) {
       const { parallelTasks } = findReadyTasks(tasksDir, currentTaskNum - 1);
       if (parallelTasks.length > 1) {
-        // Use task-parser (not task-graph) to get testCommand and suggestedScope
         const { parseTasks: parseFullTasks } = require(
           path.join(__dirname, '..', '..', '..', 'work', 'task-parser')
         );
-        const allTasks = parseFullTasks(tasksDir) || parseTasks(tasksDir);
+        const allTasks = parseFullTasks(tasksDir) || [];
 
-        const getConfig = require(path.join(__dirname, '..', '..', '..', 'lib', 'get-config'));
         const delegates = parallelTasks.map((num) => {
           const task = allTasks.find((t) => t.num === num);
+          const title = task?.title || 'Implementation';
           const agentType = resolveAgentType(tasksDir, num);
-          const parallelTestCmd = task?.testCommand || null;
-          const parallelScope = task?.suggestedScope || '';
-
-          // Detect suite per-delegate so each parallel task gets the right
-          // TEST_*_COMMAND in its prompt.
-          const pType = String(task?.type || '').toLowerCase();
-          const pTitle = String(task?.title || '');
-          const pIsE2E =
-            /e2e|playwright/i.test(parallelScope) ||
-            pType === 'e2e' ||
-            /e2e|playwright/i.test(pTitle);
-          const pIsInt =
-            /integration|\.int\./i.test(parallelScope) ||
-            pType === 'integration' ||
-            /integration/i.test(pTitle);
-          const pSuite = pIsE2E ? 'e2e' : pIsInt ? 'integration' : 'unit';
-          const pEnvVar =
-            pSuite === 'e2e'
-              ? 'TEST_E2E_COMMAND'
-              : pSuite === 'integration'
-                ? 'TEST_INTEGRATION_COMMAND'
-                : 'TEST_UNIT_COMMAND';
-          const pCmd = (() => {
-            try {
-              return getConfig(pEnvVar) || '';
-            } catch {
-              return '';
-            }
-          })();
-          const parallelTestCmdsBlock = pCmd
-            ? [
-                '### Test Commands',
-                `This task is a **${pSuite}** task. Run tests with:`,
-                '```bash',
-                `# ${pEnvVar} (resolved):`,
-                pCmd,
-                '```',
-                'Invoke via:',
-                '```bash',
-                `CHANGED_FILES="<files-you-touched>" eval "$${pEnvVar}"`,
-                '```',
-                '',
-              ]
-            : [
-                '### Test Commands',
-                `Run tests via \`$${pEnvVar}\` (project-configured).`,
-                '```bash',
-                `CHANGED_FILES="<files-you-touched>" eval "$${pEnvVar}"`,
-                '```',
-                '',
-              ];
-
-          const parallelTddSection = parallelTestCmd
-            ? [
-                ...(parallelScope
-                  ? [
-                      '### Files to implement',
-                      ...parallelScope
-                        .split('\n')
-                        .map((l) => l.trim())
-                        .filter(Boolean)
-                        .map((l) => `- \`${l.replace(/^[-*+]\s+/, '').replace(/`/g, '')}\``),
-                      '',
-                    ]
-                  : []),
-                ...parallelTestCmdsBlock,
-                '### How to verify',
-                `Run \`${parallelTestCmd}\` and ensure it passes before stopping.`,
-              ]
-            : parallelTestCmdsBlock;
-
-          const delegateRetryBlock = buildRetryFailureBlock(tasksDir, ticket, num);
           return {
             type: 'task',
             agentType,
-            description: `Task ${num}/${totalTasks} — ${task?.title || 'Implementation'}`,
-            prompt: [
-              `## Implement Task ${num}/${totalTasks} — ${task?.title || 'Implementation'}`,
-              '',
-              ...delegateRetryBlock,
-              ...parallelTddSection,
-              '',
-              '### Required Reading',
-              `- **Task details:** ${path.join(tasksDir, 'tasks.md')} (find "## Task ${num}" section)`,
-              `- **Spec:** ${path.join(tasksDir, 'spec.md')}`,
-              `- **Brief:** ${path.join(tasksDir, 'brief.md')}`,
-              '',
-              '### Rules',
-              `- Implement ONLY Task ${num} deliverables`,
-              '- Do NOT touch files reserved for other tasks',
-            ].join('\n'),
+            description: `Task ${num}/${totalTasks} — ${title}`,
+            prompt: buildSelfPacedPrompt(ticket, num, totalTasks, title),
             note: 'Pass the prompt directly to the agent.',
           };
         });
@@ -258,14 +146,11 @@ module.exports = function registerImplement(register) {
       }
     }
 
-    // Reuse taskMatch/totalTasks from parallel check above
+    // Single-task path.
     const taskNum = taskMatch ? taskMatch[1] : null;
-
-    // Extract task title from prompt
     const titleMatch = entry.agentPrompt.match(/## Current Task: Task \d+ — (.+?)(?:\n|$)/);
     const taskTitle = titleMatch ? titleMatch[1].trim() : 'Implementation';
 
-    // Mark current progress in tasks.md (shows [-] for in-progress task)
     if (tasksDir) {
       try {
         const { markProgress } = require(path.join(__dirname, '..', 'mark-task-progress'));
@@ -275,11 +160,9 @@ module.exports = function registerImplement(register) {
       }
     }
 
-    // Detect task type for checkpoint handling
+    // Checkpoint tasks: pure verification, no TDD. Keep the dedicated path.
     const taskType = resolveTaskType(tasksDir, taskNum);
-
     if (taskType === 'checkpoint') {
-      // Checkpoint tasks: verify, don't implement. No TDD needed.
       entry.agentPrompt = [
         `## Checkpoint: Task ${taskNum || '?'}/${totalTasks || '?'} — ${taskTitle}`,
         '',
@@ -296,160 +179,7 @@ module.exports = function registerImplement(register) {
       return;
     }
 
-    // Detect task suite (e2e / integration / unit) from scope + type + title.
-    // Used to surface the matching TEST_*_COMMAND env var to the agent.
-    let testSuite = null;
-    let e2eRules = '';
-    try {
-      const content = fs.readFileSync(path.join(tasksDir, 'tasks.md'), 'utf8');
-      const scopeMatch = content.match(
-        new RegExp(
-          `## Task ${taskNum}\\b[\\s\\S]*?### Suggested Scope[^\\n]*\\n([\\s\\S]*?)(?=\\n###|\\n## |$)`,
-          'm'
-        )
-      );
-      const scope = scopeMatch ? scopeMatch[1] : '';
-      const isE2E =
-        /e2e|playwright/i.test(scope) || taskType === 'e2e' || /e2e|playwright/i.test(taskTitle);
-      const isIntegration =
-        /integration|\.int\./i.test(scope) ||
-        taskType === 'integration' ||
-        /integration/i.test(taskTitle);
-      if (isE2E) testSuite = 'e2e';
-      else if (isIntegration) testSuite = 'integration';
-      else testSuite = 'unit';
-
-      if (isE2E) {
-        e2eRules = [
-          '',
-          '### E2E Test Rules (MANDATORY)',
-          '- **Selectors:** Use `data-testid` ONLY. Never `getByRole`, `getByText`, `.first()`, `.nth()`, `[role=...]`, CSS classes. Add `data-testid` to production components if missing.',
-          '- **Waits:** NEVER assert immediately after click/navigate/submit. Always wait for expected state (`waitFor`, `toBeVisible`, `waitForURL`).',
-          '- **Timeouts:** NEVER hardcode timeouts. Use project timeout tiers if they exist. Never increase timeouts — fix the root cause instead.',
-          '- **Race conditions:** Wait for API response before checking state. Wait for UI to reflect mutations before polling.',
-        ].join('\n');
-      }
-    } catch {
-      /* fail-open */
-    }
-
-    // Pick up the configured TEST_*_COMMAND for this suite so the agent runs
-    // the project's canonical test runner (with $CHANGED_FILES placeholder
-    // expansion) instead of inventing its own command line.
-    let suiteEnvVar = null;
-    let suiteCommand = '';
-    try {
-      const getConfig = require(path.join(__dirname, '..', '..', '..', 'lib', 'get-config'));
-      if (testSuite === 'e2e') {
-        suiteEnvVar = 'TEST_E2E_COMMAND';
-        suiteCommand = getConfig('TEST_E2E_COMMAND') || '';
-      } else if (testSuite === 'integration') {
-        suiteEnvVar = 'TEST_INTEGRATION_COMMAND';
-        suiteCommand = getConfig('TEST_INTEGRATION_COMMAND') || '';
-      } else if (testSuite === 'unit') {
-        suiteEnvVar = 'TEST_UNIT_COMMAND';
-        suiteCommand = getConfig('TEST_UNIT_COMMAND') || '';
-      }
-    } catch {
-      /* fail-open */
-    }
-
-    // Read task metadata (testCommand, suggestedScope) from task-parser
-    let hasGateTDD = false;
-    let taskTestCommand = null;
-    let taskScope = '';
-    try {
-      const { parseTasks: parseFullTasks } = require(
-        path.join(__dirname, '..', '..', '..', 'work', 'task-parser')
-      );
-      const allParsedTasks = parseFullTasks(tasksDir);
-      const currentTask = allParsedTasks?.find((t) => t.num === Number(taskNum));
-      taskTestCommand = currentTask?.testCommand || null;
-      taskScope = currentTask?.suggestedScope || '';
-      hasGateTDD = !!taskTestCommand;
-    } catch {
-      /* fail-open */
-    }
-
-    // Build the "### Test Commands" block listing the suite-specific
-    // env-var-based command for this task. The agent should run it via:
-    //   CHANGED_FILES="<files>" eval "$TEST_E2E_COMMAND"
-    // (or the integration / unit variant). $CHANGED_FILES gets expanded
-    // against the suggested scope.
-    const testCommandsBlock =
-      suiteEnvVar && suiteCommand
-        ? [
-            '### Test Commands',
-            `This task is a **${testSuite}** task. Run tests with the project-configured runner:`,
-            '```bash',
-            `# ${suiteEnvVar} (resolved):`,
-            suiteCommand,
-            '```',
-            'Invoke via:',
-            '```bash',
-            `CHANGED_FILES="<files-you-touched>" eval "$${suiteEnvVar}"`,
-            '```',
-            'Do NOT invent your own test command. If $CHANGED_FILES is unset, use the resolved command above.',
-            '',
-          ]
-        : suiteEnvVar
-          ? [
-              '### Test Commands',
-              `This task is a **${testSuite}** task. The project should expose \`$${suiteEnvVar}\` — invoke via:`,
-              '```bash',
-              `CHANGED_FILES="<files-you-touched>" eval "$${suiteEnvVar}"`,
-              '```',
-              `If \`$${suiteEnvVar}\` is unset, ask the user to configure it before proceeding.`,
-              '',
-            ]
-          : [];
-
-    const tddSection = hasGateTDD
-      ? [
-          ...(taskScope
-            ? [
-                '### Files to implement',
-                ...taskScope
-                  .split('\n')
-                  .map((l) => l.trim())
-                  .filter(Boolean)
-                  .map((l) => `- \`${l.replace(/^[-*+]\s+/, '').replace(/`/g, '')}\``),
-                '',
-              ]
-            : []),
-          ...testCommandsBlock,
-          '### How to verify',
-          'Run this and ensure it passes before stopping:',
-          '```',
-          taskTestCommand,
-          '```',
-        ]
-      : testCommandsBlock;
-
-    const singleRetryBlock = buildRetryFailureBlock(
-      tasksDir,
-      ticket,
-      taskNum != null ? Number(taskNum) : null
-    );
-    const devPrompt = [
-      `## Implement Task ${taskNum || '?'}/${totalTasks || '?'} — ${taskTitle}`,
-      '',
-      ...singleRetryBlock,
-      ...tddSection,
-      '',
-      '### Required Reading (read IN FULL before implementing)',
-      `- **Task details:** ${path.join(tasksDir, 'tasks.md')} (find "## Task ${taskNum}" section)`,
-      `- **Spec:** ${path.join(tasksDir, 'spec.md')}`,
-      `- **Brief:** ${path.join(tasksDir, 'brief.md')}`,
-      '',
-      '### Rules',
-      `- Implement ONLY Task ${taskNum} deliverables`,
-      '- Do NOT touch files reserved for other tasks',
-      '- Do NOT invoke /work-implement or any other skill',
-      e2eRules,
-    ].join('\n');
-
-    entry.agentPrompt = devPrompt;
+    entry.agentPrompt = buildSelfPacedPrompt(ticket, taskNum, totalTasks, taskTitle);
     entry.agentType = resolveAgentType(tasksDir, taskNum);
   });
 };

--- a/scripts/workflows/work2/lib/step-enrichments/index.js
+++ b/scripts/workflows/work2/lib/step-enrichments/index.js
@@ -67,6 +67,7 @@ function runGate(stepName, safeName, ctx, deps) {
 // --- Register built-in enrichments ---
 require('./ticket')(register);
 require('./related-tickets-inject')(register);
+require('./brief')(register);
 require('./brief-gate')(register);
 require('./spec-gate')(register);
 require('./context-inject')(register);

--- a/scripts/workflows/work2/work-next.js
+++ b/scripts/workflows/work2/work-next.js
@@ -118,10 +118,11 @@ const { createDebugLog } = require(path.join(__dirname, 'lib', 'debug-log'));
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 const TDD_GATED_STEPS = [STEPS.implement];
+const { buildVerdictRegex } = require(path.join(__dirname, '..', 'lib', 'parse-completion-status'));
 const REQUIRED_REPORTS = [
-  { file: 'tests.check.md', passPattern: /Status:\s*APPROVED/i },
-  { file: 'code-review.check.md', passPattern: /Status:\s*APPROVED/i },
-  { file: 'completion.check.md', passPattern: /Status:\s*(COMPLETE|APPROVED)/i },
+  { file: 'tests.check.md', passPattern: buildVerdictRegex(['APPROVED']) },
+  { file: 'code-review.check.md', passPattern: buildVerdictRegex(['APPROVED']) },
+  { file: 'completion.check.md', passPattern: buildVerdictRegex(['COMPLETE', 'APPROVED']) },
 ];
 
 // ─── DI wrappers (same pattern as work.workflow.js) ─────────────────────────

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -79,6 +79,49 @@ Configure in your `.envrc`:
 export BOOTSTRAP_SCRIPT="./scripts/bootstrap.sh"
 ```
 
+### Step 5.5: Open orchestrator listener channel (MANDATORY)
+
+Before reporting success, ensure the worker agent for this ticket can
+receive messages from the orchestrator/monitor. The listener uses the
+file-based mailbox at `/tmp/claude-agent-inbox/<TICKET>.log` (channel
+names are case-insensitive and uppercased by the script).
+
+Start a detached `tmux` session that tails the channel so any monitor
+message lands in a pane the agent can read. Idempotent — skips if a
+session for the ticket already exists.
+
+```bash
+LISTEN_SESSION="${TICKET_ID}-listen"
+if ! tmux has-session -t "$LISTEN_SESSION" 2>/dev/null; then
+  tmux new-session -d -s "$LISTEN_SESSION" \
+    "node $HOME/p/w-claude-plugin/claude-plugin-work/scripts/listen-communication.js $TICKET_ID"
+  echo "  ✓ orchestrator listener started: tmux session $LISTEN_SESSION"
+else
+  echo "  ✓ orchestrator listener already running: tmux session $LISTEN_SESSION"
+fi
+```
+
+After starting, verify a listener is attached by running:
+
+```bash
+node $HOME/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js --check "$TICKET_ID"
+# Exits 0 if at least one listener is attached, exits 3 otherwise.
+```
+
+**Why this is mandatory:**
+- The /orchestrate Monitor ↔ Agent Unblocking Protocol (ACK → fix → DONE)
+  depends on the worker having an active listener. Without it, monitor
+  messages are written but never seen, and the agent can stall waiting
+  for a response that already arrived.
+- The worker agent MUST also accept messages on this channel: it should
+  poll the tmux pane (`tmux capture-pane -p -t "$LISTEN_SESSION"`) or
+  attach a side pane in its own session before starting work.
+- Talking back to the monitor uses:
+  ```bash
+  node $HOME/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js \
+    MONITOR "$TICKET_ID: <message to orchestrator>"
+  ```
+
 ### Step 6: Report results
 
 After processing all tasks, display summary:
@@ -134,6 +177,7 @@ Next steps:
 | 3 | Fetch ticket details |
 | 4 | Create worktree + branch (uses `BASE_BRANCH` env var, defaults to `main`) |
 | 5 | Run custom bootstrap script (if `BOOTSTRAP_SCRIPT` is set) |
+| 5.5 | Start orchestrator listener (tmux `<TICKET>-listen` running `listen-communication.js`) |
 | 6 | Display summary |
 
 ## Notes

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -94,7 +94,7 @@ session for the ticket already exists.
 LISTEN_SESSION="${TICKET_ID}-listen"
 if ! tmux has-session -t "$LISTEN_SESSION" 2>/dev/null; then
   tmux new-session -d -s "$LISTEN_SESSION" \
-    "node $HOME/p/w-claude-plugin/claude-plugin-work/scripts/listen-communication.js $TICKET_ID"
+    "node \"${CLAUDE_PLUGIN_ROOT}/scripts/listen-communication.js\" $TICKET_ID"
   echo "  ✓ orchestrator listener started: tmux session $LISTEN_SESSION"
 else
   echo "  ✓ orchestrator listener already running: tmux session $LISTEN_SESSION"
@@ -104,7 +104,7 @@ fi
 After starting, verify a listener is attached by running:
 
 ```bash
-node $HOME/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js --check "$TICKET_ID"
+node "${CLAUDE_PLUGIN_ROOT}/scripts/communicate.js" --check "$TICKET_ID"
 # Exits 0 if at least one listener is attached, exits 3 otherwise.
 ```
 
@@ -118,7 +118,7 @@ node $HOME/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js --check "
   attach a side pane in its own session before starting work.
 - Talking back to the monitor uses:
   ```bash
-  node $HOME/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js \
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/communicate.js" \
     MONITOR "$TICKET_ID: <message to orchestrator>"
   ```
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -164,6 +164,49 @@ Failed tasks (need manual attention):
   - PROJ-853: [reason]
 ```
 
+## Monitor ↔ Agent Unblocking Protocol (MANDATORY)
+
+When you (as orchestrator/monitor) receive a message from a worker agent on
+its channel and decide to take action to unblock it, you MUST follow this
+three-step communication protocol so the agent knows what's happening:
+
+1. **ACK — "I'm starting work to unblock you."**
+   Send IMMEDIATELY upon receiving the blocker, BEFORE any code change.
+   ```bash
+   node ~/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js <TICKET> \
+     "monitor: ACK — starting work to unblock <one-line summary>. Stand by."
+   ```
+
+2. **Do the changes.**
+   Diagnose, edit code, run tests, commit, push. The agent waits.
+
+3. **DONE — "You are unblocked."**
+   Send when the fix is shipped (committed AND pushed if on a PR branch).
+   Message MUST include:
+   - The exact commit hash + branch / PR number
+   - One-line description of the fix
+   - The exact command the agent should re-invoke to resume
+   ```bash
+   node ~/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js <TICKET> \
+     "monitor: UNBLOCKED at commit <hash> on <branch> (PR #<n>). <one-line fix>. Retry: <exact command>"
+   ```
+
+**Why this is mandatory:**
+- Agents have no visibility into your work. Without ACK they assume the
+  message was lost and either retry endlessly or give up.
+- Without DONE they don't know whether to keep waiting or resume.
+- Silent fixes look identical to no fix — agents cannot tell.
+
+**Rules:**
+- Never silently fix and walk away. Both messages are required.
+- ACK goes out FIRST, before you read deeply, edit, or spawn agents.
+- DONE goes out LAST, after the fix is verifiably live (push completed).
+- If the fix takes long, send progress pings every ~10 minutes
+  (`monitor: still working — <what you're doing now>`).
+- If you decide NOT to act (false alarm, out of scope, etc.), send a
+  CLOSED message with the reason instead of going silent:
+  `monitor: CLOSED — not acting because <reason>. <next step for you>`.
+
 ## Key Behaviors
 
 ### Sequential Execution (CRITICAL)

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -173,7 +173,7 @@ three-step communication protocol so the agent knows what's happening:
 1. **ACK — "I'm starting work to unblock you."**
    Send IMMEDIATELY upon receiving the blocker, BEFORE any code change.
    ```bash
-   node ~/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js <TICKET> \
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/communicate.js" <TICKET> \
      "monitor: ACK — starting work to unblock <one-line summary>. Stand by."
    ```
 
@@ -187,7 +187,7 @@ three-step communication protocol so the agent knows what's happening:
    - One-line description of the fix
    - The exact command the agent should re-invoke to resume
    ```bash
-   node ~/p/w-claude-plugin/claude-plugin-work/scripts/communicate.js <TICKET> \
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/communicate.js" <TICKET> \
      "monitor: UNBLOCKED at commit <hash> on <branch> (PR #<n>). <one-line fix>. Retry: <exact command>"
    ```
 

--- a/skills/work2/SKILL.md
+++ b/skills/work2/SKILL.md
@@ -12,6 +12,20 @@ Run the driver script. Execute what it says. Do not improvise.
 
 ## Start
 
+**Step 0 — open the monitor channel for this ticket FIRST.** This must be
+the first tool call in the session. Each new line in the inbox file becomes
+a task-notification that resumes you mid-idle — no polling, no manual nudges.
+
+```
+Monitor(node ${CLAUDE_PLUGIN_ROOT}/scripts/listen-communication.js <TICKET>)
+```
+
+Replace `<TICKET>` with `$ARGUMENTS` (the ticket id). The Monitor runs for
+the lifetime of your session — do not stop it. Only the main /work2
+orchestrator opens this channel; dispatched subagents do NOT.
+
+**Step 1 — then start the driver:**
+
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work2/work-next.js "$ARGUMENTS" --init
 ```


### PR DESCRIPTION
Replace the inverted allowlist (`TDD_EXEMPT_TYPES: checkpoint`) for
type-skipping, remove synthesized RED+GREEN evidence generation when
no pre-test runs, and add Gate D' (gherkin @test file existence check)
so the gate refuses to enter implement until every declared test file
exists on disk. Introduces `gherkin-task-refs.js` module (parser +
cross-validator) to enforce the contract between gherkin.feature scenario
tags and tasks.md ownership, plus extends `protect-gherkin.js` to allow
edits during tasks/tasks_gate recovery flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tighten implement gating and evidence recording rules, which can block or reroute workflow execution if projects’ `gherkin.feature`/`tasks.md` or test paths don’t meet the new contract. Moderate risk due to new enforcement logic and new runner script affecting developer flows.
> 
> **Overview**
> **Closes multiple TDD bypass paths in the `work2` implement flow.** The implement gate now requires authentic RED evidence (no more synthesizing RED+GREEN when no pre-test ran), enforces TDD for all task types except `checkpoint`, and adds a pre-test check that `@test:<path>` files declared in `gherkin.feature` actually exist on disk.
> 
> **Adds a new gherkin↔tasks contract and enforces it earlier.** Introduces `gherkin-task-refs.js` (+ tests) to validate `@task:N`/`@test:<path>` tags and `tasks.md` `### Scenarios` ownership, then wires this into `tasks-gate` as an additional “Gate D” consistency check; `protect-gherkin.js` is widened to allow `gherkin.feature` edits during `tasks`/`tasks_gate` recovery.
> 
> **Moves implement execution to a self-paced runner.** Adds `work-implement/task-next.js` and simplifies `work2` `implement.js` prompts to instruct agents to run `task-next.js`, while updating the step-enforcement hook/workflow definition to mint companion write tokens for nested `tdd-phase-state.js` calls.
> 
> **Misc. workflow/ops additions.** `work` PR verification now accepts `MERGED` PRs, and new inbox/monitor tooling is added (`communicate.js`, `listen-all.js`, `listen-communication.js`, `open-channel.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b9319f93702c57138455e47559f53aa1d25d04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->