### PR TITLE
feat(monitor): workflow-manager helpers (auto-welcome, done sentinel, cleanup)

### DIFF
--- a/scripts/communicate.js
+++ b/scripts/communicate.js
@@ -6,15 +6,20 @@ const path = require('node:path');
 
 const INBOX_DIR = process.env.CLAUDE_AGENT_INBOX_DIR || '/tmp/claude-agent-inbox';
 
+const DONE_SENTINEL = '__MONITOR_DONE__';
+
 function usage(code) {
   process.stderr.write(
     'usage: communicate.js <ticket-id> <message...>\n' +
       '       communicate.js --check <ticket-id>\n' +
       '       communicate.js --watch <ticket-id>\n' +
+      '       communicate.js --done <ticket-id> [reason...]\n' +
       '  ticket-id is case-insensitive (echo-1234 → ECHO-1234)\n' +
       '  message can be a single quoted string or remaining argv joined with spaces\n' +
       '  --check prints listener PIDs for the channel (no send)\n' +
       '  --watch polls every 1s and prints listener join/leave events\n' +
+      '  --done writes a completion sentinel to the ticket channel AND notifies MONITOR;\n' +
+      '         listeners on the ticket channel exit cleanly on the sentinel.\n' +
       '  Send always reports listener count; exits 3 if zero listeners.\n'
   );
   process.exit(code);
@@ -59,11 +64,12 @@ function findListeners(inboxPath) {
 const args = process.argv.slice(2);
 const checkOnly = args[0] === '--check' || args[0] === '-c';
 const watchMode = args[0] === '--watch' || args[0] === '-w';
-if (checkOnly || watchMode) args.shift();
+const doneMode = args[0] === '--done' || args[0] === '-d';
+if (checkOnly || watchMode || doneMode) args.shift();
 
 const [rawTicket, ...rest] = args;
 if (!rawTicket) usage(1);
-if (!checkOnly && !watchMode && rest.length === 0) usage(1);
+if (!checkOnly && !watchMode && !doneMode && rest.length === 0) usage(1);
 
 const ticket = rawTicket.toUpperCase().replace(/[^A-Z0-9_-]/g, '');
 if (!ticket) {
@@ -84,6 +90,25 @@ if (checkOnly) {
     `${inbox}: ${listeners.length} listener(s)${listeners.length ? ` — pids: ${listeners.join(', ')}` : ''}\n`
   );
   process.exit(listeners.length === 0 ? 3 : 0);
+}
+
+if (doneMode) {
+  // Cleanup signal: write sentinel to the ticket's own channel AND notify
+  // the MONITOR channel (with the ticket prefix so the manager knows which
+  // session just completed). Listeners on the ticket channel exit cleanly
+  // when they see DONE_SENTINEL.
+  if (!fs.existsSync(inbox)) fs.closeSync(fs.openSync(inbox, 'a'));
+  const reason = rest.join(' ').trim();
+  const ts = new Date().toISOString();
+  const tail = reason ? ` ${reason}` : '';
+  fs.appendFileSync(inbox, `[${ts}] ${DONE_SENTINEL}${tail}\n`, { mode: 0o644 });
+
+  const monitor = path.join(INBOX_DIR, 'MONITOR.log');
+  if (!fs.existsSync(monitor)) fs.closeSync(fs.openSync(monitor, 'a'));
+  fs.appendFileSync(monitor, `[${ts}] ${ticket}: ${DONE_SENTINEL}${tail}\n`, { mode: 0o644 });
+
+  process.stdout.write(`done → ${ticket} channel + MONITOR notified${tail}\n`);
+  process.exit(0);
 }
 
 if (watchMode) {

--- a/scripts/listen-all.js
+++ b/scripts/listen-all.js
@@ -7,7 +7,40 @@ const { spawn } = require('node:child_process');
 
 const INBOX_DIR = process.env.CLAUDE_AGENT_INBOX_DIR || '/tmp/claude-agent-inbox';
 
-const filter = process.argv[2] || null;
+const { TICKET_PREFIX_RE, DONE_SENTINEL, WELCOME_MESSAGE } = require('./monitor-manager');
+
+// CLI: positional filter still works (e.g. `listen-all.js MONITOR`).
+// Optional flags:
+//   --manage           Run workflow-manager logic on the MONITOR channel
+//                      (auto-welcome on first contact, mark completion on
+//                      __MONITOR_DONE__ lines). Off by default for
+//                      back-compat.
+//   --archive          With --manage, archive completed channel logs into
+//                      <INBOX_DIR>/archived/.
+const args = process.argv.slice(2);
+let filter = null;
+let manageMode = false;
+let archiveMode = false;
+for (const a of args) {
+  if (a === '--manage') manageMode = true;
+  else if (a === '--archive') archiveMode = true;
+  else if (a === '-h' || a === '--help') {
+    process.stderr.write(
+      'usage: listen-all.js [FILTER] [--manage] [--archive]\n' +
+        '  FILTER: substring of channel name (case-insensitive)\n' +
+        '  --manage: on MONITOR channel, auto-welcome new tickets +\n' +
+        '            mark completion on __MONITOR_DONE__ sentinels\n' +
+        '  --archive: with --manage, move completed channels to\n' +
+        '             <INBOX_DIR>/archived/\n'
+    );
+    process.exit(0);
+  } else if (!filter && !a.startsWith('-')) {
+    filter = a;
+  } else {
+    process.stderr.write(`unknown arg: ${a}\n`);
+    process.exit(1);
+  }
+}
 
 fs.mkdirSync(INBOX_DIR, { recursive: true, mode: 0o755 });
 
@@ -17,6 +50,64 @@ function matchesFilter(name) {
   return true;
 }
 
+// ─── manager state (used only when --manage and channel is MONITOR) ──────
+const welcomed = new Set();
+const completed = new Set();
+
+function extractTicket(line) {
+  const m = line.match(TICKET_PREFIX_RE);
+  return m ? m[1].toUpperCase() : null;
+}
+
+function sendTo(ticket, text) {
+  const inbox = path.join(INBOX_DIR, `${ticket}.log`);
+  if (!fs.existsSync(inbox)) fs.closeSync(fs.openSync(inbox, 'a'));
+  const ts = new Date().toISOString();
+  fs.appendFileSync(inbox, `[${ts}] MONITOR: ${text}\n`, { mode: 0o644 });
+}
+
+function archiveChannel(ticket) {
+  const src = path.join(INBOX_DIR, `${ticket}.log`);
+  if (!fs.existsSync(src)) return false;
+  const archDir = path.join(INBOX_DIR, 'archived');
+  fs.mkdirSync(archDir, { recursive: true, mode: 0o755 });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const dest = path.join(archDir, `${ticket}.${stamp}.log`);
+  try {
+    fs.renameSync(src, dest);
+    return dest;
+  } catch {
+    return false;
+  }
+}
+
+function handleManagedLine(channel, line) {
+  if (channel !== 'MONITOR') return;
+  const ticket = extractTicket(line);
+  if (!ticket) return;
+
+  if (line.includes(DONE_SENTINEL)) {
+    if (completed.has(ticket)) return;
+    completed.add(ticket);
+    const archived = archiveMode ? archiveChannel(ticket) : false;
+    process.stdout.write(
+      `  -> [${ticket}] marked COMPLETE` +
+        (archived ? ` (archived to ${archived})` : '') +
+        ` (total completed: ${completed.size})\n`
+    );
+    return;
+  }
+
+  if (!welcomed.has(ticket)) {
+    welcomed.add(ticket);
+    sendTo(ticket, WELCOME_MESSAGE);
+    process.stdout.write(
+      `  -> [${ticket}] first contact — welcome sent (total welcomed: ${welcomed.size})\n`
+    );
+  }
+}
+
+// ─── tail multiplexer ────────────────────────────────────────────────────
 const tails = new Map();
 
 function startTail(file) {
@@ -32,6 +123,7 @@ function startTail(file) {
       buf = buf.slice(idx + 1);
       if (line.length === 0) continue;
       process.stdout.write(`\x07[${channel}] ${line}\n`);
+      if (manageMode) handleManagedLine(channel, line);
     }
   });
   proc.on('exit', () => tails.delete(file));
@@ -45,7 +137,9 @@ for (const f of fs.readdirSync(INBOX_DIR)) {
 
 process.stdout.write(
   `listening on ${INBOX_DIR}/*.log${filter ? ` (filter: ${filter})` : ''}` +
-    ` — ${tails.size} channel(s) at start, auto-attaching new ones. Ctrl-C to stop.\n`
+    ` — ${tails.size} channel(s) at start, auto-attaching new ones.` +
+    (manageMode ? ` workflow-manager: ON (auto-welcome${archiveMode ? ' + archive' : ''}).` : '') +
+    ' Ctrl-C to stop.\n'
 );
 
 const watcher = fs.watch(INBOX_DIR, (eventType, filename) => {

--- a/scripts/listen-communication.js
+++ b/scripts/listen-communication.js
@@ -33,6 +33,8 @@ process.stdout.write(`listening on ${inbox} (Ctrl-C to stop)\n`);
 
 const tail = spawn('tail', ['-n', '0', '-F', inbox], { stdio: ['ignore', 'pipe', 'inherit'] });
 
+const DONE_SENTINEL = '__MONITOR_DONE__';
+
 let buf = '';
 tail.stdout.on('data', (chunk) => {
   buf += chunk.toString('utf8');
@@ -42,6 +44,13 @@ tail.stdout.on('data', (chunk) => {
     buf = buf.slice(idx + 1);
     if (line.length === 0) continue;
     process.stdout.write(`\x07>>> ${line}\n`);
+    if (line.includes(DONE_SENTINEL)) {
+      process.stdout.write(`[${ticket}] channel marked complete — listener exiting.\n`);
+      try {
+        tail.kill('SIGTERM');
+      } catch {}
+      process.exit(0);
+    }
   }
 });
 

--- a/scripts/monitor-manager.js
+++ b/scripts/monitor-manager.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * monitor-manager.js
+ *
+ * Tails the MONITOR channel and acts as a lightweight workflow manager
+ * for agent sessions. Two responsibilities:
+ *
+ *   1. AUTO-WELCOME — on the first message it sees from a given ticket
+ *      (detected by a `TICKET-ID:` prefix in the line), it sends a
+ *      welcome message to that ticket's channel with a help list of
+ *      questions the agent can ask the manager.
+ *
+ *   2. CLEANUP TRACKING — on lines containing the `__MONITOR_DONE__`
+ *      sentinel it marks the ticket completed, prints a status line,
+ *      and (optionally, with --archive) moves the ticket's log file
+ *      into `<INBOX_DIR>/archived/`.
+ *
+ * Usage:
+ *   node monitor-manager.js                # MONITOR channel, no archiving
+ *   node monitor-manager.js --archive      # also archive completed channels
+ *   node monitor-manager.js --channel FOO  # use FOO instead of MONITOR
+ *
+ * The welcome text lives in `WELCOME_MESSAGE` below so it can be tuned
+ * without touching parsing logic.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const INBOX_DIR = process.env.CLAUDE_AGENT_INBOX_DIR || '/tmp/claude-agent-inbox';
+const DONE_SENTINEL = '__MONITOR_DONE__';
+
+// Matches ticket-id prefix like "ECHO-4560:", "GH-365:", "APPSUPEN-1119:",
+// "PR-1547:" — anchored at start (after the [timestamp] prefix the inbox
+// format already prepends) or stand-alone.
+const TICKET_PREFIX_RE = /(?:^|\]\s*)([A-Z][A-Z0-9_]*-\d+|PR-\d+|GH-\d+)\s*:/;
+
+const WELCOME_MESSAGE = [
+  "Hi — I'm the workflow manager. If anything blocks you during the workflow,",
+  'send a message to the MONITOR channel and I will help unblock you.',
+  '',
+  'Questions you can ask:',
+  '  - "I\'m stuck on step X because of script Y" (state-machine transition issues)',
+  '  - "task-next.js / brief-next.js returned No valid write token found" (hook/token mint failures)',
+  '  - "TDD phase gating won\'t let me edit file F" (RED/GREEN/REFACTOR phase restrictions)',
+  '  - "Workflow won\'t advance to <step> — gate says <reason>" (Gate 0-8 enforcement)',
+  '  - "PR CI failing on test <name> — looks pre-existing/unclear" (CI triage)',
+  '  - "Hook is blocking my Bash/Edit/Write with <message>" (PreToolUse hook misfires)',
+  '  - "I see a stale workflow lock from another ticket" (session-guard interference)',
+  '  - "TDD evidence missing / can\'t record RED->GREEN cycle" (tdd-phase-state issues)',
+  '  - "Plugin script throws <error> — looks like a bug" (script bugs to escalate)',
+  '',
+  'When the workflow is done on your end, run:',
+  '  node $CLAUDE_PLUGIN_ROOT/scripts/communicate.js --done <YOUR-TICKET>',
+  'That signals completion to MONITOR and stops your local listener cleanly.',
+].join(' \\n ');
+// Note: stored as a single line (newlines escaped with " \n ") so the
+// channel log stays one-line-per-message. listeners print them verbatim;
+// agents reading raw log content can replace " \n " with real newlines.
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const opts = { channel: 'MONITOR', archive: false };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--archive') opts.archive = true;
+    else if (a === '--channel') opts.channel = (args[++i] || 'MONITOR').toUpperCase();
+    else if (a === '-h' || a === '--help') {
+      process.stderr.write(
+        'usage: monitor-manager.js [--channel MONITOR] [--archive]\n' +
+          '  Tails the MONITOR channel and auto-welcomes new ticket senders.\n' +
+          '  On __MONITOR_DONE__ lines, marks the ticket complete and (with --archive)\n' +
+          '  moves the ticket log into <INBOX_DIR>/archived/.\n'
+      );
+      process.exit(0);
+    } else {
+      process.stderr.write(`unknown arg: ${a}\n`);
+      process.exit(1);
+    }
+  }
+  return opts;
+}
+
+function extractTicket(line) {
+  const m = line.match(TICKET_PREFIX_RE);
+  return m ? m[1].toUpperCase() : null;
+}
+
+function sendTo(ticket, text) {
+  const inbox = path.join(INBOX_DIR, `${ticket}.log`);
+  if (!fs.existsSync(inbox)) fs.closeSync(fs.openSync(inbox, 'a'));
+  const ts = new Date().toISOString();
+  fs.appendFileSync(inbox, `[${ts}] MONITOR: ${text}\n`, { mode: 0o644 });
+}
+
+function archiveChannel(ticket) {
+  const src = path.join(INBOX_DIR, `${ticket}.log`);
+  if (!fs.existsSync(src)) return false;
+  const archDir = path.join(INBOX_DIR, 'archived');
+  fs.mkdirSync(archDir, { recursive: true, mode: 0o755 });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const dest = path.join(archDir, `${ticket}.${stamp}.log`);
+  try {
+    fs.renameSync(src, dest);
+    return dest;
+  } catch {
+    return false;
+  }
+}
+
+function main() {
+  const opts = parseArgs(process.argv);
+  fs.mkdirSync(INBOX_DIR, { recursive: true, mode: 0o755 });
+  const inbox = path.join(INBOX_DIR, `${opts.channel}.log`);
+  if (!fs.existsSync(inbox)) fs.closeSync(fs.openSync(inbox, 'a'));
+
+  const welcomed = new Set();
+  const completed = new Set();
+
+  process.stdout.write(
+    `monitor-manager: tailing ${inbox}\n` +
+      `  auto-welcome: on\n` +
+      `  archive on done: ${opts.archive ? 'on' : 'off'}\n` +
+      `  Ctrl-C to stop.\n`
+  );
+
+  const tail = spawn('tail', ['-n', '0', '-F', inbox], { stdio: ['ignore', 'pipe', 'inherit'] });
+  let buf = '';
+  tail.stdout.on('data', (chunk) => {
+    buf += chunk.toString('utf8');
+    let idx;
+    while ((idx = buf.indexOf('\n')) !== -1) {
+      const line = buf.slice(0, idx);
+      buf = buf.slice(idx + 1);
+      if (!line) continue;
+      handleLine(line);
+    }
+  });
+  tail.on('exit', (code) => process.exit(code ?? 0));
+  process.on('SIGINT', () => tail.kill('SIGINT'));
+  process.on('SIGTERM', () => tail.kill('SIGTERM'));
+
+  function handleLine(line) {
+    process.stdout.write(`\x07[${opts.channel}] ${line}\n`);
+    const ticket = extractTicket(line);
+    if (!ticket) return;
+
+    if (line.includes(DONE_SENTINEL)) {
+      if (completed.has(ticket)) return;
+      completed.add(ticket);
+      const archived = opts.archive ? archiveChannel(ticket) : false;
+      process.stdout.write(
+        `  -> [${ticket}] marked COMPLETE` +
+          (archived ? ` (archived to ${archived})` : '') +
+          ` (total completed: ${completed.size})\n`
+      );
+      return;
+    }
+
+    if (!welcomed.has(ticket)) {
+      welcomed.add(ticket);
+      sendTo(ticket, WELCOME_MESSAGE);
+      process.stdout.write(
+        `  -> [${ticket}] first contact — welcome sent (total welcomed: ${welcomed.size})\n`
+      );
+    }
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { extractTicket, TICKET_PREFIX_RE, DONE_SENTINEL, WELCOME_MESSAGE };

--- a/scripts/workflows/lib/__tests__/monitor-manager.test.js
+++ b/scripts/workflows/lib/__tests__/monitor-manager.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const MONITOR = path.join(REPO_ROOT, 'scripts', 'monitor-manager.js');
+const COMMUNICATE = path.join(REPO_ROOT, 'scripts', 'communicate.js');
+
+const { extractTicket, TICKET_PREFIX_RE, DONE_SENTINEL } = require(MONITOR);
+
+test('extractTicket pulls ticket id from "[ts] TICKET: msg" line', () => {
+  assert.equal(extractTicket('[2026-05-18T12:00:00Z] ECHO-4560: hello there'), 'ECHO-4560');
+  assert.equal(extractTicket('[ts] PR-1547: blah'), 'PR-1547');
+  assert.equal(extractTicket('[ts] GH-365: thing'), 'GH-365');
+  assert.equal(extractTicket('[ts] APPSUPEN-1119: x'), 'APPSUPEN-1119');
+});
+
+test('extractTicket returns null when no ticket prefix present', () => {
+  assert.equal(extractTicket('[ts] just a bare line'), null);
+  assert.equal(extractTicket('[ts] not-a-ticket: text'), null);
+});
+
+test('extractTicket is case-insensitive on output but requires uppercase tag', () => {
+  // Pattern is uppercase-only by design — lowercase is rejected.
+  assert.equal(extractTicket('[ts] echo-4560: lower'), null);
+  // Already-uppercase passes through unchanged.
+  assert.equal(extractTicket('[ts] ECHO-4560: x'), 'ECHO-4560');
+});
+
+test('DONE_SENTINEL is the agreed marker string', () => {
+  assert.equal(DONE_SENTINEL, '__MONITOR_DONE__');
+});
+
+test('communicate.js --done writes sentinel to ticket channel + MONITOR', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'monitor-mgr-test-'));
+  try {
+    const r = spawnSync(
+      process.execPath,
+      [COMMUNICATE, '--done', 'echo-9999', 'workflow-complete'],
+      {
+        env: { ...process.env, CLAUDE_AGENT_INBOX_DIR: tmp },
+        encoding: 'utf8',
+      }
+    );
+    assert.equal(
+      r.status,
+      0,
+      `expected exit 0, got ${r.status}\nstdout=${r.stdout}\nstderr=${r.stderr}`
+    );
+    const ticketLog = fs.readFileSync(path.join(tmp, 'ECHO-9999.log'), 'utf8');
+    const monitorLog = fs.readFileSync(path.join(tmp, 'MONITOR.log'), 'utf8');
+    assert.match(ticketLog, /__MONITOR_DONE__ workflow-complete/);
+    assert.match(monitorLog, /ECHO-9999: __MONITOR_DONE__/);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('TICKET_PREFIX_RE handles a stand-alone (no [ts] prefix) line too', () => {
+  // For robustness — the test exists to lock the alternate match path
+  // documented in the regex.
+  assert.match('ECHO-4560: bare-start line', TICKET_PREFIX_RE);
+});

--- a/scripts/workflows/work/steps/cleanup.js
+++ b/scripts/workflows/work/steps/cleanup.js
@@ -9,15 +9,21 @@
 module.exports = function cleanupStep(add, s, ctx) {
   const { STEPS, ticket } = ctx;
 
+  // Always notify the workflow manager that this ticket's session is
+  // finishing — this both (a) stops the agent's local listener on the
+  // ticket channel cleanly via the __MONITOR_DONE__ sentinel and
+  // (b) lets the MONITOR-side manager mark the channel completed.
+  const doneCmd = `node "$CLAUDE_PLUGIN_ROOT/scripts/communicate.js" --done "${ticket}" workflow-complete 2>/dev/null || true`;
+
   if (s?.hasDevSession) {
     add(STEPS.cleanup, 'RUN', `Task(Bash)`, 'Dev session running', {
       agentType: 'Bash',
-      agentPrompt: `Run: tmux kill-session -t "${ticket}-dev" 2>/dev/null; echo "Cleanup done"`,
+      agentPrompt: `Run: tmux kill-session -t "${ticket}-dev" 2>/dev/null; ${doneCmd}; echo "Cleanup done"`,
     });
   } else {
     add(STEPS.cleanup, 'DEFER', `Task(Bash)`, 'No dev session yet — re-check at step time', {
       agentType: 'Bash',
-      agentPrompt: `Run: tmux kill-session -t "${ticket}-dev" 2>/dev/null; echo "Cleanup done (or no session)"`,
+      agentPrompt: `Run: tmux kill-session -t "${ticket}-dev" 2>/dev/null; ${doneCmd}; echo "Cleanup done (or no session)"`,
     });
   }
 };


### PR DESCRIPTION
## Summary

- Adds `--done <TICKET>` flag to `communicate.js` that writes a `__MONITOR_DONE__` sentinel to the ticket's channel and cross-posts to the `MONITOR` channel with the ticket prefix, giving the manager a single line of signal per completed session.
- `listen-communication.js` now detects the sentinel and exits cleanly, so agents stop their local listener automatically as part of cleanup without needing a manual `Ctrl-C`.
- New `scripts/monitor-manager.js` tails the MONITOR channel, auto-welcomes the first message from any new ticket with a curated help list (TDD gate, token mint, hook misfires, CI triage, etc.), and tracks `__MONITOR_DONE__` events; `--archive` moves completed channel logs into `<INBOX_DIR>/archived/`.
- `work/steps/cleanup.js` now invokes `communicate.js --done` on both the RUN and DEFER paths so completion is always signaled when the cleanup step runs.
- 6 unit/e2e tests cover `extractTicket` prefix parsing (all ticket formats: `ECHO-N`, `PR-N`, `GH-N`, `APPSUPEN-N`), the `DONE_SENTINEL` constant, the stand-alone regex match path, and the `--done` end-to-end write path against a temp inbox directory.

## Test plan

- [ ] Run `pnpm test` and confirm all 6 new tests in `scripts/workflows/lib/__tests__/monitor-manager.test.js` pass.
- [ ] In a tmux session, set `CLAUDE_AGENT_INBOX_DIR=/tmp/test-inbox` and run `node scripts/monitor-manager.js` in one pane.
- [ ] From a second pane, send a message to MONITOR with a ticket prefix: `node scripts/communicate.js MONITOR "ECHO-7777: hello"`. Confirm the manager prints `-> [ECHO-7777] first contact — welcome sent` and that a welcome message appears in `/tmp/test-inbox/ECHO-7777.log`.
- [ ] Run `node scripts/communicate.js --done ECHO-7777 workflow-complete`. Confirm the manager prints `-> [ECHO-7777] marked COMPLETE`, the sentinel appears in `ECHO-7777.log`, and `MONITOR.log` contains `ECHO-7777: __MONITOR_DONE__`.
- [ ] If `listen-communication.js ECHO-7777` is running in a third pane, confirm it prints the `channel marked complete — listener exiting` message and exits on its own.
- [ ] Repeat with `--archive` flag; confirm the ticket log is moved to `/tmp/test-inbox/archived/`.