### PR TITLE
feat(work): add self-paced registry runners for qa-feature-tester and pr-reviewer

### DIFF
--- a/scripts/workflows/lib/next-action-footer.js
+++ b/scripts/workflows/lib/next-action-footer.js
@@ -74,6 +74,10 @@ function dirFor(scriptName) {
       return 'work-completion-checker';
     case 'code-next.js':
       return 'work-code-checker';
+    case 'qa-next.js':
+      return 'work-qa-feature-tester';
+    case 'pr-review-next.js':
+      return 'work-pr-reviewer';
     default:
       return '';
   }

--- a/scripts/workflows/work-pr-reviewer/__tests__/kind-checks.test.js
+++ b/scripts/workflows/work-pr-reviewer/__tests__/kind-checks.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { getKindCheckRegistry } = require('../lib/kind-checks/kind-registry');
+const devops = require('../lib/kind-checks/devops');
+const e2e = require('../lib/kind-checks/e2e');
+
+function makeWorktree({ tasks = '', files = {}, prContext = null } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-review-kind-'));
+  const worktreeRoot = path.join(root, 'wt');
+  fs.mkdirSync(worktreeRoot, { recursive: true });
+  const tasksDir = path.join(root, 'tasks', 'ECHO-7777');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  if (tasks) fs.writeFileSync(path.join(tasksDir, 'tasks.md'), tasks);
+  if (prContext)
+    fs.writeFileSync(path.join(tasksDir, 'pr-review-context.json'), JSON.stringify(prContext));
+  for (const [rel, contents] of Object.entries(files)) {
+    const p = path.join(worktreeRoot, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, contents);
+  }
+  return { root, tasksDir, worktreeRoot };
+}
+
+test('kind-registry exposes all six kinds', () => {
+  const r = getKindCheckRegistry();
+  for (const k of ['frontend', 'backend', 'wiring', 'e2e', 'devops', 'fullstack']) {
+    assert.ok(r[k]);
+  }
+});
+
+test('devops BLOCKS on secret-leak suspect', () => {
+  const { root, tasksDir, worktreeRoot } = makeWorktree({
+    tasks: '<!-- devops -->',
+    files: { '.github/workflows/ci.yml': 'env:\n  API_KEY: "abcd1234abcd1234"\n' },
+    prContext: { number: 1, files: ['.github/workflows/ci.yml'] },
+  });
+  const r = devops.validate({ tasksDir, worktreeRoot });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes('secret')));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('devops BLOCKS on app-source drift', () => {
+  const { root, tasksDir, worktreeRoot } = makeWorktree({
+    tasks: '<!-- devops -->',
+    files: { '.github/workflows/ci.yml': 'name: ci\n' },
+    prContext: { number: 1, files: ['.github/workflows/ci.yml', 'app/api/foo.ts'] },
+  });
+  const r = devops.validate({ tasksDir, worktreeRoot });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes('app/api/foo.ts')));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('e2e BLOCKS on .only', () => {
+  const { root, tasksDir, worktreeRoot } = makeWorktree({
+    tasks: '<!-- e2e -->',
+    files: {
+      'tests/e2e/foo.spec.ts': "test.only('x', async () => { expect(1).toBe(1); });\n",
+    },
+    prContext: { number: 1, files: ['tests/e2e/foo.spec.ts'] },
+  });
+  const r = e2e.validate({ tasksDir, worktreeRoot });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes('.only')));
+  fs.rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/workflows/work-pr-reviewer/__tests__/phase-registry.test.js
+++ b/scripts/workflows/work-pr-reviewer/__tests__/phase-registry.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getPhase, hasPhase } = require('../lib/phase-registry');
+const { PR_REVIEW_PHASE_ORDER } = require('../pr-review-phase-registry');
+
+test('dispatcher registers every declared phase', () => {
+  for (const p of PR_REVIEW_PHASE_ORDER) assert.equal(hasPhase(p), true);
+});
+
+test('every phase exposes validate() and instructions()', () => {
+  for (const p of PR_REVIEW_PHASE_ORDER) {
+    const h = getPhase(p);
+    assert.equal(typeof h.validate, 'function');
+    assert.equal(typeof h.instructions, 'function');
+  }
+});
+
+test('non-terminal phases have string `next`; done has null', () => {
+  for (const p of PR_REVIEW_PHASE_ORDER) {
+    const h = getPhase(p);
+    if (p === 'done') assert.equal(h.next, null);
+    else assert.equal(typeof h.next, 'string');
+  }
+});
+
+test('getPhase throws on unknown name', () => {
+  assert.throws(() => getPhase('made-up'), /No pr-review phase handler registered/);
+});

--- a/scripts/workflows/work-pr-reviewer/__tests__/pr-review-phase-registry.test.js
+++ b/scripts/workflows/work-pr-reviewer/__tests__/pr-review-phase-registry.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  PR_REVIEW_PHASES,
+  PR_REVIEW_PHASE_ORDER,
+  PR_REVIEW_PHASE_TRANSITIONS,
+  PR_REVIEW_INITIAL_PHASE,
+  PR_REVIEW_TERMINAL_PHASE,
+  prReviewNextPhases,
+  prReviewCanTransition,
+  isPrReviewPhase,
+} = require('../pr-review-phase-registry');
+
+test('PR_REVIEW_PHASE_ORDER lists 8 phases in declared order', () => {
+  assert.deepEqual(PR_REVIEW_PHASE_ORDER, [
+    'inputs',
+    'pr_context',
+    'diff_audit',
+    'standards_audit',
+    'kind_checks',
+    'review_post',
+    'memorize',
+    'done',
+  ]);
+});
+
+test('initial is inputs, terminal is done', () => {
+  assert.equal(PR_REVIEW_INITIAL_PHASE, 'inputs');
+  assert.equal(PR_REVIEW_TERMINAL_PHASE, 'done');
+});
+
+test('every non-terminal phase advances to the next', () => {
+  for (let i = 0; i < PR_REVIEW_PHASE_ORDER.length - 1; i++) {
+    const cur = PR_REVIEW_PHASE_ORDER[i];
+    const nxt = PR_REVIEW_PHASE_ORDER[i + 1];
+    assert.ok(prReviewCanTransition(cur, nxt));
+    assert.deepEqual(prReviewNextPhases(cur), [nxt]);
+  }
+});
+
+test('done is terminal', () => {
+  assert.deepEqual(PR_REVIEW_PHASE_TRANSITIONS.done, []);
+});
+
+test('rejects backwards', () => {
+  assert.equal(prReviewCanTransition('kind_checks', 'inputs'), false);
+});
+
+test('isPrReviewPhase recognizes valid phases', () => {
+  for (const p of PR_REVIEW_PHASE_ORDER) assert.equal(isPrReviewPhase(p), true);
+  assert.equal(isPrReviewPhase('made-up'), false);
+});
+
+test('PR_REVIEW_PHASES frozen', () => {
+  assert.throws(() => {
+    PR_REVIEW_PHASES.bogus = 'x';
+  });
+});

--- a/scripts/workflows/work-pr-reviewer/lib/kind-checks/backend.js
+++ b/scripts/workflows/work-pr-reviewer/lib/kind-checks/backend.js
@@ -1,0 +1,94 @@
+/**
+ * Kind: backend — PR review for API / data-layer changes.
+ *
+ * Risk lens:
+ *  - Breaking change to procedure inputs/outputs (rename/remove fields).
+ *  - Missing integration test in the PR diff.
+ *  - Schema migration without rollback notes.
+ *  - Auth/permission check skipped on new route.
+ */
+
+'use strict';
+
+const {
+  readChangedFiles,
+  readFileFromWorktree,
+  scanTypeScriptViolations,
+  isBackendFile,
+  detectKinds,
+} = require('./shared');
+
+function appliesTo(ctx) {
+  const k = detectKinds(ctx.tasksDir);
+  return k.includes('backend') || k.includes('fullstack');
+}
+
+function validate(ctx) {
+  const changed = readChangedFiles(ctx);
+  const backendFiles = changed.filter(isBackendFile);
+  const errors = [];
+  const warnings = [];
+
+  const tsHits = scanTypeScriptViolations(ctx, backendFiles);
+  if (tsHits.length) {
+    errors.push(
+      `Backend TS safety violations (${tsHits.length}): ${tsHits
+        .slice(0, 3)
+        .map((h) => `${h.file}:${h.line} (${h.pattern})`)
+        .join('; ')}${tsHits.length > 3 ? '; …' : ''}.`
+    );
+  }
+
+  // Missing integration test in this PR.
+  const hasIntegrationTest = changed.some(
+    (f) => /\.integration\.(test|spec)\./.test(f) || /\/tests?\/integration\//.test(f)
+  );
+  if (backendFiles.length && !hasIntegrationTest) {
+    warnings.push(
+      'Backend code changed in this PR with no integration test in the diff. Ask the author for at least one.'
+    );
+  }
+
+  // Migration touched without ROLLBACK note in commit/PR body.
+  const migrations = changed.filter((f) => /\/(migrations|prisma\/migrations)\//.test(f));
+  if (migrations.length) {
+    warnings.push(
+      `${migrations.length} migration file(s) in PR. Confirm the PR description includes a rollback plan.`
+    );
+  }
+
+  // Permission/auth check heuristic for new routes.
+  const newRoutesWithoutAuth = [];
+  for (const f of backendFiles) {
+    if (!/(^|\/)app\/api\//.test(f)) continue;
+    const text = readFileFromWorktree(ctx, f);
+    if (!text) continue;
+    if (!/(authorize|permission|requireAuth|getServerSession|protectedProcedure)/i.test(text)) {
+      newRoutesWithoutAuth.push(f);
+    }
+  }
+  if (newRoutesWithoutAuth.length) {
+    warnings.push(
+      `Route(s) without visible auth/permission check: ${newRoutesWithoutAuth
+        .slice(0, 3)
+        .map((f) => `\`${f}\``)
+        .join(
+          ', '
+        )}${newRoutesWithoutAuth.length > 3 ? ', …' : ''}. Confirm intentional public access.`
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `${backendFiles.length} backend file(s), ${tsHits.length} ts-violations, ${migrations.length} migration(s)`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('backend', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-pr-reviewer/lib/kind-checks/devops.js
+++ b/scripts/workflows/work-pr-reviewer/lib/kind-checks/devops.js
@@ -1,0 +1,89 @@
+/**
+ * Kind: devops — PR review for infra / CI changes.
+ *
+ * Risk lens: secrets leakage, unpinned versions, app-source drift in an
+ * infra-only PR.
+ */
+
+'use strict';
+
+const {
+  readChangedFiles,
+  readFileFromWorktree,
+  isDevopsFile,
+  isAppSourceFile,
+  detectKinds,
+} = require('./shared');
+
+function appliesTo(ctx) {
+  return detectKinds(ctx.tasksDir).includes('devops');
+}
+
+const SECRET_PATTERNS = [
+  /(api[_-]?key|token|secret|password|passwd)\s*[:=]\s*['"][^'"\s]{8,}/i,
+  /-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----/,
+];
+
+function validate(ctx) {
+  const changed = readChangedFiles(ctx);
+  const devopsFiles = changed.filter(isDevopsFile);
+  const errors = [];
+  const warnings = [];
+
+  const appDrift = changed.filter(isAppSourceFile);
+  if (appDrift.length) {
+    errors.push(
+      `DevOps PR contains app-source files: ${appDrift
+        .map((f) => `\`${f}\``)
+        .join(', ')}. Cross-scope — request split.`
+    );
+  }
+
+  // Secret-leak scan.
+  const leakSuspects = [];
+  for (const f of devopsFiles) {
+    if (!/\.(ya?ml|sh|json|env)$/.test(f)) continue;
+    const text = readFileFromWorktree(ctx, f);
+    if (!text) continue;
+    if (SECRET_PATTERNS.some((re) => re.test(text))) leakSuspects.push(f);
+  }
+  if (leakSuspects.length) {
+    errors.push(
+      `Possible secret in: ${leakSuspects
+        .map((f) => `\`${f}\``)
+        .join(
+          ', '
+        )}. BLOCK approval — verify via secret manager / GitHub secrets instead of inline.`
+    );
+  }
+
+  // Unpinned versions in github actions (`uses: x@main`).
+  const unpinned = [];
+  for (const f of devopsFiles) {
+    if (!/^\.github\/.+\.ya?ml$/.test(f)) continue;
+    const text = readFileFromWorktree(ctx, f);
+    if (!text) continue;
+    if (/uses:\s+\S+@(main|master|latest)\b/.test(text)) unpinned.push(f);
+  }
+  if (unpinned.length) {
+    warnings.push(
+      `Unpinned action ref (\`@main\`/\`@master\`/\`@latest\`) in: ${unpinned
+        .map((f) => `\`${f}\``)
+        .join(', ')}. Recommend pinning to a SHA.`
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `${devopsFiles.length} infra file(s), ${appDrift.length} app-drift, ${leakSuspects.length} secret-suspects`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('devops', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-pr-reviewer/lib/kind-checks/e2e.js
+++ b/scripts/workflows/work-pr-reviewer/lib/kind-checks/e2e.js
@@ -1,0 +1,65 @@
+/**
+ * Kind: e2e — PR review for Playwright spec changes.
+ *
+ * Risk lens: flaky-test anti-patterns (page.waitForTimeout, .only left in),
+ * missing @e2e tag, no expect() assertion in spec.
+ */
+
+'use strict';
+
+const { readChangedFiles, readFileFromWorktree, isE2eFile, detectKinds } = require('./shared');
+
+function appliesTo(ctx) {
+  return detectKinds(ctx.tasksDir).includes('e2e');
+}
+
+function validate(ctx) {
+  const changed = readChangedFiles(ctx);
+  const specs = changed.filter(isE2eFile);
+  const errors = [];
+  const warnings = [];
+
+  if (!specs.length) {
+    return { ok: true, summary: 'no e2e specs in PR diff' };
+  }
+
+  const issues = { only: [], noExpect: [], waitTimeout: [] };
+  for (const f of specs) {
+    const text = readFileFromWorktree(ctx, f);
+    if (!text) continue;
+    if (/\b(test|describe|it)\.only\(/.test(text)) issues.only.push(f);
+    if (!/\bexpect\s*\(/.test(text)) issues.noExpect.push(f);
+    if (/page\.waitForTimeout\(\s*\d{3,}/.test(text)) issues.waitTimeout.push(f);
+  }
+  if (issues.only.length) {
+    errors.push(
+      `\`.only\` in PR spec(s): ${issues.only.map((f) => `\`${f}\``).join(', ')}. Request changes.`
+    );
+  }
+  if (issues.noExpect.length) {
+    errors.push(
+      `Spec(s) with no \`expect(\`: ${issues.noExpect.map((f) => `\`${f}\``).join(', ')}.`
+    );
+  }
+  if (issues.waitTimeout.length) {
+    warnings.push(
+      `Hardcoded \`page.waitForTimeout\` in: ${issues.waitTimeout
+        .map((f) => `\`${f}\``)
+        .join(', ')}. Flaky-test risk — recommend polling.`
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `${specs.length} spec(s) in PR`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('e2e', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-pr-reviewer/lib/kind-checks/frontend.js
+++ b/scripts/workflows/work-pr-reviewer/lib/kind-checks/frontend.js
@@ -1,0 +1,91 @@
+/**
+ * Kind: frontend — PR review for UI changes.
+ *
+ * Risk lens (different from code-checker):
+ *  - Breaking change risk: prop signature changes on exported components.
+ *  - Style drift: new `@apply` or inline styles where the codebase uses tokens.
+ *  - Missing companion test in the PR diff (PR adds component but no test).
+ */
+
+'use strict';
+
+const {
+  readChangedFiles,
+  readFileFromWorktree,
+  scanTypeScriptViolations,
+  isFrontendFile,
+  detectKinds,
+} = require('./shared');
+
+function appliesTo(ctx) {
+  const k = detectKinds(ctx.tasksDir);
+  return k.includes('frontend') || k.includes('fullstack');
+}
+
+function validate(ctx) {
+  const changed = readChangedFiles(ctx);
+  const frontendFiles = changed.filter(isFrontendFile);
+  const errors = [];
+  const warnings = [];
+
+  const tsHits = scanTypeScriptViolations(ctx, frontendFiles);
+  if (tsHits.length) {
+    errors.push(
+      `PR frontend changes contain TS safety violations (${tsHits.length}): ${tsHits
+        .slice(0, 3)
+        .map((h) => `${h.file}:${h.line} (${h.pattern})`)
+        .join('; ')}${tsHits.length > 3 ? '; …' : ''}. Request changes before approving.`
+    );
+  }
+
+  // Heuristic: any new exported component without companion test in the SAME PR.
+  const sourceComponents = frontendFiles.filter(
+    (f) => /\.(tsx|jsx)$/.test(f) && !/\.(test|spec|stories)\./.test(f)
+  );
+  const testFiles = new Set(changed.filter((f) => /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(f)));
+  const orphans = sourceComponents.filter((f) => {
+    const base = f.replace(/\.(tsx|jsx)$/, '');
+    return ![`${base}.test.tsx`, `${base}.test.ts`, `${base}.spec.tsx`, `${base}.spec.ts`].some(
+      (t) => testFiles.has(t)
+    );
+  });
+  if (orphans.length) {
+    warnings.push(
+      `${orphans.length} component(s) changed without a companion test in this PR: ${orphans
+        .slice(0, 3)
+        .map((f) => `\`${f}\``)
+        .join(', ')}${orphans.length > 3 ? ', …' : ''}. Ask the author for coverage.`
+    );
+  }
+
+  // Style drift heuristic: `style={{...}}` or `!important` in changed JSX.
+  const styleDrift = [];
+  for (const f of frontendFiles) {
+    if (!/\.(tsx|jsx)$/.test(f)) continue;
+    const text = readFileFromWorktree(ctx, f);
+    if (!text) continue;
+    if (/style=\{\{|!important/.test(text)) styleDrift.push(f);
+  }
+  if (styleDrift.length) {
+    warnings.push(
+      `Inline \`style={{…}}\` or \`!important\` found in: ${styleDrift
+        .slice(0, 3)
+        .map((f) => `\`${f}\``)
+        .join(', ')}${styleDrift.length > 3 ? ', …' : ''}. Prefer design tokens / utility classes.`
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `${frontendFiles.length} frontend file(s), ${tsHits.length} ts-violations, ${orphans.length} test-orphan(s)`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('frontend', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-pr-reviewer/lib/kind-checks/fullstack.js
+++ b/scripts/workflows/work-pr-reviewer/lib/kind-checks/fullstack.js
@@ -1,0 +1,33 @@
+/**
+ * Kind: fullstack — runs both frontend + backend PR review validators.
+ */
+
+'use strict';
+
+const frontend = require('./frontend');
+const backend = require('./backend');
+const { detectKinds } = require('./shared');
+
+function appliesTo(ctx) {
+  return detectKinds(ctx.tasksDir).includes('fullstack');
+}
+
+function validate(ctx) {
+  const fr = frontend.validate(ctx);
+  const be = backend.validate(ctx);
+  const errors = [...(fr.errors || []), ...(be.errors || [])];
+  const warnings = [...(fr.warnings || []), ...(be.warnings || [])];
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `fullstack PR: ${fr.summary || 'frontend ok'} | ${be.summary || 'backend ok'}`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('fullstack', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-pr-reviewer/lib/kind-checks/kind-registry.js
+++ b/scripts/workflows/work-pr-reviewer/lib/kind-checks/kind-registry.js
@@ -1,0 +1,32 @@
+/**
+ * Kind-check registry for pr-reviewer. Mirrors work-spec/lib/kind-checks/
+ * kind-registry.js.
+ */
+
+'use strict';
+
+const registry = Object.create(null);
+
+function registerKind(name, handler) {
+  if (
+    !handler ||
+    typeof handler.appliesTo !== 'function' ||
+    typeof handler.validate !== 'function'
+  ) {
+    throw new Error(`Invalid kind handler for "${name}" — must expose appliesTo() and validate()`);
+  }
+  registry[name] = handler;
+}
+
+function getKindCheckRegistry() {
+  return registry;
+}
+
+require('./frontend')(registerKind);
+require('./backend')(registerKind);
+require('./wiring')(registerKind);
+require('./e2e')(registerKind);
+require('./devops')(registerKind);
+require('./fullstack')(registerKind);
+
+module.exports = { registerKind, getKindCheckRegistry };

--- a/scripts/workflows/work-pr-reviewer/lib/kind-checks/shared.js
+++ b/scripts/workflows/work-pr-reviewer/lib/kind-checks/shared.js
@@ -36,8 +36,12 @@ function readChangedFiles(ctx) {
   const j = readPrContext(ctx.tasksDir);
   if (j && Array.isArray(j.files)) return j.files.slice();
   // Fallback: local git diff (when running locally without a real PR).
+  // Use the centralized config.getBaseBranch() resolution (env → git
+  // symbolic-ref → probe → fallback) instead of a hardcoded list, so
+  // repos using `dev`/`master`/non-standard default branches work.
   const root = ctx.worktreeRoot || process.cwd();
-  for (const base of ['origin/main', 'main', 'origin/dev', 'dev']) {
+  const candidates = resolveBaseCandidates(root);
+  for (const base of candidates) {
     const r = spawnSync('git', ['diff', '--name-only', `${base}...HEAD`], {
       cwd: root,
       encoding: 'utf8',
@@ -50,6 +54,25 @@ function readChangedFiles(ctx) {
     }
   }
   return [];
+}
+
+/**
+ * Build ordered diff-base candidates from `config.getBaseBranch()`. The
+ * helper returns refs like `origin/main` — we also probe the bare name so
+ * environments without a fetched remote still work. Deduped + ordered.
+ */
+function resolveBaseCandidates(cwd) {
+  let base = '';
+  try {
+    const config = require('../../../lib/config');
+    if (config && typeof config.getBaseBranch === 'function') {
+      base = config.getBaseBranch({ cwd }) || '';
+    }
+  } catch {
+    /* fall through */
+  }
+  const bare = String(base || 'main').replace(/^origin\//, '');
+  return [...new Set([`origin/${bare}`, bare])];
 }
 
 function readFileFromWorktree(ctx, relPath) {
@@ -86,6 +109,7 @@ module.exports = {
   readFile,
   readPrContext,
   readChangedFiles,
+  resolveBaseCandidates,
   readFileFromWorktree,
   scanTypeScriptViolations,
   TS_VIOLATIONS,

--- a/scripts/workflows/work-pr-reviewer/lib/kind-checks/shared.js
+++ b/scripts/workflows/work-pr-reviewer/lib/kind-checks/shared.js
@@ -1,0 +1,104 @@
+/**
+ * Shared helpers for pr-reviewer kind-check modules.
+ *
+ * Reads `pr-context.json` (snapshot of `gh pr diff` files) so all kind
+ * validators see the same view of the PR. Falls back to local git diff
+ * if pr-context.json is not yet produced.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const specShared = require('../../../work-spec/lib/kind-checks/shared');
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function readPrContext(tasksDir) {
+  const p = path.join(tasksDir, 'pr-review-context.json');
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function readChangedFiles(ctx) {
+  const j = readPrContext(ctx.tasksDir);
+  if (j && Array.isArray(j.files)) return j.files.slice();
+  // Fallback: local git diff (when running locally without a real PR).
+  const root = ctx.worktreeRoot || process.cwd();
+  for (const base of ['origin/main', 'main', 'origin/dev', 'dev']) {
+    const r = spawnSync('git', ['diff', '--name-only', `${base}...HEAD`], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    if (r.status === 0) {
+      return r.stdout
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+  }
+  return [];
+}
+
+function readFileFromWorktree(ctx, relPath) {
+  const root = ctx.worktreeRoot || process.cwd();
+  return readFile(path.join(root, relPath));
+}
+
+const TS_VIOLATIONS = [
+  { name: 'as any', re: /\bas\s+any\b/ },
+  { name: 'as unknown as', re: /\bas\s+unknown\s+as\b/ },
+  { name: '@ts-ignore', re: /@ts-ignore/ },
+  { name: ': any (param/return)', re: /:\s*any(?![A-Za-z0-9_])/ },
+];
+
+function scanTypeScriptViolations(ctx, files) {
+  const out = [];
+  for (const f of files) {
+    if (!/\.(ts|tsx)$/.test(f)) continue;
+    const text = readFileFromWorktree(ctx, f);
+    if (!text) continue;
+    const lines = text.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      for (const v of TS_VIOLATIONS) {
+        if (v.re.test(lines[i])) {
+          out.push({ file: f, line: i + 1, pattern: v.name, snippet: lines[i].trim() });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  readFile,
+  readPrContext,
+  readChangedFiles,
+  readFileFromWorktree,
+  scanTypeScriptViolations,
+  TS_VIOLATIONS,
+  readBrief: specShared.readBrief,
+  readSpec: specShared.readSpec,
+  readTasks: specShared.readTasks,
+  sliceSection: specShared.sliceSection,
+  detectKinds: specShared.detectKinds,
+  briefForbidsBackend: specShared.briefForbidsBackend,
+  isBackendFile: specShared.isBackendFile,
+  isFrontendFile: specShared.isFrontendFile,
+  isE2eFile: specShared.isE2eFile,
+  isDevopsFile: specShared.isDevopsFile,
+  isAppSourceFile: specShared.isAppSourceFile,
+  KIND_NAMES: specShared.KIND_NAMES,
+};

--- a/scripts/workflows/work-pr-reviewer/lib/kind-checks/wiring.js
+++ b/scripts/workflows/work-pr-reviewer/lib/kind-checks/wiring.js
@@ -1,0 +1,63 @@
+/**
+ * Kind: wiring — PR review for "connect-existing-pieces" PRs.
+ *
+ * Risk lens: cross-scope drift (changes outside the declared wire surface).
+ * Blocks if PR touches sibling-owned backend files when brief forbids
+ * backend changes.
+ */
+
+'use strict';
+
+const {
+  readBrief,
+  readChangedFiles,
+  briefForbidsBackend,
+  isBackendFile,
+  detectKinds,
+} = require('./shared');
+
+function appliesTo(ctx) {
+  const k = detectKinds(ctx.tasksDir);
+  if (k.includes('wiring')) return true;
+  const brief = readBrief(ctx.tasksDir);
+  return briefForbidsBackend(brief) && k.length === 0;
+}
+
+function validate(ctx) {
+  const brief = readBrief(ctx.tasksDir);
+  const changed = readChangedFiles(ctx);
+  const errors = [];
+  const warnings = [];
+
+  if (briefForbidsBackend(brief)) {
+    const drift = changed.filter(isBackendFile);
+    if (drift.length) {
+      errors.push(
+        `Wiring PR + brief forbids backend changes, but diff contains backend files: ${drift
+          .map((f) => `\`${f}\``)
+          .join(', ')}. Request author to revert and split into a sibling ticket.`
+      );
+    }
+  }
+
+  // PR size sanity for wiring: should be small. Warn if >15 files.
+  if (changed.length > 15) {
+    warnings.push(
+      `Wiring PR has ${changed.length} changed files — wiring should typically be small. Ask the author to split or justify.`
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `${changed.length} files in diff`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('wiring', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-pr-reviewer/lib/memory-plugin-config.js
+++ b/scripts/workflows/work-pr-reviewer/lib/memory-plugin-config.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../../work-brief/lib/memory-plugin-config');

--- a/scripts/workflows/work-pr-reviewer/lib/phase-registry.js
+++ b/scripts/workflows/work-pr-reviewer/lib/phase-registry.js
@@ -1,0 +1,41 @@
+/**
+ * PR-reviewer phase dispatcher. Mirrors work-spec/lib/phase-registry.js.
+ */
+
+'use strict';
+
+const handlers = Object.create(null);
+
+function registerPhase(phaseName, handler) {
+  if (
+    !handler ||
+    typeof handler.validate !== 'function' ||
+    typeof handler.instructions !== 'function'
+  ) {
+    throw new Error(
+      `Invalid phase handler for "${phaseName}" — must expose validate() and instructions()`
+    );
+  }
+  handlers[phaseName] = handler;
+}
+
+function getPhase(phaseName) {
+  const h = handlers[phaseName];
+  if (!h) throw new Error(`No pr-review phase handler registered for "${phaseName}"`);
+  return h;
+}
+
+function hasPhase(phaseName) {
+  return Boolean(handlers[phaseName]);
+}
+
+require('./phases/inputs')(registerPhase);
+require('./phases/pr_context')(registerPhase);
+require('./phases/diff_audit')(registerPhase);
+require('./phases/standards_audit')(registerPhase);
+require('./phases/kind_checks')(registerPhase);
+require('./phases/review_post')(registerPhase);
+require('./phases/memorize')(registerPhase);
+require('./phases/done')(registerPhase);
+
+module.exports = { registerPhase, getPhase, hasPhase };

--- a/scripts/workflows/work-pr-reviewer/lib/phases/diff_audit.js
+++ b/scripts/workflows/work-pr-reviewer/lib/phases/diff_audit.js
@@ -1,0 +1,95 @@
+/**
+ * Phase: diff_audit — sanity check the diff snapshot before deep review.
+ *
+ * Block conditions:
+ *  - Diff is empty (nothing to review).
+ *  - PR touches files outside any task's scope AND the agent has not
+ *    written a `## Out-of-scope justification` section in pr-review.check.md.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { PR_REVIEW_PHASES } = require('../../pr-review-phase-registry');
+const { readChangedFiles, readTasks, sliceSection } = require('../kind-checks/shared');
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function parseFilesInScope(tasksText) {
+  const out = new Set();
+  if (!tasksText) return out;
+  const re = /^###\s+Files in scope\b[\s\S]*?(?=\n###\s|\n## |$(?![\s\S]))/gim;
+  let m;
+  while ((m = re.exec(tasksText)) !== null) {
+    for (const line of m[0].split('\n')) {
+      const b = line.match(/`([^`\n]+)`/g);
+      if (!b) continue;
+      for (const tok of b) out.add(tok.replace(/`/g, '').trim());
+    }
+  }
+  return out;
+}
+
+function validate(ctx) {
+  const changed = readChangedFiles(ctx);
+  if (!changed.length) {
+    return { ok: false, errors: ['PR diff is empty — nothing to review.'] };
+  }
+  const inScope = parseFilesInScope(readTasks(ctx.tasksDir));
+  const unaccounted = inScope.size > 0 ? changed.filter((f) => !inScope.has(f)) : [];
+  const errors = [];
+  const warnings = [];
+
+  if (unaccounted.length) {
+    // If the reviewer has acknowledged with a justification section, accept.
+    const review = readFile(path.join(ctx.tasksDir, 'pr-review.check.md')) || '';
+    const hasJustification = !!sliceSection(review, /^##\s+Out-of-scope justification\b/im);
+    if (!hasJustification) {
+      warnings.push(
+        `PR touches ${unaccounted.length} file(s) not declared in any task's \`### Files in scope\`: ${unaccounted
+          .slice(0, 5)
+          .map((f) => `\`${f}\``)
+          .join(
+            ', '
+          )}${unaccounted.length > 5 ? ', …' : ''}. Either add a \`## Out-of-scope justification\` section to pr-review.check.md (with reason per file) or request the author to split.`
+      );
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `${changed.length} file(s) in PR, ${unaccounted.length} unaccounted`,
+  };
+}
+
+function instructions(ctx) {
+  return [
+    '# pr-review-next — Phase 3 of 8: DIFF AUDIT',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'I classify every changed file against the union of `### Files in scope` across all tasks. Unaccounted files surface as warnings — justify them in the review (under `## Out-of-scope justification`) or request a split.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(PR_REVIEW_PHASES.diff_audit, {
+    next: PR_REVIEW_PHASES.standards_audit,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.parseFilesInScope = parseFilesInScope;

--- a/scripts/workflows/work-pr-reviewer/lib/phases/done.js
+++ b/scripts/workflows/work-pr-reviewer/lib/phases/done.js
@@ -1,0 +1,32 @@
+/**
+ * Phase: done — terminal.
+ */
+
+'use strict';
+
+const { PR_REVIEW_PHASES } = require('../../pr-review-phase-registry');
+
+function validate() {
+  return { ok: true, summary: 'pr-reviewer terminal phase' };
+}
+
+function instructions(ctx) {
+  return [
+    '# pr-review-next — Phase 8 of 8: DONE',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'Review posted, memorized, complete. Return final pr-review.check.md.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(PR_REVIEW_PHASES.done, {
+    next: null,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;

--- a/scripts/workflows/work-pr-reviewer/lib/phases/inputs.js
+++ b/scripts/workflows/work-pr-reviewer/lib/phases/inputs.js
@@ -1,0 +1,46 @@
+/**
+ * Phase: inputs — confirm planning artifacts available for the review.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { PR_REVIEW_PHASES } = require('../../pr-review-phase-registry');
+
+function validate(ctx) {
+  const required = ['brief.md', 'spec.md', 'tasks.md'];
+  const missing = required.filter((f) => !fs.existsSync(path.join(ctx.tasksDir, f)));
+  const warnings = missing.length
+    ? [`Missing planning artifact(s): ${missing.join(', ')} — review confidence degraded.`]
+    : [];
+  return {
+    ok: true,
+    warnings,
+    summary: `${required.length - missing.length}/${required.length} artifacts present`,
+  };
+}
+
+function instructions(ctx) {
+  return [
+    '# pr-review-next — Phase 1 of 8: INPUTS',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'I check `brief.md`, `spec.md`, `tasks.md` exist. They are your review baseline.',
+    '',
+    `Memory plugin: ${ctx.memory ? ctx.memory.name : '(none detected)'}`,
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(PR_REVIEW_PHASES.inputs, {
+    next: PR_REVIEW_PHASES.pr_context,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;

--- a/scripts/workflows/work-pr-reviewer/lib/phases/kind_checks.js
+++ b/scripts/workflows/work-pr-reviewer/lib/phases/kind_checks.js
@@ -1,0 +1,127 @@
+/**
+ * Phase: kind_checks — fan-out per-task-kind PR-review validators.
+ * Mirrors work-spec/lib/phases/kind_checks.js, records into
+ * pr-review.check.md.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { PR_REVIEW_PHASES } = require('../../pr-review-phase-registry');
+const { getKindCheckRegistry } = require('../kind-checks/kind-registry');
+
+const KIND_HEADER = '## PR-review kind verification';
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function renderKindBlock(results) {
+  const lines = [KIND_HEADER, ''];
+  for (const r of results) {
+    const status = r.ok ? '✓ ok' : '✗ blocking';
+    lines.push(`- **${r.kind}** — ${status}: ${r.summary || ''}`);
+    for (const w of r.warnings || []) lines.push(`  - warning: ${w}`);
+    for (const e of r.errors || []) lines.push(`  - error: ${e}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function upsertKindSection(text, block) {
+  if (!text) return block;
+  const idx = text.indexOf(KIND_HEADER);
+  if (idx === -1) return `${text.replace(/\s+$/, '')}\n\n${block}`;
+  const after = text.slice(idx + KIND_HEADER.length);
+  const nextHdr = after.match(/^##\s/m);
+  const end = nextHdr ? idx + KIND_HEADER.length + nextHdr.index : text.length;
+  return text.slice(0, idx) + block + text.slice(end);
+}
+
+function writeKindSection(tasksDir, results) {
+  const p = path.join(tasksDir, 'pr-review.check.md');
+  const text = readFile(p);
+  const next = upsertKindSection(text, renderKindBlock(results));
+  if (next !== text) {
+    try {
+      fs.writeFileSync(p, next);
+    } catch {
+      /* hook-gated */
+    }
+  }
+}
+
+function validate(ctx) {
+  const registry = getKindCheckRegistry();
+  const matched = [];
+  for (const [kind, h] of Object.entries(registry)) {
+    let applies = false;
+    try {
+      applies = Boolean(h.appliesTo(ctx));
+    } catch {
+      applies = false;
+    }
+    if (applies) matched.push({ kind, h });
+  }
+  const results = [];
+  for (const { kind, h } of matched) {
+    let r;
+    try {
+      r = h.validate(ctx);
+    } catch (e) {
+      r = { ok: false, errors: [`kind-check "${kind}" threw: ${e.message}`] };
+    }
+    results.push({ kind, ...r });
+  }
+  if (results.length) writeKindSection(ctx.tasksDir, results);
+  const allErrors = results.flatMap((r) => (r.ok ? [] : r.errors || []));
+  if (allErrors.length) {
+    return {
+      ok: false,
+      errors: allErrors,
+      summary: `${results.filter((r) => r.ok).length}/${results.length} kinds passing`,
+    };
+  }
+  return {
+    ok: true,
+    summary: `${results.length} kind check(s) passed (${results.map((r) => r.kind).join(', ') || 'none applied'})`,
+  };
+}
+
+function instructions(ctx) {
+  return [
+    '# pr-review-next — Phase 5 of 8: KIND CHECKS',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    '### Per task kind',
+    '- **frontend**: breaking-change risk, missing companion test, style drift.',
+    '- **backend**: TS safety, missing integration test, migration without rollback, missing auth.',
+    '- **wiring**: ECHO-4579 backend drift; PR-size sanity.',
+    '- **e2e**: `.only`, missing `expect(`, hardcoded `waitForTimeout`.',
+    '- **devops**: secret-leak suspects, unpinned action refs, app-source drift.',
+    '- **fullstack**: frontend + backend.',
+    '',
+    'Recorded under `## PR-review kind verification` in pr-review.check.md.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(PR_REVIEW_PHASES.kind_checks, {
+    next: PR_REVIEW_PHASES.review_post,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.renderKindBlock = renderKindBlock;
+module.exports.upsertKindSection = upsertKindSection;
+module.exports.KIND_HEADER = KIND_HEADER;

--- a/scripts/workflows/work-pr-reviewer/lib/phases/memorize.js
+++ b/scripts/workflows/work-pr-reviewer/lib/phases/memorize.js
@@ -1,0 +1,59 @@
+/**
+ * Phase: memorize — persist the review verdict to the memory plugin.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { PR_REVIEW_PHASES } = require('../../pr-review-phase-registry');
+
+const SENTINEL = '.pr-review-memorized';
+
+function validate(ctx) {
+  if (!ctx.memory) return { ok: true, summary: 'no memory plugin detected — skipping' };
+  const p = path.join(ctx.tasksDir, SENTINEL);
+  if (!fs.existsSync(p)) {
+    return {
+      ok: false,
+      errors: [
+        `Memory plugin "${ctx.memory.name}" available but \`${SENTINEL}\` missing. Call \`${ctx.memory.remember}\` with the verdict + critical findings, then \`touch ${p}\`.`,
+      ],
+    };
+  }
+  return { ok: true, summary: `memorized via ${ctx.memory.name}` };
+}
+
+function instructions(ctx) {
+  if (!ctx.memory) {
+    return [
+      '# pr-review-next — Phase 7 of 8: MEMORIZE',
+      '',
+      'No memory plugin — auto-advance.',
+      '',
+    ].join('\n');
+  }
+  return [
+    '# pr-review-next — Phase 7 of 8: MEMORIZE',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    `Memory: **${ctx.memory.name}**`,
+    '',
+    `1. Call \`${ctx.memory.remember}\` with: PR number, verdict, top critical/important findings.`,
+    `2. \`touch ${path.join(ctx.tasksDir, SENTINEL)}\`.`,
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(PR_REVIEW_PHASES.memorize, {
+    next: PR_REVIEW_PHASES.done,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.SENTINEL = SENTINEL;

--- a/scripts/workflows/work-pr-reviewer/lib/phases/memorize.js
+++ b/scripts/workflows/work-pr-reviewer/lib/phases/memorize.js
@@ -18,7 +18,7 @@ function validate(ctx) {
     return {
       ok: false,
       errors: [
-        `Memory plugin "${ctx.memory.name}" available but \`${SENTINEL}\` missing. Call \`${ctx.memory.remember}\` with the verdict + critical findings, then \`touch ${p}\`.`,
+        `Memory plugin "${ctx.memory.name}" available but \`${SENTINEL}\` missing. Call \`${ctx.memory.rememberTool}\` with the verdict + critical findings, then \`touch ${p}\`.`,
       ],
     };
   }
@@ -40,7 +40,7 @@ function instructions(ctx) {
     '',
     `Memory: **${ctx.memory.name}**`,
     '',
-    `1. Call \`${ctx.memory.remember}\` with: PR number, verdict, top critical/important findings.`,
+    `1. Call \`${ctx.memory.rememberTool}\` with: PR number, verdict, top critical/important findings.`,
     `2. \`touch ${path.join(ctx.tasksDir, SENTINEL)}\`.`,
     '',
   ].join('\n');

--- a/scripts/workflows/work-pr-reviewer/lib/phases/pr_context.js
+++ b/scripts/workflows/work-pr-reviewer/lib/phases/pr_context.js
@@ -1,0 +1,78 @@
+/**
+ * Phase: pr_context — capture PR metadata (number, base, files) into
+ * `pr-review-context.json` for downstream phases. Agent runs gh and writes
+ * the snapshot; gate validates the snapshot has number + files.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { PR_REVIEW_PHASES } = require('../../pr-review-phase-registry');
+
+const CTX_FILE = 'pr-review-context.json';
+
+function readJson(p) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function validate(ctx) {
+  const p = path.join(ctx.tasksDir, CTX_FILE);
+  const j = readJson(p);
+  if (!j) {
+    return {
+      ok: false,
+      errors: [
+        `Missing ${p}. Run \`gh pr view <N> --json number,headRefName,baseRefName,files\` and save the relevant fields here (with \`files\` flattened to an array of paths).`,
+      ],
+    };
+  }
+  if (typeof j.number !== 'number' && typeof j.number !== 'string') {
+    return { ok: false, errors: [`${CTX_FILE} must include a \`number\` field (PR number).`] };
+  }
+  if (!Array.isArray(j.files) || j.files.length === 0) {
+    return {
+      ok: false,
+      errors: [`${CTX_FILE} must include a non-empty \`files\` array of paths in the PR diff.`],
+    };
+  }
+  return { ok: true, summary: `PR #${j.number}, ${j.files.length} file(s)` };
+}
+
+function instructions(ctx) {
+  return [
+    '# pr-review-next — Phase 2 of 8: PR CONTEXT',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    `Write \`${path.join(ctx.tasksDir, CTX_FILE)}\` with PR metadata. Suggested shape:`,
+    '',
+    '```json',
+    '{',
+    '  "number": 1234,',
+    '  "headRefName": "feature/echo-xxxx",',
+    '  "baseRefName": "main",',
+    '  "files": ["path/a.tsx", "path/b.ts"]',
+    '}',
+    '```',
+    '',
+    'Use `gh pr view <N> --json number,headRefName,baseRefName,files` and flatten `files[].path` into a string array.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(PR_REVIEW_PHASES.pr_context, {
+    next: PR_REVIEW_PHASES.diff_audit,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.CTX_FILE = CTX_FILE;

--- a/scripts/workflows/work-pr-reviewer/lib/phases/review_post.js
+++ b/scripts/workflows/work-pr-reviewer/lib/phases/review_post.js
@@ -1,0 +1,86 @@
+/**
+ * Phase: review_post — verify pr-review.check.md has the canonical
+ * structure and a final verdict (APPROVE / REQUEST_CHANGES / COMMENT).
+ *
+ * Note: this phase only checks the LOCAL artifact. Posting the review to
+ * GitHub (via `gh pr review`) is the agent's responsibility — we record
+ * a sentinel `.pr-review-posted` to confirm it happened.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { PR_REVIEW_PHASES } = require('../../pr-review-phase-registry');
+
+const REQUIRED_SECTIONS = ['Summary', 'PR-review kind verification', 'Verdict'];
+const SENTINEL = '.pr-review-posted';
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function validate(ctx) {
+  const p = path.join(ctx.tasksDir, 'pr-review.check.md');
+  const text = readFile(p);
+  if (!text) return { ok: false, errors: [`Missing ${p}.`] };
+  const missing = REQUIRED_SECTIONS.filter((s) => !text.includes(s));
+  if (missing.length) {
+    return {
+      ok: false,
+      errors: [`pr-review.check.md missing section(s): ${missing.join(', ')}.`],
+    };
+  }
+  if (!/Verdict:\s*(APPROVE|REQUEST_CHANGES|COMMENT)\b/i.test(text)) {
+    return {
+      ok: false,
+      errors: [
+        'pr-review.check.md final `Verdict:` line must be `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`.',
+      ],
+    };
+  }
+  const sentinel = path.join(ctx.tasksDir, SENTINEL);
+  if (!fs.existsSync(sentinel)) {
+    return {
+      ok: false,
+      errors: [
+        `Post the review to GitHub with \`gh pr review <N> --<verdict-flag>\` (or web UI), then \`touch ${sentinel}\` to advance.`,
+      ],
+    };
+  }
+  return { ok: true, summary: `${text.length} chars, posted` };
+}
+
+function instructions(ctx) {
+  return [
+    '# pr-review-next — Phase 6 of 8: REVIEW POST',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    `1. Finalize \`${path.join(ctx.tasksDir, 'pr-review.check.md')}\` with sections: Summary, PR-review kind verification, Verdict.`,
+    '2. End with a single line: `Verdict: APPROVE` | `REQUEST_CHANGES` | `COMMENT`.',
+    '3. Post the review to GitHub:',
+    '   - APPROVE: `gh pr review <N> --approve --body-file pr-review.check.md`',
+    '   - REQUEST_CHANGES: `gh pr review <N> --request-changes --body-file pr-review.check.md`',
+    '   - COMMENT: `gh pr review <N> --comment --body-file pr-review.check.md`',
+    `4. \`touch ${path.join(ctx.tasksDir, SENTINEL)}\`.`,
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(PR_REVIEW_PHASES.review_post, {
+    next: PR_REVIEW_PHASES.memorize,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.REQUIRED_SECTIONS = REQUIRED_SECTIONS;
+module.exports.SENTINEL = SENTINEL;

--- a/scripts/workflows/work-pr-reviewer/lib/phases/standards_audit.js
+++ b/scripts/workflows/work-pr-reviewer/lib/phases/standards_audit.js
@@ -1,0 +1,61 @@
+/**
+ * Phase: standards_audit — deterministic TS-safety scan across the PR diff.
+ * Same logic as code-checker but applied to the PR's files (reviewing
+ * someone else's diff, not your own).
+ */
+
+'use strict';
+
+const { PR_REVIEW_PHASES } = require('../../pr-review-phase-registry');
+const { readChangedFiles, scanTypeScriptViolations } = require('../kind-checks/shared');
+
+function validate(ctx) {
+  const changed = readChangedFiles(ctx);
+  const hits = scanTypeScriptViolations(ctx, changed);
+  if (!hits.length) return { ok: true, summary: 'no TS safety violations in PR diff' };
+
+  const critical = hits.filter((h) => /as any|as unknown|@ts-ignore/.test(h.pattern));
+  if (critical.length) {
+    return {
+      ok: false,
+      errors: [
+        `Critical TS safety violations in PR (${critical.length}): ${critical
+          .slice(0, 5)
+          .map((h) => `${h.file}:${h.line} (${h.pattern})`)
+          .join('; ')}${critical.length > 5 ? '; …' : ''}. Request changes — these block approval.`,
+      ],
+      summary: `${hits.length} ts hit(s), ${critical.length} critical`,
+    };
+  }
+  return {
+    ok: true,
+    warnings: [
+      `Non-critical TS hits (${hits.length}): ${hits
+        .slice(0, 5)
+        .map((h) => `${h.file}:${h.line} (${h.pattern})`)
+        .join('; ')}${hits.length > 5 ? '; …' : ''}. Note in review.`,
+    ],
+    summary: `${hits.length} ts hit(s), 0 critical`,
+  };
+}
+
+function instructions(ctx) {
+  return [
+    '# pr-review-next — Phase 4 of 8: STANDARDS AUDIT',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'I scan the PR diff for non-negotiable TS safety violations: `as any`, `as unknown as`, `@ts-ignore` (block), and `: any` (warn).',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(PR_REVIEW_PHASES.standards_audit, {
+    next: PR_REVIEW_PHASES.kind_checks,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;

--- a/scripts/workflows/work-pr-reviewer/pr-review-next.js
+++ b/scripts/workflows/work-pr-reviewer/pr-review-next.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+/**
+ * pr-review-next.js
+ *
+ * Self-paced runner for the pr-reviewer agent. Mirrors completion-next.js /
+ * code-next.js. Phases:
+ *   inputs → pr_context → diff_audit → standards_audit → kind_checks →
+ *   review_post → memorize → done
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const PR_REVIEW_PHASE_CLI = path.resolve(__dirname, 'pr-review-phase-state.js');
+
+const { PR_REVIEW_INITIAL_PHASE } = require('./pr-review-phase-registry');
+const { getPhase } = require('./lib/phase-registry');
+const { loadMemoryPluginCandidates } = require('./lib/memory-plugin-config');
+
+let logNextScriptEvent;
+try {
+  ({ logNextScriptEvent } = require('../lib/next-script-log'));
+} catch {
+  logNextScriptEvent = () => {};
+}
+
+let config;
+try {
+  config = require('../lib/config');
+} catch {
+  config = null;
+}
+
+function resolveTasksBase() {
+  return (
+    process.env.TASKS_BASE ||
+    (config && config.TASKS_BASE) ||
+    path.join(require('node:os').homedir(), 'worktrees', 'tasks')
+  );
+}
+
+function resolveWorktreeRoot() {
+  const r = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+function die(msg) {
+  process.stderr.write(`pr-review-next: ${msg}\n`);
+  process.exit(2);
+}
+
+let _companionTokenSnapshot = null;
+
+function snapshotCompanionToken(scriptBasename, ticketId) {
+  try {
+    const dir = process.env.CLAUDE_WRITE_TOKEN_DIR || '/tmp/.claude-write-tokens';
+    const bareTicket = ticketId ? String(ticketId).split('/')[0] : null;
+    const keyed = bareTicket ? path.join(dir, `${scriptBasename}.${bareTicket}`) : null;
+    const legacy = path.join(dir, scriptBasename);
+    const file = keyed && fs.existsSync(keyed) ? keyed : fs.existsSync(legacy) ? legacy : null;
+    if (!file) return;
+    _companionTokenSnapshot = { path: file, data: JSON.parse(fs.readFileSync(file, 'utf8')) };
+  } catch {
+    /* fail-open */
+  }
+}
+
+function mintCompanionToken() {
+  if (!_companionTokenSnapshot) return false;
+  try {
+    fs.mkdirSync(path.dirname(_companionTokenSnapshot.path), { recursive: true, mode: 0o700 });
+    const data = { ..._companionTokenSnapshot.data, timestamp: Date.now() };
+    fs.writeFileSync(_companionTokenSnapshot.path, JSON.stringify(data), { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectMemoryPlugin(env = process.env) {
+  const home = require('node:os').homedir();
+  const candidates = loadMemoryPluginCandidates(env);
+  for (const c of candidates) {
+    for (const base of c.manifestGlob) {
+      const dir = path.join(home, base);
+      if (!fs.existsSync(dir)) continue;
+      let entries;
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      if (entries.some((e) => c.probe.test(e.name))) return c;
+    }
+  }
+  return null;
+}
+
+function readRelatedManifest(tasksDir) {
+  const p = path.join(tasksDir, 'related-tickets.json');
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function listLinkedIds(manifest) {
+  if (!manifest) return [];
+  const ids = new Set();
+  if (manifest.parent && manifest.parent.id) ids.add(manifest.parent.id);
+  for (const key of ['siblings', 'blockedBy', 'dependsOn', 'relatedTo']) {
+    for (const e of manifest[key] || []) if (e && e.id) ids.add(e.id);
+  }
+  return [...ids];
+}
+
+function callPhaseCli(args) {
+  mintCompanionToken();
+  const r = spawnSync(process.execPath, [PR_REVIEW_PHASE_CLI, ...args], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return { code: r.status ?? -1, out: (r.stdout || '') + (r.stderr || '') };
+}
+
+function getCurrentPhase(ticket) {
+  const r = callPhaseCli(['current', ticket]);
+  if (r.code !== 0) return null;
+  try {
+    return JSON.parse(r.out.trim().split('\n').pop()).currentPhase;
+  } catch {
+    return null;
+  }
+}
+
+function ensureInit(ticket) {
+  const r = callPhaseCli(['init', ticket]);
+  if (r.code !== 0) die(`Could not init pr-review-phase state:\n${r.out}`);
+}
+
+function recordPhase(ticket, phase, summary) {
+  return callPhaseCli(['record', ticket, phase, '--summary', summary || '']);
+}
+
+function transitionPhase(ticket, target) {
+  return callPhaseCli(['transition', ticket, target]);
+}
+
+function main(argv) {
+  const startedAt = Date.now();
+  const args = argv.slice(2);
+  const ticket = args[0];
+  if (!ticket || /^-/.test(ticket)) {
+    process.stderr.write(
+      'usage: pr-review-next.js <TICKET>\n  e.g. node pr-review-next.js ECHO-4579\n'
+    );
+    process.exit(2);
+  }
+  logNextScriptEvent('pr-review-next', {
+    event: 'invoked',
+    ticket,
+    cwd: process.cwd(),
+    agent: process.env.CLAUDE_CURRENT_AGENT || null,
+  });
+
+  snapshotCompanionToken('pr-review-phase-state.js', ticket);
+
+  const tasksBase = resolveTasksBase();
+  const tasksDir = path.join(tasksBase, ticket);
+  if (!fs.existsSync(tasksDir)) die(`tasks dir not found: ${tasksDir}`);
+
+  const manifest = readRelatedManifest(tasksDir);
+  const linkedIds = listLinkedIds(manifest);
+  const memory = detectMemoryPlugin();
+  const worktreeRoot = resolveWorktreeRoot() || path.dirname(tasksBase);
+
+  ensureInit(ticket);
+  let phase = getCurrentPhase(ticket) || PR_REVIEW_INITIAL_PHASE;
+
+  const ctx = { ticket, tasksDir, tasksBase, manifest, linkedIds, memory, worktreeRoot };
+
+  const handler = getPhase(phase);
+  const verdict = handler.validate(ctx);
+
+  let advanced = false;
+  let blockReason = '';
+
+  if (verdict.ok && handler.next) {
+    const rec = recordPhase(ticket, phase, verdict.summary || '');
+    if (rec.code !== 0) {
+      blockReason = `Could not record phase ${phase}:\n${rec.out}`;
+    } else {
+      const t = transitionPhase(ticket, handler.next);
+      if (t.code !== 0) {
+        blockReason = `Could not transition to ${handler.next}:\n${t.out}`;
+      } else {
+        advanced = true;
+        phase = handler.next;
+      }
+    }
+  } else if (Array.isArray(verdict.errors) && verdict.errors.length > 0) {
+    blockReason = verdict.errors.join('\n');
+  }
+
+  const header = [
+    `pr-review-next: ${ticket}`,
+    `  tasks dir: ${tasksDir}`,
+    `  current phase (after this run): ${phase}`,
+    `  memory plugin: ${memory ? memory.name : '(none detected)'}`,
+    `  linked tickets: ${linkedIds.length}${linkedIds.length ? ` (${linkedIds.join(', ')})` : ''}`,
+    advanced ? '  result: PHASE ADVANCED' : blockReason ? '  result: BLOCKED' : '  result: WAITING',
+    '',
+  ].join('\n');
+
+  const instructorPhase = getPhase(phase);
+  const instructions = instructorPhase.instructions(ctx);
+  const body =
+    blockReason && !advanced
+      ? [
+          `## ❌ Phase ${phase.toUpperCase()} blocked`,
+          '',
+          '```',
+          blockReason,
+          '```',
+          '',
+          '---',
+          '',
+          instructions,
+        ].join('\n')
+      : instructions;
+
+  process.stdout.write(`${header}\n${body}`);
+
+  const { renderNextActionFooter } = require('../lib/next-action-footer');
+  process.stdout.write(
+    renderNextActionFooter({
+      scriptName: 'pr-review-next.js',
+      ticket,
+      phase,
+      terminalPhase: 'done',
+      advanced,
+      blockReason,
+    })
+  );
+
+  const exitCode = blockReason && !advanced ? 2 : 0;
+  logNextScriptEvent('pr-review-next', {
+    event: 'completed',
+    ticket,
+    phase,
+    advanced,
+    blocked: Boolean(blockReason),
+    blockReason: blockReason ? blockReason.slice(0, 500) : null,
+    linkedTickets: linkedIds.length,
+    memoryPlugin: memory ? memory.name : null,
+    exitCode,
+    durationMs: Date.now() - startedAt,
+  });
+  process.exit(exitCode);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv);
+  } catch (e) {
+    die(e.message || String(e));
+  }
+}
+
+module.exports = { detectMemoryPlugin };

--- a/scripts/workflows/work-pr-reviewer/pr-review-phase-registry.js
+++ b/scripts/workflows/work-pr-reviewer/pr-review-phase-registry.js
@@ -1,0 +1,73 @@
+/**
+ * pr-review-phase-registry.js
+ *
+ * Central registry for pr-reviewer phase definitions. Mirrors
+ * work-spec/spec-phase-registry.js.
+ *
+ * Phases (linear):
+ *   inputs → pr_context → diff_audit → standards_audit →
+ *   kind_checks → review_post → memorize → done
+ *
+ * `done` is terminal.
+ */
+
+'use strict';
+
+const PR_REVIEW_PHASES = Object.freeze({
+  inputs: 'inputs',
+  pr_context: 'pr_context',
+  diff_audit: 'diff_audit',
+  standards_audit: 'standards_audit',
+  kind_checks: 'kind_checks',
+  review_post: 'review_post',
+  memorize: 'memorize',
+  done: 'done',
+});
+
+const PR_REVIEW_PHASE_ORDER = Object.freeze([
+  PR_REVIEW_PHASES.inputs,
+  PR_REVIEW_PHASES.pr_context,
+  PR_REVIEW_PHASES.diff_audit,
+  PR_REVIEW_PHASES.standards_audit,
+  PR_REVIEW_PHASES.kind_checks,
+  PR_REVIEW_PHASES.review_post,
+  PR_REVIEW_PHASES.memorize,
+  PR_REVIEW_PHASES.done,
+]);
+
+const PR_REVIEW_PHASE_TRANSITIONS = Object.freeze({
+  [PR_REVIEW_PHASES.inputs]: Object.freeze([PR_REVIEW_PHASES.pr_context]),
+  [PR_REVIEW_PHASES.pr_context]: Object.freeze([PR_REVIEW_PHASES.diff_audit]),
+  [PR_REVIEW_PHASES.diff_audit]: Object.freeze([PR_REVIEW_PHASES.standards_audit]),
+  [PR_REVIEW_PHASES.standards_audit]: Object.freeze([PR_REVIEW_PHASES.kind_checks]),
+  [PR_REVIEW_PHASES.kind_checks]: Object.freeze([PR_REVIEW_PHASES.review_post]),
+  [PR_REVIEW_PHASES.review_post]: Object.freeze([PR_REVIEW_PHASES.memorize]),
+  [PR_REVIEW_PHASES.memorize]: Object.freeze([PR_REVIEW_PHASES.done]),
+  [PR_REVIEW_PHASES.done]: Object.freeze([]),
+});
+
+function prReviewNextPhases(current) {
+  return PR_REVIEW_PHASE_TRANSITIONS[current] || [];
+}
+
+function prReviewCanTransition(current, next) {
+  return prReviewNextPhases(current).includes(next);
+}
+
+function isPrReviewPhase(phase) {
+  return Object.hasOwn(PR_REVIEW_PHASES, phase);
+}
+
+const PR_REVIEW_INITIAL_PHASE = PR_REVIEW_PHASES.inputs;
+const PR_REVIEW_TERMINAL_PHASE = PR_REVIEW_PHASES.done;
+
+module.exports = {
+  PR_REVIEW_PHASES,
+  PR_REVIEW_PHASE_ORDER,
+  PR_REVIEW_PHASE_TRANSITIONS,
+  PR_REVIEW_INITIAL_PHASE,
+  PR_REVIEW_TERMINAL_PHASE,
+  prReviewNextPhases,
+  prReviewCanTransition,
+  isPrReviewPhase,
+};

--- a/scripts/workflows/work-pr-reviewer/pr-review-phase-state.js
+++ b/scripts/workflows/work-pr-reviewer/pr-review-phase-state.js
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+/**
+ * pr-review-phase-state.js
+ *
+ * Authorized writer for `tasks/<ticket>/pr-review-phase.json`. Mirrors
+ * code-phase-state.js. Only callable through Claude Code's agent system
+ * (token-protected), and only by the pr-reviewer agent.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { consumeToken } = require('../lib/scripts/write-report');
+const { normalizeAgentName } = require('../lib/agent-detection');
+const {
+  PR_REVIEW_PHASE_ORDER,
+  PR_REVIEW_INITIAL_PHASE,
+  prReviewNextPhases,
+  prReviewCanTransition,
+  isPrReviewPhase,
+} = require('./pr-review-phase-registry');
+
+let config;
+try {
+  config = require('../lib/config');
+} catch (e) {
+  if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
+  config = null;
+}
+
+const ALLOWED_AGENTS = ['pr-reviewer'];
+const GATED_SUBCOMMANDS = ['init', 'record', 'transition'];
+const TOKEN_MAX_AGE_MS = 10_000;
+
+const PHASES = PR_REVIEW_PHASE_ORDER;
+
+function errorExit(message) {
+  process.stderr.write(`${JSON.stringify({ error: true, message })}\n`);
+  process.exit(1);
+}
+
+function successOut(data) {
+  process.stdout.write(`${JSON.stringify(data)}\n`);
+}
+
+function sanitizeId(ticketId) {
+  try {
+    return require('../lib/config').safeTicketId(ticketId);
+  } catch (e) {
+    if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
+    return ticketId;
+  }
+}
+
+function resolveTasksBase() {
+  return (
+    process.env.TASKS_BASE ||
+    (config && config.TASKS_BASE) ||
+    path.join(require('node:os').homedir(), 'worktrees', 'tasks')
+  );
+}
+
+function getStatePath(ticketId) {
+  if (!ticketId || /\.\.|[\\:\x00]/.test(ticketId)) {
+    throw new Error(`Invalid ticket ID: ${ticketId}`);
+  }
+  const base = path.resolve(resolveTasksBase());
+  const safeId = sanitizeId(ticketId);
+  const resolved = path.resolve(base, safeId, 'pr-review-phase.json');
+  if (!resolved.startsWith(base + path.sep)) {
+    throw new Error(`Invalid ticket ID: ${ticketId}`);
+  }
+  return resolved;
+}
+
+function readState(ticketId) {
+  const p = getStatePath(ticketId);
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function writeState(ticketId, state) {
+  const p = getStatePath(ticketId);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+  try {
+    fs.unlinkSync(p);
+  } catch (e) {
+    if (e && e.code !== 'ENOENT') throw e;
+  }
+  fs.renameSync(tmp, p);
+}
+
+function verifyToken(expectedTicketId) {
+  const scriptBasename = path.basename(__filename);
+  const token = consumeToken(scriptBasename, expectedTicketId);
+  if (!token) {
+    errorExit(
+      "No valid write token found. This script can only be called through Claude Code's agent system."
+    );
+  }
+  if (typeof token.timestamp !== 'number' || !Number.isFinite(token.timestamp)) {
+    errorExit('Token has invalid or missing timestamp.');
+  }
+  if (typeof token.agent !== 'string' || !token.agent) {
+    errorExit('Token has invalid or missing agent field.');
+  }
+  const age = Date.now() - token.timestamp;
+  if (age < 0) errorExit(`Write token timestamp is in the future (${Math.abs(age)}ms ahead).`);
+  if (age > TOKEN_MAX_AGE_MS)
+    errorExit(`Write token expired (${age}ms old, max ${TOKEN_MAX_AGE_MS}ms).`);
+  const agentNormalized = normalizeAgentName(token.agent);
+  if (!ALLOWED_AGENTS.includes(agentNormalized)) {
+    errorExit(
+      `Agent "${token.agent}" is not authorized. Allowed agents: ${ALLOWED_AGENTS.join(', ')}.`
+    );
+  }
+  return token;
+}
+
+function parseFlag(args, name) {
+  const i = args.indexOf(name);
+  if (i === -1 || i + 1 >= args.length) return null;
+  return args[i + 1];
+}
+
+function cmdInit(ticket) {
+  const existing = readState(ticket);
+  if (existing) {
+    successOut({ ok: true, status: 'exists', state: existing });
+    return;
+  }
+  const now = new Date().toISOString();
+  const state = {
+    ticket,
+    createdAt: now,
+    updatedAt: now,
+    currentPhase: PR_REVIEW_INITIAL_PHASE,
+    phases: {},
+  };
+  writeState(ticket, state);
+  successOut({ ok: true, status: 'created', state });
+}
+
+function cmdCurrent(ticket) {
+  const state = readState(ticket);
+  if (!state) {
+    successOut({ ok: true, currentPhase: null, state: null });
+    return;
+  }
+  successOut({ ok: true, currentPhase: state.currentPhase, state });
+}
+
+function cmdRecord(ticket, phase, args) {
+  if (!isPrReviewPhase(phase)) {
+    errorExit(`Unknown phase "${phase}". Valid: ${PR_REVIEW_PHASE_ORDER.join(', ')}.`);
+  }
+  const state = readState(ticket);
+  if (!state) errorExit(`No pr-review-phase state for ${ticket}. Run \`init\` first.`);
+  const summary = parseFlag(args, '--summary') || '';
+  const now = new Date().toISOString();
+  state.phases[phase] = { completedAt: now, summary };
+  state.updatedAt = now;
+  writeState(ticket, state);
+  successOut({ ok: true, recordedPhase: phase, state });
+}
+
+function cmdTransition(ticket, target) {
+  if (!isPrReviewPhase(target)) {
+    errorExit(`Unknown target phase "${target}". Valid: ${PR_REVIEW_PHASE_ORDER.join(', ')}.`);
+  }
+  const state = readState(ticket);
+  if (!state) errorExit(`No pr-review-phase state for ${ticket}. Run \`init\` first.`);
+  if (!prReviewCanTransition(state.currentPhase, target)) {
+    const allowed = prReviewNextPhases(state.currentPhase);
+    errorExit(
+      `Invalid transition ${state.currentPhase} → ${target}. Allowed from ${state.currentPhase}: ${
+        allowed.length ? allowed.join(', ') : '(terminal)'
+      }.`
+    );
+  }
+  if (!state.phases[state.currentPhase]) {
+    errorExit(
+      `Cannot transition: phase "${state.currentPhase}" has no recorded evidence. Run \`record ${ticket} ${state.currentPhase}\` first.`
+    );
+  }
+  const now = new Date().toISOString();
+  state.currentPhase = target;
+  state.updatedAt = now;
+  writeState(ticket, state);
+  successOut({ ok: true, currentPhase: target, state });
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  const sub = args[0];
+  if (!sub) {
+    errorExit('Usage: pr-review-phase-state.js <init|current|record|transition> <TICKET> [args]');
+  }
+  const ticket = args[1];
+  if (!ticket) errorExit('Missing ticket ID.');
+
+  if (GATED_SUBCOMMANDS.includes(sub)) verifyToken(ticket);
+
+  if (sub === 'init') return cmdInit(ticket);
+  if (sub === 'current') return cmdCurrent(ticket);
+  if (sub === 'record') {
+    const phase = args[2];
+    if (!phase)
+      errorExit('Usage: pr-review-phase-state.js record <TICKET> <phase> [--summary "..."]');
+    return cmdRecord(ticket, phase, args.slice(3));
+  }
+  if (sub === 'transition') {
+    const target = args[2];
+    if (!target) errorExit('Usage: pr-review-phase-state.js transition <TICKET> <target>');
+    return cmdTransition(ticket, target);
+  }
+  errorExit(`Unknown subcommand: ${sub}`);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv);
+  } catch (e) {
+    errorExit(e.message);
+  }
+}
+
+module.exports = { PHASES, prReviewCanTransition, prReviewNextPhases };

--- a/scripts/workflows/work-qa-feature-tester/__tests__/kind-checks.test.js
+++ b/scripts/workflows/work-qa-feature-tester/__tests__/kind-checks.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { getKindCheckRegistry } = require('../lib/kind-checks/kind-registry');
+const frontend = require('../lib/kind-checks/frontend');
+const backend = require('../lib/kind-checks/backend');
+
+function makeTasksDir({ tasks = '', qaReport = '' } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'qa-kind-'));
+  const tasksDir = path.join(root, 'ECHO-7777');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  if (tasks) fs.writeFileSync(path.join(tasksDir, 'tasks.md'), tasks);
+  if (qaReport) fs.writeFileSync(path.join(tasksDir, 'qa-feature.check.md'), qaReport);
+  return { root, tasksDir };
+}
+
+test('kind-registry exposes all six kinds', () => {
+  const r = getKindCheckRegistry();
+  for (const k of ['frontend', 'backend', 'wiring', 'e2e', 'devops', 'fullstack']) {
+    assert.ok(r[k]);
+    assert.equal(typeof r[k].appliesTo, 'function');
+    assert.equal(typeof r[k].validate, 'function');
+  }
+});
+
+test('frontend BLOCKS when QA section missing', () => {
+  const { root, tasksDir } = makeTasksDir({
+    tasks: '<!-- frontend -->',
+    qaReport: '# QA\n\nNo kind sections here.\n',
+  });
+  const r = frontend.validate({ tasksDir });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('Frontend QA'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('frontend passes when all checklist items checked', () => {
+  const { root, tasksDir } = makeTasksDir({
+    tasks: '<!-- frontend -->',
+    qaReport: [
+      '# QA',
+      '',
+      '### Frontend QA',
+      '- [x] Loading state shown',
+      '- [x] Empty state shown',
+      '- [x] Error state shown',
+      '- [x] Success state shown',
+      '',
+    ].join('\n'),
+  });
+  const r = frontend.validate({ tasksDir });
+  assert.equal(r.ok, true, `errors: ${JSON.stringify(r.errors)}`);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('frontend BLOCKS when checklist has unchecked items', () => {
+  const { root, tasksDir } = makeTasksDir({
+    tasks: '<!-- frontend -->',
+    qaReport: ['### Frontend QA', '- [x] Loading state shown', '- [ ] Empty state shown', ''].join(
+      '\n'
+    ),
+  });
+  const r = frontend.validate({ tasksDir });
+  assert.equal(r.ok, false);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('backend BLOCKS when Backend QA section missing', () => {
+  const { root, tasksDir } = makeTasksDir({
+    tasks: '<!-- backend -->',
+    qaReport: '# QA\n\nNothing here.\n',
+  });
+  const r = backend.validate({ tasksDir });
+  assert.equal(r.ok, false);
+  fs.rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/workflows/work-qa-feature-tester/__tests__/phase-registry.test.js
+++ b/scripts/workflows/work-qa-feature-tester/__tests__/phase-registry.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getPhase, hasPhase } = require('../lib/phase-registry');
+const { QA_PHASE_ORDER } = require('../qa-phase-registry');
+
+test('dispatcher registers every declared phase', () => {
+  for (const p of QA_PHASE_ORDER) assert.equal(hasPhase(p), true);
+});
+
+test('every phase exposes validate() and instructions()', () => {
+  for (const p of QA_PHASE_ORDER) {
+    const h = getPhase(p);
+    assert.equal(typeof h.validate, 'function');
+    assert.equal(typeof h.instructions, 'function');
+  }
+});
+
+test('non-terminal phases have string `next`; done has null', () => {
+  for (const p of QA_PHASE_ORDER) {
+    const h = getPhase(p);
+    if (p === 'done') assert.equal(h.next, null);
+    else assert.equal(typeof h.next, 'string');
+  }
+});
+
+test('getPhase throws on unknown name', () => {
+  assert.throws(() => getPhase('made-up'), /No qa phase handler registered/);
+});

--- a/scripts/workflows/work-qa-feature-tester/__tests__/qa-phase-registry.test.js
+++ b/scripts/workflows/work-qa-feature-tester/__tests__/qa-phase-registry.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  QA_PHASES,
+  QA_PHASE_ORDER,
+  QA_PHASE_TRANSITIONS,
+  QA_INITIAL_PHASE,
+  QA_TERMINAL_PHASE,
+  qaNextPhases,
+  qaCanTransition,
+  isQaPhase,
+} = require('../qa-phase-registry');
+
+test('QA_PHASE_ORDER lists 9 phases in declared order', () => {
+  assert.deepEqual(QA_PHASE_ORDER, [
+    'inputs',
+    'env_setup',
+    'smoke',
+    'feature',
+    'kind_checks',
+    'screenshot',
+    'report',
+    'memorize',
+    'done',
+  ]);
+});
+
+test('initial is inputs, terminal is done', () => {
+  assert.equal(QA_INITIAL_PHASE, 'inputs');
+  assert.equal(QA_TERMINAL_PHASE, 'done');
+});
+
+test('every non-terminal phase advances to the next in order', () => {
+  for (let i = 0; i < QA_PHASE_ORDER.length - 1; i++) {
+    const cur = QA_PHASE_ORDER[i];
+    const nxt = QA_PHASE_ORDER[i + 1];
+    assert.ok(qaCanTransition(cur, nxt));
+    assert.deepEqual(qaNextPhases(cur), [nxt]);
+  }
+});
+
+test('done is terminal', () => {
+  assert.deepEqual(QA_PHASE_TRANSITIONS.done, []);
+});
+
+test('rejects backwards/skipping', () => {
+  assert.equal(qaCanTransition('feature', 'inputs'), false);
+  assert.equal(qaCanTransition('inputs', 'feature'), false);
+});
+
+test('isQaPhase recognizes valid phases', () => {
+  for (const p of QA_PHASE_ORDER) assert.equal(isQaPhase(p), true);
+  assert.equal(isQaPhase('made-up'), false);
+});
+
+test('QA_PHASES frozen', () => {
+  assert.throws(() => {
+    QA_PHASES.bogus = 'x';
+  });
+});

--- a/scripts/workflows/work-qa-feature-tester/lib/kind-checks/backend.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/kind-checks/backend.js
@@ -1,0 +1,56 @@
+/**
+ * Kind: backend — QA verification for API / data-layer work.
+ *
+ * Looks for "### Backend QA" section with happy-path + error-path tests,
+ * each citing the API endpoint and the HTTP response status.
+ */
+
+'use strict';
+
+const { readQaReport, hasKindSection, checklistStats, detectKinds } = require('./shared');
+
+function appliesTo(ctx) {
+  const k = detectKinds(ctx.tasksDir);
+  return k.includes('backend') || k.includes('fullstack');
+}
+
+function validate(ctx) {
+  const report = readQaReport(ctx.tasksDir);
+  const errors = [];
+  const warnings = [];
+  if (!hasKindSection(report, 'Backend')) {
+    errors.push(
+      'qa-feature.check.md missing `### Backend QA` section. Add checklist items for happy path + at least one error response, with the curl command and HTTP status code cited.'
+    );
+    return {
+      ok: false,
+      errors,
+      summary: 'no Backend QA section',
+    };
+  }
+  const stats = checklistStats(report, 'Backend');
+  if (stats.checked < stats.total) {
+    errors.push(
+      `Backend QA: ${stats.checked}/${stats.total} items checked. Run each curl/request and confirm the response.`
+    );
+  }
+  // Cheap signal: at least one HTTP status code mentioned (2xx/4xx/5xx).
+  if (!/\b[2345]\d{2}\b/.test(report)) {
+    warnings.push(
+      'Backend QA report mentions no HTTP status codes (2xx/4xx/5xx). Verify responses were actually inspected.'
+    );
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `Backend QA: ${stats.checked}/${stats.total} checked`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('backend', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-qa-feature-tester/lib/kind-checks/devops.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/kind-checks/devops.js
@@ -1,0 +1,49 @@
+/**
+ * Kind: devops — QA verification for infra / CI work.
+ *
+ * For devops, the agent should have triggered the workflow / run the
+ * deployment / exercised the script. Looks for "### DevOps QA" with
+ * either a CI run URL or a local script-run record.
+ */
+
+'use strict';
+
+const { readQaReport, hasKindSection, checklistStats, detectKinds } = require('./shared');
+
+function appliesTo(ctx) {
+  return detectKinds(ctx.tasksDir).includes('devops');
+}
+
+function validate(ctx) {
+  const report = readQaReport(ctx.tasksDir);
+  const errors = [];
+  const warnings = [];
+  if (!hasKindSection(report, 'DevOps')) {
+    errors.push(
+      'qa-feature.check.md missing `### DevOps QA` section. Add it with the workflow trigger / script run + result.'
+    );
+    return { ok: false, errors, summary: 'no DevOps QA section' };
+  }
+  const stats = checklistStats(report, 'DevOps');
+  if (stats.checked < stats.total) {
+    errors.push(`DevOps QA: ${stats.checked}/${stats.total} items checked.`);
+  }
+  if (!/(github\.com\/.+\/actions\/runs\/\d+|\$\s|exit\s+(code\s+)?0)/i.test(report)) {
+    warnings.push(
+      'DevOps QA report has no CI run URL nor visible command/exit-code evidence. Confirm the workflow actually executed.'
+    );
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `DevOps QA: ${stats.checked}/${stats.total} checked`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('devops', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-qa-feature-tester/lib/kind-checks/e2e.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/kind-checks/e2e.js
@@ -1,0 +1,49 @@
+/**
+ * Kind: e2e — QA verification for end-to-end Playwright work.
+ *
+ * For e2e, the QA agent should have RUN the playwright spec (not just
+ * read it). Looks for "### E2E QA" section with a passing test run
+ * record (e.g. "1 passed" / "tests passed" / exit code).
+ */
+
+'use strict';
+
+const { readQaReport, hasKindSection, checklistStats, detectKinds } = require('./shared');
+
+function appliesTo(ctx) {
+  return detectKinds(ctx.tasksDir).includes('e2e');
+}
+
+function validate(ctx) {
+  const report = readQaReport(ctx.tasksDir);
+  const errors = [];
+  const warnings = [];
+  if (!hasKindSection(report, 'E2E')) {
+    errors.push(
+      'qa-feature.check.md missing `### E2E QA` section. Add it with the playwright command run + passing-test confirmation.'
+    );
+    return { ok: false, errors, summary: 'no E2E QA section' };
+  }
+  const stats = checklistStats(report, 'E2E');
+  if (stats.checked < stats.total) {
+    errors.push(`E2E QA: ${stats.checked}/${stats.total} items checked.`);
+  }
+  if (!/passed|✓|pass\b/i.test(report)) {
+    warnings.push(
+      'E2E QA report contains no "passed" / "✓" evidence. Confirm the playwright run actually succeeded.'
+    );
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `E2E QA: ${stats.checked}/${stats.total} checked`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('e2e', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-qa-feature-tester/lib/kind-checks/frontend.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/kind-checks/frontend.js
@@ -1,0 +1,64 @@
+/**
+ * Kind: frontend — QA verification for UI work.
+ *
+ * Verifies the report has a "### Frontend QA" section with completed
+ * checklist items covering UI states (loading / empty / error / success).
+ */
+
+'use strict';
+
+const { readQaReport, hasKindSection, checklistStats, detectKinds } = require('./shared');
+
+const REQUIRED_STATES = ['loading', 'empty', 'error', 'success'];
+
+function appliesTo(ctx) {
+  const k = detectKinds(ctx.tasksDir);
+  return k.includes('frontend') || k.includes('fullstack');
+}
+
+function validate(ctx) {
+  const report = readQaReport(ctx.tasksDir);
+  const errors = [];
+  const warnings = [];
+  if (!hasKindSection(report, 'Frontend')) {
+    errors.push(
+      'qa-feature.check.md missing `### Frontend QA` section. Add it with checklist items for loading/empty/error/success states.'
+    );
+    return {
+      ok: false,
+      errors,
+      summary: 'no Frontend QA section',
+    };
+  }
+  const stats = checklistStats(report, 'Frontend');
+  if (stats.total < REQUIRED_STATES.length) {
+    warnings.push(
+      `Frontend QA section has only ${stats.total} checklist item(s); expected at least ${REQUIRED_STATES.length} (one per UI state).`
+    );
+  }
+  if (stats.checked < stats.total) {
+    errors.push(
+      `Frontend QA: ${stats.checked}/${stats.total} items checked. Drive each state in the browser and check the box.`
+    );
+  }
+  const reportLower = report.toLowerCase();
+  for (const s of REQUIRED_STATES) {
+    if (!reportLower.includes(s)) {
+      warnings.push(`Frontend QA report does not mention "${s}" state — verify it was exercised.`);
+    }
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `Frontend QA: ${stats.checked}/${stats.total} checked`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('frontend', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;
+module.exports.REQUIRED_STATES = REQUIRED_STATES;

--- a/scripts/workflows/work-qa-feature-tester/lib/kind-checks/fullstack.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/kind-checks/fullstack.js
@@ -1,0 +1,43 @@
+/**
+ * Kind: fullstack — runs both frontend + backend QA validators and
+ * additionally requires the report to mention the request hitting the
+ * backend (network tab evidence) so we know the wire was actually used.
+ */
+
+'use strict';
+
+const frontend = require('./frontend');
+const backend = require('./backend');
+const { readQaReport, detectKinds } = require('./shared');
+
+function appliesTo(ctx) {
+  return detectKinds(ctx.tasksDir).includes('fullstack');
+}
+
+function validate(ctx) {
+  const fr = frontend.validate(ctx);
+  const be = backend.validate(ctx);
+  const errors = [...(fr.errors || []), ...(be.errors || [])];
+  const warnings = [...(fr.warnings || []), ...(be.warnings || [])];
+
+  const report = readQaReport(ctx.tasksDir);
+  if (report && !/network|XHR|fetch|trpc|api\//i.test(report)) {
+    warnings.push(
+      'Fullstack QA report contains no network/fetch/API evidence. Verify the UI actually called the backend (network tab or curl).'
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `fullstack QA: ${fr.summary || 'frontend ok'} | ${be.summary || 'backend ok'}`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('fullstack', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-qa-feature-tester/lib/kind-checks/kind-registry.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/kind-checks/kind-registry.js
@@ -1,0 +1,32 @@
+/**
+ * Kind-check registry for qa-feature-tester. Mirrors
+ * work-spec/lib/kind-checks/kind-registry.js.
+ */
+
+'use strict';
+
+const registry = Object.create(null);
+
+function registerKind(name, handler) {
+  if (
+    !handler ||
+    typeof handler.appliesTo !== 'function' ||
+    typeof handler.validate !== 'function'
+  ) {
+    throw new Error(`Invalid kind handler for "${name}" — must expose appliesTo() and validate()`);
+  }
+  registry[name] = handler;
+}
+
+function getKindCheckRegistry() {
+  return registry;
+}
+
+require('./frontend')(registerKind);
+require('./backend')(registerKind);
+require('./wiring')(registerKind);
+require('./e2e')(registerKind);
+require('./devops')(registerKind);
+require('./fullstack')(registerKind);
+
+module.exports = { registerKind, getKindCheckRegistry };

--- a/scripts/workflows/work-qa-feature-tester/lib/kind-checks/shared.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/kind-checks/shared.js
@@ -1,0 +1,68 @@
+/**
+ * Shared helpers for qa-feature-tester kind-check modules.
+ *
+ * QA differs from code-checker / completion-checker: the agent is browser-
+ * driving (Playwright / claude-in-chrome) and the validators look for
+ * recorded test evidence in a `qa-feature.check.md` artifact rather than
+ * grepping source files.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const specShared = require('../../../work-spec/lib/kind-checks/shared');
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/** Read the agent-produced QA report; empty string if absent. */
+function readQaReport(tasksDir) {
+  return readFile(path.join(tasksDir, 'qa-feature.check.md')) || '';
+}
+
+/** Per-kind section header — e.g. `### Frontend QA`. */
+function hasKindSection(reportText, kindLabel) {
+  if (!reportText) return false;
+  return new RegExp(`^###\\s+${kindLabel}\\s+QA\\b`, 'im').test(reportText);
+}
+
+/** Extract checklist items from a kind section. Returns { total, checked }. */
+function checklistStats(reportText, kindLabel) {
+  if (!reportText) return { total: 0, checked: 0 };
+  const re = new RegExp(
+    `^###\\s+${kindLabel}\\s+QA\\b([\\s\\S]*?)(?=\\n###\\s|\\n##\\s|$(?![\\s\\S]))`,
+    'im'
+  );
+  const m = reportText.match(re);
+  if (!m) return { total: 0, checked: 0 };
+  const block = m[1];
+  const items = block.match(/^- \[[ xX]\]/gm) || [];
+  const checked = block.match(/^- \[[xX]\]/gm) || [];
+  return { total: items.length, checked: checked.length };
+}
+
+module.exports = {
+  readFile,
+  readQaReport,
+  hasKindSection,
+  checklistStats,
+  // Re-exports from spec-side shared:
+  readBrief: specShared.readBrief,
+  readSpec: specShared.readSpec,
+  readTasks: specShared.readTasks,
+  sliceSection: specShared.sliceSection,
+  detectKinds: specShared.detectKinds,
+  briefForbidsBackend: specShared.briefForbidsBackend,
+  isBackendFile: specShared.isBackendFile,
+  isFrontendFile: specShared.isFrontendFile,
+  isE2eFile: specShared.isE2eFile,
+  isDevopsFile: specShared.isDevopsFile,
+  KIND_NAMES: specShared.KIND_NAMES,
+};

--- a/scripts/workflows/work-qa-feature-tester/lib/kind-checks/wiring.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/kind-checks/wiring.js
@@ -1,0 +1,54 @@
+/**
+ * Kind: wiring — QA verification for "connect-existing-pieces" tickets.
+ *
+ * For wiring, the test should verify the integration: data flows end-to-end
+ * from the source (sibling API) to the consumer (UI) without breaking
+ * either side.
+ */
+
+'use strict';
+
+const {
+  readQaReport,
+  hasKindSection,
+  checklistStats,
+  briefForbidsBackend,
+  readBrief,
+  detectKinds,
+} = require('./shared');
+
+function appliesTo(ctx) {
+  const k = detectKinds(ctx.tasksDir);
+  if (k.includes('wiring')) return true;
+  const brief = readBrief(ctx.tasksDir);
+  return briefForbidsBackend(brief) && k.length === 0;
+}
+
+function validate(ctx) {
+  const report = readQaReport(ctx.tasksDir);
+  const errors = [];
+  if (!hasKindSection(report, 'Wiring')) {
+    errors.push(
+      'qa-feature.check.md missing `### Wiring QA` section. Add checklist items verifying data flows end-to-end (sibling API → consumer UI) without modifying sibling-owned code.'
+    );
+    return { ok: false, errors, summary: 'no Wiring QA section' };
+  }
+  const stats = checklistStats(report, 'Wiring');
+  if (stats.checked < stats.total) {
+    errors.push(
+      `Wiring QA: ${stats.checked}/${stats.total} items checked. Confirm each integration point in the browser/network tab.`
+    );
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    summary: `Wiring QA: ${stats.checked}/${stats.total} checked`,
+  };
+}
+
+module.exports = function register(registerKind) {
+  registerKind('wiring', { appliesTo, validate });
+};
+
+module.exports.appliesTo = appliesTo;
+module.exports.validate = validate;

--- a/scripts/workflows/work-qa-feature-tester/lib/memory-plugin-config.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/memory-plugin-config.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../../work-brief/lib/memory-plugin-config');

--- a/scripts/workflows/work-qa-feature-tester/lib/phase-registry.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phase-registry.js
@@ -1,0 +1,42 @@
+/**
+ * QA-feature-tester phase dispatcher. Mirrors work-spec/lib/phase-registry.js.
+ */
+
+'use strict';
+
+const handlers = Object.create(null);
+
+function registerPhase(phaseName, handler) {
+  if (
+    !handler ||
+    typeof handler.validate !== 'function' ||
+    typeof handler.instructions !== 'function'
+  ) {
+    throw new Error(
+      `Invalid phase handler for "${phaseName}" — must expose validate() and instructions()`
+    );
+  }
+  handlers[phaseName] = handler;
+}
+
+function getPhase(phaseName) {
+  const h = handlers[phaseName];
+  if (!h) throw new Error(`No qa phase handler registered for "${phaseName}"`);
+  return h;
+}
+
+function hasPhase(phaseName) {
+  return Boolean(handlers[phaseName]);
+}
+
+require('./phases/inputs')(registerPhase);
+require('./phases/env_setup')(registerPhase);
+require('./phases/smoke')(registerPhase);
+require('./phases/feature')(registerPhase);
+require('./phases/kind_checks')(registerPhase);
+require('./phases/screenshot')(registerPhase);
+require('./phases/report')(registerPhase);
+require('./phases/memorize')(registerPhase);
+require('./phases/done')(registerPhase);
+
+module.exports = { registerPhase, getPhase, hasPhase };

--- a/scripts/workflows/work-qa-feature-tester/lib/phases/done.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phases/done.js
@@ -1,0 +1,32 @@
+/**
+ * Phase: done — terminal.
+ */
+
+'use strict';
+
+const { QA_PHASES } = require('../../qa-phase-registry');
+
+function validate() {
+  return { ok: true, summary: 'qa-feature-tester terminal phase' };
+}
+
+function instructions(ctx) {
+  return [
+    '# qa-next — Phase 9 of 9: DONE',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'All QA phases passed. Return your final qa-feature.check.md to the orchestrator.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(QA_PHASES.done, {
+    next: null,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;

--- a/scripts/workflows/work-qa-feature-tester/lib/phases/env_setup.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phases/env_setup.js
@@ -1,0 +1,60 @@
+/**
+ * Phase: env_setup — confirm the dev environment is ready for QA.
+ *
+ * Gate is on a sentinel `.qa-env-ready` written by the agent after they:
+ *  - confirmed the dev server is reachable (curl / browser nav)
+ *  - confirmed test data is seeded (if applicable)
+ *  - opened a browser tab via claude-in-chrome / playwright
+ *
+ * The agent writes the sentinel themselves — we don't try to detect a
+ * running server from inside this script.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { QA_PHASES } = require('../../qa-phase-registry');
+
+const SENTINEL = '.qa-env-ready';
+
+function validate(ctx) {
+  const p = path.join(ctx.tasksDir, SENTINEL);
+  if (!fs.existsSync(p)) {
+    return {
+      ok: false,
+      errors: [
+        `Missing \`${SENTINEL}\`. Start the dev server, open the feature in a browser, seed test data if needed, then \`touch ${p}\`.`,
+      ],
+    };
+  }
+  return { ok: true, summary: 'environment confirmed ready' };
+}
+
+function instructions(ctx) {
+  return [
+    '# qa-next — Phase 2 of 9: ENV SETUP',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    '### What you do',
+    '1. Start the dev server in a tmux session (per the global tmux rules — use the branch name).',
+    '2. Confirm the URL responds (curl or browser).',
+    '3. If the feature needs test data, seed it now.',
+    '4. Open the feature in claude-in-chrome (or Playwright) and confirm the page loads.',
+    `5. \`touch ${path.join(ctx.tasksDir, SENTINEL)}\` to advance.`,
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(QA_PHASES.env_setup, {
+    next: QA_PHASES.smoke,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.SENTINEL = SENTINEL;

--- a/scripts/workflows/work-qa-feature-tester/lib/phases/feature.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phases/feature.js
@@ -1,0 +1,92 @@
+/**
+ * Phase: feature — verify the agent has tested every P0 acceptance
+ * criterion from tasks.md. Gate: `## Feature tests` section exists and
+ * has at least one checked item per task's Acceptance Criteria block.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { QA_PHASES } = require('../../qa-phase-registry');
+const { readTasks } = require('../kind-checks/shared');
+
+const SECTION_HEADER = '## Feature tests';
+
+function countAcceptanceCriteria(tasksText) {
+  if (!tasksText) return 0;
+  // Crude: count `### Acceptance Criteria` headings, each represents one task.
+  const matches = tasksText.match(/^###\s+Acceptance Criteria\b/gim) || [];
+  return matches.length;
+}
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function validate(ctx) {
+  const report = readFile(path.join(ctx.tasksDir, 'qa-feature.check.md'));
+  if (!report || !report.includes(SECTION_HEADER)) {
+    return {
+      ok: false,
+      errors: [
+        `qa-feature.check.md missing \`${SECTION_HEADER}\` section. Add a checklist covering each P0 acceptance criterion from tasks.md.`,
+      ],
+    };
+  }
+  const idx = report.indexOf(SECTION_HEADER);
+  const after = report.slice(idx + SECTION_HEADER.length);
+  const next = after.match(/^##\s/m);
+  const block = next ? after.slice(0, next.index) : after;
+  const checked = (block.match(/^- \[[xX]\]/gm) || []).length;
+  const total = (block.match(/^- \[[ xX]\]/gm) || []).length;
+
+  const expected = countAcceptanceCriteria(readTasks(ctx.tasksDir));
+  const errors = [];
+  const warnings = [];
+  if (total === 0) {
+    errors.push(`\`${SECTION_HEADER}\` has no checklist items.`);
+  } else if (checked < total) {
+    errors.push(`Feature tests: ${checked}/${total} items checked.`);
+  }
+  if (expected && total < expected) {
+    warnings.push(
+      `tasks.md has ${expected} acceptance-criteria block(s) but the feature checklist has only ${total} item(s). Add coverage for the gap.`
+    );
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: `Feature: ${checked}/${total} checked${expected ? ` (${expected} expected)` : ''}`,
+  };
+}
+
+function instructions(ctx) {
+  return [
+    '# qa-next — Phase 4 of 9: FEATURE',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    `Under \`${SECTION_HEADER}\` in qa-feature.check.md, add a checklist that maps to every Acceptance Criteria block in tasks.md. Drive each one in the browser and check the box only after verifying.`,
+    '',
+    'Skip nothing — partial verification is not verification.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(QA_PHASES.feature, {
+    next: QA_PHASES.kind_checks,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.SECTION_HEADER = SECTION_HEADER;

--- a/scripts/workflows/work-qa-feature-tester/lib/phases/inputs.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phases/inputs.js
@@ -1,0 +1,52 @@
+/**
+ * Phase: inputs — confirm planning artifacts exist before launching QA.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { QA_PHASES } = require('../../qa-phase-registry');
+
+function validate(ctx) {
+  const required = ['brief.md', 'spec.md', 'tasks.md'];
+  const missing = required.filter((f) => !fs.existsSync(path.join(ctx.tasksDir, f)));
+  if (missing.length === required.length) {
+    return {
+      ok: false,
+      errors: [
+        `No planning artifacts found in ${ctx.tasksDir}. qa-feature-tester needs at least one of: ${required.join(', ')}.`,
+      ],
+    };
+  }
+  return {
+    ok: true,
+    summary: `${required.length - missing.length}/${required.length} artifacts present`,
+  };
+}
+
+function instructions(ctx) {
+  return [
+    '# qa-next — Phase 1 of 9: INPUTS',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'I verify `brief.md`, `spec.md`, `tasks.md` exist. These tell you what to test.',
+    '',
+    `Memory plugin: ${ctx.memory ? ctx.memory.name : '(none detected)'}`,
+    '',
+    'If a memory plugin is available, recall prior QA failures for this ticket / sibling tickets before testing.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(QA_PHASES.inputs, {
+    next: QA_PHASES.env_setup,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;

--- a/scripts/workflows/work-qa-feature-tester/lib/phases/kind_checks.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phases/kind_checks.js
@@ -1,0 +1,126 @@
+/**
+ * Phase: kind_checks — fan-out per-task-kind QA validators.
+ * Mirrors work-spec/lib/phases/kind_checks.js, records into qa-feature.check.md.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { QA_PHASES } = require('../../qa-phase-registry');
+const { getKindCheckRegistry } = require('../kind-checks/kind-registry');
+
+const KIND_HEADER = '## QA kind verification';
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function renderKindBlock(results) {
+  const lines = [KIND_HEADER, ''];
+  for (const r of results) {
+    const status = r.ok ? '✓ ok' : '✗ blocking';
+    lines.push(`- **${r.kind}** — ${status}: ${r.summary || ''}`);
+    for (const w of r.warnings || []) lines.push(`  - warning: ${w}`);
+    for (const e of r.errors || []) lines.push(`  - error: ${e}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function upsertKindSection(text, block) {
+  if (!text) return block;
+  const idx = text.indexOf(KIND_HEADER);
+  if (idx === -1) return `${text.replace(/\s+$/, '')}\n\n${block}`;
+  const after = text.slice(idx + KIND_HEADER.length);
+  const nextHdr = after.match(/^##\s/m);
+  const end = nextHdr ? idx + KIND_HEADER.length + nextHdr.index : text.length;
+  return text.slice(0, idx) + block + text.slice(end);
+}
+
+function writeKindSection(tasksDir, results) {
+  const p = path.join(tasksDir, 'qa-feature.check.md');
+  const text = readFile(p);
+  const next = upsertKindSection(text, renderKindBlock(results));
+  if (next !== text) {
+    try {
+      fs.writeFileSync(p, next);
+    } catch {
+      /* hook-gated */
+    }
+  }
+}
+
+function validate(ctx) {
+  const registry = getKindCheckRegistry();
+  const matched = [];
+  for (const [kind, h] of Object.entries(registry)) {
+    let applies = false;
+    try {
+      applies = Boolean(h.appliesTo(ctx));
+    } catch {
+      applies = false;
+    }
+    if (applies) matched.push({ kind, h });
+  }
+  const results = [];
+  for (const { kind, h } of matched) {
+    let r;
+    try {
+      r = h.validate(ctx);
+    } catch (e) {
+      r = { ok: false, errors: [`kind-check "${kind}" threw: ${e.message}`] };
+    }
+    results.push({ kind, ...r });
+  }
+  if (results.length) writeKindSection(ctx.tasksDir, results);
+  const allErrors = results.flatMap((r) => (r.ok ? [] : r.errors || []));
+  if (allErrors.length) {
+    return {
+      ok: false,
+      errors: allErrors,
+      summary: `${results.filter((r) => r.ok).length}/${results.length} kinds passing`,
+    };
+  }
+  return {
+    ok: true,
+    summary: `${results.length} kind check(s) passed (${results.map((r) => r.kind).join(', ') || 'none applied'})`,
+  };
+}
+
+function instructions(ctx) {
+  return [
+    '# qa-next — Phase 5 of 9: KIND CHECKS',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    '### Per task kind',
+    '- **frontend**: `### Frontend QA` section with loading/empty/error/success checklist (all checked).',
+    '- **backend**: `### Backend QA` with happy + error responses, HTTP status codes cited.',
+    '- **wiring**: `### Wiring QA` confirming end-to-end data flow without sibling drift.',
+    '- **e2e**: `### E2E QA` with playwright command + passing-test confirmation.',
+    '- **devops**: `### DevOps QA` with workflow URL / script run + exit code 0.',
+    '- **fullstack**: frontend + backend + network/fetch evidence.',
+    '',
+    'Recorded under `## QA kind verification` in qa-feature.check.md.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(QA_PHASES.kind_checks, {
+    next: QA_PHASES.screenshot,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.renderKindBlock = renderKindBlock;
+module.exports.upsertKindSection = upsertKindSection;
+module.exports.KIND_HEADER = KIND_HEADER;

--- a/scripts/workflows/work-qa-feature-tester/lib/phases/memorize.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phases/memorize.js
@@ -18,7 +18,7 @@ function validate(ctx) {
     return {
       ok: false,
       errors: [
-        `Memory plugin "${ctx.memory.name}" available but \`${SENTINEL}\` is missing. Call \`${ctx.memory.remember}\` with the QA verdict, then \`touch ${p}\`.`,
+        `Memory plugin "${ctx.memory.name}" available but \`${SENTINEL}\` is missing. Call \`${ctx.memory.rememberTool}\` with the QA verdict, then \`touch ${p}\`.`,
       ],
     };
   }
@@ -37,7 +37,7 @@ function instructions(ctx) {
     '',
     `Memory: **${ctx.memory.name}**`,
     '',
-    `1. Call \`${ctx.memory.remember}\` with: ticket id, APPROVED/BLOCKED, key kind verdicts, any flaky scenarios.`,
+    `1. Call \`${ctx.memory.rememberTool}\` with: ticket id, APPROVED/BLOCKED, key kind verdicts, any flaky scenarios.`,
     `2. \`touch ${path.join(ctx.tasksDir, SENTINEL)}\`.`,
     '',
   ].join('\n');

--- a/scripts/workflows/work-qa-feature-tester/lib/phases/memorize.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phases/memorize.js
@@ -1,0 +1,56 @@
+/**
+ * Phase: memorize — persist QA verdict to memory plugin.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { QA_PHASES } = require('../../qa-phase-registry');
+
+const SENTINEL = '.qa-memorized';
+
+function validate(ctx) {
+  if (!ctx.memory) return { ok: true, summary: 'no memory plugin detected — skipping' };
+  const p = path.join(ctx.tasksDir, SENTINEL);
+  if (!fs.existsSync(p)) {
+    return {
+      ok: false,
+      errors: [
+        `Memory plugin "${ctx.memory.name}" available but \`${SENTINEL}\` is missing. Call \`${ctx.memory.remember}\` with the QA verdict, then \`touch ${p}\`.`,
+      ],
+    };
+  }
+  return { ok: true, summary: `memorized via ${ctx.memory.name}` };
+}
+
+function instructions(ctx) {
+  if (!ctx.memory) {
+    return ['# qa-next — Phase 8 of 9: MEMORIZE', '', 'No memory plugin — auto-advance.', ''].join(
+      '\n'
+    );
+  }
+  return [
+    '# qa-next — Phase 8 of 9: MEMORIZE',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    `Memory: **${ctx.memory.name}**`,
+    '',
+    `1. Call \`${ctx.memory.remember}\` with: ticket id, APPROVED/BLOCKED, key kind verdicts, any flaky scenarios.`,
+    `2. \`touch ${path.join(ctx.tasksDir, SENTINEL)}\`.`,
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(QA_PHASES.memorize, {
+    next: QA_PHASES.done,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.SENTINEL = SENTINEL;

--- a/scripts/workflows/work-qa-feature-tester/lib/phases/report.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phases/report.js
@@ -1,0 +1,79 @@
+/**
+ * Phase: report — verify qa-feature.check.md has the canonical structure.
+ * Final-status check: must contain `Status: APPROVED` or `Status: BLOCKED`.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { QA_PHASES } = require('../../qa-phase-registry');
+
+const REQUIRED_SECTIONS = ['Smoke test', 'Feature tests', 'QA kind verification', 'Status'];
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function validate(ctx) {
+  const p = path.join(ctx.tasksDir, 'qa-feature.check.md');
+  const text = readFile(p);
+  if (!text) return { ok: false, errors: [`Missing ${p}.`] };
+  const missing = REQUIRED_SECTIONS.filter((s) => !text.includes(s));
+  if (missing.length) {
+    return {
+      ok: false,
+      errors: [`qa-feature.check.md missing section(s): ${missing.join(', ')}.`],
+    };
+  }
+  if (!/Status:\s*(APPROVED|BLOCKED)\b/i.test(text)) {
+    return {
+      ok: false,
+      errors: [
+        'qa-feature.check.md final `Status:` line must be `APPROVED` or `BLOCKED`. Pick one based on whether all checklist items passed.',
+      ],
+    };
+  }
+  if (/Status:\s*BLOCKED/i.test(text)) {
+    return {
+      ok: false,
+      errors: [
+        'qa-feature.check.md final Status is BLOCKED. Resolve the failing items before advancing.',
+      ],
+    };
+  }
+  return { ok: true, summary: `${text.length} chars, APPROVED` };
+}
+
+function instructions(ctx) {
+  return [
+    '# qa-next — Phase 7 of 9: REPORT',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    `Finalize \`${path.join(ctx.tasksDir, 'qa-feature.check.md')}\` with sections: Smoke test, Feature tests, QA kind verification, Status. End the file with a single line:`,
+    '',
+    '```',
+    'Status: APPROVED',
+    '```',
+    '',
+    'If any kind validator blocked, write `Status: BLOCKED` instead and re-loop earlier phases.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(QA_PHASES.report, {
+    next: QA_PHASES.memorize,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.REQUIRED_SECTIONS = REQUIRED_SECTIONS;

--- a/scripts/workflows/work-qa-feature-tester/lib/phases/screenshot.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phases/screenshot.js
@@ -1,0 +1,79 @@
+/**
+ * Phase: screenshot — verify the agent captured visual evidence.
+ *
+ * Gate: at least one `.png` / `.jpg` / `.gif` file exists under
+ * `tasksDir/screenshots/` AND the report references it.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { QA_PHASES } = require('../../qa-phase-registry');
+
+function listScreenshots(tasksDir) {
+  const dir = path.join(tasksDir, 'screenshots');
+  if (!fs.existsSync(dir)) return [];
+  try {
+    return fs.readdirSync(dir).filter((f) => /\.(png|jpg|jpeg|gif|webp)$/i.test(f));
+  } catch {
+    return [];
+  }
+}
+
+function validate(ctx) {
+  const shots = listScreenshots(ctx.tasksDir);
+  const errors = [];
+  const warnings = [];
+  if (!shots.length) {
+    errors.push(
+      `No screenshot files found under \`${path.join(ctx.tasksDir, 'screenshots')}\`. Capture at least one per QA kind so pr-post-generator can attach them.`
+    );
+    return { ok: false, errors, summary: 'no screenshots' };
+  }
+  // Check the report references at least one.
+  const reportPath = path.join(ctx.tasksDir, 'qa-feature.check.md');
+  let report = '';
+  try {
+    report = fs.readFileSync(reportPath, 'utf8');
+  } catch {
+    /* ignore */
+  }
+  const referenced = shots.filter((f) => report.includes(f));
+  if (referenced.length === 0) {
+    warnings.push(
+      `Found ${shots.length} screenshot(s) but qa-feature.check.md does not reference any by filename. Add markdown image refs so they appear in the PR body.`
+    );
+  }
+  return {
+    ok: true,
+    warnings,
+    summary: `${shots.length} screenshot(s), ${referenced.length} referenced`,
+  };
+}
+
+function instructions(ctx) {
+  return [
+    '# qa-next — Phase 6 of 9: SCREENSHOT',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    `Save screenshots under \`${path.join(ctx.tasksDir, 'screenshots')}/\` and reference them by filename in qa-feature.check.md (markdown image syntax). Capture at least:`,
+    '- the happy-path success state',
+    '- one edge state (empty, error, or loading)',
+    '- any visual diff vs the spec (if you noticed one)',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(QA_PHASES.screenshot, {
+    next: QA_PHASES.report,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.listScreenshots = listScreenshots;

--- a/scripts/workflows/work-qa-feature-tester/lib/phases/smoke.js
+++ b/scripts/workflows/work-qa-feature-tester/lib/phases/smoke.js
@@ -1,0 +1,81 @@
+/**
+ * Phase: smoke — happy-path smoke section in qa-feature.check.md.
+ *
+ * Gate: report contains `## Smoke test` section with at least one checked
+ * box. Smoke just confirms the feature loads and the basic happy path
+ * works before the per-kind deep dives.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { QA_PHASES } = require('../../qa-phase-registry');
+
+const SECTION_HEADER = '## Smoke test';
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function validate(ctx) {
+  const report = readFile(path.join(ctx.tasksDir, 'qa-feature.check.md'));
+  if (!report || !report.includes(SECTION_HEADER)) {
+    return {
+      ok: false,
+      errors: [
+        `qa-feature.check.md missing \`${SECTION_HEADER}\` section. Add it with the happy-path steps you exercised.`,
+      ],
+    };
+  }
+  // Slice to next ## heading
+  const idx = report.indexOf(SECTION_HEADER);
+  const after = report.slice(idx + SECTION_HEADER.length);
+  const next = after.match(/^##\s/m);
+  const block = next ? after.slice(0, next.index) : after;
+  const checked = (block.match(/^- \[[xX]\]/gm) || []).length;
+  if (checked === 0) {
+    return {
+      ok: false,
+      errors: [
+        'Smoke test section has no `- [x]` checked items. Drive the happy path in the browser and check each step.',
+      ],
+    };
+  }
+  return { ok: true, summary: `${checked} smoke step(s) confirmed` };
+}
+
+function instructions(ctx) {
+  return [
+    '# qa-next — Phase 3 of 9: SMOKE',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'Drive the happy path in the browser. Record each step as a checklist item under',
+    `\`## Smoke test\` in \`${path.join(ctx.tasksDir, 'qa-feature.check.md')}\`. Example:`,
+    '',
+    '```',
+    '## Smoke test',
+    '- [x] Navigated to /admin/external-asset/abc',
+    '- [x] Section "Tables and Objects (3)" rendered',
+    '- [x] Selecting a row toggled the checkbox',
+    '```',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(registerPhase) {
+  registerPhase(QA_PHASES.smoke, {
+    next: QA_PHASES.feature,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.SECTION_HEADER = SECTION_HEADER;

--- a/scripts/workflows/work-qa-feature-tester/qa-next.js
+++ b/scripts/workflows/work-qa-feature-tester/qa-next.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+
+/**
+ * qa-next.js
+ *
+ * Self-paced runner for the `check` step's qa-feature-tester agent.
+ * Mirrors completion-next.js / code-next.js. Phases:
+ *   inputs → env_setup → smoke → feature → kind_checks →
+ *   screenshot → report → memorize → done
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const QA_PHASE_CLI = path.resolve(__dirname, 'qa-phase-state.js');
+
+const { QA_INITIAL_PHASE } = require('./qa-phase-registry');
+const { getPhase } = require('./lib/phase-registry');
+const { loadMemoryPluginCandidates } = require('./lib/memory-plugin-config');
+
+let logNextScriptEvent;
+try {
+  ({ logNextScriptEvent } = require('../lib/next-script-log'));
+} catch {
+  logNextScriptEvent = () => {};
+}
+
+let config;
+try {
+  config = require('../lib/config');
+} catch {
+  config = null;
+}
+
+function resolveTasksBase() {
+  return (
+    process.env.TASKS_BASE ||
+    (config && config.TASKS_BASE) ||
+    path.join(require('node:os').homedir(), 'worktrees', 'tasks')
+  );
+}
+
+function resolveWorktreeRoot() {
+  const r = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+function die(msg) {
+  process.stderr.write(`qa-next: ${msg}\n`);
+  process.exit(2);
+}
+
+let _companionTokenSnapshot = null;
+
+function snapshotCompanionToken(scriptBasename, ticketId) {
+  try {
+    const dir = process.env.CLAUDE_WRITE_TOKEN_DIR || '/tmp/.claude-write-tokens';
+    const bareTicket = ticketId ? String(ticketId).split('/')[0] : null;
+    const keyed = bareTicket ? path.join(dir, `${scriptBasename}.${bareTicket}`) : null;
+    const legacy = path.join(dir, scriptBasename);
+    const file = keyed && fs.existsSync(keyed) ? keyed : fs.existsSync(legacy) ? legacy : null;
+    if (!file) return;
+    _companionTokenSnapshot = { path: file, data: JSON.parse(fs.readFileSync(file, 'utf8')) };
+  } catch {
+    /* fail-open */
+  }
+}
+
+function mintCompanionToken() {
+  if (!_companionTokenSnapshot) return false;
+  try {
+    fs.mkdirSync(path.dirname(_companionTokenSnapshot.path), { recursive: true, mode: 0o700 });
+    const data = { ..._companionTokenSnapshot.data, timestamp: Date.now() };
+    fs.writeFileSync(_companionTokenSnapshot.path, JSON.stringify(data), { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectMemoryPlugin(env = process.env) {
+  const home = require('node:os').homedir();
+  const candidates = loadMemoryPluginCandidates(env);
+  for (const c of candidates) {
+    for (const base of c.manifestGlob) {
+      const dir = path.join(home, base);
+      if (!fs.existsSync(dir)) continue;
+      let entries;
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      if (entries.some((e) => c.probe.test(e.name))) return c;
+    }
+  }
+  return null;
+}
+
+function readRelatedManifest(tasksDir) {
+  const p = path.join(tasksDir, 'related-tickets.json');
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function listLinkedIds(manifest) {
+  if (!manifest) return [];
+  const ids = new Set();
+  if (manifest.parent && manifest.parent.id) ids.add(manifest.parent.id);
+  for (const key of ['siblings', 'blockedBy', 'dependsOn', 'relatedTo']) {
+    for (const e of manifest[key] || []) if (e && e.id) ids.add(e.id);
+  }
+  return [...ids];
+}
+
+function callPhaseCli(args) {
+  mintCompanionToken();
+  const r = spawnSync(process.execPath, [QA_PHASE_CLI, ...args], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return { code: r.status ?? -1, out: (r.stdout || '') + (r.stderr || '') };
+}
+
+function getCurrentPhase(ticket) {
+  const r = callPhaseCli(['current', ticket]);
+  if (r.code !== 0) return null;
+  try {
+    return JSON.parse(r.out.trim().split('\n').pop()).currentPhase;
+  } catch {
+    return null;
+  }
+}
+
+function ensureInit(ticket) {
+  const r = callPhaseCli(['init', ticket]);
+  if (r.code !== 0) die(`Could not init qa-phase state:\n${r.out}`);
+}
+
+function recordPhase(ticket, phase, summary) {
+  return callPhaseCli(['record', ticket, phase, '--summary', summary || '']);
+}
+
+function transitionPhase(ticket, target) {
+  return callPhaseCli(['transition', ticket, target]);
+}
+
+function main(argv) {
+  const startedAt = Date.now();
+  const args = argv.slice(2);
+  const ticket = args[0];
+  if (!ticket || /^-/.test(ticket)) {
+    process.stderr.write('usage: qa-next.js <TICKET>\n  e.g. node qa-next.js ECHO-4579\n');
+    process.exit(2);
+  }
+  logNextScriptEvent('qa-next', {
+    event: 'invoked',
+    ticket,
+    cwd: process.cwd(),
+    agent: process.env.CLAUDE_CURRENT_AGENT || null,
+  });
+
+  snapshotCompanionToken('qa-phase-state.js', ticket);
+
+  const tasksBase = resolveTasksBase();
+  const tasksDir = path.join(tasksBase, ticket);
+  if (!fs.existsSync(tasksDir)) die(`tasks dir not found: ${tasksDir}`);
+
+  const manifest = readRelatedManifest(tasksDir);
+  const linkedIds = listLinkedIds(manifest);
+  const memory = detectMemoryPlugin();
+  const worktreeRoot = resolveWorktreeRoot() || path.dirname(tasksBase);
+
+  ensureInit(ticket);
+  let phase = getCurrentPhase(ticket) || QA_INITIAL_PHASE;
+
+  const ctx = { ticket, tasksDir, tasksBase, manifest, linkedIds, memory, worktreeRoot };
+
+  const handler = getPhase(phase);
+  const verdict = handler.validate(ctx);
+
+  let advanced = false;
+  let blockReason = '';
+
+  if (verdict.ok && handler.next) {
+    const rec = recordPhase(ticket, phase, verdict.summary || '');
+    if (rec.code !== 0) {
+      blockReason = `Could not record phase ${phase}:\n${rec.out}`;
+    } else {
+      const t = transitionPhase(ticket, handler.next);
+      if (t.code !== 0) {
+        blockReason = `Could not transition to ${handler.next}:\n${t.out}`;
+      } else {
+        advanced = true;
+        phase = handler.next;
+      }
+    }
+  } else if (Array.isArray(verdict.errors) && verdict.errors.length > 0) {
+    blockReason = verdict.errors.join('\n');
+  }
+
+  const header = [
+    `qa-next: ${ticket}`,
+    `  tasks dir: ${tasksDir}`,
+    `  current phase (after this run): ${phase}`,
+    `  memory plugin: ${memory ? memory.name : '(none detected)'}`,
+    `  linked tickets: ${linkedIds.length}${linkedIds.length ? ` (${linkedIds.join(', ')})` : ''}`,
+    advanced ? '  result: PHASE ADVANCED' : blockReason ? '  result: BLOCKED' : '  result: WAITING',
+    '',
+  ].join('\n');
+
+  const instructorPhase = getPhase(phase);
+  const instructions = instructorPhase.instructions(ctx);
+  const body =
+    blockReason && !advanced
+      ? [
+          `## ❌ Phase ${phase.toUpperCase()} blocked`,
+          '',
+          '```',
+          blockReason,
+          '```',
+          '',
+          '---',
+          '',
+          instructions,
+        ].join('\n')
+      : instructions;
+
+  process.stdout.write(`${header}\n${body}`);
+
+  const { renderNextActionFooter } = require('../lib/next-action-footer');
+  process.stdout.write(
+    renderNextActionFooter({
+      scriptName: 'qa-next.js',
+      ticket,
+      phase,
+      terminalPhase: 'done',
+      advanced,
+      blockReason,
+    })
+  );
+
+  const exitCode = blockReason && !advanced ? 2 : 0;
+  logNextScriptEvent('qa-next', {
+    event: 'completed',
+    ticket,
+    phase,
+    advanced,
+    blocked: Boolean(blockReason),
+    blockReason: blockReason ? blockReason.slice(0, 500) : null,
+    linkedTickets: linkedIds.length,
+    memoryPlugin: memory ? memory.name : null,
+    exitCode,
+    durationMs: Date.now() - startedAt,
+  });
+  process.exit(exitCode);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv);
+  } catch (e) {
+    die(e.message || String(e));
+  }
+}
+
+module.exports = { detectMemoryPlugin };

--- a/scripts/workflows/work-qa-feature-tester/qa-phase-registry.js
+++ b/scripts/workflows/work-qa-feature-tester/qa-phase-registry.js
@@ -1,0 +1,76 @@
+/**
+ * qa-phase-registry.js
+ *
+ * Central registry for qa-feature-tester phase definitions, ordering, and
+ * transitions. Mirrors `work-spec/spec-phase-registry.js`.
+ *
+ * Phases (linear):
+ *   inputs → env_setup → smoke → feature → kind_checks →
+ *   screenshot → report → memorize → done
+ *
+ * `done` is terminal.
+ */
+
+'use strict';
+
+const QA_PHASES = Object.freeze({
+  inputs: 'inputs',
+  env_setup: 'env_setup',
+  smoke: 'smoke',
+  feature: 'feature',
+  kind_checks: 'kind_checks',
+  screenshot: 'screenshot',
+  report: 'report',
+  memorize: 'memorize',
+  done: 'done',
+});
+
+const QA_PHASE_ORDER = Object.freeze([
+  QA_PHASES.inputs,
+  QA_PHASES.env_setup,
+  QA_PHASES.smoke,
+  QA_PHASES.feature,
+  QA_PHASES.kind_checks,
+  QA_PHASES.screenshot,
+  QA_PHASES.report,
+  QA_PHASES.memorize,
+  QA_PHASES.done,
+]);
+
+const QA_PHASE_TRANSITIONS = Object.freeze({
+  [QA_PHASES.inputs]: Object.freeze([QA_PHASES.env_setup]),
+  [QA_PHASES.env_setup]: Object.freeze([QA_PHASES.smoke]),
+  [QA_PHASES.smoke]: Object.freeze([QA_PHASES.feature]),
+  [QA_PHASES.feature]: Object.freeze([QA_PHASES.kind_checks]),
+  [QA_PHASES.kind_checks]: Object.freeze([QA_PHASES.screenshot]),
+  [QA_PHASES.screenshot]: Object.freeze([QA_PHASES.report]),
+  [QA_PHASES.report]: Object.freeze([QA_PHASES.memorize]),
+  [QA_PHASES.memorize]: Object.freeze([QA_PHASES.done]),
+  [QA_PHASES.done]: Object.freeze([]),
+});
+
+function qaNextPhases(current) {
+  return QA_PHASE_TRANSITIONS[current] || [];
+}
+
+function qaCanTransition(current, next) {
+  return qaNextPhases(current).includes(next);
+}
+
+function isQaPhase(phase) {
+  return Object.hasOwn(QA_PHASES, phase);
+}
+
+const QA_INITIAL_PHASE = QA_PHASES.inputs;
+const QA_TERMINAL_PHASE = QA_PHASES.done;
+
+module.exports = {
+  QA_PHASES,
+  QA_PHASE_ORDER,
+  QA_PHASE_TRANSITIONS,
+  QA_INITIAL_PHASE,
+  QA_TERMINAL_PHASE,
+  qaNextPhases,
+  qaCanTransition,
+  isQaPhase,
+};

--- a/scripts/workflows/work-qa-feature-tester/qa-phase-state.js
+++ b/scripts/workflows/work-qa-feature-tester/qa-phase-state.js
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+/**
+ * qa-phase-state.js
+ *
+ * Authorized writer for `tasks/<ticket>/qa-phase.json`. Mirrors
+ * completion-phase-state.js / code-phase-state.js. Only callable through
+ * Claude Code's agent system (token-protected), and only by the
+ * qa-feature-tester agent during the `check` step.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { consumeToken } = require('../lib/scripts/write-report');
+const { normalizeAgentName } = require('../lib/agent-detection');
+const {
+  QA_PHASE_ORDER,
+  QA_INITIAL_PHASE,
+  qaNextPhases,
+  qaCanTransition,
+  isQaPhase,
+} = require('./qa-phase-registry');
+
+let config;
+try {
+  config = require('../lib/config');
+} catch (e) {
+  if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
+  config = null;
+}
+
+const ALLOWED_AGENTS = ['qa-feature-tester', 'qa-api-tester'];
+const GATED_SUBCOMMANDS = ['init', 'record', 'transition'];
+const TOKEN_MAX_AGE_MS = 10_000;
+
+const PHASES = QA_PHASE_ORDER;
+
+function errorExit(message) {
+  process.stderr.write(`${JSON.stringify({ error: true, message })}\n`);
+  process.exit(1);
+}
+
+function successOut(data) {
+  process.stdout.write(`${JSON.stringify(data)}\n`);
+}
+
+function sanitizeId(ticketId) {
+  try {
+    return require('../lib/config').safeTicketId(ticketId);
+  } catch (e) {
+    if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
+    return ticketId;
+  }
+}
+
+function resolveTasksBase() {
+  return (
+    process.env.TASKS_BASE ||
+    (config && config.TASKS_BASE) ||
+    path.join(require('node:os').homedir(), 'worktrees', 'tasks')
+  );
+}
+
+function getStatePath(ticketId) {
+  if (!ticketId || /\.\.|[\\:\x00]/.test(ticketId)) {
+    throw new Error(`Invalid ticket ID: ${ticketId}`);
+  }
+  const base = path.resolve(resolveTasksBase());
+  const safeId = sanitizeId(ticketId);
+  const resolved = path.resolve(base, safeId, 'qa-phase.json');
+  if (!resolved.startsWith(base + path.sep)) {
+    throw new Error(`Invalid ticket ID: ${ticketId}`);
+  }
+  return resolved;
+}
+
+function readState(ticketId) {
+  const p = getStatePath(ticketId);
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function writeState(ticketId, state) {
+  const p = getStatePath(ticketId);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+  try {
+    fs.unlinkSync(p);
+  } catch (e) {
+    if (e && e.code !== 'ENOENT') throw e;
+  }
+  fs.renameSync(tmp, p);
+}
+
+function verifyToken(expectedTicketId) {
+  const scriptBasename = path.basename(__filename);
+  const token = consumeToken(scriptBasename, expectedTicketId);
+  if (!token) {
+    errorExit(
+      "No valid write token found. This script can only be called through Claude Code's agent system."
+    );
+  }
+  if (typeof token.timestamp !== 'number' || !Number.isFinite(token.timestamp)) {
+    errorExit('Token has invalid or missing timestamp.');
+  }
+  if (typeof token.agent !== 'string' || !token.agent) {
+    errorExit('Token has invalid or missing agent field.');
+  }
+  const age = Date.now() - token.timestamp;
+  if (age < 0) errorExit(`Write token timestamp is in the future (${Math.abs(age)}ms ahead).`);
+  if (age > TOKEN_MAX_AGE_MS)
+    errorExit(`Write token expired (${age}ms old, max ${TOKEN_MAX_AGE_MS}ms).`);
+  const agentNormalized = normalizeAgentName(token.agent);
+  if (!ALLOWED_AGENTS.includes(agentNormalized)) {
+    errorExit(
+      `Agent "${token.agent}" is not authorized. Allowed agents: ${ALLOWED_AGENTS.join(', ')}.`
+    );
+  }
+  return token;
+}
+
+function parseFlag(args, name) {
+  const i = args.indexOf(name);
+  if (i === -1 || i + 1 >= args.length) return null;
+  return args[i + 1];
+}
+
+function cmdInit(ticket) {
+  const existing = readState(ticket);
+  if (existing) {
+    successOut({ ok: true, status: 'exists', state: existing });
+    return;
+  }
+  const now = new Date().toISOString();
+  const state = {
+    ticket,
+    createdAt: now,
+    updatedAt: now,
+    currentPhase: QA_INITIAL_PHASE,
+    phases: {},
+  };
+  writeState(ticket, state);
+  successOut({ ok: true, status: 'created', state });
+}
+
+function cmdCurrent(ticket) {
+  const state = readState(ticket);
+  if (!state) {
+    successOut({ ok: true, currentPhase: null, state: null });
+    return;
+  }
+  successOut({ ok: true, currentPhase: state.currentPhase, state });
+}
+
+function cmdRecord(ticket, phase, args) {
+  if (!isQaPhase(phase)) {
+    errorExit(`Unknown phase "${phase}". Valid: ${QA_PHASE_ORDER.join(', ')}.`);
+  }
+  const state = readState(ticket);
+  if (!state) errorExit(`No qa-phase state for ${ticket}. Run \`init\` first.`);
+  const summary = parseFlag(args, '--summary') || '';
+  const now = new Date().toISOString();
+  state.phases[phase] = { completedAt: now, summary };
+  state.updatedAt = now;
+  writeState(ticket, state);
+  successOut({ ok: true, recordedPhase: phase, state });
+}
+
+function cmdTransition(ticket, target) {
+  if (!isQaPhase(target)) {
+    errorExit(`Unknown target phase "${target}". Valid: ${QA_PHASE_ORDER.join(', ')}.`);
+  }
+  const state = readState(ticket);
+  if (!state) errorExit(`No qa-phase state for ${ticket}. Run \`init\` first.`);
+  if (!qaCanTransition(state.currentPhase, target)) {
+    const allowed = qaNextPhases(state.currentPhase);
+    errorExit(
+      `Invalid transition ${state.currentPhase} → ${target}. Allowed from ${state.currentPhase}: ${
+        allowed.length ? allowed.join(', ') : '(terminal)'
+      }.`
+    );
+  }
+  if (!state.phases[state.currentPhase]) {
+    errorExit(
+      `Cannot transition: phase "${state.currentPhase}" has no recorded evidence. Run \`record ${ticket} ${state.currentPhase}\` first.`
+    );
+  }
+  const now = new Date().toISOString();
+  state.currentPhase = target;
+  state.updatedAt = now;
+  writeState(ticket, state);
+  successOut({ ok: true, currentPhase: target, state });
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  const sub = args[0];
+  if (!sub) {
+    errorExit('Usage: qa-phase-state.js <init|current|record|transition> <TICKET> [args]');
+  }
+  const ticket = args[1];
+  if (!ticket) errorExit('Missing ticket ID.');
+
+  if (GATED_SUBCOMMANDS.includes(sub)) verifyToken(ticket);
+
+  if (sub === 'init') return cmdInit(ticket);
+  if (sub === 'current') return cmdCurrent(ticket);
+  if (sub === 'record') {
+    const phase = args[2];
+    if (!phase) errorExit('Usage: qa-phase-state.js record <TICKET> <phase> [--summary "..."]');
+    return cmdRecord(ticket, phase, args.slice(3));
+  }
+  if (sub === 'transition') {
+    const target = args[2];
+    if (!target) errorExit('Usage: qa-phase-state.js transition <TICKET> <target>');
+    return cmdTransition(ticket, target);
+  }
+  errorExit(`Unknown subcommand: ${sub}`);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv);
+  } catch (e) {
+    errorExit(e.message);
+  }
+}
+
+module.exports = { PHASES, qaCanTransition, qaNextPhases };

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -260,6 +260,30 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       agents: ['code-checker'],
       step: STEPS.check,
     },
+    // Self-paced qa-feature-tester runner: phases the manual QA loop
+    // (env setup → smoke → feature → per-kind checks → screenshot → report).
+    // Allow-list includes both qa-feature-tester and qa-api-tester so the
+    // same state-state writer can serve either testing variant.
+    'qa-next.js': {
+      agents: ['qa-feature-tester', 'qa-api-tester'],
+      step: STEPS.check,
+      companionScripts: ['qa-phase-state.js'],
+    },
+    'qa-phase-state.js': {
+      agents: ['qa-feature-tester', 'qa-api-tester'],
+      step: STEPS.check,
+    },
+    // Self-paced pr-reviewer runner: phases the PR-review loop
+    // (pr context → diff audit → standards → kind-specific → post → memorize).
+    'pr-review-next.js': {
+      agents: ['pr-reviewer'],
+      step: STEPS.check,
+      companionScripts: ['pr-review-phase-state.js'],
+    },
+    'pr-review-phase-state.js': {
+      agents: ['pr-reviewer'],
+      step: STEPS.check,
+    },
   };
 
   const workflow = {


### PR DESCRIPTION
## Existing Behavior

- The `/check` step has self-paced runners for `work-spec`, `work-completion-checker`, and `work-code-checker`, each following a phase-state machine pattern.
- No equivalent runner exists for `qa-feature-tester` / `qa-api-tester` — manual QA agents have no phased protocol to follow during the check step.
- No equivalent runner exists for `pr-reviewer` — the agent has no structured phase loop for diff audit, standards checks, kind-specific risk lenses, or review posting.
- `next-action-footer.js` `dirFor()` has no mapping for `qa-next.js` or `pr-review-next.js`.

## Intended New Behavior

- `scripts/workflows/work-qa-feature-tester/` introduces a 9-phase self-paced runner (`inputs → env_setup → smoke → feature → kind_checks → screenshot → report → memorize → done`) for `qa-feature-tester` and `qa-api-tester`. Per-kind validators enforce that the agent has actually exercised the feature (browser state checks for frontend, HTTP status citations for backend, Playwright pass for e2e, CI URL capture for devops).
- `scripts/workflows/work-pr-reviewer/` introduces an 8-phase self-paced runner (`inputs → pr_context → diff_audit → standards_audit → kind_checks → review_post → memorize → done`) for `pr-reviewer`. Per-kind validators apply risk lenses: frontend (breaking prop changes + missing companion test), backend (TS safety + missing integration test + missing auth + migration rollback), e2e (`.only` / `waitForTimeout`), devops (secret leak + unpinned action refs + app-source drift), wiring (ECHO-4579 backend-drift defense).
- `next-action-footer.js` `dirFor()` now resolves `qa-next.js` → `work-qa-feature-tester` and `pr-review-next.js` → `work-pr-reviewer`.
- Both runners registered in `workflow-definition.js` `agentGatedScripts` (step = `check`, allow-list per agent, `companionScripts` = inner phase-state writer). 16 new tests cover phase ordering, transition guards, and kind-check validators. All 98 tests pass.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Both runners are invoked by their respective agents during the `check` step. To verify manually:

**qa-feature-tester runner:**
1. Enter the `check` step on a ticket with a `qa-feature-tester` assigned session.
2. The agent calls `node scripts/workflows/work-qa-feature-tester/qa-next.js <ticket> <worktree>`.
3. Phase output should begin with `inputs` and advance through `env_setup → smoke → feature → kind_checks → screenshot → report → memorize → done`.
4. To test kind-check blocking: set `tasks.md` to include `<!-- frontend -->` and leave the diff without a companion `.test.tsx` — the `kind_checks` phase should surface a warning.

**pr-reviewer runner:**
1. Enter the `check` step on a ticket with a `pr-reviewer` assigned session.
2. The agent calls `node scripts/workflows/work-pr-reviewer/pr-review-next.js <ticket> <worktree>`.
3. Phase output should begin with `inputs` and advance through `pr_context → diff_audit → standards_audit → kind_checks → review_post → memorize → done`.
4. To test devops kind-check blocking: add a `.github/workflows/ci.yml` with an inline `API_KEY: "abcd1234abcd1234"` to the PR diff — `kind_checks` phase should block with a secret-leak error.
5. To test e2e kind-check blocking: add a `.spec.ts` containing `test.only(` — `kind_checks` should block with a `.only` error.

**Unit tests:**
```bash
node --test scripts/workflows/work-qa-feature-tester/__tests__/qa-phase-registry.test.js
node --test scripts/workflows/work-qa-feature-tester/__tests__/phase-registry.test.js
node --test scripts/workflows/work-qa-feature-tester/__tests__/kind-checks.test.js
node --test scripts/workflows/work-pr-reviewer/__tests__/pr-review-phase-registry.test.js
node --test scripts/workflows/work-pr-reviewer/__tests__/phase-registry.test.js
node --test scripts/workflows/work-pr-reviewer/__tests__/kind-checks.test.js
```

### Test Results

All 98 tests pass (16 new tests added in this PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new agent-gated phase-state machines and validators that can block or advance the `/check` workflow; mistakes could stall agents or mis-classify blocking conditions, though changes are isolated to workflow tooling.
> 
> **Overview**
> Adds two new self-paced runners in the `/check` step: `qa-next.js` (9 phases) for `qa-feature-tester`/`qa-api-tester` and `pr-review-next.js` (8 phases) for `pr-reviewer`, each with a phase registry/dispatcher, token-gated phase-state writer, and optional memory-plugin “memorize” gate via sentinel files.
> 
> Implements *kind-based validators* for both flows: QA validators require evidence recorded in `qa-feature.check.md` (per-kind sections, checked checklists, screenshots, final `Status: APPROVED`), while PR-review validators analyze the PR file list/diff snapshot (`pr-review-context.json` or git diff fallback) to flag/block TS-safety issues and common review risks (e.g., `.only` in e2e, secret leaks/unpinned actions, backend drift in wiring, missing auth heuristics).
> 
> Wires the new runners into the workflow allowlist (`workflow-definition.js`) and updates `next-action-footer` to map `qa-next.js`/`pr-review-next.js` to their directories; adds unit tests covering phase registries and representative kind-check blocking cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6543cd62c92859ec0426e8b4d1faaf153b45447e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->