### PR TITLE
feat(work): cleanup runner, ci merge gate + gh-exec fixes

### DIFF
--- a/agents/cleanup-runner.md
+++ b/agents/cleanup-runner.md
@@ -1,0 +1,60 @@
+---
+name: cleanup-runner
+description: |
+  Per-ticket cleanup agent invoked during the `cleanup` workflow step
+  (between ci and reports). Deletes the feature branch, kills tmux
+  sessions scoped to the ticket id, and archives the cleanup record.
+  Refuses to act unless the PR is verified MERGED.
+  CRITICAL: This agent must NEVER invoke itself via Task tool — do the
+  work directly.
+tools: Bash, Glob, Grep, Read, TodoWrite
+model: sonnet
+color: gray
+---
+
+You are the **Cleanup Runner**, the per-ticket housekeeper for the
+`cleanup` workflow step. You delete merged branches, kill tmux sessions
+SCOPED TO THIS TICKET ONLY, and archive the cleanup record.
+
+## CRITICAL: NEVER CALL YOURSELF
+- NEVER use the Task tool to invoke cleanup-runner.
+- You ARE this agent — do the work directly.
+
+## How to run
+
+Use the self-paced runner — do not edit `cleanup-phase.json` directly:
+
+```bash
+node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-cleanup/cleanup-next.js <TICKET>
+```
+
+Phases (7 total):
+`inputs → pr_merged_check → branch_cleanup → tmux_cleanup → state_archive → memorize → done`
+
+## Hard rules
+
+- **NEVER `tmux kill-server`.** Only kill sessions whose name includes
+  the current ticket id. The `tmux_cleanup` phase lists matching
+  sessions for you — kill only those.
+- **NEVER force-delete an unmerged branch** (`git branch -D`) without
+  first confirming `git log origin/main..<branch>` is empty. The
+  pr_merged_check phase verifies the PR was MERGED, but a stale local
+  branch may still have uncommitted work.
+- **Leave the worktree for manual removal** unless the user explicitly
+  asks you to remove it. Note worktree status in `cleanup-summary.md`
+  under `## Worktree` and use `Status: PARTIAL` if you leave it.
+
+## Report shape
+
+`cleanup-summary.md` must contain:
+
+- `## Branch` — what was deleted locally + remote
+- `## Tmux sessions` — what was killed, or "none matched"
+- `## Worktree` — path + whether removed or left for user
+- Final `Status: DONE` or `Status: PARTIAL`
+
+## Memory
+
+If a memory plugin is detected, call the configured `*_remember` tool
+in the `memorize` phase with: ticket id, branch deleted, sessions
+killed, final status, any deferred items. Then `touch .cleanup-memorized`.

--- a/agents/spec-writer.md
+++ b/agents/spec-writer.md
@@ -239,6 +239,25 @@ Numbered steps with explicit dependency notation. Each step should be the smalle
 ## Files to Create/Modify
 - `{path}` — {what changes}
 
+## Selectors
+
+**REQUIRED for e2e kind.** Enumerate every UI selector the spec will reference
+(data-testids, getByRole names, etc). For each, grep the cited sibling-owned
+file BEFORE listing — the e2e kind-check runs the same grep and BLOCKS spec_gate
+on any mismatch. This is the ECHO-4457 lesson: spec asserted testids that did
+not exist on shipped sibling components and the bug only surfaced at test run.
+
+Format (em-dash or hyphen separators, both accepted):
+```
+- `<selector-name>` — existing — `<path/to/sibling-owned-file.tsx>`
+- `<selector-name>` — new — `<path/to/file-in-this-PRs-scope.tsx>`
+```
+
+- `existing` selectors must be present in the cited file (literal grep). Any
+  miss is a blocking error.
+- `new` selectors are only valid if the cited file appears in this spec's
+  `## Files to Create/Modify`.
+
 ## Out of Scope
 
 Explicitly list what is NOT being implemented to prevent scope creep:

--- a/scripts/workflows/follow-up2/lib/steps/fix-ci.js
+++ b/scripts/workflows/follow-up2/lib/steps/fix-ci.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const { execFileSync } = require('child_process');
+const { buildChildEnv } = require('../../../work/scripts/gh-exec');
 
 module.exports = function registerFixCi(register) {
   register('fix-ci', (state, ctx) => {
@@ -131,6 +132,7 @@ module.exports = function registerFixCi(register) {
           cwd: ctx.worktreeDir,
           stdio: ['pipe', 'pipe', 'pipe'],
           maxBuffer: 10 * 1024 * 1024,
+          env: buildChildEnv(),
         });
       } catch (err) {
         ghErr(`run-view ${runId}`, err);
@@ -165,6 +167,7 @@ module.exports = function registerFixCi(register) {
               timeout: 15000,
               cwd: ctx.worktreeDir,
               stdio: ['pipe', 'pipe', 'pipe'],
+              env: buildChildEnv(),
             }
           );
           for (const line of linksOutput.split('\n').filter(Boolean)) {

--- a/scripts/workflows/follow-up2/lib/steps/fix-reviews.js
+++ b/scripts/workflows/follow-up2/lib/steps/fix-reviews.js
@@ -220,6 +220,8 @@ module.exports = function registerFixReviews(register) {
           '---',
           '',
           `When done, call: \`${nextCmd}\``,
+          '',
+          '**Do NOT pipe the output** (no `| head`, `| tail`, `| grep`, `> file`, `2>&1 |`). Piping truncates the JSON delegate block and hides next-step instructions. Run the command raw.',
         ].join('\n'),
         note: 'Pass the prompt directly to the agent.',
       },

--- a/scripts/workflows/follow-up2/lib/steps/monitor.js
+++ b/scripts/workflows/follow-up2/lib/steps/monitor.js
@@ -12,6 +12,7 @@
 
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { buildChildEnv } = require('../../../work/scripts/gh-exec');
 
 /**
  * Check if any workflow run for the PR's branch has already failed.
@@ -39,7 +40,13 @@ function hasFailedJobs(prInfo, worktreeDir) {
         '--jq',
         '.check_runs[] | select(.conclusion == "failure") | .name',
       ],
-      { encoding: 'utf8', timeout: 15000, cwd: worktreeDir, stdio: ['pipe', 'pipe', 'pipe'] }
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: worktreeDir,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: buildChildEnv(),
+      }
     ).trim();
 
     return raw.length > 0;
@@ -339,6 +346,7 @@ module.exports = function registerMonitor(register) {
             cwd: ctx.worktreeDir,
             stdio: ['pipe', 'pipe', 'pipe'],
             maxBuffer: 5 * 1024 * 1024,
+            env: buildChildEnv(),
           }
         );
         // Map normalized job name → runId (strip trailing `[tag]` suffix

--- a/scripts/workflows/lib/config.js
+++ b/scripts/workflows/lib/config.js
@@ -259,6 +259,29 @@ config.getBaseBranch = (options = {}) => {
   return 'origin/main';
 };
 
+/**
+ * Resolve the ordered list of git refs to try when diffing a branch against
+ * its base — `[origin/<base>, <base>]`. Honors BASE_BRANCH env / repo
+ * symbolic-ref via getBaseBranch(). Used by scope-diff callers (check,
+ * code-checker, completion-checker) so all three pick the same base and
+ * one is not behind merges of the others. Replaces the hardcoded
+ * ['origin/main','main','origin/dev','dev'] list that picked origin/main
+ * even on dev-based repos and surfaced phantom files (ECHO-4451/ECHO-4578).
+ *
+ * @param {{cwd?: string}} [options]
+ * @returns {string[]}
+ */
+config.getDiffBaseCandidates = (options = {}) => {
+  let base = 'main';
+  try {
+    base = config.getBaseBranch({ cwd: options.cwd }) || 'main';
+  } catch {
+    /* fall through with default */
+  }
+  const bare = String(base).replace(/^origin\//, '');
+  return [...new Set([`origin/${bare}`, bare])];
+};
+
 config.prefixTicketId = (input) => {
   if (/^\d+$/.test(input)) {
     return `${config.TICKET_PROJECT_KEY}-${input}`;

--- a/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -233,6 +233,17 @@ const TRUSTED_SCRIPT_DIRS = [
   path.resolve(__dirname, '..', '..', 'check', 'scripts'), // workflows/check/scripts/
   path.resolve(__dirname, '..', '..', 'work-implement'), // workflows/work-implement/
   path.resolve(__dirname, '..', '..', 'work-brief'), // workflows/work-brief/
+  path.resolve(__dirname, '..', '..', 'work-spec'), // workflows/work-spec/
+  path.resolve(__dirname, '..', '..', 'work-tasks'), // workflows/work-tasks/
+  path.resolve(__dirname, '..', '..', 'work-pr-step'), // workflows/work-pr-step/
+  path.resolve(__dirname, '..', '..', 'work-ci'), // workflows/work-ci/
+  path.resolve(__dirname, '..', '..', 'work-completion-checker'), // workflows/work-completion-checker/
+  path.resolve(__dirname, '..', '..', 'work-code-checker'), // workflows/work-code-checker/
+  path.resolve(__dirname, '..', '..', 'work-qa-feature-tester'), // workflows/work-qa-feature-tester/
+  path.resolve(__dirname, '..', '..', 'work-pr-reviewer'), // workflows/work-pr-reviewer/
+  path.resolve(__dirname, '..', '..', 'work-task-review'), // workflows/work-task-review/
+  path.resolve(__dirname, '..', '..', 'work-reports'), // workflows/work-reports/
+  path.resolve(__dirname, '..', '..', 'work-cleanup'), // workflows/work-cleanup/
   path.resolve(__dirname, '..', '..', 'work2'), // workflows/work2/
   path.resolve(__dirname, '..', '..', 'check2'), // workflows/check2/
   path.resolve(__dirname, '..', '..', 'follow-up2'), // workflows/follow-up2/

--- a/scripts/workflows/lib/next-action-footer.js
+++ b/scripts/workflows/lib/next-action-footer.js
@@ -82,6 +82,8 @@ function dirFor(scriptName) {
       return 'work-task-review';
     case 'reports-next.js':
       return 'work-reports';
+    case 'cleanup-next.js':
+      return 'work-cleanup';
     default:
       return '';
   }

--- a/scripts/workflows/work-ci/__tests__/registry.test.js
+++ b/scripts/workflows/work-ci/__tests__/registry.test.js
@@ -13,16 +13,25 @@ const {
 } = require('../ci-phase-registry');
 const { getPhase, hasPhase } = require('../lib/phase-registry');
 
-test('CI_PHASE_ORDER is 7 phases in declared order', () => {
+test('CI_PHASE_ORDER is 8 phases in declared order', () => {
   assert.deepEqual(CI_PHASE_ORDER, [
     'inputs',
     'wait',
     'triage',
     'fix_or_document',
     'rerun_check',
+    'wait_merge',
     'memorize',
     'done',
   ]);
+});
+
+test('rerun_check transitions to wait_merge (not memorize)', () => {
+  assert.deepEqual(ciNextPhases('rerun_check'), ['wait_merge']);
+});
+
+test('wait_merge transitions to memorize', () => {
+  assert.deepEqual(ciNextPhases('wait_merge'), ['memorize']);
 });
 
 test('every non-terminal phase transitions to next', () => {

--- a/scripts/workflows/work-ci/__tests__/wait_merge.test.js
+++ b/scripts/workflows/work-ci/__tests__/wait_merge.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const wait_merge = require('../lib/phases/wait_merge');
+
+function makeCtx({ prContext = { prNumber: 1740 } } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-waitmerge-'));
+  const tasksDir = path.join(root, 'tasks', 'ECHO-7777');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  if (prContext) {
+    fs.writeFileSync(path.join(tasksDir, 'ci-context.json'), JSON.stringify(prContext));
+  }
+  return { root, tasksDir, worktreeRoot: root, ticket: 'ECHO-7777' };
+}
+
+test('wait_merge blocks when ci-context.json is missing', () => {
+  const { root, tasksDir, worktreeRoot } = makeCtx({ prContext: null });
+  const r = wait_merge.validate({ tasksDir, worktreeRoot, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('ci-context.json'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('wait_merge advances when state=MERGED', () => {
+  const original = wait_merge.fetchPrState;
+  const ctx = makeCtx();
+  // Monkey-patch the network call.
+  wait_merge.fetchPrState = () => ({
+    state: 'MERGED',
+    mergedAt: '2026-05-19T18:00:00Z',
+    mergeCommit: { oid: 'deadbeef' },
+  });
+  try {
+    const r = wait_merge.validate(ctx);
+    assert.equal(r.ok, true);
+    assert.ok(r.summary.includes('merged'));
+  } finally {
+    wait_merge.fetchPrState = original;
+    fs.rmSync(ctx.root, { recursive: true, force: true });
+  }
+});
+
+test('wait_merge WAITS when state=OPEN (no errors, no advance)', () => {
+  const original = wait_merge.fetchPrState;
+  const ctx = makeCtx();
+  wait_merge.fetchPrState = () => ({ state: 'OPEN', mergedAt: null, mergeCommit: null });
+  try {
+    const r = wait_merge.validate(ctx);
+    assert.equal(r.ok, false);
+    assert.deepEqual(r.errors, []);
+    assert.ok(r.summary.includes('waiting for merge'));
+  } finally {
+    wait_merge.fetchPrState = original;
+    fs.rmSync(ctx.root, { recursive: true, force: true });
+  }
+});
+
+test('wait_merge BLOCKS when state=CLOSED (errors, no advance)', () => {
+  const original = wait_merge.fetchPrState;
+  const ctx = makeCtx();
+  wait_merge.fetchPrState = () => ({ state: 'CLOSED', mergedAt: null, mergeCommit: null });
+  try {
+    const r = wait_merge.validate(ctx);
+    assert.equal(r.ok, false);
+    assert.ok(r.errors[0].includes('CLOSED'));
+  } finally {
+    wait_merge.fetchPrState = original;
+    fs.rmSync(ctx.root, { recursive: true, force: true });
+  }
+});

--- a/scripts/workflows/work-ci/ci-phase-registry.js
+++ b/scripts/workflows/work-ci/ci-phase-registry.js
@@ -4,11 +4,17 @@
  * Phases for the WORK orchestrator's `ci` step.
  *
  * Phases (linear):
- *   inputs → wait → triage → fix_or_document → rerun_check → memorize → done
+ *   inputs → wait → triage → fix_or_document → rerun_check →
+ *   wait_merge → memorize → done
  *
  * `wait` is a re-entrant phase: when CI is still running, validate returns
  * `{ ok: false, errors: [] }` (no errors → waiting, not blocked), so the
  * orchestrator prints the current instructions and exits without advancing.
+ *
+ * `wait_merge` is also re-entrant (same pattern): blocks ci-step exit
+ * until `gh pr view` reports `state === MERGED`. Ensures the workflow
+ * cannot reach cleanup/reports/complete until the PR is actually merged
+ * into the base branch.
  */
 
 'use strict';
@@ -19,6 +25,7 @@ const CI_PHASES = Object.freeze({
   triage: 'triage',
   fix_or_document: 'fix_or_document',
   rerun_check: 'rerun_check',
+  wait_merge: 'wait_merge',
   memorize: 'memorize',
   done: 'done',
 });
@@ -29,6 +36,7 @@ const CI_PHASE_ORDER = Object.freeze([
   CI_PHASES.triage,
   CI_PHASES.fix_or_document,
   CI_PHASES.rerun_check,
+  CI_PHASES.wait_merge,
   CI_PHASES.memorize,
   CI_PHASES.done,
 ]);
@@ -38,7 +46,8 @@ const CI_PHASE_TRANSITIONS = Object.freeze({
   [CI_PHASES.wait]: Object.freeze([CI_PHASES.triage]),
   [CI_PHASES.triage]: Object.freeze([CI_PHASES.fix_or_document]),
   [CI_PHASES.fix_or_document]: Object.freeze([CI_PHASES.rerun_check]),
-  [CI_PHASES.rerun_check]: Object.freeze([CI_PHASES.memorize]),
+  [CI_PHASES.rerun_check]: Object.freeze([CI_PHASES.wait_merge]),
+  [CI_PHASES.wait_merge]: Object.freeze([CI_PHASES.memorize]),
   [CI_PHASES.memorize]: Object.freeze([CI_PHASES.done]),
   [CI_PHASES.done]: Object.freeze([]),
 });

--- a/scripts/workflows/work-ci/lib/phase-registry.js
+++ b/scripts/workflows/work-ci/lib/phase-registry.js
@@ -28,6 +28,7 @@ require('./phases/wait')(registerPhase);
 require('./phases/triage')(registerPhase);
 require('./phases/fix_or_document')(registerPhase);
 require('./phases/rerun_check')(registerPhase);
+require('./phases/wait_merge')(registerPhase);
 require('./phases/memorize')(registerPhase);
 require('./phases/done')(registerPhase);
 

--- a/scripts/workflows/work-ci/lib/phases/fix_or_document.js
+++ b/scripts/workflows/work-ci/lib/phases/fix_or_document.js
@@ -54,7 +54,7 @@ function validate(ctx) {
 
 function instructions(ctx) {
   return [
-    `# ci-next — Phase 4 of 7: FIX OR DOCUMENT`,
+    `# ci-next — Phase 4 of 8: FIX OR DOCUMENT`,
     `Ticket: ${ctx.ticket}`,
     '',
     '### What you do',

--- a/scripts/workflows/work-ci/lib/phases/inputs.js
+++ b/scripts/workflows/work-ci/lib/phases/inputs.js
@@ -31,9 +31,11 @@ function resolvePrNumber(worktreeRoot) {
     /* fall through */
   }
   // Fallback: gh pr view.
+  const { buildChildEnv } = require('../../../work/scripts/gh-exec');
   const r = spawnSync('gh', ['pr', 'view', '--json', 'number'], {
     cwd: worktreeRoot,
     encoding: 'utf8',
+    env: buildChildEnv(),
   });
   if (r.status === 0) {
     try {

--- a/scripts/workflows/work-ci/lib/phases/inputs.js
+++ b/scripts/workflows/work-ci/lib/phases/inputs.js
@@ -71,7 +71,7 @@ function validate(ctx) {
 
 function instructions(ctx) {
   return [
-    `# ci-next — Phase 1 of 7: INPUTS`,
+    `# ci-next — Phase 1 of 8: INPUTS`,
     `Ticket: ${ctx.ticket}`,
     '',
     `Resolves the PR number from \`pr-context.json\` (preferred) or \`gh pr view\`. Writes it to \`${CTX_FILE}\`.`,

--- a/scripts/workflows/work-ci/lib/phases/memorize.js
+++ b/scripts/workflows/work-ci/lib/phases/memorize.js
@@ -37,14 +37,14 @@ function validate(ctx) {
 function instructions(ctx) {
   if (!ctx.memory)
     return [
-      `# ci-next — Phase 6 of 7: MEMORIZE`,
+      `# ci-next — Phase 7 of 8: MEMORIZE`,
       `Ticket: ${ctx.ticket}`,
       '',
       'No memory plugin. Auto-advancing.',
       '',
     ].join('\n');
   return [
-    `# ci-next — Phase 6 of 7: MEMORIZE (${ctx.memory.name})`,
+    `# ci-next — Phase 7 of 8: MEMORIZE (${ctx.memory.name})`,
     `Ticket: ${ctx.ticket}`,
     '',
     `Call \`${ctx.memory.rememberTool}\` with the failure classifications from ci-triage.json (especially \`flake\` and \`pre-existing\` entries — these are the most valuable for future tickets).`,

--- a/scripts/workflows/work-ci/lib/phases/rerun_check.js
+++ b/scripts/workflows/work-ci/lib/phases/rerun_check.js
@@ -23,9 +23,11 @@ function readJson(p) {
 function validate(ctx) {
   const c = readJson(path.join(ctx.tasksDir, 'ci-context.json'));
   if (!c || !c.prNumber) return { ok: false, errors: ['Missing ci-context.json prNumber.'] };
+  const { buildChildEnv } = require('../../../work/scripts/gh-exec');
   const r = spawnSync('gh', ['pr', 'view', String(c.prNumber), '--json', 'statusCheckRollup'], {
     cwd: ctx.worktreeRoot,
     encoding: 'utf8',
+    env: buildChildEnv(),
   });
   if (r.status !== 0) {
     return {

--- a/scripts/workflows/work-ci/lib/phases/rerun_check.js
+++ b/scripts/workflows/work-ci/lib/phases/rerun_check.js
@@ -73,7 +73,7 @@ function validate(ctx) {
 
 function instructions(ctx) {
   return [
-    `# ci-next — Phase 5 of 7: RE-RUN CHECK`,
+    `# ci-next — Phase 5 of 8: RE-RUN CHECK`,
     `Ticket: ${ctx.ticket}`,
     '',
     'I re-query CI. If failures remain, every one must be category=pre-existing with `documentation` set.',
@@ -86,7 +86,7 @@ function instructions(ctx) {
 
 module.exports = function register(r) {
   r(CI_PHASES.rerun_check, {
-    next: CI_PHASES.memorize,
+    next: CI_PHASES.wait_merge,
     validate,
     instructions,
   });

--- a/scripts/workflows/work-ci/lib/phases/triage.js
+++ b/scripts/workflows/work-ci/lib/phases/triage.js
@@ -65,7 +65,7 @@ function validate(ctx) {
 
 function instructions(ctx) {
   return [
-    `# ci-next — Phase 3 of 7: TRIAGE`,
+    `# ci-next — Phase 3 of 8: TRIAGE`,
     `Ticket: ${ctx.ticket}`,
     '',
     '### What you do',

--- a/scripts/workflows/work-ci/lib/phases/wait.js
+++ b/scripts/workflows/work-ci/lib/phases/wait.js
@@ -25,9 +25,11 @@ function readContext(tasksDir, file) {
 }
 
 function fetchChecks(worktreeRoot, prNumber) {
+  const { buildChildEnv } = require('../../../work/scripts/gh-exec');
   const r = spawnSync('gh', ['pr', 'view', String(prNumber), '--json', 'statusCheckRollup'], {
     cwd: worktreeRoot,
     encoding: 'utf8',
+    env: buildChildEnv(),
   });
   if (r.status !== 0) return null;
   try {

--- a/scripts/workflows/work-ci/lib/phases/wait.js
+++ b/scripts/workflows/work-ci/lib/phases/wait.js
@@ -110,7 +110,7 @@ function validate(ctx) {
 
 function instructions(ctx) {
   const status = readContext(ctx.tasksDir, STATUS_FILE);
-  const lines = [`# ci-next — Phase 2 of 7: WAIT`, `Ticket: ${ctx.ticket}`, ''];
+  const lines = [`# ci-next — Phase 2 of 8: WAIT`, `Ticket: ${ctx.ticket}`, ''];
   if (status) {
     lines.push(`Last snapshot: ${status.snapshotAt}`);
     lines.push(

--- a/scripts/workflows/work-ci/lib/phases/wait_merge.js
+++ b/scripts/workflows/work-ci/lib/phases/wait_merge.js
@@ -32,10 +32,11 @@ function readContext(tasksDir, file) {
 }
 
 function fetchPrState(worktreeRoot, prNumber) {
+  const { buildChildEnv } = require('../../../work/scripts/gh-exec');
   const r = spawnSync(
     'gh',
     ['pr', 'view', String(prNumber), '--json', 'state,mergedAt,mergeCommit'],
-    { cwd: worktreeRoot, encoding: 'utf8' }
+    { cwd: worktreeRoot, encoding: 'utf8', env: buildChildEnv() }
   );
   if (r.status !== 0) return null;
   try {

--- a/scripts/workflows/work-ci/lib/phases/wait_merge.js
+++ b/scripts/workflows/work-ci/lib/phases/wait_merge.js
@@ -1,0 +1,129 @@
+/**
+ * Phase: wait_merge — block ci-step exit until the PR is actually merged.
+ *
+ * Re-entrant phase (same pattern as `wait`): when the PR is still open,
+ * validate returns `{ ok: false, errors: [] }` (no errors → waiting, not
+ * blocked), so the orchestrator prints the current instructions and exits
+ * WAITING. User re-runs the orchestrator (or ci-next.js directly) after
+ * the PR merges.
+ *
+ * Rationale: ci-step previously passed when CI checks went green, which let
+ * the workflow advance to cleanup/reports/complete BEFORE the PR landed on
+ * main. That broke "branch fully merged" assumptions downstream. Now the
+ * workflow can't move past ci until the merge happens.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { CI_PHASES } = require('../../ci-phase-registry');
+
+const MERGE_STATUS_FILE = 'ci-merge-status.json';
+
+function readContext(tasksDir, file) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(tasksDir, file), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function fetchPrState(worktreeRoot, prNumber) {
+  const r = spawnSync(
+    'gh',
+    ['pr', 'view', String(prNumber), '--json', 'state,mergedAt,mergeCommit'],
+    { cwd: worktreeRoot, encoding: 'utf8' }
+  );
+  if (r.status !== 0) return null;
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function validate(ctx) {
+  const c = readContext(ctx.tasksDir, 'ci-context.json');
+  if (!c || !c.prNumber) {
+    return { ok: false, errors: ['Missing ci-context.json prNumber (re-run inputs).'] };
+  }
+  // Indirect via module.exports so tests can monkey-patch fetchPrState.
+  const state = module.exports.fetchPrState(ctx.worktreeRoot, c.prNumber);
+  if (!state) {
+    return {
+      ok: false,
+      errors: [
+        `Could not query PR state for #${c.prNumber}. Run \`gh pr view ${c.prNumber} --json state\` manually to diagnose.`,
+      ],
+    };
+  }
+
+  // Persist the latest snapshot so the orchestrator's WAITING render is informative.
+  const snapshot = {
+    prNumber: c.prNumber,
+    state: state.state,
+    mergedAt: state.mergedAt || null,
+    mergeCommit: state.mergeCommit ? state.mergeCommit.oid || state.mergeCommit : null,
+    snapshotAt: new Date().toISOString(),
+  };
+  try {
+    fs.writeFileSync(path.join(ctx.tasksDir, MERGE_STATUS_FILE), JSON.stringify(snapshot, null, 2));
+  } catch {
+    /* hook-gated */
+  }
+
+  if (state.state === 'MERGED') {
+    return { ok: true, summary: `PR #${c.prNumber} merged at ${state.mergedAt || '(unknown)'}` };
+  }
+
+  if (state.state === 'CLOSED') {
+    return {
+      ok: false,
+      errors: [
+        `PR #${c.prNumber} is CLOSED (not merged). The ci step cannot complete. Re-open the PR and merge, or abort the workflow.`,
+      ],
+    };
+  }
+
+  // OPEN — waiting for merge. No errors, no advance.
+  return {
+    ok: false,
+    errors: [],
+    summary: `PR #${c.prNumber} state=${state.state} — waiting for merge`,
+  };
+}
+
+function instructions(ctx) {
+  const snapshot = readContext(ctx.tasksDir, MERGE_STATUS_FILE);
+  const lines = ['# ci-next — Phase 6 of 8: WAIT_MERGE', `Ticket: ${ctx.ticket}`, ''];
+  if (snapshot) {
+    lines.push(`Last snapshot: ${snapshot.snapshotAt}`);
+    lines.push(`  PR #${snapshot.prNumber} state: ${snapshot.state}`);
+    if (snapshot.mergedAt) lines.push(`  mergedAt: ${snapshot.mergedAt}`);
+  }
+  lines.push('');
+  lines.push(
+    'The ci step waits for the PR to be MERGED into the base branch before allowing the workflow to advance to cleanup/reports/complete.'
+  );
+  lines.push('');
+  lines.push(
+    'Sleep / hand off to the user, then re-invoke me. I advance to MEMORIZE as soon as `gh pr view --json state` reports `MERGED`.'
+  );
+  lines.push('');
+  return lines.join('\n');
+}
+
+module.exports = function register(r) {
+  r(CI_PHASES.wait_merge, {
+    next: CI_PHASES.memorize,
+    validate,
+    instructions,
+  });
+};
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.fetchPrState = fetchPrState;
+module.exports.MERGE_STATUS_FILE = MERGE_STATUS_FILE;

--- a/scripts/workflows/work-cleanup/__tests__/cleanup-phase-registry.test.js
+++ b/scripts/workflows/work-cleanup/__tests__/cleanup-phase-registry.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  CLEANUP_PHASES,
+  CLEANUP_PHASE_ORDER,
+  CLEANUP_PHASE_TRANSITIONS,
+  CLEANUP_INITIAL_PHASE,
+  CLEANUP_TERMINAL_PHASE,
+  cleanupNextPhases,
+  cleanupCanTransition,
+  isCleanupPhase,
+} = require('../cleanup-phase-registry');
+
+test('CLEANUP_PHASE_ORDER lists 7 phases in declared order', () => {
+  assert.deepEqual(CLEANUP_PHASE_ORDER, [
+    'inputs',
+    'pr_merged_check',
+    'branch_cleanup',
+    'tmux_cleanup',
+    'state_archive',
+    'memorize',
+    'done',
+  ]);
+});
+
+test('initial is inputs, terminal is done', () => {
+  assert.equal(CLEANUP_INITIAL_PHASE, 'inputs');
+  assert.equal(CLEANUP_TERMINAL_PHASE, 'done');
+});
+
+test('every non-terminal phase advances to the next', () => {
+  for (let i = 0; i < CLEANUP_PHASE_ORDER.length - 1; i++) {
+    const cur = CLEANUP_PHASE_ORDER[i];
+    const nxt = CLEANUP_PHASE_ORDER[i + 1];
+    assert.ok(cleanupCanTransition(cur, nxt));
+    assert.deepEqual(cleanupNextPhases(cur), [nxt]);
+  }
+});
+
+test('done is terminal', () => {
+  assert.deepEqual(CLEANUP_PHASE_TRANSITIONS.done, []);
+});
+
+test('rejects backwards transitions', () => {
+  assert.equal(cleanupCanTransition('tmux_cleanup', 'inputs'), false);
+  assert.equal(cleanupCanTransition('done', 'memorize'), false);
+});
+
+test('isCleanupPhase recognizes valid phases', () => {
+  for (const p of CLEANUP_PHASE_ORDER) assert.equal(isCleanupPhase(p), true);
+  assert.equal(isCleanupPhase('made-up'), false);
+});
+
+test('CLEANUP_PHASES is frozen', () => {
+  assert.throws(() => {
+    CLEANUP_PHASES.bogus = 'x';
+  });
+});

--- a/scripts/workflows/work-cleanup/__tests__/phase-registry.test.js
+++ b/scripts/workflows/work-cleanup/__tests__/phase-registry.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getPhase, hasPhase } = require('../lib/phase-registry');
+const { CLEANUP_PHASE_ORDER } = require('../cleanup-phase-registry');
+
+test('dispatcher registers every phase from the registry', () => {
+  for (const p of CLEANUP_PHASE_ORDER) {
+    assert.ok(hasPhase(p), `phase ${p} not registered`);
+    const h = getPhase(p);
+    assert.equal(typeof h.validate, 'function');
+    assert.equal(typeof h.instructions, 'function');
+  }
+});
+
+test('getPhase throws for unknown phases', () => {
+  assert.throws(() => getPhase('made-up'), /No cleanup phase handler/);
+});
+
+test('done is terminal (next is null)', () => {
+  assert.equal(getPhase('done').next, null);
+});

--- a/scripts/workflows/work-cleanup/__tests__/phases.test.js
+++ b/scripts/workflows/work-cleanup/__tests__/phases.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const pr_merged_check = require('../lib/phases/pr_merged_check');
+const branch_cleanup = require('../lib/phases/branch_cleanup');
+const tmux_cleanup = require('../lib/phases/tmux_cleanup');
+const state_archive = require('../lib/phases/state_archive');
+
+function makeTasksDir(files = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-phases-'));
+  const tasksDir = path.join(root, 'tasks', 'ECHO-7777');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(tasksDir, name), contents);
+  }
+  return { root, tasksDir, worktreeRoot: root, ticket: 'ECHO-7777' };
+}
+
+test('pr_merged_check blocks when cleanup-context.json is missing', () => {
+  const { root, tasksDir, worktreeRoot } = makeTasksDir();
+  const r = pr_merged_check.validate({ tasksDir, worktreeRoot, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('cleanup-context.json'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('pr_merged_check advances when state=MERGED', () => {
+  const original = pr_merged_check.fetchPrState;
+  const ctx = makeTasksDir({
+    'cleanup-context.json': JSON.stringify({ prNumber: 1740 }),
+  });
+  pr_merged_check.fetchPrState = () => ({ state: 'MERGED', mergedAt: '2026-05-19T18:00:00Z' });
+  try {
+    const r = pr_merged_check.validate(ctx);
+    assert.equal(r.ok, true);
+  } finally {
+    pr_merged_check.fetchPrState = original;
+    fs.rmSync(ctx.root, { recursive: true, force: true });
+  }
+});
+
+test('pr_merged_check HARD-BLOCKS when state=OPEN (not WAITs)', () => {
+  const original = pr_merged_check.fetchPrState;
+  const ctx = makeTasksDir({
+    'cleanup-context.json': JSON.stringify({ prNumber: 1740 }),
+  });
+  pr_merged_check.fetchPrState = () => ({ state: 'OPEN', mergedAt: null });
+  try {
+    const r = pr_merged_check.validate(ctx);
+    assert.equal(r.ok, false);
+    assert.ok(r.errors[0].includes('OPEN'));
+  } finally {
+    pr_merged_check.fetchPrState = original;
+    fs.rmSync(ctx.root, { recursive: true, force: true });
+  }
+});
+
+test('branch_cleanup blocks without sentinel', () => {
+  const { root, tasksDir } = makeTasksDir({
+    'cleanup-context.json': JSON.stringify({ branch: 'feature/x' }),
+  });
+  const r = branch_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('.branch-cleaned'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('branch_cleanup passes with sentinel present', () => {
+  const { root, tasksDir } = makeTasksDir({
+    'cleanup-context.json': JSON.stringify({ branch: 'feature/x' }),
+    '.branch-cleaned': 'ok',
+  });
+  const r = branch_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, true);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('tmux_cleanup auto-passes when no sessions match ticket', () => {
+  const original = tmux_cleanup.listSessionsMatching;
+  const { root, tasksDir } = makeTasksDir();
+  tmux_cleanup.listSessionsMatching = () => [];
+  try {
+    const r = tmux_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
+    assert.equal(r.ok, true);
+    assert.ok(r.summary.includes('no matching'));
+  } finally {
+    tmux_cleanup.listSessionsMatching = original;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('tmux_cleanup blocks when matching sessions exist without sentinel', () => {
+  const original = tmux_cleanup.listSessionsMatching;
+  const { root, tasksDir } = makeTasksDir();
+  tmux_cleanup.listSessionsMatching = () => ['ECHO-7777-dev', 'ECHO-7777-listen'];
+  try {
+    const r = tmux_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors[0].includes('ECHO-7777-dev'));
+  } finally {
+    tmux_cleanup.listSessionsMatching = original;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('state_archive blocks on missing required sections', () => {
+  const { root, tasksDir } = makeTasksDir({
+    'cleanup-summary.md': '## Branch\nx\nStatus: DONE\n',
+  });
+  const r = state_archive.validate({ tasksDir });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('missing section'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('state_archive passes when all sections + Status present', () => {
+  const md = [
+    '## Branch',
+    'deleted feature/x locally and remote',
+    '## Tmux sessions',
+    'killed ECHO-7777-dev',
+    '## Worktree',
+    'left at /home/x/worktrees/ECHO-7777 for manual removal',
+    '',
+    'Status: PARTIAL',
+  ].join('\n');
+  const { root, tasksDir } = makeTasksDir({ 'cleanup-summary.md': md });
+  const r = state_archive.validate({ tasksDir });
+  assert.equal(r.ok, true);
+  fs.rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/workflows/work-cleanup/cleanup-next.js
+++ b/scripts/workflows/work-cleanup/cleanup-next.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+/**
+ * cleanup-next.js
+ *
+ * Self-paced runner for the cleanup-runner agent during the `cleanup`
+ * step. Mirrors reports-next.js. Phases:
+ *   inputs → pr_merged_check → branch_cleanup → tmux_cleanup →
+ *   state_archive → memorize → done
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const CLEANUP_PHASE_CLI = path.resolve(__dirname, 'cleanup-phase-state.js');
+
+const { CLEANUP_INITIAL_PHASE } = require('./cleanup-phase-registry');
+const { getPhase } = require('./lib/phase-registry');
+const { loadMemoryPluginCandidates } = require('./lib/memory-plugin-config');
+
+let logNextScriptEvent;
+try {
+  ({ logNextScriptEvent } = require('../lib/next-script-log'));
+} catch {
+  logNextScriptEvent = () => {};
+}
+
+let config;
+try {
+  config = require('../lib/config');
+} catch {
+  config = null;
+}
+
+function resolveTasksBase() {
+  return (
+    process.env.TASKS_BASE ||
+    (config && config.TASKS_BASE) ||
+    path.join(require('node:os').homedir(), 'worktrees', 'tasks')
+  );
+}
+
+function resolveWorktreeRoot() {
+  const r = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+function die(msg) {
+  process.stderr.write(`cleanup-next: ${msg}\n`);
+  process.exit(2);
+}
+
+let _companionTokenSnapshot = null;
+
+function snapshotCompanionToken(scriptBasename, ticketId) {
+  try {
+    const dir = process.env.CLAUDE_WRITE_TOKEN_DIR || '/tmp/.claude-write-tokens';
+    const bareTicket = ticketId ? String(ticketId).split('/')[0] : null;
+    const keyed = bareTicket ? path.join(dir, `${scriptBasename}.${bareTicket}`) : null;
+    const legacy = path.join(dir, scriptBasename);
+    const file = keyed && fs.existsSync(keyed) ? keyed : fs.existsSync(legacy) ? legacy : null;
+    if (!file) return;
+    _companionTokenSnapshot = { path: file, data: JSON.parse(fs.readFileSync(file, 'utf8')) };
+  } catch {
+    /* fail-open */
+  }
+}
+
+function mintCompanionToken() {
+  if (!_companionTokenSnapshot) return false;
+  try {
+    fs.mkdirSync(path.dirname(_companionTokenSnapshot.path), { recursive: true, mode: 0o700 });
+    const data = { ..._companionTokenSnapshot.data, timestamp: Date.now() };
+    fs.writeFileSync(_companionTokenSnapshot.path, JSON.stringify(data), { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectMemoryPlugin(env = process.env) {
+  const home = require('node:os').homedir();
+  const candidates = loadMemoryPluginCandidates(env);
+  for (const c of candidates) {
+    for (const base of c.manifestGlob) {
+      const dir = path.join(home, base);
+      if (!fs.existsSync(dir)) continue;
+      let entries;
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      if (entries.some((e) => c.probe.test(e.name))) return c;
+    }
+  }
+  return null;
+}
+
+function readRelatedManifest(tasksDir) {
+  const p = path.join(tasksDir, 'related-tickets.json');
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function listLinkedIds(manifest) {
+  if (!manifest) return [];
+  const ids = new Set();
+  if (manifest.parent && manifest.parent.id) ids.add(manifest.parent.id);
+  for (const key of ['siblings', 'blockedBy', 'dependsOn', 'relatedTo']) {
+    for (const e of manifest[key] || []) if (e && e.id) ids.add(e.id);
+  }
+  return [...ids];
+}
+
+function callPhaseCli(args) {
+  mintCompanionToken();
+  const r = spawnSync(process.execPath, [CLEANUP_PHASE_CLI, ...args], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return { code: r.status ?? -1, out: (r.stdout || '') + (r.stderr || '') };
+}
+
+function getCurrentPhase(ticket) {
+  const r = callPhaseCli(['current', ticket]);
+  if (r.code !== 0) return null;
+  try {
+    return JSON.parse(r.out.trim().split('\n').pop()).currentPhase;
+  } catch {
+    return null;
+  }
+}
+
+function ensureInit(ticket) {
+  const r = callPhaseCli(['init', ticket]);
+  if (r.code !== 0) die(`Could not init cleanup-phase state:\n${r.out}`);
+}
+
+function recordPhase(ticket, phase, summary) {
+  return callPhaseCli(['record', ticket, phase, '--summary', summary || '']);
+}
+
+function transitionPhase(ticket, target) {
+  return callPhaseCli(['transition', ticket, target]);
+}
+
+function main(argv) {
+  const startedAt = Date.now();
+  const args = argv.slice(2);
+  const ticket = args[0];
+  if (!ticket || /^-/.test(ticket)) {
+    process.stderr.write(
+      'usage: cleanup-next.js <TICKET>\n  e.g. node cleanup-next.js ECHO-4579\n'
+    );
+    process.exit(2);
+  }
+  logNextScriptEvent('cleanup-next', {
+    event: 'invoked',
+    ticket,
+    cwd: process.cwd(),
+    agent: process.env.CLAUDE_CURRENT_AGENT || null,
+  });
+
+  snapshotCompanionToken('cleanup-phase-state.js', ticket);
+
+  const tasksBase = resolveTasksBase();
+  const tasksDir = path.join(tasksBase, ticket);
+  if (!fs.existsSync(tasksDir)) die(`tasks dir not found: ${tasksDir}`);
+
+  const manifest = readRelatedManifest(tasksDir);
+  const linkedIds = listLinkedIds(manifest);
+  const memory = detectMemoryPlugin();
+  const worktreeRoot = resolveWorktreeRoot() || path.dirname(tasksBase);
+
+  ensureInit(ticket);
+  let phase = getCurrentPhase(ticket) || CLEANUP_INITIAL_PHASE;
+
+  const ctx = { ticket, tasksDir, tasksBase, manifest, linkedIds, memory, worktreeRoot };
+
+  const handler = getPhase(phase);
+  const verdict = handler.validate(ctx);
+
+  let advanced = false;
+  let blockReason = '';
+
+  if (verdict.ok && handler.next) {
+    const rec = recordPhase(ticket, phase, verdict.summary || '');
+    if (rec.code !== 0) {
+      blockReason = `Could not record phase ${phase}:\n${rec.out}`;
+    } else {
+      const t = transitionPhase(ticket, handler.next);
+      if (t.code !== 0) {
+        blockReason = `Could not transition to ${handler.next}:\n${t.out}`;
+      } else {
+        advanced = true;
+        phase = handler.next;
+      }
+    }
+  } else if (Array.isArray(verdict.errors) && verdict.errors.length > 0) {
+    blockReason = verdict.errors.join('\n');
+  }
+
+  const header = [
+    `cleanup-next: ${ticket}`,
+    `  tasks dir: ${tasksDir}`,
+    `  current phase (after this run): ${phase}`,
+    `  memory plugin: ${memory ? memory.name : '(none detected)'}`,
+    `  linked tickets: ${linkedIds.length}${linkedIds.length ? ` (${linkedIds.join(', ')})` : ''}`,
+    advanced ? '  result: PHASE ADVANCED' : blockReason ? '  result: BLOCKED' : '  result: WAITING',
+    '',
+  ].join('\n');
+
+  const instructorPhase = getPhase(phase);
+  const instructions = instructorPhase.instructions(ctx);
+  const body =
+    blockReason && !advanced
+      ? [
+          `## ❌ Phase ${phase.toUpperCase()} blocked`,
+          '',
+          '```',
+          blockReason,
+          '```',
+          '',
+          '---',
+          '',
+          instructions,
+        ].join('\n')
+      : instructions;
+
+  process.stdout.write(`${header}\n${body}`);
+
+  const { renderNextActionFooter } = require('../lib/next-action-footer');
+  process.stdout.write(
+    renderNextActionFooter({
+      scriptName: 'cleanup-next.js',
+      ticket,
+      phase,
+      terminalPhase: 'done',
+      advanced,
+      blockReason,
+    })
+  );
+
+  const exitCode = blockReason && !advanced ? 2 : 0;
+  logNextScriptEvent('cleanup-next', {
+    event: 'completed',
+    ticket,
+    phase,
+    advanced,
+    blocked: Boolean(blockReason),
+    blockReason: blockReason ? blockReason.slice(0, 500) : null,
+    linkedTickets: linkedIds.length,
+    memoryPlugin: memory ? memory.name : null,
+    exitCode,
+    durationMs: Date.now() - startedAt,
+  });
+  process.exit(exitCode);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv);
+  } catch (e) {
+    die(e.message || String(e));
+  }
+}
+
+module.exports = { detectMemoryPlugin };

--- a/scripts/workflows/work-cleanup/cleanup-phase-registry.js
+++ b/scripts/workflows/work-cleanup/cleanup-phase-registry.js
@@ -1,0 +1,70 @@
+/**
+ * cleanup-phase-registry.js
+ *
+ * Phases for the WORK orchestrator's `cleanup` step.
+ *
+ * Phases (linear):
+ *   inputs → pr_merged_check → branch_cleanup → tmux_cleanup →
+ *   state_archive → memorize → done
+ *
+ * `pr_merged_check` is a defensive duplicate of ci-step's wait_merge —
+ * cleanup must NEVER run on a branch whose PR isn't merged. It blocks
+ * (not WAITs) if the PR is OPEN/CLOSED since the workflow shouldn't have
+ * reached cleanup at all in those states.
+ */
+
+'use strict';
+
+const CLEANUP_PHASES = Object.freeze({
+  inputs: 'inputs',
+  pr_merged_check: 'pr_merged_check',
+  branch_cleanup: 'branch_cleanup',
+  tmux_cleanup: 'tmux_cleanup',
+  state_archive: 'state_archive',
+  memorize: 'memorize',
+  done: 'done',
+});
+
+const CLEANUP_PHASE_ORDER = Object.freeze([
+  CLEANUP_PHASES.inputs,
+  CLEANUP_PHASES.pr_merged_check,
+  CLEANUP_PHASES.branch_cleanup,
+  CLEANUP_PHASES.tmux_cleanup,
+  CLEANUP_PHASES.state_archive,
+  CLEANUP_PHASES.memorize,
+  CLEANUP_PHASES.done,
+]);
+
+const CLEANUP_PHASE_TRANSITIONS = Object.freeze({
+  [CLEANUP_PHASES.inputs]: Object.freeze([CLEANUP_PHASES.pr_merged_check]),
+  [CLEANUP_PHASES.pr_merged_check]: Object.freeze([CLEANUP_PHASES.branch_cleanup]),
+  [CLEANUP_PHASES.branch_cleanup]: Object.freeze([CLEANUP_PHASES.tmux_cleanup]),
+  [CLEANUP_PHASES.tmux_cleanup]: Object.freeze([CLEANUP_PHASES.state_archive]),
+  [CLEANUP_PHASES.state_archive]: Object.freeze([CLEANUP_PHASES.memorize]),
+  [CLEANUP_PHASES.memorize]: Object.freeze([CLEANUP_PHASES.done]),
+  [CLEANUP_PHASES.done]: Object.freeze([]),
+});
+
+function cleanupNextPhases(c) {
+  return CLEANUP_PHASE_TRANSITIONS[c] || [];
+}
+function cleanupCanTransition(c, n) {
+  return cleanupNextPhases(c).includes(n);
+}
+function isCleanupPhase(p) {
+  return Object.hasOwn(CLEANUP_PHASES, p);
+}
+
+const CLEANUP_INITIAL_PHASE = CLEANUP_PHASES.inputs;
+const CLEANUP_TERMINAL_PHASE = CLEANUP_PHASES.done;
+
+module.exports = {
+  CLEANUP_PHASES,
+  CLEANUP_PHASE_ORDER,
+  CLEANUP_PHASE_TRANSITIONS,
+  CLEANUP_INITIAL_PHASE,
+  CLEANUP_TERMINAL_PHASE,
+  cleanupNextPhases,
+  cleanupCanTransition,
+  isCleanupPhase,
+};

--- a/scripts/workflows/work-cleanup/cleanup-phase-state.js
+++ b/scripts/workflows/work-cleanup/cleanup-phase-state.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+/**
+ * cleanup-phase-state.js
+ *
+ * Authorized writer for `tasks/<ticket>/cleanup-phase.json`. Mirrors
+ * reports-phase-state.js. Token-protected; allow-list = ['cleanup-runner'].
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { consumeToken } = require('../lib/scripts/write-report');
+const { normalizeAgentName } = require('../lib/agent-detection');
+const {
+  CLEANUP_PHASE_ORDER,
+  CLEANUP_INITIAL_PHASE,
+  cleanupNextPhases,
+  cleanupCanTransition,
+  isCleanupPhase,
+} = require('./cleanup-phase-registry');
+
+let config;
+try {
+  config = require('../lib/config');
+} catch (e) {
+  if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
+  config = null;
+}
+
+const ALLOWED_AGENTS = ['cleanup-runner'];
+const GATED_SUBCOMMANDS = ['init', 'record', 'transition'];
+const TOKEN_MAX_AGE_MS = 10_000;
+
+const PHASES = CLEANUP_PHASE_ORDER;
+
+function errorExit(message) {
+  process.stderr.write(`${JSON.stringify({ error: true, message })}\n`);
+  process.exit(1);
+}
+
+function successOut(data) {
+  process.stdout.write(`${JSON.stringify(data)}\n`);
+}
+
+function sanitizeId(ticketId) {
+  try {
+    return require('../lib/config').safeTicketId(ticketId);
+  } catch (e) {
+    if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
+    return ticketId;
+  }
+}
+
+function resolveTasksBase() {
+  return (
+    process.env.TASKS_BASE ||
+    (config && config.TASKS_BASE) ||
+    path.join(require('node:os').homedir(), 'worktrees', 'tasks')
+  );
+}
+
+function getStatePath(ticketId) {
+  if (!ticketId || /\.\.|[\\:\x00]/.test(ticketId)) {
+    throw new Error(`Invalid ticket ID: ${ticketId}`);
+  }
+  const base = path.resolve(resolveTasksBase());
+  const safeId = sanitizeId(ticketId);
+  const resolved = path.resolve(base, safeId, 'cleanup-phase.json');
+  if (!resolved.startsWith(base + path.sep)) {
+    throw new Error(`Invalid ticket ID: ${ticketId}`);
+  }
+  return resolved;
+}
+
+function readState(ticketId) {
+  const p = getStatePath(ticketId);
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function writeState(ticketId, state) {
+  const p = getStatePath(ticketId);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+  try {
+    fs.unlinkSync(p);
+  } catch (e) {
+    if (e && e.code !== 'ENOENT') throw e;
+  }
+  fs.renameSync(tmp, p);
+}
+
+function verifyToken(expectedTicketId) {
+  const scriptBasename = path.basename(__filename);
+  const token = consumeToken(scriptBasename, expectedTicketId);
+  if (!token) {
+    errorExit(
+      "No valid write token found. This script can only be called through Claude Code's agent system."
+    );
+  }
+  if (typeof token.timestamp !== 'number' || !Number.isFinite(token.timestamp)) {
+    errorExit('Token has invalid or missing timestamp.');
+  }
+  if (typeof token.agent !== 'string' || !token.agent) {
+    errorExit('Token has invalid or missing agent field.');
+  }
+  const age = Date.now() - token.timestamp;
+  if (age < 0) errorExit(`Write token timestamp is in the future (${Math.abs(age)}ms ahead).`);
+  if (age > TOKEN_MAX_AGE_MS)
+    errorExit(`Write token expired (${age}ms old, max ${TOKEN_MAX_AGE_MS}ms).`);
+  const agentNormalized = normalizeAgentName(token.agent);
+  if (!ALLOWED_AGENTS.includes(agentNormalized)) {
+    errorExit(
+      `Agent "${token.agent}" is not authorized. Allowed agents: ${ALLOWED_AGENTS.join(', ')}.`
+    );
+  }
+  return token;
+}
+
+function parseFlag(args, name) {
+  const i = args.indexOf(name);
+  if (i === -1 || i + 1 >= args.length) return null;
+  return args[i + 1];
+}
+
+function cmdInit(ticket) {
+  const existing = readState(ticket);
+  if (existing) {
+    successOut({ ok: true, status: 'exists', state: existing });
+    return;
+  }
+  const now = new Date().toISOString();
+  const state = {
+    ticket,
+    createdAt: now,
+    updatedAt: now,
+    currentPhase: CLEANUP_INITIAL_PHASE,
+    phases: {},
+  };
+  writeState(ticket, state);
+  successOut({ ok: true, status: 'created', state });
+}
+
+function cmdCurrent(ticket) {
+  const state = readState(ticket);
+  if (!state) {
+    successOut({ ok: true, currentPhase: null, state: null });
+    return;
+  }
+  successOut({ ok: true, currentPhase: state.currentPhase, state });
+}
+
+function cmdRecord(ticket, phase, args) {
+  if (!isCleanupPhase(phase)) {
+    errorExit(`Unknown phase "${phase}". Valid: ${CLEANUP_PHASE_ORDER.join(', ')}.`);
+  }
+  const state = readState(ticket);
+  if (!state) errorExit(`No cleanup-phase state for ${ticket}. Run \`init\` first.`);
+  const summary = parseFlag(args, '--summary') || '';
+  const now = new Date().toISOString();
+  state.phases[phase] = { completedAt: now, summary };
+  state.updatedAt = now;
+  writeState(ticket, state);
+  successOut({ ok: true, recordedPhase: phase, state });
+}
+
+function cmdTransition(ticket, target) {
+  if (!isCleanupPhase(target)) {
+    errorExit(`Unknown target phase "${target}". Valid: ${CLEANUP_PHASE_ORDER.join(', ')}.`);
+  }
+  const state = readState(ticket);
+  if (!state) errorExit(`No cleanup-phase state for ${ticket}. Run \`init\` first.`);
+  if (!cleanupCanTransition(state.currentPhase, target)) {
+    const allowed = cleanupNextPhases(state.currentPhase);
+    errorExit(
+      `Invalid transition ${state.currentPhase} → ${target}. Allowed from ${state.currentPhase}: ${
+        allowed.length ? allowed.join(', ') : '(terminal)'
+      }.`
+    );
+  }
+  if (!state.phases[state.currentPhase]) {
+    errorExit(
+      `Cannot transition: phase "${state.currentPhase}" has no recorded evidence. Run \`record ${ticket} ${state.currentPhase}\` first.`
+    );
+  }
+  const now = new Date().toISOString();
+  state.currentPhase = target;
+  state.updatedAt = now;
+  writeState(ticket, state);
+  successOut({ ok: true, currentPhase: target, state });
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  const sub = args[0];
+  if (!sub) {
+    errorExit('Usage: cleanup-phase-state.js <init|current|record|transition> <TICKET> [args]');
+  }
+  const ticket = args[1];
+  if (!ticket) errorExit('Missing ticket ID.');
+
+  if (GATED_SUBCOMMANDS.includes(sub)) verifyToken(ticket);
+
+  if (sub === 'init') return cmdInit(ticket);
+  if (sub === 'current') return cmdCurrent(ticket);
+  if (sub === 'record') {
+    const phase = args[2];
+    if (!phase)
+      errorExit('Usage: cleanup-phase-state.js record <TICKET> <phase> [--summary "..."]');
+    return cmdRecord(ticket, phase, args.slice(3));
+  }
+  if (sub === 'transition') {
+    const target = args[2];
+    if (!target) errorExit('Usage: cleanup-phase-state.js transition <TICKET> <target>');
+    return cmdTransition(ticket, target);
+  }
+  errorExit(`Unknown subcommand: ${sub}`);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv);
+  } catch (e) {
+    errorExit(e.message);
+  }
+}
+
+module.exports = { PHASES, cleanupCanTransition, cleanupNextPhases };

--- a/scripts/workflows/work-cleanup/lib/memory-plugin-config.js
+++ b/scripts/workflows/work-cleanup/lib/memory-plugin-config.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../../work-brief/lib/memory-plugin-config');

--- a/scripts/workflows/work-cleanup/lib/phase-registry.js
+++ b/scripts/workflows/work-cleanup/lib/phase-registry.js
@@ -1,0 +1,40 @@
+/**
+ * Cleanup phase dispatcher. Mirrors work-reports/lib/phase-registry.js.
+ */
+
+'use strict';
+
+const handlers = Object.create(null);
+
+function registerPhase(phaseName, handler) {
+  if (
+    !handler ||
+    typeof handler.validate !== 'function' ||
+    typeof handler.instructions !== 'function'
+  ) {
+    throw new Error(
+      `Invalid phase handler for "${phaseName}" — must expose validate() and instructions()`
+    );
+  }
+  handlers[phaseName] = handler;
+}
+
+function getPhase(phaseName) {
+  const h = handlers[phaseName];
+  if (!h) throw new Error(`No cleanup phase handler registered for "${phaseName}"`);
+  return h;
+}
+
+function hasPhase(phaseName) {
+  return Boolean(handlers[phaseName]);
+}
+
+require('./phases/inputs')(registerPhase);
+require('./phases/pr_merged_check')(registerPhase);
+require('./phases/branch_cleanup')(registerPhase);
+require('./phases/tmux_cleanup')(registerPhase);
+require('./phases/state_archive')(registerPhase);
+require('./phases/memorize')(registerPhase);
+require('./phases/done')(registerPhase);
+
+module.exports = { registerPhase, getPhase, hasPhase };

--- a/scripts/workflows/work-cleanup/lib/phases/branch_cleanup.js
+++ b/scripts/workflows/work-cleanup/lib/phases/branch_cleanup.js
@@ -1,0 +1,72 @@
+/**
+ * Phase: branch_cleanup — instruction-only.
+ *
+ * The agent runs the destructive git commands manually (we don't want
+ * cleanup-next.js to silently delete branches). This phase verifies the
+ * agent has produced a `.branch-cleaned` sentinel after running the
+ * documented commands.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+
+const SENTINEL = '.branch-cleaned';
+
+function readContext(tasksDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(tasksDir, 'cleanup-context.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function validate(ctx) {
+  const p = path.join(ctx.tasksDir, SENTINEL);
+  if (!fs.existsSync(p)) {
+    return {
+      ok: false,
+      errors: [
+        `\`${SENTINEL}\` missing. Run the branch-cleanup commands shown in instructions, then \`touch ${p}\`.`,
+      ],
+    };
+  }
+  return { ok: true, summary: 'branch cleaned' };
+}
+
+function instructions(ctx) {
+  const c = readContext(ctx.tasksDir);
+  const branch = c && c.branch ? c.branch : '<your-branch>';
+  return [
+    '# cleanup-next — Phase 3 of 7: BRANCH CLEANUP',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'Run the following from the worktree root, then `touch` the sentinel:',
+    '',
+    '```bash',
+    'git fetch origin --prune',
+    `git switch main && git pull origin main`,
+    `git branch -d ${branch}  # use -D only if -d reports unmerged work AND you've confirmed PR is merged`,
+    `git push origin --delete ${branch}  # skip if branch auto-deleted by merge`,
+    `touch ${path.join(ctx.tasksDir, SENTINEL)}`,
+    '```',
+    '',
+    'Re-run me after the sentinel exists.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(r) {
+  r(CLEANUP_PHASES.branch_cleanup, {
+    next: CLEANUP_PHASES.tmux_cleanup,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.SENTINEL = SENTINEL;

--- a/scripts/workflows/work-cleanup/lib/phases/done.js
+++ b/scripts/workflows/work-cleanup/lib/phases/done.js
@@ -1,0 +1,32 @@
+/**
+ * Phase: done — terminal.
+ */
+
+'use strict';
+
+const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+
+function validate() {
+  return { ok: true, summary: 'cleanup terminal phase' };
+}
+
+function instructions(ctx) {
+  return [
+    '# cleanup-next — Phase 7 of 7: DONE',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'Cleanup complete. Workflow can advance to reports.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(r) {
+  r(CLEANUP_PHASES.done, {
+    next: null,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;

--- a/scripts/workflows/work-cleanup/lib/phases/inputs.js
+++ b/scripts/workflows/work-cleanup/lib/phases/inputs.js
@@ -49,14 +49,30 @@ function validate(ctx) {
   } catch {
     /* hook-gated */
   }
-  const warnings = [];
-  if (!branch) warnings.push('Could not resolve current git branch.');
-  if (!prNumber)
-    warnings.push('Could not resolve PR number from branch — pr_merged_check will fail.');
+  // BLOCK (don't advance) when branch/prNumber are missing — downstream phases
+  // can't recover, and the agent would hit a dead-end "re-run inputs" loop if
+  // we advanced past this point with incomplete context.
+  const errors = [];
+  if (!branch) {
+    errors.push(
+      'Could not resolve current git branch. Ensure you are inside a git worktree (`git rev-parse --abbrev-ref HEAD` must succeed).'
+    );
+  }
+  if (!prNumber) {
+    errors.push(
+      `Could not resolve PR number for branch \`${branch || '(unknown)'}\`. Either (a) create the PR first (\`gh pr create\`), (b) verify \`gh pr view ${branch || '<branch>'} --json number\` succeeds, or (c) abort cleanup — there's nothing to clean up for a branch with no PR.`
+    );
+  }
+  if (errors.length) {
+    return {
+      ok: false,
+      errors,
+      summary: `branch=${branch || '(none)'} pr=${prNumber || '(none)'}`,
+    };
+  }
   return {
     ok: true,
-    warnings,
-    summary: `branch=${branch || '(unknown)'} pr=${prNumber || '(unknown)'}`,
+    summary: `branch=${branch} pr=${prNumber}`,
   };
 }
 

--- a/scripts/workflows/work-cleanup/lib/phases/inputs.js
+++ b/scripts/workflows/work-cleanup/lib/phases/inputs.js
@@ -18,9 +18,11 @@ function currentBranch(cwd) {
 
 function detectPrNumber(cwd, branch) {
   if (!branch) return null;
+  const { buildChildEnv } = require('../../../work/scripts/gh-exec');
   const r = spawnSync('gh', ['pr', 'view', branch, '--json', 'number'], {
     cwd,
     encoding: 'utf8',
+    env: buildChildEnv(),
   });
   if (r.status !== 0) return null;
   try {

--- a/scripts/workflows/work-cleanup/lib/phases/inputs.js
+++ b/scripts/workflows/work-cleanup/lib/phases/inputs.js
@@ -1,0 +1,86 @@
+/**
+ * Phase: inputs — record context (ticket, worktree root, branch, PR number).
+ * Persists `cleanup-context.json` for downstream phases.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+
+function currentBranch(cwd) {
+  const r = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd, encoding: 'utf8' });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+function detectPrNumber(cwd, branch) {
+  if (!branch) return null;
+  const r = spawnSync('gh', ['pr', 'view', branch, '--json', 'number'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (r.status !== 0) return null;
+  try {
+    return JSON.parse(r.stdout).number || null;
+  } catch {
+    return null;
+  }
+}
+
+function validate(ctx) {
+  const root = ctx.worktreeRoot || process.cwd();
+  const branch = currentBranch(root);
+  const prNumber = branch ? detectPrNumber(root, branch) : null;
+  const payload = {
+    ticket: ctx.ticket,
+    worktreeRoot: root,
+    branch,
+    prNumber,
+    capturedAt: new Date().toISOString(),
+  };
+  try {
+    fs.writeFileSync(
+      path.join(ctx.tasksDir, 'cleanup-context.json'),
+      JSON.stringify(payload, null, 2)
+    );
+  } catch {
+    /* hook-gated */
+  }
+  const warnings = [];
+  if (!branch) warnings.push('Could not resolve current git branch.');
+  if (!prNumber)
+    warnings.push('Could not resolve PR number from branch — pr_merged_check will fail.');
+  return {
+    ok: true,
+    warnings,
+    summary: `branch=${branch || '(unknown)'} pr=${prNumber || '(unknown)'}`,
+  };
+}
+
+function instructions(ctx) {
+  return [
+    '# cleanup-next — Phase 1 of 7: INPUTS',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'I record the current branch + PR number into `cleanup-context.json` for downstream phases.',
+    '',
+    `Memory plugin: ${ctx.memory ? ctx.memory.name : '(none detected)'}`,
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(r) {
+  r(CLEANUP_PHASES.inputs, {
+    next: CLEANUP_PHASES.pr_merged_check,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.currentBranch = currentBranch;
+module.exports.detectPrNumber = detectPrNumber;

--- a/scripts/workflows/work-cleanup/lib/phases/memorize.js
+++ b/scripts/workflows/work-cleanup/lib/phases/memorize.js
@@ -1,0 +1,59 @@
+/**
+ * Phase: memorize — persist cleanup record to the memory plugin.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+
+const SENTINEL = '.cleanup-memorized';
+
+function validate(ctx) {
+  if (!ctx.memory) return { ok: true, summary: 'no memory plugin detected — skipping' };
+  const p = path.join(ctx.tasksDir, SENTINEL);
+  if (!fs.existsSync(p)) {
+    return {
+      ok: false,
+      errors: [
+        `Memory plugin "${ctx.memory.name}" available but \`${SENTINEL}\` missing. Call \`${ctx.memory.rememberTool}\` with: ticket id, branch deleted, sessions killed, final status. Then \`touch ${p}\`.`,
+      ],
+    };
+  }
+  return { ok: true, summary: `memorized via ${ctx.memory.name}` };
+}
+
+function instructions(ctx) {
+  if (!ctx.memory) {
+    return [
+      '# cleanup-next — Phase 6 of 7: MEMORIZE',
+      '',
+      'No memory plugin — auto-advance.',
+      '',
+    ].join('\n');
+  }
+  return [
+    '# cleanup-next — Phase 6 of 7: MEMORIZE',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    `Memory: **${ctx.memory.name}**`,
+    '',
+    `1. Call \`${ctx.memory.rememberTool}\` with: ticket id, cleanup status, any items deferred (e.g. worktree left for manual removal).`,
+    `2. \`touch ${path.join(ctx.tasksDir, SENTINEL)}\`.`,
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(r) {
+  r(CLEANUP_PHASES.memorize, {
+    next: CLEANUP_PHASES.done,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.SENTINEL = SENTINEL;

--- a/scripts/workflows/work-cleanup/lib/phases/pr_merged_check.js
+++ b/scripts/workflows/work-cleanup/lib/phases/pr_merged_check.js
@@ -23,9 +23,11 @@ function readContext(tasksDir) {
 }
 
 function fetchPrState(worktreeRoot, prNumber) {
+  const { buildChildEnv } = require('../../../work/scripts/gh-exec');
   const r = spawnSync('gh', ['pr', 'view', String(prNumber), '--json', 'state,mergedAt'], {
     cwd: worktreeRoot,
     encoding: 'utf8',
+    env: buildChildEnv(),
   });
   if (r.status !== 0) return null;
   try {

--- a/scripts/workflows/work-cleanup/lib/phases/pr_merged_check.js
+++ b/scripts/workflows/work-cleanup/lib/phases/pr_merged_check.js
@@ -1,0 +1,88 @@
+/**
+ * Phase: pr_merged_check — defensive duplicate of ci-step's wait_merge.
+ *
+ * Hard-blocks (NOT WAITs) if PR is OPEN or CLOSED. The workflow shouldn't
+ * reach cleanup at all in those states — if it did, something bypassed the
+ * ci gate and we refuse to proceed with destructive cleanup actions.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+
+function readContext(tasksDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(tasksDir, 'cleanup-context.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function fetchPrState(worktreeRoot, prNumber) {
+  const r = spawnSync('gh', ['pr', 'view', String(prNumber), '--json', 'state,mergedAt'], {
+    cwd: worktreeRoot,
+    encoding: 'utf8',
+  });
+  if (r.status !== 0) return null;
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function validate(ctx) {
+  const c = readContext(ctx.tasksDir);
+  if (!c || !c.prNumber) {
+    return {
+      ok: false,
+      errors: [
+        'Cannot verify PR is merged: cleanup-context.json missing prNumber. Re-run inputs phase first.',
+      ],
+    };
+  }
+  const state = module.exports.fetchPrState(c.worktreeRoot || ctx.worktreeRoot, c.prNumber);
+  if (!state) {
+    return {
+      ok: false,
+      errors: [
+        `Could not query PR #${c.prNumber} state. Run \`gh pr view ${c.prNumber} --json state\` manually.`,
+      ],
+    };
+  }
+  if (state.state !== 'MERGED') {
+    return {
+      ok: false,
+      errors: [
+        `PR #${c.prNumber} state=${state.state} (expected MERGED). Cleanup refuses to delete branches/worktrees for a non-merged PR. Re-merge the PR or abort the workflow.`,
+      ],
+    };
+  }
+  return { ok: true, summary: `PR #${c.prNumber} merged at ${state.mergedAt || '(unknown)'}` };
+}
+
+function instructions(ctx) {
+  return [
+    '# cleanup-next — Phase 2 of 7: PR MERGED CHECK',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'Defensive double-check: cleanup must only run on MERGED PRs. If this blocks, your ci step exited prematurely (likely missing wait_merge).',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(r) {
+  r(CLEANUP_PHASES.pr_merged_check, {
+    next: CLEANUP_PHASES.branch_cleanup,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.fetchPrState = fetchPrState;

--- a/scripts/workflows/work-cleanup/lib/phases/state_archive.js
+++ b/scripts/workflows/work-cleanup/lib/phases/state_archive.js
@@ -1,0 +1,77 @@
+/**
+ * Phase: state_archive — confirm `cleanup-summary.md` exists with the
+ * final cleanup record (branch deleted? tmux killed? worktree pending?).
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+
+const SUMMARY_FILE = 'cleanup-summary.md';
+const REQUIRED_SECTIONS = [/^##\s+Branch\b/im, /^##\s+Tmux sessions\b/im, /^##\s+Worktree\b/im];
+const STATUS_RE = /^Status:\s*(DONE|PARTIAL)\b/im;
+
+function validate(ctx) {
+  const p = path.join(ctx.tasksDir, SUMMARY_FILE);
+  if (!fs.existsSync(p)) {
+    return {
+      ok: false,
+      errors: [
+        `\`${SUMMARY_FILE}\` missing. Write the cleanup record with sections: Branch, Tmux sessions, Worktree + final Status: DONE|PARTIAL.`,
+      ],
+    };
+  }
+  let text;
+  try {
+    text = fs.readFileSync(p, 'utf8');
+  } catch (e) {
+    return { ok: false, errors: [`could not read \`${SUMMARY_FILE}\`: ${e.message}`] };
+  }
+  const missing = [];
+  const names = ['## Branch', '## Tmux sessions', '## Worktree'];
+  REQUIRED_SECTIONS.forEach((re, i) => {
+    if (!re.test(text)) missing.push(names[i]);
+  });
+  if (missing.length) {
+    return {
+      ok: false,
+      errors: [`\`${SUMMARY_FILE}\` missing section(s): ${missing.join(', ')}.`],
+    };
+  }
+  if (!STATUS_RE.test(text)) {
+    return {
+      ok: false,
+      errors: [`\`${SUMMARY_FILE}\` missing final \`Status: DONE\` or \`Status: PARTIAL\`.`],
+    };
+  }
+  return { ok: true, summary: 'cleanup-summary.md complete' };
+}
+
+function instructions(ctx) {
+  return [
+    '# cleanup-next — Phase 5 of 7: STATE ARCHIVE',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'Write `cleanup-summary.md` with:',
+    '  ## Branch       (what was deleted, locally + remote)',
+    '  ## Tmux sessions (what was killed, or "none matched")',
+    '  ## Worktree     (path + whether removed or left for user)',
+    '  Status: DONE | Status: PARTIAL  (PARTIAL = worktree left for manual removal)',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(r) {
+  r(CLEANUP_PHASES.state_archive, {
+    next: CLEANUP_PHASES.memorize,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.SUMMARY_FILE = SUMMARY_FILE;

--- a/scripts/workflows/work-cleanup/lib/phases/tmux_cleanup.js
+++ b/scripts/workflows/work-cleanup/lib/phases/tmux_cleanup.js
@@ -1,0 +1,86 @@
+/**
+ * Phase: tmux_cleanup — list tmux sessions whose name CONTAINS the ticket id
+ * and instruct the agent to kill only those. Strict scoping — never touches
+ * sessions for other tickets.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+
+const SENTINEL = '.tmux-cleaned';
+
+function listSessionsMatching(ticketId) {
+  const r = spawnSync('tmux', ['list-sessions', '-F', '#{session_name}'], {
+    encoding: 'utf8',
+  });
+  if (r.status !== 0) return [];
+  const safe = String(ticketId).replace(/[^A-Za-z0-9_-]/g, '');
+  if (!safe) return [];
+  return r.stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((s) => s && s.includes(safe));
+}
+
+function validate(ctx) {
+  const p = path.join(ctx.tasksDir, SENTINEL);
+  // Indirect via module.exports so tests can monkey-patch listSessionsMatching.
+  const sessions = module.exports.listSessionsMatching(ctx.ticket);
+  if (sessions.length === 0) {
+    // Nothing to clean — auto-pass.
+    try {
+      fs.writeFileSync(p, `auto-passed at ${new Date().toISOString()}: no matching sessions\n`);
+    } catch {
+      /* hook-gated */
+    }
+    return { ok: true, summary: 'no matching tmux sessions' };
+  }
+  if (!fs.existsSync(p)) {
+    return {
+      ok: false,
+      errors: [
+        `${sessions.length} tmux session(s) match ticket ${ctx.ticket}: ${sessions.map((s) => `\`${s}\``).join(', ')}. Kill ONLY these and \`touch ${p}\`. Do NOT kill sessions for other tickets.`,
+      ],
+    };
+  }
+  return { ok: true, summary: `${sessions.length} session(s) cleaned (sentinel present)` };
+}
+
+function instructions(ctx) {
+  const sessions = listSessionsMatching(ctx.ticket);
+  const killCmds = sessions.map((s) => `tmux kill-session -t ${JSON.stringify(s)}`).join('\n');
+  return [
+    '# cleanup-next — Phase 4 of 7: TMUX CLEANUP',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    sessions.length
+      ? `Tmux sessions matching this ticket:\n  ${sessions.join('\n  ')}\n\nKill ONLY these (do NOT use tmux kill-server):`
+      : 'No tmux sessions matched this ticket — auto-pass.',
+    '',
+    sessions.length ? '```bash' : '',
+    sessions.length ? killCmds : '',
+    sessions.length ? `touch ${path.join(ctx.tasksDir, SENTINEL)}` : '',
+    sessions.length ? '```' : '',
+    '',
+  ]
+    .filter((l) => l !== '')
+    .join('\n');
+}
+
+module.exports = function register(r) {
+  r(CLEANUP_PHASES.tmux_cleanup, {
+    next: CLEANUP_PHASES.state_archive,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;
+module.exports.listSessionsMatching = listSessionsMatching;
+module.exports.SENTINEL = SENTINEL;

--- a/scripts/workflows/work-code-checker/lib/kind-checks/shared.js
+++ b/scripts/workflows/work-code-checker/lib/kind-checks/shared.js
@@ -12,6 +12,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const specShared = require('../../../work-spec/lib/kind-checks/shared');
+const config = require('../../../lib/config');
 
 function readFile(p) {
   try {
@@ -32,7 +33,9 @@ function readChangedFiles(ctx) {
     }
   }
   const root = ctx.worktreeRoot || process.cwd();
-  for (const base of ['origin/main', 'main', 'origin/dev', 'dev']) {
+  // Honor BASE_BRANCH / symbolic-ref so dev-based repos don't fall back to
+  // origin/main (which is behind merges and surfaces phantom files).
+  for (const base of config.getDiffBaseCandidates({ cwd: root })) {
     const r = spawnSync('git', ['diff', '--name-only', `${base}...HEAD`], {
       cwd: root,
       encoding: 'utf8',

--- a/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
+++ b/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
@@ -13,6 +13,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const specShared = require('../../../work-spec/lib/kind-checks/shared');
+const config = require('../../../lib/config');
 
 function readFile(p) {
   try {
@@ -38,8 +39,9 @@ function readChangedFiles(ctx) {
     }
   }
   const root = ctx.worktreeRoot || process.cwd();
-  // Try origin/main first, then main.
-  for (const base of ['origin/main', 'main', 'origin/dev', 'dev']) {
+  // Honor BASE_BRANCH / symbolic-ref so dev-based repos don't fall back to
+  // origin/main (which is behind merges and surfaces phantom files).
+  for (const base of config.getDiffBaseCandidates({ cwd: root })) {
     const r = spawnSync('git', ['diff', '--name-only', `${base}...HEAD`], {
       cwd: root,
       encoding: 'utf8',

--- a/scripts/workflows/work-spec/__tests__/kind-checks.test.js
+++ b/scripts/workflows/work-spec/__tests__/kind-checks.test.js
@@ -9,6 +9,7 @@ const path = require('node:path');
 const { getKindCheckRegistry } = require('../lib/kind-checks/kind-registry');
 const wiring = require('../lib/kind-checks/wiring');
 const fullstack = require('../lib/kind-checks/fullstack');
+const e2e = require('../lib/kind-checks/e2e');
 
 function makeTasksDir({ brief = '', spec = '', tasks = '' } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kind-check-'));
@@ -131,4 +132,126 @@ test('fullstack passes when every referenced frontend field is verified', () => 
   // We tolerate warnings — only blocking errors fail this test.
   assert.equal(r.ok, true, `errors: ${JSON.stringify(r.errors)}`);
   fs.rmSync(root, { recursive: true, force: true });
+});
+
+// ─── Selector audit (ECHO-4457 regression) ───────────────────────────────
+
+function makeE2eFixture({ specSelectorBlock = '', files = {} } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-audit-'));
+  const worktreeRoot = path.join(root, 'worktree');
+  const tasksDir = path.join(worktreeRoot, 'tasks', 'ECHO-7777');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(worktreeRoot, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+  fs.writeFileSync(
+    path.join(tasksDir, 'spec.md'),
+    [
+      '# Spec',
+      '',
+      '## Files to Create/Modify',
+      '',
+      '- `tests/e2e/specs/admin/foo.spec.ts` — new spec',
+      '',
+      '## Selectors',
+      '',
+      specSelectorBlock,
+      '',
+      '<!-- e2e kind, journey + page-object reuse -->',
+      '',
+    ].join('\n')
+  );
+  fs.writeFileSync(
+    path.join(tasksDir, 'gherkin.feature'),
+    '@e2e\nFeature: foo\n  Scenario: bar\n    Given a\n'
+  );
+  return { root, tasksDir, worktreeRoot };
+}
+
+test('e2e selector audit BLOCKS the ECHO-4457 scenario (existing selector not in sibling file)', () => {
+  const { root, tasksDir, worktreeRoot } = makeE2eFixture({
+    specSelectorBlock: [
+      '- `table-downstream-owners-row-1` — existing — `components/admin/external-asset-tables.tsx`',
+    ].join('\n'),
+    files: {
+      // Sibling component WITHOUT the asserted testid (only has the wrong name)
+      'components/admin/external-asset-tables.tsx':
+        'export function T(){ return <div data-testid="downstream-owners-row-1"/>; }\n',
+    },
+  });
+  const r = e2e.validate({ tasksDir, worktreeRoot });
+  assert.equal(r.ok, false);
+  assert.ok(
+    r.errors.some((e) => e.includes('table-downstream-owners-row-1') && e.includes('grep miss')),
+    `expected grep-miss error, got: ${JSON.stringify(r.errors)}`
+  );
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('e2e selector audit PASSES when selector is present in sibling file', () => {
+  const { root, tasksDir, worktreeRoot } = makeE2eFixture({
+    specSelectorBlock: [
+      '- `send-email-subject-input` — existing — `components/send-email-dialog.tsx`',
+    ].join('\n'),
+    files: {
+      'components/send-email-dialog.tsx':
+        'export function D(){ return <input data-testid="send-email-subject-input"/>; }\n',
+    },
+  });
+  const r = e2e.validate({ tasksDir, worktreeRoot });
+  assert.equal(r.ok, true, `errors: ${JSON.stringify(r.errors)}`);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('e2e selector audit BLOCKS new selector when owning file not in Files to Create/Modify', () => {
+  const { root, tasksDir, worktreeRoot } = makeE2eFixture({
+    specSelectorBlock: ['- `new-selector` — new — `components/not-in-scope.tsx`'].join('\n'),
+  });
+  const r = e2e.validate({ tasksDir, worktreeRoot });
+  assert.equal(r.ok, false);
+  assert.ok(
+    r.errors.some((e) => e.includes('new-selector') && e.includes('NOT in')),
+    `expected new-not-in-scope error, got: ${JSON.stringify(r.errors)}`
+  );
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('e2e selector audit BLOCKS when ## Selectors section is missing', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-audit-'));
+  const worktreeRoot = path.join(root, 'worktree');
+  const tasksDir = path.join(worktreeRoot, 'tasks', 'ECHO-7777');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(tasksDir, 'spec.md'),
+    [
+      '# Spec',
+      '## Files to Create/Modify',
+      '- `tests/e2e/specs/admin/foo.spec.ts`',
+      'journey + page-object',
+    ].join('\n')
+  );
+  fs.writeFileSync(path.join(tasksDir, 'gherkin.feature'), '@e2e\nFeature: foo');
+  const r = e2e.validate({ tasksDir, worktreeRoot });
+  assert.equal(r.ok, false);
+  assert.ok(
+    r.errors.some((e) => e.includes('## Selectors')),
+    `expected missing-selectors-section error, got: ${JSON.stringify(r.errors)}`
+  );
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('e2e selector audit parser handles both em-dash and hyphen separators', () => {
+  const lines = [
+    '- `sel-1` — existing — `file-1.tsx`',
+    '- `sel-2` - new - `file-2.tsx`',
+    '- `sel-3` — bogus — `file-3.tsx`',
+    'not a bullet',
+  ].join('\n');
+  const parsed = e2e.parseSelectorLines(lines);
+  assert.equal(parsed.length, 3);
+  assert.deepEqual(parsed[0], { selector: 'sel-1', kind: 'existing', file: 'file-1.tsx' });
+  assert.deepEqual(parsed[1], { selector: 'sel-2', kind: 'new', file: 'file-2.tsx' });
+  assert.equal(parsed[2].malformed, true);
 });

--- a/scripts/workflows/work-spec/lib/kind-checks/e2e.js
+++ b/scripts/workflows/work-spec/lib/kind-checks/e2e.js
@@ -1,9 +1,25 @@
 /**
  * Kind: e2e — Playwright / journey tests.
+ *
+ * Validates:
+ *   1. spec.md lists at least one `tests/e2e/**\/*.spec.(ts|tsx)` file in Files to Create/Modify.
+ *   2. gherkin.feature exists and tags at least one scenario `@e2e`.
+ *   3. spec.md mentions journey/page-object reuse (warning only).
+ *   4. **Selector audit (ECHO-4457 lesson)** — spec.md must include a
+ *      `## Selectors` section that enumerates every UI selector the E2E
+ *      will touch with one of two shapes:
+ *        - `- \`<selector>\` — existing — \`<file>\``
+ *        - `- \`<selector>\` — new — \`<file-to-create>\``
+ *      For "existing" entries, grep the cited file for the selector
+ *      literal and block on miss (this is the bug class where ECHO-4457's
+ *      planned spec testids didn't match shipped sibling components).
+ *      For "new" entries, the cited file must appear in spec's
+ *      `## Files to Create/Modify` so the new selector is in-scope.
  */
 
 'use strict';
 
+const fs = require('node:fs');
 const path = require('node:path');
 const {
   readSpec,
@@ -15,6 +31,48 @@ const {
 
 function appliesTo(ctx) {
   return detectKinds(ctx.tasksDir).includes('e2e');
+}
+
+function readGherkin(tasksDir) {
+  try {
+    return fs.readFileSync(path.join(tasksDir, 'gherkin.feature'), 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function resolveWorktreeRoot(ctx) {
+  if (ctx.worktreeRoot && typeof ctx.worktreeRoot === 'string') return ctx.worktreeRoot;
+  // Fall back: tasksDir is typically <worktree>/tasks/<TICKET>
+  return path.resolve(ctx.tasksDir, '..', '..');
+}
+
+function parseSelectorLines(block) {
+  if (!block) return [];
+  const out = [];
+  for (const raw of block.split('\n')) {
+    const line = raw.trim();
+    if (!line.startsWith('-') && !line.startsWith('*')) continue;
+    // Match `<sel>` — existing|new — `<file>`
+    const m = line.match(/`([^`]+)`\s*[—\-]\s*(existing|new)\s*[—\-]\s*`([^`]+)`/i);
+    if (m) {
+      out.push({ selector: m[1].trim(), kind: m[2].toLowerCase(), file: m[3].trim() });
+    } else if (/`[^`]+`/.test(line)) {
+      out.push({ malformed: true, raw: line });
+    }
+  }
+  return out;
+}
+
+function selectorPresent(content, selector) {
+  if (!content) return false;
+  // Match: data-testid="X", data-testid='X', data-testid={'X'}, data-testid={`X`}
+  // Or the raw selector token if it's a longer aria-name/role pattern (literal match).
+  const literal = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return (
+    new RegExp(`data-testid\\s*=\\s*[{]?\\s*['"\`]${literal}['"\`]`).test(content) ||
+    content.includes(selector)
+  );
 }
 
 function validate(ctx) {
@@ -29,16 +87,7 @@ function validate(ctx) {
     );
   }
 
-  // Look for the Gherkin section / scenarios with @e2e tag — gherkin.feature
-  // is a sibling artifact under tasksDir.
-  const fs = require('node:fs');
-  const gherkin = (() => {
-    try {
-      return fs.readFileSync(path.join(ctx.tasksDir, 'gherkin.feature'), 'utf8');
-    } catch {
-      return '';
-    }
-  })();
+  const gherkin = readGherkin(ctx.tasksDir);
   if (gherkin && !/@e2e\b/.test(gherkin)) {
     errors.push('e2e kind but `gherkin.feature` has no scenario tagged `@e2e`.');
   } else if (!gherkin) {
@@ -51,6 +100,58 @@ function validate(ctx) {
     warnings.push(
       'spec.md does not mention "journey" or "page object" — confirm reusable helpers are used.'
     );
+  }
+
+  // ── Selector audit ──────────────────────────────────────────────────────
+  const selectorBlock = sliceSection(spec, /^##\s+Selectors?\b/im);
+  if (!selectorBlock.trim()) {
+    errors.push(
+      'e2e kind requires a `## Selectors` section in spec.md enumerating every selector ' +
+        'the test will use. Format per line: `` `selector-name` — existing — `path/to/file.tsx` `` ' +
+        '(or `new` if this ticket creates the component). Prevents the ECHO-4457 bug class where ' +
+        'the spec asserted testids that did not exist on shipped sibling components.'
+    );
+  } else {
+    const entries = parseSelectorLines(selectorBlock);
+    if (entries.length === 0) {
+      errors.push(
+        '`## Selectors` section is empty or no entries matched the required format ' +
+          '(`` `selector` — existing|new — `file` ``).'
+      );
+    }
+    const worktreeRoot = resolveWorktreeRoot(ctx);
+    const filesToModify = new Set(files);
+    for (const entry of entries) {
+      if (entry.malformed) {
+        warnings.push(`Selector line not in canonical format: ${entry.raw}`);
+        continue;
+      }
+      if (entry.kind === 'existing') {
+        const filePath = path.resolve(worktreeRoot, entry.file);
+        let content;
+        try {
+          content = fs.readFileSync(filePath, 'utf8');
+        } catch {
+          errors.push(
+            `Selector \`${entry.selector}\` declared as existing in \`${entry.file}\` but the file does not exist.`
+          );
+          continue;
+        }
+        if (!selectorPresent(content, entry.selector)) {
+          errors.push(
+            `Selector \`${entry.selector}\` declared as existing in \`${entry.file}\` but not found there ` +
+              '(grep miss). Either the selector name is wrong, or the file changed since spec was drafted.'
+          );
+        }
+      } else if (entry.kind === 'new') {
+        if (!filesToModify.has(entry.file)) {
+          errors.push(
+            `Selector \`${entry.selector}\` declared as new in \`${entry.file}\` but that file is NOT in ` +
+              "`## Files to Create/Modify`. New selectors require an owning file in this PR's scope."
+          );
+        }
+      }
+    }
   }
 
   return {
@@ -67,3 +168,5 @@ module.exports = function register(registerKind) {
 
 module.exports.appliesTo = appliesTo;
 module.exports.validate = validate;
+module.exports.parseSelectorLines = parseSelectorLines;
+module.exports.selectorPresent = selectorPresent;

--- a/scripts/workflows/work/hooks/__tests__/protect-tasks-md.test.js
+++ b/scripts/workflows/work/hooks/__tests__/protect-tasks-md.test.js
@@ -125,7 +125,7 @@ describe('protect-tasks-md hook', () => {
     assert.strictEqual(code, 0, 'Expected exit 0 (allow) during tasks step');
   });
 
-  it('should ALLOW Edit to tasks.md when step is task_review (exit 0)', async () => {
+  it('should ALLOW Edit to tasks.md when step is tasks_gate (exit 0)', async () => {
     const { code } = await runHookWithState(
       {
         tool_name: 'Edit',
@@ -134,11 +134,11 @@ describe('protect-tasks-md hook', () => {
       'GH-99',
       {
         tasks: 'completed',
-        implement: 'completed',
-        task_review: 'in_progress',
+        tasks_gate: 'in_progress',
+        implement: 'pending',
       }
     );
-    assert.strictEqual(code, 0, 'Expected exit 0 (allow) during task_review step');
+    assert.strictEqual(code, 0, 'Expected exit 0 (allow) during tasks_gate step');
   });
 
   it('should ALLOW Edit to non-tasks.md files (exit 0)', async () => {

--- a/scripts/workflows/work/hooks/protect-tasks-md.js
+++ b/scripts/workflows/work/hooks/protect-tasks-md.js
@@ -4,11 +4,11 @@
  * PreToolUse hook: Protect tasks.md from edits outside allowed steps.
  *
  * GH-258 Task 5: Blocks Edit/Write/MultiEdit/Bash to tasks.md when the current
- * workflow step is NOT `tasks` or `task_review`. Fail-open on errors.
+ * workflow step is NOT `tasks` or `tasks_gate`. Fail-open on errors.
  *
  * Refactored to use createArtifactProtector factory (GH-258 code review).
  *
- * Allowed steps: tasks, task_review, complete
+ * Allowed steps: tasks, tasks_gate, complete
  * All other steps: blocked (exit 2)
  * No workflow active: allowed (exit 0, fail-open)
  */
@@ -18,7 +18,7 @@ const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
 const { createArtifactProtector } = require('../../lib/protect-artifact-files');
 
-const ALLOWED_STEPS = new Set(['tasks', 'task_review', 'complete']);
+const ALLOWED_STEPS = new Set(['tasks', 'tasks_gate', 'complete']);
 
 /**
  * Check whether a file named tasks.md is the root-level workflow artifact
@@ -122,7 +122,7 @@ function getStepInProgress(ticketId) {
 }
 
 const protector = createArtifactProtector({
-  artifacts: [{ basename: 'tasks.md', step: 'tasks', allowedSteps: ['task_review'] }],
+  artifacts: [{ basename: 'tasks.md', step: 'tasks', allowedSteps: ['tasks_gate'] }],
   getStepInProgress,
   getTicketId,
   // Bash write-vector detection is handled by createArtifactProtector (checks basename in command strings)

--- a/scripts/workflows/work/scripts/follow-up-pr.js
+++ b/scripts/workflows/work/scripts/follow-up-pr.js
@@ -834,6 +834,7 @@ function getReviews(prNumber) {
 
 function getRepoSlug() {
   try {
+    const { buildChildEnv } = require('./gh-exec.js');
     const result = execFileSync(
       'gh',
       ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
@@ -841,6 +842,7 @@ function getRepoSlug() {
         encoding: 'utf8',
         stdio: ['pipe', 'pipe', 'pipe'],
         timeout: 5000,
+        env: buildChildEnv(),
       }
     ).trim();
     return result.replace(/[^\w.-]/g, '_');

--- a/scripts/workflows/work/scripts/gh-exec.js
+++ b/scripts/workflows/work/scripts/gh-exec.js
@@ -14,6 +14,23 @@ const { execFileSync } = require('child_process');
  * @param {boolean} [opts.allowNonZero=false] - Tolerate non-zero exit codes
  * @returns {*} Parsed JSON or trimmed string
  */
+/**
+ * Build a child env that lets gh use its keyring auth (~/.config/gh/hosts.yml)
+ * instead of an environment-injected token. If GH_TOKEN / GITHUB_TOKEN is set
+ * in the parent process — common in dev environments where a personal-access
+ * token is exported for unrelated tooling — gh prefers the env var over the
+ * keyring. When that token belongs to a different account than the one
+ * authorized for the repo, every API call returns 404 ("Could not resolve
+ * repository" / "error connecting to api.github.com"). Scrubbing both vars
+ * forces gh to fall back to the keyring's active account.
+ */
+function buildChildEnv() {
+  const env = { ...process.env };
+  delete env.GH_TOKEN;
+  delete env.GITHUB_TOKEN;
+  return env;
+}
+
 function ghExec(ghArgs, { json = true, allowNonZero = false } = {}) {
   const args = typeof ghArgs === 'string' ? ghArgs.split(/\s+/) : ghArgs;
   try {
@@ -21,6 +38,7 @@ function ghExec(ghArgs, { json = true, allowNonZero = false } = {}) {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 30000,
+      env: buildChildEnv(),
     });
     return json ? JSON.parse(result) : result.trim();
   } catch (err) {
@@ -40,4 +58,4 @@ function ghExec(ghArgs, { json = true, allowNonZero = false } = {}) {
   }
 }
 
-module.exports = { ghExec };
+module.exports = { ghExec, buildChildEnv };

--- a/scripts/workflows/work/scripts/gh-exec.js
+++ b/scripts/workflows/work/scripts/gh-exec.js
@@ -37,7 +37,7 @@ function ghExec(ghArgs, { json = true, allowNonZero = false } = {}) {
     const result = execFileSync('gh', args, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 30000,
+      timeout: 60000,
       env: buildChildEnv(),
     });
     return json ? JSON.parse(result) : result.trim();

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -228,13 +228,30 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       step: STEPS.pr,
     },
     // Self-paced ci-step runner: phases the wait/triage/fix/rerun loop.
+    // Allow-list = the real developer agents that get dispatched to fix CI
+    // failures. `ci-runner` / `ci-triager` are reserved for future dedicated
+    // agents but kept here so explicit ci-* agents still work if registered.
     'ci-next.js': {
-      agents: ['ci-runner', 'ci-triager'],
+      agents: [
+        'ci-runner',
+        'ci-triager',
+        'developer-nodejs-tdd',
+        'developer-react-senior',
+        'developer-react-ui-architect',
+        'developer-devops',
+      ],
       step: STEPS.ci,
       companionScripts: ['ci-phase-state.js'],
     },
     'ci-phase-state.js': {
-      agents: ['ci-runner', 'ci-triager'],
+      agents: [
+        'ci-runner',
+        'ci-triager',
+        'developer-nodejs-tdd',
+        'developer-react-senior',
+        'developer-react-ui-architect',
+        'developer-devops',
+      ],
       step: STEPS.ci,
     },
     // Self-paced completion-checker runner: phases the requirement

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -626,7 +626,13 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
           // PR is proven if an open PR exists for the current branch
           try {
             const { execFileSync } = require('child_process');
-            const opts = { encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] };
+            const { buildChildEnv } = require('../lib/scripts/gh-exec');
+            const opts = {
+              encoding: 'utf-8',
+              timeout: 10000,
+              stdio: ['pipe', 'pipe', 'pipe'],
+              env: buildChildEnv(),
+            };
 
             // Resolve branch to support worktree contexts (GH-191, GH-203)
             // Note: gh pr view uses positional branch arg, not --head flag

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -626,7 +626,7 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
           // PR is proven if an open PR exists for the current branch
           try {
             const { execFileSync } = require('child_process');
-            const { buildChildEnv } = require('../lib/scripts/gh-exec');
+            const { buildChildEnv } = require('./scripts/gh-exec');
             const opts = {
               encoding: 'utf-8',
               timeout: 10000,

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -309,6 +309,19 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       agents: ['reports-writer'],
       step: STEPS.reports,
     },
+    // Self-paced cleanup runner: phases the per-ticket cleanup loop
+    // (branch delete, scoped tmux kill, state archive). Defensive
+    // pr_merged_check duplicates ci-step's wait_merge — cleanup never
+    // runs against a non-merged PR.
+    'cleanup-next.js': {
+      agents: ['cleanup-runner'],
+      step: STEPS.cleanup,
+      companionScripts: ['cleanup-phase-state.js'],
+    },
+    'cleanup-phase-state.js': {
+      agents: ['cleanup-runner'],
+      step: STEPS.cleanup,
+    },
   };
 
   const workflow = {

--- a/scripts/workflows/work2/lib/step-enrichments/check.js
+++ b/scripts/workflows/work2/lib/step-enrichments/check.js
@@ -29,17 +29,10 @@ function buildBaseCandidates(base) {
 }
 
 function gitDiffFiles(workDir) {
-  // Resolve the repo's configured base branch (honors BASE_BRANCH env / git
-  // symbolic-ref / probes for main/master/dev). Falls back to 'main' only if
-  // config.getBaseBranch() can't be resolved — and we still try `origin/<b>`
-  // first since most plugin consumers diff against the remote tip.
-  let base = 'main';
-  try {
-    base = config.getBaseBranch({ cwd: workDir }) || 'main';
-  } catch {
-    /* fall through with default */
-  }
-  const candidates = buildBaseCandidates(base);
+  // Use the shared base-candidate resolver so check, code-checker, and
+  // completion-checker all pick the same base ref. Honors BASE_BRANCH env
+  // and git symbolic-ref; falls back to origin/main.
+  const candidates = config.getDiffBaseCandidates({ cwd: workDir });
   for (const ref of candidates) {
     try {
       const out = execSync(`git diff --name-only ${ref}...HEAD`, {

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -79,49 +79,6 @@ Configure in your `.envrc`:
 export BOOTSTRAP_SCRIPT="./scripts/bootstrap.sh"
 ```
 
-### Step 5.5: Open orchestrator listener channel (MANDATORY)
-
-Before reporting success, ensure the worker agent for this ticket can
-receive messages from the orchestrator/monitor. The listener uses the
-file-based mailbox at `/tmp/claude-agent-inbox/<TICKET>.log` (channel
-names are case-insensitive and uppercased by the script).
-
-Start a detached `tmux` session that tails the channel so any monitor
-message lands in a pane the agent can read. Idempotent — skips if a
-session for the ticket already exists.
-
-```bash
-LISTEN_SESSION="${TICKET_ID}-listen"
-if ! tmux has-session -t "$LISTEN_SESSION" 2>/dev/null; then
-  tmux new-session -d -s "$LISTEN_SESSION" \
-    "node \"${CLAUDE_PLUGIN_ROOT}/scripts/listen-communication.js\" $TICKET_ID"
-  echo "  ✓ orchestrator listener started: tmux session $LISTEN_SESSION"
-else
-  echo "  ✓ orchestrator listener already running: tmux session $LISTEN_SESSION"
-fi
-```
-
-After starting, verify a listener is attached by running:
-
-```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/communicate.js" --check "$TICKET_ID"
-# Exits 0 if at least one listener is attached, exits 3 otherwise.
-```
-
-**Why this is mandatory:**
-- The /orchestrate Monitor ↔ Agent Unblocking Protocol (ACK → fix → DONE)
-  depends on the worker having an active listener. Without it, monitor
-  messages are written but never seen, and the agent can stall waiting
-  for a response that already arrived.
-- The worker agent MUST also accept messages on this channel: it should
-  poll the tmux pane (`tmux capture-pane -p -t "$LISTEN_SESSION"`) or
-  attach a side pane in its own session before starting work.
-- Talking back to the monitor uses:
-  ```bash
-  node "${CLAUDE_PLUGIN_ROOT}/scripts/communicate.js" \
-    MONITOR "$TICKET_ID: <message to orchestrator>"
-  ```
-
 ### Step 6: Report results
 
 After processing all tasks, display summary:
@@ -177,8 +134,12 @@ Next steps:
 | 3 | Fetch ticket details |
 | 4 | Create worktree + branch (uses `BASE_BRANCH` env var, defaults to `main`) |
 | 5 | Run custom bootstrap script (if `BOOTSTRAP_SCRIPT` is set) |
-| 5.5 | Start orchestrator listener (tmux `<TICKET>-listen` running `listen-communication.js`) |
 | 6 | Display summary |
+
+**Note:** Bootstrap does NOT start the orchestrator listener. The
+`<TICKET>-listen` tmux session is started by `/work2` on every
+invocation (idempotent) so the worker — not the worktree creator —
+owns the channel.
 
 ## Notes
 

--- a/skills/follow-up2/SKILL.md
+++ b/skills/follow-up2/SKILL.md
@@ -14,6 +14,11 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/workflows/follow-up2/follow-up-next.js" <TIC
 
 ## Rules
 
+- **NEVER pipe the output.** Do NOT use `| head`, `| tail`, `| grep`, `| jq`, `> file`, `2>&1 |`, or any pipe/redirection. Piping breaks stdout buffering, truncates the JSON `delegate` block, and hides phase-transition notifications — you will miss instructions and the script will appear stuck. Run it raw:
+  - ✅ `node ".../follow-up-next.js" <TICKET> --init --pr N`
+  - ❌ `node ".../follow-up-next.js" <TICKET> --init --pr N | head -30`
+  - ❌ `node ".../follow-up-next.js" <TICKET> --init --pr N 2>&1 | tee log`
+- If the output is long, scroll — do not pipe to truncate. The full JSON response is what you act on.
 - The script waits for CI internally (up to 40 attempts with adaptive intervals). **CI can take 20+ minutes. This is normal. Do NOT cancel, interrupt, or give up.**
 - Execute the returned `delegate` block exactly as described.
 - After executing, re-run follow-up-next.js (without --init) for the next instruction.

--- a/skills/work2/SKILL.md
+++ b/skills/work2/SKILL.md
@@ -24,6 +24,31 @@ Replace `<TICKET>` with `$ARGUMENTS` (the ticket id). The Monitor runs for
 the lifetime of your session — do not stop it. Only the main /work2
 orchestrator opens this channel; dispatched subagents do NOT.
 
+**Step 0.5 — ensure the tmux listener pane is running (idempotent).** This
+must run on EVERY /work2 invocation, regardless of step — bootstrap is not
+guaranteed to have run in this session (resumes, reworks, mid-workflow
+restarts). The Monitor tool consumes events into your conversation; the
+tmux pane gives a human/orchestrator a place to send nudges that the
+worker can see via `tmux capture-pane`. Both are required.
+
+```bash
+LISTEN_SESSION="${ARGUMENTS%% *}-listen"
+if ! tmux has-session -t "$LISTEN_SESSION" 2>/dev/null; then
+  tmux new-session -d -s "$LISTEN_SESSION" \
+    "node \"${CLAUDE_PLUGIN_ROOT}/scripts/listen-communication.js\" ${ARGUMENTS%% *}"
+  echo "  ✓ listener started: tmux session $LISTEN_SESSION"
+else
+  echo "  ✓ listener already running: tmux session $LISTEN_SESSION"
+fi
+```
+
+Verify a listener is attached:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/communicate.js" --check "${ARGUMENTS%% *}"
+# Exits 0 if at least one listener is attached, exits 3 otherwise.
+```
+
 **Step 1 — then start the driver:**
 
 ```bash


### PR DESCRIPTION
## Existing Behavior

- The `ci` step marked itself complete as soon as CI checks went green, allowing the workflow to advance to `cleanup`, `reports`, and `complete` before the PR was actually merged on `main`.
- No `cleanup` step runner existed; post-merge branch and tmux session teardown had no automated orchestration.
- The `work-ci/` runner had 7 phases; no gate waited for the actual GitHub merge event.
- The cleanup runner's `inputs` phase returned `ok: true` even when `prNumber` was null, causing `pr_merged_check` to fail in a dead loop.
- `gh` CLI subprocesses inherited `GH_TOKEN`/`GITHUB_TOKEN` from the parent environment, causing all API calls to return misleading 404 errors when the token belonged to a different GitHub account than the one authorized via keyring.
- `protect-tasks-md.js` blocked edits to `tasks.md` during `tasks_gate`, forcing a deadlock because the validator hint instructed users to edit the file in-place.

## Intended New Behavior

- A new `wait_merge` phase (phase 7 of 8 in `work-ci/`) polls `gh pr view --json state` in a re-entrant WAITING loop and hard-blocks if the PR is CLOSED without merging. The workflow cannot exit the `ci` step until `state === MERGED`.
- A new self-paced `work-cleanup/` runner (`cleanup-next.js`) orchestrates 7 phases — `inputs → pr_merged_check → branch_cleanup → tmux_cleanup → state_archive → memorize → done` — with a token-protected `cleanup-phase-state.js` writer, gated to `cleanup-runner` agent only.
- The `inputs` phase in the cleanup runner now validates that both `branch` and `prNumber` are present before returning `ok: true`, preventing `pr_merged_check` from entering an unrecoverable loop on null inputs.
- A new `buildChildEnv()` helper in `gh-exec.js` strips `GH_TOKEN` and `GITHUB_TOKEN` from every `gh` subprocess environment, forcing the CLI to fall back to keyring auth. Applied to all 8 direct gh callers across `follow-up2`, `work-ci`, `work-cleanup`, and `work` workflows; all 16 `ghExec()` callers benefit automatically.
- `protect-tasks-md.js` now allows edits during `tasks_gate` (replacing the erroneous `task_review` entry). `task_review` reviews code and tests — not task definitions — so the allow-list correction unblocks in-place task spec fixes.
- Hard rules in `agents/cleanup-runner.md` forbid `tmux kill-server`, force-deleting unmerged branches, and auto-removing worktrees without explicit user request.
- `next-action-footer.js` and `workflow-definition.js` wired to recognise `cleanup-next.js` and `cleanup-phase-state.js` under `STEPS.cleanup`, allow-listed to `['cleanup-runner']`.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify CI merge gate (`wait_merge` phase):**

1. Start a ticket in `ci` step with a merged PR — run `node scripts/workflows/work-ci/ci-next.js <TICKET>` and confirm it advances past `wait_merge` to `memorize`.
2. Run the same with a PR still in `state: OPEN` — confirm the orchestrator exits with `WAITING` and prints the wait instructions (no errors emitted).
3. Run with `state: CLOSED` (PR closed without merge) — confirm a hard-block error is returned and the step does not advance.

**Verify cleanup runner inputs guard:**

1. Run `node scripts/workflows/work-cleanup/cleanup-next.js <TICKET>` with a ticket that has no `prNumber` in state — confirm the `inputs` phase returns an error and does NOT set `ok: true`.
2. Confirm `pr_merged_check` is never reached in that scenario (no loop).

**Verify cleanup runner (happy path):**

1. After a PR merges, run `node scripts/workflows/work-cleanup/cleanup-next.js <TICKET>` with a valid ticket directory.
2. Confirm `pr_merged_check` passes when the PR is `MERGED`.
3. Confirm `branch_cleanup` deletes the local + remote branch.
4. Confirm `tmux_cleanup` only kills sessions whose names include the ticket ID (verify other sessions remain intact).
5. Confirm `state_archive` writes `cleanup-summary.md` with `## Branch`, `## Tmux sessions`, `## Worktree`, and `Status: DONE` or `Status: PARTIAL`.
6. Confirm `cleanup-phase-state.js` rejects writes from any agent other than `cleanup-runner`.

**Verify `buildChildEnv()` token scrubbing:**

1. Set `GH_TOKEN=<token-for-different-account>` in the shell environment.
2. Invoke any phase that calls `ghExec()` (e.g. `wait_merge`, `pr_merged_check`).
3. Confirm the call succeeds using keyring auth — no 404 "error connecting to api.github.com".
4. Confirm `GH_TOKEN` and `GITHUB_TOKEN` are absent from the child process environment via debug logging.

**Verify `tasks_gate` edit unblock:**

1. Start a workflow in the `tasks_gate` step.
2. Attempt to edit `tasks.md` in-place to fix a validator failure.
3. Confirm `protect-tasks-md.js` allows the edit (previously blocked with exit 2).
4. Confirm the same edit is still blocked when the workflow is in `task_review`.

### Test Results

Full suite: 3761/3762 passing. The single failure is the pre-existing `session-guard.test.js:474` flake (unrelated to this PR). New tests added:
- `work-cleanup/__tests__/cleanup-phase-registry.test.js` (19 new tests covering cleanup phases, inputs guard, and phase state token gating)
- `work-ci/__tests__/wait_merge.test.js`
- `work/hooks/__tests__/protect-tasks-md.test.js` — 18/18 passing after `tasks_gate` fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to new workflow step runner/state writer and CI phase gating that can block workflow progression if `gh`/state detection misbehaves; also changes auth environment passed to `gh` across multiple workflows.
> 
> **Overview**
> Adds a new self-paced **`cleanup` step runner** (`work-cleanup/cleanup-next.js`) with a phased flow (`inputs → pr_merged_check → branch_cleanup → tmux_cleanup → state_archive → memorize → done`), plus a token-gated `cleanup-phase-state.js` writer and new `cleanup-runner` agent guidance to ensure branch/tmux cleanup is strictly ticket-scoped and only runs on *merged* PRs.
> 
> Extends the `ci` step to **wait for the PR to be actually merged** by inserting a re-entrant `wait_merge` phase after `rerun_check`, preventing the workflow from advancing to cleanup/reports/complete on green CI alone.
> 
> Hardens GitHub CLI usage by introducing `buildChildEnv()` (scrubs `GH_TOKEN`/`GITHUB_TOKEN`, longer timeout) and wiring it into direct `gh` subprocess calls across follow-up2/work-ci/work/work-cleanup, and centralizes base-branch diffing via `config.getDiffBaseCandidates()` to avoid incorrect `origin/main` diffs on dev-based repos.
> 
> Tightens workflow wiring/docs: allows `tasks.md` edits during `tasks_gate` (not `task_review`), expands trusted script dirs and step footer mapping for `cleanup-next.js`, adds an e2e spec `## Selectors` audit that blocks missing/mis-scoped selectors, and updates skill docs to move tmux listener ownership to `/work2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5585a6b9c93230cc3b928ceffa4699a0028b9024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->