### PR TITLE
fix(work): require PR merged for ci gate + fix gherkin validateConsistency call signature

### DIFF
--- a/scripts/workflows/work-tasks/lib/phases/gherkin_link.js
+++ b/scripts/workflows/work-tasks/lib/phases/gherkin_link.js
@@ -54,8 +54,10 @@ function validateArtifacts(tasksDir) {
         for (const e of result.errors) errors.push(`gherkin-task-refs: ${e}`);
         return errors;
       }
-      if (result && result.ok === false && result.message) {
-        errors.push(`gherkin-task-refs: ${result.message}`);
+      // Canonical validator passed — trust it and skip the naive fallback,
+      // which can produce false positives by tasks.includes(title) on titles
+      // referenced via Acceptance Criteria or Requirements Covered.
+      if (result && result.valid === true) {
         return errors;
       }
     } catch (e) {

--- a/scripts/workflows/work-tasks/lib/phases/gherkin_link.js
+++ b/scripts/workflows/work-tasks/lib/phases/gherkin_link.js
@@ -49,7 +49,7 @@ function validateArtifacts(tasksDir) {
   // Use the canonical validator if available.
   if (typeof validateConsistency === 'function') {
     try {
-      const result = validateConsistency(gherkin, tasks);
+      const result = validateConsistency({ gherkinText: gherkin, tasksMdText: tasks });
       if (result && Array.isArray(result.errors) && result.errors.length) {
         for (const e of result.errors) errors.push(`gherkin-task-refs: ${e}`);
         return errors;

--- a/scripts/workflows/work2/lib/step-enrichments/ci-gate.js
+++ b/scripts/workflows/work2/lib/step-enrichments/ci-gate.js
@@ -54,10 +54,20 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
     // / ci-triager) is dispatched to wait + verify. Falling through is the
     // safe failure mode: it gives the agent a chance to surface the issue
     // rather than silently completing the step.
+    //
+    // Merge requirement: CI passing alone is NOT enough — the PR must also
+    // be MERGED before we declare the `ci` step complete. The agent's job
+    // ends at "code shipped to base branch," not "code ready to ship."
+    // Advancing on an unmerged PR caused the workflow to report `complete`
+    // while PR #1869 was still open (see triage echo-4448-issue-1). Without
+    // the merge requirement, the workflow declares success on work that may
+    // never land (PR closed without merge, conflicts blocking merge, review
+    // not yet granted). Both conditions are independent and BOTH are required:
+    //   - `ci.status === 'passing'` — checks went green (independent verify)
+    //   - `prInfo.state === 'MERGED'` — code actually shipped
     const ci = checkCI(prInfo.number);
-    if (ci && ci.status === 'passing') {
-      const reason = prInfo.state === 'MERGED' ? 'CI passing (PR merged)' : 'CI passing';
-      return advanceToCleanup(safeName, deps, reason);
+    if (ci && ci.status === 'passing' && prInfo.state === 'MERGED') {
+      return advanceToCleanup(safeName, deps, 'CI passing and PR merged');
     }
   } catch {
     // Can't check PR/CI state — fall through to normal transition


### PR DESCRIPTION
## Existing Behavior

- The `ci → cleanup` advancement gate in `ci-gate.js` advanced the workflow to `cleanup` (and ultimately `complete`) as soon as CI checks reported passing, regardless of whether the PR had actually been merged. This caused ECHO-4448 to report `complete` while PR #1869 was still open.
- The `gherkin_link.js` validator called `validateConsistency(gherkin, tasks)` with positional arguments. The canonical signature expects an options object `{ gherkinText, tasksMdText }`, so both fields destructured to `undefined` and the function always returned `"gherkin.feature is missing or empty"`, masking any real validation errors.

## Intended New Behavior

- `ci-gate.js` now requires BOTH `ci.status === 'passing'` AND `prInfo.state === 'MERGED'` before advancing. CI green means checks passed; merged means the code actually shipped to the base branch. Both conditions are independent and both are required — a PR can have green CI but remain unmerged due to review hold, conflicts, or being closed without merge.
- `gherkin_link.js` now calls `validateConsistency({ gherkinText: gherkin, tasksMdText: tasks })`, matching the canonical options-object signature in `gherkin-task-refs.js:170`, so real consistency errors are surfaced correctly.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**ci-gate fix (ECHO-4448 / PR #1869 regression):**

1. Trigger a `/work2` session through to the `ci` step with a PR that has green CI but is not yet merged.
2. Observe that the workflow does NOT advance to `cleanup` — it remains in `ci` until the PR is merged.
3. Merge the PR. On the next `ci` step poll, confirm the workflow advances to `cleanup` with reason `"CI passing and PR merged"`.

**gherkin_link fix (ECHO-4453):**

1. Run a `/work-tasks` session that has a `gherkin.feature` file with deliberate task-ref inconsistencies (e.g., a task number referenced in Gherkin but absent from `tasks.md`).
2. Confirm the validator now returns the actual inconsistency errors rather than the generic `"gherkin.feature is missing or empty"` message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes workflow step advancement semantics: `ci` will no longer auto-advance on green checks unless the PR is actually merged, which could increase time spent in the CI step or reveal previously hidden CI/merge state edge cases.
> 
> **Overview**
> Fixes two workflow regressions affecting task validation and CI step completion.
> 
> In `work-tasks` `gherkin_link`, updates the call to the shared `validateConsistency` to use the expected options-object signature and, when that canonical validator reports `valid: true`, skips the naive title-string fallback to avoid false positives.
> 
> In `work2` `ci-gate`, tightens the `ci → cleanup` advance gate to require **both** `checkCI(...).status === 'passing'` and `prInfo.state === 'MERGED'` before marking CI complete, preventing workflows from reporting completion for unmerged PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71252f03df5a07f7bd59e3307efa76b396febeeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->