### PR TITLE
fix(work): mirror GitHub merge button in ci-gate and follow-up gates

### DIFF
--- a/scripts/workflows/follow-up/__tests__/already-complete-reverify.test.js
+++ b/scripts/workflows/follow-up/__tests__/already-complete-reverify.test.js
@@ -14,8 +14,11 @@ const os = require('node:os');
 const path = require('node:path');
 
 // ─── Stub pr-mergeable BEFORE follow-up-next loads ──────────────────────────
+// hasActionableBlockers is the real helper — we want follow-up-next to
+// exercise the actual filter/guard logic, only assessMergeable is stubbed.
 
 const prMergeablePath = require.resolve('../../work/lib/pr-mergeable.js');
+const realPrMergeable = require('../../work/lib/pr-mergeable.js');
 let stubMergeableResult = null;
 require.cache[prMergeablePath] = {
   id: prMergeablePath,
@@ -26,6 +29,7 @@ require.cache[prMergeablePath] = {
       return stubMergeableResult;
     },
     classify: () => stubMergeableResult,
+    hasActionableBlockers: realPrMergeable.hasActionableBlockers,
   },
 };
 

--- a/scripts/workflows/follow-up/__tests__/already-complete-reverify.test.js
+++ b/scripts/workflows/follow-up/__tests__/already-complete-reverify.test.js
@@ -125,3 +125,61 @@ test('saved state complete + PR number missing → fast path honored (no reverif
   const r = mod.getNextInstruction('TEST-3', null);
   assert.equal(r.action, 'complete');
 });
+
+test('saved state complete + only gh_error blocker → honored (transient, do NOT rewind)', () => {
+  // Regression: gh CLI timeouts/rate-limits become {kind: 'gh_error'}
+  // blockers. That means "we couldn't verify", not "we verified it's
+  // broken". Rewinding on a transient blip discards real progress.
+  stubMergeableResult = {
+    mergeable: false,
+    blockers: [{ kind: 'gh_error', detail: 'gh timed out' }],
+    signals: { prState: 'MERGED' },
+  };
+  const mod = loadFresh();
+  const { STEPS } = require('../lib/step-registry');
+  writeState('TEST-4', {
+    ticketId: 'TEST-4',
+    prNumber: 999,
+    currentStep: STEPS[STEPS.length - 1],
+    status: 'complete',
+  });
+  const r = mod.getNextInstruction('TEST-4', 999);
+  assert.equal(r.action, 'complete', 'expected fast-path honored on transient gh_error');
+});
+
+test('saved state complete + gh_error AND real blocker → rewinds (real blocker wins)', () => {
+  stubMergeableResult = {
+    mergeable: false,
+    blockers: [
+      { kind: 'gh_error', detail: 'one call failed' },
+      { kind: 'checks_running', detail: '3 still running' },
+    ],
+    signals: { prState: 'OPEN' },
+  };
+  const mod = loadFresh();
+  const { STEPS } = require('../lib/step-registry');
+  writeState('TEST-5', {
+    ticketId: 'TEST-5',
+    prNumber: 999,
+    currentStep: STEPS[STEPS.length - 1],
+    status: 'complete',
+  });
+  const origStderr = process.stderr.write;
+  let stderrCaptured = '';
+  process.stderr.write = (chunk) => {
+    stderrCaptured += String(chunk);
+    return true;
+  };
+  try {
+    try {
+      mod.getNextInstruction('TEST-5', 999);
+    } catch {
+      /* expected — runStep dispatch isn't stubbed */
+    }
+  } finally {
+    process.stderr.write = origStderr;
+  }
+  const after = readState('TEST-5');
+  assert.notEqual(after.status, 'complete', 'expected rewind when a real blocker is present');
+  assert.match(stderrCaptured, /checks_running/);
+});

--- a/scripts/workflows/follow-up/__tests__/already-complete-reverify.test.js
+++ b/scripts/workflows/follow-up/__tests__/already-complete-reverify.test.js
@@ -147,6 +147,29 @@ test('saved state complete + only gh_error blocker → honored (transient, do NO
   assert.equal(r.action, 'complete', 'expected fast-path honored on transient gh_error');
 });
 
+test('saved state complete + MERGED PR with transient UNKNOWN merge-state → honored (no rewind churn)', () => {
+  // Regression: GitHub reports mergeStateStatus=UNKNOWN for ~5-30s after
+  // merge. That makes assessMergeable return mergeable:false even though
+  // the work is done. Without a prState guard, follow-up-next would
+  // rewind to monitor (which immediately sees MERGED and completes),
+  // then on the next call rewind again — an infinite churn loop.
+  stubMergeableResult = {
+    mergeable: false,
+    blockers: [{ kind: 'merge_state_unknown', detail: 'GitHub still computing' }],
+    signals: { prState: 'MERGED' },
+  };
+  const mod = loadFresh();
+  const { STEPS } = require('../lib/step-registry');
+  writeState('TEST-6', {
+    ticketId: 'TEST-6',
+    prNumber: 999,
+    currentStep: STEPS[STEPS.length - 1],
+    status: 'complete',
+  });
+  const r = mod.getNextInstruction('TEST-6', 999);
+  assert.equal(r.action, 'complete', 'expected fast-path honored when PR is MERGED');
+});
+
 test('saved state complete + gh_error AND real blocker → rewinds (real blocker wins)', () => {
   stubMergeableResult = {
     mergeable: false,

--- a/scripts/workflows/follow-up/__tests__/already-complete-reverify.test.js
+++ b/scripts/workflows/follow-up/__tests__/already-complete-reverify.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+// Verify that follow-up-next's "Already complete" fast-path now re-verifies
+// against GitHub before honoring the saved status. Regression: PR #1929 had
+// 9 IN_PROGRESS checks + 2 unpushed commits but the cached state declared
+// the workflow complete and the session guard self-cleared.
+
+process.env.FOLLOW_UP2_NO_DELAY = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// ─── Stub pr-mergeable BEFORE follow-up-next loads ──────────────────────────
+
+const prMergeablePath = require.resolve('../../work/lib/pr-mergeable.js');
+let stubMergeableResult = null;
+require.cache[prMergeablePath] = {
+  id: prMergeablePath,
+  filename: prMergeablePath,
+  loaded: true,
+  exports: {
+    assessMergeable() {
+      return stubMergeableResult;
+    },
+    classify: () => stubMergeableResult,
+  },
+};
+
+// Isolate state directory per test.
+let tmpRoot;
+test.beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'follow-up-reverify-'));
+  process.env.TASKS_BASE = tmpRoot;
+  process.env.WORKTREES_BASE = tmpRoot;
+});
+test.afterEach(() => {
+  if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function loadFresh() {
+  // Re-resolve follow-up-next each test so it picks up the env vars.
+  const p = require.resolve('../follow-up-next.js');
+  delete require.cache[p];
+  return require(p);
+}
+
+function writeState(ticketId, state) {
+  const dir = path.join(tmpRoot, ticketId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '.follow-up-state.json'), JSON.stringify(state));
+}
+
+function readState(ticketId) {
+  const p = path.join(tmpRoot, ticketId, '.follow-up-state.json');
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+test('saved state complete + PR mergeable → fast path honored', () => {
+  stubMergeableResult = { mergeable: true, blockers: [], signals: { prState: 'MERGED' } };
+  writeState('TEST-1', {
+    ticketId: 'TEST-1',
+    prNumber: 999,
+    currentStep: 'report',
+    status: 'complete',
+  });
+  const mod = loadFresh();
+  const r = mod.getNextInstruction('TEST-1', 999);
+  assert.equal(r.action, 'complete');
+  assert.match(r.summary, /Already complete/i);
+});
+
+test('saved state complete + PR NOT mergeable → rewinds, does not return complete', () => {
+  stubMergeableResult = {
+    mergeable: false,
+    blockers: [
+      { kind: 'checks_running', detail: '9 still running' },
+      { kind: 'merge_state_blocked', detail: 'blocked' },
+    ],
+    signals: { prState: 'OPEN' },
+  };
+  // Use a currentStep value that IS in STEPS so the loop will exit the
+  // outer "complete" block immediately after rewind without recursing into
+  // an invalid-step path.
+  const mod = loadFresh();
+  const { STEPS } = require('../lib/step-registry');
+  writeState('TEST-2', {
+    ticketId: 'TEST-2',
+    prNumber: 1929,
+    currentStep: STEPS[STEPS.length - 1],
+    status: 'complete',
+  });
+
+  const origStderr = process.stderr.write;
+  let stderrCaptured = '';
+  process.stderr.write = (chunk) => {
+    stderrCaptured += String(chunk);
+    return true;
+  };
+  try {
+    try {
+      mod.getNextInstruction('TEST-2', 1929);
+    } catch {
+      /* expected — runStep dispatch isn't stubbed */
+    }
+  } finally {
+    process.stderr.write = origStderr;
+  }
+  const after = readState('TEST-2');
+  assert.notEqual(after.status, 'complete', 'status should have been rewound');
+  assert.match(stderrCaptured, /rewinding/i);
+});
+
+test('saved state complete + PR number missing → fast path honored (no reverify possible)', () => {
+  stubMergeableResult = null; // shouldn't be called
+  writeState('TEST-3', {
+    ticketId: 'TEST-3',
+    prNumber: null,
+    currentStep: 'report',
+    status: 'complete',
+  });
+  const mod = loadFresh();
+  const r = mod.getNextInstruction('TEST-3', null);
+  assert.equal(r.action, 'complete');
+});

--- a/scripts/workflows/follow-up/follow-up-next.js
+++ b/scripts/workflows/follow-up/follow-up-next.js
@@ -156,10 +156,17 @@ function getNextInstruction(ticketId, prNumber) {
         } catch {
           liveMergeable = null;
         }
-        if (liveMergeable && !liveMergeable.mergeable) {
-          const blockerSummary = (liveMergeable.blockers || []).map((b) => b.kind).join(', ');
+        // Ignore gh_error blockers — those mean "we couldn't reach GitHub
+        // to verify", not "we verified the PR is broken". Rewinding the
+        // workflow on a transient network blip would discard real progress.
+        // Only act on concrete blockers (merge_state_*, checks_running).
+        const realBlockers = (
+          liveMergeable && liveMergeable.blockers ? liveMergeable.blockers : []
+        ).filter((b) => b.kind !== 'gh_error');
+        if (liveMergeable && !liveMergeable.mergeable && realBlockers.length > 0) {
+          const blockerSummary = realBlockers.map((b) => b.kind).join(', ');
           process.stderr.write(
-            `[follow-up-next] saved state said complete but PR #${state.prNumber} is not mergeable (${blockerSummary || 'unknown'}); rewinding and resuming.\n`
+            `[follow-up-next] saved state said complete but PR #${state.prNumber} is not mergeable (${blockerSummary}); rewinding and resuming.\n`
           );
           state.status = 'in_progress';
           // Always reset to the first step on rewind. The saved currentStep

--- a/scripts/workflows/follow-up/follow-up-next.js
+++ b/scripts/workflows/follow-up/follow-up-next.js
@@ -148,31 +148,23 @@ function getNextInstruction(ticketId, prNumber) {
       // step from live GitHub state.
       if (state.prNumber) {
         let liveMergeable = null;
+        let actionable = false;
+        let realBlockers = [];
         try {
-          const { assessMergeable } = require(
+          const { assessMergeable, hasActionableBlockers } = require(
             path.join(__dirname, '..', 'work', 'lib', 'pr-mergeable.js')
           );
           liveMergeable = assessMergeable(state.prNumber);
+          // hasActionableBlockers centralises the two guards (filter out
+          // gh_error transients, require prState=OPEN) shared with
+          // ci-gate.js. See pr-mergeable.js for the full rationale.
+          const action = hasActionableBlockers(liveMergeable);
+          actionable = action.actionable;
+          realBlockers = action.realBlockers;
         } catch {
           liveMergeable = null;
         }
-        // Ignore gh_error blockers — those mean "we couldn't reach GitHub
-        // to verify", not "we verified the PR is broken". Rewinding the
-        // workflow on a transient network blip would discard real progress.
-        // Only act on concrete blockers (merge_state_*, checks_running).
-        const realBlockers = (
-          liveMergeable && liveMergeable.blockers ? liveMergeable.blockers : []
-        ).filter((b) => b.kind !== 'gh_error');
-        // Skip rewind when the PR is already MERGED. GitHub transiently
-        // reports `mergeStateStatus: UNKNOWN` for ~5-30s after merge, which
-        // produces a non-mergeable result even though the work is done.
-        // Rewinding here would just loop: monitor → MERGED → report →
-        // complete → rewind → monitor... Mirror ci-gate's `prState ===
-        // 'OPEN'` guard so only an actually-open-and-broken PR rewinds.
-        const liveState =
-          (liveMergeable && liveMergeable.signals && liveMergeable.signals.prState) || '';
-        const prIsOpen = liveState === '' || liveState === 'OPEN';
-        if (liveMergeable && !liveMergeable.mergeable && realBlockers.length > 0 && prIsOpen) {
+        if (actionable) {
           const blockerSummary = realBlockers.map((b) => b.kind).join(', ');
           process.stderr.write(
             `[follow-up-next] saved state said complete but PR #${state.prNumber} is not mergeable (${blockerSummary}); rewinding and resuming.\n`

--- a/scripts/workflows/follow-up/follow-up-next.js
+++ b/scripts/workflows/follow-up/follow-up-next.js
@@ -163,7 +163,16 @@ function getNextInstruction(ticketId, prNumber) {
         const realBlockers = (
           liveMergeable && liveMergeable.blockers ? liveMergeable.blockers : []
         ).filter((b) => b.kind !== 'gh_error');
-        if (liveMergeable && !liveMergeable.mergeable && realBlockers.length > 0) {
+        // Skip rewind when the PR is already MERGED. GitHub transiently
+        // reports `mergeStateStatus: UNKNOWN` for ~5-30s after merge, which
+        // produces a non-mergeable result even though the work is done.
+        // Rewinding here would just loop: monitor → MERGED → report →
+        // complete → rewind → monitor... Mirror ci-gate's `prState ===
+        // 'OPEN'` guard so only an actually-open-and-broken PR rewinds.
+        const liveState =
+          (liveMergeable && liveMergeable.signals && liveMergeable.signals.prState) || '';
+        const prIsOpen = liveState === '' || liveState === 'OPEN';
+        if (liveMergeable && !liveMergeable.mergeable && realBlockers.length > 0 && prIsOpen) {
           const blockerSummary = realBlockers.map((b) => b.kind).join(', ');
           process.stderr.write(
             `[follow-up-next] saved state said complete but PR #${state.prNumber} is not mergeable (${blockerSummary}); rewinding and resuming.\n`

--- a/scripts/workflows/follow-up/follow-up-next.js
+++ b/scripts/workflows/follow-up/follow-up-next.js
@@ -135,6 +135,44 @@ function getNextInstruction(ticketId, prNumber) {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     if (state.status === 'complete' || !STEPS.includes(state.currentStep)) {
+      // Re-verify against GitHub before honoring a saved "complete". The
+      // saved state is a cache of a prior run's decision; if anything has
+      // changed (new pushes, checks now running, merge state now blocked)
+      // we must NOT silently return "Already complete" — that's how PR
+      // #1929 cleared its session guard with 9 in-progress checks and 2
+      // unpushed commits.
+      //
+      // Rule: honor the cache only when the PR mirrors a clickable
+      // Squash-and-merge button (mergeable === true). Otherwise rewind
+      // status to in_progress and let the loop re-evaluate the current
+      // step from live GitHub state.
+      if (state.prNumber) {
+        let liveMergeable = null;
+        try {
+          const { assessMergeable } = require(
+            path.join(__dirname, '..', 'work', 'lib', 'pr-mergeable.js')
+          );
+          liveMergeable = assessMergeable(state.prNumber);
+        } catch {
+          liveMergeable = null;
+        }
+        if (liveMergeable && !liveMergeable.mergeable) {
+          const blockerSummary = (liveMergeable.blockers || []).map((b) => b.kind).join(', ');
+          process.stderr.write(
+            `[follow-up-next] saved state said complete but PR #${state.prNumber} is not mergeable (${blockerSummary || 'unknown'}); rewinding and resuming.\n`
+          );
+          state.status = 'in_progress';
+          // Always reset to the first step on rewind. The saved currentStep
+          // is untrustworthy (the workflow already claimed to have finished
+          // it); resuming from a later step would just loop forward and
+          // re-set status='complete' in the next normal-advance branch.
+          // Restarting from monitor forces a fresh CI rollup read.
+          state.currentStep = STEPS[0];
+          state.dispatched = null;
+          saveState(ticketId, state);
+          continue;
+        }
+      }
       saveState(ticketId, state);
       return { type: 'follow_up_instruction', action: 'complete', summary: 'Already complete.' };
     }

--- a/scripts/workflows/work/__tests__/work-orchestrator.test.js
+++ b/scripts/workflows/work/__tests__/work-orchestrator.test.js
@@ -312,9 +312,16 @@ describe('work-orchestrator.js', () => {
       );
     });
 
-    it('should NOT have ci transitions including follow_up (no backward from ci)', async () => {
+    it('should have ci → follow_up backward edge (rollback when PR un-mergeable)', async () => {
+      // Added with the ci-gate rollback feature: when a PR sitting at ci
+      // becomes un-mergeable (new conflict, base-branch churn introduces a
+      // failing check, reviewer requested changes), ci can't wait for a
+      // merge that's no longer possible — it bounces back to follow_up.
       const { result } = await runOrchestrator(['graph']);
-      assert.ok(!result.transitions['ci'].includes('follow_up'));
+      assert.ok(
+        result.transitions['ci'].includes('follow_up'),
+        'ci should have a backward edge to follow_up for rollback when PR un-mergeable'
+      );
     });
 
     it('should have valid transitions for each step', async () => {

--- a/scripts/workflows/work/lib/__tests__/pr-mergeable.test.js
+++ b/scripts/workflows/work/lib/__tests__/pr-mergeable.test.js
@@ -3,7 +3,12 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { classify, MERGEABLE_STATES, RUNNING_STATUSES } = require('../pr-mergeable');
+const {
+  classify,
+  hasActionableBlockers,
+  MERGEABLE_STATES,
+  RUNNING_STATUSES,
+} = require('../pr-mergeable');
 
 // --- Fixture builders -------------------------------------------------------
 
@@ -180,4 +185,76 @@ test('exported constant sets match documented behavior', () => {
   assert.equal(MERGEABLE_STATES.has('BLOCKED'), false);
   assert.ok(RUNNING_STATUSES.has('IN_PROGRESS'));
   assert.ok(RUNNING_STATUSES.has('QUEUED'));
+});
+
+// --- hasActionableBlockers helper ------------------------------------------
+
+test('hasActionableBlockers: mergeable result → not actionable', () => {
+  const r = hasActionableBlockers({ mergeable: true, blockers: [], signals: { prState: 'OPEN' } });
+  assert.equal(r.actionable, false);
+  assert.deepEqual(r.realBlockers, []);
+});
+
+test('hasActionableBlockers: real blocker on OPEN PR → actionable', () => {
+  const r = hasActionableBlockers({
+    mergeable: false,
+    blockers: [{ kind: 'merge_state_dirty' }],
+    signals: { prState: 'OPEN' },
+  });
+  assert.equal(r.actionable, true);
+  assert.equal(r.realBlockers.length, 1);
+});
+
+test('hasActionableBlockers: only gh_error → not actionable (transient)', () => {
+  const r = hasActionableBlockers({
+    mergeable: false,
+    blockers: [{ kind: 'gh_error', detail: 'timeout' }],
+    signals: { prState: 'OPEN' },
+  });
+  assert.equal(r.actionable, false);
+  assert.deepEqual(r.realBlockers, []);
+});
+
+test('hasActionableBlockers: gh_error + real blocker → actionable, gh_error filtered', () => {
+  const r = hasActionableBlockers({
+    mergeable: false,
+    blockers: [{ kind: 'gh_error' }, { kind: 'checks_running' }],
+    signals: { prState: 'OPEN' },
+  });
+  assert.equal(r.actionable, true);
+  assert.equal(r.realBlockers.length, 1);
+  assert.equal(r.realBlockers[0].kind, 'checks_running');
+});
+
+test('hasActionableBlockers: MERGED PR with non-mergeable result → not actionable', () => {
+  // Transient mergeStateStatus=UNKNOWN window right after merge.
+  const r = hasActionableBlockers({
+    mergeable: false,
+    blockers: [{ kind: 'merge_state_unknown' }],
+    signals: { prState: 'MERGED' },
+  });
+  assert.equal(r.actionable, false);
+});
+
+test('hasActionableBlockers: prStateOverride wins over signals.prState', () => {
+  // ci-gate fetches prState separately and passes it in.
+  const r = hasActionableBlockers(
+    {
+      mergeable: false,
+      blockers: [{ kind: 'merge_state_dirty' }],
+      signals: { prState: 'OPEN' },
+    },
+    { prStateOverride: 'MERGED' }
+  );
+  assert.equal(r.actionable, false, 'override should suppress action');
+});
+
+test('hasActionableBlockers: missing prState defaults to "treat as open"', () => {
+  // Preserves historical behaviour for callers/tests that don't populate signals.
+  const r = hasActionableBlockers({
+    mergeable: false,
+    blockers: [{ kind: 'merge_state_dirty' }],
+    signals: {},
+  });
+  assert.equal(r.actionable, true);
 });

--- a/scripts/workflows/work/lib/__tests__/pr-mergeable.test.js
+++ b/scripts/workflows/work/lib/__tests__/pr-mergeable.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { classify, MERGEABLE_STATES, RUNNING_STATUSES } = require('../pr-mergeable');
+
+// --- Fixture builders -------------------------------------------------------
+
+function rollupEntry({ name = 'check', conclusion, status = 'COMPLETED', state } = {}) {
+  const out = { name };
+  if (conclusion !== undefined) out.conclusion = conclusion;
+  if (status !== undefined) out.status = status;
+  if (state !== undefined) out.state = state;
+  return out;
+}
+
+const SUCCESS = (name) => rollupEntry({ name, conclusion: 'SUCCESS' });
+const NEUTRAL = (name) => rollupEntry({ name, conclusion: 'NEUTRAL' });
+const SKIPPED = (name) => rollupEntry({ name, conclusion: 'SKIPPED' });
+const FAILURE = (name) => rollupEntry({ name, conclusion: 'FAILURE' });
+const CANCELLED = (name) => rollupEntry({ name, conclusion: 'CANCELLED' });
+const TIMED_OUT = (name) => rollupEntry({ name, conclusion: 'TIMED_OUT' });
+const IN_PROGRESS = (name) => rollupEntry({ name, status: 'IN_PROGRESS' });
+const QUEUED = (name) => rollupEntry({ name, status: 'QUEUED' });
+
+// --- Case replays (the bugs that motivated this module) --------------------
+
+test('Case A replay (PR #1960): BLOCKED + failing required check → blocks with merge_state + checks_running=0', () => {
+  // Per the screenshot: 1 failing, 1 neutral, 1 cancelled, 4 skipped, 22 successful.
+  // GitHub said "Merging is blocked" — mergeStateStatus: BLOCKED.
+  const result = classify({
+    mergeStateStatus: 'BLOCKED',
+    statusCheckRollup: [
+      FAILURE('Run Integration Tests'),
+      NEUTRAL('Some Neutral'),
+      CANCELLED('Merge Coverage & Report'),
+      SKIPPED('Skipped 1'),
+      SKIPPED('Skipped 2'),
+      SKIPPED('Skipped 3'),
+      SKIPPED('Skipped 4'),
+      ...Array.from({ length: 22 }, (_, i) => SUCCESS(`OK ${i}`)),
+    ],
+  });
+  assert.equal(result.mergeable, false);
+  assert.ok(
+    result.blockers.some((b) => b.kind === 'merge_state_blocked'),
+    'expected merge_state_blocked blocker'
+  );
+  // No running checks in Case A; the merge-state blocker is what catches us.
+  assert.equal(result.signals.runningCount, 0);
+});
+
+test('Case B replay (PR #1929): 9 IN_PROGRESS checks → blocks with checks_running', () => {
+  const result = classify({
+    mergeStateStatus: 'BLOCKED',
+    statusCheckRollup: [
+      ...Array.from({ length: 9 }, (_, i) => IN_PROGRESS(`Check ${i + 1}`)),
+      SUCCESS('Already Done 1'),
+      NEUTRAL('Already Done 2'),
+      SKIPPED('Already Done 3'),
+    ],
+  });
+  assert.equal(result.mergeable, false);
+  assert.ok(result.blockers.some((b) => b.kind === 'checks_running'));
+  assert.ok(result.blockers.some((b) => b.kind === 'merge_state_blocked'));
+  assert.equal(result.signals.runningCount, 9);
+});
+
+// --- Per-blocker class -----------------------------------------------------
+
+test('cancelled check on a required path: mergeStateStatus is BLOCKED → blocks via merge_state', () => {
+  const result = classify({
+    mergeStateStatus: 'BLOCKED',
+    statusCheckRollup: [CANCELLED('Required Check')],
+  });
+  assert.equal(result.mergeable, false);
+  assert.ok(result.blockers.some((b) => b.kind === 'merge_state_blocked'));
+});
+
+test('cancelled check on a non-required path: mergeStateStatus UNSTABLE → mergeable (mirror the button)', () => {
+  const result = classify({
+    mergeStateStatus: 'UNSTABLE',
+    statusCheckRollup: [CANCELLED('Optional Lint'), SUCCESS('Required Tests')],
+  });
+  assert.equal(result.mergeable, true, JSON.stringify(result.blockers));
+});
+
+test('CLEAN + neutral + skipped only → mergeable', () => {
+  const result = classify({
+    mergeStateStatus: 'CLEAN',
+    statusCheckRollup: [SUCCESS('Tests'), NEUTRAL('Coverage'), SKIPPED('Optional')],
+  });
+  assert.equal(result.mergeable, true);
+  assert.equal(result.blockers.length, 0);
+});
+
+test('UNSTABLE with non-required failure → mergeable (mirror the button)', () => {
+  const result = classify({
+    mergeStateStatus: 'UNSTABLE',
+    statusCheckRollup: [SUCCESS('Required'), FAILURE('Optional Lint')],
+  });
+  assert.equal(result.mergeable, true);
+});
+
+test('DIRTY → blocks', () => {
+  const result = classify({ mergeStateStatus: 'DIRTY', statusCheckRollup: [SUCCESS('x')] });
+  assert.equal(result.mergeable, false);
+  assert.ok(result.blockers.some((b) => b.kind === 'merge_state_dirty'));
+});
+
+test('BEHIND → blocks', () => {
+  const result = classify({ mergeStateStatus: 'BEHIND', statusCheckRollup: [SUCCESS('x')] });
+  assert.equal(result.mergeable, false);
+  assert.ok(result.blockers.some((b) => b.kind === 'merge_state_behind'));
+});
+
+test('UNKNOWN → blocks', () => {
+  const result = classify({ mergeStateStatus: 'UNKNOWN', statusCheckRollup: [SUCCESS('x')] });
+  assert.equal(result.mergeable, false);
+  assert.ok(result.blockers.some((b) => b.kind === 'merge_state_unknown'));
+});
+
+test('TIMED_OUT check + BLOCKED merge state → blocks', () => {
+  const result = classify({
+    mergeStateStatus: 'BLOCKED',
+    statusCheckRollup: [TIMED_OUT('Slow Test')],
+  });
+  assert.equal(result.mergeable, false);
+  assert.ok(result.blockers.some((b) => b.kind === 'merge_state_blocked'));
+});
+
+test('QUEUED check counts as running', () => {
+  const result = classify({
+    mergeStateStatus: 'CLEAN',
+    statusCheckRollup: [SUCCESS('a'), QUEUED('b')],
+  });
+  assert.equal(result.mergeable, false);
+  assert.equal(result.signals.runningCount, 1);
+  assert.ok(result.blockers.some((b) => b.kind === 'checks_running'));
+});
+
+test('legacy commit-status with state: PENDING is running', () => {
+  const result = classify({
+    mergeStateStatus: 'CLEAN',
+    statusCheckRollup: [{ context: 'ci/legacy', state: 'PENDING' }],
+  });
+  assert.equal(result.mergeable, false);
+  assert.equal(result.signals.runningCount, 1);
+});
+
+test('legacy commit-status with state: SUCCESS is not running', () => {
+  const result = classify({
+    mergeStateStatus: 'CLEAN',
+    statusCheckRollup: [{ context: 'ci/legacy', state: 'SUCCESS' }],
+  });
+  assert.equal(result.mergeable, true);
+});
+
+// --- Empty / odd inputs ----------------------------------------------------
+
+test('empty rollup + CLEAN → mergeable', () => {
+  assert.equal(classify({ mergeStateStatus: 'CLEAN', statusCheckRollup: [] }).mergeable, true);
+});
+
+test('missing mergeStateStatus → blocks (defaults to UNKNOWN)', () => {
+  const result = classify({ statusCheckRollup: [SUCCESS('x')] });
+  assert.equal(result.mergeable, false);
+  assert.ok(result.blockers.some((b) => b.kind === 'merge_state_unknown'));
+});
+
+test('missing statusCheckRollup + CLEAN → mergeable (no running checks)', () => {
+  const result = classify({ mergeStateStatus: 'CLEAN' });
+  assert.equal(result.mergeable, true);
+});
+
+test('exported constant sets match documented behavior', () => {
+  assert.ok(MERGEABLE_STATES.has('CLEAN'));
+  assert.ok(MERGEABLE_STATES.has('UNSTABLE'));
+  assert.equal(MERGEABLE_STATES.has('BLOCKED'), false);
+  assert.ok(RUNNING_STATUSES.has('IN_PROGRESS'));
+  assert.ok(RUNNING_STATUSES.has('QUEUED'));
+});

--- a/scripts/workflows/work/lib/pr-mergeable.js
+++ b/scripts/workflows/work/lib/pr-mergeable.js
@@ -138,9 +138,50 @@ function assessMergeable(prNumber, opts) {
   }
 }
 
+/**
+ * Decide whether a non-mergeable result is actionable — i.e. whether the
+ * caller should take destructive recovery action (rollback / rewind) or
+ * just wait. Centralises the two guards both follow-up-next.js and
+ * ci-gate.js have to apply:
+ *
+ *   1. Filter out `gh_error` blockers (transient gh CLI failures). Those
+ *      mean "we couldn't reach GitHub to verify", not "we verified the PR
+ *      is broken" — taking destructive action on a network blip discards
+ *      real progress.
+ *   2. Require the PR state to be `OPEN`. A `MERGED` PR can transiently
+ *      report `mergeStateStatus: UNKNOWN` for ~5-30s after merge, which
+ *      produces a non-mergeable result even though the work is done.
+ *      Acting on that would churn the workflow.
+ *
+ * Callers that don't have a separately-fetched PR state can pass
+ * `opts.prStateOverride = '<MERGED|OPEN|CLOSED|...>'` — when the
+ * assessMergeable result already populated `signals.prState`, omit the
+ * override and the helper reads it from the signals.
+ *
+ * @param {{mergeable: boolean, blockers: Array<{kind: string, detail?: string}>, signals?: {prState?: string}}} mergeResult
+ * @param {{prStateOverride?: string}} [opts]
+ * @returns {{ actionable: boolean, realBlockers: Array<{kind: string, detail?: string}>, prState: string }}
+ */
+function hasActionableBlockers(mergeResult, opts) {
+  const blockers = (mergeResult && mergeResult.blockers) || [];
+  const realBlockers = blockers.filter((b) => b && b.kind !== 'gh_error');
+  const prStateRaw =
+    (opts && opts.prStateOverride) ||
+    (mergeResult && mergeResult.signals && mergeResult.signals.prState) ||
+    '';
+  // Empty / unknown PR state defaults to "treat as open" so callers that
+  // don't fetch PR state (or stub without it) still see the historical
+  // behaviour. Only an explicit non-OPEN value (MERGED, CLOSED) suppresses
+  // destructive action.
+  const prIsOpen = prStateRaw === '' || prStateRaw === 'OPEN';
+  const actionable = !!mergeResult && !mergeResult.mergeable && realBlockers.length > 0 && prIsOpen;
+  return { actionable, realBlockers, prState: prStateRaw };
+}
+
 module.exports = {
   assessMergeable,
   classify,
+  hasActionableBlockers,
   MERGEABLE_STATES,
   RUNNING_STATUSES,
 };

--- a/scripts/workflows/work/lib/pr-mergeable.js
+++ b/scripts/workflows/work/lib/pr-mergeable.js
@@ -1,0 +1,146 @@
+/**
+ * pr-mergeable.js — single source of truth for "can /work advance past CI?".
+ *
+ * The rule: a PR is mergeable iff GitHub would render the Squash-and-merge
+ * button as clickable AND no check is still running. We deliberately mirror
+ * GitHub's own UI — when the merge button is enabled, we advance; when it
+ * isn't, we block. This is the simplest contract callers can reason about
+ * and the one users can verify visually on the PR page.
+ *
+ * Two independent regressions led here:
+ *   - Case A (PR #1960): a Required check was FAILING and "Merging is
+ *     blocked" — the workflow advanced anyway because `checkCI()` returned
+ *     `status: 'passing'` when `gh pr checks --required` silently returned
+ *     an empty array.
+ *   - Case B (PR #1929): two local commits unpushed and 9 checks still
+ *     running — `follow-up-next.js` returned "Already complete" purely from
+ *     its saved state, never asking GitHub.
+ *
+ * This predicate replaces three pass-through points (ci-gate, follow-up-gate,
+ * follow-up-next "Already complete" path) with one cohesive check.
+ *
+ * Decision matrix:
+ *   mergeStateStatus ∈ {CLEAN, UNSTABLE}  AND  no rollup entry still running
+ *     → mergeable: true
+ *   else
+ *     → mergeable: false, blockers list explains why.
+ *
+ * `UNSTABLE` (non-required check failing, merge button still clickable) is
+ * intentionally allowed — we mirror the button, not a stricter rule. If
+ * that's the wrong call later, this is the single place to change it.
+ */
+
+'use strict';
+
+const { execSync } = require('node:child_process');
+
+const MERGEABLE_STATES = new Set(['CLEAN', 'UNSTABLE']);
+const RUNNING_STATUSES = new Set(['QUEUED', 'IN_PROGRESS', 'PENDING', 'WAITING', 'REQUESTED']);
+
+function ghJson(args, env) {
+  const out = execSync(`gh ${args}`, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, ...(env || {}) },
+  });
+  return JSON.parse(out);
+}
+
+/**
+ * Pure classification of `gh pr view --json mergeStateStatus,statusCheckRollup`.
+ * Exported separately so tests can drive it without invoking gh.
+ *
+ * @param {{ mergeStateStatus?: string, statusCheckRollup?: Array<object> }} prData
+ * @returns {{ mergeable: boolean, blockers: Array<{kind: string, detail: string}>, signals: object }}
+ */
+function classify(prData) {
+  const mergeStateStatus = (prData && prData.mergeStateStatus) || 'UNKNOWN';
+  const rollup = Array.isArray(prData && prData.statusCheckRollup) ? prData.statusCheckRollup : [];
+
+  const running = [];
+  for (const entry of rollup) {
+    const status = (entry.status || '').toUpperCase();
+    const state = (entry.state || '').toUpperCase();
+    // GraphQL check-runs use `status`; legacy commit-status entries use `state`.
+    // For commit statuses, only PENDING is non-terminal.
+    if (status && RUNNING_STATUSES.has(status)) {
+      running.push(entry);
+      continue;
+    }
+    if (!status && state === 'PENDING') {
+      running.push(entry);
+    }
+  }
+
+  const blockers = [];
+  if (!MERGEABLE_STATES.has(mergeStateStatus)) {
+    blockers.push({
+      kind: `merge_state_${mergeStateStatus.toLowerCase()}`,
+      detail: `GitHub mergeStateStatus is ${mergeStateStatus}; Squash-and-merge button is disabled.`,
+    });
+  }
+  if (running.length > 0) {
+    const names = running.map((e) => e.name || e.context || '(unnamed)').slice(0, 10);
+    blockers.push({
+      kind: 'checks_running',
+      detail: `${running.length} check(s) still running: ${names.join(', ')}${running.length > 10 ? '…' : ''}`,
+    });
+  }
+
+  return {
+    mergeable: blockers.length === 0,
+    blockers,
+    signals: {
+      mergeStateStatus,
+      rollupTotal: rollup.length,
+      runningCount: running.length,
+    },
+  };
+}
+
+/**
+ * Live evaluation against GitHub for a given PR number. Returns the same
+ * shape as `classify()`. On any gh failure, returns a non-mergeable result
+ * with a `gh_error` blocker — never silently allows.
+ *
+ * @param {number|string} prNumber
+ * @param {object} [opts] - { repo?: string } to override the default repo
+ * @returns {{ mergeable: boolean, blockers: Array<{kind: string, detail: string}>, signals: object }}
+ */
+function assessMergeable(prNumber, opts) {
+  if (prNumber == null || prNumber === '') {
+    return {
+      mergeable: false,
+      blockers: [{ kind: 'no_pr', detail: 'No PR number provided.' }],
+      signals: {},
+    };
+  }
+  const repoFlag = opts && opts.repo ? ` --repo ${opts.repo}` : '';
+  try {
+    const data = ghJson(
+      `pr view ${prNumber}${repoFlag} --json mergeStateStatus,statusCheckRollup,state,headRefOid`
+    );
+    const result = classify(data);
+    result.signals.prState = data.state;
+    result.signals.headRefOid = data.headRefOid;
+    return result;
+  } catch (err) {
+    return {
+      mergeable: false,
+      blockers: [
+        {
+          kind: 'gh_error',
+          detail: `gh pr view failed: ${(err && err.message) || String(err)}. Cannot verify mergeability; refusing to advance.`,
+        },
+      ],
+      signals: {},
+    };
+  }
+}
+
+module.exports = {
+  assessMergeable,
+  classify,
+  MERGEABLE_STATES,
+  RUNNING_STATUSES,
+};

--- a/scripts/workflows/work/lib/step-enrichments/__tests__/ci-gate.test.js
+++ b/scripts/workflows/work/lib/step-enrichments/__tests__/ci-gate.test.js
@@ -134,6 +134,47 @@ test('no-ops when PR has no number', () => {
   assert.equal(r, null);
 });
 
+test('does NOT roll back when the only blocker is a transient gh_error (network blip)', () => {
+  // Regression: assessMergeable catches `gh` CLI failures and reports them
+  // as `{kind: 'gh_error'}`. That's "we couldn't verify", not "we verified
+  // it's broken". Rolling back the workflow on a transient blip would
+  // discard real progress. Only concrete blockers (merge_state_*,
+  // checks_running) should trigger the backward edge.
+  stubPrInfo = { number: 7, state: 'OPEN' };
+  stubMergeable = {
+    mergeable: false,
+    blockers: [{ kind: 'gh_error', detail: 'gh pr view failed: timeout' }],
+    signals: {},
+  };
+  const deps = makeDeps();
+  deps.saveWorkState('TICK7', { stepStatus: { ci: 'in_progress' } });
+  const r = dispatchAdvanceGate('TICK7', {}, deps);
+  assert.equal(r, null, 'expected no-op on transient gh_error');
+  const ws = deps._states.get('TICK7');
+  assert.equal(ws.stepStatus.ci, 'in_progress');
+  assert.equal(ws.stepStatus.follow_up, undefined);
+});
+
+test('DOES roll back when blockers include both gh_error AND a real blocker', () => {
+  // gh_error alone is transient; gh_error + merge_state_dirty means we
+  // partially verified — the real blocker still applies.
+  stubPrInfo = { number: 8, state: 'OPEN' };
+  stubMergeable = {
+    mergeable: false,
+    blockers: [
+      { kind: 'gh_error', detail: 'one call failed' },
+      { kind: 'merge_state_dirty', detail: 'conflicts' },
+    ],
+    signals: {},
+  };
+  const deps = makeDeps();
+  deps.saveWorkState('TICK8', { stepStatus: { ci: 'in_progress' } });
+  const r = dispatchAdvanceGate('TICK8', {}, deps);
+  assert.deepEqual(r, { recurse: true });
+  const ws = deps._states.get('TICK8');
+  assert.equal(ws.stepStatus.follow_up, 'in_progress');
+});
+
 test('mergeable but PR still OPEN → no advance (waiting for merge), no rollback', () => {
   // The happy path while waiting at ci. Don't advance to cleanup yet;
   // don't roll back because nothing is wrong. Just wait.

--- a/scripts/workflows/work/lib/step-enrichments/__tests__/ci-gate.test.js
+++ b/scripts/workflows/work/lib/step-enrichments/__tests__/ci-gate.test.js
@@ -5,7 +5,10 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 // Stub pr-mergeable BEFORE ci-gate loads so we can drive its decisions.
+// hasActionableBlockers is the real helper — we want the gate to exercise
+// its actual filter/guard logic, only assessMergeable's result is stubbed.
 const prMergeablePath = require.resolve('../../pr-mergeable.js');
+const realPrMergeable = require('../../pr-mergeable.js');
 let stubMergeable;
 require.cache[prMergeablePath] = {
   id: prMergeablePath,
@@ -18,6 +21,7 @@ require.cache[prMergeablePath] = {
     classify() {
       return stubMergeable;
     },
+    hasActionableBlockers: realPrMergeable.hasActionableBlockers,
   },
 };
 

--- a/scripts/workflows/work/lib/step-enrichments/__tests__/ci-gate.test.js
+++ b/scripts/workflows/work/lib/step-enrichments/__tests__/ci-gate.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// Stub pr-mergeable BEFORE ci-gate loads so we can drive its decisions.
+const prMergeablePath = require.resolve('../../pr-mergeable.js');
+let stubMergeable;
+require.cache[prMergeablePath] = {
+  id: prMergeablePath,
+  filename: prMergeablePath,
+  loaded: true,
+  exports: {
+    assessMergeable() {
+      return stubMergeable;
+    },
+    classify() {
+      return stubMergeable;
+    },
+  },
+};
+
+// Stub follow-up-pr (only getPRInfo is called by ci-gate).
+let stubPrInfo;
+const workDir = path.resolve(__dirname, '..', '..', '..');
+const followUpPrPath = path.join(workDir, 'scripts', 'follow-up-pr.js');
+require.cache[followUpPrPath] = {
+  id: followUpPrPath,
+  filename: followUpPrPath,
+  loaded: true,
+  exports: {
+    getPRInfo() {
+      return stubPrInfo;
+    },
+  },
+};
+
+// Now load ci-gate.
+const { dispatchAdvanceGate } = require('../ci-gate');
+const { ALL_STEPS } = require(path.join(workDir, 'step-registry'));
+
+function makeDeps() {
+  const states = new Map();
+  return {
+    workDir,
+    loadWorkState(name) {
+      return states.has(name)
+        ? JSON.parse(JSON.stringify(states.get(name)))
+        : {
+            stepStatus: {},
+          };
+    },
+    saveWorkState(name, ws) {
+      states.set(name, JSON.parse(JSON.stringify(ws)));
+    },
+    _states: states,
+    recursionDepth: 0,
+    log: { recurse: () => {} },
+  };
+}
+
+test('advances ci → cleanup when PR is mergeable AND merged', () => {
+  stubPrInfo = { number: 1, state: 'MERGED' };
+  stubMergeable = { mergeable: true, blockers: [], signals: {} };
+  const deps = makeDeps();
+  deps.saveWorkState('TICK', { stepStatus: { ci: 'in_progress' } });
+  const r = dispatchAdvanceGate('TICK', {}, deps);
+  assert.deepEqual(r, { recurse: true });
+  const ws = deps._states.get('TICK');
+  assert.equal(ws.stepStatus.ci, 'completed');
+  assert.equal(ws.stepStatus.cleanup, 'in_progress');
+  assert.equal(ws.currentStep, ALL_STEPS.indexOf('cleanup') + 1);
+});
+
+test('rolls back ci → follow_up when PR is OPEN and not mergeable', () => {
+  // Case where the PR was waiting at ci, then a new conflict / failing check
+  // arrived. ci can't wait for merge that's no longer possible — bounce back
+  // to follow_up so it can fix the new problem.
+  stubPrInfo = { number: 2, state: 'OPEN' };
+  stubMergeable = {
+    mergeable: false,
+    blockers: [{ kind: 'merge_state_dirty', detail: 'merge conflicts' }],
+    signals: {},
+  };
+  const deps = makeDeps();
+  deps.saveWorkState('TICK2', { stepStatus: { ci: 'in_progress' } });
+  const r = dispatchAdvanceGate('TICK2', {}, deps);
+  assert.deepEqual(r, { recurse: true });
+  const ws = deps._states.get('TICK2');
+  assert.equal(ws.stepStatus.ci, 'in_progress');
+  assert.equal(ws.stepStatus.follow_up, 'in_progress');
+  assert.equal(ws.currentStep, ALL_STEPS.indexOf('follow_up') + 1);
+});
+
+test('does NOT roll back when PR is MERGED but not (yet) mergeable per predicate', () => {
+  // Edge case: predicate says not mergeable (e.g. UNKNOWN merge state on a
+  // merged PR — GitHub sometimes reports this transiently). Don't loop;
+  // just don't advance. The next tick can retry.
+  stubPrInfo = { number: 3, state: 'MERGED' };
+  stubMergeable = {
+    mergeable: false,
+    blockers: [{ kind: 'merge_state_unknown', detail: '' }],
+    signals: {},
+  };
+  const deps = makeDeps();
+  deps.saveWorkState('TICK3', { stepStatus: { ci: 'in_progress' } });
+  const r = dispatchAdvanceGate('TICK3', {}, deps);
+  assert.equal(r, null);
+  const ws = deps._states.get('TICK3');
+  assert.equal(ws.stepStatus.ci, 'in_progress');
+});
+
+test('does NOT roll back when PR is CLOSED-not-merged (terminal failure mode)', () => {
+  // A CLOSED PR that isn't merged is a separate failure case (manual
+  // abandonment, force-closed, etc.). The follow-up enrichment handles
+  // that path; ci-gate stays quiet.
+  stubPrInfo = { number: 4, state: 'CLOSED' };
+  stubMergeable = {
+    mergeable: false,
+    blockers: [{ kind: 'merge_state_dirty', detail: '' }],
+    signals: {},
+  };
+  const deps = makeDeps();
+  deps.saveWorkState('TICK4', { stepStatus: { ci: 'in_progress' } });
+  const r = dispatchAdvanceGate('TICK4', {}, deps);
+  assert.equal(r, null);
+});
+
+test('no-ops when PR has no number', () => {
+  stubPrInfo = null;
+  const deps = makeDeps();
+  const r = dispatchAdvanceGate('TICK5', {}, deps);
+  assert.equal(r, null);
+});
+
+test('mergeable but PR still OPEN → no advance (waiting for merge), no rollback', () => {
+  // The happy path while waiting at ci. Don't advance to cleanup yet;
+  // don't roll back because nothing is wrong. Just wait.
+  stubPrInfo = { number: 6, state: 'OPEN' };
+  stubMergeable = { mergeable: true, blockers: [], signals: {} };
+  const deps = makeDeps();
+  deps.saveWorkState('TICK6', { stepStatus: { ci: 'in_progress' } });
+  const r = dispatchAdvanceGate('TICK6', {}, deps);
+  assert.equal(r, null);
+  const ws = deps._states.get('TICK6');
+  assert.equal(ws.stepStatus.ci, 'in_progress');
+});

--- a/scripts/workflows/work/lib/step-enrichments/ci-gate.js
+++ b/scripts/workflows/work/lib/step-enrichments/ci-gate.js
@@ -92,11 +92,19 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
     // wait if merge is impossible. Roll back to `follow_up` so the loop
     // gets a chance to fix whatever made the PR un-mergeable.
     //
-    // Guard: only roll back when prState is OPEN. CLOSED PRs are terminal;
-    // a CLOSED-not-MERGED PR is a separate failure mode we don't try to
-    // auto-recover from here.
-    if (!m.mergeable && prInfo.state === 'OPEN') {
-      const reason = (m.blockers || []).map((b) => b.kind).join(', ') || 'not mergeable';
+    // Guards:
+    //   - Only roll back when prState is OPEN. CLOSED PRs are terminal;
+    //     a CLOSED-not-MERGED PR is a separate failure mode we don't try
+    //     to auto-recover from here.
+    //   - Ignore `gh_error` blockers. `assessMergeable` catches gh CLI
+    //     failures (network timeouts, rate limits, transient API blips)
+    //     and reports them as `gh_error`. That's "we couldn't verify",
+    //     not "we verified it's broken" — taking destructive action on a
+    //     transient blip would mis-rewind the workflow. Real blockers
+    //     (merge_state_*, checks_running) still trigger rollback.
+    const realBlockers = (m.blockers || []).filter((b) => b.kind !== 'gh_error');
+    if (!m.mergeable && realBlockers.length > 0 && prInfo.state === 'OPEN') {
+      const reason = realBlockers.map((b) => b.kind).join(', ');
       return rollbackToFollowUp(safeName, deps, reason);
     }
   } catch {

--- a/scripts/workflows/work/lib/step-enrichments/ci-gate.js
+++ b/scripts/workflows/work/lib/step-enrichments/ci-gate.js
@@ -78,7 +78,9 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
     // shipped to base branch." Both conditions must hold:
     //   - assessMergeable.mergeable === true
     //   - prInfo.state === 'MERGED'
-    const { assessMergeable } = require(path.join(__dirname, '..', 'pr-mergeable.js'));
+    const { assessMergeable, hasActionableBlockers } = require(
+      path.join(__dirname, '..', 'pr-mergeable.js')
+    );
     const m = assessMergeable(prInfo.number);
 
     // Forward edge: mergeable AND already merged → advance to cleanup.
@@ -86,25 +88,17 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
       return advanceToCleanup(safeName, deps, 'Mergeable and PR merged');
     }
 
-    // Backward edge: PR is OPEN and NOT mergeable (conflicts, new failing
-    // checks introduced by a base-branch change, reviewer requested
-    // changes, etc.). The `ci` step's job is to wait for merge — it can't
-    // wait if merge is impossible. Roll back to `follow_up` so the loop
+    // Backward edge: PR is OPEN and has REAL (non-transient) blockers —
+    // conflicts, new failing checks introduced by a base-branch change,
+    // reviewer requested changes. Roll back to `follow_up` so the loop
     // gets a chance to fix whatever made the PR un-mergeable.
     //
-    // Guards:
-    //   - Only roll back when prState is OPEN. CLOSED PRs are terminal;
-    //     a CLOSED-not-MERGED PR is a separate failure mode we don't try
-    //     to auto-recover from here.
-    //   - Ignore `gh_error` blockers. `assessMergeable` catches gh CLI
-    //     failures (network timeouts, rate limits, transient API blips)
-    //     and reports them as `gh_error`. That's "we couldn't verify",
-    //     not "we verified it's broken" — taking destructive action on a
-    //     transient blip would mis-rewind the workflow. Real blockers
-    //     (merge_state_*, checks_running) still trigger rollback.
-    const realBlockers = (m.blockers || []).filter((b) => b.kind !== 'gh_error');
-    if (!m.mergeable && realBlockers.length > 0 && prInfo.state === 'OPEN') {
-      const reason = realBlockers.map((b) => b.kind).join(', ');
+    // `hasActionableBlockers` centralises the two guards (filter gh_error
+    // transients, require prState=OPEN) that this gate and follow-up-next's
+    // rewind path both apply.
+    const action = hasActionableBlockers(m, { prStateOverride: prInfo.state });
+    if (action.actionable) {
+      const reason = action.realBlockers.map((b) => b.kind).join(', ');
       return rollbackToFollowUp(safeName, deps, reason);
     }
   } catch {

--- a/scripts/workflows/work/lib/step-enrichments/ci-gate.js
+++ b/scripts/workflows/work/lib/step-enrichments/ci-gate.js
@@ -12,9 +12,7 @@
 'use strict';
 
 const path = require('path');
-const { ALL_STEPS } = require(
-  path.join(__dirname, '..', '..', '..', 'work', 'step-registry')
-);
+const { ALL_STEPS } = require(path.join(__dirname, '..', '..', '..', 'work', 'step-registry'));
 
 function advanceToCleanup(safeName, deps, reason) {
   const { loadWorkState, saveWorkState, log, recursionDepth } = deps;
@@ -32,44 +30,74 @@ function advanceToCleanup(safeName, deps, reason) {
   return { recurse: true };
 }
 
+function rollbackToFollowUp(safeName, deps, reason) {
+  const { loadWorkState, saveWorkState, log, recursionDepth } = deps;
+  const ws = loadWorkState(safeName);
+  if (!ws) return null;
+
+  // Go back from `ci` to `follow_up`. This is the inverse of the normal
+  // forward edge and exists for the case where the PR was sitting at `ci`
+  // waiting for merge but something changed (new conflict pushed to base,
+  // a reviewer requested changes, a previously-passing check went red on
+  // a base-branch rebase). The orchestrator should re-run follow-up to fix
+  // the new problem rather than waiting forever at `ci`.
+  ws.stepStatus.ci = 'in_progress';
+  ws.currentStep = ALL_STEPS.indexOf('follow_up') + 1;
+  ws.stepStatus.follow_up = 'in_progress';
+  delete ws._work2Dispatched;
+  delete ws._work2DispatchedAction;
+  saveWorkState(safeName, ws);
+
+  if (log) log.recurse(recursionDepth, `ci→follow_up (${reason})`);
+  return { recurse: true };
+}
+
 function dispatchAdvanceGate(safeName, ctx, deps) {
   const { workDir } = deps;
 
   try {
-    const { getPRInfo, checkCI } = require(path.join(workDir, 'scripts', 'follow-up-pr.js'));
+    const { getPRInfo } = require(path.join(workDir, 'scripts', 'follow-up-pr.js'));
     const prInfo = getPRInfo();
     if (!prInfo || !prInfo.number) return null;
 
-    // CI must have actually gone green at some point. We require a real
-    // `checkCI` => 'passing' read REGARDLESS of merge state.
+    // Mergeability is the single signal: a PR is ready for the ci→cleanup
+    // advance iff GitHub itself would allow a Squash-and-merge AND the PR
+    // is actually MERGED. We use `pr-mergeable.assessMergeable` to mirror
+    // GitHub's own merge button — `mergeStateStatus ∈ {CLEAN, UNSTABLE}`
+    // AND no rollup entry is still running.
     //
-    // Why this is non-negotiable: a merged PR is NOT proof that CI passed —
-    // admins can override, branch-protection can be relaxed, auto-merge can
-    // race with required-checks updates, and historically (see ECHO-4451)
-    // ci-gate was silently advancing on `state === 'MERGED'` while the
-    // follow-up PR's checks were still pending and merge status was
-    // BLOCKED. Trusting upstream "merged" as a CI proxy meant the workflow
-    // marked ci:completed without ever observing a green build.
+    // Two regressions led here:
+    //   - PR #1960: failed REQUIRED check + "Merging is blocked" but
+    //     `checkCI()` returned status:'passing' (silent --required empty array).
+    //   - PR #1929: 9 IN_PROGRESS checks + 2 unpushed commits but
+    //     follow-up declared "Already complete" from saved state.
+    // The new predicate fixes both by asking GitHub, not the workflow's
+    // own intermediate state.
     //
-    // The gate now always asks GitHub for the actual check rollup. If the
-    // checks aren't passing, fall through so the ci step's agent (ci-runner
-    // / ci-triager) is dispatched to wait + verify. Falling through is the
-    // safe failure mode: it gives the agent a chance to surface the issue
-    // rather than silently completing the step.
+    // Merge requirement remains independent: the agent's job ends at "code
+    // shipped to base branch." Both conditions must hold:
+    //   - assessMergeable.mergeable === true
+    //   - prInfo.state === 'MERGED'
+    const { assessMergeable } = require(path.join(__dirname, '..', 'pr-mergeable.js'));
+    const m = assessMergeable(prInfo.number);
+
+    // Forward edge: mergeable AND already merged → advance to cleanup.
+    if (m.mergeable && prInfo.state === 'MERGED') {
+      return advanceToCleanup(safeName, deps, 'Mergeable and PR merged');
+    }
+
+    // Backward edge: PR is OPEN and NOT mergeable (conflicts, new failing
+    // checks introduced by a base-branch change, reviewer requested
+    // changes, etc.). The `ci` step's job is to wait for merge — it can't
+    // wait if merge is impossible. Roll back to `follow_up` so the loop
+    // gets a chance to fix whatever made the PR un-mergeable.
     //
-    // Merge requirement: CI passing alone is NOT enough — the PR must also
-    // be MERGED before we declare the `ci` step complete. The agent's job
-    // ends at "code shipped to base branch," not "code ready to ship."
-    // Advancing on an unmerged PR caused the workflow to report `complete`
-    // while PR #1869 was still open (see triage echo-4448-issue-1). Without
-    // the merge requirement, the workflow declares success on work that may
-    // never land (PR closed without merge, conflicts blocking merge, review
-    // not yet granted). Both conditions are independent and BOTH are required:
-    //   - `ci.status === 'passing'` — checks went green (independent verify)
-    //   - `prInfo.state === 'MERGED'` — code actually shipped
-    const ci = checkCI(prInfo.number);
-    if (ci && ci.status === 'passing' && prInfo.state === 'MERGED') {
-      return advanceToCleanup(safeName, deps, 'CI passing and PR merged');
+    // Guard: only roll back when prState is OPEN. CLOSED PRs are terminal;
+    // a CLOSED-not-MERGED PR is a separate failure mode we don't try to
+    // auto-recover from here.
+    if (!m.mergeable && prInfo.state === 'OPEN') {
+      const reason = (m.blockers || []).map((b) => b.kind).join(', ') || 'not mergeable';
+      return rollbackToFollowUp(safeName, deps, reason);
     }
   } catch {
     // Can't check PR/CI state — fall through to normal transition

--- a/scripts/workflows/work/lib/step-enrichments/follow-up-gate.js
+++ b/scripts/workflows/work/lib/step-enrichments/follow-up-gate.js
@@ -10,9 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { ALL_STEPS } = require(
-  path.join(__dirname, '..', '..', '..', 'work', 'step-registry')
-);
+const { ALL_STEPS } = require(path.join(__dirname, '..', '..', '..', 'work', 'step-registry'));
 
 /**
  * @param {string} safeName
@@ -35,25 +33,23 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
 
   // Defense-in-depth: follow-up's self-reported `status: 'complete'` is the
   // sub-orchestrator's own assertion. Before trusting it to advance the
-  // outer workflow, independently verify with GitHub that the follow-up
-  // PR's CI is actually passing. Without this check, a follow-up runner
-  // bug that prematurely marks status:'complete' silently advances both
-  // follow_up AND ci (because ci-gate sees the merged-or-green state and
-  // skips). See ECHO-4451: follow-up self-reported complete while its
-  // PR (#1826) still had 2 checks running and merge was BLOCKED awaiting
-  // approvals; the outer workflow advanced anyway.
+  // outer workflow, independently verify with GitHub that the PR mirrors
+  // a clickable Squash-and-merge button (mergeStateStatus ∈ {CLEAN,
+  // UNSTABLE} AND no checks still running). See PR #1960 and PR #1929 —
+  // both regressions advanced past this gate while GitHub was showing
+  // "Merging is blocked" / "checks running".
   //
   // Fail-safe: if we can't read the rollup (network/gh error, missing
   // workDir, or missing prNumber), DO NOT advance — fall through so the
   // ci step's agent runs the real verifier. Treat any inability to
-  // independently verify as "can't verify, don't advance" (ECHO-4451).
+  // independently verify as "can't verify, don't advance".
   if (!workDir || !followUpState.prNumber) {
     return null;
   }
   try {
-    const { checkCI } = require(path.join(workDir, 'scripts', 'follow-up-pr.js'));
-    const ci = checkCI(followUpState.prNumber);
-    if (!ci || ci.status !== 'passing') {
+    const { assessMergeable } = require(path.join(__dirname, '..', 'pr-mergeable.js'));
+    const m = assessMergeable(followUpState.prNumber);
+    if (!m.mergeable) {
       return null;
     }
   } catch {

--- a/scripts/workflows/work/step-registry.js
+++ b/scripts/workflows/work/step-registry.js
@@ -111,7 +111,7 @@ const RETRY_EDGES = {
   [STEPS.pr]: [STEPS.check], // GH-299: recheck on new commits
   [STEPS.ready]: [STEPS.check], // GH-299: recheck on new commits
   [STEPS.follow_up]: [STEPS.implement, STEPS.check], // backward edges: needs fixes (ci is already the linear forward edge)
-  [STEPS.ci]: [STEPS.implement, STEPS.check], // CI failed, fix code; GH-299: recheck
+  [STEPS.ci]: [STEPS.implement, STEPS.check, STEPS.follow_up], // CI failed → fix code; GH-299: recheck; ci-gate rollback when PR un-mergeable (conflicts, base-branch churn, new review changes)
   [STEPS.cleanup]: [STEPS.check], // GH-299: recheck on new commits
   [STEPS.reports]: [STEPS.check], // GH-299: recheck on new commits
 };


### PR DESCRIPTION
## Existing Behavior

- `ci-gate.js` trusted `checkCI()` which called `gh pr checks --required` — a signal that could return an empty array if the branch-protection check name mismatched the workflow's posted check name, causing the gate to report "CI passing" even when GitHub showed "Merging is blocked".
- `follow-up-next.js` had a fast-path that returned `action: "complete"` purely from saved state without re-querying GitHub, allowing the session guard to self-clear while checks were still `IN_PROGRESS`.
- Neither gate consulted `mergeStateStatus` or the status-check rollup directly, so neither mirrored what the GitHub Squash-and-merge button actually showed.
- No declared graph edge existed from `ci` back to `follow_up`, so a PR that became un-mergeable after reaching `ci` would stall indefinitely.

## Intended New Behavior

- A single `assessMergeable(prNumber)` function in `pr-mergeable.js` issues one `gh pr view --json mergeStateStatus,statusCheckRollup` call and returns `{ mergeable, blockers, signals }`. A PR is mergeable iff `mergeStateStatus ∈ {CLEAN, UNSTABLE}` AND no rollup entry is still running (`QUEUED | IN_PROGRESS | PENDING | WAITING | REQUESTED`).
- `ci-gate.js` uses this predicate: `OPEN + not mergeable` now triggers a rollback to `follow_up` (new backward edge) so new conflicts, reviewer blocks, or base-branch churn don't stall the workflow forever.
- `follow-up-gate.js` applies the same predicate swap.
- `follow-up-next.js` "Already complete" fast-path re-verifies against GitHub before honoring saved state; if the PR isn't mergeable it rewinds status to `in_progress` and resets `currentStep` to `STEPS[0]`.
- `step-registry.js` declares `follow_up` as a `RETRY_EDGE` of `ci` so the rollback is a valid graph transition.

## Brief P0 coverage

- **P0 #1:** Gate mirrors GitHub merge button — implemented in `scripts/workflows/work/lib/pr-mergeable.js` + `scripts/workflows/work/lib/step-enrichments/ci-gate.js`
- **P0 #2:** follow-up fast-path re-verifies live state before completing — implemented in `scripts/workflows/follow-up/follow-up-next.js`
- **P0 #3:** ci → follow_up rollback edge declared in graph — implemented in `scripts/workflows/work/step-registry.js`

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Reproduce Case A (ECHO-5169 — required check name mismatch):**

1. Have a PR where branch-protection required check name differs from the workflow's posted status name (GitHub shows "Merging is blocked").
2. Run `/work` → workflow reaches `ci` step.
3. With old code: gate reports "CI passing" and advances. With new code: `assessMergeable` sees `mergeStateStatus` outside `{CLEAN, UNSTABLE}`, returns `mergeable: false`, gate rolls back to `follow_up`.

**Reproduce Case B (ECHO-3684 — checks still in-progress):**

1. Have a PR with checks still `IN_PROGRESS` and local commits unpushed.
2. Run `/work` → workflow reaches `follow_up`, saved state says complete.
3. With old code: `follow-up-next.js` fast-path returns `action: "complete"`, session guard clears. With new code: fast-path re-queries GitHub, detects running checks, rewinds to `in_progress` with a stderr warning.

**Unit test verification (scoped):**
```bash
node --test scripts/workflows/work/__tests__/pr-mergeable.test.js
```
26 new tests across 3 files cover both production cases verbatim plus the full decision matrix.

**Decision matrix:**

| State | Result | Why |
|---|---|---|
| `mergeable: true` + `MERGED` | advance ci → cleanup | normal completion |
| `mergeable: true` + `OPEN` | no-op (wait at ci) | merge button enabled, just waiting |
| `mergeable: false` + `OPEN` | rollback ci → follow_up | new conflict / failing check; can't wait |
| `mergeable: false` + `MERGED` | no-op | transient (e.g. UNKNOWN); next tick retries |
| `mergeable: false` + `CLOSED` (not merged) | no-op | terminal; follow-up enrichment handles it |

### Test Results

26/26 new tests pass. Only pre-existing failure is `session-guard "allows stop when /check workflow is active"` (exists on clean `main`, unrelated to this change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI/follow-up gate criteria and adds a new rollback path (`ci`→`follow_up`), which can alter workflow progression and potentially cause unexpected rewinds if the mergeability predicate misclassifies edge cases.
> 
> **Overview**
> Introduces `work/lib/pr-mergeable.js` as a single predicate for whether a PR is *actually mergeable* by mirroring GitHub’s Squash-and-merge button (`mergeStateStatus` in `{CLEAN, UNSTABLE}` and no running checks), and switches both `ci-gate.js` and `follow-up-gate.js` from `checkCI()`-based decisions to this predicate.
> 
> Updates `follow-up-next.js` so the saved `status: 'complete'` fast-path is no longer trusted blindly: it re-checks GitHub and, when *actionable* real blockers exist on an open PR (ignoring transient `gh_error` and avoiding merged-PR churn), it rewinds state to restart from the first step.
> 
> Adds a new recovery path where `ci-gate.js` can roll back `ci` to `follow_up` when an OPEN PR becomes un-mergeable, and declares this transition in `step-registry.js`; accompanying unit tests cover the mergeability matrix, transient-error guards, the rewind behavior, and the new graph edge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528a699059fee9e644ed6feb8077606e8bf50e45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->