### PR TITLE
feat(work): expose current-step helper for statusline integration

### DIFF
--- a/docs/statusline-integration.md
+++ b/docs/statusline-integration.md
@@ -1,0 +1,84 @@
+# Statusline integration
+
+The plugin ships a small helper that prints the current `/work` step name
+(e.g. `implement`, `follow_up`, `ci`) for the most-recently-active ticket.
+You can append it to your existing Claude Code statusline so the bottom of
+the editor shows something like:
+
+```
+bypass permissions on · PR #386 · step: ci
+```
+
+## The helper
+
+`scripts/workflows/work/lib/print-current-step.js` is a zero-argument Node
+script that:
+
+- Reads `TASKS_BASE` (env var, or `scripts/workflows/lib/config.js`).
+- Walks each ticket directory under `TASKS_BASE` and finds the
+  most-recently-modified `.work-state.json`.
+- Parses `currentStep` (1-indexed) and maps it to a step name via
+  `step-registry.js`'s `ALL_STEPS`.
+- Writes the step name to stdout with no trailing newline.
+
+The helper is **fail-silent by design**: any error (missing config,
+unreadable file, malformed JSON, missing field, helper itself crashing)
+results in `exit 0` with empty stdout. A broken statusline is worse than
+a missing step indicator.
+
+Run it directly to confirm it works in your environment:
+
+```bash
+node $HOME/.claude/plugins/marketplaces/work-workflow/scripts/workflows/work/lib/print-current-step.js
+```
+
+## Wrapper script
+
+Claude Code's `statusLine.command` can only point at one command. To
+combine the plugin's existing statusline output with the step name,
+create a small wrapper. Save this as `$HOME/.claude/work-statusline.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Wrapper: existing statusline output, plus ` · step: <name>` when /work is active.
+
+PAYLOAD=$(cat)
+
+# Original statusline command — adjust the path below if your install differs.
+ORIG=$(printf '%s' "$PAYLOAD" | node /home/node/.claude/plugins/dist/index.js statusline 2>/dev/null)
+
+# Current /work step (silent on any error).
+STEP=$(node "$HOME/.claude/plugins/marketplaces/work-workflow/scripts/workflows/work/lib/print-current-step.js" 2>/dev/null)
+
+printf '%s%s' "$ORIG" "${STEP:+ · step: $STEP}"
+```
+
+Then make it executable:
+
+```bash
+chmod +x $HOME/.claude/work-statusline.sh
+```
+
+And point `~/.claude/settings.json` at the wrapper:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "/home/<you>/.claude/work-statusline.sh"
+  }
+}
+```
+
+(The plugin does not edit `~/.claude/settings.json` for you — that file
+belongs to your Claude Code install, not the plugin.)
+
+## Notes
+
+- The helper does **not** know which ticket your current shell session
+  is working on. It picks the ticket directory whose `.work-state.json`
+  was modified most recently. In single-ticket workflows that's the
+  active ticket; if you run multiple tickets in parallel, the step
+  reported is whichever was touched last.
+- The helper requires `TASKS_BASE` to be resolvable via env var or the
+  plugin's `config.js`. Without it the helper exits silently.

--- a/docs/statusline-integration.md
+++ b/docs/statusline-integration.md
@@ -45,7 +45,7 @@ create a small wrapper. Save this as `$HOME/.claude/work-statusline.sh`:
 PAYLOAD=$(cat)
 
 # Original statusline command — adjust the path below if your install differs.
-ORIG=$(printf '%s' "$PAYLOAD" | node /home/node/.claude/plugins/dist/index.js statusline 2>/dev/null)
+ORIG=$(printf '%s' "$PAYLOAD" | node "$HOME/.claude/plugins/dist/index.js" statusline 2>/dev/null)
 
 # Current /work step (silent on any error).
 STEP=$(node "$HOME/.claude/plugins/marketplaces/work-workflow/scripts/workflows/work/lib/print-current-step.js" 2>/dev/null)

--- a/scripts/workflows/work/lib/__tests__/print-current-step.test.js
+++ b/scripts/workflows/work/lib/__tests__/print-current-step.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { ALL_STEPS } = require('../../step-registry');
+
+const SCRIPT = path.join(__dirname, '..', 'print-current-step.js');
+
+function runWithTasksBase(tasksBase) {
+  return spawnSync('node', [SCRIPT], {
+    env: { ...process.env, TASKS_BASE: tasksBase },
+    encoding: 'utf8',
+  });
+}
+
+function writeStateFile(dir, ticketId, payload) {
+  const ticketDir = path.join(dir, ticketId);
+  fs.mkdirSync(ticketDir, { recursive: true });
+  const statePath = path.join(ticketDir, '.work-state.json');
+  fs.writeFileSync(statePath, payload);
+  return statePath;
+}
+
+test('print-current-step: empty TASKS_BASE → exit 0, stdout empty', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcs-empty-'));
+  try {
+    const res = runWithTasksBase(tmp);
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.equal(res.stdout, '');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('print-current-step: single state file → prints mapped step name', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcs-single-'));
+  try {
+    const implementIndex = ALL_STEPS.indexOf('implement');
+    assert.ok(implementIndex >= 0, 'step registry must contain `implement`');
+    writeStateFile(tmp, 'TKT-1', JSON.stringify({
+      ticketId: 'TKT-1',
+      currentStep: implementIndex + 1, // 1-indexed
+      status: 'in_progress',
+    }));
+
+    const res = runWithTasksBase(tmp);
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.equal(res.stdout, 'implement');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('print-current-step: newest mtime wins across multiple state files', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcs-multi-'));
+  try {
+    const ciIndex = ALL_STEPS.indexOf('ci');
+    const briefIndex = ALL_STEPS.indexOf('brief');
+    assert.ok(ciIndex >= 0 && briefIndex >= 0);
+
+    const olderPath = writeStateFile(tmp, 'OLD-1', JSON.stringify({
+      currentStep: briefIndex + 1,
+    }));
+    const newerPath = writeStateFile(tmp, 'NEW-1', JSON.stringify({
+      currentStep: ciIndex + 1,
+    }));
+
+    // Force mtimes so the test is independent of write order timing.
+    const past = new Date(Date.now() - 60_000);
+    const now = new Date();
+    fs.utimesSync(olderPath, past, past);
+    fs.utimesSync(newerPath, now, now);
+
+    const res = runWithTasksBase(tmp);
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.equal(res.stdout, 'ci');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('print-current-step: malformed JSON → exit 0, stdout empty (fail-silent)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcs-bad-'));
+  try {
+    writeStateFile(tmp, 'BAD-1', '{ this is not json');
+
+    const res = runWithTasksBase(tmp);
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.equal(res.stdout, '');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('print-current-step: TASKS_BASE does not exist → exit 0, stdout empty', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcs-missing-'));
+  const missing = path.join(tmp, 'does-not-exist');
+  try {
+    const res = runWithTasksBase(missing);
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.equal(res.stdout, '');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/scripts/workflows/work/lib/__tests__/print-current-step.test.js
+++ b/scripts/workflows/work/lib/__tests__/print-current-step.test.js
@@ -97,6 +97,49 @@ test('print-current-step: malformed JSON → exit 0, stdout empty (fail-silent)'
   }
 });
 
+test('print-current-step: missing currentStep → exit 0, stdout empty (fail-silent, no fallback to step 1)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcs-missing-step-'));
+  try {
+    writeStateFile(tmp, 'TKT-NO-STEP', JSON.stringify({
+      ticketId: 'TKT-NO-STEP',
+      status: 'in_progress',
+      // currentStep intentionally omitted
+    }));
+
+    const res = runWithTasksBase(tmp);
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.equal(res.stdout, '', 'must not fall back to ALL_STEPS[0]');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('print-current-step: currentStep=0 → exit 0, stdout empty (fail-silent)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcs-zero-step-'));
+  try {
+    writeStateFile(tmp, 'TKT-ZERO', JSON.stringify({ currentStep: 0 }));
+
+    const res = runWithTasksBase(tmp);
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.equal(res.stdout, '');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('print-current-step: currentStep=null → exit 0, stdout empty (fail-silent)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcs-null-step-'));
+  try {
+    writeStateFile(tmp, 'TKT-NULL', JSON.stringify({ currentStep: null }));
+
+    const res = runWithTasksBase(tmp);
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.equal(res.stdout, '');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('print-current-step: TASKS_BASE does not exist → exit 0, stdout empty', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcs-missing-'));
   const missing = path.join(tmp, 'does-not-exist');

--- a/scripts/workflows/work/lib/print-current-step.js
+++ b/scripts/workflows/work/lib/print-current-step.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * print-current-step.js
+ *
+ * Prints the name of the active /work step (e.g. `implement`, `follow_up`,
+ * `ci`) for the most-recently-modified ticket under TASKS_BASE.
+ *
+ * Intended for use from a Claude Code statusline wrapper — see
+ * docs/statusline-integration.md.
+ *
+ * Contract:
+ *   - On success: writes the step name to stdout (no trailing newline) and
+ *     exits 0.
+ *   - On any error or "no active ticket" condition: prints nothing and
+ *     exits 0. The statusline must never break, so every failure mode is
+ *     swallowed.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+try {
+  // Resolve get-config relative to this file. We deliberately avoid
+  // resolve-plugin-root here because that helper requires the plugin's
+  // `workflows/` symlink layout, which may not exist in arbitrary callers'
+  // working directories. Going up two levels from work/lib/ lands at
+  // scripts/workflows, where the shared `lib/` sits next to `work/`.
+  const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
+  const { ALL_STEPS } = require(path.join(__dirname, '..', 'step-registry'));
+
+  const TASKS_BASE = getConfig('TASKS_BASE');
+  if (!TASKS_BASE || !fs.existsSync(TASKS_BASE)) process.exit(0);
+
+  // Find the most-recently-modified .work-state.json across all tickets.
+  let newest = null;
+  for (const ent of fs.readdirSync(TASKS_BASE, { withFileTypes: true })) {
+    if (!ent.isDirectory()) continue;
+    const statePath = path.join(TASKS_BASE, ent.name, '.work-state.json');
+    try {
+      const stat = fs.statSync(statePath);
+      if (!newest || stat.mtimeMs > newest.mtimeMs) {
+        newest = { state: statePath, mtimeMs: stat.mtimeMs };
+      }
+    } catch {
+      /* no state file in this ticket dir */
+    }
+  }
+  if (!newest) process.exit(0);
+
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(newest.state, 'utf8'));
+  } catch {
+    // Malformed state file — fail silent.
+    process.exit(0);
+  }
+
+  // currentStep in .work-state.json is 1-indexed (see e.g. ci-gate.js
+  // setting `ws.currentStep = ALL_STEPS.indexOf('cleanup') + 1`).
+  const idx = (Number(data && data.currentStep) || 1) - 1;
+  const stepName = (idx >= 0 && idx < ALL_STEPS.length) ? ALL_STEPS[idx] : '';
+  if (stepName) process.stdout.write(stepName);
+} catch {
+  // Any unexpected error → fail silent, statusline must never break.
+  process.exit(0);
+}

--- a/scripts/workflows/work/lib/print-current-step.js
+++ b/scripts/workflows/work/lib/print-current-step.js
@@ -59,7 +59,13 @@ try {
 
   // currentStep in .work-state.json is 1-indexed (see e.g. ci-gate.js
   // setting `ws.currentStep = ALL_STEPS.indexOf('cleanup') + 1`).
-  const idx = (Number(data && data.currentStep) || 1) - 1;
+  // Fail-silent contract: if currentStep is missing / not a positive
+  // integer, print nothing rather than defaulting to step 1 ("ticket"),
+  // which would be a misleading indicator.
+  const raw = data && data.currentStep;
+  const num = Number(raw);
+  if (!Number.isFinite(num) || num < 1) process.exit(0);
+  const idx = num - 1;
   const stepName = (idx >= 0 && idx < ALL_STEPS.length) ? ALL_STEPS[idx] : '';
   if (stepName) process.stdout.write(stepName);
 } catch {


### PR DESCRIPTION
## Existing Behavior

- The plugin has no way to surface the active `/work` step name outside its own hooks and scripts.
- Claude Code's statusline can show PR number via the existing statusline command, but has no access to workflow step state.
- `.work-state.json` files exist under `TASKS_BASE` per ticket but are only consumed internally.

## Intended New Behavior

- A new zero-argument Node script `scripts/workflows/work/lib/print-current-step.js` reads the newest-mtime `.work-state.json` under `TASKS_BASE`, maps `currentStep` (1-indexed) to a name via `ALL_STEPS`, and writes it to stdout (e.g. `implement`, `ci`, `follow_up`).
- The helper is **fail-silent by design**: any error (missing `TASKS_BASE`, unreadable file, malformed JSON, bad field) exits 0 with empty stdout — the statusline must never break.
- A new doc `docs/statusline-integration.md` explains a bash wrapper that appends ` · step: <name>` to existing statusline output, producing e.g. `bypass permissions on · PR #386 · step: ci`.
- `~/settings.json` is **not** touched by this PR — the doc explains how to wire it up manually.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Deviation note

The brief suggested using the `resolvePluginPaths` helper. That helper was not used here. Reason: the statusline script runs from arbitrary `cwd` (wherever the user's shell is), so using a relative `require` from `scripts/workflows/work/lib/` up two levels to `scripts/workflows/lib/get-config.js` is more robust than a helper that relies on a specific `__dirname` anchor inside the plugin tree.

## Testing Plan / Demo

Run the helper directly after cloning/updating the plugin:

```
node PLUGIN_PATH/scripts/workflows/work/lib/print-current-step.js
```

(where `PLUGIN_PATH` is the path to your work-workflow plugin install)

Expected output when a ticket is active at the `ci` step: `ci` (no trailing newline, exit 0).
Expected output when no tickets are active or `TASKS_BASE` is unset: empty stdout, exit 0.

To wire up the full statusline, follow `docs/statusline-integration.md`:

1. Create the wrapper script shown in the doc.
2. Make it executable with `chmod +x`.
3. Point `statusLine.command` in `settings.json` at the wrapper.
4. Open a new Claude Code session — the statusline should show `· step: <name>` when a `/work` ticket is active.

### Test Results

5 cases in `scripts/workflows/work/lib/__tests__/print-current-step.test.js`:

| # | Scenario | Expected |
|---|----------|----------|
| 1 | Empty `TASKS_BASE` | exit 0, stdout empty |
| 2 | Single state file | prints mapped step name (`implement`) |
| 3 | Two state files, different mtimes | newer mtime wins (`ci`) |
| 4 | Malformed JSON | exit 0, stdout empty (fail-silent) |
| 5 | `TASKS_BASE` path does not exist | exit 0, stdout empty |

Run with:

```
node --test scripts/workflows/work/lib/__tests__/print-current-step.test.js
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone, fail-silent helper script plus tests and documentation, without modifying existing workflow execution or state-writing logic.
> 
> **Overview**
> Adds a new zero-argument Node helper, `print-current-step.js`, that reads the most recently modified ticket `.work-state.json` under `TASKS_BASE`, maps its 1-indexed `currentStep` to `ALL_STEPS`, and prints the step name with **no newline**.
> 
> The helper is intentionally **fail-silent** (any missing config/file/JSON/bad `currentStep` produces empty stdout and exit 0), with a new Node test suite covering success and key failure modes. Documentation is added to show how to wrap Claude Code’s existing statusline command to append `· step: <name>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e88de97db96089b26aa5a2031e16cde8b53a1dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->