### PR TITLE
fix(hooks): harden work-hook + enforce-follow-up-script paths

### DIFF
--- a/hooks/__tests__/symlink-independence.test.js
+++ b/hooks/__tests__/symlink-independence.test.js
@@ -87,19 +87,61 @@ describe('hook scripts resolve without the workflows symlink', () => {
 
   it('enforce-follow-up-script.js loads and exits 0 with no MODULE_NOT_FOUND on stderr', () => {
     const hook = path.join(tmpRoot, 'hooks', 'enforce-follow-up-script.js');
-    // Feed a benign tool_input that won't match the gh-CI regex → early exit 0.
-    const payload = JSON.stringify({ tool_input: { command: 'ls -la' } });
+    // Use a command that DOES match the gh-CI regex so the hook actually
+    // reaches the changed require() calls for get-config and get-ticket-id.
+    // A benign command like `ls -la` would exit early and bypass the requires
+    // entirely, making this test useless as a regression guard (the swallowing
+    // try/catch in the hook would also hide MODULE_NOT_FOUND in normal flow).
+    const payload = JSON.stringify({ tool_input: { command: 'gh run list' } });
     const res = spawnSync(process.execPath, [hook], {
       input: payload,
       env: { ...process.env, CLAUDE_PLUGIN_ROOT: tmpRoot },
       encoding: 'utf8',
       timeout: 15000,
     });
-    assert.equal(res.status, 0, `expected exit 0, got ${res.status}; stderr=${res.stderr}`);
+    // Exit 0 is expected (no active follow-up session); exit 2 would mean a
+    // block, which we don't expect in this fixture. Either way the require()
+    // calls must have resolved cleanly.
+    assert.ok(
+      res.status === 0 || res.status === 2,
+      `expected exit 0 or 2, got ${res.status}; stderr=${res.stderr}`
+    );
     assert.ok(
       !/MODULE_NOT_FOUND/.test(res.stderr || ''),
       `unexpected MODULE_NOT_FOUND in stderr: ${res.stderr}`
     );
+  });
+
+  it('changed require paths resolve from the synthetic plugin root (no symlink)', () => {
+    // Directly verify that the two module paths the hooks now use can be
+    // resolved via Node's require system in a process whose plugin root has
+    // NO `workflows` symlink. This bypasses the hook's inner try/catch that
+    // would otherwise swallow MODULE_NOT_FOUND, providing a hard guarantee
+    // that the canonical scripts/workflows path works on its own.
+    const probe = `
+      'use strict';
+      const path = require('node:path');
+      const hooksDir = path.join(${JSON.stringify(tmpRoot)}, 'hooks');
+      try {
+        require.resolve(path.join(hooksDir, '..', 'scripts', 'workflows', 'lib', 'get-config'));
+        require.resolve(path.join(hooksDir, '..', 'scripts', 'workflows', 'lib', 'scripts', 'get-ticket-id'));
+        process.stdout.write('OK');
+        process.exit(0);
+      } catch (err) {
+        process.stderr.write(String(err && err.code) + ':' + String(err && err.message));
+        process.exit(1);
+      }
+    `;
+    const res = spawnSync(process.execPath, ['-e', probe], {
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    assert.equal(
+      res.status,
+      0,
+      `module resolution failed without symlink; stdout=${res.stdout} stderr=${res.stderr}`
+    );
+    assert.equal(res.stdout, 'OK');
   });
 
   it('work-hook.js still loads when CLAUDE_PLUGIN_ROOT is unset (uses __dirname)', () => {

--- a/hooks/__tests__/symlink-independence.test.js
+++ b/hooks/__tests__/symlink-independence.test.js
@@ -1,0 +1,121 @@
+/**
+ * Regression tests: hook scripts must NOT depend on the legacy
+ * `<plugin-root>/workflows -> scripts/workflows` symlink to resolve
+ * their top-level requires.
+ *
+ * Historically `hooks/work-hook.js` and `hooks/enforce-follow-up-script.js`
+ * computed module paths through a `workflows/...` segment that only
+ * resolved via that committed symlink. If the symlink ever went away
+ * (clean clone without symlinks, copy to a filesystem that strips them,
+ * intentional refactor), Node would throw MODULE_NOT_FOUND from
+ * loader:1459 at hook entry — visible to every /work invocation.
+ *
+ * These tests rebuild a minimal plugin root that has only the canonical
+ * `scripts/workflows/...` layout (no `workflows` symlink), copy each
+ * hook into it, and spawn it. A clean exit with no MODULE_NOT_FOUND
+ * proves the hook's path resolution no longer depends on the symlink.
+ */
+
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const REAL_HOOKS_DIR = path.join(REPO_ROOT, 'hooks');
+const REAL_SCRIPTS_WORKFLOWS = path.join(REPO_ROOT, 'scripts', 'workflows');
+
+function copyDirSync(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const ent of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, ent.name);
+    const d = path.join(dest, ent.name);
+    if (ent.isSymbolicLink()) {
+      // Skip symlinks entirely — that's the whole point of this test.
+      continue;
+    }
+    if (ent.isDirectory()) copyDirSync(s, d);
+    else if (ent.isFile()) fs.copyFileSync(s, d);
+  }
+}
+
+describe('hook scripts resolve without the workflows symlink', () => {
+  let tmpRoot;
+
+  before(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hook-symlink-test-'));
+    // Re-create plugin layout WITHOUT the `workflows -> scripts/workflows`
+    // symlink. We copy only what the hooks need to load: scripts/workflows.
+    copyDirSync(REAL_SCRIPTS_WORKFLOWS, path.join(tmpRoot, 'scripts', 'workflows'));
+    // Copy hooks themselves into the synthetic root.
+    copyDirSync(REAL_HOOKS_DIR, path.join(tmpRoot, 'hooks'));
+
+    // Sanity: confirm no `workflows` entry exists at the synthetic root.
+    assert.equal(
+      fs.existsSync(path.join(tmpRoot, 'workflows')),
+      false,
+      'synthetic root must NOT contain a workflows symlink — the test fixture is broken'
+    );
+  });
+
+  after(() => {
+    if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('work-hook.js loads and exits 0 with no MODULE_NOT_FOUND on stderr', () => {
+    const hook = path.join(tmpRoot, 'hooks', 'work-hook.js');
+    const res = spawnSync(process.execPath, [hook], {
+      input: '',
+      env: { ...process.env, CLAUDE_USER_PROMPT: 'hello world', CLAUDE_PLUGIN_ROOT: tmpRoot },
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    assert.equal(res.status, 0, `expected exit 0, got ${res.status}; stderr=${res.stderr}`);
+    assert.ok(
+      !/MODULE_NOT_FOUND/.test(res.stderr || ''),
+      `unexpected MODULE_NOT_FOUND in stderr: ${res.stderr}`
+    );
+    assert.ok(
+      !/loader:1459/.test(res.stderr || ''),
+      `unexpected loader stack trace in stderr: ${res.stderr}`
+    );
+  });
+
+  it('enforce-follow-up-script.js loads and exits 0 with no MODULE_NOT_FOUND on stderr', () => {
+    const hook = path.join(tmpRoot, 'hooks', 'enforce-follow-up-script.js');
+    // Feed a benign tool_input that won't match the gh-CI regex → early exit 0.
+    const payload = JSON.stringify({ tool_input: { command: 'ls -la' } });
+    const res = spawnSync(process.execPath, [hook], {
+      input: payload,
+      env: { ...process.env, CLAUDE_PLUGIN_ROOT: tmpRoot },
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    assert.equal(res.status, 0, `expected exit 0, got ${res.status}; stderr=${res.stderr}`);
+    assert.ok(
+      !/MODULE_NOT_FOUND/.test(res.stderr || ''),
+      `unexpected MODULE_NOT_FOUND in stderr: ${res.stderr}`
+    );
+  });
+
+  it('work-hook.js still loads when CLAUDE_PLUGIN_ROOT is unset (uses __dirname)', () => {
+    const hook = path.join(tmpRoot, 'hooks', 'work-hook.js');
+    const env = { ...process.env, CLAUDE_USER_PROMPT: 'hello world' };
+    delete env.CLAUDE_PLUGIN_ROOT;
+    const res = spawnSync(process.execPath, [hook], {
+      input: '',
+      env,
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    assert.equal(res.status, 0, `expected exit 0, got ${res.status}; stderr=${res.stderr}`);
+    assert.ok(
+      !/MODULE_NOT_FOUND/.test(res.stderr || ''),
+      `unexpected MODULE_NOT_FOUND in stderr: ${res.stderr}`
+    );
+  });
+});

--- a/hooks/enforce-follow-up-script.js
+++ b/hooks/enforce-follow-up-script.js
@@ -25,7 +25,9 @@ try {
   // Check if a follow-up session is active
   let tasksBase;
   try {
-    const getConfig = require(path.join(__dirname, '..', 'workflows', 'lib', 'get-config'));
+    const getConfig = require(
+      path.join(__dirname, '..', 'scripts', 'workflows', 'lib', 'get-config')
+    );
     tasksBase = getConfig('TASKS_BASE');
   } catch {
     process.exit(0); // Can't determine tasks base — fail-open
@@ -39,7 +41,7 @@ try {
   let currentTicket = '';
   try {
     const { getCurrentTaskId } = require(
-      path.join(__dirname, '..', 'workflows', 'lib', 'scripts', 'get-ticket-id')
+      path.join(__dirname, '..', 'scripts', 'workflows', 'lib', 'scripts', 'get-ticket-id')
     );
     currentTicket = getCurrentTaskId() || '';
   } catch {

--- a/hooks/work-hook.js
+++ b/hooks/work-hook.js
@@ -8,15 +8,32 @@
  */
 
 const path = require('path');
+// Resolve paths via the canonical scripts/workflows/... layout. The plugin root
+// historically also exposed `workflows -> scripts/workflows` as a committed
+// symlink, but relying on it makes these top-level requires throw with
+// MODULE_NOT_FOUND (loader:1459) if the symlink is ever missing (clean clone
+// without symlinks, copy to a filesystem that strips them, refactor that
+// removes it). Use the real path so the hook never depends on the symlink.
 const { appendAction } = require(
-  path.join(__dirname, '..', 'workflows', 'work', 'lib', 'work-actions')
+  path.join(__dirname, '..', 'scripts', 'workflows', 'work', 'lib', 'work-actions')
 );
-const { logHookError } = require(path.join(__dirname, '..', 'workflows', 'lib', 'hook-error-log'));
-const { safeExec } = require(path.join(__dirname, '..', 'workflows', 'lib', 'safe-exec'));
+const { logHookError } = require(
+  path.join(__dirname, '..', 'scripts', 'workflows', 'lib', 'hook-error-log')
+);
+const { safeExec } = require(
+  path.join(__dirname, '..', 'scripts', 'workflows', 'lib', 'safe-exec')
+);
 
 // Use CLAUDE_PLUGIN_ROOT if available, otherwise fallback to __dirname
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.dirname(__dirname);
-const ORCHESTRATOR_PATH = path.join(PLUGIN_ROOT, 'workflows', 'work', 'engine', 'work.workflow.js');
+const ORCHESTRATOR_PATH = path.join(
+  PLUGIN_ROOT,
+  'scripts',
+  'workflows',
+  'work',
+  'engine',
+  'work.workflow.js'
+);
 
 // Tokenize args string into positional single-token values.
 // Quoted multi-word args are NOT supported by design — matches pre-execFileSync


### PR DESCRIPTION
## Existing Behavior

- `hooks/work-hook.js` required `appendAction`, `logHookError`, and `safeExec` via `../workflows/work/...` and `../workflows/lib/...` paths, which resolved only through a committed `workflows -> scripts/workflows` symlink.
- `hooks/enforce-follow-up-script.js` required `get-config` and `get-ticket-id` via the same `../workflows/...` segment.
- The `ORCHESTRATOR_PATH` constant in `work-hook.js` was also built through the `workflows/` segment.
- When the symlink was absent (clean clone, filesystem copy, refactor that removed it), `work-hook.js` threw `MODULE_NOT_FOUND` at `loader:1459` on every `/work` invocation; `enforce-follow-up-script.js` silently caught the same error and exited 0, meaning enforcement never ran.

## Intended New Behavior

- Both hooks now resolve all module paths via the canonical `../scripts/workflows/...` layout — no symlink dependency.
- `work-hook.js` top-level requires and `ORCHESTRATOR_PATH` all point directly into `scripts/workflows/`, eliminating the active breakage.
- `enforce-follow-up-script.js` enforcement now runs correctly on every invocation regardless of symlink presence.
- Three regression tests in `hooks/__tests__/symlink-independence.test.js` build a synthetic plugin root in `os.tmpdir()` with only the `scripts/workflows/...` tree (no `workflows` entry), spawn each hook, and assert exit 0 with no `MODULE_NOT_FOUND` on stderr. A third case covers the `__dirname` fallback path when `CLAUDE_PLUGIN_ROOT` is unset.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / hook path fix — verify the fix in a plugin root without the symlink:**

1. Clone the repo into a temp directory: `git clone <repo> /tmp/test-plugin && cd /tmp/test-plugin`
2. Confirm no `workflows` symlink: `ls -la | grep workflows` — should show nothing.
3. Invoke `work-hook.js` directly:
   ```bash
   CLAUDE_USER_PROMPT="hello" node hooks/work-hook.js
   ```
   Expected: exits 0, no `MODULE_NOT_FOUND` on stderr.
4. Invoke `enforce-follow-up-script.js` with a benign payload:
   ```bash
   echo '{"tool_input":{"command":"ls"}}' | node hooks/enforce-follow-up-script.js
   ```
   Expected: exits 0, no `MODULE_NOT_FOUND` on stderr.
5. Run the regression suite: `pnpm test -- --test-name-pattern "hook scripts resolve"` — all 3 cases should pass.

**Pre-existing test failures (unrelated to this PR):**
- `session-guard "allows stop when /check workflow is active"` — pre-existing
- `protect-orchestrator-state "node work-next.js ECHO-4446"` — pre-existing

### Test Results

New test file `hooks/__tests__/symlink-independence.test.js` — 3 cases, all pass:
- `work-hook.js loads and exits 0 with no MODULE_NOT_FOUND on stderr`
- `enforce-follow-up-script.js loads and exits 0 with no MODULE_NOT_FOUND on stderr`
- `work-hook.js still loads when CLAUDE_PLUGIN_ROOT is unset (uses __dirname)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hook entrypoints that run on every `/work`/CI-check invocation; while changes are path-only, mistakes would cause runtime `MODULE_NOT_FOUND` or disable enforcement in real usage.
> 
> **Overview**
> Updates `work-hook.js` and `enforce-follow-up-script.js` to resolve all `require()`s and the `/work` orchestrator path via the canonical `scripts/workflows/...` tree instead of the legacy `workflows` symlink.
> 
> Adds a regression test (`hooks/__tests__/symlink-independence.test.js`) that builds a synthetic plugin root *without* the `workflows` symlink, spawns both hooks, and asserts they start cleanly (no `MODULE_NOT_FOUND`), including the `work-hook.js` fallback when `CLAUDE_PLUGIN_ROOT` is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7fa7b3128a66d099cd0bf874e43c0768ac6e2bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->