### PR TITLE
fix(work): source .envrc when BOOTSTRAP_SCRIPT undefined and direnv inactive

### DIFF
--- a/scripts/workflows/work/scripts/__tests__/bootstrap-custom-script.test.js
+++ b/scripts/workflows/work/scripts/__tests__/bootstrap-custom-script.test.js
@@ -169,6 +169,61 @@ describe('bootstrap-custom-script.js', () => {
     });
   });
 
+  describe('.envrc sourcing when BOOTSTRAP_SCRIPT not in env', () => {
+    it('sources .envrc from worktree parent directory and runs the script', () => {
+      const targetScript = makeScript('from-envrc.sh', '#!/bin/sh\necho "FROM_ENVRC_OK"\n');
+      const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'envrc-parent-'));
+      const worktreeDir = path.join(parentDir, 'worktree-1');
+      fs.mkdirSync(worktreeDir);
+      fs.writeFileSync(
+        path.join(parentDir, '.envrc'),
+        `export BOOTSTRAP_SCRIPT="${targetScript}"\n`
+      );
+
+      try {
+        const result = runResult([worktreeDir, 'TICKET-ENVRC'], { BOOTSTRAP_SCRIPT: '' });
+        assert.equal(result.status, 0);
+        assert.match(result.stdout, /Sourced \.envrc from/);
+        assert.match(result.stdout, /FROM_ENVRC_OK/);
+      } finally {
+        fs.rmSync(parentDir, { recursive: true, force: true });
+      }
+    });
+
+    it('process.env wins over .envrc value', () => {
+      const envScript = makeScript('from-env.sh', '#!/bin/sh\necho "FROM_ENV_WINS"\n');
+      const envrcScript = makeScript('from-envrc-loser.sh', '#!/bin/sh\necho "ENVRC_LOSER"\n');
+      const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'envrc-precedence-'));
+      const worktreeDir = path.join(parentDir, 'worktree-1');
+      fs.mkdirSync(worktreeDir);
+      fs.writeFileSync(
+        path.join(parentDir, '.envrc'),
+        `export BOOTSTRAP_SCRIPT="${envrcScript}"\n`
+      );
+
+      try {
+        const output = run([worktreeDir, 'TICKET-1'], { BOOTSTRAP_SCRIPT: envScript });
+        assert.match(output, /FROM_ENV_WINS/);
+        assert.doesNotMatch(output, /ENVRC_LOSER/);
+      } finally {
+        fs.rmSync(parentDir, { recursive: true, force: true });
+      }
+    });
+
+    it('still logs skipping when no .envrc and no env var is set', () => {
+      const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-envrc-'));
+      const worktreeDir = path.join(parentDir, 'worktree-1');
+      fs.mkdirSync(worktreeDir);
+
+      try {
+        const output = run([worktreeDir, 'TICKET-1'], { BOOTSTRAP_SCRIPT: '' });
+        assert.match(output, /skipping/i);
+      } finally {
+        fs.rmSync(parentDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('non-executable file (EACCES)', () => {
     it('exits 0 and warns when file exists but is not executable', () => {
       const scriptPath = path.join(tmpDir, 'no-exec.sh');

--- a/scripts/workflows/work/scripts/bootstrap-custom-script.js
+++ b/scripts/workflows/work/scripts/bootstrap-custom-script.js
@@ -24,6 +24,50 @@ const { logHookError } = require('../../lib/hook-error-log');
 const DEFAULT_TIMEOUT_SECONDS = 120;
 
 /**
+ * Source `.envrc` from candidate directories and merge missing vars into
+ * process.env. Direnv may not be active in the orchestrator's spawning
+ * shell, so the workflow can't rely on env vars from `.envrc` being present.
+ *
+ * Existing process.env values are preserved (env wins over .envrc) so that
+ * explicit overrides from the caller still take precedence.
+ *
+ * @param {string[]} candidateDirs - Directories to check for a .envrc
+ * @returns {string[]} Paths of .envrc files that were sourced
+ */
+function loadEnvrcFromDirs(candidateDirs) {
+  const sourced = [];
+  const seen = new Set();
+  for (const dir of candidateDirs) {
+    if (!dir) continue;
+    const envrcPath = path.join(dir, '.envrc');
+    if (seen.has(envrcPath)) continue;
+    seen.add(envrcPath);
+    if (!fs.existsSync(envrcPath)) continue;
+
+    const result = spawnSync(
+      'bash',
+      ['-c', `set -a; source "${envrcPath}" >/dev/null 2>&1; env -0`],
+      { encoding: 'utf-8', timeout: 10000, maxBuffer: 5 * 1024 * 1024 }
+    );
+
+    if (result.status !== 0 || !result.stdout) continue;
+
+    for (const entry of result.stdout.split('\0')) {
+      if (!entry) continue;
+      const eq = entry.indexOf('=');
+      if (eq <= 0) continue;
+      const key = entry.slice(0, eq);
+      const value = entry.slice(eq + 1);
+      if (!process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+    sourced.push(envrcPath);
+  }
+  return sourced;
+}
+
+/**
  * Resolve the script path. Supports absolute and cwd-relative paths.
  * @param {string} scriptPath - Raw path from config
  * @returns {string} Resolved absolute path
@@ -53,7 +97,16 @@ function getTimeoutMs() {
  * @returns {{ ok: boolean, stdout?: string, stderr?: string, error?: string }}
  */
 function executeCustomScript(worktreePath, ticketId) {
-  const scriptConfig = getConfig('BOOTSTRAP_SCRIPT');
+  let scriptConfig = getConfig('BOOTSTRAP_SCRIPT');
+
+  if (!scriptConfig) {
+    const sourced = loadEnvrcFromDirs([worktreePath, path.dirname(worktreePath)]);
+    if (sourced.length > 0) {
+      console.log(`Sourced .envrc from: ${sourced.join(', ')}`);
+    }
+    scriptConfig = getConfig('BOOTSTRAP_SCRIPT');
+  }
+
   if (!scriptConfig) {
     console.log('BOOTSTRAP_SCRIPT not set, skipping custom bootstrap script');
     return { ok: true };
@@ -107,7 +160,7 @@ function executeCustomScript(worktreePath, ticketId) {
   }
 }
 
-module.exports = { executeCustomScript, resolveScriptPath, getTimeoutMs };
+module.exports = { executeCustomScript, resolveScriptPath, getTimeoutMs, loadEnvrcFromDirs };
 
 // CLI entry point
 if (require.main === module) {


### PR DESCRIPTION
## Existing Behavior

- `executeCustomScript` reads `BOOTSTRAP_SCRIPT` directly from `process.env` via `getConfig`.
- When direnv is not active in the orchestrator's spawning shell, any `BOOTSTRAP_SCRIPT` defined only in `.envrc` is never seen by the process.
- The script silently logs "BOOTSTRAP_SCRIPT not set, skipping" and exits early, causing the custom bootstrap step to be silently skipped with no indication of the root cause.

## Intended New Behavior

- Before giving up on a missing `BOOTSTRAP_SCRIPT`, `executeCustomScript` calls the new `loadEnvrcFromDirs` helper, which probes the worktree directory and its parent for a `.envrc` file.
- Each found `.envrc` is sourced via `bash -c 'set -a; source <path> >/dev/null 2>&1; env -0'`, and the resulting variables are merged into `process.env` — without overwriting values already present, so explicit caller overrides always win.
- After sourcing, `getConfig('BOOTSTRAP_SCRIPT')` is called again; if the script path is now available, execution proceeds normally.
- A log line `Sourced .envrc from: <path>` is emitted whenever at least one `.envrc` is loaded, making the resolution path visible in orchestrator output.
- `loadEnvrcFromDirs` is exported so it can be unit-tested and reused.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The fix affects the backend bootstrap script execution path. To verify:

1. Set up a worktree where `BOOTSTRAP_SCRIPT` is defined only in the parent directory's `.envrc`, not in the shell environment.
2. Run the bootstrap step from an orchestrator shell where direnv is not active (i.e., `echo $BOOTSTRAP_SCRIPT` returns empty).
3. Confirm the orchestrator output contains `Sourced .envrc from: <parent-dir>/.envrc` and the custom script runs to completion.
4. To verify precedence: export a different `BOOTSTRAP_SCRIPT` in the shell before running — confirm only the shell value is used and the `.envrc` value is ignored.
5. To verify the skip path: run from a worktree with no `.envrc` anywhere and no env var set — confirm output contains `skipping`.

To run the unit tests directly:

```bash
node --test scripts/workflows/work/scripts/__tests__/bootstrap-custom-script.test.js
```

All 17 tests should pass, including the 3 new tests in the `.envrc sourcing when BOOTSTRAP_SCRIPT not in env` describe block.

### Test Results

All 17 tests pass in `scripts/workflows/work/scripts/__tests__/bootstrap-custom-script.test.js`, including:
- `sources .envrc from worktree parent directory and runs the script`
- `process.env wins over .envrc value`
- `still logs skipping when no .envrc and no env var is set`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces automatic `.envrc` sourcing via `bash` when `BOOTSTRAP_SCRIPT` is unset, which can change runtime environment and execute shell code in local repos; behavior is guarded by only filling missing env vars and covered by tests.
> 
> **Overview**
> When `BOOTSTRAP_SCRIPT` is not set, the bootstrap workflow now attempts to source `.envrc` files from the worktree directory and its parent to populate missing environment variables, then re-reads `BOOTSTRAP_SCRIPT` and logs where the `.envrc` was sourced from.
> 
> Adds `loadEnvrcFromDirs()` (exported) that shells out to `bash` to source `.envrc` and merges variables into `process.env` without overwriting existing values, plus new unit tests covering successful sourcing, precedence of `process.env` over `.envrc`, and the unchanged skip path when neither exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8026a3b9ca02cababa9d46735e6c8008008c7c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->