### PR TITLE
fix(implement-enrichment): fix null task number for single-task plans

### DIFF
--- a/scripts/workflows/work/lib/step-enrichments/__tests__/implement-task-num.test.js
+++ b/scripts/workflows/work/lib/step-enrichments/__tests__/implement-task-num.test.js
@@ -1,0 +1,115 @@
+/**
+ * Regression tests for step-enrichments/implement.js task-number extraction.
+ *
+ * Previously the enrichment only matched the "Task N of M" context block,
+ * which buildTaskPrompt emits only when allTasks.length > 1. Single-task
+ * plans produced "Task null" / "tasknull" in the dispatched prompt.
+ *
+ * Run: node --test scripts/workflows/work/lib/step-enrichments/__tests__/implement-task-num.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const registerImplement = require('../implement');
+
+function makeRegistry() {
+  const byStep = {};
+  return {
+    register: (step, fn) => {
+      if (!byStep[step]) byStep[step] = [];
+      byStep[step].push(fn);
+    },
+    run: (step, entry, ctx) => (byStep[step] || []).forEach((fn) => fn(entry, ctx)),
+  };
+}
+
+function writeTasks(tasksDir, content) {
+  fs.writeFileSync(path.join(tasksDir, 'tasks.md'), content);
+}
+
+let tmp;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'implement-enrich-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('implement enrichment — task number extraction', () => {
+  it('single-task plan: dispatched prompt contains real task num (no null/tasknull)', () => {
+    writeTasks(
+      tmp,
+      [
+        '## Task 1 — Only task',
+        '### Type',
+        'backend',
+        '### Suggested Scope',
+        '- src/foo.js',
+        '',
+      ].join('\n')
+    );
+
+    const registry = makeRegistry();
+    registerImplement(registry.register);
+
+    // Mirrors the single-task agentPrompt shape produced by buildTaskPrompt:
+    // header is present, but no "Task N of M" context block.
+    const entry = {
+      agentPrompt: [
+        '## Current Task: Task 1 — Only task',
+        '',
+        'You are implementing ONE task from the task plan.',
+      ].join('\n'),
+    };
+
+    registry.run('implement', entry, { ticket: 'GH-123', tasksDir: tmp });
+
+    assert.doesNotMatch(entry.agentPrompt, /Task null/, 'no literal "Task null"');
+    assert.doesNotMatch(entry.agentPrompt, /tasknull/, 'no literal "tasknull"');
+    assert.match(entry.agentPrompt, /## Task 1\b/);
+    assert.match(entry.agentPrompt, /\btask1\b/);
+    assert.match(entry.agentPrompt, /GH-123 task1/);
+  });
+
+  it('multi-task plan: still extracts num + total from "Task N of M" block', () => {
+    writeTasks(
+      tmp,
+      [
+        '## Task 2 — Second task',
+        '### Type',
+        'backend',
+        '### Suggested Scope',
+        '- src/bar.js',
+        '',
+      ].join('\n')
+    );
+
+    const registry = makeRegistry();
+    registerImplement(registry.register);
+
+    const entry = {
+      agentPrompt: [
+        '## Current Task: Task 2 — Second task',
+        '',
+        '### Task Context',
+        'This is Task 2 of 3. Scope boundaries are listed below to prevent drift:',
+      ].join('\n'),
+    };
+
+    // tasksDir omitted so the parallel-dispatch branch is skipped and we
+    // exercise the single-task prompt assembly path (which is the one that
+    // previously interpolated null).
+    registry.run('implement', entry, { ticket: 'GH-456', tasksDir: '' });
+
+    assert.doesNotMatch(entry.agentPrompt, /Task null/);
+    assert.doesNotMatch(entry.agentPrompt, /tasknull/);
+    assert.match(entry.agentPrompt, /## Task 2\/3\b/);
+    assert.match(entry.agentPrompt, /GH-456 task2/);
+  });
+});

--- a/scripts/workflows/work/lib/step-enrichments/implement.js
+++ b/scripts/workflows/work/lib/step-enrichments/implement.js
@@ -107,9 +107,14 @@ module.exports = function registerImplement(register) {
 
     const ticket = ctx.ticket || 'TICKET';
     const tasksDir = ctx.tasksDir || '';
-    const taskMatch = entry.agentPrompt.match(/Task (\d+) of (\d+)/);
-    const currentTaskNum = taskMatch ? parseInt(taskMatch[1], 10) : null;
-    const totalTasks = taskMatch ? parseInt(taskMatch[2], 10) : null;
+    // The "## Current Task: Task N — title" header is always emitted by
+    // buildTaskPrompt; the "Task N of M" context block is only present when
+    // allTasks.length > 1. Parse the header for the task number so single-task
+    // plans don't produce "Task null" / "tasknull" in the dispatched prompt.
+    const headerMatch = entry.agentPrompt.match(/## Current Task: Task (\d+)/);
+    const totalMatch = entry.agentPrompt.match(/Task \d+ of (\d+)/);
+    const currentTaskNum = headerMatch ? parseInt(headerMatch[1], 10) : null;
+    const totalTasks = totalMatch ? parseInt(totalMatch[1], 10) : null;
 
     // Parallel dispatch path: one delegate per ready-to-run task.
     if (tasksDir && totalTasks && totalTasks > 1) {
@@ -147,7 +152,7 @@ module.exports = function registerImplement(register) {
     }
 
     // Single-task path.
-    const taskNum = taskMatch ? taskMatch[1] : null;
+    const taskNum = currentTaskNum != null ? String(currentTaskNum) : null;
     const titleMatch = entry.agentPrompt.match(/## Current Task: Task \d+ — (.+?)(?:\n|$)/);
     const taskTitle = titleMatch ? titleMatch[1].trim() : 'Implementation';
 


### PR DESCRIPTION
## Summary

- **Root cause:** `implement.js` extracted the current task number exclusively from the `Task N of M` context block, which `buildTaskPrompt` only emits when `allTasks.length > 1`. For single-task plans that block is absent, so `taskMatch` was `null` and the dispatched developer-agent prompt contained literal `"Task null"` in its header and `"tasknull"` in the `task-next.js` invocation argument.
- **Fix:** Parse the always-present `## Current Task: Task N` header (`headerMatch`) for `currentTaskNum`, and use a separate `/Task \d+ of (\d+)/` lookup (`totalMatch`) for `totalTasks` only. The single-task path now derives `taskNum` from `currentTaskNum`, eliminating the null interpolation.
- **Regression test added:** `scripts/workflows/work/lib/step-enrichments/__tests__/implement-task-num.test.js` covers both the single-task case (no `Task N of M` block) and the multi-task case (`Task 2 of 3` block present). All 56 enrichment tests pass.

## Test plan

- [ ] Run the new regression test directly:
  ```bash
  node --test scripts/workflows/work/lib/step-enrichments/__tests__/implement-task-num.test.js
  ```
  Expected: 2 passing subtests, no failures.

- [ ] Run the full enrichment test suite to confirm no regressions:
  ```bash
  node --test scripts/workflows/work/lib/step-enrichments/__tests__/
  ```
  Expected: all 56 tests pass.

- [ ] Verify single-task plan dispatches without `"Task null"` in the prompt: create a task plan with exactly one `## Task 1 —` entry, trigger the `implement` step, and confirm the dispatched agent prompt header reads `## Task 1/1 — …` (or `## Task 1 — …`) and the `task-next.js` invocation uses `task1` not `tasknull`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to regex-based task number extraction in `implement` step enrichment plus a focused regression test, with no auth/data-path impact.
> 
> **Overview**
> Fixes `scripts/workflows/work/lib/step-enrichments/implement.js` to extract `currentTaskNum` from the always-present `## Current Task: Task N` header (and `totalTasks` separately from `Task N of M`), preventing single-task plans from dispatching prompts containing **`Task null`** / **`tasknull`**.
> 
> Adds a regression test (`implement-task-num.test.js`) covering both single-task (no `Task N of M` block) and multi-task prompts to ensure task numbers and `task-next.js` arguments are correctly formed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b27e9933c682a4ceab238d62fb2c6cc0dbc00e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->