### PR TITLE
fix(ci): bulletproof PR-merged gate (3rd attempt, defense in depth)

### DIFF
--- a/scripts/workflows/work-ci/__tests__/wait-no-dev-banner.test.js
+++ b/scripts/workflows/work-ci/__tests__/wait-no-dev-banner.test.js
@@ -1,0 +1,49 @@
+/**
+ * wait-no-dev-banner.test.js
+ *
+ * The ci/wait and ci/wait_merge phases are poll-only / merge-only. The
+ * instructions text must explicitly forbid spawning developer agents during
+ * these phases — without the banner, orchestrators misroute and spawn
+ * developer-nodejs-tdd while CI is just running or while waiting for a
+ * human merge (observed in ECHO-5218).
+ */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const wait = require('../lib/phases/wait');
+const wait_merge = require('../lib/phases/wait_merge');
+
+function makeCtx(prefix) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+  const tasksDir = path.join(root, 'tasks', 'ECHO-NODEV');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  return { root, tasksDir, worktreeRoot: root, ticket: 'ECHO-NODEV' };
+}
+
+test('wait.instructions includes POLL-ONLY banner forbidding dev agents', () => {
+  const ctx = makeCtx('ci-wait-banner');
+  try {
+    const text = wait.instructions(ctx);
+    assert.match(text, /POLL-ONLY/, 'wait phase must declare POLL-ONLY');
+    assert.match(text, /do not spawn/i, 'wait phase must forbid spawning agents');
+  } finally {
+    fs.rmSync(ctx.root, { recursive: true, force: true });
+  }
+});
+
+test('wait_merge.instructions includes WAITING FOR HUMAN MERGE banner', () => {
+  const ctx = makeCtx('ci-waitmerge-banner');
+  try {
+    const text = wait_merge.instructions(ctx);
+    assert.match(text, /WAITING FOR HUMAN MERGE/, 'wait_merge must declare HUMAN-MERGE wait');
+    assert.match(text, /do not spawn/i, 'wait_merge must forbid spawning agents');
+    assert.match(text, /(merge|merged)/i, 'wait_merge must mention merge requirement explicitly');
+  } finally {
+    fs.rmSync(ctx.root, { recursive: true, force: true });
+  }
+});

--- a/scripts/workflows/work-ci/lib/phases/wait.js
+++ b/scripts/workflows/work-ci/lib/phases/wait.js
@@ -124,8 +124,11 @@ function instructions(ctx) {
     }
   }
   lines.push('');
+  lines.push('⏳ POLL-ONLY PHASE — do not edit files, do not spawn developer agents.');
+  lines.push('There is nothing to implement while CI is running. The ONLY action is to');
+  lines.push('re-invoke ci-next.js periodically (or wait for a Monitor task to nudge you).');
   lines.push(
-    'CI can take 20+ minutes. Re-invoke me periodically (or wait for a Monitor task to nudge you). I advance to TRIAGE as soon as no checks are still running.'
+    'CI can take 20+ minutes. I advance to TRIAGE as soon as no checks are still running.'
   );
   lines.push('');
   return lines.join('\n');

--- a/scripts/workflows/work-ci/lib/phases/wait_merge.js
+++ b/scripts/workflows/work-ci/lib/phases/wait_merge.js
@@ -106,13 +106,18 @@ function instructions(ctx) {
     if (snapshot.mergedAt) lines.push(`  mergedAt: ${snapshot.mergedAt}`);
   }
   lines.push('');
+  lines.push('⛔ WAITING FOR HUMAN MERGE — do not spawn ANY agent, do not edit files.');
   lines.push(
-    'The ci step waits for the PR to be MERGED into the base branch before allowing the workflow to advance to cleanup/reports/complete.'
+    'The /work workflow CANNOT advance to cleanup/reports/complete until the user clicks "Merge" on the PR.'
+  );
+  lines.push(
+    'There is no orchestrator action that can resolve this — only the human merging the PR can.'
   );
   lines.push('');
   lines.push(
-    'Sleep / hand off to the user, then re-invoke me. I advance to MEMORIZE as soon as `gh pr view --json state` reports `MERGED`.'
+    'Hand off to the user with the PR URL. Re-invoke ci-next.js ONLY after they confirm merge.'
   );
+  lines.push('I advance to MEMORIZE as soon as `gh pr view --json state` reports `MERGED`.');
   lines.push('');
   return lines.join('\n');
 }

--- a/scripts/workflows/work/__tests__/ci-verify-requires-merge.test.js
+++ b/scripts/workflows/work/__tests__/ci-verify-requires-merge.test.js
@@ -1,0 +1,111 @@
+/**
+ * ci-verify-requires-merge.test.js
+ *
+ * Defense-in-depth gate for the `ci` step: verify() must require BOTH
+ *   1) CI checks passing (existing behavior), AND
+ *   2) PR state === 'MERGED' on the remote.
+ *
+ * Background (third attempt to fix this bug class): the top-level workflow's
+ * ci verify previously only consulted `checkCI(...).status === 'passing'`, so
+ * `transition-step.js` would happily walk ci → cleanup → reports → complete
+ * the moment CI went green, regardless of whether the PR had actually been
+ * merged. The `wait_merge` sub-phase exists but lives in a parallel state
+ * machine that this verify never consulted.
+ *
+ * This test pins the new behavior: verify() returns false until the remote
+ * reports MERGED, and only then returns true.
+ */
+'use strict';
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const Module = require('node:module');
+
+describe('ci verify gate: requires PR MERGED (not just CI passing)', () => {
+  let tmpDir;
+  let ticketId;
+  let ciGate;
+  let waitMergeModule;
+  let originalFetchPrState;
+
+  const followUpPrPath = path.resolve(__dirname, '..', 'scripts', 'follow-up-pr.js');
+  const waitMergePath = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'work-ci',
+    'lib',
+    'phases',
+    'wait_merge.js'
+  );
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-verify-merge-'));
+    ticketId = 'GH-CI-VERIFY';
+    fs.mkdirSync(path.join(tmpDir, ticketId), { recursive: true });
+
+    const stub = new Module(followUpPrPath);
+    stub.filename = followUpPrPath;
+    stub.loaded = true;
+    stub.exports = {
+      getPRInfo: () => ({ number: 4242 }),
+      checkCI: () => ({ status: 'passing' }),
+    };
+    require.cache[followUpPrPath] = stub;
+
+    waitMergeModule = require(waitMergePath);
+    originalFetchPrState = waitMergeModule.fetchPrState;
+
+    const createWorkflowDefinition = require(path.join(__dirname, '..', 'workflow-definition'));
+    const { STEPS } = require(path.join(__dirname, '..', 'step-registry'));
+    const { workflow } = createWorkflowDefinition({
+      TASKS_BASE: tmpDir,
+      safeTicketPath: (id) => id,
+      resolveGitHead: () => `ref: refs/heads/${ticketId}-test`,
+    });
+
+    ciGate = workflow.commandMap.find((g) => g.step === STEPS.ci && typeof g.verify === 'function');
+    assert.ok(ciGate, 'ci verify gate must exist in commandMap');
+  });
+
+  after(() => {
+    waitMergeModule.fetchPrState = originalFetchPrState;
+    delete require.cache[followUpPrPath];
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    waitMergeModule.fetchPrState = originalFetchPrState;
+  });
+
+  it('returns false when CI is passing but PR is OPEN (not yet merged)', () => {
+    waitMergeModule.fetchPrState = () => ({ state: 'OPEN', mergedAt: null, mergeCommit: null });
+    const result = ciGate.verify(ticketId);
+    assert.equal(result, false, 'ci verify must NOT pass until PR is MERGED');
+  });
+
+  it('returns false when CI is passing but PR is CLOSED (not merged)', () => {
+    waitMergeModule.fetchPrState = () => ({ state: 'CLOSED', mergedAt: null, mergeCommit: null });
+    const result = ciGate.verify(ticketId);
+    assert.equal(result, false, 'ci verify must NOT pass for a CLOSED-not-merged PR');
+  });
+
+  it('returns false when fetchPrState returns null (gh failure)', () => {
+    waitMergeModule.fetchPrState = () => null;
+    const result = ciGate.verify(ticketId);
+    assert.equal(result, false, 'ci verify must fail-closed when merge state unknown');
+  });
+
+  it('returns true when CI is passing AND PR state is MERGED', () => {
+    waitMergeModule.fetchPrState = () => ({
+      state: 'MERGED',
+      mergedAt: '2026-05-25T18:00:00Z',
+      mergeCommit: { oid: 'deadbeef' },
+    });
+    const result = ciGate.verify(ticketId);
+    assert.equal(result, true, 'ci verify must pass when both CI green AND PR merged');
+  });
+});

--- a/scripts/workflows/work/__tests__/work-next-pr-merged.test.js
+++ b/scripts/workflows/work/__tests__/work-next-pr-merged.test.js
@@ -117,10 +117,7 @@ function writeInProgressState(tmpBase, ticket) {
     errors: [],
     startTime: new Date().toISOString(),
   };
-  fs.writeFileSync(
-    pathMod.join(ticketDir, '.work-state.json'),
-    JSON.stringify(state, null, 2)
-  );
+  fs.writeFileSync(pathMod.join(ticketDir, '.work-state.json'), JSON.stringify(state, null, 2));
   return state;
 }
 
@@ -129,6 +126,11 @@ describe('work-next.js — PR-merged short-circuit (Task 8)', () => {
     const tmpBase = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'work-next-pr-merged-'));
     try {
       writeInProgressState(tmpBase, 'ECHO-8001');
+      // ECHO-5218 fix: short-circuit now requires ci-phase.json currentPhase === 'done'
+      fs.writeFileSync(
+        pathMod.join(tmpBase, 'ECHO-8001', 'ci-phase.json'),
+        JSON.stringify({ currentPhase: 'done', phases: { done: { recordedAt: 'x' } } })
+      );
       const shScript = `#!/usr/bin/env bash
 # Fake gh: emit MERGED state regardless of args
 echo '{"state":"MERGED"}'
@@ -225,6 +227,133 @@ exit 0
         stateAfter.stepStatus.pr,
         'completed',
         'pr step should remain in_progress when probe is skipped'
+      );
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it('does NOT short-circuit when ci-phase.json is missing (ECHO-5218 fix)', () => {
+    const tmpBase = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'work-next-pr-merged-no-phase-'));
+    try {
+      writeInProgressState(tmpBase, 'ECHO-8101');
+      const shScript = `#!/usr/bin/env bash
+echo '{"state":"MERGED"}'
+exit 0
+`;
+      const shimDir = makeShimDir(tmpBase, shScript);
+      const worktreesBase = pathMod.join(tmpBase, 'worktrees');
+      const repoName = 'fake-repo';
+      fs.mkdirSync(pathMod.join(worktreesBase, `${repoName}-ECHO-8101`), { recursive: true });
+      const env = {
+        ...process.env,
+        TASKS_BASE: tmpBase,
+        WORKTREES_BASE: worktreesBase,
+        REPO_NAME: repoName,
+        SESSION_GUARD_ENABLED: '0',
+        TICKET_PROVIDER: 'jira',
+        TICKET_PROJECT_KEY: 'ECHO',
+        PATH: `${shimDir}:${process.env.PATH || ''}`,
+      };
+      delete env.CLAUDE_PLUGIN_ROOT;
+      const res = spawnSync(process.execPath, [WORK_NEXT, 'ECHO-8101'], {
+        encoding: 'utf8',
+        timeout: 15000,
+        env,
+      });
+      const stateAfter = JSON.parse(
+        fs.readFileSync(pathMod.join(tmpBase, 'ECHO-8101', '.work-state.json'), 'utf8')
+      );
+      assert.notEqual(
+        stateAfter.status,
+        'completed',
+        `short-circuit must NOT fire without ci-phase.json done (stderr=${res.stderr})`
+      );
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it('does NOT short-circuit when ci-phase.json currentPhase !== done', () => {
+    const tmpBase = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'work-next-pr-merged-wait-phase-'));
+    try {
+      writeInProgressState(tmpBase, 'ECHO-8102');
+      // Simulate the orchestrator paused inside ci sub-workflow at wait_merge
+      fs.writeFileSync(
+        pathMod.join(tmpBase, 'ECHO-8102', 'ci-phase.json'),
+        JSON.stringify({ currentPhase: 'wait_merge', phases: {} })
+      );
+      const shScript = `#!/usr/bin/env bash
+echo '{"state":"MERGED"}'
+exit 0
+`;
+      const shimDir = makeShimDir(tmpBase, shScript);
+      const worktreesBase = pathMod.join(tmpBase, 'worktrees');
+      const repoName = 'fake-repo';
+      fs.mkdirSync(pathMod.join(worktreesBase, `${repoName}-ECHO-8102`), { recursive: true });
+      const env = {
+        ...process.env,
+        TASKS_BASE: tmpBase,
+        WORKTREES_BASE: worktreesBase,
+        REPO_NAME: repoName,
+        SESSION_GUARD_ENABLED: '0',
+        TICKET_PROVIDER: 'jira',
+        TICKET_PROJECT_KEY: 'ECHO',
+        PATH: `${shimDir}:${process.env.PATH || ''}`,
+      };
+      delete env.CLAUDE_PLUGIN_ROOT;
+      spawnSync(process.execPath, [WORK_NEXT, 'ECHO-8102'], {
+        encoding: 'utf8',
+        timeout: 15000,
+        env,
+      });
+      const stateAfter = JSON.parse(
+        fs.readFileSync(pathMod.join(tmpBase, 'ECHO-8102', '.work-state.json'), 'utf8')
+      );
+      assert.notEqual(
+        stateAfter.status,
+        'completed',
+        'short-circuit must NOT fire when ci sub-workflow is mid-flight (wait_merge)'
+      );
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  it('DOES short-circuit when ci-phase.json currentPhase === done AND PR MERGED', () => {
+    const tmpBase = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'work-next-pr-merged-done-phase-'));
+    try {
+      writeInProgressState(tmpBase, 'ECHO-8103');
+      fs.writeFileSync(
+        pathMod.join(tmpBase, 'ECHO-8103', 'ci-phase.json'),
+        JSON.stringify({ currentPhase: 'done', phases: { done: { recordedAt: 'x' } } })
+      );
+      const shScript = `#!/usr/bin/env bash
+echo '{"state":"MERGED"}'
+exit 0
+`;
+      const shimDir = makeShimDir(tmpBase, shScript);
+      const worktreesBase = pathMod.join(tmpBase, 'worktrees');
+      const repoName = 'fake-repo';
+      fs.mkdirSync(pathMod.join(worktreesBase, `${repoName}-ECHO-8103`), { recursive: true });
+      const prevWB = process.env.WORKTREES_BASE;
+      const prevRN = process.env.REPO_NAME;
+      process.env.WORKTREES_BASE = worktreesBase;
+      process.env.REPO_NAME = repoName;
+      let parsed, stderr;
+      try {
+        ({ parsed, stderr } = runWorkNext('ECHO-8103', tmpBase, shimDir));
+      } finally {
+        if (prevWB === undefined) delete process.env.WORKTREES_BASE;
+        else process.env.WORKTREES_BASE = prevWB;
+        if (prevRN === undefined) delete process.env.REPO_NAME;
+        else process.env.REPO_NAME = prevRN;
+      }
+      assert.ok(parsed, `expected JSON output, got stderr: ${stderr}`);
+      assert.equal(
+        parsed.action,
+        'complete',
+        `expected action=complete when phase=done AND merged; got: ${JSON.stringify(parsed)}`
       );
     } finally {
       fs.rmSync(tmpBase, { recursive: true, force: true });

--- a/scripts/workflows/work/steps/ci.js
+++ b/scripts/workflows/work/steps/ci.js
@@ -8,12 +8,11 @@
 module.exports = function ciStep(add, s, ctx) {
   const { STEPS, worktreeDir, ticket, t } = ctx;
   const tk = ticket || t;
-  add(STEPS.ci, 'RUN', 'Task(Bash)', 'Wait for CI', {
+  add(STEPS.ci, 'RUN', 'Task(Bash)', 'Wait for CI and PR merge', {
     agentType: 'Bash',
     agentPrompt: `cd "${worktreeDir}" && gh pr checks --watch --interval 60
+Then run: node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-ci/ci-next.js ${tk}
 
-Then run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-ci/ci-next.js ${tk}\` to advance through phases (inputs → wait → triage → fix_or_document → rerun_check → memorize → done). The runner classifies failures and gates on triage + fix evidence — do NOT edit \`ci-phase.json\` directly.
-
-Return PASS if all checks pass, FAIL with details if any fail.`,
+Follow the instructions ci-next.js prints for the current phase. Re-invoke it as those instructions say. Do NOT edit ci-phase.json.`,
   });
 };

--- a/scripts/workflows/work/work-next.js
+++ b/scripts/workflows/work/work-next.js
@@ -507,17 +507,21 @@ function getNextInstruction(ticketRaw, rework) {
     };
   }
 
-  // PR-merged short-circuit (GH-398 Task 8) — if the ticket's PR has been
-  // merged on the remote, advance to `complete` even when the local state
-  // is still mid-flight. Mirrors `engine/unstick-complete.js` semantics:
-  // mark status='completed', all stepStatus → 'completed', then return the
-  // standard terminal-short-circuit payload.
-  //
-  // Fail-open: any error from `gh` (non-zero exit, auth missing, network
-  // failure, malformed JSON, missing binary) is swallowed — the workflow
-  // falls through to its existing behavior. NEVER blocks on `gh` errors.
+  // Short-circuit to `complete` when BOTH ci-phase.json is at `done` AND
+  // `gh pr view` reports MERGED. Fail-open on gh errors; fail-closed on the
+  // phase guard (missing or non-done ci-phase.json skips the short-circuit).
   if (_preCheckState && _preCheckState.status !== 'completed') {
     try {
+      const ciPhasePath = path.join(TASKS_BASE, safeName, 'ci-phase.json');
+      let ciPhase = null;
+      try {
+        ciPhase = JSON.parse(fs.readFileSync(ciPhasePath, 'utf8'));
+      } catch {
+        // missing/unreadable → short-circuit MUST NOT fire
+      }
+      if (!ciPhase || ciPhase.currentPhase !== 'done') {
+        throw new Error('ci-phase.json not at terminal phase — skipping PR-merged probe');
+      }
       const worktreeDir = path.join(WORKTREES_BASE, `${MAIN_WORKTREE_FOLDER}-${safeBase}`);
       // Skip the probe entirely when the worktree dir is missing. Falling back
       // to process.cwd() would run `gh pr view` against whatever branch happens

--- a/scripts/workflows/work/workflow-definition.js
+++ b/scripts/workflows/work/workflow-definition.js
@@ -700,15 +700,22 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
       {
         step: STEPS.ci,
         verify: () => {
-          // Single source of truth: delegates to follow-up-pr.js functions
+          // Defense-in-depth for the third-attempt bug class (ECHO-5217/5218):
+          // ci is NOT complete just because CI checks went green — the PR must
+          // actually be MERGED on the remote. Without this, transition-step.js
+          // would walk ci → cleanup → reports → complete before the user merged.
           try {
             const { getPRInfo, checkCI } = require(
               path.join(__dirname, 'scripts', 'follow-up-pr.js')
             );
             const prInfo = getPRInfo();
             if (!prInfo || !prInfo.number) return false;
-            const ci = checkCI(prInfo.number);
-            return ci.status === 'passing';
+            if (checkCI(prInfo.number).status !== 'passing') return false;
+            const { fetchPrState } = require(
+              path.join(__dirname, '..', 'work-ci', 'lib', 'phases', 'wait_merge.js')
+            );
+            const s = fetchPrState(process.cwd(), prInfo.number);
+            return Boolean(s && s.state === 'MERGED');
           } catch {
             return false;
           }


### PR DESCRIPTION
## Existing Behavior

- `workflow-definition.js` ci `verify()` returned `true` as soon as CI checks were passing — it never checked whether the PR had actually been merged, so `transition-step.js` could walk `ci → cleanup → reports → complete` while the PR was still OPEN.
- The `work-next.js` PR-merged short-circuit fired on `gh pr view` MERGED alone, without confirming `ci-phase.json` reached its terminal phase, making it a bypass route.
- `wait.js` and `wait_merge.js` phase instructions contained no explicit banner forbidding orchestrators from spawning developer agents, leaving them free to misroute (as observed in ECHO-5218).
- The ci step `agentPrompt` ended with "Return PASS if all checks pass, FAIL with details if any fail", which misled orchestrators into treating a green CI as the completion signal and skipping the merge wait.

## Intended New Behavior

- `workflow-definition.js` ci `verify()` now requires **both** CI checks passing **and** `gh pr view --json state === MERGED` before returning `true`. The workflow is fail-closed: any `gh` failure returns `false`.
- `work-next.js` short-circuit now guards on `ci-phase.json.currentPhase === 'done'` before probing `gh pr view`; missing or non-terminal phase files skip the short-circuit entirely.
- `wait.js` instructions now open with a `POLL-ONLY PHASE — do not edit files, do not spawn developer agents` banner.
- `wait_merge.js` instructions now open with a `WAITING FOR HUMAN MERGE — do not spawn ANY agent, do not edit files` banner and make clear only the human clicking Merge can advance the workflow.
- ci step `agentPrompt` is trimmed to "run ci-next.js and follow its per-phase instructions" — the misleading "Return PASS/FAIL" sentence is removed.

## Why this is bulletproof

Every layer now independently requires MERGED. A regression in any single layer is caught by the others:

| Layer | Guard added |
|---|---|
| `workflow-definition.js` ci verify | `fetchPrState().state === 'MERGED'` in addition to CI passing |
| `work-next.js` short-circuit | requires `ci-phase.json.currentPhase === 'done'` before probing `gh` |
| `work-ci/lib/phases/wait.js` | explicit POLL-ONLY banner forbidding dev-agent spawn |
| `work-ci/lib/phases/wait_merge.js` | explicit WAITING FOR HUMAN MERGE banner with no-dev rule |
| `work/steps/ci.js` agentPrompt | drops misleading "Return PASS if all checks pass" wording |

Prior attempts and why they failed:
- **Attempt 1 (7b36639b):** added `wait_merge` phase with MERGED requirement — lived in a parallel state machine the top-level `workflow-definition.js` verify never consulted.
- **Attempt 2 (1aebf0ae):** removed agent allowlist on `ci-next.js` — fixed spawn pollution but not the verify gate.
- **Attempt 3 (d0901791):** added PR-merged short-circuit in `work-next.js` — turned out to be a bypass route itself (MERGED probe fired before ci sub-workflow finished).

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Backend behavioral verification — run each suite individually:

1. Confirm `workflow-definition.js` ci verify now blocks on OPEN/CLOSED/null and passes only on MERGED:
   ```
   node --test scripts/workflows/work/__tests__/ci-verify-requires-merge.test.js
   ```
   Expected: 4 pass.

2. Confirm `work-next.js` short-circuit is blocked by missing or non-terminal `ci-phase.json`:
   ```
   node --test scripts/workflows/work/__tests__/work-next-pr-merged.test.js
   ```
   Expected: all cases pass including the 3 new phase-guard cases.

3. Confirm POLL-ONLY and WAITING FOR HUMAN MERGE banners are present in phase instructions:
   ```
   node --test scripts/workflows/work-ci/__tests__/wait-no-dev-banner.test.js
   ```
   Expected: 2 pass.

Local baseline: 4044 pass, 1 pre-existing unrelated failure (session-guard /check — also fails on clean main). `pnpm quality:changed` clean.

### Test Results

| Suite | Cases | Result |
|---|---|---|
| `ci-verify-requires-merge.test.js` | 4 (OPEN, CLOSED, null, MERGED) | all pass |
| `wait-no-dev-banner.test.js` | 2 (POLL-ONLY, HUMAN MERGE banners) | all pass |
| `work-next-pr-merged.test.js` | +3 phase-guard cases | all pass |
| Full suite | 4044 | 4044 pass, 1 pre-existing skip |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core workflow completion gates and orchestrator instructions; behavior is well covered by new tests but mistakes could stall or prematurely advance tickets.
> 
> **Overview**
> This PR adds **defense-in-depth** so the `/work` flow cannot finish the `ci` step (or jump to `complete`) until the PR is actually **merged**, not merely green on CI.
> 
> The top-level **`ci` `verify()`** in `workflow-definition.js` now requires passing CI **and** `fetchPrState().state === 'MERGED'` (fail-closed on unknown merge state). **`work-next.js`**’s PR-merged short-circuit only runs when **`ci-phase.json`** is at `currentPhase === 'done'`, so a remote MERGED probe cannot bypass a mid-flight CI sub-workflow.
> 
> **`wait`** / **`wait_merge`** phase instructions gain explicit banners (**POLL-ONLY**, **WAITING FOR HUMAN MERGE**) that forbid spawning developer agents or editing files. The **`ci`** step prompt is retitled and trimmed so orchestrators follow **`ci-next.js`** per phase instead of treating green checks as done.
> 
> New/extended **Node tests** lock these behaviors (`ci-verify-requires-merge`, `wait-no-dev-banner`, phase-guard cases in `work-next-pr-merged`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9fd645a375dc09385dc8d6110bde4cde718f8d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->