### PR TITLE
fix(release): correct bump-version ROOT path and release 3.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
-    "version": "3.2.0"
+    "version": "3.2.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Self-contained workflow plugin with agents, hooks, skills, and orchestration. Includes 18 specialized agents, agent-specific hooks, and 25 skills.",
   "author": {
     "name": "Custom",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
   "license": "MIT",
   "repository": {

--- a/scripts/workflows/lib/scripts/bump-version.js
+++ b/scripts/workflows/lib/scripts/bump-version.js
@@ -16,7 +16,8 @@
 const fs = require('fs');
 const path = require('path');
 
-const ROOT = path.join(__dirname, '..', '..', '..');
+// __dirname = scripts/workflows/lib/scripts → repo root is 4 levels up
+const ROOT = path.join(__dirname, '..', '..', '..', '..');
 
 const FILES = [
   {


### PR DESCRIPTION
## Summary

- The `bump-version.js` script computed the repo root 3 levels up from `__dirname`, landing in `scripts/` instead of the repo root — causing `ENOENT` on every run since 2026-05-23 (CI runs 26341390967, 26401541950, 26419524627).
- Adds one additional `..` so `ROOT` resolves to the actual repo root (4 levels up from `scripts/workflows/lib/scripts/`).
- Manually bumps 3.2.0 → 3.2.1 across the three version manifests (root manifest, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`) to release PR #425 ("bulletproof PR-merged gate"), which merged with a patch-bump signal but never auto-bumped due to the broken script.

## Root cause

```
// Before (wrong — 3 levels up lands in scripts/)
const ROOT = path.join(__dirname, '..', '..', '..');

// After (correct — 4 levels up reaches repo root)
// __dirname = scripts/workflows/lib/scripts → repo root is 4 levels up
const ROOT = path.join(__dirname, '..', '..', '..', '..');
```

`bump-version.js` lives at `scripts/workflows/lib/scripts/bump-version.js`. Each `..` climbs one directory:

| Hops | Resolved path |
|------|--------------|
| 3 | `scripts/` |
| 4 | repo root ✓ |

The script then tried to open `scripts/<root-manifest>`, which does not exist → `ENOENT`.

## What this PR does

1. **Fixes the path bug** — one extra `..` in the `ROOT` constant.
2. **Releases 3.2.1** — manual bump across the three version manifests to catch up the missed release from PR #425. The bump was produced by running the now-fixed script locally.

> **Reviewer note:** when this PR merges, the auto-bump workflow WILL fire (this PR title starts with `fix(release):`, not `chore(release):`), producing version 3.2.2 immediately. That is intentional — 3.2.1 catches up the missed release from PR #425, and 3.2.2 covers the bump-script fix in this PR itself.

## Test plan

1. Merge this PR.
2. Confirm the Bump Version workflow triggers and completes successfully (no `ENOENT`).
3. Confirm the three version manifests are updated to 3.2.2 in the resulting auto-commit.
4. Consumers running `/plugin update` should now receive the latest version.

To verify the path fix locally before merging:
```bash
node -e "
  const path = require('path');
  const __dirname = '/path/to/repo/scripts/workflows/lib/scripts';
  console.log(path.join(__dirname, '..', '..', '..', '..'));
  // should print repo root
"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small release-script path fix and manifest version sync; no auth, data, or runtime product logic changes.
> 
> **Overview**
> Fixes **`bump-version.js`** so `ROOT` climbs **four** directories from `scripts/workflows/lib/scripts/` (was three, which pointed at `scripts/` and caused **`ENOENT`** when reading `package.json` and the plugin manifests).
> 
> Manually sets version **3.2.0 → 3.2.1** in `package.json`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` to ship the release that auto-bump missed while the script was broken.
> 
> After merge, CI should run the bump workflow successfully again; expect a follow-up **3.2.2** from the post-merge auto-bump on this fix PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bae3572e6539ccedad3a09ea2869cf8fa37438c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->