### PR TITLE
GH-123 - fix(synapsys): walk ancestors for worktree store discovery + CI tests

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "linear-wt": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Repo-level files (`package.json`, `pnpm-lock.yaml`, `node_modules/`, `biome.json
 ## Install (Claude Code)
 
 ```
-/plugin marketplace add tigredonorte/claude-plugin-work
+/plugin marketplace add thomfilg/claude-plugin-work
 /plugin install work-workflow@latest
 /plugin install synapsys@latest
 /plugin install maestro@latest

--- a/plugins/synapsys/lib/__tests__/worktree-injection.test.js
+++ b/plugins/synapsys/lib/__tests__/worktree-injection.test.js
@@ -1,0 +1,148 @@
+// Behavioral tests for Synapsys worktree-level memory injection.
+//
+// These assert the property the user actually cares about: from a session
+// running INSIDE a worktree, a memory stored one level up in the shared
+// `<base>/.claude/synapsys` store is discovered AND injected for a matching
+// event — and is NOT injected for a non-matching one.
+//
+// Discovered by plugins/work/scripts/run-tests.sh (searches plugins/synapsys/).
+// Manual: node --test plugins/synapsys/lib/__tests__/worktree-injection.test.js
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { discoverStores, listMemoriesFromStore, parseFrontmatter } = require(
+  path.resolve(__dirname, '..', 'memory-store')
+);
+const { selectForEvent } = require(path.resolve(__dirname, '..', 'matcher'));
+
+// ─── Fixture: a worktree base with a shared store one level up ────────────────
+//
+//   <base>/.claude/synapsys/.synapsys.json   ← store marker
+//   <base>/.claude/synapsys/ci.md            ← memory
+//   <base>/worktree-echo-1/                   ← session cwd (the "worktree")
+
+let base;
+let worktreeCwd;
+let storeDir;
+
+function writeMemory(dir, file, frontmatter, body) {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  fs.writeFileSync(path.join(dir, file), `---\n${fm}\n---\n${body}`);
+}
+
+before(() => {
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-wt-'));
+  storeDir = path.join(base, '.claude', 'synapsys');
+  worktreeCwd = path.join(base, 'worktree-echo-1');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.mkdirSync(worktreeCwd, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ kind: 'worktree', projectName: 'some-other-worktree', schemaVersion: 1 })
+  );
+
+  writeMemory(
+    storeDir,
+    'ci.md',
+    {
+      name: 'never-rerun-ci',
+      description: 'never rerun CI',
+      events: 'UserPromptSubmit,PreToolUse',
+      trigger_prompt: '\\b(ci|re-?run)\\b',
+      trigger_pretool: 'Bash:gh\\s+run',
+      inject: 'full',
+    },
+    'Fix CI locally; never gh run rerun.'
+  );
+});
+
+after(() => {
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+describe('worktree store discovery', () => {
+  it('finds the shared store one level up from the worktree cwd', () => {
+    const stores = discoverStores(worktreeCwd);
+    const wt = stores.find((s) => s.kind === 'worktree');
+    assert.ok(wt, 'worktree store should be discovered');
+    assert.equal(path.resolve(wt.dir), path.resolve(storeDir));
+  });
+
+  it('discovers stores by path, NOT by the marker projectName', () => {
+    // Marker is keyed to a different worktree name; discovery must still find it.
+    const stores = discoverStores(worktreeCwd);
+    assert.ok(stores.some((s) => s.kind === 'worktree'));
+  });
+});
+
+describe('worktree-level injection', () => {
+  function matchedNames(event, payload) {
+    const memories = discoverStores(worktreeCwd).flatMap(listMemoriesFromStore);
+    return selectForEvent(memories, event, payload).map((m) => m.name);
+  }
+
+  it('injects a matching memory on UserPromptSubmit', () => {
+    assert.deepEqual(matchedNames('UserPromptSubmit', { prompt: 'please re-run ci' }), [
+      'never-rerun-ci',
+    ]);
+  });
+
+  it('injects a matching memory on PreToolUse', () => {
+    const names = matchedNames('PreToolUse', {
+      tool_name: 'Bash',
+      tool_input: { command: 'gh run rerun 123' },
+    });
+    assert.deepEqual(names, ['never-rerun-ci']);
+  });
+
+  it('does NOT inject for a non-matching prompt (control)', () => {
+    assert.deepEqual(matchedNames('UserPromptSubmit', { prompt: 'xyzzy plugh' }), []);
+  });
+});
+
+// ─── Multi-level discovery: walk up to the nearest ancestor store ─────────────
+// A session may run from a sub-directory of the worktree (e.g. packages/app),
+// which is more than one level below the shared `.claude` base. Discovery must
+// still resolve the store by walking up the tree.
+describe('multi-level discovery', () => {
+  it('finds the shared store from a deeply-nested sub-directory', () => {
+    const nested = path.join(worktreeCwd, 'packages', 'app');
+    fs.mkdirSync(nested, { recursive: true });
+    const stores = discoverStores(nested);
+    const wt = stores.find((s) => s.kind === 'worktree');
+    assert.ok(wt, 'store should be discovered from a nested sub-directory');
+    assert.equal(path.resolve(wt.dir), path.resolve(storeDir));
+  });
+
+  it('injects a matching memory from a nested sub-directory', () => {
+    const nested = path.join(worktreeCwd, 'packages', 'app');
+    fs.mkdirSync(nested, { recursive: true });
+    const memories = discoverStores(nested).flatMap(listMemoriesFromStore);
+    const names = selectForEvent(memories, 'UserPromptSubmit', { prompt: 're-run ci' }).map(
+      (m) => m.name
+    );
+    assert.deepEqual(names, ['never-rerun-ci']);
+  });
+});
+
+// ─── Regression: parser bugs that silently disable memories ───────────────────
+describe('frontmatter parser (regression guard)', () => {
+  it('parses a memory that has frontmatter but no body', () => {
+    const { meta } = parseFrontmatter('---\nname: body-less\ntrigger_prompt: \\bfoo\\b\n---');
+    assert.equal(meta.name, 'body-less');
+    assert.equal(meta.trigger_prompt, '\\bfoo\\b');
+  });
+
+  it('keeps a bracketed regex class as a string, not an array', () => {
+    const { meta } = parseFrontmatter('---\nname: re\ntrigger_prompt: [a-z]+\n---\nbody');
+    assert.equal(meta.trigger_prompt, '[a-z]+');
+    assert.equal(Array.isArray(meta.trigger_prompt), false);
+  });
+});

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -40,14 +40,52 @@ function candidateStores(cwd, projectName) {
   ];
 }
 
-function discoverStores(cwd) {
-  const projectName = getProjectName(cwd);
-  const out = [];
-  for (const c of candidateStores(cwd || process.cwd(), projectName)) {
-    if (fs.existsSync(path.join(c.dir, MARKER))) {
-      out.push({ kind: c.kind, dir: c.dir, projectName });
+// Walk up from startDir looking for the nearest ancestor that carries a
+// store marker at `<ancestor>/.claude/synapsys/.synapsys.json`. Returns the
+// store dir, or '' when none is found before the filesystem root.
+//
+// This is why worktrees nested more than one level below the shared `.claude`
+// base still resolve: the convention puts the store at the worktree base, but
+// a session may run from a sub-directory of the worktree (e.g. packages/app).
+function findAncestorStore(startDir) {
+  let dir = startDir;
+  for (;;) {
+    if (fs.existsSync(path.join(dir, '.claude', FOLDER, MARKER))) {
+      return path.join(dir, '.claude', FOLDER);
     }
+    const parent = path.dirname(dir);
+    if (parent === dir) return '';
+    dir = parent;
   }
+}
+
+function discoverStores(cwd) {
+  const resolved = cwd || process.cwd();
+  const projectName = getProjectName(resolved);
+  const out = [];
+  const seen = new Set();
+
+  const push = (kind, dir) => {
+    const key = path.resolve(dir);
+    if (seen.has(key)) return;
+    if (!fs.existsSync(path.join(dir, MARKER))) return;
+    seen.add(key);
+    out.push({ kind, dir, projectName });
+  };
+
+  // local: store inside the cwd itself.
+  push('local', path.join(resolved, '.claude', FOLDER));
+
+  // worktree: nearest ancestor above cwd carrying a store marker. Walking the
+  // tree (not just one level up) keeps discovery working from sub-directories
+  // of a worktree. The local store above already claimed cwd, so an ancestor
+  // hit here is genuinely "up the tree", never the local store.
+  const wt = findAncestorStore(path.dirname(resolved));
+  if (wt) push('worktree', wt);
+
+  // global: per-project store under home.
+  push('global', path.join(os.homedir(), '.claude', FOLDER, projectName));
+
   return out;
 }
 

--- a/plugins/work/docs/artifacts.md
+++ b/plugins/work/docs/artifacts.md
@@ -155,7 +155,7 @@ tasks/PROJ-123/
 - `screenshots/` — QA screenshots
 - `runs/` — Archived check reports
 
-See [GH-259](https://github.com/tigredonorte/claude-plugin-work/issues/259) for discussion on scoping check reports per-task.
+See [GH-259](https://github.com/thomfilg/claude-plugin-work/issues/259) for discussion on scoping check reports per-task.
 
 ## Path Security
 

--- a/plugins/work/docs/tdd-enforcement.md
+++ b/plugins/work/docs/tdd-enforcement.md
@@ -146,7 +146,7 @@ When refactoring reveals need for more behavior:
 - File moves/renames with no behavior change
 - Non-testable infrastructure changes (CI/CD, Dockerfiles)
 
-**Known gap:** Any non-empty string is accepted. See [GH-258](https://github.com/tigredonorte/claude-plugin-work/issues/258).
+**Known gap:** Any non-empty string is accepted. See [GH-258](https://github.com/thomfilg/claude-plugin-work/issues/258).
 
 ## Per-Task vs Root State
 

--- a/plugins/work/docs/workflow-work-implement.md
+++ b/plugins/work/docs/workflow-work-implement.md
@@ -135,7 +135,7 @@ For purely mechanical changes (config-only, file moves, no testable behavior), t
 - File moves/renames with no behavior change
 - Non-testable infrastructure changes
 
-**Validation:** Currently accepts any non-empty string. See [GH-258](https://github.com/tigredonorte/claude-plugin-work/issues/258) for planned hardening.
+**Validation:** Currently accepts any non-empty string. See [GH-258](https://github.com/thomfilg/claude-plugin-work/issues/258) for planned hardening.
 
 ## File Gating Hook
 

--- a/plugins/work/scripts/run-tests.sh
+++ b/plugins/work/scripts/run-tests.sh
@@ -33,7 +33,7 @@ trap 'on_signal INT' INT
 trap 'on_signal TERM' TERM
 
 # Build space-separated file list (node --test expects positional args, not newlines)
-mapfile -t FILES < <(find plugins/work/scripts/workflows plugins/work/agents plugins/work/skills -type f \( -name '*.test.js' -o -name '*.spec.js' \) | sort)
+mapfile -t FILES < <(find plugins/work/scripts/workflows plugins/work/agents plugins/work/skills plugins/synapsys -type f \( -name '*.test.js' -o -name '*.spec.js' \) | sort)
 
 if [ -f "$SKIP_FILE" ]; then
   FILTERED=()


### PR DESCRIPTION
## Existing Behavior

- `discoverStores` in `plugins/synapsys/lib/memory-store.js` resolves the worktree store by checking exactly one level above `cwd` — `path.dirname(cwd)` — so a session running from any sub-directory of a worktree (e.g. `packages/app`) silently finds no worktree store.
- The CI test runner (`plugins/work/scripts/run-tests.sh`) only globbed `plugins/work/**` — the `plugins/synapsys` directory was never scanned, so synapsys test failures were invisible in CI.
- GitHub URLs in the README and plugin docs still pointed to the old `tigredonorte` repo owner.

## Intended New Behavior

- `discoverStores` now calls `findAncestorStore`, which walks up from `path.dirname(cwd)` to the filesystem root looking for the nearest ancestor carrying a `<ancestor>/.claude/synapsys/.synapsys.json` marker. Sessions starting from any depth inside a worktree now resolve the shared store correctly.
- Discovery is purely path-based. The `projectName` field inside the marker file is NOT used for matching — removing a prior misdiagnosis that treated it as the keying mechanism.
- `run-tests.sh` adds `plugins/synapsys` to the `find` glob so synapsys tests run on every CI invocation (Node 20 & 22).
- All GitHub URLs updated from `tigredonorte/claude-plugin-work` to `thomfilg/claude-plugin-work`.
- A project-level `.mcp.json` wires the Linear MCP server for this repo.

> **Follow-up needed:** the published synapsys plugin is stamped `0.1.2`, identical to the dev manifest. A version bump is required for the marketplace cache to pick up this fix along with the two parser fixes already in dev.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Synapsys worktree injection (backend/runtime fix):**

1. Create a worktree base with a shared store marker at `<base>/.claude/synapsys/.synapsys.json`.
2. From a sub-directory two or more levels inside the worktree (e.g. `<base>/worktree-echo-1/packages/app`), require `memory-store.js` and call `discoverStores(process.cwd())`.
3. Confirm a store with `kind: 'worktree'` is returned whose `dir` resolves to `<base>/.claude/synapsys` — previously this returned no worktree store.
4. Run the test suite: `node --test plugins/synapsys/lib/__tests__/worktree-injection.test.js` — all 9 tests should pass.

**CI coverage gap (run-tests.sh):**

1. Run `./plugins/work/scripts/run-tests.sh` from the repo root.
2. Confirm the output lists files from `plugins/synapsys/lib/__tests__/` — previously no synapsys tests appeared.

### Test Results

9/9 synapsys worktree-injection tests pass. Full suite: 4053/4054 (the single failure in session-guard is pre-existing and unrelated to this branch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted discovery logic and test/CI wiring; no auth, data, or payment paths. Behavior change is limited to when shared worktree memories are found.
> 
> **Overview**
> **Synapsys** now resolves worktree memory stores by walking ancestors for `.claude/synapsys/.synapsys.json`, so sessions in nested worktree paths (e.g. `packages/app`) pick up the shared store and matching memories inject again; discovery stays path-based, not marker `projectName`. New behavioral tests cover discovery, injection, nested cwd, and frontmatter regressions.
> 
> **CI** includes `plugins/synapsys` in `run-tests.sh` so synapsys tests run with the work-workflow suite.
> 
> **Repo hygiene:** marketplace/docs GitHub links move to `thomfilg/claude-plugin-work`; root `.mcp.json` adds the Linear HTTP MCP server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16337f97761fef0085c8c4e9fefe26ab9cbb06b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->