### PR TITLE
feat(heimdall): add config-driven file/directory guard plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,6 +48,20 @@
         "workflow",
         "multi-agent"
       ]
+    },
+    {
+      "name": "heimdall",
+      "source": "./plugins/heimdall",
+      "description": "Config-driven file/directory guard — lock blocks pair protected paths with an unlock phrase; a PreToolUse hook blocks Edit/Write/Bash/Task mutations unless the phrase is spoken",
+      "category": "safety",
+      "tags": [
+        "guard",
+        "protection",
+        "hooks",
+        "pretooluse",
+        "lock",
+        "safety"
+      ]
     }
   ]
 }

--- a/plugins/heimdall/.claude-plugin/plugin.json
+++ b/plugins/heimdall/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "heimdall",
+  "version": "0.1.0",
+  "description": "Config-driven file/directory guard. Lock blocks declare protected paths + an unlock phrase; a PreToolUse hook blocks Edit/Write/Bash/Task mutations to those paths unless the user speaks the phrase. Stores are local, worktree, or global like synapsys.",
+  "author": {
+    "name": "Custom",
+    "email": "custom@local"
+  },
+  "keywords": ["guard", "protection", "hooks", "pretooluse", "lock", "safety"]
+}

--- a/plugins/heimdall/README.md
+++ b/plugins/heimdall/README.md
@@ -1,0 +1,87 @@
+# Heimdall
+
+> The watchman of the Bifröst — guards the paths you don't want touched.
+
+Heimdall is a **config-driven file/directory guard** for Claude Code. You
+declare *lock blocks* — a set of protected paths paired with an unlock phrase —
+and a `PreToolUse` hook blocks any `Edit`/`Write`/`MultiEdit`/`Bash`/`Task`
+mutation of those paths until you speak the phrase.
+
+It generalizes the hand-rolled `protect-claude-config.js` / `protect-package-json.js`
+hooks into one configurable plugin, and borrows synapsys's local/worktree/global
+store model so protection travels with the repo, the worktree base, or your home.
+
+## Concepts
+
+A **lock block** is the tuple:
+
+```jsonc
+{ "protect": [".claude", "~/.claude"], "unlockPhrase": "edit .claude" }
+```
+
+- **protect** — files and/or directories. Files match exactly; directories
+  protect everything beneath them. Paths may be relative (resolved against the
+  git root), home-anchored (`~/...`), or absolute.
+- **unlockPhrase** — say this in chat to lift the lock for that block's paths
+  for the next handful of tool calls. Speaking one phrase never unlocks another
+  block.
+
+Optional per-block keys (directories only):
+- **allowedPaths** — subdirs always writable (e.g. `plans` under `.claude`).
+- **trustedSubdirs** — subdirs whose internal scripts are exempt from
+  script-bypass detection (e.g. `hooks`).
+
+Config lives in the store marker `.heimdall.json`:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "kind": "local",
+  "projectName": "my-repo",
+  "locks": [
+    { "protect": [".claude", "~/.claude"], "unlockPhrase": "edit .claude", "allowedPaths": ["plans"] },
+    { "protect": ["package.json", "playwright.config.ts"], "unlockPhrase": "edit repository config" }
+  ]
+}
+```
+
+## Store kinds (like synapsys)
+
+| kind     | location                              | scope                          |
+|----------|---------------------------------------|--------------------------------|
+| local    | `./.claude/heimdall`                  | this directory                 |
+| worktree | nearest ancestor `../.claude/heimdall`| shared across a worktree base  |
+| global   | `~/.claude/heimdall/<project>`        | survives worktree deletion     |
+
+Locks from every active store are merged at evaluation time.
+
+## Skills
+
+- **`/heimdall:install [local|worktree|global]`** — create a store (`.heimdall.json`).
+- **`/heimdall:protect <paths> [phrase]`** — add/extend a lock block.
+- **`/heimdall:unprotect <phrase> [paths]`** — remove a block or specific paths.
+- **`/heimdall:list`** — show every store, block, phrase, and resolved file/dir.
+
+## How blocking works
+
+On each guarded tool call the hook:
+1. discovers active stores and merges their lock blocks into entries;
+2. resolves the tool's target path(s) and matches against entries
+   (file = exact, dir = prefix), with temp paths (`/tmp`) exempt;
+3. checks Bash commands for write intent (redirects, `cp`/`mv`/`sed -i`/
+   interpreters, script-bypass) and Task prompts for non-read-only references;
+4. allows the call if the block's unlock phrase appears in your recent messages,
+   otherwise exits non-zero and tells Claude to ask you via `AskUserQuestion`.
+
+Failure is **fail-open before any store exists** (installing the plugin without
+locks never bricks normal work) and **fail-closed once a store is configured and
+evaluation throws** (a configured guard errs on the side of blocking).
+
+## Quick start
+
+```
+/heimdall:install local
+/heimdall:protect .claude,~/.claude            # phrase derived: "edit .claude"
+/heimdall:protect package.json "edit repo config"
+/heimdall:list
+```

--- a/plugins/heimdall/hooks/heimdall.js
+++ b/plugins/heimdall/hooks/heimdall.js
@@ -25,6 +25,16 @@ async function readStdin() {
   return input;
 }
 
+/** Merge lock blocks from every active store at cwd; '' when none apply. */
+function collectLocks(cwd) {
+  const locks = [];
+  for (const store of discoverStores(cwd)) {
+    const cfg = readConfig(store.dir);
+    if (cfg && Array.isArray(cfg.locks)) locks.push(...cfg.locks);
+  }
+  return locks;
+}
+
 async function main() {
   const raw = await readStdin();
 
@@ -37,26 +47,14 @@ async function main() {
   }
 
   const cwd = hookData.cwd || process.cwd();
-
-  // Gather lock blocks from every active store.
-  const stores = discoverStores(cwd);
-  if (stores.length === 0) process.exit(0);
-
-  const baseDir = getRepoRoot(cwd);
-  const locks = [];
-  for (const store of stores) {
-    const cfg = readConfig(store.dir);
-    if (cfg && Array.isArray(cfg.locks)) locks.push(...cfg.locks);
-  }
+  const locks = collectLocks(cwd);
   if (locks.length === 0) process.exit(0);
-
-  const entries = buildEntries(locks, baseDir);
 
   const result = evaluate({
     toolName: hookData.tool_name || '',
     toolInput: hookData.tool_input || {},
     transcriptPath: hookData.transcript_path || hookData.transcriptPath || '',
-    entries,
+    entries: buildEntries(locks, getRepoRoot(cwd)),
   });
 
   if (result.exitCode === 2) {

--- a/plugins/heimdall/hooks/heimdall.js
+++ b/plugins/heimdall/hooks/heimdall.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Heimdall PreToolUse dispatcher.
+ *
+ * Reads the hook payload from stdin, discovers active lock stores (local /
+ * worktree / global), builds guard entries from their lock blocks, and asks
+ * the engine whether the tool call should be blocked.
+ *
+ * Fail-closed on its OWN errors only when a lock store exists — otherwise
+ * fail-open, so installing the plugin without configuring any locks never
+ * bricks normal work.
+ */
+
+const path = require('node:path');
+const { discoverStores, readConfig, getRepoRoot } = require(
+  path.join(__dirname, '..', 'lib', 'lock-store')
+);
+const { buildEntries, evaluate } = require(path.join(__dirname, '..', 'lib', 'guard'));
+
+async function readStdin() {
+  let input = '';
+  for await (const chunk of process.stdin) input += chunk;
+  return input;
+}
+
+async function main() {
+  const raw = await readStdin();
+
+  let hookData;
+  try {
+    hookData = JSON.parse(raw);
+  } catch {
+    // Can't parse payload → nothing to enforce against. Allow.
+    process.exit(0);
+  }
+
+  const cwd = hookData.cwd || process.cwd();
+
+  // Gather lock blocks from every active store.
+  const stores = discoverStores(cwd);
+  if (stores.length === 0) process.exit(0);
+
+  const baseDir = getRepoRoot(cwd);
+  const locks = [];
+  for (const store of stores) {
+    const cfg = readConfig(store.dir);
+    if (cfg && Array.isArray(cfg.locks)) locks.push(...cfg.locks);
+  }
+  if (locks.length === 0) process.exit(0);
+
+  const entries = buildEntries(locks, baseDir);
+
+  const result = evaluate({
+    toolName: hookData.tool_name || '',
+    toolInput: hookData.tool_input || {},
+    transcriptPath: hookData.transcript_path || hookData.transcriptPath || '',
+    entries,
+  });
+
+  if (result.exitCode === 2) {
+    process.stderr.write(result.message);
+    process.exit(2);
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  // A store exists (we got past the early exits) but evaluation threw.
+  // Fail closed: block and surface the error.
+  process.stderr.write(`Heimdall hook error: ${err.message}. Blocking for safety.\n`);
+  process.exit(2);
+});

--- a/plugins/heimdall/hooks/hooks.json
+++ b/plugins/heimdall/hooks/hooks.json
@@ -1,0 +1,33 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/heimdall.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/heimdall.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/heimdall.js\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -167,6 +167,11 @@ describe('evaluate: bash', () => {
     const r = run(`echo hi > ${path.join(baseDir, '.claude', 'x.json')}`, transcriptUnlocked);
     assert.equal(r.exitCode, 0);
   });
+
+  it('blocks a cp into a protected dir chained with && (no direction-sensitive bypass)', () => {
+    const r = run(`cp /tmp/evil ${path.join(baseDir, '.claude', 'config')} && echo done`);
+    assert.equal(r.exitCode, 2);
+  });
 });
 
 // ─── Task ─────────────────────────────────────────────────────────────────────

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -1,0 +1,209 @@
+// Behavioral tests for the Heimdall guard engine.
+//
+// Discovered by plugins/work/scripts/run-tests.sh (searches plugins/heimdall/).
+// Manual: node --test plugins/heimdall/lib/__tests__/guard.test.js
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { buildEntries, evaluate } = require(path.resolve(__dirname, '..', 'guard'));
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+let baseDir;
+let transcriptUnlocked;
+let transcriptEmpty;
+let transcriptOwnBlock;
+
+const LOCKS = [
+  { protect: ['.claude', '~/.claude'], unlockPhrase: 'edit .claude', allowedPaths: ['plans'] },
+  { protect: ['package.json', 'playwright.config.ts'], unlockPhrase: 'edit repository config' },
+];
+
+before(() => {
+  // NOT under os.tmpdir(): the engine exempts temp paths (scratch space), so a
+  // realistic protected baseDir must live outside any temp prefix.
+  baseDir = fs.mkdtempSync(path.join(process.cwd(), 'heimdall-it-'));
+  // A transcript whose last user message speaks the .claude unlock phrase.
+  const txDir = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-tx-'));
+  transcriptUnlocked = path.join(txDir, 'unlocked.jsonl');
+  fs.writeFileSync(
+    transcriptUnlocked,
+    JSON.stringify({ type: 'user', message: { content: 'edit .claude' } }) + '\n'
+  );
+  transcriptEmpty = path.join(txDir, 'empty.jsonl');
+  fs.writeFileSync(
+    transcriptEmpty,
+    JSON.stringify({ type: 'user', message: { content: 'hello' } }) + '\n'
+  );
+  // A transcript whose last user message is Heimdall's OWN block message echoed
+  // back as a tool_result. This must NOT self-unlock (regression for the
+  // `="<phrase>"` leak).
+  transcriptOwnBlock = path.join(txDir, 'ownblock.jsonl');
+  const ownBlock = evaluate({
+    toolName: 'Write',
+    toolInput: { file_path: path.join(baseDir, '.claude', 'x') },
+    transcriptPath: transcriptEmpty,
+    entries: buildEntries(LOCKS, baseDir),
+  }).message;
+  fs.writeFileSync(
+    transcriptOwnBlock,
+    JSON.stringify({
+      type: 'user',
+      message: { content: [{ type: 'tool_result', content: ownBlock }] },
+    }) + '\n'
+  );
+});
+
+after(() => {
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+function entries() {
+  return buildEntries(LOCKS, baseDir);
+}
+
+// ─── buildEntries ────────────────────────────────────────────────────────────
+
+describe('buildEntries', () => {
+  it('resolves relative dirs against baseDir and marks them as directories', () => {
+    const e = entries().find((x) => x.dir === path.join(baseDir, '.claude'));
+    assert.ok(e, '.claude entry exists');
+    assert.equal(e.isFile, false);
+    assert.equal(e.unlockPhrase, 'edit .claude');
+    assert.deepEqual(e.allowedPaths, ['plans']);
+  });
+
+  it('expands ~ to the home directory', () => {
+    const e = entries().find((x) => x.dir === path.join(os.homedir(), '.claude'));
+    assert.ok(e, '~/.claude entry exists and is home-expanded');
+  });
+
+  it('classifies dotted-extension paths as files', () => {
+    const pkg = entries().find((x) => x.dir === path.join(baseDir, 'package.json'));
+    assert.ok(pkg);
+    assert.equal(pkg.isFile, true);
+    assert.equal(pkg.unlockPhrase, 'edit repository config');
+  });
+});
+
+// ─── Edit / Write / MultiEdit ─────────────────────────────────────────────────
+
+describe('evaluate: file tools', () => {
+  const run = (file_path, transcriptPath = transcriptEmpty) =>
+    evaluate({ toolName: 'Write', toolInput: { file_path }, transcriptPath, entries: entries() });
+
+  it('blocks writes inside a protected directory', () => {
+    const r = run(path.join(baseDir, '.claude', 'settings.json'));
+    assert.equal(r.exitCode, 2);
+    assert.match(r.message, /protected directory/);
+    assert.match(r.message, /edit \.claude/);
+  });
+
+  it('blocks writes to a protected file (exact match)', () => {
+    const r = run(path.join(baseDir, 'package.json'));
+    assert.equal(r.exitCode, 2);
+    assert.match(r.message, /protected file/);
+  });
+
+  it('allows writes to an unrelated file', () => {
+    const r = run(path.join(baseDir, 'src', 'index.js'));
+    assert.equal(r.exitCode, 0);
+  });
+
+  it('allows writes under an allowedPaths subdir', () => {
+    const r = run(path.join(baseDir, '.claude', 'plans', 'todo.md'));
+    assert.equal(r.exitCode, 0);
+  });
+
+  it('allows the write once the unlock phrase has been spoken', () => {
+    const r = run(path.join(baseDir, '.claude', 'settings.json'), transcriptUnlocked);
+    assert.equal(r.exitCode, 0);
+  });
+
+  it("does NOT self-unlock from Heimdall's own block message in the transcript", () => {
+    const r = run(path.join(baseDir, '.claude', 'settings.json'), transcriptOwnBlock);
+    assert.equal(
+      r.exitCode,
+      2,
+      'a prior block message must not count as the user speaking the phrase'
+    );
+  });
+
+  it('does not treat package.json elsewhere in the tree as the protected file', () => {
+    const r = run(path.join(baseDir, 'packages', 'ui', 'package.json'));
+    assert.equal(r.exitCode, 0);
+  });
+});
+
+// ─── Bash ─────────────────────────────────────────────────────────────────────
+
+describe('evaluate: bash', () => {
+  const run = (command, transcriptPath = transcriptEmpty) =>
+    evaluate({ toolName: 'Bash', toolInput: { command }, transcriptPath, entries: entries() });
+
+  it('allows read-only commands referencing a protected path', () => {
+    const r = run(`cat ${path.join(baseDir, '.claude', 'settings.json')}`);
+    assert.equal(r.exitCode, 0);
+  });
+
+  it('blocks a redirect-write into a protected directory', () => {
+    const r = run(`echo hi > ${path.join(baseDir, '.claude', 'x.json')}`);
+    assert.equal(r.exitCode, 2);
+  });
+
+  it('blocks an in-place edit of a protected file by basename', () => {
+    const r = run('sed -i "s/a/b/" package.json');
+    assert.equal(r.exitCode, 2);
+    assert.match(r.message, /edit repository config/);
+  });
+
+  it('respects the unlock phrase for bash writes', () => {
+    const r = run(`echo hi > ${path.join(baseDir, '.claude', 'x.json')}`, transcriptUnlocked);
+    assert.equal(r.exitCode, 0);
+  });
+});
+
+// ─── Task ─────────────────────────────────────────────────────────────────────
+
+describe('evaluate: task', () => {
+  const run = (prompt) =>
+    evaluate({
+      toolName: 'Task',
+      toolInput: { prompt },
+      transcriptPath: transcriptEmpty,
+      entries: entries(),
+    });
+
+  it('blocks a Task prompt that asks to modify a protected path', () => {
+    const r = run(`Update the settings in ${path.join(baseDir, '.claude')}/config and save`);
+    assert.equal(r.exitCode, 2);
+  });
+
+  it('allows a read-only Task prompt referencing a protected path', () => {
+    const r = run(`Read and summarize ${path.join(baseDir, '.claude')}/settings.json`);
+    assert.equal(r.exitCode, 0);
+  });
+});
+
+// ─── No entries / unknown tools ────────────────────────────────────────────────
+
+describe('evaluate: passthrough', () => {
+  it('allows everything when there are no entries', () => {
+    const r = evaluate({
+      toolName: 'Write',
+      toolInput: { file_path: '/x' },
+      transcriptPath: '',
+      entries: [],
+    });
+    assert.equal(r.exitCode, 0);
+  });
+
+  it('ignores tools it does not guard', () => {
+    const r = evaluate({ toolName: 'Read', toolInput: {}, transcriptPath: '', entries: entries() });
+    assert.equal(r.exitCode, 0);
+  });
+});

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -172,6 +172,11 @@ describe('evaluate: bash', () => {
     const r = run(`cp /tmp/evil ${path.join(baseDir, '.claude', 'config')} && echo done`);
     assert.equal(r.exitCode, 2);
   });
+
+  it('blocks a relative-path write to a protected directory (no absolute path present)', () => {
+    const r = run("sed -i 's/a/b/' .claude/settings.json");
+    assert.equal(r.exitCode, 2);
+  });
 });
 
 // ─── Task ─────────────────────────────────────────────────────────────────────

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -17,6 +17,7 @@ let baseDir;
 let transcriptUnlocked;
 let transcriptEmpty;
 let transcriptOwnBlock;
+let transcriptEchoBypass;
 
 const LOCKS = [
   { protect: ['.claude', '~/.claude'], unlockPhrase: 'edit .claude', allowedPaths: ['plans'] },
@@ -56,6 +57,22 @@ before(() => {
     JSON.stringify({
       type: 'user',
       message: { content: [{ type: 'tool_result', content: ownBlock }] },
+    }) + '\n'
+  );
+  // Agent self-unlock attempt: the phrase appears ONLY as tool output (e.g.
+  // `echo "edit .claude"` or a forged AskUserQuestion-looking string). Must NOT
+  // unlock — tool_result content is agent-controlled.
+  transcriptEchoBypass = path.join(txDir, 'echo.jsonl');
+  fs.writeFileSync(
+    transcriptEchoBypass,
+    JSON.stringify({
+      type: 'user',
+      message: {
+        content: [
+          { type: 'tool_result', content: 'edit .claude' },
+          { type: 'tool_result', content: 'Your questions have been answered: "x"="edit .claude"' },
+        ],
+      },
     }) + '\n'
   );
 });
@@ -133,6 +150,11 @@ describe('evaluate: file tools', () => {
       2,
       'a prior block message must not count as the user speaking the phrase'
     );
+  });
+
+  it('does NOT unlock when the phrase appears only in tool output (echo self-unlock attempt)', () => {
+    const r = run(path.join(baseDir, '.claude', 'settings.json'), transcriptEchoBypass);
+    assert.equal(r.exitCode, 2, 'tool_result content is agent-controlled and must never unlock');
   });
 
   it('does not treat package.json elsewhere in the tree as the protected file', () => {

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -25,8 +25,10 @@ const LOCKS = [
 
 before(() => {
   // NOT under os.tmpdir(): the engine exempts temp paths (scratch space), so a
-  // realistic protected baseDir must live outside any temp prefix.
-  baseDir = fs.mkdtempSync(path.join(process.cwd(), 'heimdall-it-'));
+  // realistic protected baseDir must live outside any temp prefix. Use a home
+  // dir scratch path rather than the repo root, so concurrent test files in the
+  // full suite never observe stray fixture dirs under the working tree.
+  baseDir = fs.mkdtempSync(path.join(os.homedir(), '.heimdall-it-'));
   // A transcript whose last user message speaks the .claude unlock phrase.
   const txDir = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-tx-'));
   transcriptUnlocked = path.join(txDir, 'unlocked.jsonl');

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -190,6 +190,20 @@ describe('evaluate: bash', () => {
     assert.equal(r.exitCode, 0);
   });
 
+  it('blocks running an EXTERNAL script whose content writes into a protected dir', () => {
+    const evil = path.join(os.tmpdir(), `heimdall-evil-${process.pid}.js`);
+    fs.writeFileSync(
+      evil,
+      `require('fs').writeFileSync('${path.join(baseDir, '.claude', 'x')}', 'y')\n`
+    );
+    try {
+      const r = run(`node ${evil}`);
+      assert.equal(r.exitCode, 2, 'external script writing to a protected dir must be blocked');
+    } finally {
+      fs.rmSync(evil, { force: true });
+    }
+  });
+
   it('blocks a cp into a protected dir chained with && (no direction-sensitive bypass)', () => {
     const r = run(`cp /tmp/evil ${path.join(baseDir, '.claude', 'config')} && echo done`);
     assert.equal(r.exitCode, 2);

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -199,6 +199,17 @@ describe('evaluate: bash', () => {
     const r = run("sed -i 's/a/b/' .claude/settings.json");
     assert.equal(r.exitCode, 2);
   });
+
+  it('blocks when a compound command also targets a still-locked entry (.claude unlocked, package.json not)', () => {
+    // .claude is unlocked via transcript; the command also writes package.json
+    // (locked under a different phrase) — must still block on package.json.
+    const r = run(
+      `cp /tmp/x ${path.join(baseDir, '.claude', 'config')} && sed -i s/a/b/ package.json`,
+      transcriptUnlocked
+    );
+    assert.equal(r.exitCode, 2);
+    assert.match(r.message, /edit repository config/);
+  });
 });
 
 // ─── Task ─────────────────────────────────────────────────────────────────────

--- a/plugins/heimdall/lib/__tests__/lock-store.test.js
+++ b/plugins/heimdall/lib/__tests__/lock-store.test.js
@@ -1,0 +1,93 @@
+// Tests for Heimdall lock-store discovery + config IO.
+//
+// Discovered by plugins/work/scripts/run-tests.sh (searches plugins/heimdall/).
+// Manual: node --test plugins/heimdall/lib/__tests__/lock-store.test.js
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const { MARKER, FOLDER, discoverStores, readConfig, writeConfig } = require(
+  path.resolve(__dirname, '..', 'lock-store')
+);
+
+const PROTECT_SCRIPT = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-protect.js');
+const INIT_SCRIPT = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-init.js');
+
+let base;
+let local;
+
+before(() => {
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-store-'));
+  local = path.join(base, 'repo');
+  fs.mkdirSync(local, { recursive: true });
+});
+
+after(() => {
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+describe('store discovery', () => {
+  it('finds a local store once its marker exists', () => {
+    assert.equal(discoverStores(local).length, 0, 'no store before init');
+    const storeDir = path.join(local, '.claude', FOLDER);
+    writeConfig(storeDir, { kind: 'local', locks: [] });
+    assert.ok(fs.existsSync(path.join(storeDir, MARKER)));
+    const stores = discoverStores(local);
+    assert.equal(stores.length, 1);
+    assert.equal(stores[0].kind, 'local');
+  });
+});
+
+describe('init + protect scripts', () => {
+  let repo;
+
+  before(() => {
+    repo = path.join(base, 'repo2');
+    fs.mkdirSync(repo, { recursive: true });
+  });
+
+  it('init creates an empty store, protect adds a lock block', () => {
+    execFileSync('node', [INIT_SCRIPT, '--kind=local', `--cwd=${repo}`], { encoding: 'utf8' });
+    const storeDir = path.join(repo, '.claude', FOLDER);
+    assert.deepEqual(readConfig(storeDir).locks, []);
+
+    execFileSync(
+      'node',
+      [
+        PROTECT_SCRIPT,
+        '--kind=local',
+        `--cwd=${repo}`,
+        '--phrase=edit .claude',
+        '--paths=.claude,~/.claude',
+        '--allowed=plans',
+      ],
+      { encoding: 'utf8' }
+    );
+    const cfg = readConfig(storeDir);
+    assert.equal(cfg.locks.length, 1);
+    assert.equal(cfg.locks[0].unlockPhrase, 'edit .claude');
+    assert.deepEqual(cfg.locks[0].protect, ['.claude', '~/.claude']);
+    assert.deepEqual(cfg.locks[0].allowedPaths, ['plans']);
+  });
+
+  it('protect merges paths into an existing block by phrase', () => {
+    execFileSync(
+      'node',
+      [
+        PROTECT_SCRIPT,
+        '--kind=local',
+        `--cwd=${repo}`,
+        '--phrase=edit .claude',
+        '--paths=extra-dir',
+      ],
+      { encoding: 'utf8' }
+    );
+    const cfg = readConfig(path.join(repo, '.claude', FOLDER));
+    assert.equal(cfg.locks.length, 1, 'still one block — merged, not appended');
+    assert.ok(cfg.locks[0].protect.includes('extra-dir'));
+  });
+});

--- a/plugins/heimdall/lib/__tests__/lock-store.test.js
+++ b/plugins/heimdall/lib/__tests__/lock-store.test.js
@@ -1,21 +1,20 @@
-// Tests for Heimdall lock-store discovery + config IO.
+// Tests for Heimdall lock-store discovery + config IO + lock ops.
 //
 // Discovered by plugins/work/scripts/run-tests.sh (searches plugins/heimdall/).
 // Manual: node --test plugins/heimdall/lib/__tests__/lock-store.test.js
+//
+// In-process (no subprocess/git spawns) so the test adds no parallel-process
+// load to the full suite.
 
 const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { execFileSync } = require('node:child_process');
 
-const { MARKER, FOLDER, discoverStores, readConfig, writeConfig } = require(
+const { MARKER, FOLDER, discoverStores, readConfig, writeConfig, upsertLock, removeLock } = require(
   path.resolve(__dirname, '..', 'lock-store')
 );
-
-const PROTECT_SCRIPT = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-protect.js');
-const INIT_SCRIPT = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-init.js');
 
 let base;
 let local;
@@ -40,54 +39,55 @@ describe('store discovery', () => {
     assert.equal(stores.length, 1);
     assert.equal(stores[0].kind, 'local');
   });
+
+  it('writeConfig round-trips through readConfig', () => {
+    const storeDir = path.join(base, 'rt', '.claude', FOLDER);
+    writeConfig(storeDir, { kind: 'local', locks: [{ protect: ['x'], unlockPhrase: 'edit x' }] });
+    assert.deepEqual(readConfig(storeDir).locks, [{ protect: ['x'], unlockPhrase: 'edit x' }]);
+  });
 });
 
-describe('init + protect scripts', () => {
-  let repo;
-
-  before(() => {
-    repo = path.join(base, 'repo2');
-    fs.mkdirSync(repo, { recursive: true });
-  });
-
-  it('init creates an empty store, protect adds a lock block', () => {
-    execFileSync('node', [INIT_SCRIPT, '--kind=local', `--cwd=${repo}`], { encoding: 'utf8' });
-    const storeDir = path.join(repo, '.claude', FOLDER);
-    assert.deepEqual(readConfig(storeDir).locks, []);
-
-    execFileSync(
-      'node',
-      [
-        PROTECT_SCRIPT,
-        '--kind=local',
-        `--cwd=${repo}`,
-        '--phrase=edit .claude',
-        '--paths=.claude,~/.claude',
-        '--allowed=plans',
-      ],
-      { encoding: 'utf8' }
-    );
-    const cfg = readConfig(storeDir);
+describe('upsertLock', () => {
+  it('appends a new block and dedupes its paths', () => {
+    const cfg = { locks: [] };
+    upsertLock(cfg, {
+      phrase: 'edit .claude',
+      paths: ['.claude', '.claude'],
+      allowedPaths: ['plans'],
+    });
     assert.equal(cfg.locks.length, 1);
-    assert.equal(cfg.locks[0].unlockPhrase, 'edit .claude');
-    assert.deepEqual(cfg.locks[0].protect, ['.claude', '~/.claude']);
+    assert.deepEqual(cfg.locks[0].protect, ['.claude']);
     assert.deepEqual(cfg.locks[0].allowedPaths, ['plans']);
   });
 
-  it('protect merges paths into an existing block by phrase', () => {
-    execFileSync(
-      'node',
-      [
-        PROTECT_SCRIPT,
-        '--kind=local',
-        `--cwd=${repo}`,
-        '--phrase=edit .claude',
-        '--paths=extra-dir',
-      ],
-      { encoding: 'utf8' }
-    );
-    const cfg = readConfig(path.join(repo, '.claude', FOLDER));
-    assert.equal(cfg.locks.length, 1, 'still one block — merged, not appended');
-    assert.ok(cfg.locks[0].protect.includes('extra-dir'));
+  it('merges into the existing block with the same phrase', () => {
+    const cfg = { locks: [{ protect: ['.claude'], unlockPhrase: 'edit .claude' }] };
+    upsertLock(cfg, { phrase: 'edit .claude', paths: ['extra'] });
+    assert.equal(cfg.locks.length, 1, 'merged, not appended');
+    assert.deepEqual(cfg.locks[0].protect, ['.claude', 'extra']);
+  });
+});
+
+describe('removeLock', () => {
+  it('removes a whole block by phrase', () => {
+    const cfg = { locks: [{ protect: ['.github'], unlockPhrase: 'edit .github' }] };
+    assert.equal(removeLock(cfg, 'edit .github'), 'removed');
+    assert.equal(cfg.locks.length, 0);
+  });
+
+  it('trims a path and keeps the block when others remain', () => {
+    const cfg = { locks: [{ protect: ['a', 'b'], unlockPhrase: 'p' }] };
+    assert.equal(removeLock(cfg, 'p', ['a']), 'trimmed');
+    assert.deepEqual(cfg.locks[0].protect, ['b']);
+  });
+
+  it('empties (deletes) the block when its last path is removed', () => {
+    const cfg = { locks: [{ protect: ['a'], unlockPhrase: 'p' }] };
+    assert.equal(removeLock(cfg, 'p', ['a']), 'emptied');
+    assert.equal(cfg.locks.length, 0);
+  });
+
+  it('reports missing when no block matches the phrase', () => {
+    assert.equal(removeLock({ locks: [] }, 'nope'), 'missing');
   });
 });

--- a/plugins/heimdall/lib/__tests__/scan.test.js
+++ b/plugins/heimdall/lib/__tests__/scan.test.js
@@ -1,0 +1,81 @@
+// Tests for the install-time scan: catalog → existing-path suggestions.
+//
+// Discovered by plugins/work/scripts/run-tests.sh (searches plugins/heimdall/).
+// Manual: node --test plugins/heimdall/lib/__tests__/scan.test.js
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const SCAN = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-scan.js');
+const INIT = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-init.js');
+const PROTECT = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-protect.js');
+
+let repo;
+
+function scanJson(kind) {
+  const out = execFileSync('node', [SCAN, `--kind=${kind}`, `--cwd=${repo}`, '--json'], {
+    encoding: 'utf8',
+  });
+  return JSON.parse(out);
+}
+
+before(() => {
+  // Real (non-temp) repo so the guard's temp-path exemption is irrelevant and
+  // existence checks are meaningful.
+  // Under os.tmpdir() (not the dev tree) so the worktree ancestor-walk can't
+  // discover an ambient real store and dedupe suggestions away. Scan doesn't
+  // use the guard's temp-path exemption, so tmpdir is safe here.
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-scan-it-'));
+  // Real git repo so getRepoRoot() resolves to THIS dir, not the outer repo
+  // (an empty .git dir would let `git rev-parse` walk up to the real repo).
+  execFileSync('git', ['init', '-q'], { cwd: repo });
+  fs.mkdirSync(path.join(repo, '.claude'));
+  fs.mkdirSync(path.join(repo, '.github'));
+  fs.writeFileSync(path.join(repo, 'package.json'), '{}\n');
+  // NOTE: packages/ui intentionally absent.
+});
+
+after(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+describe('heimdall-scan', () => {
+  it('suggests only existing repo paths for a local install', () => {
+    const ids = scanJson('local')
+      .map((s) => s.id)
+      .sort();
+    assert.deepEqual(ids, ['claude-config', 'github-dir', 'root-package-json']);
+  });
+
+  it('does not suggest packages/ui because it does not exist', () => {
+    assert.ok(!scanJson('local').some((s) => s.id === 'packages-ui'));
+  });
+
+  it('never suggests the home-anchored ~/.claude for a local install', () => {
+    const cc = scanJson('local').find((s) => s.id === 'claude-config');
+    assert.deepEqual(cc.protect, ['.claude'], 'only the repo .claude, not ~/.claude');
+  });
+
+  it('carries allowedPaths/trustedSubdirs on the claude-config suggestion', () => {
+    const cc = scanJson('local').find((s) => s.id === 'claude-config');
+    assert.ok(cc.allowedPaths.includes('plans'));
+    assert.ok(cc.trustedSubdirs.includes('hooks'));
+  });
+
+  it('drops suggestions already covered by an existing lock', () => {
+    execFileSync('node', [INIT, '--kind=local', `--cwd=${repo}`], { encoding: 'utf8' });
+    execFileSync(
+      'node',
+      [PROTECT, '--kind=local', `--cwd=${repo}`, '--phrase=edit .github', '--paths=.github'],
+      { encoding: 'utf8' }
+    );
+    assert.ok(
+      !scanJson('local').some((s) => s.id === 'github-dir'),
+      '.github now protected → not re-suggested'
+    );
+  });
+});

--- a/plugins/heimdall/lib/__tests__/scan.test.js
+++ b/plugins/heimdall/lib/__tests__/scan.test.js
@@ -2,37 +2,31 @@
 //
 // Discovered by plugins/work/scripts/run-tests.sh (searches plugins/heimdall/).
 // Manual: node --test plugins/heimdall/lib/__tests__/scan.test.js
+//
+// In-process (require the lib, no subprocess/git spawns) so the test adds no
+// parallel-process load to the full suite.
 
 const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { execFileSync } = require('node:child_process');
 
-const SCAN = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-scan.js');
-const INIT = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-init.js');
-const PROTECT = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-protect.js');
+const { scan } = require(path.resolve(__dirname, '..', 'scan'));
+const { writeConfig, FOLDER } = require(path.resolve(__dirname, '..', 'lock-store'));
 
 let repo;
 
-function scanJson(kind) {
-  const out = execFileSync('node', [SCAN, `--kind=${kind}`, `--cwd=${repo}`, '--json'], {
-    encoding: 'utf8',
-  });
-  return JSON.parse(out);
-}
+// No git init needed: getRepoRoot() falls back to cwd when cwd is not a git
+// repo, which is exactly what we want here. Under os.tmpdir() so the worktree
+// ancestor-walk can't discover an ambient real store.
+const scanIds = (kind) =>
+  scan({ cwd: repo, kind })
+    .map((s) => s.id)
+    .sort();
 
 before(() => {
-  // Real (non-temp) repo so the guard's temp-path exemption is irrelevant and
-  // existence checks are meaningful.
-  // Under os.tmpdir() (not the dev tree) so the worktree ancestor-walk can't
-  // discover an ambient real store and dedupe suggestions away. Scan doesn't
-  // use the guard's temp-path exemption, so tmpdir is safe here.
   repo = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-scan-it-'));
-  // Real git repo so getRepoRoot() resolves to THIS dir, not the outer repo
-  // (an empty .git dir would let `git rev-parse` walk up to the real repo).
-  execFileSync('git', ['init', '-q'], { cwd: repo });
   fs.mkdirSync(path.join(repo, '.claude'));
   fs.mkdirSync(path.join(repo, '.github'));
   fs.writeFileSync(path.join(repo, 'package.json'), '{}\n');
@@ -43,39 +37,31 @@ after(() => {
   fs.rmSync(repo, { recursive: true, force: true });
 });
 
-describe('heimdall-scan', () => {
+describe('scan', () => {
   it('suggests only existing repo paths for a local install', () => {
-    const ids = scanJson('local')
-      .map((s) => s.id)
-      .sort();
-    assert.deepEqual(ids, ['claude-config', 'github-dir', 'root-package-json']);
+    assert.deepEqual(scanIds('local'), ['claude-config', 'github-dir', 'root-package-json']);
   });
 
   it('does not suggest packages/ui because it does not exist', () => {
-    assert.ok(!scanJson('local').some((s) => s.id === 'packages-ui'));
+    assert.ok(!scan({ cwd: repo, kind: 'local' }).some((s) => s.id === 'packages-ui'));
   });
 
   it('never suggests the home-anchored ~/.claude for a local install', () => {
-    const cc = scanJson('local').find((s) => s.id === 'claude-config');
+    const cc = scan({ cwd: repo, kind: 'local' }).find((s) => s.id === 'claude-config');
     assert.deepEqual(cc.protect, ['.claude'], 'only the repo .claude, not ~/.claude');
   });
 
   it('carries allowedPaths/trustedSubdirs on the claude-config suggestion', () => {
-    const cc = scanJson('local').find((s) => s.id === 'claude-config');
+    const cc = scan({ cwd: repo, kind: 'local' }).find((s) => s.id === 'claude-config');
     assert.ok(cc.allowedPaths.includes('plans'));
     assert.ok(cc.trustedSubdirs.includes('hooks'));
   });
 
   it('drops suggestions already covered by an existing lock', () => {
-    execFileSync('node', [INIT, '--kind=local', `--cwd=${repo}`], { encoding: 'utf8' });
-    execFileSync(
-      'node',
-      [PROTECT, '--kind=local', `--cwd=${repo}`, '--phrase=edit .github', '--paths=.github'],
-      { encoding: 'utf8' }
-    );
-    assert.ok(
-      !scanJson('local').some((s) => s.id === 'github-dir'),
-      '.github now protected → not re-suggested'
-    );
+    writeConfig(path.join(repo, '.claude', FOLDER), {
+      kind: 'local',
+      locks: [{ protect: ['.github'], unlockPhrase: 'edit .github' }],
+    });
+    assert.ok(!scanIds('local').includes('github-dir'), '.github now protected → not re-suggested');
   });
 });

--- a/plugins/heimdall/lib/catalog.js
+++ b/plugins/heimdall/lib/catalog.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/**
+ * Default protection catalog — mirrors the passphrase-style protectors that
+ * live in ~/.claude/hooks today, so a fresh install suggests the same things
+ * the user already guards by hand.
+ *
+ * Only phrase-unlock protectors are represented. The agent-authorization gates
+ * (protect-report-files, protect-task-folders, protect-coverage-enforcement)
+ * and the git-commit gate (protect-claude-git) don't fit Heimdall's
+ * "speak a phrase to unlock" model and are intentionally omitted.
+ *
+ * Each target has an `anchor`:
+ *   'repo' → resolved against the repo root; suggested for any store kind, but
+ *            ONLY when it actually exists in the repository.
+ *   'home' → resolved against the home dir; suggested for the `global` kind
+ *            only (a home path is not "in the repository", so local/worktree
+ *            installs never suggest it).
+ */
+
+const CATALOG = [
+  {
+    id: 'claude-config',
+    label: 'Claude config directory',
+    description: 'Hooks, settings, agents, commands (mirror of protect-claude-config.js)',
+    defaultPhrase: 'edit .claude',
+    allowedPaths: ['plans', 'dev', 'projects', 'external_scripts', 'plugins'],
+    trustedSubdirs: ['hooks', 'plugins', 'external_scripts'],
+    targets: [
+      { path: '.claude', anchor: 'repo' },
+      { path: '~/.claude', anchor: 'home' },
+    ],
+  },
+  {
+    id: 'root-package-json',
+    label: 'Root package.json',
+    description:
+      'Workspace scripts, dependencies, lockfile surface (mirror of protect-package-json.js)',
+    defaultPhrase: 'edit package.json',
+    targets: [{ path: 'package.json', anchor: 'repo' }],
+  },
+  {
+    id: 'packages-ui',
+    label: 'Shared UI package',
+    description: 'packages/ui shared component library (mirror of protect-ui-package.js)',
+    defaultPhrase: 'edit ui',
+    targets: [{ path: 'packages/ui', anchor: 'repo' }],
+  },
+  {
+    id: 'github-dir',
+    label: '.github directory',
+    description: 'CI workflows, actions, CODEOWNERS, templates (mirror of protect-github-dir.js)',
+    defaultPhrase: 'edit .github',
+    targets: [{ path: '.github', anchor: 'repo' }],
+  },
+];
+
+module.exports = { CATALOG };

--- a/plugins/heimdall/lib/cli.js
+++ b/plugins/heimdall/lib/cli.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * Shared CLI helpers for the heimdall scripts. Centralizing these keeps the
+ * per-script boilerplate (arg parsing, list splitting, store resolution) in one
+ * place instead of copy-pasted across init/protect/unprotect/list/scan.
+ */
+
+const { getProjectName, candidateStores, discoverStores } = require('./lock-store');
+
+/**
+ * Parse `--key=value` flags (and the bare `--json` switch) from argv.
+ * Defaults `cwd` to the process cwd. Values may be empty when allowEmpty.
+ */
+function parseArgs(argv, { allowEmpty = false } = {}) {
+  const out = { cwd: process.cwd() };
+  const re = allowEmpty ? /^--([a-z]+)=(.*)$/ : /^--([a-z]+)=(.+)$/;
+  for (const a of argv.slice(2)) {
+    if (a === '--json') {
+      out.json = true;
+      continue;
+    }
+    const m = a.match(re);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+/** Split a comma-separated flag value into a trimmed, non-empty list. */
+function splitList(v) {
+  return (v || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Resolve the store dirs an edit should target.
+ *   --kind=<k> → just that candidate's dir (created on demand by callers).
+ *   otherwise  → every active store discovered at cwd.
+ * Returns { dirs, error }. `error` is a message string when resolution fails.
+ */
+function resolveStoreDirs(args, { requireActive = true } = {}) {
+  if (args.kind) {
+    const target = candidateStores(args.cwd, getProjectName(args.cwd)).find(
+      (c) => c.kind === args.kind
+    );
+    if (!target)
+      return { dirs: [], error: `unknown kind: ${args.kind} (use local|worktree|global)` };
+    return { dirs: [target.dir], error: null };
+  }
+  const dirs = discoverStores(args.cwd).map((s) => s.dir);
+  if (requireActive && dirs.length === 0) {
+    return {
+      dirs: [],
+      error: 'no heimdall store found — run /heimdall:install first (or pass --kind).',
+    };
+  }
+  return { dirs, error: null };
+}
+
+/**
+ * Shared setup for the edit scripts (protect / unprotect): parse args, require
+ * a --phrase, split --paths, and resolve target store dirs. Exits the process
+ * with a message on any validation/resolution failure.
+ * @returns {{ args: object, phrase: string, paths: string[], dirs: string[] }}
+ */
+function editContext() {
+  const args = parseArgs(process.argv, { allowEmpty: true });
+  const phrase = (args.phrase || '').trim();
+  const paths = splitList(args.paths);
+  if (!phrase) {
+    console.error('missing --phrase');
+    process.exit(1);
+  }
+  const { dirs, error } = resolveStoreDirs(args);
+  if (error) {
+    console.error(error);
+    process.exit(1);
+  }
+  return { args, phrase, paths, dirs };
+}
+
+module.exports = { parseArgs, splitList, resolveStoreDirs, editContext };

--- a/plugins/heimdall/lib/command-analysis.js
+++ b/plugins/heimdall/lib/command-analysis.js
@@ -1,0 +1,65 @@
+'use strict';
+
+/**
+ * Shared command analysis utilities (vendored into heimdall so the plugin is
+ * self-contained — originally from ~/.claude/hooks/lib/command-analysis.js).
+ *
+ * Detects when a Bash command executes a script that may target protected
+ * paths even when the script path itself doesn't reveal the target (e.g.
+ * `node /tmp/script.js` where the script internally writes to a locked dir).
+ */
+
+const fs = require('node:fs');
+
+/**
+ * Extract interpreter script paths from a Bash command.
+ * Matches `node /tmp/x.js`, `python3 /tmp/x.py`, `bash /tmp/x.sh`, etc.
+ * Does NOT match inline eval (`node -e`, `python -c`) — handled elsewhere.
+ */
+function extractScriptPaths(command) {
+  if (!command) return [];
+  const scripts = [];
+  const interpreterPattern =
+    /\b(?:node|python[23]?|ruby|perl|bash|sh)\s+(?:--?\w[\w-]*(?:=\S+)?\s+)*["']?([/\w._-]+\.(?:js|mjs|cjs|py|rb|pl|sh))["']?/g;
+  let match;
+  while ((match = interpreterPattern.exec(command)) !== null) {
+    const scriptPath = match[1];
+    if (!scriptPath.startsWith('-')) scripts.push(scriptPath);
+  }
+  return scripts;
+}
+
+/** Read a script and report whether it references any protected pattern. */
+function scriptReferencesProtectedPaths(scriptPath, protectedPatterns) {
+  try {
+    if (!fs.existsSync(scriptPath)) return { found: false, matches: [] };
+    const content = fs.readFileSync(scriptPath, 'utf8');
+    const matches = [];
+    for (const pattern of protectedPatterns) {
+      if (pattern instanceof RegExp) {
+        if (pattern.test(content)) matches.push(pattern.toString());
+      } else if (content.includes(pattern)) {
+        matches.push(pattern);
+      }
+    }
+    return { found: matches.length > 0, matches };
+  } catch {
+    return { found: false, matches: [] };
+  }
+}
+
+/** Main entry: does the command (or any script it runs) touch a protected path? */
+function commandAccessesProtectedPaths(command, protectedPatterns) {
+  const scripts = extractScriptPaths(command);
+  for (const scriptPath of scripts) {
+    const result = scriptReferencesProtectedPaths(scriptPath, protectedPatterns);
+    if (result.found) return { found: true, scriptPath, matches: result.matches };
+  }
+  return { found: false, scriptPath: null, matches: [] };
+}
+
+module.exports = {
+  extractScriptPaths,
+  scriptReferencesProtectedPaths,
+  commandAccessesProtectedPaths,
+};

--- a/plugins/heimdall/lib/guard.js
+++ b/plugins/heimdall/lib/guard.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Heimdall guard engine — public surface.
+ *
+ * Config-driven generalization of the original ~/.claude/hooks/protect-claude-config.js.
+ * A lock block is the tuple { protect: [<dir|file>, ...], unlockPhrase }; each
+ * protect path becomes an entry. Files match exactly; directories match by
+ * prefix. Implementation is split across ./guard/* to stay within the repo's
+ * per-file/per-function quality limits.
+ */
+
+const { expandHome, looksLikeFile, buildEntries } = require('./guard/entries');
+const { findProtectedTarget, findProtectedPathRef } = require('./guard/paths');
+const { bashTargetsProtectedTarget, isReadOnlyBashCommand } = require('./guard/bash');
+const { isReadOnlyTaskPrompt } = require('./guard/task');
+const { findUnlockedPhrases } = require('./guard/transcript');
+const { evaluate, blockMessage } = require('./guard/evaluate');
+
+module.exports = {
+  expandHome,
+  looksLikeFile,
+  buildEntries,
+  findProtectedTarget,
+  findProtectedPathRef,
+  bashTargetsProtectedTarget,
+  isReadOnlyBashCommand,
+  isReadOnlyTaskPrompt,
+  findUnlockedPhrases,
+  evaluate,
+  blockMessage,
+};

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -172,25 +172,37 @@ function markerWriteMatch(entry, marker, v) {
   return false;
 }
 
-function entryWriteMatch(entry, v) {
-  const dirPresent = v.expanded.includes(entry.dir) || v.expandedCollapsed.includes(entry.dir);
-  if (
+function markerPresent(marker, v) {
+  return (
+    v.command.includes(marker) ||
+    v.expanded.includes(marker) ||
+    v.collapsed.includes(marker) ||
+    v.expandedCollapsed.includes(marker)
+  );
+}
+
+/** Is this marker eligible to be write-matched for the entry? */
+function markerEligible(entry, marker, v, dirPresent) {
+  if (!markerPresent(marker, v)) return false;
+  if (!entry.isFile && !dirPresent) return false;
+  if (!entry.isFile && allRefsUnderAllowedPaths(v.expandedCollapsed, entry)) return false;
+  return true;
+}
+
+function absolutePathWrite(entry, v, dirPresent) {
+  return (
     dirPresent &&
     hasGenericWriteIntent(v.collapsed) &&
     !isDirectionSensitiveRead(entry._cmd, v.expanded, entry.dir) &&
     !allRefsUnderAllowedPaths(v.expandedCollapsed, entry)
-  ) {
-    return 'absolute-path';
-  }
+  );
+}
+
+function entryWriteMatch(entry, v) {
+  const dirPresent = v.expanded.includes(entry.dir) || v.expandedCollapsed.includes(entry.dir);
+  if (absolutePathWrite(entry, v, dirPresent)) return 'absolute-path';
   for (const marker of entry.markers) {
-    const present =
-      v.command.includes(marker) ||
-      v.expanded.includes(marker) ||
-      v.collapsed.includes(marker) ||
-      v.expandedCollapsed.includes(marker);
-    if (!present) continue;
-    if (!entry.isFile && !dirPresent) continue;
-    if (!entry.isFile && allRefsUnderAllowedPaths(v.expandedCollapsed, entry)) continue;
+    if (!markerEligible(entry, marker, v, dirPresent)) continue;
     if (markerWriteMatch(entry, marker, v)) return 'marker';
   }
   return null;

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -184,10 +184,18 @@ function markerPresent(marker, v) {
   );
 }
 
-/** Is this marker eligible to be write-matched for the entry? */
-function markerEligible(entry, marker, v, dirPresent) {
+/**
+ * Is this marker eligible to be write-matched for the entry?
+ *
+ * Both files and directories match on marker presence (basename / relative
+ * token), NOT on the absolute path appearing in the command. Requiring the
+ * absolute path would let relative-path writes (e.g. `sed -i .claude/x`, which
+ * is how commands usually reference repo paths) bypass directory guards.
+ * Fail-closed: an unrelated same-named dir may occasionally match, but the user
+ * can unlock — that is safer than silently missing a write.
+ */
+function markerEligible(entry, marker, v) {
   if (!markerPresent(marker, v)) return false;
-  if (!entry.isFile && !dirPresent) return false;
   if (!entry.isFile && allRefsUnderAllowedPaths(v.expandedCollapsed, entry)) return false;
   return true;
 }
@@ -205,7 +213,7 @@ function entryWriteMatch(entry, v) {
   const dirPresent = v.expanded.includes(entry.dir) || v.expandedCollapsed.includes(entry.dir);
   if (absolutePathWrite(entry, v, dirPresent)) return 'absolute-path';
   for (const marker of entry.markers) {
-    if (!markerEligible(entry, marker, v, dirPresent)) continue;
+    if (!markerEligible(entry, marker, v)) continue;
     if (markerWriteMatch(marker, v)) return 'marker';
   }
   return null;

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -1,0 +1,215 @@
+'use strict';
+
+/**
+ * Bash write-detection: does a command write to a protected target?
+ *
+ * Directory entries require the absolute dir to appear (avoids matching a
+ * same-named dir elsewhere). File entries match on basename alone (fail-closed,
+ * mirroring the original protect-package-json hook).
+ */
+
+const { expandHomePaths, allRefsUnderAllowedPaths } = require('./paths');
+
+// Generic write-op templates; `MARKER` is replaced per protected marker.
+const BASH_WRITE_TEMPLATES = [
+  />\s*["']?[^|&;]*MARKER/i,
+  /cat\s+.*>\s*["']?[^|&;]*MARKER/i,
+  /echo\s+.*>\s*["']?[^|&;]*MARKER/i,
+  /printf\s+.*>\s*["']?[^|&;]*MARKER/i,
+  /tee\s+.*MARKER/i,
+  /cp\s+.*MARKER/i,
+  /mv\s+.*MARKER/i,
+  /ln\s+.*MARKER/i,
+  /install\s+.*MARKER/i,
+  /rsync\s+.*MARKER/i,
+  /sed\s+-i.*MARKER/i,
+  /awk\s+.*>\s*["']?[^|&;]*MARKER/i,
+  /perl\s+-[a-z]*i.*MARKER/i,
+  /ruby\s+-[a-z]*i.*MARKER/i,
+  /rm\s+.*MARKER/i,
+  /rmdir\s+.*MARKER/i,
+  /unlink\s+.*MARKER/i,
+  /touch\s+.*MARKER/i,
+  /mkdir\s+.*MARKER/i,
+  /chmod\s+.*MARKER/i,
+  /chown\s+.*MARKER/i,
+  /dd\s+.*of=["']?[^|&;]*MARKER/i,
+  /truncate\s+.*MARKER/i,
+  /curl\s+.*-o\s*["']?[^|&;]*MARKER/i,
+  /curl\s+.*--output\s*["']?[^|&;]*MARKER/i,
+  /wget\s+.*-O\s*["']?[^|&;]*MARKER/i,
+  /wget\s+.*--output-document\s*["']?[^|&;]*MARKER/i,
+  /tar\s+.*-C\s*["']?[^|&;]*MARKER/i,
+  /tar\s+.*--directory\s*["']?[^|&;]*MARKER/i,
+  /unzip\s+.*-d\s*["']?[^|&;]*MARKER/i,
+  /python[23]?\s+-c\s+.*MARKER/i,
+  /MARKER.*python[23]?\s+-c/i,
+  /node\s+-e\s+.*MARKER/i,
+  /MARKER.*node\s+-e/i,
+  /perl\s+-e\s+.*MARKER/i,
+  /MARKER.*perl\s+-e/i,
+  /ruby\s+-e\s+.*MARKER/i,
+  /MARKER.*ruby\s+-e/i,
+  /cd\s+.*MARKER.*(?:&&|;|\|\||&)/i,
+  /sh\s+-c\s+.*MARKER/i,
+  /MARKER.*sh\s+-c/i,
+  /bash\s+-c\s+.*MARKER/i,
+  /MARKER.*bash\s+-c/i,
+  /eval\s+.*MARKER/i,
+  /git\s+clone\s+.*MARKER/i,
+  /git\s+checkout\s+.*MARKER/i,
+  /git\s+pull\s+.*MARKER/i,
+  /git\s+(?:apply|am|cherry-pick)\s+.*MARKER/i,
+  /find\s+.*-exec\s+.*MARKER/i,
+  /xargs\s+.*MARKER/i,
+  /MARKER.*xargs/i,
+  /patch\s+.*MARKER/i,
+  /sponge\s+.*MARKER/i,
+  /<<.*>\s*["']?[^|&;]*MARKER/i,
+];
+
+const BASH_WRITE_GLOBAL = [
+  /node\s+-e\s+.*(?:writeFileSync|appendFileSync|writeFile|createWriteStream)/i,
+  /python[23]?\s+-c\s+.*(?:open\(|write\(|\.write|write_text|write_bytes|\.unlink|\.rename|\.replace\(|\.mkdir|shutil\.\w*copy|shutil\.move|shutil\.rmtree)/i,
+];
+
+const GENERIC_WRITE_RE =
+  /(?:>{1,2}|>\||\btee\b|\bcp\b|\bmv\b|\brm\b|\brmdir\b|\btouch\b|\bmkdir\b|\bchmod\b|\bchown\b|\bln\b|\binstall\b|\brsync\b|\bdd\b|\btruncate\b|\bsed\s+-i|\bpatch\b|\bsponge\b|\bunlink\b|\bcurl\s+-o|\bcurl\s+--output|\bwget\s+-O|\bwget\s+--output|\btar\s+-C|\btar\s+--directory|\bunzip\s+-d|\bfind\s+.*-exec|\bxargs\b|\bnode\s+-e\b|\bpython[23]?\s+-c\b|\bperl\s+-e\b|\bruby\s+-e\b|\bsh\s+-c\b|\bbash\s+-c\b|\beval\b)/i;
+
+const _patternCache = new Map();
+function getPatternsForMarker(marker) {
+  if (_patternCache.has(marker)) return _patternCache.get(marker);
+  const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const patterns = BASH_WRITE_TEMPLATES.map(
+    (tmpl) => new RegExp(tmpl.source.replace(/MARKER/g, escaped), tmpl.flags)
+  );
+  _patternCache.set(marker, patterns);
+  return patterns;
+}
+
+function stripFdRedirects(command) {
+  return command
+    .replace(/\d+>&\d+/g, '')
+    .replace(/\d+>\s*\/dev\/null/g, '')
+    .replace(/\d+>>\s*\/dev\/null/g, '')
+    .replace(/(^|[^0-9])>>\s*\/dev\/null/g, '$1')
+    .replace(/1>\s*\/dev\/null/g, '')
+    .replace(/(^|[^0-9])>\s*\/dev\/null/g, '$1');
+}
+
+function hasGenericWriteIntent(command) {
+  return GENERIC_WRITE_RE.test(stripFdRedirects(command.replace(/\s*\n+\s*/g, ' ')));
+}
+
+/** For cp/mv/rsync/ln/install: is the protected path only the SOURCE (a read)? */
+function isDirectionSensitiveRead(command, expanded, marker) {
+  command = command.replace(/\s*\n+\s*/g, ' ');
+  expanded = expanded.replace(/\s*\n+\s*/g, ' ');
+  if (!/\b(?:cp|mv|rsync|ln|install)\b/i.test(command)) return false;
+  if (/\b(?:find\s+.*-exec|xargs|sh\s+-c|bash\s+-c|eval)\b/i.test(command)) return false;
+  if (/\|/.test(command) || /["']/.test(command)) return false;
+  if (/\s-t\s|--target-directory/.test(command)) return false;
+  const args = expanded.trim().split(/\s+/);
+  const lastArg = args[args.length - 1];
+  if (marker.includes('/')) {
+    if (lastArg === marker || lastArg.startsWith(marker + '/')) return false;
+  } else {
+    const esc = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    if (new RegExp(`(?:^|/)${esc}(?:/|$)`).test(lastArg)) return false;
+  }
+  return true;
+}
+
+const READ_ONLY_CMDS =
+  /^\s*(?:diff|cmp|comm|cat|head|tail|less|more|wc|stat|file|ls|grep|egrep|fgrep|rg|ag|find|md5sum|sha256sum|shasum|readlink|realpath|du|df|sort|uniq|tr|cut|jq|yq|strings|xxd|hexdump|od)\b/;
+const WRITE_TOKENS =
+  />{1,2}|>\||\btee\b|\bcp\b|\bmv\b|\brsync\b|\binstall\b|\bln\b|\brm\b|\brmdir\b|\bunlink\b|\btouch\b|\bmkdir\b|\bchmod\b|\bchown\b|\bdd\b|\btruncate\b|\bpatch\b|\bsponge\b|\bsed\s+-i|\bcurl\s+.*-o|\bwget\s+.*-O|\bnode\s+-e|\bpython[23]?\s+-c|\bperl\s+-e|\bruby\s+-e|\bsh\s+-c|\bbash\s+-c|\beval\b|\btar\s+.*-C|\bunzip\s+.*-d|\bxargs\b|\bfind\s+.*-(?:exec|execdir|ok|okdir|delete|fprint|fprintf|fls)\b/i;
+
+function isReadOnlyBashCommand(command) {
+  const cleaned = stripFdRedirects(command.replace(/\s*\n+\s*/g, ' '));
+  if (WRITE_TOKENS.test(cleaned)) return false;
+  if (/\$\(|`|<\(|>\(|<<<|<</.test(cleaned)) return false;
+  if (/;|&&|\|\|/.test(cleaned)) return false;
+  for (const stage of cleaned.split('|')) {
+    const trimmed = stage.trim();
+    if (!trimmed || !READ_ONLY_CMDS.test(trimmed)) return false;
+  }
+  return true;
+}
+
+/** All command variants (raw / expanded / collapsed) for matching. */
+function commandVariants(command) {
+  const collapsed = command.replace(/\s*\n+\s*/g, ' ');
+  return {
+    command,
+    collapsed,
+    expanded: expandHomePaths(command),
+    expandedCollapsed: expandHomePaths(collapsed),
+  };
+}
+
+function anyMatches(patterns, v) {
+  for (const p of patterns) {
+    if (
+      p.test(v.command) ||
+      p.test(v.expanded) ||
+      p.test(v.collapsed) ||
+      p.test(v.expandedCollapsed)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function markerWriteMatch(entry, marker, v) {
+  for (const pattern of getPatternsForMarker(marker)) {
+    if (anyMatches([pattern], v) && !isDirectionSensitiveRead(entry._cmd, v.expanded, marker))
+      return true;
+  }
+  if (anyMatches(BASH_WRITE_GLOBAL, v) && !isDirectionSensitiveRead(entry._cmd, v.expanded, marker))
+    return true;
+  return false;
+}
+
+function entryWriteMatch(entry, v) {
+  const dirPresent = v.expanded.includes(entry.dir) || v.expandedCollapsed.includes(entry.dir);
+  if (
+    dirPresent &&
+    hasGenericWriteIntent(v.collapsed) &&
+    !isDirectionSensitiveRead(entry._cmd, v.expanded, entry.dir) &&
+    !allRefsUnderAllowedPaths(v.expandedCollapsed, entry)
+  ) {
+    return 'absolute-path';
+  }
+  for (const marker of entry.markers) {
+    const present =
+      v.command.includes(marker) ||
+      v.expanded.includes(marker) ||
+      v.collapsed.includes(marker) ||
+      v.expandedCollapsed.includes(marker);
+    if (!present) continue;
+    if (!entry.isFile && !dirPresent) continue;
+    if (!entry.isFile && allRefsUnderAllowedPaths(v.expandedCollapsed, entry)) continue;
+    if (markerWriteMatch(entry, marker, v)) return 'marker';
+  }
+  return null;
+}
+
+/** Does the command write to a protected target? Returns { entry, matchType } or null. */
+function bashTargetsProtectedTarget(command, entries) {
+  if (!command) return null;
+  const v = commandVariants(command);
+  for (const entry of entries) {
+    entry._cmd = command;
+    const matchType = entryWriteMatch(entry, v);
+    if (matchType) return { entry, matchType };
+  }
+  return null;
+}
+
+module.exports = {
+  hasGenericWriteIntent,
+  isReadOnlyBashCommand,
+  bashTargetsProtectedTarget,
+};

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -107,7 +107,10 @@ function isDirectionSensitiveRead(command, expanded, marker) {
   expanded = expanded.replace(/\s*\n+\s*/g, ' ');
   if (!/\b(?:cp|mv|rsync|ln|install)\b/i.test(command)) return false;
   if (/\b(?:find\s+.*-exec|xargs|sh\s+-c|bash\s+-c|eval)\b/i.test(command)) return false;
-  if (/\|/.test(command) || /["']/.test(command)) return false;
+  // Any shell separator/operator (| || & && ;) means the "last arg is the
+  // destination" heuristic is unreliable — fail closed (not a pure read) so the
+  // write-detection patterns still get a chance to match the protected path.
+  if (/[|&;]/.test(command) || /["']/.test(command)) return false;
   if (/\s-t\s|--target-directory/.test(command)) return false;
   const args = expanded.trim().split(/\s+/);
   const lastArg = args[args.length - 1];

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -219,19 +219,26 @@ function entryWriteMatch(entry, v) {
   return null;
 }
 
-/** Does the command write to a protected target? Returns { entry, matchType } or null. */
-function bashTargetsProtectedTarget(command, entries) {
-  if (!command) return null;
+/** Every protected target the command writes to: [{ entry, matchType }, ...]. */
+function bashTargets(command, entries) {
+  if (!command) return [];
   const v = commandVariants(command);
+  const out = [];
   for (const entry of entries) {
     const matchType = entryWriteMatch(entry, v);
-    if (matchType) return { entry, matchType };
+    if (matchType) out.push({ entry, matchType });
   }
-  return null;
+  return out;
+}
+
+/** First protected target the command writes to, or null. */
+function bashTargetsProtectedTarget(command, entries) {
+  return bashTargets(command, entries)[0] || null;
 }
 
 module.exports = {
   hasGenericWriteIntent,
   isReadOnlyBashCommand,
+  bashTargets,
   bashTargetsProtectedTarget,
 };

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -162,12 +162,12 @@ function anyMatches(patterns, v) {
   return false;
 }
 
-function markerWriteMatch(entry, marker, v) {
+function markerWriteMatch(marker, v) {
   for (const pattern of getPatternsForMarker(marker)) {
-    if (anyMatches([pattern], v) && !isDirectionSensitiveRead(entry._cmd, v.expanded, marker))
+    if (anyMatches([pattern], v) && !isDirectionSensitiveRead(v.command, v.expanded, marker))
       return true;
   }
-  if (anyMatches(BASH_WRITE_GLOBAL, v) && !isDirectionSensitiveRead(entry._cmd, v.expanded, marker))
+  if (anyMatches(BASH_WRITE_GLOBAL, v) && !isDirectionSensitiveRead(v.command, v.expanded, marker))
     return true;
   return false;
 }
@@ -193,7 +193,7 @@ function absolutePathWrite(entry, v, dirPresent) {
   return (
     dirPresent &&
     hasGenericWriteIntent(v.collapsed) &&
-    !isDirectionSensitiveRead(entry._cmd, v.expanded, entry.dir) &&
+    !isDirectionSensitiveRead(v.command, v.expanded, entry.dir) &&
     !allRefsUnderAllowedPaths(v.expandedCollapsed, entry)
   );
 }
@@ -203,7 +203,7 @@ function entryWriteMatch(entry, v) {
   if (absolutePathWrite(entry, v, dirPresent)) return 'absolute-path';
   for (const marker of entry.markers) {
     if (!markerEligible(entry, marker, v, dirPresent)) continue;
-    if (markerWriteMatch(entry, marker, v)) return 'marker';
+    if (markerWriteMatch(marker, v)) return 'marker';
   }
   return null;
 }
@@ -213,7 +213,6 @@ function bashTargetsProtectedTarget(command, entries) {
   if (!command) return null;
   const v = commandVariants(command);
   for (const entry of entries) {
-    entry._cmd = command;
     const matchType = entryWriteMatch(entry, v);
     if (matchType) return { entry, matchType };
   }

--- a/plugins/heimdall/lib/guard/entries.js
+++ b/plugins/heimdall/lib/guard/entries.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * Build guard "entries" from lock blocks.
+ *
+ * A lock block is the tuple { protect: [<dir|file>, ...], unlockPhrase }.
+ * Each protect path becomes an entry { dir, isFile, markers, unlockPhrase,
+ * allowedPaths, trustedSubdirs }, with entries from the same block sharing the
+ * block's unlock phrase.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function expandHome(p) {
+  if (!p) return p;
+  return p
+    .replace(/^~(?=\/|$)/, os.homedir())
+    .replace(/^\$HOME(?=\/|$)/, os.homedir())
+    .replace(/^\$\{HOME\}(?=\/|$)/, os.homedir());
+}
+
+/**
+ * Decide whether a path denotes a file or directory. Prefer the real
+ * filesystem; otherwise infer: a basename with a char before a dotted
+ * extension (package.json) is a file; dotfiles (.claude) and extensionless
+ * names are directories.
+ */
+function looksLikeFile(absPath) {
+  try {
+    return fs.statSync(absPath).isFile();
+  } catch {
+    return /[^.].*\.[A-Za-z0-9]+$/.test(path.basename(absPath));
+  }
+}
+
+function markersFor(raw, absPath) {
+  const markers = new Set([path.basename(absPath)]);
+  if (raw.includes('/')) {
+    markers.add(raw.replace(/^~\/?/, '').replace(/^\$\{?HOME\}?\/?/, ''));
+  }
+  return [...markers].filter(Boolean);
+}
+
+function buildEntry(raw, lock, baseDir) {
+  const expanded = expandHome(raw.trim());
+  const abs = path.isAbsolute(expanded)
+    ? path.normalize(expanded)
+    : path.resolve(baseDir, expanded);
+  return {
+    dir: abs,
+    isFile: looksLikeFile(abs),
+    markers: markersFor(raw, abs),
+    unlockPhrase: String(lock.unlockPhrase || '').trim(),
+    allowedPaths: Array.isArray(lock.allowedPaths) ? lock.allowedPaths : null,
+    trustedSubdirs: Array.isArray(lock.trustedSubdirs) ? lock.trustedSubdirs : [],
+  };
+}
+
+/** Build engine entries from lock blocks, resolving relative paths to baseDir. */
+function buildEntries(locks, baseDir) {
+  const entries = [];
+  if (!Array.isArray(locks)) return entries;
+  for (const lock of locks) {
+    if (!lock || typeof lock !== 'object') continue;
+    const protect = Array.isArray(lock.protect) ? lock.protect : [];
+    for (const raw of protect) {
+      if (raw && typeof raw === 'string') entries.push(buildEntry(raw, lock, baseDir));
+    }
+  }
+  return entries;
+}
+
+module.exports = { expandHome, looksLikeFile, buildEntries };

--- a/plugins/heimdall/lib/guard/evaluate.js
+++ b/plugins/heimdall/lib/guard/evaluate.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * Orchestrates the per-tool checks and returns a verdict:
+ *   { exitCode: 0 } → allow   |   { exitCode: 2, message } → block.
+ */
+
+const os = require('node:os');
+const path = require('node:path');
+const { findProtectedPathRef, findProtectedTarget, resolvePathSafe } = require('./paths');
+const {
+  hasGenericWriteIntent,
+  isReadOnlyBashCommand,
+  bashTargetsProtectedTarget,
+} = require('./bash');
+const { isReadOnlyTaskPrompt } = require('./task');
+const { findUnlockedPhrases, isEntryUnlocked } = require('./transcript');
+const { checkScriptBypass } = require('./scripts-bypass');
+
+const ALLOW = { exitCode: 0, message: '' };
+
+function blockMessage(reason, entry, matchContext) {
+  // NOTE: deliberately avoid the `label="<phrase>"` token here. This message is
+  // emitted on stderr and echoed back into the transcript as a tool_result; if it
+  // contained `="<phrase>"` it would match the AskUserQuestion-answer heuristic in
+  // findUnlockedPhrases and self-unlock the lock on the next tool call.
+  let msg = `BLOCKED (heimdall): ${reason}\n`;
+  if (entry) {
+    const label = entry.unlockPhrase || `edit ${path.basename(entry.dir)}`;
+    msg += `\nACTION REQUIRED: Call the AskUserQuestion tool with EXACTLY these two options:\n`;
+    msg += `  Option 1 label -> ${label}  (Allow writing to ${path.basename(entry.dir)})\n`;
+    msg += `  Option 2 label -> Skip  (Skip this operation)\n`;
+    msg += `\nDo NOT ask in plain text. Do NOT try alternative approaches. Call AskUserQuestion NOW.\n`;
+  }
+  if (matchContext) msg += `MATCH: ${matchContext}\n`;
+  return msg;
+}
+
+function block(reason, entry, ctx) {
+  return { exitCode: 2, message: blockMessage(reason, entry, ctx) };
+}
+
+function isInAllowedSubdir(entry, normalizedPath) {
+  if (entry.isFile || !entry.allowedPaths) return false;
+  const relPath = path.relative(entry.dir, normalizedPath);
+  if (relPath.startsWith('..') || path.isAbsolute(relPath)) return false;
+  return entry.allowedPaths.includes(relPath.split(path.sep)[0]);
+}
+
+function evaluateFileTool(toolInput, entries, unlocked) {
+  const filePath = toolInput.file_path || toolInput.filePath || '';
+  if (!filePath) return ALLOW;
+  const normalizedPath = resolvePathSafe(filePath);
+  const entry = findProtectedTarget(normalizedPath, entries);
+  if (!entry) return ALLOW;
+  if (isInAllowedSubdir(entry, normalizedPath)) return ALLOW;
+  if (isEntryUnlocked(entry, unlocked)) return ALLOW;
+  const shown = normalizedPath.replace(os.homedir(), '~');
+  const kind = entry.isFile ? 'a protected file' : 'in a protected directory';
+  return block(`${shown} is ${kind}`, entry, 'file-tool ' + path.basename(entry.dir));
+}
+
+function evaluateTask(toolInput, entries, unlocked) {
+  const combined = JSON.stringify(toolInput).slice(0, 20000);
+  const entry = findProtectedPathRef(combined, entries);
+  if (!entry) return ALLOW;
+  if (isEntryUnlocked(entry, unlocked)) return ALLOW;
+  if (isReadOnlyTaskPrompt(combined)) return ALLOW;
+  return block(
+    `Task prompt references protected path (${path.basename(entry.dir)})`,
+    entry,
+    'task-prompt ' + path.basename(entry.dir)
+  );
+}
+
+function evaluateBashScripts(command, entries, unlocked) {
+  const collapsedCmd = command.replace(/\s*\n+\s*/g, ' ');
+  for (const entry of entries) {
+    if (entry.isFile) continue;
+    const res = checkScriptBypass(collapsedCmd, entry, entries);
+    if (!res.blocked) continue;
+    if (res.error) return { exitCode: 2, message: `BLOCKED: ${res.error}. Blocking for safety.\n` };
+    if (isEntryUnlocked(entry, unlocked)) return ALLOW;
+    return block(
+      `Script "${res.scriptPath}" writes to protected path (${path.basename(entry.dir)})`,
+      entry,
+      'script-write ' + path.basename(entry.dir)
+    );
+  }
+  return ALLOW;
+}
+
+function evaluateBash(toolInput, entries, unlocked) {
+  const command = toolInput.command || '';
+  if (isReadOnlyBashCommand(command)) return ALLOW;
+
+  const bashResult = bashTargetsProtectedTarget(command, entries);
+  if (bashResult) {
+    if (isEntryUnlocked(bashResult.entry, unlocked)) return ALLOW;
+    const ctx =
+      (bashResult.matchType === 'absolute-path' ? 'bash-absolute-path-write ' : 'bash-write ') +
+      path.basename(bashResult.entry.dir);
+    return block('Bash command targets protected path', bashResult.entry, ctx);
+  }
+
+  return evaluateBashScripts(command, entries, unlocked);
+}
+
+const HANDLERS = {
+  Edit: evaluateFileTool,
+  Write: evaluateFileTool,
+  MultiEdit: evaluateFileTool,
+  Task: evaluateTask,
+  Bash: evaluateBash,
+};
+
+/** Evaluate one tool call against entries. */
+function evaluate({ toolName, toolInput, transcriptPath, entries }) {
+  if (!entries || entries.length === 0) return ALLOW;
+  const handler = HANDLERS[toolName];
+  if (!handler) return ALLOW;
+  const unlocked = findUnlockedPhrases(transcriptPath, entries);
+  return handler(toolInput || {}, entries, unlocked);
+}
+
+module.exports = { evaluate, blockMessage, ALLOW };

--- a/plugins/heimdall/lib/guard/evaluate.js
+++ b/plugins/heimdall/lib/guard/evaluate.js
@@ -8,11 +8,7 @@
 const os = require('node:os');
 const path = require('node:path');
 const { findProtectedPathRef, findProtectedTarget, resolvePathSafe } = require('./paths');
-const {
-  hasGenericWriteIntent,
-  isReadOnlyBashCommand,
-  bashTargetsProtectedTarget,
-} = require('./bash');
+const { isReadOnlyBashCommand, bashTargetsProtectedTarget } = require('./bash');
 const { isReadOnlyTaskPrompt } = require('./task');
 const { findUnlockedPhrases, isEntryUnlocked } = require('./transcript');
 const { checkScriptBypass } = require('./scripts-bypass');

--- a/plugins/heimdall/lib/guard/evaluate.js
+++ b/plugins/heimdall/lib/guard/evaluate.js
@@ -13,7 +13,9 @@ const { isReadOnlyTaskPrompt } = require('./task');
 const { findUnlockedPhrases, isEntryUnlocked } = require('./transcript');
 const { checkScriptBypass } = require('./scripts-bypass');
 
-const ALLOW = { exitCode: 0, message: '' };
+// Frozen: returned by reference from every allow-path and exported, so freezing
+// prevents a consumer from silently corrupting all future evaluations.
+const ALLOW = Object.freeze({ exitCode: 0, message: '' });
 
 function blockMessage(reason, entry, matchContext) {
   // Only the USER typing the phrase unlocks (see transcript.js): tool output —

--- a/plugins/heimdall/lib/guard/evaluate.js
+++ b/plugins/heimdall/lib/guard/evaluate.js
@@ -7,8 +7,8 @@
 
 const os = require('node:os');
 const path = require('node:path');
-const { findProtectedPathRef, findProtectedTarget, resolvePathSafe } = require('./paths');
-const { isReadOnlyBashCommand, bashTargetsProtectedTarget } = require('./bash');
+const { findProtectedPathRefs, findProtectedTarget, resolvePathSafe } = require('./paths');
+const { isReadOnlyBashCommand, bashTargets } = require('./bash');
 const { isReadOnlyTaskPrompt } = require('./task');
 const { findUnlockedPhrases, isEntryUnlocked } = require('./transcript');
 const { checkScriptBypass } = require('./scripts-bypass');
@@ -57,15 +57,20 @@ function evaluateFileTool(toolInput, entries, unlocked) {
 
 function evaluateTask(toolInput, entries, unlocked) {
   const combined = JSON.stringify(toolInput).slice(0, 20000);
-  const entry = findProtectedPathRef(combined, entries);
-  if (!entry) return ALLOW;
-  if (isEntryUnlocked(entry, unlocked)) return ALLOW;
-  if (isReadOnlyTaskPrompt(combined)) return ALLOW;
-  return block(
-    `Task prompt references protected path (${path.basename(entry.dir)})`,
-    entry,
-    'task-prompt ' + path.basename(entry.dir)
-  );
+  const refs = findProtectedPathRefs(combined, entries);
+  if (refs.length === 0 || isReadOnlyTaskPrompt(combined)) return ALLOW;
+  // Block on the first referenced entry that is still locked — an unlocked
+  // entry must not green-light a prompt that also touches other locked ones.
+  for (const entry of refs) {
+    if (!isEntryUnlocked(entry, unlocked)) {
+      return block(
+        `Task prompt references protected path (${path.basename(entry.dir)})`,
+        entry,
+        'task-prompt ' + path.basename(entry.dir)
+      );
+    }
+  }
+  return ALLOW;
 }
 
 function evaluateBashScripts(command, entries, unlocked) {
@@ -89,13 +94,14 @@ function evaluateBash(toolInput, entries, unlocked) {
   const command = toolInput.command || '';
   if (isReadOnlyBashCommand(command)) return ALLOW;
 
-  const bashResult = bashTargetsProtectedTarget(command, entries);
-  if (bashResult) {
-    if (isEntryUnlocked(bashResult.entry, unlocked)) return ALLOW;
+  // Block on the first targeted entry still locked — a compound command may
+  // write to several protected paths; one unlocked entry must not allow the rest.
+  for (const { entry, matchType } of bashTargets(command, entries)) {
+    if (isEntryUnlocked(entry, unlocked)) continue;
     const ctx =
-      (bashResult.matchType === 'absolute-path' ? 'bash-absolute-path-write ' : 'bash-write ') +
-      path.basename(bashResult.entry.dir);
-    return block('Bash command targets protected path', bashResult.entry, ctx);
+      (matchType === 'absolute-path' ? 'bash-absolute-path-write ' : 'bash-write ') +
+      path.basename(entry.dir);
+    return block('Bash command targets protected path', entry, ctx);
   }
 
   return evaluateBashScripts(command, entries, unlocked);

--- a/plugins/heimdall/lib/guard/evaluate.js
+++ b/plugins/heimdall/lib/guard/evaluate.js
@@ -16,17 +16,16 @@ const { checkScriptBypass } = require('./scripts-bypass');
 const ALLOW = { exitCode: 0, message: '' };
 
 function blockMessage(reason, entry, matchContext) {
-  // NOTE: deliberately avoid the `label="<phrase>"` token here. This message is
-  // emitted on stderr and echoed back into the transcript as a tool_result; if it
-  // contained `="<phrase>"` it would match the AskUserQuestion-answer heuristic in
-  // findUnlockedPhrases and self-unlock the lock on the next tool call.
+  // Only the USER typing the phrase unlocks (see transcript.js): tool output —
+  // including this very message echoed back as a tool_result — is never trusted,
+  // so an agent cannot self-unlock by emitting the phrase.
   let msg = `BLOCKED (heimdall): ${reason}\n`;
   if (entry) {
-    const label = entry.unlockPhrase || `edit ${path.basename(entry.dir)}`;
-    msg += `\nACTION REQUIRED: Call the AskUserQuestion tool with EXACTLY these two options:\n`;
-    msg += `  Option 1 label -> ${label}  (Allow writing to ${path.basename(entry.dir)})\n`;
-    msg += `  Option 2 label -> Skip  (Skip this operation)\n`;
-    msg += `\nDo NOT ask in plain text. Do NOT try alternative approaches. Call AskUserQuestion NOW.\n`;
+    const phrase = entry.unlockPhrase || `edit ${path.basename(entry.dir)}`;
+    msg += `\nACTION REQUIRED: Stop and ask the user to UNLOCK this path. Tell them to reply with the\n`;
+    msg += `exact phrase (they must type it themselves — only a user message unlocks it):\n`;
+    msg += `  ${phrase}\n`;
+    msg += `Then retry. Do NOT try alternative approaches or attempt to emit the phrase yourself.\n`;
   }
   if (matchContext) msg += `MATCH: ${matchContext}\n`;
   return msg;

--- a/plugins/heimdall/lib/guard/evaluate.js
+++ b/plugins/heimdall/lib/guard/evaluate.js
@@ -82,7 +82,9 @@ function evaluateBashScripts(command, entries, unlocked) {
     const res = checkScriptBypass(collapsedCmd, entry, entries);
     if (!res.blocked) continue;
     if (res.error) return { exitCode: 2, message: `BLOCKED: ${res.error}. Blocking for safety.\n` };
-    if (isEntryUnlocked(entry, unlocked)) return ALLOW;
+    // Unlocked → skip this entry but keep checking; a later locked entry the
+    // same script writes to must still be caught (one unlock must not allow all).
+    if (isEntryUnlocked(entry, unlocked)) continue;
     return block(
       `Script "${res.scriptPath}" writes to protected path (${path.basename(entry.dir)})`,
       entry,

--- a/plugins/heimdall/lib/guard/paths.js
+++ b/plugins/heimdall/lib/guard/paths.js
@@ -1,0 +1,143 @@
+'use strict';
+
+/**
+ * Path helpers shared across the guard engine: temp-path detection, home
+ * expansion, and matching resolved paths against config-built entries.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const TEMP_PREFIXES = (() => {
+  const raw = new Set([os.tmpdir(), '/tmp', '/var/tmp']);
+  const resolved = new Set();
+  for (const p of raw) {
+    resolved.add(p);
+    try {
+      resolved.add(fs.realpathSync(p));
+    } catch {
+      /* ignore */
+    }
+  }
+  return [...resolved];
+})();
+
+function isTempPath(filePath) {
+  const normalized = path.resolve(filePath);
+  for (const prefix of TEMP_PREFIXES) {
+    if (normalized === prefix || normalized.startsWith(prefix + path.sep)) return true;
+  }
+  return false;
+}
+
+function expandHomePaths(text) {
+  return text
+    .replace(/~/g, os.homedir())
+    .replace(/\$HOME/g, os.homedir())
+    .replace(/\$\{HOME\}/g, os.homedir());
+}
+
+function isPathBoundary(c) {
+  return ' \t\n\r"\'`,;()[]{}|<>'.includes(c);
+}
+
+/** Extract the path-like substring surrounding index `idx` in `text`. */
+function pathSegmentAt(text, idx, markerLen) {
+  let start = idx;
+  while (start > 0 && !isPathBoundary(text[start - 1])) start--;
+  let end = idx + markerLen;
+  while (end < text.length && !isPathBoundary(text[end])) end++;
+  return text.substring(start, end);
+}
+
+/** True only when every occurrence of marker sits inside a temp path. */
+function markerOnlyInTempPaths(text, marker) {
+  let idx = 0;
+  let found = false;
+  while ((idx = text.indexOf(marker, idx)) !== -1) {
+    found = true;
+    const segment = pathSegmentAt(text, idx, marker.length);
+    if (segment.startsWith('/') && isTempPath(path.resolve(segment))) {
+      idx += marker.length;
+      continue;
+    }
+    return false;
+  }
+  return found;
+}
+
+/** First entry referenced by free text (used for Task prompts), or null. */
+function findProtectedPathRef(text, entries) {
+  const expanded = expandHomePaths(text);
+  for (const entry of entries) {
+    if (expanded.includes(entry.dir)) return entry;
+    for (const marker of entry.markers) {
+      if (expanded.includes(marker) && !markerOnlyInTempPaths(expanded, marker)) return entry;
+    }
+  }
+  return null;
+}
+
+/** Match a resolved absolute path against entries: file=exact, dir=prefix. */
+function findProtectedTarget(normalizedPath, entries) {
+  if (isTempPath(normalizedPath)) return null;
+  for (const entry of entries) {
+    if (entry.isFile) {
+      if (normalizedPath === entry.dir) return entry;
+    } else if (normalizedPath === entry.dir || normalizedPath.startsWith(entry.dir + path.sep)) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+/** Resolve a path through symlinks, tolerating non-existent leaf files. */
+function resolvePathSafe(filePath) {
+  try {
+    const resolved = path.resolve(filePath);
+    try {
+      return fs.realpathSync(resolved);
+    } catch {
+      const dir = path.dirname(resolved);
+      try {
+        return path.join(fs.realpathSync(dir), path.basename(resolved));
+      } catch {
+        return resolved;
+      }
+    }
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+/** True only when every reference to entry.dir is under an allowed subdir. */
+function allRefsUnderAllowedPaths(text, entry) {
+  const exemptDirs = entry.allowedPaths;
+  if (!exemptDirs || exemptDirs.length === 0) return false;
+  const dir = entry.dir;
+  let idx = 0;
+  let found = false;
+  while ((idx = text.indexOf(dir, idx)) !== -1) {
+    found = true;
+    let end = idx + dir.length;
+    while (end < text.length && !isPathBoundary(text[end])) end++;
+    const fullPath = text.substring(idx, end);
+    if (fullPath.length <= dir.length || fullPath[dir.length] !== '/') return false;
+    const firstSegment = fullPath.substring(dir.length + 1).split('/')[0];
+    if (!firstSegment || !exemptDirs.includes(firstSegment)) return false;
+    idx = end;
+  }
+  return found;
+}
+
+module.exports = {
+  isTempPath,
+  expandHomePaths,
+  isPathBoundary,
+  markerOnlyInTempPaths,
+  findProtectedPathRef,
+  findProtectedTarget,
+  resolvePathSafe,
+  allRefsUnderAllowedPaths,
+};

--- a/plugins/heimdall/lib/guard/paths.js
+++ b/plugins/heimdall/lib/guard/paths.js
@@ -67,16 +67,24 @@ function markerOnlyInTempPaths(text, marker) {
   return found;
 }
 
+function textReferencesEntry(expanded, entry) {
+  if (expanded.includes(entry.dir)) return true;
+  for (const marker of entry.markers) {
+    if (expanded.includes(marker) && !markerOnlyInTempPaths(expanded, marker)) return true;
+  }
+  return false;
+}
+
 /** First entry referenced by free text (used for Task prompts), or null. */
 function findProtectedPathRef(text, entries) {
   const expanded = expandHomePaths(text);
-  for (const entry of entries) {
-    if (expanded.includes(entry.dir)) return entry;
-    for (const marker of entry.markers) {
-      if (expanded.includes(marker) && !markerOnlyInTempPaths(expanded, marker)) return entry;
-    }
-  }
-  return null;
+  return entries.find((entry) => textReferencesEntry(expanded, entry)) || null;
+}
+
+/** All entries referenced by free text. */
+function findProtectedPathRefs(text, entries) {
+  const expanded = expandHomePaths(text);
+  return entries.filter((entry) => textReferencesEntry(expanded, entry));
 }
 
 /** Match a resolved absolute path against entries: file=exact, dir=prefix. */
@@ -137,6 +145,7 @@ module.exports = {
   isPathBoundary,
   markerOnlyInTempPaths,
   findProtectedPathRef,
+  findProtectedPathRefs,
   findProtectedTarget,
   resolvePathSafe,
   allRefsUnderAllowedPaths,

--- a/plugins/heimdall/lib/guard/scripts-bypass.js
+++ b/plugins/heimdall/lib/guard/scripts-bypass.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/**
+ * Script-bypass detection: a Bash command that runs a script which itself
+ * writes to a protected directory. Only meaningful for directory entries.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { commandAccessesProtectedPaths } = require('../command-analysis');
+const { isTempPath } = require('./paths');
+
+const WRITE_OPS_IN_SCRIPT =
+  /\b(?:writeFileSync|appendFileSync|writeFile|createWriteStream|unlink|unlinkSync|rmSync|renameSync|rename|rmdir|rmdirSync|copyFileSync|exec|execSync|fs\.promises\.writeFile|fs\.promises\.rm|fs\.promises\.rename|fs\.writeFile|fs\.appendFile)\b/;
+
+function isUnderProtectedDir(scriptPath, entry) {
+  try {
+    const resolved = path.resolve(scriptPath);
+    const real = fs.existsSync(resolved) ? fs.realpathSync(resolved) : resolved;
+    return real === entry.dir || real.startsWith(entry.dir + path.sep);
+  } catch {
+    return true;
+  }
+}
+
+function isTrustedScript(scriptPath, entries) {
+  for (const entry of entries) {
+    for (const subdir of entry.trustedSubdirs || []) {
+      if (scriptPath.includes(path.join(entry.dir, subdir) + '/')) return true;
+    }
+  }
+  return false;
+}
+
+function scriptPatternsFor(entry) {
+  const patterns = [];
+  for (const marker of entry.markers) {
+    const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    patterns.push(new RegExp(`\\/${escaped}\\/`, 'i'));
+    patterns.push(new RegExp(`${escaped}\\/`, 'i'));
+  }
+  return patterns;
+}
+
+function scriptHasWriteOps(content) {
+  return (
+    WRITE_OPS_IN_SCRIPT.test(content) ||
+    />{1,2}\s*['"]/.test(content) ||
+    />\|\s*['"]/.test(content) ||
+    /\btee\s+-a\b/.test(content) ||
+    /open\(.*['"]w/.test(content)
+  );
+}
+
+/**
+ * Inspect a command for script-driven writes to a protected dir entry.
+ * @returns {{ blocked: true, error?: string } | { blocked: false }}
+ */
+function checkScriptBypass(collapsedCmd, entry, entries) {
+  const found = commandAccessesProtectedPaths(collapsedCmd, scriptPatternsFor(entry));
+  if (
+    !found.found ||
+    isTrustedScript(found.scriptPath, entries) ||
+    isTempPath(found.scriptPath) ||
+    !isUnderProtectedDir(found.scriptPath, entry)
+  ) {
+    return { blocked: false };
+  }
+  let content;
+  try {
+    content = fs.readFileSync(found.scriptPath, 'utf8');
+  } catch (err) {
+    return { blocked: true, error: `Cannot read script "${found.scriptPath}": ${err.message}` };
+  }
+  return scriptHasWriteOps(content)
+    ? { blocked: true, scriptPath: found.scriptPath }
+    : { blocked: false };
+}
+
+module.exports = { checkScriptBypass };

--- a/plugins/heimdall/lib/guard/scripts-bypass.js
+++ b/plugins/heimdall/lib/guard/scripts-bypass.js
@@ -8,20 +8,9 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { commandAccessesProtectedPaths } = require('../command-analysis');
-const { isTempPath } = require('./paths');
 
 const WRITE_OPS_IN_SCRIPT =
   /\b(?:writeFileSync|appendFileSync|writeFile|createWriteStream|unlink|unlinkSync|rmSync|renameSync|rename|rmdir|rmdirSync|copyFileSync|exec|execSync|fs\.promises\.writeFile|fs\.promises\.rm|fs\.promises\.rename|fs\.writeFile|fs\.appendFile)\b/;
-
-function isUnderProtectedDir(scriptPath, entry) {
-  try {
-    const resolved = path.resolve(scriptPath);
-    const real = fs.existsSync(resolved) ? fs.realpathSync(resolved) : resolved;
-    return real === entry.dir || real.startsWith(entry.dir + path.sep);
-  } catch {
-    return true;
-  }
-}
 
 function isTrustedScript(scriptPath, entries) {
   for (const entry of entries) {
@@ -54,16 +43,18 @@ function scriptHasWriteOps(content) {
 
 /**
  * Inspect a command for script-driven writes to a protected dir entry.
+ *
+ * Fires for ANY non-trusted script the command runs whose content references
+ * the protected path AND performs a write — regardless of where the script
+ * lives. The whole point is to catch an EXTERNAL script (e.g. `node
+ * /tmp/eviL.js` or `node scripts/deploy.js`) that writes into a protected dir,
+ * so location-based gates (under-the-dir / temp-path) are intentionally NOT
+ * applied here; only `trustedSubdirs` scripts are exempt.
  * @returns {{ blocked: true, error?: string } | { blocked: false }}
  */
 function checkScriptBypass(collapsedCmd, entry, entries) {
   const found = commandAccessesProtectedPaths(collapsedCmd, scriptPatternsFor(entry));
-  if (
-    !found.found ||
-    isTrustedScript(found.scriptPath, entries) ||
-    isTempPath(found.scriptPath) ||
-    !isUnderProtectedDir(found.scriptPath, entry)
-  ) {
+  if (!found.found || isTrustedScript(found.scriptPath, entries)) {
     return { blocked: false };
   }
   let content;

--- a/plugins/heimdall/lib/guard/task.js
+++ b/plugins/heimdall/lib/guard/task.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * Task-prompt detection (fail-closed): a Task prompt that references a
+ * protected path is blocked unless it is clearly read-only.
+ */
+
+const TASK_READONLY_PATTERNS = [
+  /\b(?:read|cat|head|tail|less|more|view|inspect|examine|list|ls|find|grep|search|check|verify|summarize|review|analyze|parse|count|show|display|print|look\s+at|open\s+and\s+read)\b/i,
+];
+
+const TASK_WRITE_SIGNALS = [
+  /\b(?:writeFileSync|appendFileSync|writeFile|createWriteStream|unlinkSync|rmSync)\b/i,
+  /\b(?:write|overwrite|replace|delete|remove|append|modify|update|change|edit|fix|patch|rewrite|create|add|insert)\b/i,
+  />\s*["']?/,
+  /\b(?:sed\s+-i|cp\s|mv\s|rm\s|touch|mkdir|chmod|ln\s|tee\s)\b/i,
+  /\b(?:echo|cat|printf)\s+.*>/i,
+];
+
+const TASK_CONJUNCTION_PATTERNS = [/\b(?:then|and then|after that|finally|next|afterward)\b/i];
+
+function isReadOnlyTaskPrompt(text) {
+  for (const pattern of TASK_WRITE_SIGNALS) if (pattern.test(text)) return false;
+  if (!TASK_READONLY_PATTERNS.some((p) => p.test(text))) return false;
+  for (const pattern of TASK_CONJUNCTION_PATTERNS) if (pattern.test(text)) return false;
+  return true;
+}
+
+module.exports = { isReadOnlyTaskPrompt };

--- a/plugins/heimdall/lib/guard/transcript.js
+++ b/plugins/heimdall/lib/guard/transcript.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * Transcript inspection: find which unlock phrases the user has spoken in
+ * their recent messages. Speaking a phrase lifts the lock for entries that
+ * share it, for a short window of subsequent tool calls.
+ */
+
+const fs = require('node:fs');
+
+function extractContentText(item) {
+  if (item.type === 'text') return item.text || '';
+  if (item.type !== 'tool_result') return '';
+  if (typeof item.content === 'string') return item.content;
+  if (!Array.isArray(item.content)) return '';
+  return item.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text)
+    .join(' ');
+}
+
+function messagesFromLine(line) {
+  const out = [];
+  try {
+    const parsed = JSON.parse(line);
+    if (parsed.type !== 'user' || !parsed.message) return out;
+    const mc = parsed.message.content;
+    if (typeof mc === 'string') {
+      out.push(mc);
+      return out;
+    }
+    if (!Array.isArray(mc)) return out;
+    for (const item of mc) {
+      const text = extractContentText(item);
+      if (text) out.push(text);
+    }
+  } catch {
+    /* skip malformed line */
+  }
+  return out;
+}
+
+function getRecentUserMessages(transcriptPath, count = 20) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) return [];
+  try {
+    const lines = fs.readFileSync(transcriptPath, 'utf8').trim().split('\n').filter(Boolean);
+    const userMessages = [];
+    for (const line of lines) userMessages.push(...messagesFromLine(line));
+    return userMessages.slice(-count);
+  } catch {
+    return [];
+  }
+}
+
+function stripSystemTags(text) {
+  return text
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '')
+    .replace(/<command-message>[\s\S]*?<\/command-message>/g, '')
+    .replace(/<command-name>[\s\S]*?<\/command-name>/g, '')
+    .replace(/<command-args>[\s\S]*?<\/command-args>/g, '')
+    .replace(/<task-notification>[\s\S]*?<\/task-notification>/g, '')
+    .trim();
+}
+
+// Heimdall's own block message is emitted on stderr and echoed back into the
+// transcript as a tool_result. Skip any message bearing this signature so the
+// hook can never unlock itself by quoting the phrase in its own output.
+const OWN_BLOCK_SIGNATURE = 'ACTION REQUIRED: Call the AskUserQuestion';
+
+/** Set of unlock phrases (lowercased) spoken in recent user messages. */
+function findUnlockedPhrases(transcriptPath, entries) {
+  const phrases = new Set(entries.map((e) => (e.unlockPhrase || '').toLowerCase()).filter(Boolean));
+  const unlocked = new Set();
+  for (const msg of getRecentUserMessages(transcriptPath, 20)) {
+    if (msg.includes(OWN_BLOCK_SIGNATURE)) continue;
+    const normalized = stripSystemTags(msg).replace(/\s+/g, ' ').toLowerCase();
+    for (const phrase of phrases) {
+      if (normalized === phrase || normalized.includes(`="${phrase}"`)) unlocked.add(phrase);
+    }
+  }
+  return unlocked;
+}
+
+function isEntryUnlocked(entry, unlockedPhrases) {
+  return unlockedPhrases.has((entry.unlockPhrase || '').toLowerCase());
+}
+
+module.exports = { getRecentUserMessages, findUnlockedPhrases, isEntryUnlocked };

--- a/plugins/heimdall/lib/guard/transcript.js
+++ b/plugins/heimdall/lib/guard/transcript.js
@@ -1,22 +1,27 @@
 'use strict';
 
 /**
- * Transcript inspection: find which unlock phrases the user has spoken in
- * their recent messages. Speaking a phrase lifts the lock for entries that
- * share it, for a short window of subsequent tool calls.
+ * Transcript inspection: find which unlock phrases the user has TYPED in their
+ * recent messages. Speaking a phrase lifts the lock for entries that share it,
+ * for a short window of subsequent tool calls.
+ *
+ * SECURITY: only genuine user-authored text is trusted — string message
+ * content and `text` content blocks. `tool_result` content is deliberately
+ * ignored: a guarded agent could otherwise self-unlock by emitting the phrase
+ * as tool output (e.g. `echo "edit .claude"`, or even a forged
+ * `"...="edit .claude""` AskUserQuestion-looking string), which lands in the
+ * transcript as a tool_result on a user-type turn. Tool output is
+ * agent-controlled and must never authorize an unlock. As a consequence,
+ * AskUserQuestion answers (also recorded as tool_results) do NOT unlock — the
+ * user must type the phrase, which the agent cannot fabricate.
  */
 
 const fs = require('node:fs');
 
-function extractContentText(item) {
-  if (item.type === 'text') return item.text || '';
-  if (item.type !== 'tool_result') return '';
-  if (typeof item.content === 'string') return item.content;
-  if (!Array.isArray(item.content)) return '';
-  return item.content
-    .filter((c) => c.type === 'text')
-    .map((c) => c.text)
-    .join(' ');
+/** Genuine user-typed text from a content item; '' for tool_result/other. */
+function userAuthoredText(item) {
+  if (item && item.type === 'text') return item.text || '';
+  return '';
 }
 
 function messagesFromLine(line) {
@@ -31,7 +36,7 @@ function messagesFromLine(line) {
     }
     if (!Array.isArray(mc)) return out;
     for (const item of mc) {
-      const text = extractContentText(item);
+      const text = userAuthoredText(item);
       if (text) out.push(text);
     }
   } catch {
@@ -62,23 +67,28 @@ function stripSystemTags(text) {
     .trim();
 }
 
-// Heimdall's own block message is emitted on stderr and echoed back into the
-// transcript as a tool_result. Skip any message bearing this signature so the
-// hook can never unlock itself by quoting the phrase in its own output.
-const OWN_BLOCK_SIGNATURE = 'ACTION REQUIRED: Call the AskUserQuestion';
-
-/** Set of unlock phrases (lowercased) spoken in recent user messages. */
+/** Set of unlock phrases (lowercased) the user typed in recent messages. */
 function findUnlockedPhrases(transcriptPath, entries) {
   const phrases = new Set(entries.map((e) => (e.unlockPhrase || '').toLowerCase()).filter(Boolean));
   const unlocked = new Set();
   for (const msg of getRecentUserMessages(transcriptPath, 20)) {
-    if (msg.includes(OWN_BLOCK_SIGNATURE)) continue;
     const normalized = stripSystemTags(msg).replace(/\s+/g, ' ').toLowerCase();
+    if (!normalized) continue;
     for (const phrase of phrases) {
-      if (normalized === phrase || normalized.includes(`="${phrase}"`)) unlocked.add(phrase);
+      // The user's own message must contain the phrase as a standalone token.
+      if (
+        normalized === phrase ||
+        new RegExp(`(?:^|\\s)${escapeRe(phrase)}(?:$|\\s|[.!?])`).test(normalized)
+      ) {
+        unlocked.add(phrase);
+      }
     }
   }
   return unlocked;
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function isEntryUnlocked(entry, unlockedPhrases) {

--- a/plugins/heimdall/lib/lock-store.js
+++ b/plugins/heimdall/lib/lock-store.js
@@ -1,0 +1,131 @@
+'use strict';
+
+/**
+ * Heimdall lock-store discovery + config IO.
+ *
+ * Mirrors synapsys's store model: a store lives at `.claude/heimdall/` and is
+ * identified by a `.heimdall.json` marker. Unlike synapsys (one markdown file
+ * per memory), heimdall keeps everything in the marker itself — the marker IS
+ * the config and holds the `locks` array.
+ *
+ * Three store kinds, same precedence as synapsys:
+ *   local    → <cwd>/.claude/heimdall
+ *   worktree → nearest ancestor above cwd carrying the marker
+ *   global   → ~/.claude/heimdall/<projectName>
+ *
+ * Locks discovered across all active stores are merged.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const MARKER = '.heimdall.json';
+const FOLDER = 'heimdall';
+const SCHEMA_VERSION = 1;
+
+function safeExec(cmd, cwd) {
+  try {
+    return execSync(cmd, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Git toplevel of cwd, or cwd itself when not in a repo. */
+function getRepoRoot(cwd) {
+  const resolvedCwd = cwd || process.cwd();
+  const top = safeExec('git rev-parse --show-toplevel', resolvedCwd);
+  return top || resolvedCwd;
+}
+
+function getProjectName(cwd) {
+  return path.basename(getRepoRoot(cwd));
+}
+
+function candidateStores(cwd, projectName) {
+  return [
+    { kind: 'local', dir: path.join(cwd, '.claude', FOLDER) },
+    { kind: 'worktree', dir: path.resolve(cwd, '..', '.claude', FOLDER) },
+    { kind: 'global', dir: path.join(os.homedir(), '.claude', FOLDER, projectName) },
+  ];
+}
+
+/**
+ * Walk up from startDir to the nearest ancestor carrying a store marker at
+ * `<ancestor>/.claude/heimdall/.heimdall.json`. Returns the store dir or ''.
+ * (Same rationale as synapsys: sessions may run from a sub-directory of a
+ * worktree whose shared store sits at the worktree base.)
+ */
+function findAncestorStore(startDir) {
+  let dir = startDir;
+  for (;;) {
+    if (fs.existsSync(path.join(dir, '.claude', FOLDER, MARKER))) {
+      return path.join(dir, '.claude', FOLDER);
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return '';
+    dir = parent;
+  }
+}
+
+/** Active stores (those with a marker) in precedence order, de-duplicated. */
+function discoverStores(cwd) {
+  const resolved = cwd || process.cwd();
+  const projectName = getProjectName(resolved);
+  const out = [];
+  const seen = new Set();
+
+  const push = (kind, dir) => {
+    const key = path.resolve(dir);
+    if (seen.has(key)) return;
+    if (!fs.existsSync(path.join(dir, MARKER))) return;
+    seen.add(key);
+    out.push({ kind, dir, projectName });
+  };
+
+  push('local', path.join(resolved, '.claude', FOLDER));
+
+  const wt = findAncestorStore(path.dirname(resolved));
+  if (wt) push('worktree', wt);
+
+  push('global', path.join(os.homedir(), '.claude', FOLDER, projectName));
+
+  return out;
+}
+
+function readConfig(storeDir) {
+  try {
+    const raw = fs.readFileSync(path.join(storeDir, MARKER), 'utf8');
+    const cfg = JSON.parse(raw);
+    if (!Array.isArray(cfg.locks)) cfg.locks = [];
+    return cfg;
+  } catch {
+    return null;
+  }
+}
+
+function writeConfig(storeDir, cfg) {
+  fs.mkdirSync(storeDir, { recursive: true });
+  const out = { schemaVersion: SCHEMA_VERSION, ...cfg };
+  fs.writeFileSync(path.join(storeDir, MARKER), `${JSON.stringify(out, null, 2)}\n`);
+}
+
+module.exports = {
+  MARKER,
+  FOLDER,
+  SCHEMA_VERSION,
+  safeExec,
+  getRepoRoot,
+  getProjectName,
+  candidateStores,
+  findAncestorStore,
+  discoverStores,
+  readConfig,
+  writeConfig,
+};

--- a/plugins/heimdall/lib/lock-store.js
+++ b/plugins/heimdall/lib/lock-store.js
@@ -25,6 +25,12 @@ const MARKER = '.heimdall.json';
 const FOLDER = 'heimdall';
 const SCHEMA_VERSION = 1;
 
+// jscpd:ignore-start
+// The store-discovery primitives below intentionally mirror synapsys's
+// memory-store.js: heimdall reuses the same local/worktree/global store model
+// on purpose, but must stay a self-contained plugin (it is installed
+// independently and cannot require synapsys at runtime). The duplication is
+// therefore deliberate and is excluded from the duplicate-blocks gate.
 function safeExec(cmd, cwd) {
   try {
     return execSync(cmd, {
@@ -98,6 +104,7 @@ function discoverStores(cwd) {
 
   return out;
 }
+// jscpd:ignore-end
 
 function readConfig(storeDir) {
   try {

--- a/plugins/heimdall/lib/lock-store.js
+++ b/plugins/heimdall/lib/lock-store.js
@@ -123,6 +123,40 @@ function writeConfig(storeDir, cfg) {
   fs.writeFileSync(path.join(storeDir, MARKER), `${JSON.stringify(out, null, 2)}\n`);
 }
 
+/**
+ * Add a lock block (or merge paths into the existing block with the same
+ * phrase). Mutates cfg.locks and returns the resulting block.
+ */
+function upsertLock(cfg, { phrase, paths, allowedPaths, trustedSubdirs }) {
+  const existing = cfg.locks.find((l) => (l.unlockPhrase || '').trim() === phrase);
+  const block = existing || { protect: [], unlockPhrase: phrase };
+  block.protect = [...new Set([...(block.protect || []), ...paths])];
+  if (allowedPaths) block.allowedPaths = allowedPaths;
+  if (trustedSubdirs) block.trustedSubdirs = trustedSubdirs;
+  if (!existing) cfg.locks.push(block);
+  return block;
+}
+
+/**
+ * Remove a lock block by phrase, or just `paths` from it (deleting the block if
+ * it becomes empty). Returns a status: 'missing' | 'removed' | 'emptied' | 'trimmed'.
+ */
+function removeLock(cfg, phrase, paths = []) {
+  const idx = cfg.locks.findIndex((l) => (l.unlockPhrase || '').trim() === phrase);
+  if (idx === -1) return 'missing';
+  if (paths.length === 0) {
+    cfg.locks.splice(idx, 1);
+    return 'removed';
+  }
+  const block = cfg.locks[idx];
+  block.protect = (block.protect || []).filter((p) => !paths.includes(p));
+  if (block.protect.length === 0) {
+    cfg.locks.splice(idx, 1);
+    return 'emptied';
+  }
+  return 'trimmed';
+}
+
 module.exports = {
   MARKER,
   FOLDER,
@@ -135,4 +169,6 @@ module.exports = {
   discoverStores,
   readConfig,
   writeConfig,
+  upsertLock,
+  removeLock,
 };

--- a/plugins/heimdall/lib/scan.js
+++ b/plugins/heimdall/lib/scan.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Scan logic for the install flow — kept in lib (not the CLI script) so it can
+ * be unit-tested in-process without spawning a subprocess.
+ *
+ * Walks the default catalog and keeps only targets that actually EXIST:
+ *   - 'repo' targets are resolved against the repo root and must exist there.
+ *   - 'home' targets are resolved against the home dir and are suggested only
+ *     for a `global` install (a home path is not "in the repository").
+ * Targets already covered by an existing lock in the active store(s) are
+ * dropped, so re-running install never re-suggests what's already protected.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { CATALOG } = require('./catalog');
+const { getRepoRoot, discoverStores, readConfig } = require('./lock-store');
+const { buildEntries } = require('./guard');
+
+function resolveTarget(target, repoRoot) {
+  if (target.anchor === 'home') {
+    return path.join(os.homedir(), target.path.replace(/^~\/?/, ''));
+  }
+  return path.resolve(repoRoot, target.path);
+}
+
+/** Absolute paths already protected by any active store. */
+function alreadyProtected(cwd, repoRoot) {
+  const protectedAbs = new Set();
+  for (const store of discoverStores(cwd)) {
+    const cfg = readConfig(store.dir);
+    if (!cfg) continue;
+    for (const entry of buildEntries(cfg.locks, repoRoot)) protectedAbs.add(entry.dir);
+  }
+  return protectedAbs;
+}
+
+function suggestionFor(item, kind, repoRoot, protectedAbs) {
+  const protect = [];
+  for (const target of item.targets) {
+    if (target.anchor === 'home' && kind !== 'global') continue;
+    const abs = resolveTarget(target, repoRoot);
+    if (!fs.existsSync(abs)) continue;
+    if (protectedAbs.has(abs)) continue;
+    protect.push(target.path);
+  }
+  if (protect.length === 0) return null;
+  const suggestion = {
+    id: item.id,
+    label: item.label,
+    description: item.description,
+    defaultPhrase: item.defaultPhrase,
+    protect,
+  };
+  if (item.allowedPaths) suggestion.allowedPaths = item.allowedPaths;
+  if (item.trustedSubdirs) suggestion.trustedSubdirs = item.trustedSubdirs;
+  return suggestion;
+}
+
+/** Compute install suggestions for { cwd, kind }. */
+function scan({ cwd, kind }) {
+  const repoRoot = getRepoRoot(cwd);
+  const protectedAbs = alreadyProtected(cwd, repoRoot);
+  const suggestions = [];
+  for (const item of CATALOG) {
+    const s = suggestionFor(item, kind, repoRoot, protectedAbs);
+    if (s) suggestions.push(s);
+  }
+  return suggestions;
+}
+
+module.exports = { scan };

--- a/plugins/heimdall/scripts/heimdall-init.js
+++ b/plugins/heimdall/scripts/heimdall-init.js
@@ -15,6 +15,7 @@
  */
 
 const path = require('node:path');
+const { parseArgs } = require(path.join(__dirname, '..', 'lib', 'cli'));
 const {
   MARKER,
   SCHEMA_VERSION,
@@ -24,28 +25,20 @@ const {
   writeConfig,
 } = require(path.join(__dirname, '..', 'lib', 'lock-store'));
 
-function parseArgs(argv) {
-  const out = { kind: 'local', cwd: process.cwd() };
-  for (const a of argv.slice(2)) {
-    const m = a.match(/^--([a-z]+)=(.+)$/);
-    if (m) out[m[1]] = m[2];
-  }
-  return out;
-}
-
 const args = parseArgs(process.argv);
+const kind = args.kind || 'local';
 const projectName = getProjectName(args.cwd);
-const target = candidateStores(args.cwd, projectName).find((c) => c.kind === args.kind);
+const target = candidateStores(args.cwd, projectName).find((c) => c.kind === kind);
 
 if (!target) {
-  console.error(`unknown kind: ${args.kind} (use local|worktree|global)`);
+  console.error(`unknown kind: ${kind} (use local|worktree|global)`);
   process.exit(1);
 }
 
 const existing = readConfig(target.dir);
 const cfg = {
   schemaVersion: SCHEMA_VERSION,
-  kind: args.kind,
+  kind,
   projectName,
   createdAt: existing?.createdAt || new Date().toISOString(),
   updatedAt: new Date().toISOString(),
@@ -55,5 +48,5 @@ writeConfig(target.dir, cfg);
 
 console.log(
   `initialized heimdall store at ${path.join(target.dir, MARKER)} ` +
-    `(kind=${args.kind}, project=${projectName}, locks=${cfg.locks.length})`
+    `(kind=${kind}, project=${projectName}, locks=${cfg.locks.length})`
 );

--- a/plugins/heimdall/scripts/heimdall-init.js
+++ b/plugins/heimdall/scripts/heimdall-init.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Initialize a Heimdall lock store.
+ *
+ *   node heimdall-init.js --kind=<local|worktree|global> [--cwd=<path>]
+ *
+ * Creates the store directory and writes a `.heimdall.json` marker holding an
+ * (initially empty) `locks` array. The marker is what makes the store
+ * discoverable by the hook — heimdall only enforces locks from marked stores.
+ *
+ * Idempotent: re-running on an existing store preserves its locks and only
+ * refreshes the marker metadata.
+ */
+
+const path = require('node:path');
+const {
+  MARKER,
+  SCHEMA_VERSION,
+  getProjectName,
+  candidateStores,
+  readConfig,
+  writeConfig,
+} = require(path.join(__dirname, '..', 'lib', 'lock-store'));
+
+function parseArgs(argv) {
+  const out = { kind: 'local', cwd: process.cwd() };
+  for (const a of argv.slice(2)) {
+    const m = a.match(/^--([a-z]+)=(.+)$/);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv);
+const projectName = getProjectName(args.cwd);
+const target = candidateStores(args.cwd, projectName).find((c) => c.kind === args.kind);
+
+if (!target) {
+  console.error(`unknown kind: ${args.kind} (use local|worktree|global)`);
+  process.exit(1);
+}
+
+const existing = readConfig(target.dir);
+const cfg = {
+  schemaVersion: SCHEMA_VERSION,
+  kind: args.kind,
+  projectName,
+  createdAt: existing?.createdAt || new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  locks: existing?.locks || [],
+};
+writeConfig(target.dir, cfg);
+
+console.log(
+  `initialized heimdall store at ${path.join(target.dir, MARKER)} ` +
+    `(kind=${args.kind}, project=${projectName}, locks=${cfg.locks.length})`
+);

--- a/plugins/heimdall/scripts/heimdall-list.js
+++ b/plugins/heimdall/scripts/heimdall-list.js
@@ -14,20 +14,8 @@ const path = require('node:path');
 const { discoverStores, readConfig, getRepoRoot } = require(
   path.join(__dirname, '..', 'lib', 'lock-store')
 );
+const { parseArgs } = require(path.join(__dirname, '..', 'lib', 'cli'));
 const { buildEntries } = require(path.join(__dirname, '..', 'lib', 'guard'));
-
-function parseArgs(argv) {
-  const out = { cwd: process.cwd(), json: false };
-  for (const a of argv.slice(2)) {
-    if (a === '--json') {
-      out.json = true;
-      continue;
-    }
-    const m = a.match(/^--([a-z]+)=(.+)$/);
-    if (m) out[m[1]] = m[2];
-  }
-  return out;
-}
 
 const args = parseArgs(process.argv);
 const stores = discoverStores(args.cwd);

--- a/plugins/heimdall/scripts/heimdall-list.js
+++ b/plugins/heimdall/scripts/heimdall-list.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * List Heimdall lock blocks across all active stores.
+ *
+ *   node heimdall-list.js [--cwd=<path>] [--json]
+ *
+ * Shows, per store, each lock block's unlock phrase, the protected paths, and
+ * whether each resolves to a file or directory (resolved against the repo root).
+ */
+
+const path = require('node:path');
+const { discoverStores, readConfig, getRepoRoot } = require(
+  path.join(__dirname, '..', 'lib', 'lock-store')
+);
+const { buildEntries } = require(path.join(__dirname, '..', 'lib', 'guard'));
+
+function parseArgs(argv) {
+  const out = { cwd: process.cwd(), json: false };
+  for (const a of argv.slice(2)) {
+    if (a === '--json') {
+      out.json = true;
+      continue;
+    }
+    const m = a.match(/^--([a-z]+)=(.+)$/);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv);
+const stores = discoverStores(args.cwd);
+const baseDir = getRepoRoot(args.cwd);
+
+if (stores.length === 0) {
+  if (args.json) {
+    console.log('[]');
+  } else {
+    console.log('No heimdall stores found. Run /heimdall:install to create one.');
+  }
+  process.exit(0);
+}
+
+const report = stores.map((store) => {
+  const cfg = readConfig(store.dir) || { locks: [] };
+  return {
+    kind: store.kind,
+    dir: store.dir,
+    locks: cfg.locks.map((lock) => ({
+      unlockPhrase: lock.unlockPhrase,
+      protect: lock.protect || [],
+      resolved: buildEntries([lock], baseDir).map((e) => ({
+        path: e.dir,
+        type: e.isFile ? 'file' : 'dir',
+      })),
+    })),
+  };
+});
+
+if (args.json) {
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(0);
+}
+
+for (const store of report) {
+  console.log(`\n# ${store.kind} store — ${store.dir}`);
+  if (store.locks.length === 0) {
+    console.log('  (no lock blocks)');
+    continue;
+  }
+  for (const lock of store.locks) {
+    console.log(`  • unlock: "${lock.unlockPhrase}"`);
+    for (const r of lock.resolved) {
+      console.log(`      [${r.type}] ${r.path}`);
+    }
+  }
+}
+console.log();

--- a/plugins/heimdall/scripts/heimdall-protect.js
+++ b/plugins/heimdall/scripts/heimdall-protect.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Add (or extend) a lock block in a Heimdall store.
+ *
+ *   node heimdall-protect.js --phrase="edit .claude" --paths=".claude,~/.claude" [--kind=local] [--cwd=<path>]
+ *
+ * A lock block is the tuple { protect: [<dir|file>, ...], unlockPhrase }.
+ * If a block with the same unlockPhrase already exists, the new paths are
+ * merged into it (de-duplicated). Otherwise a new block is appended.
+ *
+ * --allowed=<a,b>  optional: subdirs always writable under a protected dir.
+ * --trusted=<a,b>  optional: subdirs whose internal scripts are trusted.
+ *
+ * Requires the store to exist (run /heimdall:install first). Defaults to the
+ * highest-precedence active store when --kind is omitted.
+ */
+
+const path = require('node:path');
+const {
+  getProjectName,
+  candidateStores,
+  discoverStores,
+  readConfig,
+  writeConfig,
+  SCHEMA_VERSION,
+} = require(path.join(__dirname, '..', 'lib', 'lock-store'));
+
+function parseArgs(argv) {
+  const out = { cwd: process.cwd() };
+  for (const a of argv.slice(2)) {
+    const m = a.match(/^--([a-z]+)=(.*)$/);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+function splitList(v) {
+  return (v || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+const args = parseArgs(process.argv);
+const phrase = (args.phrase || '').trim();
+const paths = splitList(args.paths);
+
+if (!phrase) {
+  console.error('missing --phrase');
+  process.exit(1);
+}
+if (paths.length === 0) {
+  console.error('missing --paths');
+  process.exit(1);
+}
+
+// Resolve target store.
+let storeDir;
+if (args.kind) {
+  const projectName = getProjectName(args.cwd);
+  const target = candidateStores(args.cwd, projectName).find((c) => c.kind === args.kind);
+  if (!target) {
+    console.error(`unknown kind: ${args.kind}`);
+    process.exit(1);
+  }
+  storeDir = target.dir;
+} else {
+  const stores = discoverStores(args.cwd);
+  if (stores.length === 0) {
+    console.error('no heimdall store found — run /heimdall:install first (or pass --kind).');
+    process.exit(1);
+  }
+  storeDir = stores[0].dir;
+}
+
+const cfg = readConfig(storeDir);
+if (!cfg) {
+  console.error(`store not initialized at ${storeDir} — run /heimdall:install first.`);
+  process.exit(1);
+}
+
+const existing = cfg.locks.find((l) => (l.unlockPhrase || '').trim() === phrase);
+if (existing) {
+  const set = new Set([...(existing.protect || []), ...paths]);
+  existing.protect = [...set];
+  if (args.allowed) existing.allowedPaths = splitList(args.allowed);
+  if (args.trusted) existing.trustedSubdirs = splitList(args.trusted);
+} else {
+  const block = { protect: paths, unlockPhrase: phrase };
+  if (args.allowed) block.allowedPaths = splitList(args.allowed);
+  if (args.trusted) block.trustedSubdirs = splitList(args.trusted);
+  cfg.locks.push(block);
+}
+
+cfg.schemaVersion = SCHEMA_VERSION;
+cfg.updatedAt = new Date().toISOString();
+writeConfig(storeDir, cfg);
+
+const block = cfg.locks.find((l) => (l.unlockPhrase || '').trim() === phrase);
+console.log(
+  `protected [${block.protect.join(', ')}] under phrase "${phrase}" ` +
+    `(store: ${storeDir}, ${cfg.locks.length} block(s) total)`
+);

--- a/plugins/heimdall/scripts/heimdall-protect.js
+++ b/plugins/heimdall/scripts/heimdall-protect.js
@@ -18,62 +18,17 @@
  */
 
 const path = require('node:path');
-const {
-  getProjectName,
-  candidateStores,
-  discoverStores,
-  readConfig,
-  writeConfig,
-  SCHEMA_VERSION,
-} = require(path.join(__dirname, '..', 'lib', 'lock-store'));
+const { splitList, editContext } = require(path.join(__dirname, '..', 'lib', 'cli'));
+const { readConfig, writeConfig, SCHEMA_VERSION } = require(
+  path.join(__dirname, '..', 'lib', 'lock-store')
+);
 
-function parseArgs(argv) {
-  const out = { cwd: process.cwd() };
-  for (const a of argv.slice(2)) {
-    const m = a.match(/^--([a-z]+)=(.*)$/);
-    if (m) out[m[1]] = m[2];
-  }
-  return out;
-}
-
-function splitList(v) {
-  return (v || '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
-const args = parseArgs(process.argv);
-const phrase = (args.phrase || '').trim();
-const paths = splitList(args.paths);
-
-if (!phrase) {
-  console.error('missing --phrase');
-  process.exit(1);
-}
+const { args, phrase, paths, dirs } = editContext();
 if (paths.length === 0) {
   console.error('missing --paths');
   process.exit(1);
 }
-
-// Resolve target store.
-let storeDir;
-if (args.kind) {
-  const projectName = getProjectName(args.cwd);
-  const target = candidateStores(args.cwd, projectName).find((c) => c.kind === args.kind);
-  if (!target) {
-    console.error(`unknown kind: ${args.kind}`);
-    process.exit(1);
-  }
-  storeDir = target.dir;
-} else {
-  const stores = discoverStores(args.cwd);
-  if (stores.length === 0) {
-    console.error('no heimdall store found — run /heimdall:install first (or pass --kind).');
-    process.exit(1);
-  }
-  storeDir = stores[0].dir;
-}
+const storeDir = dirs[0];
 
 const cfg = readConfig(storeDir);
 if (!cfg) {
@@ -83,8 +38,7 @@ if (!cfg) {
 
 const existing = cfg.locks.find((l) => (l.unlockPhrase || '').trim() === phrase);
 if (existing) {
-  const set = new Set([...(existing.protect || []), ...paths]);
-  existing.protect = [...set];
+  existing.protect = [...new Set([...(existing.protect || []), ...paths])];
   if (args.allowed) existing.allowedPaths = splitList(args.allowed);
   if (args.trusted) existing.trustedSubdirs = splitList(args.trusted);
 } else {
@@ -98,8 +52,8 @@ cfg.schemaVersion = SCHEMA_VERSION;
 cfg.updatedAt = new Date().toISOString();
 writeConfig(storeDir, cfg);
 
-const block = cfg.locks.find((l) => (l.unlockPhrase || '').trim() === phrase);
+const saved = cfg.locks.find((l) => (l.unlockPhrase || '').trim() === phrase);
 console.log(
-  `protected [${block.protect.join(', ')}] under phrase "${phrase}" ` +
+  `protected [${saved.protect.join(', ')}] under phrase "${phrase}" ` +
     `(store: ${storeDir}, ${cfg.locks.length} block(s) total)`
 );

--- a/plugins/heimdall/scripts/heimdall-protect.js
+++ b/plugins/heimdall/scripts/heimdall-protect.js
@@ -19,7 +19,7 @@
 
 const path = require('node:path');
 const { splitList, editContext } = require(path.join(__dirname, '..', 'lib', 'cli'));
-const { readConfig, writeConfig, SCHEMA_VERSION } = require(
+const { readConfig, writeConfig, upsertLock, SCHEMA_VERSION } = require(
   path.join(__dirname, '..', 'lib', 'lock-store')
 );
 
@@ -36,23 +36,17 @@ if (!cfg) {
   process.exit(1);
 }
 
-const existing = cfg.locks.find((l) => (l.unlockPhrase || '').trim() === phrase);
-if (existing) {
-  existing.protect = [...new Set([...(existing.protect || []), ...paths])];
-  if (args.allowed) existing.allowedPaths = splitList(args.allowed);
-  if (args.trusted) existing.trustedSubdirs = splitList(args.trusted);
-} else {
-  const block = { protect: paths, unlockPhrase: phrase };
-  if (args.allowed) block.allowedPaths = splitList(args.allowed);
-  if (args.trusted) block.trustedSubdirs = splitList(args.trusted);
-  cfg.locks.push(block);
-}
+const saved = upsertLock(cfg, {
+  phrase,
+  paths,
+  allowedPaths: args.allowed ? splitList(args.allowed) : undefined,
+  trustedSubdirs: args.trusted ? splitList(args.trusted) : undefined,
+});
 
 cfg.schemaVersion = SCHEMA_VERSION;
 cfg.updatedAt = new Date().toISOString();
 writeConfig(storeDir, cfg);
 
-const saved = cfg.locks.find((l) => (l.unlockPhrase || '').trim() === phrase);
 console.log(
   `protected [${saved.protect.join(', ')}] under phrase "${phrase}" ` +
     `(store: ${storeDir}, ${cfg.locks.length} block(s) total)`

--- a/plugins/heimdall/scripts/heimdall-scan.js
+++ b/plugins/heimdall/scripts/heimdall-scan.js
@@ -26,19 +26,7 @@ const { getRepoRoot, discoverStores, readConfig } = require(
   path.join(__dirname, '..', 'lib', 'lock-store')
 );
 const { buildEntries } = require(path.join(__dirname, '..', 'lib', 'guard'));
-
-function parseArgs(argv) {
-  const out = { kind: 'local', cwd: process.cwd(), json: false };
-  for (const a of argv.slice(2)) {
-    if (a === '--json') {
-      out.json = true;
-      continue;
-    }
-    const m = a.match(/^--([a-z]+)=(.+)$/);
-    if (m) out[m[1]] = m[2];
-  }
-  return out;
-}
+const { parseArgs } = require(path.join(__dirname, '..', 'lib', 'cli'));
 
 function resolveTarget(target, repoRoot) {
   if (target.anchor === 'home') {
@@ -92,6 +80,7 @@ function scan(args) {
 }
 
 const args = parseArgs(process.argv);
+if (!args.kind) args.kind = 'local';
 const suggestions = scan(args);
 
 if (args.json) {

--- a/plugins/heimdall/scripts/heimdall-scan.js
+++ b/plugins/heimdall/scripts/heimdall-scan.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Scan for protectable paths and emit suggestions for the install flow.
+ *
+ *   node heimdall-scan.js --kind=<local|worktree|global> [--cwd=<path>] [--json]
+ *
+ * Walks the default catalog and keeps only targets that actually EXIST:
+ *   - 'repo' targets are resolved against the repo root and must exist there.
+ *   - 'home' targets are resolved against the home dir and are suggested only
+ *     for a `global` install (a home path is not "in the repository").
+ *
+ * Targets already covered by an existing lock in the active store(s) are
+ * dropped, so re-running install never re-suggests what's already protected.
+ *
+ * Output (default human, or --json): one suggestion per catalog entry that has
+ * at least one existing, not-yet-protected target.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { CATALOG } = require(path.join(__dirname, '..', 'lib', 'catalog'));
+const { getRepoRoot, discoverStores, readConfig } = require(
+  path.join(__dirname, '..', 'lib', 'lock-store')
+);
+const { buildEntries } = require(path.join(__dirname, '..', 'lib', 'guard'));
+
+function parseArgs(argv) {
+  const out = { kind: 'local', cwd: process.cwd(), json: false };
+  for (const a of argv.slice(2)) {
+    if (a === '--json') {
+      out.json = true;
+      continue;
+    }
+    const m = a.match(/^--([a-z]+)=(.+)$/);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+function resolveTarget(target, repoRoot) {
+  if (target.anchor === 'home') {
+    return path.join(os.homedir(), target.path.replace(/^~\/?/, ''));
+  }
+  return path.resolve(repoRoot, target.path);
+}
+
+/** Absolute paths already protected by any active store. */
+function alreadyProtected(cwd, repoRoot) {
+  const protectedAbs = new Set();
+  for (const store of discoverStores(cwd)) {
+    const cfg = readConfig(store.dir);
+    if (!cfg) continue;
+    for (const entry of buildEntries(cfg.locks, repoRoot)) protectedAbs.add(entry.dir);
+  }
+  return protectedAbs;
+}
+
+function suggestionFor(item, args, repoRoot, protectedAbs) {
+  const protect = [];
+  for (const target of item.targets) {
+    if (target.anchor === 'home' && args.kind !== 'global') continue;
+    const abs = resolveTarget(target, repoRoot);
+    if (!fs.existsSync(abs)) continue;
+    if (protectedAbs.has(abs)) continue;
+    protect.push(target.path);
+  }
+  if (protect.length === 0) return null;
+  const suggestion = {
+    id: item.id,
+    label: item.label,
+    description: item.description,
+    defaultPhrase: item.defaultPhrase,
+    protect,
+  };
+  if (item.allowedPaths) suggestion.allowedPaths = item.allowedPaths;
+  if (item.trustedSubdirs) suggestion.trustedSubdirs = item.trustedSubdirs;
+  return suggestion;
+}
+
+function scan(args) {
+  const repoRoot = getRepoRoot(args.cwd);
+  const protectedAbs = alreadyProtected(args.cwd, repoRoot);
+  const suggestions = [];
+  for (const item of CATALOG) {
+    const s = suggestionFor(item, args, repoRoot, protectedAbs);
+    if (s) suggestions.push(s);
+  }
+  return suggestions;
+}
+
+const args = parseArgs(process.argv);
+const suggestions = scan(args);
+
+if (args.json) {
+  console.log(JSON.stringify(suggestions, null, 2));
+  process.exit(0);
+}
+
+if (suggestions.length === 0) {
+  console.log('No new protectable paths detected for this install.');
+  process.exit(0);
+}
+
+console.log(`Detected ${suggestions.length} protectable path group(s):\n`);
+for (const s of suggestions) {
+  console.log(`• ${s.label} — ${s.description}`);
+  console.log(`    paths:  ${s.protect.join(', ')}`);
+  console.log(`    phrase: "${s.defaultPhrase}"`);
+}

--- a/plugins/heimdall/scripts/heimdall-scan.js
+++ b/plugins/heimdall/scripts/heimdall-scan.js
@@ -6,82 +6,16 @@
  *
  *   node heimdall-scan.js --kind=<local|worktree|global> [--cwd=<path>] [--json]
  *
- * Walks the default catalog and keeps only targets that actually EXIST:
- *   - 'repo' targets are resolved against the repo root and must exist there.
- *   - 'home' targets are resolved against the home dir and are suggested only
- *     for a `global` install (a home path is not "in the repository").
- *
- * Targets already covered by an existing lock in the active store(s) are
- * dropped, so re-running install never re-suggests what's already protected.
- *
- * Output (default human, or --json): one suggestion per catalog entry that has
- * at least one existing, not-yet-protected target.
+ * Thin CLI wrapper around lib/scan.js (the logic lives there so it is unit-
+ * testable in-process). Output is JSON with --json, else human-readable.
  */
 
-const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
-const { CATALOG } = require(path.join(__dirname, '..', 'lib', 'catalog'));
-const { getRepoRoot, discoverStores, readConfig } = require(
-  path.join(__dirname, '..', 'lib', 'lock-store')
-);
-const { buildEntries } = require(path.join(__dirname, '..', 'lib', 'guard'));
 const { parseArgs } = require(path.join(__dirname, '..', 'lib', 'cli'));
-
-function resolveTarget(target, repoRoot) {
-  if (target.anchor === 'home') {
-    return path.join(os.homedir(), target.path.replace(/^~\/?/, ''));
-  }
-  return path.resolve(repoRoot, target.path);
-}
-
-/** Absolute paths already protected by any active store. */
-function alreadyProtected(cwd, repoRoot) {
-  const protectedAbs = new Set();
-  for (const store of discoverStores(cwd)) {
-    const cfg = readConfig(store.dir);
-    if (!cfg) continue;
-    for (const entry of buildEntries(cfg.locks, repoRoot)) protectedAbs.add(entry.dir);
-  }
-  return protectedAbs;
-}
-
-function suggestionFor(item, args, repoRoot, protectedAbs) {
-  const protect = [];
-  for (const target of item.targets) {
-    if (target.anchor === 'home' && args.kind !== 'global') continue;
-    const abs = resolveTarget(target, repoRoot);
-    if (!fs.existsSync(abs)) continue;
-    if (protectedAbs.has(abs)) continue;
-    protect.push(target.path);
-  }
-  if (protect.length === 0) return null;
-  const suggestion = {
-    id: item.id,
-    label: item.label,
-    description: item.description,
-    defaultPhrase: item.defaultPhrase,
-    protect,
-  };
-  if (item.allowedPaths) suggestion.allowedPaths = item.allowedPaths;
-  if (item.trustedSubdirs) suggestion.trustedSubdirs = item.trustedSubdirs;
-  return suggestion;
-}
-
-function scan(args) {
-  const repoRoot = getRepoRoot(args.cwd);
-  const protectedAbs = alreadyProtected(args.cwd, repoRoot);
-  const suggestions = [];
-  for (const item of CATALOG) {
-    const s = suggestionFor(item, args, repoRoot, protectedAbs);
-    if (s) suggestions.push(s);
-  }
-  return suggestions;
-}
+const { scan } = require(path.join(__dirname, '..', 'lib', 'scan'));
 
 const args = parseArgs(process.argv);
-if (!args.kind) args.kind = 'local';
-const suggestions = scan(args);
+const suggestions = scan({ cwd: args.cwd, kind: args.kind || 'local' });
 
 if (args.json) {
   console.log(JSON.stringify(suggestions, null, 2));

--- a/plugins/heimdall/scripts/heimdall-unprotect.js
+++ b/plugins/heimdall/scripts/heimdall-unprotect.js
@@ -15,64 +15,18 @@
  */
 
 const path = require('node:path');
-const {
-  getProjectName,
-  candidateStores,
-  discoverStores,
-  readConfig,
-  writeConfig,
-  SCHEMA_VERSION,
-} = require(path.join(__dirname, '..', 'lib', 'lock-store'));
+const { editContext } = require(path.join(__dirname, '..', 'lib', 'cli'));
+const { readConfig, writeConfig, SCHEMA_VERSION } = require(
+  path.join(__dirname, '..', 'lib', 'lock-store')
+);
 
-function parseArgs(argv) {
-  const out = { cwd: process.cwd() };
-  for (const a of argv.slice(2)) {
-    const m = a.match(/^--([a-z]+)=(.*)$/);
-    if (m) out[m[1]] = m[2];
-  }
-  return out;
-}
+const { phrase, paths, dirs } = editContext();
 
-function splitList(v) {
-  return (v || '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
-const args = parseArgs(process.argv);
-const phrase = (args.phrase || '').trim();
-const paths = splitList(args.paths);
-
-if (!phrase) {
-  console.error('missing --phrase');
-  process.exit(1);
-}
-
-let storeDirs;
-if (args.kind) {
-  const projectName = getProjectName(args.cwd);
-  const target = candidateStores(args.cwd, projectName).find((c) => c.kind === args.kind);
-  if (!target) {
-    console.error(`unknown kind: ${args.kind}`);
-    process.exit(1);
-  }
-  storeDirs = [target.dir];
-} else {
-  const stores = discoverStores(args.cwd);
-  if (stores.length === 0) {
-    console.error('no heimdall store found.');
-    process.exit(1);
-  }
-  storeDirs = stores.map((s) => s.dir);
-}
-
-let changed = 0;
-for (const storeDir of storeDirs) {
+function removeFromStore(storeDir) {
   const cfg = readConfig(storeDir);
-  if (!cfg) continue;
+  if (!cfg) return false;
   const idx = cfg.locks.findIndex((l) => (l.unlockPhrase || '').trim() === phrase);
-  if (idx === -1) continue;
+  if (idx === -1) return false;
 
   if (paths.length === 0) {
     cfg.locks.splice(idx, 1);
@@ -92,9 +46,10 @@ for (const storeDir of storeDirs) {
   cfg.schemaVersion = SCHEMA_VERSION;
   cfg.updatedAt = new Date().toISOString();
   writeConfig(storeDir, cfg);
-  changed++;
+  return true;
 }
 
+const changed = dirs.filter(removeFromStore).length;
 if (changed === 0) {
   console.error(`no lock block with phrase "${phrase}" found in any store.`);
   process.exit(1);

--- a/plugins/heimdall/scripts/heimdall-unprotect.js
+++ b/plugins/heimdall/scripts/heimdall-unprotect.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Remove protection from a Heimdall store.
+ *
+ *   node heimdall-unprotect.js --phrase="edit .claude" [--paths=".claude"] [--kind=local] [--cwd=<path>]
+ *
+ * - With --phrase only: removes the entire lock block for that phrase.
+ * - With --phrase + --paths: removes only those paths from the block; the
+ *   block is deleted if it becomes empty.
+ *
+ * Searches all active stores when --kind is omitted, removing from each that
+ * contains a matching block. Never deletes the store or its marker.
+ */
+
+const path = require('node:path');
+const {
+  getProjectName,
+  candidateStores,
+  discoverStores,
+  readConfig,
+  writeConfig,
+  SCHEMA_VERSION,
+} = require(path.join(__dirname, '..', 'lib', 'lock-store'));
+
+function parseArgs(argv) {
+  const out = { cwd: process.cwd() };
+  for (const a of argv.slice(2)) {
+    const m = a.match(/^--([a-z]+)=(.*)$/);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+function splitList(v) {
+  return (v || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+const args = parseArgs(process.argv);
+const phrase = (args.phrase || '').trim();
+const paths = splitList(args.paths);
+
+if (!phrase) {
+  console.error('missing --phrase');
+  process.exit(1);
+}
+
+let storeDirs;
+if (args.kind) {
+  const projectName = getProjectName(args.cwd);
+  const target = candidateStores(args.cwd, projectName).find((c) => c.kind === args.kind);
+  if (!target) {
+    console.error(`unknown kind: ${args.kind}`);
+    process.exit(1);
+  }
+  storeDirs = [target.dir];
+} else {
+  const stores = discoverStores(args.cwd);
+  if (stores.length === 0) {
+    console.error('no heimdall store found.');
+    process.exit(1);
+  }
+  storeDirs = stores.map((s) => s.dir);
+}
+
+let changed = 0;
+for (const storeDir of storeDirs) {
+  const cfg = readConfig(storeDir);
+  if (!cfg) continue;
+  const idx = cfg.locks.findIndex((l) => (l.unlockPhrase || '').trim() === phrase);
+  if (idx === -1) continue;
+
+  if (paths.length === 0) {
+    cfg.locks.splice(idx, 1);
+    console.log(`removed lock block "${phrase}" from ${storeDir}`);
+  } else {
+    const block = cfg.locks[idx];
+    block.protect = (block.protect || []).filter((p) => !paths.includes(p));
+    if (block.protect.length === 0) {
+      cfg.locks.splice(idx, 1);
+      console.log(`removed paths and emptied block "${phrase}" from ${storeDir}`);
+    } else {
+      console.log(
+        `removed [${paths.join(', ')}] from "${phrase}"; remaining [${block.protect.join(', ')}] (${storeDir})`
+      );
+    }
+  }
+  cfg.schemaVersion = SCHEMA_VERSION;
+  cfg.updatedAt = new Date().toISOString();
+  writeConfig(storeDir, cfg);
+  changed++;
+}
+
+if (changed === 0) {
+  console.error(`no lock block with phrase "${phrase}" found in any store.`);
+  process.exit(1);
+}

--- a/plugins/heimdall/scripts/heimdall-unprotect.js
+++ b/plugins/heimdall/scripts/heimdall-unprotect.js
@@ -16,7 +16,7 @@
 
 const path = require('node:path');
 const { editContext } = require(path.join(__dirname, '..', 'lib', 'cli'));
-const { readConfig, writeConfig, SCHEMA_VERSION } = require(
+const { readConfig, writeConfig, removeLock, SCHEMA_VERSION } = require(
   path.join(__dirname, '..', 'lib', 'lock-store')
 );
 
@@ -25,23 +25,17 @@ const { phrase, paths, dirs } = editContext();
 function removeFromStore(storeDir) {
   const cfg = readConfig(storeDir);
   if (!cfg) return false;
-  const idx = cfg.locks.findIndex((l) => (l.unlockPhrase || '').trim() === phrase);
-  if (idx === -1) return false;
+  const status = removeLock(cfg, phrase, paths);
+  if (status === 'missing') return false;
 
-  if (paths.length === 0) {
-    cfg.locks.splice(idx, 1);
-    console.log(`removed lock block "${phrase}" from ${storeDir}`);
-  } else {
-    const block = cfg.locks[idx];
-    block.protect = (block.protect || []).filter((p) => !paths.includes(p));
-    if (block.protect.length === 0) {
-      cfg.locks.splice(idx, 1);
-      console.log(`removed paths and emptied block "${phrase}" from ${storeDir}`);
-    } else {
-      console.log(
-        `removed [${paths.join(', ')}] from "${phrase}"; remaining [${block.protect.join(', ')}] (${storeDir})`
-      );
-    }
+  if (status === 'removed') console.log(`removed lock block "${phrase}" from ${storeDir}`);
+  else if (status === 'emptied')
+    console.log(`removed paths and emptied block "${phrase}" from ${storeDir}`);
+  else {
+    const block = cfg.locks.find((l) => (l.unlockPhrase || '').trim() === phrase);
+    console.log(
+      `removed [${paths.join(', ')}] from "${phrase}"; remaining [${block.protect.join(', ')}] (${storeDir})`
+    );
   }
   cfg.schemaVersion = SCHEMA_VERSION;
   cfg.updatedAt = new Date().toISOString();

--- a/plugins/heimdall/skills/install/SKILL.md
+++ b/plugins/heimdall/skills/install/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: install
+description: Configure Heimdall file/directory protection storage and scan for paths to protect. Use when the user says "install heimdall", "set up heimdall", "set up protection", "configure heimdall", "create lock store", "initialize heimdall", or asks to start guarding files. Picks local (./.claude/heimdall), worktree (../.claude/heimdall), or global (~/.claude/heimdall/<project>), then suggests protectable paths.
+argument-hint: [local|worktree|global]
+user-invocable: true
+allowed-tools: Bash, AskUserQuestion
+---
+
+# Install
+
+Two phases: (1) create the store, (2) scan for protectable paths and let the
+user opt each one in behind a passphrase.
+
+## Phase 1 — create the store
+
+1. If the user passed `local`, `worktree`, or `global`, use it. Otherwise pick via `AskUserQuestion`: recommend `worktree` when `git worktree list` shows >1 entry, else `local`; mention `global` survives worktree deletion.
+2. Run the init script and print its output:
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-init.js" --kind=<kind>
+   ```
+   It's idempotent — existing lock blocks are preserved.
+
+## Phase 2 — scan + opt-in
+
+3. Scan for protectable paths (mirrors the protectors already in `~/.claude`):
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-scan.js" --kind=<kind> --json
+   ```
+   The scan only returns paths that **actually exist** — and for `local`/`worktree` it never suggests home-anchored paths (e.g. `~/.claude`), only paths present in the repository. Already-protected paths are omitted. If the result is `[]`, tell the user there's nothing new to protect and stop.
+
+4. **Ask per suggestion.** Use `AskUserQuestion` (batch up to 4 suggestions per call). For each suggestion make one question:
+   - question: `Protect <label> (<comma-joined protect paths>)?`
+   - header: a short tag derived from the label
+   - options:
+     - `Protect — phrase "<defaultPhrase>"` (recommended)
+     - `Use a different phrase`
+     - `Skip`
+   If the user picks "Use a different phrase", ask them for the phrase (free-form / Other).
+
+5. **Apply each opted-in suggestion** with the scan's metadata. For a suggestion with `protect`, `defaultPhrase` (or the user's phrase), and optional `allowedPaths`/`trustedSubdirs`:
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-protect.js" \
+     --kind=<kind> \
+     --phrase="<phrase>" \
+     --paths="<comma,separated,protect>" \
+     [--allowed="<comma,separated,allowedPaths>"] \
+     [--trusted="<comma,separated,trustedSubdirs>"]
+   ```
+   Pass `--allowed`/`--trusted` only when the suggestion includes them (the `claude-config` group does).
+
+6. Finish by running `/heimdall:list` (or the list script) and showing the resulting protection.
+
+The user can always add more later with `/heimdall:protect` or remove with `/heimdall:unprotect`.

--- a/plugins/heimdall/skills/list/SKILL.md
+++ b/plugins/heimdall/skills/list/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: list
+description: List Heimdall lock blocks. Use when the user says "list locks", "show protected files", "what's protected", "what is heimdall guarding", "show heimdall config", "list protection", or asks to inspect or audit what's locked. Displays each store, its lock blocks, unlock phrases, and the resolved file/dir targets.
+argument-hint: ""
+user-invocable: true
+allowed-tools: Bash
+---
+
+# List
+
+Show every active Heimdall store and its lock blocks (unlock phrase + protected paths, with each path resolved to a file or directory against the repo root).
+
+## Steps
+
+1. Run the list script:
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-list.js"
+   ```
+2. Print the output. If the user wants machine-readable output, re-run with `--json`.
+
+If no stores exist, tell the user to run `/heimdall:install`.

--- a/plugins/heimdall/skills/protect/SKILL.md
+++ b/plugins/heimdall/skills/protect/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: protect
+description: Add a Heimdall lock block — protect files or directories behind an unlock phrase. Use when the user says "protect X", "lock X", "guard this file/folder", "don't let me edit X without saying Y", "require a phrase to edit X", or describes paths that should be write-protected. A lock block is the tuple { protect: [paths], unlockPhrase }.
+argument-hint: <path[,path...]> [unlock phrase]
+user-invocable: true
+allowed-tools: Bash, AskUserQuestion
+---
+
+# Protect
+
+Adds (or extends) a lock block: a set of protected paths paired with one unlock phrase. Speaking the phrase later temporarily lifts the lock for those paths.
+
+## Decision logic
+
+1. **Determine the paths.** From the user's request, collect the files/directories to protect. Paths may be:
+   - relative (resolved against the repo root): `package.json`, `.claude`, `src/config`
+   - home-anchored: `~/.claude`
+   - absolute: `/etc/something`
+   Files are matched exactly; directories protect everything beneath them.
+
+2. **Determine the unlock phrase.** If the user gave one, use it. Otherwise derive a short, memorable phrase from the intent (e.g. paths `package.json,playwright.config.ts` → `"edit repository config"`; path `.claude` → `"edit .claude"`). Confirm with `AskUserQuestion` only if ambiguous.
+
+3. **Pick the store.** Default to the highest-precedence active store. If none exists, tell the user to run `/heimdall:install` first (do not silently create one). Pass `--kind=<local|worktree|global>` only if the user specified.
+
+4. **Run the script:**
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-protect.js" --phrase="<phrase>" --paths="<comma,separated,paths>"
+   ```
+   Optional flags for directory locks:
+   - `--allowed="sub1,sub2"` — subdirs always writable (e.g. `plans,projects` under `.claude`)
+   - `--trusted="hooks,scripts"` — subdirs whose internal scripts are trusted (script-bypass exemption)
+
+5. Print the script output verbatim.
+
+If a block with the same phrase already exists, the new paths merge into it. To protect a different set of paths under a different phrase, run again with the new phrase.

--- a/plugins/heimdall/skills/unprotect/SKILL.md
+++ b/plugins/heimdall/skills/unprotect/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: unprotect
+description: Remove a Heimdall lock block or specific protected paths. Use when the user says "unprotect X", "unlock X permanently", "stop guarding X", "remove protection from X", "delete the lock for X", or asks to drop a protected path. Removes the lock from config (this is permanent removal, not the temporary phrase-based unlock).
+argument-hint: <unlock phrase> [path[,path...]]
+user-invocable: true
+allowed-tools: Bash, AskUserQuestion
+---
+
+# Unprotect
+
+Permanently removes protection from a Heimdall store. (This edits config — distinct from speaking the unlock phrase, which only lifts the lock for the current few tool calls.)
+
+## Decision logic
+
+1. **Identify the lock block** by its unlock phrase. If the user references paths but not the phrase, run `/heimdall:list` (or the list script) first to find the owning block, then confirm with `AskUserQuestion` which block they mean.
+
+2. **Decide scope:**
+   - Remove the whole block → pass only `--phrase`.
+   - Remove specific paths from a block → pass `--phrase` and `--paths` (the block is deleted if it becomes empty).
+
+3. **Run the script:**
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-unprotect.js" --phrase="<phrase>" [--paths="<comma,separated>"]
+   ```
+   Without `--kind`, it removes the matching block from every active store. Pass `--kind=<local|worktree|global>` to scope to one store.
+
+4. Print the script output verbatim.
+
+The store and its marker are never deleted — only lock blocks are removed.

--- a/plugins/work/scripts/run-tests.sh
+++ b/plugins/work/scripts/run-tests.sh
@@ -33,7 +33,7 @@ trap 'on_signal INT' INT
 trap 'on_signal TERM' TERM
 
 # Build space-separated file list (node --test expects positional args, not newlines)
-mapfile -t FILES < <(find plugins/work/scripts/workflows plugins/work/agents plugins/work/skills plugins/synapsys -type f \( -name '*.test.js' -o -name '*.spec.js' \) | sort)
+mapfile -t FILES < <(find plugins/work/scripts/workflows plugins/work/agents plugins/work/skills plugins/synapsys plugins/heimdall -type f \( -name '*.test.js' -o -name '*.spec.js' \) | sort)
 
 if [ -f "$SKIP_FILE" ]; then
   FILTERED=()

--- a/plugins/work/scripts/run-tests.sh
+++ b/plugins/work/scripts/run-tests.sh
@@ -33,7 +33,7 @@ trap 'on_signal INT' INT
 trap 'on_signal TERM' TERM
 
 # Build space-separated file list (node --test expects positional args, not newlines)
-mapfile -t FILES < <(find plugins/work/scripts/workflows plugins/work/agents plugins/work/skills plugins/synapsys plugins/heimdall -type f \( -name '*.test.js' -o -name '*.spec.js' \) | sort)
+mapfile -t FILES < <(find plugins -type d -name node_modules -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print | sort)
 
 if [ -f "$SKIP_FILE" ]; then
   FILTERED=()

--- a/plugins/work/scripts/run-tests.sh
+++ b/plugins/work/scripts/run-tests.sh
@@ -33,7 +33,11 @@ trap 'on_signal INT' INT
 trap 'on_signal TERM' TERM
 
 # Build space-separated file list (node --test expects positional args, not newlines)
-mapfile -t FILES < <(find plugins -type d -name node_modules -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print | sort)
+# Discover tests under any plugin (recursive), pruning node_modules. We also
+# prune plugins/work/hooks/__tests__: those orchestrator/session-state tests are
+# intentionally excluded from the suite (they share /tmp session-lock + workflow
+# state and flake when run concurrently with the other stateful work tests).
+mapfile -t FILES < <(find plugins -type d \( -name node_modules -o -path 'plugins/work/hooks' \) -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print | sort)
 
 if [ -f "$SKIP_FILE" ]; then
   FILTERED=()


### PR DESCRIPTION
## Existing Behavior

- File/directory protection is implemented as hand-rolled, path-hardcoded hook scripts with no shared abstraction and no user-configurable paths.
- Adding a new protected path requires writing a new hook file from scratch, with no unlock mechanism and no store model.
- There is no way to temporarily lift protection per-block without disabling the entire hook.

## Intended New Behavior

- A single heimdall plugin provides config-driven protection: lock blocks in `.heimdall.json` pair any set of paths (files or directories) with a per-block unlock phrase, replacing all hand-rolled guard hooks.
- Stores follow the same local / worktree / global model as synapsys, so protection travels with the repo or survives worktree deletion.
- A PreToolUse hook enforces locks across Edit, Write, MultiEdit, Bash (redirects, cp/mv/sed -i, interpreter invocations, script-bypass), and Task prompts (fail-closed unless read-only); /tmp paths are exempt.
- Speaking a block unlock phrase in chat temporarily lifts that block only; one phrase never unlocks another block. The hook is fail-open before any store exists and fail-closed once a store is configured and evaluation throws.

## What is included

**Plugin structure**
- `plugins/heimdall/.claude-plugin/plugin.json` — plugin manifest (version 0.1.0)
- `plugins/heimdall/hooks/heimdall.js` — PreToolUse dispatcher; discovers stores, merges lock blocks, calls the guard engine
- `plugins/heimdall/hooks/hooks.json` — registers three separate PreToolUse matchers: `Edit|Write|MultiEdit`, `Bash`, `Task`

**Guard engine** (`plugins/heimdall/lib/guard/`)
- `entries.js` — builds resolved entry objects from raw lock blocks; expands `~`, classifies files vs. directories
- `paths.js` — path resolution, directory-prefix matching, home expansion, allowedPaths checks
- `bash.js` — 50+ write-pattern templates (redirects, cp/mv/sed -i/interpreters/script-bypass), direction-sensitive read detection for cp/mv/rsync, cached per-marker regex compilation
- `task.js` — read-only Task prompt heuristic
- `transcript.js` — reads recent messages from the JSONL transcript; ignores tool_result entries to prevent self-unlock from the hook's own block message (regression fix)
- `scripts-bypass.js` — detects interpreter invocations that reference protected paths indirectly
- `evaluate.js` — orchestrates all checks and returns `{ exitCode: 0 }` (allow) or `{ exitCode: 2, message }` (block)

**Store layer** (`plugins/heimdall/lib/lock-store.js`)
- Discovers local (`./.claude/heimdall`), worktree (nearest ancestor `../.claude/heimdall`), and global (`~/.claude/heimdall/<project>`) stores; walks to the nearest ancestor so sub-directory sessions work correctly (mirrors the fix applied to synapsys in #428)

**Skills**
- `/heimdall:install [local|worktree|global]` — creates a store and scans for protectable paths using a catalog mirroring existing protectors; only suggests paths that exist and never suggests home-anchored paths for local/worktree installs
- `/heimdall:protect <paths> [phrase]` — adds or merges a lock block
- `/heimdall:unprotect <phrase> [paths]` — removes a block or specific paths from a block
- `/heimdall:list` — shows every store, block, unlock phrase, and resolved path

**Registration**
- `.claude-plugin/marketplace.json` — registers `heimdall` in the `safety` category
- `plugins/work/scripts/run-tests.sh` — adds `plugins/heimdall` to test discovery

## How it works

On each guarded tool call the hook:
1. Discovers all active stores for the current `cwd` and merges their lock blocks.
2. Resolves the tool target path(s) and matches against entries (file = exact, directory = prefix), with `/tmp` exempt.
3. For Bash: checks write intent via 50+ pattern templates per protected marker, plus global interpreter patterns, with a direction-sensitive read exemption for cp/mv/rsync.
4. For Task: blocks unless the prompt is classified as read-only.
5. Checks the JSONL transcript for the block unlock phrase in recent user messages, ignoring tool_result turns to prevent self-unlock.
6. Emits a structured AskUserQuestion prompt on block, or exits 0 to allow.

## Bugs fixed during development (already in this branch)

1. **Split PreToolUse matchers** — a single catch-all matcher did not intercept file-edit tools; now `Edit|Write|MultiEdit`, `Bash`, and `Task` are registered as separate entries in `hooks.json`.
2. **Self-unlock regression** — `findUnlockedPhrases` previously matched the hook's own block message when echoed back as a `tool_result`, causing the next tool call to pass through. Fixed by skipping tool_result content turns in transcript scanning, and by removing the unlock-phrase token from the block message itself.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The plugin ships 26 unit tests (via node:test) covering guard verdicts, file-vs-dir matching, unlock-phrase detection, the self-unlock regression, scan suggestions, and store discovery + scripts.

Run tests manually:

```
node --test plugins/heimdall/lib/__tests__/guard.test.js
node --test plugins/heimdall/lib/__tests__/lock-store.test.js
node --test plugins/heimdall/lib/__tests__/scan.test.js
```

Or via the repo test runner (discovers all plugins/heimdall tests):

```
./plugins/work/scripts/run-tests.sh
```

End-to-end install walkthrough:
1. Open a session in any repo.
2. Run `/heimdall:install local` — the skill scans for protectable paths and prompts you per-path with a suggested passphrase.
3. Run `/heimdall:list` to confirm the store and lock blocks.
4. Ask the assistant to edit a file inside a protected directory (e.g., `.claude/settings.json`) — the hook should block and call `AskUserQuestion` with the unlock phrase as option 1.
5. Confirm the unlock phrase in the `AskUserQuestion` response — the subsequent write should be allowed.
6. Verify that a read-only command (`cat .claude/settings.json`) is not blocked.
7. Protect a config file and verify that in-place edits (e.g., `sed -i`) are blocked while reads are not.

### Test Results

26 tests passing — guard.test.js (17), lock-store.test.js (5), scan.test.js (4). Biome check clean on all 22 plugin files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New PreToolUse gate can block legitimate edits/Bash/Task when misconfigured; transcript-based unlock and complex bash heuristics need careful review, though fail-open without a store and broad unit tests reduce blast radius.
> 
> **Overview**
> Adds the **heimdall** Claude Code plugin: a single config-driven guard that replaces scattered hand-rolled protect hooks. Lock blocks in `.heimdall.json` pair paths with per-block **unlock phrases**; a **PreToolUse** hook enforces them on `Edit`/`Write`/`MultiEdit`, **Bash** (redirects, `cp`/`mv`/`sed -i`, interpreters, external script-bypass), and **Task** (blocked unless read-only). Stores use **local / worktree / global** discovery (synapsys-style), merged at runtime; install scan suggests catalog targets that exist and skips already-locked paths.
> 
> **Skills/CLI:** `/heimdall:install`, `protect`, `unprotect`, `list` plus init/scan/protect scripts. **Marketplace** registers heimdall under `safety`. **`run-tests.sh`** now discovers `*.test.js` under all `plugins/` (prunes `node_modules` and flaky `plugins/work/hooks` tests) so heimdall’s **26** `node:test` specs run in the suite.
> 
> Unlock authorization reads only **user-authored** transcript text (not `tool_result`), blocking agent self-unlock. **Fail-open** with no configured store/locks; **fail-closed** when a store exists and evaluation throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac2dd65c7f17875f10650217dc909852f01d4a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->