### PR TITLE
fix(work): treat newline as command separator in node-invocation parser

### DIFF
--- a/plugins/work/scripts/workflows/lib/hooks/policies/__tests__/command-matching.test.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/__tests__/command-matching.test.js
@@ -48,6 +48,23 @@ describe('command-matching: getNodeInvocations', () => {
     assert.equal(captured, 'script.js');
   });
 
+  it('treats a newline as a command separator (cd on its own line)', () => {
+    const matches = getNodeInvocations('cd /some/dir\nnode script.js');
+    assert.equal(matches.length, 1);
+    const captured = matches[0][1] || matches[0][2] || matches[0][3];
+    assert.equal(captured, 'script.js');
+  });
+
+  it('treats CRLF as a command separator', () => {
+    const matches = getNodeInvocations('cd /some/dir\r\nnode script.js');
+    assert.equal(matches.length, 1);
+  });
+
+  it('matches node calls on separate lines', () => {
+    const matches = getNodeInvocations('node a.js\nnode b.js');
+    assert.equal(matches.length, 2);
+  });
+
   it('exposes a stable pattern source string', () => {
     assert.equal(typeof NODE_INVOKE_PATTERN_SRC, 'string');
     assert.ok(NODE_INVOKE_PATTERN_SRC.length > 10);

--- a/plugins/work/scripts/workflows/lib/hooks/policies/command-matching.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/command-matching.js
@@ -22,8 +22,12 @@
 // and bare `env [VAR=val ...] node ...` in addition to inline env-assignment.
 // Without this, agents using `timeout 90 node task-next.js ...` silently bypass
 // Rule 5 because the regex didn't recognize the wrapped invocation as a node call.
+// Command separators include newline/CR: multi-line Bash (e.g. `cd dir\nnode ...`)
+// must be parsed too — otherwise the node call after a newline is invisible, which
+// both breaks legitimate exemptions and lets newline-separated invocations evade
+// Rules 3b/5.
 const NODE_INVOKE_PATTERN_SRC =
-  '(?:^|&&|;|\\|)\\s*' +
+  '(?:^|&&|;|\\||\\n|\\r)\\s*' +
   // Optional wrapper commands (timeout, nice, env). All consume their args.
   '(?:timeout\\s+\\d+(?:\\.\\d+)?[smhdSMHD]?\\s+|' +
   'nice(?:\\s+-n\\s+-?\\d+)?\\s+|' +


### PR DESCRIPTION
## Existing Behavior

`getNodeInvocations()` in `command-matching.js` recognized only `^`, `&&`, `;`, and `|` as command separators. A bare newline character was not treated as a separator, so a multi-line Bash command like `cd dir\nnode script.js` produced zero matches — the `node` call after the newline was invisible to all gate hooks.

## Intended New Behavior

`\n` and `\r` are added to the separator alternation: `(?:^|&&|;||\n|\r)\s*`. All existing separators continue to work unchanged.

This closes two gaps:

- Legitimate exempt-script invocations (`work-next.js`, `task-next.js`, etc.) preceded by a `cd` on its own line are no longer wrongly blocked by the state-file protector.
- Newline-separated node invocations can no longer silently evade Rules 3b/5 enforcement (security gap closed).

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The fix is exercised by three new regression tests added to `policies/__tests__/command-matching.test.js`:

1. `cd /some/dir\nnode script.js` — expects 1 match capturing `script.js`
2. `cd /some/dir\r\nnode script.js` — CRLF separator, expects 1 match
3. `node a.js\nnode b.js` — two node calls on separate lines, expects 2 matches

Run locally:

```bash
cd plugins/work/scripts/workflows/lib/hooks/policies
node --test __tests__/command-matching.test.js
```

All new and existing command-matching tests should pass.

### Test Results

Three new regression tests added in `policies/__tests__/command-matching.test.js` covering `\n`, `\r\n`, and multi-line node calls. All existing tests continue to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens hook policy parsing for Bash commands used by Rules 3b/5; behavior change is small but security-relevant for workflow enforcement.
> 
> **Overview**
> **`getNodeInvocations()`** now treats **`\n` and `\r`** as Bash command separators (alongside `^`, `&&`, `;`, and `|`), so multi-line commands like `cd /dir` then `node script.js` are parsed correctly.
> 
> That fixes false blocks on legitimate exempt **`node`** calls after a `cd` on its own line and closes a gap where newline-separated **`node`** invocations could skip workflow **Rules 3b/5** in `enforce-step-workflow.js`. Three unit tests cover `\n`, CRLF, and multiple line-separated invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2436c0c1ed4d536911c57c138e78747cbc32e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->