### PR TITLE
fix(work): accept documentation-exempt tasks in RED gate via verification command

### DIFF
--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-docs-exempt.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-docs-exempt.test.js
@@ -1,0 +1,32 @@
+// Docs-exempt RED gate: documentation tasks have no testable code surface,
+// so they validate RED via their verification command instead of requiring a
+// *.test.* authorship file. See task-next.js `isDocsExempt()`.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isDocsExempt } = require('../task-next.js');
+
+test('isDocsExempt: true for explicit `docs` type', () => {
+  assert.equal(isDocsExempt('docs', '### Type\ndocs\n\nwhatever'), true);
+});
+
+test('isDocsExempt: true for "documentation exempt" marker in body', () => {
+  const section = '### Type\nfullstack\n\nDocs-only (no R/G/R — documentation exempt)';
+  assert.equal(isDocsExempt('fullstack', section), true);
+});
+
+test('isDocsExempt: true for "docs-only" marker regardless of type', () => {
+  assert.equal(isDocsExempt('backend', 'Docs-only task, prose only'), true);
+});
+
+test('isDocsExempt: false for a normal code task', () => {
+  assert.equal(isDocsExempt('backend', '### Type\nbackend\n\nImplement the resolver'), false);
+});
+
+test('isDocsExempt: tolerates missing/empty inputs', () => {
+  assert.equal(isDocsExempt('', ''), false);
+  assert.equal(isDocsExempt(undefined, undefined), false);
+});

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -225,6 +225,16 @@ function parseTaskType(section) {
   return (t || '').toLowerCase();
 }
 
+// Documentation tasks have no testable code surface — only prose files
+// (*.md, etc), so demanding a *.test.* authorship gate is contradictory.
+// They still run a real verification command (e.g. a grep asserting the docs
+// now contain the documented strings), so RED/GREEN are validated by that
+// command rather than by test-block authorship. Detected via an explicit
+// `docs` type or a "documentation exempt" / "docs-only" marker in the body.
+function isDocsExempt(type, section) {
+  return (type || '') === 'docs' || /documentation[\s-]*exempt|docs[-\s]?only/i.test(section || '');
+}
+
 function parseTaskTestCommand(section) {
   const m = section.match(/### *Test Command[^\n]*\n+```(?:[a-zA-Z]+)?\n([\s\S]*?)\n```/);
   return m ? m[1].trim() : '';
@@ -728,6 +738,7 @@ function main() {
   const scope = parseSuggestedScope(section);
   const type = parseTaskType(section);
   const taskTestCmd = parseTaskTestCommand(section);
+  const docsExempt = isDocsExempt(type, section);
 
   // Checkpoint tasks are verification-only — no source change, no test
   // authorship, no gherkin scenarios. Asking the agent to satisfy a TDD
@@ -868,7 +879,20 @@ function main() {
         // proving there is at least one failing test block under Suggested
         // Scope. The test command already failed (exitCode !== 0) above —
         // we just need to confirm authorship intent.
-        if (testFiles.length === 0) {
+        if (testFiles.length === 0 && docsExempt) {
+          // Docs-exempt: no test surface, but the verification command failed
+          // as RED requires (exitCode !== 0 confirmed above). Accept it.
+          const rec = recordEvidence(TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope);
+          if (!rec.ok) {
+            blockReason = `Could not record RED evidence:\n${rec.out}`;
+          } else {
+            advanced = true;
+            phase = TDD_PHASES.green;
+            process.stdout.write(
+              `task-next: RED accepted via docs-exempt fallback (documentation task — no testable code surface; verification command failed as required).\n`
+            );
+          }
+        } else if (testFiles.length === 0) {
           blockReason = `No gherkin scenarios tagged @task:${taskNum} AND no *.test.* / *.spec.* files found under Suggested Scope. Add at least one failing test in a file under Suggested Scope, then re-invoke me.`;
         } else {
           const { totalBlocks, filesWithBlocks } = countTestBlocksInFiles(testFiles);
@@ -972,7 +996,7 @@ function main() {
   process.exit(_exitCode);
 }
 
-module.exports = { filterToTestFiles, findTestFilesInScope, wrapStrictMode };
+module.exports = { filterToTestFiles, findTestFilesInScope, wrapStrictMode, isDocsExempt };
 
 if (require.main === module) {
   main();


### PR DESCRIPTION
## Existing Behavior

The TDD RED gate in `task-next.js` blocked unconditionally when a task had 0 gherkin scenarios and no `*.test.*` file under Suggested Scope. Only `type: checkpoint` was exempt. Documentation-only tasks (prose `.md` files, no code surface) were indistinguishable from undertested code tasks, causing an irresolvable block: the gate demanded test-block authorship for a task that has nothing to unit-test.

## Intended New Behavior

An exported `isDocsExempt(type, section)` helper returns `true` for an explicit `docs` type or a `documentation exempt` / `docs-only` marker in the task body. When a task is docs-exempt and the verification command exits non-zero (RED condition confirmed), the gate records RED evidence and advances to GREEN — no test-file authorship required. The verification command itself (e.g. a grep asserting the docs now contain the documented strings) acts as the RED signal. Normal code tasks are completely unaffected.

## Brief P0 coverage

- **P0 #1:** Docs-exempt tasks clear RED gate when verification command fails — implemented in `plugins/work/scripts/workflows/work-implement/task-next.js:738` + test `plugins/work/scripts/workflows/work-implement/__tests__/task-next-docs-exempt.test.js`

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Create a `/work` task with `### Type` set to `docs` (or include `documentation exempt` in the body) and a `### Test Command` that greps for a string not yet present in the target `.md` file.
2. Invoke `task-next.js` — the verification command should fail (exit non-zero), RED evidence should be recorded, and the gate should advance to GREEN without demanding any `*.test.*` file.
3. For a normal code task with no test files, confirm the gate still blocks with the original "No gherkin scenarios…" message.
4. Run the unit tests directly: `node --test plugins/work/scripts/workflows/work-implement/__tests__/task-next-docs-exempt.test.js` — all 5 assertions should pass.

### Test Results

`__tests__/task-next-docs-exempt.test.js` — 5 tests covering: explicit `docs` type, `documentation exempt` body marker, `docs-only` body marker, normal code task (returns false), and empty/undefined inputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow gate logic only; behavior is narrowly scoped to explicitly marked docs tasks and is covered by new unit tests.
> 
> **Overview**
> **Documentation-only work tasks** can now pass the TDD **RED** gate in `task-next.js` without authoring `*.test.*` files, using the same pattern as checkpoint tasks but staying on the normal RED→GREEN cycle.
> 
> A new **`isDocsExempt(type, section)`** helper treats tasks as docs-exempt when `Type` is `docs` or the task body matches `documentation exempt` / `docs-only`. For tasks with **no gherkin scenarios** and **no test files in scope**, if the task is docs-exempt and the **Test Command already failed** (RED), the runner records RED evidence and advances to GREEN instead of blocking on missing test authorship. **Code tasks are unchanged** when they lack tests.
> 
> Unit tests in `task-next-docs-exempt.test.js` cover detection rules and empty inputs; **`isDocsExempt`** is exported for testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be6402a5a8daa6b832259a9a1e50d17b6676d65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->