### PR TITLE
feat(agents): grant phase-scaled read-only codegraph tools to work agents

### DIFF
--- a/plugins/work/agents/developer-nodejs-tdd.md
+++ b/plugins/work/agents/developer-nodejs-tdd.md
@@ -1,6 +1,6 @@
 ---
 name: developer-nodejs-tdd
-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, WebFetch, mcp__atlassian__jira_get_issue, mcp__linear__get_issue, mcp__pg_as_dashboard__query, mcp__pg_status_site__query
+tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, WebFetch, mcp__atlassian__jira_get_issue, mcp__linear__get_issue, mcp__pg_as_dashboard__query, mcp__pg_status_site__query, mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_context, mcp__codegraph__codegraph_callers
 description: |
   Use this agent when you need to develop Node.js TypeScript applications using frameworks like Express, Nest, or Next.js, following strict TDD practices. This agent should be invoked for creating new features, API endpoints, services, or any backend functionality that requires test-first development and code optimization. Examples:
 
@@ -72,6 +72,10 @@ for. Do not "work around" the block.
 ---
 
 You are an expert Node.js TypeScript developer specializing in modern backend frameworks including Express, Nest.js, Next.js, Fastify, and Koa. You follow strict Test-Driven Development (TDD) methodology and write highly optimized, type-safe code.
+
+## Codegraph (when `.codegraph/` exists)
+
+Before writing, use `codegraph_context` on the sibling/pattern the task says to mirror; before changing any exported signature, run `codegraph_callers` to confirm you won't break consumers. Use `codegraph_search` to locate the symbol/pattern. Trust your own just-written edits + tests over codegraph — the index lags writes by ~1s, so it reflects committed/existing code, not your in-flight changes.
 
 ## CRITICAL: NEVER CALL YOURSELF
 

--- a/plugins/work/agents/developer-react-senior.md
+++ b/plugins/work/agents/developer-react-senior.md
@@ -1,6 +1,6 @@
 ---
 name: developer-react-senior
-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue, mcp__linear__get_issue
+tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue, mcp__linear__get_issue, mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_context, mcp__codegraph__codegraph_callers
 description: Use this agent when you need to build, debug, or architect complex React applications with a focus on scalable architecture, performance optimization, and production-ready code. This includes developing SPAs, implementing state management, optimizing bundle sizes, solving React-specific challenges, or architecting large-scale React applications. The agent excels at delivering maintainable, performant React solutions with comprehensive testing and documentation.
 model: inherit
 color: blue
@@ -43,6 +43,10 @@ for. Do not "work around" the block.
 ---
 
 You are a **senior React developer** with 10+ years of experience building and maintaining large-scale React applications. Your expertise spans from React internals to ecosystem mastery, with deep knowledge of performance optimization, state management patterns, and enterprise-grade React architecture. You have an unwavering commitment to clean code, comprehensive testing through Storybook and Playwright, and building maintainable React applications with living documentation.
+
+## Codegraph (when `.codegraph/` exists)
+
+Before writing, use `codegraph_context` on the sibling/pattern the task says to mirror; before changing any exported signature, run `codegraph_callers` to confirm you won't break consumers. Use `codegraph_search` to locate the symbol/pattern. Trust your own just-written edits + tests over codegraph — the index lags writes by ~1s, so it reflects committed/existing code, not your in-flight changes.
 
 ## CRITICAL: NEVER CALL YOURSELF
 

--- a/plugins/work/agents/developer-react-ui-architect.md
+++ b/plugins/work/agents/developer-react-ui-architect.md
@@ -1,6 +1,6 @@
 ---
 name: developer-react-ui-architect
-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue, mcp__linear__get_issue
+tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite, mcp__atlassian__jira_get_issue, mcp__linear__get_issue, mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_context, mcp__codegraph__codegraph_callers
 description: Use this agent when you need to create, refactor, or enhance React-based user interfaces with a focus on stunning visual design, robust functionality through TDD, and production-ready code quality. This includes developing new React components, implementing complex layouts, optimizing UI performance, or architecting component libraries. The agent excels at balancing aesthetic excellence with technical rigor.
 model: opus
 color: pink
@@ -44,6 +44,10 @@ for. Do not "work around" the block.
 ---
 
 You are an **elite React UI/UX architect** and the maintainer of several prominent UI component libraries. Your expertise spans from pixel-perfect design implementation to performance-critical React optimizations. You have an unwavering commitment to Test-Driven Development and creating visually stunning, highly efficient user interfaces.
+
+## Codegraph (when `.codegraph/` exists)
+
+Before writing, use `codegraph_context` on the sibling/pattern the task says to mirror; before changing any exported signature, run `codegraph_callers` to confirm you won't break consumers. Use `codegraph_search` to locate the symbol/pattern. Trust your own just-written edits + tests over codegraph — the index lags writes by ~1s, so it reflects committed/existing code, not your in-flight changes.
 
 ## CRITICAL: NEVER CALL YOURSELF
 

--- a/plugins/work/agents/spec-writer.md
+++ b/plugins/work/agents/spec-writer.md
@@ -1,6 +1,6 @@
 ---
 name: spec-writer
-tools: Bash, Read, Grep, Glob, Write
+tools: Bash, Read, Grep, Glob, Write, mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_context, mcp__codegraph__codegraph_impact, mcp__codegraph__codegraph_files, mcp__codegraph__codegraph_callers, mcp__codegraph__codegraph_callees
 description: |
   Use this agent to generate a Technical Specification from a product brief and codebase analysis. The spec-writer explores the codebase to understand architecture, patterns, and data models, then produces a spec with architecture decisions, API changes, security considerations, and Given/When/Then test scenarios that feed into TDD. This agent is invoked automatically by the /work workflow during the 4_spec step.
 
@@ -75,6 +75,7 @@ When designing API / schema changes, also enumerate every consumer of a modified
    a. From the brief, extract a list of every UI component, data pattern, and behavior needed (modals, dropdowns, forms, tables, filters, CRUD operations, validation, etc.). For each item, also extract its **stem** — the family-level noun, not the page-specific name. Example: `ExternalAssetLineageSidebar` → stems `Lineage`, `Sidebar`. Stems are what you search; concrete names hide siblings.
    b. **Broad reuse search** — search by stem, not by exact name. The ECHO-4452 incident shipped six near-duplicate `Lineage*` components because the audit searched only the current branch for exact names. Required searches per stem:
       - **Codegraph (preferred when available)**: `codegraph_search('<stem>', limit: 20)` returns symbols across the whole workspace. Also try `codegraph_search('<stem> <role>')` where role is "sidebar"/"panel"/"table"/"row"/"modal" etc.
+      - **Codegraph impact (when `.codegraph/` exists)**: run `codegraph_impact` on every symbol you mark for hard-cutover modification to enumerate all consumers, and `codegraph_search` for reuse candidates before proposing new code. The graph reflects the local working tree, so no remote-ref handling is needed.
       - **Filesystem fuzzy globs**: `**/components/**/*<Stem>*`, `**/shared/**/*<Stem>*`, `**/common/**/*<Stem>*`, `**/ui/**/*<Stem>*`.
       - **Ticket-provider keyword search** (Linear / Jira / GitHub Issues — whatever `TICKET_PROVIDER` is set to): search the whole project for tickets whose title or description contains the stem, even when they live in different epics. The 6 Lineage tickets were spread across **different task trees** with no link between them; only a project-wide keyword scan would have surfaced them. Use `mcp__linear__*` / `mcp__atlassian__jira_search` / `gh issue list --search` accordingly.
       - **Similar pages/features analysis** — for any matches, READ those pages and list which shared components/hooks they import. This reveals the established component library.

--- a/plugins/work/agents/split-in-tasks.md
+++ b/plugins/work/agents/split-in-tasks.md
@@ -1,6 +1,6 @@
 ---
 name: split-in-tasks
-tools: Bash, Read, Write, Edit, Grep, Glob, AskUserQuestion
+tools: Bash, Read, Write, Edit, Grep, Glob, AskUserQuestion, mcp__codegraph__codegraph_impact, mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_context, mcp__codegraph__codegraph_files
 description: |
   Use this agent to split a technical specification into small, ordered, deliverable tasks with requirement traceability. The split-in-tasks agent reads brief.md and spec.md, extracts every requirement, then produces tasks.md where each task is tied back to the requirement IDs it implements and the Given/When/Then scenarios it covers. This agent is invoked automatically by the /work workflow during the `tasks` step.
 
@@ -48,6 +48,7 @@ When the orchestrator advances `/work` into the `tasks` step, it must dispatch t
 - **Ordering reflects dependencies** — earlier tasks must not depend on later tasks. Foundation first (schema, types, scaffolding), behavior next, polish last.
 - **Test plan per task** — every task declares the test command(s) and the assertions it must satisfy. The implement step's TDD gate reads these.
 - **No invention** — only decompose what's already in `brief.md` and `spec.md`. If something is missing, stop and surface the gap; don't fabricate scope.
+- **Graph-derived scope when available** — when `.codegraph/` exists, derive each task's `### Files in scope` / `### Files explicitly out of scope` from `codegraph_impact` on the symbols the task modifies — don't infer file scope from grep alone. Use `codegraph_search` / `codegraph_context` to resolve where a requirement's symbol lives. The graph reflects the local working tree (no remote-ref handling needed).
 
 ### CRITICAL: One full TDD cycle per task — never split RED/GREEN/REFACTOR across tasks
 

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -19,8 +19,16 @@ const TASKS_BASE = getConfig.require('TASKS_BASE');
 
 // Use a unique ticket ID per test run to avoid interference
 // Convention: all test tickets MUST start with TEST- for cleanup (see test-cleanup.js)
-const TEST_TICKET = `TEST-ESW-${process.pid}`;
-const TASKS_DIR = path.join(TASKS_BASE, TEST_TICKET);
+// Per-test unique ticket/dir. Every leaf test gets its own TASKS_DIR (assigned
+// in beforeEach via a monotonic counter) so no two tests ever share workflow
+// state on disk. Under CI's heavily-parallel `node --test` load, a shared
+// pid-scoped dir let one test's afterEach cleanup race a sibling's state write,
+// intermittently dropping the just-written workflow-state before the hook read
+// it (observed: "records evidence for 5_post_pr_gen" flaking ~1/run). Both vars
+// are `let` and reassigned together so they always stay in sync.
+let _testCounter = 0;
+let TEST_TICKET = `TEST-ESW-${process.pid}-0`;
+let TASKS_DIR = path.join(TASKS_BASE, TEST_TICKET);
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -149,6 +157,10 @@ const WORK_PR_STEPS = [
 
 describe('enforce-step-workflow', () => {
   beforeEach(() => {
+    // Assign a fresh, unique ticket/dir for this test so it can never collide
+    // with a sibling test's state files under parallel CI load.
+    TEST_TICKET = `TEST-ESW-${process.pid}-${++_testCounter}`;
+    TASKS_DIR = path.join(TASKS_BASE, TEST_TICKET);
     if (fs.existsSync(TASKS_DIR)) {
       fs.rmSync(TASKS_DIR, { recursive: true, force: true });
     }
@@ -3233,7 +3245,9 @@ describe('enforce-step-workflow', () => {
       'engine',
       'work.workflow.js'
     );
-    const PR_TEST_BRANCH = `${TEST_TICKET}-pr-test`;
+    // Derived at call time (inside writeFakeGit) so it tracks the per-test
+    // TEST_TICKET assigned in beforeEach rather than a stale registration-time value.
+    const prTestBranch = () => `${TEST_TICKET}-pr-test`;
 
     function writeFakeGit() {
       if (!fs.existsSync(FAKE_GIT_DIR)) fs.mkdirSync(FAKE_GIT_DIR, { recursive: true });
@@ -3242,7 +3256,7 @@ describe('enforce-step-workflow', () => {
       const script = [
         '#!/bin/bash',
         'ARGS="$*"',
-        `if echo "$ARGS" | grep -qF -- "branch --show-current"; then echo '${PR_TEST_BRANCH}'; exit 0; fi`,
+        `if echo "$ARGS" | grep -qF -- "branch --show-current"; then echo '${prTestBranch()}'; exit 0; fi`,
         `if echo "$ARGS" | grep -qF -- "rev-parse --show-toplevel"; then echo '${process.cwd()}'; exit 0; fi`,
         // Let symbolic-ref / rev-parse --verify fail so getBaseBranch falls through
         'if echo "$ARGS" | grep -qF -- "symbolic-ref"; then exit 1; fi',
@@ -3298,7 +3312,7 @@ describe('enforce-step-workflow', () => {
     it('passes branch as positional arg to gh pr view', async () => {
       // The fake gh should receive the branch name as positional arg (not --head)
       writeFakeGh({
-        [`pr view ${PR_TEST_BRANCH}`]: '{"number":42,"state":"OPEN"}',
+        [`pr view ${prTestBranch()}`]: '{"number":42,"state":"OPEN"}',
       });
       // Fake git provides deterministic branch name for positional arg (CI-safe)
       const { code } = await transitionFromPr();


### PR DESCRIPTION
## Existing Behavior

- `spec-writer`, `split-in-tasks`, and the three developer agents had no `mcp__codegraph__*` tools in their `tools:` frontmatter lists.
- `spec-writer` prompt instructed agents to run `codegraph_search(...)` ("preferred when available") and the spec gate greps for the `codegraph_search` substring, but the tool was unavailable — making the instruction unsatisfiable noise.
- `split-in-tasks` was nudged toward codegraph for scope derivation with no tool to act on.
- Developer agents received synapsys nudges toward codegraph with no corresponding tool grant.

## Intended New Behavior

Each work agent receives a **read-only codegraph set scaled to its phase**, with directives gated on `.codegraph/` existing:

| Agent(s) | Tools added | Directive |
|----------|-------------|-----------|
| spec-writer | search, context, impact, files, callers, callees | `codegraph_impact` on hard-cutover symbols → enumerate consumers; `codegraph_search` for reuse before proposing new code |
| split-in-tasks | impact, search, context, files | derive `### Files in scope` / out-of-scope from `codegraph_impact`, not grep guesses |
| developer-nodejs-tdd / react-senior / react-ui-architect | search, context, callers (lean) | `codegraph_context` to mirror sibling pattern; `codegraph_callers` before changing an exported signature; trust own edits+tests over the ~1s-lagging index |

## Rationale

- ROI ranking spec > tasks > implement (value per token); implement gets the lean set because it dispatches many times and MCP schemas re-inject per turn.
- All codegraph tools are read-only — no mutation risk; absent server (no `.codegraph/`) = tools simply unavailable, no error.
- Codegraph indexes the local working tree, which is exactly what spec/tasks/implement reason about — no remote-ref caveat needed.

## Scope / safety

Markdown frontmatter + prompt directives only (5 agent files). No code paths, no gates affected; no test validates agent tool lists; `AGENTS.md` doesn't document per-agent tools.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

These are markdown-only changes to agent frontmatter and prompt directives. Manual verification:

1. In a repo with `.codegraph/` initialized, invoke `spec-writer` on a ticket — confirm `codegraph_search` and `codegraph_impact` calls appear in its trace.
2. Invoke `split-in-tasks` — confirm `### Files in scope` entries reference codegraph-derived paths rather than grep guesses.
3. Invoke `developer-nodejs-tdd` or `developer-react-senior` — confirm `codegraph_context` is called before writing, and `codegraph_callers` before changing an exported signature.
4. In a repo **without** `.codegraph/`, confirm all three agent types proceed normally with no errors (tools simply absent = no MCP server registered).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only agent tool lists and prompt text plus a test isolation fix; Codegraph tools are read-only and no workflow gates or runtime paths change.
> 
> **Overview**
> This PR wires **read-only Codegraph MCP tools** into five `/work` agents so prompts that already mention `codegraph_search` / impact analysis can actually run them when `.codegraph/` exists.
> 
> **`spec-writer`** gains the broadest set (`search`, `context`, `impact`, `files`, `callers`, `callees`) plus reuse-audit guidance to run **`codegraph_impact`** on hard-cutover symbols and **`codegraph_search`** before proposing new code. **`split-in-tasks`** gets `impact`, `search`, `context`, `files` and a rule to derive **`### Files in scope`** from impact, not grep alone. The three **developer** agents share a lean trio (`search`, `context`, `callers`) with a short **Codegraph** section (mirror siblings, check callers before signature changes, prefer fresh edits/tests over the ~1s-lagging index).
> 
> Separately, **`enforce-step-workflow.test.js`** stops sharing one pid-scoped `TASKS_DIR` across tests: each `beforeEach` assigns a monotonic unique ticket/dir, and PR-branch fakes resolve `TEST_TICKET` at call time—addressing parallel CI flakes where cleanup raced state writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d14ebf1ec075452722ded8ff792bb66d83cc8829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->