### PR TITLE
feat(synapsys): add cross-project shared memory tier

### DIFF
--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -4,13 +4,14 @@ Context-triggered memory injection plugin.
 
 Memories are markdown files with frontmatter that declares **which events** they listen to (`SessionStart`, `UserPromptSubmit`, `PreToolUse`) and **which trigger patterns** activate them. When an event fires and a memory's trigger matches the payload, the memory is injected into Claude's context.
 
-## Three storage tiers
+## Four storage tiers
 
 | Kind | Path | When to use |
 |---|---|---|
 | local | `./.claude/synapsys/` | This repo only — commit or gitignore as you like |
 | worktree | `../.claude/synapsys/` | Shared across all worktrees of this repo |
 | global | `~/.claude/synapsys/<project-name>/` | User-scoped, follows the project name (`git rev-parse --show-toplevel` basename) |
+| shared | `~/.claude/synapsys/_shared/` | User-scoped, reused across **every** project — discovered regardless of cwd or project name |
 
 A store is "active" once it contains a `.synapsys.json` marker (written by `synapsys-init.js`). The dispatcher reads from every active store on every event, so multiple tiers coexist.
 
@@ -48,7 +49,7 @@ Next time you ask Claude to run `git push ...`, the PreToolUse hook fires, match
 - `hooks/hooks.json` — Claude Code hook registrations
 - `lib/memory-store.js` — store discovery + frontmatter parser
 - `lib/matcher.js` — event/payload matchers
-- `scripts/synapsys-init.js` — `--kind=<local|worktree|global>`
+- `scripts/synapsys-init.js` — `--kind=<local|worktree|global|shared>`
 - `scripts/synapsys-list.js` — list every discovered memory with its triggers
 - `skills/synapsys/SKILL.md` — `/synapsys` slash command (init, list, new)
 

--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -11,7 +11,7 @@ Memories are markdown files with frontmatter that declares **which events** they
 | local | `./.claude/synapsys/` | This repo only — commit or gitignore as you like |
 | worktree | `../.claude/synapsys/` | Shared across all worktrees of this repo |
 | global | `~/.claude/synapsys/<project-name>/` | User-scoped, follows the project name (`git rev-parse --show-toplevel` basename) |
-| shared | `~/.claude/synapsys/_shared/` | User-scoped, reused across **every** project — discovered regardless of cwd or project name |
+| shared | `~/.claude/synapsys-shared/` | User-scoped, reused across **every** project — discovered regardless of cwd or project name |
 
 A store is "active" once it contains a `.synapsys.json` marker (written by `synapsys-init.js`). The dispatcher reads from every active store on every event, so multiple tiers coexist.
 

--- a/plugins/synapsys/hooks/synapsys.js
+++ b/plugins/synapsys/hooks/synapsys.js
@@ -59,7 +59,7 @@ const SETUP_REQUIRED_HINT =
   'AGENT: As your FIRST action this session, surface this to the user and offer to run `/synapsys:install`. Recommend the kind based on context:\n' +
   '  - If `git worktree list` shows >1 entry → recommend `worktree` (shared across all worktrees of this repo)\n' +
   '  - Otherwise → recommend `local`\n' +
-  '  - Mention `global` as an option that survives worktree deletion\n\n' +
+  '  - Mention `global` (per-project, survives worktree deletion) and `shared` (one store reused across ALL projects) as options\n\n' +
   'Do NOT install without asking — present the recommendation via `AskUserQuestion` so the user can confirm or choose differently. If the user declines, set SYNAPSYS_NO_SETUP_HINT=1 to silence this prompt for future sessions.';
 
 function emptyStoreHint(stores) {

--- a/plugins/synapsys/lib/__tests__/shared-store.test.js
+++ b/plugins/synapsys/lib/__tests__/shared-store.test.js
@@ -1,0 +1,111 @@
+// Behavioral tests for the cross-project "shared" memory tier.
+//
+// The shared store lives at `~/.claude/synapsys/_shared/` and must be
+// discovered for EVERY project — regardless of cwd or project name. These
+// tests pin HOME to a temp dir (Node's os.homedir() honours $HOME on POSIX)
+// so discovery resolves into a fixture instead of the real home directory.
+//
+// Discovered by plugins/work/scripts/run-tests.sh (searches plugins/synapsys/).
+// Manual: node --test plugins/synapsys/lib/__tests__/shared-store.test.js
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { discoverStores, listMemoriesFromStore, SHARED_DIRNAME } = require(
+  path.resolve(__dirname, '..', 'memory-store')
+);
+const { selectForEvent } = require(path.resolve(__dirname, '..', 'matcher'));
+
+// Skip when the platform doesn't resolve os.homedir() from $HOME (non-POSIX),
+// since the fixture relies on overriding it.
+const HOME_DRIVEN = process.platform !== 'win32';
+
+let home;
+let originalHome;
+let sharedDir;
+// Two unrelated project cwds — the shared store must surface for both.
+let projectA;
+let projectB;
+
+before(() => {
+  originalHome = process.env.HOME;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-shared-'));
+  process.env.HOME = home;
+
+  sharedDir = path.join(home, '.claude', 'synapsys', SHARED_DIRNAME);
+  fs.mkdirSync(sharedDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(sharedDir, '.synapsys.json'),
+    JSON.stringify({ kind: 'shared', schemaVersion: 1 })
+  );
+  fs.writeFileSync(
+    path.join(sharedDir, 'no-force-push.md'),
+    [
+      '---',
+      'name: no-force-push',
+      'description: never force-push to a shared branch',
+      'events: UserPromptSubmit,PreToolUse',
+      'trigger_prompt: \\bforce[- ]?push\\b',
+      'trigger_pretool: Bash:git\\s+push\\s+--force',
+      'inject: full',
+      '---',
+      'Never force-push to main or shared branches.',
+    ].join('\n')
+  );
+
+  projectA = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-projA-'));
+  projectB = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-projB-'));
+});
+
+after(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  for (const d of [home, projectA, projectB]) {
+    if (d) fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe('shared store discovery', { skip: !HOME_DRIVEN }, () => {
+  it('is discovered from one project', () => {
+    const stores = discoverStores(projectA);
+    const shared = stores.find((s) => s.kind === 'shared');
+    assert.ok(shared, 'shared store should be discovered');
+    assert.equal(path.resolve(shared.dir), path.resolve(sharedDir));
+  });
+
+  it('is discovered from an unrelated second project (cross-project)', () => {
+    const stores = discoverStores(projectB);
+    assert.ok(
+      stores.some((s) => s.kind === 'shared'),
+      'shared store should surface for every project'
+    );
+  });
+});
+
+describe('shared store injection', { skip: !HOME_DRIVEN }, () => {
+  function matchedNames(cwd, event, payload) {
+    const memories = discoverStores(cwd).flatMap(listMemoriesFromStore);
+    return selectForEvent(memories, event, payload).map((m) => m.name);
+  }
+
+  it('injects a matching memory on UserPromptSubmit from any project', () => {
+    assert.deepEqual(matchedNames(projectA, 'UserPromptSubmit', { prompt: 'should I force-push?' }), [
+      'no-force-push',
+    ]);
+  });
+
+  it('injects a matching memory on PreToolUse from any project', () => {
+    const names = matchedNames(projectB, 'PreToolUse', {
+      tool_name: 'Bash',
+      tool_input: { command: 'git push --force origin main' },
+    });
+    assert.deepEqual(names, ['no-force-push']);
+  });
+
+  it('does NOT inject for a non-matching prompt (control)', () => {
+    assert.deepEqual(matchedNames(projectA, 'UserPromptSubmit', { prompt: 'xyzzy plugh' }), []);
+  });
+});

--- a/plugins/synapsys/lib/__tests__/shared-store.test.js
+++ b/plugins/synapsys/lib/__tests__/shared-store.test.js
@@ -1,6 +1,6 @@
 // Behavioral tests for the cross-project "shared" memory tier.
 //
-// The shared store lives at `~/.claude/synapsys/_shared/` and must be
+// The shared store lives at `~/.claude/synapsys-shared/` and must be
 // discovered for EVERY project — regardless of cwd or project name. These
 // tests pin HOME to a temp dir (Node's os.homedir() honours $HOME on POSIX)
 // so discovery resolves into a fixture instead of the real home directory.
@@ -14,7 +14,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { discoverStores, listMemoriesFromStore, SHARED_DIRNAME } = require(
+const { discoverStores, listMemoriesFromStore, SHARED_FOLDER } = require(
   path.resolve(__dirname, '..', 'memory-store')
 );
 const { selectForEvent } = require(path.resolve(__dirname, '..', 'matcher'));
@@ -35,7 +35,7 @@ before(() => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-shared-'));
   process.env.HOME = home;
 
-  sharedDir = path.join(home, '.claude', 'synapsys', SHARED_DIRNAME);
+  sharedDir = path.join(home, '.claude', SHARED_FOLDER);
   fs.mkdirSync(sharedDir, { recursive: true });
   fs.writeFileSync(
     path.join(sharedDir, '.synapsys.json'),
@@ -82,6 +82,34 @@ describe('shared store discovery', { skip: !HOME_DRIVEN }, () => {
       stores.some((s) => s.kind === 'shared'),
       'shared store should surface for every project'
     );
+  });
+});
+
+describe('shared store does not collide with the per-project namespace', { skip: !HOME_DRIVEN }, () => {
+  it('keeps global and shared distinct even for a project named like the shared folder', () => {
+    // A project whose basename matches SHARED_FOLDER must NOT shadow the shared
+    // store: global lives under `synapsys/<name>/`, shared is a sibling of
+    // `synapsys/`, so the two paths can never resolve to the same directory.
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-collide-'));
+    const projectCwd = path.join(parent, SHARED_FOLDER);
+    fs.mkdirSync(projectCwd, { recursive: true });
+
+    const globalDir = path.join(home, '.claude', 'synapsys', SHARED_FOLDER);
+    fs.mkdirSync(globalDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(globalDir, '.synapsys.json'),
+      JSON.stringify({ kind: 'global', projectName: SHARED_FOLDER, schemaVersion: 1 })
+    );
+
+    const stores = discoverStores(projectCwd);
+    const shared = stores.find((s) => s.kind === 'shared');
+    const global = stores.find((s) => s.kind === 'global');
+    assert.ok(shared, 'shared store should still be discovered');
+    assert.ok(global, 'global store should still be discovered');
+    assert.notEqual(path.resolve(shared.dir), path.resolve(global.dir));
+
+    fs.rmSync(parent, { recursive: true, force: true });
+    fs.rmSync(globalDir, { recursive: true, force: true });
   });
 });
 

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -76,7 +76,9 @@ function discoverStores(cwd) {
     if (seen.has(key)) return;
     if (!fs.existsSync(path.join(dir, MARKER))) return;
     seen.add(key);
-    out.push({ kind, dir, projectName });
+    // The shared store is cross-project, so it must not be stamped with the
+    // caller's projectName (mirrors the marker written by synapsys-init.js).
+    out.push({ kind, dir, projectName: kind === 'shared' ? null : projectName });
   };
 
   // local: store inside the cwd itself.

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -7,11 +7,12 @@ const { execSync } = require('node:child_process');
 
 const MARKER = '.synapsys.json';
 const FOLDER = 'synapsys';
-// Reserved sub-directory under ~/.claude/synapsys for the cross-project
-// "shared" tier. Leading underscore keeps it from colliding with a real
-// project name (basename of a git toplevel), which the per-project "global"
-// tier uses as its directory name.
-const SHARED_DIRNAME = '_shared';
+// Dedicated directory for the cross-project "shared" tier. It sits OUTSIDE
+// the per-project `~/.claude/synapsys/<project>/` namespace so it can never
+// collide with a project whose name happens to match — git imposes no
+// restriction on directory names, so a sibling under `synapsys/` would not
+// be collision-proof.
+const SHARED_FOLDER = `${FOLDER}-shared`;
 
 // Pass cwd through to execSync so git resolves relative to the caller's path,
 // not the host process's cwd. Mirrors the pattern in
@@ -42,7 +43,7 @@ function candidateStores(cwd, projectName) {
     { kind: 'local', dir: path.join(cwd, '.claude', FOLDER) },
     { kind: 'worktree', dir: path.resolve(cwd, '..', '.claude', FOLDER) },
     { kind: 'global', dir: path.join(os.homedir(), '.claude', FOLDER, projectName) },
-    { kind: 'shared', dir: path.join(os.homedir(), '.claude', FOLDER, SHARED_DIRNAME) },
+    { kind: 'shared', dir: path.join(os.homedir(), '.claude', SHARED_FOLDER) },
   ];
 }
 
@@ -95,8 +96,9 @@ function discoverStores(cwd) {
   push('global', path.join(os.homedir(), '.claude', FOLDER, projectName));
 
   // shared: cross-project store under home — discovered for every project,
-  // regardless of cwd or project name.
-  push('shared', path.join(os.homedir(), '.claude', FOLDER, SHARED_DIRNAME));
+  // regardless of cwd or project name. Lives outside the per-project
+  // namespace so it can never collide with a same-named project's global store.
+  push('shared', path.join(os.homedir(), '.claude', SHARED_FOLDER));
 
   return out;
 }
@@ -196,7 +198,7 @@ function toList(v) {
 module.exports = {
   MARKER,
   FOLDER,
-  SHARED_DIRNAME,
+  SHARED_FOLDER,
   getProjectName,
   candidateStores,
   discoverStores,

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -7,6 +7,11 @@ const { execSync } = require('node:child_process');
 
 const MARKER = '.synapsys.json';
 const FOLDER = 'synapsys';
+// Reserved sub-directory under ~/.claude/synapsys for the cross-project
+// "shared" tier. Leading underscore keeps it from colliding with a real
+// project name (basename of a git toplevel), which the per-project "global"
+// tier uses as its directory name.
+const SHARED_DIRNAME = '_shared';
 
 // Pass cwd through to execSync so git resolves relative to the caller's path,
 // not the host process's cwd. Mirrors the pattern in
@@ -37,6 +42,7 @@ function candidateStores(cwd, projectName) {
     { kind: 'local', dir: path.join(cwd, '.claude', FOLDER) },
     { kind: 'worktree', dir: path.resolve(cwd, '..', '.claude', FOLDER) },
     { kind: 'global', dir: path.join(os.homedir(), '.claude', FOLDER, projectName) },
+    { kind: 'shared', dir: path.join(os.homedir(), '.claude', FOLDER, SHARED_DIRNAME) },
   ];
 }
 
@@ -85,6 +91,10 @@ function discoverStores(cwd) {
 
   // global: per-project store under home.
   push('global', path.join(os.homedir(), '.claude', FOLDER, projectName));
+
+  // shared: cross-project store under home — discovered for every project,
+  // regardless of cwd or project name.
+  push('shared', path.join(os.homedir(), '.claude', FOLDER, SHARED_DIRNAME));
 
   return out;
 }
@@ -184,6 +194,7 @@ function toList(v) {
 module.exports = {
   MARKER,
   FOLDER,
+  SHARED_DIRNAME,
   getProjectName,
   candidateStores,
   discoverStores,

--- a/plugins/synapsys/scripts/synapsys-init.js
+++ b/plugins/synapsys/scripts/synapsys-init.js
@@ -39,9 +39,11 @@ if (!target) {
 
 fs.mkdirSync(target.dir, { recursive: true });
 const markerPath = path.join(target.dir, MARKER);
+// The shared store is cross-project, so its marker must NOT be stamped with
+// whichever project happened to run init first. Omit projectName for shared.
 const marker = {
   kind: args.kind,
-  projectName,
+  ...(args.kind === 'shared' ? {} : { projectName }),
   createdAt: new Date().toISOString(),
   schemaVersion: 1,
 };

--- a/plugins/synapsys/scripts/synapsys-init.js
+++ b/plugins/synapsys/scripts/synapsys-init.js
@@ -4,7 +4,7 @@
 /**
  * Initialize a Synapsys memory store.
  *
- *   node synapsys-init.js --kind=<local|worktree|global> [--cwd=<path>]
+ *   node synapsys-init.js --kind=<local|worktree|global|shared> [--cwd=<path>]
  *
  * Creates the directory (if missing) and writes a `.synapsys.json` marker.
  * The marker is what makes the directory discoverable by the hooks —
@@ -33,7 +33,7 @@ const projectName = getProjectName(args.cwd);
 const target = candidateStores(args.cwd, projectName).find((c) => c.kind === args.kind);
 
 if (!target) {
-  console.error(`unknown kind: ${args.kind} (use local|worktree|global)`);
+  console.error(`unknown kind: ${args.kind} (use local|worktree|global|shared)`);
   process.exit(1);
 }
 
@@ -49,10 +49,13 @@ fs.writeFileSync(markerPath, `${JSON.stringify(marker, null, 2)}\n`);
 
 const indexPath = path.join(target.dir, 'INDEX.md');
 if (!fs.existsSync(indexPath)) {
+  // The shared store is cross-project; its INDEX should not be labelled with
+  // the project the init happened to run from.
+  const scopeLabel = args.kind === 'shared' ? 'all projects' : projectName;
   fs.writeFileSync(
     indexPath,
     [
-      `# Synapsys memories — ${projectName} (${args.kind})`,
+      `# Synapsys memories — ${scopeLabel} (${args.kind})`,
       '',
       'One memory per file. Frontmatter declares triggers + lifecycle events.',
       'Example schema (single-line values only — no nested YAML):',
@@ -75,6 +78,5 @@ if (!fs.existsSync(indexPath)) {
   );
 }
 
-console.log(
-  `initialized synapsys store at ${target.dir} (kind=${args.kind}, project=${projectName})`
-);
+const scopeNote = args.kind === 'shared' ? 'scope=all projects' : `project=${projectName}`;
+console.log(`initialized synapsys store at ${target.dir} (kind=${args.kind}, ${scopeNote})`);

--- a/plugins/synapsys/scripts/synapsys-memorize.js
+++ b/plugins/synapsys/scripts/synapsys-memorize.js
@@ -13,7 +13,7 @@
  *     [--pretool=<Tool:argRegex,Tool:argRegex>] \
  *     [--session=true|false] \
  *     [--inject=full|summary] \
- *     [--store=<local|worktree|global>] \
+ *     [--store=<local|worktree|global|shared>] \
  *     [--force]                              # overwrite if exists
  *     [--cwd=<path>]
  *

--- a/plugins/synapsys/skills/install/SKILL.md
+++ b/plugins/synapsys/skills/install/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: install
-description: Configure Synapsys memory storage. Use when the user says "install synapsys", "set up memory", "set up synapsys", "configure memory", "create memory store", "initialize memory", or asks to start using the memory system. Picks local (./.claude/synapsys), worktree (../.claude/synapsys), or global (~/.claude/synapsys/<project>).
-argument-hint: [local|worktree|global]
+description: Configure Synapsys memory storage. Use when the user says "install synapsys", "set up memory", "set up synapsys", "configure memory", "create memory store", "initialize memory", or asks to start using the memory system. Picks local (./.claude/synapsys), worktree (../.claude/synapsys), global (~/.claude/synapsys/<project>), or shared (~/.claude/synapsys/_shared, reused across all projects).
+argument-hint: [local|worktree|global|shared]
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion
 ---
@@ -10,8 +10,8 @@ allowed-tools: Bash, AskUserQuestion
 
 ## Decision logic
 
-1. If the user passed `local`, `worktree`, or `global` as an argument, skip to step 3 with that kind.
-2. Otherwise, use `AskUserQuestion` to pick the kind. Recommend `worktree` when `git worktree list` shows >1 entry (multi-worktree setup); recommend `local` otherwise. Mention `global` as an option that survives worktree deletion.
+1. If the user passed `local`, `worktree`, `global`, or `shared` as an argument, skip to step 3 with that kind.
+2. Otherwise, use `AskUserQuestion` to pick the kind. Recommend `worktree` when `git worktree list` shows >1 entry (multi-worktree setup); recommend `local` otherwise. Mention `global` (per-project, survives worktree deletion) and `shared` (one store reused across ALL projects) as options.
 3. Run the init script:
    ```bash
    node "${CLAUDE_PLUGIN_ROOT}/scripts/synapsys-init.js" --kind=<kind>

--- a/plugins/synapsys/skills/install/SKILL.md
+++ b/plugins/synapsys/skills/install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: install
-description: Configure Synapsys memory storage. Use when the user says "install synapsys", "set up memory", "set up synapsys", "configure memory", "create memory store", "initialize memory", or asks to start using the memory system. Picks local (./.claude/synapsys), worktree (../.claude/synapsys), global (~/.claude/synapsys/<project>), or shared (~/.claude/synapsys/_shared, reused across all projects).
+description: Configure Synapsys memory storage. Use when the user says "install synapsys", "set up memory", "set up synapsys", "configure memory", "create memory store", "initialize memory", or asks to start using the memory system. Picks local (./.claude/synapsys), worktree (../.claude/synapsys), global (~/.claude/synapsys/<project>), or shared (~/.claude/synapsys-shared, reused across all projects).
 argument-hint: [local|worktree|global|shared]
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion


### PR DESCRIPTION
## Existing Behavior

- Synapsys offered three memory tiers: `local` (repo-scoped), `worktree` (shared across worktrees of one repo), and `global` (per-project, keyed by git toplevel basename under `~/.claude/synapsys/<project-name>/`).
- There was no way to store memories that would be discovered across unrelated projects — the `global` tier was always namespaced to the current project.
- `synapsys-init.js`, `synapsys-memorize.js`, and the install skill only accepted `local|worktree|global` as valid kind values.

## Intended New Behavior

- A new fourth tier `shared` is available at `~/.claude/synapsys/_shared/`. It is discovered on every event, regardless of cwd or project name, making memories available across all projects on the machine.
- The leading underscore in `_shared` prevents collision with any real project name (git toplevel basenames never start with `_`).
- `synapsys-init.js` generates a project-agnostic `INDEX.md` header (`scope=all projects`) when initializing a shared store, rather than stamping it with the project name the init happened to run from.
- All user-facing interfaces (`synapsys-init.js`, `synapsys-memorize.js`, `--kind` help text, install SKILL.md, setup hint in the hook) are updated to include `shared` as a valid option.

## Brief P0 coverage

No `tasks/<ticket>/brief.md` found for this change — section not applicable.

## Out-of-scope changes

No out-of-scope files reported by the scope-diff verifier — section not applicable.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Initialize a shared store and verify cross-project discovery:**

1. From any repo on your machine, run:
   ```bash
   node plugins/synapsys/scripts/synapsys-init.js --kind=shared
   ```
   Expected: prints `initialized synapsys store at ~/.claude/synapsys/_shared (kind=shared, scope=all projects)`

2. Verify the marker was created:
   ```bash
   cat ~/.claude/synapsys/_shared/.synapsys.json
   ```
   Expected: `{ "kind": "shared", "schemaVersion": 1 }`

3. Verify the store is discovered from an unrelated project directory:
   ```bash
   node -e "
   const { discoverStores } = require('./plugins/synapsys/lib/memory-store');
   const stores = discoverStores('/tmp/some-other-project');
   console.log(stores.map(s => s.kind));
   "
   ```
   Expected: output includes `'shared'`

4. Run the behavioral test suite:
   ```bash
   node --test plugins/synapsys/lib/__tests__/shared-store.test.js
   ```
   Expected: 5 tests pass, 0 failures.

Closes #436

### Test Results

5 tests, 5 passed, 0 failed

```
▶ shared store discovery
  ✔ is discovered from one project (10ms)
  ✔ is discovered from an unrelated second project (cross-project) (8ms)
✔ shared store discovery

▶ shared store injection
  ✔ injects a matching memory on UserPromptSubmit from any project (9ms)
  ✔ injects a matching memory on PreToolUse from any project (8ms)
  ✔ does NOT inject for a non-matching prompt (control) (8ms)
✔ shared store injection
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive plugin behavior with fail-open hooks; shared memories only apply when a user initializes that tier, covered by new unit tests.
> 
> **Overview**
> Adds a fourth Synapsys storage tier, **`shared`**, at `~/.claude/synapsys-shared/`, so memories can be discovered and injected from **any** project cwd (not only the current repo’s `global` namespace).
> 
> **Discovery and init:** `memory-store.js` registers the shared path as a sibling of the per-project `synapsys/<name>/` tree (via `SHARED_FOLDER`) to avoid colliding with a global store for a project whose basename might match. `discoverStores` always includes an active shared marker; shared entries use `projectName: null`. `synapsys-init.js` accepts `--kind=shared`, omits `projectName` on the marker, and labels new `INDEX.md` as “all projects”.
> 
> **UX and tooling:** README, install skill, setup hint in `synapsys.js`, and `synapsys-memorize.js` `--store` are updated to document and accept `shared`. New POSIX-focused tests in `shared-store.test.js` cover cross-project discovery, global vs shared separation, and matcher injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba95d8deb30d590398895a00c416ae9b7f713e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->