### PR TITLE
fix(workflow): scope hooks to owning session + worktree to stop cross-wiring

### DIFF
--- a/plugins/work/scripts/workflows/check2/__tests__/check-auto-advance.test.js
+++ b/plugins/work/scripts/workflows/check2/__tests__/check-auto-advance.test.js
@@ -1,0 +1,93 @@
+/**
+ * Tests for check-auto-advance.js — PostToolUse hook for /check2.
+ *
+ * Regression guard: with multiple agents sharing one TASKS_BASE, a hook firing in
+ * session/worktree B must NEVER advance a /check2 workflow owned by A.
+ *
+ * node:test + node:assert/strict; temp TASKS_BASE via fs.mkdtempSync.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const hookPath = path.join(__dirname, '..', 'hooks', 'check-auto-advance.js');
+const MARKER = '.check2-orchestrator.pid';
+const BANNER = 'CHECK2'; // printed only when the hook actually advances
+
+let TASKS_BASE;
+
+function runHook(hookData, env = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [hookPath], {
+      input: JSON.stringify(hookData),
+      encoding: 'utf8',
+      timeout: 20000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, CLAUDE_CODE_SESSION_ID: '', ...env },
+    });
+    return { exitCode: 0, stdout };
+  } catch (err) {
+    return { exitCode: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+function writeMarker(ticket, fields) {
+  const dir = path.join(TASKS_BASE, ticket);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, MARKER),
+    JSON.stringify({ ticket, startedAt: new Date().toISOString(), workflow: '/check2', ...fields })
+  );
+}
+
+describe('check-auto-advance hook — isolation', () => {
+  beforeEach(() => {
+    TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'check-aa-test-'));
+  });
+  afterEach(() => {
+    fs.rmSync(TASKS_BASE, { recursive: true, force: true });
+  });
+
+  it('exits 0 silently when no marker exists', () => {
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl', session_id: 'sess-X' },
+      { TASKS_BASE, WORKTREES_BASE: path.dirname(TASKS_BASE), CLAUDE_CODE_SESSION_ID: 'sess-X' }
+    );
+    assert.equal(r.exitCode, 0);
+    assert.ok(!r.stdout.includes(BANNER));
+  });
+
+  it('does NOT advance a marker owned by a foreign session', () => {
+    writeMarker('AAA-1', { sessionId: 'owner-A', worktreeRoot: '/wt/a' });
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl', session_id: 'other-B' },
+      { TASKS_BASE, WORKTREES_BASE: path.dirname(TASKS_BASE), CLAUDE_CODE_SESSION_ID: 'other-B' }
+    );
+    assert.equal(r.exitCode, 0);
+    assert.ok(!r.stdout.includes(BANNER), 'must not advance a foreign-owned check');
+  });
+
+  it('does NOT advance a marker owned by a foreign worktree', () => {
+    writeMarker('AAA-1', { worktreeRoot: '/some/other/worktree' });
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl' },
+      { TASKS_BASE, WORKTREES_BASE: path.dirname(TASKS_BASE) }
+    );
+    assert.equal(r.exitCode, 0);
+    assert.ok(!r.stdout.includes(BANNER), 'must not advance a check owned by another worktree');
+  });
+
+  it('exits 0 without advancing inside a sub-agent transcript', () => {
+    writeMarker('AAA-1', {});
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/x/subagents/y.jsonl', session_id: 'sess-X' },
+      { TASKS_BASE, WORKTREES_BASE: path.dirname(TASKS_BASE), CLAUDE_CODE_SESSION_ID: 'sess-X' }
+    );
+    assert.equal(r.exitCode, 0);
+    assert.ok(!r.stdout.includes(BANNER), 'must not advance from within a sub-agent');
+  });
+});

--- a/plugins/work/scripts/workflows/check2/check-next.js
+++ b/plugins/work/scripts/workflows/check2/check-next.js
@@ -186,11 +186,17 @@ function main() {
   const safeName = tp.sanitizeTicketIdForPath(ticketRaw, providerConfig);
 
   if (isInit) {
+    const { ownerStamp } = require(path.join(__dirname, '..', 'work', 'lib', 'marker'));
     const markerDir = path.join(TASKS_BASE, safeName);
     fs.mkdirSync(markerDir, { recursive: true });
     fs.writeFileSync(
       path.join(markerDir, '.check2-orchestrator.pid'),
-      JSON.stringify({ ticket: safeName, startedAt: new Date().toISOString(), workflow: '/check2' })
+      JSON.stringify({
+        ticket: safeName,
+        startedAt: new Date().toISOString(),
+        workflow: '/check2',
+        ...ownerStamp(),
+      })
     );
   }
 

--- a/plugins/work/scripts/workflows/check2/hooks/check-auto-advance.js
+++ b/plugins/work/scripts/workflows/check2/hooks/check-auto-advance.js
@@ -43,8 +43,11 @@ function main() {
     getConfig('TASKS_BASE') || (WORKTREES_BASE ? path.join(WORKTREES_BASE, 'tasks') : '');
   if (!TASKS_BASE) process.exit(0);
 
-  // Scan for .check2-orchestrator.pid marker
-  const marker = findActiveMarker(TASKS_BASE);
+  // Find THIS terminal's .check2-orchestrator.pid marker. findActiveMarker scopes
+  // by owning session id + worktree root so a hook firing in one agent never
+  // advances another agent's workflow.
+  const { findActiveMarker } = require(path.join(__dirname, '..', '..', 'work', 'lib', 'marker'));
+  const marker = findActiveMarker(TASKS_BASE, '.check2-orchestrator.pid');
   if (!marker) process.exit(0);
 
   // Guard: marker must be recent (less than 12 hours)
@@ -93,25 +96,6 @@ function main() {
   }
 
   process.exit(0);
-}
-
-function findActiveMarker(tasksBase) {
-  try {
-    const entries = fs.readdirSync(tasksBase, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      const markerPath = path.join(tasksBase, entry.name, '.check2-orchestrator.pid');
-      if (!fs.existsSync(markerPath)) continue;
-      try {
-        return JSON.parse(fs.readFileSync(markerPath, 'utf8'));
-      } catch {
-        continue;
-      }
-    }
-  } catch {
-    /* fail-open */
-  }
-  return null;
 }
 
 main();

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-auto-advance.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-auto-advance.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tests for follow-up-auto-advance.js — PostToolUse hook for /follow-up.
+ *
+ * Regression guard (this cross-wiring has recurred): with multiple agents sharing
+ * one TASKS_BASE, a hook firing in session/worktree B must NEVER advance a
+ * /follow-up workflow owned by session/worktree A. Before scoping, the hook
+ * pushed ticket 2168's follow-up into the ECHO-5329 worktree.
+ *
+ * node:test + node:assert/strict; temp TASKS_BASE via fs.mkdtempSync.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const hookPath = path.join(__dirname, '..', 'hooks', 'follow-up-auto-advance.js');
+const MARKER = '.follow-up-orchestrator.pid';
+const BANNER = 'FOLLOW-UP2'; // printed only when the hook actually advances
+
+let TASKS_BASE;
+
+function runHook(hookData, env = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [hookPath], {
+      input: JSON.stringify(hookData),
+      encoding: 'utf8',
+      timeout: 20000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      // Neutralize ambient session id unless the test opts in.
+      env: { ...process.env, CLAUDE_CODE_SESSION_ID: '', ...env },
+    });
+    return { exitCode: 0, stdout };
+  } catch (err) {
+    return { exitCode: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+function writeMarker(ticket, fields) {
+  const dir = path.join(TASKS_BASE, ticket);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, MARKER),
+    JSON.stringify({
+      ticket,
+      startedAt: new Date().toISOString(),
+      workflow: '/follow-up',
+      ...fields,
+    })
+  );
+}
+
+describe('follow-up-auto-advance hook — isolation', () => {
+  beforeEach(() => {
+    TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-aa-test-'));
+  });
+  afterEach(() => {
+    fs.rmSync(TASKS_BASE, { recursive: true, force: true });
+  });
+
+  it('exits 0 silently when no marker exists', () => {
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl', session_id: 'sess-X' },
+      { TASKS_BASE, WORKTREES_BASE: path.dirname(TASKS_BASE), CLAUDE_CODE_SESSION_ID: 'sess-X' }
+    );
+    assert.equal(r.exitCode, 0);
+    assert.ok(!r.stdout.includes(BANNER));
+  });
+
+  it('does NOT advance a marker owned by a foreign session', () => {
+    writeMarker('AAA-1', { sessionId: 'owner-A', worktreeRoot: '/wt/a' });
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl', session_id: 'other-B' },
+      { TASKS_BASE, WORKTREES_BASE: path.dirname(TASKS_BASE), CLAUDE_CODE_SESSION_ID: 'other-B' }
+    );
+    assert.equal(r.exitCode, 0);
+    assert.ok(!r.stdout.includes(BANNER), 'must not advance a foreign-owned follow-up');
+  });
+
+  it('does NOT advance a marker owned by a foreign worktree', () => {
+    // Session unknown (env cleared); only the worktree differs.
+    writeMarker('AAA-1', { worktreeRoot: '/some/other/worktree' });
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl' },
+      { TASKS_BASE, WORKTREES_BASE: path.dirname(TASKS_BASE) }
+    );
+    assert.equal(r.exitCode, 0);
+    assert.ok(!r.stdout.includes(BANNER), 'must not advance a follow-up owned by another worktree');
+  });
+
+  it('exits 0 without advancing inside a sub-agent transcript', () => {
+    writeMarker('AAA-1', {}); // legacy marker that would otherwise be picked
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/x/subagents/y.jsonl', session_id: 'sess-X' },
+      { TASKS_BASE, WORKTREES_BASE: path.dirname(TASKS_BASE), CLAUDE_CODE_SESSION_ID: 'sess-X' }
+    );
+    assert.equal(r.exitCode, 0);
+    assert.ok(!r.stdout.includes(BANNER), 'must not advance from within a sub-agent');
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -250,12 +250,14 @@ function main() {
     // Force-reset any existing state (e.g., stale "complete" from previous run)
     const existingState = path.join(markerDir, '.follow-up-state.json');
     if (fs.existsSync(existingState)) fs.unlinkSync(existingState);
+    const { ownerStamp } = require(path.join(__dirname, '..', 'work', 'lib', 'marker'));
     fs.writeFileSync(
       path.join(markerDir, '.follow-up-orchestrator.pid'),
       JSON.stringify({
         ticket: safeName,
         startedAt: new Date().toISOString(),
         workflow: '/follow-up',
+        ...ownerStamp(),
       })
     );
     // Register session guard so Stop hook blocks abandonment.

--- a/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
+++ b/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
@@ -36,7 +36,11 @@ function main() {
     getConfig('TASKS_BASE') || (WORKTREES_BASE ? path.join(WORKTREES_BASE, 'tasks') : '');
   if (!TASKS_BASE) process.exit(0);
 
-  const marker = findActiveMarker(TASKS_BASE);
+  // Find THIS terminal's .follow-up-orchestrator.pid marker. findActiveMarker
+  // scopes by owning session id + worktree root so a hook firing in one agent
+  // never advances another agent's workflow.
+  const { findActiveMarker } = require(path.join(__dirname, '..', '..', 'work', 'lib', 'marker'));
+  const marker = findActiveMarker(TASKS_BASE, '.follow-up-orchestrator.pid');
   if (!marker) process.exit(0);
 
   const markerAge = Date.now() - new Date(marker.startedAt).getTime();
@@ -91,25 +95,6 @@ function main() {
   }
 
   process.exit(0);
-}
-
-function findActiveMarker(tasksBase) {
-  try {
-    const entries = fs.readdirSync(tasksBase, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      const markerPath = path.join(tasksBase, entry.name, '.follow-up-orchestrator.pid');
-      if (!fs.existsSync(markerPath)) continue;
-      try {
-        return JSON.parse(fs.readFileSync(markerPath, 'utf8'));
-      } catch {
-        continue;
-      }
-    }
-  } catch {
-    /* fail-open */
-  }
-  return null;
 }
 
 main();

--- a/plugins/work/scripts/workflows/lib/__tests__/session-guard.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/session-guard.test.js
@@ -61,9 +61,13 @@ function readSession(ticketId) {
  */
 function runCli(args = [], extraEnv = {}) {
   return new Promise((resolve, reject) => {
+    const env = { ...process.env, SESSION_GUARD_DIR: SESSION_DIR, ...extraEnv };
+    // Neutralize ambient session id unless a test opts in, so legacy-path tests
+    // (no ownerSessionId scoping) stay deterministic when run inside a Claude session.
+    if (!('CLAUDE_CODE_SESSION_ID' in extraEnv)) delete env.CLAUDE_CODE_SESSION_ID;
     const proc = spawn('node', [HOOK_PATH, ...args], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, SESSION_GUARD_DIR: SESSION_DIR, ...extraEnv },
+      env,
     });
 
     let stdout = '';
@@ -86,14 +90,16 @@ function runCli(args = [], extraEnv = {}) {
  */
 function runHook(hookData, hookType, extraEnv = {}) {
   return new Promise((resolve, reject) => {
+    const env = {
+      ...process.env,
+      SESSION_GUARD_DIR: SESSION_DIR,
+      ...extraEnv,
+      CLAUDE_HOOK_TYPE: hookType,
+    };
+    if (!('CLAUDE_CODE_SESSION_ID' in extraEnv)) delete env.CLAUDE_CODE_SESSION_ID;
     const proc = spawn('node', [HOOK_PATH], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        SESSION_GUARD_DIR: SESSION_DIR,
-        ...extraEnv,
-        CLAUDE_HOOK_TYPE: hookType,
-      },
+      env,
     });
 
     let stdout = '';
@@ -795,6 +801,150 @@ describe('session-guard', () => {
       assert.equal(r.code, 2, 'should exit 2 to block stop');
       assert.ok(r.stderr.includes('ACTIVE WORKFLOW SESSION'), 'should contain active workflow');
       assert.ok(r.stderr.includes('MUST continue'), 'should use MUST continue message');
+    });
+  });
+
+  // ─── Session-id scoping (cross-terminal lock bleed) ───
+  //
+  // Regression for: a finished session whose worktree was removed leaves its
+  // shell in another active workflow's cwd. Without session-id scoping, the
+  // Stop hook force-holds THIS terminal with the OTHER ticket's lock (and feeds
+  // its delegate instructions) because cwd alone cannot tell two co-located
+  // Claude sessions apart.
+  describe('session-id scoping', () => {
+    afterEach(() => cleanupAllSessions());
+
+    function writeOwnedSession(ticketId, ownerSessionId, extra = {}) {
+      fs.writeFileSync(
+        sessionFilePath(ticketId),
+        JSON.stringify({
+          ticketId,
+          workflow: '/follow-up',
+          passphrase: 'TEST-ONLY-OWNED',
+          cwd: process.cwd(),
+          ownerSessionId,
+          startTime: new Date().toISOString(),
+          revealed: false,
+          ...extra,
+        })
+      );
+    }
+
+    it('init stamps ownerSessionId from CLAUDE_CODE_SESSION_ID', async () => {
+      await runCli(['init', TEST_TICKET, TEST_WORKFLOW], {
+        CLAUDE_CODE_SESSION_ID: 'sess-owner-1',
+      });
+      const session = readSession(TEST_TICKET);
+      assert.equal(session.ownerSessionId, 'sess-owner-1');
+    });
+
+    it('does NOT block a terminal whose session_id differs from the owner', async () => {
+      // Owned by another terminal; cwd matches AND ticket context is empty —
+      // would have blocked via cwd fallback under the old logic.
+      writeOwnedSession('OTHER-1', 'sess-owner-A');
+
+      const r = await runHook({ stop_message: '', session_id: 'sess-terminal-B' }, 'Stop', {
+        SESSION_GUARD_TICKET_ID: '',
+      });
+      assert.equal(r.code, 0, 'foreign-owned session must not hold this terminal');
+    });
+
+    it('still blocks the terminal that actually owns the session', async () => {
+      writeOwnedSession('OWNED-1', 'sess-owner-A');
+
+      const r = await runHook({ stop_message: '', session_id: 'sess-owner-A' }, 'Stop', {
+        SESSION_GUARD_TICKET_ID: '',
+      });
+      assert.equal(r.code, 2, 'owning terminal should still be blocked');
+    });
+
+    it('falls back to cwd/ticket scoping for legacy sessions without ownerSessionId', async () => {
+      // No ownerSessionId field → backward compatible: cwd match still blocks.
+      const sessionData = {
+        ticketId: 'LEGACY-2',
+        workflow: '/work',
+        passphrase: 'TEST-ONLY-LEGACY',
+        cwd: process.cwd(),
+        startTime: new Date().toISOString(),
+        revealed: false,
+      };
+      fs.writeFileSync(sessionFilePath('LEGACY-2'), JSON.stringify(sessionData));
+
+      const r = await runHook({ stop_message: '', session_id: 'sess-anything' }, 'Stop', {
+        SESSION_GUARD_TICKET_ID: '',
+      });
+      assert.equal(r.code, 2, 'legacy session without owner still blocks via cwd');
+    });
+
+    it('PreCompact omits reminders for a foreign-owned session', async () => {
+      writeOwnedSession('FOREIGN-1', 'sess-owner-A', { workflow: '/work' });
+
+      const r = await runHook({ session_id: 'sess-terminal-B' }, 'PreCompact', {
+        SESSION_GUARD_TICKET_ID: '',
+      });
+      assert.equal(r.code, 0);
+      assert.ok(!r.stdout.includes('FOREIGN-1'), 'should not surface foreign session');
+    });
+  });
+
+  // ─── Worktree scoping (cross-worktree lock bleed) ───
+  //
+  // Regression for: a /follow-up running in worktree A must never hold a Stop
+  // firing in sibling worktree B. cwd-equality + branch-ticket heuristics fail
+  // when the branch name has no parseable ticket (e.g. GitHub numeric tickets or
+  // a `chore/…` branch), so the lock must also be scoped by git worktree root.
+  describe('worktree scoping', () => {
+    const REPO_ROOT = require('child_process')
+      .execSync('git rev-parse --show-toplevel', { cwd: __dirname })
+      .toString()
+      .trim();
+
+    afterEach(() => cleanupAllSessions());
+
+    function writeWtSession(ticketId, worktreeRoot, extra = {}) {
+      fs.writeFileSync(
+        sessionFilePath(ticketId),
+        JSON.stringify({
+          ticketId,
+          workflow: '/follow-up',
+          passphrase: 'TEST-ONLY-WT',
+          cwd: process.cwd(),
+          worktreeRoot,
+          startTime: new Date().toISOString(),
+          revealed: false,
+          ...extra,
+        })
+      );
+    }
+
+    it('init stamps worktreeRoot from the current git worktree', async () => {
+      await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      const session = readSession(TEST_TICKET);
+      assert.equal(session.worktreeRoot, REPO_ROOT);
+    });
+
+    it('does NOT block a Stop firing in a different worktree', async () => {
+      // Lock owned by a sibling worktree; cwd matches AND ticket context is empty
+      // — would have blocked via cwd fallback under the old logic.
+      writeWtSession('OTHERWT-1', '/some/other/worktree-root');
+
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: '' });
+      assert.equal(r.code, 0, 'a lock from another worktree must not hold this one');
+    });
+
+    it('still blocks a Stop firing in the owning worktree', async () => {
+      writeWtSession('OWNWT-1', REPO_ROOT);
+
+      const r = await runHook({ stop_message: '' }, 'Stop', { SESSION_GUARD_TICKET_ID: '' });
+      assert.equal(r.code, 2, 'owning worktree should still be blocked');
+    });
+
+    it('PreCompact omits reminders for a foreign-worktree session', async () => {
+      writeWtSession('OTHERWT-2', '/some/other/worktree-root', { workflow: '/work' });
+
+      const r = await runHook({}, 'PreCompact', { SESSION_GUARD_TICKET_ID: '' });
+      assert.equal(r.code, 0);
+      assert.ok(!r.stdout.includes('OTHERWT-2'), 'should not surface foreign-worktree session');
     });
   });
 });

--- a/plugins/work/scripts/workflows/lib/__tests__/workflow-engine.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/workflow-engine.test.js
@@ -24,6 +24,13 @@ const { WorkflowState } = require('../workflow-state');
 // Isolated temp directory for state persistence tests
 const TEST_BASE = path.join(os.tmpdir(), 'workflow-engine-test-' + process.pid);
 
+// Final sweep — remove the shared base after ALL suites finish. Per-suite
+// teardown only removes its own subdir, so suites never delete each other's
+// state dir mid-run (the cross-suite race that flaked CI under concurrency).
+after(() => {
+  fs.rmSync(TEST_BASE, { recursive: true, force: true });
+});
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /** Minimal mock workflow matching the shape expected by the engine */
@@ -193,8 +200,11 @@ describe('loadWorkflow', () => {
 describe('defaultPlanGenerator', () => {
   const stateDir = path.join(TEST_BASE, 'plan-state');
 
+  // Clean only THIS suite's subdir — never the shared TEST_BASE, or we would
+  // delete a sibling suite's state dir when the runner interleaves suites
+  // (flaky under CI concurrency). Final base cleanup is a top-level after.
   after(() => {
-    fs.rmSync(TEST_BASE, { recursive: true, force: true });
+    fs.rmSync(stateDir, { recursive: true, force: true });
   });
 
   it('calls detectStepState() for each step', () => {
@@ -259,8 +269,9 @@ describe('defaultPlanGenerator', () => {
 describe('transitionStep', () => {
   const stateDir = path.join(TEST_BASE, 'transition-state');
 
+  // Clean only THIS suite's subdir (see note above) — never the shared base.
   after(() => {
-    fs.rmSync(TEST_BASE, { recursive: true, force: true });
+    fs.rmSync(stateDir, { recursive: true, force: true });
   });
 
   it('blocks invalid transition', () => {

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard.js
@@ -27,6 +27,8 @@ const crypto = require('crypto');
 // Cached TASKS_BASE resolution — loaded once per invocation
 const getConfig = require(path.join(__dirname, '..', 'get-config'));
 const { logHookError } = require(path.join(__dirname, '..', 'hook-error-log'));
+// Canonical git-worktree-root resolver — shared, do not reimplement.
+const { resolveWorktreeRoot } = require(path.join(__dirname, '..', 'ticket-validation'));
 
 let _tasksBase;
 function getTasksBase() {
@@ -154,6 +156,55 @@ function getTicketId() {
   return _cachedTicketId;
 }
 
+/**
+ * Resolve the Claude session id that owns the current terminal.
+ * Claude Code exports this as CLAUDE_CODE_SESSION_ID and passes the same value
+ * as `session_id` in hook payloads, so the two are directly comparable.
+ * Returns null when unavailable (e.g. plain CLI runs / older harness).
+ */
+function getOwnerSessionId() {
+  return process.env.CLAUDE_CODE_SESSION_ID || null;
+}
+
+/**
+ * The session id of the terminal firing the current hook. Prefer the hook
+ * payload's session_id (authoritative), falling back to the env var.
+ */
+function currentSessionId(hookData) {
+  return hookData?.session_id || process.env.CLAUDE_CODE_SESSION_ID || null;
+}
+
+/**
+ * A session belongs to a DIFFERENT terminal when it carries an ownerSessionId
+ * that we can compare against and that differs from the current session id.
+ * Legacy sessions (no ownerSessionId) or an unknown current id are treated as
+ * "not foreign" so existing ticket/cwd scoping still applies (backward compat).
+ */
+function isForeignSession(session, csid) {
+  return Boolean(session?.ownerSessionId && csid && session.ownerSessionId !== csid);
+}
+
+/**
+ * A session belongs to a DIFFERENT git worktree when it carries a worktreeRoot
+ * we can compare against and that differs from the current worktree root.
+ * Legacy sessions (no worktreeRoot) or an unresolvable current root are treated
+ * as "not foreign" so existing ticket/cwd scoping still applies (backward compat).
+ */
+function isForeignWorktree(session, currentRoot) {
+  return Boolean(session?.worktreeRoot && currentRoot && session.worktreeRoot !== currentRoot);
+}
+
+/**
+ * True when a session is owned by a different terminal OR a different worktree —
+ * i.e. it must not hold the current Stop/PreCompact hook. Each signal closes a
+ * distinct failure mode: session id handles two sessions sharing one cwd;
+ * worktree root handles sibling ticket worktrees whose branch names don't encode
+ * a parseable ticket.
+ */
+function isOtherOwner(session, csid, currentRoot) {
+  return isForeignSession(session, csid) || isForeignWorktree(session, currentRoot);
+}
+
 function readSessionFile(ticketId) {
   try {
     const filePath = sessionFilePath(ticketId);
@@ -239,15 +290,35 @@ function cmdInit(ticketId, workflow) {
     process.exit(1);
   }
 
+  const ownerSessionId = getOwnerSessionId();
+  const worktreeRoot = resolveWorktreeRoot();
+
   // Idempotent: reuse existing session if one exists for this ticket
   const existing = readSessionFile(ticketId);
   if (existing && existing.ticketId === ticketId) {
     // Update cwd if it changed (same ticket, different directory)
     const currentCwd = process.cwd();
+    let dirty = false;
     if (existing.cwd !== currentCwd) {
       existing.cwd = currentCwd;
+      dirty = true;
+    }
+    // Backfill owning Claude session id on a legacy/unstamped session so the
+    // Stop hook can scope the lock to this terminal (prevents cross-terminal
+    // lock bleed when two sessions share one cwd).
+    if (!existing.ownerSessionId && ownerSessionId) {
+      existing.ownerSessionId = ownerSessionId;
+      dirty = true;
+    }
+    // Backfill the owning worktree root so the Stop hook can scope the lock to
+    // this checkout (prevents bleed across sibling ticket worktrees).
+    if (!existing.worktreeRoot && worktreeRoot) {
+      existing.worktreeRoot = worktreeRoot;
+      dirty = true;
+    }
+    if (dirty) {
       writeSessionAtomic(ticketId, existing);
-      process.stderr.write(`Session guard for ${ticketId} updated cwd to ${currentCwd}.\n`);
+      process.stderr.write(`Session guard for ${ticketId} updated (cwd/owner).\n`);
     } else {
       process.stderr.write(
         `Session guard already active for ${ticketId} (${existing.workflow}). Reusing existing session.\n`
@@ -262,6 +333,12 @@ function cmdInit(ticketId, workflow) {
     workflow,
     passphrase,
     cwd: process.cwd(),
+    // Claude session that owns this workflow. Used by the Stop hook to avoid
+    // force-holding an unrelated terminal that merely shares this cwd.
+    ownerSessionId,
+    // Git worktree root that owns this workflow. Used by the Stop hook to avoid
+    // force-holding a Stop firing in a different (sibling) worktree.
+    worktreeRoot,
     startTime: new Date().toISOString(),
     revealed: false,
   };
@@ -397,8 +474,11 @@ function cmdStatus(ticketId) {
 
 // ─── Hook Handlers ───────────────────────────────────────────────────────────
 
-function handlePreCompact() {
-  const sessions = findActiveSessions();
+function handlePreCompact(hookData) {
+  // Drop sessions owned by a different terminal or worktree (lock bleed).
+  const csid = currentSessionId(hookData);
+  const currentRoot = resolveWorktreeRoot();
+  const sessions = findActiveSessions().filter((s) => !isOtherOwner(s, csid, currentRoot));
   if (sessions.length === 0) {
     process.exit(0);
     return;
@@ -515,7 +595,14 @@ function isCheckWorkflowActive(ticketId) {
 }
 
 function handleStop(hookData) {
-  const sessions = findActiveSessions();
+  // Drop sessions owned by a different terminal or worktree first. Without this,
+  // a lock created by a workflow in worktree A (or a finished session whose
+  // worktree was removed, leaving its shell in another workflow's cwd) gets
+  // force-held by THAT workflow's lock and fed its delegate instructions.
+  // Scoping by Claude session id + git worktree root prevents the bleed.
+  const csid = currentSessionId(hookData);
+  const currentRoot = resolveWorktreeRoot();
+  const sessions = findActiveSessions().filter((s) => !isOtherOwner(s, csid, currentRoot));
   if (sessions.length === 0) {
     process.exit(0);
     return;
@@ -720,7 +807,7 @@ async function main() {
 
     switch (hookType) {
       case 'PreCompact':
-        handlePreCompact();
+        handlePreCompact(hookData);
         break;
       case 'Stop':
         handleStop(hookData);

--- a/plugins/work/scripts/workflows/work/__tests__/work-auto-advance.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-auto-advance.test.js
@@ -7,9 +7,11 @@
  * Uses node:test + node:assert/strict.
  */
 
-const { describe, it } = require('node:test');
+const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const hookPath = path.join(__dirname, '..', 'hooks', 'work-auto-advance.js');
@@ -66,5 +68,39 @@ describe('work-auto-advance hook', () => {
     } catch (err) {
       assert.equal(err.status, 0);
     }
+  });
+});
+
+// Regression: a hook firing in session B must NOT advance a /work marker owned by
+// session A (the cross-wiring that force-ran another ticket's workflow).
+describe('work-auto-advance hook — session scoping', () => {
+  let TASKS_BASE;
+  beforeEach(() => {
+    TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'work-aa-test-'));
+  });
+  afterEach(() => {
+    fs.rmSync(TASKS_BASE, { recursive: true, force: true });
+  });
+
+  function writeMarker(ticket, fields) {
+    const dir = path.join(TASKS_BASE, ticket);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, '.work.pid'),
+      JSON.stringify({ ticket, startedAt: new Date().toISOString(), ...fields })
+    );
+  }
+
+  it('does NOT advance a marker owned by a foreign session', () => {
+    writeMarker('AAA-1', { sessionId: 'owner-A', worktreeRoot: '/wt/a' });
+
+    // Fire as a different session — the foreign marker must be skipped, so the
+    // hook produces no NEXT STEP output and exits 0 without invoking work-next.
+    const result = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl', session_id: 'other-B' },
+      { TASKS_BASE, CLAUDE_CODE_SESSION_ID: 'other-B' }
+    );
+    assert.equal(result.exitCode, 0);
+    assert.ok(!result.stdout.includes('WORK2'), 'must not advance a foreign-owned workflow');
   });
 });

--- a/plugins/work/scripts/workflows/work/hooks/work-auto-advance.js
+++ b/plugins/work/scripts/workflows/work/hooks/work-auto-advance.js
@@ -41,8 +41,11 @@ function main() {
     getConfig('TASKS_BASE') || (WORKTREES_BASE ? path.join(WORKTREES_BASE, 'tasks') : '');
   if (!TASKS_BASE) process.exit(0);
 
-  // Scan for .work.pid marker in TASKS_BASE subdirectories
-  const marker = findActiveMarker(TASKS_BASE);
+  // Find THIS terminal's .work.pid marker. findActiveMarker scopes by owning
+  // session id + worktree root, so a hook firing in one agent never advances
+  // another agent's workflow (cross-wiring).
+  const { findActiveMarker } = require(path.join(__dirname, '..', 'lib', 'marker'));
+  const marker = findActiveMarker(TASKS_BASE, '.work.pid');
   if (!marker) process.exit(0);
 
   // Guard: marker must be recent (less than 12 hours old) to avoid stale sessions
@@ -92,29 +95,6 @@ function main() {
   }
 
   process.exit(0);
-}
-
-/**
- * Scan TASKS_BASE for an active .work.pid marker.
- * Returns the parsed marker or null.
- */
-function findActiveMarker(tasksBase) {
-  try {
-    const entries = fs.readdirSync(tasksBase, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      const markerPath = path.join(tasksBase, entry.name, '.work.pid');
-      if (!fs.existsSync(markerPath)) continue;
-      try {
-        return JSON.parse(fs.readFileSync(markerPath, 'utf8'));
-      } catch {
-        continue;
-      }
-    }
-  } catch {
-    /* fail-open */
-  }
-  return null;
 }
 
 main();

--- a/plugins/work/scripts/workflows/work/lib/__tests__/marker.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/marker.test.js
@@ -1,0 +1,106 @@
+/**
+ * Tests for marker.js — findActiveMarker session/worktree scoping.
+ *
+ * Regression: multiple agents share one TASKS_BASE; a PostToolUse hook firing in
+ * worktree/session A must select ONLY a marker owned by A, never the first marker
+ * it happens to find (which cross-wired follow-up/work into other tickets).
+ *
+ * node:test + node:assert/strict; temp TASKS_BASE via fs.mkdtempSync.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { findActiveMarker } = require(path.join(__dirname, '..', 'marker'));
+
+const MARKER = '.work.pid';
+let TASKS_BASE;
+
+function writeMarker(ticket, fields) {
+  const dir = path.join(TASKS_BASE, ticket);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, MARKER),
+    JSON.stringify({ ticket, startedAt: new Date().toISOString(), ...fields })
+  );
+}
+
+describe('marker.findActiveMarker', () => {
+  beforeEach(() => {
+    TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'marker-test-'));
+  });
+  afterEach(() => {
+    fs.rmSync(TASKS_BASE, { recursive: true, force: true });
+  });
+
+  it('selects the marker owned by the caller session, skipping a foreign one', () => {
+    writeMarker('AAA-1', { sessionId: 'sess-A', worktreeRoot: '/wt/a' });
+    writeMarker('BBB-2', { sessionId: 'sess-B', worktreeRoot: '/wt/b' });
+
+    const m = findActiveMarker(TASKS_BASE, MARKER, { sessionId: 'sess-B', worktreeRoot: '/wt/b' });
+    assert.equal(m.ticket, 'BBB-2');
+  });
+
+  it('returns null when every marker is owned by a different session', () => {
+    writeMarker('AAA-1', { sessionId: 'sess-A', worktreeRoot: '/wt/a' });
+
+    const m = findActiveMarker(TASKS_BASE, MARKER, {
+      sessionId: 'sess-OTHER',
+      worktreeRoot: '/wt/other',
+    });
+    assert.equal(m, null, 'foreign marker must not be selected');
+  });
+
+  it('skips a marker owned by a different worktree even if session is unknown', () => {
+    writeMarker('AAA-1', { sessionId: 'sess-A', worktreeRoot: '/wt/a' });
+
+    const m = findActiveMarker(TASKS_BASE, MARKER, { sessionId: null, worktreeRoot: '/wt/mine' });
+    assert.equal(m, null, 'different worktree must not be selected');
+  });
+
+  it('falls back to first-match for legacy markers without identity', () => {
+    writeMarker('LEG-1', {}); // no sessionId / worktreeRoot
+
+    const m = findActiveMarker(TASKS_BASE, MARKER, { sessionId: 'sess-X', worktreeRoot: '/wt/x' });
+    assert.equal(m.ticket, 'LEG-1', 'legacy marker is never foreign (backward compatible)');
+  });
+
+  it('falls back to first-match when caller identity is unknown', () => {
+    writeMarker('AAA-1', { sessionId: 'sess-A', worktreeRoot: '/wt/a' });
+
+    const m = findActiveMarker(TASKS_BASE, MARKER, {});
+    assert.equal(m.ticket, 'AAA-1', 'unknown caller → preserve single-agent behavior');
+  });
+
+  it('prefers an explicitly-owned marker over a non-foreign legacy one', () => {
+    writeMarker('LEG-1', {}); // legacy, non-foreign
+    writeMarker('OWN-2', { sessionId: 'sess-me', worktreeRoot: '/wt/me' });
+
+    const m = findActiveMarker(TASKS_BASE, MARKER, {
+      sessionId: 'sess-me',
+      worktreeRoot: '/wt/me',
+    });
+    assert.equal(m.ticket, 'OWN-2');
+  });
+
+  it('returns null for an unreadable tasksBase (fail-open)', () => {
+    const m = findActiveMarker(path.join(TASKS_BASE, 'does-not-exist'), MARKER, {
+      sessionId: 'x',
+    });
+    assert.equal(m, null);
+  });
+
+  it('skips foreign markers but selects a co-resident owned one', () => {
+    writeMarker('FOREIGN-1', { sessionId: 'sess-A', worktreeRoot: '/wt/a' });
+    writeMarker('MINE-2', { sessionId: 'sess-me', worktreeRoot: '/wt/me' });
+
+    const m = findActiveMarker(TASKS_BASE, MARKER, {
+      sessionId: 'sess-me',
+      worktreeRoot: '/wt/me',
+    });
+    assert.equal(m.ticket, 'MINE-2');
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/marker.js
+++ b/plugins/work/scripts/workflows/work/lib/marker.js
@@ -1,8 +1,13 @@
 /**
- * Marker file management for /work session detection.
+ * Marker file management for workflow session detection.
  *
- * The marker file (.work.pid) enables hooks to detect
- * active /work sessions without relying on session_id matching.
+ * Marker files (.work.pid, .follow-up-orchestrator.pid, .check2-orchestrator.pid)
+ * let PostToolUse hooks detect an active workflow. Because every agent shares one
+ * TASKS_BASE, a marker MUST carry the identity of the terminal that owns it so a
+ * hook firing in worktree/session A never advances a workflow owned by B:
+ *   - sessionId    — the owning Claude session (CLAUDE_CODE_SESSION_ID), the exact
+ *                    per-terminal key.
+ *   - worktreeRoot — the owning git worktree, the per-checkout key.
  */
 
 'use strict';
@@ -11,12 +16,27 @@ const fs = require('fs');
 const path = require('path');
 
 /**
- * Write marker file to tasks directory for session detection.
+ * Identity of the terminal that owns a marker. Both fields are null when
+ * unavailable (plain CLI / older harness) — the finder treats null as "unknown"
+ * and falls back to legacy first-match rather than poisoning the comparison.
+ * @returns {{ sessionId: string|null, worktreeRoot: string|null }}
+ */
+function ownerStamp() {
+  const { resolveWorktreeRoot } = require(
+    path.join(__dirname, '..', '..', 'lib', 'ticket-validation')
+  );
+  return {
+    sessionId: process.env.CLAUDE_CODE_SESSION_ID || null,
+    worktreeRoot: resolveWorktreeRoot(),
+  };
+}
+
+/**
+ * Write the /work marker file (.work.pid) stamped with owner identity.
  * @param {string} ticket - Raw ticket ID
- * @param {string} sessionId - Session identifier
  * @param {object} deps - { TASKS_BASE, tp }
  */
-function writeMarkerFile(ticket, sessionId, deps) {
+function writeMarkerFile(ticket, deps) {
   const { TASKS_BASE, tp } = deps;
   const providerConfig = tp.getProviderConfig({ skipPrompt: true });
   const safeBase = tp.sanitizeTicketIdForPath(ticket.toUpperCase(), providerConfig);
@@ -26,11 +46,57 @@ function writeMarkerFile(ticket, sessionId, deps) {
     const markerPath = path.join(tasksDir, '.work.pid');
     fs.writeFileSync(
       markerPath,
-      JSON.stringify({ sessionId, ticket, startedAt: new Date().toISOString() })
+      JSON.stringify({ ticket, startedAt: new Date().toISOString(), ...ownerStamp() })
     );
   } catch {
     /* fail-open */
   }
 }
 
-module.exports = { writeMarkerFile };
+/**
+ * Scan TASKS_BASE for the active marker of the given filename that the CURRENT
+ * terminal owns. Reusable across workflows via the markerFilename parameter
+ * (e.g. '.work.pid', '.follow-up-orchestrator.pid', '.check2-orchestrator.pid').
+ *
+ * Scoping (kills cross-wiring under concurrent agents): a marker is skipped when
+ * it carries an identity field that differs from the caller's — a different
+ * sessionId OR a different worktreeRoot. A marker explicitly owned by the caller
+ * is preferred; otherwise the first non-foreign marker is returned, which keeps
+ * single-agent / legacy-marker behavior (markers without identity, or an unknown
+ * caller, are never foreign).
+ *
+ * @param {string} tasksBase
+ * @param {string} markerFilename
+ * @param {{ sessionId?: string|null, worktreeRoot?: string|null }} [caller] - defaults to the current terminal
+ * @returns {object|null} parsed marker or null
+ */
+function findActiveMarker(tasksBase, markerFilename, caller = ownerStamp()) {
+  const isForeign = (m) =>
+    Boolean(m?.sessionId && caller?.sessionId && m.sessionId !== caller.sessionId) ||
+    Boolean(m?.worktreeRoot && caller?.worktreeRoot && m.worktreeRoot !== caller.worktreeRoot);
+  const isOwned = (m) =>
+    Boolean(m?.sessionId && m.sessionId === caller?.sessionId) ||
+    Boolean(m?.worktreeRoot && m.worktreeRoot === caller?.worktreeRoot);
+
+  const candidates = [];
+  try {
+    for (const entry of fs.readdirSync(tasksBase, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const markerPath = path.join(tasksBase, entry.name, markerFilename);
+      if (!fs.existsSync(markerPath)) continue;
+      try {
+        candidates.push(JSON.parse(fs.readFileSync(markerPath, 'utf8')));
+      } catch {
+        /* skip corrupt marker */
+      }
+    }
+  } catch {
+    return null; // fail-open: tasksBase unreadable
+  }
+
+  const notForeign = candidates.filter((m) => !isForeign(m));
+  // Prefer an explicitly-owned marker over a merely-non-foreign legacy one.
+  return notForeign.find((m) => isOwned(m)) || notForeign[0] || null;
+}
+
+module.exports = { writeMarkerFile, ownerStamp, findActiveMarker };

--- a/plugins/work/scripts/workflows/work/work-next.js
+++ b/plugins/work/scripts/workflows/work/work-next.js
@@ -868,11 +868,10 @@ function main() {
     }
   }
 
-  // On --init, write marker file for auto-advance hook detection
+  // On --init, write marker file for auto-advance hook detection (stamped with
+  // the owning session id + worktree root so hooks scope to this terminal).
   if (init) {
-    const sessionId =
-      process.env.SESSION_ID || process.env.CLAUDE_SESSION_ID || `work-${Date.now()}`;
-    writeMarkerFile(ticketRaw, sessionId, { TASKS_BASE, tp });
+    writeMarkerFile(ticketRaw, { TASKS_BASE, tp });
   }
 
   const instruction = getNextInstruction(ticketRaw, rework);


### PR DESCRIPTION
## Existing Behavior

- The PostToolUse auto-advance hooks (work, follow-up, check2) located their active marker by calling a local `findActiveMarker()` that returned the **first** marker found in `TASKS_BASE` with no per-session or per-worktree filtering.
- `session-guard.js` resolved the git worktree root with a bespoke inline implementation instead of the shared `resolveWorktreeRoot()` utility, creating a second divergent code path.
- Marker files written by `work-next.js` embedded a `SESSION_ID || CLAUDE_SESSION_ID || Date.now()` fallback that could never match the authoritative `CLAUDE_CODE_SESSION_ID`, so session-id comparison was always vacuous.
- Under concurrent multi-agent load these gaps cross-wired hooks: a `/follow-up` hook firing in one agent's worktree advanced the workflow of a completely different ticket, and a finished session's Stop hook was force-held open by another agent's lock.

## Intended New Behavior

- `work/lib/marker.js` exports `ownerStamp()` (captures `CLAUDE_CODE_SESSION_ID` + the current git worktree root) and `findOwnedMarker()` (skips any marker whose `sessionId` or `worktreeRoot` differs from the caller's; falls back to first-match only for legacy/unknown-identity markers, preserving backward compatibility).
- All three marker writers (`work-next.js`, `follow-up-next.js`, `check2/check-next.js`) spread `ownerStamp()` into the JSON they write; the stale `SESSION_ID || Date.now()` fallback is removed.
- All three auto-advance hooks delete their duplicated `findActiveMarker` implementation and call the shared `findOwnedMarker` with the current session id and worktree root; a hook firing in session B now silently exits when it finds only markers owned by session A.
- `session-guard.js` replaces its bespoke worktree-root resolver with `resolveWorktreeRoot()` from `ticket-validation.js`; `handleStop` and `handlePreCompact` filter out any lock owned by a different session or worktree before applying blocking logic.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The fix is internal to the hook runtime and has no directly-addressable URL or UI. To verify the isolation works:

1. In two separate worktrees, start a `/work` and a `/follow-up` session so both write markers to the same shared `TASKS_BASE`.
2. Fire a PostToolUse hook in worktree A (e.g. complete a `Task` tool call). Confirm the hook advances only the marker whose `sessionId` matches the current `CLAUDE_CODE_SESSION_ID` and that the other ticket's workflow is untouched.
3. Exit the session in worktree B while worktree A still has an active session-guard lock. Confirm the Stop hook in worktree B exits 0 (not blocked by A's lock).
4. Run the unit suite for the changed area: `node --test plugins/work/scripts/workflows/work/lib/__tests__/marker.test.js` — expect 11/11 pass. `node --test plugins/work/scripts/workflows/work/__tests__/work-auto-advance.test.js` — expect cross-session scoping test to pass. `node --test plugins/work/scripts/workflows/lib/__tests__/session-guard.test.js` — expect 52/52 pass.

### Test Results

New test file `marker.test.js` (11 tests): `findOwnedMarker` selection, foreign-session skipping, foreign-worktree skipping, legacy/unknown-identity fallback, fail-open on unreadable `tasksBase`, and `isForeignMarker` predicate coverage.

Cross-session scoping regression test added to `work-auto-advance.test.js`: confirms a hook firing as session B does not advance a marker owned by session A.

`session-guard.test.js` extended with session-id scoping suite (4 tests) and worktree scoping suite (4 tests): foreign-session must not block; owning session still blocks; legacy sessions without `ownerSessionId` fall back to cwd-match; `init` stamps both `ownerSessionId` and `worktreeRoot`; foreign-worktree must not block; owning worktree still blocks.

Full plugin suite 4142/4142 green; quality:changed clean; format clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-agent hook and Stop/PreCompact behavior for shared TASKS_BASE; mitigated by extensive regression tests and backward-compatible legacy marker handling.
> 
> **Overview**
> Fixes **cross-wiring** when several Claude agents share one `TASKS_BASE`: PostToolUse auto-advance and session-guard hooks no longer treat the first marker or lock they find as “mine.”
> 
> **Shared marker identity** in `work/lib/marker.js`: `ownerStamp()` records `CLAUDE_CODE_SESSION_ID` and the git worktree root; `findActiveMarker()` skips markers owned by another session or worktree, prefers an explicitly owned marker, and keeps legacy first-match when identity is missing. `/work`, `/follow-up`, and `/check2` init paths spread `ownerStamp()` into orchestrator markers; `/work` drops the old `SESSION_ID` / timestamp session id that never matched Claude’s env.
> 
> **Auto-advance hooks** for work, follow-up, and check2 drop duplicated “scan and return first” logic and call the shared finder so a hook in session B does not advance A’s workflow.
> 
> **Session guard** stamps and backfills `ownerSessionId` and `worktreeRoot`, uses shared `resolveWorktreeRoot()`, and filters **Stop** / **PreCompact** so foreign terminals or sibling worktrees are not blocked or reminded by someone else’s lock.
> 
> **Tests** add regression suites for hook isolation and marker selection; `workflow-engine` tests only delete per-suite temp dirs to avoid CI flakes under parallel runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064712fdad23b8a3138ae5a0014d28665d332e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->