### PR TITLE
fix(work): exempt Storybook stories-only tasks from TDD test-file gate

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/_helpers/run-hook.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/_helpers/run-hook.js
@@ -1,0 +1,139 @@
+/**
+ * Shared test helper for spawning hook subprocesses with a deterministic env.
+ *
+ * Why this exists
+ * ---------------
+ * Hook scripts spawned with `child_process.spawn` inherit the parent process's
+ * env by default. On developer machines, `.envrc` typically exports config
+ * vars like TASKS_BASE, WORKTREES_BASE, REPO_NAME, TICKET_PROVIDER, etc. The
+ * shared config loader (`scripts/workflows/lib/config.js`) prefers
+ * `process.env.TASKS_BASE` over its derivation from `WORKTREES_BASE`, so when
+ * a test passes `{ WORKTREES_BASE: TEMP_WB }` expecting the hook to read its
+ * state from `TEMP_WB/tasks`, the inherited `TASKS_BASE` from the developer
+ * shell silently wins instead. The hook then looks at the wrong directory and
+ * the test flakes / fails depending on which developer ran it.
+ *
+ * Fix: tests use `buildHookEnv()` to construct the subprocess env. The helper
+ * starts from a small allow-list of vars that subprocess needs to actually
+ * run (PATH, HOME, NODE_*, etc.), then layers `extraEnv` on top. This way:
+ *
+ *   - Tests that explicitly set a config var get exactly that value.
+ *   - Tests that don't set it get the hook's own default-derivation behavior.
+ *   - The developer's `.envrc` never leaks into the subprocess.
+ *
+ * Allow-listing (not deny-listing) is the right shape here: there's a small,
+ * known set of vars subprocesses need; the universe of config vars that COULD
+ * leak from `.envrc` is open-ended. New `.envrc` entries should not silently
+ * affect the test harness.
+ */
+
+'use strict';
+
+const { spawn } = require('child_process');
+
+// Env vars the Node subprocess legitimately needs to run, regardless of test.
+// Intentionally excludes ALL workflow-config vars (TASKS_BASE, WORKTREES_BASE,
+// REPO_NAME, TICKET_PROVIDER, WORK_TICKET_ID, JIRA_*, GH_*, WEB_APPS, etc.) so
+// tests are forced to declare the config they actually depend on.
+const PASSTHROUGH_PREFIXES = ['NODE_', 'npm_', 'NPM_'];
+const PASSTHROUGH_KEYS = new Set([
+  'PATH',
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TZ',
+  'PWD',
+  'TERM',
+  // CI marker — some hooks tweak output (no colors etc.) when set.
+  'CI',
+  // Allow tests to opt-in to Claude session scoping via extraEnv; if not set
+  // in extraEnv we deliberately do NOT inherit the developer's session id.
+]);
+
+function isPassthrough(key) {
+  if (PASSTHROUGH_KEYS.has(key)) return true;
+  for (const prefix of PASSTHROUGH_PREFIXES) {
+    if (key.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
+ * Build a deterministic subprocess env for a hook spawn.
+ *
+ * @param {Record<string,string>} extraEnv  Test-specific env overrides. These
+ *   ALWAYS win over the passthrough base.
+ * @param {object} [opts]
+ * @param {string[]} [opts.preserveExtra]  Additional parent-env keys to keep
+ *   (e.g. a test that legitimately wants to inherit the parent's TASKS_BASE).
+ *   Use sparingly — prefer setting the value explicitly in `extraEnv`.
+ * @returns {Record<string,string>}
+ */
+function buildHookEnv(extraEnv = {}, opts = {}) {
+  const preserveExtra = new Set(opts.preserveExtra || []);
+  const env = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    if (isPassthrough(key) || preserveExtra.has(key)) {
+      env[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(extraEnv)) {
+    // Allow tests to explicitly UN-set an inherited var by passing `undefined`
+    // or empty string. Empty string is preserved (some hooks distinguish "set
+    // to empty" from "unset"); only `undefined` deletes.
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+/**
+ * Spawn a hook script with stdin JSON input and capture exit code + streams.
+ *
+ * @param {string} hookPath        Absolute path to the hook .js file.
+ * @param {unknown} hookData       Object written to the subprocess stdin as JSON.
+ * @param {Record<string,string>} extraEnv  Env overrides (see buildHookEnv).
+ * @param {object} [opts]
+ * @param {string[]} [opts.args]   Extra argv passed after the hook path.
+ * @param {string[]} [opts.preserveExtra]  Forwarded to buildHookEnv.
+ * @param {string} [opts.cwd]      Subprocess working directory.
+ * @returns {Promise<{code:number|null, stdout:string, stderr:string}>}
+ */
+function spawnHook(hookPath, hookData, extraEnv = {}, opts = {}) {
+  const env = buildHookEnv(extraEnv, opts);
+  const args = [hookPath, ...(opts.args || [])];
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
+      cwd: opts.cwd,
+    });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    proc.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+    proc.on('close', (code) => resolve({ code, stdout, stderr }));
+    proc.on('error', reject);
+    if (hookData !== undefined && hookData !== null) {
+      proc.stdin.write(typeof hookData === 'string' ? hookData : JSON.stringify(hookData));
+    }
+    proc.stdin.end();
+  });
+}
+
+module.exports = { buildHookEnv, spawnHook };

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -11,6 +11,7 @@ const { spawn } = require('child_process');
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
+const { spawnHook } = require('./_helpers/run-hook');
 
 const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'enforce-step-workflow.js');
 const getConfig = require(path.join(__dirname, '..', 'get-config'));
@@ -32,32 +33,21 @@ let TASKS_DIR = path.join(TASKS_BASE, TEST_TICKET);
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+// This test suite intentionally writes per-test TEST-ESW-* ticket dirs UNDER the
+// real `TASKS_BASE` (resolved at module load above), so we preserve TASKS_BASE
+// from the parent env via `preserveExtra`. Other workflow-config vars are
+// scrubbed by the shared helper to prevent silent leaks from `.envrc`.
 function runHook(hookData, hookType = 'PreToolUse', env = {}) {
-  return new Promise((resolve, reject) => {
-    const proc = spawn('node', [HOOK_PATH], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        CLAUDE_HOOK_TYPE: hookType,
-        ENFORCE_HOOK_TICKET_ID: TEST_TICKET,
-        ...env,
-      },
-    });
-    let stdout = '';
-    let stderr = '';
-    proc.stdout.on('data', (d) => {
-      stdout += d.toString();
-    });
-    proc.stderr.on('data', (d) => {
-      stderr += d.toString();
-    });
-    proc.on('close', (code) => {
-      resolve({ code, stdout, stderr });
-    });
-    proc.on('error', reject);
-    proc.stdin.write(JSON.stringify(hookData));
-    proc.stdin.end();
-  });
+  return spawnHook(
+    HOOK_PATH,
+    hookData,
+    {
+      CLAUDE_HOOK_TYPE: hookType,
+      ENFORCE_HOOK_TICKET_ID: TEST_TICKET,
+      ...env,
+    },
+    { preserveExtra: ['TASKS_BASE', 'WORKTREES_BASE', 'REPO_NAME', 'TICKET_PROVIDER'] }
+  );
 }
 
 function writeWorkState(stepStatus, status = 'in_progress') {
@@ -3482,33 +3472,20 @@ describe('enforce-step-workflow', () => {
     const COMMIT_TICKET = `COMMITV-${process.pid}`;
 
     function runHookInRepo(hookData, hookType = 'PreToolUse', env = {}) {
-      return new Promise((resolve, reject) => {
-        const proc = spawn('node', [HOOK_PATH], {
-          stdio: ['pipe', 'pipe', 'pipe'],
+      return spawnHook(
+        HOOK_PATH,
+        hookData,
+        {
+          CLAUDE_HOOK_TYPE: hookType,
+          ENFORCE_HOOK_TICKET_ID: COMMIT_TICKET,
+          TASKS_BASE: tmpTasksBase,
+          ...env,
+        },
+        {
           cwd: gitRepoDir,
-          env: {
-            ...process.env,
-            CLAUDE_HOOK_TYPE: hookType,
-            ENFORCE_HOOK_TICKET_ID: COMMIT_TICKET,
-            TASKS_BASE: tmpTasksBase,
-            ...env,
-          },
-        });
-        let stdout = '';
-        let stderr = '';
-        proc.stdout.on('data', (d) => {
-          stdout += d.toString();
-        });
-        proc.stderr.on('data', (d) => {
-          stderr += d.toString();
-        });
-        proc.on('close', (code) => {
-          resolve({ code, stdout, stderr });
-        });
-        proc.on('error', reject);
-        proc.stdin.write(JSON.stringify(hookData));
-        proc.stdin.end();
-      });
+          preserveExtra: ['WORKTREES_BASE', 'REPO_NAME', 'TICKET_PROVIDER'],
+        }
+      );
     }
 
     function writeCommitWorkState(stepStatus, status = 'in_progress') {

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2063,27 +2063,35 @@ describe('enforce-step-workflow', () => {
     it('allows direct work-state.js complete call at terminal step (GH-276)', async () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
-      const { code } = await runHook(
+      const { code, stderr } = await runHook(
         {
           tool_name: 'Bash',
           tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET}` },
         },
         'PreToolUse'
       );
-      assert.equal(code, 0, 'direct complete should be allowed at terminal step');
+      assert.equal(
+        code,
+        0,
+        `direct complete should be allowed at terminal step. stderr: ${stderr}`
+      );
     });
 
     it('allows direct work-state.js complete with quoted path at terminal step (GH-276)', async () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
-      const { code } = await runHook(
+      const { code, stderr } = await runHook(
         {
           tool_name: 'Bash',
           tool_input: { command: `node "${WORK_STATE_PATH}" complete ${TEST_TICKET}` },
         },
         'PreToolUse'
       );
-      assert.equal(code, 0, 'quoted path complete should be allowed at terminal step');
+      assert.equal(
+        code,
+        0,
+        `quoted path complete should be allowed at terminal step. stderr: ${stderr}`
+      );
     });
 
     it('does not trigger complete bypass for untrusted path (GH-276 security)', async () => {
@@ -4505,40 +4513,40 @@ describe('enforce-step-workflow', () => {
     it('allows session-guard.js finish when workflow is at complete step (R3, R5)', async () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
-      const { code } = await runHook(
+      const { code, stderr } = await runHook(
         {
           tool_name: 'Bash',
           tool_input: { command: `node ${SESSION_GUARD_PATH} finish ${TEST_TICKET}` },
         },
         'PreToolUse'
       );
-      assert.equal(code, 0, 'finish should be allowed at complete step');
+      assert.equal(code, 0, `finish should be allowed at complete step. stderr: ${stderr}`);
     });
 
     it('allows session-guard.js reveal when workflow is at complete step (R3)', async () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
-      const { code } = await runHook(
+      const { code, stderr } = await runHook(
         {
           tool_name: 'Bash',
           tool_input: { command: `node ${SESSION_GUARD_PATH} reveal ${TEST_TICKET}` },
         },
         'PreToolUse'
       );
-      assert.equal(code, 0, 'reveal should be allowed at complete step');
+      assert.equal(code, 0, `reveal should be allowed at complete step. stderr: ${stderr}`);
     });
 
     it('allows session-guard.js complete when workflow is at complete step (R3)', async () => {
       writeWorkState(makeStepStatus('complete', WORK_STEPS));
 
-      const { code } = await runHook(
+      const { code, stderr } = await runHook(
         {
           tool_name: 'Bash',
           tool_input: { command: `node ${SESSION_GUARD_PATH} complete ${TEST_TICKET}` },
         },
         'PreToolUse'
       );
-      assert.equal(code, 0, 'complete should be allowed at complete step');
+      assert.equal(code, 0, `complete should be allowed at complete step. stderr: ${stderr}`);
     });
 
     // ─── R1/R7: Allow safe subcommands (init, status) at any step ───────────
@@ -4546,27 +4554,27 @@ describe('enforce-step-workflow', () => {
     it('allows session-guard.js init at any step (R1, R7)', async () => {
       writeWorkState(makeStepStatus('implement', WORK_STEPS));
 
-      const { code } = await runHook(
+      const { code, stderr } = await runHook(
         {
           tool_name: 'Bash',
           tool_input: { command: `node ${SESSION_GUARD_PATH} init ${TEST_TICKET}` },
         },
         'PreToolUse'
       );
-      assert.equal(code, 0, 'init should be allowed at any step');
+      assert.equal(code, 0, `init should be allowed at any step. stderr: ${stderr}`);
     });
 
     it('allows session-guard.js status at any step (R1, R7)', async () => {
       writeWorkState(makeStepStatus('implement', WORK_STEPS));
 
-      const { code } = await runHook(
+      const { code, stderr } = await runHook(
         {
           tool_name: 'Bash',
           tool_input: { command: `node ${SESSION_GUARD_PATH} status ${TEST_TICKET}` },
         },
         'PreToolUse'
       );
-      assert.equal(code, 0, 'status should be allowed at any step');
+      assert.equal(code, 0, `status should be allowed at any step. stderr: ${stderr}`);
     });
 
     // ─── R8: Block shell operators even at complete step ────────────────────

--- a/plugins/work/scripts/workflows/lib/__tests__/session-guard.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/session-guard.test.js
@@ -4,11 +4,11 @@
  * Run with: node --test hooks/__tests__/session-guard.test.js
  */
 
-const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const { describe, it, before, after, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
+const { spawnHook } = require('./_helpers/run-hook');
 
 const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'session-guard.js');
 const SESSION_DIR = path.join(require('os').tmpdir(), 'session-guard-test-' + process.pid);
@@ -57,65 +57,36 @@ function readSession(ticketId) {
 }
 
 /**
- * Run session-guard.js as a CLI subcommand
+ * Run session-guard.js as a CLI subcommand.
+ *
+ * Uses the shared `spawnHook` helper which builds a deterministic env from a
+ * small passthrough allow-list (PATH, HOME, NODE_*, ...) plus the test's
+ * explicit `extraEnv`. This prevents developer-shell `.envrc` exports
+ * (TASKS_BASE, WORKTREES_BASE, ...) from leaking into the subprocess and
+ * silently overriding `extraEnv`-derived defaults.
  */
 function runCli(args = [], extraEnv = {}) {
-  return new Promise((resolve, reject) => {
-    const env = { ...process.env, SESSION_GUARD_DIR: SESSION_DIR, ...extraEnv };
-    // Neutralize ambient session id unless a test opts in, so legacy-path tests
-    // (no ownerSessionId scoping) stay deterministic when run inside a Claude session.
-    if (!('CLAUDE_CODE_SESSION_ID' in extraEnv)) delete env.CLAUDE_CODE_SESSION_ID;
-    const proc = spawn('node', [HOOK_PATH, ...args], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env,
-    });
-
-    let stdout = '';
-    let stderr = '';
-    proc.stdout.on('data', (d) => {
-      stdout += d.toString();
-    });
-    proc.stderr.on('data', (d) => {
-      stderr += d.toString();
-    });
-    proc.on('close', (code) => resolve({ stdout, stderr, code }));
-    proc.on('error', reject);
-
-    proc.stdin.end();
-  });
+  // Always provide isolated SESSION_DIR; tests may override via extraEnv.
+  const env = { SESSION_GUARD_DIR: SESSION_DIR, ...extraEnv };
+  // Neutralize ambient session id unless a test opts in, so legacy-path tests
+  // (no ownerSessionId scoping) stay deterministic when run inside a Claude session.
+  if (!('CLAUDE_CODE_SESSION_ID' in extraEnv)) env.CLAUDE_CODE_SESSION_ID = undefined;
+  return spawnHook(HOOK_PATH, null, env, { args });
 }
 
 /**
- * Run session-guard.js as a hook (stdin JSON input, hook type via env)
+ * Run session-guard.js as a hook (stdin JSON input, hook type via env).
+ *
+ * See `runCli` doc for env-scrubbing rationale.
  */
 function runHook(hookData, hookType, extraEnv = {}) {
-  return new Promise((resolve, reject) => {
-    const env = {
-      ...process.env,
-      SESSION_GUARD_DIR: SESSION_DIR,
-      ...extraEnv,
-      CLAUDE_HOOK_TYPE: hookType,
-    };
-    if (!('CLAUDE_CODE_SESSION_ID' in extraEnv)) delete env.CLAUDE_CODE_SESSION_ID;
-    const proc = spawn('node', [HOOK_PATH], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env,
-    });
-
-    let stdout = '';
-    let stderr = '';
-    proc.stdout.on('data', (d) => {
-      stdout += d.toString();
-    });
-    proc.stderr.on('data', (d) => {
-      stderr += d.toString();
-    });
-    proc.on('close', (code) => resolve({ stdout, stderr, code }));
-    proc.on('error', reject);
-
-    proc.stdin.write(JSON.stringify(hookData));
-    proc.stdin.end();
-  });
+  const env = {
+    SESSION_GUARD_DIR: SESSION_DIR,
+    ...extraEnv,
+    CLAUDE_HOOK_TYPE: hookType,
+  };
+  if (!('CLAUDE_CODE_SESSION_ID' in extraEnv)) env.CLAUDE_CODE_SESSION_ID = undefined;
+  return spawnHook(HOOK_PATH, hookData, env);
 }
 
 describe('session-guard', () => {

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-visual-only.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-visual-only.test.js
@@ -1,0 +1,55 @@
+// Visual-only RED gate: Storybook stories are visual artifacts with no
+// executable assertions. When a task's `### Files in scope` contains only
+// `.stories.[jt]sx?` files, the gate validates RED via the verification
+// command (e.g. `pnpm dev:check`) instead of requiring a `*.test.*` file.
+// See task-next.js `isVisualOnlyTask()`.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isVisualOnlyTask } = require('../task-next.js');
+
+test('isVisualOnlyTask: true for scope of a single .stories.tsx file', () => {
+  assert.equal(
+    isVisualOnlyTask([
+      'components/content/recycle-bin-dialogs/recycle-bin-restore-destination-dialog.stories.tsx',
+    ]),
+    true
+  );
+});
+
+test('isVisualOnlyTask: true for multiple .stories.* files (tsx + ts + jsx)', () => {
+  assert.equal(
+    isVisualOnlyTask(['a/foo.stories.tsx', 'b/bar.stories.ts', 'c/baz.stories.jsx']),
+    true
+  );
+});
+
+test('isVisualOnlyTask: false when scope mixes story + non-story files', () => {
+  assert.equal(isVisualOnlyTask(['components/foo.stories.tsx', 'components/foo.tsx']), false);
+});
+
+test('isVisualOnlyTask: false for plain component file', () => {
+  assert.equal(isVisualOnlyTask(['components/foo.tsx']), false);
+});
+
+test('isVisualOnlyTask: false for a `*.test.*` file', () => {
+  assert.equal(isVisualOnlyTask(['components/foo.test.tsx']), false);
+});
+
+test('isVisualOnlyTask: false for empty / missing / wrong-shape scope', () => {
+  assert.equal(isVisualOnlyTask([]), false);
+  assert.equal(isVisualOnlyTask(undefined), false);
+  assert.equal(isVisualOnlyTask(null), false);
+  assert.equal(isVisualOnlyTask('components/foo.stories.tsx'), false);
+});
+
+test('isVisualOnlyTask: ignores non-string entries defensively', () => {
+  assert.equal(isVisualOnlyTask(['a.stories.tsx', 42]), false);
+});
+
+test('isVisualOnlyTask: case-insensitive match on extension', () => {
+  assert.equal(isVisualOnlyTask(['components/Foo.Stories.TSX']), true);
+});

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -235,6 +235,19 @@ function isDocsExempt(type, section) {
   return (type || '') === 'docs' || /documentation[\s-]*exempt|docs[-\s]?only/i.test(section || '');
 }
 
+// Storybook stories are visual artifacts — `*.stories.tsx` files have no
+// executable assertions, so demanding a `*.test.*` authorship gate is
+// contradictory. When a task's `### Files in scope` consists exclusively of
+// `.stories.[jt]sx?` entries, treat the task as test-exempt; the verification
+// command (typically `pnpm dev:check`) still proves RED by failing while the
+// story file is absent, and GREEN by passing once it lands. Detected by scope
+// shape rather than a body marker so authors don't need to remember magic
+// phrases. See split-in-tasks SKILL.md Rule 10.
+function isVisualOnlyTask(scope) {
+  if (!Array.isArray(scope) || scope.length === 0) return false;
+  return scope.every((p) => typeof p === 'string' && /\.stories\.[jt]sx?$/i.test(p));
+}
+
 function parseTaskTestCommand(section) {
   const m = section.match(/### *Test Command[^\n]*\n+```(?:[a-zA-Z]+)?\n([\s\S]*?)\n```/);
   return m ? m[1].trim() : '';
@@ -544,9 +557,7 @@ function findTestFilesInScope(repoRoot, scope) {
       const ext = path.extname(p);
       const base = path.basename(p, ext);
       const escapedBase = base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const colocatedRe = new RegExp(
-        '^' + escapedBase + '\\.(test|spec)\\.(?:m?[cj]sx?|tsx?)$',
-      );
+      const colocatedRe = new RegExp('^' + escapedBase + '\\.(test|spec)\\.(?:m?[cj]sx?|tsx?)$');
       const entries = readdirCached(parent);
       if (entries) {
         for (const e of entries) {
@@ -739,6 +750,7 @@ function main() {
   const type = parseTaskType(section);
   const taskTestCmd = parseTaskTestCommand(section);
   const docsExempt = isDocsExempt(type, section);
+  const visualOnly = isVisualOnlyTask(scope);
 
   // Checkpoint tasks are verification-only — no source change, no test
   // authorship, no gherkin scenarios. Asking the agent to satisfy a TDD
@@ -879,17 +891,22 @@ function main() {
         // proving there is at least one failing test block under Suggested
         // Scope. The test command already failed (exitCode !== 0) above —
         // we just need to confirm authorship intent.
-        if (testFiles.length === 0 && docsExempt) {
-          // Docs-exempt: no test surface, but the verification command failed
-          // as RED requires (exitCode !== 0 confirmed above). Accept it.
+        if (testFiles.length === 0 && (docsExempt || visualOnly)) {
+          // Test-exempt: no `*.test.*` authorship surface, but the verification
+          // command failed as RED requires (exitCode !== 0 confirmed above).
+          // Accept it. Fires for documentation tasks (isDocsExempt) and for
+          // Storybook stories-only tasks (isVisualOnlyTask).
           const rec = recordEvidence(TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope);
           if (!rec.ok) {
             blockReason = `Could not record RED evidence:\n${rec.out}`;
           } else {
             advanced = true;
             phase = TDD_PHASES.green;
+            const fallbackLabel = visualOnly
+              ? 'visual-only fallback (Storybook stories-only scope — no testable code surface'
+              : 'docs-exempt fallback (documentation task — no testable code surface';
             process.stdout.write(
-              `task-next: RED accepted via docs-exempt fallback (documentation task — no testable code surface; verification command failed as required).\n`
+              `task-next: RED accepted via ${fallbackLabel}; verification command failed as required).\n`
             );
           }
         } else if (testFiles.length === 0) {
@@ -996,7 +1013,13 @@ function main() {
   process.exit(_exitCode);
 }
 
-module.exports = { filterToTestFiles, findTestFilesInScope, wrapStrictMode, isDocsExempt };
+module.exports = {
+  filterToTestFiles,
+  findTestFilesInScope,
+  wrapStrictMode,
+  isDocsExempt,
+  isVisualOnlyTask,
+};
 
 if (require.main === module) {
   main();

--- a/plugins/work/skills/split-in-tasks/SKILL.md
+++ b/plugins/work/skills/split-in-tasks/SKILL.md
@@ -168,7 +168,9 @@ This is the **ECHO-4453-class wedge**. To avoid it:
 ## Task 2 — GREEN: edit get.ts
 ```
 
-Checkpoint tasks and config-only infrastructure tasks are exempt from the RED/GREEN/REFACTOR deliverables requirement. For those exempt tasks, use a non-phase deliverables list that describes the concrete verifiable work in execution order, for example: `- Update config`, `- Validate config`, `- Document rollout/usage` as applicable.
+Checkpoint tasks, config-only infrastructure tasks, and **Storybook stories-only tasks** are exempt from the RED/GREEN/REFACTOR deliverables requirement. For those exempt tasks, use a non-phase deliverables list that describes the concrete verifiable work in execution order, for example: `- Update config`, `- Validate config`, `- Document rollout/usage` as applicable.
+
+For stories-only tasks, scope shape alone signals the exemption to the implement-gate: when every entry in `### Files in scope` matches `*.stories.[jt]sx?`, `task-next.js`'s `isVisualOnlyTask()` accepts the verification command (typically `pnpm dev:check`) as RED evidence — no `*.test.*` authorship file is required. Use a `### Test Command` of `pnpm dev:check` (lint + typecheck) and document the visual artifact in deliverables. Do NOT mix story files with `.test.*`/`.spec.*` or production source in the same task's scope, or the exemption will not fire.
 
 **Rule 12 — Shared-Resource Detection (MANDATORY for parallel tasks):**
 After marking tasks as `Parallel: Yes`, scan ALL parallel tasks' Suggested Scope for **overlapping production files**. If two or more parallel tasks modify the **same production file** (not test files — those don't conflict):


### PR DESCRIPTION
## Existing Behavior

- `implement-gate` (`task-next.js`) requires at least one `*.test.*` file in scope before accepting a task's RED phase.
- The only exemption path (`isDocsExempt`) fires for tasks typed `docs` or whose body contains `documentation exempt` / `docs-only` — a magic phrase authors must remember.
- Tasks whose sole deliverable is a Storybook stories file (e.g. `RecycleBinRestoreDestinationDialog.stories.tsx`) carry no executable assertions and can never satisfy that requirement, so the gate leaves them RED forever even when `pnpm dev:check` legitimately transitions from failing → passing as the story file lands.

## Intended New Behavior

- New `isVisualOnlyTask(scope)` inspects `### Files in scope`: when **every** entry matches `*.stories.[jt]sx?` (case-insensitive), the task is treated as test-exempt — no magic body phrase needed.
- The existing RED fallback block now checks `docsExempt || visualOnly`, so stories-only tasks advance to GREEN once the verification command (typically `pnpm dev:check`) passes.
- A distinct log line distinguishes the two fallback paths (`visual-only fallback` vs `docs-exempt fallback`) so CI logs are unambiguous.
- `split-in-tasks/SKILL.md` Rule 10 is updated to document Storybook stories-only as a recognised exempt category and explains the scope-shape auto-detect contract, so task authors know they don't need a special marker.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Run the new unit tests directly:

```bash
node --test plugins/work/scripts/workflows/work-implement/__tests__/task-next-visual-only.test.js
```

Expected: 8 tests pass (single story file, multiple story extensions, mixed-scope rejects, empty/null/non-array rejects, non-string entry reject, case-insensitive match).

To verify the gate no longer blocks a real stories-only task:

1. Create a task whose `### Files in scope` contains only `*.stories.tsx` entries and `### Test Command: pnpm dev:check`.
2. Run `task-next.js` before the story file exists — `pnpm dev:check` should fail (RED confirmed).
3. Add the story file so `pnpm dev:check` passes.
4. Run `task-next.js` again — the gate should advance to GREEN and log `RED accepted via visual-only fallback`.

### Test Results

8 new tests in `task-next-visual-only.test.js` — all pass.
All 187 pre-existing `work-implement` tests continue to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to implement-gate RED acceptance for stories-only scope; hook test refactors are test-harness only with no production hook logic changes in the diff.
> 
> **Overview**
> **Storybook stories-only tasks** can advance through the implement gate without a `*.test.*` file when every path in `### Files in scope` matches `*.stories.[jt]sx?`. New `isVisualOnlyTask()` drives that scope-based exemption; RED still requires a failing verification command (e.g. `pnpm dev:check`), with a distinct **visual-only** log line vs docs-exempt. `split-in-tasks` Rule 10 documents the exemption and warns against mixing story scope with tests or production files.
> 
> Hook integration tests gain **`buildHookEnv` / `spawnHook`** so subprocesses do not inherit `.envrc` workflow vars (`TASKS_BASE`, etc.) that caused flakes; `enforce-step-workflow` and `session-guard` suites use the helper, with optional `preserveExtra` where tests intentionally keep parent config. New unit tests cover `isVisualOnlyTask`; a few hook assertions now include `stderr` on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b500031524b623bb1f7477ae825b32d2f2c2ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->