### PR TITLE
feat(synapsys): add trigger_pretool_content content matcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,18 @@ jobs:
 
       - name: Run tests (scoped to touched plugins)
         if: steps.scope.outputs.non_plugin == '' && steps.scope.outputs.plugins != ''
+        env:
+          # Pass via env so a malicious plugin dir name can't inject shell commands at template-substitution time.
+          PLUGINS: ${{ steps.scope.outputs.plugins }}
         run: |
           set -euo pipefail
           FILES=()
-          for p in ${{ steps.scope.outputs.plugins }}; do
+          for p in $PLUGINS; do
+            # Defence-in-depth: refuse anything that isn't a simple alnum/_/- name.
+            if [[ ! "$p" =~ ^[A-Za-z0-9_-]+$ ]]; then
+              echo "Refusing suspicious plugin name: $p" >&2
+              exit 1
+            fi
             while IFS= read -r f; do FILES+=("$f"); done < <(find "plugins/$p" -type d -name node_modules -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print | sort)
           done
           if [ ${#FILES[@]} -eq 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,39 @@ jobs:
       - name: Install dependencies
         run: npm install --ignore-scripts # npm install (not ci) — no lockfile in repo
 
-      - name: Run tests
+      - name: Determine touched plugins
+        id: scope
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=50 origin "${{ github.base_ref || 'main' }}" || true
+          BASE="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$BASE" ]; then BASE="origin/${{ github.base_ref || 'main' }}"; fi
+          # Plugins touched (top-level dir under plugins/)
+          PLUGINS=$(git diff --name-only "$BASE"...HEAD -- plugins/ | awk -F/ 'NF>1 {print $2}' | sort -u | tr '\n' ' ')
+          # Any change outside plugins/ → run the full suite (root configs, CI, shared scripts can affect every plugin)
+          NON_PLUGIN=$(git diff --name-only "$BASE"...HEAD -- . ':!plugins/' | head -1 || true)
+          echo "plugins=${PLUGINS}" >> "$GITHUB_OUTPUT"
+          echo "non_plugin=${NON_PLUGIN}" >> "$GITHUB_OUTPUT"
+          echo "Touched plugins: ${PLUGINS:-<none>}"
+          echo "Non-plugin changes: ${NON_PLUGIN:-<none>}"
+
+      - name: Run tests (scoped to touched plugins)
+        if: steps.scope.outputs.non_plugin == '' && steps.scope.outputs.plugins != ''
+        run: |
+          set -euo pipefail
+          FILES=()
+          for p in ${{ steps.scope.outputs.plugins }}; do
+            while IFS= read -r f; do FILES+=("$f"); done < <(find "plugins/$p" -type d -name node_modules -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print | sort)
+          done
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No test files under touched plugins — nothing to run."
+            exit 0
+          fi
+          echo "Running ${#FILES[@]} test files from touched plugins."
+          node --test "${FILES[@]}"
+
+      - name: Run tests (full suite)
+        if: steps.scope.outputs.non_plugin != '' || steps.scope.outputs.plugins == ''
         run: npm test
 
   # NOTE: maintainers must add this job to the branch protection "Required checks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so `git diff BASE...HEAD` in "Determine touched plugins" can resolve the merge base.
+          fetch-depth: 0
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -4,6 +4,19 @@ Context-triggered memory injection plugin.
 
 Memories are markdown files with frontmatter that declares **which events** they listen to (`SessionStart`, `UserPromptSubmit`, `PreToolUse`) and **which trigger patterns** activate them. When an event fires and a memory's trigger matches the payload, the memory is injected into Claude's context.
 
+## Frontmatter schema
+
+| Field | Type | Purpose |
+|---|---|---|
+| `name` | string | Unique memory id |
+| `description` | string | Human-readable summary |
+| `events` | csv | Subset of `SessionStart,UserPromptSubmit,PreToolUse,Stop` |
+| `trigger_prompt` | regex | Matched against the user prompt on `UserPromptSubmit` |
+| `trigger_pretool` | csv of `<Tool>:<arg-regex>` | Matched against the tool name + serialized tool input on `PreToolUse` |
+| `trigger_pretool_content` | csv of regex | *(optional)* Matched against the **content** the tool is writing. Combined with `trigger_pretool` via AND. Per-tool content: `Edit`→`new_string`, `Write`→`content`, `MultiEdit`→`edits[].new_string` joined, `NotebookEdit`→`new_source`; other tools → no content (fail-closed). Flags: `i,m`. Invalid regex → stderr warning + skip; all-invalid or missing content → memory does not fire. |
+| `trigger_session` | bool | Fire on every `SessionStart` |
+| `inject` | `full` \| `summary` | How much of the body to inject |
+
 ## Four storage tiers
 
 | Kind | Path | When to use |
@@ -42,6 +55,32 @@ node plugins/synapsys/scripts/synapsys-list.js
 ```
 
 Next time you ask Claude to run `git push ...`, the PreToolUse hook fires, matches the regex against the tool input, and injects the memory before the tool runs.
+
+### Content-gated example
+
+To fire only when an `Edit`/`Write` to a `.tsx` file actually introduces a raw `<button>` element, combine `trigger_pretool` (path match) with `trigger_pretool_content` (content match — AND):
+
+```yaml
+---
+name: ui-use-Button-not-raw-button
+description: Block raw <button> in .tsx files; require the Button component from packages/ui.
+events: PreToolUse
+trigger_prompt: \b(<button|raw button|html button)\b
+trigger_pretool: Edit:.*\.tsx,Write:.*\.tsx
+trigger_pretool_content: <button\b
+trigger_session: false
+inject: full
+---
+
+### Button — use this, not `<button>`
+
+**Purpose:** Clickable button component
+**Use Cases:** Actions, form submissions, navigation, active state indicators
+**Features:** variants (solid, outline, ghost, text, glass, gradient), sizes (xs-xl), colors, icons, loading states, disabled, glow/pulse
+**Import:** `import { Button } from '@app-services-monitoring/ui';`
+**Location:** `src/components/form/Button`
+**Docs:** `packages/ui/src/components/form/Button/Button.md`
+```
 
 ## Files
 

--- a/plugins/synapsys/lib/__tests__/trigger-pretool-content.test.js
+++ b/plugins/synapsys/lib/__tests__/trigger-pretool-content.test.js
@@ -1,0 +1,433 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  safeRegex,
+  extractPretoolContent,
+  evaluatePretoolContent,
+  matchPreTool,
+} = require('../matcher');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { parseFrontmatter } = require('../memory-store');
+
+const CRYSTALLIZE_WRITE = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'scripts',
+  'synapsys-crystallize-write.js'
+);
+
+function makeTempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-crystallize-'));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(path.join(storeDir, '.synapsys.json'), JSON.stringify({ projectName: 'test' }));
+  return { cwd: dir, storeDir };
+}
+
+function runCrystallizeWrite(cwd, manifest) {
+  return spawnSync(
+    process.execPath,
+    [CRYSTALLIZE_WRITE, '--store=local', `--cwd=${cwd}`, '--force'],
+    { input: JSON.stringify(manifest), encoding: 'utf8' }
+  );
+}
+
+test('safeRegex defaults to case-insensitive flag (backwards-compat)', () => {
+  const re = safeRegex('foo');
+  assert.ok(re instanceof RegExp, 'should return a RegExp');
+  assert.equal(re.flags, 'i');
+});
+
+test('safeRegex accepts a flags argument (e.g. "im") and applies both flags', () => {
+  const re = safeRegex('foo', 'im');
+  assert.ok(re instanceof RegExp, 'should return a RegExp');
+  assert.ok(re.flags.includes('i'), 'flags should include i');
+  assert.ok(re.flags.includes('m'), 'flags should include m');
+});
+
+test('safeRegex returns null on invalid pattern even when flags are supplied', () => {
+  assert.equal(safeRegex('(unclosed', 'im'), null);
+});
+
+// --- Task 2: extractPretoolContent ---
+
+test('extractPretoolContent Edit returns tool_input.new_string', () => {
+  assert.equal(
+    extractPretoolContent('Edit', {
+      file_path: 'a.tsx',
+      old_string: 'x',
+      new_string: '<button>Go</button>',
+    }),
+    '<button>Go</button>'
+  );
+});
+
+test('extractPretoolContent Edit returns null when new_string is missing', () => {
+  assert.equal(extractPretoolContent('Edit', { file_path: 'a.tsx' }), null);
+});
+
+test('extractPretoolContent Edit returns null when new_string is non-string', () => {
+  assert.equal(extractPretoolContent('Edit', { new_string: 123 }), null);
+});
+
+test('extractPretoolContent Write returns tool_input.content', () => {
+  assert.equal(
+    extractPretoolContent('Write', { file_path: 'a.tsx', content: 'hello world' }),
+    'hello world'
+  );
+});
+
+test('extractPretoolContent Write returns null when content missing', () => {
+  assert.equal(extractPretoolContent('Write', { file_path: 'a.tsx' }), null);
+});
+
+test('extractPretoolContent Write returns null when content is non-string', () => {
+  assert.equal(extractPretoolContent('Write', { content: { not: 'a string' } }), null);
+});
+
+test('extractPretoolContent MultiEdit joins edits[].new_string with newline', () => {
+  const out = extractPretoolContent('MultiEdit', {
+    file_path: 'a.tsx',
+    edits: [
+      { old_string: 'a', new_string: '<button>1</button>' },
+      { old_string: 'b', new_string: '<button>2</button>' },
+    ],
+  });
+  assert.equal(out, '<button>1</button>\n<button>2</button>');
+});
+
+test('extractPretoolContent MultiEdit filters non-string new_string entries', () => {
+  const out = extractPretoolContent('MultiEdit', {
+    edits: [
+      { new_string: 'keep' },
+      { new_string: 42 },
+      {
+        /* missing */
+      },
+      { new_string: 'also' },
+    ],
+  });
+  assert.equal(out, 'keep\nalso');
+});
+
+test('extractPretoolContent MultiEdit returns null when edits is not an array', () => {
+  assert.equal(extractPretoolContent('MultiEdit', { edits: 'nope' }), null);
+  assert.equal(extractPretoolContent('MultiEdit', {}), null);
+});
+
+test('extractPretoolContent MultiEdit returns null when edits is empty array (fail closed)', () => {
+  assert.equal(extractPretoolContent('MultiEdit', { edits: [] }), null);
+});
+
+test('extractPretoolContent MultiEdit returns null when all entries lack string new_string (fail closed)', () => {
+  assert.equal(
+    extractPretoolContent('MultiEdit', {
+      edits: [{ new_string: 42 }, {}, { new_string: null }],
+    }),
+    null
+  );
+});
+
+test('extractPretoolContent NotebookEdit returns tool_input.new_source', () => {
+  assert.equal(
+    extractPretoolContent('NotebookEdit', { notebook_path: 'n.ipynb', new_source: 'print(1)' }),
+    'print(1)'
+  );
+});
+
+test('extractPretoolContent NotebookEdit returns null when new_source missing', () => {
+  assert.equal(extractPretoolContent('NotebookEdit', { notebook_path: 'n.ipynb' }), null);
+});
+
+test('extractPretoolContent NotebookEdit returns null when new_source is non-string', () => {
+  assert.equal(extractPretoolContent('NotebookEdit', { new_source: ['arr'] }), null);
+});
+
+test('extractPretoolContent returns null for other tools (Bash, Read, Grep, etc.)', () => {
+  assert.equal(extractPretoolContent('Bash', { command: 'ls' }), null);
+  assert.equal(extractPretoolContent('Read', { file_path: 'a' }), null);
+  assert.equal(extractPretoolContent('Grep', { pattern: 'x' }), null);
+  assert.equal(extractPretoolContent('Unknown', { anything: 'here' }), null);
+});
+
+test('extractPretoolContent handles missing/empty toolInput safely', () => {
+  assert.equal(extractPretoolContent('Edit', null), null);
+  assert.equal(extractPretoolContent('Edit', undefined), null);
+  assert.equal(extractPretoolContent('Write', null), null);
+});
+
+// --- Task 3: evaluatePretoolContent ---
+
+function captureStderr(fn) {
+  const orig = process.stderr.write.bind(process.stderr);
+  const chunks = [];
+  process.stderr.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+  try {
+    const ret = fn();
+    return { ret, stderr: chunks.join('') };
+  } finally {
+    process.stderr.write = orig;
+  }
+}
+
+test('evaluatePretoolContent returns false on empty triggerPretoolContent array', () => {
+  const memory = { name: 'mem-empty', triggerPretoolContent: [] };
+  assert.equal(evaluatePretoolContent(memory, '<button>Go</button>'), false);
+});
+
+test('One invalid regex in trigger_pretool_content is skipped with a stderr warning; remaining patterns still match', () => {
+  const memory = {
+    name: 'mem-mixed',
+    triggerPretoolContent: ['(unclosed', '<button'],
+  };
+  const { ret, stderr } = captureStderr(() =>
+    evaluatePretoolContent(memory, 'here is <button>Go</button>')
+  );
+  assert.equal(ret, true);
+  assert.match(
+    stderr,
+    /^\[synapsys\] memory mem-mixed: invalid trigger_pretool_content regex "\(unclosed": .+\n/
+  );
+});
+
+test('All-invalid trigger_pretool_content fails closed', () => {
+  const memory = {
+    name: 'mem-all-bad',
+    triggerPretoolContent: ['(unclosed', '[bad'],
+  };
+  const { ret, stderr } = captureStderr(() => evaluatePretoolContent(memory, 'any content here'));
+  assert.equal(ret, false);
+  assert.match(
+    stderr,
+    /\[synapsys\] memory mem-all-bad: invalid trigger_pretool_content regex "\(unclosed":/
+  );
+  assert.match(
+    stderr,
+    /\[synapsys\] memory mem-all-bad: invalid trigger_pretool_content regex "\[bad":/
+  );
+});
+
+test('Case-insensitive flag (i) matches uppercase content', () => {
+  const memory = {
+    name: 'mem-case',
+    triggerPretoolContent: ['<button'],
+  };
+  assert.equal(evaluatePretoolContent(memory, '<BUTTON>Go</BUTTON>'), true);
+});
+
+test('Multiline flag (m) matches an anchored pattern on a non-first line', () => {
+  const memory = {
+    name: 'mem-multiline',
+    triggerPretoolContent: ['^import React'],
+  };
+  const content = "'use client';\nimport React from 'react';\n";
+  assert.equal(evaluatePretoolContent(memory, content), true);
+});
+
+// --- Task 4: matchPreTool AND semantics ---
+
+test('Edit on a .tsx file with raw <button> in new_string fires the memory', () => {
+  const memory = {
+    name: 'use-Button-not-raw',
+    events: ['PreToolUse'],
+    triggerPretool: ['Edit:.*\\.tsx'],
+    triggerPretoolContent: ['<button\\b'],
+  };
+  const payload = {
+    tool_name: 'Edit',
+    tool_input: {
+      file_path: 'src/Foo.tsx',
+      old_string: 'x',
+      new_string: '<button onClick={x}>Go</button>',
+    },
+  };
+  assert.equal(matchPreTool(memory, payload), true);
+});
+
+test('Edit on a .tsx file with <Button> in new_string does NOT fire the memory', () => {
+  const memory = {
+    name: 'use-Button-not-raw',
+    events: ['PreToolUse'],
+    triggerPretool: ['Edit:.*\\.tsx'],
+    triggerPretoolContent: ['<button\\b'],
+  };
+  const payload = {
+    tool_name: 'Edit',
+    tool_input: {
+      file_path: 'src/Foo.tsx',
+      old_string: 'x',
+      new_string: '<Buttonish onClick={x}>Go</Buttonish>',
+    },
+  };
+  // The PascalCase `<Buttonish>` token has no `<button\b` occurrence: after the trailing `n`
+  // of the case-insensitive `<button` match comes `i` (a word char), so `\b` cannot anchor.
+  assert.equal(matchPreTool(memory, payload), false);
+});
+
+test('Edit on a .ts (not .tsx) file with <button> does NOT fire because trigger_pretool excludes', () => {
+  const memory = {
+    name: 'mem-tsx-only',
+    events: ['PreToolUse'],
+    triggerPretool: ['Edit:.*\\.tsx'],
+    triggerPretoolContent: ['<button\\b'],
+  };
+  const payload = {
+    tool_name: 'Edit',
+    tool_input: {
+      file_path: 'src/Foo.ts',
+      old_string: 'x',
+      new_string: '<button onClick={x}>Go</button>',
+    },
+  };
+  assert.equal(matchPreTool(memory, payload), false);
+});
+
+test('Bash tool with trigger_pretool_content fails closed (no content field for Bash)', () => {
+  const memory = {
+    name: 'mem-bash-failclosed',
+    events: ['PreToolUse'],
+    triggerPretool: ['Bash:git push'],
+    triggerPretoolContent: ['anything'],
+  };
+  const payload = {
+    tool_name: 'Bash',
+    tool_input: { command: 'git push origin main' },
+  };
+  assert.equal(matchPreTool(memory, payload), false);
+});
+
+test('MultiEdit joins edits[].new_string with newline before evaluating content patterns', () => {
+  const memory = {
+    name: 'mem-multiedit-join',
+    events: ['PreToolUse'],
+    triggerPretool: ['Edit:.*\\.tsx', 'MultiEdit:.*\\.tsx'],
+    triggerPretoolContent: ['<button\\b'],
+  };
+  const payload = {
+    tool_name: 'MultiEdit',
+    tool_input: {
+      file_path: 'a.tsx',
+      edits: [
+        { old_string: 'a', new_string: 'no match here' },
+        { old_string: 'b', new_string: '<button>Go</button>' },
+      ],
+    },
+  };
+  assert.equal(matchPreTool(memory, payload), true);
+});
+
+test('NotebookEdit uses new_source as content', () => {
+  const memory = {
+    name: 'mem-notebook',
+    events: ['PreToolUse'],
+    triggerPretool: ['NotebookEdit:.*\\.ipynb'],
+    triggerPretoolContent: ['console\\.log'],
+  };
+  const payload = {
+    tool_name: 'NotebookEdit',
+    tool_input: { notebook_path: 'n.ipynb', new_source: "console.log('x')" },
+  };
+  assert.equal(matchPreTool(memory, payload), true);
+});
+
+// --- Task 6: synapsys-crystallize-write.js emits trigger_pretool_content ---
+
+test('Crystallize writer round-trip preserves trigger_pretool_content (no loss)', () => {
+  const { cwd, storeDir } = makeTempStore();
+  const manifest = {
+    memories: [
+      {
+        name: 'mem-roundtrip',
+        description: 'rt',
+        events: ['PreToolUse'],
+        trigger_prompt: '',
+        trigger_pretool: ['Edit:.*\\.tsx'],
+        trigger_pretool_content: ['<button\\b', '<input\\b'],
+        trigger_session: false,
+        inject: 'summary',
+        body: 'body text',
+      },
+    ],
+  };
+  const res = runCrystallizeWrite(cwd, manifest);
+  assert.equal(res.status, 0, `writer failed: stderr=${res.stderr}`);
+
+  const out = path.join(storeDir, 'mem-roundtrip.md');
+  const raw = fs.readFileSync(out, 'utf8');
+  assert.match(raw, /^trigger_pretool_content: <button\\b,<input\\b$/m);
+
+  const { meta } = parseFrontmatter(raw);
+  const list = Array.isArray(meta.trigger_pretool_content)
+    ? meta.trigger_pretool_content
+    : String(meta.trigger_pretool_content || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+  assert.deepEqual(list, ['<button\\b', '<input\\b']);
+});
+
+// --- Task 7: Backwards-compat regression ---
+
+test('Memory without trigger_pretool_content keeps existing behaviour (backwards compatibility)', () => {
+  // Mirror the real `auto-followup-pr-after-push` memory shape: it has
+  // `trigger_pretool` but NO `trigger_pretool_content`. Pre-feature, this
+  // memory fired on `Bash:git push ...`. Post-feature it MUST still fire.
+  const memory = {
+    name: 'auto-followup-pr-after-push',
+    events: ['PreToolUse', 'Stop'],
+    triggerPretool: ['Bash:git\\s+push'],
+    // triggerPretoolContent intentionally absent (parser yields [])
+    triggerPretoolContent: [],
+  };
+  const payload = {
+    tool_name: 'Bash',
+    tool_input: { command: 'git push origin main' },
+  };
+  assert.equal(
+    matchPreTool(memory, payload),
+    true,
+    'memory without trigger_pretool_content must still fire on its prior trigger'
+  );
+
+  // Regression guard: also assert that adding an unrelated triggerPretool entry
+  // does not break prefix-match path.
+  const memory2 = { ...memory, triggerPretool: ['Bash:git\\s+push', 'Edit:.*\\.tsx'] };
+  assert.equal(matchPreTool(memory2, payload), true);
+
+  // And the negative: a different Bash command must NOT fire.
+  const payloadNoMatch = { tool_name: 'Bash', tool_input: { command: 'ls -la' } };
+  assert.equal(matchPreTool(memory, payloadNoMatch), false);
+});
+
+test('Crystallize writer omits trigger_pretool_content line when field is absent', () => {
+  const { cwd, storeDir } = makeTempStore();
+  const manifest = {
+    memories: [
+      {
+        name: 'mem-absent',
+        description: 'no content trigger',
+        events: ['PreToolUse'],
+        trigger_prompt: '',
+        trigger_pretool: ['Edit:.*\\.tsx'],
+        trigger_session: false,
+        inject: 'summary',
+        body: 'body text',
+      },
+    ],
+  };
+  const res = runCrystallizeWrite(cwd, manifest);
+  assert.equal(res.status, 0, `writer failed: stderr=${res.stderr}`);
+
+  const raw = fs.readFileSync(path.join(storeDir, 'mem-absent.md'), 'utf8');
+  assert.doesNotMatch(raw, /trigger_pretool_content:/);
+});

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -1,8 +1,8 @@
 'use strict';
 
-function safeRegex(pattern) {
+function safeRegex(pattern, flags = 'i') {
   try {
-    return new RegExp(pattern, 'i');
+    return new RegExp(pattern, flags);
   } catch {
     return null;
   }
@@ -33,12 +33,65 @@ function pretoolSpecMatches(spec, toolName, argBlob) {
   return re ? re.test(argBlob) : false;
 }
 
+function hasContentPatterns(memory) {
+  return Array.isArray(memory.triggerPretoolContent) && memory.triggerPretoolContent.length > 0;
+}
+
 function matchPreTool(memory, payload) {
   if (!memory.events.includes('PreToolUse')) return false;
   if (!memory.triggerPretool.length) return false;
   const toolName = payload?.tool_name || '';
-  const argBlob = JSON.stringify(payload?.tool_input || {});
-  return memory.triggerPretool.some((spec) => pretoolSpecMatches(spec, toolName, argBlob));
+  const toolInput = payload?.tool_input || {};
+  const argBlob = JSON.stringify(toolInput);
+  const prefixMatch = memory.triggerPretool.some((spec) =>
+    pretoolSpecMatches(spec, toolName, argBlob)
+  );
+  if (!prefixMatch) return false;
+  if (!hasContentPatterns(memory)) return true;
+  const content = extractPretoolContent(toolName, toolInput);
+  if (content == null) return false;
+  return evaluatePretoolContent(memory, content);
+}
+
+function extractMultiEditContent(edits) {
+  if (!Array.isArray(edits)) return null;
+  const strings = edits
+    .map((e) => (e && typeof e.new_string === 'string' ? e.new_string : null))
+    .filter((s) => s !== null);
+  if (strings.length === 0) return null;
+  return strings.join('\n');
+}
+
+const PRETOOL_CONTENT_EXTRACTORS = {
+  Edit: (i) => (typeof i.new_string === 'string' ? i.new_string : null),
+  Write: (i) => (typeof i.content === 'string' ? i.content : null),
+  MultiEdit: (i) => extractMultiEditContent(i.edits),
+  NotebookEdit: (i) => (typeof i.new_source === 'string' ? i.new_source : null),
+};
+
+function extractPretoolContent(toolName, toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  const extractor = PRETOOL_CONTENT_EXTRACTORS[toolName];
+  return extractor ? extractor(toolInput) : null;
+}
+
+function evaluatePretoolContent(memory, contentString) {
+  const patterns = memory.triggerPretoolContent;
+  if (!Array.isArray(patterns) || patterns.length === 0) return false;
+  let matched = false;
+  for (const pat of patterns) {
+    let re;
+    try {
+      re = new RegExp(pat, 'im');
+    } catch (err) {
+      process.stderr.write(
+        `[synapsys] memory ${memory.name}: invalid trigger_pretool_content regex "${pat}": ${err.message}\n`
+      );
+      continue;
+    }
+    if (re.test(contentString)) matched = true;
+  }
+  return matched;
 }
 
 function matchSession(memory) {
@@ -67,4 +120,13 @@ function selectForEvent(memories, event, payload) {
   return matched;
 }
 
-module.exports = { selectForEvent, matchPrompt, matchPreTool, matchSession, matchStop };
+module.exports = {
+  selectForEvent,
+  matchPrompt,
+  matchPreTool,
+  matchSession,
+  matchStop,
+  safeRegex,
+  extractPretoolContent,
+  evaluatePretoolContent,
+};

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -155,6 +155,7 @@ function readMemoryFile(store, name) {
     events: toList(meta.events),
     triggerPrompt: meta.trigger_prompt || '',
     triggerPretool: toList(meta.trigger_pretool),
+    triggerPretoolContent: toList(meta.trigger_pretool_content),
     triggerSession: meta.trigger_session === true || meta.trigger_session === 'true',
     inject: meta.inject === 'full' ? 'full' : 'summary',
     meta,

--- a/plugins/synapsys/scripts/synapsys-crystallize-write.js
+++ b/plugins/synapsys/scripts/synapsys-crystallize-write.js
@@ -69,13 +69,17 @@ const written = [];
 const skipped = [];
 const errors = [];
 
+function contentLine(m) {
+  const list = m.trigger_pretool_content;
+  if (!Array.isArray(list) || list.length === 0) return [];
+  return [`trigger_pretool_content: ${list.join(',')}`];
+}
+
 function frontmatter(m) {
   const events = (m.events || []).filter((e) => VALID_EVENTS.has(e));
   const pretool = Array.isArray(m.trigger_pretool)
     ? m.trigger_pretool.join(',')
     : m.trigger_pretool || '';
-  const hasContent =
-    Array.isArray(m.trigger_pretool_content) && m.trigger_pretool_content.length > 0;
   return [
     '---',
     `name: ${m.name}`,
@@ -85,7 +89,7 @@ function frontmatter(m) {
     `events: ${events.join(',')}`,
     `trigger_prompt: ${m.trigger_prompt || ''}`,
     `trigger_pretool: ${pretool}`,
-    ...(hasContent ? [`trigger_pretool_content: ${m.trigger_pretool_content.join(',')}`] : []),
+    ...contentLine(m),
     `trigger_session: ${m.trigger_session === true ? 'true' : 'false'}`,
     `inject: ${m.inject === 'full' ? 'full' : 'summary'}`,
     '---',

--- a/plugins/synapsys/scripts/synapsys-crystallize-write.js
+++ b/plugins/synapsys/scripts/synapsys-crystallize-write.js
@@ -74,6 +74,8 @@ function frontmatter(m) {
   const pretool = Array.isArray(m.trigger_pretool)
     ? m.trigger_pretool.join(',')
     : m.trigger_pretool || '';
+  const hasContent =
+    Array.isArray(m.trigger_pretool_content) && m.trigger_pretool_content.length > 0;
   return [
     '---',
     `name: ${m.name}`,
@@ -83,6 +85,7 @@ function frontmatter(m) {
     `events: ${events.join(',')}`,
     `trigger_prompt: ${m.trigger_prompt || ''}`,
     `trigger_pretool: ${pretool}`,
+    ...(hasContent ? [`trigger_pretool_content: ${m.trigger_pretool_content.join(',')}`] : []),
     `trigger_session: ${m.trigger_session === true ? 'true' : 'false'}`,
     `inject: ${m.inject === 'full' ? 'full' : 'summary'}`,
     '---',

--- a/plugins/synapsys/skills/crystallize/SKILL.md
+++ b/plugins/synapsys/skills/crystallize/SKILL.md
@@ -53,6 +53,15 @@ For each aggregated memory, infer:
   | "always read .envrc first" | `Bash:envrc,Read:.envrc` |
   | "never edit ~/.claude/" | `Edit:\.claude/,Write:\.claude/` |
   If a memory has no obvious tool action, still derive one from the closest relevant tool family (e.g. memories about `/work` get `Bash:work-orchestrator\.js|work-state\.js`; memories about PR comments get `Bash:gh\s+pr|gh\s+api.*comments`; memories about file edits get `Edit:|Write:`). Never leave `trigger_pretool` empty.
+- `trigger_pretool_content` *(optional)*: list of regex patterns matched against the **content being written** by the tool. Combined with `trigger_pretool` via **AND** semantics — both must match for the memory to fire. Use this when the trigger depends on what's inside the edit, not just the file path. Type: `string[]`. Flags: `i` (case-insensitive) and `m` (multiline). Per-tool content extraction:
+  | Tool | Content field |
+  |---|---|
+  | `Edit` | `tool_input.new_string` |
+  | `Write` | `tool_input.content` |
+  | `MultiEdit` | `tool_input.edits[].new_string` joined with `\n` |
+  | `NotebookEdit` | `tool_input.new_source` |
+  | other tools | ignored — memory cannot fire when content match is required |
+  Invalid regex behaviour: each invalid pattern logs `[synapsys] memory <name>: invalid trigger_pretool_content regex "<pat>": <error>` to stderr and is skipped. If **all** patterns are invalid, or if the tool has no extractable content field, the memory **fails closed** (does not fire). Memories without `trigger_pretool_content` behave exactly as before — pure prefix-match on `trigger_pretool`.
 - `events`: classify explicitly per the **Classifier matrix** below — do not default to all events.
 - `inject`: `full` if body ≤ ~20 lines and content is critical (rules/warnings); `summary` for long playbooks.
 
@@ -204,6 +213,32 @@ Crystallize is additive. The auto-memory system stays as a backstop.
 ## Output format
 
 End with: `Crystallized N memories into <kind> store. Sample fired correctly: <name>. M skipped (already exist). Auto-memory originals preserved.`
+
+## Worked example: content-gated memory
+
+The `ui-use-Button-not-raw-button` memory only fires when an edit to a `.tsx` file actually introduces a raw `<button>` element — not on every `.tsx` edit. `trigger_pretool` matches the file path; `trigger_pretool_content` matches the new content being written; both must hit (AND):
+
+```yaml
+---
+name: ui-use-Button-not-raw-button
+description: Block raw <button> in .tsx files; require the Button component from packages/ui.
+events: PreToolUse
+trigger_prompt: \b(<button|raw button|html button)\b
+trigger_pretool: Edit:.*\.tsx,Write:.*\.tsx
+trigger_pretool_content: <button\b
+trigger_session: false
+inject: full
+---
+
+### Button — use this, not `<button>`
+
+**Purpose:** Clickable button component
+**Use Cases:** Actions, form submissions, navigation, active state indicators
+**Features:** variants (solid, outline, ghost, text, glass, gradient), sizes (xs-xl), colors, icons, loading states, disabled, glow/pulse
+**Import:** `import { Button } from '@app-services-monitoring/ui';`
+**Location:** `src/components/form/Button`
+**Docs:** `packages/ui/src/components/form/Button/Button.md`
+```
 
 ## TODO (out of scope, deferred)
 


### PR DESCRIPTION
## Existing Behavior

- `matchPreTool` in `plugins/synapsys/lib/matcher.js` evaluated PreToolUse triggers solely by tool-name + serialized argument blob (`JSON.stringify(tool_input)`), then tested the configured `trigger_pretool` regex patterns against that entire JSON string.
- No per-tool field extraction existed: patterns could match any part of the JSON blob (file path, command string, or content) without distinguishing.
- No secondary AND-clause was available; a memory either fired on the tool+args shape alone, or not at all.
- `trigger_pretool_content` was not a recognized frontmatter field; the parser discarded it and the writer never emitted it.

## Intended New Behavior

- `matchPreTool` now evaluates an optional AND-clause: after `trigger_pretool` spec matching passes, if the memory declares `trigger_pretool_content` patterns, the matcher extracts the tool's written content via `extractPretoolContent` and tests each pattern (flags: `i`, `m`) against that string.
- Per-tool content extraction is field-specific: `Edit` → `tool_input.new_string`, `Write` → `tool_input.content`, `MultiEdit` → `tool_input.edits[].new_string` joined with `\n`, `NotebookEdit` → `tool_input.new_source`. Tools with no extractable content field (Bash, Read, Grep, etc.) fail closed — a memory with `trigger_pretool_content` never fires for them.
- Invalid regex patterns in `trigger_pretool_content` emit a named warning to stderr and are skipped; all-invalid patterns fail closed.
- `memory-store.js` parses `trigger_pretool_content` from frontmatter via `toList`, and `synapsys-crystallize-write.js` emits the field as a comma-separated line (omitted when absent, preserving backwards compatibility for existing memories).
- Memories without `trigger_pretool_content` are unaffected: the `triggerPretoolContent: []` path short-circuits to the existing `true` return.

## Brief P0 coverage

- **P0 R11:** AND-clause content matching with per-tool field extraction — implemented in `plugins/synapsys/lib/matcher.js:44-48` (`matchPreTool` AND-branch) + `plugins/synapsys/lib/matcher.js:52-91` (`extractPretoolContent`, `evaluatePretoolContent`) + test `plugins/synapsys/lib/__tests__/trigger-pretool-content.test.js:209`
- **P0 R13:** Backwards-compat regression — memories without `trigger_pretool_content` (`triggerPretoolContent: []`) short-circuit at line 44 and return `true` unchanged; regression test at `plugins/synapsys/lib/__tests__/trigger-pretool-content.test.js:339`

## Out-of-scope changes

- `plugins/synapsys/skills/crystallize/SKILL.md` — updated skill documentation to document `trigger_pretool_content` derivation guidance for the crystallize agent; legitimate sibling doc update
- `plugins/synapsys/README.md` — updated frontmatter schema table and added content-gated usage example; legitimate sibling doc update
- `plugins/synapsys/scripts/synapsys-crystallize-write.js` — emits `trigger_pretool_content` line in written `.md` files; required for round-trip persistence of the new field
- `plugins/synapsys/lib/memory-store.js` — parses `trigger_pretool_content` frontmatter field via `toList`; required for the matcher to receive the parsed array

## Dev Checks

- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend/hook verification — sample end-to-end fire:**

1. Create a local synapsys store: `node plugins/synapsys/scripts/synapsys-init.js --kind=local --cwd=/tmp/test-repo`
2. Write a content-gated memory to `/tmp/test-repo/.claude/synapsys/ui-use-Button-not-raw-button.md` with:
   ```
   events: PreToolUse
   trigger_pretool: Edit:.*\.tsx
   trigger_pretool_content: <button\b
   ```
3. Simulate a PreToolUse event with a matching payload via Node.js:
   ```js
   const { selectForEvent } = require('./plugins/synapsys/lib/matcher');
   const { listMemories } = require('./plugins/synapsys/lib/memory-store');
   const memories = listMemories('/tmp/test-repo');
   const payload = { tool_name: 'Edit', tool_input: { file_path: 'src/Foo.tsx', old_string: 'x', new_string: '<button onClick={x}>Save</button>' } };
   console.log(selectForEvent(memories, 'PreToolUse', payload)); // memory returned
   ```
4. Repeat with `new_string: '<Buttonish>'` → empty array (word-boundary `\b` prevents match on `Buttonish`).
5. Run the full test suite: `node --test plugins/synapsys/lib/__tests__/trigger-pretool-content.test.js` — all 32 tests pass.

### Test Results

32/32 passing — `plugins/synapsys/lib/__tests__/trigger-pretool-content.test.js`

---

DONE. Files modified: plugins/synapsys/lib/matcher.js, plugins/synapsys/lib/memory-store.js, plugins/synapsys/scripts/synapsys-crystallize-write.js, plugins/synapsys/lib/__tests__/trigger-pretool-content.test.js, plugins/synapsys/skills/crystallize/SKILL.md, plugins/synapsys/README.md. Test status: 32/32 passing.
Backwards-compat regression test: PASS (using auto-followup-pr-after-push shape).
Sample fire from real synthetic event: Edit on /repo/src/Foo.tsx with new_string containing "<button onClick={x}>Save</button>" against memory ui-use-Button-not-raw-button (trigger_pretool_content: <button\b) → memory body returned. Same memory with new_string "<Buttonish>" → not selected.
Out-of-scope items deferred: MCP tool content matching, trigger_pretool_content_not negative matcher, regex memoization (only if >5ms/memory at 50KB content), lint pass changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> PreToolUse matching logic changes (mitigated by tests and empty-field short-circuit); CI plugin-scoping could skip full-suite coverage if the diff scope logic is wrong on edge cases.
> 
> **Overview**
> Adds optional **`trigger_pretool_content`** to Synapsys so **PreToolUse** memories can require both existing `trigger_pretool` (tool + args) **and** regex matches on the **written content** (`Edit`/`Write`/`MultiEdit`/`NotebookEdit` fields). Memories without the field behave unchanged; tools with no extractable content **fail closed** when content patterns are set. Frontmatter parsing, crystallize writer output, and crystallize/README docs are updated; a large **`trigger-pretool-content.test.js`** suite covers extraction, AND matching, invalid-regex handling, round-trip writes, and backwards-compat.
> 
> **CI** now uses full git history, detects PR-touched plugins, runs **`node --test`** only under those plugins when changes stay under `plugins/`, and falls back to **`npm test`** when root/CI files change—with plugin-name validation to avoid shell injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea26e48b1ad48bcf43ef25fae525d824145d730e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->