### PR TITLE
feat(split-in-tasks): add three split-warning analysis passes with shared emit module (#450)

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2068,7 +2068,8 @@ describe('enforce-step-workflow', () => {
           tool_name: 'Bash',
           tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET}` },
         },
-        'PreToolUse'
+        'PreToolUse',
+        { ENFORCE_HOOK_DEBUG: '1' }
       );
       assert.equal(
         code,
@@ -2085,7 +2086,8 @@ describe('enforce-step-workflow', () => {
           tool_name: 'Bash',
           tool_input: { command: `node "${WORK_STATE_PATH}" complete ${TEST_TICKET}` },
         },
-        'PreToolUse'
+        'PreToolUse',
+        { ENFORCE_HOOK_DEBUG: '1' }
       );
       assert.equal(
         code,

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2229,6 +2229,38 @@ describe('enforce-step-workflow', () => {
       assert.ok(stderr.includes('BLOCKED'));
     });
 
+    it('blocks work-state.js complete with NODE_OPTIONS env prefix (GH-450 security)', async () => {
+      writeWorkState(makeStepStatus('complete', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: {
+            command: `NODE_OPTIONS=--require=/evil/module node ${WORK_STATE_PATH} complete ${TEST_TICKET}`,
+          },
+        },
+        'PreToolUse'
+      );
+      assert.equal(code, 2, 'NODE_OPTIONS env prefix should be blocked at terminal step');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks work-state.js complete with arbitrary env prefix (GH-450 security)', async () => {
+      writeWorkState(makeStepStatus('complete', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: {
+            command: `FOO=bar node ${WORK_STATE_PATH} complete ${TEST_TICKET}`,
+          },
+        },
+        'PreToolUse'
+      );
+      assert.equal(code, 2, 'any env prefix should be blocked at terminal step');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
     it('blocks work-state.js init-subtask command', async () => {
       writeWorkState(makeStepStatus('implement', WORK_STEPS));
 

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2096,6 +2096,45 @@ describe('enforce-step-workflow', () => {
       );
     });
 
+    it('allows direct work-state.js complete with quoted path containing spaces (GH-450)', async () => {
+      // Regression: cursor[bot] flagged that quote-stripping BEFORE whitespace
+      // split breaks paths like `/Users/John Smith/.../work-state.js` — the
+      // internal space caused split() to produce >4 tokens and the strict
+      // 4-token bypass check failed. The quote-aware tokenizer now keeps
+      // quoted runs as a single token even when they contain whitespace.
+      writeWorkState(makeStepStatus('complete', WORK_STEPS));
+
+      // Create a trusted-dir subdirectory whose NAME contains a space, then
+      // drop a placeholder work-state.js inside it. The trusted-path check
+      // walks parents, so any descendant of WORK_DIR is trusted.
+      const SPACED_DIR = path.join(WORK_DIR, 'has space');
+      const SPACED_PATH = path.join(SPACED_DIR, 'work-state.js');
+      fs.mkdirSync(SPACED_DIR, { recursive: true });
+      fs.writeFileSync(SPACED_PATH, '// placeholder for GH-450 regression test\n');
+      try {
+        const { code, stderr } = await runHook(
+          {
+            tool_name: 'Bash',
+            tool_input: { command: `node "${SPACED_PATH}" complete ${TEST_TICKET}` },
+          },
+          'PreToolUse',
+          { ENFORCE_HOOK_DEBUG: '1' }
+        );
+        assert.equal(
+          code,
+          0,
+          `quoted path with spaces should be tokenized as a single arg and allowed at terminal step. stderr: ${stderr}`
+        );
+        // Sanity: the bypass parser must NOT have rejected on token count.
+        assert.ok(
+          !/reject: token count not 4/.test(stderr),
+          `tokenizer should preserve quoted-with-spaces path as one token. stderr: ${stderr}`
+        );
+      } finally {
+        fs.rmSync(SPACED_DIR, { recursive: true, force: true });
+      }
+    });
+
     it('does not trigger complete bypass for untrusted path (GH-276 security)', async () => {
       // /tmp/work-state.js is not in TRUSTED_SCRIPT_DIRS, so the bypass won't fire.
       // Rule 3b also skips untrusted paths (they are handled by Vector 3).

--- a/plugins/work/scripts/workflows/lib/__tests__/test-cleanup.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/test-cleanup.test.js
@@ -97,6 +97,33 @@ describe('test-cleanup: cleanupSessionGuardLocks removes only test locks', () =>
 describe('test-cleanup: cleanupTestArtifacts is the union', () => {
   it('does not throw and exposes both leak vectors', () => {
     // Smoke test — both paths are best-effort and tolerant of missing config.
-    assert.doesNotThrow(() => cleanupTestArtifacts());
+    //
+    // IMPORTANT: `cleanupTestArtifacts()` deletes ALL TEST-* dirs from the
+    // configured TASKS_BASE. Under `node --test`, test files run concurrently,
+    // so invoking it against the real TASKS_BASE here races sibling test files
+    // (e.g. enforce-step-workflow.test.js writes TEST-ESW-<pid>-N/.work-state.json
+    // and then spawns a hook that reads it; if our cleanup fires between those
+    // two steps, the hook sees `stateLoaded:false` and the sibling test fails
+    // intermittently — observed as flaky GH-276 terminal-bypass failures in CI).
+    //
+    // Isolate both leak vectors to disposable tmp dirs so this smoke test cannot
+    // touch any other test's state:
+    //   - TASKS_BASE → tmp dir (overridden via env, restored in finally)
+    //   - os.tmpdir() → tmp dir (overridden, restored in finally)
+    const tmpTasks = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-smoke-tasks-'));
+    const tmpLocks = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-smoke-locks-'));
+    const origTasksBase = process.env.TASKS_BASE;
+    const origTmpdir = os.tmpdir;
+    process.env.TASKS_BASE = tmpTasks;
+    os.tmpdir = () => tmpLocks;
+    try {
+      assert.doesNotThrow(() => cleanupTestArtifacts());
+    } finally {
+      if (origTasksBase === undefined) delete process.env.TASKS_BASE;
+      else process.env.TASKS_BASE = origTasksBase;
+      os.tmpdir = origTmpdir;
+      fs.rmSync(tmpTasks, { recursive: true, force: true });
+      fs.rmSync(tmpLocks, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -519,17 +519,18 @@ function isTerminalCompleteBypass(cmd, ticketId) {
   trace('tokens', { count: tokens.length, tokens });
 
   // Expect: node <path/work-state.js> complete <ticket>
-  // Allow optional inline env-assignments before the script path, mirroring
-  // how getNodeInvocations() tolerates them. Wrappers (timeout/nice/env) are
-  // rejected — the bypass is for the orchestrator's direct call only.
-  if (tokens.length < 4) {
-    trace('reject: too few tokens');
+  // Env-assignment prefixes (FOO=bar node ...) are DISALLOWED entirely — they
+  // would let an attacker inject `NODE_OPTIONS=--require=/evil/module` (or
+  // NODE_PATH, LD_PRELOAD, DYLD_*, NODE_TLS_REJECT_UNAUTHORIZED, etc.) which
+  // Node.js honors before executing the legitimate script. The bypass is for
+  // the orchestrator's strict, direct call only — no wrappers, no env prefix.
+  if (tokens.length !== 4) {
+    trace('reject: token count not 4');
     return false;
   }
 
   let i = 0;
-  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
-  if (i >= tokens.length || !/^(?:node|nodejs)$/.test(tokens[i])) {
+  if (!/^(?:node|nodejs)$/.test(tokens[i])) {
     trace('reject: no node token', { i, token: tokens[i] });
     return false;
   }

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -470,6 +470,64 @@ function getCurrentStep(state, steps) {
 }
 
 /**
+ * Quote-aware shell tokenizer for the strict bypass parser.
+ *
+ * Splits on whitespace EXCEPT within balanced ASCII single or double quotes,
+ * so paths containing spaces (e.g. `/Users/John Smith/...`) remain a single
+ * token. Surrounding quotes are stripped from each token before return.
+ *
+ * Rejects (returns null) on:
+ *   - Unbalanced quotes (open `"` or `'` with no matching close).
+ *   - Nested/mixed quotes within a token are simply treated literally — we do
+ *     not support shell-style escaping (`\"`, `$'..'`, etc.); the bypass is
+ *     for the orchestrator's strict, direct invocation only.
+ *
+ * @param {string} input
+ * @returns {string[] | null}
+ */
+function shellTokenize(input) {
+  const tokens = [];
+  let current = '';
+  let inToken = false;
+  let quote = null; // either '"' or "'" when inside a quoted run
+
+  for (let idx = 0; idx < input.length; idx++) {
+    const ch = input[idx];
+
+    if (quote) {
+      if (ch === quote) {
+        quote = null; // close quote — token continues (allows `a"b"c` style)
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      inToken = true;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      if (inToken) {
+        tokens.push(current);
+        current = '';
+        inToken = false;
+      }
+      continue;
+    }
+
+    current += ch;
+    inToken = true;
+  }
+
+  if (quote) return null; // unbalanced
+  if (inToken) tokens.push(current);
+  return tokens;
+}
+
+/**
  * Step-conditional bypass for `work-state.js complete` at the terminal step (GH-276).
  * Returns true ONLY when ALL conditions are met:
  *   1. Command is a strict `node <path>/work-state.js complete <ticketId>` invocation
@@ -503,19 +561,18 @@ function isTerminalCompleteBypass(cmd, ticketId) {
     return false;
   }
 
-  // Normalize by stripping balanced surrounding quote pairs from any token.
-  // This collapses both `node /abs/work-state.js ...` and
-  // `node "/abs/work-state.js" ...` into a single canonical form before we
-  // tokenize. Doing this BEFORE split avoids any per-token edge case where
-  // a leading-quote token (which starts with `"`, not `-`) could later trip
-  // an unrelated guard. We only strip ASCII " and ' — no shell-style
-  // backslash escapes are honored, matching the strict shape of the bypass.
-  const normalized = String(cmd)
-    .trim()
-    .replace(/"([^"]*)"/g, '$1')
-    .replace(/'([^']*)'/g, '$1');
-
-  const tokens = normalized.split(/\s+/);
+  // Quote-aware tokenizer: split on whitespace BUT treat quoted runs as one
+  // token. This is critical for paths containing spaces (e.g. macOS
+  // `/Users/John Smith/...`) — splitting after quote-stripping would break
+  // such paths into multiple tokens and fail the strict 4-token check.
+  // We honor only balanced ASCII " and ' pairs (no backslash escapes), which
+  // matches the strict shape of the bypass: orchestrator-issued commands.
+  // Unbalanced quotes return null → reject (caller treats as not-a-bypass).
+  const tokens = shellTokenize(String(cmd).trim());
+  if (tokens === null) {
+    trace('reject: unbalanced quotes');
+    return false;
+  }
   trace('tokens', { count: tokens.length, tokens });
 
   // Expect: node <path/work-state.js> complete <ticket>

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -592,7 +592,21 @@ function isTerminalCompleteBypass(cmd, ticketId) {
   const state = loadStateFile(ticketId, '.work-state.json');
   const currentStep = getCurrentStep(state, WORK_STEPS);
   if (currentStep !== 'complete') {
-    trace('reject: not at terminal step', { currentStep });
+    if (DEBUG_BYPASS) {
+      trace('reject: not at terminal step', {
+        currentStep,
+        ticketId,
+        TASKS_BASE,
+        safeTicketed: safeTicketPath(ticketId),
+        stateLoaded: !!state,
+        stateHasStepStatus: !!state?.stepStatus,
+        stepStatusKeys: state?.stepStatus ? Object.keys(state.stepStatus) : null,
+        completeVal: state?.stepStatus?.complete,
+        WORK_STEPS_len: WORK_STEPS.length,
+      });
+    } else {
+      trace('reject: not at terminal step', { currentStep });
+    }
     return false;
   }
   trace('allow');

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -482,66 +482,121 @@ function getCurrentStep(state, steps) {
  * @returns {boolean}
  */
 function isTerminalCompleteBypass(cmd, ticketId) {
-  // Reject shell operators and substitutions FIRST — cheapest fail-fast.
-  if (/[;&|$`<>(){}\n]/.test(cmd)) return false;
+  const DEBUG_BYPASS = process.env.ENFORCE_HOOK_DEBUG === '1';
+  const trace = (reason, extra) => {
+    if (DEBUG_BYPASS) {
+      try {
+        process.stderr.write(
+          `[isTerminalCompleteBypass] ${reason}` +
+            (extra ? ` | ${JSON.stringify(extra)}` : '') +
+            '\n'
+        );
+      } catch {
+        /* never throw from debug */
+      }
+    }
+  };
 
-  // Token-based parsing (more robust than a single big regex). This mirrors
-  // the same parser Rule 3b uses (getNodeInvocations / extractSubCommand), so
-  // the bypass and the block decision can never disagree on what the user typed.
-  // Previous all-in-one regex with `\S+[\\/]work-state\.js` was observed to
-  // not match on the GitHub Actions runner for unquoted paths even though the
-  // quoted equivalent matched — switching to token parsing eliminates that
-  // regex-engine difference.
-  const tokens = String(cmd).trim().split(/\s+/);
+  // Reject shell operators and substitutions FIRST — cheapest fail-fast.
+  if (/[;&|$`<>(){}\n]/.test(cmd)) {
+    trace('reject: shell metachars');
+    return false;
+  }
+
+  // Normalize by stripping balanced surrounding quote pairs from any token.
+  // This collapses both `node /abs/work-state.js ...` and
+  // `node "/abs/work-state.js" ...` into a single canonical form before we
+  // tokenize. Doing this BEFORE split avoids any per-token edge case where
+  // a leading-quote token (which starts with `"`, not `-`) could later trip
+  // an unrelated guard. We only strip ASCII " and ' — no shell-style
+  // backslash escapes are honored, matching the strict shape of the bypass.
+  const normalized = String(cmd)
+    .trim()
+    .replace(/"([^"]*)"/g, '$1')
+    .replace(/'([^']*)'/g, '$1');
+
+  const tokens = normalized.split(/\s+/);
+  trace('tokens', { count: tokens.length, tokens });
 
   // Expect: node <path/work-state.js> complete <ticket>
-  // Allow optional inline env-assignments and -flags before the script path,
-  // mirroring how getNodeInvocations() tolerates them.
-  if (tokens.length < 4) return false;
+  // Allow optional inline env-assignments before the script path, mirroring
+  // how getNodeInvocations() tolerates them. Wrappers (timeout/nice/env) are
+  // rejected — the bypass is for the orchestrator's direct call only.
+  if (tokens.length < 4) {
+    trace('reject: too few tokens');
+    return false;
+  }
 
-  // Find the `node` (or `nodejs`) token, skipping any leading env-assignments
-  // like FOO=bar. Reject wrappers (timeout, nice, env) — the bypass is meant
-  // for the orchestrator's direct call only, not chained/wrapped invocations.
   let i = 0;
   while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
-  if (i >= tokens.length || !/^(?:node|nodejs)$/.test(tokens[i])) return false;
+  if (i >= tokens.length || !/^(?:node|nodejs)$/.test(tokens[i])) {
+    trace('reject: no node token', { i, token: tokens[i] });
+    return false;
+  }
   i++;
 
-  // Strict bypass: no node flags allowed before the script path. Multi-arg
-  // flags like `--require evil.js` could otherwise smuggle in additional
-  // script execution before work-state.js runs.
-  if (i < tokens.length && tokens[i].startsWith('-')) return false;
+  // Strict bypass: no node flags allowed before the script path.
+  if (i < tokens.length && tokens[i].startsWith('-')) {
+    trace('reject: node flag before script', { token: tokens[i] });
+    return false;
+  }
 
-  // Script path token. Strip surrounding quotes (the shell already stripped
-  // them when the user actually typed quotes; we strip again defensively).
-  if (i >= tokens.length) return false;
-  let scriptPath = tokens[i].replace(/^['"]|['"]$/g, '');
+  // Script path token. Quote-stripping is unnecessary after normalization but
+  // kept defensively for nested-quote pathological inputs.
+  if (i >= tokens.length) {
+    trace('reject: no script token');
+    return false;
+  }
+  const scriptPath = tokens[i].replace(/^['"]|['"]$/g, '');
   i++;
-  if (!/[\\/]work-state\.js$/.test(scriptPath)) return false;
+  if (!/[\\/]work-state\.js$/.test(scriptPath)) {
+    trace('reject: not work-state.js', { scriptPath });
+    return false;
+  }
 
   // Sub-command must be exactly `complete`.
-  if (i >= tokens.length) return false;
-  if (tokens[i] !== 'complete') return false;
+  if (i >= tokens.length || tokens[i] !== 'complete') {
+    trace('reject: sub-command not complete', { token: tokens[i] });
+    return false;
+  }
   i++;
 
   // Ticket arg.
-  if (i >= tokens.length) return false;
+  if (i >= tokens.length) {
+    trace('reject: no ticket token');
+    return false;
+  }
   const targetTicket = tokens[i];
   i++;
 
   // No trailing tokens allowed — strict format only.
-  if (i !== tokens.length) return false;
+  if (i !== tokens.length) {
+    trace('reject: trailing tokens', { remaining: tokens.slice(i) });
+    return false;
+  }
 
   // Verify script path is trusted.
   const resolvedPath = expandPluginRoot(scriptPath);
-  if (!isTrustedScriptPath(resolvedPath, TRUSTED_SCRIPT_DIRS)) return false;
+  if (!isTrustedScriptPath(resolvedPath, TRUSTED_SCRIPT_DIRS)) {
+    trace('reject: untrusted script path', { resolvedPath });
+    return false;
+  }
 
   // Verify ticket arg matches active ticket.
-  if (targetTicket !== ticketId) return false;
+  if (targetTicket !== ticketId) {
+    trace('reject: ticket mismatch', { targetTicket, ticketId });
+    return false;
+  }
 
   // Verify terminal step — reuse shared helper for consistent multi-in_progress handling.
   const state = loadStateFile(ticketId, '.work-state.json');
-  return getCurrentStep(state, WORK_STEPS) === 'complete';
+  const currentStep = getCurrentStep(state, WORK_STEPS);
+  if (currentStep !== 'complete') {
+    trace('reject: not at terminal step', { currentStep });
+    return false;
+  }
+  trace('allow');
+  return true;
 }
 
 /**
@@ -564,8 +619,16 @@ function isTerminalSessionGuardBypass(cmd, ticketId) {
   // Reject shell operators and substitutions FIRST — cheapest fail-fast.
   if (/[;&|$`<>(){}\n]/.test(cmd)) return false;
 
+  // Normalize by stripping balanced surrounding quote pairs (see
+  // isTerminalCompleteBypass for rationale). Keeps quoted and unquoted forms
+  // tokenizing identically on every Node version / OS.
+  const normalized = String(cmd)
+    .trim()
+    .replace(/"([^"]*)"/g, '$1')
+    .replace(/'([^']*)'/g, '$1');
+
   // Token-based parsing (see isTerminalCompleteBypass for rationale).
-  const tokens = String(cmd).trim().split(/\s+/);
+  const tokens = normalized.split(/\s+/);
   if (tokens.length < 4) return false;
 
   let i = 0;

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -520,6 +520,7 @@ function isTerminalCompleteBypass(cmd, ticketId) {
   if (!/[\\/]work-state\.js$/.test(scriptPath)) return false;
 
   // Sub-command must be exactly `complete`.
+  if (i >= tokens.length) return false;
   if (tokens[i] !== 'complete') return false;
   i++;
 

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -482,27 +482,63 @@ function getCurrentStep(state, steps) {
  * @returns {boolean}
  */
 function isTerminalCompleteBypass(cmd, ticketId) {
-  // Strict format: only "node <path>/work-state.js complete <ticketId>"
-  // Accepts quoted paths: node "path/work-state.js" or node 'path/work-state.js'
-  // Reject anything with shell operators, substitutions, or extra arguments
-  const strictPattern =
-    /^node\s+(?:"([^"]+[\\/]work-state\.js)"|'([^']+[\\/]work-state\.js)'|(\S+[\\/]work-state\.js))\s+complete\s+(\S+)\s*$/;
-  const match = strictPattern.exec(cmd);
-  if (!match) return false;
-
-  // Reject shell operators and substitutions
+  // Reject shell operators and substitutions FIRST — cheapest fail-fast.
   if (/[;&|$`<>(){}\n]/.test(cmd)) return false;
 
-  // Extract and verify script path is trusted
-  const scriptPath = match[1] || match[2] || match[3];
+  // Token-based parsing (more robust than a single big regex). This mirrors
+  // the same parser Rule 3b uses (getNodeInvocations / extractSubCommand), so
+  // the bypass and the block decision can never disagree on what the user typed.
+  // Previous all-in-one regex with `\S+[\\/]work-state\.js` was observed to
+  // not match on the GitHub Actions runner for unquoted paths even though the
+  // quoted equivalent matched — switching to token parsing eliminates that
+  // regex-engine difference.
+  const tokens = String(cmd).trim().split(/\s+/);
+
+  // Expect: node <path/work-state.js> complete <ticket>
+  // Allow optional inline env-assignments and -flags before the script path,
+  // mirroring how getNodeInvocations() tolerates them.
+  if (tokens.length < 4) return false;
+
+  // Find the `node` (or `nodejs`) token, skipping any leading env-assignments
+  // like FOO=bar. Reject wrappers (timeout, nice, env) — the bypass is meant
+  // for the orchestrator's direct call only, not chained/wrapped invocations.
+  let i = 0;
+  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
+  if (i >= tokens.length || !/^(?:node|nodejs)$/.test(tokens[i])) return false;
+  i++;
+
+  // Strict bypass: no node flags allowed before the script path. Multi-arg
+  // flags like `--require evil.js` could otherwise smuggle in additional
+  // script execution before work-state.js runs.
+  if (i < tokens.length && tokens[i].startsWith('-')) return false;
+
+  // Script path token. Strip surrounding quotes (the shell already stripped
+  // them when the user actually typed quotes; we strip again defensively).
+  if (i >= tokens.length) return false;
+  let scriptPath = tokens[i].replace(/^['"]|['"]$/g, '');
+  i++;
+  if (!/[\\/]work-state\.js$/.test(scriptPath)) return false;
+
+  // Sub-command must be exactly `complete`.
+  if (tokens[i] !== 'complete') return false;
+  i++;
+
+  // Ticket arg.
+  if (i >= tokens.length) return false;
+  const targetTicket = tokens[i];
+  i++;
+
+  // No trailing tokens allowed — strict format only.
+  if (i !== tokens.length) return false;
+
+  // Verify script path is trusted.
   const resolvedPath = expandPluginRoot(scriptPath);
   if (!isTrustedScriptPath(resolvedPath, TRUSTED_SCRIPT_DIRS)) return false;
 
-  // Verify ticket arg matches active ticket
-  const targetTicket = match[4];
+  // Verify ticket arg matches active ticket.
   if (targetTicket !== ticketId) return false;
 
-  // Verify terminal step — reuse shared helper for consistent multi-in_progress handling
+  // Verify terminal step — reuse shared helper for consistent multi-in_progress handling.
   const state = loadStateFile(ticketId, '.work-state.json');
   return getCurrentStep(state, WORK_STEPS) === 'complete';
 }
@@ -524,27 +560,41 @@ function isTerminalCompleteBypass(cmd, ticketId) {
  * @returns {boolean}
  */
 function isTerminalSessionGuardBypass(cmd, ticketId) {
-  // Strict format: only "node <path>/session-guard.js <finish|reveal|complete> <ticketId>"
-  // Accepts quoted paths: node "path/session-guard.js" or node 'path/session-guard.js'
-  // Reject anything with shell operators, substitutions, or extra arguments
-  const strictPattern =
-    /^node\s+(?:"([^"]+[\\/]session-guard\.js)"|'([^']+[\\/]session-guard\.js)'|(\S+[\\/]session-guard\.js))\s+(finish|reveal|complete)\s+(\S+)\s*$/;
-  const match = strictPattern.exec(cmd);
-  if (!match) return false;
-
-  // Reject shell operators and substitutions
+  // Reject shell operators and substitutions FIRST — cheapest fail-fast.
   if (/[;&|$`<>(){}\n]/.test(cmd)) return false;
 
-  // Extract and verify script path is trusted
-  const scriptPath = match[1] || match[2] || match[3];
+  // Token-based parsing (see isTerminalCompleteBypass for rationale).
+  const tokens = String(cmd).trim().split(/\s+/);
+  if (tokens.length < 4) return false;
+
+  let i = 0;
+  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
+  if (i >= tokens.length || !/^(?:node|nodejs)$/.test(tokens[i])) return false;
+  i++;
+
+  if (i < tokens.length && tokens[i].startsWith('-')) return false;
+
+  if (i >= tokens.length) return false;
+  const scriptPath = tokens[i].replace(/^['"]|['"]$/g, '');
+  i++;
+  if (!/[\\/]session-guard\.js$/.test(scriptPath)) return false;
+
+  if (i >= tokens.length) return false;
+  const subCmd = tokens[i];
+  if (subCmd !== 'finish' && subCmd !== 'reveal' && subCmd !== 'complete') return false;
+  i++;
+
+  if (i >= tokens.length) return false;
+  const targetTicket = tokens[i];
+  i++;
+
+  if (i !== tokens.length) return false;
+
   const resolvedPath = expandPluginRoot(scriptPath);
   if (!isTrustedScriptPath(resolvedPath, TRUSTED_SCRIPT_DIRS)) return false;
 
-  // Verify ticket arg matches active ticket
-  const targetTicket = match[5];
   if (targetTicket !== ticketId) return false;
 
-  // Verify terminal step — reuse shared helper for consistent multi-in_progress handling
   const state = loadStateFile(ticketId, '.work-state.json');
   return getCurrentStep(state, WORK_STEPS) === 'complete';
 }

--- a/plugins/work/skills/split-in-tasks/SKILL.md
+++ b/plugins/work/skills/split-in-tasks/SKILL.md
@@ -256,18 +256,17 @@ After saving, output:
 
 After tasks are decomposed (Step 4) and before the quality review pass (Step 5), the splitter runs three static-analysis passes against the proposed tasks. Each pass that detects a problem emits a single-line `SPLIT-WARNING` token into `tasks.md` (or the splitter's stderr stream) so the operator can decide how to resolve it before committing the split.
 
-Warning line shape (all three passes share this template):
+Warning line shape (all three passes share this Markdown blockquote template, rendered by `lib/emit-warnings.js`):
 
 ```
-SPLIT-WARNING [<pass-id>] Task <N>: <one-line problem summary> — resolve: [keep | merge-with-task-<M> | edit-scope | suppress]
+> ⚠️ SPLIT-WARNING: [Pass <X>] <file>: <one-line problem summary> — hint: <suggested-resolution>
 ```
 
-The operator-resolution choices map 1:1 to the bracketed options:
+The `<suggested-resolution>` text is pass-specific (see each pass below) and names the most likely operator action. Common hint phrases:
 
-- `keep` — accept the warning, leave the split as-is (use when the analysis is a false positive)
-- `merge-with-task-<M>` — combine this task into Task M (use when Pass A/B/C detected a deadlock or scope conflict)
-- `edit-scope` — adjust the task's `### Files in scope` / `### Files explicitly out of scope` and re-run the pass
-- `suppress` — record the warning as acknowledged-but-deferred (use only when the operator has a written rationale)
+- `merge-with-prior-task or convert-to-verification-checkpoint` — Pass A typically suggests merging the empty-RED task into its predecessor or downgrading it to a checkpoint
+- coordinate-with-sibling ticket IDs (e.g. `coordinate with ECHO-5355`) — Pass B includes sibling ticket IDs harvested from `git log`
+- `(a) add a Task 0 / (b) accept blast-radius takeover / (c) confirm with brief author` — Pass C lists the three remediation options in the hint
 
 ### Pass A — Chronological Simulator
 
@@ -276,7 +275,7 @@ The operator-resolution choices map 1:1 to the bracketed options:
 **Warning template:**
 
 ```
-SPLIT-WARNING [pass-a] Task <N>: empty-RED chronological collision with Task <M> on <shared-file> — resolve: [keep | merge-with-task-<M> | edit-scope | suppress]
+> ⚠️ SPLIT-WARNING: [Pass A] <shared-file>: Task <N> RED already holds after Task <M> GREEN — hint: merge-with-prior-task or convert-to-verification-checkpoint
 ```
 
 **Limitations:**
@@ -292,7 +291,7 @@ SPLIT-WARNING [pass-a] Task <N>: empty-RED chronological collision with Task <M>
 **Warning template:**
 
 ```
-SPLIT-WARNING [pass-b] Task <N>: test command references out-of-scope file <path> owned by Task <M> — resolve: [keep | merge-with-task-<M> | edit-scope | suppress]
+> ⚠️ SPLIT-WARNING: [Pass B] <path>: contract divergence with out-of-scope file (consumer/producer shapes differ) — hint: coordinate with <SIBLING-TICKET-ID>
 ```
 
 **Limitations:**
@@ -308,7 +307,7 @@ SPLIT-WARNING [pass-b] Task <N>: test command references out-of-scope file <path
 **Warning template:**
 
 ```
-SPLIT-WARNING [pass-c] Task <N>: pre-existing lint violation in <path> outside ticket scope — resolve: [keep | merge-with-task-<M> | edit-scope | suppress]
+> ⚠️ SPLIT-WARNING: [Pass C] <path>:<line>: pre-existing lint violation (<rule>) outside ticket scope — hint: (a) add a Task 0 / (b) accept blast-radius takeover / (c) confirm with brief author
 ```
 
 **Limitations:**

--- a/plugins/work/skills/split-in-tasks/SKILL.md
+++ b/plugins/work/skills/split-in-tasks/SKILL.md
@@ -233,6 +233,7 @@ Review all generated tasks and check:
 - Every non-checkpoint implementation task has a `### Test Command` with a real, runnable test command
 - Gherkin coverage: every scenario from `gherkin.feature` is referenced by at least one task (if `gherkin.feature` exists)
 - Anti-patterns are absent
+- Split-Warning Passes (Pass A / Pass B / Pass C — see "Split-Warning Passes" section below) emit no unresolved `SPLIT-WARNING` lines, or each emitted warning has an operator-resolution decision recorded
 
 Refactor tasks if any issues are found. Re-validate coverage after any refactoring.
 
@@ -248,6 +249,77 @@ After saving, output:
 - Show requirement count and coverage status (all covered / N gaps)
 - If any coverage gaps remain, list them explicitly
 - Suggest next step: "Run `/work ${FOLDER_NAME}` to start implementation."
+
+---
+
+## Split-Warning Passes
+
+After tasks are decomposed (Step 4) and before the quality review pass (Step 5), the splitter runs three static-analysis passes against the proposed tasks. Each pass that detects a problem emits a single-line `SPLIT-WARNING` token into `tasks.md` (or the splitter's stderr stream) so the operator can decide how to resolve it before committing the split.
+
+Warning line shape (all three passes share this template):
+
+```
+SPLIT-WARNING [<pass-id>] Task <N>: <one-line problem summary> — resolve: [keep | merge-with-task-<M> | edit-scope | suppress]
+```
+
+The operator-resolution choices map 1:1 to the bracketed options:
+
+- `keep` — accept the warning, leave the split as-is (use when the analysis is a false positive)
+- `merge-with-task-<M>` — combine this task into Task M (use when Pass A/B/C detected a deadlock or scope conflict)
+- `edit-scope` — adjust the task's `### Files in scope` / `### Files explicitly out of scope` and re-run the pass
+- `suppress` — record the warning as acknowledged-but-deferred (use only when the operator has a written rationale)
+
+### Pass A — Chronological Simulator
+
+**When it fires:** After Step 4.1, when two or more tasks declare overlapping `### Files in scope` AND one of them has an empty RED deliverable (no failing test authored). This catches the ECHO-5361-class wedge where a task ships GREEN code without the RED test to gate it.
+
+**Warning template:**
+
+```
+SPLIT-WARNING [pass-a] Task <N>: empty-RED chronological collision with Task <M> on <shared-file> — resolve: [keep | merge-with-task-<M> | edit-scope | suppress]
+```
+
+**Limitations:**
+
+- Pass A does not cross task boundaries beyond direct file overlap (transitive dependencies are out of scope)
+- Pass A only inspects declared scope; it cannot detect implicit edits made via globs that overlap at runtime
+- The RED-emptiness check is a regex grep for `**RED:**` markers — tasks that use a non-standard phase prefix are not analyzed
+
+### Pass B — Contract Extractor
+
+**When it fires:** After Step 4.1, when a task's `### Test Command` references a file (via `$CHANGED_FILES`) that is NOT listed under that task's `### Files in scope` and IS listed under a sibling task's `### Files in scope`. This catches the ECHO-5362-class contract divergence where Task A's test depends on a contract owned by Task B.
+
+**Warning template:**
+
+```
+SPLIT-WARNING [pass-b] Task <N>: test command references out-of-scope file <path> owned by Task <M> — resolve: [keep | merge-with-task-<M> | edit-scope | suppress]
+```
+
+**Limitations:**
+
+- Cross-task contracts that flow through node_modules, generated code, or framework boundaries are invisible to the static parse
+- Pass B assumes every sibling task's scope is correctly declared; if a sibling's scope is itself wrong, Pass B will silently agree
+- Pass B parses the literal `CHANGED_FILES="..."` value; it does not expand shell globs or evaluate command substitution
+
+### Pass C — Lint Blast Radius
+
+**When it fires:** After Step 4.1, when a task's `### Files in scope` includes a file that currently has lint violations OR is within a directory where `pnpm lint` would surface pre-existing violations outside the ticket's stated scope. This catches the ECHO-5353-class regression where a task's GREEN edit is blocked by pre-existing lint debt the task never intended to touch.
+
+**Warning template:**
+
+```
+SPLIT-WARNING [pass-c] Task <N>: pre-existing lint violation in <path> outside ticket scope — resolve: [keep | merge-with-task-<M> | edit-scope | suppress]
+```
+
+**Limitations:**
+
+- Pass C does not run formatters (biome / prettier) — formatting drift is intentionally out of scope
+- Pass C falls back to a static AST parse when no `pnpm lint` script is detected; the static parse covers only syntactic rules, not project-specific ESLint plugins
+- The blast-radius heuristic uses directory-level grouping; very large directories may produce noisy warnings that the operator must resolve with `suppress`
+
+### De-duplication and operator workflow
+
+When the same file triggers warnings from multiple passes, the splitter collapses them into one consolidated `SPLIT-WARNING` line with the most-specific pass ID. The operator resolves each unique warning once; resolved warnings are removed from `tasks.md` before commit. The operator hint at the end of each warning is intentionally machine-readable so downstream tooling (e.g. `/work-implement`'s implement-gate) can detect unresolved warnings and refuse to advance until they are addressed.
 
 ---
 

--- a/plugins/work/skills/split-in-tasks/__tests__/chronological-simulator.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/chronological-simulator.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const MODULE_PATH = path.resolve(__dirname, '..', 'lib', 'chronological-simulator.js');
+const FIXTURES = path.resolve(__dirname, 'fixtures');
+
+/**
+ * Minimal task-parser sufficient for the simulator tests. The simulator
+ * itself does not depend on this — it consumes the parsed shape:
+ *   { id, title, deliverables: string[], redAssertions: string[] }
+ */
+function parseTasksMarkdown(md) {
+  const sections = md.split(/^## Task /m).slice(1);
+  return sections.map((section) => {
+    const headerMatch = section.match(/^(\d+)\s+—\s+(.+)$/m);
+    const id = headerMatch ? Number(headerMatch[1]) : null;
+    const title = headerMatch ? headerMatch[2].trim() : '';
+    const deliverables = [];
+    const redAssertions = [];
+    const lines = section.split('\n');
+    for (const line of lines) {
+      const m = line.match(/^\s*-\s*\[\s*\]\s*\d+\.\d+\s+\*\*(GREEN|RED|REFACTOR)[:\*]+\s*(.*)$/);
+      if (m) {
+        const phase = m[1];
+        const text = m[2].replace(/\*+/g, '').trim();
+        deliverables.push({ phase, text });
+        if (phase === 'RED') redAssertions.push(text);
+      }
+    }
+    return { id, title, deliverables, redAssertions };
+  });
+}
+
+function loadFixture(name) {
+  const dir = path.join(FIXTURES, name);
+  const md = fs.readFileSync(path.join(dir, 'tasks.md'), 'utf8');
+  const treeJson = JSON.parse(fs.readFileSync(path.join(dir, 'initial-tree.json'), 'utf8'));
+  return {
+    tasks: parseTasksMarkdown(md),
+    initialTree: treeJson.files,
+  };
+}
+
+describe('chronological-simulator — Pass A', () => {
+  describe('mutation parser / projected tree', () => {
+    it('projected tree after Task 1 omits surfaces/foo.ts in echo-5361 fixture (delete verb)', () => {
+      const { simulate } = require(MODULE_PATH);
+      const { tasks, initialTree } = loadFixture('echo-5361');
+      const result = simulate({ tasks, initialTree });
+      const projected = result.projectedTreeAfter(1);
+      assert.ok(Array.isArray(projected), 'projectedTreeAfter must return an array');
+      assert.ok(
+        !projected.includes('surfaces/foo.ts'),
+        `projected tree after Task 1 must omit surfaces/foo.ts; got: ${JSON.stringify(projected)}`
+      );
+      assert.ok(
+        projected.includes('surfaces/bar.ts'),
+        `projected tree after Task 1 must retain surfaces/bar.ts; got: ${JSON.stringify(projected)}`
+      );
+    });
+
+    it('recognises additive verbs (create/add/introduce/new file) and adds files to projected tree', () => {
+      const { simulate } = require(MODULE_PATH);
+      const tasks = [
+        {
+          id: 1,
+          title: 'Add new module',
+          deliverables: [{ phase: 'GREEN', text: 'create surfaces/new-thing.ts with the export' }],
+          redAssertions: [],
+        },
+      ];
+      const result = simulate({ tasks, initialTree: ['package.json'] });
+      const projected = result.projectedTreeAfter(1);
+      assert.ok(
+        projected.includes('surfaces/new-thing.ts'),
+        `projected tree must include newly created file; got: ${JSON.stringify(projected)}`
+      );
+    });
+  });
+
+  describe('warning emission (AC1 / AC2)', () => {
+    it('echo-5361 fixture emits exactly one warning naming Task 2 with the merge/checkpoint hint', () => {
+      const { simulate } = require(MODULE_PATH);
+      const { tasks, initialTree } = loadFixture('echo-5361');
+      const result = simulate({ tasks, initialTree });
+      assert.ok(Array.isArray(result.warnings), 'warnings must be an array');
+      assert.equal(
+        result.warnings.length,
+        1,
+        `expected exactly 1 warning, got ${result.warnings.length}: ${JSON.stringify(result.warnings)}`
+      );
+      const w = result.warnings[0];
+      const blob = `${w.message || ''} ${w.hint || ''} ${w.file || ''}`;
+      assert.match(blob, /Task 2/i, `warning must reference Task 2; got: ${JSON.stringify(w)}`);
+      assert.match(
+        blob,
+        /merge-with-prior-task or convert-to-verification-checkpoint/,
+        `warning must include the merge/checkpoint hint; got: ${JSON.stringify(w)}`
+      );
+    });
+
+    it('echo-5361-clean fixture emits zero warnings', () => {
+      const { simulate } = require(MODULE_PATH);
+      const { tasks, initialTree } = loadFixture('echo-5361-clean');
+      const result = simulate({ tasks, initialTree });
+      assert.equal(
+        result.warnings.length,
+        0,
+        `expected zero warnings, got ${result.warnings.length}: ${JSON.stringify(result.warnings)}`
+      );
+    });
+
+    it('formatted warning rendering goes through emit-warnings (formatWarnings)', () => {
+      const { simulate } = require(MODULE_PATH);
+      const { formatWarnings } = require(path.resolve(__dirname, '..', 'lib', 'emit-warnings.js'));
+      const { tasks, initialTree } = loadFixture('echo-5361');
+      const result = simulate({ tasks, initialTree });
+      const rendered = formatWarnings(result.warnings);
+      assert.match(rendered, /^> ⚠️ SPLIT-WARNING:/m, 'rendered output must use SPLIT-WARNING blockquote');
+      assert.match(rendered, /Pass A/, 'rendered output must cite Pass A');
+    });
+  });
+
+  describe('purity (R13/R14)', () => {
+    it('module source contains no console.* / process.exit calls', () => {
+      const src = fs.readFileSync(MODULE_PATH, 'utf8');
+      assert.ok(!/console\.[a-z]+\s*\(/.test(src), 'module must not call console.*');
+      assert.ok(!/process\.exit\s*\(/.test(src), 'module must not call process.exit');
+    });
+  });
+});

--- a/plugins/work/skills/split-in-tasks/__tests__/contract-extractor.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/contract-extractor.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const MODULE_PATH = path.resolve(__dirname, '..', 'lib', 'contract-extractor.js');
 const FIXTURE_DIRTY = path.resolve(__dirname, 'fixtures', 'echo-5362');
 const FIXTURE_CLEAN = path.resolve(__dirname, 'fixtures', 'echo-5362-clean');
+const FIXTURE_GENERIC = path.resolve(__dirname, 'fixtures', 'generic-array-wrapper');
 
 describe('contract-extractor — extractExports', () => {
   it('extracts the consumer signature from echo-5362 deleter-select-field.tsx and references data.map', () => {
@@ -74,7 +75,11 @@ describe('contract-extractor — runPassB on echo-5362 fixture (dirty)', () => {
     const out = runPassB(FIXTURE_DIRTY);
     assert.ok(out, 'runPassB must return a result');
     assert.ok(Array.isArray(out.warnings), 'expected warnings array');
-    assert.equal(out.warnings.length, 1, `expected exactly one warning, got ${out.warnings.length}`);
+    assert.equal(
+      out.warnings.length,
+      1,
+      `expected exactly one warning, got ${out.warnings.length}`
+    );
     const w = out.warnings[0];
     assert.equal(w.kind, 'B', 'expected Pass B warning');
     assert.match(
@@ -86,6 +91,33 @@ describe('contract-extractor — runPassB on echo-5362 fixture (dirty)', () => {
       `${w.message} ${w.hint || ''}`,
       /[A-Z]+-\d+/,
       'expected sibling ticket ID in message or hint'
+    );
+  });
+});
+
+describe('contract-extractor — runPassB on generic array-vs-wrapper fixture', () => {
+  it('detects divergence for non-fixture identifiers (items consumer, rows producer)', () => {
+    const { runPassB } = require(MODULE_PATH);
+    const out = runPassB(FIXTURE_GENERIC);
+    assert.ok(out, 'runPassB must return a result');
+    assert.ok(Array.isArray(out.warnings), 'expected warnings array');
+    assert.equal(
+      out.warnings.length,
+      1,
+      `expected exactly one warning for the generic fixture, got ${out.warnings.length}`
+    );
+    const w = out.warnings[0];
+    assert.equal(w.kind, 'B', 'expected Pass B warning');
+    assert.match(
+      `${w.message} ${w.hint || ''}`,
+      /mismatch|diverge|contract|differ/i,
+      'expected mismatch/divergence wording'
+    );
+    // Should NOT depend on `data`/`deleters` identifiers.
+    assert.doesNotMatch(
+      w.message,
+      /\bdeleters\b/,
+      'generic detector must not reference fixture-specific identifier'
     );
   });
 });

--- a/plugins/work/skills/split-in-tasks/__tests__/contract-extractor.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/contract-extractor.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const MODULE_PATH = path.resolve(__dirname, '..', 'lib', 'contract-extractor.js');
+const FIXTURE_DIRTY = path.resolve(__dirname, 'fixtures', 'echo-5362');
+const FIXTURE_CLEAN = path.resolve(__dirname, 'fixtures', 'echo-5362-clean');
+
+describe('contract-extractor — extractExports', () => {
+  it('extracts the consumer signature from echo-5362 deleter-select-field.tsx and references data.map', () => {
+    const { extractExports } = require(MODULE_PATH);
+    const filePath = path.join(FIXTURE_DIRTY, 'deleter-select-field.tsx');
+    const result = extractExports(filePath);
+    assert.ok(Array.isArray(result), 'extractExports must return an array');
+    assert.ok(result.length > 0, 'expected at least one export entry');
+    const combined = result.map((e) => e.signature || '').join('\n');
+    assert.match(combined, /data\.map/, 'expected an entry whose signature references data.map');
+  });
+
+  it('returns producer signature shape for echo-5362 router.ts referencing deleters', () => {
+    const { extractExports } = require(MODULE_PATH);
+    const filePath = path.join(FIXTURE_DIRTY, 'router.ts');
+    const result = extractExports(filePath);
+    assert.ok(Array.isArray(result) && result.length > 0, 'expected exports');
+    const combined = result.map((e) => e.signature || '').join('\n');
+    assert.match(combined, /deleters/, 'expected producer signature mentioning deleters');
+  });
+});
+
+describe('contract-extractor — safeResolve / path traversal guard', () => {
+  it('throws when filePath resolves outside the project root', () => {
+    const { extractExports } = require(MODULE_PATH);
+    assert.throws(
+      () => extractExports('../../../../etc/passwd', { root: FIXTURE_DIRTY }),
+      /escape|outside|traversal/i,
+      'expected an error mentioning traversal/escape/outside root'
+    );
+  });
+
+  it('safeResolve is exported and throws for escaping paths', () => {
+    const { safeResolve } = require(MODULE_PATH);
+    assert.equal(typeof safeResolve, 'function', 'safeResolve must be a function');
+    assert.throws(
+      () => safeResolve(FIXTURE_DIRTY, '../../../../etc/passwd'),
+      /escape|outside|traversal/i
+    );
+  });
+});
+
+describe('contract-extractor — compareSignatures', () => {
+  it('returns {equal:false, diff:...} when shapes differ', () => {
+    const { compareSignatures } = require(MODULE_PATH);
+    const consumer = { signature: 'data: Array<{ id: string; label: string }>' };
+    const producer = { signature: '{ deleters: Deleter[] }' };
+    const result = compareSignatures(consumer, producer);
+    assert.equal(result.equal, false, 'expected equal:false on differing shapes');
+    assert.ok(result.diff, 'expected diff payload');
+  });
+
+  it('returns {equal:true} when shapes match', () => {
+    const { compareSignatures } = require(MODULE_PATH);
+    const a = { signature: 'data: Array<{ id: string }>' };
+    const b = { signature: 'data: Array<{ id: string }>' };
+    const result = compareSignatures(a, b);
+    assert.equal(result.equal, true);
+  });
+});
+
+describe('contract-extractor — runPassB on echo-5362 fixture (dirty)', () => {
+  it('emits exactly one warning citing the contract mismatch and at least one sibling ticket ID', () => {
+    const { runPassB } = require(MODULE_PATH);
+    const out = runPassB(FIXTURE_DIRTY);
+    assert.ok(out, 'runPassB must return a result');
+    assert.ok(Array.isArray(out.warnings), 'expected warnings array');
+    assert.equal(out.warnings.length, 1, `expected exactly one warning, got ${out.warnings.length}`);
+    const w = out.warnings[0];
+    assert.equal(w.kind, 'B', 'expected Pass B warning');
+    assert.match(
+      `${w.message} ${w.hint || ''}`,
+      /mismatch|diverge|contract|differ/i,
+      'expected mismatch/divergence wording'
+    );
+    assert.match(
+      `${w.message} ${w.hint || ''}`,
+      /[A-Z]+-\d+/,
+      'expected sibling ticket ID in message or hint'
+    );
+  });
+});
+
+describe('contract-extractor — runPassB on echo-5362-clean fixture', () => {
+  it('emits zero warnings when no divergence exists', () => {
+    const { runPassB } = require(MODULE_PATH);
+    const out = runPassB(FIXTURE_CLEAN);
+    assert.ok(out, 'runPassB must return a result');
+    assert.ok(Array.isArray(out.warnings), 'expected warnings array');
+    assert.equal(out.warnings.length, 0, `expected zero warnings, got ${out.warnings.length}`);
+  });
+});

--- a/plugins/work/skills/split-in-tasks/__tests__/emit-warnings.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/emit-warnings.test.js
@@ -8,7 +8,12 @@ describe('emit-warnings — formatWarnings', () => {
   it('renders a blockquote line starting with > ⚠️ SPLIT-WARNING: containing kind/file/message/hint', () => {
     const { formatWarnings } = require(MODULE_PATH);
     const out = formatWarnings([
-      { kind: 'A', file: 'surfaces/foo.ts', message: 'collision detected', hint: 'merge-with-prior-task' },
+      {
+        kind: 'A',
+        file: 'surfaces/foo.ts',
+        message: 'collision detected',
+        hint: 'merge-with-prior-task',
+      },
     ]);
     assert.ok(typeof out === 'string', 'output must be a string');
     const firstLine = out.split('\n')[0];
@@ -81,6 +86,30 @@ describe('emit-warnings — dedupe', () => {
   it('returns empty array on empty input', () => {
     const { dedupe } = require(MODULE_PATH);
     assert.deepEqual(dedupe([]), []);
+  });
+
+  it('iterative merge of A+B+C produces a single non-nested citation prefix', () => {
+    const { dedupe } = require(MODULE_PATH);
+    const result = dedupe([
+      { file: 'x', kind: 'A', message: 'm1', hint: 'h1' },
+      { file: 'x', kind: 'B', message: 'm2', hint: 'h2' },
+      { file: 'x', kind: 'C', message: 'm3', hint: 'h3' },
+    ]);
+    assert.equal(result.length, 1, 'must collapse all same-file warnings into one');
+    const merged = result[0];
+    assert.equal(merged.kind, 'A+B+C', 'kind must be sorted union joined with +');
+    // Citation must appear exactly once — no inner "cites Pass" embedded in the hint.
+    const citationCount = (merged.hint.match(/cites Pass/g) || []).length;
+    assert.equal(
+      citationCount,
+      1,
+      `hint must contain exactly one "cites Pass" prefix, got: ${merged.hint}`
+    );
+    assert.equal(
+      merged.hint,
+      'cites Pass A+B+C: h1 | h2 | h3',
+      'hint must list raw hints once, prefixed by a single citation'
+    );
   });
 });
 

--- a/plugins/work/skills/split-in-tasks/__tests__/emit-warnings.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/emit-warnings.test.js
@@ -1,0 +1,100 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const MODULE_PATH = path.resolve(__dirname, '..', 'lib', 'emit-warnings.js');
+
+describe('emit-warnings — formatWarnings', () => {
+  it('renders a blockquote line starting with > ⚠️ SPLIT-WARNING: containing kind/file/message/hint', () => {
+    const { formatWarnings } = require(MODULE_PATH);
+    const out = formatWarnings([
+      { kind: 'A', file: 'surfaces/foo.ts', message: 'collision detected', hint: 'merge-with-prior-task' },
+    ]);
+    assert.ok(typeof out === 'string', 'output must be a string');
+    const firstLine = out.split('\n')[0];
+    assert.ok(
+      firstLine.startsWith('> ⚠️ SPLIT-WARNING:'),
+      `expected first line to start with "> ⚠️ SPLIT-WARNING:", got: ${firstLine}`
+    );
+    assert.match(out, /surfaces\/foo\.ts/, 'output must contain file');
+    assert.match(out, /collision detected/, 'output must contain message');
+    assert.match(out, /merge-with-prior-task/, 'output must contain hint');
+  });
+
+  it('strips $HOME prefix from emitted paths replacing with ~', () => {
+    const { formatWarnings } = require(MODULE_PATH);
+    const home = process.env.HOME || '/home/test';
+    const prev = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      const out = formatWarnings([
+        { kind: 'B', file: `${home}/repo/src/x.ts`, message: 'm', hint: 'h' },
+      ]);
+      assert.ok(!out.includes(home), `output must not contain raw $HOME (${home}): ${out}`);
+      assert.match(out, /~\/repo\/src\/x\.ts/, 'output must replace $HOME with ~');
+    } finally {
+      process.env.HOME = prev;
+    }
+  });
+
+  it('renders multiple warnings — one block per record', () => {
+    const { formatWarnings } = require(MODULE_PATH);
+    const out = formatWarnings([
+      { kind: 'A', file: 'x', message: 'm1', hint: 'h1' },
+      { kind: 'C', file: 'y', message: 'm2', hint: 'h2' },
+    ]);
+    const count = (out.match(/> ⚠️ SPLIT-WARNING:/g) || []).length;
+    assert.equal(count, 2, 'must emit one SPLIT-WARNING line per warning');
+    assert.match(out, /m1/);
+    assert.match(out, /m2/);
+  });
+});
+
+describe('emit-warnings — dedupe', () => {
+  it('collapses same-file warnings across passes into one warning citing all kinds', () => {
+    const { dedupe } = require(MODULE_PATH);
+    const result = dedupe([
+      { file: 'x', kind: 'A', message: 'm1', hint: 'h1' },
+      { file: 'x', kind: 'C', message: 'm2', hint: 'h2' },
+    ]);
+    assert.equal(result.length, 1, 'must collapse same-file warnings into one');
+    const merged = result[0];
+    assert.equal(merged.file, 'x');
+    const haystack = JSON.stringify(merged);
+    assert.match(haystack, /A/, 'merged warning must cite Pass A');
+    assert.match(haystack, /C/, 'merged warning must cite Pass C');
+    assert.match(haystack, /m1/, 'merged warning must include message m1');
+    assert.match(haystack, /m2/, 'merged warning must include message m2');
+  });
+
+  it('leaves distinct file paths as separate warnings', () => {
+    const { dedupe } = require(MODULE_PATH);
+    const result = dedupe([
+      { file: 'x', kind: 'A', message: 'm1', hint: 'h1' },
+      { file: 'y', kind: 'A', message: 'm2', hint: 'h2' },
+    ]);
+    assert.equal(result.length, 2, 'distinct files must remain separate');
+    const files = result.map((r) => r.file).sort();
+    assert.deepEqual(files, ['x', 'y']);
+  });
+
+  it('returns empty array on empty input', () => {
+    const { dedupe } = require(MODULE_PATH);
+    assert.deepEqual(dedupe([]), []);
+  });
+});
+
+describe('emit-warnings — purity', () => {
+  it('module exports formatWarnings and dedupe', () => {
+    const mod = require(MODULE_PATH);
+    assert.equal(typeof mod.formatWarnings, 'function');
+    assert.equal(typeof mod.dedupe, 'function');
+  });
+
+  it('source contains no console.* or process.exit calls', () => {
+    const fs = require('node:fs');
+    const src = fs.readFileSync(MODULE_PATH, 'utf-8');
+    assert.ok(!/console\.[a-z]+\s*\(/.test(src), 'module must not call console.*');
+    assert.ok(!/process\.exit\s*\(/.test(src), 'module must not call process.exit');
+  });
+});

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/combined/tasks.md
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/combined/tasks.md
@@ -1,0 +1,82 @@
+# Tasks (synthetic combined fixture)
+
+_Operator end-to-end fixture for the `split-in-tasks` skill (GH-450, Task 7,
+Scenario 8). Stitches the three regression fixtures into a single synthetic
+ticket so one integration sweep exercises Pass A, Pass B, and Pass C against
+the same project root._
+
+_Sub-fixture map (see sibling directories under `__tests__/fixtures/`):_
+
+- **Pass A — chronological collision** — replays `echo-5361/tasks.md`
+  (Task 1 GREEN deletes `surfaces/foo.ts`; Task 2 RED asserts the same file
+  is gone — already true after Task 1, so the RED is empty).
+- **Pass B — contract divergence** — runs against `echo-5362/`
+  (`deleter-select-field.tsx` consumes a `data: Array<…>` shape from sibling
+  ticket ECHO-5352's `router.ts` which actually returns `{ deleters: … }`).
+- **Pass C — lint blast-radius** — scans `echo-5353/`
+  (pre-existing `no-test-focus` violation in `radial-pixel-table.test.ts`
+  which is NOT in any task's `Files in scope`).
+
+## Task 1 — Chronological collision (mirrors echo-5361)
+
+### Type
+chore
+
+### Files in scope
+- `surfaces/foo.ts`
+
+### Deliverables
+- [ ] 1.1 **GREEN:** delete `surfaces/foo.ts` from the working tree
+  - Test: file `surfaces/foo.ts` no longer exists
+
+---
+
+## Task 2 — Verify legacy surface is gone (empty-RED — Pass A should warn)
+
+### Type
+verification
+
+### Files in scope
+- `surfaces/foo.ts`
+
+### Deliverables
+- [ ] 2.1 **RED:** assert that `surfaces/foo.ts` has been removed
+  - Test: `fs.existsSync('surfaces/foo.ts')` returns false
+- [ ] 2.2 **GREEN:** no implementation needed (verification only)
+
+---
+
+## Task 3 — Contract-divergent consumer (mirrors echo-5362 — Pass B should warn)
+
+### Type
+wiring
+
+### Files in scope
+- `deleter-select-field.tsx`
+
+### Files explicitly out of scope
+- `router.ts` (owned by sibling ticket ECHO-5352)
+
+### Deliverables
+- [ ] 3.1 **RED:** render the select field from `data` array
+  - Test: component renders one `<option>` per entry in `data`
+- [ ] 3.2 **GREEN:** wire `deleter-select-field.tsx` to consume the array
+
+---
+
+## Task 4 — Implement radial pixel renderer (mirrors echo-5353 — Pass C should warn)
+
+### Type
+wiring
+
+### Files in scope
+- `radial-pixel-renderer.ts`
+
+### Files explicitly out of scope
+_(no sibling tickets)_
+
+### Deliverables
+- [ ] 4.1 **RED:** assert renderer returns a non-empty canvas buffer
+  - Test: today the function does not exist
+- [ ] 4.2 **GREEN:** implement renderer
+  - Test: assertion from 4.1 passes

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5353/eslint-output.json
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5353/eslint-output.json
@@ -1,0 +1,20 @@
+[
+  {
+    "filePath": "radial-pixel-table.test.ts",
+    "messages": [
+      {
+        "ruleId": "no-test-focus",
+        "severity": 2,
+        "message": "Unexpected `it.skip` — skipped tests must be tracked or removed.",
+        "line": 17,
+        "column": 6,
+        "nodeType": "CallExpression"
+      }
+    ],
+    "errorCount": 1,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "source": ""
+  }
+]

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5353/package.json
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5353/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "echo-5353-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "_description": "Fixture package.json for ECHO-5353 Pass C regression. Intentionally has NO `lint` script so the resolver falls back to static-parsing eslint-output.json and includes a `Searched:` note in the warning.",
+  "scripts": {
+    "build": "echo no build",
+    "test": "node --test"
+  }
+}

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5353/radial-pixel-table.test.ts
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5353/radial-pixel-table.test.ts
@@ -1,0 +1,19 @@
+// Fixture for ECHO-5353 Pass C regression.
+//
+// This file is intentionally NOT in any task's `Files in scope` in the
+// sibling tasks.md fixture. It contains an `it.skip(...)` call that
+// violates the `no-test-focus` lint rule recorded in eslint-output.json.
+// Pass C must surface this as a SPLIT-WARNING citing the file, line,
+// rule, and the three resolution options.
+//
+// NOTE: This file lives under __tests__/fixtures/ and is excluded from
+// the real test runner via the fixtures path filter — it is a data
+// artifact, not an executable test.
+
+import { describe, it } from 'node:test';
+
+describe('radial-pixel-table', () => {
+  it.skip('renders the radial pixel grid (skipped — pending design review)', () => {
+    // intentionally skipped — triggers `no-test-focus` rule
+  });
+});

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5353/tasks.md
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5353/tasks.md
@@ -1,0 +1,20 @@
+# Tasks (ECHO-5353 regression fixture)
+
+_Reproduces the ECHO-5353 lint blast-radius: a pre-existing `no-test-focus` violation exists in `radial-pixel-table.test.ts`, which is NOT listed in any task's `Files in scope`. Pass C must surface this violation as a SPLIT-WARNING with the three operator-resolution options._
+
+## Task 1 — Implement radial pixel renderer
+
+### Type
+wiring
+
+### Files in scope
+- `radial-pixel-renderer.ts`
+
+### Files explicitly out of scope
+_(no sibling tickets)_
+
+### Deliverables
+- [ ] 1.1 **RED:** assert renderer returns a non-empty canvas buffer
+  - Test: today the function does not exist
+- [ ] 1.2 **GREEN:** implement renderer
+  - Test: assertion from 1.1 passes

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361-clean/initial-tree.json
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361-clean/initial-tree.json
@@ -1,0 +1,8 @@
+{
+  "_description": "Initial tree snapshot for the ECHO-5361 clean fixture. Task 1 mutates a.ts, Task 2 asserts on b.ts — disjoint files, no collision.",
+  "files": [
+    "a.ts",
+    "b.ts",
+    "package.json"
+  ]
+}

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361-clean/tasks.md
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361-clean/tasks.md
@@ -1,0 +1,31 @@
+# Tasks (ECHO-5361 clean fixture)
+
+_Negative control for Pass A: Task 1 deletes `a.ts`, Task 2 RED asserts behavior on a different file `b.ts`. No chronological collision — Pass A must stay silent._
+
+## Task 1 — Remove a.ts
+
+### Type
+chore
+
+### Files in scope
+- `a.ts`
+
+### Deliverables
+- [ ] 1.1 **GREEN:** delete `a.ts` from the working tree
+  - Test: file `a.ts` no longer exists
+
+---
+
+## Task 2 — Add behavior on b.ts
+
+### Type
+wiring
+
+### Files in scope
+- `b.ts`
+
+### Deliverables
+- [ ] 2.1 **RED:** assert `transform(b)` returns the expected mapped value
+  - Test: `transform(b)` returns `{ ok: true }` (currently throws)
+- [ ] 2.2 **GREEN:** implement `transform` in `b.ts`
+  - Test: assertion from 2.1 now passes

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361/initial-tree.json
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361/initial-tree.json
@@ -1,0 +1,8 @@
+{
+  "_description": "Initial working-tree snapshot for the ECHO-5361 chronological-collision fixture. Pass A simulates Task 1 GREEN deleting surfaces/foo.ts, then checks Task 2 RED against the projected tree.",
+  "files": [
+    "surfaces/foo.ts",
+    "surfaces/bar.ts",
+    "package.json"
+  ]
+}

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361/tasks.md
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361/tasks.md
@@ -1,0 +1,30 @@
+# Tasks (ECHO-5361 regression fixture)
+
+_Reproduces the ECHO-5361 chronological collision: Task 1 deletes `surfaces/foo.ts`, Task 2's RED then "asserts" the file is absent — which already holds after Task 1, so the RED is a no-op._
+
+## Task 1 — Remove legacy surface file
+
+### Type
+chore
+
+### Files in scope
+- `surfaces/foo.ts`
+
+### Deliverables
+- [ ] 1.1 **GREEN:** delete `surfaces/foo.ts` from the working tree
+  - Test: file `surfaces/foo.ts` no longer exists
+
+---
+
+## Task 2 — Verify legacy surface is gone
+
+### Type
+verification
+
+### Files in scope
+- `surfaces/foo.ts`
+
+### Deliverables
+- [ ] 2.1 **RED:** assert that `surfaces/foo.ts` has been removed
+  - Test: `fs.existsSync('surfaces/foo.ts')` returns false
+- [ ] 2.2 **GREEN:** no implementation needed (verification only)

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5362-clean/tasks.md
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5362-clean/tasks.md
@@ -1,0 +1,20 @@
+# Tasks (ECHO-5362 clean fixture)
+
+_Negative control for Pass B: the `### Files explicitly out of scope` section is empty, so Pass B has nothing to extract or compare._
+
+## Task 1 — Implement local feature
+
+### Type
+wiring
+
+### Files in scope
+- `local-feature.ts`
+
+### Files explicitly out of scope
+_(no sibling tickets)_
+
+### Deliverables
+- [ ] 1.1 **RED:** assert `localFeature()` returns `"ok"`
+  - Test: `localFeature()` is undefined today
+- [ ] 1.2 **GREEN:** implement `localFeature` returning `"ok"`
+  - Test: assertion from 1.1 passes

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5362/deleter-select-field.tsx
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5362/deleter-select-field.tsx
@@ -1,0 +1,26 @@
+// Fixture stub for ECHO-5362 Pass B regression.
+// The contract-extractor (Task 4) should detect that this component
+// consumes `data` as an array (it calls `data.map`), which diverges
+// from the producer shape `{ deleters: [...] }` in router.ts.
+
+import * as React from 'react';
+
+export interface DeleterSelectFieldProps {
+  data: Array<{ id: string; label: string }>;
+}
+
+export function DeleterSelectField(props: DeleterSelectFieldProps): JSX.Element {
+  const { data } = props;
+  // Consumer signature: expects an iterable with .map — diverges from {deleters:[...]}
+  return (
+    <select>
+      {data.map((d) => (
+        <option key={d.id} value={d.id}>
+          {d.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export default DeleterSelectField;

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5362/git-log.txt
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5362/git-log.txt
@@ -1,0 +1,21 @@
+commit a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0
+Author: Sibling Dev <sibling@example.com>
+Date:   2026-04-10 12:34:56 +0000
+
+    ECHO-5352: introduce DeleterSelectField component
+
+    Owns deleter-select-field.tsx; consumes an array of {id,label} items.
+
+commit b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1
+Author: Sibling Dev <sibling@example.com>
+Date:   2026-04-12 09:00:00 +0000
+
+    ECHO-5352: wire DeleterSelectField into deletion modal
+
+commit c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2
+Author: Other Dev <other@example.com>
+Date:   2026-04-15 16:20:00 +0000
+
+    ECHO-5340: refactor router payload to wrap deleters
+
+    Touched router.ts but did not coordinate with ECHO-5352.

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5362/router.ts
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5362/router.ts
@@ -1,0 +1,21 @@
+// Fixture stub for ECHO-5362 Pass B regression.
+// Producer side: returns `{ deleters: [...] }` — the consumer
+// (deleter-select-field.tsx) instead expects an array directly.
+
+export interface Deleter {
+  id: string;
+  label: string;
+}
+
+export interface GetDeletersResult {
+  deleters: Deleter[];
+}
+
+export function getDeleters(): GetDeletersResult {
+  return {
+    deleters: [
+      { id: 'd1', label: 'Deleter One' },
+      { id: 'd2', label: 'Deleter Two' },
+    ],
+  };
+}

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5362/tasks.md
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5362/tasks.md
@@ -1,0 +1,38 @@
+# Tasks (ECHO-5362 regression fixture)
+
+_Reproduces the ECHO-5362 cross-ticket contract divergence: one task consumes `deleter-select-field.tsx` (listed out of scope, owned by a sibling ticket) which reads `data.map`, while another task in this ticket produces `{deleters: [...]}` from a router stub. The shapes diverge._
+
+## Task 1 — Wire router to expose deleters
+
+### Type
+wiring
+
+### Files in scope
+- `router.ts`
+
+### Files explicitly out of scope
+- `deleter-select-field.tsx` — owned by ECHO-5352
+
+### Deliverables
+- [ ] 1.1 **GREEN:** implement `getDeleters()` in `router.ts` returning `{deleters: [...]}`
+  - Test: `getDeleters()` returns an object with a `deleters` array
+
+---
+
+## Task 2 — Integration: deleter-select-field consumes router output
+
+### Type
+integration
+
+### Files in scope
+- `router.ts`
+- `deleter-select-field.tsx`
+
+### Files explicitly out of scope
+- `deleter-select-field.tsx` — owned by ECHO-5352 (we only read it here)
+
+### Deliverables
+- [ ] 2.1 **RED:** assert `<DeleterSelectField data={getDeleters()} />` renders without throwing
+  - Test: rendering throws today because the component calls `data.map` on a non-array shape
+- [ ] 2.2 **GREEN:** reshape router payload to match consumer
+  - Test: render passes

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/generic-array-wrapper/data-source.ts
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/generic-array-wrapper/data-source.ts
@@ -1,0 +1,22 @@
+// Generic Pass B regression fixture — producer side.
+// Returns `{ rows: Row[] }` — a wrapper object containing an array
+// field. Diverges from the consumer (row-list.tsx) which expects a
+// bare array prop.
+
+export interface Row {
+  id: string;
+  label: string;
+}
+
+export interface GetRowsResult {
+  rows: Row[];
+}
+
+export function getRows(): GetRowsResult {
+  return {
+    rows: [
+      { id: 'r1', label: 'Row One' },
+      { id: 'r2', label: 'Row Two' },
+    ],
+  };
+}

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/generic-array-wrapper/git-log.txt
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/generic-array-wrapper/git-log.txt
@@ -1,0 +1,9 @@
+commit abc111 (HEAD -> feature/rows)
+Author: Sibling Dev <sib@example.com>
+
+    GH-901 add RowList consumer expecting bare array prop
+
+commit abc222
+Author: Sibling Dev <sib@example.com>
+
+    GH-902 add getRows producer returning { rows: Row[] }

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/generic-array-wrapper/row-list.tsx
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/generic-array-wrapper/row-list.tsx
@@ -1,0 +1,23 @@
+// Generic Pass B regression fixture — non-ECHO-5362 identifiers.
+// Consumer expects a bare array `items`; producer returns `{ rows: Row[] }`.
+// Identifier names differ on purpose to prove generalization beyond
+// the fixture-specific `data`/`deleters` pair.
+
+import * as React from 'react';
+
+export interface RowListProps {
+  items: Array<{ id: string; label: string }>;
+}
+
+export function RowList(props: RowListProps): JSX.Element {
+  const { items } = props;
+  return (
+    <ul>
+      {items.map((it) => (
+        <li key={it.id}>{it.label}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default RowList;

--- a/plugins/work/skills/split-in-tasks/__tests__/lint-blast-radius.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/lint-blast-radius.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const MODULE_PATH = path.resolve(__dirname, '..', 'lib', 'lint-blast-radius.js');
+const FIXTURE_5353 = path.resolve(__dirname, 'fixtures', 'echo-5353');
+
+describe('lint-blast-radius — resolveLintCommand (shell-metacharacter guard)', () => {
+  it('returns null when package.json has no lint script', () => {
+    const { resolveLintCommand } = require(MODULE_PATH);
+    const pkg = { scripts: { build: 'echo build' } };
+    const result = resolveLintCommand(pkg);
+    assert.equal(result, null, 'expected null when scripts.lint missing');
+  });
+
+  it('returns the lint command string when scripts.lint is safe', () => {
+    const { resolveLintCommand } = require(MODULE_PATH);
+    const pkg = { scripts: { lint: 'eslint . --format json' } };
+    const result = resolveLintCommand(pkg);
+    assert.equal(typeof result, 'string', 'expected a string command');
+    assert.match(result, /eslint/);
+  });
+
+  it('rejects shell metacharacter `;` and returns null', () => {
+    const { resolveLintCommand } = require(MODULE_PATH);
+    const pkg = { scripts: { lint: 'eslint .; rm -rf /' } };
+    const result = resolveLintCommand(pkg);
+    assert.equal(result, null, 'expected null when `;` present');
+  });
+
+  it('rejects shell metacharacter `&&` and returns null', () => {
+    const { resolveLintCommand } = require(MODULE_PATH);
+    const pkg = { scripts: { lint: 'eslint . && cat /etc/passwd' } };
+    const result = resolveLintCommand(pkg);
+    assert.equal(result, null, 'expected null when `&&` present');
+  });
+
+  it('rejects backticks and returns null', () => {
+    const { resolveLintCommand } = require(MODULE_PATH);
+    const pkg = { scripts: { lint: 'eslint `whoami`' } };
+    const result = resolveLintCommand(pkg);
+    assert.equal(result, null, 'expected null when backticks present');
+  });
+});
+
+describe('lint-blast-radius — scan on echo-5353 fixture (static-parse fallback)', () => {
+  it('parses eslint-output.json and emits a Pass C warning naming file, line, and rule no-test-focus', () => {
+    const { scan } = require(MODULE_PATH);
+    const out = scan({
+      projectRoot: FIXTURE_5353,
+      lintCommand: null,
+      filesInScope: new Set(),
+    });
+    assert.ok(out, 'scan must return a result');
+    assert.ok(Array.isArray(out.warnings), 'expected warnings array');
+    assert.ok(out.warnings.length >= 1, 'expected at least one warning');
+    const w = out.warnings[0];
+    assert.equal(w.kind, 'C', 'expected Pass C warning');
+    const blob = `${w.message || ''} ${w.hint || ''}`;
+    assert.match(blob, /radial-pixel-table\.test\.ts/, 'expected file name in warning');
+    assert.match(blob, /\b17\b/, 'expected line 17 in warning');
+    assert.match(blob, /no-test-focus/, 'expected rule id in warning');
+  });
+
+  it('warning includes the three operator-resolution option strings', () => {
+    const { scan } = require(MODULE_PATH);
+    const out = scan({
+      projectRoot: FIXTURE_5353,
+      lintCommand: null,
+      filesInScope: new Set(),
+    });
+    const w = out.warnings[0];
+    const blob = `${w.message || ''} ${w.hint || ''}`;
+    assert.match(blob, /\(a\) add a Task 0/, 'expected option (a)');
+    assert.match(blob, /\(b\) accept blast-radius takeover/, 'expected option (b)');
+    assert.match(blob, /\(c\) confirm with brief author/, 'expected option (c)');
+  });
+
+  it('warning includes a `Searched: <path>` note when falling back to static parse', () => {
+    const { scan } = require(MODULE_PATH);
+    const out = scan({
+      projectRoot: FIXTURE_5353,
+      lintCommand: null,
+      filesInScope: new Set(),
+    });
+    const w = out.warnings[0];
+    const blob = `${w.message || ''} ${w.hint || ''}`;
+    assert.match(blob, /Searched:\s*\S*eslint-output\.json/, 'expected Searched: note with path to eslint-output.json');
+  });
+
+  it('suppresses warning when violating file IS in scope', () => {
+    const { scan } = require(MODULE_PATH);
+    const out = scan({
+      projectRoot: FIXTURE_5353,
+      lintCommand: null,
+      filesInScope: new Set(['radial-pixel-table.test.ts']),
+    });
+    assert.ok(Array.isArray(out.warnings), 'expected warnings array');
+    assert.equal(out.warnings.length, 0, 'expected zero warnings when file is in scope');
+  });
+});
+
+describe('lint-blast-radius — fail-open subprocess behavior', () => {
+  it('emits a `lint pre-check skipped:` warning when given a non-existent command, and does not throw', () => {
+    const { scan } = require(MODULE_PATH);
+    let out;
+    assert.doesNotThrow(() => {
+      out = scan({
+        projectRoot: FIXTURE_5353,
+        lintCommand: '/nonexistent/path/to/binary-that-does-not-exist-xyz',
+        filesInScope: new Set(),
+      });
+    }, 'scan must not throw on subprocess failure');
+    assert.ok(out, 'scan must still return a result');
+    assert.ok(Array.isArray(out.warnings), 'expected warnings array');
+    const skipped = out.warnings.find((w) => /lint pre-check skipped:/i.test(`${w.message || ''} ${w.hint || ''}`));
+    assert.ok(skipped, 'expected a `lint pre-check skipped:` warning');
+  });
+
+  it('emits a `lint pre-check skipped:` warning when lintCommand contains shell metacharacters, without executing', () => {
+    const { scan } = require(MODULE_PATH);
+    const out = scan({
+      projectRoot: FIXTURE_5353,
+      lintCommand: 'eslint . ; rm -rf /',
+      filesInScope: new Set(),
+    });
+    assert.ok(out, 'scan must return a result');
+    assert.ok(Array.isArray(out.warnings), 'expected warnings array');
+    const skipped = out.warnings.find((w) => /lint pre-check skipped:/i.test(`${w.message || ''} ${w.hint || ''}`));
+    assert.ok(skipped, 'expected a `lint pre-check skipped:` warning for unsafe command');
+  });
+});
+
+describe('lint-blast-radius — module hygiene', () => {
+  it('module source has no console.* or process.exit calls', () => {
+    const fs = require('node:fs');
+    const src = fs.readFileSync(MODULE_PATH, 'utf8');
+    assert.doesNotMatch(src, /console\.\w+\s*\(/, 'module must not call console.*');
+    assert.doesNotMatch(src, /process\.exit\s*\(/, 'module must not call process.exit');
+  });
+});

--- a/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-skill-doc.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-skill-doc.test.js
@@ -20,66 +20,66 @@ const path = require('node:path');
 const SKILL_MD_PATH = path.join(__dirname, '..', 'SKILL.md');
 
 function readSkillMd() {
-	return fs.readFileSync(SKILL_MD_PATH, 'utf8');
+  return fs.readFileSync(SKILL_MD_PATH, 'utf8');
 }
 
 test('SKILL.md contains a "Split-Warning Passes" top-level section', () => {
-	const content = readSkillMd();
-	assert.match(
-		content,
-		/^##\s+Split-Warning Passes\b/m,
-		'expected a top-level "## Split-Warning Passes" section',
-	);
+  const content = readSkillMd();
+  assert.match(
+    content,
+    /^##\s+Split-Warning Passes\b/m,
+    'expected a top-level "## Split-Warning Passes" section'
+  );
 });
 
 test('SKILL.md documents Pass A, Pass B, and Pass C', () => {
-	const content = readSkillMd();
-	assert.match(content, /\bPass A\b/, 'expected mention of "Pass A"');
-	assert.match(content, /\bPass B\b/, 'expected mention of "Pass B"');
-	assert.match(content, /\bPass C\b/, 'expected mention of "Pass C"');
+  const content = readSkillMd();
+  assert.match(content, /\bPass A\b/, 'expected mention of "Pass A"');
+  assert.match(content, /\bPass B\b/, 'expected mention of "Pass B"');
+  assert.match(content, /\bPass C\b/, 'expected mention of "Pass C"');
 });
 
 test('SKILL.md mentions the SPLIT-WARNING token', () => {
-	const content = readSkillMd();
-	assert.match(
-		content,
-		/SPLIT-WARNING/,
-		'expected the warning token "SPLIT-WARNING" to appear in SKILL.md',
-	);
+  const content = readSkillMd();
+  assert.match(
+    content,
+    /SPLIT-WARNING/,
+    'expected the warning token "SPLIT-WARNING" to appear in SKILL.md'
+  );
 });
 
 test('SKILL.md describes per-pass limitations', () => {
-	const content = readSkillMd();
-	assert.match(
-		content,
-		/[Ll]imitations?/,
-		'expected the "Split-Warning Passes" section to call out limitations',
-	);
+  const content = readSkillMd();
+  assert.match(
+    content,
+    /[Ll]imitations?/,
+    'expected the "Split-Warning Passes" section to call out limitations'
+  );
 });
 
 test('SKILL.md table of contents / step list links to the new section', () => {
-	const content = readSkillMd();
-	// Either a markdown anchor link or a plain-text reference earlier in the doc.
-	const sectionIdx = content.search(/^##\s+Split-Warning Passes\b/m);
-	assert.ok(sectionIdx > 0, 'section must exist before checking TOC link');
-	const beforeSection = content.slice(0, sectionIdx);
-	assert.match(
-		beforeSection,
-		/Split-Warning Passes|split-warning-passes/i,
-		'expected the table of contents / step list (before the section) to reference "Split-Warning Passes"',
-	);
+  const content = readSkillMd();
+  // Either a markdown anchor link or a plain-text reference earlier in the doc.
+  const sectionIdx = content.search(/^##\s+Split-Warning Passes\b/m);
+  assert.ok(sectionIdx > 0, 'section must exist before checking TOC link');
+  const beforeSection = content.slice(0, sectionIdx);
+  assert.match(
+    beforeSection,
+    /Split-Warning Passes|split-warning-passes/i,
+    'expected the table of contents / step list (before the section) to reference "Split-Warning Passes"'
+  );
 });
 
 test('SKILL.md does not introduce $HOME-style absolute paths (R11)', () => {
-	const content = readSkillMd();
-	const sectionMatch = content.match(/^##\s+Split-Warning Passes\b[\s\S]*?(?=^##\s|\Z)/m);
-	if (!sectionMatch) {
-		// Pre-RED: section absent — nothing to enforce yet.
-		return;
-	}
-	assert.doesNotMatch(
-		sectionMatch[0],
-		/\$HOME\b|\/home\/[a-z]/i,
-		'Split-Warning Passes section must not embed $HOME or /home/<user> paths',
-	);
+  const content = readSkillMd();
+  const sectionMatch = content.match(/^##\s+Split-Warning Passes\b[\s\S]*?(?=^##\s|$(?![\s\S]))/m);
+  if (!sectionMatch) {
+    // Pre-RED: section absent — nothing to enforce yet.
+    return;
+  }
+  assert.doesNotMatch(
+    sectionMatch[0],
+    /\$HOME\b|\/home\/[a-z]/i,
+    'Split-Warning Passes section must not embed $HOME or /home/<user> paths'
+  );
 });

--- a/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-skill-doc.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-skill-doc.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+/**
+ * split-in-tasks-skill-doc — documentation assertion tests.
+ *
+ * Asserts that SKILL.md contains the "Split-Warning Passes" section
+ * with documentation for Pass A, Pass B, Pass C, the SPLIT-WARNING
+ * token, and the per-pass limitations text. Also asserts the section
+ * is linked from the table of contents / step list.
+ *
+ * Requirements covered: R6 (SKILL.md update), R8 (operator hint),
+ * R11 (no $HOME paths).
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SKILL_MD_PATH = path.join(__dirname, '..', 'SKILL.md');
+
+function readSkillMd() {
+	return fs.readFileSync(SKILL_MD_PATH, 'utf8');
+}
+
+test('SKILL.md contains a "Split-Warning Passes" top-level section', () => {
+	const content = readSkillMd();
+	assert.match(
+		content,
+		/^##\s+Split-Warning Passes\b/m,
+		'expected a top-level "## Split-Warning Passes" section',
+	);
+});
+
+test('SKILL.md documents Pass A, Pass B, and Pass C', () => {
+	const content = readSkillMd();
+	assert.match(content, /\bPass A\b/, 'expected mention of "Pass A"');
+	assert.match(content, /\bPass B\b/, 'expected mention of "Pass B"');
+	assert.match(content, /\bPass C\b/, 'expected mention of "Pass C"');
+});
+
+test('SKILL.md mentions the SPLIT-WARNING token', () => {
+	const content = readSkillMd();
+	assert.match(
+		content,
+		/SPLIT-WARNING/,
+		'expected the warning token "SPLIT-WARNING" to appear in SKILL.md',
+	);
+});
+
+test('SKILL.md describes per-pass limitations', () => {
+	const content = readSkillMd();
+	assert.match(
+		content,
+		/[Ll]imitations?/,
+		'expected the "Split-Warning Passes" section to call out limitations',
+	);
+});
+
+test('SKILL.md table of contents / step list links to the new section', () => {
+	const content = readSkillMd();
+	// Either a markdown anchor link or a plain-text reference earlier in the doc.
+	const sectionIdx = content.search(/^##\s+Split-Warning Passes\b/m);
+	assert.ok(sectionIdx > 0, 'section must exist before checking TOC link');
+	const beforeSection = content.slice(0, sectionIdx);
+	assert.match(
+		beforeSection,
+		/Split-Warning Passes|split-warning-passes/i,
+		'expected the table of contents / step list (before the section) to reference "Split-Warning Passes"',
+	);
+});
+
+test('SKILL.md does not introduce $HOME-style absolute paths (R11)', () => {
+	const content = readSkillMd();
+	const sectionMatch = content.match(/^##\s+Split-Warning Passes\b[\s\S]*?(?=^##\s|\Z)/m);
+	if (!sectionMatch) {
+		// Pre-RED: section absent — nothing to enforce yet.
+		return;
+	}
+	assert.doesNotMatch(
+		sectionMatch[0],
+		/\$HOME\b|\/home\/[a-z]/i,
+		'Split-Warning Passes section must not embed $HOME or /home/<user> paths',
+	);
+});

--- a/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-warnings.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-warnings.test.js
@@ -1,0 +1,212 @@
+'use strict';
+
+/**
+ * split-in-tasks-warnings — end-to-end / cross-pass integration test.
+ *
+ * Wires Pass A (chronological-simulator), Pass B (contract-extractor),
+ * and Pass C (lint-blast-radius) together against the per-ticket
+ * regression fixtures (ECHO-5361, ECHO-5362, ECHO-5353) and a synthetic
+ * combined fixture under `fixtures/combined/`. Asserts:
+ *
+ *   1. Pass A flags empty-RED chronological collision (ECHO-5361 regression)
+ *   2. Pass A produces no warnings on a clean chronological fixture
+ *   3. Pass B flags contract divergence with sibling-owned file (ECHO-5362 regression)
+ *   4. Pass B is silent when no out-of-scope file is referenced
+ *   5. Pass C flags pre-existing lint violation outside ticket scope (ECHO-5353 regression)
+ *   6. Pass C falls back to static parse when no pnpm lint script exists
+ *   7. Warning de-duplication collapses multi-pass hits on the same file (P1 #1)
+ *   8. Operator runs /split-in-tasks and sees all three warning classes in tasks.md
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const FIXTURES = path.resolve(__dirname, 'fixtures');
+const LIB = path.resolve(__dirname, '..', 'lib');
+
+const { simulate } = require(path.join(LIB, 'chronological-simulator.js'));
+const { runPassB } = require(path.join(LIB, 'contract-extractor.js'));
+const { scan } = require(path.join(LIB, 'lint-blast-radius.js'));
+const { dedupe, formatWarnings } = require(path.join(LIB, 'emit-warnings.js'));
+
+/**
+ * Minimal task-parser shared with the per-pass tests (mirrors
+ * chronological-simulator.test.js parseTasksMarkdown so this end-to-end
+ * test does not depend on the production parser, which lives outside
+ * Task 7's scope).
+ */
+function parseTasksMarkdown(md) {
+  const sections = md.split(/^## Task /m).slice(1);
+  return sections.map((section) => {
+    const headerMatch = section.match(/^(\d+)\s+—\s+(.+)$/m);
+    const id = headerMatch ? Number(headerMatch[1]) : null;
+    const title = headerMatch ? headerMatch[2].trim() : '';
+    const deliverables = [];
+    const redAssertions = [];
+    for (const line of section.split('\n')) {
+      const m = line.match(/^\s*-\s*\[\s*\]\s*\d+\.\d+\s+\*\*(GREEN|RED|REFACTOR)[:\*]+\s*(.*)$/);
+      if (m) {
+        const phase = m[1];
+        const text = m[2].replace(/\*+/g, '').trim();
+        deliverables.push({ phase, text });
+        if (phase === 'RED') redAssertions.push(text);
+      }
+    }
+    return { id, title, deliverables, redAssertions };
+  });
+}
+
+function loadChronoFixture(name) {
+  const dir = path.join(FIXTURES, name);
+  const md = fs.readFileSync(path.join(dir, 'tasks.md'), 'utf8');
+  const treeJson = JSON.parse(fs.readFileSync(path.join(dir, 'initial-tree.json'), 'utf8'));
+  return { tasks: parseTasksMarkdown(md), initialTree: treeJson.files };
+}
+
+describe('split-in-tasks warnings — Pass A integration', () => {
+  it('Pass A flags empty-RED chronological collision (ECHO-5361 regression)', () => {
+    const { tasks, initialTree } = loadChronoFixture('echo-5361');
+    const result = simulate({ tasks, initialTree });
+    assert.ok(Array.isArray(result.warnings), 'warnings must be an array');
+    assert.equal(result.warnings.length, 1, `expected 1 Pass A warning, got ${result.warnings.length}`);
+    const w = result.warnings[0];
+    assert.equal(w.kind, 'A', 'expected kind=A');
+    const blob = `${w.message} ${w.hint} ${w.file}`;
+    assert.match(blob, /Task 2/i);
+    assert.match(blob, /merge-with-prior-task or convert-to-verification-checkpoint/);
+  });
+
+  it('Pass A produces no warnings on a clean chronological fixture', () => {
+    const { tasks, initialTree } = loadChronoFixture('echo-5361-clean');
+    const result = simulate({ tasks, initialTree });
+    assert.equal(
+      result.warnings.length,
+      0,
+      `expected 0 warnings on clean fixture, got ${JSON.stringify(result.warnings)}`
+    );
+  });
+});
+
+describe('split-in-tasks warnings — Pass B integration', () => {
+  it('Pass B flags contract divergence with sibling-owned file (ECHO-5362 regression)', () => {
+    const dir = path.join(FIXTURES, 'echo-5362');
+    const out = runPassB(dir);
+    assert.ok(Array.isArray(out.warnings), 'warnings must be an array');
+    assert.equal(out.warnings.length, 1, `expected 1 Pass B warning, got ${out.warnings.length}`);
+    const w = out.warnings[0];
+    assert.equal(w.kind, 'B', 'expected kind=B');
+    const blob = `${w.message} ${w.hint}`;
+    assert.match(blob, /contract mismatch/i);
+    assert.match(blob, /ECHO-\d+/, 'expected at least one sibling ticket id in hint');
+  });
+
+  it('Pass B is silent when no out-of-scope file is referenced', () => {
+    const dir = path.join(FIXTURES, 'echo-5362-clean');
+    const out = runPassB(dir);
+    assert.equal(
+      out.warnings.length,
+      0,
+      `expected 0 warnings on clean fixture, got ${JSON.stringify(out.warnings)}`
+    );
+  });
+});
+
+describe('split-in-tasks warnings — Pass C integration', () => {
+  it('Pass C flags pre-existing lint violation outside ticket scope (ECHO-5353 regression)', () => {
+    const out = scan({
+      projectRoot: path.join(FIXTURES, 'echo-5353'),
+      lintCommand: null,
+      filesInScope: new Set(),
+    });
+    assert.ok(Array.isArray(out.warnings) && out.warnings.length >= 1, 'expected ≥1 Pass C warning');
+    const w = out.warnings[0];
+    assert.equal(w.kind, 'C');
+    const blob = `${w.message} ${w.hint}`;
+    assert.match(blob, /radial-pixel-table\.test\.ts/);
+    assert.match(blob, /no-test-focus/);
+  });
+
+  it('Pass C falls back to static parse when no pnpm lint script exists', () => {
+    // ECHO-5353 fixture's package.json has no `scripts.lint`, so scan()
+    // must fall back to parsing the cached `eslint-output.json` and
+    // annotate the warning with a `Searched:` marker.
+    const out = scan({
+      projectRoot: path.join(FIXTURES, 'echo-5353'),
+      filesInScope: new Set(),
+    });
+    assert.ok(out.warnings.length >= 1, 'expected ≥1 warning via static-parse fallback');
+    const blob = out.warnings.map((w) => `${w.message} ${w.hint}`).join('\n');
+    assert.match(blob, /Searched:/, 'expected Searched: marker indicating static-parse fallback');
+    assert.match(blob, /eslint-output\.json/);
+  });
+});
+
+describe('split-in-tasks warnings — dedupe across passes', () => {
+  it('Warning de-duplication collapses multi-pass hits on the same file (P1 #1)', () => {
+    const sharedFile = 'shared/contract.ts';
+    const warnings = [
+      { kind: 'A', file: sharedFile, message: 'empty RED', hint: 'merge-or-checkpoint' },
+      { kind: 'B', file: sharedFile, message: 'contract mismatch', hint: 'coordinate-with-siblings' },
+      { kind: 'C', file: sharedFile, message: 'lint violation', hint: '(a)/(b)/(c)' },
+      { kind: 'A', file: 'other/path.ts', message: 'distinct', hint: 'distinct' },
+    ];
+    const merged = dedupe(warnings);
+    assert.equal(merged.length, 2, `expected 2 entries after dedupe, got ${merged.length}`);
+    const sharedEntry = merged.find((w) => w.file === sharedFile);
+    assert.ok(sharedEntry, 'expected merged entry for the shared file');
+    assert.match(sharedEntry.kind, /A.*B.*C|A\+B\+C/, `expected union kind A+B+C; got ${sharedEntry.kind}`);
+    assert.match(sharedEntry.message, /empty RED/);
+    assert.match(sharedEntry.message, /contract mismatch/);
+    assert.match(sharedEntry.message, /lint violation/);
+  });
+});
+
+describe('split-in-tasks warnings — operator end-to-end (combined synthetic fixture)', () => {
+  const COMBINED = path.join(FIXTURES, 'combined');
+
+  it('Operator runs /split-in-tasks and sees all three warning classes in tasks.md', () => {
+    // The combined fixture stitches the three regression fixtures into
+    // one synthetic ticket folder so that a single integration sweep
+    // exercises Pass A, Pass B, and Pass C against the same project root.
+    assert.ok(
+      fs.existsSync(path.join(COMBINED, 'tasks.md')),
+      `expected combined fixture tasks.md at ${COMBINED}/tasks.md`
+    );
+
+    // Pass A: replay the chronological fixture against the combined tasks list.
+    const chrono = loadChronoFixture('echo-5361');
+    const passA = simulate(chrono);
+
+    // Pass B: run the contract extractor against the echo-5362 dir.
+    const passB = runPassB(path.join(FIXTURES, 'echo-5362'));
+
+    // Pass C: scan the echo-5353 fixture (static-parse fallback).
+    const passC = scan({
+      projectRoot: path.join(FIXTURES, 'echo-5353'),
+      filesInScope: new Set(),
+    });
+
+    const all = [...passA.warnings, ...passB.warnings, ...passC.warnings];
+    const kinds = new Set(all.map((w) => w.kind));
+    assert.ok(kinds.has('A'), `expected ≥1 Pass A warning; got kinds=${[...kinds]}`);
+    assert.ok(kinds.has('B'), `expected ≥1 Pass B warning; got kinds=${[...kinds]}`);
+    assert.ok(kinds.has('C'), `expected ≥1 Pass C warning; got kinds=${[...kinds]}`);
+
+    // The operator-facing rendering must surface every kind in the
+    // formatted blockquote block that gets appended to tasks.md.
+    const rendered = formatWarnings(dedupe(all));
+    assert.match(rendered, /\[Pass A\]/, 'expected rendered block to cite Pass A');
+    assert.match(rendered, /\[Pass B\]/, 'expected rendered block to cite Pass B');
+    assert.match(rendered, /\[Pass C\]/, 'expected rendered block to cite Pass C');
+
+    // The synthetic combined fixture's own tasks.md must mention each
+    // sub-fixture so an operator can trace which pass any warning came
+    // from (Scenario 8 traceability requirement).
+    const combinedMd = fs.readFileSync(path.join(COMBINED, 'tasks.md'), 'utf8');
+    assert.match(combinedMd, /echo-5361/i, 'combined tasks.md must reference echo-5361 sub-fixture');
+    assert.match(combinedMd, /echo-5362/i, 'combined tasks.md must reference echo-5362 sub-fixture');
+    assert.match(combinedMd, /echo-5353/i, 'combined tasks.md must reference echo-5353 sub-fixture');
+  });
+});

--- a/plugins/work/skills/split-in-tasks/lib/chronological-simulator.js
+++ b/plugins/work/skills/split-in-tasks/lib/chronological-simulator.js
@@ -177,7 +177,7 @@ function simulate(input) {
   for (let i = 0; i < tasks.length; i += 1) {
     const task = tasks[i];
     if (!task) continue;
-    const priorId = i === 0 ? 0 : tasks[i - 1].id;
+    const priorId = i === 0 ? 0 : (tasks[i - 1]?.id ?? 0);
     const projected = snapshots.get(priorId) || new Set();
     const w = detectEmptyRed(task, projected, priorId);
     if (w) warnings.push(w);

--- a/plugins/work/skills/split-in-tasks/lib/chronological-simulator.js
+++ b/plugins/work/skills/split-in-tasks/lib/chronological-simulator.js
@@ -118,14 +118,13 @@ function assertionAlreadyHolds(text, projected) {
 }
 
 /**
- * Run Pass A over a parsed task list.
+ * Build chronological snapshots by applying each task's GREEN deliverables in order.
  *
- * @param {{tasks: ParsedTask[], initialTree: string[]}} input
- * @returns {{warnings: Warning[], projectedTreeAfter: (n: number) => string[]}}
+ * @param {ParsedTask[]} tasks
+ * @param {string[]} initial
+ * @returns {Map<number, Set<string>>}
  */
-function simulate(input) {
-  const tasks = Array.isArray(input && input.tasks) ? input.tasks : [];
-  const initial = Array.isArray(input && input.initialTree) ? input.initialTree : [];
+function buildSnapshots(tasks, initial) {
   const snapshots = new Map();
   const current = new Set(initial);
   snapshots.set(0, new Set(current));
@@ -136,25 +135,52 @@ function simulate(input) {
     }
     snapshots.set(task.id, new Set(current));
   }
+  return snapshots;
+}
+
+/**
+ * Check a single task's RED assertions against the projected tree, returning
+ * the first empty-RED warning encountered (or null).
+ *
+ * @param {ParsedTask} task
+ * @param {Set<string>} projected
+ * @param {number|string} priorId
+ * @returns {Warning|null}
+ */
+function detectEmptyRed(task, projected, priorId) {
+  const reds = Array.isArray(task.redAssertions) ? task.redAssertions : [];
+  for (const redText of reds) {
+    if (!assertionAlreadyHolds(redText, projected)) continue;
+    const paths = extractPaths(redText);
+    return {
+      kind: 'A',
+      file: paths[0] || '',
+      message: `Task ${task.id} RED assertion already holds on the projected tree after Task ${priorId} — empty RED detected`,
+      hint: HINT_TEXT,
+    };
+  }
+  return null;
+}
+
+/**
+ * Run Pass A over a parsed task list.
+ *
+ * @param {{tasks: ParsedTask[], initialTree: string[]}} input
+ * @returns {{warnings: Warning[], projectedTreeAfter: (n: number) => string[]}}
+ */
+function simulate(input) {
+  const tasks = Array.isArray(input && input.tasks) ? input.tasks : [];
+  const initial = Array.isArray(input && input.initialTree) ? input.initialTree : [];
+  const snapshots = buildSnapshots(tasks, initial);
+
   const warnings = [];
   for (let i = 0; i < tasks.length; i += 1) {
     const task = tasks[i];
     if (!task) continue;
     const priorId = i === 0 ? 0 : tasks[i - 1].id;
     const projected = snapshots.get(priorId) || new Set();
-    const reds = Array.isArray(task.redAssertions) ? task.redAssertions : [];
-    for (const redText of reds) {
-      if (assertionAlreadyHolds(redText, projected)) {
-        const paths = extractPaths(redText);
-        warnings.push({
-          kind: 'A',
-          file: paths[0] || '',
-          message: `Task ${task.id} RED assertion already holds on the projected tree after Task ${priorId} — empty RED detected`,
-          hint: HINT_TEXT,
-        });
-        break;
-      }
-    }
+    const w = detectEmptyRed(task, projected, priorId);
+    if (w) warnings.push(w);
   }
   return {
     warnings,

--- a/plugins/work/skills/split-in-tasks/lib/chronological-simulator.js
+++ b/plugins/work/skills/split-in-tasks/lib/chronological-simulator.js
@@ -168,11 +168,7 @@ function detectEmptyRed(task, projected, priorId) {
  * @param {{tasks: ParsedTask[], initialTree: string[]}} input
  * @returns {{warnings: Warning[], projectedTreeAfter: (n: number) => string[]}}
  */
-function simulate(input) {
-  const tasks = Array.isArray(input && input.tasks) ? input.tasks : [];
-  const initial = Array.isArray(input && input.initialTree) ? input.initialTree : [];
-  const snapshots = buildSnapshots(tasks, initial);
-
+function collectWarnings(tasks, snapshots) {
   const warnings = [];
   for (let i = 0; i < tasks.length; i += 1) {
     const task = tasks[i];
@@ -182,6 +178,14 @@ function simulate(input) {
     const w = detectEmptyRed(task, projected, priorId);
     if (w) warnings.push(w);
   }
+  return warnings;
+}
+
+function simulate(input) {
+  const tasks = Array.isArray(input && input.tasks) ? input.tasks : [];
+  const initial = Array.isArray(input && input.initialTree) ? input.initialTree : [];
+  const snapshots = buildSnapshots(tasks, initial);
+  const warnings = collectWarnings(tasks, snapshots);
   return {
     warnings,
     projectedTreeAfter(n) {

--- a/plugins/work/skills/split-in-tasks/lib/chronological-simulator.js
+++ b/plugins/work/skills/split-in-tasks/lib/chronological-simulator.js
@@ -1,0 +1,172 @@
+'use strict';
+
+/**
+ * chronological-simulator — Pass A.
+ *
+ * Replays each task's deliverable text in order, mutating a projected file
+ * tree by recognising add/remove verbs. For every Task N+1 RED assertion,
+ * checks whether the assertion's filepath subject already holds on the
+ * projected tree-after-N. When it does, emits one SPLIT-WARNING with the
+ * "merge-with-prior-task or convert-to-verification-checkpoint" hint.
+ *
+ * Pure module. No I/O. No console.*. No process.exit. No runtime deps.
+ *
+ * @typedef {{phase: 'RED'|'GREEN'|'REFACTOR', text: string}} Deliverable
+ * @typedef {{id: number, title: string, deliverables: Deliverable[], redAssertions: string[]}} ParsedTask
+ * @typedef {{kind: 'A', file: string, message: string, hint: string}} Warning
+ */
+
+/**
+ * Mutation-verb regex table.
+ *
+ * The spec (Task 3 Deliverable 3.1, Requirements R1/R8) fixes the set of
+ * verbs that the chronological simulator must recognise. Each entry below
+ * documents the verbs it matches; keep them in sync with the spec — adding
+ * a new verb is a behaviour change, not a refactor.
+ *
+ *  - `REMOVE_VERB_RE` matches: delete, remove, scrub, drop, unlink
+ *  - `ADD_VERB_RE`    matches: create, add, introduce, new file
+ *
+ * `PATH_TOKEN_RE` captures quoted/backticked paths first (group 1) and falls
+ * back to bare dotted tokens (group 2) so that prose like
+ * "delete `surfaces/foo.ts`" and "create surfaces/new-thing.ts" both yield
+ * the path token without dragging in surrounding English.
+ */
+const REMOVE_VERB_RE = /\b(delete|remove|scrub|drop|unlink)\b/i;
+const ADD_VERB_RE = /\b(create|add|introduce|new file)\b/i;
+const PATH_TOKEN_RE = /[`'"]([^`'"\s]+)[`'"]|([A-Za-z0-9_./-]+\.[A-Za-z0-9]+)/g;
+
+const HINT_TEXT = 'merge-with-prior-task or convert-to-verification-checkpoint';
+
+/**
+ * Pull plausible file paths from a deliverable line. Prefers quoted/backticked
+ * paths, then falls back to bare tokens that include an extension.
+ *
+ * @param {string} text
+ * @returns {string[]}
+ */
+function extractPaths(text) {
+  const found = [];
+  let m;
+  PATH_TOKEN_RE.lastIndex = 0;
+  while ((m = PATH_TOKEN_RE.exec(text)) !== null) {
+    const candidate = m[1] || m[2];
+    if (candidate) found.push(candidate);
+  }
+  return found;
+}
+
+/**
+ * Apply one deliverable's mutations to a working set of file paths.
+ *
+ * @param {Set<string>} tree
+ * @param {Deliverable} deliverable
+ */
+function applyDeliverable(tree, deliverable) {
+  if (!deliverable || typeof deliverable.text !== 'string') return;
+  const text = deliverable.text;
+  const paths = extractPaths(text);
+  if (paths.length === 0) return;
+  const isRemove = REMOVE_VERB_RE.test(text);
+  const isAdd = ADD_VERB_RE.test(text);
+  if (isRemove) {
+    for (const p of paths) tree.delete(p);
+  } else if (isAdd) {
+    for (const p of paths) tree.add(p);
+  }
+}
+
+/**
+ * Decide whether a RED assertion already holds on the projected tree.
+ *
+ * The assertion-matching heuristic has three gates, applied in order:
+ *
+ *  1. **Subject extraction** — pull file paths from the assertion text via
+ *     `extractPaths`. No path tokens → cannot decide → return false.
+ *  2. **Absence claim** — the assertion must read like a "file is gone"
+ *     check. We match three families of English/JS phrasing:
+ *       (a) verb forms: "no longer exists", "has been removed", "is gone",
+ *           "removed", "deleted", "absent"
+ *       (b) the `existsSync(...) returns false` idiom (with or without the
+ *           literal word "returns")
+ *       (c) "asserts that … has been removed / no longer …" prose
+ *     If none match, the RED isn't claiming absence → return false.
+ *  3. **Tree state** — for any extracted path, if it is **missing** from
+ *     the projected tree-after-N, the absence claim already holds → the
+ *     RED is a no-op → return true.
+ *
+ * The heuristic deliberately errs on the side of false negatives: a
+ * partially-recognised RED prefers silence over a noisy warning (R8).
+ *
+ * @param {string} text
+ * @param {Set<string>} projected
+ * @returns {boolean}
+ */
+function assertionAlreadyHolds(text, projected) {
+  if (typeof text !== 'string' || text.length === 0) return false;
+  const paths = extractPaths(text);
+  if (paths.length === 0) return false;
+  const claimsAbsent =
+    /\b(no longer exists?|has been removed|is gone|removed|deleted|absent)\b/i.test(text) ||
+    /existsSync\([^)]*\)\s*(returns?\s*)?false/i.test(text) ||
+    /assert(?:s|ed)?\s+that\s+.+(has been removed|no longer)/i.test(text);
+  if (!claimsAbsent) return false;
+  for (const p of paths) {
+    if (!projected.has(p)) return true;
+  }
+  return false;
+}
+
+/**
+ * Run Pass A over a parsed task list.
+ *
+ * @param {{tasks: ParsedTask[], initialTree: string[]}} input
+ * @returns {{warnings: Warning[], projectedTreeAfter: (n: number) => string[]}}
+ */
+function simulate(input) {
+  const tasks = Array.isArray(input && input.tasks) ? input.tasks : [];
+  const initial = Array.isArray(input && input.initialTree) ? input.initialTree : [];
+  const snapshots = new Map();
+  const current = new Set(initial);
+  snapshots.set(0, new Set(current));
+  for (const task of tasks) {
+    if (!task || !Array.isArray(task.deliverables)) continue;
+    for (const d of task.deliverables) {
+      if (d && d.phase === 'GREEN') applyDeliverable(current, d);
+    }
+    snapshots.set(task.id, new Set(current));
+  }
+  const warnings = [];
+  for (let i = 0; i < tasks.length; i += 1) {
+    const task = tasks[i];
+    if (!task) continue;
+    const priorId = i === 0 ? 0 : tasks[i - 1].id;
+    const projected = snapshots.get(priorId) || new Set();
+    const reds = Array.isArray(task.redAssertions) ? task.redAssertions : [];
+    for (const redText of reds) {
+      if (assertionAlreadyHolds(redText, projected)) {
+        const paths = extractPaths(redText);
+        warnings.push({
+          kind: 'A',
+          file: paths[0] || '',
+          message: `Task ${task.id} RED assertion already holds on the projected tree after Task ${priorId} — empty RED detected`,
+          hint: HINT_TEXT,
+        });
+        break;
+      }
+    }
+  }
+  return {
+    warnings,
+    projectedTreeAfter(n) {
+      const snap = snapshots.get(n);
+      return snap ? Array.from(snap) : [];
+    },
+  };
+}
+
+module.exports = {
+  simulate,
+  REMOVE_VERB_RE,
+  ADD_VERB_RE,
+};

--- a/plugins/work/skills/split-in-tasks/lib/contract-extractor.js
+++ b/plugins/work/skills/split-in-tasks/lib/contract-extractor.js
@@ -132,22 +132,28 @@ function parseExports(source) {
  * @param {number} offset
  * @returns {string}
  */
+function captureBracedBody(slice, braceIdx) {
+  let depth = 0;
+  for (let i = braceIdx; i < slice.length; i++) {
+    const ch = slice[i];
+    if (ch === '{') {
+      depth++;
+      continue;
+    }
+    if (ch !== '}') continue;
+    depth--;
+    if (depth === 0) return slice.slice(0, i + 1);
+  }
+  return slice;
+}
+
 function captureBody(source, offset) {
   const slice = source.slice(offset);
   // Find first `{` on the head line (within ~200 chars) to decide mode.
   const braceIdx = slice.indexOf('{');
   const newlineIdx = slice.indexOf('\n');
   if (braceIdx !== -1 && (newlineIdx === -1 || braceIdx < newlineIdx + 1)) {
-    let depth = 0;
-    for (let i = braceIdx; i < slice.length; i++) {
-      const ch = slice[i];
-      if (ch === '{') depth++;
-      else if (ch === '}') {
-        depth--;
-        if (depth === 0) return slice.slice(0, i + 1);
-      }
-    }
-    return slice;
+    return captureBracedBody(slice, braceIdx);
   }
   // Statement-style: capture until next blank line.
   const blank = slice.indexOf('\n\n');

--- a/plugins/work/skills/split-in-tasks/lib/contract-extractor.js
+++ b/plugins/work/skills/split-in-tasks/lib/contract-extractor.js
@@ -1,0 +1,298 @@
+'use strict';
+
+/**
+ * contract-extractor — Pass B.
+ *
+ * Regex-level extraction of TypeScript export signatures and contract
+ * comparison for files referenced in `### Files explicitly out of scope`.
+ *
+ * Pure module. No process.exit. No console.*. No runtime dependencies
+ * beyond node built-ins (fs, path).
+ *
+ * @typedef {{name: string, kind: string, signature: string}} ExportEntry
+ * @typedef {{kind: 'B', file: string, message: string, hint?: string}} Warning
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { formatWarnings } = require('./emit-warnings');
+
+/**
+ * Regex matching TypeScript export signatures.
+ *
+ *   Group 1: export kind (function|interface|type|const|class|default)
+ *   Group 2: declared name (may be empty for `export default <expr>`)
+ *   Group 3: remainder of the line — body / type / parameter list — used
+ *            as the raw "signature" for shape comparison.
+ *
+ * Captures one line at a time; the body may span multiple lines but only
+ * the line containing the `export` keyword is used as the signature
+ * fingerprint. That is sufficient for Pass B's shape-divergence detection
+ * because the producer/consumer type shapes are conventionally written
+ * inline on the export line.
+ */
+const EXPORT_SIGNATURE_RE =
+  /^\s*export\s+(default\s+)?(function|interface|type|const|class)\s+([A-Za-z0-9_$]+)([^\n]*)/gm;
+
+/**
+ * Sibling ticket-ID regex per spec: `[A-Z]+-\d+`.
+ * Matches conventional ticket prefixes like `ECHO-5352`, `GH-450`, etc.
+ */
+const TICKET_ID_RE = /[A-Z]+-\d+/g;
+
+/**
+ * Maximum number of sibling ticket IDs surfaced in a single warning hint.
+ *
+ * Capped at 3 to keep operator output scannable: more than three siblings
+ * indicates a systemic coordination problem better surfaced via a
+ * dedicated escalation than by flooding the warning hint. The cap is
+ * intentional per spec (Task 4 Deliverable 4.2.3, R8).
+ */
+const SIBLING_ID_CAP = 3;
+
+/**
+ * Resolve `relPath` against `root` and reject any result that escapes the
+ * root. R10 path-traversal guard.
+ *
+ * @param {string} root
+ * @param {string} relPath
+ * @returns {string} absolute resolved path inside root
+ */
+function safeResolve(root, relPath) {
+  const absRoot = path.resolve(root);
+  const resolved = path.resolve(absRoot, relPath);
+  const rel = path.relative(absRoot, resolved);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error(
+      `safeResolve: path escapes root (traversal blocked): ${relPath} → ${resolved} (root=${absRoot})`
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Read a TypeScript file and extract its exported signatures.
+ *
+ * @param {string} filePath  Absolute path, or relative to `opts.root`.
+ * @param {{root?: string}} [opts]
+ * @returns {ExportEntry[]}
+ */
+function extractExports(filePath, opts) {
+  const root = opts && opts.root ? opts.root : null;
+  let absPath;
+  if (root) {
+    absPath = safeResolve(root, filePath);
+  } else if (path.isAbsolute(filePath)) {
+    absPath = filePath;
+  } else {
+    absPath = path.resolve(filePath);
+  }
+
+  const source = fs.readFileSync(absPath, 'utf8');
+  return parseExports(source);
+}
+
+/**
+ * Parse export signatures from a source string. Walks `EXPORT_SIGNATURE_RE`
+ * and also captures multi-line `interface`/`type` bodies as part of the
+ * signature so that consumers like `data.map` (inside the function body)
+ * can be discovered.
+ *
+ * @param {string} source
+ * @returns {ExportEntry[]}
+ */
+function parseExports(source) {
+  const entries = [];
+  EXPORT_SIGNATURE_RE.lastIndex = 0;
+  let m;
+  while ((m = EXPORT_SIGNATURE_RE.exec(source)) !== null) {
+    const kind = m[2];
+    const name = m[3];
+    const headRest = m[4] || '';
+    const headOffset = m.index + m[0].length;
+    // Capture body until matching closing brace (best-effort) or next export.
+    const body = captureBody(source, headOffset);
+    entries.push({
+      name,
+      kind,
+      signature: `${kind} ${name}${headRest}${body ? `\n${body}` : ''}`.trim(),
+    });
+  }
+  return entries;
+}
+
+/**
+ * Capture the body that follows a matched export head. Best-effort:
+ *   - If the head ends with `{`, capture until the matching `}` at the
+ *     same brace depth.
+ *   - Otherwise capture until two consecutive newlines or next `export`.
+ *
+ * @param {string} source
+ * @param {number} offset
+ * @returns {string}
+ */
+function captureBody(source, offset) {
+  const slice = source.slice(offset);
+  // Find first `{` on the head line (within ~200 chars) to decide mode.
+  const braceIdx = slice.indexOf('{');
+  const newlineIdx = slice.indexOf('\n');
+  if (braceIdx !== -1 && (newlineIdx === -1 || braceIdx < newlineIdx + 1)) {
+    let depth = 0;
+    for (let i = braceIdx; i < slice.length; i++) {
+      const ch = slice[i];
+      if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (depth === 0) return slice.slice(0, i + 1);
+      }
+    }
+    return slice;
+  }
+  // Statement-style: capture until next blank line.
+  const blank = slice.indexOf('\n\n');
+  return blank === -1 ? slice : slice.slice(0, blank);
+}
+
+/**
+ * Normalise a signature string for shape comparison: collapse whitespace,
+ * strip comments, drop identifier names so we compare shapes not labels.
+ *
+ * @param {string} sig
+ * @returns {string}
+ */
+function normaliseSignature(sig) {
+  if (!sig) return '';
+  return String(sig)
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Compare two signature entries by their normalised shapes.
+ *
+ * @param {{signature: string}} consumer
+ * @param {{signature: string}} producer
+ * @returns {{equal: boolean, diff?: {consumer: string, producer: string}}}
+ */
+function compareSignatures(consumer, producer) {
+  const c = normaliseSignature(consumer && consumer.signature);
+  const p = normaliseSignature(producer && producer.signature);
+  if (c === p) return { equal: true };
+  return { equal: false, diff: { consumer: c, producer: p } };
+}
+
+/**
+ * Extract sibling ticket IDs from a git-log text blob. Returns up to
+ * `SIBLING_ID_CAP` distinct IDs in first-seen order.
+ *
+ * @param {string} text
+ * @returns {string[]}
+ */
+function parseSiblingTicketIds(text) {
+  if (!text) return [];
+  const seen = new Set();
+  const out = [];
+  TICKET_ID_RE.lastIndex = 0;
+  let m;
+  while ((m = TICKET_ID_RE.exec(text)) !== null) {
+    const id = m[0];
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+    if (out.length >= SIBLING_ID_CAP) break;
+  }
+  return out;
+}
+
+/**
+ * Detect whether a consumer signature treats `data` as an array (`data.map`)
+ * while the producer signature wraps it (`{ deleters: ... }`). This is the
+ * specific divergence shape Pass B is required to catch (AC3).
+ *
+ * @param {ExportEntry[]} consumerExports
+ * @param {ExportEntry[]} producerExports
+ * @returns {boolean}
+ */
+function detectArrayVsWrapperDivergence(consumerExports, producerExports) {
+  const consumerText = consumerExports.map((e) => e.signature).join('\n');
+  const producerText = producerExports.map((e) => e.signature).join('\n');
+  const consumerIsArray = /data\.map\b/.test(consumerText) || /data:\s*Array</.test(consumerText);
+  const producerIsWrapper = /\bdeleters\s*:/.test(producerText);
+  return consumerIsArray && producerIsWrapper;
+}
+
+/**
+ * Run Pass B over a fixture directory. Pairs `*.tsx` consumers with
+ * `*.ts` producers, compares their export signatures, and emits one
+ * Pass B warning per detected divergence with sibling-ID enrichment
+ * sourced from `git-log.txt` (when present).
+ *
+ * @param {string} fixtureDir
+ * @returns {{warnings: Warning[], rendered: string}}
+ */
+function runPassB(fixtureDir) {
+  const absDir = path.resolve(fixtureDir);
+  const entries = fs.existsSync(absDir) ? fs.readdirSync(absDir) : [];
+  const tsxFiles = entries.filter((f) => f.endsWith('.tsx'));
+  const tsFiles = entries.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'));
+
+  const warnings = [];
+
+  for (const consumerFile of tsxFiles) {
+    const consumerPath = safeResolve(absDir, consumerFile);
+    const consumerExports = extractExports(consumerPath);
+
+    for (const producerFile of tsFiles) {
+      const producerPath = safeResolve(absDir, producerFile);
+      const producerExports = extractExports(producerPath);
+
+      if (!detectArrayVsWrapperDivergence(consumerExports, producerExports)) continue;
+
+      const consumerSig = { signature: consumerExports.map((e) => e.signature).join('\n') };
+      const producerSig = { signature: producerExports.map((e) => e.signature).join('\n') };
+      const cmp = compareSignatures(consumerSig, producerSig);
+      if (cmp.equal) continue;
+
+      const siblingIds = readSiblingIds(absDir);
+      const idsText = siblingIds.length > 0 ? ` siblings: ${siblingIds.join(', ')}` : '';
+      warnings.push({
+        kind: 'B',
+        file: path.join(absDir, consumerFile),
+        message: `contract mismatch with ${producerFile}: consumer expects array, producer returns wrapper`,
+        hint: `coordinate-with-siblings${idsText}`,
+      });
+    }
+  }
+
+  return {
+    warnings,
+    rendered: formatWarnings(warnings),
+  };
+}
+
+/**
+ * Read `git-log.txt` from a fixture directory and return up to
+ * `SIBLING_ID_CAP` sibling ticket IDs.
+ *
+ * @param {string} absDir
+ * @returns {string[]}
+ */
+function readSiblingIds(absDir) {
+  const logPath = path.join(absDir, 'git-log.txt');
+  if (!fs.existsSync(logPath)) return [];
+  const text = fs.readFileSync(logPath, 'utf8');
+  return parseSiblingTicketIds(text);
+}
+
+module.exports = {
+  extractExports,
+  compareSignatures,
+  safeResolve,
+  runPassB,
+  parseSiblingTicketIds,
+  EXPORT_SIGNATURE_RE,
+  SIBLING_ID_CAP,
+};

--- a/plugins/work/skills/split-in-tasks/lib/contract-extractor.js
+++ b/plugins/work/skills/split-in-tasks/lib/contract-extractor.js
@@ -214,9 +214,70 @@ function parseSiblingTicketIds(text) {
 }
 
 /**
- * Detect whether a consumer signature treats `data` as an array (`data.map`)
- * while the producer signature wraps it (`{ deleters: ... }`). This is the
- * specific divergence shape Pass B is required to catch (AC3).
+ * Identifiers that look like array-consuming method calls. A consumer that
+ * calls `X.map(`, `X.forEach(`, `X.filter(`, or `X.reduce(` is treating `X`
+ * as an iterable / array.
+ */
+const ARRAY_CONSUMING_METHODS = ['map', 'forEach', 'filter', 'reduce'];
+
+/**
+ * Collect identifiers the consumer treats as arrays. A consumer treats `X`
+ * as an array when any of the following appears in its signature text:
+ *
+ *   - `X.<method>(` where method ∈ {map, forEach, filter, reduce}
+ *   - `X: Array<...>` or `X: SomeType[]` (type annotation)
+ *   - `const [a, b] = X` (array destructuring)
+ *
+ * @param {string} text concatenated consumer signature text
+ * @returns {Set<string>} identifier names
+ */
+function collectConsumerArrayIdentifiers(text) {
+  const ids = new Set();
+  if (!text) return ids;
+  const methodAlt = ARRAY_CONSUMING_METHODS.join('|');
+  const methodRe = new RegExp(`\\b([A-Za-z_$][A-Za-z0-9_$]*)\\.(?:${methodAlt})\\(`, 'g');
+  let m;
+  while ((m = methodRe.exec(text)) !== null) ids.add(m[1]);
+  // `X: Array<...>` or `X: T[]` — capture annotated identifier.
+  const annotRe =
+    /\b([A-Za-z_$][A-Za-z0-9_$]*)\s*\??\s*:\s*(?:Array\s*<|(?:[A-Za-z_$][A-Za-z0-9_$<>.,\s]*?)\[\])/g;
+  while ((m = annotRe.exec(text)) !== null) ids.add(m[1]);
+  // Array destructure: `const [a, b] = X` or `let [a] = X`.
+  const destructRe = /(?:const|let|var)\s*\[[^\]]*\]\s*=\s*([A-Za-z_$][A-Za-z0-9_$]*)/g;
+  while ((m = destructRe.exec(text)) !== null) ids.add(m[1]);
+  return ids;
+}
+
+/**
+ * Collect identifiers that appear as array-typed fields on the producer's
+ * object/return types. A producer "wraps" an array when its type text
+ * contains a field like `X: Foo[]` or `X: Array<Foo>` inside an object
+ * literal or interface body.
+ *
+ * @param {string} text concatenated producer signature text
+ * @returns {Set<string>} identifier names typed as arrays on a wrapper
+ */
+function collectProducerWrapperFields(text) {
+  const ids = new Set();
+  if (!text) return ids;
+  // Field with array-type value: `X: T[]` or `X: Array<T>`. The field must
+  // be syntactically a field — preceded by `{`, `;`, `,`, or a newline.
+  const fieldRe =
+    /(?:[{;,\n]\s*)([A-Za-z_$][A-Za-z0-9_$]*)\s*\??\s*:\s*(?:Array\s*<[^>]*>|[A-Za-z_$][A-Za-z0-9_$<>.,\s]*?\[\])/g;
+  let m;
+  while ((m = fieldRe.exec(text)) !== null) ids.add(m[1]);
+  return ids;
+}
+
+/**
+ * Detect array-vs-wrapper contract divergence by shape, not identifier.
+ *
+ * Returns true when the consumer treats at least one identifier as an
+ * array (via `.map`/`.forEach`/`.filter`/`.reduce`, array type annotation,
+ * or array destructuring) AND the producer types its response/return as
+ * an object that wraps an array under some field — regardless of whether
+ * the identifier names match. The shapes are structurally divergent:
+ * consumer expects a bare array, producer hands back `{ X: T[] }`.
  *
  * @param {ExportEntry[]} consumerExports
  * @param {ExportEntry[]} producerExports
@@ -225,9 +286,9 @@ function parseSiblingTicketIds(text) {
 function detectArrayVsWrapperDivergence(consumerExports, producerExports) {
   const consumerText = consumerExports.map((e) => e.signature).join('\n');
   const producerText = producerExports.map((e) => e.signature).join('\n');
-  const consumerIsArray = /data\.map\b/.test(consumerText) || /data:\s*Array</.test(consumerText);
-  const producerIsWrapper = /\bdeleters\s*:/.test(producerText);
-  return consumerIsArray && producerIsWrapper;
+  const consumerArrayIds = collectConsumerArrayIdentifiers(consumerText);
+  const producerWrapperFields = collectProducerWrapperFields(producerText);
+  return consumerArrayIds.size > 0 && producerWrapperFields.size > 0;
 }
 
 /**

--- a/plugins/work/skills/split-in-tasks/lib/emit-warnings.js
+++ b/plugins/work/skills/split-in-tasks/lib/emit-warnings.js
@@ -79,11 +79,24 @@ function splitKinds(kind) {
  * @param {object} b — incoming warning to fold in
  * @returns {object}
  */
+/**
+ * Strip a leading `cites Pass <kinds>: ` citation prefix from a hint, if present.
+ * Iterative merges via `dedupe` re-prefix every step, so we must remove the
+ * previous citation before re-applying the union citation — otherwise the inner
+ * citation gets embedded inside the outer one.
+ *
+ * @param {string} hint
+ * @returns {string}
+ */
+function stripCitationPrefix(hint) {
+  return String(hint).replace(/^cites Pass [^:]+:\s*/, '');
+}
+
 function mergeWarnings(a, b) {
   const kinds = new Set([...splitKinds(a.kind), ...splitKinds(b.kind)]);
   const kind = Array.from(kinds).sort().join('+');
   const messages = [a.message, b.message].filter(Boolean);
-  const hints = [a.hint, b.hint].filter(Boolean);
+  const hints = [a.hint, b.hint].filter(Boolean).map(stripCitationPrefix).filter(Boolean);
   const citation = `cites Pass ${kind}`;
   return {
     file: a.file,

--- a/plugins/work/skills/split-in-tasks/lib/emit-warnings.js
+++ b/plugins/work/skills/split-in-tasks/lib/emit-warnings.js
@@ -1,0 +1,124 @@
+'use strict';
+
+/**
+ * emit-warnings — pure formatter + dedupe helpers for SPLIT-WARNING records.
+ *
+ * Warning record shape: { kind: 'A'|'B'|'C', file: string, message: string, hint?: string }
+ *
+ * No I/O. No console.*. No process.exit. Suitable for use under all three passes
+ * (chronological, contract, lint-blast-radius) and the operator integration entry.
+ */
+
+const WARNING_PREFIX = '> ⚠️ SPLIT-WARNING:';
+
+/**
+ * Replace any leading or embedded $HOME prefix with `~` so emitted text
+ * is portable across operators and CI logs (R11).
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function stripHome(text) {
+  if (typeof text !== 'string') return text;
+  const home = process.env.HOME;
+  if (!home) return text;
+  // Replace every occurrence of $HOME (longest-first via direct string replace).
+  return text.split(home).join('~');
+}
+
+/**
+ * Render a single warning record as a blockquote line.
+ *
+ * @param {{kind:string, file:string, message:string, hint?:string}} w
+ * @returns {string}
+ */
+function renderLine(w) {
+  const kind = w.kind != null ? String(w.kind) : '';
+  const file = stripHome(w.file != null ? String(w.file) : '');
+  const message = stripHome(w.message != null ? String(w.message) : '');
+  const hint = w.hint != null ? stripHome(String(w.hint)) : '';
+  const hintSuffix = hint ? ` — hint: ${hint}` : '';
+  return `${WARNING_PREFIX} [Pass ${kind}] ${file}: ${message}${hintSuffix}`;
+}
+
+/**
+ * Format an array of warning records as a newline-joined blockquote block.
+ * Each record renders to one `> ⚠️ SPLIT-WARNING:` line.
+ *
+ * @param {Array<object>} warnings
+ * @returns {string}
+ */
+function formatWarnings(warnings) {
+  if (!Array.isArray(warnings) || warnings.length === 0) return '';
+  return warnings.map(renderLine).join('\n');
+}
+
+/**
+ * Split a `kind` field into its component pass identifiers.
+ * Already-merged warnings carry compound kinds like `"A+C"`.
+ *
+ * @param {unknown} kind
+ * @returns {string[]}
+ */
+function splitKinds(kind) {
+  return String(kind || '')
+    .split(/[+,\s]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Merge two warnings that target the same file path.
+ *
+ * Contract:
+ *  - `file` is preserved from the first warning (the dedupe key).
+ *  - `kind` is the union of both warnings' kinds, sorted, joined with `+`.
+ *  - `message` concatenates non-empty messages with ` | ` for traceability.
+ *  - `hint` cites every contributing pass (R7/R8) — never silently drops info.
+ *
+ * @param {object} a — accumulator (already-merged or first warning for this file)
+ * @param {object} b — incoming warning to fold in
+ * @returns {object}
+ */
+function mergeWarnings(a, b) {
+  const kinds = new Set([...splitKinds(a.kind), ...splitKinds(b.kind)]);
+  const kind = Array.from(kinds).sort().join('+');
+  const messages = [a.message, b.message].filter(Boolean);
+  const hints = [a.hint, b.hint].filter(Boolean);
+  const citation = `cites Pass ${kind}`;
+  return {
+    file: a.file,
+    kind,
+    message: messages.join(' | '),
+    hint: hints.length > 0 ? `${citation}: ${hints.join(' | ')}` : citation,
+  };
+}
+
+/**
+ * Collapse warnings that share a `file` path into one merged record.
+ * Preserves first-seen order. Distinct file paths remain separate.
+ *
+ * @param {Array<object>} warnings
+ * @returns {Array<object>}
+ */
+function dedupe(warnings) {
+  if (!Array.isArray(warnings) || warnings.length === 0) return [];
+  const byFile = new Map();
+  const order = [];
+  for (const w of warnings) {
+    if (!w || w.file == null) continue;
+    const key = String(w.file);
+    if (byFile.has(key)) {
+      byFile.set(key, mergeWarnings(byFile.get(key), w));
+    } else {
+      byFile.set(key, { ...w });
+      order.push(key);
+    }
+  }
+  return order.map((k) => byFile.get(k));
+}
+
+module.exports = {
+  formatWarnings,
+  dedupe,
+  WARNING_PREFIX,
+};

--- a/plugins/work/skills/split-in-tasks/lib/lint-blast-radius.js
+++ b/plugins/work/skills/split-in-tasks/lib/lint-blast-radius.js
@@ -74,21 +74,31 @@ function readPackageJson(projectRoot) {
  * @param {unknown} report
  * @returns {Array<{file:string, line:number, ruleId:string}>}
  */
+function flattenEslintMessage(file, m) {
+  return {
+    file,
+    line: typeof m.line === 'number' ? m.line : 0,
+    ruleId: typeof m.ruleId === 'string' ? m.ruleId : '',
+  };
+}
+
+function flattenEslintFileEntry(fileEntry) {
+  if (!fileEntry || typeof fileEntry !== 'object') return [];
+  const file = typeof fileEntry.filePath === 'string' ? fileEntry.filePath : '';
+  const messages = Array.isArray(fileEntry.messages) ? fileEntry.messages : [];
+  const out = [];
+  for (const m of messages) {
+    if (!m || typeof m !== 'object') continue;
+    out.push(flattenEslintMessage(file, m));
+  }
+  return out;
+}
+
 function flattenEslintReport(report) {
   if (!Array.isArray(report)) return [];
   const out = [];
   for (const fileEntry of report) {
-    if (!fileEntry || typeof fileEntry !== 'object') continue;
-    const file = typeof fileEntry.filePath === 'string' ? fileEntry.filePath : '';
-    const messages = Array.isArray(fileEntry.messages) ? fileEntry.messages : [];
-    for (const m of messages) {
-      if (!m || typeof m !== 'object') continue;
-      out.push({
-        file,
-        line: typeof m.line === 'number' ? m.line : 0,
-        ruleId: typeof m.ruleId === 'string' ? m.ruleId : '',
-      });
-    }
+    out.push(...flattenEslintFileEntry(fileEntry));
   }
   return out;
 }
@@ -184,6 +194,32 @@ function isInScope(violationFile, filesInScope) {
  * @param {{projectRoot:string, lintCommand:string|null, filesInScope:Set<string>}} opts
  * @returns {{warnings:Array<object>}}
  */
+/**
+ * Resolve the effective lint command and its source.
+ * Returns { command, source } on success, or { warning } if the caller-supplied
+ * command is unsafe.
+ */
+function resolveEffectiveLintCommand(opts, projectRoot) {
+  if (opts && opts.lintCommand !== undefined && opts.lintCommand !== null) {
+    if (typeof opts.lintCommand === 'string' && !SHELL_METACHAR_RE.test(opts.lintCommand)) {
+      return { command: opts.lintCommand, source: 'caller' };
+    }
+    if (typeof opts.lintCommand === 'string') {
+      return {
+        warning: {
+          kind: 'C',
+          file: '',
+          message:
+            'lint pre-check skipped: lintCommand contains shell metacharacters; refusing to execute.',
+          hint: `Resolve via: ${OPTIONS_LINE}.`,
+        },
+      };
+    }
+  }
+  const pkg = readPackageJson(projectRoot);
+  return { command: resolveLintCommand(pkg), source: 'package.json' };
+}
+
 function scan(opts) {
   const { projectRoot } = opts || {};
   const filesInScope = (opts && opts.filesInScope) || new Set();
@@ -199,57 +235,47 @@ function scan(opts) {
     return { warnings };
   }
 
-  // Resolve the command: caller-supplied overrides package.json. An
-  // explicit null/undefined means "use static-parse fallback".
-  let effectiveCommand = null;
-  let commandSource = 'caller';
-  if (opts && opts.lintCommand !== undefined && opts.lintCommand !== null) {
-    if (typeof opts.lintCommand === 'string' && !SHELL_METACHAR_RE.test(opts.lintCommand)) {
-      effectiveCommand = opts.lintCommand;
-    } else if (typeof opts.lintCommand === 'string') {
-      // Unsafe caller-supplied string: refuse to execute.
-      warnings.push({
-        kind: 'C',
-        file: '',
-        message: 'lint pre-check skipped: lintCommand contains shell metacharacters; refusing to execute.',
-        hint: `Resolve via: ${OPTIONS_LINE}.`,
-      });
-      return { warnings };
-    }
-  } else {
-    const pkg = readPackageJson(projectRoot);
-    effectiveCommand = resolveLintCommand(pkg);
-    commandSource = 'package.json';
+  const resolved = resolveEffectiveLintCommand(opts, projectRoot);
+  if (resolved.warning) {
+    warnings.push(resolved.warning);
+    return { warnings };
   }
 
-  let violations = [];
-  let searchedPath = null;
-
-  if (effectiveCommand) {
-    const ran = runLintCommand(effectiveCommand, projectRoot);
-    if (!ran) {
-      warnings.push({
-        kind: 'C',
-        file: '',
-        message: `lint pre-check skipped: command failed or produced no parseable JSON (source: ${commandSource}).`,
-        hint: `Resolve via: ${OPTIONS_LINE}.`,
-      });
-      return { warnings };
-    }
-    violations = ran.violations;
-  } else {
-    // Static-parse fallback: no `lint` script in package.json.
-    const fallback = staticParseEslintOutput(projectRoot);
-    violations = fallback.violations;
-    searchedPath = fallback.searchedPath;
+  const collected = collectViolations(resolved, projectRoot);
+  if (collected.warning) {
+    warnings.push(collected.warning);
+    return { warnings };
   }
 
-  for (const v of violations) {
+  for (const v of collected.violations) {
     if (isInScope(v.file, filesInScope)) continue;
-    warnings.push(buildViolationWarning(v, searchedPath));
+    warnings.push(buildViolationWarning(v, collected.searchedPath));
   }
 
   return { warnings };
+}
+
+/**
+ * Collect lint violations from either a running command or the static-parse
+ * fallback. Returns { violations, searchedPath } or { warning } on failure.
+ */
+function collectViolations(resolved, projectRoot) {
+  if (resolved.command) {
+    const ran = runLintCommand(resolved.command, projectRoot);
+    if (!ran) {
+      return {
+        warning: {
+          kind: 'C',
+          file: '',
+          message: `lint pre-check skipped: command failed or produced no parseable JSON (source: ${resolved.source}).`,
+          hint: `Resolve via: ${OPTIONS_LINE}.`,
+        },
+      };
+    }
+    return { violations: ran.violations, searchedPath: null };
+  }
+  const fallback = staticParseEslintOutput(projectRoot);
+  return { violations: fallback.violations, searchedPath: fallback.searchedPath };
 }
 
 module.exports = {

--- a/plugins/work/skills/split-in-tasks/lib/lint-blast-radius.js
+++ b/plugins/work/skills/split-in-tasks/lib/lint-blast-radius.js
@@ -1,0 +1,260 @@
+'use strict';
+
+/**
+ * lint-blast-radius — Pass C scanner.
+ *
+ * Resolves the project's lint command from `package.json` `scripts.lint`
+ * (rejecting shell metacharacters), runs it, and partitions ESLint-style
+ * JSON violations by membership in any task's `Files in scope`. For
+ * out-of-scope violations, emits a SPLIT-WARNING record naming
+ * `file:line/rule` plus the three operator-resolution option strings.
+ *
+ * Falls back to static-parsing a cached `eslint-output.json` when no
+ * `scripts.lint` exists, appending a `Searched: <path>` note.
+ *
+ * Fails open on subprocess errors (emits a `lint pre-check skipped:`
+ * warning record; never throws).
+ *
+ * Pure module: no console.*, no process.exit. Pulls only Node built-ins.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+// Shell metacharacters that would allow command chaining / substitution
+// inside a string passed to a shell. Matching any of these triggers a
+// pre-check skip so we never exec attacker-influenced shell strings.
+const SHELL_METACHAR_RE = /[;&|`$<>(){}\n\r]|&&|\|\|/;
+
+// The three operator-resolution option strings (R3, AC5).
+const OPTION_A = '(a) add a Task 0 to fix the pre-existing violation';
+const OPTION_B = '(b) accept blast-radius takeover and own the fix in this ticket';
+const OPTION_C = '(c) confirm with brief author that scope is intentional';
+const OPTIONS_LINE = `${OPTION_A}; ${OPTION_B}; ${OPTION_C}`;
+
+/**
+ * Resolve a safe lint command from a parsed package.json.
+ *
+ * @param {object} pkg parsed package.json
+ * @returns {string|null} the lint command string, or null if missing/unsafe
+ */
+function resolveLintCommand(pkg) {
+  if (!pkg || typeof pkg !== 'object') return null;
+  const scripts = pkg.scripts;
+  if (!scripts || typeof scripts !== 'object') return null;
+  const lint = scripts.lint;
+  if (typeof lint !== 'string' || lint.trim() === '') return null;
+  if (SHELL_METACHAR_RE.test(lint)) return null;
+  return lint;
+}
+
+/**
+ * Read and parse `package.json` from a project root. Returns null on any
+ * error (missing file, parse failure, etc.) — callers fall back to the
+ * static-parse path.
+ *
+ * @param {string} projectRoot
+ * @returns {object|null}
+ */
+function readPackageJson(projectRoot) {
+  try {
+    const pkgPath = path.join(projectRoot, 'package.json');
+    const raw = fs.readFileSync(pkgPath, 'utf8');
+    return JSON.parse(raw);
+  } catch (_err) {
+    return null;
+  }
+}
+
+/**
+ * Parse an ESLint JSON report (array of file-result objects) into a flat
+ * list of `{ file, line, ruleId }` entries.
+ *
+ * @param {unknown} report
+ * @returns {Array<{file:string, line:number, ruleId:string}>}
+ */
+function flattenEslintReport(report) {
+  if (!Array.isArray(report)) return [];
+  const out = [];
+  for (const fileEntry of report) {
+    if (!fileEntry || typeof fileEntry !== 'object') continue;
+    const file = typeof fileEntry.filePath === 'string' ? fileEntry.filePath : '';
+    const messages = Array.isArray(fileEntry.messages) ? fileEntry.messages : [];
+    for (const m of messages) {
+      if (!m || typeof m !== 'object') continue;
+      out.push({
+        file,
+        line: typeof m.line === 'number' ? m.line : 0,
+        ruleId: typeof m.ruleId === 'string' ? m.ruleId : '',
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Try the static-parse fallback: read `eslint-output.json` from project
+ * root, return both the violations and the searched path so we can
+ * include a `Searched:` note in the warning.
+ *
+ * @param {string} projectRoot
+ * @returns {{violations:Array<object>, searchedPath:string}|null}
+ */
+function staticParseEslintOutput(projectRoot) {
+  const searchedPath = path.join(projectRoot, 'eslint-output.json');
+  try {
+    const raw = fs.readFileSync(searchedPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return { violations: flattenEslintReport(parsed), searchedPath };
+  } catch (_err) {
+    return { violations: [], searchedPath };
+  }
+}
+
+/**
+ * Run a lint command in `projectRoot` and parse its stdout as ESLint JSON.
+ * Fail-open: returns null on any failure (exception, non-zero with no
+ * parseable JSON, etc.) so the caller can emit a skipped-warning instead.
+ *
+ * @param {string} lintCommand
+ * @param {string} projectRoot
+ * @returns {{violations:Array<object>}|null}
+ */
+function runLintCommand(lintCommand, projectRoot) {
+  try {
+    // The command was already validated to contain no shell metacharacters,
+    // so a simple whitespace tokenisation is sufficient and avoids the
+    // shell entirely.
+    const tokens = lintCommand.split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return null;
+    const [cmd, ...args] = tokens;
+    const result = spawnSync(cmd, args, {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      shell: false,
+    });
+    if (result.error) return null;
+    const stdout = typeof result.stdout === 'string' ? result.stdout : '';
+    if (!stdout.trim()) return null;
+    const parsed = JSON.parse(stdout);
+    return { violations: flattenEslintReport(parsed) };
+  } catch (_err) {
+    return null;
+  }
+}
+
+/**
+ * Build a Pass C warning record for a single out-of-scope violation.
+ *
+ * @param {{file:string, line:number, ruleId:string}} v
+ * @param {string|null} searchedPath when set, appends a `Searched: <path>` note
+ * @returns {{kind:'C', file:string, message:string, hint:string}}
+ */
+function buildViolationWarning(v, searchedPath) {
+  const fileLabel = path.basename(v.file || '');
+  const searchedSuffix = searchedPath ? ` Searched: ${searchedPath}.` : '';
+  const message = `pre-existing lint violation ${fileLabel}:${v.line} (${v.ruleId}) is outside any task scope.`;
+  const hint = `Resolve via: ${OPTIONS_LINE}.${searchedSuffix}`;
+  return { kind: 'C', file: fileLabel, message, hint };
+}
+
+/**
+ * Decide whether a violation file falls inside any declared task scope.
+ *
+ * @param {string} violationFile
+ * @param {Set<string>} filesInScope
+ * @returns {boolean}
+ */
+function isInScope(violationFile, filesInScope) {
+  if (!(filesInScope instanceof Set) || filesInScope.size === 0) return false;
+  if (filesInScope.has(violationFile)) return true;
+  const base = path.basename(violationFile || '');
+  if (filesInScope.has(base)) return true;
+  for (const scoped of filesInScope) {
+    if (typeof scoped !== 'string') continue;
+    if (path.basename(scoped) === base) return true;
+  }
+  return false;
+}
+
+/**
+ * Pass C entry point.
+ *
+ * @param {{projectRoot:string, lintCommand:string|null, filesInScope:Set<string>}} opts
+ * @returns {{warnings:Array<object>}}
+ */
+function scan(opts) {
+  const { projectRoot } = opts || {};
+  const filesInScope = (opts && opts.filesInScope) || new Set();
+  const warnings = [];
+
+  if (typeof projectRoot !== 'string' || projectRoot === '') {
+    warnings.push({
+      kind: 'C',
+      file: '',
+      message: 'lint pre-check skipped: no projectRoot supplied.',
+      hint: '',
+    });
+    return { warnings };
+  }
+
+  // Resolve the command: caller-supplied overrides package.json. An
+  // explicit null/undefined means "use static-parse fallback".
+  let effectiveCommand = null;
+  let commandSource = 'caller';
+  if (opts && opts.lintCommand !== undefined && opts.lintCommand !== null) {
+    if (typeof opts.lintCommand === 'string' && !SHELL_METACHAR_RE.test(opts.lintCommand)) {
+      effectiveCommand = opts.lintCommand;
+    } else if (typeof opts.lintCommand === 'string') {
+      // Unsafe caller-supplied string: refuse to execute.
+      warnings.push({
+        kind: 'C',
+        file: '',
+        message: 'lint pre-check skipped: lintCommand contains shell metacharacters; refusing to execute.',
+        hint: `Resolve via: ${OPTIONS_LINE}.`,
+      });
+      return { warnings };
+    }
+  } else {
+    const pkg = readPackageJson(projectRoot);
+    effectiveCommand = resolveLintCommand(pkg);
+    commandSource = 'package.json';
+  }
+
+  let violations = [];
+  let searchedPath = null;
+
+  if (effectiveCommand) {
+    const ran = runLintCommand(effectiveCommand, projectRoot);
+    if (!ran) {
+      warnings.push({
+        kind: 'C',
+        file: '',
+        message: `lint pre-check skipped: command failed or produced no parseable JSON (source: ${commandSource}).`,
+        hint: `Resolve via: ${OPTIONS_LINE}.`,
+      });
+      return { warnings };
+    }
+    violations = ran.violations;
+  } else {
+    // Static-parse fallback: no `lint` script in package.json.
+    const fallback = staticParseEslintOutput(projectRoot);
+    violations = fallback.violations;
+    searchedPath = fallback.searchedPath;
+  }
+
+  for (const v of violations) {
+    if (isInScope(v.file, filesInScope)) continue;
+    warnings.push(buildViolationWarning(v, searchedPath));
+  }
+
+  return { warnings };
+}
+
+module.exports = {
+  resolveLintCommand,
+  scan,
+  SHELL_METACHAR_RE,
+  OPTIONS_LINE,
+};


### PR DESCRIPTION
## Existing Behavior

- The `split-in-tasks` skill generated task sequences without any awareness of cumulative file-mutation effects across tasks, causing later tasks' RED preconditions to be silently satisfied before execution began (ECHO-5361 pattern).
- No cross-task contract checking existed: a task could reference a file owned by a sibling ticket with a divergent data contract, leading to mid-flight type failures (ECHO-5362 pattern).
- No pre-existing lint violation check was performed at split-time: tickets would reach the GREEN/REFACTOR phase only to be blocked by lint debt in files they never intended to touch (ECHO-5353 pattern).
- `SKILL.md` documented the quality review pass (Step 5) with no mention of warning passes or the `SPLIT-WARNING` annotation format.

## Intended New Behavior

- **Pass A (Chronological Simulator):** Replays tasks 1..N-1 deliverable verbs against a projected file tree and emits a `> ⚠️ SPLIT-WARNING: [Pass A]` blockquote when Task N's RED assertion already holds on the projected tree, recommending merge-with-prior-task or conversion to a verification checkpoint.
- **Pass B (Contract Extractor):** Parses exported data contracts (regex-level signature scrape) for files referenced by a task's `### Test Command` that appear in a sibling task's `### Files in scope`, and emits a `> ⚠️ SPLIT-WARNING: [Pass B]` when consumer/producer shapes diverge, naming sibling ticket IDs harvested from `git log`.
- **Pass C (Lint Blast Radius):** Runs the project's lint command (falling back to static AST parse) over the current tree and emits a `> ⚠️ SPLIT-WARNING: [Pass C]` for each pre-existing violation in a file outside the ticket's declared scope, with three resolution options in the hint.
- A shared `lib/emit-warnings.js` module provides pure `formatWarnings` and `dedupe` helpers consumed by all three passes; same-file warnings from multiple passes are collapsed into one merged record citing all pass IDs.
- `SKILL.md` now fully documents all three passes under a new "Split-Warning Passes" section including warning line shape, per-pass firing conditions, templates, limitations, and the operator de-duplication/resolution workflow.

## Brief P0 coverage

- **P0 #1:** Chronological file-state simulation (Fix A) — implemented in `plugins/work/skills/split-in-tasks/lib/chronological-simulator.js:126` + tested in `__tests__/chronological-simulator.test.js:9`
- **P0 #2:** Cross-ticket contract awareness (Fix B) — implemented in `plugins/work/skills/split-in-tasks/lib/contract-extractor.js` + tested in `__tests__/contract-extractor.test.js:9`
- **P0 #3:** Lint blast-radius pre-check (Fix C) — implemented in `plugins/work/skills/split-in-tasks/lib/lint-blast-radius.js` + tested in `__tests__/lint-blast-radius.test.js`
- **P0 #4:** Regression fixtures (ECHO-5361, ECHO-5362, ECHO-5353, clean variants) — added in `plugins/work/skills/split-in-tasks/__tests__/fixtures/`
- **P0 #5:** Unit tests covering each warning type with clean/dirty fixtures — `__tests__/chronological-simulator.test.js`, `__tests__/contract-extractor.test.js`, `__tests__/lint-blast-radius.test.js`, `__tests__/emit-warnings.test.js`, `__tests__/split-in-tasks-warnings.test.js`
- **P0 #6:** SKILL.md update documenting three passes — implemented in `plugins/work/skills/split-in-tasks/SKILL.md:252`

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

All three warning passes are pure library modules (no I/O, no side effects) exercised directly by the Node built-in test runner.

Run each test file individually:

```
node --test plugins/work/skills/split-in-tasks/__tests__/chronological-simulator.test.js
node --test plugins/work/skills/split-in-tasks/__tests__/contract-extractor.test.js
node --test plugins/work/skills/split-in-tasks/__tests__/lint-blast-radius.test.js
node --test plugins/work/skills/split-in-tasks/__tests__/emit-warnings.test.js
node --test plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-warnings.test.js
```

Expected for each: all assertions pass, 0 failures.

Verify warning format by inspecting dirty vs clean fixture pairs:

1. `__tests__/fixtures/echo-5361/` (dirty) → Pass A emits exactly 1 warning with `surfaces/foo.ts`, message citing Task 2, hint `merge-with-prior-task or convert-to-verification-checkpoint`
2. `__tests__/fixtures/echo-5361-clean/` → Pass A emits 0 warnings
3. `__tests__/fixtures/echo-5362/` (dirty) → Pass B emits exactly 1 warning with kind `B`, message matching `mismatch|diverge|contract|differ`, hint containing a ticket ID matching `[A-Z]+-\d+`
4. `__tests__/fixtures/echo-5362-clean/` → Pass B emits 0 warnings
5. `__tests__/fixtures/echo-5353/` (dirty) → Pass C emits at least 1 warning for `radial-pixel-table.test.ts` with the three-option hint

SPLIT-WARNING line shape (all passes, defined in `lib/emit-warnings.js`):

```
> ⚠️ SPLIT-WARNING: [Pass <X>] <file>: <one-line problem summary> — hint: <suggested-resolution>
```

### Test Results

55 tests passed (all split-in-tasks unit tests green, including dirty/clean fixture pairs for all three passes).

Closes #450

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes to `enforce-step-workflow` terminal bypass parsing affect when `work-state.js complete` is allowed at the complete step; incorrect logic could block legitimate completions or widen bypass. New split-warning libraries are test-covered and mostly additive to the skill workflow.
> 
> **Overview**
> Adds **split-in-tasks** static analysis: Pass A (chronological file-tree simulation for empty REDs), Pass B (consumer/producer contract divergence with sibling ticket hints), and Pass C (out-of-scope lint blast radius), plus shared `emit-warnings` formatting/dedupe and a documented **Split-Warning Passes** section in `SKILL.md` with regression fixtures and tests.
> 
> Hardens the workflow hook **`isTerminalCompleteBypass`** with quote-aware `shellTokenize`, a strict four-token shape, **no env-assignment prefixes** (e.g. `NODE_OPTIONS`), and optional `ENFORCE_HOOK_DEBUG` tracing; extends hook tests for spaced paths and env-prefix blocks.
> 
> Fixes **test-cleanup** so `cleanupTestArtifacts` runs against disposable tmp `TASKS_BASE`/`tmpdir`, avoiding parallel-test races that flaked GH-276 terminal-bypass tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b7bd2395008650aaeb18e11092620073e7e1649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->