### PR TITLE
feat(synapsys): add trigger_pretool_content_not negative content gate (AND-NOT)

### DIFF
--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -14,6 +14,7 @@ Memories are markdown files with frontmatter that declares **which events** they
 | `trigger_prompt` | regex | Matched against the user prompt on `UserPromptSubmit` |
 | `trigger_pretool` | csv of `<Tool>:<arg-regex>` | Matched against the tool name + serialized tool input on `PreToolUse` |
 | `trigger_pretool_content` | csv of regex | *(optional)* Matched against the **content** the tool is writing. Combined with `trigger_pretool` via AND. Per-tool content: `Edit`→`new_string`, `Write`→`content`, `MultiEdit`→`edits[].new_string` joined, `NotebookEdit`→`new_source`; other tools → no content (fail-closed). Flags: `i,m`. Invalid regex → stderr warning + skip; all-invalid or missing content → memory does not fire. |
+| `trigger_pretool_content_not` | csv of regex | *(optional)* Negative content gate. Combined with `trigger_pretool_content` via **AND-NOT**: memory fires when the positive content matches AND none of these patterns match. Use to suppress fires when the file is already conformant (e.g. it already imports the correct component). Same extraction table, same `i,m` flags, same fail-closed regex handling as `trigger_pretool_content`. If **all** negative patterns are invalid, the negative gate is dropped (positive-only fallback). Absent or empty array → no negative gate. |
 | `trigger_session` | bool | Fire on every `SessionStart` |
 | `inject` | `full` \| `summary` | How much of the body to inject |
 
@@ -58,7 +59,7 @@ Next time you ask Claude to run `git push ...`, the PreToolUse hook fires, match
 
 ### Content-gated example
 
-To fire only when an `Edit`/`Write` to a `.tsx` file actually introduces a raw `<button>` element, combine `trigger_pretool` (path match) with `trigger_pretool_content` (content match — AND):
+To fire only when an `Edit`/`Write` to a `.tsx` file actually introduces a raw `<button>` element AND the file isn't already importing the `Button` component, combine `trigger_pretool` (path match), `trigger_pretool_content` (positive content match), and `trigger_pretool_content_not` (negative content gate). Semantics: positive AND-NOT negative — the memory fires when raw `<button>` is present AND the UI package import / named `Button` import is NOT already there.
 
 ```yaml
 ---
@@ -68,6 +69,7 @@ events: PreToolUse
 trigger_prompt: \b(<button|raw button|html button)\b
 trigger_pretool: Edit:.*\.tsx,Write:.*\.tsx
 trigger_pretool_content: <button\b
+trigger_pretool_content_not: from\s+['"]@app-services-monitoring/ui['"],import\s+\{[^}]*\bButton\b
 trigger_session: false
 inject: full
 ---

--- a/plugins/synapsys/lib/__tests__/memory-store.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/memory-store.integration.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { listMemoriesFromStore, parseFrontmatter } = require('../memory-store');
+
+function makeTempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-memstore-'));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'test' })
+  );
+  return { cwd: dir, storeDir };
+}
+
+function writeMemory(storeDir, name, frontmatter) {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  const content = `---\n${fm}\n---\nbody\n`;
+  fs.writeFileSync(path.join(storeDir, name), content);
+}
+
+// --- Task 1: readMemoryFile parses trigger_pretool_content_not ---
+
+test('readMemoryFile parses trigger_pretool_content_not as a list when present', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'neg.md', {
+    name: 'neg',
+    description: 'd',
+    trigger_pretool_content_not: '[foo, bar]',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.deepEqual(memories[0].triggerPretoolContentNot, ['foo', 'bar']);
+});
+
+test('readMemoryFile yields triggerPretoolContentNot: [] when field absent', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'absent.md', {
+    name: 'absent',
+    description: 'd',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.deepEqual(memories[0].triggerPretoolContentNot, []);
+});
+
+test('readMemoryFile yields triggerPretoolContentNot: [] when field is empty bracket array', () => {
+  const { storeDir } = makeTempStore();
+  // Empty array form — coerceFrontmatterValue treats `[]` without comma as a string;
+  // toList must still normalize to [].
+  writeMemory(storeDir, 'empty.md', {
+    name: 'empty',
+    description: 'd',
+    trigger_pretool_content_not: '',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.deepEqual(memories[0].triggerPretoolContentNot, []);
+});
+
+test('existing triggerPretoolContent parsing behavior unchanged (regression)', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'pos.md', {
+    name: 'pos',
+    description: 'd',
+    trigger_pretool_content: '[alpha, beta]',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.deepEqual(memories[0].triggerPretoolContent, ['alpha', 'beta']);
+  assert.deepEqual(memories[0].triggerPretoolContentNot, []);
+});
+
+test('parseFrontmatter exposes raw trigger_pretool_content_not value', () => {
+  const { meta } = parseFrontmatter(
+    '---\ntrigger_pretool_content_not: [x, y]\n---\nbody\n'
+  );
+  assert.deepEqual(meta.trigger_pretool_content_not, ['x', 'y']);
+});

--- a/plugins/synapsys/lib/__tests__/trigger-pretool-content-not.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/trigger-pretool-content-not.integration.test.js
@@ -1,0 +1,454 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const matcherModule = require('../matcher');
+const {
+  evaluatePretoolContentNot,
+  hasNegativeContentPatterns,
+  matchPreTool,
+  matchPreToolResult,
+} = matcherModule;
+
+function captureStderr(fn) {
+  const orig = process.stderr.write.bind(process.stderr);
+  const chunks = [];
+  process.stderr.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+  try {
+    const ret = fn();
+    return { ret, stderr: chunks.join('') };
+  } finally {
+    process.stderr.write = orig;
+  }
+}
+
+// --- Task 2: evaluatePretoolContentNot helper ---
+
+test('evaluatePretoolContentNot returns {excluded:true, pattern} when a negative regex matches', () => {
+  const memory = {
+    name: 'ui-use-Button-not-raw',
+    triggerPretoolContentNot: ['@app-services-monitoring/ui'],
+  };
+  const content = "import { Button } from '@app-services-monitoring/ui';";
+  const result = evaluatePretoolContentNot(memory, content);
+  assert.deepEqual(result, { excluded: true, pattern: '@app-services-monitoring/ui' });
+});
+
+test('evaluatePretoolContentNot returns {excluded:false, pattern:null} when no pattern matches', () => {
+  const memory = {
+    name: 'mem-no-match',
+    triggerPretoolContentNot: ['@app-services-monitoring/ui'],
+  };
+  const content = "import { Button } from 'somewhere-else';";
+  const result = evaluatePretoolContentNot(memory, content);
+  assert.deepEqual(result, { excluded: false, pattern: null });
+});
+
+test('evaluatePretoolContentNot returns {excluded:false, pattern:null} on empty triggerPretoolContentNot array', () => {
+  const memory = { name: 'mem-empty', triggerPretoolContentNot: [] };
+  const result = evaluatePretoolContentNot(memory, '<button>Go</button>');
+  assert.deepEqual(result, { excluded: false, pattern: null });
+});
+
+test('evaluatePretoolContentNot compiles regex with case-insensitive (i) flag', () => {
+  const memory = {
+    name: 'mem-case',
+    triggerPretoolContentNot: ['<BUTTON'],
+  };
+  const result = evaluatePretoolContentNot(memory, '<button>Go</button>');
+  assert.equal(result.excluded, true);
+  assert.equal(result.pattern, '<BUTTON');
+});
+
+test('evaluatePretoolContentNot compiles regex with multiline (m) flag', () => {
+  const memory = {
+    name: 'mem-multiline',
+    triggerPretoolContentNot: ['^import React'],
+  };
+  const content = "'use client';\nimport React from 'react';\n";
+  const result = evaluatePretoolContentNot(memory, content);
+  assert.equal(result.excluded, true);
+  assert.equal(result.pattern, '^import React');
+});
+
+test('evaluatePretoolContentNot: one invalid regex is skipped with stderr warning; remaining patterns still gate', () => {
+  const memory = {
+    name: 'mem-mixed',
+    triggerPretoolContentNot: ['(unclosed', '@app-services-monitoring/ui'],
+  };
+  const { ret, stderr } = captureStderr(() =>
+    evaluatePretoolContentNot(memory, "import x from '@app-services-monitoring/ui';")
+  );
+  assert.equal(ret.excluded, true);
+  assert.equal(ret.pattern, '@app-services-monitoring/ui');
+  assert.match(
+    stderr,
+    /\[synapsys\] memory mem-mixed: invalid trigger_pretool_content_not regex "\(unclosed":/
+  );
+});
+
+test('evaluatePretoolContentNot: all-invalid returns {excluded:false, pattern:null} (positive-only fallback)', () => {
+  const memory = {
+    name: 'mem-all-bad',
+    triggerPretoolContentNot: ['(unclosed', '[bad'],
+  };
+  const { ret, stderr } = captureStderr(() =>
+    evaluatePretoolContentNot(memory, 'any content here')
+  );
+  assert.deepEqual(ret, { excluded: false, pattern: null });
+  assert.match(
+    stderr,
+    /\[synapsys\] memory mem-all-bad: invalid trigger_pretool_content_not regex "\(unclosed":/
+  );
+  assert.match(
+    stderr,
+    /\[synapsys\] memory mem-all-bad: invalid trigger_pretool_content_not regex "\[bad":/
+  );
+});
+
+test('hasNegativeContentPatterns returns true when triggerPretoolContentNot is non-empty array', () => {
+  const memory = { triggerPretoolContentNot: ['foo'] };
+  assert.equal(hasNegativeContentPatterns(memory), true);
+});
+
+test('hasNegativeContentPatterns returns false when triggerPretoolContentNot is empty array', () => {
+  const memory = { triggerPretoolContentNot: [] };
+  assert.equal(hasNegativeContentPatterns(memory), false);
+});
+
+test('hasNegativeContentPatterns returns false when triggerPretoolContentNot is missing/undefined', () => {
+  assert.equal(hasNegativeContentPatterns({}), false);
+});
+
+test('hasNegativeContentPatterns returns false when triggerPretoolContentNot is not an array', () => {
+  assert.equal(hasNegativeContentPatterns({ triggerPretoolContentNot: 'foo' }), false);
+  assert.equal(hasNegativeContentPatterns({ triggerPretoolContentNot: null }), false);
+});
+
+test('evaluatePretoolContentNot and hasNegativeContentPatterns are exported from lib/matcher.js', () => {
+  const matcher = require('../matcher');
+  assert.equal(typeof matcher.evaluatePretoolContentNot, 'function');
+  assert.equal(typeof matcher.hasNegativeContentPatterns, 'function');
+});
+
+// --- Task 3: matchPreTool AND-NOT gate integration ---
+
+const BUTTON_MEMORY_BASE = {
+  name: 'ui-use-Button-not-raw',
+  events: ['PreToolUse'],
+  triggerPretool: ['Edit:.*\\.tsx'],
+  triggerPretoolContent: ['<button\\b'],
+};
+
+function editPayload(newString, filePath = 'src/Foo.tsx') {
+  return {
+    tool_name: 'Edit',
+    tool_input: { file_path: filePath, old_string: 'x', new_string: newString },
+  };
+}
+
+// S1 — fires on positive match w/ no negative present
+test('P0 #1, #2 — memory fires when positive matches and no negative pattern is present', () => {
+  const memory = {
+    ...BUTTON_MEMORY_BASE,
+    triggerPretoolContentNot: [],
+  };
+  assert.equal(matchPreTool(memory, editPayload('<button>Go</button>')), true);
+});
+
+// S2 — UI-package import excludes
+test('P0 #2, #3 — UI-package import excludes the memory', () => {
+  const memory = {
+    ...BUTTON_MEMORY_BASE,
+    triggerPretoolContentNot: ['@app-services-monitoring/ui'],
+  };
+  const newString =
+    "import { Button } from '@app-services-monitoring/ui';\n<button>Go</button>";
+  assert.equal(matchPreTool(memory, editPayload(newString)), false);
+});
+
+// S3 — named import excludes
+test('P0 #2 — named import excludes the memory', () => {
+  const memory = {
+    ...BUTTON_MEMORY_BASE,
+    // named-import-style negative regex: matches `import { Button }`
+    triggerPretoolContentNot: ['import\\s*\\{[^}]*\\bButton\\b[^}]*\\}'],
+  };
+  const newString = "import { Button } from 'somewhere';\n<button>Go</button>";
+  assert.equal(matchPreTool(memory, editPayload(newString)), false);
+});
+
+// S4 — short-circuit on positive miss (evaluatePretoolContentNot NOT invoked)
+test('P0 #2 (short-circuit) — no positive match means negative is never evaluated', () => {
+  const memory = {
+    ...BUTTON_MEMORY_BASE,
+    triggerPretoolContentNot: ['@app-services-monitoring/ui'],
+  };
+  const orig = matcherModule.evaluatePretoolContentNot;
+  let callCount = 0;
+  matcherModule.evaluatePretoolContentNot = (...args) => {
+    callCount += 1;
+    return orig(...args);
+  };
+  try {
+    // new_string has no <button — positive pattern misses
+    const result = matchPreTool(memory, editPayload('<Buttonish>Go</Buttonish>'));
+    assert.equal(result, false);
+    assert.equal(callCount, 0, 'evaluatePretoolContentNot must not be called when positive misses');
+  } finally {
+    matcherModule.evaluatePretoolContentNot = orig;
+  }
+});
+
+// S5 — backwards-compat: memory without trigger_pretool_content_not behaves identically
+test('P0 §Compatibility — memory without trigger_pretool_content_not behaves identically to pre-change runtime', () => {
+  const memory = { ...BUTTON_MEMORY_BASE }; // no triggerPretoolContentNot at all
+  assert.equal(matchPreTool(memory, editPayload('<button>Go</button>')), true);
+  assert.equal(matchPreTool(memory, editPayload('<Buttonish>Go</Buttonish>')), false);
+});
+
+// S6 — backwards-compat: empty trigger_pretool_content_not array behaves like absent field
+test('P0 §Compatibility — empty trigger_pretool_content_not array behaves like absent field', () => {
+  const memory = { ...BUTTON_MEMORY_BASE, triggerPretoolContentNot: [] };
+  assert.equal(matchPreTool(memory, editPayload('<button>Go</button>')), true);
+});
+
+// S7 — partial-invalid negative regex: invalid skipped, remaining still gates
+test('P0 #4 — one invalid negative regex is skipped and the rest still gate', () => {
+  const memory = {
+    ...BUTTON_MEMORY_BASE,
+    triggerPretoolContentNot: ['(unclosed', '@app-services-monitoring/ui'],
+  };
+  const newString =
+    "import { Button } from '@app-services-monitoring/ui';\n<button>Go</button>";
+  // Silence stderr to keep test output clean
+  const origWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = () => true;
+  try {
+    assert.equal(matchPreTool(memory, editPayload(newString)), false);
+  } finally {
+    process.stderr.write = origWrite;
+  }
+});
+
+// S8 — all-invalid negative regex: falls back to positive-only behavior (fires)
+test('P0 #4 — all-invalid negative regex falls back to positive-only behavior', () => {
+  const memory = {
+    ...BUTTON_MEMORY_BASE,
+    triggerPretoolContentNot: ['(unclosed', '[bad'],
+  };
+  const origWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = () => true;
+  try {
+    assert.equal(matchPreTool(memory, editPayload('<button>Go</button>')), true);
+  } finally {
+    process.stderr.write = origWrite;
+  }
+});
+
+// --- Task 4: matchPreToolResult object-mode wrapper ---
+
+// S9 — MatchResult exposes negative-excludes reason and matched.negative_pattern
+//
+// Locked decision (brief P0 #8, spec §Architecture Decisions):
+//   On negative exclusion:  { matched: false, reason: 'negative-excludes',
+//                             matched: { negative_pattern: P } }
+// In JS the second `matched` key wins, so the observable shape is:
+//   { reason: 'negative-excludes', matched: { negative_pattern: P } }
+// On positive match:        { matched: true }
+// On positive miss:         { matched: false } (no `negative-excludes` reason)
+test('P0 #8 — MatchResult exposes negative-excludes reason and matched.negative_pattern', () => {
+  assert.equal(typeof matchPreToolResult, 'function', 'matchPreToolResult must be exported');
+  const memory = {
+    ...BUTTON_MEMORY_BASE,
+    triggerPretoolContentNot: ['@app-services-monitoring/ui'],
+  };
+  const newString =
+    "import { Button } from '@app-services-monitoring/ui';\n<button>Go</button>";
+  const result = matchPreToolResult(memory, editPayload(newString));
+  assert.equal(result.reason, 'negative-excludes', 'reason must be "negative-excludes"');
+  assert.ok(result.matched && typeof result.matched === 'object', 'matched must be the details object');
+  assert.equal(
+    result.matched.negative_pattern,
+    '@app-services-monitoring/ui',
+    'matched.negative_pattern must equal the excluding pattern'
+  );
+});
+
+test('P0 #8 / S9 — matchPreToolResult on positive match (no exclusion) returns {matched:true} with no reason', () => {
+  const memory = {
+    ...BUTTON_MEMORY_BASE,
+    triggerPretoolContentNot: ['@app-services-monitoring/ui'],
+  };
+  const result = matchPreToolResult(memory, editPayload('<button>Go</button>'));
+  assert.equal(result.matched, true);
+  assert.equal(result.reason, undefined, 'no reason on positive match');
+});
+
+test('P0 #8 / S9 — matchPreToolResult on positive miss returns {matched:false} without negative-excludes reason', () => {
+  const memory = {
+    ...BUTTON_MEMORY_BASE,
+    triggerPretoolContentNot: ['@app-services-monitoring/ui'],
+  };
+  const result = matchPreToolResult(memory, editPayload('<Buttonish>Go</Buttonish>'));
+  assert.equal(result.matched, false);
+  assert.notEqual(
+    result.reason,
+    'negative-excludes',
+    'positive-miss must not report negative-excludes'
+  );
+});
+
+test('P0 #8 — boolean matchPreTool export remains unchanged (returns boolean)', () => {
+  const memory = {
+    ...BUTTON_MEMORY_BASE,
+    triggerPretoolContentNot: ['@app-services-monitoring/ui'],
+  };
+  const newString =
+    "import { Button } from '@app-services-monitoring/ui';\n<button>Go</button>";
+  const result = matchPreTool(memory, editPayload(newString));
+  assert.equal(typeof result, 'boolean');
+  assert.equal(result, false);
+});
+
+// R7 — backwards-compat regression: real-shape positive-only memory unchanged
+test('R7: positive-only memory (no negative field) matches identically to pre-change runtime', () => {
+  // Mirror the real `auto-followup-pr-after-push` memory shape
+  const memory = {
+    name: 'auto-followup-pr-after-push',
+    events: ['PreToolUse', 'Stop'],
+    triggerPretool: ['Bash:git\\s+push'],
+    triggerPretoolContent: [], // no content gating
+    // triggerPretoolContentNot intentionally absent
+  };
+  const payload = { tool_name: 'Bash', tool_input: { command: 'git push origin main' } };
+  assert.equal(matchPreTool(memory, payload), true);
+  const noMatch = { tool_name: 'Bash', tool_input: { command: 'ls -la' } };
+  assert.equal(matchPreTool(memory, noMatch), false);
+});
+
+// --- Task 5: synapsys-crystallize-write.js emits trigger_pretool_content_not ---
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { parseFrontmatter } = require('../memory-store');
+
+const CRYSTALLIZE_WRITE = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'scripts',
+  'synapsys-crystallize-write.js'
+);
+
+function makeTempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-crystallize-not-'));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(path.join(storeDir, '.synapsys.json'), JSON.stringify({ projectName: 'test' }));
+  return { cwd: dir, storeDir };
+}
+
+function runCrystallizeWrite(cwd, manifest) {
+  return spawnSync(
+    process.execPath,
+    [CRYSTALLIZE_WRITE, '--store=local', `--cwd=${cwd}`, '--force'],
+    { input: JSON.stringify(manifest), encoding: 'utf8' }
+  );
+}
+
+// S10 — writer round-trips trigger_pretool_content_not from manifest to frontmatter
+test('P0 #5 — writer round-trips trigger_pretool_content_not from manifest to frontmatter', () => {
+  const { cwd, storeDir } = makeTempStore();
+  const manifest = {
+    memories: [
+      {
+        name: 'mem-neg-roundtrip',
+        description: 'rt-neg',
+        events: ['PreToolUse'],
+        trigger_prompt: '',
+        trigger_pretool: ['Edit:.*\\.tsx'],
+        trigger_pretool_content: ['<button\\b'],
+        trigger_pretool_content_not: ['@app-services-monitoring/ui'],
+        trigger_session: false,
+        inject: 'summary',
+        body: 'body text',
+      },
+    ],
+  };
+  const res = runCrystallizeWrite(cwd, manifest);
+  assert.equal(res.status, 0, `writer failed: stderr=${res.stderr}`);
+
+  const out = path.join(storeDir, 'mem-neg-roundtrip.md');
+  const raw = fs.readFileSync(out, 'utf8');
+  assert.match(raw, /^trigger_pretool_content_not: @app-services-monitoring\/ui$/m);
+
+  const { meta } = parseFrontmatter(raw);
+  const list = Array.isArray(meta.trigger_pretool_content_not)
+    ? meta.trigger_pretool_content_not
+    : String(meta.trigger_pretool_content_not || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+  assert.deepEqual(list, ['@app-services-monitoring/ui']);
+});
+
+// S10 — absent-field omission
+test('S10 — writer omits trigger_pretool_content_not line when manifest field is absent', () => {
+  const { cwd, storeDir } = makeTempStore();
+  const manifest = {
+    memories: [
+      {
+        name: 'mem-no-neg',
+        description: 'no neg',
+        events: ['PreToolUse'],
+        trigger_prompt: '',
+        trigger_pretool: ['Edit:.*\\.tsx'],
+        trigger_pretool_content: ['<button\\b'],
+        // trigger_pretool_content_not intentionally absent
+        trigger_session: false,
+        inject: 'summary',
+        body: 'body text',
+      },
+    ],
+  };
+  const res = runCrystallizeWrite(cwd, manifest);
+  assert.equal(res.status, 0, `writer failed: stderr=${res.stderr}`);
+
+  const out = path.join(storeDir, 'mem-no-neg.md');
+  const raw = fs.readFileSync(out, 'utf8');
+  assert.doesNotMatch(raw, /^trigger_pretool_content_not:/m);
+});
+
+// Empty-array omission
+test('S10 — writer omits trigger_pretool_content_not line when manifest field is an empty array', () => {
+  const { cwd, storeDir } = makeTempStore();
+  const manifest = {
+    memories: [
+      {
+        name: 'mem-empty-neg',
+        description: 'empty neg',
+        events: ['PreToolUse'],
+        trigger_prompt: '',
+        trigger_pretool: ['Edit:.*\\.tsx'],
+        trigger_pretool_content: ['<button\\b'],
+        trigger_pretool_content_not: [],
+        trigger_session: false,
+        inject: 'summary',
+        body: 'body text',
+      },
+    ],
+  };
+  const res = runCrystallizeWrite(cwd, manifest);
+  assert.equal(res.status, 0, `writer failed: stderr=${res.stderr}`);
+
+  const out = path.join(storeDir, 'mem-empty-neg.md');
+  const raw = fs.readFileSync(out, 'utf8');
+  assert.doesNotMatch(raw, /^trigger_pretool_content_not:/m);
+});

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -50,7 +50,10 @@ function matchPreTool(memory, payload) {
   if (!hasContentPatterns(memory)) return true;
   const content = extractPretoolContent(toolName, toolInput);
   if (content == null) return false;
-  return evaluatePretoolContent(memory, content);
+  if (!evaluatePretoolContent(memory, content)) return false;
+  if (!hasNegativeContentPatterns(memory)) return true;
+  const negative = module.exports.evaluatePretoolContentNot(memory, content);
+  return !negative.excluded;
 }
 
 function extractMultiEditContent(edits) {
@@ -94,6 +97,68 @@ function evaluatePretoolContent(memory, contentString) {
   return matched;
 }
 
+function hasNegativeContentPatterns(memory) {
+  return (
+    Array.isArray(memory.triggerPretoolContentNot) && memory.triggerPretoolContentNot.length > 0
+  );
+}
+
+function evaluatePretoolContentNot(memory, contentString) {
+  const patterns = memory.triggerPretoolContentNot;
+  if (!Array.isArray(patterns) || patterns.length === 0) {
+    return { excluded: false, pattern: null };
+  }
+  for (const pat of patterns) {
+    let re;
+    try {
+      re = new RegExp(pat, 'im');
+    } catch (err) {
+      process.stderr.write(
+        `[synapsys] memory ${memory.name}: invalid trigger_pretool_content_not regex "${pat}": ${err.message}\n`
+      );
+      continue;
+    }
+    if (re.test(contentString)) {
+      return { excluded: true, pattern: pat };
+    }
+  }
+  return { excluded: false, pattern: null };
+}
+
+// matchPreToolResult — object-mode wrapper around matchPreTool.
+//
+// Locked decision (GH-445 brief P0 #8 / spec §Architecture Decisions):
+//   On negative-exclude: { matched: false, reason: 'negative-excludes',
+//                          matched: { negative_pattern: P } }
+// In JS the later `matched` key wins, so the observable shape is
+//   { reason: 'negative-excludes', matched: { negative_pattern: P } }.
+// On positive match:   { matched: true }
+// On positive miss:    { matched: false }
+//
+// Broader MatchResult contract (other reasons, explainer CLI) is GH-443's domain;
+// this wrapper exposes only the negative-excludes signal.
+function matchPreToolResult(memory, payload) {
+  if (!memory.events.includes('PreToolUse')) return { matched: false };
+  if (!memory.triggerPretool.length) return { matched: false };
+  const toolName = payload?.tool_name || '';
+  const toolInput = payload?.tool_input || {};
+  const argBlob = JSON.stringify(toolInput);
+  const prefixMatch = memory.triggerPretool.some((spec) =>
+    pretoolSpecMatches(spec, toolName, argBlob)
+  );
+  if (!prefixMatch) return { matched: false };
+  if (!hasContentPatterns(memory)) return { matched: true };
+  const content = extractPretoolContent(toolName, toolInput);
+  if (content == null) return { matched: false };
+  if (!evaluatePretoolContent(memory, content)) return { matched: false };
+  if (!hasNegativeContentPatterns(memory)) return { matched: true };
+  const negative = module.exports.evaluatePretoolContentNot(memory, content);
+  if (negative.excluded) {
+    return { reason: 'negative-excludes', matched: { negative_pattern: negative.pattern } };
+  }
+  return { matched: true };
+}
+
 function matchSession(memory) {
   if (!memory.events.includes('SessionStart')) return false;
   return memory.triggerSession === true;
@@ -124,9 +189,12 @@ module.exports = {
   selectForEvent,
   matchPrompt,
   matchPreTool,
+  matchPreToolResult,
   matchSession,
   matchStop,
   safeRegex,
   extractPretoolContent,
   evaluatePretoolContent,
+  evaluatePretoolContentNot,
+  hasNegativeContentPatterns,
 };

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -37,23 +37,48 @@ function hasContentPatterns(memory) {
   return Array.isArray(memory.triggerPretoolContent) && memory.triggerPretoolContent.length > 0;
 }
 
-function matchPreTool(memory, payload) {
-  if (!memory.events.includes('PreToolUse')) return false;
-  if (!memory.triggerPretool.length) return false;
+// Stage 1: check that the memory wants PreToolUse and the tool/argv prefix
+// patterns match. Returns null on miss, or the resolved { toolName, toolInput }
+// on hit so callers can proceed to content evaluation.
+function _evaluatePreToolPrefix(memory, payload) {
+  if (!memory.events.includes('PreToolUse')) return null;
+  if (!memory.triggerPretool.length) return null;
   const toolName = payload?.tool_name || '';
   const toolInput = payload?.tool_input || {};
   const argBlob = JSON.stringify(toolInput);
   const prefixMatch = memory.triggerPretool.some((spec) =>
     pretoolSpecMatches(spec, toolName, argBlob)
   );
-  if (!prefixMatch) return false;
-  if (!hasContentPatterns(memory)) return true;
+  if (!prefixMatch) return null;
+  return { toolName, toolInput };
+}
+
+// Stage 2: given a prefix hit, evaluate positive and negative content
+// patterns. Returns the shared match result.
+function _evaluatePreToolContentStage(memory, toolName, toolInput) {
+  if (!hasContentPatterns(memory)) return { matched: true };
   const content = extractPretoolContent(toolName, toolInput);
-  if (content == null) return false;
-  if (!evaluatePretoolContent(memory, content)) return false;
-  if (!hasNegativeContentPatterns(memory)) return true;
+  if (content == null) return { matched: false };
+  if (!evaluatePretoolContent(memory, content)) return { matched: false };
+  if (!hasNegativeContentPatterns(memory)) return { matched: true };
   const negative = module.exports.evaluatePretoolContentNot(memory, content);
-  return !negative.excluded;
+  if (negative.excluded) return { matched: false, negative: { pattern: negative.pattern } };
+  return { matched: true };
+}
+
+// Shared internal evaluator for matchPreTool / matchPreToolResult.
+// Returns one of:
+//   { matched: true }
+//   { matched: false }
+//   { matched: false, negative: { pattern: P } }  // negative-excludes
+function _evaluatePreToolMatch(memory, payload) {
+  const prefix = _evaluatePreToolPrefix(memory, payload);
+  if (!prefix) return { matched: false };
+  return _evaluatePreToolContentStage(memory, prefix.toolName, prefix.toolInput);
+}
+
+function matchPreTool(memory, payload) {
+  return _evaluatePreToolMatch(memory, payload).matched;
 }
 
 function extractMultiEditContent(edits) {
@@ -138,25 +163,15 @@ function evaluatePretoolContentNot(memory, contentString) {
 // Broader MatchResult contract (other reasons, explainer CLI) is GH-443's domain;
 // this wrapper exposes only the negative-excludes signal.
 function matchPreToolResult(memory, payload) {
-  if (!memory.events.includes('PreToolUse')) return { matched: false };
-  if (!memory.triggerPretool.length) return { matched: false };
-  const toolName = payload?.tool_name || '';
-  const toolInput = payload?.tool_input || {};
-  const argBlob = JSON.stringify(toolInput);
-  const prefixMatch = memory.triggerPretool.some((spec) =>
-    pretoolSpecMatches(spec, toolName, argBlob)
-  );
-  if (!prefixMatch) return { matched: false };
-  if (!hasContentPatterns(memory)) return { matched: true };
-  const content = extractPretoolContent(toolName, toolInput);
-  if (content == null) return { matched: false };
-  if (!evaluatePretoolContent(memory, content)) return { matched: false };
-  if (!hasNegativeContentPatterns(memory)) return { matched: true };
-  const negative = module.exports.evaluatePretoolContentNot(memory, content);
-  if (negative.excluded) {
-    return { reason: 'negative-excludes', matched: { negative_pattern: negative.pattern } };
+  const result = _evaluatePreToolMatch(memory, payload);
+  if (result.matched) return { matched: true };
+  if (result.negative) {
+    return {
+      reason: 'negative-excludes',
+      matched: { negative_pattern: result.negative.pattern },
+    };
   }
-  return { matched: true };
+  return { matched: false };
 }
 
 function matchSession(memory) {

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -156,6 +156,7 @@ function readMemoryFile(store, name) {
     triggerPrompt: meta.trigger_prompt || '',
     triggerPretool: toList(meta.trigger_pretool),
     triggerPretoolContent: toList(meta.trigger_pretool_content),
+    triggerPretoolContentNot: toList(meta.trigger_pretool_content_not),
     triggerSession: meta.trigger_session === true || meta.trigger_session === 'true',
     inject: meta.inject === 'full' ? 'full' : 'summary',
     meta,

--- a/plugins/synapsys/scripts/synapsys-crystallize-lint.js
+++ b/plugins/synapsys/scripts/synapsys-crystallize-lint.js
@@ -245,6 +245,28 @@ const RULES = [
     },
   },
   {
+    id: 'R10-neg-without-pos',
+    severity: 'warn',
+    scope: 'memory',
+    check(memory) {
+      const neg = Array.isArray(memory.trigger_pretool_content_not)
+        ? memory.trigger_pretool_content_not
+        : [];
+      if (neg.length === 0) return [];
+      const pos = Array.isArray(memory.trigger_pretool_content)
+        ? memory.trigger_pretool_content
+        : [];
+      if (pos.length > 0) return [];
+      return [
+        {
+          rule: 'R10-neg-without-pos',
+          memory: memory.name,
+          message: `memory "${memory.name}" has trigger_pretool_content_not without a positive trigger_pretool_content — negative gate has nothing to gate`,
+        },
+      ];
+    },
+  },
+  {
     id: 'R8-stop-without-retro',
     severity: 'warn',
     scope: 'memory',

--- a/plugins/synapsys/scripts/synapsys-crystallize-write.js
+++ b/plugins/synapsys/scripts/synapsys-crystallize-write.js
@@ -75,6 +75,12 @@ function contentLine(m) {
   return [`trigger_pretool_content: ${list.join(',')}`];
 }
 
+function contentNotLine(m) {
+  const list = m.trigger_pretool_content_not;
+  if (!Array.isArray(list) || list.length === 0) return [];
+  return [`trigger_pretool_content_not: ${list.join(',')}`];
+}
+
 function frontmatter(m) {
   const events = (m.events || []).filter((e) => VALID_EVENTS.has(e));
   const pretool = Array.isArray(m.trigger_pretool)
@@ -90,6 +96,7 @@ function frontmatter(m) {
     `trigger_prompt: ${m.trigger_prompt || ''}`,
     `trigger_pretool: ${pretool}`,
     ...contentLine(m),
+    ...contentNotLine(m),
     `trigger_session: ${m.trigger_session === true ? 'true' : 'false'}`,
     `inject: ${m.inject === 'full' ? 'full' : 'summary'}`,
     '---',

--- a/plugins/synapsys/skills/crystallize/SKILL.md
+++ b/plugins/synapsys/skills/crystallize/SKILL.md
@@ -62,6 +62,7 @@ For each aggregated memory, infer:
   | `NotebookEdit` | `tool_input.new_source` |
   | other tools | ignored — memory cannot fire when content match is required |
   Invalid regex behaviour: each invalid pattern logs `[synapsys] memory <name>: invalid trigger_pretool_content regex "<pat>": <error>` to stderr and is skipped. If **all** patterns are invalid, or if the tool has no extractable content field, the memory **fails closed** (does not fire). Memories without `trigger_pretool_content` behave exactly as before — pure prefix-match on `trigger_pretool`.
+- `trigger_pretool_content_not` *(optional)*: list of regex patterns matched against the **same extracted content** as `trigger_pretool_content`. Combined as **AND-NOT**: the memory fires when `trigger_pretool` matches AND at least one positive content pattern matches AND **none** of these negative patterns match. Use this to turn reminders into corrections — only fire when the file actually needs the change, not when it's already conformant (e.g. the file already imports the right component). Same `i,m` flags, same per-tool extraction table, same per-pattern invalid-regex handling as the positive matcher (stderr warning `[synapsys] memory <name>: invalid trigger_pretool_content_not regex "<pat>": <error>` + skip). If **all** negative patterns are invalid, the negative gate is dropped and behavior falls back to positive-only. Absent or empty array → no negative gate (identical to today). Lint rule `R10-neg-without-pos` warns if you set `trigger_pretool_content_not` without a positive `trigger_pretool_content` (would block all fires). When a memory is excluded by a negative pattern, the matcher result reason is `negative-excludes` and the matched pattern is exposed via `matched.negative_pattern`.
 - `events`: classify explicitly per the **Classifier matrix** below — do not default to all events.
 - `inject`: `full` if body ≤ ~20 lines and content is critical (rules/warnings); `summary` for long playbooks.
 
@@ -239,6 +240,29 @@ inject: full
 **Location:** `src/components/form/Button`
 **Docs:** `packages/ui/src/components/form/Button/Button.md`
 ```
+
+## Worked example: AND-NOT negative-content gate
+
+The positive-only version above fires on **every** `.tsx` edit that contains `<button>` — including edits to files that are already importing the `Button` component (legitimate, the file is conformant). To suppress those false-positive fires, add `trigger_pretool_content_not`:
+
+```yaml
+---
+name: ui-use-Button-not-raw
+description: Block raw <button> in .tsx files unless the file already imports the Button component.
+events: PreToolUse
+trigger_pretool: Edit:.*\.tsx,Write:.*\.tsx
+trigger_pretool_content: <button\b
+trigger_pretool_content_not:
+  - from\s+['"]@app-services-monitoring/ui['"]
+  - import\s+\{[^}]*\bButton\b
+inject: full
+---
+
+Use the Button component, not raw <button>.
+Import: `import { Button } from '@app-services-monitoring/ui';`
+```
+
+**Semantics (AND-NOT):** fires only when raw `<button>` is present AND none of the negative patterns match — i.e. the file does NOT already import from `@app-services-monitoring/ui` AND does NOT already pull in `Button` by name. Order of evaluation: positive content match first (early-exit), negative second. If all `trigger_pretool_content_not` patterns are invalid regex, the matcher falls back to positive-only behavior (the negative gate is dropped). If a single pattern is invalid, it's skipped with a stderr warning; the rest still gate. When a memory is excluded by a negative pattern, the matcher result reason is `negative-excludes` and the matched pattern is exposed via `matched.negative_pattern` (consumed by `synapsys-explain`).
 
 ## TODO (out of scope, deferred)
 

--- a/plugins/synapsys/skills/crystallize/SKILL.md
+++ b/plugins/synapsys/skills/crystallize/SKILL.md
@@ -252,9 +252,7 @@ description: Block raw <button> in .tsx files unless the file already imports th
 events: PreToolUse
 trigger_pretool: Edit:.*\.tsx,Write:.*\.tsx
 trigger_pretool_content: <button\b
-trigger_pretool_content_not:
-  - from\s+['"]@app-services-monitoring/ui['"]
-  - import\s+\{[^}]*\bButton\b
+trigger_pretool_content_not: from\s+['"]@app-services-monitoring/ui['"],import\s+\{[^}]*\bButton\b
 inject: full
 ---
 

--- a/plugins/synapsys/tests/lint.integration.test.js
+++ b/plugins/synapsys/tests/lint.integration.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const LINT_PATH = path.join(__dirname, '..', 'scripts', 'synapsys-crystallize-lint.js');
+
+function makeMemory(overrides) {
+  return Object.assign(
+    {
+      name: 'test-memory',
+      description: 'test',
+      events: ['UserPromptSubmit', 'PreToolUse'],
+      trigger_prompt: '\\b(release|version|publish)\\b',
+      trigger_pretool: ['Bash:gh release'],
+      trigger_session: false,
+      inject: 'summary',
+      body: 'Some safe body content.',
+    },
+    overrides
+  );
+}
+
+function runLint(manifest) {
+  const input = typeof manifest === 'string' ? manifest : JSON.stringify(manifest);
+  const r = spawnSync(process.execPath, [LINT_PATH], { input, encoding: 'utf8' });
+  let env = null;
+  try {
+    env = JSON.parse(r.stdout);
+  } catch (_) {
+    /* tolerate non-JSON for negative cases */
+  }
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr, env };
+}
+
+// S11 — P0 #9 — lint rule R10 warns on negative without positive
+test('P0 #9 — lint rule R10 warns on negative without positive', () => {
+  // R10-neg-without-pos: trigger_pretool_content_not present AND trigger_pretool_content absent/empty → warn.
+  const memNegOnly = makeMemory({
+    name: 'neg-only-mem',
+    trigger_pretool_content_not: ['@app-services-monitoring/ui'],
+  });
+  delete memNegOnly.trigger_pretool_content;
+  const resultMissing = runLint({ memories: [memNegOnly] });
+  const r10Missing = resultMissing.env.warnings.filter((w) => w.rule === 'R10-neg-without-pos');
+  assert.equal(
+    r10Missing.length,
+    1,
+    'exactly one R10-neg-without-pos warning when positive field absent'
+  );
+  assert.ok(
+    /neg-only-mem/.test(r10Missing[0].message || ''),
+    'R10 warning references the memory name'
+  );
+
+  // Empty positive array also triggers R10.
+  const memEmpty = makeMemory({
+    name: 'neg-only-empty-pos',
+    trigger_pretool_content: [],
+    trigger_pretool_content_not: ['@app-services-monitoring/ui'],
+  });
+  const resultEmpty = runLint({ memories: [memEmpty] });
+  const r10Empty = resultEmpty.env.warnings.filter((w) => w.rule === 'R10-neg-without-pos');
+  assert.equal(
+    r10Empty.length,
+    1,
+    'exactly one R10-neg-without-pos warning when positive field empty'
+  );
+
+  // When positive field is present and non-empty, R10 does NOT warn.
+  const memBoth = makeMemory({
+    name: 'both-fields-mem',
+    trigger_pretool_content: ['Button'],
+    trigger_pretool_content_not: ['@app-services-monitoring/ui'],
+  });
+  const resultBoth = runLint({ memories: [memBoth] });
+  const r10Both = resultBoth.env.warnings.filter((w) => w.rule === 'R10-neg-without-pos');
+  assert.equal(r10Both.length, 0, 'no R10 warning when positive field is present and non-empty');
+
+  // Registry shape: R10 registered with severity 'warn', scope 'memory'.
+  const { RULES } = require(LINT_PATH);
+  const r10 = RULES.find((r) => r.id === 'R10-neg-without-pos');
+  assert.ok(r10, 'R10-neg-without-pos registered in RULES array');
+  assert.equal(r10.severity, 'warn', 'R10 severity is "warn"');
+  assert.equal(r10.scope, 'memory', 'R10 scope is "memory"');
+});

--- a/plugins/synapsys/tests/lint.test.js
+++ b/plugins/synapsys/tests/lint.test.js
@@ -94,7 +94,7 @@ test('R2 ignores multi-word phrases', () => {
 test('R7 auto-fixes inject=full when body exceeds 30 lines', () => {
   // G4: inject=full + 50-line body → manifest.inject mutated to 'summary', R7 warning, exit 0.
   const { RULES } = require(LINT_PATH);
-  assert.equal(RULES.length, 9, 'RULES registry has 9 rules');
+  assert.equal(RULES.length, 10, 'RULES registry has 10 rules');
   const longBody = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join('\n');
   const manifest = {
     memories: [makeMemory({ name: 'long-full-mem', inject: 'full', body: longBody })],


### PR DESCRIPTION
## Existing Behavior

- The synapsys PreToolUse matcher supported only a positive `trigger_pretool_content` gate: a memory fired whenever its content regex matched the tool's written content.
- There was no way to suppress a memory when the file being edited was already conformant (e.g., already importing the correct UI component), leading to unnecessary injections.
- `synapsys-crystallize-write.js` did not emit a `trigger_pretool_content_not` frontmatter line, so any authored manifest field would be silently dropped during the write round-trip.
- The lint registry had 9 rules (R1-R9); no rule warned when a negative gate was declared without a companion positive gate.

## Intended New Behavior

- Memories can declare an optional `trigger_pretool_content_not` CSV field. The runtime evaluates it as an AND-NOT gate: the memory fires when the positive `trigger_pretool_content` matches AND none of the negative patterns match (`matcher.js:54-55`).
- Two new helpers are exported from `lib/matcher.js`: `evaluatePretoolContentNot` (returns `{excluded, pattern}`) and `hasNegativeContentPatterns` (guard check). The negative gate short-circuits — it is never evaluated if the positive pass already missed.
- `matchPreToolResult`, a new object-mode wrapper, returns `{reason: 'negative-excludes', matched: {negative_pattern: P}}` on exclusion, narrowly satisfying GH-443's MatchResult contract for this ticket without colonising the broader enum.
- `synapsys-crystallize-write.js` now emits `trigger_pretool_content_not` as a CSV line (`scripts/synapsys-crystallize-write.js:79-81`), completing the write round-trip.
- Lint rule R10-neg-without-pos (`synapsys-crystallize-lint.js:248-264`) warns when a negative gate is present without a positive `trigger_pretool_content` companion.
- README and SKILL.md document the new field with a concrete `ui-use-Button-not-raw` worked example using CSV format for flat-frontmatter-parser compatibility.

## Brief P0 coverage

- **P0 #1:** Positive-only path unchanged — implemented in `plugins/synapsys/lib/matcher.js:44-55` (no negative gate skips `evaluatePretoolContentNot`)
- **P0 #2:** AND-NOT gate evaluates negative patterns after positive match — implemented in `plugins/synapsys/lib/matcher.js:54-55` + test `plugins/synapsys/lib/__tests__/trigger-pretool-content-not.integration.test.js`
- **P0 #3:** UI-package import pattern excludes the memory — test `trigger-pretool-content-not.integration.test.js` (S2)
- **P0 #4:** Partial-invalid and all-invalid negative regex fallback — `evaluatePretoolContentNot` + tests S7/S8
- **P0 #8:** `matchPreToolResult` returns `{reason: 'negative-excludes', matched: {negative_pattern}}` — implemented in `plugins/synapsys/lib/matcher.js:157` + test S9

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / runtime — verify AND-NOT gate:**

1. Create a local synapsys store:

```
node plugins/synapsys/scripts/synapsys-init.js --kind=local
```

2. Drop the worked example memory into the synapsys store directory using the frontmatter from `plugins/synapsys/README.md` (the `ui-use-Button-not-raw-button` block).

3. Simulate a PreToolUse event where the written content contains a raw `<button>` but no import — expect the memory to fire:

```
node -e "
const { matchPreTool } = require('./plugins/synapsys/lib/matcher');
const mem = { name: 'test', events: ['PreToolUse'], triggerPretool: ['Edit:.*\.tsx'], triggerPretoolContent: ['<button\b'], triggerPretoolContentNot: ['@app-services-monitoring/ui'] };
const payload = { tool_name: 'Edit', tool_input: { file_path: 'src/Foo.tsx', old_string: 'x', new_string: '<button>Go</button>' } };
console.log('fires:', matchPreTool(mem, payload)); // expect: true
"
```

4. Repeat with a `new_string` that also contains the UI import — expect the memory to be suppressed (`fires: false`).

5. Run the integration test suite to confirm all 28 cases pass:

```
node --test plugins/synapsys/lib/__tests__/trigger-pretool-content-not.integration.test.js
```

**Lint rule R10 — verify neg-without-pos warning:**

6. Create a manifest JSON with a memory that has `trigger_pretool_content_not` but no `trigger_pretool_content`, then run:

```
node plugins/synapsys/scripts/synapsys-crystallize-lint.js --manifest=<your-manifest.json>
```

Expect a `R10-neg-without-pos` warning in the output.

**Writer round-trip — verify CSV format is preserved:**

7. Run crystallize-write with a manifest that includes `trigger_pretool_content_not` and confirm the emitted `.md` file contains the field as a CSV line (not a YAML list block).

### Test Results

Run with Node.js built-in test runner — all 28 integration tests pass:

```
node --test plugins/synapsys/lib/__tests__/trigger-pretool-content-not.integration.test.js
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Plugin-local matcher and manifest tooling with backward-compatible defaults and extensive tests; only changes when memories opt into the new field.
> 
> **Overview**
> Adds optional **`trigger_pretool_content_not`** so Synapsys PreToolUse memories can use **AND-NOT** content gating: fire when positive `trigger_pretool_content` matches and **none** of the negative regexes match the same extracted tool content (e.g. skip “use Button” reminders when the file already imports it).
> 
> **Runtime:** `memory-store` parses the new frontmatter field; `matcher` refactors PreToolUse into prefix + content stages, adds `evaluatePretoolContentNot` / `hasNegativeContentPatterns`, and wires the negative gate after a positive hit (short-circuit if positive misses). **`matchPreToolResult`** reports `reason: 'negative-excludes'` with `matched.negative_pattern`; boolean **`matchPreTool`** stays backward compatible when the field is absent or empty.
> 
> **Tooling & docs:** `synapsys-crystallize-write` round-trips the CSV line; lint **R10** warns on negative without positive; README and crystallize **SKILL** document semantics and a Button example. Broad integration tests cover parsing, matching, writer, and lint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a80f4e4c608dde54add39b139de382577bc0b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Test Results

| Test Suite | Status | Notes |
|-----------|--------|-------|
| trigger-pretool-content-not integration (28 cases) | PASS | Matcher AND-NOT semantics, invalid-regex fallback, reason: negative-excludes |
| R10 lint rule (neg-without-pos) | PASS | Wired with id, severity warn, scope memory |
| SKILL.md documentation tests (3 cases) | PASS | Split-Warning Passes section, Pass A/B/C, SPLIT-WARNING token |
| All unit tests (57 total) | PASS | Exit code 0, 0 failures |

No screenshots — backend-only feature (matcher logic, lint rule, docs).