### PR TITLE
feat(synapsys): replay false-positive analysis (GH-444)

### DIFF
--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -114,6 +114,25 @@ node plugins/synapsys/scripts/synapsys-explain.js --event=... --verbose
 
 `--only=<csv>` narrows evaluation to specific memories. `--store=<name|path>` picks a non-auto-detected store. Exit code is `0` regardless of how many memories fired; `2` only on misconfiguration.
 
+## Measuring false positives with `synapsys replay`
+
+Once a store has more than a handful of memories, gut-feel trigger tuning stops scaling. `synapsys-replay.js` walks recent transcripts under `~/.claude/projects/<hash>/*.jsonl`, replays every `UserPromptSubmit` and `PreToolUse` event against the current store, optionally asks a lightweight LLM judge whether each fired match was actually relevant, and emits a per-memory report ranked by false-positive rate.
+
+```bash
+# Zero-cost path: no LLM calls, ranks memories by raw fire counts.
+node plugins/synapsys/scripts/synapsys-replay.js --since=7d --no-judge
+
+# Full pipeline with judge (requires ANTHROPIC_API_KEY).
+node plugins/synapsys/scripts/synapsys-replay.js --since=14d
+
+# Machine-readable output.
+node plugins/synapsys/scripts/synapsys-replay.js --since=7d --no-judge --json
+```
+
+Defaults: `--since=7d`, `--max-judges=200` (hard cap with even sampling + extrapolation note), `claude-haiku-4-5` as the judge model, all `~/.claude/projects/*` directories scanned. Use `--project=<hash>` to restrict to one project, `--only=<csv>` to restrict to specific memories, `--store=<name|path>` to override store auto-detection.
+
+`--no-judge` makes zero outbound HTTP calls and requires no `ANTHROPIC_API_KEY` — `relevant` and `fp_rate` are `null`, but `fires` and `sample_matches` are still populated. With the judge enabled, expected cost is well under **$0.05** per default run (~500 input + ~5 output tokens × ≤200 calls). See `skills/replay/SKILL.md` for the full cost model, security note, and the PTU-not-judged decision.
+
 ## Staleness check
 
 `synapsys-staleness-check.js` verifies that consolidated memories are still in sync with the source notes they were built from. Run it manually before a release, in CI on every PR, or as a pre-commit hook to catch drift early.

--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -129,7 +129,7 @@ node plugins/synapsys/scripts/synapsys-replay.js --since=14d
 node plugins/synapsys/scripts/synapsys-replay.js --since=7d --no-judge --json
 ```
 
-Defaults: `--since=7d`, `--max-judges=200` (hard cap with even sampling + extrapolation note), `claude-haiku-4-5` as the judge model, all `~/.claude/projects/*` directories scanned. Use `--project=<hash>` to restrict to one project, `--only=<csv>` to restrict to specific memories, `--store=<name|path>` to override store auto-detection.
+Defaults: `--since=7d`, `--max-judges=200` (hard cap with even sampling + extrapolation note), `claude-haiku-4-5` as the judge model. Scope is the **current project only** — the cwd path with `/` replaced by `-` (matching Claude Code's `~/.claude/projects/<hash>` layout). Use `--project=<hash>` to target a different project, `--all-projects` to scan every project under `~/.claude/projects/`, `--only=<csv>` to restrict to specific memories, `--store=<name|path>` to override store auto-detection.
 
 `--no-judge` makes zero outbound HTTP calls and requires no `ANTHROPIC_API_KEY` — `relevant` and `fp_rate` are `null`, but `fires` and `sample_matches` are still populated. With the judge enabled, expected cost is well under **$0.05** per default run (~500 input + ~5 output tokens × ≤200 calls). See `skills/replay/SKILL.md` for the full cost model, security note, and the PTU-not-judged decision.
 

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -1245,6 +1245,26 @@ test('@task:8 no-transcripts window exits 0 with a friendly message (P0 #12)', (
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
+test('@task:6 renderJson includes store/window/judge_calls/items_judged from meta for machine consumers', () => {
+  const { renderJson } = require(REPLAY);
+  const out = renderJson({}, [], {
+    store: 'worktree',
+    window: '7d',
+    events_total: 42,
+    events_ups: 30,
+    events_ptu: 12,
+    judgeCalls: 4,
+    itemsJudged: 35,
+    extrapolated: true,
+  });
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.store, 'worktree', 'store name surfaced');
+  assert.equal(parsed.window, '7d', 'window surfaced');
+  assert.equal(parsed.judge_calls, 4, 'judge call count surfaced');
+  assert.equal(parsed.items_judged, 35, 'items judged surfaced');
+  assert.equal(parsed.extrapolated, true);
+});
+
 test('@task:7 judgeBatch includes memory body (first 200 chars) in the user content per spec', async () => {
   const { judgeBatch } = require(REPLAY);
   const calls = [];

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -200,7 +200,7 @@ function mkProjectsFixture() {
 
 test('@task:3 walkTranscripts returns *.jsonl files modified within --since window', () => {
   const { walkTranscripts } = require(REPLAY);
-  const { baseDir, projHash, projDir } = mkProjectsFixture();
+  const { baseDir, projDir } = mkProjectsFixture();
 
   const fresh = path.join(projDir, 'fresh.jsonl');
   const stale = path.join(projDir, 'stale.jsonl');
@@ -832,6 +832,65 @@ test('@task:6 renderJson uses deterministic top-level key order', () => {
   const keyOrderRegex =
     /"memories"[\s\S]*"suggestions"[\s\S]*"events_total"[\s\S]*"events_ups"[\s\S]*"events_ptu"/;
   assert.match(out, keyOrderRegex, 'keys appear in deterministic order');
+});
+
+test('@task:6 renderJson includes extrapolated:true when meta.extrapolated is set', () => {
+  const { renderJson } = require(REPLAY);
+  const out = renderJson({}, [], {
+    events_total: 0,
+    events_ups: 0,
+    events_ptu: 0,
+    extrapolated: true,
+  });
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.extrapolated, true, 'extrapolated flag surfaced in JSON');
+});
+
+test('@task:6 renderJson defaults extrapolated to false when meta omits it', () => {
+  const { renderJson } = require(REPLAY);
+  const out = renderJson({}, [], { events_total: 0, events_ups: 0, events_ptu: 0 });
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.extrapolated, false, 'extrapolated defaults to false');
+});
+
+test('@task:6 renderReport emits a header note when meta.extrapolated is true', () => {
+  const { renderReport } = require(REPLAY);
+  const agg = {
+    'ups-bug': {
+      fires: 5,
+      relevant: 3,
+      irrelevant: 1,
+      judge_failed: 0,
+      fp_rate: 0.25,
+      sample_matches: ['auth bug'],
+    },
+  };
+  const meta = {
+    store: 'local',
+    window: '7d',
+    events_total: 12,
+    events_ups: 7,
+    events_ptu: 5,
+    judgeCalls: 4,
+    extrapolated: true,
+  };
+  const out = renderReport(agg, [], meta);
+  assert.match(out, /extrapolated/i, 'human report mentions extrapolation');
+});
+
+test('@task:6 renderReport omits extrapolation note when meta.extrapolated is false', () => {
+  const { renderReport } = require(REPLAY);
+  const meta = {
+    store: 'local',
+    window: '7d',
+    events_total: 0,
+    events_ups: 0,
+    events_ptu: 0,
+    judgeCalls: 0,
+    extrapolated: false,
+  };
+  const out = renderReport({}, [], meta);
+  assert.ok(!/extrapolated/i.test(out), 'no extrapolation note when full dataset judged');
 });
 
 /**

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -528,6 +528,8 @@ test('@task:5 heuristic tightening suggestion fires for fp_rate > 0.70 with shor
   ]);
   // Top-level only — `|` inside `(...)` / `[...]` is not split.
   assert.deepEqual(splitTopLevelAlternation('(a|b)|cd|[e|f]'), ['(a|b)', 'cd', '[e|f]']);
+  // Backslash-escaped `|` is not a separator.
+  assert.deepEqual(splitTopLevelAlternation('auth\\|login|admin'), ['auth\\|login', 'admin']);
 
   // Memory with short alternation arms and high fp_rate → suggestion.
   const noisyMem = {

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -1107,5 +1107,30 @@ test('@task:8 no-transcripts window exits 0 with a friendly message (P0 #12)', (
   assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
   assert.match(result.stdout, /no transcripts in window/i, 'friendly stdout message');
   assert.equal(result.stderr, '', `stderr must be empty; got: ${result.stderr}`);
+
+  const jsonResult = spawnSync(
+    process.execPath,
+    [
+      REPLAY,
+      '--since=7d',
+      '--no-judge',
+      '--json',
+      `--store=${storeDir}`,
+      `--transcripts-base=${emptyBase}`,
+    ],
+    { encoding: 'utf8', env: { ...process.env, ANTHROPIC_API_KEY: '' } }
+  );
+  assert.equal(
+    jsonResult.status,
+    0,
+    `expected exit 0, got ${jsonResult.status}: ${jsonResult.stderr}`
+  );
+  const parsed = JSON.parse(jsonResult.stdout);
+  assert.deepEqual(parsed.memories, [], '--json no-transcripts: memories empty');
+  assert.deepEqual(parsed.suggestions, [], '--json no-transcripts: suggestions empty');
+  assert.equal(parsed.events_total, 0);
+  assert.equal(parsed.events_ups, 0);
+  assert.equal(parsed.events_ptu, 0);
+  assert.match(parsed.message || '', /no transcripts in window/i);
   fs.rmSync(tmp, { recursive: true, force: true });
 });

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -81,6 +81,40 @@ test('CLI exits 2 on non-numeric --max-judges', () => {
   assert.match(result.stderr, /max-judges/i);
 });
 
+test('suggestTightening fires for realistic \\b(...)\\b wrapped triggers', () => {
+  const { suggestTightening } = require(REPLAY);
+  const memory = { name: 'noisy', triggerPrompt: '\\b(push|fetch|run)\\b' };
+  const agg = { fp_rate: 0.8 };
+  const result = suggestTightening(memory, agg);
+  assert.ok(result, 'wrapped trigger should produce a suggestion');
+  assert.deepEqual(result.candidates.sort(), ['fetch', 'push', 'run']);
+});
+
+test('extractEvents skips synthetic user messages (slash commands, system reminders, tool results)', () => {
+  const { extractEvents } = require(REPLAY);
+  const cases = [
+    { type: 'user', message: { content: '<command-name>foo</command-name>' } },
+    { type: 'user', message: { content: '<system-reminder>x</system-reminder>' } },
+    { type: 'user', message: { content: '<local-command-stdout>out</local-command-stdout>' } },
+    {
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: 'x', content: 'r' }] },
+    },
+    { type: 'user', isMeta: true, message: { content: 'real user prompt' } },
+  ];
+  for (const c of cases) {
+    assert.deepEqual(
+      extractEvents(c),
+      [],
+      `should skip synthetic case: ${JSON.stringify(c).slice(0, 60)}`
+    );
+  }
+  // Real prompt still fires
+  const real = extractEvents({ type: 'user', message: { content: 'fix the login bug' } });
+  assert.equal(real.length, 1);
+  assert.equal(real[0].event, 'UserPromptSubmit');
+});
+
 test('CLI exits 2 when --only references only unknown memory names (misconfig contract)', () => {
   const os3 = require('node:os');
   const fs3 = require('node:fs');

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -1,0 +1,861 @@
+'use strict';
+
+/**
+ * Tests for `plugins/synapsys/scripts/synapsys-replay.js` (GH-444).
+ *
+ * Task 1 RED — Scaffold CLI shell + flag parser.
+ *
+ * Covers R10 (all CLI flags + defaults), spec §CLI (exit 2 on invalid
+ * `--since`), spec §Arch (test-only `module.exports.parseFlags`).
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const REPLAY = path.resolve(__dirname, '..', '..', 'scripts', 'synapsys-replay.js');
+
+test('parseFlags returns documented defaults when no argv provided', () => {
+  const { parseFlags } = require(REPLAY);
+  const parsed = parseFlags([]);
+  assert.equal(parsed.since, '7d', 'default --since=7d');
+  assert.equal(parsed.maxJudges, 200, 'default --max-judges=200');
+  assert.equal(parsed.noJudge, false);
+  assert.equal(parsed.json, false);
+  assert.equal(parsed.project, undefined);
+  assert.equal(parsed.only, undefined);
+  assert.equal(parsed.store, undefined);
+});
+
+test('parseFlags reads all R10 flags from argv', () => {
+  const { parseFlags } = require(REPLAY);
+  const parsed = parseFlags([
+    '--since=14d',
+    '--project=abc123',
+    '--no-judge',
+    '--json',
+    '--only=mem-a,mem-b',
+    '--store=my-store',
+    '--max-judges=50',
+  ]);
+  assert.equal(parsed.since, '14d');
+  assert.equal(parsed.project, 'abc123');
+  assert.equal(parsed.noJudge, true);
+  assert.equal(parsed.json, true);
+  assert.equal(parsed.only, 'mem-a,mem-b');
+  assert.equal(parsed.store, 'my-store');
+  assert.equal(parsed.maxJudges, 50);
+});
+
+test('parseFlags coerces --max-judges to a number', () => {
+  const { parseFlags } = require(REPLAY);
+  const parsed = parseFlags(['--max-judges=42']);
+  assert.equal(typeof parsed.maxJudges, 'number');
+  assert.equal(parsed.maxJudges, 42);
+});
+
+test('CLI exits 2 on invalid --since (not matching /^\\d+d$/)', () => {
+  const result = spawnSync(process.execPath, [REPLAY, '--since=abc', '--no-judge'], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 2, 'exit code 2 for invalid --since');
+  assert.match(result.stderr, /since/i);
+});
+
+test('CLI exits 0 and echoes parsed flags as JSON in no-op main', () => {
+  const result = spawnSync(
+    process.execPath,
+    [REPLAY, '--since=7d', '--no-judge', '--json', '--max-judges=10'],
+    { encoding: 'utf8' }
+  );
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.since, '7d');
+  assert.equal(parsed.noJudge, true);
+  assert.equal(parsed.json, true);
+  assert.equal(parsed.maxJudges, 10);
+});
+
+/**
+ * Task 2 RED — `extractEvents(parsedLine)` pure function (G1 + G2, R2).
+ *
+ * Synthesizes `{event:'UserPromptSubmit', prompt}` from `type=user` entries
+ * and `{event:'PreToolUse', tool, tool_input}` per `tool_use` block from
+ * `type=assistant` entries. Everything else returns `[]`.
+ */
+
+test('extractEvents synthesizes UserPromptSubmit from a user transcript entry (P0 #2)', () => {
+  const { extractEvents } = require(REPLAY);
+
+  // Plain string `content` shape.
+  const stringForm = extractEvents({
+    type: 'user',
+    message: { content: 'fix the auth bug' },
+  });
+  assert.deepEqual(stringForm, [{ event: 'UserPromptSubmit', prompt: 'fix the auth bug' }]);
+
+  // Array `content` shape with text block.
+  const arrayForm = extractEvents({
+    type: 'user',
+    message: { content: [{ type: 'text', text: 'refactor the parser' }] },
+  });
+  assert.deepEqual(arrayForm, [
+    { event: 'UserPromptSubmit', prompt: 'refactor the parser' },
+  ]);
+
+  // Unrelated entry types yield no events.
+  assert.deepEqual(extractEvents({ type: 'system', message: { content: 'hi' } }), []);
+  assert.deepEqual(extractEvents({ type: 'summary' }), []);
+});
+
+test('extractEvents synthesizes PreToolUse from an assistant tool_use block (P0 #2)', () => {
+  const { extractEvents } = require(REPLAY);
+
+  const single = extractEvents({
+    type: 'assistant',
+    message: {
+      content: [
+        { type: 'text', text: 'I will read the file.' },
+        {
+          type: 'tool_use',
+          id: 'toolu_1',
+          name: 'Read',
+          input: { file_path: '/tmp/x.txt' },
+        },
+      ],
+    },
+  });
+  assert.deepEqual(single, [
+    { event: 'PreToolUse', tool: 'Read', tool_input: { file_path: '/tmp/x.txt' } },
+  ]);
+
+  // Multiple tool_use blocks → one PTU event per block, in order.
+  const multi = extractEvents({
+    type: 'assistant',
+    message: {
+      content: [
+        { type: 'tool_use', name: 'Bash', input: { command: 'ls' } },
+        { type: 'tool_use', name: 'Grep', input: { pattern: 'foo' } },
+      ],
+    },
+  });
+  assert.deepEqual(multi, [
+    { event: 'PreToolUse', tool: 'Bash', tool_input: { command: 'ls' } },
+    { event: 'PreToolUse', tool: 'Grep', tool_input: { pattern: 'foo' } },
+  ]);
+
+  // Assistant entry with only text content → no events.
+  const textOnly = extractEvents({
+    type: 'assistant',
+    message: { content: [{ type: 'text', text: 'done' }] },
+  });
+  assert.deepEqual(textOnly, []);
+});
+
+/**
+ * Task 3 RED — `walkTranscripts({since, project, baseDir})` + `parseSince` +
+ * `iterLines` (R1, R12 walker-level).
+ *
+ * @task:3
+ *
+ * Tagged with `@task:3` so the TDD harness binds these tests to the Task 3
+ * gate (avoids the unit-only fallback). All four cases MUST fail before
+ * Task 3 GREEN — `walkTranscripts`, `parseSince`, and `iterLines` are not
+ * yet exported by synapsys-replay.js.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const { spawnSync: spawnSync2 } = require('node:child_process'); // eslint-disable-line no-unused-vars
+
+function mkProjectsFixture() {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-replay-walk-'));
+  const projHash = '-tmp-some-project';
+  const projDir = path.join(baseDir, projHash);
+  fs.mkdirSync(projDir, { recursive: true });
+  return { baseDir, projHash, projDir };
+}
+
+test('@task:3 walkTranscripts returns *.jsonl files modified within --since window', () => {
+  const { walkTranscripts } = require(REPLAY);
+  const { baseDir, projHash, projDir } = mkProjectsFixture();
+
+  const fresh = path.join(projDir, 'fresh.jsonl');
+  const stale = path.join(projDir, 'stale.jsonl');
+  const notJsonl = path.join(projDir, 'README.md');
+  fs.writeFileSync(fresh, '{"type":"user","message":{"content":"hi"}}\n');
+  fs.writeFileSync(stale, '{"type":"user","message":{"content":"old"}}\n');
+  fs.writeFileSync(notJsonl, 'ignore me');
+
+  // Backdate stale file to 30 days ago.
+  const thirtyDaysAgo = (Date.now() - 30 * 24 * 60 * 60 * 1000) / 1000;
+  fs.utimesSync(stale, thirtyDaysAgo, thirtyDaysAgo);
+
+  const files = walkTranscripts({ since: '7d', baseDir });
+  assert.ok(Array.isArray(files), 'returns array');
+  assert.ok(files.includes(fresh), 'includes fresh file');
+  assert.ok(!files.includes(stale), 'excludes stale file');
+  assert.ok(!files.includes(notJsonl), 'excludes non-jsonl');
+
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+/**
+ * Task 4 RED — `replayEvent(memories, event)` + matcher integration (R3, G3).
+ *
+ * @task:4
+ *
+ * These tests bind to the Task 4 gate. They MUST fail before Task 4 GREEN —
+ * `replayEvent`, `loadStore`, and `loadMemories` are not yet exported by
+ * synapsys-replay.js. Coverage:
+ *   - per-memory tuple shape `{memory_name, event, fired, matched_substring}`
+ *   - fire / no-fire dispatch by event type
+ *   - matched_substring sourced from `matched.prompt_substring` (UPS)
+ *     and `matched.content_substring` (PTU)
+ *   - loadStore reuses memory-store.discoverStores
+ *   - loadMemories reuses memory-store.listMemoriesFromStore
+ */
+
+function mkUpsMemory(overrides = {}) {
+  return {
+    name: 'ups-bug',
+    events: ['UserPromptSubmit'],
+    triggerPrompt: 'auth bug|login',
+    triggerPretool: [],
+    triggerPretoolContent: [],
+    triggerPretoolContentNot: [],
+    disabled: false,
+    expired: false,
+    ...overrides,
+  };
+}
+
+function mkPtuMemory(overrides = {}) {
+  return {
+    name: 'ptu-write',
+    events: ['PreToolUse'],
+    triggerPrompt: '',
+    triggerPretool: ['Write'],
+    triggerPretoolContent: ['TODO|FIXME'],
+    triggerPretoolContentNot: [],
+    disabled: false,
+    expired: false,
+    ...overrides,
+  };
+}
+
+test('@task:4 replayEvent returns per-memory tuple for a UserPromptSubmit event with matched substring', () => {
+  const { replayEvent } = require(REPLAY);
+  const memories = [mkUpsMemory(), mkPtuMemory()];
+  const event = { event: 'UserPromptSubmit', prompt: 'please fix the auth bug today' };
+  const tuples = replayEvent(memories, event);
+
+  assert.ok(Array.isArray(tuples), 'returns an array');
+  assert.equal(tuples.length, 2, 'one tuple per memory');
+
+  const ups = tuples.find((t) => t.memory_name === 'ups-bug');
+  assert.ok(ups, 'tuple exists for ups-bug');
+  assert.equal(ups.event, 'UserPromptSubmit');
+  assert.equal(ups.fired, true);
+  assert.equal(ups.matched_substring, 'auth bug', 'matched_substring from matched.prompt_substring');
+
+  const ptu = tuples.find((t) => t.memory_name === 'ptu-write');
+  assert.ok(ptu, 'tuple exists for ptu-write');
+  assert.equal(ptu.event, 'UserPromptSubmit');
+  assert.equal(ptu.fired, false, 'PTU memory does not fire on UPS event');
+});
+
+test('@task:4 replayEvent dispatches PreToolUse to matchPreTool and reads content_substring', () => {
+  const { replayEvent } = require(REPLAY);
+  const memories = [mkUpsMemory(), mkPtuMemory()];
+  const event = {
+    event: 'PreToolUse',
+    tool: 'Write',
+    tool_input: { content: 'add TODO before shipping' },
+  };
+  const tuples = replayEvent(memories, event);
+
+  assert.equal(tuples.length, 2);
+  const ups = tuples.find((t) => t.memory_name === 'ups-bug');
+  assert.equal(ups.fired, false, 'UPS memory does not fire on PTU event');
+
+  const ptu = tuples.find((t) => t.memory_name === 'ptu-write');
+  assert.equal(ptu.event, 'PreToolUse');
+  assert.equal(ptu.fired, true);
+  assert.equal(ptu.matched_substring, 'TODO', 'matched_substring from matched.content_substring');
+});
+
+test('@task:4 replayEvent no-fire tuple has matched_substring undefined and fired=false', () => {
+  const { replayEvent } = require(REPLAY);
+  const memories = [mkUpsMemory()];
+  const tuples = replayEvent(memories, {
+    event: 'UserPromptSubmit',
+    prompt: 'nothing relevant here',
+  });
+  assert.equal(tuples.length, 1);
+  assert.equal(tuples[0].fired, false);
+  assert.equal(tuples[0].matched_substring, undefined);
+});
+
+test('@task:4 loadStore reuses discoverStores; unknown --store exits with code 2', () => {
+  const { loadStore } = require(REPLAY);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-replay-load-'));
+  // Mark a fake local store so discoverStores finds it.
+  const storeDir = path.join(tmp, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(path.join(storeDir, '.synapsys.json'), '{}');
+
+  const allStores = loadStore({ storeFlag: undefined, cwd: tmp });
+  assert.ok(Array.isArray(allStores), 'returns array');
+  assert.ok(
+    allStores.some((s) => s.kind === 'local'),
+    'discovers local store'
+  );
+
+  // Path-based selector.
+  const byPath = loadStore({ storeFlag: storeDir, cwd: tmp });
+  assert.equal(byPath.length, 1);
+  assert.equal(path.resolve(byPath[0].dir), path.resolve(storeDir));
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('@task:4 loadMemories reuses listMemoriesFromStore and returns parsed memory objects', () => {
+  const { loadMemories } = require(REPLAY);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-replay-mems-'));
+  const storeDir = path.join(tmp, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(path.join(storeDir, '.synapsys.json'), '{}');
+  fs.writeFileSync(
+    path.join(storeDir, 'sample.md'),
+    [
+      '---',
+      'name: sample',
+      'description: test memory',
+      'events: UserPromptSubmit',
+      'trigger_prompt: hello',
+      '---',
+      'body',
+      '',
+    ].join('\n')
+  );
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'x' };
+  const mems = loadMemories([store]);
+  assert.equal(mems.length, 1);
+  assert.equal(mems[0].name, 'sample');
+  assert.equal(mems[0].triggerPrompt, 'hello');
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('@task:3 walkTranscripts honors --project filter and empty window returns []', () => {
+  const { walkTranscripts } = require(REPLAY);
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-replay-walk-'));
+
+  const projA = path.join(baseDir, '-proj-a');
+  const projB = path.join(baseDir, '-proj-b');
+  fs.mkdirSync(projA, { recursive: true });
+  fs.mkdirSync(projB, { recursive: true });
+  const fileA = path.join(projA, 't.jsonl');
+  const fileB = path.join(projB, 't.jsonl');
+  fs.writeFileSync(fileA, '{}\n');
+  fs.writeFileSync(fileB, '{}\n');
+
+  const onlyA = walkTranscripts({ since: '7d', project: '-proj-a', baseDir });
+  assert.ok(onlyA.includes(fileA), 'project filter includes target');
+  assert.ok(!onlyA.includes(fileB), 'project filter excludes other');
+
+  // Empty / non-existent baseDir → [] without throwing (R12 walker level).
+  const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-replay-empty-'));
+  const empty = walkTranscripts({ since: '7d', baseDir: emptyDir });
+  assert.deepEqual(empty, []);
+
+  fs.rmSync(baseDir, { recursive: true, force: true });
+  fs.rmSync(emptyDir, { recursive: true, force: true });
+});
+
+test('@task:3 parseSince converts Nd to ms; invalid format throws', () => {
+  const { parseSince } = require(REPLAY);
+  assert.equal(parseSince('7d'), 7 * 24 * 60 * 60 * 1000);
+  assert.equal(parseSince('1d'), 24 * 60 * 60 * 1000);
+  assert.equal(parseSince('30d'), 30 * 24 * 60 * 60 * 1000);
+  assert.throws(() => parseSince('abc'), /since/i);
+  assert.throws(() => parseSince('7'), /since/i);
+  assert.throws(() => parseSince(''), /since/i);
+});
+
+test('@task:3 iterLines yields parsed JSON; malformed lines warn to stderr and are skipped', () => {
+  const { iterLines } = require(REPLAY);
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-replay-iter-'));
+  const filePath = path.join(baseDir, 'mixed.jsonl');
+  fs.writeFileSync(
+    filePath,
+    [
+      '{"type":"user","message":{"content":"one"}}',
+      'not-valid-json{',
+      '{"type":"assistant","message":{"content":[]}}',
+      '',
+      '{"type":"system"}',
+    ].join('\n') + '\n'
+  );
+
+  // Capture stderr writes during the iteration.
+  const origWrite = process.stderr.write.bind(process.stderr);
+  const stderrChunks = [];
+  process.stderr.write = (chunk) => {
+    stderrChunks.push(String(chunk));
+    return true;
+  };
+
+  let parsed;
+  try {
+    parsed = Array.from(iterLines(filePath));
+  } finally {
+    process.stderr.write = origWrite;
+  }
+
+  assert.equal(parsed.length, 3, 'three valid JSON entries (malformed + empty skipped)');
+  assert.equal(parsed[0].type, 'user');
+  assert.equal(parsed[1].type, 'assistant');
+  assert.equal(parsed[2].type, 'system');
+  const stderrAll = stderrChunks.join('');
+  assert.match(stderrAll, /malformed|skip|parse/i, 'warned about malformed line');
+
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+/**
+ * Task 5 RED — `aggregateReport` + `suggestTightening` + `splitTopLevelAlternation`
+ * (R5 arithmetic, R7 judge-failed bookkeeping, R8 heuristic, G5, G7).
+ *
+ * @task:5
+ *
+ * Tagged with `@task:5` so the TDD harness binds these tests to the Task 5
+ * gate. They MUST fail before Task 5 GREEN — `aggregateReport`,
+ * `suggestTightening`, and `splitTopLevelAlternation` are not yet exported.
+ */
+
+test('@task:5 judge call is mocked and per-memory relevance is computed correctly (P0 #5)', () => {
+  const { aggregateReport } = require(REPLAY);
+
+  // Two memories, mixed events. Tuples are the output of replayEvent across
+  // a series of events; only `fired=true` rows feed the judge.
+  const tuples = [
+    // ups-bug: 5 fires (3 relevant, 1 irrelevant, 1 judge-failed) → fp = 1 - 3/4 = 0.25
+    { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: true, matched_substring: 'auth bug' },
+    { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: true, matched_substring: 'auth bug' },
+    { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: true, matched_substring: 'login' },
+    { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: true, matched_substring: 'login' },
+    { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: true, matched_substring: 'auth bug' },
+    { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: false, matched_substring: undefined },
+    // ptu-write: PTU-only memory → not judged in v1 → relevant=null, fp_rate=null
+    { memory_name: 'ptu-write', event: 'PreToolUse', fired: true, matched_substring: 'TODO' },
+    { memory_name: 'ptu-write', event: 'PreToolUse', fired: true, matched_substring: 'FIXME' },
+  ];
+
+  // Mocked judge output keyed by tuple identity (index into fired-tuples in
+  // ups-bug's slice). aggregateReport receives a `judgments` map per
+  // memory_name with `relevant[]`, `irrelevant[]`, `judge_failed` counts.
+  const judgments = {
+    'ups-bug': { relevant: 3, irrelevant: 1, judge_failed: 1 },
+  };
+
+  const report = aggregateReport(tuples, judgments);
+  assert.ok(report && typeof report === 'object', 'returns object');
+  const ups = report['ups-bug'] || (Array.isArray(report) && report.find((m) => m.name === 'ups-bug'));
+  const ptu = report['ptu-write'] || (Array.isArray(report) && report.find((m) => m.name === 'ptu-write'));
+  assert.ok(ups, 'ups-bug entry present');
+  assert.ok(ptu, 'ptu-write entry present');
+
+  assert.equal(ups.fires, 5, 'fires counts only fired=true');
+  assert.equal(ups.relevant, 3);
+  assert.equal(ups.irrelevant, 1);
+  assert.equal(ups.judge_failed, 1);
+  // fp_rate = 1 - relevant / (relevant + irrelevant); judge_failed excluded
+  assert.equal(ups.fp_rate, 1 - 3 / 4);
+
+  // sample_matches top-3 most-frequent distinct substrings.
+  assert.ok(Array.isArray(ups.sample_matches));
+  assert.ok(ups.sample_matches.includes('auth bug'));
+  assert.ok(ups.sample_matches.includes('login'));
+  assert.ok(ups.sample_matches.length <= 3);
+
+  // PTU-only memory: not judged in v1.
+  assert.equal(ptu.fires, 2);
+  assert.equal(ptu.relevant, null);
+  assert.equal(ptu.fp_rate, null);
+});
+
+test('@task:5 heuristic tightening suggestion fires for fp_rate > 0.70 with short alternation arms (P0 #8)', () => {
+  const { suggestTightening, splitTopLevelAlternation } = require(REPLAY);
+
+  // splitTopLevelAlternation splits on top-level `|` only.
+  assert.deepEqual(
+    splitTopLevelAlternation('push|fetch|deploy-production'),
+    ['push', 'fetch', 'deploy-production']
+  );
+  // Top-level only — `|` inside `(...)` / `[...]` is not split.
+  assert.deepEqual(
+    splitTopLevelAlternation('(a|b)|cd|[e|f]'),
+    ['(a|b)', 'cd', '[e|f]']
+  );
+
+  // Memory with short alternation arms and high fp_rate → suggestion.
+  const noisyMem = {
+    name: 'noisy',
+    triggerPrompt: 'push|fetch|deploy-production',
+  };
+  const agg = { fires: 10, relevant: 2, irrelevant: 8, judge_failed: 0, fp_rate: 0.8, sample_matches: ['push', 'fetch'] };
+  const suggestion = suggestTightening(noisyMem, agg);
+  assert.ok(suggestion, 'returns suggestion when fp_rate > 0.70 + short arms');
+  assert.equal(suggestion.memory, 'noisy');
+  assert.ok(Array.isArray(suggestion.candidates));
+  assert.ok(suggestion.candidates.includes('push'), 'flags short arm push');
+  assert.ok(suggestion.candidates.includes('fetch'), 'flags short arm fetch');
+  assert.ok(!suggestion.candidates.includes('deploy-production'), 'does not flag long arm');
+
+  // fp_rate <= 0.70 → no suggestion.
+  const okAgg = { fires: 10, relevant: 5, irrelevant: 5, judge_failed: 0, fp_rate: 0.5, sample_matches: [] };
+  assert.equal(suggestTightening(noisyMem, okAgg), null, 'no suggestion when fp_rate <= 0.70');
+
+  // High fp_rate but no short arms → no suggestion.
+  const longMem = { name: 'long', triggerPrompt: 'deploy-production|rollback-stage' };
+  assert.equal(suggestTightening(longMem, agg), null, 'no suggestion when all arms long');
+
+  // PTU-only memory with fp_rate=null → no suggestion.
+  const nullAgg = { fires: 5, relevant: null, irrelevant: null, judge_failed: 0, fp_rate: null, sample_matches: [] };
+  assert.equal(suggestTightening(noisyMem, nullAgg), null, 'no suggestion when fp_rate is null');
+});
+
+/**
+ * Task 6 RED — `renderJson` + `renderReport` output (R9, R11, R17, G6).
+ *
+ * @task:6
+ *
+ * Tagged with `@task:6` so the TDD harness binds these tests to the Task 6
+ * gate. They MUST fail before Task 6 GREEN — `renderJson` and `renderReport`
+ * are not yet exported by synapsys-replay.js.
+ *
+ * Covers:
+ *   - --json output shape includes memories, suggestions, and event totals (P0 #9, #11)
+ *   - text report header + per-memory table + Suggestions section
+ *   - cost footer present only when judge ran
+ *   - ANTHROPIC_API_KEY value never appears in any rendered output
+ */
+
+test('@task:6 --json output shape includes memories, suggestions, and event totals (P0 #9, #11)', () => {
+  const { renderJson } = require(REPLAY);
+
+  const agg = {
+    'ups-bug': {
+      fires: 5,
+      relevant: 3,
+      irrelevant: 1,
+      judge_failed: 1,
+      fp_rate: 0.25,
+      sample_matches: ['auth bug', 'login'],
+    },
+    'ptu-write': {
+      fires: 2,
+      relevant: null,
+      irrelevant: null,
+      judge_failed: 0,
+      fp_rate: null,
+      sample_matches: ['TODO', 'FIXME'],
+    },
+  };
+  const suggestions = [
+    { memory: 'noisy', candidates: ['push', 'fetch'] },
+  ];
+  const meta = {
+    store: 'local',
+    window: '7d',
+    events_total: 12,
+    events_ups: 7,
+    events_ptu: 5,
+    judgeCalls: 4,
+  };
+
+  const out = renderJson(agg, suggestions, meta);
+  assert.equal(typeof out, 'string', 'renderJson returns a string');
+  const parsed = JSON.parse(out);
+
+  // Top-level keys.
+  for (const k of ['memories', 'suggestions', 'events_total', 'events_ups', 'events_ptu']) {
+    assert.ok(Object.prototype.hasOwnProperty.call(parsed, k), `top-level key ${k} present`);
+  }
+  assert.equal(parsed.events_total, 12);
+  assert.equal(parsed.events_ups, 7);
+  assert.equal(parsed.events_ptu, 5);
+
+  // memories shape.
+  assert.ok(Array.isArray(parsed.memories), 'memories is an array');
+  assert.equal(parsed.memories.length, 2);
+  for (const m of parsed.memories) {
+    for (const k of ['name', 'fires', 'relevant', 'irrelevant', 'judge_failed', 'fp_rate', 'sample_matches']) {
+      assert.ok(Object.prototype.hasOwnProperty.call(m, k), `memories[].${k} present`);
+    }
+  }
+  const ups = parsed.memories.find((m) => m.name === 'ups-bug');
+  assert.equal(ups.fires, 5);
+  assert.equal(ups.relevant, 3);
+  assert.equal(ups.fp_rate, 0.25);
+
+  // suggestions shape.
+  assert.ok(Array.isArray(parsed.suggestions));
+  assert.equal(parsed.suggestions.length, 1);
+  assert.equal(parsed.suggestions[0].memory, 'noisy');
+  assert.deepEqual(parsed.suggestions[0].candidates, ['push', 'fetch']);
+
+  // ANTHROPIC_API_KEY value must not appear in output.
+  assert.ok(!out.includes('sk-ant-'), 'no API key prefix in output');
+});
+
+test('@task:6 renderReport text contains header, per-memory rows, and Suggestions section', () => {
+  const { renderReport } = require(REPLAY);
+
+  const agg = {
+    'ups-bug': {
+      fires: 5,
+      relevant: 3,
+      irrelevant: 1,
+      judge_failed: 1,
+      fp_rate: 0.25,
+      sample_matches: ['auth bug', 'login'],
+    },
+  };
+  const suggestions = [{ memory: 'noisy', candidates: ['push', 'fetch'] }];
+  const meta = {
+    store: 'local',
+    window: '7d',
+    events_total: 12,
+    events_ups: 7,
+    events_ptu: 5,
+    judgeCalls: 4,
+  };
+
+  const out = renderReport(agg, suggestions, meta);
+  assert.equal(typeof out, 'string');
+
+  // Header line bits.
+  assert.match(out, /store=/);
+  assert.match(out, /window=/);
+  assert.match(out, /events=/);
+  assert.match(out, /UPS=/);
+  assert.match(out, /PTU=/);
+
+  // Per-memory row.
+  assert.match(out, /ups-bug/);
+
+  // Suggestions section.
+  assert.match(out, /Suggestions:/);
+  assert.match(out, /noisy/);
+
+  // Cost footer present when judge ran.
+  assert.match(out, /cost/i);
+});
+
+test('@task:6 renderReport cost footer absent under --no-judge (judgeCalls=0)', () => {
+  const { renderReport } = require(REPLAY);
+  const agg = {
+    'ups-bug': {
+      fires: 5, relevant: null, irrelevant: null, judge_failed: 0,
+      fp_rate: null, sample_matches: ['auth bug'],
+    },
+  };
+  const meta = {
+    store: 'local', window: '7d',
+    events_total: 5, events_ups: 5, events_ptu: 0, judgeCalls: 0,
+  };
+  const out = renderReport(agg, [], meta);
+  assert.ok(!/cost/i.test(out), 'no cost footer under --no-judge');
+});
+
+test('@task:6 renderJson does not leak ANTHROPIC_API_KEY value', () => {
+  const { renderJson } = require(REPLAY);
+  const apiKey = 'sk-ant-supersecret-token-1234567890';
+  const prev = process.env.ANTHROPIC_API_KEY;
+  process.env.ANTHROPIC_API_KEY = apiKey;
+  try {
+    const agg = {
+      'ups-bug': {
+        fires: 1, relevant: 1, irrelevant: 0, judge_failed: 0,
+        fp_rate: 0, sample_matches: ['x'],
+      },
+    };
+    const out = renderJson(agg, [], {
+      store: 'local', window: '7d',
+      events_total: 1, events_ups: 1, events_ptu: 0, judgeCalls: 1,
+    });
+    assert.ok(!out.includes(apiKey), 'api key value not in output');
+  } finally {
+    if (prev === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = prev;
+  }
+});
+
+test('@task:6 renderJson uses deterministic top-level key order', () => {
+  const { renderJson } = require(REPLAY);
+  const out = renderJson({}, [], {
+    store: 'local', window: '7d',
+    events_total: 0, events_ups: 0, events_ptu: 0, judgeCalls: 0,
+  });
+  // Match key order: memories, suggestions, events_total, events_ups, events_ptu.
+  const keyOrderRegex = /"memories"[\s\S]*"suggestions"[\s\S]*"events_total"[\s\S]*"events_ups"[\s\S]*"events_ptu"/;
+  assert.match(out, keyOrderRegex, 'keys appear in deterministic order');
+});
+
+/**
+ * @task:7
+ *
+ * Task 7 RED — `judgeBatch` + `sampleForCap` + `--max-judges` enforcement.
+ *
+ * Tagged with `@task:7` so the TDD harness binds these tests to the Task 7
+ * cycle. Covers R5 (HTTP shape), R6 (`--max-judges` cap + extrapolation),
+ * R7 (network failure recording), R18 (batch size 10), G8 (cap honored).
+ */
+
+test('@task:7 judgeBatch POSTs to anthropic with x-api-key header, haiku model, and numbered 1) ... 2) ... user content', async () => {
+  const { judgeBatch } = require(REPLAY);
+  const calls = [];
+  const fetchImpl = async (url, opts) => {
+    calls.push({ url, opts });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ content: [{ type: 'text', text: '1: yes\n2: no' }] }),
+    };
+  };
+  const items = [
+    { memory: 'mem-a', prompt: 'fix login bug', matched: 'login' },
+    { memory: 'mem-b', prompt: 'rename file', matched: 'rename' },
+  ];
+  const results = await judgeBatch(items, {
+    fetchImpl,
+    apiKey: 'sk-test-key',
+    model: 'claude-haiku-4-5',
+  });
+  assert.equal(calls.length, 1, 'one POST per batch');
+  assert.equal(calls[0].url, 'https://api.anthropic.com/v1/messages');
+  assert.equal(calls[0].opts.method, 'POST');
+  assert.equal(calls[0].opts.headers['x-api-key'], 'sk-test-key');
+  const body = JSON.parse(calls[0].opts.body);
+  assert.equal(body.model, 'claude-haiku-4-5');
+  const userContent = body.messages[0].content;
+  assert.match(userContent, /1\)/);
+  assert.match(userContent, /2\)/);
+  assert.equal(results.length, 2);
+  assert.equal(results[0].relevant, true);
+  assert.equal(results[1].relevant, false);
+});
+
+test('@task:7 judgeBatch marks all items judge-failed on HTTP 500', async () => {
+  const { judgeBatch } = require(REPLAY);
+  const fetchImpl = async () => ({
+    ok: false,
+    status: 500,
+    json: async () => ({}),
+    text: async () => 'server error',
+  });
+  const items = [
+    { memory: 'm1', prompt: 'p1', matched: 'x' },
+    { memory: 'm2', prompt: 'p2', matched: 'y' },
+  ];
+  const results = await judgeBatch(items, { fetchImpl, apiKey: 'k', model: 'claude-haiku-4-5' });
+  assert.equal(results.length, 2);
+  assert.equal(results[0].judge_failed, true);
+  assert.equal(results[1].judge_failed, true);
+});
+
+test('@task:7 judgeBatch marks individual missing reply items as judge-failed', async () => {
+  const { judgeBatch } = require(REPLAY);
+  const fetchImpl = async () => ({
+    ok: true,
+    status: 200,
+    // Only item 1 has a reply; item 2 missing.
+    json: async () => ({ content: [{ type: 'text', text: '1: yes' }] }),
+  });
+  const items = [
+    { memory: 'm1', prompt: 'p1', matched: 'x' },
+    { memory: 'm2', prompt: 'p2', matched: 'y' },
+  ];
+  const results = await judgeBatch(items, { fetchImpl, apiKey: 'k', model: 'claude-haiku-4-5' });
+  assert.equal(results[0].relevant, true);
+  assert.equal(results[1].judge_failed, true, 'missing reply line → judge-failed');
+});
+
+test('@task:7 judgeBatch does not throw on fetch exception; marks all items judge-failed', async () => {
+  const { judgeBatch } = require(REPLAY);
+  const fetchImpl = async () => {
+    throw new Error('network down');
+  };
+  const items = [{ memory: 'm1', prompt: 'p1', matched: 'x' }];
+  const results = await judgeBatch(items, { fetchImpl, apiKey: 'k', model: 'claude-haiku-4-5' });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].judge_failed, true);
+});
+
+test('@task:7 judgeBatch error messages never include the apiKey', async () => {
+  const { judgeBatch } = require(REPLAY);
+  const apiKey = 'sk-super-secret-key-1234567890';
+  const fetchImpl = async () => {
+    throw new Error('network down');
+  };
+  const items = [{ memory: 'm1', prompt: 'p1', matched: 'x' }];
+  const results = await judgeBatch(items, { fetchImpl, apiKey, model: 'claude-haiku-4-5' });
+  for (const r of results) {
+    if (r.error) assert.ok(!String(r.error).includes(apiKey), 'apiKey leaked into error');
+  }
+});
+
+test('@task:7 sampleForCap returns items unchanged + extrapolated:false when items.length <= cap', () => {
+  const { sampleForCap } = require(REPLAY);
+  const items = [{ i: 0 }, { i: 1 }, { i: 2 }];
+  const out = sampleForCap(items, 5);
+  assert.equal(out.extrapolated, false);
+  assert.equal(out.sampled.length, 3);
+});
+
+test('@task:7 sampleForCap evenly samples and flags extrapolated:true when items.length > cap', () => {
+  const { sampleForCap } = require(REPLAY);
+  const items = Array.from({ length: 100 }, (_, i) => ({ i }));
+  const out = sampleForCap(items, 10);
+  assert.equal(out.extrapolated, true);
+  assert.equal(out.sampled.length, 10);
+  // Evenly per Math.floor(i * fires / cap): indices 0,10,20,...,90.
+  const expected = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90];
+  assert.deepEqual(out.sampled.map((x) => x.i), expected);
+});
+
+test('@task:7 --max-judges cap is honored as a hard upper bound (P0 #6)', async () => {
+  const { judgePipeline } = require(REPLAY);
+  const calls = [];
+  const fetchImpl = async (_url, opts) => {
+    calls.push(opts);
+    const body = JSON.parse(opts.body);
+    // Count numbered items in user content via "N) " markers.
+    const userContent = body.messages[0].content;
+    const lines = (userContent.match(/^\d+\)/gm) || []).map((m, i) => `${i + 1}: yes`);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ content: [{ type: 'text', text: lines.join('\n') }] }),
+    };
+  };
+  const items = Array.from({ length: 500 }, (_, i) => ({
+    memory: 'm', prompt: `p${i}`, matched: 'x',
+  }));
+  const out = await judgePipeline(items, {
+    fetchImpl,
+    apiKey: 'k',
+    model: 'claude-haiku-4-5',
+    maxJudges: 50,
+  });
+  // R18 batches of 10 → ceil(50/10) = 5 fetches max.
+  assert.ok(calls.length <= 5, `expected ≤5 fetches, got ${calls.length}`);
+  assert.equal(out.extrapolated, true, 'extrapolated when items > cap');
+  assert.ok(out.results.length <= 50, 'judged at most cap items');
+});
+

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -63,6 +63,16 @@ test('CLI exits 2 on invalid --since (not matching /^\\d+d$/)', () => {
   assert.match(result.stderr, /since/i);
 });
 
+test('CLI exits 2 on --project values that allow path traversal', () => {
+  for (const bad of ['..', '.', 'a..b', '../etc']) {
+    const result = spawnSync(process.execPath, [REPLAY, '--project=' + bad, '--no-judge'], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2, `--project=${bad} should exit 2`);
+    assert.match(result.stderr, /project/i);
+  }
+});
+
 test('CLI exits 0 and emits report JSON in --no-judge mode (Task 8 wired main)', () => {
   // Task 1 scaffold expected an echo of parsed flags. Task 8 wires main() to
   // the real pipeline, so we now assert the wired JSON shape against an empty

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -73,6 +73,14 @@ test('CLI exits 2 on --project values that allow path traversal', () => {
   }
 });
 
+test('CLI exits 2 on non-numeric --max-judges', () => {
+  const result = spawnSync(process.execPath, [REPLAY, '--max-judges=abc', '--no-judge'], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 2, '--max-judges=abc should exit 2');
+  assert.match(result.stderr, /max-judges/i);
+});
+
 test('CLI exits 0 and emits report JSON in --no-judge mode (Task 8 wired main)', () => {
   // Task 1 scaffold expected an echo of parsed flags. Task 8 wires main() to
   // the real pipeline, so we now assert the wired JSON shape against an empty

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -81,6 +81,37 @@ test('CLI exits 2 on non-numeric --max-judges', () => {
   assert.match(result.stderr, /max-judges/i);
 });
 
+test('walkTranscripts defaults to the cwd-derived project (not every project)', () => {
+  const { walkTranscripts } = require(REPLAY);
+  const os5 = require('node:os');
+  const fs5 = require('node:fs');
+  const path5 = require('node:path');
+  const root = fs5.mkdtempSync(path5.join(os5.tmpdir(), 'syn-projects-'));
+  // Two project dirs: one matching cwd hash, one not.
+  const cwd = '/fake/cwd/path';
+  const matching = cwd.split(path5.sep).join('-'); // -fake-cwd-path
+  const other = '-some-other-project';
+  fs5.mkdirSync(path5.join(root, matching));
+  fs5.mkdirSync(path5.join(root, other));
+  fs5.writeFileSync(
+    path5.join(root, matching, 'a.jsonl'),
+    '{"type":"user","message":{"content":"x"}}\n'
+  );
+  fs5.writeFileSync(
+    path5.join(root, other, 'b.jsonl'),
+    '{"type":"user","message":{"content":"y"}}\n'
+  );
+
+  const onlyCwd = walkTranscripts({ since: '7d', baseDir: root, cwd });
+  assert.equal(onlyCwd.length, 1, 'default scans ONLY the cwd-hashed project');
+  assert.ok(onlyCwd[0].includes(matching), 'walked the matching project dir');
+
+  const all = walkTranscripts({ since: '7d', baseDir: root, cwd, allProjects: true });
+  assert.equal(all.length, 2, '--all-projects scans every project dir');
+
+  fs5.rmSync(root, { recursive: true, force: true });
+});
+
 test('suggestTightening fires for realistic \\b(...)\\b wrapped triggers', () => {
   const { suggestTightening } = require(REPLAY);
   const memory = { name: 'noisy', triggerPrompt: '\\b(push|fetch|run)\\b' };

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -787,6 +787,37 @@ test('@task:6 renderJson does not leak ANTHROPIC_API_KEY value', () => {
   }
 });
 
+test('@task:6 renderJson orders memories by descending fp_rate (nulls last)', () => {
+  const { renderJson } = require(REPLAY);
+  const agg = {
+    a: {
+      fires: 1,
+      relevant: null,
+      irrelevant: null,
+      judge_failed: 0,
+      fp_rate: null,
+      sample_matches: [],
+    },
+    b: { fires: 4, relevant: 1, irrelevant: 3, judge_failed: 0, fp_rate: 0.75, sample_matches: [] },
+    c: { fires: 2, relevant: 1, irrelevant: 1, judge_failed: 0, fp_rate: 0.5, sample_matches: [] },
+    d: {
+      fires: 5,
+      relevant: null,
+      irrelevant: null,
+      judge_failed: 0,
+      fp_rate: null,
+      sample_matches: [],
+    },
+  };
+  const parsed = JSON.parse(renderJson(agg, [], { events_total: 0, events_ups: 0, events_ptu: 0 }));
+  const order = parsed.memories.map((m) => m.name);
+  assert.deepEqual(
+    order,
+    ['b', 'c', 'd', 'a'],
+    'fp_rate desc, then fires desc, name asc; nulls last'
+  );
+});
+
 test('@task:6 renderJson uses deterministic top-level key order', () => {
   const { renderJson } = require(REPLAY);
   const out = renderJson({}, [], {

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -81,6 +81,54 @@ test('CLI exits 2 on non-numeric --max-judges', () => {
   assert.match(result.stderr, /max-judges/i);
 });
 
+test('CLI exits 2 when --only references only unknown memory names (misconfig contract)', () => {
+  const os3 = require('node:os');
+  const fs3 = require('node:fs');
+  const path3 = require('node:path');
+  const tmpStore = fs3.mkdtempSync(path3.join(os3.tmpdir(), 'syn-store-'));
+  fs3.writeFileSync(path3.join(tmpStore, '.synapsys.json'), '{}');
+  fs3.writeFileSync(
+    path3.join(tmpStore, 'real-memory.md'),
+    '---\nname: real-memory\ndescription: x\nevents: UserPromptSubmit\ntrigger_prompt: foo\n---\nbody\n'
+  );
+  const tmpTx = fs3.mkdtempSync(path3.join(os3.tmpdir(), 'syn-tx-'));
+  const result = spawnSync(
+    process.execPath,
+    [
+      REPLAY,
+      '--no-judge',
+      `--store=${tmpStore}`,
+      '--only=does-not-exist,also-typo',
+      `--transcripts-base=${tmpTx}`,
+    ],
+    { encoding: 'utf8' }
+  );
+  fs3.rmSync(tmpStore, { recursive: true, force: true });
+  fs3.rmSync(tmpTx, { recursive: true, force: true });
+  assert.equal(result.status, 2, `expected exit 2, got ${result.status}: ${result.stderr}`);
+  assert.match(result.stderr, /only.*matched no memories|unknown/i);
+});
+
+test('CLI emits stderr warning and falls back to no-judge when ANTHROPIC_API_KEY is missing (AC5)', () => {
+  const os4 = require('node:os');
+  const fs4 = require('node:fs');
+  const path4 = require('node:path');
+  const tmp = fs4.mkdtempSync(path4.join(os4.tmpdir(), 'syn-cli-nokey-'));
+  const env = { ...process.env };
+  delete env.ANTHROPIC_API_KEY;
+  // Intentionally NO --no-judge: this exercises the missing-key fallback path.
+  const result = spawnSync(
+    process.execPath,
+    [REPLAY, '--since=7d', `--transcripts-base=${tmp}`, '--json'],
+    { encoding: 'utf8', env }
+  );
+  fs4.rmSync(tmp, { recursive: true, force: true });
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
+  const warnings = result.stderr.match(/ANTHROPIC_API_KEY not set/g) || [];
+  assert.equal(warnings.length, 1, `expected exactly one stderr warning, got: ${result.stderr}`);
+  assert.match(result.stderr, /proceeding as --no-judge/i);
+});
+
 test('CLI exits 0 and emits report JSON in --no-judge mode (Task 8 wired main)', () => {
   // Task 1 scaffold expected an echo of parsed flags. Task 8 wires main() to
   // the real pipeline, so we now assert the wired JSON shape against an empty

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -188,7 +188,6 @@ test('extractEvents synthesizes PreToolUse from an assistant tool_use block (P0 
 
 const fs = require('node:fs');
 const os = require('node:os');
-const { spawnSync: spawnSync2 } = require('node:child_process'); // eslint-disable-line no-unused-vars
 
 function mkProjectsFixture() {
   const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-replay-walk-'));

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -1244,3 +1244,43 @@ test('@task:8 no-transcripts window exits 0 with a friendly message (P0 #12)', (
   assert.match(parsed.message || '', /no transcripts in window/i);
   fs.rmSync(tmp, { recursive: true, force: true });
 });
+
+test('@task:7 judgeBatch includes memory body (first 200 chars) in the user content per spec', async () => {
+  const { judgeBatch } = require(REPLAY);
+  const calls = [];
+  const fetchImpl = async (url, opts) => {
+    calls.push({ url, opts });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ content: [{ type: 'text', text: '1: yes' }] }),
+    };
+  };
+  const longBody = 'A'.repeat(500);
+  const items = [{ memory: 'mem-x', body: longBody, prompt: 'p', matched: 'm' }];
+  await judgeBatch(items, { fetchImpl, apiKey: 'k', model: 'claude-haiku-4-5' });
+  const body = JSON.parse(calls[0].opts.body);
+  const userContent = body.messages[0].content;
+  assert.match(userContent, /memory titled mem-x/, 'judge sees memory name with title phrasing');
+  assert.match(userContent, /with content "A{200}"/, 'judge sees first 200 chars of body');
+  assert.ok(!userContent.includes('A'.repeat(201)), 'body is truncated at 200 chars');
+});
+
+test('@task:7 judgeBatch falls back to claude-haiku-4-5 when opts.model is omitted', async () => {
+  const { judgeBatch } = require(REPLAY);
+  const calls = [];
+  const fetchImpl = async (url, opts) => {
+    calls.push({ url, opts });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ content: [{ type: 'text', text: '1: yes' }] }),
+    };
+  };
+  await judgeBatch([{ memory: 'm', body: 'b', prompt: 'p', matched: 'm' }], {
+    fetchImpl,
+    apiKey: 'k',
+  });
+  const body = JSON.parse(calls[0].opts.body);
+  assert.equal(body.model, 'claude-haiku-4-5', 'default model used when omitted');
+});

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -526,8 +526,9 @@ test('@task:5 heuristic tightening suggestion fires for fp_rate > 0.70 with shor
     'fetch',
     'deploy-production',
   ]);
-  // Top-level only — `|` inside `(...)` / `[...]` is not split.
-  assert.deepEqual(splitTopLevelAlternation('(a|b)|cd|[e|f]'), ['(a|b)', 'cd', '[e|f]']);
+  // Top-level only — `|` inside `(...)` is not split. Brackets are NOT
+  // depth-tracked (matches matcher.js semantics exactly).
+  assert.deepEqual(splitTopLevelAlternation('(a|b)|cd|ef'), ['(a|b)', 'cd', 'ef']);
   // Backslash-escaped `|` is not a separator.
   assert.deepEqual(splitTopLevelAlternation('auth\\|login|admin'), ['auth\\|login', 'admin']);
 

--- a/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-replay.integration.test.js
@@ -63,18 +63,23 @@ test('CLI exits 2 on invalid --since (not matching /^\\d+d$/)', () => {
   assert.match(result.stderr, /since/i);
 });
 
-test('CLI exits 0 and echoes parsed flags as JSON in no-op main', () => {
+test('CLI exits 0 and emits report JSON in --no-judge mode (Task 8 wired main)', () => {
+  // Task 1 scaffold expected an echo of parsed flags. Task 8 wires main() to
+  // the real pipeline, so we now assert the wired JSON shape against an empty
+  // hermetic transcripts dir (no-transcripts message path is covered separately
+  // in the @task:8 cases). We point --transcripts-base at a missing dir so the
+  // pipeline exits 0 via the friendly no-transcripts branch.
+  const os2 = require('node:os');
+  const fs2 = require('node:fs');
+  const tmp = fs2.mkdtempSync(require('node:path').join(os2.tmpdir(), 'syn-cli-'));
   const result = spawnSync(
     process.execPath,
-    [REPLAY, '--since=7d', '--no-judge', '--json', '--max-judges=10'],
+    [REPLAY, '--since=7d', '--no-judge', '--max-judges=10', `--transcripts-base=${tmp}`],
     { encoding: 'utf8' }
   );
+  fs2.rmSync(tmp, { recursive: true, force: true });
   assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
-  const parsed = JSON.parse(result.stdout);
-  assert.equal(parsed.since, '7d');
-  assert.equal(parsed.noJudge, true);
-  assert.equal(parsed.json, true);
-  assert.equal(parsed.maxJudges, 10);
+  assert.match(result.stdout, /no transcripts in window/i);
 });
 
 /**
@@ -100,9 +105,7 @@ test('extractEvents synthesizes UserPromptSubmit from a user transcript entry (P
     type: 'user',
     message: { content: [{ type: 'text', text: 'refactor the parser' }] },
   });
-  assert.deepEqual(arrayForm, [
-    { event: 'UserPromptSubmit', prompt: 'refactor the parser' },
-  ]);
+  assert.deepEqual(arrayForm, [{ event: 'UserPromptSubmit', prompt: 'refactor the parser' }]);
 
   // Unrelated entry types yield no events.
   assert.deepEqual(extractEvents({ type: 'system', message: { content: 'hi' } }), []);
@@ -258,7 +261,11 @@ test('@task:4 replayEvent returns per-memory tuple for a UserPromptSubmit event 
   assert.ok(ups, 'tuple exists for ups-bug');
   assert.equal(ups.event, 'UserPromptSubmit');
   assert.equal(ups.fired, true);
-  assert.equal(ups.matched_substring, 'auth bug', 'matched_substring from matched.prompt_substring');
+  assert.equal(
+    ups.matched_substring,
+    'auth bug',
+    'matched_substring from matched.prompt_substring'
+  );
 
   const ptu = tuples.find((t) => t.memory_name === 'ptu-write');
   assert.ok(ptu, 'tuple exists for ptu-write');
@@ -444,12 +451,32 @@ test('@task:5 judge call is mocked and per-memory relevance is computed correctl
   // a series of events; only `fired=true` rows feed the judge.
   const tuples = [
     // ups-bug: 5 fires (3 relevant, 1 irrelevant, 1 judge-failed) → fp = 1 - 3/4 = 0.25
-    { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: true, matched_substring: 'auth bug' },
-    { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: true, matched_substring: 'auth bug' },
+    {
+      memory_name: 'ups-bug',
+      event: 'UserPromptSubmit',
+      fired: true,
+      matched_substring: 'auth bug',
+    },
+    {
+      memory_name: 'ups-bug',
+      event: 'UserPromptSubmit',
+      fired: true,
+      matched_substring: 'auth bug',
+    },
     { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: true, matched_substring: 'login' },
     { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: true, matched_substring: 'login' },
-    { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: true, matched_substring: 'auth bug' },
-    { memory_name: 'ups-bug', event: 'UserPromptSubmit', fired: false, matched_substring: undefined },
+    {
+      memory_name: 'ups-bug',
+      event: 'UserPromptSubmit',
+      fired: true,
+      matched_substring: 'auth bug',
+    },
+    {
+      memory_name: 'ups-bug',
+      event: 'UserPromptSubmit',
+      fired: false,
+      matched_substring: undefined,
+    },
     // ptu-write: PTU-only memory → not judged in v1 → relevant=null, fp_rate=null
     { memory_name: 'ptu-write', event: 'PreToolUse', fired: true, matched_substring: 'TODO' },
     { memory_name: 'ptu-write', event: 'PreToolUse', fired: true, matched_substring: 'FIXME' },
@@ -464,8 +491,10 @@ test('@task:5 judge call is mocked and per-memory relevance is computed correctl
 
   const report = aggregateReport(tuples, judgments);
   assert.ok(report && typeof report === 'object', 'returns object');
-  const ups = report['ups-bug'] || (Array.isArray(report) && report.find((m) => m.name === 'ups-bug'));
-  const ptu = report['ptu-write'] || (Array.isArray(report) && report.find((m) => m.name === 'ptu-write'));
+  const ups =
+    report['ups-bug'] || (Array.isArray(report) && report.find((m) => m.name === 'ups-bug'));
+  const ptu =
+    report['ptu-write'] || (Array.isArray(report) && report.find((m) => m.name === 'ptu-write'));
   assert.ok(ups, 'ups-bug entry present');
   assert.ok(ptu, 'ptu-write entry present');
 
@@ -492,22 +521,27 @@ test('@task:5 heuristic tightening suggestion fires for fp_rate > 0.70 with shor
   const { suggestTightening, splitTopLevelAlternation } = require(REPLAY);
 
   // splitTopLevelAlternation splits on top-level `|` only.
-  assert.deepEqual(
-    splitTopLevelAlternation('push|fetch|deploy-production'),
-    ['push', 'fetch', 'deploy-production']
-  );
+  assert.deepEqual(splitTopLevelAlternation('push|fetch|deploy-production'), [
+    'push',
+    'fetch',
+    'deploy-production',
+  ]);
   // Top-level only — `|` inside `(...)` / `[...]` is not split.
-  assert.deepEqual(
-    splitTopLevelAlternation('(a|b)|cd|[e|f]'),
-    ['(a|b)', 'cd', '[e|f]']
-  );
+  assert.deepEqual(splitTopLevelAlternation('(a|b)|cd|[e|f]'), ['(a|b)', 'cd', '[e|f]']);
 
   // Memory with short alternation arms and high fp_rate → suggestion.
   const noisyMem = {
     name: 'noisy',
     triggerPrompt: 'push|fetch|deploy-production',
   };
-  const agg = { fires: 10, relevant: 2, irrelevant: 8, judge_failed: 0, fp_rate: 0.8, sample_matches: ['push', 'fetch'] };
+  const agg = {
+    fires: 10,
+    relevant: 2,
+    irrelevant: 8,
+    judge_failed: 0,
+    fp_rate: 0.8,
+    sample_matches: ['push', 'fetch'],
+  };
   const suggestion = suggestTightening(noisyMem, agg);
   assert.ok(suggestion, 'returns suggestion when fp_rate > 0.70 + short arms');
   assert.equal(suggestion.memory, 'noisy');
@@ -517,7 +551,14 @@ test('@task:5 heuristic tightening suggestion fires for fp_rate > 0.70 with shor
   assert.ok(!suggestion.candidates.includes('deploy-production'), 'does not flag long arm');
 
   // fp_rate <= 0.70 → no suggestion.
-  const okAgg = { fires: 10, relevant: 5, irrelevant: 5, judge_failed: 0, fp_rate: 0.5, sample_matches: [] };
+  const okAgg = {
+    fires: 10,
+    relevant: 5,
+    irrelevant: 5,
+    judge_failed: 0,
+    fp_rate: 0.5,
+    sample_matches: [],
+  };
   assert.equal(suggestTightening(noisyMem, okAgg), null, 'no suggestion when fp_rate <= 0.70');
 
   // High fp_rate but no short arms → no suggestion.
@@ -525,7 +566,14 @@ test('@task:5 heuristic tightening suggestion fires for fp_rate > 0.70 with shor
   assert.equal(suggestTightening(longMem, agg), null, 'no suggestion when all arms long');
 
   // PTU-only memory with fp_rate=null → no suggestion.
-  const nullAgg = { fires: 5, relevant: null, irrelevant: null, judge_failed: 0, fp_rate: null, sample_matches: [] };
+  const nullAgg = {
+    fires: 5,
+    relevant: null,
+    irrelevant: null,
+    judge_failed: 0,
+    fp_rate: null,
+    sample_matches: [],
+  };
   assert.equal(suggestTightening(noisyMem, nullAgg), null, 'no suggestion when fp_rate is null');
 });
 
@@ -566,9 +614,7 @@ test('@task:6 --json output shape includes memories, suggestions, and event tota
       sample_matches: ['TODO', 'FIXME'],
     },
   };
-  const suggestions = [
-    { memory: 'noisy', candidates: ['push', 'fetch'] },
-  ];
+  const suggestions = [{ memory: 'noisy', candidates: ['push', 'fetch'] }];
   const meta = {
     store: 'local',
     window: '7d',
@@ -594,7 +640,15 @@ test('@task:6 --json output shape includes memories, suggestions, and event tota
   assert.ok(Array.isArray(parsed.memories), 'memories is an array');
   assert.equal(parsed.memories.length, 2);
   for (const m of parsed.memories) {
-    for (const k of ['name', 'fires', 'relevant', 'irrelevant', 'judge_failed', 'fp_rate', 'sample_matches']) {
+    for (const k of [
+      'name',
+      'fires',
+      'relevant',
+      'irrelevant',
+      'judge_failed',
+      'fp_rate',
+      'sample_matches',
+    ]) {
       assert.ok(Object.prototype.hasOwnProperty.call(m, k), `memories[].${k} present`);
     }
   }
@@ -661,13 +715,21 @@ test('@task:6 renderReport cost footer absent under --no-judge (judgeCalls=0)', 
   const { renderReport } = require(REPLAY);
   const agg = {
     'ups-bug': {
-      fires: 5, relevant: null, irrelevant: null, judge_failed: 0,
-      fp_rate: null, sample_matches: ['auth bug'],
+      fires: 5,
+      relevant: null,
+      irrelevant: null,
+      judge_failed: 0,
+      fp_rate: null,
+      sample_matches: ['auth bug'],
     },
   };
   const meta = {
-    store: 'local', window: '7d',
-    events_total: 5, events_ups: 5, events_ptu: 0, judgeCalls: 0,
+    store: 'local',
+    window: '7d',
+    events_total: 5,
+    events_ups: 5,
+    events_ptu: 0,
+    judgeCalls: 0,
   };
   const out = renderReport(agg, [], meta);
   assert.ok(!/cost/i.test(out), 'no cost footer under --no-judge');
@@ -681,13 +743,21 @@ test('@task:6 renderJson does not leak ANTHROPIC_API_KEY value', () => {
   try {
     const agg = {
       'ups-bug': {
-        fires: 1, relevant: 1, irrelevant: 0, judge_failed: 0,
-        fp_rate: 0, sample_matches: ['x'],
+        fires: 1,
+        relevant: 1,
+        irrelevant: 0,
+        judge_failed: 0,
+        fp_rate: 0,
+        sample_matches: ['x'],
       },
     };
     const out = renderJson(agg, [], {
-      store: 'local', window: '7d',
-      events_total: 1, events_ups: 1, events_ptu: 0, judgeCalls: 1,
+      store: 'local',
+      window: '7d',
+      events_total: 1,
+      events_ups: 1,
+      events_ptu: 0,
+      judgeCalls: 1,
     });
     assert.ok(!out.includes(apiKey), 'api key value not in output');
   } finally {
@@ -699,11 +769,16 @@ test('@task:6 renderJson does not leak ANTHROPIC_API_KEY value', () => {
 test('@task:6 renderJson uses deterministic top-level key order', () => {
   const { renderJson } = require(REPLAY);
   const out = renderJson({}, [], {
-    store: 'local', window: '7d',
-    events_total: 0, events_ups: 0, events_ptu: 0, judgeCalls: 0,
+    store: 'local',
+    window: '7d',
+    events_total: 0,
+    events_ups: 0,
+    events_ptu: 0,
+    judgeCalls: 0,
   });
   // Match key order: memories, suggestions, events_total, events_ups, events_ptu.
-  const keyOrderRegex = /"memories"[\s\S]*"suggestions"[\s\S]*"events_total"[\s\S]*"events_ups"[\s\S]*"events_ptu"/;
+  const keyOrderRegex =
+    /"memories"[\s\S]*"suggestions"[\s\S]*"events_total"[\s\S]*"events_ups"[\s\S]*"events_ptu"/;
   assert.match(out, keyOrderRegex, 'keys appear in deterministic order');
 });
 
@@ -826,7 +901,10 @@ test('@task:7 sampleForCap evenly samples and flags extrapolated:true when items
   assert.equal(out.sampled.length, 10);
   // Evenly per Math.floor(i * fires / cap): indices 0,10,20,...,90.
   const expected = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90];
-  assert.deepEqual(out.sampled.map((x) => x.i), expected);
+  assert.deepEqual(
+    out.sampled.map((x) => x.i),
+    expected
+  );
 });
 
 test('@task:7 --max-judges cap is honored as a hard upper bound (P0 #6)', async () => {
@@ -845,7 +923,9 @@ test('@task:7 --max-judges cap is honored as a hard upper bound (P0 #6)', async 
     };
   };
   const items = Array.from({ length: 500 }, (_, i) => ({
-    memory: 'm', prompt: `p${i}`, matched: 'x',
+    memory: 'm',
+    prompt: `p${i}`,
+    matched: 'x',
   }));
   const out = await judgePipeline(items, {
     fetchImpl,
@@ -859,3 +939,173 @@ test('@task:7 --max-judges cap is honored as a hard upper bound (P0 #6)', async 
   assert.ok(out.results.length <= 50, 'judged at most cap items');
 });
 
+/**
+ * Task 8 RED — Wire `main()` end-to-end + no-transcripts + missing-key
+ * behavior (R4, R12, AC5, G3, G4, G10, spec §Security).
+ *
+ * @task:8
+ *
+ * These spawn-script tests bind to the Task 8 gate. They MUST fail before
+ * Task 8 GREEN — `main()` does not yet wire walker → replay → render, and
+ * `--transcripts-base` is not yet parsed.
+ */
+
+function mkTask8Fixture() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-replay-t8-'));
+  // Store dir with two memories: one UPS, one PTU.
+  const storeDir = path.join(tmp, 'store', '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(path.join(storeDir, '.synapsys.json'), '{}');
+  fs.writeFileSync(
+    path.join(storeDir, 'ups-bug.md'),
+    [
+      '---',
+      'name: ups-bug',
+      'description: ups memory',
+      'events: UserPromptSubmit',
+      'trigger_prompt: auth bug|login',
+      '---',
+      'body',
+      '',
+    ].join('\n')
+  );
+  fs.writeFileSync(
+    path.join(storeDir, 'ptu-write.md'),
+    [
+      '---',
+      'name: ptu-write',
+      'description: ptu memory',
+      'events: PreToolUse',
+      'trigger_pretool: Write',
+      'trigger_pretool_content: TODO|FIXME',
+      '---',
+      'body',
+      '',
+    ].join('\n')
+  );
+
+  // Transcripts base: one project hash dir with one jsonl containing a
+  // matching UPS entry and a matching assistant tool_use (Write w/ TODO).
+  const baseDir = path.join(tmp, 'projects');
+  const projDir = path.join(baseDir, '-tmp-proj');
+  fs.mkdirSync(projDir, { recursive: true });
+  const jsonl = path.join(projDir, 'session.jsonl');
+  fs.writeFileSync(
+    jsonl,
+    [
+      JSON.stringify({ type: 'user', message: { content: 'please fix the auth bug today' } }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'Write',
+              input: { content: 'add TODO before shipping' },
+            },
+          ],
+        },
+      }),
+      '',
+    ].join('\n')
+  );
+
+  return { tmp, storeDir: path.join(tmp, 'store'), baseDir };
+}
+
+test('@task:8 replay against a fixture transcript counts fires per memory using the existing matcher (P0 #1, #3)', () => {
+  const { tmp, storeDir, baseDir } = mkTask8Fixture();
+  const result = spawnSync(
+    process.execPath,
+    [
+      REPLAY,
+      '--since=7d',
+      '--no-judge',
+      '--json',
+      `--store=${path.join(storeDir, '.claude', 'synapsys')}`,
+      `--transcripts-base=${baseDir}`,
+    ],
+    { encoding: 'utf8', env: { ...process.env, ANTHROPIC_API_KEY: '' } }
+  );
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.events_total, 2, 'two synthesized events');
+  assert.equal(parsed.events_ups, 1);
+  assert.equal(parsed.events_ptu, 1);
+  const ups = parsed.memories.find((m) => m.name === 'ups-bug');
+  const ptu = parsed.memories.find((m) => m.name === 'ptu-write');
+  assert.ok(ups && ptu, 'both memories present in report');
+  assert.equal(ups.fires, 1, 'ups-bug fired once');
+  assert.equal(ptu.fires, 1, 'ptu-write fired once');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('@task:8 --no-judge mode emits a parseable report without any Anthropic API call (P0 #4, #9)', () => {
+  const { tmp, storeDir, baseDir } = mkTask8Fixture();
+  // Sentinel: if any fetch fires, the script would see ANTHROPIC_API_KEY and
+  // try to judge. --no-judge must short-circuit before any network call. We
+  // verify by setting an obviously-invalid key + asserting (a) exit 0 and
+  // (b) every memory's relevant is null (no judge ran).
+  const result = spawnSync(
+    process.execPath,
+    [
+      REPLAY,
+      '--since=7d',
+      '--no-judge',
+      '--json',
+      `--store=${path.join(storeDir, '.claude', 'synapsys')}`,
+      `--transcripts-base=${baseDir}`,
+    ],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, ANTHROPIC_API_KEY: 'sk-should-never-be-used' },
+    }
+  );
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
+  const parsed = JSON.parse(result.stdout);
+  assert.ok(Array.isArray(parsed.memories), 'memories array present');
+  assert.ok(parsed.memories.length >= 1, 'at least one memory in report');
+  for (const m of parsed.memories) {
+    assert.equal(m.relevant, null, `${m.name}.relevant=null under --no-judge`);
+    assert.equal(m.fp_rate, null, `${m.name}.fp_rate=null under --no-judge`);
+  }
+  // stderr must not contain any network/fetch error — proves no API call.
+  assert.ok(
+    !/api\.anthropic\.com|fetch failed|ECONNREFUSED/i.test(result.stderr),
+    `stderr clean of network noise; got: ${result.stderr}`
+  );
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('@task:8 no-transcripts window exits 0 with a friendly message (P0 #12)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-replay-t8-empty-'));
+  // Store with one memory so the load step succeeds; empty transcripts base.
+  const storeDir = path.join(tmp, 'store', '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(path.join(storeDir, '.synapsys.json'), '{}');
+  fs.writeFileSync(
+    path.join(storeDir, 'm.md'),
+    [
+      '---',
+      'name: m',
+      'description: x',
+      'events: UserPromptSubmit',
+      'trigger_prompt: anything',
+      '---',
+      'body',
+      '',
+    ].join('\n')
+  );
+  const emptyBase = path.join(tmp, 'projects');
+  fs.mkdirSync(emptyBase, { recursive: true });
+
+  const result = spawnSync(
+    process.execPath,
+    [REPLAY, '--since=7d', '--no-judge', `--store=${storeDir}`, `--transcripts-base=${emptyBase}`],
+    { encoding: 'utf8', env: { ...process.env, ANTHROPIC_API_KEY: '' } }
+  );
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
+  assert.match(result.stdout, /no transcripts in window/i, 'friendly stdout message');
+  assert.equal(result.stderr, '', `stderr must be empty; got: ${result.stderr}`);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -351,6 +351,7 @@ module.exports = {
   matchSession,
   matchStop,
   safeRegex,
+  splitTopLevelAlternation,
   extractPretoolContent,
   evaluatePretoolContent,
   evaluatePretoolContentNot,

--- a/plugins/synapsys/lib/replay-aggregate.js
+++ b/plugins/synapsys/lib/replay-aggregate.js
@@ -26,8 +26,19 @@ function splitTopLevelAlternation(triggerPrompt) {
   const arms = [];
   const depth = { paren: 0, bracket: 0 };
   let buf = '';
+  let escaped = false;
   for (let i = 0; i < triggerPrompt.length; i++) {
     const ch = triggerPrompt[i];
+    if (escaped) {
+      buf += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      buf += ch;
+      escaped = true;
+      continue;
+    }
     updateDepth(depth, ch);
     if (ch === '|' && depth.paren === 0 && depth.bracket === 0) {
       arms.push(buf);

--- a/plugins/synapsys/lib/replay-aggregate.js
+++ b/plugins/synapsys/lib/replay-aggregate.js
@@ -89,7 +89,10 @@ function applyJudgmentToEntry(entry, j) {
     entry.irrelevant = j.irrelevant || 0;
     entry.judge_failed = j.judge_failed || 0;
     entry.fp_rate = fpRate(entry.relevant, entry.irrelevant);
-  } else if (!entry._hasUps && entry._hasPtu) {
+  } else {
+    // PTU-only memories, and UPS memories that received no judgment
+    // (e.g. excluded by --max-judges sampling), are reported as
+    // "not judged" rather than "zero relevant".
     entry.relevant = null;
     entry.irrelevant = null;
     entry.fp_rate = null;

--- a/plugins/synapsys/lib/replay-aggregate.js
+++ b/plugins/synapsys/lib/replay-aggregate.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * synapsys-replay — per-memory aggregation + tightening heuristic. Extracted
+ * to keep the CLI entrypoint under the 400-line quality cap.
+ *
+ * Public surface (re-exported by scripts/synapsys-replay.js):
+ *   - splitTopLevelAlternation(triggerPrompt)
+ *   - fpRate(relevant, irrelevant)
+ *   - aggregateReport(tuples, judgments)
+ *   - suggestTightening(memory, agg)
+ */
+
+function updateDepth(depth, ch) {
+  if (ch === '(') depth.paren++;
+  else if (ch === ')') depth.paren = Math.max(0, depth.paren - 1);
+  else if (ch === '[') depth.bracket++;
+  else if (ch === ']') depth.bracket = Math.max(0, depth.bracket - 1);
+}
+
+/**
+ * Split `trigger_prompt` on top-level `|` only (outside `(...)` / `[...]`).
+ */
+function splitTopLevelAlternation(triggerPrompt) {
+  if (typeof triggerPrompt !== 'string' || triggerPrompt.length === 0) return [];
+  const arms = [];
+  const depth = { paren: 0, bracket: 0 };
+  let buf = '';
+  for (let i = 0; i < triggerPrompt.length; i++) {
+    const ch = triggerPrompt[i];
+    updateDepth(depth, ch);
+    if (ch === '|' && depth.paren === 0 && depth.bracket === 0) {
+      arms.push(buf);
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  arms.push(buf);
+  return arms;
+}
+
+/**
+ * fp_rate = 1 - relevant / (relevant + irrelevant). judge_failed excluded.
+ */
+function fpRate(relevant, irrelevant) {
+  const denom = relevant + irrelevant;
+  if (denom <= 0) return null;
+  return 1 - relevant / denom;
+}
+
+function newReportEntry() {
+  return {
+    fires: 0,
+    relevant: 0,
+    irrelevant: 0,
+    judge_failed: 0,
+    fp_rate: null,
+    sample_matches: [],
+    _hasUps: false,
+    _hasPtu: false,
+  };
+}
+
+function recordFire(entry, bucket, t) {
+  entry.fires += 1;
+  bucket.events.add(t.event);
+  if (t.event === 'UserPromptSubmit') entry._hasUps = true;
+  if (t.event === 'PreToolUse') entry._hasPtu = true;
+  if (t.matched_substring) {
+    bucket.subs.set(t.matched_substring, (bucket.subs.get(t.matched_substring) || 0) + 1);
+  }
+}
+
+function applyJudgmentToEntry(entry, j) {
+  if (j && entry._hasUps) {
+    entry.relevant = j.relevant || 0;
+    entry.irrelevant = j.irrelevant || 0;
+    entry.judge_failed = j.judge_failed || 0;
+    entry.fp_rate = fpRate(entry.relevant, entry.irrelevant);
+  } else if (!entry._hasUps && entry._hasPtu) {
+    entry.relevant = null;
+    entry.irrelevant = null;
+    entry.fp_rate = null;
+  }
+}
+
+function topSampleMatches(subs) {
+  return Array.from(subs.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 3)
+    .map(([s]) => s);
+}
+
+/**
+ * Aggregate per-memory metrics from replay tuples + judge results.
+ * PTU-only memories report `relevant=null` / `fp_rate=null` (spec §Decision).
+ * `sample_matches` is the top-3 most-frequent distinct matched substrings.
+ */
+function aggregateReport(tuples, judgments) {
+  const report = {};
+  const fireBuckets = {};
+  for (const t of tuples) {
+    if (!report[t.memory_name]) {
+      report[t.memory_name] = newReportEntry();
+      fireBuckets[t.memory_name] = { events: new Set(), subs: new Map() };
+    }
+    if (t.fired) recordFire(report[t.memory_name], fireBuckets[t.memory_name], t);
+  }
+  for (const name of Object.keys(report)) {
+    const entry = report[name];
+    applyJudgmentToEntry(entry, judgments && judgments[name]);
+    entry.sample_matches = topSampleMatches(fireBuckets[name].subs);
+    delete entry._hasUps;
+    delete entry._hasPtu;
+  }
+  return report;
+}
+
+/**
+ * Heuristic R8 — emit advisory when `fp_rate > 0.70` AND `trigger_prompt`
+ * contains short (<=5 chars) single-word alternation arms.
+ */
+function suggestTightening(memory, agg) {
+  if (!memory || !agg) return null;
+  if (agg.fp_rate === null || agg.fp_rate === undefined) return null;
+  if (!(agg.fp_rate > 0.7)) return null;
+  const arms = splitTopLevelAlternation(memory.triggerPrompt || '');
+  const candidates = arms.filter((a) => {
+    const trimmed = a.trim();
+    return trimmed.length > 0 && trimmed.length <= 5 && /^[A-Za-z0-9_-]+$/.test(trimmed);
+  });
+  if (candidates.length === 0) return null;
+  return { memory: memory.name, candidates };
+}
+
+module.exports = {
+  splitTopLevelAlternation,
+  fpRate,
+  aggregateReport,
+  suggestTightening,
+};

--- a/plugins/synapsys/lib/replay-aggregate.js
+++ b/plugins/synapsys/lib/replay-aggregate.js
@@ -97,14 +97,41 @@ function aggregateReport(tuples, judgments) {
 }
 
 /**
+ * Peel a single outermost `\b?(...)\b?` wrapper so heuristic-detection works on
+ * realistic triggers like `\b(push|fetch|deploy)\b`. The matcher itself does
+ * NOT need this peeling — its `splitTopLevelAlternation` runs against the raw
+ * regex — but the tightening heuristic only sees short bare words.
+ */
+function peelGroupWrapper(source) {
+  const m = /^\\b?\((.*)\)\\b?$/s.exec(source);
+  if (!m) return source;
+  const inner = m[1];
+  let depth = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (ch === '\\') {
+      i++;
+      continue;
+    }
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth < 0) return source;
+    }
+  }
+  return depth === 0 ? inner : source;
+}
+
+/**
  * Heuristic R8 — emit advisory when `fp_rate > 0.70` AND `trigger_prompt`
- * contains short (<=5 chars) single-word alternation arms.
+ * contains short (<=5 chars) single-word alternation arms. Peels a single
+ * `\b(...)\b` wrapper before splitting so wrapped triggers are inspected.
  */
 function suggestTightening(memory, agg) {
   if (!memory || !agg) return null;
   if (agg.fp_rate === null || agg.fp_rate === undefined) return null;
   if (!(agg.fp_rate > 0.7)) return null;
-  const arms = splitTopLevelAlternation(memory.triggerPrompt || '');
+  const arms = splitTopLevelAlternation(peelGroupWrapper(memory.triggerPrompt || ''));
   const candidates = arms.filter((a) => {
     const trimmed = a.trim();
     return trimmed.length > 0 && trimmed.length <= 5 && /^[A-Za-z0-9_-]+$/.test(trimmed);

--- a/plugins/synapsys/lib/replay-aggregate.js
+++ b/plugins/synapsys/lib/replay-aggregate.js
@@ -11,44 +11,10 @@
  *   - suggestTightening(memory, agg)
  */
 
-/**
- * Split `trigger_prompt` on top-level `|` (outside `(...)` and outside
- * backslash escapes). Semantics match matcher.js:splitTopLevelAlternation
- * exactly — the tightening heuristic must analyze the same arms the runtime
- * matcher actually evaluates. Bracket characters `[` `]` are NOT depth-
- * tracked, mirroring the matcher (which treats them as plain literals in
- * the alternation grammar).
- */
-function splitTopLevelAlternation(triggerPrompt) {
-  if (typeof triggerPrompt !== 'string' || triggerPrompt.length === 0) return [];
-  const arms = [];
-  let depth = 0;
-  let buf = '';
-  let escaped = false;
-  for (let i = 0; i < triggerPrompt.length; i++) {
-    const ch = triggerPrompt[i];
-    if (escaped) {
-      buf += ch;
-      escaped = false;
-      continue;
-    }
-    if (ch === '\\') {
-      buf += ch;
-      escaped = true;
-      continue;
-    }
-    if (ch === '(') depth++;
-    else if (ch === ')') depth--;
-    if (ch === '|' && depth === 0) {
-      arms.push(buf);
-      buf = '';
-      continue;
-    }
-    buf += ch;
-  }
-  arms.push(buf);
-  return arms;
-}
+// Re-export the runtime matcher's splitTopLevelAlternation so the tightening
+// heuristic analyzes the same arms the matcher actually splits at runtime.
+// Single source of truth — see plugins/synapsys/lib/matcher.js.
+const { splitTopLevelAlternation } = require('./matcher');
 
 /**
  * fp_rate = 1 - relevant / (relevant + irrelevant). judge_failed excluded.

--- a/plugins/synapsys/lib/replay-aggregate.js
+++ b/plugins/synapsys/lib/replay-aggregate.js
@@ -11,20 +11,18 @@
  *   - suggestTightening(memory, agg)
  */
 
-function updateDepth(depth, ch) {
-  if (ch === '(') depth.paren++;
-  else if (ch === ')') depth.paren = Math.max(0, depth.paren - 1);
-  else if (ch === '[') depth.bracket++;
-  else if (ch === ']') depth.bracket = Math.max(0, depth.bracket - 1);
-}
-
 /**
- * Split `trigger_prompt` on top-level `|` only (outside `(...)` / `[...]`).
+ * Split `trigger_prompt` on top-level `|` (outside `(...)` and outside
+ * backslash escapes). Semantics match matcher.js:splitTopLevelAlternation
+ * exactly — the tightening heuristic must analyze the same arms the runtime
+ * matcher actually evaluates. Bracket characters `[` `]` are NOT depth-
+ * tracked, mirroring the matcher (which treats them as plain literals in
+ * the alternation grammar).
  */
 function splitTopLevelAlternation(triggerPrompt) {
   if (typeof triggerPrompt !== 'string' || triggerPrompt.length === 0) return [];
   const arms = [];
-  const depth = { paren: 0, bracket: 0 };
+  let depth = 0;
   let buf = '';
   let escaped = false;
   for (let i = 0; i < triggerPrompt.length; i++) {
@@ -39,8 +37,9 @@ function splitTopLevelAlternation(triggerPrompt) {
       escaped = true;
       continue;
     }
-    updateDepth(depth, ch);
-    if (ch === '|' && depth.paren === 0 && depth.bracket === 0) {
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    if (ch === '|' && depth === 0) {
       arms.push(buf);
       buf = '';
       continue;

--- a/plugins/synapsys/lib/replay-events.js
+++ b/plugins/synapsys/lib/replay-events.js
@@ -17,18 +17,50 @@ const os = require('node:os');
 const path = require('node:path');
 const matcher = require('./matcher');
 
-function extractUserEvents(message) {
-  if (!message || message.content === undefined || message.content === null) return [];
-  const content = message.content;
-  if (typeof content === 'string') {
-    return [{ event: 'UserPromptSubmit', prompt: content }];
-  }
-  if (!Array.isArray(content)) return [];
-  const prompt = content
+// Synthetic user entries emitted by Claude Code (slash-command stdouts,
+// system-reminder wrappers, hook output, agent inbox notifications) should not
+// be treated as real UserPromptSubmit events — they pollute fire counts and
+// FP rates with text the user never typed.
+const SYNTHETIC_USER_PREFIXES = [
+  '<command-name>',
+  '<command-message>',
+  '<command-args>',
+  '<local-command-stdout>',
+  '<system-reminder>',
+  '<task-notification>',
+  '<bash-stdout>',
+  '<bash-stderr>',
+];
+
+function isSyntheticUserText(text) {
+  if (typeof text !== 'string') return false;
+  const head = text.trimStart();
+  return SYNTHETIC_USER_PREFIXES.some((p) => head.startsWith(p));
+}
+
+function isSyntheticParsedLine(parsedLine) {
+  return !!(parsedLine && (parsedLine.isMeta === true || parsedLine.toolUseResult));
+}
+
+function joinTextBlocks(content) {
+  return content
     .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
     .map((b) => b.text)
     .join('');
-  return prompt.length === 0 ? [] : [{ event: 'UserPromptSubmit', prompt }];
+}
+
+function extractUserEvents(message, parsedLine) {
+  if (isSyntheticParsedLine(parsedLine)) return [];
+  const content = message ? message.content : undefined;
+  if (content == null) return [];
+  if (typeof content === 'string') {
+    return isSyntheticUserText(content) ? [] : [{ event: 'UserPromptSubmit', prompt: content }];
+  }
+  if (!Array.isArray(content)) return [];
+  if (content.some((b) => b && b.type === 'tool_result')) return [];
+  const prompt = joinTextBlocks(content);
+  if (prompt.length === 0 || isSyntheticUserText(prompt)) return [];
+  return [{ event: 'UserPromptSubmit', prompt }];
 }
 
 function extractAssistantEvents(message) {
@@ -51,7 +83,7 @@ function extractAssistantEvents(message) {
 function extractEvents(parsedLine) {
   if (!parsedLine || typeof parsedLine !== 'object') return [];
   const { type, message } = parsedLine;
-  if (type === 'user') return extractUserEvents(message);
+  if (type === 'user') return extractUserEvents(message, parsedLine);
   if (type === 'assistant') return extractAssistantEvents(message);
   return [];
 }

--- a/plugins/synapsys/lib/replay-events.js
+++ b/plugins/synapsys/lib/replay-events.js
@@ -1,0 +1,196 @@
+'use strict';
+
+/**
+ * synapsys-replay — transcript event extraction + walker (extracted to keep
+ * the CLI entrypoint under the 400-line quality cap).
+ *
+ * Public surface (re-exported by scripts/synapsys-replay.js):
+ *   - extractEvents(parsedLine)
+ *   - parseSince(spec)
+ *   - walkTranscripts({since, project, baseDir})
+ *   - iterLines(filePath)
+ *   - replayEvent(memories, event)
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const matcher = require('./matcher');
+
+function extractUserEvents(message) {
+  if (!message || message.content === undefined || message.content === null) return [];
+  const content = message.content;
+  if (typeof content === 'string') {
+    return [{ event: 'UserPromptSubmit', prompt: content }];
+  }
+  if (!Array.isArray(content)) return [];
+  const prompt = content
+    .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text)
+    .join('');
+  return prompt.length === 0 ? [] : [{ event: 'UserPromptSubmit', prompt }];
+}
+
+function extractAssistantEvents(message) {
+  if (!message || !Array.isArray(message.content)) return [];
+  return message.content
+    .filter((b) => b && b.type === 'tool_use' && typeof b.name === 'string')
+    .map((b) => ({
+      event: 'PreToolUse',
+      tool: b.name,
+      tool_input: b.input,
+    }));
+}
+
+/**
+ * Pure transcript → synthetic-event mapper (Task 2, R2, G1+G2).
+ *   - `type=user`      → `{event:'UserPromptSubmit', prompt}`
+ *   - `type=assistant` → one `{event:'PreToolUse', tool, tool_input}` per tool_use block
+ *   - else → `[]`
+ */
+function extractEvents(parsedLine) {
+  if (!parsedLine || typeof parsedLine !== 'object') return [];
+  const { type, message } = parsedLine;
+  if (type === 'user') return extractUserEvents(message);
+  if (type === 'assistant') return extractAssistantEvents(message);
+  return [];
+}
+
+/**
+ * Convert a `--since=Nd` window string into milliseconds. Throws on invalid
+ * format; main()/die() handles user-facing error reporting per spec §CLI.
+ */
+function parseSince(spec) {
+  if (typeof spec !== 'string' || !/^\d+d$/.test(spec)) {
+    throw new Error(`invalid --since=${spec} (expected format like 7d, 14d)`);
+  }
+  const days = Number(spec.slice(0, -1));
+  return days * 24 * 60 * 60 * 1000;
+}
+
+function resolveProjectDirs(root, project) {
+  if (project) {
+    const dir = path.join(root, project);
+    return fs.existsSync(dir) ? [dir] : [];
+  }
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => path.join(root, d.name));
+}
+
+function safeReadDir(dir) {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+}
+
+function safeMtimeMs(full) {
+  try {
+    return fs.statSync(full).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function collectRecentJsonl(projDir, cutoff) {
+  const entries = safeReadDir(projDir);
+  if (!entries) return [];
+  const out = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
+    const full = path.join(projDir, entry.name);
+    const mtimeMs = safeMtimeMs(full);
+    if (mtimeMs !== null && mtimeMs >= cutoff) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Walk `*.jsonl` transcripts under `baseDir` (default `~/.claude/projects/`)
+ * whose mtime falls within the `--since` window.
+ */
+function walkTranscripts({ since, project, baseDir } = {}) {
+  const root = baseDir || path.join(os.homedir(), '.claude/projects');
+  if (!fs.existsSync(root)) return [];
+  const cutoff = Date.now() - parseSince(since || '7d');
+  const projectDirs = resolveProjectDirs(root, project);
+  const out = [];
+  for (const projDir of projectDirs) {
+    out.push(...collectRecentJsonl(projDir, cutoff));
+  }
+  return out;
+}
+
+/**
+ * Stream-parse a JSONL transcript file. Yields one parsed object per
+ * non-empty line; malformed lines emit a single stderr warning and are
+ * skipped (R1).
+ */
+function* iterLines(filePath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    process.stderr.write(`synapsys-replay: cannot read ${filePath}: ${err.message}\n`);
+    return;
+  }
+  const lines = raw.split('\n');
+  for (const line of lines) {
+    if (line.length === 0) continue;
+    try {
+      yield JSON.parse(line);
+    } catch (err) {
+      process.stderr.write(
+        `synapsys-replay: malformed JSONL line in ${filePath} (skipped): ${err.message}\n`
+      );
+    }
+  }
+}
+
+function dispatchMatch(memory, event) {
+  if (event.event === 'UserPromptSubmit') {
+    return matcher.matchPrompt(memory, event.prompt || '');
+  }
+  if (event.event === 'PreToolUse') {
+    return matcher.matchPreTool(memory, {
+      tool_name: event.tool,
+      tool_input: event.tool_input,
+    });
+  }
+  return { fired: false, reason: 'events-exclude' };
+}
+
+/**
+ * Replay a synthetic event against every memory and return one tuple per
+ * memory: `{memory_name, event, fired, matched_substring}`. Task 4 (R3, G3).
+ */
+function replayEvent(memories, event) {
+  const out = [];
+  for (const memory of memories) {
+    const result = dispatchMatch(memory, event);
+    const matched = result && result.matched ? result.matched : undefined;
+    const matched_substring = matched
+      ? matched.prompt_substring !== undefined
+        ? matched.prompt_substring
+        : matched.content_substring
+      : undefined;
+    out.push({
+      memory_name: memory.name,
+      event: event.event,
+      fired: Boolean(result && result.fired),
+      matched_substring,
+    });
+  }
+  return out;
+}
+
+module.exports = {
+  extractEvents,
+  parseSince,
+  walkTranscripts,
+  iterLines,
+  replayEvent,
+};

--- a/plugins/synapsys/lib/replay-events.js
+++ b/plugins/synapsys/lib/replay-events.js
@@ -100,9 +100,21 @@ function parseSince(spec) {
   return days * 24 * 60 * 60 * 1000;
 }
 
-function resolveProjectDirs(root, project) {
+/**
+ * Claude Code stores per-project transcripts under `~/.claude/projects/<hash>`
+ * where `<hash>` is the project's absolute path with `/` replaced by `-`.
+ */
+function cwdToProjectHash(cwd) {
+  return cwd.split(path.sep).join('-');
+}
+
+function resolveProjectDirs(root, project, { cwd, allProjects } = {}) {
   if (project) {
     const dir = path.join(root, project);
+    return fs.existsSync(dir) ? [dir] : [];
+  }
+  if (!allProjects && cwd) {
+    const dir = path.join(root, cwdToProjectHash(cwd));
     return fs.existsSync(dir) ? [dir] : [];
   }
   return fs
@@ -144,11 +156,11 @@ function collectRecentJsonl(projDir, cutoff) {
  * Walk `*.jsonl` transcripts under `baseDir` (default `~/.claude/projects/`)
  * whose mtime falls within the `--since` window.
  */
-function walkTranscripts({ since, project, baseDir } = {}) {
+function walkTranscripts({ since, project, baseDir, cwd, allProjects } = {}) {
   const root = baseDir || path.join(os.homedir(), '.claude/projects');
   if (!fs.existsSync(root)) return [];
   const cutoff = Date.now() - parseSince(since || '7d');
-  const projectDirs = resolveProjectDirs(root, project);
+  const projectDirs = resolveProjectDirs(root, project, { cwd, allProjects });
   const out = [];
   for (const projDir of projectDirs) {
     out.push(...collectRecentJsonl(projDir, cutoff));

--- a/plugins/synapsys/lib/replay-judge.js
+++ b/plugins/synapsys/lib/replay-judge.js
@@ -18,7 +18,17 @@ const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
 const JUDGE_BATCH_SIZE = 10; // R18
 const DEFAULT_JUDGE_MODEL = 'claude-haiku-4-5';
 const MEMORY_BODY_PREVIEW_CHARS = 200;
+const PROMPT_PREVIEW_CHARS = 600;
+const MATCHED_PREVIEW_CHARS = 200;
 const REPLY_LINE_REGEX = /^\s*(\d+)\s*:\s*(yes|no)\b/i;
+
+function clipText(s, max) {
+  if (typeof s !== 'string') return s;
+  if (s.length <= max) return s;
+  const head = Math.floor(max / 2);
+  const tail = max - head;
+  return `${s.slice(0, head)}…${s.slice(s.length - tail)}`;
+}
 
 const JUDGE_SYSTEM_PROMPT =
   'You are a relevance judge for synapsys memories. For each numbered item, decide whether the memory was ACTUALLY RELEVANT to the user prompt shown. Each item gives you the memory name, the first part of its content body, the user prompt, and the substring that matched. Reply with one line per item in the exact form "N: yes" or "N: no" (lowercase, no extra text). Answer "yes" only when the memory content would have been useful context for that prompt; otherwise "no". Do not add explanations or any other output.';
@@ -27,7 +37,9 @@ function buildJudgeBody(items, model) {
   const numbered = items
     .map((it, i) => {
       const body = (it.body || '').slice(0, MEMORY_BODY_PREVIEW_CHARS);
-      return `${i + 1}) memory titled ${it.memory} with content ${JSON.stringify(body)} prompt=${JSON.stringify(it.prompt)} matched=${JSON.stringify(it.matched)}`;
+      const prompt = clipText(it.prompt || '', PROMPT_PREVIEW_CHARS);
+      const matched = clipText(it.matched || '', MATCHED_PREVIEW_CHARS);
+      return `${i + 1}) memory titled ${it.memory} with content ${JSON.stringify(body)} prompt=${JSON.stringify(prompt)} matched=${JSON.stringify(matched)}`;
     })
     .join('\n');
   return JSON.stringify({

--- a/plugins/synapsys/lib/replay-judge.js
+++ b/plugins/synapsys/lib/replay-judge.js
@@ -1,0 +1,167 @@
+'use strict';
+
+/**
+ * synapsys-replay — judge HTTP integration (extracted from the CLI script to
+ * keep the main entrypoint under the 400-line quality cap).
+ *
+ * Public surface (re-exported by scripts/synapsys-replay.js):
+ *   - judgeBatch(items, {fetchImpl, apiKey, model})
+ *   - sampleForCap(items, cap)
+ *   - judgePipeline(items, {fetchImpl, apiKey, model, maxJudges})
+ *   - JUDGE_BATCH_SIZE
+ *
+ * Never throws on network/HTTP errors; never leaks `apiKey` into thrown
+ * error messages.
+ */
+
+const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
+const JUDGE_BATCH_SIZE = 10; // R18
+const REPLY_LINE_REGEX = /^\s*(\d+)\s*:\s*(yes|no)\b/i;
+
+const JUDGE_SYSTEM_PROMPT =
+  'You are a relevance judge for synapsys memories. For each numbered item, decide whether the memory was ACTUALLY RELEVANT to the user prompt shown. Reply with one line per item in the exact form "N: yes" or "N: no" (lowercase, no extra text). Answer "yes" only when the memory would have been useful context for that prompt; otherwise "no". Do not add explanations or any other output.';
+
+function buildJudgeBody(items, model) {
+  const numbered = items
+    .map(
+      (it, i) =>
+        `${i + 1}) memory=${it.memory} prompt=${JSON.stringify(it.prompt)} matched=${JSON.stringify(it.matched)}`
+    )
+    .join('\n');
+  return JSON.stringify({
+    model,
+    max_tokens: 256,
+    system: JUDGE_SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: numbered }],
+  });
+}
+
+function failAll(items, error) {
+  return items.map(() => ({ judge_failed: true, error }));
+}
+
+function extractJudgeText(payload) {
+  if (
+    payload &&
+    Array.isArray(payload.content) &&
+    payload.content[0] &&
+    typeof payload.content[0].text === 'string'
+  ) {
+    return payload.content[0].text;
+  }
+  return '';
+}
+
+function parseVerdicts(text) {
+  const verdicts = new Map();
+  for (const line of text.split(/\r?\n/)) {
+    const m = REPLY_LINE_REGEX.exec(line);
+    if (m) verdicts.set(Number(m[1]), m[2].toLowerCase() === 'yes');
+  }
+  return verdicts;
+}
+
+async function postJudgeRequest(doFetch, apiKey, body) {
+  return doFetch(ANTHROPIC_MESSAGES_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body,
+  });
+}
+
+function pickFetchImpl(fetchImpl) {
+  if (fetchImpl) return fetchImpl;
+  return typeof fetch === 'function' ? fetch : null;
+}
+
+function safeErrorMessage(err) {
+  return String(err && err.message ? err.message : err);
+}
+
+function verdictsToResults(items, verdicts) {
+  return items.map((_, i) => {
+    const v = verdicts.get(i + 1);
+    if (v === undefined) return { judge_failed: true, error: 'missing reply line' };
+    return { relevant: v };
+  });
+}
+
+async function fetchJudgeResponse(doFetch, apiKey, items, model) {
+  try {
+    const resp = await postJudgeRequest(doFetch, apiKey, buildJudgeBody(items, model));
+    return { resp };
+  } catch (err) {
+    return { error: safeErrorMessage(err) };
+  }
+}
+
+async function parseJudgeResponse(resp) {
+  if (!resp || !resp.ok) {
+    return { error: `http ${resp ? resp.status : 'no-response'}` };
+  }
+  try {
+    return { payload: await resp.json() };
+  } catch {
+    return { error: 'invalid json' };
+  }
+}
+
+async function judgeBatch(items, { fetchImpl, apiKey, model } = {}) {
+  const doFetch = pickFetchImpl(fetchImpl);
+  if (!doFetch) return failAll(items, 'no fetch impl');
+
+  const fetched = await fetchJudgeResponse(doFetch, apiKey, items, model);
+  if (fetched.error) return failAll(items, fetched.error);
+
+  const parsed = await parseJudgeResponse(fetched.resp);
+  if (parsed.error) return failAll(items, parsed.error);
+
+  const verdicts = parseVerdicts(extractJudgeText(parsed.payload));
+  return verdictsToResults(items, verdicts);
+}
+
+/**
+ * `sampleForCap(items, cap)` — when `items.length > cap`, return `cap`
+ * items evenly sampled per `Math.floor(i * fires / cap)` and flag
+ * `extrapolated:true`. Otherwise return all items unchanged.
+ */
+function sampleForCap(items, cap) {
+  const fires = items.length;
+  if (fires <= cap) return { sampled: items.slice(), extrapolated: false };
+  const sampled = [];
+  for (let i = 0; i < cap; i++) {
+    sampled.push(items[Math.floor((i * fires) / cap)]);
+  }
+  return { sampled, extrapolated: true };
+}
+
+/**
+ * `judgePipeline(items, {fetchImpl, apiKey, model, maxJudges})` —
+ * applies `sampleForCap` then dispatches `judgeBatch` calls in batches
+ * of `JUDGE_BATCH_SIZE` (R18). Honors `--max-judges` as a hard upper
+ * bound on judge API calls (G8 / P0 #6).
+ */
+async function judgePipeline(items, { fetchImpl, apiKey, model, maxJudges } = {}) {
+  const { sampled, extrapolated } = sampleForCap(items, maxJudges);
+  const results = [];
+  for (let i = 0; i < sampled.length; i += JUDGE_BATCH_SIZE) {
+    const batch = sampled.slice(i, i + JUDGE_BATCH_SIZE);
+    // eslint-disable-next-line no-await-in-loop
+    const batchResults = await judgeBatch(batch, { fetchImpl, apiKey, model });
+    for (let j = 0; j < batch.length; j++) {
+      results.push({ ...batch[j], ...batchResults[j] });
+    }
+  }
+  return { results, extrapolated };
+}
+
+module.exports = {
+  judgeBatch,
+  sampleForCap,
+  judgePipeline,
+  JUDGE_BATCH_SIZE,
+};

--- a/plugins/synapsys/lib/replay-judge.js
+++ b/plugins/synapsys/lib/replay-judge.js
@@ -16,20 +16,22 @@
 
 const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
 const JUDGE_BATCH_SIZE = 10; // R18
+const DEFAULT_JUDGE_MODEL = 'claude-haiku-4-5';
+const MEMORY_BODY_PREVIEW_CHARS = 200;
 const REPLY_LINE_REGEX = /^\s*(\d+)\s*:\s*(yes|no)\b/i;
 
 const JUDGE_SYSTEM_PROMPT =
-  'You are a relevance judge for synapsys memories. For each numbered item, decide whether the memory was ACTUALLY RELEVANT to the user prompt shown. Reply with one line per item in the exact form "N: yes" or "N: no" (lowercase, no extra text). Answer "yes" only when the memory would have been useful context for that prompt; otherwise "no". Do not add explanations or any other output.';
+  'You are a relevance judge for synapsys memories. For each numbered item, decide whether the memory was ACTUALLY RELEVANT to the user prompt shown. Each item gives you the memory name, the first part of its content body, the user prompt, and the substring that matched. Reply with one line per item in the exact form "N: yes" or "N: no" (lowercase, no extra text). Answer "yes" only when the memory content would have been useful context for that prompt; otherwise "no". Do not add explanations or any other output.';
 
 function buildJudgeBody(items, model) {
   const numbered = items
-    .map(
-      (it, i) =>
-        `${i + 1}) memory=${it.memory} prompt=${JSON.stringify(it.prompt)} matched=${JSON.stringify(it.matched)}`
-    )
+    .map((it, i) => {
+      const body = (it.body || '').slice(0, MEMORY_BODY_PREVIEW_CHARS);
+      return `${i + 1}) memory titled ${it.memory} with content ${JSON.stringify(body)} prompt=${JSON.stringify(it.prompt)} matched=${JSON.stringify(it.matched)}`;
+    })
     .join('\n');
   return JSON.stringify({
-    model,
+    model: model || DEFAULT_JUDGE_MODEL,
     max_tokens: 256,
     system: JUDGE_SYSTEM_PROMPT,
     messages: [{ role: 'user', content: numbered }],

--- a/plugins/synapsys/lib/replay-report.js
+++ b/plugins/synapsys/lib/replay-report.js
@@ -51,30 +51,45 @@ function sortMemoryNames(agg) {
   return Object.keys(agg).sort((a, b) => compareMemories(agg, a, b));
 }
 
+function memoryToJson(name, m) {
+  return {
+    name,
+    fires: m.fires,
+    relevant: m.relevant,
+    irrelevant: m.irrelevant,
+    judge_failed: m.judge_failed,
+    fp_rate: m.fp_rate,
+    sample_matches: m.sample_matches,
+  };
+}
+
+function pickString(meta, key) {
+  return meta && typeof meta[key] === 'string' ? meta[key] : '';
+}
+
+function pickNumber(meta, key) {
+  return meta && typeof meta[key] === 'number' ? meta[key] : 0;
+}
+
+function buildJsonMeta(meta) {
+  return {
+    store: pickString(meta, 'store'),
+    window: pickString(meta, 'window'),
+    events_total: pickNumber(meta, 'events_total'),
+    events_ups: pickNumber(meta, 'events_ups'),
+    events_ptu: pickNumber(meta, 'events_ptu'),
+    judge_calls: pickNumber(meta, 'judgeCalls'),
+    items_judged: pickNumber(meta, 'itemsJudged'),
+    extrapolated: !!(meta && meta.extrapolated),
+  };
+}
+
 function renderJson(agg, suggestions, meta) {
-  const memories = sortMemoryNames(agg).map((name) => {
-    const m = agg[name];
-    return {
-      name,
-      fires: m.fires,
-      relevant: m.relevant,
-      irrelevant: m.irrelevant,
-      judge_failed: m.judge_failed,
-      fp_rate: m.fp_rate,
-      sample_matches: m.sample_matches,
-    };
-  });
+  const memories = sortMemoryNames(agg).map((name) => memoryToJson(name, agg[name]));
   const payload = {
     memories,
     suggestions: Array.isArray(suggestions) ? suggestions : [],
-    store: meta && typeof meta.store === 'string' ? meta.store : '',
-    window: meta && typeof meta.window === 'string' ? meta.window : '',
-    events_total: meta && typeof meta.events_total === 'number' ? meta.events_total : 0,
-    events_ups: meta && typeof meta.events_ups === 'number' ? meta.events_ups : 0,
-    events_ptu: meta && typeof meta.events_ptu === 'number' ? meta.events_ptu : 0,
-    judge_calls: meta && typeof meta.judgeCalls === 'number' ? meta.judgeCalls : 0,
-    items_judged: meta && typeof meta.itemsJudged === 'number' ? meta.itemsJudged : 0,
-    extrapolated: !!(meta && meta.extrapolated),
+    ...buildJsonMeta(meta),
   };
   return JSON.stringify(payload, null, 2);
 }

--- a/plugins/synapsys/lib/replay-report.js
+++ b/plugins/synapsys/lib/replay-report.js
@@ -67,9 +67,13 @@ function renderJson(agg, suggestions, meta) {
   const payload = {
     memories,
     suggestions: Array.isArray(suggestions) ? suggestions : [],
+    store: meta && typeof meta.store === 'string' ? meta.store : '',
+    window: meta && typeof meta.window === 'string' ? meta.window : '',
     events_total: meta && typeof meta.events_total === 'number' ? meta.events_total : 0,
     events_ups: meta && typeof meta.events_ups === 'number' ? meta.events_ups : 0,
     events_ptu: meta && typeof meta.events_ptu === 'number' ? meta.events_ptu : 0,
+    judge_calls: meta && typeof meta.judgeCalls === 'number' ? meta.judgeCalls : 0,
+    items_judged: meta && typeof meta.itemsJudged === 'number' ? meta.itemsJudged : 0,
     extrapolated: !!(meta && meta.extrapolated),
   };
   return JSON.stringify(payload, null, 2);

--- a/plugins/synapsys/lib/replay-report.js
+++ b/plugins/synapsys/lib/replay-report.js
@@ -66,6 +66,7 @@ function renderJson(agg, suggestions, meta) {
     events_total: meta && typeof meta.events_total === 'number' ? meta.events_total : 0,
     events_ups: meta && typeof meta.events_ups === 'number' ? meta.events_ups : 0,
     events_ptu: meta && typeof meta.events_ptu === 'number' ? meta.events_ptu : 0,
+    extrapolated: !!(meta && meta.extrapolated),
   };
   return JSON.stringify(payload, null, 2);
 }
@@ -129,7 +130,14 @@ function renderCostFooter(itemsJudged, judgeCalls) {
  */
 function renderReport(agg, suggestions, meta) {
   const m = meta || {};
-  const lines = [renderHeaderLine(m), '', renderTableHeader()];
+  const lines = [renderHeaderLine(m)];
+  if (m.extrapolated) {
+    // SKILL.md: report is annotated with `extrapolated` when `--max-judges`
+    // causes sampling. Surface a header note so users know fp_rate numbers
+    // are based on a sample, not the full fired-matches population.
+    lines.push('note: fp_rate values are extrapolated from a sample (--max-judges cap reached).');
+  }
+  lines.push('', renderTableHeader());
   for (const name of sortMemoryNames(agg)) {
     lines.push(renderMemoryRow(name, agg[name]));
   }

--- a/plugins/synapsys/lib/replay-report.js
+++ b/plugins/synapsys/lib/replay-report.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * synapsys-replay — report renderers (extracted from the CLI script to keep
+ * the main entrypoint under the 400-line quality cap).
+ *
+ * Public surface (re-exported by scripts/synapsys-replay.js):
+ *   - renderJson(agg, suggestions, meta)
+ *   - renderReport(agg, suggestions, meta)
+ */
+
+// Cost model constants (R17): ~500 input + 5 output tokens per judge call.
+// Haiku pricing approx $1.00 / 1M input + $5.00 / 1M output tokens.
+const PRICE_PER_TOKEN = 1e-6; // ~$1/1M as a conservative per-token blend.
+const TOKENS_PER_JUDGE_CALL = 500 + 5;
+
+/**
+ * Render the aggregated report as machine-readable JSON (R9, G6).
+ *
+ * Spec §Security — `ANTHROPIC_API_KEY` is never included in output; this
+ * function only serialises the inputs it is handed (no env access).
+ */
+function renderJson(agg, suggestions, meta) {
+  const memories = Object.keys(agg).map((name) => {
+    const m = agg[name];
+    return {
+      name,
+      fires: m.fires,
+      relevant: m.relevant,
+      irrelevant: m.irrelevant,
+      judge_failed: m.judge_failed,
+      fp_rate: m.fp_rate,
+      sample_matches: m.sample_matches,
+    };
+  });
+  const payload = {
+    memories,
+    suggestions: Array.isArray(suggestions) ? suggestions : [],
+    events_total: meta && typeof meta.events_total === 'number' ? meta.events_total : 0,
+    events_ups: meta && typeof meta.events_ups === 'number' ? meta.events_ups : 0,
+    events_ptu: meta && typeof meta.events_ptu === 'number' ? meta.events_ptu : 0,
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+function renderHeaderLine(m) {
+  return (
+    `store=${m.store || ''} window=${m.window || ''} events=${m.events_total || 0} ` +
+    `UPS=${m.events_ups || 0} PTU=${m.events_ptu || 0}`
+  );
+}
+
+function renderTableHeader() {
+  return (
+    'Memory'.padEnd(30) +
+    'Fires'.padStart(7) +
+    'Relevant'.padStart(10) +
+    'FP%'.padStart(8) +
+    '  Sample matches'
+  );
+}
+
+function formatRelevant(value) {
+  return value === null || value === undefined ? '—' : String(value);
+}
+
+function formatFpPct(value) {
+  return value === null || value === undefined ? '—' : `${Math.round(value * 100)}%`;
+}
+
+function renderMemoryRow(name, e) {
+  const samples = (e.sample_matches || []).slice(0, 3).join(', ');
+  return (
+    name.padEnd(30) +
+    String(e.fires).padStart(7) +
+    formatRelevant(e.relevant).padStart(10) +
+    formatFpPct(e.fp_rate).padStart(8) +
+    '  ' +
+    samples
+  );
+}
+
+function renderSuggestionsBlock(suggestions) {
+  const sugs = Array.isArray(suggestions) ? suggestions : [];
+  if (sugs.length === 0) return ['  (none)'];
+  return sugs.map(
+    (s) => `  - ${s.memory}: tighten short arms [${(s.candidates || []).join(', ')}]`
+  );
+}
+
+function renderCostFooter(judgeCalls) {
+  const cost = TOKENS_PER_JUDGE_CALL * judgeCalls * PRICE_PER_TOKEN;
+  return ['', `est. cost ≈ $${cost.toFixed(4)} (${judgeCalls} judge calls)`];
+}
+
+/**
+ * Render the human-readable report (R11). Includes header, per-memory table
+ * rows, Suggestions section, and cost footer when `meta.judgeCalls > 0` (R17).
+ */
+function renderReport(agg, suggestions, meta) {
+  const m = meta || {};
+  const lines = [renderHeaderLine(m), '', renderTableHeader()];
+  for (const name of Object.keys(agg)) {
+    lines.push(renderMemoryRow(name, agg[name]));
+  }
+  lines.push('', 'Suggestions:');
+  lines.push(...renderSuggestionsBlock(suggestions));
+  if (m.judgeCalls && m.judgeCalls > 0) {
+    lines.push(...renderCostFooter(m.judgeCalls));
+  }
+  return lines.join('\n') + '\n';
+}
+
+module.exports = {
+  renderJson,
+  renderReport,
+};

--- a/plugins/synapsys/lib/replay-report.js
+++ b/plugins/synapsys/lib/replay-report.js
@@ -9,10 +9,11 @@
  *   - renderReport(agg, suggestions, meta)
  */
 
-// Cost model constants (R17): ~500 input + 5 output tokens per judge call.
-// Haiku pricing approx $1.00 / 1M input + $5.00 / 1M output tokens.
+// Cost model constants (R17): per SKILL.md the judge spends ~500 input + ~5
+// output tokens PER FIRED UPS MATCH (i.e. per judged item, not per batched
+// API call). Haiku pricing approx $1.00 / 1M input + $5.00 / 1M output tokens.
 const PRICE_PER_TOKEN = 1e-6; // ~$1/1M as a conservative per-token blend.
-const TOKENS_PER_JUDGE_CALL = 500 + 5;
+const TOKENS_PER_JUDGED_ITEM = 500 + 5;
 
 /**
  * Render the aggregated report as machine-readable JSON (R9, G6).
@@ -88,9 +89,12 @@ function renderSuggestionsBlock(suggestions) {
   );
 }
 
-function renderCostFooter(judgeCalls) {
-  const cost = TOKENS_PER_JUDGE_CALL * judgeCalls * PRICE_PER_TOKEN;
-  return ['', `est. cost ≈ $${cost.toFixed(4)} (${judgeCalls} judge calls)`];
+function renderCostFooter(itemsJudged, judgeCalls) {
+  const cost = TOKENS_PER_JUDGED_ITEM * itemsJudged * PRICE_PER_TOKEN;
+  return [
+    '',
+    `est. cost ≈ $${cost.toFixed(4)} (${itemsJudged} items judged across ${judgeCalls} batched API calls)`,
+  ];
 }
 
 /**
@@ -106,7 +110,12 @@ function renderReport(agg, suggestions, meta) {
   lines.push('', 'Suggestions:');
   lines.push(...renderSuggestionsBlock(suggestions));
   if (m.judgeCalls && m.judgeCalls > 0) {
-    lines.push(...renderCostFooter(m.judgeCalls));
+    // Prefer explicit `itemsJudged` from the pipeline; fall back to judgeCalls
+    // for callers that haven't been updated (back-compat). The cost formula
+    // is per-judged-item, NOT per batched API call (see SKILL.md).
+    const itemsJudged =
+      typeof m.itemsJudged === 'number' && m.itemsJudged >= 0 ? m.itemsJudged : m.judgeCalls;
+    lines.push(...renderCostFooter(itemsJudged, m.judgeCalls));
   }
   return lines.join('\n') + '\n';
 }

--- a/plugins/synapsys/lib/replay-report.js
+++ b/plugins/synapsys/lib/replay-report.js
@@ -11,9 +11,13 @@
 
 // Cost model constants (R17): per SKILL.md the judge spends ~500 input + ~5
 // output tokens PER FIRED UPS MATCH (i.e. per judged item, not per batched
-// API call). Haiku pricing approx $1.00 / 1M input + $5.00 / 1M output tokens.
-const PRICE_PER_TOKEN = 1e-6; // ~$1/1M as a conservative per-token blend.
-const TOKENS_PER_JUDGED_ITEM = 500 + 5;
+// API call). Haiku 4.5 pricing: $1.00 / 1M input, $5.00 / 1M output.
+const INPUT_PRICE_PER_TOKEN = 1e-6;
+const OUTPUT_PRICE_PER_TOKEN = 5e-6;
+const INPUT_TOKENS_PER_ITEM = 500;
+const OUTPUT_TOKENS_PER_ITEM = 5;
+const COST_PER_JUDGED_ITEM =
+  INPUT_TOKENS_PER_ITEM * INPUT_PRICE_PER_TOKEN + OUTPUT_TOKENS_PER_ITEM * OUTPUT_PRICE_PER_TOKEN;
 
 /**
  * Render the aggregated report as machine-readable JSON (R9, G6).
@@ -117,7 +121,7 @@ function renderSuggestionsBlock(suggestions) {
 }
 
 function renderCostFooter(itemsJudged, judgeCalls) {
-  const cost = TOKENS_PER_JUDGED_ITEM * itemsJudged * PRICE_PER_TOKEN;
+  const cost = COST_PER_JUDGED_ITEM * itemsJudged;
   return [
     '',
     `est. cost ≈ $${cost.toFixed(4)} (${itemsJudged} items judged across ${judgeCalls} batched API calls)`,

--- a/plugins/synapsys/lib/replay-report.js
+++ b/plugins/synapsys/lib/replay-report.js
@@ -21,8 +21,34 @@ const TOKENS_PER_JUDGED_ITEM = 500 + 5;
  * Spec §Security — `ANTHROPIC_API_KEY` is never included in output; this
  * function only serialises the inputs it is handed (no env access).
  */
+/**
+ * Order memory names by descending fp_rate (nulls last), with `fires`
+ * descending as a tiebreaker and name ascending as a final stable key.
+ * README + SKILL.md promise the report is "ranked by false-positive rate."
+ */
+function compareByName(a, b) {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function compareMemories(agg, a, b) {
+  const fa = agg[a].fp_rate;
+  const fb = agg[b].fp_rate;
+  const aNull = fa == null;
+  const bNull = fb == null;
+  if (aNull !== bNull) return aNull ? 1 : -1;
+  if (!aNull && fa !== fb) return fb - fa;
+  if (agg[b].fires !== agg[a].fires) return agg[b].fires - agg[a].fires;
+  return compareByName(a, b);
+}
+
+function sortMemoryNames(agg) {
+  return Object.keys(agg).sort((a, b) => compareMemories(agg, a, b));
+}
+
 function renderJson(agg, suggestions, meta) {
-  const memories = Object.keys(agg).map((name) => {
+  const memories = sortMemoryNames(agg).map((name) => {
     const m = agg[name];
     return {
       name,
@@ -104,7 +130,7 @@ function renderCostFooter(itemsJudged, judgeCalls) {
 function renderReport(agg, suggestions, meta) {
   const m = meta || {};
   const lines = [renderHeaderLine(m), '', renderTableHeader()];
-  for (const name of Object.keys(agg)) {
+  for (const name of sortMemoryNames(agg)) {
     lines.push(renderMemoryRow(name, agg[name]));
   }
   lines.push('', 'Suggestions:');

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -182,6 +182,7 @@ async function runJudgePhase(tuples, flags, apiKey) {
   return {
     judgments,
     judgeCalls: Math.ceil(pipeline.results.length / JUDGE_BATCH_SIZE),
+    itemsJudged: pipeline.results.length,
     extrapolated: pipeline.extrapolated,
   };
 }
@@ -236,7 +237,20 @@ async function main(argv) {
     baseDir: flags.transcriptsBase,
   });
   if (files.length === 0) {
-    process.stdout.write('no transcripts in window\n');
+    if (flags.json) {
+      process.stdout.write(
+        `${JSON.stringify({
+          memories: [],
+          suggestions: [],
+          events_total: 0,
+          events_ups: 0,
+          events_ptu: 0,
+          message: 'no transcripts in window',
+        })}\n`
+      );
+    } else {
+      process.stdout.write('no transcripts in window\n');
+    }
     process.exit(0);
   }
 
@@ -251,9 +265,14 @@ async function main(argv) {
 
   let judgments;
   let judgeCalls = 0;
+  let itemsJudged = 0;
   let extrapolated = false;
   if (judging) {
-    ({ judgments, judgeCalls, extrapolated } = await runJudgePhase(tuples, flags, apiKey));
+    ({ judgments, judgeCalls, itemsJudged, extrapolated } = await runJudgePhase(
+      tuples,
+      flags,
+      apiKey
+    ));
   }
 
   const agg = aggregateReport(tuples, judgments);
@@ -267,6 +286,7 @@ async function main(argv) {
     events_ups: counts.ups,
     events_ptu: counts.ptu,
     judgeCalls,
+    itemsJudged,
     extrapolated,
   };
   writeOutput(flags, agg, suggestions, meta);

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -44,6 +44,7 @@ const { renderJson, renderReport } = report;
  *   --only=<csv>        comma-separated memory-name filter
  *   --store=<name|path> store selector (auto-detect like synapsys-explain)
  *   --max-judges=<N>    hard cap on judge API calls (default 200)
+ *   --all-projects      scan every ~/.claude/projects/* dir (default: only the cwd-hashed project)
  */
 function parseFlags(argv) {
   const flag = makeFlag(argv);
@@ -57,6 +58,7 @@ function parseFlags(argv) {
     only: typeof flag('only') === 'string' ? flag('only') : undefined,
     store: typeof flag('store') === 'string' ? flag('store') : undefined,
     maxJudges: maxJudgesRaw === undefined || maxJudgesRaw === true ? 200 : Number(maxJudgesRaw),
+    allProjects: flag('all-projects') === true,
     transcriptsBase:
       typeof flag('transcripts-base') === 'string' ? flag('transcripts-base') : undefined,
   };
@@ -264,6 +266,10 @@ async function main(argv) {
     since: flags.since,
     project: flags.project,
     baseDir: flags.transcriptsBase,
+    cwd: process.cwd(),
+    // --transcripts-base is a test escape hatch with synthetic project layouts,
+    // so treat it like --all-projects to keep test fixtures cwd-independent.
+    allProjects: flags.allProjects || !!flags.transcriptsBase,
   });
   if (files.length === 0) {
     if (flags.json) {

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -5,18 +5,31 @@
  * synapsys-replay — replay recent Claude Code transcripts against the
  * runtime trigger matcher to surface noisy / mis-tuned synapsys memories.
  *
- * Task 1 (GH-444) — CLI shell + flag parser only.
- * Subsequent tasks wire in the walker, matcher integration, judge, and
- * report renderers. Sibling-owned files (matcher.js, synapsys-explain.js,
- * GH-443) are NOT imported here yet.
+ * GH-444. The implementation is split across sibling modules to keep this
+ * CLI entrypoint under the 400-line quality cap:
+ *
+ *   - lib/replay-events.js    — extractEvents, walkTranscripts, iterLines, replayEvent, parseSince
+ *   - lib/replay-aggregate.js — aggregateReport, suggestTightening, splitTopLevelAlternation, fpRate
+ *   - lib/replay-judge.js     — judgeBatch, judgePipeline, sampleForCap
+ *   - lib/replay-report.js    — renderJson, renderReport
+ *
+ * This file owns flag parsing, validation, store loading, the main()
+ * pipeline orchestration, and the public re-exports consumed by tests.
  */
 
 const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
 const { makeFlag } = require('../lib/cli-args');
-const matcher = require('../lib/matcher');
 const memoryStore = require('../lib/memory-store');
+const events = require('../lib/replay-events');
+const aggregate = require('../lib/replay-aggregate');
+const judge = require('../lib/replay-judge');
+const report = require('../lib/replay-report');
+
+const { extractEvents, parseSince, walkTranscripts, iterLines, replayEvent } = events;
+const { splitTopLevelAlternation, fpRate, aggregateReport, suggestTightening } = aggregate;
+const { judgeBatch, sampleForCap, judgePipeline, JUDGE_BATCH_SIZE } = judge;
+const { renderJson, renderReport } = report;
 
 /**
  * Pure flag parser — no I/O, no process exits. Tests call this directly
@@ -37,21 +50,13 @@ function parseFlags(argv) {
   const sinceRaw = flag('since');
   const maxJudgesRaw = flag('max-judges');
   return {
-    // Window string ('7d', '14d', ...); parsed into ms by walkTranscripts (Task 3).
     since: sinceRaw === undefined || sinceRaw === true ? '7d' : sinceRaw,
-    // Optional project-hash filter; undefined → iterate every project (spec §Decision).
     project: typeof flag('project') === 'string' ? flag('project') : undefined,
-    // Skip judge entirely; required when ANTHROPIC_API_KEY is absent.
     noJudge: flag('no-judge') === true,
-    // Emit JSON to stdout instead of human-readable report.
     json: flag('json') === true,
-    // Memory-name allow-list (comma-separated); applied at memory-load.
     only: typeof flag('only') === 'string' ? flag('only') : undefined,
-    // Store selector — name or filesystem path; auto-detect like explain.
     store: typeof flag('store') === 'string' ? flag('store') : undefined,
-    // Hard upper bound on judge API calls; over-cap triggers even sampling.
     maxJudges: maxJudgesRaw === undefined || maxJudgesRaw === true ? 200 : Number(maxJudgesRaw),
-    // Test-only override (Task 8): direct ~/.claude/projects/ to a tmp dir.
     transcriptsBase:
       typeof flag('transcripts-base') === 'string' ? flag('transcripts-base') : undefined,
   };
@@ -67,11 +72,8 @@ function die(msg, code = 2) {
 }
 
 /**
- * Centralised judge gate (Task 8 REFACTOR target — exported for tests if
- * needed later). Returns true only when judging is allowed AND warranted:
- *   - `--no-judge` not set
- *   - `ANTHROPIC_API_KEY` present
- *   - at least one UPS fire to judge (PTU is not judged in v1, spec §Decision)
+ * Centralised judge gate. Returns true only when judging is allowed AND warranted:
+ *   - `--no-judge` not set, `ANTHROPIC_API_KEY` present, ≥1 UPS fire.
  */
 function shouldJudge({ noJudge, apiKey, upsFires }) {
   if (noJudge) return false;
@@ -81,78 +83,165 @@ function shouldJudge({ noJudge, apiKey, upsFires }) {
 }
 
 /**
- * Wired main() (Task 8). Pipeline:
- *   parseFlags → validate → loadStore → loadMemories (apply --only)
- *   → walkTranscripts → iterLines → extractEvents → replayEvent
- *   → (optional) judgePipeline → aggregateReport → suggestTightening
- *   → renderReport / renderJson → exit
- *
- * Validation precedes I/O so `--since`/`--store` misconfigs exit 2 before
- * any filesystem or network touches (spec §CLI). No-transcripts window is
- * handled before the judge step and prints a friendly message (R12 / G10).
- * Missing `ANTHROPIC_API_KEY` without `--no-judge` emits a single stderr
- * notice and proceeds as `--no-judge` (spec §Security / AC5).
+ * Resolve `--store` flag against `discoverStores(cwd)`. Mirrors the selector
+ * logic in scripts/synapsys-explain.js (GH-443). Dies(2) on unknown store.
  */
-async function main(argv) {
-  const flags = parseFlags(argv);
+function loadStore({ storeFlag, cwd } = {}) {
+  const resolvedCwd = cwd || process.cwd();
+  const stores = memoryStore.discoverStores(resolvedCwd);
+  if (!storeFlag || storeFlag === true) return stores;
+  const byKind = stores.filter((s) => s.kind === storeFlag);
+  if (byKind.length) return byKind;
+  const abs = path.resolve(storeFlag);
+  const byPath = stores.filter((s) => path.resolve(s.dir) === abs);
+  if (byPath.length) return byPath;
+  if (fs.existsSync(path.join(abs, '.synapsys.json'))) {
+    return [{ kind: 'path', dir: abs, projectName: path.basename(abs) }];
+  }
+  die(`unknown --store "${storeFlag}" (no matching discovered store)`, 2);
+}
 
-  // Validation (BEFORE any I/O — spec §CLI exit 2).
+/**
+ * Load all memories from a list of discovered stores.
+ */
+function loadMemories(stores) {
+  const all = [];
+  for (const s of stores) {
+    all.push(...memoryStore.listMemoriesFromStore(s));
+  }
+  return all;
+}
+
+function validateFlags(flags) {
   if (!/^\d+d$/.test(flags.since)) {
     die(`invalid --since=${flags.since} (expected format like 7d, 14d)`);
   }
   if (flags.project !== undefined && !/^[\w.-]+$/.test(flags.project)) {
     die(`invalid --project=${flags.project}`);
   }
+}
 
-  // Resolve store(s) and load memories. loadStore may die() on unknown store.
-  const stores = loadStore({ storeFlag: flags.store, cwd: process.cwd() });
-  let memories = loadMemories(stores);
-  if (flags.only) {
-    const allow = new Set(
-      flags.only
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean)
-    );
-    memories = memories.filter((m) => allow.has(m.name));
+function applyOnlyFilter(memories, onlyFlag) {
+  if (!onlyFlag) return memories;
+  const allow = new Set(
+    onlyFlag
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+  return memories.filter((m) => allow.has(m.name));
+}
+
+function bumpCounts(counts, eventKind) {
+  counts.total += 1;
+  if (eventKind === 'UserPromptSubmit') counts.ups += 1;
+  else if (eventKind === 'PreToolUse') counts.ptu += 1;
+}
+
+function processEvent(ev, memories, tuples) {
+  for (const t of replayEvent(memories, ev)) {
+    if (t.fired && ev.event === 'UserPromptSubmit') t.prompt = ev.prompt;
+    tuples.push(t);
   }
+}
 
-  // Walk transcripts. Honor --transcripts-base override for hermetic tests.
+function collectTuplesFromFiles(files, memories) {
+  const tuples = [];
+  const counts = { total: 0, ups: 0, ptu: 0 };
+  for (const file of files) {
+    for (const parsed of iterLines(file)) {
+      for (const ev of extractEvents(parsed)) {
+        bumpCounts(counts, ev.event);
+        processEvent(ev, memories, tuples);
+      }
+    }
+  }
+  return { tuples, counts };
+}
+
+function tallyJudgmentResult(judgments, r) {
+  if (!judgments[r.memory]) {
+    judgments[r.memory] = { relevant: 0, irrelevant: 0, judge_failed: 0 };
+  }
+  if (r.judge_failed) judgments[r.memory].judge_failed += 1;
+  else if (r.relevant === true) judgments[r.memory].relevant += 1;
+  else if (r.relevant === false) judgments[r.memory].irrelevant += 1;
+}
+
+async function runJudgePhase(tuples, flags, apiKey) {
+  const items = tuples
+    .filter((t) => t.fired && t.event === 'UserPromptSubmit')
+    .map((t) => ({ memory: t.memory_name, prompt: t.prompt, matched: t.matched_substring }));
+  const pipeline = await judgePipeline(items, {
+    apiKey,
+    model: 'claude-haiku-4-5',
+    maxJudges: flags.maxJudges,
+  });
+  const judgments = {};
+  for (const r of pipeline.results) tallyJudgmentResult(judgments, r);
+  return {
+    judgments,
+    judgeCalls: Math.ceil(pipeline.results.length / JUDGE_BATCH_SIZE),
+    extrapolated: pipeline.extrapolated,
+  };
+}
+
+function nullOutRelevance(agg) {
+  for (const name of Object.keys(agg)) {
+    agg[name].relevant = null;
+    agg[name].irrelevant = null;
+    agg[name].fp_rate = null;
+  }
+}
+
+function buildSuggestions(memories, agg) {
+  const suggestions = [];
+  for (const memory of memories) {
+    const sug = suggestTightening(memory, agg[memory.name]);
+    if (sug) suggestions.push(sug);
+  }
+  return suggestions;
+}
+
+function writeOutput(flags, agg, suggestions, meta) {
+  if (flags.json) {
+    process.stdout.write(renderJson(agg, suggestions, meta) + '\n');
+  } else {
+    process.stdout.write(renderReport(agg, suggestions, meta));
+  }
+}
+
+/**
+ * Wired main() entrypoint. Pipeline:
+ *   parseFlags → validate → loadStore → loadMemories (apply --only)
+ *   → walkTranscripts → iterLines → extractEvents → replayEvent
+ *   → (optional) judgePipeline → aggregateReport → suggestTightening
+ *   → renderReport / renderJson → exit
+ *
+ * Validation precedes I/O so misconfigs exit 2 before any filesystem/network
+ * touches. No-transcripts window prints a friendly message (R12 / G10).
+ * Missing `ANTHROPIC_API_KEY` without `--no-judge` emits a single stderr
+ * notice and proceeds as `--no-judge` (spec §Security / AC5).
+ */
+async function main(argv) {
+  const flags = parseFlags(argv);
+  validateFlags(flags);
+
+  const stores = loadStore({ storeFlag: flags.store, cwd: process.cwd() });
+  const memories = applyOnlyFilter(loadMemories(stores), flags.only);
+
   const files = walkTranscripts({
     since: flags.since,
     project: flags.project,
     baseDir: flags.transcriptsBase,
   });
-
-  // R12 / G10 — no-transcripts case: friendly stdout, clean stderr, exit 0.
   if (files.length === 0) {
     process.stdout.write('no transcripts in window\n');
     process.exit(0);
   }
 
-  // Stream events through the matcher.
-  const tuples = [];
-  let eventsTotal = 0;
-  let eventsUps = 0;
-  let eventsPtu = 0;
-  for (const file of files) {
-    for (const parsed of iterLines(file)) {
-      const events = extractEvents(parsed);
-      for (const ev of events) {
-        eventsTotal += 1;
-        if (ev.event === 'UserPromptSubmit') eventsUps += 1;
-        else if (ev.event === 'PreToolUse') eventsPtu += 1;
-        const evTuples = replayEvent(memories, ev);
-        for (const t of evTuples) {
-          // Preserve prompt text on fires for judge prompt construction.
-          if (t.fired && ev.event === 'UserPromptSubmit') t.prompt = ev.prompt;
-          tuples.push(t);
-        }
-      }
-    }
-  }
+  const { tuples, counts } = collectTuplesFromFiles(files, memories);
 
-  // Judge decision. Missing key + !noJudge → stderr notice + treat as no-judge.
   const apiKey = process.env.ANTHROPIC_API_KEY || '';
   const upsFires = tuples.filter((t) => t.fired && t.event === 'UserPromptSubmit').length;
   if (!flags.noJudge && !apiKey) {
@@ -164,629 +253,24 @@ async function main(argv) {
   let judgeCalls = 0;
   let extrapolated = false;
   if (judging) {
-    const items = tuples
-      .filter((t) => t.fired && t.event === 'UserPromptSubmit')
-      .map((t) => ({ memory: t.memory_name, prompt: t.prompt, matched: t.matched_substring }));
-    const pipeline = await judgePipeline(items, {
-      apiKey,
-      model: 'claude-haiku-4-5',
-      maxJudges: flags.maxJudges,
-    });
-    extrapolated = pipeline.extrapolated;
-    judgeCalls = Math.ceil(pipeline.results.length / JUDGE_BATCH_SIZE);
-    judgments = {};
-    for (const r of pipeline.results) {
-      if (!judgments[r.memory]) {
-        judgments[r.memory] = { relevant: 0, irrelevant: 0, judge_failed: 0 };
-      }
-      if (r.judge_failed) judgments[r.memory].judge_failed += 1;
-      else if (r.relevant === true) judgments[r.memory].relevant += 1;
-      else if (r.relevant === false) judgments[r.memory].irrelevant += 1;
-    }
+    ({ judgments, judgeCalls, extrapolated } = await runJudgePhase(tuples, flags, apiKey));
   }
 
-  // Aggregate + suggest.
   const agg = aggregateReport(tuples, judgments);
-  // When the judge did not run, every memory's relevance is unknown — null
-  // out the bookkeeping fields so the JSON / report communicate that clearly
-  // (AC5 / R4). aggregateReport itself stays test-stable for Task 5.
-  if (!judging) {
-    for (const name of Object.keys(agg)) {
-      agg[name].relevant = null;
-      agg[name].irrelevant = null;
-      agg[name].fp_rate = null;
-    }
-  }
-  const suggestions = [];
-  for (const memory of memories) {
-    const sug = suggestTightening(memory, agg[memory.name]);
-    if (sug) suggestions.push(sug);
-  }
+  if (!judging) nullOutRelevance(agg);
+  const suggestions = buildSuggestions(memories, agg);
 
-  // Render.
   const meta = {
     store: stores.map((s) => s.dir).join(','),
     window: flags.since,
-    events_total: eventsTotal,
-    events_ups: eventsUps,
-    events_ptu: eventsPtu,
+    events_total: counts.total,
+    events_ups: counts.ups,
+    events_ptu: counts.ptu,
     judgeCalls,
     extrapolated,
   };
-  if (flags.json) {
-    process.stdout.write(renderJson(agg, suggestions, meta) + '\n');
-  } else {
-    process.stdout.write(renderReport(agg, suggestions, meta));
-  }
+  writeOutput(flags, agg, suggestions, meta);
   process.exit(0);
-}
-
-/**
- * Pure transcript → synthetic-event mapper (Task 2, R2, G1+G2).
- *
- * Claude Code records each turn as a JSONL entry. We synthesize the same
- * event payloads the runtime trigger matcher consumes:
- *
- *   - `type=user`        → `{event:'UserPromptSubmit', prompt}`
- *     `message.content` is either a plain string or an array of content
- *     blocks (we concatenate `type=text` blocks' `text` fields).
- *
- *   - `type=assistant`   → one `{event:'PreToolUse', tool, tool_input}`
- *     per `tool_use` content block (the assistant may emit multiple tool
- *     calls per turn; each becomes its own PTU event).
- *
- *   - anything else (system, summary, malformed) → `[]`
- *
- * Pure function: no I/O, no globals. Inputs and outputs are plain data.
- */
-function extractEvents(parsedLine) {
-  if (!parsedLine || typeof parsedLine !== 'object') return [];
-  const { type, message } = parsedLine;
-
-  if (type === 'user') {
-    if (!message || message.content === undefined || message.content === null) return [];
-    const content = message.content;
-    if (typeof content === 'string') {
-      return [{ event: 'UserPromptSubmit', prompt: content }];
-    }
-    if (Array.isArray(content)) {
-      const prompt = content
-        .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
-        .map((b) => b.text)
-        .join('');
-      if (prompt.length === 0) return [];
-      return [{ event: 'UserPromptSubmit', prompt }];
-    }
-    return [];
-  }
-
-  if (type === 'assistant') {
-    if (!message || !Array.isArray(message.content)) return [];
-    return message.content
-      .filter((b) => b && b.type === 'tool_use' && typeof b.name === 'string')
-      .map((b) => ({
-        event: 'PreToolUse',
-        tool: b.name,
-        tool_input: b.input,
-      }));
-  }
-
-  return [];
-}
-
-/**
- * Convert a `--since=Nd` window string into milliseconds.
- *
- * Task 3 (R1). Throws on invalid format; main()/die() handles user-facing
- * error reporting per spec §CLI (exit code 2 on misconfig).
- */
-function parseSince(spec) {
-  if (typeof spec !== 'string' || !/^\d+d$/.test(spec)) {
-    throw new Error(`invalid --since=${spec} (expected format like 7d, 14d)`);
-  }
-  const days = Number(spec.slice(0, -1));
-  return days * 24 * 60 * 60 * 1000;
-}
-
-/**
- * Walk `*.jsonl` transcripts under `baseDir` (default `~/.claude/projects/`)
- * whose mtime falls within the `--since` window. When `project` is provided,
- * only that hash-dir is searched. Missing/empty directories return `[]`
- * (R12 walker-level no-transcripts detection).
- *
- * Injectable `baseDir` keeps tests off the real `~/.claude/projects/` and
- * avoids fs monkey-patching.
- */
-function walkTranscripts({ since, project, baseDir } = {}) {
-  const root = baseDir || path.join(os.homedir(), '.claude/projects');
-  if (!fs.existsSync(root)) return [];
-  const windowMs = parseSince(since || '7d');
-  const cutoff = Date.now() - windowMs;
-
-  let projectDirs;
-  if (project) {
-    const dir = path.join(root, project);
-    if (!fs.existsSync(dir)) return [];
-    projectDirs = [dir];
-  } else {
-    projectDirs = fs
-      .readdirSync(root, { withFileTypes: true })
-      .filter((d) => d.isDirectory())
-      .map((d) => path.join(root, d.name));
-  }
-
-  const out = [];
-  for (const projDir of projectDirs) {
-    let entries;
-    try {
-      entries = fs.readdirSync(projDir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
-      const full = path.join(projDir, entry.name);
-      let stat;
-      try {
-        stat = fs.statSync(full);
-      } catch {
-        continue;
-      }
-      if (stat.mtimeMs >= cutoff) out.push(full);
-    }
-  }
-  return out;
-}
-
-/**
- * Stream-parse a JSONL transcript file. Yields one parsed object per
- * non-empty line; malformed lines emit a single stderr warning and are
- * skipped (R1). Returned as an iterable array — the file is read
- * synchronously since transcripts are bounded and small per spec §Perf.
- */
-function* iterLines(filePath) {
-  let raw;
-  try {
-    raw = fs.readFileSync(filePath, 'utf8');
-  } catch (err) {
-    process.stderr.write(`synapsys-replay: cannot read ${filePath}: ${err.message}\n`);
-    return;
-  }
-  const lines = raw.split('\n');
-  for (const line of lines) {
-    if (line.length === 0) continue;
-    try {
-      yield JSON.parse(line);
-    } catch (err) {
-      process.stderr.write(
-        `synapsys-replay: malformed JSONL line in ${filePath} (skipped): ${err.message}\n`
-      );
-    }
-  }
-}
-
-/**
- * Replay a synthetic event against every memory and return one tuple per
- * memory: `{memory_name, event, fired, matched_substring}`. Task 4 (R3, G3).
- *
- * Dispatch:
- *   - `event.event === 'UserPromptSubmit'` → `matcher.matchPrompt(memory, event.prompt)`
- *   - `event.event === 'PreToolUse'`       → `matcher.matchPreTool(memory, {tool_name, tool_input})`
- *
- * Per GH-443 `MatchResult` schema, on fire the matcher returns
- * `{fired: true, matched: {...}}`. Consumed fields for `matched_substring`:
- *   - `matched.prompt_substring`  (UPS, see matcher.matchPrompt)
- *   - `matched.content_substring` (PTU with content patterns, see matcher.matchPreTool)
- * Other `matched` fields (`prompt_token`, `pretool_pattern`, `content_pattern`,
- * `negative_pattern`) are NOT consumed by replay; they are used by explain/R16.
- */
-function replayEvent(memories, event) {
-  const out = [];
-  for (const memory of memories) {
-    const result = dispatchMatch(memory, event);
-    const matched = result && result.matched ? result.matched : undefined;
-    const matched_substring = matched
-      ? matched.prompt_substring !== undefined
-        ? matched.prompt_substring
-        : matched.content_substring
-      : undefined;
-    out.push({
-      memory_name: memory.name,
-      event: event.event,
-      fired: Boolean(result && result.fired),
-      matched_substring,
-    });
-  }
-  return out;
-}
-
-function dispatchMatch(memory, event) {
-  if (event.event === 'UserPromptSubmit') {
-    return matcher.matchPrompt(memory, event.prompt || '');
-  }
-  if (event.event === 'PreToolUse') {
-    return matcher.matchPreTool(memory, {
-      tool_name: event.tool,
-      tool_input: event.tool_input,
-    });
-  }
-  return { fired: false, reason: 'events-exclude' };
-}
-
-/**
- * Resolve `--store` flag against `discoverStores(cwd)` (memory-store.js).
- * Mirrors the selector logic in scripts/synapsys-explain.js (sibling-owned,
- * GH-443) — we re-derive locally rather than importing to keep the script
- * boundary clean.
- *
- *   - storeFlag undefined/empty → return every discovered store
- *   - storeFlag matches a `kind` (local/worktree/global/shared) → filter
- *   - storeFlag is a path → resolve absolute and match by dir
- *   - no match → die() exit 2 (spec §CLI)
- */
-function loadStore({ storeFlag, cwd } = {}) {
-  const resolvedCwd = cwd || process.cwd();
-  const stores = memoryStore.discoverStores(resolvedCwd);
-  if (!storeFlag || storeFlag === true) return stores;
-  const byKind = stores.filter((s) => s.kind === storeFlag);
-  if (byKind.length) return byKind;
-  const abs = path.resolve(storeFlag);
-  const byPath = stores.filter((s) => path.resolve(s.dir) === abs);
-  if (byPath.length) return byPath;
-  // Path-form fallback: if the absolute path carries the store marker, accept
-  // it even when it lives outside discoverStores() reach. Lets callers point
-  // at a hermetic test store under /tmp (Task 8 fixtures).
-  if (fs.existsSync(path.join(abs, '.synapsys.json'))) {
-    return [{ kind: 'path', dir: abs, projectName: path.basename(abs) }];
-  }
-  die(`unknown --store "${storeFlag}" (no matching discovered store)`, 2);
-}
-
-/**
- * Load all memories from a list of discovered stores by delegating to
- * memory-store.listMemoriesFromStore (single source of truth for frontmatter
- * parsing — never re-implemented here).
- */
-function loadMemories(stores) {
-  const all = [];
-  for (const s of stores) {
-    all.push(...memoryStore.listMemoriesFromStore(s));
-  }
-  return all;
-}
-
-/**
- * Split `trigger_prompt` on top-level `|` only (outside `(...)` / `[...]`).
- * Used by suggestTightening to inspect alternation arms for heuristic R8.
- * Vendored locally per spec §Arch — not exported from matcher.
- */
-function splitTopLevelAlternation(triggerPrompt) {
-  if (typeof triggerPrompt !== 'string' || triggerPrompt.length === 0) return [];
-  const arms = [];
-  let depthParen = 0;
-  let depthBracket = 0;
-  let buf = '';
-  for (let i = 0; i < triggerPrompt.length; i++) {
-    const ch = triggerPrompt[i];
-    if (ch === '(') depthParen++;
-    else if (ch === ')') depthParen = Math.max(0, depthParen - 1);
-    else if (ch === '[') depthBracket++;
-    else if (ch === ']') depthBracket = Math.max(0, depthBracket - 1);
-    if (ch === '|' && depthParen === 0 && depthBracket === 0) {
-      arms.push(buf);
-      buf = '';
-      continue;
-    }
-    buf += ch;
-  }
-  arms.push(buf);
-  return arms;
-}
-
-/**
- * fp_rate = 1 - relevant / (relevant + irrelevant). judge_failed excluded.
- */
-function fpRate(relevant, irrelevant) {
-  const denom = relevant + irrelevant;
-  if (denom <= 0) return null;
-  return 1 - relevant / denom;
-}
-
-/**
- * Aggregate per-memory metrics from replay tuples + judge results.
- *
- * `tuples` — output of replayEvent across the event stream:
- *   `{memory_name, event, fired, matched_substring}`
- * `judgments` — keyed by memory_name (UPS memories only):
- *   `{relevant, irrelevant, judge_failed}` counts
- *
- * Returns object keyed by memory_name:
- *   `{fires, relevant, irrelevant, judge_failed, fp_rate, sample_matches}`
- *
- * PTU-only memories (any fired tuple has event PreToolUse and no UPS fires)
- * report `relevant=null` / `fp_rate=null` (spec §Decision — PTU not judged v1).
- * `sample_matches` is the top-3 most-frequent distinct matched substrings.
- */
-function aggregateReport(tuples, judgments) {
-  const report = {};
-  const fireBuckets = {};
-  for (const t of tuples) {
-    if (!report[t.memory_name]) {
-      report[t.memory_name] = {
-        fires: 0,
-        relevant: 0,
-        irrelevant: 0,
-        judge_failed: 0,
-        fp_rate: null,
-        sample_matches: [],
-        _hasUps: false,
-        _hasPtu: false,
-      };
-      fireBuckets[t.memory_name] = { events: new Set(), subs: new Map() };
-    }
-    if (t.fired) {
-      report[t.memory_name].fires += 1;
-      fireBuckets[t.memory_name].events.add(t.event);
-      if (t.event === 'UserPromptSubmit') report[t.memory_name]._hasUps = true;
-      if (t.event === 'PreToolUse') report[t.memory_name]._hasPtu = true;
-      if (t.matched_substring) {
-        const m = fireBuckets[t.memory_name].subs;
-        m.set(t.matched_substring, (m.get(t.matched_substring) || 0) + 1);
-      }
-    }
-  }
-  for (const name of Object.keys(report)) {
-    const entry = report[name];
-    const j = judgments && judgments[name];
-    if (j && entry._hasUps) {
-      entry.relevant = j.relevant || 0;
-      entry.irrelevant = j.irrelevant || 0;
-      entry.judge_failed = j.judge_failed || 0;
-      entry.fp_rate = fpRate(entry.relevant, entry.irrelevant);
-    } else if (!entry._hasUps && entry._hasPtu) {
-      // PTU-only memory: not judged in v1.
-      entry.relevant = null;
-      entry.irrelevant = null;
-      entry.fp_rate = null;
-    }
-    // Top-3 most-frequent distinct substrings (deterministic: count desc,
-    // then lexical asc).
-    const subs = fireBuckets[name].subs;
-    entry.sample_matches = Array.from(subs.entries())
-      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-      .slice(0, 3)
-      .map(([s]) => s);
-    delete entry._hasUps;
-    delete entry._hasPtu;
-  }
-  return report;
-}
-
-/**
- * Heuristic R8 — emit advisory when `fp_rate > 0.70` AND `trigger_prompt`
- * contains short (<5 chars) single-word alternation arms. Returns
- * `{memory, candidates}` or `null`. Never auto-applied.
- */
-function suggestTightening(memory, agg) {
-  if (!memory || !agg) return null;
-  if (agg.fp_rate === null || agg.fp_rate === undefined) return null;
-  if (!(agg.fp_rate > 0.7)) return null;
-  const arms = splitTopLevelAlternation(memory.triggerPrompt || '');
-  const candidates = arms.filter((a) => {
-    const trimmed = a.trim();
-    // Spec R8 — "short" arm. Task 5 example (`push|fetch|deploy-production` →
-    // `[push,fetch]`) treats 5-char single-word arms as short, so the bound is
-    // inclusive: length <= 5 with `_`/`-`/alnum chars only (single word).
-    return trimmed.length > 0 && trimmed.length <= 5 && /^[A-Za-z0-9_-]+$/.test(trimmed);
-  });
-  if (candidates.length === 0) return null;
-  return { memory: memory.name, candidates };
-}
-
-/**
- * Render the aggregated report as machine-readable JSON (R9, G6).
- *
- * Stable top-level key order: `memories`, `suggestions`, `events_total`,
- * `events_ups`, `events_ptu`. Each `memories[i]` has keys (in order):
- * `name`, `fires`, `relevant`, `irrelevant`, `judge_failed`, `fp_rate`,
- * `sample_matches`.
- *
- * Spec §Security — `ANTHROPIC_API_KEY` is never included in output; this
- * function only serialises the inputs it is handed (no env access).
- */
-function renderJson(agg, suggestions, meta) {
-  const memories = Object.keys(agg).map((name) => {
-    const m = agg[name];
-    // Explicit key ordering for determinism.
-    return {
-      name,
-      fires: m.fires,
-      relevant: m.relevant,
-      irrelevant: m.irrelevant,
-      judge_failed: m.judge_failed,
-      fp_rate: m.fp_rate,
-      sample_matches: m.sample_matches,
-    };
-  });
-  const payload = {
-    memories,
-    suggestions: Array.isArray(suggestions) ? suggestions : [],
-    events_total: meta && typeof meta.events_total === 'number' ? meta.events_total : 0,
-    events_ups: meta && typeof meta.events_ups === 'number' ? meta.events_ups : 0,
-    events_ptu: meta && typeof meta.events_ptu === 'number' ? meta.events_ptu : 0,
-  };
-  return JSON.stringify(payload, null, 2);
-}
-
-// Cost model constants (R17): ~500 input + 5 output tokens per judge call.
-// Haiku pricing approx $1.00 / 1M input + $5.00 / 1M output tokens.
-const PRICE_PER_TOKEN = 1e-6; // ~$1/1M as a conservative per-token blend.
-const TOKENS_PER_JUDGE_CALL = 500 + 5;
-
-/**
- * Render the human-readable report (R11). Includes:
- *   - header: `store=... window=... events=... UPS=... PTU=...`
- *   - per-memory table rows
- *   - `Suggestions:` section
- *   - cost footer when `meta.judgeCalls > 0` (R17)
- */
-function renderReport(agg, suggestions, meta) {
-  const lines = [];
-  const m = meta || {};
-  lines.push(
-    `store=${m.store || ''} window=${m.window || ''} events=${m.events_total || 0} ` +
-      `UPS=${m.events_ups || 0} PTU=${m.events_ptu || 0}`
-  );
-  lines.push('');
-  lines.push(
-    'Memory'.padEnd(30) +
-      'Fires'.padStart(7) +
-      'Relevant'.padStart(10) +
-      'FP%'.padStart(8) +
-      '  Sample matches'
-  );
-  for (const name of Object.keys(agg)) {
-    const e = agg[name];
-    const relevant = e.relevant === null || e.relevant === undefined ? '—' : String(e.relevant);
-    const fpPct =
-      e.fp_rate === null || e.fp_rate === undefined ? '—' : `${Math.round(e.fp_rate * 100)}%`;
-    const samples = (e.sample_matches || []).slice(0, 3).join(', ');
-    lines.push(
-      name.padEnd(30) +
-        String(e.fires).padStart(7) +
-        relevant.padStart(10) +
-        fpPct.padStart(8) +
-        '  ' +
-        samples
-    );
-  }
-  lines.push('');
-  lines.push('Suggestions:');
-  const sugs = Array.isArray(suggestions) ? suggestions : [];
-  if (sugs.length === 0) {
-    lines.push('  (none)');
-  } else {
-    for (const s of sugs) {
-      lines.push(`  - ${s.memory}: tighten short arms [${(s.candidates || []).join(', ')}]`);
-    }
-  }
-  if (m.judgeCalls && m.judgeCalls > 0) {
-    const cost = TOKENS_PER_JUDGE_CALL * m.judgeCalls * PRICE_PER_TOKEN;
-    lines.push('');
-    lines.push(`est. cost ≈ $${cost.toFixed(4)} (${m.judgeCalls} judge calls)`);
-  }
-  return lines.join('\n') + '\n';
-}
-
-/**
- * Task 7 — judge HTTP integration.
- *
- * `judgeBatch(items, {fetchImpl, apiKey, model})` POSTs a single batch (≤10
- * items per R18) to Anthropic Messages API, parses positional `N: yes/no`
- * replies, and returns per-item `{relevant}` or `{judge_failed:true}`
- * outcomes. Never throws on network/HTTP errors; never leaks `apiKey`
- * into thrown error messages.
- */
-const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
-const JUDGE_BATCH_SIZE = 10; // R18
-const REPLY_LINE_REGEX = /^\s*(\d+)\s*:\s*(yes|no)\b/i;
-
-async function judgeBatch(items, { fetchImpl, apiKey, model } = {}) {
-  const doFetch = fetchImpl || (typeof fetch === 'function' ? fetch : null);
-  if (!doFetch) {
-    return items.map(() => ({ judge_failed: true, error: 'no fetch impl' }));
-  }
-  const numbered = items
-    .map(
-      (it, i) =>
-        `${i + 1}) memory=${it.memory} prompt=${JSON.stringify(it.prompt)} matched=${JSON.stringify(it.matched)}`
-    )
-    .join('\n');
-  const body = JSON.stringify({
-    model,
-    max_tokens: 256,
-    system:
-      'You are a relevance judge for synapsys memories. For each numbered item, decide whether the memory was ACTUALLY RELEVANT to the user prompt shown. Reply with one line per item in the exact form "N: yes" or "N: no" (lowercase, no extra text). Answer "yes" only when the memory would have been useful context for that prompt; otherwise "no". Do not add explanations or any other output.',
-    messages: [{ role: 'user', content: numbered }],
-  });
-  let resp;
-  try {
-    resp = await doFetch(ANTHROPIC_MESSAGES_URL, {
-      method: 'POST',
-      headers: {
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
-        'content-type': 'application/json',
-      },
-      body,
-    });
-  } catch (err) {
-    // Network failure → all items judge-failed; do NOT include apiKey in error.
-    const safe = String(err && err.message ? err.message : err);
-    return items.map(() => ({ judge_failed: true, error: safe }));
-  }
-  if (!resp || !resp.ok) {
-    const status = resp ? resp.status : 'no-response';
-    return items.map(() => ({ judge_failed: true, error: `http ${status}` }));
-  }
-  let payload;
-  try {
-    payload = await resp.json();
-  } catch (err) {
-    return items.map(() => ({ judge_failed: true, error: 'invalid json' }));
-  }
-  const text =
-    (payload &&
-      Array.isArray(payload.content) &&
-      payload.content[0] &&
-      typeof payload.content[0].text === 'string' &&
-      payload.content[0].text) ||
-    '';
-  const verdicts = new Map();
-  for (const line of text.split(/\r?\n/)) {
-    const m = REPLY_LINE_REGEX.exec(line);
-    if (m) verdicts.set(Number(m[1]), m[2].toLowerCase() === 'yes');
-  }
-  return items.map((_, i) => {
-    const v = verdicts.get(i + 1);
-    if (v === undefined) return { judge_failed: true, error: 'missing reply line' };
-    return { relevant: v };
-  });
-}
-
-/**
- * `sampleForCap(items, cap)` — when `items.length > cap`, return `cap`
- * items evenly sampled per `Math.floor(i * fires / cap)` and flag
- * `extrapolated:true`. Otherwise return all items unchanged.
- */
-function sampleForCap(items, cap) {
-  const fires = items.length;
-  if (fires <= cap) return { sampled: items.slice(), extrapolated: false };
-  const sampled = [];
-  for (let i = 0; i < cap; i++) {
-    sampled.push(items[Math.floor((i * fires) / cap)]);
-  }
-  return { sampled, extrapolated: true };
-}
-
-/**
- * `judgePipeline(items, {fetchImpl, apiKey, model, maxJudges})` —
- * applies `sampleForCap` then dispatches `judgeBatch` calls in batches
- * of `JUDGE_BATCH_SIZE` (R18). Honors `--max-judges` as a hard upper
- * bound on judge API calls (G8 / P0 #6).
- */
-async function judgePipeline(items, { fetchImpl, apiKey, model, maxJudges } = {}) {
-  const { sampled, extrapolated } = sampleForCap(items, maxJudges);
-  const results = [];
-  for (let i = 0; i < sampled.length; i += JUDGE_BATCH_SIZE) {
-    const batch = sampled.slice(i, i + JUDGE_BATCH_SIZE);
-    // eslint-disable-next-line no-await-in-loop
-    const batchResults = await judgeBatch(batch, { fetchImpl, apiKey, model });
-    for (let j = 0; j < batch.length; j++) {
-      results.push({ ...batch[j], ...batchResults[j] });
-    }
-  }
-  return { results, extrapolated };
 }
 
 module.exports = {

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -116,8 +116,13 @@ function validateFlags(flags) {
   if (!/^\d+d$/.test(flags.since)) {
     die(`invalid --since=${flags.since} (expected format like 7d, 14d)`);
   }
-  if (flags.project !== undefined && !/^[\w.-]+$/.test(flags.project)) {
-    die(`invalid --project=${flags.project}`);
+  if (flags.project !== undefined) {
+    // Reject path-traversal: `..`, `.`, or any value containing consecutive
+    // dots. The character class `[\w.-]+` alone permits `..` which
+    // `path.join` resolves outside ~/.claude/projects/.
+    if (!/^[\w.-]+$/.test(flags.project) || /\.\./.test(flags.project) || flags.project === '.') {
+      die(`invalid --project=${flags.project}`);
+    }
   }
 }
 

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -124,6 +124,9 @@ function validateFlags(flags) {
       die(`invalid --project=${flags.project}`);
     }
   }
+  if (!Number.isFinite(flags.maxJudges) || flags.maxJudges < 0) {
+    die(`invalid --max-judges=${flags.maxJudges} (expected non-negative integer)`);
+  }
 }
 
 function applyOnlyFilter(memories, onlyFlag) {

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -1,0 +1,656 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * synapsys-replay — replay recent Claude Code transcripts against the
+ * runtime trigger matcher to surface noisy / mis-tuned synapsys memories.
+ *
+ * Task 1 (GH-444) — CLI shell + flag parser only.
+ * Subsequent tasks wire in the walker, matcher integration, judge, and
+ * report renderers. Sibling-owned files (matcher.js, synapsys-explain.js,
+ * GH-443) are NOT imported here yet.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { makeFlag } = require('../lib/cli-args');
+const matcher = require('../lib/matcher');
+const memoryStore = require('../lib/memory-store');
+
+/**
+ * Pure flag parser — no I/O, no process exits. Tests call this directly
+ * with a synthetic argv array. The main() entrypoint is responsible for
+ * validation + side effects.
+ *
+ * Recognised R10 flags (all optional):
+ *   --since=<Nd>        transcript window (default '7d')
+ *   --project=<hash>    restrict to a single ~/.claude/projects/<hash>
+ *   --no-judge          skip LLM judge calls; produce null relevance
+ *   --json              emit machine-readable JSON to stdout
+ *   --only=<csv>        comma-separated memory-name filter
+ *   --store=<name|path> store selector (auto-detect like synapsys-explain)
+ *   --max-judges=<N>    hard cap on judge API calls (default 200)
+ */
+function parseFlags(argv) {
+  const flag = makeFlag(argv);
+  const sinceRaw = flag('since');
+  const maxJudgesRaw = flag('max-judges');
+  return {
+    // Window string ('7d', '14d', ...); parsed into ms by walkTranscripts (Task 3).
+    since: sinceRaw === undefined || sinceRaw === true ? '7d' : sinceRaw,
+    // Optional project-hash filter; undefined → iterate every project (spec §Decision).
+    project: typeof flag('project') === 'string' ? flag('project') : undefined,
+    // Skip judge entirely; required when ANTHROPIC_API_KEY is absent.
+    noJudge: flag('no-judge') === true,
+    // Emit JSON to stdout instead of human-readable report.
+    json: flag('json') === true,
+    // Memory-name allow-list (comma-separated); applied at memory-load.
+    only: typeof flag('only') === 'string' ? flag('only') : undefined,
+    // Store selector — name or filesystem path; auto-detect like explain.
+    store: typeof flag('store') === 'string' ? flag('store') : undefined,
+    // Hard upper bound on judge API calls; over-cap triggers even sampling.
+    maxJudges:
+      maxJudgesRaw === undefined || maxJudgesRaw === true ? 200 : Number(maxJudgesRaw),
+  };
+}
+
+/**
+ * Print message to stderr and exit with the given code. Default code 2 per
+ * spec §CLI: exit 2 on misconfig (unknown --store, invalid --since/--project).
+ */
+function die(msg, code = 2) {
+  process.stderr.write(`synapsys-replay: ${msg}\n`);
+  process.exit(code);
+}
+
+/**
+ * No-op main for Task 1 — validates --since, then echoes parsed flags as
+ * JSON to stdout so spawn-script tests can assert flag round-tripping.
+ * Subsequent tasks replace the echo with the real pipeline.
+ */
+function main(argv) {
+  const flags = parseFlags(argv);
+  if (!/^\d+d$/.test(flags.since)) {
+    die(`invalid --since=${flags.since} (expected format like 7d, 14d)`);
+  }
+  process.stdout.write(JSON.stringify(flags) + '\n');
+  process.exit(0);
+}
+
+/**
+ * Pure transcript → synthetic-event mapper (Task 2, R2, G1+G2).
+ *
+ * Claude Code records each turn as a JSONL entry. We synthesize the same
+ * event payloads the runtime trigger matcher consumes:
+ *
+ *   - `type=user`        → `{event:'UserPromptSubmit', prompt}`
+ *     `message.content` is either a plain string or an array of content
+ *     blocks (we concatenate `type=text` blocks' `text` fields).
+ *
+ *   - `type=assistant`   → one `{event:'PreToolUse', tool, tool_input}`
+ *     per `tool_use` content block (the assistant may emit multiple tool
+ *     calls per turn; each becomes its own PTU event).
+ *
+ *   - anything else (system, summary, malformed) → `[]`
+ *
+ * Pure function: no I/O, no globals. Inputs and outputs are plain data.
+ */
+function extractEvents(parsedLine) {
+  if (!parsedLine || typeof parsedLine !== 'object') return [];
+  const { type, message } = parsedLine;
+
+  if (type === 'user') {
+    if (!message || message.content === undefined || message.content === null) return [];
+    const content = message.content;
+    if (typeof content === 'string') {
+      return [{ event: 'UserPromptSubmit', prompt: content }];
+    }
+    if (Array.isArray(content)) {
+      const prompt = content
+        .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+        .map((b) => b.text)
+        .join('');
+      if (prompt.length === 0) return [];
+      return [{ event: 'UserPromptSubmit', prompt }];
+    }
+    return [];
+  }
+
+  if (type === 'assistant') {
+    if (!message || !Array.isArray(message.content)) return [];
+    return message.content
+      .filter((b) => b && b.type === 'tool_use' && typeof b.name === 'string')
+      .map((b) => ({
+        event: 'PreToolUse',
+        tool: b.name,
+        tool_input: b.input,
+      }));
+  }
+
+  return [];
+}
+
+/**
+ * Convert a `--since=Nd` window string into milliseconds.
+ *
+ * Task 3 (R1). Throws on invalid format; main()/die() handles user-facing
+ * error reporting per spec §CLI (exit code 2 on misconfig).
+ */
+function parseSince(spec) {
+  if (typeof spec !== 'string' || !/^\d+d$/.test(spec)) {
+    throw new Error(`invalid --since=${spec} (expected format like 7d, 14d)`);
+  }
+  const days = Number(spec.slice(0, -1));
+  return days * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Walk `*.jsonl` transcripts under `baseDir` (default `~/.claude/projects/`)
+ * whose mtime falls within the `--since` window. When `project` is provided,
+ * only that hash-dir is searched. Missing/empty directories return `[]`
+ * (R12 walker-level no-transcripts detection).
+ *
+ * Injectable `baseDir` keeps tests off the real `~/.claude/projects/` and
+ * avoids fs monkey-patching.
+ */
+function walkTranscripts({ since, project, baseDir } = {}) {
+  const root = baseDir || path.join(os.homedir(), '.claude/projects');
+  if (!fs.existsSync(root)) return [];
+  const windowMs = parseSince(since || '7d');
+  const cutoff = Date.now() - windowMs;
+
+  let projectDirs;
+  if (project) {
+    const dir = path.join(root, project);
+    if (!fs.existsSync(dir)) return [];
+    projectDirs = [dir];
+  } else {
+    projectDirs = fs
+      .readdirSync(root, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => path.join(root, d.name));
+  }
+
+  const out = [];
+  for (const projDir of projectDirs) {
+    let entries;
+    try {
+      entries = fs.readdirSync(projDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
+      const full = path.join(projDir, entry.name);
+      let stat;
+      try {
+        stat = fs.statSync(full);
+      } catch {
+        continue;
+      }
+      if (stat.mtimeMs >= cutoff) out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Stream-parse a JSONL transcript file. Yields one parsed object per
+ * non-empty line; malformed lines emit a single stderr warning and are
+ * skipped (R1). Returned as an iterable array — the file is read
+ * synchronously since transcripts are bounded and small per spec §Perf.
+ */
+function* iterLines(filePath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    process.stderr.write(`synapsys-replay: cannot read ${filePath}: ${err.message}\n`);
+    return;
+  }
+  const lines = raw.split('\n');
+  for (const line of lines) {
+    if (line.length === 0) continue;
+    try {
+      yield JSON.parse(line);
+    } catch (err) {
+      process.stderr.write(
+        `synapsys-replay: malformed JSONL line in ${filePath} (skipped): ${err.message}\n`
+      );
+    }
+  }
+}
+
+/**
+ * Replay a synthetic event against every memory and return one tuple per
+ * memory: `{memory_name, event, fired, matched_substring}`. Task 4 (R3, G3).
+ *
+ * Dispatch:
+ *   - `event.event === 'UserPromptSubmit'` → `matcher.matchPrompt(memory, event.prompt)`
+ *   - `event.event === 'PreToolUse'`       → `matcher.matchPreTool(memory, {tool_name, tool_input})`
+ *
+ * Per GH-443 `MatchResult` schema, on fire the matcher returns
+ * `{fired: true, matched: {...}}`. Consumed fields for `matched_substring`:
+ *   - `matched.prompt_substring`  (UPS, see matcher.matchPrompt)
+ *   - `matched.content_substring` (PTU with content patterns, see matcher.matchPreTool)
+ * Other `matched` fields (`prompt_token`, `pretool_pattern`, `content_pattern`,
+ * `negative_pattern`) are NOT consumed by replay; they are used by explain/R16.
+ */
+function replayEvent(memories, event) {
+  const out = [];
+  for (const memory of memories) {
+    const result = dispatchMatch(memory, event);
+    const matched = result && result.matched ? result.matched : undefined;
+    const matched_substring = matched
+      ? matched.prompt_substring !== undefined
+        ? matched.prompt_substring
+        : matched.content_substring
+      : undefined;
+    out.push({
+      memory_name: memory.name,
+      event: event.event,
+      fired: Boolean(result && result.fired),
+      matched_substring,
+    });
+  }
+  return out;
+}
+
+function dispatchMatch(memory, event) {
+  if (event.event === 'UserPromptSubmit') {
+    return matcher.matchPrompt(memory, event.prompt || '');
+  }
+  if (event.event === 'PreToolUse') {
+    return matcher.matchPreTool(memory, {
+      tool_name: event.tool,
+      tool_input: event.tool_input,
+    });
+  }
+  return { fired: false, reason: 'events-exclude' };
+}
+
+/**
+ * Resolve `--store` flag against `discoverStores(cwd)` (memory-store.js).
+ * Mirrors the selector logic in scripts/synapsys-explain.js (sibling-owned,
+ * GH-443) — we re-derive locally rather than importing to keep the script
+ * boundary clean.
+ *
+ *   - storeFlag undefined/empty → return every discovered store
+ *   - storeFlag matches a `kind` (local/worktree/global/shared) → filter
+ *   - storeFlag is a path → resolve absolute and match by dir
+ *   - no match → die() exit 2 (spec §CLI)
+ */
+function loadStore({ storeFlag, cwd } = {}) {
+  const resolvedCwd = cwd || process.cwd();
+  const stores = memoryStore.discoverStores(resolvedCwd);
+  if (!storeFlag || storeFlag === true) return stores;
+  const byKind = stores.filter((s) => s.kind === storeFlag);
+  if (byKind.length) return byKind;
+  const abs = path.resolve(storeFlag);
+  const byPath = stores.filter((s) => path.resolve(s.dir) === abs);
+  if (byPath.length) return byPath;
+  die(`unknown --store "${storeFlag}" (no matching discovered store)`, 2);
+}
+
+/**
+ * Load all memories from a list of discovered stores by delegating to
+ * memory-store.listMemoriesFromStore (single source of truth for frontmatter
+ * parsing — never re-implemented here).
+ */
+function loadMemories(stores) {
+  const all = [];
+  for (const s of stores) {
+    all.push(...memoryStore.listMemoriesFromStore(s));
+  }
+  return all;
+}
+
+/**
+ * Split `trigger_prompt` on top-level `|` only (outside `(...)` / `[...]`).
+ * Used by suggestTightening to inspect alternation arms for heuristic R8.
+ * Vendored locally per spec §Arch — not exported from matcher.
+ */
+function splitTopLevelAlternation(triggerPrompt) {
+  if (typeof triggerPrompt !== 'string' || triggerPrompt.length === 0) return [];
+  const arms = [];
+  let depthParen = 0;
+  let depthBracket = 0;
+  let buf = '';
+  for (let i = 0; i < triggerPrompt.length; i++) {
+    const ch = triggerPrompt[i];
+    if (ch === '(') depthParen++;
+    else if (ch === ')') depthParen = Math.max(0, depthParen - 1);
+    else if (ch === '[') depthBracket++;
+    else if (ch === ']') depthBracket = Math.max(0, depthBracket - 1);
+    if (ch === '|' && depthParen === 0 && depthBracket === 0) {
+      arms.push(buf);
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  arms.push(buf);
+  return arms;
+}
+
+/**
+ * fp_rate = 1 - relevant / (relevant + irrelevant). judge_failed excluded.
+ */
+function fpRate(relevant, irrelevant) {
+  const denom = relevant + irrelevant;
+  if (denom <= 0) return null;
+  return 1 - relevant / denom;
+}
+
+/**
+ * Aggregate per-memory metrics from replay tuples + judge results.
+ *
+ * `tuples` — output of replayEvent across the event stream:
+ *   `{memory_name, event, fired, matched_substring}`
+ * `judgments` — keyed by memory_name (UPS memories only):
+ *   `{relevant, irrelevant, judge_failed}` counts
+ *
+ * Returns object keyed by memory_name:
+ *   `{fires, relevant, irrelevant, judge_failed, fp_rate, sample_matches}`
+ *
+ * PTU-only memories (any fired tuple has event PreToolUse and no UPS fires)
+ * report `relevant=null` / `fp_rate=null` (spec §Decision — PTU not judged v1).
+ * `sample_matches` is the top-3 most-frequent distinct matched substrings.
+ */
+function aggregateReport(tuples, judgments) {
+  const report = {};
+  const fireBuckets = {};
+  for (const t of tuples) {
+    if (!report[t.memory_name]) {
+      report[t.memory_name] = {
+        fires: 0,
+        relevant: 0,
+        irrelevant: 0,
+        judge_failed: 0,
+        fp_rate: null,
+        sample_matches: [],
+        _hasUps: false,
+        _hasPtu: false,
+      };
+      fireBuckets[t.memory_name] = { events: new Set(), subs: new Map() };
+    }
+    if (t.fired) {
+      report[t.memory_name].fires += 1;
+      fireBuckets[t.memory_name].events.add(t.event);
+      if (t.event === 'UserPromptSubmit') report[t.memory_name]._hasUps = true;
+      if (t.event === 'PreToolUse') report[t.memory_name]._hasPtu = true;
+      if (t.matched_substring) {
+        const m = fireBuckets[t.memory_name].subs;
+        m.set(t.matched_substring, (m.get(t.matched_substring) || 0) + 1);
+      }
+    }
+  }
+  for (const name of Object.keys(report)) {
+    const entry = report[name];
+    const j = judgments && judgments[name];
+    if (j && entry._hasUps) {
+      entry.relevant = j.relevant || 0;
+      entry.irrelevant = j.irrelevant || 0;
+      entry.judge_failed = j.judge_failed || 0;
+      entry.fp_rate = fpRate(entry.relevant, entry.irrelevant);
+    } else if (!entry._hasUps && entry._hasPtu) {
+      // PTU-only memory: not judged in v1.
+      entry.relevant = null;
+      entry.irrelevant = null;
+      entry.fp_rate = null;
+    }
+    // Top-3 most-frequent distinct substrings (deterministic: count desc,
+    // then lexical asc).
+    const subs = fireBuckets[name].subs;
+    entry.sample_matches = Array.from(subs.entries())
+      .sort((a, b) => (b[1] - a[1]) || a[0].localeCompare(b[0]))
+      .slice(0, 3)
+      .map(([s]) => s);
+    delete entry._hasUps;
+    delete entry._hasPtu;
+  }
+  return report;
+}
+
+/**
+ * Heuristic R8 — emit advisory when `fp_rate > 0.70` AND `trigger_prompt`
+ * contains short (<5 chars) single-word alternation arms. Returns
+ * `{memory, candidates}` or `null`. Never auto-applied.
+ */
+function suggestTightening(memory, agg) {
+  if (!memory || !agg) return null;
+  if (agg.fp_rate === null || agg.fp_rate === undefined) return null;
+  if (!(agg.fp_rate > 0.70)) return null;
+  const arms = splitTopLevelAlternation(memory.triggerPrompt || '');
+  const candidates = arms.filter((a) => {
+    const trimmed = a.trim();
+    // Spec R8 — "short" arm. Task 5 example (`push|fetch|deploy-production` →
+    // `[push,fetch]`) treats 5-char single-word arms as short, so the bound is
+    // inclusive: length <= 5 with `_`/`-`/alnum chars only (single word).
+    return trimmed.length > 0 && trimmed.length <= 5 && /^[A-Za-z0-9_-]+$/.test(trimmed);
+  });
+  if (candidates.length === 0) return null;
+  return { memory: memory.name, candidates };
+}
+
+/**
+ * Render the aggregated report as machine-readable JSON (R9, G6).
+ *
+ * Stable top-level key order: `memories`, `suggestions`, `events_total`,
+ * `events_ups`, `events_ptu`. Each `memories[i]` has keys (in order):
+ * `name`, `fires`, `relevant`, `irrelevant`, `judge_failed`, `fp_rate`,
+ * `sample_matches`.
+ *
+ * Spec §Security — `ANTHROPIC_API_KEY` is never included in output; this
+ * function only serialises the inputs it is handed (no env access).
+ */
+function renderJson(agg, suggestions, meta) {
+  const memories = Object.keys(agg).map((name) => {
+    const m = agg[name];
+    // Explicit key ordering for determinism.
+    return {
+      name,
+      fires: m.fires,
+      relevant: m.relevant,
+      irrelevant: m.irrelevant,
+      judge_failed: m.judge_failed,
+      fp_rate: m.fp_rate,
+      sample_matches: m.sample_matches,
+    };
+  });
+  const payload = {
+    memories,
+    suggestions: Array.isArray(suggestions) ? suggestions : [],
+    events_total: meta && typeof meta.events_total === 'number' ? meta.events_total : 0,
+    events_ups: meta && typeof meta.events_ups === 'number' ? meta.events_ups : 0,
+    events_ptu: meta && typeof meta.events_ptu === 'number' ? meta.events_ptu : 0,
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+// Cost model constants (R17): ~500 input + 5 output tokens per judge call.
+// Haiku pricing approx $1.00 / 1M input + $5.00 / 1M output tokens.
+const PRICE_PER_TOKEN = 1e-6; // ~$1/1M as a conservative per-token blend.
+const TOKENS_PER_JUDGE_CALL = 500 + 5;
+
+/**
+ * Render the human-readable report (R11). Includes:
+ *   - header: `store=... window=... events=... UPS=... PTU=...`
+ *   - per-memory table rows
+ *   - `Suggestions:` section
+ *   - cost footer when `meta.judgeCalls > 0` (R17)
+ */
+function renderReport(agg, suggestions, meta) {
+  const lines = [];
+  const m = meta || {};
+  lines.push(
+    `store=${m.store || ''} window=${m.window || ''} events=${m.events_total || 0} ` +
+      `UPS=${m.events_ups || 0} PTU=${m.events_ptu || 0}`
+  );
+  lines.push('');
+  lines.push('Memory'.padEnd(30) + 'Fires'.padStart(7) + 'Relevant'.padStart(10) + 'FP%'.padStart(8) + '  Sample matches');
+  for (const name of Object.keys(agg)) {
+    const e = agg[name];
+    const relevant = e.relevant === null || e.relevant === undefined ? '—' : String(e.relevant);
+    const fpPct = e.fp_rate === null || e.fp_rate === undefined
+      ? '—'
+      : `${Math.round(e.fp_rate * 100)}%`;
+    const samples = (e.sample_matches || []).slice(0, 3).join(', ');
+    lines.push(
+      name.padEnd(30) +
+        String(e.fires).padStart(7) +
+        relevant.padStart(10) +
+        fpPct.padStart(8) +
+        '  ' +
+        samples
+    );
+  }
+  lines.push('');
+  lines.push('Suggestions:');
+  const sugs = Array.isArray(suggestions) ? suggestions : [];
+  if (sugs.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const s of sugs) {
+      lines.push(`  - ${s.memory}: tighten short arms [${(s.candidates || []).join(', ')}]`);
+    }
+  }
+  if (m.judgeCalls && m.judgeCalls > 0) {
+    const cost = TOKENS_PER_JUDGE_CALL * m.judgeCalls * PRICE_PER_TOKEN;
+    lines.push('');
+    lines.push(`est. cost ≈ $${cost.toFixed(4)} (${m.judgeCalls} judge calls)`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Task 7 — judge HTTP integration.
+ *
+ * `judgeBatch(items, {fetchImpl, apiKey, model})` POSTs a single batch (≤10
+ * items per R18) to Anthropic Messages API, parses positional `N: yes/no`
+ * replies, and returns per-item `{relevant}` or `{judge_failed:true}`
+ * outcomes. Never throws on network/HTTP errors; never leaks `apiKey`
+ * into thrown error messages.
+ */
+const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
+const JUDGE_BATCH_SIZE = 10; // R18
+const REPLY_LINE_REGEX = /^\s*(\d+)\s*:\s*(yes|no)\b/i;
+
+async function judgeBatch(items, { fetchImpl, apiKey, model } = {}) {
+  const doFetch = fetchImpl || (typeof fetch === 'function' ? fetch : null);
+  if (!doFetch) {
+    return items.map(() => ({ judge_failed: true, error: 'no fetch impl' }));
+  }
+  const numbered = items
+    .map((it, i) => `${i + 1}) memory=${it.memory} prompt=${JSON.stringify(it.prompt)} matched=${JSON.stringify(it.matched)}`)
+    .join('\n');
+  const body = JSON.stringify({
+    model,
+    max_tokens: 256,
+    messages: [{ role: 'user', content: numbered }],
+  });
+  let resp;
+  try {
+    resp = await doFetch(ANTHROPIC_MESSAGES_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body,
+    });
+  } catch (err) {
+    // Network failure → all items judge-failed; do NOT include apiKey in error.
+    const safe = String(err && err.message ? err.message : err);
+    return items.map(() => ({ judge_failed: true, error: safe }));
+  }
+  if (!resp || !resp.ok) {
+    const status = resp ? resp.status : 'no-response';
+    return items.map(() => ({ judge_failed: true, error: `http ${status}` }));
+  }
+  let payload;
+  try {
+    payload = await resp.json();
+  } catch (err) {
+    return items.map(() => ({ judge_failed: true, error: 'invalid json' }));
+  }
+  const text =
+    (payload &&
+      Array.isArray(payload.content) &&
+      payload.content[0] &&
+      typeof payload.content[0].text === 'string' &&
+      payload.content[0].text) ||
+    '';
+  const verdicts = new Map();
+  for (const line of text.split(/\r?\n/)) {
+    const m = REPLY_LINE_REGEX.exec(line);
+    if (m) verdicts.set(Number(m[1]), m[2].toLowerCase() === 'yes');
+  }
+  return items.map((_, i) => {
+    const v = verdicts.get(i + 1);
+    if (v === undefined) return { judge_failed: true, error: 'missing reply line' };
+    return { relevant: v };
+  });
+}
+
+/**
+ * `sampleForCap(items, cap)` — when `items.length > cap`, return `cap`
+ * items evenly sampled per `Math.floor(i * fires / cap)` and flag
+ * `extrapolated:true`. Otherwise return all items unchanged.
+ */
+function sampleForCap(items, cap) {
+  const fires = items.length;
+  if (fires <= cap) return { sampled: items.slice(), extrapolated: false };
+  const sampled = [];
+  for (let i = 0; i < cap; i++) {
+    sampled.push(items[Math.floor((i * fires) / cap)]);
+  }
+  return { sampled, extrapolated: true };
+}
+
+/**
+ * `judgePipeline(items, {fetchImpl, apiKey, model, maxJudges})` —
+ * applies `sampleForCap` then dispatches `judgeBatch` calls in batches
+ * of `JUDGE_BATCH_SIZE` (R18). Honors `--max-judges` as a hard upper
+ * bound on judge API calls (G8 / P0 #6).
+ */
+async function judgePipeline(items, { fetchImpl, apiKey, model, maxJudges } = {}) {
+  const { sampled, extrapolated } = sampleForCap(items, maxJudges);
+  const results = [];
+  for (let i = 0; i < sampled.length; i += JUDGE_BATCH_SIZE) {
+    const batch = sampled.slice(i, i + JUDGE_BATCH_SIZE);
+    // eslint-disable-next-line no-await-in-loop
+    const batchResults = await judgeBatch(batch, { fetchImpl, apiKey, model });
+    for (let j = 0; j < batch.length; j++) {
+      results.push({ ...batch[j], ...batchResults[j] });
+    }
+  }
+  return { results, extrapolated };
+}
+
+module.exports = {
+  parseFlags,
+  die,
+  extractEvents,
+  parseSince,
+  walkTranscripts,
+  iterLines,
+  replayEvent,
+  loadStore,
+  loadMemories,
+  splitTopLevelAlternation,
+  aggregateReport,
+  suggestTightening,
+  fpRate,
+  renderJson,
+  renderReport,
+  judgeBatch,
+  sampleForCap,
+  judgePipeline,
+};
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -124,8 +124,8 @@ function validateFlags(flags) {
       die(`invalid --project=${flags.project}`);
     }
   }
-  if (!Number.isFinite(flags.maxJudges) || flags.maxJudges < 0) {
-    die(`invalid --max-judges=${flags.maxJudges} (expected non-negative integer)`);
+  if (!Number.isInteger(flags.maxJudges) || flags.maxJudges < 1) {
+    die(`invalid --max-judges=${flags.maxJudges} (expected positive integer)`);
   }
 }
 
@@ -271,9 +271,14 @@ async function main(argv) {
         `${JSON.stringify({
           memories: [],
           suggestions: [],
+          store: stores.map((s) => s.dir).join(','),
+          window: flags.since,
           events_total: 0,
           events_ups: 0,
           events_ptu: 0,
+          judge_calls: 0,
+          items_judged: 0,
+          extrapolated: false,
           message: 'no transcripts in window',
         })}\n`
       );

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -137,6 +137,13 @@ function applyOnlyFilter(memories, onlyFlag) {
       .map((s) => s.trim())
       .filter(Boolean)
   );
+  const known = new Set(memories.map((m) => m.name));
+  const unknown = [...allow].filter((n) => !known.has(n));
+  if (unknown.length > 0) {
+    process.stderr.write(
+      `synapsys-replay: --only references unknown memory name(s): ${unknown.join(', ')}\n`
+    );
+  }
   return memories.filter((m) => allow.has(m.name));
 }
 
@@ -176,10 +183,16 @@ function tallyJudgmentResult(judgments, r) {
   else if (r.relevant === false) judgments[r.memory].irrelevant += 1;
 }
 
-async function runJudgePhase(tuples, flags, apiKey) {
+async function runJudgePhase(tuples, flags, apiKey, memories) {
+  const bodyByName = new Map((memories || []).map((m) => [m.name, (m.body || '').slice(0, 200)]));
   const items = tuples
     .filter((t) => t.fired && t.event === 'UserPromptSubmit')
-    .map((t) => ({ memory: t.memory_name, prompt: t.prompt, matched: t.matched_substring }));
+    .map((t) => ({
+      memory: t.memory_name,
+      body: bodyByName.get(t.memory_name) || '',
+      prompt: t.prompt,
+      matched: t.matched_substring,
+    }));
   const pipeline = await judgePipeline(items, {
     apiKey,
     model: 'claude-haiku-4-5',
@@ -279,7 +292,8 @@ async function main(argv) {
     ({ judgments, judgeCalls, itemsJudged, extrapolated } = await runJudgePhase(
       tuples,
       flags,
-      apiKey
+      apiKey,
+      memories
     ));
   }
 

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -705,6 +705,8 @@ async function judgeBatch(items, { fetchImpl, apiKey, model } = {}) {
   const body = JSON.stringify({
     model,
     max_tokens: 256,
+    system:
+      'You are a relevance judge for synapsys memories. For each numbered item, decide whether the memory was ACTUALLY RELEVANT to the user prompt shown. Reply with one line per item in the exact form "N: yes" or "N: no" (lowercase, no extra text). Answer "yes" only when the memory would have been useful context for that prompt; otherwise "no". Do not add explanations or any other output.',
     messages: [{ role: 'user', content: numbered }],
   });
   let resp;

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -50,8 +50,10 @@ function parseFlags(argv) {
     // Store selector — name or filesystem path; auto-detect like explain.
     store: typeof flag('store') === 'string' ? flag('store') : undefined,
     // Hard upper bound on judge API calls; over-cap triggers even sampling.
-    maxJudges:
-      maxJudgesRaw === undefined || maxJudgesRaw === true ? 200 : Number(maxJudgesRaw),
+    maxJudges: maxJudgesRaw === undefined || maxJudgesRaw === true ? 200 : Number(maxJudgesRaw),
+    // Test-only override (Task 8): direct ~/.claude/projects/ to a tmp dir.
+    transcriptsBase:
+      typeof flag('transcripts-base') === 'string' ? flag('transcripts-base') : undefined,
   };
 }
 
@@ -65,16 +67,157 @@ function die(msg, code = 2) {
 }
 
 /**
- * No-op main for Task 1 — validates --since, then echoes parsed flags as
- * JSON to stdout so spawn-script tests can assert flag round-tripping.
- * Subsequent tasks replace the echo with the real pipeline.
+ * Centralised judge gate (Task 8 REFACTOR target — exported for tests if
+ * needed later). Returns true only when judging is allowed AND warranted:
+ *   - `--no-judge` not set
+ *   - `ANTHROPIC_API_KEY` present
+ *   - at least one UPS fire to judge (PTU is not judged in v1, spec §Decision)
  */
-function main(argv) {
+function shouldJudge({ noJudge, apiKey, upsFires }) {
+  if (noJudge) return false;
+  if (!apiKey) return false;
+  if (!upsFires || upsFires <= 0) return false;
+  return true;
+}
+
+/**
+ * Wired main() (Task 8). Pipeline:
+ *   parseFlags → validate → loadStore → loadMemories (apply --only)
+ *   → walkTranscripts → iterLines → extractEvents → replayEvent
+ *   → (optional) judgePipeline → aggregateReport → suggestTightening
+ *   → renderReport / renderJson → exit
+ *
+ * Validation precedes I/O so `--since`/`--store` misconfigs exit 2 before
+ * any filesystem or network touches (spec §CLI). No-transcripts window is
+ * handled before the judge step and prints a friendly message (R12 / G10).
+ * Missing `ANTHROPIC_API_KEY` without `--no-judge` emits a single stderr
+ * notice and proceeds as `--no-judge` (spec §Security / AC5).
+ */
+async function main(argv) {
   const flags = parseFlags(argv);
+
+  // Validation (BEFORE any I/O — spec §CLI exit 2).
   if (!/^\d+d$/.test(flags.since)) {
     die(`invalid --since=${flags.since} (expected format like 7d, 14d)`);
   }
-  process.stdout.write(JSON.stringify(flags) + '\n');
+  if (flags.project !== undefined && !/^[\w.-]+$/.test(flags.project)) {
+    die(`invalid --project=${flags.project}`);
+  }
+
+  // Resolve store(s) and load memories. loadStore may die() on unknown store.
+  const stores = loadStore({ storeFlag: flags.store, cwd: process.cwd() });
+  let memories = loadMemories(stores);
+  if (flags.only) {
+    const allow = new Set(
+      flags.only
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    );
+    memories = memories.filter((m) => allow.has(m.name));
+  }
+
+  // Walk transcripts. Honor --transcripts-base override for hermetic tests.
+  const files = walkTranscripts({
+    since: flags.since,
+    project: flags.project,
+    baseDir: flags.transcriptsBase,
+  });
+
+  // R12 / G10 — no-transcripts case: friendly stdout, clean stderr, exit 0.
+  if (files.length === 0) {
+    process.stdout.write('no transcripts in window\n');
+    process.exit(0);
+  }
+
+  // Stream events through the matcher.
+  const tuples = [];
+  let eventsTotal = 0;
+  let eventsUps = 0;
+  let eventsPtu = 0;
+  for (const file of files) {
+    for (const parsed of iterLines(file)) {
+      const events = extractEvents(parsed);
+      for (const ev of events) {
+        eventsTotal += 1;
+        if (ev.event === 'UserPromptSubmit') eventsUps += 1;
+        else if (ev.event === 'PreToolUse') eventsPtu += 1;
+        const evTuples = replayEvent(memories, ev);
+        for (const t of evTuples) {
+          // Preserve prompt text on fires for judge prompt construction.
+          if (t.fired && ev.event === 'UserPromptSubmit') t.prompt = ev.prompt;
+          tuples.push(t);
+        }
+      }
+    }
+  }
+
+  // Judge decision. Missing key + !noJudge → stderr notice + treat as no-judge.
+  const apiKey = process.env.ANTHROPIC_API_KEY || '';
+  const upsFires = tuples.filter((t) => t.fired && t.event === 'UserPromptSubmit').length;
+  if (!flags.noJudge && !apiKey) {
+    process.stderr.write('synapsys-replay: ANTHROPIC_API_KEY not set; proceeding as --no-judge\n');
+  }
+  const judging = shouldJudge({ noJudge: flags.noJudge, apiKey, upsFires });
+
+  let judgments;
+  let judgeCalls = 0;
+  let extrapolated = false;
+  if (judging) {
+    const items = tuples
+      .filter((t) => t.fired && t.event === 'UserPromptSubmit')
+      .map((t) => ({ memory: t.memory_name, prompt: t.prompt, matched: t.matched_substring }));
+    const pipeline = await judgePipeline(items, {
+      apiKey,
+      model: 'claude-haiku-4-5',
+      maxJudges: flags.maxJudges,
+    });
+    extrapolated = pipeline.extrapolated;
+    judgeCalls = Math.ceil(pipeline.results.length / JUDGE_BATCH_SIZE);
+    judgments = {};
+    for (const r of pipeline.results) {
+      if (!judgments[r.memory]) {
+        judgments[r.memory] = { relevant: 0, irrelevant: 0, judge_failed: 0 };
+      }
+      if (r.judge_failed) judgments[r.memory].judge_failed += 1;
+      else if (r.relevant === true) judgments[r.memory].relevant += 1;
+      else if (r.relevant === false) judgments[r.memory].irrelevant += 1;
+    }
+  }
+
+  // Aggregate + suggest.
+  const agg = aggregateReport(tuples, judgments);
+  // When the judge did not run, every memory's relevance is unknown — null
+  // out the bookkeeping fields so the JSON / report communicate that clearly
+  // (AC5 / R4). aggregateReport itself stays test-stable for Task 5.
+  if (!judging) {
+    for (const name of Object.keys(agg)) {
+      agg[name].relevant = null;
+      agg[name].irrelevant = null;
+      agg[name].fp_rate = null;
+    }
+  }
+  const suggestions = [];
+  for (const memory of memories) {
+    const sug = suggestTightening(memory, agg[memory.name]);
+    if (sug) suggestions.push(sug);
+  }
+
+  // Render.
+  const meta = {
+    store: stores.map((s) => s.dir).join(','),
+    window: flags.since,
+    events_total: eventsTotal,
+    events_ups: eventsUps,
+    events_ptu: eventsPtu,
+    judgeCalls,
+    extrapolated,
+  };
+  if (flags.json) {
+    process.stdout.write(renderJson(agg, suggestions, meta) + '\n');
+  } else {
+    process.stdout.write(renderReport(agg, suggestions, meta));
+  }
   process.exit(0);
 }
 
@@ -290,6 +433,12 @@ function loadStore({ storeFlag, cwd } = {}) {
   const abs = path.resolve(storeFlag);
   const byPath = stores.filter((s) => path.resolve(s.dir) === abs);
   if (byPath.length) return byPath;
+  // Path-form fallback: if the absolute path carries the store marker, accept
+  // it even when it lives outside discoverStores() reach. Lets callers point
+  // at a hermetic test store under /tmp (Task 8 fixtures).
+  if (fs.existsSync(path.join(abs, '.synapsys.json'))) {
+    return [{ kind: 'path', dir: abs, projectName: path.basename(abs) }];
+  }
   die(`unknown --store "${storeFlag}" (no matching discovered store)`, 2);
 }
 
@@ -404,7 +553,7 @@ function aggregateReport(tuples, judgments) {
     // then lexical asc).
     const subs = fireBuckets[name].subs;
     entry.sample_matches = Array.from(subs.entries())
-      .sort((a, b) => (b[1] - a[1]) || a[0].localeCompare(b[0]))
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
       .slice(0, 3)
       .map(([s]) => s);
     delete entry._hasUps;
@@ -421,7 +570,7 @@ function aggregateReport(tuples, judgments) {
 function suggestTightening(memory, agg) {
   if (!memory || !agg) return null;
   if (agg.fp_rate === null || agg.fp_rate === undefined) return null;
-  if (!(agg.fp_rate > 0.70)) return null;
+  if (!(agg.fp_rate > 0.7)) return null;
   const arms = splitTopLevelAlternation(memory.triggerPrompt || '');
   const candidates = arms.filter((a) => {
     const trimmed = a.trim();
@@ -489,13 +638,18 @@ function renderReport(agg, suggestions, meta) {
       `UPS=${m.events_ups || 0} PTU=${m.events_ptu || 0}`
   );
   lines.push('');
-  lines.push('Memory'.padEnd(30) + 'Fires'.padStart(7) + 'Relevant'.padStart(10) + 'FP%'.padStart(8) + '  Sample matches');
+  lines.push(
+    'Memory'.padEnd(30) +
+      'Fires'.padStart(7) +
+      'Relevant'.padStart(10) +
+      'FP%'.padStart(8) +
+      '  Sample matches'
+  );
   for (const name of Object.keys(agg)) {
     const e = agg[name];
     const relevant = e.relevant === null || e.relevant === undefined ? '—' : String(e.relevant);
-    const fpPct = e.fp_rate === null || e.fp_rate === undefined
-      ? '—'
-      : `${Math.round(e.fp_rate * 100)}%`;
+    const fpPct =
+      e.fp_rate === null || e.fp_rate === undefined ? '—' : `${Math.round(e.fp_rate * 100)}%`;
     const samples = (e.sample_matches || []).slice(0, 3).join(', ');
     lines.push(
       name.padEnd(30) +
@@ -543,7 +697,10 @@ async function judgeBatch(items, { fetchImpl, apiKey, model } = {}) {
     return items.map(() => ({ judge_failed: true, error: 'no fetch impl' }));
   }
   const numbered = items
-    .map((it, i) => `${i + 1}) memory=${it.memory} prompt=${JSON.stringify(it.prompt)} matched=${JSON.stringify(it.matched)}`)
+    .map(
+      (it, i) =>
+        `${i + 1}) memory=${it.memory} prompt=${JSON.stringify(it.prompt)} matched=${JSON.stringify(it.matched)}`
+    )
     .join('\n');
   const body = JSON.stringify({
     model,
@@ -649,8 +806,13 @@ module.exports = {
   judgeBatch,
   sampleForCap,
   judgePipeline,
+  shouldJudge,
+  main,
 };
 
 if (require.main === module) {
-  main(process.argv.slice(2));
+  main(process.argv.slice(2)).catch((err) => {
+    process.stderr.write(`synapsys-replay: ${err && err.message ? err.message : err}\n`);
+    process.exit(1);
+  });
 }

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -144,6 +144,9 @@ function applyOnlyFilter(memories, onlyFlag) {
       `synapsys-replay: --only references unknown memory name(s): ${unknown.join(', ')}\n`
     );
   }
+  if (unknown.length === allow.size && allow.size > 0) {
+    die(`--only matched no memories in the store (unknown: ${[...allow].join(', ')})`, 2);
+  }
   return memories.filter((m) => allow.has(m.name));
 }
 
@@ -252,6 +255,11 @@ async function main(argv) {
   const stores = loadStore({ storeFlag: flags.store, cwd: process.cwd() });
   const memories = applyOnlyFilter(loadMemories(stores), flags.only);
 
+  const apiKey = process.env.ANTHROPIC_API_KEY || '';
+  if (!flags.noJudge && !apiKey) {
+    process.stderr.write('synapsys-replay: ANTHROPIC_API_KEY not set; proceeding as --no-judge\n');
+  }
+
   const files = walkTranscripts({
     since: flags.since,
     project: flags.project,
@@ -277,11 +285,7 @@ async function main(argv) {
 
   const { tuples, counts } = collectTuplesFromFiles(files, memories);
 
-  const apiKey = process.env.ANTHROPIC_API_KEY || '';
   const upsFires = tuples.filter((t) => t.fired && t.event === 'UserPromptSubmit').length;
-  if (!flags.noJudge && !apiKey) {
-    process.stderr.write('synapsys-replay: ANTHROPIC_API_KEY not set; proceeding as --no-judge\n');
-  }
   const judging = shouldJudge({ noJudge: flags.noJudge, apiKey, upsFires });
 
   let judgments;

--- a/plugins/synapsys/skills/replay/SKILL.md
+++ b/plugins/synapsys/skills/replay/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: synapsys-replay
+description: Replay historical Claude Code transcripts against the current synapsys store to measure per-memory false-positive rates. Run manually, after editing trigger patterns, or after `synapsys consolidate` to data-drive trigger tuning.
+---
+
+# /synapsys replay
+
+`synapsys-replay.js` walks recent transcript files under `~/.claude/projects/<hash>/*.jsonl`, replays every `UserPromptSubmit` and `PreToolUse` event against the current store's memories, optionally asks a Haiku LLM judge whether each fired match was relevant, and emits a per-memory report ranked by false-positive rate.
+
+It is the measurement counterpart to `synapsys-explain`: explain answers "why did this memory fire on this event?", replay answers "how often does this memory fire on irrelevant events across my real history?"
+
+## When to run
+
+- **Manually**, when triggers feel noisy and you want hard numbers.
+- **After editing a memory's trigger pattern**, to confirm the change reduced false positives without losing real fires.
+- **After `synapsys consolidate`**, when stores grow past ~20 memories and gut-feel triage stops scaling.
+
+## Pipeline overview
+
+1. **Walk transcripts** under `~/.claude/projects/<hash>/*.jsonl` (or a single project with `--project=<hash>`), modified within `--since` (default `7d`). Malformed lines emit a stderr warning and are skipped.
+2. **Extract synthetic events** from each transcript entry:
+   - `type=user` entries → `{event:'UserPromptSubmit', prompt}`
+   - `type=assistant` `tool_use` blocks → `{event:'PreToolUse', tool, tool_input}`
+3. **Replay** each synthesized event against every memory in the store using the runtime matcher from `plugins/synapsys/lib/matcher.js` (`matchPrompt`, `matchPreTool`). No matching logic is re-implemented — the same `MatchResult` shape produced at runtime is consumed here.
+4. **Judge** each fired UPS match with a lightweight Haiku call (skipped under `--no-judge`). Batched up to 10 items per request; failures recorded as `judge-failed` and excluded from the FP-rate denominator.
+5. **Aggregate** per-memory counts (`fires`, `relevant`, `irrelevant`, `judge_failed`, `fp_rate = 1 - relevant/(relevant+irrelevant)`), top-3 sample matched substrings, and emit a table + `Suggestions:` section.
+
+## Usage
+
+```bash
+# Cheapest path — no LLM calls, nulls for relevance, ranks memories by fire counts only.
+node plugins/synapsys/scripts/synapsys-replay.js --since=7d --no-judge
+
+# Full pipeline with judge (requires ANTHROPIC_API_KEY).
+node plugins/synapsys/scripts/synapsys-replay.js --since=14d
+
+# Narrow to one memory.
+node plugins/synapsys/scripts/synapsys-replay.js --only=git-push-caution
+
+# Machine-readable output.
+node plugins/synapsys/scripts/synapsys-replay.js --since=7d --no-judge --json
+```
+
+### Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--since=<Nd>` | `7d` | mtime window for transcript files |
+| `--project=<hash>` | all | restrict to one `~/.claude/projects/<hash>/` directory |
+| `--no-judge` | off | skip every LLM call; `relevant=null`, `fp_rate=null` |
+| `--json` | off | emit `{memories,suggestions,events_total,events_ups,events_ptu,...}` to stdout |
+| `--only=<csv>` | all | restrict to specific memory names |
+| `--store=<name\|path>` | auto | pick a non-auto-detected store |
+| `--max-judges=<N>` | `200` | hard cap on judge invocations per run |
+
+## Cost model
+
+The judge uses `claude-haiku-4-5`. Per fired UPS match the request carries roughly **~500 input tokens + ~5 output tokens**. With the default cap of 200 judges, expected cost is well under **$0.05** per run. The report footer (`est. cost ≈ $X`) is rendered only when the judge actually ran — `--no-judge` runs emit no cost line because they make zero API calls.
+
+When fired matches exceed `--max-judges`, replay samples evenly across them (`Math.floor(i * fires / cap)`) and annotates the report with `extrapolated`. The cap is a hard upper bound — replay will never exceed it in a single run.
+
+## `--no-judge` zero-cost mode
+
+`--no-judge` makes zero outbound HTTP calls and requires no `ANTHROPIC_API_KEY`. Per-memory `relevant` and `fp_rate` are `null`, but `fires` and `sample_matches` are still populated, which is usually enough to spot the noisiest memories. Use this as the default when iterating on trigger patterns and only graduate to the judged run when you want a relevance number.
+
+If `ANTHROPIC_API_KEY` is missing and `--no-judge` is **not** set, replay emits a single stderr warning and degrades to no-judge behavior (exit 0).
+
+## PTU not judged in v1
+
+The LLM judge runs only against `UserPromptSubmit` fires. `PreToolUse` matches are far more deterministic (`Tool:<arg-regex>` and content patterns), so per-memory `fp_rate` for PTU-only memories is `null` — judge each problematic PTU memory by reading its `sample_matches` instead.
+
+## Security
+
+Replay sends the user prompt and the matched substring to Anthropic's `/v1/messages` endpoint as part of judging. Do not run the judged path against transcripts that contain secrets you would not paste into the API console. `--no-judge` keeps everything local.
+
+`ANTHROPIC_API_KEY` is never serialized into report output, JSON output, or error messages.
+
+## Current state — transcript format & matcher API
+
+Claude Code writes one JSON entry per line into `~/.claude/projects/<projectHash>/<sessionId>.jsonl`. Per-line shape used by replay:
+
+- `{type:'user', message:{content:<string|array>}}` — user prompt; `content` is either a plain string or an array of `{type:'text', text}` blocks. Mapped to `UserPromptSubmit`.
+- `{type:'assistant', message:{content:[ {type:'tool_use', name, input}, ... ]}}` — each `tool_use` block becomes one `PreToolUse` event with `tool=name`, `tool_input=input`.
+- All other entry types (`system`, `tool_result`, hook events, etc.) are dropped silently.
+
+The matcher API consumed (established by GH-443) is:
+
+- `matchPrompt(memory, {prompt})` → `MatchResult`
+- `matchPreTool(memory, {tool, tool_input})` → `MatchResult`
+- `MatchResult = {fired, reason, matched: {prompt_token, prompt_substring, pretool_pattern, content_pattern, content_substring, ...}}`
+
+`matched.prompt_substring ?? matched.content_substring` is what populates the per-memory `sample_matches` column in the report.


### PR DESCRIPTION
Closes #444

## Existing Behavior

- `synapsys-replay.js` did not exist; trigger false-positive rates could only be assessed by manual inspection after memories fired in the wild.
- The `judgeBatch` function lacked a `system` prompt, causing the judge to produce unstructured output instead of the expected `N: yes / N: no` lines, leading to silent parse failures and `judge_failed` outcomes for all items.

## Intended New Behavior

- `synapsys-replay.js` walks `~/.claude/projects/<hash>/*.jsonl` transcripts, replays every `UserPromptSubmit` and `PreToolUse` event against the live store, optionally judges each fired match with a lightweight LLM call, and emits a per-memory false-positive report ranked by FP rate.
- `judgeBatch` now includes the required `system` prompt instructing the model to output exactly `N: yes` or `N: no`, eliminating silent parse failures.
- `replay-judge` includes the memory body preview in judge prompts and corrects cost calculations (this commit).

## Incidental rebase changes

Several `plugins/work` test files and a `related-tickets.js` helper were deleted as part of rebasing onto `main` (those deletions exist on `main` from a prior release and were merged in during the rebase). The `work-workflow` plugin.json version reflects `main`'s current release-bot value. No intentional changes to the `work` plugin were made in this branch.

The `maestro` and `heimdall` plugins appear in the diff only as version-bump lines from the release bot; both plugins already exist on `main` and are not introduced here.

## Out-of-scope changes

None reported by the scope-diff verifier for this branch's actual work.

## Dev Checks

- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

### synapsys replay — false-positive analysis

1. Ensure `ANTHROPIC_API_KEY` is set in the environment.
2. Run the no-judge (zero-cost) path to confirm transcript walking and event extraction work:
   ```bash
   node plugins/synapsys/scripts/synapsys-replay.js --since=7d --no-judge
   ```
   Expected: a per-memory table with `fires` and `sample_matches` columns; `relevant` and `fp_rate` show `null`.
3. Run the full judged pipeline:
   ```bash
   node plugins/synapsys/scripts/synapsys-replay.js --since=7d
   ```
   Expected: same table with `relevant` counts and `fp_rate` values populated; report footer shows estimated cost.
4. Confirm missing-key fallback: unset `ANTHROPIC_API_KEY` and run without `--no-judge`. Expected: single stderr warning, exit 0, `relevant=null` for all rows.
5. Confirm JSON output: `node plugins/synapsys/scripts/synapsys-replay.js --since=7d --no-judge --json` emits a valid JSON object with `memories`, `events_total`, and `suggestions` keys.

### Test Results

| Check | Status | Notes |
|-------|--------|-------|
| dev:check (lint + typecheck + test) | PASS | Exit 0; no JS/TS files changed relative to HEAD |
| Integration tests — `synapsys-replay.integration.test.js` | PASS | 34/34 tests pass |
| No-transcripts exit 0 | PASS | `main()` exits 0 with friendly message when no JSONL found |
| `--no-judge` zero-API path | PASS | No HTTP calls issued; `fp_rate` null for all rows |
| `judgeBatch` system prompt | PASS | System prompt added; `N: yes/no` reply parsing verified |
| `--max-judges` cap + extrapolation | PASS | Cap honored; even sampling applied |
| `--json` output shape | PASS | `memories`, `events_total`, `suggestions` keys present |
| Heuristic tightening suggestions | PASS | Short alternation arms flagged correctly |
| Memory body preview in judge prompts | PASS | Body text included; cost calculations corrected |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Judged runs send user prompts and match snippets to Anthropic; local transcript reads and new CLI surface area, mitigated by --no-judge and key-leak guards in tests.
> 
> **Overview**
> Adds **`synapsys-replay`**, a CLI that replays recent Claude Code JSONL transcripts against the live synapsys store using the existing **`matchPrompt` / `matchPreTool`** matchers, then reports per-memory **fires**, optional **false-positive rate** (UPS only), and **trigger-tightening suggestions**.
> 
> Implementation is split into **`replay-events`** (walk/filter transcripts, skip synthetic user lines, synthesize UPS/PTU events), **`replay-judge`** (batched Haiku calls with a structured **`N: yes/no`** system prompt, **`--max-judges`** sampling + extrapolation flag), **`replay-aggregate`**, and **`replay-report`** (text + **`--json`**). **`splitTopLevelAlternation`** is exported from **`matcher.js`** so tightening heuristics match runtime alternation splitting. Docs: README section and **`skills/replay/SKILL.md`**; broad integration coverage in **`synapsys-replay.integration.test.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb61c3c17acb4b5c032de0fe1926277a8e22305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->