### PR TITLE
fix(work-implement): refuse to record GREEN/REFACTOR on empty-command trap

### DIFF
--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-empty-command-trap.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-empty-command-trap.test.js
@@ -1,0 +1,122 @@
+/**
+ * RC-D regression tests for the empty-command trap.
+ *
+ * Symptom: an unbound test-command env var expanded inside `eval "$VAR"`
+ * becomes `eval ""` and exits 0 silently. The original guard only checked
+ * the exit code, so it recorded false-positive GREEN evidence. The task
+ * advanced and the next task's scope hook then blocked edits to the
+ * still-unwritten source — agents could not recover via /work (observed
+ * on GH-417 / 432 / 452).
+ *
+ * Defense: refuse to record GREEN or REFACTOR when the command exits 0 AND
+ * produced empty stdout AND empty stderr. Real test runners always emit
+ * something (a summary line, a progress dot, anything).
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const CLI_PATH = path.join(__dirname, '..', 'tdd-phase-state.js');
+
+function mkTempHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdd-empty-cmd-'));
+  fs.mkdirSync(path.join(dir, 'worktrees', 'tasks'), { recursive: true });
+  return dir;
+}
+
+function runCli(args, homeDir) {
+  try {
+    const stdout = execSync(`node ${CLI_PATH} ${args}`, {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        TASKS_BASE: path.join(homeDir, 'worktrees', 'tasks'),
+        WORK_TDD_TOKEN_SKIP: '1',
+        WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (e) {
+    return {
+      stdout: e.stdout || '',
+      stderr: e.stderr || e.message,
+      exitCode: typeof e.status === 'number' ? e.status : 1,
+    };
+  }
+}
+
+function seedPhase(homeDir, ticket, phase) {
+  runCli(`init ${ticket}`, homeDir);
+  const statePath = path.join(homeDir, 'worktrees', 'tasks', ticket, 'tdd-phase.json');
+  const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  state.currentPhase = phase;
+  state.cycles = [
+    {
+      cycle: 1,
+      red: {
+        testFiles: ['x.test.ts'],
+        testCommand: 'false',
+        testExitCode: 1,
+        timestamp: new Date().toISOString(),
+      },
+    },
+  ];
+  if (phase === 'refactor') {
+    state.cycles[0].green = {
+      testCommand: "echo 'real output'",
+      testExitCode: 0,
+      timestamp: new Date().toISOString(),
+    };
+  }
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+}
+
+describe('RC-D — empty-command trap', () => {
+  let homeDir;
+  beforeEach(() => { homeDir = mkTempHome(); });
+  afterEach(() => { fs.rmSync(homeDir, { recursive: true, force: true }); });
+
+  it('GREEN: refuses to record when eval-of-empty-string exits 0', () => {
+    seedPhase(homeDir, 'TEST-1', 'green');
+    const r = runCli('record-green TEST-1 --cmd \'eval ""\'', homeDir);
+    assert.notStrictEqual(r.exitCode, 0);
+    assert.match(r.stderr, /empty-command trap|NO stdout\/stderr/i);
+  });
+
+  it('GREEN: catches unbound test-command env var pattern', () => {
+    seedPhase(homeDir, 'TEST-2', 'green');
+    // Simulate the real wedge: env var is unset, expanded inside eval.
+    const r = runCli('record-green TEST-2 --cmd \'eval "$TEST_UNIT_COMMAND_UNSET"\'', homeDir);
+    assert.notStrictEqual(r.exitCode, 0);
+    assert.match(r.stderr, /empty-command trap|NO stdout\/stderr/i);
+  });
+
+  it('GREEN: accepts command that prints to stdout (real test runner)', () => {
+    seedPhase(homeDir, 'TEST-3', 'green');
+    const sh = path.join(homeDir, 'pass-stdout.sh');
+    fs.writeFileSync(sh, "#!/bin/sh\necho '1 passed'\nexit 0\n", { mode: 0o755 });
+    const r = runCli(`record-green TEST-3 --cmd "${sh}"`, homeDir);
+    assert.strictEqual(r.exitCode, 0, `stderr: ${r.stderr}`);
+  });
+
+  it('GREEN: accepts command that prints only to stderr', () => {
+    seedPhase(homeDir, 'TEST-4', 'green');
+    const sh = path.join(homeDir, 'pass-stderr.sh');
+    fs.writeFileSync(sh, "#!/bin/sh\necho '1 passed' >&2\nexit 0\n", { mode: 0o755 });
+    const r = runCli(`record-green TEST-4 --cmd "${sh}"`, homeDir);
+    assert.strictEqual(r.exitCode, 0, `stderr: ${r.stderr}`);
+  });
+
+  it('REFACTOR: same empty-command guard fires', () => {
+    seedPhase(homeDir, 'TEST-5', 'refactor');
+    const r = runCli('record-refactor TEST-5 --cmd \'eval ""\'', homeDir);
+    assert.notStrictEqual(r.exitCode, 0);
+    assert.match(r.stderr, /empty-command trap|NO stdout\/stderr/i);
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -22,7 +22,14 @@ function createTempHome() {
 
 function createExitScript(dir, exitCode) {
   const scriptPath = path.join(dir, `exit-${exitCode}.sh`);
-  fs.writeFileSync(scriptPath, `#!/bin/sh\nexit ${exitCode}\n`, { mode: 0o755 });
+  // Always emit a token to stdout. RC-D refuses to record exit-0 with
+  // completely empty output (that's the empty-command trap). Real test
+  // runners always print something, so test fixtures that stand in for
+  // them must too.
+  const body = exitCode === 0
+    ? `#!/bin/sh\necho 'simulated test runner: 1 passed'\nexit 0\n`
+    : `#!/bin/sh\necho 'simulated test runner: 1 failed' >&2\nexit ${exitCode}\n`;
+  fs.writeFileSync(scriptPath, body, { mode: 0o755 });
   return scriptPath;
 }
 
@@ -261,7 +268,12 @@ describe('tdd-phase-state CLI', () => {
       assert.strictEqual(after.cycles[0].green.testExitCode, 0);
     });
 
-    it('accepts silent runner with no parseable summary', () => {
+    it('rejects silent runner with no output (RC-D empty-command trap)', () => {
+      // History: this case used to be accepted "for leniency", but it IS the
+      // empty-command trap (e.g. `eval "$UNBOUND_VAR"` → exits 0, prints nothing).
+      // The wedge that followed (false GREEN advanced the task; next-task scope
+      // hook then blocked edits to the still-unwritten source) made tickets
+      // unrecoverable via /work. Real test runners always emit something.
       runCli('init TEST-GRN-SILENT', homeDir);
       const statePath = path.join(
         homeDir,
@@ -285,10 +297,20 @@ describe('tdd-phase-state CLI', () => {
       ];
       fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
 
-      // Silent runner: exit 0, no summary output → allow (lenient on format).
-      const silentScript = createExitScript(scriptDir, 0);
-      const { exitCode } = runCli(`record-green TEST-GRN-SILENT --cmd "${silentScript}"`, homeDir);
-      assert.strictEqual(exitCode, 0);
+      // Inline truly-silent script (createExitScript always emits a token now;
+      // this test specifically wants empty stdout AND empty stderr).
+      const silentScript = path.join(scriptDir, 'truly-silent.sh');
+      fs.writeFileSync(silentScript, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+      const { exitCode, stderr } = runCli(
+        `record-green TEST-GRN-SILENT --cmd "${silentScript}"`,
+        homeDir
+      );
+      assert.notStrictEqual(exitCode, 0, 'silent runner should now be rejected');
+      assert.match(
+        stderr,
+        /empty-command trap|NO stdout\/stderr/i,
+        `expected RC-D rejection message, got: ${stderr}`
+      );
     });
   });
 

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -719,6 +719,23 @@ function cmdRecordGreen(ticketId, args) {
     errorExit('Tests must PASS in GREEN phase. Tests failed (exit ' + exitCode + ').');
   }
 
+  // RC-D defense: refuse the "empty command exits 0" trap. A wrapped command
+  // like `eval "$TEST_UNIT_COMMAND"` with `$TEST_UNIT_COMMAND` unbound expands
+  // to `eval ""` and exits 0 silently. The wedge that follows (false GREEN →
+  // task advanced → next task scope blocks edits to the still-unwritten source)
+  // was observed on GH-417 / GH-432 / GH-452 — agents could not recover via
+  // /work. Real test runners always emit something to stdout or stderr; if
+  // both are empty AND exit was 0, the command did no work. Refuse to record.
+  if (stdout.trim() === '' && stderr.trim() === '') {
+    errorExit(
+      'GREEN test command exited 0 with NO stdout/stderr output. This is the ' +
+        'empty-command trap (typically an unbound test-command env var expanded ' +
+        'to `eval ""`). Real test runs always emit output. Source the worktree' +
+        "'s .envrc so $TEST_UNIT_COMMAND / $TEST_INTEGRATION_COMMAND are bound, " +
+        'verify the command runs real tests, then retry.'
+    );
+  }
+
   // RC-B defense: reject all-skipped false positives. A spec where every test
   // is .skip exits 0 but delivers zero coverage. Recording that as GREEN lets
   // the workflow advance with no work shipped (ECHO-4451 hit this).
@@ -767,6 +784,17 @@ function cmdRecordRefactor(ticketId, args) {
   const { exitCode, stdout, stderr } = runTestCommandWithOutput(cmd);
   if (exitCode !== 0) {
     errorExit('Tests must still PASS after refactoring. Tests failed (exit ' + exitCode + ').');
+  }
+
+  // RC-D defense: same empty-command guard as GREEN. Refuse exit-0-with-no-output.
+  if (stdout.trim() === '' && stderr.trim() === '') {
+    errorExit(
+      'REFACTOR test command exited 0 with NO stdout/stderr output. This is the ' +
+        'empty-command trap (typically an unbound test-command env var expanded ' +
+        'to `eval ""`). Real test runs always emit output. Source the worktree' +
+        "'s .envrc so test-command env vars are bound, verify the command runs " +
+        'real tests, then retry.'
+    );
   }
 
   // RC-B defense: same all-skipped guard as GREEN — REFACTOR also delivers


### PR DESCRIPTION
## Summary

Closes the false-GREEN trap that wedged three live agents today (GH-417 / GH-432 / GH-452) and was filed as issue #417.

## The bug

The implement-gate spawns its test command via `bash -lc "$cmd"` where `$cmd` is usually a wrapper like `eval "$TEST_UNIT_COMMAND"`. If the inner env var is unbound (e.g. `.envrc` wasn't sourced into the gate's spawn env), the expansion becomes literally `eval ""` — which exits 0 silently. The previous guard only checked exit code, so this got recorded as a passing GREEN.

The wedge that followed was unrecoverable via `/work`:

1. False GREEN → `currentTaskIndex` advanced
2. `protect-task-scope` hook now treats the next task as active
3. Edits to the previous task's still-unwritten source are blocked
4. Agent loops on permission refusals; ticket can't progress

## Fix

`cmdRecordGreen` and `cmdRecordRefactor` in `tdd-phase-state.js` now refuse to record evidence when the command exits 0 AND **both** stdout and stderr are completely empty. Real test runners always emit something (a summary line, a progress dot). An exit-0 with no output is the trap.

```
GREEN test command exited 0 with NO stdout/stderr output. This is the
empty-command trap (typically an unbound test-command env var expanded
to `eval ""`). Real test runs always emit output. Source the worktree's
.envrc so $TEST_UNIT_COMMAND / $TEST_INTEGRATION_COMMAND are bound,
verify the command runs real tests, then retry.
```

## Test plan

- [ ] New tests in `tdd-phase-state-empty-command-trap.test.js` cover:
  - GREEN refuses `eval ""`
  - GREEN refuses unbound-var pattern (`eval "$UNSET_VAR"`)
  - GREEN accepts stdout-only output
  - GREEN accepts stderr-only output
  - REFACTOR same empty-command guard
- [ ] Existing `tdd-phase-state.test.js` updated:
  - `createExitScript` test helper now always emits a token (real test runners never produce zero output; fixtures shouldn't either)
  - `accepts silent runner with no parseable summary` renamed to `rejects silent runner with no output (RC-D empty-command trap)` — its previous leniency WAS the trap
- [ ] Full `tdd-phase-state` suite passes locally

## Out of scope

Issue #417 also called out empty-on-RED and CI-env-mismatch which are separate guards — those remain follow-ups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TDD evidence gates for all implement workflows; mis-tuned runners that truly produce no output could be blocked, but the guard only applies after exit 0 and is covered by new regression tests.
> 
> **Overview**
> Stops **false GREEN/REFACTOR** evidence when the implement gate runs a test wrapper that effectively does nothing (e.g. unbound `eval "$TEST_UNIT_COMMAND"` → `eval ""`, exit 0, no output). **`tdd-phase-state.js`** now rejects recording after a passing run if **both stdout and stderr are empty**, with an error that points at sourcing `.envrc` and binding test-command env vars.
> 
> Tests add **`tdd-phase-state-empty-command-trap.test.js`** (RC-D) for `eval ""`, unbound-var patterns, and stdout/stderr-only success; **`tdd-phase-state.test.js`** stops treating fully silent exit-0 as acceptable and makes **`createExitScript`** emit minimal runner-like output so fixtures match real runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c0b2f2838b501b31e6f3ce092739ff0eda1328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->