### PR TITLE
fix(work): normalise TRUSTED_SCRIPT_DIRS at module load via realpathSync (GH-452)

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -74,6 +74,29 @@ function atomicWriteJson(targetPath, value) {
   }
 }
 
+// GH-452: variant of atomicWriteJson for tests that need to write a
+// deliberately-malformed payload (corrupt-file regression tests). Same
+// tmp + rename + dir-fsync boundary; bytes are passed through verbatim
+// so the test can simulate disk corruption without going through
+// JSON.stringify.
+function writeRawAtomic(targetPath, rawBytes) {
+  const dir = path.dirname(targetPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const tmpPath = `${targetPath}.tmp.${process.pid}.${Date.now()}`;
+  fs.writeFileSync(tmpPath, rawBytes);
+  fs.renameSync(tmpPath, targetPath);
+  try {
+    const fd = fs.openSync(dir, 'r');
+    try {
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    // best-effort
+  }
+}
+
 function writeWorkState(stepStatus, status = 'in_progress') {
   if (!fs.existsSync(TASKS_DIR)) fs.mkdirSync(TASKS_DIR, { recursive: true });
   const state = {
@@ -720,14 +743,20 @@ describe('enforce-step-workflow', () => {
 
     it('handles corrupt evidence file gracefully', () => {
       if (!fs.existsSync(TASKS_DIR)) fs.mkdirSync(TASKS_DIR, { recursive: true });
-      fs.writeFileSync(path.join(TASKS_DIR, '.step-evidence.json'), 'not json {{{');
+      // GH-452: write corrupt payload through the atomic helper so the rename
+      // boundary matches every other state-file writer in this suite. The
+      // helper takes a JS value (it JSON.stringifies internally), so we wrap
+      // the deliberately-malformed payload in a small atomic-equivalent
+      // sequence that preserves the raw bytes the test needs.
+      writeRawAtomic(path.join(TASKS_DIR, '.step-evidence.json'), 'not json {{{');
       const evidence = readEvidence('.step-evidence.json');
       assert.deepEqual(evidence, {});
     });
 
     it('handles corrupt workflow-state file gracefully', () => {
       if (!fs.existsSync(TASKS_DIR)) fs.mkdirSync(TASKS_DIR, { recursive: true });
-      fs.writeFileSync(path.join(TASKS_DIR, '.work-pr.workflow-state.json'), 'corrupted');
+      // GH-452: see note above — atomic write of a deliberately-corrupt body.
+      writeRawAtomic(path.join(TASKS_DIR, '.work-pr.workflow-state.json'), 'corrupted');
       // Should not crash — fail-open
     });
   });
@@ -4903,6 +4932,301 @@ describe('enforce-step-workflow', () => {
         !stateBlocked,
         `expected no spurious BLOCKED due to missing state, got: ${stateBlocked && stateBlocked.stderr}`
       );
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // GH-452: Self-scan — every state-file write MUST go through atomicWriteJson
+  // ═══════════════════════════════════════════════════════════════════════════
+  describe('GH-452 atomic state-file write coverage', () => {
+    it('test file contains zero raw fs.writeFileSync(...) calls targeting state JSON shapes', () => {
+      const src = fs.readFileSync(__filename, 'utf-8');
+      // Strip the helper definition itself (atomicWriteJson uses writeFileSync
+      // internally — that single call is the sanctioned escape) and any comment
+      // lines or string-literal lines (those are simulated agent fixtures, not
+      // real writers we control).
+      const lines = src.split('\n');
+      const offenders = [];
+      const stateShapeRe =
+        /fs\.writeFileSync\s*\([^)]*\.(work-state|workflow-state|step-evidence)[^)]*\.json/;
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // Skip strings: lines that contain the writeFileSync call inside a
+        // quoted JS string (simulated agent code). Detect by leading quote
+        // or "'const fs = require" prefix.
+        if (/^\s*['"`]/.test(line.trim())) continue;
+        // Skip comment lines.
+        if (/^\s*\/\//.test(line)) continue;
+        if (stateShapeRe.test(line)) {
+          offenders.push(`${i + 1}: ${line.trim()}`);
+        }
+      }
+      assert.equal(
+        offenders.length,
+        0,
+        `GH-452: state-file writers must use atomicWriteJson(), found raw fs.writeFileSync calls:\n${offenders.join('\n')}`
+      );
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // GH-452 Task 3 — Normalise TRUSTED_SCRIPT_DIRS at module load via realpathSync
+  // ═══════════════════════════════════════════════════════════════════════════
+  describe('GH-452 Task 3: TRUSTED_SCRIPT_DIRS module-load realpath normalisation', () => {
+    // Resolve the real workflows root (the source-of-truth dir whose subtree
+    // contains the hook). We use this as the realpath target for the symlink
+    // shim so the spawned child can require the hook through a symlinked
+    // ancestor and we can inspect its normalised trustedDirs.
+    const REAL_WORKFLOWS_DIR = fs.realpathSync(
+      path.resolve(__dirname, '..', '..') // .../scripts/workflows
+    );
+
+    // Spawn a fresh node process that requires the hook through `requirePath`
+    // with ENFORCE_HOOK_DEBUG=1 so Task 1's logGh452Diagnostics() dumps each
+    // trusted-dir entry on stderr at module load. Parse those lines back into
+    // an array. We need a child process so module load happens fresh on every
+    // test (parent's require cache already holds the unsymlinked instance).
+    function loadTrustedDirsVia(requirePath, extraEnv = {}) {
+      return new Promise((resolve, reject) => {
+        // We don't care about hook exit code or its normal stdout — we only
+        // care about ENFORCE_HOOK_DEBUG stderr lines emitted at module load.
+        const code = `
+          try {
+            require(${JSON.stringify(requirePath)});
+          } catch (err) {
+            process.stderr.write('LOAD_ERROR: ' + err.message + '\\n' + err.stack + '\\n');
+            process.exit(7);
+          }
+        `;
+        // --preserve-symlinks keeps the symlinked require path intact in
+        // __dirname, mirroring the Node 20 plugin-cache symlink behaviour
+        // that the GH-452 RCA blames for the trust-prefix mismatch. Without
+        // this flag Node's loader auto-realpaths __dirname and the bug is
+        // invisible.
+        const child = spawn(process.execPath, ['--preserve-symlinks', '-e', code], {
+          env: {
+            ...process.env,
+            ENFORCE_HOOK_DEBUG: '1',
+            // Hook is not running under Claude — avoid hook-self-reentrancy
+            // checks by clearing CLAUDE_HOOK_TYPE.
+            CLAUDE_HOOK_TYPE: '',
+            ...extraEnv,
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (d) => {
+          stdout += d.toString();
+        });
+        child.stderr.on('data', (d) => {
+          stderr += d.toString();
+        });
+        child.on('error', reject);
+        child.on('close', (exitCode) => {
+          // Extract trusted-dir entries from stderr. Task 1's diagnostic
+          // format: `GH-452 trusted-dir entry=<path> realpath=<resolved>`
+          const trustedDirs = [];
+          const realpathByEntry = new Map();
+          for (const line of stderr.split('\n')) {
+            const m = /^GH-452 trusted-dir entry=(.+?) realpath=(.+)$/.exec(line);
+            if (m) {
+              trustedDirs.push(m[1]);
+              realpathByEntry.set(m[1], m[2]);
+            }
+          }
+          resolve({ exitCode, stdout, stderr, trustedDirs, realpathByEntry });
+        });
+      });
+    }
+
+    it('normalises TRUSTED_SCRIPT_DIRS to realpaths when hook is loaded via a symlinked plugin-cache ancestor', async () => {
+      // Create a temp dir, symlink it to the real workflows dir, then require
+      // the hook through the symlink. The hook's __dirname will live under
+      // /tmp/.../symlink-cache/lib/hooks; without realpath normalisation the
+      // resulting TRUSTED_SCRIPT_DIRS entries will contain "/symlink-cache/"
+      // rather than the realpath. With Task 3 normalisation they must contain
+      // the realpath segment of REAL_WORKFLOWS_DIR.
+      const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gh452-task3-symlink-'));
+      const symlinkCache = path.join(tmpRoot, 'symlink-cache');
+      fs.symlinkSync(REAL_WORKFLOWS_DIR, symlinkCache, 'dir');
+      const requirePath = path.join(symlinkCache, 'lib', 'hooks', 'enforce-step-workflow.js');
+
+      try {
+        const { exitCode, stderr, trustedDirs } = await loadTrustedDirsVia(requirePath);
+        assert.equal(exitCode, 0, `child exited non-zero. stderr=${stderr}`);
+        assert.ok(
+          trustedDirs.length > 0,
+          `expected at least one trusted-dir entry in stderr; got stderr:\n${stderr}`
+        );
+        // Every entry whose realpath would succeed must have been normalised
+        // away from the symlink path. The symlink segment is "/symlink-cache/";
+        // it must NOT appear in any normalised entry.
+        const symlinkSegment = `${path.sep}symlink-cache${path.sep}`;
+        const unNormalised = trustedDirs.filter((d) => d.includes(symlinkSegment));
+        assert.deepEqual(
+          unNormalised,
+          [],
+          `expected zero trustedDirs containing the symlink path; found:\n${unNormalised.join('\n')}`
+        );
+        // And the realpath segment of the workflows root must appear in at
+        // least one entry — confirming the dirs were actually realpath'd
+        // through to the underlying target.
+        const normalisedCount = trustedDirs.filter((d) => d.startsWith(REAL_WORKFLOWS_DIR)).length;
+        assert.ok(
+          normalisedCount > 0,
+          `expected at least one trustedDir to start with realpath ${REAL_WORKFLOWS_DIR}; got entries:\n${trustedDirs.join('\n')}`
+        );
+      } finally {
+        try {
+          fs.rmSync(tmpRoot, { recursive: true, force: true });
+        } catch {
+          /* cleanup */
+        }
+      }
+    });
+
+    it('warns to stderr with GH-452 marker and retains unresolved path when a trusted-dir realpath fails', async () => {
+      // Build a fake mini-workflows-tree where the hook can require its
+      // siblings, but one of the trusted-dir entries' underlying real path is
+      // missing. We achieve this by copying just enough of the real tree and
+      // deliberately omitting one sibling that TRUSTED_SCRIPT_DIRS references
+      // (e.g. workflows/work-cleanup/). The expected behaviour: load succeeds
+      // (fail-open per entry), stderr contains a `GH-452 trusted-dir realpath
+      // failed` line, and trustedDirs still includes the unresolved path.
+      //
+      // Simpler implementation: symlink the whole real workflows tree (so the
+      // hook can load all its requires), but ALSO place an outer wrapper dir
+      // where one of the resolved trusted dirs gets pre-broken by overlay. We
+      // can't easily break a sibling that real code depends on, so instead we
+      // verify fail-open via a different mechanism: symlink the workflows
+      // dir as before, but additionally create a broken symlink at one of
+      // the trusted-dir locations inside an OVERLAY tree and require through
+      // that overlay.
+      //
+      // Approach: copy the workflows directory structure shallowly into a
+      // tmpdir (just dirs, no files) for sibling entries; copy the real lib/
+      // subtree so the hook can require its dependencies; and break one
+      // trusted-dir entry by replacing it with a dangling symlink. realpath
+      // on a dangling symlink throws ENOENT.
+      const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gh452-task3-failopen-'));
+      const fakeWorkflows = path.join(tmpRoot, 'workflows');
+      fs.mkdirSync(fakeWorkflows);
+
+      // Symlink lib/ to the real lib/ — the hook itself + all its dependencies
+      // load through here.
+      const realLib = path.join(REAL_WORKFLOWS_DIR, 'lib');
+      fs.symlinkSync(realLib, path.join(fakeWorkflows, 'lib'), 'dir');
+
+      // For each sibling dir referenced by TRUSTED_SCRIPT_DIRS, create a
+      // matching symlink to the real one — EXCEPT for `work-cleanup`, which
+      // we replace with a dangling symlink to force realpathSync to throw.
+      const siblings = [
+        'work',
+        'check',
+        'work-implement',
+        'work-brief',
+        'work-spec',
+        'work-tasks',
+        'work-pr-step',
+        'work-ci',
+        'work-completion-checker',
+        'work-code-checker',
+        'work-qa-feature-tester',
+        'work-pr-reviewer',
+        'work-task-review',
+        'work-reports',
+        'check2',
+        'follow-up',
+      ];
+      for (const sib of siblings) {
+        const realSib = path.join(REAL_WORKFLOWS_DIR, sib);
+        if (fs.existsSync(realSib)) {
+          fs.symlinkSync(realSib, path.join(fakeWorkflows, sib), 'dir');
+        }
+      }
+      // The dangling entry — `work-cleanup` symlink pointing at a nonexistent
+      // target. realpathSync on this entry should throw ENOENT.
+      const danglingTarget = path.join(tmpRoot, 'does-not-exist');
+      fs.symlinkSync(danglingTarget, path.join(fakeWorkflows, 'work-cleanup'), 'dir');
+
+      const requirePath = path.join(fakeWorkflows, 'lib', 'hooks', 'enforce-step-workflow.js');
+      try {
+        const { exitCode, stderr, trustedDirs } = await loadTrustedDirsVia(requirePath);
+        assert.equal(exitCode, 0, `child exited non-zero. stderr=${stderr}`);
+        // (a) stderr must contain the GH-452 realpath-failed warning emitted by
+        // the Task 3 safeRealpath() helper at module load.
+        assert.ok(
+          /GH-452 trusted-dir realpath failed/.test(stderr),
+          `expected GH-452 trusted-dir realpath warning on stderr; got:\n${stderr}`
+        );
+        // (b) The unresolved (dangling) path must remain in TRUSTED_SCRIPT_DIRS
+        // — fail-open semantics keep the entry rather than dropping it.
+        const danglingEntryRetained = trustedDirs.some((d) =>
+          d.endsWith(`${path.sep}work-cleanup`)
+        );
+        assert.ok(
+          danglingEntryRetained,
+          `expected unresolved work-cleanup entry to be retained in trustedDirs; got:\n${trustedDirs.join('\n')}`
+        );
+      } finally {
+        try {
+          fs.rmSync(tmpRoot, { recursive: true, force: true });
+        } catch {
+          /* cleanup */
+        }
+      }
+    });
+
+    // GH-452 Task 3 deliverable 3.2.3: shared fixture for placing a
+    // fake-but-correctly-named script at an untrusted (os.tmpdir) path.
+    // The fake's basename is preserved so the hook's basename-based exempt-
+    // script matcher fires, then the trust-prefix check rejects it.
+    async function withTempFakeScript(name, fn) {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), `gh452-task3-fake-${process.pid}-`)
+      );
+      const fakePath = path.join(tmpDir, name);
+      fs.writeFileSync(
+        fakePath,
+        'const fs = require("fs"); fs.writeFileSync(".work-state.json", "{}");'
+      );
+      try {
+        return await fn(fakePath);
+      } finally {
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          /* cleanup */
+        }
+      }
+    }
+
+    // GH-452 Vector 3 boundary preservation
+    // The fake script MUST be named `work-orchestrator.js` (an EXEMPT script
+    // basename) and live at an untrusted path. The hook should match the
+    // basename, then fail the trust-prefix check and BLOCK. This locks in the
+    // trust boundary so the Task 3 normalisation cannot silently widen trust.
+    it('still BLOCKs an untrusted os.tmpdir()-placed fake work-orchestrator.js after normalisation', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+      await withTempFakeScript('work-orchestrator.js', async (fakePath) => {
+        const { code, stderr } = await runHook(
+          {
+            tool_name: 'Bash',
+            tool_input: { command: `node ${fakePath} transition TEST-1 commit` },
+          },
+          'PreToolUse'
+        );
+        assert.equal(
+          code,
+          2,
+          `Vector 3: untrusted exempt-named path must BLOCK; got exit=${code} stderr=${stderr}`
+        );
+        assert.ok(
+          stderr.includes('BLOCKED'),
+          `Vector 3: stderr must contain BLOCKED; got:\n${stderr}`
+        );
+      });
     });
   });
 });

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -4982,7 +4982,7 @@ describe('enforce-step-workflow', () => {
     );
 
     // Spawn a fresh node process that requires the hook through `requirePath`
-    // with ENFORCE_HOOK_DEBUG=1 so Task 1's logGh452Diagnostics() dumps each
+    // with ENFORCE_HOOK_DEBUG=1 so Task 1's debugLogTrustedDirs() dumps each
     // trusted-dir entry on stderr at module load. Parse those lines back into
     // an array. We need a child process so module load happens fresh on every
     // test (parent's require cache already holds the unsymlinked instance).

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2794,8 +2794,9 @@ describe('enforce-step-workflow', () => {
         startTime: new Date().toISOString(),
         lastUpdate: new Date().toISOString(),
       };
-      fs.writeFileSync(path.join(flatDir, '.work-state.json'), JSON.stringify(flatState, null, 2));
-      fs.writeFileSync(path.join(flatDir, '.step-evidence.json'), JSON.stringify({}, null, 2));
+      // GH-452: atomic writes prevent ENOENT races on Node 20 GH Actions runner.
+      atomicWriteJson(path.join(flatDir, '.work-state.json'), flatState);
+      atomicWriteJson(path.join(flatDir, '.step-evidence.json'), {});
 
       // Invalid suffix should be ignored — hook falls back to flat path
       const { code } = await runHook(
@@ -2824,8 +2825,9 @@ describe('enforce-step-workflow', () => {
         startTime: new Date().toISOString(),
         lastUpdate: new Date().toISOString(),
       };
-      fs.writeFileSync(path.join(flatDir, '.work-state.json'), JSON.stringify(flatState, null, 2));
-      fs.writeFileSync(path.join(flatDir, '.step-evidence.json'), JSON.stringify({}, null, 2));
+      // GH-452: atomic writes prevent ENOENT races on Node 20 GH Actions runner.
+      atomicWriteJson(path.join(flatDir, '.work-state.json'), flatState);
+      atomicWriteJson(path.join(flatDir, '.step-evidence.json'), {});
 
       // Without suffix env, hook should look in flat path
       const { code } = await runHook(
@@ -3605,7 +3607,8 @@ describe('enforce-step-workflow', () => {
         startTime: new Date().toISOString(),
         lastUpdate: new Date().toISOString(),
       };
-      fs.writeFileSync(path.join(taskDir, '.work-state.json'), JSON.stringify(state, null, 2));
+      // GH-452: atomic write to close ENOENT race window for spawned hook reads.
+      atomicWriteJson(path.join(taskDir, '.work-state.json'), state);
     }
 
     beforeEach(() => {
@@ -4797,6 +4800,108 @@ describe('enforce-step-workflow', () => {
         code,
         2,
         'Rule 5 should run for gated script and block on untrusted path (proves no early-return)'
+      );
+    });
+  });
+
+  // GH-452: ENFORCE_HOOK_DEBUG=1 instrumentation — module-load and per-call
+  // diagnostic stderr lines used to classify the Node 20 CI failure mode.
+  describe('ENFORCE_HOOK_DEBUG instrumentation (GH-452)', () => {
+    it('emits module-load GH-452 trusted-dir realpath lines when ENFORCE_HOOK_DEBUG=1', async () => {
+      // Spawn the hook with the debug flag set. Use a minimal benign payload —
+      // we only care about the module-load stderr output, not the decision.
+      const { stderr } = await runHook(
+        { tool_name: 'Read', tool_input: { file_path: '/tmp/anything.txt' } },
+        'PreToolUse',
+        { ENFORCE_HOOK_DEBUG: '1' }
+      );
+      assert.match(
+        stderr,
+        /GH-452.*__dirname/i,
+        'expected a GH-452 __dirname diagnostic line in stderr'
+      );
+      assert.match(
+        stderr,
+        /GH-452.*trusted-dir.*realpath/i,
+        'expected a GH-452 trusted-dir realpath diagnostic line in stderr'
+      );
+    });
+
+    it('is silent (no GH-452 lines) when ENFORCE_HOOK_DEBUG is unset', async () => {
+      const { stderr } = await runHook(
+        { tool_name: 'Read', tool_input: { file_path: '/tmp/anything.txt' } },
+        'PreToolUse',
+        { ENFORCE_HOOK_DEBUG: undefined }
+      );
+      assert.doesNotMatch(
+        stderr,
+        /GH-452/,
+        'no GH-452 diagnostic lines should appear when flag is unset'
+      );
+    });
+
+    it('emits a per-call GH-452 candidate=<path> realpath=<resolved> line for a trusted script invocation', async () => {
+      // Pick a known trusted script that lives under one of the TRUSTED_SCRIPT_DIRS
+      // (workflows/work/work-state.js is referenced by the agent-gated list and
+      // resolves under workflows/work/).
+      const trustedScript = path.resolve(
+        __dirname,
+        '..',
+        '..',
+        'work',
+        'work-state.js'
+      );
+      assert.ok(
+        fs.existsSync(trustedScript),
+        'trusted candidate script must exist for this test fixture'
+      );
+      const { stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${trustedScript} get` },
+        },
+        'PreToolUse',
+        { ENFORCE_HOOK_DEBUG: '1', ENFORCE_HOOK_TICKET_ID: TEST_TICKET }
+      );
+      assert.match(
+        stderr,
+        /GH-452.*candidate=.*realpath=/i,
+        'expected a GH-452 candidate=<path> realpath=<resolved> line for the trusted invocation'
+      );
+    });
+  });
+
+  // GH-452: Node 20 CI regression — atomic state writes must close the ENOENT
+  // window where a spawned hook subprocess can read state files before the
+  // parent test process finishes writing them. Loops writeWorkState + runHook
+  // N=20 times and asserts the hook never sees ENOENT or spuriously BLOCKS due
+  // to missing state. Used to be flaky on GH Actions Node 20 runners.
+  describe('Node 20 CI regression (GH-452)', () => {
+    function simulateConcurrencyRace() {
+      return (async () => {
+        const results = [];
+        for (let i = 0; i < 20; i++) {
+          writeWorkState(makeStepStatus('implement', WORK_STEPS));
+          const r = await runHook(
+            { tool_name: 'Bash', tool_input: { command: 'echo race' } },
+            'PreToolUse'
+          );
+          results.push(r);
+        }
+        return results;
+      })();
+    }
+
+    it('never reads ENOENT or BLOCKS due to missing state across N=20 spawns', async () => {
+      const results = await simulateConcurrencyRace();
+      const enoent = results.find((r) => /ENOENT/.test(r.stderr));
+      assert.ok(!enoent, `expected no ENOENT in any spawn, got: ${enoent && enoent.stderr}`);
+      const stateBlocked = results.find(
+        (r) => r.code === 2 && /missing state|state file/i.test(r.stderr)
+      );
+      assert.ok(
+        !stateBlocked,
+        `expected no spurious BLOCKED due to missing state, got: ${stateBlocked && stateBlocked.stderr}`
       );
     });
   });

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -285,6 +285,28 @@ const TRUSTED_SCRIPT_DIRS = [
   path.resolve(__dirname, '..', '..', 'follow-up'), // workflows/follow-up/
 ];
 
+// GH-452: Normalise TRUSTED_SCRIPT_DIRS via fs.realpathSync at module load so the
+// prefix containment check does not depend on per-call realpath resolution
+// against a possibly-symlinked plugin-cache directory. Membership is NOT
+// widened — the same set of directories is normalised in place. Per-entry
+// realpath failure is fail-open (keep the unresolved path so
+// isTrustedScriptPath defence-in-depth per-call realpath retains today's
+// behaviour) and emits a `GH-452 trusted-dir realpath failed` warning on
+// stderr.
+function safeRealpath(entry) {
+  try {
+    return fs.realpathSync(entry);
+  } catch (err) {
+    process.stderr.write(
+      `GH-452 trusted-dir realpath failed: ${entry} (${err && err.code ? err.code : 'EUNKNOWN'})\n`
+    );
+    return entry;
+  }
+}
+for (let i = 0; i < TRUSTED_SCRIPT_DIRS.length; i++) {
+  TRUSTED_SCRIPT_DIRS[i] = safeRealpath(TRUSTED_SCRIPT_DIRS[i]);
+}
+
 // GH-452: Diagnostic instrumentation gated behind ENFORCE_HOOK_DEBUG=1.
 // Dumps __dirname and each TRUSTED_SCRIPT_DIRS entry alongside its realpath at
 // module load, plus a per-call candidate=<path> realpath=<resolved> line inside

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -285,26 +285,6 @@ const TRUSTED_SCRIPT_DIRS = [
   path.resolve(__dirname, '..', '..', 'follow-up'), // workflows/follow-up/
 ];
 
-// GH-452: Normalise TRUSTED_SCRIPT_DIRS via fs.realpathSync at module load so the
-// prefix containment check does not depend on per-call realpath resolution
-// against a possibly-symlinked plugin-cache directory. Membership is NOT
-// widened — the same set of directories is normalised in place. Per-entry
-// realpath failure is fail-open (keep the unresolved path so
-// isTrustedScriptPath defence-in-depth per-call realpath retains today behaviour).
-function safeRealpath(entry) {
-  try {
-    return fs.realpathSync(entry);
-  } catch (err) {
-    process.stderr.write(
-      `GH-452 trusted-dir realpath failed: ${entry} (${err && err.code ? err.code : 'EUNKNOWN'})\n`
-    );
-    return entry;
-  }
-}
-for (let i = 0; i < TRUSTED_SCRIPT_DIRS.length; i++) {
-  TRUSTED_SCRIPT_DIRS[i] = safeRealpath(TRUSTED_SCRIPT_DIRS[i]);
-}
-
 // GH-452: Diagnostic instrumentation gated behind ENFORCE_HOOK_DEBUG=1.
 // Dumps __dirname and each TRUSTED_SCRIPT_DIRS entry alongside its realpath at
 // module load, plus a per-call candidate=<path> realpath=<resolved> line inside

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -313,7 +313,7 @@ for (let i = 0; i < TRUSTED_SCRIPT_DIRS.length; i++) {
 // the authorization decision path. Used to classify CI failure modes (resolve
 // drift, symlink skew, race) without altering trust semantics. Absolute paths
 // only — no secrets. See GH-452.
-function logGh452Diagnostics() {
+function debugLogTrustedDirs() {
   if (process.env.ENFORCE_HOOK_DEBUG !== '1') return;
   process.stderr.write(`GH-452 __dirname=${__dirname}\n`);
   for (const dir of TRUSTED_SCRIPT_DIRS) {
@@ -326,7 +326,7 @@ function logGh452Diagnostics() {
     process.stderr.write(`GH-452 trusted-dir entry=${dir} realpath=${realpath}\n`);
   }
 }
-function logGh452Candidate(candidate) {
+function debugLogCandidatePath(candidate) {
   if (process.env.ENFORCE_HOOK_DEBUG !== '1') return;
   let realpath;
   try {
@@ -336,7 +336,7 @@ function logGh452Candidate(candidate) {
   }
   process.stderr.write(`GH-452 candidate=${candidate} realpath=${realpath}\n`);
 }
-logGh452Diagnostics();
+debugLogTrustedDirs();
 
 // Agent-gated writer scripts — map script basename to { agents, step }.
 // When a Bash command invokes one of these scripts, the hook verifies:
@@ -731,7 +731,7 @@ function isTerminalCompleteBypass(cmd, ticketId) {
 
   // Verify script path is trusted.
   const resolvedPath = expandPluginRoot(scriptPath);
-  logGh452Candidate(resolvedPath);
+  debugLogCandidatePath(resolvedPath);
   if (!isTrustedScriptPath(resolvedPath, TRUSTED_SCRIPT_DIRS)) {
     trace('reject: untrusted script path', { resolvedPath });
     return false;
@@ -824,7 +824,7 @@ function isTerminalSessionGuardBypass(cmd, ticketId) {
   if (i !== tokens.length) return false;
 
   const resolvedPath = expandPluginRoot(scriptPath);
-  logGh452Candidate(resolvedPath);
+  debugLogCandidatePath(resolvedPath);
   if (!isTrustedScriptPath(resolvedPath, TRUSTED_SCRIPT_DIRS)) return false;
 
   if (targetTicket !== ticketId) return false;
@@ -930,7 +930,7 @@ function handlePreToolUse(hookData) {
       if (safeSet) {
         const resolvedPath = expandPluginRoot(scriptPath);
         // Verify trusted directory - skip untrusted (Vector 3 handles those)
-        logGh452Candidate(resolvedPath);
+        debugLogCandidatePath(resolvedPath);
         if (!isTrustedScriptPath(resolvedPath, TRUSTED_SCRIPT_DIRS)) continue;
 
         const subCmd = extractSubCommand(cmd, m, scriptBase);
@@ -1016,7 +1016,7 @@ function handlePreToolUse(hookData) {
           hookAgentType: hookData?.agent_type || null,
         });
         const allowedAgents = gatedEntry.agents;
-        logGh452Candidate(scriptPath);
+        debugLogCandidatePath(scriptPath);
         if (!isTrustedScriptPath(scriptPath, TRUSTED_SCRIPT_DIRS)) {
           didBlock = true;
           const trustedSample = TRUSTED_SCRIPT_DIRS[0] || '<plugin>/scripts/workflows';

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -24,6 +24,37 @@
  * Pure rule logic lives in workflows/lib/hooks/policies/* and is unit-tested
  * in isolation. This file remains the source of truth for the wiring, the
  * documented patches (1–14), and the orchestration of the per-workflow loop.
+ *
+ * ─── GH-452: Node 20 CI hardening ──────────────────────────
+ * The Node 20 GitHub Actions runner exposed two latent issues invisible on
+ * developer machines and on Node 22/24 CI:
+ *
+ *   1. Trust-prefix drift. On the runner, the plugin cache path that
+ *      path.resolve(__dirname, '..') computes can diverge from the realpath
+ *      of the same directory (symlinks in the cache layer, cwd differences
+ *      between the spawned hook and the test parent). isTrustedScriptPath
+ *      realpaths BOTH sides per-call as defence-in-depth, but the prefix
+ *      containment compared the raw TRUSTED_SCRIPT_DIRS entries against the
+ *      resolved candidate, occasionally returning false on CI for
+ *      genuinely-trusted scripts and tripping Vector 3 assertions. Fix:
+ *      normalise TRUSTED_SCRIPT_DIRS via fs.realpathSync at module load
+ *      (per-entry, fail-open on failure with a stderr warning). Membership
+ *      is NOT widened — same set of directories, realpath form.
+ *
+ *   2. State-file ENOENT race. Tests that fs.writeFileSync a JSON state file
+ *      (e.g. .work-state.json) and immediately spawn the hook can race
+ *      the spawned subprocess on the runner: the child reads the file before
+ *      the parent's write becomes visible. Tests now route every JSON-state
+ *      write through an atomicWriteJson helper (tmp + rename + directory
+ *      fsync) which closes the window.
+ *
+ *   3. Diagnostic switch. ENFORCE_HOOK_DEBUG=1 dumps __dirname, each
+ *      TRUSTED_SCRIPT_DIRS entry alongside its realpath, and a per-call
+ *      GH-452 candidate=<path> realpath=<resolved> line. Used to classify
+ *      future drift fast on CI. Output is stderr-only, absolute paths only.
+ *
+ * The fix preserves the trust boundary: an untrusted script under
+ * os.tmpdir() still exits 2 with BLOCKED. Tracking: GH-452.
  */
 
 const fs = require('fs');
@@ -253,6 +284,57 @@ const TRUSTED_SCRIPT_DIRS = [
   path.resolve(__dirname, '..', '..', 'check2'), // workflows/check2/
   path.resolve(__dirname, '..', '..', 'follow-up'), // workflows/follow-up/
 ];
+
+// GH-452: Normalise TRUSTED_SCRIPT_DIRS via fs.realpathSync at module load so the
+// prefix containment check does not depend on per-call realpath resolution
+// against a possibly-symlinked plugin-cache directory. Membership is NOT
+// widened — the same set of directories is normalised in place. Per-entry
+// realpath failure is fail-open (keep the unresolved path so
+// isTrustedScriptPath defence-in-depth per-call realpath retains today behaviour).
+function safeRealpath(entry) {
+  try {
+    return fs.realpathSync(entry);
+  } catch (err) {
+    process.stderr.write(
+      `GH-452 trusted-dir realpath failed: ${entry} (${err && err.code ? err.code : 'EUNKNOWN'})\n`
+    );
+    return entry;
+  }
+}
+for (let i = 0; i < TRUSTED_SCRIPT_DIRS.length; i++) {
+  TRUSTED_SCRIPT_DIRS[i] = safeRealpath(TRUSTED_SCRIPT_DIRS[i]);
+}
+
+// GH-452: Diagnostic instrumentation gated behind ENFORCE_HOOK_DEBUG=1.
+// Dumps __dirname and each TRUSTED_SCRIPT_DIRS entry alongside its realpath at
+// module load, plus a per-call candidate=<path> realpath=<resolved> line inside
+// the authorization decision path. Used to classify CI failure modes (resolve
+// drift, symlink skew, race) without altering trust semantics. Absolute paths
+// only — no secrets. See GH-452.
+function logGh452Diagnostics() {
+  if (process.env.ENFORCE_HOOK_DEBUG !== '1') return;
+  process.stderr.write(`GH-452 __dirname=${__dirname}\n`);
+  for (const dir of TRUSTED_SCRIPT_DIRS) {
+    let realpath;
+    try {
+      realpath = fs.realpathSync(dir);
+    } catch (err) {
+      realpath = `<realpath-error: ${err && err.code ? err.code : 'EUNKNOWN'}>`;
+    }
+    process.stderr.write(`GH-452 trusted-dir entry=${dir} realpath=${realpath}\n`);
+  }
+}
+function logGh452Candidate(candidate) {
+  if (process.env.ENFORCE_HOOK_DEBUG !== '1') return;
+  let realpath;
+  try {
+    realpath = fs.realpathSync(path.resolve(candidate));
+  } catch (err) {
+    realpath = `<realpath-error: ${err && err.code ? err.code : 'EUNKNOWN'}>`;
+  }
+  process.stderr.write(`GH-452 candidate=${candidate} realpath=${realpath}\n`);
+}
+logGh452Diagnostics();
 
 // Agent-gated writer scripts — map script basename to { agents, step }.
 // When a Bash command invokes one of these scripts, the hook verifies:
@@ -647,6 +729,7 @@ function isTerminalCompleteBypass(cmd, ticketId) {
 
   // Verify script path is trusted.
   const resolvedPath = expandPluginRoot(scriptPath);
+  logGh452Candidate(resolvedPath);
   if (!isTrustedScriptPath(resolvedPath, TRUSTED_SCRIPT_DIRS)) {
     trace('reject: untrusted script path', { resolvedPath });
     return false;
@@ -739,6 +822,7 @@ function isTerminalSessionGuardBypass(cmd, ticketId) {
   if (i !== tokens.length) return false;
 
   const resolvedPath = expandPluginRoot(scriptPath);
+  logGh452Candidate(resolvedPath);
   if (!isTrustedScriptPath(resolvedPath, TRUSTED_SCRIPT_DIRS)) return false;
 
   if (targetTicket !== ticketId) return false;
@@ -844,6 +928,7 @@ function handlePreToolUse(hookData) {
       if (safeSet) {
         const resolvedPath = expandPluginRoot(scriptPath);
         // Verify trusted directory - skip untrusted (Vector 3 handles those)
+        logGh452Candidate(resolvedPath);
         if (!isTrustedScriptPath(resolvedPath, TRUSTED_SCRIPT_DIRS)) continue;
 
         const subCmd = extractSubCommand(cmd, m, scriptBase);
@@ -929,6 +1014,7 @@ function handlePreToolUse(hookData) {
           hookAgentType: hookData?.agent_type || null,
         });
         const allowedAgents = gatedEntry.agents;
+        logGh452Candidate(scriptPath);
         if (!isTrustedScriptPath(scriptPath, TRUSTED_SCRIPT_DIRS)) {
           didBlock = true;
           const trustedSample = TRUSTED_SCRIPT_DIRS[0] || '<plugin>/scripts/workflows';


### PR DESCRIPTION
## Existing Behavior

- `TRUSTED_SCRIPT_DIRS` in `enforce-step-workflow.js` is built using `path.resolve(__dirname, '..')` at module load, producing raw paths without realpath resolution.
- When the hook module is loaded through a symlinked plugin-cache ancestor (as in the Node 20 CI runner), `__dirname` contains the symlink path rather than the real filesystem path.
- `isTrustedScriptPath()` compares a realpath-resolved candidate against symlinked (non-canonical) trusted-dir entries — the containment check fails and legitimate trusted scripts are BLOCKED.
- This produces three Node 20 CI failures in the enforce-step-workflow test suite (`not ok 11`, `not ok 23`, `not ok 102`).

## Intended New Behavior

- A `safeRealpath(entry)` helper is introduced; it calls `fs.realpathSync()` and falls back to the original unresolved path on failure, emitting a warning to stderr (fail-open per entry).
- A normalisation loop at module load runs `safeRealpath()` over every `TRUSTED_SCRIPT_DIRS` entry so all entries are canonical real paths before any trust comparison occurs.
- `isTrustedScriptPath()` retains its per-call `fs.realpathSync` on the candidate, providing defence-in-depth.
- Node 20 CI failures are resolved: trusted scripts loaded via symlinked ancestors are correctly allowed; untrusted `/tmp`-placed scripts remain BLOCKED.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / hook behaviour:**

1. Run the full unit suite locally on Node 20 via `pnpm test`.
   Expected: all tests pass, including the three previously-failing assertions (`not ok 11`, `not ok 23`, `not ok 102`).

2. Symlink-cache normalisation: the new test creates a temp dir symlinked to the real workflows directory, spawns the hook with `--preserve-symlinks`, and asserts no `trustedDirs` entry still contains the symlink path segment.

3. Fail-open: a companion test creates a dangling symlink for one `TRUSTED_SCRIPT_DIRS` entry; the hook must retain the unresolved path and emit a warning rather than throwing.

4. Trust boundary: a fake orchestrator script placed in `os.tmpdir()` must still receive exit 2 (BLOCKED) — the normalisation must not widen the set of trusted paths.

### Test Results
Node 22 was already green. Node 20 failures (`not ok 11`, `not ok 23`, `not ok 102`) are resolved by the module-load normalisation introduced in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trust-directory resolution for the enforcement hook (security-sensitive) but keeps the same directory set and adds regression tests; mis-normalization could affect allow/block decisions on CI.
> 
> **Overview**
> Hardens the **enforce-step-workflow** hook and its test suite for **Node 20 GitHub Actions** (GH-452): symlinked plugin-cache paths were causing trusted-script checks to fail, and tests could race spawned hook reads against non-atomic state writes.
> 
> In **`enforce-step-workflow.js`**, **`TRUSTED_SCRIPT_DIRS`** is now canonicalized at module load via **`safeRealpath`** (`fs.realpathSync` per entry, fail-open with a stderr warning if resolution fails). Optional **`ENFORCE_HOOK_DEBUG=1`** logs `__dirname`, each trusted-dir entry/realpath, and per-invocation **candidate/realpath** lines on the authorization path—without changing allow/block semantics.
> 
> The **test file** routes workflow/state JSON setup through **`atomicWriteJson`** (and **`writeRawAtomic`** for deliberate corrupt payloads), adds a **20-iteration** spawn loop to guard against **ENOENT** / spurious blocks, a **self-scan** that forbids raw **`fs.writeFileSync`** on state JSON shapes, and coverage for debug output, symlinked require paths (`--preserve-symlinks`), fail-open on a broken trusted-dir entry, and that an **untrusted** exempt-named script under **`os.tmpdir()`** still **BLOCK**s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38fdabe661ee9a693de1ac5c234be7bc33230bbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->