### PR TITLE
fix(follow-up): cross-reference pending bots against CI check status to avoid infinite wait loop

### DIFF
--- a/plugins/work/scripts/workflows/work/scripts/follow-up-pr.js
+++ b/plugins/work/scripts/workflows/work/scripts/follow-up-pr.js
@@ -755,12 +755,60 @@ function getReviews(prNumber) {
       'chatgpt-codex-connector[bot]': ['chatgpt-codex-connector'],
       'chatgpt-codex-connector': ['chatgpt-codex-connector[bot]'],
     };
+    // Cross-reference with CI check status: if the bot's status check has
+    // already COMPLETED, the bot is effectively done even if GitHub's
+    // requested_reviewers API hasn't caught up yet. Without this guard, a
+    // green CI run with a lagging requested_reviewers entry would trap the
+    // monitor in an "awaiting bot reviews" wait loop forever.
+    // Keyword map: bot login → substring(s) found in its status-check name.
+    const botCheckKeywords = {
+      'copilot-pull-request-reviewer': ['copilot'],
+      'cursor-ai[bot]': ['cursor', 'bugbot'],
+      'cursor-ai': ['cursor', 'bugbot'],
+      'chatgpt-codex-connector[bot]': ['codex', 'chatgpt'],
+      'chatgpt-codex-connector': ['codex', 'chatgpt'],
+    };
+    const checks = data.statusCheckRollup || [];
+    const isTerminalNonCancelled = (ck) => {
+      if (ck.status === 'COMPLETED') {
+        // CheckRun shape — `conclusion` carries the outcome. CANCELLED /
+        // SKIPPED / STALE / TIMED_OUT mean the run was aborted before
+        // finishing; the bot did NOT actually produce a verdict.
+        const conclusion = (ck.conclusion || '').toUpperCase();
+        return conclusion === 'SUCCESS' || conclusion === 'FAILURE' || conclusion === 'NEUTRAL';
+      }
+      // StatusContext shape — terminal states are SUCCESS / FAILURE / ERROR.
+      return ck.state === 'SUCCESS' || ck.state === 'FAILURE' || ck.state === 'ERROR';
+    };
+    const isStillRunning = (ck) => {
+      if (ck.status && ck.status !== 'COMPLETED') return true;
+      if (ck.state === 'PENDING' || ck.state === 'EXPECTED') return true;
+      return false;
+    };
+    const botCheckCompleted = (bot) => {
+      const keywords = botCheckKeywords[bot.toLowerCase()] || botCheckKeywords[bot] || [
+        bot.toLowerCase().replace(/\[bot\]$/, ''),
+      ];
+      const matching = checks.filter((ck) => {
+        const name = (ck.name || ck.context || '').toLowerCase();
+        return keywords.some((kw) => name.includes(kw));
+      });
+      if (matching.length === 0) return false;
+      // statusCheckRollup can contain multiple entries for the same check
+      // when workflows use `concurrency: cancel-in-progress` — an old
+      // CANCELLED run plus a newer IN_PROGRESS run. If ANY matching entry
+      // is still running, the bot is NOT done — even if an older run has
+      // a terminal conclusion.
+      if (matching.some(isStillRunning)) return false;
+      // At least one non-cancelled terminal verdict means the bot finished.
+      return matching.some(isTerminalNonCancelled);
+    };
     for (const bot of botReviewers) {
       const aliases = botLoginAliases[bot] || [bot.toLowerCase()];
       const isPending = requestedLogins.some((login) =>
         aliases.some((alias) => login === alias || login.includes(alias))
       );
-      if (isPending) {
+      if (isPending && !botCheckCompleted(bot)) {
         pendingBots.push(bot);
       }
     }


### PR DESCRIPTION
## Existing Behavior

- `getReviews` computes `pendingBots` exclusively from GitHub's `requested_reviewers` REST API field.
- When a bot's status check (e.g. Cursor Bugbot) flips to `COMPLETED`, GitHub's `requested_reviewers` list does not immediately reflect that — the API lag can be several minutes.
- During this lag window, the monitor emits `Reviews: Awaiting bot reviews`, `triage.js:118-124` routes back to `monitor` with a 30-60s wait, and the workflow continues polling on already-green CI.
- This polling loop runs until it hits the 40-attempt cap, leaving a merge-clean PR blocked for up to ~10 minutes with no action taken.

## Intended New Behavior

- `getReviews` cross-references each pending bot against `data.statusCheckRollup` before adding it to `pendingBots`.
- A bot-check keyword map (`cursor`/`bugbot` for cursor-ai; `copilot` for copilot; `codex`/`chatgpt` for codex) is used to match the bot login against its corresponding status-check name.
- If a matching check is `COMPLETED` (or has a terminal `SUCCESS`/`FAILURE` state), the bot is dropped from `pendingBots` — the bot is done; the API simply hasn't caught up yet.
- When all bots are resolved via check status, the workflow proceeds immediately to `action: complete` instead of entering the wait loop.
- Behavior is unchanged when the bot's check has not yet completed, and the fallback `catch` branch is unaffected.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Verify on a PR where Cursor Bugbot's check has just flipped to ✅ but `requested_reviewers` still lists cursor-ai:

1. Open a PR that has Cursor Bugbot as a requested reviewer.
2. Wait for Cursor Bugbot's status check to complete (green) while `requested_reviewers` still shows it pending (API lag window).
3. Run `/follow-up` against that PR.
4. **Expected (fixed):** The workflow reads `statusCheckRollup`, finds `cursor`/`bugbot` keywords in a `COMPLETED` check, drops the bot from `pendingBots`, and transitions to `action: complete` immediately.
5. **Previously (broken):** The workflow would emit `Reviews: Awaiting bot reviews` and loop for up to 40 attempts (~10 minutes) before surfacing the PR.

To verify the guard does not fire prematurely:

1. Open a PR where Cursor Bugbot is requested but its check is still `IN_PROGRESS`.
2. Run `/follow-up` — the bot should remain in `pendingBots` and the monitor should correctly report it as pending.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when follow-up considers bot reviews finished by inferring completion from check names and rollup shape; mis-matched keywords or concurrency edge cases could clear pending too early or too late, but scope is limited to the monitor’s pending-bot list.
> 
> **Overview**
> The follow-up PR monitor no longer treats a bot as **awaiting review** solely because it still appears in GitHub’s `requested_reviewers` API. **`getReviews`** now cross-checks each configured bot against **`statusCheckRollup`** using name keywords (e.g. Cursor/Bugbot, Copilot, Codex/ChatGPT).
> 
> A bot is removed from **`pendingBots`** when its matching check has a **real terminal outcome** (`SUCCESS`, `FAILURE`, or `NEUTRAL` on CheckRuns; `SUCCESS`/`FAILURE`/`ERROR` on legacy contexts), while **ignoring** aborted conclusions (`CANCELLED`, `SKIPPED`, etc.). If **any** matching rollup entry is still in progress—including duplicate entries from **cancel-in-progress** workflows—the bot stays pending.
> 
> The pending condition changes from “listed as requested reviewer” to “listed **and** bot check not completed,” so green CI with stale reviewer state can proceed instead of polling until the attempt cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61535f4220f8b9295878edc6b02d61bda26d1a6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->