### PR TITLE
Chore/bump all plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
-    "version": "3.13.0"
+    "version": "3.13.1"
   },
   "plugins": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
   "license": "MIT",
   "repository": {

--- a/plugins/heimdall/.claude-plugin/plugin.json
+++ b/plugins/heimdall/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "heimdall",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Config-driven file/directory guard. Lock blocks declare protected paths + an unlock phrase; a PreToolUse hook blocks Edit/Write/Bash/Task mutations to those paths unless the user speaks the phrase. Stores are local, worktree, or global like synapsys.",
   "author": {
     "name": "Custom",

--- a/plugins/maestro/.claude-plugin/plugin.json
+++ b/plugins/maestro/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Multi-agent orchestrator. Bootstraps per-ticket tmux sessions in isolated worktrees, conducts them (auto-restart on silence, surface real prompts to the operator), and exposes a file-mailbox signal channel.",
   "author": {
     "name": "Custom",

--- a/plugins/synapsys/.claude-plugin/plugin.json
+++ b/plugins/synapsys/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsys",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Context-triggered memory injection. Memories declare trigger patterns + lifecycle events in frontmatter; matching memories are injected into Claude's context on the right hook.",
   "author": {
     "name": "Custom",

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Self-contained workflow plugin with agents, hooks, skills, and orchestration. Includes 18 specialized agents, agent-specific hooks, and 25 skills.",
   "author": {
     "name": "Custom",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version bumps with no logic or dependency changes.
> 
> **Overview**
> This PR only **bumps published version strings** so the root package, marketplace metadata, and each plugin manifest stay aligned for release or install.
> 
> **work-workflow** moves from `3.13.0` to `3.13.1` in `package.json`, `.claude-plugin/marketplace.json` (`metadata.version`), and `plugins/work/.claude-plugin/plugin.json`. **heimdall** and **maestro** go `0.1.0` → `0.1.1`; **synapsys** goes `0.1.2` → `0.1.3`. No runtime code, hooks, or config behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca563fa1070d1d01ba3d6c7abc3a22dee0f8dfe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->