### PR TITLE
fix(synapsys): polish staleness-check — tests, JSON output, stdout/color and crystallize docs

### DIFF
--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -114,6 +114,63 @@ node plugins/synapsys/scripts/synapsys-explain.js --event=... --verbose
 
 `--only=<csv>` narrows evaluation to specific memories. `--store=<name|path>` picks a non-auto-detected store. Exit code is `0` regardless of how many memories fired; `2` only on misconfiguration.
 
+## Staleness check
+
+`synapsys-staleness-check.js` verifies that consolidated memories are still in sync with the source notes they were built from. Run it manually before a release, in CI on every PR, or as a pre-commit hook to catch drift early.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Fresh — every consolidated memory matches its source notes; no orphan notes. |
+| `1` | Drift or orphan — at least one consolidated memory is out of date, or at least one source note is not consolidated. |
+| `2` | Misconfiguration — invalid flags, missing store, or unreadable frontmatter. |
+
+### Manual
+
+```bash
+node plugins/synapsys/scripts/synapsys-staleness-check.js
+node plugins/synapsys/scripts/synapsys-staleness-check.js --verbose
+node plugins/synapsys/scripts/synapsys-staleness-check.js --json
+node plugins/synapsys/scripts/synapsys-staleness-check.js --store=local
+```
+
+`--verbose` prints per-memory hash comparisons. `--json` emits a machine-readable report. `--store=<name|path>` narrows the check to a single store.
+
+### CI
+
+```yaml
+# .github/workflows/synapsys-staleness.yml
+name: synapsys-staleness
+on: [pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check consolidated memories are fresh
+        run: |
+          PLUGIN="plugins/synapsys"
+          node "$PLUGIN/scripts/synapsys-staleness-check.js"
+```
+
+The job fails on exit `1` (drift) or `2` (misconfig); exit `0` keeps the PR green.
+
+### Pre-commit
+
+```bash
+# .git/hooks/pre-commit (or via husky/lefthook)
+#!/usr/bin/env bash
+node plugins/synapsys/scripts/synapsys-staleness-check.js || {
+  echo "synapsys: consolidated memories are stale — re-consolidate before committing." >&2
+  exit 1
+}
+```
+
+### `--re-consolidate`
+
+Once GH-442 lands the `consolidate` skill, passing `--re-consolidate` will rebuild any drifted memory in-place instead of just reporting drift. Until then the flag is a no-op placeholder.
+
 ## Design choices
 
 - **Fail-open** — any error in the dispatcher exits 0 with no output. Memory injection must never block a user prompt or tool call.

--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -169,7 +169,7 @@ node plugins/synapsys/scripts/synapsys-staleness-check.js || {
 
 ### `--re-consolidate`
 
-Once GH-442 lands the `consolidate` skill, passing `--re-consolidate` will rebuild any drifted memory in-place instead of just reporting drift. Until then the flag is a no-op placeholder.
+Passing `--re-consolidate` dispatches the owning profile for each drifted source by spawning the sibling consolidate script with `--profile=<name>`. Profile ownership is resolved by intersecting each profile module's declared source paths against the drifted source. Orphan sources (whose source file no longer exists) are skipped — they require human judgement. Ambiguous sources (claimed by multiple profiles) emit a warning and are skipped. Profile lookup requires the `consolidate-profiles/` directory, which is delivered by GH-442; until it lands, `--re-consolidate` will warn that no profile owns the source and exit non-zero.
 
 ## Design choices
 

--- a/plugins/synapsys/lib/__tests__/staleness.test.js
+++ b/plugins/synapsys/lib/__tests__/staleness.test.js
@@ -1,0 +1,196 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { hashFile, classifyMemory, groupResultsBySource, summarise } = require('../staleness');
+
+const repoRoot = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'sample-repo');
+const docARel = 'docs/a.md';
+const docBRel = 'docs/b.md';
+const docCRel = 'docs/c.md'; // intentionally absent
+
+function sha256OfFile(absPath) {
+  const buf = fs.readFileSync(absPath);
+  return 'sha256:' + crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+const knownHashA = sha256OfFile(path.join(repoRoot, docARel));
+
+test('hashFile returns sha256:<64-hex> for an existing file', () => {
+  const result = hashFile(path.join(repoRoot, docARel));
+  assert.match(result, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(result, knownHashA);
+});
+
+test('hashFile returns null for a missing file', () => {
+  const result = hashFile(path.join(repoRoot, 'docs', 'does-not-exist.md'));
+  assert.equal(result, null);
+});
+
+test('CASE 1 — classifyMemory returns fresh when stored_hash matches current', () => {
+  const memory = {
+    name: 'mem-a.md',
+    meta: { source: docARel, source_hash: knownHashA },
+  };
+  const result = classifyMemory(memory, { repoRoot });
+  assert.equal(result.status, 'fresh');
+  assert.equal(result.current_hash, knownHashA);
+  assert.equal(result.stored_hash, knownHashA);
+  assert.equal(result.current_hash, result.stored_hash);
+});
+
+test('CASE 2 — classifyMemory returns drifted when stored_hash differs from current', () => {
+  const mutated = 'sha256:' + 'a'.repeat(64);
+  const memory = {
+    name: 'mem-a.md',
+    meta: { source: docARel, source_hash: mutated },
+  };
+  const result = classifyMemory(memory, { repoRoot });
+  assert.equal(result.status, 'drifted');
+  assert.equal(result.stored_hash, mutated);
+  assert.equal(result.current_hash, knownHashA);
+  assert.notEqual(result.current_hash, result.stored_hash);
+  assert.ok(result.stored_hash);
+  assert.ok(result.current_hash);
+});
+
+test('CASE 3 — classifyMemory returns orphan when source file is missing', () => {
+  const memory = {
+    name: 'mem-c.md',
+    meta: { source: docCRel, source_hash: 'sha256:' + 'b'.repeat(64) },
+  };
+  const result = classifyMemory(memory, { repoRoot });
+  assert.equal(result.status, 'orphan');
+  assert.equal(result.current_hash, null);
+});
+
+test('CASE 4 — classifyMemory returns skip when source_hash is missing (manual memory)', () => {
+  const memory = {
+    name: 'manual.md',
+    meta: { /* no source_hash, possibly no source */ },
+  };
+  const result = classifyMemory(memory, { repoRoot });
+  assert.equal(result.status, 'skip');
+});
+
+test('classifyMemory classifies path-traversal source as orphan', () => {
+  const memory = {
+    name: 'evil.md',
+    meta: { source: '../../etc/passwd', source_hash: 'sha256:' + 'c'.repeat(64) },
+  };
+  const result = classifyMemory(memory, { repoRoot });
+  assert.equal(result.status, 'orphan');
+  assert.equal(result.current_hash, null);
+});
+
+test('groupResultsBySource groups by source, sorts memories asc, and filters skip', () => {
+  const storedA = 'sha256:' + '1'.repeat(64);
+  const storedB = 'sha256:' + '2'.repeat(64);
+  const currentA = 'sha256:' + '3'.repeat(64);
+  const classifications = [
+    // Two memories share docARel (drifted) — memories must sort asc.
+    {
+      name: 'zeta.md',
+      status: 'drifted',
+      source: docARel,
+      stored_hash: storedA,
+      current_hash: currentA,
+    },
+    {
+      name: 'alpha.md',
+      status: 'drifted',
+      source: docARel,
+      stored_hash: storedA,
+      current_hash: currentA,
+    },
+    // Orphan with its own source
+    {
+      name: 'orph.md',
+      status: 'orphan',
+      source: docCRel,
+      stored_hash: storedB,
+      current_hash: null,
+    },
+    // Fresh with docBRel
+    {
+      name: 'mid.md',
+      status: 'fresh',
+      source: docBRel,
+      stored_hash: storedB,
+      current_hash: storedB,
+    },
+    // skip must be filtered
+    { name: 'manual.md', status: 'skip' },
+  ];
+  const grouped = groupResultsBySource(classifications);
+  assert.ok(Array.isArray(grouped));
+  assert.equal(grouped.length, 3, 'three source groups (skip filtered)');
+  // No skip groups
+  assert.equal(grouped.find((g) => g.status === 'skip'), undefined);
+
+  const docAGroup = grouped.find((g) => g.source === docARel);
+  assert.ok(docAGroup, 'docA group exists');
+  assert.equal(docAGroup.status, 'drifted');
+  assert.equal(docAGroup.stored_hash, storedA);
+  assert.equal(docAGroup.current_hash, currentA);
+  assert.deepEqual(docAGroup.memories, ['alpha.md', 'zeta.md']);
+
+  const docCGroup = grouped.find((g) => g.source === docCRel);
+  assert.ok(docCGroup);
+  assert.equal(docCGroup.status, 'orphan');
+  assert.deepEqual(docCGroup.memories, ['orph.md']);
+
+  const docBGroup = grouped.find((g) => g.source === docBRel);
+  assert.ok(docBGroup);
+  assert.equal(docBGroup.status, 'fresh');
+  assert.deepEqual(docBGroup.memories, ['mid.md']);
+});
+
+test('summarise returns drifted/orphan/fresh counts plus totalAffectedMemories and fresh_memories', () => {
+  const storedA = 'sha256:' + '1'.repeat(64);
+  const storedB = 'sha256:' + '2'.repeat(64);
+  const storedC = 'sha256:' + '4'.repeat(64);
+  const currentA = 'sha256:' + '3'.repeat(64);
+  const grouped = [
+    {
+      source: 'docs/a.md',
+      status: 'drifted',
+      stored_hash: storedA,
+      current_hash: currentA,
+      memories: ['alpha.md', 'zeta.md'],
+    },
+    {
+      source: 'docs/b.md',
+      status: 'fresh',
+      stored_hash: storedB,
+      current_hash: storedB,
+      memories: ['mid.md'],
+    },
+    {
+      source: 'docs/c.md',
+      status: 'orphan',
+      stored_hash: storedC,
+      current_hash: null,
+      memories: ['orph.md'],
+    },
+    {
+      source: 'docs/d.md',
+      status: 'fresh',
+      stored_hash: storedB,
+      current_hash: storedB,
+      memories: ['delta.md', 'echo.md'],
+    },
+  ];
+  const summary = summarise(grouped);
+  assert.equal(summary.drifted, 1);
+  assert.equal(summary.orphan, 1);
+  assert.equal(summary.fresh, 2);
+  // totalAffectedMemories counts memories under drifted + orphan groups (alpha, zeta, orph = 3)
+  assert.equal(summary.totalAffectedMemories, 3);
+  // fresh_memories counts memories under fresh groups (mid, delta, echo = 3)
+  assert.equal(summary.fresh_memories, 3);
+});

--- a/plugins/synapsys/lib/staleness.js
+++ b/plugins/synapsys/lib/staleness.js
@@ -188,23 +188,6 @@ function summarise(grouped) {
   return summary;
 }
 
-/**
- * Look up which consolidate profile (if any) owns a given source path by
- * scanning all `.js` files under `profilesDir`. Each profile module must
- * export an object containing at least a `sources` array. Profiles
- * intersecting the requested `sourcePath` are collected.
- *
- *   - No `profilesDir` or directory missing → returns `null` (tolerated).
- *   - 0 hits                                → returns `null`.
- *   - 1 hit                                 → returns `{ name }` (falls back
- *                                             to the filename stem when the
- *                                             module did not export `name`).
- *   - >1 hits                               → returns
- *                                             `{ ambiguous: true, profiles: [names] }`.
- *
- * @param {string} sourcePath repo-relative source path (e.g. 'docs/a.md')
- * @param {{ profilesDir?: string }} [opts]
- */
 function loadProfileModule(absPath) {
   try {
     delete require.cache[require.resolve(absPath)];
@@ -233,6 +216,23 @@ function listProfileEntries(profilesDir) {
   }
 }
 
+/**
+ * Look up which consolidate profile (if any) owns a given source path by
+ * scanning all `.js` files under `profilesDir`. Each profile module must
+ * export an object containing at least a `sources` array. Profiles
+ * intersecting the requested `sourcePath` are collected.
+ *
+ *   - No `profilesDir` or directory missing → returns `null` (tolerated).
+ *   - 0 hits                                → returns `null`.
+ *   - 1 hit                                 → returns `{ name }` (falls back
+ *                                             to the filename stem when the
+ *                                             module did not export `name`).
+ *   - >1 hits                               → returns
+ *                                             `{ ambiguous: true, profiles: [names] }`.
+ *
+ * @param {string} sourcePath repo-relative source path (e.g. 'docs/a.md')
+ * @param {{ profilesDir?: string }} [opts]
+ */
 function getProfileForSource(sourcePath, opts) {
   const profilesDir = opts && opts.profilesDir;
   const entries = listProfileEntries(profilesDir);

--- a/plugins/synapsys/lib/staleness.js
+++ b/plugins/synapsys/lib/staleness.js
@@ -189,34 +189,41 @@ function summarise(grouped) {
  * @param {string} sourcePath repo-relative source path (e.g. 'docs/a.md')
  * @param {{ profilesDir?: string }} [opts]
  */
-function getProfileForSource(sourcePath, opts) {
-  const profilesDir = opts && opts.profilesDir;
-  if (!profilesDir || typeof profilesDir !== 'string') return null;
-  if (!fs.existsSync(profilesDir)) return null;
-  let entries;
+function loadProfileModule(absPath) {
   try {
-    entries = fs.readdirSync(profilesDir);
+    delete require.cache[require.resolve(absPath)];
+    return require(absPath);
   } catch (_e) {
     return null;
   }
+}
+
+function profileClaimsSource(mod, sourcePath) {
+  return mod && Array.isArray(mod.sources) && mod.sources.includes(sourcePath);
+}
+
+function profileName(mod, entry) {
+  if (mod && typeof mod.name === 'string' && mod.name.length > 0) return mod.name;
+  return path.basename(entry, '.js');
+}
+
+function listProfileEntries(profilesDir) {
+  if (!profilesDir || typeof profilesDir !== 'string') return [];
+  if (!fs.existsSync(profilesDir)) return [];
+  try {
+    return fs.readdirSync(profilesDir).filter((e) => e.endsWith('.js'));
+  } catch (_e) {
+    return [];
+  }
+}
+
+function getProfileForSource(sourcePath, opts) {
+  const profilesDir = opts && opts.profilesDir;
+  const entries = listProfileEntries(profilesDir);
   const hits = [];
   for (const entry of entries) {
-    if (!entry.endsWith('.js')) continue;
-    const abs = path.join(profilesDir, entry);
-    let mod;
-    try {
-      // Bust require cache so test sandboxes are not contaminated.
-      delete require.cache[require.resolve(abs)];
-      mod = require(abs);
-    } catch (_e) {
-      continue;
-    }
-    if (!mod || !Array.isArray(mod.sources)) continue;
-    if (!mod.sources.includes(sourcePath)) continue;
-    const name = typeof mod.name === 'string' && mod.name.length > 0
-      ? mod.name
-      : path.basename(entry, '.js');
-    hits.push(name);
+    const mod = loadProfileModule(path.join(profilesDir, entry));
+    if (profileClaimsSource(mod, sourcePath)) hits.push(profileName(mod, entry));
   }
   if (hits.length === 0) return null;
   if (hits.length === 1) return { name: hits[0] };

--- a/plugins/synapsys/lib/staleness.js
+++ b/plugins/synapsys/lib/staleness.js
@@ -1,0 +1,232 @@
+'use strict';
+
+/**
+ * Pure helpers for synapsys staleness detection.
+ *
+ * Public API:
+ *   - hashFile(absPath) — returns 'sha256:<hex>' or null if the file is missing.
+ *   - classifyMemory(memory, { repoRoot }) — classifies a memory as
+ *     'fresh' | 'drifted' | 'orphan' | 'skip' based on its frontmatter
+ *     `source` / `source_hash` vs the current on-disk source file.
+ *
+ * No I/O outside `hashFile`. `classifyMemory` is pure given { repoRoot }
+ * (modulo the single read inside hashFile).
+ *
+ * Reuses only Node stdlib: node:fs, node:path, node:crypto.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+/**
+ * Compute the sha256 of a file's raw bytes.
+ * @param {string} absPath absolute path to the file
+ * @returns {string|null} 'sha256:<64-hex>' or null when the file is missing
+ */
+function hashFile(absPath) {
+  if (!absPath || !fs.existsSync(absPath)) return null;
+  const buf = fs.readFileSync(absPath);
+  return 'sha256:' + crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+/**
+ * Resolve `source` against `repoRoot`. Returns the absolute path only when
+ * the resolved path is still inside repoRoot; otherwise returns null
+ * (path-traversal guard).
+ */
+function resolveSafeAbsPath(source, repoRoot) {
+  if (typeof source !== 'string' || source.length === 0) return null;
+  const normalizedRoot = path.resolve(repoRoot);
+  const resolved = path.resolve(normalizedRoot, source);
+  const rootWithSep = normalizedRoot.endsWith(path.sep)
+    ? normalizedRoot
+    : normalizedRoot + path.sep;
+  if (resolved !== normalizedRoot && !resolved.startsWith(rootWithSep)) {
+    return null;
+  }
+  return resolved;
+}
+
+/**
+ * Classify a single memory against its source file.
+ * @param {{ name?: string, meta?: { source?: string, source_hash?: string } }} memory
+ * @param {{ repoRoot: string }} ctx
+ */
+function classifyMemory(memory, ctx) {
+  const meta = (memory && memory.meta) || {};
+  const storedHash = meta.source_hash;
+  const source = meta.source;
+
+  // R3: no source_hash → skip (manual memory, not produced by consolidate).
+  if (!storedHash) {
+    return { status: 'skip' };
+  }
+
+  const repoRoot = ctx && ctx.repoRoot;
+  const safeAbs = resolveSafeAbsPath(source, repoRoot);
+
+  // Path-traversal escape OR no source declared → classify as orphan.
+  if (!safeAbs) {
+    return {
+      status: 'orphan',
+      source,
+      stored_hash: storedHash,
+      current_hash: null,
+    };
+  }
+
+  const currentHash = hashFile(safeAbs);
+
+  if (currentHash === null) {
+    return {
+      status: 'orphan',
+      source,
+      stored_hash: storedHash,
+      current_hash: null,
+    };
+  }
+
+  if (currentHash === storedHash) {
+    return {
+      status: 'fresh',
+      source,
+      stored_hash: storedHash,
+      current_hash: currentHash,
+    };
+  }
+
+  return {
+    status: 'drifted',
+    source,
+    stored_hash: storedHash,
+    current_hash: currentHash,
+  };
+}
+
+/**
+ * Group classifications by source path. Each group reports the source's
+ * single status / stored_hash / current_hash (drifted, orphan, or fresh)
+ * and the alphabetically-sorted list of memory names that reference it.
+ * `skip` classifications are filtered out.
+ *
+ * Expected input shape: array of objects returned by classifyMemory plus
+ * a `name` field copied from the originating memory, i.e.
+ *   { name, status, source, stored_hash, current_hash }
+ *
+ * @param {Array<{name?: string, status: string, source?: string,
+ *   stored_hash?: string, current_hash?: string|null}>} classifications
+ * @returns {Array<{source: string, status: string, stored_hash?: string,
+ *   current_hash?: string|null, memories: string[]}>}
+ */
+function groupResultsBySource(classifications) {
+  if (!Array.isArray(classifications)) return [];
+  const bySource = new Map();
+  for (const c of classifications) {
+    if (!c || c.status === 'skip') continue;
+    const key = c.source;
+    if (!bySource.has(key)) {
+      bySource.set(key, {
+        source: c.source,
+        status: c.status,
+        stored_hash: c.stored_hash,
+        current_hash: c.current_hash,
+        memories: [],
+      });
+    }
+    if (c.name) bySource.get(key).memories.push(c.name);
+  }
+  const groups = Array.from(bySource.values());
+  for (const g of groups) g.memories.sort();
+  return groups;
+}
+
+/**
+ * Reduce grouped results to summary counters.
+ *
+ * @param {ReturnType<typeof groupResultsBySource>} grouped
+ * @returns {{ drifted: number, orphan: number, fresh: number,
+ *   totalAffectedMemories: number, fresh_memories: number }}
+ */
+function summarise(grouped) {
+  const summary = {
+    drifted: 0,
+    orphan: 0,
+    fresh: 0,
+    totalAffectedMemories: 0,
+    fresh_memories: 0,
+  };
+  if (!Array.isArray(grouped)) return summary;
+  for (const g of grouped) {
+    if (g.status === 'drifted') {
+      summary.drifted += 1;
+      summary.totalAffectedMemories += g.memories.length;
+    } else if (g.status === 'orphan') {
+      summary.orphan += 1;
+      summary.totalAffectedMemories += g.memories.length;
+    } else if (g.status === 'fresh') {
+      summary.fresh += 1;
+      summary.fresh_memories += g.memories.length;
+    }
+  }
+  return summary;
+}
+
+/**
+ * Look up which consolidate profile (if any) owns a given source path by
+ * scanning all `.js` files under `profilesDir`. Each profile module must
+ * export an object containing at least a `sources` array. Profiles
+ * intersecting the requested `sourcePath` are collected.
+ *
+ *   - No `profilesDir` or directory missing → returns `null` (tolerated).
+ *   - 0 hits                                → returns `null`.
+ *   - 1 hit                                 → returns `{ name }` (falls back
+ *                                             to the filename stem when the
+ *                                             module did not export `name`).
+ *   - >1 hits                               → returns
+ *                                             `{ ambiguous: true, profiles: [names] }`.
+ *
+ * @param {string} sourcePath repo-relative source path (e.g. 'docs/a.md')
+ * @param {{ profilesDir?: string }} [opts]
+ */
+function getProfileForSource(sourcePath, opts) {
+  const profilesDir = opts && opts.profilesDir;
+  if (!profilesDir || typeof profilesDir !== 'string') return null;
+  if (!fs.existsSync(profilesDir)) return null;
+  let entries;
+  try {
+    entries = fs.readdirSync(profilesDir);
+  } catch (_e) {
+    return null;
+  }
+  const hits = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.js')) continue;
+    const abs = path.join(profilesDir, entry);
+    let mod;
+    try {
+      // Bust require cache so test sandboxes are not contaminated.
+      delete require.cache[require.resolve(abs)];
+      mod = require(abs);
+    } catch (_e) {
+      continue;
+    }
+    if (!mod || !Array.isArray(mod.sources)) continue;
+    if (!mod.sources.includes(sourcePath)) continue;
+    const name = typeof mod.name === 'string' && mod.name.length > 0
+      ? mod.name
+      : path.basename(entry, '.js');
+    hits.push(name);
+  }
+  if (hits.length === 0) return null;
+  if (hits.length === 1) return { name: hits[0] };
+  return { ambiguous: true, profiles: hits };
+}
+
+module.exports = {
+  hashFile,
+  classifyMemory,
+  groupResultsBySource,
+  summarise,
+  getProfileForSource,
+};

--- a/plugins/synapsys/lib/staleness.js
+++ b/plugins/synapsys/lib/staleness.js
@@ -126,31 +126,35 @@ function classifyMemory(memory, ctx) {
 // store surfaces as drifted/orphan in its group's status.
 const STATUS_RANK = { fresh: 0, drifted: 1, orphan: 2 };
 
+function newGroup(c) {
+  return {
+    source: c.source,
+    status: c.status,
+    stored_hash: c.stored_hash,
+    current_hash: c.current_hash,
+    memories: [],
+  };
+}
+
+function mergeGroup(g, c) {
+  const incoming = STATUS_RANK[c.status] ?? 0;
+  const existing = STATUS_RANK[g.status] ?? 0;
+  if (incoming > existing) {
+    g.status = c.status;
+    g.stored_hash = c.stored_hash;
+    g.current_hash = c.current_hash;
+  }
+}
+
 function groupResultsBySource(classifications) {
   if (!Array.isArray(classifications)) return [];
   const bySource = new Map();
   for (const c of classifications) {
     if (!c || c.status === 'skip') continue;
-    const key = c.source;
-    if (!bySource.has(key)) {
-      bySource.set(key, {
-        source: c.source,
-        status: c.status,
-        stored_hash: c.stored_hash,
-        current_hash: c.current_hash,
-        memories: [],
-      });
-    } else {
-      const g = bySource.get(key);
-      const incoming = STATUS_RANK[c.status] ?? 0;
-      const existing = STATUS_RANK[g.status] ?? 0;
-      if (incoming > existing) {
-        g.status = c.status;
-        g.stored_hash = c.stored_hash;
-        g.current_hash = c.current_hash;
-      }
-    }
-    if (c.name) bySource.get(key).memories.push(c.name);
+    const existing = bySource.get(c.source);
+    if (existing) mergeGroup(existing, c);
+    else bySource.set(c.source, newGroup(c));
+    if (c.name) bySource.get(c.source).memories.push(c.name);
   }
   const groups = Array.from(bySource.values());
   for (const g of groups) g.memories.sort();

--- a/plugins/synapsys/lib/staleness.js
+++ b/plugins/synapsys/lib/staleness.js
@@ -119,6 +119,13 @@ function classifyMemory(memory, ctx) {
  * @returns {Array<{source: string, status: string, stored_hash?: string,
  *   current_hash?: string|null, memories: string[]}>}
  */
+// Status precedence: when multiple memories share a source but were
+// consolidated at different times, the most severe status wins. Orphan
+// (source file missing) outranks drifted (hash mismatch) outranks fresh.
+// This preserves the exit-code contract: any out-of-date memory in the
+// store surfaces as drifted/orphan in its group's status.
+const STATUS_RANK = { fresh: 0, drifted: 1, orphan: 2 };
+
 function groupResultsBySource(classifications) {
   if (!Array.isArray(classifications)) return [];
   const bySource = new Map();
@@ -133,6 +140,15 @@ function groupResultsBySource(classifications) {
         current_hash: c.current_hash,
         memories: [],
       });
+    } else {
+      const g = bySource.get(key);
+      const incoming = STATUS_RANK[c.status] ?? 0;
+      const existing = STATUS_RANK[g.status] ?? 0;
+      if (incoming > existing) {
+        g.status = c.status;
+        g.stored_hash = c.stored_hash;
+        g.current_hash = c.current_hash;
+      }
     }
     if (c.name) bySource.get(key).memories.push(c.name);
   }

--- a/plugins/synapsys/scripts/synapsys-staleness-check.js
+++ b/plugins/synapsys/scripts/synapsys-staleness-check.js
@@ -245,56 +245,60 @@ function dispatchReconsolidate(grouped, opts) {
   return { sawSpawnFailure };
 }
 
-function main() {
+function parseCliOptions() {
   const { flag, cwd: rawCwd } = setupCli();
-  const cwd = path.resolve(rawCwd);
-  const cwdFlagExplicit = typeof flag('cwd') === 'string';
-  const json = !!flag('json');
-  const verbose = !!flag('verbose');
-  const noColor = !!flag('no-color') || !!process.env.NO_COLOR;
-  const reConsolidate = !!flag('re-consolidate');
-
   const storeFlag = flag('store');
-  const { stores, error } = resolveStores(
-    typeof storeFlag === 'string' ? storeFlag : null,
-    cwd
-  );
+  return {
+    cwd: path.resolve(rawCwd),
+    cwdFlagExplicit: typeof flag('cwd') === 'string',
+    json: !!flag('json'),
+    verbose: !!flag('verbose'),
+    noColor: !!flag('no-color') || !!process.env.NO_COLOR,
+    reConsolidate: !!flag('re-consolidate'),
+    storeFlag: typeof storeFlag === 'string' ? storeFlag : null,
+  };
+}
+
+function renderReport(grouped, summary, opts) {
+  return opts.json
+    ? renderJson(grouped, summary, { store: opts.storeFlag || 'all' })
+    : renderText(grouped, summary, { verbose: opts.verbose, useColor: !opts.noColor });
+}
+
+function maybeReconsolidate(grouped, opts) {
+  if (!opts.reConsolidate) return false;
+  const consolidateBin =
+    process.env.SYNAPSYS_CONSOLIDATE_BIN_FOR_TEST ||
+    path.join(__dirname, 'synapsys-consolidate.js');
+  const profilesDir =
+    process.env.SYNAPSYS_PROFILES_DIR_FOR_TEST ||
+    path.join(__dirname, 'consolidate-profiles');
+  const dispatched = dispatchReconsolidate(grouped, {
+    consolidateBin,
+    profilesDir,
+    stderr: process.stderr,
+  });
+  return dispatched.sawSpawnFailure;
+}
+
+function main() {
+  const opts = parseCliOptions();
+  const { stores, error } = resolveStores(opts.storeFlag, opts.cwd);
   if (error) {
     process.stderr.write(error + '\n');
     process.exit(2);
     return;
   }
 
-  const repoRoot = cwdFlagExplicit ? cwd : findRepoRoot(cwd);
+  const repoRoot = opts.cwdFlagExplicit ? opts.cwd : findRepoRoot(opts.cwd);
   const grouped = classifyStores(stores, repoRoot);
   const summary = summarise(grouped);
 
-  const storeLabel = typeof storeFlag === 'string' ? storeFlag : 'all';
-  const out = json
-    ? renderJson(grouped, summary, { store: storeLabel })
-    : renderText(grouped, summary, { verbose, useColor: !noColor });
-  process.stdout.write(out);
+  process.stdout.write(renderReport(grouped, summary, opts));
 
-  let sawSpawnFailure = false;
-  if (reConsolidate) {
-    const consolidateBin =
-      process.env.SYNAPSYS_CONSOLIDATE_BIN_FOR_TEST ||
-      path.join(__dirname, 'synapsys-consolidate.js');
-    const profilesDir =
-      process.env.SYNAPSYS_PROFILES_DIR_FOR_TEST ||
-      path.join(__dirname, 'consolidate-profiles');
-    const dispatched = dispatchReconsolidate(grouped, {
-      consolidateBin,
-      profilesDir,
-      stderr: process.stderr,
-    });
-    sawSpawnFailure = dispatched.sawSpawnFailure;
-  }
-
-  if (summary.drifted > 0 || summary.orphan > 0 || sawSpawnFailure) {
-    process.exit(1);
-  }
-  process.exit(0);
+  const sawSpawnFailure = maybeReconsolidate(grouped, opts);
+  const hasIssue = summary.drifted > 0 || summary.orphan > 0 || sawSpawnFailure;
+  process.exit(hasIssue ? 1 : 0);
 }
 
 main();

--- a/plugins/synapsys/scripts/synapsys-staleness-check.js
+++ b/plugins/synapsys/scripts/synapsys-staleness-check.js
@@ -230,10 +230,15 @@ function dispatchReconsolidate(grouped, opts) {
       );
       continue;
     }
+    // Route child stdout to stderr when --json is active so the parent's
+    // JSON payload remains the only thing on stdout.
+    const childStdio = opts.json
+      ? ['inherit', process.stderr, 'inherit']
+      : 'inherit';
     const result = spawnSync(
       process.execPath,
       [consolidateBin, '--profile=' + profile.name],
-      { stdio: 'inherit' }
+      { stdio: childStdio }
     );
     if (result.status !== 0) {
       sawSpawnFailure = true;
@@ -277,6 +282,7 @@ function maybeReconsolidate(grouped, opts) {
     consolidateBin,
     profilesDir,
     stderr: process.stderr,
+    json: opts.json,
   });
   return dispatched.sawSpawnFailure;
 }

--- a/plugins/synapsys/scripts/synapsys-staleness-check.js
+++ b/plugins/synapsys/scripts/synapsys-staleness-check.js
@@ -159,7 +159,8 @@ function renderText(grouped, summary, opts) {
   }
   const summaryLine =
     `Summary: drifted=${summary.drifted} orphan=${summary.orphan} ` +
-    `fresh=${summary.fresh} memories_affected=${summary.totalAffectedMemories}`;
+    `fresh=${summary.fresh} memories_affected=${summary.totalAffectedMemories} ` +
+    `fresh_memories=${summary.fresh_memories}`;
   sections.push(summaryLine);
   return sections.join('\n\n') + '\n';
 }
@@ -184,6 +185,7 @@ function renderJson(grouped, summary, opts) {
       orphan: summary.orphan,
       fresh: summary.fresh,
       memories_affected: summary.totalAffectedMemories,
+      fresh_memories: summary.fresh_memories,
     },
   };
   return JSON.stringify(payload, null, 2) + '\n';

--- a/plugins/synapsys/scripts/synapsys-staleness-check.js
+++ b/plugins/synapsys/scripts/synapsys-staleness-check.js
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * synapsys-staleness-check — CLI that reports memories whose `source_hash`
+ * no longer matches their referenced source file (drifted), or whose source
+ * has disappeared (orphan), versus those that are still fresh.
+ *
+ * Flags:
+ *   --cwd=<path>          Override repo root resolution (default: cwd, or
+ *                         the nearest ancestor containing a `.git/` dir).
+ *   --store=<kind|path>   Limit scan to a single store. `kind` filters the
+ *                         `discoverStores()` output (local|worktree|global|
+ *                         shared). A path (absolute or containing `/`) is
+ *                         treated as the store directory itself.
+ *   --json                Emit machine-readable JSON instead of a text report.
+ *   --verbose             Include a `FRESH` block alongside drifted / orphan.
+ *   --no-color            Disable ANSI colour codes (also honours $NO_COLOR).
+ *   --re-consolidate      Declared here; behaviour wired in Task 4.
+ *
+ * Exit codes (R7):
+ *   0 — no drifted, no orphan
+ *   1 — at least one drifted or orphan source detected
+ *   2 — invalid invocation (store not found, etc.)
+ */
+
+const nodePath = require('node:path');
+const { spawnSync } = require('node:child_process');
+const {
+  fs,
+  path,
+  setupCli,
+  discoverStores,
+  listMemoriesFromStore,
+} = require(nodePath.join(__dirname, '..', 'lib', 'script-bootstrap'));
+const {
+  classifyMemory,
+  groupResultsBySource,
+  summarise,
+  getProfileForSource,
+} = require(nodePath.join(__dirname, '..', 'lib', 'staleness'));
+
+// ---------------------------------------------------------------------------
+// Repo-root resolution
+// ---------------------------------------------------------------------------
+
+function findRepoRoot(startDir) {
+  let dir = path.resolve(startDir);
+  for (;;) {
+    if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return path.resolve(startDir);
+    dir = parent;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Store resolution
+// ---------------------------------------------------------------------------
+
+const KNOWN_KINDS = new Set(['local', 'worktree', 'global', 'shared']);
+
+function looksLikePath(value) {
+  if (!value) return false;
+  return path.isAbsolute(value) || value.includes('/') || value.includes(path.sep);
+}
+
+/**
+ * Resolve the set of stores to scan from the `--store` flag.
+ * Returns { stores, error } — `error` is set when the user asked for a
+ * specific kind/path that does not exist.
+ */
+function resolveStores(storeFlag, cwd) {
+  if (storeFlag && looksLikePath(storeFlag)) {
+    const abs = path.resolve(cwd, storeFlag);
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) {
+      return { stores: [], error: `store not found: ${storeFlag}` };
+    }
+    return {
+      stores: [{ kind: 'explicit', dir: abs, projectName: null }],
+      error: null,
+    };
+  }
+  const discovered = discoverStores(cwd);
+  if (storeFlag && KNOWN_KINDS.has(storeFlag)) {
+    const filtered = discovered.filter((s) => s.kind === storeFlag);
+    if (filtered.length === 0) {
+      return { stores: [], error: `store not found: kind=${storeFlag}` };
+    }
+    return { stores: filtered, error: null };
+  }
+  if (storeFlag) {
+    return { stores: [], error: `store not found: ${storeFlag}` };
+  }
+  return { stores: discovered, error: null };
+}
+
+// ---------------------------------------------------------------------------
+// Classification pipeline
+// ---------------------------------------------------------------------------
+
+function classifyStores(stores, repoRoot) {
+  const classifications = [];
+  for (const store of stores) {
+    const memories = listMemoriesFromStore(store);
+    for (const mem of memories) {
+      const c = classifyMemory(mem, { repoRoot });
+      if (c.status === 'skip') continue;
+      classifications.push(Object.assign({ name: mem.name }, c));
+    }
+  }
+  return groupResultsBySource(classifications);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering — text
+// ---------------------------------------------------------------------------
+
+const SAMPLE_CAP = 3;
+
+function colourise(useColor, code, text) {
+  if (!useColor) return text;
+  return `[${code}m${text}[0m`;
+}
+
+function renderSourceBlock(label, entries, useColor) {
+  if (entries.length === 0) return '';
+  const header = colourise(useColor, '1', `${label} (${entries.length})`);
+  const lines = [header];
+  for (const e of entries) {
+    const sample = e.memories.slice(0, SAMPLE_CAP).join(', ');
+    const more =
+      e.memories.length > SAMPLE_CAP
+        ? ` … ${e.memories.length - SAMPLE_CAP} more — use --verbose`
+        : '';
+    lines.push(`  - ${e.source} → ${sample}${more}`);
+    lines.push(`    suggested: synapsys consolidate --profile=<owner>`);
+  }
+  return lines.join('\n');
+}
+
+function renderText(grouped, summary, opts) {
+  const useColor = opts.useColor;
+  const drifted = grouped.filter((g) => g.status === 'drifted');
+  const orphan = grouped.filter((g) => g.status === 'orphan');
+  const fresh = grouped.filter((g) => g.status === 'fresh');
+  const sections = [];
+  const driftedBlock = renderSourceBlock('DRIFTED', drifted, useColor);
+  if (driftedBlock) sections.push(driftedBlock);
+  const orphanBlock = renderSourceBlock('ORPHAN', orphan, useColor);
+  if (orphanBlock) sections.push(orphanBlock);
+  if (opts.verbose) {
+    const freshBlock = renderSourceBlock('FRESH', fresh, useColor);
+    if (freshBlock) sections.push(freshBlock);
+  }
+  const summaryLine =
+    `Summary: drifted=${summary.drifted} orphan=${summary.orphan} ` +
+    `fresh=${summary.fresh} memories_affected=${summary.totalAffectedMemories}`;
+  sections.push(summaryLine);
+  return sections.join('\n\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Rendering — JSON
+// ---------------------------------------------------------------------------
+
+function renderJson(grouped, summary) {
+  const results = grouped.map((g) => ({
+    source: g.source,
+    status: g.status,
+    stored_hash: g.stored_hash || null,
+    current_hash: g.current_hash || null,
+    memories: g.memories.slice(),
+  }));
+  const payload = {
+    results,
+    summary: {
+      drifted: summary.drifted,
+      orphan: summary.orphan,
+      fresh: summary.fresh,
+      memories_affected: summary.totalAffectedMemories,
+    },
+  };
+  return JSON.stringify(payload, null, 2) + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-consolidate dispatcher (Task 4 / S10).
+ *
+ * For each `drifted` source (orphans are explicitly skipped — there is no
+ * source file left to re-derive from), resolve the owning profile via
+ * `getProfileForSource` and spawn the consolidate binary with
+ * `--profile=<name>`. Per-source spawn failures are logged but do not abort
+ * the loop; the overall failure is reported by the caller via the returned
+ * `sawSpawnFailure` flag.
+ *
+ * Inputs are injected for testability:
+ *   - `consolidateBin` — absolute path to the binary to spawn
+ *   - `profilesDir`    — absolute path to the directory of profile modules
+ *   - `stderr`         — writable used for warnings (defaults to process.stderr)
+ *
+ * @returns {{ sawSpawnFailure: boolean }}
+ */
+function dispatchReconsolidate(grouped, opts) {
+  const consolidateBin = opts.consolidateBin;
+  const profilesDir = opts.profilesDir;
+  const stderr = opts.stderr || process.stderr;
+  let sawSpawnFailure = false;
+  for (const g of grouped) {
+    if (g.status !== 'drifted') continue;
+    const profile = getProfileForSource(g.source, { profilesDir });
+    if (profile && profile.ambiguous) {
+      stderr.write(
+        `warning: ambiguous profile for source ${g.source} — matched [${profile.profiles.join(', ')}]; skipping\n`
+      );
+      continue;
+    }
+    if (!profile || !profile.name) {
+      stderr.write(
+        `warning: no profile owns source ${g.source}; skipping\n`
+      );
+      continue;
+    }
+    const result = spawnSync(
+      process.execPath,
+      [consolidateBin, '--profile=' + profile.name],
+      { stdio: 'inherit' }
+    );
+    if (result.status !== 0) {
+      sawSpawnFailure = true;
+      stderr.write(
+        `warning: consolidate --profile=${profile.name} exited with code ${result.status}\n`
+      );
+    }
+  }
+  return { sawSpawnFailure };
+}
+
+function main() {
+  const { flag, cwd: rawCwd } = setupCli();
+  const cwd = path.resolve(rawCwd);
+  const cwdFlagExplicit = typeof flag('cwd') === 'string';
+  const json = !!flag('json');
+  const verbose = !!flag('verbose');
+  const noColor = !!flag('no-color') || !!process.env.NO_COLOR;
+  const reConsolidate = !!flag('re-consolidate');
+
+  const storeFlag = flag('store');
+  const { stores, error } = resolveStores(
+    typeof storeFlag === 'string' ? storeFlag : null,
+    cwd
+  );
+  if (error) {
+    process.stderr.write(error + '\n');
+    process.exit(2);
+    return;
+  }
+
+  const repoRoot = cwdFlagExplicit ? cwd : findRepoRoot(cwd);
+  const grouped = classifyStores(stores, repoRoot);
+  const summary = summarise(grouped);
+
+  const out = json
+    ? renderJson(grouped, summary)
+    : renderText(grouped, summary, { verbose, useColor: !noColor });
+  process.stdout.write(out);
+
+  let sawSpawnFailure = false;
+  if (reConsolidate) {
+    const consolidateBin =
+      process.env.SYNAPSYS_CONSOLIDATE_BIN_FOR_TEST ||
+      path.join(__dirname, 'synapsys-consolidate.js');
+    const profilesDir =
+      process.env.SYNAPSYS_PROFILES_DIR_FOR_TEST ||
+      path.join(__dirname, 'consolidate-profiles');
+    const dispatched = dispatchReconsolidate(grouped, {
+      consolidateBin,
+      profilesDir,
+      stderr: process.stderr,
+    });
+    sawSpawnFailure = dispatched.sawSpawnFailure;
+  }
+
+  if (summary.drifted > 0 || summary.orphan > 0 || sawSpawnFailure) {
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main();

--- a/plugins/synapsys/scripts/synapsys-staleness-check.js
+++ b/plugins/synapsys/scripts/synapsys-staleness-check.js
@@ -137,8 +137,8 @@ function renderSourceBlock(label, entries, useColor) {
     if (e.status === 'drifted' || e.status === 'orphan') {
       lines.push(`    stored:  ${e.stored_hash || '(missing)'}`);
       lines.push(`    current: ${e.current_hash || '(source deleted)'}`);
+      lines.push(`    suggested: synapsys consolidate --profile=<owner>`);
     }
-    lines.push(`    suggested: synapsys consolidate --profile=<owner>`);
   }
   return lines.join('\n');
 }

--- a/plugins/synapsys/scripts/synapsys-staleness-check.js
+++ b/plugins/synapsys/scripts/synapsys-staleness-check.js
@@ -131,7 +131,7 @@ function renderSourceBlock(label, entries, useColor) {
     const sample = e.memories.slice(0, SAMPLE_CAP).join(', ');
     const more =
       e.memories.length > SAMPLE_CAP
-        ? ` … ${e.memories.length - SAMPLE_CAP} more — use --verbose`
+        ? ` … ${e.memories.length - SAMPLE_CAP} more — use --json for full list`
         : '';
     lines.push(`  - ${e.source} → ${sample}${more}`);
     if (e.status === 'drifted' || e.status === 'orphan') {

--- a/plugins/synapsys/scripts/synapsys-staleness-check.js
+++ b/plugins/synapsys/scripts/synapsys-staleness-check.js
@@ -120,7 +120,7 @@ const SAMPLE_CAP = 3;
 
 function colourise(useColor, code, text) {
   if (!useColor) return text;
-  return `[${code}m${text}[0m`;
+  return `\x1b[${code}m${text}\x1b[0m`;
 }
 
 function renderSourceBlock(label, entries, useColor) {

--- a/plugins/synapsys/scripts/synapsys-staleness-check.js
+++ b/plugins/synapsys/scripts/synapsys-staleness-check.js
@@ -134,6 +134,10 @@ function renderSourceBlock(label, entries, useColor) {
         ? ` … ${e.memories.length - SAMPLE_CAP} more — use --verbose`
         : '';
     lines.push(`  - ${e.source} → ${sample}${more}`);
+    if (e.status === 'drifted' || e.status === 'orphan') {
+      lines.push(`    stored:  ${e.stored_hash || '(missing)'}`);
+      lines.push(`    current: ${e.current_hash || '(source deleted)'}`);
+    }
     lines.push(`    suggested: synapsys consolidate --profile=<owner>`);
   }
   return lines.join('\n');
@@ -164,7 +168,7 @@ function renderText(grouped, summary, opts) {
 // Rendering — JSON
 // ---------------------------------------------------------------------------
 
-function renderJson(grouped, summary) {
+function renderJson(grouped, summary, opts) {
   const results = grouped.map((g) => ({
     source: g.source,
     status: g.status,
@@ -173,6 +177,7 @@ function renderJson(grouped, summary) {
     memories: g.memories.slice(),
   }));
   const payload = {
+    store: (opts && opts.store) || 'all',
     results,
     summary: {
       drifted: summary.drifted,
@@ -264,8 +269,9 @@ function main() {
   const grouped = classifyStores(stores, repoRoot);
   const summary = summarise(grouped);
 
+  const storeLabel = typeof storeFlag === 'string' ? storeFlag : 'all';
   const out = json
-    ? renderJson(grouped, summary)
+    ? renderJson(grouped, summary, { store: storeLabel })
     : renderText(grouped, summary, { verbose, useColor: !noColor });
   process.stdout.write(out);
 

--- a/plugins/synapsys/skills/crystallize/SKILL.md
+++ b/plugins/synapsys/skills/crystallize/SKILL.md
@@ -23,6 +23,25 @@ Returns JSON: `{ repo, current: {hash, dir, count}, siblings: [...], existingSto
 - If `current.count === 0` AND no sibling has memories → no auto-memories to crystallize. Stop.
 - If `existingStores` is empty → tell the user to run `/synapsys:install` first. Stop.
 
+### 1.5. Pre-flight drift check (idempotency gate)
+
+Crystallize is **idempotent**: re-running it on top of an existing store skips memories whose name + source are unchanged (the writer drops duplicates by name). To make idempotency drift-aware, run the staleness check against each existing store before continuing:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/synapsys-staleness-check.js" --json --store=<kind>
+```
+
+Interpretation:
+
+- Exit 0 → all consolidated memories in that store are in sync with their source files. Continue.
+- Exit 1 → at least one memory is `drifted` (source file changed) or `orphan` (source file deleted). Parse the JSON `results[]` and surface a short table (source → status → memory names) to the user via `AskUserQuestion`:
+  - **Re-derive drifted memories now** — pass the drifted memory names to the writer with `--force` after step 8 so they get rewritten with current source hashes. Orphan memories are listed but not auto-deleted (user decides).
+  - **Continue without re-deriving** — proceed with the new crystallization only; existing drift stays unresolved.
+  - **Abort** — stop the skill; user can run `synapsys consolidate` or fix sources first.
+- Exit 2 → invocation error (e.g., store path missing). Skip the gate with a stderr warning and continue — drift detection is supplementary, not blocking.
+
+Skip this gate entirely when the target store has zero existing memories (nothing to drift against).
+
 ### 2. Pick sources (if more than one has memories)
 
 If only the current worktree has memories (or only one sibling does), skip the question.
@@ -205,6 +224,7 @@ Crystallize is additive. The auto-memory system stays as a backstop.
 
 ## Rules
 
+- **Idempotent by design.** Re-running crystallize on top of an existing store must not duplicate work. The writer skips existing memory names; the Step 1.5 staleness gate catches the harder case where a memory exists but its source has drifted. If the user picks "Re-derive drifted memories now", invoke the writer with `--force` only for the drifted set — never blanket-force the whole batch.
 - **No catch-all triggers.** A pattern like `.*` will inject the memory on every prompt and poison context. If you can't derive a specific pattern for a memory, ask the user for 2–3 example phrases.
 - **Preserve `[[name]]` links** between memories in bodies.
 - **Prefer `PreToolUse` for action reminders.** "Don't push --force" should fire when the agent is about to run `git push`, not when the user types "push".

--- a/plugins/synapsys/tests/fixtures/sample-repo/docs/a.md
+++ b/plugins/synapsys/tests/fixtures/sample-repo/docs/a.md
@@ -1,0 +1,5 @@
+# Sample Doc A
+
+This file is fixture content for the staleness-check helper tests.
+It represents a source document that has been consolidated into a memory.
+The contents are stable so its sha256 hash is deterministic.

--- a/plugins/synapsys/tests/fixtures/sample-repo/docs/b.md
+++ b/plugins/synapsys/tests/fixtures/sample-repo/docs/b.md
@@ -1,0 +1,4 @@
+# Sample Doc B
+
+Second fixture source document used to exercise the multi-source
+aggregation paths of the staleness-check pipeline.

--- a/plugins/synapsys/tests/fixtures/store-all-fresh/mem-fresh-a.md
+++ b/plugins/synapsys/tests/fixtures/store-all-fresh/mem-fresh-a.md
@@ -1,0 +1,7 @@
+---
+name: mem-fresh-a
+description: Fresh memory for docs/a.md
+source: docs/a.md
+source_hash: sha256:6bdb53c269d1146aa6e982c5434a294bca1166fcfb95f711bfb6e249edd18a2a
+---
+Body.

--- a/plugins/synapsys/tests/fixtures/store-all-fresh/mem-fresh-b.md
+++ b/plugins/synapsys/tests/fixtures/store-all-fresh/mem-fresh-b.md
@@ -1,0 +1,7 @@
+---
+name: mem-fresh-b
+description: Fresh memory for docs/b.md
+source: docs/b.md
+source_hash: sha256:6ffb2c3036d997efa6452b5d9fb955ff0d485ac20050bb7341ee6c6374821224
+---
+Body.

--- a/plugins/synapsys/tests/fixtures/store-mixed/mem-drifted-b.md
+++ b/plugins/synapsys/tests/fixtures/store-mixed/mem-drifted-b.md
@@ -1,0 +1,7 @@
+---
+name: mem-drifted-b
+description: Drifted memory pointing at docs/b.md with stale hash
+source: docs/b.md
+source_hash: sha256:0000000000000000000000000000000000000000000000000000000000000000
+---
+Body of drifted memory.

--- a/plugins/synapsys/tests/fixtures/store-mixed/mem-fresh-a.md
+++ b/plugins/synapsys/tests/fixtures/store-mixed/mem-fresh-a.md
@@ -1,0 +1,7 @@
+---
+name: mem-fresh-a
+description: Fresh memory pointing at docs/a.md
+source: docs/a.md
+source_hash: sha256:6bdb53c269d1146aa6e982c5434a294bca1166fcfb95f711bfb6e249edd18a2a
+---
+Body of fresh memory.

--- a/plugins/synapsys/tests/fixtures/store-mixed/mem-manual-1.md
+++ b/plugins/synapsys/tests/fixtures/store-mixed/mem-manual-1.md
@@ -1,0 +1,5 @@
+---
+name: mem-manual-1
+description: Manual memory with no source_hash (should be skipped)
+---
+Hand-authored memory body.

--- a/plugins/synapsys/tests/fixtures/store-mixed/mem-manual-2.md
+++ b/plugins/synapsys/tests/fixtures/store-mixed/mem-manual-2.md
@@ -1,0 +1,5 @@
+---
+name: mem-manual-2
+description: Second manual memory with no source_hash (should be skipped)
+---
+Another hand-authored memory body.

--- a/plugins/synapsys/tests/fixtures/store-mixed/mem-orphan-c.md
+++ b/plugins/synapsys/tests/fixtures/store-mixed/mem-orphan-c.md
@@ -1,0 +1,7 @@
+---
+name: mem-orphan-c
+description: Orphan memory whose source file no longer exists
+source: docs/c-missing.md
+source_hash: sha256:1111111111111111111111111111111111111111111111111111111111111111
+---
+Body of orphan memory.

--- a/plugins/synapsys/tests/staleness.integration.test.js
+++ b/plugins/synapsys/tests/staleness.integration.test.js
@@ -238,3 +238,34 @@ test('CASE S10c — --re-consolidate continues to next source after a spawn fail
     `expected at least one --profile=good invocation, got ${JSON.stringify(calls)}`
   );
 });
+
+// ---------------------------------------------------------------------------
+// CASE 8 / CASE 9 — pending GH-442 (stamping contract lives in sibling
+// `synapsys-consolidate.js`, which is not yet on disk in this ticket).
+// These are documentation-only `test.skip` entries so `node --test` output
+// records the eventual contract surface. When GH-442 lands, lift the `.skip`
+// and implement the bodies against the real consolidate script.
+// ---------------------------------------------------------------------------
+
+test.skip(
+  'CASE 8 — pending GH-442 — stamping hook lives in sibling consolidate script',
+  () => {
+    // Eventual contract: after `synapsys-consolidate` writes a memory file,
+    // its frontmatter MUST contain:
+    //   - `source: <repo-relative path>` (no leading slash, POSIX separators)
+    //   - `source_hash: sha256:<64 lowercase hex>` matching
+    //     /^sha256:[0-9a-f]{64}$/ over the raw bytes of the source file.
+    assert.ok(true);
+  }
+);
+
+test.skip(
+  'CASE 9 — pending GH-442 — stamp stability across runs',
+  () => {
+    // Eventual contract: running `synapsys-consolidate` twice against an
+    // unchanged source file MUST yield byte-identical `source_hash` values
+    // in the resulting memory frontmatter (deterministic hashing, no
+    // timestamp leakage into the hashed payload).
+    assert.ok(true);
+  }
+);

--- a/plugins/synapsys/tests/staleness.integration.test.js
+++ b/plugins/synapsys/tests/staleness.integration.test.js
@@ -1,0 +1,240 @@
+'use strict';
+
+/**
+ * Integration tests for `scripts/synapsys-staleness-check.js`.
+ *
+ * Spawns the CLI as a subprocess (mirrors `lint.integration.test.js`) and
+ * asserts on exit codes + stdout shape for the five gherkin scenarios this
+ * task covers: S5, S6, S7, S8, S9.
+ *
+ * Fixtures live under `tests/fixtures/store-mixed/` and `store-all-fresh/`.
+ * Their pre-computed `source_hash` frontmatter values were generated against
+ * the sibling `tests/fixtures/sample-repo/docs/*.md` byte content (see the
+ * helper at the bottom of this file for the recipe).
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const CLI = path.join(__dirname, '..', 'scripts', 'synapsys-staleness-check.js');
+const SAMPLE_REPO = path.join(__dirname, 'fixtures', 'sample-repo');
+const STORE_MIXED = path.join(__dirname, 'fixtures', 'store-mixed');
+const STORE_ALL_FRESH = path.join(__dirname, 'fixtures', 'store-all-fresh');
+
+function run(args, opts) {
+  const env = Object.assign({}, process.env, { NO_COLOR: '1' }, (opts && opts.env) || {});
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    env,
+  });
+}
+
+test('CASE 5 (S5) — exit code 1 when store has drifted or orphan sources', () => {
+  const r = run([`--cwd=${SAMPLE_REPO}`, `--store=${STORE_MIXED}`, '--no-color']);
+  assert.equal(r.status, 1, `expected exit 1, got ${r.status}. stderr=${r.stderr}`);
+  // At least one of DRIFTED / ORPHAN block headers must appear in stdout.
+  assert.ok(
+    /DRIFTED|ORPHAN/.test(r.stdout),
+    `expected DRIFTED or ORPHAN block in stdout, got:\n${r.stdout}`
+  );
+});
+
+test('CASE 6 (S6) — exit code 0 when all sources are fresh', () => {
+  const r = run([`--cwd=${SAMPLE_REPO}`, `--store=${STORE_ALL_FRESH}`, '--no-color']);
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}. stderr=${r.stderr}\nstdout=${r.stdout}`);
+  // Summary line should report zero drifted and zero orphan.
+  assert.match(r.stdout, /drifted[^0-9]*0/i);
+  assert.match(r.stdout, /orphan[^0-9]*0/i);
+});
+
+test('CASE 7 (S7) — --json emits per-source results + summary on store-mixed', () => {
+  const r = run([`--cwd=${SAMPLE_REPO}`, `--store=${STORE_MIXED}`, '--json']);
+  // Exit code is still 1 (drifted/orphan present) but stdout MUST parse.
+  let payload;
+  assert.doesNotThrow(() => {
+    payload = JSON.parse(r.stdout);
+  }, `stdout was not parseable JSON:\n${r.stdout}`);
+  assert.ok(Array.isArray(payload.results), 'results is an array');
+  assert.ok(payload.results.length > 0, 'at least one result entry');
+  for (const entry of payload.results) {
+    for (const key of ['source', 'status', 'stored_hash', 'current_hash', 'memories']) {
+      assert.ok(key in entry, `result entry missing key '${key}': ${JSON.stringify(entry)}`);
+    }
+    assert.ok(Array.isArray(entry.memories), 'memories is an array');
+  }
+  assert.ok(payload.summary && typeof payload.summary === 'object', 'summary present');
+  for (const key of ['drifted', 'orphan', 'fresh', 'memories_affected']) {
+    assert.ok(key in payload.summary, `summary missing key '${key}'`);
+    assert.equal(typeof payload.summary[key], 'number', `summary.${key} is a number`);
+  }
+});
+
+test('CASE S8 — exit code 2 + "store not found" on stderr for missing store kind', () => {
+  const r = run([`--cwd=${SAMPLE_REPO}`, '--store=does-not-exist', '--no-color']);
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}. stdout=${r.stdout}\nstderr=${r.stderr}`);
+  assert.match(r.stderr, /store not found/i);
+});
+
+test('CASE S9 — --verbose adds FRESH block in addition to DRIFTED block', () => {
+  const r = run([`--cwd=${SAMPLE_REPO}`, `--store=${STORE_MIXED}`, '--verbose', '--no-color']);
+  // Mixed store contains both fresh and drifted sources, so both blocks should appear.
+  assert.match(r.stdout, /FRESH/, `expected FRESH block in --verbose stdout:\n${r.stdout}`);
+  assert.match(r.stdout, /DRIFTED/, `expected DRIFTED block in --verbose stdout:\n${r.stdout}`);
+});
+
+// ---------------------------------------------------------------------------
+// S10 — --re-consolidate dispatches the owning profile for each drifted source
+// ---------------------------------------------------------------------------
+
+function mkTmpDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/**
+ * Build a fresh sandbox containing:
+ *   - profilesDir with the given profile files
+ *   - a stub consolidate binary that logs its argv to a file and exits with
+ *     the supplied code for matching --profile=<name> calls
+ * Returns paths and a helper to read the captured argv lines.
+ */
+function makeStubConsolidate({ exitFor } = {}) {
+  const stubDir = mkTmpDir('synapsys-stub-');
+  const logFile = path.join(stubDir, 'calls.log');
+  const exitMap = exitFor || {};
+  const stub = `#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+fs.appendFileSync(${JSON.stringify(logFile)}, JSON.stringify(process.argv.slice(2)) + '\\n');
+const exitMap = ${JSON.stringify(exitMap)};
+const profileArg = process.argv.slice(2).find((a) => a.startsWith('--profile='));
+const name = profileArg ? profileArg.slice('--profile='.length) : '';
+process.exit(exitMap[name] != null ? exitMap[name] : 0);
+`;
+  const stubPath = path.join(stubDir, 'stub-consolidate.js');
+  fs.writeFileSync(stubPath, stub, { mode: 0o755 });
+  return {
+    stubPath,
+    logFile,
+    readCalls() {
+      if (!fs.existsSync(logFile)) return [];
+      return fs
+        .readFileSync(logFile, 'utf8')
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l));
+    },
+  };
+}
+
+function makeProfilesDir(profiles) {
+  const dir = mkTmpDir('synapsys-profiles-');
+  for (const [filename, exportObj] of Object.entries(profiles)) {
+    fs.writeFileSync(
+      path.join(dir, filename),
+      `'use strict';\nmodule.exports = ${JSON.stringify(exportObj)};\n`
+    );
+  }
+  return dir;
+}
+
+test('CASE S10a — --re-consolidate spawns stub with --profile=<owner> for drifted source, skips orphan', () => {
+  // store-mixed has a drifted source `docs/b.md` and an orphan `docs/c-missing.md`.
+  const profilesDir = makeProfilesDir({
+    'good-profile.js': { name: 'good', sources: ['docs/b.md'] },
+  });
+  const stub = makeStubConsolidate();
+  const r = run([`--cwd=${SAMPLE_REPO}`, `--store=${STORE_MIXED}`, '--re-consolidate', '--no-color'], {
+    env: {
+      SYNAPSYS_CONSOLIDATE_BIN_FOR_TEST: stub.stubPath,
+      SYNAPSYS_PROFILES_DIR_FOR_TEST: profilesDir,
+    },
+  });
+  // Drift remained (we don't actually mutate hashes) so exit stays non-zero.
+  assert.notEqual(r.status, 0, `expected non-zero exit, got ${r.status}. stderr=${r.stderr}\nstdout=${r.stdout}`);
+  const calls = stub.readCalls();
+  assert.ok(calls.length >= 1, `expected at least one spawn call, got ${calls.length}`);
+  // Spawn must include --profile=good for the drifted source.
+  const flat = calls.flat();
+  assert.ok(
+    flat.includes('--profile=good'),
+    `expected --profile=good in spawn argv, got ${JSON.stringify(calls)}`
+  );
+  // Orphan source `docs/c-missing.md` must NOT be dispatched: no call should
+  // contain a missing-profile argument referencing that path.
+  const orphanCall = calls.find((argv) => argv.some((a) => a.includes('c-missing')));
+  assert.equal(orphanCall, undefined, `orphan must not be auto-acted on, got ${JSON.stringify(calls)}`);
+});
+
+test('CASE S10b — --re-consolidate emits stderr warning AND skips spawn when source is ambiguous', () => {
+  // Both profiles claim docs/b.md → ambiguous.
+  const profilesDir = makeProfilesDir({
+    'first-profile.js': { name: 'first', sources: ['docs/b.md'] },
+    'second-profile.js': { name: 'second', sources: ['docs/b.md'] },
+  });
+  const stub = makeStubConsolidate();
+  const r = run([`--cwd=${SAMPLE_REPO}`, `--store=${STORE_MIXED}`, '--re-consolidate', '--no-color'], {
+    env: {
+      SYNAPSYS_CONSOLIDATE_BIN_FOR_TEST: stub.stubPath,
+      SYNAPSYS_PROFILES_DIR_FOR_TEST: profilesDir,
+    },
+  });
+  // Warning must name both profiles.
+  assert.match(r.stderr, /first/, `expected 'first' in ambiguity warning: ${r.stderr}`);
+  assert.match(r.stderr, /second/, `expected 'second' in ambiguity warning: ${r.stderr}`);
+  assert.match(r.stderr, /ambiguous/i, `expected 'ambiguous' wording: ${r.stderr}`);
+  // No spawn at all for the ambiguous source.
+  const calls = stub.readCalls();
+  const matched = calls.find((argv) => argv.some((a) => a === '--profile=first' || a === '--profile=second'));
+  assert.equal(matched, undefined, `ambiguous source must be skipped, got ${JSON.stringify(calls)}`);
+});
+
+test('CASE S10d — getProfileForSource: single match returns { name }, no match returns null, missing dir tolerated', () => {
+  const { getProfileForSource } = require('../lib/staleness');
+  // Missing dir → null (no crash).
+  assert.equal(
+    getProfileForSource('docs/a.md', { profilesDir: path.join(os.tmpdir(), 'definitely-not-here-' + Date.now()) }),
+    null
+  );
+  // Single match → { name }
+  const single = makeProfilesDir({ 'p.js': { name: 'p', sources: ['docs/a.md'] } });
+  const hit = getProfileForSource('docs/a.md', { profilesDir: single });
+  assert.ok(hit && hit.name === 'p', `expected { name: 'p' }, got ${JSON.stringify(hit)}`);
+  // No match → null
+  const empty = makeProfilesDir({ 'p.js': { name: 'p', sources: ['docs/other.md'] } });
+  assert.equal(getProfileForSource('docs/a.md', { profilesDir: empty }), null);
+  // Ambiguous → { ambiguous: true, profiles: [...] }
+  const ambig = makeProfilesDir({
+    'p1.js': { name: 'p1', sources: ['docs/a.md'] },
+    'p2.js': { name: 'p2', sources: ['docs/a.md'] },
+  });
+  const amb = getProfileForSource('docs/a.md', { profilesDir: ambig });
+  assert.ok(amb && amb.ambiguous === true, `expected ambiguous result, got ${JSON.stringify(amb)}`);
+  assert.deepEqual([...amb.profiles].sort(), ['p1', 'p2']);
+});
+
+test('CASE S10c — --re-consolidate continues to next source after a spawn failure and exits non-zero overall', () => {
+  // Two drifted sources both owned by `good`; stub fails for the first profile
+  // invocation but the script must keep going and ultimately exit non-zero.
+  const profilesDir = makeProfilesDir({
+    'good-profile.js': { name: 'good', sources: ['docs/b.md'] },
+  });
+  const stub = makeStubConsolidate({ exitFor: { good: 7 } });
+  const r = run([`--cwd=${SAMPLE_REPO}`, `--store=${STORE_MIXED}`, '--re-consolidate', '--no-color'], {
+    env: {
+      SYNAPSYS_CONSOLIDATE_BIN_FOR_TEST: stub.stubPath,
+      SYNAPSYS_PROFILES_DIR_FOR_TEST: profilesDir,
+    },
+  });
+  // Stub failed → overall exit code must be non-zero.
+  assert.notEqual(r.status, 0, `expected non-zero exit after spawn failure, got ${r.status}`);
+  // Stub was actually invoked at least once for the drifted source.
+  const calls = stub.readCalls();
+  assert.ok(
+    calls.some((argv) => argv.includes('--profile=good')),
+    `expected at least one --profile=good invocation, got ${JSON.stringify(calls)}`
+  );
+});


### PR DESCRIPTION
## Existing Behavior

- `staleness-check` had no unit tests covering `hashFile`, `classifyMemory`, `groupResultsBySource`, or `summarise` helpers.
- Running `--json` while `consolidate` was active caused stdout interleaving, producing unparseable JSON output.
- The staleness-check report did not include `fresh_memories` in its summary, omitting important context about unaffected memories.
- The `getProfileForSource` JSDoc was attached to the wrong function, making the helper undiscoverable.
- `groupResultsBySource` sorted by an undefined precedence, sometimes returning drifted/orphan in wrong order.
- ANSI colour codes used raw ESC bytes (`\x1b` written literally as control chars) instead of proper escape sequences.
- The `consolidate` suggestion appeared outside the drifted/orphan guard, triggering it for fresh-only runs.
- Cyclomatic complexity helpers were mis-located, causing the quality gate to fail.
- The `--json` truncation hint referenced `--verbose` instead of the correct `--json` flag.

## Intended New Behavior

- Full unit test suite added under `lib/__tests__/staleness.test.js` covering all five classification states and the `summarise` function including `fresh_memories` count.
- `--json` output is isolated from `consolidate` subprocess stdout, ensuring clean parseable JSON every time.
- Staleness summary now includes `fresh_memories` so callers can verify full store health at a glance.
- ANSI escape sequences use proper `\x1b` form instead of raw control bytes, fixing colour rendering in CI logs.
- `consolidate` re-consolidation suggestion is scoped to drifted/orphan results only, not emitted on clean runs.
- `getProfileForSource` JSDoc is correctly placed on the function declaration.
- `groupResultsBySource` applies status-rank precedence (orphan > drifted > fresh) for multi-memory sources.
- Crystallize SKILL.md gains a Step 1.5 drift-detection gate and an idempotence rule.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Run the staleness-check unit tests directly:**

```bash
node --test plugins/synapsys/lib/__tests__/staleness.test.js
```

Expected: all assertions pass, `fresh_memories` count is correct in the `summarise` test.

**Run the integration test suite:**

```bash
node --test plugins/synapsys/tests/staleness.integration.test.js
```

Expected: S5 exits 1 + shows DRIFTED/ORPHAN; S6 exits 0 + reports drifted=0 orphan=0; S7 emits valid JSON with `results` array and `summary`; S8 exits 2 with "store not found" on stderr; S9 shows both FRESH and DRIFTED blocks with `--verbose`.

**Verify --json stdout isolation (stdout interleaving fix):**

```bash
node plugins/synapsys/scripts/synapsys-staleness-check.js --json --store=<path-to-mixed-store> 2>/dev/null | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ JSON.parse(d); console.log('OK — valid JSON'); })"
```

Expected: prints `OK — valid JSON` with no parse error.

**Verify fresh_memories in summary:**

```bash
node plugins/synapsys/scripts/synapsys-staleness-check.js --json --store=<all-fresh-store> | node -e "const p=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')); console.log(p.summary.fresh_memories);"
```

Expected: prints the count of fresh memory files (> 0 for the all-fresh fixture).

### Test Results
[Will be populated after PR creation with actual test run output]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a read-mostly validation CLI and tests with path-traversal guards; optional subprocess re-consolidate is test-hooked and documented as dependent on GH-442 profiles.
> 
> **Overview**
> Adds a **staleness check** for Synapsys consolidated memories: compare each memory’s `source_hash` to the current source file and report **fresh**, **drifted**, **orphan**, or skip manual entries.
> 
> New **`lib/staleness.js`** implements hashing, safe path resolution, per-memory classification, grouping by source with **orphan > drifted > fresh** precedence, summaries including **`fresh_memories`**, and **`getProfileForSource`** for consolidate profiles. **`scripts/synapsys-staleness-check.js`** scans discovered stores, prints text or **`--json`** reports (exit 0/1/2), optionally **`--re-consolidate`** by spawning consolidate with the owning profile while keeping child stdout off stdout when **`--json`** is set. README documents CI/pre-commit usage; **crystallize** gains **Step 1.5** drift gate and idempotency rules. Unit and integration tests plus fixtures cover classification, JSON shape, and re-consolidate behavior (GH-442 stamping tests remain skipped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616077094ade1fd5cfd7d11abe7456c86ff3f94e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->