### PR TITLE
chore(release): bump all plugin versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
-    "version": "3.13.0"
+    "version": "3.13.1"
   },
   "plugins": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
   "license": "MIT",
   "repository": {

--- a/plugins/heimdall/.claude-plugin/plugin.json
+++ b/plugins/heimdall/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "heimdall",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Config-driven file/directory guard. Lock blocks declare protected paths + an unlock phrase; a PreToolUse hook blocks Edit/Write/Bash/Task mutations to those paths unless the user speaks the phrase. Stores are local, worktree, or global like synapsys.",
   "author": {
     "name": "Custom",

--- a/plugins/maestro/.claude-plugin/plugin.json
+++ b/plugins/maestro/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Multi-agent orchestrator. Bootstraps per-ticket tmux sessions in isolated worktrees, conducts them (auto-restart on silence, surface real prompts to the operator), and exposes a file-mailbox signal channel.",
   "author": {
     "name": "Custom",

--- a/plugins/synapsys/.claude-plugin/plugin.json
+++ b/plugins/synapsys/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsys",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Context-triggered memory injection. Memories declare trigger patterns + lifecycle events in frontmatter; matching memories are injected into Claude's context on the right hook.",
   "author": {
     "name": "Custom",

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Self-contained workflow plugin with agents, hooks, skills, and orchestration. Includes 18 specialized agents, agent-specific hooks, and 25 skills.",
   "author": {
     "name": "Custom",


### PR DESCRIPTION
## Summary

Manual catch-up bump of every plugin version after recent merges. The release bot today only bumps `work-workflow` — see commit `aad9e989` ("chore(release): bump version to 3.13.0"), which touched only `marketplace.json`, root manifest, and `plugins/work/.claude-plugin/plugin.json`. The other three plugins (`synapsys`, `maestro`, `heimdall`) never receive a version bump even after their code lands on main, so consumers see stale versions.

A long-term auto-bump-all-plugins solution is being worked on separately. This PR is the manual stopgap so the next install picks up the new code.

## Changes

Single commit, version strings only — no behavior changes.

| File | From | To |
|------|------|----|
| `.claude-plugin/marketplace.json` (metadata.version) | 3.13.0 | 3.13.1 |
| `package.json` (root) | 3.13.0 | 3.13.1 |
| `plugins/work/.claude-plugin/plugin.json` | 3.13.0 | 3.13.1 |
| `plugins/synapsys/.claude-plugin/plugin.json` | 0.1.2 | 0.1.3 |
| `plugins/maestro/.claude-plugin/plugin.json` | 0.1.0 | 0.1.1 |
| `plugins/heimdall/.claude-plugin/plugin.json` | 0.1.0 | 0.1.1 |

## Test plan

- [ ] CI is green.
- [ ] No code paths touched — version strings only.
- [ ] Marketplace metadata, root manifest, and each per-plugin manifest each move by exactly one patch increment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no code or behavior changes.
> 
> **Overview**
> Manual **patch bump** across the marketplace metadata, root `package.json`, and every plugin manifest so installed versions match code already on `main`. **`work-workflow`** goes **3.13.0 → 3.13.1** in three places; **`synapsys`**, **`maestro`**, and **`heimdall`** each advance one patch in their own `plugin.json` only.
> 
> No runtime, hook, or script changes—version strings only, as a stopgap until release automation bumps all plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca563fa1070d1d01ba3d6c7abc3a22dee0f8dfe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->