### PR TITLE
ci: add CodeQL static analysis for JavaScript/TypeScript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Existing Behavior

The repo has no automated static analysis or code scanning workflow. The main branch ruleset has a `code_scanning` rule pinned to CodeQL, but with no workflow supplying results, the gate is a no-op — PRs are not blocked on security or quality alerts.

## Intended New Behavior

- A new `.github/workflows/codeql.yml` workflow runs CodeQL analysis for `javascript-typescript` on every push and PR targeting `main`, and on a weekly schedule (Monday 04:23 UTC).
- The query suite is `security-and-quality`, covering both security vulnerabilities and code quality issues.
- Uses `github/codeql-action@v3` throughout (init, analyze steps).
- Once this lands and the baseline scan of `main` completes, the existing branch ruleset `code_scanning` gate activates — future PRs will be blocked on any new CodeQL alert of medium+ severity.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. After this PR merges, navigate to **Actions → CodeQL** in the repo to confirm the baseline scan triggers automatically on the push to `main`.
2. Once the scan completes, go to **Security → Code scanning alerts** and verify results appear (no alerts expected initially, but the dashboard should show the scan ran).
3. Open a test PR against `main` and confirm the `code_scanning / CodeQL` status check appears and is required by the branch ruleset.
4. To verify the weekly schedule: check **Actions → CodeQL** the following Monday after 04:23 UTC for a scheduled run entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with no application runtime changes; main effect is enabling automated security/quality scanning and merge gates once results exist.
> 
> **Overview**
> Adds a **CodeQL** GitHub Actions workflow so JavaScript/TypeScript is scanned with the **security-and-quality** query suite on pushes and PRs to `main`, plus a weekly Monday schedule.
> 
> The job checks out the repo, runs `github/codeql-action` init/analyze (v3), and uploads results with permissions for **security-events**. After a baseline scan on `main`, this should feed the repo’s existing **code scanning** branch protection so new medium+ alerts can block merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 641354eff085b8899802c06be3882bd6d9f9f854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->