### PR TITLE
fix(release): dynamic plugin bumping scoped by commit range

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,6 +20,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # Need history so `git diff --name-only <before>..<sha>` can resolve
+          # both endpoints when bump-version.js computes touched plugins.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -50,6 +53,10 @@ jobs:
           echo "type=$TYPE" >> "$GITHUB_OUTPUT"
 
       - name: Bump version (${{ steps.bump-type.outputs.type }})
+        env:
+          # Scope plugin bumps to plugins whose files actually changed in the
+          # push range. Workspace + marketplace manifests bump unconditionally.
+          BUMP_RANGE: ${{ github.event.before }}..${{ github.sha }}
         run: node plugins/work/scripts/workflows/lib/scripts/bump-version.js ${{ steps.bump-type.outputs.type }}
 
       - name: Commit and push
@@ -57,6 +64,13 @@ jobs:
           git config user.name "claude-plugin-work-botApp[bot]"
           git config user.email "claude-plugin-work-botApp[bot]@users.noreply.github.com"
           VERSION=$(node -p "require('./package.json').version")
-          git add package.json plugins/work/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+          # Stage every plugin manifest dynamically — bump-version.js may have
+          # touched any subset of plugins/*/.claude-plugin/plugin.json.
+          git add package.json .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json
+          # Nothing to commit if the bump was a no-op (already at target version).
+          if git diff --cached --quiet; then
+            echo "No version changes to commit."
+            exit 0
+          fi
           git commit -m "chore(release): bump version to ${VERSION}"
           git push

--- a/plugins/work/scripts/workflows/lib/scripts/bump-version.js
+++ b/plugins/work/scripts/workflows/lib/scripts/bump-version.js
@@ -1,27 +1,52 @@
 #!/usr/bin/env node
 
 /**
- * bump-version.js — Bump version across all 3 version files.
+ * bump-version.js — Bump version across every plugin that has changes in
+ * a commit range, plus the workspace + marketplace manifests.
+ *
+ * Plugin discovery is dynamic: every directory under `plugins/<name>/` that
+ * contains a `.claude-plugin/plugin.json` is a plugin candidate. There are no
+ * hardcoded plugin names — adding a new plugin to the marketplace makes it
+ * eligible automatically.
+ *
+ * Bump scope:
+ *   - `package.json`                   — workspace manifest, always bumped
+ *   - `.claude-plugin/marketplace.json` — marketplace `metadata.version`,
+ *                                          always bumped
+ *   - `plugins/<name>/.claude-plugin/plugin.json` — only bumped when the
+ *                                          commit range touched files under
+ *                                          `plugins/<name>/**`.
+ *
+ * Touched-plugin detection uses `git diff --name-only <range>` against an
+ * env-supplied range (`BUMP_RANGE`, e.g. `${{ github.event.before }}..${{ github.sha }}`).
+ * When `BUMP_RANGE` is unset (local invocation, or no range available in CI),
+ * the script falls back to bumping ALL plugins — preserves the old
+ * "bump everything" behaviour and prevents drift in manual `pnpm release`
+ * runs.
  *
  * Usage:
- *   node scripts/bump-version.js <patch|minor|major>
- *   node scripts/bump-version.js 2.4.0
+ *   node bump-version.js <patch|minor|major>
+ *   node bump-version.js 2.4.0
+ *   BUMP_RANGE=abc123..def456 node bump-version.js patch
  *
- * Files updated:
- *   - package.json              (field: version)
- *   - .claude-plugin/plugin.json (field: version)
- *   - .claude-plugin/marketplace.json (field: metadata.version)
+ * Exit codes:
+ *   0  bump succeeded (or already at the requested version)
+ *   1  usage/argument error
  */
 
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 
 // __dirname = plugins/work/scripts/workflows/lib/scripts → repo root is 6 levels up
 const ROOT = path.join(__dirname, '..', '..', '..', '..', '..', '..');
+const PLUGINS_DIR = path.join(ROOT, 'plugins');
 
-const FILES = [
+// Files that are bumped unconditionally on every release. Plugin manifests
+// are discovered dynamically below.
+const ALWAYS_BUMP = [
   {
-    // workspace manifest (stays at repo root)
+    label: 'package.json',
     path: 'package.json',
     get: (j) => j.version,
     set: (j, v) => {
@@ -29,15 +54,7 @@ const FILES = [
     },
   },
   {
-    // work plugin manifest (lives inside the plugin)
-    path: 'plugins/work/.claude-plugin/plugin.json',
-    get: (j) => j.version,
-    set: (j, v) => {
-      j.version = v;
-    },
-  },
-  {
-    // marketplace manifest (stays at repo root)
+    label: '.claude-plugin/marketplace.json (metadata.version)',
     path: '.claude-plugin/marketplace.json',
     get: (j) => j.metadata?.version,
     set: (j, v) => {
@@ -60,19 +77,88 @@ function bumpSemver(current, type) {
   }
 }
 
+/**
+ * Discover every plugin in plugins/<name>/ that has a plugin.json manifest.
+ * No hardcoded names — adding a new plugin folder makes it eligible.
+ */
+function discoverPlugins() {
+  if (!fs.existsSync(PLUGINS_DIR)) return [];
+  return fs
+    .readdirSync(PLUGINS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .filter((name) => fs.existsSync(path.join(PLUGINS_DIR, name, '.claude-plugin', 'plugin.json')))
+    .map((name) => ({
+      name,
+      label: `plugins/${name}/.claude-plugin/plugin.json`,
+      path: path.join('plugins', name, '.claude-plugin', 'plugin.json'),
+      relPrefix: `plugins/${name}/`,
+      get: (j) => j.version,
+      set: (j, v) => {
+        j.version = v;
+      },
+    }));
+}
+
+/**
+ * Return the set of plugin names that have any file under plugins/<name>/
+ * changed in the given git range. When the range is empty/missing, returns
+ * null to signal "bump every plugin".
+ */
+function pluginsTouchedIn(range, pluginNames) {
+  if (!range) return null;
+  let diff;
+  try {
+    diff = execSync(`git diff --name-only ${range}`, {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    console.warn(
+      `[bump-version] could not run \`git diff --name-only ${range}\` — falling back to "all plugins"`
+    );
+    console.warn(`  ${err.message.split('\n')[0]}`);
+    return null;
+  }
+  const touched = new Set();
+  for (const line of diff.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    for (const name of pluginNames) {
+      if (trimmed.startsWith(`plugins/${name}/`)) touched.add(name);
+    }
+  }
+  return touched;
+}
+
+function logBumpPlan({ range, allPlugins, pluginsToBump, skippedPlugins }) {
+  if (!range) {
+    const names = allPlugins.map((p) => p.name).join(', ');
+    console.log(`[bump-version] BUMP_RANGE not set — bumping ALL plugins (${names})`);
+    return;
+  }
+  console.log(`[bump-version] range: ${range}`);
+  const touchedNames = pluginsToBump.length
+    ? pluginsToBump.map((p) => p.name).join(', ')
+    : '(none)';
+  console.log(`[bump-version] plugins touched: ${touchedNames}`);
+  if (skippedPlugins.length) {
+    console.log(`[bump-version] plugins skipped (no changes): ${skippedPlugins.join(', ')}`);
+  }
+}
+
 function main() {
   const arg = process.argv[2];
   if (!arg) {
-    console.error('Usage: node scripts/bump-version.js <patch|minor|major|x.y.z>');
+    console.error('Usage: node bump-version.js <patch|minor|major|x.y.z>');
     process.exit(1);
   }
 
-  // Read current version from package.json
   const pkgPath = path.join(ROOT, 'package.json');
   const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
   const current = pkg.version;
 
-  // Determine new version
   let newVersion;
   if (/^\d+\.\d+\.\d+$/.test(arg)) {
     newVersion = arg;
@@ -89,14 +175,31 @@ function main() {
     process.exit(0);
   }
 
-  // Update all files
-  for (const file of FILES) {
+  const allPlugins = discoverPlugins();
+  const range = process.env.BUMP_RANGE;
+  const touched = pluginsTouchedIn(
+    range,
+    allPlugins.map((p) => p.name)
+  );
+
+  // Build the bump set: ALWAYS_BUMP + touched plugin manifests (or all
+  // plugins when no range is available).
+  const pluginsToBump =
+    touched === null ? allPlugins : allPlugins.filter((p) => touched.has(p.name));
+  const skippedPlugins = touched
+    ? allPlugins.filter((p) => !touched.has(p.name)).map((p) => p.name)
+    : [];
+
+  logBumpPlan({ range, allPlugins, pluginsToBump, skippedPlugins });
+
+  const allTargets = [...ALWAYS_BUMP, ...pluginsToBump];
+  for (const file of allTargets) {
     const filePath = path.join(ROOT, file.path);
     const content = JSON.parse(fs.readFileSync(filePath, 'utf8'));
     const old = file.get(content);
     file.set(content, newVersion);
     fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + '\n');
-    console.log(`  ${file.path}: ${old} → ${newVersion}`);
+    console.log(`  ${file.label}: ${old} → ${newVersion}`);
   }
 
   console.log(`\nBumped ${current} → ${newVersion}`);

--- a/plugins/work/scripts/workflows/lib/scripts/bump-version.js
+++ b/plugins/work/scripts/workflows/lib/scripts/bump-version.js
@@ -36,7 +36,21 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
+
+// Strict allowlist for git rev ranges passed to `git diff`. Accepts:
+//   - refs/branches/tags/SHAs containing [A-Za-z0-9._/-]
+//   - optional `..` or `...` separator between two such refs
+// Anything with shell metacharacters (`;`, `|`, `&`, `$`, backticks, spaces,
+// quotes, redirects, newlines, etc.) is rejected. This is defence-in-depth on
+// top of execFileSync (no shell), to keep CodeQL happy and to fail fast on
+// obviously bogus values from BUMP_RANGE.
+const SAFE_REV = '[A-Za-z0-9._/-]+';
+const SAFE_RANGE_RE = new RegExp(`^${SAFE_REV}(\\.\\.\\.?${SAFE_REV})?$`);
+
+function isSafeRange(range) {
+  return typeof range === 'string' && range.length > 0 && SAFE_RANGE_RE.test(range);
+}
 
 // __dirname = plugins/work/scripts/workflows/lib/scripts → repo root is 6 levels up
 const ROOT = path.join(__dirname, '..', '..', '..', '..', '..', '..');
@@ -107,9 +121,15 @@ function discoverPlugins() {
  */
 function pluginsTouchedIn(range, pluginNames) {
   if (!range) return null;
+  if (!isSafeRange(range)) {
+    console.warn(
+      `[bump-version] BUMP_RANGE="${range}" rejected (must match ${SAFE_RANGE_RE}) — falling back to "all plugins"`
+    );
+    return null;
+  }
   let diff;
   try {
-    diff = execSync(`git diff --name-only ${range}`, {
+    diff = execFileSync('git', ['diff', '--name-only', range], {
       cwd: ROOT,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/plugins/work/scripts/workflows/lib/scripts/bump-version.js
+++ b/plugins/work/scripts/workflows/lib/scripts/bump-version.js
@@ -40,12 +40,13 @@ const { execFileSync } = require('child_process');
 
 // Strict allowlist for git rev ranges passed to `git diff`. Accepts:
 //   - refs/branches/tags/SHAs containing [A-Za-z0-9._/-]
+//   - the standard git rev modifiers `~` and `^` (e.g. HEAD~1, HEAD^)
 //   - optional `..` or `...` separator between two such refs
 // Anything with shell metacharacters (`;`, `|`, `&`, `$`, backticks, spaces,
 // quotes, redirects, newlines, etc.) is rejected. This is defence-in-depth on
 // top of execFileSync (no shell), to keep CodeQL happy and to fail fast on
 // obviously bogus values from BUMP_RANGE.
-const SAFE_REV = '[A-Za-z0-9._/-]+';
+const SAFE_REV = '[A-Za-z0-9._/~^-]+';
 const SAFE_RANGE_RE = new RegExp(`^${SAFE_REV}(\\.\\.\\.?${SAFE_REV})?$`);
 
 function isSafeRange(range) {

--- a/plugins/work/scripts/workflows/lib/scripts/bump-version.js
+++ b/plugins/work/scripts/workflows/lib/scripts/bump-version.js
@@ -106,7 +106,6 @@ function discoverPlugins() {
       name,
       label: `plugins/${name}/.claude-plugin/plugin.json`,
       path: path.join('plugins', name, '.claude-plugin', 'plugin.json'),
-      relPrefix: `plugins/${name}/`,
       get: (j) => j.version,
       set: (j, v) => {
         j.version = v;

--- a/plugins/work/scripts/workflows/lib/scripts/bump-version.js
+++ b/plugins/work/scripts/workflows/lib/scripts/bump-version.js
@@ -152,10 +152,17 @@ function pluginsTouchedIn(range, pluginNames) {
   return touched;
 }
 
-function logBumpPlan({ range, allPlugins, pluginsToBump, skippedPlugins }) {
-  if (!range) {
+function logBumpPlan({ range, touched, allPlugins, pluginsToBump, skippedPlugins }) {
+  // `touched === null` is the fallback signal from pluginsTouchedIn: either
+  // BUMP_RANGE was unset, the range failed the safety regex, or `git diff`
+  // errored. In all three cases we bump every plugin — keep the log honest
+  // about that so CI output does not claim a "scoped" bump when it's full.
+  if (touched === null) {
     const names = allPlugins.map((p) => p.name).join(', ');
-    console.log(`[bump-version] BUMP_RANGE not set — bumping ALL plugins (${names})`);
+    const reason = range
+      ? `BUMP_RANGE="${range}" rejected or git diff failed`
+      : 'BUMP_RANGE not set';
+    console.log(`[bump-version] ${reason} — bumping ALL plugins (${names})`);
     return;
   }
   console.log(`[bump-version] range: ${range}`);
@@ -210,7 +217,7 @@ function main() {
     ? allPlugins.filter((p) => !touched.has(p.name)).map((p) => p.name)
     : [];
 
-  logBumpPlan({ range, allPlugins, pluginsToBump, skippedPlugins });
+  logBumpPlan({ range, touched, allPlugins, pluginsToBump, skippedPlugins });
 
   const allTargets = [...ALWAYS_BUMP, ...pluginsToBump];
   for (const file of allTargets) {


### PR DESCRIPTION
## Existing Behavior

- `bump-version.js` hardcoded the `work` plugin as the only manifest to update, causing `heimdall`, `maestro`, `synapsys`, and any future plugins to silently drift behind the workspace manifest.
- The CI workflow `git add` listed only the work plugin manifest explicitly, so other plugin manifests would never be staged even if the script were fixed.
- `actions/checkout` used the default `fetch-depth: 1`, meaning `git diff --name-only <before>..<sha>` would fail to resolve older commits.
- No guard existed for a no-op bump, causing spurious empty commits.

## Intended New Behavior

- `bump-version.js` dynamically discovers every `plugins/<name>/.claude-plugin/plugin.json` on disk — no hardcoded names; adding a new plugin folder makes it eligible automatically.
- When `BUMP_RANGE` env var is set (CI push), only plugins whose files appear in `git diff --name-only <range>` get their manifests bumped; plugins with no changes in the range are skipped.
- When `BUMP_RANGE` is unset (local invocation), all plugins are bumped — preserving the old "bump everything" behaviour as a safe fallback.
- Input is validated through `isSafeRange()` allowlist regex before reaching `execFileSync` (replaces shell-interpolated `execSync`), addressing CodeQL alert #362.
- CI workflow sets `fetch-depth: 0`, passes `BUMP_RANGE=${{ github.event.before }}..${{ github.sha }}`, stages manifests via `plugins/*/.claude-plugin/plugin.json` glob, and exits cleanly on no-op.
- Extracted `logBumpPlan()` helper keeps cyclomatic complexity <= 10 for `main()`.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify scoped bumping in CI:**

1. Push a commit that only touches `plugins/synapsys/` files — confirm the release workflow bumps `plugins/synapsys/.claude-plugin/plugin.json` but leaves `plugins/work/.claude-plugin/plugin.json` unchanged.
2. Push a commit that touches both `plugins/work/` and `plugins/heimdall/` files — confirm both manifests are bumped and neither `synapsys` nor `maestro` manifest changes.
3. Push a commit that touches only root files (no plugin files) — confirm no plugin manifest is bumped and the no-op guard exits 0 without creating a commit.

**Verify fallback ("bump all") locally:**

```bash
# From repo root — no BUMP_RANGE set
node plugins/work/scripts/workflows/lib/scripts/bump-version.js patch
# Expected: all plugins/<name>/.claude-plugin/plugin.json files bumped
```

**Verify scoped bump locally:**

```bash
BUMP_RANGE=HEAD~1..HEAD node plugins/work/scripts/workflows/lib/scripts/bump-version.js patch
# Expected: only plugin manifests for plugins with files changed in last commit are bumped
```

**Verify invalid range falls back safely:**

```bash
BUMP_RANGE='$(malicious)' node plugins/work/scripts/workflows/lib/scripts/bump-version.js patch
# Expected: warning logged, falls back to bumping all plugins, no shell execution
```

Closes #479

> Replaces closed PR #480 (branch was renamed for /follow-up ticket-ID detection).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and which plugin versions advance on each push; incorrect scoping could leave plugin manifests out of sync with workspace/marketplace versions.
> 
> **Overview**
> Release bumping now **scopes plugin manifest updates** to plugins with files changed in the push, while **workspace** `package.json` and **marketplace** `.claude-plugin/marketplace.json` still bump on every release.
> 
> `bump-version.js` **discovers** all `plugins/*/.claude-plugin/plugin.json` manifests instead of hardcoding `work`, uses **`BUMP_RANGE`** with `git diff --name-only` (validated range + `execFileSync`), and **falls back to bumping every plugin** when the range is missing, invalid, or `git diff` fails. The **bump-version** workflow uses **`fetch-depth: 0`**, passes **`BUMP_RANGE`**, stages manifests with a **glob**, and **skips commit** when nothing changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c12c24a3b2b3e2f898430ba9649800db0a5f2bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->