### PR TITLE
#484 - chore(release): minor bump across all plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
-    "version": "3.15.0"
+    "version": "3.16.0"
   },
   "plugins": [
     {
@@ -14,54 +14,28 @@
       "source": "./plugins/work",
       "description": "Orchestrated /work command with pre-computed action plans",
       "category": "workflow",
-      "tags": [
-        "workflow",
-        "jira",
-        "orchestrator",
-        "state-machine",
-        "automation"
-      ]
+      "tags": ["workflow", "jira", "orchestrator", "state-machine", "automation"]
     },
     {
       "name": "synapsys",
       "source": "./plugins/synapsys",
       "description": "Context-triggered memory injection — memories declare event hooks + trigger patterns and are injected when matched",
       "category": "memory",
-      "tags": [
-        "memory",
-        "hooks",
-        "injection",
-        "context",
-        "recall"
-      ]
+      "tags": ["memory", "hooks", "injection", "context", "recall"]
     },
     {
       "name": "maestro",
       "source": "./plugins/maestro",
       "description": "Multi-agent orchestrator — bootstraps per-ticket tmux sessions, conducts them (silence detection + auto-restart), and surfaces real prompts to the operator",
       "category": "orchestration",
-      "tags": [
-        "orchestrate",
-        "conduct",
-        "agents",
-        "tmux",
-        "workflow",
-        "multi-agent"
-      ]
+      "tags": ["orchestrate", "conduct", "agents", "tmux", "workflow", "multi-agent"]
     },
     {
       "name": "heimdall",
       "source": "./plugins/heimdall",
       "description": "Config-driven file/directory guard — lock blocks pair protected paths with an unlock phrase; a PreToolUse hook blocks Edit/Write/Bash/Task mutations unless the phrase is spoken",
       "category": "safety",
-      "tags": [
-        "guard",
-        "protection",
-        "hooks",
-        "pretooluse",
-        "lock",
-        "safety"
-      ]
+      "tags": ["guard", "protection", "hooks", "pretooluse", "lock", "safety"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
   "license": "MIT",
   "repository": {

--- a/plugins/heimdall/.claude-plugin/plugin.json
+++ b/plugins/heimdall/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "heimdall",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Config-driven file/directory guard. Lock blocks declare protected paths + an unlock phrase; a PreToolUse hook blocks Edit/Write/Bash/Task mutations to those paths unless the user speaks the phrase. Stores are local, worktree, or global like synapsys.",
   "author": {
     "name": "Custom",

--- a/plugins/maestro/.claude-plugin/plugin.json
+++ b/plugins/maestro/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Multi-agent orchestrator. Bootstraps per-ticket tmux sessions in isolated worktrees, conducts them (auto-restart on silence, surface real prompts to the operator), and exposes a file-mailbox signal channel.",
   "author": {
     "name": "Custom",

--- a/plugins/synapsys/.claude-plugin/plugin.json
+++ b/plugins/synapsys/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsys",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Context-triggered memory injection. Memories declare trigger patterns + lifecycle events in frontmatter; matching memories are injected into Claude's context on the right hook.",
   "author": {
     "name": "Custom",

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Self-contained workflow plugin with agents, hooks, skills, and orchestration. Includes 18 specialized agents, agent-specific hooks, and 25 skills.",
   "author": {
     "name": "Custom",


### PR DESCRIPTION
## Existing Behavior

- heimdall plugin at version 0.1.1
- maestro plugin at version 0.1.1
- synapsys plugin at version 0.1.3
- work plugin and workspace at version 3.15.0; marketplace metadata reflects 3.15.0

## Intended New Behavior

- heimdall plugin bumped to 0.2.0
- maestro plugin bumped to 0.2.0
- synapsys plugin bumped to 0.2.0
- work plugin, workspace package.json, and marketplace metadata all bumped to 3.16.0

## Dev Checks
- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a coordinated release-only version bump with no behavior changes.

1. Verify `plugins/heimdall/.claude-plugin/plugin.json` version field reads `0.2.0`
2. Verify `plugins/maestro/.claude-plugin/plugin.json` version field reads `0.2.0`
3. Verify `plugins/synapsys/.claude-plugin/plugin.json` version field reads `0.2.0`
4. Verify `plugins/work/.claude-plugin/plugin.json` version field reads `3.16.0`
5. Verify root `package.json` version reads `3.16.0`
6. Verify `.claude-plugin/marketplace.json` metadata version reads `3.16.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only version and formatting updates with no code or behavior changes.
> 
> **Overview**
> Coordinated **release-only** version bumps with no runtime or logic changes.
> 
> **work-workflow** moves from **3.15.0** to **3.16.0** in root `package.json`, `plugins/work/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` metadata. **heimdall**, **maestro**, and **synapsys** each move to **0.2.0** in their respective `plugin.json` files (from 0.1.1 / 0.1.1 / 0.1.3). The marketplace file also **reformats** plugin `tags` arrays to single-line style only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c706525b2c3b6822cac36ed9beb6448a7a0495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->