### PR TITLE
feat(work): accept render-only Gherkin scenarios without When step

### DIFF
--- a/plugins/work/scripts/workflows/work/lib/__tests__/parse-gherkin.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/parse-gherkin.test.js
@@ -535,77 +535,6 @@ describe('parse-gherkin: validate', () => {
     assert.deepEqual(DEFAULT_REQUIRED_TAGS, ['@integration', '@e2e']);
   });
 
-  it('fails when scenario is missing When step', () => {
-    const parseResult = {
-      features: [
-        {
-          name: 'F',
-          scenarios: [
-            {
-              name: 'Missing When',
-              tags: ['@integration'],
-              steps: [
-                { keyword: 'Given', text: 'x' },
-                { keyword: 'Then', text: 'z' },
-              ],
-            },
-            {
-              name: 'Complete',
-              tags: [],
-              steps: [
-                { keyword: 'Given', text: 'a' },
-                { keyword: 'When', text: 'b' },
-                { keyword: 'Then', text: 'c' },
-              ],
-            },
-          ],
-        },
-      ],
-      errors: [],
-    };
-    const result = validate(parseResult, { minScenarios: 1, requireTags: ['@integration'] });
-    assert.equal(result.valid, false);
-    assert.ok(result.errors.some((e) => e.includes('Missing When') && e.includes('When')));
-  });
-
-  it('fails when scenario has only Given and Then (missing When mentioned)', () => {
-    const parseResult = {
-      features: [
-        {
-          name: 'F',
-          scenarios: [
-            {
-              name: 'Incomplete scenario',
-              tags: ['@e2e'],
-              steps: [
-                { keyword: 'Given', text: 'setup' },
-                { keyword: 'Then', text: 'result' },
-              ],
-            },
-            {
-              name: 'Full',
-              tags: [],
-              steps: [
-                { keyword: 'Given', text: 'a' },
-                { keyword: 'When', text: 'b' },
-                { keyword: 'Then', text: 'c' },
-              ],
-            },
-          ],
-        },
-      ],
-      errors: [],
-    };
-    const result = validate(parseResult, { minScenarios: 1, requireTags: ['@e2e'] });
-    assert.equal(result.valid, false);
-    const stepError = result.errors.find((e) => e.includes('Incomplete scenario'));
-    assert.ok(stepError);
-    assert.ok(stepError.includes('When'));
-    // Should only mention the missing keyword, not the ones already present
-    assert.ok(!stepError.includes('missing Given'));
-    assert.ok(!stepError.includes('missing Then'));
-  });
-
   it('passes when scenario has Given/When/Then plus And (And extends previous)', () => {
     const parseResult = {
       features: [
@@ -640,6 +569,142 @@ describe('parse-gherkin: validate', () => {
     const result = validate(parseResult, { minScenarios: 1, requireTags: ['@integration'] });
     assert.equal(result.valid, true);
     assert.deepEqual(result.errors, []);
+  });
+
+  it('Render-only scenario with only Given and Then passes validation', () => {
+    const parseResult = {
+      features: [
+        {
+          name: 'Render-only feature',
+          scenarios: [
+            {
+              name: 'render-only scenario',
+              tags: ['@integration'],
+              steps: [
+                { keyword: 'Given', text: 'a precondition' },
+                { keyword: 'Then', text: 'an outcome is observed' },
+              ],
+            },
+            {
+              name: 'second render-only scenario',
+              tags: ['@e2e'],
+              steps: [
+                { keyword: 'Given', text: 'another precondition' },
+                { keyword: 'Then', text: 'another outcome is observed' },
+              ],
+            },
+          ],
+        },
+      ],
+      errors: [],
+    };
+    const result = validate(parseResult);
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.errors, []);
+  });
+
+  it('Given/When/Then scenarios continue to validate', () => {
+    const parseResult = {
+      features: [
+        {
+          name: 'Classic feature',
+          scenarios: [
+            {
+              name: 'classic Given-When-Then',
+              tags: ['@integration'],
+              steps: [
+                { keyword: 'Given', text: 'a precondition' },
+                { keyword: 'When', text: 'an action occurs' },
+                { keyword: 'Then', text: 'an outcome is observed' },
+              ],
+            },
+            {
+              name: 'second classic scenario',
+              tags: ['@e2e'],
+              steps: [
+                { keyword: 'Given', text: 'another precondition' },
+                { keyword: 'When', text: 'another action occurs' },
+                { keyword: 'Then', text: 'another outcome is observed' },
+              ],
+            },
+          ],
+        },
+      ],
+      errors: [],
+    };
+    const result = validate(parseResult);
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.errors, []);
+  });
+
+  it('Missing Given fails with clear error', () => {
+    const parseResult = {
+      features: [
+        {
+          name: 'Missing Given feature',
+          scenarios: [
+            {
+              name: 'no Given scenario',
+              tags: ['@integration'],
+              steps: [
+                { keyword: 'When', text: 'an action occurs' },
+                { keyword: 'Then', text: 'an outcome is observed' },
+              ],
+            },
+            {
+              name: 'filler scenario',
+              tags: ['@e2e'],
+              steps: [
+                { keyword: 'Given', text: 'a precondition' },
+                { keyword: 'Then', text: 'an outcome is observed' },
+              ],
+            },
+          ],
+        },
+      ],
+      errors: [],
+    };
+    const result = validate(parseResult);
+    assert.equal(result.valid, false);
+    assert.ok(
+      result.errors.some((e) => /Given/.test(e)),
+      `expected an error mentioning Given, got: ${JSON.stringify(result.errors)}`
+    );
+  });
+
+  it('Missing Then fails with clear error', () => {
+    const parseResult = {
+      features: [
+        {
+          name: 'Missing Then feature',
+          scenarios: [
+            {
+              name: 'no Then scenario',
+              tags: ['@integration'],
+              steps: [
+                { keyword: 'Given', text: 'a precondition' },
+                { keyword: 'When', text: 'an action occurs' },
+              ],
+            },
+            {
+              name: 'filler scenario',
+              tags: ['@e2e'],
+              steps: [
+                { keyword: 'Given', text: 'a precondition' },
+                { keyword: 'Then', text: 'an outcome is observed' },
+              ],
+            },
+          ],
+        },
+      ],
+      errors: [],
+    };
+    const result = validate(parseResult);
+    assert.equal(result.valid, false);
+    assert.ok(
+      result.errors.some((e) => /Then/.test(e)),
+      `expected an error mentioning Then, got: ${JSON.stringify(result.errors)}`
+    );
   });
 });
 

--- a/plugins/work/scripts/workflows/work/lib/parse-gherkin.js
+++ b/plugins/work/scripts/workflows/work/lib/parse-gherkin.js
@@ -250,12 +250,10 @@ function validate(parseResult, options) {
       const keywords = new Set(scenario.steps.map((s) => s.keyword));
       // And/But extend the previous keyword, so we only require the primary three
       const hasGiven = keywords.has('Given');
-      const hasWhen = keywords.has('When');
       const hasThen = keywords.has('Then');
-      if (!hasGiven || !hasWhen || !hasThen) {
+      if (!hasGiven || !hasThen) {
         const missing = [];
         if (!hasGiven) missing.push('Given');
-        if (!hasWhen) missing.push('When');
         if (!hasThen) missing.push('Then');
         validationErrors.push(
           `Scenario "${scenario.name}" is missing ${missing.join(', ')} step(s)`

--- a/plugins/work/scripts/workflows/work/steps/__tests__/spec-gate.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/spec-gate.test.js
@@ -347,4 +347,32 @@ describe('spec-gate with standalone gherkin.feature', () => {
     assert.match(entries[0].reason, /skip override/i);
     assert.match(entries[0].reason, /config-only/i);
   });
+
+  // GH-400 Task 2: spec_gate accepts a standalone gherkin.feature with only Given/Then
+  const GHERKIN_FEATURE_RENDER_ONLY = [
+    'Feature: Render-only behavior',
+    '  @integration',
+    '  Scenario: Renders the dashboard widget',
+    '    Given the dashboard is mounted with default props',
+    '    Then the widget container is visible',
+    '',
+    '  @integration',
+    '  Scenario: Renders the empty state',
+    '    Given the dashboard is mounted with no data',
+    '    Then the empty-state message is visible',
+    '',
+  ].join('\n');
+
+  it('spec_gate accepts a standalone gherkin.feature with only Given/Then', () => {
+    const dir = makeTmpWithGherkinFeature(GHERKIN_FEATURE_RENDER_ONLY);
+    createdDirs.push(dir);
+    const { add, entries } = makeAdd();
+    specGateStep(add, makeState(), makeCtx({ tasksDir: dir }));
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.spec_gate);
+    assert.equal(entries[0].action, 'DEFER');
+    assert.match(entries[0].reason, /passed/i);
+    assert.match(entries[0].reason, /2 scenarios/);
+    assert.match(entries[0].reason, /2 @integration/);
+  });
 });


### PR DESCRIPTION
## Existing Behavior

- `validate()` in `parse-gherkin.js` required every Gherkin scenario to contain a `When` step; any scenario without one was rejected with a "missing When" error.
- Render-only specs that describe initial state (Given) and expected output (Then) without an interaction step could not pass `spec_gate` validation.
- Two unit tests asserted that a missing `When` step was a hard validation failure.

## Intended New Behavior

- `validate()` now only requires `Given` and `Then` steps per scenario; `When` is optional, enabling render-only scenarios (e.g., "Given a dashboard / Then widgets are displayed").
- Classic Given-When-Then scenarios continue to pass; the change is strictly additive.
- Missing `Given` or missing `Then` still fails with clear, specific error messages.
- 4 new unit tests cover: render-only Given+Then valid, full GWT regression guard, missing Given fails, missing Then fails. 2 obsolete "missing When" tests removed.
- New integration test in `spec-gate.test.js` validates a standalone render-only `gherkin.feature` passes `spec_gate` end-to-end.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Unit tests (parse-gherkin):**
```bash
node --test plugins/work/scripts/workflows/work/lib/__tests__/parse-gherkin.test.js
```
Expected: all tests pass, including the 4 new render-only scenarios.

**Integration test (spec-gate):**
```bash
node --test plugins/work/scripts/workflows/work/steps/__tests__/spec-gate.test.js
```
Expected: the standalone render-only gherkin.feature test passes.

**Manual verification — render-only scenario passes gate:**
1. Create a `spec.md` with a Gherkin section containing only Given+Then steps (no When):
   ```gherkin
   Feature: Dashboard render
     @integration
     Scenario: Widgets are displayed on load
       Given the dashboard page is open
       Then all configured widgets are visible
   ```
2. Run `spec_gate` against that spec — expect it to pass without "missing When" errors.
3. Remove the `Given` line and rerun — expect a clear "missing Given" error.
4. Restore `Given`, remove `Then`, rerun — expect a clear "missing Then" error.

Closes #400

### Test Results
Tests pass locally — 4 new unit tests added, 2 obsolete tests removed, 1 new integration test added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow validation rule relaxation in test/spec tooling only; no auth, data, or runtime product behavior changes.
> 
> **Overview**
> **Gherkin validation** in `parse-gherkin.js` no longer requires a `When` step per scenario—only **Given** and **Then** are mandatory. Render-only specs (setup + observable outcome, no interaction) can pass `validate()` and **spec_gate** without a false “missing When” failure; full Given-When-Then scenarios are unchanged.
> 
> Tests were updated: removed expectations that missing `When` fails; added cases for render-only Given+Then success, classic GWT still passing, and clear failures when **Given** or **Then** is absent. **spec-gate** integration test confirms a standalone `gherkin.feature` with two Given/Then scenarios DEFERs with a passed reason and scenario/tag counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77390f69d14f6470933b7daf02476b1f944470a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->