### PR TITLE
test(check): regression coverage for emoji markers in negation context

### DIFF
--- a/plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.integration.test.js
+++ b/plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.integration.test.js
@@ -1,8 +1,0 @@
-// Placeholder for GH-279 Task 2 — integration tests for validateCodeReview()
-// against a ticket-sentence fixture. Created in Task 1 per tasks.md
-// "Files in scope" (NEW). Populated by Task 2.
-//
-// Intentionally empty: contains no test() invocations so that Task 1's
-// RED phase scope (test files only) is satisfied without coupling Task 1
-// evidence to Task 2 deliverables.
-'use strict';

--- a/plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.integration.test.js
+++ b/plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.integration.test.js
@@ -1,0 +1,8 @@
+// Placeholder for GH-279 Task 2 — integration tests for validateCodeReview()
+// against a ticket-sentence fixture. Created in Task 1 per tasks.md
+// "Files in scope" (NEW). Populated by Task 2.
+//
+// Intentionally empty: contains no test() invocations so that Task 1's
+// RED phase scope (test files only) is satisfied without coupling Task 1
+// evidence to Task 2 deliverables.
+'use strict';

--- a/plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.test.js
+++ b/plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.test.js
@@ -273,14 +273,22 @@ describe('severity-detection', () => {
     it('Bullet-list negation with leading "-" is not a finding', () => {
       const report = '- No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.';
       const result = detectSeverityMarkers(report);
-      assert.equal(result.critical.length, 0, 'leading "-" list-marker negation must be suppressed');
+      assert.equal(
+        result.critical.length,
+        0,
+        'leading "-" list-marker negation must be suppressed'
+      );
       assert.equal(result.important.length, 0);
     });
 
     it('Bullet-list negation with leading "*" is not a finding', () => {
       const report = '* No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.';
       const result = detectSeverityMarkers(report);
-      assert.equal(result.critical.length, 0, 'leading "*" list-marker negation must be suppressed');
+      assert.equal(
+        result.critical.length,
+        0,
+        'leading "*" list-marker negation must be suppressed'
+      );
       assert.equal(result.important.length, 0);
     });
 
@@ -425,5 +433,57 @@ describe('validateCodeReview integration', () => {
   it('is exported via module.exports', () => {
     const mod = require('../../hooks/check-validate-reports');
     assert.equal(typeof mod.validateCodeReview, 'function');
+  });
+
+  // -------------------------------------------------------------------------
+  // GH-279 Task 2 — ticket-sentence fixture scenarios (verbatim titles).
+  // -------------------------------------------------------------------------
+
+  /**
+   * Build a code-review fixture body with the required Changes Hash header.
+   * @param {string} body
+   */
+  function fixtureWithHash(body) {
+    return ['**Changes Hash:** abc123', '', body].join('\n');
+  }
+
+  it('validateCodeReview returns valid=true for negation-only report', () => {
+    const content = fixtureWithHash('No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.');
+
+    const result = runValidation(content);
+
+    assert.equal(result.exists, true, 'fixture file must be discovered');
+    assert.equal(result.hasCritical, false, 'negation-only must not flag critical');
+    assert.equal(result.hasImportant, false, 'negation-only must not flag important');
+    assert.equal(result.valid, true, 'negation-only report must be valid');
+    assert.equal(
+      result.requiresAction,
+      false,
+      'negation-only report must not require action (R5 return shape)'
+    );
+  });
+
+  it('validateCodeReview returns hasCritical=true for a genuine CRITICAL finding', () => {
+    const content = fixtureWithHash('🔴 CRITICAL: SQL injection vulnerability in query builder');
+
+    const result = runValidation(content);
+
+    assert.equal(result.exists, true);
+    assert.equal(result.hasCritical, true, 'genuine CRITICAL must flag hasCritical');
+    assert.equal(result.valid, false, 'a genuine CRITICAL must make report invalid');
+  });
+
+  it('Genuine bold-bracket CRITICAL finding is detected', () => {
+    const content = fixtureWithHash('**[🔴 CRITICAL] Missing input validation in auth handler**');
+
+    const result = runValidation(content);
+
+    assert.equal(result.exists, true);
+    assert.equal(
+      result.hasCritical,
+      true,
+      'bold-bracket CRITICAL format must be detected as a finding'
+    );
+    assert.equal(result.valid, false, 'bold-bracket CRITICAL must make report invalid');
   });
 });

--- a/plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.test.js
+++ b/plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.test.js
@@ -231,6 +231,106 @@ describe('severity-detection', () => {
       assert.equal(result.important.length, 0);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // GH-279 regression scenarios — literal ticket sentence + variants
+  // Each scenario title below maps verbatim to tasks.md Task 1 scenarios.
+  // -------------------------------------------------------------------------
+  describe('GH-279 regression — literal ticket sentence + variants', () => {
+    // Scenario: Negation-only summary line is not a finding
+    it('Negation-only summary line is not a finding', () => {
+      // Literal ticket sentence with trailing period.
+      // Matches Verification Checklist regex:
+      //   /No remaining .* CRITICAL or .* IMPORTANT issues\./
+      const report = 'No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'literal ticket sentence must yield zero CRITICAL');
+      assert.equal(result.important.length, 0, 'literal ticket sentence must yield zero IMPORTANT');
+    });
+
+    it('Negation-only summary line — casing variant', () => {
+      const report = 'No Remaining 🔴 CRITICAL or 🟡 IMPORTANT Issues.';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+      assert.equal(result.important.length, 0);
+    });
+
+    it('Negation-only summary line — no trailing punctuation', () => {
+      const report = 'No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+      assert.equal(result.important.length, 0);
+    });
+
+    it('Negation-only summary line — exclamation point trailing punctuation', () => {
+      const report = 'No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues!';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0);
+      assert.equal(result.important.length, 0);
+    });
+
+    // Scenario: Bullet-list negation with leading "-" is not a finding
+    it('Bullet-list negation with leading "-" is not a finding', () => {
+      const report = '- No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'leading "-" list-marker negation must be suppressed');
+      assert.equal(result.important.length, 0);
+    });
+
+    it('Bullet-list negation with leading "*" is not a finding', () => {
+      const report = '* No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'leading "*" list-marker negation must be suppressed');
+      assert.equal(result.important.length, 0);
+    });
+
+    // Scenario: Blockquote negation with leading ">" is not a finding
+    it('Blockquote negation with leading ">" is not a finding', () => {
+      const report = '> No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'blockquote negation must be suppressed');
+      assert.equal(result.important.length, 0);
+    });
+
+    // Scenario: Section heading label without finding body is not counted
+    it('Section heading label without finding body is not counted', () => {
+      const report = '### 🔴 CRITICAL ISSUES';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'heading label alone must not count as a finding');
+      assert.equal(result.important.length, 0);
+    });
+
+    // Scenario: Inline-code-spanned marker inside a backtick code span is ignored
+    it('Inline-code-spanned marker inside a backtick code span is ignored', () => {
+      const report = 'See helper `🔴 CRITICAL: leftover from older docs` in legacy notes.';
+      const result = detectSeverityMarkers(report);
+      assert.equal(result.critical.length, 0, 'marker inside backticks must be ignored');
+    });
+
+    // Scenario: Mid-line "no...issues" phrase does not suppress a real co-occurring CRITICAL finding
+    it('Mid-line "no...issues" phrase does not suppress a real co-occurring CRITICAL finding', () => {
+      const report = 'there are no blocking issues with 🔴 CRITICAL: the session token expiry';
+      const result = detectSeverityMarkers(report);
+      assert.equal(
+        result.critical.length,
+        1,
+        'mid-line negation phrase must not suppress a genuine co-occurring finding'
+      );
+    });
+
+    // Scenario: Severity justification metadata line is not counted as a finding
+    it('Severity justification metadata line is not counted as a finding', () => {
+      const report =
+        '- Severity justification: 🟡 Important because the emoji convention is the enforced standard';
+      const result = detectSeverityMarkers(report);
+      assert.equal(
+        result.important.length,
+        0,
+        'severity justification metadata must not count as a finding'
+      );
+      assert.equal(result.critical.length, 0);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/plugins/work/scripts/workflows/lib/ticket-provider.js
+++ b/plugins/work/scripts/workflows/lib/ticket-provider.js
@@ -459,9 +459,9 @@ function getTransitionPrompt(ticketId, status, providerConfig) {
       );
     case 'linear':
       return (
-        'Update Linear issue ' +
+        'Transition Linear issue ' +
         ticketId +
-        ' status to "' +
+        ' to "' +
         status +
         '" using mcp__linear__save_issue with id "' +
         ticketId +


### PR DESCRIPTION
## Existing Behavior

- `detectSeverityMarkers()` in `severity-detection.js` correctly suppresses emoji markers that appear in negation contexts (e.g., "No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.") via `NEGATION_PATTERNS`, but there were no regression tests locking this behavior.
- The `validateCodeReview` integration path had no test coverage for the negation-context scenario.
- `getTransitionPrompt` in `ticket-provider.js` returned "Update Linear issue ... status to ..." as the first word of the Linear prompt, while `work-orchestrator.test.js:820` asserts every 2b_transition RUN prompt contains "transition" or "Transition" — causing a pre-existing failure when `TICKET_PROVIDER=linear` leaked from the shell into the test environment.

## Intended New Behavior

- 14 regression tests added in `severity-detection.test.js` (test count: 31 → 45) lock the negation-suppression behavior so it cannot silently regress.
- 11 unit tests cover the literal ticket sentence "No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues." plus list-marker (`-`, `*`), blockquote (`>`), casing, and punctuation variants against `detectSeverityMarkers()`.
- 3 `validateCodeReview` integration tests use a new `fixtureWithHash()` helper to cover: negation-only summary → `valid=true`; genuine CRITICAL finding → `hasCritical=true`; bold-bracket CRITICAL format detection.
- `getTransitionPrompt` for the Linear provider now opens with "Transition Linear issue ..." aligning with the Jira wording and satisfying the `work-orchestrator.test.js` assertion contract.

## Brief P0 coverage

- **P0 #1:** Regression tests lock "No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues." negation — implemented in `plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.test.js:58` (unit) and `:448` (integration via `fixtureWithHash`)
- **P0 #2:** Variants (list-markers, blockquote, casing, punctuation) also suppressed — implemented in `plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.test.js:267–330`
- **P0 #3:** Genuine findings are NOT suppressed by negation phrases — implemented in `plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.test.js:80–157` (false-positive-prevention boundary tests)

## Out-of-scope changes

- `plugins/work/scripts/workflows/lib/ticket-provider.js` — Maestro-authorized fix: changed Linear `getTransitionPrompt` opening word from "Update" to "Transition" to satisfy the existing `work-orchestrator.test.js:820` assertion (`TICKET_PROVIDER=linear` shell-leak surfaced the pre-existing failure during GH-279 check2 gate).

## Dev Checks

- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The changes are test-only (plus an orthogonal prompt-wording fix). Verify by running the affected test file directly:

1. Run the severity-detection test suite:
   ```bash
   node --test plugins/work/scripts/workflows/check/lib/__tests__/severity-detection.test.js
   ```
   Expected: all 45 tests pass, including the 14 new negation-context tests in the `negation context — false positive prevention` and `validateCodeReview integration` describe blocks.

2. Spot-check the negation boundary test:
   ```bash
   node -e "const { detectSeverityMarkers } = require('./plugins/work/scripts/workflows/check/lib/severity-detection'); const r = detectSeverityMarkers('No remaining issues.'); console.log('critical:', r.critical.length, '(expected 0)');"
   ```

3. Verify the Linear transition prompt wording fix does not break the orchestrator test:
   ```bash
   node --test plugins/work/scripts/workflows/lib/__tests__/work-orchestrator.test.js 2>&1 | grep -E "pass|fail"
   ```
   Expected: test `should handle 2b_transition based on provider` passes.

4. Full suite regression check:
   ```bash
   pnpm test 2>&1 | tail -5
   ```
   Expected: 4565/4567 pass, 0 fail (2 pre-existing skips unrelated to GH-279).

### Test Results

Quality gate (check2): 4565/4567 pass, 0 fail — APPROVED

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage plus a one-word prompt string change; no production severity-detection logic changes in the diff.
> 
> **Overview**
> Adds **GH-279 regression tests** so negation-style review text (e.g. *No remaining 🔴 CRITICAL or 🟡 IMPORTANT issues.*) and related markdown variants cannot be mistaken for real findings again. New cases cover list/blockquote prefixes, headings without bodies, inline code, mid-line negation vs real CRITICAL, and severity-justification lines; **`validateCodeReview`** integration tests use a **`fixtureWithHash`** helper for negation-only validity, genuine CRITICAL, and bold-bracket CRITICAL formats.
> 
> Separately, the Linear **`getTransitionPrompt`** string now starts with **"Transition"** instead of **"Update"**, matching Jira wording and an existing orchestrator test that requires transition prompts to include that word.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd1db1aeec5fef07d85341d52a328627b5928e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->