### PR TITLE
fix(hooks): resolve CLAUDE_PLUGIN_ROOT correctly when set to parent plugins-base dir

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/resolve-plugin-root-hook.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/resolve-plugin-root-hook.test.js
@@ -5,13 +5,41 @@
  * Run with: node --test hooks/__tests__/resolve-plugin-root-hook.test.js
  */
 
-const { describe, it } = require('node:test');
+const { describe, it, after } = require('node:test');
 const assert = require('node:assert');
 const { spawn } = require('child_process');
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
 
 const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'resolve-plugin-root-hook.js');
 const FAKE_ROOT = '/fake/plugin/root';
+
+// Track temp dirs for cleanup
+const TEMP_DIRS = [];
+function makeFixturePluginsBase() {
+  // Builds a parent plugins-base dir containing marketplaces/work-workflow/workflows/work
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'plugins-base-'));
+  TEMP_DIRS.push(base);
+  fs.mkdirSync(path.join(base, 'marketplaces', 'work-workflow', 'workflows', 'work'), {
+    recursive: true,
+  });
+  return base;
+}
+function makeFixtureLeafPlugin() {
+  // Builds a leaf plugin dir that directly contains workflows/work
+  const leaf = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-leaf-'));
+  TEMP_DIRS.push(leaf);
+  fs.mkdirSync(path.join(leaf, 'workflows', 'work'), { recursive: true });
+  return leaf;
+}
+after(() => {
+  for (const d of TEMP_DIRS) {
+    try {
+      fs.rmSync(d, { recursive: true, force: true });
+    } catch (_) {}
+  }
+});
 
 function runHook(input, env = {}) {
   return new Promise((resolve, reject) => {
@@ -54,7 +82,7 @@ describe('resolve-plugin-root-hook', () => {
     assert.ok(stderr.includes(`node ${FAKE_ROOT}/hooks/test.js`));
   });
 
-  it('should ALLOW commands without CLAUDE_PLUGIN_ROOT', async () => {
+  it('command without CLAUDE_PLUGIN_ROOT is allowed through unchanged', async () => {
     const { code, stderr } = await runHook({
       tool_input: { command: 'ls -la' },
     });
@@ -121,7 +149,7 @@ describe('resolve-plugin-root-hook', () => {
     assert.strictEqual(stderr, '');
   });
 
-  it('should ALLOW escaped \\$CLAUDE_PLUGIN_ROOT (not rewrite)', async () => {
+  it('escaped reference is left alone', async () => {
     const { code, stderr } = await runHook({
       tool_input: { command: 'grep \\$CLAUDE_PLUGIN_ROOT file.txt' },
     });
@@ -144,5 +172,56 @@ describe('resolve-plugin-root-hook', () => {
     );
     assert.strictEqual(code, 2);
     assert.ok(stderr.includes('/path/with/$pecial/chars'));
+  });
+
+  it('env var set to parent plugins-base directory is resolved to the marketplace subdir', async () => {
+    // env var = parent plugins-base dir; hook must probe down to marketplaces/work-workflow
+    const pluginsBase = makeFixturePluginsBase();
+    const expectedLeaf = path.join(pluginsBase, 'marketplaces', 'work-workflow');
+    const { code, stderr } = await runHook(
+      { tool_input: { command: 'node ${CLAUDE_PLUGIN_ROOT}/hooks/test.js' } },
+      { CLAUDE_PLUGIN_ROOT: pluginsBase }
+    );
+    assert.strictEqual(code, 2);
+    assert.ok(
+      stderr.includes(expectedLeaf),
+      `expected stderr to include leaf marketplace path ${expectedLeaf}, got:\n${stderr}`
+    );
+    // Should NOT use the bare parent plugins-base path as the rewrite root
+    assert.ok(
+      !stderr.includes(`node ${pluginsBase}/hooks/test.js`),
+      `hook must not rewrite to bare parent plugins-base dir, got:\n${stderr}`
+    );
+  });
+
+  it('env var set to leaf plugin directory is honoured as-is', async () => {
+    // env var = leaf plugin dir already containing workflows/work → use as-is
+    const leaf = makeFixtureLeafPlugin();
+    const { code, stderr } = await runHook(
+      { tool_input: { command: 'node ${CLAUDE_PLUGIN_ROOT}/hooks/test.js' } },
+      { CLAUDE_PLUGIN_ROOT: leaf }
+    );
+    assert.strictEqual(code, 2);
+    assert.ok(
+      stderr.includes(`node ${leaf}/hooks/test.js`),
+      `expected stderr to contain leaf path verbatim, got:\n${stderr}`
+    );
+  });
+
+  it('env var unset falls back to __dirname probing', async () => {
+    // env var unset → must fall back via resolvePluginRoot(__dirname, 3) probing
+    const { code, stderr } = await runHook(
+      { tool_input: { command: 'node ${CLAUDE_PLUGIN_ROOT}/hooks/test.js' } },
+      { CLAUDE_PLUGIN_ROOT: '' }
+    );
+    assert.strictEqual(code, 2);
+    // Resolved root must point at the actual plugin dir containing workflows/work
+    const match = stderr.match(/node (\S+)\/hooks\/test\.js/);
+    assert.ok(match, `expected rewritten command in stderr, got:\n${stderr}`);
+    const resolvedRoot = match[1];
+    assert.ok(
+      fs.existsSync(path.join(resolvedRoot, 'workflows', 'work')),
+      `expected resolved root ${resolvedRoot} to contain workflows/work`
+    );
   });
 });

--- a/plugins/work/scripts/workflows/lib/__tests__/resolve-plugin-root-hook.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/resolve-plugin-root-hook.test.js
@@ -13,7 +13,6 @@ const fs = require('fs');
 const os = require('os');
 
 const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'resolve-plugin-root-hook.js');
-const FAKE_ROOT = '/fake/plugin/root';
 
 // Track temp dirs for cleanup
 const TEMP_DIRS = [];
@@ -33,6 +32,11 @@ function makeFixtureLeafPlugin() {
   fs.mkdirSync(path.join(leaf, 'workflows', 'work'), { recursive: true });
   return leaf;
 }
+// Shared real-leaf fixture used as the default CLAUDE_PLUGIN_ROOT for tests
+// that don't override it. resolvePluginRoot() requires the env path to actually
+// contain workflows/work, so a real directory is needed in place of a fake path.
+const DEFAULT_ROOT = makeFixtureLeafPlugin();
+
 after(() => {
   for (const d of TEMP_DIRS) {
     try {
@@ -45,7 +49,7 @@ function runHook(input, env = {}) {
   return new Promise((resolve, reject) => {
     const proc = spawn('node', [HOOK_PATH], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, CLAUDE_PLUGIN_ROOT: FAKE_ROOT, ...env },
+      env: { ...process.env, CLAUDE_PLUGIN_ROOT: DEFAULT_ROOT, ...env },
     });
     let stdout = '';
     let stderr = '';
@@ -70,8 +74,8 @@ describe('resolve-plugin-root-hook', () => {
       tool_input: { command: 'node ${CLAUDE_PLUGIN_ROOT}/hooks/work-orchestrator.js test' },
     });
     assert.strictEqual(code, 2);
-    assert.ok(stderr.includes(FAKE_ROOT));
-    assert.ok(stderr.includes(`node ${FAKE_ROOT}/hooks/work-orchestrator.js test`));
+    assert.ok(stderr.includes(DEFAULT_ROOT));
+    assert.ok(stderr.includes(`node ${DEFAULT_ROOT}/hooks/work-orchestrator.js test`));
   });
 
   it('should BLOCK when command contains $CLAUDE_PLUGIN_ROOT (no braces)', async () => {
@@ -79,7 +83,7 @@ describe('resolve-plugin-root-hook', () => {
       tool_input: { command: 'node $CLAUDE_PLUGIN_ROOT/hooks/test.js' },
     });
     assert.strictEqual(code, 2);
-    assert.ok(stderr.includes(`node ${FAKE_ROOT}/hooks/test.js`));
+    assert.ok(stderr.includes(`node ${DEFAULT_ROOT}/hooks/test.js`));
   });
 
   it('command without CLAUDE_PLUGIN_ROOT is allowed through unchanged', async () => {
@@ -107,7 +111,7 @@ describe('resolve-plugin-root-hook', () => {
     });
     assert.strictEqual(code, 2);
     assert.ok(
-      stderr.includes(`node ${FAKE_ROOT}/lib/engine.js && node ${FAKE_ROOT}/hooks/test.js`)
+      stderr.includes(`node ${DEFAULT_ROOT}/lib/engine.js && node ${DEFAULT_ROOT}/hooks/test.js`)
     );
   });
 

--- a/plugins/work/scripts/workflows/lib/hooks/resolve-plugin-root-hook.js
+++ b/plugins/work/scripts/workflows/lib/hooks/resolve-plugin-root-hook.js
@@ -14,6 +14,7 @@
 
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', 'hook-error-log'));
+const { resolvePluginRoot } = require('../../work/lib/resolve-plugin-root');
 
 // Fail-open: unexpected errors should never block unrelated commands
 process.on('uncaughtException', (err) => {
@@ -25,7 +26,23 @@ process.on('unhandledRejection', (err) => {
   process.exit(0);
 });
 
-const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..', '..', '..');
+function computePluginRoot() {
+  const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  // Probe env var (handles leaf-dir OR parent plugins-base) and __dirname fallback
+  const probed = resolvePluginRoot(__dirname, 3);
+  if (probed) {
+    // If env var is set, prefer probed result only when it derives from the env var.
+    // When env var is set but doesn't probe (e.g., points to a non-existent dir),
+    // honour it verbatim for backwards compatibility.
+    if (envRoot && !probed.startsWith(envRoot)) {
+      return envRoot;
+    }
+    return probed;
+  }
+  if (envRoot) return envRoot;
+  return path.resolve(__dirname, '..', '..', '..');
+}
+const PLUGIN_ROOT = computePluginRoot();
 
 async function main() {
   let input = ''; // read hook JSON from stdin

--- a/plugins/work/scripts/workflows/lib/hooks/resolve-plugin-root-hook.js
+++ b/plugins/work/scripts/workflows/lib/hooks/resolve-plugin-root-hook.js
@@ -27,7 +27,9 @@ process.on('unhandledRejection', (err) => {
 });
 
 function computePluginRoot() {
-  const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  const rawEnvRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  // Normalize to strip trailing slashes so the boundary check is reliable
+  const envRoot = rawEnvRoot ? path.resolve(rawEnvRoot) : '';
   // Probe env var (handles leaf-dir OR parent plugins-base) and __dirname fallback
   const probed = resolvePluginRoot(__dirname, 3);
   if (probed) {

--- a/plugins/work/scripts/workflows/lib/hooks/resolve-plugin-root-hook.js
+++ b/plugins/work/scripts/workflows/lib/hooks/resolve-plugin-root-hook.js
@@ -26,25 +26,17 @@ process.on('unhandledRejection', (err) => {
   process.exit(0);
 });
 
-function computePluginRoot() {
-  const rawEnvRoot = process.env.CLAUDE_PLUGIN_ROOT;
-  // Normalize to strip trailing slashes so the boundary check is reliable
-  const envRoot = rawEnvRoot ? path.resolve(rawEnvRoot) : '';
-  // Probe env var (handles leaf-dir OR parent plugins-base) and __dirname fallback
-  const probed = resolvePluginRoot(__dirname, 3);
-  if (probed) {
-    // If env var is set, prefer probed result only when it derives from the env var.
-    // When env var is set but doesn't probe (e.g., points to a non-existent dir),
-    // honour it verbatim for backwards compatibility.
-    if (envRoot && probed !== envRoot && !probed.startsWith(envRoot + path.sep)) {
-      return envRoot;
-    }
-    return probed;
-  }
-  if (envRoot) return envRoot;
-  return path.resolve(__dirname, '..', '..', '..');
-}
-const PLUGIN_ROOT = computePluginRoot();
+// Honour CLAUDE_PLUGIN_ROOT verbatim when set: if the env path doesn't match
+// the on-disk leaf/parent layout, resolvePluginRoot silently falls back to a
+// callerDir probe that has nothing to do with what the user set. For the
+// command-substitution use case, prefer the env value over an unrelated probe.
+const envRoot =
+  process.env.CLAUDE_PLUGIN_ROOT && path.resolve(process.env.CLAUDE_PLUGIN_ROOT);
+const probed = resolvePluginRoot(__dirname, 3);
+const PLUGIN_ROOT =
+  envRoot && probed && !probed.startsWith(envRoot)
+    ? envRoot
+    : probed || envRoot || path.resolve(__dirname, '..', '..', '..');
 
 async function main() {
   let input = ''; // read hook JSON from stdin

--- a/plugins/work/scripts/workflows/lib/hooks/resolve-plugin-root-hook.js
+++ b/plugins/work/scripts/workflows/lib/hooks/resolve-plugin-root-hook.js
@@ -34,7 +34,7 @@ function computePluginRoot() {
     // If env var is set, prefer probed result only when it derives from the env var.
     // When env var is set but doesn't probe (e.g., points to a non-existent dir),
     // honour it verbatim for backwards compatibility.
-    if (envRoot && !probed.startsWith(envRoot)) {
+    if (envRoot && probed !== envRoot && !probed.startsWith(envRoot + path.sep)) {
       return envRoot;
     }
     return probed;


### PR DESCRIPTION
## Existing Behavior

- `resolve-plugin-root-hook.js` read `CLAUDE_PLUGIN_ROOT` verbatim and used it as the plugin root without any validation.
- When `.envrc` exported `CLAUDE_PLUGIN_ROOT` pointing at the parent plugins-base directory, the hook rewrote commands to paths that did not exist in the actual leaf marketplace plugin directory.
- No path-probing logic existed; the hook could not distinguish between a parent plugins-base dir and a correct leaf plugin dir.
- Two test names did not clearly describe their intent, and no tests covered the parent-dir vs leaf-dir distinction.

## Intended New Behavior

- `computePluginRoot()` in `resolve-plugin-root-hook.js` now delegates to `resolvePluginRoot(__dirname, 3)` to probe directory structure, correctly resolving both a parent plugins-base env var (walks down to `marketplaces/work-workflow`) and a leaf plugin dir env var (used as-is).
- When `CLAUDE_PLUGIN_ROOT` is unset or empty, the hook falls back to `__dirname`-based probing, landing on the actual plugin dir containing `workflows/work`.
- When the env var is set but probing yields a path that does not derive from it (non-existent dir edge-case), the env var is honoured verbatim for backwards compatibility.
- Three new test cases cover: parent plugins-base env var resolves to marketplace subdir, leaf plugin dir env var honoured as-is, and unset env var triggers `__dirname` fallback that produces a path containing `workflows/work`.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Hook change — verify end-to-end resolution:**

1. Set `CLAUDE_PLUGIN_ROOT` to the plugins-base parent directory and pipe a JSON command that references the plugin root env var into the hook. Confirm the rewritten path in stderr points at the marketplace subdir (`marketplaces/work-workflow`), not the bare parent.

2. Set `CLAUDE_PLUGIN_ROOT` to a leaf plugin dir (one that directly contains `workflows/work`). Confirm the hook uses the path verbatim.

3. Unset `CLAUDE_PLUGIN_ROOT` entirely. Confirm the hook resolves via `__dirname` probing to a path that contains `workflows/work`.

4. Run the test file directly:
   ```bash
   node --test plugins/work/scripts/workflows/lib/__tests__/resolve-plugin-root-hook.test.js
   ```
   All 16 tests should pass.

Closes #284

### Test Results

16/16 tests passing (confirmed locally before PR creation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized PreToolUse Bash hook path resolution with unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> The PreToolUse Bash hook that rewrites unresolved `${CLAUDE_PLUGIN_ROOT}` in commands now derives the plugin root via **`resolvePluginRoot`** instead of using the env var or a fixed `__dirname` hop blindly.
> 
> When **`CLAUDE_PLUGIN_ROOT`** points at a **parent plugins-base** directory, rewrites target the **`marketplaces/work-workflow`** leaf (paths that actually contain `workflows/work`). A **leaf** env path is used as-is. If probing would ignore a set env path (e.g. missing layout), the hook still **honours the env value** for backward compatibility. Tests use **real temp directory fixtures**, clean them up after the suite, and add coverage for parent vs leaf vs empty env fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6adb76391026997791c8941fa46f5f2be185ffe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->