### PR TITLE
feat(maestro): pr-status detector + CI-gate slot rotation + heartbeat

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
-    "version": "3.15.0"
+    "version": "3.16.0"
   },
   "plugins": [
     {
@@ -14,54 +14,28 @@
       "source": "./plugins/work",
       "description": "Orchestrated /work command with pre-computed action plans",
       "category": "workflow",
-      "tags": [
-        "workflow",
-        "jira",
-        "orchestrator",
-        "state-machine",
-        "automation"
-      ]
+      "tags": ["workflow", "jira", "orchestrator", "state-machine", "automation"]
     },
     {
       "name": "synapsys",
       "source": "./plugins/synapsys",
       "description": "Context-triggered memory injection — memories declare event hooks + trigger patterns and are injected when matched",
       "category": "memory",
-      "tags": [
-        "memory",
-        "hooks",
-        "injection",
-        "context",
-        "recall"
-      ]
+      "tags": ["memory", "hooks", "injection", "context", "recall"]
     },
     {
       "name": "maestro",
       "source": "./plugins/maestro",
       "description": "Multi-agent orchestrator — bootstraps per-ticket tmux sessions, conducts them (silence detection + auto-restart), and surfaces real prompts to the operator",
       "category": "orchestration",
-      "tags": [
-        "orchestrate",
-        "conduct",
-        "agents",
-        "tmux",
-        "workflow",
-        "multi-agent"
-      ]
+      "tags": ["orchestrate", "conduct", "agents", "tmux", "workflow", "multi-agent"]
     },
     {
       "name": "heimdall",
       "source": "./plugins/heimdall",
       "description": "Config-driven file/directory guard — lock blocks pair protected paths with an unlock phrase; a PreToolUse hook blocks Edit/Write/Bash/Task mutations unless the phrase is spoken",
       "category": "safety",
-      "tags": [
-        "guard",
-        "protection",
-        "hooks",
-        "pretooluse",
-        "lock",
-        "safety"
-      ]
+      "tags": ["guard", "protection", "hooks", "pretooluse", "lock", "safety"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Deterministic workflow orchestrator for Jira task implementation with state machine validation.",
   "license": "MIT",
   "repository": {

--- a/plugins/heimdall/.claude-plugin/plugin.json
+++ b/plugins/heimdall/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "heimdall",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Config-driven file/directory guard. Lock blocks declare protected paths + an unlock phrase; a PreToolUse hook blocks Edit/Write/Bash/Task mutations to those paths unless the user speaks the phrase. Stores are local, worktree, or global like synapsys.",
   "author": {
     "name": "Custom",

--- a/plugins/maestro/.claude-plugin/plugin.json
+++ b/plugins/maestro/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Multi-agent orchestrator. Bootstraps per-ticket tmux sessions in isolated worktrees, conducts them (auto-restart on silence, surface real prompts to the operator), and exposes a file-mailbox signal channel.",
   "author": {
     "name": "Custom",

--- a/plugins/maestro/docs/OPERATOR_PLAYBOOK.md
+++ b/plugins/maestro/docs/OPERATOR_PLAYBOOK.md
@@ -1,0 +1,68 @@
+# maestro operator playbook
+
+You are operating the maestro daemon (`scripts/maestro-conduct.js --daemon`)
+across one or more `/work` agents. The daemon does NOT make decisions for you —
+it surfaces signals and you act on them. This doc is the contract for how to
+read those signals.
+
+## The daemon's event vocabulary
+
+The daemon emits exactly these signals to its sinks (`/tmp/maestro-conduct.log`,
+`/tmp/maestro-alerts.jsonl`, and the `maestro-alerts` tmux session).
+**Subscribe to all of them.** See `skills/orchestrate/SKILL.md` for the
+canonical Monitor regex.
+
+| Signal | Meaning | Operator action |
+|---|---|---|
+| `QUESTION-DETECTED` | An agent has a menu or permission prompt sitting unanswered | Capture the agent pane, read every menu option, pick the one that is not a bypass |
+| `MAESTRO-ALERT … kind=pr-ready` | All CI checks SUCCESS and `mergeStateStatus=CLEAN` | Run the bypass checker (`work-workflow:code-checker` against the diff) before merging. On APPROVED, the PR is yours to merge or hand to your operator |
+| `MAESTRO-ALERT … kind=pr-broken` | A check is failing or merge state is DIRTY | Identify the failing checks, drive the originating agent to fix in this PR (do not defer to a follow-up) |
+| `MAESTRO-ALERT … kind=wedged` | A session has been auto-restarted ≥3 times in 30m — daemon will not restart it for the next 60m | Inspect the pane manually. Diagnose why /work keeps dying |
+| `MAESTRO-ALERT … kind=nudges-exhausted` | A phase exceeded its budget past `maxNudges` | Surface to operator — the agent may be genuinely stuck |
+| `MAESTRO-ALERT … kind=pr-comments-stuck` | Unaddressed bot review comments on the agent's PR with no new HEAD | Direct the agent to address them in this PR |
+| `MAESTRO-ALERT … kind=question-pending` | Question sat ≥`Q_WAIT_MIN` minutes | Same as QUESTION-DETECTED — pick the legitimate option |
+| `commit-stall NNNm (threshold=TTTm)` | Worktree had no new commits across one of the thresholds (`30/60/120/240/480` by default) | If agent is in `implement` and threshold escalated → capture pane. If agent is in `wait_merge`/`complete` → ignore, expected |
+| `NUDGE soft` / `NUDGE interrupt` | Daemon already poked the agent's pane | No operator action — daemon handles escalation |
+| `AUTO-RESTART after Ns silence` | Daemon relaunched a dead `-work` session | Only act if a `wedged` alert follows |
+| `AUTO-RESTART skipped: non-work helper` | Throttled log when an idle `-listen` or `-dev` pane was checked | Ignore — informational |
+| `HEARTBEAT N active, X pr-ready, Y pr-broken, Z pr-pending, W wedged \| <per-ticket>` | Periodic summary, default every 30m | **Re-read it.** This is the forced re-check that exists because operators desensitize to noisy ticks. If `X >= 1` and you have not yet surfaced those PRs, do it now |
+
+## Anti-patterns that cause operators to fail
+
+1. **Reading the line shape, not the value.** `commit-stall 30m → 60m → 120m → 240m → 480m` looks the same; the number is the signal. Always read the number.
+2. **Treating silence as "nothing to do."** A silent agent is either (a) shipped and waiting for merge or (b) wedged. The daemon emits `pr-ready` for (a). If you see no `pr-ready`, no `nudges-exhausted`, and no `QUESTION-DETECTED`, but an agent has been silent — poll `gh pr list --state open` for the ticket's branch. Verify positively; don't assume.
+3. **Approving the menu option the agent labelled "Recommended"** without reading the others. The agent's recommendation does not override the no-bypass rules. Read every option; pick the legitimate one even if the agent flagged it as higher-risk.
+4. **Editing files in the agent's worktree.** Communicate via `tmux send-keys` to the `-work` pane, or via the `/tmp/claude-agent-inbox/<TICKET>.log` mailbox if your agent listens there.
+5. **Re-running CI to "see if it goes green this time."** Diagnose the failure; fix the root cause.
+
+## The pr-ready playbook (every time)
+
+When `MAESTRO-ALERT kind=pr-ready` lands:
+
+1. Spawn the bypass-checker against the diff. The check must answer ONE question: is this PR trying to bypass any /work workflow gate (TDD evidence, completion check, set-step CLI, fake state files, commit-hook skipping, transition-through bypass)?
+2. Watch the checker's verdict (`APPROVED` / `NEEDS-WORK`).
+3. **APPROVED:** surface the PR URL to the human operator. **Never call `gh pr merge`** — the operator merges.
+4. **NEEDS-WORK:** capture the checker's verbatim findings and forward them to the originating `/work` agent via `tmux send-keys -t <TICKET>-work`. Re-run the checker after the agent pushes again.
+
+Every new commit on the PR head needs a fresh check. Do not approve once and assume the next force-push is still clean.
+
+## The question playbook (every time)
+
+When `QUESTION-DETECTED` lands:
+
+1. `tmux capture-pane -t <TICKET>-work -p | tail -40` — read the full menu, not just the alert summary.
+2. Research before answering — check repository docs, skill `SKILL.md` files, and the codebase for the symbol in question. Do not answer from memory.
+3. Pick the option that does NOT bypass any workflow gate.
+4. If all menu options bypass, send the agent a directive via "Type something" pointing at the legitimate path (rewind via /work, cache hot-patch + file a bug, ship-as-is with rationale, etc.).
+
+## Slot rotation
+
+When an agent's PR is in `pr-ready` AND the bypass checker has APPROVED it, that agent's slot is effectively free — it sits in `wait_merge` doing nothing while it waits for human merge. You may bootstrap another ticket into a new slot at that point. Do not kill the existing tmux session; let it persist so the agent can pick up review comments after the operator merges (or doesn't).
+
+## When you're unsure
+
+Ask the operator. Do not invent state. Do not edit `.work-state.json` directly. Do not call `work-state.js set-step`. Those are bypass attempts and the next bypass-check will catch them.
+
+## Tuning
+
+All thresholds are env-tunable — see `skills/orchestrate/SKILL.md` for the full table. The defaults are conservative; loosen them in CI / dev shells and tighten them in long-running sessions.

--- a/plugins/maestro/hooks/active-session-reminder.js
+++ b/plugins/maestro/hooks/active-session-reminder.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * active-session-reminder.js — UserPromptSubmit / SessionStart hook.
+ *
+ * If a maestro orchestration session is active (a manifest exists under
+ * MAESTRO_SESSION_DIR), inject a reminder block so the operator (or a fresh
+ * conversation) doesn't:
+ *   - accidentally start a second parallel orchestration
+ *   - forget the priority + dependency plan
+ *   - lose track of which tasks are in flight vs done vs pending
+ *
+ * Install (user must add to ~/.claude/settings.json — plugin can't auto-install):
+ *
+ *   "UserPromptSubmit": [{
+ *     "matcher": ".*",
+ *     "hooks": [{
+ *       "type": "command",
+ *       "command": "node /path/to/plugins/maestro/hooks/active-session-reminder.js"
+ *     }]
+ *   }]
+ *
+ * Fail-open: any error → exit 0 silently. Never block the prompt.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SESSION_DIR =
+  process.env.MAESTRO_SESSION_DIR || path.join(os.homedir(), '.cache', 'maestro', 'sessions');
+
+try {
+  if (!fs.existsSync(SESSION_DIR)) process.exit(0);
+  const files = fs.readdirSync(SESSION_DIR).filter((f) => f.endsWith('.json'));
+  if (!files.length) process.exit(0);
+
+  const lines = [
+    '[maestro] ACTIVE ORCHESTRATION SESSION(S) — do not start a parallel orchestration without checking these first:',
+  ];
+  for (const f of files) {
+    let s;
+    try {
+      s = JSON.parse(fs.readFileSync(path.join(SESSION_DIR, f), 'utf8'));
+    } catch {
+      continue;
+    }
+    const counts = { pending: 0, in_progress: 0, done: 0, blocked: 0 };
+    for (const t of s.tasks) counts[t.status] = (counts[t.status] || 0) + 1;
+    lines.push(
+      `  • ${s.topic} — slots=${s.slots} | ` +
+        `${counts.in_progress} in flight, ${counts.done}/${s.tasks.length} done, ${counts.pending} pending` +
+        (counts.blocked ? `, ${counts.blocked} blocked` : '')
+    );
+    // Show the next 3 eligible tasks (deps resolved, sorted by priority).
+    const doneIds = new Set(s.tasks.filter((t) => t.status === 'done').map((t) => t.id));
+    const eligible = s.tasks
+      .filter((t) => t.status === 'pending')
+      .filter((t) => (t.deps || []).every((d) => doneIds.has(d)))
+      .sort((a, b) => a.priority - b.priority)
+      .slice(0, 3);
+    if (eligible.length) {
+      lines.push(
+        `    next eligible: ${eligible
+          .map(
+            (t) =>
+              `${t.id}#p${t.priority}${(t.deps || []).length ? `[deps:${t.deps.join(',')}✓]` : ''}`
+          )
+          .join(', ')}`
+      );
+    }
+    const blockedByDeps = s.tasks
+      .filter((t) => t.status === 'pending')
+      .filter((t) => (t.deps || []).some((d) => !doneIds.has(d)));
+    if (blockedByDeps.length) {
+      lines.push(
+        `    waiting on deps: ${blockedByDeps
+          .slice(0, 3)
+          .map((t) => `${t.id}(needs: ${(t.deps || []).filter((d) => !doneIds.has(d)).join(',')})`)
+          .join(', ')}`
+      );
+    }
+  }
+  lines.push(
+    '  CLI: node plugins/maestro/scripts/maestro-session.js {summary|show <topic>|next <topic>|update <topic> <task> <status>|clear <topic>}'
+  );
+
+  process.stdout.write(lines.join('\n') + '\n');
+} catch {
+  /* fail-open */
+}

--- a/plugins/maestro/scripts/__tests__/actions-free-ci-gate-slot.test.js
+++ b/plugins/maestro/scripts/__tests__/actions-free-ci-gate-slot.test.js
@@ -1,0 +1,108 @@
+// freeCIGateSlot: kill -work + -listen panes when PR is at CI gate, emit
+// kind=slot-freed alert. Idempotent per SHA. Disabled by AUTO_FREE_CI_SLOT=0.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const ACTIONS_PATH = path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'actions');
+
+function freshActions({ stateDir, alertFile, tmuxStub, env = {} }) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  process.env.ALERT_FILE = alertFile;
+  process.env.LOG_FILE = path.join(stateDir, '.log');
+  delete process.env.AUTO_FREE_CI_SLOT;
+  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+  const cp = require('child_process');
+  cp.spawnSync = (cmd, args) => {
+    if (cmd === 'tmux') {
+      tmuxStub.push({ cmd, args });
+      return { status: 0, stdout: '' };
+    }
+    return { status: 0, stdout: '' };
+  };
+  return require(ACTIONS_PATH);
+}
+
+test('freeCIGateSlot kills -work + -listen and emits slot-freed alert', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcg-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  const result = actions.freeCIGateSlot({
+    session: 'GH-9-listen',
+    ticket: 'GH-9',
+    prNumber: 999,
+    sha: 'abc123',
+  });
+
+  assert.equal(result, true);
+  const killed = tmuxStub.filter((c) => c.args[0] === 'kill-session').map((c) => c.args[2]);
+  assert.deepEqual(killed.sort(), ['GH-9-listen', 'GH-9-work']);
+
+  const lines = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
+  const slotFreed = lines.map(JSON.parse).filter((a) => a.kind === 'slot-freed');
+  assert.equal(slotFreed.length, 1);
+  assert.equal(slotFreed[0].prNumber, 999);
+  assert.equal(slotFreed[0].sha, 'abc123');
+});
+
+test('freeCIGateSlot is idempotent on the same SHA', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcg-idem-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  const args = { session: 'GH-10-listen', ticket: 'GH-10', prNumber: 10, sha: 'same' };
+  assert.equal(actions.freeCIGateSlot(args), true);
+  assert.equal(actions.freeCIGateSlot(args), false, 'second call same SHA must no-op');
+  assert.equal(actions.freeCIGateSlot(args), false);
+
+  // Only one slot-freed alert despite three calls.
+  const lines = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
+  const slotFreed = lines.map(JSON.parse).filter((a) => a.kind === 'slot-freed');
+  assert.equal(slotFreed.length, 1);
+
+  // Only one kill-session pair (2 args entries: work + listen) despite 3 calls.
+  const killed = tmuxStub.filter((c) => c.args[0] === 'kill-session');
+  assert.equal(killed.length, 2);
+});
+
+test('freeCIGateSlot re-fires when SHA changes (operator pushed a new commit)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcg-sha-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  assert.equal(
+    actions.freeCIGateSlot({ session: 's', ticket: 't', prNumber: 1, sha: 'aaa' }),
+    true
+  );
+  assert.equal(
+    actions.freeCIGateSlot({ session: 's', ticket: 't', prNumber: 1, sha: 'bbb' }),
+    true
+  );
+  const lines = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
+  const slotFreed = lines.map(JSON.parse).filter((a) => a.kind === 'slot-freed');
+  assert.equal(slotFreed.length, 2);
+});
+
+test('AUTO_FREE_CI_SLOT=0 disables the action entirely', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcg-off-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub, env: { AUTO_FREE_CI_SLOT: '0' } });
+
+  const result = actions.freeCIGateSlot({ session: 's', ticket: 't', prNumber: 1, sha: 'x' });
+  assert.equal(result, false);
+  assert.equal(tmuxStub.length, 0, 'no tmux kill when disabled');
+  assert.equal(fs.existsSync(alertFile), false, 'no alert when disabled');
+});

--- a/plugins/maestro/scripts/__tests__/alerts-escalation.test.js
+++ b/plugins/maestro/scripts/__tests__/alerts-escalation.test.js
@@ -1,0 +1,106 @@
+// alerts.alert() returns {count} reflecting how many times the same
+// (session, kind, sha-or-phase) has been emitted. Used by maestro-conduct.js
+// to escalate to freeDeadEndSlot when the same alert re-fires too often.
+// Also: alerts without an `instruction` field are dropped (log-only).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const ALERTS_PATH = path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'alerts');
+
+function freshAlerts(stateDir, alertFile) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  process.env.ALERT_FILE = alertFile;
+  process.env.LOG_FILE = path.join(stateDir, '.log');
+  // Stub tmux so we don't hit the real binary.
+  const cp = require('child_process');
+  cp.spawnSync = () => ({ status: 0, stdout: '' });
+  // Stub tmux.ensureSession via the module the alerts depends on. Easiest:
+  // monkey-patch after require by also stubbing the tmux module's exports.
+  const tmuxPath = require.resolve(path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'tmux'));
+  require.cache[tmuxPath] = {
+    id: tmuxPath,
+    filename: tmuxPath,
+    loaded: true,
+    exports: { ensureSession: () => {}, sendLine: () => {} },
+  };
+  return require(ALERTS_PATH);
+}
+
+test('alert without instruction is dropped (no alert-file write)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'al-drop-'));
+  const file = path.join(dir, 'alerts.jsonl');
+  const alerts = freshAlerts(dir, file);
+  const r = alerts.alert({ session: 's', ticket: 't', kind: 'wedged' });
+  assert.equal(r.count, 0);
+  assert.equal(fs.existsSync(file), false, 'no alert file when instruction missing');
+});
+
+test('alert with instruction writes to alert file and returns count=1', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'al-1-'));
+  const file = path.join(dir, 'alerts.jsonl');
+  const alerts = freshAlerts(dir, file);
+  const r = alerts.alert({
+    session: 's',
+    ticket: 't',
+    kind: 'question-pending',
+    sha: 'abc',
+    instruction: 'capture pane and pick legitimate option',
+  });
+  assert.equal(r.count, 1);
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+  assert.equal(lines.length, 1);
+  const payload = JSON.parse(lines[0]);
+  assert.equal(payload.repeatCount, 1);
+  assert.equal(payload.instruction, 'capture pane and pick legitimate option');
+});
+
+test('repeated alert on same (session,kind,sha) increments count + prefixes instruction with [REPEAT N]', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'al-rep-'));
+  const file = path.join(dir, 'alerts.jsonl');
+  const alerts = freshAlerts(dir, file);
+  const args = {
+    session: 's',
+    ticket: 't',
+    kind: 'question-pending',
+    sha: 'aaa',
+    instruction: 'do the thing',
+  };
+  assert.equal(alerts.alert(args).count, 1);
+  assert.equal(alerts.alert(args).count, 2);
+  assert.equal(alerts.alert(args).count, 3);
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.equal(lines.length, 3);
+  assert.equal(lines[0].instruction, 'do the thing');
+  assert.equal(lines[1].instruction, '[REPEAT 2] do the thing');
+  assert.equal(lines[2].instruction, '[REPEAT 3] do the thing');
+});
+
+test('different SHA resets the count (new state, fresh emit)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'al-sha-'));
+  const file = path.join(dir, 'alerts.jsonl');
+  const alerts = freshAlerts(dir, file);
+  const base = { session: 's', ticket: 't', kind: 'pr-broken', instruction: 'fix CI' };
+  assert.equal(alerts.alert({ ...base, sha: 'aaa' }).count, 1);
+  assert.equal(alerts.alert({ ...base, sha: 'aaa' }).count, 2);
+  assert.equal(alerts.alert({ ...base, sha: 'bbb' }).count, 1, 'new SHA must start fresh');
+});
+
+test('resetCount clears a specific (session,kind,sha) key', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'al-reset-'));
+  const file = path.join(dir, 'alerts.jsonl');
+  const alerts = freshAlerts(dir, file);
+  const args = { session: 's', ticket: 't', kind: 'wedged', sha: 'x', instruction: 'inspect' };
+  alerts.alert(args);
+  alerts.alert(args);
+  alerts.resetCount(alerts.alertKey(args));
+  assert.equal(alerts.alert(args).count, 1, 'count starts at 1 after reset');
+});

--- a/plugins/maestro/scripts/__tests__/detectors-commit-stall-dedup.test.js
+++ b/plugins/maestro/scripts/__tests__/detectors-commit-stall-dedup.test.js
@@ -1,0 +1,120 @@
+// commit-stall dedup contract: emit only on threshold crossings, not every tick.
+//
+// Drive `detect()` across many simulated "minutes since last commit" values
+// and assert the detector hits exactly once per crossing of
+// `[30, 60, 120, 240, 480]`. Without dedup it would hit ~480 times for an
+// 8-hour stall — the very behaviour that desensitized the orchestrator and
+// prompted this change.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const DETECTOR_PATH = path.resolve(
+  __dirname,
+  '..',
+  'lib',
+  'maestro-conduct',
+  'detectors',
+  'commit-stall'
+);
+
+function freshDetector(stateDir, spawnSyncFake) {
+  // Wipe the entire maestro-conduct require subtree so STATE_DIR rebinds
+  // when the module re-requires state.js.
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  // Patch BEFORE requiring the detector so its `const { spawnSync } = require('child_process')`
+  // captures the fake instead of the real binding.
+  if (spawnSyncFake) {
+    const cp = require('child_process');
+    cp.spawnSync = spawnSyncFake;
+  }
+  return require(DETECTOR_PATH);
+}
+
+function makeMinutesController() {
+  const cp = require('child_process');
+  const original = cp.spawnSync;
+  const ctl = { mins: 0 };
+  ctl.spawnSync = (cmd, args, opts) => {
+    if (cmd === 'git' && Array.isArray(args) && args.includes('log')) {
+      const ct = Math.floor(Date.now() / 1000) - ctl.mins * 60;
+      return { status: 0, stdout: `${ct}\n` };
+    }
+    return original(cmd, args, opts);
+  };
+  ctl.restore = () => {
+    cp.spawnSync = original;
+  };
+  return ctl;
+}
+
+test('thresholdFor returns the highest crossed threshold (or 0 below the floor)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-th-'));
+  const { thresholdFor } = freshDetector(stateDir);
+  assert.equal(thresholdFor(0), 0);
+  assert.equal(thresholdFor(29), 0);
+  assert.equal(thresholdFor(30), 30);
+  assert.equal(thresholdFor(59), 30);
+  assert.equal(thresholdFor(60), 60);
+  assert.equal(thresholdFor(119), 60);
+  assert.equal(thresholdFor(120), 120);
+  assert.equal(thresholdFor(240), 240);
+  assert.equal(thresholdFor(480), 480);
+  assert.equal(thresholdFor(9999), 480);
+});
+
+test('detect hits exactly once per threshold crossing across 500 simulated minutes', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-cross-'));
+  const ctl = makeMinutesController();
+  const detector = freshDetector(stateDir, ctl.spawnSync);
+  try {
+    let hits = 0;
+    const observedThresholds = [];
+    // Tick every "minute" from 0..500. With dedup, expect exactly 5 hits
+    // (at 30/60/120/240/480). Without dedup we'd get ~471 hits.
+    for (let m = 0; m <= 500; m++) {
+      ctl.mins = m;
+      const r = detector.detect({ ticket: 'GH-DEDUP', worktree: '/tmp' });
+      if (r.hit) {
+        hits++;
+        observedThresholds.push(r.threshold);
+      }
+    }
+    assert.equal(hits, 5, `expected 5 threshold crossings over 500 minutes, got ${hits}`);
+    assert.deepStrictEqual(observedThresholds, [30, 60, 120, 240, 480]);
+  } finally {
+    ctl.restore();
+  }
+});
+
+test('recovery (mins back below floor) clears marker so next stall re-emits', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-recov-'));
+  const ctl = makeMinutesController();
+  const detector = freshDetector(stateDir, ctl.spawnSync);
+  try {
+    // First stall climbs to 60m and back to 0 (commit landed).
+    ctl.mins = 30;
+    assert.equal(detector.detect({ ticket: 'GH-RECOV', worktree: '/tmp' }).hit, true);
+    ctl.mins = 60;
+    assert.equal(detector.detect({ ticket: 'GH-RECOV', worktree: '/tmp' }).hit, true);
+    ctl.mins = 5; // commit landed; below floor
+    assert.equal(detector.detect({ ticket: 'GH-RECOV', worktree: '/tmp' }).hit, false);
+
+    // Second stall climbs back to 30m — the FIRST stall already announced 30m
+    // BUT recovery cleared the marker, so we re-emit on the next 30m crossing.
+    ctl.mins = 30;
+    const r = detector.detect({ ticket: 'GH-RECOV', worktree: '/tmp' });
+    assert.equal(r.hit, true, 'must re-emit at 30m after recovery cleared the marker');
+    assert.equal(r.threshold, 30);
+  } finally {
+    ctl.restore();
+  }
+});

--- a/plugins/maestro/scripts/__tests__/detectors-pr-status.test.js
+++ b/plugins/maestro/scripts/__tests__/detectors-pr-status.test.js
@@ -1,0 +1,188 @@
+// pr-status detector: emit pr-ready / pr-broken / pr-pending on transitions.
+//
+// The detector calls `gh pr list` + `gh pr view --json` and inspects the
+// statusCheckRollup + mergeStateStatus. We mock spawnSync to return shaped
+// gh-output JSON, then assert the classification and dedup behavior.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const DETECTOR_PATH = path.resolve(
+  __dirname,
+  '..',
+  'lib',
+  'maestro-conduct',
+  'detectors',
+  'pr-status'
+);
+
+function freshDetector(stateDir, ghResponses) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  process.env.PR_STATUS_RE_EMIT_MIN = '30';
+  process.env.GITHUB_REPO = 'thomfilg/claude-plugin-work';
+  // Patch spawnSync BEFORE requiring the detector so its captured reference
+  // points at the fake.
+  const cp = require('child_process');
+  cp.spawnSync = (cmd, args) => {
+    if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+      return { status: 0, stdout: ghResponses.list || '[]' };
+    }
+    if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view') {
+      return { status: 0, stdout: ghResponses.view || '{}' };
+    }
+    if (cmd === 'git') return { status: 0, stdout: '' };
+    return { status: 0, stdout: '' };
+  };
+  return require(DETECTOR_PATH);
+}
+
+function viewJson({ sha, checks, merge }) {
+  return JSON.stringify({
+    headRefOid: sha,
+    statusCheckRollup: checks,
+    mergeStateStatus: merge,
+  });
+}
+
+test('classify maps the (checks, mergeable) tuple to event kind', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-classify-'));
+  const { classify } = freshDetector(stateDir, {});
+  assert.equal(classify('SUCCESS', 'CLEAN'), 'pr-ready');
+  assert.equal(classify('SUCCESS', 'UNSTABLE'), null); // SUCCESS but not CLEAN → silent
+  assert.equal(classify('FAILURE', 'CLEAN'), 'pr-broken');
+  assert.equal(classify('FAILURE', 'DIRTY'), 'pr-broken');
+  assert.equal(classify('SUCCESS', 'DIRTY'), 'pr-broken'); // merge conflict counts as broken
+  assert.equal(classify('PENDING', 'CLEAN'), 'pr-pending');
+  assert.equal(classify('UNKNOWN', 'BLOCKED'), null); // no signal
+});
+
+test('all-SUCCESS + CLEAN emits pr-ready once, then dedups on same SHA', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-ready-'));
+  const detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 488 }]),
+    view: viewJson({
+      sha: 'abc123def',
+      checks: [
+        { name: 'Test (Node 20)', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        { name: 'CodeQL', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        { name: 'Quality', conclusion: 'SUCCESS', status: 'COMPLETED' },
+      ],
+      merge: 'CLEAN',
+    }),
+  });
+
+  // First call: state transition (no marker) → hits.
+  const r1 = detector.detect({ ticket: 'GH-400', worktree: '/tmp' });
+  assert.equal(r1.hit, true);
+  assert.equal(r1.kind, 'pr-ready');
+  assert.equal(r1.prNumber, 488);
+  assert.equal(r1.sha, 'abc123def');
+  assert.equal(r1.checksState, 'SUCCESS');
+  assert.equal(r1.mergeable, 'CLEAN');
+
+  // Second call same state same SHA → dedup'd (no hit) until RE_EMIT_MIN.
+  const r2 = detector.detect({ ticket: 'GH-400', worktree: '/tmp' });
+  assert.equal(r2.hit, false, 'same state + same SHA must not re-emit within cooldown');
+});
+
+test('failing check emits pr-broken with failingChecks populated', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-broken-'));
+  const detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 555 }]),
+    view: viewJson({
+      sha: 'badcommit',
+      checks: [
+        { name: 'Test (Node 20)', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        {
+          name: 'Quality',
+          conclusion: 'FAILURE',
+          status: 'COMPLETED',
+          detailsUrl: 'https://ci.example/jobs/42',
+        },
+      ],
+      merge: 'BLOCKED',
+    }),
+  });
+  const r = detector.detect({ ticket: 'GH-BROKEN', worktree: '/tmp' });
+  assert.equal(r.hit, true);
+  assert.equal(r.kind, 'pr-broken');
+  assert.equal(r.failingChecks.length, 1);
+  assert.equal(r.failingChecks[0].name, 'Quality');
+  assert.equal(r.failingChecks[0].url, 'https://ci.example/jobs/42');
+});
+
+test('SHA change re-emits even when state is unchanged (operator pushed a new commit)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-sha-'));
+
+  // First: green at SHA "aaa".
+  let detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 100 }]),
+    view: viewJson({
+      sha: 'aaa',
+      checks: [{ name: 'CI', conclusion: 'SUCCESS', status: 'COMPLETED' }],
+      merge: 'CLEAN',
+    }),
+  });
+  assert.equal(detector.detect({ ticket: 'GH-SHA', worktree: '/tmp' }).hit, true);
+
+  // Re-require with the SAME state dir but updated gh response (new SHA).
+  detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 100 }]),
+    view: viewJson({
+      sha: 'bbb',
+      checks: [{ name: 'CI', conclusion: 'SUCCESS', status: 'COMPLETED' }],
+      merge: 'CLEAN',
+    }),
+  });
+  const r = detector.detect({ ticket: 'GH-SHA', worktree: '/tmp' });
+  assert.equal(r.hit, true, 'new SHA must re-emit even for the same kind');
+  assert.equal(r.sha, 'bbb');
+});
+
+test('pending checks classify as pr-pending (informational)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-pending-'));
+  const detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 999 }]),
+    view: viewJson({
+      sha: 'wip',
+      checks: [{ name: 'CI', conclusion: null, status: 'IN_PROGRESS' }],
+      merge: 'CLEAN',
+    }),
+  });
+  const r = detector.detect({ ticket: 'GH-PEND', worktree: '/tmp' });
+  assert.equal(r.hit, true);
+  assert.equal(r.kind, 'pr-pending');
+});
+
+test('no PR for the head ref → silent (hit=false)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-nopr-'));
+  const detector = freshDetector(stateDir, { list: '[]' });
+  const r = detector.detect({ ticket: 'GH-NOPR', worktree: '/tmp' });
+  assert.equal(r.hit, false);
+});
+
+test('SUCCESS+UNSTABLE (e.g., approval missing) is silent — no emit', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-unstable-'));
+  const detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 77 }]),
+    view: viewJson({
+      sha: 'unstable',
+      checks: [{ name: 'CI', conclusion: 'SUCCESS', status: 'COMPLETED' }],
+      merge: 'UNSTABLE',
+    }),
+  });
+  const r = detector.detect({ ticket: 'GH-UN', worktree: '/tmp' });
+  assert.equal(
+    r.hit,
+    false,
+    'UNSTABLE is not pr-ready (CLEAN required) and not broken — daemon stays quiet'
+  );
+});

--- a/plugins/maestro/scripts/__tests__/detectors-restart-loop.test.js
+++ b/plugins/maestro/scripts/__tests__/detectors-restart-loop.test.js
@@ -1,0 +1,143 @@
+// restart-loop guard inside actions.autoRestart.
+//
+// Contract: if a `-work` session is auto-restarted ≥ RESTART_LOOP_THRESHOLD
+// times within RESTART_WINDOW_MIN minutes, declare it WEDGED — stop
+// restarting for WEDGED_QUIET_MIN minutes and emit a `kind:'wedged'` alert.
+// This is the escalation that prevents endless restart loops on agents
+// that auto-restart only to immediately go silent again.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const ACTIONS_PATH = path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'actions');
+
+function fakeWorktree() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rl-wt-'));
+}
+
+function freshActions({ stateDir, alertFile, tmuxStub }) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  process.env.ALERT_FILE = alertFile;
+  process.env.LOG_FILE = path.join(stateDir, '.log');
+  process.env.RESTART_LOOP_THRESHOLD = '3';
+  process.env.RESTART_WINDOW_MIN = '30';
+  process.env.WEDGED_QUIET_MIN = '60';
+
+  // Patch spawnSync so we don't actually call tmux. tmuxStub records calls.
+  const cp = require('child_process');
+  cp.spawnSync = (cmd, args, opts) => {
+    if (cmd === 'tmux') {
+      tmuxStub.push({ cmd, args });
+      return { status: 0, stdout: '' };
+    }
+    if (cmd === 'sleep') return { status: 0, stdout: '' };
+    return { status: 0, stdout: '' };
+  };
+
+  return require(ACTIONS_PATH);
+}
+
+test('3rd restart within window declares WEDGED, stops further restarts, emits alert', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rl-state-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const wt = fakeWorktree();
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  const args = { session: 'GH-X-work', ticket: 'GH-X', worktree: wt, silenceSec: 305 };
+
+  // First two restarts succeed.
+  assert.equal(actions.autoRestart(args), true, 'restart 1 should proceed');
+  assert.equal(actions.autoRestart(args), true, 'restart 2 should proceed');
+
+  // Third call hits the threshold and is suppressed.
+  assert.equal(actions.autoRestart(args), false, 'restart 3 must be suppressed as WEDGED');
+
+  // Subsequent restarts during the quiet window are also suppressed.
+  assert.equal(
+    actions.autoRestart(args),
+    false,
+    'restart 4 (within quiet window) must be suppressed'
+  );
+
+  // Alert file should contain one wedged row.
+  const alertLines = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
+  const wedgedAlerts = alertLines.map(JSON.parse).filter((a) => a.kind === 'wedged');
+  assert.equal(
+    wedgedAlerts.length,
+    1,
+    `expected exactly one wedged alert, got ${wedgedAlerts.length}`
+  );
+  assert.equal(wedgedAlerts[0].session, 'GH-X-work');
+  assert.equal(wedgedAlerts[0].restartsInWindow, 3);
+});
+
+test('restarts outside the rolling window do not count toward the threshold', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rl-window-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const wt = fakeWorktree();
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  // Seed marker with two restarts that happened 31m ago (outside the 30m
+  // window). Use the real state.js so the actions module reads it back.
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct/state')) delete require.cache[k];
+  }
+  const state = require(path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'state'));
+  const longAgo = state.now() - 31 * 60;
+  state.write('GH-Y-work', 'restart-loop', { restarts: [longAgo, longAgo + 5] });
+
+  // Now do 2 fresh restarts. Combined with the 2 stale (outside window),
+  // we should be at count=2 fresh — still below threshold=3.
+  const args = { session: 'GH-Y-work', ticket: 'GH-Y', worktree: wt, silenceSec: 305 };
+  assert.equal(
+    actions.autoRestart(args),
+    true,
+    'fresh restart 1 should proceed (stale entries pruned)'
+  );
+  assert.equal(actions.autoRestart(args), true, 'fresh restart 2 should proceed');
+
+  // No wedged alert yet — only 2 in-window restarts.
+  const alertLinesA = fs.existsSync(alertFile)
+    ? fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean)
+    : [];
+  assert.equal(alertLinesA.map(JSON.parse).filter((a) => a.kind === 'wedged').length, 0);
+
+  // 3rd in-window restart should now declare WEDGED.
+  assert.equal(actions.autoRestart(args), false, 'fresh restart 3 must declare WEDGED');
+  const alertLinesB = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
+  assert.equal(alertLinesB.map(JSON.parse).filter((a) => a.kind === 'wedged').length, 1);
+});
+
+test('autoRestart bails early when worktree does not exist (no marker mutation)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rl-nowt-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  const args = {
+    session: 'GH-Z-work',
+    ticket: 'GH-Z',
+    worktree: '/tmp/definitely-does-not-exist-xyz-' + Date.now(),
+    silenceSec: 305,
+  };
+  assert.equal(actions.autoRestart(args), false);
+
+  // No marker should be created (worktree-missing branch returns before
+  // touching state).
+  const markerFile = path.join(stateDir, 'GH-Z-work.restart-loop.json');
+  assert.equal(
+    fs.existsSync(markerFile),
+    false,
+    'no marker should be written for missing worktree'
+  );
+});

--- a/plugins/maestro/scripts/__tests__/maestro-session.test.js
+++ b/plugins/maestro/scripts/__tests__/maestro-session.test.js
@@ -1,0 +1,129 @@
+// maestro-session.js — orchestration session manifest CRUD + dep resolver.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+function freshModule(sessionDir) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('maestro-session')) delete require.cache[k];
+  }
+  process.env.MAESTRO_SESSION_DIR = sessionDir;
+  return require(path.resolve(__dirname, '..', 'maestro-session.js'));
+}
+
+test('init persists topic, slots, tasks; status starts pending', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-'));
+  const m = freshModule(dir);
+  const s = m.init('plug-bugs', 5, [
+    { id: 'GH-1', priority: 1, deps: [] },
+    { id: 'GH-2', priority: 2, deps: ['GH-1'] },
+  ]);
+  assert.equal(s.topic, 'plug-bugs');
+  assert.equal(s.slots, 5);
+  assert.equal(s.tasks.length, 2);
+  assert.equal(s.tasks[0].status, 'pending');
+  assert.equal(s.tasks[1].status, 'pending');
+  const onDisk = JSON.parse(fs.readFileSync(path.join(dir, 'plug-bugs.json'), 'utf8'));
+  assert.equal(onDisk.topic, 'plug-bugs');
+});
+
+test('init rejects task with unknown dep reference', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-bad-'));
+  const m = freshModule(dir);
+  assert.throws(
+    () => m.init('bad', 1, [{ id: 'A', priority: 1, deps: ['UNKNOWN'] }]),
+    /depends on unknown UNKNOWN/
+  );
+});
+
+test('init rejects invalid topic / zero slots / empty tasks', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-val-'));
+  const m = freshModule(dir);
+  assert.throws(() => m.init('bad topic', 1, [{ id: 'A', priority: 1 }]), /bad topic/);
+  assert.throws(() => m.init('ok', 0, [{ id: 'A', priority: 1 }]), /slots must be/);
+  assert.throws(() => m.init('ok', 1, []), /at least one task/);
+});
+
+test('update flips status and persists', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-upd-'));
+  const m = freshModule(dir);
+  m.init('topic', 3, [{ id: 'X', priority: 1, deps: [] }]);
+  m.update('topic', 'X', 'in_progress');
+  assert.equal(m.read('topic').tasks[0].status, 'in_progress');
+  m.update('topic', 'X', 'done', 'merged in PR #42');
+  const t = m.read('topic').tasks[0];
+  assert.equal(t.status, 'done');
+  assert.equal(t.note, 'merged in PR #42');
+  assert.ok(t.updatedAt);
+});
+
+test('update rejects unknown status', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-bs-'));
+  const m = freshModule(dir);
+  m.init('t', 1, [{ id: 'X', priority: 1 }]);
+  assert.throws(() => m.update('t', 'X', 'banana'), /bad status/);
+});
+
+test('nextEligible returns highest-priority pending task whose deps are done', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-next-'));
+  const m = freshModule(dir);
+  m.init('t', 2, [
+    { id: 'A', priority: 1, deps: [] }, // top priority
+    { id: 'B', priority: 2, deps: ['A'] }, // needs A
+    { id: 'C', priority: 3, deps: [] }, // independent, lower priority
+  ]);
+  // A is eligible first (priority 1, no deps).
+  assert.equal(m.nextEligible('t').id, 'A');
+  m.update('t', 'A', 'done');
+  // Now B is eligible (deps satisfied) and beats C on priority.
+  assert.equal(m.nextEligible('t').id, 'B');
+  m.update('t', 'B', 'in_progress');
+  // B is in_progress (not pending) — C is the only pending eligible.
+  assert.equal(m.nextEligible('t').id, 'C');
+  m.update('t', 'B', 'done');
+  m.update('t', 'C', 'done');
+  // All done — nothing eligible.
+  assert.equal(m.nextEligible('t'), null);
+});
+
+test('list returns all active sessions', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-list-'));
+  const m = freshModule(dir);
+  m.init('a', 1, [{ id: 'X', priority: 1 }]);
+  m.init('b', 2, [{ id: 'Y', priority: 1 }]);
+  const all = m.list();
+  assert.equal(all.length, 2);
+  assert.deepEqual(all.map((s) => s.topic).sort(), ['a', 'b']);
+});
+
+test('summarize emits the operator-facing one-liner', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-sum-'));
+  const m = freshModule(dir);
+  const s = m.init('topic', 5, [
+    { id: 'A', priority: 1 },
+    { id: 'B', priority: 2 },
+    { id: 'C', priority: 3 },
+  ]);
+  m.update('topic', 'A', 'done');
+  m.update('topic', 'B', 'in_progress');
+  const line = m.summarize(m.read('topic'));
+  assert.match(line, /topic: slots=5/);
+  assert.match(line, /1 in flight/);
+  assert.match(line, /1\/3 done/);
+  assert.match(line, /1 pending/);
+});
+
+test('clear removes the session file', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-clr-'));
+  const m = freshModule(dir);
+  m.init('rm', 1, [{ id: 'X', priority: 1 }]);
+  assert.ok(fs.existsSync(path.join(dir, 'rm.json')));
+  assert.equal(m.clear('rm'), true);
+  assert.equal(fs.existsSync(path.join(dir, 'rm.json')), false);
+  assert.equal(m.clear('rm'), false);
+});

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -102,6 +102,7 @@ function autoRestart({ session, ticket, worktree, silenceSec }) {
       windowMin: RESTART_WINDOW_MIN,
       quietMin: WEDGED_QUIET_MIN,
       silenceSec,
+      instruction: `tmux capture-pane -t ${session} -p | tail -50 — agent restarted ${restarts.length + 1}x in ${RESTART_WINDOW_MIN}m. Daemon won't restart for ${WEDGED_QUIET_MIN}m. Diagnose root cause; if dead-end, kill session and bootstrap next bug.`,
     });
     return false;
   }
@@ -159,9 +160,40 @@ function freeCIGateSlot({ session, ticket, prNumber, sha }) {
     kind: 'slot-freed',
     prNumber,
     sha,
-    reason: 'pr-ready at CI gate — auto-killed to free pool slot',
+    instruction: `Pool slot free. Pick next bug: gh issue list --repo thomfilg/claude-plugin-work --state open --label bug --json number,title | head; then: bash plugins/maestro/scripts/maestro-bootstrap.sh GH-<pick>. Skip tickets whose diff overlaps PR #${prNumber}.`,
   });
   return true;
 }
 
-module.exports = { soft, interrupt, alert, autoRestart, freeCIGateSlot };
+/**
+ * freeDeadEndSlot — same kill mechanics as freeCIGateSlot but for an agent
+ * stuck in a non-recoverable state (e.g. every menu option is a workflow
+ * bypass; PR has no path forward without manual intervention). Triggered by
+ * the re-emit escalation: when the same alert kind fires ≥ DEAD_END_REEMITS
+ * times on the same session+sha+phase, the caller invokes this.
+ *
+ * Emits a kind=dead-end alert with a crystal-clear instruction so the
+ * operator knows to bootstrap the next ticket. Idempotent per ticket.
+ */
+function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
+  if (process.env.AUTO_FREE_DEAD_END === '0') return false;
+  const marker = state.read(ticket, 'dead-end') || {};
+  if (marker.killed) return false; // already freed
+  for (const suffix of ['work', 'listen']) {
+    spawnSync('tmux', ['kill-session', '-t', `${ticket}-${suffix}`], { stdio: 'ignore' });
+  }
+  state.write(ticket, 'dead-end', { killed: true, freedAt: state.now(), trigger: kind });
+  alerts.log(`${session} DEAD-END ${kind} re-fired ${repeatCount}x — tmux killed, slot freed`);
+  alert({
+    session,
+    ticket,
+    kind: 'dead-end',
+    trigger: kind,
+    repeatCount,
+    sha,
+    instruction: `Bootstrap next bug into freed slot: gh issue list --repo thomfilg/claude-plugin-work --state open --label bug --json number,title | head; bash plugins/maestro/scripts/maestro-bootstrap.sh GH-<pick>`,
+  });
+  return true;
+}
+
+module.exports = { soft, interrupt, alert, autoRestart, freeCIGateSlot, freeDeadEndSlot };

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -15,9 +15,17 @@ const fs = require('fs');
 const { spawnSync } = require('child_process');
 const tmux = require('./tmux');
 const alerts = require('./alerts');
+const state = require('./state');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
 const SKILL_NAME = process.env.SKILL_NAME || 'work';
+
+// Restart-loop guard: how many auto-restarts within RESTART_WINDOW_MIN before
+// we declare the session WEDGED and stop restarting. Caller is freed of state
+// management — autoRestart() owns the marker.
+const RESTART_LOOP_THRESHOLD = parseInt(process.env.RESTART_LOOP_THRESHOLD || '3', 10);
+const RESTART_WINDOW_MIN = parseInt(process.env.RESTART_WINDOW_MIN || '30', 10);
+const WEDGED_QUIET_MIN = parseInt(process.env.WEDGED_QUIET_MIN || '60', 10);
 
 function msgFor(reason, mode) {
   const base = `MAESTRO (${mode}): ${reason}. Audit uncommitted files via git status. If any are present, dispatch the commit agent with 'autonomous' to land them, then push. Re-run task-next.js to advance the gate.`;
@@ -59,6 +67,48 @@ function autoRestart({ session, ticket, worktree, silenceSec }) {
     alerts.log(`${session} AUTO-RESTART skipped: worktree ${worktree} not found`);
     return false;
   }
+
+  // Restart-loop guard. Read the per-session marker once and decide whether
+  // we're still in the "WEDGED quiet" window from a prior loop. The marker
+  // shape:
+  //   { restarts: [unix_ts, ...], wedgedUntil?: unix_ts }
+  // restarts[] is pruned to the last RESTART_WINDOW_MIN.
+  const now = state.now();
+  const marker = state.read(session, 'restart-loop') || { restarts: [] };
+
+  if (marker.wedgedUntil && marker.wedgedUntil > now) {
+    // Already declared wedged — don't restart, don't re-alert. We logged on
+    // entry; further silence triggers can re-read this marker silently.
+    return false;
+  }
+
+  // Prune older entries outside the rolling window.
+  const cutoff = now - RESTART_WINDOW_MIN * 60;
+  const restarts = (marker.restarts || []).filter((t) => t >= cutoff);
+
+  // If we'd be at-or-over the threshold AFTER this restart, declare wedged
+  // INSTEAD of restarting. The operator must intervene.
+  if (restarts.length + 1 >= RESTART_LOOP_THRESHOLD) {
+    const wedgedUntil = now + WEDGED_QUIET_MIN * 60;
+    state.write(session, 'restart-loop', { restarts: [...restarts, now], wedgedUntil });
+    alerts.log(
+      `${session} WEDGED — ${restarts.length + 1} auto-restarts in ${RESTART_WINDOW_MIN}m; suppressing restarts for ${WEDGED_QUIET_MIN}m`
+    );
+    alerts.alert({
+      session,
+      ticket,
+      kind: 'wedged',
+      restartsInWindow: restarts.length + 1,
+      windowMin: RESTART_WINDOW_MIN,
+      quietMin: WEDGED_QUIET_MIN,
+      silenceSec,
+    });
+    return false;
+  }
+
+  // Record this restart and proceed.
+  state.write(session, 'restart-loop', { restarts: [...restarts, now] });
+
   alerts.log(
     `${session} AUTO-RESTART after ${silenceSec}s silence — relaunching /${SKILL_NAME} ${ticket}`
   );
@@ -82,4 +132,36 @@ function autoRestart({ session, ticket, worktree, silenceSec }) {
   return true;
 }
 
-module.exports = { soft, interrupt, alert, autoRestart };
+/**
+ * freeCIGateSlot — kill the -work and -listen panes of a ticket whose PR has
+ * reached CI gate (CLEAN/SUCCESS, awaiting operator merge). Emits a
+ * structured alert kind=slot-freed so the orchestrator can bootstrap the next
+ * ticket. Idempotent: writes a per-ticket marker so repeated pr-ready emits
+ * on the same SHA don't try to kill an already-killed session.
+ *
+ * No-op if AUTO_FREE_CI_SLOT=0.
+ */
+function freeCIGateSlot({ session, ticket, prNumber, sha }) {
+  if (process.env.AUTO_FREE_CI_SLOT === '0') return false;
+  const marker = state.read(session, 'slot-freed') || {};
+  if (marker.sha === sha) return false; // already freed for this SHA
+  // Kill -work and -listen panes. Tmux kill-session is idempotent; ignore errors.
+  for (const suffix of ['work', 'listen']) {
+    spawnSync('tmux', ['kill-session', '-t', `${ticket}-${suffix}`], { stdio: 'ignore' });
+  }
+  state.write(session, 'slot-freed', { sha, prNumber, freedAt: state.now() });
+  alerts.log(
+    `${session} SLOT-FREED at CI gate — PR #${prNumber} sha=${(sha || '').slice(0, 7)} awaiting operator merge; tmux -work + -listen killed`
+  );
+  alert({
+    session,
+    ticket,
+    kind: 'slot-freed',
+    prNumber,
+    sha,
+    reason: 'pr-ready at CI gate — auto-killed to free pool slot',
+  });
+  return true;
+}
+
+module.exports = { soft, interrupt, alert, autoRestart, freeCIGateSlot };

--- a/plugins/maestro/scripts/lib/maestro-conduct/alerts.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/alerts.js
@@ -7,28 +7,97 @@
  * and the main loop decides when to escalate.
  */
 const fs = require('fs');
+const path = require('path');
 const tmux = require('./tmux');
 
 const ALERT_FILE = process.env.ALERT_FILE || '/tmp/maestro-alerts.jsonl';
 const ALERT_SESSION = process.env.ALERT_SESSION || 'maestro-alerts';
+const STATE_DIR = process.env.STATE_DIR || '/tmp/maestro-conduct';
+
+// In-process emit counter keyed by `${session}|${kind}|${sha||phase}`. Cleared
+// by the caller (typically via freeDeadEndSlot or phase advance). Persisted to
+// disk in STATE_DIR/_alert-counts.json so a daemon restart doesn't lose count.
+const COUNT_FILE = path.join(STATE_DIR, '_alert-counts.json');
+function loadCounts() {
+  try {
+    return JSON.parse(fs.readFileSync(COUNT_FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+function saveCounts(counts) {
+  try {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+    fs.writeFileSync(COUNT_FILE, JSON.stringify(counts));
+  } catch {}
+}
+function bumpCount(key) {
+  const counts = loadCounts();
+  counts[key] = (counts[key] || 0) + 1;
+  saveCounts(counts);
+  return counts[key];
+}
+function resetCount(key) {
+  const counts = loadCounts();
+  if (key in counts) {
+    delete counts[key];
+    saveCounts(counts);
+  }
+}
+function alertKey(obj) {
+  return `${obj.session || obj.ticket}|${obj.kind}|${obj.sha || obj.phase || '_'}`;
+}
 
 function log(line) {
   const ts = new Date().toISOString();
   const out = `[${ts}] ${line}\n`;
   process.stderr.write(out);
-  try { fs.appendFileSync(process.env.LOG_FILE || '/tmp/maestro-conduct.log', out); }
-  catch {}
+  try {
+    fs.appendFileSync(process.env.LOG_FILE || '/tmp/maestro-conduct.log', out);
+  } catch {}
 }
 
+/**
+ * Emit an action-required alert. Refuses payloads without an `instruction`
+ * field — informational events must use log() instead. The operator should
+ * be able to read the instruction and execute it without further context.
+ *
+ * Expected shape:
+ *   {
+ *     session, ticket, kind,        // identity
+ *     ...event-specific fields,     // sha, prNumber, options, etc.
+ *     instruction: '...',           // REQUIRED — exact action to take
+ *   }
+ *
+ * The tmux summary line embeds the kind + instruction so it's grep-friendly
+ * and self-explanatory in the maestro-alerts pane.
+ */
+/**
+ * Emit an action-required alert. Returns { count } — the number of times this
+ * same (session, kind, sha-or-phase) has been emitted since last reset.
+ *
+ * The caller must check the count and escalate when it crosses a threshold
+ * (typically auto-call freeDeadEndSlot at count >= 3). The instruction string
+ * gets a [REPEAT N] prefix when count > 1 so the operator can see momentum.
+ */
 function alert(obj) {
-  const payload = { ts: new Date().toISOString(), ...obj };
-  try { fs.appendFileSync(ALERT_FILE, JSON.stringify(payload) + '\n'); } catch {}
+  if (!obj || typeof obj.instruction !== 'string' || !obj.instruction.trim()) {
+    log(`ALERT-DROPPED (no instruction): ${JSON.stringify(obj)}`);
+    return { count: 0 };
+  }
+  const key = alertKey(obj);
+  const count = bumpCount(key);
+  const prefix = count > 1 ? `[REPEAT ${count}] ` : '';
+  const instruction = `${prefix}${obj.instruction}`;
+  const payload = { ts: new Date().toISOString(), ...obj, instruction, repeatCount: count };
+  try {
+    fs.appendFileSync(ALERT_FILE, JSON.stringify(payload) + '\n');
+  } catch {}
   tmux.ensureSession(ALERT_SESSION);
-  const summary = `MAESTRO-ALERT ${obj.session || obj.ticket || '?'} ${obj.kind}` +
-    (obj.phase ? ` phase=${obj.phase}` : '') +
-    (typeof obj.elapsedMin === 'number' ? ` elapsed=${obj.elapsedMin}m` : '');
+  const summary = `ACTION ${obj.session || obj.ticket || '?'} kind=${obj.kind} → ${instruction}`;
   tmux.sendLine(ALERT_SESSION, summary);
-  log(`ALERT ${JSON.stringify(payload)}`);
+  log(`ACTION ${JSON.stringify(payload)}`);
+  return { count };
 }
 
-module.exports = { alert, log, ALERT_FILE, ALERT_SESSION };
+module.exports = { alert, log, resetCount, alertKey, ALERT_FILE, ALERT_SESSION };

--- a/plugins/maestro/scripts/lib/maestro-conduct/detectors/commit-stall.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/detectors/commit-stall.js
@@ -4,12 +4,23 @@
  * Informational signal for the implement phase: warn when no commits
  * have landed in the worktree for COMMIT_STALL_MIN minutes.
  *
- * Does NOT itself trigger a nudge; the main loop pairs this with
- * phase-stall to enrich alerts.
+ * Dedup contract: this detector only "hits" when the stall has crossed a
+ * NEW threshold since last we asked. Thresholds are `[30, 60, 120, 240, 480]`
+ * minutes by default. Without this dedup the detector fires every tick (60s),
+ * producing hundreds of identical log lines that desensitize the orchestrator
+ * — see SKILL.md "Daemon event vocabulary" for the contract.
+ *
+ * Does NOT trigger a nudge; the main loop pairs this with phase-stall.
  */
 const { spawnSync } = require('child_process');
+const state = require('../state');
 
 const COMMIT_STALL_MIN = parseInt(process.env.COMMIT_STALL_MIN || '30', 10);
+const COMMIT_STALL_THRESHOLDS = (process.env.COMMIT_STALL_THRESHOLDS || '30,60,120,240,480')
+  .split(',')
+  .map((s) => parseInt(s.trim(), 10))
+  .filter((n) => Number.isFinite(n) && n >= COMMIT_STALL_MIN)
+  .sort((a, b) => a - b);
 
 function minutesSinceLastCommit(worktree) {
   const res = spawnSync('git', ['-C', worktree, 'log', '-1', '--format=%ct'], {
@@ -22,11 +33,31 @@ function minutesSinceLastCommit(worktree) {
   return Math.floor((Date.now() / 1000 - secs) / 60);
 }
 
-function detect({ worktree }) {
-  if (!worktree) return { hit: false };
-  const mins = minutesSinceLastCommit(worktree);
-  if (mins < COMMIT_STALL_MIN) return { hit: false };
-  return { hit: true, kind: 'commit-stall', mins };
+/**
+ * Highest threshold not exceeding `mins`. Returns 0 when below the floor.
+ */
+function thresholdFor(mins) {
+  return COMMIT_STALL_THRESHOLDS.reduce((acc, t) => (mins >= t ? t : acc), 0);
 }
 
-module.exports = { name: 'commitStall', detect };
+function detect({ ticket, worktree }) {
+  if (!worktree) return { hit: false };
+  const mins = minutesSinceLastCommit(worktree);
+  if (mins < COMMIT_STALL_MIN) {
+    // Recovered — clear marker so the next stall starts fresh.
+    if (ticket && state.read(ticket, 'commit-stall')) state.clear(ticket, 'commit-stall');
+    return { hit: false };
+  }
+  const level = thresholdFor(mins);
+  if (level === 0) return { hit: false };
+  // Dedup against marker. Marker is per-ticket because the worktree (and
+  // therefore commit cadence) belongs to the ticket, not the pane.
+  const marker = (ticket && state.read(ticket, 'commit-stall')) || { lastThreshold: 0 };
+  if (level <= marker.lastThreshold) return { hit: false };
+  if (ticket) {
+    state.write(ticket, 'commit-stall', { lastThreshold: level, lastAt: state.now() });
+  }
+  return { hit: true, kind: 'commit-stall', mins, threshold: level };
+}
+
+module.exports = { name: 'commitStall', detect, thresholdFor, COMMIT_STALL_THRESHOLDS };

--- a/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-status.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-status.js
@@ -1,0 +1,192 @@
+/**
+ * detectors/pr-status.js
+ *
+ * Positive-signal detector. For each ticket with an open PR on
+ * `<ticket>-maestro`, watch the CI rollup + merge state and emit a
+ * `pr-ready` / `pr-broken` event the moment the state transitions.
+ *
+ * The orchestrator's failure mode this is built to defeat: when every
+ * other signal is "wedged-shaped" (commit-stall, silence, phase-stall),
+ * a ready PR is silent — indistinguishable from a stuck agent. By
+ * emitting a discrete `pr-ready` alert on transition, the operator has
+ * an unambiguous "go merge this" signal.
+ *
+ * State machine per ticket:
+ *   <no marker>          -> read PR, write marker, emit if SUCCESS/CLEAN
+ *   SUCCESS/CLEAN        -> emit `pr-ready` once; re-emit only if SHA changes
+ *                           OR after RE_EMIT_MIN minutes have elapsed
+ *   FAILURE or DIRTY     -> emit `pr-broken` with failing-check details
+ *   PENDING              -> log only, never alert (CI still running)
+ *
+ * Reuses the gh-call pattern from `pr-comments.js` (`gh pr list --head ...`
+ * + `gh api`/`gh pr view --json`). Same bot-API and same caching cadence.
+ */
+const { spawnSync } = require('child_process');
+const state = require('../state');
+
+const RE_EMIT_MIN = parseInt(process.env.PR_STATUS_RE_EMIT_MIN || '30', 10);
+
+function spawnOut(cmd, args) {
+  const res = spawnSync(cmd, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  return res.status === 0 ? res.stdout || '' : '';
+}
+
+function gitOut(worktree, args) {
+  return spawnOut('git', ['-C', worktree, ...args]).trim();
+}
+
+function deriveRepo(worktree) {
+  const url = gitOut(worktree || '.', ['remote', 'get-url', 'origin']);
+  if (!url) return '';
+  const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+  return m ? `${m[1]}/${m[2]}` : '';
+}
+
+function repoSlug(worktree) {
+  return process.env.GITHUB_REPO || deriveRepo(worktree);
+}
+
+function prNumberFor(ticket, worktree) {
+  const repo = repoSlug(worktree);
+  if (!repo) return null;
+  const json = spawnOut('gh', [
+    'pr',
+    'list',
+    '--repo',
+    repo,
+    '--head',
+    `${ticket}-maestro`,
+    '--state',
+    'open',
+    '--json',
+    'number',
+    '--limit',
+    '1',
+  ]);
+  if (!json) return null;
+  try {
+    const arr = JSON.parse(json);
+    return arr[0] && arr[0].number;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read PR status from gh. Returns:
+ *   { prNumber, sha, checksState, mergeable, failingChecks: [{name, conclusion, url}] }
+ * checksState: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'UNKNOWN'
+ * mergeable: GitHub mergeStateStatus verbatim ('CLEAN', 'DIRTY', 'BLOCKED', 'BEHIND', 'UNSTABLE', 'UNKNOWN')
+ */
+function fetchPrStatus(prNumber, worktree) {
+  const repo = repoSlug(worktree);
+  if (!repo) return null;
+  const json = spawnOut('gh', [
+    'pr',
+    'view',
+    String(prNumber),
+    '--repo',
+    repo,
+    '--json',
+    'statusCheckRollup,mergeStateStatus,headRefOid',
+  ]);
+  if (!json) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  const rollup = Array.isArray(parsed.statusCheckRollup) ? parsed.statusCheckRollup : [];
+  // GH normalises CheckRun + StatusContext into a single rollup. Both shapes
+  // carry `conclusion` (`SUCCESS`/`FAILURE`/...) once finished, and `status`
+  // (`COMPLETED`/`IN_PROGRESS`/...) until then.
+  const failing = rollup
+    .filter((c) => /FAILURE|TIMED_OUT|CANCELLED|STARTUP_FAILURE/i.test(c.conclusion || ''))
+    .map((c) => ({
+      name: c.name || c.context || '?',
+      conclusion: c.conclusion,
+      url: c.detailsUrl || c.targetUrl || null,
+    }));
+  const pending = rollup.filter(
+    (c) => !c.conclusion && /(PENDING|IN_PROGRESS|QUEUED|WAITING)/i.test(c.status || '')
+  );
+  let checksState = 'UNKNOWN';
+  if (rollup.length === 0) checksState = 'UNKNOWN';
+  else if (failing.length > 0) checksState = 'FAILURE';
+  else if (pending.length > 0) checksState = 'PENDING';
+  else checksState = 'SUCCESS';
+  return {
+    prNumber,
+    sha: parsed.headRefOid || '',
+    checksState,
+    mergeable: parsed.mergeStateStatus || 'UNKNOWN',
+    failingChecks: failing,
+  };
+}
+
+/**
+ * Classify the (checksState, mergeable) tuple into the emit kind.
+ *   pr-ready   : checks SUCCESS AND mergeable CLEAN (the green-merge state)
+ *   pr-broken  : any failing check OR mergeable DIRTY (must intervene)
+ *   pr-pending : checks PENDING (log-only)
+ *   none       : everything else (UNSTABLE, BLOCKED awaiting review, etc.)
+ *                — we deliberately don't emit on these; they're transient or
+ *                require an external action that we already surface elsewhere.
+ */
+function classify(checksState, mergeable) {
+  if (checksState === 'FAILURE' || mergeable === 'DIRTY') return 'pr-broken';
+  if (checksState === 'SUCCESS' && mergeable === 'CLEAN') return 'pr-ready';
+  if (checksState === 'PENDING') return 'pr-pending';
+  return null;
+}
+
+function detect({ ticket, worktree }) {
+  if (!ticket || !worktree) return { hit: false };
+
+  const prNumber = prNumberFor(ticket, worktree);
+  if (!prNumber) return { hit: false }; // no open PR yet
+
+  const status = fetchPrStatus(prNumber, worktree);
+  if (!status) return { hit: false };
+
+  const kind = classify(status.checksState, status.mergeable);
+  if (!kind) return { hit: false };
+
+  const prev = state.read(ticket, 'pr-status');
+  const now = state.now();
+
+  // First sighting or state change → emit.
+  // Rate-limit re-emit of the SAME state to once per RE_EMIT_MIN, so a flapping
+  // check (SUCCESS → PENDING → SUCCESS) doesn't spam.
+  const shaChanged = !prev || prev.sha !== status.sha;
+  const stateChanged = !prev || prev.lastState !== kind;
+  const sinceLast = prev && prev.lastEmittedAt ? state.minutesSince(prev.lastEmittedAt) : Infinity;
+  const shouldEmit = stateChanged || shaChanged || sinceLast >= RE_EMIT_MIN;
+
+  // Always write the marker so subsequent reads see the latest state, even
+  // if we don't emit this tick.
+  state.write(ticket, 'pr-status', {
+    prNumber,
+    sha: status.sha,
+    lastState: kind,
+    lastEmittedAt: shouldEmit ? now : (prev && prev.lastEmittedAt) || 0,
+  });
+
+  if (!shouldEmit) return { hit: false };
+
+  return {
+    hit: true,
+    kind,
+    prNumber,
+    sha: status.sha,
+    checksState: status.checksState,
+    mergeable: status.mergeable,
+    failingChecks: status.failingChecks,
+  };
+}
+
+module.exports = { name: 'prStatus', detect, classify };

--- a/plugins/maestro/scripts/lib/maestro-conduct/phase-registry.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/phase-registry.js
@@ -21,9 +21,12 @@
 // Base profile every phase inherits unless overridden.
 // 'silence' runs in every phase — it watches for fully-dead panes and
 // auto-restarts -work sessions (ported from maestro-conduct.sh).
+// 'prStatus' runs in every phase too — it's a no-op when the ticket
+// has no open PR, but ensures pr-ready/pr-broken still surfaces after
+// /work has advanced to 'complete' (the agent's final-step state).
 const BASE = Object.freeze({
   maxNudges: 3,
-  detectors: ['question', 'silence', 'spinner', 'phaseStall'],
+  detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
   exempts: () => false,
 });
 
@@ -44,13 +47,22 @@ const PHASES = Object.freeze({
   commit: { budgetMin: 5 },
   task_review: { budgetMin: 30 },
   check: { budgetMin: 15 },
-  pr: { budgetMin: 10 },
-  ready: { budgetMin: 5 },
+  pr: {
+    budgetMin: 10,
+    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
+  },
+  ready: {
+    budgetMin: 5,
+    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
+  },
   follow_up: {
     budgetMin: 60,
-    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prComments'],
+    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prComments', 'prStatus'],
   },
-  ci: { budgetMin: 30 },
+  ci: {
+    budgetMin: 30,
+    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
+  },
   cleanup: { budgetMin: 5 },
   reports: { budgetMin: 5 },
   complete: { budgetMin: 1 },

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -29,7 +29,14 @@ const DETECTORS = {
   phaseStall: require('./lib/maestro-conduct/detectors/phase-stall'),
   commitStall: require('./lib/maestro-conduct/detectors/commit-stall'),
   prComments: require('./lib/maestro-conduct/detectors/pr-comments'),
+  prStatus: require('./lib/maestro-conduct/detectors/pr-status'),
 };
+
+// Heartbeat: every HEARTBEAT_MIN emit a positive summary so silence on the
+// daemon side can't be mistaken for "nothing happening." See detectors/commit-stall.js
+// for the threshold dedup contract used to keep commit-stall noise bounded.
+const HEARTBEAT_MIN = parseInt(process.env.HEARTBEAT_MIN || '30', 10);
+let lastHeartbeatAt = 0;
 
 // Only -work sessions are restart-eligible (matches maestro-conduct.sh
 // gating). Helpers like -dev / -listen are surfaced informationally but
@@ -223,13 +230,54 @@ function runPhaseStallDetector(ctx) {
 }
 
 function runCommitStallDetector(ctx) {
+  // detector handles its own dedup + marker — only "hits" on threshold crossings.
   const cHit = DETECTORS.commitStall.detect(ctx);
-  if (cHit.hit) alerts.log(`${ctx.session} commit-stall ${cHit.mins}m in phase=${ctx.phase}`);
+  if (!cHit.hit) return;
+  alerts.log(
+    `${ctx.session} commit-stall ${cHit.mins}m in phase=${ctx.phase} (threshold=${cHit.threshold}m)`
+  );
 }
 
 function runPrCommentsDetector(ctx) {
   const cHit = DETECTORS.prComments.detect(ctx);
   if (cHit.hit) handlePrComments(ctx, cHit);
+}
+
+function runPrStatusDetector(ctx) {
+  const sHit = DETECTORS.prStatus.detect(ctx);
+  if (!sHit.hit) return;
+  // pr-pending is informational only — log but never escalate to alert sink.
+  if (sHit.kind === 'pr-pending') {
+    alerts.log(
+      `${ctx.session} pr-pending PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} checks running`
+    );
+    return;
+  }
+  // pr-ready / pr-broken go to the structured alert sink so a downstream
+  // grep can match them distinctly from nudges.
+  actions.alert({
+    session: ctx.session,
+    ticket: ctx.ticket,
+    kind: sHit.kind,
+    phase: ctx.phase,
+    prNumber: sHit.prNumber,
+    sha: sHit.sha,
+    checksState: sHit.checksState,
+    mergeable: sHit.mergeable,
+    failingChecks: sHit.failingChecks,
+  });
+  // CI-gate slot rotation: when PR is CLEAN/SUCCESS and the agent is sitting
+  // in a wait-for-merge phase, free the pool slot automatically so the
+  // orchestrator can bootstrap the next ticket. Operator merges separately.
+  // Disable with AUTO_FREE_CI_SLOT=0.
+  if (sHit.kind === 'pr-ready' && ['ci', 'wait_merge'].includes(ctx.phase)) {
+    actions.freeCIGateSlot({
+      session: ctx.session,
+      ticket: ctx.ticket,
+      prNumber: sHit.prNumber,
+      sha: sHit.sha,
+    });
+  }
 }
 
 /** Run the per-session pipeline. Returns when the session has been fully processed. */
@@ -253,6 +301,58 @@ function tickSession(session) {
   if (detectorsToRun.includes('phaseStall')) runPhaseStallDetector(ctx);
   if (detectorsToRun.includes('commitStall')) runCommitStallDetector(ctx);
   if (detectorsToRun.includes('prComments')) runPrCommentsDetector(ctx);
+  if (detectorsToRun.includes('prStatus')) runPrStatusDetector(ctx);
+}
+
+/**
+ * Build the heartbeat summary line. Lists every -work session and its terse
+ * state derived from on-disk markers + phase. The HEARTBEAT keyword is the
+ * grep handle for downstream tooling.
+ */
+function buildHeartbeat(sessions) {
+  const workSessions = sessions.filter(restartEligible);
+  const parts = [];
+  let prReady = 0;
+  let prBroken = 0;
+  let prPending = 0;
+  let wedged = 0;
+  for (const s of workSessions) {
+    const tid = tmux.ticketIdFor(s);
+    const ws = workstate.snapshot(tid);
+    const prMarker = state.read(tid, 'pr-status');
+    const wedgedMarker = state.read(s, 'restart-loop');
+    const commitMarker = state.read(tid, 'commit-stall');
+    const flags = [];
+    if (prMarker && prMarker.lastState === 'pr-ready') {
+      flags.push('pr-ready');
+      prReady++;
+    } else if (prMarker && prMarker.lastState === 'pr-broken') {
+      flags.push('pr-broken');
+      prBroken++;
+    } else if (prMarker && prMarker.lastState === 'pr-pending') {
+      flags.push('pr-pending');
+      prPending++;
+    }
+    if (wedgedMarker && wedgedMarker.wedgedUntil && wedgedMarker.wedgedUntil > state.now()) {
+      flags.push('WEDGED');
+      wedged++;
+    }
+    if (commitMarker && commitMarker.lastThreshold >= 240) {
+      flags.push(`stall=${commitMarker.lastThreshold}m`);
+    }
+    parts.push(`${tid}(${ws.phase || '?'}${flags.length ? ',' + flags.join(',') : ''})`);
+  }
+  return (
+    `HEARTBEAT ${workSessions.length} active, ${prReady} pr-ready, ${prBroken} pr-broken, ${prPending} pr-pending, ${wedged} wedged` +
+    (parts.length ? ` | ${parts.join(' ')}` : '')
+  );
+}
+
+function maybeEmitHeartbeat(sessions) {
+  const now = state.now();
+  if (lastHeartbeatAt && now - lastHeartbeatAt < HEARTBEAT_MIN * 60) return;
+  lastHeartbeatAt = now;
+  alerts.log(buildHeartbeat(sessions));
 }
 
 function tick() {
@@ -262,6 +362,7 @@ function tick() {
     return;
   }
   for (const session of sessions) tickSession(session);
+  maybeEmitHeartbeat(sessions);
 }
 
 function handlePrComments(ctx, cHit) {

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -38,6 +38,23 @@ const DETECTORS = {
 const HEARTBEAT_MIN = parseInt(process.env.HEARTBEAT_MIN || '30', 10);
 let lastHeartbeatAt = 0;
 
+// Re-emit escalation: when the same (session, kind, sha/phase) alert fires
+// this many times in a row, the daemon auto-rotates the slot (kills the
+// session via freeDeadEndSlot). Operator no longer needs to make a judgment
+// call on whether a stuck agent is recoverable.
+const DEAD_END_REEMITS = parseInt(process.env.DEAD_END_REEMITS || '3', 10);
+
+function maybeEscalateToDeadEnd(ctx, kind, repeatCount, sha) {
+  if (repeatCount < DEAD_END_REEMITS) return;
+  actions.freeDeadEndSlot({
+    session: ctx.session,
+    ticket: ctx.ticket,
+    kind,
+    repeatCount,
+    sha,
+  });
+}
+
 // Only -work sessions are restart-eligible (matches maestro-conduct.sh
 // gating). Helpers like -dev / -listen are surfaced informationally but
 // would re-launch wrong if relaunched as /work <tid>.
@@ -75,7 +92,7 @@ function handleQuestion(ctx, qHit) {
   }
   const mins = state.minutesSince(prev.startedAt);
   if (mins >= Q_WAIT_MIN && !prev.alerted) {
-    actions.alert({
+    const r = actions.alert({
       session: ctx.session,
       ticket: ctx.ticket,
       kind: 'question-pending',
@@ -83,8 +100,10 @@ function handleQuestion(ctx, qHit) {
       elapsedMin: mins,
       options: qHit.options,
       promptKind: qHit.promptKind,
+      instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — read full menu, pick the option that does NOT bypass any workflow gate (avoid: state-file edits, set-step CLI, completion-checker skip, --no-verify). If all options bypass, send a directive via "Type something".`,
     });
     state.write(ctx.session, 'question', { startedAt: prev.startedAt, alerted: true });
+    maybeEscalateToDeadEnd(ctx, 'question-pending', r.count, null);
   }
 }
 
@@ -140,7 +159,7 @@ function handlePhaseStall(ctx, stallHit) {
   const reason = `phase=${ctx.phase} stuck ${stallHit.elapsedMin}m budget=${stallHit.budgetMin}m nudge ${marker.nudges + 1}/${stallHit.maxNudges}`;
 
   if (escalation === 'alert') {
-    actions.alert({
+    const r = actions.alert({
       session: ctx.session,
       ticket: ctx.ticket,
       kind: 'nudges-exhausted',
@@ -148,7 +167,9 @@ function handlePhaseStall(ctx, stallHit) {
       elapsedMin: stallHit.elapsedMin,
       budgetMin: stallHit.budgetMin,
       nudges: marker.nudges,
+      instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — agent exceeded phase=${ctx.phase} budget (${stallHit.elapsedMin}m vs ${stallHit.budgetMin}m). Diagnose or send directive via "Type something".`,
     });
+    maybeEscalateToDeadEnd(ctx, 'nudges-exhausted', r.count, ctx.phase);
   } else if (escalation === 'interrupt') {
     actions.interrupt(ctx.session, reason);
   } else {
@@ -255,6 +276,13 @@ function runPrStatusDetector(ctx) {
   }
   // pr-ready / pr-broken go to the structured alert sink so a downstream
   // grep can match them distinctly from nudges.
+  const failingList = (sHit.failingChecks || [])
+    .map((c) => `${c.name}(${c.conclusion})`)
+    .join(', ');
+  const instruction =
+    sHit.kind === 'pr-ready'
+      ? `Run bypass-checker on PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} (Agent tool, work-workflow:code-checker). On APPROVED → surface PR URL to operator. Slot will be auto-freed if phase=ci/wait_merge.`
+      : `tmux capture-pane -t ${ctx.session} -p | tail -40 — drive agent to fix failing checks IN-PR (no skip, no follow-up issue). Failing: ${failingList || 'see PR'}.`;
   actions.alert({
     session: ctx.session,
     ticket: ctx.ticket,
@@ -265,6 +293,7 @@ function runPrStatusDetector(ctx) {
     checksState: sHit.checksState,
     mergeable: sHit.mergeable,
     failingChecks: sHit.failingChecks,
+    instruction,
   });
   // CI-gate slot rotation: when PR is CLEAN/SUCCESS and the agent is sitting
   // in a wait-for-merge phase, free the pool slot automatically so the
@@ -386,7 +415,7 @@ function handlePrComments(ctx, cHit) {
   const escalation = escalationFor(ctx.phase, nudges);
 
   if (escalation === 'alert') {
-    actions.alert({
+    const r = actions.alert({
       session: ctx.session,
       ticket: ctx.ticket,
       kind: 'pr-comments-stuck',
@@ -395,7 +424,9 @@ function handlePrComments(ctx, cHit) {
       count: cHit.count,
       elapsedMin: cHit.minsStuck,
       summary: cHit.summary,
+      instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — agent left ${cHit.count} bot comment(s) on PR #${cHit.prNumber} unaddressed for ${cHit.minsStuck}m, HEAD unchanged. Send directive: "Address each bot comment in the PR; never dismiss as stale."`,
     });
+    maybeEscalateToDeadEnd(ctx, 'pr-comments-stuck', r.count, null);
   } else if (escalation === 'interrupt') {
     actions.interrupt(ctx.session, reason);
   } else {

--- a/plugins/maestro/scripts/maestro-session.js
+++ b/plugins/maestro/scripts/maestro-session.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * maestro-session.js — manifest for an active orchestration session.
+ *
+ * Persists the orchestrator's plan when launching N parallel agents over M
+ * tasks: the ordered task list (by priority), dependency graph, slot count,
+ * and per-task status. Survives orchestrator restart, drives the
+ * SessionStart reminder so a fresh session doesn't accidentally start a
+ * parallel orchestration or forget the priority/dep plan.
+ *
+ * Storage: one JSON file per topic under MAESTRO_SESSION_DIR
+ *          (default ~/.cache/maestro/sessions).
+ *
+ * Schema:
+ *   {
+ *     topic: string,                 // e.g. "claude-plugin-work-bugs-2026-06"
+ *     slots: number,                 // parallel agent cap (the N)
+ *     createdAt: ISO,
+ *     tasks: [{
+ *       id: string,                  // e.g. "GH-498"
+ *       priority: number,            // lower = earlier; 1 is highest
+ *       deps: string[],              // task ids that must be 'done' first
+ *       status: 'pending'|'in_progress'|'done'|'blocked',
+ *       updatedAt?: ISO,
+ *       note?: string,
+ *     }, ...]
+ *   }
+ *
+ * CLI:
+ *   init <topic> <slots> <id>:<prio>[:dep,dep] ...    create
+ *   show <topic>                                       print full session
+ *   list                                               all active sessions
+ *   summary                                            short status per session
+ *   update <topic> <id> <status> [note]                update one task
+ *   next <topic>                                       next eligible task
+ *   clear <topic>                                      remove session file
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SESSION_DIR =
+  process.env.MAESTRO_SESSION_DIR || path.join(os.homedir(), '.cache', 'maestro', 'sessions');
+const VALID_STATUS = new Set(['pending', 'in_progress', 'done', 'blocked']);
+
+function ensureDir() {
+  fs.mkdirSync(SESSION_DIR, { recursive: true });
+}
+function sessionPath(topic) {
+  return path.join(SESSION_DIR, `${topic}.json`);
+}
+
+function init(topic, slots, tasks) {
+  if (!topic || !/^[A-Za-z0-9_.-]+$/.test(topic)) throw new Error(`bad topic: ${topic}`);
+  if (!(slots > 0)) throw new Error(`slots must be > 0`);
+  if (!tasks.length) throw new Error(`at least one task required`);
+  // Validate dep references — every dep must be a task in the same session.
+  const ids = new Set(tasks.map((t) => t.id));
+  for (const t of tasks) {
+    for (const d of t.deps || []) {
+      if (!ids.has(d)) throw new Error(`task ${t.id} depends on unknown ${d}`);
+    }
+  }
+  ensureDir();
+  const session = {
+    topic,
+    slots,
+    createdAt: new Date().toISOString(),
+    tasks: tasks.map((t) => ({
+      id: t.id,
+      priority: typeof t.priority === 'number' ? t.priority : 999,
+      deps: t.deps || [],
+      status: 'pending',
+    })),
+  };
+  fs.writeFileSync(sessionPath(topic), JSON.stringify(session, null, 2));
+  return session;
+}
+
+function read(topic) {
+  try {
+    return JSON.parse(fs.readFileSync(sessionPath(topic), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function update(topic, taskId, status, note) {
+  if (!VALID_STATUS.has(status)) throw new Error(`bad status: ${status}`);
+  const s = read(topic);
+  if (!s) throw new Error(`no session: ${topic}`);
+  const t = s.tasks.find((x) => x.id === taskId);
+  if (!t) throw new Error(`no task ${taskId} in ${topic}`);
+  t.status = status;
+  t.updatedAt = new Date().toISOString();
+  if (note) t.note = note;
+  fs.writeFileSync(sessionPath(topic), JSON.stringify(s, null, 2));
+  return t;
+}
+
+function list() {
+  if (!fs.existsSync(SESSION_DIR)) return [];
+  return fs
+    .readdirSync(SESSION_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(fs.readFileSync(path.join(SESSION_DIR, f), 'utf8')));
+}
+
+function nextEligible(topic) {
+  const s = read(topic);
+  if (!s) return null;
+  const doneIds = new Set(s.tasks.filter((t) => t.status === 'done').map((t) => t.id));
+  const eligible = s.tasks
+    .filter((t) => t.status === 'pending')
+    .filter((t) => (t.deps || []).every((d) => doneIds.has(d)));
+  eligible.sort((a, b) => a.priority - b.priority);
+  return eligible[0] || null;
+}
+
+function summarize(s) {
+  const counts = { pending: 0, in_progress: 0, done: 0, blocked: 0 };
+  for (const t of s.tasks) counts[t.status] = (counts[t.status] || 0) + 1;
+  return (
+    `${s.topic}: slots=${s.slots} | ${counts.in_progress} in flight, ${counts.done}/${s.tasks.length} done, ${counts.pending} pending` +
+    (counts.blocked ? `, ${counts.blocked} blocked` : '')
+  );
+}
+
+function clear(topic) {
+  try {
+    fs.unlinkSync(sessionPath(topic));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  init,
+  read,
+  update,
+  list,
+  nextEligible,
+  summarize,
+  clear,
+  SESSION_DIR,
+  sessionPath,
+};
+
+if (require.main === module) {
+  const [, , cmd, ...args] = process.argv;
+  try {
+    switch (cmd) {
+      case 'init': {
+        const [topic, slotsStr, ...taskSpecs] = args;
+        const slots = parseInt(slotsStr, 10);
+        const tasks = taskSpecs.map((spec) => {
+          const [id, prio, deps] = spec.split(':');
+          return {
+            id,
+            priority: parseInt(prio, 10),
+            deps: deps ? deps.split(',').filter(Boolean) : [],
+          };
+        });
+        console.log(JSON.stringify(init(topic, slots, tasks), null, 2));
+        break;
+      }
+      case 'show':
+        console.log(JSON.stringify(read(args[0]), null, 2));
+        break;
+      case 'list':
+        console.log(JSON.stringify(list(), null, 2));
+        break;
+      case 'summary': {
+        const sessions = list();
+        if (!sessions.length) console.log('No active maestro sessions.');
+        else for (const s of sessions) console.log(summarize(s));
+        break;
+      }
+      case 'update':
+        update(args[0], args[1], args[2], args.slice(3).join(' ') || undefined);
+        console.log('ok');
+        break;
+      case 'next':
+        console.log(JSON.stringify(nextEligible(args[0]), null, 2));
+        break;
+      case 'clear':
+        console.log(clear(args[0]) ? 'cleared' : 'not found');
+        break;
+      default:
+        console.error('usage: maestro-session.js <init|show|list|summary|update|next|clear> ...');
+        process.exit(1);
+    }
+  } catch (e) {
+    console.error(`error: ${e.message}`);
+    process.exit(1);
+  }
+}

--- a/plugins/maestro/skills/orchestrate/SKILL.md
+++ b/plugins/maestro/skills/orchestrate/SKILL.md
@@ -36,12 +36,66 @@ Examples:
 - **Silent agents** auto-restart after `SILENCE_LIMIT_SEC` (default 300s). `/work` is resumable from `.work-state.json`.
 - **Snapshot** anytime with `bash plugins/maestro/scripts/maestro-pulse.sh` (or `/pulse`).
 
+## Daemon event vocabulary (the only thing your Monitor filter should match)
+
+The .js daemon emits exactly these event kinds. Anything else is bookkeeping noise — do not subscribe to it. Each kind below is dedup'd as noted; if you see it, it carries new information.
+
+| Event | Shape | Emitted by | Dedup |
+|---|---|---|---|
+| `QUESTION-DETECTED` | `[<S>] QUESTION-DETECTED: …` + structured `MAESTRO-ALERT` row | `detectors/question.js` | Per-session, fires once when prompt sits ≥`Q_WAIT_MIN` minutes |
+| `MAESTRO-ALERT … kind=…` | JSONL row in `/tmp/maestro-alerts.jsonl`, summary line in tmux `maestro-alerts` | `actions.alert` | One per kind per ticket per state, then mutes until state flips |
+| `pr-ready` | `MAESTRO-ALERT … kind=pr-ready prNumber=N sha=…` | `detectors/pr-status.js` | Emit on first sight + state transition; re-emit same state at most every `PR_STATUS_RE_EMIT_MIN` (30m) |
+| `pr-broken` | `MAESTRO-ALERT … kind=pr-broken failingChecks=[…]` | `detectors/pr-status.js` | Same dedup as `pr-ready` |
+| `pr-pending` | log-only, `<S> pr-pending PR #N sha=… checks running` | `detectors/pr-status.js` | Per-tick log; informational, **not** an alert |
+| `wedged` | `MAESTRO-ALERT … kind=wedged restartsInWindow=N` + `<S> WEDGED — N auto-restarts in Mm` | `actions.autoRestart` (restart-loop guard) | Once per session per `WEDGED_QUIET_MIN` (60m) suppression window |
+| `AUTO-RESTART after Ns silence` | log-only | `actions.autoRestart` | One per restart, not throttled |
+| `AUTO-RESTART skipped: non-work helper` | log-only | `runSilenceDetector` | Throttled by `SILENCE_LIMIT_SEC` |
+| `NUDGE soft` / `NUDGE interrupt` | log-only + tmux send to agent pane | `actions.soft` / `actions.interrupt` | Per phase `reNudgeMin` |
+| `nudges-exhausted` | `MAESTRO-ALERT … kind=nudges-exhausted` | `handlePhaseStall` | One alert per phase, until phase advances |
+| `pr-comments-stuck` | `MAESTRO-ALERT … kind=pr-comments-stuck` | `handlePrComments` | One alert until comment count or HEAD changes |
+| `commit-stall NNNm` | `<S> commit-stall NNNm in phase=… (threshold=TTTm)` | `runCommitStallDetector` | **Threshold-only**: emits at `[30, 60, 120, 240, 480]` minutes, at most 5 lines per stall |
+| `HEARTBEAT N active, X pr-ready, Y pr-broken, Z pr-pending, W wedged ‖ …` | log-only | `maybeEmitHeartbeat` (main loop) | Once per `HEARTBEAT_MIN` (default 30m); always emits even when nothing else changed |
+
+## Recommended Monitor filter
+
+Use this exact regex. Anything outside it is noise:
+
+```
+QUESTION-DETECTED|AUTO-RESTART|SESSION-GONE|NUDGE|MAESTRO-ALERT|pr-ready|pr-broken|wedged|WEDGED|HEARTBEAT|commit-stall
+```
+
+`pr-ready` is the **positive** signal — when you see it, the agent's PR is CLEAN and all checks are green; merge it (or hold per `[[never-auto-merge-pr]]`). `wedged` is the **escalation** signal — auto-restart loop hit its cap; operator must inspect. `HEARTBEAT` is the periodic forced re-read; never ignore it.
+
 ## Env
 
-`WORKTREES_BASE`, `REPO_NAME`, `BASE_BRANCH`, `SILENCE_LIMIT_SEC` — see plugin README.
+| Variable | Default | What it tunes |
+|---|---|---|
+| `WORKTREES_BASE` | — | Where worktrees live |
+| `REPO_NAME` | `claude-plugin-work` | Resolves to `<base>/<repo>-<ticket>` worktree path |
+| `BASE_BRANCH` | `main` | Branch the worktree forks from |
+| `SILENCE_LIMIT_SEC` | 300 | Auto-restart after this much pane silence |
+| `Q_WAIT_MIN` | 3 | Question-pending alert delay |
+| `TICK_SEC` | 60 | Daemon tick cadence |
+| `COMMIT_STALL_MIN` | 30 | Floor below which commit-stall is suppressed |
+| `PR_STATUS_RE_EMIT_MIN` | 30 | Cooldown between re-emits of same PR state |
+| `RESTART_LOOP_THRESHOLD` | 3 | Restarts within window before declaring WEDGED |
+| `RESTART_WINDOW_MIN` | 30 | Rolling window for restart-loop counter |
+| `WEDGED_QUIET_MIN` | 60 | How long to suppress restarts after WEDGED |
+| `HEARTBEAT_MIN` | 30 | Heartbeat cadence |
+
+## After launch
+
+- **Real questions** from any agent surface as `[<SESSION>] QUESTION-DETECTED: …` lines. Handle them via `tmux send-keys -t <SESSION>` against the agent pane.
+- **Silent agents** auto-restart after `SILENCE_LIMIT_SEC` (default 300s). `/work` is resumable from `.work-state.json`.
+- **PR ready** surfaces as `pr-ready` — operator merges per `[[never-auto-merge-pr]]`.
+- **PR broken** surfaces as `pr-broken` with failing-check list — orchestrator nudges the originating agent to fix.
+- **Wedged sessions** suppress further restarts; operator must inspect the pane to unwedge.
+- **Snapshot** anytime with `bash plugins/maestro/scripts/maestro-pulse.sh` (or `/pulse`).
 
 ## Anti-patterns
 
 - Do **not** kill sessions belonging to other tickets — scoped per `<TICKET>-work` only.
 - Do **not** auto-merge PRs without operator approval; the orchestrator does not call `gh pr merge`.
+- Do **not** ignore `pr-ready` — that's the positive signal you were waiting for.
+- Do **not** ignore `HEARTBEAT` — it is the periodic forced re-read that exists specifically because operators desensitize to repeated noise.
 - The inbox at `/tmp/claude-agent-inbox/<TICKET>.log` is human-facing; agents do not read it. Talk to agents via `tmux send-keys`.

--- a/plugins/synapsys/.claude-plugin/plugin.json
+++ b/plugins/synapsys/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsys",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Context-triggered memory injection. Memories declare trigger patterns + lifecycle events in frontmatter; matching memories are injected into Claude's context on the right hook.",
   "author": {
     "name": "Custom",

--- a/plugins/work/.claude-plugin/plugin.json
+++ b/plugins/work/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "work-workflow",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Self-contained workflow plugin with agents, hooks, skills, and orchestration. Includes 18 specialized agents, agent-specific hooks, and 25 skills.",
   "author": {
     "name": "Custom",


### PR DESCRIPTION
## Existing Behavior

- The maestro daemon had no positive signal for PR readiness — a CLEAN PR was indistinguishable from a wedged agent; operators had to poll `gh pr list` manually
- `commit-stall` fired every daemon tick (60s), generating hundreds of duplicate log lines that desensitized operators to real escalations
- Auto-restart could loop indefinitely on a crash-looping session with no operator notification and no suppression
- The main loop emitted no periodic summary, so a silent daemon gave no indication of how many PRs were ready, broken, or waiting
- `phase-registry.js` left CI-gate phases (`ci`, `pr`, `ready`, `follow_up`) without the `prStatus` detector, meaning PR state was never checked during the phases where it matters most

## Intended New Behavior

- A new `pr-status` detector polls `gh pr view` per ticket and emits `MAESTRO-ALERT kind=pr-ready` (or `pr-broken`) on state transitions, rate-limited by `PR_STATUS_RE_EMIT_MIN`; operators receive an unambiguous "go merge this" signal without manual polling
- `commit-stall` deduplicates against a per-ticket state marker: it fires at most once per threshold crossing (`30/60/120/240/480` min), capping the alert volume to 5 lines per stall
- A restart-loop guard in `autoRestart()` counts restarts within a rolling `RESTART_WINDOW_MIN` window; upon reaching `RESTART_LOOP_THRESHOLD`, it writes a `wedgedUntil` marker, emits `kind=wedged`, and suppresses further auto-restarts for `WEDGED_QUIET_MIN`
- The main loop emits a `HEARTBEAT` line every `HEARTBEAT_MIN` minutes summarising `N active, X pr-ready, Y pr-broken, Z pr-pending, W wedged` so operators can orient without reading every tick
- `freeCIGateSlot` auto-kills the `-work` and `-listen` tmux sessions when `pr-ready` fires in `ci`/`wait_merge` phase; idempotent per SHA; disabled via `AUTO_FREE_CI_SLOT=0`
- `phase-registry.js` adds `prStatus` to the BASE detector list (all phases) and explicit detector arrays for `pr`, `ready`, `follow_up`, and `ci` phases so PR state is tracked from the moment a branch is pushed
- `SKILL.md` documents the complete daemon event vocabulary and recommended Monitor regex; new `OPERATOR_PLAYBOOK.md` provides a reusable runbook for every signal kind

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Run the test suite for all changed detectors and actions:

```
node --test plugins/maestro/scripts/__tests__/*.test.js
```

Expected: 52/52 tests pass (12 new tests added in this bundle).

The 12 new tests cover:

- `actions-free-ci-gate-slot.test.js` — `freeCIGateSlot` idempotency per SHA, `AUTO_FREE_CI_SLOT=0` no-op, tmux kill invocation
- `detectors-commit-stall-dedup.test.js` — threshold-crossing dedup, recovery clearing marker, below-floor suppression
- `detectors-pr-status.test.js` — `classify()` matrix (`pr-ready`/`pr-broken`/`pr-pending`/null), state-transition emit, SHA-change re-emit, rate-limit suppression
- `detectors-restart-loop.test.js` — rolling window pruning, threshold-exact wedge declaration, `wedgedUntil` suppression, countdown expiry

### Env tuning table

| Variable | Default | What it tunes |
|---|---|---|
| `AUTO_FREE_CI_SLOT` | `1` (enabled) | Set to `0` to disable tmux kill on `pr-ready` at CI gate |
| `PR_STATUS_RE_EMIT_MIN` | `30` | Cooldown (minutes) between re-emits of the same PR state on the same SHA |
| `HEARTBEAT_MIN` | `30` | Cadence (minutes) of the periodic `HEARTBEAT` summary line |
| `RESTART_LOOP_THRESHOLD` | `3` | Number of auto-restarts within the window before declaring WEDGED |
| `RESTART_WINDOW_MIN` | `30` | Rolling window (minutes) for the restart-loop counter |
| `WEDGED_QUIET_MIN` | `60` | How long (minutes) to suppress restarts after declaring WEDGED |

### Test Results

All 52 tests passing. New tests: 12 (spread across 4 new test files under `plugins/maestro/scripts/__tests__/`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-kill tmux sessions and drive operator actions via GitHub CLI; behavior is env-tunable and well-tested, but mis-tuned thresholds or `AUTO_FREE_CI_SLOT` could disrupt in-flight agents.
> 
> **Overview**
> This release bumps **work-workflow** to **3.16.0** and **maestro** (plus synapsys/heimdall) to **0.2.0**, with minor marketplace JSON formatting.
> 
> **Maestro conduct daemon** gains a **`pr-status`** detector that polls GitHub for each ticket’s open PR and emits structured **`pr-ready`** / **`pr-broken`** alerts (with dedup, SHA-change re-emit, and `PR_STATUS_RE_EMIT_MIN` cooldown). **`commit-stall`** now fires only on threshold crossings (30→480m), not every tick. **`autoRestart`** adds a restart-loop guard that declares **`wedged`** and suppresses further restarts. The main loop adds periodic **`HEARTBEAT`** summaries and wires **`freeCIGateSlot`** (kill `-work`/`-listen` when green in `ci`/`wait_merge`, idempotent per SHA) and **`freeDeadEndSlot`** after repeated alerts (`DEAD_END_REEMITS`). Alerts require an **`instruction`** field, track repeat counts, and escalate from question/phase/PR-comment handlers.
> 
> **Operator tooling**: new **`OPERATOR_PLAYBOOK.md`**, expanded **`orchestrate/SKILL.md`** (event vocabulary, monitor regex, env table), **`maestro-session.js`** (priority/deps manifest + CLI), and **`active-session-reminder`** hook. **`phase-registry`** registers **`prStatus`** on base and CI/PR-related phases.
> 
> **Tests**: new Node test files for pr-status, commit-stall dedup, restart-loop, CI slot free, alert escalation, and maestro-session (PR cites 52 passing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce92a1cb12690cd9148267b556f1b327a4195407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->