### PR TITLE
feat(pr-post-generator): add fabrication-detector module and validation guard

### DIFF
--- a/plugins/work/agents/pr-post-generator.md
+++ b/plugins/work/agents/pr-post-generator.md
@@ -60,7 +60,9 @@ Use this exact wording in the PR SECTION FORMAT:
 ```
 
 Acceptable `Status` values when no artifact is present: `pending`, `not run`,
-`skipped`, `n/a`, `—`. If every row is `pending`, that is correct and the
+`skipped`, `n/a`. Blank or dash placeholders (`—`, `-`, `""`) are NOT
+accepted — the validator treats them as verdict claims and will block. If
+every row is `pending`, that is correct and the
 validator will allow it. Inventing a `PASS`/`FAIL` to "fill the table" is
 fabrication and the `pr-post-generator-validator` will block the PR with exit
 code 2.

--- a/plugins/work/agents/pr-post-generator.md
+++ b/plugins/work/agents/pr-post-generator.md
@@ -28,6 +28,47 @@ You enhance PR descriptions with visual documentation and test results AFTER the
 - Screenshots are uploaded to the wiki page ONLY
 - The PR gets a **link** to the wiki page, NOT embedded images
 
+## FABRICATION GUARD
+
+**Test-evidence rule (zero tolerance):** every `PASS`, `FAIL`, "stability run",
+"10/10", or "N/N stability" claim you put in the PR body MUST be quotable
+verbatim from a file in `${TASK_DIR}` — specifically `tests.check.md`,
+`completion.check.md`, or a file explicitly named in your input. If the line
+you want to write does not exist as text in one of those files, you MUST NOT
+write it.
+
+**Explicitly forbidden phrases (never invent these):**
+- `10/10` (and any `N/N` or `N/N stability` run count)
+- `N/N stability`
+- `stability run`, `stable across N runs`, "ran the suite 10 times", etc.
+- Any `PASS` or `FAIL` row whose `Test` column text is not a literal substring
+  of `tests.check.md` or `completion.check.md`
+
+**These claims are ONLY allowed when a matching artifact exists in `${TASK_DIR}`:**
+- A `stability*.log` or `stability*.md` file backs a stability-run claim, OR
+- `tests.check.md` contains the exact `PASS`/`FAIL` row text as a substring.
+
+**When there is no artifact for a row, write `pending` (never invent PASS/FAIL).**
+Use this exact wording in the PR SECTION FORMAT:
+
+```markdown
+## Test Results
+
+| Test | Status | Notes |
+|------|--------|-------|
+| modal opens on click | pending | awaiting tests.check.md |
+```
+
+Acceptable `Status` values when no artifact is present: `pending`, `not run`,
+`skipped`, `n/a`, `—`. If every row is `pending`, that is correct and the
+validator will allow it. Inventing a `PASS`/`FAIL` to "fill the table" is
+fabrication and the `pr-post-generator-validator` will block the PR with exit
+code 2.
+
+**Do not extrapolate.** If your input says "tests were run" but no
+`tests.check.md` row covers a given assertion, write `pending` for that row —
+do not infer the result from CI green or from "the code looks correct".
+
 ## WORKFLOW
 
 ### Step 1: Find task reports and screenshots
@@ -256,8 +297,12 @@ See [PROJ-XXX Screenshots](https://github.com/REPO/wiki/PROJ-XXX) for visual ver
 
 | Test | Status | Notes |
 |------|--------|-------|
-| [Feature-specific test only] | PASS/FAIL | [Brief note] |
+| [Feature-specific test only] | pending | awaiting tests.check.md |
 ```
+
+Use the literal status from `tests.check.md` / `completion.check.md` — or
+`pending` if no artifact backs the row. See **FABRICATION GUARD** above; the
+validator will block on invented `PASS`/`FAIL` rows or `N/N stability` claims.
 
 **IMPORTANT - What to INCLUDE in test results:**
 - Only test results for the TICKET'S REQUIREMENTS

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.integration.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.integration.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { detectFabrication } = require('../fabrication-detector');
+
+test('integration: real temp taskDir with tests.check.md sources a PASS row', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fabdet-int-'));
+  fs.writeFileSync(
+    path.join(dir, 'tests.check.md'),
+    '# checks\n- modal opens on click: verified locally\n',
+    'utf8'
+  );
+  const prBody = [
+    '## Test Results',
+    '',
+    '| Test | Status | Notes |',
+    '| --- | --- | --- |',
+    '| modal opens on click | PASS | covered by E2E |',
+    '',
+  ].join('\n');
+  const { violations } = detectFabrication(prBody, dir);
+  assert.equal(violations.length, 0);
+});
+
+test('integration: real temp taskDir without artifacts flags an unsourced PASS row', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fabdet-int-'));
+  const prBody = [
+    '## Test Results',
+    '',
+    '| Test | Status | Notes |',
+    '| --- | --- | --- |',
+    '| user can log in | PASS | smoke verified |',
+    '',
+  ].join('\n');
+  const { violations } = detectFabrication(prBody, dir);
+  assert.ok(violations.some((v) => v.reason === 'unsourced-test-row'));
+});

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { detectFabrication } = require('../fabrication-detector');
+
+function makeTaskDir(files = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fabdet-'));
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), content, 'utf8');
+  }
+  return dir;
+}
+
+test('case A: stability claim with no artifact yields stability-claim violation', () => {
+  const dir = makeTaskDir();
+  const prBody = 'This change is verified with 10/10 stability run across CI.';
+  const { violations } = detectFabrication(prBody, dir);
+  assert.ok(violations.length >= 1, 'expected at least one violation');
+  const stab = violations.find((v) => v.reason === 'stability-claim');
+  assert.ok(stab, 'expected a stability-claim violation');
+  assert.match(stab.phrase, /10\/10|stability/i);
+});
+
+test('case B: only-pending Test Results table yields zero violations', () => {
+  const dir = makeTaskDir();
+  const prBody = [
+    '## Test Results',
+    '',
+    '| Test | Status | Notes |',
+    '| --- | --- | --- |',
+    '| modal opens on click | pending | awaiting |',
+    '| login flow | not run | — |',
+    '| signup flow | skipped | n/a |',
+    '| dashboard render | n/a | — |',
+    '| nav link | — | — |',
+    '',
+  ].join('\n');
+  const { violations } = detectFabrication(prBody, dir);
+  assert.equal(violations.length, 0);
+});
+
+test('case C: PASS row supported by tests.check.md substring yields zero violations', () => {
+  const dir = makeTaskDir({
+    'tests.check.md': 'Verified: modal opens on click — passed in CI.\n',
+  });
+  const prBody = [
+    '## Test Results',
+    '',
+    '| Test | Status | Notes |',
+    '| --- | --- | --- |',
+    '| modal opens on click | PASS | covered by E2E |',
+    '',
+  ].join('\n');
+  const { violations } = detectFabrication(prBody, dir);
+  assert.equal(violations.length, 0);
+});
+
+test('Unsourced PASS row under Test Results', () => {
+  const dir = makeTaskDir({
+    'tests.check.md': 'No matching content here.\n',
+  });
+  const prBody = [
+    '## Test Results',
+    '',
+    '| Test | Status | Notes |',
+    '| --- | --- | --- |',
+    '| user can log in | PASS | smoke verified |',
+    '',
+  ].join('\n');
+  const { violations } = detectFabrication(prBody, dir);
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].reason, 'unsourced-test-row');
+  assert.match(violations[0].suggestion, /pending/i);
+});

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
@@ -113,6 +113,16 @@ test('Empty or dash Status no longer bypasses sourcing', () => {
   }
 });
 
+test('Bare 10/10 in a calendar date does NOT trip a stability violation', () => {
+  // Calendar dates like 10/10/2026 used to false-positive on the bare 10/10
+  // regex. Now the pattern requires no trailing `/` or digit.
+  const dir = makeTaskDir();
+  const prBody = 'Scheduled rollout on 10/10/2026. No stability claims here.';
+  const { violations } = detectFabrication(prBody, dir);
+  const stab = violations.find((v) => v.reason === 'stability-claim');
+  assert.ok(!stab, 'expected no stability-claim violation for calendar date 10/10/2026');
+});
+
 test('Unsourced row with synonym status (ok/passed/green) trips a violation', () => {
   // Previously only `pass`/`fail` were cross-checked; any other verdict-like
   // text (passed, ok, green, success, verified) silently bypassed the guard.

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
@@ -60,6 +60,26 @@ test('case C: PASS row supported by tests.check.md substring yields zero violati
   assert.equal(violations.length, 0);
 });
 
+test('empty stability artifact does NOT suppress stability-claim violation', () => {
+  // An empty (or whitespace-only) stability.log placeholder must not pass as
+  // evidence — otherwise the guard is bypassable by `touch stability.log`.
+  const dir = makeTaskDir({ 'stability.log': '   \n\n' });
+  const prBody = 'Verified with 10/10 stability run on CI.';
+  const { violations } = detectFabrication(prBody, dir);
+  const stab = violations.find((v) => v.reason === 'stability-claim');
+  assert.ok(stab, 'expected stability-claim violation despite empty artifact');
+});
+
+test('substantive stability artifact suppresses stability-claim violation', () => {
+  const dir = makeTaskDir({
+    'stability.log': 'iter 1 ok\niter 2 ok\niter 3 ok\niter 4 ok\niter 5 ok\n',
+  });
+  const prBody = 'Verified with 10/10 stability run on CI.';
+  const { violations } = detectFabrication(prBody, dir);
+  const stab = violations.find((v) => v.reason === 'stability-claim');
+  assert.ok(!stab, 'expected no stability-claim violation when artifact has content');
+});
+
 test('Unsourced PASS row under Test Results', () => {
   const dir = makeTaskDir({
     'tests.check.md': 'No matching content here.\n',

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
@@ -70,6 +70,19 @@ test('empty stability artifact does NOT suppress stability-claim violation', () 
   assert.ok(stab, 'expected stability-claim violation despite empty artifact');
 });
 
+test('incidental "10/10" mention in tests.check.md does NOT clear stability violation', () => {
+  // Past behavior: any substring match in tests.check.md cleared the claim.
+  // That was bypassable: a warning like "never write 10/10 without proof"
+  // would suppress R11. Now stability claims require a real stability artifact.
+  const dir = makeTaskDir({
+    'tests.check.md': 'Reminder: do not write 10/10 without a stability log.\n',
+  });
+  const prBody = 'Verified with 10/10 stability run on CI.';
+  const { violations } = detectFabrication(prBody, dir);
+  const stab = violations.find((v) => v.reason === 'stability-claim');
+  assert.ok(stab, 'expected stability-claim violation despite incidental phrase in tests.check.md');
+});
+
 test('substantive stability artifact suppresses stability-claim violation', () => {
   const dir = makeTaskDir({
     'stability.log': 'iter 1 ok\niter 2 ok\niter 3 ok\niter 4 ok\niter 5 ok\n',

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
@@ -37,7 +37,7 @@ test('case B: only-pending Test Results table yields zero violations', () => {
     '| login flow | not run | — |',
     '| signup flow | skipped | n/a |',
     '| dashboard render | n/a | — |',
-    '| nav link | — | — |',
+    '| nav link | pending | — |',
     '',
   ].join('\n');
   const { violations } = detectFabrication(prBody, dir);
@@ -91,6 +91,26 @@ test('substantive stability artifact suppresses stability-claim violation', () =
   const { violations } = detectFabrication(prBody, dir);
   const stab = violations.find((v) => v.reason === 'stability-claim');
   assert.ok(!stab, 'expected no stability-claim violation when artifact has content');
+});
+
+test('Empty or dash Status no longer bypasses sourcing', () => {
+  // Previously '', '-', '—' were in ALLOWED_STATUSES, so a row could leave
+  // Status blank and smuggle verdict language into Notes. Now those values
+  // must be sourced like any other claim.
+  const dir = makeTaskDir({ 'tests.check.md': 'unrelated content\n' });
+  for (const status of ['', '-', '—']) {
+    const prBody = [
+      '## Test Results',
+      '',
+      '| Test | Status | Notes |',
+      '| --- | --- | --- |',
+      `| sneaky verdict in notes | ${status} | works in prod |`,
+      '',
+    ].join('\n');
+    const { violations } = detectFabrication(prBody, dir);
+    const row = violations.find((v) => v.reason === 'unsourced-test-row');
+    assert.ok(row, `expected unsourced-test-row violation for status="${status}"`);
+  }
 });
 
 test('Unsourced row with synonym status (ok/passed/green) trips a violation', () => {

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
@@ -93,6 +93,25 @@ test('substantive stability artifact suppresses stability-claim violation', () =
   assert.ok(!stab, 'expected no stability-claim violation when artifact has content');
 });
 
+test('Unsourced row with synonym status (ok/passed/green) trips a violation', () => {
+  // Previously only `pass`/`fail` were cross-checked; any other verdict-like
+  // text (passed, ok, green, success, verified) silently bypassed the guard.
+  const dir = makeTaskDir({ 'tests.check.md': 'unrelated content\n' });
+  for (const status of ['passed', 'ok', 'green', 'success', 'verified']) {
+    const prBody = [
+      '## Test Results',
+      '',
+      '| Test | Status | Notes |',
+      '| --- | --- | --- |',
+      `| feature X works | ${status} | manual |`,
+      '',
+    ].join('\n');
+    const { violations } = detectFabrication(prBody, dir);
+    const row = violations.find((v) => v.reason === 'unsourced-test-row');
+    assert.ok(row, `expected unsourced-test-row violation for status="${status}"`);
+  }
+});
+
 test('Unsourced PASS row under Test Results', () => {
   const dir = makeTaskDir({
     'tests.check.md': 'No matching content here.\n',

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.integration.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.integration.test.js
@@ -1,0 +1,270 @@
+'use strict';
+
+/**
+ * Integration tests for pr-post-generator-validator.js hook.
+ *
+ * Spawns the hook with child_process.spawn (matching the
+ * pr-generator/__tests__ pattern). The hook depends on three external
+ * commands — `gh`, `git`, and `node <REPO_DIR>/scripts/get-affected.js` —
+ * which we stub by prepending a temp bin directory to PATH and by pointing
+ * WORKTREES_BASE/REPO_NAME/APPS_DIR at temp scaffolding.
+ *
+ * These tests exercise the fabrication-check wiring (Task 2):
+ *   case A — fabricated "10/10 stability run" + no artifact → exit 2
+ *   case B — only-pending Test Results body → exit 0
+ *   case C — body claim sourced by tests.check.md → exit 0
+ *   case D — zero affected frontend apps + fabrication phrase → still exit 2
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const HOOK_PATH = path.join(__dirname, '..', 'pr-post-generator-validator.js');
+
+const TICKET_ID = 'GH-401';
+const TICKET_BRANCH = 'GH-401-fabrication-guard';
+
+let SANDBOX;
+let TASKS_BASE;
+let WORKTREES_BASE;
+let REPO_DIR;
+let APPS_DIR;
+let BIN_DIR;
+
+const AGENT_OUTPUT_STUB =
+  'PR updated via gh pr edit; wiki link present at https://github.com/example/repo/wiki/GH-401. ' +
+  'Screenshots uploaded to wiki. This filler keeps the payload above the 50-char minimum.';
+
+function writeStubBin(name, body) {
+  const filePath = path.join(BIN_DIR, name);
+  fs.writeFileSync(filePath, body, { mode: 0o755 });
+  fs.chmodSync(filePath, 0o755);
+}
+
+function setStubs({ prBody, affectedJson }) {
+  // gh — only `gh pr view --json body -q .body` is invoked.
+  // Quote body so newlines survive heredoc indirection.
+  writeStubBin(
+    'gh',
+    `#!/usr/bin/env bash\ncat <<'__PR_BODY_EOF__'\n${prBody}\n__PR_BODY_EOF__\n`
+  );
+  // git — only `git branch --show-current` is invoked by the new fabrication wiring.
+  writeStubBin('git', `#!/usr/bin/env bash\necho '${TICKET_BRANCH}'\n`);
+  // get-affected.js — invoked via `node <REPO_DIR>/scripts/get-affected.js main json`.
+  // We stamp a stub script the validator can exec.
+  const getAffectedDir = path.join(REPO_DIR, 'scripts');
+  fs.mkdirSync(getAffectedDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(getAffectedDir, 'get-affected.js'),
+    `process.stdout.write(${JSON.stringify(JSON.stringify(affectedJson))});\n`,
+    'utf8'
+  );
+}
+
+function runHook(payload) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', [HOOK_PATH], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        PATH: `${BIN_DIR}${path.delimiter}${process.env.PATH || ''}`,
+        WORKTREES_BASE,
+        REPO_NAME: 'my-project',
+        APPS_DIR,
+        TASKS_BASE,
+        TICKET_PROVIDER: 'github',
+      },
+    });
+
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    proc.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+    proc.on('error', reject);
+    proc.on('close', (code) => resolve({ code, stdout, stderr }));
+    proc.stdin.write(JSON.stringify(payload));
+    proc.stdin.end();
+  });
+}
+
+function loadActions() {
+  const actionsPath = path.join(TASKS_BASE, TICKET_ID, '.work-actions.json');
+  try {
+    return JSON.parse(fs.readFileSync(actionsPath, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function resetTaskDir() {
+  const taskDir = path.join(TASKS_BASE, TICKET_ID);
+  if (fs.existsSync(taskDir)) {
+    fs.rmSync(taskDir, { recursive: true, force: true });
+  }
+  fs.mkdirSync(taskDir, { recursive: true });
+}
+
+before(() => {
+  SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-post-val-int-'));
+  TASKS_BASE = path.join(SANDBOX, 'tasks');
+  WORKTREES_BASE = path.join(SANDBOX, 'worktrees');
+  REPO_DIR = path.join(WORKTREES_BASE, 'my-project');
+  APPS_DIR = path.join(REPO_DIR, 'apps');
+  BIN_DIR = path.join(SANDBOX, 'bin');
+
+  fs.mkdirSync(TASKS_BASE, { recursive: true });
+  fs.mkdirSync(APPS_DIR, { recursive: true });
+  fs.mkdirSync(BIN_DIR, { recursive: true });
+});
+
+after(() => {
+  if (SANDBOX && fs.existsSync(SANDBOX)) {
+    fs.rmSync(SANDBOX, { recursive: true, force: true });
+  }
+});
+
+describe('pr-post-generator-validator: fabrication check', () => {
+  it('PR body contains fabricated stability claim with no artifact', async () => {
+    resetTaskDir();
+    // One frontend app so the legacy path can run, but the fabrication check
+    // should fire BEFORE that and gate the whole hook.
+    fs.mkdirSync(path.join(APPS_DIR, 'web'), { recursive: true });
+    fs.writeFileSync(path.join(APPS_DIR, 'web', 'react-router.config.ts'), 'export default {};\n');
+
+    const prBody = [
+      '## Summary',
+      'Adds GH-401 fabrication guard.',
+      '',
+      'Verified with 10/10 stability run on CI.',
+      '',
+      '[wiki](https://github.com/example/repo/wiki/GH-401)',
+    ].join('\n');
+
+    setStubs({ prBody, affectedJson: ['web'] });
+
+    const { code, stderr } = await runHook({
+      agent_name: 'pr-post-generator',
+      agent_output: AGENT_OUTPUT_STUB,
+    });
+
+    assert.equal(code, 2, `expected exit 2, got ${code}; stderr=\n${stderr}`);
+    assert.match(
+      stderr,
+      /10\/10/,
+      `expected stderr to surface the offending phrase; got:\n${stderr}`
+    );
+    assert.match(
+      stderr,
+      /[╔╗╚╝═║]/,
+      `expected box-drawn ASCII failure block; got:\n${stderr}`
+    );
+
+    const actions = loadActions();
+    const fab = actions.filter((a) => a && a.type === 'fabrication-block');
+    assert.ok(
+      fab.length >= 1,
+      `expected at least one fabrication-block row in .work-actions.json; got ${JSON.stringify(actions)}`
+    );
+  });
+
+  it('PR body contains only pending placeholders', async () => {
+    resetTaskDir();
+    // Frontend app present + wiki link in PR body so the existing visual-doc
+    // checks are satisfied and the hook can reach exit 0.
+    fs.mkdirSync(path.join(APPS_DIR, 'web'), { recursive: true });
+    fs.writeFileSync(path.join(APPS_DIR, 'web', 'react-router.config.ts'), 'export default {};\n');
+
+    const prBody = [
+      '## Summary',
+      'Adds GH-401 fabrication guard.',
+      '',
+      '[wiki](https://github.com/example/repo/wiki/GH-401)',
+      '',
+      '## Test Results',
+      '',
+      '| Test | Status | Notes |',
+      '| --- | --- | --- |',
+      '| modal opens on click | pending | awaiting tests.check.md |',
+      '| settings save | not run | follow-up |',
+      '',
+    ].join('\n');
+
+    setStubs({ prBody, affectedJson: ['web'] });
+
+    const { code, stderr } = await runHook({
+      agent_name: 'pr-post-generator',
+      agent_output: AGENT_OUTPUT_STUB,
+    });
+
+    assert.equal(code, 0, `expected exit 0, got ${code}; stderr=\n${stderr}`);
+  });
+
+  it('PR body claims are supported by tests.check.md', async () => {
+    resetTaskDir();
+    fs.mkdirSync(path.join(APPS_DIR, 'web'), { recursive: true });
+    fs.writeFileSync(path.join(APPS_DIR, 'web', 'react-router.config.ts'), 'export default {};\n');
+
+    fs.writeFileSync(
+      path.join(TASKS_BASE, TICKET_ID, 'tests.check.md'),
+      '# checks\n- modal opens on click: verified locally\n',
+      'utf8'
+    );
+
+    const prBody = [
+      '## Summary',
+      'Adds GH-401 fabrication guard.',
+      '',
+      '[wiki](https://github.com/example/repo/wiki/GH-401)',
+      '',
+      '## Test Results',
+      '',
+      '| Test | Status | Notes |',
+      '| --- | --- | --- |',
+      '| modal opens on click | PASS | covered by E2E |',
+      '',
+    ].join('\n');
+
+    setStubs({ prBody, affectedJson: ['web'] });
+
+    const { code, stderr } = await runHook({
+      agent_name: 'pr-post-generator',
+      agent_output: AGENT_OUTPUT_STUB,
+    });
+
+    assert.equal(code, 0, `expected exit 0, got ${code}; stderr=\n${stderr}`);
+  });
+
+  it('Backend-only change still runs the fabrication check', async () => {
+    resetTaskDir();
+    // No frontend apps registered in APPS_DIR for this case — but even if
+    // there were, get-affected returns empty so affectedFrontendApps === [].
+    const prBody = [
+      '## Summary',
+      'Adds GH-401 backend-only guard.',
+      '',
+      'Verified with 10/10 stability run on CI.',
+    ].join('\n');
+
+    setStubs({ prBody, affectedJson: [] });
+
+    const { code, stderr } = await runHook({
+      agent_name: 'pr-post-generator',
+      agent_output: AGENT_OUTPUT_STUB,
+    });
+
+    assert.equal(
+      code,
+      2,
+      `expected exit 2 (fabrication check must run before frontend early-exit); got ${code}; stderr=\n${stderr}`
+    );
+    assert.match(stderr, /10\/10/, `expected stderr to surface the offending phrase`);
+  });
+});

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.integration.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.integration.test.js
@@ -168,7 +168,7 @@ describe('pr-post-generator-validator: fabrication check', () => {
     );
 
     const actions = loadActions();
-    const fab = actions.filter((a) => a && a.type === 'fabrication-block');
+    const fab = actions.filter((a) => a && a.what === 'fabrication-block');
     assert.ok(
       fab.length >= 1,
       `expected at least one fabrication-block row in .work-actions.json; got ${JSON.stringify(actions)}`

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.integration.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.integration.test.js
@@ -242,6 +242,37 @@ describe('pr-post-generator-validator: fabrication check', () => {
     assert.equal(code, 0, `expected exit 0, got ${code}; stderr=\n${stderr}`);
   });
 
+  it('Fails closed when gh pr view fails (cannot fetch PR body)', async () => {
+    resetTaskDir();
+    // Stub `gh` so it exits non-zero — getPRBody() returns null and the
+    // validator must block (exit 2) rather than silently allow.
+    writeStubBin('gh', '#!/usr/bin/env bash\nexit 1\n');
+    writeStubBin('git', `#!/usr/bin/env bash\necho '${TICKET_BRANCH}'\n`);
+    const getAffectedDir = path.join(REPO_DIR, 'scripts');
+    fs.mkdirSync(getAffectedDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(getAffectedDir, 'get-affected.js'),
+      `process.stdout.write(${JSON.stringify(JSON.stringify([]))});\n`,
+      'utf8'
+    );
+
+    const { code, stderr } = await runHook({
+      agent_name: 'pr-post-generator',
+      agent_output: AGENT_OUTPUT_STUB,
+    });
+
+    assert.equal(
+      code,
+      2,
+      `expected exit 2 when gh pr view fails; got ${code}; stderr=\n${stderr}`
+    );
+    assert.match(
+      stderr,
+      /COULD NOT FETCH PR BODY/,
+      `expected block reason in stderr; got:\n${stderr}`
+    );
+  });
+
   it('Backend-only change still runs the fabrication check', async () => {
     resetTaskDir();
     // No frontend apps registered in APPS_DIR for this case — but even if

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.integration.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.integration.test.js
@@ -65,19 +65,24 @@ function setStubs({ prBody, affectedJson }) {
   );
 }
 
-function runHook(payload) {
+function runHook(payload, envOverrides = {}) {
   return new Promise((resolve, reject) => {
+    const baseEnv = {
+      ...process.env,
+      PATH: `${BIN_DIR}${path.delimiter}${process.env.PATH || ''}`,
+      WORKTREES_BASE,
+      REPO_NAME: 'my-project',
+      APPS_DIR,
+      TASKS_BASE,
+      TICKET_PROVIDER: 'github',
+    };
+    for (const [k, v] of Object.entries(envOverrides)) {
+      if (v === undefined) delete baseEnv[k];
+      else baseEnv[k] = v;
+    }
     const proc = spawn('node', [HOOK_PATH], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        PATH: `${BIN_DIR}${path.delimiter}${process.env.PATH || ''}`,
-        WORKTREES_BASE,
-        REPO_NAME: 'my-project',
-        APPS_DIR,
-        TASKS_BASE,
-        TICKET_PROVIDER: 'github',
-      },
+      env: baseEnv,
     });
 
     let stdout = '';
@@ -271,6 +276,30 @@ describe('pr-post-generator-validator: fabrication check', () => {
       /COULD NOT FETCH PR BODY/,
       `expected block reason in stderr; got:\n${stderr}`
     );
+  });
+
+  it('Runs fabrication check even when TASKS_BASE is unset', async () => {
+    resetTaskDir();
+    const prBody = [
+      '## Summary',
+      'Adds GH-401 fabrication guard.',
+      '',
+      'Verified with 10/10 stability run on CI.',
+    ].join('\n');
+
+    setStubs({ prBody, affectedJson: [] });
+
+    const { code, stderr } = await runHook(
+      { agent_name: 'pr-post-generator', agent_output: AGENT_OUTPUT_STUB },
+      { TASKS_BASE: undefined }
+    );
+
+    assert.equal(
+      code,
+      2,
+      `expected exit 2 even without TASKS_BASE; got ${code}; stderr=\n${stderr}`
+    );
+    assert.match(stderr, /10\/10/, `expected stderr to surface the offending phrase`);
   });
 
   it('Backend-only change still runs the fabrication check', async () => {

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.test.js
@@ -16,12 +16,9 @@ const WORKFLOW_COPY = path.join(
 );
 
 function readResolved(filePath) {
-  // Resolve symlinks (workflow copy may be a symlink to the agent file)
-  const stat = fs.lstatSync(filePath);
-  const target = stat.isSymbolicLink()
-    ? path.resolve(path.dirname(filePath), fs.readlinkSync(filePath))
-    : filePath;
-  return fs.readFileSync(target, 'utf8');
+  // fs.readFileSync follows symlinks atomically — no separate stat/readlink
+  // step (avoids TOCTOU race flagged by CodeQL).
+  return fs.readFileSync(filePath, 'utf8');
 }
 
 describe('agent prompt — FABRICATION GUARD', () => {

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/pr-post-generator-validator.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../../../../..');
+const AGENT_PROMPT = path.join(
+  REPO_ROOT,
+  'plugins/work/agents/pr-post-generator.md'
+);
+const WORKFLOW_COPY = path.join(
+  REPO_ROOT,
+  'plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator.md'
+);
+
+function readResolved(filePath) {
+  // Resolve symlinks (workflow copy may be a symlink to the agent file)
+  const stat = fs.lstatSync(filePath);
+  const target = stat.isSymbolicLink()
+    ? path.resolve(path.dirname(filePath), fs.readlinkSync(filePath))
+    : filePath;
+  return fs.readFileSync(target, 'utf8');
+}
+
+describe('agent prompt — FABRICATION GUARD', () => {
+  test('Agent prompt edits prevent regeneration of fabricated content', () => {
+    const content = readResolved(AGENT_PROMPT);
+    // The agent prompt must contain the FABRICATION GUARD section, a pending
+    // example row, and an explicit prohibition of 10/10 or N/N stability
+    // phrasing. Together these prevent the agent from regenerating fabricated
+    // test-evidence content.
+    assert.match(content, /FABRICATION GUARD/, 'missing FABRICATION GUARD');
+    assert.match(content, /\|\s*[^|]+\|\s*pending\s*\|/i, 'missing pending example row');
+    const hasProhibition =
+      /10\/10/.test(content) || /N\/N\s+stability/i.test(content);
+    assert.ok(hasProhibition, 'missing prohibition of 10/10 or N/N stability phrasing');
+    // R16 — workflow-referenced copy must mirror the same content.
+    assert.ok(fs.existsSync(WORKFLOW_COPY), 'workflow copy must exist (currently broken symlink)');
+    assert.match(readResolved(WORKFLOW_COPY), /FABRICATION GUARD/, 'workflow copy missing FABRICATION GUARD');
+  });
+
+  test('AC6/R1 — pr-post-generator.md contains FABRICATION GUARD section', () => {
+    const content = readResolved(AGENT_PROMPT);
+    assert.match(
+      content,
+      /FABRICATION GUARD/,
+      'agent prompt must contain FABRICATION GUARD section'
+    );
+  });
+
+  test('AC6/R1 — pr-post-generator.md contains a pending example row', () => {
+    const content = readResolved(AGENT_PROMPT);
+    assert.match(
+      content,
+      /\|\s*[^|]+\|\s*pending\s*\|/i,
+      'agent prompt must include a pending example row demonstrating the correct rewrite'
+    );
+  });
+
+  test('AC6/R2 — pr-post-generator.md prohibits 10/10 or N/N stability phrasing', () => {
+    const content = readResolved(AGENT_PROMPT);
+    const hasProhibition =
+      /10\/10/.test(content) || /N\/N\s+stability/i.test(content);
+    assert.ok(
+      hasProhibition,
+      'agent prompt must explicitly prohibit 10/10 or N/N stability phrasing'
+    );
+  });
+
+  test('R16 — workflow-referenced copy resolves and contains FABRICATION GUARD', () => {
+    // File must exist (currently broken symlink) and resolve to content
+    assert.ok(
+      fs.existsSync(WORKFLOW_COPY),
+      `workflow copy must exist at ${WORKFLOW_COPY} (currently a broken symlink)`
+    );
+    const content = readResolved(WORKFLOW_COPY);
+    assert.match(
+      content,
+      /FABRICATION GUARD/,
+      'workflow copy must contain FABRICATION GUARD section (R16)'
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -68,22 +68,35 @@ function hasStabilityArtifact(taskDir, claimText) {
 }
 
 function checkStabilityClaims(prBody, taskDir) {
-  const violations = [];
-  const seen = new Set();
+  // Collect all matches across the overlapping STABILITY_REGEXES, then dedup
+  // by character range: if a new match's [start, end) overlaps any already-
+  // accepted range, drop it. Prefer longer matches when ranges overlap so a
+  // phrase like "10/10 stability run" yields one violation, not three.
+  const candidates = [];
   for (const re of STABILITY_REGEXES) {
-    for (const match of prBody.matchAll(re)) {
-      const phrase = match[0];
-      const key = `${match.index}:${phrase}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      if (hasStabilityArtifact(taskDir, phrase)) continue;
-      violations.push({
-        phrase,
-        reason: 'stability-claim',
-        suggestion:
-          'Remove the stability claim or attach a stability*.log/stability*.md artifact in the task folder.',
-      });
+    for (const m of prBody.matchAll(re)) {
+      candidates.push({ start: m.index, end: m.index + m[0].length, phrase: m[0] });
     }
+  }
+  candidates.sort((a, b) => b.end - b.start - (a.end - a.start));
+
+  const accepted = [];
+  const overlaps = (a, b) => a.start < b.end && b.start < a.end;
+  for (const c of candidates) {
+    if (accepted.some((a) => overlaps(a, c))) continue;
+    accepted.push(c);
+  }
+  accepted.sort((a, b) => a.start - b.start);
+
+  const violations = [];
+  for (const c of accepted) {
+    if (hasStabilityArtifact(taskDir, c.phrase)) continue;
+    violations.push({
+      phrase: c.phrase,
+      reason: 'stability-claim',
+      suggestion:
+        'Remove the stability claim or attach a stability*.log/stability*.md artifact in the task folder.',
+    });
   }
   return violations;
 }

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -55,11 +55,19 @@ function safeReaddir(dirPath) {
   }
 }
 
+// Minimum non-whitespace bytes required for a stability artifact to count as
+// real evidence. An empty or whitespace-only placeholder file must not
+// suppress the violation — that would make the guard trivially bypassable by
+// dropping `touch stability.log` in the task folder.
+const STABILITY_ARTIFACT_MIN_BYTES = 16;
+
 function hasStabilityArtifact(taskDir, claimText) {
   if (!taskDir) return false;
   const entries = safeReaddir(taskDir);
   for (const entry of entries) {
-    if (STABILITY_ARTIFACT_PATTERNS.some((re) => re.test(entry))) return true;
+    if (!STABILITY_ARTIFACT_PATTERNS.some((re) => re.test(entry))) continue;
+    const content = safeReadFile(path.join(taskDir, entry));
+    if (content && content.trim().length >= STABILITY_ARTIFACT_MIN_BYTES) return true;
   }
   // tests.check.md containing the literal claim text also counts as evidence.
   const checks = safeReadFile(path.join(taskDir, 'tests.check.md'));

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -28,7 +28,10 @@ const path = require('node:path');
 const STABILITY_REGEXES = [
   /\b\d+\/\d+\s+(stability|stable|runs?)\b/gi,
   /\bstability\s+run\b/gi,
-  /\b10\/10\b/gi,
+  // Bare "10/10" only matches when NOT followed by another `/` or digit, so
+  // calendar dates like `10/10/2026` and longer ratios like `10/100` are not
+  // misclassified as stability claims.
+  /\b10\/10\b(?![/\d])/gi,
 ];
 
 const STABILITY_ARTIFACT_PATTERNS = [/^stability.*\.log$/i, /^stability.*\.md$/i];

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -83,29 +83,32 @@ function checkStabilityClaims(prBody, taskDir) {
   return violations;
 }
 
+function parseTableRow(line) {
+  const m = line.match(TABLE_ROW);
+  if (!m) return null;
+  const cells = m[1].split('|').map((c) => c.trim());
+  if (cells.length < 2) return null;
+  if (cells.every((c) => /^[-:\s]*$/.test(c))) return null;
+  if (cells[0].toLowerCase() === 'test') return null;
+  return { test: cells[0], status: cells[1], notes: cells[2] || '' };
+}
+
 function parseTestResultsRows(prBody) {
   const lines = prBody.split(/\r?\n/);
   const rows = [];
   let inSection = false;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  for (const line of lines) {
     if (TEST_RESULTS_HEADING.test(line)) {
       inSection = true;
       continue;
     }
-    if (inSection && ANY_H2.test(line) && !TEST_RESULTS_HEADING.test(line)) {
+    if (inSection && ANY_H2.test(line)) {
       inSection = false;
       continue;
     }
     if (!inSection) continue;
-    const m = line.match(TABLE_ROW);
-    if (!m) continue;
-    const cells = m[1].split('|').map((c) => c.trim());
-    if (cells.length < 2) continue;
-    // Skip header/separator rows: header is non-status text; separator has only dashes.
-    if (cells.every((c) => /^[-:\s]*$/.test(c))) continue;
-    if (cells[0].toLowerCase() === 'test') continue;
-    rows.push({ test: cells[0], status: cells[1], notes: cells[2] || '' });
+    const row = parseTableRow(line);
+    if (row) rows.push(row);
   }
   return rows;
 }

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -1,0 +1,150 @@
+'use strict';
+
+/**
+ * fabrication-detector.js
+ *
+ * Pure-function detector for fabricated test evidence in PR bodies.
+ *
+ * Exports `detectFabrication(prBody, taskDir)` which returns
+ *   { violations: [{ phrase, reason, suggestion }] }
+ *
+ * Rules:
+ *  R11 — Flag stability claims ("10/10", "N/N stability|stable|runs",
+ *        "stability run") when no stability artifact exists in taskDir.
+ *  R12 — Flag PASS/FAIL rows under "## Test Results" whose Test column is
+ *        not present as a literal substring in tests.check.md or
+ *        completion.check.md.
+ *  R13 — Rows with Status pending|not run|skipped|n/a|— are always allowed.
+ *  R14 — fs read errors → treat artifact as absent (fail-open for reads,
+ *        which produces violations for unsourced claims — the safer default).
+ *
+ * Only allowed `reason` values: 'stability-claim' | 'unsourced-test-row'.
+ * CommonJS, zero runtime deps.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const STABILITY_REGEXES = [
+  /\b\d+\/\d+\s+(stability|stable|runs?)\b/i,
+  /\bstability\s+run\b/i,
+  /\b10\/10\b/i,
+];
+
+const STABILITY_ARTIFACT_PATTERNS = [/^stability.*\.log$/i, /^stability.*\.md$/i];
+
+const ALLOWED_STATUSES = new Set(['pending', 'not run', 'skipped', 'n/a', '—', '-', '']);
+
+const TEST_RESULTS_HEADING = /^##\s+Test Results\s*$/i;
+const ANY_H2 = /^##\s+/;
+const TABLE_ROW = /^\s*\|(.+)\|\s*$/;
+
+function safeReadFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function safeReaddir(dirPath) {
+  try {
+    return fs.readdirSync(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+function hasStabilityArtifact(taskDir, claimText) {
+  if (!taskDir) return false;
+  const entries = safeReaddir(taskDir);
+  for (const entry of entries) {
+    if (STABILITY_ARTIFACT_PATTERNS.some((re) => re.test(entry))) return true;
+  }
+  // tests.check.md containing the literal claim text also counts as evidence.
+  const checks = safeReadFile(path.join(taskDir, 'tests.check.md'));
+  if (checks && claimText && checks.includes(claimText)) return true;
+  return false;
+}
+
+function checkStabilityClaims(prBody, taskDir) {
+  const violations = [];
+  for (const re of STABILITY_REGEXES) {
+    const m = prBody.match(re);
+    if (!m) continue;
+    if (hasStabilityArtifact(taskDir, m[0])) continue;
+    violations.push({
+      phrase: m[0],
+      reason: 'stability-claim',
+      suggestion:
+        'Remove the stability claim or attach a stability*.log/stability*.md artifact in the task folder.',
+    });
+  }
+  return violations;
+}
+
+function parseTestResultsRows(prBody) {
+  const lines = prBody.split(/\r?\n/);
+  const rows = [];
+  let inSection = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (TEST_RESULTS_HEADING.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && ANY_H2.test(line) && !TEST_RESULTS_HEADING.test(line)) {
+      inSection = false;
+      continue;
+    }
+    if (!inSection) continue;
+    const m = line.match(TABLE_ROW);
+    if (!m) continue;
+    const cells = m[1].split('|').map((c) => c.trim());
+    if (cells.length < 2) continue;
+    // Skip header/separator rows: header is non-status text; separator has only dashes.
+    if (cells.every((c) => /^[-:\s]*$/.test(c))) continue;
+    if (cells[0].toLowerCase() === 'test') continue;
+    rows.push({ test: cells[0], status: cells[1], notes: cells[2] || '' });
+  }
+  return rows;
+}
+
+function rowIsSourced(testName, taskDir) {
+  if (!taskDir || !testName) return false;
+  const candidates = ['tests.check.md', 'completion.check.md'];
+  for (const name of candidates) {
+    const content = safeReadFile(path.join(taskDir, name));
+    if (content && content.includes(testName)) return true;
+  }
+  return false;
+}
+
+function checkTestResultsRows(prBody, taskDir) {
+  const violations = [];
+  const rows = parseTestResultsRows(prBody);
+  for (const row of rows) {
+    const statusLower = row.status.toLowerCase();
+    if (ALLOWED_STATUSES.has(statusLower)) continue;
+    if (statusLower !== 'pass' && statusLower !== 'fail') continue;
+    if (rowIsSourced(row.test, taskDir)) continue;
+    violations.push({
+      phrase: `| ${row.test} | ${row.status} |`,
+      reason: 'unsourced-test-row',
+      suggestion: `Rewrite Status to "pending" until tests.check.md or completion.check.md contains "${row.test}".`,
+    });
+  }
+  return violations;
+}
+
+function detectFabrication(prBody, taskDir) {
+  const body = typeof prBody === 'string' ? prBody : '';
+  const dir = typeof taskDir === 'string' ? taskDir : '';
+  const violations = [
+    ...checkStabilityClaims(body, dir),
+    ...checkTestResultsRows(body, dir),
+  ];
+  return { violations };
+}
+
+module.exports = { detectFabrication };

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -61,7 +61,12 @@ function safeReaddir(dirPath) {
 // dropping `touch stability.log` in the task folder.
 const STABILITY_ARTIFACT_MIN_BYTES = 16;
 
-function hasStabilityArtifact(taskDir, claimText) {
+function hasStabilityArtifact(taskDir) {
+  // Stability claims require a real stability*.log/.md artifact with
+  // substantive content. We deliberately do NOT honor a tests.check.md
+  // substring fallback: warnings or negations that incidentally mention a
+  // phrase like "10/10" would otherwise clear the violation. The agent prompt
+  // mandates the stability log if a stability claim is made.
   if (!taskDir) return false;
   const entries = safeReaddir(taskDir);
   for (const entry of entries) {
@@ -69,9 +74,6 @@ function hasStabilityArtifact(taskDir, claimText) {
     const content = safeReadFile(path.join(taskDir, entry));
     if (content && content.trim().length >= STABILITY_ARTIFACT_MIN_BYTES) return true;
   }
-  // tests.check.md containing the literal claim text also counts as evidence.
-  const checks = safeReadFile(path.join(taskDir, 'tests.check.md'));
-  if (checks && claimText && checks.includes(claimText)) return true;
   return false;
 }
 
@@ -98,7 +100,7 @@ function checkStabilityClaims(prBody, taskDir) {
 
   const violations = [];
   for (const c of accepted) {
-    if (hasStabilityArtifact(taskDir, c.phrase)) continue;
+    if (hasStabilityArtifact(taskDir)) continue;
     violations.push({
       phrase: c.phrase,
       reason: 'stability-claim',

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -33,7 +33,11 @@ const STABILITY_REGEXES = [
 
 const STABILITY_ARTIFACT_PATTERNS = [/^stability.*\.log$/i, /^stability.*\.md$/i];
 
-const ALLOWED_STATUSES = new Set(['pending', 'not run', 'skipped', 'n/a', '—', '-', '']);
+// Only explicit pending-like words count as "no verdict claimed". Empty cells
+// or dash placeholders are NOT allowed — otherwise a row can leave Status
+// blank and smuggle verdict language into Notes, bypassing the sourcing
+// check. The agent prompt requires "pending" explicitly.
+const ALLOWED_STATUSES = new Set(['pending', 'not run', 'skipped', 'n/a']);
 
 const TEST_RESULTS_HEADING = /^##\s+Test Results\s*$/i;
 const ANY_H2 = /^##\s+/;

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -156,8 +156,11 @@ function checkTestResultsRows(prBody, taskDir) {
   const rows = parseTestResultsRows(prBody);
   for (const row of rows) {
     const statusLower = row.status.toLowerCase();
+    // Allowed (pending-like) statuses never produce a violation. Every other
+    // status — pass, fail, passed, ok, green, success, verified, etc. — is
+    // treated as a verdict claim that must be sourced. Whitelisting only
+    // `pass`/`fail` previously let synonyms slip through the guard.
     if (ALLOWED_STATUSES.has(statusLower)) continue;
-    if (statusLower !== 'pass' && statusLower !== 'fail') continue;
     if (rowIsSourced(row.test, taskDir)) continue;
     violations.push({
       phrase: `| ${row.test} | ${row.status} |`,

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -26,9 +26,9 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const STABILITY_REGEXES = [
-  /\b\d+\/\d+\s+(stability|stable|runs?)\b/i,
-  /\bstability\s+run\b/i,
-  /\b10\/10\b/i,
+  /\b\d+\/\d+\s+(stability|stable|runs?)\b/gi,
+  /\bstability\s+run\b/gi,
+  /\b10\/10\b/gi,
 ];
 
 const STABILITY_ARTIFACT_PATTERNS = [/^stability.*\.log$/i, /^stability.*\.md$/i];
@@ -69,16 +69,21 @@ function hasStabilityArtifact(taskDir, claimText) {
 
 function checkStabilityClaims(prBody, taskDir) {
   const violations = [];
+  const seen = new Set();
   for (const re of STABILITY_REGEXES) {
-    const m = prBody.match(re);
-    if (!m) continue;
-    if (hasStabilityArtifact(taskDir, m[0])) continue;
-    violations.push({
-      phrase: m[0],
-      reason: 'stability-claim',
-      suggestion:
-        'Remove the stability claim or attach a stability*.log/stability*.md artifact in the task folder.',
-    });
+    for (const match of prBody.matchAll(re)) {
+      const phrase = match[0];
+      const key = `${match.index}:${phrase}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (hasStabilityArtifact(taskDir, phrase)) continue;
+      violations.push({
+        phrase,
+        reason: 'stability-claim',
+        suggestion:
+          'Remove the stability claim or attach a stability*.log/stability*.md artifact in the task folder.',
+      });
+    }
   }
   return violations;
 }

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
@@ -249,6 +249,10 @@ async function main() {
   } else if (ticketId) {
     const taskDir = path.join(tasksBase, ticketId);
     runFabricationCheck(prBody, taskDir, ticketId);
+  } else {
+    process.stderr.write(
+      'PR-POST-GENERATOR VALIDATOR: could not extract ticket ID from branch name (expected /[A-Z]+-[0-9]+/); skipping fabrication check (fail-open).\n'
+    );
   }
 
   // ========== CHECK IF FRONTEND APPS ARE AFFECTED ==========

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
@@ -199,6 +199,24 @@ async function main() {
   const prBody = getPRBody();
   const ticketId = getCurrentTaskId();
   const tasksBase = getConfig('TASKS_BASE');
+  // Fail-closed when the PR body cannot be fetched: a transient `gh` failure
+  // must not become a silent bypass for fabricated test evidence. Empty body
+  // (`""`) is fine — nothing to scan — but `null` means we never saw the body.
+  if (prBody === null) {
+    process.stderr.write(`
+╔══════════════════════════════════════════════════════════════════════╗
+║  POST-PR-GENERATOR: COULD NOT FETCH PR BODY                          ║
+╠══════════════════════════════════════════════════════════════════════╣
+║                                                                      ║
+║  \`gh pr view --json body\` failed; fabrication check cannot run.      ║
+║  Blocking to avoid silently accepting unverified PR content.         ║
+║                                                                      ║
+║  Re-run after confirming \`gh\` auth and PR association.               ║
+║                                                                      ║
+╚══════════════════════════════════════════════════════════════════════╝
+`);
+    process.exit(2);
+  }
   if (!tasksBase) {
     process.stderr.write(
       'PR-POST-GENERATOR VALIDATOR: TASKS_BASE not configured; skipping fabrication check (fail-open).\n'

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
@@ -72,41 +72,15 @@ ${lines.map((l) => `║  ${l.padEnd(66)}║`).join('\n')}
 `);
 
   if (ticketId) {
-    const tasksBase = getConfig('TASKS_BASE');
-    if (tasksBase) {
-      const actionsPath = path.join(tasksBase, ticketId, '.work-actions.json');
-      for (const v of violations) {
-        try {
-          // appendAction normalizes to {step, timestamp, what, meta}, but the
-          // contract here is "row carries top-level type === 'fabrication-block'"
-          // so we append directly. Fail-open: never let logging crash the hook.
-          const dir = path.dirname(actionsPath);
-          if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-          let rows = [];
-          try {
-            rows = JSON.parse(fs.readFileSync(actionsPath, 'utf8'));
-            if (!Array.isArray(rows)) rows = [];
-          } catch {
-            rows = [];
-          }
-          rows.push({
-            type: 'fabrication-block',
-            timestamp: new Date().toISOString(),
-            step: 'pr',
-            phrase: v.phrase,
-            reason: v.reason,
-          });
-          fs.writeFileSync(actionsPath, JSON.stringify(rows, null, 2));
-        } catch {
-          // fail-open
-        }
-      }
-      // Also call appendAction for the standard action log (spec R7).
+    // Route audit rows through appendAction so they land in the same file as
+    // every other action log (safeId-sanitized path). One row per violation
+    // — analytics can count by `what === 'fabrication-block'`.
+    for (const v of violations) {
       try {
         appendAction(ticketId, {
           step: 'pr',
           what: 'fabrication-block',
-          meta: { reasons: violations.map((v) => v.reason) },
+          meta: { phrase: v.phrase, reason: v.reason },
         });
       } catch {
         // fail-open

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
@@ -63,7 +63,7 @@ function runFabricationCheck(prBody, taskDir, ticketId) {
 ║  POST-PR-GENERATOR: FABRICATED TEST EVIDENCE DETECTED                ║
 ╠══════════════════════════════════════════════════════════════════════╣
 ║                                                                      ║
-${lines.map((l) => `║  ${l.padEnd(66)}║`).join('\n')}
+${lines.map((l) => `║  ${l.padEnd(68)}║`).join('\n')}
 ║  Remove invented PASS/FAIL or stability claims, or attach the        ║
 ║  supporting artifact (tests.check.md / stability*.log) to the task   ║
 ║  folder before re-running the agent.                                 ║

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
@@ -16,10 +16,106 @@ const fs = require('fs');
 const path = require('path');
 
 const getConfig = require(path.join(__dirname, '..', '..', '..', 'lib', 'get-config'));
+const { detectFabrication } = require('./fabrication-detector');
+const { appendAction } = require(path.join(__dirname, '..', '..', '..', 'work', 'lib', 'work-actions'));
 const WORKTREES_BASE = getConfig.orExit('WORKTREES_BASE');
 const REPO_NAME = getConfig('REPO_NAME') || 'my-project';
 const REPO_DIR = path.join(WORKTREES_BASE, REPO_NAME);
 const APPS_DIR = process.env.APPS_DIR || path.join(REPO_DIR, 'apps');
+
+/**
+ * Resolve the active ticket ID from the current git branch, returning the
+ * first `[A-Z]+-[0-9]+` match. Returns null if git fails or no match.
+ */
+function getTicketIdFromBranch() {
+  try {
+    const branch = execSync('git branch --show-current', {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const m = branch.match(/[A-Z]+-[0-9]+/);
+    return m ? m[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the fabrication-detector against the live PR body and emit a
+ * box-drawn ASCII failure block + `appendAction({type:'fabrication-block'})`
+ * rows when violations exist. Exits the process with code 2 on violation.
+ * Fail-open: missing TASKS_BASE → stderr warning + return (caller continues).
+ */
+function runFabricationCheck(prBody, taskDir, ticketId) {
+  if (!prBody) return;
+  const { violations } = detectFabrication(prBody, taskDir || '');
+  if (!violations || violations.length === 0) return;
+
+  const lines = violations.flatMap((v) => [
+    `Phrase:      ${v.phrase}`,
+    `Reason:      ${v.reason}`,
+    `Suggestion:  ${v.suggestion}`,
+    '',
+  ]);
+  process.stderr.write(`
+╔══════════════════════════════════════════════════════════════════════╗
+║  POST-PR-GENERATOR: FABRICATED TEST EVIDENCE DETECTED                ║
+╠══════════════════════════════════════════════════════════════════════╣
+║                                                                      ║
+${lines.map((l) => `║  ${l.padEnd(66)}║`).join('\n')}
+║  Remove invented PASS/FAIL or stability claims, or attach the        ║
+║  supporting artifact (tests.check.md / stability*.log) to the task   ║
+║  folder before re-running the agent.                                 ║
+║                                                                      ║
+╚══════════════════════════════════════════════════════════════════════╝
+`);
+
+  if (ticketId) {
+    const tasksBase = getConfig('TASKS_BASE');
+    if (tasksBase) {
+      const actionsPath = path.join(tasksBase, ticketId, '.work-actions.json');
+      for (const v of violations) {
+        try {
+          // appendAction normalizes to {step, timestamp, what, meta}, but the
+          // contract here is "row carries top-level type === 'fabrication-block'"
+          // so we append directly. Fail-open: never let logging crash the hook.
+          const dir = path.dirname(actionsPath);
+          if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+          let rows = [];
+          try {
+            rows = JSON.parse(fs.readFileSync(actionsPath, 'utf8'));
+            if (!Array.isArray(rows)) rows = [];
+          } catch {
+            rows = [];
+          }
+          rows.push({
+            type: 'fabrication-block',
+            timestamp: new Date().toISOString(),
+            step: 'pr',
+            phrase: v.phrase,
+            reason: v.reason,
+          });
+          fs.writeFileSync(actionsPath, JSON.stringify(rows, null, 2));
+        } catch {
+          // fail-open
+        }
+      }
+      // Also call appendAction for the standard action log (spec R7).
+      try {
+        appendAction(ticketId, {
+          step: 'pr',
+          what: 'fabrication-block',
+          meta: { reasons: violations.map((v) => v.reason) },
+        });
+      } catch {
+        // fail-open
+      }
+    }
+  }
+
+  process.exit(2);
+}
 
 /**
  * Check if an app is a frontend app by looking for react-router.config.ts
@@ -142,17 +238,29 @@ async function main() {
   const issues = [];
   const warnings = [];
 
+  // ========== FABRICATION CHECK (runs FIRST, regardless of frontend status) ==========
+  const prBody = getPRBody();
+  const ticketId = getTicketIdFromBranch();
+  const tasksBase = getConfig('TASKS_BASE');
+  if (!tasksBase) {
+    process.stderr.write(
+      'PR-POST-GENERATOR VALIDATOR: TASKS_BASE not configured; skipping fabrication check (fail-open).\n'
+    );
+  } else if (ticketId) {
+    const taskDir = path.join(tasksBase, ticketId);
+    runFabricationCheck(prBody, taskDir, ticketId);
+  }
+
   // ========== CHECK IF FRONTEND APPS ARE AFFECTED ==========
   const affectedApps = getAffectedApps();
   const affectedFrontendApps = getAffectedFrontendApps(affectedApps || []);
 
   if (affectedFrontendApps.length === 0) {
-    // Backend-only changes - images not required
+    // Backend-only changes - images not required (visual-doc checks only)
     process.exit(0);
   }
 
-  // ========== FETCH ACTUAL PR BODY AND VERIFY VISUAL DOCUMENTATION ==========
-  const prBody = getPRBody();
+  // ========== VERIFY VISUAL DOCUMENTATION (frontend only) ==========
   if (prBody) {
     const hasLink = hasWikiLink(prBody);
 

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
@@ -18,28 +18,11 @@ const path = require('path');
 const getConfig = require(path.join(__dirname, '..', '..', '..', 'lib', 'get-config'));
 const { detectFabrication } = require('./fabrication-detector');
 const { appendAction } = require(path.join(__dirname, '..', '..', '..', 'work', 'lib', 'work-actions'));
+const { getCurrentTaskId } = require(path.join(__dirname, '..', '..', '..', 'lib', 'scripts', 'get-ticket-id'));
 const WORKTREES_BASE = getConfig.orExit('WORKTREES_BASE');
 const REPO_NAME = getConfig('REPO_NAME') || 'my-project';
 const REPO_DIR = path.join(WORKTREES_BASE, REPO_NAME);
 const APPS_DIR = process.env.APPS_DIR || path.join(REPO_DIR, 'apps');
-
-/**
- * Resolve the active ticket ID from the current git branch, returning the
- * first `[A-Z]+-[0-9]+` match. Returns null if git fails or no match.
- */
-function getTicketIdFromBranch() {
-  try {
-    const branch = execSync('git branch --show-current', {
-      encoding: 'utf8',
-      timeout: 5000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-    const m = branch.match(/[A-Z]+-[0-9]+/);
-    return m ? m[0] : null;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Run the fabrication-detector against the live PR body and emit a
@@ -214,19 +197,23 @@ async function main() {
 
   // ========== FABRICATION CHECK (runs FIRST, regardless of frontend status) ==========
   const prBody = getPRBody();
-  const ticketId = getTicketIdFromBranch();
+  const ticketId = getCurrentTaskId();
   const tasksBase = getConfig('TASKS_BASE');
   if (!tasksBase) {
     process.stderr.write(
       'PR-POST-GENERATOR VALIDATOR: TASKS_BASE not configured; skipping fabrication check (fail-open).\n'
     );
-  } else if (ticketId) {
-    const taskDir = path.join(tasksBase, ticketId);
-    runFabricationCheck(prBody, taskDir, ticketId);
   } else {
-    process.stderr.write(
-      'PR-POST-GENERATOR VALIDATOR: could not extract ticket ID from branch name (expected /[A-Z]+-[0-9]+/); skipping fabrication check (fail-open).\n'
-    );
+    // Detection runs even without a ticketId — only the audit-log appendAction
+    // requires it. A missing ticketId yields taskDir === tasksBase, which has
+    // no tests.check.md / stability artifacts, so unsourced claims still trip.
+    const taskDir = ticketId ? path.join(tasksBase, ticketId) : tasksBase;
+    if (!ticketId) {
+      process.stderr.write(
+        'PR-POST-GENERATOR VALIDATOR: could not resolve ticket ID; running fabrication check without audit log.\n'
+      );
+    }
+    runFabricationCheck(prBody, taskDir, ticketId);
   }
 
   // ========== CHECK IF FRONTEND APPS ARE AFFECTED ==========

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
@@ -217,22 +217,21 @@ async function main() {
 `);
     process.exit(2);
   }
+  // Run the fabrication check unconditionally. Missing TASKS_BASE or ticketId
+  // must not become a silent bypass — without a task folder the detector sees
+  // no artifacts, so unsourced stability/PASS/FAIL claims still trip. Only the
+  // audit-log appendAction is skipped when ticketId is absent.
   if (!tasksBase) {
     process.stderr.write(
-      'PR-POST-GENERATOR VALIDATOR: TASKS_BASE not configured; skipping fabrication check (fail-open).\n'
+      'PR-POST-GENERATOR VALIDATOR: TASKS_BASE not configured; running fabrication check without task folder (no audit log).\n'
     );
-  } else {
-    // Detection runs even without a ticketId — only the audit-log appendAction
-    // requires it. A missing ticketId yields taskDir === tasksBase, which has
-    // no tests.check.md / stability artifacts, so unsourced claims still trip.
-    const taskDir = ticketId ? path.join(tasksBase, ticketId) : tasksBase;
-    if (!ticketId) {
-      process.stderr.write(
-        'PR-POST-GENERATOR VALIDATOR: could not resolve ticket ID; running fabrication check without audit log.\n'
-      );
-    }
-    runFabricationCheck(prBody, taskDir, ticketId);
+  } else if (!ticketId) {
+    process.stderr.write(
+      'PR-POST-GENERATOR VALIDATOR: could not resolve ticket ID; running fabrication check without audit log.\n'
+    );
   }
+  const taskDir = tasksBase && ticketId ? path.join(tasksBase, ticketId) : '';
+  runFabricationCheck(prBody, taskDir, ticketId);
 
   // ========== CHECK IF FRONTEND APPS ARE AFFECTED ==========
   const affectedApps = getAffectedApps();

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator.md
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator.md
@@ -1,1 +1,1 @@
-../../../../agents/pr-post-generator.md
+../../../../../agents/pr-post-generator.md


### PR DESCRIPTION
## Existing Behavior

- `pr-post-generator-validator.js` has no mechanism to detect fabricated test evidence in PR bodies — stability-run claims, PASS/FAIL row counts, and "10/10" phrasing were accepted regardless of whether any supporting artifact existed in the task folder.
- The agent prompt for `pr-post-generator` contained no explicit rule prohibiting the agent from synthesizing test-result claims it could not source from a file.
- The validator's early-exit logic skipped when no frontend apps were affected, meaning non-frontend PRs could bypass all checks including any future fabrication guard.

## Intended New Behavior

- A new pure-function module `fabrication-detector.js` implements four detection rules (R11–R14): flags stability claims lacking a `stability*.log`/`stability*.md` artifact, flags PASS/FAIL test-result rows whose test names are not present as substrings in `tests.check.md` or `completion.check.md`, allows rows with status `pending`/`not run`/`skipped`/`n/a`, and treats unreadable artifacts as absent (fail-safe).
- `pr-post-generator-validator.js` calls `detectFabrication(prBody, taskDir)` after fetching the live PR body and exits with code 2 on any violation, emitting a box-drawn ASCII error block naming each offending phrase, its reason, and the corrective action.
- A `fabrication-block` row is appended to `.work-actions.json` for each violation, enabling audit-time counting.
- The `pr-post-generator.md` agent prompt now contains an explicit **FABRICATION GUARD** section forbidding invented PASS/FAIL and stability-run claims and specifying the correct `pending` wording to use when no artifact is present.
- The validator's frontend-only early-exit is restructured so the fabrication check runs unconditionally for all PRs, regardless of whether frontend apps are affected.

## Brief P0 coverage

- **P0 #1:** Agent prompt MUST NOT synthesize test-result claims without artifact support — implemented in `plugins/work/agents/pr-post-generator.md` (FABRICATION GUARD section) + symlinked into `plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator.md`
- **P0 #2:** Agent prompt forbids stability-run/N-of-N/10-of-10 claims without stability artifact — implemented in `plugins/work/agents/pr-post-generator.md` (FABRICATION GUARD section, "Explicitly forbidden phrases" block)
- **P0 #3:** Validator detects fabricated evidence and exits 2 — implemented in `plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js` (`runFabricationCheck`) + `fabrication-detector.js` (R11/R12)
- **P0 #4:** Validator cross-references PR body against task folder artifacts, not agent chat output — implemented in `fabrication-detector.js` via `safeReadFile(path.join(taskDir, 'tests.check.md'))` and `safeReaddir(taskDir)` filesystem reads
- **P0 #5:** Unit tests for 3 fabrication paths — implemented in `plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js` (fabricated stability claim → exit 2; pending-only body → exit 0; claim backed by tests.check.md → exit 0)

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Fabrication blocked scenario (validator exits 2):**
1. In a worktree running the `pr` step for any ticket, ensure no `tests.check.md` or `stability*.log` exists in the task folder.
2. Trigger `pr-post-generator` (SubagentStop hook fires automatically after the agent completes).
3. If the agent synthesized a "Test Results" table with PASS/FAIL rows or any "10/10 stability" wording, the validator emits the box-drawn ASCII error block to stderr and exits 2, blocking the SubagentStop.
4. The offending phrase and corrective suggestion are printed; a `fabrication-block` entry appears in `<TASKS_BASE>/<TICKET>/.work-actions.json`.

**Approved scenario (validator exits 0):**
1. Same setup, but the agent writes `pending` in the Status column for all unverified rows (matching the new prompt guidance).
2. Validator runs `detectFabrication` — no violations found — exits 0, SubagentStop proceeds normally.

**Artifact-backed scenario (validator exits 0):**
1. Place a `tests.check.md` in the task folder containing the exact test name and PASS verdict.
2. Agent writes a matching row; `fabrication-detector.js` finds the test name as a substring in the artifact — no violation — exits 0.

### Test Results

Unit tests added under `plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/`:
- `fabrication-detector.test.js` — covers R11/R12/R13/R14 detection rules and all 3 P0 scenarios
- `fabrication-detector.integration.test.js` — exercises filesystem reads against real temp directories
- `pr-post-generator-validator.test.js` — validator wiring: fabrication check fires after PR body fetch
- `pr-post-generator-validator.integration.test.js` — end-to-end validator behavior with mocked `gh` CLI

Additionally, `plugins/work/scripts/workflows/lib/hooks/policies/__tests__/evidence-recorder.test.js` covers the `evidence-recorder.js` policy added to the hook pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SubagentStop hook behavior (exit 2 on gh failures and fabricated claims) and gates all PRs, not only frontend—workflow failures are possible until agents use `pending` or real artifacts.
> 
> **Overview**
> Adds a **fabrication guard** so PR post-generation cannot claim test evidence without task-folder artifacts.
> 
> **`fabrication-detector.js`** scans the live PR body for unsourced stability wording (`10/10`, `N/N stability`, etc.) and for verdict-like rows under `## Test Results`, cross-checking test names against `tests.check.md` / `completion.check.md` and stability claims against substantive `stability*.log` / `stability*.md` files.
> 
> **`pr-post-generator-validator.js`** runs that check first for every PR (including backend-only and missing `TASKS_BASE`), **fails closed** when `gh pr view` cannot return the body, exits **2** with a boxed error on violations, and logs **`fabrication-block`** rows via `appendAction`. Frontend wiki-link checks still run only when frontend apps are affected.
> 
> The **`pr-post-generator`** agent prompt gains a **FABRICATION GUARD** section (use `pending` instead of invented PASS/FAIL); the workflow symlink target is fixed. Unit and integration tests cover detector edge cases and full hook behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56558614080af90ea071b91de1b50f355ce9203b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

close #401 