### PR TITLE
feat(maestro): action-required alerts + CI-gate slot rotation + session manifest

### DIFF
--- a/plugins/maestro/docs/OPERATOR_PLAYBOOK.md
+++ b/plugins/maestro/docs/OPERATOR_PLAYBOOK.md
@@ -1,0 +1,68 @@
+# maestro operator playbook
+
+You are operating the maestro daemon (`scripts/maestro-conduct.js --daemon`)
+across one or more `/work` agents. The daemon does NOT make decisions for you —
+it surfaces signals and you act on them. This doc is the contract for how to
+read those signals.
+
+## The daemon's event vocabulary
+
+The daemon emits exactly these signals to its sinks (`/tmp/maestro-conduct.log`,
+`/tmp/maestro-alerts.jsonl`, and the `maestro-alerts` tmux session).
+**Subscribe to all of them.** See `skills/orchestrate/SKILL.md` for the
+canonical Monitor regex.
+
+| Signal | Meaning | Operator action |
+|---|---|---|
+| `QUESTION-DETECTED` | An agent has a menu or permission prompt sitting unanswered | Capture the agent pane, read every menu option, pick the one that is not a bypass |
+| `MAESTRO-ALERT … kind=pr-ready` | All CI checks SUCCESS and `mergeStateStatus=CLEAN` | Run the bypass checker (`work-workflow:code-checker` against the diff) before merging. On APPROVED, the PR is yours to merge or hand to your operator |
+| `MAESTRO-ALERT … kind=pr-broken` | A check is failing or merge state is DIRTY | Identify the failing checks, drive the originating agent to fix in this PR (do not defer to a follow-up) |
+| `MAESTRO-ALERT … kind=wedged` | A session has been auto-restarted ≥3 times in 30m — daemon will not restart it for the next 60m | Inspect the pane manually. Diagnose why /work keeps dying |
+| `MAESTRO-ALERT … kind=nudges-exhausted` | A phase exceeded its budget past `maxNudges` | Surface to operator — the agent may be genuinely stuck |
+| `MAESTRO-ALERT … kind=pr-comments-stuck` | Unaddressed bot review comments on the agent's PR with no new HEAD | Direct the agent to address them in this PR |
+| `MAESTRO-ALERT … kind=question-pending` | Question sat ≥`Q_WAIT_MIN` minutes | Same as QUESTION-DETECTED — pick the legitimate option |
+| `commit-stall NNNm (threshold=TTTm)` | Worktree had no new commits across one of the thresholds (`30/60/120/240/480` by default) | If agent is in `implement` and threshold escalated → capture pane. If agent is in `wait_merge`/`complete` → ignore, expected |
+| `NUDGE soft` / `NUDGE interrupt` | Daemon already poked the agent's pane | No operator action — daemon handles escalation |
+| `AUTO-RESTART after Ns silence` | Daemon relaunched a dead `-work` session | Only act if a `wedged` alert follows |
+| `AUTO-RESTART skipped: non-work helper` | Throttled log when an idle `-listen` or `-dev` pane was checked | Ignore — informational |
+| `HEARTBEAT N active, X pr-ready, Y pr-broken, Z pr-pending, W wedged \| <per-ticket>` | Periodic summary, default every 30m | **Re-read it.** This is the forced re-check that exists because operators desensitize to noisy ticks. If `X >= 1` and you have not yet surfaced those PRs, do it now |
+
+## Anti-patterns that cause operators to fail
+
+1. **Reading the line shape, not the value.** `commit-stall 30m → 60m → 120m → 240m → 480m` looks the same; the number is the signal. Always read the number.
+2. **Treating silence as "nothing to do."** A silent agent is either (a) shipped and waiting for merge or (b) wedged. The daemon emits `pr-ready` for (a). If you see no `pr-ready`, no `nudges-exhausted`, and no `QUESTION-DETECTED`, but an agent has been silent — poll `gh pr list --state open` for the ticket's branch. Verify positively; don't assume.
+3. **Approving the menu option the agent labelled "Recommended"** without reading the others. The agent's recommendation does not override the no-bypass rules. Read every option; pick the legitimate one even if the agent flagged it as higher-risk.
+4. **Editing files in the agent's worktree.** Communicate via `tmux send-keys` to the `-work` pane, or via the `/tmp/claude-agent-inbox/<TICKET>.log` mailbox if your agent listens there.
+5. **Re-running CI to "see if it goes green this time."** Diagnose the failure; fix the root cause.
+
+## The pr-ready playbook (every time)
+
+When `MAESTRO-ALERT kind=pr-ready` lands:
+
+1. Spawn the bypass-checker against the diff. The check must answer ONE question: is this PR trying to bypass any /work workflow gate (TDD evidence, completion check, set-step CLI, fake state files, commit-hook skipping, transition-through bypass)?
+2. Watch the checker's verdict (`APPROVED` / `NEEDS-WORK`).
+3. **APPROVED:** surface the PR URL to the human operator. **Never call `gh pr merge`** — the operator merges.
+4. **NEEDS-WORK:** capture the checker's verbatim findings and forward them to the originating `/work` agent via `tmux send-keys -t <TICKET>-work`. Re-run the checker after the agent pushes again.
+
+Every new commit on the PR head needs a fresh check. Do not approve once and assume the next force-push is still clean.
+
+## The question playbook (every time)
+
+When `QUESTION-DETECTED` lands:
+
+1. `tmux capture-pane -t <TICKET>-work -p | tail -40` — read the full menu, not just the alert summary.
+2. Research before answering — check repository docs, skill `SKILL.md` files, and the codebase for the symbol in question. Do not answer from memory.
+3. Pick the option that does NOT bypass any workflow gate.
+4. If all menu options bypass, send the agent a directive via "Type something" pointing at the legitimate path (rewind via /work, cache hot-patch + file a bug, ship-as-is with rationale, etc.).
+
+## Slot rotation
+
+When an agent's PR is in `pr-ready` AND the bypass checker has APPROVED it, that agent's slot is effectively free — it sits in `wait_merge` doing nothing while it waits for human merge. You may bootstrap another ticket into a new slot at that point. Do not kill the existing tmux session; let it persist so the agent can pick up review comments after the operator merges (or doesn't).
+
+## When you're unsure
+
+Ask the operator. Do not invent state. Do not edit `.work-state.json` directly. Do not call `work-state.js set-step`. Those are bypass attempts and the next bypass-check will catch them.
+
+## Tuning
+
+All thresholds are env-tunable — see `skills/orchestrate/SKILL.md` for the full table. The defaults are conservative; loosen them in CI / dev shells and tighten them in long-running sessions.

--- a/plugins/maestro/docs/OPERATOR_PLAYBOOK.md
+++ b/plugins/maestro/docs/OPERATOR_PLAYBOOK.md
@@ -15,12 +15,12 @@ canonical Monitor regex.
 | Signal | Meaning | Operator action |
 |---|---|---|
 | `QUESTION-DETECTED` | An agent has a menu or permission prompt sitting unanswered | Capture the agent pane, read every menu option, pick the one that is not a bypass |
-| `MAESTRO-ALERT … kind=pr-ready` | All CI checks SUCCESS and `mergeStateStatus=CLEAN` | Run the bypass checker (`work-workflow:code-checker` against the diff) before merging. On APPROVED, the PR is yours to merge or hand to your operator |
-| `MAESTRO-ALERT … kind=pr-broken` | A check is failing or merge state is DIRTY | Identify the failing checks, drive the originating agent to fix in this PR (do not defer to a follow-up) |
-| `MAESTRO-ALERT … kind=wedged` | A session has been auto-restarted ≥3 times in 30m — daemon will not restart it for the next 60m | Inspect the pane manually. Diagnose why /work keeps dying |
-| `MAESTRO-ALERT … kind=nudges-exhausted` | A phase exceeded its budget past `maxNudges` | Surface to operator — the agent may be genuinely stuck |
-| `MAESTRO-ALERT … kind=pr-comments-stuck` | Unaddressed bot review comments on the agent's PR with no new HEAD | Direct the agent to address them in this PR |
-| `MAESTRO-ALERT … kind=question-pending` | Question sat ≥`Q_WAIT_MIN` minutes | Same as QUESTION-DETECTED — pick the legitimate option |
+| `ACTION … kind=pr-ready` | All CI checks SUCCESS and `mergeStateStatus=CLEAN` | Run the bypass checker (`work-workflow:code-checker` against the diff) before merging. On APPROVED, the PR is yours to merge or hand to your operator |
+| `ACTION … kind=pr-broken` | A check is failing or merge state is DIRTY | Identify the failing checks, drive the originating agent to fix in this PR (do not defer to a follow-up) |
+| `ACTION … kind=wedged` | A session has been auto-restarted ≥3 times in 30m — daemon will not restart it for the next 60m | Inspect the pane manually. Diagnose why /work keeps dying |
+| `ACTION … kind=nudges-exhausted` | A phase exceeded its budget past `maxNudges` | Surface to operator — the agent may be genuinely stuck |
+| `ACTION … kind=pr-comments-stuck` | Unaddressed bot review comments on the agent's PR with no new HEAD | Direct the agent to address them in this PR |
+| `ACTION … kind=question-pending` | Question sat ≥`Q_WAIT_MIN` minutes | Same as QUESTION-DETECTED — pick the legitimate option |
 | `commit-stall NNNm (threshold=TTTm)` | Worktree had no new commits across one of the thresholds (`30/60/120/240/480` by default) | If agent is in `implement` and threshold escalated → capture pane. If agent is in `wait_merge`/`complete` → ignore, expected |
 | `NUDGE soft` / `NUDGE interrupt` | Daemon already poked the agent's pane | No operator action — daemon handles escalation |
 | `AUTO-RESTART after Ns silence` | Daemon relaunched a dead `-work` session | Only act if a `wedged` alert follows |
@@ -37,7 +37,7 @@ canonical Monitor regex.
 
 ## The pr-ready playbook (every time)
 
-When `MAESTRO-ALERT kind=pr-ready` lands:
+When `ACTION kind=pr-ready` lands:
 
 1. Spawn `work-workflow:code-checker` against the PR diff inside a tmux session and keep it alive until verdict. The check must answer FOUR questions:
    1. **Completion** — did the agent finish every requirement / AC declared in the ticket?

--- a/plugins/maestro/docs/OPERATOR_PLAYBOOK.md
+++ b/plugins/maestro/docs/OPERATOR_PLAYBOOK.md
@@ -39,8 +39,12 @@ canonical Monitor regex.
 
 When `MAESTRO-ALERT kind=pr-ready` lands:
 
-1. Spawn the bypass-checker against the diff. The check must answer ONE question: is this PR trying to bypass any /work workflow gate (TDD evidence, completion check, set-step CLI, fake state files, commit-hook skipping, transition-through bypass)?
-2. Watch the checker's verdict (`APPROVED` / `NEEDS-WORK`).
+1. Spawn `work-workflow:code-checker` against the PR diff inside a tmux session and keep it alive until verdict. The check must answer FOUR questions:
+   1. **Completion** — did the agent finish every requirement / AC declared in the ticket?
+   2. **Bugs** — did it introduce any logic error, regression, or broken edge case?
+   3. **Vulnerabilities** — did it add any security issue (injection, secret leak, unsafe shell, path traversal, unbounded input)?
+   4. **Bypass** — did it dodge any /work workflow gate (state-file edits, set-step CLI, completion-checker skip, fake TDD evidence, commit-hook skipping with `--no-verify`, transition-through bypass, deferral annotations added to mask a check)?
+2. Verdict is `APPROVED` only when ALL FOUR are clean. Otherwise `NEEDS-WORK`.
 3. **APPROVED:** surface the PR URL to the human operator. **Never call `gh pr merge`** — the operator merges.
 4. **NEEDS-WORK:** capture the checker's verbatim findings and forward them to the originating `/work` agent via `tmux send-keys -t <TICKET>-work`. Re-run the checker after the agent pushes again.
 

--- a/plugins/maestro/hooks/active-session-reminder.js
+++ b/plugins/maestro/hooks/active-session-reminder.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * active-session-reminder.js — UserPromptSubmit / SessionStart hook.
+ *
+ * If a maestro orchestration session is active (a manifest exists under
+ * MAESTRO_SESSION_DIR), inject a reminder block so the operator (or a fresh
+ * conversation) doesn't:
+ *   - accidentally start a second parallel orchestration
+ *   - forget the priority + dependency plan
+ *   - lose track of which tasks are in flight vs done vs pending
+ *
+ * Install (user must add to ~/.claude/settings.json — plugin can't auto-install):
+ *
+ *   "UserPromptSubmit": [{
+ *     "matcher": ".*",
+ *     "hooks": [{
+ *       "type": "command",
+ *       "command": "node /path/to/plugins/maestro/hooks/active-session-reminder.js"
+ *     }]
+ *   }]
+ *
+ * Fail-open: any error → exit 0 silently. Never block the prompt.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SESSION_DIR =
+  process.env.MAESTRO_SESSION_DIR || path.join(os.homedir(), '.cache', 'maestro', 'sessions');
+
+try {
+  if (!fs.existsSync(SESSION_DIR)) process.exit(0);
+  const files = fs.readdirSync(SESSION_DIR).filter((f) => f.endsWith('.json'));
+  if (!files.length) process.exit(0);
+
+  const lines = [
+    '[maestro] ACTIVE ORCHESTRATION SESSION(S) — do not start a parallel orchestration without checking these first:',
+  ];
+  for (const f of files) {
+    let s;
+    try {
+      s = JSON.parse(fs.readFileSync(path.join(SESSION_DIR, f), 'utf8'));
+    } catch {
+      continue;
+    }
+    const counts = { pending: 0, in_progress: 0, done: 0, blocked: 0 };
+    for (const t of s.tasks) counts[t.status] = (counts[t.status] || 0) + 1;
+    lines.push(
+      `  • ${s.topic} — slots=${s.slots} | ` +
+        `${counts.in_progress} in flight, ${counts.done}/${s.tasks.length} done, ${counts.pending} pending` +
+        (counts.blocked ? `, ${counts.blocked} blocked` : '')
+    );
+    // Show the next 3 eligible tasks (deps resolved, sorted by priority).
+    const doneIds = new Set(s.tasks.filter((t) => t.status === 'done').map((t) => t.id));
+    const eligible = s.tasks
+      .filter((t) => t.status === 'pending')
+      .filter((t) => (t.deps || []).every((d) => doneIds.has(d)))
+      .sort((a, b) => a.priority - b.priority)
+      .slice(0, 3);
+    if (eligible.length) {
+      lines.push(
+        `    next eligible: ${eligible
+          .map(
+            (t) =>
+              `${t.id}#p${t.priority}${(t.deps || []).length ? `[deps:${t.deps.join(',')}✓]` : ''}`
+          )
+          .join(', ')}`
+      );
+    }
+    const blockedByDeps = s.tasks
+      .filter((t) => t.status === 'pending')
+      .filter((t) => (t.deps || []).some((d) => !doneIds.has(d)));
+    if (blockedByDeps.length) {
+      lines.push(
+        `    waiting on deps: ${blockedByDeps
+          .slice(0, 3)
+          .map((t) => `${t.id}(needs: ${(t.deps || []).filter((d) => !doneIds.has(d)).join(',')})`)
+          .join(', ')}`
+      );
+    }
+  }
+  lines.push(
+    '  CLI: node plugins/maestro/scripts/maestro-session.js {summary|show <topic>|next <topic>|update <topic> <task> <status>|clear <topic>}'
+  );
+
+  process.stdout.write(lines.join('\n') + '\n');
+} catch {
+  /* fail-open */
+}

--- a/plugins/maestro/hooks/active-session-reminder.js
+++ b/plugins/maestro/hooks/active-session-reminder.js
@@ -25,10 +25,13 @@
 
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
 
-const SESSION_DIR =
-  process.env.MAESTRO_SESSION_DIR || path.join(os.homedir(), '.cache', 'maestro', 'sessions');
+const {
+  SESSION_DIR,
+  countByStatus,
+  doneIdSet,
+  eligibleTasks,
+} = require('../scripts/lib/maestro-conduct/session-shared');
 
 try {
   if (!fs.existsSync(SESSION_DIR)) process.exit(0);
@@ -45,20 +48,15 @@ try {
     } catch {
       continue;
     }
-    const counts = { pending: 0, in_progress: 0, done: 0, blocked: 0 };
-    for (const t of s.tasks) counts[t.status] = (counts[t.status] || 0) + 1;
+    const counts = countByStatus(s.tasks);
     lines.push(
       `  • ${s.topic} — slots=${s.slots} | ` +
         `${counts.in_progress} in flight, ${counts.done}/${s.tasks.length} done, ${counts.pending} pending` +
         (counts.blocked ? `, ${counts.blocked} blocked` : '')
     );
     // Show the next 3 eligible tasks (deps resolved, sorted by priority).
-    const doneIds = new Set(s.tasks.filter((t) => t.status === 'done').map((t) => t.id));
-    const eligible = s.tasks
-      .filter((t) => t.status === 'pending')
-      .filter((t) => (t.deps || []).every((d) => doneIds.has(d)))
-      .sort((a, b) => a.priority - b.priority)
-      .slice(0, 3);
+    const doneIds = doneIdSet(s.tasks);
+    const eligible = eligibleTasks(s.tasks).slice(0, 3);
     if (eligible.length) {
       lines.push(
         `    next eligible: ${eligible

--- a/plugins/maestro/scripts/__tests__/actions-find-next-tiebreak.test.js
+++ b/plugins/maestro/scripts/__tests__/actions-find-next-tiebreak.test.js
@@ -1,0 +1,109 @@
+// findNextEligibleTask: when two manifests have eligible tasks with the same
+// priority, the pick must be deterministic across filesystems. We stabilize
+// readdirSync order by sorting filenames, which gives a ticket-id tie-break
+// (since manifests are named after the topic/ticket).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const ACTIONS_PATH = path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'actions');
+
+function freshActions({ stateDir, alertFile, sessionDir, tmuxStub, env = {} }) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  process.env.ALERT_FILE = alertFile;
+  process.env.LOG_FILE = path.join(stateDir, '.log');
+  process.env.MAESTRO_SESSION_DIR = sessionDir;
+  delete process.env.AUTO_FREE_CI_SLOT;
+  delete process.env.AUTO_BOOTSTRAP_NEXT;
+  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+  const cp = require('child_process');
+  cp.spawnSync = (cmd, args) => {
+    if (cmd === 'tmux') {
+      tmuxStub.push({ cmd, args });
+      return { status: 0, stdout: '' };
+    }
+    return { status: 0, stdout: '' };
+  };
+  return require(ACTIONS_PATH);
+}
+
+function writeManifest(dir, name, topic, tasks) {
+  fs.writeFileSync(path.join(dir, name), JSON.stringify({ topic, tasks }));
+}
+
+test('findNextEligibleTask: equal-priority tasks broken by filename order (deterministic)', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fne-tb-'));
+  const stateDir = path.join(root, 'state');
+  const sessionDir = path.join(root, 'sessions');
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+
+  // Two manifests, two eligible tasks, SAME priority. Write the
+  // "higher" filename first so naive readdirSync order could pick either
+  // depending on FS; sorted order must always pick GH-100 (filename
+  // GH-100.json sorts before GH-200.json).
+  writeManifest(sessionDir, 'GH-200.json', 'GH-200', [
+    { id: 'task1', status: 'pending', priority: 5 },
+  ]);
+  writeManifest(sessionDir, 'GH-100.json', 'GH-100', [
+    { id: 'taskA', status: 'pending', priority: 5 },
+  ]);
+
+  const actions = freshActions({ stateDir, alertFile, sessionDir, tmuxStub });
+  // Drive findNextEligibleTask via freeCIGateSlot, which surfaces the result
+  // in the slot-freed alert's nextTopic field.
+  actions.freeCIGateSlot({ session: 'X-listen', ticket: 'X', prNumber: 1, sha: 'a' });
+
+  const alerts = fs
+    .readFileSync(alertFile, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(JSON.parse);
+  const slotFreed = alerts.find((a) => a.kind === 'slot-freed');
+  assert.ok(slotFreed, 'expected a slot-freed alert');
+  assert.equal(slotFreed.nextTopic, 'GH-100', 'tie-break must be deterministic by filename');
+});
+
+test('findNextEligibleTask: lower priority still wins regardless of filename order', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fne-pri-'));
+  const stateDir = path.join(root, 'state');
+  const sessionDir = path.join(root, 'sessions');
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+
+  // GH-100.json sorts first, but its task has WORSE (higher) priority.
+  // The lower-priority task in GH-200.json must still win — sort must not
+  // override the priority comparison.
+  writeManifest(sessionDir, 'GH-100.json', 'GH-100', [
+    { id: 'taskA', status: 'pending', priority: 9 },
+  ]);
+  writeManifest(sessionDir, 'GH-200.json', 'GH-200', [
+    { id: 'task1', status: 'pending', priority: 1 },
+  ]);
+
+  const actions = freshActions({ stateDir, alertFile, sessionDir, tmuxStub });
+  actions.freeCIGateSlot({ session: 'Y-listen', ticket: 'Y', prNumber: 2, sha: 'b' });
+
+  const alerts = fs
+    .readFileSync(alertFile, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(JSON.parse);
+  const slotFreed = alerts.find((a) => a.kind === 'slot-freed');
+  assert.ok(slotFreed);
+  assert.equal(slotFreed.nextTopic, 'GH-200', 'priority must outrank filename tie-break');
+});

--- a/plugins/maestro/scripts/__tests__/actions-free-ci-gate-slot.test.js
+++ b/plugins/maestro/scripts/__tests__/actions-free-ci-gate-slot.test.js
@@ -1,0 +1,108 @@
+// freeCIGateSlot: kill -work + -listen panes when PR is at CI gate, emit
+// kind=slot-freed alert. Idempotent per SHA. Disabled by AUTO_FREE_CI_SLOT=0.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const ACTIONS_PATH = path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'actions');
+
+function freshActions({ stateDir, alertFile, tmuxStub, env = {} }) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  process.env.ALERT_FILE = alertFile;
+  process.env.LOG_FILE = path.join(stateDir, '.log');
+  delete process.env.AUTO_FREE_CI_SLOT;
+  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+  const cp = require('child_process');
+  cp.spawnSync = (cmd, args) => {
+    if (cmd === 'tmux') {
+      tmuxStub.push({ cmd, args });
+      return { status: 0, stdout: '' };
+    }
+    return { status: 0, stdout: '' };
+  };
+  return require(ACTIONS_PATH);
+}
+
+test('freeCIGateSlot kills -work + -listen and emits slot-freed alert', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcg-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  const result = actions.freeCIGateSlot({
+    session: 'GH-9-listen',
+    ticket: 'GH-9',
+    prNumber: 999,
+    sha: 'abc123',
+  });
+
+  assert.equal(result, true);
+  const killed = tmuxStub.filter((c) => c.args[0] === 'kill-session').map((c) => c.args[2]);
+  assert.deepEqual(killed.sort(), ['GH-9-listen', 'GH-9-work']);
+
+  const lines = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
+  const slotFreed = lines.map(JSON.parse).filter((a) => a.kind === 'slot-freed');
+  assert.equal(slotFreed.length, 1);
+  assert.equal(slotFreed[0].prNumber, 999);
+  assert.equal(slotFreed[0].sha, 'abc123');
+});
+
+test('freeCIGateSlot is idempotent on the same SHA', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcg-idem-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  const args = { session: 'GH-10-listen', ticket: 'GH-10', prNumber: 10, sha: 'same' };
+  assert.equal(actions.freeCIGateSlot(args), true);
+  assert.equal(actions.freeCIGateSlot(args), false, 'second call same SHA must no-op');
+  assert.equal(actions.freeCIGateSlot(args), false);
+
+  // Only one slot-freed alert despite three calls.
+  const lines = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
+  const slotFreed = lines.map(JSON.parse).filter((a) => a.kind === 'slot-freed');
+  assert.equal(slotFreed.length, 1);
+
+  // Only one kill-session pair (2 args entries: work + listen) despite 3 calls.
+  const killed = tmuxStub.filter((c) => c.args[0] === 'kill-session');
+  assert.equal(killed.length, 2);
+});
+
+test('freeCIGateSlot re-fires when SHA changes (operator pushed a new commit)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcg-sha-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  assert.equal(
+    actions.freeCIGateSlot({ session: 's', ticket: 't', prNumber: 1, sha: 'aaa' }),
+    true
+  );
+  assert.equal(
+    actions.freeCIGateSlot({ session: 's', ticket: 't', prNumber: 1, sha: 'bbb' }),
+    true
+  );
+  const lines = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
+  const slotFreed = lines.map(JSON.parse).filter((a) => a.kind === 'slot-freed');
+  assert.equal(slotFreed.length, 2);
+});
+
+test('AUTO_FREE_CI_SLOT=0 disables the action entirely', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fcg-off-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub, env: { AUTO_FREE_CI_SLOT: '0' } });
+
+  const result = actions.freeCIGateSlot({ session: 's', ticket: 't', prNumber: 1, sha: 'x' });
+  assert.equal(result, false);
+  assert.equal(tmuxStub.length, 0, 'no tmux kill when disabled');
+  assert.equal(fs.existsSync(alertFile), false, 'no alert when disabled');
+});

--- a/plugins/maestro/scripts/__tests__/actions-free-ci-gate-slot.test.js
+++ b/plugins/maestro/scripts/__tests__/actions-free-ci-gate-slot.test.js
@@ -66,14 +66,15 @@ test('freeCIGateSlot is idempotent on the same SHA', () => {
   assert.equal(actions.freeCIGateSlot(args), false, 'second call same SHA must no-op');
   assert.equal(actions.freeCIGateSlot(args), false);
 
-  // Only one slot-freed alert despite three calls.
+  // Only one slot-freed alert despite three calls (alert is sha-idempotent).
   const lines = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
   const slotFreed = lines.map(JSON.parse).filter((a) => a.kind === 'slot-freed');
   assert.equal(slotFreed.length, 1);
 
-  // Only one kill-session pair (2 args entries: work + listen) despite 3 calls.
+  // Tmux kill fires on EVERY call (defensive against zombie sessions
+  // resurrected by autoRestart between ticks). 3 calls × 2 suffixes = 6.
   const killed = tmuxStub.filter((c) => c.args[0] === 'kill-session');
-  assert.equal(killed.length, 2);
+  assert.equal(killed.length, 6);
 });
 
 test('freeCIGateSlot re-fires when SHA changes (operator pushed a new commit)', () => {

--- a/plugins/maestro/scripts/__tests__/alerts-escalation.test.js
+++ b/plugins/maestro/scripts/__tests__/alerts-escalation.test.js
@@ -1,0 +1,106 @@
+// alerts.alert() returns {count} reflecting how many times the same
+// (session, kind, sha-or-phase) has been emitted. Used by maestro-conduct.js
+// to escalate to freeDeadEndSlot when the same alert re-fires too often.
+// Also: alerts without an `instruction` field are dropped (log-only).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const ALERTS_PATH = path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'alerts');
+
+function freshAlerts(stateDir, alertFile) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  process.env.ALERT_FILE = alertFile;
+  process.env.LOG_FILE = path.join(stateDir, '.log');
+  // Stub tmux so we don't hit the real binary.
+  const cp = require('child_process');
+  cp.spawnSync = () => ({ status: 0, stdout: '' });
+  // Stub tmux.ensureSession via the module the alerts depends on. Easiest:
+  // monkey-patch after require by also stubbing the tmux module's exports.
+  const tmuxPath = require.resolve(path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'tmux'));
+  require.cache[tmuxPath] = {
+    id: tmuxPath,
+    filename: tmuxPath,
+    loaded: true,
+    exports: { ensureSession: () => {}, sendLine: () => {} },
+  };
+  return require(ALERTS_PATH);
+}
+
+test('alert without instruction is dropped (no alert-file write)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'al-drop-'));
+  const file = path.join(dir, 'alerts.jsonl');
+  const alerts = freshAlerts(dir, file);
+  const r = alerts.alert({ session: 's', ticket: 't', kind: 'wedged' });
+  assert.equal(r.count, 0);
+  assert.equal(fs.existsSync(file), false, 'no alert file when instruction missing');
+});
+
+test('alert with instruction writes to alert file and returns count=1', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'al-1-'));
+  const file = path.join(dir, 'alerts.jsonl');
+  const alerts = freshAlerts(dir, file);
+  const r = alerts.alert({
+    session: 's',
+    ticket: 't',
+    kind: 'question-pending',
+    sha: 'abc',
+    instruction: 'capture pane and pick legitimate option',
+  });
+  assert.equal(r.count, 1);
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+  assert.equal(lines.length, 1);
+  const payload = JSON.parse(lines[0]);
+  assert.equal(payload.repeatCount, 1);
+  assert.equal(payload.instruction, 'capture pane and pick legitimate option');
+});
+
+test('repeated alert on same (session,kind,sha) increments count + prefixes instruction with [REPEAT N]', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'al-rep-'));
+  const file = path.join(dir, 'alerts.jsonl');
+  const alerts = freshAlerts(dir, file);
+  const args = {
+    session: 's',
+    ticket: 't',
+    kind: 'question-pending',
+    sha: 'aaa',
+    instruction: 'do the thing',
+  };
+  assert.equal(alerts.alert(args).count, 1);
+  assert.equal(alerts.alert(args).count, 2);
+  assert.equal(alerts.alert(args).count, 3);
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n').map(JSON.parse);
+  assert.equal(lines.length, 3);
+  assert.equal(lines[0].instruction, 'do the thing');
+  assert.equal(lines[1].instruction, '[REPEAT 2] do the thing');
+  assert.equal(lines[2].instruction, '[REPEAT 3] do the thing');
+});
+
+test('different SHA resets the count (new state, fresh emit)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'al-sha-'));
+  const file = path.join(dir, 'alerts.jsonl');
+  const alerts = freshAlerts(dir, file);
+  const base = { session: 's', ticket: 't', kind: 'pr-broken', instruction: 'fix CI' };
+  assert.equal(alerts.alert({ ...base, sha: 'aaa' }).count, 1);
+  assert.equal(alerts.alert({ ...base, sha: 'aaa' }).count, 2);
+  assert.equal(alerts.alert({ ...base, sha: 'bbb' }).count, 1, 'new SHA must start fresh');
+});
+
+test('resetCount clears a specific (session,kind,sha) key', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'al-reset-'));
+  const file = path.join(dir, 'alerts.jsonl');
+  const alerts = freshAlerts(dir, file);
+  const args = { session: 's', ticket: 't', kind: 'wedged', sha: 'x', instruction: 'inspect' };
+  alerts.alert(args);
+  alerts.alert(args);
+  alerts.resetCount(alerts.alertKey(args));
+  assert.equal(alerts.alert(args).count, 1, 'count starts at 1 after reset');
+});

--- a/plugins/maestro/scripts/__tests__/detectors-commit-stall-dedup.test.js
+++ b/plugins/maestro/scripts/__tests__/detectors-commit-stall-dedup.test.js
@@ -1,0 +1,120 @@
+// commit-stall dedup contract: emit only on threshold crossings, not every tick.
+//
+// Drive `detect()` across many simulated "minutes since last commit" values
+// and assert the detector hits exactly once per crossing of
+// `[30, 60, 120, 240, 480]`. Without dedup it would hit ~480 times for an
+// 8-hour stall — the very behaviour that desensitized the orchestrator and
+// prompted this change.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const DETECTOR_PATH = path.resolve(
+  __dirname,
+  '..',
+  'lib',
+  'maestro-conduct',
+  'detectors',
+  'commit-stall'
+);
+
+function freshDetector(stateDir, spawnSyncFake) {
+  // Wipe the entire maestro-conduct require subtree so STATE_DIR rebinds
+  // when the module re-requires state.js.
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  // Patch BEFORE requiring the detector so its `const { spawnSync } = require('child_process')`
+  // captures the fake instead of the real binding.
+  if (spawnSyncFake) {
+    const cp = require('child_process');
+    cp.spawnSync = spawnSyncFake;
+  }
+  return require(DETECTOR_PATH);
+}
+
+function makeMinutesController() {
+  const cp = require('child_process');
+  const original = cp.spawnSync;
+  const ctl = { mins: 0 };
+  ctl.spawnSync = (cmd, args, opts) => {
+    if (cmd === 'git' && Array.isArray(args) && args.includes('log')) {
+      const ct = Math.floor(Date.now() / 1000) - ctl.mins * 60;
+      return { status: 0, stdout: `${ct}\n` };
+    }
+    return original(cmd, args, opts);
+  };
+  ctl.restore = () => {
+    cp.spawnSync = original;
+  };
+  return ctl;
+}
+
+test('thresholdFor returns the highest crossed threshold (or 0 below the floor)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-th-'));
+  const { thresholdFor } = freshDetector(stateDir);
+  assert.equal(thresholdFor(0), 0);
+  assert.equal(thresholdFor(29), 0);
+  assert.equal(thresholdFor(30), 30);
+  assert.equal(thresholdFor(59), 30);
+  assert.equal(thresholdFor(60), 60);
+  assert.equal(thresholdFor(119), 60);
+  assert.equal(thresholdFor(120), 120);
+  assert.equal(thresholdFor(240), 240);
+  assert.equal(thresholdFor(480), 480);
+  assert.equal(thresholdFor(9999), 480);
+});
+
+test('detect hits exactly once per threshold crossing across 500 simulated minutes', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-cross-'));
+  const ctl = makeMinutesController();
+  const detector = freshDetector(stateDir, ctl.spawnSync);
+  try {
+    let hits = 0;
+    const observedThresholds = [];
+    // Tick every "minute" from 0..500. With dedup, expect exactly 5 hits
+    // (at 30/60/120/240/480). Without dedup we'd get ~471 hits.
+    for (let m = 0; m <= 500; m++) {
+      ctl.mins = m;
+      const r = detector.detect({ ticket: 'GH-DEDUP', worktree: '/tmp' });
+      if (r.hit) {
+        hits++;
+        observedThresholds.push(r.threshold);
+      }
+    }
+    assert.equal(hits, 5, `expected 5 threshold crossings over 500 minutes, got ${hits}`);
+    assert.deepStrictEqual(observedThresholds, [30, 60, 120, 240, 480]);
+  } finally {
+    ctl.restore();
+  }
+});
+
+test('recovery (mins back below floor) clears marker so next stall re-emits', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-recov-'));
+  const ctl = makeMinutesController();
+  const detector = freshDetector(stateDir, ctl.spawnSync);
+  try {
+    // First stall climbs to 60m and back to 0 (commit landed).
+    ctl.mins = 30;
+    assert.equal(detector.detect({ ticket: 'GH-RECOV', worktree: '/tmp' }).hit, true);
+    ctl.mins = 60;
+    assert.equal(detector.detect({ ticket: 'GH-RECOV', worktree: '/tmp' }).hit, true);
+    ctl.mins = 5; // commit landed; below floor
+    assert.equal(detector.detect({ ticket: 'GH-RECOV', worktree: '/tmp' }).hit, false);
+
+    // Second stall climbs back to 30m — the FIRST stall already announced 30m
+    // BUT recovery cleared the marker, so we re-emit on the next 30m crossing.
+    ctl.mins = 30;
+    const r = detector.detect({ ticket: 'GH-RECOV', worktree: '/tmp' });
+    assert.equal(r.hit, true, 'must re-emit at 30m after recovery cleared the marker');
+    assert.equal(r.threshold, 30);
+  } finally {
+    ctl.restore();
+  }
+});

--- a/plugins/maestro/scripts/__tests__/detectors-pr-status.test.js
+++ b/plugins/maestro/scripts/__tests__/detectors-pr-status.test.js
@@ -1,0 +1,188 @@
+// pr-status detector: emit pr-ready / pr-broken / pr-pending on transitions.
+//
+// The detector calls `gh pr list` + `gh pr view --json` and inspects the
+// statusCheckRollup + mergeStateStatus. We mock spawnSync to return shaped
+// gh-output JSON, then assert the classification and dedup behavior.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const DETECTOR_PATH = path.resolve(
+  __dirname,
+  '..',
+  'lib',
+  'maestro-conduct',
+  'detectors',
+  'pr-status'
+);
+
+function freshDetector(stateDir, ghResponses) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  process.env.PR_STATUS_RE_EMIT_MIN = '30';
+  process.env.GITHUB_REPO = 'thomfilg/claude-plugin-work';
+  // Patch spawnSync BEFORE requiring the detector so its captured reference
+  // points at the fake.
+  const cp = require('child_process');
+  cp.spawnSync = (cmd, args) => {
+    if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+      return { status: 0, stdout: ghResponses.list || '[]' };
+    }
+    if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view') {
+      return { status: 0, stdout: ghResponses.view || '{}' };
+    }
+    if (cmd === 'git') return { status: 0, stdout: '' };
+    return { status: 0, stdout: '' };
+  };
+  return require(DETECTOR_PATH);
+}
+
+function viewJson({ sha, checks, merge }) {
+  return JSON.stringify({
+    headRefOid: sha,
+    statusCheckRollup: checks,
+    mergeStateStatus: merge,
+  });
+}
+
+test('classify maps the (checks, mergeable) tuple to event kind', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-classify-'));
+  const { classify } = freshDetector(stateDir, {});
+  assert.equal(classify('SUCCESS', 'CLEAN'), 'pr-ready');
+  assert.equal(classify('SUCCESS', 'UNSTABLE'), null); // SUCCESS but not CLEAN → silent
+  assert.equal(classify('FAILURE', 'CLEAN'), 'pr-broken');
+  assert.equal(classify('FAILURE', 'DIRTY'), 'pr-broken');
+  assert.equal(classify('SUCCESS', 'DIRTY'), 'pr-broken'); // merge conflict counts as broken
+  assert.equal(classify('PENDING', 'CLEAN'), 'pr-pending');
+  assert.equal(classify('UNKNOWN', 'BLOCKED'), null); // no signal
+});
+
+test('all-SUCCESS + CLEAN emits pr-ready once, then dedups on same SHA', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-ready-'));
+  const detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 488 }]),
+    view: viewJson({
+      sha: 'abc123def',
+      checks: [
+        { name: 'Test (Node 20)', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        { name: 'CodeQL', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        { name: 'Quality', conclusion: 'SUCCESS', status: 'COMPLETED' },
+      ],
+      merge: 'CLEAN',
+    }),
+  });
+
+  // First call: state transition (no marker) → hits.
+  const r1 = detector.detect({ ticket: 'GH-400', worktree: '/tmp' });
+  assert.equal(r1.hit, true);
+  assert.equal(r1.kind, 'pr-ready');
+  assert.equal(r1.prNumber, 488);
+  assert.equal(r1.sha, 'abc123def');
+  assert.equal(r1.checksState, 'SUCCESS');
+  assert.equal(r1.mergeable, 'CLEAN');
+
+  // Second call same state same SHA → dedup'd (no hit) until RE_EMIT_MIN.
+  const r2 = detector.detect({ ticket: 'GH-400', worktree: '/tmp' });
+  assert.equal(r2.hit, false, 'same state + same SHA must not re-emit within cooldown');
+});
+
+test('failing check emits pr-broken with failingChecks populated', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-broken-'));
+  const detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 555 }]),
+    view: viewJson({
+      sha: 'badcommit',
+      checks: [
+        { name: 'Test (Node 20)', conclusion: 'SUCCESS', status: 'COMPLETED' },
+        {
+          name: 'Quality',
+          conclusion: 'FAILURE',
+          status: 'COMPLETED',
+          detailsUrl: 'https://ci.example/jobs/42',
+        },
+      ],
+      merge: 'BLOCKED',
+    }),
+  });
+  const r = detector.detect({ ticket: 'GH-BROKEN', worktree: '/tmp' });
+  assert.equal(r.hit, true);
+  assert.equal(r.kind, 'pr-broken');
+  assert.equal(r.failingChecks.length, 1);
+  assert.equal(r.failingChecks[0].name, 'Quality');
+  assert.equal(r.failingChecks[0].url, 'https://ci.example/jobs/42');
+});
+
+test('SHA change re-emits even when state is unchanged (operator pushed a new commit)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-sha-'));
+
+  // First: green at SHA "aaa".
+  let detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 100 }]),
+    view: viewJson({
+      sha: 'aaa',
+      checks: [{ name: 'CI', conclusion: 'SUCCESS', status: 'COMPLETED' }],
+      merge: 'CLEAN',
+    }),
+  });
+  assert.equal(detector.detect({ ticket: 'GH-SHA', worktree: '/tmp' }).hit, true);
+
+  // Re-require with the SAME state dir but updated gh response (new SHA).
+  detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 100 }]),
+    view: viewJson({
+      sha: 'bbb',
+      checks: [{ name: 'CI', conclusion: 'SUCCESS', status: 'COMPLETED' }],
+      merge: 'CLEAN',
+    }),
+  });
+  const r = detector.detect({ ticket: 'GH-SHA', worktree: '/tmp' });
+  assert.equal(r.hit, true, 'new SHA must re-emit even for the same kind');
+  assert.equal(r.sha, 'bbb');
+});
+
+test('pending checks classify as pr-pending (informational)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-pending-'));
+  const detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 999 }]),
+    view: viewJson({
+      sha: 'wip',
+      checks: [{ name: 'CI', conclusion: null, status: 'IN_PROGRESS' }],
+      merge: 'CLEAN',
+    }),
+  });
+  const r = detector.detect({ ticket: 'GH-PEND', worktree: '/tmp' });
+  assert.equal(r.hit, true);
+  assert.equal(r.kind, 'pr-pending');
+});
+
+test('no PR for the head ref → silent (hit=false)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-nopr-'));
+  const detector = freshDetector(stateDir, { list: '[]' });
+  const r = detector.detect({ ticket: 'GH-NOPR', worktree: '/tmp' });
+  assert.equal(r.hit, false);
+});
+
+test('SUCCESS+UNSTABLE (e.g., approval missing) is silent — no emit', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ps-unstable-'));
+  const detector = freshDetector(stateDir, {
+    list: JSON.stringify([{ number: 77 }]),
+    view: viewJson({
+      sha: 'unstable',
+      checks: [{ name: 'CI', conclusion: 'SUCCESS', status: 'COMPLETED' }],
+      merge: 'UNSTABLE',
+    }),
+  });
+  const r = detector.detect({ ticket: 'GH-UN', worktree: '/tmp' });
+  assert.equal(
+    r.hit,
+    false,
+    'UNSTABLE is not pr-ready (CLEAN required) and not broken — daemon stays quiet'
+  );
+});

--- a/plugins/maestro/scripts/__tests__/detectors-restart-loop.test.js
+++ b/plugins/maestro/scripts/__tests__/detectors-restart-loop.test.js
@@ -1,0 +1,143 @@
+// restart-loop guard inside actions.autoRestart.
+//
+// Contract: if a `-work` session is auto-restarted ≥ RESTART_LOOP_THRESHOLD
+// times within RESTART_WINDOW_MIN minutes, declare it WEDGED — stop
+// restarting for WEDGED_QUIET_MIN minutes and emit a `kind:'wedged'` alert.
+// This is the escalation that prevents endless restart loops on agents
+// that auto-restart only to immediately go silent again.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const ACTIONS_PATH = path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'actions');
+
+function fakeWorktree() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rl-wt-'));
+}
+
+function freshActions({ stateDir, alertFile, tmuxStub }) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  process.env.ALERT_FILE = alertFile;
+  process.env.LOG_FILE = path.join(stateDir, '.log');
+  process.env.RESTART_LOOP_THRESHOLD = '3';
+  process.env.RESTART_WINDOW_MIN = '30';
+  process.env.WEDGED_QUIET_MIN = '60';
+
+  // Patch spawnSync so we don't actually call tmux. tmuxStub records calls.
+  const cp = require('child_process');
+  cp.spawnSync = (cmd, args, opts) => {
+    if (cmd === 'tmux') {
+      tmuxStub.push({ cmd, args });
+      return { status: 0, stdout: '' };
+    }
+    if (cmd === 'sleep') return { status: 0, stdout: '' };
+    return { status: 0, stdout: '' };
+  };
+
+  return require(ACTIONS_PATH);
+}
+
+test('3rd restart within window declares WEDGED, stops further restarts, emits alert', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rl-state-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const wt = fakeWorktree();
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  const args = { session: 'GH-X-work', ticket: 'GH-X', worktree: wt, silenceSec: 305 };
+
+  // First two restarts succeed.
+  assert.equal(actions.autoRestart(args), true, 'restart 1 should proceed');
+  assert.equal(actions.autoRestart(args), true, 'restart 2 should proceed');
+
+  // Third call hits the threshold and is suppressed.
+  assert.equal(actions.autoRestart(args), false, 'restart 3 must be suppressed as WEDGED');
+
+  // Subsequent restarts during the quiet window are also suppressed.
+  assert.equal(
+    actions.autoRestart(args),
+    false,
+    'restart 4 (within quiet window) must be suppressed'
+  );
+
+  // Alert file should contain one wedged row.
+  const alertLines = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
+  const wedgedAlerts = alertLines.map(JSON.parse).filter((a) => a.kind === 'wedged');
+  assert.equal(
+    wedgedAlerts.length,
+    1,
+    `expected exactly one wedged alert, got ${wedgedAlerts.length}`
+  );
+  assert.equal(wedgedAlerts[0].session, 'GH-X-work');
+  assert.equal(wedgedAlerts[0].restartsInWindow, 3);
+});
+
+test('restarts outside the rolling window do not count toward the threshold', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rl-window-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const wt = fakeWorktree();
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  // Seed marker with two restarts that happened 31m ago (outside the 30m
+  // window). Use the real state.js so the actions module reads it back.
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('/maestro-conduct/state')) delete require.cache[k];
+  }
+  const state = require(path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'state'));
+  const longAgo = state.now() - 31 * 60;
+  state.write('GH-Y-work', 'restart-loop', { restarts: [longAgo, longAgo + 5] });
+
+  // Now do 2 fresh restarts. Combined with the 2 stale (outside window),
+  // we should be at count=2 fresh — still below threshold=3.
+  const args = { session: 'GH-Y-work', ticket: 'GH-Y', worktree: wt, silenceSec: 305 };
+  assert.equal(
+    actions.autoRestart(args),
+    true,
+    'fresh restart 1 should proceed (stale entries pruned)'
+  );
+  assert.equal(actions.autoRestart(args), true, 'fresh restart 2 should proceed');
+
+  // No wedged alert yet — only 2 in-window restarts.
+  const alertLinesA = fs.existsSync(alertFile)
+    ? fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean)
+    : [];
+  assert.equal(alertLinesA.map(JSON.parse).filter((a) => a.kind === 'wedged').length, 0);
+
+  // 3rd in-window restart should now declare WEDGED.
+  assert.equal(actions.autoRestart(args), false, 'fresh restart 3 must declare WEDGED');
+  const alertLinesB = fs.readFileSync(alertFile, 'utf8').trim().split('\n').filter(Boolean);
+  assert.equal(alertLinesB.map(JSON.parse).filter((a) => a.kind === 'wedged').length, 1);
+});
+
+test('autoRestart bails early when worktree does not exist (no marker mutation)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rl-nowt-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+
+  const args = {
+    session: 'GH-Z-work',
+    ticket: 'GH-Z',
+    worktree: '/tmp/definitely-does-not-exist-xyz-' + Date.now(),
+    silenceSec: 305,
+  };
+  assert.equal(actions.autoRestart(args), false);
+
+  // No marker should be created (worktree-missing branch returns before
+  // touching state).
+  const markerFile = path.join(stateDir, 'GH-Z-work.restart-loop.json');
+  assert.equal(
+    fs.existsSync(markerFile),
+    false,
+    'no marker should be written for missing worktree'
+  );
+});

--- a/plugins/maestro/scripts/__tests__/detectors-restart-loop.test.js
+++ b/plugins/maestro/scripts/__tests__/detectors-restart-loop.test.js
@@ -141,3 +141,43 @@ test('autoRestart bails early when worktree does not exist (no marker mutation)'
     'no marker should be written for missing worktree'
   );
 });
+
+test('autoRestart skips when dead-end marker is set (slot rotated, do not resurrect)', () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rl-deadend-'));
+  const alertFile = path.join(stateDir, 'alerts.jsonl');
+  const tmuxStub = [];
+  const actions = freshActions({ stateDir, alertFile, tmuxStub });
+  const worktree = fakeWorktree();
+
+  // Seed a dead-end marker as freeDeadEndSlot would (per-ticket, killed:true).
+  fs.writeFileSync(
+    path.join(stateDir, 'GH-DE.dead-end.json'),
+    JSON.stringify({
+      killed: true,
+      freedAt: Math.floor(Date.now() / 1000),
+      trigger: 'phase-stall',
+    })
+  );
+
+  const args = {
+    session: 'GH-DE-work',
+    ticket: 'GH-DE',
+    worktree,
+    silenceSec: 600,
+  };
+  assert.equal(actions.autoRestart(args), false, 'must not resurrect after dead-end rotation');
+
+  // No tmux kill / new-session must have been issued.
+  const tmuxCalls = tmuxStub.filter(
+    (c) => c.args[0] === 'kill-session' || c.args[0] === 'new-session'
+  );
+  assert.equal(tmuxCalls.length, 0, 'dead-end guard must short-circuit before any tmux call');
+
+  // No restart-loop marker should be written (guard returns before recording).
+  const markerFile = path.join(stateDir, 'GH-DE-work.restart-loop.json');
+  assert.equal(
+    fs.existsSync(markerFile),
+    false,
+    'dead-end short-circuit must not touch restart-loop state'
+  );
+});

--- a/plugins/maestro/scripts/__tests__/maestro-cleanup-purge-alert-counts.test.js
+++ b/plugins/maestro/scripts/__tests__/maestro-cleanup-purge-alert-counts.test.js
@@ -1,0 +1,79 @@
+// purgeAlertCountsForTicket must match the ticket on a boundary, not as a
+// substring. Alert keys are `${session}|${kind}|${sha-or-phase}` where the
+// session is `${ticket}` or `${ticket}-work` / `${ticket}-listen`, so a naive
+// `key.includes(ticket)` would purge GH-10 / GH-11 counts when cleaning GH-1.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+function freshCleanup(stateDir) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('maestro-cleanup')) delete require.cache[k];
+  }
+  process.env.STATE_DIR = stateDir;
+  return require(path.resolve(__dirname, '..', 'maestro-cleanup'));
+}
+
+test('purgeAlertCountsForTicket only removes exact ticket-boundary keys', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-purge-'));
+  const file = path.join(dir, '_alert-counts.json');
+  const counts = {
+    'GH-1|wedged|_': 1,
+    'GH-1-work|silence|abc': 2,
+    'GH-1-listen|stall|def': 3,
+    'GH-10|wedged|_': 4,
+    'GH-10-work|silence|xyz': 5,
+    'GH-11-work|wedged|_': 6,
+    'OTHER|wedged|_': 7,
+  };
+  fs.writeFileSync(file, JSON.stringify(counts));
+
+  const { purgeAlertCountsForTicket } = freshCleanup(dir);
+  const removed = purgeAlertCountsForTicket('GH-1', false);
+
+  assert.equal(removed, 3, 'should remove exactly the three GH-1* keys');
+  const after = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.deepEqual(Object.keys(after).sort(), [
+    'GH-10-work|silence|xyz',
+    'GH-10|wedged|_',
+    'GH-11-work|wedged|_',
+    'OTHER|wedged|_',
+  ]);
+});
+
+test('purgeAlertCountsForTicket dry-run leaves file untouched', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-purge-dry-'));
+  const file = path.join(dir, '_alert-counts.json');
+  const counts = { 'GH-1|wedged|_': 1, 'GH-10|wedged|_': 2 };
+  fs.writeFileSync(file, JSON.stringify(counts));
+
+  const { purgeAlertCountsForTicket } = freshCleanup(dir);
+  const removed = purgeAlertCountsForTicket('GH-1', true);
+
+  assert.equal(removed, 1);
+  const after = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.deepEqual(after, counts, 'dry-run must not modify the file');
+});
+
+test('purgeAlertCountsForTicket escapes regex metacharacters in ticket', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-purge-esc-'));
+  const file = path.join(dir, '_alert-counts.json');
+  // `.` is a regex metachar — must be escaped so it doesn't match arbitrary chars.
+  const counts = {
+    'A.B|wedged|_': 1,
+    'AXB|wedged|_': 2,
+  };
+  fs.writeFileSync(file, JSON.stringify(counts));
+
+  const { purgeAlertCountsForTicket } = freshCleanup(dir);
+  const removed = purgeAlertCountsForTicket('A.B', false);
+
+  assert.equal(removed, 1);
+  const after = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.deepEqual(Object.keys(after), ['AXB|wedged|_']);
+});

--- a/plugins/maestro/scripts/__tests__/maestro-session.test.js
+++ b/plugins/maestro/scripts/__tests__/maestro-session.test.js
@@ -1,0 +1,129 @@
+// maestro-session.js — orchestration session manifest CRUD + dep resolver.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+function freshModule(sessionDir) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('maestro-session')) delete require.cache[k];
+  }
+  process.env.MAESTRO_SESSION_DIR = sessionDir;
+  return require(path.resolve(__dirname, '..', 'maestro-session.js'));
+}
+
+test('init persists topic, slots, tasks; status starts pending', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-'));
+  const m = freshModule(dir);
+  const s = m.init('plug-bugs', 5, [
+    { id: 'GH-1', priority: 1, deps: [] },
+    { id: 'GH-2', priority: 2, deps: ['GH-1'] },
+  ]);
+  assert.equal(s.topic, 'plug-bugs');
+  assert.equal(s.slots, 5);
+  assert.equal(s.tasks.length, 2);
+  assert.equal(s.tasks[0].status, 'pending');
+  assert.equal(s.tasks[1].status, 'pending');
+  const onDisk = JSON.parse(fs.readFileSync(path.join(dir, 'plug-bugs.json'), 'utf8'));
+  assert.equal(onDisk.topic, 'plug-bugs');
+});
+
+test('init rejects task with unknown dep reference', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-bad-'));
+  const m = freshModule(dir);
+  assert.throws(
+    () => m.init('bad', 1, [{ id: 'A', priority: 1, deps: ['UNKNOWN'] }]),
+    /depends on unknown UNKNOWN/
+  );
+});
+
+test('init rejects invalid topic / zero slots / empty tasks', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-val-'));
+  const m = freshModule(dir);
+  assert.throws(() => m.init('bad topic', 1, [{ id: 'A', priority: 1 }]), /bad topic/);
+  assert.throws(() => m.init('ok', 0, [{ id: 'A', priority: 1 }]), /slots must be/);
+  assert.throws(() => m.init('ok', 1, []), /at least one task/);
+});
+
+test('update flips status and persists', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-upd-'));
+  const m = freshModule(dir);
+  m.init('topic', 3, [{ id: 'X', priority: 1, deps: [] }]);
+  m.update('topic', 'X', 'in_progress');
+  assert.equal(m.read('topic').tasks[0].status, 'in_progress');
+  m.update('topic', 'X', 'done', 'merged in PR #42');
+  const t = m.read('topic').tasks[0];
+  assert.equal(t.status, 'done');
+  assert.equal(t.note, 'merged in PR #42');
+  assert.ok(t.updatedAt);
+});
+
+test('update rejects unknown status', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-bs-'));
+  const m = freshModule(dir);
+  m.init('t', 1, [{ id: 'X', priority: 1 }]);
+  assert.throws(() => m.update('t', 'X', 'banana'), /bad status/);
+});
+
+test('nextEligible returns highest-priority pending task whose deps are done', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-next-'));
+  const m = freshModule(dir);
+  m.init('t', 2, [
+    { id: 'A', priority: 1, deps: [] }, // top priority
+    { id: 'B', priority: 2, deps: ['A'] }, // needs A
+    { id: 'C', priority: 3, deps: [] }, // independent, lower priority
+  ]);
+  // A is eligible first (priority 1, no deps).
+  assert.equal(m.nextEligible('t').id, 'A');
+  m.update('t', 'A', 'done');
+  // Now B is eligible (deps satisfied) and beats C on priority.
+  assert.equal(m.nextEligible('t').id, 'B');
+  m.update('t', 'B', 'in_progress');
+  // B is in_progress (not pending) — C is the only pending eligible.
+  assert.equal(m.nextEligible('t').id, 'C');
+  m.update('t', 'B', 'done');
+  m.update('t', 'C', 'done');
+  // All done — nothing eligible.
+  assert.equal(m.nextEligible('t'), null);
+});
+
+test('list returns all active sessions', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-list-'));
+  const m = freshModule(dir);
+  m.init('a', 1, [{ id: 'X', priority: 1 }]);
+  m.init('b', 2, [{ id: 'Y', priority: 1 }]);
+  const all = m.list();
+  assert.equal(all.length, 2);
+  assert.deepEqual(all.map((s) => s.topic).sort(), ['a', 'b']);
+});
+
+test('summarize emits the operator-facing one-liner', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-sum-'));
+  const m = freshModule(dir);
+  const s = m.init('topic', 5, [
+    { id: 'A', priority: 1 },
+    { id: 'B', priority: 2 },
+    { id: 'C', priority: 3 },
+  ]);
+  m.update('topic', 'A', 'done');
+  m.update('topic', 'B', 'in_progress');
+  const line = m.summarize(m.read('topic'));
+  assert.match(line, /topic: slots=5/);
+  assert.match(line, /1 in flight/);
+  assert.match(line, /1\/3 done/);
+  assert.match(line, /1 pending/);
+});
+
+test('clear removes the session file', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-clr-'));
+  const m = freshModule(dir);
+  m.init('rm', 1, [{ id: 'X', priority: 1 }]);
+  assert.ok(fs.existsSync(path.join(dir, 'rm.json')));
+  assert.equal(m.clear('rm'), true);
+  assert.equal(fs.existsSync(path.join(dir, 'rm.json')), false);
+  assert.equal(m.clear('rm'), false);
+});

--- a/plugins/maestro/scripts/__tests__/maestro-session.test.js
+++ b/plugins/maestro/scripts/__tests__/maestro-session.test.js
@@ -104,7 +104,7 @@ test('list returns all active sessions', () => {
 test('summarize emits the operator-facing one-liner', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms-sum-'));
   const m = freshModule(dir);
-  const s = m.init('topic', 5, [
+  m.init('topic', 5, [
     { id: 'A', priority: 1 },
     { id: 'B', priority: 2 },
     { id: 'C', priority: 3 },

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -118,7 +118,7 @@ function interrupt(session, reason) {
 }
 
 function alert(reasonObj) {
-  alerts.alert(reasonObj);
+  return alerts.alert(reasonObj);
 }
 
 /**

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -19,6 +19,7 @@ const alerts = require('./alerts');
 const state = require('./state');
 const { headSha } = require('./detectors/gh-shared');
 const { eligibleTasks } = require('./session-shared');
+const { purgeAlertCountsForTicket } = require('../../maestro-cleanup');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
 const SKILL_NAME = process.env.SKILL_NAME || 'work';
@@ -326,6 +327,14 @@ function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
   const marker = state.read(ticket, 'dead-end') || {};
   if (marker.killed) return false; // already freed
   killTicketTmux(ticket);
+  // Purge persisted alert counts so a fresh agent on the same ticket starts
+  // with a clean repeat-count slate (otherwise it could inherit a count
+  // already ≥ DEAD_END_REEMITS and immediately re-trigger rotation).
+  try {
+    purgeAlertCountsForTicket(ticket, false);
+  } catch (err) {
+    alerts.log(`${session} freeDeadEndSlot: purgeAlertCountsForTicket failed: ${err.message}`);
+  }
   state.write(ticket, 'dead-end', { killed: true, freedAt: state.now(), trigger: kind });
   const next = findNextEligibleTask();
   const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -15,9 +15,17 @@ const fs = require('fs');
 const { spawnSync } = require('child_process');
 const tmux = require('./tmux');
 const alerts = require('./alerts');
+const state = require('./state');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
 const SKILL_NAME = process.env.SKILL_NAME || 'work';
+
+// Restart-loop guard: how many auto-restarts within RESTART_WINDOW_MIN before
+// we declare the session WEDGED and stop restarting. Caller is freed of state
+// management — autoRestart() owns the marker.
+const RESTART_LOOP_THRESHOLD = parseInt(process.env.RESTART_LOOP_THRESHOLD || '3', 10);
+const RESTART_WINDOW_MIN = parseInt(process.env.RESTART_WINDOW_MIN || '30', 10);
+const WEDGED_QUIET_MIN = parseInt(process.env.WEDGED_QUIET_MIN || '60', 10);
 
 function msgFor(reason, mode) {
   const base = `MAESTRO (${mode}): ${reason}. Audit uncommitted files via git status. If any are present, dispatch the commit agent with 'autonomous' to land them, then push. Re-run task-next.js to advance the gate.`;
@@ -59,6 +67,49 @@ function autoRestart({ session, ticket, worktree, silenceSec }) {
     alerts.log(`${session} AUTO-RESTART skipped: worktree ${worktree} not found`);
     return false;
   }
+
+  // Restart-loop guard. Read the per-session marker once and decide whether
+  // we're still in the "WEDGED quiet" window from a prior loop. The marker
+  // shape:
+  //   { restarts: [unix_ts, ...], wedgedUntil?: unix_ts }
+  // restarts[] is pruned to the last RESTART_WINDOW_MIN.
+  const now = state.now();
+  const marker = state.read(session, 'restart-loop') || { restarts: [] };
+
+  if (marker.wedgedUntil && marker.wedgedUntil > now) {
+    // Already declared wedged — don't restart, don't re-alert. We logged on
+    // entry; further silence triggers can re-read this marker silently.
+    return false;
+  }
+
+  // Prune older entries outside the rolling window.
+  const cutoff = now - RESTART_WINDOW_MIN * 60;
+  const restarts = (marker.restarts || []).filter((t) => t >= cutoff);
+
+  // If we'd be at-or-over the threshold AFTER this restart, declare wedged
+  // INSTEAD of restarting. The operator must intervene.
+  if (restarts.length + 1 >= RESTART_LOOP_THRESHOLD) {
+    const wedgedUntil = now + WEDGED_QUIET_MIN * 60;
+    state.write(session, 'restart-loop', { restarts: [...restarts, now], wedgedUntil });
+    alerts.log(
+      `${session} WEDGED — ${restarts.length + 1} auto-restarts in ${RESTART_WINDOW_MIN}m; suppressing restarts for ${WEDGED_QUIET_MIN}m`
+    );
+    alerts.alert({
+      session,
+      ticket,
+      kind: 'wedged',
+      restartsInWindow: restarts.length + 1,
+      windowMin: RESTART_WINDOW_MIN,
+      quietMin: WEDGED_QUIET_MIN,
+      silenceSec,
+      instruction: `tmux capture-pane -t ${session} -p | tail -50 — agent restarted ${restarts.length + 1}x in ${RESTART_WINDOW_MIN}m. Daemon won't restart for ${WEDGED_QUIET_MIN}m. Diagnose root cause; if dead-end, kill session and bootstrap next bug.`,
+    });
+    return false;
+  }
+
+  // Record this restart and proceed.
+  state.write(session, 'restart-loop', { restarts: [...restarts, now] });
+
   alerts.log(
     `${session} AUTO-RESTART after ${silenceSec}s silence — relaunching /${SKILL_NAME} ${ticket}`
   );
@@ -82,4 +133,67 @@ function autoRestart({ session, ticket, worktree, silenceSec }) {
   return true;
 }
 
-module.exports = { soft, interrupt, alert, autoRestart };
+/**
+ * freeCIGateSlot — kill the -work and -listen panes of a ticket whose PR has
+ * reached CI gate (CLEAN/SUCCESS, awaiting operator merge). Emits a
+ * structured alert kind=slot-freed so the orchestrator can bootstrap the next
+ * ticket. Idempotent: writes a per-ticket marker so repeated pr-ready emits
+ * on the same SHA don't try to kill an already-killed session.
+ *
+ * No-op if AUTO_FREE_CI_SLOT=0.
+ */
+function freeCIGateSlot({ session, ticket, prNumber, sha }) {
+  if (process.env.AUTO_FREE_CI_SLOT === '0') return false;
+  const marker = state.read(session, 'slot-freed') || {};
+  if (marker.sha === sha) return false; // already freed for this SHA
+  // Kill -work and -listen panes. Tmux kill-session is idempotent; ignore errors.
+  for (const suffix of ['work', 'listen']) {
+    spawnSync('tmux', ['kill-session', '-t', `${ticket}-${suffix}`], { stdio: 'ignore' });
+  }
+  state.write(session, 'slot-freed', { sha, prNumber, freedAt: state.now() });
+  alerts.log(
+    `${session} SLOT-FREED at CI gate — PR #${prNumber} sha=${(sha || '').slice(0, 7)} awaiting operator merge; tmux -work + -listen killed`
+  );
+  alert({
+    session,
+    ticket,
+    kind: 'slot-freed',
+    prNumber,
+    sha,
+    instruction: `Pool slot free. Pick next bug: gh issue list --repo thomfilg/claude-plugin-work --state open --label bug --json number,title | head; then: bash plugins/maestro/scripts/maestro-bootstrap.sh GH-<pick>. Skip tickets whose diff overlaps PR #${prNumber}.`,
+  });
+  return true;
+}
+
+/**
+ * freeDeadEndSlot — same kill mechanics as freeCIGateSlot but for an agent
+ * stuck in a non-recoverable state (e.g. every menu option is a workflow
+ * bypass; PR has no path forward without manual intervention). Triggered by
+ * the re-emit escalation: when the same alert kind fires ≥ DEAD_END_REEMITS
+ * times on the same session+sha+phase, the caller invokes this.
+ *
+ * Emits a kind=dead-end alert with a crystal-clear instruction so the
+ * operator knows to bootstrap the next ticket. Idempotent per ticket.
+ */
+function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
+  if (process.env.AUTO_FREE_DEAD_END === '0') return false;
+  const marker = state.read(ticket, 'dead-end') || {};
+  if (marker.killed) return false; // already freed
+  for (const suffix of ['work', 'listen']) {
+    spawnSync('tmux', ['kill-session', '-t', `${ticket}-${suffix}`], { stdio: 'ignore' });
+  }
+  state.write(ticket, 'dead-end', { killed: true, freedAt: state.now(), trigger: kind });
+  alerts.log(`${session} DEAD-END ${kind} re-fired ${repeatCount}x — tmux killed, slot freed`);
+  alert({
+    session,
+    ticket,
+    kind: 'dead-end',
+    trigger: kind,
+    repeatCount,
+    sha,
+    instruction: `Bootstrap next bug into freed slot: gh issue list --repo thomfilg/claude-plugin-work --state open --label bug --json number,title | head; bash plugins/maestro/scripts/maestro-bootstrap.sh GH-<pick>`,
+  });
+  return true;
+}
+
+module.exports = { soft, interrupt, alert, autoRestart, freeCIGateSlot, freeDeadEndSlot };

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -154,51 +154,40 @@ function declareWedged({ session, ticket, restarts, now, silenceSec }) {
  * for restart eligibility (only -work sessions) and for clearing per-ticket
  * markers after the restart so detectors don't fire against the stale state.
  */
+function checkCiGateFreedGuard({ session, ticket, worktree }) {
+  const ciFreed = state.read(ticket, 'ci-gate-freed');
+  if (!ciFreed || !ciFreed.killed) return { skip: false };
+  const currentSha = headSha(worktree);
+  if (currentSha && ciFreed.sha && currentSha !== ciFreed.sha) {
+    alerts.log(
+      `${session} AUTO-RESTART ci-gate-freed marker cleared: HEAD moved ${(ciFreed.sha || '').slice(0, 7)} -> ${currentSha.slice(0, 7)}`
+    );
+    state.clear(ticket, 'ci-gate-freed');
+    return { skip: false };
+  }
+  alerts.log(
+    `${session} AUTO-RESTART skipped: ticket ${ticket} CI-gate-freed at sha=${(ciFreed.sha || '').slice(0, 7)}; awaiting operator merge`
+  );
+  return { skip: true };
+}
+
+function checkDeadEndGuard({ session, ticket }) {
+  const deadEnd = state.read(ticket, 'dead-end');
+  if (!deadEnd || !deadEnd.killed) return { skip: false };
+  alerts.log(
+    `${session} AUTO-RESTART skipped: ticket ${ticket} dead-end-freed (trigger=${deadEnd.trigger || 'unknown'}); slot rotated, do not resurrect`
+  );
+  return { skip: true };
+}
+
 function checkRestartGuards({ session, ticket, worktree }) {
   if (!worktree || !fs.existsSync(worktree)) {
     alerts.log(`${session} AUTO-RESTART skipped: worktree ${worktree} not found`);
     return { skip: true };
   }
-  // CI-gate slot-freed guard. If freeCIGateSlot already killed this ticket's
-  // tmux because its PR hit pr-ready, do NOT resurrect it — the agent's job
-  // is done until operator merges. Marker is per-ticket, written by
-  // freeCIGateSlot / freeDeadEndSlot.
-  //
-  // SHA-gated clear: if the worktree HEAD has moved past the stored SHA (new
-  // commit pushed, e.g. CI broke again and the agent — or operator — pushed
-  // a fix), the freeze is stale. Clear the marker and let autoRestart proceed
-  // so the agent can resume monitoring the new CI run. Without this clear,
-  // `killed: true` would block restarts forever even after the underlying
-  // PR state has changed.
-  const ciFreed = state.read(ticket, 'ci-gate-freed');
-  if (ciFreed && ciFreed.killed) {
-    const currentSha = headSha(worktree);
-    if (currentSha && ciFreed.sha && currentSha !== ciFreed.sha) {
-      alerts.log(
-        `${session} AUTO-RESTART ci-gate-freed marker cleared: HEAD moved ${(ciFreed.sha || '').slice(0, 7)} -> ${currentSha.slice(0, 7)}`
-      );
-      state.clear(ticket, 'ci-gate-freed');
-      return { skip: false };
-    }
-    alerts.log(
-      `${session} AUTO-RESTART skipped: ticket ${ticket} CI-gate-freed at sha=${(ciFreed.sha || '').slice(0, 7)}; awaiting operator merge`
-    );
-    return { skip: true };
-  }
-  // Dead-end guard. If freeDeadEndSlot already killed this ticket's tmux
-  // because the agent was stuck in a non-recoverable state, do NOT resurrect
-  // it. Unlike ci-gate-freed, dead-end has no SHA-gated clear: the slot has
-  // been rotated and the operator must bootstrap the next ticket manually
-  // (or it was auto-bootstrapped). Resurrecting here would undo slot rotation
-  // if tmux wasn't fully torn down or a session reappeared between ticks.
-  const deadEnd = state.read(ticket, 'dead-end');
-  if (deadEnd && deadEnd.killed) {
-    alerts.log(
-      `${session} AUTO-RESTART skipped: ticket ${ticket} dead-end-freed (trigger=${deadEnd.trigger || 'unknown'}); slot rotated, do not resurrect`
-    );
-    return { skip: true };
-  }
-  return { skip: false };
+  const ciGuard = checkCiGateFreedGuard({ session, ticket, worktree });
+  if (ciGuard.skip) return ciGuard;
+  return checkDeadEndGuard({ session, ticket });
 }
 
 function autoRestart({ session, ticket, worktree, silenceSec }) {

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -17,6 +17,7 @@ const { spawnSync } = require('child_process');
 const tmux = require('./tmux');
 const alerts = require('./alerts');
 const state = require('./state');
+const { headSha } = require('./detectors/gh-shared');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
 const SKILL_NAME = process.env.SKILL_NAME || 'work';
@@ -161,10 +162,24 @@ function checkRestartGuards({ session, ticket, worktree }) {
   // CI-gate slot-freed guard. If freeCIGateSlot already killed this ticket's
   // tmux because its PR hit pr-ready, do NOT resurrect it — the agent's job
   // is done until operator merges. Marker is per-ticket, written by
-  // freeCIGateSlot / freeDeadEndSlot. Cleared automatically on SHA change
-  // (next pr-ready emit with a new sha overwrites the marker).
+  // freeCIGateSlot / freeDeadEndSlot.
+  //
+  // SHA-gated clear: if the worktree HEAD has moved past the stored SHA (new
+  // commit pushed, e.g. CI broke again and the agent — or operator — pushed
+  // a fix), the freeze is stale. Clear the marker and let autoRestart proceed
+  // so the agent can resume monitoring the new CI run. Without this clear,
+  // `killed: true` would block restarts forever even after the underlying
+  // PR state has changed.
   const ciFreed = state.read(ticket, 'ci-gate-freed');
   if (ciFreed && ciFreed.killed) {
+    const currentSha = headSha(worktree);
+    if (currentSha && ciFreed.sha && currentSha !== ciFreed.sha) {
+      alerts.log(
+        `${session} AUTO-RESTART ci-gate-freed marker cleared: HEAD moved ${(ciFreed.sha || '').slice(0, 7)} -> ${currentSha.slice(0, 7)}`
+      );
+      state.clear(ticket, 'ci-gate-freed');
+      return { skip: false };
+    }
     alerts.log(
       `${session} AUTO-RESTART skipped: ticket ${ticket} CI-gate-freed at sha=${(ciFreed.sha || '').slice(0, 7)}; awaiting operator merge`
     );

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -12,6 +12,7 @@
  * Avoid literal CLI strings that trip the enforce-agent-usage hook.
  */
 const fs = require('fs');
+const path = require('path');
 const { spawnSync } = require('child_process');
 const tmux = require('./tmux');
 const alerts = require('./alerts');
@@ -19,6 +20,59 @@ const state = require('./state');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
 const SKILL_NAME = process.env.SKILL_NAME || 'work';
+
+const SESSION_MANIFEST_DIR =
+  process.env.MAESTRO_SESSION_DIR ||
+  path.join(process.env.HOME || '/tmp', '.cache', 'maestro', 'sessions');
+const BOOTSTRAP_SCRIPT = path.join(__dirname, '..', '..', 'maestro-bootstrap.sh');
+const REPO_NAME = process.env.REPO_NAME || 'claude-plugin-work';
+
+/**
+ * Look across every orchestration manifest in ~/.cache/maestro/sessions/ for
+ * the next pending task whose deps are all done. Returns { topic, taskId } or
+ * null. First match wins (lowest priority across all manifests).
+ */
+function findNextEligibleTask() {
+  if (!fs.existsSync(SESSION_MANIFEST_DIR)) return null;
+  let best = null;
+  for (const entry of fs.readdirSync(SESSION_MANIFEST_DIR)) {
+    if (!entry.endsWith('.json')) continue;
+    let manifest;
+    try {
+      manifest = JSON.parse(fs.readFileSync(path.join(SESSION_MANIFEST_DIR, entry), 'utf8'));
+    } catch {
+      continue;
+    }
+    const tasks = Array.isArray(manifest.tasks) ? manifest.tasks : [];
+    const doneIds = new Set(tasks.filter((t) => t.status === 'done').map((t) => t.id));
+    const pending = tasks.filter(
+      (t) => t.status === 'pending' && (t.deps || []).every((d) => doneIds.has(d))
+    );
+    if (pending.length === 0) continue;
+    pending.sort((a, b) => (a.priority || 9999) - (b.priority || 9999));
+    const top = pending[0];
+    if (!best || (top.priority || 9999) < (best.priority || 9999)) {
+      best = { topic: manifest.topic || entry.replace(/\.json$/, ''), taskId: top.id, priority: top.priority };
+    }
+  }
+  return best;
+}
+
+/**
+ * Optionally bootstrap a fresh tmux + worktree for the next ticket. Returns
+ * true on launch. Gated by AUTO_BOOTSTRAP_NEXT=1 (default off — explicit
+ * opt-in).
+ */
+function maybeAutoBootstrap(taskId) {
+  if (process.env.AUTO_BOOTSTRAP_NEXT !== '1') return false;
+  if (!taskId || !/^[A-Z]+-\d+$/.test(taskId)) return false;
+  if (!fs.existsSync(BOOTSTRAP_SCRIPT)) return false;
+  const res = spawnSync('bash', [BOOTSTRAP_SCRIPT, taskId], {
+    stdio: 'ignore',
+    env: { ...process.env, REPO_NAME },
+  });
+  return res.status === 0;
+}
 
 // Restart-loop guard: how many auto-restarts within RESTART_WINDOW_MIN before
 // we declare the session WEDGED and stop restarting. Caller is freed of state
@@ -65,6 +119,19 @@ function alert(reasonObj) {
 function autoRestart({ session, ticket, worktree, silenceSec }) {
   if (!worktree || !fs.existsSync(worktree)) {
     alerts.log(`${session} AUTO-RESTART skipped: worktree ${worktree} not found`);
+    return false;
+  }
+
+  // CI-gate slot-freed guard. If freeCIGateSlot already killed this ticket's
+  // tmux because its PR hit pr-ready, do NOT resurrect it — the agent's job
+  // is done until operator merges. Marker is per-ticket, written by
+  // freeCIGateSlot / freeDeadEndSlot. Cleared automatically on SHA change
+  // (next pr-ready emit with a new sha overwrites the marker).
+  const ciFreed = state.read(ticket, 'ci-gate-freed');
+  if (ciFreed && ciFreed.killed) {
+    alerts.log(
+      `${session} AUTO-RESTART skipped: ticket ${ticket} CI-gate-freed at sha=${(ciFreed.sha || '').slice(0, 7)}; awaiting operator merge`
+    );
     return false;
   }
 
@@ -145,14 +212,35 @@ function autoRestart({ session, ticket, worktree, silenceSec }) {
 function freeCIGateSlot({ session, ticket, prNumber, sha }) {
   if (process.env.AUTO_FREE_CI_SLOT === '0') return false;
   const marker = state.read(session, 'slot-freed') || {};
-  if (marker.sha === sha) return false; // already freed for this SHA
-  // Kill -work and -listen panes. Tmux kill-session is idempotent; ignore errors.
+  const ciFreed = state.read(ticket, 'ci-gate-freed') || {};
+  // Always kill any alive tmux sessions for this ticket — defensive against
+  // sessions resurrected by autoRestart between ticks. tmux kill-session is
+  // idempotent and silent when the session is already gone.
   for (const suffix of ['work', 'listen']) {
     spawnSync('tmux', ['kill-session', '-t', `${ticket}-${suffix}`], { stdio: 'ignore' });
   }
+  // Per-ticket marker that autoRestart consults to refuse resurrection.
+  // Overwritten on each fresh SHA so a force-push that re-opens CI naturally
+  // re-engages the agent.
+  state.write(ticket, 'ci-gate-freed', { killed: true, sha, prNumber, freedAt: state.now() });
+  // Skip alert + bootstrap if this exact SHA was already announced — prevents
+  // spam on every tick. The kill above still runs (defensive).
+  if (marker.sha === sha && ciFreed.sha === sha) return false;
   state.write(session, 'slot-freed', { sha, prNumber, freedAt: state.now() });
+  const next = findNextEligibleTask();
+  const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);
+  let instruction;
+  if (autoBootstrapped) {
+    instruction = `Slot freed for PR #${prNumber} (sha=${(sha || '').slice(0, 7)}). NEXT_ACTION=auto-bootstrapped ${next.taskId} from manifest "${next.topic}". No operator action needed unless bootstrap log shows failure.`;
+  } else if (next) {
+    instruction = `Slot freed for PR #${prNumber} (sha=${(sha || '').slice(0, 7)}). NEXT_ACTION=bootstrap ${next.taskId} (manifest "${next.topic}", priority=${next.priority}). Run: bash plugins/maestro/scripts/maestro-bootstrap.sh ${next.taskId}. Set AUTO_BOOTSTRAP_NEXT=1 to skip this step. Operator merges PR #${prNumber} separately.`;
+  } else {
+    instruction = `Slot freed for PR #${prNumber} (sha=${(sha || '').slice(0, 7)}). NEXT_ACTION=do-nothing — no eligible pending task across orchestration manifests. Operator merges PR #${prNumber} separately.`;
+  }
   alerts.log(
-    `${session} SLOT-FREED at CI gate — PR #${prNumber} sha=${(sha || '').slice(0, 7)} awaiting operator merge; tmux -work + -listen killed`
+    `${session} SLOT-FREED at CI gate — PR #${prNumber} sha=${(sha || '').slice(0, 7)} awaiting operator merge; tmux -work + -listen killed${
+      autoBootstrapped ? `; AUTO-BOOTSTRAPPED ${next.taskId}` : ''
+    }`
   );
   alert({
     session,
@@ -160,7 +248,10 @@ function freeCIGateSlot({ session, ticket, prNumber, sha }) {
     kind: 'slot-freed',
     prNumber,
     sha,
-    instruction: `Pool slot free. Pick next bug: gh issue list --repo thomfilg/claude-plugin-work --state open --label bug --json number,title | head; then: bash plugins/maestro/scripts/maestro-bootstrap.sh GH-<pick>. Skip tickets whose diff overlaps PR #${prNumber}.`,
+    nextTask: next ? next.taskId : null,
+    nextTopic: next ? next.topic : null,
+    autoBootstrapped: !!autoBootstrapped,
+    instruction,
   });
   return true;
 }
@@ -183,7 +274,21 @@ function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
     spawnSync('tmux', ['kill-session', '-t', `${ticket}-${suffix}`], { stdio: 'ignore' });
   }
   state.write(ticket, 'dead-end', { killed: true, freedAt: state.now(), trigger: kind });
-  alerts.log(`${session} DEAD-END ${kind} re-fired ${repeatCount}x — tmux killed, slot freed`);
+  const next = findNextEligibleTask();
+  const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);
+  let instruction;
+  if (autoBootstrapped) {
+    instruction = `DEAD-END on ${ticket} after ${kind} ×${repeatCount}. NEXT_ACTION=auto-bootstrapped ${next.taskId} from manifest "${next.topic}". No operator action needed unless bootstrap log shows failure.`;
+  } else if (next) {
+    instruction = `DEAD-END on ${ticket} after ${kind} ×${repeatCount}. NEXT_ACTION=bootstrap ${next.taskId} (manifest "${next.topic}", priority=${next.priority}). Run: bash plugins/maestro/scripts/maestro-bootstrap.sh ${next.taskId}. Set AUTO_BOOTSTRAP_NEXT=1 to skip this step.`;
+  } else {
+    instruction = `DEAD-END on ${ticket} after ${kind} ×${repeatCount}. NEXT_ACTION=do-nothing — no eligible pending task across orchestration manifests.`;
+  }
+  alerts.log(
+    `${session} DEAD-END ${kind} re-fired ${repeatCount}x — tmux killed, slot freed${
+      autoBootstrapped ? `; AUTO-BOOTSTRAPPED ${next.taskId}` : ''
+    }`
+  );
   alert({
     session,
     ticket,
@@ -191,7 +296,10 @@ function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
     trigger: kind,
     repeatCount,
     sha,
-    instruction: `Bootstrap next bug into freed slot: gh issue list --repo thomfilg/claude-plugin-work --state open --label bug --json number,title | head; bash plugins/maestro/scripts/maestro-bootstrap.sh GH-<pick>`,
+    nextTask: next ? next.taskId : null,
+    nextTopic: next ? next.topic : null,
+    autoBootstrapped: !!autoBootstrapped,
+    instruction,
   });
   return true;
 }

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -185,6 +185,19 @@ function checkRestartGuards({ session, ticket, worktree }) {
     );
     return { skip: true };
   }
+  // Dead-end guard. If freeDeadEndSlot already killed this ticket's tmux
+  // because the agent was stuck in a non-recoverable state, do NOT resurrect
+  // it. Unlike ci-gate-freed, dead-end has no SHA-gated clear: the slot has
+  // been rotated and the operator must bootstrap the next ticket manually
+  // (or it was auto-bootstrapped). Resurrecting here would undo slot rotation
+  // if tmux wasn't fully torn down or a session reappeared between ticks.
+  const deadEnd = state.read(ticket, 'dead-end');
+  if (deadEnd && deadEnd.killed) {
+    alerts.log(
+      `${session} AUTO-RESTART skipped: ticket ${ticket} dead-end-freed (trigger=${deadEnd.trigger || 'unknown'}); slot rotated, do not resurrect`
+    );
+    return { skip: true };
+  }
   return { skip: false };
 }
 

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -32,27 +32,41 @@ const REPO_NAME = process.env.REPO_NAME || 'claude-plugin-work';
  * the next pending task whose deps are all done. Returns { topic, taskId } or
  * null. First match wins (lowest priority across all manifests).
  */
+function readManifestSafe(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function topPendingForManifest(manifest, entry) {
+  const tasks = Array.isArray(manifest.tasks) ? manifest.tasks : [];
+  const doneIds = new Set(tasks.filter((t) => t.status === 'done').map((t) => t.id));
+  const pending = tasks.filter(
+    (t) => t.status === 'pending' && (t.deps || []).every((d) => doneIds.has(d))
+  );
+  if (pending.length === 0) return null;
+  pending.sort((a, b) => (a.priority || 9999) - (b.priority || 9999));
+  const top = pending[0];
+  return {
+    topic: manifest.topic || entry.replace(/\.json$/, ''),
+    taskId: top.id,
+    priority: top.priority,
+  };
+}
+
 function findNextEligibleTask() {
   if (!fs.existsSync(SESSION_MANIFEST_DIR)) return null;
   let best = null;
   for (const entry of fs.readdirSync(SESSION_MANIFEST_DIR)) {
     if (!entry.endsWith('.json')) continue;
-    let manifest;
-    try {
-      manifest = JSON.parse(fs.readFileSync(path.join(SESSION_MANIFEST_DIR, entry), 'utf8'));
-    } catch {
-      continue;
-    }
-    const tasks = Array.isArray(manifest.tasks) ? manifest.tasks : [];
-    const doneIds = new Set(tasks.filter((t) => t.status === 'done').map((t) => t.id));
-    const pending = tasks.filter(
-      (t) => t.status === 'pending' && (t.deps || []).every((d) => doneIds.has(d))
-    );
-    if (pending.length === 0) continue;
-    pending.sort((a, b) => (a.priority || 9999) - (b.priority || 9999));
-    const top = pending[0];
-    if (!best || (top.priority || 9999) < (best.priority || 9999)) {
-      best = { topic: manifest.topic || entry.replace(/\.json$/, ''), taskId: top.id, priority: top.priority };
+    const manifest = readManifestSafe(path.join(SESSION_MANIFEST_DIR, entry));
+    if (!manifest) continue;
+    const candidate = topPendingForManifest(manifest, entry);
+    if (!candidate) continue;
+    if (!best || (candidate.priority || 9999) < (best.priority || 9999)) {
+      best = candidate;
     }
   }
   return best;
@@ -108,6 +122,29 @@ function alert(reasonObj) {
 }
 
 /**
+ * Declare an agent wedged: record marker, log, and emit alert. Extracted from
+ * autoRestart() to keep that function under the max-lines-per-function gate.
+ */
+function declareWedged({ session, ticket, restarts, now, silenceSec }) {
+  const wedgedUntil = now + WEDGED_QUIET_MIN * 60;
+  const count = restarts.length + 1;
+  state.write(session, 'restart-loop', { restarts: [...restarts, now], wedgedUntil });
+  alerts.log(
+    `${session} WEDGED — ${count} auto-restarts in ${RESTART_WINDOW_MIN}m; suppressing restarts for ${WEDGED_QUIET_MIN}m`
+  );
+  alerts.alert({
+    session,
+    ticket,
+    kind: 'wedged',
+    restartsInWindow: count,
+    windowMin: RESTART_WINDOW_MIN,
+    quietMin: WEDGED_QUIET_MIN,
+    silenceSec,
+    instruction: `tmux capture-pane -t ${session} -p | tail -50 — agent restarted ${count}x in ${RESTART_WINDOW_MIN}m. Daemon won't restart for ${WEDGED_QUIET_MIN}m. Diagnose root cause; if dead-end, kill session and bootstrap next bug.`,
+  });
+}
+
+/**
  * Auto-restart a dead -work session in place: kill the existing tmux
  * session, then relaunch `claude --dangerously-skip-permissions /<skill> <ticket>`
  * inside the worktree. Returns true if the restart command was issued.
@@ -116,12 +153,11 @@ function alert(reasonObj) {
  * for restart eligibility (only -work sessions) and for clearing per-ticket
  * markers after the restart so detectors don't fire against the stale state.
  */
-function autoRestart({ session, ticket, worktree, silenceSec }) {
+function checkRestartGuards({ session, ticket, worktree }) {
   if (!worktree || !fs.existsSync(worktree)) {
     alerts.log(`${session} AUTO-RESTART skipped: worktree ${worktree} not found`);
-    return false;
+    return { skip: true };
   }
-
   // CI-gate slot-freed guard. If freeCIGateSlot already killed this ticket's
   // tmux because its PR hit pr-ready, do NOT resurrect it — the agent's job
   // is done until operator merges. Marker is per-ticket, written by
@@ -132,8 +168,13 @@ function autoRestart({ session, ticket, worktree, silenceSec }) {
     alerts.log(
       `${session} AUTO-RESTART skipped: ticket ${ticket} CI-gate-freed at sha=${(ciFreed.sha || '').slice(0, 7)}; awaiting operator merge`
     );
-    return false;
+    return { skip: true };
   }
+  return { skip: false };
+}
+
+function autoRestart({ session, ticket, worktree, silenceSec }) {
+  if (checkRestartGuards({ session, ticket, worktree }).skip) return false;
 
   // Restart-loop guard. Read the per-session marker once and decide whether
   // we're still in the "WEDGED quiet" window from a prior loop. The marker
@@ -156,21 +197,7 @@ function autoRestart({ session, ticket, worktree, silenceSec }) {
   // If we'd be at-or-over the threshold AFTER this restart, declare wedged
   // INSTEAD of restarting. The operator must intervene.
   if (restarts.length + 1 >= RESTART_LOOP_THRESHOLD) {
-    const wedgedUntil = now + WEDGED_QUIET_MIN * 60;
-    state.write(session, 'restart-loop', { restarts: [...restarts, now], wedgedUntil });
-    alerts.log(
-      `${session} WEDGED — ${restarts.length + 1} auto-restarts in ${RESTART_WINDOW_MIN}m; suppressing restarts for ${WEDGED_QUIET_MIN}m`
-    );
-    alerts.alert({
-      session,
-      ticket,
-      kind: 'wedged',
-      restartsInWindow: restarts.length + 1,
-      windowMin: RESTART_WINDOW_MIN,
-      quietMin: WEDGED_QUIET_MIN,
-      silenceSec,
-      instruction: `tmux capture-pane -t ${session} -p | tail -50 — agent restarted ${restarts.length + 1}x in ${RESTART_WINDOW_MIN}m. Daemon won't restart for ${WEDGED_QUIET_MIN}m. Diagnose root cause; if dead-end, kill session and bootstrap next bug.`,
-    });
+    declareWedged({ session, ticket, restarts, now, silenceSec });
     return false;
   }
 
@@ -209,34 +236,23 @@ function autoRestart({ session, ticket, worktree, silenceSec }) {
  *
  * No-op if AUTO_FREE_CI_SLOT=0.
  */
-function freeCIGateSlot({ session, ticket, prNumber, sha }) {
-  if (process.env.AUTO_FREE_CI_SLOT === '0') return false;
-  const marker = state.read(session, 'slot-freed') || {};
-  const ciFreed = state.read(ticket, 'ci-gate-freed') || {};
-  // Always kill any alive tmux sessions for this ticket — defensive against
-  // sessions resurrected by autoRestart between ticks. tmux kill-session is
-  // idempotent and silent when the session is already gone.
+function buildNextActionInstruction({ prefix, suffix, next, autoBootstrapped }) {
+  if (autoBootstrapped) {
+    return `${prefix}NEXT_ACTION=auto-bootstrapped ${next.taskId} from manifest "${next.topic}". No operator action needed unless bootstrap log shows failure.`;
+  }
+  if (next) {
+    return `${prefix}NEXT_ACTION=bootstrap ${next.taskId} (manifest "${next.topic}", priority=${next.priority}). Run: bash plugins/maestro/scripts/maestro-bootstrap.sh ${next.taskId}. Set AUTO_BOOTSTRAP_NEXT=1 to skip this step.${suffix}`;
+  }
+  return `${prefix}NEXT_ACTION=do-nothing — no eligible pending task across orchestration manifests.${suffix}`;
+}
+
+function killTicketTmux(ticket) {
   for (const suffix of ['work', 'listen']) {
     spawnSync('tmux', ['kill-session', '-t', `${ticket}-${suffix}`], { stdio: 'ignore' });
   }
-  // Per-ticket marker that autoRestart consults to refuse resurrection.
-  // Overwritten on each fresh SHA so a force-push that re-opens CI naturally
-  // re-engages the agent.
-  state.write(ticket, 'ci-gate-freed', { killed: true, sha, prNumber, freedAt: state.now() });
-  // Skip alert + bootstrap if this exact SHA was already announced — prevents
-  // spam on every tick. The kill above still runs (defensive).
-  if (marker.sha === sha && ciFreed.sha === sha) return false;
-  state.write(session, 'slot-freed', { sha, prNumber, freedAt: state.now() });
-  const next = findNextEligibleTask();
-  const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);
-  let instruction;
-  if (autoBootstrapped) {
-    instruction = `Slot freed for PR #${prNumber} (sha=${(sha || '').slice(0, 7)}). NEXT_ACTION=auto-bootstrapped ${next.taskId} from manifest "${next.topic}". No operator action needed unless bootstrap log shows failure.`;
-  } else if (next) {
-    instruction = `Slot freed for PR #${prNumber} (sha=${(sha || '').slice(0, 7)}). NEXT_ACTION=bootstrap ${next.taskId} (manifest "${next.topic}", priority=${next.priority}). Run: bash plugins/maestro/scripts/maestro-bootstrap.sh ${next.taskId}. Set AUTO_BOOTSTRAP_NEXT=1 to skip this step. Operator merges PR #${prNumber} separately.`;
-  } else {
-    instruction = `Slot freed for PR #${prNumber} (sha=${(sha || '').slice(0, 7)}). NEXT_ACTION=do-nothing — no eligible pending task across orchestration manifests. Operator merges PR #${prNumber} separately.`;
-  }
+}
+
+function emitSlotFreedAlert({ session, ticket, prNumber, sha, next, autoBootstrapped, instruction }) {
   alerts.log(
     `${session} SLOT-FREED at CI gate — PR #${prNumber} sha=${(sha || '').slice(0, 7)} awaiting operator merge; tmux -work + -listen killed${
       autoBootstrapped ? `; AUTO-BOOTSTRAPPED ${next.taskId}` : ''
@@ -253,6 +269,30 @@ function freeCIGateSlot({ session, ticket, prNumber, sha }) {
     autoBootstrapped: !!autoBootstrapped,
     instruction,
   });
+}
+
+function freeCIGateSlot({ session, ticket, prNumber, sha }) {
+  if (process.env.AUTO_FREE_CI_SLOT === '0') return false;
+  const marker = state.read(session, 'slot-freed') || {};
+  const ciFreed = state.read(ticket, 'ci-gate-freed') || {};
+  // Always kill any alive tmux sessions for this ticket — defensive against
+  // sessions resurrected by autoRestart between ticks. tmux kill-session is
+  // idempotent and silent when the session is already gone.
+  killTicketTmux(ticket);
+  // Per-ticket marker that autoRestart consults to refuse resurrection.
+  // Overwritten on each fresh SHA so a force-push that re-opens CI naturally
+  // re-engages the agent.
+  state.write(ticket, 'ci-gate-freed', { killed: true, sha, prNumber, freedAt: state.now() });
+  // Skip alert + bootstrap if this exact SHA was already announced — prevents
+  // spam on every tick. The kill above still runs (defensive).
+  if (marker.sha === sha && ciFreed.sha === sha) return false;
+  state.write(session, 'slot-freed', { sha, prNumber, freedAt: state.now() });
+  const next = findNextEligibleTask();
+  const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);
+  const prefix = `Slot freed for PR #${prNumber} (sha=${(sha || '').slice(0, 7)}). `;
+  const suffix = ` Operator merges PR #${prNumber} separately.`;
+  const instruction = buildNextActionInstruction({ prefix, suffix, next, autoBootstrapped });
+  emitSlotFreedAlert({ session, ticket, prNumber, sha, next, autoBootstrapped, instruction });
   return true;
 }
 
@@ -270,20 +310,12 @@ function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
   if (process.env.AUTO_FREE_DEAD_END === '0') return false;
   const marker = state.read(ticket, 'dead-end') || {};
   if (marker.killed) return false; // already freed
-  for (const suffix of ['work', 'listen']) {
-    spawnSync('tmux', ['kill-session', '-t', `${ticket}-${suffix}`], { stdio: 'ignore' });
-  }
+  killTicketTmux(ticket);
   state.write(ticket, 'dead-end', { killed: true, freedAt: state.now(), trigger: kind });
   const next = findNextEligibleTask();
   const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);
-  let instruction;
-  if (autoBootstrapped) {
-    instruction = `DEAD-END on ${ticket} after ${kind} ×${repeatCount}. NEXT_ACTION=auto-bootstrapped ${next.taskId} from manifest "${next.topic}". No operator action needed unless bootstrap log shows failure.`;
-  } else if (next) {
-    instruction = `DEAD-END on ${ticket} after ${kind} ×${repeatCount}. NEXT_ACTION=bootstrap ${next.taskId} (manifest "${next.topic}", priority=${next.priority}). Run: bash plugins/maestro/scripts/maestro-bootstrap.sh ${next.taskId}. Set AUTO_BOOTSTRAP_NEXT=1 to skip this step.`;
-  } else {
-    instruction = `DEAD-END on ${ticket} after ${kind} ×${repeatCount}. NEXT_ACTION=do-nothing — no eligible pending task across orchestration manifests.`;
-  }
+  const prefix = `DEAD-END on ${ticket} after ${kind} ×${repeatCount}. `;
+  const instruction = buildNextActionInstruction({ prefix, suffix: '', next, autoBootstrapped });
   alerts.log(
     `${session} DEAD-END ${kind} re-fired ${repeatCount}x — tmux killed, slot freed${
       autoBootstrapped ? `; AUTO-BOOTSTRAPPED ${next.taskId}` : ''

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -301,7 +301,7 @@ function freeCIGateSlot({ session, ticket, prNumber, sha }) {
   state.write(ticket, 'ci-gate-freed', { killed: true, sha, prNumber, freedAt: state.now() });
   // Skip alert + bootstrap if this exact SHA was already announced — prevents
   // spam on every tick. The kill above still runs (defensive).
-  if (marker.sha === sha && ciFreed.sha === sha) return false;
+  if (marker.sha === sha || ciFreed.sha === sha) return false;
   state.write(session, 'slot-freed', { sha, prNumber, freedAt: state.now() });
   const next = findNextEligibleTask();
   const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -59,7 +59,12 @@ function topPendingForManifest(manifest, entry) {
 function findNextEligibleTask() {
   if (!fs.existsSync(SESSION_MANIFEST_DIR)) return null;
   let best = null;
-  for (const entry of fs.readdirSync(SESSION_MANIFEST_DIR)) {
+  // Sort manifest filenames so readdirSync iteration order is deterministic
+  // across filesystems. This gives a stable tie-break by filename when two
+  // eligible tasks share the same numeric priority (the natural tie-break
+  // here is ticket id, since manifest filenames are derived from topic/ticket).
+  const entries = fs.readdirSync(SESSION_MANIFEST_DIR).slice().sort();
+  for (const entry of entries) {
     if (!entry.endsWith('.json')) continue;
     const manifest = readManifestSafe(path.join(SESSION_MANIFEST_DIR, entry));
     if (!manifest) continue;

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -18,6 +18,7 @@ const tmux = require('./tmux');
 const alerts = require('./alerts');
 const state = require('./state');
 const { headSha } = require('./detectors/gh-shared');
+const { eligibleTasks } = require('./session-shared');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
 const SKILL_NAME = process.env.SKILL_NAME || 'work';
@@ -42,14 +43,11 @@ function readManifestSafe(file) {
 }
 
 function topPendingForManifest(manifest, entry) {
-  const tasks = Array.isArray(manifest.tasks) ? manifest.tasks : [];
-  const doneIds = new Set(tasks.filter((t) => t.status === 'done').map((t) => t.id));
-  const pending = tasks.filter(
-    (t) => t.status === 'pending' && (t.deps || []).every((d) => doneIds.has(d))
-  );
-  if (pending.length === 0) return null;
-  pending.sort((a, b) => (a.priority || 9999) - (b.priority || 9999));
-  const top = pending[0];
+  // Reuse session-shared.eligibleTasks so the slot-freed bootstrap path and
+  // the maestro-session CLI agree on the next task (incl. default priority).
+  const ranked = eligibleTasks(Array.isArray(manifest.tasks) ? manifest.tasks : []);
+  if (ranked.length === 0) return null;
+  const top = ranked[0];
   return {
     topic: manifest.topic || entry.replace(/\.json$/, ''),
     taskId: top.id,
@@ -66,7 +64,7 @@ function findNextEligibleTask() {
     if (!manifest) continue;
     const candidate = topPendingForManifest(manifest, entry);
     if (!candidate) continue;
-    if (!best || (candidate.priority || 9999) < (best.priority || 9999)) {
+    if (!best || (candidate.priority || 999) < (best.priority || 999)) {
       best = candidate;
     }
   }

--- a/plugins/maestro/scripts/lib/maestro-conduct/alerts.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/alerts.js
@@ -7,12 +7,17 @@
  * and the main loop decides when to escalate.
  */
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const tmux = require('./tmux');
 
 const ALERT_FILE = process.env.ALERT_FILE || '/tmp/maestro-alerts.jsonl';
 const ALERT_SESSION = process.env.ALERT_SESSION || 'maestro-alerts';
-const STATE_DIR = process.env.STATE_DIR || '/tmp/maestro-conduct';
+// Must match state.js default so persisted alert counts live alongside the
+// per-ticket markers that gate dead-end escalation. Previously defaulted to
+// /tmp/maestro-conduct, which diverged from state.js (~/.cache/maestro-conduct)
+// and caused repeat counts to be stored in the wrong place.
+const STATE_DIR = process.env.STATE_DIR || path.join(os.homedir(), '.cache', 'maestro-conduct');
 
 // In-process emit counter keyed by `${session}|${kind}|${sha||phase}`. Cleared
 // by the caller (typically via freeDeadEndSlot or phase advance). Persisted to

--- a/plugins/maestro/scripts/lib/maestro-conduct/alerts.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/alerts.js
@@ -7,28 +7,97 @@
  * and the main loop decides when to escalate.
  */
 const fs = require('fs');
+const path = require('path');
 const tmux = require('./tmux');
 
 const ALERT_FILE = process.env.ALERT_FILE || '/tmp/maestro-alerts.jsonl';
 const ALERT_SESSION = process.env.ALERT_SESSION || 'maestro-alerts';
+const STATE_DIR = process.env.STATE_DIR || '/tmp/maestro-conduct';
+
+// In-process emit counter keyed by `${session}|${kind}|${sha||phase}`. Cleared
+// by the caller (typically via freeDeadEndSlot or phase advance). Persisted to
+// disk in STATE_DIR/_alert-counts.json so a daemon restart doesn't lose count.
+const COUNT_FILE = path.join(STATE_DIR, '_alert-counts.json');
+function loadCounts() {
+  try {
+    return JSON.parse(fs.readFileSync(COUNT_FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+function saveCounts(counts) {
+  try {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+    fs.writeFileSync(COUNT_FILE, JSON.stringify(counts));
+  } catch {}
+}
+function bumpCount(key) {
+  const counts = loadCounts();
+  counts[key] = (counts[key] || 0) + 1;
+  saveCounts(counts);
+  return counts[key];
+}
+function resetCount(key) {
+  const counts = loadCounts();
+  if (key in counts) {
+    delete counts[key];
+    saveCounts(counts);
+  }
+}
+function alertKey(obj) {
+  return `${obj.session || obj.ticket}|${obj.kind}|${obj.sha || obj.phase || '_'}`;
+}
 
 function log(line) {
   const ts = new Date().toISOString();
   const out = `[${ts}] ${line}\n`;
   process.stderr.write(out);
-  try { fs.appendFileSync(process.env.LOG_FILE || '/tmp/maestro-conduct.log', out); }
-  catch {}
+  try {
+    fs.appendFileSync(process.env.LOG_FILE || '/tmp/maestro-conduct.log', out);
+  } catch {}
 }
 
+/**
+ * Emit an action-required alert. Refuses payloads without an `instruction`
+ * field — informational events must use log() instead. The operator should
+ * be able to read the instruction and execute it without further context.
+ *
+ * Expected shape:
+ *   {
+ *     session, ticket, kind,        // identity
+ *     ...event-specific fields,     // sha, prNumber, options, etc.
+ *     instruction: '...',           // REQUIRED — exact action to take
+ *   }
+ *
+ * The tmux summary line embeds the kind + instruction so it's grep-friendly
+ * and self-explanatory in the maestro-alerts pane.
+ */
+/**
+ * Emit an action-required alert. Returns { count } — the number of times this
+ * same (session, kind, sha-or-phase) has been emitted since last reset.
+ *
+ * The caller must check the count and escalate when it crosses a threshold
+ * (typically auto-call freeDeadEndSlot at count >= 3). The instruction string
+ * gets a [REPEAT N] prefix when count > 1 so the operator can see momentum.
+ */
 function alert(obj) {
-  const payload = { ts: new Date().toISOString(), ...obj };
-  try { fs.appendFileSync(ALERT_FILE, JSON.stringify(payload) + '\n'); } catch {}
+  if (!obj || typeof obj.instruction !== 'string' || !obj.instruction.trim()) {
+    log(`ALERT-DROPPED (no instruction): ${JSON.stringify(obj)}`);
+    return { count: 0 };
+  }
+  const key = alertKey(obj);
+  const count = bumpCount(key);
+  const prefix = count > 1 ? `[REPEAT ${count}] ` : '';
+  const instruction = `${prefix}${obj.instruction}`;
+  const payload = { ts: new Date().toISOString(), ...obj, instruction, repeatCount: count };
+  try {
+    fs.appendFileSync(ALERT_FILE, JSON.stringify(payload) + '\n');
+  } catch {}
   tmux.ensureSession(ALERT_SESSION);
-  const summary = `MAESTRO-ALERT ${obj.session || obj.ticket || '?'} ${obj.kind}` +
-    (obj.phase ? ` phase=${obj.phase}` : '') +
-    (typeof obj.elapsedMin === 'number' ? ` elapsed=${obj.elapsedMin}m` : '');
+  const summary = `ACTION ${obj.session || obj.ticket || '?'} kind=${obj.kind} → ${instruction}`;
   tmux.sendLine(ALERT_SESSION, summary);
-  log(`ALERT ${JSON.stringify(payload)}`);
+  log(`ACTION ${JSON.stringify(payload)}`);
+  return { count };
 }
 
-module.exports = { alert, log, ALERT_FILE, ALERT_SESSION };
+module.exports = { alert, log, resetCount, alertKey, ALERT_FILE, ALERT_SESSION };

--- a/plugins/maestro/scripts/lib/maestro-conduct/alerts.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/alerts.js
@@ -71,14 +71,12 @@ function log(line) {
  *
  * The tmux summary line embeds the kind + instruction so it's grep-friendly
  * and self-explanatory in the maestro-alerts pane.
- */
-/**
- * Emit an action-required alert. Returns { count } — the number of times this
- * same (session, kind, sha-or-phase) has been emitted since last reset.
  *
- * The caller must check the count and escalate when it crosses a threshold
- * (typically auto-call freeDeadEndSlot at count >= 3). The instruction string
- * gets a [REPEAT N] prefix when count > 1 so the operator can see momentum.
+ * Returns { count } — the number of times this same (session, kind,
+ * sha-or-phase) has been emitted since last reset. The caller must check
+ * the count and escalate when it crosses a threshold (typically auto-call
+ * freeDeadEndSlot at count >= 3). The instruction string gets a [REPEAT N]
+ * prefix when count > 1 so the operator can see momentum.
  */
 function alert(obj) {
   if (!obj || typeof obj.instruction !== 'string' || !obj.instruction.trim()) {

--- a/plugins/maestro/scripts/lib/maestro-conduct/detectors/commit-stall.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/detectors/commit-stall.js
@@ -4,12 +4,23 @@
  * Informational signal for the implement phase: warn when no commits
  * have landed in the worktree for COMMIT_STALL_MIN minutes.
  *
- * Does NOT itself trigger a nudge; the main loop pairs this with
- * phase-stall to enrich alerts.
+ * Dedup contract: this detector only "hits" when the stall has crossed a
+ * NEW threshold since last we asked. Thresholds are `[30, 60, 120, 240, 480]`
+ * minutes by default. Without this dedup the detector fires every tick (60s),
+ * producing hundreds of identical log lines that desensitize the orchestrator
+ * — see SKILL.md "Daemon event vocabulary" for the contract.
+ *
+ * Does NOT trigger a nudge; the main loop pairs this with phase-stall.
  */
 const { spawnSync } = require('child_process');
+const state = require('../state');
 
 const COMMIT_STALL_MIN = parseInt(process.env.COMMIT_STALL_MIN || '30', 10);
+const COMMIT_STALL_THRESHOLDS = (process.env.COMMIT_STALL_THRESHOLDS || '30,60,120,240,480')
+  .split(',')
+  .map((s) => parseInt(s.trim(), 10))
+  .filter((n) => Number.isFinite(n) && n >= COMMIT_STALL_MIN)
+  .sort((a, b) => a - b);
 
 function minutesSinceLastCommit(worktree) {
   const res = spawnSync('git', ['-C', worktree, 'log', '-1', '--format=%ct'], {
@@ -22,11 +33,31 @@ function minutesSinceLastCommit(worktree) {
   return Math.floor((Date.now() / 1000 - secs) / 60);
 }
 
-function detect({ worktree }) {
-  if (!worktree) return { hit: false };
-  const mins = minutesSinceLastCommit(worktree);
-  if (mins < COMMIT_STALL_MIN) return { hit: false };
-  return { hit: true, kind: 'commit-stall', mins };
+/**
+ * Highest threshold not exceeding `mins`. Returns 0 when below the floor.
+ */
+function thresholdFor(mins) {
+  return COMMIT_STALL_THRESHOLDS.reduce((acc, t) => (mins >= t ? t : acc), 0);
 }
 
-module.exports = { name: 'commitStall', detect };
+function detect({ ticket, worktree }) {
+  if (!worktree) return { hit: false };
+  const mins = minutesSinceLastCommit(worktree);
+  if (mins < COMMIT_STALL_MIN) {
+    // Recovered — clear marker so the next stall starts fresh.
+    if (ticket && state.read(ticket, 'commit-stall')) state.clear(ticket, 'commit-stall');
+    return { hit: false };
+  }
+  const level = thresholdFor(mins);
+  if (level === 0) return { hit: false };
+  // Dedup against marker. Marker is per-ticket because the worktree (and
+  // therefore commit cadence) belongs to the ticket, not the pane.
+  const marker = (ticket && state.read(ticket, 'commit-stall')) || { lastThreshold: 0 };
+  if (level <= marker.lastThreshold) return { hit: false };
+  if (ticket) {
+    state.write(ticket, 'commit-stall', { lastThreshold: level, lastAt: state.now() });
+  }
+  return { hit: true, kind: 'commit-stall', mins, threshold: level };
+}
+
+module.exports = { name: 'commitStall', detect, thresholdFor, COMMIT_STALL_THRESHOLDS };

--- a/plugins/maestro/scripts/lib/maestro-conduct/detectors/gh-shared.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/detectors/gh-shared.js
@@ -1,0 +1,68 @@
+/**
+ * detectors/gh-shared.js
+ *
+ * Shared `gh` + `git` helpers for PR-aware detectors (pr-comments, pr-status).
+ * Extracted to deduplicate the spawn / repo-derivation / pr-lookup block that
+ * was copy-pasted across detector files.
+ */
+const { spawnSync } = require('child_process');
+
+function spawnOut(cmd, args) {
+  const res = spawnSync(cmd, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  return res.status === 0 ? res.stdout || '' : '';
+}
+
+function gitOut(worktree, args) {
+  return spawnOut('git', ['-C', worktree, ...args]).trim();
+}
+
+function headSha(worktree) {
+  return gitOut(worktree, ['rev-parse', 'HEAD']);
+}
+
+function deriveRepo(worktree) {
+  const url = gitOut(worktree || '.', ['remote', 'get-url', 'origin']);
+  if (!url) return '';
+  // Match owner/repo from https://github.com/owner/repo(.git) or git@github.com:owner/repo(.git)
+  const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+  return m ? `${m[1]}/${m[2]}` : '';
+}
+
+function repoSlug(worktree) {
+  return process.env.GITHUB_REPO || deriveRepo(worktree);
+}
+
+/**
+ * Look up the open PR for `<ticket>-maestro` on the resolved repo. Returns
+ * the PR number or null when no open PR exists / lookup fails.
+ */
+function prNumberFor(ticket, worktree) {
+  const repo = repoSlug(worktree);
+  if (!repo) return null;
+  const json = spawnOut('gh', [
+    'pr',
+    'list',
+    '--repo',
+    repo,
+    '--head',
+    `${ticket}-maestro`,
+    '--state',
+    'open',
+    '--json',
+    'number',
+    '--limit',
+    '1',
+  ]);
+  if (!json) return null;
+  try {
+    const arr = JSON.parse(json);
+    return arr[0] && arr[0].number;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { spawnOut, gitOut, headSha, deriveRepo, repoSlug, prNumberFor };

--- a/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-comments.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-comments.js
@@ -16,65 +16,10 @@
  * The PR number is resolved from the branch name `<ticket>-maestro` via
  * `gh pr list --head`. Result is cached per tick.
  */
-const { spawnSync } = require('child_process');
 const state = require('../state');
+const { spawnOut, headSha, repoSlug, prNumberFor } = require('./gh-shared');
 
 const BOT_RE = /(cursor|copilot|bugbot|codex|sourcery)/i;
-
-function spawnOut(cmd, args) {
-  const res = spawnSync(cmd, args, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'ignore'],
-  });
-  return res.status === 0 ? res.stdout || '' : '';
-}
-
-function gitOut(worktree, args) {
-  return spawnOut('git', ['-C', worktree, ...args]).trim();
-}
-
-function headSha(worktree) {
-  return gitOut(worktree, ['rev-parse', 'HEAD']);
-}
-
-function deriveRepo(worktree) {
-  const url = gitOut(worktree || '.', ['remote', 'get-url', 'origin']);
-  if (!url) return '';
-  // Match owner/repo from https://github.com/owner/repo(.git) or git@github.com:owner/repo(.git)
-  const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
-  return m ? `${m[1]}/${m[2]}` : '';
-}
-
-function repoSlug(worktree) {
-  return process.env.GITHUB_REPO || deriveRepo(worktree);
-}
-
-function prNumberFor(ticket, worktree) {
-  const repo = repoSlug(worktree);
-  if (!repo) return null;
-  // Branch convention from maestro-bootstrap: <ticket>-maestro
-  const json = spawnOut('gh', [
-    'pr',
-    'list',
-    '--repo',
-    repo,
-    '--head',
-    `${ticket}-maestro`,
-    '--state',
-    'open',
-    '--json',
-    'number',
-    '--limit',
-    '1',
-  ]);
-  if (!json) return null;
-  try {
-    const arr = JSON.parse(json);
-    return arr[0] && arr[0].number;
-  } catch {
-    return null;
-  }
-}
 
 function fetchBotComments(prNumber, worktree) {
   const repo = repoSlug(worktree);

--- a/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-comments.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-comments.js
@@ -64,10 +64,12 @@ function detect({ ticket, worktree }) {
   const prev = state.read(ticket, 'pr-comments');
   const now = state.now();
 
-  // No comments → clear any stale marker and bail.
+  // No comments → clear any stale marker and bail. Signal reset so the caller
+  // can also purge the persisted alert repeat count; otherwise a later stuck
+  // cycle would inherit the prior count and fire freeDeadEndSlot too soon.
   if (count === 0) {
     if (prev) state.clear(ticket, 'pr-comments');
-    return { hit: false };
+    return { hit: false, reset: !!prev };
   }
 
   // First time we see comments — record and bail. Wait for a stable read.
@@ -76,18 +78,20 @@ function detect({ ticket, worktree }) {
     return { hit: false };
   }
 
-  // HEAD moved since last check → agent has pushed; reset the watch.
+  // HEAD moved since last check → agent has pushed; reset the watch. Also
+  // reset the persisted alert repeat count so a new stuck cycle starts at 1.
   if (prev.sha !== sha) {
     state.write(ticket, 'pr-comments', { count, sha, firstSeenAt: now, alerted: false });
-    return { hit: false };
+    return { hit: false, reset: true };
   }
 
   // Count changed (bot still posting, or new wave of comments) → reset the
   // full watch: nudges + alerted clear too. Otherwise an exhausted prior
   // escalation cycle would silence escalation for the new comments forever.
+  // Reset the persisted alert count for the same reason.
   if (prev.count !== count) {
     state.write(ticket, 'pr-comments', { count, sha, firstSeenAt: now, alerted: false });
-    return { hit: false };
+    return { hit: false, reset: true };
   }
 
   // Same sha and same count two reads in a row → agent sat on them.

--- a/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-status.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-status.js
@@ -1,0 +1,192 @@
+/**
+ * detectors/pr-status.js
+ *
+ * Positive-signal detector. For each ticket with an open PR on
+ * `<ticket>-maestro`, watch the CI rollup + merge state and emit a
+ * `pr-ready` / `pr-broken` event the moment the state transitions.
+ *
+ * The orchestrator's failure mode this is built to defeat: when every
+ * other signal is "wedged-shaped" (commit-stall, silence, phase-stall),
+ * a ready PR is silent — indistinguishable from a stuck agent. By
+ * emitting a discrete `pr-ready` alert on transition, the operator has
+ * an unambiguous "go merge this" signal.
+ *
+ * State machine per ticket:
+ *   <no marker>          -> read PR, write marker, emit if SUCCESS/CLEAN
+ *   SUCCESS/CLEAN        -> emit `pr-ready` once; re-emit only if SHA changes
+ *                           OR after RE_EMIT_MIN minutes have elapsed
+ *   FAILURE or DIRTY     -> emit `pr-broken` with failing-check details
+ *   PENDING              -> log only, never alert (CI still running)
+ *
+ * Reuses the gh-call pattern from `pr-comments.js` (`gh pr list --head ...`
+ * + `gh api`/`gh pr view --json`). Same bot-API and same caching cadence.
+ */
+const { spawnSync } = require('child_process');
+const state = require('../state');
+
+const RE_EMIT_MIN = parseInt(process.env.PR_STATUS_RE_EMIT_MIN || '30', 10);
+
+function spawnOut(cmd, args) {
+  const res = spawnSync(cmd, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  return res.status === 0 ? res.stdout || '' : '';
+}
+
+function gitOut(worktree, args) {
+  return spawnOut('git', ['-C', worktree, ...args]).trim();
+}
+
+function deriveRepo(worktree) {
+  const url = gitOut(worktree || '.', ['remote', 'get-url', 'origin']);
+  if (!url) return '';
+  const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+  return m ? `${m[1]}/${m[2]}` : '';
+}
+
+function repoSlug(worktree) {
+  return process.env.GITHUB_REPO || deriveRepo(worktree);
+}
+
+function prNumberFor(ticket, worktree) {
+  const repo = repoSlug(worktree);
+  if (!repo) return null;
+  const json = spawnOut('gh', [
+    'pr',
+    'list',
+    '--repo',
+    repo,
+    '--head',
+    `${ticket}-maestro`,
+    '--state',
+    'open',
+    '--json',
+    'number',
+    '--limit',
+    '1',
+  ]);
+  if (!json) return null;
+  try {
+    const arr = JSON.parse(json);
+    return arr[0] && arr[0].number;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read PR status from gh. Returns:
+ *   { prNumber, sha, checksState, mergeable, failingChecks: [{name, conclusion, url}] }
+ * checksState: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'UNKNOWN'
+ * mergeable: GitHub mergeStateStatus verbatim ('CLEAN', 'DIRTY', 'BLOCKED', 'BEHIND', 'UNSTABLE', 'UNKNOWN')
+ */
+function fetchPrStatus(prNumber, worktree) {
+  const repo = repoSlug(worktree);
+  if (!repo) return null;
+  const json = spawnOut('gh', [
+    'pr',
+    'view',
+    String(prNumber),
+    '--repo',
+    repo,
+    '--json',
+    'statusCheckRollup,mergeStateStatus,headRefOid',
+  ]);
+  if (!json) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  const rollup = Array.isArray(parsed.statusCheckRollup) ? parsed.statusCheckRollup : [];
+  // GH normalises CheckRun + StatusContext into a single rollup. Both shapes
+  // carry `conclusion` (`SUCCESS`/`FAILURE`/...) once finished, and `status`
+  // (`COMPLETED`/`IN_PROGRESS`/...) until then.
+  const failing = rollup
+    .filter((c) => /FAILURE|TIMED_OUT|CANCELLED|STARTUP_FAILURE/i.test(c.conclusion || ''))
+    .map((c) => ({
+      name: c.name || c.context || '?',
+      conclusion: c.conclusion,
+      url: c.detailsUrl || c.targetUrl || null,
+    }));
+  const pending = rollup.filter(
+    (c) => !c.conclusion && /(PENDING|IN_PROGRESS|QUEUED|WAITING)/i.test(c.status || '')
+  );
+  let checksState = 'UNKNOWN';
+  if (rollup.length === 0) checksState = 'UNKNOWN';
+  else if (failing.length > 0) checksState = 'FAILURE';
+  else if (pending.length > 0) checksState = 'PENDING';
+  else checksState = 'SUCCESS';
+  return {
+    prNumber,
+    sha: parsed.headRefOid || '',
+    checksState,
+    mergeable: parsed.mergeStateStatus || 'UNKNOWN',
+    failingChecks: failing,
+  };
+}
+
+/**
+ * Classify the (checksState, mergeable) tuple into the emit kind.
+ *   pr-ready   : checks SUCCESS AND mergeable CLEAN (the green-merge state)
+ *   pr-broken  : any failing check OR mergeable DIRTY (must intervene)
+ *   pr-pending : checks PENDING (log-only)
+ *   none       : everything else (UNSTABLE, BLOCKED awaiting review, etc.)
+ *                — we deliberately don't emit on these; they're transient or
+ *                require an external action that we already surface elsewhere.
+ */
+function classify(checksState, mergeable) {
+  if (checksState === 'FAILURE' || mergeable === 'DIRTY') return 'pr-broken';
+  if (checksState === 'SUCCESS' && mergeable === 'CLEAN') return 'pr-ready';
+  if (checksState === 'PENDING') return 'pr-pending';
+  return null;
+}
+
+function detect({ ticket, worktree }) {
+  if (!ticket || !worktree) return { hit: false };
+
+  const prNumber = prNumberFor(ticket, worktree);
+  if (!prNumber) return { hit: false }; // no open PR yet
+
+  const status = fetchPrStatus(prNumber, worktree);
+  if (!status) return { hit: false };
+
+  const kind = classify(status.checksState, status.mergeable);
+  if (!kind) return { hit: false };
+
+  const prev = state.read(ticket, 'pr-status');
+  const now = state.now();
+
+  // First sighting or state change → emit.
+  // Rate-limit re-emit of the SAME state to once per RE_EMIT_MIN, so a flapping
+  // check (SUCCESS → PENDING → SUCCESS) doesn't spam.
+  const shaChanged = !prev || prev.sha !== status.sha;
+  const stateChanged = !prev || prev.lastState !== kind;
+  const sinceLast = prev && prev.lastEmittedAt ? state.minutesSince(prev.lastEmittedAt) : Infinity;
+  const shouldEmit = stateChanged || shaChanged || sinceLast >= RE_EMIT_MIN;
+
+  // Always write the marker so subsequent reads see the latest state, even
+  // if we don't emit this tick.
+  state.write(ticket, 'pr-status', {
+    prNumber,
+    sha: status.sha,
+    lastState: kind,
+    lastEmittedAt: shouldEmit ? now : (prev && prev.lastEmittedAt) || 0,
+  });
+
+  if (!shouldEmit) return { hit: false };
+
+  return {
+    hit: true,
+    kind,
+    prNumber,
+    sha: status.sha,
+    checksState: status.checksState,
+    mergeable: status.mergeable,
+    failingChecks: status.failingChecks,
+  };
+}
+
+module.exports = { name: 'prStatus', detect, classify };

--- a/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-status.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-status.js
@@ -112,7 +112,6 @@ function resolvePrContext({ ticket, worktree }) {
   const status = fetchPrStatus(prNumber, worktree);
   if (!status) return null;
   const kind = classify(status.checksState, status.mergeable);
-  if (!kind) return null;
   return { prNumber, status, kind };
 }
 
@@ -123,10 +122,23 @@ function detect({ ticket, worktree }) {
 
   const prev = state.read(ticket, 'pr-status');
   const now = state.now();
+
+  // Unclassified state (UNSTABLE/BLOCKED/etc.): refresh marker so heartbeat
+  // doesn't keep reporting a stale lastState (e.g. lingering 'pr-ready'),
+  // but don't emit. Marker write is unconditional so downstream readers
+  // always see the current PR snapshot.
+  if (!kind) {
+    state.write(ticket, 'pr-status', {
+      prNumber,
+      sha: status.sha,
+      lastState: null,
+      lastEmittedAt: (prev && prev.lastEmittedAt) || 0,
+    });
+    return { hit: false };
+  }
+
   const shouldEmit = computeEmitDecision(prev, status, kind);
 
-  // Always write the marker so subsequent reads see the latest state, even
-  // if we don't emit this tick.
   state.write(ticket, 'pr-status', {
     prNumber,
     sha: status.sha,

--- a/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-status.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-status.js
@@ -65,7 +65,7 @@ function fetchPrStatus(prNumber, worktree) {
   const pending = rollup.filter(
     (c) => !c.conclusion && /(PENDING|IN_PROGRESS|QUEUED|WAITING)/i.test(c.status || '')
   );
-  let checksState = 'UNKNOWN';
+  let checksState;
   if (rollup.length === 0) checksState = 'UNKNOWN';
   else if (failing.length > 0) checksState = 'FAILURE';
   else if (pending.length > 0) checksState = 'PENDING';

--- a/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-status.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/detectors/pr-status.js
@@ -21,59 +21,10 @@
  * Reuses the gh-call pattern from `pr-comments.js` (`gh pr list --head ...`
  * + `gh api`/`gh pr view --json`). Same bot-API and same caching cadence.
  */
-const { spawnSync } = require('child_process');
 const state = require('../state');
+const { spawnOut, repoSlug, prNumberFor } = require('./gh-shared');
 
 const RE_EMIT_MIN = parseInt(process.env.PR_STATUS_RE_EMIT_MIN || '30', 10);
-
-function spawnOut(cmd, args) {
-  const res = spawnSync(cmd, args, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'ignore'],
-  });
-  return res.status === 0 ? res.stdout || '' : '';
-}
-
-function gitOut(worktree, args) {
-  return spawnOut('git', ['-C', worktree, ...args]).trim();
-}
-
-function deriveRepo(worktree) {
-  const url = gitOut(worktree || '.', ['remote', 'get-url', 'origin']);
-  if (!url) return '';
-  const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
-  return m ? `${m[1]}/${m[2]}` : '';
-}
-
-function repoSlug(worktree) {
-  return process.env.GITHUB_REPO || deriveRepo(worktree);
-}
-
-function prNumberFor(ticket, worktree) {
-  const repo = repoSlug(worktree);
-  if (!repo) return null;
-  const json = spawnOut('gh', [
-    'pr',
-    'list',
-    '--repo',
-    repo,
-    '--head',
-    `${ticket}-maestro`,
-    '--state',
-    'open',
-    '--json',
-    'number',
-    '--limit',
-    '1',
-  ]);
-  if (!json) return null;
-  try {
-    const arr = JSON.parse(json);
-    return arr[0] && arr[0].number;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Read PR status from gh. Returns:
@@ -144,28 +95,35 @@ function classify(checksState, mergeable) {
   return null;
 }
 
-function detect({ ticket, worktree }) {
-  if (!ticket || !worktree) return { hit: false };
-
-  const prNumber = prNumberFor(ticket, worktree);
-  if (!prNumber) return { hit: false }; // no open PR yet
-
-  const status = fetchPrStatus(prNumber, worktree);
-  if (!status) return { hit: false };
-
-  const kind = classify(status.checksState, status.mergeable);
-  if (!kind) return { hit: false };
-
-  const prev = state.read(ticket, 'pr-status');
-  const now = state.now();
-
+function computeEmitDecision(prev, status, kind) {
   // First sighting or state change → emit.
   // Rate-limit re-emit of the SAME state to once per RE_EMIT_MIN, so a flapping
   // check (SUCCESS → PENDING → SUCCESS) doesn't spam.
   const shaChanged = !prev || prev.sha !== status.sha;
   const stateChanged = !prev || prev.lastState !== kind;
   const sinceLast = prev && prev.lastEmittedAt ? state.minutesSince(prev.lastEmittedAt) : Infinity;
-  const shouldEmit = stateChanged || shaChanged || sinceLast >= RE_EMIT_MIN;
+  return stateChanged || shaChanged || sinceLast >= RE_EMIT_MIN;
+}
+
+function resolvePrContext({ ticket, worktree }) {
+  if (!ticket || !worktree) return null;
+  const prNumber = prNumberFor(ticket, worktree);
+  if (!prNumber) return null;
+  const status = fetchPrStatus(prNumber, worktree);
+  if (!status) return null;
+  const kind = classify(status.checksState, status.mergeable);
+  if (!kind) return null;
+  return { prNumber, status, kind };
+}
+
+function detect({ ticket, worktree }) {
+  const ctx = resolvePrContext({ ticket, worktree });
+  if (!ctx) return { hit: false };
+  const { prNumber, status, kind } = ctx;
+
+  const prev = state.read(ticket, 'pr-status');
+  const now = state.now();
+  const shouldEmit = computeEmitDecision(prev, status, kind);
 
   // Always write the marker so subsequent reads see the latest state, even
   // if we don't emit this tick.

--- a/plugins/maestro/scripts/lib/maestro-conduct/heartbeat.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/heartbeat.js
@@ -1,0 +1,63 @@
+/**
+ * heartbeat.js — periodic positive summary line for the maestro daemon.
+ *
+ * Extracted from maestro-conduct.js so the conductor stays under the
+ * max-lines-per-file gate. The HEARTBEAT keyword is the grep handle for
+ * downstream tooling; the format is one line per tick window.
+ */
+const tmux = require('./tmux');
+const state = require('./state');
+const workstate = require('./workstate');
+
+// Only -work sessions are restart-eligible / counted in active totals.
+function restartEligible(session) {
+  return /-work$/.test(session);
+}
+
+function collectPrFlag(prMarker, totals) {
+  if (!prMarker) return null;
+  if (prMarker.lastState === 'pr-ready') {
+    totals.prReady++;
+    return 'pr-ready';
+  }
+  if (prMarker.lastState === 'pr-broken') {
+    totals.prBroken++;
+    return 'pr-broken';
+  }
+  if (prMarker.lastState === 'pr-pending') {
+    totals.prPending++;
+    return 'pr-pending';
+  }
+  return null;
+}
+
+function classifySession(session, totals) {
+  const tid = tmux.ticketIdFor(session);
+  const ws = workstate.snapshot(tid);
+  const prMarker = state.read(tid, 'pr-status');
+  const wedgedMarker = state.read(session, 'restart-loop');
+  const commitMarker = state.read(tid, 'commit-stall');
+  const flags = [];
+  const prFlag = collectPrFlag(prMarker, totals);
+  if (prFlag) flags.push(prFlag);
+  if (wedgedMarker && wedgedMarker.wedgedUntil && wedgedMarker.wedgedUntil > state.now()) {
+    flags.push('WEDGED');
+    totals.wedged++;
+  }
+  if (commitMarker && commitMarker.lastThreshold >= 240) {
+    flags.push(`stall=${commitMarker.lastThreshold}m`);
+  }
+  return `${tid}(${ws.phase || '?'}${flags.length ? ',' + flags.join(',') : ''})`;
+}
+
+function buildHeartbeat(sessions) {
+  const workSessions = sessions.filter(restartEligible);
+  const totals = { prReady: 0, prBroken: 0, prPending: 0, wedged: 0 };
+  const parts = workSessions.map((s) => classifySession(s, totals));
+  return (
+    `HEARTBEAT ${workSessions.length} active, ${totals.prReady} pr-ready, ${totals.prBroken} pr-broken, ${totals.prPending} pr-pending, ${totals.wedged} wedged` +
+    (parts.length ? ` | ${parts.join(' ')}` : '')
+  );
+}
+
+module.exports = { restartEligible, collectPrFlag, classifySession, buildHeartbeat };

--- a/plugins/maestro/scripts/lib/maestro-conduct/phase-registry.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/phase-registry.js
@@ -21,9 +21,12 @@
 // Base profile every phase inherits unless overridden.
 // 'silence' runs in every phase — it watches for fully-dead panes and
 // auto-restarts -work sessions (ported from maestro-conduct.sh).
+// 'prStatus' runs in every phase too — it's a no-op when the ticket
+// has no open PR, but ensures pr-ready/pr-broken still surfaces after
+// /work has advanced to 'complete' (the agent's final-step state).
 const BASE = Object.freeze({
   maxNudges: 3,
-  detectors: ['question', 'silence', 'spinner', 'phaseStall'],
+  detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
   exempts: () => false,
 });
 
@@ -44,13 +47,22 @@ const PHASES = Object.freeze({
   commit: { budgetMin: 5 },
   task_review: { budgetMin: 30 },
   check: { budgetMin: 15 },
-  pr: { budgetMin: 10 },
-  ready: { budgetMin: 5 },
+  pr: {
+    budgetMin: 10,
+    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
+  },
+  ready: {
+    budgetMin: 5,
+    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
+  },
   follow_up: {
     budgetMin: 60,
-    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prComments'],
+    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prComments', 'prStatus'],
   },
-  ci: { budgetMin: 30 },
+  ci: {
+    budgetMin: 30,
+    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
+  },
   cleanup: { budgetMin: 5 },
   reports: { budgetMin: 5 },
   complete: { budgetMin: 1 },

--- a/plugins/maestro/scripts/lib/maestro-conduct/phase-registry.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/phase-registry.js
@@ -42,7 +42,7 @@ const PHASES = Object.freeze({
   tasks_gate: { budgetMin: 5 },
   implement: {
     budgetMin: 60,
-    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'commitStall'],
+    detectors: ['question', 'silence', 'spinner', 'phaseStall', 'commitStall', 'prStatus'],
   },
   commit: { budgetMin: 5 },
   task_review: { budgetMin: 30 },

--- a/plugins/maestro/scripts/lib/maestro-conduct/session-shared.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/session-shared.js
@@ -1,0 +1,43 @@
+/**
+ * session-shared.js — helpers shared between maestro-session.js (CLI) and
+ * active-session-reminder.js (UserPromptSubmit hook). Extracted to satisfy
+ * the duplicate-blocks quality gate.
+ */
+'use strict';
+
+const path = require('path');
+const os = require('os');
+
+function getSessionDir() {
+  return (
+    process.env.MAESTRO_SESSION_DIR || path.join(os.homedir(), '.cache', 'maestro', 'sessions')
+  );
+}
+
+function countByStatus(tasks) {
+  const counts = { pending: 0, in_progress: 0, done: 0, blocked: 0 };
+  for (const t of tasks || []) counts[t.status] = (counts[t.status] || 0) + 1;
+  return counts;
+}
+
+function doneIdSet(tasks) {
+  return new Set((tasks || []).filter((t) => t.status === 'done').map((t) => t.id));
+}
+
+function eligibleTasks(tasks) {
+  const done = doneIdSet(tasks);
+  return (tasks || [])
+    .filter((t) => t.status === 'pending')
+    .filter((t) => (t.deps || []).every((d) => done.has(d)))
+    .sort((a, b) => (a.priority || 999) - (b.priority || 999));
+}
+
+module.exports = {
+  get SESSION_DIR() {
+    return getSessionDir();
+  },
+  getSessionDir,
+  countByStatus,
+  doneIdSet,
+  eligibleTasks,
+};

--- a/plugins/maestro/scripts/maestro-cleanup.js
+++ b/plugins/maestro/scripts/maestro-cleanup.js
@@ -161,9 +161,15 @@ function purgeAlertCountsForTicket(ticket, dryRun) {
   } catch {
     return 0;
   }
+  // Alert keys are `${session}|${kind}|${sha-or-phase}` where session is
+  // typically `${ticket}` or `${ticket}-work` / `${ticket}-listen` etc.
+  // A substring match would purge counts for GH-10/GH-11 when cleaning GH-1,
+  // so anchor on the ticket boundary: ticket followed by `|` (session==ticket)
+  // or `-...|` (session==`${ticket}-suffix`).
+  const tickRe = new RegExp(`^${escapeRegex(ticket)}(-[^|]*)?\\|`);
   let removed = 0;
   for (const key of Object.keys(counts)) {
-    if (key.includes(ticket)) {
+    if (tickRe.test(key)) {
       if (!dryRun) delete counts[key];
       removed += 1;
     }
@@ -239,4 +245,8 @@ function main() {
   runTicketMode({ ticket: positional[0], ...flags });
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { purgeAlertCountsForTicket };

--- a/plugins/maestro/scripts/maestro-cleanup.js
+++ b/plugins/maestro/scripts/maestro-cleanup.js
@@ -70,10 +70,16 @@ function listMarkers() {
   }
 }
 
+// Escape regex metacharacters in user-supplied input so a ticket like
+// "GH-1.*" can't widen the marker-match pattern (CodeQL js/regex-injection).
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function markersForTicket(ticket) {
   if (!fs.existsSync(STATE_DIR)) return [];
   const prefix = `${ticket}`;
-  const tickRe = new RegExp(`^${ticket}(-(work|listen|dev))?\\.[^/]+\\.json$`);
+  const tickRe = new RegExp(`^${escapeRegex(ticket)}(-(work|listen|dev))?\\.[^/]+\\.json$`);
   return fs
     .readdirSync(STATE_DIR)
     .filter((name) => name.startsWith(prefix) && tickRe.test(name))

--- a/plugins/maestro/scripts/maestro-cleanup.js
+++ b/plugins/maestro/scripts/maestro-cleanup.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+// maestro-cleanup.js — purge daemon state so the orchestrator doesn't have to
+// ask permission to `rm` markers / kill tmux every time an agent gets stuck.
+//
+// Usage:
+//   node maestro-cleanup.js <TICKET> [--tmux] [--alert-counts]
+//   node maestro-cleanup.js --all  [--tmux] [--alert-counts]
+//   node maestro-cleanup.js --list
+//
+// Flags:
+//   --tmux           also kill <TICKET>-work and <TICKET>-listen tmux sessions
+//   --alert-counts   purge entries for the ticket from _alert-counts.json
+//                    (or wipe the whole file when used with --all)
+//   --dry-run        print what would be deleted without touching anything
+//
+// Always idempotent: missing files / sessions are not errors.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const STATE_DIR =
+  process.env.MAESTRO_STATE_DIR ||
+  path.join(process.env.HOME || '/tmp', '.cache', 'maestro-conduct');
+const ALERT_COUNTS = path.join(STATE_DIR, '_alert-counts.json');
+
+function usage(code = 1) {
+  process.stderr.write(
+    `usage:\n` +
+      `  maestro-cleanup <TICKET> [--tmux] [--alert-counts] [--dry-run]\n` +
+      `  maestro-cleanup --all      [--tmux] [--alert-counts] [--dry-run]\n` +
+      `  maestro-cleanup --list\n`
+  );
+  process.exit(code);
+}
+
+function listMarkers() {
+  if (!fs.existsSync(STATE_DIR)) {
+    process.stdout.write(`(no STATE_DIR at ${STATE_DIR})\n`);
+    return;
+  }
+  const tickets = new Map();
+  for (const entry of fs.readdirSync(STATE_DIR)) {
+    if (entry.startsWith('_')) continue;
+    const m = entry.match(/^([A-Z]+-\d+)/);
+    if (!m) continue;
+    const id = m[1];
+    tickets.set(id, (tickets.get(id) || 0) + 1);
+  }
+  if (tickets.size === 0) {
+    process.stdout.write('(no per-ticket markers)\n');
+    return;
+  }
+  for (const [id, n] of [...tickets].sort()) {
+    process.stdout.write(`${id}: ${n} marker file(s)\n`);
+  }
+  if (fs.existsSync(ALERT_COUNTS)) {
+    try {
+      const counts = JSON.parse(fs.readFileSync(ALERT_COUNTS, 'utf8'));
+      process.stdout.write(`_alert-counts.json: ${Object.keys(counts).length} key(s)\n`);
+    } catch {
+      process.stdout.write(`_alert-counts.json: (unparseable)\n`);
+    }
+  }
+}
+
+function markersForTicket(ticket) {
+  if (!fs.existsSync(STATE_DIR)) return [];
+  const prefix = `${ticket}`;
+  const tickRe = new RegExp(`^${ticket}(-(work|listen|dev))?\\.[^/]+\\.json$`);
+  return fs
+    .readdirSync(STATE_DIR)
+    .filter((name) => name.startsWith(prefix) && tickRe.test(name))
+    .map((name) => path.join(STATE_DIR, name));
+}
+
+function allTicketMarkers() {
+  if (!fs.existsSync(STATE_DIR)) return [];
+  return fs
+    .readdirSync(STATE_DIR)
+    .filter((name) => !name.startsWith('_') && name.endsWith('.json'))
+    .map((name) => path.join(STATE_DIR, name));
+}
+
+function deleteFiles(files, dryRun) {
+  let removed = 0;
+  for (const f of files) {
+    if (dryRun) {
+      process.stdout.write(`(dry-run) would remove ${f}\n`);
+      continue;
+    }
+    try {
+      fs.unlinkSync(f);
+      removed += 1;
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        process.stderr.write(`warn: failed to remove ${f}: ${err.message}\n`);
+      }
+    }
+  }
+  return removed;
+}
+
+function killTmux(ticket, dryRun) {
+  let killed = 0;
+  for (const suffix of ['work', 'listen']) {
+    const session = `${ticket}-${suffix}`;
+    if (dryRun) {
+      process.stdout.write(`(dry-run) would tmux kill-session -t ${session}\n`);
+      continue;
+    }
+    const res = spawnSync('tmux', ['kill-session', '-t', session], { stdio: 'ignore' });
+    if (res.status === 0) killed += 1;
+  }
+  return killed;
+}
+
+function killAllTmuxFromMarkers(dryRun) {
+  const tickets = new Set();
+  for (const f of allTicketMarkers()) {
+    const m = path.basename(f).match(/^([A-Z]+-\d+)/);
+    if (m) tickets.add(m[1]);
+  }
+  let killed = 0;
+  for (const t of tickets) killed += killTmux(t, dryRun);
+  return killed;
+}
+
+function purgeAlertCounts(ticket, dryRun) {
+  if (!fs.existsSync(ALERT_COUNTS)) return 0;
+  if (!ticket) {
+    if (dryRun) {
+      process.stdout.write(`(dry-run) would wipe ${ALERT_COUNTS}\n`);
+      return 0;
+    }
+    fs.unlinkSync(ALERT_COUNTS);
+    return 1;
+  }
+  let counts;
+  try {
+    counts = JSON.parse(fs.readFileSync(ALERT_COUNTS, 'utf8'));
+  } catch {
+    return 0;
+  }
+  let removed = 0;
+  for (const key of Object.keys(counts)) {
+    if (key.includes(ticket)) {
+      if (!dryRun) delete counts[key];
+      removed += 1;
+    }
+  }
+  if (!dryRun && removed > 0) {
+    fs.writeFileSync(ALERT_COUNTS, JSON.stringify(counts, null, 2));
+  } else if (dryRun) {
+    process.stdout.write(`(dry-run) would purge ${removed} key(s) for ${ticket} from _alert-counts.json\n`);
+  }
+  return removed;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) usage();
+
+  if (args.includes('--list')) {
+    listMarkers();
+    return;
+  }
+
+  const dryRun = args.includes('--dry-run');
+  const wantTmux = args.includes('--tmux');
+  const wantAlertCounts = args.includes('--alert-counts');
+  const positional = args.filter((a) => !a.startsWith('--'));
+
+  if (args.includes('--all')) {
+    const files = allTicketMarkers();
+    const removed = deleteFiles(files, dryRun);
+    const killedTmux = wantTmux ? killAllTmuxFromMarkers(dryRun) : 0;
+    const wipedCounts = wantAlertCounts ? purgeAlertCounts(null, dryRun) : 0;
+    process.stdout.write(
+      `cleanup --all: removed ${removed} marker(s)` +
+        (wantTmux ? `, killed ${killedTmux} tmux session(s)` : '') +
+        (wantAlertCounts ? `, alert-counts wiped=${wipedCounts}` : '') +
+        '\n'
+    );
+    return;
+  }
+
+  if (positional.length !== 1) usage();
+  const ticket = positional[0];
+  if (!/^[A-Z]+-\d+$/.test(ticket)) {
+    process.stderr.write(`error: ticket "${ticket}" must match /^[A-Z]+-\\d+$/\n`);
+    process.exit(1);
+  }
+  const files = markersForTicket(ticket);
+  const removed = deleteFiles(files, dryRun);
+  const killedTmux = wantTmux ? killTmux(ticket, dryRun) : 0;
+  const purgedCounts = wantAlertCounts ? purgeAlertCounts(ticket, dryRun) : 0;
+  process.stdout.write(
+    `cleanup ${ticket}: removed ${removed} marker(s)` +
+      (wantTmux ? `, killed ${killedTmux} tmux session(s)` : '') +
+      (wantAlertCounts ? `, purged ${purgedCounts} alert-count key(s)` : '') +
+      '\n'
+  );
+}
+
+main();

--- a/plugins/maestro/scripts/maestro-cleanup.js
+++ b/plugins/maestro/scripts/maestro-cleanup.js
@@ -128,16 +128,16 @@ function killAllTmuxFromMarkers(dryRun) {
   return killed;
 }
 
-function purgeAlertCounts(ticket, dryRun) {
-  if (!fs.existsSync(ALERT_COUNTS)) return 0;
-  if (!ticket) {
-    if (dryRun) {
-      process.stdout.write(`(dry-run) would wipe ${ALERT_COUNTS}\n`);
-      return 0;
-    }
-    fs.unlinkSync(ALERT_COUNTS);
-    return 1;
+function wipeAllAlertCounts(dryRun) {
+  if (dryRun) {
+    process.stdout.write(`(dry-run) would wipe ${ALERT_COUNTS}\n`);
+    return 0;
   }
+  fs.unlinkSync(ALERT_COUNTS);
+  return 1;
+}
+
+function purgeAlertCountsForTicket(ticket, dryRun) {
   let counts;
   try {
     counts = JSON.parse(fs.readFileSync(ALERT_COUNTS, 'utf8'));
@@ -159,36 +159,26 @@ function purgeAlertCounts(ticket, dryRun) {
   return removed;
 }
 
-function main() {
-  const args = process.argv.slice(2);
-  if (args.length === 0) usage();
+function purgeAlertCounts(ticket, dryRun) {
+  if (!fs.existsSync(ALERT_COUNTS)) return 0;
+  if (!ticket) return wipeAllAlertCounts(dryRun);
+  return purgeAlertCountsForTicket(ticket, dryRun);
+}
 
-  if (args.includes('--list')) {
-    listMarkers();
-    return;
-  }
+function runAllMode({ dryRun, wantTmux, wantAlertCounts }) {
+  const files = allTicketMarkers();
+  const removed = deleteFiles(files, dryRun);
+  const killedTmux = wantTmux ? killAllTmuxFromMarkers(dryRun) : 0;
+  const wipedCounts = wantAlertCounts ? purgeAlertCounts(null, dryRun) : 0;
+  process.stdout.write(
+    `cleanup --all: removed ${removed} marker(s)` +
+      (wantTmux ? `, killed ${killedTmux} tmux session(s)` : '') +
+      (wantAlertCounts ? `, alert-counts wiped=${wipedCounts}` : '') +
+      '\n'
+  );
+}
 
-  const dryRun = args.includes('--dry-run');
-  const wantTmux = args.includes('--tmux');
-  const wantAlertCounts = args.includes('--alert-counts');
-  const positional = args.filter((a) => !a.startsWith('--'));
-
-  if (args.includes('--all')) {
-    const files = allTicketMarkers();
-    const removed = deleteFiles(files, dryRun);
-    const killedTmux = wantTmux ? killAllTmuxFromMarkers(dryRun) : 0;
-    const wipedCounts = wantAlertCounts ? purgeAlertCounts(null, dryRun) : 0;
-    process.stdout.write(
-      `cleanup --all: removed ${removed} marker(s)` +
-        (wantTmux ? `, killed ${killedTmux} tmux session(s)` : '') +
-        (wantAlertCounts ? `, alert-counts wiped=${wipedCounts}` : '') +
-        '\n'
-    );
-    return;
-  }
-
-  if (positional.length !== 1) usage();
-  const ticket = positional[0];
+function runTicketMode({ ticket, dryRun, wantTmux, wantAlertCounts }) {
   if (!/^[A-Z]+-\d+$/.test(ticket)) {
     process.stderr.write(`error: ticket "${ticket}" must match /^[A-Z]+-\\d+$/\n`);
     process.exit(1);
@@ -203,6 +193,31 @@ function main() {
       (wantAlertCounts ? `, purged ${purgedCounts} alert-count key(s)` : '') +
       '\n'
   );
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) usage();
+
+  if (args.includes('--list')) {
+    listMarkers();
+    return;
+  }
+
+  const flags = {
+    dryRun: args.includes('--dry-run'),
+    wantTmux: args.includes('--tmux'),
+    wantAlertCounts: args.includes('--alert-counts'),
+  };
+  const positional = args.filter((a) => !a.startsWith('--'));
+
+  if (args.includes('--all')) {
+    runAllMode(flags);
+    return;
+  }
+
+  if (positional.length !== 1) usage();
+  runTicketMode({ ticket: positional[0], ...flags });
 }
 
 main();

--- a/plugins/maestro/scripts/maestro-cleanup.js
+++ b/plugins/maestro/scripts/maestro-cleanup.js
@@ -143,8 +143,15 @@ function wipeAllAlertCounts(dryRun) {
     process.stdout.write(`(dry-run) would wipe ${ALERT_COUNTS}\n`);
     return 0;
   }
-  fs.unlinkSync(ALERT_COUNTS);
-  return 1;
+  // Avoid TOCTOU: try-unlink and treat ENOENT as "already gone" instead of
+  // checking existence first (CodeQL js/file-system-race).
+  try {
+    fs.unlinkSync(ALERT_COUNTS);
+    return 1;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return 0;
+    throw err;
+  }
 }
 
 function purgeAlertCountsForTicket(ticket, dryRun) {
@@ -170,7 +177,9 @@ function purgeAlertCountsForTicket(ticket, dryRun) {
 }
 
 function purgeAlertCounts(ticket, dryRun) {
-  if (!fs.existsSync(ALERT_COUNTS)) return 0;
+  // No existence pre-check; the inner functions handle a missing file via
+  // their read/unlink try/catch. Avoids TOCTOU between check and use
+  // (CodeQL js/file-system-race).
   if (!ticket) return wipeAllAlertCounts(dryRun);
   return purgeAlertCountsForTicket(ticket, dryRun);
 }

--- a/plugins/maestro/scripts/maestro-cleanup.js
+++ b/plugins/maestro/scripts/maestro-cleanup.js
@@ -21,7 +21,11 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
+// Honor STATE_DIR (matches state.js / alerts.js) so custom deployments clean
+// the same directory the daemon writes to. MAESTRO_STATE_DIR kept as a legacy
+// fallback for any existing callers.
 const STATE_DIR =
+  process.env.STATE_DIR ||
   process.env.MAESTRO_STATE_DIR ||
   path.join(process.env.HOME || '/tmp', '.cache', 'maestro-conduct');
 const ALERT_COUNTS = path.join(STATE_DIR, '_alert-counts.json');

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -283,7 +283,7 @@ function runPrStatusDetector(ctx) {
     .join(', ');
   const instruction =
     sHit.kind === 'pr-ready'
-      ? `Spawn work-workflow:code-checker (Agent tool, keep alive in tmux until verdict) on PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} for ${ctx.ticket}. Reviewer must answer FOUR questions: (1) Did the agent complete every requirement/AC in the ticket? (2) Did it introduce any bug (logic errors, regressions, broken edge cases)? (3) Did it add any security vulnerability (injection, secrets, unsafe shell, path traversal)? (4) Did it bypass any /work workflow gate (state edits, set-step CLI, completion-checker skip, fake TDD evidence, --no-verify, deferral annotations)? Verdict must be APPROVED only if ALL four are clean. On NEEDS-WORK → forward verbatim findings to ${ctx.session} via tmux send-keys; re-run after agent pushes. On APPROVED → surface PR URL to operator. Slot will be auto-freed if phase=ci/wait_merge.`
+      ? `Spawn work-workflow:code-checker (Agent tool, keep alive in tmux until verdict) on PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} for ${ctx.ticket}. Reviewer must answer FOUR questions: (1) Did the agent complete every requirement/AC in the ticket? (2) Did it introduce any bug (logic errors, regressions, broken edge cases)? (3) Did it add any security vulnerability (injection, secrets, unsafe shell, path traversal)? (4) Did it bypass any /work workflow gate (state edits, set-step CLI, completion-checker skip, fake TDD evidence, --no-verify, deferral annotations)? Verdict must be APPROVED only if ALL four are clean. On NEEDS-WORK → forward verbatim findings to ${ctx.session} via tmux send-keys; re-run after agent pushes. On APPROVED → surface PR URL to operator; operator merges PR and kills tmux sessions ${ctx.ticket}-work + ${ctx.ticket}-listen to free the pool slot.`
       : `tmux capture-pane -t ${ctx.session} -p | tail -40 — drive agent to fix failing checks IN-PR (no skip, no follow-up issue). Failing: ${failingList || 'see PR'}.`;
   actions.alert({
     session: ctx.session,
@@ -297,18 +297,14 @@ function runPrStatusDetector(ctx) {
     failingChecks: sHit.failingChecks,
     instruction,
   });
-  // CI-gate slot rotation: when PR is CLEAN/SUCCESS and the agent is sitting
-  // in a wait-for-merge phase, free the pool slot automatically so the
-  // orchestrator can bootstrap the next ticket. Operator merges separately.
-  // Disable with AUTO_FREE_CI_SLOT=0.
-  if (sHit.kind === 'pr-ready' && ['ci', 'wait_merge'].includes(ctx.phase)) {
-    actions.freeCIGateSlot({
-      session: ctx.session,
-      ticket: ctx.ticket,
-      prNumber: sHit.prNumber,
-      sha: sHit.sha,
-    });
-  }
+  // CI-gate slot rotation removed: previously this called freeCIGateSlot
+  // unconditionally on pr-ready in ci/wait_merge, which killed the -work
+  // tmux session the alert instruction had just told the operator to forward
+  // code-checker NEEDS-WORK findings to. The race destroyed the remediation
+  // path inside the same alert. Slot freeing is now operator-driven (see
+  // maestro-free-slot.sh) and must happen only AFTER the code-checker
+  // verdict is APPROVED. AUTO_FREE_CI_SLOT env var is preserved by
+  // freeCIGateSlot itself for callers that re-enable this path explicitly.
 }
 
 /** Run the per-session pipeline. Returns when the session has been fully processed. */

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -34,15 +34,12 @@ const DETECTORS = {
 };
 
 // Heartbeat: every HEARTBEAT_MIN emit a positive summary so silence on the
-// daemon side can't be mistaken for "nothing happening." See detectors/commit-stall.js
-// for the threshold dedup contract used to keep commit-stall noise bounded.
+// daemon side can't be mistaken for "nothing happening."
 const HEARTBEAT_MIN = parseInt(process.env.HEARTBEAT_MIN || '30', 10);
 let lastHeartbeatAt = 0;
 
 // Re-emit escalation: when the same (session, kind, sha/phase) alert fires
-// this many times in a row, the daemon auto-rotates the slot (kills the
-// session via freeDeadEndSlot). Operator no longer needs to make a judgment
-// call on whether a stuck agent is recoverable.
+// this many times, auto-rotate the slot via freeDeadEndSlot.
 const DEAD_END_REEMITS = parseInt(process.env.DEAD_END_REEMITS || '3', 10);
 
 function maybeEscalateToDeadEnd(ctx, kind, repeatCount, sha) {
@@ -314,6 +311,9 @@ function tickSession(session) {
     return;
   }
   state.clear(ctx.session, 'question');
+  // Reset persisted question-pending count so a later prompt in the same
+  // phase doesn't inherit [REPEAT N] and fire freeDeadEndSlot prematurely.
+  alerts.resetCount(alerts.alertKey({ session: ctx.session, kind: 'question-pending', phase: ctx.phase }));
 
   const detectorsToRun = phaseFor(ctx.phase).detectors.filter((k) => k !== 'question');
 

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -87,10 +87,8 @@ function handleQuestion(ctx, qHit) {
   }
   const mins = state.minutesSince(prev.startedAt);
   if (mins < Q_WAIT_MIN) return;
-  // Re-emit on Q_WAIT_MIN cadence so the alert count can grow to
-  // DEAD_END_REEMITS and trigger freeDeadEndSlot. Previously this branch
-  // gated on !prev.alerted, which capped the count at 1 and made dead-end
-  // auto-rotation unreachable from the daemon loop.
+  // Re-emit on Q_WAIT_MIN cadence so alert count can grow to DEAD_END_REEMITS
+  // and trigger freeDeadEndSlot (one-shot gate previously capped count at 1).
   if (prev.alerted) {
     const sinceLastAlert = prev.lastAlertAt ? state.minutesSince(prev.lastAlertAt) : Infinity;
     if (sinceLastAlert < Q_WAIT_MIN) return;
@@ -153,12 +151,8 @@ function handlePhaseStall(ctx, stallHit) {
   const sinceLastNudge = marker.lastNudgeAt ? state.minutesSince(marker.lastNudgeAt) : Infinity;
   // Don't re-nudge before the per-phase cooldown.
   if (marker.lastNudgeAt && sinceLastNudge < stallHit.reNudgeMin) return;
-  // After the one-shot alert fires, keep re-emitting on reNudgeMin cadence so
-  // the alert count grows to DEAD_END_REEMITS and triggers freeDeadEndSlot.
-  // Previously this branch fully suppressed re-alerting, which capped the count
-  // at 1 and made dead-end auto-rotation unreachable. The phase-stall detector
-  // resets the marker on phase change, so re-emits stop naturally on advance.
-
+  // Re-emit on reNudgeMin cadence so alert count grows to DEAD_END_REEMITS
+  // (marker resets on phase change, so re-emits stop naturally on advance).
   const escalation = escalationFor(ctx.phase, marker.nudges);
   const reason = `phase=${ctx.phase} stuck ${stallHit.elapsedMin}m budget=${stallHit.budgetMin}m nudge ${marker.nudges + 1}/${stallHit.maxNudges}`;
 
@@ -217,12 +211,8 @@ function runSilenceDetector(ctx) {
   const sHit = DETECTORS.silence.detect(ctx);
   if (!sHit.hit) return false;
   if (!restartEligible(ctx.session)) {
-    // Helper (-dev / -listen) is idle past SILENCE_LIMIT_SEC but we won't kill
-    // it. Without resetting the marker, silence would fire every subsequent
-    // tick → log spam + short-circuit of other detectors forever. Instead:
-    // log once, refresh the marker so the silence timer restarts, and let the
-    // remaining detectors run by returning false. Worst case we log again in
-    // another SILENCE_LIMIT_SEC, not every tick.
+    // Helper (-dev / -listen) idle past SILENCE_LIMIT_SEC — don't kill. Refresh
+    // marker so silence timer restarts (else fires every tick → log spam).
     alerts.log(
       `${ctx.session} AUTO-RESTART skipped: non-work helper session (not restart-eligible)`
     );

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -230,8 +230,12 @@ function runSilenceDetector(ctx) {
     // ticket because the workflow state belongs to the ticket, not the pane).
     ['silence', 'spinner', 'question'].forEach((k) => state.clear(ctx.session, k));
     ['phase', 'pr-comments'].forEach((k) => state.clear(ctx.ticket, k));
+    return true;
   }
-  return true;
+  // autoRestart skipped (wedged quiet window, ci-gate-freed, dead-end, or
+  // missing worktree) — pane is still alive and listed, so let downstream
+  // detectors (notably prStatus) keep emitting pr-ready/pr-broken transitions.
+  return false;
 }
 
 function runPhaseStallDetector(ctx) {

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -281,7 +281,7 @@ function runPrStatusDetector(ctx) {
     .join(', ');
   const instruction =
     sHit.kind === 'pr-ready'
-      ? `Run bypass-checker on PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} (Agent tool, work-workflow:code-checker). On APPROVED → surface PR URL to operator. Slot will be auto-freed if phase=ci/wait_merge.`
+      ? `Spawn work-workflow:code-checker (Agent tool, keep alive in tmux until verdict) on PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} for ${ctx.ticket}. Reviewer must answer FOUR questions: (1) Did the agent complete every requirement/AC in the ticket? (2) Did it introduce any bug (logic errors, regressions, broken edge cases)? (3) Did it add any security vulnerability (injection, secrets, unsafe shell, path traversal)? (4) Did it bypass any /work workflow gate (state edits, set-step CLI, completion-checker skip, fake TDD evidence, --no-verify, deferral annotations)? Verdict must be APPROVED only if ALL four are clean. On NEEDS-WORK → forward verbatim findings to ${ctx.session} via tmux send-keys; re-run after agent pushes. On APPROVED → surface PR URL to operator. Slot will be auto-freed if phase=ci/wait_merge.`
       : `tmux capture-pane -t ${ctx.session} -p | tail -40 — drive agent to fix failing checks IN-PR (no skip, no follow-up issue). Failing: ${failingList || 'see PR'}.`;
   actions.alert({
     session: ctx.session,

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -29,7 +29,31 @@ const DETECTORS = {
   phaseStall: require('./lib/maestro-conduct/detectors/phase-stall'),
   commitStall: require('./lib/maestro-conduct/detectors/commit-stall'),
   prComments: require('./lib/maestro-conduct/detectors/pr-comments'),
+  prStatus: require('./lib/maestro-conduct/detectors/pr-status'),
 };
+
+// Heartbeat: every HEARTBEAT_MIN emit a positive summary so silence on the
+// daemon side can't be mistaken for "nothing happening." See detectors/commit-stall.js
+// for the threshold dedup contract used to keep commit-stall noise bounded.
+const HEARTBEAT_MIN = parseInt(process.env.HEARTBEAT_MIN || '30', 10);
+let lastHeartbeatAt = 0;
+
+// Re-emit escalation: when the same (session, kind, sha/phase) alert fires
+// this many times in a row, the daemon auto-rotates the slot (kills the
+// session via freeDeadEndSlot). Operator no longer needs to make a judgment
+// call on whether a stuck agent is recoverable.
+const DEAD_END_REEMITS = parseInt(process.env.DEAD_END_REEMITS || '3', 10);
+
+function maybeEscalateToDeadEnd(ctx, kind, repeatCount, sha) {
+  if (repeatCount < DEAD_END_REEMITS) return;
+  actions.freeDeadEndSlot({
+    session: ctx.session,
+    ticket: ctx.ticket,
+    kind,
+    repeatCount,
+    sha,
+  });
+}
 
 // Only -work sessions are restart-eligible (matches maestro-conduct.sh
 // gating). Helpers like -dev / -listen are surfaced informationally but
@@ -68,7 +92,7 @@ function handleQuestion(ctx, qHit) {
   }
   const mins = state.minutesSince(prev.startedAt);
   if (mins >= Q_WAIT_MIN && !prev.alerted) {
-    actions.alert({
+    const r = actions.alert({
       session: ctx.session,
       ticket: ctx.ticket,
       kind: 'question-pending',
@@ -76,8 +100,10 @@ function handleQuestion(ctx, qHit) {
       elapsedMin: mins,
       options: qHit.options,
       promptKind: qHit.promptKind,
+      instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — read full menu, pick the option that does NOT bypass any workflow gate (avoid: state-file edits, set-step CLI, completion-checker skip, --no-verify). If all options bypass, send a directive via "Type something".`,
     });
     state.write(ctx.session, 'question', { startedAt: prev.startedAt, alerted: true });
+    maybeEscalateToDeadEnd(ctx, 'question-pending', r.count, null);
   }
 }
 
@@ -133,7 +159,7 @@ function handlePhaseStall(ctx, stallHit) {
   const reason = `phase=${ctx.phase} stuck ${stallHit.elapsedMin}m budget=${stallHit.budgetMin}m nudge ${marker.nudges + 1}/${stallHit.maxNudges}`;
 
   if (escalation === 'alert') {
-    actions.alert({
+    const r = actions.alert({
       session: ctx.session,
       ticket: ctx.ticket,
       kind: 'nudges-exhausted',
@@ -141,7 +167,9 @@ function handlePhaseStall(ctx, stallHit) {
       elapsedMin: stallHit.elapsedMin,
       budgetMin: stallHit.budgetMin,
       nudges: marker.nudges,
+      instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — agent exceeded phase=${ctx.phase} budget (${stallHit.elapsedMin}m vs ${stallHit.budgetMin}m). Diagnose or send directive via "Type something".`,
     });
+    maybeEscalateToDeadEnd(ctx, 'nudges-exhausted', r.count, ctx.phase);
   } else if (escalation === 'interrupt') {
     actions.interrupt(ctx.session, reason);
   } else {
@@ -223,13 +251,62 @@ function runPhaseStallDetector(ctx) {
 }
 
 function runCommitStallDetector(ctx) {
+  // detector handles its own dedup + marker — only "hits" on threshold crossings.
   const cHit = DETECTORS.commitStall.detect(ctx);
-  if (cHit.hit) alerts.log(`${ctx.session} commit-stall ${cHit.mins}m in phase=${ctx.phase}`);
+  if (!cHit.hit) return;
+  alerts.log(
+    `${ctx.session} commit-stall ${cHit.mins}m in phase=${ctx.phase} (threshold=${cHit.threshold}m)`
+  );
 }
 
 function runPrCommentsDetector(ctx) {
   const cHit = DETECTORS.prComments.detect(ctx);
   if (cHit.hit) handlePrComments(ctx, cHit);
+}
+
+function runPrStatusDetector(ctx) {
+  const sHit = DETECTORS.prStatus.detect(ctx);
+  if (!sHit.hit) return;
+  // pr-pending is informational only — log but never escalate to alert sink.
+  if (sHit.kind === 'pr-pending') {
+    alerts.log(
+      `${ctx.session} pr-pending PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} checks running`
+    );
+    return;
+  }
+  // pr-ready / pr-broken go to the structured alert sink so a downstream
+  // grep can match them distinctly from nudges.
+  const failingList = (sHit.failingChecks || [])
+    .map((c) => `${c.name}(${c.conclusion})`)
+    .join(', ');
+  const instruction =
+    sHit.kind === 'pr-ready'
+      ? `Run bypass-checker on PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} (Agent tool, work-workflow:code-checker). On APPROVED → surface PR URL to operator. Slot will be auto-freed if phase=ci/wait_merge.`
+      : `tmux capture-pane -t ${ctx.session} -p | tail -40 — drive agent to fix failing checks IN-PR (no skip, no follow-up issue). Failing: ${failingList || 'see PR'}.`;
+  actions.alert({
+    session: ctx.session,
+    ticket: ctx.ticket,
+    kind: sHit.kind,
+    phase: ctx.phase,
+    prNumber: sHit.prNumber,
+    sha: sHit.sha,
+    checksState: sHit.checksState,
+    mergeable: sHit.mergeable,
+    failingChecks: sHit.failingChecks,
+    instruction,
+  });
+  // CI-gate slot rotation: when PR is CLEAN/SUCCESS and the agent is sitting
+  // in a wait-for-merge phase, free the pool slot automatically so the
+  // orchestrator can bootstrap the next ticket. Operator merges separately.
+  // Disable with AUTO_FREE_CI_SLOT=0.
+  if (sHit.kind === 'pr-ready' && ['ci', 'wait_merge'].includes(ctx.phase)) {
+    actions.freeCIGateSlot({
+      session: ctx.session,
+      ticket: ctx.ticket,
+      prNumber: sHit.prNumber,
+      sha: sHit.sha,
+    });
+  }
 }
 
 /** Run the per-session pipeline. Returns when the session has been fully processed. */
@@ -253,6 +330,58 @@ function tickSession(session) {
   if (detectorsToRun.includes('phaseStall')) runPhaseStallDetector(ctx);
   if (detectorsToRun.includes('commitStall')) runCommitStallDetector(ctx);
   if (detectorsToRun.includes('prComments')) runPrCommentsDetector(ctx);
+  if (detectorsToRun.includes('prStatus')) runPrStatusDetector(ctx);
+}
+
+/**
+ * Build the heartbeat summary line. Lists every -work session and its terse
+ * state derived from on-disk markers + phase. The HEARTBEAT keyword is the
+ * grep handle for downstream tooling.
+ */
+function buildHeartbeat(sessions) {
+  const workSessions = sessions.filter(restartEligible);
+  const parts = [];
+  let prReady = 0;
+  let prBroken = 0;
+  let prPending = 0;
+  let wedged = 0;
+  for (const s of workSessions) {
+    const tid = tmux.ticketIdFor(s);
+    const ws = workstate.snapshot(tid);
+    const prMarker = state.read(tid, 'pr-status');
+    const wedgedMarker = state.read(s, 'restart-loop');
+    const commitMarker = state.read(tid, 'commit-stall');
+    const flags = [];
+    if (prMarker && prMarker.lastState === 'pr-ready') {
+      flags.push('pr-ready');
+      prReady++;
+    } else if (prMarker && prMarker.lastState === 'pr-broken') {
+      flags.push('pr-broken');
+      prBroken++;
+    } else if (prMarker && prMarker.lastState === 'pr-pending') {
+      flags.push('pr-pending');
+      prPending++;
+    }
+    if (wedgedMarker && wedgedMarker.wedgedUntil && wedgedMarker.wedgedUntil > state.now()) {
+      flags.push('WEDGED');
+      wedged++;
+    }
+    if (commitMarker && commitMarker.lastThreshold >= 240) {
+      flags.push(`stall=${commitMarker.lastThreshold}m`);
+    }
+    parts.push(`${tid}(${ws.phase || '?'}${flags.length ? ',' + flags.join(',') : ''})`);
+  }
+  return (
+    `HEARTBEAT ${workSessions.length} active, ${prReady} pr-ready, ${prBroken} pr-broken, ${prPending} pr-pending, ${wedged} wedged` +
+    (parts.length ? ` | ${parts.join(' ')}` : '')
+  );
+}
+
+function maybeEmitHeartbeat(sessions) {
+  const now = state.now();
+  if (lastHeartbeatAt && now - lastHeartbeatAt < HEARTBEAT_MIN * 60) return;
+  lastHeartbeatAt = now;
+  alerts.log(buildHeartbeat(sessions));
 }
 
 function tick() {
@@ -262,6 +391,7 @@ function tick() {
     return;
   }
   for (const session of sessions) tickSession(session);
+  maybeEmitHeartbeat(sessions);
 }
 
 function handlePrComments(ctx, cHit) {
@@ -285,7 +415,7 @@ function handlePrComments(ctx, cHit) {
   const escalation = escalationFor(ctx.phase, nudges);
 
   if (escalation === 'alert') {
-    actions.alert({
+    const r = actions.alert({
       session: ctx.session,
       ticket: ctx.ticket,
       kind: 'pr-comments-stuck',
@@ -294,7 +424,9 @@ function handlePrComments(ctx, cHit) {
       count: cHit.count,
       elapsedMin: cHit.minsStuck,
       summary: cHit.summary,
+      instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — agent left ${cHit.count} bot comment(s) on PR #${cHit.prNumber} unaddressed for ${cHit.minsStuck}m, HEAD unchanged. Send directive: "Address each bot comment in the PR; never dismiss as stale."`,
     });
+    maybeEscalateToDeadEnd(ctx, 'pr-comments-stuck', r.count, null);
   } else if (escalation === 'interrupt') {
     actions.interrupt(ctx.session, reason);
   } else {

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -278,17 +278,18 @@ function runPrStatusDetector(ctx) {
     );
     return;
   }
-  // pr-ready / pr-broken go to the structured alert sink so a downstream
-  // grep can match them distinctly from nudges.
+  // pr-ready / pr-broken → structured alert sink. Target -work explicitly
+  // (pr-status dedups per-ticket so -listen could otherwise own the alert).
+  const workSession = `${ctx.ticket}-work`;
   const failingList = (sHit.failingChecks || [])
     .map((c) => `${c.name}(${c.conclusion})`)
     .join(', ');
   const instruction =
     sHit.kind === 'pr-ready'
-      ? `Spawn work-workflow:code-checker (Agent tool, keep alive in tmux until verdict) on PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} for ${ctx.ticket}. Reviewer must answer FOUR questions: (1) Did the agent complete every requirement/AC in the ticket? (2) Did it introduce any bug (logic errors, regressions, broken edge cases)? (3) Did it add any security vulnerability (injection, secrets, unsafe shell, path traversal)? (4) Did it bypass any /work workflow gate (state edits, set-step CLI, completion-checker skip, fake TDD evidence, --no-verify, deferral annotations)? Verdict must be APPROVED only if ALL four are clean. On NEEDS-WORK → forward verbatim findings to ${ctx.session} via tmux send-keys; re-run after agent pushes. On APPROVED → surface PR URL to operator; operator merges PR and kills tmux sessions ${ctx.ticket}-work + ${ctx.ticket}-listen to free the pool slot.`
-      : `tmux capture-pane -t ${ctx.session} -p | tail -40 — drive agent to fix failing checks IN-PR (no skip, no follow-up issue). Failing: ${failingList || 'see PR'}.`;
+      ? `Spawn work-workflow:code-checker (Agent tool, keep alive in tmux until verdict) on PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} for ${ctx.ticket}. Reviewer must answer FOUR questions: (1) Did the agent complete every requirement/AC in the ticket? (2) Did it introduce any bug (logic errors, regressions, broken edge cases)? (3) Did it add any security vulnerability (injection, secrets, unsafe shell, path traversal)? (4) Did it bypass any /work workflow gate (state edits, set-step CLI, completion-checker skip, fake TDD evidence, --no-verify, deferral annotations)? Verdict must be APPROVED only if ALL four are clean. On NEEDS-WORK → forward verbatim findings to ${workSession} via tmux send-keys; re-run after agent pushes. On APPROVED → surface PR URL to operator; operator merges PR and kills tmux sessions ${ctx.ticket}-work + ${ctx.ticket}-listen to free the pool slot.`
+      : `tmux capture-pane -t ${workSession} -p | tail -40 — drive agent to fix failing checks IN-PR (no skip, no follow-up issue). Failing: ${failingList || 'see PR'}.`;
   actions.alert({
-    session: ctx.session,
+    session: workSession,
     ticket: ctx.ticket,
     kind: sHit.kind,
     phase: ctx.phase,
@@ -299,9 +300,8 @@ function runPrStatusDetector(ctx) {
     failingChecks: sHit.failingChecks,
     instruction,
   });
-  // CI-gate slot rotation removed: auto-freeing on pr-ready killed the -work
-  // session before code-checker could forward NEEDS-WORK findings. Slot freeing
-  // is now operator-driven via maestro-free-slot.sh after APPROVED verdict.
+  // CI-gate slot rotation removed: auto-freeing on pr-ready killed -work before
+  // code-checker could forward NEEDS-WORK. Slot freeing is operator-driven now.
 }
 
 /** Run the per-session pipeline. Returns when the session has been fully processed. */

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -252,7 +252,18 @@ function runCommitStallDetector(ctx) {
 
 function runPrCommentsDetector(ctx) {
   const cHit = DETECTORS.prComments.detect(ctx);
-  if (cHit.hit) handlePrComments(ctx, cHit);
+  if (cHit.hit) {
+    handlePrComments(ctx, cHit);
+    return;
+  }
+  // Detector reset its marker (comments gone, HEAD moved, or count changed) →
+  // also purge the persisted pr-comments-stuck alert count so a fresh stuck
+  // cycle starts at 1 instead of inheriting a near-dead-end repeat count.
+  if (cHit.reset) {
+    alerts.resetCount(
+      alerts.alertKey({ session: ctx.session, kind: 'pr-comments-stuck', phase: ctx.phase })
+    );
+  }
 }
 
 function runPrStatusDetector(ctx) {

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -43,7 +43,7 @@ let lastHeartbeatAt = 0;
 const DEAD_END_REEMITS = parseInt(process.env.DEAD_END_REEMITS || '3', 10);
 
 function maybeEscalateToDeadEnd(ctx, kind, repeatCount, sha) {
-  if (repeatCount < DEAD_END_REEMITS) return;
+  if (repeatCount < DEAD_END_REEMITS || ['wait_merge', 'ci', 'complete'].includes(ctx.phase)) return;
   actions.freeDeadEndSlot({
     session: ctx.session,
     ticket: ctx.ticket,

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -86,20 +86,31 @@ function handleQuestion(ctx, qHit) {
     return;
   }
   const mins = state.minutesSince(prev.startedAt);
-  if (mins >= Q_WAIT_MIN && !prev.alerted) {
-    const r = actions.alert({
-      session: ctx.session,
-      ticket: ctx.ticket,
-      kind: 'question-pending',
-      phase: ctx.phase,
-      elapsedMin: mins,
-      options: qHit.options,
-      promptKind: qHit.promptKind,
-      instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — read full menu, pick the option that does NOT bypass any workflow gate (avoid: state-file edits, set-step CLI, completion-checker skip, --no-verify). If all options bypass, send a directive via "Type something".`,
-    });
-    state.write(ctx.session, 'question', { startedAt: prev.startedAt, alerted: true });
-    maybeEscalateToDeadEnd(ctx, 'question-pending', r.count, null);
+  if (mins < Q_WAIT_MIN) return;
+  // Re-emit on Q_WAIT_MIN cadence so the alert count can grow to
+  // DEAD_END_REEMITS and trigger freeDeadEndSlot. Previously this branch
+  // gated on !prev.alerted, which capped the count at 1 and made dead-end
+  // auto-rotation unreachable from the daemon loop.
+  if (prev.alerted) {
+    const sinceLastAlert = prev.lastAlertAt ? state.minutesSince(prev.lastAlertAt) : Infinity;
+    if (sinceLastAlert < Q_WAIT_MIN) return;
   }
+  const r = actions.alert({
+    session: ctx.session,
+    ticket: ctx.ticket,
+    kind: 'question-pending',
+    phase: ctx.phase,
+    elapsedMin: mins,
+    options: qHit.options,
+    promptKind: qHit.promptKind,
+    instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — read full menu, pick the option that does NOT bypass any workflow gate (avoid: state-file edits, set-step CLI, completion-checker skip, --no-verify). If all options bypass, send a directive via "Type something".`,
+  });
+  state.write(ctx.session, 'question', {
+    startedAt: prev.startedAt,
+    alerted: true,
+    lastAlertAt: state.now(),
+  });
+  maybeEscalateToDeadEnd(ctx, 'question-pending', r.count, null);
 }
 
 // Healthy "waiting on user" patterns the agent emits to the pane while halted.
@@ -142,11 +153,11 @@ function handlePhaseStall(ctx, stallHit) {
   const sinceLastNudge = marker.lastNudgeAt ? state.minutesSince(marker.lastNudgeAt) : Infinity;
   // Don't re-nudge before the per-phase cooldown.
   if (marker.lastNudgeAt && sinceLastNudge < stallHit.reNudgeMin) return;
-  // Once nudges are exhausted AND the one-shot alert has fired, stop re-alerting
-  // until the phase actually advances. The marker is reset on phase change inside
-  // the phase-stall detector. We must NOT early-return before the alert branch
-  // fires, since escalationFor() only returns 'alert' once nudges >= maxNudges.
-  if (marker.nudges >= stallHit.maxNudges && marker.alerted) return;
+  // After the one-shot alert fires, keep re-emitting on reNudgeMin cadence so
+  // the alert count grows to DEAD_END_REEMITS and triggers freeDeadEndSlot.
+  // Previously this branch fully suppressed re-alerting, which capped the count
+  // at 1 and made dead-end auto-rotation unreachable. The phase-stall detector
+  // resets the marker on phase change, so re-emits stop naturally on advance.
 
   const escalation = escalationFor(ctx.phase, marker.nudges);
   const reason = `phase=${ctx.phase} stuck ${stallHit.elapsedMin}m budget=${stallHit.budgetMin}m nudge ${marker.nudges + 1}/${stallHit.maxNudges}`;
@@ -351,12 +362,12 @@ function handlePrComments(ctx, cHit) {
   if (marker.lastNudgeAt && sinceLastNudge < profile.reNudgeMin) return;
 
   const nudges = marker.nudges || 0;
-  const maxNudges = profile.maxNudges || 3;
-  // Once nudges are exhausted AND the one-shot alert has fired, stop re-alerting
-  // until HEAD moves or the comments are gone. The detector resets the marker on
-  // either change. We must NOT early-return before the alert branch fires, since
-  // escalationFor() only returns 'alert' once nudges >= maxNudges.
-  if (nudges >= maxNudges && marker.alerted) return;
+  // After the one-shot alert fires, keep re-emitting on reNudgeMin cadence so
+  // the alert count grows to DEAD_END_REEMITS and triggers freeDeadEndSlot.
+  // Previously this branch fully suppressed re-alerting, which capped the count
+  // at 1 and made dead-end auto-rotation unreachable. The pr-comments detector
+  // resets the marker when HEAD moves or comments are gone, so re-emits stop
+  // naturally once the agent acts.
   const top = cHit.summary
     .map((s) => `${s.file}:${s.line} [${s.severity || '?'}] ${s.title}`)
     .join(' | ');

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -21,6 +21,7 @@ const workstate = require('./lib/maestro-conduct/workstate');
 const { phaseFor, escalationFor } = require('./lib/maestro-conduct/phase-registry');
 const actions = require('./lib/maestro-conduct/actions');
 const alerts = require('./lib/maestro-conduct/alerts');
+const heartbeat = require('./lib/maestro-conduct/heartbeat');
 
 const DETECTORS = {
   question: require('./lib/maestro-conduct/detectors/question'),
@@ -57,10 +58,9 @@ function maybeEscalateToDeadEnd(ctx, kind, repeatCount, sha) {
 
 // Only -work sessions are restart-eligible (matches maestro-conduct.sh
 // gating). Helpers like -dev / -listen are surfaced informationally but
-// would re-launch wrong if relaunched as /work <tid>.
-function restartEligible(session) {
-  return /-work$/.test(session);
-}
+// would re-launch wrong if relaunched as /work <tid>. Re-exported from
+// heartbeat.js so module.exports keeps the historical surface.
+const restartEligible = heartbeat.restartEligible;
 
 const REPO_NAME = process.env.REPO_NAME || 'claude-plugin-work';
 const Q_WAIT_MIN = parseInt(process.env.Q_WAIT_MIN || '3', 10);
@@ -68,12 +68,9 @@ const TICK_SEC = parseInt(process.env.TICK_SEC || '60', 10);
 
 /** Build the context object passed to every detector. */
 function ctxFor(session) {
-  // Strip the maestro session-suffix (-work / -dev / -listen). Helper sessions
-  // still derive a meaningful ticket id — they are surfaced informationally
-  // but never auto-restarted (see restartEligible above).
+  // Strip session-suffix to derive ticket id. -dev/-listen are informational only;
+  // restartEligible() gates auto-restart to -work. Snapshot is a single on-disk read.
   const ticket = tmux.ticketIdFor(session);
-  // Single read so phase and step come from the same on-disk snapshot
-  // (the file can be rewritten by /work between reads otherwise).
   const { phase, step } = workstate.snapshot(ticket);
   const worktree = path.join(workstate.WORKTREES_BASE, `${REPO_NAME}-${ticket}`);
   const pane = tmux.capture(session);
@@ -81,9 +78,7 @@ function ctxFor(session) {
 }
 
 function handleQuestion(ctx, qHit) {
-  // Question marker is per-SESSION: a `-work` session showing a prompt while
-  // an `-dev` helper is idle (or vice versa) must not clobber each other's
-  // markers. Multiple sessions can map to the same ticket.
+  // Question marker is per-SESSION so -work/-dev/-listen don't clobber each other.
   const prev = state.read(ctx.session, 'question');
   const now = state.now();
   if (!prev) {
@@ -120,9 +115,7 @@ function isHaltedWaitingForUser(pane) {
   return HALTED_WAITING_PATTERNS.some((re) => re.test(pane));
 }
 
-// Advance a marker after sending a nudge/alert. `alerted=true` flips the
-// one-shot flag so subsequent ticks suppress re-alerting until the marker is
-// reset (phase advance, HEAD change, etc.).
+// Advance marker after a nudge/alert; `alerted=true` flips the one-shot flag.
 function bumpMarker(ticket, key, marker, alerted) {
   state.write(ticket, key, {
     ...marker,
@@ -333,55 +326,11 @@ function tickSession(session) {
   if (detectorsToRun.includes('prStatus')) runPrStatusDetector(ctx);
 }
 
-/**
- * Build the heartbeat summary line. Lists every -work session and its terse
- * state derived from on-disk markers + phase. The HEARTBEAT keyword is the
- * grep handle for downstream tooling.
- */
-function buildHeartbeat(sessions) {
-  const workSessions = sessions.filter(restartEligible);
-  const parts = [];
-  let prReady = 0;
-  let prBroken = 0;
-  let prPending = 0;
-  let wedged = 0;
-  for (const s of workSessions) {
-    const tid = tmux.ticketIdFor(s);
-    const ws = workstate.snapshot(tid);
-    const prMarker = state.read(tid, 'pr-status');
-    const wedgedMarker = state.read(s, 'restart-loop');
-    const commitMarker = state.read(tid, 'commit-stall');
-    const flags = [];
-    if (prMarker && prMarker.lastState === 'pr-ready') {
-      flags.push('pr-ready');
-      prReady++;
-    } else if (prMarker && prMarker.lastState === 'pr-broken') {
-      flags.push('pr-broken');
-      prBroken++;
-    } else if (prMarker && prMarker.lastState === 'pr-pending') {
-      flags.push('pr-pending');
-      prPending++;
-    }
-    if (wedgedMarker && wedgedMarker.wedgedUntil && wedgedMarker.wedgedUntil > state.now()) {
-      flags.push('WEDGED');
-      wedged++;
-    }
-    if (commitMarker && commitMarker.lastThreshold >= 240) {
-      flags.push(`stall=${commitMarker.lastThreshold}m`);
-    }
-    parts.push(`${tid}(${ws.phase || '?'}${flags.length ? ',' + flags.join(',') : ''})`);
-  }
-  return (
-    `HEARTBEAT ${workSessions.length} active, ${prReady} pr-ready, ${prBroken} pr-broken, ${prPending} pr-pending, ${wedged} wedged` +
-    (parts.length ? ` | ${parts.join(' ')}` : '')
-  );
-}
-
 function maybeEmitHeartbeat(sessions) {
   const now = state.now();
   if (lastHeartbeatAt && now - lastHeartbeatAt < HEARTBEAT_MIN * 60) return;
   lastHeartbeatAt = now;
-  alerts.log(buildHeartbeat(sessions));
+  alerts.log(heartbeat.buildHeartbeat(sessions));
 }
 
 function tick() {

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -53,10 +53,8 @@ function maybeEscalateToDeadEnd(ctx, kind, repeatCount, sha) {
   });
 }
 
-// Only -work sessions are restart-eligible (matches maestro-conduct.sh
-// gating). Helpers like -dev / -listen are surfaced informationally but
-// would re-launch wrong if relaunched as /work <tid>. Re-exported from
-// heartbeat.js so module.exports keeps the historical surface.
+// Only -work sessions restart-eligible (matches maestro-conduct.sh gating).
+// Re-exported from heartbeat.js so module.exports keeps the historical surface.
 const restartEligible = heartbeat.restartEligible;
 
 const REPO_NAME = process.env.REPO_NAME || 'claude-plugin-work';
@@ -297,14 +295,9 @@ function runPrStatusDetector(ctx) {
     failingChecks: sHit.failingChecks,
     instruction,
   });
-  // CI-gate slot rotation removed: previously this called freeCIGateSlot
-  // unconditionally on pr-ready in ci/wait_merge, which killed the -work
-  // tmux session the alert instruction had just told the operator to forward
-  // code-checker NEEDS-WORK findings to. The race destroyed the remediation
-  // path inside the same alert. Slot freeing is now operator-driven (see
-  // maestro-free-slot.sh) and must happen only AFTER the code-checker
-  // verdict is APPROVED. AUTO_FREE_CI_SLOT env var is preserved by
-  // freeCIGateSlot itself for callers that re-enable this path explicitly.
+  // CI-gate slot rotation removed: auto-freeing on pr-ready killed the -work
+  // session before code-checker could forward NEEDS-WORK findings. Slot freeing
+  // is now operator-driven via maestro-free-slot.sh after APPROVED verdict.
 }
 
 /** Run the per-session pipeline. Returns when the session has been fully processed. */
@@ -359,12 +352,8 @@ function handlePrComments(ctx, cHit) {
   if (marker.lastNudgeAt && sinceLastNudge < profile.reNudgeMin) return;
 
   const nudges = marker.nudges || 0;
-  // After the one-shot alert fires, keep re-emitting on reNudgeMin cadence so
-  // the alert count grows to DEAD_END_REEMITS and triggers freeDeadEndSlot.
-  // Previously this branch fully suppressed re-alerting, which capped the count
-  // at 1 and made dead-end auto-rotation unreachable. The pr-comments detector
-  // resets the marker when HEAD moves or comments are gone, so re-emits stop
-  // naturally once the agent acts.
+  // Keep re-emitting on reNudgeMin cadence so count grows to DEAD_END_REEMITS;
+  // detector resets the marker when HEAD moves or comments clear.
   const top = cHit.summary
     .map((s) => `${s.file}:${s.line} [${s.severity || '?'}] ${s.title}`)
     .join(' | ');

--- a/plugins/maestro/scripts/maestro-session.js
+++ b/plugins/maestro/scripts/maestro-session.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * maestro-session.js — manifest for an active orchestration session.
+ *
+ * Persists the orchestrator's plan when launching N parallel agents over M
+ * tasks: the ordered task list (by priority), dependency graph, slot count,
+ * and per-task status. Survives orchestrator restart, drives the
+ * SessionStart reminder so a fresh session doesn't accidentally start a
+ * parallel orchestration or forget the priority/dep plan.
+ *
+ * Storage: one JSON file per topic under MAESTRO_SESSION_DIR
+ *          (default ~/.cache/maestro/sessions).
+ *
+ * Schema:
+ *   {
+ *     topic: string,                 // e.g. "claude-plugin-work-bugs-2026-06"
+ *     slots: number,                 // parallel agent cap (the N)
+ *     createdAt: ISO,
+ *     tasks: [{
+ *       id: string,                  // e.g. "GH-498"
+ *       priority: number,            // lower = earlier; 1 is highest
+ *       deps: string[],              // task ids that must be 'done' first
+ *       status: 'pending'|'in_progress'|'done'|'blocked',
+ *       updatedAt?: ISO,
+ *       note?: string,
+ *     }, ...]
+ *   }
+ *
+ * CLI:
+ *   init <topic> <slots> <id>:<prio>[:dep,dep] ...    create
+ *   show <topic>                                       print full session
+ *   list                                               all active sessions
+ *   summary                                            short status per session
+ *   update <topic> <id> <status> [note]                update one task
+ *   next <topic>                                       next eligible task
+ *   clear <topic>                                      remove session file
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SESSION_DIR =
+  process.env.MAESTRO_SESSION_DIR || path.join(os.homedir(), '.cache', 'maestro', 'sessions');
+const VALID_STATUS = new Set(['pending', 'in_progress', 'done', 'blocked']);
+
+function ensureDir() {
+  fs.mkdirSync(SESSION_DIR, { recursive: true });
+}
+function sessionPath(topic) {
+  return path.join(SESSION_DIR, `${topic}.json`);
+}
+
+function init(topic, slots, tasks) {
+  if (!topic || !/^[A-Za-z0-9_.-]+$/.test(topic)) throw new Error(`bad topic: ${topic}`);
+  if (!(slots > 0)) throw new Error(`slots must be > 0`);
+  if (!tasks.length) throw new Error(`at least one task required`);
+  // Validate dep references — every dep must be a task in the same session.
+  const ids = new Set(tasks.map((t) => t.id));
+  for (const t of tasks) {
+    for (const d of t.deps || []) {
+      if (!ids.has(d)) throw new Error(`task ${t.id} depends on unknown ${d}`);
+    }
+  }
+  ensureDir();
+  const session = {
+    topic,
+    slots,
+    createdAt: new Date().toISOString(),
+    tasks: tasks.map((t) => ({
+      id: t.id,
+      priority: typeof t.priority === 'number' ? t.priority : 999,
+      deps: t.deps || [],
+      status: 'pending',
+    })),
+  };
+  fs.writeFileSync(sessionPath(topic), JSON.stringify(session, null, 2));
+  return session;
+}
+
+function read(topic) {
+  try {
+    return JSON.parse(fs.readFileSync(sessionPath(topic), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function update(topic, taskId, status, note) {
+  if (!VALID_STATUS.has(status)) throw new Error(`bad status: ${status}`);
+  const s = read(topic);
+  if (!s) throw new Error(`no session: ${topic}`);
+  const t = s.tasks.find((x) => x.id === taskId);
+  if (!t) throw new Error(`no task ${taskId} in ${topic}`);
+  t.status = status;
+  t.updatedAt = new Date().toISOString();
+  if (note) t.note = note;
+  fs.writeFileSync(sessionPath(topic), JSON.stringify(s, null, 2));
+  return t;
+}
+
+function list() {
+  if (!fs.existsSync(SESSION_DIR)) return [];
+  return fs
+    .readdirSync(SESSION_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(fs.readFileSync(path.join(SESSION_DIR, f), 'utf8')));
+}
+
+function nextEligible(topic) {
+  const s = read(topic);
+  if (!s) return null;
+  const doneIds = new Set(s.tasks.filter((t) => t.status === 'done').map((t) => t.id));
+  const eligible = s.tasks
+    .filter((t) => t.status === 'pending')
+    .filter((t) => (t.deps || []).every((d) => doneIds.has(d)));
+  eligible.sort((a, b) => a.priority - b.priority);
+  return eligible[0] || null;
+}
+
+function summarize(s) {
+  const counts = { pending: 0, in_progress: 0, done: 0, blocked: 0 };
+  for (const t of s.tasks) counts[t.status] = (counts[t.status] || 0) + 1;
+  return (
+    `${s.topic}: slots=${s.slots} | ${counts.in_progress} in flight, ${counts.done}/${s.tasks.length} done, ${counts.pending} pending` +
+    (counts.blocked ? `, ${counts.blocked} blocked` : '')
+  );
+}
+
+function clear(topic) {
+  try {
+    fs.unlinkSync(sessionPath(topic));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  init,
+  read,
+  update,
+  list,
+  nextEligible,
+  summarize,
+  clear,
+  SESSION_DIR,
+  sessionPath,
+};
+
+if (require.main === module) {
+  const [, , cmd, ...args] = process.argv;
+  try {
+    switch (cmd) {
+      case 'init': {
+        const [topic, slotsStr, ...taskSpecs] = args;
+        const slots = parseInt(slotsStr, 10);
+        const tasks = taskSpecs.map((spec) => {
+          const [id, prio, deps] = spec.split(':');
+          return {
+            id,
+            priority: parseInt(prio, 10),
+            deps: deps ? deps.split(',').filter(Boolean) : [],
+          };
+        });
+        console.log(JSON.stringify(init(topic, slots, tasks), null, 2));
+        break;
+      }
+      case 'show':
+        console.log(JSON.stringify(read(args[0]), null, 2));
+        break;
+      case 'list':
+        console.log(JSON.stringify(list(), null, 2));
+        break;
+      case 'summary': {
+        const sessions = list();
+        if (!sessions.length) console.log('No active maestro sessions.');
+        else for (const s of sessions) console.log(summarize(s));
+        break;
+      }
+      case 'update':
+        update(args[0], args[1], args[2], args.slice(3).join(' ') || undefined);
+        console.log('ok');
+        break;
+      case 'next':
+        console.log(JSON.stringify(nextEligible(args[0]), null, 2));
+        break;
+      case 'clear':
+        console.log(clear(args[0]) ? 'cleared' : 'not found');
+        break;
+      default:
+        console.error('usage: maestro-session.js <init|show|list|summary|update|next|clear> ...');
+        process.exit(1);
+    }
+  } catch (e) {
+    console.error(`error: ${e.message}`);
+    process.exit(1);
+  }
+}

--- a/plugins/maestro/scripts/maestro-session.js
+++ b/plugins/maestro/scripts/maestro-session.js
@@ -39,17 +39,16 @@
 
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
 
-const SESSION_DIR =
-  process.env.MAESTRO_SESSION_DIR || path.join(os.homedir(), '.cache', 'maestro', 'sessions');
+const shared = require('./lib/maestro-conduct/session-shared');
+const { countByStatus, eligibleTasks, getSessionDir } = shared;
 const VALID_STATUS = new Set(['pending', 'in_progress', 'done', 'blocked']);
 
 function ensureDir() {
-  fs.mkdirSync(SESSION_DIR, { recursive: true });
+  fs.mkdirSync(getSessionDir(), { recursive: true });
 }
 function sessionPath(topic) {
-  return path.join(SESSION_DIR, `${topic}.json`);
+  return path.join(getSessionDir(), `${topic}.json`);
 }
 
 function init(topic, slots, tasks) {
@@ -101,31 +100,35 @@ function update(topic, taskId, status, note) {
 }
 
 function list() {
-  if (!fs.existsSync(SESSION_DIR)) return [];
+  const dir = getSessionDir();
+  if (!fs.existsSync(dir)) return [];
   return fs
-    .readdirSync(SESSION_DIR)
+    .readdirSync(dir)
     .filter((f) => f.endsWith('.json'))
-    .map((f) => JSON.parse(fs.readFileSync(path.join(SESSION_DIR, f), 'utf8')));
+    .map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')));
 }
 
 function nextEligible(topic) {
   const s = read(topic);
   if (!s) return null;
-  const doneIds = new Set(s.tasks.filter((t) => t.status === 'done').map((t) => t.id));
-  const eligible = s.tasks
-    .filter((t) => t.status === 'pending')
-    .filter((t) => (t.deps || []).every((d) => doneIds.has(d)));
-  eligible.sort((a, b) => a.priority - b.priority);
-  return eligible[0] || null;
+  return eligibleTasks(s.tasks)[0] || null;
 }
 
 function summarize(s) {
-  const counts = { pending: 0, in_progress: 0, done: 0, blocked: 0 };
-  for (const t of s.tasks) counts[t.status] = (counts[t.status] || 0) + 1;
+  const counts = countByStatus(s.tasks);
   return (
     `${s.topic}: slots=${s.slots} | ${counts.in_progress} in flight, ${counts.done}/${s.tasks.length} done, ${counts.pending} pending` +
     (counts.blocked ? `, ${counts.blocked} blocked` : '')
   );
+}
+
+function printSummary() {
+  const sessions = list();
+  if (!sessions.length) {
+    console.log('No active maestro sessions.');
+    return;
+  }
+  for (const s of sessions) console.log(summarize(s));
 }
 
 function clear(topic) {
@@ -145,7 +148,9 @@ module.exports = {
   nextEligible,
   summarize,
   clear,
-  SESSION_DIR,
+  get SESSION_DIR() {
+    return getSessionDir();
+  },
   sessionPath,
 };
 
@@ -173,12 +178,9 @@ if (require.main === module) {
       case 'list':
         console.log(JSON.stringify(list(), null, 2));
         break;
-      case 'summary': {
-        const sessions = list();
-        if (!sessions.length) console.log('No active maestro sessions.');
-        else for (const s of sessions) console.log(summarize(s));
+      case 'summary':
+        printSummary();
         break;
-      }
       case 'update':
         update(args[0], args[1], args[2], args.slice(3).join(' ') || undefined);
         console.log('ok');

--- a/plugins/maestro/skills/orchestrate/SKILL.md
+++ b/plugins/maestro/skills/orchestrate/SKILL.md
@@ -42,17 +42,17 @@ The .js daemon emits exactly these event kinds. Anything else is bookkeeping noi
 
 | Event | Shape | Emitted by | Dedup |
 |---|---|---|---|
-| `QUESTION-DETECTED` | `[<S>] QUESTION-DETECTED: …` + structured `MAESTRO-ALERT` row | `detectors/question.js` | Per-session, fires once when prompt sits ≥`Q_WAIT_MIN` minutes |
-| `MAESTRO-ALERT … kind=…` | JSONL row in `/tmp/maestro-alerts.jsonl`, summary line in tmux `maestro-alerts` | `actions.alert` | One per kind per ticket per state, then mutes until state flips |
-| `pr-ready` | `MAESTRO-ALERT … kind=pr-ready prNumber=N sha=…` | `detectors/pr-status.js` | Emit on first sight + state transition; re-emit same state at most every `PR_STATUS_RE_EMIT_MIN` (30m) |
-| `pr-broken` | `MAESTRO-ALERT … kind=pr-broken failingChecks=[…]` | `detectors/pr-status.js` | Same dedup as `pr-ready` |
+| `QUESTION-DETECTED` | `[<S>] QUESTION-DETECTED: …` + structured `ACTION` row | `detectors/question.js` | Per-session, fires once when prompt sits ≥`Q_WAIT_MIN` minutes |
+| `ACTION … kind=…` | JSONL row in `/tmp/maestro-alerts.jsonl`, summary line in tmux `maestro-alerts` | `actions.alert` | One per kind per ticket per state, then mutes until state flips |
+| `pr-ready` | `ACTION … kind=pr-ready prNumber=N sha=…` | `detectors/pr-status.js` | Emit on first sight + state transition; re-emit same state at most every `PR_STATUS_RE_EMIT_MIN` (30m) |
+| `pr-broken` | `ACTION … kind=pr-broken failingChecks=[…]` | `detectors/pr-status.js` | Same dedup as `pr-ready` |
 | `pr-pending` | log-only, `<S> pr-pending PR #N sha=… checks running` | `detectors/pr-status.js` | Per-tick log; informational, **not** an alert |
-| `wedged` | `MAESTRO-ALERT … kind=wedged restartsInWindow=N` + `<S> WEDGED — N auto-restarts in Mm` | `actions.autoRestart` (restart-loop guard) | Once per session per `WEDGED_QUIET_MIN` (60m) suppression window |
+| `wedged` | `ACTION … kind=wedged restartsInWindow=N` + `<S> WEDGED — N auto-restarts in Mm` | `actions.autoRestart` (restart-loop guard) | Once per session per `WEDGED_QUIET_MIN` (60m) suppression window |
 | `AUTO-RESTART after Ns silence` | log-only | `actions.autoRestart` | One per restart, not throttled |
 | `AUTO-RESTART skipped: non-work helper` | log-only | `runSilenceDetector` | Throttled by `SILENCE_LIMIT_SEC` |
 | `NUDGE soft` / `NUDGE interrupt` | log-only + tmux send to agent pane | `actions.soft` / `actions.interrupt` | Per phase `reNudgeMin` |
-| `nudges-exhausted` | `MAESTRO-ALERT … kind=nudges-exhausted` | `handlePhaseStall` | One alert per phase, until phase advances |
-| `pr-comments-stuck` | `MAESTRO-ALERT … kind=pr-comments-stuck` | `handlePrComments` | One alert until comment count or HEAD changes |
+| `nudges-exhausted` | `ACTION … kind=nudges-exhausted` | `handlePhaseStall` | One alert per phase, until phase advances |
+| `pr-comments-stuck` | `ACTION … kind=pr-comments-stuck` | `handlePrComments` | One alert until comment count or HEAD changes |
 | `commit-stall NNNm` | `<S> commit-stall NNNm in phase=… (threshold=TTTm)` | `runCommitStallDetector` | **Threshold-only**: emits at `[30, 60, 120, 240, 480]` minutes, at most 5 lines per stall |
 | `HEARTBEAT N active, X pr-ready, Y pr-broken, Z pr-pending, W wedged ‖ …` | log-only | `maybeEmitHeartbeat` (main loop) | Once per `HEARTBEAT_MIN` (default 30m); always emits even when nothing else changed |
 
@@ -61,7 +61,7 @@ The .js daemon emits exactly these event kinds. Anything else is bookkeeping noi
 Use this exact regex. Anything outside it is noise:
 
 ```
-QUESTION-DETECTED|AUTO-RESTART|SESSION-GONE|NUDGE|MAESTRO-ALERT|pr-ready|pr-broken|wedged|WEDGED|HEARTBEAT|commit-stall
+QUESTION-DETECTED|AUTO-RESTART|SESSION-GONE|NUDGE|ACTION|pr-ready|pr-broken|wedged|WEDGED|HEARTBEAT|commit-stall
 ```
 
 `pr-ready` is the **positive** signal — when you see it, the agent's PR is CLEAN and all checks are green; merge it (or hold per `[[never-auto-merge-pr]]`). `wedged` is the **escalation** signal — auto-restart loop hit its cap; operator must inspect. `HEARTBEAT` is the periodic forced re-read; never ignore it.

--- a/plugins/maestro/skills/orchestrate/SKILL.md
+++ b/plugins/maestro/skills/orchestrate/SKILL.md
@@ -36,12 +36,66 @@ Examples:
 - **Silent agents** auto-restart after `SILENCE_LIMIT_SEC` (default 300s). `/work` is resumable from `.work-state.json`.
 - **Snapshot** anytime with `bash plugins/maestro/scripts/maestro-pulse.sh` (or `/pulse`).
 
+## Daemon event vocabulary (the only thing your Monitor filter should match)
+
+The .js daemon emits exactly these event kinds. Anything else is bookkeeping noise — do not subscribe to it. Each kind below is dedup'd as noted; if you see it, it carries new information.
+
+| Event | Shape | Emitted by | Dedup |
+|---|---|---|---|
+| `QUESTION-DETECTED` | `[<S>] QUESTION-DETECTED: …` + structured `MAESTRO-ALERT` row | `detectors/question.js` | Per-session, fires once when prompt sits ≥`Q_WAIT_MIN` minutes |
+| `MAESTRO-ALERT … kind=…` | JSONL row in `/tmp/maestro-alerts.jsonl`, summary line in tmux `maestro-alerts` | `actions.alert` | One per kind per ticket per state, then mutes until state flips |
+| `pr-ready` | `MAESTRO-ALERT … kind=pr-ready prNumber=N sha=…` | `detectors/pr-status.js` | Emit on first sight + state transition; re-emit same state at most every `PR_STATUS_RE_EMIT_MIN` (30m) |
+| `pr-broken` | `MAESTRO-ALERT … kind=pr-broken failingChecks=[…]` | `detectors/pr-status.js` | Same dedup as `pr-ready` |
+| `pr-pending` | log-only, `<S> pr-pending PR #N sha=… checks running` | `detectors/pr-status.js` | Per-tick log; informational, **not** an alert |
+| `wedged` | `MAESTRO-ALERT … kind=wedged restartsInWindow=N` + `<S> WEDGED — N auto-restarts in Mm` | `actions.autoRestart` (restart-loop guard) | Once per session per `WEDGED_QUIET_MIN` (60m) suppression window |
+| `AUTO-RESTART after Ns silence` | log-only | `actions.autoRestart` | One per restart, not throttled |
+| `AUTO-RESTART skipped: non-work helper` | log-only | `runSilenceDetector` | Throttled by `SILENCE_LIMIT_SEC` |
+| `NUDGE soft` / `NUDGE interrupt` | log-only + tmux send to agent pane | `actions.soft` / `actions.interrupt` | Per phase `reNudgeMin` |
+| `nudges-exhausted` | `MAESTRO-ALERT … kind=nudges-exhausted` | `handlePhaseStall` | One alert per phase, until phase advances |
+| `pr-comments-stuck` | `MAESTRO-ALERT … kind=pr-comments-stuck` | `handlePrComments` | One alert until comment count or HEAD changes |
+| `commit-stall NNNm` | `<S> commit-stall NNNm in phase=… (threshold=TTTm)` | `runCommitStallDetector` | **Threshold-only**: emits at `[30, 60, 120, 240, 480]` minutes, at most 5 lines per stall |
+| `HEARTBEAT N active, X pr-ready, Y pr-broken, Z pr-pending, W wedged ‖ …` | log-only | `maybeEmitHeartbeat` (main loop) | Once per `HEARTBEAT_MIN` (default 30m); always emits even when nothing else changed |
+
+## Recommended Monitor filter
+
+Use this exact regex. Anything outside it is noise:
+
+```
+QUESTION-DETECTED|AUTO-RESTART|SESSION-GONE|NUDGE|MAESTRO-ALERT|pr-ready|pr-broken|wedged|WEDGED|HEARTBEAT|commit-stall
+```
+
+`pr-ready` is the **positive** signal — when you see it, the agent's PR is CLEAN and all checks are green; merge it (or hold per `[[never-auto-merge-pr]]`). `wedged` is the **escalation** signal — auto-restart loop hit its cap; operator must inspect. `HEARTBEAT` is the periodic forced re-read; never ignore it.
+
 ## Env
 
-`WORKTREES_BASE`, `REPO_NAME`, `BASE_BRANCH`, `SILENCE_LIMIT_SEC` — see plugin README.
+| Variable | Default | What it tunes |
+|---|---|---|
+| `WORKTREES_BASE` | — | Where worktrees live |
+| `REPO_NAME` | `claude-plugin-work` | Resolves to `<base>/<repo>-<ticket>` worktree path |
+| `BASE_BRANCH` | `main` | Branch the worktree forks from |
+| `SILENCE_LIMIT_SEC` | 300 | Auto-restart after this much pane silence |
+| `Q_WAIT_MIN` | 3 | Question-pending alert delay |
+| `TICK_SEC` | 60 | Daemon tick cadence |
+| `COMMIT_STALL_MIN` | 30 | Floor below which commit-stall is suppressed |
+| `PR_STATUS_RE_EMIT_MIN` | 30 | Cooldown between re-emits of same PR state |
+| `RESTART_LOOP_THRESHOLD` | 3 | Restarts within window before declaring WEDGED |
+| `RESTART_WINDOW_MIN` | 30 | Rolling window for restart-loop counter |
+| `WEDGED_QUIET_MIN` | 60 | How long to suppress restarts after WEDGED |
+| `HEARTBEAT_MIN` | 30 | Heartbeat cadence |
+
+## After launch
+
+- **Real questions** from any agent surface as `[<SESSION>] QUESTION-DETECTED: …` lines. Handle them via `tmux send-keys -t <SESSION>` against the agent pane.
+- **Silent agents** auto-restart after `SILENCE_LIMIT_SEC` (default 300s). `/work` is resumable from `.work-state.json`.
+- **PR ready** surfaces as `pr-ready` — operator merges per `[[never-auto-merge-pr]]`.
+- **PR broken** surfaces as `pr-broken` with failing-check list — orchestrator nudges the originating agent to fix.
+- **Wedged sessions** suppress further restarts; operator must inspect the pane to unwedge.
+- **Snapshot** anytime with `bash plugins/maestro/scripts/maestro-pulse.sh` (or `/pulse`).
 
 ## Anti-patterns
 
 - Do **not** kill sessions belonging to other tickets — scoped per `<TICKET>-work` only.
 - Do **not** auto-merge PRs without operator approval; the orchestrator does not call `gh pr merge`.
+- Do **not** ignore `pr-ready` — that's the positive signal you were waiting for.
+- Do **not** ignore `HEARTBEAT` — it is the periodic forced re-read that exists specifically because operators desensitize to repeated noise.
 - The inbox at `/tmp/claude-agent-inbox/<TICKET>.log` is human-facing; agents do not read it. Talk to agents via `tmux send-keys`.


### PR DESCRIPTION
## Existing Behavior

- Commit-stall detector fires on every tick regardless of whether it already fired at that threshold, producing duplicate alerts
- The daemon has no awareness of PR state transitions (open/broken/merged/pending) and cannot emit targeted alerts when a PR becomes ready or broken
- Restart-loop detection has no wedged-guard: a slot can restart indefinitely without being flagged as stuck
- `alerts.alert()` has no required instruction field; repeated alerts are re-emitted with no indication of recurrence, and no auto-rotation is triggered when a slot is persistently dead-ended
- No periodic heartbeat confirms the daemon is alive during long idle periods
- `freeCIGateSlot` does not auto-kill the tmux session for slots in `ci` or `wait_merge` phase when a PR is ready
- No orchestration manifest to track active sessions, dependencies, or next-session routing
- No UserPromptSubmit hook to surface active session context at conversation start

## Intended New Behavior

- **PR-status detector** emits `pr-ready`, `pr-broken`, or `pr-pending` events on state transitions; `freeCIGateSlot` auto-kills the tmux session for slots at `phase=ci|wait_merge` when PR is ready
- **Commit-stall dedup** fires only once per threshold level using a `[30, 60, 120, 240, 480]` minute ladder — no repeat alerts for the same stall bucket
- **Restart-loop wedged guard** detects a slot that keeps restarting without making progress and marks it wedged after configurable thresholds
- **Periodic HEARTBEAT** (default 30 min) emits a heartbeat event to confirm the daemon is alive during idle periods
- **`alerts.alert()` requires an `instruction` field**; repeated alerts carry a `[REPEAT N]` prefix; `freeDeadEndSlot` auto-rotates the slot on the 3rd repeat (`DEAD_END_REEMITS=3` default)
- **`maestro-session.js`** — new orchestration manifest CLI (`init / show / list / summary / update / next / clear`) with a dependency graph stored at `~/.cache/maestro/sessions/`
- **`active-session-reminder.js`** — new UserPromptSubmit hook that surfaces the active session manifest at conversation start
- **`OPERATOR_PLAYBOOK.md`** — new runbook covering daemon ops, slot lifecycle, alert triage, and env knob reference
- 27 new tests added; all 66/66 maestro suite tests green

## Dev Checks

- [ ] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Environment Knobs

| Variable | Default | Effect |
|---|---|---|
| `AUTO_FREE_CI_SLOT` | `true` | Auto-kill tmux for ci/wait_merge slots on pr-ready |
| `AUTO_FREE_DEAD_END` | `true` | Enable dead-end slot auto-rotation |
| `DEAD_END_REEMITS` | `3` | Repeat count before freeDeadEndSlot triggers |
| `PR_STATUS_RE_EMIT_MIN` | `10` | Minimum minutes between pr-status re-emits |
| `HEARTBEAT_MIN` | `30` | Heartbeat interval in minutes |
| `RESTART_LOOP_THRESHOLD` | `5` | Restart count before wedged guard fires |
| `RESTART_WINDOW_MIN` | `60` | Time window for restart-loop counting |
| `WEDGED_QUIET_MIN` | `20` | Quiet period after wedged alert before re-alerting |

## Notes

- **Supersedes PR #500** — that branch was cut off old main pre-3.18.0 reset and carried cross-plugin conflicts; this branch is rebased cleanly onto current main
- **Daemon must be restarted** to pick up any of these changes
- No `Closes #N` — this is direct infrastructure, not tracked against a GitHub issue

## Testing Plan / Demo

**To verify daemon improvements after restart:**

1. Start (or restart) the maestro daemon so the new build is loaded
2. Trigger a commit-stall scenario — confirm the alert fires once per threshold bucket, not on every tick
3. Open or close a PR tied to a tracked slot — confirm `pr-ready` / `pr-broken` events appear in daemon logs
4. For CI-gate auto-rotation: set `AUTO_FREE_CI_SLOT=true`, move a slot to `phase=ci`, mark the PR ready — confirm the tmux session for that slot is killed automatically
5. Confirm `alerts.alert()` rejects calls without an `instruction` field
6. Let a slot re-alert 3+ times — confirm `[REPEAT N]` prefix and auto-rotation after the 3rd repeat
7. Run the session manifest CLI: `node plugins/maestro/scripts/maestro-session.js init`, then `show`, `list`, `summary`, `next`, `clear`
8. Open a new conversation — confirm `active-session-reminder.js` surfaces the active session context

**To run the test suite:**

```bash
cd plugins/maestro && pnpm test --testPathPattern="__tests__"
# Expected: 66/66 passing
```

### Test Results

27 new tests added across 4 new spec files:

- `actions-free-ci-gate-slot.test.js` — freeCIGateSlot tmux auto-kill + pr-ready trigger
- `alerts-escalation.test.js` — [REPEAT N] prefix, instruction enforcement, freeDeadEndSlot threshold
- `detectors-commit-stall-dedup.test.js` — per-bucket dedup across the 5-level threshold ladder
- `detectors-pr-status.test.js` — state-transition events (pr-ready/pr-broken/pr-pending)
- `detectors-restart-loop.test.js` — wedged guard, window expiry, threshold counting
- `maestro-session.test.js` — manifest CLI init/show/list/summary/update/next/clear

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tmux lifecycle, auto-restart, and alert semantics for long-running orchestration; mis-tuned env vars or a stale daemon could kill sessions or miss pr-ready signals until restart.
> 
> **Overview**
> This PR upgrades the **maestro** orchestration daemon and operator tooling so signals are actionable, deduplicated, and easier to run at scale.
> 
> **Daemon behavior:** Alerts now require an **`instruction`** string, persist **repeat counts** (with `[REPEAT N]` prefixes), and can escalate to **`freeDeadEndSlot`** after **`DEAD_END_REEMITS`**. A new **`pr-status`** detector emits **`pr-ready` / `pr-broken` / `pr-pending`** from GitHub CI + merge state; the conductor surfaces **`pr-ready`** with a **code-checker** playbook and **no longer auto-calls `freeCIGateSlot` on green** (so agents stay alive for NEEDS-WORK). **`commit-stall`** only fires on ladder crossings (**30→480m**). **`autoRestart`** gains a **wedged** guard, **ci-gate-freed** / **dead-end** resurrection blocks, plus optional **`freeCIGateSlot`** / **`freeDeadEndSlot`** (tmux kill, manifest-based next task, optional **`AUTO_BOOTSTRAP_NEXT`**). Periodic **`HEARTBEAT`** summaries and **`prStatus`** in more phases address “silent but ready” tickets.
> 
> **Operator & hygiene:** Adds **`maestro-session.js`** (priority + dependency manifests), **`active-session-reminder`** hook, **`maestro-cleanup.js`**, **`OPERATOR_PLAYBOOK.md`**, and expanded **`orchestrate/SKILL.md`** (event vocabulary, monitor regex, env table). Shared **`gh-shared`** / **`session-shared`** reduce duplication. Broad **unit test** coverage for the new detectors and actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 719d228225c8a622e44f95f4c2cdebca450191c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->