### PR TITLE
bootstrap: honor Linear's gitBranchName and validate branch name regex

### DIFF
--- a/plugins/work/scripts/workflows/work/scripts/__tests__/bootstrap-branch.integration.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/bootstrap-branch.integration.test.js
@@ -1,0 +1,155 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const SCRIPT = path.join(__dirname, '..', 'bootstrap-branch.js');
+
+/**
+ * Spawn the bootstrap-branch.js helper as a subprocess and return
+ * { stdout, stderr, status }. Env starts from a clean slate (no
+ * inherited BRANCH_PREFIX / BRANCH_NAME_REGEX / TICKET_PROVIDER) so
+ * each test owns its config surface.
+ */
+function runResult(args, env = {}) {
+  // Start from process.env but strip every var the helper consults so
+  // tests do not inherit ambient .envrc values from the dev shell.
+  const merged = { ...process.env };
+  for (const key of ['BRANCH_PREFIX', 'BRANCH_NAME_REGEX', 'TICKET_PROVIDER']) {
+    delete merged[key];
+  }
+  Object.assign(merged, env);
+  // Treat empty-string overrides as "explicitly empty" — keep them as ''.
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      encoding: 'utf-8',
+      env: merged,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    });
+    return { stdout, stderr: '', status: 0 };
+  } catch (err) {
+    return {
+      stdout: err.stdout ? err.stdout.toString() : '',
+      stderr: err.stderr ? err.stderr.toString() : '',
+      status: err.status ?? 1,
+    };
+  }
+}
+
+describe('bootstrap-branch.js — Task 1 (CLI contract + resolver)', () => {
+  describe('Linear gitBranchName is used verbatim when present and provider is Linear', () => {
+    it('returns --git-branch-name value verbatim on stdout with exit 0 when TICKET_PROVIDER=linear', () => {
+      const result = runResult(
+        [
+          '--ticket-id', 'ECHO-4454',
+          '--summary', 'Fix Foo Bar',
+          '--git-branch-name', 'feature/echo-4454-foo',
+        ],
+        { TICKET_PROVIDER: 'linear' },
+      );
+      assert.equal(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+      assert.equal(result.stdout.trim(), 'feature/echo-4454-foo');
+      // stdout must contain only the resolved name (no trailing diagnostics)
+      assert.equal(result.stdout.replace(/\n$/, ''), 'feature/echo-4454-foo');
+    });
+  });
+
+  describe('Fallback constructs <BRANCH_PREFIX><TICKET-ID>-<kebab-summary> when gitBranchName is absent', () => {
+    it('with BRANCH_PREFIX=feature/ produces feature/echo-4454-fix-foo-bar (ticket-ID lowercased)', () => {
+      const result = runResult(
+        ['--ticket-id', 'ECHO-4454', '--summary', 'Fix Foo Bar'],
+        { BRANCH_PREFIX: 'feature/' },
+      );
+      assert.equal(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+      assert.equal(result.stdout.trim(), 'feature/echo-4454-fix-foo-bar');
+    });
+  });
+
+  describe('Fallback works with empty BRANCH_PREFIX for backward compatibility', () => {
+    it('with empty BRANCH_PREFIX produces echo-4454-fix-foo-bar', () => {
+      const result = runResult(
+        ['--ticket-id', 'ECHO-4454', '--summary', 'Fix Foo Bar'],
+        { BRANCH_PREFIX: '' },
+      );
+      assert.equal(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+      assert.equal(result.stdout.trim(), 'echo-4454-fix-foo-bar');
+    });
+  });
+
+  describe('CLI argument validation', () => {
+    it('exits 1 with stderr explaining the missing flag when --ticket-id is absent', () => {
+      const result = runResult(['--summary', 'Fix Foo Bar']);
+      assert.equal(result.status, 1, `expected exit 1, got ${result.status}`);
+      assert.match(result.stderr, /--ticket-id/, `expected stderr to mention --ticket-id, got: ${result.stderr}`);
+    });
+  });
+});
+
+describe('bootstrap-branch.js — Task 2 (BRANCH_NAME_REGEX gate + safety + prefix suggestion)', () => {
+  describe('Helper aborts BEFORE git worktree add when name fails BRANCH_NAME_REGEX', () => {
+    it('(a) BRANCH_NAME_REGEX=^(feature|fix)/.+$ rejects echo-4454-foo with stderr containing name and regex', () => {
+      const result = runResult(
+        ['--ticket-id', 'ECHO-4454', '--summary', 'Foo'],
+        { BRANCH_NAME_REGEX: '^(feature|fix)/.+$' },
+      );
+      assert.equal(result.status, 1, `expected exit 1, got ${result.status}. stderr: ${result.stderr}`);
+      assert.match(result.stderr, /echo-4454-foo/, `expected stderr to mention offending name, got: ${result.stderr}`);
+      assert.match(result.stderr, /\^\(feature\|fix\)\/\.\+\$/, `expected stderr to mention regex source, got: ${result.stderr}`);
+    });
+
+    it('(e) regex mismatch + BRANCH_PREFIX would have matched: stderr suggests setting BRANCH_PREFIX', () => {
+      const result = runResult(
+        ['--ticket-id', 'ECHO-4454', '--summary', 'Foo'],
+        { BRANCH_NAME_REGEX: '^feature/.+$', BRANCH_PREFIX: 'feature/' },
+      );
+      // With BRANCH_PREFIX set the name is already feature/echo-4454-foo → would pass.
+      // To exercise the suggestion path, BRANCH_PREFIX is configured but the test
+      // simulates the mismatch case where prepending the configured prefix would help.
+      // The implementation must compute: if regex.test(prefix + name) === true, suggest it.
+      // Here we invert: set regex requiring feature/ and BRANCH_PREFIX empty but configured
+      // via a separate run.
+      // Re-run with empty prefix to actually trigger suggestion:
+      const r2 = runResult(
+        ['--ticket-id', 'ECHO-4454', '--summary', 'Foo'],
+        { BRANCH_NAME_REGEX: '^feature/.+$', BRANCH_PREFIX: '' },
+      );
+      assert.equal(r2.status, 1, `expected exit 1, got ${r2.status}`);
+      // Suggestion line per AC 1.2.1(e):
+      assert.match(r2.stderr, /BRANCH_PREFIX/, `expected suggestion mentioning BRANCH_PREFIX, got: ${r2.stderr}`);
+      // Also verify the first run (which would have passed) actually does pass:
+      assert.equal(result.status, 0, `expected exit 0 when prefix already matches, got ${result.status}. stderr: ${result.stderr}`);
+    });
+  });
+
+  describe('Validation is skipped when BRANCH_NAME_REGEX is unset', () => {
+    it('(b) unset BRANCH_NAME_REGEX resolves echo-4454-foo with exit 0 (backward compat)', () => {
+      const result = runResult(
+        ['--ticket-id', 'ECHO-4454', '--summary', 'Foo'],
+        {},
+      );
+      assert.equal(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+      assert.equal(result.stdout.trim(), 'echo-4454-foo');
+    });
+
+    it('(d) safety regex blocks shell metacharacters even when BRANCH_NAME_REGEX is unset', () => {
+      // Pass a Linear gitBranchName containing a shell metachar; with TICKET_PROVIDER=linear
+      // it would be used verbatim, so safety regex must still reject it.
+      const result = runResult(
+        ['--ticket-id', 'ECHO-4454', '--summary', 'Foo', '--git-branch-name', 'feature/bad;name'],
+        { TICKET_PROVIDER: 'linear' },
+      );
+      assert.equal(result.status, 1, `expected exit 1 (shell metachar), got ${result.status}. stderr: ${result.stderr}`);
+    });
+  });
+
+  describe('Linear gitBranchName that violates BRANCH_NAME_REGEX causes fail-fast abort', () => {
+    it('(c) --git-branch-name=bad name! with BRANCH_NAME_REGEX=^feature/.+$ exits 1 (regex wins over Linear)', () => {
+      const result = runResult(
+        ['--ticket-id', 'ECHO-4454', '--summary', 'Foo', '--git-branch-name', 'bad name!'],
+        { TICKET_PROVIDER: 'linear', BRANCH_NAME_REGEX: '^feature/.+$' },
+      );
+      assert.equal(result.status, 1, `expected exit 1 (regex wins), got ${result.status}. stderr: ${result.stderr}`);
+    });
+  });
+});

--- a/plugins/work/scripts/workflows/work/scripts/bootstrap-branch.js
+++ b/plugins/work/scripts/workflows/work/scripts/bootstrap-branch.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * bootstrap-branch.js
+ *
+ * Resolves the worktree branch name for the bootstrap skill.
+ *
+ * Precedence (Task 1 scope):
+ *   1. If `--git-branch-name <value>` is provided AND the configured ticket
+ *      provider is Linear (TICKET_PROVIDER=linear), the value is used
+ *      verbatim — Linear's `gitBranchName` field is authoritative.
+ *   2. Otherwise, fall back to `<BRANCH_PREFIX><ticket-id-lowercased>-<kebab-summary>`.
+ *      BRANCH_PREFIX defaults to empty string for backward compatibility.
+ *
+ * CLI contract:
+ *   --ticket-id <id>           (required)
+ *   --summary <text>           (required unless --git-branch-name is provided
+ *                               AND it is used verbatim via the Linear path)
+ *   --git-branch-name <value>  (optional)
+ *
+ * Output: resolved branch name on stdout (no trailing diagnostics).
+ * Exit 0 on success; exit 1 on validation failure or missing required arg.
+ */
+
+'use strict';
+
+const getConfig = require('../../lib/get-config');
+
+function parseArgs(argv) {
+  const out = { ticketId: null, summary: null, gitBranchName: null };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const next = argv[i + 1];
+    if (flag === '--ticket-id') {
+      out.ticketId = next;
+      i++;
+    } else if (flag === '--summary') {
+      out.summary = next;
+      i++;
+    } else if (flag === '--git-branch-name') {
+      out.gitBranchName = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+function kebab(text) {
+  return String(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function resolveBranchName({ ticketId, summary, gitBranchName }) {
+  const provider = (getConfig('TICKET_PROVIDER') || '').toLowerCase();
+  // Precedence rule (R1): Linear gitBranchName wins verbatim.
+  if (gitBranchName && provider === 'linear') {
+    return gitBranchName;
+  }
+  // Fallback composition (R2, R7).
+  const prefix = getConfig('BRANCH_PREFIX') || '';
+  const idSegment = String(ticketId).toLowerCase();
+  const summarySegment = kebab(summary || '');
+  return `${prefix}${idSegment}-${summarySegment}`;
+}
+
+function fail(message) {
+  process.stderr.write(`bootstrap-branch: ${message}\n`);
+  process.exit(1);
+}
+
+// Conservative safety regex: blocks shell metacharacters (`;`, `|`, `&`,
+// backticks, `$`, whitespace) and `..` traversal sequences. Applied
+// unconditionally — even when BRANCH_NAME_REGEX is unset (Task 2 / AC 1.2.1(d)).
+const SAFETY_REGEX = /^[A-Za-z0-9._\-/]+$/;
+
+/**
+ * Build a "did you mean to set BRANCH_PREFIX=…?" suggestion for the failure
+ * message when the resolved name fails BRANCH_NAME_REGEX but prepending a
+ * plausible prefix would make it pass.
+ *
+ * Candidates considered, in order:
+ *   1. The configured BRANCH_PREFIX (if non-empty).
+ *   2. Prefixes inferred from a `^(a|b|c)/...` regex head.
+ *   3. A prefix inferred from a `^literal/...` regex head.
+ */
+function inferPrefixCandidates(regex) {
+  const candidates = [];
+  const groupHead = /^\^\(\?:?([A-Za-z0-9_|\\\-]+)\)\\?\//.exec(regex)
+    || /^\^\(([A-Za-z0-9_|\\\-]+)\)\\?\//.exec(regex);
+  if (groupHead) {
+    for (const alt of groupHead[1].split('|')) {
+      candidates.push(`${alt.replace(/\\/g, '')}/`);
+    }
+    return candidates;
+  }
+  const literalHead = /^\^([A-Za-z0-9_\-]+)\\?\//.exec(regex);
+  if (literalHead) candidates.push(`${literalHead[1]}/`);
+  return candidates;
+}
+
+function buildPrefixSuggestion({ name, userRegex, regex, prefix }) {
+  const candidates = [];
+  if (prefix) candidates.push(prefix);
+  for (const cand of inferPrefixCandidates(regex)) {
+    if (!candidates.includes(cand)) candidates.push(cand);
+  }
+  for (const cand of candidates) {
+    try {
+      if (userRegex.test(`${cand}${name}`)) {
+        return ` (did you mean to set BRANCH_PREFIX=${cand}?)`;
+      }
+    } catch (_err) {
+      // ignore — main error message still produced
+    }
+  }
+  return '';
+}
+
+function validate(name, { regex, prefix }) {
+  // 1. Unconditional safety regex (shell metachars / `..` / whitespace).
+  if (!SAFETY_REGEX.test(name) || name.includes('..')) {
+    fail(`resolved name '${name}' contains disallowed characters (shell metacharacters or '..')`);
+  }
+  // 2. Optional user-configured BRANCH_NAME_REGEX gate.
+  if (regex) {
+    let userRegex;
+    try {
+      userRegex = new RegExp(regex);
+    } catch (err) {
+      fail(`BRANCH_NAME_REGEX '${regex}' is not a valid regular expression: ${err.message}`);
+      return;
+    }
+    let matches = false;
+    try {
+      matches = userRegex.test(name);
+    } catch (err) {
+      fail(`BRANCH_NAME_REGEX '${regex}' threw during test: ${err.message}`);
+      return;
+    }
+    if (!matches) {
+      const suggestion = buildPrefixSuggestion({ name, userRegex, regex, prefix });
+      fail(`resolved name '${name}' does not match BRANCH_NAME_REGEX ${regex}${suggestion}`);
+    }
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.ticketId) {
+    fail('missing required flag --ticket-id');
+  }
+  // --summary is only required when there is no Linear verbatim path.
+  const providerIsLinear = (getConfig('TICKET_PROVIDER') || '').toLowerCase() === 'linear';
+  if (!args.summary && !(args.gitBranchName && providerIsLinear)) {
+    fail('missing required flag --summary (required unless --git-branch-name is provided with TICKET_PROVIDER=linear)');
+  }
+  const name = resolveBranchName(args);
+  const regex = getConfig('BRANCH_NAME_REGEX') || '';
+  const prefix = getConfig('BRANCH_PREFIX') || '';
+  validate(name, { regex, prefix });
+  process.stdout.write(`${name}\n`);
+  process.exit(0);
+}
+
+main();

--- a/plugins/work/scripts/workflows/work/scripts/bootstrap-branch.js
+++ b/plugins/work/scripts/workflows/work/scripts/bootstrap-branch.js
@@ -118,7 +118,7 @@ function buildPrefixSuggestion({ name, userRegex, regex, prefix }) {
   return '';
 }
 
-function validate(name, { regex, prefix }) {
+function validate(name, { regex, prefix, isLinearVerbatim }) {
   // 1. Unconditional safety regex (shell metachars / `..` / whitespace).
   if (!SAFETY_REGEX.test(name) || name.includes('..')) {
     fail(`resolved name '${name}' contains disallowed characters (shell metacharacters or '..')`);
@@ -140,7 +140,13 @@ function validate(name, { regex, prefix }) {
       return;
     }
     if (!matches) {
-      const suggestion = buildPrefixSuggestion({ name, userRegex, regex, prefix });
+      // Skip the BRANCH_PREFIX suggestion when the name is Linear's verbatim
+      // `gitBranchName` — changing BRANCH_PREFIX has no effect on that path,
+      // so the hint would mislead operators per the regex-vs-Linear conflict
+      // documented in SKILL.md.
+      const suggestion = isLinearVerbatim
+        ? ''
+        : buildPrefixSuggestion({ name, userRegex, regex, prefix });
       fail(`resolved name '${name}' does not match BRANCH_NAME_REGEX ${regex}${suggestion}`);
     }
   }
@@ -162,7 +168,8 @@ function main() {
   const name = resolveBranchName(args);
   const regex = getConfig('BRANCH_NAME_REGEX') || '';
   const prefix = getConfig('BRANCH_PREFIX') || '';
-  validate(name, { regex, prefix });
+  const isLinearVerbatim = Boolean(args.gitBranchName) && providerIsLinear;
+  validate(name, { regex, prefix, isLinearVerbatim });
   process.stdout.write(`${name}\n`);
   process.exit(0);
 }

--- a/plugins/work/scripts/workflows/work/scripts/bootstrap-branch.js
+++ b/plugins/work/scripts/workflows/work/scripts/bootstrap-branch.js
@@ -24,6 +24,7 @@
 'use strict';
 
 const getConfig = require('../../lib/get-config');
+const { loadEnvrcFromDirs } = require('./bootstrap-custom-script');
 
 function parseArgs(argv) {
   const out = { ticketId: null, summary: null, gitBranchName: null };
@@ -150,6 +151,9 @@ function main() {
   if (!args.ticketId) {
     fail('missing required flag --ticket-id');
   }
+  // Mirror bootstrap-custom-script: source .envrc when direnv is not active so
+  // TICKET_PROVIDER / BRANCH_PREFIX / BRANCH_NAME_REGEX are honored under bare shells.
+  loadEnvrcFromDirs([process.cwd(), require('path').dirname(process.cwd())]);
   // --summary is only required when there is no Linear verbatim path.
   const providerIsLinear = (getConfig('TICKET_PROVIDER') || '').toLowerCase() === 'linear';
   if (!args.summary && !(args.gitBranchName && providerIsLinear)) {

--- a/plugins/work/skills/bootstrap/SKILL.md
+++ b/plugins/work/skills/bootstrap/SKILL.md
@@ -43,7 +43,17 @@ Extract:
 - Description (for PR body)
 - Status (verify it's not already Done)
 
-### Step 4: Create branch and worktree
+### Step 4: Resolve + validate branch name, then create worktree
+
+Branch naming is delegated to `bootstrap-branch.js`, which:
+
+1. Uses Linear's `gitBranchName` field **verbatim** when present (provider is Linear).
+2. Otherwise constructs `<BRANCH_PREFIX><TICKET-ID>-<kebab-summary>` (ticket ID lowercased).
+3. Validates the resolved name against `BRANCH_NAME_REGEX` (if set) plus a hard-coded
+   safety class `^[A-Za-z0-9._\-/]+$` — exits non-zero on mismatch.
+
+The skill MUST capture stdout into `BRANCH_NAME` and **abort on non-zero exit** so no
+`git worktree add` runs with an invalid name.
 
 ```bash
 $REPO_NAME="look your current directory, then look if there are worktrees (folders in a directory above with same prefix). Eg: worktrees/my-repository-ticket-A, worktrees/my-repository-ticket-B, worktrees/my-repository << this is the main directory"
@@ -55,15 +65,50 @@ BASE_BRANCH="${BASE_BRANCH#refs/remotes/origin/}"
 BASE_BRANCH="${BASE_BRANCH#origin/}"
 git fetch origin "$BASE_BRANCH"
 
-# Generate branch name from ticket
+# Inputs derived from Step 3 ticket fetch
 TICKET_ID="PROJ-XXX"
-SHORT_DESC="short-description-kebab-case"  # Derived from summary
-BRANCH_NAME="${TICKET_ID}-${SHORT_DESC}"
+SUMMARY="Fix the foo bar"                # Ticket summary (used only in fallback path)
+GIT_BRANCH_NAME=""                       # Linear gitBranchName field, "" if absent
+
+# Resolve + validate the branch name via the helper.
+# Stdout = the resolved name; non-zero exit = validation failed → abort the skill.
+if [ -n "$GIT_BRANCH_NAME" ]; then
+  BRANCH_NAME=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work/scripts/bootstrap-branch.js" \
+    --ticket-id "$TICKET_ID" \
+    --summary "$SUMMARY" \
+    --git-branch-name "$GIT_BRANCH_NAME") || {
+      echo "❌ $TICKET_ID: bootstrap-branch.js exited non-zero (validation failed); aborting — no worktree created." >&2
+      exit 1
+    }
+else
+  BRANCH_NAME=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work/scripts/bootstrap-branch.js" \
+    --ticket-id "$TICKET_ID" \
+    --summary "$SUMMARY") || {
+      echo "❌ $TICKET_ID: bootstrap-branch.js exited non-zero (validation failed); aborting — no worktree created." >&2
+      exit 1
+    }
+fi
+
 WORKTREE_PATH="../{$REPO_NAME}-${TICKET_ID}"
 
-# Create worktree
+# Only reached when the helper exited 0 → name is safe to feed to git.
 git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" "origin/$BASE_BRANCH"
 ```
+
+#### Branch-naming environment variables
+
+| Var | Default | Effect |
+|---|---|---|
+| `BRANCH_PREFIX` | _empty_ | Prepended to the fallback name, e.g. `feature/`. Empty = backward-compatible (`<TICKET-ID>-<kebab>`). |
+| `BRANCH_NAME_REGEX` | _unset_ | If set, the resolved branch name must match this regex or the helper exits 1. Unset = validation skipped. Example: `^(?:(fix|feature|hotfix|release|refactor|chore|revert|vendorkit|main|dev).+|revert-pr-\d+)$`. |
+
+#### Linear `gitBranchName` precedence
+
+When `TICKET_PROVIDER=linear` and the fetched issue carries a non-empty `gitBranchName`,
+the helper uses that value **verbatim** (no kebab transformation, no prefix prepending).
+`BRANCH_NAME_REGEX` still applies — **regex wins on conflict**: if Linear's
+`gitBranchName` fails the configured regex, the helper aborts with both the offending
+name and the regex in stderr, and no worktree is created.
 
 ### Step 5: Run custom bootstrap script (if configured)
 

--- a/plugins/work/skills/bootstrap/SKILL.md
+++ b/plugins/work/skills/bootstrap/SKILL.md
@@ -42,6 +42,7 @@ Extract:
 - Summary (for branch name)
 - Description (for PR body)
 - Status (verify it's not already Done)
+- `gitBranchName` (Linear only — passed verbatim to `bootstrap-branch.js` in Step 4 via `--git-branch-name`; empty string when the field is absent or the provider is not Linear)
 
 ### Step 4: Resolve + validate branch name, then create worktree
 

--- a/plugins/work/skills/bootstrap/SKILL.test.js
+++ b/plugins/work/skills/bootstrap/SKILL.test.js
@@ -1,0 +1,36 @@
+// Task 3 RED tests — colocated with SKILL.md so task-next.js discovers them
+// via findTestFilesInScope colocated-sibling rule (basename SKILL + .test.js).
+// These tests assert that SKILL.md wires in bootstrap-branch.js correctly.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const SKILL_MD = path.join(__dirname, "SKILL.md");
+
+describe("bootstrap SKILL.md — Task 3 wiring", () => {
+  describe("SKILL.md invokes the helper and aborts the skill on non-zero exit", () => {
+    it("Step 4 invokes bootstrap-branch.js, captures stdout into BRANCH_NAME, and aborts on non-zero exit", () => {
+      const md = fs.readFileSync(SKILL_MD, "utf8");
+      assert.match(md, /bootstrap-branch\.js/, "SKILL.md must reference bootstrap-branch.js");
+      assert.match(md, /BRANCH_NAME=/, "SKILL.md must capture stdout into BRANCH_NAME");
+      assert.match(
+        md,
+        /(abort|exit\s+(?:non-zero|1)|\$\?\s*!=\s*0|exit\s+\$\?)/i,
+        "SKILL.md must abort on non-zero helper exit",
+      );
+    });
+  });
+
+  describe("SKILL.md does not create a worktree when validation fails", () => {
+    it("git worktree add is gated behind helper exit-0 and uses validated BRANCH_NAME", () => {
+      const md = fs.readFileSync(SKILL_MD, "utf8");
+      assert.match(md, /git worktree add/, "SKILL.md must contain git worktree add");
+      assert.match(md, /\$BRANCH_NAME/, "git worktree add must use $BRANCH_NAME");
+      assert.match(md, /BRANCH_NAME_REGEX/, "SKILL.md must document BRANCH_NAME_REGEX");
+      assert.match(md, /BRANCH_PREFIX/, "SKILL.md must document BRANCH_PREFIX");
+      assert.match(md, /gitBranchName/, "SKILL.md must document Linear gitBranchName precedence");
+    });
+  });
+});


### PR DESCRIPTION
## Existing Behavior

- The bootstrap skill (Step 4) generated branch names inline using a hardcoded `<TICKET-ID>-<short-description>` pattern with no validation.
- No support for Linear's `gitBranchName` field — provider-specific branch names were ignored.
- No configurable regex gate; any string, including shell-unsafe characters, could be passed to `git worktree add`.
- `BRANCH_PREFIX` was not documented or honored in the branch name composition path.

## Intended New Behavior

- A dedicated `bootstrap-branch.js` helper resolves the branch name before any `git worktree add` runs.
- When `TICKET_PROVIDER=linear` and `--git-branch-name` is supplied, that value is used verbatim (Linear precedence).
- Fallback composition produces `<BRANCH_PREFIX><ticket-id-lowercased>-<kebab-summary>`; `BRANCH_PREFIX` defaults to empty for backward compatibility.
- All resolved names are validated against an unconditional safety regex (`^[A-Za-z0-9._\-/]+$`) and, optionally, against a user-configured `BRANCH_NAME_REGEX`; the helper exits non-zero before `git worktree add` on any mismatch — "regex wins" even over Linear's `gitBranchName`.
- When a name fails `BRANCH_NAME_REGEX` but prepending a plausible prefix would make it pass, stderr includes a `BRANCH_PREFIX=…` suggestion.
- SKILL.md Step 4 is rewritten to capture `bootstrap-branch.js` stdout into `BRANCH_NAME` and abort the skill on non-zero exit; `BRANCH_PREFIX`, `BRANCH_NAME_REGEX`, and Linear precedence semantics are documented in a new env-var table.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify Linear `gitBranchName` verbatim path:**

1. Set `TICKET_PROVIDER=linear` in `.envrc`.
2. Run bootstrap skill against a Linear ticket that has a `gitBranchName` field set (e.g. `feature/echo-4454-foo`).
3. Confirm the worktree is created on a branch named exactly `feature/echo-4454-foo` — no kebab transformation, no prefix prepended.

**Verify fallback composition with `BRANCH_PREFIX`:**

1. Unset `TICKET_PROVIDER` (or set to a non-`linear` value).
2. Set `BRANCH_PREFIX=feature/` in `.envrc`.
3. Run bootstrap for ticket `ECHO-4454` with summary `Fix Foo Bar`.
4. Confirm worktree branch is `feature/echo-4454-fix-foo-bar`.

**Verify `BRANCH_NAME_REGEX` gate:**

1. Set `BRANCH_NAME_REGEX=^(feature|fix)/.+$` in `.envrc`.
2. Run bootstrap for a ticket without `BRANCH_PREFIX` set.
3. Confirm the skill aborts with a non-zero exit before creating any worktree, stderr includes the offending name and the regex, and a `BRANCH_PREFIX=feature/` suggestion is shown.

**Direct helper test:**

```bash
cd plugins/work/scripts/workflows/work/scripts

node bootstrap-branch.js --ticket-id ECHO-4454 --summary "Fix foo bar"
# expected stdout: echo-4454-fix-foo-bar  exit 0

BRANCH_NAME_REGEX='^(feature|fix)/.+$' node bootstrap-branch.js --ticket-id ECHO-4454 --summary "Fix foo bar"
# expected: exit 1, stderr contains name + regex + BRANCH_PREFIX suggestion

TICKET_PROVIDER=linear node bootstrap-branch.js --ticket-id ECHO-4454 --summary "Fix foo bar" --git-branch-name "feature/echo-4454-foo"
# expected stdout: feature/echo-4454-foo  exit 0

TICKET_PROVIDER=linear node bootstrap-branch.js --ticket-id ECHO-4454 --summary "Fix foo bar" --git-branch-name "feature/bad;name"
# expected: exit 1 (shell metachar blocked by safety regex)
```

### Test Results

9 integration tests, all passing — `bootstrap-branch.integration.test.js` and `SKILL.test.js`.

Closes #399

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and CLI helper changes with fail-fast validation and tests; empty `BRANCH_PREFIX` preserves prior naming, though strict `BRANCH_NAME_REGEX` can block bootstrap until configured.
> 
> **Overview**
> Bootstrap worktree creation no longer builds branch names inline in **SKILL.md** Step 4. A new **`bootstrap-branch.js`** helper resolves the name on stdout and must exit 0 before **`git worktree add`** runs.
> 
> **Resolution:** With `TICKET_PROVIDER=linear` and `--git-branch-name`, Linear’s name is used verbatim. Otherwise the helper builds `<BRANCH_PREFIX><ticket-id-lowercased>-<kebab-summary>` (empty prefix keeps the old `<TICKET-ID>-<kebab>` shape).
> 
> **Validation:** Names always pass a safety allowlist (blocks shell metacharacters and `..`). Optional **`BRANCH_NAME_REGEX`** can reject names before any worktree; configured regex wins over Linear’s name. On fallback-path regex failures, stderr may suggest **`BRANCH_PREFIX`**. Step 3 documents passing Linear **`gitBranchName`**; Step 4 captures helper stdout into **`BRANCH_NAME`** and aborts on failure.
> 
> Coverage: subprocess integration tests for the helper and **`SKILL.test.js`** checks that **`SKILL.md`** documents the wiring and env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57c49e0764f7b35a24c7469958f6c71df6d95ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->