### PR TITLE
Gh 512 (synapsys)

### DIFF
--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -190,6 +190,70 @@ node plugins/synapsys/scripts/synapsys-staleness-check.js || {
 
 Passing `--re-consolidate` dispatches the owning profile for each drifted source by spawning the sibling consolidate script with `--profile=<name>`. Profile ownership is resolved by intersecting each profile module's declared source paths against the drifted source. Orphan sources (whose source file no longer exists) are skipped — they require human judgement. Ambiguous sources (claimed by multiple profiles) emit a warning and are skipped. Profile lookup requires the `consolidate-profiles/` directory, which is delivered by GH-442; until it lands, `--re-consolidate` will warn that no profile owns the source and exit non-zero.
 
+## Telemetry
+
+Synapsys records two kinds of events per session so you can measure which memories actually matter:
+
+- `fired` — a memory matched and was injected into the context.
+- `cited` — on the `Stop` event, the assistant's response mentions a previously-fired memory's signals (declared `cite_signals` or auto-extracted from the body).
+
+### On-disk lifecycle
+
+Per-session JSONL files live under:
+
+```
+~/.claude/synapsys/.telemetry/<session_id>.jsonl
+```
+
+On first write the directory is created and a sibling `.gitignore` is seeded with `*` so the telemetry stays local. Missing `session_id` payloads route to `_unknown-session.jsonl` and the `reason` field carries a `${pid}-${startMs}` token so multi-process noise can be untangled.
+
+All telemetry writes are wrapped in an inner `try/catch` and never crash the dispatcher — synapsys is fail-open by design.
+
+### `cite_signals` frontmatter
+
+Add `cite_signals` to a memory's frontmatter to declare the exact strings the cite scanner should look for in the assistant's response. When present, it overrides the auto-extraction (single-backticked identifiers, first H2/H3 heading body text, memory name).
+
+```yaml
+---
+name: ui-use-Button-not-raw-button
+description: Block raw <button> in .tsx; require the Button component.
+events: PreToolUse,Stop
+trigger_pretool: Edit:.*\.tsx,Write:.*\.tsx
+inject: full
+cite_signals: Button, packages/ui, @app-services-monitoring/ui
+---
+```
+
+Without `cite_signals`, synapsys auto-extracts signal candidates from the body: backticked identifiers (≥ 2 chars), the first H2/H3 heading text (≥ 4 chars, skipping code fences), and the memory `name`. Matching is `String.prototype.includes()` (not regex) and each memory can cite at most once per response; the captured `match` field is capped at 200 characters for privacy.
+
+### Opt-outs
+
+Two independent ways to suppress telemetry:
+
+| Mechanism | Scope | Example |
+|---|---|---|
+| Per-memory frontmatter `telemetry: false` | One memory only — `fired`/`cited` writes skipped for that file | `telemetry: false` in the YAML block |
+| Env var `SYNAPSYS_TELEMETRY=0` | Process-wide — all writes suppressed | `SYNAPSYS_TELEMETRY=0 claude ...` |
+
+Absent `telemetry` defaults to enabled. Either flag suppresses both `fired` and `cited` for the affected scope; matched memories still inject normally.
+
+### `synapsys:stats` — aggregating the JSONL
+
+Run the `/synapsys:stats` skill (or invoke the script directly) to summarize what your memories actually did over a time window:
+
+```bash
+node plugins/synapsys/scripts/synapsys-stats.js --last 7d
+node plugins/synapsys/scripts/synapsys-stats.js --last 30d --no-color
+```
+
+The output has three sections:
+
+- **Top influencers** — memories sorted by `cited` desc (tiebreak `fired × cited` desc). These earn their slot.
+- **Noise candidates** — memories with `fired >= 10 AND cited == 0`. Strong signal the trigger is too loose; tune `trigger_prompt`/`trigger_pretool` or add `cite_signals` so citations register.
+- **Never-fired** — memories present in active stores with zero `fired` events in the window. Either obsolete or simply not triggered yet.
+
+The `--last <Nd>` flag filters telemetry `.jsonl` files by `mtime`; default is `7d`. `--cwd` overrides discovery. Exit code is always `0` — read errors emit a stderr note but never fail the command.
+
 ## Design choices
 
 - **Fail-open** — any error in the dispatcher exits 0 with no output. Memory injection must never block a user prompt or tool call.

--- a/plugins/synapsys/hooks/synapsys.js
+++ b/plugins/synapsys/hooks/synapsys.js
@@ -116,70 +116,95 @@ function readFiredMemoryNames(sessionId) {
   return out;
 }
 
-function extractResponseText(payload) {
-  if (payload && typeof payload.response === 'string') return payload.response;
-  if (payload && typeof payload.transcript_path === 'string') {
-    try {
-      const raw = fs.readFileSync(payload.transcript_path, 'utf8');
-      // Take last assistant block — best-effort, JSONL format common in Claude.
-      const lines = raw.split('\n').filter((l) => l.length > 0);
-      for (let i = lines.length - 1; i >= 0; i--) {
-        try {
-          const obj = JSON.parse(lines[i]);
-          if (obj && obj.role === 'assistant' && typeof obj.content === 'string') {
-            return obj.content;
-          }
-        } catch {
-          // skip
-        }
-      }
-    } catch {
-      // fail-open
-    }
+// Coerce one transcript JSONL row into assistant text. Supports both:
+//   - Claude Code: `{type: 'assistant', message: {content: [{type: 'text', text}]}}`
+//   - Legacy:     `{role: 'assistant', content: '<string>'}`
+// Returns '' for any other shape so the caller can keep scanning.
+function transcriptRowToText(obj) {
+  if (!obj) return '';
+  if (obj.role === 'assistant' && typeof obj.content === 'string') return obj.content;
+  const isAssistantMsg = obj.type === 'assistant' || obj.role === 'assistant';
+  if (!isAssistantMsg) return '';
+  const content = obj.message && obj.message.content;
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+      .map((b) => b.text)
+      .join('\n');
   }
   return '';
 }
 
+function extractFromTranscript(transcriptPath) {
+  try {
+    const raw = fs.readFileSync(transcriptPath, 'utf8');
+    const lines = raw.split('\n').filter((l) => l.length > 0);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const text = transcriptRowToText(JSON.parse(lines[i]));
+        if (text) return text;
+      } catch {
+        // skip malformed line
+      }
+    }
+  } catch {
+    // fail-open
+  }
+  return '';
+}
+
+function extractResponseText(payload) {
+  if (!payload) return '';
+  if (typeof payload.response === 'string') return payload.response;
+  if (typeof payload.transcript_path === 'string') return extractFromTranscript(payload.transcript_path);
+  return '';
+}
+
+// Parse a YAML block-list under `cite_signals:` from raw frontmatter text.
+// Returns [] when no list is present.
+function parseCiteSignalsList(frontmatterText) {
+  const lines = frontmatterText.split(/\r?\n/);
+  const found = [];
+  let inList = false;
+  for (const line of lines) {
+    if (/^cite_signals\s*:\s*$/.test(line)) {
+      inList = true;
+      continue;
+    }
+    if (!inList) continue;
+    const item = line.match(/^\s+-\s+(.+?)\s*$/);
+    if (item) {
+      found.push(item[1].replace(/^["']|["']$/g, ''));
+      continue;
+    }
+    // End of list on next top-level key or blank line.
+    if (line.trim() === '' || /^[a-zA-Z_][\w]*\s*:/.test(line)) inList = false;
+  }
+  return found;
+}
+
 // Re-parse `cite_signals` from a memory's raw file to recover YAML-list
 // frontmatter the simple memory-store parser drops (it only handles
-// inline `key: value` lines). Fail-open: returns the memory unchanged on
-// any error or when nothing extra is found.
+// inline `key: value` lines). Fail-open.
 function recoverCiteSignals(memory) {
   try {
     if (!memory || !memory.file) return memory;
+    const meta = memory.meta;
     const existing =
-      memory.meta && Array.isArray(memory.meta.cite_signals)
-        ? memory.meta.cite_signals.filter((s) => typeof s === 'string' && s.length > 0)
+      meta && Array.isArray(meta.cite_signals)
+        ? meta.cite_signals.filter((s) => typeof s === 'string' && s.length > 0)
         : [];
     if (existing.length > 0) return memory;
     const raw = fs.readFileSync(memory.file, 'utf8');
     const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (!fm) return memory;
-    const lines = fm[1].split(/\r?\n/);
-    const found = [];
-    let inList = false;
-    for (const line of lines) {
-      if (/^cite_signals\s*:\s*$/.test(line)) {
-        inList = true;
-        continue;
-      }
-      if (inList) {
-        const item = line.match(/^\s+-\s+(.+?)\s*$/);
-        if (item) {
-          found.push(item[1].replace(/^["']|["']$/g, ''));
-          continue;
-        }
-        // End of list when we hit any other key or blank
-        if (line.trim() === '' || /^[a-zA-Z_][\w]*\s*:/.test(line)) {
-          inList = false;
-        }
-      }
-    }
+    const found = parseCiteSignalsList(fm[1]);
     if (!found.length) return memory;
     return {
       ...memory,
       citeSignals: found.slice(),
-      meta: { ...(memory.meta || {}), cite_signals: found.slice() },
+      meta: { ...(meta || {}), cite_signals: found.slice() },
     };
   } catch {
     return memory;
@@ -221,6 +246,18 @@ function formatMatchedOutput(matched) {
   return `${out.slice(0, MAX_INJECT_CHARS)}\n\n[synapsys: output truncated at ${MAX_INJECT_CHARS} chars]`;
 }
 
+function emitMatched(matched, payload, event) {
+  if (!matched.length) return;
+  for (const m of matched) {
+    try {
+      recordFired(m, payload, event);
+    } catch {
+      // fail-open
+    }
+  }
+  process.stdout.write(formatMatchedOutput(matched));
+}
+
 (async () => {
   try {
     const event = process.argv[2];
@@ -237,23 +274,8 @@ function formatMatchedOutput(matched) {
       process.exit(0);
     }
 
-    if (!memories.length) {
-      if (event === 'Stop') runCiteScan(payload, memories);
-      process.exit(0);
-    }
-    const matched = selectForEvent(memories, event, payload);
-
-    if (matched.length) {
-      for (const m of matched) {
-        try {
-          recordFired(m, payload, event);
-        } catch {
-          // fail-open
-        }
-      }
-      process.stdout.write(formatMatchedOutput(matched));
-    }
-
+    const matched = memories.length ? selectForEvent(memories, event, payload) : [];
+    emitMatched(matched, payload, event);
     if (event === 'Stop') runCiteScan(payload, memories);
 
     process.exit(0);

--- a/plugins/synapsys/hooks/synapsys.js
+++ b/plugins/synapsys/hooks/synapsys.js
@@ -215,6 +215,20 @@ function recoverCiteSignals(memory) {
   }
 }
 
+// Dedupe scanForCitations hits per memory and emit recordCited; fail-open.
+function emitCitations(hits, payload) {
+  const seen = new Set();
+  for (const hit of hits) {
+    if (!hit || !hit.memory || seen.has(hit.memory.name)) continue;
+    seen.add(hit.memory.name);
+    try {
+      recordCited(hit.memory, payload, hit.match);
+    } catch {
+      // fail-open
+    }
+  }
+}
+
 // Stop-only: scan response text for citations of any previously-fired memory.
 // Dedupes via Set so each memory is recorded at most once per Stop.
 function runCiteScan(payload, memories) {
@@ -235,17 +249,7 @@ function runCiteScan(payload, memories) {
       .filter((m) => m && firedNames.has(m.name))
       .map(recoverCiteSignals);
     if (!candidates.length) return;
-    const hits = scanForCitations(candidates, responseText);
-    const seen = new Set();
-    for (const hit of hits) {
-      if (!hit || !hit.memory || seen.has(hit.memory.name)) continue;
-      seen.add(hit.memory.name);
-      try {
-        recordCited(hit.memory, payload, hit.match);
-      } catch {
-        // fail-open
-      }
-    }
+    emitCitations(scanForCitations(candidates, responseText), payload);
   } catch {
     // fail-open
   }

--- a/plugins/synapsys/hooks/synapsys.js
+++ b/plugins/synapsys/hooks/synapsys.js
@@ -156,7 +156,11 @@ function extractFromTranscript(transcriptPath) {
 
 function extractResponseText(payload) {
   if (!payload) return '';
-  if (typeof payload.response === 'string') return payload.response;
+  // Prefer payload.response only when it's non-empty; an empty string here
+  // would otherwise mask a transcript_path with the real assistant output.
+  if (typeof payload.response === 'string' && payload.response.length > 0) {
+    return payload.response;
+  }
   if (typeof payload.transcript_path === 'string') return extractFromTranscript(payload.transcript_path);
   return '';
 }

--- a/plugins/synapsys/hooks/synapsys.js
+++ b/plugins/synapsys/hooks/synapsys.js
@@ -222,6 +222,13 @@ function runCiteScan(payload, memories) {
     const responseText = extractResponseText(payload);
     if (!responseText) return;
     const sessionId = resolveSessionId(payload);
+    // _unknown-session.jsonl pools writes from every anonymous process across
+    // its lifetime, so a Stop here cannot prove a fired memory was actually
+    // injected in *this* logical session. The dispatcher runs as a fresh
+    // process per event, so pid-based filtering can't link Stop to the
+    // earlier fired-process either. Skip the cite scan rather than risk
+    // emitting cross-session false-positive `cited` events.
+    if (sessionId === '_unknown-session') return;
     const firedNames = readFiredMemoryNames(sessionId);
     if (firedNames.size === 0) return;
     const candidates = memories

--- a/plugins/synapsys/hooks/synapsys.js
+++ b/plugins/synapsys/hooks/synapsys.js
@@ -182,8 +182,10 @@ function parseCiteSignalsList(frontmatterText) {
       found.push(item[1].replace(/^["']|["']$/g, ''));
       continue;
     }
-    // End of list on next top-level key or blank line.
-    if (line.trim() === '' || /^[a-zA-Z_][\w]*\s*:/.test(line)) inList = false;
+    // Skip blank lines — common YAML formatting puts one between the key
+    // and its `- items`. End the list only when a new top-level key appears.
+    if (line.trim() === '') continue;
+    if (/^[a-zA-Z_][\w]*\s*:/.test(line)) inList = false;
   }
   return found;
 }

--- a/plugins/synapsys/hooks/synapsys.js
+++ b/plugins/synapsys/hooks/synapsys.js
@@ -292,8 +292,13 @@ function emitMatched(matched, payload, event) {
     }
 
     const matched = memories.length ? selectForEvent(memories, event, payload) : [];
-    emitMatched(matched, payload, event);
+    // On Stop the cite scan must read the session JSONL state from BEFORE
+    // this turn's Stop-time fired writes; Stop-injections happen after the
+    // assistant response, so attributing citations to them would be a
+    // false positive (the response cannot reference a memory that wasn't
+    // yet injected at the time it was written).
     if (event === 'Stop') runCiteScan(payload, memories);
+    emitMatched(matched, payload, event);
 
     process.exit(0);
   } catch {

--- a/plugins/synapsys/hooks/synapsys.js
+++ b/plugins/synapsys/hooks/synapsys.js
@@ -15,11 +15,19 @@
  * never block the user's prompt or tool call.
  */
 
+const fs = require('node:fs');
 const path = require('node:path');
 const { discoverStores, listMemoriesFromStore } = require(
   path.join(__dirname, '..', 'lib', 'memory-store')
 );
 const { selectForEvent } = require(path.join(__dirname, '..', 'lib', 'matcher'));
+const {
+  recordFired,
+  recordCited,
+  scanForCitations,
+  resolveSessionId,
+  telemetryDir,
+} = require(path.join(__dirname, '..', 'lib', 'telemetry'));
 
 const VALID_EVENTS = new Set(['SessionStart', 'UserPromptSubmit', 'PreToolUse', 'Stop']);
 const MAX_INJECT_CHARS = 8000;
@@ -83,6 +91,130 @@ function getSessionStartHint(event, stores, memories) {
   return null;
 }
 
+// Read names of memories with event:"fired" from the session JSONL.
+// Fail-open: any error returns an empty Set.
+function readFiredMemoryNames(sessionId) {
+  const out = new Set();
+  try {
+    const file = path.join(telemetryDir(), `${sessionId}.jsonl`);
+    if (!fs.existsSync(file)) return out;
+    const raw = fs.readFileSync(file, 'utf8');
+    for (const line of raw.split('\n')) {
+      if (!line) continue;
+      try {
+        const obj = JSON.parse(line);
+        if (obj && obj.event === 'fired' && typeof obj.memory === 'string') {
+          out.add(obj.memory);
+        }
+      } catch {
+        // skip malformed line
+      }
+    }
+  } catch {
+    // fail-open
+  }
+  return out;
+}
+
+function extractResponseText(payload) {
+  if (payload && typeof payload.response === 'string') return payload.response;
+  if (payload && typeof payload.transcript_path === 'string') {
+    try {
+      const raw = fs.readFileSync(payload.transcript_path, 'utf8');
+      // Take last assistant block — best-effort, JSONL format common in Claude.
+      const lines = raw.split('\n').filter((l) => l.length > 0);
+      for (let i = lines.length - 1; i >= 0; i--) {
+        try {
+          const obj = JSON.parse(lines[i]);
+          if (obj && obj.role === 'assistant' && typeof obj.content === 'string') {
+            return obj.content;
+          }
+        } catch {
+          // skip
+        }
+      }
+    } catch {
+      // fail-open
+    }
+  }
+  return '';
+}
+
+// Re-parse `cite_signals` from a memory's raw file to recover YAML-list
+// frontmatter the simple memory-store parser drops (it only handles
+// inline `key: value` lines). Fail-open: returns the memory unchanged on
+// any error or when nothing extra is found.
+function recoverCiteSignals(memory) {
+  try {
+    if (!memory || !memory.file) return memory;
+    const existing =
+      memory.meta && Array.isArray(memory.meta.cite_signals)
+        ? memory.meta.cite_signals.filter((s) => typeof s === 'string' && s.length > 0)
+        : [];
+    if (existing.length > 0) return memory;
+    const raw = fs.readFileSync(memory.file, 'utf8');
+    const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!fm) return memory;
+    const lines = fm[1].split(/\r?\n/);
+    const found = [];
+    let inList = false;
+    for (const line of lines) {
+      if (/^cite_signals\s*:\s*$/.test(line)) {
+        inList = true;
+        continue;
+      }
+      if (inList) {
+        const item = line.match(/^\s+-\s+(.+?)\s*$/);
+        if (item) {
+          found.push(item[1].replace(/^["']|["']$/g, ''));
+          continue;
+        }
+        // End of list when we hit any other key or blank
+        if (line.trim() === '' || /^[a-zA-Z_][\w]*\s*:/.test(line)) {
+          inList = false;
+        }
+      }
+    }
+    if (!found.length) return memory;
+    return {
+      ...memory,
+      citeSignals: found.slice(),
+      meta: { ...(memory.meta || {}), cite_signals: found.slice() },
+    };
+  } catch {
+    return memory;
+  }
+}
+
+// Stop-only: scan response text for citations of any previously-fired memory.
+// Dedupes via Set so each memory is recorded at most once per Stop.
+function runCiteScan(payload, memories) {
+  try {
+    const responseText = extractResponseText(payload);
+    if (!responseText) return;
+    const sessionId = resolveSessionId(payload);
+    const firedNames = readFiredMemoryNames(sessionId);
+    if (firedNames.size === 0) return;
+    const candidates = memories
+      .filter((m) => m && firedNames.has(m.name))
+      .map(recoverCiteSignals);
+    if (!candidates.length) return;
+    const hits = scanForCitations(candidates, responseText);
+    const seen = new Set();
+    for (const hit of hits) {
+      if (!hit || !hit.memory || seen.has(hit.memory.name)) continue;
+      seen.add(hit.memory.name);
+      try {
+        recordCited(hit.memory, payload, hit.match);
+      } catch {
+        // fail-open
+      }
+    }
+  } catch {
+    // fail-open
+  }
+}
+
 function formatMatchedOutput(matched) {
   const out = matched.map(formatMemory).join('\n\n---\n\n');
   if (out.length <= MAX_INJECT_CHARS) return out;
@@ -105,11 +237,25 @@ function formatMatchedOutput(matched) {
       process.exit(0);
     }
 
-    if (!memories.length) process.exit(0);
+    if (!memories.length) {
+      if (event === 'Stop') runCiteScan(payload, memories);
+      process.exit(0);
+    }
     const matched = selectForEvent(memories, event, payload);
-    if (!matched.length) process.exit(0);
 
-    process.stdout.write(formatMatchedOutput(matched));
+    if (matched.length) {
+      for (const m of matched) {
+        try {
+          recordFired(m, payload, event);
+        } catch {
+          // fail-open
+        }
+      }
+      process.stdout.write(formatMatchedOutput(matched));
+    }
+
+    if (event === 'Stop') runCiteScan(payload, memories);
+
     process.exit(0);
   } catch {
     process.exit(0);

--- a/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
@@ -484,3 +484,45 @@ test('Cited event fires when Stop reads from transcript_path with Claude Code fo
   const cited = rows.filter((r) => r.event === 'cited' && r.memory === 'tx-memory');
   assert.equal(cited.length, 1, `expected 1 cited row for tx-memory, got ${cited.length}. rows: ${JSON.stringify(rows)}`);
 });
+
+// PR #524 cursor[bot] Medium — empty payload.response must not short-circuit transcript_path
+test('Empty payload.response falls through to transcript_path scan', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'fallback-memory', {
+    description: 'x',
+    events: '[UserPromptSubmit, Stop]',
+    triggerPrompt: 'fallback-trigger',
+    body: 'fallback-memory body',
+  });
+
+  const sessionId = 'fallback-session-1';
+  const firedRes = runDispatcher(
+    'UserPromptSubmit',
+    { cwd: fx.cwd, session_id: sessionId, prompt: 'mentions fallback-trigger here' },
+    { home }
+  );
+  assert.equal(firedRes.status, 0);
+
+  const transcript = path.join(home, 'transcript.jsonl');
+  fs.writeFileSync(
+    transcript,
+    JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'I use fallback-memory now.' }] },
+    }) + '\n'
+  );
+
+  const stopRes = runDispatcher(
+    'Stop',
+    { cwd: fx.cwd, session_id: sessionId, response: '', transcript_path: transcript },
+    { home }
+  );
+  assert.equal(stopRes.status, 0);
+
+  const jsonl = path.join(telemetryDirFor(home), `${sessionId}.jsonl`);
+  const cited = readJsonl(jsonl).filter((r) => r.event === 'cited' && r.memory === 'fallback-memory');
+  assert.equal(cited.length, 1, `expected 1 cited row when response='' and transcript_path is set`);
+});

--- a/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
@@ -440,3 +440,47 @@ test('Missing session_id falls back to _unknown-session.jsonl', (t) => {
   const firedRows = rows.filter((r) => r.event === 'fired' && r.memory === 'mem-unknown');
   assert.ok(firedRows.length >= 1, 'fired row must be recorded in _unknown-session.jsonl');
 });
+
+// PR #524 cursor[bot] High — extractResponseText must read Claude Code transcript format
+// (type: 'assistant', message.content as text blocks), not just the legacy
+// role: 'assistant' with string content.
+test('Cited event fires when Stop reads from transcript_path with Claude Code format', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'tx-memory', {
+    description: 'x',
+    events: '[UserPromptSubmit, Stop]',
+    triggerPrompt: 'tx-trigger',
+    body: 'tx-memory body',
+  });
+
+  const sessionId = 'tx-session-1';
+  const firedRes = runDispatcher(
+    'UserPromptSubmit',
+    { cwd: fx.cwd, session_id: sessionId, prompt: 'mentions tx-trigger here' },
+    { home }
+  );
+  assert.equal(firedRes.status, 0, `fired exit: ${firedRes.stderr}`);
+
+  // Build a Claude Code transcript: each row is `{type: 'assistant', message: {content: [...]}}`
+  const transcript = path.join(home, 'transcript.jsonl');
+  const blocks = [
+    { type: 'assistant', message: { content: [{ type: 'text', text: 'Some prelude.' }] } },
+    { type: 'assistant', message: { content: [{ type: 'text', text: 'I will use tx-memory next.' }] } },
+  ];
+  fs.writeFileSync(transcript, blocks.map((b) => JSON.stringify(b)).join('\n') + '\n');
+
+  const stopRes = runDispatcher(
+    'Stop',
+    { cwd: fx.cwd, session_id: sessionId, transcript_path: transcript },
+    { home }
+  );
+  assert.equal(stopRes.status, 0, `stop exit: ${stopRes.stderr}`);
+
+  const jsonl = path.join(telemetryDirFor(home), `${sessionId}.jsonl`);
+  const rows = readJsonl(jsonl);
+  const cited = rows.filter((r) => r.event === 'cited' && r.memory === 'tx-memory');
+  assert.equal(cited.length, 1, `expected 1 cited row for tx-memory, got ${cited.length}. rows: ${JSON.stringify(rows)}`);
+});

--- a/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
@@ -612,3 +612,45 @@ test('cite_signals YAML list survives a blank line after the key', (t) => {
   assert.equal(cited.length, 1, `expected 1 cited row using declared signal across YAML blank line, got ${cited.length}`);
   assert.equal(cited[0].match, 'declared-token-beta');
 });
+
+// PR #524 cursor[bot] Medium — Stop-time fires must not produce false cited on the same turn.
+test('Stop event: cite scan ignores memories first fired during this same Stop turn', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  // Memory that fires ONLY on Stop, with trigger_session so it injects every Stop.
+  fs.writeFileSync(
+    path.join(fx.storeDir, 'stop-injected.md'),
+    [
+      '---',
+      'name: stop-injected',
+      'description: x',
+      'events: Stop',
+      'trigger_session: true',
+      '---',
+      '',
+      'Body for stop-injected.',
+    ].join('\n')
+  );
+
+  const sessionId = 'stop-only-session';
+  // Response mentions the memory name. It would falsely register a cited
+  // event if the cite scan saw the Stop-time fired row written this turn.
+  const stopRes = runDispatcher(
+    'Stop',
+    { cwd: fx.cwd, session_id: sessionId, response: 'I mention stop-injected casually.' },
+    { home }
+  );
+  assert.equal(stopRes.status, 0);
+
+  const jsonl = path.join(telemetryDirFor(home), `${sessionId}.jsonl`);
+  const rows = fs.existsSync(jsonl) ? readJsonl(jsonl) : [];
+  // The fired row for this turn IS recorded.
+  const fired = rows.filter((r) => r.event === 'fired' && r.memory === 'stop-injected');
+  assert.equal(fired.length, 1, `expected 1 fired row this Stop turn, got ${fired.length}`);
+  // But NO cited row, because the Stop-time fired write happens after the
+  // cite scan reads session state.
+  const cited = rows.filter((r) => r.event === 'cited' && r.memory === 'stop-injected');
+  assert.equal(cited.length, 0, `Stop-time fire must not generate a same-turn cited row, got ${cited.length}`);
+});

--- a/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
@@ -526,3 +526,42 @@ test('Empty payload.response falls through to transcript_path scan', (t) => {
   const cited = readJsonl(jsonl).filter((r) => r.event === 'cited' && r.memory === 'fallback-memory');
   assert.equal(cited.length, 1, `expected 1 cited row when response='' and transcript_path is set`);
 });
+
+// PR #524 cursor[bot] Medium — unknown-session cite cross-talk
+// When session_id is missing, _unknown-session.jsonl pools fired events
+// across processes; a Stop scan in one anonymous session must not emit
+// cited events for memories fired in a different anonymous session.
+test('Stop with missing session_id does not emit cited events', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'cross-talk-memory', {
+    description: 'x',
+    events: '[UserPromptSubmit, Stop]',
+    triggerPrompt: 'cross-talk-trigger',
+    body: 'cross-talk-memory body',
+  });
+
+  // Fire under unknown session (no session_id).
+  const firedRes = runDispatcher(
+    'UserPromptSubmit',
+    { cwd: fx.cwd, prompt: 'mentions cross-talk-trigger here' },
+    { home }
+  );
+  assert.equal(firedRes.status, 0);
+
+  // Stop also under unknown session — should NOT emit cited even though
+  // the response would otherwise match.
+  const stopRes = runDispatcher(
+    'Stop',
+    { cwd: fx.cwd, response: 'I use cross-talk-memory now.' },
+    { home }
+  );
+  assert.equal(stopRes.status, 0);
+
+  const unknown = path.join(telemetryDirFor(home), '_unknown-session.jsonl');
+  const rows = fs.existsSync(unknown) ? readJsonl(unknown) : [];
+  const cited = rows.filter((r) => r.event === 'cited');
+  assert.equal(cited.length, 0, `unknown-session must not emit cited rows, got ${cited.length}: ${JSON.stringify(cited)}`);
+});

--- a/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
@@ -1,0 +1,442 @@
+'use strict';
+
+/**
+ * Dispatcher telemetry integration tests (GH-512, Task 3).
+ *
+ * These tests spawn `plugins/synapsys/hooks/synapsys.js` against a temporary
+ * memory store and a temporary HOME (so `~/.claude/synapsys/.telemetry/`
+ * resolves into the test sandbox via os.homedir()).
+ *
+ * Scenarios (matches tasks.md Task 3 + gherkin):
+ *   (a) UserPromptSubmit with matching memory writes one `fired` JSONL line
+ *       and stdout still contains the injection (AC1).
+ *   (e) SYNAPSYS_TELEMETRY=0 suppresses all writes; stdout still has injection (AC2).
+ *   (f) Per-memory `telemetry: false` skips that memory only (AC3).
+ *   (d) Telemetry write failure (mocked fs.appendFileSync EACCES) does not
+ *       break injection — dispatcher exits 0 and stdout still has injection (AC4).
+ *   (b) Cited event emitted on Stop when response mentions a fired memory name (AC6).
+ *   AC7 — cite_signals frontmatter wins over auto-extraction.
+ *   AC8 — Auto-extracted signals fire when cite_signals absent.
+ *   (g) Missing session_id routes to _unknown-session.jsonl (AC9).
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const DISPATCHER = path.resolve(__dirname, '..', '..', 'hooks', 'synapsys.js');
+
+function mktemp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeMemory(storeDir, name, opts) {
+  const lines = ['---', `name: ${name}`];
+  if (opts.description) lines.push(`description: ${opts.description}`);
+  if (opts.events) lines.push(`events: ${opts.events}`);
+  if (opts.triggerPrompt) lines.push(`trigger_prompt: ${opts.triggerPrompt}`);
+  if (opts.triggerSession !== undefined) lines.push(`trigger_session: ${opts.triggerSession}`);
+  if (opts.inject) lines.push(`inject: ${opts.inject}`);
+  if (opts.telemetry === false) lines.push('telemetry: false');
+  if (opts.citeSignals) {
+    lines.push('cite_signals:');
+    for (const s of opts.citeSignals) lines.push(`  - ${s}`);
+  }
+  lines.push('---', '', opts.body || 'Body for ' + name, '');
+  fs.writeFileSync(path.join(storeDir, `${name}.md`), lines.join('\n'));
+}
+
+function makeFixture({ home }) {
+  const cwd = mktemp('synapsys-disp-tel-cwd-');
+  const storeDir = path.join(cwd, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'dispatcher-telemetry-fixture' })
+  );
+  return {
+    cwd,
+    storeDir,
+    cleanup: () => {
+      try { fs.rmSync(cwd, { recursive: true, force: true }); } catch {}
+      if (home) try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+    },
+  };
+}
+
+function runDispatcher(event, payload, { home, extraEnv } = {}) {
+  const env = { ...process.env, SYNAPSYS_NO_SETUP_HINT: '1', HOME: home };
+  delete env.SYNAPSYS_TELEMETRY;
+  if (extraEnv) Object.assign(env, extraEnv);
+  return spawnSync(process.execPath, [DISPATCHER, event], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    env,
+  });
+}
+
+function telemetryDirFor(home) {
+  return path.join(home, '.claude', 'synapsys', '.telemetry');
+}
+
+function readJsonl(file) {
+  if (!fs.existsSync(file)) return [];
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+// ---- Scenario (a) — fired event written on match ---------------------------
+
+test('Dispatcher writes a fired event when a memory matches', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'mem-fired', {
+    description: 'fires for prompt',
+    events: 'UserPromptSubmit',
+    triggerPrompt: 'hello-fired-trigger',
+    triggerSession: false,
+    inject: 'full',
+    body: 'Body of mem-fired.',
+  });
+
+  const sessionId = 'session-aaa';
+  const result = runDispatcher(
+    'UserPromptSubmit',
+    {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'hello-fired-trigger please',
+      cwd: fx.cwd,
+      session_id: sessionId,
+    },
+    { home }
+  );
+
+  assert.equal(result.status, 0, `stderr=${result.stderr}`);
+  assert.ok(result.stdout.includes('mem-fired'), 'stdout missing injection');
+
+  const jsonl = path.join(telemetryDirFor(home), `${sessionId}.jsonl`);
+  const rows = readJsonl(jsonl);
+  const firedRows = rows.filter((r) => r.event === 'fired' && r.memory === 'mem-fired');
+  assert.equal(firedRows.length, 1, `expected exactly 1 fired row, got ${rows.length} total`);
+});
+
+// ---- Scenario (e) — SYNAPSYS_TELEMETRY=0 opt-out ---------------------------
+
+test('Opt-out via SYNAPSYS_TELEMETRY=0 suppresses all writes', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'mem-optout-env', {
+    description: 'env opt-out',
+    events: 'UserPromptSubmit',
+    triggerPrompt: 'opt-env-trigger',
+    triggerSession: false,
+    inject: 'full',
+  });
+
+  const sessionId = 'session-bbb';
+  const result = runDispatcher(
+    'UserPromptSubmit',
+    {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'opt-env-trigger now',
+      cwd: fx.cwd,
+      session_id: sessionId,
+    },
+    { home, extraEnv: { SYNAPSYS_TELEMETRY: '0' } }
+  );
+
+  assert.equal(result.status, 0, `stderr=${result.stderr}`);
+  assert.ok(result.stdout.includes('mem-optout-env'), 'stdout missing injection');
+
+  const jsonl = path.join(telemetryDirFor(home), `${sessionId}.jsonl`);
+  assert.equal(fs.existsSync(jsonl), false, 'telemetry file must not exist with SYNAPSYS_TELEMETRY=0');
+});
+
+// ---- Scenario (f) — per-memory opt-out -------------------------------------
+
+test('Per-memory opt-out via telemetry false skips that memory only', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'mem-telemetered', {
+    description: 'normal',
+    events: 'UserPromptSubmit',
+    triggerPrompt: 'multi-trigger',
+    triggerSession: false,
+    inject: 'full',
+  });
+  writeMemory(fx.storeDir, 'mem-silent', {
+    description: 'opted out',
+    events: 'UserPromptSubmit',
+    triggerPrompt: 'multi-trigger',
+    triggerSession: false,
+    inject: 'full',
+    telemetry: false,
+  });
+
+  const sessionId = 'session-ccc';
+  const result = runDispatcher(
+    'UserPromptSubmit',
+    {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'multi-trigger fire both',
+      cwd: fx.cwd,
+      session_id: sessionId,
+    },
+    { home }
+  );
+
+  assert.equal(result.status, 0, `stderr=${result.stderr}`);
+
+  const jsonl = path.join(telemetryDirFor(home), `${sessionId}.jsonl`);
+  const rows = readJsonl(jsonl);
+  const names = rows.filter((r) => r.event === 'fired').map((r) => r.memory);
+  assert.ok(names.includes('mem-telemetered'), 'mem-telemetered must be recorded');
+  assert.ok(!names.includes('mem-silent'), 'mem-silent must NOT be recorded');
+});
+
+// ---- Scenario (d) — fail-open under telemetry write failure ----------------
+
+test('Telemetry write failure does not break injection (fail-open)', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'mem-failopen', {
+    description: 'fail-open check',
+    events: 'UserPromptSubmit',
+    triggerPrompt: 'failopen-trigger',
+    triggerSession: false,
+    inject: 'full',
+  });
+
+  // Make the telemetry dir un-writable: create it as a regular FILE so
+  // mkdirSync / appendFileSync inside telemetry.js will throw, exercising
+  // the fail-open path inside the dispatcher.
+  const telDir = telemetryDirFor(home);
+  fs.mkdirSync(path.dirname(telDir), { recursive: true });
+  fs.writeFileSync(telDir, 'not-a-dir');
+
+  const result = runDispatcher(
+    'UserPromptSubmit',
+    {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'failopen-trigger now',
+      cwd: fx.cwd,
+      session_id: 'session-ddd',
+    },
+    { home }
+  );
+
+  assert.equal(result.status, 0, `stderr=${result.stderr}`);
+  assert.ok(
+    result.stdout.includes('mem-failopen'),
+    'injection must still be written even if telemetry write fails'
+  );
+});
+
+// ---- Scenario (b) — cited on Stop when response mentions memory name -------
+
+test('Cited event is emitted on Stop when the response mentions a fired memory name', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'mem-cited', {
+    description: 'fires then cited',
+    events: 'UserPromptSubmit',
+    triggerPrompt: 'cited-trigger',
+    triggerSession: false,
+    inject: 'full',
+  });
+
+  const sessionId = 'session-eee';
+
+  // 1) Fire on UserPromptSubmit so the fired row exists in JSONL.
+  const fired = runDispatcher(
+    'UserPromptSubmit',
+    {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'cited-trigger fire it',
+      cwd: fx.cwd,
+      session_id: sessionId,
+    },
+    { home }
+  );
+  assert.equal(fired.status, 0, `fired stderr=${fired.stderr}`);
+
+  // 2) Stop with response text that mentions the memory name (auto-extracted signal).
+  const stopRes = runDispatcher(
+    'Stop',
+    {
+      hook_event_name: 'Stop',
+      cwd: fx.cwd,
+      session_id: sessionId,
+      response: 'I followed mem-cited and finished the task.',
+    },
+    { home }
+  );
+  assert.equal(stopRes.status, 0, `stop stderr=${stopRes.stderr}`);
+
+  const rows = readJsonl(path.join(telemetryDirFor(home), `${sessionId}.jsonl`));
+  const citedRows = rows.filter((r) => r.event === 'cited' && r.memory === 'mem-cited');
+  assert.equal(citedRows.length, 1, `expected exactly 1 cited row, got ${citedRows.length}`);
+});
+
+// ---- AC7 — cite_signals frontmatter wins over auto-extraction --------------
+
+test('cite_signals frontmatter wins over auto-extraction', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'mem-signals', {
+    description: 'explicit signals',
+    events: 'UserPromptSubmit',
+    triggerPrompt: 'signals-trigger',
+    triggerSession: false,
+    inject: 'full',
+    citeSignals: ['MAGIC_SIGNAL_X'],
+    body: 'Mentions `random-ident` and ## A Heading.',
+  });
+
+  const sessionId = 'session-fff';
+  runDispatcher(
+    'UserPromptSubmit',
+    {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'signals-trigger go',
+      cwd: fx.cwd,
+      session_id: sessionId,
+    },
+    { home }
+  );
+
+  // Response text mentions the memory NAME but NOT the explicit signal.
+  // Because cite_signals declared, auto-extraction is suppressed — no cited row.
+  const stopRes = runDispatcher(
+    'Stop',
+    {
+      hook_event_name: 'Stop',
+      cwd: fx.cwd,
+      session_id: sessionId,
+      response: 'mentioned mem-signals only, not the magic token',
+    },
+    { home }
+  );
+  assert.equal(stopRes.status, 0);
+
+  let rows = readJsonl(path.join(telemetryDirFor(home), `${sessionId}.jsonl`));
+  let cited = rows.filter((r) => r.event === 'cited');
+  assert.equal(cited.length, 0, 'must NOT cite based on auto-name when cite_signals declared');
+
+  // Now run Stop again with response mentioning the declared signal.
+  const stopRes2 = runDispatcher(
+    'Stop',
+    {
+      hook_event_name: 'Stop',
+      cwd: fx.cwd,
+      session_id: sessionId,
+      response: 'I observed MAGIC_SIGNAL_X firing.',
+    },
+    { home }
+  );
+  assert.equal(stopRes2.status, 0);
+
+  rows = readJsonl(path.join(telemetryDirFor(home), `${sessionId}.jsonl`));
+  cited = rows.filter((r) => r.event === 'cited' && r.memory === 'mem-signals');
+  assert.equal(cited.length, 1, 'declared signal must trigger cited row');
+  assert.equal(cited[0].match, 'MAGIC_SIGNAL_X');
+});
+
+// ---- AC8 — auto-extracted signals fire when cite_signals absent ------------
+
+test('Auto-extracted signals fire when cite_signals is absent', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'mem-auto', {
+    description: 'auto-extract from body',
+    events: 'UserPromptSubmit',
+    triggerPrompt: 'auto-trigger',
+    triggerSession: false,
+    inject: 'full',
+    body: 'Use the `auto-ident-token` somewhere later.',
+  });
+
+  const sessionId = 'session-ggg';
+  runDispatcher(
+    'UserPromptSubmit',
+    {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'auto-trigger ok',
+      cwd: fx.cwd,
+      session_id: sessionId,
+    },
+    { home }
+  );
+
+  // Response mentions the backticked identifier from the body — auto-extraction
+  // should pick it up.
+  const stopRes = runDispatcher(
+    'Stop',
+    {
+      hook_event_name: 'Stop',
+      cwd: fx.cwd,
+      session_id: sessionId,
+      response: 'I used auto-ident-token to finish.',
+    },
+    { home }
+  );
+  assert.equal(stopRes.status, 0);
+
+  const rows = readJsonl(path.join(telemetryDirFor(home), `${sessionId}.jsonl`));
+  const cited = rows.filter((r) => r.event === 'cited' && r.memory === 'mem-auto');
+  assert.equal(cited.length, 1, 'auto-extracted signal must cite');
+});
+
+// ---- Scenario (g) — missing session_id falls back to _unknown-session.jsonl
+
+test('Missing session_id falls back to _unknown-session.jsonl', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  writeMemory(fx.storeDir, 'mem-unknown', {
+    description: 'no session id',
+    events: 'UserPromptSubmit',
+    triggerPrompt: 'unknown-session-trigger',
+    triggerSession: false,
+    inject: 'full',
+  });
+
+  const result = runDispatcher(
+    'UserPromptSubmit',
+    {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'unknown-session-trigger go',
+      cwd: fx.cwd,
+      // session_id intentionally omitted
+    },
+    { home }
+  );
+  assert.equal(result.status, 0, `stderr=${result.stderr}`);
+
+  const unknown = path.join(telemetryDirFor(home), '_unknown-session.jsonl');
+  assert.equal(fs.existsSync(unknown), true, '_unknown-session.jsonl must be created');
+  const rows = readJsonl(unknown);
+  const firedRows = rows.filter((r) => r.event === 'fired' && r.memory === 'mem-unknown');
+  assert.ok(firedRows.length >= 1, 'fired row must be recorded in _unknown-session.jsonl');
+});

--- a/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/dispatcher-telemetry.test.js
@@ -565,3 +565,50 @@ test('Stop with missing session_id does not emit cited events', (t) => {
   const cited = rows.filter((r) => r.event === 'cited');
   assert.equal(cited.length, 0, `unknown-session must not emit cited rows, got ${cited.length}: ${JSON.stringify(cited)}`);
 });
+
+// PR #524 cursor[bot] Medium — blank line must not break cite_signals YAML block parse
+test('cite_signals YAML list survives a blank line after the key', (t) => {
+  const home = mktemp('synapsys-disp-tel-home-');
+  const fx = makeFixture({ home });
+  t.after(fx.cleanup);
+
+  // Author-written memory with a blank line between `cite_signals:` and items.
+  const memPath = path.join(fx.storeDir, 'blank-line-sig.md');
+  fs.writeFileSync(
+    memPath,
+    [
+      '---',
+      'name: blank-line-sig',
+      'description: x',
+      'events: [UserPromptSubmit, Stop]',
+      'trigger_prompt: bls-trigger',
+      'cite_signals:',
+      '',
+      '  - declared-token-alpha',
+      '  - declared-token-beta',
+      '---',
+      '',
+      'Body — should NOT be auto-extracted because cite_signals is declared.',
+    ].join('\n')
+  );
+
+  const sessionId = 'bls-session-1';
+  const firedRes = runDispatcher(
+    'UserPromptSubmit',
+    { cwd: fx.cwd, session_id: sessionId, prompt: 'use bls-trigger now' },
+    { home }
+  );
+  assert.equal(firedRes.status, 0);
+
+  const stopRes = runDispatcher(
+    'Stop',
+    { cwd: fx.cwd, session_id: sessionId, response: 'I emit declared-token-beta here.' },
+    { home }
+  );
+  assert.equal(stopRes.status, 0);
+
+  const jsonl = path.join(telemetryDirFor(home), `${sessionId}.jsonl`);
+  const cited = readJsonl(jsonl).filter((r) => r.event === 'cited' && r.memory === 'blank-line-sig');
+  assert.equal(cited.length, 1, `expected 1 cited row using declared signal across YAML blank line, got ${cited.length}`);
+  assert.equal(cited[0].match, 'declared-token-beta');
+});

--- a/plugins/synapsys/lib/__tests__/memory-store.test.js
+++ b/plugins/synapsys/lib/__tests__/memory-store.test.js
@@ -142,3 +142,32 @@ test('readMemoryFile top-level telemetry is undefined when field absent', () => 
   assert.equal(memories.length, 1);
   assert.equal(memories[0].telemetry, undefined);
 });
+
+// PR #524 cursor[bot] Medium — inline comma-separated cite_signals must be split
+// per the README example `cite_signals: Button, packages/ui, @scope/foo`.
+test('readMemoryFile splits inline comma-separated cite_signals into tokens', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'inline-csv.md', {
+    name: 'inline-csv',
+    description: 'd',
+    cite_signals: 'Button, packages/ui, @app/foo',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.deepEqual(memories[0].citeSignals, ['Button', 'packages/ui', '@app/foo']);
+});
+
+test('readMemoryFile keeps a single scalar cite_signal as one token', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'inline-solo.md', {
+    name: 'inline-solo',
+    description: 'd',
+    cite_signals: 'solo',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.deepEqual(memories[0].citeSignals, ['solo']);
+});

--- a/plugins/synapsys/lib/__tests__/memory-store.test.js
+++ b/plugins/synapsys/lib/__tests__/memory-store.test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { listMemoriesFromStore } = require('../memory-store');
+
+function makeTempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-memstore-unit-'));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'test' })
+  );
+  return { storeDir };
+}
+
+function writeMemory(storeDir, name, frontmatter) {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  const content = `---\n${fm}\n---\nbody\n`;
+  fs.writeFileSync(path.join(storeDir, name), content);
+}
+
+// --- Task 1: cite_signals + telemetry frontmatter surfaced via meta ---
+
+test('readMemoryFile surfaces cite_signals as an array of strings on meta', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'cite.md', {
+    name: 'cite',
+    description: 'd',
+    cite_signals: '[alpha, beta, gamma]',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.deepEqual(memories[0].meta.cite_signals, ['alpha', 'beta', 'gamma']);
+});
+
+test('readMemoryFile surfaces telemetry: false as a boolean on meta', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'opt-out.md', {
+    name: 'opt-out',
+    description: 'd',
+    telemetry: 'false',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.equal(memories[0].meta.telemetry, false);
+});
+
+test('readMemoryFile yields meta.cite_signals === undefined when field absent', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'absent.md', {
+    name: 'absent',
+    description: 'd',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.equal(memories[0].meta.cite_signals, undefined);
+});
+
+test('readMemoryFile yields meta.telemetry === undefined when field absent (consumers treat as enabled)', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'absent-tel.md', {
+    name: 'absent-tel',
+    description: 'd',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.equal(memories[0].meta.telemetry, undefined);
+});
+
+// Explicit field-forwarding: the memory object exposes top-level
+// `citeSignals` (array of strings or undefined) and `telemetry`
+// (boolean or undefined), mirroring the camelCase forwarding pattern
+// used for other frontmatter fields (`triggerPretoolContentNot`, etc.).
+// Consumers should not have to dig into `meta` for these.
+
+test('readMemoryFile forwards cite_signals to top-level citeSignals (array)', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'cite-top.md', {
+    name: 'cite-top',
+    description: 'd',
+    cite_signals: '[one, two]',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.deepEqual(memories[0].citeSignals, ['one', 'two']);
+});
+
+test('readMemoryFile forwards telemetry to top-level telemetry (boolean false)', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'tel-top.md', {
+    name: 'tel-top',
+    description: 'd',
+    telemetry: 'false',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.equal(memories[0].telemetry, false);
+});
+
+test('readMemoryFile top-level citeSignals is undefined when field absent', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'no-cite.md', {
+    name: 'no-cite',
+    description: 'd',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.equal(memories[0].citeSignals, undefined);
+});
+
+test('readMemoryFile top-level telemetry is undefined when field absent', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'no-tel.md', {
+    name: 'no-tel',
+    description: 'd',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.equal(memories[0].telemetry, undefined);
+});

--- a/plugins/synapsys/lib/__tests__/memory-store.test.js
+++ b/plugins/synapsys/lib/__tests__/memory-store.test.js
@@ -171,3 +171,17 @@ test('readMemoryFile keeps a single scalar cite_signal as one token', () => {
   const memories = listMemoriesFromStore(store);
   assert.deepEqual(memories[0].citeSignals, ['solo']);
 });
+
+// PR #524 cursor[bot] Low — single-element bracket scalar must drop the brackets
+test('readMemoryFile strips brackets from a single-element bracket cite_signal', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'one-bracket.md', {
+    name: 'one-bracket',
+    description: 'd',
+    cite_signals: '[MAGIC_SIGNAL_X]',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.deepEqual(memories[0].citeSignals, ['MAGIC_SIGNAL_X']);
+});

--- a/plugins/synapsys/lib/__tests__/synapsys-stats.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-stats.integration.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+/**
+ * Integration tests for `plugins/synapsys/scripts/synapsys-stats.js`
+ * (GH-512, Task 4). Spawns the CLI against a temp fixture store and asserts
+ * on stdout/stderr/exit code, covering AC10 (sections) and AC11 (mtime window).
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const STATS = path.resolve(__dirname, '..', '..', 'scripts', 'synapsys-stats.js');
+
+function writeMemoryFile(storeDir, name) {
+  const body = ['---', `name: ${name}`, 'description: x', 'events: UserPromptSubmit', 'trigger_prompt: x', '---', ''].join('\n');
+  fs.writeFileSync(path.join(storeDir, `${name}.md`), body);
+}
+
+function makeFixture() {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-stats-int-'));
+  const storeDir = path.join(cwd, '.claude', 'synapsys');
+  const telDir = path.join(storeDir, '.telemetry');
+  fs.mkdirSync(telDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'synapsys-stats-int-fixture' })
+  );
+  return { cwd, storeDir, telDir, cleanup: () => fs.rmSync(cwd, { recursive: true, force: true }) };
+}
+
+function writeJsonl(file, lines) {
+  fs.writeFileSync(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+}
+
+function runCli(args, fixtureCwd) {
+  return spawnSync(process.execPath, [STATS, ...args, `--cwd=${fixtureCwd}`, '--no-color'], {
+    encoding: 'utf8',
+  });
+}
+
+test('synapsys:stats surfaces top influencers, noise, and never-fired in a 7d window', () => {
+  const fx = makeFixture();
+  try {
+    writeMemoryFile(fx.storeDir, 'mem-influencer');
+    writeMemoryFile(fx.storeDir, 'mem-noise');
+    writeMemoryFile(fx.storeDir, 'mem-quiet');
+
+    const now = Date.now();
+    const lines = [];
+    for (let i = 0; i < 5; i++) {
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'mem-influencer', event: 'fired' });
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'mem-influencer', event: 'cited', match: 'x' });
+    }
+    for (let i = 0; i < 10; i++) {
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'mem-noise', event: 'fired' });
+    }
+    writeJsonl(path.join(fx.telDir, 'session-1.jsonl'), lines);
+
+    const res = runCli(['--last=7d'], fx.cwd);
+    assert.equal(res.status, 0, `exit non-zero: ${res.stderr}`);
+    assert.match(res.stdout, /Top influencers/);
+    assert.match(res.stdout, /Noise candidates/);
+    assert.match(res.stdout, /Never-fired/);
+    assert.match(res.stdout, /mem-influencer/);
+    assert.match(res.stdout, /mem-noise/);
+    assert.match(res.stdout, /mem-quiet/);
+    // mem-quiet should appear under Never-fired, not Top influencers
+    const topSection = res.stdout.split(/Noise candidates/)[0];
+    assert.ok(!/mem-quiet/.test(topSection), 'mem-quiet should not appear in Top influencers');
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test('synapsys:stats honors --last 30d window', () => {
+  const fx = makeFixture();
+  try {
+    writeMemoryFile(fx.storeDir, 'mem-old');
+
+    const oldTs = Date.now() - 1000 * 60 * 60 * 24 * 20;
+    const oldFile = path.join(fx.telDir, 'old-session.jsonl');
+    writeJsonl(oldFile, [
+      { ts: new Date(oldTs).toISOString(), memory: 'mem-old', event: 'fired' },
+      { ts: new Date(oldTs).toISOString(), memory: 'mem-old', event: 'cited', match: 'x' },
+    ]);
+    fs.utimesSync(oldFile, new Date(oldTs), new Date(oldTs));
+
+    const res7 = runCli(['--last=7d'], fx.cwd);
+    assert.equal(res7.status, 0);
+    // mem-old must appear under Never-fired (no in-window fired events)
+    const never7 = res7.stdout.split(/Never-fired/)[1] || '';
+    assert.match(never7, /mem-old/, '7d window: mem-old should be Never-fired');
+
+    const res30 = runCli(['--last=30d'], fx.cwd);
+    assert.equal(res30.status, 0);
+    const never30 = res30.stdout.split(/Never-fired/)[1] || '';
+    assert.ok(!/mem-old/.test(never30), '30d window: mem-old should NOT be Never-fired');
+    // It should now appear earlier (Top influencers since cited=1)
+    assert.match(res30.stdout, /Top influencers[\s\S]*mem-old/);
+  } finally {
+    fx.cleanup();
+  }
+});

--- a/plugins/synapsys/lib/__tests__/synapsys-stats.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-stats.integration.test.js
@@ -22,23 +22,38 @@ function writeMemoryFile(storeDir, name) {
 
 function makeFixture() {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-stats-int-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-stats-int-home-'));
   const storeDir = path.join(cwd, '.claude', 'synapsys');
-  const telDir = path.join(storeDir, '.telemetry');
+  // Telemetry lives under the FIXED home dir (matches lib/telemetry.telemetryDir()).
+  const telDir = path.join(home, '.claude', 'synapsys', '.telemetry');
+  fs.mkdirSync(storeDir, { recursive: true });
   fs.mkdirSync(telDir, { recursive: true });
   fs.writeFileSync(
     path.join(storeDir, '.synapsys.json'),
     JSON.stringify({ projectName: 'synapsys-stats-int-fixture' })
   );
-  return { cwd, storeDir, telDir, cleanup: () => fs.rmSync(cwd, { recursive: true, force: true }) };
+  return {
+    cwd,
+    home,
+    storeDir,
+    telDir,
+    cleanup: () => {
+      try { fs.rmSync(cwd, { recursive: true, force: true }); } catch {}
+      try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+    },
+  };
 }
 
 function writeJsonl(file, lines) {
   fs.writeFileSync(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
 }
 
-function runCli(args, fixtureCwd) {
+function runCli(args, fixtureCwd, home) {
+  const env = { ...process.env };
+  if (home) env.HOME = home;
   return spawnSync(process.execPath, [STATS, ...args, `--cwd=${fixtureCwd}`, '--no-color'], {
     encoding: 'utf8',
+    env,
   });
 }
 
@@ -60,7 +75,7 @@ test('synapsys:stats surfaces top influencers, noise, and never-fired in a 7d wi
     }
     writeJsonl(path.join(fx.telDir, 'session-1.jsonl'), lines);
 
-    const res = runCli(['--last=7d'], fx.cwd);
+    const res = runCli(['--last=7d'], fx.cwd, fx.home);
     assert.equal(res.status, 0, `exit non-zero: ${res.stderr}`);
     assert.match(res.stdout, /Top influencers/);
     assert.match(res.stdout, /Noise candidates/);
@@ -89,18 +104,60 @@ test('synapsys:stats honors --last 30d window', () => {
     ]);
     fs.utimesSync(oldFile, new Date(oldTs), new Date(oldTs));
 
-    const res7 = runCli(['--last=7d'], fx.cwd);
+    const res7 = runCli(['--last=7d'], fx.cwd, fx.home);
     assert.equal(res7.status, 0);
     // mem-old must appear under Never-fired (no in-window fired events)
     const never7 = res7.stdout.split(/Never-fired/)[1] || '';
     assert.match(never7, /mem-old/, '7d window: mem-old should be Never-fired');
 
-    const res30 = runCli(['--last=30d'], fx.cwd);
+    const res30 = runCli(['--last=30d'], fx.cwd, fx.home);
     assert.equal(res30.status, 0);
     const never30 = res30.stdout.split(/Never-fired/)[1] || '';
     assert.ok(!/mem-old/.test(never30), '30d window: mem-old should NOT be Never-fired');
     // It should now appear earlier (Top influencers since cited=1)
     assert.match(res30.stdout, /Top influencers[\s\S]*mem-old/);
+  } finally {
+    fx.cleanup();
+  }
+});
+
+// Cross-pipeline end-to-end: dispatcher writes telemetry → stats reads it.
+test('dispatcher write → stats read share the same telemetry directory', () => {
+  const fx = makeFixture();
+  try {
+    writeMemoryFile(fx.storeDir, 'mem-flow');
+    // Append the trigger_prompt so the dispatcher actually matches.
+    fs.writeFileSync(
+      path.join(fx.storeDir, 'mem-flow.md'),
+      ['---', 'name: mem-flow', 'description: x', 'events: UserPromptSubmit',
+       'trigger_prompt: flow-token', '---', '', 'Body'].join('\n')
+    );
+
+    const DISPATCHER = path.resolve(__dirname, '..', '..', 'hooks', 'synapsys.js');
+    const env = { ...process.env, HOME: fx.home, SYNAPSYS_NO_SETUP_HINT: '1' };
+    delete env.SYNAPSYS_TELEMETRY;
+    const sessionId = 'flow-session-1';
+    const payload = { cwd: fx.cwd, session_id: sessionId, prompt: 'contains flow-token here' };
+    const fired = spawnSync(process.execPath, [DISPATCHER, 'UserPromptSubmit'], {
+      input: JSON.stringify(payload),
+      encoding: 'utf8',
+      env,
+    });
+    assert.equal(fired.status, 0, `dispatcher exit non-zero: ${fired.stderr}`);
+
+    // Telemetry MUST land in fx.telDir (the fixed home-rooted path).
+    const jsonl = path.join(fx.telDir, `${sessionId}.jsonl`);
+    assert.ok(fs.existsSync(jsonl), `expected telemetry at ${jsonl}`);
+
+    // Stats CLI must see the events written by the dispatcher.
+    const res = runCli(['--last=7d'], fx.cwd, fx.home);
+    assert.equal(res.status, 0, `stats exit non-zero: ${res.stderr}`);
+    const top = res.stdout.split(/Noise candidates/)[0];
+    // mem-flow fired once → not in Top influencers (no cited yet) but listed somewhere
+    // with fired:1; what matters is the Never-fired section excludes it.
+    const never = res.stdout.split(/Never-fired/)[1] || '';
+    assert.ok(!/mem-flow/.test(never), `cross-pipeline: mem-flow must NOT be Never-fired. stdout:\n${res.stdout}`);
+    void top;
   } finally {
     fx.cleanup();
   }

--- a/plugins/synapsys/lib/__tests__/synapsys-stats.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-stats.test.js
@@ -180,3 +180,47 @@ test('synapsys:stats excludes Stop-only memories from Noise candidates', () => {
     fx.cleanup();
   }
 });
+
+// PR #524 cursor[bot] Medium — sections must restrict to memories discovered via --cwd.
+// Other-project / deleted memories must NOT appear in Top influencers or Noise candidates
+// just because their events were written to the global telemetry directory.
+test('synapsys:stats excludes unknown (other-project/deleted) memories from Top and Noise', () => {
+  assert.ok(helpers, 'synapsys-stats.js must export pure helpers');
+  const { parseWindow, aggregate, formatSections } = helpers;
+
+  const fx = makeFixture();
+  try {
+    // Only one memory is discoverable via fx.cwd's store.
+    writeMemoryFile(fx.storeDir, 'known-mem');
+
+    const now = Date.now();
+    const lines = [];
+    // Known memory: looks like a top-influencer.
+    for (let i = 0; i < 3; i++) {
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'known-mem', event: 'fired' });
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'known-mem', event: 'cited', match: 'x' });
+    }
+    // UNKNOWN memory (from another project): high fired + cited.
+    for (let i = 0; i < 4; i++) {
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'other-project-influencer', event: 'fired' });
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'other-project-influencer', event: 'cited', match: 'y' });
+    }
+    // UNKNOWN memory: high fired, zero cited — would otherwise be flagged noise.
+    for (let i = 0; i < 12; i++) {
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'other-project-noise', event: 'fired' });
+    }
+    writeJsonl(path.join(fx.telDir, 'cross-project.jsonl'), lines);
+
+    const out = formatSections(aggregate(fx.cwd, { windowMs: parseWindow('7d') }), { color: false });
+    const topSection = out.split(/Noise candidates/)[0];
+    const noiseSection = out.split(/Noise candidates/)[1].split(/Never-fired/)[0];
+
+    assert.match(topSection, /known-mem/);
+    assert.ok(!/other-project-influencer/.test(topSection),
+      'other-project memory must NOT appear in Top influencers');
+    assert.ok(!/other-project-noise/.test(noiseSection),
+      'other-project memory must NOT appear in Noise candidates');
+  } finally {
+    fx.cleanup();
+  }
+});

--- a/plugins/synapsys/lib/__tests__/synapsys-stats.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-stats.test.js
@@ -34,14 +34,30 @@ function writeMemoryFile(storeDir, name) {
 
 function makeFixture() {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-stats-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-stats-home-'));
   const storeDir = path.join(cwd, '.claude', 'synapsys');
-  const telDir = path.join(storeDir, '.telemetry');
+  // Telemetry lives under the FIXED home dir (matches lib/telemetry.telemetryDir()),
+  // not under the per-store directory.
+  const telDir = path.join(home, '.claude', 'synapsys', '.telemetry');
+  fs.mkdirSync(storeDir, { recursive: true });
   fs.mkdirSync(telDir, { recursive: true });
   fs.writeFileSync(
     path.join(storeDir, '.synapsys.json'),
     JSON.stringify({ projectName: 'synapsys-stats-fixture' })
   );
-  return { cwd, storeDir, telDir, cleanup: () => fs.rmSync(cwd, { recursive: true, force: true }) };
+  const prevHome = process.env.HOME;
+  process.env.HOME = home;
+  return {
+    cwd,
+    home,
+    storeDir,
+    telDir,
+    cleanup: () => {
+      process.env.HOME = prevHome;
+      try { fs.rmSync(cwd, { recursive: true, force: true }); } catch {}
+      try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+    },
+  };
 }
 
 function writeJsonl(file, lines) {

--- a/plugins/synapsys/lib/__tests__/synapsys-stats.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-stats.test.js
@@ -139,3 +139,44 @@ test('synapsys:stats honors --last 30d window', () => {
     fx.cleanup();
   }
 });
+
+// PR #524 cursor[bot] Medium — Stop-only memories must NOT appear in Noise candidates
+// even when they hit fired >= 10 with cited == 0 (they fire on every assistant turn
+// by design; the "tighten triggers" advice does not apply).
+test('synapsys:stats excludes Stop-only memories from Noise candidates', () => {
+  assert.ok(helpers, 'synapsys-stats.js must export pure helpers');
+  const { parseWindow, aggregate, formatSections } = helpers;
+
+  const fx = makeFixture();
+  try {
+    // Stop-only memory — declares only the Stop event.
+    fs.writeFileSync(
+      path.join(fx.storeDir, 'stop-only-mem.md'),
+      ['---', 'name: stop-only-mem', 'description: x', 'events: Stop',
+       'trigger_session: true', '---', ''].join('\n')
+    );
+    // Multi-event noise memory — fires on UserPromptSubmit AND Stop.
+    fs.writeFileSync(
+      path.join(fx.storeDir, 'real-noise.md'),
+      ['---', 'name: real-noise', 'description: x', 'events: [UserPromptSubmit, Stop]',
+       'trigger_prompt: x', '---', ''].join('\n')
+    );
+
+    const now = Date.now();
+    const lines = [];
+    for (let i = 0; i < 15; i++) {
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'stop-only-mem', event: 'fired' });
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'real-noise', event: 'fired' });
+    }
+    writeJsonl(path.join(fx.telDir, 'session-1.jsonl'), lines);
+
+    const stats = aggregate(fx.cwd, { windowMs: parseWindow('7d') });
+    const out = formatSections(stats, { color: false });
+
+    const noiseSection = out.split(/Noise candidates/)[1].split(/Never-fired/)[0];
+    assert.ok(!/stop-only-mem/.test(noiseSection), 'stop-only-mem must NOT appear in Noise candidates');
+    assert.ok(/real-noise/.test(noiseSection), 'real-noise (multi-event) should still be flagged');
+  } finally {
+    fx.cleanup();
+  }
+});

--- a/plugins/synapsys/lib/__tests__/synapsys-stats.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-stats.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+/**
+ * Unit tests for `plugins/synapsys/scripts/synapsys-stats.js` (GH-512, Task 4).
+ *
+ * Covers Gherkin scenarios AC10 / AC11 — windowed aggregation across
+ * `.telemetry/*.jsonl` files producing Top influencers / Noise candidates /
+ * Never-fired sections.
+ *
+ * Requirements: R3, C2, C6.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const STATS = path.resolve(__dirname, '..', '..', 'scripts', 'synapsys-stats.js');
+let helpers;
+try {
+  // Pure helpers are exported once REFACTOR completes. During RED/GREEN the
+  // require may fail; tests below tolerate `helpers === null` by skipping
+  // helper-only assertions.
+  helpers = require(STATS);
+} catch {
+  helpers = null;
+}
+
+function writeMemoryFile(storeDir, name) {
+  const body = ['---', `name: ${name}`, 'description: x', 'events: UserPromptSubmit', 'trigger_prompt: x', '---', ''].join('\n');
+  fs.writeFileSync(path.join(storeDir, `${name}.md`), body);
+}
+
+function makeFixture() {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-stats-'));
+  const storeDir = path.join(cwd, '.claude', 'synapsys');
+  const telDir = path.join(storeDir, '.telemetry');
+  fs.mkdirSync(telDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'synapsys-stats-fixture' })
+  );
+  return { cwd, storeDir, telDir, cleanup: () => fs.rmSync(cwd, { recursive: true, force: true }) };
+}
+
+function writeJsonl(file, lines) {
+  fs.writeFileSync(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+}
+
+test('synapsys:stats surfaces top influencers, noise, and never-fired in a 7d window', () => {
+  assert.ok(helpers, 'synapsys-stats.js must export pure helpers (parseWindow, aggregate, formatSections)');
+  const { parseWindow, aggregate, formatSections } = helpers;
+
+  const fx = makeFixture();
+  try {
+    writeMemoryFile(fx.storeDir, 'mem-influencer');
+    writeMemoryFile(fx.storeDir, 'mem-noise');
+    writeMemoryFile(fx.storeDir, 'mem-quiet');
+
+    const now = Date.now();
+    const lines = [];
+    for (let i = 0; i < 5; i++) {
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'mem-influencer', event: 'fired' });
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'mem-influencer', event: 'cited', match: 'x' });
+    }
+    for (let i = 0; i < 10; i++) {
+      lines.push({ ts: new Date(now - 1000 * i).toISOString(), memory: 'mem-noise', event: 'fired' });
+    }
+    const sessionFile = path.join(fx.telDir, 'session-1.jsonl');
+    writeJsonl(sessionFile, lines);
+
+    const windowMs = parseWindow('7d');
+    assert.equal(typeof windowMs, 'number');
+    assert.ok(windowMs > 0);
+
+    const stats = aggregate(fx.cwd, { windowMs });
+    const byName = new Map(stats.perMemory.map((m) => [m.name, m]));
+    assert.equal(byName.get('mem-influencer').cited, 5);
+    assert.equal(byName.get('mem-influencer').fired, 5);
+    assert.equal(byName.get('mem-noise').fired, 10);
+    assert.equal(byName.get('mem-noise').cited, 0);
+
+    const out = formatSections(stats, { color: false });
+    assert.match(out, /Top influencers[\s\S]*mem-influencer/);
+    assert.match(out, /Noise candidates[\s\S]*mem-noise/);
+    assert.match(out, /Never-fired[\s\S]*mem-quiet/);
+    // mem-quiet must not appear in Top influencers
+    const topSection = out.split(/Noise candidates/)[0];
+    assert.ok(!/mem-quiet/.test(topSection), 'mem-quiet should not appear in Top influencers');
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test('synapsys:stats honors --last 30d window', () => {
+  assert.ok(helpers, 'synapsys-stats.js must export pure helpers');
+  const { parseWindow, aggregate } = helpers;
+
+  const fx = makeFixture();
+  try {
+    writeMemoryFile(fx.storeDir, 'mem-old');
+
+    const oldTs = Date.now() - 1000 * 60 * 60 * 24 * 20; // 20 days ago
+    const oldFile = path.join(fx.telDir, 'old-session.jsonl');
+    writeJsonl(oldFile, [
+      { ts: new Date(oldTs).toISOString(), memory: 'mem-old', event: 'fired' },
+      { ts: new Date(oldTs).toISOString(), memory: 'mem-old', event: 'cited', match: 'm' },
+    ]);
+    // Force mtime to 20 days ago so window filter sees it correctly.
+    fs.utimesSync(oldFile, new Date(oldTs), new Date(oldTs));
+
+    const stats7 = aggregate(fx.cwd, { windowMs: parseWindow('7d') });
+    const found7 = stats7.perMemory.find((m) => m.name === 'mem-old');
+    assert.ok(!found7 || (found7.fired === 0 && found7.cited === 0), '7d window must exclude 20-day-old file');
+
+    const stats30 = aggregate(fx.cwd, { windowMs: parseWindow('30d') });
+    const found30 = stats30.perMemory.find((m) => m.name === 'mem-old');
+    assert.ok(found30, '30d window must include 20-day-old file');
+    assert.equal(found30.fired, 1);
+    assert.equal(found30.cited, 1);
+  } finally {
+    fx.cleanup();
+  }
+});

--- a/plugins/synapsys/lib/__tests__/telemetry.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/telemetry.integration.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function withTempHome(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-telemetry-int-'));
+  const prevHome = process.env.HOME;
+  const prevDisable = process.env.SYNAPSYS_TELEMETRY;
+  process.env.HOME = tmp;
+  delete process.env.SYNAPSYS_TELEMETRY;
+  delete require.cache[require.resolve('../telemetry')];
+  try {
+    return fn(tmp);
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevDisable === undefined) delete process.env.SYNAPSYS_TELEMETRY;
+    else process.env.SYNAPSYS_TELEMETRY = prevDisable;
+    delete require.cache[require.resolve('../telemetry')];
+  }
+}
+
+function readJsonl(file) {
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+// AC5 — real fs: first write seeds dir + .gitignore with *
+test('integration: first recordFired creates .telemetry dir + .gitignore on real fs', () => {
+  withTempHome((home) => {
+    const telemetry = require('../telemetry');
+    telemetry.recordFired(
+      { name: 'real-mem', meta: {} },
+      { session_id: 'real-sess' },
+      'UserPromptSubmit'
+    );
+    const dir = path.join(home, '.claude', 'synapsys', '.telemetry');
+    const gi = path.join(dir, '.gitignore');
+    const sessFile = path.join(dir, 'real-sess.jsonl');
+    assert.ok(fs.existsSync(dir));
+    assert.equal(fs.readFileSync(gi, 'utf8'), '*\n');
+    assert.ok(fs.existsSync(sessFile));
+    const rows = readJsonl(sessFile);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].event, 'fired');
+  });
+});
+
+// AC4 — fail-open: real EACCES on dir (read-only) does not throw
+test('integration: recordFired fail-open under EACCES on real read-only dir', () => {
+  withTempHome((home) => {
+    const telemetry = require('../telemetry');
+    // Pre-create the dir read-only.
+    const dir = path.join(home, '.claude', 'synapsys', '.telemetry');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.chmodSync(dir, 0o500); // r-x only
+    try {
+      assert.doesNotThrow(() => {
+        telemetry.recordFired({ name: 'm', meta: {} }, { session_id: 's' }, 'r');
+      });
+    } finally {
+      fs.chmodSync(dir, 0o700);
+    }
+  });
+});
+
+// End-to-end fired + cite scan + recordCited pipeline on real fs
+test('integration: fired → scanForCitations → recordCited writes both event rows', () => {
+  withTempHome((home) => {
+    const telemetry = require('../telemetry');
+    const memory = {
+      name: 'flowmem',
+      meta: { cite_signals: ['flowmem'] },
+    };
+    telemetry.recordFired(memory, { session_id: 'flow' }, 'UserPromptSubmit');
+
+    const responseText = 'The assistant mentioned flowmem in this reply.';
+    const hits = telemetry.scanForCitations([memory], responseText);
+    assert.equal(hits.length, 1);
+    for (const hit of hits) {
+      telemetry.recordCited(hit.memory, { session_id: 'flow' }, hit.match);
+    }
+
+    const file = path.join(home, '.claude', 'synapsys', '.telemetry', 'flow.jsonl');
+    const rows = readJsonl(file);
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].event, 'fired');
+    assert.equal(rows[1].event, 'cited');
+  });
+});

--- a/plugins/synapsys/lib/__tests__/telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/telemetry.test.js
@@ -231,3 +231,21 @@ test('extractSignals honors top-level memory.citeSignals (scalar normalized to a
     assert.deepEqual(telemetry.extractSignals(memMeta), ['c']);
   });
 });
+
+// PR #524 cursor[bot] Medium — session_id sanitization (path traversal defense)
+test('resolveSessionId rejects unsafe values (path separators, dotdot, absolute)', () => {
+  withTempHome(() => {
+    const telemetry = require('../telemetry');
+    // Allowed
+    assert.equal(telemetry.resolveSessionId({ session_id: 'abc123' }), 'abc123');
+    assert.equal(telemetry.resolveSessionId({ session_id: 'a-b_c.1' }), 'a-b_c.1');
+    // Disallowed — fall back to _unknown-session
+    assert.equal(telemetry.resolveSessionId({ session_id: '../evil' }), '_unknown-session');
+    assert.equal(telemetry.resolveSessionId({ session_id: '/etc/passwd' }), '_unknown-session');
+    assert.equal(telemetry.resolveSessionId({ session_id: 'a/b' }), '_unknown-session');
+    assert.equal(telemetry.resolveSessionId({ session_id: 'a\\b' }), '_unknown-session');
+    assert.equal(telemetry.resolveSessionId({ session_id: '..' }), '_unknown-session');
+    assert.equal(telemetry.resolveSessionId({ session_id: '.hidden' }), '_unknown-session');
+    assert.equal(telemetry.resolveSessionId({ session_id: 'x'.repeat(200) }), '_unknown-session');
+  });
+});

--- a/plugins/synapsys/lib/__tests__/telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/telemetry.test.js
@@ -203,3 +203,31 @@ test('telemetryDir returns ~/.claude/synapsys/.telemetry', () => {
     assert.equal(telemetry.telemetryDir(), path.join(home, '.claude', 'synapsys', '.telemetry'));
   });
 });
+
+// PR #524 cursor[bot] Low — isDisabled must honor top-level memory.telemetry
+test('isDisabled honors top-level memory.telemetry === false (memory-store normalized field)', () => {
+  withTempHome(() => {
+    const telemetry = require('../telemetry');
+    assert.equal(telemetry.isDisabled({ name: 'm', telemetry: false }), true);
+    assert.equal(telemetry.isDisabled({ name: 'm', telemetry: true }), false);
+    assert.equal(telemetry.isDisabled({ name: 'm' }), false);
+    // meta fallback still works
+    assert.equal(telemetry.isDisabled({ name: 'm', meta: { telemetry: false } }), true);
+  });
+});
+
+// PR #524 cursor[bot] Medium — extractSignals must honor top-level memory.citeSignals
+test('extractSignals honors top-level memory.citeSignals (scalar normalized to array by memory-store)', () => {
+  withTempHome(() => {
+    const telemetry = require('../telemetry');
+    // Scalar in YAML becomes a one-element array on top-level via memory-store.
+    const memScalar = { name: 'm', citeSignals: ['solo'], body: 'unused', meta: {} };
+    assert.deepEqual(telemetry.extractSignals(memScalar), ['solo']);
+    // Array form
+    const memArr = { name: 'm', citeSignals: ['a', 'b'], body: 'unused', meta: {} };
+    assert.deepEqual(telemetry.extractSignals(memArr), ['a', 'b']);
+    // meta fallback still works when top-level absent
+    const memMeta = { name: 'm', body: 'unused', meta: { cite_signals: ['c'] } };
+    assert.deepEqual(telemetry.extractSignals(memMeta), ['c']);
+  });
+});

--- a/plugins/synapsys/lib/__tests__/telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/telemetry.test.js
@@ -1,0 +1,205 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function withTempHome(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-telemetry-unit-'));
+  const prevHome = process.env.HOME;
+  const prevDisable = process.env.SYNAPSYS_TELEMETRY;
+  process.env.HOME = tmp;
+  delete process.env.SYNAPSYS_TELEMETRY;
+  delete require.cache[require.resolve('../telemetry')];
+  try {
+    return fn(tmp);
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevDisable === undefined) delete process.env.SYNAPSYS_TELEMETRY;
+    else process.env.SYNAPSYS_TELEMETRY = prevDisable;
+    delete require.cache[require.resolve('../telemetry')];
+  }
+}
+
+function readJsonl(file) {
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+// AC5 — First write seeds the telemetry .gitignore
+test('first recordFired write seeds .telemetry/ dir and .gitignore with *', () => {
+  withTempHome((home) => {
+    const telemetry = require('../telemetry');
+    telemetry.recordFired({ name: 'demo-mem', meta: {} }, { session_id: 'sess-1' }, 'UserPromptSubmit');
+    const dir = path.join(home, '.claude', 'synapsys', '.telemetry');
+    const gi = path.join(dir, '.gitignore');
+    assert.ok(fs.existsSync(dir));
+    assert.ok(fs.existsSync(gi));
+    assert.equal(fs.readFileSync(gi, 'utf8'), '*\n');
+  });
+});
+
+// R1 — JSONL line shape with ISO ts + reason
+test('recordFired writes one JSONL line with ts, memory, event=fired, reason', () => {
+  withTempHome((home) => {
+    const telemetry = require('../telemetry');
+    telemetry.recordFired({ name: 'mem-a', meta: {} }, { session_id: 'sess-X' }, 'UserPromptSubmit');
+    const file = path.join(home, '.claude', 'synapsys', '.telemetry', 'sess-X.jsonl');
+    const rows = readJsonl(file);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].memory, 'mem-a');
+    assert.equal(rows[0].event, 'fired');
+    assert.equal(rows[0].reason, 'UserPromptSubmit');
+    assert.match(rows[0].ts, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});
+
+// AC2 — SYNAPSYS_TELEMETRY=0 suppresses all writes
+test('SYNAPSYS_TELEMETRY=0 suppresses recordFired writes', () => {
+  withTempHome((home) => {
+    process.env.SYNAPSYS_TELEMETRY = '0';
+    const telemetry = require('../telemetry');
+    telemetry.recordFired({ name: 'mem-a', meta: {} }, { session_id: 'sess-1' }, 'UserPromptSubmit');
+    const file = path.join(home, '.claude', 'synapsys', '.telemetry', 'sess-1.jsonl');
+    assert.equal(fs.existsSync(file), false);
+  });
+});
+
+// AC3 — per-memory telemetry:false suppresses for that memory only
+test('per-memory telemetry:false skips only that memory', () => {
+  withTempHome((home) => {
+    const telemetry = require('../telemetry');
+    telemetry.recordFired({ name: 'silent', meta: { telemetry: false } }, { session_id: 's' }, 'r');
+    telemetry.recordFired({ name: 'loud', meta: {} }, { session_id: 's' }, 'r');
+    const file = path.join(home, '.claude', 'synapsys', '.telemetry', 's.jsonl');
+    const rows = readJsonl(file);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].memory, 'loud');
+  });
+});
+
+// AC4 — fail-open under unwritable dir (mock fs.appendFileSync throw)
+test('recordFired is fail-open when fs.appendFileSync throws', () => {
+  withTempHome(() => {
+    const telemetry = require('../telemetry');
+    const orig = fs.appendFileSync;
+    fs.appendFileSync = () => {
+      const e = new Error('EACCES');
+      e.code = 'EACCES';
+      throw e;
+    };
+    try {
+      assert.doesNotThrow(() => {
+        telemetry.recordFired({ name: 'm', meta: {} }, { session_id: 's' }, 'r');
+      });
+    } finally {
+      fs.appendFileSync = orig;
+    }
+  });
+});
+
+// isDisabled unit
+test('isDisabled returns true for env var and per-memory flag', () => {
+  withTempHome(() => {
+    const telemetry = require('../telemetry');
+    assert.equal(telemetry.isDisabled({ name: 'a', meta: {} }), false);
+    assert.equal(telemetry.isDisabled({ name: 'a', meta: { telemetry: false } }), true);
+    process.env.SYNAPSYS_TELEMETRY = '0';
+    assert.equal(telemetry.isDisabled({ name: 'a', meta: {} }), true);
+  });
+});
+
+// AC7 — cite_signals wins over auto-extraction
+test('extractSignals returns declared cite_signals when non-empty', () => {
+  withTempHome(() => {
+    const telemetry = require('../telemetry');
+    const memory = {
+      name: 'mem-1',
+      meta: { cite_signals: ['flagA', 'flagB'] },
+      body: '## Heading\n`autoIdent`',
+    };
+    const sigs = telemetry.extractSignals(memory);
+    assert.deepEqual(sigs.sort(), ['flagA', 'flagB'].sort());
+  });
+});
+
+// AC8 — auto-extracted signals when cite_signals absent
+test('extractSignals auto-extracts backticked identifiers, first H2/H3 heading, and memory name', () => {
+  withTempHome(() => {
+    const telemetry = require('../telemetry');
+    const memory = {
+      name: 'mem-auto',
+      meta: {},
+      body: '## My Heading Text\nUse `doThing` and `xy`.\n```\n`shouldSkip`\n```',
+    };
+    const sigs = telemetry.extractSignals(memory);
+    assert.ok(sigs.includes('mem-auto'));
+    assert.ok(sigs.includes('doThing'));
+    assert.ok(sigs.includes('xy'));
+    assert.ok(sigs.includes('My Heading Text'));
+    assert.ok(!sigs.includes('shouldSkip'), 'must skip code-fence backticks');
+  });
+});
+
+// AC9 — missing session_id → _unknown-session.jsonl; reason carries pid+start token
+test('resolveSessionId falls back to _unknown-session; recordFired reason has pid+start token', () => {
+  withTempHome((home) => {
+    const telemetry = require('../telemetry');
+    assert.equal(telemetry.resolveSessionId({}), '_unknown-session');
+    assert.equal(telemetry.resolveSessionId({ session_id: 'abc' }), 'abc');
+    telemetry.recordFired({ name: 'm', meta: {} }, {}, 'UserPromptSubmit');
+    const file = path.join(home, '.claude', 'synapsys', '.telemetry', '_unknown-session.jsonl');
+    const rows = readJsonl(file);
+    assert.equal(rows.length, 1);
+    assert.match(rows[0].reason, new RegExp(`${process.pid}-\\d+`));
+  });
+});
+
+// R2 — scanForCitations dedupe + match cap
+test('scanForCitations dedupes per memory and caps match at 200 chars', () => {
+  withTempHome(() => {
+    const telemetry = require('../telemetry');
+    const memories = [
+      { name: 'alpha', meta: { cite_signals: ['alpha'] } },
+      { name: 'beta', meta: { cite_signals: ['beta'] } },
+    ];
+    const text = 'alpha shows up. alpha again. beta also here.';
+    const hits = telemetry.scanForCitations(memories, text);
+    assert.equal(hits.length, 2);
+    const names = hits.map((h) => h.memory.name).sort();
+    assert.deepEqual(names, ['alpha', 'beta']);
+
+    const longText = 'x'.repeat(500) + 'alpha' + 'y'.repeat(500);
+    const hits2 = telemetry.scanForCitations([memories[0]], longText);
+    assert.equal(hits2.length, 1);
+    assert.ok(hits2[0].match.length <= 200);
+  });
+});
+
+// recordCited writes JSONL line
+test('recordCited writes a cited JSONL line with match field', () => {
+  withTempHome((home) => {
+    const telemetry = require('../telemetry');
+    telemetry.recordCited({ name: 'mem-c', meta: {} }, { session_id: 's2' }, 'alpha-match');
+    const file = path.join(home, '.claude', 'synapsys', '.telemetry', 's2.jsonl');
+    const rows = readJsonl(file);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].event, 'cited');
+    assert.equal(rows[0].memory, 'mem-c');
+    assert.equal(rows[0].match, 'alpha-match');
+  });
+});
+
+// telemetryDir returns correct path
+test('telemetryDir returns ~/.claude/synapsys/.telemetry', () => {
+  withTempHome((home) => {
+    const telemetry = require('../telemetry');
+    assert.equal(telemetry.telemetryDir(), path.join(home, '.claude', 'synapsys', '.telemetry'));
+  });
+});

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -184,8 +184,11 @@ function normalizeCiteSignals(value) {
     const filtered = value.map((s) => String(s).trim()).filter(Boolean);
     return filtered.length ? filtered : undefined;
   }
-  const s = String(value).trim();
-  return s ? [s] : undefined;
+  // Inline scalar form matches the README example `cite_signals: A, B, C`;
+  // split on commas so each token is a separate signal rather than a single
+  // combined string that would never match the assistant response.
+  const tokens = String(value).split(',').map((s) => s.trim()).filter(Boolean);
+  return tokens.length ? tokens : undefined;
 }
 
 // Coerce `meta.telemetry` to a boolean when explicitly set, or `undefined`

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -161,9 +161,42 @@ function readMemoryFile(store, name) {
     inject: meta.inject === 'full' ? 'full' : 'summary',
     disabled: meta.disabled === true || meta.disabled === 'true',
     expired: parseExpired(meta.expires),
+    // Telemetry-related forwarded fields (GH-512 Task 1). These mirror the
+    // values surfaced under `meta`; consumers can read the top-level
+    // properties directly without digging into `meta`. Missing frontmatter
+    // keys leave both as `undefined` so callers can treat absent
+    // `telemetry` as "enabled" and absent `cite_signals` as "auto-extract".
+    citeSignals: normalizeCiteSignals(meta.cite_signals),
+    telemetry: normalizeTelemetry(meta.telemetry),
     meta,
     body,
   };
+}
+
+// Coerce `meta.cite_signals` to an array of non-empty strings, or `undefined`
+// when the frontmatter key is absent. The frontmatter parser already turns
+// `[a, b]` into a JS array, but a single scalar (e.g. `cite_signals: solo`)
+// should still surface as a one-element array so downstream consumers don't
+// have to special-case the shape.
+function normalizeCiteSignals(value) {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (Array.isArray(value)) {
+    const filtered = value.map((s) => String(s).trim()).filter(Boolean);
+    return filtered.length ? filtered : undefined;
+  }
+  const s = String(value).trim();
+  return s ? [s] : undefined;
+}
+
+// Coerce `meta.telemetry` to a boolean when explicitly set, or `undefined`
+// when absent. Consumers treat absent telemetry as enabled (opt-out semantics),
+// so we must distinguish "missing" from "explicit false".
+function normalizeTelemetry(value) {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value === 'boolean') return value;
+  if (value === 'false') return false;
+  if (value === 'true') return true;
+  return undefined;
 }
 
 function parseExpired(value) {

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -187,7 +187,13 @@ function normalizeCiteSignals(value) {
   // Inline scalar form matches the README example `cite_signals: A, B, C`;
   // split on commas so each token is a separate signal rather than a single
   // combined string that would never match the assistant response.
-  const tokens = String(value).split(',').map((s) => s.trim()).filter(Boolean);
+  // The frontmatter parser surfaces YAML flow lists like `[A]` / `[A, B]`
+  // as the literal bracketed string when it doesn't recognize the array
+  // form, so strip a single matched pair of outer brackets before splitting.
+  let scalar = String(value).trim();
+  const bracketed = scalar.match(/^\[(.*)\]$/);
+  if (bracketed) scalar = bracketed[1];
+  const tokens = scalar.split(',').map((s) => s.trim()).filter(Boolean);
   return tokens.length ? tokens : undefined;
 }
 

--- a/plugins/synapsys/lib/telemetry.js
+++ b/plugins/synapsys/lib/telemetry.js
@@ -29,7 +29,11 @@ function telemetryDir() {
 
 function isDisabled(memory) {
   if (process.env.SYNAPSYS_TELEMETRY === '0') return true;
-  if (memory && memory.meta && memory.meta.telemetry === false) return true;
+  if (!memory) return false;
+  // Read top-level normalized field (preferred — memory-store sets this) and
+  // fall back to raw meta for memories constructed without normalization.
+  if (memory.telemetry === false) return true;
+  if (memory.meta && memory.meta.telemetry === false) return true;
   return false;
 }
 
@@ -48,9 +52,13 @@ function ensureDir() {
   try {
     const dir = telemetryDir();
     fs.mkdirSync(dir, { recursive: true });
-    const gi = path.join(dir, '.gitignore');
-    if (!fs.existsSync(gi)) {
-      fs.writeFileSync(gi, '*\n');
+    // Atomic create-if-missing: avoids the TOCTOU window between existsSync
+    // and writeFileSync. EEXIST on concurrent first-write is the desired
+    // "already there" outcome — swallow it.
+    try {
+      fs.writeFileSync(path.join(dir, '.gitignore'), '*\n', { flag: 'wx' });
+    } catch (err) {
+      if (!err || err.code !== 'EEXIST') throw err;
     }
     return dir;
   } catch {
@@ -124,11 +132,12 @@ function stripFences(body) {
 }
 
 function extractAuto(memory) {
+  // Callers (extractSignals) guarantee `memory` is truthy.
   const out = new Set();
-  if (memory && typeof memory.name === 'string' && memory.name.length > 0) {
+  if (typeof memory.name === 'string' && memory.name.length > 0) {
     out.add(memory.name);
   }
-  const body = memory && typeof memory.body === 'string' ? memory.body : '';
+  const body = typeof memory.body === 'string' ? memory.body : '';
   const stripped = stripFences(body);
 
   // First H2/H3 heading text (≥ 4 chars).
@@ -150,10 +159,17 @@ function extractAuto(memory) {
 
 function extractSignals(memory) {
   if (!memory) return [];
-  const declared =
-    memory.meta && Array.isArray(memory.meta.cite_signals)
-      ? memory.meta.cite_signals.filter((s) => typeof s === 'string' && s.length > 0)
-      : [];
+  // Prefer the top-level normalized `citeSignals` array (memory-store coerces
+  // both scalar and list YAML forms here). Fall back to raw `meta.cite_signals`
+  // for memories that bypass the normalizer.
+  const source = Array.isArray(memory.citeSignals)
+    ? memory.citeSignals
+    : Array.isArray(memory.meta && memory.meta.cite_signals)
+      ? memory.meta.cite_signals
+      : null;
+  const declared = source
+    ? source.filter((s) => typeof s === 'string' && s.length > 0)
+    : [];
   if (declared.length > 0) return declared.slice();
   return extractAuto(memory);
 }

--- a/plugins/synapsys/lib/telemetry.js
+++ b/plugins/synapsys/lib/telemetry.js
@@ -37,11 +37,23 @@ function isDisabled(memory) {
   return false;
 }
 
+// Whitelist filename characters so an attacker-controlled session_id (or one
+// containing path separators / "..") can never make appendFileSync escape
+// the telemetry directory. Anything containing characters outside [A-Za-z0-9._-]
+// — including '/', '\\', or "..", and leading dots used to hide files — falls
+// back to the unknown-session bucket.
+const SAFE_SESSION_ID = /^[A-Za-z0-9._-]{1,128}$/;
+
 function resolveSessionId(payload) {
-  if (payload && typeof payload.session_id === 'string' && payload.session_id) {
-    return payload.session_id;
+  if (!payload || typeof payload.session_id !== 'string' || !payload.session_id) {
+    return '_unknown-session';
   }
-  return '_unknown-session';
+  const candidate = payload.session_id;
+  if (!SAFE_SESSION_ID.test(candidate)) return '_unknown-session';
+  if (candidate.startsWith('.') || candidate === '..' || candidate.includes('..')) {
+    return '_unknown-session';
+  }
+  return candidate;
 }
 
 function unknownSessionToken() {

--- a/plugins/synapsys/lib/telemetry.js
+++ b/plugins/synapsys/lib/telemetry.js
@@ -174,6 +174,14 @@ function extractSignals(memory) {
   return extractAuto(memory);
 }
 
+function findFirstSignal(signals, responseText) {
+  for (const sig of signals) {
+    if (typeof sig !== 'string' || sig.length === 0) continue;
+    if (responseText.includes(sig)) return sig;
+  }
+  return undefined;
+}
+
 function scanForCitations(memories, responseText) {
   const results = [];
   if (typeof responseText !== 'string' || responseText.length === 0) return results;
@@ -181,15 +189,7 @@ function scanForCitations(memories, responseText) {
 
   for (const memory of memories) {
     if (!memory || isDisabled(memory)) continue;
-    const signals = extractSignals(memory);
-    let matched;
-    for (const sig of signals) {
-      if (typeof sig !== 'string' || sig.length === 0) continue;
-      if (responseText.includes(sig)) {
-        matched = sig;
-        break;
-      }
-    }
+    const matched = findFirstSignal(extractSignals(memory), responseText);
     if (matched !== undefined) {
       const capped = matched.length > MATCH_CAP ? matched.slice(0, MATCH_CAP) : matched;
       results.push({ memory, match: capped });

--- a/plugins/synapsys/lib/telemetry.js
+++ b/plugins/synapsys/lib/telemetry.js
@@ -1,0 +1,193 @@
+'use strict';
+
+/**
+ * synapsys telemetry — per-session JSONL writer + cite scanner.
+ *
+ * Public API:
+ *   - recordFired(memory, payload, reason)
+ *   - recordCited(memory, payload, match)
+ *   - scanForCitations(memories, responseText) -> [{memory, match}]
+ *   - extractSignals(memory) -> string[]
+ *   - resolveSessionId(payload) -> string
+ *   - telemetryDir() -> string
+ *   - isDisabled(memory) -> boolean
+ *
+ * All disk-touching ops are wrapped in inner try/catch — fail-open.
+ * Restricted to node:fs, node:path, node:os.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const PROCESS_START_MS = Date.now();
+const MATCH_CAP = 200;
+
+function telemetryDir() {
+  return path.join(os.homedir(), '.claude', 'synapsys', '.telemetry');
+}
+
+function isDisabled(memory) {
+  if (process.env.SYNAPSYS_TELEMETRY === '0') return true;
+  if (memory && memory.meta && memory.meta.telemetry === false) return true;
+  return false;
+}
+
+function resolveSessionId(payload) {
+  if (payload && typeof payload.session_id === 'string' && payload.session_id) {
+    return payload.session_id;
+  }
+  return '_unknown-session';
+}
+
+function unknownSessionToken() {
+  return `${process.pid}-${PROCESS_START_MS}`;
+}
+
+function ensureDir() {
+  try {
+    const dir = telemetryDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const gi = path.join(dir, '.gitignore');
+    if (!fs.existsSync(gi)) {
+      fs.writeFileSync(gi, '*\n');
+    }
+    return dir;
+  } catch {
+    return undefined;
+  }
+}
+
+function sessionFilePath(sessionId) {
+  return path.join(telemetryDir(), `${sessionId}.jsonl`);
+}
+
+function writeLine(sessionId, record) {
+  try {
+    const dir = ensureDir();
+    if (!dir) return;
+    const file = sessionFilePath(sessionId);
+    fs.appendFileSync(file, JSON.stringify(record) + '\n');
+  } catch {
+    // fail-open
+  }
+}
+
+function recordFired(memory, payload, reason) {
+  try {
+    if (!memory || isDisabled(memory)) return;
+    const sessionId = resolveSessionId(payload);
+    let finalReason = reason;
+    if (sessionId === '_unknown-session') {
+      const token = unknownSessionToken();
+      finalReason = reason ? `${reason} ${token}` : token;
+    }
+    const record = {
+      ts: new Date().toISOString(),
+      memory: memory.name,
+      event: 'fired',
+      reason: finalReason,
+    };
+    writeLine(sessionId, record);
+  } catch {
+    // fail-open
+  }
+}
+
+function recordCited(memory, payload, match) {
+  try {
+    if (!memory || isDisabled(memory)) return;
+    const sessionId = resolveSessionId(payload);
+    const cappedMatch =
+      typeof match === 'string' && match.length > MATCH_CAP
+        ? match.slice(0, MATCH_CAP)
+        : match;
+    const record = {
+      ts: new Date().toISOString(),
+      memory: memory.name,
+      event: 'cited',
+      match: cappedMatch,
+    };
+    writeLine(sessionId, record);
+  } catch {
+    // fail-open
+  }
+}
+
+/**
+ * Strip fenced code blocks from a markdown body so we don't auto-extract
+ * identifiers from inside them.
+ */
+function stripFences(body) {
+  if (typeof body !== 'string') return '';
+  return body.replace(/```[\s\S]*?```/g, '');
+}
+
+function extractAuto(memory) {
+  const out = new Set();
+  if (memory && typeof memory.name === 'string' && memory.name.length > 0) {
+    out.add(memory.name);
+  }
+  const body = memory && typeof memory.body === 'string' ? memory.body : '';
+  const stripped = stripFences(body);
+
+  // First H2/H3 heading text (≥ 4 chars).
+  const headingMatch = stripped.match(/^[ \t]*#{2,3}[ \t]+(.+?)[ \t]*$/m);
+  if (headingMatch) {
+    const headingText = headingMatch[1].trim();
+    if (headingText.length >= 4) out.add(headingText);
+  }
+
+  // Backticked identifiers: single-backticked, ≥ 2 chars, no newlines.
+  const ident = /`([^`\n]{2,})`/g;
+  let m;
+  while ((m = ident.exec(stripped)) !== null) {
+    out.add(m[1]);
+  }
+
+  return Array.from(out);
+}
+
+function extractSignals(memory) {
+  if (!memory) return [];
+  const declared =
+    memory.meta && Array.isArray(memory.meta.cite_signals)
+      ? memory.meta.cite_signals.filter((s) => typeof s === 'string' && s.length > 0)
+      : [];
+  if (declared.length > 0) return declared.slice();
+  return extractAuto(memory);
+}
+
+function scanForCitations(memories, responseText) {
+  const results = [];
+  if (typeof responseText !== 'string' || responseText.length === 0) return results;
+  if (!Array.isArray(memories)) return results;
+
+  for (const memory of memories) {
+    if (!memory || isDisabled(memory)) continue;
+    const signals = extractSignals(memory);
+    let matched;
+    for (const sig of signals) {
+      if (typeof sig !== 'string' || sig.length === 0) continue;
+      if (responseText.includes(sig)) {
+        matched = sig;
+        break;
+      }
+    }
+    if (matched !== undefined) {
+      const capped = matched.length > MATCH_CAP ? matched.slice(0, MATCH_CAP) : matched;
+      results.push({ memory, match: capped });
+    }
+  }
+  return results;
+}
+
+module.exports = {
+  recordFired,
+  recordCited,
+  scanForCitations,
+  extractSignals,
+  resolveSessionId,
+  telemetryDir,
+  isDisabled,
+};

--- a/plugins/synapsys/scripts/synapsys-stats.js
+++ b/plugins/synapsys/scripts/synapsys-stats.js
@@ -68,27 +68,31 @@ function readJsonlInWindow(file, cutoffMs) {
   return out;
 }
 
-function aggregate(cwd, { windowMs }) {
-  const cutoff = Date.now() - windowMs;
-  const stores = discoverStores(cwd);
-  const counts = new Map(); // name → { fired, cited }
+function collectKnownMemoryNames(stores) {
   const known = new Set();
-
   for (const store of stores) {
     for (const mem of listMemoriesFromStore(store)) {
       if (mem && mem.name) known.add(mem.name);
     }
   }
+  return known;
+}
+
+function tallyEvent(counts, ev) {
+  if (!ev || !ev.memory || !ev.event) return;
+  const c = counts.get(ev.memory) || { fired: 0, cited: 0 };
+  if (ev.event === 'fired') c.fired += 1;
+  else if (ev.event === 'cited') c.cited += 1;
+  counts.set(ev.memory, c);
+}
+
+function aggregate(cwd, { windowMs }) {
+  const cutoff = Date.now() - windowMs;
+  const known = collectKnownMemoryNames(discoverStores(cwd));
+  const counts = new Map(); // name → { fired, cited }
 
   for (const file of listJsonlFiles(telemetryDir())) {
-    const events = readJsonlInWindow(file, cutoff);
-    for (const ev of events) {
-      if (!ev || !ev.memory || !ev.event) continue;
-      const c = counts.get(ev.memory) || { fired: 0, cited: 0 };
-      if (ev.event === 'fired') c.fired += 1;
-      else if (ev.event === 'cited') c.cited += 1;
-      counts.set(ev.memory, c);
-    }
+    for (const ev of readJsonlInWindow(file, cutoff)) tallyEvent(counts, ev);
   }
 
   // Include zero-fire known memories so Never-fired can list them.

--- a/plugins/synapsys/scripts/synapsys-stats.js
+++ b/plugins/synapsys/scripts/synapsys-stats.js
@@ -18,6 +18,7 @@ const {
   discoverStores,
   listMemoriesFromStore,
 } = require(require('node:path').join(__dirname, '..', 'lib', 'script-bootstrap'));
+const { telemetryDir } = require(require('node:path').join(__dirname, '..', 'lib', 'telemetry'));
 
 const NOISE_FIRED_THRESHOLD = 10;
 
@@ -26,10 +27,6 @@ function parseWindow(spec) {
   const m = s.match(/^(\d+)d$/i);
   const days = m ? parseInt(m[1], 10) : 7;
   return days * 24 * 60 * 60 * 1000;
-}
-
-function telemetryDirFor(store) {
-  return path.join(store.dir, '.telemetry');
 }
 
 function listJsonlFiles(telDir) {
@@ -81,15 +78,16 @@ function aggregate(cwd, { windowMs }) {
     for (const mem of listMemoriesFromStore(store)) {
       if (mem && mem.name) known.add(mem.name);
     }
-    for (const file of listJsonlFiles(telemetryDirFor(store))) {
-      const events = readJsonlInWindow(file, cutoff);
-      for (const ev of events) {
-        if (!ev || !ev.memory || !ev.event) continue;
-        const c = counts.get(ev.memory) || { fired: 0, cited: 0 };
-        if (ev.event === 'fired') c.fired += 1;
-        else if (ev.event === 'cited') c.cited += 1;
-        counts.set(ev.memory, c);
-      }
+  }
+
+  for (const file of listJsonlFiles(telemetryDir())) {
+    const events = readJsonlInWindow(file, cutoff);
+    for (const ev of events) {
+      if (!ev || !ev.memory || !ev.event) continue;
+      const c = counts.get(ev.memory) || { fired: 0, cited: 0 };
+      if (ev.event === 'fired') c.fired += 1;
+      else if (ev.event === 'cited') c.cited += 1;
+      counts.set(ev.memory, c);
     }
   }
 

--- a/plugins/synapsys/scripts/synapsys-stats.js
+++ b/plugins/synapsys/scripts/synapsys-stats.js
@@ -78,6 +78,21 @@ function collectKnownMemoryNames(stores) {
   return known;
 }
 
+// Memories whose only event is Stop fire on every assistant turn by design,
+// so they would otherwise dominate Noise candidates even when working as
+// intended. Build a Set of their names so the noise filter can skip them.
+function collectStopOnlyMemoryNames(stores) {
+  const stopOnly = new Set();
+  for (const store of stores) {
+    for (const mem of listMemoriesFromStore(store)) {
+      if (!mem || !mem.name || !Array.isArray(mem.events)) continue;
+      const events = mem.events.filter((e) => typeof e === 'string' && e.length > 0);
+      if (events.length === 1 && events[0] === 'Stop') stopOnly.add(mem.name);
+    }
+  }
+  return stopOnly;
+}
+
 function tallyEvent(counts, ev) {
   if (!ev || !ev.memory || !ev.event) return;
   const c = counts.get(ev.memory) || { fired: 0, cited: 0 };
@@ -88,7 +103,9 @@ function tallyEvent(counts, ev) {
 
 function aggregate(cwd, { windowMs }) {
   const cutoff = Date.now() - windowMs;
-  const known = collectKnownMemoryNames(discoverStores(cwd));
+  const stores = discoverStores(cwd);
+  const known = collectKnownMemoryNames(stores);
+  const stopOnly = collectStopOnlyMemoryNames(stores);
   const counts = new Map(); // name → { fired, cited }
 
   for (const file of listJsonlFiles(telemetryDir())) {
@@ -105,6 +122,7 @@ function aggregate(cwd, { windowMs }) {
     fired: c.fired,
     cited: c.cited,
     known: known.has(name),
+    stopOnly: stopOnly.has(name),
   }));
 
   return { perMemory, known: Array.from(known) };
@@ -120,8 +138,11 @@ function formatSections(stats, { color = false } = {}) {
       return b.fired * b.cited - a.fired * a.cited;
     });
 
+  // Stop-only memories fire on every assistant turn by design; the
+  // "tighten triggers" advice does not apply to them, so they're excluded
+  // from noise classification regardless of fired count.
   const noise = perMemory
-    .filter((m) => m.fired >= NOISE_FIRED_THRESHOLD && m.cited === 0)
+    .filter((m) => !m.stopOnly && m.fired >= NOISE_FIRED_THRESHOLD && m.cited === 0)
     .sort((a, b) => b.fired - a.fired);
 
   const never = perMemory

--- a/plugins/synapsys/scripts/synapsys-stats.js
+++ b/plugins/synapsys/scripts/synapsys-stats.js
@@ -131,8 +131,13 @@ function aggregate(cwd, { windowMs }) {
 function formatSections(stats, { color = false } = {}) {
   const { perMemory } = stats;
 
+  // All three sections must restrict to memories discovered via --cwd
+  // (`m.known`). The global ~/.claude/synapsys/.telemetry/ aggregates events
+  // from every project, so without this filter Top influencers and Noise
+  // candidates would surface deleted or other-project memories that the
+  // current store no longer (or never) owned.
   const top = perMemory
-    .filter((m) => m.cited > 0)
+    .filter((m) => m.known && m.cited > 0)
     .sort((a, b) => {
       if (b.cited !== a.cited) return b.cited - a.cited;
       return b.fired * b.cited - a.fired * a.cited;
@@ -142,7 +147,7 @@ function formatSections(stats, { color = false } = {}) {
   // "tighten triggers" advice does not apply to them, so they're excluded
   // from noise classification regardless of fired count.
   const noise = perMemory
-    .filter((m) => !m.stopOnly && m.fired >= NOISE_FIRED_THRESHOLD && m.cited === 0)
+    .filter((m) => m.known && !m.stopOnly && m.fired >= NOISE_FIRED_THRESHOLD && m.cited === 0)
     .sort((a, b) => b.fired - a.fired);
 
   const never = perMemory

--- a/plugins/synapsys/scripts/synapsys-stats.js
+++ b/plugins/synapsys/scripts/synapsys-stats.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * synapsys:stats — aggregate per-memory telemetry from
+ * `.telemetry/*.jsonl` files across discoverable stores and emit three
+ * sections (Top influencers / Noise candidates / Never-fired) within
+ * a time window selectable via `--last=<Nd>` (default `7d`).
+ *
+ * Pure helpers (parseWindow, readJsonlInWindow, aggregate, formatSections)
+ * are exported for unit tests; CLI runs only when invoked directly.
+ */
+
+const {
+  fs,
+  path,
+  setupCli,
+  discoverStores,
+  listMemoriesFromStore,
+} = require(require('node:path').join(__dirname, '..', 'lib', 'script-bootstrap'));
+
+const NOISE_FIRED_THRESHOLD = 10;
+
+function parseWindow(spec) {
+  const s = String(spec || '7d').trim();
+  const m = s.match(/^(\d+)d$/i);
+  const days = m ? parseInt(m[1], 10) : 7;
+  return days * 24 * 60 * 60 * 1000;
+}
+
+function telemetryDirFor(store) {
+  return path.join(store.dir, '.telemetry');
+}
+
+function listJsonlFiles(telDir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(telDir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((n) => n.endsWith('.jsonl'))
+    .map((n) => path.join(telDir, n));
+}
+
+function readJsonlInWindow(file, cutoffMs) {
+  let stat;
+  try {
+    stat = fs.statSync(file);
+  } catch {
+    return [];
+  }
+  if (stat.mtimeMs < cutoffMs) return [];
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      out.push(JSON.parse(trimmed));
+    } catch {
+      // malformed line — skip, fail-open
+    }
+  }
+  return out;
+}
+
+function aggregate(cwd, { windowMs }) {
+  const cutoff = Date.now() - windowMs;
+  const stores = discoverStores(cwd);
+  const counts = new Map(); // name → { fired, cited }
+  const known = new Set();
+
+  for (const store of stores) {
+    for (const mem of listMemoriesFromStore(store)) {
+      if (mem && mem.name) known.add(mem.name);
+    }
+    for (const file of listJsonlFiles(telemetryDirFor(store))) {
+      const events = readJsonlInWindow(file, cutoff);
+      for (const ev of events) {
+        if (!ev || !ev.memory || !ev.event) continue;
+        const c = counts.get(ev.memory) || { fired: 0, cited: 0 };
+        if (ev.event === 'fired') c.fired += 1;
+        else if (ev.event === 'cited') c.cited += 1;
+        counts.set(ev.memory, c);
+      }
+    }
+  }
+
+  // Include zero-fire known memories so Never-fired can list them.
+  for (const name of known) {
+    if (!counts.has(name)) counts.set(name, { fired: 0, cited: 0 });
+  }
+
+  const perMemory = Array.from(counts.entries()).map(([name, c]) => ({
+    name,
+    fired: c.fired,
+    cited: c.cited,
+    known: known.has(name),
+  }));
+
+  return { perMemory, known: Array.from(known) };
+}
+
+function formatSections(stats, { color = false } = {}) {
+  const { perMemory } = stats;
+
+  const top = perMemory
+    .filter((m) => m.cited > 0)
+    .sort((a, b) => {
+      if (b.cited !== a.cited) return b.cited - a.cited;
+      return b.fired * b.cited - a.fired * a.cited;
+    });
+
+  const noise = perMemory
+    .filter((m) => m.fired >= NOISE_FIRED_THRESHOLD && m.cited === 0)
+    .sort((a, b) => b.fired - a.fired);
+
+  const never = perMemory
+    .filter((m) => m.known && m.fired === 0 && m.cited === 0)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const lines = [];
+  lines.push('Top influencers (fired × cited):');
+  if (top.length === 0) lines.push('  (none)');
+  for (const m of top) {
+    const ratio = m.fired === 0 ? 0 : (m.cited / m.fired).toFixed(2);
+    lines.push(`  ${m.name}   fired:${m.fired}  cited:${m.cited}  influence:${ratio}  keep`);
+  }
+  lines.push('');
+  lines.push('Noise candidates (fired ≥10, cited:0):');
+  if (noise.length === 0) lines.push('  (none)');
+  for (const m of noise) {
+    lines.push(`  ${m.name}   fired:${m.fired}  cited:${m.cited}  narrow trigger or delete`);
+  }
+  lines.push('');
+  lines.push('Never-fired (consider deletion or session-start docs instead):');
+  if (never.length === 0) lines.push('  (none)');
+  for (const m of never) {
+    lines.push(`  ${m.name}   fired:0  cited:0`);
+  }
+  void color;
+  return lines.join('\n') + '\n';
+}
+
+function main() {
+  const { flag, cwd } = setupCli();
+  const windowMs = parseWindow(flag('last') || '7d');
+  const useColor = !flag('no-color');
+  let stats;
+  try {
+    stats = aggregate(cwd, { windowMs });
+  } catch (err) {
+    process.stderr.write(`synapsys:stats: aggregation error: ${err.message}\n`);
+    stats = { perMemory: [], known: [] };
+  }
+  if (flag('json')) {
+    process.stdout.write(JSON.stringify(stats, null, 2) + '\n');
+  } else {
+    process.stdout.write(formatSections(stats, { color: useColor }));
+  }
+  process.exit(0);
+}
+
+module.exports = {
+  parseWindow,
+  readJsonlInWindow,
+  aggregate,
+  formatSections,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/plugins/synapsys/skills/stats/SKILL.md
+++ b/plugins/synapsys/skills/stats/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: stats
+description: Aggregate Synapsys telemetry into Top influencers, Noise candidates, and Never-fired sections. Use when the user says "stats", "synapsys stats", "memory stats", "show telemetry", "which memories are noisy", "which memories never fire", or asks to audit memory effectiveness over a time window.
+argument-hint: [--last=<7d|30d|Nd>] [--cwd=<path>] [--no-color]
+user-invocable: true
+allowed-tools: Bash
+---
+
+# Stats
+
+Run the script. Pass through its output verbatim. It prints three sections (Top influencers / Noise candidates / Never-fired) plus a header line summarizing the window. No agent post-processing.
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/synapsys-stats.js" $ARGUMENTS
+```
+
+Optional flags (pass through if user provided them):
+- `--last=<7d|30d|Nd>` — time window for the aggregation (defaults to `7d`); filters telemetry `.jsonl` files by `mtime`
+- `--cwd=<path>` — override the discovery cwd (defaults to `process.cwd()`)
+- `--no-color` — disable ANSI color output (useful for piping or CI)
+
+### Sections
+
+- **Top influencers** — memories sorted by `cited` count desc, tiebroken by `fired × cited`. These are the memories that fired AND were referenced in the assistant's response.
+- **Noise candidates** — memories with `fired >= 10 AND cited == 0`. Strong signal that the trigger fires too often without being useful.
+- **Never-fired** — memories discovered in active stores but with zero `fired` events in the window. Either dead weight or simply not triggered yet.
+
+The script handles empty telemetry directories and malformed JSONL lines (fail-open). Exit code is always `0`. Do not narrate the output; just run and exit.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the hook dispatcher and writes under the user home directory, but telemetry is fail-open, session IDs are sanitized, and injection behavior is preserved when writes fail.
> 
> **Overview**
> Adds **per-session telemetry** for Synapsys: when memories inject, the dispatcher writes **`fired`** JSONL lines under `~/.claude/synapsys/.telemetry/`; on **`Stop`**, it scans the assistant reply (or `transcript_path`) for **`cite_signals`** / auto-extracted tokens and records **`cited`** for memories that fired earlier in the same session. Writes stay **fail-open**; opt out via `SYNAPSYS_TELEMETRY=0` or per-memory `telemetry: false`.
> 
> **`memory-store`** now normalizes **`cite_signals`** (comma-separated / bracket forms) and **`telemetry`** onto top-level fields. **`synapsys-stats.js`** and **`/synapsys:stats`** aggregate windowed JSONL into **Top influencers**, **Noise candidates**, and **Never-fired**, scoped to memories discovered for `--cwd` (excluding Stop-only noise and cross-project ghost rows). README documents the lifecycle; broad unit/integration tests cover edge cases (unknown session, same-turn Stop cites, YAML list parsing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca076dace88e085a9facdaa07501d576e6e9dbbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

closes #512 