### PR TITLE
fix(hooks): resolvePluginRoot misses marketplace install layout

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/resolve-plugin-root-hook.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/resolve-plugin-root-hook.test.js
@@ -13,11 +13,49 @@ const fs = require('fs');
 const os = require('os');
 
 const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'resolve-plugin-root-hook.js');
+const {
+  resolvePluginRoot,
+  resolvePluginRootHonouringEnv,
+} = require('../../work/lib/resolve-plugin-root');
 
 // Track temp dirs for cleanup
 const TEMP_DIRS = [];
+
+/**
+ * Build a realistic cache install fixture mirroring the real on-disk layout:
+ *   <tmp>/cache/work-workflow/work-workflow/3.20.2/workflows/work
+ * Returns { base, pluginRoot } where pluginRoot is the leaf containing workflows/work.
+ */
+function makeFixtureCacheInstall() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'cache-install-'));
+  TEMP_DIRS.push(base);
+  const pluginRoot = path.join(base, 'cache', 'work-workflow', 'work-workflow', '3.20.2');
+  fs.mkdirSync(path.join(pluginRoot, 'workflows', 'work'), { recursive: true });
+  return { base, pluginRoot };
+}
+
+/**
+ * Build a realistic marketplace install fixture mirroring the real layout:
+ *   <tmp>/marketplaces/work-workflow/plugins/work/workflows/work
+ * Returns { base, marketplaceDir, pluginRoot }:
+ *   base           = parent plugins-base dir (CLAUDE_PLUGIN_ROOT parent shape)
+ *   marketplaceDir = <base>/marketplaces/work-workflow (leaf shape env)
+ *   pluginRoot     = <base>/marketplaces/work-workflow/plugins/work (expected resolution)
+ */
+function makeFixtureMarketplaceInstall() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'marketplace-install-'));
+  TEMP_DIRS.push(base);
+  const marketplaceDir = path.join(base, 'marketplaces', 'work-workflow');
+  const pluginRoot = path.join(marketplaceDir, 'plugins', 'work');
+  fs.mkdirSync(path.join(pluginRoot, 'workflows', 'work'), { recursive: true });
+  return { base, marketplaceDir, pluginRoot };
+}
+
+/**
+ * Build a parent plugins-base dir containing the cache-style parent layout
+ * (marketplaces/work-workflow/workflows/work) — preserved cache-parent shape.
+ */
 function makeFixturePluginsBase() {
-  // Builds a parent plugins-base dir containing marketplaces/work-workflow/workflows/work
   const base = fs.mkdtempSync(path.join(os.tmpdir(), 'plugins-base-'));
   TEMP_DIRS.push(base);
   fs.mkdirSync(path.join(base, 'marketplaces', 'work-workflow', 'workflows', 'work'), {
@@ -25,13 +63,17 @@ function makeFixturePluginsBase() {
   });
   return base;
 }
+
+/**
+ * Build a leaf plugin dir that directly contains workflows/work (cache-leaf shape).
+ */
 function makeFixtureLeafPlugin() {
-  // Builds a leaf plugin dir that directly contains workflows/work
   const leaf = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-leaf-'));
   TEMP_DIRS.push(leaf);
   fs.mkdirSync(path.join(leaf, 'workflows', 'work'), { recursive: true });
   return leaf;
 }
+
 // Shared real-leaf fixture used as the default CLAUDE_PLUGIN_ROOT for tests
 // that don't override it. resolvePluginRoot() requires the env path to actually
 // contain workflows/work, so a real directory is needed in place of a fake path.
@@ -178,8 +220,9 @@ describe('resolve-plugin-root-hook', () => {
     assert.ok(stderr.includes('/path/with/$pecial/chars'));
   });
 
-  it('env var set to parent plugins-base directory is resolved to the marketplace subdir', async () => {
-    // env var = parent plugins-base dir; hook must probe down to marketplaces/work-workflow
+  it('cache-install behaviour is preserved (parent shape): env at parent plugins-base resolves to marketplaces/work-workflow', async () => {
+    // cache-install behaviour preserved (parent shape): env at parent base,
+    // marketplaces/work-workflow/workflows/work exists → return marketplace dir.
     const pluginsBase = makeFixturePluginsBase();
     const expectedLeaf = path.join(pluginsBase, 'marketplaces', 'work-workflow');
     const { code, stderr } = await runHook(
@@ -191,15 +234,15 @@ describe('resolve-plugin-root-hook', () => {
       stderr.includes(expectedLeaf),
       `expected stderr to include leaf marketplace path ${expectedLeaf}, got:\n${stderr}`
     );
-    // Should NOT use the bare parent plugins-base path as the rewrite root
     assert.ok(
       !stderr.includes(`node ${pluginsBase}/hooks/test.js`),
       `hook must not rewrite to bare parent plugins-base dir, got:\n${stderr}`
     );
   });
 
-  it('env var set to leaf plugin directory is honoured as-is', async () => {
-    // env var = leaf plugin dir already containing workflows/work → use as-is
+  it('cache-install behaviour is preserved (leaf shape): env at leaf plugin dir is honoured as-is', async () => {
+    // cache-install behaviour preserved (leaf shape): env points at a dir that
+    // already contains workflows/work → use verbatim.
     const leaf = makeFixtureLeafPlugin();
     const { code, stderr } = await runHook(
       { tool_input: { command: 'node ${CLAUDE_PLUGIN_ROOT}/hooks/test.js' } },
@@ -212,20 +255,114 @@ describe('resolve-plugin-root-hook', () => {
     );
   });
 
-  it('env var unset falls back to __dirname probing', async () => {
-    // env var unset → must fall back via resolvePluginRoot(__dirname, 3) probing
+  it('cache install fixture mirrors real layout cache/work-workflow/<ver>/workflows/work', async () => {
+    // Realistic fixture path mirrors ~/.claude/plugins/cache/work-workflow/work-workflow/3.20.2.
+    const { pluginRoot } = makeFixtureCacheInstall();
+    assert.ok(
+      fs.existsSync(path.join(pluginRoot, 'workflows', 'work')),
+      `expected cache install fixture pluginRoot ${pluginRoot} to contain workflows/work`
+    );
+    // resolvePluginRoot with env pointing at the cache-leaf must return it verbatim.
+    const prev = process.env.CLAUDE_PLUGIN_ROOT;
+    process.env.CLAUDE_PLUGIN_ROOT = pluginRoot;
+    try {
+      assert.strictEqual(resolvePluginRoot(), pluginRoot);
+    } finally {
+      process.env.CLAUDE_PLUGIN_ROOT = prev;
+    }
+  });
+
+  it('env unset falls back to __dirname probing', async () => {
     const { code, stderr } = await runHook(
       { tool_input: { command: 'node ${CLAUDE_PLUGIN_ROOT}/hooks/test.js' } },
       { CLAUDE_PLUGIN_ROOT: '' }
     );
     assert.strictEqual(code, 2);
-    // Resolved root must point at the actual plugin dir containing workflows/work
     const match = stderr.match(/node (\S+)\/hooks\/test\.js/);
     assert.ok(match, `expected rewritten command in stderr, got:\n${stderr}`);
     const resolvedRoot = match[1];
     assert.ok(
       fs.existsSync(path.join(resolvedRoot, 'workflows', 'work')),
       `expected resolved root ${resolvedRoot} to contain workflows/work`
+    );
+  });
+
+  it('env set to unrelated path falls through without false match: resolvePluginRoot returns null; honouring wrapper returns env verbatim', () => {
+    // Unrelated path (no workflows/work anywhere under it) → resolvePluginRoot
+    // returns null; resolvePluginRootHonouringEnv returns env verbatim.
+    const unrelated = fs.mkdtempSync(path.join(os.tmpdir(), 'unrelated-'));
+    TEMP_DIRS.push(unrelated);
+    const prev = process.env.CLAUDE_PLUGIN_ROOT;
+    process.env.CLAUDE_PLUGIN_ROOT = unrelated;
+    try {
+      assert.strictEqual(resolvePluginRoot(), null);
+      assert.strictEqual(resolvePluginRootHonouringEnv(), path.resolve(unrelated));
+    } finally {
+      process.env.CLAUDE_PLUGIN_ROOT = prev;
+    }
+  });
+
+  it('env var points at marketplace parent plugins-base dir resolves to marketplaces/work-workflow/plugins/work leaf', () => {
+    // AC1: parent-base marketplace shape — env at <tmp> parent base, real layout
+    // <tmp>/marketplaces/work-workflow/plugins/work/workflows/work exists →
+    // resolvePluginRoot must return <tmp>/marketplaces/work-workflow/plugins/work.
+    const { base, pluginRoot } = makeFixtureMarketplaceInstall();
+    const prev = process.env.CLAUDE_PLUGIN_ROOT;
+    process.env.CLAUDE_PLUGIN_ROOT = base;
+    try {
+      assert.strictEqual(resolvePluginRoot(), pluginRoot);
+    } finally {
+      process.env.CLAUDE_PLUGIN_ROOT = prev;
+    }
+  });
+
+  it('env var points at marketplace leaf (work-workflow dir) resolves to plugins/work subdir leaf', () => {
+    // AC2: leaf marketplace shape — env at <tmp>/marketplaces/work-workflow,
+    // <env>/plugins/work/workflows/work exists → return <env>/plugins/work.
+    const { marketplaceDir, pluginRoot } = makeFixtureMarketplaceInstall();
+    const prev = process.env.CLAUDE_PLUGIN_ROOT;
+    process.env.CLAUDE_PLUGIN_ROOT = marketplaceDir;
+    try {
+      assert.strictEqual(resolvePluginRoot(), pluginRoot);
+    } finally {
+      process.env.CLAUDE_PLUGIN_ROOT = prev;
+    }
+  });
+
+  it('PreToolUse Bash hook rewrites ${CLAUDE_PLUGIN_ROOT} using the marketplace install path (parent-base env value)', async () => {
+    // AC6: hook spawned with env=parent base on a real marketplace fixture
+    // must rewrite ${CLAUDE_PLUGIN_ROOT} to the plugins/work leaf.
+    const { base, pluginRoot } = makeFixtureMarketplaceInstall();
+    const { code, stderr } = await runHook(
+      { tool_input: { command: 'node ${CLAUDE_PLUGIN_ROOT}/hooks/test.js' } },
+      { CLAUDE_PLUGIN_ROOT: base }
+    );
+    assert.strictEqual(code, 2);
+    assert.ok(
+      stderr.includes(`node ${pluginRoot}/hooks/test.js`),
+      `expected hook to rewrite to marketplace pluginRoot ${pluginRoot}, got:\n${stderr}`
+    );
+    assert.ok(
+      !stderr.includes(`node ${base}/hooks/test.js`),
+      `hook must not rewrite to bare parent plugins-base dir, got:\n${stderr}`
+    );
+  });
+
+  it('PreToolUse Bash hook honours the marketplace leaf env value and rewrites to plugins/work leaf', async () => {
+    // AC7: hook spawned with env=marketplace leaf must rewrite to plugins/work.
+    const { marketplaceDir, pluginRoot } = makeFixtureMarketplaceInstall();
+    const { code, stderr } = await runHook(
+      { tool_input: { command: 'node ${CLAUDE_PLUGIN_ROOT}/hooks/test.js' } },
+      { CLAUDE_PLUGIN_ROOT: marketplaceDir }
+    );
+    assert.strictEqual(code, 2);
+    assert.ok(
+      stderr.includes(`node ${pluginRoot}/hooks/test.js`),
+      `expected hook to rewrite to plugins/work leaf ${pluginRoot}, got:\n${stderr}`
+    );
+    assert.ok(
+      !stderr.includes(`node ${marketplaceDir}/hooks/test.js`),
+      `hook must not rewrite to bare marketplace dir, got:\n${stderr}`
     );
   });
 });

--- a/plugins/work/scripts/workflows/work/lib/resolve-plugin-root.js
+++ b/plugins/work/scripts/workflows/work/lib/resolve-plugin-root.js
@@ -22,11 +22,19 @@ const path = require('path');
 function resolvePluginRoot(callerDir, levelsUp = 2) {
   const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
   if (envRoot) {
-    // Direct: already points to the plugin
+    // cache-leaf: env already points at a dir containing workflows/work
     if (fs.existsSync(path.join(envRoot, 'workflows', 'work'))) return envRoot;
-    // Parent: points to plugins dir — resolve to marketplace subdir
-    const mp = path.join(envRoot, 'marketplaces', 'work-workflow');
-    if (fs.existsSync(path.join(mp, 'workflows', 'work'))) return mp;
+    // cache-parent: env points at the plugins-base dir, marketplace cache layout
+    const cacheParent = path.join(envRoot, 'marketplaces', 'work-workflow');
+    if (fs.existsSync(path.join(cacheParent, 'workflows', 'work'))) return cacheParent;
+    // marketplace-leaf: env points at marketplaces/work-workflow with the real
+    // on-disk layout nested under plugins/work
+    const mpLeaf = path.join(envRoot, 'plugins', 'work');
+    if (fs.existsSync(path.join(mpLeaf, 'workflows', 'work'))) return mpLeaf;
+    // marketplace-parent: env points at the parent plugins-base dir with the
+    // real marketplace install layout (marketplaces/work-workflow/plugins/work)
+    const mpParent = path.join(envRoot, 'marketplaces', 'work-workflow', 'plugins', 'work');
+    if (fs.existsSync(path.join(mpParent, 'workflows', 'work'))) return mpParent;
   }
   // Fallback: resolve from caller's __dirname
   if (callerDir) {


### PR DESCRIPTION
## Summary

- Extended `resolvePluginRoot` in `resolve-plugin-root.js` with two new probe branches for the marketplace install layout (marketplace-leaf and marketplace-parent shapes), fixing the root cause of #526 that PR #496 only appeared to fix.
- Rewrote test fixtures in `resolve-plugin-root-hook.test.js` to mirror real cache and marketplace on-disk layouts; added acceptance tests for AC1 (parent-base) and AC2 (leaf) marketplace shapes.
- 22 tests, all green; public API unchanged.

## Existing Behavior

- `resolvePluginRoot` probed only two install-layout shapes: cache-leaf (`<envRoot>/workflows/work`) and cache-parent (`<envRoot>/marketplaces/work-workflow/workflows/work`).
- Neither shape matches the real marketplace install layout, where the plugin is nested under `plugins/work/` (e.g. `marketplaces/work-workflow/plugins/work/workflows/work`).
- When `CLAUDE_PLUGIN_ROOT` points at either the parent plugins-base dir or the marketplace leaf, both probes miss and the helper falls through to `__dirname` probing — resolving to the cache path instead.
- Test fixtures in `resolve-plugin-root-hook.test.js` asserted against a layout that does not exist on disk, making the regression invisible. This is the root cause PR #496 appeared to fix but did not.

## Intended New Behavior

- `resolvePluginRoot` now recognises two additional marketplace install shapes:
  - **marketplace-leaf**: env at `marketplaces/work-workflow`, `<envRoot>/plugins/work/workflows/work` exists — returns `<envRoot>/plugins/work`
  - **marketplace-parent**: env at the plugins-base dir, `<envRoot>/marketplaces/work-workflow/plugins/work/workflows/work` exists — returns `<envRoot>/marketplaces/work-workflow/plugins/work`
- All four install shapes (cache-leaf, cache-parent, marketplace-leaf, marketplace-parent) are probed in sequence; existing cache-install resolution is fully preserved.
- Test fixtures now mirror real on-disk layouts for cache (`cache/work-workflow/work-workflow/<version>/workflows/work`) and marketplace (`marketplaces/work-workflow/plugins/work/workflows/work`) installs.
- 22 tests pass, including AC1 (parent-base shape) and AC2 (leaf shape) acceptance tests added by this ticket.

## Brief P0 coverage

- **P0 #1:** Extend envRoot probe sequence with marketplace shapes — implemented in `plugins/work/scripts/workflows/work/lib/resolve-plugin-root.js:30-37`
- **P0 #2:** Preserve existing cache-install probe behaviour — probes at lines 25-28 unchanged; regression-tested by all 22 passing tests
- **P0 #3:** Preserve `__dirname`/`levelsUp` fallback and `resolvePluginRootHonouringEnv` semantics — unchanged code paths; covered by `resolve-plugin-root-hook.test.js:286-295`
- **P0 #4:** Replace fixtures with realistic layouts for both install types — `plugins/work/scripts/workflows/lib/__tests__/resolve-plugin-root-hook.test.js:28-70`; acceptance tests at lines 308-336
- **P0 #5:** All existing tests continue to pass — 22/22 green

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Test plan

- [ ] Run `node --test plugins/work/scripts/workflows/lib/__tests__/resolve-plugin-root-hook.test.js` — expect `pass 22`, `fail 0`
- [ ] AC1: With `CLAUDE_PLUGIN_ROOT` pointing at the parent plugins-base dir of a marketplace install, `resolvePluginRoot()` returns `<base>/marketplaces/work-workflow/plugins/work`
- [ ] AC2: With `CLAUDE_PLUGIN_ROOT` pointing at the marketplace leaf (`marketplaces/work-workflow`), `resolvePluginRoot()` returns `<leaf>/plugins/work`
- [ ] Existing cache-leaf and cache-parent shapes continue to resolve correctly (verified by full 22-test run)

### Test Results

```
tests 22 | pass 22 | fail 0 | duration 1147ms
```

## Linked tickets

- Closes #526
- Related: #284 (original symptom)
- Related: #496 (prior incomplete fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes path resolution for PreToolUse Bash `${CLAUDE_PLUGIN_ROOT}` rewrites; wrong probes could still misroute commands, but scope is limited to install-layout detection with expanded regression tests.
> 
> **Overview**
> **`resolvePluginRoot`** now recognizes marketplace installs where the real plugin lives under **`plugins/work/workflows/work`**, not only cache-style paths. When **`CLAUDE_PLUGIN_ROOT`** is the plugins-base parent or the **`marketplaces/work-workflow`** leaf, resolution returns **`.../marketplaces/work-workflow/plugins/work`** instead of missing and falling back to **`__dirname`** (which pointed Bash hooks at the wrong install).
> 
> Existing cache-leaf and cache-parent probing is unchanged in behavior; comments were aligned to those shapes. **`resolve-plugin-root-hook.test.js`** adds fixtures that mirror real cache and marketplace on-disk trees, plus unit and PreToolUse hook tests for marketplace parent/leaf env values and unrelated-path fallthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42946ec564c9fb1bd10dd71f134950c06aca05a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->