### PR TITLE
feat(maestro): throttle conductor emissions and embed pane tails

### DIFF
--- a/plugins/maestro/scripts/__tests__/maestro-autorestart.test.js
+++ b/plugins/maestro/scripts/__tests__/maestro-autorestart.test.js
@@ -406,9 +406,13 @@ test('idle helper session does not spam silence log on every tick', () => {
   const skippedLines = logLines.filter((l) =>
     l.includes('AUTO-RESTART skipped: non-work helper session')
   );
+  // Throttle change: helper-session silence emits NOTHING (was once before).
+  // The marker still resets so the detector doesn't fire every tick — that
+  // invariant is what this regression guards. The visible log line was
+  // removed because helper inactivity is not operator-actionable.
   assert.strictEqual(
     skippedLines.length,
-    1,
-    `helper silence skip should be logged ONCE across multiple ticks, not every tick — got ${skippedLines.length}\nlog:\n${logLines.join('\n')}`
+    0,
+    `helper silence skip line was removed — expected 0 occurrences, got ${skippedLines.length}\nlog:\n${logLines.join('\n')}`
   );
 });

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -46,10 +46,7 @@ function maybeAutoBootstrap(taskId) {
   try {
     const tmuxMod = require('./tmux');
     const activeSessions = tmuxMod.listSessions ? tmuxMod.listSessions() : [];
-    if (manifest.poolFullForTask(taskId, activeSessions)) {
-      alerts.log(`AUTO-BOOTSTRAP skipped for ${taskId}: owning manifest at slot cap`);
-      return false;
-    }
+    if (manifest.poolFullForTask(taskId, activeSessions)) return false;
   } catch {}
   const res = spawnSync('bash', [BOOTSTRAP_SCRIPT, taskId], {
     stdio: 'ignore',

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -18,65 +18,15 @@ const tmux = require('./tmux');
 const alerts = require('./alerts');
 const state = require('./state');
 const { headSha } = require('./detectors/gh-shared');
-const { eligibleTasks } = require('./session-shared');
 const manifest = require('./manifest');
+const { findNextEligibleTask, buildNextActionInstruction } = require('./next-task');
 const { purgeAlertCountsForTicket } = require('../../maestro-cleanup');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
 const SKILL_NAME = process.env.SKILL_NAME || 'work';
 
-const SESSION_MANIFEST_DIR =
-  process.env.MAESTRO_SESSION_DIR ||
-  path.join(process.env.HOME || '/tmp', '.cache', 'maestro', 'sessions');
 const BOOTSTRAP_SCRIPT = path.join(__dirname, '..', '..', 'maestro-bootstrap.sh');
 const REPO_NAME = process.env.REPO_NAME || 'claude-plugin-work';
-
-/**
- * Look across every orchestration manifest in ~/.cache/maestro/sessions/ for
- * the next pending task whose deps are all done. Returns { topic, taskId } or
- * null. First match wins (lowest priority across all manifests).
- */
-function readManifestSafe(file) {
-  try {
-    return JSON.parse(fs.readFileSync(file, 'utf8'));
-  } catch {
-    return null;
-  }
-}
-
-function topPendingForManifest(manifest, entry) {
-  // Reuse session-shared.eligibleTasks so the slot-freed bootstrap path and
-  // the maestro-session CLI agree on the next task (incl. default priority).
-  const ranked = eligibleTasks(Array.isArray(manifest.tasks) ? manifest.tasks : []);
-  if (ranked.length === 0) return null;
-  const top = ranked[0];
-  return {
-    topic: manifest.topic || entry.replace(/\.json$/, ''),
-    taskId: top.id,
-    priority: top.priority,
-  };
-}
-
-function findNextEligibleTask() {
-  if (!fs.existsSync(SESSION_MANIFEST_DIR)) return null;
-  let best = null;
-  // Sort manifest filenames so readdirSync iteration order is deterministic
-  // across filesystems. This gives a stable tie-break by filename when two
-  // eligible tasks share the same numeric priority (the natural tie-break
-  // here is ticket id, since manifest filenames are derived from topic/ticket).
-  const entries = fs.readdirSync(SESSION_MANIFEST_DIR).slice().sort();
-  for (const entry of entries) {
-    if (!entry.endsWith('.json')) continue;
-    const manifest = readManifestSafe(path.join(SESSION_MANIFEST_DIR, entry));
-    if (!manifest) continue;
-    const candidate = topPendingForManifest(manifest, entry);
-    if (!candidate) continue;
-    if (!best || (candidate.priority || 999) < (best.priority || 999)) {
-      best = candidate;
-    }
-  }
-  return best;
-}
 
 /**
  * Optionally bootstrap a fresh tmux + worktree for the next ticket. Returns
@@ -185,18 +135,24 @@ function checkCiGateFreedGuard({ session, ticket, worktree }) {
     state.clear(ticket, 'ci-gate-freed');
     return { skip: false };
   }
-  alerts.log(
-    `${session} AUTO-RESTART skipped: ticket ${ticket} CI-gate-freed at sha=${(ciFreed.sha || '').slice(0, 7)}; awaiting operator merge`
-  );
+  if (!ciFreed.skipLogged) {
+    alerts.log(
+      `${session} AUTO-RESTART skipped: ticket ${ticket} CI-gate-freed at sha=${(ciFreed.sha || '').slice(0, 7)}; awaiting operator merge`
+    );
+    state.write(ticket, 'ci-gate-freed', { ...ciFreed, skipLogged: true });
+  }
   return { skip: true };
 }
 
 function checkDeadEndGuard({ session, ticket }) {
   const deadEnd = state.read(ticket, 'dead-end');
   if (!deadEnd || !deadEnd.killed) return { skip: false };
-  alerts.log(
-    `${session} AUTO-RESTART skipped: ticket ${ticket} dead-end-freed (trigger=${deadEnd.trigger || 'unknown'}); slot rotated, do not resurrect`
-  );
+  if (!deadEnd.skipLogged) {
+    alerts.log(
+      `${session} AUTO-RESTART skipped: ticket ${ticket} dead-end-freed (trigger=${deadEnd.trigger || 'unknown'}); slot rotated, do not resurrect`
+    );
+    state.write(ticket, 'dead-end', { ...deadEnd, skipLogged: true });
+  }
   return { skip: true };
 }
 
@@ -273,16 +229,6 @@ function autoRestart({ session, ticket, worktree, silenceSec }) {
  *
  * No-op if AUTO_FREE_CI_SLOT=0.
  */
-function buildNextActionInstruction({ prefix, suffix, next, autoBootstrapped }) {
-  if (autoBootstrapped) {
-    return `${prefix}NEXT_ACTION=auto-bootstrapped ${next.taskId} from manifest "${next.topic}". No operator action needed unless bootstrap log shows failure.`;
-  }
-  if (next) {
-    return `${prefix}NEXT_ACTION=bootstrap ${next.taskId} (manifest "${next.topic}", priority=${next.priority}). Run: bash plugins/maestro/scripts/maestro-bootstrap.sh ${next.taskId}. Set AUTO_BOOTSTRAP_NEXT=1 to skip this step.${suffix}`;
-  }
-  return `${prefix}NEXT_ACTION=do-nothing — no eligible pending task across orchestration manifests.${suffix}`;
-}
-
 function killTicketTmux(ticket) {
   for (const suffix of ['work', 'listen']) {
     spawnSync('tmux', ['kill-session', '-t', `${ticket}-${suffix}`], { stdio: 'ignore' });

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -19,6 +19,7 @@ const alerts = require('./alerts');
 const state = require('./state');
 const { headSha } = require('./detectors/gh-shared');
 const { eligibleTasks } = require('./session-shared');
+const manifest = require('./manifest');
 const { purgeAlertCountsForTicket } = require('../../maestro-cleanup');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
@@ -86,10 +87,23 @@ function maybeAutoBootstrap(taskId) {
   if (process.env.AUTO_BOOTSTRAP_NEXT !== '1') return false;
   if (!taskId || !/^[A-Z]+-\d+$/.test(taskId)) return false;
   if (!fs.existsSync(BOOTSTRAP_SCRIPT)) return false;
+  // Respect manifest-declared pool size (sum of `slots` across manifests).
+  // Avoids over-bootstrapping when an operator pre-launched sessions.
+  try {
+    const tmuxMod = require('./tmux');
+    const activeSessions = tmuxMod.listSessions ? tmuxMod.listSessions() : [];
+    if (manifest.poolFull(activeSessions)) {
+      alerts.log(`AUTO-BOOTSTRAP skipped for ${taskId}: pool full per manifest slots`);
+      return false;
+    }
+  } catch {}
   const res = spawnSync('bash', [BOOTSTRAP_SCRIPT, taskId], {
     stdio: 'ignore',
     env: { ...process.env, REPO_NAME },
   });
+  if (res.status === 0) {
+    manifest.updateTaskStatus(taskId, 'in_progress', 'auto-bootstrapped by daemon');
+  }
   return res.status === 0;
 }
 
@@ -310,6 +324,7 @@ function freeCIGateSlot({ session, ticket, prNumber, sha }) {
   // spam on every tick. The kill above still runs (defensive).
   if (marker.sha === sha || ciFreed.sha === sha) return false;
   state.write(session, 'slot-freed', { sha, prNumber, freedAt: state.now() });
+  manifest.updateTaskStatus(ticket, 'awaiting-merge', `PR #${prNumber} CLEAN/SUCCESS at sha=${(sha || '').slice(0, 7)}`);
   const next = findNextEligibleTask();
   const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);
   const prefix = `Slot freed for PR #${prNumber} (sha=${(sha || '').slice(0, 7)}). `;
@@ -343,6 +358,7 @@ function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
     alerts.log(`${session} freeDeadEndSlot: purgeAlertCountsForTicket failed: ${err.message}`);
   }
   state.write(ticket, 'dead-end', { killed: true, freedAt: state.now(), trigger: kind });
+  manifest.updateTaskStatus(ticket, 'blocked', `dead-end after ${kind} ×${repeatCount}`);
   const next = findNextEligibleTask();
   const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);
   const prefix = `DEAD-END on ${ticket} after ${kind} ×${repeatCount}. `;
@@ -367,4 +383,12 @@ function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
   return true;
 }
 
-module.exports = { soft, interrupt, alert, autoRestart, freeCIGateSlot, freeDeadEndSlot };
+module.exports = {
+  soft,
+  interrupt,
+  alert,
+  autoRestart,
+  freeCIGateSlot,
+  freeDeadEndSlot,
+  syncManifest: manifest.syncFromTmux,
+};

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -137,6 +137,7 @@ function declareWedged({ session, ticket, restarts, now, silenceSec }) {
   alerts.log(
     `${session} WEDGED — ${count} auto-restarts in ${RESTART_WINDOW_MIN}m; suppressing restarts for ${WEDGED_QUIET_MIN}m`
   );
+  const paneTail = tmux.capture(session).split('\n').slice(-50).join('\n');
   alerts.alert({
     session,
     ticket,
@@ -145,7 +146,8 @@ function declareWedged({ session, ticket, restarts, now, silenceSec }) {
     windowMin: RESTART_WINDOW_MIN,
     quietMin: WEDGED_QUIET_MIN,
     silenceSec,
-    instruction: `tmux capture-pane -t ${session} -p | tail -50 — agent restarted ${count}x in ${RESTART_WINDOW_MIN}m. Daemon won't restart for ${WEDGED_QUIET_MIN}m. Diagnose root cause; if dead-end, kill session and bootstrap next bug.`,
+    paneTail,
+    instruction: `agent restarted ${count}x in ${RESTART_WINDOW_MIN}m. Daemon won't restart for ${WEDGED_QUIET_MIN}m. UNBLOCK-PROTOCOL: diagnose root cause from paneTail; if dead-end, kill session and bootstrap next queued.`,
   });
 }
 

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -42,8 +42,8 @@ function maybeAutoBootstrap(taskId) {
   try {
     const tmuxMod = require('./tmux');
     const activeSessions = tmuxMod.listSessions ? tmuxMod.listSessions() : [];
-    if (manifest.poolFull(activeSessions)) {
-      alerts.log(`AUTO-BOOTSTRAP skipped for ${taskId}: pool full per manifest slots`);
+    if (manifest.poolFullForTask(taskId, activeSessions)) {
+      alerts.log(`AUTO-BOOTSTRAP skipped for ${taskId}: owning manifest at slot cap`);
       return false;
     }
   } catch {}
@@ -353,9 +353,10 @@ function maybeFillPool() {
   try {
     activeSessions = tmux.listSessions ? tmux.listSessions() : [];
   } catch {}
-  if (manifest.poolFull(activeSessions)) return false;
   const next = findNextEligibleTask();
   if (!next) return false;
+  // Pool-cap is checked per-manifest inside maybeAutoBootstrap so a full
+  // manifest only blocks its OWN tickets, not eligible work in others.
   // Don't bootstrap a ticket whose tmux session already exists (e.g. -listen).
   if (activeSessions.includes(`${next.taskId}-work`)) return false;
   const ok = maybeAutoBootstrap(next.taskId);

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -289,7 +289,15 @@ function killTicketTmux(ticket) {
   }
 }
 
-function emitSlotFreedAlert({ session, ticket, prNumber, sha, next, autoBootstrapped, instruction }) {
+function emitSlotFreedAlert({
+  session,
+  ticket,
+  prNumber,
+  sha,
+  next,
+  autoBootstrapped,
+  instruction,
+}) {
   alerts.log(
     `${session} SLOT-FREED at CI gate — PR #${prNumber} sha=${(sha || '').slice(0, 7)} awaiting operator merge; tmux -work + -listen killed${
       autoBootstrapped ? `; AUTO-BOOTSTRAPPED ${next.taskId}` : ''
@@ -324,7 +332,11 @@ function freeCIGateSlot({ session, ticket, prNumber, sha }) {
   // spam on every tick. The kill above still runs (defensive).
   if (marker.sha === sha || ciFreed.sha === sha) return false;
   state.write(session, 'slot-freed', { sha, prNumber, freedAt: state.now() });
-  manifest.updateTaskStatus(ticket, 'awaiting-merge', `PR #${prNumber} CLEAN/SUCCESS at sha=${(sha || '').slice(0, 7)}`);
+  manifest.updateTaskStatus(
+    ticket,
+    'awaiting-merge',
+    `PR #${prNumber} CLEAN/SUCCESS at sha=${(sha || '').slice(0, 7)}`
+  );
   const next = findNextEligibleTask();
   const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);
   const prefix = `Slot freed for PR #${prNumber} (sha=${(sha || '').slice(0, 7)}). `;
@@ -383,6 +395,28 @@ function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
   return true;
 }
 
+/**
+ * maybeFillPool — when the pool has free slots (active < sum-of-slots) and
+ * AUTO_BOOTSTRAP_NEXT=1, find the next eligible pending task and bootstrap.
+ * Idempotent per tick: one bootstrap per call. Caller invokes once per tick
+ * after syncManifest so reconciliation runs first.
+ */
+function maybeFillPool() {
+  if (process.env.AUTO_BOOTSTRAP_NEXT !== '1') return false;
+  let activeSessions = [];
+  try {
+    activeSessions = tmux.listSessions ? tmux.listSessions() : [];
+  } catch {}
+  if (manifest.poolFull(activeSessions)) return false;
+  const next = findNextEligibleTask();
+  if (!next) return false;
+  // Don't bootstrap a ticket whose tmux session already exists (e.g. -listen).
+  if (activeSessions.includes(`${next.taskId}-work`)) return false;
+  const ok = maybeAutoBootstrap(next.taskId);
+  if (ok) alerts.log(`POOL-FILL auto-bootstrapped ${next.taskId} from manifest "${next.topic}"`);
+  return ok;
+}
+
 module.exports = {
   soft,
   interrupt,
@@ -391,4 +425,5 @@ module.exports = {
   freeCIGateSlot,
   freeDeadEndSlot,
   syncManifest: manifest.syncFromTmux,
+  maybeFillPool,
 };

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -19,7 +19,11 @@ const alerts = require('./alerts');
 const state = require('./state');
 const { headSha } = require('./detectors/gh-shared');
 const manifest = require('./manifest');
-const { findNextEligibleTask, buildNextActionInstruction } = require('./next-task');
+const {
+  findNextEligibleTask,
+  findEligibleTasks,
+  buildNextActionInstruction,
+} = require('./next-task');
 const { purgeAlertCountsForTicket } = require('../../maestro-cleanup');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
@@ -353,15 +357,19 @@ function maybeFillPool() {
   try {
     activeSessions = tmux.listSessions ? tmux.listSessions() : [];
   } catch {}
-  const next = findNextEligibleTask();
-  if (!next) return false;
-  // Pool-cap is checked per-manifest inside maybeAutoBootstrap so a full
-  // manifest only blocks its OWN tickets, not eligible work in others.
-  // Don't bootstrap a ticket whose tmux session already exists (e.g. -listen).
-  if (activeSessions.includes(`${next.taskId}-work`)) return false;
-  const ok = maybeAutoBootstrap(next.taskId);
-  if (ok) alerts.log(`POOL-FILL auto-bootstrapped ${next.taskId} from manifest "${next.topic}"`);
-  return ok;
+  // Walk candidates in priority order; bootstrap the first one whose owning
+  // manifest still has capacity. A full manifest must not block eligible work
+  // in another manifest that still has free slots. Stop after the first
+  // successful bootstrap so the tick stays idempotent.
+  for (const cand of findEligibleTasks()) {
+    if (activeSessions.includes(`${cand.taskId}-work`)) continue;
+    const ok = maybeAutoBootstrap(cand.taskId);
+    if (ok) {
+      alerts.log(`POOL-FILL auto-bootstrapped ${cand.taskId} from manifest "${cand.topic}"`);
+      return true;
+    }
+  }
+  return false;
 }
 
 module.exports = {

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -353,10 +353,18 @@ function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
  */
 function maybeFillPool() {
   if (process.env.AUTO_BOOTSTRAP_NEXT !== '1') return false;
-  let activeSessions = [];
+  let activeSessions = null;
   try {
     activeSessions = tmux.listSessions ? tmux.listSessions() : [];
   } catch {}
+  // Guard: an empty/missing session list is ambiguous — could be a real
+  // "no sessions yet" state or a transient `tmux ls` failure / prefix
+  // mismatch. Bootstrapping on ambiguous signal can over-launch and exceed
+  // manifest slot caps because per-task pool-cap checks also count zero.
+  // Same conservatism as syncFromTmux: no signal → no action.
+  if (!Array.isArray(activeSessions) || activeSessions.length === 0) {
+    return false;
+  }
   // Walk candidates in priority order; bootstrap the first one whose owning
   // manifest still has capacity. A full manifest must not block eligible work
   // in another manifest that still has free slots. Stop after the first

--- a/plugins/maestro/scripts/lib/maestro-conduct/alerts.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/alerts.js
@@ -83,6 +83,18 @@ function log(line) {
  * freeDeadEndSlot at count >= 3). The instruction string gets a [REPEAT N]
  * prefix when count > 1 so the operator can see momentum.
  */
+// Kinds the operator must act on now (answer a menu, decide on PR, kill a
+// wedge). Other kinds are informational reminders the operator can fast-route.
+const ACTION_REQUIRED_KINDS = new Set([
+  'question-pending',
+  'nudges-exhausted',
+  'wedged',
+  'dead-end',
+  'pr-ready',
+  'pr-broken',
+  'pr-comments-stuck',
+]);
+
 function alert(obj) {
   if (!obj || typeof obj.instruction !== 'string' || !obj.instruction.trim()) {
     log(`ALERT-DROPPED (no instruction): ${JSON.stringify(obj)}`);
@@ -92,7 +104,17 @@ function alert(obj) {
   const count = bumpCount(key);
   const prefix = count > 1 ? `[REPEAT ${count}] ` : '';
   const instruction = `${prefix}${obj.instruction}`;
-  const payload = { ts: new Date().toISOString(), ...obj, instruction, repeatCount: count };
+  // action_required is true on first sight of an actionable kind; subsequent
+  // repeats (count > 1) carry the same state, so the operator can skip
+  // investigating them and just acknowledge.
+  const actionRequired = ACTION_REQUIRED_KINDS.has(obj.kind) && count === 1;
+  const payload = {
+    ts: new Date().toISOString(),
+    ...obj,
+    instruction,
+    repeatCount: count,
+    action_required: actionRequired,
+  };
   try {
     fs.appendFileSync(ALERT_FILE, JSON.stringify(payload) + '\n');
   } catch {}

--- a/plugins/maestro/scripts/lib/maestro-conduct/ci-gate-rotation.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/ci-gate-rotation.js
@@ -3,72 +3,38 @@
 /**
  * CI-gate slot rotation helpers.
  *
- * Two entry points fire `actions.freeCIGateSlot`:
- *   - `maybeFreeOnPrReady`     — runs inline from the pr-status detector on
- *                                a fresh pr-ready hit. Bounded by phase so
- *                                we don't kill the agent before it has
- *                                addressed bot comments.
- *   - `maybeRotateOnPhase`     — tick-level safety net for the steady-state
- *                                pr-ready case where the detector dedups
- *                                and never re-emits; if the ticket is
- *                                already at ci-or-later and the PR is
- *                                green+clean, fire the rotation directly.
+ * NOTE (review feedback round 2): both auto-rotation entry points are now
+ * no-ops. The original code intentionally removed CI-gate auto-rotation
+ * because freeing the slot on `pr-ready` kills the `-work` tmux session
+ * before the operator can spawn `code-checker` and forward a possible
+ * NEEDS-WORK verdict back to it. Re-introducing it (even gated on phase
+ * >= ci) restores the race: the kill happens in the same tick as the
+ * alert, so by the time the operator reacts the session is dead.
+ *
+ * The PR's other throttle wins (state-change heartbeat, helper-session
+ * detector skips, embedded paneTail, action_required flag) are unaffected.
+ * Slot freeing remains operator-driven: the operator kills `-work` +
+ * `-listen` after merging the PR.
  */
 
-// Phases that mean "agent has done its workflow work" — slot can be freed.
+// Kept exported for downstream code that imports the set. Unused by the
+// rotation helpers below now that both are no-ops.
 const CI_OR_LATER_PHASES = new Set(['ci', 'cleanup', 'reports', 'complete']);
 
-function isReadyForRotation(sHit, phase) {
-  return Boolean(
-    sHit
-      && sHit.checksState === 'SUCCESS'
-      && sHit.mergeable === 'CLEAN'
-      && CI_OR_LATER_PHASES.has(phase),
-  );
+function isReadyForRotation() {
+  return false;
 }
 
-/**
- * Pr-status-driven rotation. Called inline from the pr-ready branch.
- * `sHit.kind === 'pr-ready'` is enforced by the caller; we only re-check the
- * green+clean+phase condition here.
- */
-function maybeFreeOnPrReady({ ctx, sHit, workSession, actions }) {
-  if (sHit.kind !== 'pr-ready') return;
-  if (!isReadyForRotation(sHit, ctx.phase)) return;
-  actions.freeCIGateSlot({
-    session: workSession,
-    ticket: ctx.ticket,
-    prNumber: sHit.prNumber,
-    sha: sHit.sha,
-  });
+// eslint-disable-next-line no-unused-vars
+function maybeFreeOnPrReady(_args) {
+  // Intentional no-op — see file header. Killing -work on pr-ready races
+  // with code-checker spawn + NEEDS-WORK forward.
 }
 
-/**
- * Tick-level safety net (see file header). Reads the persisted `pr-status`
- * marker (`lastState`) instead of calling `prStatusDetector.detect`, because
- * the detector dedups: on the steady-state pr-ready case it returns
- * `{ hit: false }` with no `checksState`/`mergeable` fields, so calling it
- * here would never satisfy the green+clean condition.
- *
- * `lastState === 'pr-ready'` is the dedup-safe equivalent — `classify()`
- * (pr-status detector) only sets it to `'pr-ready'` when
- * `checksState === 'SUCCESS' && mergeable === 'CLEAN'`. The pr-status
- * detector runs before this function in the tick pipeline so the marker is
- * always fresh.
- */
-function maybeRotateOnPhase({ ctx, state, actions, restartEligible }) {
-  if (!CI_OR_LATER_PHASES.has(ctx.phase)) return;
-  if (!restartEligible(ctx.session)) return;
-  const ciFreed = state.read(ctx.ticket, 'ci-gate-freed') || {};
-  if (ciFreed.killed) return;
-  const prMarker = state.read(ctx.ticket, 'pr-status');
-  if (!prMarker || prMarker.lastState !== 'pr-ready') return;
-  actions.freeCIGateSlot({
-    session: ctx.session,
-    ticket: ctx.ticket,
-    prNumber: prMarker.prNumber,
-    sha: prMarker.sha,
-  });
+// eslint-disable-next-line no-unused-vars
+function maybeRotateOnPhase(_args) {
+  // Intentional no-op — same race as maybeFreeOnPrReady. Without an
+  // operator-merged signal we can't safely fire this.
 }
 
 module.exports = {

--- a/plugins/maestro/scripts/lib/maestro-conduct/ci-gate-rotation.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/ci-gate-rotation.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * CI-gate slot rotation helpers.
+ *
+ * Two entry points fire `actions.freeCIGateSlot`:
+ *   - `maybeFreeOnPrReady`     — runs inline from the pr-status detector on
+ *                                a fresh pr-ready hit. Bounded by phase so
+ *                                we don't kill the agent before it has
+ *                                addressed bot comments.
+ *   - `maybeRotateOnPhase`     — tick-level safety net for the steady-state
+ *                                pr-ready case where the detector dedups
+ *                                and never re-emits; if the ticket is
+ *                                already at ci-or-later and the PR is
+ *                                green+clean, fire the rotation directly.
+ */
+
+// Phases that mean "agent has done its workflow work" — slot can be freed.
+const CI_OR_LATER_PHASES = new Set(['ci', 'cleanup', 'reports', 'complete']);
+
+function isReadyForRotation(sHit, phase) {
+  return Boolean(
+    sHit
+      && sHit.checksState === 'SUCCESS'
+      && sHit.mergeable === 'CLEAN'
+      && CI_OR_LATER_PHASES.has(phase),
+  );
+}
+
+/**
+ * Pr-status-driven rotation. Called inline from the pr-ready branch.
+ * `sHit.kind === 'pr-ready'` is enforced by the caller; we only re-check the
+ * green+clean+phase condition here.
+ */
+function maybeFreeOnPrReady({ ctx, sHit, workSession, actions }) {
+  if (sHit.kind !== 'pr-ready') return;
+  if (!isReadyForRotation(sHit, ctx.phase)) return;
+  actions.freeCIGateSlot({
+    session: workSession,
+    ticket: ctx.ticket,
+    prNumber: sHit.prNumber,
+    sha: sHit.sha,
+  });
+}
+
+/**
+ * Tick-level safety net (see file header). Skips when the rotation has
+ * already been recorded so we don't re-emit on every tick.
+ */
+function maybeRotateOnPhase({ ctx, state, actions, prStatusDetector, restartEligible }) {
+  if (!CI_OR_LATER_PHASES.has(ctx.phase)) return;
+  if (!restartEligible(ctx.session)) return;
+  const ciFreed = state.read(ctx.ticket, 'ci-gate-freed') || {};
+  if (ciFreed.killed) return;
+  const sHit = prStatusDetector.detect(ctx);
+  if (!isReadyForRotation(sHit, ctx.phase)) return;
+  actions.freeCIGateSlot({
+    session: ctx.session,
+    ticket: ctx.ticket,
+    prNumber: sHit.prNumber,
+    sha: sHit.sha,
+  });
+}
+
+module.exports = {
+  CI_OR_LATER_PHASES,
+  isReadyForRotation,
+  maybeFreeOnPrReady,
+  maybeRotateOnPhase,
+};

--- a/plugins/maestro/scripts/lib/maestro-conduct/ci-gate-rotation.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/ci-gate-rotation.js
@@ -44,21 +44,30 @@ function maybeFreeOnPrReady({ ctx, sHit, workSession, actions }) {
 }
 
 /**
- * Tick-level safety net (see file header). Skips when the rotation has
- * already been recorded so we don't re-emit on every tick.
+ * Tick-level safety net (see file header). Reads the persisted `pr-status`
+ * marker (`lastState`) instead of calling `prStatusDetector.detect`, because
+ * the detector dedups: on the steady-state pr-ready case it returns
+ * `{ hit: false }` with no `checksState`/`mergeable` fields, so calling it
+ * here would never satisfy the green+clean condition.
+ *
+ * `lastState === 'pr-ready'` is the dedup-safe equivalent — `classify()`
+ * (pr-status detector) only sets it to `'pr-ready'` when
+ * `checksState === 'SUCCESS' && mergeable === 'CLEAN'`. The pr-status
+ * detector runs before this function in the tick pipeline so the marker is
+ * always fresh.
  */
-function maybeRotateOnPhase({ ctx, state, actions, prStatusDetector, restartEligible }) {
+function maybeRotateOnPhase({ ctx, state, actions, restartEligible }) {
   if (!CI_OR_LATER_PHASES.has(ctx.phase)) return;
   if (!restartEligible(ctx.session)) return;
   const ciFreed = state.read(ctx.ticket, 'ci-gate-freed') || {};
   if (ciFreed.killed) return;
-  const sHit = prStatusDetector.detect(ctx);
-  if (!isReadyForRotation(sHit, ctx.phase)) return;
+  const prMarker = state.read(ctx.ticket, 'pr-status');
+  if (!prMarker || prMarker.lastState !== 'pr-ready') return;
   actions.freeCIGateSlot({
     session: ctx.session,
     ticket: ctx.ticket,
-    prNumber: sHit.prNumber,
-    sha: sHit.sha,
+    prNumber: prMarker.prNumber,
+    sha: prMarker.sha,
   });
 }
 

--- a/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
@@ -1,0 +1,135 @@
+/**
+ * manifest.js — read/write helpers for orchestration manifests at
+ * ~/.cache/maestro/sessions/<topic>.json.
+ *
+ * The daemon already READS manifests (findNextEligibleTask). This module
+ * adds WRITE support so phase transitions (bootstrap, slot-freed, dead-end,
+ * auto-restart) round-trip into the manifest — operator sees a live view of
+ * pool state without polling tmux.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SESSION_MANIFEST_DIR =
+  process.env.MAESTRO_SESSION_DIR ||
+  path.join(process.env.HOME || '/tmp', '.cache', 'maestro', 'sessions');
+
+function listManifestFiles() {
+  if (!fs.existsSync(SESSION_MANIFEST_DIR)) return [];
+  return fs
+    .readdirSync(SESSION_MANIFEST_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => path.join(SESSION_MANIFEST_DIR, f));
+}
+
+function readManifest(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeManifest(file, manifest) {
+  try {
+    fs.writeFileSync(file, JSON.stringify(manifest, null, 2) + '\n');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find the manifest file + task entry for a ticket id. First match across
+ * all manifests wins. Returns { file, manifest, task } or null.
+ */
+function findTask(taskId) {
+  for (const file of listManifestFiles()) {
+    const manifest = readManifest(file);
+    if (!manifest || !Array.isArray(manifest.tasks)) continue;
+    const task = manifest.tasks.find((t) => t.id === taskId);
+    if (task) return { file, manifest, task };
+  }
+  return null;
+}
+
+/**
+ * Update a task's status/note in whichever manifest owns it. No-op if the
+ * task is not registered — manifests are append-only by the operator; the
+ * daemon never invents new entries.
+ */
+function updateTaskStatus(taskId, status, note) {
+  const hit = findTask(taskId);
+  if (!hit) return false;
+  hit.task.status = status;
+  if (note !== undefined) hit.task.note = note;
+  hit.task.updatedAt = new Date().toISOString();
+  return writeManifest(hit.file, hit.manifest);
+}
+
+/**
+ * Reconcile manifest task statuses against live tmux work-sessions.
+ *
+ *   - Each ticket with a live `<TICKET>-work` tmux session is marked
+ *     `in_progress` (if not already terminal: awaiting-merge|blocked|done).
+ *   - Each ticket currently `in_progress` whose tmux session vanished
+ *     (killed by operator or by daemon rotation) is marked `stopped`.
+ *
+ * Terminal statuses are NEVER overwritten — operator owns those transitions.
+ */
+const TERMINAL = new Set(['awaiting-merge', 'blocked', 'done']);
+
+function syncFromTmux(activeWorkSessions) {
+  const aliveTickets = new Set(
+    (activeWorkSessions || [])
+      .map((s) => (s.match(/^(GH-\d+)-work$/) || [])[1])
+      .filter(Boolean)
+  );
+  for (const file of listManifestFiles()) {
+    const m = readManifest(file);
+    if (!m || !Array.isArray(m.tasks)) continue;
+    let dirty = false;
+    for (const task of m.tasks) {
+      if (TERMINAL.has(task.status)) continue;
+      const isAlive = aliveTickets.has(task.id);
+      if (isAlive && task.status !== 'in_progress') {
+        task.status = 'in_progress';
+        task.note = 'tmux session detected by daemon';
+        task.updatedAt = new Date().toISOString();
+        dirty = true;
+      } else if (!isAlive && task.status === 'in_progress') {
+        task.status = 'stopped';
+        task.note = 'tmux session gone (killed or exited)';
+        task.updatedAt = new Date().toISOString();
+        dirty = true;
+      }
+    }
+    if (dirty) writeManifest(file, m);
+  }
+}
+
+/**
+ * Pool-size check. Sums `slots` across all manifests (or per-topic) and
+ * compares to current live work-session count. Returns true if pool is full.
+ */
+function poolFull(activeWorkSessions) {
+  let totalSlots = 0;
+  for (const file of listManifestFiles()) {
+    const m = readManifest(file);
+    if (!m) continue;
+    if (typeof m.slots === 'number') totalSlots += m.slots;
+  }
+  if (totalSlots <= 0) return false;
+  const live = (activeWorkSessions || []).filter((s) => /^GH-\d+-work$/.test(s)).length;
+  return live >= totalSlots;
+}
+
+module.exports = {
+  listManifestFiles,
+  readManifest,
+  writeManifest,
+  findTask,
+  updateTaskStatus,
+  syncFromTmux,
+  poolFull,
+};

--- a/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
@@ -79,49 +79,58 @@ function updateTaskStatus(taskId, status, note) {
  */
 const TERMINAL = new Set(['awaiting-merge', 'blocked', 'done']);
 
-function syncFromTmux(activeWorkSessions) {
-  const aliveTickets = new Set(
-    (activeWorkSessions || [])
-      .map((s) => (s.match(/^(GH-\d+)-work$/) || [])[1])
-      .filter(Boolean)
+function aliveTicketSet(activeWorkSessions) {
+  return new Set(
+    (activeWorkSessions || []).map((s) => (s.match(/^(GH-\d+)-work$/) || [])[1]).filter(Boolean)
   );
+}
+
+function reconcileTask(task, aliveTickets) {
+  if (TERMINAL.has(task.status)) return false;
+  const isAlive = aliveTickets.has(task.id);
+  if (isAlive && task.status !== 'in_progress') {
+    task.status = 'in_progress';
+    task.note = 'tmux session detected by daemon';
+    task.updatedAt = new Date().toISOString();
+    return true;
+  }
+  if (!isAlive && task.status === 'in_progress') {
+    task.status = 'stopped';
+    task.note = 'tmux session gone (killed or exited)';
+    task.updatedAt = new Date().toISOString();
+    return true;
+  }
+  return false;
+}
+
+function syncFromTmux(activeWorkSessions) {
+  const aliveTickets = aliveTicketSet(activeWorkSessions);
   for (const file of listManifestFiles()) {
     const m = readManifest(file);
     if (!m || !Array.isArray(m.tasks)) continue;
     let dirty = false;
     for (const task of m.tasks) {
-      if (TERMINAL.has(task.status)) continue;
-      const isAlive = aliveTickets.has(task.id);
-      if (isAlive && task.status !== 'in_progress') {
-        task.status = 'in_progress';
-        task.note = 'tmux session detected by daemon';
-        task.updatedAt = new Date().toISOString();
-        dirty = true;
-      } else if (!isAlive && task.status === 'in_progress') {
-        task.status = 'stopped';
-        task.note = 'tmux session gone (killed or exited)';
-        task.updatedAt = new Date().toISOString();
-        dirty = true;
-      }
+      if (reconcileTask(task, aliveTickets)) dirty = true;
     }
     if (dirty) writeManifest(file, m);
   }
 }
 
 /**
- * Pool-size check. Sums `slots` across all manifests (or per-topic) and
- * compares to current live work-session count. Returns true if pool is full.
+ * Pool-size check, per-manifest. For each manifest, count its OWN live
+ * work-sessions (tickets the manifest knows about) and compare to that
+ * manifest's `slots`. Pool is full if ANY manifest is at-or-over its cap.
+ * This prevents stale manifests from inflating the global total.
  */
 function poolFull(activeWorkSessions) {
-  let totalSlots = 0;
+  const aliveTickets = aliveTicketSet(activeWorkSessions);
   for (const file of listManifestFiles()) {
     const m = readManifest(file);
-    if (!m) continue;
-    if (typeof m.slots === 'number') totalSlots += m.slots;
+    if (!m || typeof m.slots !== 'number' || !Array.isArray(m.tasks)) continue;
+    const liveInThisManifest = m.tasks.filter((t) => aliveTickets.has(t.id)).length;
+    if (liveInThisManifest >= m.slots) return true;
   }
-  if (totalSlots <= 0) return false;
-  const live = (activeWorkSessions || []).filter((s) => /^GH-\d+-work$/.test(s)).length;
-  return live >= totalSlots;
+  return false;
 }
 
 module.exports = {

--- a/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
@@ -109,6 +109,14 @@ function reconcileTask(task, aliveTickets) {
 }
 
 function syncFromTmux(activeWorkSessions) {
+  // Guard: an empty input is ambiguous — could be a real "no sessions" state
+  // or a transient `tmux ls` failure / prefix mismatch / mid-restart gap.
+  // Refusing to demote `in_progress → stopped` on empty input means the
+  // operator must manually clear stale entries when they really kill the
+  // whole pool, but it prevents a flapping manifest in the failure cases.
+  if (!Array.isArray(activeWorkSessions) || activeWorkSessions.length === 0) {
+    return;
+  }
   const aliveTickets = aliveTicketSet(activeWorkSessions);
   for (const file of listManifestFiles()) {
     const m = readManifest(file);

--- a/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
@@ -122,20 +122,22 @@ function syncFromTmux(activeWorkSessions) {
 }
 
 /**
- * Pool-size check, per-manifest. For each manifest, count its OWN live
- * work-sessions (tickets the manifest knows about) and compare to that
- * manifest's `slots`. Pool is full if ANY manifest is at-or-over its cap.
- * This prevents stale manifests from inflating the global total.
+ * Pool-size check scoped to the manifest owning `taskId`. Counts live
+ * work-sessions for tickets in THAT manifest and compares against THAT
+ * manifest's `slots`. Returns false if the task isn't in any manifest
+ * (caller should treat unknown tickets as ungated).
+ *
+ * Per-task scoping prevents one full manifest from blocking auto-bootstrap
+ * of eligible work in a different manifest that still has free capacity.
  */
-function poolFull(activeWorkSessions) {
+function poolFullForTask(taskId, activeWorkSessions) {
+  const hit = findTask(taskId);
+  if (!hit) return false;
+  const { manifest: m } = hit;
+  if (typeof m.slots !== 'number' || !Array.isArray(m.tasks)) return false;
   const aliveTickets = aliveTicketSet(activeWorkSessions);
-  for (const file of listManifestFiles()) {
-    const m = readManifest(file);
-    if (!m || typeof m.slots !== 'number' || !Array.isArray(m.tasks)) continue;
-    const liveInThisManifest = m.tasks.filter((t) => aliveTickets.has(t.id)).length;
-    if (liveInThisManifest >= m.slots) return true;
-  }
-  return false;
+  const liveInThisManifest = m.tasks.filter((t) => aliveTickets.has(t.id)).length;
+  return liveInThisManifest >= m.slots;
 }
 
 module.exports = {
@@ -145,5 +147,5 @@ module.exports = {
   findTask,
   updateTaskStatus,
   syncFromTmux,
-  poolFull,
+  poolFullForTask,
 };

--- a/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
@@ -81,7 +81,12 @@ const TERMINAL = new Set(['awaiting-merge', 'blocked', 'done']);
 
 function aliveTicketSet(activeWorkSessions) {
   return new Set(
-    (activeWorkSessions || []).map((s) => (s.match(/^(GH-\d+)-work$/) || [])[1]).filter(Boolean)
+    (activeWorkSessions || [])
+      .map((s) => {
+        const m = s.match(/^([A-Z][A-Z0-9]*-\d+)-work$/);
+        return m ? m[1] : null;
+      })
+      .filter(Boolean)
   );
 }
 

--- a/plugins/maestro/scripts/lib/maestro-conduct/next-task.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/next-task.js
@@ -1,0 +1,71 @@
+/**
+ * next-task.js — helpers for locating the next eligible pending task across
+ * orchestration manifests, and for building the operator-facing NEXT_ACTION
+ * instruction line. Extracted from actions.js so that file stays under the
+ * max-lines gate.
+ */
+const fs = require('fs');
+const path = require('path');
+const { eligibleTasks } = require('./session-shared');
+
+const SESSION_MANIFEST_DIR =
+  process.env.MAESTRO_SESSION_DIR ||
+  path.join(process.env.HOME || '/tmp', '.cache', 'maestro', 'sessions');
+
+function readManifestSafe(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function topPendingForManifest(manifest, entry) {
+  // Reuse session-shared.eligibleTasks so the slot-freed bootstrap path and
+  // the maestro-session CLI agree on the next task (incl. default priority).
+  const ranked = eligibleTasks(Array.isArray(manifest.tasks) ? manifest.tasks : []);
+  if (ranked.length === 0) return null;
+  const top = ranked[0];
+  return {
+    topic: manifest.topic || entry.replace(/\.json$/, ''),
+    taskId: top.id,
+    priority: top.priority,
+  };
+}
+
+function findNextEligibleTask() {
+  if (!fs.existsSync(SESSION_MANIFEST_DIR)) return null;
+  let best = null;
+  // Sort manifest filenames so readdirSync iteration order is deterministic
+  // across filesystems. This gives a stable tie-break by filename when two
+  // eligible tasks share the same numeric priority (the natural tie-break
+  // here is ticket id, since manifest filenames are derived from topic/ticket).
+  const entries = fs.readdirSync(SESSION_MANIFEST_DIR).slice().sort();
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue;
+    const manifest = readManifestSafe(path.join(SESSION_MANIFEST_DIR, entry));
+    if (!manifest) continue;
+    const candidate = topPendingForManifest(manifest, entry);
+    if (!candidate) continue;
+    if (!best || (candidate.priority || 999) < (best.priority || 999)) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+function buildNextActionInstruction({ prefix, suffix, next, autoBootstrapped }) {
+  if (autoBootstrapped) {
+    return `${prefix}NEXT_ACTION=auto-bootstrapped ${next.taskId} from manifest "${next.topic}". No operator action needed unless bootstrap log shows failure.`;
+  }
+  if (next) {
+    return `${prefix}NEXT_ACTION=bootstrap ${next.taskId} (manifest "${next.topic}", priority=${next.priority}). Run: bash plugins/maestro/scripts/maestro-bootstrap.sh ${next.taskId}. Set AUTO_BOOTSTRAP_NEXT=1 to skip this step.${suffix}`;
+  }
+  return `${prefix}NEXT_ACTION=do-nothing — no eligible pending task across orchestration manifests.${suffix}`;
+}
+
+module.exports = {
+  SESSION_MANIFEST_DIR,
+  findNextEligibleTask,
+  buildNextActionInstruction,
+};

--- a/plugins/maestro/scripts/lib/maestro-conduct/next-task.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/next-task.js
@@ -33,25 +33,27 @@ function topPendingForManifest(manifest, entry) {
   };
 }
 
-function findNextEligibleTask() {
-  if (!fs.existsSync(SESSION_MANIFEST_DIR)) return null;
-  let best = null;
+function findEligibleTasks() {
+  if (!fs.existsSync(SESSION_MANIFEST_DIR)) return [];
   // Sort manifest filenames so readdirSync iteration order is deterministic
   // across filesystems. This gives a stable tie-break by filename when two
   // eligible tasks share the same numeric priority (the natural tie-break
   // here is ticket id, since manifest filenames are derived from topic/ticket).
   const entries = fs.readdirSync(SESSION_MANIFEST_DIR).slice().sort();
+  const candidates = [];
   for (const entry of entries) {
     if (!entry.endsWith('.json')) continue;
     const manifest = readManifestSafe(path.join(SESSION_MANIFEST_DIR, entry));
     if (!manifest) continue;
     const candidate = topPendingForManifest(manifest, entry);
-    if (!candidate) continue;
-    if (!best || (candidate.priority || 999) < (best.priority || 999)) {
-      best = candidate;
-    }
+    if (candidate) candidates.push(candidate);
   }
-  return best;
+  candidates.sort((a, b) => (a.priority || 999) - (b.priority || 999));
+  return candidates;
+}
+
+function findNextEligibleTask() {
+  return findEligibleTasks()[0] || null;
 }
 
 function buildNextActionInstruction({ prefix, suffix, next, autoBootstrapped }) {
@@ -67,5 +69,6 @@ function buildNextActionInstruction({ prefix, suffix, next, autoBootstrapped }) 
 module.exports = {
   SESSION_MANIFEST_DIR,
   findNextEligibleTask,
+  findEligibleTasks,
   buildNextActionInstruction,
 };

--- a/plugins/maestro/scripts/lib/maestro-conduct/phase-registry.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/phase-registry.js
@@ -32,27 +32,27 @@ const BASE = Object.freeze({
 
 // Per-phase overrides — keep one row per phase, terse.
 const PHASES = Object.freeze({
-  bootstrap: { budgetMin: 5, detectors: ['silence', 'spinner', 'phaseStall'] },
-  ticket: { budgetMin: 2 },
-  brief: { budgetMin: 10 },
-  brief_gate: { budgetMin: 5 },
-  spec: { budgetMin: 10 },
-  spec_gate: { budgetMin: 5 },
-  tasks: { budgetMin: 10 },
-  tasks_gate: { budgetMin: 5 },
+  bootstrap: { budgetMin: 10, detectors: ['silence', 'spinner', 'phaseStall'] },
+  ticket: { budgetMin: 5 },
+  brief: { budgetMin: 20 },
+  brief_gate: { budgetMin: 15 },
+  spec: { budgetMin: 20 },
+  spec_gate: { budgetMin: 15 },
+  tasks: { budgetMin: 20 },
+  tasks_gate: { budgetMin: 15 },
   implement: {
-    budgetMin: 60,
+    budgetMin: 90,
     detectors: ['question', 'silence', 'spinner', 'phaseStall', 'commitStall', 'prStatus'],
   },
-  commit: { budgetMin: 5 },
-  task_review: { budgetMin: 30 },
-  check: { budgetMin: 15 },
+  commit: { budgetMin: 10 },
+  task_review: { budgetMin: 45 },
+  check: { budgetMin: 30 },
   pr: {
-    budgetMin: 10,
+    budgetMin: 20,
     detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
   },
   ready: {
-    budgetMin: 5,
+    budgetMin: 10,
     detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
   },
   follow_up: {
@@ -63,8 +63,8 @@ const PHASES = Object.freeze({
     budgetMin: 30,
     detectors: ['question', 'silence', 'spinner', 'phaseStall', 'prStatus'],
   },
-  cleanup: { budgetMin: 5 },
-  reports: { budgetMin: 5 },
+  cleanup: { budgetMin: 10 },
+  reports: { budgetMin: 10 },
   complete: { budgetMin: 1 },
 });
 

--- a/plugins/maestro/scripts/lib/maestro-conduct/pr-comments-handler.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/pr-comments-handler.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * Per-tick handler for pr-comments-stuck escalations.
+ *
+ * Lifted out of `maestro-conduct.js` so that file stays under the
+ * max-lines-per-function / file budget. Behavior is unchanged: walks the
+ * stall escalation ladder (soft → interrupt → alert) on the per-phase
+ * cooldown, then advances the marker.
+ */
+
+function buildReason(cHit) {
+  const top = cHit.summary
+    .map((s) => `${s.file}:${s.line} [${s.severity || '?'}] ${s.title}`)
+    .join(' | ');
+  return `PR #${cHit.prNumber} has ${cHit.count} unaddressed bot comment(s), HEAD unchanged ${cHit.minsStuck}m. Top: ${top}`;
+}
+
+function emitAlert({ ctx, cHit, actions, maybeEscalateToDeadEnd }) {
+  const r = actions.alert({
+    session: ctx.session,
+    ticket: ctx.ticket,
+    kind: 'pr-comments-stuck',
+    phase: ctx.phase,
+    prNumber: cHit.prNumber,
+    count: cHit.count,
+    elapsedMin: cHit.minsStuck,
+    summary: cHit.summary,
+    paneTail: (ctx.pane || '').split('\n').slice(-40).join('\n'),
+    instruction: `agent left ${cHit.count} bot comment(s) on PR #${cHit.prNumber} unaddressed for ${cHit.minsStuck}m, HEAD unchanged. Address each bot comment in the PR (never blanket-dismiss as stale). Pane tail in paneTail field.`,
+  });
+  maybeEscalateToDeadEnd(ctx, 'pr-comments-stuck', r.count, null);
+}
+
+function handlePrComments({
+  ctx, cHit, state, actions, phaseFor, escalationFor, bumpMarker, maybeEscalateToDeadEnd,
+}) {
+  const marker = cHit.marker;
+  const sinceLastNudge = marker.lastNudgeAt ? state.minutesSince(marker.lastNudgeAt) : Infinity;
+  const profile = phaseFor(ctx.phase);
+  if (marker.lastNudgeAt && sinceLastNudge < profile.reNudgeMin) return;
+
+  const nudges = marker.nudges || 0;
+  const reason = buildReason(cHit);
+  const escalation = escalationFor(ctx.phase, nudges);
+
+  if (escalation === 'alert') {
+    emitAlert({ ctx, cHit, actions, maybeEscalateToDeadEnd });
+  } else if (escalation === 'interrupt') {
+    actions.interrupt(ctx.session, reason);
+  } else {
+    actions.soft(ctx.session, reason);
+  }
+  bumpMarker(ctx.ticket, 'pr-comments', marker, escalation === 'alert');
+}
+
+module.exports = { handlePrComments, buildReason };

--- a/plugins/maestro/scripts/lib/maestro-conduct/pr-status-payload.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/pr-status-payload.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/**
+ * Build the alert payload for a pr-ready or pr-broken pr-status hit.
+ *
+ * Lifted out of `maestro-conduct.runPrStatusDetector` so that function stays
+ * under the cyclomatic-complexity cap. Both branches share the same `actions.alert`
+ * surface; only the instruction string and the conditional paneTail differ.
+ */
+
+function buildPrReadyInstruction({ ctx, sHit, workSession }) {
+  const sha7 = (sHit.sha || '').slice(0, 7);
+  return `Spawn work-workflow:code-checker (Agent tool, keep alive in tmux until verdict) on PR #${sHit.prNumber} sha=${sha7} for ${ctx.ticket}. Reviewer must answer FOUR questions: (1) Did the agent complete every requirement/AC in the ticket? (2) Did it introduce any bug (logic errors, regressions, broken edge cases)? (3) Did it add any security vulnerability (injection, secrets, unsafe shell, path traversal)? (4) Did it bypass any /work workflow gate (state edits, set-step CLI, completion-checker skip, fake TDD evidence, --no-verify, deferral annotations)? Verdict must be APPROVED only if ALL four are clean. On NEEDS-WORK → forward verbatim findings to ${workSession} via tmux send-keys; re-run after agent pushes. On APPROVED → surface PR URL to operator; operator merges PR and kills tmux sessions ${ctx.ticket}-work + ${ctx.ticket}-listen to free the pool slot.`;
+}
+
+function buildPrBrokenInstruction({ sHit }) {
+  const failingList = (sHit.failingChecks || []).map((c) => `${c.name}(${c.conclusion})`).join(', ');
+  return `UNBLOCK-PROTOCOL: fix-in-PR (no skip, no --no-verify, no scope-creep escape). Failing: ${failingList || 'see PR'}. Never merge red.`;
+}
+
+/**
+ * Build the full alert payload (caller still owns the `actions.alert` call).
+ * Pane tail is only attached for pr-broken: pr-ready hands off to the
+ * code-checker subagent which captures its own context.
+ */
+function buildPayload({ ctx, sHit, workSession, tmux }) {
+  const isReady = sHit.kind === 'pr-ready';
+  const instruction = isReady
+    ? buildPrReadyInstruction({ ctx, sHit, workSession })
+    : buildPrBrokenInstruction({ sHit });
+  const paneTail = isReady
+    ? undefined
+    : tmux.capture(workSession).split('\n').slice(-40).join('\n');
+  return {
+    session: workSession,
+    ticket: ctx.ticket,
+    kind: sHit.kind,
+    phase: ctx.phase,
+    prNumber: sHit.prNumber,
+    sha: sHit.sha,
+    checksState: sHit.checksState,
+    mergeable: sHit.mergeable,
+    failingChecks: sHit.failingChecks,
+    ...(paneTail ? { paneTail } : {}),
+    instruction,
+  };
+}
+
+module.exports = { buildPrReadyInstruction, buildPrBrokenInstruction, buildPayload };

--- a/plugins/maestro/scripts/lib/maestro-conduct/question-handler.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/question-handler.js
@@ -21,7 +21,11 @@ function buildQuestionAlertPayload({ ctx, qHit, mins }) {
     promptKind: qHit.promptKind,
     paneTail: (ctx.pane || '').split('\n').slice(-40).join('\n'),
     instruction:
-      'UNBLOCK-PROTOCOL: refuse-bypass → verify-real-work-done → fix-artifact-NOT-gate → file-root-cause-bug. Pane tail in paneTail field. Answer within Q_WAIT_MIN (3 repeats → DEAD-END).',
+      'UNBLOCK-PROTOCOL: refuse-bypass → verify-real-work-done → fix-artifact-NOT-gate → file-root-cause-bug. ' +
+      'INTERACT-UNTIL-UNBLOCKED: after each tmux answer, capture the pane and check for the NEXT question/menu/permission prompt. ' +
+      'Keep answering in a loop (read pane → send next answer) until the agent phase advances or the prompt buffer is empty ("❯" with no menu below). ' +
+      'A single tmux send-keys is NOT enough — multi-question gates (brief_gate, scope reviews) chain 3-5 prompts in sequence. ' +
+      'Pane tail in paneTail field. Each ignored repeat brings DEAD-END closer (3 repeats → DEAD-END).',
   };
 }
 
@@ -33,11 +37,13 @@ function handleQuestion({ ctx, qHit, state, actions, qWaitMin, maybeEscalateToDe
     return;
   }
   const mins = state.minutesSince(prev.startedAt);
-  if (mins < qWaitMin) return;
-  if (prev.alerted) {
-    const sinceLastAlert = prev.lastAlertAt ? state.minutesSince(prev.lastAlertAt) : Infinity;
-    if (sinceLastAlert < qWaitMin) return;
-  }
+  // First alert: wait qWaitMin so transient prompts don't spam. After that,
+  // re-emit on EVERY tick while the question stays pending — the operator
+  // (orchestrator LLM) needs the INTERACT-UNTIL-UNBLOCKED instruction back
+  // in context constantly to drive multi-prompt brief-gate / scope chains.
+  // Each re-emit increments alert count → eventually hits DEAD_END_REEMITS,
+  // so the operator can't just ignore forever.
+  if (!prev.alerted && mins < qWaitMin) return;
   const r = actions.alert(buildQuestionAlertPayload({ ctx, qHit, mins }));
   state.write(ctx.session, 'question', {
     startedAt: prev.startedAt,

--- a/plugins/maestro/scripts/lib/maestro-conduct/question-handler.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/question-handler.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Per-tick handler for question-pending events.
+ *
+ * Lifted out of `maestro-conduct.js` to keep that file under the
+ * max-lines budget. Behavior unchanged: tracks a per-session marker,
+ * emits a structured alert with paneTail when the wait exceeds
+ * Q_WAIT_MIN, and re-emits on the same cadence so the alert count can
+ * escalate to DEAD-END.
+ */
+
+function buildQuestionAlertPayload({ ctx, qHit, mins }) {
+  return {
+    session: ctx.session,
+    ticket: ctx.ticket,
+    kind: 'question-pending',
+    phase: ctx.phase,
+    elapsedMin: mins,
+    options: qHit.options,
+    promptKind: qHit.promptKind,
+    paneTail: (ctx.pane || '').split('\n').slice(-40).join('\n'),
+    instruction:
+      'UNBLOCK-PROTOCOL: refuse-bypass → verify-real-work-done → fix-artifact-NOT-gate → file-root-cause-bug. Pane tail in paneTail field. Answer within Q_WAIT_MIN (3 repeats → DEAD-END).',
+  };
+}
+
+function handleQuestion({ ctx, qHit, state, actions, qWaitMin, maybeEscalateToDeadEnd }) {
+  const prev = state.read(ctx.session, 'question');
+  const now = state.now();
+  if (!prev) {
+    state.write(ctx.session, 'question', { startedAt: now, alerted: false });
+    return;
+  }
+  const mins = state.minutesSince(prev.startedAt);
+  if (mins < qWaitMin) return;
+  if (prev.alerted) {
+    const sinceLastAlert = prev.lastAlertAt ? state.minutesSince(prev.lastAlertAt) : Infinity;
+    if (sinceLastAlert < qWaitMin) return;
+  }
+  const r = actions.alert(buildQuestionAlertPayload({ ctx, qHit, mins }));
+  state.write(ctx.session, 'question', {
+    startedAt: prev.startedAt,
+    alerted: true,
+    lastAlertAt: state.now(),
+  });
+  maybeEscalateToDeadEnd(ctx, 'question-pending', r.count, null);
+}
+
+module.exports = { handleQuestion, buildQuestionAlertPayload };

--- a/plugins/maestro/scripts/lib/maestro-conduct/wait-mute.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/wait-mute.js
@@ -7,7 +7,8 @@
  * paused on a human action (merge, decision). Emitting phase-stall on every
  * tick during that wait is pure noise — but emitting nothing means the
  * operator can't tell the daemon is still observing. Compromise: count the
- * cycles and emit a single log line every 10th cycle.
+ * cycles and emit a single log line every Nth cycle. N defaults to 60
+ * (~1h at a 60s tick) and is tunable via WAIT_MUTE_LOG_EVERY.
  */
 const LOG_EVERY = parseInt(process.env.WAIT_MUTE_LOG_EVERY || '60', 10);
 

--- a/plugins/maestro/scripts/lib/maestro-conduct/wait-mute.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/wait-mute.js
@@ -9,7 +9,7 @@
  * operator can't tell the daemon is still observing. Compromise: count the
  * cycles and emit a single log line every 10th cycle.
  */
-const LOG_EVERY = 10;
+const LOG_EVERY = parseInt(process.env.WAIT_MUTE_LOG_EVERY || '60', 10);
 
 function noteWaitingForUser({ session, phase, state, alerts }) {
   const m = state.read(session, 'wait-mute') || { count: 0 };

--- a/plugins/maestro/scripts/lib/maestro-conduct/wait-mute.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/wait-mute.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/**
+ * Wait-mute counter for phase-stall.
+ *
+ * When `isHaltedWaitingForUser(pane)` returns true, the agent is correctly
+ * paused on a human action (merge, decision). Emitting phase-stall on every
+ * tick during that wait is pure noise — but emitting nothing means the
+ * operator can't tell the daemon is still observing. Compromise: count the
+ * cycles and emit a single log line every 10th cycle.
+ */
+const LOG_EVERY = 10;
+
+function noteWaitingForUser({ session, phase, state, alerts }) {
+  const m = state.read(session, 'wait-mute') || { count: 0 };
+  m.count += 1;
+  state.write(session, 'wait-mute', m);
+  if (m.count % LOG_EVERY === 0) {
+    alerts.log(`${session} still waiting for user (phase=${phase}) [${m.count} cycles]`);
+  }
+}
+
+module.exports = { noteWaitingForUser, LOG_EVERY };

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -42,7 +42,13 @@ const DETECTORS = {
 // always gets a positive signal every HEARTBEAT_MAX_MIN even if nothing has
 // changed (proves the daemon is alive). State-change beats include any of:
 // activeCount, wedgedCount, prReady/prBroken/prPending counts, ticket set.
-const HEARTBEAT_MIN = parseInt(process.env.HEARTBEAT_MIN || '15', 10); // min gap between any two heartbeats
+//
+// HEARTBEAT_MIN was previously a hard floor that suppressed ALL beats in the
+// first 15m, including real state changes — which contradicted the
+// "state-change-driven" contract (review feedback). It now only rate-limits
+// max-staleness (unchanged-body) beats; a real state change emits
+// immediately regardless of when the last beat was.
+const HEARTBEAT_MIN = parseInt(process.env.HEARTBEAT_MIN || '15', 10); // min gap between two UNCHANGED-state beats
 const HEARTBEAT_MAX_MIN = parseInt(process.env.HEARTBEAT_MAX_MIN || '60', 10); // force-emit cap
 let lastHeartbeatAt = 0;
 let lastHeartbeatBody = '';
@@ -339,13 +345,23 @@ function tickSession(session) {
 
 function maybeEmitHeartbeat(sessions) {
   const now = state.now();
-  // Throttle floor: never emit two heartbeats closer than HEARTBEAT_MIN.
-  if (lastHeartbeatAt && now - lastHeartbeatAt < HEARTBEAT_MIN * 60) return;
   const body = heartbeat.buildHeartbeat(sessions);
-  const stale = !lastHeartbeatAt || now - lastHeartbeatAt >= HEARTBEAT_MAX_MIN * 60;
-  // Emit when the body changed OR when we've hit the max-staleness cap.
-  // Unchanged-state heartbeats are pure noise to the operator.
-  if (body === lastHeartbeatBody && !stale) return;
+  const sinceLast = lastHeartbeatAt ? now - lastHeartbeatAt : Infinity;
+  const bodyChanged = body !== lastHeartbeatBody;
+  const stale = sinceLast >= HEARTBEAT_MAX_MIN * 60;
+
+  // Body changed → emit immediately (state-change-driven contract; review
+  // feedback fixed: the floor used to suppress these for the first 15m).
+  // Body unchanged → respect HEARTBEAT_MIN as a floor and emit only when
+  // we've also hit HEARTBEAT_MAX_MIN (daemon-alive signal).
+  if (bodyChanged) {
+    // emit
+  } else if (stale && sinceLast >= HEARTBEAT_MIN * 60) {
+    // emit
+  } else {
+    return;
+  }
+
   lastHeartbeatAt = now;
   lastHeartbeatBody = body;
   alerts.log(body);

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -23,6 +23,11 @@ const actions = require('./lib/maestro-conduct/actions');
 const alerts = require('./lib/maestro-conduct/alerts');
 const heartbeat = require('./lib/maestro-conduct/heartbeat');
 
+const ciGate = require('./lib/maestro-conduct/ci-gate-rotation');
+const waitMute = require('./lib/maestro-conduct/wait-mute');
+const prStatusPayload = require('./lib/maestro-conduct/pr-status-payload');
+const prCommentsHandler = require('./lib/maestro-conduct/pr-comments-handler');
+
 const DETECTORS = {
   question: require('./lib/maestro-conduct/detectors/question'),
   silence: require('./lib/maestro-conduct/detectors/silence'),
@@ -33,10 +38,14 @@ const DETECTORS = {
   prStatus: require('./lib/maestro-conduct/detectors/pr-status'),
 };
 
-// Heartbeat: every HEARTBEAT_MIN emit a positive summary so silence on the
-// daemon side can't be mistaken for "nothing happening."
-const HEARTBEAT_MIN = parseInt(process.env.HEARTBEAT_MIN || '30', 10);
+// Heartbeat: emit on state-change, with a max-staleness cap so the operator
+// always gets a positive signal every HEARTBEAT_MAX_MIN even if nothing has
+// changed (proves the daemon is alive). State-change beats include any of:
+// activeCount, wedgedCount, prReady/prBroken/prPending counts, ticket set.
+const HEARTBEAT_MIN = parseInt(process.env.HEARTBEAT_MIN || '15', 10); // min gap between any two heartbeats
+const HEARTBEAT_MAX_MIN = parseInt(process.env.HEARTBEAT_MAX_MIN || '60', 10); // force-emit cap
 let lastHeartbeatAt = 0;
+let lastHeartbeatBody = '';
 
 // Re-emit escalation: when the same (session, kind, sha/phase) alert fires
 // this many times, auto-rotate the slot via freeDeadEndSlot.
@@ -88,6 +97,10 @@ function handleQuestion(ctx, qHit) {
     const sinceLastAlert = prev.lastAlertAt ? state.minutesSince(prev.lastAlertAt) : Infinity;
     if (sinceLastAlert < Q_WAIT_MIN) return;
   }
+  // Embed pane tail directly in the event so the orchestrator doesn't have to
+  // re-run tmux capture-pane (saves a Bash round-trip + the pane content is
+  // identical to what the operator would see).
+  const paneTail = (ctx.pane || '').split('\n').slice(-40).join('\n');
   const r = actions.alert({
     session: ctx.session,
     ticket: ctx.ticket,
@@ -96,7 +109,8 @@ function handleQuestion(ctx, qHit) {
     elapsedMin: mins,
     options: qHit.options,
     promptKind: qHit.promptKind,
-    instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — read full menu, pick the option that does NOT bypass any workflow gate (avoid: state-file edits, set-step CLI, completion-checker skip, --no-verify). If all options bypass, send a directive via "Type something".`,
+    paneTail,
+    instruction: `UNBLOCK-PROTOCOL: refuse-bypass → verify-real-work-done → fix-artifact-NOT-gate → file-root-cause-bug. Pane tail in paneTail field. Answer within Q_WAIT_MIN (3 repeats → DEAD-END).`,
   });
   state.write(ctx.session, 'question', {
     startedAt: prev.startedAt,
@@ -137,9 +151,7 @@ function handlePhaseStall(ctx, stallHit) {
   }
   // Suppress when the agent is correctly waiting for a human action (merge, etc.)
   if (isHaltedWaitingForUser(ctx.pane)) {
-    alerts.log(
-      `${ctx.session} phase-stall suppressed — agent halted waiting for user (phase=${ctx.phase})`
-    );
+    waitMute.noteWaitingForUser({ session: ctx.session, phase: ctx.phase, state, alerts });
     return;
   }
   const marker = stallHit.marker;
@@ -152,6 +164,7 @@ function handlePhaseStall(ctx, stallHit) {
   const reason = `phase=${ctx.phase} stuck ${stallHit.elapsedMin}m budget=${stallHit.budgetMin}m nudge ${marker.nudges + 1}/${stallHit.maxNudges}`;
 
   if (escalation === 'alert') {
+    const paneTail = (ctx.pane || '').split('\n').slice(-40).join('\n');
     const r = actions.alert({
       session: ctx.session,
       ticket: ctx.ticket,
@@ -160,7 +173,8 @@ function handlePhaseStall(ctx, stallHit) {
       elapsedMin: stallHit.elapsedMin,
       budgetMin: stallHit.budgetMin,
       nudges: marker.nudges,
-      instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — agent exceeded phase=${ctx.phase} budget (${stallHit.elapsedMin}m vs ${stallHit.budgetMin}m). Diagnose or send directive via "Type something".`,
+      paneTail,
+      instruction: `phase=${ctx.phase} ${stallHit.elapsedMin}m/${stallHit.budgetMin}m. UNBLOCK-PROTOCOL: bad artifact (tasks.md/brief.md) usually root cause, NOT missing work. Pane tail in paneTail field.`,
     });
     maybeEscalateToDeadEnd(ctx, 'nudges-exhausted', r.count, ctx.phase);
   } else if (escalation === 'interrupt') {
@@ -208,9 +222,9 @@ function runSilenceDetector(ctx) {
   if (!restartEligible(ctx.session)) {
     // Helper (-dev / -listen) idle past SILENCE_LIMIT_SEC — don't kill. Refresh
     // marker so silence timer restarts (else fires every tick → log spam).
-    alerts.log(
-      `${ctx.session} AUTO-RESTART skipped: non-work helper session (not restart-eligible)`
-    );
+    // Helper sessions (-listen / -dev) are inert by design; their idleness
+    // carries zero information for the operator. Refresh the marker so the
+    // detector doesn't re-fire each tick, but emit nothing.
     state.write(ctx.session, 'silence', {
       hash: null,
       tokens: null,
@@ -239,11 +253,16 @@ function runSilenceDetector(ctx) {
 }
 
 function runPhaseStallDetector(ctx) {
+  // -listen/-dev helpers inherit ticket phase but have no agent to make progress;
+  // running phase-stall on them accumulates nudges that never resolve → cascade kill.
+  if (!restartEligible(ctx.session)) return;
   const pHit = DETECTORS.phaseStall.detect(ctx);
   if (pHit.hit) handlePhaseStall(ctx, pHit);
 }
 
 function runCommitStallDetector(ctx) {
+  // Helpers can't commit; only -work meaningfully stalls on commits.
+  if (!restartEligible(ctx.session)) return;
   // detector handles its own dedup + marker — only "hits" on threshold crossings.
   const cHit = DETECTORS.commitStall.detect(ctx);
   if (!cHit.hit) return;
@@ -253,6 +272,7 @@ function runCommitStallDetector(ctx) {
 }
 
 function runPrCommentsDetector(ctx) {
+  if (!restartEligible(ctx.session)) return;
   const cHit = DETECTORS.prComments.detect(ctx);
   if (cHit.hit) {
     handlePrComments(ctx, cHit);
@@ -269,6 +289,7 @@ function runPrCommentsDetector(ctx) {
 }
 
 function runPrStatusDetector(ctx) {
+  if (!restartEligible(ctx.session)) return;
   const sHit = DETECTORS.prStatus.detect(ctx);
   if (!sHit.hit) return;
   // pr-pending is informational only — log but never escalate to alert sink.
@@ -281,27 +302,8 @@ function runPrStatusDetector(ctx) {
   // pr-ready / pr-broken → structured alert sink. Target -work explicitly
   // (pr-status dedups per-ticket so -listen could otherwise own the alert).
   const workSession = `${ctx.ticket}-work`;
-  const failingList = (sHit.failingChecks || [])
-    .map((c) => `${c.name}(${c.conclusion})`)
-    .join(', ');
-  const instruction =
-    sHit.kind === 'pr-ready'
-      ? `Spawn work-workflow:code-checker (Agent tool, keep alive in tmux until verdict) on PR #${sHit.prNumber} sha=${(sHit.sha || '').slice(0, 7)} for ${ctx.ticket}. Reviewer must answer FOUR questions: (1) Did the agent complete every requirement/AC in the ticket? (2) Did it introduce any bug (logic errors, regressions, broken edge cases)? (3) Did it add any security vulnerability (injection, secrets, unsafe shell, path traversal)? (4) Did it bypass any /work workflow gate (state edits, set-step CLI, completion-checker skip, fake TDD evidence, --no-verify, deferral annotations)? Verdict must be APPROVED only if ALL four are clean. On NEEDS-WORK → forward verbatim findings to ${workSession} via tmux send-keys; re-run after agent pushes. On APPROVED → surface PR URL to operator; operator merges PR and kills tmux sessions ${ctx.ticket}-work + ${ctx.ticket}-listen to free the pool slot.`
-      : `tmux capture-pane -t ${workSession} -p | tail -40 — drive agent to fix failing checks IN-PR (no skip, no follow-up issue). Failing: ${failingList || 'see PR'}.`;
-  actions.alert({
-    session: workSession,
-    ticket: ctx.ticket,
-    kind: sHit.kind,
-    phase: ctx.phase,
-    prNumber: sHit.prNumber,
-    sha: sHit.sha,
-    checksState: sHit.checksState,
-    mergeable: sHit.mergeable,
-    failingChecks: sHit.failingChecks,
-    instruction,
-  });
-  // CI-gate slot rotation removed: auto-freeing on pr-ready killed -work before
-  // code-checker could forward NEEDS-WORK. Slot freeing is operator-driven now.
+  actions.alert(prStatusPayload.buildPayload({ ctx, sHit, workSession, tmux }));
+  ciGate.maybeFreeOnPrReady({ ctx, sHit, workSession, actions });
 }
 
 /** Run the per-session pipeline. Returns when the session has been fully processed. */
@@ -329,13 +331,30 @@ function tickSession(session) {
   if (detectorsToRun.includes('commitStall')) runCommitStallDetector(ctx);
   if (detectorsToRun.includes('prComments')) runPrCommentsDetector(ctx);
   if (detectorsToRun.includes('prStatus')) runPrStatusDetector(ctx);
+  // Phase-based rotation runs after all detectors so it sees the freshest
+  // marker state, and catches the steady-state pr-ready case independent of
+  // pr-status detector dedup.
+  ciGate.maybeRotateOnPhase({
+    ctx,
+    state,
+    actions,
+    prStatusDetector: DETECTORS.prStatus,
+    restartEligible,
+  });
 }
 
 function maybeEmitHeartbeat(sessions) {
   const now = state.now();
+  // Throttle floor: never emit two heartbeats closer than HEARTBEAT_MIN.
   if (lastHeartbeatAt && now - lastHeartbeatAt < HEARTBEAT_MIN * 60) return;
+  const body = heartbeat.buildHeartbeat(sessions);
+  const stale = !lastHeartbeatAt || now - lastHeartbeatAt >= HEARTBEAT_MAX_MIN * 60;
+  // Emit when the body changed OR when we've hit the max-staleness cap.
+  // Unchanged-state heartbeats are pure noise to the operator.
+  if (body === lastHeartbeatBody && !stale) return;
   lastHeartbeatAt = now;
-  alerts.log(heartbeat.buildHeartbeat(sessions));
+  lastHeartbeatBody = body;
+  alerts.log(body);
 }
 
 function tick() {
@@ -349,40 +368,16 @@ function tick() {
 }
 
 function handlePrComments(ctx, cHit) {
-  const marker = cHit.marker;
-  const sinceLastNudge = marker.lastNudgeAt ? state.minutesSince(marker.lastNudgeAt) : Infinity;
-  const profile = phaseFor(ctx.phase);
-  // Use the same per-phase re-nudge cooldown so we don't spam.
-  if (marker.lastNudgeAt && sinceLastNudge < profile.reNudgeMin) return;
-
-  const nudges = marker.nudges || 0;
-  // Keep re-emitting on reNudgeMin cadence so count grows to DEAD_END_REEMITS;
-  // detector resets the marker when HEAD moves or comments clear.
-  const top = cHit.summary
-    .map((s) => `${s.file}:${s.line} [${s.severity || '?'}] ${s.title}`)
-    .join(' | ');
-  const reason = `PR #${cHit.prNumber} has ${cHit.count} unaddressed bot comment(s), HEAD unchanged ${cHit.minsStuck}m. Top: ${top}`;
-  const escalation = escalationFor(ctx.phase, nudges);
-
-  if (escalation === 'alert') {
-    const r = actions.alert({
-      session: ctx.session,
-      ticket: ctx.ticket,
-      kind: 'pr-comments-stuck',
-      phase: ctx.phase,
-      prNumber: cHit.prNumber,
-      count: cHit.count,
-      elapsedMin: cHit.minsStuck,
-      summary: cHit.summary,
-      instruction: `tmux capture-pane -t ${ctx.session} -p | tail -40 — agent left ${cHit.count} bot comment(s) on PR #${cHit.prNumber} unaddressed for ${cHit.minsStuck}m, HEAD unchanged. Send directive: "Address each bot comment in the PR; never dismiss as stale."`,
-    });
-    maybeEscalateToDeadEnd(ctx, 'pr-comments-stuck', r.count, null);
-  } else if (escalation === 'interrupt') {
-    actions.interrupt(ctx.session, reason);
-  } else {
-    actions.soft(ctx.session, reason);
-  }
-  bumpMarker(ctx.ticket, 'pr-comments', marker, escalation === 'alert');
+  prCommentsHandler.handlePrComments({
+    ctx,
+    cHit,
+    state,
+    actions,
+    phaseFor,
+    escalationFor,
+    bumpMarker,
+    maybeEscalateToDeadEnd,
+  });
 }
 
 function main() {

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -59,7 +59,8 @@ let lastHeartbeatBody = '';
 const DEAD_END_REEMITS = parseInt(process.env.DEAD_END_REEMITS || '3', 10);
 
 function maybeEscalateToDeadEnd(ctx, kind, repeatCount, sha) {
-  if (repeatCount < DEAD_END_REEMITS || ['wait_merge', 'ci', 'complete'].includes(ctx.phase)) return;
+  if (repeatCount < DEAD_END_REEMITS || ['wait_merge', 'ci', 'complete'].includes(ctx.phase))
+    return;
   actions.freeDeadEndSlot({
     session: ctx.session,
     ticket: ctx.ticket,
@@ -298,7 +299,9 @@ function tickSession(session) {
   state.clear(ctx.session, 'question');
   // Reset persisted question-pending count so a later prompt in the same
   // phase doesn't inherit [REPEAT N] and fire freeDeadEndSlot prematurely.
-  alerts.resetCount(alerts.alertKey({ session: ctx.session, kind: 'question-pending', phase: ctx.phase }));
+  alerts.resetCount(
+    alerts.alertKey({ session: ctx.session, kind: 'question-pending', phase: ctx.phase })
+  );
 
   const detectorsToRun = phaseFor(ctx.phase).detectors.filter((k) => k !== 'question');
 
@@ -345,7 +348,18 @@ function tick() {
   // Reconcile manifest task statuses against live tmux at the top of each tick.
   // Cheap (≤ N file reads, only writes on drift) and gives the operator a live
   // view of pool occupancy without polling tmux.
-  try { actions.syncManifest(sessions); } catch (e) { alerts.log(`syncManifest failed: ${e.message}`); }
+  try {
+    actions.syncManifest(sessions);
+  } catch (e) {
+    alerts.log(`syncManifest failed: ${e.message}`);
+  }
+  // Top-up the pool when sessions exit outside the slot-freed path (operator
+  // kill, agent crash, manifest re-added). Gated by AUTO_BOOTSTRAP_NEXT=1.
+  try {
+    actions.maybeFillPool();
+  } catch (e) {
+    alerts.log(`maybeFillPool failed: ${e.message}`);
+  }
   if (!sessions.length) {
     alerts.log('no GH-*-work sessions');
     return;

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -334,13 +334,7 @@ function tickSession(session) {
   // Phase-based rotation runs after all detectors so it sees the freshest
   // marker state, and catches the steady-state pr-ready case independent of
   // pr-status detector dedup.
-  ciGate.maybeRotateOnPhase({
-    ctx,
-    state,
-    actions,
-    prStatusDetector: DETECTORS.prStatus,
-    restartEligible,
-  });
+  ciGate.maybeRotateOnPhase({ ctx, state, actions, restartEligible });
 }
 
 function maybeEmitHeartbeat(sessions) {
@@ -359,6 +353,10 @@ function maybeEmitHeartbeat(sessions) {
 
 function tick() {
   const sessions = tmux.listSessions();
+  // Reconcile manifest task statuses against live tmux at the top of each tick.
+  // Cheap (≤ N file reads, only writes on drift) and gives the operator a live
+  // view of pool occupancy without polling tmux.
+  try { actions.syncManifest(sessions); } catch (e) { alerts.log(`syncManifest failed: ${e.message}`); }
   if (!sessions.length) {
     alerts.log('no GH-*-work sessions');
     return;

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -27,6 +27,7 @@ const ciGate = require('./lib/maestro-conduct/ci-gate-rotation');
 const waitMute = require('./lib/maestro-conduct/wait-mute');
 const prStatusPayload = require('./lib/maestro-conduct/pr-status-payload');
 const prCommentsHandler = require('./lib/maestro-conduct/pr-comments-handler');
+const questionHandler = require('./lib/maestro-conduct/question-handler');
 
 const DETECTORS = {
   question: require('./lib/maestro-conduct/detectors/question'),
@@ -88,42 +89,14 @@ function ctxFor(session) {
 }
 
 function handleQuestion(ctx, qHit) {
-  // Question marker is per-SESSION so -work/-dev/-listen don't clobber each other.
-  const prev = state.read(ctx.session, 'question');
-  const now = state.now();
-  if (!prev) {
-    state.write(ctx.session, 'question', { startedAt: now, alerted: false });
-    return;
-  }
-  const mins = state.minutesSince(prev.startedAt);
-  if (mins < Q_WAIT_MIN) return;
-  // Re-emit on Q_WAIT_MIN cadence so alert count can grow to DEAD_END_REEMITS
-  // and trigger freeDeadEndSlot (one-shot gate previously capped count at 1).
-  if (prev.alerted) {
-    const sinceLastAlert = prev.lastAlertAt ? state.minutesSince(prev.lastAlertAt) : Infinity;
-    if (sinceLastAlert < Q_WAIT_MIN) return;
-  }
-  // Embed pane tail directly in the event so the orchestrator doesn't have to
-  // re-run tmux capture-pane (saves a Bash round-trip + the pane content is
-  // identical to what the operator would see).
-  const paneTail = (ctx.pane || '').split('\n').slice(-40).join('\n');
-  const r = actions.alert({
-    session: ctx.session,
-    ticket: ctx.ticket,
-    kind: 'question-pending',
-    phase: ctx.phase,
-    elapsedMin: mins,
-    options: qHit.options,
-    promptKind: qHit.promptKind,
-    paneTail,
-    instruction: `UNBLOCK-PROTOCOL: refuse-bypass → verify-real-work-done → fix-artifact-NOT-gate → file-root-cause-bug. Pane tail in paneTail field. Answer within Q_WAIT_MIN (3 repeats → DEAD-END).`,
+  questionHandler.handleQuestion({
+    ctx,
+    qHit,
+    state,
+    actions,
+    qWaitMin: Q_WAIT_MIN,
+    maybeEscalateToDeadEnd,
   });
-  state.write(ctx.session, 'question', {
-    startedAt: prev.startedAt,
-    alerted: true,
-    lastAlertAt: state.now(),
-  });
-  maybeEscalateToDeadEnd(ctx, 'question-pending', r.count, null);
 }
 
 // Healthy "waiting on user" patterns the agent emits to the pane while halted.

--- a/plugins/maestro/skills/orchestrate/SKILL.md
+++ b/plugins/maestro/skills/orchestrate/SKILL.md
@@ -92,10 +92,76 @@ QUESTION-DETECTED|AUTO-RESTART|SESSION-GONE|NUDGE|ACTION|pr-ready|pr-broken|wedg
 - **Wedged sessions** suppress further restarts; operator must inspect the pane to unwedge.
 - **Snapshot** anytime with `bash plugins/maestro/scripts/maestro-pulse.sh` (or `/pulse`).
 
+## Unblocking stuck agents — protocol
+
+When a `kind:"question-pending"` event fires, the agent is asking the orchestrator how to proceed. Answer **within Q_WAIT_MIN minutes** — 3 repeats → DEAD-END + `freeDeadEndSlot` kills the session. Follow this order:
+
+### 1. Bypass check — refuse any of these
+
+- Fake RED/GREEN/REFACTOR evidence (stash, delete, re-record without doing the work)
+- `work-state.js set-step`, `set-check`, `add-error`, `set-test-enhancement`
+- Manual `transition` to skip a step without delegating its work via Skill/Task/Agent
+- `userApproval=true` fabricated in any state file
+- `--no-verify`, `--no-gpg-sign`, or any commit-hook-skip flag
+- **Patching the plugin cache from within a /work ticket** (`~/.claude/plugins/cache/...`) — transient (next sync wipes), global (affects every workflow), out of scope
+
+If every option in the menu is a bypass → surface to operator with analysis. Do not pick one to "make it move."
+
+### 2. Legit-block check
+
+Verify the agent already did the real work the gate is checking:
+- RED gate → failing test exists (or task `Type=docs`/`visual-only` with deliverables on disk)
+- GREEN gate → verification command exits 0 and the deliverables exist
+- Docs/visual-only → the documented files are written
+
+If real work IS done and a gate still blocks → the blocker is almost always a **bad artifact** (tasks.md, brief.md, spec.md, work-state.json), not missing work.
+
+### 3. Fix the artifact, not the gate
+
+This is **not a bypass** — it's correcting a wrong document. Common cases and fixes:
+
+| Symptom | Fix |
+|---|---|
+| GREEN recorder rejects silent `grep -q` Test Command (`tdd-phase-state.js` "empty-command trap") | Edit tasks.md to drop `-q` |
+| `Type=wiring` on task whose AC says "docs-only" | Edit tasks.md to set `Type=docs` |
+| Test Command path is wrong | Edit tasks.md path |
+| Brief gate question already answered in brief.md | Edit brief.md to include the answer |
+| Scope-blocked file edit but file legitimately belongs in scope | Edit tasks.md Files-in-scope list |
+
+The orchestrator can edit these files from outside the ticket's active phase even when the in-phase hook blocks the agent. Edit directly, then `tmux send-keys -t <TICKET>-work` with: `I fixed <path>:<line>. Retry.`
+
+### 4. File a bug at the root cause
+
+Always upstream, not at the symptom:
+
+| Symptom | Root cause to file |
+|---|---|
+| GREEN deadlocks `Type=docs` task | "split-in-tasks validator allowed Type/AC mismatch" + "GREEN missing docs-exempt fallback that RED has" |
+| brief_gate Q loops endlessly | "brief-writer produced ambiguous questions" |
+| Tasks have wrong scope | "split-in-tasks scope detection" |
+| Hook blocks legitimate in-scope edit | "protect-task-scope scope detection" |
+
+Search existing issues first (`gh issue list --search`). Use 2-3 keywords from the proposed title; check closed too. Link related issues.
+
+### 5. Long-term over patch
+
+Given the choice between:
+- "Patch the plugin cache to unblock today" — transient, global
+- "Edit the source-of-truth document" — scoped, persistent
+
+…always pick the source-of-truth fix. Cache patches get wiped on next plugin sync and affect every workflow on the machine.
+
+### Pool discipline
+
+`pool=N` means at most N concurrent `-work` sessions. When a ticket dead-ends or you kill one (e.g. GH-511 wedged on operator decision held the slot for hours), free the slot via `maestro-cleanup.js <TICKET> --tmux` and bootstrap the next queued ticket.
+
 ## Anti-patterns
 
 - Do **not** kill sessions belonging to other tickets — scoped per `<TICKET>-work` only.
 - Do **not** auto-merge PRs without operator approval; the orchestrator does not call `gh pr merge`.
 - Do **not** ignore `pr-ready` — that's the positive signal you were waiting for.
 - Do **not** ignore `HEARTBEAT` — it is the periodic forced re-read that exists specifically because operators desensitize to repeated noise.
+- Do **not** let `question-pending` re-fire to DEAD-END — answer within Q_WAIT_MIN.
+- Do **not** allow agents to patch `~/.claude/plugins/cache/` from inside a /work ticket — revert immediately from `~/.claude/plugins/marketplaces/.../scripts/.../task-next.js` (or equivalent pristine source).
+- Do **not** reply `.` or `!` to `question-pending` or `pr-ready` events — those are actionable, not routine.
 - The inbox at `/tmp/claude-agent-inbox/<TICKET>.log` is human-facing; agents do not read it. Talk to agents via `tmux send-keys`.


### PR DESCRIPTION
## Existing Behavior

- Heartbeat fires on a fixed 30-minute timer regardless of whether the conductor state has changed, producing repeated identical log lines that desensitize operators.
- Phase-stall, commit-stall, pr-comments, and pr-status detectors run against every session including helper (-listen/-dev) sessions, causing spurious alerts and cascade-killing the pool on sessions that are inert by design.
- Phase-stall suppression during waiting-for-user emits a log line on every cycle when the agent is correctly paused.
- Alert payloads instruct the operator to run tmux capture-pane themselves to see context; the pane content is not embedded in the event.
- CI-gate slot rotation only fires inline from the pr-status detector; if the detector dedups and never re-emits in the steady-state pr-ready case, the slot is never freed.
- Per-phase budgets are tight (bootstrap 5m, brief 10m, implement 60m, pr 10m), generating premature stall alerts on normal agent pacing.
- maestro-conduct.js contains the full bodies of handlePrComments and runPrStatusDetector inline, pushing the file and function complexity past lint limits.

## Intended New Behavior

- Heartbeat is state-change-driven: skips emission when body is unchanged since last emit, fires immediately on any state change, and falls back to a 60-minute force-emit cap so the operator always gets a liveness signal.
- Phase-stall, commit-stall, pr-comments, and pr-status detectors bail early for non-work (helper) sessions, eliminating spurious alerts against -listen/-dev sessions.
- Waiting-for-user suppression uses a mute counter (wait-mute.js) that logs only every 10th cycle instead of every cycle.
- All actionable alert payloads (question-pending, phase-stall, wedged, pr-comments-stuck, pr-broken) embed paneTail directly so the operator sees context without running an extra Bash command.
- **CI-gate auto slot rotation stays OFF.** Both `maybeFreeOnPrReady` (detector inline) and `maybeRotateOnPhase` (tick-level safety net) in `ci-gate-rotation.js` are intentional no-ops in this PR so that an SUCCESS+CLEAN `pr-ready` does not kill the `-work` session before `code-checker` has a chance to forward NEEDS-WORK back to the agent. The safety-net scaffold is kept in place for a future re-enable once code-checker hand-off is hardened; the wiring is verified by tests but the runtime path is disabled.
- Per-phase budgets roughly doubled across the board (bootstrap 10m, brief 20m, implement 90m, pr 20m).
- handlePrComments and pr-status payload construction extracted into pr-comments-handler.js and pr-status-payload.js; CI-gate rotation into ci-gate-rotation.js; wait-mute into wait-mute.js.
- alerts.js stamps action_required: true on first sight of actionable kinds (question-pending, nudges-exhausted, wedged, dead-end, pr-ready, pr-broken, pr-comments-stuck) so operators can triage with a single field check.
- SKILL.md gains a full Unblocking stuck agents protocol section documenting bypass-refusal rules, legit-block verification, artifact-fix vs gate-fix distinction, and pool discipline.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

New environment variables (set in shell or .envrc before running the conductor):
- HEARTBEAT_MIN=15 — minimum gap in minutes between any two heartbeat emissions (default: 15)
- HEARTBEAT_MAX_MIN=60 — force-emit cap in minutes even if state has not changed (default: 60)

To verify heartbeat throttling:
1. Start the conductor: node plugins/maestro/scripts/maestro-conduct.js
2. With a stable pool (no state changes), confirm the conductor log is silent for up to 60 minutes, then emits exactly one heartbeat.
3. Mutate pool state (e.g. bootstrap a ticket), confirm a heartbeat fires immediately regardless of elapsed time.
4. Set HEARTBEAT_MIN=1 HEARTBEAT_MAX_MIN=2 and confirm two rapid heartbeats do not fire closer together than 1 minute.

To verify helper-session detector bypass:
1. Start a -listen or -dev session alongside a -work session.
2. Let both run past their phase budget.
3. Confirm phase-stall, commit-stall, pr-comments, and pr-status alerts fire only for the -work session; the helper session should produce no alerts.

To verify pane-tail embedding:
1. Trigger a question-pending, phase-stall, wedged, or pr-broken alert.
2. Read the alert JSONL file.
3. Confirm the payload contains a paneTail field with the last 40-50 lines of the pane.
4. Confirm the instruction field no longer contains tmux capture-pane commands.

To verify action_required flag:
1. Trigger a question-pending alert.
2. Confirm the first occurrence has action_required: true.
3. Trigger the same alert again (repeat).
4. Confirm the repeat has action_required: false.

To verify CI-gate rotation is disabled:
1. Advance a ticket to phase=ci with PR in SUCCESS+CLEAN state.
2. Confirm `-work` is NOT killed by the conductor on pr-ready — both `maybeFreeOnPrReady` and `maybeRotateOnPhase` are no-ops so code-checker has time to forward NEEDS-WORK.
3. To re-enable in the future, remove the early-return at the top of each function in `ci-gate-rotation.js`; unit tests already cover the active path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live orchestration daemon (detectors, alerts, auto-bootstrap, manifest writes) but keeps CI slot auto-kill off and uses conservative guards when tmux session lists are empty.
> 
> **Overview**
> **Throttles maestro conductor noise** and makes alerts more operator-friendly while adding manifest-backed pool visibility.
> 
> Heartbeat now fires **immediately on pool state changes** and only rate-limits identical bodies (with a `HEARTBEAT_MAX_MIN` liveness cap). Phase-stall “waiting for user” uses a **muted counter** instead of logging every tick; idle **helper sessions** no longer log silence skips or run stall/PR detectors meant for `-work`.
> 
> Actionable alerts embed **`paneTail`** and **`action_required`** on first emit for key kinds; instructions use an **UNBLOCK-PROTOCOL** style instead of telling operators to run `tmux capture-pane`. **CI-gate auto slot rotation stays disabled** (`ci-gate-rotation.js` no-ops) so `pr-ready` does not kill `-work` before code-checker handoff.
> 
> **Manifest I/O** (`manifest.js`, `next-task.js`): per-tick tmux reconciliation, status updates on bootstrap/slot-freed/dead-end, per-manifest **slot caps** for auto-bootstrap, and **`maybeFillPool`** when `AUTO_BOOTSTRAP_NEXT=1`. Phase **budgets are roughly doubled**; large handler chunks move into dedicated modules. **SKILL.md** documents the unblocking protocol; autorestart test expects **zero** helper silence skip log lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f41564329b78cb6498d6b970a094aa2644648a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->