### PR TITLE
feat(follow-up): auto-detect single-shard CI infra failures and auto-retry up to 3x before dispatching fix-ci (GH-508)

### DIFF
--- a/plugins/work/scripts/workflows/follow-up/__tests__/ci-progression.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/ci-progression.test.js
@@ -192,7 +192,7 @@ describe('CI progression with mocked gh calls', () => {
   });
 
   describe('Scenario 3: CI failing', () => {
-    it('monitor → exitCode 1, triage → fix-ci', () => {
+    it('monitor → exitCode 1, triage → infra-retry (Bug A)', () => {
       setGhMocks({
         checks: [
           { name: 'Test (Node 20)', bucket: 'fail' },
@@ -214,7 +214,7 @@ describe('CI progression with mocked gh calls', () => {
       state.currentStep = 'triage';
       triage(state, {});
       assert.equal(state.failureCategory, 'ci_failure');
-      assert.equal(state.currentStep, 'fix-ci');
+      assert.equal(state.currentStep, 'infra-retry');
     });
   });
 
@@ -267,7 +267,7 @@ describe('CI progression with mocked gh calls', () => {
   });
 
   describe('Scenario 6: pending checks + failure → fail fast', () => {
-    it('2 pending + 1 fail → triage → fix-ci (does not wait for pending)', () => {
+    it('2 pending + 1 fail → triage → infra-retry (does not wait for pending) (Bug A)', () => {
       setGhMocks({
         checks: [
           { name: 'Cursor Bugbot', bucket: 'pending' },
@@ -290,7 +290,7 @@ describe('CI progression with mocked gh calls', () => {
       state.currentStep = 'triage';
       triage(state, {});
       assert.equal(state.failureCategory, 'ci_failure');
-      assert.equal(state.currentStep, 'fix-ci');
+      assert.equal(state.currentStep, 'infra-retry');
     });
   });
 

--- a/plugins/work/scripts/workflows/follow-up/__tests__/classifier-ctx-smoke.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/classifier-ctx-smoke.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * Structural smoke test: `lib/classifier-ctx.js` is reachable in isolation,
+ * exposes the documented contract, and mirrors `state._ciFailedTests` onto
+ * `state.failedTests` (the deliberate back-compat state mutation).
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('lib/classifier-ctx — smoke (isolated require)', () => {
+  it('exports buildExecForCtx and buildClassifierCtx', () => {
+    const mod = require('../lib/classifier-ctx');
+    assert.equal(typeof mod.buildExecForCtx, 'function');
+    assert.equal(typeof mod.buildClassifierCtx, 'function');
+  });
+
+  it('buildClassifierCtx surfaces the documented fields and mirrors failedTests onto state', () => {
+    const { buildClassifierCtx } = require('../lib/classifier-ctx');
+    const state = {
+      _ciFailedJobs: [{ runId: '987', jobId: '111' }],
+      _ciAllJobs: [{ name: 'shard-1' }, { name: 'shard-2' }],
+      _ciFailedLogs: 'cache: MISS\n',
+      _ciFailedTests: ['src/foo.test.ts'],
+      _ciStatus: 'failing',
+    };
+    const ctx = buildClassifierCtx(state, '/nonexistent/path');
+    assert.equal(typeof ctx.exec, 'function');
+    assert.ok(Array.isArray(ctx.allJobs));
+    assert.equal(ctx.allJobs.length, 2);
+    assert.ok(Array.isArray(ctx.prDiffFiles)); // fails open with [] on bad path
+    assert.equal(ctx.rawLogs, 'cache: MISS\n');
+    assert.equal(ctx.runId, '987');
+    assert.equal(ctx.jobId, '111');
+    assert.equal(ctx.ciStatus, 'failing');
+    assert.deepEqual(state.failedTests, ['src/foo.test.ts'], 'mirrors onto state.failedTests');
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-auto-advance-surface.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-auto-advance-surface.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+/**
+ * Task 6.2 (RED): hooks/follow-up-auto-advance.js must treat
+ * `action: 'surface'` as a terminal instruction — same as 'blocked' — so the
+ * auto-advance loop stops and a user-visible message containing the surface
+ * reason (e.g. 'infra-stuck') is emitted.
+ *
+ * Two complementary checks:
+ *   1. End-to-end: run the hook with a stubbed `follow-up-next.js` returning
+ *      `{action:'surface', payload:{reason:'infra-stuck'}}` — assert exit 0,
+ *      banner printed, single invocation (no loop), 'infra-stuck' in stdout.
+ *   2. Source-text: hook source mentions 'surface' alongside 'blocked' in the
+ *      action-dispatch / terminal-set handling.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const HOOK_PATH = path.resolve(
+  __dirname,
+  '..',
+  'hooks',
+  'follow-up-auto-advance.js'
+);
+const HOOK_SRC = fs.readFileSync(HOOK_PATH, 'utf8');
+
+const MARKER = '.follow-up-orchestrator.pid';
+
+let TASKS_BASE;
+let WORKTREES_BASE;
+let STUB_NEXT_PATH;
+let INVOCATION_LOG;
+let TMP_ROOT;
+
+function setupStub(stubInstruction) {
+  // Use the FOLLOW_UP_NEXT_PATH test seam so we can run the REAL hook in place
+  // (no staging needed). Production code never sets that env var.
+  TMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-aa-surface-'));
+  WORKTREES_BASE = TMP_ROOT;
+  TASKS_BASE = path.join(TMP_ROOT, 'tasks');
+  fs.mkdirSync(TASKS_BASE, { recursive: true });
+
+  STUB_NEXT_PATH = path.join(TMP_ROOT, 'follow-up-next.js');
+  INVOCATION_LOG = path.join(TMP_ROOT, 'invocations.log');
+
+  const stub = [
+    '#!/usr/bin/env node',
+    "'use strict';",
+    'const fs = require("fs");',
+    `fs.appendFileSync(${JSON.stringify(INVOCATION_LOG)}, "called\\n");`,
+    `process.stdout.write(${JSON.stringify(JSON.stringify(stubInstruction))});`,
+    'process.exit(0);',
+  ].join('\n');
+  fs.writeFileSync(STUB_NEXT_PATH, stub, { mode: 0o755 });
+}
+
+function writeMarker(ticket) {
+  const dir = path.join(TASKS_BASE, ticket);
+  fs.mkdirSync(dir, { recursive: true });
+  // Tag the marker with the current session + worktree so the hook
+  // claims it as its own.
+  // Omit worktreeRoot so the marker is treated as legacy (non-foreign) by
+  // findActiveMarker; sessionId match makes it explicitly owned by us.
+  fs.writeFileSync(
+    path.join(dir, MARKER),
+    JSON.stringify({
+      ticket,
+      startedAt: new Date().toISOString(),
+      workflow: '/follow-up',
+      sessionId: 'sess-test',
+    })
+  );
+}
+
+function runStagedHook(hookData, env = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [STAGED_HOOK_PATH], {
+      input: JSON.stringify(hookData),
+      encoding: 'utf8',
+      timeout: 20000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        CLAUDE_CODE_SESSION_ID: 'sess-test',
+        WORKTREES_BASE,
+        TASKS_BASE,
+        ...env,
+      },
+    });
+    return { exitCode: 0, stdout };
+  } catch (err) {
+    return {
+      exitCode: err.status,
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+    };
+  }
+}
+
+describe('follow-up-auto-advance hook — surface action (Task 6.2)', () => {
+  let stageRoot;
+
+  afterEach(() => {
+    if (stageRoot) {
+      fs.rmSync(stageRoot, { recursive: true, force: true });
+      stageRoot = null;
+    }
+    if (TASKS_BASE && fs.existsSync(TASKS_BASE)) {
+      // TASKS_BASE lives under a separate tmp; remove its parent.
+      const parent = path.dirname(TASKS_BASE);
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('treats action:surface as terminal and emits a user-visible message', () => {
+    ({ stageRoot } = setupStagedHook({
+      action: 'surface',
+      payload: { reason: 'infra-stuck' },
+      summary: 'Surface: infra-stuck after 3 retries',
+    }));
+    writeMarker('GH-508');
+
+    const r = runStagedHook({
+      tool_name: 'Task',
+      transcript_path: '/tmp/t.jsonl',
+      session_id: 'sess-test',
+    });
+
+    assert.equal(r.exitCode, 0, `hook should exit 0; got ${r.exitCode}`);
+    assert.match(
+      r.stdout,
+      /infra-stuck/,
+      'hook stdout must contain the surface reason'
+    );
+    assert.match(
+      r.stdout,
+      /SURFACE|surface/,
+      'hook stdout must include a SURFACE banner identifying the terminal action'
+    );
+
+    // Single invocation of follow-up-next — the hook MUST NOT loop after surface.
+    const calls = fs.existsSync(INVOCATION_LOG)
+      ? fs.readFileSync(INVOCATION_LOG, 'utf8').split('\n').filter(Boolean)
+      : [];
+    assert.equal(
+      calls.length,
+      1,
+      `expected exactly 1 invocation of follow-up-next (surface is terminal); got ${calls.length}`
+    );
+  });
+
+  it('hook source declares surface alongside blocked in the terminal-action handling', () => {
+    assert.match(
+      HOOK_SRC,
+      /['"]surface['"]/,
+      "hook source must reference the 'surface' action literal"
+    );
+    // Mirrors the existing 'blocked' handling: either an explicit branch or a
+    // TERMINAL_ACTIONS set listing blocked + surface (+ complete).
+    const hasSurfaceBranch =
+      /action\s*===\s*['"]surface['"]/.test(HOOK_SRC) ||
+      /TERMINAL_ACTIONS[\s\S]{0,200}surface/.test(HOOK_SRC);
+    assert.ok(
+      hasSurfaceBranch,
+      "hook must dispatch on action==='surface' (or include it in a TERMINAL_ACTIONS set) the way 'blocked' is dispatched"
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-auto-advance-surface.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-auto-advance-surface.test.js
@@ -77,20 +77,27 @@ function writeMarker(ticket) {
   );
 }
 
-function runStagedHook(hookData, env = {}) {
+function runHook(hookData, env = {}) {
   try {
-    const stdout = execFileSync(process.execPath, [STAGED_HOOK_PATH], {
+    const stdout = execFileSync(process.execPath, [HOOK_PATH], {
       input: JSON.stringify(hookData),
       encoding: 'utf8',
       timeout: 20000,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        CLAUDE_CODE_SESSION_ID: 'sess-test',
-        WORKTREES_BASE,
-        TASKS_BASE,
-        ...env,
-      },
+      env: (() => {
+        const e = { ...process.env };
+        // Hook guards itself with NODE_TEST_CONTEXT to avoid auto-run under
+        // `node --test`; scrub it for the child so main() executes.
+        delete e.NODE_TEST_CONTEXT;
+        return {
+          ...e,
+          CLAUDE_CODE_SESSION_ID: 'sess-test',
+          WORKTREES_BASE,
+          TASKS_BASE,
+          FOLLOW_UP_NEXT_PATH: STUB_NEXT_PATH,
+          ...env,
+        };
+      })(),
     });
     return { exitCode: 0, stdout };
   } catch (err) {
@@ -103,29 +110,22 @@ function runStagedHook(hookData, env = {}) {
 }
 
 describe('follow-up-auto-advance hook — surface action (Task 6.2)', () => {
-  let stageRoot;
-
   afterEach(() => {
-    if (stageRoot) {
-      fs.rmSync(stageRoot, { recursive: true, force: true });
-      stageRoot = null;
-    }
-    if (TASKS_BASE && fs.existsSync(TASKS_BASE)) {
-      // TASKS_BASE lives under a separate tmp; remove its parent.
-      const parent = path.dirname(TASKS_BASE);
-      fs.rmSync(parent, { recursive: true, force: true });
+    if (TMP_ROOT && fs.existsSync(TMP_ROOT)) {
+      fs.rmSync(TMP_ROOT, { recursive: true, force: true });
+      TMP_ROOT = null;
     }
   });
 
   it('treats action:surface as terminal and emits a user-visible message', () => {
-    ({ stageRoot } = setupStagedHook({
+    setupStub({
       action: 'surface',
       payload: { reason: 'infra-stuck' },
       summary: 'Surface: infra-stuck after 3 retries',
-    }));
+    });
     writeMarker('GH-508');
 
-    const r = runStagedHook({
+    const r = runHook({
       tool_name: 'Task',
       transcript_path: '/tmp/t.jsonl',
       session_id: 'sess-test',

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-auto-advance-surface.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-auto-advance-surface.test.js
@@ -14,19 +14,14 @@
  *      action-dispatch / terminal-set handling.
  */
 
-const { describe, it, beforeEach, afterEach } = require('node:test');
+const { describe, it, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const HOOK_PATH = path.resolve(
-  __dirname,
-  '..',
-  'hooks',
-  'follow-up-auto-advance.js'
-);
+const HOOK_PATH = path.resolve(__dirname, '..', 'hooks', 'follow-up-auto-advance.js');
 const HOOK_SRC = fs.readFileSync(HOOK_PATH, 'utf8');
 
 const MARKER = '.follow-up-orchestrator.pid';
@@ -132,11 +127,7 @@ describe('follow-up-auto-advance hook — surface action (Task 6.2)', () => {
     });
 
     assert.equal(r.exitCode, 0, `hook should exit 0; got ${r.exitCode}`);
-    assert.match(
-      r.stdout,
-      /infra-stuck/,
-      'hook stdout must contain the surface reason'
-    );
+    assert.match(r.stdout, /infra-stuck/, 'hook stdout must contain the surface reason');
     assert.match(
       r.stdout,
       /SURFACE|surface/,

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-auto-advance-surface.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-auto-advance-surface.test.js
@@ -133,6 +133,14 @@ describe('follow-up-auto-advance hook — surface action (Task 6.2)', () => {
       /SURFACE|surface/,
       'hook stdout must include a SURFACE banner identifying the terminal action'
     );
+    // Bug D (GH-508): banner reads from payload.reason — must NOT degrade to
+    // 'unknown' when the payload is well-formed.
+    assert.match(r.stdout, /reason:\s*infra-stuck/, 'banner must show the actual reason');
+    assert.doesNotMatch(
+      r.stdout,
+      /reason:\s*unknown/,
+      'banner must NOT fall back to "unknown" for a well-formed surface payload'
+    );
 
     // Single invocation of follow-up-next — the hook MUST NOT loop after surface.
     const calls = fs.existsSync(INVOCATION_LOG)

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-default-branch.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-default-branch.test.js
@@ -15,6 +15,16 @@ const path = require('node:path');
 const cp = require('node:child_process');
 
 const NEXT_PATH = require.resolve('../follow-up-next.js');
+const REPO_META_PATH = require.resolve('../lib/repo-meta.js');
+
+function freshNext() {
+  // The default-branch + diff helpers cache per-worktree at the module level
+  // of `lib/repo-meta.js`. Drop both modules from the cache so each test gets
+  // a fresh cache (replaces the prior `_resetDefaultBranchCache` escape hatch).
+  delete require.cache[NEXT_PATH];
+  delete require.cache[REPO_META_PATH];
+  return require(NEXT_PATH);
+}
 
 let TMP;
 let WORKTREE;
@@ -55,10 +65,7 @@ describe('follow-up-next — default branch detection (Bug F)', () => {
   });
 
   it('detectDefaultBranch falls back to git remote show origin when gh is unavailable', () => {
-    // Reload module to clear the per-process cache.
-    delete require.cache[NEXT_PATH];
-    const mod = require(NEXT_PATH);
-    mod.__test__._resetDefaultBranchCache();
+    const mod = freshNext();
     const branch = mod.__test__.detectDefaultBranch(WORKTREE);
     // `gh repo view` will fail without auth in the sandbox; fallback path
     // reads `git remote show origin` → returns 'develop'. If gh somehow
@@ -69,9 +76,7 @@ describe('follow-up-next — default branch detection (Bug F)', () => {
   });
 
   it('loadPrDiffFiles uses the detected branch (returns the feature commit file)', () => {
-    delete require.cache[NEXT_PATH];
-    const mod = require(NEXT_PATH);
-    mod.__test__._resetDefaultBranchCache();
+    const mod = freshNext();
     const files = mod.__test__.loadPrDiffFiles(WORKTREE);
     // Diff between origin/develop and HEAD should include new.txt — the
     // hardcoded `origin/main` would have returned [] because no such ref exists.
@@ -87,9 +92,7 @@ describe('follow-up-next — default branch detection (Bug F)', () => {
   it('cache is keyed per worktree, not shared across worktrees', () => {
     // Bug #542-5 (GH-508): the cache used to be a single var, so a second
     // worktree in the same process would receive the first worktree's branch.
-    delete require.cache[NEXT_PATH];
-    const mod = require(NEXT_PATH);
-    mod.__test__._resetDefaultBranchCache();
+    const mod = freshNext();
 
     // Build a second sibling worktree whose origin defaults to `master`.
     const TMP2 = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-default-branch-2-'));

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-default-branch.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-default-branch.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * Bug F (GH-508): loadPrDiffFiles must use the repo's detected default branch,
+ * not a hardcoded `origin/main`. Repos defaulting to `develop`/`master`/etc.
+ * previously got empty diffs, which made signal3 (unrelated failures)
+ * misclassify every CI failure.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+const NEXT_PATH = require.resolve('../follow-up-next.js');
+
+let TMP;
+let WORKTREE;
+
+function sh(cmd, cwd) {
+  return cp.execSync(cmd, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+}
+
+describe('follow-up-next — default branch detection (Bug F)', () => {
+  before(() => {
+    // Stand up a tiny git repo with `develop` as the default branch, and an
+    // `origin/develop` ref so `git diff --name-only origin/develop...HEAD`
+    // resolves. No `origin/main` exists — the hardcoded path would fail open
+    // (return []) where the dynamic path returns real files.
+    TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-default-branch-'));
+    const bare = path.join(TMP, 'origin.git');
+    WORKTREE = path.join(TMP, 'work');
+    fs.mkdirSync(bare);
+    fs.mkdirSync(WORKTREE);
+    sh('git init --bare --initial-branch=develop .', bare);
+
+    sh('git init --initial-branch=develop .', WORKTREE);
+    sh('git config user.email "t@t"', WORKTREE);
+    sh('git config user.name "T"', WORKTREE);
+    fs.writeFileSync(path.join(WORKTREE, 'base.txt'), 'base\n');
+    sh('git add base.txt', WORKTREE);
+    sh('git commit -m base', WORKTREE);
+    sh(`git remote add origin ${bare}`, WORKTREE);
+    sh('git push origin develop', WORKTREE);
+    sh('git checkout -b feature', WORKTREE);
+    fs.writeFileSync(path.join(WORKTREE, 'new.txt'), 'new\n');
+    sh('git add new.txt', WORKTREE);
+    sh('git commit -m feature', WORKTREE);
+  });
+
+  after(() => {
+    if (TMP && fs.existsSync(TMP)) fs.rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('detectDefaultBranch falls back to git remote show origin when gh is unavailable', () => {
+    // Reload module to clear the per-process cache.
+    delete require.cache[NEXT_PATH];
+    const mod = require(NEXT_PATH);
+    mod.__test__._resetDefaultBranchCache();
+    const branch = mod.__test__.detectDefaultBranch(WORKTREE);
+    // `gh repo view` will fail without auth in the sandbox; fallback path
+    // reads `git remote show origin` → returns 'develop'. If gh somehow
+    // succeeds for the cwd's outer repo, branch could differ — accept either
+    // the temp repo's 'develop' or 'main' (gh's fallback). The contract is
+    // that it must NOT crash and must return a non-empty string.
+    assert.ok(typeof branch === 'string' && branch.length > 0);
+  });
+
+  it('loadPrDiffFiles uses the detected branch (returns the feature commit file)', () => {
+    delete require.cache[NEXT_PATH];
+    const mod = require(NEXT_PATH);
+    mod.__test__._resetDefaultBranchCache();
+    const files = mod.__test__.loadPrDiffFiles(WORKTREE);
+    // Diff between origin/develop and HEAD should include new.txt — the
+    // hardcoded `origin/main` would have returned [] because no such ref exists.
+    assert.ok(Array.isArray(files), 'loadPrDiffFiles returns an array');
+    // The test is meaningful only if we actually detected develop. When gh
+    // sneaks in a different branch from the outer repo, the diff is empty
+    // but the call still succeeds.
+    if (mod.__test__.detectDefaultBranch(WORKTREE) === 'develop') {
+      assert.ok(files.includes('new.txt'), 'diff against origin/develop must list new.txt');
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-default-branch.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-default-branch.test.js
@@ -83,4 +83,48 @@ describe('follow-up-next — default branch detection (Bug F)', () => {
       assert.ok(files.includes('new.txt'), 'diff against origin/develop must list new.txt');
     }
   });
+
+  it('cache is keyed per worktree, not shared across worktrees', () => {
+    // Bug #542-5 (GH-508): the cache used to be a single var, so a second
+    // worktree in the same process would receive the first worktree's branch.
+    delete require.cache[NEXT_PATH];
+    const mod = require(NEXT_PATH);
+    mod.__test__._resetDefaultBranchCache();
+
+    // Build a second sibling worktree whose origin defaults to `master`.
+    const TMP2 = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-default-branch-2-'));
+    const bare2 = path.join(TMP2, 'origin.git');
+    const WT2 = path.join(TMP2, 'work');
+    fs.mkdirSync(bare2);
+    fs.mkdirSync(WT2);
+    sh('git init --bare --initial-branch=master .', bare2);
+    sh('git init --initial-branch=master .', WT2);
+    sh('git config user.email "t@t"', WT2);
+    sh('git config user.name "T"', WT2);
+    fs.writeFileSync(path.join(WT2, 'b.txt'), 'b\n');
+    sh('git add b.txt', WT2);
+    sh('git commit -m b', WT2);
+    sh(`git remote add origin ${bare2}`, WT2);
+    sh('git push origin master', WT2);
+
+    const first = mod.__test__.detectDefaultBranch(WORKTREE);
+    const second = mod.__test__.detectDefaultBranch(WT2);
+
+    // Both must be honored independently — distinct cache entries per worktree.
+    // gh repo view may resolve to the outer repo's branch in either call;
+    // accept any non-empty string, but assert the second call did NOT return
+    // a stale 'develop' from the first worktree's fallback path.
+    assert.ok(typeof first === 'string' && first.length > 0);
+    assert.ok(typeof second === 'string' && second.length > 0);
+    if (first === 'develop' && second !== 'develop') {
+      // Per-worktree cache worked as expected when gh is unavailable.
+      assert.notStrictEqual(
+        second,
+        'develop',
+        'second worktree must not inherit first worktree branch'
+      );
+    }
+
+    fs.rmSync(TMP2, { recursive: true, force: true });
+  });
 });

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-ctx.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-ctx.test.js
@@ -153,4 +153,71 @@ describe('follow-up-next.js — ctx wiring (Bug 2)', () => {
 
     delete process.env.WORK_AUTO_RETRY_INFRA;
   });
+
+  it('PR #542: rebuilds ctx inside the loop so a step that mutates state._ciStatus is visible to the next step', () => {
+    delete require.cache[FOLLOW_UP_NEXT_PATH];
+    delete require.cache[STEP_REGISTRY_PATH];
+
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-next-ctx-loop-'));
+    const tasksBase = path.join(tmp, 'tasks');
+    fs.mkdirSync(path.join(tasksBase, 'GH-LOOP'), { recursive: true });
+
+    const state = {
+      ticketId: 'GH-LOOP',
+      prNumber: 542,
+      currentStep: 'monitor',
+      status: 'in_progress',
+      attempt: 1,
+      maxAttempts: 40,
+      _ciStatus: 'failing',
+      _ciAllJobs: [],
+      _ciFailedLogs: '',
+      failureCategory: null,
+    };
+    fs.writeFileSync(
+      path.join(tasksBase, 'GH-LOOP', '.' + 'follow-up' + '-state.json'),
+      JSON.stringify(state, null, 2)
+    );
+    process.env.TASKS_BASE = tasksBase;
+    process.env.WORKTREES_BASE = tmp;
+
+    const observed = [];
+    require.cache[STEP_REGISTRY_PATH] = {
+      id: STEP_REGISTRY_PATH,
+      filename: STEP_REGISTRY_PATH,
+      loaded: true,
+      exports: {
+        STEPS: ['monitor', 'infra-retry'],
+        runStep: (stepName, st, ctx) => {
+          observed.push({ stepName, ciStatus: ctx.ciStatus, rawLogs: ctx.rawLogs });
+          if (stepName === 'monitor') {
+            // Simulate monitor refreshing CI state mid-loop.
+            st._ciStatus = 'success';
+            st._ciFailedLogs = 'cache HIT\n';
+            return null; // advance to next step
+          }
+          // Terminal so the loop exits.
+          return { type: 'follow_up_instruction', action: 'blocked', reason: 'captured' };
+        },
+      },
+    };
+
+    const mod = require(FOLLOW_UP_NEXT_PATH);
+    mod.getNextInstruction('GH-LOOP', 542);
+
+    assert.equal(observed.length, 2, 'both steps must run in one invocation');
+    assert.equal(observed[0].stepName, 'monitor');
+    assert.equal(observed[0].ciStatus, 'failing', 'monitor sees the pre-mutation snapshot');
+    assert.equal(observed[1].stepName, 'infra-retry');
+    assert.equal(
+      observed[1].ciStatus,
+      'success',
+      'infra-retry must see the post-monitor _ciStatus, not the snapshot taken before the loop'
+    );
+    assert.match(
+      observed[1].rawLogs,
+      /cache HIT/,
+      'infra-retry must see the post-monitor _ciFailedLogs'
+    );
+  });
 });

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-ctx.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-ctx.test.js
@@ -138,7 +138,6 @@ describe('follow-up-next.js — ctx wiring (Bug 2)', () => {
     );
     process.env.TASKS_BASE = tasksBase;
     process.env.WORKTREES_BASE = tmp;
-    process.env.WORK_AUTO_RETRY_INFRA = 'true';
 
     const mod = require(FOLLOW_UP_NEXT_PATH);
     mod.getNextInstruction('GH-CTX4', 542);
@@ -151,8 +150,6 @@ describe('follow-up-next.js — ctx wiring (Bug 2)', () => {
       'succeeded',
       'pending attempt must be marked succeeded when _ciStatus=success in state'
     );
-
-    delete process.env.WORK_AUTO_RETRY_INFRA;
   });
 
   it('PR #542: rebuilds ctx inside the loop so a step that mutates state._ciStatus is visible to the next step', () => {

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-ctx.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-ctx.test.js
@@ -116,6 +116,7 @@ describe('follow-up-next.js — ctx wiring (Bug 2)', () => {
       maxAttempts: 40,
       _ciFailedJobs: [],
       _ciStatus: 'success',
+      _ciStatusFreshness: { pid: process.pid, at: new Date().toISOString() },
       failureCategory: 'ci_failure',
       infraRetry: {
         count: 1,

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-ctx.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-ctx.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+/**
+ * Regression: follow-up-next.js must build a ctx that the classifier and the
+ * infra-retry step can actually use. Before this fix, ctx had only
+ * { tasksDir, worktreeDir, TASKS_BASE, workScriptsDir } — so classifier saw
+ * no allJobs / prDiffFiles / rawLogs / exec / jobId / ciStatus and trivially
+ * returned code-failure, defeating the whole feature.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const FOLLOW_UP_NEXT_PATH = require.resolve('../follow-up-next.js');
+const STEP_REGISTRY_PATH = require.resolve('../lib/step-registry.js');
+
+function loadWithStubs(stateFixture, captured) {
+  delete require.cache[FOLLOW_UP_NEXT_PATH];
+  delete require.cache[STEP_REGISTRY_PATH];
+
+  // Build a state file the loader will read.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-next-ctx-'));
+  const tasksBase = path.join(tmp, 'tasks');
+  fs.mkdirSync(path.join(tasksBase, 'GH-CTX'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tasksBase, 'GH-CTX', '.' + 'follow-up' + '-state.json'),
+    JSON.stringify(stateFixture, null, 2)
+  );
+  process.env.TASKS_BASE = tasksBase;
+  process.env.WORKTREES_BASE = tmp;
+
+  // Stub the step registry with a single capture step matching the state's
+  // currentStep.
+  require.cache[STEP_REGISTRY_PATH] = {
+    id: STEP_REGISTRY_PATH,
+    filename: STEP_REGISTRY_PATH,
+    loaded: true,
+    exports: {
+      STEPS: [stateFixture.currentStep, 'report'],
+      runStep: (stepName, state, ctx) => {
+        captured.stepName = stepName;
+        captured.ctx = ctx;
+        captured.state = state;
+        // Return a non-null instruction so the loop exits immediately.
+        return { type: 'follow_up_instruction', action: 'blocked', reason: 'captured' };
+      },
+    },
+  };
+
+  return require(FOLLOW_UP_NEXT_PATH);
+}
+
+describe('follow-up-next.js — ctx wiring (Bug 2)', () => {
+  it('passes ciStatus, exec, jobId, prDiffFiles, allJobs, rawLogs to step handlers', () => {
+    const captured = {};
+    const state = {
+      ticketId: 'GH-508',
+      prNumber: 542,
+      currentStep: 'infra-retry',
+      status: 'in_progress',
+      attempt: 1,
+      maxAttempts: 40,
+      _ciFailedJobs: [{ name: 'e2e [shard-4]', runId: '987654', id: '111' }],
+      _ciStatus: 'failing',
+      _ciFailedLogs: 'cache: MISS\nfallback install FAILED\n',
+      _ciAllJobs: [{ name: 'e2e [shard-1]' }, { name: 'e2e [shard-4]' }],
+      failureCategory: null,
+    };
+    const mod = loadWithStubs(state, captured);
+    mod.getNextInstruction('GH-CTX', 542);
+
+    assert.ok(captured.ctx, 'ctx must be passed to the step handler');
+    const ctx = captured.ctx;
+
+    // Existing fields preserved.
+    assert.ok(ctx.tasksDir, 'tasksDir');
+    assert.ok(ctx.workScriptsDir, 'workScriptsDir');
+
+    // New fields the classifier needs.
+    assert.equal(typeof ctx.exec, 'function', 'ctx.exec must be a function');
+    assert.ok('ciStatus' in ctx, 'ctx.ciStatus must be present (read by maybeHandleRetrySuccess)');
+    assert.ok('jobId' in ctx, 'ctx.jobId must be present (read by signal2)');
+    assert.ok(Array.isArray(ctx.prDiffFiles), 'ctx.prDiffFiles must be an array');
+    assert.ok(Array.isArray(ctx.allJobs), 'ctx.allJobs must be an array');
+    assert.equal(typeof ctx.rawLogs, 'string', 'ctx.rawLogs must be a string');
+
+    // jobId from the first failed job's id field.
+    assert.equal(ctx.jobId, '111');
+    // allJobs from state._ciAllJobs.
+    assert.equal(ctx.allJobs.length, 2);
+    // rawLogs from state._ciFailedLogs.
+    assert.match(ctx.rawLogs, /cache: MISS/);
+  });
+
+  it('Bug 4: infra-retry step sees ctx.ciStatus=success from state._ciStatus and detects retry-success', () => {
+    // Use the production ctx builder to drive the REAL infra-retry handler.
+    // Reset registries so the real step-registry is loaded (no stub).
+    delete require.cache[FOLLOW_UP_NEXT_PATH];
+    delete require.cache[STEP_REGISTRY_PATH];
+
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-next-ctx-bug4-'));
+    const tasksBase = path.join(tmp, 'tasks');
+    fs.mkdirSync(path.join(tasksBase, 'GH-CTX4'), { recursive: true });
+
+    const state = {
+      ticketId: 'GH-CTX4',
+      prNumber: 542,
+      currentStep: 'infra-retry',
+      status: 'in_progress',
+      attempt: 1,
+      maxAttempts: 40,
+      _ciFailedJobs: [],
+      _ciStatus: 'success',
+      failureCategory: 'ci_failure',
+      infraRetry: {
+        count: 1,
+        attempts: [
+          {
+            attemptNumber: 1,
+            timestamp: '2026-01-01T00:00:00.000Z',
+            runId: '11111',
+            signals: ['signal1', 'signal2'],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+        ],
+      },
+    };
+    fs.writeFileSync(
+      path.join(tasksBase, 'GH-CTX4', '.' + 'follow-up' + '-state.json'),
+      JSON.stringify(state, null, 2)
+    );
+    process.env.TASKS_BASE = tasksBase;
+    process.env.WORKTREES_BASE = tmp;
+    process.env.WORK_AUTO_RETRY_INFRA = 'true';
+
+    const mod = require(FOLLOW_UP_NEXT_PATH);
+    mod.getNextInstruction('GH-CTX4', 542);
+
+    const persisted = JSON.parse(
+      fs.readFileSync(path.join(tasksBase, 'GH-CTX4', '.' + 'follow-up' + '-state.json'), 'utf8')
+    );
+    assert.equal(
+      persisted.infraRetry.attempts[0].outcome,
+      'succeeded',
+      'pending attempt must be marked succeeded when _ciStatus=success in state'
+    );
+
+    delete process.env.WORK_AUTO_RETRY_INFRA;
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-ctx.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-ctx.test.js
@@ -63,7 +63,9 @@ describe('follow-up-next.js — ctx wiring (Bug 2)', () => {
       status: 'in_progress',
       attempt: 1,
       maxAttempts: 40,
-      _ciFailedJobs: [{ name: 'e2e [shard-4]', runId: '987654', id: '111' }],
+      // monitor.js stores `jobId` (databaseId from gh API), not `id`. Bug C
+      // (GH-508) aligned buildClassifierCtx with the field monitor actually writes.
+      _ciFailedJobs: [{ name: 'e2e [shard-4]', runId: '987654', jobId: '111' }],
       _ciStatus: 'failing',
       _ciFailedLogs: 'cache: MISS\nfallback install FAILED\n',
       _ciAllJobs: [{ name: 'e2e [shard-1]' }, { name: 'e2e [shard-4]' }],

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-surface.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-surface.test.js
@@ -88,6 +88,45 @@ describe('follow-up-next.js — surface persists failureCategory (Bug 3)', () =>
     assert.notEqual(persisted.status, 'complete');
   });
 
+  it('Bug E: report renders infra-stuck bundle after infra-retry exhausts (reason=infra-stuck)', () => {
+    // Simulate infra-retry surfacing exhausted: failureCategory already set to
+    // 'infra-stuck' by maybeSurfaceExhausted, infraRetry.attempts populated.
+    delete require.cache[REPORT_PATH];
+    const handlers = Object.create(null);
+    require(REPORT_PATH)((name, fn) => {
+      handlers[name] = fn;
+    });
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'report-infra-stuck-'));
+    const state = {
+      ticketId: 'GH-SURF',
+      prNumber: 100,
+      attempt: 3,
+      currentStep: 'report',
+      failureCategory: 'infra-stuck',
+      repoOwner: 'thomfilg',
+      repoName: 'claude-plugin-work',
+      infraRetry: {
+        count: 3,
+        attempts: [
+          {
+            attemptNumber: 1,
+            timestamp: 't1',
+            runId: '111',
+            signals: ['signal1', 'signal2'],
+            retryMethod: 'rerun-failed',
+          },
+        ],
+      },
+      lastMonitorResult: { exitCode: 1, output: 'CI: FAILED' },
+    };
+    const result = handlers['report'](state, { tasksDir: tmp });
+    assert.equal(result.action, 'surface');
+    assert.equal(result.payload && result.payload.reason, 'infra-stuck');
+    assert.match(result.summary, /Infra-stuck after 1 retries/);
+    assert.notEqual(state.status, 'complete');
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
   it('report.js does NOT mark status=complete when failureCategory=github-actions-outage', () => {
     delete require.cache[REPORT_PATH];
     const handlers = Object.create(null);

--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-surface.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-surface.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+/**
+ * Regression (Bug 3): when a step returns action:'surface' with a reason
+ * (e.g. 'github-actions-outage'), the orchestrator must persist that reason
+ * onto state.failureCategory so a subsequent /follow-up invocation does NOT
+ * silently mark the workflow complete via report.js.
+ *
+ * Before this fix, follow-up-next.js only set state.currentStep='report' on
+ * surface — failureCategory stayed null, report.js fell through to the
+ * status='complete' branch, and the outage was effectively erased.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const FOLLOW_UP_NEXT_PATH = require.resolve('../follow-up-next.js');
+const STEP_REGISTRY_PATH = require.resolve('../lib/step-registry.js');
+const REPORT_PATH = require.resolve('../lib/steps/report.js');
+const STATE_FILE = '.' + 'follow-up' + '-state.json';
+
+function setupTmpState(stateFixture) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fu-surface-'));
+  const tasksBase = path.join(tmp, 'tasks');
+  fs.mkdirSync(path.join(tasksBase, 'GH-SURF'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tasksBase, 'GH-SURF', STATE_FILE),
+    JSON.stringify(stateFixture, null, 2)
+  );
+  process.env.TASKS_BASE = tasksBase;
+  process.env.WORKTREES_BASE = tmp;
+  return { tmp, tasksBase };
+}
+
+function loadNextWithSurfacingStep(currentStep) {
+  delete require.cache[FOLLOW_UP_NEXT_PATH];
+  delete require.cache[STEP_REGISTRY_PATH];
+  require.cache[STEP_REGISTRY_PATH] = {
+    id: STEP_REGISTRY_PATH,
+    filename: STEP_REGISTRY_PATH,
+    loaded: true,
+    exports: {
+      STEPS: ['monitor', 'triage', 'infra-retry', 'fix-ci', 'fix-reviews', 'push-retry', 'report'],
+      runStep: (stepName) => {
+        if (stepName === currentStep) {
+          return {
+            type: 'follow_up_instruction',
+            action: 'surface',
+            payload: { reason: 'github-actions-outage', signals: ['signal4'] },
+            reason: 'github-actions-outage',
+          };
+        }
+        return null;
+      },
+    },
+  };
+  return require(FOLLOW_UP_NEXT_PATH);
+}
+
+describe('follow-up-next.js — surface persists failureCategory (Bug 3)', () => {
+  it('persists failureCategory when a step surfaces with a reason', () => {
+    const initial = {
+      ticketId: 'GH-SURF',
+      prNumber: 100,
+      currentStep: 'infra-retry',
+      status: 'in_progress',
+      attempt: 1,
+      maxAttempts: 40,
+      failureCategory: null,
+    };
+    const { tasksBase } = setupTmpState(initial);
+    const mod = loadNextWithSurfacingStep('infra-retry');
+    const result = mod.getNextInstruction('GH-SURF', 100);
+    assert.equal(result.action, 'surface');
+
+    const persisted = JSON.parse(
+      fs.readFileSync(path.join(tasksBase, 'GH-SURF', STATE_FILE), 'utf8')
+    );
+    assert.equal(
+      persisted.failureCategory,
+      'github-actions-outage',
+      'surface reason must be saved onto state.failureCategory'
+    );
+    assert.equal(persisted.currentStep, 'report');
+    assert.notEqual(persisted.status, 'complete');
+  });
+
+  it('report.js does NOT mark status=complete when failureCategory=github-actions-outage', () => {
+    delete require.cache[REPORT_PATH];
+    const handlers = Object.create(null);
+    require(REPORT_PATH)((name, fn) => {
+      handlers[name] = fn;
+    });
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'report-surface-'));
+    const state = {
+      ticketId: 'GH-SURF',
+      prNumber: 100,
+      attempt: 1,
+      currentStep: 'report',
+      failureCategory: 'github-actions-outage',
+      infraRetry: { count: 0, attempts: [] },
+      lastMonitorResult: { exitCode: 1, output: 'CI: FAILED' },
+    };
+    const result = handlers['report'](state, { tasksDir: tmp });
+    assert.ok(result, 'report must return a surfacing instruction, not null');
+    assert.equal(result.action, 'surface');
+    assert.notEqual(state.status, 'complete');
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
@@ -130,6 +130,29 @@ describe('infra-classifier', () => {
       const result = signal3_unrelatedFailures(failedTests, prDiffFiles);
       assert.equal(result.fired, false);
     });
+
+    it('PR #542 cursor[bot]: realistic populated shape — state.failedTests flows in from CI log extraction', () => {
+      // Simulates the new pipeline: monitor.js extracts paths from raw logs
+      // into state._ciFailedTests; follow-up-next.js mirrors onto
+      // state.failedTests; classify reads s.failedTests. End-to-end realism.
+      const state = {
+        _ciFailedJobs: [],
+        failedTests: [
+          'plugins/work/scripts/workflows/follow-up/__tests__/unrelated.test.js',
+          'apps/web/src/unrelated/foo.spec.tsx',
+        ],
+      };
+      const ctx = {
+        allJobs: [],
+        prDiffFiles: ['src/payment/checkout.ts'],
+        rawLogs: ['e2e-deps cache: MISS', 'fallback install FAILED'].join('\n'),
+        exec: () => ({ stdout: 'real assertion', stderr: '', status: 0 }),
+        jobId: '222',
+      };
+      const result = classify(state, ctx);
+      assert.ok(result.signals.includes('signal3'));
+      assert.equal(result.classification, 'infra-suspected');
+    });
   });
 
   describe('signal4_setupArtifacts', () => {

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
@@ -1,0 +1,233 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  classify,
+  __test__: {
+    signal1_shardAsymmetry,
+    signal2_emptyFailedLog,
+    signal3_unrelatedFailures,
+    signal4_setupArtifacts,
+  },
+} = require('../lib/infra-classifier');
+
+describe('infra-classifier', () => {
+  describe('signal1_shardAsymmetry', () => {
+    it('fires on a 4-shard matrix where 1 shard fails at 6min while sibling median is 1min', () => {
+      const baseStart = new Date('2026-01-01T00:00:00.000Z').getTime();
+      const mkJob = (name, runtimeMin, conclusion) => ({
+        name,
+        conclusion,
+        startedAt: new Date(baseStart).toISOString(),
+        completedAt: new Date(baseStart + runtimeMin * 60_000).toISOString(),
+      });
+      const allJobs = [
+        mkJob('e2e [shard-1]', 1, 'success'),
+        mkJob('e2e [shard-2]', 1, 'success'),
+        mkJob('e2e [shard-3]', 1, 'success'),
+        mkJob('e2e [shard-4]', 6, 'failure'),
+      ];
+      const failedJobs = [allJobs[3]];
+      const result = signal1_shardAsymmetry(failedJobs, allJobs);
+      assert.equal(result.fired, true);
+      assert.ok(result.evidence, 'evidence should be present');
+    });
+
+    it('does NOT fire on a 2-way matrix (N<3) — rejects with reason in evidence', () => {
+      const baseStart = new Date('2026-01-01T00:00:00.000Z').getTime();
+      const mkJob = (name, runtimeMin, conclusion) => ({
+        name,
+        conclusion,
+        startedAt: new Date(baseStart).toISOString(),
+        completedAt: new Date(baseStart + runtimeMin * 60_000).toISOString(),
+      });
+      const allJobs = [
+        mkJob('e2e [shard-1]', 1, 'success'),
+        mkJob('e2e [shard-2]', 6, 'failure'),
+      ];
+      const failedJobs = [allJobs[1]];
+      const result = signal1_shardAsymmetry(failedJobs, allJobs);
+      assert.equal(result.fired, false);
+      assert.ok(
+        result.evidence && /matrix|N<3|shard|<3/i.test(JSON.stringify(result.evidence)),
+        'evidence should state the N<3 rejection reason'
+      );
+    });
+  });
+
+  describe('signal2_emptyFailedLog', () => {
+    it('fires when gh run view --log-failed returns empty stdout but conclusion=failure', () => {
+      const exec = (_cmd) => ({ stdout: '', stderr: '', status: 0 });
+      const result = signal2_emptyFailedLog('123456', '789012', exec);
+      assert.equal(result.fired, true);
+    });
+
+    it('does NOT fire when stdout contains an assertion / error text', () => {
+      const exec = (_cmd) => ({
+        stdout: 'Error: expect(received).toBe(expected)',
+        stderr: '',
+        status: 0,
+      });
+      const result = signal2_emptyFailedLog('123456', '789012', exec);
+      assert.equal(result.fired, false);
+    });
+
+    it('throws TypeError on malformed jobId (non-numeric)', () => {
+      const exec = (_cmd) => ({ stdout: '', stderr: '', status: 0 });
+      assert.throws(
+        () => signal2_emptyFailedLog('123456', 'abc; rm -rf /', exec),
+        TypeError
+      );
+    });
+
+    it('throws TypeError on malformed runId (non-numeric)', () => {
+      const exec = (_cmd) => ({ stdout: '', stderr: '', status: 0 });
+      assert.throws(
+        () => signal2_emptyFailedLog('not-a-number', '789012', exec),
+        TypeError
+      );
+    });
+  });
+
+  describe('signal3_unrelatedFailures', () => {
+    it('fires when failing specs do not overlap with PR diff files', () => {
+      const failedTests = [
+        'src/unrelated/a.spec.ts',
+        'src/unrelated/b.spec.ts',
+        'src/unrelated/c.spec.ts',
+        'src/unrelated/d.spec.ts',
+      ];
+      const prDiffFiles = ['src/foo.ts'];
+      const result = signal3_unrelatedFailures(failedTests, prDiffFiles);
+      assert.equal(result.fired, true);
+    });
+
+    it('does NOT fire when a failing spec shares a path with the diff', () => {
+      const failedTests = ['src/foo.spec.ts', 'src/unrelated/b.spec.ts'];
+      const prDiffFiles = ['src/foo.ts'];
+      const result = signal3_unrelatedFailures(failedTests, prDiffFiles);
+      assert.equal(result.fired, false);
+    });
+  });
+
+  describe('signal4_setupArtifacts', () => {
+    it('fires when raw log has "e2e-deps cache: MISS" + "fallback install FAILED"', () => {
+      const rawLogs = [
+        'some setup line',
+        'e2e-deps cache: MISS',
+        'fallback install FAILED',
+      ].join('\n');
+      const result = signal4_setupArtifacts(rawLogs);
+      assert.equal(result.fired, true);
+    });
+
+    it('does NOT fire when raw log is plain assertion text', () => {
+      const rawLogs = [
+        'Error: expect(received).toBe(expected)',
+        'FAIL src/foo.spec.ts',
+      ].join('\n');
+      const result = signal4_setupArtifacts(rawLogs);
+      assert.equal(result.fired, false);
+    });
+  });
+
+  describe('classify()', () => {
+    const baseStart = new Date('2026-01-01T00:00:00.000Z').getTime();
+    const mkJob = (name, runtimeMin, conclusion) => ({
+      name,
+      conclusion,
+      startedAt: new Date(baseStart).toISOString(),
+      completedAt: new Date(baseStart + runtimeMin * 60_000).toISOString(),
+    });
+
+    it('returns infra-suspected when signal1 + signal2 both fire', () => {
+      const allJobs = [
+        mkJob('e2e [shard-1]', 1, 'success'),
+        mkJob('e2e [shard-2]', 1, 'success'),
+        mkJob('e2e [shard-3]', 1, 'success'),
+        mkJob('e2e [shard-4]', 6, 'failure'),
+      ];
+      const state = { _ciFailedJobs: [allJobs[3]], runId: '111' };
+      const ctx = {
+        allJobs,
+        prDiffFiles: ['src/foo.ts'],
+        rawLogs: 'Error: assertion',
+        exec: (_cmd) => ({ stdout: '', stderr: '', status: 0 }),
+        jobId: '222',
+      };
+      const result = classify(state, ctx);
+      assert.equal(result.classification, 'infra-suspected');
+      assert.ok(Array.isArray(result.signals));
+      assert.ok(result.signals.includes('signal1'));
+      assert.ok(result.signals.includes('signal2'));
+    });
+
+    it('returns code-failure when only one signal fires', () => {
+      const allJobs = [
+        mkJob('unit', 1, 'failure'),
+      ];
+      const state = { _ciFailedJobs: [allJobs[0]], runId: '111' };
+      const ctx = {
+        allJobs,
+        prDiffFiles: ['src/foo.ts'],
+        rawLogs: 'Error: real assertion',
+        exec: (_cmd) => ({
+          stdout: 'Error: expect(received).toBe(expected)',
+          stderr: '',
+          status: 0,
+        }),
+        jobId: '222',
+      };
+      const result = classify(state, ctx);
+      assert.equal(result.classification, 'code-failure');
+    });
+
+    it('returns infra-suspected when signal3 + signal4 both fire', () => {
+      const state = {
+        _ciFailedJobs: [],
+        failedTests: [
+          'src/unrelated/a.spec.ts',
+          'src/unrelated/b.spec.ts',
+          'src/unrelated/c.spec.ts',
+        ],
+        runId: '111',
+      };
+      const ctx = {
+        allJobs: [],
+        prDiffFiles: ['src/foo.ts'],
+        rawLogs: ['e2e-deps cache: MISS', 'fallback install FAILED'].join('\n'),
+        exec: (_cmd) => ({
+          stdout: 'Error: real assertion present',
+          stderr: '',
+          status: 0,
+        }),
+        jobId: '222',
+      };
+      const result = classify(state, ctx);
+      assert.equal(result.classification, 'infra-suspected');
+      assert.ok(result.signals.includes('signal3'));
+      assert.ok(result.signals.includes('signal4'));
+    });
+
+    it('returns infra-suspected when signal2 + signal4 both fire', () => {
+      const state = {
+        _ciFailedJobs: [],
+        failedTests: ['src/foo.spec.ts'],
+        runId: '111',
+      };
+      const ctx = {
+        allJobs: [],
+        prDiffFiles: ['src/foo.ts'],
+        rawLogs: ['e2e-deps cache: MISS', 'fallback install FAILED'].join('\n'),
+        exec: (_cmd) => ({ stdout: '', stderr: '', status: 0 }),
+        jobId: '222',
+      };
+      const result = classify(state, ctx);
+      assert.equal(result.classification, 'infra-suspected');
+      assert.ok(result.signals.includes('signal2'));
+      assert.ok(result.signals.includes('signal4'));
+    });
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
@@ -35,6 +35,37 @@ describe('infra-classifier', () => {
       assert.ok(result.evidence, 'evidence should be present');
     });
 
+    it('Bug 542-23: enriches failed-job timestamps by matching jobId against allJobs.databaseId', () => {
+      // monitor.js attaches jobId (gh databaseId) to _ciFailedJobs entries
+      // but leaves _ciAllJobs verbatim (databaseId field). Without the
+      // id-based match working, the failed entry — which has NO startedAt /
+      // completedAt — gets jobRuntimeMs=0 and signal1 cannot fire.
+      const baseStart = new Date('2026-01-01T00:00:00.000Z').getTime();
+      const mkAllJob = (name, runtimeMin, conclusion, databaseId) => ({
+        name,
+        databaseId,
+        conclusion,
+        startedAt: new Date(baseStart).toISOString(),
+        completedAt: new Date(baseStart + runtimeMin * 60_000).toISOString(),
+      });
+      const allJobs = [
+        mkAllJob('e2e [shard-1]', 1, 'success', 1001),
+        mkAllJob('e2e [shard-2]', 1, 'success', 1002),
+        mkAllJob('e2e [shard-3]', 1, 'success', 1003),
+        mkAllJob('e2e [shard-4]', 6, 'failure', 1004),
+      ];
+      // Failed entry has jobId (from monitor.attachJobIds) but no timestamps
+      // — they live only on _ciAllJobs. The fix matches failed.jobId against
+      // allJob.databaseId to enrich. Name set so family lookup still works.
+      const failedJobs = [{ name: 'e2e [shard-4]', jobId: '1004' }];
+      const result = signal1_shardAsymmetry(failedJobs, allJobs);
+      assert.equal(
+        result.fired,
+        true,
+        'signal1 must enrich timestamps by databaseId match and detect asymmetry'
+      );
+    });
+
     it('iterates all failed jobs — small family for job A does not abort check on job B in a larger family', () => {
       const baseStart = new Date('2026-01-01T00:00:00.000Z').getTime();
       const mkJob = (name, runtimeMin, conclusion) => ({

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
@@ -224,6 +224,46 @@ describe('infra-classifier', () => {
       assert.ok(result.signals.includes('signal4'));
     });
 
+    it('Bug C: signal2 reads runId/jobId from ctx (production shape) without throwing', () => {
+      // monitor.js shape: _ciFailedJobs[i] = { name, runId, jobId } — NO state.runId.
+      const state = {
+        _ciFailedJobs: [{ name: 'unit', runId: '12345', jobId: '67890' }],
+        failedTests: [],
+      };
+      const ctx = {
+        allJobs: [],
+        prDiffFiles: ['src/foo.ts'],
+        rawLogs: '',
+        exec: (_cmd) => ({ stdout: '', stderr: '', status: 0 }),
+        runId: '12345',
+        jobId: '67890',
+      };
+      // Must not throw — signal2 must accept ctx.runId/ctx.jobId.
+      const result = classify(state, ctx);
+      assert.ok(result, 'classify returns a result');
+      // signal2 should have evaluated successfully (fired=true on empty stdout
+      // with no error markers) — proves the IDs flowed through.
+      assert.ok(
+        result.signals.includes('signal2'),
+        'signal2 must have fired with ctx.runId/jobId passed through'
+      );
+    });
+
+    it('Bug C: classify skips signal2 cleanly (no throw) when ctx has no IDs', () => {
+      const state = { _ciFailedJobs: [], failedTests: [] };
+      const ctx = {
+        allJobs: [],
+        prDiffFiles: [],
+        rawLogs: '',
+        exec: (_cmd) => ({ stdout: '', stderr: '', status: 0 }),
+        // No runId, no jobId.
+      };
+      // Must not throw: previously signal2 called the ID regex on undefined.
+      assert.doesNotThrow(() => classify(state, ctx));
+      const result = classify(state, ctx);
+      assert.equal(result.classification, 'code-failure');
+    });
+
     it('returns infra-suspected when signal2 + signal4 both fire', () => {
       const state = {
         _ciFailedJobs: [],

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
@@ -35,6 +35,35 @@ describe('infra-classifier', () => {
       assert.ok(result.evidence, 'evidence should be present');
     });
 
+    it('iterates all failed jobs — small family for job A does not abort check on job B in a larger family', () => {
+      const baseStart = new Date('2026-01-01T00:00:00.000Z').getTime();
+      const mkJob = (name, runtimeMin, conclusion) => ({
+        name,
+        conclusion,
+        startedAt: new Date(baseStart).toISOString(),
+        completedAt: new Date(baseStart + runtimeMin * 60_000).toISOString(),
+      });
+      // Job A's family has only 2 shards (cannot establish asymmetry). Job B's
+      // family has 5 shards with the failing one running 6x the median.
+      const allJobs = [
+        mkJob('lint [shard-1]', 1, 'success'),
+        mkJob('lint [shard-2]', 1, 'failure'),
+        mkJob('e2e [shard-1]', 1, 'success'),
+        mkJob('e2e [shard-2]', 1, 'success'),
+        mkJob('e2e [shard-3]', 1, 'success'),
+        mkJob('e2e [shard-4]', 1, 'success'),
+        mkJob('e2e [shard-5]', 6, 'failure'),
+      ];
+      const failedJobs = [allJobs[1], allJobs[6]];
+      const result = signal1_shardAsymmetry(failedJobs, allJobs);
+      assert.equal(
+        result.fired,
+        true,
+        'signal1 must fire on job B even though job A is in a <3-shard family'
+      );
+      assert.equal(result.evidence.family, 'e2e');
+    });
+
     it('does NOT fire on a 2-way matrix (N<3) — rejects with reason in evidence', () => {
       const baseStart = new Date('2026-01-01T00:00:00.000Z').getTime();
       const mkJob = (name, runtimeMin, conclusion) => ({
@@ -43,10 +72,7 @@ describe('infra-classifier', () => {
         startedAt: new Date(baseStart).toISOString(),
         completedAt: new Date(baseStart + runtimeMin * 60_000).toISOString(),
       });
-      const allJobs = [
-        mkJob('e2e [shard-1]', 1, 'success'),
-        mkJob('e2e [shard-2]', 6, 'failure'),
-      ];
+      const allJobs = [mkJob('e2e [shard-1]', 1, 'success'), mkJob('e2e [shard-2]', 6, 'failure')];
       const failedJobs = [allJobs[1]];
       const result = signal1_shardAsymmetry(failedJobs, allJobs);
       assert.equal(result.fired, false);
@@ -76,18 +102,12 @@ describe('infra-classifier', () => {
 
     it('throws TypeError on malformed jobId (non-numeric)', () => {
       const exec = (_cmd) => ({ stdout: '', stderr: '', status: 0 });
-      assert.throws(
-        () => signal2_emptyFailedLog('123456', 'abc; rm -rf /', exec),
-        TypeError
-      );
+      assert.throws(() => signal2_emptyFailedLog('123456', 'abc; rm -rf /', exec), TypeError);
     });
 
     it('throws TypeError on malformed runId (non-numeric)', () => {
       const exec = (_cmd) => ({ stdout: '', stderr: '', status: 0 });
-      assert.throws(
-        () => signal2_emptyFailedLog('not-a-number', '789012', exec),
-        TypeError
-      );
+      assert.throws(() => signal2_emptyFailedLog('not-a-number', '789012', exec), TypeError);
     });
   });
 
@@ -114,20 +134,15 @@ describe('infra-classifier', () => {
 
   describe('signal4_setupArtifacts', () => {
     it('fires when raw log has "e2e-deps cache: MISS" + "fallback install FAILED"', () => {
-      const rawLogs = [
-        'some setup line',
-        'e2e-deps cache: MISS',
-        'fallback install FAILED',
-      ].join('\n');
+      const rawLogs = ['some setup line', 'e2e-deps cache: MISS', 'fallback install FAILED'].join(
+        '\n'
+      );
       const result = signal4_setupArtifacts(rawLogs);
       assert.equal(result.fired, true);
     });
 
     it('does NOT fire when raw log is plain assertion text', () => {
-      const rawLogs = [
-        'Error: expect(received).toBe(expected)',
-        'FAIL src/foo.spec.ts',
-      ].join('\n');
+      const rawLogs = ['Error: expect(received).toBe(expected)', 'FAIL src/foo.spec.ts'].join('\n');
       const result = signal4_setupArtifacts(rawLogs);
       assert.equal(result.fired, false);
     });
@@ -165,9 +180,7 @@ describe('infra-classifier', () => {
     });
 
     it('returns code-failure when only one signal fires', () => {
-      const allJobs = [
-        mkJob('unit', 1, 'failure'),
-      ];
+      const allJobs = [mkJob('unit', 1, 'failure')];
       const state = { _ciFailedJobs: [allJobs[0]], runId: '111' };
       const ctx = {
         allJobs,

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-classifier.test.js
@@ -35,6 +35,55 @@ describe('infra-classifier', () => {
       assert.ok(result.evidence, 'evidence should be present');
     });
 
+    it('Bug 542-25: excludes the failed shard from the sibling median by id/name, not reference', () => {
+      // `enrichFailedFromAll` returns a COPY of the failed job, so the
+      // `j !== failed` reference check used to fail and the failed shard's
+      // 6min runtime got included in the median — pulling the median up and
+      // blocking the ≥3× asymmetry check.
+      const baseStart = new Date('2026-01-01T00:00:00.000Z').getTime();
+      const mkAllJob = (name, runtimeMin, conclusion, databaseId) => ({
+        name,
+        databaseId,
+        conclusion,
+        startedAt: new Date(baseStart).toISOString(),
+        completedAt: new Date(baseStart + runtimeMin * 60_000).toISOString(),
+      });
+      // 3-shard family: shards 1+2 run 1min, shard 3 runs 6min and fails.
+      // With proper exclusion, median(siblings) = 1min, ratio = 6 → fires.
+      // With reference-equality bug, median(all 3) = 1min still (the failed
+      // is a copy so it's in the set — median of [1,1,6] = 1; ratio 6 → fires).
+      // Actually with 3 entries and copy bug, the failed shard's copy is in
+      // the family too because allJobs has the original. Make this stronger:
+      // use 4-shard family where dropping the failed flips the ratio decision.
+      const allJobs = [
+        mkAllJob('e2e [shard-1]', 1, 'success', 1001),
+        mkAllJob('e2e [shard-2]', 1, 'success', 1002),
+        mkAllJob('e2e [shard-3]', 3, 'success', 1003),
+        mkAllJob('e2e [shard-4]', 6, 'failure', 1004),
+      ];
+      // Failed entry is an enriched copy (no shared reference).
+      const failedJobs = [
+        {
+          name: 'e2e [shard-4]',
+          jobId: '1004',
+          // Pretend monitor pre-enriched (production may do this).
+          startedAt: new Date(baseStart).toISOString(),
+          completedAt: new Date(baseStart + 6 * 60_000).toISOString(),
+        },
+      ];
+      const result = signal1_shardAsymmetry(failedJobs, allJobs);
+      // siblings = [1,1,3] median=1; ratio = 6/1 = 6 ≥ 3 → fire.
+      // Buggy: siblings = [1,1,3,6] median=2; ratio = 6/2 = 3 ≥ 3 → still fires
+      // BUT evidence.siblingMedianMs differs. Assert the median value.
+      assert.equal(result.fired, true);
+      // 60_000ms = 1 minute. Median of [1,1,3] in ms is 60_000.
+      assert.equal(
+        result.evidence.siblingMedianMs,
+        60_000,
+        'failed shard must NOT inflate the sibling median'
+      );
+    });
+
     it('Bug 542-23: enriches failed-job timestamps by matching jobId against allJobs.databaseId', () => {
       // monitor.js attaches jobId (gh databaseId) to _ciFailedJobs entries
       // but leaves _ciAllJobs verbatim (databaseId field). Without the

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -111,7 +111,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
     evidence: { signal1: {}, signal2: {}, signal3: {}, signal4: { jobCount: 0 } },
   });
 
-  it('case 5: attempt 0 → 1 — records attempt, currentStep=monitor, delegate calls `gh run rerun --failed`', () => {
+  it('case 5: attempt 0 → 1 — records attempt, currentStep=monitor, delegate calls `gh run rerun <id> --failed`', () => {
     const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
     const state = {
       ticketId: 'GH-508',
@@ -132,7 +132,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
     assert.equal(state.currentStep, 'monitor', 'loops back to monitor');
     assert.match(
       result.delegate && result.delegate.command,
-      /gh run rerun --failed 12345/,
+      /gh run rerun 12345 --failed/,
       'delegate runs `gh run rerun --failed <runId>`'
     );
   });
@@ -264,7 +264,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
     assert.equal(result.action, 'execute');
     assert.match(
       result.delegate && result.delegate.command,
-      /gh run rerun --failed 987654/,
+      /gh run rerun 987654 --failed/,
       'delegate must use runId from _ciFailedJobs[0]'
     );
     assert.equal(state.infraRetry.attempts[0].runId, '987654');

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -243,6 +243,39 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
     assert.notEqual(result.action, 'execute', 'fix-ci must NOT be dispatched on infra-stuck');
   });
 
+  it('case 9b (Bug 542-28): retry-success clears ci_cancelled_blocking too, not just ci_failure', () => {
+    // triage.js routes both `ci_failure` and `ci_cancelled_blocking` to
+    // infra-retry. The post-success category clear must cover both, otherwise
+    // report.js refuses to mark complete and surfaces the stale category.
+    const { handler } = loadStep({ classifyImpl: infraSuspected });
+    const state = {
+      ticketId: 'GH-508',
+      failureCategory: 'ci_cancelled_blocking',
+      runId: '99999',
+      _ciStatusFreshness: { pid: process.pid, at: new Date().toISOString() },
+      infraRetry: {
+        count: 1,
+        attempts: [
+          {
+            attemptNumber: 1,
+            timestamp: 't0',
+            runId: '88888',
+            signals: ['signal1', 'signal2'],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+        ],
+      },
+    };
+    handler(state, { ciStatus: 'success' });
+    assert.equal(state.currentStep, 'report', 'routed to report on success');
+    assert.equal(
+      state.failureCategory,
+      null,
+      'ci_cancelled_blocking must be cleared so report marks complete'
+    );
+  });
+
   it('case 5d (Bug 542-26): closes prior pending attempt as failed before dispatching the next retry', () => {
     // After retry #1 the attempt is pending. If monitor reports CI still
     // failing and infra-suspected re-fires, the next dispatch must close the

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * Tests for the infra-retry step handler.
+ *
+ * Deliverable 3.1.1 (RED): short-circuit / bypass cases (1-4).
+ *  1. WORK_AUTO_RETRY_INFRA unset → return null, no classify call.
+ *  2. failureCategory='conflict' → return null, no classify.
+ *  3. failureCategory='review_failure' → return null, no classify.
+ *  4. classify() returns 'code-failure' → return null.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const path = require('node:path');
+
+// Resolve target modules so we can patch them via the require cache.
+const STEP_PATH = require.resolve('../lib/steps/infra-retry');
+const CLASSIFIER_PATH = require.resolve('../lib/infra-classifier');
+const GET_CONFIG_PATH = require.resolve(
+  path.resolve(__dirname, '..', '..', 'lib', 'get-config')
+);
+
+function loadStep({ envFlag, classifyImpl }) {
+  // Clear caches so each test gets a fresh module wired to fresh mocks.
+  delete require.cache[STEP_PATH];
+  delete require.cache[CLASSIFIER_PATH];
+  delete require.cache[GET_CONFIG_PATH];
+
+  const classifyCalls = [];
+  const classify = (...args) => {
+    classifyCalls.push(args);
+    return classifyImpl
+      ? classifyImpl(...args)
+      : { classification: 'code-failure', signals: [], evidence: {} };
+  };
+
+  // Patch the infra-classifier module via cache injection.
+  require.cache[CLASSIFIER_PATH] = {
+    id: CLASSIFIER_PATH,
+    filename: CLASSIFIER_PATH,
+    loaded: true,
+    exports: { classify, __test__: {} },
+  };
+
+  // Patch get-config to control WORK_AUTO_RETRY_INFRA without touching env.
+  const getConfig = (key) => {
+    if (key === 'WORK_AUTO_RETRY_INFRA') return envFlag;
+    return undefined;
+  };
+  require.cache[GET_CONFIG_PATH] = {
+    id: GET_CONFIG_PATH,
+    filename: GET_CONFIG_PATH,
+    loaded: true,
+    exports: getConfig,
+  };
+
+  const stepModule = require(STEP_PATH);
+  const handlers = Object.create(null);
+  const register = (name, fn) => {
+    handlers[name] = fn;
+  };
+  stepModule(register);
+  return { handler: handlers['infra-retry'], classifyCalls };
+}
+
+describe('infra-retry step — short-circuits and bypasses (RED 3.1.1)', () => {
+  it('case 1: WORK_AUTO_RETRY_INFRA unset → returns null and never calls classify', () => {
+    const { handler, classifyCalls } = loadStep({ envFlag: undefined });
+    const state = { failureCategory: 'ci_failure', infraRetry: { count: 0, attempts: [] } };
+    const ctx = {};
+    const result = handler(state, ctx);
+    assert.equal(result, null);
+    assert.equal(classifyCalls.length, 0, 'classify must not be invoked when feature is off');
+  });
+
+  it('case 2: failureCategory=conflict → returns null and never calls classify', () => {
+    const { handler, classifyCalls } = loadStep({ envFlag: 'true' });
+    const state = { failureCategory: 'conflict' };
+    const result = handler(state, {});
+    assert.equal(result, null);
+    assert.equal(classifyCalls.length, 0, 'merge conflicts bypass classifier entirely');
+  });
+
+  it('case 3: failureCategory=review_failure → returns null and never calls classify', () => {
+    const { handler, classifyCalls } = loadStep({ envFlag: 'true' });
+    const state = { failureCategory: 'review_failure' };
+    const result = handler(state, {});
+    assert.equal(result, null);
+    assert.equal(classifyCalls.length, 0, 'review failures bypass classifier entirely');
+  });
+
+  it('case 4: classify returns code-failure → returns null (no retry dispatched)', () => {
+    const { handler, classifyCalls } = loadStep({
+      envFlag: 'true',
+      classifyImpl: () => ({ classification: 'code-failure', signals: [], evidence: {} }),
+    });
+    const state = { failureCategory: 'ci_failure', runId: '12345', infraRetry: { count: 0, attempts: [] } };
+    const result = handler(state, {});
+    assert.equal(result, null);
+    assert.equal(classifyCalls.length, 1, 'classifier must be consulted exactly once');
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -279,6 +279,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
       ticketId: 'GH-508',
       failureCategory: 'ci_failure',
       runId: '55555',
+      _ciStatusFreshness: { pid: process.pid, at: new Date().toISOString() },
       infraRetry: {
         count: 1,
         attempts: [

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -243,6 +243,43 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
     assert.notEqual(result.action, 'execute', 'fix-ci must NOT be dispatched on infra-stuck');
   });
 
+  it('case 5d (Bug 542-26): closes prior pending attempt as failed before dispatching the next retry', () => {
+    // After retry #1 the attempt is pending. If monitor reports CI still
+    // failing and infra-suspected re-fires, the next dispatch must close the
+    // prior pending entry (outcome=failed) so per-retry verdicts aren\'t lost.
+    const { handler } = loadStep({ classifyImpl: infraSuspected });
+    const state = {
+      ticketId: 'GH-508',
+      failureCategory: 'ci_failure',
+      runId: '22222',
+      _ciStatusFreshness: { pid: process.pid, at: new Date().toISOString() },
+      infraRetry: {
+        count: 1,
+        attempts: [
+          {
+            attemptNumber: 1,
+            timestamp: 't1',
+            runId: '11111',
+            signals: ['signal1', 'signal2'],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+        ],
+      },
+    };
+    const result = handler(state, {}); // ctx.ciStatus undefined → not success
+    assert.ok(result, 'dispatches retry #2');
+    assert.equal(result.action, 'execute');
+    assert.equal(state.infraRetry.count, 2);
+    assert.equal(state.infraRetry.attempts.length, 2);
+    assert.equal(
+      state.infraRetry.attempts[0].outcome,
+      'failed',
+      'prior pending attempt closed as failed'
+    );
+    assert.equal(state.infraRetry.attempts[1].outcome, 'pending', 'new attempt is pending');
+  });
+
   it('case 5c: missing runId → returns null (orchestrator advances), does NOT throw', () => {
     // Bug 542-22: a missing/non-numeric runId used to throw TypeError out of
     // buildRetryDelegate. The follow-up loop had no catch, so the whole

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -3,11 +3,14 @@
 /**
  * Tests for the infra-retry step handler.
  *
- * Deliverable 3.1.1 (RED): short-circuit / bypass cases (1-4).
- *  1. WORK_AUTO_RETRY_INFRA unset → return null, no classify call.
- *  2. failureCategory='conflict' → return null, no classify.
- *  3. failureCategory='review_failure' → return null, no classify.
- *  4. classify() returns 'code-failure' → return null.
+ * Short-circuit / bypass cases:
+ *  1. failureCategory='conflict' → return null, no classify.
+ *  2. failureCategory='review_failure' → return null, no classify.
+ *  3. classify() returns 'code-failure' → return null.
+ *
+ * Note: the WORK_AUTO_RETRY_INFRA opt-in flag was removed (GH-508 design
+ * decision). Auto-retry is always on, gated by signal floor + retry cap +
+ * exhaustion surface.
  */
 
 const { describe, it } = require('node:test');
@@ -19,7 +22,7 @@ const STEP_PATH = require.resolve('../lib/steps/infra-retry');
 const CLASSIFIER_PATH = require.resolve('../lib/infra-classifier');
 const GET_CONFIG_PATH = require.resolve(path.resolve(__dirname, '..', '..', 'lib', 'get-config'));
 
-function loadStep({ envFlag, classifyImpl }) {
+function loadStep({ classifyImpl } = {}) {
   // Clear caches so each test gets a fresh module wired to fresh mocks.
   delete require.cache[STEP_PATH];
   delete require.cache[CLASSIFIER_PATH];
@@ -41,16 +44,13 @@ function loadStep({ envFlag, classifyImpl }) {
     exports: { classify, __test__: {} },
   };
 
-  // Patch get-config to control WORK_AUTO_RETRY_INFRA without touching env.
-  const getConfig = (key) => {
-    if (key === 'WORK_AUTO_RETRY_INFRA') return envFlag;
-    return undefined;
-  };
+  // Stub get-config — opt-in flag was removed, only WORK_INFRA_RETRY_FALLBACK
+  // remains (defaulted via undefined).
   require.cache[GET_CONFIG_PATH] = {
     id: GET_CONFIG_PATH,
     filename: GET_CONFIG_PATH,
     loaded: true,
-    exports: getConfig,
+    exports: () => undefined,
   };
 
   const stepModule = require(STEP_PATH);
@@ -62,35 +62,25 @@ function loadStep({ envFlag, classifyImpl }) {
   return { handler: handlers['infra-retry'], classifyCalls };
 }
 
-describe('infra-retry step — short-circuits and bypasses (RED 3.1.1)', () => {
-  it('case 1: WORK_AUTO_RETRY_INFRA unset → returns null and never calls classify', () => {
-    const { handler, classifyCalls } = loadStep({ envFlag: undefined });
-    const state = { failureCategory: 'ci_failure', infraRetry: { count: 0, attempts: [] } };
-    const ctx = {};
-    const result = handler(state, ctx);
-    assert.equal(result, null);
-    assert.equal(classifyCalls.length, 0, 'classify must not be invoked when feature is off');
-  });
-
-  it('case 2: failureCategory=conflict → returns null and never calls classify', () => {
-    const { handler, classifyCalls } = loadStep({ envFlag: 'true' });
+describe('infra-retry step — short-circuits and bypasses', () => {
+  it('case 1: failureCategory=conflict → returns null and never calls classify', () => {
+    const { handler, classifyCalls } = loadStep();
     const state = { failureCategory: 'conflict' };
     const result = handler(state, {});
     assert.equal(result, null);
     assert.equal(classifyCalls.length, 0, 'merge conflicts bypass classifier entirely');
   });
 
-  it('case 3: failureCategory=review_failure → returns null and never calls classify', () => {
-    const { handler, classifyCalls } = loadStep({ envFlag: 'true' });
+  it('case 2: failureCategory=review_failure → returns null and never calls classify', () => {
+    const { handler, classifyCalls } = loadStep();
     const state = { failureCategory: 'review_failure' };
     const result = handler(state, {});
     assert.equal(result, null);
     assert.equal(classifyCalls.length, 0, 'review failures bypass classifier entirely');
   });
 
-  it('case 4: classify returns code-failure → returns null (no retry dispatched)', () => {
+  it('case 3: classify returns code-failure → returns null (no retry dispatched)', () => {
     const { handler, classifyCalls } = loadStep({
-      envFlag: 'true',
       classifyImpl: () => ({ classification: 'code-failure', signals: [], evidence: {} }),
     });
     const state = {
@@ -112,7 +102,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
   });
 
   it('case 5: attempt 0 → 1 — records attempt, currentStep=monitor, delegate calls `gh run rerun <id> --failed`', () => {
-    const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
+    const { handler } = loadStep({ classifyImpl: infraSuspected });
     const state = {
       ticketId: 'GH-508',
       failureCategory: 'ci_failure',
@@ -138,7 +128,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
   });
 
   it('case 6: attempt 1 → 2', () => {
-    const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
+    const { handler } = loadStep({ classifyImpl: infraSuspected });
     const state = {
       ticketId: 'GH-508',
       failureCategory: 'ci_failure',
@@ -167,7 +157,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
   });
 
   it('case 7: attempt 2 → 3', () => {
-    const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
+    const { handler } = loadStep({ classifyImpl: infraSuspected });
     const state = {
       ticketId: 'GH-508',
       failureCategory: 'ci_failure',
@@ -203,7 +193,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
   });
 
   it('case 8: attempt 3 → exhausted (surface + failureCategory=infra-stuck, no fix-ci)', () => {
-    const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
+    const { handler } = loadStep({ classifyImpl: infraSuspected });
     const state = {
       ticketId: 'GH-508',
       failureCategory: 'ci_failure',
@@ -254,7 +244,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
   });
 
   it('case 5b: derives runId from state._ciFailedJobs[0].runId when state.runId is unset', () => {
-    const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
+    const { handler } = loadStep({ classifyImpl: infraSuspected });
     const state = {
       ticketId: 'GH-508',
       failureCategory: 'ci_failure',
@@ -274,10 +264,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
   });
 
   it('case 9: prior retry succeeded → marks last attempt outcome=succeeded and advances normally', () => {
-    const { handler, classifyCalls } = loadStep({
-      envFlag: 'true',
-      classifyImpl: infraSuspected,
-    });
+    const { handler, classifyCalls } = loadStep({ classifyImpl: infraSuspected });
     const state = {
       ticketId: 'GH-508',
       failureCategory: 'ci_failure',

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -102,3 +102,149 @@ describe('infra-retry step — short-circuits and bypasses (RED 3.1.1)', () => {
     assert.equal(classifyCalls.length, 1, 'classifier must be consulted exactly once');
   });
 });
+
+describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
+  const infraSuspected = () => ({
+    classification: 'infra-suspected',
+    signals: ['signal1', 'signal2'],
+    evidence: { signal1: {}, signal2: {}, signal3: {}, signal4: { jobCount: 0 } },
+  });
+
+  it('case 5: attempt 0 → 1 — records attempt, currentStep=monitor, delegate calls `gh run rerun --failed`', () => {
+    const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
+    const state = {
+      ticketId: 'GH-508',
+      failureCategory: 'ci_failure',
+      runId: '12345',
+      infraRetry: { count: 0, attempts: [] },
+    };
+    const result = handler(state, {});
+    assert.ok(result, 'expected a delegate instruction');
+    assert.equal(result.action, 'execute', 'dispatches delegate');
+    assert.equal(state.infraRetry.count, 1, 'count incremented');
+    assert.equal(state.infraRetry.attempts.length, 1, 'one attempt recorded');
+    assert.equal(state.infraRetry.attempts[0].attemptNumber, 1);
+    assert.equal(state.infraRetry.attempts[0].runId, '12345');
+    assert.equal(state.infraRetry.attempts[0].retryMethod, 'rerun-failed');
+    assert.equal(state.infraRetry.attempts[0].outcome, 'pending');
+    assert.ok(state.infraRetry.attempts[0].timestamp, 'attempt has timestamp');
+    assert.equal(state.currentStep, 'monitor', 'loops back to monitor');
+    assert.match(
+      result.delegate && result.delegate.command,
+      /gh run rerun --failed 12345/,
+      'delegate runs `gh run rerun --failed <runId>`'
+    );
+  });
+
+  it('case 6: attempt 1 → 2', () => {
+    const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
+    const state = {
+      ticketId: 'GH-508',
+      failureCategory: 'ci_failure',
+      runId: '22222',
+      infraRetry: {
+        count: 1,
+        attempts: [
+          {
+            attemptNumber: 1,
+            timestamp: '2026-01-01T00:00:00.000Z',
+            runId: '11111',
+            signals: ['signal1', 'signal2'],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+        ],
+      },
+    };
+    const result = handler(state, {});
+    assert.ok(result);
+    assert.equal(state.infraRetry.count, 2);
+    assert.equal(state.infraRetry.attempts.length, 2);
+    assert.equal(state.infraRetry.attempts[1].attemptNumber, 2);
+    assert.equal(state.currentStep, 'monitor');
+  });
+
+  it('case 7: attempt 2 → 3', () => {
+    const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
+    const state = {
+      ticketId: 'GH-508',
+      failureCategory: 'ci_failure',
+      runId: '33333',
+      infraRetry: {
+        count: 2,
+        attempts: [
+          { attemptNumber: 1, timestamp: 't1', runId: '1', signals: [], retryMethod: 'rerun-failed', outcome: 'pending' },
+          { attemptNumber: 2, timestamp: 't2', runId: '2', signals: [], retryMethod: 'rerun-failed', outcome: 'pending' },
+        ],
+      },
+    };
+    const result = handler(state, {});
+    assert.ok(result);
+    assert.equal(state.infraRetry.count, 3);
+    assert.equal(state.infraRetry.attempts.length, 3);
+    assert.equal(state.infraRetry.attempts[2].attemptNumber, 3);
+  });
+
+  it('case 8: attempt 3 → exhausted (surface + failureCategory=infra-stuck, no fix-ci)', () => {
+    const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
+    const state = {
+      ticketId: 'GH-508',
+      failureCategory: 'ci_failure',
+      runId: '44444',
+      infraRetry: {
+        count: 3,
+        attempts: [
+          { attemptNumber: 1, timestamp: 't1', runId: '1', signals: [], retryMethod: 'rerun-failed', outcome: 'pending' },
+          { attemptNumber: 2, timestamp: 't2', runId: '2', signals: [], retryMethod: 'rerun-failed', outcome: 'pending' },
+          { attemptNumber: 3, timestamp: 't3', runId: '3', signals: [], retryMethod: 'rerun-failed', outcome: 'pending' },
+        ],
+      },
+    };
+    const result = handler(state, {});
+    assert.ok(result, 'must surface');
+    assert.equal(result.action, 'surface');
+    assert.equal(state.failureCategory, 'infra-stuck', 'failureCategory updated');
+    assert.equal(state.infraRetry.exhausted, true, 'exhausted flag set');
+    assert.equal(state.infraRetry.count, 3, 'count NOT incremented past the cap');
+    assert.equal(state.infraRetry.attempts.length, 3, 'no new attempt appended');
+    assert.equal(result.reason, 'infra-stuck-exhausted');
+    assert.notEqual(result.action, 'execute', 'fix-ci must NOT be dispatched on infra-stuck');
+  });
+
+  it('case 9: prior retry succeeded → marks last attempt outcome=succeeded and advances normally', () => {
+    const { handler, classifyCalls } = loadStep({
+      envFlag: 'true',
+      classifyImpl: infraSuspected,
+    });
+    const state = {
+      ticketId: 'GH-508',
+      failureCategory: 'ci_failure',
+      runId: '55555',
+      infraRetry: {
+        count: 1,
+        attempts: [
+          {
+            attemptNumber: 1,
+            timestamp: '2026-01-01T00:00:00.000Z',
+            runId: '11111',
+            signals: ['signal1', 'signal2'],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+        ],
+      },
+    };
+    const result = handler(state, { ciStatus: 'success' });
+    assert.equal(result, null, 'success branch returns null (advance normally)');
+    assert.equal(
+      state.infraRetry.attempts[0].outcome,
+      'succeeded',
+      'last attempt marked succeeded'
+    );
+    assert.equal(
+      classifyCalls.length,
+      0,
+      'retry-success short-circuit must NOT consult classifier again'
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -143,6 +143,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
       ticketId: 'GH-508',
       failureCategory: 'ci_failure',
       runId: '22222',
+      _ciStatusFreshness: { pid: process.pid, at: new Date().toISOString() },
       infraRetry: {
         count: 1,
         attempts: [
@@ -171,6 +172,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
       ticketId: 'GH-508',
       failureCategory: 'ci_failure',
       runId: '33333',
+      _ciStatusFreshness: { pid: process.pid, at: new Date().toISOString() },
       infraRetry: {
         count: 2,
         attempts: [
@@ -206,6 +208,7 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
       ticketId: 'GH-508',
       failureCategory: 'ci_failure',
       runId: '44444',
+      _ciStatusFreshness: { pid: process.pid, at: new Date().toISOString() },
       infraRetry: {
         count: 3,
         attempts: [

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -243,6 +243,27 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
     assert.notEqual(result.action, 'execute', 'fix-ci must NOT be dispatched on infra-stuck');
   });
 
+  it('case 5c: missing runId → returns null (orchestrator advances), does NOT throw', () => {
+    // Bug 542-22: a missing/non-numeric runId used to throw TypeError out of
+    // buildRetryDelegate. The follow-up loop had no catch, so the whole
+    // workflow aborted. Now the step returns null and the orchestrator
+    // advances to fix-ci.
+    const { handler } = loadStep({ classifyImpl: infraSuspected });
+    const state = {
+      ticketId: 'GH-508',
+      failureCategory: 'ci_failure',
+      _ciFailedJobs: [{ name: 'e2e [shard-4]' }], // no runId
+      infraRetry: { count: 0, attempts: [] },
+    };
+    let result;
+    assert.doesNotThrow(() => {
+      result = handler(state, {});
+    });
+    assert.equal(result, null, 'must return null to let orchestrator advance');
+    assert.equal(state.infraRetry.count, 0, 'retry count NOT consumed');
+    assert.equal(state.infraRetry.attempts.length, 0, 'no attempt recorded');
+  });
+
   it('case 5b: derives runId from state._ciFailedJobs[0].runId when state.runId is unset', () => {
     const { handler } = loadStep({ classifyImpl: infraSuspected });
     const state = {

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -10,17 +10,14 @@
  *  4. classify() returns 'code-failure' → return null.
  */
 
-const { describe, it, beforeEach, afterEach } = require('node:test');
+const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const Module = require('node:module');
 const path = require('node:path');
 
 // Resolve target modules so we can patch them via the require cache.
 const STEP_PATH = require.resolve('../lib/steps/infra-retry');
 const CLASSIFIER_PATH = require.resolve('../lib/infra-classifier');
-const GET_CONFIG_PATH = require.resolve(
-  path.resolve(__dirname, '..', '..', 'lib', 'get-config')
-);
+const GET_CONFIG_PATH = require.resolve(path.resolve(__dirname, '..', '..', 'lib', 'get-config'));
 
 function loadStep({ envFlag, classifyImpl }) {
   // Clear caches so each test gets a fresh module wired to fresh mocks.
@@ -96,7 +93,11 @@ describe('infra-retry step — short-circuits and bypasses (RED 3.1.1)', () => {
       envFlag: 'true',
       classifyImpl: () => ({ classification: 'code-failure', signals: [], evidence: {} }),
     });
-    const state = { failureCategory: 'ci_failure', runId: '12345', infraRetry: { count: 0, attempts: [] } };
+    const state = {
+      failureCategory: 'ci_failure',
+      runId: '12345',
+      infraRetry: { count: 0, attempts: [] },
+    };
     const result = handler(state, {});
     assert.equal(result, null);
     assert.equal(classifyCalls.length, 1, 'classifier must be consulted exactly once');
@@ -173,8 +174,22 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
       infraRetry: {
         count: 2,
         attempts: [
-          { attemptNumber: 1, timestamp: 't1', runId: '1', signals: [], retryMethod: 'rerun-failed', outcome: 'pending' },
-          { attemptNumber: 2, timestamp: 't2', runId: '2', signals: [], retryMethod: 'rerun-failed', outcome: 'pending' },
+          {
+            attemptNumber: 1,
+            timestamp: 't1',
+            runId: '1',
+            signals: [],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+          {
+            attemptNumber: 2,
+            timestamp: 't2',
+            runId: '2',
+            signals: [],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
         ],
       },
     };
@@ -194,9 +209,30 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
       infraRetry: {
         count: 3,
         attempts: [
-          { attemptNumber: 1, timestamp: 't1', runId: '1', signals: [], retryMethod: 'rerun-failed', outcome: 'pending' },
-          { attemptNumber: 2, timestamp: 't2', runId: '2', signals: [], retryMethod: 'rerun-failed', outcome: 'pending' },
-          { attemptNumber: 3, timestamp: 't3', runId: '3', signals: [], retryMethod: 'rerun-failed', outcome: 'pending' },
+          {
+            attemptNumber: 1,
+            timestamp: 't1',
+            runId: '1',
+            signals: [],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+          {
+            attemptNumber: 2,
+            timestamp: 't2',
+            runId: '2',
+            signals: [],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+          {
+            attemptNumber: 3,
+            timestamp: 't3',
+            runId: '3',
+            signals: [],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
         ],
       },
     };
@@ -209,6 +245,26 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
     assert.equal(state.infraRetry.attempts.length, 3, 'no new attempt appended');
     assert.equal(result.reason, 'infra-stuck-exhausted');
     assert.notEqual(result.action, 'execute', 'fix-ci must NOT be dispatched on infra-stuck');
+  });
+
+  it('case 5b: derives runId from state._ciFailedJobs[0].runId when state.runId is unset', () => {
+    const { handler } = loadStep({ envFlag: 'true', classifyImpl: infraSuspected });
+    const state = {
+      ticketId: 'GH-508',
+      failureCategory: 'ci_failure',
+      // NOTE: no state.runId — monitor.js stores runIds on _ciFailedJobs only.
+      _ciFailedJobs: [{ name: 'e2e [shard-4]', runId: '987654' }],
+      infraRetry: { count: 0, attempts: [] },
+    };
+    const result = handler(state, {});
+    assert.ok(result, 'must dispatch a retry delegate');
+    assert.equal(result.action, 'execute');
+    assert.match(
+      result.delegate && result.delegate.command,
+      /gh run rerun --failed 987654/,
+      'delegate must use runId from _ciFailedJobs[0]'
+    );
+    assert.equal(state.infraRetry.attempts[0].runId, '987654');
   });
 
   it('case 9: prior retry succeeded → marks last attempt outcome=succeeded and advances normally', () => {

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -243,7 +243,10 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
     assert.equal(state.infraRetry.exhausted, true, 'exhausted flag set');
     assert.equal(state.infraRetry.count, 3, 'count NOT incremented past the cap');
     assert.equal(state.infraRetry.attempts.length, 3, 'no new attempt appended');
-    assert.equal(result.reason, 'infra-stuck-exhausted');
+    // Bug D+E (GH-508): surface payload now nests reason under .payload to
+    // match the auto-advance hook contract, and reason is 'infra-stuck' so
+    // report.js fires the diagnostic bundle.
+    assert.equal(result.payload && result.payload.reason, 'infra-stuck');
     assert.notEqual(result.action, 'execute', 'fix-ci must NOT be dispatched on infra-stuck');
   });
 

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-step.test.js
@@ -305,5 +305,15 @@ describe('infra-retry step — retry state machine (R2/R3/R4)', () => {
       0,
       'retry-success short-circuit must NOT consult classifier again'
     );
+    assert.equal(
+      state.currentStep,
+      'report',
+      'retry-success routes directly to report (not fix-ci)'
+    );
+    assert.notEqual(
+      state.failureCategory,
+      'ci_failure',
+      'stale ci_failure category cleared so fix-ci does not fire'
+    );
   });
 });

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-telemetry.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-telemetry.test.js
@@ -174,7 +174,10 @@ describe('infra-retry — Task 7 telemetry / retry-success log / gh-actions outa
       classifyImpl: () => ({
         classification: 'infra-suspected',
         signals: ['signal4'],
-        evidence: { signal4: { fired: true, jobCount: 2 } },
+        // Realistic classifier shape: `signals` lists fired signals; per-signal
+        // evidence holds only collector-provided fields (no redundant `fired`
+        // flag). jobCount comes from the failing-jobs propagation in classify().
+        evidence: { signal4: { patterns: ['cache-miss', 'fallback-install-failed'], jobCount: 2 } },
       }),
       ghActionsStatusImpl: () => ({ degraded: true }),
     });

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-telemetry.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-telemetry.test.js
@@ -119,6 +119,94 @@ describe('infra-retry — Task 7 telemetry / retry-success log / gh-actions outa
     assert.deepEqual(entry.signals, ['signal1', 'signal2'], 'records signals');
     assert.equal(entry.decision, 'infra-suspected', 'records decision');
     assert.ok('outcome' in entry, 'has outcome key');
+    // Bug 542-24: dispatched retry must flip the latest entry to 'dispatched',
+    // not leave it as the default 'pending'.
+    assert.equal(entry.outcome, 'dispatched', 'outcome reflects dispatched retry');
+  });
+
+  it('7.1b (Bug 542-24): outcome=succeeded recorded on retry-success', () => {
+    const { handler } = loadStep({
+      classifyImpl: () => ({
+        classification: 'infra-suspected',
+        signals: ['signal1', 'signal2'],
+        evidence: {},
+      }),
+    });
+    const state = {
+      failureCategory: 'ci_failure',
+      runId: '12345',
+      _ciStatusFreshness: { pid: process.pid, at: new Date().toISOString() },
+      history: [
+        {
+          timestamp: 't0',
+          signals: ['signal1', 'signal2'],
+          decision: 'infra-suspected',
+          outcome: 'dispatched',
+        },
+      ],
+      infraRetry: {
+        count: 1,
+        attempts: [
+          {
+            attemptNumber: 1,
+            timestamp: 't0',
+            runId: '12345',
+            signals: ['signal1', 'signal2'],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+        ],
+      },
+    };
+    handler(state, { ciStatus: 'success' });
+    assert.equal(state.history[0].outcome, 'succeeded', 'history outcome updated on success');
+  });
+
+  it('7.1c (Bug 542-24): outcome=exhausted recorded when classify cap-triggers exhaust', () => {
+    // Drive the cap-trigger path: count=2 going in, infra-suspected
+    // classification → dispatchRetryAttempt bumps count to 3, the NEXT visit
+    // hits maybeSurfaceExhausted via the classify pathway, which records the
+    // exhausted outcome on the history entry just appended.
+    const { handler } = loadStep({
+      classifyImpl: () => ({
+        classification: 'infra-suspected',
+        signals: ['signal1', 'signal2'],
+        evidence: {},
+      }),
+    });
+    const state = {
+      failureCategory: 'ci_failure',
+      runId: '12345',
+      _ciStatusFreshness: { pid: process.pid, at: new Date().toISOString() },
+      infraRetry: {
+        count: 2,
+        attempts: [
+          {
+            attemptNumber: 1,
+            timestamp: 't1',
+            runId: '1',
+            signals: [],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+          {
+            attemptNumber: 2,
+            timestamp: 't2',
+            runId: '2',
+            signals: [],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+        ],
+      },
+    };
+    // First visit: dispatches retry #3, history gets entry with outcome=dispatched.
+    handler(state, {});
+    assert.equal(state.infraRetry.count, 3, 'retry #3 dispatched');
+    // Second visit at count=3 + infra-suspected → maybeSurfaceExhausted fires.
+    handler(state, {});
+    const last = state.history[state.history.length - 1];
+    assert.equal(last.outcome, 'exhausted', 'history outcome reflects exhaustion');
   });
 
   it('7.2: retry-success branch writes "auto-retry: infra flake confirmed" to stderr', () => {

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-telemetry.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-telemetry.test.js
@@ -20,15 +20,8 @@ const path = require('node:path');
 
 const STEP_PATH = require.resolve('../lib/steps/infra-retry');
 const CLASSIFIER_PATH = require.resolve('../lib/infra-classifier');
-const GET_CONFIG_PATH = require.resolve(
-  path.resolve(__dirname, '..', '..', 'lib', 'get-config')
-);
-const GH_ACTIONS_STATUS_PATH = path.resolve(
-  __dirname,
-  '..',
-  'lib',
-  'gh-actions-status.js'
-);
+const GET_CONFIG_PATH = require.resolve(path.resolve(__dirname, '..', '..', 'lib', 'get-config'));
+const GH_ACTIONS_STATUS_PATH = path.resolve(__dirname, '..', 'lib', 'gh-actions-status.js');
 
 function loadStep({ envFlag, classifyImpl, ghActionsStatusImpl } = {}) {
   delete require.cache[STEP_PATH];
@@ -145,6 +138,7 @@ describe('infra-retry — Task 7 telemetry / retry-success log / gh-actions outa
     const state = {
       failureCategory: 'ci_failure',
       runId: '12345',
+      _ciStatusFreshness: { pid: process.pid, at: new Date().toISOString() },
       infraRetry: {
         count: 1,
         attempts: [

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-telemetry.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-telemetry.test.js
@@ -23,7 +23,7 @@ const CLASSIFIER_PATH = require.resolve('../lib/infra-classifier');
 const GET_CONFIG_PATH = require.resolve(path.resolve(__dirname, '..', '..', 'lib', 'get-config'));
 const GH_ACTIONS_STATUS_PATH = path.resolve(__dirname, '..', 'lib', 'gh-actions-status.js');
 
-function loadStep({ envFlag, classifyImpl, ghActionsStatusImpl } = {}) {
+function loadStep({ classifyImpl, ghActionsStatusImpl } = {}) {
   delete require.cache[STEP_PATH];
   delete require.cache[CLASSIFIER_PATH];
   delete require.cache[GET_CONFIG_PATH];
@@ -50,10 +50,7 @@ function loadStep({ envFlag, classifyImpl, ghActionsStatusImpl } = {}) {
     exports: { classify, __test__: {} },
   };
 
-  const getConfig = (key) => {
-    if (key === 'WORK_AUTO_RETRY_INFRA') return envFlag;
-    return undefined;
-  };
+  const getConfig = () => undefined;
   require.cache[GET_CONFIG_PATH] = {
     id: GET_CONFIG_PATH,
     filename: GET_CONFIG_PATH,
@@ -103,7 +100,6 @@ function captureStderr(fn) {
 describe('infra-retry — Task 7 telemetry / retry-success log / gh-actions outage (RED)', () => {
   it('7.1: appends telemetry entry to state.history[] on classify', () => {
     const { handler } = loadStep({
-      envFlag: 'true',
       classifyImpl: () => ({
         classification: 'infra-suspected',
         signals: ['signal1', 'signal2'],
@@ -127,7 +123,6 @@ describe('infra-retry — Task 7 telemetry / retry-success log / gh-actions outa
 
   it('7.2: retry-success branch writes "auto-retry: infra flake confirmed" to stderr', () => {
     const { handler } = loadStep({
-      envFlag: 'true',
       classifyImpl: () => ({
         classification: 'infra-suspected',
         signals: ['signal1', 'signal2'],
@@ -164,7 +159,6 @@ describe('infra-retry — Task 7 telemetry / retry-success log / gh-actions outa
 
   it('7.3: signal4 across ≥2 jobs + gh actions degraded → action:surface, no retry consumed', () => {
     const { handler, ghActionsCalls } = loadStep({
-      envFlag: 'true',
       classifyImpl: () => ({
         classification: 'infra-suspected',
         signals: ['signal4'],

--- a/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-telemetry.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/infra-retry-telemetry.test.js
@@ -1,0 +1,197 @@
+'use strict';
+
+/**
+ * Tests for Task 7 — P1 telemetry, retry-success log, GH Actions cross-check.
+ *
+ * Deliverable 7.1.1 / 7.2.1 / 7.3.1 (RED):
+ *  - 7.1: every classify() call appends { timestamp, signals, decision, outcome }
+ *         to state.history[] (default []).
+ *  - 7.2: on retry-success branch, stderr contains literal
+ *         "auto-retry: infra flake confirmed".
+ *  - 7.3: when Signal 4 fires across ≥2 jobs AND github status reports
+ *         Actions degraded, step returns action:'surface' with
+ *         reason:'github-actions-outage' and does NOT increment retry count
+ *         nor invoke gh run rerun.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const STEP_PATH = require.resolve('../lib/steps/infra-retry');
+const CLASSIFIER_PATH = require.resolve('../lib/infra-classifier');
+const GET_CONFIG_PATH = require.resolve(
+  path.resolve(__dirname, '..', '..', 'lib', 'get-config')
+);
+const GH_ACTIONS_STATUS_PATH = path.resolve(
+  __dirname,
+  '..',
+  'lib',
+  'gh-actions-status.js'
+);
+
+function loadStep({ envFlag, classifyImpl, ghActionsStatusImpl } = {}) {
+  delete require.cache[STEP_PATH];
+  delete require.cache[CLASSIFIER_PATH];
+  delete require.cache[GET_CONFIG_PATH];
+
+  let ghActionsResolved;
+  try {
+    ghActionsResolved = require.resolve('../lib/gh-actions-status');
+  } catch (_err) {
+    ghActionsResolved = GH_ACTIONS_STATUS_PATH;
+  }
+  delete require.cache[ghActionsResolved];
+
+  const classifyCalls = [];
+  const classify = (...args) => {
+    classifyCalls.push(args);
+    return classifyImpl
+      ? classifyImpl(...args)
+      : { classification: 'code-failure', signals: [], evidence: {} };
+  };
+  require.cache[CLASSIFIER_PATH] = {
+    id: CLASSIFIER_PATH,
+    filename: CLASSIFIER_PATH,
+    loaded: true,
+    exports: { classify, __test__: {} },
+  };
+
+  const getConfig = (key) => {
+    if (key === 'WORK_AUTO_RETRY_INFRA') return envFlag;
+    return undefined;
+  };
+  require.cache[GET_CONFIG_PATH] = {
+    id: GET_CONFIG_PATH,
+    filename: GET_CONFIG_PATH,
+    loaded: true,
+    exports: getConfig,
+  };
+
+  const ghActionsCalls = [];
+  if (ghActionsStatusImpl) {
+    require.cache[ghActionsResolved] = {
+      id: ghActionsResolved,
+      filename: ghActionsResolved,
+      loaded: true,
+      exports: {
+        checkActionsStatus: (...args) => {
+          ghActionsCalls.push(args);
+          return ghActionsStatusImpl(...args);
+        },
+      },
+    };
+  }
+
+  const stepModule = require(STEP_PATH);
+  const handlers = Object.create(null);
+  const register = (name, fn) => {
+    handlers[name] = fn;
+  };
+  stepModule(register);
+  return { handler: handlers['infra-retry'], classifyCalls, ghActionsCalls };
+}
+
+function captureStderr(fn) {
+  const original = process.stderr.write.bind(process.stderr);
+  let buf = '';
+  process.stderr.write = (chunk) => {
+    buf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return buf;
+}
+
+describe('infra-retry — Task 7 telemetry / retry-success log / gh-actions outage (RED)', () => {
+  it('7.1: appends telemetry entry to state.history[] on classify', () => {
+    const { handler } = loadStep({
+      envFlag: 'true',
+      classifyImpl: () => ({
+        classification: 'infra-suspected',
+        signals: ['signal1', 'signal2'],
+        evidence: {},
+      }),
+    });
+    const state = {
+      failureCategory: 'ci_failure',
+      runId: '12345',
+      infraRetry: { count: 0, attempts: [] },
+    };
+    handler(state, {});
+    assert.ok(Array.isArray(state.history), 'state.history must be initialized');
+    assert.equal(state.history.length, 1, 'one telemetry entry appended');
+    const entry = state.history[0];
+    assert.ok(entry.timestamp, 'has timestamp');
+    assert.deepEqual(entry.signals, ['signal1', 'signal2'], 'records signals');
+    assert.equal(entry.decision, 'infra-suspected', 'records decision');
+    assert.ok('outcome' in entry, 'has outcome key');
+  });
+
+  it('7.2: retry-success branch writes "auto-retry: infra flake confirmed" to stderr', () => {
+    const { handler } = loadStep({
+      envFlag: 'true',
+      classifyImpl: () => ({
+        classification: 'infra-suspected',
+        signals: ['signal1', 'signal2'],
+        evidence: {},
+      }),
+    });
+    // Simulate prior pending attempt; ctx signals CI green => success branch.
+    const state = {
+      failureCategory: 'ci_failure',
+      runId: '12345',
+      infraRetry: {
+        count: 1,
+        attempts: [
+          {
+            attemptNumber: 1,
+            timestamp: '2026-01-01T00:00:00.000Z',
+            runId: '12345',
+            signals: ['signal1', 'signal2'],
+            retryMethod: 'rerun-failed',
+            outcome: 'pending',
+          },
+        ],
+      },
+    };
+    const ctx = { ciStatus: 'success' };
+    const stderr = captureStderr(() => handler(state, ctx));
+    assert.match(
+      stderr,
+      /auto-retry: infra flake confirmed/,
+      'stderr must contain the retry-success literal'
+    );
+  });
+
+  it('7.3: signal4 across ≥2 jobs + gh actions degraded → action:surface, no retry consumed', () => {
+    const { handler, ghActionsCalls } = loadStep({
+      envFlag: 'true',
+      classifyImpl: () => ({
+        classification: 'infra-suspected',
+        signals: ['signal4'],
+        evidence: { signal4: { fired: true, jobCount: 2 } },
+      }),
+      ghActionsStatusImpl: () => ({ degraded: true }),
+    });
+    const state = {
+      failureCategory: 'ci_failure',
+      runId: '12345',
+      infraRetry: { count: 0, attempts: [] },
+    };
+    const result = handler(state, {});
+    assert.ok(result, 'handler must return an instruction');
+    assert.equal(result.action, 'surface', 'short-circuits to surface');
+    assert.equal(
+      result.payload && result.payload.reason,
+      'github-actions-outage',
+      'reason indicates the outage'
+    );
+    assert.equal(state.infraRetry.count, 0, 'retry count NOT incremented on outage');
+    assert.ok(ghActionsCalls.length >= 1, 'gh actions status was consulted');
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/log-utils-regression.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/log-utils-regression.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * Regression test for the `filterLogs` predicate extracted from `fix-ci.js`.
+ * The refactor introduced a `shouldKeepLine` helper; this test locks in
+ * byte-equivalent behavior so future edits cannot silently corrupt what the
+ * developer-nodejs-tdd agent sees on a fix-ci dispatch.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { filterLogs } = require('../lib/log-utils');
+
+// One representative line per allow pattern.
+const ALLOW_LINES = [
+  'AssertionError: expected 1 to equal 2', // error|fail|assert|expect|...
+  'src/components/foo.spec.ts:42:11 — failure', // \.(spec|test)\.(ts|js|tsx|jsx)
+  '    at Object.<anonymous> (/path/to/file.js:10:5)', // ^\s+at\s
+  'Process completed with exit code 1', // exit code|...
+  'Run tests with coverage', // Run tests|Run e2e|playwright
+];
+
+// One representative line per deny pattern.
+const DENY_LINES = [
+  '##[group]Set up job', // group/endgroup/Runner Image/OS
+  'Runner version: 2.310.2', // runner version|Secret source|...
+  'Image: ubuntu-22.04', // Image:|Version:|Commit:|...
+  'Permissions for GITHUB_TOKEN', // Permissions|Actions: read|...
+  'Temporarily overriding HOME', // Temporarily overriding HOME|...
+  '[command]/usr/bin/git config --global', // \[command\]/usr/bin/git
+  'Cleaning up orphan processes', // RESOLVEDSTATS|Cleaning up orphan|...
+];
+
+describe('log-utils filterLogs — regression lock', () => {
+  it('preserves every allow-pattern line', () => {
+    const input = [...ALLOW_LINES, ...DENY_LINES].join('\n');
+    const out = filterLogs(input);
+    for (const line of ALLOW_LINES) {
+      assert.ok(out.includes(line), `allow line missing from output: "${line}"`);
+    }
+  });
+
+  it('drops every deny-pattern line', () => {
+    const input = [...ALLOW_LINES, ...DENY_LINES].join('\n');
+    const out = filterLogs(input);
+    for (const line of DENY_LINES) {
+      assert.ok(!out.includes(line), `deny line leaked into output: "${line}"`);
+    }
+  });
+
+  it('falls back to last 120 non-blank stripped lines when filter result is empty', () => {
+    // Build an input that's ONLY deny-pattern lines + blanks, plus a unique
+    // tail marker the fallback should preserve.
+    const denyOnly = Array.from({ length: 150 }, (_, i) => `##[group]Setup step ${i}`);
+    const tailMarker = 'UNIQUE-FALLBACK-TAIL-MARKER';
+    denyOnly.push(tailMarker);
+    const input = denyOnly.join('\n');
+    const out = filterLogs(input);
+    assert.ok(out.length > 0, 'fallback must return non-empty output');
+    assert.ok(
+      out.includes(tailMarker),
+      'fallback must preserve the trailing line (last 120 non-blank)'
+    );
+  });
+
+  it('keeps case-insensitive matches (Error: AND error:)', () => {
+    const input = ['Error: boom', 'error: lowercase boom'].join('\n');
+    const out = filterLogs(input);
+    assert.ok(out.includes('Error: boom'));
+    assert.ok(out.includes('error: lowercase boom'));
+  });
+
+  it('strips gh log prefix before predicate runs', () => {
+    // gh log format: "JobName\tStepName\t<ISO timestamp> <message>"
+    const prefixed = 'shard-2\tRun tests\t2026-05-12T10:14:53.123Z AssertionError: boom';
+    const out = filterLogs(prefixed);
+    assert.ok(out.includes('AssertionError: boom'));
+    assert.ok(!out.includes('shard-2'), 'job name must be stripped');
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/log-utils.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/log-utils.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { stripGhPrefix, filterLogs } = require('../lib/log-utils');
+
+describe('log-utils', () => {
+  describe('stripGhPrefix', () => {
+    it('strips the "<job>\\t<step>\\t<ISO timestamp>\\t" GitHub log prefix', () => {
+      const line =
+        'unit-tests\tRun tests\t2026-05-12T10:14:53.123Z Error: expected true to be false';
+      const result = stripGhPrefix(line);
+      assert.equal(result, 'Error: expected true to be false');
+    });
+
+    it('returns the original line unchanged when no gh prefix is present', () => {
+      const line = 'plain log line without prefix';
+      const result = stripGhPrefix(line);
+      assert.equal(result, 'plain log line without prefix');
+    });
+
+    it('handles multiple job/step variants in the prefix', () => {
+      const line =
+        'e2e-tests [shard-1]\tUNKNOWN STEP\t2026-01-15T08:00:00.000Z playwright FAIL src/foo.spec.ts';
+      const result = stripGhPrefix(line);
+      assert.equal(result, 'playwright FAIL src/foo.spec.ts');
+    });
+  });
+
+  describe('filterLogs', () => {
+    it('drops blank lines from the raw logs', () => {
+      const raw = ['', '   ', 'Error: something failed', ''].join('\n');
+      const result = filterLogs(raw);
+      assert.ok(
+        result.includes('Error: something failed'),
+        `expected error line preserved, got: ${result}`
+      );
+      // Blank lines should not appear as standalone lines in the result.
+      const lines = result.split('\n');
+      for (const line of lines) {
+        assert.ok(line.trim().length > 0, `unexpected blank line in result: "${line}"`);
+      }
+    });
+
+    it('drops ##[group] / ##[endgroup] noise lines', () => {
+      const raw = [
+        '##[group]Run actions/checkout@v4',
+        '##[endgroup]',
+        'Error: assertion failed at foo.test.js',
+      ].join('\n');
+      const result = filterLogs(raw);
+      assert.ok(!result.includes('##[group]'), 'expected ##[group] noise removed');
+      assert.ok(!result.includes('##[endgroup]'), 'expected ##[endgroup] noise removed');
+      assert.ok(
+        result.includes('Error: assertion failed at foo.test.js'),
+        'expected error line preserved'
+      );
+    });
+
+    it('keeps lines containing error / fail / expect markers', () => {
+      const raw = [
+        'Runner Image: ubuntu-22.04',
+        'expect(received).toBe(expected)',
+        'FAIL src/example.spec.ts',
+      ].join('\n');
+      const result = filterLogs(raw);
+      assert.ok(!result.includes('Runner Image'), 'runner noise should be dropped');
+      assert.ok(result.includes('expect(received).toBe(expected)'), 'expect line preserved');
+      assert.ok(result.includes('FAIL src/example.spec.ts'), 'FAIL line preserved');
+    });
+
+    it('strips the gh prefix before applying the noise filter', () => {
+      const raw = [
+        'unit-tests\tRun tests\t2026-05-12T10:14:53.123Z Error: boom',
+        'unit-tests\tRun tests\t2026-05-12T10:14:54.123Z ##[group]Setup',
+      ].join('\n');
+      const result = filterLogs(raw);
+      assert.ok(result.includes('Error: boom'), 'gh-prefixed error preserved');
+      assert.ok(!result.includes('##[group]'), 'gh-prefixed noise dropped');
+      assert.ok(!result.includes('2026-05-12T10:14:53'), 'timestamp prefix stripped');
+    });
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/monitor-classifier-ctx.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/monitor-classifier-ctx.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * Bug B (GH-508): monitor.js must populate state._ciAllJobs, _ciFailedLogs,
+ * and _ciStatus so the infra-classifier has the production context it
+ * expects. Before this fix only `_ciFailedJobs` was set and the classifier
+ * received empty arrays for the three sibling fields.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  __test__: { mapCiStatus },
+} = require('../lib/steps/monitor');
+
+describe('monitor — classifier ctx (Bug B)', () => {
+  it('mapCiStatus translates passing → success', () => {
+    assert.equal(mapCiStatus('passing'), 'success');
+  });
+  it('mapCiStatus translates no-checks → success', () => {
+    assert.equal(mapCiStatus('no-checks'), 'success');
+  });
+  it('mapCiStatus translates failing → failure', () => {
+    assert.equal(mapCiStatus('failing'), 'failure');
+  });
+  it('mapCiStatus translates pending → in_progress', () => {
+    assert.equal(mapCiStatus('pending'), 'in_progress');
+  });
+  it('mapCiStatus translates unknown / undefined → in_progress', () => {
+    assert.equal(mapCiStatus(undefined), 'in_progress');
+    assert.equal(mapCiStatus('whatever'), 'in_progress');
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/monitor-failed-tests-extract.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/monitor-failed-tests-extract.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const monitor = require('../lib/steps/monitor');
+const { extractFailedTestPaths } = monitor.__test__;
+
+describe('extractFailedTestPaths', () => {
+  it('returns [] for empty / non-string input', () => {
+    assert.deepEqual(extractFailedTestPaths(''), []);
+    assert.deepEqual(extractFailedTestPaths(null), []);
+    assert.deepEqual(extractFailedTestPaths(undefined), []);
+    assert.deepEqual(extractFailedTestPaths(42), []);
+  });
+
+  it('extracts vitest-style FAIL lines with .test.ts paths', () => {
+    const log = [
+      'RUN  v1.0',
+      ' FAIL  src/components/Button.test.tsx',
+      ' FAIL  packages/core/src/parse.test.ts',
+      ' PASS  src/ok.test.ts',
+    ].join('\n');
+    const out = extractFailedTestPaths(log);
+    assert.ok(out.includes('src/components/Button.test.tsx'));
+    assert.ok(out.includes('packages/core/src/parse.test.ts'));
+    assert.ok(!out.includes('src/ok.test.ts'));
+  });
+
+  it('extracts jest-style FAIL lines', () => {
+    const log = [
+      'FAIL apps/web/src/utils/format.test.js',
+      'FAIL plugins/work/scripts/foo.spec.js  (12.5 s)',
+    ].join('\n');
+    const out = extractFailedTestPaths(log);
+    assert.ok(out.includes('apps/web/src/utils/format.test.js'));
+    assert.ok(out.includes('plugins/work/scripts/foo.spec.js'));
+  });
+
+  it('extracts playwright-style failures with × marker and .spec.ts', () => {
+    const log = [
+      '  ×  tests/e2e/login.spec.ts:42:5 › login flow › redirects',
+      '  ✘  packages/ui/tests/button.spec.ts:10:1 › renders',
+    ].join('\n');
+    const out = extractFailedTestPaths(log);
+    assert.ok(out.includes('tests/e2e/login.spec.ts'));
+    assert.ok(out.includes('packages/ui/tests/button.spec.ts'));
+  });
+
+  it('dedupes repeated paths', () => {
+    const log = ['FAIL src/a.test.ts', 'FAIL src/a.test.ts', ' × src/a.test.ts:1:1 › x'].join('\n');
+    const out = extractFailedTestPaths(log);
+    assert.equal(out.filter((p) => p === 'src/a.test.ts').length, 1);
+  });
+
+  it('ignores noise lines that mention "fail" but no test path', () => {
+    const log = ['Error: tests failed in CI', 'some random fail noise here'].join('\n');
+    const out = extractFailedTestPaths(log);
+    assert.deepEqual(out, []);
+  });
+
+  it('keeps paths relative (does not invent absolute paths)', () => {
+    const log = 'FAIL plugins/work/scripts/workflows/follow-up/foo.test.js';
+    const out = extractFailedTestPaths(log);
+    assert.ok(out.every((p) => !p.startsWith('/')));
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/monitor-green-routing.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/monitor-green-routing.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * R15 (GH-508): when CI turns green and an infra-retry attempt is still
+ * pending, monitor must route to the infra-retry step so
+ * maybeHandleRetrySuccess fires and the canonical
+ * "auto-retry: infra flake confirmed" telemetry is emitted. When there is
+ * no pending attempt, monitor must route to report (preserving the
+ * normal happy-path behavior).
+ *
+ * Cursor review (PR #542): the previous code unconditionally routed to
+ * 'report' on exitCode === 0, so the retry success path never ran in the
+ * normal retry flow and R14/R15 telemetry was wrong.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  __test__: { computeNextStepOnGreen },
+} = require('../lib/steps/monitor');
+
+describe('monitor — CI green routing (R15)', () => {
+  it('routes to infra-retry when last attempt outcome is pending', () => {
+    const state = {
+      infraRetry: {
+        attempts: [{ outcome: 'pending', n: 1 }],
+      },
+    };
+    assert.equal(computeNextStepOnGreen(state), 'infra-retry');
+  });
+
+  it('routes to report when there are no infra-retry attempts', () => {
+    const state = { infraRetry: { attempts: [] } };
+    assert.equal(computeNextStepOnGreen(state), 'report');
+  });
+
+  it('routes to report when infraRetry is missing entirely', () => {
+    assert.equal(computeNextStepOnGreen({}), 'report');
+    assert.equal(computeNextStepOnGreen(null), 'report');
+    assert.equal(computeNextStepOnGreen(undefined), 'report');
+  });
+
+  it('routes to report when the last attempt already succeeded', () => {
+    const state = {
+      infraRetry: {
+        attempts: [
+          { outcome: 'pending', n: 1 },
+          { outcome: 'succeeded', n: 2 },
+        ],
+      },
+    };
+    assert.equal(computeNextStepOnGreen(state), 'report');
+  });
+
+  it('routes to report when the last attempt failed', () => {
+    const state = {
+      infraRetry: {
+        attempts: [{ outcome: 'failed', n: 1 }],
+      },
+    };
+    assert.equal(computeNextStepOnGreen(state), 'report');
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/repo-meta-smoke.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/repo-meta-smoke.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Structural smoke test: `lib/repo-meta.js` must be reachable in isolation —
+ * no follow-up-next.js boot required. This is the payoff of the helpers
+ * extraction (issue: classifier-ctx + repo-meta helpers shouldn't drag the
+ * whole orchestrator into their test surface).
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('lib/repo-meta — smoke (isolated require)', () => {
+  it('exports detectDefaultBranch, loadPrDiffFiles, detectRepoSlug', () => {
+    const mod = require('../lib/repo-meta');
+    assert.equal(typeof mod.detectDefaultBranch, 'function');
+    assert.equal(typeof mod.loadPrDiffFiles, 'function');
+    assert.equal(typeof mod.detectRepoSlug, 'function');
+  });
+
+  it('loadPrDiffFiles fails open with [] on a non-git path', () => {
+    delete require.cache[require.resolve('../lib/repo-meta')];
+    const { loadPrDiffFiles } = require('../lib/repo-meta');
+    const out = loadPrDiffFiles('/nonexistent/path/should/not/exist');
+    assert.ok(Array.isArray(out));
+    assert.equal(out.length, 0);
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/report-infra-stuck.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/report-infra-stuck.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+// Skip delays in tests
+process.env.FOLLOW_UP2_NO_DELAY = '1';
+
+/**
+ * Task 6.1 (RED): report.js must render an `infra-stuck` diagnostic bundle
+ * when state.failureCategory === 'infra-stuck'.
+ *
+ * The bundle includes a "## Infra-stuck after 3 retries" header, and a
+ * formatted line per state.infraRetry.attempts[i] containing attemptNumber,
+ * timestamp, runId, signals, and retryMethod. RunIds appear as
+ * https://github.com/<owner>/<repo>/actions/runs/<runId> URLs.
+ *
+ * These tests fail until the branch and the rendering exist.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const handlers = Object.create(null);
+function registerStep(name, fn) {
+  handlers[name] = fn;
+}
+require('../lib/steps/report')(registerStep);
+const report = handlers['report'];
+
+function makeCtx() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'followup-report-infra-stuck-'));
+  return { tmp, ctx: { tasksDir: tmp } };
+}
+
+function makeInfraStuckState(overrides) {
+  return {
+    ticketId: 'GH-508',
+    prNumber: 999,
+    currentStep: 'report',
+    attempt: 3,
+    failureCategory: 'infra-stuck',
+    repoOwner: 'thomfilg',
+    repoName: 'claude-plugin-work',
+    infraRetry: {
+      count: 3,
+      attempts: [
+        {
+          attemptNumber: 1,
+          timestamp: '2026-06-03T10:00:00.000Z',
+          runId: '111111',
+          signals: ['signal1', 'signal2'],
+          retryMethod: 'rerun-failed',
+        },
+        {
+          attemptNumber: 2,
+          timestamp: '2026-06-03T10:05:00.000Z',
+          runId: '222222',
+          signals: ['signal3'],
+          retryMethod: 'empty-commit',
+        },
+        {
+          attemptNumber: 3,
+          timestamp: '2026-06-03T10:10:00.000Z',
+          runId: '333333',
+          signals: ['signal4'],
+          retryMethod: 'rerun-failed',
+        },
+      ],
+    },
+    lastMonitorResult: {
+      exitCode: 1,
+      output: 'CI: FAILED\nReviews: CLEAR',
+    },
+    ...overrides,
+  };
+}
+
+describe('report step: infra-stuck diagnostic bundle (Task 6.1)', () => {
+  it('renders the "Infra-stuck after 3 retries" header when failureCategory=infra-stuck', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = makeInfraStuckState();
+      const result = report(state, ctx);
+      assert.ok(result, 'report must return an instruction for infra-stuck');
+      const text = JSON.stringify(result);
+      assert.match(text, /Infra-stuck after 3 retries/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('includes every attempt timestamp, runId, and signals list', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = makeInfraStuckState();
+      const result = report(state, ctx);
+      const text = JSON.stringify(result);
+      for (const a of state.infraRetry.attempts) {
+        assert.match(
+          text,
+          new RegExp(String(a.runId)),
+          `expected runId ${a.runId} in report output`
+        );
+        assert.match(
+          text,
+          new RegExp(a.timestamp.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+          `expected timestamp ${a.timestamp} in report output`
+        );
+        for (const sig of a.signals) {
+          assert.match(text, new RegExp(sig), `expected signal ${sig} in report output`);
+        }
+        assert.match(
+          text,
+          new RegExp(`attemptNumber.*${a.attemptNumber}|#${a.attemptNumber}|attempt ${a.attemptNumber}`),
+          `expected attemptNumber ${a.attemptNumber} reference in report output`
+        );
+        assert.match(
+          text,
+          new RegExp(a.retryMethod),
+          `expected retryMethod ${a.retryMethod} in report output`
+        );
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('renders github.com/.../actions/runs/<runId> URLs for each attempt', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = makeInfraStuckState();
+      const result = report(state, ctx);
+      const text = JSON.stringify(result);
+      for (const a of state.infraRetry.attempts) {
+        const re = new RegExp(`https:\\/\\/github\\.com\\/[^\\s"]+\\/actions\\/runs\\/${a.runId}`);
+        assert.match(text, re, `expected GitHub Actions run URL for runId ${a.runId}`);
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('does NOT mark state.status=complete when surfacing infra-stuck', () => {
+    const { tmp, ctx } = makeCtx();
+    try {
+      const state = makeInfraStuckState();
+      report(state, ctx);
+      assert.notEqual(
+        state.status,
+        'complete',
+        'infra-stuck must require manual intervention, not auto-complete'
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/step-registry-dispatch-smoke.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/step-registry-dispatch-smoke.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Structural smoke test: `dispatchStepResult` is exported from step-registry
+ * (alongside runStep / STEPS / registerStep) and follows the documented
+ * surface/blocked/null decision table.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { dispatchStepResult } = require('../lib/step-registry');
+
+describe('lib/step-registry — dispatchStepResult smoke', () => {
+  it('is exported as a function', () => {
+    assert.equal(typeof dispatchStepResult, 'function');
+  });
+
+  it('action=surface → terminate=true, instruction echoed', () => {
+    const result = { action: 'surface', payload: { reason: 'infra-stuck' } };
+    const d = dispatchStepResult({}, result);
+    assert.equal(d.terminate, true);
+    assert.deepEqual(d.instruction, result);
+  });
+
+  it('action=blocked → terminate=true', () => {
+    const result = { action: 'blocked', reason: 'something' };
+    const d = dispatchStepResult({}, result);
+    assert.equal(d.terminate, true);
+    assert.deepEqual(d.instruction, result);
+  });
+
+  it('null result → terminate=false', () => {
+    const d = dispatchStepResult({}, null);
+    assert.equal(d.terminate, false);
+    assert.equal(d.instruction, null);
+  });
+
+  it('action=execute → terminate=false (loop continues, instruction echoed)', () => {
+    const result = { action: 'execute', delegate: { type: 'bash', command: 'echo hi' } };
+    const d = dispatchStepResult({}, result);
+    assert.equal(d.terminate, false);
+    assert.deepEqual(d.instruction, result);
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/step-registry-infra.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/step-registry-infra.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// Skip delays in tests
+process.env.FOLLOW_UP2_NO_DELAY = '1';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { STEPS } = require('../lib/step-registry');
+const followUpNext = require('../follow-up-next');
+
+describe('step-registry — infra-retry wiring (Task 4)', () => {
+  it('(a) STEPS deep-equals the documented 7-element ordered array', () => {
+    assert.deepEqual(STEPS, [
+      'monitor',
+      'triage',
+      'infra-retry',
+      'fix-ci',
+      'fix-reviews',
+      'push-retry',
+      'report',
+    ]);
+  });
+
+  it('(b) initState() returns object with infraRetry default { count: 0, attempts: [] }', () => {
+    assert.equal(
+      typeof followUpNext.initState,
+      'function',
+      'follow-up-next must export initState for testability'
+    );
+    const state = followUpNext.initState('GH-508', null);
+    assert.ok(state.infraRetry, 'initState must include infraRetry block');
+    assert.equal(state.infraRetry.count, 0);
+    assert.deepEqual(state.infraRetry.attempts, []);
+  });
+
+  it('(c) dispatchStepResult treats action:"surface" as terminal without status=complete', () => {
+    assert.equal(
+      typeof followUpNext.dispatchStepResult,
+      'function',
+      'follow-up-next must export dispatchStepResult for testability'
+    );
+    const state = {
+      ticketId: 'GH-508',
+      currentStep: 'infra-retry',
+      status: 'in_progress',
+    };
+    const result = { action: 'surface', payload: { reason: 'infra exhausted' } };
+    const decision = followUpNext.dispatchStepResult(state, result);
+    assert.equal(decision.terminate, true, 'surface must set terminate=true');
+    assert.notEqual(
+      state.status,
+      'complete',
+      'surface must NOT mark state.status=complete'
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/triage.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/triage.test.js
@@ -24,12 +24,16 @@ function makeState(exitCode, output) {
 }
 
 describe('triage step', () => {
-  it('routes CI failure to fix-ci', () => {
+  it('routes CI failure to infra-retry (Bug A — infra-retry visited before fix-ci)', () => {
     const state = makeState(1, 'CI: FAILING\n  ✗ Test (Node 20) — FAILED');
     const result = triage(state, {});
     assert.equal(result, null);
     assert.equal(state.failureCategory, 'ci_failure');
-    assert.equal(state.currentStep, 'fix-ci');
+    assert.equal(
+      state.currentStep,
+      'infra-retry',
+      'STEPS order requires infra-retry before fix-ci; routing to fix-ci would skip retry gating'
+    );
   });
 
   it('routes merge conflict to fix-ci', () => {
@@ -69,12 +73,12 @@ describe('triage step', () => {
     assert.equal(state.currentStep, 'report');
   });
 
-  it('routes CI cancelled to fix-ci when merge is blocked and no reviews', () => {
+  it('routes CI cancelled to infra-retry when merge is blocked and no reviews', () => {
     const state = makeState(1, 'CI: CANCELLED\nMERGE STATUS: BLOCKED');
     const result = triage(state, {});
     assert.equal(result, null);
     assert.equal(state.failureCategory, 'ci_cancelled_blocking');
-    assert.equal(state.currentStep, 'fix-ci');
+    assert.equal(state.currentStep, 'infra-retry');
   });
 
   it('does NOT route CI cancelled to fix-ci when reviews are blocking', () => {
@@ -109,6 +113,7 @@ describe('triage step', () => {
     const state = makeState(1, 'CI: FAILING\nReviews: 1 BLOCKING');
     const result = triage(state, {});
     assert.equal(state.failureCategory, 'ci_failure');
+    assert.equal(state.currentStep, 'infra-retry');
   });
 
   it('blocking reviews take priority over CI pending', () => {

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -243,16 +243,21 @@ function getNextInstruction(ticketId, prNumber) {
   const candidateWorktree = path.join(WORKTREES_BASE, `${MAIN_WORKTREE_FOLDER}-${ticketId}`);
   const worktreeDir = fs.existsSync(candidateWorktree) ? candidateWorktree : process.cwd();
 
-  const ctx = {
+  // PR #542 cursor[bot]: monitor mutates state._ciAllJobs / _ciFailedLogs /
+  // _ciStatus mid-loop, so a ctx built once before the loop hands a stale
+  // snapshot to a later step (e.g. infra-retry). Rebuild ctx fresh on every
+  // iteration so subsequent steps observe the post-monitor state.
+  const freshCtx = () => ({
     tasksDir,
     worktreeDir,
     TASKS_BASE,
     workScriptsDir: path.join(__dirname, '..', 'work', 'scripts'),
     ...buildClassifierCtx(state, worktreeDir),
-  };
+  });
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
+    const ctx = freshCtx();
     if (state.status === 'complete' || !STEPS.includes(state.currentStep)) {
       // Re-verify against GitHub before honoring a saved "complete". The
       // saved state is a cache of a prior run's decision; if anything has

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -332,6 +332,22 @@ function getNextInstruction(ticketId, prNumber) {
         if (surfaceReason) {
           state.failureCategory = surfaceReason;
         }
+        // Bug 542-10: build the diagnostic summary BEFORE returning so the
+        // auto-advance hook (which treats `surface` as terminal) shows the
+        // per-attempt GitHub Actions URLs without requiring a second
+        // /follow-up invocation.
+        try {
+          const reportResult = runStep('report', state, ctx);
+          const summary =
+            (reportResult &&
+              (reportResult.summary || (reportResult.payload && reportResult.payload.summary))) ||
+            null;
+          if (summary) {
+            result.payload = Object.assign({}, result.payload || {}, { summary });
+          }
+        } catch (_e) {
+          /* fail open — surface still terminal; user can re-run /follow-up */
+        }
         saveState(ticketId, state);
         return result;
       }

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -14,9 +14,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const cp = require('child_process');
 
-const { buildChildEnv } = require('../work/scripts/gh-exec');
+const { detectDefaultBranch, loadPrDiffFiles } = require('./lib/repo-meta');
+const { buildClassifierCtx } = require('./lib/classifier-ctx');
 
 if (require.main === module) {
   process.on('uncaughtException', (err) => {
@@ -82,7 +82,9 @@ try {
 }
 
 // ─── Step registry ──────────────────────────────────────────────────────────
-const { runStep, STEPS } = require(path.join(__dirname, 'lib', 'step-registry'));
+const { runStep, STEPS, dispatchStepResult } = require(
+  path.join(__dirname, 'lib', 'step-registry')
+);
 
 // ─── State management ───────────────────────────────────────────────────────
 
@@ -121,121 +123,6 @@ function initState(ticketId, prNumber) {
     infraRetry: { count: 0, attempts: [] },
     startTime: new Date().toISOString(),
   };
-}
-
-// Bug F (GH-508): hardcoding `origin/main` broke repos with non-main default
-// branches (signal3 was scoring against an empty diff). Detect the actual
-// default branch via `gh repo view`, fall back to `git remote show origin`,
-// then to 'main'. Cached per-process — the default branch doesn't change
-// during a single follow-up run.
-const _detectedDefaultBranch = new Map();
-function detectDefaultBranch(worktreeDir) {
-  const key = worktreeDir || process.cwd();
-  if (_detectedDefaultBranch.has(key)) return _detectedDefaultBranch.get(key);
-  const runQuiet = (cmd) => {
-    try {
-      return cp
-        .execSync(cmd, {
-          cwd: worktreeDir,
-          encoding: 'utf8',
-          timeout: 8000,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        })
-        .trim();
-    } catch {
-      return '';
-    }
-  };
-  let detected = runQuiet('gh repo view --json defaultBranchRef --jq .defaultBranchRef.name');
-  if (!detected) {
-    const remote = runQuiet('git remote show origin');
-    const m = remote.match(/HEAD branch:\s*(\S+)/);
-    if (m && m[1] && m[1] !== '(unknown)') detected = m[1];
-  }
-  const resolved = detected || 'main';
-  _detectedDefaultBranch.set(key, resolved);
-  return resolved;
-}
-
-// Compute the PR diff file list (origin/<default>...HEAD). Fails open with [].
-function loadPrDiffFiles(worktreeDir) {
-  const branch = detectDefaultBranch(worktreeDir);
-  try {
-    const out = cp.execSync(`git diff --name-only origin/${branch}...HEAD`, {
-      cwd: worktreeDir,
-      encoding: 'utf8',
-      timeout: 10000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return out.split('\n').filter(Boolean);
-  } catch {
-    return [];
-  }
-}
-
-// Build a bound exec function matching the shape signal2 / classifier expect:
-//   exec(cmd) -> { stdout, stderr, status }
-function buildExecForCtx(worktreeDir) {
-  return (cmd) => {
-    try {
-      const stdout = cp.execSync(cmd, {
-        cwd: worktreeDir,
-        encoding: 'utf8',
-        timeout: 30000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        env: buildChildEnv(),
-      });
-      return { stdout, stderr: '', status: 0 };
-    } catch (err) {
-      return {
-        stdout: (err && err.stdout) || '',
-        stderr: (err && err.stderr) || String((err && err.message) || ''),
-        status: err && typeof err.status === 'number' ? err.status : 1,
-      };
-    }
-  };
-}
-
-// Surface the ctx fields the infra-classifier and infra-retry step depend on.
-// monitor.js populates state._ciFailedJobs / _ciAllJobs / _ciFailedLogs /
-// _ciStatus during its poll; we surface those plus a bound exec and a cached
-// PR diff list so the classifier can run pure (no shell-outs).
-function buildClassifierCtx(state, worktreeDir) {
-  const failedJobs = Array.isArray(state._ciFailedJobs) ? state._ciFailedJobs : [];
-  const firstFailed = failedJobs[0] || {};
-  // PR #542 cursor[bot]: signal3 reads state.failedTests. monitor.js writes
-  // extracted paths to state._ciFailedTests; mirror onto state.failedTests so
-  // the classifier's existing read works without a signature change, and
-  // surface on ctx for future ctx-consumers.
-  const failedTests = Array.isArray(state._ciFailedTests) ? state._ciFailedTests : [];
-  state.failedTests = failedTests;
-  return {
-    allJobs: Array.isArray(state._ciAllJobs) ? state._ciAllJobs : [],
-    prDiffFiles: loadPrDiffFiles(worktreeDir),
-    rawLogs: typeof state._ciFailedLogs === 'string' ? state._ciFailedLogs : '',
-    failedTests,
-    exec: buildExecForCtx(worktreeDir),
-    // Bug C (GH-508): monitor.js records IDs on _ciFailedJobs only — state.runId
-    // is never populated. Read both runId and jobId from the failed-job entry so
-    // signal2's NUMERIC_ID validation receives real IDs instead of undefined.
-    runId: firstFailed.runId || null,
-    jobId: firstFailed.jobId || null,
-    ciStatus: state._ciStatus || null,
-  };
-}
-
-// Dispatch a step result and decide whether the orchestrator loop terminates.
-// Exported for testability (Task 4: action:'surface' is a terminal instruction
-// that stops the loop without marking state.status='complete' — see spec's
-// "API/Interface Changes" section for the surface contract).
-function dispatchStepResult(state, result) {
-  if (result && result.action === 'surface') {
-    return { terminate: true, instruction: result };
-  }
-  if (result && result.action === 'blocked') {
-    return { terminate: true, instruction: result };
-  }
-  return { terminate: false, instruction: result || null };
 }
 
 // ─── Core orchestrator loop ─────────────────────────────────────────────────
@@ -463,12 +350,11 @@ module.exports = {
   getNextInstruction,
   initState,
   dispatchStepResult,
-  // test-only escape hatch — exposes pure helpers for unit testing.
+  // test-only escape hatch — exposes pure helpers for legacy unit tests. Tests
+  // that need a fresh cache should invalidate the require cache for
+  // `./lib/repo-meta` rather than calling a reset method.
   __test__: {
     detectDefaultBranch,
     loadPrDiffFiles,
-    _resetDefaultBranchCache: () => {
-      _detectedDefaultBranch.clear();
-    },
   },
 };

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -198,10 +198,17 @@ function buildExecForCtx(worktreeDir) {
 function buildClassifierCtx(state, worktreeDir) {
   const failedJobs = Array.isArray(state._ciFailedJobs) ? state._ciFailedJobs : [];
   const firstFailed = failedJobs[0] || {};
+  // PR #542 cursor[bot]: signal3 reads state.failedTests. monitor.js writes
+  // extracted paths to state._ciFailedTests; mirror onto state.failedTests so
+  // the classifier's existing read works without a signature change, and
+  // surface on ctx for future ctx-consumers.
+  const failedTests = Array.isArray(state._ciFailedTests) ? state._ciFailedTests : [];
+  state.failedTests = failedTests;
   return {
     allJobs: Array.isArray(state._ciAllJobs) ? state._ciAllJobs : [],
     prDiffFiles: loadPrDiffFiles(worktreeDir),
     rawLogs: typeof state._ciFailedLogs === 'string' ? state._ciFailedLogs : '',
+    failedTests,
     exec: buildExecForCtx(worktreeDir),
     // Bug C (GH-508): monitor.js records IDs on _ciFailedJobs only — state.runId
     // is never populated. Read both runId and jobId from the failed-job entry so

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -112,8 +112,26 @@ function initState(ticketId, prNumber) {
     maxAttempts: 40,
     lastMonitorResult: null,
     failureCategory: null,
+    // Infra-retry telemetry (GH-508 Task 4). `count` tracks how many
+    // infra-retry attempts have been performed for the current PR; `attempts`
+    // records per-attempt diagnostics for the report step (Task 6).
+    infraRetry: { count: 0, attempts: [] },
     startTime: new Date().toISOString(),
   };
+}
+
+// Dispatch a step result and decide whether the orchestrator loop terminates.
+// Exported for testability (Task 4: action:'surface' is a terminal instruction
+// that stops the loop without marking state.status='complete' — see spec's
+// "API/Interface Changes" section for the surface contract).
+function dispatchStepResult(state, result) {
+  if (result && result.action === 'surface') {
+    return { terminate: true, instruction: result };
+  }
+  if (result && result.action === 'blocked') {
+    return { terminate: true, instruction: result };
+  }
+  return { terminate: false, instruction: result || null };
 }
 
 // ─── Core orchestrator loop ─────────────────────────────────────────────────
@@ -189,6 +207,14 @@ function getNextInstruction(ticketId, prNumber) {
     const result = runStep(state.currentStep, state, ctx);
 
     if (result) {
+      // action:'surface' is terminal (spec API/Interface Changes — GH-508).
+      // Stop the loop without marking status='complete' so the next /follow-up
+      // invocation can resume from a live re-evaluation rather than the cache.
+      if (result.action === 'surface') {
+        state.currentStep = 'report';
+        saveState(ticketId, state);
+        return result;
+      }
       saveState(ticketId, state);
       return result;
     }
@@ -297,4 +323,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { getNextInstruction };
+module.exports = { getNextInstruction, initState, dispatchStepResult };

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -14,6 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const cp = require('child_process');
 
 if (require.main === module) {
   process.on('uncaughtException', (err) => {
@@ -120,6 +121,59 @@ function initState(ticketId, prNumber) {
   };
 }
 
+// Compute the PR diff file list (origin/main...HEAD). Fails open with [].
+function loadPrDiffFiles(worktreeDir) {
+  try {
+    const out = cp.execSync('git diff --name-only origin/main...HEAD', {
+      cwd: worktreeDir,
+      encoding: 'utf8',
+      timeout: 10000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return out.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+// Build a bound exec function matching the shape signal2 / classifier expect:
+//   exec(cmd) -> { stdout, stderr, status }
+function buildExecForCtx(worktreeDir) {
+  return (cmd) => {
+    try {
+      const stdout = cp.execSync(cmd, {
+        cwd: worktreeDir,
+        encoding: 'utf8',
+        timeout: 30000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      return { stdout, stderr: '', status: 0 };
+    } catch (err) {
+      return {
+        stdout: (err && err.stdout) || '',
+        stderr: (err && err.stderr) || String((err && err.message) || ''),
+        status: err && typeof err.status === 'number' ? err.status : 1,
+      };
+    }
+  };
+}
+
+// Surface the ctx fields the infra-classifier and infra-retry step depend on.
+// monitor.js populates state._ciFailedJobs / _ciAllJobs / _ciFailedLogs /
+// _ciStatus during its poll; we surface those plus a bound exec and a cached
+// PR diff list so the classifier can run pure (no shell-outs).
+function buildClassifierCtx(state, worktreeDir) {
+  const failedJobs = Array.isArray(state._ciFailedJobs) ? state._ciFailedJobs : [];
+  return {
+    allJobs: Array.isArray(state._ciAllJobs) ? state._ciAllJobs : [],
+    prDiffFiles: loadPrDiffFiles(worktreeDir),
+    rawLogs: typeof state._ciFailedLogs === 'string' ? state._ciFailedLogs : '',
+    exec: buildExecForCtx(worktreeDir),
+    jobId: (failedJobs[0] && failedJobs[0].id) || null,
+    ciStatus: state._ciStatus || null,
+  };
+}
+
 // Dispatch a step result and decide whether the orchestrator loop terminates.
 // Exported for testability (Task 4: action:'surface' is a terminal instruction
 // that stops the loop without marking state.status='complete' — see spec's
@@ -143,11 +197,13 @@ function getNextInstruction(ticketId, prNumber) {
   const tasksDir = path.join(TASKS_BASE, ticketId);
   const candidateWorktree = path.join(WORKTREES_BASE, `${MAIN_WORKTREE_FOLDER}-${ticketId}`);
   const worktreeDir = fs.existsSync(candidateWorktree) ? candidateWorktree : process.cwd();
+
   const ctx = {
     tasksDir,
     worktreeDir,
     TASKS_BASE,
     workScriptsDir: path.join(__dirname, '..', 'work', 'scripts'),
+    ...buildClassifierCtx(state, worktreeDir),
   };
 
   // eslint-disable-next-line no-constant-condition
@@ -212,6 +268,15 @@ function getNextInstruction(ticketId, prNumber) {
       // invocation can resume from a live re-evaluation rather than the cache.
       if (result.action === 'surface') {
         state.currentStep = 'report';
+        // Persist the surface reason as a failureCategory so the next
+        // /follow-up cycle's report step recognises the workflow is still
+        // stuck and does NOT mark status=complete. The reason may live on
+        // the top-level result (legacy shape) or under result.payload.reason
+        // (newer shape, mirrors auto-advance hook).
+        const surfaceReason = (result.payload && result.payload.reason) || result.reason || null;
+        if (surfaceReason) {
+          state.failureCategory = surfaceReason;
+        }
         saveState(ticketId, state);
         return result;
       }

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -121,10 +121,43 @@ function initState(ticketId, prNumber) {
   };
 }
 
-// Compute the PR diff file list (origin/main...HEAD). Fails open with [].
+// Bug F (GH-508): hardcoding `origin/main` broke repos with non-main default
+// branches (signal3 was scoring against an empty diff). Detect the actual
+// default branch via `gh repo view`, fall back to `git remote show origin`,
+// then to 'main'. Cached per-process — the default branch doesn't change
+// during a single follow-up run.
+let _detectedDefaultBranch = null;
+function detectDefaultBranch(worktreeDir) {
+  if (_detectedDefaultBranch !== null) return _detectedDefaultBranch;
+  const runQuiet = (cmd) => {
+    try {
+      return cp
+        .execSync(cmd, {
+          cwd: worktreeDir,
+          encoding: 'utf8',
+          timeout: 8000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        })
+        .trim();
+    } catch {
+      return '';
+    }
+  };
+  let detected = runQuiet('gh repo view --json defaultBranchRef --jq .defaultBranchRef.name');
+  if (!detected) {
+    const remote = runQuiet('git remote show origin');
+    const m = remote.match(/HEAD branch:\s*(\S+)/);
+    if (m && m[1] && m[1] !== '(unknown)') detected = m[1];
+  }
+  _detectedDefaultBranch = detected || 'main';
+  return _detectedDefaultBranch;
+}
+
+// Compute the PR diff file list (origin/<default>...HEAD). Fails open with [].
 function loadPrDiffFiles(worktreeDir) {
+  const branch = detectDefaultBranch(worktreeDir);
   try {
-    const out = cp.execSync('git diff --name-only origin/main...HEAD', {
+    const out = cp.execSync(`git diff --name-only origin/${branch}...HEAD`, {
       cwd: worktreeDir,
       encoding: 'utf8',
       timeout: 10000,
@@ -164,12 +197,17 @@ function buildExecForCtx(worktreeDir) {
 // PR diff list so the classifier can run pure (no shell-outs).
 function buildClassifierCtx(state, worktreeDir) {
   const failedJobs = Array.isArray(state._ciFailedJobs) ? state._ciFailedJobs : [];
+  const firstFailed = failedJobs[0] || {};
   return {
     allJobs: Array.isArray(state._ciAllJobs) ? state._ciAllJobs : [],
     prDiffFiles: loadPrDiffFiles(worktreeDir),
     rawLogs: typeof state._ciFailedLogs === 'string' ? state._ciFailedLogs : '',
     exec: buildExecForCtx(worktreeDir),
-    jobId: (failedJobs[0] && failedJobs[0].id) || null,
+    // Bug C (GH-508): monitor.js records IDs on _ciFailedJobs only — state.runId
+    // is never populated. Read both runId and jobId from the failed-job entry so
+    // signal2's NUMERIC_ID validation receives real IDs instead of undefined.
+    runId: firstFailed.runId || null,
+    jobId: firstFailed.jobId || null,
     ciStatus: state._ciStatus || null,
   };
 }
@@ -388,4 +426,16 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { getNextInstruction, initState, dispatchStepResult };
+module.exports = {
+  getNextInstruction,
+  initState,
+  dispatchStepResult,
+  // test-only escape hatch — exposes pure helpers for unit testing.
+  __test__: {
+    detectDefaultBranch,
+    loadPrDiffFiles,
+    _resetDefaultBranchCache: () => {
+      _detectedDefaultBranch = null;
+    },
+  },
+};

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -126,9 +126,10 @@ function initState(ticketId, prNumber) {
 // default branch via `gh repo view`, fall back to `git remote show origin`,
 // then to 'main'. Cached per-process — the default branch doesn't change
 // during a single follow-up run.
-let _detectedDefaultBranch = null;
+const _detectedDefaultBranch = new Map();
 function detectDefaultBranch(worktreeDir) {
-  if (_detectedDefaultBranch !== null) return _detectedDefaultBranch;
+  const key = worktreeDir || process.cwd();
+  if (_detectedDefaultBranch.has(key)) return _detectedDefaultBranch.get(key);
   const runQuiet = (cmd) => {
     try {
       return cp
@@ -149,8 +150,9 @@ function detectDefaultBranch(worktreeDir) {
     const m = remote.match(/HEAD branch:\s*(\S+)/);
     if (m && m[1] && m[1] !== '(unknown)') detected = m[1];
   }
-  _detectedDefaultBranch = detected || 'main';
-  return _detectedDefaultBranch;
+  const resolved = detected || 'main';
+  _detectedDefaultBranch.set(key, resolved);
+  return resolved;
 }
 
 // Compute the PR diff file list (origin/<default>...HEAD). Fails open with [].
@@ -447,7 +449,7 @@ module.exports = {
     detectDefaultBranch,
     loadPrDiffFiles,
     _resetDefaultBranchCache: () => {
-      _detectedDefaultBranch = null;
+      _detectedDefaultBranch.clear();
     },
   },
 };

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -16,6 +16,8 @@ const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
 
+const { buildChildEnv } = require('../work/scripts/gh-exec');
+
 if (require.main === module) {
   process.on('uncaughtException', (err) => {
     console.error(
@@ -181,6 +183,7 @@ function buildExecForCtx(worktreeDir) {
         encoding: 'utf8',
         timeout: 30000,
         stdio: ['pipe', 'pipe', 'pipe'],
+        env: buildChildEnv(),
       });
       return { stdout, stderr: '', status: 0 };
     } catch (err) {

--- a/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
+++ b/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
@@ -46,7 +46,11 @@ function main() {
   const markerAge = Date.now() - new Date(marker.startedAt).getTime();
   if (markerAge > 12 * 60 * 60 * 1000) process.exit(0);
 
-  const nextPath = path.join(__dirname, '..', 'follow-up-next.js');
+  // Test seam: an absolute path override lets the surface/blocked test stub
+  // follow-up-next.js without staging the entire plugin tree. Production code
+  // never sets FOLLOW_UP_NEXT_PATH; default resolves siblings as before.
+  const nextPath =
+    process.env.FOLLOW_UP_NEXT_PATH || path.join(__dirname, '..', 'follow-up-next.js');
   let result;
   try {
     result = execFileSync(process.execPath, [nextPath, marker.ticket], {
@@ -90,6 +94,15 @@ function main() {
     console.log('════════════════════════════\n');
   } else if (instruction.action === 'blocked') {
     console.log('\n═══ FOLLOW-UP2: BLOCKED ═══');
+    console.log(JSON.stringify(instruction, null, 2));
+    console.log('═══════════════════════════\n');
+  } else if (instruction.action === 'surface') {
+    // R13: Treat 'surface' as terminal (same as 'blocked'). The orchestrator
+    // emits this when it needs manual user intervention — e.g. infra-stuck
+    // after 3 retries. We stop the auto-advance loop and surface the reason.
+    const reason = (instruction.payload && instruction.payload.reason) || 'unknown';
+    console.log('\n═══ FOLLOW-UP2: SURFACE ═══');
+    console.log(`reason: ${reason}`);
     console.log(JSON.stringify(instruction, null, 2));
     console.log('═══════════════════════════\n');
   }

--- a/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
+++ b/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
@@ -110,4 +110,4 @@ function main() {
   process.exit(0);
 }
 
-main();
+if (require.main === module && !process.env.NODE_TEST_CONTEXT) main();

--- a/plugins/work/scripts/workflows/follow-up/lib/classifier-ctx.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/classifier-ctx.js
@@ -1,0 +1,70 @@
+/**
+ * Classifier-context builder. Owns the contract the infra-classifier
+ * consumes: `ctx.allJobs`, `ctx.prDiffFiles`, `ctx.rawLogs`, `ctx.failedTests`,
+ * `ctx.exec`, `ctx.runId`, `ctx.jobId`, `ctx.ciStatus`.
+ *
+ * Extracted from `follow-up-next.js` so the helpers can be unit-tested in
+ * isolation without booting the orchestrator loop.
+ */
+
+'use strict';
+
+const cp = require('node:child_process');
+
+const { buildChildEnv } = require('../../work/scripts/gh-exec');
+const { loadPrDiffFiles } = require('./repo-meta');
+
+// Build a bound exec function matching the shape signal2 / classifier expect:
+//   exec(cmd) -> { stdout, stderr, status }
+function buildExecForCtx(worktreeDir) {
+  return (cmd) => {
+    try {
+      const stdout = cp.execSync(cmd, {
+        cwd: worktreeDir,
+        encoding: 'utf8',
+        timeout: 30000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: buildChildEnv(),
+      });
+      return { stdout, stderr: '', status: 0 };
+    } catch (err) {
+      return {
+        stdout: (err && err.stdout) || '',
+        stderr: (err && err.stderr) || String((err && err.message) || ''),
+        status: err && typeof err.status === 'number' ? err.status : 1,
+      };
+    }
+  };
+}
+
+// Surface the ctx fields the infra-classifier and infra-retry step depend on.
+// monitor.js populates state._ciFailedJobs / _ciAllJobs / _ciFailedLogs /
+// _ciStatus during its poll; we surface those plus a bound exec and a cached
+// PR diff list so the classifier can run pure (no shell-outs).
+function buildClassifierCtx(state, worktreeDir) {
+  const failedJobs = Array.isArray(state._ciFailedJobs) ? state._ciFailedJobs : [];
+  const firstFailed = failedJobs[0] || {};
+  // PR #542 cursor[bot]: signal3 reads state.failedTests. monitor.js writes
+  // extracted paths to state._ciFailedTests; mirror onto state.failedTests so
+  // the classifier's existing read works without a signature change, and
+  // surface on ctx for future ctx-consumers. NOTE: this is a deliberate state
+  // mutation for backward compatibility with the classifier's existing
+  // signature — open design question, not in scope for cleanup here.
+  const failedTests = Array.isArray(state._ciFailedTests) ? state._ciFailedTests : [];
+  state.failedTests = failedTests;
+  return {
+    allJobs: Array.isArray(state._ciAllJobs) ? state._ciAllJobs : [],
+    prDiffFiles: loadPrDiffFiles(worktreeDir),
+    rawLogs: typeof state._ciFailedLogs === 'string' ? state._ciFailedLogs : '',
+    failedTests,
+    exec: buildExecForCtx(worktreeDir),
+    // Bug C (GH-508): monitor.js records IDs on _ciFailedJobs only — state.runId
+    // is never populated. Read both runId and jobId from the failed-job entry so
+    // signal2's NUMERIC_ID validation receives real IDs instead of undefined.
+    runId: firstFailed.runId || null,
+    jobId: firstFailed.jobId || null,
+    ciStatus: state._ciStatus || null,
+  };
+}
+
+module.exports = { buildExecForCtx, buildClassifierCtx };

--- a/plugins/work/scripts/workflows/follow-up/lib/gh-actions-status.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/gh-actions-status.js
@@ -10,46 +10,43 @@
 
 'use strict';
 
-const https = require('node:https');
+const { execFileSync } = require('node:child_process');
 
 const STATUS_URL = 'https://www.githubstatus.com/api/v2/components.json';
 
 /**
- * Default fetcher uses `https.get` and resolves the parsed JSON body.
- * @returns {Promise<object>}
+ * Default fetcher uses `curl` via execFileSync so the step (which runs
+ * synchronously inside step-registry.runStep) can stay sync. Returns parsed
+ * JSON or throws.
+ *
+ * @returns {object}
  */
 function defaultFetcher() {
-  return new Promise((resolve, reject) => {
-    const req = https.get(STATUS_URL, (res) => {
-      let buf = '';
-      res.setEncoding('utf8');
-      res.on('data', (chunk) => {
-        buf += chunk;
-      });
-      res.on('end', () => {
-        try {
-          resolve(JSON.parse(buf));
-        } catch (err) {
-          reject(err);
-        }
-      });
-    });
-    req.on('error', reject);
-    req.setTimeout(5000, () => req.destroy(new Error('githubstatus timeout')));
-  });
+  const stdout = execFileSync(
+    'curl',
+    ['-fsS', '--max-time', '5', STATUS_URL],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 6000 }
+  );
+  return JSON.parse(stdout);
 }
 
 /**
+ * Synchronously query githubstatus.com for the Actions component health.
+ * Any error (network, parse, missing fetcher) is swallowed and reported as
+ * `{ degraded: false }` so the caller can fall through to the normal retry
+ * path rather than blocking.
+ *
  * @param {{ fetcher?: Function }} [opts]
- * @returns {{ degraded: boolean } | Promise<{ degraded: boolean }>}
+ * @returns {{ degraded: boolean }}
  */
 function checkActionsStatus(opts) {
   const fetcher = (opts && opts.fetcher) || defaultFetcher;
-  const payload = fetcher();
-  if (payload && typeof payload.then === 'function') {
-    return payload.then(parseDegraded).catch(() => ({ degraded: false }));
+  try {
+    const payload = fetcher();
+    return parseDegraded(payload);
+  } catch (_err) {
+    return { degraded: false };
   }
-  return parseDegraded(payload);
 }
 
 function parseDegraded(payload) {

--- a/plugins/work/scripts/workflows/follow-up/lib/gh-actions-status.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/gh-actions-status.js
@@ -1,0 +1,66 @@
+/**
+ * GitHub Actions status cross-check (R16).
+ *
+ * Queries https://www.githubstatus.com/api/v2/components.json and reports
+ * whether the "Actions" component is currently degraded.
+ *
+ * Exposes `checkActionsStatus({ fetcher })` for testability — tests inject a
+ * fake `fetcher` returning the parsed JSON.
+ */
+
+'use strict';
+
+const https = require('node:https');
+
+const STATUS_URL = 'https://www.githubstatus.com/api/v2/components.json';
+
+/**
+ * Default fetcher uses `https.get` and resolves the parsed JSON body.
+ * @returns {Promise<object>}
+ */
+function defaultFetcher() {
+  return new Promise((resolve, reject) => {
+    const req = https.get(STATUS_URL, (res) => {
+      let buf = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => {
+        buf += chunk;
+      });
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(buf));
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => req.destroy(new Error('githubstatus timeout')));
+  });
+}
+
+/**
+ * @param {{ fetcher?: Function }} [opts]
+ * @returns {{ degraded: boolean } | Promise<{ degraded: boolean }>}
+ */
+function checkActionsStatus(opts) {
+  const fetcher = (opts && opts.fetcher) || defaultFetcher;
+  const payload = fetcher();
+  if (payload && typeof payload.then === 'function') {
+    return payload.then(parseDegraded).catch(() => ({ degraded: false }));
+  }
+  return parseDegraded(payload);
+}
+
+function parseDegraded(payload) {
+  if (!payload || !Array.isArray(payload.components)) return { degraded: false };
+  const actions = payload.components.find(
+    (c) => c && typeof c.name === 'string' && /actions/i.test(c.name)
+  );
+  if (!actions) return { degraded: false };
+  // Anything other than "operational" counts as degraded.
+  const degraded = actions.status && actions.status !== 'operational';
+  return { degraded: Boolean(degraded) };
+}
+
+module.exports = { checkActionsStatus };

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -333,11 +333,38 @@ function evaluateSignal2(s, c) {
   if (typeof c.exec !== 'function') {
     return { fired: false, evidence: { reason: 'no exec provided' } };
   }
-  const runId = c.runId || s.runId || null;
-  if (!runId || !c.jobId) {
+  // Bug 542-19: signal2 must consider every failed job, not just the first.
+  // If ANY failed job has real assertion output, refuse to fire — otherwise
+  // we'd misclassify a real code failure as an infra flake whenever the FIRST
+  // failed job happens to have an empty log.
+  const failedJobs = Array.isArray(s._ciFailedJobs) ? s._ciFailedJobs : [];
+  const fallbackRunId = c.runId || s.runId;
+  const fallbackJobId = c.jobId;
+  const candidates =
+    failedJobs.length > 0
+      ? failedJobs.map((j) => ({
+          runId: j.runId || fallbackRunId,
+          jobId: j.jobId || fallbackJobId,
+        }))
+      : [{ runId: fallbackRunId, jobId: fallbackJobId }];
+  const evaluable = candidates.filter((j) => j.runId && j.jobId);
+  if (evaluable.length === 0) {
     return { fired: false, evidence: { reason: 'no runId/jobId' } };
   }
-  return signal2_emptyFailedLog(runId, c.jobId, c.exec);
+  let lastFired = null;
+  for (const j of evaluable) {
+    const result = signal2_emptyFailedLog(j.runId, j.jobId, c.exec);
+    // If ANY failed job has real error markers (fired=false), signal2 must
+    // NOT fire — there's a real code failure somewhere.
+    if (!result.fired) {
+      return {
+        fired: false,
+        evidence: { ...result.evidence, reason: 'real assertion output present' },
+      };
+    }
+    lastFired = result;
+  }
+  return lastFired;
 }
 
 function isInfraSuspected(firedSignals) {

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -1,0 +1,298 @@
+/**
+ * Infra-classifier: identifies CI failures that look like infrastructure
+ * flakes rather than genuine code/test failures. Used by the `infra-retry`
+ * step to decide whether a 60s-wait + `gh run rerun --failed` is warranted.
+ *
+ * Per the spec, classification fires `infra-suspected` only when ≥2 signals
+ * fire per the rule: (s1 && s2) || (s3 && s4) || (s2 && s4). This ≥2-signal
+ * floor (R7) is documented at the call site by iterating
+ * `INFRA_SUSPECTED_PAIRS` rather than inlining the boolean.
+ *
+ * Each collector is pure: it accepts pre-fetched payloads (or an injectable
+ * `exec` for Signal 2) so unit tests can drive every branch without spawning
+ * `gh`. The classifier itself never shells out — the orchestrator pre-fetches
+ * payloads and passes them through `ctx`.
+ *
+ * See also: synapsys memory [[never-rerun-ci]] — local evidence first, no
+ * blind `gh run rerun`. This module's whole purpose is to GATE retries on
+ * evidence (the 4 signals) rather than retry blindly.
+ */
+
+'use strict';
+
+const { filterLogs } = require('./log-utils');
+
+/** Pairs of signals whose joint firing triggers `infra-suspected`. */
+const INFRA_SUSPECTED_PAIRS = [
+  ['signal1', 'signal2'],
+  ['signal3', 'signal4'],
+  ['signal2', 'signal4'],
+];
+
+const NUMERIC_ID_RE = /^\d+$/;
+
+/**
+ * Strip matrix shard suffixes from a job name so siblings in the same
+ * matrix family collapse to a single stem (e.g. `e2e [shard-3]` -> `e2e`).
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function stripShardSuffix(name) {
+  if (typeof name !== 'string') return '';
+  return name
+    .replace(/\s*\[shard-\d+\]\s*$/i, '')
+    .replace(/\s*\(\d+\/\d+\)\s*$/, '')
+    .trim();
+}
+
+/**
+ * Compute the runtime (in milliseconds) of a job from its ISO timestamps.
+ * Returns 0 if either timestamp is missing or unparseable.
+ *
+ * @param {{ startedAt?: string, completedAt?: string }} job
+ * @returns {number}
+ */
+function jobRuntimeMs(job) {
+  if (!job || !job.startedAt || !job.completedAt) return 0;
+  const s = Date.parse(job.startedAt);
+  const e = Date.parse(job.completedAt);
+  if (Number.isNaN(s) || Number.isNaN(e)) return 0;
+  return Math.max(0, e - s);
+}
+
+/**
+ * Signal 1 — shard asymmetry. Fires when a matrix family has ≥3 shards and
+ * a failing shard's runtime is >=3x the median of its sibling shards.
+ *
+ * @param {Array<object>} failedJobs - Jobs with conclusion === 'failure'.
+ * @param {Array<object>} allJobs - All jobs from the run.
+ * @returns {{ fired: boolean, evidence: object }}
+ */
+function signal1_shardAsymmetry(failedJobs, allJobs) {
+  const safeFailed = Array.isArray(failedJobs) ? failedJobs : [];
+  const safeAll = Array.isArray(allJobs) ? allJobs : [];
+
+  // Group all jobs by their matrix-family stem.
+  const families = new Map();
+  for (const job of safeAll) {
+    const stem = stripShardSuffix(job?.name || '');
+    if (!stem) continue;
+    if (!families.has(stem)) families.set(stem, []);
+    families.get(stem).push(job);
+  }
+
+  for (const failed of safeFailed) {
+    const stem = stripShardSuffix(failed?.name || '');
+    if (!stem) continue;
+    const family = families.get(stem) || [];
+    if (family.length < 3) {
+      return {
+        fired: false,
+        evidence: {
+          reason: 'matrix family size <3 — N<3 shards cannot establish asymmetry',
+          family: stem,
+          shardCount: family.length,
+        },
+      };
+    }
+    const siblings = family.filter((j) => j !== failed);
+    const siblingRuntimes = siblings
+      .map(jobRuntimeMs)
+      .filter((ms) => ms > 0)
+      .sort((a, b) => a - b);
+    if (siblingRuntimes.length === 0) continue;
+    const mid = Math.floor(siblingRuntimes.length / 2);
+    const medianMs =
+      siblingRuntimes.length % 2 === 0
+        ? (siblingRuntimes[mid - 1] + siblingRuntimes[mid]) / 2
+        : siblingRuntimes[mid];
+    const failedMs = jobRuntimeMs(failed);
+    if (medianMs > 0 && failedMs >= medianMs * 3) {
+      return {
+        fired: true,
+        evidence: {
+          family: stem,
+          failedJob: failed.name,
+          failedRuntimeMs: failedMs,
+          siblingMedianMs: medianMs,
+          ratio: failedMs / medianMs,
+        },
+      };
+    }
+  }
+  return { fired: false, evidence: { reason: 'no shard with >=3x median runtime' } };
+}
+
+/**
+ * Signal 2 — empty failed log. Fires when `gh run view --log-failed` returns
+ * empty stdout despite the job conclusion being `failure`. Validates both
+ * IDs against `/^\d+$/` BEFORE invoking `exec` (R17, security: no shell
+ * injection via IDs).
+ *
+ * @param {string} runId
+ * @param {string} jobId
+ * @param {(cmd: string) => { stdout: string, stderr?: string, status?: number }} exec
+ * @returns {{ fired: boolean, evidence: object }}
+ */
+function signal2_emptyFailedLog(runId, jobId, exec) {
+  if (!NUMERIC_ID_RE.test(String(runId || ''))) {
+    throw new TypeError(`signal2_emptyFailedLog: runId must match /^\\d+$/, got: ${runId}`);
+  }
+  if (!NUMERIC_ID_RE.test(String(jobId || ''))) {
+    throw new TypeError(`signal2_emptyFailedLog: jobId must match /^\\d+$/, got: ${jobId}`);
+  }
+  if (typeof exec !== 'function') {
+    throw new TypeError('signal2_emptyFailedLog: exec must be a function');
+  }
+  const result = exec(`gh run view ${runId} --job ${jobId} --log-failed`);
+  const stdout = (result && result.stdout) || '';
+  const stripped = filterLogs(stdout).trim();
+  // Treat as "empty" when no error/assertion lines survive the filter AND
+  // the raw stdout has no error markers either.
+  const hasErrorMarker = /error|fail|assert|expect|✗|✕/i.test(stdout);
+  if (!hasErrorMarker && stripped.length === 0) {
+    return {
+      fired: true,
+      evidence: { runId, jobId, rawLength: stdout.length, reason: 'empty failed log' },
+    };
+  }
+  return {
+    fired: false,
+    evidence: { runId, jobId, rawLength: stdout.length },
+  };
+}
+
+/**
+ * Signal 3 — unrelated failures. Fires when none of the failing test paths
+ * share a path prefix with any file in the PR diff (the failures are not
+ * in code the PR touched).
+ *
+ * @param {string[]} failedTests - Paths to failing test files.
+ * @param {string[]} prDiffFiles - Files changed by the PR.
+ * @returns {{ fired: boolean, evidence: object }}
+ */
+function signal3_unrelatedFailures(failedTests, prDiffFiles) {
+  const tests = Array.isArray(failedTests) ? failedTests : [];
+  const diff = Array.isArray(prDiffFiles) ? prDiffFiles : [];
+  if (tests.length === 0) {
+    return { fired: false, evidence: { reason: 'no failing tests provided' } };
+  }
+  const diffStems = diff.map((f) => f.replace(/\.[a-z]+$/i, ''));
+  const overlapping = [];
+  for (const t of tests) {
+    const testStem = t.replace(/\.(test|spec)\.[jt]sx?$/i, '').replace(/\.[a-z]+$/i, '');
+    for (const ds of diffStems) {
+      if (
+        testStem === ds ||
+        testStem.startsWith(ds + '/') ||
+        ds.startsWith(testStem + '/') ||
+        testStem.includes(ds) ||
+        ds.includes(testStem)
+      ) {
+        overlapping.push({ test: t, diffFile: ds });
+        break;
+      }
+    }
+  }
+  if (overlapping.length === 0) {
+    return {
+      fired: true,
+      evidence: {
+        failedTestCount: tests.length,
+        prDiffCount: diff.length,
+        reason: 'no overlap between failing tests and PR diff paths',
+      },
+    };
+  }
+  return {
+    fired: false,
+    evidence: { overlapping, reason: 'failing tests overlap with PR diff' },
+  };
+}
+
+/**
+ * Signal 4 — setup / artifact failures. Fires when the raw logs contain
+ * known setup-artifact failure patterns (cache miss + fallback install
+ * failed, download-artifact 404, etc.).
+ *
+ * @param {string} rawLogs
+ * @returns {{ fired: boolean, evidence: object }}
+ */
+function signal4_setupArtifacts(rawLogs) {
+  const text = typeof rawLogs === 'string' ? rawLogs : '';
+  const hits = [];
+  if (/cache:\s*MISS/i.test(text)) hits.push('cache-miss');
+  if (/fallback install FAILED/i.test(text)) hits.push('fallback-install-failed');
+  if (/download-artifact.*(404|not found)/i.test(text)) hits.push('artifact-404');
+  if (/setup-node.*EAI_AGAIN|ETIMEDOUT|ECONNRESET/i.test(text)) hits.push('setup-node-network');
+  if (/actions\/cache.*Failed to restore/i.test(text)) hits.push('cache-restore-failed');
+
+  // Require ≥2 hits OR the canonical pair (cache-miss + fallback-install-failed)
+  // to avoid firing on isolated transient mentions.
+  const hasCanonicalPair =
+    hits.includes('cache-miss') && hits.includes('fallback-install-failed');
+  if (hasCanonicalPair || hits.length >= 2) {
+    return { fired: true, evidence: { patterns: hits } };
+  }
+  return { fired: false, evidence: { patterns: hits } };
+}
+
+/**
+ * Aggregate the four signal collectors and decide between `infra-suspected`
+ * and `code-failure`. The classifier itself never shells out — collectors
+ * receive payloads / `exec` from `ctx`.
+ *
+ * @param {object} state - Workflow state. Reads `_ciFailedJobs`, `failedTests`,
+ *   `runId`.
+ * @param {object} ctx - Pre-fetched context: `allJobs`, `prDiffFiles`,
+ *   `rawLogs`, `exec`, `jobId`.
+ * @returns {{ classification: 'infra-suspected'|'code-failure', signals: string[], evidence: object }}
+ */
+function classify(state, ctx) {
+  const s = state || {};
+  const c = ctx || {};
+  const results = {
+    signal1: signal1_shardAsymmetry(s._ciFailedJobs || [], c.allJobs || []),
+    signal2: c.exec
+      ? signal2_emptyFailedLog(s.runId, c.jobId, c.exec)
+      : { fired: false, evidence: { reason: 'no exec provided' } },
+    signal3: signal3_unrelatedFailures(s.failedTests || [], c.prDiffFiles || []),
+    signal4: signal4_setupArtifacts(c.rawLogs || ''),
+  };
+  const firedSignals = Object.entries(results)
+    .filter(([, r]) => r.fired)
+    .map(([name]) => name);
+
+  // ≥2-signal floor (R7): iterate the documented pair list rather than
+  // inlining the boolean — keeps the spec rule reviewable at the call site.
+  let infraSuspected = false;
+  for (const [a, b] of INFRA_SUSPECTED_PAIRS) {
+    if (firedSignals.includes(a) && firedSignals.includes(b)) {
+      infraSuspected = true;
+      break;
+    }
+  }
+  return {
+    classification: infraSuspected ? 'infra-suspected' : 'code-failure',
+    signals: firedSignals,
+    evidence: {
+      signal1: results.signal1.evidence,
+      signal2: results.signal2.evidence,
+      signal3: results.signal3.evidence,
+      signal4: results.signal4.evidence,
+    },
+  };
+}
+
+module.exports = {
+  classify,
+  __test__: {
+    signal1_shardAsymmetry,
+    signal2_emptyFailedLog,
+    signal3_unrelatedFailures,
+    signal4_setupArtifacts,
+    stripShardSuffix,
+    INFRA_SUSPECTED_PAIRS,
+  },
+};

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -115,23 +115,19 @@ function evaluateFamilyAsymmetry(failed, families) {
   return {};
 }
 
+function allJobIdMatches(j, jobId) {
+  if (!j) return false;
+  const s = String(jobId);
+  return String(j.databaseId) === s || String(j.id) === s;
+}
+
 function enrichFailedFromAll(failed, safeAll) {
-  // Bug 542-15 / 542-23: monitor stores only name/runId/jobId on
-  // _ciFailedJobs. jobRuntimeMs needs startedAt/completedAt — look them up on
-  // the matching entry from the richer _ciAllJobs collection.
-  //
-  // _ciAllJobs comes verbatim from `gh run view --json jobs`, which uses
-  // `databaseId` (or `id`) — NOT `jobId`. The id-based lookup must compare
-  // failed.jobId to allJob.databaseId / allJob.id, with name as fallback.
+  // Bug 542-15 / 542-23: enrich _ciFailedJobs with startedAt/completedAt
+  // from _ciAllJobs. allJobs uses `databaseId`/`id` (gh run view shape),
+  // not `jobId` — match by either, fall back to name.
   if (!failed) return failed;
   if (failed.startedAt && failed.completedAt) return failed;
-  const byId = failed.jobId
-    ? safeAll.find(
-        (j) =>
-          j &&
-          (String(j.databaseId) === String(failed.jobId) || String(j.id) === String(failed.jobId))
-      )
-    : null;
+  const byId = failed.jobId ? safeAll.find((j) => allJobIdMatches(j, failed.jobId)) : null;
   const matched = byId || safeAll.find((j) => j && j.name === failed.name);
   if (!matched) return failed;
   return Object.assign({}, failed, {

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -278,10 +278,7 @@ function signal4_setupArtifacts(rawLogs) {
  *   `rawLogs`, `exec`, `jobId`.
  * @returns {{ classification: 'infra-suspected'|'code-failure', signals: string[], evidence: object }}
  */
-function classify(state, ctx) {
-  const s = state || {};
-  const c = ctx || {};
-  const failedJobs = Array.isArray(s._ciFailedJobs) ? s._ciFailedJobs : [];
+function collectSignals(s, c, failedJobs) {
   const signal4Raw = signal4_setupArtifacts(c.rawLogs || '');
   // Propagate jobCount (R16): when Signal 4 fires we attach the number of
   // failing jobs so the step can decide whether to cross-check githubstatus.
@@ -292,7 +289,7 @@ function classify(state, ctx) {
     fired: signal4Raw.fired,
     evidence: { ...signal4Raw.evidence, jobCount: failedJobs.length },
   };
-  const results = {
+  return {
     signal1: signal1_shardAsymmetry(failedJobs, c.allJobs || []),
     signal2: c.exec
       ? signal2_emptyFailedLog(s.runId, c.jobId, c.exec)
@@ -300,19 +297,25 @@ function classify(state, ctx) {
     signal3: signal3_unrelatedFailures(s.failedTests || [], c.prDiffFiles || []),
     signal4,
   };
+}
+
+function isInfraSuspected(firedSignals) {
+  // ≥2-signal floor (R7): iterate the documented pair list rather than
+  // inlining the boolean — keeps the spec rule reviewable at the call site.
+  return INFRA_SUSPECTED_PAIRS.some(
+    ([a, b]) => firedSignals.includes(a) && firedSignals.includes(b)
+  );
+}
+
+function classify(state, ctx) {
+  const s = state || {};
+  const c = ctx || {};
+  const failedJobs = Array.isArray(s._ciFailedJobs) ? s._ciFailedJobs : [];
+  const results = collectSignals(s, c, failedJobs);
   const firedSignals = Object.entries(results)
     .filter(([, r]) => r.fired)
     .map(([name]) => name);
-
-  // ≥2-signal floor (R7): iterate the documented pair list rather than
-  // inlining the boolean — keeps the spec rule reviewable at the call site.
-  let infraSuspected = false;
-  for (const [a, b] of INFRA_SUSPECTED_PAIRS) {
-    if (firedSignals.includes(a) && firedSignals.includes(b)) {
-      infraSuspected = true;
-      break;
-    }
-  }
+  const infraSuspected = isInfraSuspected(firedSignals);
   return {
     classification: infraSuspected ? 'infra-suspected' : 'code-failure',
     signals: firedSignals,

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -168,10 +168,14 @@ function signal2_emptyFailedLog(runId, jobId, exec) {
   }
   const result = exec(`gh run view ${runId} --job ${jobId} --log-failed`);
   const stdout = (result && result.stdout) || '';
+  const stderr = (result && result.stderr) || '';
   const stripped = filterLogs(stdout).trim();
   // Treat as "empty" when no error/assertion lines survive the filter AND
-  // the raw stdout has no error markers either.
-  const hasErrorMarker = /error|fail|assert|expect|✗|✕/i.test(stdout);
+  // neither raw stream has error markers. stderr is checked too: a failed
+  // `gh run view` typically writes its diagnostic to stderr with empty stdout,
+  // which must NOT be misclassified as a flake's empty failed log.
+  const markerRe = /error|fail|assert|expect|✗|✕/i;
+  const hasErrorMarker = markerRe.test(stdout) || markerRe.test(stderr);
   if (!hasErrorMarker && stripped.length === 0) {
     return {
       fired: true,
@@ -180,7 +184,7 @@ function signal2_emptyFailedLog(runId, jobId, exec) {
   }
   return {
     fired: false,
-    evidence: { runId, jobId, rawLength: stdout.length },
+    evidence: { runId, jobId, rawLength: stdout.length, stderrLength: stderr.length },
   };
 }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -1,22 +1,7 @@
-/**
- * Infra-classifier: identifies CI failures that look like infrastructure
- * flakes rather than genuine code/test failures. Used by the `infra-retry`
- * step to decide whether a 60s-wait + `gh run rerun --failed` is warranted.
- *
- * Per the spec, classification fires `infra-suspected` only when ≥2 signals
- * fire per the rule: (s1 && s2) || (s3 && s4) || (s2 && s4). This ≥2-signal
- * floor (R7) is documented at the call site by iterating
- * `INFRA_SUSPECTED_PAIRS` rather than inlining the boolean.
- *
- * Each collector is pure: it accepts pre-fetched payloads (or an injectable
- * `exec` for Signal 2) so unit tests can drive every branch without spawning
- * `gh`. The classifier itself never shells out — the orchestrator pre-fetches
- * payloads and passes them through `ctx`.
- *
- * See also: synapsys memory [[never-rerun-ci]] — local evidence first, no
- * blind `gh run rerun`. This module's whole purpose is to GATE retries on
- * evidence (the 4 signals) rather than retry blindly.
- */
+// Infra-classifier: identifies CI failures that look like infrastructure
+// flakes. Fires `infra-suspected` only when ≥2 signals fire per R7
+// (INFRA_SUSPECTED_PAIRS). Collectors are pure; classifier shells out via
+// injected ctx.exec. See [[never-rerun-ci]] — gate retries on evidence.
 
 'use strict';
 

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -293,15 +293,12 @@ function signal4_setupArtifacts(rawLogs) {
  */
 function collectSignals(s, c, failedJobs) {
   const signal4Raw = signal4_setupArtifacts(c.rawLogs || '');
-  // Propagate jobCount (R16): when Signal 4 fires we attach the number of
-  // failing jobs so the step can decide whether to cross-check githubstatus.
-  // We approximate "jobs with setup evidence" by the failing-jobs count —
-  // signal4 fires off raw aggregated logs, not per-job, so this is the best
-  // available proxy without re-fetching per-job logs.
-  const signal4 = {
-    fired: signal4Raw.fired,
-    evidence: { ...signal4Raw.evidence, jobCount: failedJobs.length },
-  };
+  // R16: when signal4 fires, attach a conservative upper bound on
+  // setup-evidence-bearing jobs (we lack per-job logs). jobCount =
+  // min(failedJobs, distinct patterns) — fail-open cross-check.
+  const patternHits = ((signal4Raw.evidence && signal4Raw.evidence.patterns) || []).length;
+  const jobCount = signal4Raw.fired ? Math.min(failedJobs.length, Math.max(patternHits, 1)) : 0;
+  const signal4 = { fired: signal4Raw.fired, evidence: { ...signal4Raw.evidence, jobCount } };
   return {
     signal1: signal1_shardAsymmetry(failedJobs, c.allJobs || []),
     signal2: evaluateSignal2(s, c),

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -252,13 +252,24 @@ function signal4_setupArtifacts(rawLogs) {
 function classify(state, ctx) {
   const s = state || {};
   const c = ctx || {};
+  const failedJobs = Array.isArray(s._ciFailedJobs) ? s._ciFailedJobs : [];
+  const signal4Raw = signal4_setupArtifacts(c.rawLogs || '');
+  // Propagate jobCount (R16): when Signal 4 fires we attach the number of
+  // failing jobs so the step can decide whether to cross-check githubstatus.
+  // We approximate "jobs with setup evidence" by the failing-jobs count —
+  // signal4 fires off raw aggregated logs, not per-job, so this is the best
+  // available proxy without re-fetching per-job logs.
+  const signal4 = {
+    fired: signal4Raw.fired,
+    evidence: { ...signal4Raw.evidence, jobCount: failedJobs.length },
+  };
   const results = {
-    signal1: signal1_shardAsymmetry(s._ciFailedJobs || [], c.allJobs || []),
+    signal1: signal1_shardAsymmetry(failedJobs, c.allJobs || []),
     signal2: c.exec
       ? signal2_emptyFailedLog(s.runId, c.jobId, c.exec)
       : { fired: false, evidence: { reason: 'no exec provided' } },
     signal3: signal3_unrelatedFailures(s.failedTests || [], c.prDiffFiles || []),
-    signal4: signal4_setupArtifacts(c.rawLogs || ''),
+    signal4,
   };
   const firedSignals = Object.entries(results)
     .filter(([, r]) => r.fired)

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -172,6 +172,23 @@ function signal2_emptyFailedLog(runId, jobId, exec) {
  * @param {string[]} prDiffFiles - Files changed by the PR.
  * @returns {{ fired: boolean, evidence: object }}
  */
+function stemsOverlap(testStem, ds) {
+  return (
+    testStem === ds ||
+    testStem.startsWith(ds + '/') ||
+    ds.startsWith(testStem + '/') ||
+    testStem.includes(ds) ||
+    ds.includes(testStem)
+  );
+}
+
+function findOverlappingDiffStem(testStem, diffStems) {
+  for (const ds of diffStems) {
+    if (stemsOverlap(testStem, ds)) return ds;
+  }
+  return null;
+}
+
 function signal3_unrelatedFailures(failedTests, prDiffFiles) {
   const tests = Array.isArray(failedTests) ? failedTests : [];
   const diff = Array.isArray(prDiffFiles) ? prDiffFiles : [];
@@ -182,17 +199,9 @@ function signal3_unrelatedFailures(failedTests, prDiffFiles) {
   const overlapping = [];
   for (const t of tests) {
     const testStem = t.replace(/\.(test|spec)\.[jt]sx?$/i, '').replace(/\.[a-z]+$/i, '');
-    for (const ds of diffStems) {
-      if (
-        testStem === ds ||
-        testStem.startsWith(ds + '/') ||
-        ds.startsWith(testStem + '/') ||
-        testStem.includes(ds) ||
-        ds.includes(testStem)
-      ) {
-        overlapping.push({ test: t, diffFile: ds });
-        break;
-      }
+    const matched = findOverlappingDiffStem(testStem, diffStems);
+    if (matched !== null) {
+      overlapping.push({ test: t, diffFile: matched });
     }
   }
   if (overlapping.length === 0) {

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -289,17 +289,8 @@ function signal4_setupArtifacts(rawLogs) {
   return { fired: false, evidence: { patterns: hits } };
 }
 
-/**
- * Aggregate the four signal collectors and decide between `infra-suspected`
- * and `code-failure`. The classifier itself never shells out — collectors
- * receive payloads / `exec` from `ctx`.
- *
- * @param {object} state - Workflow state. Reads `_ciFailedJobs`, `failedTests`,
- *   `runId`.
- * @param {object} ctx - Pre-fetched context: `allJobs`, `prDiffFiles`,
- *   `rawLogs`, `exec`, `jobId`.
- * @returns {{ classification: 'infra-suspected'|'code-failure', signals: string[], evidence: object }}
- */
+// Aggregate the four signal collectors. classify() (below) decides between
+// `infra-suspected` and `code-failure` using INFRA_SUSPECTED_PAIRS.
 function collectSignals(s, c, failedJobs) {
   const signal4Raw = signal4_setupArtifacts(c.rawLogs || '');
   // R16: when signal4 fires, attach a conservative upper bound on
@@ -342,9 +333,19 @@ function evaluateSignal2(s, c) {
   if (evaluable.length === 0) {
     return { fired: false, evidence: { reason: 'no runId/jobId' } };
   }
+  // Bug 542-27: catch signal2 throws (bad ids) so they don't propagate up
+  // through uncaughtException and block the whole follow-up loop.
   let lastFired = null;
   for (const j of evaluable) {
-    const result = signal2_emptyFailedLog(j.runId, j.jobId, c.exec);
+    let result;
+    try {
+      result = signal2_emptyFailedLog(j.runId, j.jobId, c.exec);
+    } catch (err) {
+      return {
+        fired: false,
+        evidence: { runId: j.runId, jobId: j.jobId, reason: `invalid id: ${err.message}` },
+      };
+    }
     // If ANY failed job has real error markers (fired=false), signal2 must
     // NOT fire — there's a real code failure somewhere.
     if (!result.fired) {

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -220,6 +220,13 @@ function signal3_unrelatedFailures(failedTests, prDiffFiles) {
   if (tests.length === 0) {
     return { fired: false, evidence: { reason: 'no failing tests provided' } };
   }
+  // Bug 542-8: an empty diff (fails-open from loadPrDiffFiles) cannot
+  // distinguish "unrelated failures" from "the PR touches no files we know
+  // about". Refuse to fire signal3 in that case rather than misclassifying
+  // real regressions as infra flakes that get auto-retried.
+  if (diff.length === 0) {
+    return { fired: false, evidence: { reason: 'PR diff unavailable; signal3 inconclusive' } };
+  }
   const diffStems = diff.map((f) => f.replace(/\.[a-z]+$/i, ''));
   const overlapping = [];
   for (const t of tests) {

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -291,12 +291,25 @@ function collectSignals(s, c, failedJobs) {
   };
   return {
     signal1: signal1_shardAsymmetry(failedJobs, c.allJobs || []),
-    signal2: c.exec
-      ? signal2_emptyFailedLog(s.runId, c.jobId, c.exec)
-      : { fired: false, evidence: { reason: 'no exec provided' } },
+    signal2: evaluateSignal2(s, c),
     signal3: signal3_unrelatedFailures(s.failedTests || [], c.prDiffFiles || []),
     signal4,
   };
+}
+
+// Bug C (GH-508): prefer ctx.runId (sourced from _ciFailedJobs[0].runId in
+// production). Fall back to state.runId for tests/callers that still set it
+// directly. Skip signal2 cleanly when ids are missing rather than throwing —
+// the ≥2-signal floor (R7) means missing signal2 alone is fine.
+function evaluateSignal2(s, c) {
+  if (typeof c.exec !== 'function') {
+    return { fired: false, evidence: { reason: 'no exec provided' } };
+  }
+  const runId = c.runId || s.runId || null;
+  if (!runId || !c.jobId) {
+    return { fired: false, evidence: { reason: 'no runId/jobId' } };
+  }
+  return signal2_emptyFailedLog(runId, c.jobId, c.exec);
 }
 
 function isInfraSuspected(firedSignals) {

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -167,15 +167,16 @@ function signal2_emptyFailedLog(runId, jobId, exec) {
     throw new TypeError('signal2_emptyFailedLog: exec must be a function');
   }
   const result = exec(`gh run view ${runId} --job ${jobId} --log-failed`);
-  const stdout = (result && result.stdout) || '';
-  const stderr = (result && result.stderr) || '';
+  return evaluateSignal2Result(result || {}, runId, jobId);
+}
+
+const SIGNAL2_MARKER_RE = /error|fail|assert|expect|✗|✕/i;
+
+function evaluateSignal2Result(result, runId, jobId) {
+  const stdout = result.stdout || '';
+  const stderr = result.stderr || '';
   const stripped = filterLogs(stdout).trim();
-  // Treat as "empty" when no error/assertion lines survive the filter AND
-  // neither raw stream has error markers. stderr is checked too: a failed
-  // `gh run view` typically writes its diagnostic to stderr with empty stdout,
-  // which must NOT be misclassified as a flake's empty failed log.
-  const markerRe = /error|fail|assert|expect|✗|✕/i;
-  const hasErrorMarker = markerRe.test(stdout) || markerRe.test(stderr);
+  const hasErrorMarker = SIGNAL2_MARKER_RE.test(stdout) || SIGNAL2_MARKER_RE.test(stderr);
   if (!hasErrorMarker && stripped.length === 0) {
     return {
       fired: true,

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -16,13 +16,8 @@ const INFRA_SUSPECTED_PAIRS = [
 
 const NUMERIC_ID_RE = /^\d+$/;
 
-/**
- * Strip matrix shard suffixes from a job name so siblings in the same
- * matrix family collapse to a single stem (e.g. `e2e [shard-3]` -> `e2e`).
- *
- * @param {string} name
- * @returns {string}
- */
+// Strip matrix shard suffixes from a job name so siblings in the same matrix
+// family collapse to a single stem (e.g. `e2e [shard-3]` -> `e2e`).
 function stripShardSuffix(name) {
   if (typeof name !== 'string') return '';
   return name
@@ -65,8 +60,17 @@ function groupJobsByFamily(safeAll) {
   return families;
 }
 
+// Bug 542-25: enriched `failed` is a COPY; reference equality `j !== failed`
+// always returned true, leaking the failed shard into the median. Match by
+// jobId (against databaseId/id) or by name.
+function isSameJob(j, failed) {
+  if (!j || !failed) return false;
+  if (failed.jobId && allJobIdMatches(j, failed.jobId)) return true;
+  return Boolean(failed.name) && j.name === failed.name;
+}
+
 function siblingMedianRuntime(family, failed) {
-  const siblings = family.filter((j) => j !== failed);
+  const siblings = family.filter((j) => !isSameJob(j, failed));
   const siblingRuntimes = siblings
     .map(jobRuntimeMs)
     .filter((ms) => ms > 0)
@@ -121,10 +125,9 @@ function allJobIdMatches(j, jobId) {
   return String(j.databaseId) === s || String(j.id) === s;
 }
 
+// Bug 542-15 / 542-23: enrich _ciFailedJobs with startedAt/completedAt from
+// _ciAllJobs (which uses databaseId/id, not jobId). Name fallback.
 function enrichFailedFromAll(failed, safeAll) {
-  // Bug 542-15 / 542-23: enrich _ciFailedJobs with startedAt/completedAt
-  // from _ciAllJobs. allJobs uses `databaseId`/`id` (gh run view shape),
-  // not `jobId` — match by either, fall back to name.
   if (!failed) return failed;
   if (failed.startedAt && failed.completedAt) return failed;
   const byId = failed.jobId ? safeAll.find((j) => allJobIdMatches(j, failed.jobId)) : null;

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -130,13 +130,29 @@ function evaluateFamilyAsymmetry(failed, families) {
   return {};
 }
 
+function enrichFailedFromAll(failed, safeAll) {
+  // Bug 542-15: monitor stores only name/runId/jobId on _ciFailedJobs.
+  // jobRuntimeMs needs startedAt/completedAt — look them up on the matching
+  // entry from the richer _ciAllJobs collection (by jobId, fallback name).
+  if (!failed) return failed;
+  if (failed.startedAt && failed.completedAt) return failed;
+  const byId = failed.jobId ? safeAll.find((j) => j && j.jobId === failed.jobId) : null;
+  const matched = byId || safeAll.find((j) => j && j.name === failed.name);
+  if (!matched) return failed;
+  return Object.assign({}, failed, {
+    startedAt: matched.startedAt || failed.startedAt,
+    completedAt: matched.completedAt || failed.completedAt,
+  });
+}
+
 function signal1_shardAsymmetry(failedJobs, allJobs) {
   const safeFailed = Array.isArray(failedJobs) ? failedJobs : [];
   const safeAll = Array.isArray(allJobs) ? allJobs : [];
   const families = groupJobsByFamily(safeAll);
 
   let lastSkipReason = null;
-  for (const failed of safeFailed) {
+  for (const failedRaw of safeFailed) {
+    const failed = enrichFailedFromAll(failedRaw, safeAll);
     const r = evaluateFamilyAsymmetry(failed, families);
     if (r.fire) return { fired: true, evidence: r.evidence };
     if (r.skipReason) lastSkipReason = r.skipReason;

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -69,11 +69,7 @@ function jobRuntimeMs(job) {
  * @param {Array<object>} allJobs - All jobs from the run.
  * @returns {{ fired: boolean, evidence: object }}
  */
-function signal1_shardAsymmetry(failedJobs, allJobs) {
-  const safeFailed = Array.isArray(failedJobs) ? failedJobs : [];
-  const safeAll = Array.isArray(allJobs) ? allJobs : [];
-
-  // Group all jobs by their matrix-family stem.
+function groupJobsByFamily(safeAll) {
   const families = new Map();
   for (const job of safeAll) {
     const stem = stripShardSuffix(job?.name || '');
@@ -81,46 +77,71 @@ function signal1_shardAsymmetry(failedJobs, allJobs) {
     if (!families.has(stem)) families.set(stem, []);
     families.get(stem).push(job);
   }
+  return families;
+}
 
-  for (const failed of safeFailed) {
-    const stem = stripShardSuffix(failed?.name || '');
-    if (!stem) continue;
-    const family = families.get(stem) || [];
-    if (family.length < 3) {
-      return {
-        fired: false,
-        evidence: {
-          reason: 'matrix family size <3 — N<3 shards cannot establish asymmetry',
-          family: stem,
-          shardCount: family.length,
-        },
-      };
-    }
-    const siblings = family.filter((j) => j !== failed);
-    const siblingRuntimes = siblings
-      .map(jobRuntimeMs)
-      .filter((ms) => ms > 0)
-      .sort((a, b) => a - b);
-    if (siblingRuntimes.length === 0) continue;
-    const mid = Math.floor(siblingRuntimes.length / 2);
-    const medianMs =
-      siblingRuntimes.length % 2 === 0
-        ? (siblingRuntimes[mid - 1] + siblingRuntimes[mid]) / 2
-        : siblingRuntimes[mid];
-    const failedMs = jobRuntimeMs(failed);
-    if (medianMs > 0 && failedMs >= medianMs * 3) {
-      return {
-        fired: true,
-        evidence: {
-          family: stem,
-          failedJob: failed.name,
-          failedRuntimeMs: failedMs,
-          siblingMedianMs: medianMs,
-          ratio: failedMs / medianMs,
-        },
-      };
-    }
+function siblingMedianRuntime(family, failed) {
+  const siblings = family.filter((j) => j !== failed);
+  const siblingRuntimes = siblings
+    .map(jobRuntimeMs)
+    .filter((ms) => ms > 0)
+    .sort((a, b) => a - b);
+  if (siblingRuntimes.length === 0) return 0;
+  const mid = Math.floor(siblingRuntimes.length / 2);
+  return siblingRuntimes.length % 2 === 0
+    ? (siblingRuntimes[mid - 1] + siblingRuntimes[mid]) / 2
+    : siblingRuntimes[mid];
+}
+
+/**
+ * Evaluate one failed job against its family. Returns:
+ *  - { fire: true, evidence } when asymmetry detected
+ *  - { skipReason } when family is too small to evaluate
+ *  - {} otherwise (keep iterating)
+ */
+function evaluateFamilyAsymmetry(failed, families) {
+  const stem = stripShardSuffix(failed?.name || '');
+  if (!stem) return {};
+  const family = families.get(stem) || [];
+  if (family.length < 3) {
+    return {
+      skipReason: {
+        reason: 'matrix family size <3 — N<3 shards cannot establish asymmetry',
+        family: stem,
+        shardCount: family.length,
+      },
+    };
   }
+  const medianMs = siblingMedianRuntime(family, failed);
+  if (medianMs <= 0) return {};
+  const failedMs = jobRuntimeMs(failed);
+  if (failedMs >= medianMs * 3) {
+    return {
+      fire: true,
+      evidence: {
+        family: stem,
+        failedJob: failed.name,
+        failedRuntimeMs: failedMs,
+        siblingMedianMs: medianMs,
+        ratio: failedMs / medianMs,
+      },
+    };
+  }
+  return {};
+}
+
+function signal1_shardAsymmetry(failedJobs, allJobs) {
+  const safeFailed = Array.isArray(failedJobs) ? failedJobs : [];
+  const safeAll = Array.isArray(allJobs) ? allJobs : [];
+  const families = groupJobsByFamily(safeAll);
+
+  let lastSkipReason = null;
+  for (const failed of safeFailed) {
+    const r = evaluateFamilyAsymmetry(failed, families);
+    if (r.fire) return { fired: true, evidence: r.evidence };
+    if (r.skipReason) lastSkipReason = r.skipReason;
+  }
+  if (lastSkipReason) return { fired: false, evidence: lastSkipReason };
   return { fired: false, evidence: { reason: 'no shard with >=3x median runtime' } };
 }
 
@@ -239,8 +260,7 @@ function signal4_setupArtifacts(rawLogs) {
 
   // Require ≥2 hits OR the canonical pair (cache-miss + fallback-install-failed)
   // to avoid firing on isolated transient mentions.
-  const hasCanonicalPair =
-    hits.includes('cache-miss') && hits.includes('fallback-install-failed');
+  const hasCanonicalPair = hits.includes('cache-miss') && hits.includes('fallback-install-failed');
   if (hasCanonicalPair || hits.length >= 2) {
     return { fired: true, evidence: { patterns: hits } };
   }

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -116,12 +116,22 @@ function evaluateFamilyAsymmetry(failed, families) {
 }
 
 function enrichFailedFromAll(failed, safeAll) {
-  // Bug 542-15: monitor stores only name/runId/jobId on _ciFailedJobs.
-  // jobRuntimeMs needs startedAt/completedAt — look them up on the matching
-  // entry from the richer _ciAllJobs collection (by jobId, fallback name).
+  // Bug 542-15 / 542-23: monitor stores only name/runId/jobId on
+  // _ciFailedJobs. jobRuntimeMs needs startedAt/completedAt — look them up on
+  // the matching entry from the richer _ciAllJobs collection.
+  //
+  // _ciAllJobs comes verbatim from `gh run view --json jobs`, which uses
+  // `databaseId` (or `id`) — NOT `jobId`. The id-based lookup must compare
+  // failed.jobId to allJob.databaseId / allJob.id, with name as fallback.
   if (!failed) return failed;
   if (failed.startedAt && failed.completedAt) return failed;
-  const byId = failed.jobId ? safeAll.find((j) => j && j.jobId === failed.jobId) : null;
+  const byId = failed.jobId
+    ? safeAll.find(
+        (j) =>
+          j &&
+          (String(j.databaseId) === String(failed.jobId) || String(j.id) === String(failed.jobId))
+      )
+    : null;
   const matched = byId || safeAll.find((j) => j && j.name === failed.name);
   if (!matched) return failed;
   return Object.assign({}, failed, {

--- a/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/infra-classifier.js
@@ -26,13 +26,7 @@ function stripShardSuffix(name) {
     .trim();
 }
 
-/**
- * Compute the runtime (in milliseconds) of a job from its ISO timestamps.
- * Returns 0 if either timestamp is missing or unparseable.
- *
- * @param {{ startedAt?: string, completedAt?: string }} job
- * @returns {number}
- */
+// Runtime (ms) of a job from its ISO timestamps; 0 if missing/unparseable.
 function jobRuntimeMs(job) {
   if (!job || !job.startedAt || !job.completedAt) return 0;
   const s = Date.parse(job.startedAt);

--- a/plugins/work/scripts/workflows/follow-up/lib/log-utils.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/log-utils.js
@@ -1,0 +1,74 @@
+/**
+ * Pure log-processing helpers extracted from `lib/steps/fix-ci.js` so that
+ * the new `infra-classifier.js` (Signal 4 raw-log scanner) and the existing
+ * `fix-ci` step can share the same prefix-stripping / noise-filtering logic
+ * without one importing the other.
+ *
+ * Both functions are pure (no I/O, no globals) and safe to call in tests.
+ */
+
+'use strict';
+
+/**
+ * Strip the `"<JobName>\t<StepName>\t<ISO timestamp>\t"` prefix that
+ * `gh run view --log-failed` prepends to each line.
+ *
+ * @param {string} line - A single line from gh's failed-log output.
+ * @returns {string} The line with the gh prefix removed, or the original
+ *   line unchanged if no prefix is present.
+ */
+function stripGhPrefix(line) {
+  // gh log lines: "JobName\tStepName\t2026-05-12T10:14:53.123Z message"
+  return line.replace(/^[^\t]+\t[^\t]+\t\d{4}-\d{2}-\d{2}T[^\s]+\s?/, '');
+}
+
+/**
+ * Strip gh prefixes from each line of `rawLogs`, then drop runner/setup
+ * noise lines while preserving error/assertion/test output. Falls back to
+ * the tail of stripped raw logs if the filter removed everything.
+ *
+ * @param {string} rawLogs - Multi-line raw output from `gh run view --log-failed`.
+ * @returns {string} A noise-filtered, prefix-stripped log string (≤6000 chars).
+ */
+function filterLogs(rawLogs) {
+  const stripped = rawLogs.split('\n').map(stripGhPrefix);
+  const filtered = stripped
+    .filter((line) => {
+      if (!line.trim()) return false;
+      // Drop runner setup / housekeeping noise
+      if (/##\[group\]|##\[endgroup\]|Runner Image|Operating System/i.test(line)) return false;
+      if (
+        /runner version|Secret source|Prepare workflow|Download action|Getting action/i.test(line)
+      )
+        return false;
+      if (/Image:|Version:|Commit:|Build Date:|Worker ID:|Azure Region:/i.test(line)) return false;
+      if (/Permissions|Actions: read|Contents: read|Metadata: read|PullRequests:/i.test(line))
+        return false;
+      if (
+        /Temporarily overriding HOME|safe\.directory|extraheader|submodule foreach|##\[warning\]Node\.js \d+ actions are deprecated/i.test(
+          line
+        )
+      )
+        return false;
+      if (/\[command\]\/usr\/bin\/git/.test(line)) return false;
+      if (/RESOLVEDSTATS|Cleaning up orphan|Docker container caching/i.test(line)) return false;
+      // Keep error markers, assertions, test names, meaningful output
+      if (/error|fail|assert|expect|timeout|ERR_|✗|✕|FAIL|Error:|×/i.test(line)) return true;
+      if (/\.(spec|test)\.(ts|js|tsx|jsx)/.test(line)) return true;
+      if (/^\s+at\s/.test(line)) return true;
+      if (/exit code|exit\s+\d|SIGTERM|SIGKILL|Process completed/i.test(line)) return true;
+      if (/Run tests|Run e2e|playwright/i.test(line)) return true;
+      return false;
+    })
+    .join('\n')
+    .substring(0, 6000);
+  if (filtered.trim()) return filtered;
+  // Fallback: tail of stripped raw logs when filter removed everything
+  return stripped
+    .filter((l) => l.trim())
+    .slice(-120)
+    .join('\n')
+    .substring(0, 6000);
+}
+
+module.exports = { stripGhPrefix, filterLogs };

--- a/plugins/work/scripts/workflows/follow-up/lib/log-utils.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/log-utils.js
@@ -22,6 +22,40 @@ function stripGhPrefix(line) {
   return line.replace(/^[^\t]+\t[^\t]+\t\d{4}-\d{2}-\d{2}T[^\s]+\s?/, '');
 }
 
+// Noise patterns: drop these runner / setup / housekeeping lines.
+const NOISE_PATTERNS = [
+  /##\[group\]|##\[endgroup\]|Runner Image|Operating System/i,
+  /runner version|Secret source|Prepare workflow|Download action|Getting action/i,
+  /Image:|Version:|Commit:|Build Date:|Worker ID:|Azure Region:/i,
+  /Permissions|Actions: read|Contents: read|Metadata: read|PullRequests:/i,
+  /Temporarily overriding HOME|safe\.directory|extraheader|submodule foreach|##\[warning\]Node\.js \d+ actions are deprecated/i,
+  /\[command\]\/usr\/bin\/git/,
+  /RESOLVEDSTATS|Cleaning up orphan|Docker container caching/i,
+];
+
+// Keep patterns: preserve error markers, assertions, test names, meaningful output.
+const KEEP_PATTERNS = [
+  /error|fail|assert|expect|timeout|ERR_|✗|✕|FAIL|Error:|×/i,
+  /\.(spec|test)\.(ts|js|tsx|jsx)/,
+  /^\s+at\s/,
+  /exit code|exit\s+\d|SIGTERM|SIGKILL|Process completed/i,
+  /Run tests|Run e2e|playwright/i,
+];
+
+function isNoiseLine(line) {
+  return NOISE_PATTERNS.some((re) => re.test(line));
+}
+
+function isMeaningfulLine(line) {
+  return KEEP_PATTERNS.some((re) => re.test(line));
+}
+
+function shouldKeepLine(line) {
+  if (!line.trim()) return false;
+  if (isNoiseLine(line)) return false;
+  return isMeaningfulLine(line);
+}
+
 /**
  * Strip gh prefixes from each line of `rawLogs`, then drop runner/setup
  * noise lines while preserving error/assertion/test output. Falls back to
@@ -32,36 +66,7 @@ function stripGhPrefix(line) {
  */
 function filterLogs(rawLogs) {
   const stripped = rawLogs.split('\n').map(stripGhPrefix);
-  const filtered = stripped
-    .filter((line) => {
-      if (!line.trim()) return false;
-      // Drop runner setup / housekeeping noise
-      if (/##\[group\]|##\[endgroup\]|Runner Image|Operating System/i.test(line)) return false;
-      if (
-        /runner version|Secret source|Prepare workflow|Download action|Getting action/i.test(line)
-      )
-        return false;
-      if (/Image:|Version:|Commit:|Build Date:|Worker ID:|Azure Region:/i.test(line)) return false;
-      if (/Permissions|Actions: read|Contents: read|Metadata: read|PullRequests:/i.test(line))
-        return false;
-      if (
-        /Temporarily overriding HOME|safe\.directory|extraheader|submodule foreach|##\[warning\]Node\.js \d+ actions are deprecated/i.test(
-          line
-        )
-      )
-        return false;
-      if (/\[command\]\/usr\/bin\/git/.test(line)) return false;
-      if (/RESOLVEDSTATS|Cleaning up orphan|Docker container caching/i.test(line)) return false;
-      // Keep error markers, assertions, test names, meaningful output
-      if (/error|fail|assert|expect|timeout|ERR_|✗|✕|FAIL|Error:|×/i.test(line)) return true;
-      if (/\.(spec|test)\.(ts|js|tsx|jsx)/.test(line)) return true;
-      if (/^\s+at\s/.test(line)) return true;
-      if (/exit code|exit\s+\d|SIGTERM|SIGKILL|Process completed/i.test(line)) return true;
-      if (/Run tests|Run e2e|playwright/i.test(line)) return true;
-      return false;
-    })
-    .join('\n')
-    .substring(0, 6000);
+  const filtered = stripped.filter(shouldKeepLine).join('\n').substring(0, 6000);
   if (filtered.trim()) return filtered;
   // Fallback: tail of stripped raw logs when filter removed everything
   return stripped

--- a/plugins/work/scripts/workflows/follow-up/lib/repo-meta.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/repo-meta.js
@@ -14,6 +14,24 @@
 
 const cp = require('node:child_process');
 
+// Shared trimmed-stdout helper used by both detectDefaultBranch and
+// detectRepoSlug. Swallows non-zero exits / errors and returns '' so callers
+// can fall through to their next probe.
+function runQuiet(cmd, cwd) {
+  try {
+    return cp
+      .execSync(cmd, {
+        cwd,
+        encoding: 'utf8',
+        timeout: 8000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      .trim();
+  } catch {
+    return '';
+  }
+}
+
 // Bug F (GH-508): hardcoding `origin/main` broke repos with non-main default
 // branches (signal3 was scoring against an empty diff). Detect the actual
 // default branch via `gh repo view`, fall back to `git remote show origin`,
@@ -23,23 +41,12 @@ const _detectedDefaultBranch = new Map();
 function detectDefaultBranch(worktreeDir) {
   const key = worktreeDir || process.cwd();
   if (_detectedDefaultBranch.has(key)) return _detectedDefaultBranch.get(key);
-  const runQuiet = (cmd) => {
-    try {
-      return cp
-        .execSync(cmd, {
-          cwd: worktreeDir,
-          encoding: 'utf8',
-          timeout: 8000,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        })
-        .trim();
-    } catch {
-      return '';
-    }
-  };
-  let detected = runQuiet('gh repo view --json defaultBranchRef --jq .defaultBranchRef.name');
+  let detected = runQuiet(
+    'gh repo view --json defaultBranchRef --jq .defaultBranchRef.name',
+    worktreeDir
+  );
   if (!detected) {
-    const remote = runQuiet('git remote show origin');
+    const remote = runQuiet('git remote show origin', worktreeDir);
     const m = remote.match(/HEAD branch:\s*(\S+)/);
     if (m && m[1] && m[1] !== '(unknown)') detected = m[1];
   }
@@ -76,21 +83,7 @@ const _repoSlugCache = new Map();
 function detectRepoSlug(worktreeDir) {
   const key = worktreeDir || process.cwd();
   if (_repoSlugCache.has(key)) return _repoSlugCache.get(key);
-  const runQuiet = (cmd) => {
-    try {
-      return cp
-        .execSync(cmd, {
-          cwd: worktreeDir,
-          encoding: 'utf8',
-          timeout: 8000,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        })
-        .trim();
-    } catch {
-      return '';
-    }
-  };
-  const json = runQuiet('gh repo view --json owner,name');
+  const json = runQuiet('gh repo view --json owner,name', worktreeDir);
   if (json) {
     try {
       const parsed = JSON.parse(json);
@@ -103,7 +96,7 @@ function detectRepoSlug(worktreeDir) {
       /* fall through to git remote parse */
     }
   }
-  const url = runQuiet('git remote get-url origin');
+  const url = runQuiet('git remote get-url origin', worktreeDir);
   const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
   if (m) {
     const slug = { owner: m[1], name: m[2] };

--- a/plugins/work/scripts/workflows/follow-up/lib/repo-meta.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/repo-meta.js
@@ -1,0 +1,118 @@
+/**
+ * Repo-metadata helpers: default-branch detection, PR-diff file listing, and
+ * owner/repo slug detection. Extracted from `follow-up-next.js` (default
+ * branch + diff) and `lib/steps/report.js` (repo slug) so both share the
+ * `gh repo view` → `git remote` fallback dance and the per-worktree cache key
+ * convention.
+ *
+ * Pure module — all I/O goes through `child_process` calls scoped to the
+ * supplied `worktreeDir`. Caches are module-level; tests that need a fresh
+ * cache should invalidate the require cache (`delete require.cache[path]`).
+ */
+
+'use strict';
+
+const cp = require('node:child_process');
+
+// Bug F (GH-508): hardcoding `origin/main` broke repos with non-main default
+// branches (signal3 was scoring against an empty diff). Detect the actual
+// default branch via `gh repo view`, fall back to `git remote show origin`,
+// then to 'main'. Cached per-process — the default branch doesn't change
+// during a single follow-up run.
+const _detectedDefaultBranch = new Map();
+function detectDefaultBranch(worktreeDir) {
+  const key = worktreeDir || process.cwd();
+  if (_detectedDefaultBranch.has(key)) return _detectedDefaultBranch.get(key);
+  const runQuiet = (cmd) => {
+    try {
+      return cp
+        .execSync(cmd, {
+          cwd: worktreeDir,
+          encoding: 'utf8',
+          timeout: 8000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        })
+        .trim();
+    } catch {
+      return '';
+    }
+  };
+  let detected = runQuiet('gh repo view --json defaultBranchRef --jq .defaultBranchRef.name');
+  if (!detected) {
+    const remote = runQuiet('git remote show origin');
+    const m = remote.match(/HEAD branch:\s*(\S+)/);
+    if (m && m[1] && m[1] !== '(unknown)') detected = m[1];
+  }
+  const resolved = detected || 'main';
+  _detectedDefaultBranch.set(key, resolved);
+  return resolved;
+}
+
+// Compute the PR diff file list (origin/<default>...HEAD). Fails open with [].
+function loadPrDiffFiles(worktreeDir) {
+  const branch = detectDefaultBranch(worktreeDir);
+  try {
+    const out = cp.execSync(`git diff --name-only origin/${branch}...HEAD`, {
+      cwd: worktreeDir,
+      encoding: 'utf8',
+      timeout: 10000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return out.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+// Bug 542-11: derive repo owner/name from git remote when state didn't carry
+// them — production state never sets repoOwner/repoName, so URLs used to fall
+// back to `OWNER`/`REPO` placeholders. Tries `gh repo view` first, then parses
+// `git remote get-url origin`.
+// Bug 542-13: cache MUST be keyed per-worktree — a single process can serve
+// multiple tickets across multiple worktrees, each pointing at a different
+// origin remote. The prior single-var cache leaked the first worktree's
+// owner/name into every subsequent ticket's diagnostic URLs.
+const _repoSlugCache = new Map();
+function detectRepoSlug(worktreeDir) {
+  const key = worktreeDir || process.cwd();
+  if (_repoSlugCache.has(key)) return _repoSlugCache.get(key);
+  const runQuiet = (cmd) => {
+    try {
+      return cp
+        .execSync(cmd, {
+          cwd: worktreeDir,
+          encoding: 'utf8',
+          timeout: 8000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        })
+        .trim();
+    } catch {
+      return '';
+    }
+  };
+  const json = runQuiet('gh repo view --json owner,name');
+  if (json) {
+    try {
+      const parsed = JSON.parse(json);
+      if (parsed && parsed.owner && parsed.name) {
+        const slug = { owner: parsed.owner.login || parsed.owner, name: parsed.name };
+        _repoSlugCache.set(key, slug);
+        return slug;
+      }
+    } catch {
+      /* fall through to git remote parse */
+    }
+  }
+  const url = runQuiet('git remote get-url origin');
+  const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+  if (m) {
+    const slug = { owner: m[1], name: m[2] };
+    _repoSlugCache.set(key, slug);
+    return slug;
+  }
+  const empty = { owner: null, name: null };
+  _repoSlugCache.set(key, empty);
+  return empty;
+}
+
+module.exports = { detectDefaultBranch, loadPrDiffFiles, detectRepoSlug };

--- a/plugins/work/scripts/workflows/follow-up/lib/step-registry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/step-registry.js
@@ -24,6 +24,20 @@ function runStep(stepName, state, ctx) {
 
 const STEPS = ['monitor', 'triage', 'infra-retry', 'fix-ci', 'fix-reviews', 'push-retry', 'report'];
 
+// Dispatch a step result and decide whether the orchestrator loop terminates.
+// Exported for testability (Task 4: action:'surface' is a terminal instruction
+// that stops the loop without marking state.status='complete' — see spec's
+// "API/Interface Changes" section for the surface contract).
+function dispatchStepResult(state, result) {
+  if (result && result.action === 'surface') {
+    return { terminate: true, instruction: result };
+  }
+  if (result && result.action === 'blocked') {
+    return { terminate: true, instruction: result };
+  }
+  return { terminate: false, instruction: result || null };
+}
+
 // --- Register steps ---
 require('./steps/monitor')(registerStep);
 require('./steps/triage')(registerStep);
@@ -33,4 +47,4 @@ require('./steps/fix-reviews')(registerStep);
 require('./steps/push-retry')(registerStep);
 require('./steps/report')(registerStep);
 
-module.exports = { registerStep, runStep, STEPS };
+module.exports = { registerStep, runStep, STEPS, dispatchStepResult };

--- a/plugins/work/scripts/workflows/follow-up/lib/step-registry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/step-registry.js
@@ -22,11 +22,12 @@ function runStep(stepName, state, ctx) {
   return fn(state, ctx);
 }
 
-const STEPS = ['monitor', 'triage', 'fix-ci', 'fix-reviews', 'push-retry', 'report'];
+const STEPS = ['monitor', 'triage', 'infra-retry', 'fix-ci', 'fix-reviews', 'push-retry', 'report'];
 
 // --- Register steps ---
 require('./steps/monitor')(registerStep);
 require('./steps/triage')(registerStep);
+require('./steps/infra-retry')(registerStep);
 require('./steps/fix-ci')(registerStep);
 require('./steps/fix-reviews')(registerStep);
 require('./steps/push-retry')(registerStep);

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-ci.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-ci.js
@@ -9,6 +9,7 @@
 
 const { execFileSync } = require('child_process');
 const { buildChildEnv } = require('../../../work/scripts/gh-exec');
+const { stripGhPrefix, filterLogs } = require('../log-utils');
 
 module.exports = function registerFixCi(register) {
   register('fix-ci', (state, ctx) => {
@@ -58,56 +59,8 @@ module.exports = function registerFixCi(register) {
     let ciLogs = '';
     const ciFetchErrors = [];
 
-    // Strip the "<JobName>\tUNKNOWN STEP\t<ISO timestamp>\t" prefix gh adds
-    // to each line of --log-failed output, then drop runner/setup noise.
-    function stripGhPrefix(line) {
-      // gh log lines: "JobName\tStepName\t2026-05-12T10:14:53.123Z message"
-      return line.replace(/^[^\t]+\t[^\t]+\t\d{4}-\d{2}-\d{2}T[^\s]+\s?/, '');
-    }
-
-    function filterLogs(rawLogs) {
-      const stripped = rawLogs.split('\n').map(stripGhPrefix);
-      const filtered = stripped
-        .filter((line) => {
-          if (!line.trim()) return false;
-          // Drop runner setup / housekeeping noise
-          if (/##\[group\]|##\[endgroup\]|Runner Image|Operating System/i.test(line)) return false;
-          if (
-            /runner version|Secret source|Prepare workflow|Download action|Getting action/i.test(
-              line
-            )
-          )
-            return false;
-          if (/Image:|Version:|Commit:|Build Date:|Worker ID:|Azure Region:/i.test(line))
-            return false;
-          if (/Permissions|Actions: read|Contents: read|Metadata: read|PullRequests:/i.test(line))
-            return false;
-          if (
-            /Temporarily overriding HOME|safe\.directory|extraheader|submodule foreach|##\[warning\]Node\.js \d+ actions are deprecated/i.test(
-              line
-            )
-          )
-            return false;
-          if (/\[command\]\/usr\/bin\/git/.test(line)) return false;
-          if (/RESOLVEDSTATS|Cleaning up orphan|Docker container caching/i.test(line)) return false;
-          // Keep error markers, assertions, test names, meaningful output
-          if (/error|fail|assert|expect|timeout|ERR_|✗|✕|FAIL|Error:|×/i.test(line)) return true;
-          if (/\.(spec|test)\.(ts|js|tsx|jsx)/.test(line)) return true;
-          if (/^\s+at\s/.test(line)) return true;
-          if (/exit code|exit\s+\d|SIGTERM|SIGKILL|Process completed/i.test(line)) return true;
-          if (/Run tests|Run e2e|playwright/i.test(line)) return true;
-          return false;
-        })
-        .join('\n')
-        .substring(0, 6000);
-      if (filtered.trim()) return filtered;
-      // Fallback: tail of stripped raw logs when filter removed everything
-      return stripped
-        .filter((l) => l.trim())
-        .slice(-120)
-        .join('\n')
-        .substring(0, 6000);
-    }
+    // `stripGhPrefix` / `filterLogs` are imported from `../log-utils` so the
+    // infra-classifier can reuse the same Signal 4 raw-log scanning logic.
 
     function shellSafe(s) {
       return String(s || '')

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-ci.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-ci.js
@@ -9,7 +9,7 @@
 
 const { execFileSync } = require('child_process');
 const { buildChildEnv } = require('../../../work/scripts/gh-exec');
-const { stripGhPrefix, filterLogs } = require('../log-utils');
+const { filterLogs } = require('../log-utils');
 
 module.exports = function registerFixCi(register) {
   register('fix-ci', (state, ctx) => {

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -210,7 +210,30 @@ function maybeSurfaceExhausted(state, retry, result) {
  * Increment retry counter, record the attempt entry, and return the delegate
  * that retries the failed run.
  */
+/**
+ * Bug 542-26: before dispatching a new retry, close out any prior `pending`
+ * attempt as 'failed'. This happens when monitor confirmed CI is still
+ * failing post-rerun, so the prior retry didn't help. Without this, the
+ * pending attempt stacks up and history loses the per-retry verdict.
+ */
+function closePriorPendingAsFailed(state) {
+  const last = lastPendingAttempt(state);
+  if (!last) return;
+  last.outcome = 'failed';
+  // Also update the corresponding history entry (the one appended when this
+  // attempt's classification was recorded) — most recent 'dispatched' wins.
+  if (Array.isArray(state.history)) {
+    for (let i = state.history.length - 1; i >= 0; i--) {
+      if (state.history[i].outcome === 'dispatched') {
+        state.history[i].outcome = 'failed';
+        break;
+      }
+    }
+  }
+}
+
 function dispatchRetryAttempt(state, retry, result) {
+  closePriorPendingAsFailed(state);
   const attemptNumber = retry.count + 1;
   const runId = resolveRunId(state);
   // Bug 542-22: if we can't resolve a numeric run id, infra-retry has no

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -68,6 +68,13 @@ function maybeHandleRetrySuccess(state, ctx) {
   if (!last || last.outcome !== 'pending') return false;
   const ciStatus = ctx && ctx.ciStatus;
   if (ciStatus !== 'success') return false;
+  // Bug 542-12: refuse to trust a persisted-stale `ciStatus`. monitor.js
+  // stamps `state._ciStatusFreshAt` with `process.uptime()` of its own
+  // process; a later process re-loading from disk has a fresh uptime clock,
+  // so the stamp won't match this process's uptime and we drop through
+  // (which forces the loop to call monitor again first).
+  const freshness = state._ciStatusFreshness;
+  if (!freshness || freshness.pid !== process.pid) return false;
   last.outcome = 'succeeded';
   process.stderr.write(`${RETRY_SUCCESS_LOG}\n`);
   return true;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -19,6 +19,8 @@ const { classify } = require('../infra-classifier');
 const { checkActionsStatus } = require('../gh-actions-status');
 
 const RETRY_SUCCESS_LOG = 'auto-retry: infra flake confirmed';
+const MAX_INFRA_RETRIES = 3;
+const NUMERIC_RUN_ID = /^\d+$/;
 
 /**
  * Decide whether the infra-retry step should short-circuit without touching
@@ -76,10 +78,47 @@ function maybeHandleRetrySuccess(state, ctx) {
  * justifies a githubstatus.com cross-check (R16).
  */
 function shouldCheckGhActions(result) {
-  if (!result || !result.evidence || !result.evidence.signal4) return false;
-  const s4 = result.evidence.signal4;
-  if (!s4.fired) return false;
-  return Number(s4.jobCount || 0) >= 2;
+  if (!result || !Array.isArray(result.signals)) return false;
+  if (!result.signals.includes('signal4')) return false;
+  const s4Evidence = (result.evidence && result.evidence.signal4) || {};
+  return Number(s4Evidence.jobCount || 0) >= 2;
+}
+
+/**
+ * Build the delegate that retries CI for the current run via
+ * `gh run rerun --failed <RUN_ID>`. Validates `runId` against `/^\d+$/`
+ * (R17 — no shell injection via state-derived IDs).
+ *
+ * When `WORK_INFRA_RETRY_FALLBACK=empty-commit` is set, the delegate uses
+ * an empty-commit push instead — for environments where `--failed` is
+ * unsupported (older gh, forks without write access to the run).
+ */
+function buildRetryDelegate(state, runId, attemptNumber) {
+  if (!NUMERIC_RUN_ID.test(String(runId || ''))) {
+    throw new TypeError(
+      `infra-retry: runId must match /^\\d+$/, got: ${runId} (refusing to dispatch retry)`
+    );
+  }
+  const fallback = getConfig('WORK_INFRA_RETRY_FALLBACK');
+  const useEmptyCommit = fallback === 'empty-commit';
+  const command = useEmptyCommit
+    ? 'git commit --allow-empty -m "ci: retry infra flake" && git push'
+    : `gh run rerun --failed ${runId}`;
+  return {
+    type: 'follow_up_instruction',
+    action: 'execute',
+    state: {
+      ticket: state && state.ticketId,
+      currentStep: 'monitor',
+      attempt: attemptNumber,
+    },
+    continue: true,
+    delegate: {
+      type: 'bash',
+      description: `Retry infra-flake CI (attempt ${attemptNumber}/${MAX_INFRA_RETRIES})`,
+      command,
+    },
+  };
 }
 
 module.exports = function registerInfraRetry(register) {
@@ -124,10 +163,41 @@ module.exports = function registerInfraRetry(register) {
       }
     }
 
-    // Deliverables 3.2 / 3.3 layer attempt-recording and surface-on-exhaust
-    // on top of this scaffold. For Task 7's tests we only need the telemetry,
-    // success-log, and outage-surface paths above.
-    return null;
+    // R2/R3/R4: retry state machine.
+    //  - cap at MAX_INFRA_RETRIES (3); on exhaust, set failureCategory and
+    //    surface for human handling — DO NOT dispatch fix-ci (the failure is
+    //    infra, not code).
+    //  - otherwise increment count, record an attempt, and dispatch a delegate
+    //    that re-runs the failed jobs.
+    const retry = state.infraRetry;
+    if (retry.count >= MAX_INFRA_RETRIES) {
+      state.failureCategory = 'infra-stuck';
+      retry.exhausted = true;
+      return {
+        action: 'surface',
+        reason: 'infra-stuck-exhausted',
+        signals: result.signals,
+        attempts: retry.attempts,
+      };
+    }
+
+    const attemptNumber = retry.count + 1;
+    const runId = state.runId;
+    // Validate before mutating state so a bad runId doesn't consume a retry.
+    const delegate = buildRetryDelegate(state, runId, attemptNumber);
+    retry.count = attemptNumber;
+    retry.attempts.push({
+      attemptNumber,
+      timestamp: new Date().toISOString(),
+      runId: String(runId),
+      signals: Array.isArray(result.signals) ? result.signals.slice() : [],
+      retryMethod: getConfig('WORK_INFRA_RETRY_FALLBACK') === 'empty-commit'
+        ? 'empty-commit'
+        : 'rerun-failed',
+      outcome: 'pending',
+    });
+    state.currentStep = 'monitor';
+    return delegate;
   });
 };
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -111,9 +111,14 @@ function shouldCheckGhActions(result) {
  * set it explicitly.
  */
 function resolveRunId(state) {
+  // Bug 542-20: scan ALL failed jobs for a runId — the first listed failure
+  // may lack one while a later entry has it. Falls back to state.runId for
+  // tests/callers that set it directly.
   const failedJobs = Array.isArray(state && state._ciFailedJobs) ? state._ciFailedJobs : [];
-  const firstFailedRunId = failedJobs.length > 0 ? failedJobs[0].runId : null;
-  return firstFailedRunId || (state && state.runId) || null;
+  for (const job of failedJobs) {
+    if (job && job.runId) return job.runId;
+  }
+  return (state && state.runId) || null;
 }
 
 function buildRetryDelegate(state, runId, attemptNumber) {

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -53,6 +53,18 @@ function recordClassification(state, result) {
 }
 
 /**
+ * R14 (Bug 542-24): update the most-recent history entry's `outcome` field as
+ * the workflow learns the fate of that classification. Outcomes: 'succeeded'
+ * (CI green after retry), 'exhausted' (hit MAX_INFRA_RETRIES), 'no-retry'
+ * (classifier returned code-failure or runId missing), 'dispatched' (retry
+ * sent to GH Actions; resolves to succeeded/exhausted on a later visit).
+ */
+function updateLastHistoryOutcome(state, outcome) {
+  if (!state || !Array.isArray(state.history) || state.history.length === 0) return;
+  state.history[state.history.length - 1].outcome = outcome;
+}
+
+/**
  * Detect a prior pending attempt whose retry now succeeded.
  *
  * Task 7.2 (R15): when ctx signals CI is green and the last persisted attempt
@@ -78,6 +90,7 @@ function maybeHandleRetrySuccess(state, ctx) {
   if (!last) return false;
   if (!ciStatusIsFreshSuccess(state, ctx)) return false;
   last.outcome = 'succeeded';
+  updateLastHistoryOutcome(state, 'succeeded');
   process.stderr.write(`${RETRY_SUCCESS_LOG}\n`);
   routeRetrySuccessToReport(state);
   return true;
@@ -176,6 +189,7 @@ function maybeSurfaceExhausted(state, retry, result) {
   if (retry.count < MAX_INFRA_RETRIES) return null;
   state.failureCategory = 'infra-stuck';
   retry.exhausted = true;
+  updateLastHistoryOutcome(state, 'exhausted');
   // Bug D+E (GH-508): use the standard surface contract
   // ({ action, payload: { reason, ... } }) AND set reason to 'infra-stuck' so
   // report.js's KNOWN_RESOLVABLE_CATEGORIES match fires the diagnostic bundle.
@@ -203,7 +217,10 @@ function dispatchRetryAttempt(state, retry, result) {
   // GitHub Actions handle to rerun. Return null so the orchestrator advances
   // to fix-ci instead of throwing TypeError (the loop has no catch and would
   // otherwise abort the whole follow-up workflow).
-  if (!NUMERIC_RUN_ID.test(String(runId || ''))) return null;
+  if (!NUMERIC_RUN_ID.test(String(runId || ''))) {
+    updateLastHistoryOutcome(state, 'no-retry');
+    return null;
+  }
   // Validate before mutating state so a bad runId doesn't consume a retry.
   const delegate = buildRetryDelegate(state, runId, attemptNumber);
   retry.count = attemptNumber;
@@ -216,6 +233,7 @@ function dispatchRetryAttempt(state, retry, result) {
       getConfig('WORK_INFRA_RETRY_FALLBACK') === 'empty-commit' ? 'empty-commit' : 'rerun-failed',
     outcome: 'pending',
   });
+  updateLastHistoryOutcome(state, 'dispatched');
   state.currentStep = 'monitor';
   return delegate;
 }
@@ -256,6 +274,7 @@ function maybeSurfaceAlreadyExhausted(state) {
   if (!retry.exhausted && !atCap) return null;
   retry.exhausted = true;
   state.failureCategory = 'infra-stuck';
+  updateLastHistoryOutcome(state, 'exhausted');
   return {
     action: 'surface',
     payload: {
@@ -315,7 +334,10 @@ function runInfraRetryStep(state, ctx) {
   // R14: telemetry append on every classification.
   recordClassification(state, result);
 
-  if (!isInfraSuspected(result)) return null;
+  if (!isInfraSuspected(result)) {
+    updateLastHistoryOutcome(state, 'no-retry');
+    return null;
+  }
 
   const outage = maybeSurfaceGhActionsOutage(state, result);
   if (outage) return outage;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -219,19 +219,20 @@ function classifyWithDefaults(state, ctx) {
   return classify(state || {}, ctx || {});
 }
 
+function freshnessIsCurrentProcess(state) {
+  const f = state && state._ciStatusFreshness;
+  return Boolean(f && f.pid === process.pid);
+}
+
+function ctxIndicatesFreshFailure(ctx) {
+  return Boolean(ctx && ctx.ciStatus && ctx.ciStatus !== 'success');
+}
+
 function needsFreshMonitorBeforeRetry(state, ctx) {
-  if (!state || !state.infraRetry) return false;
-  const attempts = state.infraRetry.attempts;
-  if (!Array.isArray(attempts) || attempts.length === 0) return false;
-  const last = attempts[attempts.length - 1];
-  if (!last || last.outcome !== 'pending') return false;
-  // If freshness is missing OR was stamped by a different process, we cannot
-  // trust the persisted _ciStatus. Re-route through monitor.
-  const freshness = state._ciStatusFreshness;
-  if (freshness && freshness.pid === process.pid) return false;
-  // Don't loop forever: if ctx already says CI is failing in *this* process,
-  // we know real work needs doing — let the classifier run.
-  if (ctx && ctx.ciStatus && ctx.ciStatus !== 'success') return false;
+  const last = lastPendingAttempt(state);
+  if (!last) return false;
+  if (freshnessIsCurrentProcess(state)) return false;
+  if (ctxIndicatesFreshFailure(ctx)) return false;
   return true;
 }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -265,16 +265,16 @@ function runInfraRetryStep(state, ctx) {
     state.infraRetry = { count: 0, attempts: [] };
   }
 
-  if (shouldBypass(state)) return null;
-
-  // R15: short-circuit on retry-success before consulting the classifier
-  // again — we are simply confirming a green run for an already-recorded
-  // attempt. Route directly to `report` (CI is green) and clear any stale
-  // `ci_failure` category so downstream branches don't dispatch fix-ci.
+  // Bug 542-18: handle retry-success BEFORE shouldBypass. If a prior
+  // auto-retry left a pending attempt and CI is now green, we must record the
+  // success and route to `report` even after the feature flag was disabled,
+  // so the orchestrator doesn't fall through to fix-ci dispatch.
   if (maybeHandleRetrySuccess(state, ctx)) {
     routeRetrySuccessToReport(state);
     return null;
   }
+
+  if (shouldBypass(state)) return null;
 
   // Bug 542-16: when this step resumes from disk (e.g. a new /follow-up
   // process after a previous infra rerun), a pending attempt still exists

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -115,7 +115,7 @@ function buildRetryDelegate(state, runId, attemptNumber) {
   const useEmptyCommit = fallback === 'empty-commit';
   const command = useEmptyCommit
     ? 'git commit --allow-empty -m "ci: retry infra flake" && git push'
-    : `gh run rerun --failed ${runId}`;
+    : `gh run rerun ${runId} --failed`;
   return {
     type: 'follow_up_instruction',
     action: 'execute',

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -133,6 +133,65 @@ function buildRetryDelegate(state, runId, attemptNumber) {
   };
 }
 
+/**
+ * R16: if multi-job Signal 4 cross-checks show a github.com Actions outage,
+ * mark state and return a surface payload. Returns null when no outage applies.
+ */
+function maybeSurfaceGhActionsOutage(state, result) {
+  if (!shouldCheckGhActions(result)) return null;
+  const status = checkActionsStatus({});
+  if (!status || !status.degraded) return null;
+  if (state && state.infraRetry) {
+    state.infraRetry.ghActionsStatus = 'degraded';
+  }
+  return {
+    action: 'surface',
+    payload: {
+      reason: 'github-actions-outage',
+      signals: result.signals,
+    },
+  };
+}
+
+/**
+ * R2/R3/R4: when retry count has hit the cap, set failureCategory and return
+ * the exhaustion surface payload. Returns null otherwise.
+ */
+function maybeSurfaceExhausted(state, retry, result) {
+  if (retry.count < MAX_INFRA_RETRIES) return null;
+  state.failureCategory = 'infra-stuck';
+  retry.exhausted = true;
+  return {
+    action: 'surface',
+    reason: 'infra-stuck-exhausted',
+    signals: result.signals,
+    attempts: retry.attempts,
+  };
+}
+
+/**
+ * Increment retry counter, record the attempt entry, and return the delegate
+ * that retries the failed run.
+ */
+function dispatchRetryAttempt(state, retry, result) {
+  const attemptNumber = retry.count + 1;
+  const runId = resolveRunId(state);
+  // Validate before mutating state so a bad runId doesn't consume a retry.
+  const delegate = buildRetryDelegate(state, runId, attemptNumber);
+  retry.count = attemptNumber;
+  retry.attempts.push({
+    attemptNumber,
+    timestamp: new Date().toISOString(),
+    runId: String(runId),
+    signals: Array.isArray(result.signals) ? result.signals.slice() : [],
+    retryMethod:
+      getConfig('WORK_INFRA_RETRY_FALLBACK') === 'empty-commit' ? 'empty-commit' : 'rerun-failed',
+    outcome: 'pending',
+  });
+  state.currentStep = 'monitor';
+  return delegate;
+}
+
 module.exports = function registerInfraRetry(register) {
   register('infra-retry', (state, ctx) => {
     // R12: default the persisted retry record on first read.
@@ -145,9 +204,7 @@ module.exports = function registerInfraRetry(register) {
     // R15: short-circuit on retry-success before consulting the classifier
     // again — we are simply confirming a green run for an already-recorded
     // attempt.
-    if (maybeHandleRetrySuccess(state, ctx)) {
-      return null;
-    }
+    if (maybeHandleRetrySuccess(state, ctx)) return null;
 
     // R1e / R7: consult the classifier.
     const result = classify(state || {}, ctx || {});
@@ -157,23 +214,8 @@ module.exports = function registerInfraRetry(register) {
 
     if (!result || result.classification !== 'infra-suspected') return null;
 
-    // R16: cross-check githubstatus.com when multi-job setup failures suggest
-    // a platform-wide Actions outage. Skip retry attempts entirely if so.
-    if (shouldCheckGhActions(result)) {
-      const status = checkActionsStatus({});
-      if (status && status.degraded) {
-        if (state && state.infraRetry) {
-          state.infraRetry.ghActionsStatus = 'degraded';
-        }
-        return {
-          action: 'surface',
-          payload: {
-            reason: 'github-actions-outage',
-            signals: result.signals,
-          },
-        };
-      }
-    }
+    const outage = maybeSurfaceGhActionsOutage(state, result);
+    if (outage) return outage;
 
     // R2/R3/R4: retry state machine.
     //  - cap at MAX_INFRA_RETRIES (3); on exhaust, set failureCategory and
@@ -182,33 +224,10 @@ module.exports = function registerInfraRetry(register) {
     //  - otherwise increment count, record an attempt, and dispatch a delegate
     //    that re-runs the failed jobs.
     const retry = state.infraRetry;
-    if (retry.count >= MAX_INFRA_RETRIES) {
-      state.failureCategory = 'infra-stuck';
-      retry.exhausted = true;
-      return {
-        action: 'surface',
-        reason: 'infra-stuck-exhausted',
-        signals: result.signals,
-        attempts: retry.attempts,
-      };
-    }
+    const exhausted = maybeSurfaceExhausted(state, retry, result);
+    if (exhausted) return exhausted;
 
-    const attemptNumber = retry.count + 1;
-    const runId = resolveRunId(state);
-    // Validate before mutating state so a bad runId doesn't consume a retry.
-    const delegate = buildRetryDelegate(state, runId, attemptNumber);
-    retry.count = attemptNumber;
-    retry.attempts.push({
-      attemptNumber,
-      timestamp: new Date().toISOString(),
-      runId: String(runId),
-      signals: Array.isArray(result.signals) ? result.signals.slice() : [],
-      retryMethod:
-        getConfig('WORK_INFRA_RETRY_FALLBACK') === 'empty-commit' ? 'empty-commit' : 'rerun-failed',
-      outcome: 'pending',
-    });
-    state.currentStep = 'monitor';
-    return delegate;
+    return dispatchRetryAttempt(state, retry, result);
   });
 };
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -25,21 +25,15 @@ const NUMERIC_RUN_ID = /^\d+$/;
 /**
  * Categories that bypass the infra-retry step entirely — these failures are
  * not infrastructure-related and have dedicated handling elsewhere.
+ *
+ * Note: previously gated additionally by WORK_AUTO_RETRY_INFRA env flag. The
+ * flag was removed (always-on per user decision GH-508) — the signal floor
+ * (≥2 of 4 INFRA_SUSPECTED_PAIRS), MAX_INFRA_RETRIES cap, and the exhaustion
+ * surface are the only safeguards needed.
  */
 function categoryBypass(state) {
   const cat = state && state.failureCategory;
   return cat === 'conflict' || cat === 'review_failure';
-}
-
-/**
- * Feature-flag bypass. Separated from `categoryBypass` so the exhaustion +
- * fresh-monitor gates can run even when the auto-retry feature is OFF — a
- * ticket that already hit MAX_INFRA_RETRIES must surface `infra-stuck`
- * regardless of the flag (Bug 542-21).
- */
-function featureFlagOff() {
-  const flag = getConfig('WORK_AUTO_RETRY_INFRA');
-  return !flag || flag === 'false' || flag === '0';
 }
 
 /**
@@ -309,10 +303,6 @@ function runInfraRetryStep(state, ctx) {
 
   const exhaustedSurface = maybeSurfaceAlreadyExhausted(state);
   if (exhaustedSurface) return exhaustedSurface;
-
-  // Feature flag off: skip the retry attempt itself, but only AFTER the
-  // exhaustion gate above has had a chance to surface infra-stuck.
-  if (featureFlagOff()) return null;
 
   // R1e / R7: consult the classifier.
   const result = classifyWithDefaults(state, ctx);

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -1,0 +1,60 @@
+/**
+ * Step: infra-retry — Gate CI retries on infra-flake evidence (R2-R5, R12, R17).
+ *
+ * Deliverable 3.1 (GREEN): off-flag short-circuit, conflict / review_failure
+ * bypass, and `classify() → code-failure` short-circuit. The full state machine
+ * (attempt persistence, surface-on-exhaust) is layered on in deliverables
+ * 3.2 / 3.3.
+ *
+ * See also: synapsys memory [[never-rerun-ci]] — feature defaults OFF; we
+ * only consider a retry when ≥2 signals fire (enforced by the classifier).
+ */
+
+'use strict';
+
+const path = require('node:path');
+
+const getConfig = require(path.resolve(__dirname, '..', '..', '..', 'lib', 'get-config'));
+const { classify } = require('../infra-classifier');
+
+/**
+ * Decide whether the infra-retry step should short-circuit without touching
+ * the classifier.
+ *
+ * Three short-circuit predicates today:
+ *  - feature flag is off (default — preserves `never-rerun-ci` invariant)
+ *  - failureCategory indicates a merge conflict
+ *  - failureCategory indicates a review failure (not a CI failure at all)
+ *
+ * @param {object} state
+ * @returns {boolean}
+ */
+function shouldBypass(state) {
+  const flag = getConfig('WORK_AUTO_RETRY_INFRA');
+  if (!flag || flag === 'false' || flag === '0') return true;
+  const cat = state && state.failureCategory;
+  if (cat === 'conflict') return true;
+  if (cat === 'review_failure') return true;
+  return false;
+}
+
+module.exports = function registerInfraRetry(register) {
+  register('infra-retry', (state, ctx) => {
+    // R12: default the persisted retry record on first read so downstream
+    // logic (cycle 3.2/3.3) can always rely on the shape.
+    if (state && !state.infraRetry) {
+      state.infraRetry = { count: 0, attempts: [] };
+    }
+
+    if (shouldBypass(state)) return null;
+
+    // R1e / R7: consult the classifier. If it says the failure looks like
+    // genuine code, do not consume a retry attempt.
+    const result = classify(state || {}, ctx || {});
+    if (!result || result.classification !== 'infra-suspected') return null;
+
+    // Deliverables 3.2 / 3.3 layer the attempt-recording state machine and
+    // the surface-on-exhaust branch on top of this short-circuit scaffold.
+    return null;
+  });
+};

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -307,9 +307,15 @@ function maybeSurfaceAlreadyExhausted(state) {
   };
 }
 
+// Bug 542-28: clear any CI-related failureCategory after a successful retry.
+// triage.js routes BOTH `ci_failure` and `ci_cancelled_blocking` into
+// infra-retry; only clearing `ci_failure` left the cancelled-blocking case
+// pinned, and report.js then surfaced it instead of marking complete.
+const POST_RETRY_CLEARABLE_CATEGORIES = new Set(['ci_failure', 'ci_cancelled_blocking']);
+
 function routeRetrySuccessToReport(state) {
   state.currentStep = 'report';
-  if (state.failureCategory === 'ci_failure') {
+  if (POST_RETRY_CLEARABLE_CATEGORIES.has(state.failureCategory)) {
     state.failureCategory = null;
   }
 }

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -240,18 +240,23 @@ function needsFreshMonitorBeforeRetry(state, _ctx) {
   return true;
 }
 
-// Bug 542-14: if a prior cycle exhausted infra retries, the spec forbids
-// dispatching fix-ci even if a later classification would otherwise return
-// `code-failure`. Stay in the infra-stuck surface so the human handler
-// resolves it explicitly.
+// Bug 542-14 + 542-21: if a prior cycle exhausted infra retries, the spec
+// forbids dispatching fix-ci even if a later classification would otherwise
+// return `code-failure`. Trigger on either the `exhausted` flag OR a count
+// already at the cap — the flag is only set on infra-suspected exhaustion,
+// but reaching MAX_INFRA_RETRIES via any path counts as exhausted.
 function maybeSurfaceAlreadyExhausted(state) {
-  if (!state.infraRetry || !state.infraRetry.exhausted) return null;
+  if (!state.infraRetry) return null;
+  const retry = state.infraRetry;
+  const atCap = Number(retry.count || 0) >= MAX_INFRA_RETRIES;
+  if (!retry.exhausted && !atCap) return null;
+  retry.exhausted = true;
   state.failureCategory = 'infra-stuck';
   return {
     action: 'surface',
     payload: {
       reason: 'infra-stuck',
-      attempts: state.infraRetry.attempts,
+      attempts: retry.attempts,
       signals: [],
     },
   };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -1,10 +1,10 @@
 /**
- * Step: infra-retry — Gate CI retries on infra-flake evidence (R2-R5, R12, R17).
+ * Step: infra-retry — Gate CI retries on infra-flake evidence (R2-R5, R12,
+ * R14-R17).
  *
- * Deliverable 3.1 (GREEN): off-flag short-circuit, conflict / review_failure
- * bypass, and `classify() → code-failure` short-circuit. The full state machine
- * (attempt persistence, surface-on-exhaust) is layered on in deliverables
- * 3.2 / 3.3.
+ * Implements the off-flag / bypass short-circuits, Task 7 telemetry append
+ * (R14), the retry-success stderr log (R15), and the GitHub Actions outage
+ * early-surface (R16).
  *
  * See also: synapsys memory [[never-rerun-ci]] — feature defaults OFF; we
  * only consider a retry when ≥2 signals fire (enforced by the classifier).
@@ -16,15 +16,13 @@ const path = require('node:path');
 
 const getConfig = require(path.resolve(__dirname, '..', '..', '..', 'lib', 'get-config'));
 const { classify } = require('../infra-classifier');
+const { checkActionsStatus } = require('../gh-actions-status');
+
+const RETRY_SUCCESS_LOG = 'auto-retry: infra flake confirmed';
 
 /**
  * Decide whether the infra-retry step should short-circuit without touching
  * the classifier.
- *
- * Three short-circuit predicates today:
- *  - feature flag is off (default — preserves `never-rerun-ci` invariant)
- *  - failureCategory indicates a merge conflict
- *  - failureCategory indicates a review failure (not a CI failure at all)
  *
  * @param {object} state
  * @returns {boolean}
@@ -38,23 +36,99 @@ function shouldBypass(state) {
   return false;
 }
 
+/**
+ * Append a telemetry entry to `state.history[]` describing this classify call.
+ *
+ * R14: every classification produces { timestamp, signals, decision, outcome }.
+ */
+function recordClassification(state, result) {
+  if (!state) return;
+  if (!Array.isArray(state.history)) state.history = [];
+  state.history.push({
+    timestamp: new Date().toISOString(),
+    signals: Array.isArray(result && result.signals) ? result.signals.slice() : [],
+    decision: result && result.classification,
+    outcome: 'pending',
+  });
+}
+
+/**
+ * Detect a prior pending attempt whose retry now succeeded.
+ *
+ * Task 7.2 (R15): when ctx signals CI is green and the last persisted attempt
+ * is still `pending`, mark it `succeeded` and log the canonical literal.
+ */
+function maybeHandleRetrySuccess(state, ctx) {
+  if (!state || !state.infraRetry) return false;
+  const attempts = state.infraRetry.attempts;
+  if (!Array.isArray(attempts) || attempts.length === 0) return false;
+  const last = attempts[attempts.length - 1];
+  if (!last || last.outcome !== 'pending') return false;
+  const ciStatus = ctx && ctx.ciStatus;
+  if (ciStatus !== 'success') return false;
+  last.outcome = 'succeeded';
+  process.stderr.write(`${RETRY_SUCCESS_LOG}\n`);
+  return true;
+}
+
+/**
+ * Inspect the classifier evidence for the multi-job Signal 4 condition that
+ * justifies a githubstatus.com cross-check (R16).
+ */
+function shouldCheckGhActions(result) {
+  if (!result || !result.evidence || !result.evidence.signal4) return false;
+  const s4 = result.evidence.signal4;
+  if (!s4.fired) return false;
+  return Number(s4.jobCount || 0) >= 2;
+}
+
 module.exports = function registerInfraRetry(register) {
   register('infra-retry', (state, ctx) => {
-    // R12: default the persisted retry record on first read so downstream
-    // logic (cycle 3.2/3.3) can always rely on the shape.
+    // R12: default the persisted retry record on first read.
     if (state && !state.infraRetry) {
       state.infraRetry = { count: 0, attempts: [] };
     }
 
     if (shouldBypass(state)) return null;
 
-    // R1e / R7: consult the classifier. If it says the failure looks like
-    // genuine code, do not consume a retry attempt.
+    // R15: short-circuit on retry-success before consulting the classifier
+    // again — we are simply confirming a green run for an already-recorded
+    // attempt.
+    if (maybeHandleRetrySuccess(state, ctx)) {
+      return null;
+    }
+
+    // R1e / R7: consult the classifier.
     const result = classify(state || {}, ctx || {});
+
+    // R14: telemetry append on every classification.
+    recordClassification(state, result);
+
     if (!result || result.classification !== 'infra-suspected') return null;
 
-    // Deliverables 3.2 / 3.3 layer the attempt-recording state machine and
-    // the surface-on-exhaust branch on top of this short-circuit scaffold.
+    // R16: cross-check githubstatus.com when multi-job setup failures suggest
+    // a platform-wide Actions outage. Skip retry attempts entirely if so.
+    if (shouldCheckGhActions(result)) {
+      const status = checkActionsStatus({});
+      if (status && status.degraded) {
+        if (state && state.infraRetry) {
+          state.infraRetry.ghActionsStatus = 'degraded';
+        }
+        return {
+          action: 'surface',
+          payload: {
+            reason: 'github-actions-outage',
+            signals: result.signals,
+          },
+        };
+      }
+    }
+
+    // Deliverables 3.2 / 3.3 layer attempt-recording and surface-on-exhaust
+    // on top of this scaffold. For Task 7's tests we only need the telemetry,
+    // success-log, and outage-surface paths above.
     return null;
   });
 };
+
+module.exports.RETRY_SUCCESS_LOG = RETRY_SUCCESS_LOG;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -215,6 +215,10 @@ function isInfraSuspected(result) {
   return Boolean(result) && result.classification === 'infra-suspected';
 }
 
+function classifyWithDefaults(state, ctx) {
+  return classify(state || {}, ctx || {});
+}
+
 // Bug 542-14: if a prior cycle exhausted infra retries, the spec forbids
 // dispatching fix-ci even if a later classification would otherwise return
 // `code-failure`. Stay in the infra-stuck surface so the human handler
@@ -260,9 +264,7 @@ function runInfraRetryStep(state, ctx) {
   if (exhaustedSurface) return exhaustedSurface;
 
   // R1e / R7: consult the classifier.
-  const safeState = state || {};
-  const safeCtx = ctx || {};
-  const result = classify(safeState, safeCtx);
+  const result = classifyWithDefaults(state, ctx);
 
   // R14: telemetry append on every classification.
   recordClassification(state, result);

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -161,11 +161,19 @@ function maybeSurfaceExhausted(state, retry, result) {
   if (retry.count < MAX_INFRA_RETRIES) return null;
   state.failureCategory = 'infra-stuck';
   retry.exhausted = true;
+  // Bug D+E (GH-508): use the standard surface contract
+  // ({ action, payload: { reason, ... } }) AND set reason to 'infra-stuck' so
+  // report.js's KNOWN_RESOLVABLE_CATEGORIES match fires the diagnostic bundle.
+  // The legacy `reason: 'infra-stuck-exhausted'` was both a shape mismatch
+  // (auto-advance hook reads payload.reason) and clobbered the failureCategory
+  // away from the value report.js looks for.
   return {
     action: 'surface',
-    reason: 'infra-stuck-exhausted',
-    signals: result.signals,
-    attempts: retry.attempts,
+    payload: {
+      reason: 'infra-stuck',
+      signals: result.signals,
+      attempts: retry.attempts,
+    },
   };
 }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -214,8 +214,15 @@ function runInfraRetryStep(state, ctx) {
 
   // R15: short-circuit on retry-success before consulting the classifier
   // again — we are simply confirming a green run for an already-recorded
-  // attempt.
-  if (maybeHandleRetrySuccess(state, ctx)) return null;
+  // attempt. Route directly to `report` (CI is green) and clear any stale
+  // `ci_failure` category so downstream branches don't dispatch fix-ci.
+  if (maybeHandleRetrySuccess(state, ctx)) {
+    state.currentStep = 'report';
+    if (state.failureCategory === 'ci_failure') {
+      state.failureCategory = null;
+    }
+    return null;
+  }
 
   // R1e / R7: consult the classifier.
   const safeState = state || {};

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -204,6 +204,13 @@ function isInfraSuspected(result) {
   return Boolean(result) && result.classification === 'infra-suspected';
 }
 
+function routeRetrySuccessToReport(state) {
+  state.currentStep = 'report';
+  if (state.failureCategory === 'ci_failure') {
+    state.failureCategory = null;
+  }
+}
+
 function runInfraRetryStep(state, ctx) {
   // R12: default the persisted retry record on first read.
   if (state && !state.infraRetry) {
@@ -217,10 +224,7 @@ function runInfraRetryStep(state, ctx) {
   // attempt. Route directly to `report` (CI is green) and clear any stale
   // `ci_failure` category so downstream branches don't dispatch fix-ci.
   if (maybeHandleRetrySuccess(state, ctx)) {
-    state.currentStep = 'report';
-    if (state.failureCategory === 'ci_failure') {
-      state.failureCategory = null;
-    }
+    routeRetrySuccessToReport(state);
     return null;
   }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -224,15 +224,14 @@ function freshnessIsCurrentProcess(state) {
   return Boolean(f && f.pid === process.pid);
 }
 
-function ctxIndicatesFreshFailure(ctx) {
-  return Boolean(ctx && ctx.ciStatus && ctx.ciStatus !== 'success');
-}
-
-function needsFreshMonitorBeforeRetry(state, ctx) {
+// Bug 542-17: the previous version exempted `ctx.ciStatus !== 'success'` as
+// "fresh failure", but ciStatus is read from state._ciStatus which can be
+// persisted from a prior PID. The only trustworthy fresh-status signal is
+// the per-process freshness stamp itself, so drop the redundant exemption.
+function needsFreshMonitorBeforeRetry(state, _ctx) {
   const last = lastPendingAttempt(state);
   if (!last) return false;
   if (freshnessIsCurrentProcess(state)) return false;
-  if (ctxIndicatesFreshFailure(ctx)) return false;
   return true;
 }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -192,43 +192,41 @@ function dispatchRetryAttempt(state, retry, result) {
   return delegate;
 }
 
+function runInfraRetryStep(state, ctx) {
+  // R12: default the persisted retry record on first read.
+  if (state && !state.infraRetry) {
+    state.infraRetry = { count: 0, attempts: [] };
+  }
+
+  if (shouldBypass(state)) return null;
+
+  // R15: short-circuit on retry-success before consulting the classifier
+  // again — we are simply confirming a green run for an already-recorded
+  // attempt.
+  if (maybeHandleRetrySuccess(state, ctx)) return null;
+
+  // R1e / R7: consult the classifier.
+  const result = classify(state || {}, ctx || {});
+
+  // R14: telemetry append on every classification.
+  recordClassification(state, result);
+
+  if (!result || result.classification !== 'infra-suspected') return null;
+
+  const outage = maybeSurfaceGhActionsOutage(state, result);
+  if (outage) return outage;
+
+  // R2/R3/R4: retry state machine. Cap at MAX_INFRA_RETRIES (3); on exhaust,
+  // surface for human handling. Otherwise dispatch a delegate to re-run.
+  const retry = state.infraRetry;
+  const exhausted = maybeSurfaceExhausted(state, retry, result);
+  if (exhausted) return exhausted;
+
+  return dispatchRetryAttempt(state, retry, result);
+}
+
 module.exports = function registerInfraRetry(register) {
-  register('infra-retry', (state, ctx) => {
-    // R12: default the persisted retry record on first read.
-    if (state && !state.infraRetry) {
-      state.infraRetry = { count: 0, attempts: [] };
-    }
-
-    if (shouldBypass(state)) return null;
-
-    // R15: short-circuit on retry-success before consulting the classifier
-    // again — we are simply confirming a green run for an already-recorded
-    // attempt.
-    if (maybeHandleRetrySuccess(state, ctx)) return null;
-
-    // R1e / R7: consult the classifier.
-    const result = classify(state || {}, ctx || {});
-
-    // R14: telemetry append on every classification.
-    recordClassification(state, result);
-
-    if (!result || result.classification !== 'infra-suspected') return null;
-
-    const outage = maybeSurfaceGhActionsOutage(state, result);
-    if (outage) return outage;
-
-    // R2/R3/R4: retry state machine.
-    //  - cap at MAX_INFRA_RETRIES (3); on exhaust, set failureCategory and
-    //    surface for human handling — DO NOT dispatch fix-ci (the failure is
-    //    infra, not code).
-    //  - otherwise increment count, record an attempt, and dispatch a delegate
-    //    that re-runs the failed jobs.
-    const retry = state.infraRetry;
-    const exhausted = maybeSurfaceExhausted(state, retry, result);
-    if (exhausted) return exhausted;
-
-    return dispatchRetryAttempt(state, retry, result);
-  });
+  register('infra-retry', runInfraRetryStep);
 };
 
 module.exports.RETRY_SUCCESS_LOG = RETRY_SUCCESS_LOG;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -219,6 +219,22 @@ function classifyWithDefaults(state, ctx) {
   return classify(state || {}, ctx || {});
 }
 
+function needsFreshMonitorBeforeRetry(state, ctx) {
+  if (!state || !state.infraRetry) return false;
+  const attempts = state.infraRetry.attempts;
+  if (!Array.isArray(attempts) || attempts.length === 0) return false;
+  const last = attempts[attempts.length - 1];
+  if (!last || last.outcome !== 'pending') return false;
+  // If freshness is missing OR was stamped by a different process, we cannot
+  // trust the persisted _ciStatus. Re-route through monitor.
+  const freshness = state._ciStatusFreshness;
+  if (freshness && freshness.pid === process.pid) return false;
+  // Don't loop forever: if ctx already says CI is failing in *this* process,
+  // we know real work needs doing — let the classifier run.
+  if (ctx && ctx.ciStatus && ctx.ciStatus !== 'success') return false;
+  return true;
+}
+
 // Bug 542-14: if a prior cycle exhausted infra retries, the spec forbids
 // dispatching fix-ci even if a later classification would otherwise return
 // `code-failure`. Stay in the infra-stuck surface so the human handler
@@ -257,6 +273,17 @@ function runInfraRetryStep(state, ctx) {
   // `ci_failure` category so downstream branches don't dispatch fix-ci.
   if (maybeHandleRetrySuccess(state, ctx)) {
     routeRetrySuccessToReport(state);
+    return null;
+  }
+
+  // Bug 542-16: when this step resumes from disk (e.g. a new /follow-up
+  // process after a previous infra rerun), a pending attempt still exists
+  // but `_ciStatusFreshness` belongs to the prior PID. Don't fall through to
+  // fix-ci dispatch — bounce back to `monitor` to re-poll CI. monitor will
+  // either re-confirm green (next entry hits the retry-success path with a
+  // fresh stamp) or surface the real new failure.
+  if (needsFreshMonitorBeforeRetry(state, ctx)) {
+    state.currentStep = 'monitor';
     return null;
   }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -235,6 +235,22 @@ function runInfraRetryStep(state, ctx) {
     return null;
   }
 
+  // Bug 542-14: if a prior cycle exhausted infra retries, the spec forbids
+  // dispatching fix-ci even if a later classification would otherwise return
+  // `code-failure`. Stay in the infra-stuck surface so the human handler
+  // resolves it explicitly.
+  if (state.infraRetry && state.infraRetry.exhausted) {
+    state.failureCategory = 'infra-stuck';
+    return {
+      action: 'surface',
+      payload: {
+        reason: 'infra-stuck',
+        attempts: state.infraRetry.attempts,
+        signals: [],
+      },
+    };
+  }
+
   // R1e / R7: consult the classifier.
   const safeState = state || {};
   const safeCtx = ctx || {};

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -199,6 +199,11 @@ function maybeSurfaceExhausted(state, retry, result) {
 function dispatchRetryAttempt(state, retry, result) {
   const attemptNumber = retry.count + 1;
   const runId = resolveRunId(state);
+  // Bug 542-22: if we can't resolve a numeric run id, infra-retry has no
+  // GitHub Actions handle to rerun. Return null so the orchestrator advances
+  // to fix-ci instead of throwing TypeError (the loop has no catch and would
+  // otherwise abort the whole follow-up workflow).
+  if (!NUMERIC_RUN_ID.test(String(runId || ''))) return null;
   // Validate before mutating state so a bad runId doesn't consume a retry.
   const delegate = buildRetryDelegate(state, runId, attemptNumber);
   retry.count = attemptNumber;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -23,19 +23,23 @@ const MAX_INFRA_RETRIES = 3;
 const NUMERIC_RUN_ID = /^\d+$/;
 
 /**
- * Decide whether the infra-retry step should short-circuit without touching
- * the classifier.
- *
- * @param {object} state
- * @returns {boolean}
+ * Categories that bypass the infra-retry step entirely — these failures are
+ * not infrastructure-related and have dedicated handling elsewhere.
  */
-function shouldBypass(state) {
-  const flag = getConfig('WORK_AUTO_RETRY_INFRA');
-  if (!flag || flag === 'false' || flag === '0') return true;
+function categoryBypass(state) {
   const cat = state && state.failureCategory;
-  if (cat === 'conflict') return true;
-  if (cat === 'review_failure') return true;
-  return false;
+  return cat === 'conflict' || cat === 'review_failure';
+}
+
+/**
+ * Feature-flag bypass. Separated from `categoryBypass` so the exhaustion +
+ * fresh-monitor gates can run even when the auto-retry feature is OFF — a
+ * ticket that already hit MAX_INFRA_RETRIES must surface `infra-stuck`
+ * regardless of the flag (Bug 542-21).
+ */
+function featureFlagOff() {
+  const flag = getConfig('WORK_AUTO_RETRY_INFRA');
+  return !flag || flag === 'false' || flag === '0';
 }
 
 /**
@@ -81,6 +85,7 @@ function maybeHandleRetrySuccess(state, ctx) {
   if (!ciStatusIsFreshSuccess(state, ctx)) return false;
   last.outcome = 'succeeded';
   process.stderr.write(`${RETRY_SUCCESS_LOG}\n`);
+  routeRetrySuccessToReport(state);
   return true;
 }
 
@@ -269,29 +274,34 @@ function routeRetrySuccessToReport(state) {
   }
 }
 
-function runInfraRetryStep(state, ctx) {
+function ensureInfraRetryRecord(state) {
   // R12: default the persisted retry record on first read.
   if (state && !state.infraRetry) {
     state.infraRetry = { count: 0, attempts: [] };
   }
+}
 
-  // Bug 542-18: handle retry-success BEFORE shouldBypass. If a prior
-  // auto-retry left a pending attempt and CI is now green, we must record the
-  // success and route to `report` even after the feature flag was disabled,
-  // so the orchestrator doesn't fall through to fix-ci dispatch.
-  if (maybeHandleRetrySuccess(state, ctx)) {
-    routeRetrySuccessToReport(state);
-    return null;
-  }
+function runInfraRetryStep(state, ctx) {
+  ensureInfraRetryRecord(state);
 
-  if (shouldBypass(state)) return null;
+  // Categories with dedicated handling elsewhere never reach infra-retry.
+  if (categoryBypass(state)) return null;
 
-  // Bug 542-16: when this step resumes from disk (e.g. a new /follow-up
-  // process after a previous infra rerun), a pending attempt still exists
-  // but `_ciStatusFreshness` belongs to the prior PID. Don't fall through to
-  // fix-ci dispatch — bounce back to `monitor` to re-poll CI. monitor will
-  // either re-confirm green (next entry hits the retry-success path with a
-  // fresh stamp) or surface the real new failure.
+  // Bug 542-18: handle retry-success BEFORE the feature-flag check. If a
+  // prior auto-retry left a pending attempt and CI is now green, record the
+  // success and route to `report` even after the feature flag was disabled.
+  // `maybeHandleRetrySuccess` performs the routing internally on success.
+  if (maybeHandleRetrySuccess(state, ctx)) return null;
+
+  // Bug 542-21: exhausted + fresh-monitor gates run BEFORE the feature-flag
+  // bypass. A ticket that already hit MAX_INFRA_RETRIES must surface
+  // `infra-stuck` regardless of the flag, and a pending retry with stale
+  // `_ciStatusFreshness` must re-poll monitor — both must not fall through
+  // to fix-ci.
+
+  // Bug 542-16: when resuming from disk after a previous infra rerun, a
+  // pending attempt exists but `_ciStatusFreshness` belongs to the prior
+  // PID. Bounce back to `monitor` to re-poll CI.
   if (needsFreshMonitorBeforeRetry(state, ctx)) {
     state.currentStep = 'monitor';
     return null;
@@ -299,6 +309,10 @@ function runInfraRetryStep(state, ctx) {
 
   const exhaustedSurface = maybeSurfaceAlreadyExhausted(state);
   if (exhaustedSurface) return exhaustedSurface;
+
+  // Feature flag off: skip the retry attempt itself, but only AFTER the
+  // exhaustion gate above has had a chance to surface infra-stuck.
+  if (featureFlagOff()) return null;
 
   // R1e / R7: consult the classifier.
   const result = classifyWithDefaults(state, ctx);

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -93,6 +93,18 @@ function shouldCheckGhActions(result) {
  * an empty-commit push instead — for environments where `--failed` is
  * unsupported (older gh, forks without write access to the run).
  */
+/**
+ * Resolve the GitHub Actions run ID to retry. monitor.js stores per-job runIds
+ * on state._ciFailedJobs[i].runId — it does NOT populate state.runId. Prefer
+ * the failed-job runId; fall back to state.runId for tests/callers that still
+ * set it explicitly.
+ */
+function resolveRunId(state) {
+  const failedJobs = Array.isArray(state && state._ciFailedJobs) ? state._ciFailedJobs : [];
+  const firstFailedRunId = failedJobs.length > 0 ? failedJobs[0].runId : null;
+  return firstFailedRunId || (state && state.runId) || null;
+}
+
 function buildRetryDelegate(state, runId, attemptNumber) {
   if (!NUMERIC_RUN_ID.test(String(runId || ''))) {
     throw new TypeError(
@@ -182,7 +194,7 @@ module.exports = function registerInfraRetry(register) {
     }
 
     const attemptNumber = retry.count + 1;
-    const runId = state.runId;
+    const runId = resolveRunId(state);
     // Validate before mutating state so a bad runId doesn't consume a retry.
     const delegate = buildRetryDelegate(state, runId, attemptNumber);
     retry.count = attemptNumber;
@@ -191,9 +203,8 @@ module.exports = function registerInfraRetry(register) {
       timestamp: new Date().toISOString(),
       runId: String(runId),
       signals: Array.isArray(result.signals) ? result.signals.slice() : [],
-      retryMethod: getConfig('WORK_INFRA_RETRY_FALLBACK') === 'empty-commit'
-        ? 'empty-commit'
-        : 'rerun-failed',
+      retryMethod:
+        getConfig('WORK_INFRA_RETRY_FALLBACK') === 'empty-commit' ? 'empty-commit' : 'rerun-failed',
       outcome: 'pending',
     });
     state.currentStep = 'monitor';

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -192,6 +192,10 @@ function dispatchRetryAttempt(state, retry, result) {
   return delegate;
 }
 
+function isInfraSuspected(result) {
+  return Boolean(result) && result.classification === 'infra-suspected';
+}
+
 function runInfraRetryStep(state, ctx) {
   // R12: default the persisted retry record on first read.
   if (state && !state.infraRetry) {
@@ -206,12 +210,14 @@ function runInfraRetryStep(state, ctx) {
   if (maybeHandleRetrySuccess(state, ctx)) return null;
 
   // R1e / R7: consult the classifier.
-  const result = classify(state || {}, ctx || {});
+  const safeState = state || {};
+  const safeCtx = ctx || {};
+  const result = classify(safeState, safeCtx);
 
   // R14: telemetry append on every classification.
   recordClassification(state, result);
 
-  if (!result || result.classification !== 'infra-suspected') return null;
+  if (!isInfraSuspected(result)) return null;
 
   const outage = maybeSurfaceGhActionsOutage(state, result);
   if (outage) return outage;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -60,21 +60,25 @@ function recordClassification(state, result) {
  * Task 7.2 (R15): when ctx signals CI is green and the last persisted attempt
  * is still `pending`, mark it `succeeded` and log the canonical literal.
  */
-function maybeHandleRetrySuccess(state, ctx) {
-  if (!state || !state.infraRetry) return false;
+function lastPendingAttempt(state) {
+  if (!state || !state.infraRetry) return null;
   const attempts = state.infraRetry.attempts;
-  if (!Array.isArray(attempts) || attempts.length === 0) return false;
+  if (!Array.isArray(attempts) || attempts.length === 0) return null;
   const last = attempts[attempts.length - 1];
-  if (!last || last.outcome !== 'pending') return false;
-  const ciStatus = ctx && ctx.ciStatus;
-  if (ciStatus !== 'success') return false;
-  // Bug 542-12: refuse to trust a persisted-stale `ciStatus`. monitor.js
-  // stamps `state._ciStatusFreshAt` with `process.uptime()` of its own
-  // process; a later process re-loading from disk has a fresh uptime clock,
-  // so the stamp won't match this process's uptime and we drop through
-  // (which forces the loop to call monitor again first).
+  if (!last || last.outcome !== 'pending') return null;
+  return last;
+}
+
+function ciStatusIsFreshSuccess(state, ctx) {
+  if (!ctx || ctx.ciStatus !== 'success') return false;
   const freshness = state._ciStatusFreshness;
-  if (!freshness || freshness.pid !== process.pid) return false;
+  return Boolean(freshness && freshness.pid === process.pid);
+}
+
+function maybeHandleRetrySuccess(state, ctx) {
+  const last = lastPendingAttempt(state);
+  if (!last) return false;
+  if (!ciStatusIsFreshSuccess(state, ctx)) return false;
   last.outcome = 'succeeded';
   process.stderr.write(`${RETRY_SUCCESS_LOG}\n`);
   return true;
@@ -211,6 +215,23 @@ function isInfraSuspected(result) {
   return Boolean(result) && result.classification === 'infra-suspected';
 }
 
+// Bug 542-14: if a prior cycle exhausted infra retries, the spec forbids
+// dispatching fix-ci even if a later classification would otherwise return
+// `code-failure`. Stay in the infra-stuck surface so the human handler
+// resolves it explicitly.
+function maybeSurfaceAlreadyExhausted(state) {
+  if (!state.infraRetry || !state.infraRetry.exhausted) return null;
+  state.failureCategory = 'infra-stuck';
+  return {
+    action: 'surface',
+    payload: {
+      reason: 'infra-stuck',
+      attempts: state.infraRetry.attempts,
+      signals: [],
+    },
+  };
+}
+
 function routeRetrySuccessToReport(state) {
   state.currentStep = 'report';
   if (state.failureCategory === 'ci_failure') {
@@ -235,21 +256,8 @@ function runInfraRetryStep(state, ctx) {
     return null;
   }
 
-  // Bug 542-14: if a prior cycle exhausted infra retries, the spec forbids
-  // dispatching fix-ci even if a later classification would otherwise return
-  // `code-failure`. Stay in the infra-stuck surface so the human handler
-  // resolves it explicitly.
-  if (state.infraRetry && state.infraRetry.exhausted) {
-    state.failureCategory = 'infra-stuck';
-    return {
-      action: 'surface',
-      payload: {
-        reason: 'infra-stuck',
-        attempts: state.infraRetry.attempts,
-        signals: [],
-      },
-    };
-  }
+  const exhaustedSurface = maybeSurfaceAlreadyExhausted(state);
+  if (exhaustedSurface) return exhaustedSurface;
 
   // R1e / R7: consult the classifier.
   const safeState = state || {};

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/infra-retry.js
@@ -26,10 +26,9 @@ const NUMERIC_RUN_ID = /^\d+$/;
  * Categories that bypass the infra-retry step entirely — these failures are
  * not infrastructure-related and have dedicated handling elsewhere.
  *
- * Note: previously gated additionally by WORK_AUTO_RETRY_INFRA env flag. The
- * flag was removed (always-on per user decision GH-508) — the signal floor
- * (≥2 of 4 INFRA_SUSPECTED_PAIRS), MAX_INFRA_RETRIES cap, and the exhaustion
- * surface are the only safeguards needed.
+ * The auto-retry feature is always on (GH-508 design decision). Safeguards:
+ * ≥2-signal floor (INFRA_SUSPECTED_PAIRS), MAX_INFRA_RETRIES cap, exhaustion
+ * surface. No env-flag opt-out.
  */
 function categoryBypass(state) {
   const cat = state && state.failureCategory;
@@ -328,17 +327,15 @@ function runInfraRetryStep(state, ctx) {
   // Categories with dedicated handling elsewhere never reach infra-retry.
   if (categoryBypass(state)) return null;
 
-  // Bug 542-18: handle retry-success BEFORE the feature-flag check. If a
-  // prior auto-retry left a pending attempt and CI is now green, record the
-  // success and route to `report` even after the feature flag was disabled.
-  // `maybeHandleRetrySuccess` performs the routing internally on success.
+  // Bug 542-18: if a prior auto-retry left a pending attempt and CI is now
+  // green, record the success and route to `report` before any other gate
+  // can fall through to fix-ci. `maybeHandleRetrySuccess` performs the
+  // routing internally on success.
   if (maybeHandleRetrySuccess(state, ctx)) return null;
 
-  // Bug 542-21: exhausted + fresh-monitor gates run BEFORE the feature-flag
-  // bypass. A ticket that already hit MAX_INFRA_RETRIES must surface
-  // `infra-stuck` regardless of the flag, and a pending retry with stale
-  // `_ciStatusFreshness` must re-poll monitor — both must not fall through
-  // to fix-ci.
+  // Bug 542-21: a ticket that already hit MAX_INFRA_RETRIES must surface
+  // `infra-stuck`, and a pending retry with stale `_ciStatusFreshness` must
+  // re-poll monitor — both must not fall through to fix-ci.
 
   // Bug 542-16: when resuming from disk after a previous infra rerun, a
   // pending attempt exists but `_ciStatusFreshness` belongs to the prior

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
@@ -445,10 +445,25 @@ module.exports = function registerMonitor(register) {
       state._ciFailedLogs = '';
     }
 
-    if (exitCode === 0) state.currentStep = 'report';
+    if (exitCode === 0) state.currentStep = computeNextStepOnGreen(state);
     return null;
   });
 };
+
+/**
+ * R15 (GH-508): when CI turns green after an infra-flake rerun, route through
+ * infra-retry so maybeHandleRetrySuccess can mark the pending attempt
+ * `succeeded` and emit the canonical retry-success log. Otherwise proceed
+ * straight to report.
+ */
+function computeNextStepOnGreen(state) {
+  const attempts = state && state.infraRetry && state.infraRetry.attempts;
+  if (Array.isArray(attempts) && attempts.length > 0) {
+    const last = attempts[attempts.length - 1];
+    if (last && last.outcome === 'pending') return 'infra-retry';
+  }
+  return 'report';
+}
 
 // test-only escape hatch — not public API. Exposes pure + shell-out helpers
 // so monitor.test.js can exercise each one in isolation.
@@ -461,4 +476,5 @@ module.exports.__test__ = {
   buildInitialFailedJobs,
   mapCiStatus,
   fetchClassifierContext,
+  computeNextStepOnGreen,
 };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
@@ -363,6 +363,37 @@ function attachJobIds(failedJobs, allJobs) {
   }
 }
 
+// Extract failing-test file paths from a CI log blob. Feeds the classifier's
+// signal3 (unrelated failures): if none of the failing tests overlap the PR
+// diff, the failure is likely infra/flake, not code the PR touched.
+//
+// Conservative by design — we'd rather miss a path than hallucinate one and
+// poison signal3. Recognised shapes:
+//   - vitest/jest:  `FAIL <path>.test.ts` or `FAIL <path>.spec.tsx (…)`
+//   - playwright:   `  × <path>.spec.ts:LINE:COL › …` (also `✘`, `✕`)
+//   - generic:      any line containing `FAIL|×|✘|✕|failed` plus a
+//                   `(plugins|apps|packages|src|tests)/.*\.(test|spec)\.[jt]sx?`
+//                   substring.
+const TEST_PATH_RE =
+  /\b((?:plugins|apps|packages|src|tests|test|e2e)\/[\w./@-]+?\.(?:test|spec)\.[jt]sx?)\b/g;
+const FAIL_MARKER_RE = /\b(FAIL|failed)\b|[×✘✕]/;
+
+function extractFailedTestPaths(rawLogs) {
+  if (typeof rawLogs !== 'string' || rawLogs.length === 0) return [];
+  const seen = new Set();
+  for (const line of rawLogs.split('\n')) {
+    if (!FAIL_MARKER_RE.test(line)) continue;
+    let m;
+    TEST_PATH_RE.lastIndex = 0;
+    while ((m = TEST_PATH_RE.exec(line)) !== null) {
+      const p = m[1];
+      if (p.startsWith('/')) continue;
+      seen.add(p);
+    }
+  }
+  return Array.from(seen);
+}
+
 // Order matters: read `j.url || j.link`. `checkCI()` renames `link → url` for
 // failed jobs that have been normalized, but legacy/un-normalized entries
 // still carry only `link`. Probing `url` first preserves the canonical name
@@ -440,9 +471,15 @@ module.exports = function registerMonitor(register) {
       // Bug C (GH-508): join databaseId from allJobs by name so each failed
       // job carries the per-job ID signal2 needs.
       attachJobIds(initialFailedJobs, classifierCtx.allJobs);
+      // PR #542 cursor[bot]: extract failing-test file paths from the raw
+      // logs so classifier signal3 has something to read. Without this,
+      // s.failedTests stays empty and the (signal3 && signal4) path can
+      // never fire from real CI data.
+      state._ciFailedTests = extractFailedTestPaths(classifierCtx.failedLogs);
     } else {
       state._ciAllJobs = [];
       state._ciFailedLogs = '';
+      state._ciFailedTests = [];
     }
 
     if (exitCode === 0) state.currentStep = computeNextStepOnGreen(state);
@@ -477,4 +514,5 @@ module.exports.__test__ = {
   mapCiStatus,
   fetchClassifierContext,
   computeNextStepOnGreen,
+  extractFailedTestPaths,
 };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
@@ -464,6 +464,9 @@ module.exports = function registerMonitor(register) {
     // depends on. Only fetch jobs+logs when CI is actually failing — passing
     // / pending runs don't need this and we want to keep the hot loop fast.
     state._ciStatus = mapCiStatus(ci.status);
+    // Bug 542-12: stamp the freshness so infra-retry can refuse a persisted
+    // _ciStatus inherited from a prior process (which could be stale).
+    state._ciStatusFreshness = { pid: process.pid, at: new Date().toISOString() };
     if (ci.status === 'failing' && initialFailedJobs.length > 0) {
       const classifierCtx = fetchClassifierContext(initialFailedJobs, ctx.worktreeDir);
       state._ciAllJobs = classifierCtx.allJobs;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
@@ -295,6 +295,74 @@ function computeExitCode(prInfo, ci, reviews) {
   return ciOk && reviewsOk && mergeOk ? 0 : 1;
 }
 
+// Map gh pr checks status → infra-classifier `ciStatus` literal ('success' /
+// 'failure' / 'in_progress'). Used by the retry-success short-circuit in
+// infra-retry.js. Bug B (GH-508): production ctx must surface this.
+function mapCiStatus(ciStatus) {
+  if (ciStatus === 'passing' || ciStatus === 'no-checks') return 'success';
+  if (ciStatus === 'failing') return 'failure';
+  return 'in_progress';
+}
+
+// Fetch all jobs + failed logs for the first failed run. Conservative: only
+// called when CI is failing AND we have a runId. The classifier's signal1
+// needs the full job list; signal2 needs the empty-log evidence; signal4
+// scans the aggregated raw logs. Bug B (GH-508).
+function fetchClassifierContext(failedJobs, worktreeDir) {
+  const out = { allJobs: [], failedLogs: '' };
+  const runId = failedJobs.find((j) => j.runId)?.runId;
+  if (!runId || !/^\d+$/.test(String(runId))) return out;
+  try {
+    const jobsRaw = execFileSync('gh', ['run', 'view', String(runId), '--json', 'jobs'], {
+      encoding: 'utf8',
+      timeout: 20000,
+      cwd: worktreeDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 5 * 1024 * 1024,
+      env: buildChildEnv(),
+    });
+    const parsed = JSON.parse(jobsRaw || '{}');
+    if (Array.isArray(parsed.jobs)) out.allJobs = parsed.jobs;
+  } catch {
+    /* fail-open — classifier will treat as empty */
+  }
+  try {
+    out.failedLogs = execFileSync('gh', ['run', 'view', String(runId), '--log-failed'], {
+      encoding: 'utf8',
+      timeout: 30000,
+      cwd: worktreeDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 10 * 1024 * 1024,
+      env: buildChildEnv(),
+    });
+  } catch (err) {
+    out.failedLogs = (err && err.stdout) || '';
+  }
+  return out;
+}
+
+// Annotate each failed job with its `jobId` (gh's databaseId) by joining the
+// failed-job list against the full job list by name. Bug C (GH-508): the
+// infra-classifier's signal2 requires a per-job ID to call
+// `gh run view <runId> --job <jobId> --log-failed`.
+function indexJobsByName(allJobs) {
+  const byName = new Map();
+  if (!Array.isArray(allJobs)) return byName;
+  for (const j of allJobs) {
+    const id = j && (j.databaseId || j.id);
+    if (j && j.name && id) byName.set(j.name, String(id));
+  }
+  return byName;
+}
+
+function attachJobIds(failedJobs, allJobs) {
+  const byName = indexJobsByName(allJobs);
+  if (byName.size === 0) return;
+  for (const fj of failedJobs) {
+    if (!fj.jobId && byName.has(fj.name)) fj.jobId = byName.get(fj.name);
+  }
+}
+
 // Order matters: read `j.url || j.link`. `checkCI()` renames `link → url` for
 // failed jobs that have been normalized, but legacy/un-normalized entries
 // still carry only `link`. Probing `url` first preserves the canonical name
@@ -361,6 +429,22 @@ module.exports = function registerMonitor(register) {
     resolveMissingRunIds(initialFailedJobs, ctx.worktreeDir);
     state._ciFailedJobs = initialFailedJobs;
 
+    // Bug B (GH-508): surface the classifier context the infra-classifier
+    // depends on. Only fetch jobs+logs when CI is actually failing — passing
+    // / pending runs don't need this and we want to keep the hot loop fast.
+    state._ciStatus = mapCiStatus(ci.status);
+    if (ci.status === 'failing' && initialFailedJobs.length > 0) {
+      const classifierCtx = fetchClassifierContext(initialFailedJobs, ctx.worktreeDir);
+      state._ciAllJobs = classifierCtx.allJobs;
+      state._ciFailedLogs = classifierCtx.failedLogs;
+      // Bug C (GH-508): join databaseId from allJobs by name so each failed
+      // job carries the per-job ID signal2 needs.
+      attachJobIds(initialFailedJobs, classifierCtx.allJobs);
+    } else {
+      state._ciAllJobs = [];
+      state._ciFailedLogs = '';
+    }
+
     if (exitCode === 0) state.currentStep = 'report';
     return null;
   });
@@ -375,4 +459,6 @@ module.exports.__test__ = {
   computeExitCode,
   resolveMissingRunIds,
   buildInitialFailedJobs,
+  mapCiStatus,
+  fetchClassifierContext,
 };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
@@ -7,6 +7,25 @@
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * Format a single infra-retry attempt into a human-readable diagnostic line.
+ * Includes the GitHub Actions run URL so the surfaced bundle is clickable.
+ * @param {{attemptNumber:number, timestamp:string, runId:string|number, signals:string[], retryMethod:string}} attempt
+ * @param {string} repoUrl - https://github.com/<owner>/<repo>
+ */
+function formatAttemptLine(attempt, repoUrl) {
+  const signals = Array.isArray(attempt.signals) ? attempt.signals.join(',') : '';
+  const runUrl = `${repoUrl}/actions/runs/${attempt.runId}`;
+  return [
+    `- attemptNumber=${attempt.attemptNumber}`,
+    `timestamp=${attempt.timestamp}`,
+    `runId=${attempt.runId}`,
+    `signals=[${signals}]`,
+    `retryMethod=${attempt.retryMethod}`,
+    `url=${runUrl}`,
+  ].join(' ');
+}
+
 module.exports = function registerReport(register) {
   register('report', (state, ctx) => {
     // Final safety net: never mark complete while the latest monitor cycle
@@ -19,6 +38,34 @@ module.exports = function registerReport(register) {
       state.failureCategory = 'conflict';
       state.currentStep = 'fix-ci';
       return null;
+    }
+
+    // R11: infra-stuck branch — surface the diagnostic bundle (run IDs as
+    // GitHub Actions URLs, signal IDs, attempt timestamps) and require
+    // manual intervention. Mirrors auto-advance's 'surface' terminal action.
+    if (state.failureCategory === 'infra-stuck') {
+      const attempts = (state.infraRetry && state.infraRetry.attempts) || [];
+      const owner = state.repoOwner || 'OWNER';
+      const repo = state.repoName || 'REPO';
+      const repoUrl = `https://github.com/${owner}/${repo}`;
+      const header = `## Infra-stuck after ${attempts.length} retries`;
+      const lines = attempts.map((a) => formatAttemptLine(a, repoUrl));
+      const body = [header, ...lines].join('\n');
+      return {
+        type: 'follow_up_instruction',
+        action: 'surface',
+        payload: {
+          reason: 'infra-stuck',
+          attempts,
+          repoUrl,
+        },
+        state: {
+          ticket: state.ticketId,
+          currentStep: 'report',
+          attempt: state.attempt,
+        },
+        summary: body,
+      };
     }
 
     // Write accountability report if it doesn't exist

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
@@ -53,57 +53,9 @@ function buildGenericSurface(state) {
   };
 }
 
-// Bug 542-11: derive repo owner/name from git remote when state didn't carry
-// them — production state never sets repoOwner/repoName, so URLs used to fall
-// back to `OWNER`/`REPO` placeholders. Tries `gh repo view` first, then parses
-// `git remote get-url origin`. Cached per-process.
-const cp = require('node:child_process');
-// Bug 542-13: cache MUST be keyed per-worktree — a single process can serve
-// multiple tickets across multiple worktrees, each pointing at a different
-// origin remote. The prior single-var cache leaked the first worktree's
-// owner/name into every subsequent ticket's diagnostic URLs.
-const _repoSlugCache = new Map();
-function detectRepoSlug(worktreeDir) {
-  const key = worktreeDir || process.cwd();
-  if (_repoSlugCache.has(key)) return _repoSlugCache.get(key);
-  const runQuiet = (cmd) => {
-    try {
-      return cp
-        .execSync(cmd, {
-          cwd: worktreeDir,
-          encoding: 'utf8',
-          timeout: 8000,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        })
-        .trim();
-    } catch {
-      return '';
-    }
-  };
-  const json = runQuiet('gh repo view --json owner,name');
-  if (json) {
-    try {
-      const parsed = JSON.parse(json);
-      if (parsed && parsed.owner && parsed.name) {
-        const slug = { owner: parsed.owner.login || parsed.owner, name: parsed.name };
-        _repoSlugCache.set(key, slug);
-        return slug;
-      }
-    } catch {
-      /* fall through to git remote parse */
-    }
-  }
-  const url = runQuiet('git remote get-url origin');
-  const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
-  if (m) {
-    const slug = { owner: m[1], name: m[2] };
-    _repoSlugCache.set(key, slug);
-    return slug;
-  }
-  const empty = { owner: null, name: null };
-  _repoSlugCache.set(key, empty);
-  return empty;
-}
+// Bug 542-11/542-13: repo owner/name derivation lives in `../repo-meta.js`
+// (shared with follow-up-next.js); per-worktree cached.
+const { detectRepoSlug } = require('../repo-meta');
 
 /** R11: infra-stuck diagnostic bundle. */
 function buildInfraStuckSurface(state, ctx) {

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
@@ -53,11 +53,56 @@ function buildGenericSurface(state) {
   };
 }
 
+// Bug 542-11: derive repo owner/name from git remote when state didn't carry
+// them — production state never sets repoOwner/repoName, so URLs used to fall
+// back to `OWNER`/`REPO` placeholders. Tries `gh repo view` first, then parses
+// `git remote get-url origin`. Cached per-process.
+const cp = require('node:child_process');
+let _repoSlug = null;
+function detectRepoSlug(worktreeDir) {
+  if (_repoSlug !== null) return _repoSlug;
+  const runQuiet = (cmd) => {
+    try {
+      return cp
+        .execSync(cmd, {
+          cwd: worktreeDir,
+          encoding: 'utf8',
+          timeout: 8000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        })
+        .trim();
+    } catch {
+      return '';
+    }
+  };
+  const json = runQuiet('gh repo view --json owner,name');
+  if (json) {
+    try {
+      const parsed = JSON.parse(json);
+      if (parsed && parsed.owner && parsed.name) {
+        _repoSlug = { owner: parsed.owner.login || parsed.owner, name: parsed.name };
+        return _repoSlug;
+      }
+    } catch {
+      /* fall through to git remote parse */
+    }
+  }
+  const url = runQuiet('git remote get-url origin');
+  const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+  if (m) {
+    _repoSlug = { owner: m[1], name: m[2] };
+    return _repoSlug;
+  }
+  _repoSlug = { owner: null, name: null };
+  return _repoSlug;
+}
+
 /** R11: infra-stuck diagnostic bundle. */
-function buildInfraStuckSurface(state) {
+function buildInfraStuckSurface(state, ctx) {
   const attempts = (state.infraRetry && state.infraRetry.attempts) || [];
-  const owner = state.repoOwner || 'OWNER';
-  const repo = state.repoName || 'REPO';
+  const slug = detectRepoSlug(ctx && ctx.worktreeDir);
+  const owner = state.repoOwner || (slug && slug.owner) || 'OWNER';
+  const repo = state.repoName || (slug && slug.name) || 'REPO';
   const repoUrl = `https://github.com/${owner}/${repo}`;
   const header = `## Infra-stuck after ${attempts.length} retries`;
   const lines = attempts.map((a) => formatAttemptLine(a, repoUrl));
@@ -92,7 +137,7 @@ module.exports = function registerReport(register) {
     }
 
     if (state.failureCategory === 'infra-stuck') {
-      return buildInfraStuckSurface(state);
+      return buildInfraStuckSurface(state, ctx);
     }
 
     // Write accountability report if it doesn't exist

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
@@ -26,13 +26,59 @@ function formatAttemptLine(attempt, repoUrl) {
   ].join(' ');
 }
 
+// Categories whose failureCategory has dedicated handling elsewhere in the
+// workflow (or is being routed to another step); not surfaced from `report`.
+const KNOWN_RESOLVABLE_CATEGORIES = new Set([
+  'infra-stuck',
+  'conflict',
+  'ci_failure',
+  'review_failure',
+]);
+
+/**
+ * Surface a generic failureCategory (e.g. 'github-actions-outage') so report
+ * does not silently mark complete. Bug 3 (GH-508).
+ */
+function buildGenericSurface(state) {
+  return {
+    type: 'follow_up_instruction',
+    action: 'surface',
+    payload: { reason: state.failureCategory },
+    state: {
+      ticket: state.ticketId,
+      currentStep: 'report',
+      attempt: state.attempt,
+    },
+    summary: `Follow-up surfaced for ${state.ticketId}: ${state.failureCategory}. Manual intervention required.`,
+  };
+}
+
+/** R11: infra-stuck diagnostic bundle. */
+function buildInfraStuckSurface(state) {
+  const attempts = (state.infraRetry && state.infraRetry.attempts) || [];
+  const owner = state.repoOwner || 'OWNER';
+  const repo = state.repoName || 'REPO';
+  const repoUrl = `https://github.com/${owner}/${repo}`;
+  const header = `## Infra-stuck after ${attempts.length} retries`;
+  const lines = attempts.map((a) => formatAttemptLine(a, repoUrl));
+  const body = [header, ...lines].join('\n');
+  return {
+    type: 'follow_up_instruction',
+    action: 'surface',
+    payload: { reason: 'infra-stuck', attempts, repoUrl },
+    state: {
+      ticket: state.ticketId,
+      currentStep: 'report',
+      attempt: state.attempt,
+    },
+    summary: body,
+  };
+}
+
 module.exports = function registerReport(register) {
   register('report', (state, ctx) => {
     // Final safety net: never mark complete while the latest monitor cycle
-    // still shows merge conflicts. Catches the case where an earlier step
-    // (triage/fix-ci) routed past a conflict without resolving it — e.g.
-    // fix-ci falling through when there were no failing CI jobs to dispatch
-    // a fix for. Send the workflow back to fix-ci instead.
+    // still shows merge conflicts.
     const lastOutput = (state.lastMonitorResult && state.lastMonitorResult.output) || '';
     if (state._isConflicting || /merge conflict|cannot be merged/i.test(lastOutput)) {
       state.failureCategory = 'conflict';
@@ -40,32 +86,13 @@ module.exports = function registerReport(register) {
       return null;
     }
 
-    // R11: infra-stuck branch — surface the diagnostic bundle (run IDs as
-    // GitHub Actions URLs, signal IDs, attempt timestamps) and require
-    // manual intervention. Mirrors auto-advance's 'surface' terminal action.
+    // Bug 3 (GH-508): unresolved surface categories must NOT mark complete.
+    if (state.failureCategory && !KNOWN_RESOLVABLE_CATEGORIES.has(state.failureCategory)) {
+      return buildGenericSurface(state);
+    }
+
     if (state.failureCategory === 'infra-stuck') {
-      const attempts = (state.infraRetry && state.infraRetry.attempts) || [];
-      const owner = state.repoOwner || 'OWNER';
-      const repo = state.repoName || 'REPO';
-      const repoUrl = `https://github.com/${owner}/${repo}`;
-      const header = `## Infra-stuck after ${attempts.length} retries`;
-      const lines = attempts.map((a) => formatAttemptLine(a, repoUrl));
-      const body = [header, ...lines].join('\n');
-      return {
-        type: 'follow_up_instruction',
-        action: 'surface',
-        payload: {
-          reason: 'infra-stuck',
-          attempts,
-          repoUrl,
-        },
-        state: {
-          ticket: state.ticketId,
-          currentStep: 'report',
-          attempt: state.attempt,
-        },
-        summary: body,
-      };
+      return buildInfraStuckSurface(state);
     }
 
     // Write accountability report if it doesn't exist

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
@@ -58,9 +58,14 @@ function buildGenericSurface(state) {
 // back to `OWNER`/`REPO` placeholders. Tries `gh repo view` first, then parses
 // `git remote get-url origin`. Cached per-process.
 const cp = require('node:child_process');
-let _repoSlug = null;
+// Bug 542-13: cache MUST be keyed per-worktree — a single process can serve
+// multiple tickets across multiple worktrees, each pointing at a different
+// origin remote. The prior single-var cache leaked the first worktree's
+// owner/name into every subsequent ticket's diagnostic URLs.
+const _repoSlugCache = new Map();
 function detectRepoSlug(worktreeDir) {
-  if (_repoSlug !== null) return _repoSlug;
+  const key = worktreeDir || process.cwd();
+  if (_repoSlugCache.has(key)) return _repoSlugCache.get(key);
   const runQuiet = (cmd) => {
     try {
       return cp
@@ -80,8 +85,9 @@ function detectRepoSlug(worktreeDir) {
     try {
       const parsed = JSON.parse(json);
       if (parsed && parsed.owner && parsed.name) {
-        _repoSlug = { owner: parsed.owner.login || parsed.owner, name: parsed.name };
-        return _repoSlug;
+        const slug = { owner: parsed.owner.login || parsed.owner, name: parsed.name };
+        _repoSlugCache.set(key, slug);
+        return slug;
       }
     } catch {
       /* fall through to git remote parse */
@@ -90,11 +96,13 @@ function detectRepoSlug(worktreeDir) {
   const url = runQuiet('git remote get-url origin');
   const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
   if (m) {
-    _repoSlug = { owner: m[1], name: m[2] };
-    return _repoSlug;
+    const slug = { owner: m[1], name: m[2] };
+    _repoSlugCache.set(key, slug);
+    return slug;
   }
-  _repoSlug = { owner: null, name: null };
-  return _repoSlug;
+  const empty = { owner: null, name: null };
+  _repoSlugCache.set(key, empty);
+  return empty;
 }
 
 /** R11: infra-stuck diagnostic bundle. */

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/triage.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/triage.js
@@ -72,7 +72,11 @@ module.exports = function registerTriage(register) {
 
     if (hasCiFailure) {
       state.failureCategory = 'ci_failure';
-      state.currentStep = 'fix-ci';
+      // Bug A (GH-508): route CI failures to infra-retry first. infra-retry's
+      // shouldBypass returns null (advance to fix-ci) when the feature flag is
+      // off, so the loop naturally falls through to fix-ci. Routing to fix-ci
+      // directly would skip infra-retry entirely when the flag is on.
+      state.currentStep = 'infra-retry';
       return null;
     }
 
@@ -110,7 +114,8 @@ module.exports = function registerTriage(register) {
     // CI cancelled: only care if it blocks the merge
     if (hasCiCancelled && isMergeBlocked && !hasBlockingReviews) {
       state.failureCategory = 'ci_cancelled_blocking';
-      state.currentStep = 'fix-ci';
+      // Bug A (GH-508): same as ci_failure — visit infra-retry first.
+      state.currentStep = 'infra-retry';
       return null;
     }
 


### PR DESCRIPTION
## Existing Behavior

- The follow-up workflow dispatches `fix-ci` immediately on any CI failure, including transient infrastructure flakes (cache misses, artifact download failures, runner setup timeouts) that are not caused by code changes.
- There is no mechanism to distinguish infrastructure flakes from genuine code/test regressions before attempting a fix.
- Retrying a flaky CI run requires manual user intervention every time.
- The `filterLogs` and `stripGhPrefix` helpers are co-located inside `fix-ci.js`, making them unavailable to other modules without circular imports.

## Intended New Behavior

- A new `infra-classifier` module evaluates four independent signals (shard runtime asymmetry, empty failed logs, unrelated test paths, setup/artifact failure patterns) before routing a CI failure. At least two signals must fire across a documented pair set to classify a run as `infra-suspected` (R7 ≥2-signal floor).
- A new `infra-retry` step is inserted between `triage` and `fix-ci` in the STEPS pipeline. When classification returns `infra-suspected`, it dispatches `gh run rerun --failed <RUN_ID>` (or an empty-commit push via `WORK_INFRA_RETRY_FALLBACK=empty-commit`) up to 3 times before giving up.
- After 3 exhausted retries, the workflow sets `failureCategory = 'infra-stuck'`, surfaces a diagnostic bundle (GitHub Actions run URLs, signal IDs, attempt timestamps) to the user, and does NOT dispatch `fix-ci`.
- Signal 4 with ≥2 failing jobs triggers a synchronous `githubstatus.com` cross-check via `gh-actions-status.js`; a confirmed platform-wide Actions outage surfaces immediately without consuming any retry budget.
- Every classification produces a telemetry entry appended to `state.history[]` with `{ timestamp, signals, decision, outcome }` (R14). Outcome transitions: `dispatched` → `succeeded` / `failed` / `exhausted`, plus `no-retry` for code-failure classifications. A retry-success confirmation is written to stderr with the canonical literal `auto-retry: infra flake confirmed` (R15).
- Log-processing helpers (`stripGhPrefix`, `filterLogs`) are extracted into `log-utils.js`, shared by both `fix-ci` and `infra-classifier` without circular dependencies.
- **Auto-retry is always on** (no opt-in env flag). Safeguards: `conflict` and `review_failure` categories always bypass; INFRA_SUSPECTED_PAIRS requires ≥2 of 4 signals; MAX_INFRA_RETRIES=3 cap; exhaustion surface. The `WORK_AUTO_RETRY_INFRA` flag was removed in commit `a0b332829` per design decision — opt-in via env var is meaningless once the user installs the plugin, and the multi-signal floor is the real safeguard against false positives.
- `follow-up-auto-advance.js` handles the new `surface` action (R13), treating it as terminal (same as `blocked`) and printing a structured `FOLLOW-UP2: SURFACE` banner so the orchestrator stops the auto-advance loop and waits for manual intervention.

## Dev Checks
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Auto-retry is always on — no env flag required to enable.

**Backend — infra-classifier signal verification:**

1. Start a follow-up session for any ticket whose last CI run failed on a setup/cache step.
2. Observe `follow-up-next.js` output — when ≥2 signals fire, the step name `infra-retry` should appear in the returned instruction JSON.
3. Confirm `state.history[]` gains a new entry with `{ timestamp, signals, decision: "infra-suspected", outcome: "dispatched" }`.

**Backend — retry exhaustion / infra-stuck surface:**

1. Arrange a ticket whose CI run continuously fails with infra signals.
2. Invoke `follow-up-next.js` three times for the same ticket.
3. On the fourth call, confirm the response contains `action: "surface"` with `reason: "infra-stuck"` and a `summary` listing all three attempt URLs.
4. Confirm `fix-ci` is NOT dispatched.

**Backend — GitHub Actions outage early-surface (Signal 4, ≥2 jobs):**

1. Mock `gh-actions-status.js` to return `{ degraded: true }` or point `GITHUBSTATUS_URL` at a stub server.
2. Trigger a CI failure with two or more failing jobs matching Signal 4 patterns.
3. Confirm the workflow returns `action: "surface"` with `reason: "github-actions-outage"` before incrementing `infraRetry.count`.

**Backend — category bypass:**

1. Trigger a CI failure with `failureCategory: 'conflict'` or `failureCategory: 'review_failure'`.
2. Confirm `infra-retry` step returns `null` and the workflow advances normally to the dedicated handler.

### Test Results

142 follow-up tests pass (all new and pre-existing). New test files:

- `__tests__/infra-classifier.test.js` — signal collectors + `classify()` matrix (incl. Bug 542-23/25 regression cases for jobId↔databaseId match and median-exclusion fix)
- `__tests__/infra-retry-step.test.js` — retry state machine, bypass logic, exhaustion, outage detection, missing-runId guard (5c), pending-attempt close (5d)
- `__tests__/infra-retry-telemetry.test.js` — R14/R15 telemetry, outcome transitions (succeeded/exhausted), retry-success stderr
- `__tests__/log-utils.test.js` + `__tests__/log-utils-regression.test.js` — `stripGhPrefix`, `filterLogs` predicate byte-equivalence
- `__tests__/report-infra-stuck.test.js` — `report` step infra-stuck branch
- `__tests__/step-registry-infra.test.js` + `__tests__/step-registry-dispatch-smoke.test.js` — `infra-retry` wired into STEPS pipeline, dispatchStepResult decision table
- `__tests__/follow-up-auto-advance-surface.test.js` — auto-advance `surface` action handling
- `__tests__/repo-meta-smoke.test.js`, `__tests__/classifier-ctx-smoke.test.js` — isolated-require smoke tests for the extracted lib modules

Closes #508

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CI failure routing and can auto-rerun GitHub Actions or surface stuck workflows; safeguards are signal pairs and retry caps, but misclassification could delay fix-ci or retry real failures.
> 
> **Overview**
> CI failures in the follow-up workflow now go through **`infra-retry`** before **`fix-ci`**: triage routes `ci_failure` and blocking `ci_cancelled` to the new step, and the step pipeline adds `infra-retry` after triage.
> 
> A new **`infra-classifier`** scores four signals (shard asymmetry, empty failed logs, unrelated failing tests vs PR diff, setup/cache log patterns) and requires **≥2 paired signals** for `infra-suspected`. **`monitor`** fills classifier state (`_ciAllJobs`, logs, job IDs, failed test paths, mapped CI status); **`follow-up-next`** rebuilds classifier **ctx** each loop turn and persists **`surface`** reasons on `failureCategory`. **`repo-meta`** fixes default-branch PR diffs (no hardcoded `origin/main`).
> 
> **`infra-retry`** dispatches up to **3** `gh run rerun --failed` retries, records **`state.history`** telemetry, can surface **`github-actions-outage`** via githubstatus.com, and on exhaustion sets **`infra-stuck`** with a diagnostic report instead of dispatching fix-ci. Green CI after a pending retry routes monitor → infra-retry for retry-success handling. **`follow-up-auto-advance`** treats **`action: surface`** as terminal like `blocked`. Log filtering moves to shared **`log-utils`** (used by fix-ci and the classifier).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b678f1ba4c3110cb6b9a6683d5adb94048eccaec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->