### PR TITLE
feat(synapsys): exclude_prompt / exclude_pretool / exclude_preset negative trigger gating (GH-510)

### DIFF
--- a/plugins/synapsys/lib/__tests__/dispatcher-golden.test.js
+++ b/plugins/synapsys/lib/__tests__/dispatcher-golden.test.js
@@ -25,7 +25,11 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+const { listMemoriesFromStore } = require('../memory-store');
+const { matchPrompt } = require('../matcher');
+
 const DISPATCHER = path.resolve(__dirname, '..', '..', 'hooks', 'synapsys.js');
+const PRESETS_PATH = path.resolve(__dirname, '..', 'synapsys-presets.json');
 
 const MEMORY_NAME = 'golden-prompt-memory';
 const KNOWN_PROMPT = 'golden dispatcher regression prompt';
@@ -68,6 +72,68 @@ function makeFixtureStore() {
 
   return { cwd, cleanup: () => fs.rmSync(cwd, { recursive: true, force: true }) };
 }
+
+// GH-510 R20 / Task 2.2 — exclude-matched golden row.
+//
+// Contract: when a memory's `trigger_prompt` hits AND its resolved exclude
+// list (from `exclude_preset: git-ops`) also matches the same prompt, the
+// matcher MUST emit:
+//   { fired: false, reason: 'exclude-matched',
+//     matched: { excluded_pattern: <git-ops body resolved from presets.json> } }
+//
+// The asserted `excluded_pattern` is read from the shipped
+// `synapsys-presets.json` at test time so the row stays in sync if the
+// preset body is ever edited (hard-coding the regex would silently drift).
+function makeExcludeFixtureStore() {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-dispatcher-exclude-'));
+  const storeDir = path.join(cwd, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'dispatcher-exclude-fixture' })
+  );
+
+  const memoryFile = path.join(storeDir, 'golden-exclude-memory.md');
+  const frontmatter = [
+    '---',
+    'name: golden-exclude-memory',
+    'description: Golden regression memory for exclude-matched reason.',
+    'events: UserPromptSubmit',
+    'trigger_prompt: \\bticket\\b',
+    'exclude_preset: git-ops',
+    'inject: full',
+    '---',
+    '',
+    'Body for exclude-matched golden row.',
+    '',
+  ].join('\n');
+  fs.writeFileSync(memoryFile, frontmatter);
+
+  return { cwd, storeDir, cleanup: () => fs.rmSync(cwd, { recursive: true, force: true }) };
+}
+
+test('matcher emits {fired:false, reason:exclude-matched, excluded_pattern:<git-ops body>} when trigger and git-ops preset both hit', (t) => {
+  const { storeDir, cleanup } = makeExcludeFixtureStore();
+  t.after(cleanup);
+
+  const gitOpsBody = JSON.parse(fs.readFileSync(PRESETS_PATH, 'utf8'))['git-ops'];
+  assert.ok(gitOpsBody, 'git-ops preset body must exist in synapsys-presets.json');
+
+  const memories = listMemoriesFromStore({
+    kind: 'local',
+    dir: storeDir,
+    projectName: 'dispatcher-exclude-fixture',
+  });
+  assert.equal(memories.length, 1, 'expected exactly one fixture memory');
+  const memory = memories[0];
+
+  const result = matchPrompt(memory, 'git rebase the ticket branch');
+  assert.deepEqual(result, {
+    fired: false,
+    reason: 'exclude-matched',
+    matched: { excluded_pattern: gitOpsBody },
+  });
+});
 
 test('dispatcher stdout for UserPromptSubmit payload matches golden', (t) => {
   const { cwd, cleanup } = makeFixtureStore();

--- a/plugins/synapsys/lib/__tests__/exclude-preset-multi.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/exclude-preset-multi.integration.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * GH-510 retrofit fallback — proves multi-preset `exclude_preset` composition.
+ *
+ * The brief's preferred retrofit candidate
+ * (`linear-no-external-refs-cortex-instead`) is not shipped under
+ * `plugins/synapsys/` version control, so this test instead exercises a
+ * new fixture that adopts BOTH `git-ops` and `ci-monitor` presets at once.
+ *
+ * Contract:
+ *   - `excludePreset` round-trips to the parsed CSV
+ *   - `excludeResolved` carries one entry per resolved preset (length === 2)
+ *   - prompts matching EITHER preset are suppressed with reason
+ *     `exclude-matched`
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { listMemoriesFromStore } = require('../memory-store');
+const { matchPrompt } = require('../matcher');
+
+const FIXTURE_DIR = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'tests',
+  'fixtures',
+  'store-exclude-multi-preset'
+);
+
+function loadFixture() {
+  const store = { kind: 'local', dir: FIXTURE_DIR, projectName: 'multi-preset' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1, 'expected exactly one fixture memory');
+  return memories[0];
+}
+
+test('multi-preset fixture parses exclude_preset CSV into both names', () => {
+  const m = loadFixture();
+  assert.deepEqual(m.excludePreset, ['git-ops', 'ci-monitor']);
+});
+
+test('multi-preset fixture resolves both presets into excludeResolved (length === 2)', () => {
+  const m = loadFixture();
+  assert.ok(Array.isArray(m.excludeResolved));
+  assert.equal(
+    m.excludeResolved.length,
+    2,
+    'excludeResolved must carry one body per resolved preset'
+  );
+});
+
+test('git-ops prompt is suppressed (exclude-matched)', () => {
+  const m = loadFixture();
+  const r = matchPrompt(m, 'git rebase the ticket branch');
+  assert.equal(r.fired, false);
+  assert.equal(r.reason, 'exclude-matched');
+});
+
+test('ci-monitor prompt is suppressed (exclude-matched)', () => {
+  const m = loadFixture();
+  const r = matchPrompt(m, 'gh run watch the linear ticket job');
+  assert.equal(r.fired, false);
+  assert.equal(r.reason, 'exclude-matched');
+});
+
+test('non-excluded ticket prompt still fires', () => {
+  const m = loadFixture();
+  const r = matchPrompt(m, 'open the ticket and read the description');
+  assert.equal(r.fired, true);
+});

--- a/plugins/synapsys/lib/__tests__/exclude-preset-worked-example.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/exclude-preset-worked-example.integration.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/**
+ * GH-510 Task 5 — Worked example: a fixture memory adopts
+ * `exclude_preset: git-ops` so the end-to-end load → match → suppression
+ * flow is exercised against the shipped preset bundle.
+ *
+ * The fixture lives under `plugins/synapsys/tests/fixtures/` so the docs
+ * in Task 6 can link to it as the canonical worked example for R7.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { listMemoriesFromStore } = require('../memory-store');
+const { matchPrompt } = require('../matcher');
+
+const FIXTURE_DIR = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'tests',
+  'fixtures',
+  'store-exclude-worked-example'
+);
+const FIXTURE_FILE = path.join(FIXTURE_DIR, 'mem-worked-example.md');
+
+test('worked-example fixture file exists under tests/fixtures/', () => {
+  assert.ok(
+    fs.existsSync(FIXTURE_FILE),
+    `worked-example fixture missing at ${FIXTURE_FILE}`
+  );
+});
+
+test('loading the worked-example store yields excludePreset=[git-ops] with non-empty excludeResolved', () => {
+  const store = {
+    kind: 'local',
+    dir: FIXTURE_DIR,
+    projectName: 'worked-example',
+  };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1, 'expected exactly one fixture memory');
+  const m = memories[0];
+  assert.deepEqual(m.excludePreset, ['git-ops']);
+  assert.ok(
+    Array.isArray(m.excludeResolved) && m.excludeResolved.length > 0,
+    'excludeResolved must be populated from the git-ops preset'
+  );
+});
+
+test('a `git rebase` prompt that hits trigger_prompt is suppressed with reason exclude-matched', () => {
+  const store = {
+    kind: 'local',
+    dir: FIXTURE_DIR,
+    projectName: 'worked-example',
+  };
+  const memories = listMemoriesFromStore(store);
+  const m = memories[0];
+  const result = matchPrompt(m, 'git rebase the ticket branch');
+  assert.equal(result.fired, false);
+  assert.equal(result.reason, 'exclude-matched');
+  assert.ok(
+    result.matched && typeof result.matched.excluded_pattern === 'string',
+    'matched.excluded_pattern must be present'
+  );
+});
+
+test('a non-git prompt that hits trigger_prompt fires normally', () => {
+  const store = {
+    kind: 'local',
+    dir: FIXTURE_DIR,
+    projectName: 'worked-example',
+  };
+  const memories = listMemoriesFromStore(store);
+  const m = memories[0];
+  const result = matchPrompt(m, 'open the ticket and read the description');
+  assert.equal(result.fired, true, 'non-git prompt must fire (no exclude match)');
+});

--- a/plugins/synapsys/lib/__tests__/exclude-prompt-pretool.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/exclude-prompt-pretool.integration.test.js
@@ -70,12 +70,6 @@ function writeMemory(store, basename, frontmatterLines, body = 'Body line.') {
   return file;
 }
 
-const BASE_MEMORY = {
-  events: ['UserPromptSubmit'],
-  disabled: false,
-  expired: false,
-};
-
 // ---------------------------------------------------------------------------
 // Direct helper assertions
 // ---------------------------------------------------------------------------

--- a/plugins/synapsys/lib/__tests__/exclude-prompt-pretool.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/exclude-prompt-pretool.integration.test.js
@@ -1,0 +1,320 @@
+'use strict';
+
+/**
+ * Integration tests for GH-510 Task 2 — exclude_prompt / exclude_pretool /
+ * exclude_preset gating in matcher.js.
+ *
+ * Six scenarios mirror Feature: synapsys exclude gating in gherkin.feature:
+ *   1. positive trigger fires when no exclude matches
+ *   2. exclude_prompt suppresses a positive trigger match
+ *   3. exclude_pretool suppresses a positive pretool match
+ *   4. exclude_preset resolves named bundle from synapsys-presets.json
+ *   5. invalid exclude regex is skipped without aborting the matcher
+ *   6. backwards-compat: memories without exclude_* fields behave identically
+ *
+ * Plus direct-helper assertions on evaluateExcludePrompt /
+ * evaluateExcludePretool / hasExcludePatterns.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const matcherModule = require('../matcher');
+const {
+  matchPrompt,
+  matchPreTool,
+  matchPreToolResult,
+  evaluateExcludePrompt,
+  evaluateExcludePretool,
+  hasExcludePatterns,
+} = matcherModule;
+const { listMemoriesFromStore, resolvePreset } = require('../memory-store');
+
+function captureStderr(fn) {
+  const orig = process.stderr.write.bind(process.stderr);
+  const chunks = [];
+  process.stderr.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+  try {
+    const ret = fn();
+    return { ret, stderr: chunks.join('') };
+  } finally {
+    process.stderr.write = orig;
+  }
+}
+
+function makeStoreDir(label) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `synapsys-exclude-${label}-`));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: `exclude-${label}-fixture` })
+  );
+  return {
+    cwd: dir,
+    store: { kind: 'local', dir: storeDir, projectName: `exclude-${label}-fixture` },
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function writeMemory(store, basename, frontmatterLines, body = 'Body line.') {
+  const file = path.join(store.dir, `${basename}.md`);
+  const content = ['---', ...frontmatterLines, '---', '', body, ''].join('\n');
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+const BASE_MEMORY = {
+  events: ['UserPromptSubmit'],
+  disabled: false,
+  expired: false,
+};
+
+// ---------------------------------------------------------------------------
+// Direct helper assertions
+// ---------------------------------------------------------------------------
+
+test('evaluateExcludePrompt returns {excluded:true, pattern} when a resolved pattern matches', () => {
+  const mem = { name: 'mem-x', excludeResolved: ['\\bgit\\s+merge\\b'] };
+  const r = evaluateExcludePrompt(mem, 'git merge feature');
+  assert.deepEqual(r, { excluded: true, pattern: '\\bgit\\s+merge\\b' });
+});
+
+test('evaluateExcludePrompt returns {excluded:false, pattern:null} when no pattern matches', () => {
+  const mem = { name: 'mem-x', excludeResolved: ['\\bgit\\s+merge\\b'] };
+  const r = evaluateExcludePrompt(mem, 'review the PR');
+  assert.deepEqual(r, { excluded: false, pattern: null });
+});
+
+test('evaluateExcludePrompt returns {excluded:false, pattern:null} on empty/missing excludeResolved', () => {
+  assert.deepEqual(evaluateExcludePrompt({ name: 'a' }, 'anything'), {
+    excluded: false,
+    pattern: null,
+  });
+  assert.deepEqual(evaluateExcludePrompt({ name: 'b', excludeResolved: [] }, 'anything'), {
+    excluded: false,
+    pattern: null,
+  });
+});
+
+test('evaluateExcludePrompt: invalid regex is skipped with stderr warning; remaining patterns still gate', () => {
+  const mem = { name: 'mem-mixed', excludeResolved: ['(unclosed', '\\bgit\\s+merge\\b'] };
+  const { ret, stderr } = captureStderr(() => evaluateExcludePrompt(mem, 'git merge x'));
+  assert.deepEqual(ret, { excluded: true, pattern: '\\bgit\\s+merge\\b' });
+  assert.match(stderr, /\[synapsys\]/);
+  assert.match(stderr, /invalid exclude/i);
+  assert.match(stderr, /\(unclosed/);
+});
+
+test('evaluateExcludePretool returns {excluded:true, pattern} when a spec matches tool+argblob', () => {
+  const mem = {
+    name: 'mem-pt',
+    excludePretool: ['Bash:git\\s+(merge|push|rebase)'],
+  };
+  const r = evaluateExcludePretool(mem, 'Bash', JSON.stringify({ command: 'git merge main' }));
+  assert.deepEqual(r, { excluded: true, pattern: 'Bash:git\\s+(merge|push|rebase)' });
+});
+
+test('evaluateExcludePretool returns {excluded:false, pattern:null} when tool name does not match spec', () => {
+  const mem = { name: 'mem-pt', excludePretool: ['Bash:git\\s+merge'] };
+  const r = evaluateExcludePretool(mem, 'Edit', JSON.stringify({ new_string: 'git merge' }));
+  assert.deepEqual(r, { excluded: false, pattern: null });
+});
+
+test('evaluateExcludePretool returns {excluded:false, pattern:null} on empty/missing excludePretool', () => {
+  assert.deepEqual(evaluateExcludePretool({ name: 'a' }, 'Bash', '{}'), {
+    excluded: false,
+    pattern: null,
+  });
+});
+
+test('hasExcludePatterns returns true iff excludeResolved or excludePretool is non-empty', () => {
+  assert.equal(hasExcludePatterns({ name: 'a' }), false);
+  assert.equal(hasExcludePatterns({ name: 'b', excludeResolved: [], excludePretool: [] }), false);
+  assert.equal(hasExcludePatterns({ name: 'c', excludeResolved: ['x'] }), true);
+  assert.equal(hasExcludePatterns({ name: 'd', excludePretool: ['Bash:x'] }), true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1: positive trigger fires when no exclude matches
+// ---------------------------------------------------------------------------
+
+test('Scenario 1: positive trigger fires when no exclude matches', (t) => {
+  const fx = makeStoreDir('s1');
+  t.after(fx.cleanup);
+  writeMemory(fx.store, 'mem', [
+    'name: mem',
+    'events: UserPromptSubmit',
+    'trigger_prompt: \\blinear\\b',
+    'exclude_prompt: \\bgit\\s+merge\\b',
+  ]);
+  const [mem] = listMemoriesFromStore(fx.store);
+  const result = matchPrompt(mem, 'fetch the linear ticket');
+  assert.equal(result.fired, true);
+  assert.equal(result.reason, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: exclude_prompt suppresses a positive trigger match
+// ---------------------------------------------------------------------------
+
+test('Scenario 2: exclude_prompt suppresses a positive trigger match', (t) => {
+  const fx = makeStoreDir('s2');
+  t.after(fx.cleanup);
+  writeMemory(fx.store, 'mem', [
+    'name: mem',
+    'events: UserPromptSubmit',
+    'trigger_prompt: \\blinear\\b',
+    'exclude_prompt: \\bgit\\s+merge\\b',
+  ]);
+  const [mem] = listMemoriesFromStore(fx.store);
+  const result = matchPrompt(mem, 'git merge linear branch into main');
+  assert.equal(result.fired, false);
+  assert.equal(result.reason, 'exclude-matched');
+  assert.ok(result.matched);
+  assert.match(result.matched.excluded_pattern, /git\\s\+merge/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: exclude_pretool suppresses a positive pretool match
+// ---------------------------------------------------------------------------
+
+test('Scenario 3: exclude_pretool suppresses a positive pretool match', (t) => {
+  const fx = makeStoreDir('s3');
+  t.after(fx.cleanup);
+  writeMemory(fx.store, 'mem', [
+    'name: mem',
+    'events: PreToolUse',
+    'trigger_pretool: Bash:git',
+    'exclude_pretool: Bash:git\\s+(merge|push|rebase)',
+  ]);
+  const [mem] = listMemoriesFromStore(fx.store);
+  const payload = {
+    tool_name: 'Bash',
+    tool_input: { command: 'git merge feature' },
+  };
+  const result = matchPreTool(mem, payload);
+  assert.equal(result.fired, false);
+  assert.equal(result.reason, 'exclude-matched');
+  assert.ok(result.matched);
+  assert.match(result.matched.excluded_pattern, /merge|push|rebase/);
+
+  // matchPreToolResult mirrors the same shape
+  const rResult = matchPreToolResult(mem, payload);
+  assert.equal(rResult.reason, 'exclude-matched');
+  assert.ok(rResult.matched.excluded_pattern);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4: exclude_preset resolves named bundle from synapsys-presets.json
+// ---------------------------------------------------------------------------
+
+test('Scenario 4: exclude_preset resolves named bundle and suppresses match', (t) => {
+  const fx = makeStoreDir('s4');
+  t.after(fx.cleanup);
+  writeMemory(fx.store, 'mem', [
+    'name: mem',
+    'events: UserPromptSubmit',
+    'trigger_prompt: \\bticket\\b',
+    'exclude_preset: git-ops',
+  ]);
+  const [mem] = listMemoriesFromStore(fx.store);
+  assert.deepEqual(mem.excludePreset, ['git-ops']);
+  assert.ok(mem.excludeResolved.length > 0, 'preset should be resolved into excludeResolved');
+
+  const result = matchPrompt(mem, 'git rebase the ticket branch');
+  assert.equal(result.fired, false);
+  assert.equal(result.reason, 'exclude-matched');
+  const gitOpsBody = resolvePreset('git-ops');
+  assert.equal(
+    result.matched.excluded_pattern,
+    gitOpsBody,
+    'excluded_pattern should be the git-ops preset body'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 5: invalid exclude regex is skipped without aborting the matcher
+// ---------------------------------------------------------------------------
+
+test('Scenario 5: invalid exclude regex is skipped with stderr warning; remaining presets still gate', (t) => {
+  const fx = makeStoreDir('s5');
+  t.after(fx.cleanup);
+  writeMemory(fx.store, 'mem', [
+    'name: mem',
+    'events: UserPromptSubmit',
+    'trigger_prompt: \\bdeploy\\b',
+    "exclude_prompt: '(unclosed'",
+    'exclude_preset: ci-monitor',
+  ]);
+  const [mem] = listMemoriesFromStore(fx.store);
+  const { ret, stderr } = captureStderr(() =>
+    matchPrompt(mem, 'gh run watch the deploy workflow')
+  );
+  assert.equal(ret.fired, false);
+  assert.equal(ret.reason, 'exclude-matched');
+  assert.match(stderr, /\[synapsys\]/);
+  assert.match(stderr, /invalid exclude/i);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 6: backwards compatibility — no exclude_* fields behave identically
+// ---------------------------------------------------------------------------
+
+test('Scenario 6: memories without any exclude_* field behave identically (backwards-compat)', (t) => {
+  const fx = makeStoreDir('s6');
+  t.after(fx.cleanup);
+  writeMemory(fx.store, 'mem', [
+    'name: mem',
+    'events: UserPromptSubmit',
+    'trigger_prompt: \\bticket\\b',
+  ]);
+  const [mem] = listMemoriesFromStore(fx.store);
+  assert.deepEqual(mem.excludeResolved, []);
+  assert.deepEqual(mem.excludePretool, []);
+
+  const result = matchPrompt(mem, 'open the ticket linked in the PR');
+  assert.equal(result.fired, true);
+  assert.equal(result.reason, undefined);
+  // Matched contract identical to today: prompt_token + prompt_substring only.
+  assert.ok(result.matched);
+  assert.ok(result.matched.prompt_token);
+  assert.ok(result.matched.prompt_substring);
+  assert.equal(result.matched.excluded_pattern, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Bonus: exclude composes with GH-445 content-not without conflict
+// ---------------------------------------------------------------------------
+
+test('Bonus: exclude composes with content-not; negative-excludes retains priority', (t) => {
+  const fx = makeStoreDir('compose');
+  t.after(fx.cleanup);
+  writeMemory(fx.store, 'mem', [
+    'name: mem',
+    'events: PreToolUse',
+    'trigger_pretool: Edit:.*',
+    'trigger_pretool_content: import React',
+    'trigger_pretool_content_not: alreadyImported',
+    'exclude_pretool: Bash:git\\s+merge',
+  ]);
+  const [mem] = listMemoriesFromStore(fx.store);
+  // Edit payload with alreadyImported in content -> negative-excludes path
+  const payload = {
+    tool_name: 'Edit',
+    tool_input: { new_string: 'import React; // alreadyImported' },
+  };
+  const result = matchPreTool(mem, payload);
+  assert.equal(result.fired, false);
+  assert.equal(
+    result.reason,
+    'negative-excludes',
+    'negative-excludes from content-not must take priority over exclude-matched'
+  );
+});

--- a/plugins/synapsys/lib/__tests__/memory-store-exclude.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/memory-store-exclude.integration.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { listMemoriesFromStore } = require('../memory-store');
+
+function makeTempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-memstore-exclude-'));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'test' })
+  );
+  return { cwd: dir, storeDir };
+}
+
+function writeMemory(storeDir, name, frontmatter) {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  const content = `---\n${fm}\n---\nbody\n`;
+  fs.writeFileSync(path.join(storeDir, name), content);
+}
+
+function captureStderr(fn) {
+  const orig = process.stderr.write.bind(process.stderr);
+  const chunks = [];
+  process.stderr.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+  try {
+    const ret = fn();
+    return { ret, stderr: chunks.join('') };
+  } finally {
+    process.stderr.write = orig;
+  }
+}
+
+// --- 1.2.1 RED assertions ---
+
+test('readMemoryFile parses exclude_prompt, exclude_pretool, exclude_preset into memory object', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'ex.md', {
+    name: 'ex',
+    description: 'd',
+    exclude_prompt: '\\bfoo\\b',
+    exclude_pretool: 'Bash:bar',
+    exclude_preset: 'git-ops',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  const m = memories[0];
+  assert.equal(m.excludePrompt, '\\bfoo\\b');
+  assert.deepEqual(m.excludePretool, ['Bash:bar']);
+  assert.deepEqual(m.excludePreset, ['git-ops']);
+  assert.ok(Array.isArray(m.excludeResolved), 'excludeResolved must be an array');
+  // Must contain the explicit excludePrompt regex body.
+  assert.ok(
+    m.excludeResolved.includes('\\bfoo\\b'),
+    'excludeResolved must include excludePrompt regex body'
+  );
+  // Must contain at least the git-ops preset resolution (non-empty string).
+  assert.ok(
+    m.excludeResolved.length >= 2,
+    'excludeResolved must include at least the prompt body and the git-ops preset'
+  );
+});
+
+test('unknown preset name in exclude_preset emits one stderr warning at load time', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'unk.md', {
+    name: 'unk',
+    description: 'd',
+    exclude_preset: '[git-ops, does-not-exist]',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const { ret: memories, stderr } = captureStderr(() => listMemoriesFromStore(store));
+  assert.equal(memories.length, 1);
+  assert.deepEqual(memories[0].excludePreset, ['git-ops', 'does-not-exist']);
+  assert.match(stderr, /does-not-exist/);
+});
+
+test('memory without any exclude_* field defaults to empty values (backwards compat)', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'plain.md', {
+    name: 'plain',
+    description: 'd',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  const m = memories[0];
+  assert.equal(m.excludePrompt, '');
+  assert.deepEqual(m.excludePretool, []);
+  assert.deepEqual(m.excludePreset, []);
+  assert.deepEqual(m.excludeResolved, []);
+});

--- a/plugins/synapsys/lib/__tests__/presets-loader.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/presets-loader.integration.test.js
@@ -39,9 +39,8 @@ function withPresetsFile(replacement, fn) {
     return fn(fresh);
   } finally {
     if (original === null) {
-      try {
-        fs.unlinkSync(PRESETS_PATH);
-      } catch (_) {}
+      // rmSync with force:true is idempotent: no check-then-act, no throw on ENOENT.
+      fs.rmSync(PRESETS_PATH, { force: true });
     } else {
       fs.writeFileSync(PRESETS_PATH, original);
     }

--- a/plugins/synapsys/lib/__tests__/presets-loader.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/presets-loader.integration.test.js
@@ -25,7 +25,12 @@ function captureStderr(fn) {
 const PRESETS_PATH = path.join(__dirname, '..', 'synapsys-presets.json');
 
 function withPresetsFile(replacement, fn) {
-  const original = fs.existsSync(PRESETS_PATH) ? fs.readFileSync(PRESETS_PATH, 'utf8') : null;
+  let original = null;
+  try {
+    original = fs.readFileSync(PRESETS_PATH, 'utf8');
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
   try {
     fs.writeFileSync(PRESETS_PATH, replacement);
     // Bust require cache so loadPresets re-reads from disk.

--- a/plugins/synapsys/lib/__tests__/presets-loader.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/presets-loader.integration.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const memoryStore = require('../memory-store');
+
+function captureStderr(fn) {
+  const orig = process.stderr.write.bind(process.stderr);
+  const chunks = [];
+  process.stderr.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+  try {
+    const ret = fn();
+    return { ret, stderr: chunks.join('') };
+  } finally {
+    process.stderr.write = orig;
+  }
+}
+
+const PRESETS_PATH = path.join(__dirname, '..', 'synapsys-presets.json');
+
+function withPresetsFile(replacement, fn) {
+  const original = fs.existsSync(PRESETS_PATH) ? fs.readFileSync(PRESETS_PATH, 'utf8') : null;
+  try {
+    fs.writeFileSync(PRESETS_PATH, replacement);
+    // Bust require cache so loadPresets re-reads from disk.
+    delete require.cache[require.resolve('../memory-store')];
+    const fresh = require('../memory-store');
+    return fn(fresh);
+  } finally {
+    if (original === null) {
+      try {
+        fs.unlinkSync(PRESETS_PATH);
+      } catch (_) {}
+    } else {
+      fs.writeFileSync(PRESETS_PATH, original);
+    }
+    delete require.cache[require.resolve('../memory-store')];
+  }
+}
+
+// --- 1.1.1 RED assertions ---
+
+test('loadPresets() returns a Map containing git-ops, ci-monitor, review-comment-handling', () => {
+  const { loadPresets } = memoryStore;
+  assert.equal(typeof loadPresets, 'function', 'loadPresets must be exported');
+  const presets = loadPresets();
+  assert.ok(presets instanceof Map, 'loadPresets must return a Map');
+  assert.ok(presets.has('git-ops'), 'preset "git-ops" must be present');
+  assert.ok(presets.has('ci-monitor'), 'preset "ci-monitor" must be present');
+  assert.ok(
+    presets.has('review-comment-handling'),
+    'preset "review-comment-handling" must be present'
+  );
+});
+
+test('resolvePreset("git-ops") returns a non-empty regex string', () => {
+  const { resolvePreset } = memoryStore;
+  assert.equal(typeof resolvePreset, 'function', 'resolvePreset must be exported');
+  const body = resolvePreset('git-ops');
+  assert.equal(typeof body, 'string');
+  assert.ok(body.length > 0, 'git-ops preset must resolve to a non-empty string');
+});
+
+test('resolvePreset("does-not-exist") returns null and emits stderr warning', () => {
+  const { resolvePreset } = memoryStore;
+  const { ret, stderr } = captureStderr(() => resolvePreset('does-not-exist'));
+  assert.equal(ret, null);
+  assert.match(stderr, /does-not-exist/);
+});
+
+test('malformed synapsys-presets.json: loadPresets returns empty Map + stderr warning', () => {
+  withPresetsFile('{not valid json', (fresh) => {
+    const { ret, stderr } = captureStderr(() => fresh.loadPresets());
+    assert.ok(ret instanceof Map, 'loadPresets must still return a Map on bad JSON');
+    assert.equal(ret.size, 0, 'malformed JSON must degrade to empty Map');
+    assert.match(stderr, /presets\.json invalid/);
+  });
+});

--- a/plugins/synapsys/lib/__tests__/presets-loader.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/presets-loader.integration.test.js
@@ -3,6 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const memoryStore = require('../memory-store');
@@ -22,29 +23,28 @@ function captureStderr(fn) {
   }
 }
 
-const PRESETS_PATH = path.join(__dirname, '..', 'synapsys-presets.json');
-
+// Point memory-store at a tmpdir presets file via SYNAPSYS_PRESETS_PATH so
+// the shipped synapsys-presets.json is never mutated. Mutating the real file
+// would race with any concurrent worker calling loadPresets() — that worker
+// would cache an empty Map for its lifetime.
 function withPresetsFile(replacement, fn) {
-  let original = null;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-presets-test-'));
+  const tmpPath = path.join(dir, 'synapsys-presets.json');
+  fs.writeFileSync(tmpPath, replacement);
+  const previousEnv = process.env.SYNAPSYS_PRESETS_PATH;
+  process.env.SYNAPSYS_PRESETS_PATH = tmpPath;
   try {
-    original = fs.readFileSync(PRESETS_PATH, 'utf8');
-  } catch (err) {
-    if (err.code !== 'ENOENT') throw err;
-  }
-  try {
-    fs.writeFileSync(PRESETS_PATH, replacement);
-    // Bust require cache so loadPresets re-reads from disk.
     delete require.cache[require.resolve('../memory-store')];
     const fresh = require('../memory-store');
     return fn(fresh);
   } finally {
-    if (original === null) {
-      // rmSync with force:true is idempotent: no check-then-act, no throw on ENOENT.
-      fs.rmSync(PRESETS_PATH, { force: true });
+    if (previousEnv === undefined) {
+      delete process.env.SYNAPSYS_PRESETS_PATH;
     } else {
-      fs.writeFileSync(PRESETS_PATH, original);
+      process.env.SYNAPSYS_PRESETS_PATH = previousEnv;
     }
     delete require.cache[require.resolve('../memory-store')];
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 }
 

--- a/plugins/synapsys/lib/__tests__/synapsys-explain-exclude.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-explain-exclude.integration.test.js
@@ -86,6 +86,38 @@ test('Task 4: --verbose surfaces exclude-matched reason and matched.excluded_pat
   );
 });
 
+test('Task 4: --verbose surfaces exclude-matched label via MATCHED_LABELS', (t) => {
+  const memories = [
+    {
+      name: 'jira-ops-exclude-demo-2',
+      frontmatter: {
+        description: 'Demo memory with exclude_prompt suppression',
+        events: 'UserPromptSubmit',
+        trigger_prompt: 'create jira ticket',
+        exclude_prompt: 'dry-run',
+      },
+      body: 'Use the jira task creator.',
+    },
+  ];
+  const { cwd, cleanup } = makeFixtureStore(memories);
+  t.after(cleanup);
+
+  const result = runExplain([
+    '--verbose',
+    '--event=UserPromptSubmit',
+    '--prompt=create jira ticket dry-run',
+    `--cwd=${cwd}`,
+  ]);
+
+  assert.equal(result.status, 0, `exit non-zero. stderr=${result.stderr}`);
+  // The labels block (mirrors negative-excludes) should render the excluded_pattern key.
+  assert.match(
+    result.stdout,
+    /excluded_pattern/,
+    `expected excluded_pattern label in verbose output. stdout=${result.stdout}`
+  );
+});
+
 test('Task 4: table mode shows exclude-matched reason in row', (t) => {
   const memories = [
     {

--- a/plugins/synapsys/lib/__tests__/synapsys-explain-exclude.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-explain-exclude.integration.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+/**
+ * Integration tests for `plugins/synapsys/scripts/synapsys-explain.js`
+ * exclude-matched rendering (GH-510, Task 4).
+ *
+ * Asserts that `synapsys:explain` over a memory whose `exclude_prompt`
+ * suppresses a positive `trigger_prompt` match prints:
+ *   - reason `exclude-matched` (table + verbose)
+ *   - `matched.excluded_pattern: <regex>` line (verbose)
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const EXPLAIN = path.resolve(__dirname, '..', '..', 'scripts', 'synapsys-explain.js');
+
+function writeMemory(storeDir, name, frontmatter, body = '') {
+  const lines = ['---', `name: ${name}`];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    lines.push(`${k}: ${v}`);
+  }
+  lines.push('---', '', body, '');
+  fs.writeFileSync(path.join(storeDir, `${name}.md`), lines.join('\n'));
+}
+
+function makeFixtureStore(memories) {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-explain-exclude-'));
+  const storeDir = path.join(cwd, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'synapsys-explain-exclude-fixture' })
+  );
+  for (const mem of memories) {
+    writeMemory(storeDir, mem.name, mem.frontmatter, mem.body || '');
+  }
+  return { cwd, cleanup: () => fs.rmSync(cwd, { recursive: true, force: true }) };
+}
+
+function runExplain(args, opts = {}) {
+  return spawnSync(process.execPath, [EXPLAIN, ...args], {
+    encoding: 'utf8',
+    input: opts.input,
+    env: { ...process.env, SYNAPSYS_NO_SETUP_HINT: '1' },
+  });
+}
+
+test('Task 4: --verbose surfaces exclude-matched reason and matched.excluded_pattern', (t) => {
+  const memories = [
+    {
+      name: 'jira-ops-exclude-demo',
+      frontmatter: {
+        description: 'Demo memory with exclude_prompt suppression',
+        events: 'UserPromptSubmit',
+        trigger_prompt: 'create jira ticket',
+        exclude_prompt: 'dry-run',
+      },
+      body: 'Use the jira task creator.',
+    },
+  ];
+  const { cwd, cleanup } = makeFixtureStore(memories);
+  t.after(cleanup);
+
+  const result = runExplain([
+    '--verbose',
+    '--event=UserPromptSubmit',
+    '--prompt=create jira ticket dry-run',
+    `--cwd=${cwd}`,
+  ]);
+
+  assert.equal(result.status, 0, `exit non-zero. stderr=${result.stderr}`);
+  assert.match(
+    result.stdout,
+    /exclude-matched/,
+    `expected exclude-matched reason in verbose output. stdout=${result.stdout}`
+  );
+  assert.match(
+    result.stdout,
+    /matched\.excluded_pattern:\s*dry-run/,
+    `expected matched.excluded_pattern line. stdout=${result.stdout}`
+  );
+});
+
+test('Task 4: table mode shows exclude-matched reason in row', (t) => {
+  const memories = [
+    {
+      name: 'jira-ops-exclude-demo',
+      frontmatter: {
+        description: 'Demo memory with exclude_prompt suppression',
+        events: 'UserPromptSubmit',
+        trigger_prompt: 'create jira ticket',
+        exclude_prompt: 'dry-run',
+      },
+      body: 'Use the jira task creator.',
+    },
+  ];
+  const { cwd, cleanup } = makeFixtureStore(memories);
+  t.after(cleanup);
+
+  const result = runExplain([
+    '--event=UserPromptSubmit',
+    '--prompt=create jira ticket dry-run',
+    `--cwd=${cwd}`,
+  ]);
+
+  assert.equal(result.status, 0, `exit non-zero. stderr=${result.stderr}`);
+  const row = result.stdout
+    .split('\n')
+    .find((l) => l.includes('jira-ops-exclude-demo'));
+  assert.ok(row, `expected row for jira-ops-exclude-demo. stdout=${result.stdout}`);
+  assert.match(row, /exclude-matched/, `expected exclude-matched in row: ${row}`);
+  assert.match(row, /✗/, `expected fired ✗ in row: ${row}`);
+});

--- a/plugins/synapsys/lib/__tests__/synapsys-list-exclude.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-list-exclude.integration.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * Tests for `plugins/synapsys/scripts/synapsys-list.js` (GH-510 Task 3).
+ *
+ * Task 3 RED — synapsys-list must surface exclude rules in JSON + verbose
+ * output. Covers R5 + Gherkin "synapsys:list verbose output surfaces exclude
+ * rules" row.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const LIST_SCRIPT = path.resolve(__dirname, '..', '..', 'scripts', 'synapsys-list.js');
+
+function makeTempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-list-exclude-'));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'test' })
+  );
+  return { cwd: dir, storeDir };
+}
+
+function writeMemory(storeDir, name, frontmatter) {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  const content = `---\n${fm}\n---\nbody\n`;
+  fs.writeFileSync(path.join(storeDir, name), content);
+}
+
+function runList(cwd, args) {
+  return spawnSync(
+    process.execPath,
+    [LIST_SCRIPT, `--cwd=${cwd}`, '--no-color', ...args],
+    { encoding: 'utf8', env: { ...process.env, NO_COLOR: '1' } }
+  );
+}
+
+test('synapsys-list --json includes excludePrompt, excludePretool, excludePreset per memory', () => {
+  const { cwd, storeDir } = makeTempStore();
+  writeMemory(storeDir, 'ex.md', {
+    name: 'ex',
+    description: 'd',
+    trigger_prompt: '\\bticket\\b',
+    exclude_prompt: '\\bgit\\s+merge\\b',
+    exclude_preset: 'ci-monitor',
+  });
+
+  const result = runList(cwd, ['--json']);
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
+  const payload = JSON.parse(result.stdout);
+  assert.ok(Array.isArray(payload.memories), 'payload.memories must be an array');
+  const mem = payload.memories.find((m) => m.name === 'ex');
+  assert.ok(mem, 'memory "ex" must appear in JSON output');
+  assert.equal(mem.excludePrompt, '\\bgit\\s+merge\\b', 'excludePrompt must be emitted in JSON');
+  assert.deepEqual(mem.excludePretool, [], 'excludePretool must default to [] in JSON');
+  assert.deepEqual(mem.excludePreset, ['ci-monitor'], 'excludePreset must be emitted in JSON');
+});
+
+test('synapsys-list --verbose prints exclude_prompt and exclude_preset labeled rows', () => {
+  const { cwd, storeDir } = makeTempStore();
+  writeMemory(storeDir, 'ex.md', {
+    name: 'ex',
+    description: 'd',
+    trigger_prompt: '\\bticket\\b',
+    exclude_prompt: '\\bgit\\s+merge\\b',
+    exclude_preset: 'ci-monitor',
+  });
+
+  const result = runList(cwd, ['--verbose']);
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
+  assert.match(
+    result.stdout,
+    /exclude_prompt:.*\\bgit\\s\+merge\\b/,
+    'verbose output must contain an "exclude_prompt:" row with the regex'
+  );
+  assert.match(
+    result.stdout,
+    /exclude_preset:.*ci-monitor/,
+    'verbose output must contain an "exclude_preset:" row listing the preset name'
+  );
+});
+
+test('synapsys-list --verbose omits exclude rows for memories without exclude fields', () => {
+  const { cwd, storeDir } = makeTempStore();
+  writeMemory(storeDir, 'plain.md', {
+    name: 'plain',
+    description: 'd',
+    trigger_prompt: '\\bticket\\b',
+  });
+
+  const result = runList(cwd, ['--verbose']);
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
+  assert.doesNotMatch(
+    result.stdout,
+    /exclude_prompt:/,
+    'verbose output must NOT contain "exclude_prompt:" when the field is empty'
+  );
+  assert.doesNotMatch(
+    result.stdout,
+    /exclude_preset:/,
+    'verbose output must NOT contain "exclude_preset:" when the field is empty'
+  );
+  assert.doesNotMatch(
+    result.stdout,
+    /exclude_pretool:/,
+    'verbose output must NOT contain "exclude_pretool:" when the field is empty'
+  );
+});

--- a/plugins/synapsys/lib/matcher-content.js
+++ b/plugins/synapsys/lib/matcher-content.js
@@ -1,0 +1,93 @@
+'use strict';
+
+/**
+ * Pretool content extraction and `trigger_pretool_content` /
+ * `trigger_pretool_content_not` evaluators. Split out of matcher.js so the
+ * stage-3 helpers live alongside their data shape and the main matcher file
+ * stays under the quality gate's max-lines budget.
+ */
+
+function extractMultiEditContent(edits) {
+  if (!Array.isArray(edits)) return null;
+  const strings = edits
+    .map((e) => (e && typeof e.new_string === 'string' ? e.new_string : null))
+    .filter((s) => s !== null);
+  if (strings.length === 0) return null;
+  return strings.join('\n');
+}
+
+const PRETOOL_CONTENT_EXTRACTORS = {
+  Edit: (i) => (typeof i.new_string === 'string' ? i.new_string : null),
+  Write: (i) => (typeof i.content === 'string' ? i.content : null),
+  MultiEdit: (i) => extractMultiEditContent(i.edits),
+  NotebookEdit: (i) => (typeof i.new_source === 'string' ? i.new_source : null),
+};
+
+function extractPretoolContent(toolName, toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  const extractor = PRETOOL_CONTENT_EXTRACTORS[toolName];
+  return extractor ? extractor(toolInput) : null;
+}
+
+function findContentMatch(memory, contentString) {
+  const patterns = memory.triggerPretoolContent;
+  if (!Array.isArray(patterns) || patterns.length === 0) return null;
+  let hit = null;
+  for (const pat of patterns) {
+    let re;
+    try {
+      re = new RegExp(pat, 'im');
+    } catch (err) {
+      process.stderr.write(
+        `[synapsys] memory ${memory.name}: invalid trigger_pretool_content regex "${pat}": ${err.message}\n`
+      );
+      continue;
+    }
+    const m = re.exec(contentString);
+    if (m && hit === null) {
+      hit = { pattern: pat, substring: m[0] };
+    }
+  }
+  return hit;
+}
+
+function evaluatePretoolContent(memory, contentString) {
+  return findContentMatch(memory, contentString) !== null;
+}
+
+function hasNegativeContentPatterns(memory) {
+  return (
+    Array.isArray(memory.triggerPretoolContentNot) && memory.triggerPretoolContentNot.length > 0
+  );
+}
+
+function evaluatePretoolContentNot(memory, contentString) {
+  const patterns = memory.triggerPretoolContentNot;
+  if (!Array.isArray(patterns) || patterns.length === 0) {
+    return { excluded: false, pattern: null };
+  }
+  for (const pat of patterns) {
+    let re;
+    try {
+      re = new RegExp(pat, 'im');
+    } catch (err) {
+      process.stderr.write(
+        `[synapsys] memory ${memory.name}: invalid trigger_pretool_content_not regex "${pat}": ${err.message}\n`
+      );
+      continue;
+    }
+    if (re.test(contentString)) {
+      return { excluded: true, pattern: pat };
+    }
+  }
+  return { excluded: false, pattern: null };
+}
+
+module.exports = {
+  extractMultiEditContent,
+  extractPretoolContent,
+  evaluatePretoolContent,
+  findContentMatch,
+  hasNegativeContentPatterns,
+  evaluatePretoolContentNot,
+};

--- a/plugins/synapsys/lib/matcher-excludes.js
+++ b/plugins/synapsys/lib/matcher-excludes.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * Stage-4 exclude evaluators (`exclude_prompt`/`exclude_preset` resolved list
+ * and `exclude_pretool` specs). Split out of matcher.js so the locked stage
+ * ladder file stays under the quality gate's max-lines budget without
+ * compromising the explainer contract.
+ */
+
+function safeRegex(pattern, flags = 'i') {
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when the memory carries any exclude signal (resolved prompt/preset
+ * list, or any `exclude_pretool` spec).
+ *
+ * @param {object} memory
+ * @returns {boolean}
+ */
+function hasExcludePatterns(memory) {
+  const resolved = Array.isArray(memory.excludeResolved) && memory.excludeResolved.length > 0;
+  const pretool = Array.isArray(memory.excludePretool) && memory.excludePretool.length > 0;
+  return resolved || pretool;
+}
+
+/**
+ * Evaluate the resolved exclude list (inline `exclude_prompt` + flattened
+ * `exclude_preset` bodies, in `memory.excludeResolved`) against an input
+ * string (typically a user prompt or a stringified tool_input blob).
+ * Invalid regex entries are skipped with a stderr warning so a single bad
+ * pattern cannot abort the matcher (fail-closed / R15).
+ *
+ * @param {object} memory
+ * @param {string} input
+ * @returns {{ excluded: boolean, pattern: string|null }}
+ */
+function evaluateExcludePrompt(memory, input) {
+  const patterns = memory.excludeResolved;
+  if (!Array.isArray(patterns) || patterns.length === 0) {
+    return { excluded: false, pattern: null };
+  }
+  const text = input || '';
+  // Two-pass evaluation:
+  //   pass 1 — compile every pattern, emit stderr warnings for invalid ones
+  //            so memory authors are told about all bad regex even when an
+  //            earlier valid one matches (fail-closed / R15).
+  //   pass 2 — return on the first valid regex that matches.
+  const compiled = [];
+  for (const pat of patterns) {
+    const re = safeRegex(pat);
+    if (!re) {
+      process.stderr.write(`[synapsys] memory ${memory.name}: invalid exclude regex "${pat}"\n`);
+      continue;
+    }
+    compiled.push({ pat, re });
+  }
+  for (const { pat, re } of compiled) {
+    if (re.test(text)) return { excluded: true, pattern: pat };
+  }
+  return { excluded: false, pattern: null };
+}
+
+/**
+ * Evaluate `memory.excludePretool` (array of `tool:pattern` specs sharing the
+ * shape of `trigger_pretool`) against a candidate (toolName, argBlob).
+ * Caller passes the shared `parsePretoolSpec` / `pretoolSpecMatches` helpers
+ * from matcher.js so the spec grammar stays in one place.
+ *
+ * @param {object} memory
+ * @param {string} toolName
+ * @param {string} argBlob
+ * @param {{ parsePretoolSpec: Function, pretoolSpecMatches: Function }} helpers
+ * @returns {{ excluded: boolean, pattern: string|null }}
+ */
+function evaluateExcludePretool(memory, toolName, argBlob, helpers) {
+  const specs = memory.excludePretool;
+  if (!Array.isArray(specs) || specs.length === 0) {
+    return { excluded: false, pattern: null };
+  }
+  const { parsePretoolSpec, pretoolSpecMatches } = helpers;
+  // Two-pass evaluation mirrors evaluateExcludePrompt (R15 fail-closed):
+  //   pass 1 — pre-validate each spec's regex and emit stderr warnings for
+  //            invalid patterns so authors learn about every bad regex,
+  //            even when an earlier valid spec matches.
+  //   pass 2 — return on the first valid spec that matches.
+  // `pretoolSpecMatches` calls `safeRegex` which silently returns null on
+  // invalid input, so without this validation a bad pattern would be a
+  // silent no-op rather than a documented warn+skip.
+  const valid = [];
+  for (const spec of specs) {
+    const { pat } = parsePretoolSpec(spec);
+    if (pat && !safeRegex(pat)) {
+      process.stderr.write(
+        `[synapsys] memory ${memory.name}: invalid exclude_pretool spec "${spec}"\n`
+      );
+      continue;
+    }
+    valid.push(spec);
+  }
+  for (const spec of valid) {
+    try {
+      if (pretoolSpecMatches(spec, toolName, argBlob || '')) {
+        return { excluded: true, pattern: spec };
+      }
+    } catch (err) {
+      process.stderr.write(
+        `[synapsys] memory ${memory.name}: invalid exclude_pretool spec "${spec}": ${err.message}\n`
+      );
+    }
+  }
+  return { excluded: false, pattern: null };
+}
+
+module.exports = {
+  hasExcludePatterns,
+  evaluateExcludePrompt,
+  evaluateExcludePretool,
+};

--- a/plugins/synapsys/lib/matcher-excludes.js
+++ b/plugins/synapsys/lib/matcher-excludes.js
@@ -7,13 +7,7 @@
  * compromising the explainer contract.
  */
 
-function safeRegex(pattern, flags = 'i') {
-  try {
-    return new RegExp(pattern, flags);
-  } catch {
-    return null;
-  }
-}
+const { safeRegex } = require('./matcher-regex');
 
 /**
  * True when the memory carries any exclude signal (resolved prompt/preset

--- a/plugins/synapsys/lib/matcher-regex.js
+++ b/plugins/synapsys/lib/matcher-regex.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// Shared regex compile-or-null helper. Used by matcher.js and
+// matcher-excludes.js so the fail-closed behavior on invalid patterns
+// stays defined in exactly one place. Default flag is `i` to match the
+// case-insensitive convention used across synapsys trigger/exclude regexes.
+function safeRegex(pattern, flags = 'i') {
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { safeRegex };

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -399,7 +399,26 @@ function evaluateExcludePretool(memory, toolName, argBlob) {
   if (!Array.isArray(specs) || specs.length === 0) {
     return { excluded: false, pattern: null };
   }
+  // Two-pass evaluation mirrors evaluateExcludePrompt (R15 fail-closed):
+  //   pass 1 — pre-validate each spec's regex and emit stderr warnings for
+  //            invalid patterns so authors learn about every bad regex,
+  //            even when an earlier valid spec matches.
+  //   pass 2 — return on the first valid spec that matches.
+  // `pretoolSpecMatches` calls `safeRegex` which silently returns null on
+  // invalid input, so without this validation a bad pattern would be a
+  // silent no-op rather than a documented warn+skip.
+  const valid = [];
   for (const spec of specs) {
+    const { pat } = parsePretoolSpec(spec);
+    if (pat && !safeRegex(pat)) {
+      process.stderr.write(
+        `[synapsys] memory ${memory.name}: invalid exclude_pretool spec "${spec}"\n`
+      );
+      continue;
+    }
+    valid.push(spec);
+  }
+  for (const spec of valid) {
     try {
       if (pretoolSpecMatches(spec, toolName, argBlob || '')) {
         return { excluded: true, pattern: spec };

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -3,12 +3,9 @@
 const excludes = require('./matcher-excludes');
 const content = require('./matcher-content');
 
-const extractMultiEditContent = content.extractMultiEditContent;
 const extractPretoolContent = content.extractPretoolContent;
-const evaluatePretoolContent = content.evaluatePretoolContent;
 const findContentMatch = content.findContentMatch;
 const hasNegativeContentPatterns = content.hasNegativeContentPatterns;
-const evaluatePretoolContentNot = content.evaluatePretoolContentNot;
 
 /**
  * @typedef {Object} Matched
@@ -416,8 +413,8 @@ module.exports = {
   safeRegex,
   splitTopLevelAlternation,
   extractPretoolContent,
-  evaluatePretoolContent,
-  evaluatePretoolContentNot,
+  evaluatePretoolContent: content.evaluatePretoolContent,
+  evaluatePretoolContentNot: content.evaluatePretoolContentNot,
   hasNegativeContentPatterns,
   isDomainMismatch,
   evaluateExcludePrompt,

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -1,5 +1,15 @@
 'use strict';
 
+const excludes = require('./matcher-excludes');
+const content = require('./matcher-content');
+
+const extractMultiEditContent = content.extractMultiEditContent;
+const extractPretoolContent = content.extractPretoolContent;
+const evaluatePretoolContent = content.evaluatePretoolContent;
+const findContentMatch = content.findContentMatch;
+const hasNegativeContentPatterns = content.hasNegativeContentPatterns;
+const evaluatePretoolContentNot = content.evaluatePretoolContentNot;
+
 /**
  * @typedef {Object} Matched
  * @property {string} [prompt_token]      The matched alternative arm of trigger_prompt.
@@ -49,32 +59,32 @@ function makeMatched(fields) {
   return matched;
 }
 
+// Find which top-level alternative arm of trigger_prompt matched. Falls back
+// to the full pattern when no individual arm hits (naive split — spec assumes
+// human-authored simple alternation).
+function _resolvePromptToken(triggerPrompt, prompt) {
+  const arms = splitTopLevelAlternation(triggerPrompt);
+  for (const arm of arms) {
+    const armRe = safeRegex(arm);
+    if (armRe && armRe.test(prompt)) return arm;
+  }
+  return triggerPrompt;
+}
+
 function matchPrompt(memory, prompt) {
   const gate = gateMemory(memory, 'UserPromptSubmit');
   if (gate) return { fired: false, reason: gate };
   if (!memory.triggerPrompt) return { fired: false, reason: 'no-prompt-match' };
   const re = safeRegex(memory.triggerPrompt);
   if (!re) return { fired: false, reason: 'no-prompt-match' };
-  const m = re.exec(prompt || '');
+  const promptText = prompt || '';
+  const m = re.exec(promptText);
   if (!m) return { fired: false, reason: 'no-prompt-match' };
-
-  // Determine which top-level alternative arm matched. Split memory.triggerPrompt
-  // by top-level `|` (naive, but trigger_prompt regex is human-authored simple
-  // alternation per the spec). Pick the first arm whose own regex matches.
-  const arms = splitTopLevelAlternation(memory.triggerPrompt);
-  let prompt_token = memory.triggerPrompt;
-  for (const arm of arms) {
-    const armRe = safeRegex(arm);
-    if (armRe && armRe.test(prompt || '')) {
-      prompt_token = arm;
-      break;
-    }
-  }
 
   // Locked evaluation order (GH-510): trigger → exclude. After a positive
   // trigger_prompt match, evaluate the merged exclude list. Any hit suppresses
   // the fire and returns reason 'exclude-matched' with the offending pattern.
-  const excluded = evaluateExcludePrompt(memory, prompt || '');
+  const excluded = evaluateExcludePrompt(memory, promptText);
   if (excluded.excluded) {
     return {
       fired: false,
@@ -83,6 +93,7 @@ function matchPrompt(memory, prompt) {
     };
   }
 
+  const prompt_token = _resolvePromptToken(memory.triggerPrompt, promptText);
   return {
     fired: true,
     matched: makeMatched({ prompt_token, prompt_substring: m[0] }),
@@ -200,6 +211,26 @@ function _evaluatePreToolMatch(memory, payload) {
  * inputs the trigger considered. Reordering would silently flip which reason
  * surfaces to memory authors, breaking the explainer contract.
  */
+// Stage 4 helper: evaluate exclude_pretool + exclude_prompt against the
+// pre-tool payload. Returns an exclude-matched verdict if any pattern hits,
+// otherwise null. Extracted from matchPreTool to keep cyclomatic complexity
+// of the locked stage ladder under the quality gate.
+function _evaluatePreToolExcludes(memory, payload) {
+  const argBlob = JSON.stringify(payload?.tool_input || {});
+  const toolName = payload?.tool_name || '';
+  const excluded = evaluateExcludePretool(memory, toolName, argBlob);
+  if (excluded.excluded) {
+    return makeMatched({ excluded_pattern: excluded.pattern });
+  }
+  // R11 OR composition: exclude_prompt patterns apply to any input the
+  // trigger saw, matching the prompt-side semantics consistently.
+  const excludedByPrompt = evaluateExcludePrompt(memory, argBlob);
+  if (excludedByPrompt.excluded) {
+    return makeMatched({ excluded_pattern: excludedByPrompt.pattern });
+  }
+  return null;
+}
+
 function matchPreTool(memory, payload) {
   const gate = gateMemory(memory, 'PreToolUse');
   if (gate) return { fired: false, reason: gate };
@@ -210,26 +241,9 @@ function matchPreTool(memory, payload) {
   if (result.matched) {
     // Stage 4: exclude evaluation runs AFTER positive + content stages so
     // negative-excludes retains priority over exclude-matched (locked order).
-    const argBlob = JSON.stringify(payload?.tool_input || {});
-    const toolName = payload?.tool_name || '';
-    const excluded = evaluateExcludePretool(memory, toolName, argBlob);
-    if (excluded.excluded) {
-      return {
-        fired: false,
-        reason: 'exclude-matched',
-        matched: makeMatched({ excluded_pattern: excluded.pattern }),
-      };
-    }
-    // Also evaluate exclude_prompt against the argBlob to honor R11 OR
-    // composition — exclude_prompt patterns apply to any input the trigger
-    // saw (matching the prompt-side semantics consistently).
-    const excludedByPrompt = evaluateExcludePrompt(memory, argBlob);
-    if (excludedByPrompt.excluded) {
-      return {
-        fired: false,
-        reason: 'exclude-matched',
-        matched: makeMatched({ excluded_pattern: excludedByPrompt.pattern }),
-      };
+    const excludedMatched = _evaluatePreToolExcludes(memory, payload);
+    if (excludedMatched) {
+      return { fired: false, reason: 'exclude-matched', matched: excludedMatched };
     }
     return {
       fired: true,
@@ -254,81 +268,9 @@ function matchPreTool(memory, payload) {
   return { fired: false, reason: 'no-content-match' };
 }
 
-function extractMultiEditContent(edits) {
-  if (!Array.isArray(edits)) return null;
-  const strings = edits
-    .map((e) => (e && typeof e.new_string === 'string' ? e.new_string : null))
-    .filter((s) => s !== null);
-  if (strings.length === 0) return null;
-  return strings.join('\n');
-}
-
-const PRETOOL_CONTENT_EXTRACTORS = {
-  Edit: (i) => (typeof i.new_string === 'string' ? i.new_string : null),
-  Write: (i) => (typeof i.content === 'string' ? i.content : null),
-  MultiEdit: (i) => extractMultiEditContent(i.edits),
-  NotebookEdit: (i) => (typeof i.new_source === 'string' ? i.new_source : null),
-};
-
-function extractPretoolContent(toolName, toolInput) {
-  if (!toolInput || typeof toolInput !== 'object') return null;
-  const extractor = PRETOOL_CONTENT_EXTRACTORS[toolName];
-  return extractor ? extractor(toolInput) : null;
-}
-
-function evaluatePretoolContent(memory, contentString) {
-  return findContentMatch(memory, contentString) !== null;
-}
-
-function findContentMatch(memory, contentString) {
-  const patterns = memory.triggerPretoolContent;
-  if (!Array.isArray(patterns) || patterns.length === 0) return null;
-  let hit = null;
-  for (const pat of patterns) {
-    let re;
-    try {
-      re = new RegExp(pat, 'im');
-    } catch (err) {
-      process.stderr.write(
-        `[synapsys] memory ${memory.name}: invalid trigger_pretool_content regex "${pat}": ${err.message}\n`
-      );
-      continue;
-    }
-    const m = re.exec(contentString);
-    if (m && hit === null) {
-      hit = { pattern: pat, substring: m[0] };
-    }
-  }
-  return hit;
-}
-
-function hasNegativeContentPatterns(memory) {
-  return (
-    Array.isArray(memory.triggerPretoolContentNot) && memory.triggerPretoolContentNot.length > 0
-  );
-}
-
-function evaluatePretoolContentNot(memory, contentString) {
-  const patterns = memory.triggerPretoolContentNot;
-  if (!Array.isArray(patterns) || patterns.length === 0) {
-    return { excluded: false, pattern: null };
-  }
-  for (const pat of patterns) {
-    let re;
-    try {
-      re = new RegExp(pat, 'im');
-    } catch (err) {
-      process.stderr.write(
-        `[synapsys] memory ${memory.name}: invalid trigger_pretool_content_not regex "${pat}": ${err.message}\n`
-      );
-      continue;
-    }
-    if (re.test(contentString)) {
-      return { excluded: true, pattern: pat };
-    }
-  }
-  return { excluded: false, pattern: null };
-}
+// Content helpers (extract*, evaluate*Content*, findContentMatch) live in
+// matcher-content.js and are re-bound at the top of this file so the public
+// matcher API stays stable for memory-store.js and the explainer CLI.
 
 /**
  * True iff the memory carries any resolved exclude pattern (either inline
@@ -338,98 +280,16 @@ function evaluatePretoolContentNot(memory, contentString) {
  * @param {object} memory
  * @returns {boolean}
  */
-function hasExcludePatterns(memory) {
-  const resolved = Array.isArray(memory.excludeResolved) && memory.excludeResolved.length > 0;
-  const pretool = Array.isArray(memory.excludePretool) && memory.excludePretool.length > 0;
-  return resolved || pretool;
-}
-
-/**
- * Evaluate the resolved exclude list (inline `exclude_prompt` + flattened
- * `exclude_preset` bodies, in `memory.excludeResolved`) against an input
- * string (typically a user prompt or a stringified tool_input blob).
- * Invalid regex entries are skipped with a stderr warning so a single bad
- * pattern cannot abort the matcher (fail-closed / R15).
- *
- * @param {object} memory
- * @param {string} input
- * @returns {{ excluded: boolean, pattern: string|null }}
- */
-function evaluateExcludePrompt(memory, input) {
-  const patterns = memory.excludeResolved;
-  if (!Array.isArray(patterns) || patterns.length === 0) {
-    return { excluded: false, pattern: null };
-  }
-  const text = input || '';
-  // Two-pass evaluation:
-  //   pass 1 — compile every pattern, emit stderr warnings for invalid ones
-  //            so memory authors are told about all bad regex even when an
-  //            earlier valid one matches (fail-closed / R15).
-  //   pass 2 — return on the first valid regex that matches.
-  const compiled = [];
-  for (const pat of patterns) {
-    const re = safeRegex(pat);
-    if (!re) {
-      process.stderr.write(
-        `[synapsys] memory ${memory.name}: invalid exclude regex "${pat}"\n`
-      );
-      continue;
-    }
-    compiled.push({ pat, re });
-  }
-  for (const { pat, re } of compiled) {
-    if (re.test(text)) return { excluded: true, pattern: pat };
-  }
-  return { excluded: false, pattern: null };
-}
-
-/**
- * Evaluate `memory.excludePretool` (array of `tool:pattern` specs sharing the
- * shape of `trigger_pretool`) against a candidate (toolName, argBlob). Reuses
- * `parsePretoolSpec` / `pretoolSpecMatches` so the spec grammar stays in one
- * place. Invalid regex inside a spec is fail-closed (no exclude fires).
- *
- * @param {object} memory
- * @param {string} toolName
- * @param {string} argBlob
- * @returns {{ excluded: boolean, pattern: string|null }}
- */
+// Stage-4 exclude evaluators are implemented in matcher-excludes.js. These
+// thin wrappers bind matcher.js's pretool spec helpers so call-sites here
+// stay parameter-free and the public API surface is unchanged.
+const hasExcludePatterns = excludes.hasExcludePatterns;
+const evaluateExcludePrompt = excludes.evaluateExcludePrompt;
 function evaluateExcludePretool(memory, toolName, argBlob) {
-  const specs = memory.excludePretool;
-  if (!Array.isArray(specs) || specs.length === 0) {
-    return { excluded: false, pattern: null };
-  }
-  // Two-pass evaluation mirrors evaluateExcludePrompt (R15 fail-closed):
-  //   pass 1 — pre-validate each spec's regex and emit stderr warnings for
-  //            invalid patterns so authors learn about every bad regex,
-  //            even when an earlier valid spec matches.
-  //   pass 2 — return on the first valid spec that matches.
-  // `pretoolSpecMatches` calls `safeRegex` which silently returns null on
-  // invalid input, so without this validation a bad pattern would be a
-  // silent no-op rather than a documented warn+skip.
-  const valid = [];
-  for (const spec of specs) {
-    const { pat } = parsePretoolSpec(spec);
-    if (pat && !safeRegex(pat)) {
-      process.stderr.write(
-        `[synapsys] memory ${memory.name}: invalid exclude_pretool spec "${spec}"\n`
-      );
-      continue;
-    }
-    valid.push(spec);
-  }
-  for (const spec of valid) {
-    try {
-      if (pretoolSpecMatches(spec, toolName, argBlob || '')) {
-        return { excluded: true, pattern: spec };
-      }
-    } catch (err) {
-      process.stderr.write(
-        `[synapsys] memory ${memory.name}: invalid exclude_pretool spec "${spec}": ${err.message}\n`
-      );
-    }
-  }
-  return { excluded: false, pattern: null };
+  return excludes.evaluateExcludePretool(memory, toolName, argBlob, {
+    parsePretoolSpec,
+    pretoolSpecMatches,
+  });
 }
 
 // matchPreToolResult — object-mode wrapper around matchPreTool.

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -2,6 +2,7 @@
 
 const excludes = require('./matcher-excludes');
 const content = require('./matcher-content');
+const { safeRegex } = require('./matcher-regex');
 
 const extractPretoolContent = content.extractPretoolContent;
 const findContentMatch = content.findContentMatch;
@@ -24,14 +25,6 @@ const hasNegativeContentPatterns = content.hasNegativeContentPatterns;
  * @property {('events-exclude'|'no-prompt-match'|'no-pretool-match'|'no-content-match'|'negative-excludes'|'exclude-matched'|'no-session-trigger'|'expired'|'disabled'|'domain-mismatch')} [reason]
  * @property {Matched} [matched]
  */
-
-function safeRegex(pattern, flags = 'i') {
-  try {
-    return new RegExp(pattern, flags);
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Resolve the deterministic gate ladder: events-exclude → disabled → expired.

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -8,12 +8,13 @@
  * @property {string} [content_pattern]   The trigger_pretool_content regex that matched.
  * @property {string} [content_substring] The actual substring matched in the tool input content.
  * @property {string} [negative_pattern]  The trigger_pretool_content_not regex that excluded a match.
+ * @property {string} [excluded_pattern]  The exclude_* regex/spec that suppressed an otherwise-positive match.
  */
 
 /**
  * @typedef {Object} MatchResult
  * @property {boolean} fired
- * @property {('events-exclude'|'no-prompt-match'|'no-pretool-match'|'no-content-match'|'negative-excludes'|'no-session-trigger'|'expired'|'disabled'|'domain-mismatch')} [reason]
+ * @property {('events-exclude'|'no-prompt-match'|'no-pretool-match'|'no-content-match'|'negative-excludes'|'exclude-matched'|'no-session-trigger'|'expired'|'disabled'|'domain-mismatch')} [reason]
  * @property {Matched} [matched]
  */
 
@@ -68,6 +69,18 @@ function matchPrompt(memory, prompt) {
       prompt_token = arm;
       break;
     }
+  }
+
+  // Locked evaluation order (GH-510): trigger → exclude. After a positive
+  // trigger_prompt match, evaluate the merged exclude list. Any hit suppresses
+  // the fire and returns reason 'exclude-matched' with the offending pattern.
+  const excluded = evaluateExcludePrompt(memory, prompt || '');
+  if (excluded.excluded) {
+    return {
+      fired: false,
+      reason: 'exclude-matched',
+      matched: makeMatched({ excluded_pattern: excluded.pattern }),
+    };
   }
 
   return {
@@ -172,6 +185,21 @@ function _evaluatePreToolMatch(memory, payload) {
   return { ...stage, matchedSpec: prefix.matchedSpec };
 }
 
+/**
+ * Locked evaluation order for matchPreTool / matchPreToolResult (GH-510):
+ *   1. events gate / disabled / expired
+ *   2. positive trigger_pretool prefix match (`no-pretool-match` on miss)
+ *   3. trigger_pretool_content stage (GH-445): content positive then
+ *      `trigger_pretool_content_not` — produces `'negative-excludes'` which
+ *      retains priority over `'exclude-matched'`
+ *   4. exclude_prompt / exclude_pretool / exclude_preset suppression
+ *      (`'exclude-matched'`)
+ *
+ * The order matters: `'negative-excludes'` is a stage-3 verdict against the
+ * tool input content; `'exclude-matched'` is a stage-4 veto against the same
+ * inputs the trigger considered. Reordering would silently flip which reason
+ * surfaces to memory authors, breaking the explainer contract.
+ */
 function matchPreTool(memory, payload) {
   const gate = gateMemory(memory, 'PreToolUse');
   if (gate) return { fired: false, reason: gate };
@@ -180,6 +208,29 @@ function matchPreTool(memory, payload) {
   }
   const result = _evaluatePreToolMatch(memory, payload);
   if (result.matched) {
+    // Stage 4: exclude evaluation runs AFTER positive + content stages so
+    // negative-excludes retains priority over exclude-matched (locked order).
+    const argBlob = JSON.stringify(payload?.tool_input || {});
+    const toolName = payload?.tool_name || '';
+    const excluded = evaluateExcludePretool(memory, toolName, argBlob);
+    if (excluded.excluded) {
+      return {
+        fired: false,
+        reason: 'exclude-matched',
+        matched: makeMatched({ excluded_pattern: excluded.pattern }),
+      };
+    }
+    // Also evaluate exclude_prompt against the argBlob to honor R11 OR
+    // composition — exclude_prompt patterns apply to any input the trigger
+    // saw (matching the prompt-side semantics consistently).
+    const excludedByPrompt = evaluateExcludePrompt(memory, argBlob);
+    if (excludedByPrompt.excluded) {
+      return {
+        fired: false,
+        reason: 'exclude-matched',
+        matched: makeMatched({ excluded_pattern: excludedByPrompt.pattern }),
+      };
+    }
     return {
       fired: true,
       matched: makeMatched({
@@ -279,6 +330,89 @@ function evaluatePretoolContentNot(memory, contentString) {
   return { excluded: false, pattern: null };
 }
 
+/**
+ * True iff the memory carries any resolved exclude pattern (either inline
+ * `exclude_prompt` / `exclude_preset` flattened into `excludeResolved`, or
+ * any `exclude_pretool` spec).
+ *
+ * @param {object} memory
+ * @returns {boolean}
+ */
+function hasExcludePatterns(memory) {
+  const resolved = Array.isArray(memory.excludeResolved) && memory.excludeResolved.length > 0;
+  const pretool = Array.isArray(memory.excludePretool) && memory.excludePretool.length > 0;
+  return resolved || pretool;
+}
+
+/**
+ * Evaluate the resolved exclude list (inline `exclude_prompt` + flattened
+ * `exclude_preset` bodies, in `memory.excludeResolved`) against an input
+ * string (typically a user prompt or a stringified tool_input blob).
+ * Invalid regex entries are skipped with a stderr warning so a single bad
+ * pattern cannot abort the matcher (fail-closed / R15).
+ *
+ * @param {object} memory
+ * @param {string} input
+ * @returns {{ excluded: boolean, pattern: string|null }}
+ */
+function evaluateExcludePrompt(memory, input) {
+  const patterns = memory.excludeResolved;
+  if (!Array.isArray(patterns) || patterns.length === 0) {
+    return { excluded: false, pattern: null };
+  }
+  const text = input || '';
+  // Two-pass evaluation:
+  //   pass 1 — compile every pattern, emit stderr warnings for invalid ones
+  //            so memory authors are told about all bad regex even when an
+  //            earlier valid one matches (fail-closed / R15).
+  //   pass 2 — return on the first valid regex that matches.
+  const compiled = [];
+  for (const pat of patterns) {
+    const re = safeRegex(pat);
+    if (!re) {
+      process.stderr.write(
+        `[synapsys] memory ${memory.name}: invalid exclude regex "${pat}"\n`
+      );
+      continue;
+    }
+    compiled.push({ pat, re });
+  }
+  for (const { pat, re } of compiled) {
+    if (re.test(text)) return { excluded: true, pattern: pat };
+  }
+  return { excluded: false, pattern: null };
+}
+
+/**
+ * Evaluate `memory.excludePretool` (array of `tool:pattern` specs sharing the
+ * shape of `trigger_pretool`) against a candidate (toolName, argBlob). Reuses
+ * `parsePretoolSpec` / `pretoolSpecMatches` so the spec grammar stays in one
+ * place. Invalid regex inside a spec is fail-closed (no exclude fires).
+ *
+ * @param {object} memory
+ * @param {string} toolName
+ * @param {string} argBlob
+ * @returns {{ excluded: boolean, pattern: string|null }}
+ */
+function evaluateExcludePretool(memory, toolName, argBlob) {
+  const specs = memory.excludePretool;
+  if (!Array.isArray(specs) || specs.length === 0) {
+    return { excluded: false, pattern: null };
+  }
+  for (const spec of specs) {
+    try {
+      if (pretoolSpecMatches(spec, toolName, argBlob || '')) {
+        return { excluded: true, pattern: spec };
+      }
+    } catch (err) {
+      process.stderr.write(
+        `[synapsys] memory ${memory.name}: invalid exclude_pretool spec "${spec}": ${err.message}\n`
+      );
+    }
+  }
+  return { excluded: false, pattern: null };
+}
+
 // matchPreToolResult — object-mode wrapper around matchPreTool.
 //
 // Locked decision (GH-445 brief P0 #8 / spec §Architecture Decisions):
@@ -294,7 +428,26 @@ function evaluatePretoolContentNot(memory, contentString) {
 function matchPreToolResult(memory, payload) {
   if (gateMemory(memory, 'PreToolUse')) return { matched: false };
   const result = _evaluatePreToolMatch(memory, payload);
-  if (result.matched) return { matched: true };
+  if (result.matched) {
+    // Stage 4: exclude evaluation — same locked order as matchPreTool.
+    const argBlob = JSON.stringify(payload?.tool_input || {});
+    const toolName = payload?.tool_name || '';
+    const excluded = evaluateExcludePretool(memory, toolName, argBlob);
+    if (excluded.excluded) {
+      return {
+        reason: 'exclude-matched',
+        matched: { excluded_pattern: excluded.pattern },
+      };
+    }
+    const excludedByPrompt = evaluateExcludePrompt(memory, argBlob);
+    if (excludedByPrompt.excluded) {
+      return {
+        reason: 'exclude-matched',
+        matched: { excluded_pattern: excludedByPrompt.pattern },
+      };
+    }
+    return { matched: true };
+  }
   if (result.negative) {
     return {
       reason: 'negative-excludes',
@@ -388,4 +541,7 @@ module.exports = {
   evaluatePretoolContentNot,
   hasNegativeContentPatterns,
   isDomainMismatch,
+  evaluateExcludePrompt,
+  evaluateExcludePretool,
+  hasExcludePatterns,
 };

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -208,22 +208,17 @@ function _evaluatePreToolMatch(memory, payload) {
  * inputs the trigger considered. Reordering would silently flip which reason
  * surfaces to memory authors, breaking the explainer contract.
  */
-// Stage 4 helper: evaluate exclude_pretool + exclude_prompt against the
-// pre-tool payload. Returns an exclude-matched verdict if any pattern hits,
-// otherwise null. Extracted from matchPreTool to keep cyclomatic complexity
-// of the locked stage ladder under the quality gate.
+// Stage 4 helper: evaluate exclude_pretool against the pre-tool payload.
+// Returns an exclude-matched verdict if any pattern hits, otherwise null.
+// Per R4 (brief P0 #4): exclude_prompt is scoped to the user prompt and
+// is NOT evaluated against the pretool argBlob — there is no prompt
+// string available in the PreToolUse context.
 function _evaluatePreToolExcludes(memory, payload) {
   const argBlob = JSON.stringify(payload?.tool_input || {});
   const toolName = payload?.tool_name || '';
   const excluded = evaluateExcludePretool(memory, toolName, argBlob);
   if (excluded.excluded) {
     return makeMatched({ excluded_pattern: excluded.pattern });
-  }
-  // R11 OR composition: exclude_prompt patterns apply to any input the
-  // trigger saw, matching the prompt-side semantics consistently.
-  const excludedByPrompt = evaluateExcludePrompt(memory, argBlob);
-  if (excludedByPrompt.excluded) {
-    return makeMatched({ excluded_pattern: excludedByPrompt.pattern });
   }
   return null;
 }
@@ -313,13 +308,6 @@ function matchPreToolResult(memory, payload) {
       return {
         reason: 'exclude-matched',
         matched: { excluded_pattern: excluded.pattern },
-      };
-    }
-    const excludedByPrompt = evaluateExcludePrompt(memory, argBlob);
-    if (excludedByPrompt.excluded) {
-      return {
-        reason: 'exclude-matched',
-        matched: { excluded_pattern: excludedByPrompt.pattern },
       };
     }
     return { matched: true };

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -257,14 +257,6 @@ function matchPreTool(memory, payload) {
 // matcher-content.js and are re-bound at the top of this file so the public
 // matcher API stays stable for memory-store.js and the explainer CLI.
 
-/**
- * True iff the memory carries any resolved exclude pattern (either inline
- * `exclude_prompt` / `exclude_preset` flattened into `excludeResolved`, or
- * any `exclude_pretool` spec).
- *
- * @param {object} memory
- * @returns {boolean}
- */
 // Stage-4 exclude evaluators are implemented in matcher-excludes.js. These
 // thin wrappers bind matcher.js's pretool spec helpers so call-sites here
 // stay parameter-free and the public API surface is unchanged.

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -212,6 +212,23 @@ function resolvePreset(name) {
   return null;
 }
 
+// Resolve all exclude_preset names through the preset map and concatenate
+// the raw exclude_prompt regex (if any). Skips presets that fail to resolve;
+// resolvePreset already emits its own stderr warning.
+function _buildExcludeResolved(excludePreset, excludePrompt) {
+  const resolved = [];
+  for (const presetName of excludePreset) {
+    const r = resolvePreset(presetName);
+    if (r) resolved.push(r);
+  }
+  if (excludePrompt) resolved.push(excludePrompt);
+  return resolved;
+}
+
+function _truthy(value) {
+  return value === true || value === 'true';
+}
+
 function readMemoryFile(store, name) {
   if (!name.endsWith('.md') || SKIP_FILES.has(name)) return null;
   const file = path.join(store.dir, name);
@@ -226,12 +243,7 @@ function readMemoryFile(store, name) {
   const excludePrompt = meta.exclude_prompt || '';
   const excludePretool = toList(meta.exclude_pretool);
   const excludePreset = toList(meta.exclude_preset);
-  const excludeResolved = [];
-  for (const presetName of excludePreset) {
-    const resolved = resolvePreset(presetName);
-    if (resolved) excludeResolved.push(resolved);
-  }
-  if (excludePrompt) excludeResolved.push(excludePrompt);
+  const excludeResolved = _buildExcludeResolved(excludePreset, excludePrompt);
   return {
     store,
     file,
@@ -242,10 +254,10 @@ function readMemoryFile(store, name) {
     triggerPretool: toList(meta.trigger_pretool),
     triggerPretoolContent: toList(meta.trigger_pretool_content),
     triggerPretoolContentNot: toList(meta.trigger_pretool_content_not),
-    triggerSession: meta.trigger_session === true || meta.trigger_session === 'true',
+    triggerSession: _truthy(meta.trigger_session),
     domain: toList(meta.domain),
     inject: meta.inject === 'full' ? 'full' : 'summary',
-    disabled: meta.disabled === true || meta.disabled === 'true',
+    disabled: _truthy(meta.disabled),
     expired: parseExpired(meta.expires),
     fireMode: parseFireMode(meta.fire_mode, memoryName),
     fireCadence: parseFireCadence(meta.fire_cadence, memoryName),

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -181,7 +181,13 @@ function parseFireCadence(raw, memoryName) {
   return DEFAULT_FIRE_CADENCE;
 }
 
-const PRESETS_PATH = path.join(__dirname, 'synapsys-presets.json');
+// Production resolves to the shipped JSON. Tests opt into a temp file via
+// SYNAPSYS_PRESETS_PATH so they never mutate the on-disk shipped file —
+// concurrent workers reading the real file mid-test would otherwise cache
+// an empty preset Map for their lifetime.
+const PRESETS_PATH = process.env.SYNAPSYS_PRESETS_PATH
+  ? path.resolve(process.env.SYNAPSYS_PRESETS_PATH)
+  : path.join(__dirname, 'synapsys-presets.json');
 let _presetsCache = null;
 
 // Read shipped synapsys-presets.json once and cache the resulting Map.

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -118,6 +118,8 @@ const BRACKET_LIST_KEYS = new Set([
   'trigger_pretool_content',
   'trigger_pretool_content_not',
   'cite_signals',
+  'exclude_pretool',
+  'exclude_preset',
 ]);
 
 function coerceFrontmatterValue(raw, key) {

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -179,6 +179,39 @@ function parseFireCadence(raw, memoryName) {
   return DEFAULT_FIRE_CADENCE;
 }
 
+const PRESETS_PATH = path.join(__dirname, 'synapsys-presets.json');
+let _presetsCache = null;
+
+// Read shipped synapsys-presets.json once and cache the resulting Map.
+// On malformed JSON, degrade to an empty Map and emit a single stderr warning
+// (mirrors the safeRegex fail-closed convention at matcher.js:241).
+function loadPresets() {
+  if (_presetsCache) return _presetsCache;
+  try {
+    const raw = fs.readFileSync(PRESETS_PATH, 'utf8');
+    const obj = JSON.parse(raw);
+    const map = new Map();
+    for (const [k, v] of Object.entries(obj)) {
+      if (typeof v === 'string' && v.length > 0) map.set(k, v);
+    }
+    _presetsCache = map;
+  } catch (err) {
+    process.stderr.write(`[synapsys] presets.json invalid: ${err.message}\n`);
+    _presetsCache = new Map();
+  }
+  return _presetsCache;
+}
+
+// Resolve a preset name to its regex body string. Returns null and emits a
+// single stderr warning for unknown names (caller is expected to call this
+// once per memory at load time so the warning cadence stays sane).
+function resolvePreset(name) {
+  const map = loadPresets();
+  if (map.has(name)) return map.get(name);
+  process.stderr.write(`[synapsys] unknown preset ${name}\n`);
+  return null;
+}
+
 function readMemoryFile(store, name) {
   if (!name.endsWith('.md') || SKIP_FILES.has(name)) return null;
   const file = path.join(store.dir, name);
@@ -190,6 +223,15 @@ function readMemoryFile(store, name) {
   }
   const { meta, body } = parseFrontmatter(raw);
   const memoryName = meta.name || path.basename(name, '.md');
+  const excludePrompt = meta.exclude_prompt || '';
+  const excludePretool = toList(meta.exclude_pretool);
+  const excludePreset = toList(meta.exclude_preset);
+  const excludeResolved = [];
+  for (const presetName of excludePreset) {
+    const resolved = resolvePreset(presetName);
+    if (resolved) excludeResolved.push(resolved);
+  }
+  if (excludePrompt) excludeResolved.push(excludePrompt);
   return {
     store,
     file,
@@ -214,6 +256,10 @@ function readMemoryFile(store, name) {
     // `telemetry` as "enabled" and absent `cite_signals` as "auto-extract".
     citeSignals: normalizeCiteSignals(meta.cite_signals),
     telemetry: normalizeTelemetry(meta.telemetry),
+    excludePrompt,
+    excludePretool,
+    excludePreset,
+    excludeResolved,
     meta,
     body,
   };
@@ -307,5 +353,7 @@ module.exports = {
   parseFrontmatter,
   listMemories,
   listMemoriesFromStore,
+  loadPresets,
+  resolvePreset,
   safeExec,
 };

--- a/plugins/synapsys/lib/synapsys-presets.json
+++ b/plugins/synapsys/lib/synapsys-presets.json
@@ -1,5 +1,5 @@
 {
-  "git-ops": "\\b(git\\s+(push|pull|fetch|merge|rebase|reset|stash|cherry-pick|checkout|switch|branch|tag|remote|clone|init|add|rm|mv|log|diff|status|show|blame|bisect|reflog|worktree|submodule|config))\\b",
-  "ci-monitor": "\\b(gh\\s+run\\s+(list|view|watch|rerun|cancel|download|view-log)|gh\\s+workflow|gh\\s+pr\\s+checks|ci\\s+(status|logs|monitor)|workflow\\s+run|github\\s+actions)\\b",
-  "review-comment-handling": "\\b(resolve\\s+(comment|thread|review)|dismiss\\s+(comment|review)|reply\\s+to\\s+(comment|review)|address\\s+(comment|review|feedback)|gh\\s+pr\\s+review|gh\\s+api\\s+.*/(comments|reviews)|copilot.*comment|cursor.*comment)\\b"
+  "git-ops": "\\b(git\\s+(merge|push|rebase|cherry-pick|reset|checkout)|gh\\s+pr\\s+(merge|view|checks|create|edit)|cascade-merge|merge\\s+conflict)\\b",
+  "ci-monitor": "\\b(follow-up-next|gh\\s+run\\s+(view|rerun|watch)|gh\\s+pr\\s+checks|--log-failed)\\b",
+  "review-comment-handling": "(--solve-comment|--skip-comment|cursor\\[bot\\]|copilot\\[bot\\]|\\breview\\s+(thread|comment)\\b)"
 }

--- a/plugins/synapsys/lib/synapsys-presets.json
+++ b/plugins/synapsys/lib/synapsys-presets.json
@@ -1,0 +1,5 @@
+{
+  "git-ops": "\\b(git\\s+(push|pull|fetch|merge|rebase|reset|stash|cherry-pick|checkout|switch|branch|tag|remote|clone|init|add|rm|mv|log|diff|status|show|blame|bisect|reflog|worktree|submodule|config))\\b",
+  "ci-monitor": "\\b(gh\\s+run\\s+(list|view|watch|rerun|cancel|download|view-log)|gh\\s+workflow|gh\\s+pr\\s+checks|ci\\s+(status|logs|monitor)|workflow\\s+run|github\\s+actions)\\b",
+  "review-comment-handling": "\\b(resolve\\s+(comment|thread|review)|dismiss\\s+(comment|review)|reply\\s+to\\s+(comment|review)|address\\s+(comment|review|feedback)|gh\\s+pr\\s+review|gh\\s+api\\s+.*/(comments|reviews)|copilot.*comment|cursor.*comment)\\b"
+}

--- a/plugins/synapsys/scripts/synapsys-explain.js
+++ b/plugins/synapsys/scripts/synapsys-explain.js
@@ -171,6 +171,7 @@ const MATCHED_LABELS = [
   ['pretool_pattern', 'matched.pretool_pattern'],
   ['content_pattern', 'matched.content_pattern'],
   ['content_substring', 'matched.content_substring'],
+  ['excluded_pattern', 'matched.excluded_pattern'],
 ];
 
 function renderFiredBlock(matched) {
@@ -182,8 +183,15 @@ function renderFiredBlock(matched) {
   return lines;
 }
 
-function renderNotFiredBlock(memory, reason) {
+function renderNotFiredBlock(memory, reason, matched) {
   const lines = [`  fired: ✗  (gate: ${reason || 'unknown'})`];
+  // Surface matched.* keys on suppressed results so reasons like
+  // `exclude-matched` (GH-510) or `negative-excludes` (GH-445) show the
+  // offending pattern alongside the gate label.
+  const m = matched || {};
+  for (const [key, label] of MATCHED_LABELS) {
+    if (m[key] !== undefined) lines.push(`  ${label}: ${m[key]}`);
+  }
   const bodyLines = (memory.body || '').split('\n').filter(Boolean).slice(0, 3);
   if (bodyLines.length) {
     lines.push('  body (first 3 lines):');
@@ -200,7 +208,7 @@ function renderVerboseBlock(memory, result, event) {
   if (trig) lines.push(`  trigger: ${trig}`);
   const body = result.fired
     ? renderFiredBlock(result.matched)
-    : renderNotFiredBlock(memory, result.reason);
+    : renderNotFiredBlock(memory, result.reason, result.matched);
   lines.push(...body);
   return lines.join('\n');
 }

--- a/plugins/synapsys/scripts/synapsys-list.js
+++ b/plugins/synapsys/scripts/synapsys-list.js
@@ -91,6 +91,9 @@ function emitJsonOutput(stores, memories) {
           triggerPrompt: m.triggerPrompt,
           triggerPretool: m.triggerPretool,
           triggerSession: m.triggerSession,
+          excludePrompt: m.excludePrompt || '',
+          excludePretool: Array.isArray(m.excludePretool) ? m.excludePretool : [],
+          excludePreset: Array.isArray(m.excludePreset) ? m.excludePreset : [],
           inject: m.inject,
           domain: Array.isArray(m.domain) ? m.domain : [],
           fireMode: m.fireMode || 'once',
@@ -140,6 +143,12 @@ function renderVerbose(m, fi, C) {
   if (m.triggerPretool.length)
     console.log(`    ${C.dim('pretool:')} ${C.magenta(m.triggerPretool.join(', '))}`);
   if (m.triggerSession) console.log(`    ${C.dim('session:')} ${C.magenta('yes')}`);
+  if (m.excludePrompt)
+    console.log(`    ${C.dim('exclude_prompt:')}  ${C.magenta('/' + m.excludePrompt + '/i')}`);
+  if (Array.isArray(m.excludePretool) && m.excludePretool.length)
+    console.log(`    ${C.dim('exclude_pretool:')} ${C.magenta(m.excludePretool.join(', '))}`);
+  if (Array.isArray(m.excludePreset) && m.excludePreset.length)
+    console.log(`    ${C.dim('exclude_preset:')}  ${C.magenta(m.excludePreset.join(', '))}`);
   console.log(`    ${C.dim('file:')}    ${C.dim(m.file)}`);
 }
 

--- a/plugins/synapsys/tests/fixtures/store-exclude-multi-preset/mem-multi-preset.md
+++ b/plugins/synapsys/tests/fixtures/store-exclude-multi-preset/mem-multi-preset.md
@@ -1,0 +1,14 @@
+---
+name: mem-multi-preset
+description: GH-510 retrofit fallback — adopts BOTH git-ops + ci-monitor presets so the load → resolve path exercises multi-preset composition.
+events: UserPromptSubmit
+trigger_prompt: '\b(ticket|linear|jira)\b'
+exclude_preset: git-ops, ci-monitor
+---
+
+Retrofit fallback fixture (GH-510): the upstream candidate
+`linear-no-external-refs-cortex-instead` is not under version control in
+`plugins/synapsys/`, so this fixture stands in as the canonical adoption
+sample for multi-preset `exclude_preset` composition. Reminds future
+authors that `exclude_preset` accepts a CSV of preset names and the
+resolver concatenates each body into `excludeResolved` at load time.

--- a/plugins/synapsys/tests/fixtures/store-exclude-worked-example/mem-worked-example.md
+++ b/plugins/synapsys/tests/fixtures/store-exclude-worked-example/mem-worked-example.md
@@ -1,0 +1,13 @@
+---
+name: mem-worked-example
+description: Worked example for GH-510 R7 — trigger_prompt fires on ticket work, but exclude_preset suppresses git-ops chatter.
+events: UserPromptSubmit
+trigger_prompt: '\bticket\b'
+exclude_preset: git-ops
+---
+
+Worked example (GH-510): this memory fires on any prompt mentioning "ticket"
+but the `git-ops` preset suppresses the match whenever the same prompt is
+about a git operation (rebase, merge, push, etc.) so the reminder does not
+inject during routine git plumbing. Docs link here as the canonical adoption
+sample for the `exclude_preset` field.


### PR DESCRIPTION
## Existing Behavior

- Synapsys memories only support positive `trigger_prompt` and `trigger_pretool` matching — any keyword hit injects the memory, with no way to suppress injection when the agent is operating in a different context (e.g. git ops, CI monitoring).
- The `MatchResult` typedef has no `excluded_pattern` field; `synapsys-explain` cannot surface why a match was suppressed post-trigger.
- `synapsys:list --verbose` does not display any exclude rules, so authors cannot audit which memories carry suppression patterns.
- No bundled preset library exists; every memory must hard-code its own full exclusion regex, duplicating maintenance effort across teams.

## Intended New Behavior

- Three new frontmatter fields — `exclude_prompt`, `exclude_pretool`, `exclude_preset` — allow memory authors to veto an otherwise-positive trigger match. Evaluation order is locked: trigger → exclude → fire, with `negative-excludes` (GH-445 stage 3) retaining priority over `exclude-matched` (stage 4).
- `synapsys-presets.json` ships three named presets (`git-ops`, `ci-monitor`, `review-comment-handling`) that authors reference by name, keeping frontmatter concise. Preset bodies match the ticket spec verbatim — narrow on purpose so routine commands (`git status`, `git log`, `git diff`) don't silently suppress memories that target code work. Broaden by adding a per-memory `exclude_prompt` if a memory really needs to exclude more than the preset.
- `memory-store.js` resolves `exclude_preset` entries at load time into `excludeResolved`, merging preset regex bodies with any inline `exclude_prompt` pattern.
- `evaluateExcludePrompt` and `evaluateExcludePretool` matcher functions enforce fail-closed invalid-regex handling (two-pass compile then match; bad patterns emit stderr warnings and are skipped rather than aborting).
- `synapsys:list --verbose` surfaces `exclude_prompt`, `exclude_pretool`, and `exclude_preset` lines; `synapsys-explain` renders `matched.excluded_pattern` in both fired and not-fired blocks.

## Brief P0 coverage

- **P0 #1:** `exclude_prompt` frontmatter field gates trigger_prompt matches — implemented in `plugins/synapsys/lib/matcher.js` (`evaluateExcludePrompt`, `matchPrompt`) + `plugins/synapsys/lib/memory-store.js` (`readMemoryFile`)
- **P0 #2:** `exclude_pretool` frontmatter field gates trigger_pretool matches — implemented in `plugins/synapsys/lib/matcher.js` (`evaluateExcludePretool`, `matchPreTool`, `matchPreToolResult`)
- **P0 #3:** `exclude_preset` expands named preset to regex body at load time — implemented in `plugins/synapsys/lib/memory-store.js` (`loadPresets`, `resolvePreset`) + `plugins/synapsys/lib/synapsys-presets.json`
- **P0 #4:** Locked evaluation order (trigger → exclude → fire) documented and enforced — `plugins/synapsys/lib/matcher.js:74-84` (prompt path) and `:188-254` (pretool path)
- **P0 #5:** `hasExcludePatterns` helper exposed for list/explain CLI surface — `plugins/synapsys/lib/matcher.js:341-345`
- **P0 #6:** `synapsys:list --verbose` surfaces exclude rules — `plugins/synapsys/scripts/synapsys-list.js:155-162`
- **P0 #7:** `synapsys-explain` renders `excluded_pattern` label — `plugins/synapsys/scripts/synapsys-explain.js:153, 168-172`
- **P0 #8:** Worked-example fixture demonstrates `exclude_preset: git-ops` + integration test — `plugins/synapsys/tests/fixtures/store-exclude-worked-example/mem-worked-example.md` + `plugins/synapsys/lib/__tests__/exclude-preset-worked-example.integration.test.js`

## Dev Checks

- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Integration test suite:**

The seven exclude-focused test files cover the complete exclude surface:

1. `presets-loader.integration.test.js` — verifies `loadPresets()` / `resolvePreset()` correctly parse `synapsys-presets.json`, handle unknown preset names with stderr warnings, and degrade to an empty map on malformed JSON.
2. `memory-store-exclude.integration.test.js` — verifies `readMemoryFile` correctly populates `excludePrompt`, `excludePretool`, `excludePreset`, and `excludeResolved` from frontmatter.
3. `exclude-prompt-pretool.integration.test.js` — end-to-end matcher tests: a trigger_prompt match is suppressed when `exclude_prompt` matches; a `trigger_pretool` match is suppressed when `exclude_pretool` matches; `negative-excludes` (GH-445) retains priority over `exclude-matched`.
4. `synapsys-list-exclude.integration.test.js` — verifies `synapsys-list --verbose` output includes `exclude_prompt`, `exclude_pretool`, and `exclude_preset` lines.
5. `synapsys-explain-exclude.integration.test.js` — verifies `synapsys-explain` renders `matched.excluded_pattern` and shows `gate: exclude-matched` in the not-fired block.
6. `exclude-preset-worked-example.integration.test.js` — end-to-end scenario: memory with `exclude_preset: git-ops` fires on "fix the ticket" but is suppressed on "git rebase the ticket branch".
7. `exclude-preset-multi.integration.test.js` — multi-preset retrofit fallback: a fixture memory adopts BOTH `git-ops` and `ci-monitor` presets and asserts `excludeResolved.length === 2` plus suppression coverage for prompts matching either preset.

`dispatcher-golden.test.js` also carries a new `exclude-matched` golden row (R20 / Task 2.2) asserting the matcher emits `{ fired: false, reason: 'exclude-matched', matched: { excluded_pattern: <git-ops body> } }` when both trigger and exclude hit the same prompt.

**Manual verification steps:**

1. Install synapsys plugin in a test project (`/synapsys:install`).
2. Create a memory with `exclude_preset: git-ops` in its frontmatter alongside `trigger_prompt: \bticket\b`.
3. Run `synapsys:list --verbose` — confirm the `exclude_preset: git-ops` line appears under the memory.
4. Run `synapsys-explain --prompt "fix the ticket"` — confirm `fired: yes` and `matched.prompt_substring: ticket`.
5. Run `synapsys-explain --prompt "git rebase the ticket branch"` — confirm `fired: no (gate: exclude-matched)` with `matched.excluded_pattern` showing the git-ops regex body.

P1.3 (README/SKILL.md docs) is outstanding but is Should-Have, not blocking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core matcher injection decisions for memories that adopt exclude fields; backward compatibility for memories without excludes is tested, but misconfigured excludes could silently change when reminders fire.
> 
> **Overview**
> Adds **negative trigger gating** for Synapsys memories via `exclude_prompt`, `exclude_pretool`, and `exclude_preset`, plus a shipped **`synapsys-presets.json`** bundle (`git-ops`, `ci-monitor`, `review-comment-handling`).
> 
> After a positive trigger match, the matcher runs exclude rules and returns **`exclude-matched`** with **`matched.excluded_pattern`** instead of firing. **PreToolUse** keeps a fixed ladder: content **`negative-excludes`** still wins over **`exclude-matched`**; prompt excludes are not applied on pretool paths. Invalid exclude regexes are warned on stderr and skipped.
> 
> **`memory-store`** parses the new frontmatter fields, resolves presets at load into **`excludeResolved`**, and exports **`loadPresets`** / **`resolvePreset`**. **`matcher.js`** is split into **`matcher-excludes`**, **`matcher-content`**, and **`matcher-regex`** for line limits.
> 
> **`synapsys-list`** (`--json` / `--verbose`) and **`synapsys-explain`** surface exclude rules and suppressed-match diagnostics. Broad integration tests and fixture memories document single- and multi-preset adoption; **`dispatcher-golden`** adds an **`exclude-matched`** matcher regression row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c965f48fcb7b4ffc177abd57829cfb3719420981. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

