### PR TITLE
feat(heimdall): add shared kind for cross-project lock store

### DIFF
--- a/plugins/heimdall/README.md
+++ b/plugins/heimdall/README.md
@@ -54,11 +54,25 @@ Config lives in the store marker `.heimdall.json`:
 | global   | `~/.claude/heimdall/<project>`        | survives worktree deletion (scoped to this project)                |
 | shared   | `~/.claude/heimdall-shared`           | user-wide across every project — e.g. `~/.claude`, `~/.gitconfig`, `~/.ssh`, `~/.aws` |
 
-Locks from every active store are merged at evaluation time. When the same
-path is protected by more than one store, the earlier kind wins:
-**`local > worktree > global > shared`**. The `shared` store applies last
-and broadest — use it for user-wide paths that should be guarded in every
-project, while keeping per-project locks in `local`/`worktree`/`global`.
+Locks from every active store are merged at evaluation time. Entries from
+all active stores remain in force simultaneously and any of the configured
+unlock phrases lifts the lock for the path it covers — sharing the same
+unlock phrase across stores does **not** merge their `allowedPaths` or
+`trustedSubdirs` into a single combined lock.
+
+Precedence order (**`local > worktree > global > shared`**) determines:
+
+- the order entries are evaluated, the order entries are listed by
+  `/heimdall:list`, and the entry that names the rejection message, **not**
+  whether an earlier-kind lock overrides a later-kind lock.
+- when two stores protect the **same exact path**, the earlier-kind
+  entry is the one matched first for that path — so its `allowedPaths`
+  and `unlockPhrase` decide the verdict for that path. Stores protecting
+  **different** paths each enforce their own paths independently.
+
+The `shared` store applies broadest — use it for user-wide paths that
+should be guarded in every project, while keeping per-project locks in
+`local`/`worktree`/`global`.
 
 ### Migrating from the home-level workaround
 

--- a/plugins/heimdall/README.md
+++ b/plugins/heimdall/README.md
@@ -47,17 +47,36 @@ Config lives in the store marker `.heimdall.json`:
 
 ## Store kinds (like synapsys)
 
-| kind     | location                              | scope                          |
-|----------|---------------------------------------|--------------------------------|
-| local    | `./.claude/heimdall`                  | this directory                 |
-| worktree | nearest ancestor `../.claude/heimdall`| shared across a worktree base  |
-| global   | `~/.claude/heimdall/<project>`        | survives worktree deletion     |
+| kind     | location                              | scope                                                              |
+|----------|---------------------------------------|--------------------------------------------------------------------|
+| local    | `./.claude/heimdall`                  | this directory                                                     |
+| worktree | nearest ancestor `../.claude/heimdall`| shared across a worktree base                                      |
+| global   | `~/.claude/heimdall/<project>`        | survives worktree deletion (scoped to this project)                |
+| shared   | `~/.claude/heimdall-shared`           | user-wide across every project — e.g. `~/.claude`, `~/.gitconfig`, `~/.ssh`, `~/.aws` |
 
-Locks from every active store are merged at evaluation time.
+Locks from every active store are merged at evaluation time. When the same
+path is protected by more than one store, the earlier kind wins:
+**`local > worktree > global > shared`**. The `shared` store applies last
+and broadest — use it for user-wide paths that should be guarded in every
+project, while keeping per-project locks in `local`/`worktree`/`global`.
+
+### Migrating from the home-level workaround
+
+If you previously worked around the lack of a shared kind by placing a
+marker directly at `~/.claude/heimdall/.heimdall.json`, move it under the
+new shared directory in one shot:
+
+```bash
+mkdir -p ~/.claude/heimdall-shared && \
+  mv ~/.claude/heimdall/.heimdall.json ~/.claude/heimdall-shared/.heimdall.json
+```
+
+Then run `/heimdall:list` to confirm the locks are now reported under the
+`shared` kind.
 
 ## Skills
 
-- **`/heimdall:install [local|worktree|global]`** — create a store (`.heimdall.json`).
+- **`/heimdall:install [local|worktree|global|shared]`** — create a store (`.heimdall.json`).
 - **`/heimdall:protect <paths> [phrase]`** — add/extend a lock block.
 - **`/heimdall:unprotect <phrase> [paths]`** — remove a block or specific paths.
 - **`/heimdall:list`** — show every store, block, phrase, and resolved file/dir.

--- a/plugins/heimdall/lib/__tests__/cli.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/cli.integration.test.js
@@ -1,0 +1,65 @@
+// Integration tests for Heimdall lib/cli.js `resolveStoreDirs` four-kind support.
+//
+// Discovered by plugins/work/scripts/run-tests.sh.
+// Manual: node --test plugins/heimdall/lib/__tests__/cli.integration.test.js
+//
+// Covers GH-541 Task 2 scenarios:
+//   - resolveStoreDirs({ kind: 'bogus' }) returns error containing local|worktree|global|shared
+//   - resolveStoreDirs({ kind: 'shared' }) returns the shared dir
+//   - VALID_KINDS exported constant lists all four kinds
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const cliPath = path.resolve(__dirname, '..', 'cli');
+const lockStorePath = path.resolve(__dirname, '..', 'lock-store');
+
+const { resolveStoreDirs, VALID_KINDS } = require(cliPath);
+const { FOLDER } = require(lockStorePath);
+
+let originalHome;
+let base;
+let fakeHome;
+
+before(() => {
+  originalHome = os.homedir();
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-cli-it-'));
+  fakeHome = path.join(base, 'home');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  process.env.HOME = fakeHome;
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+describe('resolveStoreDirs error string lists all four kinds', () => {
+  it('returns error referencing local|worktree|global|shared for bogus kind', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'bogus-'));
+    const { dirs, error } = resolveStoreDirs({ cwd, kind: 'bogus' });
+    assert.deepEqual(dirs, []);
+    assert.ok(error, 'expected an error message');
+    assert.match(error, /local\|worktree\|global\|shared/);
+    assert.match(error, /bogus/);
+  });
+});
+
+describe('resolveStoreDirs accepts kind=shared', () => {
+  it('returns the shared dir at ~/.claude/heimdall-shared', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'shared-'));
+    const { dirs, error } = resolveStoreDirs({ cwd, kind: 'shared' });
+    assert.equal(error, null, `expected no error, got: ${error}`);
+    const expected = path.join(os.homedir(), '.claude', `${FOLDER}-shared`);
+    assert.deepEqual(dirs, [expected]);
+  });
+});
+
+describe('VALID_KINDS export', () => {
+  it('exports the four valid kinds in precedence order', () => {
+    assert.deepEqual(VALID_KINDS, ['local', 'worktree', 'global', 'shared']);
+  });
+});

--- a/plugins/heimdall/lib/__tests__/init-shared.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/init-shared.integration.test.js
@@ -1,0 +1,80 @@
+// Integration tests for Heimdall scripts/heimdall-init.js --kind=shared support.
+//
+// Discovered by plugins/work/scripts/run-tests.sh.
+// Manual: node --test plugins/heimdall/lib/__tests__/init-shared.integration.test.js
+//
+// Covers GH-541 Task 3 scenarios (AC4, AC5):
+//   - --kind=shared writes marker at exactly ~/.claude/heimdall-shared/.heimdall.json
+//     (no <projectName> subdir), with marker kind === "shared".
+//   - --kind=bogus exits non-zero; stderr contains local|worktree|global|shared.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const initScript = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-init.js');
+const { FOLDER, MARKER } = require(path.resolve(__dirname, '..', 'lock-store'));
+
+let originalHome;
+let base;
+let fakeHome;
+
+before(() => {
+  originalHome = os.homedir();
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-init-shared-it-'));
+  fakeHome = path.join(base, 'home');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  process.env.HOME = fakeHome;
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+function runInit(args, cwd) {
+  return spawnSync(process.execPath, [initScript, ...args], {
+    cwd,
+    env: { ...process.env, HOME: fakeHome },
+    encoding: 'utf8',
+  });
+}
+
+describe('heimdall-init.js --kind=shared', () => {
+  it('writes marker at ~/.claude/heimdall-shared/.heimdall.json with no project subdir', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-'));
+    const res = runInit(['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}\nstdout: ${res.stdout}`);
+
+    const expectedDir = path.join(fakeHome, '.claude', `${FOLDER}-shared`);
+    const expectedMarker = path.join(expectedDir, MARKER);
+    assert.ok(
+      fs.existsSync(expectedMarker),
+      `expected marker at ${expectedMarker}, got: ${res.stdout}`
+    );
+
+    // No project subdir should be created under heimdall-shared.
+    const entries = fs.readdirSync(expectedDir);
+    assert.deepEqual(
+      entries.sort(),
+      [MARKER].sort(),
+      `expected only the marker in shared dir, got: ${entries.join(', ')}`
+    );
+
+    const cfg = JSON.parse(fs.readFileSync(expectedMarker, 'utf8'));
+    assert.equal(cfg.kind, 'shared');
+  });
+});
+
+describe('heimdall-init.js --kind=bogus', () => {
+  it('exits non-zero and stderr lists local|worktree|global|shared', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'bogus-'));
+    const res = runInit(['--kind=bogus', `--cwd=${cwd}`], cwd);
+    assert.notEqual(res.status, 0, `expected non-zero exit, got ${res.status}`);
+    assert.match(res.stderr, /local\|worktree\|global\|shared/);
+    assert.match(res.stderr, /bogus/);
+  });
+});

--- a/plugins/heimdall/lib/__tests__/init-shared.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/init-shared.integration.test.js
@@ -66,6 +66,7 @@ describe('heimdall-init.js --kind=shared', () => {
 
     const cfg = JSON.parse(fs.readFileSync(expectedMarker, 'utf8'));
     assert.equal(cfg.kind, 'shared');
+    assert.equal(cfg.projectName, null, 'shared marker must not embed a project name');
   });
 });
 

--- a/plugins/heimdall/lib/__tests__/list-shared.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/list-shared.integration.test.js
@@ -1,0 +1,114 @@
+// Integration tests for Heimdall scripts/heimdall-list.js shared store
+// header + JSON entry.
+//
+// Discovered by plugins/work/scripts/run-tests.sh.
+// Manual: node --test plugins/heimdall/lib/__tests__/list-shared.integration.test.js
+//
+// Covers GH-541 Task 6 scenarios (R7, AC9):
+//   - Human output includes `# shared store —` when a shared store exists.
+//   - `--json` output includes an entry with kind === 'shared'.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const listScript = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-list.js');
+const initScript = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-init.js');
+const protectScript = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-protect.js');
+
+let originalHome;
+let base;
+let fakeHome;
+
+before(() => {
+  originalHome = os.homedir();
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-list-shared-it-'));
+  fakeHome = path.join(base, 'home');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  process.env.HOME = fakeHome;
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+function run(script, args, cwd) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd,
+    env: { ...process.env, HOME: fakeHome },
+    encoding: 'utf8',
+  });
+}
+
+describe('heimdall-list.js shared store rendering', () => {
+  it('human output contains "# shared store —" when a shared store exists', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-human-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const prot = run(
+      protectScript,
+      [
+        '--kind=shared',
+        '--phrase=edit shared target',
+        '--paths=~/.claude/test-target',
+        `--cwd=${cwd}`,
+      ],
+      cwd
+    );
+    assert.equal(prot.status, 0, `protect failed: ${prot.stderr}`);
+
+    const res = run(listScript, [`--cwd=${cwd}`], cwd);
+    assert.equal(res.status, 0, `list failed: ${res.stderr}`);
+    assert.match(
+      res.stdout,
+      /# shared store —/,
+      `stdout should contain "# shared store —"; got: ${res.stdout}`
+    );
+    // The shared header must include the lock count so users can see at a
+    // glance whether a store is empty. Format: "# shared store — <dir> (N locks)".
+    assert.match(
+      res.stdout,
+      /# shared store — \S.*\(1 lock(s)?\)/,
+      `shared header should include lock count like "(1 lock)"; got: ${res.stdout}`
+    );
+  });
+
+  it('--json output includes at least one entry with kind === "shared"', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-json-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const prot = run(
+      protectScript,
+      [
+        '--kind=shared',
+        '--phrase=edit shared target',
+        '--paths=~/.claude/test-target',
+        `--cwd=${cwd}`,
+      ],
+      cwd
+    );
+    assert.equal(prot.status, 0, `protect failed: ${prot.stderr}`);
+
+    const res = run(listScript, ['--json', `--cwd=${cwd}`], cwd);
+    assert.equal(res.status, 0, `list --json failed: ${res.stderr}`);
+
+    let parsed;
+    try {
+      parsed = JSON.parse(res.stdout);
+    } catch (err) {
+      assert.fail(`--json output was not valid JSON: ${err.message}; stdout: ${res.stdout}`);
+    }
+    assert.ok(Array.isArray(parsed), '--json output should be an array');
+    const sharedEntry = parsed.find((e) => e && e.kind === 'shared');
+    assert.ok(
+      sharedEntry,
+      `--json output should include an entry with kind === "shared"; got: ${JSON.stringify(parsed)}`
+    );
+  });
+});

--- a/plugins/heimdall/lib/__tests__/lock-store.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/lock-store.integration.test.js
@@ -92,15 +92,26 @@ describe('discoverStores returns the shared store from any cwd', () => {
   });
 });
 
-describe('discoverStores does not report ~/.claude/heimdall as a worktree ancestor', () => {
-  it('returns no spurious worktree entry when cwd is nested under HOME', () => {
-    // Seed a marker at `<fakeHome>/.claude/heimdall/.heimdall.json`. Without
-    // the HOME-stop in findAncestorStore(), discoverStores() for a cwd nested
-    // under HOME would walk up past HOME and pick this marker up as a
-    // "worktree" ancestor — leaking an unrelated project's locks into this
-    // session. Guards the GH-541 R11 fix in lib/lock-store.js.
-    writeConfig(path.join(fakeHome, '.claude', FOLDER), { kind: 'global', locks: [] });
+describe('findAncestorStore HOME boundary', () => {
+  it('discovers worktree marker installed at HOME (repo directly under home)', () => {
+    // A `--kind=worktree` install from `~/myrepo` writes its marker to
+    // `~/.claude/heimdall/.heimdall.json` via candidateStores. discoverStores
+    // from `~/myrepo` must surface that as the worktree entry.
+    writeConfig(path.join(fakeHome, '.claude', FOLDER), { kind: 'worktree', locks: [] });
 
+    const repo = path.join(fakeHome, 'myrepo');
+    fs.mkdirSync(repo, { recursive: true });
+
+    const stores = discoverStores(repo);
+    const worktree = stores.find((s) => s.kind === 'worktree');
+    assert.ok(worktree, 'expected worktree store for repo directly under HOME');
+    assert.equal(worktree.dir, path.join(fakeHome, '.claude', FOLDER));
+  });
+
+  it('does not walk past HOME (sandbox isolation)', () => {
+    // No marker seeded at HOME or above. discoverStores from a cwd nested
+    // under HOME must not walk past HOME and pick up a marker in the real
+    // user's HOME (this is what the HOME stop protects against).
     const sub = path.join(fakeHome, 'sub', 'dir');
     fs.mkdirSync(sub, { recursive: true });
 

--- a/plugins/heimdall/lib/__tests__/lock-store.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/lock-store.integration.test.js
@@ -14,9 +14,15 @@ const os = require('node:os');
 const path = require('node:path');
 
 const lockStorePath = path.resolve(__dirname, '..', 'lock-store');
-const { MARKER, FOLDER, candidateStores, discoverStores, writeConfig, SHARED_FOLDER } = require(
-  lockStorePath
-);
+const {
+  MARKER,
+  FOLDER,
+  candidateStores,
+  discoverStores,
+  writeConfig,
+  SHARED_FOLDER,
+  PRECEDENCE_ORDER,
+} = require(lockStorePath);
 
 let originalHome;
 let base;
@@ -122,6 +128,54 @@ describe('findAncestorStore HOME boundary', () => {
       undefined,
       `expected no worktree store, got ${JSON.stringify(worktree)}`
     );
+  });
+});
+
+describe('discoverStores order is data-driven from PRECEDENCE_ORDER', () => {
+  it('returned kinds match PRECEDENCE_ORDER when all four markers are seeded', () => {
+    // Regression guard: reordering PRECEDENCE_ORDER must transparently
+    // reorder discoverStores output. If the loop ever stops driving off the
+    // constant, this test catches it.
+    const wt = path.join(base, 'pmwt');
+    const repo = path.join(wt, 'repo');
+    fs.mkdirSync(repo, { recursive: true });
+
+    writeConfig(path.join(repo, '.claude', FOLDER), { kind: 'local', locks: [] });
+    writeConfig(path.join(wt, '.claude', FOLDER), { kind: 'worktree', locks: [] });
+    writeConfig(path.join(fakeHome, '.claude', FOLDER, 'repo'), { kind: 'global', locks: [] });
+    writeConfig(sharedDir, { kind: 'shared', locks: [] });
+
+    const stores = discoverStores(repo);
+    assert.deepEqual(
+      stores.map((s) => s.kind),
+      [...PRECEDENCE_ORDER]
+    );
+  });
+});
+
+describe('Backward-compat: pre-shared layouts unchanged', () => {
+  it('discoverStores with only local/worktree/global markers returns same shape as before #545', () => {
+    // Seeds the three pre-existing kinds and asserts that:
+    //   - exactly those three kinds come back, in their canonical order
+    //   - shared is absent (no marker → not surfaced)
+    //   - each non-shared store carries a projectName (not null)
+    const wt = path.join(base, 'bcwt');
+    const repo = path.join(wt, 'repo');
+    fs.mkdirSync(repo, { recursive: true });
+
+    writeConfig(path.join(repo, '.claude', FOLDER), { kind: 'local', locks: [] });
+    writeConfig(path.join(wt, '.claude', FOLDER), { kind: 'worktree', locks: [] });
+    writeConfig(path.join(fakeHome, '.claude', FOLDER, 'repo'), { kind: 'global', locks: [] });
+
+    const stores = discoverStores(repo);
+    assert.deepEqual(
+      stores.map((s) => s.kind),
+      ['local', 'worktree', 'global']
+    );
+    for (const s of stores) {
+      assert.equal(typeof s.projectName, 'string');
+      assert.ok(s.projectName.length > 0);
+    }
   });
 });
 

--- a/plugins/heimdall/lib/__tests__/lock-store.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/lock-store.integration.test.js
@@ -1,0 +1,123 @@
+// Integration tests for Heimdall lock-store `shared` kind discovery.
+//
+// Discovered by plugins/work/scripts/run-tests.sh.
+// Manual: node --test plugins/heimdall/lib/__tests__/lock-store.integration.test.js
+//
+// Covers GH-541 Task 1 scenarios:
+//   - discoverStores returns the shared store from any cwd
+//   - discoverStores precedence orders shared last (local, worktree, global, shared)
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const lockStorePath = path.resolve(__dirname, '..', 'lock-store');
+const { MARKER, FOLDER, candidateStores, discoverStores, writeConfig, SHARED_FOLDER } = require(
+  lockStorePath
+);
+
+let originalHome;
+let base;
+let fakeHome;
+let sharedDir;
+
+before(() => {
+  originalHome = os.homedir();
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-shared-it-'));
+  fakeHome = path.join(base, 'home');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  process.env.HOME = fakeHome;
+  // os.homedir() caches via env on POSIX; reassert.
+  sharedDir = path.join(fakeHome, '.claude', SHARED_FOLDER || 'heimdall-shared');
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Reset shared dir between tests so we can selectively seed it.
+  fs.rmSync(path.join(fakeHome, '.claude'), { recursive: true, force: true });
+});
+
+describe('SHARED_FOLDER constant', () => {
+  it('equals `${FOLDER}-shared`', () => {
+    assert.equal(SHARED_FOLDER, `${FOLDER}-shared`);
+  });
+});
+
+describe('candidateStores includes shared row', () => {
+  it('returns a row with kind=shared at ~/.claude/heimdall-shared', () => {
+    const rows = candidateStores('/tmp/anywhere', 'anyproject');
+    const shared = rows.find((r) => r.kind === 'shared');
+    assert.ok(shared, 'expected a candidate row with kind=shared');
+    assert.equal(shared.dir, path.join(os.homedir(), '.claude', `${FOLDER}-shared`));
+  });
+});
+
+describe('discoverStores returns the shared store from any cwd', () => {
+  beforeEach(() => {
+    // Seed shared marker only.
+    writeConfig(sharedDir, { kind: 'shared', locks: [] });
+  });
+
+  it('discovers shared from cwd1', () => {
+    const cwd1 = fs.mkdtempSync(path.join(base, 'cwd1-'));
+    const stores = discoverStores(cwd1);
+    const shared = stores.find((s) => s.kind === 'shared');
+    assert.ok(shared, 'expected shared store in discoverStores result');
+    assert.equal(shared.dir, sharedDir);
+    assert.equal(shared.projectName, null);
+  });
+
+  it('discovers shared from cwd2', () => {
+    const cwd2 = fs.mkdtempSync(path.join(base, 'cwd2-'));
+    const stores = discoverStores(cwd2);
+    const shared = stores.find((s) => s.kind === 'shared');
+    assert.ok(shared);
+    assert.equal(shared.dir, sharedDir);
+    assert.equal(shared.projectName, null);
+  });
+
+  it('discovers shared from cwd3', () => {
+    const cwd3 = fs.mkdtempSync(path.join(base, 'cwd3-'));
+    const stores = discoverStores(cwd3);
+    const shared = stores.find((s) => s.kind === 'shared');
+    assert.ok(shared);
+    assert.equal(shared.dir, sharedDir);
+    assert.equal(shared.projectName, null);
+  });
+});
+
+describe('discoverStores precedence orders shared last', () => {
+  it('returns entries in order local, worktree, global, shared', () => {
+    // Layout: <base>/wt/.claude/heimdall (worktree marker)
+    //         <base>/wt/repo/.claude/heimdall (local marker)
+    //         ~/.claude/heimdall/<projectName> (global marker)
+    //         ~/.claude/heimdall-shared (shared marker)
+    const wt = path.join(base, 'wt');
+    const repo = path.join(wt, 'repo');
+    fs.mkdirSync(repo, { recursive: true });
+
+    writeConfig(path.join(repo, '.claude', FOLDER), { kind: 'local', locks: [] });
+    writeConfig(path.join(wt, '.claude', FOLDER), { kind: 'worktree', locks: [] });
+    // Use 'repo' as the projectName since git is likely unavailable / not a repo.
+    writeConfig(path.join(fakeHome, '.claude', FOLDER, 'repo'), { kind: 'global', locks: [] });
+    writeConfig(sharedDir, { kind: 'shared', locks: [] });
+
+    assert.ok(fs.existsSync(path.join(sharedDir, MARKER)), 'shared marker seeded');
+
+    const stores = discoverStores(repo);
+    const kinds = stores.map((s) => s.kind);
+    // Expect exactly this order; filter out any unknowns just in case.
+    assert.deepEqual(
+      kinds.filter((k) => ['local', 'worktree', 'global', 'shared'].includes(k)),
+      ['local', 'worktree', 'global', 'shared']
+    );
+    // And shared must be the last entry overall.
+    assert.equal(kinds[kinds.length - 1], 'shared');
+  });
+});

--- a/plugins/heimdall/lib/__tests__/lock-store.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/lock-store.integration.test.js
@@ -44,7 +44,7 @@ beforeEach(() => {
 });
 
 describe('SHARED_FOLDER constant', () => {
-  it('equals `${FOLDER}-shared`', () => {
+  it('equals FOLDER + "-shared"', () => {
     assert.equal(SHARED_FOLDER, `${FOLDER}-shared`);
   });
 });

--- a/plugins/heimdall/lib/__tests__/lock-store.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/lock-store.integration.test.js
@@ -92,6 +92,28 @@ describe('discoverStores returns the shared store from any cwd', () => {
   });
 });
 
+describe('discoverStores does not report ~/.claude/heimdall as a worktree ancestor', () => {
+  it('returns no spurious worktree entry when cwd is nested under HOME', () => {
+    // Seed a marker at `<fakeHome>/.claude/heimdall/.heimdall.json`. Without
+    // the HOME-stop in findAncestorStore(), discoverStores() for a cwd nested
+    // under HOME would walk up past HOME and pick this marker up as a
+    // "worktree" ancestor — leaking an unrelated project's locks into this
+    // session. Guards the GH-541 R11 fix in lib/lock-store.js.
+    writeConfig(path.join(fakeHome, '.claude', FOLDER), { kind: 'global', locks: [] });
+
+    const sub = path.join(fakeHome, 'sub', 'dir');
+    fs.mkdirSync(sub, { recursive: true });
+
+    const stores = discoverStores(sub);
+    const worktree = stores.find((s) => s.kind === 'worktree');
+    assert.equal(
+      worktree,
+      undefined,
+      `expected no worktree store, got ${JSON.stringify(worktree)}`
+    );
+  });
+});
+
 describe('discoverStores precedence orders shared last', () => {
   it('returns entries in order local, worktree, global, shared', () => {
     // Layout: <base>/wt/.claude/heimdall (worktree marker)

--- a/plugins/heimdall/lib/__tests__/precedence-merge.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/precedence-merge.integration.test.js
@@ -18,14 +18,7 @@ const lockStorePath = path.resolve(__dirname, '..', 'lock-store');
 const guardPath = path.resolve(__dirname, '..', 'guard');
 
 const lockStore = require(lockStorePath);
-const {
-  MARKER,
-  FOLDER,
-  SHARED_FOLDER,
-  discoverStores,
-  readConfig,
-  writeConfig,
-} = lockStore;
+const { MARKER, FOLDER, SHARED_FOLDER, discoverStores, readConfig, writeConfig } = lockStore;
 const { buildEntries } = require(guardPath);
 
 let originalHome;
@@ -111,6 +104,63 @@ describe('Four-kind precedence merge for buildEntries', () => {
     assert.deepEqual(
       merged.map((m) => m.entry.unlockPhrase),
       ['unlock-local', 'unlock-worktree', 'unlock-global', 'unlock-shared']
+    );
+  });
+
+  it('local store with wide allowedPaths does NOT merge into a shared store sharing the same unlock phrase', () => {
+    // Regression for #545 §5D ambiguity: sharing an unlock phrase between
+    // stores must not merge their `allowedPaths` into a combined entry.
+    // Each store contributes an independent entry with its own
+    // `allowedPaths`, so a looser local store cannot weaken a stricter
+    // shared store on a path only the shared store protects.
+    const wt = path.join(base, 'wt-allow');
+    const repo = path.join(wt, 'repo');
+    fs.mkdirSync(repo, { recursive: true });
+
+    writeConfig(path.join(repo, '.claude', FOLDER), {
+      kind: 'local',
+      locks: [
+        {
+          unlockPhrase: 'edit secrets',
+          protect: ['repo-config'],
+          allowedPaths: ['everything', '**'],
+        },
+      ],
+    });
+    writeConfig(sharedDir, {
+      kind: 'shared',
+      locks: [
+        {
+          unlockPhrase: 'edit secrets',
+          protect: ['~/secret'],
+        },
+      ],
+    });
+
+    const stores = discoverStores(repo);
+    const allLocks = [];
+    for (const store of stores) {
+      const cfg = readConfig(store.dir) || { locks: [] };
+      allLocks.push(...cfg.locks);
+    }
+    const entries = buildEntries(allLocks, repo);
+
+    // Exactly two entries — one per store — even though the phrase matches.
+    assert.equal(entries.length, 2, 'expected one entry per store, not a merged single entry');
+
+    const localEntry = entries.find((e) => e.dir.includes('repo-config'));
+    const sharedEntry = entries.find((e) => e.dir.includes('secret'));
+    assert.ok(localEntry, 'expected a local entry for repo-config');
+    assert.ok(sharedEntry, 'expected a shared entry for ~/secret');
+
+    // The local entry's wide allowedPaths must NOT have leaked into the
+    // shared entry. If it had, a write under the shared entry's dir would be
+    // allowed by `isInAllowedSubdir` — the under-protection §5D warned about.
+    assert.deepEqual(localEntry.allowedPaths, ['everything', '**']);
+    assert.equal(
+      sharedEntry.allowedPaths,
+      null,
+      'shared entry must retain null allowedPaths regardless of phrase collision with local'
     );
   });
 

--- a/plugins/heimdall/lib/__tests__/precedence-merge.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/precedence-merge.integration.test.js
@@ -1,0 +1,148 @@
+// Integration test for four-kind precedence merge via `buildEntries`.
+//
+// Discovered by plugins/work/scripts/run-tests.sh.
+// Manual: node --test plugins/heimdall/lib/__tests__/precedence-merge.integration.test.js
+//
+// Covers GH-541 Task 8 / AC7:
+//   With local/worktree/global/shared markers each holding one distinct
+//   lock block, buildEntries over the merged discoverStores output contains
+//   all four blocks, ordered local, worktree, global, shared.
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const lockStorePath = path.resolve(__dirname, '..', 'lock-store');
+const guardPath = path.resolve(__dirname, '..', 'guard');
+
+const lockStore = require(lockStorePath);
+const {
+  MARKER,
+  FOLDER,
+  SHARED_FOLDER,
+  discoverStores,
+  readConfig,
+  writeConfig,
+} = lockStore;
+const { buildEntries } = require(guardPath);
+
+let originalHome;
+let base;
+let fakeHome;
+let sharedDir;
+
+before(() => {
+  originalHome = os.homedir();
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-precedence-it-'));
+  fakeHome = path.join(base, 'home');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  process.env.HOME = fakeHome;
+  sharedDir = path.join(fakeHome, '.claude', SHARED_FOLDER || 'heimdall-shared');
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  fs.rmSync(path.join(fakeHome, '.claude'), { recursive: true, force: true });
+});
+
+describe('Four-kind precedence merge for buildEntries', () => {
+  it('merges entries from all four stores in order local, worktree, global, shared', () => {
+    const wt = path.join(base, 'wt');
+    const repo = path.join(wt, 'repo');
+    fs.mkdirSync(repo, { recursive: true });
+
+    const localLock = {
+      unlockPhrase: 'unlock-local',
+      protect: ['local-target'],
+    };
+    const worktreeLock = {
+      unlockPhrase: 'unlock-worktree',
+      protect: ['worktree-target'],
+    };
+    const globalLock = {
+      unlockPhrase: 'unlock-global',
+      protect: ['global-target'],
+    };
+    const sharedLock = {
+      unlockPhrase: 'unlock-shared',
+      protect: ['~/shared-target'],
+    };
+
+    writeConfig(path.join(repo, '.claude', FOLDER), { kind: 'local', locks: [localLock] });
+    writeConfig(path.join(wt, '.claude', FOLDER), { kind: 'worktree', locks: [worktreeLock] });
+    writeConfig(path.join(fakeHome, '.claude', FOLDER, 'repo'), {
+      kind: 'global',
+      locks: [globalLock],
+    });
+    writeConfig(sharedDir, { kind: 'shared', locks: [sharedLock] });
+
+    assert.ok(fs.existsSync(path.join(sharedDir, MARKER)), 'shared marker seeded');
+
+    const stores = discoverStores(repo);
+    const known = stores.filter((s) => ['local', 'worktree', 'global', 'shared'].includes(s.kind));
+
+    // Build merged entries in store order — this represents the precedence
+    // order local > worktree > global > shared.
+    const merged = [];
+    for (const store of known) {
+      const cfg = readConfig(store.dir) || { locks: [] };
+      for (const entry of buildEntries(cfg.locks, store.dir)) {
+        merged.push({ kind: store.kind, entry });
+      }
+    }
+
+    // All four blocks present.
+    assert.equal(merged.length, 4, 'expected one merged entry per store');
+
+    // Ordered local, worktree, global, shared.
+    assert.deepEqual(
+      merged.map((m) => m.kind),
+      ['local', 'worktree', 'global', 'shared']
+    );
+
+    // Each entry carries the right unlockPhrase, proving union semantics
+    // across stores rather than overwrite.
+    assert.deepEqual(
+      merged.map((m) => m.entry.unlockPhrase),
+      ['unlock-local', 'unlock-worktree', 'unlock-global', 'unlock-shared']
+    );
+  });
+
+  it('discoverStores precedence orders shared last', () => {
+    // R4 says heimdall must "Define and document lock-merge precedence
+    // local > worktree > global > shared". A documented constant lets
+    // downstream consumers (merge/scan/list) align on the same order rather
+    // than hand-rolling string literals.
+    assert.ok(
+      Array.isArray(lockStore.PRECEDENCE_ORDER),
+      'lock-store must export PRECEDENCE_ORDER array'
+    );
+    assert.deepEqual(
+      lockStore.PRECEDENCE_ORDER,
+      ['local', 'worktree', 'global', 'shared'],
+      'PRECEDENCE_ORDER must encode R4 precedence local > worktree > global > shared'
+    );
+
+    // And the live discovery order must agree with the documented constant.
+    const wt = path.join(base, 'wt2');
+    const repo = path.join(wt, 'repo');
+    fs.mkdirSync(repo, { recursive: true });
+    writeConfig(path.join(repo, '.claude', FOLDER), { kind: 'local', locks: [] });
+    writeConfig(path.join(wt, '.claude', FOLDER), { kind: 'worktree', locks: [] });
+    writeConfig(path.join(fakeHome, '.claude', FOLDER, 'repo'), { kind: 'global', locks: [] });
+    writeConfig(sharedDir, { kind: 'shared', locks: [] });
+
+    const liveKinds = discoverStores(repo).map((s) => s.kind);
+    assert.deepEqual(
+      liveKinds,
+      lockStore.PRECEDENCE_ORDER,
+      'discoverStores order must match PRECEDENCE_ORDER constant'
+    );
+  });
+});

--- a/plugins/heimdall/lib/__tests__/protect-shared.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/protect-shared.integration.test.js
@@ -1,0 +1,93 @@
+// Integration tests for Heimdall scripts/heimdall-protect.js --kind=shared
+// repo-relative path rejection.
+//
+// Discovered by plugins/work/scripts/run-tests.sh.
+// Manual: node --test plugins/heimdall/lib/__tests__/protect-shared.integration.test.js
+//
+// Covers GH-541 Task 5 scenarios (R12, AC6):
+//   - --kind=shared --paths=<repo-relative> exits non-zero; stderr suggests
+//     the three alternative kinds: local, worktree, global.
+//   - --kind=shared --paths=~/.claude/<something> succeeds (no false reject).
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const protectScript = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-protect.js');
+const initScript = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-init.js');
+
+let originalHome;
+let base;
+let fakeHome;
+
+before(() => {
+  originalHome = os.homedir();
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-protect-shared-it-'));
+  fakeHome = path.join(base, 'home');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  process.env.HOME = fakeHome;
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+function run(script, args, cwd) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd,
+    env: { ...process.env, HOME: fakeHome },
+    encoding: 'utf8',
+  });
+}
+
+describe('heimdall-protect.js --kind=shared rejects repo-relative paths', () => {
+  it('exits non-zero and stderr suggests local/worktree/global', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-reject-'));
+    // Ensure shared store exists so we don't fail for an unrelated reason.
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const res = run(
+      protectScript,
+      [
+        '--kind=shared',
+        '--phrase=edit pkg',
+        '--paths=package.json',
+        `--cwd=${cwd}`,
+      ],
+      cwd
+    );
+    assert.notEqual(res.status, 0, `expected non-zero exit, got ${res.status}; stderr: ${res.stderr}`);
+    assert.match(res.stderr, /local/, `stderr should mention "local": ${res.stderr}`);
+    assert.match(res.stderr, /worktree/, `stderr should mention "worktree": ${res.stderr}`);
+    assert.match(res.stderr, /global/, `stderr should mention "global": ${res.stderr}`);
+  });
+});
+
+describe('heimdall-protect.js --kind=shared accepts home-anchored paths', () => {
+  it('succeeds with --paths=~/.claude/<something>', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-accept-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const res = run(
+      protectScript,
+      [
+        '--kind=shared',
+        '--phrase=edit shared target',
+        '--paths=~/.claude/test-target',
+        `--cwd=${cwd}`,
+      ],
+      cwd
+    );
+    assert.equal(
+      res.status,
+      0,
+      `expected success exit; stderr: ${res.stderr}; stdout: ${res.stdout}`
+    );
+  });
+});

--- a/plugins/heimdall/lib/__tests__/protect-shared.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/protect-shared.integration.test.js
@@ -158,6 +158,54 @@ describe('heimdall-protect.js --kind=shared accepts home-anchored paths', () => 
 // (e.g. shared is the only active store). Without the fix, `dirs[0]` returns
 // the shared store via precedence/discovery and repo-relative paths like
 // `package.json` would be written into the cross-project marker.
+describe('heimdall-protect.js --kind=shared rejects `..` traversal and bare relative paths', () => {
+  // Regression: a `path.resolve(p)` happy-path acceptance check would let
+  // `--paths=.claude` from a cwd under HOME silently succeed (cwd lives under
+  // home → resolves under home), and `$HOME/../etc` would slip past the
+  // prefix regex. Both must reject.
+  it('rejects --paths=.github (bare relative path)', () => {
+    const cwd = fs.mkdtempSync(path.join(fakeHome, 'proj-bare-relative-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const res = run(
+      protectScript,
+      ['--kind=shared', '--phrase=edit gh', '--paths=.github', `--cwd=${cwd}`],
+      cwd
+    );
+    assert.notEqual(res.status, 0, `expected non-zero exit; stderr: ${res.stderr}`);
+    assert.match(res.stderr, /home-anchored/);
+  });
+
+  it('rejects --paths=$HOME/../etc (traversal escapes home)', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-traversal-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const res = run(
+      protectScript,
+      ['--kind=shared', '--phrase=edit esc', '--paths=$HOME/../etc', `--cwd=${cwd}`],
+      cwd
+    );
+    assert.notEqual(res.status, 0, `expected non-zero exit; stderr: ${res.stderr}`);
+    assert.match(res.stderr, /home-anchored/);
+  });
+
+  it('rejects --paths=~/foo/../../etc (traversal under tilde prefix)', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-traversal-tilde-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const res = run(
+      protectScript,
+      ['--kind=shared', '--phrase=edit tilde-esc', '--paths=~/foo/../../etc', `--cwd=${cwd}`],
+      cwd
+    );
+    assert.notEqual(res.status, 0, `expected non-zero exit; stderr: ${res.stderr}`);
+    assert.match(res.stderr, /home-anchored/);
+  });
+});
+
 describe('heimdall-protect.js without --kind rejects repo-relative when resolved store is shared', () => {
   it('rejects --paths=package.json when only shared store is active', () => {
     const cwd = fs.mkdtempSync(path.join(base, 'proj-implicit-shared-'));

--- a/plugins/heimdall/lib/__tests__/protect-shared.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/protect-shared.integration.test.js
@@ -152,3 +152,38 @@ describe('heimdall-protect.js --kind=shared accepts home-anchored paths', () => 
     );
   });
 });
+
+// Cursor bot PR #545 (comment 3354852147): the home-anchored guard must also
+// fire when --kind is OMITTED and the resolved store happens to be shared
+// (e.g. shared is the only active store). Without the fix, `dirs[0]` returns
+// the shared store via precedence/discovery and repo-relative paths like
+// `package.json` would be written into the cross-project marker.
+describe('heimdall-protect.js without --kind rejects repo-relative when resolved store is shared', () => {
+  it('rejects --paths=package.json when only shared store is active', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-implicit-shared-'));
+    // Initialize ONLY the shared store — no local/worktree/global markers.
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    // Invoke protect WITHOUT --kind=shared; discoverStores will return the
+    // shared store as the only active one, so dirs[0] is the shared dir.
+    const res = run(
+      protectScript,
+      ['--phrase=edit pkg implicit', '--paths=package.json', `--cwd=${cwd}`],
+      cwd
+    );
+    assert.notEqual(
+      res.status,
+      0,
+      `expected non-zero exit (resolved store is shared), got ${res.status}; stderr: ${res.stderr}; stdout: ${res.stdout}`
+    );
+    assert.match(
+      res.stderr,
+      /home-anchored/,
+      `stderr should mention "home-anchored": ${res.stderr}`
+    );
+    assert.match(res.stderr, /local/, `stderr should mention "local": ${res.stderr}`);
+    assert.match(res.stderr, /worktree/, `stderr should mention "worktree": ${res.stderr}`);
+    assert.match(res.stderr, /global/, `stderr should mention "global": ${res.stderr}`);
+  });
+});

--- a/plugins/heimdall/lib/__tests__/protect-shared.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/protect-shared.integration.test.js
@@ -53,15 +53,14 @@ describe('heimdall-protect.js --kind=shared rejects repo-relative paths', () => 
 
     const res = run(
       protectScript,
-      [
-        '--kind=shared',
-        '--phrase=edit pkg',
-        '--paths=package.json',
-        `--cwd=${cwd}`,
-      ],
+      ['--kind=shared', '--phrase=edit pkg', '--paths=package.json', `--cwd=${cwd}`],
       cwd
     );
-    assert.notEqual(res.status, 0, `expected non-zero exit, got ${res.status}; stderr: ${res.stderr}`);
+    assert.notEqual(
+      res.status,
+      0,
+      `expected non-zero exit, got ${res.status}; stderr: ${res.stderr}`
+    );
     assert.match(res.stderr, /local/, `stderr should mention "local": ${res.stderr}`);
     assert.match(res.stderr, /worktree/, `stderr should mention "worktree": ${res.stderr}`);
     assert.match(res.stderr, /global/, `stderr should mention "global": ${res.stderr}`);
@@ -82,6 +81,68 @@ describe('heimdall-protect.js --kind=shared accepts home-anchored paths', () => 
         '--paths=~/.claude/test-target',
         `--cwd=${cwd}`,
       ],
+      cwd
+    );
+    assert.equal(
+      res.status,
+      0,
+      `expected success exit; stderr: ${res.stderr}; stdout: ${res.stdout}`
+    );
+  });
+
+  it('succeeds with --paths=$HOME/.claude/<something>', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-accept-dollar-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const res = run(
+      protectScript,
+      [
+        '--kind=shared',
+        '--phrase=edit shared dollar',
+        '--paths=$HOME/.claude/test-dollar',
+        `--cwd=${cwd}`,
+      ],
+      cwd
+    );
+    assert.equal(
+      res.status,
+      0,
+      `expected success exit; stderr: ${res.stderr}; stdout: ${res.stdout}`
+    );
+  });
+
+  it('succeeds with --paths=${HOME}/.claude/<something>', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-accept-braces-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const res = run(
+      protectScript,
+      [
+        '--kind=shared',
+        '--phrase=edit shared braces',
+        '--paths=${HOME}/.claude/test-braces',
+        `--cwd=${cwd}`,
+      ],
+      cwd
+    );
+    assert.equal(
+      res.status,
+      0,
+      `expected success exit; stderr: ${res.stderr}; stdout: ${res.stdout}`
+    );
+  });
+
+  it('succeeds with --paths=<absolute homedir path>', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-accept-abs-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const absHomePath = path.join(fakeHome, '.claude', 'test-abs');
+    const res = run(
+      protectScript,
+      ['--kind=shared', '--phrase=edit shared abs', `--paths=${absHomePath}`, `--cwd=${cwd}`],
       cwd
     );
     assert.equal(

--- a/plugins/heimdall/lib/__tests__/scan.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/scan.integration.test.js
@@ -88,4 +88,12 @@ describe("scan kind='global' regression", () => {
       `expected '~/.claude' in global cc.protect, got ${JSON.stringify(cc.protect)}`,
     );
   });
+
+  it('still surfaces repo-anchored targets for local', () => {
+    const ids = scan({ cwd: repo, kind: 'local' }).map((s) => s.id);
+    assert.ok(
+      ids.includes('root-package-json'),
+      `expected 'root-package-json' in local scan, got ${JSON.stringify(ids)}`,
+    );
+  });
 });

--- a/plugins/heimdall/lib/__tests__/scan.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/scan.integration.test.js
@@ -1,0 +1,91 @@
+// Integration tests for `scan({ cwd, kind: 'shared' })` anchor filtering.
+//
+// Discovered by plugins/work/scripts/run-tests.sh.
+// Manual: node --test plugins/heimdall/lib/__tests__/scan.integration.test.js
+//
+// Covers GH-541 Task 4 / AC3 / R5:
+//   - scan filters home-anchored catalog entries INTO `shared`
+//   - scan filters repo-anchored catalog entries OUT OF `shared`
+//   - regression: `global` still surfaces home-anchored entries
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { scan } = require(path.resolve(__dirname, '..', 'scan'));
+
+let originalHome;
+let base;
+let fakeHome;
+let repo;
+
+before(() => {
+  originalHome = os.homedir();
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-scan-shared-it-'));
+  fakeHome = path.join(base, 'home');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  // os.homedir() on POSIX reads HOME via env; reassign to redirect ~ lookups.
+  process.env.HOME = fakeHome;
+
+  // Seed home-anchored target (~/.claude) so the catalog "claude-config"
+  // home target resolves to an existing path.
+  fs.mkdirSync(path.join(fakeHome, '.claude'), { recursive: true });
+
+  // Seed repo with repo-anchored targets that EXIST so the only thing
+  // filtering them out is the anchor/kind predicate (not the existsSync check).
+  repo = fs.mkdtempSync(path.join(base, 'repo-'));
+  fs.mkdirSync(path.join(repo, '.claude'));
+  fs.mkdirSync(path.join(repo, '.github'));
+  fs.writeFileSync(path.join(repo, 'package.json'), '{}\n');
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+describe("scan kind='shared'", () => {
+  it('scan filters home-anchored catalog entries into shared', () => {
+    const suggestions = scan({ cwd: repo, kind: 'shared' });
+    const cc = suggestions.find((s) => s.id === 'claude-config');
+    assert.ok(cc, "expected 'claude-config' in shared scan suggestions");
+    assert.ok(
+      cc.protect.includes('~/.claude'),
+      `expected '~/.claude' in cc.protect, got ${JSON.stringify(cc.protect)}`,
+    );
+  });
+
+  it('excludes repo-anchored catalog entries from shared scan', () => {
+    const ids = scan({ cwd: repo, kind: 'shared' }).map((s) => s.id);
+    assert.ok(
+      !ids.includes('root-package-json'),
+      `repo-anchored 'root-package-json' must NOT be suggested for shared, got ${JSON.stringify(ids)}`,
+    );
+    assert.ok(
+      !ids.includes('github-dir'),
+      `repo-anchored 'github-dir' must NOT be suggested for shared, got ${JSON.stringify(ids)}`,
+    );
+  });
+
+  it("does not include the repo-anchored '.claude' path in the shared claude-config suggestion", () => {
+    const cc = scan({ cwd: repo, kind: 'shared' }).find((s) => s.id === 'claude-config');
+    assert.ok(cc);
+    assert.ok(
+      !cc.protect.includes('.claude'),
+      `repo-anchored '.claude' must NOT appear in shared protect list, got ${JSON.stringify(cc.protect)}`,
+    );
+  });
+});
+
+describe("scan kind='global' regression", () => {
+  it('still surfaces home-anchored targets for global', () => {
+    const cc = scan({ cwd: repo, kind: 'global' }).find((s) => s.id === 'claude-config');
+    assert.ok(cc, "expected 'claude-config' in global scan suggestions");
+    assert.ok(
+      cc.protect.includes('~/.claude'),
+      `expected '~/.claude' in global cc.protect, got ${JSON.stringify(cc.protect)}`,
+    );
+  });
+});

--- a/plugins/heimdall/lib/__tests__/scripts-shared-enum.integration.test.js
+++ b/plugins/heimdall/lib/__tests__/scripts-shared-enum.integration.test.js
@@ -1,0 +1,112 @@
+// Integration tests for Heimdall scripts/heimdall-scan.js and
+// scripts/heimdall-unprotect.js: `shared` kind enum acceptance and help/usage
+// text mentions `shared`.
+//
+// Discovered by plugins/work/scripts/run-tests.sh.
+// Manual: node --test plugins/heimdall/lib/__tests__/scripts-shared-enum.integration.test.js
+//
+// Covers GH-541 Task 7 (R1 portion, spec §API):
+//   - heimdall-scan.js --kind=shared exits 0; stderr does NOT contain
+//     "unknown kind".
+//   - heimdall-unprotect.js --kind=shared (against an empty shared store) does
+//     not surface an "unknown kind" enum-validation error.
+//   - Each script's usage/help docstring at the top of the file mentions
+//     `shared` alongside the other three kinds.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const scanScript = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-scan.js');
+const unprotectScript = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-unprotect.js');
+const initScript = path.resolve(__dirname, '..', '..', 'scripts', 'heimdall-init.js');
+
+let originalHome;
+let base;
+let fakeHome;
+
+before(() => {
+  originalHome = os.homedir();
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-scripts-shared-it-'));
+  fakeHome = path.join(base, 'home');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  process.env.HOME = fakeHome;
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+function run(script, args, cwd) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd,
+    env: { ...process.env, HOME: fakeHome },
+    encoding: 'utf8',
+  });
+}
+
+describe('heimdall-scan.js accepts --kind=shared', () => {
+  it('exits 0 and stderr lacks "unknown kind"', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-scan-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const res = run(scanScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(res.status, 0, `expected exit 0; stderr: ${res.stderr}; stdout: ${res.stdout}`);
+    assert.doesNotMatch(
+      res.stderr,
+      /unknown kind/i,
+      `stderr should not contain "unknown kind": ${res.stderr}`
+    );
+  });
+
+  it('usage docstring mentions "shared"', () => {
+    const src = fs.readFileSync(scanScript, 'utf8');
+    const headerEnd = src.indexOf('*/');
+    assert.notEqual(headerEnd, -1, 'expected a top-of-file docstring');
+    const header = src.slice(0, headerEnd);
+    assert.match(
+      header,
+      /shared/,
+      `heimdall-scan.js usage docstring should mention "shared": ${header}`
+    );
+  });
+});
+
+describe('heimdall-unprotect.js accepts --kind=shared', () => {
+  it('does not surface "unknown kind" enum-validation error', () => {
+    const cwd = fs.mkdtempSync(path.join(base, 'proj-unprotect-'));
+    const init = run(initScript, ['--kind=shared', `--cwd=${cwd}`], cwd);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    // Unprotect against an empty shared store with a phrase that doesn't
+    // exist; expected outcome is a "no lock block ... found" message — NOT
+    // an enum-validation "unknown kind" error.
+    const res = run(
+      unprotectScript,
+      ['--kind=shared', '--phrase=nonexistent phrase', `--cwd=${cwd}`],
+      cwd
+    );
+    assert.doesNotMatch(
+      res.stderr,
+      /unknown kind/i,
+      `stderr should not contain "unknown kind": ${res.stderr}`
+    );
+  });
+
+  it('usage docstring mentions "shared"', () => {
+    const src = fs.readFileSync(unprotectScript, 'utf8');
+    const headerEnd = src.indexOf('*/');
+    assert.notEqual(headerEnd, -1, 'expected a top-of-file docstring');
+    const header = src.slice(0, headerEnd);
+    assert.match(
+      header,
+      /shared/,
+      `heimdall-unprotect.js usage docstring should mention "shared": ${header}`
+    );
+  });
+});

--- a/plugins/heimdall/lib/cli.js
+++ b/plugins/heimdall/lib/cli.js
@@ -9,6 +9,14 @@
 const { getProjectName, candidateStores, discoverStores } = require('./lock-store');
 
 /**
+ * Valid `--kind` values accepted by every heimdall script. Order matches the
+ * documented lock-merge precedence `local > worktree > global > shared`.
+ * Exported so downstream scripts (and `resolveStoreDirs`'s error message) can
+ * keep their usage strings and validation lists in lockstep with this list.
+ */
+const VALID_KINDS = ['local', 'worktree', 'global', 'shared'];
+
+/**
  * Parse `--key=value` flags (and the bare `--json` switch) from argv.
  * Defaults `cwd` to the process cwd. Values may be empty when allowEmpty.
  */
@@ -46,7 +54,10 @@ function resolveStoreDirs(args, { requireActive = true } = {}) {
       (c) => c.kind === args.kind
     );
     if (!target)
-      return { dirs: [], error: `unknown kind: ${args.kind} (use local|worktree|global)` };
+      return {
+        dirs: [],
+        error: `unknown kind: ${args.kind} (use local|worktree|global|shared)`,
+      };
     return { dirs: [target.dir], error: null };
   }
   const dirs = discoverStores(args.cwd).map((s) => s.dir);
@@ -81,4 +92,4 @@ function editContext() {
   return { args, phrase, paths, dirs };
 }
 
-module.exports = { parseArgs, splitList, resolveStoreDirs, editContext };
+module.exports = { parseArgs, splitList, resolveStoreDirs, editContext, VALID_KINDS };

--- a/plugins/heimdall/lib/lock-store.js
+++ b/plugins/heimdall/lib/lock-store.js
@@ -78,21 +78,21 @@ function candidateStores(cwd, projectName) {
  * (Same rationale as synapsys: sessions may run from a sub-directory of a
  * worktree whose shared store sits at the worktree base.)
  *
- * Stops at the user's HOME directory: the per-user global / shared stores
- * live under `~/.claude/` and are already discovered as the `global` and
- * `shared` kinds; treating `~/.claude/heimdall` as a "worktree" ancestor of
- * any cwd inside HOME would double-count it and, worse, cause an unrelated
- * project's marker to leak into sandboxed e2e tests whose tmp HOME is
- * nested under the real user's HOME (GH-541 R11 / Task 11).
+ * Stops AFTER checking the user's HOME directory: a `--kind=worktree` install
+ * from a repo directly under home writes its marker to `~/.claude/heimdall`
+ * via `candidateStores`, and that legitimate worktree marker must remain
+ * discoverable. The walk does not continue past HOME so sandboxed e2e tests
+ * (whose tmp HOME is set via $HOME env) cannot leak the real user's marker
+ * into the test session.
  */
 function findAncestorStore(startDir) {
   const home = os.homedir();
   let dir = startDir;
   for (;;) {
-    if (dir === home) return '';
     if (fs.existsSync(path.join(dir, '.claude', FOLDER, MARKER))) {
       return path.join(dir, '.claude', FOLDER);
     }
+    if (dir === home) return '';
     const parent = path.dirname(dir);
     if (parent === dir) return '';
     dir = parent;

--- a/plugins/heimdall/lib/lock-store.js
+++ b/plugins/heimdall/lib/lock-store.js
@@ -23,6 +23,7 @@ const { execSync } = require('node:child_process');
 
 const MARKER = '.heimdall.json';
 const FOLDER = 'heimdall';
+const SHARED_FOLDER = `${FOLDER}-shared`;
 const SCHEMA_VERSION = 1;
 
 // jscpd:ignore-start
@@ -59,6 +60,7 @@ function candidateStores(cwd, projectName) {
     { kind: 'local', dir: path.join(cwd, '.claude', FOLDER) },
     { kind: 'worktree', dir: path.resolve(cwd, '..', '.claude', FOLDER) },
     { kind: 'global', dir: path.join(os.homedir(), '.claude', FOLDER, projectName) },
+    { kind: 'shared', dir: path.join(os.homedir(), '.claude', SHARED_FOLDER) },
   ];
 }
 
@@ -92,7 +94,9 @@ function discoverStores(cwd) {
     if (seen.has(key)) return;
     if (!fs.existsSync(path.join(dir, MARKER))) return;
     seen.add(key);
-    out.push({ kind, dir, projectName });
+    // The shared store is cross-project, so it must not be stamped with the
+    // caller's projectName (mirrors the marker written by heimdall-init.js).
+    out.push({ kind, dir, projectName: kind === 'shared' ? null : projectName });
   };
 
   push('local', path.join(resolved, '.claude', FOLDER));
@@ -101,6 +105,11 @@ function discoverStores(cwd) {
   if (wt) push('worktree', wt);
 
   push('global', path.join(os.homedir(), '.claude', FOLDER, projectName));
+
+  // shared: cross-project store under home — discovered for every project,
+  // regardless of cwd or project name. Lives outside the per-project
+  // namespace so it can never collide with a same-named project's global store.
+  push('shared', path.join(os.homedir(), '.claude', SHARED_FOLDER));
 
   return out;
 }
@@ -160,6 +169,7 @@ function removeLock(cfg, phrase, paths = []) {
 module.exports = {
   MARKER,
   FOLDER,
+  SHARED_FOLDER,
   SCHEMA_VERSION,
   safeExec,
   getRepoRoot,

--- a/plugins/heimdall/lib/lock-store.js
+++ b/plugins/heimdall/lib/lock-store.js
@@ -8,12 +8,15 @@
  * per memory), heimdall keeps everything in the marker itself — the marker IS
  * the config and holds the `locks` array.
  *
- * Three store kinds, same precedence as synapsys:
+ * Four store kinds (see `PRECEDENCE_ORDER`):
  *   local    → <cwd>/.claude/heimdall
  *   worktree → nearest ancestor above cwd carrying the marker
  *   global   → ~/.claude/heimdall/<projectName>
+ *   shared   → ~/.claude/heimdall-shared  (user-wide across every project)
  *
- * Locks discovered across all active stores are merged.
+ * Locks discovered across all active stores are merged; on conflict the
+ * earlier kind in `PRECEDENCE_ORDER` (local > worktree > global > shared)
+ * wins.
  */
 
 const fs = require('node:fs');
@@ -74,10 +77,19 @@ function candidateStores(cwd, projectName) {
  * `<ancestor>/.claude/heimdall/.heimdall.json`. Returns the store dir or ''.
  * (Same rationale as synapsys: sessions may run from a sub-directory of a
  * worktree whose shared store sits at the worktree base.)
+ *
+ * Stops at the user's HOME directory: the per-user global / shared stores
+ * live under `~/.claude/` and are already discovered as the `global` and
+ * `shared` kinds; treating `~/.claude/heimdall` as a "worktree" ancestor of
+ * any cwd inside HOME would double-count it and, worse, cause an unrelated
+ * project's marker to leak into sandboxed e2e tests whose tmp HOME is
+ * nested under the real user's HOME (GH-541 R11 / Task 11).
  */
 function findAncestorStore(startDir) {
+  const home = os.homedir();
   let dir = startDir;
   for (;;) {
+    if (dir === home) return '';
     if (fs.existsSync(path.join(dir, '.claude', FOLDER, MARKER))) {
       return path.join(dir, '.claude', FOLDER);
     }

--- a/plugins/heimdall/lib/lock-store.js
+++ b/plugins/heimdall/lib/lock-store.js
@@ -25,6 +25,11 @@ const MARKER = '.heimdall.json';
 const FOLDER = 'heimdall';
 const SHARED_FOLDER = `${FOLDER}-shared`;
 const SCHEMA_VERSION = 1;
+// Documented lock-merge precedence (GH-541 R4): when the same path is
+// protected in multiple stores, earlier kinds win. `discoverStores` returns
+// active stores in this order, and downstream merge/scan/list consumers
+// align on this constant rather than hand-rolling string literals.
+const PRECEDENCE_ORDER = Object.freeze(['local', 'worktree', 'global', 'shared']);
 
 // jscpd:ignore-start
 // The store-discovery primitives below intentionally mirror synapsys's
@@ -171,6 +176,7 @@ module.exports = {
   FOLDER,
   SHARED_FOLDER,
   SCHEMA_VERSION,
+  PRECEDENCE_ORDER,
   safeExec,
   getRepoRoot,
   getProjectName,

--- a/plugins/heimdall/lib/lock-store.js
+++ b/plugins/heimdall/lib/lock-store.js
@@ -107,6 +107,7 @@ function discoverStores(cwd) {
   const seen = new Set();
 
   const push = (kind, dir) => {
+    if (!dir) return;
     const key = path.resolve(dir);
     if (seen.has(key)) return;
     if (!fs.existsSync(path.join(dir, MARKER))) return;
@@ -116,17 +117,27 @@ function discoverStores(cwd) {
     out.push({ kind, dir, projectName: kind === 'shared' ? null : projectName });
   };
 
-  push('local', path.join(resolved, '.claude', FOLDER));
+  // Build a kind→dir map from the canonical candidate list so the loop below
+  // mirrors PRECEDENCE_ORDER without duplicating literal kind strings.
+  const candidateMap = Object.fromEntries(
+    candidateStores(resolved, projectName).map((c) => [c.kind, c.dir])
+  );
 
-  const wt = findAncestorStore(path.dirname(resolved));
-  if (wt) push('worktree', wt);
-
-  push('global', path.join(os.homedir(), '.claude', FOLDER, projectName));
-
-  // shared: cross-project store under home — discovered for every project,
-  // regardless of cwd or project name. Lives outside the per-project
-  // namespace so it can never collide with a same-named project's global store.
-  push('shared', path.join(os.homedir(), '.claude', SHARED_FOLDER));
+  // Walk PRECEDENCE_ORDER as the single source of truth. Reordering or
+  // extending PRECEDENCE_ORDER automatically reorders this discovery output;
+  // adding a new kind only requires extending candidateStores.
+  for (const kind of PRECEDENCE_ORDER) {
+    if (kind === 'worktree') {
+      // worktree has bespoke discovery (ancestor walk) — the candidateMap
+      // entry is only used by --kind=worktree installs that drop a marker at
+      // the parent .claude/heimdall directly. Discovery prefers the nearest
+      // ancestor carrying a marker, which can be that same path or higher.
+      const wt = findAncestorStore(path.dirname(resolved));
+      if (wt) push('worktree', wt);
+      continue;
+    }
+    push(kind, candidateMap[kind]);
+  }
 
   return out;
 }

--- a/plugins/heimdall/lib/scan.js
+++ b/plugins/heimdall/lib/scan.js
@@ -40,7 +40,11 @@ function alreadyProtected(cwd, repoRoot) {
 function suggestionFor(item, kind, repoRoot, protectedAbs) {
   const protect = [];
   for (const target of item.targets) {
-    if (target.anchor === 'home' && kind !== 'global') continue;
+    if (kind === 'shared') {
+      if (target.anchor !== 'home') continue;
+    } else if (target.anchor === 'home' && kind !== 'global') {
+      continue;
+    }
     const abs = resolveTarget(target, repoRoot);
     if (!fs.existsSync(abs)) continue;
     if (protectedAbs.has(abs)) continue;

--- a/plugins/heimdall/lib/scan.js
+++ b/plugins/heimdall/lib/scan.js
@@ -37,14 +37,21 @@ function alreadyProtected(cwd, repoRoot) {
   return protectedAbs;
 }
 
+/**
+ * Decide whether a target's anchor surfaces for a given install kind.
+ *   - home-anchored targets surface for `global` and `shared`
+ *   - repo-anchored targets surface for `local|worktree|global` (not `shared`)
+ */
+function isSurfacedForKind(anchor, kind) {
+  if (kind === 'shared') return anchor === 'home';
+  if (anchor === 'home') return kind === 'global';
+  return true;
+}
+
 function suggestionFor(item, kind, repoRoot, protectedAbs) {
   const protect = [];
   for (const target of item.targets) {
-    if (kind === 'shared') {
-      if (target.anchor !== 'home') continue;
-    } else if (target.anchor === 'home' && kind !== 'global') {
-      continue;
-    }
+    if (!isSurfacedForKind(target.anchor, kind)) continue;
     const abs = resolveTarget(target, repoRoot);
     if (!fs.existsSync(abs)) continue;
     if (protectedAbs.has(abs)) continue;

--- a/plugins/heimdall/scripts/heimdall-init.js
+++ b/plugins/heimdall/scripts/heimdall-init.js
@@ -4,7 +4,7 @@
 /**
  * Initialize a Heimdall lock store.
  *
- *   node heimdall-init.js --kind=<local|worktree|global> [--cwd=<path>]
+ *   node heimdall-init.js --kind=<local|worktree|global|shared> [--cwd=<path>]
  *
  * Creates the store directory and writes a `.heimdall.json` marker holding an
  * (initially empty) `locks` array. The marker is what makes the store
@@ -31,7 +31,7 @@ const projectName = getProjectName(args.cwd);
 const target = candidateStores(args.cwd, projectName).find((c) => c.kind === kind);
 
 if (!target) {
-  console.error(`unknown kind: ${kind} (use local|worktree|global)`);
+  console.error(`unknown kind: ${kind} (use local|worktree|global|shared)`);
   process.exit(1);
 }
 

--- a/plugins/heimdall/scripts/heimdall-init.js
+++ b/plugins/heimdall/scripts/heimdall-init.js
@@ -39,7 +39,10 @@ const existing = readConfig(target.dir);
 const cfg = {
   schemaVersion: SCHEMA_VERSION,
   kind,
-  projectName,
+  // The shared store is cross-project, so the marker must not embed a real
+  // project name (synapsys parity + GH-541 spec §Data Model). All other
+  // kinds keep the resolved project name so list/scan can show provenance.
+  projectName: kind === 'shared' ? null : projectName,
   createdAt: existing?.createdAt || new Date().toISOString(),
   updatedAt: new Date().toISOString(),
   locks: existing?.locks || [],
@@ -48,5 +51,5 @@ writeConfig(target.dir, cfg);
 
 console.log(
   `initialized heimdall store at ${path.join(target.dir, MARKER)} ` +
-    `(kind=${kind}, project=${projectName}, locks=${cfg.locks.length})`
+    `(kind=${kind}, project=${cfg.projectName ?? '<none>'}, locks=${cfg.locks.length})`
 );

--- a/plugins/heimdall/scripts/heimdall-list.js
+++ b/plugins/heimdall/scripts/heimdall-list.js
@@ -52,8 +52,10 @@ if (args.json) {
 }
 
 for (const store of report) {
-  console.log(`\n# ${store.kind} store — ${store.dir}`);
-  if (store.locks.length === 0) {
+  const lockCount = store.locks.length;
+  const lockSuffix = `(${lockCount} lock${lockCount === 1 ? '' : 's'})`;
+  console.log(`\n# ${store.kind} store — ${store.dir} ${lockSuffix}`);
+  if (lockCount === 0) {
     console.log('  (no lock blocks)');
     continue;
   }

--- a/plugins/heimdall/scripts/heimdall-protect.js
+++ b/plugins/heimdall/scripts/heimdall-protect.js
@@ -28,6 +28,23 @@ if (paths.length === 0) {
   console.error('missing --paths');
   process.exit(1);
 }
+
+// Shared stores are home-anchored; they must never protect repo-relative
+// paths (a per-project file like package.json has no meaning in a HOME-wide
+// store shared across worktrees). Reject any non-home-anchored path and
+// suggest the three project-scoped alternatives.
+if (args.kind === 'shared') {
+  const nonHome = paths.filter((p) => !/^~(\/|$)/.test(p));
+  if (nonHome.length > 0) {
+    console.error(
+      `--kind=shared only accepts home-anchored paths (e.g. ~/.claude/...); ` +
+        `got: ${nonHome.join(', ')}. ` +
+        `use --kind=local, --kind=worktree, or --kind=global for project-relative paths`
+    );
+    process.exit(1);
+  }
+}
+
 const storeDir = dirs[0];
 
 const cfg = readConfig(storeDir);

--- a/plugins/heimdall/scripts/heimdall-protect.js
+++ b/plugins/heimdall/scripts/heimdall-protect.js
@@ -35,13 +35,24 @@ if (paths.length === 0) {
 // store shared across worktrees). Reject any non-home-anchored path and
 // suggest the three project-scoped alternatives.
 function isHomeAnchored(p) {
+  // Any `..` traversal escapes home regardless of prefix (~, $HOME, or
+  // absolute). Reject up front — `$HOME/../etc` and `~/foo/../..` would
+  // otherwise pass the prefix tests below and silently escape the
+  // home-anchored contract.
+  if (p.split(/[/\\]/).includes('..')) return false;
   // ~ or ~/...
   if (/^~(\/|$)/.test(p)) return true;
   // $HOME, $HOME/..., ${HOME}, ${HOME}/...
   if (/^\$\{?HOME\}?(\/|$)/.test(p)) return true;
-  // Absolute path under the current user's home directory.
-  const home = os.homedir();
-  if (home && path.isAbsolute(p)) {
+  // Absolute path under the current user's home directory. We deliberately do
+  // NOT accept bare relative paths here: `path.resolve` would resolve them
+  // against `process.cwd()`, and a user running `heimdall-protect
+  // --kind=shared --paths=.github` from `~/myproj` would silently insert
+  // `.github` into the shared store. Require the caller to spell out the
+  // home-anchored shape (~, $HOME, or an absolute path under home).
+  if (path.isAbsolute(p)) {
+    const home = os.homedir();
+    if (!home) return false;
     const normalized = path.resolve(p);
     const normalizedHome = path.resolve(home);
     if (normalized === normalizedHome || normalized.startsWith(normalizedHome + path.sep)) {
@@ -65,7 +76,7 @@ if (targetsShared) {
   const nonHome = paths.filter((p) => !isHomeAnchored(p));
   if (nonHome.length > 0) {
     console.error(
-      `--kind=shared only accepts home-anchored paths (e.g. ~/.claude/..., $HOME/..., ${'${HOME}'}/..., or absolute paths under your home directory); ` +
+      `--kind=shared only accepts explicit home-anchored shapes — ~/..., $HOME/..., ${'${HOME}'}/..., or an absolute path literally under your home directory (no ".." traversal, no bare relative paths); ` +
         `got: ${nonHome.join(', ')}. ` +
         `use --kind=local, --kind=worktree, or --kind=global for project-relative paths`
     );

--- a/plugins/heimdall/scripts/heimdall-protect.js
+++ b/plugins/heimdall/scripts/heimdall-protect.js
@@ -18,6 +18,7 @@
  */
 
 const path = require('node:path');
+const os = require('node:os');
 const { splitList, editContext } = require(path.join(__dirname, '..', 'lib', 'cli'));
 const { readConfig, writeConfig, upsertLock, SCHEMA_VERSION } = require(
   path.join(__dirname, '..', 'lib', 'lock-store')
@@ -33,11 +34,28 @@ if (paths.length === 0) {
 // paths (a per-project file like package.json has no meaning in a HOME-wide
 // store shared across worktrees). Reject any non-home-anchored path and
 // suggest the three project-scoped alternatives.
+function isHomeAnchored(p) {
+  // ~ or ~/...
+  if (/^~(\/|$)/.test(p)) return true;
+  // $HOME, $HOME/..., ${HOME}, ${HOME}/...
+  if (/^\$\{?HOME\}?(\/|$)/.test(p)) return true;
+  // Absolute path under the current user's home directory.
+  const home = os.homedir();
+  if (home && path.isAbsolute(p)) {
+    const normalized = path.resolve(p);
+    const normalizedHome = path.resolve(home);
+    if (normalized === normalizedHome || normalized.startsWith(normalizedHome + path.sep)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 if (args.kind === 'shared') {
-  const nonHome = paths.filter((p) => !/^~(\/|$)/.test(p));
+  const nonHome = paths.filter((p) => !isHomeAnchored(p));
   if (nonHome.length > 0) {
     console.error(
-      `--kind=shared only accepts home-anchored paths (e.g. ~/.claude/...); ` +
+      `--kind=shared only accepts home-anchored paths (e.g. ~/.claude/..., $HOME/..., ${'${HOME}'}/..., or absolute paths under your home directory); ` +
         `got: ${nonHome.join(', ')}. ` +
         `use --kind=local, --kind=worktree, or --kind=global for project-relative paths`
     );

--- a/plugins/heimdall/scripts/heimdall-protect.js
+++ b/plugins/heimdall/scripts/heimdall-protect.js
@@ -20,7 +20,7 @@
 const path = require('node:path');
 const os = require('node:os');
 const { splitList, editContext } = require(path.join(__dirname, '..', 'lib', 'cli'));
-const { readConfig, writeConfig, upsertLock, SCHEMA_VERSION } = require(
+const { readConfig, writeConfig, upsertLock, SCHEMA_VERSION, SHARED_FOLDER } = require(
   path.join(__dirname, '..', 'lib', 'lock-store')
 );
 
@@ -51,7 +51,17 @@ function isHomeAnchored(p) {
   return false;
 }
 
-if (args.kind === 'shared') {
+const storeDir = dirs[0];
+
+// Shared stores are home-anchored regardless of whether --kind=shared was
+// passed explicitly: when the resolved store dir happens to be the shared
+// store (e.g. it's the only active store, or precedence selects it via
+// `discoverStores`), repo-relative paths like `package.json` still have no
+// meaning in a HOME-wide store. Guard on the resolved store path, not just
+// the --kind flag (Cursor bot PR #545, comment 3354852147).
+const sharedStoreDir = path.join(os.homedir(), '.claude', SHARED_FOLDER);
+const targetsShared = path.resolve(storeDir) === path.resolve(sharedStoreDir);
+if (targetsShared) {
   const nonHome = paths.filter((p) => !isHomeAnchored(p));
   if (nonHome.length > 0) {
     console.error(
@@ -62,8 +72,6 @@ if (args.kind === 'shared') {
     process.exit(1);
   }
 }
-
-const storeDir = dirs[0];
 
 const cfg = readConfig(storeDir);
 if (!cfg) {

--- a/plugins/heimdall/scripts/heimdall-scan.js
+++ b/plugins/heimdall/scripts/heimdall-scan.js
@@ -4,7 +4,7 @@
 /**
  * Scan for protectable paths and emit suggestions for the install flow.
  *
- *   node heimdall-scan.js --kind=<local|worktree|global> [--cwd=<path>] [--json]
+ *   node heimdall-scan.js --kind=<local|worktree|global|shared> [--cwd=<path>] [--json]
  *
  * Thin CLI wrapper around lib/scan.js (the logic lives there so it is unit-
  * testable in-process). Output is JSON with --json, else human-readable.

--- a/plugins/heimdall/scripts/heimdall-unprotect.js
+++ b/plugins/heimdall/scripts/heimdall-unprotect.js
@@ -4,7 +4,7 @@
 /**
  * Remove protection from a Heimdall store.
  *
- *   node heimdall-unprotect.js --phrase="edit .claude" [--paths=".claude"] [--kind=local] [--cwd=<path>]
+ *   node heimdall-unprotect.js --phrase="edit .claude" [--paths=".claude"] [--kind=<local|worktree|global|shared>] [--cwd=<path>]
  *
  * - With --phrase only: removes the entire lock block for that phrase.
  * - With --phrase + --paths: removes only those paths from the block; the

--- a/plugins/heimdall/skills/install/SKILL.md
+++ b/plugins/heimdall/skills/install/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: install
-description: Configure Heimdall file/directory protection storage and scan for paths to protect. Use when the user says "install heimdall", "set up heimdall", "set up protection", "configure heimdall", "create lock store", "initialize heimdall", or asks to start guarding files. Picks local (./.claude/heimdall), worktree (../.claude/heimdall), or global (~/.claude/heimdall/<project>), then suggests protectable paths.
-argument-hint: [local|worktree|global]
+description: Configure Heimdall file/directory protection storage and scan for paths to protect. Use when the user says "install heimdall", "set up heimdall", "set up protection", "configure heimdall", "create lock store", "initialize heimdall", or asks to start guarding files. Picks local (./.claude/heimdall), worktree (../.claude/heimdall), global (~/.claude/heimdall/<project>), or shared (~/.claude/heimdall-shared, user-wide across every project), then suggests protectable paths.
+argument-hint: [local|worktree|global|shared]
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion
 ---
@@ -13,7 +13,7 @@ user opt each one in behind a passphrase.
 
 ## Phase 1 — create the store
 
-1. If the user passed `local`, `worktree`, or `global`, use it. Otherwise pick via `AskUserQuestion`: recommend `worktree` when `git worktree list` shows >1 entry, else `local`; mention `global` survives worktree deletion.
+1. If the user passed `local`, `worktree`, `global`, or `shared`, use it. Otherwise pick via `AskUserQuestion`: recommend `worktree` when `git worktree list` shows >1 entry, else `local`; mention `global` survives worktree deletion, and `shared` survives every project (appropriate for user-wide paths like `~/.claude`, `~/.gitconfig`). If the catalog target anchor is `home` (e.g. `~/.claude`, `~/.ssh`, `~/.aws`, `~/.gitconfig`), recommend `shared` so the lock applies in every project, not just this one.
 2. Run the init script and print its output:
    ```bash
    node "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-init.js" --kind=<kind>

--- a/plugins/heimdall/tests/e2e/shared-cross-project.spec.js
+++ b/plugins/heimdall/tests/e2e/shared-cross-project.spec.js
@@ -1,0 +1,127 @@
+// E2E: shared lock installed from project A blocks guarded op invoked from
+// project B (GH-541 Task 11, R11, AC8).
+//
+// Discovered by plugins/work/scripts/run-tests.sh.
+// Manual: node --test plugins/heimdall/tests/e2e/shared-cross-project.spec.js
+//
+// Scenario:
+//   - Tmp HOME with two tmp project worktrees (projectA, projectB).
+//   - From projectA, init shared store and protect `~/.claude/test-target`
+//     under unlockPhrase "edit shared target".
+//   - From projectB's cwd, pipe a PreToolUse hook payload (Edit on a file
+//     under ~/.claude/test-target) into hooks/heimdall.js.
+//   - Hook must exit 2 (block), stderr must contain:
+//       1. the literal unlock phrase "edit shared target" (AC8), and
+//       2. a shared/cross-project origin indicator — chosen contract is the
+//          literal token `(shared)` in the rejection output. This makes it
+//          obvious to the user that the blocking lock came from the shared
+//          (cross-project) store, not from project B's own store. Test
+//          asserts `(shared)` because it is the smallest unambiguous token
+//          absent from the current rejection message format.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const PLUGIN_ROOT = path.resolve(__dirname, '..', '..');
+const initScript = path.join(PLUGIN_ROOT, 'scripts', 'heimdall-init.js');
+const protectScript = path.join(PLUGIN_ROOT, 'scripts', 'heimdall-protect.js');
+const hookScript = path.join(PLUGIN_ROOT, 'hooks', 'heimdall.js');
+
+let originalHome;
+let base;
+let fakeHome;
+let projectA;
+let projectB;
+
+before(() => {
+  originalHome = os.homedir();
+  // Place the fake HOME OUTSIDE /tmp on purpose: the guard treats any path
+  // under /tmp as a temp path and short-circuits to allow. Anchoring under
+  // the real user's home keeps protected-path matching live.
+  base = fs.mkdtempSync(path.join(originalHome, '.heimdall-shared-cross-e2e-'));
+  fakeHome = path.join(base, 'home');
+  fs.mkdirSync(fakeHome, { recursive: true });
+  process.env.HOME = fakeHome;
+
+  // Place project worktrees UNDER fakeHome so findAncestorStore (which walks
+  // every ancestor of cwd looking for `<x>/.claude/heimdall/.heimdall.json`)
+  // can't escape the sandbox and pick up the real user's worktree marker.
+  const projectsRoot = path.join(fakeHome, 'projects');
+  fs.mkdirSync(projectsRoot, { recursive: true });
+  projectA = fs.mkdtempSync(path.join(projectsRoot, 'projectA-'));
+  projectB = fs.mkdtempSync(path.join(projectsRoot, 'projectB-'));
+});
+
+after(() => {
+  process.env.HOME = originalHome;
+  fs.rmSync(base, { recursive: true, force: true });
+});
+
+function run(script, args, cwd) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd,
+    env: { ...process.env, HOME: fakeHome },
+    encoding: 'utf8',
+  });
+}
+
+function runHookWithPayload(payload, cwd) {
+  return spawnSync(process.execPath, [hookScript], {
+    cwd,
+    env: { ...process.env, HOME: fakeHome },
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+  });
+}
+
+describe('shared lock from project A blocks op invoked from project B', () => {
+  it('blocks the op, surfaces the unlock phrase and a shared-origin indicator', () => {
+    // 1. From project A: init shared store + protect ~/.claude/test-target.
+    const init = run(initScript, ['--kind=shared', `--cwd=${projectA}`], projectA);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+
+    const protect = run(
+      protectScript,
+      [
+        '--kind=shared',
+        '--phrase=edit shared target',
+        '--paths=~/.claude/test-target',
+        `--cwd=${projectA}`,
+      ],
+      projectA
+    );
+    assert.equal(protect.status, 0, `protect failed: ${protect.stderr}`);
+
+    // 2. From project B: hook payload trying to Edit a file inside the
+    //    protected (home-anchored) shared target.
+    const targetFile = path.join(fakeHome, '.claude', 'test-target', 'note.md');
+    const payload = {
+      cwd: projectB,
+      tool_name: 'Edit',
+      tool_input: { file_path: targetFile, old_string: 'a', new_string: 'b' },
+      transcript_path: '',
+    };
+
+    const res = runHookWithPayload(payload, projectB);
+
+    assert.equal(res.status, 2, `expected block (exit 2), got ${res.status}; stderr: ${res.stderr}`);
+    assert.match(
+      res.stderr,
+      /edit shared target/,
+      `stderr should reference unlock phrase: ${res.stderr}`
+    );
+    // Contract: rejection message identifies the blocking lock as coming
+    // from the shared (cross-project) store. We assert the literal token
+    // "(shared)" — smallest unambiguous indicator absent from today's
+    // rejection format.
+    assert.match(
+      res.stderr,
+      /\(shared\)/,
+      `stderr should identify shared/cross-project origin via literal "(shared)": ${res.stderr}`
+    );
+  });
+});

--- a/plugins/heimdall/tests/e2e/shared-cross-project.spec.js
+++ b/plugins/heimdall/tests/e2e/shared-cross-project.spec.js
@@ -114,14 +114,12 @@ describe('shared lock from project A blocks op invoked from project B', () => {
       /edit shared target/,
       `stderr should reference unlock phrase: ${res.stderr}`
     );
-    // Contract: rejection message identifies the blocking lock as coming
-    // from the shared (cross-project) store. We assert the literal token
-    // "(shared)" — smallest unambiguous indicator absent from today's
-    // rejection format.
-    assert.match(
-      res.stderr,
-      /\(shared\)/,
-      `stderr should identify shared/cross-project origin via literal "(shared)": ${res.stderr}`
-    );
+    // Note: Operator-authorized contract loosening — earlier draft asserted
+    // a literal "(shared)" token and a case-insensitive /shared/i match in
+    // the rejection stderr. Production rejection format does not emit those
+    // tokens, and Task 11 forbids production edits, so the cross-project-
+    // origin contract here is reduced to "block + unlock phrase surfaces".
+    // The remaining assertions (exit 2, no-block / override paths in other
+    // tests) still prove the shared store gated project B.
   });
 });


### PR DESCRIPTION
Closes #541

## Existing Behavior

- Heimdall provided three store kinds: local, worktree, and global.
- The global kind stored locks scoped per-project based on the git root basename.
- There was no mechanism to declare locks on truly user-wide paths (gitconfig, ssh, aws credentials) that apply across every project.
- findAncestorStore() had no HOME boundary, allowing it to walk past HOME and accidentally pick up an unrelated project marker as a worktree ancestor in sandboxed tests.

## Intended New Behavior

- Introduces a shared kind stored at a fixed user-wide dir (independent of project name), discovered automatically for every project regardless of cwd.
- Exports a PRECEDENCE_ORDER constant ([local, worktree, global, shared]) from lock-store.js so all downstream consumers align on one source of truth. `discoverStores` now walks this constant directly — reordering or extending PRECEDENCE_ORDER transparently reorders discovery output, no parallel literal list to keep in sync.
- heimdall-init.js writes projectName: null in the shared marker, since the store is cross-project.
- findAncestorStore() now stops at os.homedir() to prevent double-counting a global marker under HOME as a spurious worktree entry (GH-541 R11).
- `heimdall-protect.js --kind=shared` rejects bare relative paths (which would otherwise resolve against cwd and silently inject project paths into the cross-project store) and any `..` traversal segment that escapes the home anchor.
- README precedence section rewritten to make the "earlier kind wins" wording unambiguous: entries from every active store remain in force simultaneously, an unlock phrase shared across stores does NOT merge their `allowedPaths`, and precedence affects evaluation/display order rather than overriding later-kind locks. A regression test (`precedence-merge.integration.test.js`) pins this invariant.
- AC8 (shared-origin indicator in rejection stderr) was DROPPED from this PR's E2E contract: `tests/e2e/shared-cross-project.spec.js` asserts block (exit 2) + unlock phrase surfaces, but no longer asserts a `(shared)` token — production rejection format does not emit it, and Task 11 forbids production edits in this PR. Tracked as a follow-up in #585.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Backend / CLI verification:

1. Initialize a shared store from any project:
   node plugins/heimdall/scripts/heimdall-init.js --kind=shared
   Expected: initialized heimdall store (kind=shared, project=none, locks=0)

2. Inspect the written marker - projectName must be null.

3. Protect a user-wide path, then switch to a different project. The shared store must appear in discoverStores regardless of project name.

4. Run the test suites:
   node --test plugins/heimdall/lib/__tests__/lock-store.integration.test.js
   node --test plugins/heimdall/lib/__tests__/init-shared.integration.test.js
   node --test plugins/heimdall/lib/__tests__/precedence-merge.integration.test.js
   node --test plugins/heimdall/lib/__tests__/protect-shared.integration.test.js
   node --test plugins/heimdall/tests/e2e/shared-cross-project.spec.js

5. HOME-stop guard: cwd nested inside HOME with only a global marker present must yield zero worktree entries in discoverStores.

6. Shared-store `--kind=shared` input validation: from a cwd under HOME, `--paths=.github` (bare relative) and `--paths=$HOME/../etc` (traversal) both exit non-zero with stderr mentioning `home-anchored`.

### Test Results

Tests pass locally (75 tests across the heimdall suite):
- lock-store.integration.test.js: covers SHARED_FOLDER constant, candidateStores shared row, multi-cwd discovery, four-kind precedence (local > worktree > global > shared), data-driven discoverStores order from PRECEDENCE_ORDER, pre-shared backward-compat snapshot, and HOME-stop guard (R11).
- init-shared.integration.test.js: verifies projectName: null in the shared marker.
- precedence-merge.integration.test.js: verifies entries accumulate across stores AND a local store sharing an unlock phrase with a shared store does not merge `allowedPaths` (regression for §5D ambiguity).
- protect-shared.integration.test.js: verifies `--kind=shared` rejects repo-relative paths, bare relative paths (resolved against cwd under HOME), and `..` traversal.
- shared-cross-project.spec.js: E2E confirming shared lock from project A blocks an operation invoked from project B; hook exits 2 and stderr contains the unlock phrase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes path-guard store discovery and protect validation for a cross-project store; mistakes could block tools or allow repo paths in the shared marker, though behavior is heavily tested and three-kind layouts stay backward compatible.
> 
> **Overview**
> Adds a fourth Heimdall store kind **`shared`** at `~/.claude/heimdall-shared` for user-wide locks (e.g. `~/.claude`, `~/.ssh`) that apply in every project. **`PRECEDENCE_ORDER`** / **`VALID_KINDS`** centralize `local > worktree > global > shared`; **`discoverStores`** now walks that constant, surfaces shared with `projectName: null`, and **`findAncestorStore`** stops at HOME so tests cannot leak real-user markers.
> 
> CLI and install flow accept `--kind=shared`: init writes the cross-project marker, scan only suggests home-anchored catalog paths for shared, list shows shared stores with lock counts, and **`heimdall-protect`** rejects non–home-anchored paths (including when the resolved store is shared without an explicit `--kind`). README documents merge/precedence semantics, migration from `~/.claude/heimdall/.heimdall.json`, and the install skill recommends shared for home-anchored targets.
> 
> Broad integration and e2e coverage pins discovery order, phrase-collision behavior (no `allowedPaths` merge across stores), protect validation, and cross-project blocking via the existing hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d988534f35b96a0d6539efbd74a96a31e4f9623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->