### PR TITLE
feat(work): add gh auth diagnostic to ghExec error handling (GH-535)

### DIFF
--- a/plugins/work/docs/README.md
+++ b/plugins/work/docs/README.md
@@ -68,3 +68,32 @@ follow_up → ci → cleanup → reports → complete
 | `spec.md` | `TASKS_BASE/<ticket>/` | Technical specification |
 | `tasks.md` | `TASKS_BASE/<ticket>/` | Task decomposition |
 | `*.check.md` | `TASKS_BASE/<ticket>/` | Quality reports |
+
+## Troubleshooting
+
+### `gh` calls fail with "Could not resolve to a Repository"
+
+`ghExec` (`scripts/workflows/work/scripts/gh-exec.js`) scrubs `GH_TOKEN` and
+`GITHUB_TOKEN` from the child env so `gh` falls back to the keyring's **active**
+`hosts.yml` account. When that active account lacks access to the target repo,
+every gh call fails with the GraphQL message
+`Could not resolve to a Repository with the name '<owner>/<repo>'` — even
+though the repo exists.
+
+To make this faster to diagnose, `ghExec` detects auth-shaped failures
+(`Could not resolve to a Repository`, `Resource not accessible`,
+`HTTP 401/403/404`, `requires authentication`) and appends a diagnostic block
+to the thrown error containing the active gh account, other configured
+accounts, and a `gh auth switch --user <correct-account>` hint.
+
+**If you see the diagnostic block:**
+1. Run `gh auth status` locally to confirm the active account.
+2. Switch to the account that owns the target repo:
+   `gh auth switch --user <correct-account>`
+3. Or unset `GH_TOKEN` / `GITHUB_TOKEN` in your shell so `gh` resolves
+   authentication from the keyring consistently.
+
+**Opt-out:** Set `GH_EXEC_NO_DIAG=1` (strict match) to suppress the
+diagnostic block — e.g. in CI environments where the raw error is preferred.
+The diagnostic is additive to the thrown `Error.message`; it never changes
+return shapes or `ghExec` semantics on the success path.

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/gh-exec.integration.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/gh-exec.integration.test.js
@@ -1,0 +1,296 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const MODULE_PATH = path.join(__dirname, '..', 'gh-exec.js');
+
+let tmpDir;
+let originalPath;
+
+before(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-exec-'));
+  originalPath = process.env.PATH;
+});
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  process.env.PATH = originalPath;
+});
+
+/**
+ * Write a fake `gh` script into a fresh dir, prepend to PATH, and return the
+ * dir so the test can clean up. Repeated invocations of `gh` log args to a
+ * file so tests can assert on how `gh` was called.
+ *
+ * The shell script dispatches on its first arg:
+ *   gh <real-args>   -> primary call (json or arbitrary)
+ *   gh auth status   -> diagnostic subprocess
+ *
+ * Behavior is parameterized via env vars in the fake `gh`:
+ *   FAKE_GH_MAIN_STDOUT, FAKE_GH_MAIN_STDERR, FAKE_GH_MAIN_EXIT
+ *   FAKE_GH_AUTH_STDOUT, FAKE_GH_AUTH_STDERR, FAKE_GH_AUTH_EXIT
+ *   FAKE_GH_CALL_LOG (path)
+ */
+function installFakeGh() {
+  const shimDir = fs.mkdtempSync(path.join(tmpDir, 'shim-'));
+  const ghPath = path.join(shimDir, 'gh');
+  const callLog = path.join(shimDir, 'calls.log');
+  const script = `#!/bin/sh
+echo "$@" >> "$FAKE_GH_CALL_LOG"
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  if [ -n "$FAKE_GH_AUTH_STDOUT" ]; then printf '%s' "$FAKE_GH_AUTH_STDOUT"; fi
+  if [ -n "$FAKE_GH_AUTH_STDERR" ]; then printf '%s' "$FAKE_GH_AUTH_STDERR" 1>&2; fi
+  exit \${FAKE_GH_AUTH_EXIT:-0}
+fi
+if [ -n "$FAKE_GH_MAIN_STDOUT" ]; then printf '%s' "$FAKE_GH_MAIN_STDOUT"; fi
+if [ -n "$FAKE_GH_MAIN_STDERR" ]; then printf '%s' "$FAKE_GH_MAIN_STDERR" 1>&2; fi
+exit \${FAKE_GH_MAIN_EXIT:-0}
+`;
+  fs.writeFileSync(ghPath, script, { mode: 0o755 });
+  process.env.PATH = `${shimDir}:${originalPath}`;
+  process.env.FAKE_GH_CALL_LOG = callLog;
+  return { shimDir, callLog };
+}
+
+function setFakeGhEnv({
+  mainStdout = '',
+  mainStderr = '',
+  mainExit = 0,
+  authStdout = '',
+  authStderr = '',
+  authExit = 0,
+} = {}) {
+  process.env.FAKE_GH_MAIN_STDOUT = mainStdout;
+  process.env.FAKE_GH_MAIN_STDERR = mainStderr;
+  process.env.FAKE_GH_MAIN_EXIT = String(mainExit);
+  process.env.FAKE_GH_AUTH_STDOUT = authStdout;
+  process.env.FAKE_GH_AUTH_STDERR = authStderr;
+  process.env.FAKE_GH_AUTH_EXIT = String(authExit);
+}
+
+function clearFakeGhEnv() {
+  for (const k of [
+    'FAKE_GH_MAIN_STDOUT',
+    'FAKE_GH_MAIN_STDERR',
+    'FAKE_GH_MAIN_EXIT',
+    'FAKE_GH_AUTH_STDOUT',
+    'FAKE_GH_AUTH_STDERR',
+    'FAKE_GH_AUTH_EXIT',
+    'GH_EXEC_NO_DIAG',
+  ]) {
+    delete process.env[k];
+  }
+}
+
+function freshRequire() {
+  delete require.cache[require.resolve(MODULE_PATH)];
+  return require(MODULE_PATH);
+}
+
+function readCalls(callLog) {
+  if (!fs.existsSync(callLog)) return [];
+  return fs
+    .readFileSync(callLog, 'utf8')
+    .split('\n')
+    .filter((line) => line.length > 0);
+}
+
+const AUTH_STATUS_OUTPUT_TWO_ACCOUNTS = [
+  'github.com',
+  '  ✓ Logged in to github.com account thomfilg (keyring)',
+  '  - Active account: true',
+  '  - Git operations protocol: ssh',
+  '  ✓ Logged in to github.com account otherbot (keyring)',
+  '  - Active account: false',
+  '',
+].join('\n');
+
+describe('gh-exec.js — auth diagnostic', () => {
+  describe('clean success path', () => {
+    it('clean success path returns parsed JSON without diagnostic', () => {
+      const { callLog } = installFakeGh();
+      setFakeGhEnv({ mainStdout: '{"login":"thomfilg"}', mainExit: 0 });
+      try {
+        const { ghExec } = freshRequire();
+        const result = ghExec(['api', 'user']);
+        assert.deepEqual(result, { login: 'thomfilg' });
+        const calls = readCalls(callLog);
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0], 'api user');
+        assert.equal(
+          calls.some((c) => c.startsWith('auth status')),
+          false,
+          'gh auth status MUST NOT be spawned on the happy path'
+        );
+      } finally {
+        clearFakeGhEnv();
+      }
+    });
+  });
+
+  describe('non-auth error', () => {
+    it('non-auth error rethrows without diagnostic', () => {
+      const { callLog } = installFakeGh();
+      setFakeGhEnv({
+        mainStderr: 'fatal: something unrelated blew up',
+        mainExit: 1,
+      });
+      try {
+        const { ghExec } = freshRequire();
+        assert.throws(
+          () => ghExec(['api', 'repos/foo/bar']),
+          (err) => {
+            assert.match(err.message, /gh command failed/);
+            assert.match(err.message, /something unrelated blew up/);
+            assert.doesNotMatch(err.message, /Likely auth issue/);
+            return true;
+          }
+        );
+        const calls = readCalls(callLog);
+        assert.equal(
+          calls.some((c) => c.startsWith('auth status')),
+          false,
+          'gh auth status MUST NOT be spawned for non-auth errors'
+        );
+      } finally {
+        clearFakeGhEnv();
+      }
+    });
+  });
+
+  describe('auth-shaped error', () => {
+    it('auth-shaped error appends diagnostic with active account', () => {
+      const { callLog } = installFakeGh();
+      setFakeGhEnv({
+        mainStderr:
+          'GraphQL: Could not resolve to a Repository with the name \'foo/bar\' (repository)',
+        mainExit: 1,
+        authStdout: AUTH_STATUS_OUTPUT_TWO_ACCOUNTS,
+        authExit: 0,
+      });
+      try {
+        const { ghExec } = freshRequire();
+        assert.throws(
+          () => ghExec(['api', 'repos/foo/bar']),
+          (err) => {
+            assert.match(err.message, /gh command failed/);
+            assert.match(err.message, /Could not resolve to a Repository/);
+            assert.match(err.message, /Likely auth issue/);
+            assert.match(err.message, /Active gh account:\s*thomfilg/);
+            assert.match(err.message, /gh auth switch --user otherbot/);
+            assert.match(err.message, /GH_TOKEN/);
+            assert.match(err.message, /GITHUB_TOKEN/);
+            return true;
+          }
+        );
+        const calls = readCalls(callLog);
+        assert.equal(
+          calls.some((c) => c.startsWith('auth status')),
+          true,
+          'gh auth status MUST be spawned to build diagnostic'
+        );
+      } finally {
+        clearFakeGhEnv();
+      }
+    });
+
+    it('matches HTTP 401 / 403 / 404 / Resource not accessible / requires authentication', () => {
+      const stderrs = [
+        'HTTP 401: unauthorized',
+        'HTTP 403: forbidden',
+        'HTTP 404: not found',
+        'Resource not accessible by integration',
+        'gh: this command requires authentication',
+      ];
+      for (const stderrMsg of stderrs) {
+        installFakeGh();
+        setFakeGhEnv({
+          mainStderr: stderrMsg,
+          mainExit: 1,
+          authStdout: AUTH_STATUS_OUTPUT_TWO_ACCOUNTS,
+          authExit: 0,
+        });
+        try {
+          const { ghExec } = freshRequire();
+          assert.throws(
+            () => ghExec(['api', 'repos/foo/bar']),
+            (err) => {
+              assert.match(
+                err.message,
+                /Likely auth issue/,
+                `expected auth diagnostic for stderr "${stderrMsg}"`
+              );
+              return true;
+            }
+          );
+        } finally {
+          clearFakeGhEnv();
+        }
+      }
+    });
+  });
+
+  describe('gh auth status itself fails', () => {
+    it('gh auth status itself fails → fallback hint', () => {
+      installFakeGh();
+      setFakeGhEnv({
+        mainStderr: 'HTTP 404: Could not resolve to a Repository',
+        mainExit: 1,
+        authStderr: 'gh auth status: not logged in to any host',
+        authExit: 1,
+      });
+      try {
+        const { ghExec } = freshRequire();
+        assert.throws(
+          () => ghExec(['api', 'repos/foo/bar']),
+          (err) => {
+            assert.match(err.message, /gh command failed/);
+            assert.match(err.message, /Likely auth issue/);
+            assert.match(err.message, /Run `gh auth status` to inspect active account/);
+            assert.doesNotMatch(err.message, /Active gh account:/);
+            return true;
+          }
+        );
+      } finally {
+        clearFakeGhEnv();
+      }
+    });
+  });
+
+  describe('GH_EXEC_NO_DIAG=1 opt-out', () => {
+    it('GH_EXEC_NO_DIAG=1 opts out of the diagnostic', () => {
+      const { callLog } = installFakeGh();
+      setFakeGhEnv({
+        mainStderr:
+          'GraphQL: Could not resolve to a Repository with the name \'foo/bar\' (repository)',
+        mainExit: 1,
+        authStdout: AUTH_STATUS_OUTPUT_TWO_ACCOUNTS,
+        authExit: 0,
+      });
+      process.env.GH_EXEC_NO_DIAG = '1';
+      try {
+        const { ghExec } = freshRequire();
+        assert.throws(
+          () => ghExec(['api', 'repos/foo/bar']),
+          (err) => {
+            assert.match(err.message, /gh command failed/);
+            assert.match(err.message, /Could not resolve to a Repository/);
+            assert.doesNotMatch(err.message, /Likely auth issue/);
+            assert.doesNotMatch(err.message, /Active gh account:/);
+            return true;
+          }
+        );
+        const calls = readCalls(callLog);
+        assert.equal(
+          calls.some((c) => c.startsWith('auth status')),
+          false,
+          'GH_EXEC_NO_DIAG=1 MUST suppress gh auth status spawn'
+        );
+      } finally {
+        clearFakeGhEnv();
+      }
+    });
+  });
+});

--- a/plugins/work/scripts/workflows/work/scripts/gh-exec.js
+++ b/plugins/work/scripts/workflows/work/scripts/gh-exec.js
@@ -3,27 +3,19 @@
  *
  * Executes `gh` commands via execFileSync with JSON parsing,
  * error handling, and optional non-zero exit tolerance.
+ *
+ * Auth diagnostic: when `gh` exits non-zero with an auth-shaped stderr
+ * (matched by AUTH_ERROR_REGEX), `ghExec` spawns `gh auth status` with a
+ * scrubbed env (no GH_TOKEN/GITHUB_TOKEN) and appends a diagnostic block to
+ * the thrown Error.message listing the active gh account, other configured
+ * accounts, the `gh auth switch --user <other>` hint, and a reminder to
+ * unset GH_TOKEN/GITHUB_TOKEN. Set `GH_EXEC_NO_DIAG=1` (strict string match)
+ * to opt out and restore today's raw-error behavior.
  */
 const { execFileSync } = require('child_process');
 
-/**
- * Execute a gh CLI command synchronously.
- * @param {string|string[]} ghArgs - Command arguments (string is split on whitespace)
- * @param {object} [opts]
- * @param {boolean} [opts.json=true] - Parse stdout as JSON
- * @param {boolean} [opts.allowNonZero=false] - Tolerate non-zero exit codes
- * @returns {*} Parsed JSON or trimmed string
- */
-/**
- * Build a child env that lets gh use its keyring auth (~/.config/gh/hosts.yml)
- * instead of an environment-injected token. If GH_TOKEN / GITHUB_TOKEN is set
- * in the parent process — common in dev environments where a personal-access
- * token is exported for unrelated tooling — gh prefers the env var over the
- * keyring. When that token belongs to a different account than the one
- * authorized for the repo, every API call returns 404 ("Could not resolve
- * repository" / "error connecting to api.github.com"). Scrubbing both vars
- * forces gh to fall back to the keyring's active account.
- */
+const AUTH_ERROR_REGEX = /Could not resolve to a Repository|Resource not accessible|HTTP 40[134]|requires authentication/i;
+
 function buildChildEnv() {
   const env = { ...process.env };
   delete env.GH_TOKEN;
@@ -31,6 +23,96 @@ function buildChildEnv() {
   return env;
 }
 
+function looksLikeAuthFailure(stderrText) {
+  if (!stderrText) return false;
+  return AUTH_ERROR_REGEX.test(stderrText);
+}
+
+/**
+ * Parse `gh auth status` stdout/stderr into `{ active, others }`.
+ * Only extracts account names — never echoes raw output.
+ */
+function parseGhAuthStatusOutput(text) {
+  if (!text || typeof text !== 'string') return null;
+  const lines = text.split('\n');
+  const accounts = [];
+  let active = null;
+  let lastAccount = null;
+  for (const raw of lines) {
+    const line = raw.trim();
+    const acctMatch = line.match(/Logged in to [^\s]+ account ([A-Za-z0-9_.-]+)/);
+    if (acctMatch) {
+      lastAccount = acctMatch[1];
+      accounts.push(lastAccount);
+      continue;
+    }
+    const activeMatch = line.match(/Active account:\s*(true|false)/i);
+    if (activeMatch && lastAccount && activeMatch[1].toLowerCase() === 'true') {
+      active = lastAccount;
+    }
+  }
+  if (!active && accounts.length > 0) active = accounts[0];
+  if (!active) return null;
+  const others = accounts.filter((a) => a !== active);
+  return { active, others };
+}
+
+function runGhAuthStatus() {
+  try {
+    let stdout = '';
+    let stderr = '';
+    try {
+      stdout = execFileSync('gh', ['auth', 'status'], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 5000,
+        env: buildChildEnv(),
+      });
+    } catch (err) {
+      // gh auth status often prints to stderr even on success; capture both.
+      stdout = err.stdout ? err.stdout.toString() : '';
+      stderr = err.stderr ? err.stderr.toString() : '';
+      if (!stdout && !stderr) return null;
+    }
+    const combined = `${stdout}\n${stderr}`;
+    return parseGhAuthStatusOutput(combined);
+  } catch {
+    return null;
+  }
+}
+
+function buildAuthDiagnostic(parsed) {
+  if (!parsed) {
+    return '\n↳ Likely auth issue. Run `gh auth status` to inspect active account.';
+  }
+  const lines = [];
+  lines.push('');
+  lines.push('↳ Likely auth issue.');
+  lines.push(`   Active gh account: ${parsed.active}`);
+  if (parsed.others && parsed.others.length > 0) {
+    lines.push(`   Other configured accounts: ${parsed.others.join(', ')}`);
+    for (const other of parsed.others) {
+      lines.push(`   Try: gh auth switch --user ${other}`);
+    }
+  }
+  lines.push('   If GH_TOKEN or GITHUB_TOKEN is set in your env, unset them so gh uses the keyring.');
+  return lines.join('\n');
+}
+
+/**
+ * Execute a gh CLI command synchronously.
+ *
+ * On non-zero exits whose stderr matches AUTH_ERROR_REGEX, appends an auth
+ * diagnostic block (active account + switch hints) to the thrown Error.message.
+ * Set `GH_EXEC_NO_DIAG=1` (strict) to suppress the diagnostic and restore
+ * today's raw-error behavior.
+ *
+ * @param {string|string[]} ghArgs - Command arguments (string is split on whitespace)
+ * @param {object} [opts]
+ * @param {boolean} [opts.json=true] - Parse stdout as JSON
+ * @param {boolean} [opts.allowNonZero=false] - Tolerate non-zero exit codes
+ * @returns {*} Parsed JSON or trimmed string
+ */
 function ghExec(ghArgs, { json = true, allowNonZero = false } = {}) {
   const args = typeof ghArgs === 'string' ? ghArgs.split(/\s+/) : ghArgs;
   try {
@@ -54,7 +136,15 @@ function ghExec(ghArgs, { json = true, allowNonZero = false } = {}) {
       if (!json && stdout) return stdout;
     }
     const stderr = err.stderr ? err.stderr.toString().trim() : '';
-    throw new Error(`gh command failed: gh ${args.join(' ')}\n${stderr}`);
+    const baseMessage = `gh command failed: gh ${args.join(' ')}\n${stderr}`;
+    if (process.env.GH_EXEC_NO_DIAG === '1') {
+      throw new Error(baseMessage);
+    }
+    if (!looksLikeAuthFailure(stderr)) {
+      throw new Error(baseMessage);
+    }
+    const parsed = runGhAuthStatus();
+    throw new Error(baseMessage + buildAuthDiagnostic(parsed));
   }
 }
 


### PR DESCRIPTION
## Existing Behavior

- `ghExec` catches errors from failed `gh` commands and rethrows a plain error containing the raw stderr and the command string.
- Auth-shaped failures (GraphQL "Could not resolve to a Repository", HTTP 401/403/404, "Resource not accessible", "requires authentication") are indistinguishable in the error message from a genuinely missing repo or a typo in the owner/name.
- Diagnosing the active-account-mismatch root cause required manually running `gh auth status`, identifying the active account, and reasoning through `buildChildEnv`'s token-scrubbing behavior — typically ~10 minutes of agent time.

## Intended New Behavior

- `ghExec` detects auth-shaped stderr via `AUTH_ERROR_REGEX` and, on match, spawns `gh auth status` (using the same scrubbed env) to extract the active account and all other configured accounts.
- The thrown error is augmented with a diagnostic block: active account name, suggested `gh auth switch --user <account>` command for each alternate account, and a reminder to unset `GH_TOKEN`/`GITHUB_TOKEN` in the shell.
- If `gh auth status` itself fails, a fallback hint ("Run `gh auth status` to inspect active account") is appended instead — the original error is always preserved.
- Diagnostic behavior is opt-out via `GH_EXEC_NO_DIAG=1` for CI environments that prefer raw errors.
- A Troubleshooting section in `plugins/work/docs/README.md` documents the active-account-mismatch failure mode, the diagnostic block format, and the opt-out.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Verify the diagnostic triggers on an auth-shaped failure:

1. Set up a fake gh that exits non-zero with `GraphQL: Could not resolve to a Repository`:
   ```bash
   export GH_EXEC_NO_DIAG=  # ensure opt-out is not set
   ```
2. In a Node REPL or test script, require `plugins/work/scripts/workflows/work/scripts/gh-exec.js` and call `ghExec(['api', 'repos/nonexistent/repo'])` against a real `gh` pointed at an org the active account cannot access.
3. Confirm the thrown error contains:
   - `gh command failed: gh api repos/nonexistent/repo`
   - `Likely auth issue`
   - `Active gh account: <your-active-account>`
   - `gh auth switch --user <other-account>` for each alternate account
   - `GH_TOKEN` / `GITHUB_TOKEN` reminder line
4. Verify non-auth errors (e.g. a network timeout) do NOT include the diagnostic block.
5. Set `GH_EXEC_NO_DIAG=1` and repeat step 2 — confirm the error contains only the raw stderr, no diagnostic.
6. Run the integration test suite directly:
   ```bash
   node --test plugins/work/scripts/workflows/work/scripts/__tests__/gh-exec.integration.test.js
   ```
   All 6 scenarios should pass.

### Test Results

6 integration tests in `gh-exec.integration.test.js` cover:
- Clean success — no diagnostic spawned
- Non-auth error — no diagnostic spawned
- Auth-shaped error (GraphQL "Could not resolve") — diagnostic with active account and switch suggestion
- All 5 auth pattern variants (HTTP 401/403/404, "Resource not accessible", "requires authentication")
- `gh auth status` itself failing — fallback hint appended
- `GH_EXEC_NO_DIAG=1` opt-out — raw error only

Closes #535

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Failure-path-only, additive error messages with CI opt-out; success behavior and return shapes are unchanged.
> 
> **Overview**
> **`ghExec`** now treats certain `gh` failures as likely auth problems and **enriches the thrown error** instead of only echoing stderr. On non-zero exit, stderr is matched against an auth-shaped pattern (e.g. *Could not resolve to a Repository*, HTTP 401/403/404, *Resource not accessible*, *requires authentication*). Matches trigger a second call to **`gh auth status`** (still using the token-scrubbed child env) and append a **“Likely auth issue”** block with the active account, other accounts, **`gh auth switch`** hints, and a reminder to unset **`GH_TOKEN`** / **`GITHUB_TOKEN`**. Success paths and non-auth errors are unchanged; **`GH_EXEC_NO_DIAG=1`** restores the previous raw error only.
> 
> Documentation adds a **Troubleshooting** section for the active-account / keyring mismatch case. A new **integration test suite** (fake `gh` on `PATH`) covers happy path, non-auth errors, all auth patterns, failed `gh auth status`, and the opt-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 036859f461149fcac0c64c80601e8ba41817dbec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->