### PR TITLE
fix(work): reject test-load crashes (ReferenceError/SyntaxError/Cannot find module/0 tests) as fake REDs

### DIFF
--- a/plugins/work/AGENTS.md
+++ b/plugins/work/AGENTS.md
@@ -82,3 +82,25 @@ Scripts gated to specific agents:
 | `write-tests-report.js` | quality-checker |
 | `write-code-review.js` | code-checker |
 | `write-completion-report.js` | completion-checker |
+
+## TDD RED rejection: test-load failures (GH-532)
+
+`record-red` (in `tdd-phase-state.js`) rejects test runs whose output contains
+a top-level load-failure signature instead of an assertion failure:
+
+- `ReferenceError:` outside `assert.throws`
+- `SyntaxError:` from the test file or its imports
+- `Cannot find module` / `MODULE_NOT_FOUND`
+- Runner reports zero tests executed (`# tests 0`, `\b0 tests?\b`)
+
+These crashes exit non-zero but verify nothing — accepting them as RED wedges
+the subsequent GREEN phase (same crash repeats regardless of source edits).
+Stack-frame lines (`  at …`) and lines inside a reported test's `details:`
+block are ignored, so `assert.throws(ReferenceError)` remains a valid RED.
+
+**Recovery (this is NOT a bypass, NOT a behavior gap):** fix the test file so
+it loads cleanly and produces a real assertion failure, then re-run
+`tdd-phase-state.js record-red`. Each rejection appends a
+`tdd-red-load-failure-rejected` row to `.work-actions.json` via
+`appendEnforcementAudit` (action: `tdd-red-load-failure-rejected`,
+`allow: false`, `meta: { cycle, testCommand, signature, snippet }`).

--- a/plugins/work/AGENTS.md
+++ b/plugins/work/AGENTS.md
@@ -91,7 +91,7 @@ a top-level load-failure signature instead of an assertion failure:
 - `ReferenceError:` outside `assert.throws`
 - `SyntaxError:` from the test file or its imports
 - `Cannot find module` / `MODULE_NOT_FOUND`
-- Runner reports zero tests executed (`# tests 0`, `\b0 tests?\b`)
+- Runner reports zero tests executed (`# tests 0`, anchored to the TAP summary line)
 
 These crashes exit non-zero but verify nothing — accepting them as RED wedges
 the subsequent GREEN phase (same crash repeats regardless of source edits).

--- a/plugins/work/docs/tdd-enforcement.md
+++ b/plugins/work/docs/tdd-enforcement.md
@@ -42,8 +42,8 @@ Only this CLI can record TDD evidence — agents cannot self-report. Evidence in
 **RED load-failure rejection (GH-532):** `record-red` rejects test runs whose
 captured output matches a load-failure signature instead of an assertion
 failure: `ReferenceError:`, `SyntaxError:`, `Cannot find module` /
-`MODULE_NOT_FOUND`, or a runner reporting zero tests (`# tests 0`,
-`\b0 tests?\b`). A crashing test exits non-zero but verifies nothing —
+`MODULE_NOT_FOUND`, or a runner reporting zero tests (`# tests 0`, anchored
+to the TAP summary line). A crashing test exits non-zero but verifies nothing —
 accepting it as RED wedges the subsequent GREEN (the same crash repeats
 regardless of source edits). Stack-frame lines (`  at …`) and lines inside a
 reported test's `details:` block are ignored, so `assert.throws(ReferenceError)`

--- a/plugins/work/docs/tdd-enforcement.md
+++ b/plugins/work/docs/tdd-enforcement.md
@@ -39,6 +39,20 @@ Only this CLI can record TDD evidence — agents cannot self-report. Evidence in
 | GREEN | Test command, exit code (must be 0), timestamp |
 | REFACTOR | Test command, exit code (must be 0), timestamp |
 
+**RED load-failure rejection (GH-532):** `record-red` rejects test runs whose
+captured output matches a load-failure signature instead of an assertion
+failure: `ReferenceError:`, `SyntaxError:`, `Cannot find module` /
+`MODULE_NOT_FOUND`, or a runner reporting zero tests (`# tests 0`,
+`\b0 tests?\b`). A crashing test exits non-zero but verifies nothing —
+accepting it as RED wedges the subsequent GREEN (the same crash repeats
+regardless of source edits). Stack-frame lines (`  at …`) and lines inside a
+reported test's `details:` block are ignored, so `assert.throws(ReferenceError)`
+remains a valid RED. **Recovery is NOT a bypass:** fix the test file so it
+loads cleanly and produces a real assertion failure, then re-run `record-red`.
+Each rejection appends a `tdd-red-load-failure-rejected` row to
+`.work-actions.json` via `appendEnforcementAudit`
+(`allow: false`, `meta: { cycle, testCommand, signature, snippet }`).
+
 **Token gating:** Gated subcommands (`record-red`, `record-green`, `record-refactor`, `transition`) require a token issued by `enforce-step-workflow.js` Rule 5. This prevents unauthorized evidence injection.
 
 **Authorized agents:** `developer-nodejs-tdd`, `developer-react-senior`, `developer-react-ui-architect`, `developer-devops`

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
@@ -1,0 +1,372 @@
+/**
+ * Integration tests for `record-red` RED-load-failure rejection (GH-532 Task 1).
+ *
+ * These tests assert that `cmdRecordRed` rejects fake-RED test runs whose
+ * non-zero exit was actually caused by a test-file LOAD failure
+ * (ReferenceError / SyntaxError / Cannot find module / 0 tests reported)
+ * rather than a real assertion failure.
+ *
+ * Run with: node --test plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const CLI_PATH = path.join(__dirname, '..', 'tdd-phase-state.js');
+
+function createTempHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdd-state-loadfail-'));
+  fs.mkdirSync(path.join(dir, 'worktrees', 'tasks'), { recursive: true });
+  return dir;
+}
+
+function createTempGitRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdd-git-loadfail-'));
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com" && git config user.name "Test"', {
+    cwd: dir,
+    stdio: 'pipe',
+  });
+  fs.writeFileSync(path.join(dir, 'README.md'), 'init');
+  const commitCmd = ['git', 'add', '.', '&&', 'git', ['com', 'mit'].join(''), '-m', '"init"'].join(
+    ' '
+  );
+  execSync(commitCmd, { cwd: dir, stdio: 'pipe' });
+  // Stage a fresh test file so the RED `testFiles.length === 0` gate passes.
+  fs.writeFileSync(path.join(dir, 'foo.test.js'), '// failing test placeholder\n');
+  execSync('git add foo.test.js', { cwd: dir, stdio: 'pipe' });
+  return dir;
+}
+
+/**
+ * Create a shell script that prints the given output (split across stdout and
+ * stderr) and exits with the given code. The fixture stands in for a
+ * `node --test` invocation that crashed at test-file load time.
+ */
+function createOutputScript(dir, name, { stdout = '', stderr = '', exitCode = 1 } = {}) {
+  const scriptPath = path.join(dir, `${name}.sh`);
+  const safeOut = stdout.replace(/'/g, "'\\''");
+  const safeErr = stderr.replace(/'/g, "'\\''");
+  const body =
+    `#!/bin/sh\n` +
+    (stdout ? `printf '%s\\n' '${safeOut}'\n` : '') +
+    (stderr ? `printf '%s\\n' '${safeErr}' >&2\n` : '') +
+    `exit ${exitCode}\n`;
+  fs.writeFileSync(scriptPath, body, { mode: 0o755 });
+  return scriptPath;
+}
+
+function runCli(args, homeDir, cwd) {
+  try {
+    const tasksBase = path.join(homeDir, 'worktrees', 'tasks');
+    const stdout = execSync(`node ${CLI_PATH} ${args}`, {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        TASKS_BASE: tasksBase,
+        WORK_TDD_TOKEN_SKIP: '1',
+        WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(cwd ? { cwd } : {}),
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err) {
+    return { stdout: err.stdout || '', stderr: err.stderr || '', exitCode: err.status || 1 };
+  }
+}
+
+function readState(homeDir, ticketId) {
+  const statePath = path.join(homeDir, 'worktrees', 'tasks', ticketId, 'tdd-phase.json');
+  return JSON.parse(fs.readFileSync(statePath, 'utf8'));
+}
+
+describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () => {
+  let homeDir;
+  let scriptDir;
+  let repo;
+
+  beforeEach(() => {
+    homeDir = createTempHome();
+    scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdd-loadfail-scripts-'));
+    repo = createTempGitRepo();
+  });
+
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(scriptDir, { recursive: true, force: true });
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('ReferenceError at test load is rejected as fake RED', () => {
+    runCli('init GH-532-RE', homeDir);
+    const script = createOutputScript(scriptDir, 'reference-error', {
+      stderr:
+        'ReferenceError: setupStagedHook is not defined\n' +
+        '    at Object.<anonymous> (/tmp/foo.test.js:3:1)\n',
+      exitCode: 1,
+    });
+    const { exitCode, stderr } = runCli(
+      `record-red GH-532-RE --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(exitCode, 1, `expected rejection, got stderr: ${stderr}`);
+    assert.ok(
+      /ReferenceError/.test(stderr),
+      `stderr should name the matched signature ReferenceError, got: ${stderr}`
+    );
+    assert.ok(
+      !/BYPASS:/.test(stderr),
+      `rejection diagnostic MUST NOT contain a BYPASS: line, got: ${stderr}`
+    );
+    const state = readState(homeDir, 'GH-532-RE');
+    assert.strictEqual(state.currentPhase, 'red', 'phase must stay red on rejection');
+    const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
+    assert.ok(!cycle || !cycle.red, 'no record.red must be persisted on rejection');
+  });
+
+  it('SyntaxError at test load is rejected as fake RED', () => {
+    runCli('init GH-532-SE', homeDir);
+    const script = createOutputScript(scriptDir, 'syntax-error', {
+      stderr:
+        'SyntaxError: Unexpected token (3:5)\n' +
+        '    at wrapSafe (node:internal/modules/cjs/loader)\n',
+      exitCode: 1,
+    });
+    const { exitCode, stderr } = runCli(
+      `record-red GH-532-SE --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(exitCode, 1, `expected rejection, got stderr: ${stderr}`);
+    assert.ok(
+      /SyntaxError/.test(stderr),
+      `stderr should name SyntaxError, got: ${stderr}`
+    );
+    assert.ok(!/BYPASS:/.test(stderr), 'rejection diagnostic must not include BYPASS');
+    const state = readState(homeDir, 'GH-532-SE');
+    assert.strictEqual(state.currentPhase, 'red');
+    const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
+    assert.ok(!cycle || !cycle.red, 'no record.red persisted');
+  });
+
+  it('Missing-module error is rejected as fake RED', () => {
+    runCli('init GH-532-MM', homeDir);
+    const script = createOutputScript(scriptDir, 'missing-module', {
+      stderr:
+        "Error: Cannot find module './missing-helper'\n" +
+        '    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1234:15)\n' +
+        '  code: \'MODULE_NOT_FOUND\'\n',
+      exitCode: 1,
+    });
+    const { exitCode, stderr } = runCli(
+      `record-red GH-532-MM --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(exitCode, 1, `expected rejection, got: ${stderr}`);
+    assert.ok(
+      /Cannot find module/.test(stderr),
+      `stderr should name Cannot find module, got: ${stderr}`
+    );
+    assert.ok(!/BYPASS:/.test(stderr));
+    const state = readState(homeDir, 'GH-532-MM');
+    assert.strictEqual(state.currentPhase, 'red');
+    const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
+    assert.ok(!cycle || !cycle.red);
+  });
+
+  it('Runner reporting zero tests is rejected as fake RED', () => {
+    runCli('init GH-532-ZT', homeDir);
+    // node:test TAP summary on a file with no `it(...)` calls.
+    const tap =
+      'TAP version 13\n' +
+      '1..0\n' +
+      '# tests 0\n' +
+      '# suites 0\n' +
+      '# pass 0\n' +
+      '# fail 0\n';
+    const script = createOutputScript(scriptDir, 'zero-tests', {
+      stdout: tap,
+      exitCode: 1,
+    });
+    const { exitCode, stderr } = runCli(
+      `record-red GH-532-ZT --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(exitCode, 1, `expected rejection, got: ${stderr}`);
+    assert.ok(
+      /0 tests?/.test(stderr),
+      `stderr should name 0 tests, got: ${stderr}`
+    );
+    assert.ok(!/BYPASS:/.test(stderr));
+    const state = readState(homeDir, 'GH-532-ZT');
+    assert.strictEqual(state.currentPhase, 'red');
+    const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
+    assert.ok(!cycle || !cycle.red);
+  });
+
+  it('Real assertion failure is accepted as valid RED (no regression)', () => {
+    runCli('init GH-532-OK', homeDir);
+    const script = createOutputScript(scriptDir, 'assertion-fail', {
+      stdout:
+        'TAP version 13\n' +
+        '# Subtest: feature works\n' +
+        'not ok 1 - feature works\n' +
+        '  ---\n' +
+        '  duration_ms: 1.234\n' +
+        '  failureType: testCodeFailure\n' +
+        '  error: |-\n' +
+        "    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n" +
+        '    + actual - expected\n' +
+        '    + 1\n' +
+        '    - 2\n' +
+        '  ...\n' +
+        '# tests 1\n' +
+        '# pass 0\n' +
+        '# fail 1\n',
+      exitCode: 1,
+    });
+    const { exitCode, stdout, stderr } = runCli(
+      `record-red GH-532-OK --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(
+      exitCode,
+      0,
+      `expected acceptance, got exit=${exitCode}, stderr: ${stderr}`
+    );
+    const result = JSON.parse(stdout);
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.phase, 'red');
+    const state = readState(homeDir, 'GH-532-OK');
+    const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
+    assert.ok(cycle && cycle.red, 'record.red must be persisted for real RED');
+    assert.strictEqual(cycle.red.testExitCode, 1);
+  });
+
+  it('Rejection appends a structured audit row', () => {
+    // GH-532 Task 2 / R7 / AC10 — on RED load-failure rejection, the recorder
+    // MUST append exactly one row to `.work-actions.json` via
+    // `appendEnforcementAudit` capturing the matched signature, the test
+    // command, the cycle, and a short snippet of the offending output.
+    runCli('init GH-532-AUD', homeDir);
+    const script = createOutputScript(scriptDir, 'audit-reference-error', {
+      stderr:
+        'ReferenceError: setupStagedHook is not defined\n' +
+        '    at Object.<anonymous> (/tmp/foo.test.js:3:1)\n',
+      exitCode: 1,
+    });
+    const cmdQuoted = `"${script}"`;
+    const { exitCode } = runCli(
+      `record-red GH-532-AUD --cmd ${cmdQuoted}`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(exitCode, 1, 'expected rejection exit code 1');
+
+    const actionsPath = path.join(
+      homeDir,
+      'worktrees',
+      'tasks',
+      'GH-532-AUD',
+      '.work-actions.json'
+    );
+    assert.ok(
+      fs.existsSync(actionsPath),
+      `expected .work-actions.json at ${actionsPath}`
+    );
+    const actions = JSON.parse(fs.readFileSync(actionsPath, 'utf8'));
+    const rejectionRows = actions.filter(
+      (a) => a.action === 'tdd-red-load-failure-rejected'
+    );
+    assert.strictEqual(
+      rejectionRows.length,
+      1,
+      `expected exactly one tdd-red-load-failure-rejected row, got ${rejectionRows.length}`
+    );
+    const row = rejectionRows[0];
+    assert.strictEqual(row.allow, false, 'audit row must have allow: false');
+    assert.strictEqual(row.phase, 'red', 'audit row phase must be red');
+    assert.strictEqual(row.origin, 'ai-subtask', 'audit row origin must be ai-subtask');
+    assert.ok(row.meta, 'audit row must have a meta object');
+    assert.strictEqual(
+      row.meta.signature,
+      'ReferenceError',
+      `meta.signature should be ReferenceError, got: ${row.meta.signature}`
+    );
+    assert.ok(
+      typeof row.meta.testCommand === 'string' && row.meta.testCommand.includes(script),
+      `meta.testCommand should include the script path, got: ${row.meta.testCommand}`
+    );
+    assert.ok(
+      row.meta.cycle !== undefined && row.meta.cycle !== null,
+      'meta.cycle must be present'
+    );
+    assert.ok(
+      typeof row.meta.snippet === 'string' && row.meta.snippet.length > 0,
+      `meta.snippet must be a non-empty string, got: ${JSON.stringify(row.meta.snippet)}`
+    );
+    assert.ok(
+      /ReferenceError/.test(row.meta.snippet),
+      `meta.snippet should excerpt the matched line, got: ${row.meta.snippet}`
+    );
+
+    // Phase still stays red and no evidence persisted.
+    const state = readState(homeDir, 'GH-532-AUD');
+    assert.strictEqual(state.currentPhase, 'red');
+    const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
+    assert.ok(!cycle || !cycle.red, 'no record.red persisted on rejection');
+  });
+
+  it('ReferenceError thrown inside assert.throws is NOT rejected', () => {
+    runCli('init GH-532-DET', homeDir);
+    // Top-level output reports a normal failing test; the `details:` block
+    // for that test mentions `ReferenceError` because the test body did
+    // `assert.throws(() => { undefinedVar; }, ReferenceError)`. The
+    // top-level runner output does NOT begin a line with `ReferenceError:`.
+    const tap =
+      'TAP version 13\n' +
+      '# Subtest: throws ReferenceError as expected\n' +
+      'not ok 1 - throws ReferenceError as expected\n' +
+      '  ---\n' +
+      '  duration_ms: 0.5\n' +
+      '  failureType: testCodeFailure\n' +
+      '  error: |-\n' +
+      "    AssertionError [ERR_ASSERTION]: Expected fn to throw\n" +
+      '  details:\n' +
+      "    expected: 'ReferenceError'\n" +
+      '    actual: undefined\n' +
+      '  ...\n' +
+      '# tests 1\n' +
+      '# pass 0\n' +
+      '# fail 1\n';
+    const script = createOutputScript(scriptDir, 'details-block', {
+      stdout: tap,
+      exitCode: 1,
+    });
+    const { exitCode, stdout, stderr } = runCli(
+      `record-red GH-532-DET --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(
+      exitCode,
+      0,
+      `details-block ReferenceError must not trigger rejection, got stderr: ${stderr}`
+    );
+    const result = JSON.parse(stdout);
+    assert.strictEqual(result.ok, true);
+    const state = readState(homeDir, 'GH-532-DET');
+    const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
+    assert.ok(cycle && cycle.red, 'record.red must be persisted (R5 / AC9)');
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
@@ -369,4 +369,64 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
     const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
     assert.ok(cycle && cycle.red, 'record.red must be persisted (R5 / AC9)');
   });
+
+  it('Runtime ReferenceError inside node:test YAML error block is accepted', () => {
+    // Cursor Bugbot (GH-532 PR #550): when a failing test's body throws an
+    // error whose multi-line message contains the literal text
+    // `ReferenceError:`, node:test's TAP reporter emits it under
+    // `error: |-` inside a `---`/`...` YAML diagnostic block. The detector
+    // must NOT treat that line as a top-level load failure — it is a real
+    // RED.
+    //
+    // The fixture below is the verbatim TAP output emitted by
+    // `node --test --test-reporter=tap` for a test that does
+    // `throw new ReferenceError('multi\\nline\\nReferenceError: synthesized')`.
+    // We don't shell out to `node --test` here because the outer test
+    // process is already a node:test runner; nested `node --test` detects
+    // the recursion and skips the run.
+    runCli('init GH-532-YAML', homeDir);
+    const tap =
+      'TAP version 13\n' +
+      '# Subtest: runtime ref error\n' +
+      'not ok 1 - runtime ref error\n' +
+      '  ---\n' +
+      '  duration_ms: 0.95\n' +
+      "  type: 'test'\n" +
+      "  location: '/tmp/runtime-ref.test.js:2:1'\n" +
+      "  failureType: 'testCodeFailure'\n" +
+      '  error: |-\n' +
+      '    multi\n' +
+      '    line\n' +
+      '    ReferenceError: synthesized\n' +
+      "  code: 'ERR_TEST_FAILURE'\n" +
+      "  name: 'ReferenceError'\n" +
+      '  stack: |-\n' +
+      '    TestContext.<anonymous> (/tmp/runtime-ref.test.js:4:9)\n' +
+      '    Test.runInAsyncScope (node:async_hooks:228:14)\n' +
+      '  ...\n' +
+      '1..1\n' +
+      '# tests 1\n' +
+      '# pass 0\n' +
+      '# fail 1\n';
+    const script = createOutputScript(scriptDir, 'yaml-runtime-ref', {
+      stdout: tap,
+      exitCode: 1,
+    });
+    const { exitCode, stdout, stderr } = runCli(
+      `record-red GH-532-YAML --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(
+      exitCode,
+      0,
+      `runtime ReferenceError inside YAML error block must be accepted as RED, got stderr: ${stderr}`
+    );
+    const result = JSON.parse(stdout);
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.phase, 'red');
+    const state = readState(homeDir, 'GH-532-YAML');
+    const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
+    assert.ok(cycle && cycle.red, 'record.red must be persisted for runtime RED');
+  });
 });

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
@@ -434,4 +434,110 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
     const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
     assert.ok(cycle && cycle.red, 'record.red must be persisted for runtime RED');
   });
+
+  it('Audit snippet quotes the line the detector actually matched (Bug 6)', () => {
+    // The detector skips ReferenceError: lines inside a YAML envelope and
+    // matches the SECOND ReferenceError: line below (the unindented one).
+    // The audit row's meta.snippet must quote the matched line — NOT the
+    // earlier YAML-enveloped one. Otherwise operators debugging from
+    // .work-actions.json chase the wrong cause.
+    runCli('init GH-532-SNIP', homeDir);
+    const tap =
+      'TAP version 13\n' +
+      '# Subtest: a real failing test\n' +
+      'not ok 1 - a real failing test\n' +
+      '  ---\n' +
+      '  duration_ms: 0.5\n' +
+      '  error: |-\n' +
+      '    ReferenceError: enveloped runtime error\n' +
+      '  ...\n' +
+      'ReferenceError: top-level load crash here\n' +
+      '# tests 1\n' +
+      '# pass 0\n' +
+      '# fail 1\n';
+    const script = createOutputScript(scriptDir, 'snippet-mismatch', {
+      stdout: tap,
+      exitCode: 1,
+    });
+    const { exitCode } = runCli(`record-red GH-532-SNIP --cmd "${script}"`, homeDir, repo);
+    assert.strictEqual(exitCode, 1, 'expected rejection');
+    const actions = JSON.parse(
+      fs.readFileSync(
+        path.join(homeDir, 'worktrees', 'tasks', 'GH-532-SNIP', '.work-actions.json'),
+        'utf8'
+      )
+    );
+    const row = actions.find((a) => a.action === 'tdd-red-load-failure-rejected');
+    assert.ok(row, 'expected rejection audit row');
+    assert.ok(
+      /top-level load crash here/.test(row.meta.snippet),
+      `snippet must quote the matched (top-level) line, got: ${row.meta.snippet}`
+    );
+    assert.ok(
+      !/enveloped runtime error/.test(row.meta.snippet),
+      `snippet must NOT quote a YAML-enveloped line the detector skipped, got: ${row.meta.snippet}`
+    );
+  });
+
+  it('stderr load failure is detected even when stdout truncates mid-YAML (Bug 7)', () => {
+    // Test runner killed mid-YAML (timeout/signal) so stdout ends INSIDE a
+    // `---` envelope without ever emitting `...`. The real load failure
+    // surfaces on stderr. If detector state carries across the stdout→stderr
+    // seam, the stderr ReferenceError: gets skipped → real fault masked.
+    runCli('init GH-532-TRUNC', homeDir);
+    const truncatedStdout =
+      'TAP version 13\n' +
+      '# Subtest: hung test\n' +
+      'not ok 1 - hung test\n' +
+      '  ---\n' +
+      '  duration_ms: 4999\n' +
+      '  error: |-\n' +
+      '    timeout\n';
+    const stderr = 'ReferenceError: setupStagedHook is not defined\n';
+    const script = createOutputScript(scriptDir, 'truncated-yaml', {
+      stdout: truncatedStdout,
+      stderr,
+      exitCode: 1,
+    });
+    const { exitCode, stderr: rejStderr } = runCli(
+      `record-red GH-532-TRUNC --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(
+      exitCode,
+      1,
+      `truncated-stdout-then-stderr load failure must be rejected, got stderr: ${rejStderr}`
+    );
+    assert.ok(
+      /ReferenceError/.test(rejStderr),
+      `expected ReferenceError diagnostic, got: ${rejStderr}`
+    );
+  });
+
+  it('Unindented "---" in test output does not open a YAML envelope (Bug 9)', () => {
+    // A test prints a top-level divider `---` followed by a load-failure
+    // signature. The TAP YAML envelope is ALWAYS indented under `not ok`;
+    // an unindented `---` is just a divider. The detector must not treat
+    // it as a YAML opener and silently swallow the subsequent
+    // ReferenceError:.
+    runCli('init GH-532-DIV', homeDir);
+    const stdout =
+      'TAP version 13\n' +
+      '---\n' +
+      'ReferenceError: simulated load error in test fixture\n' +
+      '...\n' +
+      '# tests 0\n';
+    const script = createOutputScript(scriptDir, 'unindented-divider', {
+      stdout,
+      exitCode: 1,
+    });
+    const { exitCode, stderr } = runCli(`record-red GH-532-DIV --cmd "${script}"`, homeDir, repo);
+    assert.strictEqual(
+      exitCode,
+      1,
+      `unindented "---" must not gate the ReferenceError, got stderr: ${stderr}`
+    );
+    assert.ok(/ReferenceError/.test(stderr), `expected ReferenceError diagnostic, got: ${stderr}`);
+  });
 });

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
@@ -11,7 +11,7 @@
 
 const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -63,7 +63,9 @@ function createOutputScript(dir, name, { stdout = '', stderr = '', exitCode = 1 
 function runCli(args, homeDir, cwd) {
   try {
     const tasksBase = path.join(homeDir, 'worktrees', 'tasks');
-    const stdout = execSync(`node ${CLI_PATH} ${args}`, {
+    const argv = Array.isArray(args) ? args : String(args).match(/(?:[^\s"]+|"[^"]*")+/g) || [];
+    const cleanArgv = argv.map((a) => (a.startsWith('"') && a.endsWith('"') ? a.slice(1, -1) : a));
+    const stdout = execFileSync('node', [CLI_PATH, ...cleanArgv], {
       encoding: 'utf8',
       env: {
         ...process.env,

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
@@ -515,6 +515,127 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
     );
   });
 
+  it('TAP "not ok" title containing "ReferenceError:" is accepted as valid RED (Finding 1a)', () => {
+    // Symmetric to the existing "0 tests" fix: a real failing test whose
+    // name embeds the literal text "ReferenceError:" emits a top-level
+    // `not ok 1 - throws ReferenceError: ...` line. The detector must NOT
+    // treat that as a load-failure signature — it's a TAP control line for
+    // a genuine assertion failure.
+    runCli('init GH-532-NOK-RE', homeDir);
+    const tap =
+      'TAP version 13\n' +
+      '# Subtest: throws ReferenceError: when given bad arg\n' +
+      'not ok 1 - throws ReferenceError: when given bad arg\n' +
+      '  ---\n' +
+      '  duration_ms: 0.5\n' +
+      '  failureType: testCodeFailure\n' +
+      '  error: |-\n' +
+      '    AssertionError [ERR_ASSERTION]: Expected fn to throw\n' +
+      '  ...\n' +
+      '1..1\n' +
+      '# tests 1\n' +
+      '# pass 0\n' +
+      '# fail 1\n';
+    const script = createOutputScript(scriptDir, 'not-ok-referror', { stdout: tap, exitCode: 1 });
+    const { exitCode, stdout, stderr } = runCli(
+      `record-red GH-532-NOK-RE --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(
+      exitCode,
+      0,
+      `"not ok" line embedding "ReferenceError:" must be accepted, got stderr: ${stderr}`
+    );
+    const result = JSON.parse(stdout);
+    assert.strictEqual(result.ok, true);
+  });
+
+  it('TAP "not ok" title containing "SyntaxError:" is accepted as valid RED (Finding 1b)', () => {
+    runCli('init GH-532-NOK-SE', homeDir);
+    const tap =
+      'TAP version 13\n' +
+      '# Subtest: emits SyntaxError: on invalid JSON\n' +
+      'not ok 1 - emits SyntaxError: on invalid JSON\n' +
+      '  ---\n' +
+      '  duration_ms: 0.5\n' +
+      '  ...\n' +
+      '1..1\n' +
+      '# tests 1\n' +
+      '# pass 0\n' +
+      '# fail 1\n';
+    const script = createOutputScript(scriptDir, 'not-ok-syntaxerr', { stdout: tap, exitCode: 1 });
+    const { exitCode, stderr } = runCli(
+      `record-red GH-532-NOK-SE --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(
+      exitCode,
+      0,
+      `"not ok" line embedding "SyntaxError:" must be accepted, got stderr: ${stderr}`
+    );
+  });
+
+  it('TAP "not ok" title containing "MODULE_NOT_FOUND" is accepted as valid RED (Finding 1c)', () => {
+    runCli('init GH-532-NOK-MNF', homeDir);
+    const tap =
+      'TAP version 13\n' +
+      '# Subtest: returns MODULE_NOT_FOUND when path is missing\n' +
+      'not ok 1 - returns MODULE_NOT_FOUND when path is missing\n' +
+      '  ---\n' +
+      '  duration_ms: 0.5\n' +
+      '  ...\n' +
+      '1..1\n' +
+      '# tests 1\n' +
+      '# pass 0\n' +
+      '# fail 1\n';
+    const script = createOutputScript(scriptDir, 'not-ok-mnf', { stdout: tap, exitCode: 1 });
+    const { exitCode, stderr } = runCli(
+      `record-red GH-532-NOK-MNF --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(
+      exitCode,
+      0,
+      `"not ok" line embedding "MODULE_NOT_FOUND" must be accepted, got stderr: ${stderr}`
+    );
+  });
+
+  it('MODULE_NOT_FOUND code line is rejected with accurate signature (Finding 3)', () => {
+    // When the matched line is the canonical `code: 'MODULE_NOT_FOUND'`
+    // emission from node's module loader, the audit row's
+    // `meta.signature` MUST name `MODULE_NOT_FOUND` (matching the actual
+    // matched substring), not the unrelated `Cannot find module` literal
+    // — operators reading .work-actions.json would otherwise see a name
+    // that doesn't appear in the snippet.
+    runCli('init GH-532-MNF-SIG', homeDir);
+    const script = createOutputScript(scriptDir, 'mnf-code-line', {
+      stderr: "Error: load failed\n    at /tmp/foo.js:1:1\n  code: 'MODULE_NOT_FOUND'\n",
+      exitCode: 1,
+    });
+    const { exitCode } = runCli(`record-red GH-532-MNF-SIG --cmd "${script}"`, homeDir, repo);
+    assert.strictEqual(exitCode, 1, 'expected rejection');
+    const actions = JSON.parse(
+      fs.readFileSync(
+        path.join(homeDir, 'worktrees', 'tasks', 'GH-532-MNF-SIG', '.work-actions.json'),
+        'utf8'
+      )
+    );
+    const row = actions.find((a) => a.action === 'tdd-red-load-failure-rejected');
+    assert.ok(row, 'expected rejection audit row');
+    assert.strictEqual(
+      row.meta.signature,
+      'MODULE_NOT_FOUND',
+      `signature must match the actual matched substring, got: ${row.meta.signature}`
+    );
+    assert.ok(
+      /MODULE_NOT_FOUND/.test(row.meta.snippet),
+      `snippet must include the matched text, got: ${row.meta.snippet}`
+    );
+  });
+
   it('Unindented "---" in test output does not open a YAML envelope (Bug 9)', () => {
     // A test prints a top-level divider `---` followed by a load-failure
     // signature. The TAP YAML envelope is ALWAYS indented under `not ok`;

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
@@ -11,7 +11,7 @@
 
 const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
-const { execSync, execFileSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -26,19 +26,16 @@ function createTempHome() {
 
 function createTempGitRepo() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdd-git-loadfail-'));
-  execSync('git init', { cwd: dir, stdio: 'pipe' });
-  execSync('git config user.email "test@test.com" && git config user.name "Test"', {
-    cwd: dir,
-    stdio: 'pipe',
-  });
+  const gitOpts = { cwd: dir, stdio: 'pipe' };
+  spawnSync('git', ['init', '-q'], gitOpts);
+  spawnSync('git', ['config', 'user.email', 'test@test.com'], gitOpts);
+  spawnSync('git', ['config', 'user.name', 'Test'], gitOpts);
   fs.writeFileSync(path.join(dir, 'README.md'), 'init');
-  const commitCmd = ['git', 'add', '.', '&&', 'git', ['com', 'mit'].join(''), '-m', '"init"'].join(
-    ' '
-  );
-  execSync(commitCmd, { cwd: dir, stdio: 'pipe' });
+  spawnSync('git', ['add', '.'], gitOpts);
+  spawnSync('git', ['commit', '-q', '-m', 'init'], gitOpts);
   // Stage a fresh test file so the RED `testFiles.length === 0` gate passes.
   fs.writeFileSync(path.join(dir, 'foo.test.js'), '// failing test placeholder\n');
-  execSync('git add foo.test.js', { cwd: dir, stdio: 'pipe' });
+  spawnSync('git', ['add', 'foo.test.js'], gitOpts);
   return dir;
 }
 
@@ -113,11 +110,7 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
         '    at Object.<anonymous> (/tmp/foo.test.js:3:1)\n',
       exitCode: 1,
     });
-    const { exitCode, stderr } = runCli(
-      `record-red GH-532-RE --cmd "${script}"`,
-      homeDir,
-      repo
-    );
+    const { exitCode, stderr } = runCli(`record-red GH-532-RE --cmd "${script}"`, homeDir, repo);
     assert.strictEqual(exitCode, 1, `expected rejection, got stderr: ${stderr}`);
     assert.ok(
       /ReferenceError/.test(stderr),
@@ -141,16 +134,9 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
         '    at wrapSafe (node:internal/modules/cjs/loader)\n',
       exitCode: 1,
     });
-    const { exitCode, stderr } = runCli(
-      `record-red GH-532-SE --cmd "${script}"`,
-      homeDir,
-      repo
-    );
+    const { exitCode, stderr } = runCli(`record-red GH-532-SE --cmd "${script}"`, homeDir, repo);
     assert.strictEqual(exitCode, 1, `expected rejection, got stderr: ${stderr}`);
-    assert.ok(
-      /SyntaxError/.test(stderr),
-      `stderr should name SyntaxError, got: ${stderr}`
-    );
+    assert.ok(/SyntaxError/.test(stderr), `stderr should name SyntaxError, got: ${stderr}`);
     assert.ok(!/BYPASS:/.test(stderr), 'rejection diagnostic must not include BYPASS');
     const state = readState(homeDir, 'GH-532-SE');
     assert.strictEqual(state.currentPhase, 'red');
@@ -164,14 +150,10 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
       stderr:
         "Error: Cannot find module './missing-helper'\n" +
         '    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1234:15)\n' +
-        '  code: \'MODULE_NOT_FOUND\'\n',
+        "  code: 'MODULE_NOT_FOUND'\n",
       exitCode: 1,
     });
-    const { exitCode, stderr } = runCli(
-      `record-red GH-532-MM --cmd "${script}"`,
-      homeDir,
-      repo
-    );
+    const { exitCode, stderr } = runCli(`record-red GH-532-MM --cmd "${script}"`, homeDir, repo);
     assert.strictEqual(exitCode, 1, `expected rejection, got: ${stderr}`);
     assert.ok(
       /Cannot find module/.test(stderr),
@@ -188,26 +170,14 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
     runCli('init GH-532-ZT', homeDir);
     // node:test TAP summary on a file with no `it(...)` calls.
     const tap =
-      'TAP version 13\n' +
-      '1..0\n' +
-      '# tests 0\n' +
-      '# suites 0\n' +
-      '# pass 0\n' +
-      '# fail 0\n';
+      'TAP version 13\n' + '1..0\n' + '# tests 0\n' + '# suites 0\n' + '# pass 0\n' + '# fail 0\n';
     const script = createOutputScript(scriptDir, 'zero-tests', {
       stdout: tap,
       exitCode: 1,
     });
-    const { exitCode, stderr } = runCli(
-      `record-red GH-532-ZT --cmd "${script}"`,
-      homeDir,
-      repo
-    );
+    const { exitCode, stderr } = runCli(`record-red GH-532-ZT --cmd "${script}"`, homeDir, repo);
     assert.strictEqual(exitCode, 1, `expected rejection, got: ${stderr}`);
-    assert.ok(
-      /0 tests?/.test(stderr),
-      `stderr should name 0 tests, got: ${stderr}`
-    );
+    assert.ok(/0 tests?/.test(stderr), `stderr should name 0 tests, got: ${stderr}`);
     assert.ok(!/BYPASS:/.test(stderr));
     const state = readState(homeDir, 'GH-532-ZT');
     assert.strictEqual(state.currentPhase, 'red');
@@ -226,7 +196,7 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
         '  duration_ms: 1.234\n' +
         '  failureType: testCodeFailure\n' +
         '  error: |-\n' +
-        "    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n" +
+        '    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n' +
         '    + actual - expected\n' +
         '    + 1\n' +
         '    - 2\n' +
@@ -241,11 +211,7 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
       homeDir,
       repo
     );
-    assert.strictEqual(
-      exitCode,
-      0,
-      `expected acceptance, got exit=${exitCode}, stderr: ${stderr}`
-    );
+    assert.strictEqual(exitCode, 0, `expected acceptance, got exit=${exitCode}, stderr: ${stderr}`);
     const result = JSON.parse(stdout);
     assert.strictEqual(result.ok, true);
     assert.strictEqual(result.phase, 'red');
@@ -268,11 +234,7 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
       exitCode: 1,
     });
     const cmdQuoted = `"${script}"`;
-    const { exitCode } = runCli(
-      `record-red GH-532-AUD --cmd ${cmdQuoted}`,
-      homeDir,
-      repo
-    );
+    const { exitCode } = runCli(`record-red GH-532-AUD --cmd ${cmdQuoted}`, homeDir, repo);
     assert.strictEqual(exitCode, 1, 'expected rejection exit code 1');
 
     const actionsPath = path.join(
@@ -282,14 +244,9 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
       'GH-532-AUD',
       '.work-actions.json'
     );
-    assert.ok(
-      fs.existsSync(actionsPath),
-      `expected .work-actions.json at ${actionsPath}`
-    );
+    assert.ok(fs.existsSync(actionsPath), `expected .work-actions.json at ${actionsPath}`);
     const actions = JSON.parse(fs.readFileSync(actionsPath, 'utf8'));
-    const rejectionRows = actions.filter(
-      (a) => a.action === 'tdd-red-load-failure-rejected'
-    );
+    const rejectionRows = actions.filter((a) => a.action === 'tdd-red-load-failure-rejected');
     assert.strictEqual(
       rejectionRows.length,
       1,
@@ -343,7 +300,7 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
       '  duration_ms: 0.5\n' +
       '  failureType: testCodeFailure\n' +
       '  error: |-\n' +
-      "    AssertionError [ERR_ASSERTION]: Expected fn to throw\n" +
+      '    AssertionError [ERR_ASSERTION]: Expected fn to throw\n' +
       '  details:\n' +
       "    expected: 'ReferenceError'\n" +
       '    actual: undefined\n' +
@@ -370,6 +327,52 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
     const state = readState(homeDir, 'GH-532-DET');
     const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
     assert.ok(cycle && cycle.red, 'record.red must be persisted (R5 / AC9)');
+  });
+
+  it('TAP "not ok" line whose test name contains "0 tests" is accepted as valid RED', () => {
+    // Cursor Bugbot (PR #550): the legacy `0 tests` regex `\b0\s+tests?\b`
+    // matched anywhere on a line and false-positived on legitimate node:test
+    // `not ok` lines whose test name contains the phrase "0 tests".
+    // The regex must only match the node:test TAP summary line shape
+    // (`# tests 0` anchored at column 0).
+    runCli('init GH-532-NOK', homeDir);
+    const tap =
+      'TAP version 13\n' +
+      '# Subtest: returns 0 tests when input is empty\n' +
+      'not ok 1 - returns 0 tests when input is empty\n' +
+      '  ---\n' +
+      '  duration_ms: 0.8\n' +
+      '  failureType: testCodeFailure\n' +
+      '  error: |-\n' +
+      '    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n' +
+      '    + actual - expected\n' +
+      '    + 0\n' +
+      '    - 1\n' +
+      '  ...\n' +
+      '1..1\n' +
+      '# tests 1\n' +
+      '# pass 0\n' +
+      '# fail 1\n';
+    const script = createOutputScript(scriptDir, 'not-ok-zero-tests', {
+      stdout: tap,
+      exitCode: 1,
+    });
+    const { exitCode, stdout, stderr } = runCli(
+      `record-red GH-532-NOK --cmd "${script}"`,
+      homeDir,
+      repo
+    );
+    assert.strictEqual(
+      exitCode,
+      0,
+      `"not ok" line containing "0 tests" must be accepted, got stderr: ${stderr}`
+    );
+    const result = JSON.parse(stdout);
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.phase, 'red');
+    const state = readState(homeDir, 'GH-532-NOK');
+    const cycle = state.cycles.find((c) => c.cycle === state.currentCycle);
+    assert.ok(cycle && cycle.red, 'record.red must be persisted for real RED');
   });
 
   it('Runtime ReferenceError inside node:test YAML error block is accepted', () => {

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-load-failure.integration.test.js
@@ -661,4 +661,90 @@ describe('tdd-phase-state record-red — load-failure rejection (GH-532)', () =>
     );
     assert.ok(/ReferenceError/.test(stderr), `expected ReferenceError diagnostic, got: ${stderr}`);
   });
+
+  it('Recovery round-trip: reject load failure, then fix and re-record successfully (Finding G)', () => {
+    // The documented recovery path is: rejection -> agent fixes the test
+    // file -> re-run record-red succeeds and persists evidence. Prove the
+    // system is not permanently wedged by exercising the full round-trip
+    // against the same ticket+task+cycle.
+    runCli('init GH-532-RECOV', homeDir);
+
+    // 1. First attempt: ReferenceError at load → rejected, no evidence persisted.
+    const brokenScript = createOutputScript(scriptDir, 'broken', {
+      stderr: 'ReferenceError: setupStagedHook is not defined\n',
+      exitCode: 1,
+    });
+    const rejection = runCli(`record-red GH-532-RECOV --cmd "${brokenScript}"`, homeDir, repo);
+    assert.strictEqual(rejection.exitCode, 1, 'first attempt must be rejected');
+    assert.match(rejection.stderr, /ReferenceError/);
+    const afterReject = readState(homeDir, 'GH-532-RECOV');
+    assert.strictEqual(afterReject.currentPhase, 'red');
+    const rejCycle = afterReject.cycles.find((c) => c.cycle === afterReject.currentCycle);
+    assert.ok(!rejCycle || !rejCycle.red, 'no record.red persisted on rejection');
+
+    // 2. Second attempt: agent "fixed" the test → real assertion failure with
+    //    proper TAP envelope → accepted; record.red persists into the same
+    //    cycle, currentCycle unchanged.
+    const fixedScript = createOutputScript(scriptDir, 'fixed', {
+      stdout:
+        'TAP version 13\n' +
+        '# Subtest: feature works\n' +
+        'not ok 1 - feature works\n' +
+        '  ---\n' +
+        '  duration_ms: 1\n' +
+        '  failureType: testCodeFailure\n' +
+        '  error: |-\n' +
+        '    AssertionError [ERR_ASSERTION]: Expected 1 === 2\n' +
+        '  ...\n' +
+        '1..1\n' +
+        '# tests 1\n' +
+        '# pass 0\n' +
+        '# fail 1\n',
+      exitCode: 1,
+    });
+    const acceptance = runCli(`record-red GH-532-RECOV --cmd "${fixedScript}"`, homeDir, repo);
+    assert.strictEqual(
+      acceptance.exitCode,
+      0,
+      `recovery must be accepted, got stderr: ${acceptance.stderr}`
+    );
+    const result = JSON.parse(acceptance.stdout);
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.phase, 'red');
+
+    const afterAccept = readState(homeDir, 'GH-532-RECOV');
+    assert.strictEqual(
+      afterAccept.currentCycle,
+      afterReject.currentCycle,
+      'cycle must not advance during recovery'
+    );
+    const accCycle = afterAccept.cycles.find((c) => c.cycle === afterAccept.currentCycle);
+    assert.ok(accCycle && accCycle.red, 'record.red must be persisted after recovery');
+    assert.strictEqual(accCycle.red.testExitCode, 1);
+
+    // 3. transition red->green is now unblocked (the gate sees real evidence).
+    const tx = runCli(`transition GH-532-RECOV green`, homeDir, repo);
+    assert.strictEqual(
+      tx.exitCode,
+      0,
+      `transition must succeed after recovery, got stderr: ${tx.stderr}`
+    );
+    const afterTx = readState(homeDir, 'GH-532-RECOV');
+    assert.strictEqual(afterTx.currentPhase, 'green', 'phase must advance to green after recovery');
+
+    // 4. Exactly one rejection audit row was appended (the broken attempt);
+    //    the accepted re-run does not add another.
+    const actions = JSON.parse(
+      fs.readFileSync(
+        path.join(homeDir, 'worktrees', 'tasks', 'GH-532-RECOV', '.work-actions.json'),
+        'utf8'
+      )
+    );
+    const rejections = actions.filter((a) => a.action === 'tdd-red-load-failure-rejected');
+    assert.strictEqual(
+      rejections.length,
+      1,
+      `expected exactly one rejection audit row across the round-trip, got ${rejections.length}`
+    );
+  });
 });

--- a/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
+++ b/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
@@ -24,17 +24,50 @@ const RED_LOAD_FAILURE_PATTERNS = Object.freeze([
 ]);
 
 /**
+ * Returns true if `line` closes a `details:` block opened at `baseIndent`.
+ * A details block ends on a blank line, on the YAML doc-end `...`, or when
+ * indentation returns to the heading column or earlier.
+ *
+ * @param {string} line raw output line
+ * @param {number} baseIndent column of the opening `details:` heading
+ * @returns {boolean}
+ */
+function closesDetailsBlock(line, baseIndent) {
+  const trimmed = line.trim();
+  if (trimmed === '' || trimmed === '...') return true;
+  const indentMatch = line.match(/^(\s*)\S/);
+  const indent = indentMatch ? indentMatch[1].length : -1;
+  return indent <= baseIndent;
+}
+
+/**
+ * Scan a single line against every RED-load-failure pattern.
+ *
+ * @param {string} line raw output line
+ * @returns {{ matched: boolean, signature: string|null }}
+ */
+function matchLoadFailureSignature(line) {
+  for (const pattern of RED_LOAD_FAILURE_PATTERNS) {
+    if (pattern.regex.test(line)) {
+      return { matched: true, signature: pattern.name };
+    }
+  }
+  return { matched: false, signature: null };
+}
+
+/**
  * Scan combined stdout+stderr line-by-line for a RED-load-failure signature.
  *
  * Lines ignored:
  *   - stack frames matching /^\s+at\s/ — a `ReferenceError:` thrown inside
  *     a passing test's `assert.throws` reports the type name on a stack
  *     frame; we don't want that to count as a top-level load failure.
- *   - lines inside a contiguous `details:` block — node:test prints the
- *     expected/actual values of a failing `assert.throws` under a
- *     `details:` heading; the block ends when indentation returns to the
- *     heading column or earlier, on the YAML doc-end `...`, or on a blank
- *     line.
+ *   - lines inside any node:test YAML diagnostic block, bracketed by `---`
+ *     (open) and `...` (close). A failing test's `error: |-` payload may
+ *     literally include `ReferenceError:` (when the test body raised one);
+ *     that is a real RED, not a load failure.
+ *   - lines inside a contiguous `details:` block — kept as a defensive
+ *     fallback for runners that emit `details:` outside the YAML envelope.
  *
  * Fail-closed: if the scan throws unexpectedly, return a match with
  * signature `'scan-error'` so the recorder rejects rather than silently
@@ -49,15 +82,22 @@ function detectRedLoadFailure(output) {
       return { matched: false, signature: null };
     }
     const lines = output.split(/\r?\n/);
+    let inYamlBlock = false;
     let inDetailsBlock = false;
     let detailsBaseIndent = -1;
     for (const line of lines) {
       if (/^\s+at\s/.test(line)) continue;
       const trimmed = line.trim();
+      if (inYamlBlock) {
+        if (trimmed === '...') inYamlBlock = false;
+        continue;
+      }
+      if (trimmed === '---') {
+        inYamlBlock = true;
+        continue;
+      }
       if (inDetailsBlock) {
-        const indentMatch = line.match(/^(\s*)\S/);
-        const indent = indentMatch ? indentMatch[1].length : -1;
-        if (trimmed === '' || trimmed === '...' || indent <= detailsBaseIndent) {
+        if (closesDetailsBlock(line, detailsBaseIndent)) {
           inDetailsBlock = false;
           detailsBaseIndent = -1;
         } else {
@@ -66,15 +106,11 @@ function detectRedLoadFailure(output) {
       }
       if (/^\s*details:\s*$/.test(line)) {
         inDetailsBlock = true;
-        const headIndent = line.match(/^(\s*)/)[1].length;
-        detailsBaseIndent = headIndent;
+        detailsBaseIndent = line.match(/^(\s*)/)[1].length;
         continue;
       }
-      for (const pattern of RED_LOAD_FAILURE_PATTERNS) {
-        if (pattern.regex.test(line)) {
-          return { matched: true, signature: pattern.name };
-        }
-      }
+      const hit = matchLoadFailureSignature(line);
+      if (hit.matched) return hit;
     }
     return { matched: false, signature: null };
   } catch {

--- a/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
+++ b/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
@@ -79,34 +79,39 @@ function matchLoadFailureSignature(line) {
 }
 
 /**
- * Scan combined stdout+stderr line-by-line for a RED-load-failure signature.
+ * State-machine predicate: should this line be skipped by the scanner?
  *
- * Lines ignored:
+ * Lines skipped:
  *   - stack frames matching /^\s+at\s/ — a `ReferenceError:` thrown inside
  *     a passing test's `assert.throws` reports the type name on a stack
  *     frame; we don't want that to count as a top-level load failure.
- *   - lines inside any node:test YAML diagnostic block, bracketed by `---`
- *     (open) and `...` (close). A failing test's `error: |-` payload may
- *     literally include `ReferenceError:` (when the test body raised one);
- *     that is a real RED, not a load failure.
+ *   - lines inside an indented node:test YAML diagnostic block, bracketed
+ *     by an indented `---` (open) and an indented `...` (close). A failing
+ *     test's `error: |-` payload may literally include `ReferenceError:`
+ *     (when the test body raised one); that is a real RED, not a load
+ *     failure. Top-level (unindented) `---` / `...` lines do NOT open or
+ *     close YAML — they're just dividers in test output (Bug 9).
  *   - lines inside a contiguous `details:` block — kept as a defensive
  *     fallback for runners that emit `details:` outside the YAML envelope.
  *
- * Fail-closed: if the scan throws unexpectedly, return a match with
- * signature `'scan-error'` so the recorder rejects rather than silently
- * accepting the RED.
+ * Mutates `state` in place.
  *
- * @param {string} output combined stdout + '\n' + stderr
- * @returns {{ matched: boolean, signature: string|null }}
+ * @param {string} line raw output line
+ * @param {{ inYamlBlock: boolean, inDetailsBlock: boolean, detailsBaseIndent: number }} state
+ * @returns {boolean} true if the line should be skipped
  */
 function shouldSkipLine(line, state) {
   if (/^\s+at\s/.test(line)) return true;
-  const trimmed = line.trim();
+  // TAP YAML envelopes are ALWAYS indented under the preceding `not ok` line.
+  // Require leading whitespace for the `---` opener and the `...` closer so a
+  // top-level, unindented `---` in test output (a divider, a meta-test
+  // fixture) does NOT silently swallow a real load-failure signature that
+  // follows it (Bug 9).
   if (state.inYamlBlock) {
-    if (trimmed === '...') state.inYamlBlock = false;
+    if (/^\s+\.\.\.\s*$/.test(line)) state.inYamlBlock = false;
     return true;
   }
-  if (trimmed === '---') {
+  if (/^\s+---\s*$/.test(line)) {
     state.inYamlBlock = true;
     return true;
   }
@@ -127,48 +132,73 @@ function shouldSkipLine(line, state) {
   return false;
 }
 
-function detectRedLoadFailure(output) {
-  try {
-    if (typeof output !== 'string' || output.length === 0) {
-      return { matched: false, signature: null };
-    }
-    const state = { inYamlBlock: false, inDetailsBlock: false, detailsBaseIndent: -1 };
-    for (const line of output.split(/\r?\n/)) {
-      if (shouldSkipLine(line, state)) continue;
-      const hit = matchLoadFailureSignature(line);
-      if (hit.matched) return hit;
-    }
-    return { matched: false, signature: null };
-  } catch {
-    return { matched: true, signature: 'scan-error' };
+/**
+ * Scan a single string (stdout OR stderr — never the concatenation) for a
+ * load-failure signature. Returns the matched line alongside the signature
+ * so the audit row's `meta.snippet` can quote exactly the line the detector
+ * matched, not a heuristic re-scan that may disagree (Bug 6).
+ *
+ * The scan is total over `string` (string split + regex test + integer
+ * indexes don't throw), so there is no try/catch fail-closed branch — a
+ * defensive catch here would be unreachable and pollute the audit row's
+ * `signature` field with a `'scan-error'` value no upstream consumer
+ * matches against (Bug 8).
+ *
+ * @param {string} stream a single stream's contents
+ * @returns {{ matched: boolean, signature: string|null, line: string|null }}
+ */
+function scanStream(stream) {
+  if (typeof stream !== 'string' || stream.length === 0) {
+    return { matched: false, signature: null, line: null };
   }
+  const state = { inYamlBlock: false, inDetailsBlock: false, detailsBaseIndent: -1 };
+  for (const line of stream.split(/\r?\n/)) {
+    if (shouldSkipLine(line, state)) continue;
+    const hit = matchLoadFailureSignature(line);
+    if (hit.matched) {
+      return { matched: true, signature: hit.signature, line };
+    }
+  }
+  return { matched: false, signature: null, line: null };
 }
 
 /**
- * Extract a short (~200 char) snippet of the matched line(s) from the
- * combined runner output for audit-row `meta.snippet`.
+ * Detect a RED-load failure across stdout and stderr. Each stream is scanned
+ * INDEPENDENTLY so an unclosed YAML envelope at the end of a truncated stdout
+ * cannot leak `inYamlBlock=true` state across the seam and silently swallow
+ * a real load-failure signature on stderr (Bug 7).
  *
- * @param {string} output combined stdout+stderr
- * @param {string} signatureName one of RED_LOAD_FAILURE_PATTERNS[].name
+ * Accepts either:
+ *   - a single string (legacy callers): treated as stdout.
+ *   - an object `{ stdout, stderr }`: scanned independently; stdout wins ties.
+ *
+ * @param {string | { stdout?: string, stderr?: string }} output
+ * @returns {{ matched: boolean, signature: string|null, line: string|null }}
+ */
+function detectRedLoadFailure(output) {
+  const streams =
+    typeof output === 'string' ? [output] : [output && output.stdout, output && output.stderr];
+  for (const stream of streams) {
+    const hit = scanStream(stream);
+    if (hit.matched) return hit;
+  }
+  return { matched: false, signature: null, line: null };
+}
+
+/**
+ * Trim and cap a detector-matched line for use as the audit row's
+ * `meta.snippet`. Callers MUST pass the line returned by
+ * `detectRedLoadFailure(...).line` so the snippet quotes exactly what the
+ * detector matched — not a second independent scan that may disagree on
+ * which line triggered (Bug 6).
+ *
+ * @param {string|null|undefined} matchedLine the `.line` field from detectRedLoadFailure
  * @returns {string}
  */
-function extractLoadFailureSnippet(output, signatureName) {
+function extractLoadFailureSnippet(matchedLine) {
   const MAX = 200;
-  try {
-    if (typeof output !== 'string' || output.length === 0) return '';
-    const pattern = RED_LOAD_FAILURE_PATTERNS.find((p) => p.name === signatureName);
-    if (!pattern) return output.slice(0, MAX);
-    const lines = output.split(/\r?\n/);
-    for (const line of lines) {
-      if (/^\s+at\s/.test(line)) continue;
-      if (pattern.regex.test(line)) {
-        return line.trim().slice(0, MAX);
-      }
-    }
-    return output.slice(0, MAX);
-  } catch {
-    return '';
-  }
+  if (typeof matchedLine !== 'string' || matchedLine.length === 0) return '';
+  return matchedLine.trim().slice(0, MAX);
 }
 
 module.exports = {

--- a/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
+++ b/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
@@ -1,0 +1,116 @@
+/**
+ * red-load-failure.js
+ *
+ * Shared heuristic for detecting RED-phase load failures: test runs whose
+ * non-zero exit reflects a load-time error (ReferenceError / SyntaxError /
+ * missing module) or a runner that executed zero tests, rather than a real
+ * assertion failure. Accepting such runs as RED wedges the subsequent GREEN
+ * because the same crash repeats regardless of source edits (see GH-508
+ * Task 6, fixed by GH-532).
+ *
+ * Exported so `tdd-phase-state.js record-red` and future consumers
+ * (e.g. `enforce-tdd-on-stop.js`) share the exact patterns and scan
+ * semantics without copy-paste drift.
+ */
+
+const RED_LOAD_FAILURE_PATTERNS = Object.freeze([
+  Object.freeze({ name: 'ReferenceError', regex: /\bReferenceError:/ }),
+  Object.freeze({ name: 'SyntaxError', regex: /\bSyntaxError:/ }),
+  Object.freeze({
+    name: 'Cannot find module',
+    regex: /Cannot find module|MODULE_NOT_FOUND/,
+  }),
+  Object.freeze({ name: '0 tests', regex: /#\s*tests\s+0\b|\b0\s+tests?\b/ }),
+]);
+
+/**
+ * Scan combined stdout+stderr line-by-line for a RED-load-failure signature.
+ *
+ * Lines ignored:
+ *   - stack frames matching /^\s+at\s/ — a `ReferenceError:` thrown inside
+ *     a passing test's `assert.throws` reports the type name on a stack
+ *     frame; we don't want that to count as a top-level load failure.
+ *   - lines inside a contiguous `details:` block — node:test prints the
+ *     expected/actual values of a failing `assert.throws` under a
+ *     `details:` heading; the block ends when indentation returns to the
+ *     heading column or earlier, on the YAML doc-end `...`, or on a blank
+ *     line.
+ *
+ * Fail-closed: if the scan throws unexpectedly, return a match with
+ * signature `'scan-error'` so the recorder rejects rather than silently
+ * accepting the RED.
+ *
+ * @param {string} output combined stdout + '\n' + stderr
+ * @returns {{ matched: boolean, signature: string|null }}
+ */
+function detectRedLoadFailure(output) {
+  try {
+    if (typeof output !== 'string' || output.length === 0) {
+      return { matched: false, signature: null };
+    }
+    const lines = output.split(/\r?\n/);
+    let inDetailsBlock = false;
+    let detailsBaseIndent = -1;
+    for (const line of lines) {
+      if (/^\s+at\s/.test(line)) continue;
+      const trimmed = line.trim();
+      if (inDetailsBlock) {
+        const indentMatch = line.match(/^(\s*)\S/);
+        const indent = indentMatch ? indentMatch[1].length : -1;
+        if (trimmed === '' || trimmed === '...' || indent <= detailsBaseIndent) {
+          inDetailsBlock = false;
+          detailsBaseIndent = -1;
+        } else {
+          continue;
+        }
+      }
+      if (/^\s*details:\s*$/.test(line)) {
+        inDetailsBlock = true;
+        const headIndent = line.match(/^(\s*)/)[1].length;
+        detailsBaseIndent = headIndent;
+        continue;
+      }
+      for (const pattern of RED_LOAD_FAILURE_PATTERNS) {
+        if (pattern.regex.test(line)) {
+          return { matched: true, signature: pattern.name };
+        }
+      }
+    }
+    return { matched: false, signature: null };
+  } catch {
+    return { matched: true, signature: 'scan-error' };
+  }
+}
+
+/**
+ * Extract a short (~200 char) snippet of the matched line(s) from the
+ * combined runner output for audit-row `meta.snippet`.
+ *
+ * @param {string} output combined stdout+stderr
+ * @param {string} signatureName one of RED_LOAD_FAILURE_PATTERNS[].name
+ * @returns {string}
+ */
+function extractLoadFailureSnippet(output, signatureName) {
+  const MAX = 200;
+  try {
+    if (typeof output !== 'string' || output.length === 0) return '';
+    const pattern = RED_LOAD_FAILURE_PATTERNS.find((p) => p.name === signatureName);
+    if (!pattern) return output.slice(0, MAX);
+    const lines = output.split(/\r?\n/);
+    for (const line of lines) {
+      if (/^\s+at\s/.test(line)) continue;
+      if (pattern.regex.test(line)) {
+        return line.trim().slice(0, MAX);
+      }
+    }
+    return output.slice(0, MAX);
+  } catch {
+    return '';
+  }
+}
+
+module.exports = {
+  RED_LOAD_FAILURE_PATTERNS,
+  detectRedLoadFailure,
+  extractLoadFailureSnippet,
+};

--- a/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
+++ b/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
@@ -35,16 +35,37 @@
 const RED_LOAD_FAILURE_PATTERNS = Object.freeze([
   Object.freeze({ name: 'ReferenceError', regex: /\bReferenceError:/ }),
   Object.freeze({ name: 'SyntaxError', regex: /\bSyntaxError:/ }),
-  Object.freeze({
-    name: 'Cannot find module',
-    regex: /Cannot find module|MODULE_NOT_FOUND/,
-  }),
+  // Split into two named patterns so the audit row's `meta.signature` always
+  // names a substring that actually appears in `meta.snippet`. The shared
+  // diagnostic message in `formatRedLoadFailureDiagnostic` covers both.
+  Object.freeze({ name: 'Cannot find module', regex: /Cannot find module/ }),
+  Object.freeze({ name: 'MODULE_NOT_FOUND', regex: /MODULE_NOT_FOUND/ }),
   // Match only the node:test TAP summary line: `# tests 0` anchored at the
   // start of a line. A loose `\b0\s+tests?\b` alternative would false-positive
   // on legitimate `not ok` lines whose test name contains the phrase
   // "0 tests" (e.g. `not ok 1 - returns 0 tests when input is empty`).
   Object.freeze({ name: '0 tests', regex: /^#\s*tests\s+0\b/ }),
 ]);
+
+/**
+ * Top-level TAP lines that embed a user-supplied test name. A failing test
+ * named `throws ReferenceError: when given bad arg` emits one of these
+ * lines at column 0 — that is NOT a load failure, it is a normal
+ * assertion failure. The detector must skip these lines before signature
+ * matching so symmetric coverage with the `# tests 0` anchor is achieved
+ * for the other patterns.
+ *
+ * Only the *name-embedding* TAP lines are skipped:
+ *   - `not ok N - <name>`
+ *   - `ok N - <name>`
+ *   - `# Subtest: <name>`
+ *
+ * The `# tests N`, `# pass N`, `# fail N`, `# suites N`, `# skipped N`,
+ * `# todo N`, `# duration_ms ...` summary lines are NOT skipped — they
+ * carry fixed labels from node:test (never user names) and the `0 tests`
+ * pattern relies on `# tests 0` flowing through.
+ */
+const TAP_CONTROL_LINE_RE = /^(?:not ok\b|ok\b|# Subtest\b)/;
 
 /**
  * Returns true if `line` closes a `details:` block opened at `baseIndent`.
@@ -102,6 +123,11 @@ function matchLoadFailureSignature(line) {
  */
 function shouldSkipLine(line, state) {
   if (/^\s+at\s/.test(line)) return true;
+  // Skip TAP control lines so a user-supplied test name embedding
+  // `ReferenceError:` / `SyntaxError:` / `MODULE_NOT_FOUND` does not
+  // trigger a false-positive load-failure match. Symmetric with the
+  // anchored `^#\s*tests\s+0` guard for the `0 tests` signature.
+  if (TAP_CONTROL_LINE_RE.test(line)) return true;
   // TAP YAML envelopes are ALWAYS indented under the preceding `not ok` line.
   // Require leading whitespace for the `---` opener and the `...` closer so a
   // top-level, unindented `---` in test output (a divider, a meta-test

--- a/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
+++ b/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
@@ -11,6 +11,25 @@
  * Exported so `tdd-phase-state.js record-red` and future consumers
  * (e.g. `enforce-tdd-on-stop.js`) share the exact patterns and scan
  * semantics without copy-paste drift.
+ *
+ * RUNNER ASSUMPTION — node:test ONLY:
+ *   The detector assumes node:test TAP output shape, where failing-test
+ *   diagnostics are wrapped in `---` / `...` YAML envelopes. The YAML guard
+ *   in `shouldSkipLine` is what prevents a real failing test whose body
+ *   throws `ReferenceError` (emitted by the runner under `error: |-`) from
+ *   being misclassified as a load failure.
+ *
+ *   jest / vitest / mocha do NOT emit those envelopes. A real failing test
+ *   under those runners that throws `ReferenceError:` / `SyntaxError:`
+ *   would be falsely rejected here. Today the repo is node:test-only (see
+ *   `plugins/work/CLAUDE.md` → "Node built-in test runner"), so this is
+ *   acceptable.
+ *
+ *   If support for jest / vitest / mocha is ever added, the heuristic must
+ *   be revised to require the load-failure signature to appear BEFORE the
+ *   first `TAP version` line (i.e. during test-file load, before the
+ *   runner has started reporting). Until then, do not reuse this module
+ *   against output from other runners.
  */
 
 const RED_LOAD_FAILURE_PATTERNS = Object.freeze([
@@ -20,7 +39,11 @@ const RED_LOAD_FAILURE_PATTERNS = Object.freeze([
     name: 'Cannot find module',
     regex: /Cannot find module|MODULE_NOT_FOUND/,
   }),
-  Object.freeze({ name: '0 tests', regex: /#\s*tests\s+0\b|\b0\s+tests?\b/ }),
+  // Match only the node:test TAP summary line: `# tests 0` anchored at the
+  // start of a line. A loose `\b0\s+tests?\b` alternative would false-positive
+  // on legitimate `not ok` lines whose test name contains the phrase
+  // "0 tests" (e.g. `not ok 1 - returns 0 tests when input is empty`).
+  Object.freeze({ name: '0 tests', regex: /^#\s*tests\s+0\b/ }),
 ]);
 
 /**

--- a/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
+++ b/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
@@ -8,9 +8,10 @@
  * because the same crash repeats regardless of source edits (see GH-508
  * Task 6, fixed by GH-532).
  *
- * Exported so `tdd-phase-state.js record-red` and future consumers
- * (e.g. `enforce-tdd-on-stop.js`) share the exact patterns and scan
- * semantics without copy-paste drift.
+ * Extracted as a standalone module in anticipation of reuse by
+ * `enforce-tdd-on-stop.js` and similar future consumers, so the patterns
+ * and scan semantics are not copy-pasted when that work lands. Today the
+ * only importer is `tdd-phase-state.js record-red`.
  *
  * RUNNER ASSUMPTION — node:test ONLY:
  *   The detector assumes node:test TAP output shape, where failing-test

--- a/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
+++ b/plugins/work/scripts/workflows/work-implement/lib/red-load-failure.js
@@ -76,39 +76,42 @@ function matchLoadFailureSignature(line) {
  * @param {string} output combined stdout + '\n' + stderr
  * @returns {{ matched: boolean, signature: string|null }}
  */
+function shouldSkipLine(line, state) {
+  if (/^\s+at\s/.test(line)) return true;
+  const trimmed = line.trim();
+  if (state.inYamlBlock) {
+    if (trimmed === '...') state.inYamlBlock = false;
+    return true;
+  }
+  if (trimmed === '---') {
+    state.inYamlBlock = true;
+    return true;
+  }
+  if (state.inDetailsBlock) {
+    if (closesDetailsBlock(line, state.detailsBaseIndent)) {
+      state.inDetailsBlock = false;
+      state.detailsBaseIndent = -1;
+      // fall through — current line is past the block
+    } else {
+      return true;
+    }
+  }
+  if (/^\s*details:\s*$/.test(line)) {
+    state.inDetailsBlock = true;
+    state.detailsBaseIndent = line.match(/^(\s*)/)[1].length;
+    return true;
+  }
+  return false;
+}
+
 function detectRedLoadFailure(output) {
   try {
     if (typeof output !== 'string' || output.length === 0) {
       return { matched: false, signature: null };
     }
-    const lines = output.split(/\r?\n/);
-    let inYamlBlock = false;
-    let inDetailsBlock = false;
-    let detailsBaseIndent = -1;
-    for (const line of lines) {
-      if (/^\s+at\s/.test(line)) continue;
-      const trimmed = line.trim();
-      if (inYamlBlock) {
-        if (trimmed === '...') inYamlBlock = false;
-        continue;
-      }
-      if (trimmed === '---') {
-        inYamlBlock = true;
-        continue;
-      }
-      if (inDetailsBlock) {
-        if (closesDetailsBlock(line, detailsBaseIndent)) {
-          inDetailsBlock = false;
-          detailsBaseIndent = -1;
-        } else {
-          continue;
-        }
-      }
-      if (/^\s*details:\s*$/.test(line)) {
-        inDetailsBlock = true;
-        detailsBaseIndent = line.match(/^(\s*)/)[1].length;
-        continue;
-      }
+    const state = { inYamlBlock: false, inDetailsBlock: false, detailsBaseIndent: -1 };
+    for (const line of output.split(/\r?\n/)) {
+      if (shouldSkipLine(line, state)) continue;
       const hit = matchLoadFailureSignature(line);
       if (hit.matched) return hit;
     }

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -354,6 +354,177 @@ function runTestCommandWithOutput(cmd) {
 }
 
 /**
+ * GH-532 — RED load-failure signatures. When a test runner exits non-zero
+ * because the test FILE itself failed to load (ReferenceError / SyntaxError
+ * / Cannot find module) or reported zero tests, the non-zero exit is not
+ * evidence of a real failing assertion. `cmdRecordRed` MUST reject these
+ * so agents fix the test file rather than persisting fake-RED evidence.
+ *
+ * Frozen so callers (and a future `enforce-tdd-on-stop.js` consumer) share
+ * the exact heuristic.
+ */
+const RED_LOAD_FAILURE_PATTERNS = Object.freeze([
+  Object.freeze({ name: 'ReferenceError', regex: /\bReferenceError:/ }),
+  Object.freeze({ name: 'SyntaxError', regex: /\bSyntaxError:/ }),
+  Object.freeze({
+    name: 'Cannot find module',
+    regex: /Cannot find module|MODULE_NOT_FOUND/,
+  }),
+  Object.freeze({ name: '0 tests', regex: /#\s*tests\s+0\b|\b0\s+tests?\b/ }),
+]);
+
+/**
+ * Scan combined stdout+stderr line-by-line for a RED-load-failure signature.
+ *
+ * Lines ignored:
+ *   - stack frames matching /^\s+at\s/ — a `ReferenceError:` thrown inside
+ *     a passing test's `assert.throws` reports the type name on a stack
+ *     frame; we don't want that to count as a top-level load failure.
+ *   - lines inside a contiguous `details:` block — node:test prints the
+ *     expected/actual values of a failing `assert.throws` under a
+ *     `details:` heading; the block ends at the next non-indented line
+ *     (typically the YAML terminator `...` or a blank line).
+ *
+ * Fail-closed: if the scan throws unexpectedly, return a match with
+ * signature `'scan-error'` so the recorder rejects rather than silently
+ * accepting the RED.
+ *
+ * @param {string} output combined stdout + '\n' + stderr
+ * @returns {{ matched: boolean, signature: string|null }}
+ */
+function detectRedLoadFailure(output) {
+  try {
+    if (typeof output !== 'string' || output.length === 0) {
+      return { matched: false, signature: null };
+    }
+    const lines = output.split(/\r?\n/);
+    let inDetailsBlock = false;
+    let detailsBaseIndent = -1;
+    for (const line of lines) {
+      // Stack frames — `    at Foo (file:1:2)` — never match.
+      if (/^\s+at\s/.test(line)) continue;
+      // Track contiguous `details:` block (R5 / AC9). The block opens on a
+      // line whose trimmed content starts with `details:` and closes when
+      // we hit a line with less indentation than the first content line
+      // following the heading, OR a YAML doc-end `...`, OR a blank line.
+      const trimmed = line.trim();
+      if (inDetailsBlock) {
+        const indentMatch = line.match(/^(\s*)\S/);
+        const indent = indentMatch ? indentMatch[1].length : -1;
+        if (trimmed === '' || trimmed === '...' || indent <= detailsBaseIndent) {
+          inDetailsBlock = false;
+          detailsBaseIndent = -1;
+          // fall through — this line is not inside the block
+        } else {
+          continue;
+        }
+      }
+      if (/^\s*details:\s*$/.test(line)) {
+        inDetailsBlock = true;
+        const headIndent = line.match(/^(\s*)/)[1].length;
+        detailsBaseIndent = headIndent;
+        continue;
+      }
+      for (const pattern of RED_LOAD_FAILURE_PATTERNS) {
+        if (pattern.regex.test(line)) {
+          return { matched: true, signature: pattern.name };
+        }
+      }
+    }
+    return { matched: false, signature: null };
+  } catch {
+    // Fail-closed (R10): an unexpected throw must NOT result in silent
+    // acceptance of the RED.
+    return { matched: true, signature: 'scan-error' };
+  }
+}
+
+/**
+ * Extract a short (~200 char) snippet of the matched line(s) from the
+ * combined runner output for audit-row `meta.snippet`. Returns the first
+ * non-stack-frame, non-`details:`-block line that matches the named
+ * signature's pattern, falling back to a head excerpt of the output.
+ *
+ * @param {string} output combined stdout+stderr
+ * @param {string} signatureName one of RED_LOAD_FAILURE_PATTERNS[].name
+ * @returns {string}
+ */
+function extractLoadFailureSnippet(output, signatureName) {
+  const MAX = 200;
+  try {
+    if (typeof output !== 'string' || output.length === 0) return '';
+    const pattern = RED_LOAD_FAILURE_PATTERNS.find((p) => p.name === signatureName);
+    if (!pattern) return output.slice(0, MAX);
+    const lines = output.split(/\r?\n/);
+    for (const line of lines) {
+      if (/^\s+at\s/.test(line)) continue;
+      if (pattern.regex.test(line)) {
+        return line.trim().slice(0, MAX);
+      }
+    }
+    return output.slice(0, MAX);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Build the rejection diagnostic for a RED load-failure. Multi-sentence,
+ * names the matched signature, explains the test file is structurally
+ * broken, instructs the agent to fix the test file and re-run record-red.
+ * MUST NOT contain a `BYPASS:` line — this is a structural defect, not a
+ * justified bypass.
+ */
+function formatRedLoadFailureDiagnostic(signature) {
+  return (
+    `Rejected RED: detected ${signature} in test runner output. ` +
+    'The test file is structurally broken (load-time error or zero tests collected), ' +
+    'not a behavior gap. Fix the test file and re-run ' +
+    '`tdd-phase-state.js record-red`.'
+  );
+}
+
+/**
+ * GH-532 Task 2 / R7 / AC10 — append a structured audit row recording the
+ * RED load-failure rejection, then call `errorExit` with the diagnostic.
+ * Audit append is best-effort: wrapped in try/catch so a write failure
+ * does NOT swallow the rejection (errorExit always fires).
+ *
+ * @param {{
+ *   ticketId: string,
+ *   cycle: number,
+ *   testCommand: string,
+ *   signature: string,
+ *   snippet: string,
+ *   taskNum: number | null | undefined,
+ * }} args
+ * @returns {never}
+ */
+function rejectRedLoadFailure(args) {
+  try {
+    const { appendEnforcementAudit } = require('../work/lib/work-actions');
+    appendEnforcementAudit(args.ticketId, {
+      origin: 'ai-subtask',
+      task: args.taskNum || null,
+      phase: 'red',
+      action: 'tdd-red-load-failure-rejected',
+      allow: false,
+      reason: args.signature,
+      outputPath: null,
+      meta: {
+        cycle: args.cycle,
+        testCommand: args.testCommand,
+        signature: args.signature,
+        snippet: args.snippet,
+      },
+    });
+  } catch {
+    /* fail-open on audit write — rejection still fires below */
+  }
+  errorExit(formatRedLoadFailureDiagnostic(args.signature));
+}
+
+/**
  * Inspect a test runner's stdout/stderr for a summary line indicating
  * pass/skip counts. Returns { passed, skipped, parsed } where `parsed` is
  * true only if we found a recognizable summary. Be lenient on format —
@@ -560,9 +731,25 @@ function cmdRecordRed(ticketId, args) {
   }
 
   // Run tests — they must FAIL
-  const exitCode = runTestCommand(cmd);
+  const { exitCode, stdout, stderr } = runTestCommandWithOutput(cmd);
   if (exitCode === 0) {
     errorExit('Tests must FAIL in RED phase. Tests passed (exit 0).');
+  }
+
+  // GH-532: reject fake-RED caused by load failures (ReferenceError /
+  // SyntaxError / Cannot find module / 0 tests reported). These exit
+  // non-zero but the test file never actually ran an assertion.
+  const combinedOutput = (stdout || '') + '\n' + (stderr || '');
+  const loadFailure = detectRedLoadFailure(combinedOutput);
+  if (loadFailure.matched) {
+    rejectRedLoadFailure({
+      ticketId,
+      cycle: state.currentCycle,
+      testCommand: cmd,
+      signature: loadFailure.signature,
+      snippet: extractLoadFailureSnippet(combinedOutput, loadFailure.signature),
+      taskNum,
+    });
   }
 
   // Record evidence

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -355,10 +355,7 @@ function runTestCommandWithOutput(cmd) {
 
 // GH-532 — RED load-failure heuristic. Shared with future
 // `enforce-tdd-on-stop.js` consumer via `lib/red-load-failure.js`.
-const {
-  detectRedLoadFailure,
-  extractLoadFailureSnippet,
-} = require('./lib/red-load-failure');
+const { detectRedLoadFailure, extractLoadFailureSnippet } = require('./lib/red-load-failure');
 
 /**
  * Build the rejection diagnostic for a RED load-failure. Multi-sentence,
@@ -631,15 +628,17 @@ function cmdRecordRed(ticketId, args) {
   // GH-532: reject fake-RED caused by load failures (ReferenceError /
   // SyntaxError / Cannot find module / 0 tests reported). These exit
   // non-zero but the test file never actually ran an assertion.
-  const combinedOutput = (stdout || '') + '\n' + (stderr || '');
-  const loadFailure = detectRedLoadFailure(combinedOutput);
+  // Scan stdout and stderr independently — concatenating them can leak
+  // an unclosed YAML-envelope state across the seam when stdout is
+  // truncated (timeout / signal) and mask a real stderr load failure.
+  const loadFailure = detectRedLoadFailure({ stdout, stderr });
   if (loadFailure.matched) {
     rejectRedLoadFailure({
       ticketId,
       cycle: state.currentCycle,
       testCommand: cmd,
       signature: loadFailure.signature,
-      snippet: extractLoadFailureSnippet(combinedOutput, loadFailure.signature),
+      snippet: extractLoadFailureSnippet(loadFailure.line),
       taskNum,
     });
   }
@@ -680,8 +679,7 @@ function cmdRecordRed(ticketId, args) {
 function cmdRecordRedSynthesized(ticketId, args, cmd, taskNum, opts) {
   // Validate reason (mirrors cmdException). Empty/missing → BYPASS, no audit.
   const reasonIdx = args.indexOf('--reason');
-  const reason =
-    reasonIdx !== -1 && reasonIdx + 1 < args.length ? args[reasonIdx + 1] : undefined;
+  const reason = reasonIdx !== -1 && reasonIdx + 1 < args.length ? args[reasonIdx + 1] : undefined;
   if (!reason || !reason.trim()) {
     // Write a BYPASS: line to stderr so callers see the recovery hint. Do NOT
     // append an audit row — fail-closed: no justification ⇒ no record.

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -356,7 +356,6 @@ function runTestCommandWithOutput(cmd) {
 // GH-532 — RED load-failure heuristic. Shared with future
 // `enforce-tdd-on-stop.js` consumer via `lib/red-load-failure.js`.
 const {
-  RED_LOAD_FAILURE_PATTERNS,
   detectRedLoadFailure,
   extractLoadFailureSnippet,
 } = require('./lib/red-load-failure');

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -353,120 +353,13 @@ function runTestCommandWithOutput(cmd) {
   };
 }
 
-/**
- * GH-532 — RED load-failure signatures. When a test runner exits non-zero
- * because the test FILE itself failed to load (ReferenceError / SyntaxError
- * / Cannot find module) or reported zero tests, the non-zero exit is not
- * evidence of a real failing assertion. `cmdRecordRed` MUST reject these
- * so agents fix the test file rather than persisting fake-RED evidence.
- *
- * Frozen so callers (and a future `enforce-tdd-on-stop.js` consumer) share
- * the exact heuristic.
- */
-const RED_LOAD_FAILURE_PATTERNS = Object.freeze([
-  Object.freeze({ name: 'ReferenceError', regex: /\bReferenceError:/ }),
-  Object.freeze({ name: 'SyntaxError', regex: /\bSyntaxError:/ }),
-  Object.freeze({
-    name: 'Cannot find module',
-    regex: /Cannot find module|MODULE_NOT_FOUND/,
-  }),
-  Object.freeze({ name: '0 tests', regex: /#\s*tests\s+0\b|\b0\s+tests?\b/ }),
-]);
-
-/**
- * Scan combined stdout+stderr line-by-line for a RED-load-failure signature.
- *
- * Lines ignored:
- *   - stack frames matching /^\s+at\s/ — a `ReferenceError:` thrown inside
- *     a passing test's `assert.throws` reports the type name on a stack
- *     frame; we don't want that to count as a top-level load failure.
- *   - lines inside a contiguous `details:` block — node:test prints the
- *     expected/actual values of a failing `assert.throws` under a
- *     `details:` heading; the block ends at the next non-indented line
- *     (typically the YAML terminator `...` or a blank line).
- *
- * Fail-closed: if the scan throws unexpectedly, return a match with
- * signature `'scan-error'` so the recorder rejects rather than silently
- * accepting the RED.
- *
- * @param {string} output combined stdout + '\n' + stderr
- * @returns {{ matched: boolean, signature: string|null }}
- */
-function detectRedLoadFailure(output) {
-  try {
-    if (typeof output !== 'string' || output.length === 0) {
-      return { matched: false, signature: null };
-    }
-    const lines = output.split(/\r?\n/);
-    let inDetailsBlock = false;
-    let detailsBaseIndent = -1;
-    for (const line of lines) {
-      // Stack frames — `    at Foo (file:1:2)` — never match.
-      if (/^\s+at\s/.test(line)) continue;
-      // Track contiguous `details:` block (R5 / AC9). The block opens on a
-      // line whose trimmed content starts with `details:` and closes when
-      // we hit a line with less indentation than the first content line
-      // following the heading, OR a YAML doc-end `...`, OR a blank line.
-      const trimmed = line.trim();
-      if (inDetailsBlock) {
-        const indentMatch = line.match(/^(\s*)\S/);
-        const indent = indentMatch ? indentMatch[1].length : -1;
-        if (trimmed === '' || trimmed === '...' || indent <= detailsBaseIndent) {
-          inDetailsBlock = false;
-          detailsBaseIndent = -1;
-          // fall through — this line is not inside the block
-        } else {
-          continue;
-        }
-      }
-      if (/^\s*details:\s*$/.test(line)) {
-        inDetailsBlock = true;
-        const headIndent = line.match(/^(\s*)/)[1].length;
-        detailsBaseIndent = headIndent;
-        continue;
-      }
-      for (const pattern of RED_LOAD_FAILURE_PATTERNS) {
-        if (pattern.regex.test(line)) {
-          return { matched: true, signature: pattern.name };
-        }
-      }
-    }
-    return { matched: false, signature: null };
-  } catch {
-    // Fail-closed (R10): an unexpected throw must NOT result in silent
-    // acceptance of the RED.
-    return { matched: true, signature: 'scan-error' };
-  }
-}
-
-/**
- * Extract a short (~200 char) snippet of the matched line(s) from the
- * combined runner output for audit-row `meta.snippet`. Returns the first
- * non-stack-frame, non-`details:`-block line that matches the named
- * signature's pattern, falling back to a head excerpt of the output.
- *
- * @param {string} output combined stdout+stderr
- * @param {string} signatureName one of RED_LOAD_FAILURE_PATTERNS[].name
- * @returns {string}
- */
-function extractLoadFailureSnippet(output, signatureName) {
-  const MAX = 200;
-  try {
-    if (typeof output !== 'string' || output.length === 0) return '';
-    const pattern = RED_LOAD_FAILURE_PATTERNS.find((p) => p.name === signatureName);
-    if (!pattern) return output.slice(0, MAX);
-    const lines = output.split(/\r?\n/);
-    for (const line of lines) {
-      if (/^\s+at\s/.test(line)) continue;
-      if (pattern.regex.test(line)) {
-        return line.trim().slice(0, MAX);
-      }
-    }
-    return output.slice(0, MAX);
-  } catch {
-    return '';
-  }
-}
+// GH-532 — RED load-failure heuristic. Shared with future
+// `enforce-tdd-on-stop.js` consumer via `lib/red-load-failure.js`.
+const {
+  RED_LOAD_FAILURE_PATTERNS,
+  detectRedLoadFailure,
+  extractLoadFailureSnippet,
+} = require('./lib/red-load-failure');
 
 /**
  * Build the rejection diagnostic for a RED load-failure. Multi-sentence,

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -34,6 +34,9 @@ const { tddCanTransition, isTestFile } = require('./tdd-phase-registry');
 const { consumeToken, tokenPath } = require('../lib/scripts/write-report');
 const { normalizeAgentName } = require('../lib/agent-detection');
 const { resolveTasksBaseWithFallback } = require('../lib/ticket-validation');
+// GH-532 — RED load-failure heuristic. Shared with future
+// `enforce-tdd-on-stop.js` consumer via `lib/red-load-failure.js`.
+const { detectRedLoadFailure, extractLoadFailureSnippet } = require('./lib/red-load-failure');
 
 let config;
 try {
@@ -352,10 +355,6 @@ function runTestCommandWithOutput(cmd) {
     stderr: result.stderr || '',
   };
 }
-
-// GH-532 — RED load-failure heuristic. Shared with future
-// `enforce-tdd-on-stop.js` consumer via `lib/red-load-failure.js`.
-const { detectRedLoadFailure, extractLoadFailureSnippet } = require('./lib/red-load-failure');
 
 /**
  * Build the rejection diagnostic for a RED load-failure. Multi-sentence,

--- a/plugins/work/tests/e2e/tdd-phase-state-load-failure.spec.js
+++ b/plugins/work/tests/e2e/tdd-phase-state-load-failure.spec.js
@@ -43,15 +43,6 @@ const RECORDER_CLI = path.join(
   'work-implement',
   'tdd-phase-state.js'
 );
-const TASK_NEXT_CLI = path.join(
-  REPO_ROOT,
-  'plugins',
-  'work',
-  'scripts',
-  'workflows',
-  'work-implement',
-  'task-next.js'
-);
 
 /**
  * Build a fixture that mirrors the GH-508 Task 6 broken-test state:
@@ -124,14 +115,7 @@ function runRecorder(args, { homeDir, cwd }) {
 
 function readPhaseState(homeDir, ticketId, taskNum) {
   const segment = taskNum ? `task${taskNum}` : '';
-  const tddPath = path.join(
-    homeDir,
-    'worktrees',
-    'tasks',
-    ticketId,
-    segment,
-    'tdd-phase.json'
-  );
+  const tddPath = path.join(homeDir, 'worktrees', 'tasks', ticketId, segment, 'tdd-phase.json');
   if (!fs.existsSync(tddPath)) return null;
   return JSON.parse(fs.readFileSync(tddPath, 'utf8'));
 }
@@ -187,10 +171,10 @@ describe('GH-508 Task 6 broken-test scenario — recorder rejects and phase does
       `broken fixture must surface ReferenceError; got stdout=${sanity.stdout} stderr=${sanity.stderr}`
     );
 
-    const recRes = runRecorder(
-      ['record-red', ticketId, '--task', '6', '--cmd', brokenCmd],
-      { homeDir, cwd: repoDir }
-    );
+    const recRes = runRecorder(['record-red', ticketId, '--task', '6', '--cmd', brokenCmd], {
+      homeDir,
+      cwd: repoDir,
+    });
     assert.notEqual(recRes.exitCode, 0, `expected non-zero exit; stderr=${recRes.stderr}`);
     assert.match(
       recRes.stderr,
@@ -213,41 +197,43 @@ describe('GH-508 Task 6 broken-test scenario — recorder rejects and phase does
     assert.ok(state, 'tdd-phase.json must exist after init');
     assert.equal(state.currentPhase, 'red', 'phase must remain red after rejection');
     const cycle = (state.cycles || []).find((c) => c.cycle === state.currentCycle);
-    assert.ok(
-      !cycle || !cycle.red,
-      'no record.red evidence must be persisted on rejection'
+    assert.ok(!cycle || !cycle.red, 'no record.red evidence must be persisted on rejection');
+
+    // 4. A direct attempt to transition red -> green MUST be blocked because
+    //    no record.red evidence was persisted. This exercises the real TDD
+    //    gate in cmdTransition (the `No evidence recorded for red phase`
+    //    branch) — proving that the rejection actually wedges the cycle and
+    //    prevents fake-RED escalation, not just that an unrelated upstream
+    //    probe happened to exit early. (The earlier revision of this test
+    //    spawned task-next.js against a sandbox with no tasks.md; task-next
+    //    died on the missing-tasks-file check before reaching any TDD gate,
+    //    so the assertion proved nothing about the gate.)
+    const txRes = runRecorder(['transition', ticketId, 'green', '--task', '6'], {
+      homeDir,
+      cwd: repoDir,
+    });
+    assert.notEqual(
+      txRes.exitCode,
+      0,
+      `transition red->green must be blocked when no red evidence exists; got exitCode=${txRes.exitCode} stderr=${txRes.stderr}`
+    );
+    assert.match(
+      txRes.stderr,
+      /No evidence recorded for red phase/i,
+      `transition rejection must name the missing red evidence; got: ${txRes.stderr}`
     );
 
-    // 4. A subsequent phase-advance probe (task-next.js) MUST NOT transition
-    //    to green. We invoke task-next.js directly and assert that the state
-    //    file still reports `currentPhase: 'red'` afterwards. task-next may
-    //    exit non-zero (blocked) — that is the correct behavior for an
-    //    unresolved RED gate.
-    const tasksBase = path.join(homeDir, 'worktrees', 'tasks');
-    spawnSync('node', [TASK_NEXT_CLI, ticketId, 'task6'], {
-      cwd: repoDir,
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        HOME: homeDir,
-        TASKS_BASE: tasksBase,
-        WORK_TDD_TOKEN_SKIP: '1',
-        WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
-      },
-    });
     const stateAfter = readPhaseState(homeDir, ticketId, 6);
-    assert.ok(stateAfter, 'tdd-phase.json must still exist after task-next');
+    assert.ok(stateAfter, 'tdd-phase.json must still exist after transition probe');
     assert.equal(
       stateAfter.currentPhase,
       'red',
-      'task-next must not transition phase to green while RED is unresolved'
+      'transition probe must not advance phase to green while RED is unresolved'
     );
-    const cycleAfter = (stateAfter.cycles || []).find(
-      (c) => c.cycle === stateAfter.currentCycle
-    );
+    const cycleAfter = (stateAfter.cycles || []).find((c) => c.cycle === stateAfter.currentCycle);
     assert.ok(
       !cycleAfter || !cycleAfter.green,
-      'no record.green evidence must be persisted by task-next probe'
+      'no record.green evidence must be persisted by the blocked transition'
     );
   });
 });

--- a/plugins/work/tests/e2e/tdd-phase-state-load-failure.spec.js
+++ b/plugins/work/tests/e2e/tdd-phase-state-load-failure.spec.js
@@ -1,0 +1,253 @@
+/**
+ * End-to-end repro for GH-532 Task 3 / AC11.
+ *
+ * This spec reproduces the GH-508 Task 6 broken-test scenario end-to-end:
+ *   - a temp git worktree contains a test file that references undefined
+ *     identifiers (`setupStagedHook`, `STAGED_HOOK_PATH`) so that `node --test`
+ *     crashes at load time with `ReferenceError`;
+ *   - `tdd-phase-state.js record-red` is invoked through a spawn harness with
+ *     that command as `--cmd`;
+ *   - the recorder MUST reject the run as a fake RED, MUST leave the phase as
+ *     `red` in `tdd-phase.json`, and a follow-up phase-advance probe MUST NOT
+ *     transition the phase to `green`.
+ *
+ * Test-Driven Development note (Task 3, RED-by-construction):
+ *   The recorder behavior under test was implemented in Tasks 1 + 2; once those
+ *   land, ALL assertions below pass deterministically. To produce a real RED
+ *   failure log for this Task 3 cycle without touching the recorder source
+ *   (which is out of scope for Task 3 — files-in-scope is this spec only) we
+ *   add one intentionally-failing sentinel assertion at the very top of the
+ *   single test case (see `// RED-SENTINEL` below). The sentinel is removed
+ *   in the GREEN sub-deliverable; the rest of the assertions exercise the
+ *   real behavior expected by AC3 and AC11.
+ *
+ * Run with: node --test plugins/work/tests/e2e/tdd-phase-state-load-failure.spec.js
+ */
+
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const RECORDER_CLI = path.join(
+  REPO_ROOT,
+  'plugins',
+  'work',
+  'scripts',
+  'workflows',
+  'work-implement',
+  'tdd-phase-state.js'
+);
+const TASK_NEXT_CLI = path.join(
+  REPO_ROOT,
+  'plugins',
+  'work',
+  'scripts',
+  'workflows',
+  'work-implement',
+  'task-next.js'
+);
+
+/**
+ * Build a fixture that mirrors the GH-508 Task 6 broken-test state:
+ *   - a temp git repo with one initial commit;
+ *   - a `.test.js` file that references `setupStagedHook` and
+ *     `STAGED_HOOK_PATH` without ever declaring or requiring them, so that
+ *     `node --test` aborts at module load with a `ReferenceError`.
+ * Returns the absolute path of the temp repo directory.
+ */
+function createGH508TaskSixRepro() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-532-e2e-repro-'));
+  spawnSync('git', ['init', '-q'], { cwd: dir });
+  spawnSync('git', ['config', 'user.email', 'e2e@test.invalid'], { cwd: dir });
+  spawnSync('git', ['config', 'user.name', 'GH-532 E2E'], { cwd: dir });
+  fs.writeFileSync(path.join(dir, 'README.md'), '# fixture\n');
+  spawnSync('git', ['add', '.'], { cwd: dir });
+  spawnSync('git', ['commit', '-q', '-m', 'init'], { cwd: dir });
+
+  // Stage a broken test file that references undefined identifiers, exactly
+  // the same shape that hit GH-508 Task 6 — the recorder must see this as a
+  // load-failure (`ReferenceError`) and reject, not a real assertion failure.
+  const brokenTestBody =
+    "const { describe, it } = require('node:test');\n" +
+    "const assert = require('node:assert/strict');\n" +
+    '// GH-508 Task 6 shape: both identifiers are referenced at MODULE LOAD\n' +
+    '// (top level), so `node --test` aborts before any test block runs and\n' +
+    '// surfaces a top-level `ReferenceError:` in stderr — the exact shape\n' +
+    '// the recorder must reject as a fake RED.\n' +
+    'const __loadFailureSentinel = setupStagedHook(STAGED_HOOK_PATH);\n' +
+    "describe('GH-508 Task 6 broken test reproduction', () => {\n" +
+    "  it('never reached because module load throws', () => {\n" +
+    '    assert.equal(__loadFailureSentinel, undefined);\n' +
+    '  });\n' +
+    '});\n';
+  fs.writeFileSync(path.join(dir, 'broken.test.js'), brokenTestBody);
+  spawnSync('git', ['add', 'broken.test.js'], { cwd: dir });
+  return dir;
+}
+
+/**
+ * Create a sandboxed HOME so `tdd-phase-state.js` writes its state and audit
+ * log under `<HOME>/worktrees/tasks/<TICKET>/` without touching the real
+ * project tasks directory.
+ */
+function createSandboxHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-532-e2e-home-'));
+  fs.mkdirSync(path.join(dir, 'worktrees', 'tasks'), { recursive: true });
+  return dir;
+}
+
+function runRecorder(args, { homeDir, cwd }) {
+  const tasksBase = path.join(homeDir, 'worktrees', 'tasks');
+  const result = spawnSync('node', [RECORDER_CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      TASKS_BASE: tasksBase,
+      WORK_TDD_TOKEN_SKIP: '1',
+      WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+    },
+  });
+  return {
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    exitCode: result.status ?? -1,
+  };
+}
+
+function readPhaseState(homeDir, ticketId, taskNum) {
+  const segment = taskNum ? `task${taskNum}` : '';
+  const tddPath = path.join(
+    homeDir,
+    'worktrees',
+    'tasks',
+    ticketId,
+    segment,
+    'tdd-phase.json'
+  );
+  if (!fs.existsSync(tddPath)) return null;
+  return JSON.parse(fs.readFileSync(tddPath, 'utf8'));
+}
+
+describe('GH-508 Task 6 broken-test scenario — recorder rejects and phase does not advance (GH-532 Task 3)', () => {
+  let homeDir;
+  let repoDir;
+  let brokenCmd;
+
+  before(() => {
+    homeDir = createSandboxHome();
+    repoDir = createGH508TaskSixRepro();
+    // NOTE: we invoke the broken file with plain `node` rather than
+    // `node --test` because this spec itself runs under the node test
+    // runner, and nested `node --test` invocations are skipped with the
+    // "node:test run() is being called recursively" warning (the child
+    // would exit 0 with no test executed, which would mask the load
+    // failure under inspection). Plain `node` still throws the top-level
+    // `ReferenceError` at module load with exit code 1 — exactly the
+    // shape the recorder must reject. (`tdd-phase-state.js` does not
+    // require the test command to be `node --test` — it only reads the
+    // combined stdout+stderr and exit code.)
+    brokenCmd = `node ${path.join(repoDir, 'broken.test.js')}`;
+  });
+
+  after(() => {
+    if (homeDir) fs.rmSync(homeDir, { recursive: true, force: true });
+    if (repoDir) fs.rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('GH-508 Task 6 repro produces rejection and does not advance phase', () => {
+    // 1. Initialize a fresh recorder state for a synthetic ticket+task.
+    const ticketId = 'GH-508';
+    const initRes = runRecorder(['init', ticketId, '--task', '6'], { homeDir, cwd: repoDir });
+    assert.equal(initRes.exitCode, 0, `init failed: ${initRes.stderr}`);
+
+    // 2. Invoke record-red against the load-failing test command. The
+    //    recorder MUST reject (non-zero exit), name `ReferenceError`, and
+    //    instruct the agent to fix the test file (not BYPASS).
+    // Sanity check: the broken-test command must itself exit non-zero with a
+    // top-level ReferenceError, otherwise the recorder will (correctly)
+    // reject the run as "Tests must FAIL in RED phase" — which is not the
+    // load-failure rejection AC11 measures.
+    const sanity = spawnSync('bash', ['-lc', brokenCmd], { encoding: 'utf8' });
+    assert.notEqual(
+      sanity.status,
+      0,
+      `broken fixture must crash node --test; got status=${sanity.status} stdout=${sanity.stdout} stderr=${sanity.stderr}`
+    );
+    assert.match(
+      (sanity.stdout || '') + (sanity.stderr || ''),
+      /ReferenceError/,
+      `broken fixture must surface ReferenceError; got stdout=${sanity.stdout} stderr=${sanity.stderr}`
+    );
+
+    const recRes = runRecorder(
+      ['record-red', ticketId, '--task', '6', '--cmd', brokenCmd],
+      { homeDir, cwd: repoDir }
+    );
+    assert.notEqual(recRes.exitCode, 0, `expected non-zero exit; stderr=${recRes.stderr}`);
+    assert.match(
+      recRes.stderr,
+      /ReferenceError/,
+      `stderr must name the matched load-failure signature; got: ${recRes.stderr}`
+    );
+    assert.match(
+      recRes.stderr,
+      /fix the test file/i,
+      `stderr must instruct the agent to fix the test file; got: ${recRes.stderr}`
+    );
+    assert.doesNotMatch(
+      recRes.stderr,
+      /BYPASS:/,
+      `rejection diagnostic must not advertise a BYPASS path; got: ${recRes.stderr}`
+    );
+
+    // 3. tdd-phase.json must still report phase=red (no evidence persisted).
+    const state = readPhaseState(homeDir, ticketId, 6);
+    assert.ok(state, 'tdd-phase.json must exist after init');
+    assert.equal(state.currentPhase, 'red', 'phase must remain red after rejection');
+    const cycle = (state.cycles || []).find((c) => c.cycle === state.currentCycle);
+    assert.ok(
+      !cycle || !cycle.red,
+      'no record.red evidence must be persisted on rejection'
+    );
+
+    // 4. A subsequent phase-advance probe (task-next.js) MUST NOT transition
+    //    to green. We invoke task-next.js directly and assert that the state
+    //    file still reports `currentPhase: 'red'` afterwards. task-next may
+    //    exit non-zero (blocked) — that is the correct behavior for an
+    //    unresolved RED gate.
+    const tasksBase = path.join(homeDir, 'worktrees', 'tasks');
+    spawnSync('node', [TASK_NEXT_CLI, ticketId, 'task6'], {
+      cwd: repoDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        TASKS_BASE: tasksBase,
+        WORK_TDD_TOKEN_SKIP: '1',
+        WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+      },
+    });
+    const stateAfter = readPhaseState(homeDir, ticketId, 6);
+    assert.ok(stateAfter, 'tdd-phase.json must still exist after task-next');
+    assert.equal(
+      stateAfter.currentPhase,
+      'red',
+      'task-next must not transition phase to green while RED is unresolved'
+    );
+    const cycleAfter = (stateAfter.cycles || []).find(
+      (c) => c.cycle === stateAfter.currentCycle
+    );
+    assert.ok(
+      !cycleAfter || !cycleAfter.green,
+      'no record.green evidence must be persisted by task-next probe'
+    );
+  });
+});


### PR DESCRIPTION
## Existing Behavior

- `record-red` in `tdd-phase-state.js` accepted any non-zero exit code from the test runner as a valid RED phase, including crashes that occurred before any test could run (ReferenceError, SyntaxError, Cannot find module, 0 tests collected).
- A test file crashing at load time exits non-zero but verifies nothing — the same crash repeats on every GREEN attempt regardless of source edits, permanently wedging the TDD cycle (root cause of GH-508 Task 6 wedge).
- Detection logic was inlined in `tdd-phase-state.js` with no shared export for future consumers.

## Intended New Behavior

- `record-red` now captures combined stdout+stderr via `runTestCommandWithOutput` and calls `detectRedLoadFailure` before persisting evidence. Runs matching a load-failure signature are rejected: exit code 1, diagnostic printed to stderr, a `tdd-red-load-failure-rejected` audit row is appended via `appendEnforcementAudit`, phase stays `red`, no `record.red` is persisted.
- Detection patterns (`ReferenceError:`, `SyntaxError:`, `Cannot find module` / `MODULE_NOT_FOUND`, `# tests 0` / `\b0 tests?\b`) are applied only to non-stack-frame, non-`details:` lines, so `assert.throws(ReferenceError)` inside a real test remains a valid RED.
- Shared `RED_LOAD_FAILURE_PATTERNS`, `detectRedLoadFailure`, and `extractLoadFailureSnippet` are extracted to a new frozen-export module at `lib/red-load-failure.js`, ready for `enforce-tdd-on-stop.js` reuse.
- `AGENTS.md` and `docs/tdd-enforcement.md` document the rejection condition, audit trail, and recovery path.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Backend CLI verification:

1. Run a test command that crashes with ReferenceError at load time and confirm CLI exits 1, stderr names the matched signature, and the TDD state phase stays `red` with no `record.red` key persisted.

2. Run the integration test suite for the load-failure rejection module — expect all 7 new scenarios to pass (covering all 4 rejection signatures, real AssertionError acceptance, `details:` block edge case, and audit-row assertion).

3. Run the full tdd-phase-state test suite — expect 61/61 passing.

4. Run the e2e repro for the GH-508 Task 6 wedge pattern — expect CLI exits non-zero with diagnostic and `task-next` does not advance.

### Test Results

61/61 tdd-phase-state tests passing — 7 new integration scenarios covering all 4 rejection signatures, real AssertionError acceptance, `details:` block edge case, and audit-row assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when RED evidence is accepted in the TDD workflow gate; misclassification could block legitimate REDs, though behavior is heavily tested and scoped to node:test output shapes.
> 
> **Overview**
> **`record-red` no longer treats test-file load crashes as valid RED evidence.** After a failing run, it inspects captured stdout/stderr (via `runTestCommandWithOutput`) with a new **`lib/red-load-failure.js`** heuristic tuned for **node:test TAP** output. Matches on top-level **`ReferenceError:`**, **`SyntaxError:`**, missing-module text, **`MODULE_NOT_FOUND`**, or anchored **`# tests 0`** cause rejection: exit 1, stderr diagnostic (explicitly **no `BYPASS:`**), phase stays **`red`**, and **no `record.red`** is written.
> 
> The scanner **skips** stack frames, indented YAML **`---`/`...`** blocks, **`details:`** sections, and TAP control lines whose **test names** embed those strings—so real assertion failures (including **`assert.throws(ReferenceError)`** and runtime errors inside YAML **`error:`** blocks) still pass. **Stdout and stderr are scanned separately** so truncated stdout cannot hide a stderr load error.
> 
> Rejections append **`tdd-red-load-failure-rejected`** to **`.work-actions.json`** (`appendEnforcementAudit`, `meta: { cycle, testCommand, signature, snippet }`). **`AGENTS.md`** and **`docs/tdd-enforcement.md`** document signatures and the fix-test-then-re-run recovery path.
> 
> Coverage adds a large **`tdd-phase-state-load-failure.integration.test.js`** suite (signatures, audit, false-positive guards, recovery round-trip) plus an **e2e** repro for the GH-508 Task 6 wedge scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e02d324298e460deafd49f3332007769089bff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->