### PR TITLE
GH-531: follow-up driver recovery path for hook-protected state + stale Copilot threads

### DIFF
--- a/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-init-fresh-state.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/follow-up-next-init-fresh-state.test.js
@@ -1,0 +1,112 @@
+/**
+ * Tests for initFreshState(ticketId) helper extracted from follow-up-next.js.
+ *
+ * Task 1 (GH-531) RED: assert the helper is exported, returns a fresh state
+ * shape matching the existing init path, writes the state file at the correct
+ * path under TASKS_BASE/<ticket>/.follow-up-state.json, and is idempotent
+ * (second call overwrites with a fresh state).
+ *
+ * node:test + node:assert/strict; isolated TASKS_BASE via fs.mkdtempSync.
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const MODULE_PATH = path.join(__dirname, '..', 'follow-up-next.js');
+
+let TASKS_BASE;
+let prevTasksBase;
+let prevWorktreesBase;
+
+function loadModuleFresh() {
+  // follow-up-next.js reads TASKS_BASE at require time via getConfig; clear
+  // the require cache so each test sees the temp TASKS_BASE.
+  delete require.cache[require.resolve(MODULE_PATH)];
+  return require(MODULE_PATH);
+}
+
+beforeEach(() => {
+  TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'follow-up-next-init-'));
+  prevTasksBase = process.env.TASKS_BASE;
+  prevWorktreesBase = process.env.WORKTREES_BASE;
+  process.env.TASKS_BASE = TASKS_BASE;
+  process.env.WORKTREES_BASE = TASKS_BASE;
+});
+
+afterEach(() => {
+  if (prevTasksBase === undefined) delete process.env.TASKS_BASE;
+  else process.env.TASKS_BASE = prevTasksBase;
+  if (prevWorktreesBase === undefined) delete process.env.WORKTREES_BASE;
+  else process.env.WORKTREES_BASE = prevWorktreesBase;
+  fs.rmSync(TASKS_BASE, { recursive: true, force: true });
+});
+
+describe('follow-up-next.js → initFreshState(ticketId)', () => {
+  it('is exported as a function from follow-up-next.js', () => {
+    const mod = loadModuleFresh();
+    assert.equal(
+      typeof mod.initFreshState,
+      'function',
+      'initFreshState must be exported from follow-up-next.js'
+    );
+  });
+
+  it('returns a fresh state object with the canonical init shape', () => {
+    const { initFreshState } = loadModuleFresh();
+    const state = initFreshState('GH-999');
+
+    assert.ok(state && typeof state === 'object', 'returns an object');
+    assert.equal(state.ticketId, 'GH-999');
+    assert.equal(state.status, 'in_progress');
+    assert.equal(state.attempt, 0);
+    assert.equal(state.maxAttempts, 40);
+    assert.equal(state.lastMonitorResult, null);
+    assert.equal(state.failureCategory, null);
+    assert.equal(state.dispatched, null);
+    assert.ok(typeof state.currentStep === 'string' && state.currentStep.length > 0);
+    assert.ok(typeof state.startTime === 'string' && state.startTime.length > 0);
+  });
+
+  it('writes the state file at TASKS_BASE/<ticket>/.follow-up-state.json', () => {
+    const { initFreshState } = loadModuleFresh();
+    const ticketId = 'GH-999';
+    const expectedPath = path.join(TASKS_BASE, ticketId, '.follow-up-state.json');
+
+    initFreshState(ticketId);
+
+    assert.ok(fs.existsSync(expectedPath), `state file written at ${expectedPath}`);
+    const onDisk = JSON.parse(fs.readFileSync(expectedPath, 'utf8'));
+    assert.equal(onDisk.ticketId, ticketId);
+    assert.equal(onDisk.attempt, 0);
+    assert.equal(onDisk.status, 'in_progress');
+  });
+
+  it('is idempotent — calling twice overwrites with a fresh state', () => {
+    const { initFreshState } = loadModuleFresh();
+    const ticketId = 'GH-999';
+    const statePath = path.join(TASKS_BASE, ticketId, '.follow-up-state.json');
+
+    initFreshState(ticketId);
+    // Mutate on-disk state to simulate progress.
+    const dirty = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    dirty.attempt = 27;
+    dirty.status = 'blocked';
+    dirty.failureCategory = 'something';
+    fs.writeFileSync(statePath, JSON.stringify(dirty, null, 2));
+
+    const second = initFreshState(ticketId);
+    assert.equal(second.attempt, 0, 'returned state is fresh');
+    assert.equal(second.status, 'in_progress', 'returned state is fresh');
+    assert.equal(second.failureCategory, null, 'returned state is fresh');
+
+    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assert.equal(onDisk.attempt, 0, 'on-disk state overwritten fresh');
+    assert.equal(onDisk.status, 'in_progress', 'on-disk state overwritten fresh');
+    assert.equal(onDisk.failureCategory, null, 'on-disk state overwritten fresh');
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/push-retry.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/push-retry.test.js
@@ -41,16 +41,23 @@ describe('push-retry step', () => {
     assert.ok(result.reason && result.reason.includes('Max push-retry'));
     assert.ok(
       typeof result.instruction === 'string' && result.instruction.includes('reset-follow-up'),
-      'instruction must mention reset-follow-up',
+      'instruction must mention reset-follow-up'
     );
     assert.ok(
       result.instruction.includes('GH-531'),
-      'instruction must include the actual ticket id',
+      'instruction must include the actual ticket id'
     );
-    assert.ok(result.nextAction && typeof result.nextAction === 'object', 'nextAction object required');
+    assert.ok(
+      result.nextAction && typeof result.nextAction === 'object',
+      'nextAction object required'
+    );
     assert.equal(result.nextAction.command, 'workflow-engine');
     assert.equal(result.nextAction.subcommand, 'reset-follow-up');
-    assert.deepEqual(result.nextAction.args, ['GH-531']);
+    assert.deepEqual(result.nextAction.args, ['GH-531', '--yes']);
+    assert.ok(
+      result.instruction.includes('--yes'),
+      'instruction must include --yes so the recovery command actually mutates state'
+    );
   });
 
   it('loops back to monitor when already dispatched', () => {

--- a/plugins/work/scripts/workflows/follow-up/__tests__/push-retry.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/push-retry.test.js
@@ -34,6 +34,25 @@ describe('push-retry step', () => {
     assert.ok(result.reason.includes('Max push-retry'));
   });
 
+  it('push-retry at cap returns actionable instruction', () => {
+    const state = makeState({ _pushRetryCount: 39, maxAttempts: 40, ticketId: 'GH-531' });
+    const result = pushRetry(state, ctx);
+    assert.equal(result.action, 'blocked');
+    assert.ok(result.reason && result.reason.includes('Max push-retry'));
+    assert.ok(
+      typeof result.instruction === 'string' && result.instruction.includes('reset-follow-up'),
+      'instruction must mention reset-follow-up',
+    );
+    assert.ok(
+      result.instruction.includes('GH-531'),
+      'instruction must include the actual ticket id',
+    );
+    assert.ok(result.nextAction && typeof result.nextAction === 'object', 'nextAction object required');
+    assert.equal(result.nextAction.command, 'workflow-engine');
+    assert.equal(result.nextAction.subcommand, 'reset-follow-up');
+    assert.deepEqual(result.nextAction.args, ['GH-531']);
+  });
+
   it('loops back to monitor when already dispatched', () => {
     const state = makeState({ dispatched: 'push-retry' });
     const result = pushRetry(state, ctx);

--- a/plugins/work/scripts/workflows/follow-up/__tests__/reset-follow-up.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/reset-follow-up.test.js
@@ -164,4 +164,24 @@ describe('reset-follow-up', () => {
       assert.equal(fresh.status, 'in_progress');
     });
   });
+
+  describe('reset-follow-up preserves saved PR number across reset', () => {
+    it('reads prNumber from existing state and re-applies it to the fresh state', () => {
+      const ticketId = 'GH-553';
+      const dir = path.join(TASKS_BASE, ticketId);
+      fs.mkdirSync(dir, { recursive: true });
+      const statePath = path.join(dir, '.follow-up-state.json');
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({ ticketId, status: 'blocked', attempt: 40, prNumber: 553 }, null, 2)
+      );
+
+      const result = runReset([ticketId, '--yes']);
+      assert.equal(result.status, 0, `exit 0 expected, got ${result.status}: ${result.stderr}`);
+
+      const fresh = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+      assert.equal(fresh.ticketId, ticketId);
+      assert.equal(fresh.prNumber, 553, 'prNumber preserved across reset');
+    });
+  });
 });

--- a/plugins/work/scripts/workflows/follow-up/__tests__/reset-follow-up.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/reset-follow-up.test.js
@@ -1,0 +1,167 @@
+/**
+ * Tests for reset-follow-up.js (Task 4 / GH-531).
+ *
+ * Covers the three RED scenarios from tasks.md:
+ *   1. reset-follow-up wipes state without tripping protect-state-files
+ *   2. reset-follow-up validates ticket id
+ *   3. reset-follow-up is idempotent when state files are already gone
+ *
+ * The module is invoked as a CLI via `child_process.spawn` so we exercise the
+ * exit code + stdout/stderr contract surfaced to workflow-engine.js.
+ *
+ * node:test + node:assert/strict; isolated TASKS_BASE via fs.mkdtempSync.
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const MODULE_PATH = path.join(__dirname, '..', 'reset-follow-up.js');
+
+let TASKS_BASE;
+let prevTasksBase;
+let prevWorktreesBase;
+
+function runReset(args, opts = {}) {
+  return spawnSync(process.execPath, [MODULE_PATH, ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TASKS_BASE,
+      WORKTREES_BASE: TASKS_BASE,
+      ...(opts.env || {}),
+    },
+  });
+}
+
+function seedTicketState(ticketId) {
+  const dir = path.join(TASKS_BASE, ticketId);
+  fs.mkdirSync(dir, { recursive: true });
+  const statePath = path.join(dir, '.follow-up-state.json');
+  const commentsPath = path.join(dir, 'follow-up-comments.json');
+  fs.writeFileSync(
+    statePath,
+    JSON.stringify({ ticketId, status: 'blocked', attempt: 40 }, null, 2)
+  );
+  fs.writeFileSync(commentsPath, JSON.stringify({ comments: [{ id: 1 }] }, null, 2));
+  return { dir, statePath, commentsPath };
+}
+
+beforeEach(() => {
+  TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'reset-follow-up-'));
+  prevTasksBase = process.env.TASKS_BASE;
+  prevWorktreesBase = process.env.WORKTREES_BASE;
+  process.env.TASKS_BASE = TASKS_BASE;
+  process.env.WORKTREES_BASE = TASKS_BASE;
+});
+
+afterEach(() => {
+  if (prevTasksBase === undefined) delete process.env.TASKS_BASE;
+  else process.env.TASKS_BASE = prevTasksBase;
+  if (prevWorktreesBase === undefined) delete process.env.WORKTREES_BASE;
+  else process.env.WORKTREES_BASE = prevWorktreesBase;
+  fs.rmSync(TASKS_BASE, { recursive: true, force: true });
+});
+
+describe('reset-follow-up', () => {
+  describe('reset-follow-up wipes state without tripping protect-state-files', () => {
+    it('removes .follow-up-state.json and follow-up-comments.json, re-inits, exit 0, provenance row appended', () => {
+      const ticketId = 'GH-999';
+      const { statePath, commentsPath, dir } = seedTicketState(ticketId);
+
+      const result = runReset([ticketId, '--yes']);
+
+      assert.equal(result.status, 0, `exit 0 expected, got ${result.status}: ${result.stderr}`);
+
+      // Stdout is JSON with the documented shape.
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.ok, true);
+      assert.equal(payload.ticket, ticketId);
+      assert.equal(payload.reinit, true);
+      assert.ok(Array.isArray(payload.removed), 'removed must be an array');
+      assert.equal(payload.removed.length, 2, 'both files reported as removed');
+
+      // Fresh state file was re-initialized.
+      assert.ok(fs.existsSync(statePath), 'fresh state re-initialized at original path');
+      const fresh = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+      assert.equal(fresh.ticketId, ticketId);
+      assert.equal(fresh.attempt, 0);
+      assert.equal(fresh.status, 'in_progress');
+
+      // follow-up-comments.json stays gone (idempotent wipe target).
+      assert.equal(fs.existsSync(commentsPath), false, 'follow-up-comments.json wiped');
+
+      // Provenance row appended to .work-actions.json.
+      const actionsPath = path.join(dir, '.work-actions.json');
+      assert.ok(fs.existsSync(actionsPath), '.work-actions.json written');
+      const actions = JSON.parse(fs.readFileSync(actionsPath, 'utf8'));
+      const rows = Array.isArray(actions) ? actions : actions.actions || actions.rows;
+      assert.ok(Array.isArray(rows), '.work-actions.json holds an array of rows');
+      const row = rows.find((r) => r && r.kind === 'reset-follow-up');
+      assert.ok(row, 'reset-follow-up provenance row present');
+      assert.equal(row.ticket, ticketId);
+      assert.ok(row.ts, 'ts recorded');
+      assert.ok(typeof row.invoker === 'string' && row.invoker.length > 0, 'invoker recorded');
+    });
+  });
+
+  describe('reset-follow-up validates ticket id', () => {
+    it('rejects ../etc/passwd with exit 1, stderr "must match", and no out-of-base writes', () => {
+      const result = runReset(['../etc/passwd', '--yes']);
+
+      assert.equal(result.status, 1, `exit 1 expected, got ${result.status}`);
+      assert.match(
+        result.stderr,
+        /must match/,
+        `stderr must contain "must match"; got: ${result.stderr}`
+      );
+
+      // No file should have been touched outside TASKS_BASE.
+      assert.equal(
+        fs.existsSync(path.join(TASKS_BASE, '..', 'etc', 'passwd')),
+        false,
+        'no out-of-base file created'
+      );
+      // And nothing inside TASKS_BASE either.
+      const entries = fs.readdirSync(TASKS_BASE);
+      assert.deepEqual(entries, [], 'TASKS_BASE remains empty');
+    });
+
+    it('rejects lowercase / non-canonical ids with exit 1 and "must match"', () => {
+      const result = runReset(['gh-1', '--yes']);
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /must match/);
+    });
+  });
+
+  describe('reset-follow-up is idempotent when state files are already gone', () => {
+    it('exit 0, removed list empty, fresh state still re-initialized', () => {
+      const ticketId = 'GH-1234';
+      // Note: do NOT seed state — both target files are absent.
+
+      const result = runReset([ticketId, '--yes']);
+
+      assert.equal(result.status, 0, `exit 0 expected, got ${result.status}: ${result.stderr}`);
+
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.ok, true);
+      assert.equal(payload.ticket, ticketId);
+      assert.equal(payload.reinit, true);
+      assert.ok(Array.isArray(payload.removed), 'removed is an array');
+      assert.equal(payload.removed.length, 0, 'nothing pre-existing was removed');
+
+      // Fresh state initialized despite no prior state.
+      const statePath = path.join(TASKS_BASE, ticketId, '.follow-up-state.json');
+      assert.ok(fs.existsSync(statePath), 'fresh state initialized');
+      const fresh = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+      assert.equal(fresh.ticketId, ticketId);
+      assert.equal(fresh.attempt, 0);
+      assert.equal(fresh.status, 'in_progress');
+    });
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/__tests__/reset-follow-up.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/reset-follow-up.test.js
@@ -184,4 +184,35 @@ describe('reset-follow-up', () => {
       assert.equal(fresh.prNumber, 553, 'prNumber preserved across reset');
     });
   });
+
+  describe('reset-follow-up preserves a corrupt .work-actions.json before overwriting', () => {
+    it('renames the corrupt file to .corrupt-<ts> and writes a fresh one-row file', () => {
+      const ticketId = 'GH-777';
+      seedTicketState(ticketId);
+      const dir = path.join(TASKS_BASE, ticketId);
+      const actionsPath = path.join(dir, '.work-actions.json');
+      fs.writeFileSync(actionsPath, '{ this is : not json ]');
+
+      const result = runReset([ticketId, '--yes']);
+      assert.equal(result.status, 0, `exit 0 expected, got ${result.status}: ${result.stderr}`);
+
+      // Corrupt sibling preserved
+      const siblings = fs
+        .readdirSync(dir)
+        .filter((f) => f.startsWith('.work-actions.json.corrupt-'));
+      assert.equal(siblings.length, 1, 'one corrupt-<ts> sibling must exist');
+      assert.equal(
+        fs.readFileSync(path.join(dir, siblings[0]), 'utf8'),
+        '{ this is : not json ]',
+        'corrupt contents must be preserved verbatim'
+      );
+
+      // Fresh file contains exactly one provenance row
+      const fresh = JSON.parse(fs.readFileSync(actionsPath, 'utf8'));
+      assert.ok(Array.isArray(fresh), 'fresh actions file must be an array');
+      assert.equal(fresh.length, 1, 'fresh actions file must contain exactly one row');
+      assert.equal(fresh[0].kind, 'reset-follow-up');
+      assert.equal(fresh[0].ticket, ticketId);
+    });
+  });
 });

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -138,6 +138,25 @@ function initState(ticketId, prNumber) {
   };
 }
 
+/**
+ * Build a fresh /follow-up state object for `ticketId`, persist it to the
+ * canonical state-file path (`TASKS_BASE/<ticket>/.follow-up-state.json`),
+ * and return the new state.
+ *
+ * Idempotent: calling twice overwrites the on-disk state with a fresh one.
+ * Used both by the existing init code path in this module and by the
+ * `/reset-follow-up` command (Task 2) to re-initialize after push-retry
+ * exhaustion (GH-531).
+ *
+ * @param {string} ticketId — sanitized ticket id (e.g. `GH-999`).
+ * @returns {object} the freshly-initialized state object.
+ */
+function initFreshState(ticketId) {
+  const state = initState(ticketId, null);
+  saveState(ticketId, state);
+  return state;
+}
+
 // ─── Core orchestrator loop ─────────────────────────────────────────────────
 
 function getNextInstruction(ticketId, prNumber) {
@@ -378,6 +397,7 @@ if (require.main === module) main();
 module.exports = {
   getNextInstruction,
   initState,
+  initFreshState,
   dispatchStepResult,
   __test__: {
     initState,

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -155,10 +155,13 @@ function initState(ticketId, prNumber) {
  * exhaustion (GH-531).
  *
  * @param {string} ticketId — sanitized ticket id (e.g. `GH-999`).
+ * @param {object} [opts] — optional overrides.
+ * @param {number|null} [opts.prNumber] — preserve an existing PR number across reset.
  * @returns {object} the freshly-initialized state object.
  */
-function initFreshState(ticketId) {
-  const state = initState(ticketId, null);
+function initFreshState(ticketId, opts) {
+  const prNumber = opts && opts.prNumber != null ? opts.prNumber : null;
+  const state = initState(ticketId, prNumber);
   saveState(ticketId, state);
   return state;
 }

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -127,6 +127,12 @@ function initState(ticketId, prNumber) {
     attempt: 0,
     maxAttempts: 40,
     // monitor cache (see infra-patterns.js for invalidation rules)
+    // GH-531 Task 6 (AC10): explicitly reset the push-retry counter so the
+    // cap-exhausted recovery path can't immediately re-trigger after
+    // `reset-follow-up`. Was previously `undefined` (incremented to 1 on
+    // first push-retry), which matches the same observable behavior; the
+    // explicit `0` makes the recovery guarantee inspectable by operators.
+    _pushRetryCount: 0,
     lastMonitorResult: null,
     lastMonitorAt: null,
     failureCategory: null,

--- a/plugins/work/scripts/workflows/follow-up/lib/__tests__/git-hunk-changed.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/__tests__/git-hunk-changed.test.js
@@ -8,7 +8,6 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const Module = require('node:module');
 
 const MODULE_PATH = require.resolve('../git-hunk-changed.js');
 

--- a/plugins/work/scripts/workflows/follow-up/lib/__tests__/git-hunk-changed.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/__tests__/git-hunk-changed.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+// Unit tests for gitHunkChangedSince() — pure unit, execFileSync stubbed.
+// Covers:
+//   (1) changed-hunk → true  (git log -L emits output)
+//   (2) no-change-since-timestamp → false (git log -L empty)
+//   (3) invalid sinceIso → throws
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const MODULE_PATH = require.resolve('../git-hunk-changed.js');
+
+function withStubbedExecFileSync(stub, fn) {
+  const childProcess = require('node:child_process');
+  const original = childProcess.execFileSync;
+  childProcess.execFileSync = stub;
+  // Force re-require so the module picks up the stubbed binding if it
+  // captured a local reference at load time.
+  delete require.cache[MODULE_PATH];
+  try {
+    return fn(require(MODULE_PATH));
+  } finally {
+    childProcess.execFileSync = original;
+    delete require.cache[MODULE_PATH];
+  }
+}
+
+test('gitHunkChangedSince returns true when git log -L emits output (hunk changed)', () => {
+  const calls = [];
+  const stub = (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    return Buffer.from(
+      'commit abc123\nAuthor: x\nDate: ...\n\ndiff --git a/foo.js b/foo.js\n@@ -10,1 +10,1 @@\n-old\n+new\n'
+    );
+  };
+  withStubbedExecFileSync(stub, (mod) => {
+    const result = mod.gitHunkChangedSince('src/foo.js', 10, '2026-01-01T00:00:00Z');
+    assert.equal(result, true);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].cmd, 'git');
+    assert.ok(calls[0].args.includes('--since'), 'git args should include --since');
+    assert.ok(
+      calls[0].args.includes('2026-01-01T00:00:00Z'),
+      'git args should include the sinceIso value'
+    );
+    // -L should be passed as a flag with a line,line:file argument
+    const lFlagIdx = calls[0].args.indexOf('-L');
+    assert.ok(lFlagIdx >= 0, '-L flag should be present');
+    const lArg = calls[0].args[lFlagIdx + 1];
+    assert.ok(
+      /^10,10:src\/foo\.js$/.test(lArg),
+      `expected -L arg to be '10,10:src/foo.js', got '${lArg}'`
+    );
+  });
+});
+
+test('gitHunkChangedSince returns false when git log -L output is empty (no change)', () => {
+  const stub = () => Buffer.from('');
+  withStubbedExecFileSync(stub, (mod) => {
+    const result = mod.gitHunkChangedSince('src/foo.js', 42, '2026-01-01T00:00:00Z');
+    assert.equal(result, false);
+  });
+});
+
+test('gitHunkChangedSince throws on invalid sinceIso', () => {
+  const stub = () => {
+    throw new Error('execFileSync should not be called on invalid sinceIso');
+  };
+  withStubbedExecFileSync(stub, (mod) => {
+    assert.throws(
+      () => mod.gitHunkChangedSince('src/foo.js', 10, 'not-an-iso-date'),
+      /sinceIso|ISO|invalid/i
+    );
+    assert.throws(() => mod.gitHunkChangedSince('src/foo.js', 10, ''), /sinceIso|ISO|invalid/i);
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/lib/__tests__/git-hunk-changed.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/__tests__/git-hunk-changed.test.js
@@ -63,6 +63,33 @@ test('gitHunkChangedSince returns false when git log -L output is empty (no chan
   });
 });
 
+test('gitHunkChangedSince passes timeout=5000 and forwards ctx.cwd to execFileSync', () => {
+  const calls = [];
+  const stub = (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    return Buffer.from('');
+  };
+  withStubbedExecFileSync(stub, (mod) => {
+    mod.gitHunkChangedSince('src/foo.js', 10, '2026-01-01T00:00:00Z', { cwd: '/tmp/wt' });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].opts.timeout, 5000, 'timeout option must be 5000ms');
+    assert.equal(calls[0].opts.cwd, '/tmp/wt', 'ctx.cwd must be forwarded');
+  });
+});
+
+test('gitHunkChangedSince omits cwd when ctx has no cwd', () => {
+  const calls = [];
+  const stub = (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    return Buffer.from('');
+  };
+  withStubbedExecFileSync(stub, (mod) => {
+    mod.gitHunkChangedSince('src/foo.js', 10, '2026-01-01T00:00:00Z');
+    assert.equal(calls[0].opts.cwd, undefined, 'cwd should be unset to inherit process.cwd()');
+    assert.equal(calls[0].opts.timeout, 5000);
+  });
+});
+
 test('gitHunkChangedSince throws on invalid sinceIso', () => {
   const stub = () => {
     throw new Error('execFileSync should not be called on invalid sinceIso');

--- a/plugins/work/scripts/workflows/follow-up/lib/git-hunk-changed.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/git-hunk-changed.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * git-hunk-changed — detect whether a single-line "hunk" of a file has been
+ * touched by any git commit since a given ISO-8601 timestamp.
+ *
+ * Used by the Copilot stale-thread heuristic in `follow-up-pr-comments.js`:
+ * a Copilot review comment whose original line range was already modified
+ * after the comment's `created_at` is treated as "code-addressed, thread-
+ * stale" and auto-resolved locally.
+ *
+ * Constraints (GH-531 spec):
+ *   - Node built-ins only (zero runtime deps).
+ *   - `execFileSync` with arg array — never shell interpolation (C7).
+ *   - `sinceIso` is validated against `^\d{4}-\d{2}-\d{2}T` BEFORE being
+ *     passed to git, defense-in-depth against any caller-controlled value.
+ */
+
+const { execFileSync } = require('node:child_process');
+
+const ISO_PREFIX_RE = /^\d{4}-\d{2}-\d{2}T/;
+
+/**
+ * Return `true` if `git log -L <line>,<line>:<file> --since <sinceIso>`
+ * produces non-empty output (i.e. at least one commit since `sinceIso`
+ * touched the given line range), `false` otherwise.
+ *
+ * @param {string} filePath    repo-relative path to the file under inspection
+ * @param {number} originalLine 1-indexed line of the original comment anchor
+ * @param {string} sinceIso    ISO-8601 timestamp (must start `YYYY-MM-DDT`)
+ * @param {object} [_ctx]      reserved for future cwd/logger plumbing
+ * @returns {boolean}
+ * @throws {Error} if `sinceIso` fails the ISO-prefix regex
+ */
+function gitHunkChangedSince(filePath, originalLine, sinceIso, _ctx) {
+  if (typeof sinceIso !== 'string' || !ISO_PREFIX_RE.test(sinceIso)) {
+    throw new Error(
+      `gitHunkChangedSince: invalid sinceIso — expected ISO-8601 timestamp starting YYYY-MM-DDT, got ${JSON.stringify(sinceIso)}`
+    );
+  }
+  const line = Number(originalLine);
+  const lArg = `${line},${line}:${filePath}`;
+  const out = execFileSync('git', ['log', '--since', sinceIso, '-L', lArg], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return String(out).trim().length > 0;
+}
+
+module.exports = { gitHunkChangedSince };

--- a/plugins/work/scripts/workflows/follow-up/lib/git-hunk-changed.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/git-hunk-changed.js
@@ -28,11 +28,13 @@ const ISO_PREFIX_RE = /^\d{4}-\d{2}-\d{2}T/;
  * @param {string} filePath    repo-relative path to the file under inspection
  * @param {number} originalLine 1-indexed line of the original comment anchor
  * @param {string} sinceIso    ISO-8601 timestamp (must start `YYYY-MM-DDT`)
- * @param {object} [_ctx]      reserved for future cwd/logger plumbing
+ * @param {{ cwd?: string }} [ctx] optional context — `cwd` is forwarded to
+ *   execFileSync so callers can pin the git invocation to a specific worktree.
+ *   When omitted, git inherits `process.cwd()`.
  * @returns {boolean}
  * @throws {Error} if `sinceIso` fails the ISO-prefix regex
  */
-function gitHunkChangedSince(filePath, originalLine, sinceIso, _ctx) {
+function gitHunkChangedSince(filePath, originalLine, sinceIso, ctx) {
   if (typeof sinceIso !== 'string' || !ISO_PREFIX_RE.test(sinceIso)) {
     throw new Error(
       `gitHunkChangedSince: invalid sinceIso — expected ISO-8601 timestamp starting YYYY-MM-DDT, got ${JSON.stringify(sinceIso)}`
@@ -40,10 +42,13 @@ function gitHunkChangedSince(filePath, originalLine, sinceIso, _ctx) {
   }
   const line = Number(originalLine);
   const lArg = `${line},${line}:${filePath}`;
-  const out = execFileSync('git', ['log', '--since', sinceIso, '-L', lArg], {
+  const opts = {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+    timeout: 5000,
+  };
+  if (ctx && typeof ctx.cwd === 'string') opts.cwd = ctx.cwd;
+  const out = execFileSync('git', ['log', '--since', sinceIso, '-L', lArg], opts);
   return String(out).trim().length > 0;
 }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/push-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/push-retry.js
@@ -22,7 +22,7 @@ module.exports = function registerPushRetry(register) {
     const maxAttempts = state.maxAttempts || 40;
     if (state._pushRetryCount >= maxAttempts) {
       const ticketId = state.ticketId;
-      const instruction = `Run: workflow-engine reset-follow-up ${ticketId}`;
+      const instruction = `Run: workflow-engine reset-follow-up ${ticketId} --yes`;
       return {
         type: 'follow_up_instruction',
         action: 'blocked',
@@ -31,7 +31,7 @@ module.exports = function registerPushRetry(register) {
         nextAction: {
           command: 'workflow-engine',
           subcommand: 'reset-follow-up',
-          args: [ticketId],
+          args: [ticketId, '--yes'],
         },
       };
     }

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/push-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/push-retry.js
@@ -19,11 +19,20 @@ module.exports = function registerPushRetry(register) {
     if (state.dispatched !== 'push-retry') {
       state._pushRetryCount = (state._pushRetryCount || 0) + 1;
     }
-    if (state._pushRetryCount >= (state.maxAttempts || 40)) {
+    const maxAttempts = state.maxAttempts || 40;
+    if (state._pushRetryCount >= maxAttempts) {
+      const ticketId = state.ticketId;
+      const instruction = `Run: workflow-engine reset-follow-up ${ticketId}`;
       return {
         type: 'follow_up_instruction',
         action: 'blocked',
-        reason: `Max push-retry cycles (${state.maxAttempts || 40}) reached. PR still has issues.`,
+        reason: `Max push-retry cycles (${maxAttempts}) reached. PR still has issues.`,
+        instruction,
+        nextAction: {
+          command: 'workflow-engine',
+          subcommand: 'reset-follow-up',
+          args: [ticketId],
+        },
       };
     }
 

--- a/plugins/work/scripts/workflows/follow-up/reset-follow-up.js
+++ b/plugins/work/scripts/workflows/follow-up/reset-follow-up.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+/**
+ * reset-follow-up <TICKET> [--dry-run] [--yes]
+ *
+ * GH-531 R2: wipe `/follow-up` state for a ticket and re-initialize fresh
+ * state, without tripping `protect-state-files`. Invoked through the
+ * already-EXEMPT `workflow-engine.js` dispatcher so the standard write-
+ * protection hook recognizes the caller.
+ *
+ * Behavior:
+ *   - Validate ticket id against /^[A-Z]+-\d+$/ before any path work.
+ *   - Path containment check: refuse to operate outside TASKS_BASE/<ticket>/.
+ *   - ENOENT-safe unlink of `.follow-up-state.json` and `follow-up-comments.json`.
+ *   - Call `initFreshState(ticketId)` from follow-up-next.js to re-init.
+ *   - Append provenance row to `<ticketDir>/.work-actions.json`:
+ *       { kind: 'reset-follow-up', ticket, ts, invoker: $USER || 'unknown' }
+ *   - Print JSON `{ ok, ticket, removed, reinit }` and exit 0.
+ *
+ * Flags:
+ *   --dry-run   Print what would be unlinked; do not touch disk.
+ *   --yes       Skip the "print suggested command + stop" confirm gate.
+ *               Without --yes, the command prints a suggested command line
+ *               and exits 0 without mutating state.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const libDir = path.join(__dirname, '..', 'lib');
+const getConfig = require(path.join(libDir, 'get-config'));
+
+const TICKET_RE = /^[A-Z]+-\d+$/;
+const STATE_FILES = ['.follow-up-state.json', 'follow-up-comments.json'];
+
+function parseArgs(argv) {
+  const positional = [];
+  const flags = { dryRun: false, yes: false };
+  for (const a of argv) {
+    if (a === '--dry-run') flags.dryRun = true;
+    else if (a === '--yes' || a === '-y') flags.yes = true;
+    else if (a.startsWith('-')) {
+      // unknown flag — fail loudly so callers learn the contract
+      process.stderr.write(`reset-follow-up: unknown flag: ${a}\n`);
+      process.exit(1);
+    } else {
+      positional.push(a);
+    }
+  }
+  return { positional, flags };
+}
+
+function resolveTasksBase() {
+  const base =
+    getConfig('TASKS_BASE') ||
+    (process.env.WORKTREES_BASE ? path.join(process.env.WORKTREES_BASE, 'tasks') : '');
+  if (!base) {
+    process.stderr.write(
+      'reset-follow-up: TASKS_BASE not configured (check .envrc / get-config).\n'
+    );
+    process.exit(1);
+  }
+  return base;
+}
+
+function assertContained(targetPath, baseDir) {
+  const resolved = path.resolve(targetPath);
+  const baseResolved = path.resolve(baseDir);
+  const rel = path.relative(baseResolved, resolved);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    process.stderr.write(`reset-follow-up: refusing to operate outside TASKS_BASE: ${resolved}\n`);
+    process.exit(1);
+  }
+}
+
+function safeUnlink(p) {
+  try {
+    fs.unlinkSync(p);
+    return true;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+function appendProvenance(ticketDir, ticket) {
+  const actionsPath = path.join(ticketDir, '.work-actions.json');
+  let rows = [];
+  try {
+    const raw = fs.readFileSync(actionsPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    rows = Array.isArray(parsed) ? parsed : Array.isArray(parsed.actions) ? parsed.actions : [];
+  } catch (err) {
+    if (!err || err.code !== 'ENOENT') {
+      // Corrupt file — start a fresh array rather than fail the reset.
+      rows = [];
+    }
+  }
+  rows.push({
+    kind: 'reset-follow-up',
+    ticket,
+    ts: new Date().toISOString(),
+    invoker: process.env.USER || 'unknown',
+  });
+  fs.mkdirSync(ticketDir, { recursive: true });
+  fs.writeFileSync(actionsPath, `${JSON.stringify(rows, null, 2)}\n`);
+}
+
+function run(argv) {
+  const { positional, flags } = parseArgs(argv);
+
+  if (positional.length < 1) {
+    process.stderr.write(
+      'reset-follow-up: missing <TICKET>. Ticket id must match /^[A-Z]+-\\d+$/.\n'
+    );
+    return 1;
+  }
+  const ticket = positional[0];
+
+  if (!TICKET_RE.test(ticket)) {
+    process.stderr.write(
+      `reset-follow-up: invalid ticket id "${ticket}" — must match /^[A-Z]+-\\d+$/.\n`
+    );
+    return 1;
+  }
+
+  if (!flags.yes && !flags.dryRun) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          ok: false,
+          ticket,
+          needsConfirm: true,
+          suggested: `node ${path.basename(__filename)} ${ticket} --yes`,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return 0;
+  }
+
+  const TASKS_BASE = resolveTasksBase();
+  const ticketDir = path.join(TASKS_BASE, ticket);
+  assertContained(ticketDir, TASKS_BASE);
+
+  const removed = [];
+  for (const name of STATE_FILES) {
+    const p = path.join(ticketDir, name);
+    assertContained(p, TASKS_BASE);
+    if (flags.dryRun) {
+      if (fs.existsSync(p)) removed.push(name);
+      continue;
+    }
+    if (safeUnlink(p)) removed.push(name);
+  }
+
+  if (flags.dryRun) {
+    process.stdout.write(
+      `${JSON.stringify({ ok: true, ticket, removed, reinit: false, dryRun: true }, null, 2)}\n`
+    );
+    return 0;
+  }
+
+  // Re-initialize fresh state via Task 1's helper.
+  const { initFreshState } = require(path.join(__dirname, 'follow-up-next.js'));
+  initFreshState(ticket);
+
+  // Provenance row.
+  appendProvenance(ticketDir, ticket);
+
+  process.stdout.write(`${JSON.stringify({ ok: true, ticket, removed, reinit: true }, null, 2)}\n`);
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exit(run(process.argv.slice(2)));
+  } catch (err) {
+    process.stderr.write(`reset-follow-up: ${err && err.message ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+}
+
+module.exports = { run };

--- a/plugins/work/scripts/workflows/follow-up/reset-follow-up.js
+++ b/plugins/work/scripts/workflows/follow-up/reset-follow-up.js
@@ -108,23 +108,53 @@ function appendProvenance(ticketDir, ticket) {
   fs.writeFileSync(actionsPath, `${JSON.stringify(rows, null, 2)}\n`);
 }
 
-function run(argv) {
-  const { positional, flags } = parseArgs(argv);
-
+function validateTicket(positional) {
   if (positional.length < 1) {
     process.stderr.write(
       'reset-follow-up: missing <TICKET>. Ticket id must match /^[A-Z]+-\\d+$/.\n'
     );
-    return 1;
+    return null;
   }
   const ticket = positional[0];
-
   if (!TICKET_RE.test(ticket)) {
     process.stderr.write(
       `reset-follow-up: invalid ticket id "${ticket}" — must match /^[A-Z]+-\\d+$/.\n`
     );
-    return 1;
+    return null;
   }
+  return ticket;
+}
+
+function readPreservedPrNumber(ticketDir) {
+  try {
+    const raw = fs.readFileSync(path.join(ticketDir, '.follow-up-state.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && parsed.prNumber != null ? parsed.prNumber : null;
+  } catch {
+    return null;
+  }
+}
+
+function removeStateFiles(ticketDir, TASKS_BASE, dryRun) {
+  const removed = [];
+  for (const name of STATE_FILES) {
+    const p = path.join(ticketDir, name);
+    assertContained(p, TASKS_BASE);
+    const exists = fs.existsSync(p);
+    if (dryRun) {
+      if (exists) removed.push(name);
+    } else if (safeUnlink(p)) {
+      removed.push(name);
+    }
+  }
+  return removed;
+}
+
+function run(argv) {
+  const { positional, flags } = parseArgs(argv);
+
+  const ticket = validateTicket(positional);
+  if (!ticket) return 1;
 
   if (!flags.yes && !flags.dryRun) {
     process.stdout.write(
@@ -146,28 +176,10 @@ function run(argv) {
   const ticketDir = path.join(TASKS_BASE, ticket);
   assertContained(ticketDir, TASKS_BASE);
 
-  // Preserve the saved PR number across reset so follow-up re-entry can
-  // still reach the PR after a cap-blocked cycle (GH-531).
-  let preservedPrNumber = null;
-  try {
-    const statePath = path.join(ticketDir, '.follow-up-state.json');
-    const raw = fs.readFileSync(statePath, 'utf8');
-    const parsed = JSON.parse(raw);
-    if (parsed && parsed.prNumber != null) preservedPrNumber = parsed.prNumber;
-  } catch {
-    // ENOENT or parse error — nothing to preserve.
-  }
-
-  const removed = [];
-  for (const name of STATE_FILES) {
-    const p = path.join(ticketDir, name);
-    assertContained(p, TASKS_BASE);
-    if (flags.dryRun) {
-      if (fs.existsSync(p)) removed.push(name);
-      continue;
-    }
-    if (safeUnlink(p)) removed.push(name);
-  }
+  // Preserve the saved PR number across reset (GH-531) so follow-up re-entry
+  // can still reach the PR after a cap-blocked cycle.
+  const preservedPrNumber = readPreservedPrNumber(ticketDir);
+  const removed = removeStateFiles(ticketDir, TASKS_BASE, flags.dryRun);
 
   if (flags.dryRun) {
     process.stdout.write(
@@ -176,11 +188,8 @@ function run(argv) {
     return 0;
   }
 
-  // Re-initialize fresh state via Task 1's helper, preserving any prior PR number.
   const { initFreshState } = require(path.join(__dirname, 'follow-up-next.js'));
   initFreshState(ticket, { prNumber: preservedPrNumber });
-
-  // Provenance row.
   appendProvenance(ticketDir, ticket);
 
   process.stdout.write(`${JSON.stringify({ ok: true, ticket, removed, reinit: true }, null, 2)}\n`);

--- a/plugins/work/scripts/workflows/follow-up/reset-follow-up.js
+++ b/plugins/work/scripts/workflows/follow-up/reset-follow-up.js
@@ -146,6 +146,18 @@ function run(argv) {
   const ticketDir = path.join(TASKS_BASE, ticket);
   assertContained(ticketDir, TASKS_BASE);
 
+  // Preserve the saved PR number across reset so follow-up re-entry can
+  // still reach the PR after a cap-blocked cycle (GH-531).
+  let preservedPrNumber = null;
+  try {
+    const statePath = path.join(ticketDir, '.follow-up-state.json');
+    const raw = fs.readFileSync(statePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.prNumber != null) preservedPrNumber = parsed.prNumber;
+  } catch {
+    // ENOENT or parse error — nothing to preserve.
+  }
+
   const removed = [];
   for (const name of STATE_FILES) {
     const p = path.join(ticketDir, name);
@@ -164,9 +176,9 @@ function run(argv) {
     return 0;
   }
 
-  // Re-initialize fresh state via Task 1's helper.
+  // Re-initialize fresh state via Task 1's helper, preserving any prior PR number.
   const { initFreshState } = require(path.join(__dirname, 'follow-up-next.js'));
-  initFreshState(ticket);
+  initFreshState(ticket, { prNumber: preservedPrNumber });
 
   // Provenance row.
   appendProvenance(ticketDir, ticket);

--- a/plugins/work/scripts/workflows/follow-up/reset-follow-up.js
+++ b/plugins/work/scripts/workflows/follow-up/reset-follow-up.js
@@ -92,8 +92,18 @@ function appendProvenance(ticketDir, ticket) {
     const parsed = JSON.parse(raw);
     rows = Array.isArray(parsed) ? parsed : Array.isArray(parsed.actions) ? parsed.actions : [];
   } catch (err) {
-    if (!err || err.code !== 'ENOENT') {
-      // Corrupt file — start a fresh array rather than fail the reset.
+    if (err && err.code === 'ENOENT') {
+      rows = [];
+    } else {
+      // Corrupt file — preserve the existing contents under a timestamped
+      // sibling so the audit trail isn't silently dropped, then start fresh.
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+      try {
+        fs.renameSync(actionsPath, `${actionsPath}.corrupt-${stamp}`);
+      } catch {
+        // best-effort — if rename fails (e.g. file gone between read+rename)
+        // we still want the reset to proceed with a fresh provenance row.
+      }
       rows = [];
     }
   }

--- a/plugins/work/scripts/workflows/follow-up/reset-follow-up.js
+++ b/plugins/work/scripts/workflows/follow-up/reset-follow-up.js
@@ -53,9 +53,8 @@ function parseArgs(argv) {
 }
 
 function resolveTasksBase() {
-  const base =
-    getConfig('TASKS_BASE') ||
-    (process.env.WORKTREES_BASE ? path.join(process.env.WORKTREES_BASE, 'tasks') : '');
+  const worktreesBase = getConfig('WORKTREES_BASE') || process.env.WORKTREES_BASE;
+  const base = getConfig('TASKS_BASE') || (worktreesBase ? path.join(worktreesBase, 'tasks') : '');
   if (!base) {
     process.stderr.write(
       'reset-follow-up: TASKS_BASE not configured (check .envrc / get-config).\n'

--- a/plugins/work/scripts/workflows/lib/workflow-engine.js
+++ b/plugins/work/scripts/workflows/lib/workflow-engine.js
@@ -401,6 +401,15 @@ function main() {
     return;
   }
 
+  // GH-531 R2: `reset-follow-up <TICKET>` — wipe `/follow-up` state files and
+  // re-initialize a fresh state. Routed through workflow-engine.js so it
+  // inherits the existing EXEMPT_SCRIPTS write-rights and does not trip
+  // `protect-state-files` (no new exemption entry is added).
+  if (args[0] === 'reset-follow-up') {
+    const { run } = require(path.join(__dirname, '..', 'follow-up', 'reset-follow-up.js'));
+    process.exit(run(args.slice(1)));
+  }
+
   const workflowName = args[0];
   const command = args[1] || 'plan';
   const rest = args.slice(2);

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-comments-stale-copilot-integration.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-comments-stale-copilot-integration.test.js
@@ -195,4 +195,37 @@ describe('follow-up-pr-comments — handleSnapshot wires Copilot stale-thread he
       'resolution should reference the Copilot stale-thread heuristic'
     );
   });
+
+  it('Fixture C: threadId-only previousStatus (no .status) still routes to Copilot heuristic', () => {
+    // Seed prior state with a threadId-only entry (GH-358-style preservation
+    // for non-terminal comments). Without the `!previousStatus?.status` guard,
+    // the truthy previousStatus would skip the Copilot default and the
+    // snapshot would auto-resolve the unchanged-hunk thread.
+    const ticketDir = path.join(tmpDir, 'GH-531');
+    fs.mkdirSync(ticketDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(ticketDir, 'follow-up-comments.json'),
+      JSON.stringify({ comments: [{ id: 9003, threadId: 'thread-abc' }] })
+    );
+
+    installFollowUpPrMock([makeCopilotOutdatedComment({ id: 9003 })]);
+    installGitHunkMock(false); // hunk UNCHANGED — must stay unsolved
+    const mod = loadScript();
+
+    const code = runSnapshotCatchingExit(mod, '123');
+    assert.equal(code, 0);
+
+    const state = JSON.parse(
+      fs.readFileSync(path.join(ticketDir, 'follow-up-comments.json'), 'utf8')
+    );
+    const c = state.comments.find((x) => x.id === 9003);
+    assert.ok(c, 'comment 9003 must be in the snapshot');
+    assert.equal(
+      c.status,
+      'unsolved',
+      'threadId-only previousStatus must not bypass the Copilot stale-thread guard'
+    );
+    assert.equal(c.resolution, null);
+    assert.equal(c.threadId, 'thread-abc', 'threadId should be preserved');
+  });
 });

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-comments-stale-copilot-integration.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-comments-stale-copilot-integration.test.js
@@ -1,0 +1,198 @@
+'use strict';
+
+/**
+ * Integration test: handleSnapshot() must invoke the Copilot stale-thread
+ * heuristic (classifyOutdatedCopilotThread) in the outdated-thread branch
+ * so that R1 actually flips the per-comment status based on
+ * gitHunkChangedSince(...) instead of unconditionally stamping 'resolved'.
+ *
+ * We mock:
+ *   - ../follow-up-pr (ghExec / getResolvedCommentIds / hash / priority)
+ *   - ../../follow-up/lib/git-hunk-changed (gitHunkChangedSince)
+ *   - TASKS_BASE + WORK_TICKET_ID env so state is written to a tmp dir.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const SCRIPT_PATH = path.resolve(__dirname, '..', 'follow-up-pr-comments.js');
+const FOLLOW_UP_PR_PATH = path.resolve(__dirname, '..', 'follow-up-pr.js');
+const GIT_HUNK_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'follow-up',
+  'lib',
+  'git-hunk-changed.js'
+);
+
+function makeCopilotOutdatedComment(overrides = {}) {
+  return {
+    id: 9001,
+    user: { login: 'copilot-pull-request-reviewer' },
+    body: 'Consider null-checking here',
+    path: 'src/handler.js',
+    line: null,
+    original_line: 42,
+    position: null,
+    original_position: 5,
+    position_outdated: true,
+    created_at: '2026-05-01T00:00:00Z',
+    in_reply_to_id: null,
+    ...overrides,
+  };
+}
+
+function installFollowUpPrMock(inlineComments) {
+  delete require.cache[FOLLOW_UP_PR_PATH];
+  const fakeModule = {
+    ghExec(cmd) {
+      // cmd may be string ("repo view --json nameWithOwner", "pr view N --json reviews")
+      // or array (["api", "repos/...pulls/N/comments?..."])
+      if (typeof cmd === 'string') {
+        if (cmd.includes('repo view')) return { nameWithOwner: 'acme/widgets' };
+        if (cmd.includes('pr view')) return { reviews: [] };
+      }
+      if (Array.isArray(cmd) && cmd[0] === 'api') {
+        const url = String(cmd[1] || '');
+        // Return the comments on page=1, empty on page>=2 to terminate pagination.
+        if (/page=1\b/.test(url)) return inlineComments;
+        return [];
+      }
+      return null;
+    },
+    getResolvedCommentIds() {
+      return { resolved: new Set(), outdatedThreadIds: new Set() };
+    },
+    computeCommentHash(p, b) {
+      return `${p || 'null'}::${(b || '').slice(0, 16)}`;
+    },
+    classifyCommentPriority() {
+      return 'medium';
+    },
+  };
+  require.cache[FOLLOW_UP_PR_PATH] = {
+    id: FOLLOW_UP_PR_PATH,
+    filename: FOLLOW_UP_PR_PATH,
+    loaded: true,
+    exports: fakeModule,
+    children: [],
+    paths: [],
+  };
+}
+
+function installGitHunkMock(returnValue) {
+  delete require.cache[GIT_HUNK_PATH];
+  require.cache[GIT_HUNK_PATH] = {
+    id: GIT_HUNK_PATH,
+    filename: GIT_HUNK_PATH,
+    loaded: true,
+    exports: {
+      gitHunkChangedSince() {
+        return returnValue;
+      },
+    },
+    children: [],
+    paths: [],
+  };
+}
+
+function loadScript() {
+  delete require.cache[SCRIPT_PATH];
+  return require(SCRIPT_PATH);
+}
+
+describe('follow-up-pr-comments — handleSnapshot wires Copilot stale-thread heuristic (R1)', () => {
+  let tmpDir;
+  let prevTasksBase;
+  let prevTicketId;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fupcc-int-'));
+    prevTasksBase = process.env.TASKS_BASE;
+    prevTicketId = process.env.WORK_TICKET_ID;
+    process.env.TASKS_BASE = tmpDir;
+    process.env.WORK_TICKET_ID = 'GH-531';
+  });
+
+  afterEach(() => {
+    if (prevTasksBase === undefined) delete process.env.TASKS_BASE;
+    else process.env.TASKS_BASE = prevTasksBase;
+    if (prevTicketId === undefined) delete process.env.WORK_TICKET_ID;
+    else process.env.WORK_TICKET_ID = prevTicketId;
+    delete require.cache[FOLLOW_UP_PR_PATH];
+    delete require.cache[GIT_HUNK_PATH];
+    delete require.cache[SCRIPT_PATH];
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runSnapshotCatchingExit(mod, pr) {
+    const origExit = process.exit;
+    let exitCode = null;
+    process.exit = (code) => {
+      if (exitCode === null) {
+        exitCode = code;
+        throw new Error(`__exit_${code}__`);
+      }
+      // Suppress subsequent exits (handleSnapshot's catch may call exit(2)
+      // after intercepting our thrown sentinel — we already captured the
+      // real exit code from the first call).
+    };
+    try {
+      try {
+        mod.handleSnapshot(pr);
+      } catch (e) {
+        if (!/^__exit_/.test(e.message)) throw e;
+      }
+    } finally {
+      process.exit = origExit;
+    }
+    return exitCode;
+  }
+
+  it('Fixture A: code UNCHANGED since created_at → comment remains unsolved (no false positive)', () => {
+    installFollowUpPrMock([makeCopilotOutdatedComment()]);
+    installGitHunkMock(false); // hunk did NOT change
+    const mod = loadScript();
+
+    const code = runSnapshotCatchingExit(mod, '123');
+    assert.equal(code, 0, 'handleSnapshot should exit 0 on success');
+
+    const statePath = path.join(tmpDir, 'GH-531', 'follow-up-comments.json');
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assert.equal(state.comments.length, 1);
+    const c = state.comments[0];
+    assert.equal(c.id, 9001);
+    assert.equal(
+      c.status,
+      'unsolved',
+      'Copilot stale-thread heuristic must NOT auto-resolve when hunk is unchanged'
+    );
+    assert.equal(c.resolution, null);
+  });
+
+  it('Fixture B: code CHANGED since created_at → comment resolved with stale-thread reason', () => {
+    installFollowUpPrMock([makeCopilotOutdatedComment({ id: 9002 })]);
+    installGitHunkMock(true); // hunk CHANGED
+    const mod = loadScript();
+
+    const code = runSnapshotCatchingExit(mod, '123');
+    assert.equal(code, 0);
+
+    const statePath = path.join(tmpDir, 'GH-531', 'follow-up-comments.json');
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assert.equal(state.comments.length, 1);
+    const c = state.comments[0];
+    assert.equal(c.id, 9002);
+    assert.equal(c.status, 'resolved');
+    assert.match(
+      c.resolution || '',
+      /Copilot stale-thread heuristic/,
+      'resolution should reference the Copilot stale-thread heuristic'
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-comments-stale-copilot.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-comments-stale-copilot.test.js
@@ -1,9 +1,8 @@
 'use strict';
 
-const { describe, it, beforeEach, afterEach, mock } = require('node:test');
+const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
-const Module = require('node:module');
 
 const SCRIPT_PATH = path.join(__dirname, '..', 'follow-up-pr-comments.js');
 const GIT_HUNK_REQUEST_PATH = path.resolve(

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-comments-stale-copilot.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-comments-stale-copilot.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const SCRIPT_PATH = path.join(__dirname, '..', 'follow-up-pr-comments.js');
+const GIT_HUNK_REQUEST_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'follow-up',
+  'lib',
+  'git-hunk-changed.js'
+);
+
+/**
+ * Inject a mock for `git-hunk-changed.js` into the require cache so that
+ * when `follow-up-pr-comments.js` does `require('.../git-hunk-changed')`,
+ * it receives our stubbed implementation. We also clear the script cache
+ * so a fresh require picks up the mock.
+ */
+function installGitHunkMock(returnValue, calls) {
+  // Clear any existing cached script + mock target.
+  delete require.cache[SCRIPT_PATH];
+  delete require.cache[GIT_HUNK_REQUEST_PATH];
+
+  const fakeModule = {
+    gitHunkChangedSince(filePath, originalLine, sinceIso, ctx) {
+      calls.push({ filePath, originalLine, sinceIso, ctx });
+      return typeof returnValue === 'function'
+        ? returnValue({ filePath, originalLine, sinceIso, ctx })
+        : returnValue;
+    },
+  };
+
+  // Pre-seed require cache for git-hunk-changed.
+  require.cache[GIT_HUNK_REQUEST_PATH] = {
+    id: GIT_HUNK_REQUEST_PATH,
+    filename: GIT_HUNK_REQUEST_PATH,
+    loaded: true,
+    exports: fakeModule,
+    children: [],
+    paths: [],
+  };
+}
+
+function loadScript() {
+  delete require.cache[SCRIPT_PATH];
+  return require(SCRIPT_PATH);
+}
+
+function makeCopilotOutdatedComment(overrides = {}) {
+  return {
+    id: 9001,
+    user: { login: 'copilot-pull-request-reviewer' },
+    body: 'Consider null-checking here',
+    path: 'src/handler.js',
+    line: null,
+    original_line: 42,
+    position: null,
+    original_position: 5,
+    position_outdated: true,
+    created_at: '2026-05-01T00:00:00Z',
+    in_reply_to_id: null,
+    ...overrides,
+  };
+}
+
+describe('follow-up-pr-comments — Copilot stale-thread heuristic', () => {
+  let calls;
+
+  beforeEach(() => {
+    calls = [];
+  });
+
+  afterEach(() => {
+    delete require.cache[GIT_HUNK_REQUEST_PATH];
+    delete require.cache[SCRIPT_PATH];
+  });
+
+  it('Copilot stale thread auto-resolved when code changed since created_at', () => {
+    installGitHunkMock(true, calls);
+    const mod = loadScript();
+
+    assert.equal(
+      typeof mod.classifyOutdatedCopilotThread,
+      'function',
+      'follow-up-pr-comments.js must export classifyOutdatedCopilotThread for stale-thread heuristic'
+    );
+
+    const comment = makeCopilotOutdatedComment();
+    const result = mod.classifyOutdatedCopilotThread(comment, {
+      previousStatus: null,
+    });
+
+    assert.equal(result.status, 'resolved');
+    assert.match(
+      result.resolution,
+      /Copilot stale-thread heuristic/,
+      'resolution should reference the Copilot stale-thread heuristic'
+    );
+    // gitHunkChangedSince must have been consulted with the original line + created_at.
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].filePath, 'src/handler.js');
+    assert.equal(calls[0].originalLine, 42);
+    assert.equal(calls[0].sinceIso, '2026-05-01T00:00:00Z');
+  });
+
+  it('Stale-thread heuristic does not false-positive on unchanged code', () => {
+    installGitHunkMock(false, calls);
+    const mod = loadScript();
+
+    assert.equal(typeof mod.classifyOutdatedCopilotThread, 'function');
+
+    const comment = makeCopilotOutdatedComment({ id: 9002 });
+    const result = mod.classifyOutdatedCopilotThread(comment, {
+      previousStatus: null,
+    });
+
+    assert.equal(
+      result.status,
+      'unsolved',
+      'unchanged code must NOT be marked resolved by the heuristic'
+    );
+    assert.equal(
+      result.resolution,
+      null,
+      'unchanged-code path must leave resolution null (no false positive)'
+    );
+    assert.equal(calls.length, 1, 'heuristic must still consult gitHunkChangedSince');
+  });
+});

--- a/plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js
+++ b/plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js
@@ -428,7 +428,7 @@ function handleSnapshot(prNumber) {
               line: cm.line || cm.original_line || null,
               original_line: cm.original_line || null,
               priority: classifyCommentPriority(author, body),
-              status: previousStatus ? previousStatus.status : defaultStatus,
+              status: previousStatus?.status || defaultStatus,
               commitSha: previousStatus?.commitSha || null,
               resolution: previousStatus?.resolution || defaultResolution,
               threadId: commentIdToThreadId.get(cm.id) || previousStatus?.threadId || null,

--- a/plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js
+++ b/plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js
@@ -50,6 +50,82 @@ function getFollowUpPr() {
 
 const getConfig = require('../../lib/get-config');
 const { getCurrentTaskId } = require('../../lib/scripts/get-ticket-id');
+const { gitHunkChangedSince } = require('../../follow-up/lib/git-hunk-changed');
+
+const COPILOT_AUTHORS = new Set([
+  'copilot-pull-request-reviewer',
+  'copilot-pull-request-reviewer[bot]',
+  'github-copilot[bot]',
+  'copilot',
+]);
+
+function isCopilotAuthor(login) {
+  if (!login) return false;
+  return COPILOT_AUTHORS.has(String(login).toLowerCase());
+}
+
+/**
+ * Classify a Copilot review thread that GitHub marks as outdated
+ * (line === null, position === null but original_position !== null,
+ * and/or position_outdated === true).
+ *
+ * Returns { status, resolution } where:
+ *   - status === 'resolved' when `gitHunkChangedSince` confirms the
+ *     originally-commented line actually changed since `created_at`
+ *     (R1 — Copilot stale-thread heuristic);
+ *   - status === 'unsolved', resolution null when the hunk has NOT
+ *     changed since `created_at` (AC5 — no false positives).
+ *
+ * For non-Copilot threads the heuristic is NOT applied — callers fall
+ * back to the existing "Outdated (code changed since comment)" path.
+ *
+ * `previousStatus` lets us preserve any prior recorded state (so a
+ * thread the user already marked solved/skipped stays that way).
+ *
+ * @param {object} cm GitHub PR review comment payload.
+ * @param {{ previousStatus?: {status:string,resolution:string,commitSha?:string}|null, logger?: (msg:string)=>void }} [opts]
+ * @returns {{ status: 'resolved'|'unsolved', resolution: string|null, applied: boolean }}
+ */
+function classifyOutdatedCopilotThread(cm, opts = {}) {
+  const { previousStatus = null, logger = console.error } = opts;
+  if (previousStatus && previousStatus.status) {
+    return {
+      status: previousStatus.status,
+      resolution: previousStatus.resolution || null,
+      applied: false,
+    };
+  }
+  const author = cm?.user?.login || '';
+  if (!isCopilotAuthor(author)) {
+    return { status: 'resolved', resolution: null, applied: false };
+  }
+  const filePath = cm?.path || null;
+  const originalLine = cm?.original_line || null;
+  const createdAt = cm?.created_at || null;
+  if (!filePath || !originalLine || !createdAt) {
+    return { status: 'unsolved', resolution: null, applied: false };
+  }
+  let changed = false;
+  try {
+    changed = gitHunkChangedSince(filePath, originalLine, createdAt, {});
+  } catch (err) {
+    logger(
+      `[follow-up-pr-comments] gitHunkChangedSince failed for ${filePath}:${originalLine} — ${err.message}`
+    );
+    return { status: 'unsolved', resolution: null, applied: false };
+  }
+  if (changed) {
+    logger(
+      `[follow-up-pr-comments] Copilot stale-thread heuristic fired for comment ${cm.id} (${filePath}:${originalLine})`
+    );
+    return {
+      status: 'resolved',
+      resolution: 'Outdated (Copilot stale-thread heuristic — code changed since created_at)',
+      applied: true,
+    };
+  }
+  return { status: 'unsolved', resolution: null, applied: false };
+}
 
 // ── Deprecation warnings (Task 3, GH-537) ────────────────────────────────────
 // Legacy flag aliases keep working for a 2-3 release window but must emit

--- a/plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js
+++ b/plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js
@@ -410,7 +410,7 @@ function handleSnapshot(prNumber) {
             if (classification.applied) {
               defaultStatus = classification.status;
               defaultResolution = classification.resolution;
-            } else if (isCopilotAuthor(author) && !previousStatus) {
+            } else if (isCopilotAuthor(author) && !previousStatus?.status) {
               // Copilot author but helper said not-applied AND no prior
               // status — that means the hunk did NOT change since
               // created_at (AC5: no false positives). Keep the comment

--- a/plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js
+++ b/plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js
@@ -773,4 +773,6 @@ if (require.main === module) {
 module.exports = {
   solveLocally,
   skipLocally,
+  classifyOutdatedCopilotThread,
+  isCopilotAuthor,
 };

--- a/plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js
+++ b/plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js
@@ -395,6 +395,30 @@ function handleSnapshot(prNumber) {
             const hashKey = String(cm.id);
             if (seenHashes.has(hashKey)) continue;
             seenHashes.add(hashKey);
+
+            // R1 — Copilot stale-thread heuristic: for Copilot-authored
+            // threads with line:null + position_outdated semantics, only
+            // declare the thread resolved when the originally-commented
+            // hunk has actually changed since `created_at`. Non-Copilot
+            // threads fall through to the legacy unconditional 'resolved'.
+            const previousStatus = previousStatusMap.get(String(cm.id)) || null;
+            let defaultStatus = 'resolved';
+            let defaultResolution = 'Outdated (code changed since comment)';
+            const classification = classifyOutdatedCopilotThread(cm, {
+              previousStatus,
+            });
+            if (classification.applied) {
+              defaultStatus = classification.status;
+              defaultResolution = classification.resolution;
+            } else if (isCopilotAuthor(author) && !previousStatus) {
+              // Copilot author but helper said not-applied AND no prior
+              // status — that means the hunk did NOT change since
+              // created_at (AC5: no false positives). Keep the comment
+              // surfaced as unsolved instead of auto-resolving.
+              defaultStatus = classification.status; // 'unsolved'
+              defaultResolution = classification.resolution; // null
+            }
+
             comments.push({
               id: cm.id,
               hash: computeCommentHash(filePath, body),
@@ -404,17 +428,10 @@ function handleSnapshot(prNumber) {
               line: cm.line || cm.original_line || null,
               original_line: cm.original_line || null,
               priority: classifyCommentPriority(author, body),
-              status: previousStatusMap.get(String(cm.id))?.status
-                ? previousStatusMap.get(String(cm.id)).status
-                : 'resolved',
-              commitSha: previousStatusMap.get(String(cm.id))?.commitSha || null,
-              resolution:
-                previousStatusMap.get(String(cm.id))?.resolution ||
-                'Outdated (code changed since comment)',
-              threadId:
-                commentIdToThreadId.get(cm.id) ||
-                previousStatusMap.get(String(cm.id))?.threadId ||
-                null,
+              status: previousStatus ? previousStatus.status : defaultStatus,
+              commitSha: previousStatus?.commitSha || null,
+              resolution: previousStatus?.resolution || defaultResolution,
+              threadId: commentIdToThreadId.get(cm.id) || previousStatus?.threadId || null,
             });
             continue;
           }
@@ -775,4 +792,5 @@ module.exports = {
   skipLocally,
   classifyOutdatedCopilotThread,
   isCopilotAuthor,
+  handleSnapshot,
 };

--- a/tests/e2e/follow-up-recovery.spec.js
+++ b/tests/e2e/follow-up-recovery.spec.js
@@ -21,12 +21,12 @@
  *   - "Existing follow-up state files remain compatible after deploy"
  */
 
-const { describe, it, before, after, beforeEach } = require('node:test');
+const { describe, it, after, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync, spawnSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const RESET_SCRIPT = path.join(
@@ -36,7 +36,7 @@ const RESET_SCRIPT = path.join(
   'scripts',
   'workflows',
   'follow-up',
-  'reset-follow-up.js',
+  'reset-follow-up.js'
 );
 const ENGINE_SCRIPT = path.join(
   REPO_ROOT,
@@ -45,16 +45,7 @@ const ENGINE_SCRIPT = path.join(
   'scripts',
   'workflows',
   'lib',
-  'workflow-engine.js',
-);
-const FOLLOW_UP_NEXT = path.join(
-  REPO_ROOT,
-  'plugins',
-  'work',
-  'scripts',
-  'workflows',
-  'follow-up',
-  'follow-up-next.js',
+  'workflow-engine.js'
 );
 const PUSH_RETRY = path.join(
   REPO_ROOT,
@@ -65,7 +56,7 @@ const PUSH_RETRY = path.join(
   'follow-up',
   'lib',
   'steps',
-  'push-retry.js',
+  'push-retry.js'
 );
 
 const TICKET = 'GH-999931';
@@ -158,7 +149,7 @@ describe('GH-531 e2e — Operator recovers from cap-exhausted dead-end via reset
         currentStep: 'push-retry',
         _pushRetryCount: 40,
         maxAttempts: 40,
-      }),
+      })
     );
     fs.writeFileSync(commentsFile, JSON.stringify({ comments: [] }));
 
@@ -173,18 +164,18 @@ describe('GH-531 e2e — Operator recovers from cap-exhausted dead-end via reset
         maxAttempts: 40,
         _pushRetryCount: 39,
       },
-      { worktreeDir: ticketDir },
+      { worktreeDir: ticketDir }
     );
     assert.equal(blocked.action, 'blocked', 'expected blocked action at cap');
     assert.ok(
-      typeof blocked.instruction === 'string'
-        && blocked.instruction.includes('reset-follow-up'),
-      'expected instruction referencing reset-follow-up',
+      typeof blocked.instruction === 'string' && blocked.instruction.includes('reset-follow-up'),
+      'expected instruction referencing reset-follow-up'
     );
     assert.ok(blocked.instruction.includes(TICKET), 'instruction must include ticket');
     assert.equal(blocked.nextAction.command, 'workflow-engine');
     assert.equal(blocked.nextAction.subcommand, 'reset-follow-up');
-    assert.deepEqual(blocked.nextAction.args, [TICKET]);
+    assert.deepEqual(blocked.nextAction.args, [TICKET, '--yes']);
+    assert.ok(blocked.instruction.includes('--yes'), 'instruction must include --yes');
 
     // 2) Run reset via workflow-engine dispatcher (so we exercise the EXEMPT
     //    route used in production — not just the module directly).
@@ -196,11 +187,11 @@ describe('GH-531 e2e — Operator recovers from cap-exhausted dead-end via reset
     assert.equal(resetPayload.reinit, true);
     assert.ok(
       resetPayload.removed.includes('.follow-up-state.json'),
-      'expected .follow-up-state.json in removed list',
+      'expected .follow-up-state.json in removed list'
     );
     assert.ok(
       resetPayload.removed.includes('follow-up-comments.json'),
-      'expected follow-up-comments.json in removed list',
+      'expected follow-up-comments.json in removed list'
     );
 
     // 3) Old comments file removed; fresh state file re-initialized.
@@ -216,12 +207,12 @@ describe('GH-531 e2e — Operator recovers from cap-exhausted dead-end via reset
     assert.equal(
       fresh._pushRetryCount,
       0,
-      `fresh state must explicitly reset _pushRetryCount to 0, got ${fresh._pushRetryCount}`,
+      `fresh state must explicitly reset _pushRetryCount to 0, got ${fresh._pushRetryCount}`
     );
     assert.equal(
       fresh.currentStep,
       'monitor',
-      'fresh state must re-enter the monitor step on next invocation',
+      'fresh state must re-enter the monitor step on next invocation'
     );
 
     // 4) Provenance row appended.
@@ -244,7 +235,7 @@ describe('GH-531 e2e — Operator recovers from cap-exhausted dead-end via reset
         maxAttempts: 40,
         _pushRetryCount: fresh._pushRetryCount || 0,
       },
-      { worktreeDir: ticketDir },
+      { worktreeDir: ticketDir }
     );
     // Either it loops to monitor (null/no-op) or it returns an execute payload,
     // but it MUST NOT immediately re-block at cap.
@@ -252,7 +243,7 @@ describe('GH-531 e2e — Operator recovers from cap-exhausted dead-end via reset
       assert.notEqual(
         reEntered.action,
         'blocked',
-        'post-reset push-retry must not re-block immediately',
+        'post-reset push-retry must not re-block immediately'
       );
     }
   });
@@ -285,7 +276,13 @@ describe('GH-531 e2e — Existing follow-up state files remain compatible after 
     // push-retry must respect the prior _pushRetryCount semantics for non-
     // Copilot causes: increment by 1 on a fresh entry (dispatched !== 'push-retry').
     const pushRetry = loadPushRetry();
-    const state = { ...loaded, currentStep: 'push-retry', dispatched: null, attempt: 0, maxAttempts: 40 };
+    const state = {
+      ...loaded,
+      currentStep: 'push-retry',
+      dispatched: null,
+      attempt: 0,
+      maxAttempts: 40,
+    };
     // We don't run the full step (it would shell out to git); we just assert
     // that the cap logic uses the prior counter as the floor.
     state._pushRetryCount = 39; // one shy of cap
@@ -310,7 +307,7 @@ describe('GH-531 e2e — Existing follow-up state files remain compatible after 
     assert.notEqual(
       after._pushRetryCount,
       7,
-      'fresh init must overwrite the legacy _pushRetryCount value',
+      'fresh init must overwrite the legacy _pushRetryCount value'
     );
   });
 });

--- a/tests/e2e/follow-up-recovery.spec.js
+++ b/tests/e2e/follow-up-recovery.spec.js
@@ -1,0 +1,316 @@
+'use strict';
+
+/**
+ * GH-531 Task 6 — Integration test: cap-exhausted recovery end-to-end.
+ *
+ * Verifies the full recovery path stitched together by Tasks 1–5:
+ *   - push-retry at cap returns a blocked payload with an actionable
+ *     `instruction` and `nextAction` referencing `reset-follow-up`
+ *     (Task 5 / R3).
+ *   - Running `workflow-engine reset-follow-up <TICKET> --yes` removes the
+ *     state files and re-initializes a fresh state via `initFreshState`
+ *     (Task 1 + Task 4 / R2).
+ *   - After reset, the follow-up driver can re-enter and does not infinite-
+ *     loop on the next push-retry cycle (AC1, AC2, AC10).
+ *   - A pre-existing/“prior-version” state file remains loadable and
+ *     `_pushRetryCount` semantics for non-Copilot causes are preserved
+ *     (AC11, C3).
+ *
+ * Scenario tags (parsed by task-next.js scope check):
+ *   - "Operator recovers from cap-exhausted dead-end via reset command"
+ *   - "Existing follow-up state files remain compatible after deploy"
+ */
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync, spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const RESET_SCRIPT = path.join(
+  REPO_ROOT,
+  'plugins',
+  'work',
+  'scripts',
+  'workflows',
+  'follow-up',
+  'reset-follow-up.js',
+);
+const ENGINE_SCRIPT = path.join(
+  REPO_ROOT,
+  'plugins',
+  'work',
+  'scripts',
+  'workflows',
+  'lib',
+  'workflow-engine.js',
+);
+const FOLLOW_UP_NEXT = path.join(
+  REPO_ROOT,
+  'plugins',
+  'work',
+  'scripts',
+  'workflows',
+  'follow-up',
+  'follow-up-next.js',
+);
+const PUSH_RETRY = path.join(
+  REPO_ROOT,
+  'plugins',
+  'work',
+  'scripts',
+  'workflows',
+  'follow-up',
+  'lib',
+  'steps',
+  'push-retry.js',
+);
+
+const TICKET = 'GH-999931';
+let sandbox;
+
+function freshSandbox() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh531-e2e-'));
+  const tasksBase = path.join(dir, 'tasks');
+  fs.mkdirSync(path.join(tasksBase, TICKET), { recursive: true });
+  return { dir, tasksBase };
+}
+
+function writePriorVersionState(tasksBase, ticket) {
+  // Simulates a state file written by a previous plugin release. It must
+  // remain loadable and the `_pushRetryCount` field must keep its semantic
+  // meaning for non-Copilot causes (C3 / AC11).
+  const statePath = path.join(tasksBase, ticket, '.follow-up-state.json');
+  const priorState = {
+    schemaVersion: 1,
+    ticketId: ticket,
+    currentStep: 'monitor',
+    status: 'in_progress',
+    _pushRetryCount: 7,
+    attempt: 0,
+    resolvedComments: [],
+    legacyField: 'should-not-break-load',
+  };
+  fs.writeFileSync(statePath, JSON.stringify(priorState, null, 2));
+  return statePath;
+}
+
+function runReset(tasksBase, args) {
+  const env = {
+    ...process.env,
+    TASKS_BASE: tasksBase,
+    USER: process.env.USER || 'e2e-test',
+  };
+  return spawnSync('node', [RESET_SCRIPT, ...args], {
+    env,
+    encoding: 'utf8',
+    timeout: 20000,
+  });
+}
+
+function runEngineReset(tasksBase, args) {
+  const env = {
+    ...process.env,
+    TASKS_BASE: tasksBase,
+    USER: process.env.USER || 'e2e-test',
+  };
+  return spawnSync('node', [ENGINE_SCRIPT, 'reset-follow-up', ...args], {
+    env,
+    encoding: 'utf8',
+    timeout: 20000,
+  });
+}
+
+function loadPushRetry() {
+  // Re-require fresh each time so module state can't leak between tests.
+  delete require.cache[require.resolve(PUSH_RETRY)];
+  const handlers = Object.create(null);
+  require(PUSH_RETRY)((name, fn) => {
+    handlers[name] = fn;
+  });
+  return handlers['push-retry'];
+}
+
+beforeEach(() => {
+  sandbox = freshSandbox();
+});
+
+after(() => {
+  if (sandbox) {
+    fs.rmSync(sandbox.dir, { recursive: true, force: true });
+  }
+});
+
+describe('GH-531 e2e — Operator recovers from cap-exhausted dead-end via reset command', () => {
+  it('push-retry → reset-follow-up → re-enter, no infinite loop', () => {
+    const { tasksBase } = sandbox;
+    const ticketDir = path.join(tasksBase, TICKET);
+    const stateFile = path.join(ticketDir, '.follow-up-state.json');
+    const commentsFile = path.join(ticketDir, 'follow-up-comments.json');
+
+    // Seed pre-existing state + comments so reset has something to remove.
+    fs.writeFileSync(
+      stateFile,
+      JSON.stringify({
+        ticketId: TICKET,
+        currentStep: 'push-retry',
+        _pushRetryCount: 40,
+        maxAttempts: 40,
+      }),
+    );
+    fs.writeFileSync(commentsFile, JSON.stringify({ comments: [] }));
+
+    // 1) push-retry at cap returns blocked payload with actionable instruction
+    const pushRetry = loadPushRetry();
+    const blocked = pushRetry(
+      {
+        ticketId: TICKET,
+        currentStep: 'push-retry',
+        dispatched: null,
+        attempt: 0,
+        maxAttempts: 40,
+        _pushRetryCount: 39,
+      },
+      { worktreeDir: ticketDir },
+    );
+    assert.equal(blocked.action, 'blocked', 'expected blocked action at cap');
+    assert.ok(
+      typeof blocked.instruction === 'string'
+        && blocked.instruction.includes('reset-follow-up'),
+      'expected instruction referencing reset-follow-up',
+    );
+    assert.ok(blocked.instruction.includes(TICKET), 'instruction must include ticket');
+    assert.equal(blocked.nextAction.command, 'workflow-engine');
+    assert.equal(blocked.nextAction.subcommand, 'reset-follow-up');
+    assert.deepEqual(blocked.nextAction.args, [TICKET]);
+
+    // 2) Run reset via workflow-engine dispatcher (so we exercise the EXEMPT
+    //    route used in production — not just the module directly).
+    const reset = runEngineReset(tasksBase, [TICKET, '--yes']);
+    assert.equal(reset.status, 0, `engine reset failed: ${reset.stderr}\n${reset.stdout}`);
+    const resetPayload = JSON.parse(reset.stdout.trim());
+    assert.equal(resetPayload.ok, true);
+    assert.equal(resetPayload.ticket, TICKET);
+    assert.equal(resetPayload.reinit, true);
+    assert.ok(
+      resetPayload.removed.includes('.follow-up-state.json'),
+      'expected .follow-up-state.json in removed list',
+    );
+    assert.ok(
+      resetPayload.removed.includes('follow-up-comments.json'),
+      'expected follow-up-comments.json in removed list',
+    );
+
+    // 3) Old comments file removed; fresh state file re-initialized.
+    assert.ok(!fs.existsSync(commentsFile), 'comments file should be wiped');
+    assert.ok(fs.existsSync(stateFile), 'fresh state file should be re-initialized');
+    const fresh = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+    assert.equal(fresh.ticketId, TICKET);
+    // The fresh state must explicitly zero the push-retry counter so that
+    // operators (and the auto-advance loop) can see the recovery without
+    // having to special-case `undefined`. This is the "no infinite re-trigger"
+    // guarantee from AC10 — the only way the next cycle can re-block at cap
+    // is by re-incrementing from a known 0.
+    assert.equal(
+      fresh._pushRetryCount,
+      0,
+      `fresh state must explicitly reset _pushRetryCount to 0, got ${fresh._pushRetryCount}`,
+    );
+    assert.equal(
+      fresh.currentStep,
+      'monitor',
+      'fresh state must re-enter the monitor step on next invocation',
+    );
+
+    // 4) Provenance row appended.
+    const actionsPath = path.join(ticketDir, '.work-actions.json');
+    assert.ok(fs.existsSync(actionsPath), 'provenance file must exist');
+    const rows = JSON.parse(fs.readFileSync(actionsPath, 'utf8'));
+    const resetRow = rows.find((r) => r.kind === 'reset-follow-up');
+    assert.ok(resetRow, 'expected reset-follow-up provenance row');
+    assert.equal(resetRow.ticket, TICKET);
+    assert.ok(resetRow.ts && /^\d{4}-\d{2}-\d{2}T/.test(resetRow.ts), 'ts must be ISO');
+
+    // 5) After reset, a *new* push-retry cycle does NOT immediately re-block —
+    //    the counter resets and the driver can re-enter monitor.
+    const reEntered = pushRetry(
+      {
+        ticketId: TICKET,
+        currentStep: 'push-retry',
+        dispatched: null,
+        attempt: 0,
+        maxAttempts: 40,
+        _pushRetryCount: fresh._pushRetryCount || 0,
+      },
+      { worktreeDir: ticketDir },
+    );
+    // Either it loops to monitor (null/no-op) or it returns an execute payload,
+    // but it MUST NOT immediately re-block at cap.
+    if (reEntered && reEntered.action) {
+      assert.notEqual(
+        reEntered.action,
+        'blocked',
+        'post-reset push-retry must not re-block immediately',
+      );
+    }
+  });
+
+  it('reset is idempotent — re-running after success does not error', () => {
+    const { tasksBase } = sandbox;
+    // First reset on empty state still succeeds (Task 4 AC9).
+    const r1 = runReset(tasksBase, [TICKET, '--yes']);
+    assert.equal(r1.status, 0, `first reset failed: ${r1.stderr}`);
+    const r2 = runReset(tasksBase, [TICKET, '--yes']);
+    assert.equal(r2.status, 0, `second reset failed: ${r2.stderr}`);
+    const payload2 = JSON.parse(r2.stdout.trim());
+    assert.equal(payload2.ok, true);
+    assert.equal(payload2.reinit, true);
+  });
+});
+
+describe('GH-531 e2e — Existing follow-up state files remain compatible after deploy', () => {
+  it('prior-version state loads without error and preserves _pushRetryCount semantics', () => {
+    const { tasksBase } = sandbox;
+    const statePath = writePriorVersionState(tasksBase, TICKET);
+
+    // The state file written by a prior plugin release must remain JSON-
+    // parseable and keep its `_pushRetryCount` value verbatim (C3 / AC11).
+    const loaded = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assert.equal(loaded.ticketId, TICKET);
+    assert.equal(loaded._pushRetryCount, 7, 'prior _pushRetryCount must be preserved on load');
+    assert.equal(loaded.legacyField, 'should-not-break-load');
+
+    // push-retry must respect the prior _pushRetryCount semantics for non-
+    // Copilot causes: increment by 1 on a fresh entry (dispatched !== 'push-retry').
+    const pushRetry = loadPushRetry();
+    const state = { ...loaded, currentStep: 'push-retry', dispatched: null, attempt: 0, maxAttempts: 40 };
+    // We don't run the full step (it would shell out to git); we just assert
+    // that the cap logic uses the prior counter as the floor.
+    state._pushRetryCount = 39; // one shy of cap
+    const result = pushRetry(state, { worktreeDir: path.dirname(statePath) });
+    assert.equal(result.action, 'blocked', 'cap behavior must trigger using the legacy counter');
+    assert.ok(result.instruction.includes('reset-follow-up'));
+  });
+
+  it('initFreshState round-trip: prior-version file can be replaced by a fresh init', () => {
+    const { tasksBase } = sandbox;
+    const statePath = writePriorVersionState(tasksBase, TICKET);
+    const prior = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assert.equal(prior._pushRetryCount, 7);
+
+    // Mutate TASKS_BASE for the duration of this require (initFreshState reads
+    // it from get-config / WORKTREES_BASE). Easiest path: spawn the engine.
+    const reset = runEngineReset(tasksBase, [TICKET, '--yes']);
+    assert.equal(reset.status, 0, `engine reset failed: ${reset.stderr}`);
+
+    const after = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assert.equal(after.ticketId, TICKET);
+    assert.notEqual(
+      after._pushRetryCount,
+      7,
+      'fresh init must overwrite the legacy _pushRetryCount value',
+    );
+  });
+});


### PR DESCRIPTION
## Existing Behavior

- The follow-up driver's `monitor → triage` cycle had no way to distinguish stale Copilot review threads (`line:null` + `position_outdated` after force-push) from genuinely unaddressed ones, causing infinite re-triage loops.
- When `_pushRetryCount` reached 40 in `push-retry.js`, the blocked result returned only a dead-end `reason` string with no actionable path for the agent or operator.
- There was no sanctioned command to wipe and re-initialize follow-up state; direct edits of the follow-up state file were blocked by the `protect-state-file` hook, leaving agents with only bypass options when retry exhaustion hit.

## Intended New Behavior

- `follow-up-pr-comments.js` now detects Copilot threads where `line:null` and `position_outdated` by calling the new `gitHunkChangedSince` helper; threads whose commented hunk has changed since `created_at` are auto-marked code-addressed locally, stopping the re-triage loop without touching the remote thread.
- `push-retry.js` at cap now returns a structured `nextAction` payload (`{ command: "workflow-engine", subcommand: "reset-follow-up", args: ["<TICKET>"] }`) alongside a human-readable `instruction` field so both agents and operators have a concrete, unambiguous recovery command rather than a dead-end string.
- `workflow-engine reset-follow-up <TICKET>` is a new sanctioned sub-command (backed by `reset-follow-up.js`) that wipes follow-up state and comments cache, re-initializes fresh state via `initFreshState()`, appends a provenance row to `.work-actions.json`, and exits 0 — all without triggering the protect-state-file hook.

## Brief P0 coverage

- **P0 #1:** Copilot stale-thread detection in `follow-up-pr-comments.js` wired into `handleSnapshot` — implemented in `plugins/work/scripts/workflows/work/scripts/follow-up-pr-comments.js` + `plugins/work/scripts/workflows/follow-up/lib/git-hunk-changed.js`; unit-tested in `follow-up-pr-comments-stale-copilot.test.js` and `follow-up-pr-comments-stale-copilot-integration.test.js`
- **P0 #2:** `reset-follow-up` command registered in `workflow-engine.js` — implemented in `plugins/work/scripts/workflows/follow-up/reset-follow-up.js` + `plugins/work/scripts/workflows/lib/workflow-engine.js`; tested in `reset-follow-up.test.js` and `follow-up-next-init-fresh-state.test.js`
- **P0 #3:** Actionable unblock message in `push-retry.js` when `_pushRetryCount >= maxAttempts` — implemented in `plugins/work/scripts/workflows/follow-up/lib/steps/push-retry.js`; tested in `push-retry.test.js`

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify stale Copilot thread detection:**
1. Obtain (or simulate) a PR where Copilot left review threads that are now `position_outdated` with `line: null`.
2. Run `workflow-engine follow-up <TICKET>` against that PR.
3. Confirm the follow-up driver marks those threads code-addressed locally and does not re-flag them on the next `monitor → triage` cycle.

**Verify push-retry exhaustion unblock message:**
1. Advance `_pushRetryCount` to the cap (40) via the workflow engine on a test ticket.
2. Trigger the push-retry step.
3. Confirm the result contains `action: "blocked"`, an `instruction` string referencing `reset-follow-up <TICKET>`, and a `nextAction` object `{ command: "workflow-engine", subcommand: "reset-follow-up", args: ["<TICKET>"] }`.

**Verify reset-follow-up command:**

Run: `workflow-engine reset-follow-up GH-XYZ --yes`

Expected: exit 0, JSON stdout `{ ok: true, ticket: "GH-XYZ", reinit: true, removed: [...] }`. Fresh follow-up state re-initialized with `attempt: 0, status: "in_progress"`. `.work-actions.json` gains a `{ kind: "reset-follow-up", ticket, ts, invoker }` provenance row.

**Run e2e recovery test:**

Run the spec at `tests/e2e/follow-up-recovery.spec.js` via the project's scoped test runner. All scenarios should pass: retry exhaustion → reset → re-entry without hook protection trip.

### Test Results
New test files are included in this PR covering all three P0 deliverables. Run them via the project's scoped dev-check tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes follow-up orchestration and sanctioned state-file wipes under TASKS_BASE; ticket validation and containment checks mitigate path traversal, but incorrect git heuristics could mis-classify Copilot comments.
> 
> **Overview**
> Adds a **recovery path** when the follow-up driver hits push-retry exhaustion, and **smarter local handling** of outdated Copilot PR review threads so monitor/triage does not loop forever.
> 
> **Push-retry cap → reset:** When `_pushRetryCount` reaches `maxAttempts`, `push-retry` now returns `instruction` plus structured `nextAction` pointing at `workflow-engine reset-follow-up <TICKET> --yes` instead of only a dead-end reason. New CLI `reset-follow-up.js` validates ticket IDs and path containment, wipes `.follow-up-state.json` and `follow-up-comments.json`, preserves `prNumber`, re-inits via exported **`initFreshState()`** in `follow-up-next.js` (with explicit `_pushRetryCount: 0`), and records provenance in `.work-actions.json`. **`workflow-engine`** registers the `reset-follow-up` top-level subcommand so writes stay on the existing exempt path and avoid `protect-state-files`.
> 
> **Copilot stale threads:** New **`gitHunkChangedSince`** uses `git log -L` to detect whether the commented line changed since `created_at`. **`follow-up-pr-comments.js`** applies `classifyOutdatedCopilotThread` in the outdated-inline branch of `handleSnapshot` so Copilot threads auto-resolve locally only when the hunk actually changed; unchanged code stays **unsolved** (including threadId-only prior state).
> 
> Coverage is added across unit, integration, and **`tests/e2e/follow-up-recovery.spec.js`** for the full cap → reset → re-enter flow and backward-compatible state loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d70f9346517d7ccd8270c56b87f704791fe0cae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->