### PR TITLE
feat(split-in-tasks): Type/AC mismatch validation + GREEN docs-exempt fallback in task-next

### DIFF
--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-changed-test-files-scope.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-changed-test-files-scope.test.js
@@ -1,0 +1,95 @@
+/**
+ * Tests for filterChangedTestFilesByScope helper in task-next.js.
+ *
+ * Cursor comment #3377758763 (Review Comment 4 — Medium):
+ *
+ *   detectChangedTestFilesInScope treats scope with exact paths or
+ *   directory prefixes only; it does not use the existing
+ *   fileMatchesScope glob logic. Tasks whose `### Files in scope` lists
+ *   patterns like `src/**` will not count modified in-scope test files,
+ *   so `Type=tests-only` GREEN can block even when the agent edited the
+ *   right tests.
+ *
+ * The pure helper `filterChangedTestFilesByScope(changedPaths, scope)`
+ * applies the same two filters that the production callsite applies
+ * (test-file extension AND scope match) but without the git lookup, so
+ * the scope-match semantics can be exercised directly.
+ *
+ * Run with:
+ *   node --test scripts/workflows/work-implement/__tests__/task-next-changed-test-files-scope.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const taskNext = require('../task-next');
+
+describe('filterChangedTestFilesByScope (glob-aware scope matching for tests-only GREEN)', () => {
+  it('is exported as a named export of task-next.js', () => {
+    assert.equal(
+      typeof taskNext.filterChangedTestFilesByScope,
+      'function',
+      'filterChangedTestFilesByScope must be a named export of task-next.js'
+    );
+  });
+
+  it('keeps a changed test file matched by an exact scope entry (legacy behavior)', () => {
+    const { filterChangedTestFilesByScope } = taskNext;
+    const result = filterChangedTestFilesByScope(
+      ['plugins/work/scripts/foo.test.js'],
+      ['plugins/work/scripts/foo.test.js']
+    );
+    assert.deepEqual(result, ['plugins/work/scripts/foo.test.js']);
+  });
+
+  it('keeps a changed test file matched by a directory-prefix scope entry (legacy behavior)', () => {
+    const { filterChangedTestFilesByScope } = taskNext;
+    const result = filterChangedTestFilesByScope(
+      ['plugins/work/scripts/sub/foo.test.js'],
+      ['plugins/work/scripts/sub']
+    );
+    assert.deepEqual(result, ['plugins/work/scripts/sub/foo.test.js']);
+  });
+
+  it('keeps a changed test file matched by a `**` glob scope entry (regression fix)', () => {
+    const { filterChangedTestFilesByScope } = taskNext;
+    const result = filterChangedTestFilesByScope(
+      ['plugins/work/scripts/workflows/work-implement/__tests__/x.test.js'],
+      ['plugins/work/**/*.test.js']
+    );
+    assert.deepEqual(result, ['plugins/work/scripts/workflows/work-implement/__tests__/x.test.js']);
+  });
+
+  it('keeps a changed test file matched by a single-`*` glob segment', () => {
+    const { filterChangedTestFilesByScope } = taskNext;
+    const result = filterChangedTestFilesByScope(
+      ['plugins/work/scripts/foo.test.js'],
+      ['plugins/work/scripts/*.test.js']
+    );
+    assert.deepEqual(result, ['plugins/work/scripts/foo.test.js']);
+  });
+
+  it('excludes a non-test file even when it matches the scope glob', () => {
+    const { filterChangedTestFilesByScope } = taskNext;
+    const result = filterChangedTestFilesByScope(
+      ['plugins/work/scripts/foo.js', 'plugins/work/scripts/foo.test.js'],
+      ['plugins/work/**']
+    );
+    assert.deepEqual(result, ['plugins/work/scripts/foo.test.js']);
+  });
+
+  it('excludes a changed test file outside the scope glob', () => {
+    const { filterChangedTestFilesByScope } = taskNext;
+    const result = filterChangedTestFilesByScope(
+      ['unrelated/elsewhere/bar.test.js'],
+      ['plugins/work/**/*.test.js']
+    );
+    assert.deepEqual(result, []);
+  });
+
+  it('falls back to "any changed test file" when scope is empty', () => {
+    const { filterChangedTestFilesByScope } = taskNext;
+    const result = filterChangedTestFilesByScope(['anywhere/x.test.js', 'anywhere/y.js'], []);
+    assert.deepEqual(result, ['anywhere/x.test.js']);
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-contract-red-fallback.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-contract-red-fallback.integration.test.js
@@ -1,0 +1,282 @@
+'use strict';
+
+/**
+ * GH-528 review comment #7 — RED-fallback gate by contract.
+ *
+ * The RED-fallback entry condition in task-next.js predates the closed-Type
+ * taxonomy. It only fires when `isDocsExempt()` or `isVisualOnlyTask()` is
+ * true. But the central contract (`gateContractFor`) flags `config`, `ci`,
+ * and `file-move` Types with `rcdEmptyTrap: false` — meaning they are
+ * treated as silent-verifier-exempt downstream, yet RED currently blocks
+ * them because they have no `*.test.*` authorship surface.
+ *
+ * Correct gate: the fallback fires whenever
+ * `gateContractFor(type, scope).redRequiresTestFiles === false` AND
+ * `testFiles.length === 0`. This file is the failing-tests-first deliverable
+ * for that change.
+ *
+ * Run with:
+ *   node --test scripts/workflows/work-implement/__tests__/task-next-red-contract-fallback.integration.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execSync, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const TASK_NEXT = path.resolve(__dirname, '..', 'task-next.js');
+const TDD_CLI = path.resolve(__dirname, '..', 'tdd-phase-state.js');
+
+function makeTmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function setupGitRepo() {
+  const repo = makeTmp('red-cf-repo-');
+  execSync('git init -q', { cwd: repo, stdio: 'pipe' });
+  execSync('git config user.email t@t.com && git config user.name T', {
+    cwd: repo,
+    stdio: 'pipe',
+    shell: '/bin/bash',
+  });
+  fs.writeFileSync(path.join(repo, 'README.md'), 'init\n');
+  execSync('git add . && git ' + 'commit -q -m init', {
+    cwd: repo,
+    stdio: 'pipe',
+    shell: '/bin/bash',
+  });
+  return repo;
+}
+
+function childEnv(tasksBase) {
+  return {
+    ...process.env,
+    TASKS_BASE: tasksBase,
+    WORK_TDD_TOKEN_SKIP: '1',
+    WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+    HOME: process.env.HOME || '/tmp',
+  };
+}
+
+function runTaskNext(tasksBase, cwd, ticket, taskNum) {
+  const r = spawnSync('node', [TASK_NEXT, ticket, 'task' + taskNum], {
+    cwd,
+    encoding: 'utf8',
+    env: childEnv(tasksBase),
+  });
+  return {
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+    exitCode: r.status == null ? 1 : r.status,
+  };
+}
+
+function runTddInit(tasksBase, cwd, ticket, taskNum) {
+  const r = spawnSync('node', [TDD_CLI, 'init', ticket, '--task', String(taskNum)], {
+    cwd,
+    encoding: 'utf8',
+    env: childEnv(tasksBase),
+  });
+  return {
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+    exitCode: r.status == null ? 1 : r.status,
+  };
+}
+
+function readPhaseState(tasksBase, ticket, taskNum) {
+  const p = path.join(tasksBase, ticket, 'task' + taskNum, 'tdd-phase.json');
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+/**
+ * Build a tasks.md fixture whose Type is `type`, scope contains only the
+ * given non-test file, and the verifier exits non-zero (RED satisfies the
+ * "real failing test" requirement on the verifier alone — there is no
+ * `*.test.*` authorship surface).
+ */
+function writeContractFixture({ tasksDir, repo, taskNum, type, scopePath, scopeBody }) {
+  const abs = path.join(repo, scopePath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, scopeBody);
+  execSync('git add .', { cwd: repo, stdio: 'pipe' });
+  const md = [
+    '# Tasks',
+    '',
+    '## Task ' + taskNum + ' — ' + type + ' contract RED fallback',
+    '',
+    '### Type',
+    type,
+    '',
+    '### Description',
+    'Silent-verifier-exempt Type per gateContractFor. No *.test.* surface; ' +
+      'RED is satisfied by the verifier exiting non-zero.',
+    '',
+    '### Files in scope',
+    '- ' + scopePath,
+    '',
+    '### Test Command',
+    '```bash',
+    // `grep -q` is a real verifier (not flagged as a fake-test-command).
+    // The marker is never present in scopeBody → exit code 1 → RED satisfied.
+    'grep -q ZZZ_NEVER_PRESENT_MARKER ' + scopePath,
+    '```',
+    '',
+    '### Scenarios',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(tasksDir, 'tasks.md'), md);
+}
+
+const CONTRACT_CASES = [
+  {
+    label: 'Type=config',
+    type: 'config',
+    scopePath: 'biome.json',
+    scopeBody: '{\n  "version": 0\n}\n',
+  },
+  {
+    label: 'Type=ci',
+    type: 'ci',
+    // Any non-test file works — the contract gate is keyed off `### Type`,
+    // not the path. Using a neutral directory avoids the heimdall
+    // protected-path source-grep on the workflow folder name.
+    scopePath: 'ci/workflows/foo.yml',
+    scopeBody: 'name: foo\non: push\n',
+  },
+  {
+    label: 'Type=file-move',
+    type: 'file-move',
+    scopePath: 'src/moved.js',
+    scopeBody: '// placeholder\n',
+  },
+];
+
+describe('task-next.js RED contract-driven fallback', () => {
+  let tasksBase;
+  let repo;
+
+  beforeEach(() => {
+    tasksBase = makeTmp('red-cf-tasks-');
+    repo = setupGitRepo();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tasksBase, { recursive: true, force: true });
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  for (const tc of CONTRACT_CASES) {
+    it(`${tc.label}: failing verifier + no *.test.* surface → RED fallback accepts`, () => {
+      const TICKET = 'TEST-RCF-' + tc.type.toUpperCase();
+      const TASK_NUM = 1;
+      fs.mkdirSync(path.join(tasksBase, TICKET), { recursive: true });
+      writeContractFixture({
+        tasksDir: path.join(tasksBase, TICKET),
+        repo,
+        taskNum: TASK_NUM,
+        type: tc.type,
+        scopePath: tc.scopePath,
+        scopeBody: tc.scopeBody,
+      });
+
+      const init = runTddInit(tasksBase, repo, TICKET, TASK_NUM);
+      assert.equal(init.exitCode, 0, 'init failed: ' + init.stderr);
+
+      const r = runTaskNext(tasksBase, repo, TICKET, TASK_NUM);
+
+      const state = readPhaseState(tasksBase, TICKET, TASK_NUM);
+      assert.ok(state, 'tdd-phase.json should exist after the cycle');
+      assert.equal(
+        state.currentPhase,
+        'green',
+        tc.label +
+          ' must advance RED → GREEN via the contract fallback.\n' +
+          'stdout:\n' +
+          r.stdout +
+          '\nstderr:\n' +
+          r.stderr +
+          '\nstate: ' +
+          JSON.stringify(state, null, 2)
+      );
+    });
+  }
+
+  it('Type=tdd-code regression: scope with src + *.test.* still requires the test-file guard', () => {
+    const TICKET = 'TEST-RCF-TDD';
+    const TASK_NUM = 1;
+    fs.mkdirSync(path.join(tasksBase, TICKET), { recursive: true });
+
+    const srcDir = path.join(repo, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(srcDir, 'thing.js'), '// src\n');
+    fs.writeFileSync(
+      path.join(srcDir, 'thing.test.js'),
+      [
+        "const test = require('node:test');",
+        "test('tdd-code regression block', () => { throw new Error('fail'); });",
+        '',
+      ].join('\n')
+    );
+    execSync('git add .', { cwd: repo, stdio: 'pipe' });
+    const md = [
+      '# Tasks',
+      '',
+      '## Task ' + TASK_NUM + ' — tdd-code regression',
+      '',
+      '### Type',
+      'tdd-code',
+      '',
+      '### Description',
+      'Real failing test under scope. Fallback must NOT fire for tdd-code.',
+      '',
+      '### Files in scope',
+      '- src/thing.js',
+      '- src/thing.test.js',
+      '',
+      '### Test Command',
+      '```bash',
+      // Real verifier (not on FAKE_CMD_PATTERNS) that exits 1 — proves the
+      // RED test-command-failed gate. The fixture's *.test.* file is what
+      // task-next's "Allowed file globs" / authorship check inspects; the
+      // verifier merely needs to fail.
+      'grep -q ZZZ_NEVER_PRESENT_MARKER src/thing.test.js',
+      '```',
+      '',
+      '### Scenarios',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tasksBase, TICKET, 'tasks.md'), md);
+
+    const init = runTddInit(tasksBase, repo, TICKET, TASK_NUM);
+    assert.equal(init.exitCode, 0, 'init failed: ' + init.stderr);
+
+    const r = runTaskNext(tasksBase, repo, TICKET, TASK_NUM);
+    const state = readPhaseState(tasksBase, TICKET, TASK_NUM);
+
+    // tdd-code with a real failing test file in scope → normal RED path
+    // accepts (NOT the docs-exempt fallback). Advance to GREEN.
+    assert.equal(
+      state.currentPhase,
+      'green',
+      'tdd-code with a real test file should still advance via the normal ' +
+        'RED path (no regression). stdout:\n' +
+        r.stdout +
+        '\nstderr:\n' +
+        r.stderr +
+        '\nstate: ' +
+        JSON.stringify(state, null, 2)
+    );
+
+    // Must NOT use the docs-exempt fallback diagnostic.
+    const combined = r.stdout + r.stderr;
+    assert.doesNotMatch(
+      combined,
+      /docs-exempt fallback|visual-only fallback/,
+      'tdd-code path must not fire the contract fallback diagnostic. ' + 'Got:\n' + combined
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-docs-exempt.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-docs-exempt.test.js
@@ -1,6 +1,11 @@
 // Docs-exempt RED gate: documentation tasks have no testable code surface,
 // so they validate RED via their verification command instead of requiring a
 // *.test.* authorship file. See task-next.js `isDocsExempt()`.
+//
+// GH-528: the body-prose regex branch was removed. Detection is now
+// `### Type === 'docs'` ONLY — the planner authors Type and it is
+// scope-protected at implement time, so the implementer agent cannot flip
+// the gate by inserting "docs-only" / "documentation exempt" phrases.
 
 'use strict';
 
@@ -10,16 +15,16 @@ const assert = require('node:assert/strict');
 const { isDocsExempt } = require('../task-next.js');
 
 test('isDocsExempt: true for explicit `docs` type', () => {
-  assert.equal(isDocsExempt('docs', '### Type\ndocs\n\nwhatever'), true);
+  assert.equal(isDocsExempt('docs'), true);
 });
 
-test('isDocsExempt: true for "documentation exempt" marker in body', () => {
+test('GH-528: body prose "documentation exempt" NO LONGER flips the gate', () => {
   const section = '### Type\nfullstack\n\nDocs-only (no R/G/R — documentation exempt)';
-  assert.equal(isDocsExempt('fullstack', section), true);
+  assert.equal(isDocsExempt('fullstack', section), false);
 });
 
-test('isDocsExempt: true for "docs-only" marker regardless of type', () => {
-  assert.equal(isDocsExempt('backend', 'Docs-only task, prose only'), true);
+test('GH-528: body prose "docs-only" NO LONGER flips the gate', () => {
+  assert.equal(isDocsExempt('backend', 'Docs-only task, prose only'), false);
 });
 
 test('isDocsExempt: false for a normal code task', () => {

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-green-docs-exempt.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-green-docs-exempt.integration.test.js
@@ -192,7 +192,7 @@ describe('task-next.js GREEN docs-exempt fallback', () => {
     const TICKET = 'TEST-GDE-1';
     const TASK_NUM = 1;
     fs.mkdirSync(path.join(tasksBase, TICKET), { recursive: true });
-    writeDocsExemptTasksMd(path.join(tasksBase, TICKET), TASK_NUM);
+    writeDocsExemptTasksMd(path.join(tasksBase, TICKET), repo, TASK_NUM);
 
     const init = runTddInit(tasksBase, repo, TICKET, TASK_NUM);
     assert.equal(init.exitCode, 0, 'init failed: ' + init.stderr);
@@ -202,6 +202,14 @@ describe('task-next.js GREEN docs-exempt fallback', () => {
     // for docs-exempt, the existing RED docs-exempt block accepts it).
     // After this, state advances to GREEN.
     const r1 = runTaskNext(tasksBase, repo, TICKET, TASK_NUM);
+
+    // Author the marker that the GREEN verifier greps for (setup mirrors
+    // the fixture docstring: "then we write the marker and the GREEN
+    // verifier exits 0 silently").
+    fs.writeFileSync(
+      path.join(repo, 'docs', 'README.md'),
+      'placeholder DOCS_MARKER\n'
+    );
 
     // Invocation 2: GREEN. Same silent `true` cmd exits 0. Without the
     // GREEN docs-exempt fallback, recordEvidence forwards no flag and

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-green-docs-exempt.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-green-docs-exempt.integration.test.js
@@ -1,0 +1,292 @@
+'use strict';
+
+/**
+ * Task 4 — Integration: GREEN docs-exempt fallback in task-next.js.
+ *
+ * Sibling of Task 3 (RC-D `--docs-exempt` relaxation on `tdd-phase-state.js
+ * record-green`). This test exercises the *orchestrator* side: when a task
+ * is docs-exempt and the verification command runs silently (RC-D would
+ * normally trap it), task-next.js must forward `--docs-exempt` to the
+ * recorder so the GREEN phase advances rather than wedging.
+ *
+ * Scenarios (verbatim from tasks.md):
+ *   - docs-exempt task advances RED → GREEN → REFACTOR on a single pass
+ *   - non-docs task with a silent verifier still wedges (regression guard)
+ *
+ * Run with:
+ *   node --test scripts/workflows/work-implement/__tests__/task-next-green-docs-exempt.integration.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execSync, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const TASK_NEXT = path.resolve(__dirname, '..', 'task-next.js');
+const TDD_CLI = path.resolve(__dirname, '..', 'tdd-phase-state.js');
+
+function makeTmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function setupGitRepo() {
+  const repo = makeTmp('green-de-repo-');
+  execSync('git init -q', { cwd: repo, stdio: 'pipe' });
+  execSync('git config user.email t@t.com && git config user.name T', {
+    cwd: repo,
+    stdio: 'pipe',
+    shell: '/bin/bash',
+  });
+  fs.writeFileSync(path.join(repo, 'README.md'), 'init\n');
+  execSync('git add . && git ' + 'commit -q -m init', {
+    cwd: repo,
+    stdio: 'pipe',
+    shell: '/bin/bash',
+  });
+  return repo;
+}
+
+function childEnv(tasksBase) {
+  return {
+    ...process.env,
+    TASKS_BASE: tasksBase,
+    WORK_TDD_TOKEN_SKIP: '1',
+    WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+    HOME: process.env.HOME || '/tmp',
+  };
+}
+
+function runTaskNext(tasksBase, cwd, ticket, taskNum) {
+  const r = spawnSync('node', [TASK_NEXT, ticket, 'task' + taskNum], {
+    cwd,
+    encoding: 'utf8',
+    env: childEnv(tasksBase),
+  });
+  return {
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+    exitCode: r.status == null ? 1 : r.status,
+  };
+}
+
+function runTddInit(tasksBase, cwd, ticket, taskNum) {
+  const r = spawnSync(
+    'node',
+    [TDD_CLI, 'init', ticket, '--task', String(taskNum)],
+    { cwd, encoding: 'utf8', env: childEnv(tasksBase) }
+  );
+  return {
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+    exitCode: r.status == null ? 1 : r.status,
+  };
+}
+
+function readPhaseState(tasksBase, ticket, taskNum) {
+  const p = path.join(tasksBase, ticket, 'task' + taskNum, 'tdd-phase.json');
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+/**
+ * tasks.md fixture for a docs-exempt task whose verification command
+ * (`true`) exits 0 but emits zero stdout/stderr — the canonical RC-D
+ * silent-verifier shape. Scope contains only `.md` entries (no test files)
+ * to drive the GREEN docs-exempt fallback.
+ */
+function writeDocsExemptTasksMd(tasksDir, repo, taskNum) {
+  // Create a docs file that initially does NOT contain the marker the
+  // verifier greps for — RED verifier exits non-zero (failing as required),
+  // then we write the marker and the GREEN verifier exits 0 silently.
+  const docsDir = path.join(repo, 'docs');
+  fs.mkdirSync(docsDir, { recursive: true });
+  fs.writeFileSync(path.join(docsDir, 'README.md'), 'placeholder\n');
+  execSync('git add .', { cwd: repo, stdio: 'pipe' });
+  const md = [
+    '# Tasks',
+    '',
+    '## Task ' + taskNum + ' — Docs-only verification fixture',
+    '',
+    '### Type',
+    'docs',
+    '',
+    '### Description',
+    'Docs-only (no R/G/R — documentation exempt). Fixture for GREEN docs-exempt fallback.',
+    '',
+    '### Files in scope',
+    '- docs/README.md',
+    '',
+    '### Test Command',
+    '```bash',
+    'grep -q DOCS_MARKER docs/README.md',
+    '```',
+    '',
+    '### Scenarios',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(tasksDir, 'tasks.md'), md);
+}
+
+/**
+ * tasks.md fixture for a NON-docs task whose verification command also
+ * emits zero stdout/stderr (regression: RC-D trap must still fire). Scope
+ * is a code file + a test file so neither docs-exempt nor visual-only
+ * fallbacks apply.
+ */
+function writeNonDocsSilentTasksMd(tasksDir, repo, taskNum) {
+  const srcDir = path.join(repo, 'src');
+  fs.mkdirSync(srcDir, { recursive: true });
+  fs.writeFileSync(path.join(srcDir, 'feature.js'), '// src\n');
+  fs.writeFileSync(
+    path.join(srcDir, 'feature.test.js'),
+    [
+      "const test = require('node:test');",
+      "test('non-docs silent', () => { throw new Error('fail'); });",
+      '',
+    ].join('\n')
+  );
+  execSync('git add .', { cwd: repo, stdio: 'pipe' });
+  const md = [
+    '# Tasks',
+    '',
+    '## Task ' + taskNum + ' — Non-docs silent verifier fixture',
+    '',
+    '### Type',
+    'backend',
+    '',
+    '### Description',
+    'Normal code task. Regression guard for RC-D empty-command trap.',
+    '',
+    '### Files in scope',
+    '- src/feature.js',
+    '- src/feature.test.js',
+    '',
+    '### Test Command',
+    '```bash',
+    'true',
+    '```',
+    '',
+    '### Scenarios',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(tasksDir, 'tasks.md'), md);
+}
+
+describe('task-next.js GREEN docs-exempt fallback', () => {
+  let tasksBase;
+  let repo;
+
+  beforeEach(() => {
+    tasksBase = makeTmp('green-de-tasks-');
+    repo = setupGitRepo();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tasksBase, { recursive: true, force: true });
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('docs-exempt task advances RED → GREEN → REFACTOR on a single pass', () => {
+    const TICKET = 'TEST-GDE-1';
+    const TASK_NUM = 1;
+    fs.mkdirSync(path.join(tasksBase, TICKET), { recursive: true });
+    writeDocsExemptTasksMd(path.join(tasksBase, TICKET), TASK_NUM);
+
+    const init = runTddInit(tasksBase, repo, TICKET, TASK_NUM);
+    assert.equal(init.exitCode, 0, 'init failed: ' + init.stderr);
+
+    // Invocation 1: RED. Docs-exempt + silent `true` cmd → RED fallback
+    // accepts (verification cmd exits 0 but exitCode-!==0 is NOT required
+    // for docs-exempt, the existing RED docs-exempt block accepts it).
+    // After this, state advances to GREEN.
+    const r1 = runTaskNext(tasksBase, repo, TICKET, TASK_NUM);
+
+    // Invocation 2: GREEN. Same silent `true` cmd exits 0. Without the
+    // GREEN docs-exempt fallback, recordEvidence forwards no flag and
+    // tdd-phase-state.js's RC-D empty-command trap rejects. With the
+    // fallback (this task's deliverable), the orchestrator passes
+    // `--docs-exempt` and the recorder accepts, advancing to refactor.
+    const r2 = runTaskNext(tasksBase, repo, TICKET, TASK_NUM);
+
+    const state = readPhaseState(tasksBase, TICKET, TASK_NUM);
+    assert.ok(state, 'tdd-phase.json should exist after the cycle');
+    assert.equal(
+      state.currentPhase,
+      'refactor',
+      'docs-exempt task should advance to refactor.\n' +
+        'r1 stdout:\n' + r1.stdout + '\nr1 stderr:\n' + r1.stderr +
+        '\nr2 stdout:\n' + r2.stdout + '\nr2 stderr:\n' + r2.stderr +
+        '\nstate: ' + JSON.stringify(state, null, 2)
+    );
+
+    // Diagnostic line must surface the GREEN docs-exempt fallback so the
+    // operator sees why a silent verifier was accepted.
+    const combined2 = r2.stdout + r2.stderr;
+    assert.match(
+      combined2,
+      /docs-exempt fallback/,
+      'GREEN docs-exempt path must emit a diagnostic containing the literal ' +
+        '"docs-exempt fallback". Got:\n' + combined2
+    );
+  });
+
+  it('non-docs task with a silent verifier still wedges (regression guard)', () => {
+    const TICKET = 'TEST-GDE-2';
+    const TASK_NUM = 1;
+    fs.mkdirSync(path.join(tasksBase, TICKET), { recursive: true });
+    writeNonDocsSilentTasksMd(path.join(tasksBase, TICKET), repo, TASK_NUM);
+
+    const init = runTddInit(tasksBase, repo, TICKET, TASK_NUM);
+    assert.equal(init.exitCode, 0, 'init failed: ' + init.stderr);
+
+    // Seed phase state to green so we exercise the GREEN branch directly
+    // (skip the RED dance, which is not the regression surface).
+    const statePath = path.join(
+      tasksBase, TICKET, 'task' + TASK_NUM, 'tdd-phase.json'
+    );
+    const state0 = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    state0.currentPhase = 'green';
+    state0.cycles = [
+      {
+        cycle: 1,
+        red: {
+          testFiles: ['src/feature.test.js'],
+          testCommand: 'true',
+          testExitCode: 1,
+          timestamp: new Date().toISOString(),
+        },
+      },
+    ];
+    fs.writeFileSync(statePath, JSON.stringify(state0, null, 2));
+
+    // Run task-next.js. The verifier (`true`) exits 0 silently. Because
+    // the task type is `backend` and scope contains real code, neither
+    // isDocsExempt nor isVisualOnlyTask is true — so the GREEN fallback
+    // MUST NOT fire. RC-D trap in tdd-phase-state.js should reject.
+    const r = runTaskNext(tasksBase, repo, TICKET, TASK_NUM);
+
+    const stateAfter = readPhaseState(tasksBase, TICKET, TASK_NUM);
+    assert.equal(
+      stateAfter.currentPhase,
+      'green',
+      'non-docs task with silent verifier must remain wedged at GREEN. ' +
+        'stdout:\n' + r.stdout + '\nstderr:\n' + r.stderr +
+        '\nstate: ' + JSON.stringify(stateAfter, null, 2)
+    );
+    assert.notEqual(
+      r.exitCode,
+      0,
+      'non-docs silent verifier should produce a non-zero exit. ' +
+        'stdout:\n' + r.stdout + '\nstderr:\n' + r.stderr
+    );
+    const combined = r.stdout + r.stderr;
+    assert.doesNotMatch(
+      combined,
+      /docs-exempt fallback/,
+      'non-docs path must NOT emit the docs-exempt fallback diagnostic. ' +
+        'Got:\n' + combined
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-isdocsexempt-typeonly.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-isdocsexempt-typeonly.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isDocsExempt } = require('../task-next');
+
+test('Type=docs is docs-exempt', () => {
+  assert.equal(isDocsExempt('docs'), true);
+});
+
+test('Type=tdd-code is NOT docs-exempt regardless of body prose', () => {
+  assert.equal(isDocsExempt('tdd-code'), false);
+});
+
+test('GH-528 bypass closure: body-prose phrases no longer trigger docs-exempt', () => {
+  // Pre-fix: body containing "docs-only" or "documentation exempt" anywhere
+  // would flip the gate. The implementer-agent could insert these phrases
+  // into ACs at implement time and skip RED. After GH-528: ignored.
+  const malicious = [
+    'This task is docs-only — no test surface',
+    'documentation exempt because the spec says so',
+    'documentation-exempt',
+    'docs only',
+  ];
+  for (const body of malicious) {
+    // arity is now 1; passing a 2nd arg must NOT re-enable the bypass
+    assert.equal(isDocsExempt('tdd-code', body), false, `body "${body}" must not flip`);
+    assert.equal(isDocsExempt('tests-only', body), false, `body "${body}" must not flip`);
+    assert.equal(isDocsExempt('', body), false, `body "${body}" must not flip empty type`);
+  }
+});
+
+test('empty / missing type is NOT docs-exempt', () => {
+  assert.equal(isDocsExempt(''), false);
+  assert.equal(isDocsExempt(undefined), false);
+  assert.equal(isDocsExempt(null), false);
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-scope-admits-only-tests.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-scope-admits-only-tests.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * Tests for scopeEntryAdmitsOnlyTestFiles helper in task-next.js.
+ *
+ * Context (cursor[bot] review, GH-528): the tests-only GREEN gate
+ * previously rejected any `### Files in scope` entry that did not itself
+ * end in `*.test.*` / `*.spec.*`. That worked for literal paths but
+ * mis-classified glob entries whose basename DOES constrain to test
+ * files (e.g. `plugins/work/**\/*.test.js` — match set is test-only)
+ * while correctly rejecting open-ended globs like `src/**` whose match
+ * set admits non-test files.
+ *
+ * Rule: an entry "admits only test files" when EITHER
+ *   (a) it is a literal path matching `*.test.<ext>` / `*.spec.<ext>`, OR
+ *   (b) it is a glob whose final segment (basename) ends in a test-file
+ *       extension pattern.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const taskNext = require('../task-next.js');
+
+describe('scopeEntryAdmitsOnlyTestFiles (tests-only GREEN scope classifier)', () => {
+  it('is exported from task-next.js', () => {
+    assert.equal(
+      typeof taskNext.scopeEntryAdmitsOnlyTestFiles,
+      'function',
+      'scopeEntryAdmitsOnlyTestFiles must be a named export of task-next.js'
+    );
+  });
+
+  it('accepts a literal test-file path', () => {
+    const { scopeEntryAdmitsOnlyTestFiles } = taskNext;
+    assert.equal(scopeEntryAdmitsOnlyTestFiles('src/foo.test.js'), true);
+    assert.equal(scopeEntryAdmitsOnlyTestFiles('plugins/x/a.spec.tsx'), true);
+  });
+
+  it('rejects a literal non-test path', () => {
+    const { scopeEntryAdmitsOnlyTestFiles } = taskNext;
+    assert.equal(scopeEntryAdmitsOnlyTestFiles('src/foo.js'), false);
+    assert.equal(scopeEntryAdmitsOnlyTestFiles('lib/index.ts'), false);
+  });
+
+  it('accepts a glob whose basename constrains to test files', () => {
+    const { scopeEntryAdmitsOnlyTestFiles } = taskNext;
+    assert.equal(scopeEntryAdmitsOnlyTestFiles('plugins/work/**/*.test.js'), true);
+    assert.equal(scopeEntryAdmitsOnlyTestFiles('src/foo/**/*.spec.tsx'), true);
+    assert.equal(scopeEntryAdmitsOnlyTestFiles('**/*.test.ts'), true);
+  });
+
+  it('rejects an open-ended glob whose match set could include non-tests', () => {
+    const { scopeEntryAdmitsOnlyTestFiles } = taskNext;
+    assert.equal(scopeEntryAdmitsOnlyTestFiles('src/**'), false);
+    assert.equal(scopeEntryAdmitsOnlyTestFiles('lib/**/*.js'), false);
+    assert.equal(scopeEntryAdmitsOnlyTestFiles('plugins/work/**'), false);
+  });
+
+  it('rejects empty / non-string entries', () => {
+    const { scopeEntryAdmitsOnlyTestFiles } = taskNext;
+    assert.equal(scopeEntryAdmitsOnlyTestFiles(''), false);
+    assert.equal(scopeEntryAdmitsOnlyTestFiles(null), false);
+    assert.equal(scopeEntryAdmitsOnlyTestFiles(undefined), false);
+    assert.equal(scopeEntryAdmitsOnlyTestFiles(42), false);
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-tests-only-rcd.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-tests-only-rcd.integration.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+/**
+ * task-next.js — Type=tests-only must NOT disable the RC-D empty-output trap.
+ *
+ * Regression for GH-528 review comment #3 (cursor[bot]):
+ *
+ *   The GREEN branch for Type=tests-only used to call recordEvidence with
+ *   `docsExempt: true`, which forwards `--docs-exempt` to tdd-phase-state.js
+ *   and disables the RC-D empty-output trap. Per `gateContractFor('tests-only')`
+ *   the contract is `rcdEmptyTrap: true` — a silent verifier such as `true`
+ *   (exit 0, no stdout/stderr) must therefore be REJECTED at GREEN even when
+ *   an in-scope test file has been modified.
+ *
+ *   This test wires a silent verifier (`true`), modifies an in-scope test
+ *   file (so the tests-only "must-modify" check passes), and asserts that
+ *   GREEN recording is rejected by the RC-D trap.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const TASK_NEXT = path.resolve(__dirname, '..', 'task-next.js');
+const TICKET = 'TEST-528-RCD';
+
+function makeWorkspace({ scope, testCmd }) {
+  const tasksBase = fs.mkdtempSync(path.join(os.tmpdir(), 'task-next-to-rcd-'));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-next-to-rcd-repo-'));
+  spawnSync('git', ['init', '-q'], { cwd: repoRoot });
+  spawnSync('git', ['config', 'user.email', 't@t'], { cwd: repoRoot });
+  spawnSync('git', ['config', 'user.name', 't'], { cwd: repoRoot });
+  fs.writeFileSync(path.join(repoRoot, 'README.md'), '# seed\n');
+  spawnSync('git', ['add', '.'], { cwd: repoRoot });
+  spawnSync('git', ['commit', '-q', '-m', 'seed'], { cwd: repoRoot });
+
+  fs.mkdirSync(path.join(tasksBase, TICKET), { recursive: true });
+  const md = [
+    '# Tasks',
+    '',
+    '## Task 1 — add coverage',
+    '',
+    '### Type',
+    'tests-only',
+    '',
+    '### Files in scope',
+    ...scope.map((s) => `- ${s}`),
+    '',
+    '### Test Command',
+    '```bash',
+    testCmd,
+    '```',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(tasksBase, TICKET, 'tasks.md'), md);
+  fs.writeFileSync(
+    path.join(tasksBase, TICKET, '.work' + '-state.json'),
+    JSON.stringify({ ticketId: TICKET })
+  );
+  return { tasksBase, repoRoot };
+}
+
+function runTaskNext(tasksBase, repoRoot) {
+  return spawnSync('node', [TASK_NEXT, TICKET, 'task1'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TASKS_BASE: tasksBase,
+      WORK_TDD_TOKEN_SKIP: '1',
+      WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+    },
+  });
+}
+
+describe('task-next.js — tests-only GREEN must NOT disable RC-D empty-output trap', () => {
+  let ws;
+  beforeEach(() => {
+    // Silent verifier: `node -e ""` exits 0 with no stdout/stderr (and is
+    // not on the FAKE_CMD_PATTERNS list, so it gets past the parseCmd
+    // pre-check). Without the RC-D trap, this records GREEN even though
+    // nothing was actually verified. gateContractFor('tests-only')
+    // has rcdEmptyTrap=true, so the trap MUST reject.
+    ws = makeWorkspace({ scope: ['src/foo.test.js'], testCmd: 'node -e ""' });
+    fs.mkdirSync(path.join(ws.repoRoot, 'src'), { recursive: true });
+  });
+  afterEach(() => {
+    if (ws) {
+      fs.rmSync(ws.tasksBase, { recursive: true, force: true });
+      fs.rmSync(ws.repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects GREEN when verifier is silent (exit 0, no output)', () => {
+    // Step 1: skip RED via the tests-only contract.
+    const skip = runTaskNext(ws.tasksBase, ws.repoRoot);
+    assert.equal(skip.status, 0, `RED-skip failed; stdout=${skip.stdout} stderr=${skip.stderr}`);
+
+    // Step 2: modify an in-scope test file so the "must-modify" check passes.
+    fs.writeFileSync(
+      path.join(ws.repoRoot, 'src', 'foo.test.js'),
+      'const { test } = require("node:test");\ntest("x", () => {});\n'
+    );
+
+    // Step 3: re-invoke for GREEN. Verifier is `true` (silent). RC-D
+    // empty-output trap must reject — task-next must exit non-zero.
+    const r = runTaskNext(ws.tasksBase, ws.repoRoot);
+    assert.notEqual(
+      r.status,
+      0,
+      `tests-only GREEN MUST reject silent verifier via RC-D, but exited 0. ` +
+        `stdout=${r.stdout} stderr=${r.stderr}`
+    );
+    // Surface the RC-D rejection diagnostic so the operator sees what fired.
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.match(
+      combined,
+      /empty-command trap|NO stdout\/stderr|Could not record GREEN evidence/i,
+      `expected RC-D trap diagnostic; got: ${combined}`
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-tests-only.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-tests-only.integration.test.js
@@ -162,3 +162,58 @@ describe('task-next.js — tests-only GREEN refuses non-test scope', () => {
     assert.match(r.stdout, /ONLY \*\.test\.\* \/ \*\.spec\.\* files/);
   });
 });
+
+describe('task-next.js — tests-only GREEN accepts test-constrained glob scope', () => {
+  let ws;
+  afterEach(() => {
+    if (ws) {
+      fs.rmSync(ws.tasksBase, { recursive: true, force: true });
+      fs.rmSync(ws.repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('GREEN succeeds when scope is a `**\\/*.test.js` glob and an in-scope test was modified', () => {
+    ws = makeWorkspace({
+      scope: ['src/**/*.test.js'],
+      testCmd: 'node --test src/sub/foo.test.js',
+    });
+    fs.mkdirSync(path.join(ws.repoRoot, 'src', 'sub'), { recursive: true });
+    runTaskNext(ws.tasksBase, ws.repoRoot); // skip RED
+    fs.writeFileSync(
+      path.join(ws.repoRoot, 'src', 'sub', 'foo.test.js'),
+      'const { test } = require("node:test");\ntest("x", () => {});\n'
+    );
+    const r = runTaskNext(ws.tasksBase, ws.repoRoot);
+    assert.equal(r.status, 0, `expected 0; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.match(r.stdout, /GREEN accepted via tests-only/);
+  });
+
+  it('GREEN succeeds when scope is a `**\\/*.spec.js` glob and an in-scope spec was modified', () => {
+    ws = makeWorkspace({
+      scope: ['src/foo/**/*.spec.js'],
+      testCmd: 'node --test src/foo/sub/bar.spec.js',
+    });
+    fs.mkdirSync(path.join(ws.repoRoot, 'src', 'foo', 'sub'), { recursive: true });
+    runTaskNext(ws.tasksBase, ws.repoRoot); // skip RED
+    fs.writeFileSync(
+      path.join(ws.repoRoot, 'src', 'foo', 'sub', 'bar.spec.js'),
+      'const { test } = require("node:test");\ntest("x", () => {});\n'
+    );
+    const r = runTaskNext(ws.tasksBase, ws.repoRoot);
+    assert.equal(r.status, 0, `expected 0; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.match(r.stdout, /GREEN accepted via tests-only/);
+  });
+
+  it('GREEN blocks when scope is an open-ended glob like `src/**` (admits non-tests)', () => {
+    ws = makeWorkspace({ scope: ['src/**'] });
+    fs.mkdirSync(path.join(ws.repoRoot, 'src'), { recursive: true });
+    runTaskNext(ws.tasksBase, ws.repoRoot); // skip RED
+    fs.writeFileSync(
+      path.join(ws.repoRoot, 'src', 'foo.test.js'),
+      'const { test } = require("node:test");\ntest("x", () => {});\n'
+    );
+    const r = runTaskNext(ws.tasksBase, ws.repoRoot);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stdout, /ONLY \*\.test\.\* \/ \*\.spec\.\* files/);
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-tests-only.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-tests-only.integration.test.js
@@ -1,0 +1,164 @@
+'use strict';
+
+/**
+ * task-next.js — Type=tests-only RED-skipped → GREEN → REFACTOR (GH-528).
+ *
+ * E2E:
+ *   - On first invocation, RED is skipped via record-skip-red; state file
+ *     shows {skipped: true}.
+ *   - On second invocation, with a modified in-scope test file and passing
+ *     verifier, GREEN is recorded.
+ *   - On third, REFACTOR is recorded.
+ *
+ * Negative:
+ *   - GREEN refuses when scope includes a non-test file.
+ *   - GREEN refuses when no in-scope test file was modified.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const TASK_NEXT = path.resolve(__dirname, '..', 'task-next.js');
+const STATE_FILENAME = 'tdd' + '-phase' + '.json';
+const TICKET = 'TEST-528';
+
+function makeWorkspace({ scope, testCmd = 'node --test src/foo.test.js' }) {
+  const tasksBase = fs.mkdtempSync(path.join(os.tmpdir(), 'task-next-to-'));
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'task-next-to-repo-'));
+  spawnSync('git', ['init', '-q'], { cwd: repoRoot });
+  spawnSync('git', ['config', 'user.email', 't@t'], { cwd: repoRoot });
+  spawnSync('git', ['config', 'user.name', 't'], { cwd: repoRoot });
+  // Seed an empty commit so `git diff HEAD` works.
+  fs.writeFileSync(path.join(repoRoot, 'README.md'), '# seed\n');
+  spawnSync('git', ['add', '.'], { cwd: repoRoot });
+  spawnSync('git', ['commit', '-q', '-m', 'seed'], { cwd: repoRoot });
+
+  // Build tasks.md with Type=tests-only.
+  fs.mkdirSync(path.join(tasksBase, TICKET), { recursive: true });
+  const md = [
+    '# Tasks',
+    '',
+    '## Task 1 — add coverage',
+    '',
+    '### Type',
+    'tests-only',
+    '',
+    '### Files in scope',
+    ...scope.map((s) => `- ${s}`),
+    '',
+    '### Test Command',
+    '```bash',
+    testCmd,
+    '```',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(tasksBase, TICKET, 'tasks.md'), md);
+  fs.writeFileSync(
+    path.join(tasksBase, TICKET, '.work' + '-state.json'),
+    JSON.stringify({ ticketId: TICKET })
+  );
+  return { tasksBase, repoRoot };
+}
+
+function runTaskNext(tasksBase, repoRoot) {
+  return spawnSync('node', [TASK_NEXT, TICKET, 'task1'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TASKS_BASE: tasksBase,
+      WORK_TDD_TOKEN_SKIP: '1',
+      WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+    },
+  });
+}
+
+function readState(tasksBase) {
+  const p = path.join(tasksBase, TICKET, 'task1', STATE_FILENAME);
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+describe('task-next.js — tests-only RED→GREEN→REFACTOR', () => {
+  let ws;
+  beforeEach(() => {
+    ws = makeWorkspace({ scope: ['src/foo.test.js'] });
+    fs.mkdirSync(path.join(ws.repoRoot, 'src'), { recursive: true });
+  });
+  afterEach(() => {
+    if (ws) {
+      fs.rmSync(ws.tasksBase, { recursive: true, force: true });
+      fs.rmSync(ws.repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('RED is skipped with structured marker on first invocation', () => {
+    const r = runTaskNext(ws.tasksBase, ws.repoRoot);
+    assert.equal(r.status, 0, `expected 0; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.match(r.stdout, /RED skipped via tests-only/);
+    const state = readState(ws.tasksBase);
+    assert.equal(state.currentPhase, 'green');
+    const cycle = state.cycles.find((c) => c.cycle === 1);
+    assert.equal(cycle.red.skipped, true);
+    assert.ok(cycle.red.reason);
+  });
+
+  it('GREEN succeeds when scope has only test files AND one is modified', () => {
+    runTaskNext(ws.tasksBase, ws.repoRoot); // skip RED
+    fs.writeFileSync(
+      path.join(ws.repoRoot, 'src', 'foo.test.js'),
+      'const { test } = require("node:test");\ntest("x", () => {});\n'
+    );
+    const r = runTaskNext(ws.tasksBase, ws.repoRoot);
+    assert.equal(r.status, 0, `expected 0; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.match(r.stdout, /GREEN accepted via tests-only/);
+    const state = readState(ws.tasksBase);
+    assert.equal(state.currentPhase, 'refactor');
+    const cycle = state.cycles.find((c) => c.cycle === 1);
+    assert.ok(cycle.green);
+  });
+
+  it('GREEN blocks when no in-scope test file modified (committed baseline)', () => {
+    // Create + COMMIT the test file BEFORE skip-RED so the verifier passes,
+    // then ensure no further edits — git diff vs HEAD is empty.
+    fs.writeFileSync(
+      path.join(ws.repoRoot, 'src', 'foo.test.js'),
+      'const { test } = require("node:test");\ntest("x", () => {});\n'
+    );
+    spawnSync('git', ['add', '.'], { cwd: ws.repoRoot });
+    spawnSync('git', ['commit', '-q', '-m', 'baseline'], { cwd: ws.repoRoot });
+    runTaskNext(ws.tasksBase, ws.repoRoot); // skip RED
+    const r = runTaskNext(ws.tasksBase, ws.repoRoot);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stdout, /requires at least one in-scope test file to be modified/);
+  });
+});
+
+describe('task-next.js — tests-only GREEN refuses non-test scope', () => {
+  let ws;
+  beforeEach(() => {
+    ws = makeWorkspace({ scope: ['src/foo.test.js', 'src/foo.js'] });
+    fs.mkdirSync(path.join(ws.repoRoot, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(ws.repoRoot, 'src', 'foo.test.js'),
+      'const { test } = require("node:test");\ntest("x", () => {});\n'
+    );
+  });
+  afterEach(() => {
+    if (ws) {
+      fs.rmSync(ws.tasksBase, { recursive: true, force: true });
+      fs.rmSync(ws.repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('GREEN blocks because scope includes src/foo.js', () => {
+    runTaskNext(ws.tasksBase, ws.repoRoot); // skip RED
+    const r = runTaskNext(ws.tasksBase, ws.repoRoot);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stdout, /ONLY \*\.test\.\* \/ \*\.spec\.\* files/);
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-docs-exempt.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-docs-exempt.integration.test.js
@@ -62,13 +62,36 @@ function seedGreenPhase(homeDir, ticket) {
     },
   ];
   fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+  // GH-528 round-2 follow-up (Cursor[bot] HIGH/Medium): record-green's
+  // `--docs-exempt` flag is now gated on the active task's Type via on-disk
+  // tasks.md. Plant a Type=docs task so the relaxation contract test still
+  // passes through the new gate. The seed leaves taskNum unset on the CLI
+  // call, so the recorder falls back to the legacy ticket-root state path;
+  // tasks.md still lives at the ticket root and the gate reads `Task 1`.
+  fs.writeFileSync(
+    path.join(homeDir, 'worktrees', 'tasks', ticket, 'tasks.md'),
+    [
+      '## Task 1 — sample',
+      '',
+      '### Type',
+      'docs',
+      '',
+      '### Files in scope',
+      '- README.md',
+      '',
+    ].join('\n')
+  );
   return statePath;
 }
 
 describe('RC-D --docs-exempt relaxation', () => {
   let homeDir;
-  beforeEach(() => { homeDir = mkTempHome(); });
-  afterEach(() => { fs.rmSync(homeDir, { recursive: true, force: true }); });
+  beforeEach(() => {
+    homeDir = mkTempHome();
+  });
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
 
   it('tdd-phase-state record-green still rejects silent verifiers by default', () => {
     seedGreenPhase(homeDir, 'TEST-DOCS-1');

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-docs-exempt.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-docs-exempt.integration.test.js
@@ -12,7 +12,7 @@
 
 const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -26,30 +26,27 @@ function mkTempHome() {
 }
 
 function runCli(args, homeDir) {
-  try {
-    const stdout = execSync(`node ${CLI_PATH} ${args}`, {
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        HOME: homeDir,
-        TASKS_BASE: path.join(homeDir, 'worktrees', 'tasks'),
-        WORK_TDD_TOKEN_SKIP: '1',
-        WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
-      },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { stdout, stderr: '', exitCode: 0 };
-  } catch (e) {
-    return {
-      stdout: e.stdout || '',
-      stderr: e.stderr || e.message,
-      exitCode: typeof e.status === 'number' ? e.status : 1,
-    };
-  }
+  const argv = Array.isArray(args) ? args : [];
+  const res = spawnSync(process.execPath, [CLI_PATH, ...argv], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      TASKS_BASE: path.join(homeDir, 'worktrees', 'tasks'),
+      WORK_TDD_TOKEN_SKIP: '1',
+      WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    stdout: res.stdout || '',
+    stderr: res.stderr || '',
+    exitCode: typeof res.status === 'number' ? res.status : 1,
+  };
 }
 
 function seedGreenPhase(homeDir, ticket) {
-  runCli(`init ${ticket}`, homeDir);
+  runCli(['init', ticket], homeDir);
   const statePath = path.join(homeDir, 'worktrees', 'tasks', ticket, 'tdd-phase.json');
   const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
   state.currentPhase = 'green';
@@ -75,14 +72,14 @@ describe('RC-D --docs-exempt relaxation', () => {
 
   it('tdd-phase-state record-green still rejects silent verifiers by default', () => {
     seedGreenPhase(homeDir, 'TEST-DOCS-1');
-    const r = runCli('record-green TEST-DOCS-1 --cmd \'eval ""\'', homeDir);
+    const r = runCli(['record-green', 'TEST-DOCS-1', '--cmd', 'eval ""'], homeDir);
     assert.notStrictEqual(r.exitCode, 0, 'default invocation must still reject empty output');
     assert.match(r.stderr, /empty-command trap|NO stdout\/stderr/i);
   });
 
   it('tdd-phase-state record-green accepts silent verifiers when docs-exempt flag is set', () => {
     const statePath = seedGreenPhase(homeDir, 'TEST-DOCS-2');
-    const r = runCli('record-green TEST-DOCS-2 --docs-exempt --cmd \'eval ""\'', homeDir);
+    const r = runCli(['record-green', 'TEST-DOCS-2', '--docs-exempt', '--cmd', 'eval ""'], homeDir);
     assert.strictEqual(
       r.exitCode,
       0,

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-docs-exempt.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-docs-exempt.integration.test.js
@@ -1,0 +1,95 @@
+/**
+ * RC-D --docs-exempt relaxation tests (Task 3, GH-528).
+ *
+ * Default `record-green` invocation must continue to reject silent
+ * verifiers (RC-D empty-command trap). When the new `--docs-exempt` CLI
+ * flag is supplied, the same empty-output evidence must be accepted and
+ * persisted to disk as a normal `record.green` payload.
+ *
+ * Mirrors the spawn + mkdtempSync harness from
+ * `tdd-phase-state-empty-command-trap.test.js`.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const CLI_PATH = path.join(__dirname, '..', 'tdd-phase-state.js');
+
+function mkTempHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdd-docs-exempt-'));
+  fs.mkdirSync(path.join(dir, 'worktrees', 'tasks'), { recursive: true });
+  return dir;
+}
+
+function runCli(args, homeDir) {
+  try {
+    const stdout = execSync(`node ${CLI_PATH} ${args}`, {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        TASKS_BASE: path.join(homeDir, 'worktrees', 'tasks'),
+        WORK_TDD_TOKEN_SKIP: '1',
+        WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (e) {
+    return {
+      stdout: e.stdout || '',
+      stderr: e.stderr || e.message,
+      exitCode: typeof e.status === 'number' ? e.status : 1,
+    };
+  }
+}
+
+function seedGreenPhase(homeDir, ticket) {
+  runCli(`init ${ticket}`, homeDir);
+  const statePath = path.join(homeDir, 'worktrees', 'tasks', ticket, 'tdd-phase.json');
+  const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  state.currentPhase = 'green';
+  state.cycles = [
+    {
+      cycle: 1,
+      red: {
+        testFiles: ['x.test.ts'],
+        testCommand: 'false',
+        testExitCode: 1,
+        timestamp: new Date().toISOString(),
+      },
+    },
+  ];
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+  return statePath;
+}
+
+describe('RC-D --docs-exempt relaxation', () => {
+  let homeDir;
+  beforeEach(() => { homeDir = mkTempHome(); });
+  afterEach(() => { fs.rmSync(homeDir, { recursive: true, force: true }); });
+
+  it('record-green still rejects silent verifiers by default (regression guard)', () => {
+    seedGreenPhase(homeDir, 'TEST-DOCS-1');
+    const r = runCli('record-green TEST-DOCS-1 --cmd \'eval ""\'', homeDir);
+    assert.notStrictEqual(r.exitCode, 0, 'default invocation must still reject empty output');
+    assert.match(r.stderr, /empty-command trap|NO stdout\/stderr/i);
+  });
+
+  it('record-green accepts silent verifiers when --docs-exempt flag is set', () => {
+    const statePath = seedGreenPhase(homeDir, 'TEST-DOCS-2');
+    const r = runCli('record-green TEST-DOCS-2 --docs-exempt --cmd \'eval ""\'', homeDir);
+    assert.strictEqual(
+      r.exitCode,
+      0,
+      `--docs-exempt should accept empty output. stderr: ${r.stderr}`
+    );
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    const greenRec = state.cycles[0] && state.cycles[0].green;
+    assert.ok(greenRec, 'record.green payload should be persisted to disk');
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-docs-exempt.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-docs-exempt.integration.test.js
@@ -73,14 +73,14 @@ describe('RC-D --docs-exempt relaxation', () => {
   beforeEach(() => { homeDir = mkTempHome(); });
   afterEach(() => { fs.rmSync(homeDir, { recursive: true, force: true }); });
 
-  it('record-green still rejects silent verifiers by default (regression guard)', () => {
+  it('tdd-phase-state record-green still rejects silent verifiers by default', () => {
     seedGreenPhase(homeDir, 'TEST-DOCS-1');
     const r = runCli('record-green TEST-DOCS-1 --cmd \'eval ""\'', homeDir);
     assert.notStrictEqual(r.exitCode, 0, 'default invocation must still reject empty output');
     assert.match(r.stderr, /empty-command trap|NO stdout\/stderr/i);
   });
 
-  it('record-green accepts silent verifiers when --docs-exempt flag is set', () => {
+  it('tdd-phase-state record-green accepts silent verifiers when docs-exempt flag is set', () => {
     const statePath = seedGreenPhase(homeDir, 'TEST-DOCS-2');
     const r = runCli('record-green TEST-DOCS-2 --docs-exempt --cmd \'eval ""\'', homeDir);
     assert.strictEqual(

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-docs-exempt.integration.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-docs-exempt.integration.test.js
@@ -46,8 +46,11 @@ function runCli(args, homeDir) {
 }
 
 function seedGreenPhase(homeDir, ticket) {
-  runCli(['init', ticket], homeDir);
-  const statePath = path.join(homeDir, 'worktrees', 'tasks', ticket, 'tdd-phase.json');
+  // GH-528 round-2 follow-up (Cursor[bot] HIGH): --docs-exempt requires
+  // --task <N> so the recorder can resolve the active task block on disk.
+  // Seed with --task 1 (per-task state path) instead of ticket-root.
+  runCli(['init', ticket, '--task', '1'], homeDir);
+  const statePath = path.join(homeDir, 'worktrees', 'tasks', ticket, 'task1', 'tdd-phase.json');
   const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
   state.currentPhase = 'green';
   state.cycles = [
@@ -62,12 +65,7 @@ function seedGreenPhase(homeDir, ticket) {
     },
   ];
   fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
-  // GH-528 round-2 follow-up (Cursor[bot] HIGH/Medium): record-green's
-  // `--docs-exempt` flag is now gated on the active task's Type via on-disk
-  // tasks.md. Plant a Type=docs task so the relaxation contract test still
-  // passes through the new gate. The seed leaves taskNum unset on the CLI
-  // call, so the recorder falls back to the legacy ticket-root state path;
-  // tasks.md still lives at the ticket root and the gate reads `Task 1`.
+  // Plant tasks.md so the Type-gate accepts --docs-exempt for Type=docs.
   fs.writeFileSync(
     path.join(homeDir, 'worktrees', 'tasks', ticket, 'tasks.md'),
     [
@@ -95,14 +93,17 @@ describe('RC-D --docs-exempt relaxation', () => {
 
   it('tdd-phase-state record-green still rejects silent verifiers by default', () => {
     seedGreenPhase(homeDir, 'TEST-DOCS-1');
-    const r = runCli(['record-green', 'TEST-DOCS-1', '--cmd', 'eval ""'], homeDir);
+    const r = runCli(['record-green', 'TEST-DOCS-1', '--task', '1', '--cmd', 'eval ""'], homeDir);
     assert.notStrictEqual(r.exitCode, 0, 'default invocation must still reject empty output');
     assert.match(r.stderr, /empty-command trap|NO stdout\/stderr/i);
   });
 
   it('tdd-phase-state record-green accepts silent verifiers when docs-exempt flag is set', () => {
     const statePath = seedGreenPhase(homeDir, 'TEST-DOCS-2');
-    const r = runCli(['record-green', 'TEST-DOCS-2', '--docs-exempt', '--cmd', 'eval ""'], homeDir);
+    const r = runCli(
+      ['record-green', 'TEST-DOCS-2', '--task', '1', '--docs-exempt', '--cmd', 'eval ""'],
+      homeDir
+    );
     assert.strictEqual(
       r.exitCode,
       0,

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-exception-gated.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-exception-gated.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const CLI = path.resolve(__dirname, '..', 'tdd-phase-state.js');
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gh528-exc-'));
+}
+
+function runWithEnv(args, env) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+}
+
+test('GH-528: `exception` is blocked when WORK_OPERATOR_TOKEN is unset and WORK_TDD_TOKEN_SKIP is unset', () => {
+  const tmp = mkTmp();
+  try {
+    const env = {
+      HOME: tmp,
+      TASKS_BASE: path.join(tmp, 'tasks'),
+      // Bypass the agent-token gate so we get past line ~1020 and into
+      // cmdException; but leave WORK_OPERATOR_TOKEN unset so the new
+      // operator-only gate inside cmdException fires.
+      WORK_TDD_TOKEN_SKIP: '1',
+      WORK_OPERATOR_TOKEN: '',
+    };
+    const r = runWithEnv(
+      ['exception', 'TEST-1', '--category', 'config-only', '--reason', 'x'],
+      env
+    );
+    assert.notStrictEqual(r.status, 0, 'exception should be blocked without operator token');
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.match(
+      combined,
+      /operator-only|WORK_OPERATOR_TOKEN|Type taxonomy/i,
+      'error should mention operator gate'
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('GH-528: `exception` allowed when WORK_OPERATOR_TOKEN=1 (escape hatch)', () => {
+  const tmp = mkTmp();
+  try {
+    // First init a workspace so the workspace-marker check passes
+    const env = {
+      HOME: tmp,
+      TASKS_BASE: path.join(tmp, 'tasks'),
+      WORK_TDD_TOKEN_SKIP: '1', // skip token gating in this test
+      WORK_OPERATOR_TOKEN: '1', // open the operator escape hatch
+    };
+    // Need a workspace marker to satisfy requireTicketWorkspace
+    const ticketDir = path.join(tmp, 'tasks', 'TEST-EX');
+    fs.mkdirSync(ticketDir, { recursive: true });
+    fs.writeFileSync(path.join(ticketDir, 'ticket.json'), '{}');
+
+    const r = runWithEnv(
+      ['exception', 'TEST-EX', '--category', 'config-only', '--reason', 'op rescue'],
+      env
+    );
+    // Either exits 0 (happy) OR fails for unrelated reasons (e.g. new-export
+    // check that needs git). We just need to confirm it got PAST the
+    // operator-token gate. The gate's error message would mention
+    // "WORK_OPERATOR_TOKEN"; if we don't see that, we passed it.
+    const combined = (r.stdout || '') + (r.stderr || '');
+    assert.doesNotMatch(
+      combined,
+      /WORK_OPERATOR_TOKEN/,
+      'with WORK_OPERATOR_TOKEN=1, the gate must not fire'
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-mechanical-refactor-red.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-mechanical-refactor-red.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+/**
+ * tdd-phase-state.js record-red — mechanical-refactor + bare-CLI fixes
+ * (GH-528 round-2 follow-up, Cursor[bot] comments).
+ *
+ * Bug 1 (mechanical-refactor RED wedge):
+ *   gateContractFor('mechanical-refactor') returns redRequiresTestFiles=false,
+ *   so task-next.js takes the RED fallback when no test files are in scope.
+ *   But docsExemptForward is driven by rcdEmptyTrap===false (NOT by
+ *   redRequiresTestFiles) — so for mechanical-refactor (rcdEmptyTrap=true)
+ *   the recorder gets docsExempt=false and rejects the call with "No test
+ *   files changed". Verifier-only mechanical-refactor tasks wedge.
+ *
+ *   Fix: add a separate `--red-skip-file-guard` flag that relaxes ONLY the
+ *   RED "no test files changed" guard, independent of `--docs-exempt`
+ *   (which still controls the RC-D empty-output trap at GREEN/REFACTOR).
+ *
+ * Bug 2 (bare CLI exits zero silently):
+ *   `node tdd-phase-state.js` with no subcommand currently calls
+ *   process.exit(0) when argv.length < 3 — to support `node --test`
+ *   loading the file. Operators / wrappers misread a no-arg invocation as
+ *   success.
+ *
+ *   Fix: distinguish "loaded by node --test" (require.main !== module)
+ *   from "directly invoked with no args" (require.main === module &&
+ *   argv.length < 3). Only the former is silent; the latter errors.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const CLI = path.resolve(__dirname, '..', 'tdd-phase-state.js');
+const TICKET = 'TEST-528-MR';
+
+function makeTasksBase() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdd-mr-'));
+  fs.mkdirSync(path.join(dir, TICKET, 'task1'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, TICKET, '.work' + '-state.json'),
+    JSON.stringify({ ticketId: TICKET })
+  );
+  return dir;
+}
+
+function runCli(args, tasksBase, extraEnv = {}) {
+  // Run from a non-git cwd so `git diff` inside record-red returns no
+  // changed files — otherwise the project's own dirty tree leaks in and
+  // the testFiles guard never triggers.
+  return spawnSync('node', [CLI, ...args], {
+    cwd: tasksBase,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TASKS_BASE: tasksBase,
+      WORK_TDD_TOKEN_SKIP: '1',
+      WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+      ...extraEnv,
+    },
+  });
+}
+
+// ── Bug 1: mechanical-refactor RED wedge ────────────────────────────────────
+
+describe('tdd-phase-state record-red — mechanical-refactor / verifier-only', () => {
+  let tasksBase;
+  beforeEach(() => {
+    tasksBase = makeTasksBase();
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+  });
+  afterEach(() => {
+    if (tasksBase) fs.rmSync(tasksBase, { recursive: true, force: true });
+  });
+
+  it('record-red without --docs-exempt and without test-file changes is REJECTED (current contract)', () => {
+    // Sanity: confirm the wedge condition exists today — no test files
+    // changed + no relaxation flag → errorExit.
+    const r = runCli(
+      ['record-red', TICKET, '--task', '1', '--cmd', 'node -e "process.exit(1)"'],
+      tasksBase
+    );
+    assert.notEqual(r.status, 0, `expected non-zero exit; stderr=${r.stderr}`);
+    assert.match(r.stderr, /No test files changed/);
+  });
+
+  it('record-red --red-skip-file-guard accepts RED when test command fails but no test files changed', () => {
+    // The new flag relaxes the "No test files changed" guard for Types
+    // whose contract sets redRequiresTestFiles=false (mechanical-refactor,
+    // tests-only fallback, etc.). The test command must still FAIL.
+    const r = runCli(
+      [
+        'record-red',
+        TICKET,
+        '--task',
+        '1',
+        '--cmd',
+        'node -e "process.exit(1)"',
+        '--red-skip-file-guard',
+      ],
+      tasksBase
+    );
+    assert.equal(r.status, 0, `expected accept; stderr=${r.stderr} stdout=${r.stdout}`);
+  });
+
+  it('record-red --red-skip-file-guard still requires the test command to FAIL', () => {
+    // Critical contract: the flag relaxes the file-guard, NOT the
+    // exit-code guard. RED still means "verifier fails before the
+    // refactor / fix".
+    const r = runCli(
+      [
+        'record-red',
+        TICKET,
+        '--task',
+        '1',
+        '--cmd',
+        'node -e "process.exit(0)"',
+        '--red-skip-file-guard',
+      ],
+      tasksBase
+    );
+    assert.notEqual(r.status, 0, `expected reject when cmd passes; stderr=${r.stderr}`);
+    assert.match(r.stderr, /Tests must FAIL/);
+  });
+});
+
+// ── Bug 2: bare CLI exits zero silently ─────────────────────────────────────
+
+describe('tdd-phase-state CLI — bare invocation', () => {
+  it('node tdd-phase-state.js with no args exits non-zero (no silent success)', () => {
+    const r = spawnSync('node', [CLI], {
+      encoding: 'utf8',
+      env: { ...process.env, WORK_TDD_TOKEN_SKIP: '1', WORK_TDD_SKIP_WORKSPACE_CHECK: '1' },
+    });
+    assert.notEqual(
+      r.status,
+      0,
+      `bare CLI must not silently succeed; stdout=${r.stdout} stderr=${r.stderr}`
+    );
+  });
+
+  it('node tdd-phase-state.js prints a usage hint on bare invocation', () => {
+    const r = spawnSync('node', [CLI], {
+      encoding: 'utf8',
+      env: { ...process.env, WORK_TDD_TOKEN_SKIP: '1', WORK_TDD_SKIP_WORKSPACE_CHECK: '1' },
+    });
+    const combined = (r.stderr || '') + (r.stdout || '');
+    assert.match(
+      combined,
+      /Usage|subcommand|init|record-red/i,
+      `expected usage hint on bare invocation; got: ${combined}`
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-mechanical-refactor-red.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-mechanical-refactor-red.test.js
@@ -252,6 +252,168 @@ describe('tdd-phase-state record-red --red-skip-file-guard — Type gate', () =>
   });
 });
 
+// ── Bug 5: --docs-exempt must require contract+scope (Cursor[bot] HIGH/Medium) ──
+//
+// Same shape as --red-skip-file-guard and record-skip-red: the recorder
+// honors `--docs-exempt` from argv alone across all three record phases
+// (record-red, record-green, record-refactor) without consulting the active
+// task's Type. A tokened agent can pass --docs-exempt on a tdd-code task to
+// skip the RED file guard or the GREEN/REFACTOR RC-D empty-output trap.
+//
+// Gate the flag on `gateContractFor(type).rcdEmptyTrap === false` (matches
+// the orchestrator's `contractAllowsDocsExempt` discriminator). Visual-only
+// Storybook scope is an orthogonal allow path covered by reading the task's
+// Files in scope from tasks.md.
+
+function makeTasksBaseWithScope(type, scope) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdd-de-'));
+  fs.mkdirSync(path.join(dir, TICKET, 'task1'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, TICKET, '.work' + '-state.json'),
+    JSON.stringify({ ticketId: TICKET })
+  );
+  const lines = [
+    '## Task 1 — sample',
+    '',
+    '### Type',
+    type,
+    '',
+    '### Files in scope',
+    ...scope.map((s) => `- ${s}`),
+    '',
+  ];
+  fs.writeFileSync(path.join(dir, TICKET, 'tasks.md'), lines.join('\n'));
+  return dir;
+}
+
+describe('tdd-phase-state record-red --docs-exempt — Type gate', () => {
+  let tasksBase;
+  afterEach(() => {
+    if (tasksBase) {
+      fs.rmSync(tasksBase, { recursive: true, force: true });
+      tasksBase = null;
+    }
+  });
+
+  it('--docs-exempt is REJECTED at record-red for Type=tdd-code', () => {
+    tasksBase = makeTasksBaseWithScope('tdd-code', ['src/**']);
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    const r = runCli(
+      ['record-red', TICKET, '--task', '1', '--cmd', 'node -e "process.exit(1)"', '--docs-exempt'],
+      tasksBase
+    );
+    assert.notEqual(r.status, 0, `--docs-exempt must be rejected for tdd-code; stderr=${r.stderr}`);
+    assert.match(r.stderr, /docs-exempt|tdd-code|Type/);
+  });
+
+  it('--docs-exempt is HONORED at record-red for Type=docs', () => {
+    tasksBase = makeTasksBaseWithScope('docs', ['README.md']);
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    const r = runCli(
+      ['record-red', TICKET, '--task', '1', '--cmd', 'node -e "process.exit(1)"', '--docs-exempt'],
+      tasksBase
+    );
+    assert.equal(r.status, 0, `expected accept; stderr=${r.stderr}`);
+  });
+
+  it('--docs-exempt is HONORED for visual-only Storybook scope (any Type)', () => {
+    // Visual-only Storybook tasks have all scope entries matching
+    // *.stories.[jt]sx? — orchestrator forwards --docs-exempt regardless
+    // of Type. Recorder must honor the same allow-path.
+    tasksBase = makeTasksBaseWithScope('tdd-code', [
+      'src/Button.stories.tsx',
+      'src/Card.stories.tsx',
+    ]);
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    const r = runCli(
+      ['record-red', TICKET, '--task', '1', '--cmd', 'node -e "process.exit(1)"', '--docs-exempt'],
+      tasksBase
+    );
+    assert.equal(r.status, 0, `visual-only scope must allow --docs-exempt; stderr=${r.stderr}`);
+  });
+});
+
+describe('tdd-phase-state record-green --docs-exempt — Type gate', () => {
+  let tasksBase;
+  afterEach(() => {
+    if (tasksBase) {
+      fs.rmSync(tasksBase, { recursive: true, force: true });
+      tasksBase = null;
+    }
+  });
+
+  it('--docs-exempt is REJECTED at record-green for Type=tdd-code', () => {
+    tasksBase = makeTasksBaseWithScope('tdd-code', ['src/**']);
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    // Advance to green via record-red with redSkipFileGuard for setup
+    // would require mechanical-refactor — instead, transition directly.
+    const transition = runCli(['transition', TICKET, 'green', '--task', '1'], tasksBase);
+    // Transition may fail in test fixture; what we care about is the
+    // docs-exempt rejection at record-green. Force currentPhase via direct
+    // file edit if transition refused — keep test focused on the gate.
+    if (transition.status !== 0) {
+      const statePath = path.join(tasksBase, TICKET, 'task1', 'tdd-phase.json');
+      const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+      state.currentPhase = 'green';
+      fs.writeFileSync(statePath, JSON.stringify(state));
+    }
+    const r = runCli(
+      [
+        'record-green',
+        TICKET,
+        '--task',
+        '1',
+        '--cmd',
+        'node -e "console.log(\'ok\')"',
+        '--docs-exempt',
+      ],
+      tasksBase
+    );
+    assert.notEqual(r.status, 0, `--docs-exempt must be rejected for tdd-code; stderr=${r.stderr}`);
+    assert.match(r.stderr, /docs-exempt|tdd-code|Type/);
+  });
+});
+
+describe('tdd-phase-state record-refactor --docs-exempt — Type gate', () => {
+  let tasksBase;
+  afterEach(() => {
+    if (tasksBase) {
+      fs.rmSync(tasksBase, { recursive: true, force: true });
+      tasksBase = null;
+    }
+  });
+
+  it('--docs-exempt is REJECTED at record-refactor for Type=tdd-code', () => {
+    tasksBase = makeTasksBaseWithScope('tdd-code', ['src/**']);
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    // Force currentPhase to refactor — focus the test on the gate, not
+    // the full RED→GREEN→REFACTOR ramp.
+    const statePath = path.join(tasksBase, TICKET, 'task1', 'tdd-phase.json');
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    state.currentPhase = 'refactor';
+    fs.writeFileSync(statePath, JSON.stringify(state));
+    const r = runCli(
+      [
+        'record-refactor',
+        TICKET,
+        '--task',
+        '1',
+        '--cmd',
+        'node -e "console.log(\'ok\')"',
+        '--docs-exempt',
+      ],
+      tasksBase
+    );
+    assert.notEqual(r.status, 0, `--docs-exempt must be rejected for tdd-code; stderr=${r.stderr}`);
+    assert.match(r.stderr, /docs-exempt|tdd-code|Type/);
+  });
+});
+
 // ── Bug 2: bare CLI exits zero silently ─────────────────────────────────────
 
 describe('tdd-phase-state CLI — bare invocation', () => {

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-mechanical-refactor-red.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-mechanical-refactor-red.test.js
@@ -378,6 +378,37 @@ describe('tdd-phase-state record-green --docs-exempt — Type gate', () => {
   });
 });
 
+describe('tdd-phase-state --docs-exempt — no-task bypass closed (Cursor[bot] HIGH)', () => {
+  // Earlier draft of ITEM 8 fell through for no-task callers — that left
+  // the gate exploitable by omitting --task. The legacy compat shim is
+  // removed; missing --task fails closed.
+  let tasksBase;
+  afterEach(() => {
+    if (tasksBase) {
+      fs.rmSync(tasksBase, { recursive: true, force: true });
+      tasksBase = null;
+    }
+  });
+
+  it('--docs-exempt without --task is REJECTED (no legacy bypass)', () => {
+    tasksBase = makeTasksBaseWithScope('tdd-code', ['src/**']);
+    // Init at ticket root (no --task) so the legacy ticket-root state path
+    // exists and currentPhase is RED.
+    const init = runCli(['init', TICKET], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    const r = runCli(
+      ['record-red', TICKET, '--cmd', 'node -e "process.exit(1)"', '--docs-exempt'],
+      tasksBase
+    );
+    assert.notEqual(
+      r.status,
+      0,
+      `--docs-exempt without --task must be rejected; stderr=${r.stderr}`
+    );
+    assert.match(r.stderr, /--task|docs-exempt/);
+  });
+});
+
 describe('tdd-phase-state record-refactor --docs-exempt — Type gate', () => {
   let tasksBase;
   afterEach(() => {

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-mechanical-refactor-red.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-mechanical-refactor-red.test.js
@@ -37,13 +37,27 @@ const { spawnSync } = require('node:child_process');
 const CLI = path.resolve(__dirname, '..', 'tdd-phase-state.js');
 const TICKET = 'TEST-528-MR';
 
-function makeTasksBase() {
+function makeTasksBase(type = 'mechanical-refactor') {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdd-mr-'));
   fs.mkdirSync(path.join(dir, TICKET, 'task1'), { recursive: true });
   fs.writeFileSync(
     path.join(dir, TICKET, '.work' + '-state.json'),
     JSON.stringify({ ticketId: TICKET })
   );
+  // GH-528 round-2 follow-up: the recorder now reads the active task's
+  // Type from tasks.md to gate `--red-skip-file-guard` and `record-skip-red`.
+  // Write a minimal tasks.md with the requested Type.
+  const tasksMd = [
+    '## Task 1 — sample',
+    '',
+    '### Type',
+    type,
+    '',
+    '### Files in scope',
+    '- src/**',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, TICKET, 'tasks.md'), tasksMd);
   return dir;
 }
 
@@ -125,6 +139,116 @@ describe('tdd-phase-state record-red — mechanical-refactor / verifier-only', (
     );
     assert.notEqual(r.status, 0, `expected reject when cmd passes; stderr=${r.stderr}`);
     assert.match(r.stderr, /Tests must FAIL/);
+  });
+});
+
+// ── Bug 3: record-skip-red must require Type=tests-only (Cursor[bot] HIGH) ──
+
+describe('tdd-phase-state record-skip-red — Type gate', () => {
+  let tasksBase;
+  afterEach(() => {
+    if (tasksBase) {
+      fs.rmSync(tasksBase, { recursive: true, force: true });
+      tasksBase = null;
+    }
+  });
+
+  it('record-skip-red is REJECTED for Type=tdd-code (closes self-report surface)', () => {
+    tasksBase = makeTasksBase('tdd-code');
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    const r = runCli(
+      ['record-skip-red', TICKET, '--task', '1', '--reason', 'agent claims tests-only'],
+      tasksBase
+    );
+    assert.notEqual(
+      r.status,
+      0,
+      `record-skip-red must reject non-tests-only Types; stderr=${r.stderr}`
+    );
+    assert.match(r.stderr, /tests-only|Type/);
+  });
+
+  it('record-skip-red is REJECTED for Type=mechanical-refactor', () => {
+    tasksBase = makeTasksBase('mechanical-refactor');
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    const r = runCli(
+      ['record-skip-red', TICKET, '--task', '1', '--reason', 'bypass attempt'],
+      tasksBase
+    );
+    assert.notEqual(r.status, 0, `stderr=${r.stderr}`);
+  });
+
+  it('record-skip-red is ACCEPTED for Type=tests-only (contract still works)', () => {
+    tasksBase = makeTasksBase('tests-only');
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    const r = runCli(
+      ['record-skip-red', TICKET, '--task', '1', '--reason', 'tests-only task'],
+      tasksBase
+    );
+    assert.equal(r.status, 0, `expected accept; stderr=${r.stderr}`);
+  });
+});
+
+// ── Bug 4: --red-skip-file-guard must require contract-allowed Type (Cursor[bot] HIGH) ──
+
+describe('tdd-phase-state record-red --red-skip-file-guard — Type gate', () => {
+  let tasksBase;
+  afterEach(() => {
+    if (tasksBase) {
+      fs.rmSync(tasksBase, { recursive: true, force: true });
+      tasksBase = null;
+    }
+  });
+
+  it('--red-skip-file-guard is IGNORED for Type=tdd-code (file guard re-fires)', () => {
+    // For tdd-code, gateContractFor.redRequiresTestFiles === true. A direct
+    // CLI call with --red-skip-file-guard from an allow-listed agent must
+    // NOT relax the guard — agent self-report on the file guard is the exact
+    // shape no-fake-tdd-evidence guards against.
+    tasksBase = makeTasksBase('tdd-code');
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    const r = runCli(
+      [
+        'record-red',
+        TICKET,
+        '--task',
+        '1',
+        '--cmd',
+        'node -e "process.exit(1)"',
+        '--red-skip-file-guard',
+      ],
+      tasksBase
+    );
+    assert.notEqual(
+      r.status,
+      0,
+      `--red-skip-file-guard must be ignored for tdd-code; stderr=${r.stderr}`
+    );
+    assert.match(r.stderr, /No test files changed|tests-only|Type/);
+  });
+
+  it('--red-skip-file-guard is HONORED for Type=mechanical-refactor', () => {
+    // mechanical-refactor.redRequiresTestFiles === false → flag is valid.
+    tasksBase = makeTasksBase('mechanical-refactor');
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+    const r = runCli(
+      [
+        'record-red',
+        TICKET,
+        '--task',
+        '1',
+        '--cmd',
+        'node -e "process.exit(1)"',
+        '--red-skip-file-guard',
+      ],
+      tasksBase
+    );
+    assert.equal(r.status, 0, `expected accept; stderr=${r.stderr}`);
   });
 });
 

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-tests-only.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-tests-only.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * tdd-phase-state.js record-skip-red — tests-only contract (GH-528).
+ *
+ * Type=tests-only tasks add tests against code that already works — there is
+ * no "failing test → passing implementation" cycle. RED is intentionally
+ * skipped. Acceptance:
+ *
+ *   - `record-skip-red <TICKET> --task N --reason "tests-only"` accepts the
+ *     skip, persists the cycle's `red` slot with `{skipped: true, reason}`,
+ *     and transitions currentPhase RED → GREEN.
+ *   - The persisted state clearly shows RED was intentionally skipped — not
+ *     faked. The marker is the structured `{skipped: true}` field, not a
+ *     synthetic test command.
+ *   - Reason is required (empty reason → BYPASS line, no state change).
+ *   - record-skip-red ignores --cmd entirely (no test command runs).
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const CLI = path.resolve(__dirname, '..', 'tdd-phase-state.js');
+const TICKET = 'TEST-528';
+
+function makeTasksBase() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tdd-tests-only-'));
+  // Pre-create the ticket workspace marker so writeState's
+  // requireTicketWorkspace check passes.
+  fs.mkdirSync(path.join(dir, TICKET, 'task1'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, TICKET, '.work' + '-state.json'),
+    JSON.stringify({ ticketId: TICKET })
+  );
+  return dir;
+}
+
+function runCli(args, tasksBase) {
+  return spawnSync('node', [CLI, ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TASKS_BASE: tasksBase,
+      WORK_TDD_TOKEN_SKIP: '1', // gate covered by other tests
+      WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+    },
+  });
+}
+
+describe('tdd-phase-state record-skip-red — tests-only contract', () => {
+  let tasksBase;
+  beforeEach(() => {
+    tasksBase = makeTasksBase();
+    // init phase state
+    const init = runCli(['init', TICKET, '--task', '1'], tasksBase);
+    assert.equal(init.status, 0, `init failed: ${init.stderr}`);
+  });
+  afterEach(() => {
+    if (tasksBase) fs.rmSync(tasksBase, { recursive: true, force: true });
+  });
+
+  it('record-skip-red --reason "tests-only" advances RED→GREEN with skipped marker', () => {
+    const r = runCli(
+      ['record-skip-red', TICKET, '--task', '1', '--reason', 'tests-only task'],
+      tasksBase
+    );
+    assert.equal(r.status, 0, `expected 0; stdout=${r.stdout} stderr=${r.stderr}`);
+    const statePath = path.join(tasksBase, TICKET, 'task1', 'tdd' + '-phase' + '.json');
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assert.equal(state.currentPhase, 'green');
+    const cycle = state.cycles.find((c) => c.cycle === 1);
+    assert.ok(cycle && cycle.red, 'expected red slot to be populated');
+    assert.equal(cycle.red.skipped, true, 'red.skipped must be true');
+    assert.equal(cycle.red.reason, 'tests-only task');
+    // No testCommand field — record-skip-red never runs a command.
+    assert.equal(cycle.red.testCommand, undefined);
+  });
+
+  it('record-skip-red rejects empty reason (no state change, BYPASS line)', () => {
+    const r = runCli(['record-skip-red', TICKET, '--task', '1', '--reason', ''], tasksBase);
+    assert.notEqual(r.status, 0, 'expected non-zero exit on empty reason');
+    assert.match(`${r.stdout}\n${r.stderr}`, /BYPASS:|reason/i);
+    // State must still be RED.
+    const statePath = path.join(tasksBase, TICKET, 'task1', 'tdd' + '-phase' + '.json');
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assert.equal(state.currentPhase, 'red');
+  });
+
+  it('record-skip-red rejects when current phase is not RED', () => {
+    // Move to GREEN first via the skip path.
+    runCli(['record-skip-red', TICKET, '--task', '1', '--reason', 'first skip'], tasksBase);
+    // Now try to record-skip-red again — should reject.
+    const r = runCli(['record-skip-red', TICKET, '--task', '1', '--reason', 'second'], tasksBase);
+    assert.notEqual(r.status, 0);
+    assert.match(`${r.stdout}\n${r.stderr}`, /current phase/i);
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-tests-only.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-tests-only.test.js
@@ -36,6 +36,23 @@ function makeTasksBase() {
     path.join(dir, TICKET, '.work' + '-state.json'),
     JSON.stringify({ ticketId: TICKET })
   );
+  // GH-528 round-2 follow-up (Cursor[bot] HIGH): record-skip-red now reads
+  // the active task's Type from on-disk tasks.md and requires it to be
+  // exactly `tests-only`. Plant a minimal tasks.md so the tests-only
+  // contract tests still satisfy the new Type gate.
+  fs.writeFileSync(
+    path.join(dir, TICKET, 'tasks.md'),
+    [
+      '## Task 1 — sample',
+      '',
+      '### Type',
+      'tests-only',
+      '',
+      '### Files in scope',
+      '- src/**/*.test.js',
+      '',
+    ].join('\n')
+  );
   return dir;
 }
 

--- a/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state.test.js
@@ -26,9 +26,10 @@ function createExitScript(dir, exitCode) {
   // completely empty output (that's the empty-command trap). Real test
   // runners always print something, so test fixtures that stand in for
   // them must too.
-  const body = exitCode === 0
-    ? `#!/bin/sh\necho 'simulated test runner: 1 passed'\nexit 0\n`
-    : `#!/bin/sh\necho 'simulated test runner: 1 failed' >&2\nexit ${exitCode}\n`;
+  const body =
+    exitCode === 0
+      ? `#!/bin/sh\necho 'simulated test runner: 1 passed'\nexit 0\n`
+      : `#!/bin/sh\necho 'simulated test runner: 1 failed' >&2\nexit ${exitCode}\n`;
   fs.writeFileSync(scriptPath, body, { mode: 0o755 });
   return scriptPath;
 }
@@ -70,6 +71,9 @@ function runCli(args, homeDir, cwd) {
         TASKS_BASE: tasksBase,
         WORK_TDD_TOKEN_SKIP: '1',
         WORK_TDD_SKIP_WORKSPACE_CHECK: '1',
+        // GH-528: `exception` subcommand is now operator-only.
+        // Tests act as the operator.
+        WORK_OPERATOR_TOKEN: '1',
       },
       stdio: ['pipe', 'pipe', 'pipe'],
       ...(cwd ? { cwd } : {}),

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -621,6 +621,14 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope, opts = {}) {
     ) {
       recordArgs.push('--docs-exempt');
     }
+    // GH-528 round-2 follow-up (Cursor[bot] medium): mechanical-refactor
+    // and other Types whose contract sets `redRequiresTestFiles === false`
+    // need the RED "no test files changed" guard relaxed without
+    // implying RC-D relaxation at GREEN/REFACTOR. The `--docs-exempt`
+    // flag conflated both; this flag covers only the RED file guard.
+    if (opts && opts.redSkipFileGuard === true && phase === TDD_PHASES.red) {
+      recordArgs.push('--red-skip-file-guard');
+    }
     return spawnSync(process.execPath, recordArgs, {
       cwd,
       stdio: 'pipe',
@@ -1133,8 +1141,17 @@ function main() {
           // they bypass the RED file guard, keeping RC-D protection intact for
           // GREEN/REFACTOR. For docs/config/ci/file-move/checkpoint the trap
           // is also relaxed by contract.
+          //
+          // GH-528 round-2 follow-up (Cursor[bot] medium): the recorder also
+          // has a "No test files changed" guard at RED that fires
+          // independently of RC-D. Without forwarding `--red-skip-file-guard`,
+          // mechanical-refactor (redRequiresTestFiles=false, rcdEmptyTrap=true)
+          // wedges: the orchestrator accepts the fallback, the recorder
+          // rejects it. Forward `redSkipFileGuard: true` whenever this branch
+          // fires — by definition the contract has waived the file guard.
           const rec = recordEvidence(TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope, {
             docsExempt: docsExemptForward,
+            redSkipFileGuard: true,
           });
           if (!rec.ok) {
             blockReason = `Could not record RED evidence:\n${rec.out}`;

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -448,25 +448,15 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope, opts = {}) {
       '--cmd',
       wrapStrictMode(cmd),
     ];
-    // Task 4 (GH-528): when the orchestrator detects a docs-exempt or
-    // visual-only GREEN, forward `--docs-exempt` so the recorder relaxes
-    // the RC-D empty-command trap for this single invocation. Sibling of
-    // the RED-side fallback emitted around line 909.
-    if (opts && opts.docsExempt === true && phase === TDD_PHASES.green) {
-      recordArgs.push('--docs-exempt');
-    }
-    // Task 4 (GH-528): RED-side parity — the existing RED docs-exempt
-    // fallback (line ~911) calls recordEvidence without opts when scope
-    // contains zero test files (the documented docs-exempt/visual-only
-    // shape). The recorder's `record-red` "No test files changed" guard
-    // would otherwise reject. Auto-forward `--docs-exempt` for that exact
-    // shape so the recorder accepts the documentation-task RED evidence.
-    // This is a recordEvidence-internal heuristic and does NOT modify the
-    // sibling-owned RED branch call site at line ~911.
+    // Task 4 (GH-528): caller opt-in for `--docs-exempt` (symmetric across
+    // RED and GREEN). Only the docs-exempt / visual-only RED and GREEN
+    // fallback call sites pass `opts.docsExempt: true`. All other callers
+    // get default behavior so the RED test-file guard and GREEN RC-D
+    // empty-command trap stay armed for normal code tasks.
     if (
-      phase === TDD_PHASES.red &&
-      Array.isArray(scope) &&
-      filterToTestFiles(scope).length === 0
+      opts &&
+      opts.docsExempt === true &&
+      (phase === TDD_PHASES.red || phase === TDD_PHASES.green)
     ) {
       recordArgs.push('--docs-exempt');
     }
@@ -928,7 +918,10 @@ function main() {
           // command failed as RED requires (exitCode !== 0 confirmed above).
           // Accept it. Fires for documentation tasks (isDocsExempt) and for
           // Storybook stories-only tasks (isVisualOnlyTask).
-          const rec = recordEvidence(TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope);
+          const rec = recordEvidence(
+            TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope,
+            { docsExempt: true }
+          );
           if (!rec.ok) {
             blockReason = `Could not record RED evidence:\n${rec.out}`;
           } else {

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -70,6 +70,43 @@ function filterToTestFiles(scope) {
 }
 
 /**
+ * Classify a `### Files in scope` entry: does its match set consist
+ * EXCLUSIVELY of test/spec files?
+ *
+ * Used by the Type=tests-only GREEN gate (cursor[bot] review, GH-528):
+ * the previous check applied a raw extension test to each entry, which
+ * mis-rejected glob patterns whose basename DOES constrain to test
+ * files (e.g. `plugins/work/**\/*.test.js`) while needing to keep
+ * rejecting open-ended globs like `src/**` that admit non-test files.
+ *
+ * Rules:
+ *   - Empty / non-string                                     → false.
+ *   - Glob entry (contains `*`): inspect its basename — the
+ *     segment after the last `/`. Accept iff the basename ends in
+ *     `*.test.<ext>` / `*.spec.<ext>` (ext one of j/tsx?). This
+ *     accepts `src/**\/*.test.js` and rejects `src/**`, `lib/**\/*.js`.
+ *   - Literal entry: delegate to the same test-extension regex used
+ *     by `filterToTestFiles`. Accept `src/foo.test.js`, reject
+ *     `src/foo.js`.
+ *
+ * @param {string} entry
+ * @returns {boolean}
+ */
+function scopeEntryAdmitsOnlyTestFiles(entry) {
+  if (typeof entry !== 'string' || !entry) return false;
+  const isGlob = entry.includes('*');
+  if (!isGlob) {
+    return /\.(test|spec)\.[jt]sx?$/i.test(entry);
+  }
+  // Glob: examine the basename. A glob whose final segment ends in a
+  // test-file extension pattern admits ONLY test files; any other
+  // shape could match a non-test file.
+  const lastSlash = entry.lastIndexOf('/');
+  const basename = lastSlash >= 0 ? entry.slice(lastSlash + 1) : entry;
+  return /\.(test|spec)\.[jt]sx?$/i.test(basename);
+}
+
+/**
  * Wrap chained / multiline shell commands in strict mode so that
  * middle-of-chain failures surface as a non-zero exit (instead of
  * being masked by a successful final command).
@@ -1188,7 +1225,14 @@ function main() {
       // also checks this — defense in depth), and (b) at least one in-scope
       // test file was actually modified vs. HEAD. Without (b) the agent
       // could no-op into GREEN.
-      const nonTestInScope = scope.filter((p) => p && !/\.(test|spec)\.[jt]sx?$/i.test(p));
+      // cursor[bot] review (GH-528): classify each scope entry via
+      // scopeEntryAdmitsOnlyTestFiles so glob patterns whose basename
+      // constrains to test files (e.g. `src/**\/*.test.js`) are accepted,
+      // while open-ended globs (`src/**`, `lib/**\/*.js`) that admit
+      // non-test matches are still rejected. The old raw-extension test
+      // mis-rejected the former case before detectChangedTestFilesInScope
+      // had a chance to run.
+      const nonTestInScope = scope.filter((p) => p && !scopeEntryAdmitsOnlyTestFiles(p));
       if (nonTestInScope.length > 0) {
         blockReason =
           `Type=tests-only requires scope to contain ONLY *.test.* / *.spec.* files. ` +
@@ -1328,6 +1372,7 @@ function main() {
 
 module.exports = {
   filterToTestFiles,
+  scopeEntryAdmitsOnlyTestFiles,
   filterChangedTestFilesByScope,
   findTestFilesInScope,
   wrapStrictMode,

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -455,6 +455,21 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope, opts = {}) {
     if (opts && opts.docsExempt === true && phase === TDD_PHASES.green) {
       recordArgs.push('--docs-exempt');
     }
+    // Task 4 (GH-528): RED-side parity — the existing RED docs-exempt
+    // fallback (line ~911) calls recordEvidence without opts when scope
+    // contains zero test files (the documented docs-exempt/visual-only
+    // shape). The recorder's `record-red` "No test files changed" guard
+    // would otherwise reject. Auto-forward `--docs-exempt` for that exact
+    // shape so the recorder accepts the documentation-task RED evidence.
+    // This is a recordEvidence-internal heuristic and does NOT modify the
+    // sibling-owned RED branch call site at line ~911.
+    if (
+      phase === TDD_PHASES.red &&
+      Array.isArray(scope) &&
+      filterToTestFiles(scope).length === 0
+    ) {
+      recordArgs.push('--docs-exempt');
+    }
     return spawnSync(process.execPath, recordArgs, {
       cwd,
       stdio: 'pipe',
@@ -1062,6 +1077,13 @@ module.exports = {
   parseSuggestedScope,
 };
 
-if (require.main === module) {
+// Main guard: skip CLI dispatch when node:test loaded this file as a test
+// target with no CLI args (it would otherwise print usage and fail the suite
+// with zero test() blocks). Child spawns of this script always pass a ticket
+// + task arg, so they keep running main() — NODE_TEST_CONTEXT propagation
+// via inherited env is harmless when argv carries the real CLI args.
+const _isBareTestLoad =
+  process.env.NODE_TEST_CONTEXT && process.argv.length <= 2;
+if (require.main === module && !_isBareTestLoad) {
   main();
 }

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -1109,17 +1109,27 @@ function main() {
         // proving there is at least one failing test block under Suggested
         // Scope. The test command already failed (exitCode !== 0) above —
         // we just need to confirm authorship intent.
-        if (testFiles.length === 0 && (docsExempt || visualOnly)) {
+        // GH-528 review comment #7: the RED-fallback entry condition
+        // predates the closed-Type taxonomy. Drive it from the central
+        // contract — any Type whose `redRequiresTestFiles === false`
+        // (docs, config, ci, file-move, mechanical-refactor, checkpoint,
+        // tests-only) qualifies. Visual-only Storybook scope inherits the
+        // same semantics by scope shape (orthogonal to Type) and is added
+        // as an OR. tdd-code keeps `redRequiresTestFiles: true`, so it
+        // continues to require a `*.test.*` file in scope.
+        const redFileGuardWaived =
+          gateContractFor(type, scope).redRequiresTestFiles === false || visualOnly;
+        if (testFiles.length === 0 && redFileGuardWaived) {
           // Test-exempt: no `*.test.*` authorship surface, but the verification
           // command failed as RED requires (exitCode !== 0 confirmed above).
-          // Accept it. Fires for documentation tasks (isDocsExempt) and for
-          // Storybook stories-only tasks (isVisualOnlyTask).
-          // GH-528 review comment #3: drive `docsExempt` from the central
-          // contract (`gateContractFor`) rather than hard-coding `true`. For
-          // Type=docs (and visual-only Storybook scope) this resolves to
-          // true; for any other Type that reaches this fallback the trap
-          // stays armed. Guarded by the `(docsExempt || visualOnly)`
-          // condition above, so `docsExemptForward` is the right value here.
+          // Accept it. Fires for the silent-verifier-exempt Types listed above
+          // and for Storybook stories-only tasks (isVisualOnlyTask).
+          // `docsExemptForward` (driven by `rcdEmptyTrap === false || visualOnly`)
+          // is the right `--docs-exempt` forwarding value for the recorder:
+          // it stays armed for `mechanical-refactor` / `tests-only` even though
+          // they bypass the RED file guard, keeping RC-D protection intact for
+          // GREEN/REFACTOR. For docs/config/ci/file-move/checkpoint the trap
+          // is also relaxed by contract.
           const rec = recordEvidence(TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope, {
             docsExempt: docsExemptForward,
           });
@@ -1128,9 +1138,12 @@ function main() {
           } else {
             advanced = true;
             phase = TDD_PHASES.green;
+            const contractKind = gateContractFor(type, scope).kind;
             const fallbackLabel = visualOnly
               ? 'visual-only fallback (Storybook stories-only scope — no testable code surface'
-              : 'docs-exempt fallback (documentation task — no testable code surface';
+              : docsExempt
+                ? 'docs-exempt fallback (documentation task — no testable code surface'
+                : `contract fallback (Type=${contractKind} — no *.test.* authorship surface required by gate contract`;
             process.stdout.write(
               `task-next: RED accepted via ${fallbackLabel}; verification command failed as required).\n`
             );

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -412,6 +412,113 @@ function mintCompanionToken() {
 }
 
 // eslint-disable-next-line max-lines-per-function, complexity -- allowlisted pre-existing; see .quality-exceptions
+/**
+ * Persist an intentional RED skip via `tdd-phase-state.js record-skip-red`.
+ *
+ * Used for Type=tests-only tasks where RED is incoherent by design (no
+ * failing-test → passing-impl loop exists). Mirrors the spawn pattern of
+ * `recordEvidence` so token re-minting / token verification stay aligned
+ * across all phase writes. Returns `{ ok, out, exitCode }`.
+ */
+/**
+ * Return the subset of changed (vs HEAD + staged + untracked) files that are
+ * test/spec files AND fall under the task's declared scope. Used by the
+ * tests-only GREEN gate to ensure the agent actually wrote new test code
+ * (not a no-op cycle).
+ *
+ * Scope match is intentionally lenient: any changed test file whose POSIX
+ * path starts with a scope-listed directory, or matches a scope-listed file
+ * exactly, counts. Glob expansion is out of scope — Pass D enforces the
+ * planner-side allowlist.
+ */
+function detectChangedTestFilesInScope(repoRoot, scope) {
+  const out = [];
+  let diff = '';
+  let staged = '';
+  let untracked = '';
+  try {
+    diff =
+      spawnSync('git', ['diff', '--name-only'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      }).stdout || '';
+    staged =
+      spawnSync('git', ['diff', '--cached', '--name-only'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      }).stdout || '';
+    untracked =
+      spawnSync('git', ['ls-files', '--others', '--exclude-standard'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      }).stdout || '';
+  } catch {
+    /* git unavailable — treat as empty */
+  }
+  const changed = new Set(
+    [...diff.split('\n'), ...staged.split('\n'), ...untracked.split('\n')]
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+  const scopeList = Array.isArray(scope) ? scope : [];
+  for (const rel of changed) {
+    if (!/\.(test|spec)\.[jt]sx?$/i.test(rel)) continue;
+    const inScope = scopeList.some((s) => {
+      if (!s) return false;
+      if (rel === s) return true;
+      if (rel.startsWith(s.replace(/\/+$/, '') + '/')) return true;
+      return false;
+    });
+    // If scope is empty/file-only, treat any changed test file as in-scope.
+    if (scopeList.length === 0 || inScope) out.push(rel);
+  }
+  return out;
+}
+
+function recordSkipRed(ticket, taskNum, reason, cwd) {
+  mintCompanionToken();
+  const args = [TDD_CLI, 'record-skip-red', ticket, '--task', String(taskNum), '--reason', reason];
+  // Auto-init the state file the first time, mirroring recordEvidence().
+  function runOnce() {
+    mintCompanionToken();
+    return spawnSync(process.execPath, args, {
+      cwd,
+      stdio: 'pipe',
+      encoding: 'utf8',
+      env: { ...process.env },
+    });
+  }
+  let r = runOnce();
+  if (r.status !== 0) {
+    const combined = (r.stdout || '') + (r.stderr || '');
+    if (/No TDD phase state found/i.test(combined)) {
+      mintCompanionToken();
+      const initRes = spawnSync(
+        process.execPath,
+        [TDD_CLI, 'init', ticket, '--task', String(taskNum)],
+        { cwd, stdio: 'pipe', encoding: 'utf8', env: { ...process.env } }
+      );
+      if (initRes.status !== 0) {
+        return {
+          ok: false,
+          out:
+            combined +
+            '\n--- auto-init failed ---\n' +
+            (initRes.stdout || '') +
+            (initRes.stderr || ''),
+          exitCode: initRes.status,
+        };
+      }
+      r = runOnce();
+    }
+  }
+  return {
+    ok: r.status === 0,
+    out: (r.stdout || '') + (r.stderr || ''),
+    exitCode: r.status,
+  };
+}
+
 function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope, opts = {}) {
   // Delegate to tdd-phase-state.js — the only authorized writer. Forward
   // `--task N` so the recorder resolves the per-task state path. Records
@@ -779,6 +886,7 @@ function main() {
   const taskTestCmd = parseTaskTestCommand(section);
   const docsExempt = isDocsExempt(type);
   const visualOnly = isVisualOnlyTask(scope);
+  const testsOnly = type === 'tests-only';
 
   // Checkpoint tasks are verification-only — no source change, no test
   // authorship, no gherkin scenarios. Asking the agent to satisfy a TDD
@@ -887,6 +995,32 @@ function main() {
     );
   }
 
+  // Task 4 (GH-528): Type=tests-only RED-skipped contract. Tests-only tasks
+  // add coverage for code that already works — there is no "failing test →
+  // passing impl" loop, so RED is incoherent by design. Skip straight to
+  // GREEN via the dedicated record-skip-red subcommand, which persists a
+  // structured `{skipped: true, reason}` marker so the audit trail shows
+  // an intentional skip (not faked evidence — see [[no-fake-tdd-evidence]]).
+  // Verifier (test command) is then re-run by the GREEN branch below as the
+  // first real validation step.
+  if (testsOnly && phase === TDD_PHASES.red) {
+    const skip = recordSkipRed(ticket, taskNum, 'tests-only: Type contract', repoRoot);
+    if (!skip.ok) {
+      process.stdout.write(
+        `task-next: ${ticket} task${taskNum} — ${taskTitle}\n` +
+          `  state file: ${tddPath}\n` +
+          `  result:     BLOCKED in red (tests-only skip failed)\n\n` +
+          `## Why you did not advance\n\n${skip.out}\n\n`
+      );
+      process.exit(2);
+    }
+    process.stdout.write(
+      `task-next: RED skipped via tests-only Type contract; ` +
+        `cycle red slot persisted with {skipped: true}. Re-invoke me for GREEN.\n`
+    );
+    process.exit(0);
+  }
+
   // Run the test command.
   const run = runTest(testCmd, repoRoot, scope);
   const passed = run.exitCode === 0;
@@ -973,6 +1107,40 @@ function main() {
   } else if (phase === TDD_PHASES.green) {
     if (!passed) {
       blockReason = `Test command still failing (exit ${run.exitCode}). Last output:\n\n${run.combined}`;
+    } else if (testsOnly) {
+      // Task 4 (GH-528): tests-only GREEN gate. Beyond the verifier exiting
+      // 0, require (a) scope contains ONLY test files (planner-side Pass D
+      // also checks this — defense in depth), and (b) at least one in-scope
+      // test file was actually modified vs. HEAD. Without (b) the agent
+      // could no-op into GREEN.
+      const nonTestInScope = scope.filter((p) => p && !/\.(test|spec)\.[jt]sx?$/i.test(p));
+      if (nonTestInScope.length > 0) {
+        blockReason =
+          `Type=tests-only requires scope to contain ONLY *.test.* / *.spec.* files. ` +
+          `Non-test entries in scope: ${nonTestInScope.join(', ')}. ` +
+          `Move source edits to a tdd-code task, or change Type.`;
+      } else {
+        const changedTestFiles = detectChangedTestFilesInScope(repoRoot, scope);
+        if (changedTestFiles.length === 0) {
+          blockReason =
+            'Type=tests-only GREEN requires at least one in-scope test file to be modified. ' +
+            'No `*.test.*` / `*.spec.*` file under scope has changes vs. HEAD.';
+        } else {
+          const rec = recordEvidence(TDD_PHASES.green, ticket, taskNum, testCmd, repoRoot, scope, {
+            docsExempt: true,
+          });
+          if (!rec.ok) {
+            blockReason = `Could not record GREEN evidence:\n${rec.out}`;
+          } else {
+            advanced = true;
+            phase = TDD_PHASES.refactor;
+            process.stdout.write(
+              `task-next: GREEN accepted via tests-only contract; ` +
+                `${changedTestFiles.length} in-scope test file(s) modified.\n`
+            );
+          }
+        }
+      }
     } else {
       // Task 4 (GH-528): GREEN docs-exempt fallback (sibling of RED block
       // at ~lines 904-921). When the verification command exits 0 silently

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -43,6 +43,7 @@ try {
 const TDD_CLI = path.join(__dirname, 'tdd-phase-state.js');
 
 const { TDD_PHASES, TDD_PHASE_TRANSITIONS } = require('./tdd-phase-registry');
+const { gateContractFor } = require('../../../skills/split-in-tasks/lib/task-types');
 
 // `done` is derived in this script (a cycle with red+green+refactor evidence
 // is treated as complete). It is NOT a state-machine target in the registry.
@@ -887,6 +888,17 @@ function main() {
   const docsExempt = isDocsExempt(type);
   const visualOnly = isVisualOnlyTask(scope);
   const testsOnly = type === 'tests-only';
+  // GH-528 review comment #3 (cursor[bot]): single source of truth for
+  // whether `--docs-exempt` should be forwarded to the recorder. The
+  // recorder relaxes RC-D (empty-output trap) only when this flag is set.
+  // Per the central contract in skills/split-in-tasks/lib/task-types.js,
+  // ONLY Types with `rcdEmptyTrap === false` (docs, config, ci, file-move,
+  // checkpoint) qualify. tests-only / tdd-code / mechanical-refactor keep
+  // the trap armed. Visual-only Storybook tasks have no executable surface
+  // and inherit the docs-exempt semantics by scope shape (orthogonal to
+  // Type) — they are added on as an OR.
+  const contractAllowsDocsExempt = gateContractFor(type, scope).rcdEmptyTrap === false;
+  const docsExemptForward = contractAllowsDocsExempt || visualOnly;
 
   // Checkpoint tasks are verification-only — no source change, no test
   // authorship, no gherkin scenarios. Asking the agent to satisfy a TDD
@@ -1058,8 +1070,14 @@ function main() {
           // command failed as RED requires (exitCode !== 0 confirmed above).
           // Accept it. Fires for documentation tasks (isDocsExempt) and for
           // Storybook stories-only tasks (isVisualOnlyTask).
+          // GH-528 review comment #3: drive `docsExempt` from the central
+          // contract (`gateContractFor`) rather than hard-coding `true`. For
+          // Type=docs (and visual-only Storybook scope) this resolves to
+          // true; for any other Type that reaches this fallback the trap
+          // stays armed. Guarded by the `(docsExempt || visualOnly)`
+          // condition above, so `docsExemptForward` is the right value here.
           const rec = recordEvidence(TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope, {
-            docsExempt: true,
+            docsExempt: docsExemptForward,
           });
           if (!rec.ok) {
             blockReason = `Could not record RED evidence:\n${rec.out}`;
@@ -1126,8 +1144,15 @@ function main() {
             'Type=tests-only GREEN requires at least one in-scope test file to be modified. ' +
             'No `*.test.*` / `*.spec.*` file under scope has changes vs. HEAD.';
         } else {
+          // GH-528 review comment #3 (cursor[bot]): tests-only's gate contract
+          // is `rcdEmptyTrap: true` (see gateContractFor('tests-only')). We
+          // therefore MUST NOT forward `--docs-exempt` here — doing so would
+          // disable the RC-D empty-output trap and let a silent verifier
+          // (e.g. `node -e ""`) record GREEN after merely touching a test
+          // file. `docsExemptForward` is driven by the central contract and
+          // resolves to `false` for tests-only, keeping the trap armed.
           const rec = recordEvidence(TDD_PHASES.green, ticket, taskNum, testCmd, repoRoot, scope, {
-            docsExempt: true,
+            docsExempt: docsExemptForward,
           });
           if (!rec.ok) {
             blockReason = `Could not record GREEN evidence:\n${rec.out}`;
@@ -1151,16 +1176,19 @@ function main() {
       // so we forward `--docs-exempt` to the recorder, which relaxes the
       // RC-D trap for this one invocation. Emit a diagnostic so operators
       // see why a silent verifier was accepted. See R8 + R9.
-      const greenDocsExempt = docsExempt || visualOnly;
+      // GH-528 review comment #3: `docsExemptForward` is now driven by the
+      // central `gateContractFor()` contract (plus visual-only OR), not by
+      // ad-hoc `docsExempt || visualOnly`. Same observable behaviour for
+      // docs/visual-only but routed through the single source of truth.
       const rec = recordEvidence(TDD_PHASES.green, ticket, taskNum, testCmd, repoRoot, scope, {
-        docsExempt: greenDocsExempt,
+        docsExempt: docsExemptForward,
       });
       if (!rec.ok) {
         blockReason = `Could not record GREEN evidence:\n${rec.out}`;
       } else {
         advanced = true;
         phase = TDD_PHASES.refactor;
-        if (greenDocsExempt) {
+        if (docsExemptForward) {
           const fallbackLabel = visualOnly
             ? 'visual-only fallback (Storybook stories-only scope — no testable code surface'
             : 'docs-exempt fallback (documentation task — no testable code surface';
@@ -1178,9 +1206,11 @@ function main() {
       // code surface, so their REFACTOR verifier is silent (`grep -q`,
       // `test -f`, etc.). Forward `--docs-exempt` so the recorder relaxes
       // RC-D for this single invocation — symmetric with RED and GREEN.
-      const refactorDocsExempt = docsExempt || visualOnly;
+      // GH-528 review comment #3: same single-source-of-truth routing as
+      // the GREEN branch above. `docsExemptForward` is `false` for tests-only
+      // (rcdEmptyTrap stays armed) and for any tdd-code task.
       const rec = recordEvidence(TDD_PHASES.refactor, ticket, taskNum, testCmd, repoRoot, scope, {
-        docsExempt: refactorDocsExempt,
+        docsExempt: docsExemptForward,
       });
       if (!rec.ok) {
         blockReason = `Could not record REFACTOR evidence:\n${rec.out}`;

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -233,10 +233,16 @@ function parseTaskType(section) {
 // (*.md, etc), so demanding a *.test.* authorship gate is contradictory.
 // They still run a real verification command (e.g. a grep asserting the docs
 // now contain the documented strings), so RED/GREEN are validated by that
-// command rather than by test-block authorship. Detected via an explicit
-// `docs` type or a "documentation exempt" / "docs-only" marker in the body.
-function isDocsExempt(type, section) {
-  return (type || '') === 'docs' || /documentation[\s-]*exempt|docs[-\s]?only/i.test(section || '');
+// command rather than by test-block authorship.
+//
+// GH-528 follow-up: Detection is `### Type === 'docs'` ONLY. The previous
+// body-prose regex (matching "docs-only" / "documentation exempt" anywhere
+// in the task body) let the implementer-agent bypass the TDD gate by writing
+// trigger phrases into ACs at implement time. The Type field is authored by
+// the planner, scope-protected at implement time (Type-line edit guard), and
+// cannot be flipped by the agent under the hook.
+function isDocsExempt(type /* , _section unused — see GH-528 */) {
+  return (type || '') === 'docs';
 }
 
 // Storybook stories are visual artifacts — `*.stories.tsx` files have no
@@ -456,9 +462,7 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope, opts = {}) {
     if (
       opts &&
       opts.docsExempt === true &&
-      (phase === TDD_PHASES.red ||
-        phase === TDD_PHASES.green ||
-        phase === TDD_PHASES.refactor)
+      (phase === TDD_PHASES.red || phase === TDD_PHASES.green || phase === TDD_PHASES.refactor)
     ) {
       recordArgs.push('--docs-exempt');
     }
@@ -773,7 +777,7 @@ function main() {
   const scope = parseSuggestedScope(section);
   const type = parseTaskType(section);
   const taskTestCmd = parseTaskTestCommand(section);
-  const docsExempt = isDocsExempt(type, section);
+  const docsExempt = isDocsExempt(type);
   const visualOnly = isVisualOnlyTask(scope);
 
   // Checkpoint tasks are verification-only — no source change, no test
@@ -920,10 +924,9 @@ function main() {
           // command failed as RED requires (exitCode !== 0 confirmed above).
           // Accept it. Fires for documentation tasks (isDocsExempt) and for
           // Storybook stories-only tasks (isVisualOnlyTask).
-          const rec = recordEvidence(
-            TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope,
-            { docsExempt: true }
-          );
+          const rec = recordEvidence(TDD_PHASES.red, ticket, taskNum, testCmd, repoRoot, scope, {
+            docsExempt: true,
+          });
           if (!rec.ok) {
             blockReason = `Could not record RED evidence:\n${rec.out}`;
           } else {
@@ -981,10 +984,9 @@ function main() {
       // RC-D trap for this one invocation. Emit a diagnostic so operators
       // see why a silent verifier was accepted. See R8 + R9.
       const greenDocsExempt = docsExempt || visualOnly;
-      const rec = recordEvidence(
-        TDD_PHASES.green, ticket, taskNum, testCmd, repoRoot, scope,
-        { docsExempt: greenDocsExempt }
-      );
+      const rec = recordEvidence(TDD_PHASES.green, ticket, taskNum, testCmd, repoRoot, scope, {
+        docsExempt: greenDocsExempt,
+      });
       if (!rec.ok) {
         blockReason = `Could not record GREEN evidence:\n${rec.out}`;
       } else {
@@ -1009,10 +1011,9 @@ function main() {
       // `test -f`, etc.). Forward `--docs-exempt` so the recorder relaxes
       // RC-D for this single invocation — symmetric with RED and GREEN.
       const refactorDocsExempt = docsExempt || visualOnly;
-      const rec = recordEvidence(
-        TDD_PHASES.refactor, ticket, taskNum, testCmd, repoRoot, scope,
-        { docsExempt: refactorDocsExempt }
-      );
+      const rec = recordEvidence(TDD_PHASES.refactor, ticket, taskNum, testCmd, repoRoot, scope, {
+        docsExempt: refactorDocsExempt,
+      });
       if (!rec.ok) {
         blockReason = `Could not record REFACTOR evidence:\n${rec.out}`;
       } else {
@@ -1085,8 +1086,7 @@ module.exports = {
 // with zero test() blocks). Child spawns of this script always pass a ticket
 // + task arg, so they keep running main() — NODE_TEST_CONTEXT propagation
 // via inherited env is harmless when argv carries the real CLI args.
-const _isBareTestLoad =
-  process.env.NODE_TEST_CONTEXT && process.argv.length <= 2;
+const _isBareTestLoad = process.env.NODE_TEST_CONTEXT && process.argv.length <= 2;
 if (require.main === module && !_isBareTestLoad) {
   main();
 }

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -491,24 +491,36 @@ function detectChangedTestFilesInScope(repoRoot, scope) {
   let diff = '';
   let staged = '';
   let untracked = '';
+  // GH-528 round-2 follow-up note: check `git` exit status so a real git
+  // failure (corrupt repo, mid-rebase, missing git binary) is distinguishable
+  // from "no changes" downstream. Without this, all three sources silently
+  // return '' on error and the tests-only GREEN gate fires with the
+  // misleading "No *.test.* file under scope has changes" message.
+  let gitFailed = false;
   try {
-    diff =
-      spawnSync('git', ['diff', '--name-only'], {
-        cwd: repoRoot,
-        encoding: 'utf8',
-      }).stdout || '';
-    staged =
-      spawnSync('git', ['diff', '--cached', '--name-only'], {
-        cwd: repoRoot,
-        encoding: 'utf8',
-      }).stdout || '';
-    untracked =
-      spawnSync('git', ['ls-files', '--others', '--exclude-standard'], {
-        cwd: repoRoot,
-        encoding: 'utf8',
-      }).stdout || '';
+    const r1 = spawnSync('git', ['diff', '--name-only'], { cwd: repoRoot, encoding: 'utf8' });
+    if (r1.status !== 0) gitFailed = true;
+    diff = r1.stdout || '';
+    const r2 = spawnSync('git', ['diff', '--cached', '--name-only'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (r2.status !== 0) gitFailed = true;
+    staged = r2.stdout || '';
+    const r3 = spawnSync('git', ['ls-files', '--others', '--exclude-standard'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (r3.status !== 0) gitFailed = true;
+    untracked = r3.stdout || '';
   } catch {
-    /* git unavailable — treat as empty */
+    gitFailed = true;
+  }
+  if (gitFailed) {
+    process.stderr.write(
+      'task-next: git change detection failed (corrupt repo or detached state?); ' +
+        'treating changed-files as empty. Downstream gate may block with a misleading message.\n'
+    );
   }
   const changed = [
     ...new Set(

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -456,7 +456,9 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope, opts = {}) {
     if (
       opts &&
       opts.docsExempt === true &&
-      (phase === TDD_PHASES.red || phase === TDD_PHASES.green)
+      (phase === TDD_PHASES.red ||
+        phase === TDD_PHASES.green ||
+        phase === TDD_PHASES.refactor)
     ) {
       recordArgs.push('--docs-exempt');
     }
@@ -1002,7 +1004,15 @@ function main() {
     if (!passed) {
       blockReason = `Regression detected — tests failed during refactor (exit ${run.exitCode}). Revert the breaking change before re-invoking me.\n\n${run.combined}`;
     } else {
-      const rec = recordEvidence(TDD_PHASES.refactor, ticket, taskNum, testCmd, repoRoot, scope);
+      // Task 4 (GH-528): docs-exempt / visual-only tasks have no testable
+      // code surface, so their REFACTOR verifier is silent (`grep -q`,
+      // `test -f`, etc.). Forward `--docs-exempt` so the recorder relaxes
+      // RC-D for this single invocation — symmetric with RED and GREEN.
+      const refactorDocsExempt = docsExempt || visualOnly;
+      const rec = recordEvidence(
+        TDD_PHASES.refactor, ticket, taskNum, testCmd, repoRoot, scope,
+        { docsExempt: refactorDocsExempt }
+      );
       if (!rec.ok) {
         blockReason = `Could not record REFACTOR evidence:\n${rec.out}`;
       } else {

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -406,7 +406,7 @@ function mintCompanionToken() {
 }
 
 // eslint-disable-next-line max-lines-per-function, complexity -- allowlisted pre-existing; see .quality-exceptions
-function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope) {
+function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope, opts = {}) {
   // Delegate to tdd-phase-state.js — the only authorized writer. Forward
   // `--task N` so the recorder resolves the per-task state path. Records
   // evidence for the just-completed phase, then (for red/green only)
@@ -448,6 +448,13 @@ function recordEvidence(phase, ticket, taskNum, cmd, cwd, scope) {
       '--cmd',
       wrapStrictMode(cmd),
     ];
+    // Task 4 (GH-528): when the orchestrator detects a docs-exempt or
+    // visual-only GREEN, forward `--docs-exempt` so the recorder relaxes
+    // the RC-D empty-command trap for this single invocation. Sibling of
+    // the RED-side fallback emitted around line 909.
+    if (opts && opts.docsExempt === true && phase === TDD_PHASES.green) {
+      recordArgs.push('--docs-exempt');
+    }
     return spawnSync(process.execPath, recordArgs, {
       cwd,
       stdio: 'pipe',
@@ -954,12 +961,33 @@ function main() {
     if (!passed) {
       blockReason = `Test command still failing (exit ${run.exitCode}). Last output:\n\n${run.combined}`;
     } else {
-      const rec = recordEvidence(TDD_PHASES.green, ticket, taskNum, testCmd, repoRoot, scope);
+      // Task 4 (GH-528): GREEN docs-exempt fallback (sibling of RED block
+      // at ~lines 904-921). When the verification command exits 0 silently
+      // (no stdout/stderr), tdd-phase-state.js's RC-D empty-command trap
+      // normally rejects. For docs-exempt tasks (Type=docs / "docs-only" /
+      // "documentation exempt" markers) and visual-only Storybook tasks,
+      // the verifier IS the test surface — there's no code to assert on —
+      // so we forward `--docs-exempt` to the recorder, which relaxes the
+      // RC-D trap for this one invocation. Emit a diagnostic so operators
+      // see why a silent verifier was accepted. See R8 + R9.
+      const greenDocsExempt = docsExempt || visualOnly;
+      const rec = recordEvidence(
+        TDD_PHASES.green, ticket, taskNum, testCmd, repoRoot, scope,
+        { docsExempt: greenDocsExempt }
+      );
       if (!rec.ok) {
         blockReason = `Could not record GREEN evidence:\n${rec.out}`;
       } else {
         advanced = true;
         phase = TDD_PHASES.refactor;
+        if (greenDocsExempt) {
+          const fallbackLabel = visualOnly
+            ? 'visual-only fallback (Storybook stories-only scope — no testable code surface'
+            : 'docs-exempt fallback (documentation task — no testable code surface';
+          process.stdout.write(
+            `task-next: GREEN accepted via ${fallbackLabel}; verification command exited 0 as required).\n`
+          );
+        }
       }
     }
   } else if (phase === TDD_PHASES.refactor) {

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -43,7 +43,10 @@ try {
 const TDD_CLI = path.join(__dirname, 'tdd-phase-state.js');
 
 const { TDD_PHASES, TDD_PHASE_TRANSITIONS } = require('./tdd-phase-registry');
-const { gateContractFor } = require('../../../skills/split-in-tasks/lib/task-types');
+const {
+  gateContractFor,
+  scopeEntryAdmitsOnlyTestFiles,
+} = require('../../../skills/split-in-tasks/lib/task-types');
 const { fileMatchesScope } = require('../lib/task-scope');
 
 // `done` is derived in this script (a cycle with red+green+refactor evidence
@@ -67,43 +70,6 @@ const TDD_DERIVED_DONE = 'done';
 function filterToTestFiles(scope) {
   if (!Array.isArray(scope)) return [];
   return scope.filter((p) => typeof p === 'string' && /\.(test|spec)\.[jt]sx?$/i.test(p));
-}
-
-/**
- * Classify a `### Files in scope` entry: does its match set consist
- * EXCLUSIVELY of test/spec files?
- *
- * Used by the Type=tests-only GREEN gate (cursor[bot] review, GH-528):
- * the previous check applied a raw extension test to each entry, which
- * mis-rejected glob patterns whose basename DOES constrain to test
- * files (e.g. `plugins/work/**\/*.test.js`) while needing to keep
- * rejecting open-ended globs like `src/**` that admit non-test files.
- *
- * Rules:
- *   - Empty / non-string                                     → false.
- *   - Glob entry (contains `*`): inspect its basename — the
- *     segment after the last `/`. Accept iff the basename ends in
- *     `*.test.<ext>` / `*.spec.<ext>` (ext one of j/tsx?). This
- *     accepts `src/**\/*.test.js` and rejects `src/**`, `lib/**\/*.js`.
- *   - Literal entry: delegate to the same test-extension regex used
- *     by `filterToTestFiles`. Accept `src/foo.test.js`, reject
- *     `src/foo.js`.
- *
- * @param {string} entry
- * @returns {boolean}
- */
-function scopeEntryAdmitsOnlyTestFiles(entry) {
-  if (typeof entry !== 'string' || !entry) return false;
-  const isGlob = entry.includes('*');
-  if (!isGlob) {
-    return /\.(test|spec)\.[jt]sx?$/i.test(entry);
-  }
-  // Glob: examine the basename. A glob whose final segment ends in a
-  // test-file extension pattern admits ONLY test files; any other
-  // shape could match a non-test file.
-  const lastSlash = entry.lastIndexOf('/');
-  const basename = lastSlash >= 0 ? entry.slice(lastSlash + 1) : entry;
-  return /\.(test|spec)\.[jt]sx?$/i.test(basename);
 }
 
 /**

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -44,6 +44,7 @@ const TDD_CLI = path.join(__dirname, 'tdd-phase-state.js');
 
 const { TDD_PHASES, TDD_PHASE_TRANSITIONS } = require('./tdd-phase-registry');
 const { gateContractFor } = require('../../../skills/split-in-tasks/lib/task-types');
+const { fileMatchesScope } = require('../lib/task-scope');
 
 // `done` is derived in this script (a cycle with red+green+refactor evidence
 // is treated as complete). It is NOT a state-machine target in the registry.
@@ -422,15 +423,65 @@ function mintCompanionToken() {
  * across all phase writes. Returns `{ ok, out, exitCode }`.
  */
 /**
+ * Pure helper: filter a list of changed POSIX paths down to those that are
+ * test/spec files AND fall under the task's declared scope.
+ *
+ * Scope match delegates to `fileMatchesScope` from `../lib/task-scope` (the
+ * same matcher used by the production scope-protection layer), so glob
+ * patterns like `src/**` or `plugins/work/**\/*.test.js` are honored.
+ * Bare-directory entries (no glob meta, no trailing `/`) keep their legacy
+ * "directory prefix" semantics so existing task definitions don't regress.
+ *
+ * Scope behaviors preserved:
+ *   - exact path entry          → matches that path
+ *   - directory entry (`a/b`)   → matches `a/b/**` (legacy prefix)
+ *   - directory entry (`a/b/`)  → matches `a/b/**` (via fileMatchesScope)
+ *   - glob entry  (`a/**\/*.test.js`) → standard glob match (NEW)
+ *   - empty scope               → any changed test file passes through
+ *
+ * The test-file extension filter always applies last: a file matched by
+ * scope but not ending in `.test.<ext>` / `.spec.<ext>` is excluded.
+ *
+ * @param {string[]} changedPaths POSIX-style paths relative to repoRoot.
+ * @param {string[]} scope        `### Files in scope` entries from tasks.md.
+ * @returns {string[]}            The subset that should count as "agent
+ *                                actually wrote in-scope test code".
+ */
+function filterChangedTestFilesByScope(changedPaths, scope) {
+  const out = [];
+  const scopeList = Array.isArray(scope) ? scope.filter((s) => typeof s === 'string' && s) : [];
+  for (const rel of Array.isArray(changedPaths) ? changedPaths : []) {
+    if (typeof rel !== 'string' || !rel) continue;
+    if (!/\.(test|spec)\.[jt]sx?$/i.test(rel)) continue;
+    if (scopeList.length === 0) {
+      out.push(rel);
+      continue;
+    }
+    const inScope = scopeList.some((s) => {
+      if (rel === s) return true;
+      // Legacy bare-directory prefix: `a/b` matches `a/b/...`. We keep this
+      // because fileMatchesScope would compile `a/b` as a literal glob and
+      // miss the descendants.
+      if (rel.startsWith(s.replace(/\/+$/, '') + '/')) return true;
+      // Delegate everything else (exact match was handled above) to the
+      // shared glob-aware matcher — this is the regression fix for `**`
+      // and `*` segment patterns.
+      return fileMatchesScope(rel, [s]);
+    });
+    if (inScope) out.push(rel);
+  }
+  return out;
+}
+
+/**
  * Return the subset of changed (vs HEAD + staged + untracked) files that are
  * test/spec files AND fall under the task's declared scope. Used by the
  * tests-only GREEN gate to ensure the agent actually wrote new test code
  * (not a no-op cycle).
  *
- * Scope match is intentionally lenient: any changed test file whose POSIX
- * path starts with a scope-listed directory, or matches a scope-listed file
- * exactly, counts. Glob expansion is out of scope — Pass D enforces the
- * planner-side allowlist.
+ * Scope-match semantics live in `filterChangedTestFilesByScope` (pure,
+ * unit-tested). This function is the git-aware wrapper that collects the
+ * "changed" set from working tree + index + untracked files.
  */
 function detectChangedTestFilesInScope(repoRoot, scope) {
   const out = [];
@@ -456,24 +507,17 @@ function detectChangedTestFilesInScope(repoRoot, scope) {
   } catch {
     /* git unavailable — treat as empty */
   }
-  const changed = new Set(
-    [...diff.split('\n'), ...staged.split('\n'), ...untracked.split('\n')]
-      .map((s) => s.trim())
-      .filter(Boolean)
-  );
-  const scopeList = Array.isArray(scope) ? scope : [];
-  for (const rel of changed) {
-    if (!/\.(test|spec)\.[jt]sx?$/i.test(rel)) continue;
-    const inScope = scopeList.some((s) => {
-      if (!s) return false;
-      if (rel === s) return true;
-      if (rel.startsWith(s.replace(/\/+$/, '') + '/')) return true;
-      return false;
-    });
-    // If scope is empty/file-only, treat any changed test file as in-scope.
-    if (scopeList.length === 0 || inScope) out.push(rel);
-  }
-  return out;
+  const changed = [
+    ...new Set(
+      [...diff.split('\n'), ...staged.split('\n'), ...untracked.split('\n')]
+        .map((s) => s.trim())
+        .filter(Boolean)
+    ),
+  ];
+  return filterChangedTestFilesByScope(changed, scope).reduce((acc, rel) => {
+    acc.push(rel);
+    return acc;
+  }, out);
 }
 
 function recordSkipRed(ticket, taskNum, reason, cwd) {
@@ -1271,6 +1315,7 @@ function main() {
 
 module.exports = {
   filterToTestFiles,
+  filterChangedTestFilesByScope,
   findTestFilesInScope,
   wrapStrictMode,
   isDocsExempt,

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -54,6 +54,7 @@ const ALLOWED_AGENTS = [
 // Subcommands that require token verification
 const GATED_SUBCOMMANDS = [
   'record-red',
+  'record-skip-red',
   'record-green',
   'record-refactor',
   'transition',
@@ -703,6 +704,57 @@ function cmdRecordRedSynthesized(ticketId, args, cmd, taskNum, opts) {
   });
 }
 
+/**
+ * record-skip-red — tests-only Type RED-skipped contract (GH-528 item 4).
+ *
+ * Type=tests-only tasks add tests against code that already works, so the
+ * "failing test → passing impl" cycle is incoherent — RED is impossible by
+ * design. This subcommand persists an intentional skip so the audit trail
+ * clearly distinguishes a skipped-by-design cycle from a fabricated one
+ * (see [[no-fake-tdd-evidence]]).
+ *
+ * Contract:
+ *   - --reason is required (empty → BYPASS line, no state change).
+ *   - Current phase must be `red`.
+ *   - Persists `cycle.red = { skipped: true, reason, timestamp }` and
+ *     transitions currentPhase RED → GREEN in the same write.
+ *   - Does NOT run any --cmd; the skip is a contract, not a verification.
+ */
+function cmdRecordSkipRed(ticketId, args) {
+  if (!ticketId) errorExit('Missing ticket ID.');
+  const taskNum = safeParseTask(args);
+  const opts = taskNum ? { taskNum } : undefined;
+
+  const reasonIdx = args.indexOf('--reason');
+  const reason = reasonIdx !== -1 && reasonIdx + 1 < args.length ? args[reasonIdx + 1] : undefined;
+  if (!reason || !reason.trim()) {
+    process.stderr.write(
+      'BYPASS: tdd-phase-state.js record-skip-red --reason "<why RED is intentionally skipped>"\n'
+    );
+    process.exit(1);
+  }
+
+  const state = readState(ticketId, opts);
+  if (!state) errorExit('No TDD phase state found. Run "init" first.');
+  if (state.currentPhase !== 'red') {
+    errorExit(
+      'Cannot record skip-red: current phase is "' +
+        state.currentPhase +
+        '". record-skip-red only valid during red phase.'
+    );
+  }
+
+  const record = getCurrentCycleRecord(state);
+  record.red = {
+    skipped: true,
+    reason,
+    timestamp: new Date().toISOString(),
+  };
+  state.currentPhase = 'green';
+  writeState(ticketId, state, opts);
+  successOut({ ok: true, phase: 'green', cycle: state.currentCycle, skipped: true, reason });
+}
+
 function cmdRecordGreen(ticketId, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
   const cmd = parseCmd(args);
@@ -1049,6 +1101,9 @@ switch (subcommand) {
   case 'record-red':
     cmdRecordRed(ticketId, args.slice(2));
     break;
+  case 'record-skip-red':
+    cmdRecordSkipRed(ticketId, args.slice(2));
+    break;
   case 'record-green':
     cmdRecordGreen(ticketId, args.slice(2));
     break;
@@ -1064,6 +1119,6 @@ switch (subcommand) {
   default:
     errorExit(
       `Unknown subcommand: ${subcommand}. ` +
-        'Valid: init, current, record-red, record-green, record-refactor, transition, exception'
+        'Valid: init, current, record-red, record-skip-red, record-green, record-refactor, transition, exception'
     );
 }

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -98,16 +98,16 @@ const TOKEN_MAX_AGE_MS = 10_000; // 10 seconds
  * Callers MUST handle `null` as "Type unknown, fail closed at the gate"
  * (i.e. do NOT honor `record-skip-red` or `--red-skip-file-guard`).
  */
-function readActiveTaskType(ticketId, taskNum) {
-  if (!ticketId || !Number.isInteger(taskNum) || taskNum < 1) return null;
+function readActiveTaskBlock(ticketId, taskNum) {
+  if (!ticketId || !Number.isInteger(taskNum) || taskNum < 1) {
+    return { type: null, scope: [] };
+  }
   try {
     const base = resolveTasksBaseWithFallback();
     const safeId = sanitizeId(ticketId);
     const tasksMdPath = path.resolve(base, safeId, 'tasks.md');
-    if (!fs.existsSync(tasksMdPath)) return null;
+    if (!fs.existsSync(tasksMdPath)) return { type: null, scope: [] };
     const md = fs.readFileSync(tasksMdPath, 'utf8');
-    // Locate `## Task <N>` header (case-insensitive, allow em-dash / hyphen
-    // separators). Read forward until the next `## ` heading.
     const lines = md.split(/\r?\n/);
     const headerRe = new RegExp(`^##\\s+Task\\s+${taskNum}\\b`, 'i');
     let start = -1;
@@ -117,7 +117,7 @@ function readActiveTaskType(ticketId, taskNum) {
         break;
       }
     }
-    if (start === -1) return null;
+    if (start === -1) return { type: null, scope: [] };
     let end = lines.length;
     for (let i = start + 1; i < lines.length; i += 1) {
       if (/^##\s+/.test(lines[i])) {
@@ -125,23 +125,99 @@ function readActiveTaskType(ticketId, taskNum) {
         break;
       }
     }
-    // Inside the task block, find `### Type` and take the next non-blank
-    // non-heading line as the Type value.
+    let type = null;
+    const scope = [];
     for (let i = start + 1; i < end; i += 1) {
-      if (/^###\s+Type\s*$/i.test(lines[i].trim())) {
+      const trimmed = lines[i].trim();
+      if (/^###\s+Type\s*$/i.test(trimmed)) {
         for (let j = i + 1; j < end; j += 1) {
           const next = lines[j].trim();
           if (!next) continue;
-          if (next.startsWith('#')) return null;
-          return next.toLowerCase();
+          if (next.startsWith('#')) break;
+          type = next.toLowerCase();
+          break;
         }
-        return null;
+        continue;
+      }
+      if (/^###\s+Files in scope\b/i.test(trimmed)) {
+        for (let j = i + 1; j < end; j += 1) {
+          const next = lines[j].trim();
+          if (!next) continue;
+          if (/^###\s+/.test(next) || /^##\s+/.test(next)) break;
+          const bullet = next.match(/^[-*+]\s+(.*)$/);
+          if (!bullet) continue;
+          const cleaned = bullet[1]
+            .replace(/`/g, '')
+            .replace(/\s+#.*$/, '')
+            .trim();
+          if (cleaned) scope.push(cleaned);
+        }
       }
     }
-    return null;
+    return { type, scope };
   } catch {
-    return null;
+    return { type: null, scope: [] };
   }
+}
+
+// Backward-compatible helper — returns only the Type, used by the existing
+// record-skip-red and --red-skip-file-guard gates.
+function readActiveTaskType(ticketId, taskNum) {
+  return readActiveTaskBlock(ticketId, taskNum).type;
+}
+
+// Visual-only Storybook detection (mirrors task-next.js isVisualOnlyTask).
+// When every scope entry matches `*.stories.[jt]sx?`, the task has no
+// executable test surface and `--docs-exempt` is legitimate even for
+// Type=tdd-code. See split-in-tasks SKILL.md Rule 10.
+function isVisualOnlyScope(scope) {
+  if (!Array.isArray(scope) || scope.length === 0) return false;
+  return scope.every((p) => typeof p === 'string' && /\.stories\.[jt]sx?$/i.test(p));
+}
+
+/**
+ * GH-528 round-2 follow-up (Cursor[bot] HIGH/Medium): single allow-check
+ * for `--docs-exempt`. Mirrors the orchestrator's `docsExemptForward`
+ * discriminator (task-next.js):
+ *     docsExemptForward = contractAllowsDocsExempt || visualOnly
+ *
+ * `--docs-exempt` is legitimate iff EITHER:
+ *   - gateContractFor(type).rcdEmptyTrap === false
+ *     (docs / config / ci / file-move / checkpoint), OR
+ *   - the task's scope is visual-only Storybook (any Type).
+ *
+ * Returns { allowed: boolean, type: string|null, reason: string }.
+ * `reason` carries an operator-facing message when allowed=false.
+ */
+function isDocsExemptAllowed(ticketId, taskNum) {
+  // Legacy compat: callers without --task wrote to the ticket-root state path
+  // (GH-219 pre-per-task). The Type-gate requires --task to resolve the
+  // active block; without it, fall through (the orchestrator always passes
+  // --task on the new code path that the round-2 review is securing).
+  if (!Number.isInteger(taskNum) || taskNum < 1) {
+    return { allowed: true, type: null, reason: 'legacy no-task caller' };
+  }
+  const { type, scope } = readActiveTaskBlock(ticketId, taskNum);
+  if (isVisualOnlyScope(scope)) {
+    return { allowed: true, type, reason: 'visual-only Storybook scope' };
+  }
+  if (type && taskTypes && typeof taskTypes.gateContractFor === 'function') {
+    const contract = taskTypes.gateContractFor(type);
+    if (contract && contract.rcdEmptyTrap === false) {
+      return { allowed: true, type, reason: 'contract rcdEmptyTrap=false' };
+    }
+  }
+  return {
+    allowed: false,
+    type,
+    reason:
+      `--docs-exempt is restricted to Types whose contract sets ` +
+      `rcdEmptyTrap=false (docs / config / ci / file-move / checkpoint) ` +
+      `or to visual-only Storybook scope. ` +
+      `Task ${taskNum || '?'} has Type="${type || 'unknown'}" and non-visual scope; ` +
+      `the RC-D empty-output trap and RED file guard stay armed. ` +
+      `Either fix the \`### Type\` line in tasks.md or drop --docs-exempt.`,
+  };
 }
 
 function sanitizeId(ticketId) {
@@ -654,7 +730,17 @@ function cmdRecordRed(ticketId, args) {
   // `--red-skip-file-guard` ONLY relaxes the file guard; `--docs-exempt`
   // continues to relax both (back-compat). Orchestrator forwards the new
   // flag for any Type whose contract says redRequiresTestFiles===false.
-  const docsExempt = Array.isArray(args) && args.includes('--docs-exempt');
+  // GH-528 round-2 follow-up (Cursor[bot] HIGH/Medium): --docs-exempt at
+  // record-red waives the "No test files changed" guard. Same Type+scope
+  // gate as record-green/record-refactor so a direct CLI call cannot relax
+  // the guard on a tdd-code task.
+  const docsExemptRequested = Array.isArray(args) && args.includes('--docs-exempt');
+  let docsExempt = false;
+  if (docsExemptRequested) {
+    const check = isDocsExemptAllowed(ticketId, taskNum);
+    if (!check.allowed) errorExit(check.reason);
+    docsExempt = true;
+  }
   const redSkipFileGuardRequested = Array.isArray(args) && args.includes('--red-skip-file-guard');
   // GH-528 round-2 follow-up (Cursor[bot] HIGH): the file-guard relaxation
   // must be cross-checked against the active task's contract — otherwise an
@@ -903,7 +989,17 @@ function cmdRecordGreen(ticketId, args) {
   // the RC-D empty-stdout/stderr guard would always trip. Callers (the planner
   // / task-next driver) opt in via this flag; default false preserves existing
   // strict behavior for all code tasks.
-  const docsExempt = Array.isArray(args) && args.includes('--docs-exempt');
+  //
+  // GH-528 round-2 follow-up (Cursor[bot] HIGH/Medium): gate the flag on the
+  // active task's Type + scope. Without this, a tokened agent can pass
+  // --docs-exempt directly to bypass RC-D on a tdd-code task.
+  const docsExemptRequested = Array.isArray(args) && args.includes('--docs-exempt');
+  let docsExempt = false;
+  if (docsExemptRequested) {
+    const check = isDocsExemptAllowed(ticketId, taskNum);
+    if (!check.allowed) errorExit(check.reason);
+    docsExempt = true;
+  }
 
   const state = readState(ticketId, opts);
   if (!state) errorExit('No TDD phase state found. Run "init" first.');
@@ -990,7 +1086,16 @@ function cmdRecordRefactor(ticketId, args) {
   // documentation-only tasks with silent verifiers (e.g. `grep -q`) can
   // finish the full RED → GREEN → REFACTOR cycle. Default behavior keeps
   // RC-D armed for every existing caller.
-  const docsExempt = Array.isArray(args) && args.includes('--docs-exempt');
+  //
+  // GH-528 round-2 follow-up (Cursor[bot] HIGH/Medium): same Type+scope gate
+  // as record-red/record-green to close the direct-CLI bypass surface.
+  const docsExemptRequested = Array.isArray(args) && args.includes('--docs-exempt');
+  let docsExempt = false;
+  if (docsExemptRequested) {
+    const check = isDocsExemptAllowed(ticketId, taskNum);
+    if (!check.allowed) errorExit(check.reason);
+    docsExempt = true;
+  }
 
   const { exitCode, stdout, stderr } = runTestCommandWithOutput(cmd);
   if (exitCode !== 0) {

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -562,8 +562,22 @@ function cmdRecordRed(ticketId, args) {
   // already gates this on isDocsExempt/isVisualOnlyTask and forwards
   // `--docs-exempt`; we relax the "No test files changed" guard for that
   // explicit opt-in. RC-D semantics still apply to record-green.
+  //
+  // GH-528 round-2 follow-up (Cursor[bot] medium): mechanical-refactor's
+  // gateContractFor sets redRequiresTestFiles=false AND rcdEmptyTrap=true.
+  // task-next.js' RED fallback waives the file guard for any Type with
+  // redRequiresTestFiles===false, but `docsExemptForward` is driven by
+  // rcdEmptyTrap (so RC-D stays armed at GREEN/REFACTOR) — mechanical-
+  // refactor therefore got docsExempt=false here and the recorder
+  // rejected the call with "No test files changed", wedging the cycle.
+  //
+  // Fix: separate the RED file-guard relaxation from the RC-D relaxation.
+  // `--red-skip-file-guard` ONLY relaxes the file guard; `--docs-exempt`
+  // continues to relax both (back-compat). Orchestrator forwards the new
+  // flag for any Type whose contract says redRequiresTestFiles===false.
   const docsExempt = Array.isArray(args) && args.includes('--docs-exempt');
-  if (testFiles.length === 0 && !docsExempt) {
+  const redSkipFileGuard = Array.isArray(args) && args.includes('--red-skip-file-guard');
+  if (testFiles.length === 0 && !docsExempt && !redSkipFileGuard) {
     errorExit('No test files changed. RED phase requires modified .test or .spec files.');
   }
 
@@ -1076,7 +1090,19 @@ function cmdException(ticketId, args) {
 // file with zero tests instead of hitting the subcommand switch + errorExit.
 // Using process.exit(0) instead of top-level `return` because the standalone
 // biome parser (used by the pre-commit format gate) rejects top-level return.
+//
+// GH-528 round-2 follow-up (Cursor[bot] low): distinguish "loaded by another
+// module / node --test runner" (require.main !== module) from "operator
+// invoked the bare CLI" (require.main === module && argv has no subcommand).
+// The former must stay silent; the latter must error so operators / wrappers
+// don't misread a no-op invocation as success.
 if (process.argv.length < 3) {
+  if (require.main === module) {
+    errorExit(
+      'Missing subcommand. Usage: tdd-phase-state.js <subcommand> <TICKET_ID> [...]. ' +
+        'Valid subcommands: init, current, record-red, record-skip-red, record-green, record-refactor, transition, exception.'
+    );
+  }
   process.exit(0);
 }
 

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -555,7 +555,14 @@ function cmdRecordRed(ticketId, args) {
   }
   const testFiles = allChanged.filter((f) => isTestFile(f));
 
-  if (testFiles.length === 0) {
+  // Task 4 (GH-528): RED docs-exempt fallback. Documentation-only tasks
+  // have no testable code surface — their "scope" is a .md file and there
+  // are no test files to author. The orchestrator (task-next.js RED block)
+  // already gates this on isDocsExempt/isVisualOnlyTask and forwards
+  // `--docs-exempt`; we relax the "No test files changed" guard for that
+  // explicit opt-in. RC-D semantics still apply to record-green.
+  const docsExempt = Array.isArray(args) && args.includes('--docs-exempt');
+  if (testFiles.length === 0 && !docsExempt) {
     errorExit('No test files changed. RED phase requires modified .test or .spec files.');
   }
 

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -703,6 +703,11 @@ function cmdRecordGreen(ticketId, args) {
   if (!cmd) errorExit('Missing --cmd argument.');
   const taskNum = safeParseTask(args);
   const opts = taskNum ? { taskNum } : undefined;
+  // --docs-exempt: documentation-only tasks have no testable code surface, so
+  // the RC-D empty-stdout/stderr guard would always trip. Callers (the planner
+  // / task-next driver) opt in via this flag; default false preserves existing
+  // strict behavior for all code tasks.
+  const docsExempt = Array.isArray(args) && args.includes('--docs-exempt');
 
   const state = readState(ticketId, opts);
   if (!state) errorExit('No TDD phase state found. Run "init" first.');
@@ -726,7 +731,11 @@ function cmdRecordGreen(ticketId, args) {
   // was observed on GH-417 / GH-432 / GH-452 — agents could not recover via
   // /work. Real test runners always emit something to stdout or stderr; if
   // both are empty AND exit was 0, the command did no work. Refuse to record.
-  if (stdout.trim() === '' && stderr.trim() === '') {
+  // RC-D armed for non-docs-exempt tasks (R5, GH-528). Documentation-only
+  // tasks have no testable code surface, so callers may opt in via the
+  // `--docs-exempt` CLI flag to bypass the empty-output guard; RC-B and the
+  // `exitCode !== 0` defenses below remain unconditional.
+  if (!docsExempt && stdout.trim() === '' && stderr.trim() === '') {
     errorExit(
       'GREEN test command exited 0 with NO stdout/stderr output. This is the ' +
         'empty-command trap (typically an unbound test-command env var expanded ' +
@@ -979,6 +988,14 @@ function cmdException(ticketId, args) {
 }
 
 // ─── Main ───────────────────────────────────────────────────────────────────
+
+// CLI dispatch only when invoked with subcommand arguments. When `node --test`
+// loads this file (e.g. CHANGED_FILES sweeps that include the source alongside
+// tests), argv has no subcommand — skip dispatch so the runner just records the
+// file with zero tests instead of hitting the subcommand switch + errorExit.
+if (process.argv.length < 3) {
+  return;
+}
 
 const args = process.argv.slice(2);
 const subcommand = args[0];

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -797,13 +797,19 @@ function cmdRecordRefactor(ticketId, args) {
         '". Transition to refactor first.'
     );
 
+  // Task 4 (GH-528): mirror the GREEN `--docs-exempt` opt-in on REFACTOR so
+  // documentation-only tasks with silent verifiers (e.g. `grep -q`) can
+  // finish the full RED → GREEN → REFACTOR cycle. Default behavior keeps
+  // RC-D armed for every existing caller.
+  const docsExempt = Array.isArray(args) && args.includes('--docs-exempt');
+
   const { exitCode, stdout, stderr } = runTestCommandWithOutput(cmd);
   if (exitCode !== 0) {
     errorExit('Tests must still PASS after refactoring. Tests failed (exit ' + exitCode + ').');
   }
 
   // RC-D defense: same empty-command guard as GREEN. Refuse exit-0-with-no-output.
-  if (stdout.trim() === '' && stderr.trim() === '') {
+  if (!docsExempt && stdout.trim() === '' && stderr.trim() === '') {
     errorExit(
       'REFACTOR test command exited 0 with NO stdout/stderr output. This is the ' +
         'empty-command trap (typically an unbound test-command env var expanded ' +

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -35,6 +35,20 @@ const { consumeToken, tokenPath } = require('../lib/scripts/write-report');
 const { normalizeAgentName } = require('../lib/agent-detection');
 const { resolveTasksBaseWithFallback } = require('../lib/ticket-validation');
 
+// GH-528 round-2 follow-up (Cursor[bot] HIGH): the recorder reads the active
+// task's Type from on-disk tasks.md to gate `record-skip-red` and
+// `--red-skip-file-guard`. tasks.md is the same source-of-truth the hook
+// layer uses, and the Type-line edit guard (protect-task-scope.js) blocks
+// mid-implement Type flips, so reading it here is trust-equivalent to the
+// planner's authored value.
+let taskTypes;
+try {
+  taskTypes = require('../../../skills/split-in-tasks/lib/task-types');
+} catch (e) {
+  if (e && e.code !== 'MODULE_NOT_FOUND') throw e;
+  taskTypes = null;
+}
+
 let config;
 try {
   config = require('../lib/config');
@@ -64,6 +78,71 @@ const GATED_SUBCOMMANDS = [
 const TOKEN_MAX_AGE_MS = 10_000; // 10 seconds
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * GH-528 round-2 follow-up (Cursor[bot] HIGH): read the declared `### Type`
+ * value for the active task from on-disk tasks.md.
+ *
+ * Why on-disk (not caller-supplied): a caller-supplied flag would re-open
+ * the agent self-report surface that the planner-side Type was designed to
+ * close. tasks.md is protected from mid-implement Type flips by the
+ * Type-line edit guard in protect-task-scope.js — so what we read here is
+ * trust-equivalent to what the planner authored.
+ *
+ * Returns the lowercase Type string, or null when:
+ *   - tasks.md is missing (fail-open — pre-existing tickets without the
+ *     closed taxonomy don't break)
+ *   - the requested task block is missing
+ *   - parsing fails
+ *
+ * Callers MUST handle `null` as "Type unknown, fail closed at the gate"
+ * (i.e. do NOT honor `record-skip-red` or `--red-skip-file-guard`).
+ */
+function readActiveTaskType(ticketId, taskNum) {
+  if (!ticketId || !Number.isInteger(taskNum) || taskNum < 1) return null;
+  try {
+    const base = resolveTasksBaseWithFallback();
+    const safeId = sanitizeId(ticketId);
+    const tasksMdPath = path.resolve(base, safeId, 'tasks.md');
+    if (!fs.existsSync(tasksMdPath)) return null;
+    const md = fs.readFileSync(tasksMdPath, 'utf8');
+    // Locate `## Task <N>` header (case-insensitive, allow em-dash / hyphen
+    // separators). Read forward until the next `## ` heading.
+    const lines = md.split(/\r?\n/);
+    const headerRe = new RegExp(`^##\\s+Task\\s+${taskNum}\\b`, 'i');
+    let start = -1;
+    for (let i = 0; i < lines.length; i += 1) {
+      if (headerRe.test(lines[i])) {
+        start = i;
+        break;
+      }
+    }
+    if (start === -1) return null;
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i += 1) {
+      if (/^##\s+/.test(lines[i])) {
+        end = i;
+        break;
+      }
+    }
+    // Inside the task block, find `### Type` and take the next non-blank
+    // non-heading line as the Type value.
+    for (let i = start + 1; i < end; i += 1) {
+      if (/^###\s+Type\s*$/i.test(lines[i].trim())) {
+        for (let j = i + 1; j < end; j += 1) {
+          const next = lines[j].trim();
+          if (!next) continue;
+          if (next.startsWith('#')) return null;
+          return next.toLowerCase();
+        }
+        return null;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 function sanitizeId(ticketId) {
   try {
@@ -576,7 +655,33 @@ function cmdRecordRed(ticketId, args) {
   // continues to relax both (back-compat). Orchestrator forwards the new
   // flag for any Type whose contract says redRequiresTestFiles===false.
   const docsExempt = Array.isArray(args) && args.includes('--docs-exempt');
-  const redSkipFileGuard = Array.isArray(args) && args.includes('--red-skip-file-guard');
+  const redSkipFileGuardRequested = Array.isArray(args) && args.includes('--red-skip-file-guard');
+  // GH-528 round-2 follow-up (Cursor[bot] HIGH): the file-guard relaxation
+  // must be cross-checked against the active task's contract — otherwise an
+  // allow-listed agent with a valid token can pass --red-skip-file-guard
+  // for a tdd-code task and bypass the file guard the orchestrator was
+  // supposed to enforce. Read the Type from on-disk tasks.md and verify
+  // gateContractFor(type).redRequiresTestFiles === false. Unknown/missing
+  // tasks.md fails closed (flag rejected → operator must fix tasks.md or
+  // author a real failing test).
+  let redSkipFileGuard = false;
+  if (redSkipFileGuardRequested) {
+    const declaredType = readActiveTaskType(ticketId, taskNum);
+    if (declaredType && taskTypes && typeof taskTypes.gateContractFor === 'function') {
+      const contract = taskTypes.gateContractFor(declaredType);
+      redSkipFileGuard = contract && contract.redRequiresTestFiles === false;
+    }
+    if (!redSkipFileGuard) {
+      errorExit(
+        '--red-skip-file-guard is restricted to Types whose contract sets ' +
+          'redRequiresTestFiles=false (tests-only / docs / config / ci / ' +
+          'mechanical-refactor / file-move / checkpoint). ' +
+          `Task ${taskNum || '?'} has Type="${declaredType || 'unknown'}", ` +
+          'which still requires a *.test.* file modification at RED. ' +
+          'Author a failing test, or fix the `### Type` line in tasks.md.'
+      );
+    }
+  }
   if (testFiles.length === 0 && !docsExempt && !redSkipFileGuard) {
     errorExit('No test files changed. RED phase requires modified .test or .spec files.');
   }
@@ -755,6 +860,25 @@ function cmdRecordSkipRed(ticketId, args) {
       'Cannot record skip-red: current phase is "' +
         state.currentPhase +
         '". record-skip-red only valid during red phase.'
+    );
+  }
+
+  // GH-528 round-2 follow-up (Cursor[bot] HIGH): Type=tests-only gate.
+  // Without this, any allow-listed developer agent holding a valid token
+  // can call `record-skip-red` for a tdd-code task and skip RED entirely —
+  // exactly the agent self-report surface the closed-Type taxonomy was
+  // designed to close. Read the Type from on-disk tasks.md (trust-
+  // equivalent to the planner's authored value, see readActiveTaskType
+  // docstring) and require it to be exactly `tests-only`. Unknown / non-
+  // tests-only Types fail closed.
+  const declaredType = readActiveTaskType(ticketId, taskNum);
+  if (declaredType !== 'tests-only') {
+    errorExit(
+      'record-skip-red is restricted to Type=tests-only tasks. ' +
+        `Task ${taskNum || '?'} has Type="${declaredType || 'unknown'}". ` +
+        'If this task is genuinely tests-only, fix the `### Type` line in tasks.md ' +
+        '(only the planner may author Type values — see split-in-tasks/lib/task-types.js). ' +
+        'Otherwise run record-red with a real failing test.'
     );
   }
 

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -190,12 +190,22 @@ function isVisualOnlyScope(scope) {
  * `reason` carries an operator-facing message when allowed=false.
  */
 function isDocsExemptAllowed(ticketId, taskNum) {
-  // Legacy compat: callers without --task wrote to the ticket-root state path
-  // (GH-219 pre-per-task). The Type-gate requires --task to resolve the
-  // active block; without it, fall through (the orchestrator always passes
-  // --task on the new code path that the round-2 review is securing).
+  // GH-528 round-2 follow-up (Cursor[bot] HIGH): the gate fires for ALL
+  // callers, including those that omit --task. An earlier draft fell
+  // through for no-task callers under the assumption that legacy
+  // ticket-root state was vestigial, but that left a self-report surface
+  // intact: a tokened agent could simply omit --task to bypass the gate.
+  // Now: missing --task fails closed. The orchestrator always passes
+  // --task (task-next.js recordEvidence builds the argv with it); test
+  // fixtures that need --docs-exempt must seed tasks.md and pass --task.
   if (!Number.isInteger(taskNum) || taskNum < 1) {
-    return { allowed: true, type: null, reason: 'legacy no-task caller' };
+    return {
+      allowed: false,
+      type: null,
+      reason:
+        '--docs-exempt requires --task <N> so the recorder can verify the ' +
+        "active task's Type against on-disk tasks.md. Re-run with --task <N>.",
+    };
   }
   const { type, scope } = readActiveTaskBlock(ticketId, taskNum);
   if (isVisualOnlyScope(scope)) {

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state.js
@@ -608,8 +608,7 @@ function cmdRecordRed(ticketId, args) {
 function cmdRecordRedSynthesized(ticketId, args, cmd, taskNum, opts) {
   // Validate reason (mirrors cmdException). Empty/missing → BYPASS, no audit.
   const reasonIdx = args.indexOf('--reason');
-  const reason =
-    reasonIdx !== -1 && reasonIdx + 1 < args.length ? args[reasonIdx + 1] : undefined;
+  const reason = reasonIdx !== -1 && reasonIdx + 1 < args.length ? args[reasonIdx + 1] : undefined;
   if (!reason || !reason.trim()) {
     // Write a BYPASS: line to stderr so callers see the recovery hint. Do NOT
     // append an audit row — fail-closed: no justification ⇒ no record.
@@ -901,6 +900,23 @@ function auditException(ticketId, taskNum, category, reason, allow) {
 function cmdException(ticketId, args) {
   if (!ticketId) errorExit('Missing ticket ID.');
 
+  // GH-528: `exception` is a runtime escape hatch that lets the agent skip the
+  // entire RED/GREEN/REFACTOR cycle. With closed-Type taxonomy enforced at
+  // planner time, agents never need this — config/docs/ci/tests-only/etc. all
+  // have proper Type-driven contracts now. Keep the subcommand only as an
+  // operator-only escape hatch (e.g. emergency CI rescue) gated behind an env
+  // token the agent's environment never carries. Existing non-test callers
+  // (work-implement-enforce.js, tdd-enforcement.js) only inspect previously-
+  // recorded exception evidence — they do not write new exceptions through
+  // this CLI, so they are unaffected.
+  if (process.env.WORK_OPERATOR_TOKEN !== '1') {
+    errorExit(
+      'The `exception` subcommand is operator-only and requires WORK_OPERATOR_TOKEN=1. ' +
+        'Agents must use the Type taxonomy (docs / tests-only / config / ci / mechanical-refactor / file-move / checkpoint) ' +
+        'set by the planner instead. See plugins/work/skills/split-in-tasks/lib/task-types.js.'
+    );
+  }
+
   // Parse --category (required)
   const category = parseCategory(args);
   const taskNum = safeParseTask(args);
@@ -1006,8 +1022,10 @@ function cmdException(ticketId, args) {
 // loads this file (e.g. CHANGED_FILES sweeps that include the source alongside
 // tests), argv has no subcommand — skip dispatch so the runner just records the
 // file with zero tests instead of hitting the subcommand switch + errorExit.
+// Using process.exit(0) instead of top-level `return` because the standalone
+// biome parser (used by the pre-commit format gate) rejects top-level return.
 if (process.argv.length < 3) {
-  return;
+  process.exit(0);
 }
 
 const args = process.argv.slice(2);

--- a/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-bypass-token.test.js
+++ b/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-bypass-token.test.js
@@ -1,0 +1,304 @@
+'use strict';
+
+/**
+ * protect-task-scope.js — env-bypass gated behind WORK_OPERATOR_TOKEN
+ * (GH-528 round-2 follow-up ITEM 1).
+ *
+ * The bypass env-var pair (PROTECT_TASK_SCOPE_BYPASS_REASON +
+ * PROTECT_TASK_SCOPE_BYPASS_TARGET) lets the caller override three guards:
+ *   1. filesInScope / decideEdit (out-of-scope writes)
+ *   2. per-Type closed-allowlist (tests-only / docs / config / ci)
+ *   3. Type-line edit guard (Write/Edit/MultiEdit on tasks.md `### Type` value)
+ *
+ * Env vars inherit into the agent shell, so without an operator-only token
+ * the agent can flip the bypass on. We gate each guard with
+ * WORK_OPERATOR_TOKEN === '1' — the same pattern as the `exception`
+ * subcommand in tdd-phase-state.js. Without the token, the env pair is
+ * treated as unset AND the rejected attempt is audited as
+ * `action: 'scope-bypass-rejected'`.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const HOOK = path.resolve(__dirname, '..', 'protect-task-scope.js');
+const WORK_STATE_FILENAME = '.work' + '-state.json';
+const WORK_ACTIONS_FILENAME = '.work' + '-actions.json';
+const TICKET = 'TEST-528';
+
+function readActions(tasksBase) {
+  const p = path.join(tasksBase, TICKET, WORK_ACTIONS_FILENAME);
+  if (!fs.existsSync(p)) return [];
+  const raw = fs.readFileSync(p, 'utf8').trim();
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return raw
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  }
+}
+
+function writeWorkState(tasksDir) {
+  fs.writeFileSync(
+    path.join(tasksDir, WORK_STATE_FILENAME),
+    JSON.stringify({
+      ticketId: TICKET,
+      stepStatus: { ticket: 'completed', implement: 'in_progress' },
+      tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task_1', status: 'in_progress' }] },
+    })
+  );
+}
+
+function writeTasksMd(tasksDir, { type, filesInScope }) {
+  const lines = [
+    '## Task 1 — sample',
+    '',
+    '### Type',
+    type,
+    '',
+    '### Files in scope',
+    ...filesInScope.map((f) => `- ${f}`),
+    '',
+  ];
+  fs.writeFileSync(path.join(tasksDir, 'tasks.md'), lines.join('\n'));
+}
+
+function runHook({ tasksBase, cwd, toolName, toolInput, env = {} }) {
+  return spawnSync('node', [HOOK], {
+    input: JSON.stringify({ tool_name: toolName, tool_input: toolInput }),
+    encoding: 'utf8',
+    cwd,
+    env: {
+      ...process.env,
+      TASKS_BASE: tasksBase,
+      PROTECT_TASK_SCOPE_TICKET_ID: TICKET,
+      // Default — explicitly clear bypass pair AND token. Tests opt in.
+      PROTECT_TASK_SCOPE_BYPASS_REASON: '',
+      PROTECT_TASK_SCOPE_BYPASS_TARGET: '',
+      WORK_OPERATOR_TOKEN: '',
+      ...env,
+    },
+  });
+}
+
+// ── Guard 1: filesInScope / decideEdit bypass ──────────────────────────────
+
+describe('protect-task-scope — WORK_OPERATOR_TOKEN gate on filesInScope bypass', () => {
+  let tmpHome;
+  let tasksBase;
+  let tasksDir;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pts-tok-files-'));
+    tasksBase = path.join(tmpHome, 'tasks');
+    tasksDir = path.join(tasksBase, TICKET);
+    fs.mkdirSync(tasksDir, { recursive: true });
+    writeWorkState(tasksDir);
+    // tdd-code so the per-Type allowlist guard never fires — isolate the
+    // filesInScope guard.
+    writeTasksMd(tasksDir, { type: 'tdd-code', filesInScope: ['src/**'] });
+  });
+  afterEach(() => fs.rmSync(tmpHome, { recursive: true, force: true }));
+
+  it('token=1 + pair → bypass fires, audit scope-bypass written', () => {
+    const target = path.join(tmpHome, 'lib/foo.js');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: target, content: 'x' },
+      env: {
+        WORK_OPERATOR_TOKEN: '1',
+        PROTECT_TASK_SCOPE_BYPASS_REASON: 'planned cross-task edit',
+        PROTECT_TASK_SCOPE_BYPASS_TARGET: 'lib/foo.js',
+      },
+    });
+    assert.equal(r.status, 0, `expected bypass; stderr=${r.stderr}`);
+    const rows = readActions(tasksBase);
+    const bypassRows = rows.filter((row) => row && row.action === 'scope-bypass');
+    assert.equal(
+      bypassRows.length,
+      1,
+      `expected one scope-bypass row; rows=${JSON.stringify(rows)}`
+    );
+  });
+
+  it('token unset + pair → bypass IGNORED, blocked, audit scope-bypass-rejected', () => {
+    const target = path.join(tmpHome, 'lib/foo.js');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: target, content: 'x' },
+      env: {
+        PROTECT_TASK_SCOPE_BYPASS_REASON: 'planned cross-task edit',
+        PROTECT_TASK_SCOPE_BYPASS_TARGET: 'lib/foo.js',
+        // No WORK_OPERATOR_TOKEN
+      },
+    });
+    assert.equal(r.status, 2, `expected block; stderr=${r.stderr}`);
+    const rows = readActions(tasksBase);
+    const rejected = rows.filter((row) => row && row.action === 'scope-bypass-rejected');
+    assert.equal(
+      rejected.length,
+      1,
+      `expected one scope-bypass-rejected row; rows=${JSON.stringify(rows)}`
+    );
+    const row = rejected[0];
+    assert.equal(row.allow, false, 'rejected row records the block decision');
+    assert.equal(
+      row.meta && row.meta.configuredTarget,
+      'lib/foo.js',
+      `rejected row meta records configuredTarget; got ${JSON.stringify(row)}`
+    );
+    assert.equal(
+      row.reason,
+      'planned cross-task edit',
+      `rejected row records the supplied reason; got ${JSON.stringify(row)}`
+    );
+    const bypassRows = rows.filter((r2) => r2 && r2.action === 'scope-bypass');
+    assert.equal(bypassRows.length, 0, 'no scope-bypass row when token missing');
+  });
+});
+
+// ── Guard 2: per-Type allowlist bypass ─────────────────────────────────────
+
+describe('protect-task-scope — WORK_OPERATOR_TOKEN gate on per-Type allowlist bypass', () => {
+  let tmpHome;
+  let tasksBase;
+  let tasksDir;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pts-tok-type-'));
+    tasksBase = path.join(tmpHome, 'tasks');
+    tasksDir = path.join(tasksBase, TICKET);
+    fs.mkdirSync(tasksDir, { recursive: true });
+    writeWorkState(tasksDir);
+    // docs Type — src/foo.js NOT in docs allowlist, filesInScope **/* makes
+    // decideEdit pass, so ONLY the per-Type allowlist guard can block.
+    writeTasksMd(tasksDir, { type: 'docs', filesInScope: ['**/*'] });
+  });
+  afterEach(() => fs.rmSync(tmpHome, { recursive: true, force: true }));
+
+  it('token=1 + pair → bypass fires, audit scope-bypass written (guard=type-allowlist)', () => {
+    const target = path.join(tmpHome, 'src/foo.js');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: target, content: 'x' },
+      env: {
+        WORK_OPERATOR_TOKEN: '1',
+        PROTECT_TASK_SCOPE_BYPASS_REASON: 'emergency docs ship',
+        PROTECT_TASK_SCOPE_BYPASS_TARGET: 'src/foo.js',
+      },
+    });
+    assert.equal(r.status, 0, `expected bypass; stderr=${r.stderr}`);
+    const rows = readActions(tasksBase);
+    const bypassRows = rows.filter((row) => row && row.action === 'scope-bypass');
+    assert.equal(bypassRows.length, 1);
+    assert.equal(bypassRows[0].meta && bypassRows[0].meta.guard, 'type-allowlist');
+  });
+
+  it('token unset + pair → bypass IGNORED, blocked, audit scope-bypass-rejected (guard=type-allowlist)', () => {
+    const target = path.join(tmpHome, 'src/foo.js');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: target, content: 'x' },
+      env: {
+        PROTECT_TASK_SCOPE_BYPASS_REASON: 'emergency docs ship',
+        PROTECT_TASK_SCOPE_BYPASS_TARGET: 'src/foo.js',
+      },
+    });
+    assert.equal(r.status, 2, `expected block; stderr=${r.stderr}`);
+    const rows = readActions(tasksBase);
+    const rejected = rows.filter((row) => row && row.action === 'scope-bypass-rejected');
+    assert.equal(
+      rejected.length,
+      1,
+      `expected scope-bypass-rejected; rows=${JSON.stringify(rows)}`
+    );
+    assert.equal(rejected[0].meta && rejected[0].meta.guard, 'type-allowlist');
+    const bypassRows = rows.filter((r2) => r2 && r2.action === 'scope-bypass');
+    assert.equal(bypassRows.length, 0);
+  });
+});
+
+// ── Guard 3: Type-line edit bypass ─────────────────────────────────────────
+
+describe('protect-task-scope — WORK_OPERATOR_TOKEN gate on Type-line bypass', () => {
+  let tmpHome;
+  let tasksBase;
+  let tasksDir;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pts-tok-tline-'));
+    tasksBase = path.join(tmpHome, 'tasks');
+    tasksDir = path.join(tasksBase, TICKET);
+    fs.mkdirSync(tasksDir, { recursive: true });
+    writeWorkState(tasksDir);
+    writeTasksMd(tasksDir, {
+      type: 'tdd-code',
+      filesInScope: ['src/**', 'tasks/**/tasks.md'],
+    });
+  });
+  afterEach(() => fs.rmSync(tmpHome, { recursive: true, force: true }));
+
+  it('token=1 + pair → Type-line bypass fires, audit scope-bypass (guard=type-line)', () => {
+    const target = path.join(tasksDir, 'tasks.md');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Edit',
+      toolInput: {
+        file_path: target,
+        old_string: 'tdd-code',
+        new_string: 'docs',
+      },
+      env: {
+        WORK_OPERATOR_TOKEN: '1',
+        PROTECT_TASK_SCOPE_BYPASS_REASON: 'planner re-keying type mid-cycle',
+        PROTECT_TASK_SCOPE_BYPASS_TARGET: path.relative(tmpHome, target),
+      },
+    });
+    assert.equal(r.status, 0, `expected bypass; stderr=${r.stderr}`);
+    const rows = readActions(tasksBase);
+    const bypassRows = rows.filter((row) => row && row.action === 'scope-bypass');
+    assert.equal(bypassRows.length, 1);
+    assert.equal(bypassRows[0].meta && bypassRows[0].meta.guard, 'type-line');
+  });
+
+  it('token unset + pair → Type-line bypass IGNORED, blocked, audit scope-bypass-rejected (guard=type-line)', () => {
+    const target = path.join(tasksDir, 'tasks.md');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Edit',
+      toolInput: {
+        file_path: target,
+        old_string: 'tdd-code',
+        new_string: 'docs',
+      },
+      env: {
+        PROTECT_TASK_SCOPE_BYPASS_REASON: 'planner re-keying type mid-cycle',
+        PROTECT_TASK_SCOPE_BYPASS_TARGET: path.relative(tmpHome, target),
+      },
+    });
+    assert.equal(r.status, 2, `expected block; stderr=${r.stderr}`);
+    const rows = readActions(tasksBase);
+    const rejected = rows.filter((row) => row && row.action === 'scope-bypass-rejected');
+    assert.equal(
+      rejected.length,
+      1,
+      `expected scope-bypass-rejected; rows=${JSON.stringify(rows)}`
+    );
+    assert.equal(rejected[0].meta && rejected[0].meta.guard, 'type-line');
+  });
+});

--- a/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-bypass.test.js
+++ b/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-bypass.test.js
@@ -123,6 +123,10 @@ describe('protect-task-scope.js escape hatch + cross-task allow-list (GH-392 Tas
       toolName: 'Edit',
       toolInput: { file_path: target },
       env: {
+        // GH-528 ITEM 1: bypass requires the operator token in addition to
+        // REASON+TARGET. Env vars inherit into the agent shell; the token
+        // doesn't.
+        WORK_OPERATOR_TOKEN: '1',
         PROTECT_TASK_SCOPE_BYPASS_REASON: reason,
         PROTECT_TASK_SCOPE_BYPASS_TARGET: 'src/shared/schema.ts',
       },
@@ -151,7 +155,9 @@ describe('protect-task-scope.js escape hatch + cross-task allow-list (GH-392 Tas
       `audit row meta should record configuredTarget; got: ${serialized}`
     );
     assert.ok(
-      row.task === 1 || row.task === '1' || (row.meta && (row.meta.taskNum === 1 || row.meta.task === 1)),
+      row.task === 1 ||
+        row.task === '1' ||
+        (row.meta && (row.meta.taskNum === 1 || row.meta.task === 1)),
       `audit row should reference task 1; got: ${serialized}`
     );
   });
@@ -205,6 +211,8 @@ describe('protect-task-scope.js escape hatch + cross-task allow-list (GH-392 Tas
       toolName: 'Edit',
       toolInput: { file_path: target },
       env: {
+        // GH-528 ITEM 1: bypass requires WORK_OPERATOR_TOKEN.
+        WORK_OPERATOR_TOKEN: '1',
         PROTECT_TASK_SCOPE_BYPASS_REASON: 'pattern bypass',
         PROTECT_TASK_SCOPE_BYPASS_TARGET: 'src/shared/**',
       },
@@ -229,7 +237,11 @@ describe('protect-task-scope.js escape hatch + cross-task allow-list (GH-392 Tas
       // no bypass reason, no cross-task deps → must block
     });
 
-    assert.equal(r.status, 2, `expected exit 2 when no bypass and no cross-task dep; stderr=${r.stderr}`);
+    assert.equal(
+      r.status,
+      2,
+      `expected exit 2 when no bypass and no cross-task dep; stderr=${r.stderr}`
+    );
     const stderr = r.stderr.trimEnd();
     const lastLine = stderr.split('\n').pop() || '';
     assert.match(

--- a/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js
+++ b/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js
@@ -1,0 +1,272 @@
+'use strict';
+
+/**
+ * protect-task-scope.js — per-Type closed-allowlist tests (GH-528 item 5).
+ *
+ * Each kind:
+ *   - tests-only → write target must be *.test.* / *.spec.*
+ *   - docs → write target must be *.md
+ *   - config → write target must be in config allowlist
+ *   - ci → write target must be dot-github/workflows/** etc.
+ *   - tdd-code → unchanged (no per-Type restriction)
+ *
+ * Plus:
+ *   - Type-line edit in tasks.md is blocked (Write + Edit + MultiEdit).
+ *   - One-shot env bypass (REASON+TARGET) still works through per-Type layer.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const HOOK = path.resolve(__dirname, '..', 'protect-task-scope.js');
+const WORK_STATE_FILENAME = '.work' + '-state.json';
+const TICKET = 'TEST-528';
+
+function writeWorkState(tasksDir) {
+  fs.writeFileSync(
+    path.join(tasksDir, WORK_STATE_FILENAME),
+    JSON.stringify({
+      ticketId: TICKET,
+      stepStatus: { ticket: 'completed', implement: 'in_progress' },
+      tasksMeta: { currentTaskIndex: 0, tasks: [{ id: 'task_1', status: 'in_progress' }] },
+    })
+  );
+}
+
+function writeTasksMd(tasksDir, { type, filesInScope }) {
+  const lines = [
+    '## Task 1 — sample',
+    '',
+    '### Type',
+    type,
+    '',
+    '### Files in scope',
+    ...filesInScope.map((f) => `- ${f}`),
+    '',
+  ];
+  fs.writeFileSync(path.join(tasksDir, 'tasks.md'), lines.join('\n'));
+}
+
+function runHook({ tasksBase, cwd, toolName, toolInput, env = {} }) {
+  return spawnSync('node', [HOOK], {
+    input: JSON.stringify({ tool_name: toolName, tool_input: toolInput }),
+    encoding: 'utf8',
+    cwd,
+    env: {
+      ...process.env,
+      TASKS_BASE: tasksBase,
+      PROTECT_TASK_SCOPE_TICKET_ID: TICKET,
+      PROTECT_TASK_SCOPE_BYPASS_REASON: '',
+      PROTECT_TASK_SCOPE_BYPASS_TARGET: '',
+      ...env,
+    },
+  });
+}
+
+describe('protect-task-scope — per-Type allowlist', () => {
+  let tmpHome;
+  let tasksBase;
+  let tasksDir;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pts-type-'));
+    tasksBase = path.join(tmpHome, 'tasks');
+    tasksDir = path.join(tasksBase, TICKET);
+    fs.mkdirSync(tasksDir, { recursive: true });
+    writeWorkState(tasksDir);
+  });
+  afterEach(() => fs.rmSync(tmpHome, { recursive: true, force: true }));
+
+  it('Type=tests-only — *.test.js target ALLOWED', () => {
+    writeTasksMd(tasksDir, { type: 'tests-only', filesInScope: ['src/**'] });
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: path.join(tmpHome, 'src/foo.test.js'), content: 'x' },
+    });
+    assert.equal(r.status, 0, `expected allow; stderr=${r.stderr}`);
+  });
+
+  it('Type=tests-only — src/foo.js target BLOCKED', () => {
+    writeTasksMd(tasksDir, { type: 'tests-only', filesInScope: ['src/**'] });
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: path.join(tmpHome, 'src/foo.js'), content: 'x' },
+    });
+    assert.equal(r.status, 2, `expected block; stdout=${r.stdout}`);
+    assert.match(r.stderr, /tests-only/);
+  });
+
+  it('Type=docs — README.md ALLOWED', () => {
+    writeTasksMd(tasksDir, { type: 'docs', filesInScope: ['**/*.md'] });
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: path.join(tmpHome, 'README.md'), content: 'x' },
+    });
+    assert.equal(r.status, 0, `expected allow; stderr=${r.stderr}`);
+  });
+
+  it('Type=docs — src/foo.js BLOCKED', () => {
+    writeTasksMd(tasksDir, { type: 'docs', filesInScope: ['**/*'] });
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: path.join(tmpHome, 'src/foo.js'), content: 'x' },
+    });
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /docs allowlist/);
+  });
+
+  it('Type=config — package.json ALLOWED', () => {
+    writeTasksMd(tasksDir, { type: 'config', filesInScope: ['**/*'] });
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: path.join(tmpHome, 'package.json'), content: 'x' },
+    });
+    assert.equal(r.status, 0, `expected allow; stderr=${r.stderr}`);
+  });
+
+  it('Type=config — src/server.js BLOCKED', () => {
+    writeTasksMd(tasksDir, { type: 'config', filesInScope: ['**/*'] });
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: path.join(tmpHome, 'src/server.js'), content: 'x' },
+    });
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /config allowlist/);
+  });
+
+  it('Type=ci — dot-github/workflows/ci.yml ALLOWED', () => {
+    writeTasksMd(tasksDir, { type: 'ci', filesInScope: ['**/*'] });
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: path.join(tmpHome, '.git' + 'hub/workflows/ci.yml'), content: 'x' },
+    });
+    assert.equal(r.status, 0, `expected allow; stderr=${r.stderr}`);
+  });
+
+  it('Type=ci — src/foo.js BLOCKED', () => {
+    writeTasksMd(tasksDir, { type: 'ci', filesInScope: ['**/*'] });
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: path.join(tmpHome, 'src/foo.js'), content: 'x' },
+    });
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /ci allowlist/);
+  });
+
+  it('Type=tdd-code — existing behavior unchanged (no per-Type restriction)', () => {
+    writeTasksMd(tasksDir, { type: 'tdd-code', filesInScope: ['src/**'] });
+    // Even non-test, non-md file is allowed because tdd-code has no allowlist.
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: path.join(tmpHome, 'src/foo.js'), content: 'x' },
+    });
+    assert.equal(r.status, 0, `expected allow for tdd-code; stderr=${r.stderr}`);
+  });
+
+  it('one-shot bypass pair still works for per-Type layer', () => {
+    writeTasksMd(tasksDir, { type: 'docs', filesInScope: ['**/*'] });
+    const target = path.join(tmpHome, 'src/foo.js');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: target, content: 'x' },
+      env: {
+        PROTECT_TASK_SCOPE_BYPASS_REASON: 'emergency docs ship',
+        PROTECT_TASK_SCOPE_BYPASS_TARGET: 'src/foo.js',
+      },
+    });
+    assert.equal(r.status, 0, `expected bypass to allow; stderr=${r.stderr}`);
+  });
+});
+
+describe('protect-task-scope — Type-line edit guard', () => {
+  let tmpHome;
+  let tasksBase;
+  let tasksDir;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pts-type-line-'));
+    tasksBase = path.join(tmpHome, 'tasks');
+    tasksDir = path.join(tasksBase, TICKET);
+    fs.mkdirSync(tasksDir, { recursive: true });
+    writeWorkState(tasksDir);
+    writeTasksMd(tasksDir, { type: 'tdd-code', filesInScope: ['src/**'] });
+  });
+  afterEach(() => fs.rmSync(tmpHome, { recursive: true, force: true }));
+
+  it('Write to tasks.md that flips Type tdd-code → docs is BLOCKED', () => {
+    const newContent = [
+      '## Task 1 — sample',
+      '',
+      '### Type',
+      'docs',
+      '',
+      '### Files in scope',
+      '- src/**',
+      '',
+    ].join('\n');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        content: newContent,
+      },
+    });
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /### Type/);
+  });
+
+  it('Write to tasks.md that preserves Type lines is permitted by Type-line guard (other gates may still block)', () => {
+    const sameContent = fs.readFileSync(path.join(tasksDir, 'tasks.md'), 'utf8');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        content: sameContent,
+      },
+    });
+    // Note: scope check may still block (tasks.md is not under src/**), but
+    // the message must not mention `### Type`.
+    assert.doesNotMatch(r.stderr || '', /refusing to modify `### Type`/);
+  });
+
+  it('Edit tool whose patch changes `### Type` line is BLOCKED', () => {
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Edit',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        old_string: '### Type\ntdd-code',
+        new_string: '### Type\ndocs',
+      },
+    });
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /### Type/);
+  });
+});

--- a/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js
+++ b/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js
@@ -211,7 +211,13 @@ describe('protect-task-scope — Type-line edit guard', () => {
     tasksDir = path.join(tasksBase, TICKET);
     fs.mkdirSync(tasksDir, { recursive: true });
     writeWorkState(tasksDir);
-    writeTasksMd(tasksDir, { type: 'tdd-code', filesInScope: ['src/**'] });
+    // Include tasks.md in scope so the ONLY gate that can block these edits
+    // is the Type-line guard itself — proves the guard, not the scope gate,
+    // is doing the work.
+    writeTasksMd(tasksDir, {
+      type: 'tdd-code',
+      filesInScope: ['src/**', 'tasks/**/tasks.md'],
+    });
   });
   afterEach(() => fs.rmSync(tmpHome, { recursive: true, force: true }));
 
@@ -268,5 +274,118 @@ describe('protect-task-scope — Type-line edit guard', () => {
     });
     assert.equal(r.status, 2);
     assert.match(r.stderr, /### Type/);
+  });
+
+  // Comment 5 — cursor[bot] HIGH: value-only patches must be blocked too.
+  it('Edit tool with value-only patch (no `### Type` header in strings) is BLOCKED', () => {
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Edit',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        old_string: 'tdd-code',
+        new_string: 'docs',
+      },
+    });
+    assert.equal(r.status, 2, `expected block; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.match(r.stderr, /### Type/);
+  });
+
+  it('Edit tool with whitespace-tricked value patch is BLOCKED', () => {
+    // Author the on-disk Type value with trailing whitespace so a patch can
+    // strip it and still flip semantic value.
+    const lines = [
+      '## Task 1 — sample',
+      '',
+      '### Type',
+      'tdd-code  ',
+      '',
+      '### Files in scope',
+      '- src/**',
+      '- tasks/**/tasks.md',
+      '',
+    ];
+    fs.writeFileSync(path.join(tasksDir, 'tasks.md'), lines.join('\n'));
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Edit',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        old_string: 'tdd-code  ',
+        new_string: 'docs',
+      },
+    });
+    assert.equal(r.status, 2, `expected block; stderr=${r.stderr}`);
+  });
+
+  it('MultiEdit split across two value-only edits that flip Type is BLOCKED', () => {
+    // Neither edit contains `### Type`; the combined effect flips tdd-code → docs.
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'MultiEdit',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        edits: [
+          { old_string: 'tdd-code', new_string: 'PLACEHOLDER_X' },
+          { old_string: 'PLACEHOLDER_X', new_string: 'docs' },
+        ],
+      },
+    });
+    assert.equal(r.status, 2, `expected block; stderr=${r.stderr}`);
+  });
+
+  it('Edit on a non-Type line of tasks.md is NOT blocked by Type-line guard', () => {
+    // Patches the `### Files in scope` bullet, not Type — Type-line guard must
+    // not fire. (Other gates may still block tasks.md edits, but the stderr
+    // must not mention the Type-line refusal message.)
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Edit',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        old_string: '- src/**',
+        new_string: '- src/**\n- lib/**',
+      },
+    });
+    assert.doesNotMatch(r.stderr || '', /refusing to (modify|edit) `### Type`/);
+  });
+
+  it('Edit on a totally different file does NOT trigger Type-line guard', () => {
+    // Out-of-scope path so the scope check may block — but the Type-line guard
+    // must not fire (no false positive on non-tasks.md files).
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Edit',
+      toolInput: {
+        file_path: path.join(tmpHome, 'src/foo.js'),
+        old_string: 'tdd-code',
+        new_string: 'docs',
+      },
+    });
+    assert.doesNotMatch(r.stderr || '', /refusing to (modify|edit) `### Type`/);
+  });
+
+  it('one-shot bypass pair still works for Type-line guard when target matches', () => {
+    const target = path.join(tasksDir, 'tasks.md');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Edit',
+      toolInput: {
+        file_path: target,
+        old_string: 'tdd-code',
+        new_string: 'docs',
+      },
+      env: {
+        PROTECT_TASK_SCOPE_BYPASS_REASON: 'planner re-keying type mid-cycle',
+        PROTECT_TASK_SCOPE_BYPASS_TARGET: path.relative(tmpHome, target),
+      },
+    });
+    assert.equal(r.status, 0, `expected bypass to allow; stderr=${r.stderr}`);
   });
 });

--- a/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js
+++ b/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js
@@ -24,7 +24,24 @@ const { spawnSync } = require('node:child_process');
 
 const HOOK = path.resolve(__dirname, '..', 'protect-task-scope.js');
 const WORK_STATE_FILENAME = '.work' + '-state.json';
+const WORK_ACTIONS_FILENAME = '.work' + '-actions.json';
 const TICKET = 'TEST-528';
+
+function readActions(tasksBase) {
+  const p = path.join(tasksBase, TICKET, WORK_ACTIONS_FILENAME);
+  if (!fs.existsSync(p)) return [];
+  const raw = fs.readFileSync(p, 'utf8').trim();
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return raw
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  }
+}
 
 function writeWorkState(tasksDir) {
   fs.writeFileSync(
@@ -187,17 +204,85 @@ describe('protect-task-scope — per-Type allowlist', () => {
   it('one-shot bypass pair still works for per-Type layer', () => {
     writeTasksMd(tasksDir, { type: 'docs', filesInScope: ['**/*'] });
     const target = path.join(tmpHome, 'src/foo.js');
+    const reason = 'emergency docs ship';
     const r = runHook({
       tasksBase,
       cwd: tmpHome,
       toolName: 'Write',
       toolInput: { file_path: target, content: 'x' },
       env: {
-        PROTECT_TASK_SCOPE_BYPASS_REASON: 'emergency docs ship',
+        PROTECT_TASK_SCOPE_BYPASS_REASON: reason,
         PROTECT_TASK_SCOPE_BYPASS_TARGET: 'src/foo.js',
       },
     });
     assert.equal(r.status, 0, `expected bypass to allow; stderr=${r.stderr}`);
+
+    // Audit trail: per-Type bypass must append a scope-bypass row with
+    // guard='type-allowlist'. Without this, operators can override the
+    // closed-allowlist gate silently.
+    const rows = readActions(tasksBase);
+    const bypassRows = rows.filter((row) => row && row.action === 'scope-bypass');
+    assert.equal(bypassRows.length, 1, 'exactly one scope-bypass audit row expected');
+    const row = bypassRows[0];
+    assert.equal(row.reason, reason, 'audit row carries the supplied reason');
+    assert.equal(row.allow, true, 'audit row records the allow decision');
+    assert.equal(
+      row.meta && row.meta.guard,
+      'type-allowlist',
+      `audit row meta should discriminate the type-allowlist guard; got: ${JSON.stringify(row)}`
+    );
+    assert.equal(
+      row.meta && row.meta.configuredTarget,
+      'src/foo.js',
+      `audit row meta should record configuredTarget; got: ${JSON.stringify(row)}`
+    );
+    const serialized = JSON.stringify(row);
+    assert.ok(
+      serialized.includes('src/foo.js'),
+      `audit row should reference the actual write target; got: ${serialized}`
+    );
+  });
+
+  it('per-Type bypass with NON-matching TARGET does NOT append audit row and blocks', () => {
+    writeTasksMd(tasksDir, { type: 'docs', filesInScope: ['**/*'] });
+    const target = path.join(tmpHome, 'src/foo.js');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: target, content: 'x' },
+      env: {
+        PROTECT_TASK_SCOPE_BYPASS_REASON: 'some reason',
+        PROTECT_TASK_SCOPE_BYPASS_TARGET: 'src/elsewhere.js',
+      },
+    });
+    assert.equal(r.status, 2, `expected block when TARGET mismatches; stderr=${r.stderr}`);
+    const rows = readActions(tasksBase);
+    const bypassRows = rows.filter((row) => row && row.action === 'scope-bypass');
+    assert.equal(bypassRows.length, 0, 'no scope-bypass row when per-Type TARGET mismatches');
+  });
+
+  it('per-Type bypass with REASON set but no TARGET does NOT append audit row and blocks', () => {
+    writeTasksMd(tasksDir, { type: 'docs', filesInScope: ['**/*'] });
+    const target = path.join(tmpHome, 'src/foo.js');
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Write',
+      toolInput: { file_path: target, content: 'x' },
+      env: {
+        PROTECT_TASK_SCOPE_BYPASS_REASON: 'lone reason',
+        // No TARGET set
+      },
+    });
+    assert.equal(r.status, 2, `expected block when TARGET missing; stderr=${r.stderr}`);
+    const rows = readActions(tasksBase);
+    const bypassRows = rows.filter((row) => row && row.action === 'scope-bypass');
+    assert.equal(
+      bypassRows.length,
+      0,
+      'REASON alone never opens the per-Type gate or appends audit'
+    );
   });
 });
 

--- a/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js
+++ b/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js
@@ -201,7 +201,7 @@ describe('protect-task-scope — per-Type allowlist', () => {
     assert.equal(r.status, 0, `expected allow for tdd-code; stderr=${r.stderr}`);
   });
 
-  it('one-shot bypass pair still works for per-Type layer', () => {
+  it('one-shot bypass pair still works for per-Type layer (with WORK_OPERATOR_TOKEN)', () => {
     writeTasksMd(tasksDir, { type: 'docs', filesInScope: ['**/*'] });
     const target = path.join(tmpHome, 'src/foo.js');
     const reason = 'emergency docs ship';
@@ -211,6 +211,8 @@ describe('protect-task-scope — per-Type allowlist', () => {
       toolName: 'Write',
       toolInput: { file_path: target, content: 'x' },
       env: {
+        // GH-528 ITEM 1: bypass requires the operator token too.
+        WORK_OPERATOR_TOKEN: '1',
         PROTECT_TASK_SCOPE_BYPASS_REASON: reason,
         PROTECT_TASK_SCOPE_BYPASS_TARGET: 'src/foo.js',
       },
@@ -455,7 +457,7 @@ describe('protect-task-scope — Type-line edit guard', () => {
     assert.doesNotMatch(r.stderr || '', /refusing to (modify|edit) `### Type`/);
   });
 
-  it('one-shot bypass pair still works for Type-line guard when target matches', () => {
+  it('one-shot bypass pair still works for Type-line guard when target matches (with WORK_OPERATOR_TOKEN)', () => {
     const target = path.join(tasksDir, 'tasks.md');
     const r = runHook({
       tasksBase,
@@ -467,6 +469,8 @@ describe('protect-task-scope — Type-line edit guard', () => {
         new_string: 'docs',
       },
       env: {
+        // GH-528 ITEM 1: bypass requires the operator token too.
+        WORK_OPERATOR_TOKEN: '1',
         PROTECT_TASK_SCOPE_BYPASS_REASON: 'planner re-keying type mid-cycle',
         PROTECT_TASK_SCOPE_BYPASS_TARGET: path.relative(tmpHome, target),
       },

--- a/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js
+++ b/plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js
@@ -457,6 +457,149 @@ describe('protect-task-scope — Type-line edit guard', () => {
     assert.doesNotMatch(r.stderr || '', /refusing to (modify|edit) `### Type`/);
   });
 
+  // ── GH-528 round-2 follow-up ITEM 5: regression cases for Type-line
+  //    patch tricks. Cases 1-3 are already covered above; the four below
+  //    plug remaining gaps the checkEditTypeLines simulator must catch.
+
+  it('ITEM 5 — case 4a: MultiEdit replace_all on shared token that FLIPS Type → BLOCKED', () => {
+    // On-disk Type value `tdd-code` collides with no other token, so plant
+    // one inside an AC bullet that the planner authored. replace_all rewrites
+    // every occurrence including the Type-line value → simulated Type
+    // changes → must block.
+    const lines = [
+      '## Task 1 — sample',
+      '',
+      '### Type',
+      'tdd-code',
+      '',
+      '### Acceptance Criteria',
+      '- This task is tdd-code-shaped and lists tdd-code coverage.',
+      '',
+      '### Files in scope',
+      '- src/**',
+      '- tasks/**/tasks.md',
+      '',
+    ];
+    fs.writeFileSync(path.join(tasksDir, 'tasks.md'), lines.join('\n'));
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'MultiEdit',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        edits: [{ old_string: 'tdd-code', new_string: 'docs', replace_all: true }],
+      },
+    });
+    assert.equal(r.status, 2, `expected block; stderr=${r.stderr}`);
+    assert.match(r.stderr, /### Type/);
+  });
+
+  it('ITEM 5 — case 4b: MultiEdit replace_all on shared token that does NOT change Type-line → ALLOWED by Type-line guard', () => {
+    // Plant `tdd-code` only inside the Type heading-LINE itself and an AC
+    // bullet of a different task — then replace_all on a token that exists
+    // ONLY in non-Type-line prose must not trigger the guard.
+    const lines = [
+      '## Task 1 — sample',
+      '',
+      '### Type',
+      'tdd-code',
+      '',
+      '### Description',
+      'Reference: see docs/foo.md and docs/bar.md',
+      '',
+      '### Files in scope',
+      '- src/**',
+      '- tasks/**/tasks.md',
+      '',
+    ];
+    fs.writeFileSync(path.join(tasksDir, 'tasks.md'), lines.join('\n'));
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'MultiEdit',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        edits: [{ old_string: 'docs/', new_string: 'documentation/', replace_all: true }],
+      },
+    });
+    // Type-line guard must NOT fire — the simulated `### Type` value
+    // (tdd-code) is unchanged. (Other gates may still allow.)
+    assert.doesNotMatch(
+      r.stderr || '',
+      /refusing to (modify|edit) `### Type`/,
+      `Type-line guard fired on a replace_all that didn't touch Type; stderr=${r.stderr}`
+    );
+  });
+
+  it('ITEM 5 — case 5: Edit on an AC bullet containing the word "Type" (not the heading) → NOT blocked by Type-line guard', () => {
+    // Authoring "Type" inside a description bullet (not the `### Type` heading
+    // line) used to be ambiguous in the legacy extractor. With the simulator
+    // approach the on-disk Type value is unchanged → guard must stay quiet.
+    const lines = [
+      '## Task 1 — sample',
+      '',
+      '### Type',
+      'tdd-code',
+      '',
+      '### Acceptance Criteria',
+      '- Document Type taxonomy in README',
+      '',
+      '### Files in scope',
+      '- src/**',
+      '- tasks/**/tasks.md',
+      '',
+    ];
+    fs.writeFileSync(path.join(tasksDir, 'tasks.md'), lines.join('\n'));
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Edit',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        old_string: '- Document Type taxonomy in README',
+        new_string: '- Document Type taxonomy and gate contract in README',
+      },
+    });
+    assert.doesNotMatch(
+      r.stderr || '',
+      /refusing to (modify|edit) `### Type`/,
+      `Type-line guard fired on a non-heading line containing "Type"; stderr=${r.stderr}`
+    );
+  });
+
+  it('ITEM 5 — case 6: Edit that adds whitespace ONLY to the `### Type` heading line → ALLOWED (value unchanged)', () => {
+    // The simulator compares the EXTRACTED Type value lines, not the raw
+    // heading line — trailing whitespace on `### Type` itself is cosmetic
+    // and must not trigger the guard.
+    const lines = [
+      '## Task 1 — sample',
+      '',
+      '### Type',
+      'tdd-code',
+      '',
+      '### Files in scope',
+      '- src/**',
+      '- tasks/**/tasks.md',
+      '',
+    ];
+    fs.writeFileSync(path.join(tasksDir, 'tasks.md'), lines.join('\n'));
+    const r = runHook({
+      tasksBase,
+      cwd: tmpHome,
+      toolName: 'Edit',
+      toolInput: {
+        file_path: path.join(tasksDir, 'tasks.md'),
+        old_string: '### Type',
+        new_string: '### Type   ',
+      },
+    });
+    assert.doesNotMatch(
+      r.stderr || '',
+      /refusing to (modify|edit) `### Type`/,
+      `Type-line guard fired on whitespace-only heading edit; stderr=${r.stderr}`
+    );
+  });
+
   it('one-shot bypass pair still works for Type-line guard when target matches (with WORK_OPERATOR_TOKEN)', () => {
     const target = path.join(tasksDir, 'tasks.md');
     const r = runHook({

--- a/plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
+++ b/plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
@@ -577,7 +577,7 @@ async function main() {
     process.exit(2);
   }
 
-  const typeBlock = checkPerTypeAllowlist(active, toolName, toolInput, cwd);
+  const typeBlock = checkPerTypeAllowlist(active, toolName, toolInput, cwd, ticketId);
   if (typeBlock.blocked) {
     process.stderr.write(typeBlock.reason + '\n');
     process.exit(2);
@@ -592,7 +592,7 @@ async function main() {
  * (their existing behavior). Honors the one-shot env-var bypass pair so
  * operators can still pin a single override target across this layer.
  */
-function checkPerTypeAllowlist(active, toolName, toolInput, cwd) {
+function checkPerTypeAllowlist(active, toolName, toolInput, cwd, ticketId) {
   if (!active.type || !TYPE_ENFORCED_KINDS.has(active.type)) return { blocked: false };
   const target = extractTargetPath(toolName, toolInput) || '';
   if (!target) return { blocked: false };
@@ -604,7 +604,37 @@ function checkPerTypeAllowlist(active, toolName, toolInput, cwd) {
     bypassReason &&
     bypassTargetCfg &&
     (relTarget === bypassTargetCfg || findMatch(relTarget, [bypassTargetCfg]) !== null);
-  if (bypassMatched) return { blocked: false };
+  if (bypassMatched) {
+    // Mirror the scope-bypass audit pattern (see main() around L519 and the
+    // type-line guard's tryTypeLineBypass) so a closed-allowlist override is
+    // never silent. Discriminator: meta.guard='type-allowlist'.
+    if (ticketId) {
+      try {
+        appendEnforcementAudit(ticketId, {
+          origin: 'ai-subtask',
+          task: active.taskNum,
+          phase: null,
+          action: 'scope-bypass',
+          allow: true,
+          reason: bypassReason,
+          outputPath: relTarget,
+          meta: {
+            taskNum: active.taskNum,
+            target: relTarget,
+            configuredTarget: bypassTargetCfg,
+            guard: 'type-allowlist',
+          },
+        });
+      } catch (err) {
+        try {
+          logHookError(__filename, err);
+        } catch {
+          /* swallow */
+        }
+      }
+    }
+    return { blocked: false };
+  }
   return typeAllowlistDecision(active.type, relTarget);
 }
 

--- a/plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
+++ b/plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
@@ -280,24 +280,100 @@ function checkWriteTypeLines(toolInput, onDiskTypes) {
   };
 }
 
-function checkEditTypeLines(toolName, toolInput) {
+/**
+ * Apply a single Edit patch in memory using the same semantics Claude Code's
+ * Edit tool uses: literal string replacement, first occurrence only unless
+ * `replace_all` is true. Returns the patched content, or null when the patch
+ * cannot be applied (old_string not found) — caller treats null as a fall-
+ * through (no change simulated, the real tool would error).
+ */
+function applyEditPatch(content, edit) {
+  const oldStr = (edit.old_string || '').toString();
+  const newStr = (edit.new_string || '').toString();
+  if (!oldStr) return content;
+  if (edit.replace_all) {
+    return content.split(oldStr).join(newStr);
+  }
+  const idx = content.indexOf(oldStr);
+  if (idx === -1) return null;
+  return content.slice(0, idx) + newStr + content.slice(idx + oldStr.length);
+}
+
+/**
+ * Cursor[bot] Comment 5 (GH-528): value-only patches must be detected.
+ *
+ * The old heuristic (string-match `### Type` in patch text) missed:
+ *   - `old: "tdd-code", new: "docs"` (no header in patch strings)
+ *   - whitespace tricks (`old: "tdd-code  ", new: "docs"`)
+ *   - MultiEdit split across two edits that combine to flip the value
+ *
+ * The source of truth is "what does the resolved file look like after the
+ * patch?" — so we read tasks.md from disk, simulate the Edit/MultiEdit, and
+ * compare extracted `### Type` lines before vs after. If they differ, block.
+ *
+ * This function is invoked only when the write target IS tasks.md (caller
+ * guarantees), so the cost of reading + simulating is bounded.
+ */
+function checkEditTypeLines(toolName, toolInput, onDiskContent, onDiskTypes) {
   const edits =
     toolName === 'Edit' ? [toolInput] : Array.isArray(toolInput.edits) ? toolInput.edits : [];
+  if (edits.length === 0) return { blocked: false };
+
+  let simulated = onDiskContent;
   for (const edit of edits) {
-    const oldStr = (edit.old_string || '').toString();
-    const newStr = (edit.new_string || '').toString();
-    const oldHas = /^###\s+Type\b/m.test(oldStr);
-    const newHas = /^###\s+Type\b/m.test(newStr);
-    if ((oldHas || newHas) && oldStr !== newStr) {
-      return {
-        blocked: true,
-        reason:
-          `protect-task-scope: refusing to edit \`### Type\` line in tasks.md ` +
-          `mid-implement. Type is planner-authored.`,
-      };
+    const next = applyEditPatch(simulated, edit);
+    // null = old_string not found; the real tool would error, so the file
+    // wouldn't change. Skip this edit in the simulation.
+    if (next !== null) simulated = next;
+  }
+
+  const newTypes = extractTypeLines(simulated);
+  if (typesEqual(onDiskTypes, newTypes)) return { blocked: false };
+
+  return {
+    blocked: true,
+    reason:
+      `protect-task-scope: refusing to edit \`### Type\` line in tasks.md ` +
+      `mid-implement. Type is planner-authored. On disk: ${JSON.stringify(onDiskTypes)} ` +
+      `→ after patch: ${JSON.stringify(newTypes)}.`,
+  };
+}
+
+/**
+ * Honor the one-shot env-var escape hatch for the Type-line guard. Returns
+ * true when the bypass fired (audit appended, caller should exit 0).
+ */
+function tryTypeLineBypass(toolName, toolInput, cwd, ticketId, active) {
+  const rel = relativizePath(extractTargetPath(toolName, toolInput) || '', cwd);
+  const bypassReason = (process.env.PROTECT_TASK_SCOPE_BYPASS_REASON || '').trim();
+  const bypassTargetCfg = (process.env.PROTECT_TASK_SCOPE_BYPASS_TARGET || '').trim();
+  if (!bypassReason || !bypassTargetCfg || !rel) return false;
+  const matched = rel === bypassTargetCfg || findMatch(rel, [bypassTargetCfg]) !== null;
+  if (!matched) return false;
+  try {
+    appendEnforcementAudit(ticketId, {
+      origin: 'ai-subtask',
+      task: active.taskNum,
+      phase: null,
+      action: 'scope-bypass',
+      allow: true,
+      reason: bypassReason,
+      outputPath: rel,
+      meta: {
+        taskNum: active.taskNum,
+        target: rel,
+        configuredTarget: bypassTargetCfg,
+        guard: 'type-line',
+      },
+    });
+  } catch (err) {
+    try {
+      logHookError(__filename, err);
+    } catch {
+      /* swallow */
     }
   }
-  return { blocked: false };
+  return true;
 }
 
 function typeLineGuard(toolName, toolInput, workDir, tasksDir) {
@@ -318,7 +394,7 @@ function typeLineGuard(toolName, toolInput, workDir, tasksDir) {
 
   if (toolName === 'Write') return checkWriteTypeLines(toolInput, onDiskTypes);
   if (toolName === 'Edit' || toolName === 'MultiEdit') {
-    return checkEditTypeLines(toolName, toolInput);
+    return checkEditTypeLines(toolName, toolInput, onDisk, onDiskTypes);
   }
   return { blocked: false };
 }
@@ -410,6 +486,7 @@ async function main() {
   // blocks the bypass of flipping `### Type` mid-implement.
   const typeLineDecision = typeLineGuard(toolName, toolInput, cwd, tasksDir);
   if (typeLineDecision.blocked) {
+    if (tryTypeLineBypass(toolName, toolInput, cwd, ticketId, active)) process.exit(0);
     process.stderr.write(typeLineDecision.reason + '\n');
     process.exit(2);
   }

--- a/plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
+++ b/plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
@@ -48,6 +48,9 @@ const { decideEdit, relativizePath, findMatch } = require(
   path.join(__dirname, '..', '..', 'lib', 'hooks', 'policies', 'scope-protection')
 );
 const { parseTasks } = require(path.join(__dirname, '..', '..', 'work', 'lib', 'task-parser'));
+const { matchesTypeScope, scopeRulesFor, isTestFilePath } = require(
+  path.join(__dirname, '..', '..', '..', '..', 'skills', 'split-in-tasks', 'lib', 'task-types')
+);
 const { appendEnforcementAudit } = require(
   path.join(__dirname, '..', '..', 'work', 'lib', 'work-actions')
 );
@@ -144,6 +147,13 @@ function getActiveTask(tasksDir) {
     // by sibling tasks). decideEdit blocks would be overridden to exit 0 with
     // a `cross-task-dep-allow` audit row.
     crossTaskDeps: Array.isArray(task.crossTaskDeps) ? task.crossTaskDeps : [],
+    // GH-528 item 5: per-Type allowlist layer. tdd-code / checkpoint /
+    // mechanical-refactor / file-move keep existing behavior (no per-Type
+    // restriction beyond the filesInScope/filesOutOfScope check). The
+    // closed-allowlist types (tests-only, docs, config, ci) additionally
+    // require the write target to match their per-Type pattern set in
+    // skills/split-in-tasks/lib/task-types.js.
+    type: typeof task.type === 'string' ? task.type : '',
   };
 }
 
@@ -207,6 +217,140 @@ function extractBashWriteTargets(cmd) {
 
 // ─── Main hook ──────────────────────────────────────────────────────────────
 
+// ─── GH-528 item 5: per-Type allowlist + Type-line edit guard ───────────────
+
+/**
+ * Per-Type closed-allowlist types. For these, the write target must match
+ * the Type's scopePatterns regex in addition to the active task's filesInScope.
+ * Types not in this set keep the existing behavior (filesInScope check only).
+ */
+const TYPE_ENFORCED_KINDS = new Set(['tests-only', 'docs', 'config', 'ci']);
+
+function typeAllowlistDecision(type, relTarget) {
+  if (!type || !TYPE_ENFORCED_KINDS.has(type)) return { blocked: false };
+  const rules = scopeRulesFor(type);
+  if (!rules || !rules.scopePatterns) return { blocked: false };
+  if (matchesTypeScope(type, relTarget)) {
+    // For tests-only also require the target to be a test file. matchesTypeScope
+    // already enforces this via the TEST_FILE_PATTERN pattern but keep an
+    // explicit check so the error message is precise.
+    if (type === 'tests-only' && !isTestFilePath(relTarget)) {
+      return {
+        blocked: true,
+        reason:
+          `Type=tests-only restricts writes to *.test.* / *.spec.* files. ` +
+          `Target "${relTarget}" is not a test file.`,
+      };
+    }
+    return { blocked: false };
+  }
+  return {
+    blocked: true,
+    reason:
+      `Type=${type} restricts writes to a closed allowlist (see ` +
+      `plugins/work/skills/split-in-tasks/lib/task-types.js). ` +
+      `Target "${relTarget}" is not in the ${type} allowlist.`,
+  };
+}
+
+/**
+ * Detect attempts to edit the `### Type` line inside a tasks.md write. The
+ * planner authors `### Type`; the implementer must not be able to flip it
+ * mid-implement (which would let them switch from tdd-code to docs to bypass
+ * the TDD gate). For Write tool calls targeting tasks.md, reject when the
+ * new content's `### Type` line differs from the on-disk version.
+ *
+ * Returns `{ blocked: true, reason }` to block, `{ blocked: false }` to allow.
+ *
+ * Scope: only triggers when the target relative path ends with `tasks.md`.
+ * Edit / MultiEdit tools that operate via `old_string` / `new_string` patches
+ * are checked by scanning the patches for the `### Type` line.
+ */
+function checkWriteTypeLines(toolInput, onDiskTypes) {
+  const newContent = (toolInput.content || '').toString();
+  const newTypes = extractTypeLines(newContent);
+  if (typesEqual(onDiskTypes, newTypes)) return { blocked: false };
+  return {
+    blocked: true,
+    reason:
+      `protect-task-scope: refusing to modify \`### Type\` lines in tasks.md ` +
+      `mid-implement. The planner sets Type; the implementer cannot change it ` +
+      `(would bypass the per-Type TDD contract). On disk: ${JSON.stringify(onDiskTypes)} ` +
+      `→ new: ${JSON.stringify(newTypes)}.`,
+  };
+}
+
+function checkEditTypeLines(toolName, toolInput) {
+  const edits =
+    toolName === 'Edit' ? [toolInput] : Array.isArray(toolInput.edits) ? toolInput.edits : [];
+  for (const edit of edits) {
+    const oldStr = (edit.old_string || '').toString();
+    const newStr = (edit.new_string || '').toString();
+    const oldHas = /^###\s+Type\b/m.test(oldStr);
+    const newHas = /^###\s+Type\b/m.test(newStr);
+    if ((oldHas || newHas) && oldStr !== newStr) {
+      return {
+        blocked: true,
+        reason:
+          `protect-task-scope: refusing to edit \`### Type\` line in tasks.md ` +
+          `mid-implement. Type is planner-authored.`,
+      };
+    }
+  }
+  return { blocked: false };
+}
+
+function typeLineGuard(toolName, toolInput, workDir, tasksDir) {
+  if (!toolInput || !tasksDir) return { blocked: false };
+  const target = (toolInput.file_path || '').toString();
+  if (!target) return { blocked: false };
+  const resolvedTarget = path.isAbsolute(target) ? target : path.resolve(workDir, target);
+  const tasksMdPath = path.resolve(tasksDir, 'tasks.md');
+  if (resolvedTarget !== tasksMdPath) return { blocked: false };
+
+  let onDisk = '';
+  try {
+    onDisk = fs.readFileSync(tasksMdPath, 'utf8');
+  } catch {
+    return { blocked: false };
+  }
+  const onDiskTypes = extractTypeLines(onDisk);
+
+  if (toolName === 'Write') return checkWriteTypeLines(toolInput, onDiskTypes);
+  if (toolName === 'Edit' || toolName === 'MultiEdit') {
+    return checkEditTypeLines(toolName, toolInput);
+  }
+  return { blocked: false };
+}
+
+function extractTypeLines(md) {
+  const out = [];
+  const lines = md.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    if (/^###\s+Type\s*$/i.test(lines[i].trim())) {
+      // Find the next non-blank line.
+      for (let j = i + 1; j < lines.length; j += 1) {
+        const next = lines[j].trim();
+        if (!next) continue;
+        if (next.startsWith('#')) {
+          out.push('');
+          break;
+        }
+        out.push(next.toLowerCase());
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+function typesEqual(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) if (a[i] !== b[i]) return false;
+  return true;
+}
+
 function evaluateTool(toolName, toolInput, active, workDir) {
   if (FILE_WRITE_TOOLS.has(toolName)) {
     const filePath = toolInput && toolInput.file_path;
@@ -260,6 +404,15 @@ async function main() {
 
   const toolName = hookData.tool_name || '';
   const toolInput = hookData.tool_input || {};
+
+  // GH-528 item 5: Type-line edit guard runs before scope evaluation.
+  // tasks.md is generally out of scope already, but this specifically
+  // blocks the bypass of flipping `### Type` mid-implement.
+  const typeLineDecision = typeLineGuard(toolName, toolInput, cwd, tasksDir);
+  if (typeLineDecision.blocked) {
+    process.stderr.write(typeLineDecision.reason + '\n');
+    process.exit(2);
+  }
 
   const decision = evaluateTool(toolName, toolInput, active, cwd);
   if (decision && decision.blocked) {
@@ -346,7 +499,36 @@ async function main() {
     process.stderr.write(decision.reason + '\n');
     process.exit(2);
   }
+
+  const typeBlock = checkPerTypeAllowlist(active, toolName, toolInput, cwd);
+  if (typeBlock.blocked) {
+    process.stderr.write(typeBlock.reason + '\n');
+    process.exit(2);
+  }
   process.exit(0);
+}
+
+/**
+ * GH-528 item 5: per-Type closed-allowlist check. Runs after the standard
+ * filesInScope decision has allowed the write. For tdd-code / checkpoint /
+ * mechanical-refactor / file-move, returns {blocked:false} unconditionally
+ * (their existing behavior). Honors the one-shot env-var bypass pair so
+ * operators can still pin a single override target across this layer.
+ */
+function checkPerTypeAllowlist(active, toolName, toolInput, cwd) {
+  if (!active.type || !TYPE_ENFORCED_KINDS.has(active.type)) return { blocked: false };
+  const target = extractTargetPath(toolName, toolInput) || '';
+  if (!target) return { blocked: false };
+  const relTarget = relativizePath(target, cwd);
+  if (!relTarget) return { blocked: false };
+  const bypassReason = (process.env.PROTECT_TASK_SCOPE_BYPASS_REASON || '').trim();
+  const bypassTargetCfg = (process.env.PROTECT_TASK_SCOPE_BYPASS_TARGET || '').trim();
+  const bypassMatched =
+    bypassReason &&
+    bypassTargetCfg &&
+    (relTarget === bypassTargetCfg || findMatch(relTarget, [bypassTargetCfg]) !== null);
+  if (bypassMatched) return { blocked: false };
+  return typeAllowlistDecision(active.type, relTarget);
 }
 
 /**
@@ -377,4 +559,13 @@ if (require.main === module) {
   });
 }
 
-module.exports = { evaluateTool, extractBashWriteTargets, getTicketId, getActiveTask };
+module.exports = {
+  evaluateTool,
+  extractBashWriteTargets,
+  getTicketId,
+  getActiveTask,
+  typeAllowlistDecision,
+  typeLineGuard,
+  extractTypeLines,
+  TYPE_ENFORCED_KINDS,
+};

--- a/plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
+++ b/plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
@@ -17,14 +17,28 @@
  *
  * Escape hatches (GH-392 Task 8 + follow-up):
  *   1. Env var PAIR — `PROTECT_TASK_SCOPE_BYPASS_REASON` AND
- *      `PROTECT_TASK_SCOPE_BYPASS_TARGET` must BOTH be set. The bypass only
- *      fires when the relativized target matches `BYPASS_TARGET` exactly OR
- *      via the same `findMatch` glob logic used elsewhere (so glob patterns
- *      like `src/shared/**` are honoured). One-shot by design: REASON alone
- *      opens a hole for any path; pairing it with TARGET pins the bypass to
- *      a single planned edit. When fired, appends a `scope-bypass` audit row
+ *      `PROTECT_TASK_SCOPE_BYPASS_TARGET` must BOTH be set, AND
+ *      `WORK_OPERATOR_TOKEN=1` must also be present in the environment
+ *      (GH-528 round-2 follow-up ITEM 1). The bypass only fires when the
+ *      relativized target matches `BYPASS_TARGET` exactly OR via the same
+ *      `findMatch` glob logic used elsewhere (so glob patterns like
+ *      `src/shared/**` are honoured). One-shot by design: REASON alone opens
+ *      a hole for any path; pairing it with TARGET pins the bypass to a
+ *      single planned edit. When fired, appends a `scope-bypass` audit row
  *      via `appendEnforcementAudit` (spec §P0#6) carrying both the configured
  *      TARGET and the actual write path.
+ *
+ *      WORK_OPERATOR_TOKEN gate (GH-528 round-2 ITEM 1): bypass env vars
+ *      inherit into every child process the agent spawns, so an agent that
+ *      can set REASON+TARGET in its own shell would otherwise be able to
+ *      flip the bypass on without operator intent. The token is an
+ *      operator-only env var (same pattern as the `exception` subcommand
+ *      in tdd-phase-state.js) that the agent's harness never carries. When
+ *      the token is missing AND REASON+TARGET match the write target, the
+ *      hook treats the env pair as unset (block stays) and appends a
+ *      `scope-bypass-rejected` audit row carrying the configured target
+ *      and reason — so the rejected attempt is visible without trusting
+ *      caller-supplied state.
  *   2. `### Cross-Task Dependencies` — paths in the active task's
  *      `crossTaskDeps` list bypass the would-be block and append a
  *      `cross-task-dep-allow` audit row (spec §P0#7b).
@@ -56,6 +70,52 @@ const { appendEnforcementAudit } = require(
 );
 
 const FILE_WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
+
+// GH-528 round-2 ITEM 1: WORK_OPERATOR_TOKEN gate on env-bypass.
+// Centralised so all three bypass call sites stay in lockstep.
+function isOperatorTokenPresent() {
+  return process.env.WORK_OPERATOR_TOKEN === '1';
+}
+
+/**
+ * Append a `scope-bypass-rejected` audit row recording that the env-var pair
+ * matched the write target but WORK_OPERATOR_TOKEN was missing. We log this
+ * regardless of guard so an operator can see every rejected attempt across
+ * the three layers.
+ */
+function auditScopeBypassRejected({
+  ticketId,
+  active,
+  relTarget,
+  bypassReason,
+  bypassTargetCfg,
+  guard,
+}) {
+  try {
+    appendEnforcementAudit(ticketId, {
+      origin: 'ai-subtask',
+      task: active.taskNum,
+      phase: null,
+      action: 'scope-bypass-rejected',
+      allow: false,
+      reason: bypassReason,
+      outputPath: relTarget,
+      meta: {
+        taskNum: active.taskNum,
+        target: relTarget,
+        configuredTarget: bypassTargetCfg,
+        guard,
+        rejectReason: 'WORK_OPERATOR_TOKEN missing',
+      },
+    });
+  } catch (err) {
+    try {
+      logHookError(__filename, err);
+    } catch {
+      /* swallow */
+    }
+  }
+}
 
 // ─── Active-ticket discovery (mirrors enforce-step-workflow.getTicketId) ────
 
@@ -350,6 +410,20 @@ function tryTypeLineBypass(toolName, toolInput, cwd, ticketId, active) {
   if (!bypassReason || !bypassTargetCfg || !rel) return false;
   const matched = rel === bypassTargetCfg || findMatch(rel, [bypassTargetCfg]) !== null;
   if (!matched) return false;
+  // GH-528 ITEM 1: WORK_OPERATOR_TOKEN gate — bypass env pair matched the
+  // write target but the operator token is missing. Treat as unset (block
+  // stays) and audit the rejected attempt.
+  if (!isOperatorTokenPresent()) {
+    auditScopeBypassRejected({
+      ticketId,
+      active,
+      relTarget: rel,
+      bypassReason,
+      bypassTargetCfg,
+      guard: 'type-line',
+    });
+    return false;
+  }
   try {
     appendEnforcementAudit(ticketId, {
       origin: 'ai-subtask',
@@ -515,29 +589,43 @@ async function main() {
       const matched =
         relTarget === bypassTargetCfg || findMatch(relTarget, [bypassTargetCfg]) !== null;
       if (matched) {
-        try {
-          appendEnforcementAudit(ticketId, {
-            origin: 'ai-subtask',
-            task: active.taskNum,
-            phase: null,
-            action: 'scope-bypass',
-            allow: true,
-            reason: bypassReason,
-            outputPath: relTarget,
-            meta: {
-              taskNum: active.taskNum,
-              target: relTarget,
-              configuredTarget: bypassTargetCfg,
-            },
+        // GH-528 ITEM 1: WORK_OPERATOR_TOKEN gate — bypass env pair matched
+        // the write target but the operator token is missing. Treat as unset
+        // (block stays) and audit the rejected attempt.
+        if (!isOperatorTokenPresent()) {
+          auditScopeBypassRejected({
+            ticketId,
+            active,
+            relTarget,
+            bypassReason,
+            bypassTargetCfg,
+            guard: 'files-in-scope',
           });
-        } catch (err) {
+        } else {
           try {
-            logHookError(__filename, err);
-          } catch {
-            /* swallow */
+            appendEnforcementAudit(ticketId, {
+              origin: 'ai-subtask',
+              task: active.taskNum,
+              phase: null,
+              action: 'scope-bypass',
+              allow: true,
+              reason: bypassReason,
+              outputPath: relTarget,
+              meta: {
+                taskNum: active.taskNum,
+                target: relTarget,
+                configuredTarget: bypassTargetCfg,
+              },
+            });
+          } catch (err) {
+            try {
+              logHookError(__filename, err);
+            } catch {
+              /* swallow */
+            }
           }
+          process.exit(0);
         }
-        process.exit(0);
       }
       // REASON+TARGET set but TARGET didn't match — fall through to the
       // block. NO audit row: a mis-targeted bypass is indistinguishable
@@ -605,6 +693,22 @@ function checkPerTypeAllowlist(active, toolName, toolInput, cwd, ticketId) {
     bypassTargetCfg &&
     (relTarget === bypassTargetCfg || findMatch(relTarget, [bypassTargetCfg]) !== null);
   if (bypassMatched) {
+    // GH-528 ITEM 1: WORK_OPERATOR_TOKEN gate — env pair matched but token
+    // missing. Treat as unset (fall through to allowlist decision = block)
+    // and audit the rejected attempt.
+    if (!isOperatorTokenPresent()) {
+      if (ticketId) {
+        auditScopeBypassRejected({
+          ticketId,
+          active,
+          relTarget,
+          bypassReason,
+          bypassTargetCfg,
+          guard: 'type-allowlist',
+        });
+      }
+      return typeAllowlistDecision(active.type, relTarget);
+    }
     // Mirror the scope-bypass audit pattern (see main() around L519 and the
     // type-line guard's tryTypeLineBypass) so a closed-allowlist override is
     // never silent. Discriminator: meta.guard='type-allowlist'.

--- a/plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
+++ b/plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
@@ -347,6 +347,20 @@ function checkWriteTypeLines(toolInput, onDiskTypes) {
  * cannot be applied (old_string not found) — caller treats null as a fall-
  * through (no change simulated, the real tool would error).
  */
+// GH-528 round-2 follow-up note: when an Edit/MultiEdit's `old_string` is
+// not found, applyEditPatch returns null and the caller skips that single
+// patch in the simulation. The real Edit tool errors on missing
+// `old_string` and aborts the whole tool call, so the simulator's "skip
+// and continue" can diverge if a later patch in a MultiEdit was authored
+// against the expected post-first-patch state. In practice the divergence
+// can only ALLOW patches the real tool would reject (the real tool errors
+// before applying anything; the simulator might allow a residual
+// Type-flipping patch through if it happens to apply against the
+// unchanged file). The block-direction risk is the one we care about —
+// the Type-line guard's final equality check still compares the simulated
+// post-state Type lines against on-disk, so a Type flip still gets
+// caught regardless of upstream patch sequencing. Worth a note for
+// future maintainers.
 function applyEditPatch(content, edit) {
   const oldStr = (edit.old_string || '').toString();
   const newStr = (edit.new_string || '').toString();
@@ -473,6 +487,14 @@ function typeLineGuard(toolName, toolInput, workDir, tasksDir) {
   return { blocked: false };
 }
 
+// GH-528 round-2 follow-up note: extracted Type values are normalized to
+// lowercase. typesEqual is a case-sensitive string compare against the
+// already-normalized arrays, so case-only patches (e.g. `tdd-code` →
+// `TDD-Code`) are treated as no-ops. That is intentional — every
+// downstream Type consumer (gateContractFor, lint-type-ac-consistency,
+// readActiveTaskType in tdd-phase-state.js) also lowercases the value
+// before comparing against the closed enum. Blocking case-only edits
+// would create false positives without closing any real bypass.
 function extractTypeLines(md) {
   const out = [];
   const lines = md.split(/\r?\n/);

--- a/plugins/work/skills/split-in-tasks/SKILL.md
+++ b/plugins/work/skills/split-in-tasks/SKILL.md
@@ -15,7 +15,7 @@ Split a technical specification into small, ordered, dependency-aware tasks. Eac
 | Doc | When to consult |
 |---|---|
 | [docs/decomposition-rules.md](./docs/decomposition-rules.md) | Rules 1–12 + anti-patterns for Step 4.1 |
-| [docs/split-warning-passes.md](./docs/split-warning-passes.md) | Pass A / B / C static-analysis warnings emitted after Step 4 |
+| [docs/split-warning-passes.md](./docs/split-warning-passes.md) | Pass A / B / C / D static-analysis warnings emitted after Step 4 |
 | [docs/output-format.md](./docs/output-format.md) | Exact `tasks.md` structure — task formats, file layout, format rules |
 | [docs/test-command.md](./docs/test-command.md) | `### Test Command` block: runner env vars, file-name patterns, scope rules |
 | [docs/scope-sections.md](./docs/scope-sections.md) | `### Files in scope` / `### Files explicitly out of scope` — Gate C + intra-ticket exclusion rule |
@@ -131,7 +131,7 @@ Review all generated tasks and check:
 - Every non-checkpoint implementation task has a `### Test Command` with a real, runnable test command (see [docs/test-command.md](./docs/test-command.md))
 - Gherkin coverage: every scenario from `gherkin.feature` is referenced by at least one task (if `gherkin.feature` exists)
 - Anti-patterns are absent (see anti-pattern blocklist in [docs/decomposition-rules.md](./docs/decomposition-rules.md))
-- Split-Warning Passes (Pass A / Pass B / Pass C — see [docs/split-warning-passes.md](./docs/split-warning-passes.md)) emit no unresolved `SPLIT-WARNING` lines, or each emitted warning has an operator-resolution decision recorded
+- Split-Warning Passes (Pass A / Pass B / Pass C / Pass D — see [docs/split-warning-passes.md](./docs/split-warning-passes.md)) emit no unresolved `SPLIT-WARNING` lines, or each emitted warning has an operator-resolution decision recorded. Pass D is invoked deterministically as `node "${CLAUDE_PLUGIN_ROOT}/plugins/work/skills/split-in-tasks/lib/emit-warnings.js" "${TASKS_DIR}"` and exits non-zero when any kind-D violation is emitted; treat its exit code as a gate alongside Pass A/B/C.
 
 Refactor tasks if any issues are found. Re-validate coverage after any refactoring.
 

--- a/plugins/work/skills/split-in-tasks/SKILL.md
+++ b/plugins/work/skills/split-in-tasks/SKILL.md
@@ -131,7 +131,7 @@ Review all generated tasks and check:
 - Every non-checkpoint implementation task has a `### Test Command` with a real, runnable test command (see [docs/test-command.md](./docs/test-command.md))
 - Gherkin coverage: every scenario from `gherkin.feature` is referenced by at least one task (if `gherkin.feature` exists)
 - Anti-patterns are absent (see anti-pattern blocklist in [docs/decomposition-rules.md](./docs/decomposition-rules.md))
-- Split-Warning Passes (Pass A / Pass B / Pass C / Pass D — see [docs/split-warning-passes.md](./docs/split-warning-passes.md)) emit no unresolved `SPLIT-WARNING` lines, or each emitted warning has an operator-resolution decision recorded. Pass D is invoked deterministically as `node "${CLAUDE_PLUGIN_ROOT}/plugins/work/skills/split-in-tasks/lib/emit-warnings.js" "${TASKS_DIR}"` and exits non-zero when any kind-D violation is emitted; treat its exit code as a gate alongside Pass A/B/C.
+- Split-Warning Passes (Pass A / Pass B / Pass C / Pass D — see [docs/split-warning-passes.md](./docs/split-warning-passes.md)) emit no unresolved `SPLIT-WARNING` lines, or each emitted warning has an operator-resolution decision recorded. Pass D is invoked deterministically as `node "${CLAUDE_PLUGIN_ROOT}/plugins/work/skills/split-in-tasks/lib/emit-warnings.js" "${TASKS_DIR}"` and exits non-zero when any kind-D violation is emitted; treat its exit code as a gate alongside Pass A/B/C. **Severity asymmetry:** Pass A/B/C are advisory (operator resolves inline); Pass D is a hard gate (non-zero exit blocks the commit). See [Severity model](./docs/split-warning-passes.md#severity-model--why-d-is-blocking-and-abc-are-advisory) for the rationale.
 
 Refactor tasks if any issues are found. Re-validate coverage after any refactoring.
 

--- a/plugins/work/skills/split-in-tasks/__tests__/emit-warnings.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/emit-warnings.test.js
@@ -120,10 +120,17 @@ describe('emit-warnings — purity', () => {
     assert.equal(typeof mod.dedupe, 'function');
   });
 
-  it('source contains no console.* or process.exit calls', () => {
+  it('library functions contain no console.* calls (CLI exit is gated to require.main === module)', () => {
     const fs = require('node:fs');
     const src = fs.readFileSync(MODULE_PATH, 'utf-8');
     assert.ok(!/console\.[a-z]+\s*\(/.test(src), 'module must not call console.*');
-    assert.ok(!/process\.exit\s*\(/.test(src), 'module must not call process.exit');
+    // process.exit IS allowed — but only inside the CLI runCli() helper
+    // and only when invoked via the `require.main === module` guard. The
+    // library exports (formatWarnings, dedupe, etc.) remain pure.
+    assert.match(
+      src,
+      /if \(require\.main === module\)/,
+      'process.exit must be guarded by `if (require.main === module)` so library callers stay pure'
+    );
   });
 });

--- a/plugins/work/skills/split-in-tasks/__tests__/lint-type-ac-consistency.integration.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/lint-type-ac-consistency.integration.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const MODULE_PATH = path.resolve(
+  __dirname,
+  '..',
+  'lib',
+  'lint-type-ac-consistency.js',
+);
+
+function buildTaskModel({ type, acLines, taskNumber = 1, file = 'tasks.md' }) {
+  const sectionLines = [
+    `## Task ${taskNumber} — sample`,
+    '',
+    '### Type',
+    type,
+    '',
+    '### Acceptance Criteria',
+    ...acLines.map((line) => `- ${line}`),
+    '',
+  ];
+  return {
+    file,
+    tasks: [
+      {
+        number: taskNumber,
+        section: sectionLines.join('\n'),
+        acceptanceCriteria: acLines,
+      },
+    ],
+  };
+}
+
+describe('split-in-tasks recognises every canonical docs-exemption phrase', () => {
+  const cases = [
+    {
+      name: 'documentation exempt',
+      ac: 'This task is documentation exempt and ships docs only.',
+    },
+    {
+      name: 'docs-only',
+      ac: 'docs-only update; no behaviour change.',
+    },
+    {
+      name: 'no RED/GREEN/REFACTOR cycle required',
+      ac: 'no RED/GREEN/REFACTOR cycle required for this change.',
+    },
+    {
+      name: 'documentation/manifest only',
+      ac: 'documentation/manifest only — no behaviour change.',
+    },
+    {
+      name: 'config-only',
+      ac: 'config-only edit to package.json.',
+    },
+    {
+      name: 'manifest-only',
+      ac: 'manifest-only update of plugin.json.',
+    },
+    {
+      name: 'no testable surface',
+      ac: 'this change has no testable surface.',
+    },
+  ];
+
+  for (const c of cases) {
+    it(`flags Type=wiring + AC "${c.name}" as kind-D SPLIT-WARNING`, () => {
+      const { lintTypeAcConsistency } = require(MODULE_PATH);
+      const model = buildTaskModel({
+        type: 'wiring',
+        acLines: [c.ac],
+        taskNumber: 7,
+        file: 'tasks.md',
+      });
+      const result = lintTypeAcConsistency(model);
+      assert.ok(result, 'expected a warning record, got null/undefined');
+      assert.equal(result.kind, 'D', 'expected kind === "D"');
+      assert.equal(result.file, 'tasks.md');
+      assert.equal(result.hint, 'propose Type: docs');
+      assert.match(
+        result.message,
+        /task\s*7/i,
+        'message should name the task number',
+      );
+      assert.ok(
+        result.message.includes(c.ac) ||
+          result.message.toLowerCase().includes(c.ac.toLowerCase()),
+        'message should include the offending AC line',
+      );
+      assert.match(
+        result.message,
+        /wiring/i,
+        'message should name the declared Type',
+      );
+    });
+  }
+
+  it('returns null on the Type=docs happy path', () => {
+    const { lintTypeAcConsistency } = require(MODULE_PATH);
+    const model = buildTaskModel({
+      type: 'docs',
+      acLines: [
+        'documentation/manifest only — no RED/GREEN/REFACTOR cycle required',
+      ],
+    });
+    const result = lintTypeAcConsistency(model);
+    assert.equal(result, null, 'expected null when Type=docs');
+  });
+});

--- a/plugins/work/skills/split-in-tasks/__tests__/lint-type-ac-consistency.integration.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/lint-type-ac-consistency.integration.test.js
@@ -4,12 +4,7 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
 
-const MODULE_PATH = path.resolve(
-  __dirname,
-  '..',
-  'lib',
-  'lint-type-ac-consistency.js',
-);
+const MODULE_PATH = path.resolve(__dirname, '..', 'lib', 'lint-type-ac-consistency.js');
 
 function buildTaskModel({ type, acLines, taskNumber = 1, file = 'tasks.md' }) {
   const sectionLines = [
@@ -80,21 +75,12 @@ describe('split-in-tasks recognises every canonical docs-exemption phrase', () =
       assert.equal(result.kind, 'D', 'expected kind === "D"');
       assert.equal(result.file, 'tasks.md');
       assert.equal(result.hint, 'propose Type: docs');
-      assert.match(
-        result.message,
-        /task\s*7/i,
-        'message should name the task number',
-      );
+      assert.match(result.message, /task\s*7/i, 'message should name the task number');
       assert.ok(
-        result.message.includes(c.ac) ||
-          result.message.toLowerCase().includes(c.ac.toLowerCase()),
-        'message should include the offending AC line',
+        result.message.includes(c.ac) || result.message.toLowerCase().includes(c.ac.toLowerCase()),
+        'message should include the offending AC line'
       );
-      assert.match(
-        result.message,
-        /wiring/i,
-        'message should name the declared Type',
-      );
+      assert.match(result.message, /wiring/i, 'message should name the declared Type');
     });
   }
 
@@ -102,11 +88,51 @@ describe('split-in-tasks recognises every canonical docs-exemption phrase', () =
     const { lintTypeAcConsistency } = require(MODULE_PATH);
     const model = buildTaskModel({
       type: 'docs',
-      acLines: [
-        'documentation/manifest only — no RED/GREEN/REFACTOR cycle required',
-      ],
+      acLines: ['documentation/manifest only — no RED/GREEN/REFACTOR cycle required'],
     });
     const result = lintTypeAcConsistency(model);
     assert.equal(result, null, 'expected null when Type=docs');
+  });
+});
+
+describe('docs-exemption phrases suppress warnings when Type aligns', () => {
+  const alignedCases = [
+    { type: 'config', ac: 'config-only edit to package.json.' },
+    { type: 'file-move', ac: 'manifest-only update of plugin.json.' },
+    { type: 'config', ac: 'manifest-only update of plugin.json.' },
+    {
+      type: 'file-move',
+      ac: 'no RED/GREEN/REFACTOR cycle required for this change.',
+    },
+    {
+      type: 'mechanical-refactor',
+      ac: 'this change has no testable surface.',
+    },
+    { type: 'ci', ac: 'no RED/GREEN cycle required.' },
+  ];
+
+  for (const c of alignedCases) {
+    it(`suppresses warning for Type=${c.type} + AC "${c.ac}"`, () => {
+      const { lintTypeAcConsistency } = require(MODULE_PATH);
+      const model = buildTaskModel({ type: c.type, acLines: [c.ac] });
+      const result = lintTypeAcConsistency(model);
+      assert.equal(
+        result,
+        null,
+        `expected no warning when Type=${c.type} aligns with exempt phrase`
+      );
+    });
+  }
+
+  it('still warns when Type does not align with the phrase (config-only + Type=file-move)', () => {
+    const { lintTypeAcConsistency } = require(MODULE_PATH);
+    const model = buildTaskModel({
+      type: 'file-move',
+      acLines: ['config-only edit to package.json.'],
+    });
+    const result = lintTypeAcConsistency(model);
+    assert.ok(result, 'expected a warning when Type=file-move + config-only AC');
+    assert.equal(result.kind, 'D');
+    assert.equal(result.hint, 'propose Type: docs');
   });
 });

--- a/plugins/work/skills/split-in-tasks/__tests__/pass-d-cli.integration.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/pass-d-cli.integration.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+/**
+ * Pass D — Spawn-based E2E for the emit-warnings.js CLI.
+ *
+ * SKILL.md Step 5 invokes Pass D via `node emit-warnings.js <ticket-dir>`.
+ * This test spawns that exact CLI (not the lib function) against a fixture
+ * tasks.md where Type=tdd-code but scope is only *.md, asserting:
+ *   - non-zero exit
+ *   - stdout contains `[Pass D]` SPLIT-WARNING
+ *   - a happy fixture exits 0 with no warning lines
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+
+const CLI = path.resolve(__dirname, '..', 'lib', 'emit-warnings.js');
+
+function makeTicketDir(md) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pass-d-cli-'));
+  fs.writeFileSync(path.join(dir, 'tasks.md'), md, 'utf8');
+  return dir;
+}
+
+function runCli(ticketDir) {
+  return spawnSync('node', [CLI, ticketDir], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+}
+
+describe('Pass D — emit-warnings.js CLI E2E', () => {
+  const dirs = [];
+  after(() => {
+    for (const d of dirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch (_) {
+        /* best-effort */
+      }
+    }
+  });
+
+  it('exits non-zero with [Pass D] line when Type=tdd-code but scope is only *.md', () => {
+    const md = [
+      '# Tasks',
+      '',
+      '## Task 1 — sample',
+      '',
+      '### Type',
+      'tdd-code',
+      '',
+      '### Acceptance Criteria',
+      '- Implement the feature',
+      '',
+      '### Files in scope',
+      '- README.md',
+      '',
+    ].join('\n');
+    const dir = makeTicketDir(md);
+    dirs.push(dir);
+    const r = runCli(dir);
+    assert.notEqual(r.status, 0, `expected non-zero; stdout=${r.stdout} stderr=${r.stderr}`);
+    const blob = `${r.stdout}\n${r.stderr}`;
+    assert.match(blob, /\[Pass D\]/);
+    assert.match(blob, /no `\*\.test\.\*`/);
+  });
+
+  it('exits 0 with no warnings on happy tdd-code fixture', () => {
+    const md = [
+      '# Tasks',
+      '',
+      '## Task 1 — sample',
+      '',
+      '### Type',
+      'tdd-code',
+      '',
+      '### Acceptance Criteria',
+      '- Cover the reducer',
+      '',
+      '### Files in scope',
+      '- src/foo.js',
+      '- src/foo.test.js',
+      '',
+    ].join('\n');
+    const dir = makeTicketDir(md);
+    dirs.push(dir);
+    const r = runCli(dir);
+    assert.equal(r.status, 0, `expected 0; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.doesNotMatch(`${r.stdout}\n${r.stderr}`, /\[Pass D\]/);
+  });
+
+  it('exits non-zero with config allowlist warning when Type=config has src/ in scope', () => {
+    const md = [
+      '# Tasks',
+      '',
+      '## Task 1 — config',
+      '',
+      '### Type',
+      'config',
+      '',
+      '### Acceptance Criteria',
+      '- Bump version',
+      '',
+      '### Files in scope',
+      '- package.json',
+      '- src/server.js',
+      '',
+    ].join('\n');
+    const dir = makeTicketDir(md);
+    dirs.push(dir);
+    const r = runCli(dir);
+    assert.notEqual(r.status, 0);
+    assert.match(`${r.stdout}`, /config allowlist/);
+  });
+
+  it('exits 2 when ticket-dir arg is missing', () => {
+    const r = spawnSync('node', [CLI], { encoding: 'utf8' });
+    assert.equal(r.status, 2);
+  });
+});

--- a/plugins/work/skills/split-in-tasks/__tests__/pass-d-type-scope.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/pass-d-type-scope.test.js
@@ -333,6 +333,116 @@ describe('Pass D — lintTypeAcConsistency backward compat', () => {
   });
 });
 
+// GH-528 round-2 follow-up ITEM 4: tune acForbidNewBehavior regex.
+//
+// Strategy (a): NEW_BEHAVIOR_PATTERNS now only checks the first AC bullet
+// (the summary line). Supporting bullets can legitimately use low-level
+// verbs like "implement"/"fix" — e.g. mechanical-refactor describing
+// "implement the rename across N import paths".
+//
+// Boundary cases:
+//   - First bullet describes the task's purpose → patterns fire (warn).
+//   - Supporting bullets use refactor-safe phrasings → patterns DO NOT fire.
+describe('Pass D — acForbidNewBehavior scoped to summary line (ITEM 4)', () => {
+  it('TRUE positive: first AC bullet says "implement the new /users endpoint" → warns (tests-only)', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tests-only',
+        scope: ['src/foo.test.js'],
+        acLines: ['implement the new /users endpoint', 'verify status codes'],
+      })
+    );
+    assert.ok(
+      ws.some((w) => /new behavior/.test(w.message)),
+      `expected new-behavior warning; got ${JSON.stringify(ws)}`
+    );
+  });
+
+  it('TRUE positive: first AC bullet says "add a feature flag for X" → warns (docs)', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'docs',
+        scope: ['README.md'],
+        acLines: ['add a feature flag for X', 'document toggle'],
+      })
+    );
+    assert.ok(
+      ws.some((w) => /promises behavior change/.test(w.message)),
+      `expected behavior-change warning; got ${JSON.stringify(ws)}`
+    );
+  });
+
+  it('TRUE positive: first AC bullet says "fix the auth-token expiry bug" → warns (tests-only)', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tests-only',
+        scope: ['src/auth.test.js'],
+        acLines: ['fix the auth-token expiry bug', 'add coverage'],
+      })
+    );
+    assert.ok(
+      ws.some((w) => /new behavior/.test(w.message)),
+      `expected new-behavior warning; got ${JSON.stringify(ws)}`
+    );
+  });
+
+  it('FALSE positive STOPS: supporting bullet says "implement the rename across 18 import paths" (mechanical-refactor)', () => {
+    // First bullet (the summary) is refactor-safe; "implement" appears only
+    // in a supporting bullet, which is now ignored by the regex.
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'mechanical-refactor',
+        scope: ['src/foo.js', 'src/bar.js'],
+        acLines: [
+          'rename `oldName` to `newName` codebase-wide',
+          'implement the rename across 18 import paths',
+        ],
+      })
+    );
+    assert.equal(
+      ws.filter((w) => /new behavior|behavior change/.test(w.message)).length,
+      0,
+      `mechanical-refactor supporting bullet should NOT warn; got ${JSON.stringify(ws)}`
+    );
+  });
+
+  it('FALSE positive STOPS: supporting bullet says "fix the import paths in callers after the move" (file-move)', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'file-move',
+        scope: ['src/old/foo.js', 'src/new/foo.js'],
+        acLines: [
+          'move `src/old/foo.js` to `src/new/foo.js`',
+          'fix the import paths in callers after the move',
+        ],
+      })
+    );
+    assert.equal(
+      ws.filter((w) => /new behavior|behavior change/.test(w.message)).length,
+      0,
+      `file-move supporting bullet should NOT warn; got ${JSON.stringify(ws)}`
+    );
+  });
+
+  it('FALSE positive STOPS: tests-only with summary "add coverage for the existing X behavior"', () => {
+    // "add" alone is not in NEW_BEHAVIOR_PATTERNS (the pattern is
+    // `add (a/new) (feature|endpoint|api|capability)`); verify this stays
+    // true and the summary line is refactor-safe.
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tests-only',
+        scope: ['src/foo.test.js'],
+        acLines: ['add coverage for the existing X behavior', 'cover undefined-input branch'],
+      })
+    );
+    assert.equal(
+      ws.filter((w) => /new behavior/.test(w.message)).length,
+      0,
+      `existing-behavior wording should NOT warn; got ${JSON.stringify(ws)}`
+    );
+  });
+});
+
 describe('Pass D — parseFilesInScope helper', () => {
   it('reads bulleted scope entries, strips backticks and trailing comments', () => {
     const section = [

--- a/plugins/work/skills/split-in-tasks/__tests__/pass-d-type-scope.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/pass-d-type-scope.test.js
@@ -1,0 +1,293 @@
+'use strict';
+
+/**
+ * Pass D — Type/AC/Scope Consistency unit tests.
+ *
+ * Each violation = one kind-D warning. These tests cover every per-Type
+ * branch added in GH-528 follow-up (item 2):
+ *   - tdd-code: scope must include ≥1 test file AND ≥1 source file
+ *   - tests-only: scope must contain ONLY *.test.* / *.spec.*; AC must not
+ *     describe new behavior
+ *   - docs: scope must be ONLY *.md; AC must not promise behavior changes
+ *   - config: scope must match the config allowlist in task-types.js
+ *   - ci: scope must match .github/** etc.
+ *   - unknown Type: warns
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  lintAllPassD,
+  lintTypeAcConsistency,
+  parseFilesInScope,
+} = require('../lib/lint-type-ac-consistency');
+
+function buildModel({ type, acLines = [], scope = [], number = 1, file = 'tasks.md' }) {
+  const lines = [
+    `## Task ${number} — sample`,
+    '',
+    '### Type',
+    type,
+    '',
+    '### Acceptance Criteria',
+    ...acLines.map((l) => `- ${l}`),
+    '',
+    '### Files in scope',
+    ...scope.map((s) => `- ${s}`),
+    '',
+  ];
+  return {
+    file,
+    tasks: [
+      {
+        number,
+        section: lines.join('\n'),
+        acceptanceCriteria: acLines,
+      },
+    ],
+  };
+}
+
+describe('Pass D — tdd-code contract', () => {
+  it('warns when scope has no test file', () => {
+    const ws = lintAllPassD(
+      buildModel({ type: 'tdd-code', scope: ['src/foo.js'], acLines: ['Behavior X'] })
+    );
+    const messages = ws.map((w) => w.message).join('\n');
+    assert.match(messages, /no `\*\.test\.\*`/);
+  });
+
+  it('warns when scope has no source file', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tdd-code',
+        scope: ['src/foo.test.js'],
+        acLines: ['Behavior X'],
+      })
+    );
+    const messages = ws.map((w) => w.message).join('\n');
+    assert.match(messages, /no non-test source file/);
+  });
+
+  it('happy path — both test + source in scope', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tdd-code',
+        scope: ['src/foo.js', 'src/foo.test.js'],
+        acLines: ['Behavior X'],
+      })
+    );
+    assert.equal(ws.length, 0, `expected zero warnings, got: ${JSON.stringify(ws)}`);
+  });
+});
+
+describe('Pass D — tests-only contract', () => {
+  it('warns when scope is empty', () => {
+    const ws = lintAllPassD(
+      buildModel({ type: 'tests-only', scope: [], acLines: ['cover existing behavior'] })
+    );
+    assert.ok(
+      ws.some((w) => /Files in scope` is empty/.test(w.message)),
+      `expected empty-scope warning; got ${JSON.stringify(ws)}`
+    );
+  });
+
+  it('warns when scope includes source files', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tests-only',
+        scope: ['src/foo.test.js', 'src/foo.js'],
+        acLines: ['cover existing behavior'],
+      })
+    );
+    assert.ok(ws.some((w) => /non-test file/.test(w.message)));
+  });
+
+  it('warns when AC describes new behavior', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tests-only',
+        scope: ['src/foo.test.js'],
+        acLines: ['implement feature X'],
+      })
+    );
+    assert.ok(ws.some((w) => /new behavior/.test(w.message)));
+  });
+
+  it('happy path — only test file + existing-behavior AC', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tests-only',
+        scope: ['src/foo.test.js'],
+        acLines: ['cover existing reducer branch on undefined input'],
+      })
+    );
+    assert.equal(ws.length, 0, `expected zero warnings; got ${JSON.stringify(ws)}`);
+  });
+});
+
+describe('Pass D — docs contract', () => {
+  it('warns when scope includes non-.md files', () => {
+    const ws = lintAllPassD(
+      buildModel({ type: 'docs', scope: ['README.md', 'src/foo.js'], acLines: ['update README'] })
+    );
+    assert.ok(ws.some((w) => /non-`\.md`/.test(w.message)));
+  });
+
+  it('warns when AC promises new behavior', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'docs',
+        scope: ['README.md'],
+        acLines: ['implement new endpoint'],
+      })
+    );
+    assert.ok(ws.some((w) => /promises behavior change/.test(w.message)));
+  });
+
+  it('happy path — only .md + doc AC', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'docs',
+        scope: ['README.md'],
+        acLines: ['document the migration steps'],
+      })
+    );
+    assert.equal(ws.length, 0, `expected zero warnings; got ${JSON.stringify(ws)}`);
+  });
+});
+
+describe('Pass D — config allowlist', () => {
+  it('happy path — package.json / tsconfig.json in scope', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'config',
+        scope: ['package.json', 'tsconfig.json', '.eslintrc.json'],
+        acLines: ['bump strict to true'],
+      })
+    );
+    assert.equal(ws.length, 0, `expected zero warnings; got ${JSON.stringify(ws)}`);
+  });
+
+  it('warns when scope includes runtime source', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'config',
+        scope: ['package.json', 'src/server.js'],
+        acLines: ['bump version'],
+      })
+    );
+    assert.ok(
+      ws.some((w) => /outside the config allowlist/.test(w.message)),
+      `expected allowlist warning; got ${JSON.stringify(ws)}`
+    );
+  });
+});
+
+describe('Pass D — ci allowlist', () => {
+  it('happy path — .github/workflows/*', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'ci',
+        scope: ['.github/workflows/ci.yml'],
+        acLines: ['add quality job'],
+      })
+    );
+    assert.equal(ws.length, 0, `expected zero warnings; got ${JSON.stringify(ws)}`);
+  });
+
+  it('warns when scope includes src/', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'ci',
+        scope: ['.github/workflows/ci.yml', 'src/server.js'],
+        acLines: ['add CI job'],
+      })
+    );
+    assert.ok(ws.some((w) => /outside the ci allowlist/.test(w.message)));
+  });
+});
+
+describe('Pass D — unknown Type', () => {
+  it('warns on Type=wiring (not in closed taxonomy)', () => {
+    const ws = lintAllPassD(
+      buildModel({ type: 'wiring', scope: ['src/a.js'], acLines: ['do stuff'] })
+    );
+    assert.ok(
+      ws.some((w) => /closed taxonomy/.test(w.message)),
+      `expected unknown-Type warning; got ${JSON.stringify(ws)}`
+    );
+  });
+
+  it('does not warn on tdd-code (known)', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tdd-code',
+        scope: ['src/a.js', 'src/a.test.js'],
+        acLines: ['cover'],
+      })
+    );
+    const unknown = ws.filter((w) => /closed taxonomy/.test(w.message));
+    assert.equal(unknown.length, 0);
+  });
+});
+
+describe('Pass D — docs-exemption phrase retained', () => {
+  it('Type=tdd-code with docs-exemption AC still warns "propose Type: docs"', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tdd-code',
+        scope: ['src/a.js', 'src/a.test.js'],
+        acLines: ['docs-only update'],
+      })
+    );
+    assert.ok(
+      ws.some((w) => w.hint === 'propose Type: docs'),
+      `expected docs-exemption warning; got ${JSON.stringify(ws)}`
+    );
+  });
+});
+
+describe('Pass D — lintTypeAcConsistency backward compat', () => {
+  it('still returns a single warning for legacy callers', () => {
+    const w = lintTypeAcConsistency(
+      buildModel({
+        type: 'wiring',
+        scope: ['src/a.js'],
+        acLines: ['documentation/manifest only'],
+      })
+    );
+    assert.ok(w);
+    assert.equal(w.kind, 'D');
+    assert.equal(w.hint, 'propose Type: docs');
+  });
+
+  it('returns null when no warnings', () => {
+    const w = lintTypeAcConsistency(
+      buildModel({
+        type: 'tdd-code',
+        scope: ['src/a.js', 'src/a.test.js'],
+        acLines: ['cover behavior'],
+      })
+    );
+    assert.equal(w, null);
+  });
+});
+
+describe('Pass D — parseFilesInScope helper', () => {
+  it('reads bulleted scope entries, strips backticks and trailing comments', () => {
+    const section = [
+      '## Task 1',
+      '',
+      '### Files in scope',
+      '- `src/foo.js`',
+      '- src/bar.js  # owned by Task 1',
+      '- src/baz.js',
+      '',
+      '### Files explicitly out of scope',
+      '- src/other.js',
+    ].join('\n');
+    const out = parseFilesInScope(section);
+    assert.deepEqual(out, ['src/foo.js', 'src/bar.js', 'src/baz.js']);
+  });
+});

--- a/plugins/work/skills/split-in-tasks/__tests__/pass-d-type-scope.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/pass-d-type-scope.test.js
@@ -124,6 +124,65 @@ describe('Pass D — tests-only contract', () => {
     );
     assert.equal(ws.length, 0, `expected zero warnings; got ${JSON.stringify(ws)}`);
   });
+
+  // GH-528 cursor[bot] follow-up: Pass D must use the same scope classifier
+  // as the implement-time gate (scopeEntryAdmitsOnlyTestFiles). Globs whose
+  // basename constrains to test files (e.g. `src/**\/*.test.js`) admit ONLY
+  // test files and must NOT trigger the non-test-file warning at plan time —
+  // otherwise valid tasks fail Step 5 while implementation would accept them.
+  it('does not warn on a test-constrained glob scope (src/**/*.test.js)', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tests-only',
+        scope: ['src/**/*.test.js'],
+        acLines: ['cover existing branch'],
+      })
+    );
+    const offenders = ws.filter((w) => /non-test file/.test(w.message));
+    assert.equal(
+      offenders.length,
+      0,
+      `expected no non-test-file warning for glob scope; got ${JSON.stringify(offenders)}`
+    );
+  });
+
+  it('does not warn on **/*.spec.ts glob', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tests-only',
+        scope: ['**/*.spec.ts'],
+        acLines: ['cover existing branch'],
+      })
+    );
+    const offenders = ws.filter((w) => /non-test file/.test(w.message));
+    assert.equal(offenders.length, 0, `got ${JSON.stringify(offenders)}`);
+  });
+
+  it('does not warn on nested test glob (src/foo/**/*.test.js)', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tests-only',
+        scope: ['src/foo/**/*.test.js'],
+        acLines: ['cover existing branch'],
+      })
+    );
+    const offenders = ws.filter((w) => /non-test file/.test(w.message));
+    assert.equal(offenders.length, 0, `got ${JSON.stringify(offenders)}`);
+  });
+
+  it('STILL warns on open-ended glob that admits non-tests (src/**)', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tests-only',
+        scope: ['src/**'],
+        acLines: ['cover existing branch'],
+      })
+    );
+    assert.ok(
+      ws.some((w) => /non-test file/.test(w.message)),
+      `expected non-test-file warning for open-ended glob; got ${JSON.stringify(ws)}`
+    );
+  });
 });
 
 describe('Pass D — docs contract', () => {

--- a/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-type-ac.integration.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-type-ac.integration.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+/**
+ * split-in-tasks-type-ac integration — wires lintTypeAcConsistency into
+ * emit-warnings.js aggregation pipeline.
+ *
+ * Spawn-based end-to-end test (mirrors split-in-tasks-warnings.test.js
+ * pattern, using child_process.spawn + fs.mkdtempSync). Verifies:
+ *
+ *   (a) Mismatched fixture (Type=wiring + docs-exemption AC) causes the
+ *       skill aggregation to exit non-zero AND stdout/stderr contains
+ *       both the offending AC line substring and the hint
+ *       `propose Type: docs`.
+ *   (b) Same fixture with Type=docs exits zero AND emits no kind-`D`
+ *       SPLIT-WARNING.
+ *
+ * The aggregation entry-point under test is `emit-warnings.js` invoked as
+ * a CLI against a ticket directory containing tasks.md. RED-phase: that
+ * entry-point does not yet require lint-type-ac-consistency.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+
+const EMIT_WARNINGS = path.resolve(
+  __dirname,
+  '..',
+  'lib',
+  'emit-warnings.js',
+);
+
+// The skill's library is intentionally pure (no console.* / process.exit),
+// so the integration test spawns a tiny driver that requires
+// emit-warnings.js, prints aggregated kind-D warnings, and exits non-zero
+// when any are produced. This mirrors how the operator-facing split-in-tasks
+// flow surfaces warnings.
+const DRIVER = `
+const { aggregateTypeAcWarnings, formatWarnings } = require(${JSON.stringify(EMIT_WARNINGS)});
+const ticketDir = process.argv[process.argv.length - 1];
+const warnings = aggregateTypeAcWarnings(ticketDir);
+if (warnings.length > 0) {
+  process.stdout.write(formatWarnings(warnings) + '\\n');
+  process.exit(1);
+}
+process.exit(0);
+`;
+
+const DOCS_EXEMPTION_AC =
+  'documentation/manifest only — no RED/GREEN/REFACTOR cycle required';
+
+function buildTasksMd({ type }) {
+  return [
+    '# Tasks',
+    '',
+    '## Task 1 — sample wiring task',
+    '',
+    '### Type',
+    type,
+    '',
+    '### Description',
+    'A task whose AC declares docs-exemption.',
+    '',
+    '### Acceptance Criteria',
+    `- ${DOCS_EXEMPTION_AC}`,
+    '- Module B re-exports A.',
+    '',
+    '### Files in scope',
+    '- src/b.js',
+    '',
+  ].join('\n');
+}
+
+function makeTicketDir({ type }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'split-type-ac-'));
+  fs.writeFileSync(path.join(dir, 'tasks.md'), buildTasksMd({ type }), 'utf8');
+  return dir;
+}
+
+function runEmitWarnings(ticketDir) {
+  return spawnSync('node', ['-e', DRIVER, '--', ticketDir], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+}
+
+describe('split-in-tasks aggregation — Type/AC consistency (kind D)', () => {
+  const dirs = [];
+  after(() => {
+    for (const d of dirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch (_) {
+        /* best-effort cleanup */
+      }
+    }
+  });
+
+  it('split-in-tasks rejects Type=wiring on an AC declaring docs-exemption', () => {
+    const ticketDir = makeTicketDir({ type: 'wiring' });
+    dirs.push(ticketDir);
+
+    const result = runEmitWarnings(ticketDir);
+
+    assert.notEqual(
+      result.status,
+      0,
+      `expected emit-warnings to exit non-zero on mismatched fixture; got status=${result.status} stdout=${result.stdout} stderr=${result.stderr}`,
+    );
+    const blob = `${result.stdout || ''}\n${result.stderr || ''}`;
+    assert.match(
+      blob,
+      /documentation\/manifest only/i,
+      `expected offending AC line substring in output; got: ${blob}`,
+    );
+    assert.match(
+      blob,
+      /propose Type:\s*docs/i,
+      `expected hint 'propose Type: docs' in output; got: ${blob}`,
+    );
+    assert.match(
+      blob,
+      /\bTask\s*1\b/,
+      `expected task number reference in output; got: ${blob}`,
+    );
+  });
+
+  it('split-in-tasks accepts Type=docs on the same AC', () => {
+    const ticketDir = makeTicketDir({ type: 'docs' });
+    dirs.push(ticketDir);
+
+    const result = runEmitWarnings(ticketDir);
+
+    assert.equal(
+      result.status,
+      0,
+      `expected emit-warnings to exit 0 on docs fixture; got status=${result.status} stdout=${result.stdout} stderr=${result.stderr}`,
+    );
+    const blob = `${result.stdout || ''}\n${result.stderr || ''}`;
+    assert.doesNotMatch(
+      blob,
+      /propose Type:\s*docs/i,
+      `expected no kind-D 'propose Type: docs' hint on happy-path; got: ${blob}`,
+    );
+    assert.doesNotMatch(
+      blob,
+      /\[Pass D\]/,
+      `expected no '[Pass D]' marker on happy-path; got: ${blob}`,
+    );
+  });
+});

--- a/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-type-ac.integration.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-type-ac.integration.test.js
@@ -19,7 +19,7 @@
  * entry-point does not yet require lint-type-ac-consistency.
  */
 
-const { describe, it, before, after } = require('node:test');
+const { describe, it, after } = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
 const fs = require('node:fs');

--- a/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-type-ac.integration.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-type-ac.integration.test.js
@@ -26,12 +26,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const { spawnSync } = require('node:child_process');
 
-const EMIT_WARNINGS = path.resolve(
-  __dirname,
-  '..',
-  'lib',
-  'emit-warnings.js',
-);
+const EMIT_WARNINGS = path.resolve(__dirname, '..', 'lib', 'emit-warnings.js');
 
 // The skill's library is intentionally pure (no console.* / process.exit),
 // so the integration test spawns a tiny driver that requires
@@ -49,10 +44,14 @@ if (warnings.length > 0) {
 process.exit(0);
 `;
 
-const DOCS_EXEMPTION_AC =
-  'documentation/manifest only — no RED/GREEN/REFACTOR cycle required';
+const DOCS_EXEMPTION_AC = 'documentation/manifest only — no RED/GREEN/REFACTOR cycle required';
 
 function buildTasksMd({ type }) {
+  // Scope choice depends on Type — Pass D now enforces per-Type scope
+  // allowlists. For Type=docs the scope must consist of *.md files; for
+  // any other Type, src/b.js is a non-test source entry that satisfies
+  // the docs-exemption Type-mismatch check we care about here.
+  const scopeEntries = type === 'docs' ? ['- README.md'] : ['- src/b.js'];
   return [
     '# Tasks',
     '',
@@ -69,7 +68,7 @@ function buildTasksMd({ type }) {
     '- Module B re-exports A.',
     '',
     '### Files in scope',
-    '- src/b.js',
+    ...scopeEntries,
     '',
   ].join('\n');
 }
@@ -108,24 +107,20 @@ describe('split-in-tasks aggregation — Type/AC consistency (kind D)', () => {
     assert.notEqual(
       result.status,
       0,
-      `expected emit-warnings to exit non-zero on mismatched fixture; got status=${result.status} stdout=${result.stdout} stderr=${result.stderr}`,
+      `expected emit-warnings to exit non-zero on mismatched fixture; got status=${result.status} stdout=${result.stdout} stderr=${result.stderr}`
     );
     const blob = `${result.stdout || ''}\n${result.stderr || ''}`;
     assert.match(
       blob,
       /documentation\/manifest only/i,
-      `expected offending AC line substring in output; got: ${blob}`,
+      `expected offending AC line substring in output; got: ${blob}`
     );
     assert.match(
       blob,
       /propose Type:\s*docs/i,
-      `expected hint 'propose Type: docs' in output; got: ${blob}`,
+      `expected hint 'propose Type: docs' in output; got: ${blob}`
     );
-    assert.match(
-      blob,
-      /\bTask\s*1\b/,
-      `expected task number reference in output; got: ${blob}`,
-    );
+    assert.match(blob, /\bTask\s*1\b/, `expected task number reference in output; got: ${blob}`);
   });
 
   it('split-in-tasks accepts Type=docs on the same AC', () => {
@@ -137,18 +132,18 @@ describe('split-in-tasks aggregation — Type/AC consistency (kind D)', () => {
     assert.equal(
       result.status,
       0,
-      `expected emit-warnings to exit 0 on docs fixture; got status=${result.status} stdout=${result.stdout} stderr=${result.stderr}`,
+      `expected emit-warnings to exit 0 on docs fixture; got status=${result.status} stdout=${result.stdout} stderr=${result.stderr}`
     );
     const blob = `${result.stdout || ''}\n${result.stderr || ''}`;
     assert.doesNotMatch(
       blob,
       /propose Type:\s*docs/i,
-      `expected no kind-D 'propose Type: docs' hint on happy-path; got: ${blob}`,
+      `expected no kind-D 'propose Type: docs' hint on happy-path; got: ${blob}`
     );
     assert.doesNotMatch(
       blob,
       /\[Pass D\]/,
-      `expected no '[Pass D]' marker on happy-path; got: ${blob}`,
+      `expected no '[Pass D]' marker on happy-path; got: ${blob}`
     );
   });
 });

--- a/plugins/work/skills/split-in-tasks/__tests__/task-types.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/task-types.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  TASK_TYPES,
+  TDD_REQUIRED_TYPES,
+  TDD_EXEMPT_TYPES,
+  isTddRequired,
+  isTddExempt,
+  isKnownTaskType,
+  allTaskTypes,
+  gateContractFor,
+} = require('../lib/task-types');
+
+test('TASK_TYPES is frozen', () => {
+  assert.equal(Object.isFrozen(TASK_TYPES), true);
+});
+
+test('TDD-required vs exempt partition is complete and disjoint', () => {
+  const all = new Set(allTaskTypes());
+  const req = new Set(TDD_REQUIRED_TYPES);
+  const ex = new Set(TDD_EXEMPT_TYPES);
+  // partition: union == all, intersection empty
+  for (const t of req) assert.equal(all.has(t), true, `required type ${t} missing from all`);
+  for (const t of ex) assert.equal(all.has(t), true, `exempt type ${t} missing from all`);
+  for (const t of req) assert.equal(ex.has(t), false, `${t} appears in both`);
+  assert.equal(req.size + ex.size, all.size, 'partition mismatch');
+});
+
+test('tdd-code is required; docs/tests-only/config/ci/etc are exempt', () => {
+  assert.equal(isTddRequired('tdd-code'), true);
+  assert.equal(isTddRequired('docs'), false);
+  assert.equal(isTddExempt('docs'), true);
+  assert.equal(isTddExempt('tests-only'), true);
+  assert.equal(isTddExempt('config'), true);
+  assert.equal(isTddExempt('ci'), true);
+  assert.equal(isTddExempt('mechanical-refactor'), true);
+  assert.equal(isTddExempt('file-move'), true);
+  assert.equal(isTddExempt('checkpoint'), true);
+});
+
+test('unknown types are neither required nor exempt; isKnownTaskType=false', () => {
+  assert.equal(isKnownTaskType('wiring'), false);
+  assert.equal(isKnownTaskType('feature'), false);
+  assert.equal(isTddRequired('wiring'), false);
+  assert.equal(isTddExempt('wiring'), false);
+});
+
+test('case-insensitive / whitespace-tolerant', () => {
+  assert.equal(isKnownTaskType('TDD-CODE'), true);
+  assert.equal(isKnownTaskType('  docs  '), true);
+  assert.equal(isTddExempt('Docs'), true);
+});
+
+test('gateContractFor returns per-Type contract shape', () => {
+  const code = gateContractFor('tdd-code');
+  assert.equal(code.kind, 'tdd-code');
+  assert.equal(code.redRequiresTestFiles, true);
+  assert.equal(code.rcdEmptyTrap, true);
+
+  const docs = gateContractFor('docs');
+  assert.equal(docs.kind, 'docs');
+  assert.equal(docs.redRequiresTestFiles, false);
+  assert.equal(docs.rcdEmptyTrap, false);
+
+  const testsOnly = gateContractFor('tests-only');
+  assert.equal(testsOnly.kind, 'tests-only');
+  assert.equal(testsOnly.redRequiresTestFiles, false);
+  assert.equal(testsOnly.rcdEmptyTrap, true);
+
+  const ci = gateContractFor('ci');
+  assert.equal(ci.rcdEmptyTrap, false);
+
+  const cfg = gateContractFor('config');
+  assert.equal(cfg.rcdEmptyTrap, false);
+});
+
+test('gateContractFor on unknown type defaults to tdd-code (strict)', () => {
+  const unk = gateContractFor('wiring');
+  assert.equal(unk.kind, 'tdd-code');
+  assert.equal(unk.redRequiresTestFiles, true);
+  assert.equal(unk.rcdEmptyTrap, true);
+});

--- a/plugins/work/skills/split-in-tasks/docs/decomposition-rules.md
+++ b/plugins/work/skills/split-in-tasks/docs/decomposition-rules.md
@@ -87,6 +87,18 @@ This is the **ECHO-4453-class wedge**. To avoid it:
 - TDD-required: `tdd-code` (the only Type that runs the full RED→GREEN→REFACTOR cycle)
 - TDD-exempt: `tests-only`, `docs`, `config`, `ci`, `mechanical-refactor`, `file-move`, `checkpoint`
 
+**Build configs are NOT `Type: config`.** The `config` allowlist covers inert configuration (package.json, lockfiles, linter/formatter configs); it intentionally excludes build configs because they ship runtime behavior. Use `Type: tdd-code` (TDD-required) for:
+
+- `vite.config.{ts,js,mjs,cjs}`
+- `rollup.config.{ts,js,mjs,cjs}`
+- `webpack.config.{ts,js,mjs,cjs}`
+- `jest.config.{ts,js,mjs,cjs}`
+- `vitest.config.{ts,js,mjs,cjs}`
+- `next.config.{ts,js,mjs,cjs}`
+- `astro.config.{ts,js,mjs,cjs}`
+
+See [output-format.md "Common migration gotchas"](./output-format.md#common-migration-gotchas--build-configs-are-not-type-config) for the full rationale.
+
 For exempt tasks, use a non-phase deliverables list that describes the concrete verifiable work in execution order, for example: `- Update config`, `- Validate config`, `- Document rollout/usage` as applicable. The implement-time gate maps each Type to a specific contract via `gateContractFor()` — `tests-only` for example uses `record-skip-red` for RED and requires an in-scope test-file modification at GREEN; `docs` accepts silent verifiers via the RC-D relaxation. **Storybook stories-only tasks** are detected by scope shape (every entry matches `*.stories.[jt]sx?`) and use the visual-only gate path.
 
 For stories-only tasks, scope shape alone signals the exemption to the implement-gate: when every entry in `### Files in scope` matches `*.stories.[jt]sx?`, `task-next.js`'s `isVisualOnlyTask()` accepts the verification command (typically `pnpm dev:check`) as RED evidence — no `*.test.*` authorship file is required. Use a `### Test Command` of `pnpm dev:check` (lint + typecheck) and document the visual artifact in deliverables. Do NOT mix story files with `.test.*`/`.spec.*` or production source in the same task's scope, or the exemption will not fire.

--- a/plugins/work/skills/split-in-tasks/docs/decomposition-rules.md
+++ b/plugins/work/skills/split-in-tasks/docs/decomposition-rules.md
@@ -82,16 +82,22 @@ This is the **ECHO-4453-class wedge**. To avoid it:
 ## Task 2 — GREEN: edit get.ts
 ```
 
-Checkpoint tasks, config-only infrastructure tasks, and **Storybook stories-only tasks** are exempt from the RED/GREEN/REFACTOR deliverables requirement. For those exempt tasks, use a non-phase deliverables list that describes the concrete verifiable work in execution order, for example: `- Update config`, `- Validate config`, `- Document rollout/usage` as applicable.
+**TDD-exempt Types** are exempt from the RED/GREEN/REFACTOR deliverables requirement. Per the closed taxonomy in [`lib/task-types.js`](../lib/task-types.js), TDD-required vs exempt partitions as:
+
+- TDD-required: `tdd-code` (the only Type that runs the full RED→GREEN→REFACTOR cycle)
+- TDD-exempt: `tests-only`, `docs`, `config`, `ci`, `mechanical-refactor`, `file-move`, `checkpoint`
+
+For exempt tasks, use a non-phase deliverables list that describes the concrete verifiable work in execution order, for example: `- Update config`, `- Validate config`, `- Document rollout/usage` as applicable. The implement-time gate maps each Type to a specific contract via `gateContractFor()` — `tests-only` for example uses `record-skip-red` for RED and requires an in-scope test-file modification at GREEN; `docs` accepts silent verifiers via the RC-D relaxation. **Storybook stories-only tasks** are detected by scope shape (every entry matches `*.stories.[jt]sx?`) and use the visual-only gate path.
 
 For stories-only tasks, scope shape alone signals the exemption to the implement-gate: when every entry in `### Files in scope` matches `*.stories.[jt]sx?`, `task-next.js`'s `isVisualOnlyTask()` accepts the verification command (typically `pnpm dev:check`) as RED evidence — no `*.test.*` authorship file is required. Use a `### Test Command` of `pnpm dev:check` (lint + typecheck) and document the visual artifact in deliverables. Do NOT mix story files with `.test.*`/`.spec.*` or production source in the same task's scope, or the exemption will not fire.
 
 **Rule 11 — Documentation Task:**
-If the spec references user-facing behavior changes, API changes, configuration changes, or existing `.md` documentation files are related to the changes, add a task of type `checkpoint` titled "Documentation Review" that verifies:
+If the spec references user-facing behavior changes, API changes, configuration changes, or existing `.md` documentation files are related to the changes, add a task of `### Type: docs` titled "Documentation Review" that verifies:
 - Affected `.md` files are updated (README, architecture docs, API docs)
 - New features are documented if user-facing
 - Configuration changes are documented
-This task is checkpoint type (auto-TDD-exception) and should be the second-to-last task (before the final verification checkpoint).
+
+This task uses `Type: docs` (the dedicated documentation contract in the closed taxonomy — see [`lib/task-types.js`](../lib/task-types.js)). It should be the second-to-last task (before the final verification checkpoint). The previous guidance to misuse `Type: checkpoint` for documentation is obsolete: docs tasks have their own scope-allowlist (`.md` only) and gate contract (silent verifiers accepted via the RC-D relaxation), so they get proper enforcement without piggybacking on the checkpoint exception.
 
 **Rule 12 — Shared-Resource Detection (MANDATORY for parallel tasks):**
 After marking tasks as `Parallel: Yes`, scan ALL parallel tasks' Suggested Scope for **overlapping production files**. If two or more parallel tasks modify the **same production file** (not test files — those don't conflict):

--- a/plugins/work/skills/split-in-tasks/docs/output-format.md
+++ b/plugins/work/skills/split-in-tasks/docs/output-format.md
@@ -76,6 +76,22 @@ The closed enum is defined in [`lib/task-types.js`](../lib/task-types.js). Addin
 ---
 ```
 
+## Common migration gotchas — build configs are NOT `Type: config`
+
+`Type: config` is reserved for inert configuration (package.json, lockfiles, linter/formatter configs, `.editorconfig`, etc. — see `TYPE_SCOPE_RULES.config.scopePatterns` in [`../lib/task-types.js`](../lib/task-types.js) for the full allowlist). Build configs are deliberately excluded because they ship runtime behavior — a vite plugin, a webpack loader, or a jest setup file directly affects what runs in production or test.
+
+When migrating an in-flight `tasks.md` to the closed Type taxonomy, the following files should use **`Type: tdd-code`**, not `Type: config`:
+
+- `vite.config.{ts,js,mjs,cjs}`
+- `rollup.config.{ts,js,mjs,cjs}`
+- `webpack.config.{ts,js,mjs,cjs}`
+- `jest.config.{ts,js,mjs,cjs}`
+- `vitest.config.{ts,js,mjs,cjs}`
+- `next.config.{ts,js,mjs,cjs}`
+- `astro.config.{ts,js,mjs,cjs}`
+
+These ship runtime behavior, so they need the full RED → GREEN → REFACTOR TDD cycle. Pass D will warn (`config allowlist`) if you list one under `Type: config`; the per-Type write guard in [`protect-task-scope.js`](../../../scripts/workflows/work/hooks/protect-task-scope.js) will then block the edit at implement time.
+
 ## Task format (checkpoint tasks)
 
 ```markdown

--- a/plugins/work/skills/split-in-tasks/docs/output-format.md
+++ b/plugins/work/skills/split-in-tasks/docs/output-format.md
@@ -17,7 +17,18 @@ All deliverables start with `[ ]`. The workflow engine updates them automaticall
 ## Task N — <title>
 
 ### Type
-<infrastructure | backend | frontend | integration | test | checkpoint>
+<one of the closed enum: tdd-code | tests-only | docs | config | ci | mechanical-refactor | file-move | checkpoint>
+
+The closed enum is defined in [`lib/task-types.js`](../lib/task-types.js). Adding a new Type requires a code change there + a Pass D rule update in [`lib/lint-type-ac-consistency.js`](../lib/lint-type-ac-consistency.js); the planner cannot invent ad-hoc values. Each Type maps to a gate contract (see [`gateContractFor()`](../lib/task-types.js)):
+
+- `tdd-code` — strict TDD: RED requires `*.test.*` authorship; GREEN/REFACTOR keep RC-D empty-output trap armed
+- `tests-only` — RED is intentionally skipped (no failing test → passing impl loop); GREEN requires an in-scope test file to be modified
+- `docs` — `.md`-only scope; verifier may be silent (grep / test -f)
+- `config` — package.json / lockfiles / linter configs (see allowlist in task-types.js)
+- `ci` — CI configs only (`.github/**`, `Jenkinsfile`, etc.)
+- `mechanical-refactor` — pure transforms with no behavior change
+- `file-move` — moves only, no edits beyond import updates
+- `checkpoint` — verification-only; no source, no tests
 
 ### Description
 <1-3 sentence summary of what this task delivers>

--- a/plugins/work/skills/split-in-tasks/docs/split-warning-passes.md
+++ b/plugins/work/skills/split-in-tasks/docs/split-warning-passes.md
@@ -2,6 +2,14 @@
 
 After tasks are decomposed (Step 4) and before the quality review pass (Step 5), the splitter runs four static-analysis passes against the proposed tasks. Each pass that detects a problem emits a single-line `SPLIT-WARNING` token into `tasks.md` (or the splitter's stderr stream) so the operator can decide how to resolve it before committing the split.
 
+## Severity model — why D is blocking and A/B/C are advisory
+
+**Pass A, B, and C are advisory** (warn + record; the operator resolves them inline before commit). **Pass D is a hard gate** — any kind-D violation exits non-zero and blocks the commit.
+
+The asymmetry is intentional. A/B/C surface judgment calls — overlapping scope, contract divergence, blast-radius lint — that a human operator must weigh against ticket context. They are signals, not verdicts.
+
+Pass D, by contrast, checks whether the declared `### Type` is consistent with `### Files in scope` and `### Acceptance Criteria`. The downstream gate machinery (implement-gate, `gateContractFor()`, protect-task-scope per-Type allowlist) reads `Type` as a fact: tdd-code runs RED→GREEN→REFACTOR, tests-only skips RED, docs accepts silent verifiers, and so on. If `Type` is wrong, every per-Type contract enforced after the split is unsafe — the planner has effectively lied to the implementer. Blocking at split time is cheaper than discovering the mismatch mid-implement when the agent is already wedged.
+
 Warning line shape (all three passes share this Markdown blockquote template, rendered by `lib/emit-warnings.js`):
 
 ```
@@ -15,6 +23,8 @@ The `<suggested-resolution>` text is pass-specific (see each pass below) and nam
 - `(a) add a Task 0 / (b) accept blast-radius takeover / (c) confirm with brief author` — Pass C lists the three remediation options in the hint
 
 ## Pass A — Chronological Simulator
+
+**Severity:** Advisory (warn + record; operator resolves inline before commit).
 
 **When it fires:** After Step 4.1, when two or more tasks declare overlapping `### Files in scope` AND one of them has an empty RED deliverable (no failing test authored). This catches the ECHO-5361-class wedge where a task ships GREEN code without the RED test to gate it.
 
@@ -32,6 +42,8 @@ The `<suggested-resolution>` text is pass-specific (see each pass below) and nam
 
 ## Pass B — Contract Extractor
 
+**Severity:** Advisory (warn + record; operator resolves inline before commit).
+
 **When it fires:** After Step 4.1, when a task's `### Test Command` references a file (via `$CHANGED_FILES`) that is NOT listed under that task's `### Files in scope` and IS listed under a sibling task's `### Files in scope`. This catches the ECHO-5362-class contract divergence where Task A's test depends on a contract owned by Task B.
 
 **Warning template:**
@@ -48,6 +60,8 @@ The `<suggested-resolution>` text is pass-specific (see each pass below) and nam
 
 ## Pass C — Lint Blast Radius
 
+**Severity:** Advisory (warn + record; operator resolves inline before commit).
+
 **When it fires:** After Step 4.1, when a task's `### Files in scope` includes a file that currently has lint violations OR is within a directory where `pnpm lint` would surface pre-existing violations outside the ticket's stated scope. This catches the ECHO-5353-class regression where a task's GREEN edit is blocked by pre-existing lint debt the task never intended to touch.
 
 **Warning template:**
@@ -63,6 +77,8 @@ The `<suggested-resolution>` text is pass-specific (see each pass below) and nam
 - The blast-radius heuristic uses directory-level grouping; very large directories may produce noisy warnings that the operator must resolve with `suppress`
 
 ## Pass D — Type/AC/Scope Consistency
+
+**Severity:** **Hard gate** (non-zero exit blocks the commit). Unlike Pass A/B/C, kind-D warnings cannot be deferred — see the [severity rationale](#severity-model--why-d-is-blocking-and-abc-are-advisory) for why.
 
 **When it fires:** After Step 4.1, when a task's `### Type` field, `### Files in scope`, and `### Acceptance Criteria` are not mutually consistent under the closed Type taxonomy. The taxonomy and per-Type allowlists live in [`lib/task-types.js`](../lib/task-types.js); the validator lives in [`lib/lint-type-ac-consistency.js`](../lib/lint-type-ac-consistency.js) and is invoked via the CLI at [`lib/emit-warnings.js`](../lib/emit-warnings.js).
 

--- a/plugins/work/skills/split-in-tasks/docs/split-warning-passes.md
+++ b/plugins/work/skills/split-in-tasks/docs/split-warning-passes.md
@@ -1,6 +1,6 @@
 # Split-Warning Passes
 
-After tasks are decomposed (Step 4) and before the quality review pass (Step 5), the splitter runs three static-analysis passes against the proposed tasks. Each pass that detects a problem emits a single-line `SPLIT-WARNING` token into `tasks.md` (or the splitter's stderr stream) so the operator can decide how to resolve it before committing the split.
+After tasks are decomposed (Step 4) and before the quality review pass (Step 5), the splitter runs four static-analysis passes against the proposed tasks. Each pass that detects a problem emits a single-line `SPLIT-WARNING` token into `tasks.md` (or the splitter's stderr stream) so the operator can decide how to resolve it before committing the split.
 
 Warning line shape (all three passes share this Markdown blockquote template, rendered by `lib/emit-warnings.js`):
 
@@ -61,6 +61,40 @@ The `<suggested-resolution>` text is pass-specific (see each pass below) and nam
 - Pass C does not run formatters (biome / prettier) — formatting drift is intentionally out of scope
 - Pass C falls back to a static AST parse when no `pnpm lint` script is detected; the static parse covers only syntactic rules, not project-specific ESLint plugins
 - The blast-radius heuristic uses directory-level grouping; very large directories may produce noisy warnings that the operator must resolve with `suppress`
+
+## Pass D — Type/AC/Scope Consistency
+
+**When it fires:** After Step 4.1, when a task's `### Type` field, `### Files in scope`, and `### Acceptance Criteria` are not mutually consistent under the closed Type taxonomy. The taxonomy and per-Type allowlists live in [`lib/task-types.js`](../lib/task-types.js); the validator lives in [`lib/lint-type-ac-consistency.js`](../lib/lint-type-ac-consistency.js) and is invoked via the CLI at [`lib/emit-warnings.js`](../lib/emit-warnings.js).
+
+Pass D enforces these contracts per task (each violation = one kind-D warning):
+
+- **Type=tdd-code** — scope must list ≥1 `*.test.*` / `*.spec.*` AND ≥1 non-test source. ACs containing docs-exemption phrases still emit the legacy "propose Type: docs" warning.
+- **Type=tests-only** — scope must contain ONLY `*.test.*` / `*.spec.*` files. AC must describe coverage of EXISTING behavior — wording like "implement", "add feature", "fix bug", "introduce" is flagged.
+- **Type=docs** — scope must contain ONLY `*.md` files. AC must not promise behavior changes (same "implement / add feature / fix bug / introduce" set).
+- **Type=config** — scope must match the config-path allowlist (`package.json`, lockfiles, `tsconfig*.json`, `.eslintrc*`, `biome.json`, `.prettierrc*`, `.editorconfig`, `.nvmrc`, `.envrc`, `.env*`, `.gitignore`, `.gitattributes`, `.quality-exceptions`, `turbo.json`, `nx.json`). Build configs that ship behavior belong to `tdd-code`.
+- **Type=ci** — scope must match `.github/**`, `.circleci/**`, `.gitlab-ci.yml`, `azure-pipelines.y(a)ml`, `.buildkite/**`, `.woodpecker(.yml|/**)`, `Jenkinsfile`.
+- **Unknown Type** — any `### Type` value outside the closed enum warns with a hint to pick a Type from `lib/task-types.js`. Implementers fall back to the strictest contract (`tdd-code`) for fail-closed safety; the planner is expected to fix the Type before commit.
+- **AC declares docs-exemption but Type ≠ docs** — retained from earlier work; hint "propose Type: docs".
+
+**Warning template:**
+
+```
+> ⚠️ SPLIT-WARNING: [Pass D] tasks.md: Task <N>: <one-line problem summary> — hint: <suggested-resolution>
+```
+
+**Limitations:**
+
+- Pass D only validates the literal `### Type` / `### Files in scope` / `### Acceptance Criteria` fields. Globs in scope (e.g. `src/**`) are not expanded — the allowlist regex matches the literal path, so `src/**` against a `ci` Type would correctly warn, but `app/api/**` against a `tdd-code` Type with no test sibling listed will warn unless an actual `*.test.*` file is also enumerated.
+- "New behavior" detection is a small set of English-language patterns; the planner can phrase around it. The intent is a *warn*, not a hard block — operators may resolve and continue.
+- The config allowlist is intentionally narrow. New project-specific config files require extending [`lib/task-types.js`](../lib/task-types.js) — Pass D will not auto-discover unfamiliar config conventions.
+
+**Operator invocation:** SKILL.md Step 5 invokes Pass D as a deterministic gate alongside A/B/C:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/plugins/work/skills/split-in-tasks/lib/emit-warnings.js" "${TASKS_DIR}"
+```
+
+Exit 0 = no warnings. Exit 1 = warnings printed to stdout (one `[Pass D]` line per violation). Exit 2 = invocation error (missing arg / unreadable tasks.md).
 
 ## De-duplication and operator workflow
 

--- a/plugins/work/skills/split-in-tasks/lib/emit-warnings.js
+++ b/plugins/work/skills/split-in-tasks/lib/emit-warnings.js
@@ -3,11 +3,21 @@
 /**
  * emit-warnings — pure formatter + dedupe helpers for SPLIT-WARNING records.
  *
- * Warning record shape: { kind: 'A'|'B'|'C', file: string, message: string, hint?: string }
+ * Warning record shape: { kind: 'A'|'B'|'C'|'D', file: string, message: string, hint?: string }
  *
- * No I/O. No console.*. No process.exit. Suitable for use under all three passes
- * (chronological, contract, lint-blast-radius) and the operator integration entry.
+ * No I/O. No console.*. No process.exit at module scope. Suitable for use
+ * under all four passes (chronological, contract, lint-blast-radius,
+ * type-ac-consistency) and the operator integration entry.
+ *
+ * Also exposes a CLI entrypoint: `node emit-warnings.js <ticket-dir>` parses
+ * the ticket's tasks.md, runs the kind-D Type/AC consistency lint via
+ * `lint-type-ac-consistency.js`, prints any aggregated SPLIT-WARNING lines,
+ * and exits non-zero when at least one kind-D warning is emitted.
  */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { lintTypeAcConsistency } = require('./lint-type-ac-consistency');
 
 const WARNING_PREFIX = '> ⚠️ SPLIT-WARNING:';
 
@@ -130,8 +140,77 @@ function dedupe(warnings) {
   return order.map((k) => byFile.get(k));
 }
 
+/**
+ * Parse a tasks.md string into the minimal task model the kind-D linter
+ * expects: `{ file, tasks: [{ number, section, acceptanceCriteria }] }`.
+ *
+ * Splits on `^## Task N` headings. For each section, captures the literal
+ * AC bullet lines under `### Acceptance Criteria` until the next `###`
+ * or `## ` heading.
+ *
+ * @param {string} md
+ * @param {string} file
+ * @returns {{ file: string, tasks: Array<{ number: number, section: string, acceptanceCriteria: string[] }> }}
+ */
+function parseTasksMdForTypeAc(md, file) {
+  const tasks = [];
+  if (typeof md !== 'string' || md.length === 0) return { file, tasks };
+  const parts = md.split(/^## Task /m).slice(1);
+  for (const raw of parts) {
+    const section = `## Task ${raw}`;
+    const headerMatch = raw.match(/^(\d+)\b/);
+    const number = headerMatch ? Number(headerMatch[1]) : null;
+    const acceptanceCriteria = extractAcceptanceCriteria(raw);
+    tasks.push({ number, section, acceptanceCriteria });
+  }
+  return { file, tasks };
+}
+
+function extractAcceptanceCriteria(section) {
+  const lines = section.split(/\r?\n/);
+  const out = [];
+  let inAc = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (/^###\s+Acceptance Criteria\s*$/i.test(trimmed)) {
+      inAc = true;
+      continue;
+    }
+    if (!inAc) continue;
+    if (/^###\s+/.test(trimmed) || /^##\s+/.test(trimmed)) break;
+    const bullet = trimmed.match(/^[-*]\s+(.*)$/);
+    if (bullet) out.push(bullet[1].trim());
+  }
+  return out;
+}
+
+/**
+ * Aggregate kind-D warnings for a ticket directory by reading tasks.md
+ * and invoking `lintTypeAcConsistency` once per parsed task. Reuses the
+ * existing `dedupe` path so a future multi-pass run can fold these into
+ * the broader SPLIT-WARNING aggregation.
+ *
+ * @param {string} ticketDir
+ * @returns {Array<object>} merged warning records (may be empty)
+ */
+function aggregateTypeAcWarnings(ticketDir) {
+  const tasksPath = path.join(ticketDir, 'tasks.md');
+  if (!fs.existsSync(tasksPath)) return [];
+  const md = fs.readFileSync(tasksPath, 'utf8');
+  const model = parseTasksMdForTypeAc(md, 'tasks.md');
+  const warnings = [];
+  for (const task of model.tasks) {
+    const singleTaskModel = { file: model.file, tasks: [task] };
+    const w = lintTypeAcConsistency(singleTaskModel);
+    if (w) warnings.push(w);
+  }
+  return dedupe(warnings);
+}
+
 module.exports = {
   formatWarnings,
   dedupe,
+  parseTasksMdForTypeAc,
+  aggregateTypeAcWarnings,
   WARNING_PREFIX,
 };

--- a/plugins/work/skills/split-in-tasks/lib/emit-warnings.js
+++ b/plugins/work/skills/split-in-tasks/lib/emit-warnings.js
@@ -17,11 +17,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const {
-  lintTypeAcConsistency,
-  lintAllPassD,
-  parseFilesInScope,
-} = require('./lint-type-ac-consistency');
+const { lintAllPassD, parseFilesInScope } = require('./lint-type-ac-consistency');
 
 const WARNING_PREFIX = '> ⚠️ SPLIT-WARNING:';
 

--- a/plugins/work/skills/split-in-tasks/lib/emit-warnings.js
+++ b/plugins/work/skills/split-in-tasks/lib/emit-warnings.js
@@ -17,7 +17,11 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { lintTypeAcConsistency } = require('./lint-type-ac-consistency');
+const {
+  lintTypeAcConsistency,
+  lintAllPassD,
+  parseFilesInScope,
+} = require('./lint-type-ac-consistency');
 
 const WARNING_PREFIX = '> ⚠️ SPLIT-WARNING:';
 
@@ -161,7 +165,8 @@ function parseTasksMdForTypeAc(md, file) {
     const headerMatch = raw.match(/^(\d+)\b/);
     const number = headerMatch ? Number(headerMatch[1]) : null;
     const acceptanceCriteria = extractAcceptanceCriteria(raw);
-    tasks.push({ number, section, acceptanceCriteria });
+    const filesInScope = parseFilesInScope(section);
+    tasks.push({ number, section, acceptanceCriteria, filesInScope });
   }
   return { file, tasks };
 }
@@ -198,19 +203,79 @@ function aggregateTypeAcWarnings(ticketDir) {
   if (!fs.existsSync(tasksPath)) return [];
   const md = fs.readFileSync(tasksPath, 'utf8');
   const model = parseTasksMdForTypeAc(md, 'tasks.md');
-  const warnings = [];
-  for (const task of model.tasks) {
-    const singleTaskModel = { file: model.file, tasks: [task] };
-    const w = lintTypeAcConsistency(singleTaskModel);
-    if (w) warnings.push(w);
+  // Pass D: collect EVERY kind-D warning (full Type/AC/scope consistency
+  // sweep), not just the first docs-exemption mismatch. The legacy single-
+  // warning helper `lintTypeAcConsistency` is preserved for callers that
+  // only need the binary signal.
+  const warnings = lintAllPassD(model);
+  // Use a stable per-warning key so distinct violations on the same task
+  // don't merge into one cryptic message. dedupe() folds by `file` alone,
+  // which made multi-violation tasks collapse — we use {file, message} to
+  // preserve them.
+  return dedupeByMessage(warnings);
+}
+
+/**
+ * Stable per-warning dedupe: two warnings dedupe only when both `file` AND
+ * `message` match exactly. Used for Pass D where one task may emit several
+ * distinct violations.
+ */
+function dedupeByMessage(warnings) {
+  if (!Array.isArray(warnings) || warnings.length === 0) return [];
+  const seen = new Set();
+  const out = [];
+  for (const w of warnings) {
+    if (!w) continue;
+    const key = `${w.file || ''}::${w.message || ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(w);
   }
-  return dedupe(warnings);
+  return out;
 }
 
 module.exports = {
   formatWarnings,
   dedupe,
+  dedupeByMessage,
   parseTasksMdForTypeAc,
   aggregateTypeAcWarnings,
   WARNING_PREFIX,
 };
+
+// ─── CLI entrypoint ─────────────────────────────────────────────────────────
+//
+// Usage: `node emit-warnings.js <ticket-dir>` — parses ticket's tasks.md,
+// runs all Pass D checks via aggregateTypeAcWarnings, prints aggregated
+// SPLIT-WARNING lines, and exits non-zero when any are emitted. Matches the
+// docstring contract.
+//
+// Designed to be invokable both directly and from SKILL.md Step 5 alongside
+// Pass A/B/C. The CLI takes a single positional arg (ticket dir).
+function runCli(argv) {
+  const args = (argv || []).slice(2);
+  const ticketDir = args.find((a) => a && !a.startsWith('-'));
+  if (!ticketDir) {
+    process.stderr.write('usage: emit-warnings.js <ticket-dir>\n');
+    process.exit(2);
+  }
+  let warnings;
+  try {
+    warnings = aggregateTypeAcWarnings(ticketDir);
+  } catch (err) {
+    process.stderr.write(`emit-warnings: ${err && err.message ? err.message : String(err)}\n`);
+    process.exit(2);
+  }
+  if (!warnings || warnings.length === 0) {
+    process.exit(0);
+  }
+  process.stdout.write(formatWarnings(warnings) + '\n');
+  process.exit(1);
+}
+
+// Only dispatch when invoked as a script. Using process.exit(0) instead of
+// top-level `return` because the standalone biome parser used by pre-commit
+// rejects top-level `return` (see commit 497c1d292).
+if (require.main === module) {
+  runCli(process.argv);
+}

--- a/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
+++ b/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const DOCS_EXEMPTION_PATTERNS = Object.freeze([
+  /documentation[\s-]*exempt/i,
+  /docs[-\s]?only/i,
+  /no\s+RED[\/\s]GREEN(?:[\/\s]REFACTOR)?\s+(?:cycle\s+)?required/i,
+  /documentation\/manifest only/i,
+  /config[-\s]?only/i,
+  /manifest[-\s]?only/i,
+  /no\s+test(?:able)?\s+surface/i,
+]);
+
+function parseTaskType(section) {
+  if (typeof section !== 'string') return null;
+  const lines = section.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    if (/^###\s+Type\s*$/i.test(lines[i].trim())) {
+      for (let j = i + 1; j < lines.length; j += 1) {
+        const next = lines[j].trim();
+        if (!next) continue;
+        if (next.startsWith('#')) break;
+        return next.toLowerCase();
+      }
+    }
+  }
+  return null;
+}
+
+function findOffendingAcLine(acLines) {
+  if (!Array.isArray(acLines)) return null;
+  for (const line of acLines) {
+    if (typeof line !== 'string') continue;
+    for (const pattern of DOCS_EXEMPTION_PATTERNS) {
+      if (pattern.test(line)) return line;
+    }
+  }
+  return null;
+}
+
+function buildWarning({ file, taskNumber, acLine, declaredType }) {
+  return {
+    kind: 'D',
+    file,
+    message:
+      `Task ${taskNumber}: Acceptance Criteria "${acLine}" declares ` +
+      `docs-exemption but Type is "${declaredType}".`,
+    hint: 'propose Type: docs',
+  };
+}
+
+/**
+ * Validate Type/AC consistency across a parsed tasks.md model.
+ *
+ * Input shape:
+ *   { file: string, tasks: Array<{ number, section, acceptanceCriteria }> }
+ *
+ * For each task whose AC list contains a docs-exemption phrase from the
+ * frozen DOCS_EXEMPTION_PATTERNS set, returns a SPLIT-WARNING record:
+ *   { kind: 'D', file, message, hint: 'propose Type: docs' }
+ * Returns null when the task's Type is "docs" (happy path) or when no
+ * tasks have an exemption phrase.
+ */
+function lintTypeAcConsistency(taskModel) {
+  if (!taskModel || !Array.isArray(taskModel.tasks)) return null;
+  const file = taskModel.file || 'tasks.md';
+  for (const task of taskModel.tasks) {
+    if (!task) continue;
+    const acLine = findOffendingAcLine(task.acceptanceCriteria);
+    if (!acLine) continue;
+    const declaredType = parseTaskType(task.section);
+    if (declaredType === 'docs') continue;
+    return buildWarning({
+      file,
+      taskNumber: task.number,
+      acLine,
+      declaredType: declaredType || 'unknown',
+    });
+  }
+  return null;
+}
+
+module.exports = {
+  lintTypeAcConsistency,
+  DOCS_EXEMPTION_PATTERNS,
+};

--- a/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
+++ b/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
@@ -7,15 +7,37 @@ const {
   isTestFilePath,
 } = require('./task-types');
 
-const DOCS_EXEMPTION_PATTERNS = Object.freeze([
-  /documentation[\s-]*exempt/i,
-  /docs[-\s]?only/i,
-  /no\s+RED[\/\s]GREEN(?:[\/\s]REFACTOR)?\s+(?:cycle\s+)?required/i,
-  /documentation\/manifest only/i,
-  /config[-\s]?only/i,
-  /manifest[-\s]?only/i,
-  /no\s+test(?:able)?\s+surface/i,
+// Types that legitimately have no RED/GREEN cycle (exempt from TDD).
+// Used to determine when a docs-exemption phrase aligns with the declared Type.
+const EXEMPT_TYPES_ANY = Object.freeze([
+  'docs',
+  'config',
+  'ci',
+  'tests-only',
+  'mechanical-refactor',
+  'file-move',
 ]);
+
+// Each exemption phrase pairs with the set of Types it legitimately aligns
+// with. The lint warns only when the declared Type is NOT in that set.
+const DOCS_EXEMPTION_RULES = Object.freeze([
+  { pattern: /documentation[\s-]*exempt/i, alignedTypes: Object.freeze(['docs']) },
+  { pattern: /docs[-\s]?only/i, alignedTypes: Object.freeze(['docs']) },
+  {
+    pattern: /no\s+RED[\/\s]GREEN(?:[\/\s]REFACTOR)?\s+(?:cycle\s+)?required/i,
+    alignedTypes: EXEMPT_TYPES_ANY,
+  },
+  { pattern: /documentation\/manifest only/i, alignedTypes: Object.freeze(['docs', 'file-move']) },
+  { pattern: /config[-\s]?only/i, alignedTypes: Object.freeze(['docs', 'config']) },
+  {
+    pattern: /manifest[-\s]?only/i,
+    alignedTypes: Object.freeze(['docs', 'config', 'file-move']),
+  },
+  { pattern: /no\s+test(?:able)?\s+surface/i, alignedTypes: EXEMPT_TYPES_ANY },
+]);
+
+// Backward-compatible export — list of just the regex patterns.
+const DOCS_EXEMPTION_PATTERNS = Object.freeze(DOCS_EXEMPTION_RULES.map((r) => r.pattern));
 
 // "new behavior" markers that should not appear in a tests-only / docs /
 // mechanical-refactor / file-move AC. These tasks describe existing-behavior
@@ -79,6 +101,19 @@ function findOffendingAcLine(acLines) {
   return null;
 }
 
+// Returns { line, alignedTypes } for the first AC line that matches a
+// docs-exemption rule, or null if none match.
+function findOffendingAcRule(acLines) {
+  if (!Array.isArray(acLines)) return null;
+  for (const line of acLines) {
+    if (typeof line !== 'string') continue;
+    for (const rule of DOCS_EXEMPTION_RULES) {
+      if (rule.pattern.test(line)) return { line, alignedTypes: rule.alignedTypes };
+    }
+  }
+  return null;
+}
+
 function findNewBehaviorLine(acLines) {
   if (!Array.isArray(acLines)) return null;
   for (const line of acLines) {
@@ -97,15 +132,16 @@ function makeWarning({ file, taskNumber, message, hint }) {
 // ── Per-Type checks ─────────────────────────────────────────────────────────
 
 function checkDocsExemptionTypeMismatch({ file, taskNumber, section, acceptanceCriteria }) {
-  const acLine = findOffendingAcLine(acceptanceCriteria);
-  if (!acLine) return null;
+  const offender = findOffendingAcRule(acceptanceCriteria);
+  if (!offender) return null;
   const declaredType = parseTaskType(section);
-  if (declaredType === 'docs') return null;
+  // Suppress when the declared Type is among the phrase's aligned types.
+  if (declaredType && offender.alignedTypes.includes(declaredType)) return null;
   return {
     kind: 'D',
     file,
     message:
-      `Task ${taskNumber}: Acceptance Criteria "${acLine}" declares ` +
+      `Task ${taskNumber}: Acceptance Criteria "${offender.line}" declares ` +
       `docs-exemption but Type is "${declaredType || 'unknown'}".`,
     hint: 'propose Type: docs',
   };

--- a/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
+++ b/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
@@ -43,10 +43,24 @@ const DOCS_EXEMPTION_PATTERNS = Object.freeze(DOCS_EXEMPTION_RULES.map((r) => r.
 // "new behavior" markers that should not appear in a tests-only / docs /
 // mechanical-refactor / file-move AC. These tasks describe existing-behavior
 // coverage or pure transforms, not new feature work.
+//
+// GH-528 round-2 follow-up ITEM 4 — scope and tuning:
+//   findNewBehaviorLine applies these patterns ONLY to the SUMMARY bullet
+//   (first AC bullet under `### Acceptance Criteria`). The summary line
+//   describes the task's purpose, so "implement"/"fix"/"introduce" there
+//   imply real behavior work. Supporting bullets legitimately use the same
+//   verbs as low-level steps — "implement the rename across N import paths"
+//   is fine in a mechanical-refactor task as long as the SUMMARY says
+//   "rename codebase-wide". This kills the false-positive class flagged in
+//   the round-2 review without weakening the contract for the summary.
+//
+//   Patterns are also kept narrow enough to skip refactor-safe phrasings:
+//   "rename", "move", "extract" never match; "fix … bug" allows free-form
+//   words between fix and bug to catch "fix the auth-token expiry bug".
 const NEW_BEHAVIOR_PATTERNS = Object.freeze([
   /\bimplement\b/i,
-  /\badd\s+(?:a\s+)?(?:new\s+)?(?:feature|endpoint|api|capability)\b/i,
-  /\bfix\s+(?:a\s+)?bug\b/i,
+  /\badd\s+(?:a\s+)?(?:new\s+)?(?:feature|endpoint|api|capability|flag)\b/i,
+  /\bfix\s+(?:\w[\w-]*\s+){0,5}?bug\b/i,
   /\bnew\s+behavior\b/i,
   /\bintroduce\s+(?:a\s+)?(?:new\s+)?\w+/i,
 ]);
@@ -115,13 +129,16 @@ function findOffendingAcRule(acLines) {
   return null;
 }
 
+// GH-528 round-2 ITEM 4: scope to the SUMMARY bullet only (first AC bullet).
+// Supporting bullets can legitimately use "implement"/"fix" as low-level
+// verbs without flipping the task's Type semantics. See NEW_BEHAVIOR_PATTERNS
+// docblock above for the rationale.
 function findNewBehaviorLine(acLines) {
   if (!Array.isArray(acLines)) return null;
-  for (const line of acLines) {
-    if (typeof line !== 'string') continue;
-    for (const pattern of NEW_BEHAVIOR_PATTERNS) {
-      if (pattern.test(line)) return line;
-    }
+  const summary = acLines.find((l) => typeof l === 'string' && l.trim().length > 0);
+  if (!summary) return null;
+  for (const pattern of NEW_BEHAVIOR_PATTERNS) {
+    if (pattern.test(summary)) return summary;
   }
   return null;
 }

--- a/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
+++ b/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
@@ -1,5 +1,12 @@
 'use strict';
 
+const {
+  isKnownTaskType,
+  scopeRulesFor,
+  matchesTypeScope,
+  isTestFilePath,
+} = require('./task-types');
+
 const DOCS_EXEMPTION_PATTERNS = Object.freeze([
   /documentation[\s-]*exempt/i,
   /docs[-\s]?only/i,
@@ -8,6 +15,17 @@ const DOCS_EXEMPTION_PATTERNS = Object.freeze([
   /config[-\s]?only/i,
   /manifest[-\s]?only/i,
   /no\s+test(?:able)?\s+surface/i,
+]);
+
+// "new behavior" markers that should not appear in a tests-only / docs /
+// mechanical-refactor / file-move AC. These tasks describe existing-behavior
+// coverage or pure transforms, not new feature work.
+const NEW_BEHAVIOR_PATTERNS = Object.freeze([
+  /\bimplement\b/i,
+  /\badd\s+(?:a\s+)?(?:new\s+)?(?:feature|endpoint|api|capability)\b/i,
+  /\bfix\s+(?:a\s+)?bug\b/i,
+  /\bnew\s+behavior\b/i,
+  /\bintroduce\s+(?:a\s+)?(?:new\s+)?\w+/i,
 ]);
 
 function parseTaskType(section) {
@@ -26,6 +44,30 @@ function parseTaskType(section) {
   return null;
 }
 
+function parseFilesInScope(section) {
+  if (typeof section !== 'string') return [];
+  const lines = section.split(/\r?\n/);
+  const out = [];
+  let inScope = false;
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, '');
+    const trimmed = line.trim();
+    if (/^###\s+Files in scope\b/i.test(trimmed)) {
+      inScope = true;
+      continue;
+    }
+    if (!inScope) continue;
+    if (/^###\s+/.test(trimmed) || /^##\s+/.test(trimmed)) break;
+    const bullet = trimmed.match(/^[-*+]\s+(.*)$/);
+    if (!bullet) continue;
+    const cleaned = bullet[1].replace(/`/g, '').trim();
+    // Drop trailing comments " # owned by …".
+    const withoutComment = cleaned.replace(/\s+#.*$/, '').trim();
+    if (withoutComment) out.push(withoutComment);
+  }
+  return out;
+}
+
 function findOffendingAcLine(acLines) {
   if (!Array.isArray(acLines)) return null;
   for (const line of acLines) {
@@ -37,49 +79,250 @@ function findOffendingAcLine(acLines) {
   return null;
 }
 
-function buildWarning({ file, taskNumber, acLine, declaredType }) {
+function findNewBehaviorLine(acLines) {
+  if (!Array.isArray(acLines)) return null;
+  for (const line of acLines) {
+    if (typeof line !== 'string') continue;
+    for (const pattern of NEW_BEHAVIOR_PATTERNS) {
+      if (pattern.test(line)) return line;
+    }
+  }
+  return null;
+}
+
+function makeWarning({ file, taskNumber, message, hint }) {
+  return { kind: 'D', file, message: `Task ${taskNumber}: ${message}`, hint };
+}
+
+// ── Per-Type checks ─────────────────────────────────────────────────────────
+
+function checkDocsExemptionTypeMismatch({ file, taskNumber, section, acceptanceCriteria }) {
+  const acLine = findOffendingAcLine(acceptanceCriteria);
+  if (!acLine) return null;
+  const declaredType = parseTaskType(section);
+  if (declaredType === 'docs') return null;
   return {
     kind: 'D',
     file,
     message:
       `Task ${taskNumber}: Acceptance Criteria "${acLine}" declares ` +
-      `docs-exemption but Type is "${declaredType}".`,
+      `docs-exemption but Type is "${declaredType || 'unknown'}".`,
     hint: 'propose Type: docs',
   };
+}
+
+function checkTddCodeContract({ file, taskNumber, type, filesInScope, acceptanceCriteria }) {
+  if (type !== 'tdd-code') return [];
+  const warnings = [];
+  const hasTest = filesInScope.some(isTestFilePath);
+  const hasSource = filesInScope.some((p) => p && !isTestFilePath(p));
+  if (!hasTest) {
+    warnings.push(
+      makeWarning({
+        file,
+        taskNumber,
+        message: 'Type=tdd-code but `### Files in scope` lists no `*.test.*` / `*.spec.*` file.',
+        hint: 'add the failing-test file to scope, or change Type to tests-only/docs/config/ci',
+      })
+    );
+  }
+  if (!hasSource) {
+    warnings.push(
+      makeWarning({
+        file,
+        taskNumber,
+        message: 'Type=tdd-code but `### Files in scope` lists no non-test source file.',
+        hint: 'add the implementation file to scope, or change Type to tests-only',
+      })
+    );
+  }
+  if (findOffendingAcLine(acceptanceCriteria)) {
+    // Already handled by checkDocsExemptionTypeMismatch — skip duplicate.
+  }
+  return warnings;
+}
+
+function checkTestsOnlyContract({ file, taskNumber, type, filesInScope, acceptanceCriteria }) {
+  if (type !== 'tests-only') return [];
+  const warnings = [];
+  if (filesInScope.length === 0) {
+    warnings.push(
+      makeWarning({
+        file,
+        taskNumber,
+        message: 'Type=tests-only but `### Files in scope` is empty.',
+        hint: 'list at least one `*.test.*` / `*.spec.*` file in scope',
+      })
+    );
+  } else {
+    const nonTest = filesInScope.filter((p) => !isTestFilePath(p));
+    if (nonTest.length > 0) {
+      warnings.push(
+        makeWarning({
+          file,
+          taskNumber,
+          message: `Type=tests-only but scope includes non-test file(s): ${nonTest.join(', ')}.`,
+          hint: 'move source edits to a tdd-code task, or change Type to tdd-code',
+        })
+      );
+    }
+  }
+  const newBehavior = findNewBehaviorLine(acceptanceCriteria);
+  if (newBehavior) {
+    warnings.push(
+      makeWarning({
+        file,
+        taskNumber,
+        message:
+          `Type=tests-only AC "${newBehavior}" describes new behavior — ` +
+          'tests-only tasks cover EXISTING behavior.',
+        hint: 'rewrite AC to describe coverage of existing behavior, or change Type to tdd-code',
+      })
+    );
+  }
+  return warnings;
+}
+
+function checkDocsContract({ file, taskNumber, type, filesInScope, acceptanceCriteria }) {
+  if (type !== 'docs') return [];
+  const warnings = [];
+  if (filesInScope.length > 0) {
+    const nonMd = filesInScope.filter((p) => !/\.md$/i.test(p));
+    if (nonMd.length > 0) {
+      warnings.push(
+        makeWarning({
+          file,
+          taskNumber,
+          message: `Type=docs but scope includes non-\`.md\` file(s): ${nonMd.join(', ')}.`,
+          hint: 'move non-docs edits to a tdd-code/config/ci task, or split the task',
+        })
+      );
+    }
+  }
+  const newBehavior = findNewBehaviorLine(acceptanceCriteria);
+  if (newBehavior) {
+    warnings.push(
+      makeWarning({
+        file,
+        taskNumber,
+        message:
+          `Type=docs AC "${newBehavior}" promises behavior change — ` +
+          'docs tasks must not ship behavior.',
+        hint: 'rewrite AC to describe documentation only, or change Type',
+      })
+    );
+  }
+  return warnings;
+}
+
+function checkAllowlistedScope({ file, taskNumber, type, filesInScope }) {
+  // For closed-allowlist types (config, ci), verify every scope entry matches.
+  if (type !== 'config' && type !== 'ci') return [];
+  const rules = scopeRulesFor(type);
+  if (!rules || !rules.scopePatterns) return [];
+  const offenders = filesInScope.filter((p) => !matchesTypeScope(type, p));
+  if (offenders.length === 0) return [];
+  return [
+    makeWarning({
+      file,
+      taskNumber,
+      message:
+        `Type=${type} but scope includes file(s) outside the ${type} allowlist: ` +
+        `${offenders.join(', ')}.`,
+      hint:
+        type === 'config'
+          ? 'move runtime/behavior files to a tdd-code task, or extend task-types.js allowlist'
+          : 'move non-CI files to the appropriate Type, or extend task-types.js allowlist',
+    }),
+  ];
+}
+
+function checkUnknownType({ file, taskNumber, type }) {
+  if (!type) return null;
+  if (isKnownTaskType(type)) return null;
+  return makeWarning({
+    file,
+    taskNumber,
+    message:
+      `Type="${type}" is not in the closed taxonomy ` +
+      '(tdd-code, tests-only, docs, config, ci, mechanical-refactor, file-move, checkpoint).',
+    hint: 'pick a Type from plugins/work/skills/split-in-tasks/lib/task-types.js',
+  });
 }
 
 /**
  * Validate Type/AC consistency across a parsed tasks.md model.
  *
+ * Backward-compatible: returns the FIRST docs-exemption / Type mismatch
+ * warning (legacy callers — Pass D aggregation used `for-each task` and
+ * stopped at the first one). Use `lintAllPassD` for the multi-warning surface
+ * Pass D needs.
+ */
+function lintTypeAcConsistency(taskModel) {
+  const all = lintAllPassD(taskModel);
+  if (all.length === 0) return null;
+  // Prefer the legacy docs-exemption shape if present (hint === 'propose Type: docs')
+  // so existing callers see the same record they used to.
+  const legacy = all.find((w) => w.hint === 'propose Type: docs');
+  return legacy || all[0];
+}
+
+/**
+ * Run every kind-D check across a parsed tasks.md model and return ALL
+ * warnings. Each task may contribute 0..N warnings.
+ *
  * Input shape:
  *   { file: string, tasks: Array<{ number, section, acceptanceCriteria }> }
  *
- * For each task whose AC list contains a docs-exemption phrase from the
- * frozen DOCS_EXEMPTION_PATTERNS set, returns a SPLIT-WARNING record:
- *   { kind: 'D', file, message, hint: 'propose Type: docs' }
- * Returns null when the task's Type is "docs" (happy path) or when no
- * tasks have an exemption phrase.
+ * Warning shape: { kind: 'D', file, message, hint }
  */
-function lintTypeAcConsistency(taskModel) {
-  if (!taskModel || !Array.isArray(taskModel.tasks)) return null;
+function buildTaskCtx(task, file) {
+  const taskNumber = task.number;
+  const section = task.section || '';
+  const acceptanceCriteria = task.acceptanceCriteria || [];
+  const type = parseTaskType(section) || '';
+  const filesInScope =
+    Array.isArray(task.filesInScope) && task.filesInScope.length > 0
+      ? task.filesInScope
+      : parseFilesInScope(section);
+  return { file, taskNumber, type, section, filesInScope, acceptanceCriteria };
+}
+
+function lintOneTask(ctx) {
+  const warnings = [];
+  const { file, taskNumber, section, acceptanceCriteria, type } = ctx;
+  const docsMismatch = checkDocsExemptionTypeMismatch({
+    file,
+    taskNumber,
+    section,
+    acceptanceCriteria,
+  });
+  if (docsMismatch) warnings.push(docsMismatch);
+  const unknown = checkUnknownType({ file, taskNumber, type });
+  if (unknown) warnings.push(unknown);
+  warnings.push(...checkTddCodeContract(ctx));
+  warnings.push(...checkTestsOnlyContract(ctx));
+  warnings.push(...checkDocsContract(ctx));
+  warnings.push(...checkAllowlistedScope(ctx));
+  return warnings;
+}
+
+function lintAllPassD(taskModel) {
+  if (!taskModel || !Array.isArray(taskModel.tasks)) return [];
   const file = taskModel.file || 'tasks.md';
+  const warnings = [];
   for (const task of taskModel.tasks) {
     if (!task) continue;
-    const acLine = findOffendingAcLine(task.acceptanceCriteria);
-    if (!acLine) continue;
-    const declaredType = parseTaskType(task.section);
-    if (declaredType === 'docs') continue;
-    return buildWarning({
-      file,
-      taskNumber: task.number,
-      acLine,
-      declaredType: declaredType || 'unknown',
-    });
+    const ctx = buildTaskCtx(task, file);
+    warnings.push(...lintOneTask(ctx));
   }
-  return null;
+  return warnings;
 }
 
 module.exports = {
   lintTypeAcConsistency,
+  lintAllPassD,
+  parseFilesInScope,
   DOCS_EXEMPTION_PATTERNS,
+  NEW_BEHAVIOR_PATTERNS,
 };

--- a/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
+++ b/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
@@ -5,6 +5,7 @@ const {
   scopeRulesFor,
   matchesTypeScope,
   isTestFilePath,
+  scopeEntryAdmitsOnlyTestFiles,
 } = require('./task-types');
 
 // Types that legitimately have no RED/GREEN cycle (exempt from TDD).
@@ -191,7 +192,12 @@ function checkTestsOnlyContract({ file, taskNumber, type, filesInScope, acceptan
       })
     );
   } else {
-    const nonTest = filesInScope.filter((p) => !isTestFilePath(p));
+    // Use the shared scope classifier so Pass D and the implement-time
+    // Type=tests-only GREEN gate (task-next.js) agree on what counts as
+    // a test-only entry — globs whose basename constrains to test files
+    // (e.g. `src/**/*.test.js`) must NOT warn while open-ended globs
+    // (`src/**`) STILL warn. cursor[bot] follow-up, GH-528.
+    const nonTest = filesInScope.filter((p) => !scopeEntryAdmitsOnlyTestFiles(p));
     if (nonTest.length > 0) {
       warnings.push(
         makeWarning({

--- a/plugins/work/skills/split-in-tasks/lib/task-types.js
+++ b/plugins/work/skills/split-in-tasks/lib/task-types.js
@@ -92,13 +92,166 @@ function gateContractFor(type /* , _scope */) {
   }
 }
 
+/**
+ * Per-Type file-pattern allowlist (regex source strings — RE2-compatible).
+ *
+ * Used by:
+ *   - Pass D (lib/lint-type-ac-consistency.js) at planner time to verify each
+ *     task's `### Files in scope` matches the contract for its declared Type.
+ *   - protect-task-scope.js at implementer time to block write targets that
+ *     don't match the active task's Type allowlist.
+ *
+ * Semantics:
+ *   - Each pattern matches against a relative POSIX path (forward slashes).
+ *   - "scopeMatchAll" means every scope entry must match at least one pattern.
+ *   - "scopeMatchAny" means the patterns are advisory — scope is unconstrained
+ *     beyond the kind's primary contract (used for tdd-code / checkpoint).
+ *   - `mustHaveSource` true requires at least one non-test source entry
+ *     (used by tdd-code Pass D check).
+ *   - `mustHaveTest` true requires at least one *.test.* / *.spec.* entry.
+ *   - `mustBeOnlyTests` true requires the scope to consist ONLY of test files.
+ *   - `acForbidNewBehavior` true marks types whose AC must not describe
+ *     "implement"/"add feature"/"fix bug" wording (warn at planner time).
+ *
+ * Config allowlist (Type=config) is intentionally narrow — only files the
+ * planner would call "configuration" at decomposition time. Build/runtime
+ * config that ships behavior (e.g. webpack.config.js exporting a plugin
+ * factory) does NOT belong here — that is `tdd-code`.
+ */
+const TEST_FILE_PATTERN = '\\.(test|spec)\\.[jt]sx?$';
+
+const TYPE_SCOPE_RULES = Object.freeze({
+  'tdd-code': Object.freeze({
+    scopePatterns: null, // unconstrained
+    mustHaveTest: true,
+    mustHaveSource: true,
+    mustBeOnlyTests: false,
+    acForbidNewBehavior: false,
+  }),
+  'tests-only': Object.freeze({
+    scopePatterns: Object.freeze([TEST_FILE_PATTERN]),
+    mustHaveTest: true,
+    mustHaveSource: false,
+    mustBeOnlyTests: true,
+    acForbidNewBehavior: true,
+  }),
+  docs: Object.freeze({
+    scopePatterns: Object.freeze(['\\.md$']),
+    mustHaveTest: false,
+    mustHaveSource: false,
+    mustBeOnlyTests: false,
+    acForbidNewBehavior: true,
+  }),
+  config: Object.freeze({
+    // Narrow allowlist — packaging manifests, formatter configs, env files.
+    // Build configs that ship behavior (rollup.config.js, vite plugins,
+    // webpack loaders) belong to `tdd-code`, not `config`.
+    scopePatterns: Object.freeze([
+      '(^|/)package\\.json$',
+      '(^|/)package-lock\\.json$',
+      '(^|/)pnpm-lock\\.yaml$',
+      '(^|/)pnpm-workspace\\.yaml$',
+      '(^|/)tsconfig(\\.[^/]*)?\\.json$',
+      '(^|/)\\.eslintrc(\\.[^/]*)?$',
+      '(^|/)eslint\\.config\\.[cm]?js$',
+      '(^|/)biome\\.json$',
+      '(^|/)\\.prettierrc(\\.[^/]*)?$',
+      '(^|/)prettier\\.config\\.[cm]?js$',
+      '(^|/)\\.editorconfig$',
+      '(^|/)\\.nvmrc$',
+      '(^|/)\\.node-version$',
+      '(^|/)\\.envrc$',
+      '(^|/)\\.env(\\.[^/]*)?$',
+      '(^|/)\\.gitignore$',
+      '(^|/)\\.gitattributes$',
+      '(^|/)\\.quality-exceptions$',
+      '(^|/)turbo\\.json$',
+      '(^|/)nx\\.json$',
+    ]),
+    mustHaveTest: false,
+    mustHaveSource: false,
+    mustBeOnlyTests: false,
+    acForbidNewBehavior: false,
+  }),
+  ci: Object.freeze({
+    scopePatterns: Object.freeze([
+      '(^|/)\\.github/.*',
+      '(^|/)\\.circleci/.*',
+      '(^|/)\\.gitlab-ci\\.yml$',
+      '(^|/)azure-pipelines\\.ya?ml$',
+      '(^|/)\\.buildkite/.*',
+      '(^|/)\\.woodpecker(\\.ya?ml|/.*)$',
+      '(^|/)Jenkinsfile$',
+    ]),
+    mustHaveTest: false,
+    mustHaveSource: false,
+    mustBeOnlyTests: false,
+    acForbidNewBehavior: false,
+  }),
+  'mechanical-refactor': Object.freeze({
+    scopePatterns: null,
+    mustHaveTest: false,
+    mustHaveSource: false,
+    mustBeOnlyTests: false,
+    acForbidNewBehavior: true,
+  }),
+  'file-move': Object.freeze({
+    scopePatterns: null,
+    mustHaveTest: false,
+    mustHaveSource: false,
+    mustBeOnlyTests: false,
+    acForbidNewBehavior: true,
+  }),
+  checkpoint: Object.freeze({
+    scopePatterns: null,
+    mustHaveTest: false,
+    mustHaveSource: false,
+    mustBeOnlyTests: false,
+    acForbidNewBehavior: false,
+  }),
+});
+
+/**
+ * Look up the scope/AC rules for a Type. Unknown types return null so callers
+ * can decide their own fallback (Pass D treats unknown as "skip kind-D scope
+ * checks" — the freeform-Type warning is emitted by the existing kind-D
+ * docs-exemption check instead).
+ */
+function scopeRulesFor(type) {
+  const t = normalize(type);
+  return TYPE_SCOPE_RULES[t] || null;
+}
+
+/**
+ * Return true if the relative path matches any of the Type's scope patterns.
+ * Used by Pass D and protect-task-scope.js. Always compares as POSIX path.
+ */
+function matchesTypeScope(type, relPath) {
+  const rules = scopeRulesFor(type);
+  if (!rules || !rules.scopePatterns) return true; // unconstrained
+  const posix = String(relPath || '').replace(/\\/g, '/');
+  for (const src of rules.scopePatterns) {
+    if (new RegExp(src).test(posix)) return true;
+  }
+  return false;
+}
+
+function isTestFilePath(relPath) {
+  return new RegExp(TEST_FILE_PATTERN).test(String(relPath || '').replace(/\\/g, '/'));
+}
+
 module.exports = {
   TASK_TYPES,
   TDD_REQUIRED_TYPES,
   TDD_EXEMPT_TYPES,
+  TYPE_SCOPE_RULES,
+  TEST_FILE_PATTERN,
   isKnownTaskType,
   isTddRequired,
   isTddExempt,
   allTaskTypes,
   gateContractFor,
+  scopeRulesFor,
+  matchesTypeScope,
+  isTestFilePath,
 };

--- a/plugins/work/skills/split-in-tasks/lib/task-types.js
+++ b/plugins/work/skills/split-in-tasks/lib/task-types.js
@@ -240,6 +240,39 @@ function isTestFilePath(relPath) {
   return new RegExp(TEST_FILE_PATTERN).test(String(relPath || '').replace(/\\/g, '/'));
 }
 
+/**
+ * scopeEntryAdmitsOnlyTestFiles — true iff a `### Files in scope` entry can
+ * ONLY match test files (`*.test.<ext>` / `*.spec.<ext>`). Shared classifier
+ * for the planner-time Pass D gate (lint-type-ac-consistency.js) and the
+ * implement-time Type=tests-only GREEN gate (task-next.js) — keeping both
+ * sides on the same function prevents drift (cursor[bot] follow-up, GH-528).
+ *
+ * Rules:
+ *   - Empty / non-string                                     → false.
+ *   - Glob entry (contains `*`): inspect its basename — the segment after
+ *     the last `/`. Accept iff the basename ends in `*.test.<ext>` /
+ *     `*.spec.<ext>`. This accepts `src/**\/*.test.js` and rejects
+ *     `src/**`, `lib/**\/*.js`.
+ *   - Literal entry: delegate to `isTestFilePath`. Accept `src/foo.test.js`,
+ *     reject `src/foo.js`.
+ *
+ * @param {string} entry
+ * @returns {boolean}
+ */
+function scopeEntryAdmitsOnlyTestFiles(entry) {
+  if (typeof entry !== 'string' || !entry) return false;
+  const isGlob = entry.includes('*');
+  if (!isGlob) {
+    return isTestFilePath(entry);
+  }
+  // Glob: examine the basename. A glob whose final segment ends in a
+  // test-file extension pattern admits ONLY test files; any other shape
+  // could match a non-test file.
+  const lastSlash = entry.lastIndexOf('/');
+  const basename = lastSlash >= 0 ? entry.slice(lastSlash + 1) : entry;
+  return new RegExp(TEST_FILE_PATTERN).test(basename);
+}
+
 module.exports = {
   TASK_TYPES,
   TDD_REQUIRED_TYPES,
@@ -254,4 +287,5 @@ module.exports = {
   scopeRulesFor,
   matchesTypeScope,
   isTestFilePath,
+  scopeEntryAdmitsOnlyTestFiles,
 };

--- a/plugins/work/skills/split-in-tasks/lib/task-types.js
+++ b/plugins/work/skills/split-in-tasks/lib/task-types.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * task-types.js — Closed enum for the `### Type` field in tasks.md.
+ *
+ * Single source of truth for which gate contract a task gets at implement time.
+ * The planner (split-in-tasks) writes ONE of these values into each task's
+ * `### Type` line; the implementer (task-next.js / tdd-phase-state.js) reads it
+ * and applies the matching contract. The implementer must not be able to
+ * promote a TDD-required task to a TDD-exempt one — that decision belongs to
+ * the planner and is enforced by hooks (protect-task-scope.js + a Type-line
+ * edit guard).
+ *
+ * Adding a new Type: add it to either TDD_REQUIRED_TYPES or TDD_EXEMPT_TYPES
+ * (never both), and extend gateContractFor() with its rcdEmptyTrap /
+ * redRequiresTestFiles flags. Pass D (lib/lint-type-ac-consistency.js) will
+ * pick it up automatically through allTaskTypes().
+ */
+
+const TDD_REQUIRED_TYPES = Object.freeze(['tdd-code']);
+
+const TDD_EXEMPT_TYPES = Object.freeze([
+  'tests-only',
+  'docs',
+  'config',
+  'ci',
+  'mechanical-refactor',
+  'file-move',
+  'checkpoint',
+]);
+
+const TASK_TYPES = Object.freeze([...TDD_REQUIRED_TYPES, ...TDD_EXEMPT_TYPES]);
+
+function normalize(t) {
+  if (typeof t !== 'string') return '';
+  return t.trim().toLowerCase();
+}
+
+function isKnownTaskType(t) {
+  return TASK_TYPES.includes(normalize(t));
+}
+
+function isTddRequired(t) {
+  return TDD_REQUIRED_TYPES.includes(normalize(t));
+}
+
+function isTddExempt(t) {
+  return TDD_EXEMPT_TYPES.includes(normalize(t));
+}
+
+function allTaskTypes() {
+  return TASK_TYPES.slice();
+}
+
+/**
+ * Per-Type gate contract returned to the implementer.
+ *
+ * Fields:
+ *   - kind                 — the canonical Type string
+ *   - redRequiresTestFiles — if true, RED phase requires modified *.test.* /
+ *                            *.spec.* files in scope (tdd-code only)
+ *   - rcdEmptyTrap         — if true, GREEN / REFACTOR refuse exit-0 with no
+ *                            stdout/stderr (RC-D defense in tdd-phase-state.js)
+ *
+ * Unknown types fall back to the strictest contract (tdd-code) so missing
+ * planner data fails closed.
+ */
+function gateContractFor(type /* , _scope */) {
+  const t = normalize(type);
+  switch (t) {
+    case 'tdd-code':
+      return { kind: 'tdd-code', redRequiresTestFiles: true, rcdEmptyTrap: true };
+    case 'tests-only':
+      return { kind: 'tests-only', redRequiresTestFiles: false, rcdEmptyTrap: true };
+    case 'docs':
+      return { kind: 'docs', redRequiresTestFiles: false, rcdEmptyTrap: false };
+    case 'config':
+      return { kind: 'config', redRequiresTestFiles: false, rcdEmptyTrap: false };
+    case 'ci':
+      return { kind: 'ci', redRequiresTestFiles: false, rcdEmptyTrap: false };
+    case 'mechanical-refactor':
+      return { kind: 'mechanical-refactor', redRequiresTestFiles: false, rcdEmptyTrap: true };
+    case 'file-move':
+      return { kind: 'file-move', redRequiresTestFiles: false, rcdEmptyTrap: false };
+    case 'checkpoint':
+      return { kind: 'checkpoint', redRequiresTestFiles: false, rcdEmptyTrap: false };
+    default:
+      // Unknown / freeform Type → strictest contract. Planner-side Pass D
+      // should reject this before reaching the implementer, but failing
+      // closed here keeps a defense-in-depth layer.
+      return { kind: 'tdd-code', redRequiresTestFiles: true, rcdEmptyTrap: true };
+  }
+}
+
+module.exports = {
+  TASK_TYPES,
+  TDD_REQUIRED_TYPES,
+  TDD_EXEMPT_TYPES,
+  isKnownTaskType,
+  isTddRequired,
+  isTddExempt,
+  allTaskTypes,
+  gateContractFor,
+};


### PR DESCRIPTION
## Summary

Closes #528. Replaces the implicit, free-form `### Type` field in `tasks.md` with a closed taxonomy enforced by a deterministic gate chain: planner-side Pass D, implementer-side Type-driven contracts, and hook-side per-Type allowlists. Removes the body-prose bypass that let agents flip the TDD gate by writing trigger phrases into ACs, gates the runtime `exception` subcommand behind an operator token, and adds a dedicated tests-only RED-skipped contract so test-backfill tasks no longer fabricate evidence.

## Closed Type taxonomy

The Type field is now a closed enum defined in [`plugins/work/skills/split-in-tasks/lib/task-types.js`](plugins/work/skills/split-in-tasks/lib/task-types.js):

| Type | TDD | Scope allowlist | Notes |
|---|---|---|---|
| `tdd-code` | required | unconstrained | Standard RED→GREEN→REFACTOR; full RC-D + test-file authorship guards |
| `tests-only` | RED skipped | `*.test.*` / `*.spec.*` only | New `record-skip-red` subcommand; GREEN requires in-scope test-file mods |
| `docs` | RED-fallback | `*.md` only | Silent verifiers accepted via `--docs-exempt` |
| `config` | exempt | manifests, lockfiles, lint/format configs, `.envrc`, `.env*`, `tsconfig*`, `.editorconfig`, `.nvmrc`, `.gitignore`, `.quality-exceptions`, `turbo.json`, `nx.json` | See `TYPE_SCOPE_RULES` in task-types.js |
| `ci` | exempt | `.github/**`, `.circleci/**`, `.gitlab-ci.yml`, `azure-pipelines.y(a)ml`, `.buildkite/**`, `.woodpecker(/**\|.yml)`, `Jenkinsfile` | |
| `mechanical-refactor` | exempt | unconstrained | Pure transforms |
| `file-move` | exempt | unconstrained | Moves + import updates only |
| `checkpoint` | exempt | unconstrained | Verification-only task |

`gateContractFor()` returns the per-Type contract `{kind, redRequiresTestFiles, rcdEmptyTrap}`. Unknown Types fall back to the strictest contract (`tdd-code`) for fail-closed safety.

## Bypass-proof gate chain

The gate is enforced end-to-end across three layers:

1. **Planner-side — Pass D static validation** (`split-in-tasks` Step 5). [`lib/lint-type-ac-consistency.js`](plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js) runs the full Type/AC/scope sweep through the [`emit-warnings.js` CLI](plugins/work/skills/split-in-tasks/lib/emit-warnings.js): unknown Types, scope-allowlist violations, docs-exemption phrases on non-docs Types, "implement / add feature / fix bug" wording on tests-only or docs tasks, etc. Exit non-zero on any violation. Documented in [`docs/split-warning-passes.md`](plugins/work/skills/split-in-tasks/docs/split-warning-passes.md) alongside Pass A/B/C.

2. **Implementer-side — Type-driven contract** (`task-next.js` + `tdd-phase-state.js`). Each Type maps to a contract: tdd-code runs the full cycle; tests-only walks RED→GREEN→REFACTOR with `record-skip-red` for RED and an "in-scope test file modified" check at GREEN; docs/visual-only forwards `--docs-exempt` so the RC-D empty-output trap relaxes. The body-prose bypass in `isDocsExempt()` is removed — only `### Type === 'docs'` triggers the docs path. The `exception` subcommand is operator-only (`WORK_OPERATOR_TOKEN=1`).

3. **Hook-side — per-Type allowlist + Type-line guard** ([`protect-task-scope.js`](plugins/work/scripts/workflows/work/hooks/protect-task-scope.js)). On top of the existing `### Files in scope` check, the closed-allowlist Types (`tests-only`, `docs`, `config`, `ci`) additionally require every write target to match the Type's scope patterns from `task-types.js`. An attempt to flip the `### Type` line in `tasks.md` mid-implement is blocked for Write, Edit, and MultiEdit. The one-shot `PROTECT_TASK_SCOPE_BYPASS_REASON` + `PROTECT_TASK_SCOPE_BYPASS_TARGET` pair is preserved across both layers.

## Files

**Library / closed enum**
- `plugins/work/skills/split-in-tasks/lib/task-types.js` — closed enum, partition (TDD-required vs exempt), `gateContractFor()`, `TYPE_SCOPE_RULES` allowlist, `matchesTypeScope()` / `isTestFilePath()` helpers
- `plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js` — Pass D multi-warning sweep (`lintAllPassD()`) plus the legacy single-warning `lintTypeAcConsistency()` for backward compat
- `plugins/work/skills/split-in-tasks/lib/emit-warnings.js` — real CLI (`require.main === module` guarded), `aggregateTypeAcWarnings()` uses the full Pass D sweep with per-message dedupe

**Implementer-side**
- `plugins/work/scripts/workflows/work-implement/task-next.js` — tests-only RED-skipped branch, tests-only GREEN gate (in-scope test-file mod required), `recordSkipRed()` + `detectChangedTestFilesInScope()` helpers
- `plugins/work/scripts/workflows/work-implement/tdd-phase-state.js` — new `record-skip-red` subcommand; existing `exception` gated on `WORK_OPERATOR_TOKEN`; existing `record-red`/`record-green`/`record-refactor` `--docs-exempt` opt-in

**Hook-side**
- `plugins/work/scripts/workflows/work/hooks/protect-task-scope.js` — per-Type allowlist layer, Type-line edit guard for Write/Edit/MultiEdit, bypass-pair preserved

**Docs**
- `plugins/work/skills/split-in-tasks/SKILL.md` — Step 5 invokes Pass D as a deterministic gate
- `plugins/work/skills/split-in-tasks/docs/split-warning-passes.md` — Pass D section mirroring A/B/C (template, scope, limitations, operator invocation)
- `plugins/work/skills/split-in-tasks/docs/output-format.md` — `### Type` now documents the closed enum with link to `task-types.js`
- `plugins/work/skills/split-in-tasks/docs/decomposition-rules.md` — Rule 10 lists TDD-required vs exempt Types; Rule 11 replaces the "checkpoint" hack with `Type: docs`

**Tests added**
- `plugins/work/skills/split-in-tasks/__tests__/pass-d-type-scope.test.js` — 20 unit cases across every per-Type branch
- `plugins/work/skills/split-in-tasks/__tests__/pass-d-cli.integration.test.js` — spawn-based E2E for the SKILL.md flow
- `plugins/work/scripts/workflows/work-implement/__tests__/tdd-phase-state-tests-only.test.js` — `record-skip-red` subcommand contract
- `plugins/work/scripts/workflows/work-implement/__tests__/task-next-tests-only.integration.test.js` — happy path + negative regressions for tests-only RED→GREEN→REFACTOR
- `plugins/work/scripts/workflows/work/hooks/__tests__/protect-task-scope-type-allowlist.test.js` — 13 hook cases across every allowlist Type + Type-line guard

## Migration

Any in-flight `tasks.md` whose `### Type` value is outside the closed enum (e.g. `wiring`, `backend`, `frontend`, `infrastructure`, `integration`, `test`) will fail Pass D on the next `/work` invocation. Operators have two paths:

1. **Re-run the planner** (preferred): `/split-in-tasks <TICKET> --force` regenerates `tasks.md` with closed-enum Types.

2. **Manual migration** for in-progress tickets where re-planning is too expensive: edit each `### Type` line to the closest closed-enum value, then re-run the Pass D gate to confirm:

```bash
# For each in-flight ticket folder under $TASKS_BASE:
node "${CLAUDE_PLUGIN_ROOT}/plugins/work/skills/split-in-tasks/lib/emit-warnings.js" "${TASKS_BASE}/<TICKET>"
```

Mapping cheat-sheet for the common freeform values:

| Old freeform | Replacement |
|---|---|
| `backend` / `frontend` / `integration` / `infrastructure` | `tdd-code` (the default for behavior-shipping work) |
| `test` / `tests` | `tests-only` (coverage of existing behavior) or `tdd-code` (new test+impl pair) |
| `wiring` | `tdd-code` if it ships behavior; `config` if it's pure manifest/lockfile edits |
| `docs` / `documentation` | `docs` |
| `ci` / `pipeline` / `workflow` | `ci` |
| `cleanup` / `refactor` | `mechanical-refactor` |
| `move` / `rename` | `file-move` |

Existing `Type: checkpoint` tasks remain valid — the closed enum still includes `checkpoint`. The Rule 11 "Documentation Review" task is the only documented former-`checkpoint` use that should migrate to `Type: docs`.

### Common migration gotcha — build configs are NOT `Type: config`

`Type: config` is for inert configuration (package.json, lockfiles, linter/formatter configs). Build configs ship runtime behavior and need the full TDD cycle, so use **`Type: tdd-code`** for:

- `vite.config.{ts,js,mjs,cjs}`
- `rollup.config.{ts,js,mjs,cjs}`
- `webpack.config.{ts,js,mjs,cjs}`
- `jest.config.{ts,js,mjs,cjs}`
- `vitest.config.{ts,js,mjs,cjs}`
- `next.config.{ts,js,mjs,cjs}`
- `astro.config.{ts,js,mjs,cjs}`

Listing one under `Type: config` will warn at Pass D (`config allowlist`) and block at the per-Type write guard.

## Round-2 follow-ups

Five follow-ups from the round-2 review, addressed in this same PR before merge:

1. **`fix(protect-task-scope): gate env bypass behind WORK_OPERATOR_TOKEN`** (`847caa07c`) — all three guards in `protect-task-scope.js` (filesInScope override, per-Type allowlist, Type-line edit) now require `WORK_OPERATOR_TOKEN=1` in addition to the `PROTECT_TASK_SCOPE_BYPASS_REASON` + `PROTECT_TASK_SCOPE_BYPASS_TARGET` pair. Without the token, the rejected attempt is audited as `scope-bypass-rejected`.
2. **`docs(split-warning-passes): document Pass A/B/C/D severity asymmetry`** (`4003025ae`) — A/B/C are advisory; D is a hard gate. Rationale and per-pass Severity subsections added; SKILL.md Step 5 cross-links the new section.
3. **`docs(split-in-tasks): build-config migration gotcha under Type:config`** (`7901e1f4b`) — explicit list of vite/rollup/webpack/jest/vitest/next/astro configs under `output-format.md` "Common migration gotchas" and `decomposition-rules.md` Rule 10.
4. **`fix(lint-type-ac-consistency): scope acForbidNewBehavior to summary line`** (`f0ec44f38`) — `NEW_BEHAVIOR_PATTERNS` now applies only to the first AC bullet (summary). Supporting bullets in mechanical-refactor / file-move tasks can legitimately say "implement the rename across N import paths" without warning. Pattern 3 broadened to catch "fix the X bug"; pattern 2 extended to include "flag".
5. **`test(protect-task-scope): regression cases for Type-line patch tricks`** (`34b144a34`) — adds regression coverage for `MultiEdit replace_all` flipping (and NOT flipping) the Type value, an Edit on an AC bullet containing the word "Type", and whitespace-only edits to the `### Type` heading line.

### Post-round-2 Cursor[bot] follow-ups

6. **`fix(tdd-phase-state): close mechanical-refactor RED wedge + bare-CLI silent exit`** (`afb9f42dd`) — two Cursor[bot] comments on the round-2 commits:
   - **Medium:** `gateContractFor('mechanical-refactor')` returns `redRequiresTestFiles=false` + `rcdEmptyTrap=true`. The orchestrator's RED fallback accepted that contract, but `docsExemptForward` was driven by `rcdEmptyTrap` so the recorder got `--docs-exempt=false` and rejected the call with "No test files changed", wedging verifier-only mechanical-refactor cycles. Added a new `--red-skip-file-guard` flag that relaxes ONLY the file guard, independent of `--docs-exempt` (which still controls RC-D at GREEN/REFACTOR). Orchestrator forwards it from the contract-fallback branch.
   - **Low:** Bare `node tdd-phase-state.js` (no subcommand) silently exited 0 because `argv.length < 3` was treated as a `node --test` load. Now distinguishes `require.main !== module` (silent) from `require.main === module` (errorExit with usage hint).

7. **`fix(tdd-phase-state): gate record-skip-red + --red-skip-file-guard on Type`** (`8311d72de`) — closes two structural self-report holes the round-2 commits left behind. Both flagged HIGH on review:
   - **`record-skip-red` accepted any Type.** Docblock said "tests-only contract" but the body only checked `--reason` non-empty and `currentPhase === 'red'`. Any allow-listed developer agent with a valid token could call `record-skip-red` on a `tdd-code` task and advance RED→GREEN with zero failing-test authorship.
   - **`--red-skip-file-guard` accepted any Type.** The orchestrator (task-next.js) only forwarded it when `gateContractFor(type).redRequiresTestFiles === false`, but the recorder honored it unconditionally — a direct CLI call from an allow-listed agent bypassed the gate.
   
   Fix: the recorder now reads the active task's `### Type` from on-disk `tasks.md` (same source-of-truth the hook layer uses; mid-implement Type flips are blocked by the Type-line guard) and gates both call sites. `record-skip-red` requires `Type === 'tests-only'`; `--red-skip-file-guard` requires `gateContractFor(type).redRequiresTestFiles === false`. Unknown/missing tasks.md fails closed.
   
   Also folds in three secondary findings: a comment explaining intentional case-equivalence in `extractTypeLines`/`typesEqual`, a comment on `applyEditPatch`'s null-on-miss + final-equality-check safety, and a `git`-exit-status check in `detectChangedTestFilesInScope` so corrupt-repo/mid-rebase states emit a clear diagnostic instead of silently returning empty.

8. **`fix(tdd-phase-state): gate --docs-exempt on Type+scope across all record phases`** (`063827177`) — third hole in the same family as ITEMs 6 & 7, flagged HIGH/Medium by Cursor[bot]. `record-red`, `record-green`, and `record-refactor` all honored `--docs-exempt` from argv alone without consulting `gateContractFor`. A tokened agent could pass `--docs-exempt` on a `tdd-code` task to skip the RED file guard OR the GREEN/REFACTOR RC-D empty-output trap, bypassing orchestrator routing.
   
   Fix mirrors ITEMs 6 & 7: extended the tasks.md helper to return both `### Type` AND `### Files in scope`, added an `isDocsExemptAllowed()` check that mirrors the orchestrator's `docsExemptForward` discriminator (`gateContractFor(type).rcdEmptyTrap === false` OR visual-only Storybook scope), wired into all three record sites. Direct CLI bypass on `tdd-code` errors with an operator-facing message.

9. **`fix(tdd-phase-state): close --docs-exempt no-task bypass (legacy compat shim)`** (`8e37bf5f3`) — Cursor[bot] caught the legacy compat shim I added in commit `063827177`: `isDocsExemptAllowed` returned `allowed: true` whenever `taskNum` was missing, so a tokened agent could omit `--task`, pass `--docs-exempt`, and relax the RED file guard or RC-D trap on a `tdd-code` task. The shim is removed — missing `--task` now fails closed with an operator-facing message. The orchestrator always passes `--task` so no production caller is affected; test fixtures were updated to pass `--task 1`.

## Test plan

- [x] `pnpm test` — 4856 tests, 4854 pass (2 unrelated failures: `maestro-autorestart.test.js`, `synapsys-explain.test.js`)
- [x] `pnpm quality` — exit 0; no new allowlist entries
- [x] Pass D unit tests — every per-Type branch covered
- [x] Pass D CLI E2E — spawn-based test exercises SKILL.md Step 5 invocation
- [x] `record-skip-red` contract — happy path + empty-reason rejection + wrong-phase rejection
- [x] tests-only RED→GREEN→REFACTOR E2E — skip-RED marker persisted, GREEN requires in-scope test modification
- [x] protect-task-scope per-Type allowlist — every closed-allowlist Type covered positive + negative
- [x] Type-line edit guard — Write / Edit blocked; one-shot env bypass preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication-adjacent enforcement (TDD phase recording, scope hooks, operator tokens) across the implement workflow; regressions could block legitimate tasks or allow evidence bypass.
> 
> **Overview**
> **GH-528** hardens the closed `### Type` taxonomy end-to-end so implementer agents can’t bypass TDD with body prose, env bypass, or direct CLI flags.
> 
> **`task-next.js`** now routes RED/GREEN/REFACTOR through `gateContractFor()` (including contract-driven RED fallback when no `*.test.*` surface), adds a **tests-only** path (`record-skip-red`, GREEN requires in-scope test edits via glob-aware `filterChangedTestFilesByScope`), and limits docs-exempt forwarding to contract/visual-only types. **`isDocsExempt`** is **`Type === 'docs'` only** (no AC phrase bypass).
> 
> **`tdd-phase-state.js`** adds **`record-skip-red`**, gates **`--docs-exempt`** and **`--red-skip-file-guard`** on on-disk `tasks.md` Type/scope (with **`--task` required** for docs-exempt), restricts **`exception`** to **`WORK_OPERATOR_TOKEN=1`**, and errors on bare CLI invocation.
> 
> **`protect-task-scope.js`** enforces per-Type write allowlists (`tests-only`, `docs`, `config`, `ci`), blocks mid-implement **`### Type`** edits (simulated patch checks), and requires **`WORK_OPERATOR_TOKEN`** for env bypass (auditing **`scope-bypass-rejected`** when missing).
> 
> Large integration/unit test suites cover these paths; **`emit-warnings`** purity test now allows **`process.exit`** only behind **`require.main === module`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e37bf5f329be974265fa294e097a98b28716a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




