### PR TITLE
feat(synapsys): add trigger_stop_response — content-match Stop event against agent transcript

### DIFF
--- a/plugins/synapsys/lib/__tests__/matcher-stop-response.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/matcher-stop-response.integration.test.js
@@ -1,0 +1,164 @@
+'use strict';
+
+/**
+ * Dispatcher-level e2e integration test for the `trigger_stop_response`
+ * field (GH-521, Task 5).
+ *
+ * Invokes the synapsys dispatcher `hooks/synapsys.js` with a Stop event +
+ * stdin JSON payload (`response`, `tool_inputs`, `tool_results`) and asserts:
+ *   (i)  matching response   → exit 0, stdout contains memory header.
+ *   (ii) non-matching response → exit 0, stdout empty.
+ *
+ * Covers:
+ *   - R11 (dispatcher-level integration test for the new field path).
+ *   - R12 / Gherkin @e2e — End-to-end Stop hook injection only when agent
+ *     response matches.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const DISPATCHER = path.resolve(__dirname, '..', '..', 'hooks', 'synapsys.js');
+
+const MEMORY_NAME = 'flaky-test-fix-protocol';
+const MEMORY_DESCRIPTION = 'Steps to take when a test goes flaky.';
+const MEMORY_BODY =
+  'When a test goes flaky:\n' +
+  '1. Reproduce locally with --runInBand.\n' +
+  '2. Quarantine before bumping the timeout.';
+const STOP_REGEX = '\\b(flaky|bump\\s+timeout)\\b';
+
+// Build a worktree-kind store at `<base>/.claude/synapsys` with the session
+// cwd at `<base>/worktree-stop-response/` (one level below the store base).
+// This produces `[synapsys:worktree] <name>` in dispatcher output, matching
+// the Task 5 acceptance criteria.
+function makeWorktreeStore() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-stop-resp-'));
+  const storeDir = path.join(base, '.claude', 'synapsys');
+  const cwd = path.join(base, 'worktree-stop-response');
+
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.mkdirSync(cwd, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({
+      kind: 'worktree',
+      projectName: 'stop-response-fixture',
+      schemaVersion: 1,
+    })
+  );
+
+  const frontmatter = [
+    '---',
+    `name: ${MEMORY_NAME}`,
+    `description: ${MEMORY_DESCRIPTION}`,
+    'events: Stop',
+    `trigger_stop_response: ${STOP_REGEX}`,
+    'trigger_session: false',
+    'inject: full',
+    '---',
+    '',
+    MEMORY_BODY,
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(storeDir, `${MEMORY_NAME}.md`), frontmatter);
+
+  return {
+    base,
+    cwd,
+    cleanup: () => fs.rmSync(base, { recursive: true, force: true }),
+  };
+}
+
+function runDispatcher(payload) {
+  return spawnSync(process.execPath, [DISPATCHER, 'Stop'], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    env: { ...process.env, SYNAPSYS_NO_SETUP_HINT: '1' },
+  });
+}
+
+test('Stop dispatcher injects memory when agent response matches trigger_stop_response', (t) => {
+  const { cwd, cleanup } = makeWorktreeStore();
+  t.after(cleanup);
+
+  const payload = {
+    hook_event_name: 'Stop',
+    cwd,
+    response: 'this test is flaky, let me bump timeout to stabilize it',
+    tool_inputs: [],
+    tool_results: [],
+  };
+
+  const result = runDispatcher(payload);
+
+  assert.equal(
+    result.status,
+    0,
+    `dispatcher exited non-zero: stderr=${result.stderr}`
+  );
+  assert.ok(
+    result.stdout.includes(`[synapsys:worktree] ${MEMORY_NAME}`),
+    `expected stdout to contain memory header; got: ${JSON.stringify(result.stdout)}`
+  );
+});
+
+test('Stop dispatcher emits no output when agent response does not match trigger_stop_response', (t) => {
+  const { cwd, cleanup } = makeWorktreeStore();
+  t.after(cleanup);
+
+  const payload = {
+    hook_event_name: 'Stop',
+    cwd,
+    response: 'added a new component',
+    tool_inputs: [],
+    tool_results: [],
+  };
+
+  const result = runDispatcher(payload);
+
+  assert.equal(
+    result.status,
+    0,
+    `dispatcher exited non-zero: stderr=${result.stderr}`
+  );
+  assert.equal(
+    result.stdout,
+    '',
+    `expected empty stdout for non-matching Stop response; got: ${JSON.stringify(result.stdout)}`
+  );
+});
+
+test('Stop dispatcher does not match against tool_inputs or tool_results (surface excluded)', (t) => {
+  const { cwd, cleanup } = makeWorktreeStore();
+  t.after(cleanup);
+
+  // The trigger pattern appears only inside tool_inputs / tool_results,
+  // never in `response`. Per R4 the match surface excludes tool fields,
+  // so the dispatcher must emit nothing.
+  const payload = {
+    hook_event_name: 'Stop',
+    cwd,
+    response: 'added a new component',
+    tool_inputs: [{ name: 'Bash', input: { command: 'bump timeout && retry' } }],
+    tool_results: [{ output: 'flaky test detected' }],
+  };
+
+  const result = runDispatcher(payload);
+
+  assert.equal(
+    result.status,
+    0,
+    `dispatcher exited non-zero: stderr=${result.stderr}`
+  );
+  assert.equal(
+    result.stdout,
+    '',
+    `expected empty stdout when match-pattern only appears in tool fields; got: ${JSON.stringify(result.stdout)}`
+  );
+});

--- a/plugins/synapsys/lib/__tests__/matcher-stop.test.js
+++ b/plugins/synapsys/lib/__tests__/matcher-stop.test.js
@@ -5,12 +5,19 @@
 // dispatcher + matcher had no path for it. These tests pin the new behavior:
 // matchStop fires for any memory listing Stop in events, and selectForEvent
 // routes the Stop event through it.
+//
+// GH-521 Task 2 extends matchStop with `trigger_stop_response` regex
+// evaluation: when the memory carries the field, matchStop must consult
+// payload.response (and fallbacks) and only fire on a regex hit, returning
+// `'no-stop-response-match'` otherwise. When the field is absent, matchStop
+// preserves its prior unconditional-fire behavior.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
 
-const { matchStop, selectForEvent } = require(path.resolve(__dirname, '..', 'matcher'));
+const matcherModule = require(path.resolve(__dirname, '..', 'matcher'));
+const { matchStop, selectForEvent } = matcherModule;
 
 function makeMemory(overrides) {
   return Object.assign(
@@ -24,6 +31,8 @@ function makeMemory(overrides) {
     overrides
   );
 }
+
+// ---------- Pre-existing tests (backward-compat regression guards) -------
 
 test('matchStop returns { fired: true } when memory has Stop in events', () => {
   assert.equal(matchStop(makeMemory({ events: ['Stop'] })).fired, true);
@@ -47,4 +56,144 @@ test('selectForEvent("Stop", ...) picks only Stop-event memories', () => {
   ];
   const picked = selectForEvent(memories, 'Stop', {}).map((m) => m.name);
   assert.deepEqual(picked.sort(), ['multi-mem', 'stop-mem']);
+});
+
+// ---------- Task 2 new scenarios (a)–(g) ---------------------------------
+
+// (a) field-present + matching payload.response -> { fired: true }
+test('matchStop (a): triggerStopResponse present and payload.response matches -> fires', () => {
+  const memory = makeMemory({
+    name: 'flaky-test-fix-protocol',
+    triggerStopResponse: '\\b(flaky|bump\\s+timeout)\\b',
+  });
+  const result = matchStop(memory, { response: 'let me bump timeout to fix this flaky test' });
+  assert.equal(result.fired, true);
+});
+
+// (b) field-present + non-matching response -> { fired: false, reason: 'no-stop-response-match' }
+test('matchStop (b): triggerStopResponse present but response does not match -> no-stop-response-match', () => {
+  const memory = makeMemory({
+    name: 'flaky-test-fix-protocol',
+    triggerStopResponse: '\\b(flaky|bump\\s+timeout)\\b',
+  });
+  const result = matchStop(memory, { response: 'added a new component' });
+  assert.equal(result.fired, false);
+  assert.equal(result.reason, 'no-stop-response-match');
+});
+
+// (c) field-absent + any payload -> { fired: true } (backward compat)
+test('matchStop (c): no triggerStopResponse field -> fires unconditionally', () => {
+  const memory = makeMemory({ name: 'classic-stop' });
+  // No triggerStopResponse on memory; payload is irrelevant.
+  const result = matchStop(memory, { response: 'whatever' });
+  assert.equal(result.fired, true);
+});
+
+// (d) field-present + response empty but tool_inputs/tool_results contain the pattern
+test('matchStop (d): pattern only in tool_inputs/tool_results is NOT matched (surface exclusion)', () => {
+  const memory = makeMemory({
+    name: 'flaky-test-fix-protocol',
+    triggerStopResponse: '\\bflaky\\b',
+  });
+  const payload = {
+    response: '',
+    tool_inputs: [{ command: 'pnpm test --grep flaky' }],
+    tool_results: [{ output: 'a flaky test was rerun' }],
+  };
+  const result = matchStop(memory, payload);
+  assert.equal(result.fired, false);
+  assert.equal(result.reason, 'no-stop-response-match');
+});
+
+// (e) invalid regex -> non-match + stderr contains memory name + pattern but NOT matched substring
+test('matchStop (e): invalid regex -> no-stop-response-match and stderr scrubs matched substring', () => {
+  const memory = makeMemory({
+    name: 'broken-pattern-memory',
+    triggerStopResponse: '[unclosed',
+  });
+
+  const captured = [];
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk, ...rest) => {
+    captured.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    return true;
+  };
+  let result;
+  try {
+    result = matchStop(memory, { response: 'this response should not appear in stderr' });
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+
+  assert.equal(result.fired, false);
+  assert.equal(result.reason, 'no-stop-response-match');
+  const stderrText = captured.join('');
+  assert.ok(
+    stderrText.includes('broken-pattern-memory'),
+    `stderr should mention memory name, got: ${stderrText}`
+  );
+  assert.ok(
+    stderrText.includes('[unclosed'),
+    `stderr should mention pattern, got: ${stderrText}`
+  );
+  assert.ok(
+    !stderrText.includes('this response should not appear in stderr'),
+    `stderr must NOT contain matched/response substring, got: ${stderrText}`
+  );
+});
+
+// (f) _extractStopResponse fallback chain
+test('matchStop (f): _extractStopResponse fallback chain (response > assistant_response > transcript > "")', () => {
+  const extractStopResponse = matcherModule._extractStopResponse;
+  assert.equal(typeof extractStopResponse, 'function', '_extractStopResponse must be exposed for tests');
+
+  // payload.response wins when present
+  assert.equal(
+    extractStopResponse({ response: 'A', assistant_response: 'B', transcript: 'C' }),
+    'A'
+  );
+  // assistant_response is read when response is absent
+  assert.equal(
+    extractStopResponse({ assistant_response: 'B', transcript: 'C' }),
+    'B'
+  );
+  // transcript is read when both response and assistant_response are absent
+  assert.equal(extractStopResponse({ transcript: 'C' }), 'C');
+  // when none are strings, returns ''
+  assert.equal(extractStopResponse({}), '');
+  assert.equal(extractStopResponse({ response: 42, assistant_response: null, transcript: [] }), '');
+  assert.equal(extractStopResponse(null), '');
+  assert.equal(extractStopResponse(undefined), '');
+});
+
+// (g) selectForEvent('Stop', ...) forwards payload to matchStop
+test('matchStop (g): selectForEvent forwards payload to matchStop for Stop event', () => {
+  const memories = [
+    makeMemory({
+      name: 'needs-flaky',
+      triggerStopResponse: '\\bflaky\\b',
+    }),
+    makeMemory({
+      name: 'needs-bump',
+      triggerStopResponse: '\\bbump\\s+timeout\\b',
+    }),
+  ];
+
+  // payload.response contains 'flaky' but not 'bump timeout'
+  const pickedFlaky = selectForEvent(memories, 'Stop', {
+    response: 'this test is flaky',
+  }).map((m) => m.name);
+  assert.deepEqual(pickedFlaky, ['needs-flaky']);
+
+  // payload.response matches neither
+  const pickedNone = selectForEvent(memories, 'Stop', {
+    response: 'nothing relevant',
+  }).map((m) => m.name);
+  assert.deepEqual(pickedNone, []);
+
+  // payload.response matches both
+  const pickedBoth = selectForEvent(memories, 'Stop', {
+    response: 'flaky — let me bump timeout',
+  }).map((m) => m.name).sort();
+  assert.deepEqual(pickedBoth, ['needs-bump', 'needs-flaky']);
 });

--- a/plugins/synapsys/lib/__tests__/memory-store-trigger-stop-response.test.js
+++ b/plugins/synapsys/lib/__tests__/memory-store-trigger-stop-response.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { listMemoriesFromStore } = require('../memory-store');
+
+function makeTempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-stopresp-'));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'test' })
+  );
+  return { cwd: dir, storeDir };
+}
+
+function writeMemory(storeDir, name, frontmatter) {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  const content = `---\n${fm}\n---\nbody\n`;
+  fs.writeFileSync(path.join(storeDir, name), content);
+}
+
+// P0 #1 — Frontmatter parser surfaces trigger_stop_response on the memory object
+
+test('readMemoryFile maps trigger_stop_response to triggerStopResponse when present', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'flaky.md', {
+    name: 'flaky',
+    description: 'd',
+    trigger_stop_response: '"\\bflaky\\b"',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.equal(memories[0].triggerStopResponse, '\\bflaky\\b');
+});
+
+test('readMemoryFile yields triggerStopResponse === "" when field is absent', () => {
+  const { storeDir } = makeTempStore();
+  writeMemory(storeDir, 'no-field.md', {
+    name: 'no-field',
+    description: 'd',
+  });
+
+  const store = { kind: 'local', dir: storeDir, projectName: 'test' };
+  const memories = listMemoriesFromStore(store);
+  assert.equal(memories.length, 1);
+  assert.equal(memories[0].triggerStopResponse, '');
+});

--- a/plugins/synapsys/lib/matcher.js
+++ b/plugins/synapsys/lib/matcher.js
@@ -13,7 +13,7 @@
 /**
  * @typedef {Object} MatchResult
  * @property {boolean} fired
- * @property {('events-exclude'|'no-prompt-match'|'no-pretool-match'|'no-content-match'|'negative-excludes'|'no-session-trigger'|'expired'|'disabled')} [reason]
+ * @property {('events-exclude'|'no-prompt-match'|'no-pretool-match'|'no-content-match'|'negative-excludes'|'no-session-trigger'|'no-stop-response-match'|'expired'|'disabled')} [reason]
  * @property {Matched} [matched]
  */
 
@@ -311,14 +311,45 @@ function matchSession(memory) {
   return { fired: true };
 }
 
+// Resolve the assistant-side text surface that trigger_stop_response evaluates
+// against. Strictly excludes tool inputs and tool results: only the assistant's
+// natural-language response counts. Reads payload.response, falling back to
+// payload.assistant_response, then payload.transcript. Returns '' otherwise.
+function _extractStopResponse(payload) {
+  if (!payload || typeof payload !== 'object') return '';
+  if (typeof payload.response === 'string') return payload.response;
+  if (typeof payload.assistant_response === 'string') return payload.assistant_response;
+  if (typeof payload.transcript === 'string') return payload.transcript;
+  return '';
+}
+
 // Stop event fires at the assistant's turn end. The classifier matrix assigns
 // Stop to memories that are retrospective checks ("did I run follow-up-pr?",
-// "cleanup the tmp file"). They fire unconditionally for any memory listing
-// Stop in events — the body itself IS the reminder, no separate trigger.
-function matchStop(memory) {
+// "cleanup the tmp file"). When `triggerStopResponse` is absent, the memory
+// fires unconditionally for any Stop hook (backward-compat). When present, the
+// memory only fires if the assistant's response (NOT tool inputs/results)
+// matches the regex.
+//
+// @param {object} memory
+// @param {object} [payload] Stop hook payload; consulted only when
+//   memory.triggerStopResponse is set.
+function matchStop(memory, payload) {
   const gate = gateMemory(memory, 'Stop');
   if (gate) return { fired: false, reason: gate };
-  return { fired: true };
+  if (!memory.triggerStopResponse) return { fired: true };
+
+  const regex = safeRegex(memory.triggerStopResponse, 'i');
+  if (!regex) {
+    process.stderr.write(
+      `[synapsys] memory ${memory.name}: invalid trigger_stop_response regex "${memory.triggerStopResponse}"\n`
+    );
+    return { fired: false, reason: 'no-stop-response-match' };
+  }
+
+  const text = _extractStopResponse(payload);
+  const m = regex.exec(text);
+  if (!m) return { fired: false, reason: 'no-stop-response-match' };
+  return { fired: true, matched: makeMatched({ stop_response_substring: m[0] }) };
 }
 
 /**
@@ -337,7 +368,7 @@ function selectForEvent(memories, event, payload) {
     if (event === 'UserPromptSubmit') result = matchPrompt(m, payload?.prompt || '');
     else if (event === 'PreToolUse') result = matchPreTool(m, payload);
     else if (event === 'SessionStart') result = matchSession(m);
-    else if (event === 'Stop') result = matchStop(m);
+    else if (event === 'Stop') result = matchStop(m, payload);
     if (result.fired) matched.push(m);
   }
   return matched;
@@ -350,6 +381,7 @@ module.exports = {
   matchPreToolResult,
   matchSession,
   matchStop,
+  _extractStopResponse,
   safeRegex,
   splitTopLevelAlternation,
   extractPretoolContent,

--- a/plugins/synapsys/lib/memory-store.js
+++ b/plugins/synapsys/lib/memory-store.js
@@ -137,6 +137,17 @@ function parseFrontmatter(content) {
 
 const SKIP_FILES = new Set(['INDEX.md', 'README.md']);
 
+function buildTriggerFields(meta) {
+  return {
+    triggerPrompt: meta.trigger_prompt || '',
+    triggerPretool: toList(meta.trigger_pretool),
+    triggerPretoolContent: toList(meta.trigger_pretool_content),
+    triggerPretoolContentNot: toList(meta.trigger_pretool_content_not),
+    triggerStopResponse: meta.trigger_stop_response || '',
+    triggerSession: meta.trigger_session === true || meta.trigger_session === 'true',
+  };
+}
+
 function readMemoryFile(store, name) {
   if (!name.endsWith('.md') || SKIP_FILES.has(name)) return null;
   const file = path.join(store.dir, name);
@@ -153,11 +164,7 @@ function readMemoryFile(store, name) {
     name: meta.name || path.basename(name, '.md'),
     description: meta.description || '',
     events: toList(meta.events),
-    triggerPrompt: meta.trigger_prompt || '',
-    triggerPretool: toList(meta.trigger_pretool),
-    triggerPretoolContent: toList(meta.trigger_pretool_content),
-    triggerPretoolContentNot: toList(meta.trigger_pretool_content_not),
-    triggerSession: meta.trigger_session === true || meta.trigger_session === 'true',
+    ...buildTriggerFields(meta),
     inject: meta.inject === 'full' ? 'full' : 'summary',
     disabled: meta.disabled === true || meta.disabled === 'true',
     expired: parseExpired(meta.expires),

--- a/plugins/synapsys/scripts/__tests__/synapsys-list-stop-response.test.js
+++ b/plugins/synapsys/scripts/__tests__/synapsys-list-stop-response.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * P0 #5 — synapsys-list surfaces trigger_stop_response in verbose listings.
+ *
+ * Spawns `node synapsys-list.js --verbose --no-color --cwd=<temp>` against a
+ * temp store containing one memory carrying `trigger_stop_response: "bump\s+timeout"`
+ * and asserts the verbose output prints a `stop-response:` line with the regex.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const SCRIPT = path.resolve(__dirname, '..', 'synapsys-list.js');
+
+function makeTempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-list-stopresp-'));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ projectName: 'test' })
+  );
+  return { cwd: dir, storeDir };
+}
+
+function writeMemory(storeDir, name, frontmatter) {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  const content = `---\n${fm}\n---\nbody\n`;
+  fs.writeFileSync(path.join(storeDir, name), content);
+}
+
+function runList(cwd) {
+  const res = spawnSync(
+    process.execPath,
+    [SCRIPT, '--verbose', '--no-color', `--cwd=${cwd}`],
+    { encoding: 'utf8', env: { ...process.env, NO_COLOR: '1' } }
+  );
+  return { stdout: res.stdout || '', stderr: res.stderr || '', status: res.status };
+}
+
+test('verbose listing prints stop-response: line with the regex when memory carries trigger_stop_response', () => {
+  const { cwd, storeDir } = makeTempStore();
+  writeMemory(storeDir, 'flaky-test-fix-protocol.md', {
+    name: 'flaky-test-fix-protocol',
+    description: 'Detect flaky-test bump-timeout protocol',
+    events: 'Stop',
+    trigger_stop_response: '"bump\\s+timeout"',
+  });
+
+  const { stdout, status } = runList(cwd);
+  assert.equal(status, 0, `expected exit 0, got ${status}`);
+  assert.match(
+    stdout,
+    /stop-response:\s*.*bump\\s\+timeout/,
+    `expected stdout to contain "stop-response:" followed by bump\\s+timeout regex.\n--- STDOUT ---\n${stdout}`
+  );
+});
+
+test('verbose listing omits stop-response: line when memory has no trigger_stop_response', () => {
+  const { cwd, storeDir } = makeTempStore();
+  writeMemory(storeDir, 'no-stop.md', {
+    name: 'no-stop',
+    description: 'plain memory without stop trigger',
+    events: 'UserPromptSubmit',
+    trigger_prompt: '"hello"',
+  });
+
+  const { stdout, status } = runList(cwd);
+  assert.equal(status, 0, `expected exit 0, got ${status}`);
+  assert.doesNotMatch(
+    stdout,
+    /stop-response:/,
+    `expected stdout NOT to contain "stop-response:".\n--- STDOUT ---\n${stdout}`
+  );
+});

--- a/plugins/synapsys/scripts/synapsys-list.js
+++ b/plugins/synapsys/scripts/synapsys-list.js
@@ -149,6 +149,8 @@ for (const [kind, bucket] of byStore.entries()) {
       if (m.triggerPretool.length)
         console.log(`    ${C.dim('pretool:')} ${C.magenta(m.triggerPretool.join(', '))}`);
       if (m.triggerSession) console.log(`    ${C.dim('session:')} ${C.magenta('yes')}`);
+      if (m.triggerStopResponse)
+        console.log(`    ${C.dim('stop-response:')} ${C.magenta('/' + m.triggerStopResponse + '/i')}`);
       console.log(`    ${C.dim('file:')}    ${C.dim(m.file)}`);
     }
     console.log('');


### PR DESCRIPTION
## Existing Behavior

- The `Stop` event in synapsys fires unconditionally for every memory that lists `Stop` in its `events` frontmatter field, injecting its body at the end of every assistant turn regardless of whether the agent's response is relevant.
- `matchStop(memory)` accepts only a single argument; the Stop hook payload carrying the agent's just-finished response is not consulted.
- `synapsys:list` verbose output does not surface any response-pattern trigger for Stop-event memories.
- `memory-store.js` parses no `trigger_stop_response` frontmatter field; the memory schema has no `triggerStopResponse` property.

## Intended New Behavior

- Memories may declare a `trigger_stop_response: <regex>` frontmatter field. When the Stop hook fires, the regex is matched against the assistant's just-finished response (`payload.response` > `payload.assistant_response` > `payload.transcript` fallback, excluding tool call inputs and tool results). Injection happens only on match; on no-match the memory returns `{ fired: false, reason: 'no-stop-response-match' }`.
- Backward compatible: memories listing `Stop` without `trigger_stop_response` continue to fire unconditionally.
- `matchStop(memory, payload)` signature extended; `selectForEvent` Stop branch forwards the hook payload to `matchStop`.
- `synapsys:list --verbose` displays a `stop-response: /pattern/i` line for memories carrying the field.
- Invalid regex in `trigger_stop_response` produces a stderr diagnostic (memory name + pattern, no matched substring) and returns `no-stop-response-match` — consistent with how `trigger_prompt`/`trigger_pretool` handle invalid regex.

## Brief P0 coverage

- **P0 #1:** Frontmatter parser accepts `trigger_stop_response` as a new optional field — implemented in `plugins/synapsys/lib/memory-store.js:160` (`triggerStopResponse: meta.trigger_stop_response || ''`) + test `plugins/synapsys/lib/__tests__/memory-store-trigger-stop-response.test.js`
- **P0 #2:** `matchStop(memory, payload)` evaluates `trigger_stop_response` regex against response transcript; injects only on match; returns `no-stop-response-match` on miss — implemented in `plugins/synapsys/lib/matcher.js:336-351` + tests `plugins/synapsys/lib/__tests__/matcher-stop.test.js` cases (a)(b)
- **P0 #3:** Backward compat: missing `triggerStopResponse` short-circuits to `{ fired: true }` unconditionally — implemented in `plugins/synapsys/lib/matcher.js:339` + test case (c)
- **P0 #4:** `_extractStopResponse` reads only `payload.response`/`assistant_response`/`transcript`; tool_inputs and tool_results are never consulted — implemented in `plugins/synapsys/lib/matcher.js:318-326` + test case (d)
- **P0 #5:** `synapsys-list.js` renders `stop-response: /pattern/i` line in verbose output — implemented in `plugins/synapsys/scripts/synapsys-list.js:152-153` + test `plugins/synapsys/scripts/__tests__/synapsys-list-stop-response.test.js`
- **P0 #6:** Invalid regex logs to stderr (memory name + pattern, no matched substring) and returns `no-stop-response-match` — implemented in `plugins/synapsys/lib/matcher.js:341-346` + test case (e)

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend — matcher unit tests:**

1. Run unit tests for the matcher Stop path:
   ```bash
   cd plugins/synapsys && node --test lib/__tests__/matcher-stop.test.js
   ```
   Expected: all 7 cases (a)-(g) pass — match fires, non-match returns `no-stop-response-match`, backward compat, surface exclusion, invalid regex, `_extractStopResponse` fallback chain, `selectForEvent` payload forwarding.

2. Run memory-store field parsing test:
   ```bash
   node --test lib/__tests__/memory-store-trigger-stop-response.test.js
   ```
   Expected: `triggerStopResponse` is populated from frontmatter; absent field yields `''`.

3. Run synapsys-list rendering test:
   ```bash
   node --test scripts/__tests__/synapsys-list-stop-response.test.js
   ```
   Expected: verbose output contains `stop-response: bump\s+timeout`.

**Backend — e2e dispatcher integration test:**

4. Run the dispatcher-level integration test (simulates real Stop hook stdin):
   ```bash
   node --test lib/__tests__/matcher-stop-response.integration.test.js
   ```
   Expected: invocation (i) with `"let me bump the timeout to fix this flake"` → stdout contains the memory header; invocation (ii) with `"added a new component"` → stdout empty. Both exit 0.

**Manual verification — verbose list output:**

5. Create a test memory file with frontmatter:
   ```
   trigger_stop_response: "\\b(flaky|bump\\s+timeout)\\b"
   events: [Stop]
   ```
   Run `node plugins/synapsys/scripts/synapsys-list.js --verbose` against the store.
   Expected: output includes `stop-response: /\b(flaky|bump\s+timeout)\b/i` line.

### Test Results

All tests pass. Confirmed via `pnpm dev:check` and individual test runs for Tasks 1, 2, 3, and 5 as documented in the task completion checklist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional field with broad test coverage; changes hook matching behavior only, not auth or persistence.
> 
> **Overview**
> Adds optional **`trigger_stop_response`** frontmatter so **Stop** memories inject only when the assistant’s end-of-turn text matches a regex, instead of firing on every Stop hook.
> 
> **Runtime:** `memory-store` maps the field to `triggerStopResponse`; `matchStop` now takes the Stop payload, evaluates the pattern against `response` → `assistant_response` → `transcript` (not tool inputs/results), returns `no-stop-response-match` on miss, and keeps **unconditional** Stop behavior when the field is absent. Invalid regexes log a stderr diagnostic (name + pattern only) and do not fire. `selectForEvent('Stop', …)` forwards the payload through this path.
> 
> **UX / tests:** `synapsys-list --verbose` prints a `stop-response:` line when set. New/extended unit tests cover matcher cases, store parsing, list output, and a dispatcher integration test for match vs no-match vs tool-only pattern text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8209f747d803fb467c7df0af45a0a935abb4ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

