### PR TITLE
feat(scope): reject duplicate Files-in-scope peer ownership (GH-515)

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/task-scope.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/task-scope.test.js
@@ -131,7 +131,7 @@ describe('validateCrossTaskDepsOwnership', () => {
     assert.match(errors[0], /no other task lists it in/);
   });
 
-  it('accepts a crossTaskDep that literally appears in another task\'s scope', () => {
+  it("accepts a crossTaskDep that literally appears in another task's scope", () => {
     const tasks = [
       { num: 1, filesInScope: ['src/a.ts'], crossTaskDeps: ['src/shared/schema.ts'] },
       { num: 2, filesInScope: ['src/shared/schema.ts', 'src/b.ts'] },
@@ -139,7 +139,7 @@ describe('validateCrossTaskDepsOwnership', () => {
     assert.deepEqual(ts.validateCrossTaskDepsOwnership(tasks), []);
   });
 
-  it('accepts a crossTaskDep covered by another task\'s glob scope', () => {
+  it("accepts a crossTaskDep covered by another task's glob scope", () => {
     const tasks = [
       { num: 1, filesInScope: ['src/a.ts'], crossTaskDeps: ['src/shared/schema.ts'] },
       { num: 2, filesInScope: ['src/shared/**'] },
@@ -754,5 +754,97 @@ describe('findTask', () => {
   it('returns null for bad input', () => {
     assert.equal(ts.findTask(null, 1), null);
     assert.equal(ts.findTask([{ num: 1 }], 'nope'), null);
+  });
+});
+
+describe('validateIntraTicketScope joint in-scope ownership (GH-515)', () => {
+  it('rejects two peer tasks listing the same literal path under Files in scope', () => {
+    const result = ts.validateAll([
+      { num: 1, filesInScope: ['components/X.tsx'], filesOutOfScope: [] },
+      { num: 2, filesInScope: ['components/X.tsx'], filesOutOfScope: [] },
+    ]);
+    assert.equal(result.valid, false);
+    const jointErrors = result.errors.filter((e) => /joint ownership/i.test(e));
+    assert.equal(
+      jointErrors.length,
+      1,
+      `expected exactly one joint-ownership error, got: ${result.errors.join(' | ')}`
+    );
+    const err = jointErrors[0];
+    assert.match(err, /components\/X\.tsx/);
+    assert.match(err, /Task 1/);
+    assert.match(err, /Task 2/);
+    assert.match(err, /scope-sections\.md/);
+  });
+
+  it('rejects glob-vs-literal symmetric overlap with exactly one joint-ownership error', () => {
+    const result = ts.validateAll([
+      { num: 1, filesInScope: ['lib/foo/**'], filesOutOfScope: [] },
+      { num: 2, filesInScope: ['lib/foo/bar.ts'], filesOutOfScope: [] },
+    ]);
+    assert.equal(result.valid, false);
+    const jointErrors = result.errors.filter((e) => /joint ownership/i.test(e));
+    assert.equal(
+      jointErrors.length,
+      1,
+      `expected exactly one joint-ownership error, got: ${result.errors.join(' | ')}`
+    );
+    const err = jointErrors[0];
+    assert.match(err, /Task 1/);
+    assert.match(err, /Task 2/);
+    assert.ok(
+      /lib\/foo\/\*\*/.test(err) || /lib\/foo\/bar\.ts/.test(err),
+      `error should mention one of the overlapping entries; got: ${err}`
+    );
+  });
+
+  it('three peer tasks all list the same path under Files in scope', () => {
+    const result = ts.validateAll([
+      { num: 1, filesInScope: ['lib/shared.ts'], filesOutOfScope: [] },
+      { num: 2, filesInScope: ['lib/shared.ts'], filesOutOfScope: [] },
+      { num: 3, filesInScope: ['lib/shared.ts'], filesOutOfScope: [] },
+    ]);
+    assert.equal(result.valid, false);
+    const jointErrors = result.errors.filter((e) => /joint ownership/i.test(e));
+    assert.equal(
+      jointErrors.length,
+      3,
+      `expected C(3,2)=3 joint-ownership errors, got: ${result.errors.join(' | ')}`
+    );
+    for (const e of jointErrors) {
+      assert.match(e, /lib\/shared\.ts/);
+    }
+  });
+
+  it('single-owner-per-path shape produces zero joint-ownership false positives', () => {
+    const result = ts.validateAll([
+      { num: 1, filesInScope: ['a.ts'], filesOutOfScope: [] },
+      { num: 2, filesInScope: ['b.ts'], filesOutOfScope: ['a.ts'] },
+    ]);
+    const jointErrors = result.errors.filter((e) => /joint ownership/i.test(e));
+    assert.equal(jointErrors.length, 0, `unexpected joint errors: ${jointErrors.join(' | ')}`);
+  });
+
+  it('cross-ticket sibling-owned in-scope paths do not conflict across tickets', () => {
+    // Validator operates ONLY on the tasks array argument it receives.
+    // A path owned by a sibling ticket's task must NOT trigger a joint-ownership
+    // error here, because that sibling task is not in the passed array.
+    const ticketATasks = [
+      { num: 1, filesInScope: ['ticketA/only.ts'], filesOutOfScope: [] },
+      { num: 2, filesInScope: ['ticketA/other.ts'], filesOutOfScope: [] },
+    ];
+    const result = ts.validateAll(ticketATasks);
+    const jointErrors = result.errors.filter((e) => /joint ownership/i.test(e));
+    assert.equal(
+      jointErrors.length,
+      0,
+      `validator must not reach across tickets; got: ${jointErrors.join(' | ')}`
+    );
+    // Even if a sibling ticket also owns one of the same paths, the validator
+    // run on ticketA alone must not emit a joint-ownership error for it.
+    const ticketBTasks = [{ num: 1, filesInScope: ['ticketA/only.ts'], filesOutOfScope: [] }];
+    const isolated = ts.validateAll(ticketBTasks);
+    const isolatedJoint = isolated.errors.filter((e) => /joint ownership/i.test(e));
+    assert.equal(isolatedJoint.length, 0);
   });
 });

--- a/plugins/work/scripts/workflows/work/__tests__/tasks-gate-intra-ticket.integration.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/tasks-gate-intra-ticket.integration.test.js
@@ -77,9 +77,109 @@ CHANGED_FILES="components/X.test.tsx" eval "$TEST_UNIT_COMMAND"
 \`\`\`
 `;
 
+// Joint in-scope ownership fixture: both Task 1 and Task 2 list the SAME
+// `components/X.tsx` path under `### Files in scope` (no cross-section
+// out-of-scope reference). This exercises the joint-ownership branch of
+// validateIntraTicketScope (Task 1 of GH-515) and the tasks-gate routing
+// regression for it (Task 3 — this test file).
+const JOINT_OWNERSHIP_TASKS_MD = `# Tasks (hand-crafted invalid for joint in-scope ownership)
+
+## Task 1 — Build component X (variant A)
+
+### Type
+fullstack
+
+### Files in scope
+- \`components/X.tsx\`
+
+### Deliverables
+- [ ] 1.1 **GREEN:** render X
+  - Test: \`<X />\` renders
+
+### Test Command
+\`\`\`bash
+CHANGED_FILES="components/X.test.tsx" eval "$TEST_UNIT_COMMAND"
+\`\`\`
+
+---
+
+## Task 2 — Build component X (variant B)
+
+### Type
+fullstack
+
+### Files in scope
+- \`components/X.tsx\`
+
+### Deliverables
+- [ ] 2.1 **GREEN:** wire X variant B
+  - Test: \`<X variant="b" />\` renders
+
+### Test Command
+\`\`\`bash
+CHANGED_FILES="components/X.test.tsx" eval "$TEST_UNIT_COMMAND"
+\`\`\`
+`;
+
 describe('tasks-gate intra-ticket scope routing', () => {
   beforeEach(() => setup());
   afterEach(() => teardown());
+
+  it('tasks-gate hard-fails and routes to split-in-tasks on joint ownership', () => {
+    // Task 3 RED — proves that when two peer tasks both list the same path
+    // under `### Files in scope` (joint in-scope ownership, not cross-section
+    // overlap), tasks-gate routes RUN /work-workflow:split-in-tasks with the
+    // conflicting path AND both task numbers surfaced in the routing `reason`.
+    fs.writeFileSync(path.join(tmpDir, 'tasks.md'), JOINT_OWNERSHIP_TASKS_MD, 'utf8');
+
+    const tasksGateStep = require('../steps/tasks-gate');
+    const STEPS = { tasks_gate: 'tasks_gate' };
+    const calls = [];
+    const add = (step, decision, agent, reason, opts) =>
+      calls.push({ step, decision, agent, reason, opts });
+
+    tasksGateStep(
+      add,
+      { hasTasks: true },
+      {
+        STEPS,
+        tasksDir: tmpDir,
+        path,
+      }
+    );
+
+    assert.equal(calls.length, 1, `expected exactly one add() call; got ${JSON.stringify(calls)}`);
+    const [c] = calls;
+    assert.equal(c.step, 'tasks_gate');
+    assert.equal(
+      c.decision,
+      'RUN',
+      `gate must RUN split-in-tasks on joint ownership, not DEFER; got ${JSON.stringify(c)}`
+    );
+    assert.equal(c.agent, '/work-workflow:split-in-tasks');
+    assert.match(
+      c.reason,
+      /components\/X\.tsx/,
+      `RUN reason must surface the joint-ownership conflicting file path; got: ${c.reason}`
+    );
+    assert.match(
+      c.reason,
+      /\bTask\s*1\b/i,
+      `RUN reason must reference Task 1 as a joint owner; got: ${c.reason}`
+    );
+    assert.match(
+      c.reason,
+      /\bTask\s*2\b/i,
+      `RUN reason must reference Task 2 as a joint owner; got: ${c.reason}`
+    );
+    // Confirm this is the joint-ownership branch (not a cross-section error)
+    // by matching the joint-ownership marker emitted by validateIntraTicketScope.
+    assert.match(
+      c.reason,
+      /joint|both list|in scope/i,
+      `RUN reason must indicate the joint in-scope ownership error class; got: ${c.reason}`
+    );
+  });
 
   it('tasksGateStep (real step function) routes to RUN split-in-tasks with intra-ticket error', () => {
     // Drives the actual `tasksGateStep` function the workflow engine invokes
@@ -94,16 +194,24 @@ describe('tasks-gate intra-ticket scope routing', () => {
     const add = (step, decision, agent, reason, opts) =>
       calls.push({ step, decision, agent, reason, opts });
 
-    tasksGateStep(add, { hasTasks: true }, {
-      STEPS,
-      tasksDir: tmpDir,
-      path,
-    });
+    tasksGateStep(
+      add,
+      { hasTasks: true },
+      {
+        STEPS,
+        tasksDir: tmpDir,
+        path,
+      }
+    );
 
     assert.equal(calls.length, 1, `expected exactly one add() call; got ${JSON.stringify(calls)}`);
     const [c] = calls;
     assert.equal(c.step, 'tasks_gate');
-    assert.equal(c.decision, 'RUN', `gate must RUN split-in-tasks, not DEFER; got ${JSON.stringify(c)}`);
+    assert.equal(
+      c.decision,
+      'RUN',
+      `gate must RUN split-in-tasks, not DEFER; got ${JSON.stringify(c)}`
+    );
     assert.equal(c.agent, '/work-workflow:split-in-tasks');
     assert.match(
       c.reason,

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/intra-ticket-scope-conflict/tasks.dup-in-scope.glob.md
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/intra-ticket-scope-conflict/tasks.dup-in-scope.glob.md
@@ -1,0 +1,39 @@
+# Tasks (intra-ticket joint in-scope ownership fixture — dup-in-scope glob+literal)
+
+_Invalid fixture: Task 1 owns `lib/foo/**` (glob) and Task 2 owns `lib/foo/bar.ts` (literal) under `### Files in scope`. The glob covers the literal — the intra-ticket validator must flag exactly one joint-ownership conflict._
+
+## Task 1 — Own lib/foo glob
+
+### Type
+wiring
+
+### Files in scope
+- `lib/foo/**`
+
+### Deliverables
+- [ ] 1.1 **GREEN:** populate lib/foo
+  - Test: lib/foo modules export expected symbols
+
+### Test Command
+```bash
+CHANGED_FILES="lib/foo/index.test.ts" eval "$TEST_UNIT_COMMAND"
+```
+
+---
+
+## Task 2 — Own lib/foo/bar.ts
+
+### Type
+wiring
+
+### Files in scope
+- `lib/foo/bar.ts`
+
+### Deliverables
+- [ ] 2.1 **GREEN:** implement bar
+  - Test: `bar()` returns expected value
+
+### Test Command
+```bash
+CHANGED_FILES="lib/foo/bar.test.ts" eval "$TEST_UNIT_COMMAND"
+```

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/intra-ticket-scope-conflict/tasks.dup-in-scope.md
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/intra-ticket-scope-conflict/tasks.dup-in-scope.md
@@ -1,0 +1,39 @@
+# Tasks (intra-ticket joint in-scope ownership fixture — dup-in-scope literal)
+
+_Invalid fixture: Task 1 and Task 2 both list the literal `components/X.tsx` under `### Files in scope`. The intra-ticket validator must flag this joint-ownership conflict._
+
+## Task 1 — Wire components/X.tsx variant A
+
+### Type
+wiring
+
+### Files in scope
+- `components/X.tsx`
+
+### Deliverables
+- [ ] 1.1 **GREEN:** render X variant A
+  - Test: `<X variant="a" />` renders
+
+### Test Command
+```bash
+CHANGED_FILES="components/X.test.tsx" eval "$TEST_UNIT_COMMAND"
+```
+
+---
+
+## Task 2 — Wire components/X.tsx variant B
+
+### Type
+wiring
+
+### Files in scope
+- `components/X.tsx`
+
+### Deliverables
+- [ ] 2.1 **GREEN:** render X variant B
+  - Test: `<X variant="b" />` renders
+
+### Test Command
+```bash
+CHANGED_FILES="components/X.test.tsx" eval "$TEST_UNIT_COMMAND"
+```

--- a/plugins/work/skills/split-in-tasks/__tests__/intra-ticket-scope.integration.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/intra-ticket-scope.integration.test.js
@@ -1,5 +1,6 @@
 /**
- * Integration tests for `validateIntraTicketScope` (Task 1 of GH-485).
+ * Integration tests for `validateIntraTicketScope` (Task 1 of GH-485,
+ * extended in GH-515 for joint in-scope ownership).
  *
  * Scenarios covered (verbatim titles required by task-next.js RED gate):
  *   - validator rejects tasks.md where a file is in-scope for one task and
@@ -7,6 +8,18 @@
  *   - validator accepts tasks.md after intra-ticket conflict is removed
  *   - validator preserves cross-ticket sibling-owned out-of-scope semantics
  *   - glob in-scope entry conflicts with literal out-of-scope entry in a peer task
+ *
+ * GH-515 Task 2 — joint in-scope ownership scenarios:
+ *   - two peer tasks list the same literal path under Files in scope
+ *   - glob in-scope entry overlaps a literal in-scope entry in a peer task
+ *   - single owner per file remains valid (no regression)
+ *   - pre-existing intra-ticket cross-section conflict is still rejected
+ *
+ * Fixtures referenced:
+ *   - fixtures/intra-ticket-scope-conflict/tasks.md (ECHO-5538 cross-section)
+ *   - fixtures/intra-ticket-scope-conflict/tasks.fixed.md
+ *   - fixtures/intra-ticket-scope-conflict/tasks.dup-in-scope.md (NEW — GH-515)
+ *   - fixtures/intra-ticket-scope-conflict/tasks.dup-in-scope.glob.md (NEW — GH-515)
  *
  * Uses node:test + node:assert/strict (project convention — see
  * plugins/work/CLAUDE.md "Node built-in test runner").
@@ -236,6 +249,97 @@ describe('validateIntraTicketScope', () => {
       err,
       /\bTask\s*2\b/i,
       `error must name Task 2 (out-of-scope declarant); got: ${err}`
+    );
+  });
+});
+
+describe('joint in-scope ownership (GH-515 — dup-in-scope)', () => {
+  beforeEach(() => setup());
+  afterEach(() => teardown());
+
+  it('two peer tasks list the same literal path under Files in scope', () => {
+    const { validateIntraTicketScope } = require(TASK_SCOPE_PATH);
+    const tasks = parseFixture('tasks.dup-in-scope.md');
+    assert.ok(
+      Array.isArray(tasks) && tasks.length >= 2,
+      `dup-in-scope fixture must parse to >=2 tasks; got ${tasks && tasks.length}`
+    );
+    const errors = validateIntraTicketScope(tasks);
+    assert.ok(Array.isArray(errors), 'validator must return an array');
+    const jointErrors = errors.filter((e) => /joint ownership/i.test(e));
+    assert.ok(
+      jointErrors.length >= 1,
+      `expected at least one joint-ownership error; got: ${JSON.stringify(errors, null, 2)}`
+    );
+    const [err] = jointErrors;
+    assert.match(
+      err,
+      /components\/X\.tsx/,
+      `joint-ownership error must name the conflicting literal path; got: ${err}`
+    );
+    assert.match(err, /\bTask\s*1\b/i, `joint error must name Task 1; got: ${err}`);
+    assert.match(err, /\bTask\s*2\b/i, `joint error must name Task 2; got: ${err}`);
+    assert.match(err, /scope-sections\.md/, `joint error must cite scope-sections.md; got: ${err}`);
+  });
+
+  it('glob in-scope entry overlaps a literal in-scope entry in a peer task', () => {
+    const { validateIntraTicketScope } = require(TASK_SCOPE_PATH);
+    const tasks = parseFixture('tasks.dup-in-scope.glob.md');
+    assert.ok(
+      Array.isArray(tasks) && tasks.length >= 2,
+      `dup-in-scope.glob fixture must parse to >=2 tasks; got ${tasks && tasks.length}`
+    );
+    const errors = validateIntraTicketScope(tasks);
+    const jointErrors = errors.filter((e) => /joint ownership/i.test(e));
+    assert.equal(
+      jointErrors.length,
+      1,
+      `glob+literal joint-ownership must yield exactly one error; got ${jointErrors.length}: ${JSON.stringify(errors, null, 2)}`
+    );
+    const [err] = jointErrors;
+    assert.match(
+      err,
+      /lib\/foo\/(\*\*|bar\.ts)/,
+      `joint-ownership error must name one of the overlapping entries; got: ${err}`
+    );
+    assert.match(err, /\bTask\s*1\b/i, `joint error must name Task 1; got: ${err}`);
+    assert.match(err, /\bTask\s*2\b/i, `joint error must name Task 2; got: ${err}`);
+  });
+
+  it('single owner per file remains valid (no regression)', () => {
+    const { validateIntraTicketScope } = require(TASK_SCOPE_PATH);
+    const tasks = parseFixture('tasks.fixed.md');
+    const errors = validateIntraTicketScope(tasks);
+    assert.deepEqual(
+      errors,
+      [],
+      `single-owner fixture must produce zero intra-ticket errors (incl. joint-ownership); got: ${JSON.stringify(errors, null, 2)}`
+    );
+    const jointFalsePositives = errors.filter((e) => /joint ownership/i.test(e));
+    assert.deepEqual(
+      jointFalsePositives,
+      [],
+      `single-owner fixture must produce zero joint-ownership errors; got: ${JSON.stringify(jointFalsePositives, null, 2)}`
+    );
+  });
+
+  it('pre-existing intra-ticket cross-section conflict is still rejected', () => {
+    const { validateIntraTicketScope } = require(TASK_SCOPE_PATH);
+    const tasks = parseFixture('tasks.md');
+    const errors = validateIntraTicketScope(tasks);
+    const crossSectionErrors = errors.filter(
+      (e) => /\bFiles explicitly out of scope\b/.test(e) && !/joint ownership/i.test(e)
+    );
+    assert.equal(
+      crossSectionErrors.length,
+      3,
+      `ECHO-5538 cross-section fixture must still produce exactly 3 cross-section errors; got ${crossSectionErrors.length}: ${JSON.stringify(errors, null, 2)}`
+    );
+    const jointFalsePositives = errors.filter((e) => /joint ownership/i.test(e));
+    assert.deepEqual(
+      jointFalsePositives,
+      [],
+      `ECHO-5538 fixture must NOT produce joint-ownership false positives; got: ${JSON.stringify(jointFalsePositives, null, 2)}`
     );
   });
 });

--- a/plugins/work/skills/split-in-tasks/docs/__tests__/scope-sections-doc.test.js
+++ b/plugins/work/skills/split-in-tasks/docs/__tests__/scope-sections-doc.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DOC_PATH = path.join(__dirname, '..', 'scope-sections.md');
+
+function readDoc() {
+  return fs.readFileSync(DOC_PATH, 'utf8');
+}
+
+test('scope-sections.md mentions joint ownership (substring "joint")', () => {
+  const contents = readDoc();
+  assert.match(
+    contents,
+    /joint/i,
+    'expected scope-sections.md to mention "joint" (joint in-scope ownership worked example missing)'
+  );
+});
+
+test('scope-sections.md mentions duplicate failure mode (substring "duplicate")', () => {
+  const contents = readDoc();
+  assert.match(
+    contents,
+    /duplicate/i,
+    'expected scope-sections.md to mention "duplicate" (duplicate-in-scope worked example missing)'
+  );
+});
+
+test('scope-sections.md uses the canonical sample path components/X.tsx', () => {
+  const contents = readDoc();
+  assert.ok(
+    contents.includes('components/X.tsx'),
+    'expected scope-sections.md to reference the canonical sample path "components/X.tsx" in the worked example'
+  );
+});
+
+test('scope-sections.md has a heading mentioning both "Files in scope" and "duplicate" in the same section', () => {
+  const contents = readDoc();
+  const lines = contents.split('\n');
+
+  // Find headings (lines starting with #) and their section bodies.
+  const headingIndices = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^#{1,6}\s/.test(lines[i])) headingIndices.push(i);
+  }
+  headingIndices.push(lines.length); // sentinel
+
+  let found = false;
+  for (let h = 0; h < headingIndices.length - 1; h++) {
+    const headingLine = lines[headingIndices[h]];
+    const sectionBody = lines.slice(headingIndices[h], headingIndices[h + 1]).join('\n');
+    const headingMentionsBoth =
+      /Files in scope/i.test(headingLine) && /duplicate/i.test(headingLine);
+    const sectionMentionsBoth =
+      /Files in scope/i.test(sectionBody) && /duplicate/i.test(sectionBody);
+    if (headingMentionsBoth || sectionMentionsBoth) {
+      found = true;
+      break;
+    }
+  }
+
+  assert.ok(
+    found,
+    'expected a heading (or its section body) in scope-sections.md to mention both "Files in scope" and "duplicate"'
+  );
+});

--- a/plugins/work/skills/split-in-tasks/docs/scope-sections.md
+++ b/plugins/work/skills/split-in-tasks/docs/scope-sections.md
@@ -32,7 +32,37 @@ filesOutOfScope = siblingTicketOwnedFiles − ∪(otherTasks[*].filesInScope)
 
 That is: start from the surfaces owned by **other tickets** (sibling-ticket boundary), then subtract every path that any peer task within the **same ticket** lists under `### Files in scope`. The remainder is what may appear under `### Files explicitly out of scope`. The `validateIntraTicketScope` validator in `plugins/work/scripts/workflows/lib/task-scope.js` enforces this and hard-fails `tasks-gate` on any violation.
 
-**Worked example (ECHO-5538 four-task shape):** Task 3 owns `components/X.tsx` under its `### Files in scope`. Tasks 1, 2, and 4 — peers within the same ticket — MUST NOT list `components/X.tsx` under ANY scope section (neither `### Files in scope` nor `### Files explicitly out of scope`). The exclusion list is reserved for files owned by other tickets entirely.
+**Worked example (ECHO-5538 four-task shape):** Task 3 owns `components/X.tsx` under its `### Files in scope`. Tasks 1, 2, and 4 — peers within the same ticket — MUST NOT list `components/X.tsx` under ANY scope section (neither `### Files in scope` nor `### Files explicitly out of scope`). The exclusion list is reserved for files owned by other tickets entirely. See also: the [duplicate Files-in-scope worked example](#intra-ticket-joint-in-scope-ownership-duplicate-files-in-scope-also-hard-failed) below for the symmetric failure mode where two peers each list the same path.
+
+## Intra-ticket joint in-scope ownership (duplicate Files in scope — also hard-failed)
+
+The exclusion rule above covers the case where Task A lists Task B's owned file under `### Files explicitly out of scope`. The symmetric failure mode is **duplicate joint ownership**: two (or more) peer tasks within the same ticket each list the **same** path under their own `### Files in scope` sections. This is also a structural error and is hard-failed by `validateIntraTicketScope` in `plugins/work/scripts/workflows/lib/task-scope.js`.
+
+**Worked example (duplicate-in-scope shape):** Suppose `tasks.md` declares:
+
+```markdown
+## Task 1 — Add header
+
+### Files in scope
+- `components/X.tsx`
+
+## Task 2 — Add footer
+
+### Files in scope
+- `components/X.tsx`
+```
+
+Both Task 1 and Task 2 list `components/X.tsx` under `### Files in scope`. `validateIntraTicketScope` walks every unordered peer pair `(i, j)` with `i < j` and emits **exactly one error per unordered peer pair** naming both task numbers and the shared path:
+
+```
+Tasks 1 and 2 both list `components/X.tsx` under `### Files in scope`
+(see plugins/work/skills/split-in-tasks/docs/scope-sections.md
+ § "Intra-ticket joint in-scope ownership"). Exactly one peer task may own a path.
+```
+
+If three peers (Tasks 1, 2, and 3) all duplicate the same path, the validator emits three errors — one per unordered pair `(1,2)`, `(1,3)`, `(2,3)` — never more, never fewer. The error message cites this very doc section so the author can read the rule alongside the failure.
+
+**How to fix:** pick exactly one task to own the path under `### Files in scope` and remove the duplicate entries from the other peers. Peers needing to coordinate around a single file should sequence their work via dependencies, not via co-ownership.
 
 ## Unique-ownership rule (hard-failed at `tasks-gate`)
 


### PR DESCRIPTION
## Existing Behavior

- `validateIntraTicketScope` rejects cross-section violations (a file in `### Files in scope` for Task A appearing under `### Files explicitly out of scope` for Task B) but does NOT reject the case where the same path appears under `### Files in scope` of two or more peer tasks.
- A `tasks.md` with joint in-scope ownership (e.g. two peer tasks both listing `components/X.tsx` under their own `### Files in scope`) silently passes `tasks-gate`, creating an undetected structural invariant violation.
- `scope-sections.md` documents only the ECHO-5538 cross-section shape without a worked example for the symmetric duplicate-in-scope failure mode.

## Intended New Behavior

- `validateIntraTicketScope` now detects joint in-scope ownership: any path appearing under `### Files in scope` of two or more peer tasks within the same ticket is rejected with exactly one error per unordered pair naming both task numbers and the conflicting path, with a citation to `scope-sections.md`.
- Literal-vs-glob overlap is covered via the same symmetric `fileMatchesScope` semantics used by the existing cross-section check (e.g. `lib/foo/**` vs `lib/foo/bar.ts` is caught).
- `tasks-gate` continues to hard-fail and routes `RUN /work-workflow:split-in-tasks` on any `validateAll` error, now including joint-ownership errors; the conflicting path and both task numbers appear in the routing `reason`.
- `scope-sections.md` gains a worked example for the duplicate-in-scope shape with a fix prescription, cross-referenced from the existing ECHO-5538 example.
- Joint-ownership detection is factored into four private helpers (`_detectJointInScopeOwnership`, `_hasInScope`, `_findFirstScopeOverlap`, `_buildJointError`) to keep per-function cognitive complexity within the quality gate without growing `.quality-exceptions`.

## Brief P0 coverage

- **P0 #1 (detect joint ownership, name path + task numbers + cite docs):** implemented in `plugins/work/scripts/workflows/lib/task-scope.js` — `_detectJointInScopeOwnership` + `_buildJointError`; integration-tested in `plugins/work/skills/split-in-tasks/__tests__/intra-ticket-scope.integration.test.js` at the `two peer tasks list the same literal path` case.
- **P0 #2 (literal-and-glob symmetric overlap):** implemented via `_entriesOverlap` in `task-scope.js` using the existing `fileMatchesScope` with both-direction check; tested in `task-scope.test.js` (`rejects glob-vs-literal symmetric overlap`) and `intra-ticket-scope.integration.test.js` (`glob in-scope entry overlaps a literal in-scope entry`).
- **P0 #3 (integration coverage):** 9 `it()` cases added across `intra-ticket-scope.integration.test.js` (4 new) and `task-scope.test.js` (5 new) covering literal, glob, three-owner C(3,2)=3 errors, no-false-positive, and cross-ticket isolation.
- **P0 #4 (unit coverage at `validateAll` boundary):** added in `plugins/work/scripts/workflows/lib/__tests__/task-scope.test.js` — five new `it()` cases inside the `validateIntraTicketScope joint in-scope ownership (GH-515)` describe block.
- **P0 #5 (tasks-gate regression — routes RUN with conflicting path in reason):** implemented in `plugins/work/scripts/workflows/work/__tests__/tasks-gate-intra-ticket.integration.test.js` — `tasks-gate hard-fails and routes to split-in-tasks on joint ownership` (new `it()` block with `JOINT_OWNERSHIP_TASKS_MD` fixture).

## Out-of-scope changes

None. All 8 changed files are directly tied to the GH-515 brief: the validator implementation, its unit tests, the integration test suite, two new invalid fixture files, the tasks-gate regression test, the docs test, and the scope-sections doc update.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Run the four affected suites directly (112/112 passing, confirmed pre-PR):

1. Unit tests at the `validateAll` boundary:
   ```bash
   node --test plugins/work/scripts/workflows/lib/__tests__/task-scope.test.js
   ```

2. Integration tests at the `validateIntraTicketScope` surface (includes 4 new GH-515 cases):
   ```bash
   node --test plugins/work/skills/split-in-tasks/__tests__/intra-ticket-scope.integration.test.js
   ```

3. tasks-gate routing regression (joint-ownership RUN path):
   ```bash
   node --test plugins/work/scripts/workflows/work/__tests__/tasks-gate-intra-ticket.integration.test.js
   ```

4. scope-sections.md doc coverage test:
   ```bash
   node --test plugins/work/skills/split-in-tasks/docs/__tests__/scope-sections-doc.test.js
   ```

To manually verify the validator rejects a duplicate-in-scope `tasks.md`:
- Create a `tasks.md` where Task 1 and Task 2 both list `components/X.tsx` under `### Files in scope`.
- Run `tasks-gate` against it; expect a hard-fail with reason matching `/joint|both list|in scope/i` and referencing both `Task 1` and `Task 2` with `components/X.tsx`.

Closes #515

> Note: the original `GH-515-maestro` branch was an orphan from a TDD recovery cycle. This PR uses `GH-515-pr` as the clean equivalent rebased onto `origin/main`.

### Test Results

- `task-scope.test.js` — all tests pass (includes 5 new GH-515 cases)
- `intra-ticket-scope.integration.test.js` — all tests pass (includes 4 new GH-515 cases)
- `tasks-gate-intra-ticket.integration.test.js` — all tests pass (includes 1 new GH-515 regression case)
- `scope-sections-doc.test.js` — all 4 doc-coverage cases pass
- Total: 112/112 passing across all 4 suites

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tighten tasks-gate structural validation for scope ownership; regressions could block valid tasks.md or miss invalid joint ownership, but impact is confined to workflow validation and is heavily test-covered.
> 
> **Overview**
> Adds **GH-515** coverage for **joint in-scope ownership**: when two or more peer tasks list the same path (or overlapping glob/literal) under `### Files in scope`, validation must fail with **joint-ownership** errors that name both tasks, the path, and `scope-sections.md`.
> 
> **Tests & fixtures:** Five new `validateAll` cases in `task-scope.test.js` (literal duplicate, glob overlap, three-way C(3,2) errors, no false positives, ticket isolation). Integration tests in `intra-ticket-scope.integration.test.js` use new fixtures `tasks.dup-in-scope.md` and `tasks.dup-in-scope.glob.md`. `tasks-gate-intra-ticket.integration.test.js` adds a case that **`tasks-gate` RUNs** `/work-workflow:split-in-tasks` with path and both task numbers in the reason.
> 
> **Docs:** `scope-sections.md` documents the duplicate-in-scope failure mode (worked example, error shape, fix guidance) and links from the ECHO-5538 cross-section example. New `scope-sections-doc.test.js` locks in required doc phrases.
> 
> Minor test-only quote style tweaks in two existing `crossTaskDep` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f2793dab36b3f881eb631a73f3cb3fdd03d90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Code Review Summary

| Area | Status |
|------|--------|
| Task-Doc Compliance | Partial — see note below |
| Code Reuse | Pass |
| TDD / Test Discipline | Pass |
| TypeScript Safety | N/A (plain JavaScript) |
| Code Smells | Partial — see note below |
| SOLID / Design Quality | Pass |
| Dependency Hygiene | Pass |

**Note — `diff_scope.js` label edit:** The one-line string change (`Phase 3 of 8` to `Phase 3 of 11`) in `diff_scope.js` is a forbidden surface per the brief. The change is cosmetic (zero logic impact) but technically violates R9. Recommend moving it to a separate follow-up commit/ticket.

**Note — dead `key` variable:** `_detectJointInScopeOwnership` (task-scope.js:666-669) computes and stores a `key` in `reported` but never checks it — the actual deduplication guard is the `${i}:${j}` pair key. No functional impact; the comment is misleading. Recommend removing `const key = ...` and `reported.add(key)` in a follow-up.