### PR TITLE
fix(fabrication-detector): notes scanning and word-boundary sourcing

### DIFF
--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
@@ -142,6 +142,74 @@ test('Unsourced row with synonym status (ok/passed/green) trips a violation', ()
   }
 });
 
+test('Verdict in Notes column with pending Status still trips a violation', () => {
+  // Smuggling: Status=pending but Notes contains "PASS in CI" or similar.
+  const dir = makeTaskDir({ 'tests.check.md': 'unrelated content\n' });
+  const cases = ['PASS in CI', 'works in prod', 'verified manually', 'green', 'OK on staging'];
+  for (const notes of cases) {
+    const prBody = [
+      '## Test Results',
+      '',
+      '| Test | Status | Notes |',
+      '| --- | --- | --- |',
+      `| feature Y | pending | ${notes} |`,
+      '',
+    ].join('\n');
+    const { violations } = detectFabrication(prBody, dir);
+    const row = violations.find((v) => v.reason === 'unsourced-test-row');
+    assert.ok(row, `expected violation for pending row with notes="${notes}"`);
+  }
+});
+
+test('Plain pending row with non-verdict Notes does not trip', () => {
+  const dir = makeTaskDir();
+  const prBody = [
+    '## Test Results',
+    '',
+    '| Test | Status | Notes |',
+    '| --- | --- | --- |',
+    '| modal opens | pending | awaiting tests.check.md |',
+    '| login flow | pending | follow-up next sprint |',
+    '',
+  ].join('\n');
+  const { violations } = detectFabrication(prBody, dir);
+  assert.equal(violations.length, 0);
+});
+
+test('Sourcing requires word-boundary match, not naive substring', () => {
+  // `login` as a substring of `loginflow` / `logins` must NOT count as evidence.
+  const dir = makeTaskDir({
+    'tests.check.md': 'See logins table and loginflow utility for context.\n',
+  });
+  const prBody = [
+    '## Test Results',
+    '',
+    '| Test | Status | Notes |',
+    '| --- | --- | --- |',
+    '| login | PASS | smoke |',
+    '',
+  ].join('\n');
+  const { violations } = detectFabrication(prBody, dir);
+  const row = violations.find((v) => v.reason === 'unsourced-test-row');
+  assert.ok(row, 'expected violation — "login" inside "loginflow"/"logins" should not source the claim');
+});
+
+test('Whole-word sourcing in tests.check.md clears the claim', () => {
+  const dir = makeTaskDir({
+    'tests.check.md': '- login: verified via smoke run in CI.\n',
+  });
+  const prBody = [
+    '## Test Results',
+    '',
+    '| Test | Status | Notes |',
+    '| --- | --- | --- |',
+    '| login | PASS | smoke |',
+    '',
+  ].join('\n');
+  const { violations } = detectFabrication(prBody, dir);
+  assert.equal(violations.length, 0);
+});
+
 test('Unsourced PASS row under Test Results', () => {
   const dir = makeTaskDir({
     'tests.check.md': 'No matching content here.\n',

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/__tests__/fabrication-detector.test.js
@@ -161,6 +161,49 @@ test('Verdict in Notes column with pending Status still trips a violation', () =
   }
 });
 
+test('Known over-eager cases: benign Notes containing verdict words DO trip (documented)', () => {
+  // The Notes verdict regex is deliberately over-eager — a false positive
+  // forces the agent to source the row or rewrite Notes, which is the safer
+  // failure mode. This test pins that behavior so future tightening is a
+  // conscious choice, not an accidental drift.
+  const dir = makeTaskDir({ 'tests.check.md': 'unrelated content\n' });
+  const benignCases = [
+    'works in progress',
+    'verified pending product review',
+    'OK to merge after review',
+    'follow-up: passed manual but not yet in tests.check.md',
+  ];
+  for (const notes of benignCases) {
+    const prBody = [
+      '## Test Results',
+      '',
+      '| Test | Status | Notes |',
+      '| --- | --- | --- |',
+      `| feature Z | pending | ${notes} |`,
+      '',
+    ].join('\n');
+    const { violations } = detectFabrication(prBody, dir);
+    const row = violations.find((v) => v.reason === 'unsourced-test-row');
+    assert.ok(row, `over-eager (expected) violation for benign notes="${notes}"`);
+  }
+});
+
+test('Row with no Notes column (2-column row) does not crash and does not trip', () => {
+  // parseTableRow defaults notes to '' when only Test and Status are present.
+  // Guards `!!row.notes` against undefined / null defensively.
+  const dir = makeTaskDir();
+  const prBody = [
+    '## Test Results',
+    '',
+    '| Test | Status |',
+    '| --- | --- |',
+    '| modal opens | pending |',
+    '',
+  ].join('\n');
+  const { violations } = detectFabrication(prBody, dir);
+  assert.equal(violations.length, 0);
+});
+
 test('Plain pending row with non-verdict Notes does not trip', () => {
   const dir = makeTaskDir();
   const prBody = [

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -182,14 +182,15 @@ function checkTestResultsRows(prBody, taskDir) {
     // If Status is pending-like but the Notes column smuggles a verdict
     // (e.g. "PASS in CI" or "works in prod"), treat the row as a claim that
     // still needs sourcing. Otherwise pending rows always pass.
-    const notesHasVerdict = !!row.notes && NOTES_VERDICT_REGEX.test(row.notes);
+    const notes = typeof row.notes === 'string' ? row.notes : '';
+    const notesHasVerdict = notes.length > 0 && NOTES_VERDICT_REGEX.test(notes);
     if (statusAllowed && !notesHasVerdict) continue;
     if (rowIsSourced(row.test, taskDir)) continue;
     // Surface the offending content — the Notes verdict if that's what
     // tripped it, otherwise the Status verdict.
-    const offending = statusAllowed ? row.notes : row.status;
+    const offending = statusAllowed ? notes : row.status;
     violations.push({
-      phrase: `| ${row.test} | ${row.status} | ${row.notes} |`,
+      phrase: `| ${row.test} | ${row.status} | ${notes} |`,
       reason: 'unsourced-test-row',
       suggestion: `Rewrite to "pending" — remove "${offending}" or source "${row.test}" in tests.check.md / completion.check.md before claiming a verdict.`,
     });

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.js
@@ -148,12 +148,27 @@ function parseTestResultsRows(prBody) {
   return rows;
 }
 
+// Verdict-like wording that, when found in the Notes column of an otherwise
+// pending row, indicates the agent is smuggling a claim past the Status check.
+const NOTES_VERDICT_REGEX =
+  /\b(pass(?:ed|es|ing)?|fail(?:ed|s|ing)?|ok|okay|green|success(?:ful)?|verified|works?|confirmed)\b/i;
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function rowIsSourced(testName, taskDir) {
   if (!taskDir || !testName) return false;
+  // Word-boundary match — a test name like "login" must appear as a whole
+  // word, not buried inside "login-flow-broken" or a random URL fragment.
+  // Pad with non-word-char alternatives so tokens that don't start/end on a
+  // word char (e.g. `"modal opens"`) still match.
+  const escaped = escapeRegExp(testName);
+  const re = new RegExp(`(^|[^A-Za-z0-9_])${escaped}([^A-Za-z0-9_]|$)`, 'i');
   const candidates = ['tests.check.md', 'completion.check.md'];
   for (const name of candidates) {
     const content = safeReadFile(path.join(taskDir, name));
-    if (content && content.includes(testName)) return true;
+    if (content && re.test(content)) return true;
   }
   return false;
 }
@@ -163,16 +178,20 @@ function checkTestResultsRows(prBody, taskDir) {
   const rows = parseTestResultsRows(prBody);
   for (const row of rows) {
     const statusLower = row.status.toLowerCase();
-    // Allowed (pending-like) statuses never produce a violation. Every other
-    // status — pass, fail, passed, ok, green, success, verified, etc. — is
-    // treated as a verdict claim that must be sourced. Whitelisting only
-    // `pass`/`fail` previously let synonyms slip through the guard.
-    if (ALLOWED_STATUSES.has(statusLower)) continue;
+    const statusAllowed = ALLOWED_STATUSES.has(statusLower);
+    // If Status is pending-like but the Notes column smuggles a verdict
+    // (e.g. "PASS in CI" or "works in prod"), treat the row as a claim that
+    // still needs sourcing. Otherwise pending rows always pass.
+    const notesHasVerdict = !!row.notes && NOTES_VERDICT_REGEX.test(row.notes);
+    if (statusAllowed && !notesHasVerdict) continue;
     if (rowIsSourced(row.test, taskDir)) continue;
+    // Surface the offending content — the Notes verdict if that's what
+    // tripped it, otherwise the Status verdict.
+    const offending = statusAllowed ? row.notes : row.status;
     violations.push({
-      phrase: `| ${row.test} | ${row.status} |`,
+      phrase: `| ${row.test} | ${row.status} | ${row.notes} |`,
       reason: 'unsourced-test-row',
-      suggestion: `Rewrite Status to "pending" until tests.check.md or completion.check.md contains "${row.test}".`,
+      suggestion: `Rewrite to "pending" — remove "${offending}" or source "${row.test}" in tests.check.md / completion.check.md before claiming a verdict.`,
     });
   }
   return violations;


### PR DESCRIPTION
## Existing Behavior

- The fabrication detector scanned only the Status column of test-result table rows; Notes cells were never checked for verdict language. A row like `| feature X | pending | PASS in CI |` would not trigger detection because Status=pending short-circuited evaluation before Notes was read.
- Row sourcing used a plain `content.includes(testName)` substring match, so a test named `login` was considered sourced even when the artifact only contained `loginflow` or `logins`.

## Intended New Behavior

- A new `NOTES_VERDICT_REGEX` pattern (pass/passed/fail/ok/green/success/verified/works/confirmed) is applied to the Notes column. Pending rows whose Notes cell contains any of these terms must now be backed by an entry in `tests.check.md` or `completion.check.md`, or detection fires.
- `rowIsSourced` builds a word-boundary regex `(^|[^A-Za-z0-9_])<escaped>([^A-Za-z0-9_]|$)` and escapes all regex metacharacters before testing. Only whole-word matches count as evidence; partial-word occurrences no longer clear a row.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

All 22 unit tests pass. To verify locally:

1. Navigate to the fabrication-detector test suite and run it:
   ```
   node --test plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/fabrication-detector.test.js
   ```
2. Confirm the following new cases pass:
   - A pending row with Notes containing `PASS in CI` trips detection when not sourced.
   - A pending row with Notes containing `works in prod`, `verified manually`, `green`, `OK on staging` also trips.
   - A pending row with plain non-verdict Notes (e.g. `needs review`) does not trip.
   - A test named `login` is NOT sourced when the artifact only contains `loginflow`.
   - A test named `login` IS sourced when the artifact contains `login` as a whole word.

### Test Results

All 22 tests pass (0 failures).

Follow-up to #501.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow guard logic and tests only; stricter validation may flag more PR bodies until agents rewrite Notes or fix artifact wording.
> 
> **Overview**
> The PR **tightens** the work-PR `fabrication-detector` so agents cannot claim test success without matching task artifacts.
> 
> **Notes column:** Pending (and other allowed) statuses no longer skip the row when **Notes** contains verdict-like words (`NOTES_VERDICT_REGEX`). Those rows still require sourcing in `tests.check.md` / `completion.check.md`, and violation messages now call out the smuggled Notes text when that is what tripped the check.
> 
> **Sourcing:** `rowIsSourced` replaces naive `includes(testName)` with a **whole-token** regex (escaped test name, padded for non-word boundaries) so partial matches like `login` inside `loginflow` do not clear a PASS row.
> 
> **Tests:** New unit cases cover Notes smuggling, intentional over-eager Notes false positives, two-column tables, benign pending Notes, and word-boundary sourcing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e7210658e16994411de721ef4df4792f7f9b41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->