### PR TITLE
docs(work-extensions): add Phase 1 extension API documentation (GH-522) [1/7]

### DIFF
--- a/plugins/work/docs/work-extensions.md
+++ b/plugins/work/docs/work-extensions.md
@@ -1,0 +1,241 @@
+# /work Extensions — Author Guide
+
+A per-repo pluggable extension API for /work's semantic events. Repos drop
+JavaScript files into `.claude/work-extensions/` to react to /work's
+lifecycle events without modifying the core plugin.
+
+> **Phase 1 surface.** This document covers what ships today: the five
+> Phase 1 events plus `passthrough` and `injectContext`. Phase 2 adds
+> `handled` / `block`; Phase 3 adds the rest of the event surface. The
+> Phase boundary is enforced in code (see [Phase boundary](#phase-boundary)).
+
+## Quick start
+
+```js
+// .claude/work-extensions/log-ticket.js
+module.exports = {
+  events: ['OnTicketResolved'],
+  priority: 50,
+  handler: async (payload, ctx) => {
+    ctx.injectContext(`[log-ticket] resolved ticket: ${payload.ticketId}`);
+    return ctx.passthrough();
+  },
+};
+```
+
+Drop the file under `.claude/work-extensions/` in your repo. /work
+discovers and registers it on the next session. No build step, no
+configuration file — the export shape is the contract.
+
+## Event taxonomy (Phase 1)
+
+Each event fires at a well-defined site inside /work. Handlers receive
+the payload below plus a `ctx` object.
+
+| Event | Fires when | Payload shape |
+|---|---|---|
+| `OnSessionStart` | /work session begins (first `work-next.js` call after marker resolution) | `{ticketId: string, tasksDir: string, repoRoot: string}` |
+| `OnTicketResolved` | `steps/ticket.js` transitions to resolved | `{ticketId: string, resolution: object, tasksDir: string}` |
+| `OnPreToolCall` | PreToolUse hook fires, after the existing hook body, gated on active marker | `{toolName: string, toolInput: object}` |
+| `OnPostToolCall` | PostToolUse hook fires, before auto-advance logic, gated on active marker | `{toolName: string, toolInput: object, toolResult: object}` |
+| `OnAgentResponseMatched` | Plugin-level regex match against agent response text | `{responseText: string, match: {pattern: string, substring: string}}` |
+
+### `OnAgentResponseMatched` declaration
+
+Handlers for this event declare a `match` pattern at registration time.
+The dispatcher compiles it once via `safeRegex` (`plugins/synapsys/lib/matcher.js`),
+re-uses the compiled regex on each dispatch, and only fires the handler
+when the response text matches.
+
+```js
+module.exports = {
+  events: ['OnAgentResponseMatched'],
+  match: /flak(e|y)/i,
+  handler: async (payload, ctx) => {
+    ctx.injectContext('See: docs/flake-runbook.md');
+    return ctx.passthrough();
+  },
+};
+```
+
+Invalid patterns are rejected at registration with a logged error.
+
+## Handler interface
+
+A handler receives `(payload, ctx)` and returns a sentinel from `ctx`.
+
+### `ctx.passthrough()` — Phase 1
+
+Explicit no-op sentinel. Continues the dispatch chain. Most handlers
+return `passthrough` after performing side effects.
+
+```js
+handler: async (payload, ctx) => {
+  ctx.injectContext('cortex memories: 3 matched');
+  return ctx.passthrough();
+}
+```
+
+### `ctx.injectContext(text)` — Phase 1
+
+Queues text for prompt injection. Multiple calls within the same dispatch
+accumulate in insertion order. The accumulated text is returned by
+`dispatch(...)` so call sites can wire it into the next prompt.
+
+```js
+ctx.injectContext('a');
+ctx.injectContext('b');
+// ctx.getInjectedContext() === ['a', 'b']
+```
+
+### `ctx.handled({result})` — Phase 2 (stub)
+
+Throws `PhaseNotReadyError` in Phase 1. When Phase 2 lands, returning
+`handled` will short-circuit the chain and replace /work's default action.
+
+### `ctx.block({reason})` — Phase 2 (stub)
+
+Throws `PhaseNotReadyError` in Phase 1. When Phase 2 lands, returning
+`block` will abort the current workflow step with a structured error.
+
+### `ctx.callTool(name, args)` — Phase 3 (stub)
+
+Throws `PhaseNotReadyError` in Phase 1. When Phase 3 lands, handlers
+will be able to invoke MCP tools (e.g. cortex_recall, rulesync) from
+within a handler.
+
+## Registration shape
+
+```js
+module.exports = {
+  events: string[],       // required — event names to subscribe to
+  handler: Function,      // required — (payload, ctx) => Promise<sentinel>
+  priority?: number,      // optional — default 50, higher runs first
+  match?: string | RegExp // required for OnAgentResponseMatched only
+};
+```
+
+### Priority & tiebreaker
+
+Handlers run in **priority descending** order (default `50`). Equal-priority
+handlers run in **lexical filename ascending** order. The first handler
+that returns `handled` or `block` short-circuits the chain (Phase 2+);
+`passthrough` continues to the next.
+
+## Fire order (per workflow step)
+
+```
+SessionStart        →  OnSessionStart   (once per process)
+  ↓
+ticket step         →  OnTicketResolved (on resolve transition)
+  ↓
+PreToolUse hook     →  OnPreToolCall    (per tool dispatch)
+  ↓
+PostToolUse hook    →  OnPostToolCall   (per tool result)
+                    →  OnAgentResponseMatched (when text matches)
+  ↓
+... continues per step
+```
+
+`OnSessionStart` is guaranteed to fire before any other event. Tool-call
+events fire on every gated PreToolUse / PostToolUse for the active session.
+
+## Phase boundary
+
+The Phase 1 → 2 → 3 boundary is enforced in code, not only docs.
+`ctx.handled`, `ctx.block`, and `ctx.callTool` are present on the ctx
+object in Phase 1, but throw a typed `PhaseNotReadyError` when called.
+
+```js
+try {
+  return ctx.handled({result: 'foo'});
+} catch (err) {
+  if (err.name === 'PhaseNotReadyError') {
+    // Phase 2 not yet enabled — fall back to passthrough
+    return ctx.passthrough();
+  }
+  throw err;
+}
+```
+
+When Phase 2 ships, the stubs become real and existing handlers continue
+to work without modification.
+
+## Type guidance (JSDoc)
+
+Author handlers with JSDoc for editor autocomplete:
+
+```js
+/**
+ * @typedef {object} OnTicketResolvedPayload
+ * @property {string} ticketId
+ * @property {object} resolution
+ * @property {string} tasksDir
+ */
+
+/**
+ * @param {OnTicketResolvedPayload} payload
+ * @param {import('../../scripts/workflows/work/lib/extensions/ctx').Ctx} ctx
+ */
+module.exports.handler = async (payload, ctx) => { ... };
+```
+
+The plugin's `ctx.js` and `event-bus.js` carry full JSDoc on every exported
+function and method.
+
+## Error isolation
+
+- **Load errors** (bad export shape, syntax errors, throw at `require()`):
+  logged via `createDebugLog(tasksDir).error(...)` AND emitted to stderr
+  at `warn` level. The extension is skipped; /work continues.
+- **Handler runtime errors**: caught in `event-bus.dispatch`, logged via
+  the same dual sink, and treated as `passthrough`. Subsequent handlers
+  in the priority chain still run.
+- **A broken extension MUST NOT crash /work.** This is enforced by tests
+  in `__tests__/error-isolation.test.js` and `__tests__/loader.test.js`.
+
+## Latency budget
+
+Per-event dispatch overhead target: **< 5ms p99** with ≤ 3 handlers per
+event. The registry is a pure in-memory map; the comparator runs once at
+registration; `OnAgentResponseMatched` regexes are compiled once. The
+common case has zero I/O on the dispatch path.
+
+## Security posture
+
+- **Host-machine trust model.** Extensions run in the same Node process
+  as /work with full FS / network access. Treat `.claude/work-extensions/`
+  as trusted code; review before committing.
+- **Path-traversal hardening.** The loader resolves each candidate file
+  via `fs.realpathSync` and rejects any file whose realpath does not
+  remain under the resolved `.claude/work-extensions/` directory.
+  Symlink escapes are blocked before `require()`.
+- **No remote execution.** Phase 1 has no mechanism to fetch or load
+  extensions from the network. Local files only.
+
+## Diagnostic command
+
+```bash
+node plugins/work/scripts/workflows/work/scripts/work-extensions-status.js
+# → [{"file":"cortex-auto-recall.js","events":["OnTicketResolved"],"loaded":true}, ...]
+
+# Add --pretty for indented output
+node ... --pretty
+```
+
+Lists every discovered extension file, its declared events, whether it
+loaded, and the error message if not.
+
+## Reference extensions
+
+Three reference extensions ship in-tree under
+`plugins/work/references/work-extensions/`:
+
+| File | Events | Purpose |
+|---|---|---|
+| `cortex-auto-recall.js` | `OnTicketResolved` | Calls cortex_recall, injects matching memories |
+| `flaky-test-runbook.js` | `OnAgentResponseMatched` (match: `/flak(e|y)/i`) | Injects runbook when agent mentions test flakes |
+| `rulesync-redirect.js` | `OnReadDenied` (Phase 3 stub) | Demonstrates Phase 3 boundary — registers but logs "Phase 3 not yet enabled" |
+
+Copy any of these into your repo's `.claude/work-extensions/` as a
+starting point.


### PR DESCRIPTION
## Existing Behavior

There is no documentation for the /work extension API. Repos have no
supported path to hook into /work lifecycle events without modifying the
core plugin directly.

## Intended New Behavior

Adds `plugins/work/docs/work-extensions.md` — the Phase 1 author guide
for the per-repo extension API. No runtime code ships in this slice; this
is documentation only.

The guide covers:
- Quick-start example (drop a `.js` file under the work-extensions directory)
- Phase 1 event taxonomy: `OnSessionStart`, `OnTicketResolved`, `OnPreToolCall`, `OnPostToolCall`, `OnAgentResponseMatched`
- Handler interface: `ctx.passthrough()`, `ctx.injectContext()`, and Phase 2/3 stubs with `PhaseNotReadyError` contract
- Registration shape, priority + tiebreaker ordering, fire order diagram
- Phase boundary enforcement model (stubs throw, not silent no-ops)
- Error isolation guarantees (load errors and handler runtime errors never crash /work)
- Security posture (host-machine trust model, path-traversal hardening, no remote execution)
- Latency budget (< 5ms p99 per-event dispatch target)
- Diagnostic command (`work-extensions-status.js`)
- Reference extensions table (three in-tree examples)

## Slice 1 of 7 — stack roadmap

| Slice | Branch | Contents |
|---|---|---|
| 1 (this PR) | `GH-522-1-docs` | `plugins/work/docs/work-extensions.md` (docs only) |
| 2 | `GH-522-2-ctx` | Extension context object (`ctx.js`) |
| 3 | `GH-522-3-event-bus` | Event bus dispatcher (`event-bus.js`) |
| 4 | `GH-522-4-loader` | Extension loader (`loader.js`) |
| 5 | `GH-522-5-index-and-status` | Index entry + status CLI script |
| 6 | `GH-522-6-reference-extensions` | Three reference extensions |
| 7 | `GH-522-7-wiring` | Hook wiring into existing /work lifecycle sites |

## Dev Checks
- [ ] Functionality can be toggled on/off — N/A (docs only)
- [ ] New code is covered by unit/integration tests — N/A (docs only)
- [ ] Breaking changes for the API have been inserted into a deprecation cycle — N/A (docs only)
- [Y] There is appropriate documentation for the new work — this PR is the documentation
- [ ] Any new environment variables are populated into variable groups for all environments — N/A (docs only)

## Testing Plan / Demo

Docs-only slice — no runtime changes to exercise.

To verify the file landed correctly, run from the repo root:

```
git show HEAD -- plugins/work/docs/work-extensions.md | wc -l
```

Confirm 241 lines are present and the document renders correctly in GitHub's markdown viewer by navigating to `plugins/work/docs/work-extensions.md` on the branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no executable code or behavior changes in this slice.
> 
> **Overview**
> Adds **`plugins/work/docs/work-extensions.md`**, the Phase 1 author guide for per-repo `/work` extensions (drop JS under `.claude/work-extensions/`). The doc defines the **five Phase 1 events**, **`ctx.passthrough()` / `ctx.injectContext()`**, registration shape, **priority + fire order**, and documents **Phase 2/3 stubs** (`handled`, `block`, `callTool`) that throw **`PhaseNotReadyError`** until later slices ship.
> 
> It also specifies **error isolation** (broken extensions must not crash `/work`), **security** (trusted local code, `realpath` containment), a **latency budget**, the **`work-extensions-status.js`** diagnostic, and a **reference extensions** table—**no runtime or test changes** in this PR (slice 1/7).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a241e091b6dc04b7f8d661b55b9ed4e2cc29e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->