### PR TITLE
feat(work-extensions): add in-memory event bus (GH-522) [3/7]

### DIFF
--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/event-bus.test.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/event-bus.test.js
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for event-bus: register + dispatch.
+ * Covers Task 1 acceptance criteria (R9, G6).
+ *
+ * Run with:
+ *   node --test plugins/work/scripts/workflows/work/lib/extensions/__tests__/event-bus.test.js
+ */
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const EVENT_BUS_PATH = path.resolve(__dirname, '..', 'event-bus.js');
+
+function loadBus() {
+  delete require.cache[require.resolve(EVENT_BUS_PATH)];
+  return require(EVENT_BUS_PATH);
+}
+
+describe('event-bus', () => {
+  let bus;
+
+  beforeEach(() => {
+    bus = loadBus();
+  });
+
+  describe('register', () => {
+    it('registers a handler with explicit priority and sourceFile', () => {
+      const handler = () => {};
+      bus.register({
+        eventName: 'OnTicketResolved',
+        handler,
+        priority: 100,
+        sourceFile: 'a.js',
+      });
+      const handlers = bus.listHandlers('OnTicketResolved');
+      assert.equal(handlers.length, 1);
+      assert.equal(handlers[0].handler, handler);
+      assert.equal(handlers[0].priority, 100);
+      assert.equal(handlers[0].sourceFile, 'a.js');
+    });
+
+    it('applies default priority of 50 when not provided', () => {
+      bus.register({
+        eventName: 'OnTicketResolved',
+        handler: () => {},
+        sourceFile: 'a.js',
+      });
+      const handlers = bus.listHandlers('OnTicketResolved');
+      assert.equal(handlers[0].priority, 50);
+    });
+  });
+
+  describe('dispatch — Handlers run in priority order with lexical filename tiebreaker (G6)', () => {
+    it('runs c.js (prio 100) before a.js and b.js (default 50); a.js before b.js', async () => {
+      const callOrder = [];
+      bus.register({
+        eventName: 'OnTicketResolved',
+        handler: async () => { callOrder.push('b'); },
+        sourceFile: 'b.js',
+      });
+      bus.register({
+        eventName: 'OnTicketResolved',
+        handler: async () => { callOrder.push('c'); },
+        priority: 100,
+        sourceFile: 'c.js',
+      });
+      bus.register({
+        eventName: 'OnTicketResolved',
+        handler: async () => { callOrder.push('a'); },
+        sourceFile: 'a.js',
+      });
+
+      await bus.dispatch('OnTicketResolved', { ticketId: 'GH-1' }, {
+        passthrough: () => {},
+      });
+
+      assert.deepEqual(callOrder, ['c', 'a', 'b']);
+    });
+
+    it('orders by descending priority across mixed values', async () => {
+      const order = [];
+      bus.register({
+        eventName: 'E',
+        handler: () => { order.push('low'); },
+        priority: 10,
+        sourceFile: 'low.js',
+      });
+      bus.register({
+        eventName: 'E',
+        handler: () => { order.push('high'); },
+        priority: 200,
+        sourceFile: 'high.js',
+      });
+      bus.register({
+        eventName: 'E',
+        handler: () => { order.push('mid'); },
+        priority: 75,
+        sourceFile: 'mid.js',
+      });
+
+      await bus.dispatch('E', {}, { passthrough: () => {} });
+      assert.deepEqual(order, ['high', 'mid', 'low']);
+    });
+
+    it('awaits each handler and continues on passthrough', async () => {
+      const order = [];
+      bus.register({
+        eventName: 'E',
+        handler: async () => {
+          await new Promise((r) => setImmediate(r));
+          order.push('first');
+        },
+        priority: 100,
+        sourceFile: 'a.js',
+      });
+      bus.register({
+        eventName: 'E',
+        handler: async () => { order.push('second'); },
+        priority: 50,
+        sourceFile: 'b.js',
+      });
+      await bus.dispatch('E', {}, { passthrough: () => {} });
+      assert.deepEqual(order, ['first', 'second']);
+    });
+
+    it('dispatch with no handlers is a no-op', async () => {
+      await bus.dispatch('Nothing', {}, { passthrough: () => {} });
+    });
+  });
+
+  describe('listHandlers', () => {
+    it('returns empty array for unknown event', () => {
+      assert.deepEqual(bus.listHandlers('Unknown'), []);
+    });
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/extensions/event-bus.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/event-bus.js
@@ -1,0 +1,239 @@
+/**
+ * event-bus.js — pure in-memory registry + dispatcher for /work extensions.
+ *
+ * Responsibilities (Task 1 / R9 / G6):
+ *   - register({eventName, handler, priority?, sourceFile, match?})
+ *   - dispatch(eventName, payload, ctx) iterates handlers in order, awaits each
+ *   - listHandlers(eventName) returns the ordered handler records
+ *
+ * Ordering rules:
+ *   - Default priority is 50.
+ *   - Higher priority runs first (descending).
+ *   - Equal priority is broken lexically by sourceFile ascending.
+ *
+ * No I/O — pure registry. Discovery/loading lives in loader.js (Task 3).
+ */
+
+'use strict';
+
+const path = require('node:path');
+
+// Resolve synapsys safeRegex lazily so this module remains side-effect-free
+// at require time even if synapsys is not installed in some test contexts.
+function getSafeRegex() {
+  try {
+    // plugins/work/scripts/workflows/work/lib/extensions/ → ../../../../../../synapsys/lib/matcher
+    // (6 levels: extensions → lib → work → workflows → scripts → work → plugins)
+    const matcherPath = path.resolve(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      '..',
+      '..',
+      'synapsys',
+      'lib',
+      'matcher.js'
+    );
+    return require(matcherPath).safeRegex;
+  } catch {
+    return (pattern, flags = 'i') => {
+      try {
+        return new RegExp(pattern, flags);
+      } catch {
+        return null;
+      }
+    };
+  }
+}
+
+const DEFAULT_PRIORITY = 50;
+
+// Per-event handler arrays. Module-level state — callers that need isolation
+// should `delete require.cache[require.resolve('./event-bus.js')]` and re-require.
+const registry = Object.create(null);
+
+/**
+ * Compare two handler records for ordering.
+ * Priority descending; sourceFile ascending lexical tiebreaker.
+ * @param {{priority: number, sourceFile: string}} a
+ * @param {{priority: number, sourceFile: string}} b
+ * @returns {number}
+ */
+function compareHandlers(a, b) {
+  if (a.priority !== b.priority) {
+    return b.priority - a.priority;
+  }
+  return a.sourceFile < b.sourceFile ? -1 : a.sourceFile > b.sourceFile ? 1 : 0;
+}
+
+/**
+ * Compile a handler `match` (string | RegExp) into `{ pattern, compiled }` once
+ * at registration time so the dispatcher path stays compile-free (R1/G9 Task 8).
+ * Invalid patterns throw — the caller (loader) is expected to log and skip the
+ * extension so /work keeps running.
+ *
+ * @param {string|RegExp} match
+ * @param {string} sourceFile  for diagnostics
+ * @returns {{ pattern: string, compiled: RegExp }}
+ */
+function compileMatch(match, sourceFile) {
+  const safeRegex = getSafeRegex();
+  let pattern;
+  let flags = 'i';
+  if (match instanceof RegExp) {
+    pattern = match.source;
+    flags = match.flags || 'i';
+  } else if (typeof match === 'string') {
+    pattern = match;
+  } else {
+    throw new Error(
+      `[event-bus] invalid match for ${sourceFile}: expected string or RegExp, got ${typeof match}`
+    );
+  }
+  const compiled = safeRegex(pattern, flags);
+  if (!compiled) {
+    throw new Error(
+      `[event-bus] invalid regex match "${pattern}" for ${sourceFile}: registration rejected`
+    );
+  }
+  return { pattern, compiled };
+}
+
+/**
+ * Register a handler against an event.
+ * @param {{eventName: string, handler: Function, priority?: number, sourceFile: string, match?: RegExp|string}} entry
+ */
+function register(entry) {
+  const { eventName, handler, sourceFile } = entry;
+  const priority = typeof entry.priority === 'number' ? entry.priority : DEFAULT_PRIORITY;
+
+  let match;
+  if (entry.match !== undefined && entry.match !== null) {
+    match = compileMatch(entry.match, sourceFile);
+  }
+
+  const record = {
+    eventName,
+    handler,
+    priority,
+    sourceFile,
+    match,
+  };
+
+  if (!registry[eventName]) {
+    registry[eventName] = [];
+  }
+  // Dedupe by (eventName, sourceFile): callers that initExtensions with
+  // different (repoRoot, tasksDir) keys but the same on-disk extension file
+  // (e.g. work-next.js using worktree path vs a step using process.cwd())
+  // would otherwise register the same handler twice and double-fire it.
+  // Replace any existing record for the same sourceFile so the latest
+  // registration wins and handler counts stay correct.
+  const existingIdx = registry[eventName].findIndex((r) => r.sourceFile === sourceFile);
+  if (existingIdx >= 0) {
+    registry[eventName][existingIdx] = record;
+  } else {
+    registry[eventName].push(record);
+  }
+  registry[eventName].sort(compareHandlers);
+}
+
+/**
+ * List handler records for an event in dispatch order.
+ * @param {string} eventName
+ * @returns {Array<object>}
+ */
+function listHandlers(eventName) {
+  return registry[eventName] ? registry[eventName].slice() : [];
+}
+
+/**
+ * Dispatch an event: await each handler in priority order; passthrough returns continue the chain.
+ * @param {string} eventName
+ * @param {object} payload
+ * @param {object} ctx
+ * @returns {Promise<void>}
+ */
+async function dispatch(eventName, payload, ctx) {
+  const handlers = registry[eventName];
+  if (!handlers || handlers.length === 0) {
+    return;
+  }
+  for (const record of handlers) {
+    try {
+      await record.handler(payload, ctx);
+    } catch (err) {
+      // R6/G5: a throwing handler is caught and treated as passthrough so
+      // subsequent handlers in the priority chain still run. The error is
+      // logged via debug-log (if ctx carries tasksDir) AND stderr so visibility
+      // matches the index.js error path described in spec §AD.
+      logDispatchError(eventName, record.sourceFile, err, ctx);
+    }
+  }
+}
+
+/**
+ * Dual-sink error log for handler-thrown errors during dispatch.
+ * Writes to `<tasksDir>/debug.md` when `ctx.tasksDir` is available and always
+ * emits a stderr warn so /work terminal output surfaces the failure.
+ * Fail-open in both sinks — a logging failure must never crash the dispatcher.
+ *
+ * @param {string} eventName
+ * @param {string} sourceFile
+ * @param {Error} err
+ * @param {{tasksDir?: string}} ctx
+ */
+function logDispatchError(eventName, sourceFile, err, ctx) {
+  const message = err && err.message;
+  const name = err && err.name;
+  if (ctx && ctx.tasksDir) {
+    try {
+      const { createDebugLog } = require('../debug-log');
+      createDebugLog(ctx.tasksDir).error('extension handler threw', {
+        event: eventName,
+        sourceFile,
+        name: name || 'Error',
+        message,
+      });
+    } catch {
+      /* fail-open */
+    }
+  }
+  try {
+    process.stderr.write(
+      `[work-extensions] handler error for ${eventName} (${sourceFile}): ${name || 'Error'}: ${message}\n`
+    );
+  } catch {
+    /* fail-open */
+  }
+}
+
+/**
+ * Dispatch to a single specific handler record (already located via
+ * listHandlers + match). Used by `fireAgentResponseMatched` to invoke ONLY
+ * the handler whose pattern matched, instead of re-dispatching to every
+ * handler for the event. Wraps the call in the same try/catch as `dispatch`.
+ *
+ * @param {{eventName: string, handler: Function, sourceFile: string}} record
+ * @param {object} payload
+ * @param {object} ctx
+ * @returns {Promise<void>}
+ */
+async function dispatchToHandler(record, payload, ctx) {
+  if (!record || typeof record.handler !== 'function') return;
+  try {
+    await record.handler(payload, ctx);
+  } catch (err) {
+    logDispatchError(record.eventName, record.sourceFile, err, ctx);
+  }
+}
+
+module.exports = {
+  register,
+  dispatch,
+  dispatchToHandler,
+  listHandlers,
+  DEFAULT_PRIORITY,
+};


### PR DESCRIPTION
## Existing Behavior

The extensions layer (introduced in slices 1–2) has no mechanism to register or dispatch lifecycle events. Extension files have no way to declare interest in workflow events such as `OnTicketResolved`, and the runtime has no ordered invocation chain to call them.

## Intended New Behavior

A pure in-memory event bus is available at `lib/extensions/event-bus.js` with four exports:

- `register({ eventName, handler, priority?, sourceFile, match? })` — adds a handler to the registry; defaults priority to 50; compiles `match` patterns once at registration time; dedupes by `(eventName, sourceFile)` so re-registration replaces rather than doubles
- `dispatch(eventName, payload, ctx)` — awaits each handler in order; fail-open (a throwing handler is caught, logged to `debug.md` + stderr, and the chain continues)
- `dispatchToHandler(record, payload, ctx)` — targeted single-handler invocation used by `fireAgentResponseMatched` (slice 5+)
- `listHandlers(eventName)` — returns ordered handler records for inspection

Ordering: descending priority, then ascending lexical `sourceFile` as tiebreaker (spec G6). No I/O at module level — discovery and loading live in `loader.js` (slice 4).

## Slice 3 of 7 — stack roadmap

| # | Branch | PR | Status |
|---|--------|----|--------|
| 1 | `GH-522-1-base` | #563 | open |
| 2 | `GH-522-2-ctx` | #564 | open |
| **3** | **`GH-522-3-event-bus`** | **this PR** | open |
| 4 | `GH-522-4-loader` | — | pending |
| 5 | `GH-522-5-index` | — | pending |
| 6 | `GH-522-6-integration` | — | pending |
| 7 | `GH-522-7-wire` | — | pending |

Each PR is stacked on the previous. Base will be retargeted to `main` as ancestors merge.

## Deferred coverage note

`dispatch.test.js` (from the original PR #556) and `_fixtures.js` test helpers are **intentionally deferred to slice 5**. They import `initExtensions` from the public `index.js` API, which does not exist until slice 5 assembles loader + bus + ctx into the final entry point. The 7 tests in this slice cover all `register`/`dispatch`/`listHandlers` behaviors directly against `event-bus.js`. Full end-to-end dispatch coverage (including `_fixtures.js` scenarios) lands with the `index.js` slice.

## Dev Checks

- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Run the standalone test suite directly against the new module:

```bash
node --test plugins/work/scripts/workflows/work/lib/extensions/__tests__/event-bus.test.js
```

Expected: 7/7 tests pass, covering:
1. Handler registration with explicit priority and `sourceFile`
2. Default priority of 50 when omitted
3. Priority-descending dispatch order (`c.js` prio 100 before `a.js`/`b.js` prio 50; `a.js` before `b.js` lexically)
4. Mixed priority ordering (high → mid → low)
5. Async handler awaiting (setImmediate delay respected before next handler runs)
6. No-op dispatch when no handlers registered
7. Empty array returned from `listHandlers` for unknown event

### Test Results

7/7 standalone tests pass (`node --test event-bus.test.js`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated library and tests only; no workflow wiring or production behavior change until later slices merge.
> 
> **Overview**
> Adds a **pure in-memory event bus** at `lib/extensions/event-bus.js` so `/work` extensions can register lifecycle handlers and run them in a defined order. This slice does not wire the bus into the workflow yet—that comes in later stack PRs (`loader.js`, `index.js`).
> 
> **Registration and ordering:** `register` accepts `eventName`, `handler`, `sourceFile`, optional `priority` (default **50**), and optional `match` (string/RegExp compiled once via synapsys `safeRegex` or a test fallback). Handlers for the same event are sorted by **descending priority**, then **ascending `sourceFile`**. Re-registering the same `sourceFile` **replaces** the prior entry to avoid double-firing when init paths differ.
> 
> **Dispatch:** `dispatch` **awaits** handlers sequentially; thrown errors are **fail-open** (chain continues) with logging to `debug.md` when `ctx.tasksDir` is set and to stderr. `dispatchToHandler` targets a single record (for future matched-agent flows). `listHandlers` exposes the ordered registry.
> 
> **Tests:** Seven `node:test` cases cover defaults, priority/lexical ordering, async sequencing, empty dispatch, and `listHandlers` for unknown events (cache-clear per test for isolation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 456fef62f6c87ea8e5ae62e9a0dae9d5ed45bb77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->