### PR TITLE
feat(work-extensions): add extension loader + tasksDir on marker (GH-522) [4/7]

### DIFF
--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/loader.test.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/loader.test.js
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for loader: discovery, validation, error isolation, .ts skip, path-traversal hardening.
+ * Covers Task 3 acceptance criteria (R3, R6, R8, G1, G2, G4, G8).
+ *
+ * Run with:
+ *   node --test plugins/work/scripts/workflows/work/lib/extensions/__tests__/loader.test.js
+ */
+
+'use strict';
+
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const LOADER_PATH = path.resolve(__dirname, '..', 'loader.js');
+const EVENT_BUS_PATH = path.resolve(__dirname, '..', 'event-bus.js');
+
+function loadLoader() {
+  delete require.cache[require.resolve(LOADER_PATH)];
+  return require(LOADER_PATH);
+}
+
+function loadBus() {
+  delete require.cache[require.resolve(EVENT_BUS_PATH)];
+  return require(EVENT_BUS_PATH);
+}
+
+function makeTempRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'loader-test-'));
+  const tasksDir = path.join(root, 'tasks', 'GH-522');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  return { root, tasksDir };
+}
+
+function makeExtensionsDir(repoRoot) {
+  const extDir = path.join(repoRoot, '.claude', 'work-extensions');
+  fs.mkdirSync(extDir, { recursive: true });
+  return extDir;
+}
+
+function captureStderr(fn) {
+  const original = process.stderr.write.bind(process.stderr);
+  const chunks = [];
+  process.stderr.write = (chunk) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    return true;
+  };
+  try {
+    const result = fn();
+    return { result, stderr: chunks.join('') };
+  } finally {
+    process.stderr.write = original;
+  }
+}
+
+describe('loader', () => {
+  let tmpDirs = [];
+
+  afterEach(() => {
+    for (const d of tmpDirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {}
+    }
+    tmpDirs = [];
+  });
+
+  describe('No extensions directory — backward compatibility (G1, R8)', () => {
+    it('returns empty status and logs "no extensions directory; skipping" when dir missing', () => {
+      const { root, tasksDir } = makeTempRepo();
+      tmpDirs.push(root);
+      const bus = loadBus();
+      const { loadExtensions } = loadLoader();
+
+      const { stderr } = captureStderr(() => {
+        const status = loadExtensions({ repoRoot: root, tasksDir, bus });
+        assert.ok(Array.isArray(status), 'status must be an array');
+        assert.equal(status.length, 0, 'status must be empty when no dir');
+      });
+
+      // Either via debug log or stderr — the message must appear somewhere observable.
+      const debugPath = path.join(tasksDir, 'debug.md');
+      const debugContent = fs.existsSync(debugPath) ? fs.readFileSync(debugPath, 'utf8') : '';
+      const combined = stderr + debugContent;
+      assert.match(combined, /no extensions directory; skipping/i);
+    });
+  });
+
+  describe('Valid extension is discovered and registered (G2)', () => {
+    it('loads a .js extension with {events, handler} and registers against the bus', () => {
+      const { root, tasksDir } = makeTempRepo();
+      tmpDirs.push(root);
+      const extDir = makeExtensionsDir(root);
+
+      fs.writeFileSync(
+        path.join(extDir, 'sample.js'),
+        `module.exports = {
+           events: ['OnTicketResolved'],
+           handler: function(payload, ctx) { return 'ok'; },
+           priority: 75,
+         };`
+      );
+
+      const bus = loadBus();
+      const { loadExtensions } = loadLoader();
+      const status = loadExtensions({ repoRoot: root, tasksDir, bus });
+
+      assert.equal(status.length, 1);
+      assert.equal(status[0].loaded, true);
+      assert.deepEqual(status[0].events, ['OnTicketResolved']);
+      assert.match(status[0].file, /sample\.js$/);
+
+      const handlers = bus.listHandlers('OnTicketResolved');
+      assert.equal(handlers.length, 1);
+      assert.equal(handlers[0].priority, 75);
+    });
+  });
+
+  describe('Broken extension at load time does not crash /work (G4, R6)', () => {
+    it('catches require() throw, logs error, emits stderr warn, and continues', () => {
+      const { root, tasksDir } = makeTempRepo();
+      tmpDirs.push(root);
+      const extDir = makeExtensionsDir(root);
+
+      fs.writeFileSync(path.join(extDir, 'broken.js'), `throw new Error('kaboom at load');`);
+      fs.writeFileSync(
+        path.join(extDir, 'good.js'),
+        `module.exports = { events: ['OnSessionStart'], handler: () => {} };`
+      );
+
+      const bus = loadBus();
+      const { loadExtensions } = loadLoader();
+
+      let status;
+      const { stderr } = captureStderr(() => {
+        status = loadExtensions({ repoRoot: root, tasksDir, bus });
+      });
+
+      const broken = status.find((s) => /broken\.js$/.test(s.file));
+      const good = status.find((s) => /good\.js$/.test(s.file));
+      assert.ok(broken, 'broken entry present');
+      assert.equal(broken.loaded, false);
+      assert.match(broken.error || '', /kaboom/);
+      assert.ok(good, 'good entry present');
+      assert.equal(good.loaded, true);
+
+      // Stderr warn emission
+      assert.match(stderr, /kaboom|broken\.js/);
+
+      // Debug log error emission
+      const debugPath = path.join(tasksDir, 'debug.md');
+      const debugContent = fs.existsSync(debugPath) ? fs.readFileSync(debugPath, 'utf8') : '';
+      assert.match(debugContent + stderr, /broken\.js/);
+
+      // The good extension is still registered
+      assert.equal(bus.listHandlers('OnSessionStart').length, 1);
+    });
+  });
+
+  describe('.ts extension files are detected and skipped in Phase 1 (G8)', () => {
+    it('skips .ts files with warning "Phase 1 supports .js only" referencing the file', () => {
+      const { root, tasksDir } = makeTempRepo();
+      tmpDirs.push(root);
+      const extDir = makeExtensionsDir(root);
+
+      fs.writeFileSync(path.join(extDir, 'typed.ts'), `export const x = 1;`);
+
+      const bus = loadBus();
+      const { loadExtensions } = loadLoader();
+
+      let status;
+      const { stderr } = captureStderr(() => {
+        status = loadExtensions({ repoRoot: root, tasksDir, bus });
+      });
+
+      const ts = status.find((s) => /typed\.ts$/.test(s.file));
+      assert.ok(ts, 'ts file appears in status');
+      assert.equal(ts.loaded, false);
+
+      const debugPath = path.join(tasksDir, 'debug.md');
+      const debugContent = fs.existsSync(debugPath) ? fs.readFileSync(debugPath, 'utf8') : '';
+      const combined = stderr + debugContent;
+      assert.match(combined, /Phase 1 supports \.js only/);
+      assert.match(combined, /typed\.ts/);
+    });
+  });
+
+  describe('Invalid export shape — validation', () => {
+    it('skips files missing events or handler with a logged validation error', () => {
+      const { root, tasksDir } = makeTempRepo();
+      tmpDirs.push(root);
+      const extDir = makeExtensionsDir(root);
+
+      fs.writeFileSync(
+        path.join(extDir, 'no-events.js'),
+        `module.exports = { handler: () => {} };`
+      );
+      fs.writeFileSync(
+        path.join(extDir, 'no-handler.js'),
+        `module.exports = { events: ['OnSessionStart'] };`
+      );
+
+      const bus = loadBus();
+      const { loadExtensions } = loadLoader();
+
+      let status;
+      const { stderr } = captureStderr(() => {
+        status = loadExtensions({ repoRoot: root, tasksDir, bus });
+      });
+
+      const noEv = status.find((s) => /no-events\.js$/.test(s.file));
+      const noH = status.find((s) => /no-handler\.js$/.test(s.file));
+      assert.equal(noEv.loaded, false);
+      assert.equal(noH.loaded, false);
+      assert.match((noEv.error || '') + stderr, /events/i);
+      assert.match((noH.error || '') + stderr, /handler/i);
+
+      // Nothing registered
+      assert.equal(bus.listHandlers('OnSessionStart').length, 0);
+    });
+  });
+
+  describe('Path-traversal hardening', () => {
+    it('rejects symlinks whose realpath escapes the extensions directory', () => {
+      const { root, tasksDir } = makeTempRepo();
+      tmpDirs.push(root);
+      const extDir = makeExtensionsDir(root);
+
+      // Create a real file outside the extensions dir
+      const outsideDir = path.join(root, 'outside');
+      fs.mkdirSync(outsideDir, { recursive: true });
+      const outsideFile = path.join(outsideDir, 'evil.js');
+      fs.writeFileSync(outsideFile, `module.exports = { events: ['OnPwn'], handler: () => {} };`);
+
+      // Symlink inside extensions dir → outside file
+      const linkPath = path.join(extDir, 'evil.js');
+      try {
+        fs.symlinkSync(outsideFile, linkPath);
+      } catch (err) {
+        // If symlinks not supported (rare on CI), skip the assertion path
+        return;
+      }
+
+      const bus = loadBus();
+      const { loadExtensions } = loadLoader();
+
+      let status;
+      const { stderr } = captureStderr(() => {
+        status = loadExtensions({ repoRoot: root, tasksDir, bus });
+      });
+
+      const evil = status.find((s) => /evil\.js$/.test(s.file));
+      assert.ok(evil, 'evil symlink appears in status');
+      assert.equal(evil.loaded, false, 'symlink escaping ext dir must be rejected');
+
+      const debugPath = path.join(tasksDir, 'debug.md');
+      const debugContent = fs.existsSync(debugPath) ? fs.readFileSync(debugPath, 'utf8') : '';
+      assert.match(stderr + debugContent, /path|traversal|outside|realpath/i);
+
+      // Handler must NOT be registered
+      assert.equal(bus.listHandlers('OnPwn').length, 0);
+    });
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/extensions/loader.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/loader.js
@@ -1,0 +1,204 @@
+/**
+ * loader.js — discovers, validates, and registers /work extension modules.
+ *
+ * Responsibilities (Task 3 / R3, R6, R8, G1, G2, G4, G8):
+ *   - Discover `.js` files under `<repoRoot>/.claude/work-extensions/`.
+ *   - Skip `.ts` files in Phase 1 with a warning (G8).
+ *   - Validate `{events, handler, priority?}` export shape.
+ *   - Reject files whose realpath escapes the extensions directory (security).
+ *   - Isolate require()-time errors per file so one broken extension does not
+ *     crash /work (G4, R6).
+ *   - Register valid extensions against the supplied event bus.
+ *
+ * Errors are logged via `createDebugLog(tasksDir).error(...)` and surfaced to
+ * stderr at warn level.
+ *
+ * Session scoping: callers (index.js / hook entry points) gate on
+ * `findActiveMarker` from `../marker` before invoking `loadExtensions`, so
+ * this module stays pure (no I/O outside the supplied repoRoot/tasksDir) and
+ * relies on the marker check upstream to scope extension loading to an active
+ * /work session.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { createDebugLog } = require('../debug-log');
+// marker.js — referenced by callers (index.js / hooks) via findActiveMarker
+// to gate loadExtensions on an active /work session; loader itself is pure.
+const _marker = require('../marker'); // eslint-disable-line no-unused-vars
+
+const EXTENSIONS_REL = path.join('.claude', 'work-extensions');
+
+/**
+ * Validate a loaded extension module shape.
+ * @param {unknown} mod
+ * @returns {string|null} error message, or null if valid
+ */
+function validateExport(mod) {
+  if (!mod || typeof mod !== 'object') {
+    return 'extension export must be an object with {events, handler}';
+  }
+  if (!Array.isArray(mod.events) || mod.events.length === 0) {
+    return 'extension export missing required `events` array';
+  }
+  if (typeof mod.handler !== 'function') {
+    return 'extension export missing required `handler` function';
+  }
+  return null;
+}
+
+function warn(log, file, message) {
+  try {
+    log.error(message, { file });
+  } catch {
+    /* fail-open */
+  }
+  try {
+    process.stderr.write(`[work-extensions] ${file}: ${message}\n`);
+  } catch {
+    /* fail-open */
+  }
+}
+
+/**
+ * Discover and load extensions from `<repoRoot>/.claude/work-extensions/`.
+ *
+ * @param {{repoRoot: string, tasksDir: string, bus: {register: Function}}} opts
+ * @returns {Array<{file: string, events: string[], loaded: boolean, error?: string}>}
+ */
+function loadExtensions(opts) {
+  const { repoRoot, tasksDir, bus } = opts || {};
+  const log = createDebugLog(tasksDir);
+  const status = [];
+
+  const extDir = path.join(repoRoot, EXTENSIONS_REL);
+
+  if (!fs.existsSync(extDir)) {
+    // R8 backward compatibility: repos without `.claude/work-extensions/`
+    // MUST NOT see any stderr warning. Debug-log is kept (only visible when
+    // tasksDir is opened) but stderr is silenced for the common no-extensions
+    // case so /work behaves identically to today for non-extension repos.
+    try {
+      log.error('no extensions directory; skipping', { dir: extDir });
+    } catch {
+      /* fail-open */
+    }
+    return status;
+  }
+
+  let realExtDir;
+  try {
+    realExtDir = fs.realpathSync(extDir);
+  } catch (err) {
+    warn(log, extDir, `failed to resolve realpath: ${err.message}`);
+    return status;
+  }
+
+  let entries;
+  try {
+    entries = fs.readdirSync(extDir);
+  } catch (err) {
+    warn(log, extDir, `failed to read extensions directory: ${err.message}`);
+    return status;
+  }
+
+  for (const name of entries) {
+    const full = path.join(extDir, name);
+    const entry = loadOneExtension(name, full, realExtDir, log, bus);
+    if (entry) status.push(entry);
+  }
+
+  return status;
+}
+
+/**
+ * Resolve realpath and verify it stays under the extensions dir.
+ * @param {string} full
+ * @param {string} realExtDir
+ * @param {{error: Function}} log
+ * @returns {{realFile: string|null, error: string|null}}
+ */
+function resolveRealFile(full, realExtDir, log) {
+  let realFile;
+  try {
+    realFile = fs.realpathSync(full);
+  } catch (err) {
+    const msg = `failed to resolve realpath: ${err.message}`;
+    warn(log, full, msg);
+    return { realFile: null, error: err.message };
+  }
+  const rel = path.relative(realExtDir, realFile);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    const msg = `path traversal rejected — realpath outside extensions dir: ${realFile}`;
+    warn(log, full, msg);
+    return { realFile: null, error: msg };
+  }
+  return { realFile, error: null };
+}
+
+/**
+ * Process a single candidate file: classify by extension, require, validate,
+ * and register against the bus. Returns a status entry or null when the file
+ * type is silently skipped (non-.js / non-.ts).
+ * Extracted from loadExtensions to keep the parent function under the
+ * cyclomatic-complexity gate.
+ *
+ * @param {string} name  basename
+ * @param {string} full  full filesystem path
+ * @param {string} realExtDir
+ * @param {{error: Function}} log
+ * @param {{register: Function}} bus
+ * @returns {object|null}
+ */
+function loadOneExtension(name, full, realExtDir, log, bus) {
+  const ext = path.extname(name).toLowerCase();
+  if (ext === '.ts') {
+    const msg = `Phase 1 supports .js only — skipping ${name}`;
+    warn(log, full, msg);
+    return { file: full, events: [], loaded: false, error: msg };
+  }
+  if (ext !== '.js') return null;
+
+  const { realFile, error: realErr } = resolveRealFile(full, realExtDir, log);
+  if (!realFile) return { file: full, events: [], loaded: false, error: realErr };
+
+  let mod;
+  try {
+    delete require.cache[realFile];
+    mod = require(realFile);
+  } catch (err) {
+    warn(log, full, `failed to require extension: ${err.message}`);
+    return { file: full, events: [], loaded: false, error: err.message };
+  }
+
+  const validationError = validateExport(mod);
+  if (validationError) {
+    warn(log, full, validationError);
+    return { file: full, events: [], loaded: false, error: validationError };
+  }
+
+  try {
+    for (const eventName of mod.events) {
+      bus.register({
+        eventName,
+        handler: mod.handler,
+        priority: mod.priority,
+        sourceFile: full,
+        match: mod.match,
+      });
+    }
+  } catch (err) {
+    warn(log, full, `failed to register extension: ${err.message}`);
+    return { file: full, events: mod.events || [], loaded: false, error: err.message };
+  }
+
+  return { file: full, events: mod.events.slice(), loaded: true };
+}
+
+module.exports = {
+  loadExtensions,
+  validateExport,
+};

--- a/plugins/work/scripts/workflows/work/lib/marker.js
+++ b/plugins/work/scripts/workflows/work/lib/marker.js
@@ -85,7 +85,13 @@ function findActiveMarker(tasksBase, markerFilename, caller = ownerStamp()) {
       const markerPath = path.join(tasksBase, entry.name, markerFilename);
       if (!fs.existsSync(markerPath)) continue;
       try {
-        candidates.push(JSON.parse(fs.readFileSync(markerPath, 'utf8')));
+        // Enrich the parsed marker with the resolved tasksDir so callers can
+        // route extension dispatch to the correct per-ticket scope without
+        // re-deriving it from `ticket` (which is the raw input, not the
+        // sanitized directory name).
+        const parsed = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+        parsed.tasksDir = path.join(tasksBase, entry.name);
+        candidates.push(parsed);
       } catch {
         /* skip corrupt marker */
       }


### PR DESCRIPTION
## Existing Behavior

- `findActiveMarker` returns parsed marker JSON as-is; callers that need to route to the per-ticket `tasksDir` must re-derive the path from the raw `ticket` field themselves.
- No extension discovery or loading mechanism exists; any future extension hooks have no entry point to register against the event bus.

## Intended New Behavior

- `findActiveMarker` enriches each parsed marker with a `tasksDir` field set to the resolved `<tasksBase>/<entry>` directory, eliminating per-caller path reconstruction and providing a stable, sanitized scope for extension dispatch.
- `loadExtensions({ repoRoot, tasksDir, bus })` discovers all `.js` files under `<repoRoot>/.claude/work-extensions/`, skips `.ts` files with a Phase-1 warning, validates `{events, handler}` export shape, rejects symlinks whose realpath escapes the extensions directory, isolates `require()`-time errors per file so one broken extension cannot crash `/work`, registers valid extensions against the supplied event bus, and returns a status array for observability.
- Repos with no extensions directory emit no stderr output, preserving full backward compatibility.

## Slice 4 of 7 — stack roadmap

| # | Branch | Description | Status |
|---|--------|-------------|--------|
| 1 | `GH-522-1-debug-log` | `createDebugLog` utility | merged into main |
| 2 | `GH-522-2-ctx` | Extension `ctx` object | merged into main |
| 3 | `GH-522-3-event-bus` | Priority event bus | base of this PR |
| **4** | **`GH-522-4-loader`** | **Extension loader + tasksDir on marker** | **this PR** |
| 5 | `GH-522-5-dispatch` | Extension dispatch + error-isolation tests | stacked on 4 |
| 6 | `GH-522-6-index` | `initExtensions` public facade | stacked on 5 |
| 7 | `GH-522-7-integration` | End-to-end integration tests | stacked on 6 |

All PRs will be retargeted to `main` as their ancestors merge.

## Deferred coverage note

`error-isolation.test.js` (from PR #556) is deferred to slice 5. It imports `_fixtures.js` which requires `index.js` — the public `initExtensions` facade introduced in slice 6. Running it here would import a module that does not yet exist, causing false test failures. It will be included in `GH-522-5-dispatch` alongside the dispatch layer that owns the isolation guarantee.

## Dev Checks

- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Run loader tests standalone (no `index.js` dependency):**

```bash
node --test plugins/work/scripts/workflows/work/lib/extensions/__tests__/loader.test.js
```

**Verify marker enrichment:**

```bash
node -e "
  const { findActiveMarker } = require('./plugins/work/scripts/workflows/work/lib/marker');
  const m = findActiveMarker(process.env.TASKS_BASE, 'work-session.json');
  console.log(m && m.tasksDir);
"
```

Expected: the resolved per-ticket `tasksDir` path is printed; previously this field was absent from the returned marker object.

**Verify backward compatibility (no extensions directory present):**

Invoke `loadExtensions` in a repo without the extensions directory. Confirm no stderr is produced and the return value is an empty array.

### Test Results

```
✔ returns empty status and logs "no extensions directory; skipping" when dir missing
✔ loads a .js extension with {events, handler} and registers against the bus
✔ catches require() throw, logs error, emits stderr warn, and continues
✔ skips .ts files with warning "Phase 1 supports .js only" referencing the file
✔ skips files missing events or handler with a logged validation error
✔ rejects symlinks whose realpath escapes the extensions directory

tests 6 | pass 6 | fail 0 — duration 94ms
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Loads arbitrary `.js` from a repo-controlled directory via `require()` with path-traversal checks; failures are isolated but extension code still runs in the /work process.
> 
> **Overview**
> Adds **`loadExtensions`** to discover `.js` modules under `.claude/work-extensions/`, validate `{events, handler}`, register handlers on the event bus, and return per-file status—without breaking repos that have no extensions dir (no stderr in that case).
> 
> **`findActiveMarker`** now attaches **`tasksDir`** (resolved `tasksBase/<entry>`) on each marker so extension dispatch can target the correct ticket folder without re-deriving paths from raw `ticket`.
> 
> The loader **skips `.ts`** in Phase 1, **isolates** per-file `require`/validation failures, and **rejects** paths whose `realpath` escapes the extensions directory. Unit tests cover discovery, backward compatibility, broken modules, and symlink hardening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79fa276d301cc5fcb27fff591c41fdd04c80fbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->