### PR TITLE
feat(work-extensions): add initExtensions facade + status CLI (GH-522) [5/7]

### DIFF
--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/_fixtures.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/_fixtures.js
@@ -1,0 +1,115 @@
+/**
+ * _fixtures.js — shared test helpers for Task 11 cross-cutting suites.
+ *
+ * Pure helpers — no test logic, no node:test imports. Just temp-dir
+ * + write-extension utilities used by:
+ *   - dispatch.test.js
+ *   - error-isolation.test.js
+ *   - end-to-end.integration.test.js
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const EXTENSIONS_REL = path.join('.claude', 'work-extensions');
+const INDEX_PATH = path.resolve(__dirname, '..', 'index.js');
+const EVENT_BUS_PATH = path.resolve(__dirname, '..', 'event-bus.js');
+
+/**
+ * Force-fresh require of the public extensions entry point.
+ * Clears the index module AND the event-bus module (the latter holds
+ * module-level handler registry state).
+ * @returns {{initExtensions: Function}}
+ */
+function loadFreshIndex() {
+  delete require.cache[require.resolve(INDEX_PATH)];
+  delete require.cache[require.resolve(EVENT_BUS_PATH)];
+  return require(INDEX_PATH);
+}
+
+/**
+ * Create a temp repo with `<root>/tasks/<ticket>` populated.
+ * @param {string} [prefix]
+ * @returns {{root: string, tasksDir: string}}
+ */
+function makeTempRepo(prefix) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix || 'ext-fix-'}`));
+  const tasksDir = path.join(root, 'tasks', 'GH-522');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  return { root, tasksDir };
+}
+
+/**
+ * Ensure `<repoRoot>/.claude/work-extensions/` exists and return its path.
+ * @param {string} repoRoot
+ * @returns {string}
+ */
+function makeExtensionsDir(repoRoot) {
+  const extDir = path.join(repoRoot, EXTENSIONS_REL);
+  fs.mkdirSync(extDir, { recursive: true });
+  return extDir;
+}
+
+/**
+ * Write an extension file with `body` source code into `extDir/name`.
+ * @param {string} extDir
+ * @param {string} name
+ * @param {string} body
+ * @returns {string} full path to the written file
+ */
+function writeExtension(extDir, name, body) {
+  const full = path.join(extDir, name);
+  fs.writeFileSync(full, body);
+  return full;
+}
+
+/**
+ * Copy the in-tree reference extension (from plugins/work/references/work-extensions/)
+ * into the temp repo's `.claude/work-extensions/` directory so loader can find it.
+ * @param {string} repoRoot
+ * @param {string} referenceName e.g. 'cortex-auto-recall.js'
+ * @returns {string} full path to the installed copy
+ */
+function installReferenceExtension(repoRoot, referenceName) {
+  // __tests__ → extensions → lib → work → workflows → scripts → work → references
+  const src = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    '..',
+    '..',
+    'references',
+    'work-extensions',
+    referenceName
+  );
+  const extDir = makeExtensionsDir(repoRoot);
+  const dst = path.join(extDir, referenceName);
+  fs.copyFileSync(src, dst);
+  return dst;
+}
+
+/**
+ * Best-effort cleanup of a temp repo root.
+ * @param {string} root
+ */
+function cleanup(root) {
+  try {
+    fs.rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+module.exports = {
+  loadFreshIndex,
+  makeTempRepo,
+  makeExtensionsDir,
+  writeExtension,
+  installReferenceExtension,
+  cleanup,
+};

--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/dispatch.test.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/dispatch.test.js
@@ -1,0 +1,155 @@
+/**
+ * dispatch.test.js — G6 priority chain through the public `initExtensions` API.
+ *
+ * Verifies:
+ *   - Multiple handlers per event run in priority-descending order.
+ *   - Equal priority uses lexical filename ascending as tiebreaker.
+ *   - `passthrough` continues the chain (each handler in sequence still runs).
+ *   - Dispatch awaits async handlers in order.
+ *
+ * Covers Task 11 acceptance criteria (G6, R9).
+ */
+
+'use strict';
+
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadFreshIndex,
+  makeTempRepo,
+  makeExtensionsDir,
+  writeExtension,
+  cleanup,
+} = require('./_fixtures');
+
+const created = [];
+afterEach(() => {
+  while (created.length) {
+    cleanup(created.pop());
+  }
+});
+
+function freshRepo() {
+  const r = makeTempRepo('dispatch-test-');
+  created.push(r.root);
+  return r;
+}
+
+/** Build an extension body that appends a tag to a shared sentinel JSON array. */
+function appenderExt(sentinelPath, tag, priority) {
+  return `const fs = require('node:fs');
+module.exports = {
+  events: ['OnTicketResolved'],
+  priority: ${priority},
+  handler: (payload, ctx) => {
+    const order = JSON.parse(fs.readFileSync(${JSON.stringify(sentinelPath)}, 'utf8'));
+    order.push(${JSON.stringify(tag)});
+    fs.writeFileSync(${JSON.stringify(sentinelPath)}, JSON.stringify(order));
+    ctx.passthrough();
+  },
+};`;
+}
+
+describe('dispatch — G6 priority chain through initExtensions', () => {
+  it('runs handlers in priority-descending order across multiple extensions', async () => {
+    const { initExtensions } = loadFreshIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    const sentinel = `${root}/order.json`;
+    require('node:fs').writeFileSync(sentinel, '[]');
+
+    // priority 10 (lowest), 50 (default-ish), 90 (highest)
+    writeExtension(extDir, 'low.js', appenderExt(sentinel, 'low-10', 10));
+    writeExtension(extDir, 'mid.js', appenderExt(sentinel, 'mid-50', 50));
+    writeExtension(extDir, 'high.js', appenderExt(sentinel, 'high-90', 90));
+
+    const api = initExtensions({ repoRoot: root, tasksDir });
+    await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+
+    const order = JSON.parse(require('node:fs').readFileSync(sentinel, 'utf8'));
+    assert.deepEqual(order, ['high-90', 'mid-50', 'low-10']);
+  });
+
+  it('breaks priority ties by lexical filename ascending', async () => {
+    const { initExtensions } = loadFreshIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    const sentinel = `${root}/tiebreak.json`;
+    require('node:fs').writeFileSync(sentinel, '[]');
+
+    // Same priority — must order by filename ascending: a, b, c.
+    writeExtension(extDir, 'c-third.js', appenderExt(sentinel, 'c', 50));
+    writeExtension(extDir, 'a-first.js', appenderExt(sentinel, 'a', 50));
+    writeExtension(extDir, 'b-second.js', appenderExt(sentinel, 'b', 50));
+
+    const api = initExtensions({ repoRoot: root, tasksDir });
+    await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+
+    const order = JSON.parse(require('node:fs').readFileSync(sentinel, 'utf8'));
+    assert.deepEqual(order, ['a', 'b', 'c']);
+  });
+
+  it('passthrough continues the chain — every subsequent handler still runs', async () => {
+    const { initExtensions } = loadFreshIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    const sentinel = `${root}/chain.json`;
+    require('node:fs').writeFileSync(sentinel, '[]');
+
+    writeExtension(extDir, 'h1.js', appenderExt(sentinel, 'h1', 70));
+    writeExtension(extDir, 'h2.js', appenderExt(sentinel, 'h2', 60));
+    writeExtension(extDir, 'h3.js', appenderExt(sentinel, 'h3', 50));
+
+    const api = initExtensions({ repoRoot: root, tasksDir });
+    await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+
+    const order = JSON.parse(require('node:fs').readFileSync(sentinel, 'utf8'));
+    assert.deepEqual(order, ['h1', 'h2', 'h3']);
+  });
+
+  it('awaits async handlers in priority order', async () => {
+    const { initExtensions } = loadFreshIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    const sentinel = `${root}/async.json`;
+    require('node:fs').writeFileSync(sentinel, '[]');
+
+    writeExtension(
+      extDir,
+      'slow-high.js',
+      `const fs = require('node:fs');
+module.exports = {
+  events: ['OnTicketResolved'],
+  priority: 90,
+  handler: async (payload, ctx) => {
+    await new Promise((r) => setTimeout(r, 15));
+    const o = JSON.parse(fs.readFileSync(${JSON.stringify(sentinel)}, 'utf8'));
+    o.push('slow-high');
+    fs.writeFileSync(${JSON.stringify(sentinel)}, JSON.stringify(o));
+  },
+};`
+    );
+    writeExtension(
+      extDir,
+      'fast-low.js',
+      `const fs = require('node:fs');
+module.exports = {
+  events: ['OnTicketResolved'],
+  priority: 10,
+  handler: (payload, ctx) => {
+    const o = JSON.parse(fs.readFileSync(${JSON.stringify(sentinel)}, 'utf8'));
+    o.push('fast-low');
+    fs.writeFileSync(${JSON.stringify(sentinel)}, JSON.stringify(o));
+  },
+};`
+    );
+
+    const api = initExtensions({ repoRoot: root, tasksDir });
+    await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+
+    const order = JSON.parse(require('node:fs').readFileSync(sentinel, 'utf8'));
+    // Even though fast-low is synchronous, the dispatcher must await slow-high first.
+    assert.deepEqual(order, ['slow-high', 'fast-low']);
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/error-isolation.test.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/error-isolation.test.js
@@ -1,0 +1,248 @@
+/**
+ * error-isolation.test.js — G5 + G7 through the public `initExtensions` API.
+ *
+ * Verifies:
+ *   - G5: a sync handler throw is caught, error logged, and subsequent handlers
+ *     in the priority chain still run (treated as passthrough).
+ *   - G5: dispatch itself never rejects when a handler throws (R6).
+ *   - G7: a PhaseNotReadyError thrown from a handler that invoked a Phase 2 ctx
+ *     method is caught and treated as passthrough; phase context surfaces in
+ *     the logged error.
+ *
+ * Covers Task 11 acceptance criteria (G5, G7, R6).
+ */
+
+'use strict';
+
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const {
+  loadFreshIndex,
+  makeTempRepo,
+  makeExtensionsDir,
+  writeExtension,
+  cleanup,
+} = require('./_fixtures');
+
+const created = [];
+afterEach(() => {
+  while (created.length) {
+    cleanup(created.pop());
+  }
+});
+
+function freshRepo() {
+  const r = makeTempRepo('err-iso-test-');
+  created.push(r.root);
+  return r;
+}
+
+/**
+ * Capture stderr writes for the duration of `fn`.
+ * Restored even when `fn` throws.
+ * @param {() => Promise<void>} fn
+ * @returns {Promise<string>}
+ */
+async function withStderr(fn) {
+  const chunks = [];
+  const original = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (buf) => {
+    chunks.push(String(buf));
+    return true;
+  };
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return chunks.join('');
+}
+
+describe('error isolation — G5 sync handler throw caught', () => {
+  it('catches a throwing handler and runs subsequent handlers in the chain', async () => {
+    const { initExtensions } = loadFreshIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    const sentinel = `${root}/chain.json`;
+    fs.writeFileSync(sentinel, '[]');
+
+    // Highest priority — throws.
+    writeExtension(
+      extDir,
+      'a-boom.js',
+      `module.exports = {
+  events: ['OnTicketResolved'],
+  priority: 90,
+  handler: () => { throw new Error('boom from a-boom'); },
+};`
+    );
+    // Middle priority — records and continues.
+    writeExtension(
+      extDir,
+      'b-mid.js',
+      `const fs = require('node:fs');
+module.exports = {
+  events: ['OnTicketResolved'],
+  priority: 50,
+  handler: () => {
+    const o = JSON.parse(fs.readFileSync(${JSON.stringify(sentinel)}, 'utf8'));
+    o.push('b-mid');
+    fs.writeFileSync(${JSON.stringify(sentinel)}, JSON.stringify(o));
+  },
+};`
+    );
+    // Lowest priority — records.
+    writeExtension(
+      extDir,
+      'c-low.js',
+      `const fs = require('node:fs');
+module.exports = {
+  events: ['OnTicketResolved'],
+  priority: 10,
+  handler: () => {
+    const o = JSON.parse(fs.readFileSync(${JSON.stringify(sentinel)}, 'utf8'));
+    o.push('c-low');
+    fs.writeFileSync(${JSON.stringify(sentinel)}, JSON.stringify(o));
+  },
+};`
+    );
+
+    const api = initExtensions({ repoRoot: root, tasksDir });
+
+    const stderr = await withStderr(async () => {
+      await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+    });
+
+    // The chain must continue past the throw.
+    const order = JSON.parse(fs.readFileSync(sentinel, 'utf8'));
+    assert.deepEqual(order, ['b-mid', 'c-low']);
+
+    // The error must be logged (stderr warn line).
+    assert.match(stderr, /boom from a-boom/);
+    assert.match(stderr, /OnTicketResolved/);
+  });
+
+  it('dispatch never rejects even when every handler throws', async () => {
+    const { initExtensions } = loadFreshIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+
+    writeExtension(
+      extDir,
+      'boom-1.js',
+      `module.exports = {
+  events: ['OnTicketResolved'],
+  handler: () => { throw new Error('boom 1'); },
+};`
+    );
+    writeExtension(
+      extDir,
+      'boom-2.js',
+      `module.exports = {
+  events: ['OnTicketResolved'],
+  handler: () => { throw new Error('boom 2'); },
+};`
+    );
+
+    const api = initExtensions({ repoRoot: root, tasksDir });
+
+    let rejected = false;
+    await withStderr(async () => {
+      try {
+        await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+      } catch {
+        rejected = true;
+      }
+    });
+
+    assert.equal(rejected, false, 'dispatch must never reject when a handler throws');
+  });
+});
+
+describe('error isolation — G7 PhaseNotReadyError caught as passthrough', () => {
+  it('Handler runtime error is caught and treated as passthrough', async () => {
+    // This title verbatim covers the task-next scenario:
+    // "Handler runtime error is caught and treated as passthrough".
+    const { initExtensions } = loadFreshIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    const sentinel = `${root}/after-phase.json`;
+    fs.writeFileSync(sentinel, '[]');
+
+    // Handler calls a Phase 2 method → PhaseNotReadyError thrown.
+    writeExtension(
+      extDir,
+      'a-phase2.js',
+      `module.exports = {
+  events: ['OnTicketResolved'],
+  priority: 90,
+  handler: (payload, ctx) => {
+    // Phase 2 method must throw PhaseNotReadyError in Phase 1.
+    ctx.handled({ result: 'nope' });
+  },
+};`
+    );
+    // Subsequent handler still records — proving the throw was treated as passthrough.
+    writeExtension(
+      extDir,
+      'b-after.js',
+      `const fs = require('node:fs');
+module.exports = {
+  events: ['OnTicketResolved'],
+  priority: 10,
+  handler: () => {
+    const o = JSON.parse(fs.readFileSync(${JSON.stringify(sentinel)}, 'utf8'));
+    o.push('after-phase2');
+    fs.writeFileSync(${JSON.stringify(sentinel)}, JSON.stringify(o));
+  },
+};`
+    );
+
+    const api = initExtensions({ repoRoot: root, tasksDir });
+
+    const stderr = await withStderr(async () => {
+      await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+    });
+
+    const order = JSON.parse(fs.readFileSync(sentinel, 'utf8'));
+    assert.deepEqual(order, ['after-phase2'], 'subsequent handler must run after PhaseNotReadyError');
+
+    // Phase context surfaces — either the error name or the Phase 2 marker.
+    assert.match(stderr, /Phase 2|PhaseNotReadyError|ctx\.handled/);
+  });
+
+  it('catches an explicit PhaseNotReadyError throw from a handler', async () => {
+    const { initExtensions } = loadFreshIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+
+    writeExtension(
+      extDir,
+      'phase-throw.js',
+      `module.exports = {
+  events: ['OnTicketResolved'],
+  handler: () => {
+    const err = new Error('Phase 2 method ctx.block() not available');
+    err.name = 'PhaseNotReadyError';
+    throw err;
+  },
+};`
+    );
+
+    const api = initExtensions({ repoRoot: root, tasksDir });
+
+    let rejected = false;
+    const stderr = await withStderr(async () => {
+      try {
+        await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+      } catch {
+        rejected = true;
+      }
+    });
+
+    assert.equal(rejected, false, 'PhaseNotReadyError from a handler must not reject dispatch');
+    assert.match(stderr, /Phase 2|PhaseNotReadyError/);
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/index.test.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/index.test.js
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for the extensions public entry point — `initExtensions`.
+ * Covers Task 4 acceptance criteria (R3, R6, R8).
+ *
+ * Run with:
+ *   node --test plugins/work/scripts/workflows/work/lib/extensions/__tests__/index.test.js
+ */
+
+'use strict';
+
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const INDEX_PATH = path.resolve(__dirname, '..', 'index.js');
+const EVENT_BUS_PATH = path.resolve(__dirname, '..', 'event-bus.js');
+
+function loadIndex() {
+  // Force fresh module + fresh event-bus (event-bus has module-level state).
+  delete require.cache[require.resolve(INDEX_PATH)];
+  delete require.cache[require.resolve(EVENT_BUS_PATH)];
+  return require(INDEX_PATH);
+}
+
+function makeTempRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'index-test-'));
+  const tasksDir = path.join(root, 'tasks', 'GH-522');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  return { root, tasksDir };
+}
+
+function makeExtensionsDir(repoRoot) {
+  const extDir = path.join(repoRoot, '.claude', 'work-extensions');
+  fs.mkdirSync(extDir, { recursive: true });
+  return extDir;
+}
+
+function writeExt(extDir, name, body) {
+  const full = path.join(extDir, name);
+  fs.writeFileSync(full, body);
+  return full;
+}
+
+const created = [];
+afterEach(() => {
+  while (created.length) {
+    const dir = created.pop();
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+function freshRepo() {
+  const r = makeTempRepo();
+  created.push(r.root);
+  return r;
+}
+
+describe('initExtensions — public entry point', () => {
+  it('exports initExtensions as a function', () => {
+    const mod = loadIndex();
+    assert.equal(typeof mod.initExtensions, 'function');
+  });
+
+  it('returns an object with dispatch and status functions', () => {
+    const { initExtensions } = loadIndex();
+    const { root, tasksDir } = freshRepo();
+    const api = initExtensions({ repoRoot: root, tasksDir });
+    assert.equal(typeof api.dispatch, 'function');
+    assert.equal(typeof api.status, 'function');
+  });
+
+  it('returns empty status and dispatch is a safe no-op when no extensions dir exists (R8)', async () => {
+    const { initExtensions } = loadIndex();
+    const { root, tasksDir } = freshRepo();
+    const api = initExtensions({ repoRoot: root, tasksDir });
+    assert.deepEqual(api.status(), []);
+    // dispatch must not throw even with no handlers registered
+    await api.dispatch('OnSessionStart', { ticketId: 'GH-522' });
+  });
+
+  it('status() returns loader entries with file/events/loaded for a valid extension', () => {
+    const { initExtensions } = loadIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    writeExt(
+      extDir,
+      'valid-ext.js',
+      `module.exports = { events: ['OnTicketResolved'], handler: () => {} };`
+    );
+    const api = initExtensions({ repoRoot: root, tasksDir });
+    const status = api.status();
+    assert.equal(status.length, 1);
+    assert.equal(status[0].loaded, true);
+    assert.deepEqual(status[0].events, ['OnTicketResolved']);
+    assert.match(status[0].file, /valid-ext\.js$/);
+  });
+
+  it('dispatch invokes a registered handler with a ctx built from createCtx', async () => {
+    const { initExtensions } = loadIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    // The handler writes into a sentinel file so we can verify it was invoked
+    // with the right payload and a real ctx (passthrough + injectContext present).
+    const sentinel = path.join(root, 'sentinel.json');
+    writeExt(
+      extDir,
+      'capture.js',
+      `const fs = require('node:fs');
+module.exports = {
+  events: ['OnTicketResolved'],
+  handler: (payload, ctx) => {
+    ctx.injectContext('hello from ext');
+    fs.writeFileSync(${JSON.stringify(sentinel)}, JSON.stringify({
+      event: ctx.event,
+      payload,
+      hasPassthrough: typeof ctx.passthrough === 'function',
+      injected: ctx.getInjectedContext(),
+    }));
+  },
+};`
+    );
+    const api = initExtensions({ repoRoot: root, tasksDir });
+    await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+    const captured = JSON.parse(fs.readFileSync(sentinel, 'utf8'));
+    assert.equal(captured.event, 'OnTicketResolved');
+    assert.deepEqual(captured.payload, { ticketId: 'GH-522' });
+    assert.equal(captured.hasPassthrough, true);
+    assert.equal(captured.injected, 'hello from ext');
+  });
+
+  it('memoizes the result per (repoRoot, tasksDir) — does not re-load on repeat calls', () => {
+    const { initExtensions } = loadIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    writeExt(extDir, 'a.js', `module.exports = { events: ['OnSessionStart'], handler: () => {} };`);
+    const a = initExtensions({ repoRoot: root, tasksDir });
+    const firstStatus = a.status();
+    // Add a second extension AFTER init — memoization means it must not appear.
+    writeExt(extDir, 'b.js', `module.exports = { events: ['OnSessionStart'], handler: () => {} };`);
+    const b = initExtensions({ repoRoot: root, tasksDir });
+    assert.equal(a, b, 'same keypair must return the identical API object');
+    assert.deepEqual(
+      b.status(),
+      firstStatus,
+      'status must be the original loader result, not re-loaded'
+    );
+    assert.equal(b.status().length, 1);
+  });
+
+  it('returns a different instance for a different (repoRoot, tasksDir) keypair', () => {
+    const { initExtensions } = loadIndex();
+    const r1 = freshRepo();
+    const r2 = freshRepo();
+    const a = initExtensions({ repoRoot: r1.root, tasksDir: r1.tasksDir });
+    const b = initExtensions({ repoRoot: r2.root, tasksDir: r2.tasksDir });
+    assert.notEqual(a, b);
+  });
+
+  it('dispatch is a safe no-op for an event name with no registered handlers', async () => {
+    const { initExtensions } = loadIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    writeExt(
+      extDir,
+      'only-session.js',
+      `module.exports = { events: ['OnSessionStart'], handler: () => {} };`
+    );
+    const api = initExtensions({ repoRoot: root, tasksDir });
+    // Dispatching an event nobody subscribed to must not throw (R6/R8).
+    await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+  });
+
+  it('isolates a throwing handler from the dispatch caller (R6)', async () => {
+    const { initExtensions } = loadIndex();
+    const { root, tasksDir } = freshRepo();
+    const extDir = makeExtensionsDir(root);
+    writeExt(
+      extDir,
+      'boom.js',
+      `module.exports = {
+        events: ['OnTicketResolved'],
+        handler: () => { throw new Error('boom'); },
+      };`
+    );
+    const api = initExtensions({ repoRoot: root, tasksDir });
+    // event-bus catches handler errors and logs — dispatch must resolve.
+    await api.dispatch('OnTicketResolved', { ticketId: 'GH-522' });
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/status-command.test.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/status-command.test.js
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the work-extensions-status diagnostic command (Task 9).
+ * Covers G10: Diagnostic command lists loaded extensions and load errors.
+ *
+ * The script spawns as a child process against a fixture repo containing one
+ * valid and one broken extension, asserting JSON output shape per
+ * `ExtensionStatusEntry[]`.
+ *
+ * Run with:
+ *   node --test plugins/work/scripts/workflows/work/lib/extensions/__tests__/status-command.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const SCRIPT_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'scripts',
+  'work-extensions-status.js'
+);
+
+function makeTempRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'status-cmd-'));
+  const tasksDir = path.join(repoRoot, 'tasks', 'GH-522');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  const extDir = path.join(repoRoot, '.claude', 'work-extensions');
+  fs.mkdirSync(extDir, { recursive: true });
+  return { repoRoot, tasksDir, extDir };
+}
+
+function writeFile(p, contents) {
+  fs.writeFileSync(p, contents);
+}
+
+function runScript(args, env) {
+  const result = spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return { exitCode: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+describe('Diagnostic command lists loaded extensions and load errors', () => {
+  /** @type {string[]} */
+  let toCleanup = [];
+
+  beforeEach(() => {
+    toCleanup = [];
+  });
+
+  afterEach(() => {
+    for (const dir of toCleanup) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it('script file exists at expected location', () => {
+    assert.ok(fs.existsSync(SCRIPT_PATH), `expected script at ${SCRIPT_PATH}`);
+  });
+
+  it('emits one-line JSON ExtensionStatusEntry[] for a fixture dir (one valid + one broken)', () => {
+    const { repoRoot, tasksDir, extDir } = makeTempRepo();
+    toCleanup.push(repoRoot);
+
+    // Valid extension
+    writeFile(
+      path.join(extDir, 'valid-ext.js'),
+      "module.exports = { events: ['OnSessionStart'], handler: (ctx) => ctx.passthrough() };\n"
+    );
+    // Broken extension — throws on require
+    writeFile(path.join(extDir, 'broken-ext.js'), "throw new Error('boom-at-load');\n");
+
+    const out = runScript(['--repo-root', repoRoot, '--tasks-dir', tasksDir], {});
+    assert.equal(out.exitCode, 0, `script failed: stderr=${out.stderr}`);
+    assert.ok(out.stdout.trim().length > 0, 'expected JSON on stdout');
+
+    // Default output must be one-line JSON (no trailing newline noise from indent).
+    const lines = out.stdout.trim().split('\n');
+    assert.equal(lines.length, 1, `expected one-line JSON by default, got:\n${out.stdout}`);
+
+    const parsed = JSON.parse(out.stdout);
+    assert.ok(Array.isArray(parsed), 'output must be an array');
+    assert.equal(parsed.length, 2, `expected 2 entries, got ${parsed.length}`);
+
+    const valid = parsed.find((e) => e.file && e.file.includes('valid-ext'));
+    const broken = parsed.find((e) => e.file && e.file.includes('broken-ext'));
+    assert.ok(valid, 'expected entry for valid-ext.js');
+    assert.ok(broken, 'expected entry for broken-ext.js');
+
+    assert.equal(valid.loaded, true, 'valid extension should be loaded:true');
+    assert.deepEqual(valid.events, ['OnSessionStart']);
+
+    assert.equal(broken.loaded, false, 'broken extension should be loaded:false');
+    assert.equal(typeof broken.error, 'string', 'broken entry must include error message');
+    assert.ok(broken.error.length > 0, 'broken.error must be non-empty');
+  });
+
+  it('--pretty flag toggles indented JSON output', () => {
+    const { repoRoot, tasksDir, extDir } = makeTempRepo();
+    toCleanup.push(repoRoot);
+
+    writeFile(
+      path.join(extDir, 'valid-ext.js'),
+      "module.exports = { events: ['OnSessionStart'], handler: (ctx) => ctx.passthrough() };\n"
+    );
+
+    const out = runScript(['--repo-root', repoRoot, '--tasks-dir', tasksDir, '--pretty'], {});
+    assert.equal(out.exitCode, 0, `script failed: stderr=${out.stderr}`);
+
+    // Pretty output spans multiple lines.
+    const lines = out.stdout.trim().split('\n');
+    assert.ok(lines.length > 1, `expected multi-line pretty JSON, got:\n${out.stdout}`);
+
+    const parsed = JSON.parse(out.stdout);
+    assert.ok(Array.isArray(parsed));
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].loaded, true);
+  });
+
+  it('emits empty JSON array when no extensions directory exists', () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'status-cmd-empty-'));
+    const tasksDir = path.join(repoRoot, 'tasks', 'GH-522');
+    fs.mkdirSync(tasksDir, { recursive: true });
+    toCleanup.push(repoRoot);
+
+    const out = runScript(['--repo-root', repoRoot, '--tasks-dir', tasksDir], {});
+    assert.equal(out.exitCode, 0, `script failed: stderr=${out.stderr}`);
+    const parsed = JSON.parse(out.stdout);
+    assert.deepEqual(parsed, []);
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/extensions/index.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/index.js
@@ -1,0 +1,152 @@
+/**
+ * extensions/index.js — public entry point for the /work extension system.
+ *
+ * Composes the three Phase 1 building blocks:
+ *   - `event-bus.js`  — registry + dispatch (Task 1)
+ *   - `ctx.js`        — per-dispatch context factory (Task 2)
+ *   - `loader.js`     — discovery, validation, error isolation (Task 3)
+ *
+ * Exposes `initExtensions({repoRoot, tasksDir})` returning `{dispatch, status}`:
+ *   - `dispatch(eventName, payload)` builds a fresh ctx via `createCtx` and
+ *     forwards to `event-bus.dispatch`.
+ *   - `status()` returns the loader's `ExtensionStatusEntry[]` snapshot.
+ *
+ * Behavior:
+ *   - Missing `.claude/work-extensions/` directory → `status() === []` and
+ *     `dispatch` is a safe no-op (R8 — backward compatibility).
+ *   - Result is memoized per `(repoRoot, tasksDir)` keypair, so repeated
+ *     callers in the same Node process share a single registry rather than
+ *     re-discovering / re-requiring extension files.
+ *
+ * Covers Task 4 acceptance criteria (R3, R6, R8).
+ */
+
+'use strict';
+
+const eventBus = require('./event-bus');
+const { createCtx } = require('./ctx');
+const { loadExtensions } = require('./loader');
+const { createDebugLog } = require('../debug-log');
+
+/**
+ * Memoization cache. Keyed by `${repoRoot}\x00${tasksDir}` so the two
+ * components cannot collide via string concatenation.
+ * @type {Map<string, {dispatch: Function, status: Function}>}
+ */
+const cache = new Map();
+
+/** @param {string} repoRoot @param {string} tasksDir @returns {string} */
+function cacheKey(repoRoot, tasksDir) {
+  return `${repoRoot}\x00${tasksDir}`;
+}
+
+/**
+ * Log a handler error to both the debug log and stderr without ever throwing.
+ * Two independent try/catch blocks so a failure in one sink cannot suppress
+ * the other.
+ * @param {{error: Function}} log
+ * @param {string} eventName
+ * @param {Error} err
+ */
+function logHandlerError(log, eventName, err) {
+  const message = err && err.message;
+  try {
+    log.error('extension handler threw', { event: eventName, message });
+  } catch {
+    /* fail-open */
+  }
+  try {
+    process.stderr.write(`[work-extensions] handler error for ${eventName}: ${message}\n`);
+  } catch {
+    /* fail-open */
+  }
+}
+
+/**
+ * Initialize the extension system for a (repoRoot, tasksDir) pair.
+ *
+ * Discovery + registration happens exactly once per keypair per process.
+ * The returned API is stable: subsequent calls with the same keypair return
+ * the identical object reference.
+ *
+ * @param {{repoRoot: string, tasksDir: string}} opts
+ * @returns {{
+ *   dispatch: (eventName: string, payload: object) => Promise<void>,
+ *   status: () => Array<{file: string, events: string[], loaded: boolean, error?: string}>,
+ * }}
+ */
+function initExtensions(opts) {
+  const { repoRoot, tasksDir } = opts || {};
+  const key = cacheKey(repoRoot, tasksDir);
+
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const statusEntries = loadExtensions({ repoRoot, tasksDir, bus: eventBus });
+  const log = createDebugLog(tasksDir);
+
+  /**
+   * Dispatch an event by name with a payload.
+   * Builds a fresh ctx per call so handlers cannot leak state across events.
+   * Safe no-op when no handlers are registered (R8). A throwing handler is
+   * caught and logged so /work never crashes on a broken extension (R6).
+   * @param {string} eventName
+   * @param {object} payload
+   * @returns {Promise<void>}
+   */
+  async function dispatch(eventName, payload) {
+    const ctx = createCtx({ event: eventName, payload, tasksDir });
+    try {
+      await eventBus.dispatch(eventName, payload, ctx);
+    } catch (err) {
+      logHandlerError(log, eventName, err);
+    }
+    return ctx.getInjectedContext();
+  }
+
+  /**
+   * Snapshot of the loader's per-file status entries.
+   * @returns {Array<{file: string, events: string[], loaded: boolean, error?: string}>}
+   */
+  function status() {
+    return statusEntries.slice();
+  }
+
+  /**
+   * List registered handlers for a given event name. Forwards to event-bus.
+   * Used by `work-auto-advance.js` to iterate `OnAgentResponseMatched`
+   * handlers and perform plugin-level regex matching before dispatch.
+   * @param {string} eventName
+   * @returns {Array<object>}
+   */
+  function listHandlers(eventName) {
+    return eventBus.listHandlers(eventName);
+  }
+
+  /**
+   * Dispatch to a single handler record located via `listHandlers`. Used by
+   * fireAgentResponseMatched so a regex match invokes ONLY the matched
+   * handler — not every handler subscribed to OnAgentResponseMatched.
+   * Returns the injected-context string for that single handler invocation.
+   * @param {object} record
+   * @param {object} payload
+   * @returns {Promise<string>}
+   */
+  async function dispatchToHandler(record, payload) {
+    const ctx = createCtx({ event: (record && record.eventName) || '', payload, tasksDir });
+    try {
+      await eventBus.dispatchToHandler(record, payload, ctx);
+    } catch (err) {
+      logHandlerError(log, (record && record.eventName) || '', err);
+    }
+    return ctx.getInjectedContext();
+  }
+
+  const api = { dispatch, status, listHandlers, dispatchToHandler };
+  cache.set(key, api);
+  return api;
+}
+
+module.exports = {
+  initExtensions,
+};

--- a/plugins/work/scripts/workflows/work/scripts/work-extensions-status.js
+++ b/plugins/work/scripts/workflows/work/scripts/work-extensions-status.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * work-extensions-status — diagnostic command for the /work extension system.
+ *
+ * Lists every discovered extension in `.claude/work-extensions/` with its
+ * load status, declared events, and any load-time error. Output is a JSON
+ * array of `ExtensionStatusEntry`:
+ *
+ *   { file: string, events: string[], loaded: boolean, error?: string }
+ *
+ * Covers Task 9 acceptance criteria (R7, G10).
+ *
+ * Usage:
+ *   work-extensions-status [--repo-root <path>] [--tasks-dir <path>] [--pretty]
+ *
+ * Resolution order for repoRoot / tasksDir:
+ *   1. Explicit `--repo-root` / `--tasks-dir` CLI flags (used by tests).
+ *   2. `findActiveMarker(TASKS_BASE, '.work.pid')` against the configured
+ *      TASKS_BASE — derives both from the active marker.
+ *
+ * Output:
+ *   - Default: single-line JSON to stdout (pipe-friendly).
+ *   - `--pretty`: 2-space-indented JSON.
+ *   - Empty array when no extensions directory exists (R8 backward compat).
+ */
+
+'use strict';
+
+const path = require('node:path');
+const fs = require('node:fs');
+
+const { initExtensions } = require(path.join(__dirname, '..', 'lib', 'extensions'));
+
+/**
+ * Parse `argv` into a flag object. Supports `--key value` and `--flag`.
+ * @param {string[]} argv
+ * @returns {{repoRoot?: string, tasksDir?: string, pretty: boolean}}
+ */
+function parseArgs(argv) {
+  const out = { pretty: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--pretty') {
+      out.pretty = true;
+    } else if (arg === '--repo-root' && i + 1 < argv.length) {
+      out.repoRoot = argv[++i];
+    } else if (arg === '--tasks-dir' && i + 1 < argv.length) {
+      out.tasksDir = argv[++i];
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve {repoRoot, tasksDir} from CLI flags or via findActiveMarker.
+ * Returns null when no marker is active and no flags supplied (no-op exit).
+ * @param {{repoRoot?: string, tasksDir?: string}} flags
+ * @returns {{repoRoot: string, tasksDir: string} | null}
+ */
+function resolveFromMarker(flags) {
+  const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
+  const wt = getConfig('WORKTREES_BASE') || '';
+  const TASKS_BASE = getConfig('TASKS_BASE') || (wt && path.join(wt, 'tasks'));
+  if (!TASKS_BASE) return null;
+  const { findActiveMarker } = require(path.join(__dirname, '..', 'lib', 'marker'));
+  const marker = findActiveMarker(TASKS_BASE, '.work.pid');
+  if (!marker) return null;
+  const tasksDir = locateTasksDir(TASKS_BASE, marker);
+  if (!tasksDir) return null;
+  return { repoRoot: marker.worktreeRoot || flags.repoRoot || process.cwd(), tasksDir };
+}
+
+function resolveContext(flags) {
+  if (flags.repoRoot && flags.tasksDir) {
+    return { repoRoot: flags.repoRoot, tasksDir: flags.tasksDir };
+  }
+  try {
+    return resolveFromMarker(flags);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find the tasksDir for the marker by scanning TASKS_BASE for a `.work.pid`
+ * whose ticket field matches.
+ * @param {string} tasksBase
+ * @param {{ticket?: string}} marker
+ * @returns {string | null}
+ */
+function locateTasksDir(tasksBase, marker) {
+  try {
+    for (const entry of fs.readdirSync(tasksBase, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const candidate = path.join(tasksBase, entry.name);
+      const markerPath = path.join(candidate, '.work.pid');
+      if (!fs.existsSync(markerPath)) continue;
+      try {
+        const parsed = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+        if (parsed.ticket === marker.ticket) return candidate;
+      } catch {
+        /* skip corrupt marker */
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Print the status array to stdout.
+ * @param {Array<object>} entries
+ * @param {boolean} pretty
+ */
+function emit(entries, pretty) {
+  const text = pretty ? JSON.stringify(entries, null, 2) : JSON.stringify(entries);
+  process.stdout.write(`${text}\n`);
+}
+
+function main() {
+  const flags = parseArgs(process.argv.slice(2));
+  const ctx = resolveContext(flags);
+  if (!ctx) {
+    // No active marker and no explicit context — emit empty array so
+    // downstream consumers always get valid JSON.
+    emit([], flags.pretty);
+    return;
+  }
+  const api = initExtensions({ repoRoot: ctx.repoRoot, tasksDir: ctx.tasksDir });
+  emit(api.status(), flags.pretty);
+}
+
+main();


### PR DESCRIPTION
## Existing Behavior

- No public entry point exists for the extension system — callers cannot compose loader + event-bus + ctx without wiring the three modules together themselves.
- No diagnostic surface exists to inspect which extensions loaded, which events they subscribe to, or whether any failed at load time.
- Cross-cutting tests for dispatch priority ordering, error isolation, and the public API surface were deferred from slices 3/4 because they require the composed facade to run.

## Intended New Behavior

- `lib/extensions/index.js` exports `initExtensions({ repoRoot, tasksDir })` which composes loader + event-bus + ctx into a single stable API, memoized per `(repoRoot, tasksDir)` keypair so repeated callers in the same Node process share one registry.
- The returned API exposes `dispatch(eventName, payload)`, `status()`, `listHandlers(eventName)`, and `dispatchToHandler(record, payload)` — covering all consumption patterns needed by `/work` hooks in slice 7.
- Missing extensions directory under the repo root is a safe no-op: `status()` returns `[]` and `dispatch` never throws (R8 backward compat).
- `scripts/work-extensions-status.js` is a runnable diagnostic CLI that emits a JSON array of `ExtensionStatusEntry` to stdout, with `--pretty` for human-readable output. Resolves context from `--repo-root`/`--tasks-dir` flags or via `findActiveMarker` against `TASKS_BASE`.
- Cross-cutting test suites (`dispatch.test.js`, `error-isolation.test.js`, `index.test.js`, `status-command.test.js`) plus shared `_fixtures.js` helpers are now in place, covering G5/G6/G7/R6/R8/R9 acceptance criteria.
- Still no wiring into `/work` hooks — that lands in slice 7.

## Slice 5 of 7 — stack roadmap

| # | Branch | PR | Description |
|---|--------|----|-------------|
| 1 | `GH-522-1-docs` | #563 | Phase 1 extension API documentation |
| 2 | `GH-522-2-ctx` | #564 | ctx primitives + PhaseNotReadyError |
| 3 | `GH-522-3-event-bus` | #565 | In-memory event bus |
| 4 | `GH-522-4-loader` | #566 | Extension loader + tasksDir on marker |
| **5** | **`GH-522-5-index-and-status`** | **this PR** | **initExtensions facade + status CLI** |
| 6 | `GH-522-6-references` | — | Reference extensions |
| 7 | `GH-522-7-wiring` | — | Wire initExtensions into /work hooks |

## Deferred coverage

`end-to-end.integration.test.js` is deferred to slice 6. It exercises full dispatch flows through the reference extension implementations which do not exist until slice 6 lands. The 21 tests in this slice cover all units that can be exercised without reference extensions.

## Dev Checks

- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend — verify the status CLI:**

1. In a worktree with an active `.work.pid` marker or passing flags explicitly:
   ```
   node plugins/work/scripts/workflows/work/scripts/work-extensions-status.js \
     --repo-root <path> --tasks-dir <path> --pretty
   ```
2. Expected: JSON array where each entry has `{ file, events, loaded, error? }`.
3. With no extensions directory under the repo root, output is `[]`.

**Run the 21 tests directly:**
```
node --test plugins/work/scripts/workflows/work/lib/extensions/__tests__/dispatch.test.js
node --test plugins/work/scripts/workflows/work/lib/extensions/__tests__/error-isolation.test.js
node --test plugins/work/scripts/workflows/work/lib/extensions/__tests__/index.test.js
node --test plugins/work/scripts/workflows/work/lib/extensions/__tests__/status-command.test.js
```

### Test Results

21/21 tests pass across the four new suites (`dispatch.test.js`, `error-isolation.test.js`, `index.test.js`, `status-command.test.js`). `end-to-end.integration.test.js` is deferred to slice 6.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New library entry point, diagnostic script, and tests only; production /work hooks are unchanged until a later slice.
> 
> **Overview**
> Adds a **public facade** for the `/work` extension stack: `initExtensions({ repoRoot, tasksDir })` wires loader, event-bus, and per-dispatch `createCtx`, caches one API per repo/tasks pair, and exposes `dispatch`, `status`, `listHandlers`, and `dispatchToHandler` (including injected-context return values). Missing `.claude/work-extensions/` stays backward compatible—empty `status()` and non-throwing `dispatch`; handler failures are logged to debug + stderr without rejecting callers.
> 
> Introduces **`work-extensions-status.js`**, a Node CLI that prints `ExtensionStatusEntry[]` JSON (compact or `--pretty`), resolving context from flags or an active `.work.pid` marker.
> 
> Adds **cross-cutting tests** (`_fixtures.js`, `index`, `dispatch`, `error-isolation`, `status-command`) covering memoization, priority/tie-break ordering, fail-open dispatch, and load diagnostics. **No `/work` hook wiring** in this slice—that is deferred to a later PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41bfb5a29e2ca474d060d24a36e21ee9a93a622. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->