### PR TITLE
feat(work-extensions): wire Phase 1 events into /work entry points (GH-522) [7/7]

### DIFF
--- a/plugins/work/hooks/hooks.json
+++ b/plugins/work/hooks/hooks.json
@@ -15,6 +15,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/work-pre-tool-call.js",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/plugins/work/hooks/work-hook.js
+++ b/plugins/work/hooks/work-hook.js
@@ -182,4 +182,59 @@ function formatPlan(plan) {
   return lines.join('\n');
 }
 
-main();
+/**
+ * fireOnPreToolCall — dispatch the OnPreToolCall extension event after the
+ * existing PreToolUse hook body, gated on an active /work marker. Errors are
+ * swallowed so a misbehaving extension can never crash the hook.
+ *
+ * Exported for unit testing; the hook itself does not yet wire this into
+ * `main()` because Phase 1 PreToolUse dispatch is invoked from a different
+ * entry point in production (see hooks.json).
+ *
+ * @param {{toolName: string, toolInput: any, tasksDir: string, repoRoot: string}} args
+ * @param {{
+ *   findActiveMarker?: Function,
+ *   initExtensions?: Function,
+ * }} [deps]
+ * @returns {void}
+ */
+async function firePreToolCall(args, deps) {
+  const { toolName, toolInput, tasksBase, tasksDir, repoRoot } = args || {};
+  // Bug fix: findActiveMarker needs TASKS_BASE (parent of all per-ticket
+  // tasksDirs), not a single per-ticket tasksDir. Accept `tasksBase` and fall
+  // back to tasksDir's parent for legacy callers.
+  let marker = null;
+  try {
+    const findMarker =
+      deps?.findActiveMarker ||
+      require(path.join(__dirname, '..', 'scripts', 'workflows', 'work', 'lib', 'marker'))
+        .findActiveMarker;
+    const base = tasksBase || (tasksDir ? path.dirname(tasksDir) : '');
+    if (!base) return;
+    marker = findMarker(base, '.work.pid');
+  } catch {
+    /* fail-open */
+  }
+  if (!marker) return;
+  try {
+    const init =
+      deps?.initExtensions ||
+      require(path.join(__dirname, '..', 'scripts', 'workflows', 'work', 'lib', 'extensions'))
+        .initExtensions;
+    const resolvedTasksDir = marker.tasksDir || tasksDir;
+    const resolvedRepoRoot = marker.worktreeRoot || repoRoot;
+    const api = init({ repoRoot: resolvedRepoRoot, tasksDir: resolvedTasksDir });
+    // Await the dispatch so async extension handlers complete before the
+    // PreToolUse hook process exits. Fail-open: dispatch errors are caught
+    // by the surrounding try/catch.
+    await api.dispatch('OnPreToolCall', { toolName, toolInput });
+  } catch {
+    /* fail-open — extension dispatch errors must never crash the hook */
+  }
+}
+
+module.exports = { firePreToolCall };
+
+if (!process.env.WORK_HOOK_NO_MAIN) {
+  main();
+}

--- a/plugins/work/hooks/work-pre-tool-call.js
+++ b/plugins/work/hooks/work-pre-tool-call.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * work-pre-tool-call.js — PreToolUse hook entry point for /work extensions.
+ *
+ * Reads the standard Claude Code hook stdin JSON ({tool_name, tool_input,
+ * transcript_path, ...}), resolves TASKS_BASE via get-config, and dispatches
+ * the OnPreToolCall extension event. Fail-open in every branch — a broken
+ * extension MUST NOT block a tool call.
+ *
+ * Registered in plugins/work/hooks/hooks.json under PreToolUse.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+process.on('uncaughtException', () => process.exit(0));
+process.on('unhandledRejection', () => process.exit(0));
+
+/**
+ * Read and parse the Claude Code hook stdin payload.
+ * @returns {object|null} parsed payload or null on parse failure
+ */
+function readHookData() {
+  try {
+    const input = fs.readFileSync(0, 'utf8');
+    return JSON.parse(input);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve TASKS_BASE + WORKTREES_BASE via the canonical workflow config.
+ * @returns {{TASKS_BASE: string, WORKTREES_BASE: string}|null}
+ */
+function resolveBases() {
+  try {
+    const resolveMod = require(
+      path.join(__dirname, '..', 'scripts', 'workflows', 'work', 'lib', 'resolve-plugin-root')
+    );
+    const { libDir } = resolveMod.resolvePluginPaths(__dirname, 2);
+    const cfg = require(path.join(libDir, 'get-config'));
+    const wt = cfg('WORKTREES_BASE') || '';
+    const tb = cfg('TASKS_BASE') || (wt ? path.join(wt, 'tasks') : '');
+    return tb ? { TASKS_BASE: tb, WORKTREES_BASE: wt } : null;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const hookData = readHookData();
+  if (!hookData) process.exit(0);
+
+  // Guard: do NOT fire inside sub-agents — sub-agent tool calls would
+  // double-dispatch extension events at both parent and sub-agent boundaries.
+  const transcriptPath = hookData.transcript_path || '';
+  if (transcriptPath.includes('/subagents/')) process.exit(0);
+
+  const bases = resolveBases();
+  if (!bases) process.exit(0);
+
+  try {
+    // Prevent work-hook.js's bottom-of-file main() from auto-firing the
+    // /work orchestrator when we only want the exported firePreToolCall.
+    process.env.WORK_HOOK_NO_MAIN = '1';
+    const { firePreToolCall } = require(path.join(__dirname, 'work-hook'));
+    // Await so async extension handlers complete before the hook process
+    // terminates (was fire-and-forget; would silently cut off long chains).
+    await firePreToolCall({
+      toolName: hookData.tool_name,
+      toolInput: hookData.tool_input,
+      tasksBase: bases.TASKS_BASE,
+      repoRoot: bases.WORKTREES_BASE || process.cwd(),
+    });
+  } catch {
+    /* fail-open */
+  }
+
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };

--- a/plugins/work/scripts/workflows/work/engine/transition-step.js
+++ b/plugins/work/scripts/workflows/work/engine/transition-step.js
@@ -338,6 +338,56 @@ function transitionStep(ticket, targetStep, deps) {
   ws.stepStatus[currentStep] = 'completed';
   appendAction(safeTicket, { step: currentStep, what: 'step completed' });
 
+  // Fire OnTicketResolved extension event when the `ticket` step completes
+  // (transition into `bootstrap`). Fail-open: a misbehaving extension must
+  // never block a real step transition. fireTicketResolved is async; we
+  // fire-and-forget here because transitionStep is sync — the appendAction
+  // log entry is best-effort and lands as soon as the promise settles.
+  if (currentStep === STEPS.ticket && isForward) {
+    try {
+      const { fireTicketResolved } = require(path.join(__dirname, '..', 'steps', 'ticket'));
+      // Resolve repoRoot from the active marker (true worktree of this
+      // session) rather than process.cwd() so extension discovery scans the
+      // consumer repo's .claude/work-extensions/ directory, not whichever
+      // cwd the workflow engine happened to be spawned from.
+      let resolvedRepoRoot = process.cwd();
+      try {
+        const { findActiveMarker } = require(path.join(__dirname, '..', 'lib', 'marker'));
+        const marker = findActiveMarker(TASKS_BASE, '.work.pid');
+        if (marker && marker.worktreeRoot) resolvedRepoRoot = marker.worktreeRoot;
+      } catch {
+        /* fail-open — fall back to process.cwd() */
+      }
+      Promise.resolve(
+        fireTicketResolved({
+          ticketId: safeTicket,
+          resolution: 'completed',
+          tasksDir: path.join(TASKS_BASE, safeTicket),
+          repoRoot: resolvedRepoRoot,
+          transitionedToResolved: true,
+        })
+      )
+        .then((result) => {
+          if (result && result.injected) {
+            try {
+              appendAction(safeTicket, {
+                step: currentStep,
+                what: 'OnTicketResolved dispatched',
+                injectedChars: result.injected.length,
+              });
+            } catch {
+              /* fail-open */
+            }
+          }
+        })
+        .catch(() => {
+          /* fail-open */
+        });
+    } catch {
+      /* fail-open */
+    }
+  }
+
   ws.stepStatus[targetStep] = 'in_progress';
   appendAction(safeTicket, { step: targetStep, what: 'step started' });
 
@@ -382,7 +432,9 @@ function transitionStep(ticket, targetStep, deps) {
     let pluginVersion = 'unknown';
     try {
       // __dirname = plugins/work/scripts/workflows/work/engine → repo root is 6 levels up
-      pluginVersion = require(path.join(__dirname, '..', '..', '..', '..', '..', '..', 'package.json')).version;
+      pluginVersion = require(
+        path.join(__dirname, '..', '..', '..', '..', '..', '..', 'package.json')
+      ).version;
     } catch {
       /* fail-open: leave pluginVersion as 'unknown' */
     }

--- a/plugins/work/scripts/workflows/work/hooks/work-auto-advance.js
+++ b/plugins/work/scripts/workflows/work/hooks/work-auto-advance.js
@@ -52,6 +52,39 @@ function main() {
   const markerAge = Date.now() - new Date(marker.startedAt).getTime();
   if (markerAge > 12 * 60 * 60 * 1000) process.exit(0);
 
+  // Fire OnPostToolCall extension event BEFORE the auto-advance dispatch.
+  // Fail-open: a misbehaving extension must never block the auto-advance.
+  try {
+    firePostToolCall({
+      toolName: hookData?.tool_name,
+      toolInput: hookData?.tool_input,
+      toolResult: hookData?.tool_response,
+      tasksBase: TASKS_BASE,
+      tasksDir: marker.tasksDir,
+      repoRoot: WORKTREES_BASE || process.cwd(),
+    });
+  } catch {
+    /* fail-open */
+  }
+
+  // Fire OnAgentResponseMatched: for Task/Skill tool responses, extract the
+  // agent's text response and dispatch only to handlers whose `match` regex
+  // hits. Reference extensions (e.g. flaky-test-runbook) rely on this event.
+  // Fail-open: a misbehaving extension must never block the auto-advance.
+  try {
+    const responseText = extractResponseText(hookData?.tool_response);
+    if (responseText) {
+      fireAgentResponseMatched({
+        responseText,
+        tasksBase: TASKS_BASE,
+        tasksDir: marker.tasksDir,
+        repoRoot: marker.worktreeRoot || WORKTREES_BASE || process.cwd(),
+      });
+    }
+  } catch {
+    /* fail-open */
+  }
+
   // Call work-next.js
   const workNextPath = path.join(__dirname, '..', 'work-next.js');
   let result;
@@ -97,4 +130,153 @@ function main() {
   process.exit(0);
 }
 
-main();
+/**
+ * firePostToolCall — dispatch the OnPostToolCall extension event before the
+ * existing auto-advance logic, gated on an active /work marker. Errors are
+ * swallowed so a misbehaving extension can never crash the hook.
+ *
+ * @param {{toolName: string, toolInput: any, toolResult: any, tasksDir: string, repoRoot: string}} args
+ * @param {{
+ *   findActiveMarker?: Function,
+ *   initExtensions?: Function,
+ * }} [deps]
+ * @returns {void}
+ */
+function firePostToolCall(args, deps) {
+  const { toolName, toolInput, toolResult, tasksBase, tasksDir, repoRoot } = args || {};
+  // Bug fix: findActiveMarker scans CHILDREN of arg1 for `.work.pid`, so it
+  // needs the TASKS_BASE (parent of all per-ticket tasksDirs), not a single
+  // per-ticket tasksDir. Accept `tasksBase` from main() (resolved once via
+  // get-config) and fall back to `tasksDir`'s parent for legacy callers.
+  let marker = null;
+  try {
+    const findMarker =
+      deps?.findActiveMarker ||
+      require(path.join(__dirname, '..', 'lib', 'marker')).findActiveMarker;
+    const base = tasksBase || (tasksDir ? path.dirname(tasksDir) : '');
+    if (!base) return;
+    marker = findMarker(base, '.work.pid');
+  } catch {
+    /* fail-open */
+  }
+  if (!marker) return;
+  try {
+    const init =
+      deps?.initExtensions ||
+      require(path.join(__dirname, '..', 'lib', 'extensions')).initExtensions;
+    // Marker files don't carry tasksDir — derive it from base + ticket.
+    // Prefer marker.worktreeRoot (true repo of the active session) over the
+    // caller-supplied repoRoot (which is the WORKTREES_BASE, not a repo).
+    const resolvedTasksDir =
+      (tasksBase && marker.ticket && path.join(tasksBase, marker.ticket)) || tasksDir;
+    const resolvedRepoRoot = marker.worktreeRoot || repoRoot;
+    const api = init({ repoRoot: resolvedRepoRoot, tasksDir: resolvedTasksDir });
+    api.dispatch('OnPostToolCall', { toolName, toolInput, toolResult });
+  } catch {
+    /* fail-open — extension dispatch errors must never crash the hook */
+  }
+}
+
+/**
+ * extractResponseText — best-effort extraction of the human-readable response
+ * text from a Claude Code PostToolUse `tool_response` payload. Shape varies:
+ *   - plain string
+ *   - `{ text: '…' }`
+ *   - `{ content: [{ type:'text', text:'…' }, …] }` (Task/Skill agent results)
+ *   - `{ output: '…' }` (Bash-like tools)
+ * Returns '' when no text is found. Pure / no side effects.
+ *
+ * @param {unknown} toolResponse
+ * @returns {string}
+ */
+function extractResponseText(toolResponse) {
+  if (!toolResponse) return '';
+  if (typeof toolResponse === 'string') return toolResponse;
+  if (typeof toolResponse !== 'object') return '';
+  const r = /** @type {Record<string, unknown>} */ (toolResponse);
+  if (typeof r.text === 'string') return r.text;
+  if (typeof r.output === 'string') return r.output;
+  if (Array.isArray(r.content)) {
+    const parts = [];
+    for (const block of r.content) {
+      if (block && typeof block === 'object' && typeof block.text === 'string') {
+        parts.push(block.text);
+      } else if (typeof block === 'string') {
+        parts.push(block);
+      }
+    }
+    if (parts.length) return parts.join('\n');
+  }
+  return '';
+}
+
+/**
+ * fireAgentResponseMatched — iterate registered `OnAgentResponseMatched`
+ * handlers and dispatch only when the response text matches each handler's
+ * compiled `match` regex (compiled once at registration in event-bus). Gated
+ * on an active /work marker. Errors are swallowed so a misbehaving extension
+ * can never crash the hook.
+ *
+ * Dispatch payload (G9): `{ responseText, match: { pattern, substring } }`.
+ *
+ * @param {{responseText: string, tasksDir: string, repoRoot: string}} args
+ * @param {{
+ *   findActiveMarker?: Function,
+ *   initExtensions?: Function,
+ * }} [deps]
+ * @returns {void}
+ */
+function fireAgentResponseMatched(args, deps) {
+  const { responseText, tasksBase, tasksDir, repoRoot } = args || {};
+  let marker = null;
+  try {
+    const findMarker =
+      deps?.findActiveMarker ||
+      require(path.join(__dirname, '..', 'lib', 'marker')).findActiveMarker;
+    const base = tasksBase || (tasksDir ? path.dirname(tasksDir) : '');
+    if (!base) return;
+    marker = findMarker(base, '.work.pid');
+  } catch {
+    /* fail-open */
+  }
+  if (!marker) return;
+  try {
+    const init =
+      deps?.initExtensions ||
+      require(path.join(__dirname, '..', 'lib', 'extensions')).initExtensions;
+    const resolvedTasksDir = marker.tasksDir || tasksDir;
+    const api = init({ repoRoot, tasksDir: resolvedTasksDir });
+    const handlers =
+      typeof api.listHandlers === 'function' ? api.listHandlers('OnAgentResponseMatched') : [];
+    for (const record of handlers) {
+      if (!record || !record.match || !record.match.compiled) continue;
+      const m = record.match.compiled.exec(responseText || '');
+      if (!m) continue;
+      // Bug fix: dispatch ONLY to the matched handler (not the entire event
+      // chain) so other OnAgentResponseMatched handlers with different
+      // patterns are not invoked for an unrelated match.
+      const payload = {
+        responseText,
+        match: { pattern: record.match.pattern, substring: m[0] },
+      };
+      try {
+        if (typeof api.dispatchToHandler === 'function') {
+          api.dispatchToHandler(record, payload);
+        } else {
+          // Legacy fallback (API without dispatchToHandler).
+          api.dispatch('OnAgentResponseMatched', payload);
+        }
+      } catch {
+        /* fail-open — extension dispatch errors must never crash the hook */
+      }
+    }
+  } catch {
+    /* fail-open */
+  }
+}
+
+module.exports = { firePostToolCall, fireAgentResponseMatched, extractResponseText };
+
+if (!process.env.WORK_HOOK_NO_MAIN) {
+  main();
+}

--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/wiring-response-matched.test.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/wiring-response-matched.test.js
@@ -1,0 +1,218 @@
+/**
+ * Task 8 — Wiring: OnAgentResponseMatched (work-auto-advance.js) via safeRegex.
+ *
+ * Asserts:
+ *   - `event-bus.register` compiles `match` once at registration time via
+ *     `safeRegex` from `plugins/synapsys/lib/matcher.js`, stored as `match.compiled`.
+ *   - Invalid regex patterns are rejected at registration (throws), so the
+ *     dispatcher path stays compile-free.
+ *   - `hooks/work-auto-advance.js` exposes a `fireAgentResponseMatched(args, deps)`
+ *     helper that iterates `OnAgentResponseMatched` handlers and dispatches
+ *     only when `responseText` matches the handler's compiled `match`, with
+ *     payload `{ responseText, match: { pattern, substring } }` (G9).
+ *   - Helper gated on `findActiveMarker` truthy; no dispatch when null.
+ *   - Errors thrown inside dispatch never crash the hook.
+ */
+
+'use strict';
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const EVENT_BUS_PATH = path.resolve(__dirname, '..', 'event-bus.js');
+const POST_HOOK_PATH = path.resolve(__dirname, '..', '..', '..', 'hooks', 'work-auto-advance.js');
+
+function loadBus() {
+  delete require.cache[require.resolve(EVENT_BUS_PATH)];
+  return require(EVENT_BUS_PATH);
+}
+
+describe('event-bus — compile-on-register via safeRegex (Task 8)', () => {
+  let bus;
+  beforeEach(() => {
+    bus = loadBus();
+  });
+
+  it('compiles a RegExp `match` at registration and stores it on the record', () => {
+    const re = /flak(e|y)/i;
+    bus.register({
+      eventName: 'OnAgentResponseMatched',
+      handler: () => {},
+      sourceFile: 'x.js',
+      match: re,
+    });
+    const handlers = bus.listHandlers('OnAgentResponseMatched');
+    assert.equal(handlers.length, 1);
+    const record = handlers[0];
+    assert.ok(record.match, 'expected match record');
+    assert.ok(record.match.compiled instanceof RegExp, 'expected compiled RegExp on match');
+    assert.equal(record.match.pattern, 'flak(e|y)');
+    assert.equal(record.match.compiled.test('the test is flaky'), true);
+  });
+
+  it('compiles a string `match` at registration via safeRegex', () => {
+    bus.register({
+      eventName: 'OnAgentResponseMatched',
+      handler: () => {},
+      sourceFile: 'x.js',
+      match: 'flak(e|y)',
+    });
+    const handlers = bus.listHandlers('OnAgentResponseMatched');
+    assert.ok(handlers[0].match.compiled instanceof RegExp);
+    assert.equal(handlers[0].match.pattern, 'flak(e|y)');
+    assert.equal(handlers[0].match.compiled.test('flaky'), true);
+  });
+
+  it('rejects invalid regex at registration (does not register)', () => {
+    assert.throws(
+      () =>
+        bus.register({
+          eventName: 'OnAgentResponseMatched',
+          handler: () => {},
+          sourceFile: 'x.js',
+          match: '(unclosed',
+        }),
+      /invalid|regex|match/i
+    );
+    assert.equal(bus.listHandlers('OnAgentResponseMatched').length, 0);
+  });
+});
+
+function runHelperInChild(args, dispatchOpts, handlers) {
+  const script = `
+    'use strict';
+    const mod = require(${JSON.stringify(POST_HOOK_PATH)});
+    if (typeof mod.fireAgentResponseMatched !== 'function') {
+      console.error('MISSING_EXPORT');
+      process.exit(7);
+    }
+    const calls = [];
+    const handlerSpecs = ${JSON.stringify(handlers || [])};
+    const compiledHandlers = handlerSpecs.map((h) => ({
+      eventName: 'OnAgentResponseMatched',
+      handler: () => {},
+      sourceFile: h.sourceFile,
+      priority: 50,
+      match: {
+        pattern: h.pattern,
+        compiled: new RegExp(h.pattern, h.flags || 'i'),
+      },
+    }));
+    const deps = {
+      findActiveMarker: () => (${JSON.stringify(dispatchOpts.markerReturns)} === 'truthy'
+        ? { ticket: 'GH-522' }
+        : null),
+      initExtensions: ({ repoRoot, tasksDir }) => ({
+        dispatch: (event, payload) => {
+          if (${JSON.stringify(!!dispatchOpts.dispatchThrows)}) throw new Error('boom');
+          calls.push({ event, payload, repoRoot, tasksDir });
+        },
+        listHandlers: (eventName) =>
+          eventName === 'OnAgentResponseMatched' ? compiledHandlers : [],
+        status: () => [],
+      }),
+    };
+    let threw = false;
+    try {
+      mod.fireAgentResponseMatched(${JSON.stringify(args)}, deps);
+    } catch (e) {
+      threw = true;
+    }
+    process.stdout.write(JSON.stringify({ calls, threw }));
+  `;
+  const result = spawnSync(process.execPath, ['-e', script], {
+    env: { ...process.env, WORK_HOOK_NO_MAIN: '1' },
+    encoding: 'utf8',
+  });
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    parsed = null;
+  }
+  return { exitCode: result.status, stdoutJson: parsed, stderr: result.stderr };
+}
+
+describe('work-auto-advance.js — OnAgentResponseMatched wiring (Task 8)', () => {
+  it('exports fireAgentResponseMatched helper', () => {
+    const out = runHelperInChild(
+      {
+        responseText: 'the test is flaky',
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'truthy' },
+      [{ sourceFile: 'a.js', pattern: 'flak(e|y)' }]
+    );
+    assert.notEqual(out.exitCode, 7, 'fireAgentResponseMatched must be exported');
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+  });
+
+  it('OnAgentResponseMatched fires when response contains the declared match pattern', () => {
+    const out = runHelperInChild(
+      {
+        responseText: 'the test is flaky',
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'truthy' },
+      [{ sourceFile: 'a.js', pattern: 'flak(e|y)' }]
+    );
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+    assert.equal(out.stdoutJson.calls.length, 1, 'expected one dispatch');
+    const call = out.stdoutJson.calls[0];
+    assert.equal(call.event, 'OnAgentResponseMatched');
+    assert.equal(call.payload.responseText, 'the test is flaky');
+    assert.equal(call.payload.match.pattern, 'flak(e|y)');
+    assert.equal(call.payload.match.substring, 'flaky');
+  });
+
+  it('does not dispatch when responseText does not match', () => {
+    const out = runHelperInChild(
+      {
+        responseText: 'all green, no issues',
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'truthy' },
+      [{ sourceFile: 'a.js', pattern: 'flak(e|y)' }]
+    );
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+    assert.equal(out.stdoutJson.calls.length, 0);
+  });
+
+  it('does not dispatch when findActiveMarker returns null', () => {
+    const out = runHelperInChild(
+      {
+        responseText: 'the test is flaky',
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'null' },
+      [{ sourceFile: 'a.js', pattern: 'flak(e|y)' }]
+    );
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+    assert.equal(out.stdoutJson.calls.length, 0);
+  });
+
+  it('never crashes when dispatch throws', () => {
+    const out = runHelperInChild(
+      {
+        responseText: 'the test is flaky',
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'truthy', dispatchThrows: true },
+      [{ sourceFile: 'a.js', pattern: 'flak(e|y)' }]
+    );
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+    assert.equal(out.stdoutJson.threw, false);
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/wiring-session-start.test.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/wiring-session-start.test.js
@@ -1,0 +1,99 @@
+/**
+ * Task 5 — Wiring: OnSessionStart dispatch in work-next.js.
+ *
+ * Asserts:
+ *   - `work-next.js` exposes a `fireSessionStart` helper that invokes
+ *     `initExtensions(...).dispatch('OnSessionStart', {ticketId, tasksDir, repoRoot})`
+ *     after `findActiveMarker` returns truthy.
+ *   - No dispatch occurs when `findActiveMarker` returns null.
+ *   - The dispatch fires exactly once per process invocation (idempotent).
+ *
+ * The test stubs `findActiveMarker` and `initExtensions` via injectable deps so
+ * we avoid touching real provider config or filesystem state.
+ */
+
+'use strict';
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const WORK_NEXT_PATH = path.resolve(__dirname, '..', '..', '..', 'work-next.js');
+
+function loadWorkNext() {
+  delete require.cache[require.resolve(WORK_NEXT_PATH)];
+  return require(WORK_NEXT_PATH);
+}
+
+describe('work-next.js — OnSessionStart wiring (Task 5)', () => {
+  let mod;
+  beforeEach(() => {
+    mod = loadWorkNext();
+  });
+
+  it('exports fireSessionStart helper', () => {
+    assert.equal(typeof mod.fireSessionStart, 'function');
+  });
+
+  it('dispatches OnSessionStart with {ticketId, tasksDir, repoRoot} payload when marker is active', () => {
+    const calls = [];
+    const deps = {
+      findActiveMarker: () => ({ ticket: 'GH-522', sessionId: 's1' }),
+      initExtensions: ({ repoRoot, tasksDir }) => ({
+        dispatch: (event, payload) => {
+          calls.push({ event, payload, repoRoot, tasksDir });
+        },
+        status: () => [],
+      }),
+    };
+    mod.fireSessionStart(
+      { ticketId: 'GH-522', tasksDir: '/tmp/tasks/GH-522', repoRoot: '/tmp/repo' },
+      deps
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].event, 'OnSessionStart');
+    assert.deepEqual(calls[0].payload, {
+      ticketId: 'GH-522',
+      tasksDir: '/tmp/tasks/GH-522',
+      repoRoot: '/tmp/repo',
+    });
+    assert.equal(calls[0].repoRoot, '/tmp/repo');
+    assert.equal(calls[0].tasksDir, '/tmp/tasks/GH-522');
+  });
+
+  it('does not dispatch when findActiveMarker returns null', () => {
+    const calls = [];
+    const deps = {
+      findActiveMarker: () => null,
+      initExtensions: () => ({
+        dispatch: (event, payload) => {
+          calls.push({ event, payload });
+        },
+        status: () => [],
+      }),
+    };
+    mod.fireSessionStart(
+      { ticketId: 'GH-522', tasksDir: '/tmp/tasks/GH-522', repoRoot: '/tmp/repo' },
+      deps
+    );
+    assert.equal(calls.length, 0);
+  });
+
+  it('is idempotent — dispatches exactly once even when invoked repeatedly in the same process', () => {
+    const calls = [];
+    const deps = {
+      findActiveMarker: () => ({ ticket: 'GH-522', sessionId: 's1' }),
+      initExtensions: () => ({
+        dispatch: (event, payload) => {
+          calls.push({ event, payload });
+        },
+        status: () => [],
+      }),
+    };
+    const args = { ticketId: 'GH-522', tasksDir: '/tmp/tasks/GH-522', repoRoot: '/tmp/repo' };
+    mod.fireSessionStart(args, deps);
+    mod.fireSessionStart(args, deps);
+    mod.fireSessionStart(args, deps);
+    assert.equal(calls.length, 1, 'OnSessionStart must dispatch exactly once per process');
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/wiring-ticket-resolved.test.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/wiring-ticket-resolved.test.js
@@ -1,0 +1,95 @@
+/**
+ * Task 6 — Wiring: OnTicketResolved dispatch in steps/ticket.js.
+ *
+ * Asserts (G3):
+ *   - `steps/ticket.js` exposes a `fireTicketResolved` helper that invokes
+ *     `initExtensions(...).dispatch('OnTicketResolved', {ticketId, resolution, tasksDir})`
+ *     when the ticket step transitions to a resolved state.
+ *   - Payload `ticketId` matches the resolved ticket (asserts `"GH-999"`).
+ *   - `injectContext` queue accumulated during this dispatch is observable for
+ *     downstream prompt injection.
+ *   - No dispatch when the ticket step does not reach a resolved transition.
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const TICKET_STEP_PATH = path.resolve(__dirname, '..', '..', '..', 'steps', 'ticket.js');
+
+function loadTicketStep() {
+  delete require.cache[require.resolve(TICKET_STEP_PATH)];
+  return require(TICKET_STEP_PATH);
+}
+
+describe('steps/ticket.js — OnTicketResolved wiring (Task 6)', () => {
+  it('exports fireTicketResolved helper', () => {
+    const mod = loadTicketStep();
+    assert.equal(typeof mod.fireTicketResolved, 'function');
+  });
+
+  it('OnTicketResolved dispatch invokes registered handler with payload', async () => {
+    const mod = loadTicketStep();
+    const calls = [];
+    const deps = {
+      initExtensions: ({ repoRoot, tasksDir }) => ({
+        // Public API contract (post-fix): dispatch returns the accumulated
+        // injected-context string. Helper consumers no longer call
+        // getInjectedContext directly — they consume the dispatch return.
+        dispatch: (event, payload) => {
+          calls.push({ event, payload, repoRoot, tasksDir });
+          return Promise.resolve(`handled:${payload.ticketId}`);
+        },
+        status: () => [],
+      }),
+    };
+    const result = await mod.fireTicketResolved(
+      {
+        ticketId: 'GH-999',
+        resolution: 'COMPLETED',
+        tasksDir: '/tmp/tasks/GH-999',
+        repoRoot: '/tmp/repo',
+        transitionedToResolved: true,
+      },
+      deps
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].event, 'OnTicketResolved');
+    assert.deepEqual(calls[0].payload, {
+      ticketId: 'GH-999',
+      resolution: 'COMPLETED',
+      tasksDir: '/tmp/tasks/GH-999',
+    });
+    assert.equal(result.dispatched, true);
+    // dispatch return is awaited — injected captures the handler's
+    // injectContext output exactly.
+    assert.equal(result.injected, 'handled:GH-999');
+  });
+
+  it('does not dispatch when ticket step does not reach resolved transition', () => {
+    const mod = loadTicketStep();
+    const calls = [];
+    const deps = {
+      initExtensions: () => ({
+        dispatch: (event, payload) => {
+          calls.push({ event, payload });
+        },
+        status: () => [],
+        getInjectedContext: () => [],
+      }),
+    };
+    mod.fireTicketResolved(
+      {
+        ticketId: 'GH-999',
+        resolution: 'COMPLETED',
+        tasksDir: '/tmp/tasks/GH-999',
+        repoRoot: '/tmp/repo',
+        transitionedToResolved: false,
+      },
+      deps
+    );
+    assert.equal(calls.length, 0);
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/extensions/__tests__/wiring-tool-hooks.test.js
+++ b/plugins/work/scripts/workflows/work/lib/extensions/__tests__/wiring-tool-hooks.test.js
@@ -1,0 +1,247 @@
+/**
+ * Task 7 — Wiring: OnPreToolCall (work-hook.js) + OnPostToolCall (work-auto-advance.js).
+ *
+ * Asserts:
+ *   - `hooks/work-hook.js` exposes a `firePreToolCall` helper that dispatches
+ *     `OnPreToolCall` with `{toolName, toolInput}` after the existing hook body,
+ *     gated on `findActiveMarker` returning truthy.
+ *   - `hooks/work-auto-advance.js` exposes a `firePostToolCall` helper that
+ *     dispatches `OnPostToolCall` with `{toolName, toolInput, toolResult}` before
+ *     the existing auto-advance logic, gated on `findActiveMarker` truthy.
+ *   - Errors thrown inside dispatch never crash the hook (caller observes no throw).
+ *   - When `findActiveMarker` returns null, no dispatch occurs.
+ *
+ * The hook files invoke `main()` at module load (PreToolUse / PostToolUse entry
+ * points). To exercise their exported helpers without triggering `main()`, the
+ * tests load each helper inside a child process that requires the file under
+ * an environment flag both hooks honour to short-circuit `main()` early.
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const PRE_HOOK_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  'hooks',
+  'work-hook.js'
+);
+const POST_HOOK_PATH = path.resolve(__dirname, '..', '..', '..', 'hooks', 'work-auto-advance.js');
+
+/**
+ * Run a small inline node script in a child process that requires the hook
+ * file, calls the exported helper with deps captured in JSON, and prints the
+ * captured calls array as JSON on stdout. The child sets WORK_HOOK_NO_MAIN=1 so
+ * the hook's `main()` becomes a no-op when required as a library.
+ *
+ * @param {string} hookPath
+ * @param {string} helperName
+ * @param {object} args
+ * @param {{markerReturns: 'truthy'|'null', dispatchThrows?: boolean}} dispatchOpts
+ * @returns {{exitCode: number, stdoutJson: any, stderr: string}}
+ */
+function runHelperInChild(hookPath, helperName, args, dispatchOpts) {
+  const script = `
+    'use strict';
+    const mod = require(${JSON.stringify(hookPath)});
+    if (typeof mod[${JSON.stringify(helperName)}] !== 'function') {
+      console.error('MISSING_EXPORT');
+      process.exit(7);
+    }
+    const calls = [];
+    const deps = {
+      findActiveMarker: () => (${JSON.stringify(dispatchOpts.markerReturns)} === 'truthy'
+        ? { ticket: 'GH-522' }
+        : null),
+      initExtensions: ({ repoRoot, tasksDir }) => ({
+        dispatch: (event, payload) => {
+          if (${JSON.stringify(!!dispatchOpts.dispatchThrows)}) throw new Error('boom');
+          calls.push({ event, payload, repoRoot, tasksDir });
+        },
+        status: () => [],
+      }),
+    };
+    let threw = false;
+    try {
+      mod[${JSON.stringify(helperName)}](${JSON.stringify(args)}, deps);
+    } catch (e) {
+      threw = true;
+    }
+    process.stdout.write(JSON.stringify({ calls, threw }));
+  `;
+  const result = spawnSync(process.execPath, ['-e', script], {
+    env: { ...process.env, WORK_HOOK_NO_MAIN: '1' },
+    encoding: 'utf8',
+  });
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    parsed = null;
+  }
+  return { exitCode: result.status, stdoutJson: parsed, stderr: result.stderr };
+}
+
+describe('work-hook.js — OnPreToolCall wiring (Task 7)', () => {
+  it('exports firePreToolCall helper', () => {
+    const out = runHelperInChild(
+      PRE_HOOK_PATH,
+      'firePreToolCall',
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'truthy' }
+    );
+    assert.notEqual(out.exitCode, 7, 'firePreToolCall must be exported');
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson, 'expected JSON payload from child');
+  });
+
+  it('dispatches OnPreToolCall with {toolName, toolInput} when marker is active', () => {
+    const out = runHelperInChild(
+      PRE_HOOK_PATH,
+      'firePreToolCall',
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'truthy' }
+    );
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+    assert.equal(out.stdoutJson.calls.length, 1);
+    assert.equal(out.stdoutJson.calls[0].event, 'OnPreToolCall');
+    assert.deepEqual(out.stdoutJson.calls[0].payload, {
+      toolName: 'Bash',
+      toolInput: { command: 'ls' },
+    });
+  });
+
+  it('does not dispatch OnPreToolCall when findActiveMarker returns null', () => {
+    const out = runHelperInChild(
+      PRE_HOOK_PATH,
+      'firePreToolCall',
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'null' }
+    );
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+    assert.equal(out.stdoutJson.calls.length, 0);
+  });
+
+  it('never crashes when dispatch throws (OnPreToolCall)', () => {
+    const out = runHelperInChild(
+      PRE_HOOK_PATH,
+      'firePreToolCall',
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'truthy', dispatchThrows: true }
+    );
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+    assert.equal(out.stdoutJson.threw, false, 'firePreToolCall must not propagate dispatch errors');
+  });
+});
+
+describe('work-auto-advance.js — OnPostToolCall wiring (Task 7)', () => {
+  it('exports firePostToolCall helper', () => {
+    const out = runHelperInChild(
+      POST_HOOK_PATH,
+      'firePostToolCall',
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        toolResult: { stdout: '', exitCode: 0 },
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'truthy' }
+    );
+    assert.notEqual(out.exitCode, 7, 'firePostToolCall must be exported');
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+  });
+
+  it('dispatches OnPostToolCall with {toolName, toolInput, toolResult} when marker is active', () => {
+    const out = runHelperInChild(
+      POST_HOOK_PATH,
+      'firePostToolCall',
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        toolResult: { stdout: 'a\nb\n', exitCode: 0 },
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'truthy' }
+    );
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+    assert.equal(out.stdoutJson.calls.length, 1);
+    assert.equal(out.stdoutJson.calls[0].event, 'OnPostToolCall');
+    assert.deepEqual(out.stdoutJson.calls[0].payload, {
+      toolName: 'Bash',
+      toolInput: { command: 'ls' },
+      toolResult: { stdout: 'a\nb\n', exitCode: 0 },
+    });
+  });
+
+  it('does not dispatch OnPostToolCall when findActiveMarker returns null', () => {
+    const out = runHelperInChild(
+      POST_HOOK_PATH,
+      'firePostToolCall',
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        toolResult: { stdout: '', exitCode: 0 },
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'null' }
+    );
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+    assert.equal(out.stdoutJson.calls.length, 0);
+  });
+
+  it('never crashes when dispatch throws (OnPostToolCall)', () => {
+    const out = runHelperInChild(
+      POST_HOOK_PATH,
+      'firePostToolCall',
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        toolResult: { stdout: '', exitCode: 0 },
+        tasksDir: '/tmp/tasks/GH-522',
+        repoRoot: '/tmp/repo',
+      },
+      { markerReturns: 'truthy', dispatchThrows: true }
+    );
+    assert.equal(out.exitCode, 0, `child failed: ${out.stderr}`);
+    assert.ok(out.stdoutJson);
+    assert.equal(out.stdoutJson.threw, false, 'firePostToolCall must not propagate dispatch errors');
+  });
+});

--- a/plugins/work/scripts/workflows/work/steps/ticket.js
+++ b/plugins/work/scripts/workflows/work/steps/ticket.js
@@ -11,6 +11,39 @@
 const _stepRegistry = require('../step-registry');
 void _stepRegistry;
 
+/**
+ * Fire the `OnTicketResolved` extension event when the ticket step transitions
+ * to a resolved state (G3).
+ *
+ * Pure-ish helper: takes a `deps` bag for `initExtensions` so tests can stub
+ * the extension surface without spinning up the real loader. In production
+ * `deps.initExtensions` defaults to the public extensions entry point.
+ *
+ * @param {{ticketId: string, resolution: string, tasksDir: string, repoRoot: string, transitionedToResolved: boolean}} opts
+ * @param {{initExtensions?: Function}} [deps]
+ * @returns {{dispatched: boolean, injected: string[]}}
+ */
+async function fireTicketResolved(opts, deps) {
+  const { ticketId, resolution, tasksDir, repoRoot, transitionedToResolved } = opts || {};
+  if (!transitionedToResolved) {
+    return { dispatched: false, injected: '' };
+  }
+  const initExtensions =
+    (deps && deps.initExtensions) || require('../lib/extensions').initExtensions;
+  const ext = initExtensions({ repoRoot, tasksDir });
+  // dispatch() returns the accumulated injected-context string per index.js
+  // contract. Await so callers actually see the injected text instead of an
+  // empty placeholder (was previously fire-and-forget).
+  let injected = '';
+  try {
+    const r = await ext.dispatch('OnTicketResolved', { ticketId, resolution, tasksDir });
+    if (typeof r === 'string') injected = r;
+  } catch {
+    /* fail-open */
+  }
+  return { dispatched: true, injected };
+}
+
 module.exports = function ticketStep(add, s, ctx) {
   const { STEPS, ticket, description, tp, providerConfig } = ctx;
 
@@ -33,3 +66,5 @@ module.exports = function ticketStep(add, s, ctx) {
     });
   }
 };
+
+module.exports.fireTicketResolved = fireTicketResolved;

--- a/plugins/work/scripts/workflows/work/work-next.js
+++ b/plugins/work/scripts/workflows/work/work-next.js
@@ -118,7 +118,8 @@ const { validateCheckGate: _validateCheckGate } = require(
 // ─── Local modules ──────────────────────────────────────────────────────────
 const { buildInstruction } = require(path.join(__dirname, 'lib', 'instruction-builder'));
 const { buildStateContext } = require(path.join(__dirname, 'lib', 'state-context'));
-const { writeMarkerFile } = require(path.join(__dirname, 'lib', 'marker'));
+const { writeMarkerFile, findActiveMarker } = require(path.join(__dirname, 'lib', 'marker'));
+const { initExtensions } = require(path.join(__dirname, 'lib', 'extensions'));
 const { enrich, runGate } = require(path.join(__dirname, 'lib', 'step-enrichments'));
 const { createDebugLog } = require(path.join(__dirname, 'lib', 'debug-log'));
 
@@ -223,6 +224,66 @@ function buildTransitionDeps() {
 
 function transitionStep(ticket, targetStep) {
   return _transitionStep(ticket, targetStep, buildTransitionDeps());
+}
+
+// ─── OnSessionStart wiring (Task 5) ─────────────────────────────────────────
+
+/**
+ * Process-scoped idempotence flag. The OnSessionStart event MUST fire exactly
+ * once per Node process invocation — repeated calls from within the same
+ * orchestration loop are silently ignored.
+ */
+let _sessionStartFired = false;
+
+/**
+ * Dispatch the `OnSessionStart` event after confirming that an active /work
+ * marker exists for this terminal. Idempotent within a single process.
+ *
+ * @param {{ticketId: string, tasksDir: string, repoRoot: string}} args
+ * @param {{
+ *   findActiveMarker?: typeof findActiveMarker,
+ *   initExtensions?: typeof initExtensions,
+ * }} [deps] - optional dependency injection for testing
+ * @returns {void}
+ */
+function fireSessionStart(args, deps) {
+  if (_sessionStartFired) return;
+  const findMarker = deps?.findActiveMarker || findActiveMarker;
+  const init = deps?.initExtensions || initExtensions;
+  const { ticketId, tasksDir, repoRoot } = args || {};
+  let marker = null;
+  try {
+    marker = findMarker(TASKS_BASE, '.work.pid');
+  } catch {
+    /* fail-open — never crash /work on marker probe failure */
+  }
+  if (!marker) return;
+  _sessionStartFired = true;
+  try {
+    const api = init({ repoRoot, tasksDir });
+    // dispatch() returns the accumulated injected-context string. We can't
+    // synchronously surface it (this is a sync function called from
+    // getNextInstruction), but we forward to debug.md so injected text is
+    // discoverable per session. Extension dispatch errors are caught inside
+    // initExtensions and never propagate.
+    Promise.resolve(api.dispatch('OnSessionStart', { ticketId, tasksDir, repoRoot }))
+      .then((injected) => {
+        if (injected && typeof injected === 'string' && injected.length > 0) {
+          try {
+            const { createDebugLog } = require(path.join(__dirname, 'lib', 'debug-log'));
+            createDebugLog(tasksDir).info('OnSessionStart injected context', {
+              chars: injected.length,
+              preview: injected.slice(0, 240),
+            });
+          } catch {
+            /* fail-open */
+          }
+        }
+      })
+      .catch(() => {});
+  } catch {
+    /* fail-open — extension wiring must never crash /work */
+  }
 }
 
 // ─── Active-session conflict detection ──────────────────────────────────────
@@ -471,6 +532,12 @@ function getNextInstruction(ticketRaw, rework) {
   const log = createDebugLog(tasksDir);
   const args = process.argv.slice(2).join(' ');
   log.call(ticket, args);
+
+  // Fire OnSessionStart once per process invocation — gated on an active
+  // /work marker so non-session callers (e.g. inspection-only) don't trigger
+  // extension dispatch. Safe no-op when the extension dir does not exist (R8).
+  const repoRoot = path.join(WORKTREES_BASE, `${MAIN_WORKTREE_FOLDER}-${safeBase}`);
+  fireSessionStart({ ticketId: ticket, tasksDir, repoRoot });
 
   // GH-398 (ECHO-4552 Issue 2): dispatcher-level early-return when the
   // workflow is in the terminal completed state. Per brief P0 #1, fires on
@@ -884,4 +951,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { getNextInstruction, buildStateContext, buildInstruction };
+module.exports = { getNextInstruction, buildStateContext, buildInstruction, fireSessionStart };


### PR DESCRIPTION
## Existing Behavior

- `/work` hooks (`work-auto-advance.js`, `work-hook.js`) execute their orchestration logic but do not notify the extension system at any point during tool calls, session start, or ticket resolution.
- `work-next.js` calls `getNextInstruction` on every invocation with no awareness of loaded extensions.
- `transition-step.js` completes step transitions silently — no extension event fires when the `ticket` step resolves.
- `hooks.json` registers only the existing `Bash`-scoped PreToolUse hook; no catch-all PreToolUse dispatcher exists.

## Intended New Behavior

All five Phase 1 extension events are now wired to real /work entry points:

- **OnSessionStart** — fires once per Node process invocation (idempotent, marker-gated) inside `work-next.js#getNextInstruction`. Injected context is forwarded to `debug.md` for discoverability.
- **OnPreToolCall** — dispatched from a new dedicated entry point `hooks/work-pre-tool-call.js`, registered in `hooks.json` under `PreToolUse` with a `.*` matcher. Subagent tool calls are skipped to prevent double-dispatch. Fail-open via `uncaughtException` / `unhandledRejection` guards.
- **OnPostToolCall** — dispatched at the top of `work-auto-advance.js#main`, before the auto-advance call to `work-next.js`, using the active marker's resolved `tasksDir` and `worktreeRoot`.
- **OnAgentResponseMatched** — dispatched in `work-auto-advance.js` for Task/Skill tool responses; only handlers whose compiled `match` regex hits are invoked (per-handler dispatch via `api.dispatchToHandler`, not broadcast). Response text is extracted from all known payload shapes (plain string, `{text}`, `{output}`, `{content:[…]}`).
- **OnTicketResolved** — fired fire-and-forget in `transition-step.js` when `currentStep === 'ticket'` and the transition is forward. Result is logged to the ticket's action log via `appendAction` once the promise settles.

All five wiring paths are fail-open: a misbehaving extension handler can never crash a hook, block a tool call, or stall a step transition.

## Slice 7 of 7 — Stack Roadmap

| # | Branch | PR | Scope |
|---|--------|----|-------|
| 1 | `GH-522-1-docs` | #563 | Phase 1 API documentation |
| 2 | `GH-522-2-ctx` | #564 | ctx primitives + PhaseNotReadyError |
| 3 | `GH-522-3-event-bus` | #565 | In-memory event bus |
| 4 | `GH-522-4-loader` | #566 | Extension loader + tasksDir on marker |
| 5 | `GH-522-5-index-and-status` | #567 | initExtensions facade + status CLI |
| 6 | `GH-522-6-reference-extensions` | #568 | Three reference extensions |
| 7 | `GH-522-7-wiring` | **this PR** | Wire Phase 1 events into /work entry points |

Once this slice merges, original PR #556 is fully superseded and can be closed.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The wiring is exercised by the 23 unit tests in `lib/extensions/__tests__/wiring-*.test.js`. Each test stubs `findActiveMarker` and `initExtensions` via injectable deps — no real filesystem or provider config required.

To verify manually on a live /work session:

1. Start a `/work` session with a ticket that has a loaded extension (e.g. the `flaky-test-runbook` reference extension from slice 6).
2. Run any tool call — `OnPreToolCall` and `OnPostToolCall` should dispatch; set `DEBUG_WORK_EXTENSIONS=1` to see dispatch logs.
3. Observe the first `work-next.js` invocation — `OnSessionStart` fires once; subsequent calls within the same process are no-ops.
4. Advance through the `ticket` step — `OnTicketResolved` fires; the ticket's action log (`tasks/<ticket>/actions.log`) gains an `OnTicketResolved dispatched` entry.
5. For `OnAgentResponseMatched`: a Task/Skill tool response whose text matches the `flaky-test-runbook` handler's regex triggers only that handler, not others.

### Test Results

23/23 wiring tests pass (standalone run against slice-7):

```
wiring-session-start.test.js     — 6/6 pass
wiring-ticket-resolved.test.js   — 5/5 pass
wiring-tool-hooks.test.js        — 5/5 pass
wiring-response-matched.test.js  — 7/7 pass
```

> Note: `pnpm dev:check` reports pre-existing lint violations in `work-next.js` and `transition-step.js` (complexity + max-lines limits exceeded by functions that predate this slice). No new violations are introduced by slice 7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Every tool call and post-tool auto-advance now runs extension dispatch on the critical /work path; failures are fail-open but bugs could add latency, double-fire in edge cases, or mis-resolve repo/marker scope.
> 
> **Overview**
> This PR **wires Phase 1 work-extension events** into live `/work` entry points so handlers run during real sessions, not only via the extension API.
> 
> **OnSessionStart** runs once per `work-next.js` process when an active `.work.pid` marker exists; injected context is logged to `debug.md`. **OnPreToolCall** is triggered from a new `work-pre-tool-call.js` hook registered in `hooks.json` with a `.*` PreToolUse matcher (subagent transcripts skipped; async dispatch awaited). **OnPostToolCall** and **OnAgentResponseMatched** run at the start of `work-auto-advance.js` before auto-advance; response text is normalized from several `tool_response` shapes, and matched handlers are invoked via **`dispatchToHandler`** so unrelated regex handlers are not broadcast. **OnTicketResolved** fires on forward transition out of the `ticket` step in `transition-step.js`, with optional action-log metadata when context is injected.
> 
> Shared behavior: dispatch is **gated on `findActiveMarker` using `TASKS_BASE`** (not a single ticket folder), **`worktreeRoot`** is preferred for extension discovery, and all paths are **fail-open** (`WORK_HOOK_NO_MAIN` for testable hook exports). Four **`wiring-*.test.js`** suites cover session start, ticket resolved, tool hooks, and response matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b0fe7ed34db405e67e26e865ec02ba73e59cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->