### PR TITLE
refactor(work): extract helpers to reduce complexity violations

### DIFF
--- a/plugins/work/scripts/workflows/check/check.workflow.js
+++ b/plugins/work/scripts/workflows/check/check.workflow.js
@@ -33,6 +33,105 @@ const REPO_DIR = config.repoDir();
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+const STEP_STATE_DETECTORS = {
+  '1_setup': () => ({ action: 'RUN', reason: 'Initialize variables and check cache' }),
+
+  '2_start_env': (d) => {
+    if (d.readmeHashMatch) {
+      return {
+        action: 'SKIP',
+        reason: `Cache valid — hash ${d.changesHash} matches README.md`,
+      };
+    }
+    return {
+      action: 'RUN',
+      reason: `Start dev environment for ${d.impactedApps?.length || 0} app(s)`,
+      command: 'node "${CLAUDE_PLUGIN_ROOT}/hooks/check-start-env.js"',
+    };
+  },
+
+  '3_verify_playwright': (d) => {
+    if (d.readmeHashMatch) {
+      return { action: 'SKIP', reason: 'Cache valid — skipping Playwright check' };
+    }
+    if (d.hasWebApps === false) {
+      return { action: 'SKIP', reason: 'No web apps configured — Playwright not needed' };
+    }
+    return {
+      action: 'RUN',
+      reason: 'Verify Playwright MCP connectivity before launching QA agents',
+      command: 'mcp__playwright__browser_navigate',
+    };
+  },
+
+  '4_phase1_agents': (d) => {
+    if (d.allPhase1ReportsMatch) {
+      return {
+        action: 'SKIP',
+        reason: `All Phase 1 reports exist with matching hash (${d.changesHash})`,
+      };
+    }
+    return {
+      action: 'RUN',
+      reason: d.missingReports?.length
+        ? `Missing/stale reports: ${d.missingReports.join(', ')}`
+        : 'Run all Phase 1 agents',
+      command: 'Task(code-checker, quality-checker, qa-*, completion-checker)',
+    };
+  },
+
+  '5_phase2_consensus': (d) => {
+    if (!d.codeReviewHasSuggestions) {
+      return { action: 'SKIP', reason: 'No suggestions in code-review.check.md' };
+    }
+    if (d.replyExists && d.replyHashMatch && d.consensusLogExists) {
+      return {
+        action: 'SKIP',
+        reason: 'code-review-reply.check.md and consensus log exist with matching hash',
+      };
+    }
+    return {
+      action: 'RUN',
+      reason: 'Code review has suggestions — developers must evaluate',
+      command: 'Task(developer-*, code-checker)',
+    };
+  },
+
+  '6_quality_recheck': (d) => {
+    if (!d.replyHasImplementations) {
+      return {
+        action: 'SKIP',
+        reason: 'No IMPLEMENTED suggestions in reply — no re-check needed',
+      };
+    }
+    return {
+      action: 'RUN',
+      reason: 'Developer(s) implemented suggestions — re-validate affected files',
+      command: 'Task(quality-checker)',
+    };
+  },
+
+  '7_validate_summary': (d) => {
+    if (d.readmeHashMatch) {
+      return { action: 'SKIP', reason: 'Cache valid — summary already generated' };
+    }
+    return {
+      action: 'RUN',
+      reason: 'Validate reports and generate README.md summary',
+      command: 'node check-validate-reports.js + check-generate-summary.js',
+    };
+  },
+
+  '8_output': () => ({ action: 'RUN', reason: 'Display final results to user' }),
+
+  '9_cleanup': (d) => {
+    if (d.readmeHashMatch) {
+      return { action: 'SKIP', reason: 'Cache valid — no environment was started' };
+    }
+    return { action: 'RUN', reason: 'Stop dev servers and cleanup resources' };
+  },
+};
+
 function safeExec(cmd, options = {}) {
   try {
     return execSync(cmd, { encoding: 'utf8', cwd: REPO_DIR, ...options }).trim();
@@ -329,103 +428,9 @@ module.exports = {
    */
   detectStepState(stepId, instanceId, state, inspectData) {
     const d = inspectData || {};
-
-    switch (stepId) {
-      case '1_setup':
-        return { action: 'RUN', reason: 'Initialize variables and check cache' };
-
-      case '2_start_env':
-        if (d.readmeHashMatch) {
-          return {
-            action: 'SKIP',
-            reason: `Cache valid — hash ${d.changesHash} matches README.md`,
-          };
-        }
-        return {
-          action: 'RUN',
-          reason: `Start dev environment for ${d.impactedApps?.length || 0} app(s)`,
-          command: 'node "${CLAUDE_PLUGIN_ROOT}/hooks/check-start-env.js"',
-        };
-
-      case '3_verify_playwright':
-        if (d.readmeHashMatch) {
-          return { action: 'SKIP', reason: 'Cache valid — skipping Playwright check' };
-        }
-        if (d.hasWebApps === false) {
-          return { action: 'SKIP', reason: 'No web apps configured — Playwright not needed' };
-        }
-        return {
-          action: 'RUN',
-          reason: 'Verify Playwright MCP connectivity before launching QA agents',
-          command: 'mcp__playwright__browser_navigate',
-        };
-
-      case '4_phase1_agents':
-        if (d.allPhase1ReportsMatch) {
-          return {
-            action: 'SKIP',
-            reason: `All Phase 1 reports exist with matching hash (${d.changesHash})`,
-          };
-        }
-        return {
-          action: 'RUN',
-          reason: d.missingReports?.length
-            ? `Missing/stale reports: ${d.missingReports.join(', ')}`
-            : 'Run all Phase 1 agents',
-          command: 'Task(code-checker, quality-checker, qa-*, completion-checker)',
-        };
-
-      case '5_phase2_consensus':
-        if (!d.codeReviewHasSuggestions) {
-          return { action: 'SKIP', reason: 'No suggestions in code-review.check.md' };
-        }
-        if (d.replyExists && d.replyHashMatch && d.consensusLogExists) {
-          return {
-            action: 'SKIP',
-            reason: 'code-review-reply.check.md and consensus log exist with matching hash',
-          };
-        }
-        return {
-          action: 'RUN',
-          reason: 'Code review has suggestions — developers must evaluate',
-          command: 'Task(developer-*, code-checker)',
-        };
-
-      case '6_quality_recheck':
-        if (!d.replyHasImplementations) {
-          return {
-            action: 'SKIP',
-            reason: 'No IMPLEMENTED suggestions in reply — no re-check needed',
-          };
-        }
-        return {
-          action: 'RUN',
-          reason: 'Developer(s) implemented suggestions — re-validate affected files',
-          command: 'Task(quality-checker)',
-        };
-
-      case '7_validate_summary':
-        if (d.readmeHashMatch) {
-          return { action: 'SKIP', reason: 'Cache valid — summary already generated' };
-        }
-        return {
-          action: 'RUN',
-          reason: 'Validate reports and generate README.md summary',
-          command: 'node check-validate-reports.js + check-generate-summary.js',
-        };
-
-      case '8_output':
-        return { action: 'RUN', reason: 'Display final results to user' };
-
-      case '9_cleanup':
-        if (d.readmeHashMatch) {
-          return { action: 'SKIP', reason: 'Cache valid — no environment was started' };
-        }
-        return { action: 'RUN', reason: 'Stop dev servers and cleanup resources' };
-
-      default:
-        return { action: 'RUN', reason: 'Unknown step' };
-    }
+    const detector = STEP_STATE_DETECTORS[stepId];
+    if (!detector) return { action: 'RUN', reason: 'Unknown step' };
+    return detector(d);
   },
 
   /** Extra fields to include in initial state */

--- a/plugins/work/scripts/workflows/check/hooks/enforce-env-start-failure.js
+++ b/plugins/work/scripts/workflows/check/hooks/enforce-env-start-failure.js
@@ -72,13 +72,7 @@ function skipQaMarkerPath(ticketId) {
 
 // ─── PHASE 1: PostToolUse/Bash — detect failure, write marker ───
 
-function phase1_detectFailure(hookData) {
-  const command = hookData.tool_input?.command || '';
-  if (!command.includes('check-start-env')) return;
-
-  const transcriptPath = hookData.transcript_path;
-  if (!transcriptPath || !fs.existsSync(transcriptPath)) return;
-
+function readTranscriptOutput(transcriptPath) {
   let output = '';
   try {
     const content = fs.readFileSync(transcriptPath, 'utf8');
@@ -96,64 +90,93 @@ function phase1_detectFailure(hookData) {
       }
     }
   } catch {
-    return;
+    return null;
   }
+  return output;
+}
 
+function extractFailedApps(output) {
+  const failedMatches = output.match(/"name":\s*"([^"]+)"[^}]*"started":\s*false/g) || [];
+  return failedMatches.map((m) => {
+    const n = m.match(/"name":\s*"([^"]+)"/);
+    return n ? n[1] : 'unknown';
+  });
+}
+
+function extractPorts(output) {
+  const portMatches = output.match(/"port":\s*(\d+)/g) || [];
+  return portMatches
+    .map((m) => {
+      const p = m.match(/(\d+)/);
+      return p ? parseInt(p[1], 10) : null;
+    })
+    .filter(Boolean);
+}
+
+function extractUrls(output) {
+  const urlMatches = output.match(/"url":\s*"([^"]+)"/g) || [];
+  return urlMatches
+    .map((m) => {
+      const u = m.match(/"url":\s*"([^"]+)"/);
+      return u ? u[1] : null;
+    })
+    .filter(Boolean);
+}
+
+function writeFailureMarker(mp, ticketId, output, hasFail, hasEmptyApps) {
+  const failedApps = extractFailedApps(output);
+  const ports = extractPorts(output);
+  const urls = extractUrls(output);
+  fs.writeFileSync(
+    mp,
+    JSON.stringify({
+      failedApps,
+      status: ACCESS_FAILED,
+      timestamp: new Date().toISOString(),
+      ticketId,
+      diagnostic: { ports, urls, hasEmptyApps, hasFail },
+    })
+  );
+  process.stderr.write(
+    `ENV_FAILURE [${ACCESS_FAILED}]: marker written (${failedApps.join(', ')})\n`
+  );
+}
+
+function detectFailureSignals(output) {
   const hasFail =
     /"started":\s*false/.test(output) || /Timeout waiting for app to start/.test(output);
   const hasEmptyApps = /"runningApps":\s*\{\s*\}/.test(output) && /"apps":\s*\{/.test(output);
+  return { hasFail, hasEmptyApps };
+}
 
+function unlinkMarkerQuiet(mp) {
+  try {
+    fs.unlinkSync(mp);
+  } catch {
+    /* */
+  }
+}
+
+function getCheckStartEnvOutput(hookData) {
+  const command = hookData.tool_input?.command || '';
+  if (!command.includes('check-start-env')) return null;
+  const transcriptPath = hookData.transcript_path;
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) return null;
+  return readTranscriptOutput(transcriptPath);
+}
+
+function phase1_detectFailure(hookData) {
+  const output = getCheckStartEnvOutput(hookData);
+  if (output === null) return;
+
+  const { hasFail, hasEmptyApps } = detectFailureSignals(output);
   const ticketId = getTicketId();
   const mp = markerPath(ticketId);
 
   if (hasFail || hasEmptyApps) {
-    const failedMatches = output.match(/"name":\s*"([^"]+)"[^}]*"started":\s*false/g) || [];
-    const failedApps = failedMatches.map((m) => {
-      const n = m.match(/"name":\s*"([^"]+)"/);
-      return n ? n[1] : 'unknown';
-    });
-
-    // Extract diagnostic details from the output for the marker payload
-    const portMatches = output.match(/"port":\s*(\d+)/g) || [];
-    const ports = portMatches
-      .map((m) => {
-        const p = m.match(/(\d+)/);
-        return p ? parseInt(p[1], 10) : null;
-      })
-      .filter(Boolean);
-
-    const urlMatches = output.match(/"url":\s*"([^"]+)"/g) || [];
-    const urls = urlMatches
-      .map((m) => {
-        const u = m.match(/"url":\s*"([^"]+)"/);
-        return u ? u[1] : null;
-      })
-      .filter(Boolean);
-
-    fs.writeFileSync(
-      mp,
-      JSON.stringify({
-        failedApps,
-        status: ACCESS_FAILED,
-        timestamp: new Date().toISOString(),
-        ticketId,
-        diagnostic: {
-          ports,
-          urls,
-          hasEmptyApps,
-          hasFail,
-        },
-      })
-    );
-    process.stderr.write(
-      `ENV_FAILURE [${ACCESS_FAILED}]: marker written (${failedApps.join(', ')})\n`
-    );
+    writeFailureMarker(mp, ticketId, output, hasFail, hasEmptyApps);
   } else {
-    try {
-      fs.unlinkSync(mp);
-    } catch {
-      /* */
-    }
+    unlinkMarkerQuiet(mp);
   }
 }
 

--- a/plugins/work/scripts/workflows/lib/hook-error-log.js
+++ b/plugins/work/scripts/workflows/lib/hook-error-log.js
@@ -90,71 +90,79 @@ function getBranch() {
  * @param {string} [context.tool] - Tool name (e.g. "Edit", "Bash", "Task")
  * @param {object} [context.input] - Tool input (file_path, command, etc.)
  */
+function truncateCommand(cmd) {
+  return cmd.length > 200 ? cmd.slice(0, 200) + '...' : cmd;
+}
+
+const INPUT_FIELD_MAP = [
+  ['file_path', 'file', (v) => v],
+  ['command', 'cmd', truncateCommand],
+  ['skill', 'skill', (v) => v],
+  ['subagent_type', 'agent', (v) => v],
+];
+
+function buildInputParts(input) {
+  const parts = [];
+  if (!input) return parts;
+  for (const [key, label, transform] of INPUT_FIELD_MAP) {
+    if (input[key]) parts.push(`${label}=${transform(input[key])}`);
+  }
+  return parts;
+}
+
+function buildContextParts(context) {
+  const parts = [`pid=${process.pid}`];
+  const branch = getBranch();
+  if (branch) parts.push(`branch=${branch}`);
+  parts.push(`cwd=${process.cwd()}`);
+  if (context?.tool) parts.push(`tool=${context.tool}`);
+  parts.push(...buildInputParts(context?.input));
+  return parts;
+}
+
+function sanitizeLine(line) {
+  const MAX_BYTES = 3800;
+  const safeLine = line.replace(/\n/g, ' ').replace(/\r/g, '');
+  let finalLine = safeLine + '\n';
+  if (Buffer.byteLength(finalLine, 'utf8') > MAX_BYTES) {
+    let truncated = safeLine;
+    while (Buffer.byteLength(truncated + '...\n', 'utf8') > MAX_BYTES && truncated.length > 0) {
+      truncated = truncated.slice(0, -100);
+    }
+    finalLine = truncated + '...\n';
+  }
+  return finalLine;
+}
+
+function writeLogLine(fd, line, timestamp) {
+  try {
+    const stat = fs.fstatSync(fd);
+    if (stat.size > MAX_LOG_SIZE) {
+      fs.ftruncateSync(fd, 0);
+      fs.writeSync(fd, `[${timestamp}] --- log rotated ---\n`);
+    }
+    fs.writeSync(fd, sanitizeLine(line));
+  } catch {
+    // Can't log -- silently discard. Never write to stderr from hooks.
+  }
+}
+
 function logHookError(sourceFile, err, context) {
   const name = path.basename(sourceFile);
   const message = err?.message || String(err);
   const timestamp = new Date().toISOString();
-  const pid = process.pid;
-  const cwd = process.cwd();
-  const branch = getBranch();
-
-  // Build structured context: pid identifies this specific hook invocation
-  const parts = [`pid=${pid}`];
-  if (branch) parts.push(`branch=${branch}`);
-  parts.push(`cwd=${cwd}`);
-  if (context?.tool) parts.push(`tool=${context.tool}`);
-  if (context?.input?.file_path) parts.push(`file=${context.input.file_path}`);
-  if (context?.input?.command) {
-    // Truncate long commands to keep the line under PIPE_BUF for atomic writes
-    const cmd =
-      context.input.command.length > 200
-        ? context.input.command.slice(0, 200) + '...'
-        : context.input.command;
-    parts.push(`cmd=${cmd}`);
-  }
-  if (context?.input?.skill) parts.push(`skill=${context.input.skill}`);
-  if (context?.input?.subagent_type) parts.push(`agent=${context.input.subagent_type}`);
-
-  const ctx = parts.join(' ');
-  // Raw line before sanitization -- may contain newlines or exceed PIPE_BUF limit
+  const ctx = buildContextParts(context).join(' ');
   const line = `[${timestamp}] ${name} | ${ctx} | ${message}`;
 
   if (process.env.ENFORCE_HOOK_DEBUG) {
-    // In debug mode, write to stderr with optional stack trace for visibility
     const stack = err?.stack?.split('\n')[1]?.trim() || '';
     process.stderr.write(`[${name}] ${ctx} | ${message}${stack ? '\n  ' + stack : ''}\n`);
     return;
   }
 
   const fd = getLogFd();
-  if (fd <= 0) return; // can't log -- fd open failed, silently discard
-
-  try {
-    // Auto-rotate: check size via fstatSync on the fd (no path-based reopen needed)
-    const stat = fs.fstatSync(fd);
-    if (stat.size > MAX_LOG_SIZE) {
-      fs.ftruncateSync(fd, 0);
-      fs.writeSync(fd, `[${timestamp}] --- log rotated ---\n`);
-    }
-
-    // Sanitize: flatten to single line and truncate to stay under ~4KB (PIPE_BUF)
-    const MAX_BYTES = 3800;
-    const safeLine = line.replace(/\n/g, ' ').replace(/\r/g, '');
-    let finalLine = safeLine + '\n';
-    if (Buffer.byteLength(finalLine, 'utf8') > MAX_BYTES) {
-      // Truncate by slicing characters in chunks until under byte limit
-      let truncated = safeLine;
-      while (Buffer.byteLength(truncated + '...\n', 'utf8') > MAX_BYTES && truncated.length > 0) {
-        truncated = truncated.slice(0, -100);
-      }
-      finalLine = truncated + '...\n';
-    }
-
-    // Write via fd -- O_APPEND + short line = effectively atomic on Linux ext4/xfs
-    fs.writeSync(fd, finalLine);
-  } catch {
-    // Can't log -- silently discard. Never write to stderr from hooks.
-  }
+  if (fd <= 0) return;
+  writeLogLine(fd, line, timestamp);
 }
 
 /** @see lib/__tests__/hook-error-log.test.js for tests covering fd-based writes, rotation, symlink guard, and truncation */

--- a/plugins/work/scripts/workflows/lib/protect-state-files.js
+++ b/plugins/work/scripts/workflows/lib/protect-state-files.js
@@ -363,69 +363,57 @@ function createFileProtector(opts) {
     });
   }
 
+  function extractInlineCode(cmd, interpreterMatch) {
+    const flagIdx = interpreterMatch.index;
+    const afterFlag = cmd.slice(flagIdx);
+    const quotedMatch = afterFlag.match(/\s-[ce]\s+(["'])([\s\S]*?)\1/);
+    const unquotedMatch =
+      !quotedMatch && afterFlag.match(/\s-[ce]\s+(.*?)(?:\s*(?:\||;|&&|\|\|)\s|$)/s);
+    return quotedMatch ? quotedMatch[2] : unquotedMatch ? unquotedMatch[1] : cmd;
+  }
+
+  function checkInlineMatch(inlineCode, bareInterpreter, toolInput, hookData) {
+    const tokens = extractTokens(inlineCode);
+    const hasWriteOp = INLINE_INTERPRETER_WRITES.test(inlineCode);
+    for (const token of tokens) {
+      const match = isProtected(token);
+      if (match && hasWriteOp && !isExempt('Bash', toolInput, hookData)) {
+        return {
+          blocked: true,
+          match,
+          vector: `Bash(${bareInterpreter})`,
+          message: fmt(match, `Bash(${bareInterpreter})`),
+          skipRemainingChecks: false,
+        };
+      }
+    }
+    if (
+      BASE64_EVASION_PATTERN.test(inlineCode) &&
+      hasWriteOp &&
+      !isExempt('Bash', toolInput, hookData)
+    ) {
+      return {
+        blocked: true,
+        match: '(base64-encoded)',
+        vector: `Bash(${bareInterpreter} base64)`,
+        message: fmt('(base64-encoded)', `Bash(${bareInterpreter} base64)`),
+        skipRemainingChecks: false,
+      };
+    }
+    return null;
+  }
+
   function checkInlineInterpreterBypass(cmd, toolInput, hookData) {
-    // Use global scan to check ALL inline interpreter occurrences in compound commands
-    // (e.g. `python3 -c "print(1)"; python3 -c "open('.state.json','w')..."`)
     const globalPattern = new RegExp(INLINE_INTERPRETER_PATTERN.source, 'g');
     const allMatches = [...cmd.matchAll(globalPattern)];
     if (allMatches.length === 0) return { blocked: false, skipRemainingChecks: false };
 
     for (const interpreterMatch of allMatches) {
-      // Extract the interpreter name and flag from the match (e.g. "python3 -c", "ruby -e")
-      const matchStr = interpreterMatch[0].trim();
-      // Remove /usr/bin/env prefix if present to get bare interpreter + flag
-      const bareInterpreter = matchStr.replace(/^\/usr\/bin\/env\s+/, '');
-
-      // Extract the inline code portion (everything after -c/-e flag).
-      // This scopes filename and base64 checks to only the interpreter code,
-      // avoiding false positives when protected filenames or base64 appear
-      // in other command segments (e.g. `echo .state.json; python3 -c "..."`)
-      // or in pipeline stages (e.g. `python3 -c "print('hello')" | base64`).
-      const flagIdx = interpreterMatch.index;
-      const afterFlag = cmd.slice(flagIdx);
-      // Try to extract the quoted code argument first (respects quotes around inline code).
-      // If unquoted, capture up to the first unquoted shell operator (|, ;, &&, ||).
-      const quotedMatch = afterFlag.match(/\s-[ce]\s+(["'])([\s\S]*?)\1/);
-      const unquotedMatch =
-        !quotedMatch && afterFlag.match(/\s-[ce]\s+(.*?)(?:\s*(?:\||;|&&|\|\|)\s|$)/s);
-      const inlineCode = quotedMatch ? quotedMatch[2] : unquotedMatch ? unquotedMatch[1] : cmd; // fallback to full cmd
-
-      // Check tokens from inline code only (not full cmd)
-      const tokens = extractTokens(inlineCode);
-
-      // Check for direct protected filename reference + write operation (scoped to inline code)
-      const hasWriteOp = INLINE_INTERPRETER_WRITES.test(inlineCode);
-      for (const token of tokens) {
-        const match = isProtected(token);
-        if (match && hasWriteOp && !isExempt('Bash', toolInput, hookData)) {
-          return {
-            blocked: true,
-            match,
-            vector: `Bash(${bareInterpreter})`,
-            message: fmt(match, `Bash(${bareInterpreter})`),
-            skipRemainingChecks: false,
-          };
-        }
-      }
-
-      // Base64 evasion: block when all three signals present (interpreter + base64 keyword + write op)
-      // even without a visible protected filename, since the filename may be base64-encoded.
-      // This is an intentional over-blocking tradeoff — see GH-107 spec "Open Questions" section.
-      // False positives on non-protected file writes are accepted to prevent evasion.
-      // Scoped to inline code only — base64 CLI usage outside the -c/-e code is not flagged.
-      if (BASE64_EVASION_PATTERN.test(inlineCode) && hasWriteOp) {
-        if (!isExempt('Bash', toolInput, hookData)) {
-          return {
-            blocked: true,
-            match: '(base64-encoded)',
-            vector: `Bash(${bareInterpreter} base64)`,
-            message: fmt('(base64-encoded)', `Bash(${bareInterpreter} base64)`),
-            skipRemainingChecks: false,
-          };
-        }
-      } // end base64 evasion check
-    } // end for each interpreter match
-
+      const bareInterpreter = interpreterMatch[0].trim().replace(/^\/usr\/bin\/env\s+/, '');
+      const inlineCode = extractInlineCode(cmd, interpreterMatch);
+      const result = checkInlineMatch(inlineCode, bareInterpreter, toolInput, hookData);
+      if (result) return result;
+    }
     return { blocked: false, skipRemainingChecks: false };
   }
 

--- a/plugins/work/scripts/workflows/work/gates/check-gate.js
+++ b/plugins/work/scripts/workflows/work/gates/check-gate.js
@@ -35,36 +35,40 @@ function readFile(p) {
  * @param {Error & { stdout?: string, stderr?: string }} err
  * @returns {string[]}
  */
-function parseSpecVerifyError(err) {
-  const stdout =
-    typeof err.stdout === 'string'
-      ? err.stdout
-      : Buffer.isBuffer(err.stdout)
-        ? err.stdout.toString()
-        : '';
-  const stderr =
-    typeof err.stderr === 'string'
-      ? err.stderr.trim()
-      : Buffer.isBuffer(err.stderr)
-        ? err.stderr.toString().trim()
-        : '';
-  if (stdout) {
-    try {
-      const result = JSON.parse(stdout);
-      if (typeof result.success === 'boolean' && !result.success && Array.isArray(result.checks)) {
-        const failures = result.checks
-          .filter((c) => !c.passed)
-          .map(
-            (c) =>
-              `Spec verification failed: ${c.type} ${Array.isArray(c.args) ? c.args.join(' ') : ''} — ${c.reason || 'check failed'}`
-          );
-        return failures.length > 0
-          ? failures
-          : ['Spec verification failed but no specific check details available'];
-      }
-    } catch {
-      /* stdout wasn't valid JSON, fall through to generic error */
+function streamToString(value, trim) {
+  let str;
+  if (typeof value === 'string') str = value;
+  else if (Buffer.isBuffer(value)) str = value.toString();
+  else return '';
+  return trim ? str.trim() : str;
+}
+
+function parseSpecVerifyStdout(stdout) {
+  try {
+    const result = JSON.parse(stdout);
+    if (typeof result.success !== 'boolean' || result.success || !Array.isArray(result.checks)) {
+      return null;
     }
+    const failures = result.checks
+      .filter((c) => !c.passed)
+      .map(
+        (c) =>
+          `Spec verification failed: ${c.type} ${Array.isArray(c.args) ? c.args.join(' ') : ''} — ${c.reason || 'check failed'}`
+      );
+    return failures.length > 0
+      ? failures
+      : ['Spec verification failed but no specific check details available'];
+  } catch {
+    return null;
+  }
+}
+
+function parseSpecVerifyError(err) {
+  const stdout = streamToString(err.stdout, false);
+  const stderr = streamToString(err.stderr, true);
+  if (stdout) {
+    const parsed = parseSpecVerifyStdout(stdout);
+    if (parsed) return parsed;
   }
   return [`Spec verification script error: ${stderr || err.message || 'unknown error'}`];
 }


### PR DESCRIPTION
## Existing Behavior

- `check.workflow.js` `detectStepState` used a large `switch` statement with all 9 step branches inlined, exceeding `max-lines-per-function` and `complexity` limits.
- `enforce-env-start-failure.js` `phase1_detectFailure` contained inline parsing of transcript output, app extraction, and marker writing, all in one dense function.
- `hook-error-log.js` `logHookError` built context parts and sanitized log lines inline, triggering `max-lines-per-function`.
- `protect-state-files.js` `checkInlineInterpreterBypass` and `check-gate.js` `parseSpecVerifyError` mixed extraction, transformation, and decision logic in single functions.

## Intended New Behavior

- `check.workflow.js`: `STEP_STATE_DETECTORS` lookup table replaces the `switch`, reducing `detectStepState` to a 3-line dispatch; all per-step logic is isolated in named detector functions.
- `enforce-env-start-failure.js`: extraction helpers `readTranscriptOutput`, `extractFailedApps`, `extractPorts`, `extractUrls`, `detectFailureSignals`, `writeFailureMarker`, and `unlinkMarkerQuiet` replace the inlined logic in `phase1_detectFailure`.
- `hook-error-log.js`: `truncateCommand`, `INPUT_FIELD_MAP`, `buildInputParts`, `buildContextParts`, `sanitizeLine`, and `writeLogLine` are extracted; `logHookError` shrinks to a clear orchestration body.
- `protect-state-files.js`: `extractInlineCode` and `checkInlineMatch` are extracted from `checkInlineInterpreterBypass`.
- `check-gate.js`: `streamToString` and `parseSpecVerifyStdout` extracted from `parseSpecVerifyError`.
- No behavior change — all logic is preserved exactly; only structure changes.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Notes

This PR was split from PR #529 (GH-513 synapsys work) so that the synapsys PR remains focused on the synapsys domain. The refactor commit (`214427057`) was originally authored on `GH-513-maestro` and reverted there (`dc84eabbc`) to keep the two concerns separate.

Files changed (all under `plugins/work/scripts/workflows/`):
- `check/check.workflow.js`
- `check/hooks/enforce-env-start-failure.js`
- `lib/hook-error-log.js`
- `lib/protect-state-files.js`
- `work/gates/check-gate.js`

## Testing Plan / Demo

This is a pure structural refactor with no behavior change. Verification steps:

1. Run `pnpm dev:test` scoped to the 5 changed files and confirm all existing tests pass without modification.
2. Confirm ESLint no longer reports `max-lines-per-function` or `complexity` violations on the 5 changed files: `pnpm dev:lint`.
3. Manually exercise a check workflow run end-to-end and confirm step detection output is identical to pre-refactor behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural-only refactor across workflow hooks and gates; behavior is preserved and existing tests are the main safety net.
> 
> **Overview**
> This PR **restructures** five workflow scripts under `plugins/work/scripts/workflows/` so large functions satisfy ESLint `max-lines-per-function` and `complexity` rules. **Runtime behavior is intended to stay the same**—logic is moved into named helpers and lookup tables, not rewritten.
> 
> In **`check.workflow.js`**, the nine-branch `switch` inside `detectStepState` becomes a **`STEP_STATE_DETECTORS`** map; dispatch is a short lookup with the same RUN/SKIP reasons and commands per step.
> 
> **`enforce-env-start-failure.js`** splits `phase1_detectFailure` into helpers for transcript reading, failure signal detection, JSON field extraction (failed apps, ports, URLs), marker write/clear, and gating on `check-start-env` Bash output.
> 
> **`hook-error-log.js`** pulls context building (`INPUT_FIELD_MAP`, `buildInputParts`, `buildContextParts`), line sanitization, and fd-based rotation/write out of `logHookError`.
> 
> **`protect-state-files.js`** extracts `extractInlineCode` and `checkInlineMatch` from `checkInlineInterpreterBypass` while keeping the same inline-interpreter and base64 evasion checks.
> 
> **`check-gate.js`** adds `streamToString` and `parseSpecVerifyStdout` so `parseSpecVerifyError` only orchestrates stdout/stderr handling for failed `spec-verify.js` runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2144270570365ea3c50f6ed6e5109cb118fdd543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->