### PR TITLE
docs(synapsys): document exclude_prompt/exclude_pretool/exclude_preset + adoption guide (GH-510)

### DIFF
--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -144,7 +144,7 @@ After adding `exclude_preset`, replay the trigger against a colliding prompt to 
 ```bash
 node plugins/synapsys/scripts/synapsys-explain.js \
   --event=UserPromptSubmit \
-  --prompt="rebasing onto main" \
+  --prompt="git rebase onto main" \
   --only=read-envrc-first --verbose
 # expect: Fired ✗ — reason cites the matched exclude_preset pattern.
 ```

--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -16,6 +16,9 @@ Memories are markdown files with frontmatter that declares **which events** they
 | `trigger_pretool_content` | csv of regex | *(optional)* Matched against the **content** the tool is writing. Combined with `trigger_pretool` via AND. Per-tool content: `Edit`→`new_string`, `Write`→`content`, `MultiEdit`→`edits[].new_string` joined, `NotebookEdit`→`new_source`; other tools → no content (fail-closed). Flags: `i,m`. Invalid regex → stderr warning + skip; all-invalid or missing content → memory does not fire. |
 | `trigger_pretool_content_not` | csv of regex | *(optional)* Negative content gate. Combined with `trigger_pretool_content` via **AND-NOT**: memory fires when the positive content matches AND none of these patterns match. Use to suppress fires when the file is already conformant (e.g. it already imports the correct component). Same extraction table, same `i,m` flags, same fail-closed regex handling as `trigger_pretool_content`. If **all** negative patterns are invalid, the negative gate is dropped (positive-only fallback). Absent or empty array → no negative gate. |
 | `trigger_session` | bool | Fire on every `SessionStart` |
+| `exclude_prompt` | regex | *(optional)* Negative prompt gate. If the user prompt matches this regex, the memory does NOT fire even if `trigger_prompt` also matches. Use to suppress fires during off-topic prompts that happen to collide with the broader positive trigger. Flags: `i`. Invalid regex → stderr warning + skip. |
+| `exclude_preset` | string or csv of strings | *(optional)* Named exclude patterns sourced from `lib/synapsys-presets.json`. Resolved at load time and concatenated with `exclude_prompt` into one OR-joined exclude list (`memory.excludeResolved`). Built-in presets: `git-ops`, `ci-monitor`, `review-comment-handling` — see [Adopting `exclude_preset`](#adopting-exclude_preset) below. Unknown preset name → stderr warning + skip. |
+| `exclude_pretool` | csv of `<Tool>:<arg-regex>` | *(optional)* Negative pretool gate. Same shape as `trigger_pretool`. If the tool name + serialized tool input matches any spec here, the memory does NOT fire even if `trigger_pretool` matches. Invalid spec → stderr warning + skip. |
 | `inject` | `full` \| `summary` | How much of the body to inject |
 
 ## Four storage tiers
@@ -83,6 +86,70 @@ inject: full
 **Location:** `src/components/form/Button`
 **Docs:** `packages/ui/src/components/form/Button/Button.md`
 ```
+
+## Adopting `exclude_preset`
+
+Use `exclude_preset` to silence a memory during routine workflows where its content doesn't apply. The presets in `lib/synapsys-presets.json` cover the most common collision categories — adopt them on existing memories rather than hand-rolling `exclude_prompt` regexes.
+
+### Built-in presets
+
+| Preset | Suppresses when prompt contains | Pattern |
+|---|---|---|
+| `git-ops` | `git merge/push/rebase/cherry-pick/reset/checkout`, `gh pr merge/view/checks/create/edit`, `cascade-merge`, `merge conflict` | `\b(git\s+(merge\|push\|rebase\|cherry-pick\|reset\|checkout)\|gh\s+pr\s+(merge\|view\|checks\|create\|edit)\|cascade-merge\|merge\s+conflict)\b` |
+| `ci-monitor` | `follow-up-next`, `gh run view/rerun/watch`, `gh pr checks`, `--log-failed` | `\b(follow-up-next\|gh\s+run\s+(view\|rerun\|watch)\|gh\s+pr\s+checks\|--log-failed)\b` |
+| `review-comment-handling` | `--solve-comment`, `--skip-comment`, `cursor[bot]`, `copilot[bot]`, `review thread/comment` | `(--solve-comment\|--skip-comment\|cursor\[bot\]\|copilot\[bot\]\|\breview\s+(thread\|comment)\b)` |
+
+### Picking the right preset(s)
+
+Walk through the decision per memory:
+
+1. **What is this memory actually about?** Read the body. If it's about TDD evidence, plugin bootstrap, environment config, etc. — none of the preset domains apply, so all three presets are safe to exclude.
+2. **Does the memory's purpose overlap with any preset?** If it's about reviews (e.g. *"never blanket-dismiss Copilot comments"*), don't exclude `review-comment-handling` — the memory needs to fire there. Same for PR-creation memories and `git-ops`, CI-failure memories and `ci-monitor`.
+3. **Is `trigger_prompt` broad enough to collide?** Triggers like `\b(review|comment)\b` or `\b(push|deploy)\b` collide easily with routine ops. Narrow ones like `\b(\.envrc|bootstrap)\b` rarely do. Adopt presets aggressively for broad triggers, sparingly for narrow ones.
+
+### Worked example — frontmatter form
+
+Single preset (string form):
+
+```yaml
+---
+name: read-envrc-first
+description: Read ../.envrc before bootstrap actions
+events: UserPromptSubmit,PreToolUse
+trigger_prompt: \b(\.envrc|bootstrap|setup|feature flag)\b
+exclude_preset: git-ops
+inject: full
+---
+```
+
+Multiple presets (bracket-list form):
+
+```yaml
+---
+name: no-fake-tdd-evidence
+description: Never run record commands to fill missing TDD evidence
+events: UserPromptSubmit
+trigger_prompt: \b(tdd|fake.*evidence|record.*phase)\b
+exclude_preset: [git-ops, ci-monitor, review-comment-handling]
+inject: full
+---
+```
+
+Both `exclude_preset` and inline `exclude_prompt` can coexist — they're OR-joined into one resolved exclude list. Add a per-memory `exclude_prompt` when the built-in presets don't cover your collision case.
+
+### Verifying with `synapsys-explain`
+
+After adding `exclude_preset`, replay the trigger against a colliding prompt to confirm the memory now stays silent:
+
+```bash
+node plugins/synapsys/scripts/synapsys-explain.js \
+  --event=UserPromptSubmit \
+  --prompt="rebasing onto main" \
+  --only=read-envrc-first --verbose
+# expect: Fired ✗ — reason cites the matched exclude_preset pattern.
+```
+
+A working exclude shows `excluded_pattern` in the explainer output. If the memory still fires, double-check the preset name spelling and the regex flavor (presets are case-sensitive on their literal patterns).
 
 ## Files
 


### PR DESCRIPTION
## Existing Behavior

- The Frontmatter schema table in `plugins/synapsys/README.md` had no entries for `exclude_prompt`, `exclude_preset`, or `exclude_pretool` — these fields shipped in PR #544 (GH-510) with no public documentation.
- Memory authors had no guidance on when or how to adopt the built-in presets (`git-ops`, `ci-monitor`, `review-comment-handling`).
- No verification recipe existed to confirm that an exclude gate was working correctly after adoption.

## Intended New Behavior

- The Frontmatter schema table now includes rows for `exclude_prompt`, `exclude_preset`, and `exclude_pretool` with full semantics, flag behavior, and fail-closed handling.
- A new "Adopting `exclude_preset`" section documents all three built-in presets (pattern + suppression domain), a decision walk-through for picking the right preset(s), and worked frontmatter examples in both single-string and bracket-list form.
- A `synapsys-explain` verification recipe lets authors replay a colliding prompt and confirm the memory stays silent after adding `exclude_preset`.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Docs-only change — no runtime behavior is modified.

To verify the rendered output:

1. Open `plugins/synapsys/README.md` in the GitHub PR preview.
2. Confirm the Frontmatter schema table contains new rows for `exclude_prompt`, `exclude_preset`, and `exclude_pretool`.
3. Confirm the "Adopting `exclude_preset`" section renders with the built-in presets table, the decision walk-through, and both frontmatter examples.
4. Confirm the `synapsys-explain` code block is syntactically correct and the expected output comment is present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to plugins/synapsys/README.md; no runtime or hook behavior is modified.
> 
> **Overview**
> Documents Synapsys memory **exclude** frontmatter that already ships in code but was missing from the public README.
> 
> The **Frontmatter schema** table now describes `exclude_prompt`, `exclude_preset`, and `exclude_pretool` (negative gates, preset resolution into `memory.excludeResolved`, invalid-regex / unknown-preset behavior). A new **Adopting `exclude_preset`** section lists the three built-in presets (`git-ops`, `ci-monitor`, `review-comment-handling`), when to apply vs avoid them, YAML examples for single and multiple presets, and how they combine with inline `exclude_prompt`. It also adds a **`synapsys-explain`** replay recipe to confirm a colliding prompt is suppressed (`excluded_pattern` in verbose output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9762c121779eeb7e2aba1009cd6cb68a17e3f57b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->