### PR TITLE
fix(synapsys): plumb payload to matcher.matchStop in synapsys-explain (GH-521)

### DIFF
--- a/plugins/synapsys/scripts/__tests__/synapsys-explain-stop-response.test.js
+++ b/plugins/synapsys/scripts/__tests__/synapsys-explain-stop-response.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+/**
+ * synapsys-explain — debug CLI must not lie about Stop+trigger_stop_response
+ * memories. Before this fix, evaluateMemory called matcher.matchStop(memory)
+ * with no payload, which made _extractStopResponse return '' and the regex
+ * miss, producing a misleading `fired: ✗ no-stop-response-match` row.
+ *
+ * Covers gap from PR #575 review:
+ *   - default invocation (no --response) reports an informational "would fire"
+ *     state instead of claiming the memory will never fire.
+ *   - --response=<matching text> reports the memory as fired.
+ *   - --response=<non-matching text> reports `no-stop-response-match`.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const SCRIPT = path.resolve(__dirname, '..', 'synapsys-explain.js');
+const MEMORY_NAME = 'flaky-test-fix-protocol';
+const STOP_REGEX = 'bump\\s+timeout';
+
+function makeTempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-explain-stopresp-'));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ kind: 'worktree', projectName: 'test', schemaVersion: 1 })
+  );
+  const frontmatter = [
+    '---',
+    `name: ${MEMORY_NAME}`,
+    'description: Steps to take when a test goes flaky.',
+    'events: Stop',
+    `trigger_stop_response: ${STOP_REGEX}`,
+    'inject: full',
+    '---',
+    '',
+    'body',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(storeDir, `${MEMORY_NAME}.md`), frontmatter);
+  return { cwd: dir };
+}
+
+function runExplain(cwd, extraArgs = []) {
+  const res = spawnSync(
+    process.execPath,
+    [SCRIPT, '--event=Stop', `--cwd=${cwd}`, ...extraArgs],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        NO_COLOR: '1',
+        SYNAPSYS_DISABLE_HOME_STORES: '1',
+      },
+    }
+  );
+  return { stdout: res.stdout || '', stderr: res.stderr || '', status: res.status };
+}
+
+test('synapsys-explain Stop+trigger_stop_response without --response does not lie about fired:false', () => {
+  const { cwd } = makeTempStore();
+  const { stdout, status } = runExplain(cwd);
+  assert.equal(status, 0, `expected exit 0, got ${status}; stdout=${stdout}`);
+
+  // Must NOT report the negative `no-stop-response-match` reason that the
+  // pre-fix matcher.matchStop(memory) regression produced.
+  assert.doesNotMatch(
+    stdout,
+    /no-stop-response-match/,
+    `output should not claim the memory will never fire.\n--- STDOUT ---\n${stdout}`
+  );
+
+  // Must surface the informational "would fire" hint (table truncates the
+  // reason column; the full phrase shows up in --verbose mode, asserted
+  // separately below).
+  assert.match(
+    stdout,
+    /would fire if response/,
+    `expected informational "would fire if response" hint.\n--- STDOUT ---\n${stdout}`
+  );
+
+  // The ? marker is the table's "needs input to evaluate" state.
+  assert.match(
+    stdout,
+    new RegExp(`${MEMORY_NAME}\\s+\\|\\s+\\?`),
+    `expected ${MEMORY_NAME} row to render with "?" pending-input marker.\n--- STDOUT ---\n${stdout}`
+  );
+});
+
+test('synapsys-explain Stop with --response matching trigger_stop_response reports fired ✓', () => {
+  const { cwd } = makeTempStore();
+  const { stdout, status } = runExplain(cwd, ['--response=please bump timeout for now']);
+  assert.equal(status, 0, `expected exit 0, got ${status}; stdout=${stdout}`);
+
+  assert.match(
+    stdout,
+    new RegExp(`${MEMORY_NAME}\\s+\\|\\s+✓`),
+    `expected ${MEMORY_NAME} row to mark fired ✓.\n--- STDOUT ---\n${stdout}`
+  );
+  assert.match(stdout, /1\/1 memories fired\./, `expected "1/1 memories fired." footer`);
+});
+
+test('synapsys-explain Stop with --response not matching trigger_stop_response reports no-stop-response-match', () => {
+  const { cwd } = makeTempStore();
+  const { stdout, status } = runExplain(cwd, ['--response=ran the tests and they passed']);
+  assert.equal(status, 0, `expected exit 0, got ${status}; stdout=${stdout}`);
+
+  assert.match(
+    stdout,
+    new RegExp(`${MEMORY_NAME}\\s+\\|\\s+✗\\s+\\|\\s+no-stop-response-match`),
+    `expected ${MEMORY_NAME} row to mark ✗ with no-stop-response-match reason.\n--- STDOUT ---\n${stdout}`
+  );
+});
+
+test('synapsys-explain --verbose surfaces the would_fire_if hint when --response is omitted', () => {
+  const { cwd } = makeTempStore();
+  const { stdout, status } = runExplain(cwd, ['--verbose']);
+  assert.equal(status, 0, `expected exit 0, got ${status}; stdout=${stdout}`);
+
+  assert.match(stdout, /fired:\s+\?\s+\(needs --response/, `expected "fired: ?" needs-response label`);
+  assert.match(
+    stdout,
+    /would_fire_if:\s+response matches \/bump/,
+    `expected would_fire_if line with regex pattern.\n--- STDOUT ---\n${stdout}`
+  );
+});
+
+test('synapsys-explain Stop with NO trigger_stop_response still fires unconditionally', () => {
+  // Backward-compat: memories without trigger_stop_response should still
+  // report fired ✓ for any Stop event invocation, regardless of --response.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-explain-stopresp-uncond-'));
+  const storeDir = path.join(dir, '.claude', 'synapsys');
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ kind: 'worktree', projectName: 'test', schemaVersion: 1 })
+  );
+  const frontmatter = [
+    '---',
+    'name: unconditional-stop-memory',
+    'description: Always fires on Stop',
+    'events: Stop',
+    'inject: full',
+    '---',
+    '',
+    'body',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(storeDir, 'unconditional-stop-memory.md'), frontmatter);
+
+  const res = spawnSync(
+    process.execPath,
+    [SCRIPT, '--event=Stop', `--cwd=${dir}`],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        NO_COLOR: '1',
+        SYNAPSYS_DISABLE_HOME_STORES: '1',
+      },
+    }
+  );
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, /unconditional-stop-memory\s+\|\s+✓/);
+});

--- a/plugins/synapsys/scripts/synapsys-explain.js
+++ b/plugins/synapsys/scripts/synapsys-explain.js
@@ -88,6 +88,25 @@ function loadMemories(stores) {
   return all;
 }
 
+// When the memory carries trigger_stop_response, matchStop needs the agent's
+// response surface to decide. synapsys-explain is a dry-run tool and has no
+// live response, so unless the operator supplies --response=… we short-circuit
+// with an informational pseudo-result rather than lying about fired:false
+// (which is what `matchStop(memory)` with no payload would otherwise return
+// via the empty-string regex path).
+function evaluateStop(memory, payload) {
+  const hasStopResponse = !!memory.triggerStopResponse;
+  const responseProvided = typeof payload.response === 'string' && payload.response !== '';
+  if (hasStopResponse && !responseProvided) {
+    return {
+      fired: null,
+      reason: 'needs-response',
+      triggerStopResponse: memory.triggerStopResponse,
+    };
+  }
+  return matcher.matchStop(memory, payload);
+}
+
 function evaluateMemory(memory, event, payload, activeDomains) {
   // Domain gate must run BEFORE per-event trigger checks, mirroring
   // selectForEvent in the dispatcher hook. Otherwise explain reports
@@ -104,9 +123,7 @@ function evaluateMemory(memory, event, payload, activeDomains) {
   if (event === 'SessionStart') {
     return matcher.matchSession(memory);
   }
-  if (event === 'Stop') {
-    return matcher.matchStop(memory);
-  }
+  if (event === 'Stop') return evaluateStop(memory, payload);
   return { fired: false, reason: 'events-exclude' };
 }
 
@@ -136,9 +153,15 @@ function renderTable(results) {
 
   let fired = 0;
   for (const r of results) {
-    const mark = r.result.fired ? '✓' : '✗';
+    const isNeedsResponse = r.result.fired === null && r.result.reason === 'needs-response';
+    const mark = r.result.fired ? '✓' : isNeedsResponse ? '?' : '✗';
     if (r.result.fired) fired++;
-    const reason = r.result.fired ? '' : r.result.reason || '';
+    let reason = '';
+    if (isNeedsResponse) {
+      reason = `would fire if response matches /${r.result.triggerStopResponse}/i`;
+    } else if (!r.result.fired) {
+      reason = r.result.reason || '';
+    }
     out.push(
       `${r.memory.name.padEnd(nameWidth)} | ${mark}     | ${truncate(reason, REASON_COL_MAX).padEnd(REASON_COL_MAX)}`
     );
@@ -146,6 +169,13 @@ function renderTable(results) {
   out.push('');
   out.push(`${fired}/${results.length} memories fired.`);
   return out.join('\n') + '\n';
+}
+
+function stopTriggerSource(memory) {
+  if (memory.triggerStopResponse) {
+    return `stop_response: /${memory.triggerStopResponse}/i`;
+  }
+  return '(unconditional on Stop)';
 }
 
 function eventTriggerSource(memory, event) {
@@ -161,7 +191,7 @@ function eventTriggerSource(memory, event) {
     return parts.join(' | ');
   }
   if (event === 'SessionStart') return `trigger_session: ${memory.triggerSession}`;
-  if (event === 'Stop') return '(unconditional on Stop)';
+  if (event === 'Stop') return stopTriggerSource(memory);
   return '';
 }
 
@@ -181,6 +211,14 @@ function renderFiredBlock(matched) {
     if (m[key] !== undefined) lines.push(`  ${label}: ${m[key]}`);
   }
   return lines;
+}
+
+function renderNeedsResponseBlock(memory, result) {
+  return [
+    `  fired: ?  (needs --response=… to evaluate trigger_stop_response)`,
+    `  would_fire_if: response matches /${result.triggerStopResponse}/i`,
+    `  re-run with: --response="<assistant turn text>"`,
+  ];
 }
 
 function renderNotFiredBlock(memory, reason, matched) {
@@ -206,9 +244,12 @@ function renderVerboseBlock(memory, result, event) {
   lines.push(`  events: ${eventsList}`);
   const trig = eventTriggerSource(memory, event);
   if (trig) lines.push(`  trigger: ${trig}`);
-  const body = result.fired
-    ? renderFiredBlock(result.matched)
-    : renderNotFiredBlock(memory, result.reason, result.matched);
+  const isNeedsResponse = result.fired === null && result.reason === 'needs-response';
+  const body = isNeedsResponse
+    ? renderNeedsResponseBlock(memory, result)
+    : result.fired
+      ? renderFiredBlock(result.matched)
+      : renderNotFiredBlock(memory, result.reason, result.matched);
   lines.push(...body);
   return lines.join('\n');
 }
@@ -265,12 +306,13 @@ function applyOnlyFilter(memories, only) {
   return memories.filter((m) => onlySet.has(m.name));
 }
 
-function buildPayload(event, prompt, tool, toolInput, cwd) {
+function buildPayload(event, prompt, tool, toolInput, cwd, response) {
   return {
     hook_event_name: event,
     prompt: prompt === true ? '' : prompt || '',
     tool_name: tool === true ? '' : tool || '',
     tool_input: toolInput || {},
+    response: response === true ? '' : response || '',
     cwd,
   };
 }
@@ -284,12 +326,14 @@ function main() {
   const prompt = flag('prompt') !== undefined ? flag('prompt') : stdinPayload.prompt;
   const tool = flag('tool') !== undefined ? flag('tool') : stdinPayload.tool_name;
   const toolInput = resolveToolInput(flag, stdinPayload);
+  const response =
+    flag('response') !== undefined ? flag('response') : stdinPayload.response;
   const verbose = !!flag('verbose');
   const only = parseOnlyList(flag);
 
   const stores = loadStore(flag('store'), cwd);
   const memories = applyOnlyFilter(loadMemories(stores), only);
-  const payload = buildPayload(event, prompt, tool, toolInput, cwd);
+  const payload = buildPayload(event, prompt, tool, toolInput, cwd, response);
 
   const activeDomains = computeActiveDomainsForExplain(event, payload);
   const results = memories.map((memory) => ({


### PR DESCRIPTION
## Existing Behavior

- `synapsys-explain.js` calls `matcher.matchStop(memory)` with no payload argument.
- `_extractStopResponse(undefined)` returns `''`, causing the regex to never match.
- Any memory with `triggerStopResponse` shows `fired: ✗ no-stop-response-match` regardless of its pattern — a misleading false negative.
- `evaluateMemory` and `eventTriggerSource` contain Stop-branch logic inline, pushing cyclomatic complexity above the cap of 10.

## Intended New Behavior

- New `--response=<text>` CLI flag plumbs into a synthetic Stop payload so `matcher.matchStop(memory, payload)` runs the real evaluation path.
- When `--response` is omitted and the memory has `triggerStopResponse`, a new `evaluateStop` helper short-circuits with `{ fired: null, reason: 'needs-response', triggerStopResponse }`. The table renderer marks the row `?` with a truncated hint; `--verbose` shows `would_fire_if: response matches /<pattern>/i` and a `re-run with --response=…` prompt — no more lying about `fired: ✗`.
- `evaluateStop` and `stopTriggerSource` helpers extracted from `evaluateMemory` / `eventTriggerSource` to keep both functions under the cyclomatic-complexity-10 cap.
- AC6 telemetry (Gap 2) verified already satisfied: `hooks/synapsys.js:204` calls `recordFired` and `lib/telemetry.js:96-115` writes `{ event: 'fired', reason: 'Stop' }` per fired memory — no code change needed.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / CLI verification:**

1. No `--response` flag — row must show `?`, not `✗`:
   ```
   node plugins/synapsys/scripts/synapsys-explain.js <memory-id>
   ```
   Expected: row marker is `?`; output does NOT contain `no-stop-response-match`; contains `would fire if response`.

2. Matching response — row must show `✓`:
   ```
   node plugins/synapsys/scripts/synapsys-explain.js <memory-id> --response="hello world"
   ```
   Expected: `✓` row, footer `1/1 memories fired.`

3. Non-matching response — row must show `✗`:
   ```
   node plugins/synapsys/scripts/synapsys-explain.js <memory-id> --response="unrelated text"
   ```
   Expected: `✗` row with `no-stop-response-match`.

4. Verbose mode:
   ```
   node plugins/synapsys/scripts/synapsys-explain.js <memory-id> --verbose
   ```
   Expected: `fired: ?  (needs --response…` and `would_fire_if: response matches /<pattern>/i`.

5. Stop memories without `trigger_stop_response` still fire unconditionally — backward compat unchanged.

### Test Results

`node --test plugins/synapsys/lib/__tests__/*.test.js plugins/synapsys/scripts/__tests__/*.test.js` → **412/412 pass** (407 baseline from #575 + 5 new explain tests).

`pnpm dev:lint plugins/synapsys/scripts/synapsys-explain.js` → 0 errors, 0 complexity violations.

## Stack & Merge Order

- Base: `GH-521-trigger-stop-response` (PR #575) → targets `main`.
- After #575 merges to `main`, GitHub will auto-retarget this PR to `main`.

Stacks on #575. Implements GH-521 review follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic CLI and test-only changes; no hook runtime or injection path modified.
> 
> **Overview**
> Fixes **synapsys-explain** so Stop memories with `trigger_stop_response` are no longer reported as false negatives when no assistant text is available.
> 
> The CLI adds **`--response`** (and stdin `response`) on the synthetic Stop payload and routes Stop evaluation through **`evaluateStop`**, which returns a pending **`needs-response`** result (`fired: null`, `?` in the table) instead of calling `matchStop` with an empty response. Table and **`--verbose`** output explain that evaluation needs `--response` and show the regex; Stop trigger lines now show **`stop_response: /pattern/i`** when applicable. **`evaluateStop`** / **`stopTriggerSource`** are extracted to keep complexity under the lint cap. Five CLI integration tests lock in the new behavior and unconditional Stop backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b9e15e56306247ff8153fde80bd88d68fb44f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->