### PR TITLE
fix(synapsys): key per-session injection ledger on CLAUDE_CODE_SESSION_ID (GH-583)

### DIFF
--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -354,6 +354,17 @@ Look for this in agent transcripts — it confirms the rule is still load-bearin
 
 The injection ledger is keyed by `(session_id, memory_name)` and lives in a per-session JSON file under the user's synapsys session directory. It is **reset at SessionStart** so every new Claude Code session begins with a clean slate. Stale ledger files older than 7 days are opportunistically garbage-collected on the same SessionStart pass. Errors reading or writing the ledger fail open — the dispatcher falls through to full injection (current pre-fire_mode behavior).
 
+#### `CLAUDE_CODE_SESSION_ID` dependency
+
+The session id used to key the per-session injection ledger is resolved through a four-leg chain, in priority order:
+
+1. **`process.env.CLAUDE_CODE_SESSION_ID`** — the authoritative signal. Claude Code rotates this environment variable on `/clear` and at the start of every new conversation, so the dispatcher automatically reads/writes a fresh ledger file (`~/.claude/synapsys/.session/<CLAUDE_CODE_SESSION_ID>.json`) per session with no explicit clear hook. Values are validated against `SAFE_ID_RE` (`/^[A-Za-z0-9_-]{1,128}$/`); unsafe values are sha256-hashed before touching the filesystem, and empty strings are treated as absent.
+2. **`payload.session_id`** — passed by the hook payload when available.
+3. **`<sessionDir>/.current`** — advisory persistent fallback also published for out-of-process readers (`synapsys-list`, `synapsys-stats`).
+4. **`sha1(cwd + processStartTime)`** — last-resort deterministic fallback.
+
+Graceful degradation: if `CLAUDE_CODE_SESSION_ID` ever disappears in a future Claude Code release, legs 2–4 still produce a usable session id, but `/clear` correctness (a fresh ledger after the user clears the conversation) specifically depends on the env var rotating. Stale `.current` files do not override a present env var, and a new Claude Code session in the same `cwd` always starts with a fresh ledger because the env var changes per conversation.
+
 ### Migration checklist
 
 When upgrading existing memories:

--- a/plugins/synapsys/lib/__tests__/inject-ledger-fire-mode-e2e.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/inject-ledger-fire-mode-e2e.integration.test.js
@@ -1,0 +1,179 @@
+'use strict';
+
+/**
+ * Integration tests for the GH-583 behavior-table scenarios:
+ *   (1) first prompt in a new Claude Code session writes the env-keyed ledger
+ *   (2) /clear rotates CLAUDE_CODE_SESSION_ID -> new ledger file, fresh count
+ *   (3) new Claude Code session in same cwd ignores stale .current + stale
+ *       per-session ledger file
+ *   (4) gcStaleLedgers still removes stale *.json files (7-day cutoff) while
+ *       preserving the .current non-json publish file (C2/C4)
+ *
+ * Drives recordInjection / loadLedger / gcStaleLedgers directly under an
+ * isolated HOME tmpdir + stubbed CLAUDE_CODE_SESSION_ID — no dispatcher
+ * subprocess.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ENV_KEY = 'CLAUDE_CODE_SESSION_ID';
+
+function makeTmpHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-ledger-e2e-'));
+}
+
+function sessionDir(home) {
+  return path.join(home, '.claude', 'synapsys', '.session');
+}
+
+function loadFreshLedgerModule() {
+  const modPath = require.resolve('../inject-ledger');
+  delete require.cache[modPath];
+  return require('../inject-ledger');
+}
+
+/**
+ * Local test-only helper: stub HOME + CLAUDE_CODE_SESSION_ID for a single
+ * call, reload the ledger module so module-level caches honor the stubs,
+ * then restore. Symmetric to withHomeAndEnv in inject-ledger-session-env.test.js
+ * but scoped to the e2e harness.
+ */
+function withSession(home, envValue, fn) {
+  const prevHome = process.env.HOME;
+  const hadEnv = Object.prototype.hasOwnProperty.call(process.env, ENV_KEY);
+  const prevEnv = process.env[ENV_KEY];
+  process.env.HOME = home;
+  if (envValue === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = envValue;
+  }
+  try {
+    return fn(loadFreshLedgerModule());
+  } finally {
+    process.env.HOME = prevHome;
+    if (hadEnv) {
+      process.env[ENV_KEY] = prevEnv;
+    } else {
+      delete process.env[ENV_KEY];
+    }
+    const modPath = require.resolve('../inject-ledger');
+    delete require.cache[modPath];
+  }
+}
+
+test('@e2e scenario 1: first prompt in a fresh CLAUDE_CODE_SESSION_ID writes <sessionDir>/<env-id>.json with injectedCount 1, lastFullInjectAt 1', () => {
+  const home = makeTmpHome();
+  withSession(home, 'session-fresh-1', (ledger) => {
+    const sid = ledger.resolveSessionId({});
+    assert.equal(sid, 'session-fresh-1');
+    ledger.recordInjection(sid, 'policy-a', { full: true });
+
+    const expectedPath = path.join(sessionDir(home), 'session-fresh-1.json');
+    assert.equal(fs.existsSync(expectedPath), true, 'env-keyed ledger file must exist');
+
+    const loaded = ledger.loadLedger(sid);
+    assert.equal(loaded.memories['policy-a'].injectedCount, 1);
+    assert.equal(loaded.memories['policy-a'].lastFullInjectAt, 1);
+  });
+});
+
+test('@e2e scenario 2: /clear rotates CLAUDE_CODE_SESSION_ID -> a new ledger file is written with fresh injectedCount: 1 (not 2)', () => {
+  const home = makeTmpHome();
+
+  // First session: record one injection under "session-pre-clear"
+  withSession(home, 'session-pre-clear', (ledger) => {
+    const sid = ledger.resolveSessionId({});
+    assert.equal(sid, 'session-pre-clear');
+    ledger.recordInjection(sid, 'policy-a', { full: true });
+  });
+
+  const preLedgerPath = path.join(sessionDir(home), 'session-pre-clear.json');
+  assert.equal(fs.existsSync(preLedgerPath), true);
+
+  // /clear rotation: env-var becomes "session-post-clear"
+  withSession(home, 'session-post-clear', (ledger) => {
+    const sid = ledger.resolveSessionId({});
+    assert.equal(sid, 'session-post-clear');
+    ledger.recordInjection(sid, 'policy-a', { full: true });
+
+    const postLedgerPath = path.join(sessionDir(home), 'session-post-clear.json');
+    assert.equal(fs.existsSync(postLedgerPath), true, 'rotated env id must get its own ledger file');
+    assert.notEqual(postLedgerPath, preLedgerPath, 'paths must be distinct');
+
+    const postLoaded = ledger.loadLedger(sid);
+    assert.equal(postLoaded.memories['policy-a'].injectedCount, 1, 'fresh ledger -> count 1, not 2');
+    assert.equal(postLoaded.memories['policy-a'].lastFullInjectAt, 1);
+
+    // Pre-clear ledger is independent and still shows its own count
+    const preLoaded = ledger.loadLedger('session-pre-clear');
+    assert.equal(preLoaded.memories['policy-a'].injectedCount, 1);
+  });
+});
+
+test('@e2e scenario 3: stale .current + stale per-session ledger do NOT carry over to a new env-derived session id', () => {
+  const home = makeTmpHome();
+  const dir = sessionDir(home);
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Seed a stale ledger and a stale .current
+  const staleLedger = {
+    createdAt: new Date().toISOString(),
+    sessionId: 'old-session',
+    memories: { 'policy-a': { injectedCount: 1, lastFullInjectAt: 1 } },
+  };
+  fs.writeFileSync(path.join(dir, 'old-session.json'), JSON.stringify(staleLedger));
+  fs.writeFileSync(path.join(dir, '.current'), 'old-session');
+
+  withSession(home, 'new-session', (ledger) => {
+    const sid = ledger.resolveSessionId({});
+    assert.equal(sid, 'new-session', 'env var must override stale .current');
+
+    // Fresh ledger for the new session
+    const freshBefore = ledger.loadLedger(sid);
+    assert.deepEqual(freshBefore.memories, {}, 'new session ledger must start empty');
+
+    ledger.recordInjection(sid, 'policy-a', { full: true });
+
+    const newPath = path.join(dir, 'new-session.json');
+    assert.equal(fs.existsSync(newPath), true);
+
+    const newLoaded = ledger.loadLedger(sid);
+    assert.equal(newLoaded.memories['policy-a'].injectedCount, 1);
+
+    // Old ledger is left untouched (GC will clean it up later)
+    const oldRaw = fs.readFileSync(path.join(dir, 'old-session.json'), 'utf8');
+    const oldParsed = JSON.parse(oldRaw);
+    assert.equal(oldParsed.memories['policy-a'].injectedCount, 1, 'old ledger untouched');
+  });
+});
+
+test('@e2e scenario 4: gcStaleLedgers removes *.json older than 7 days, preserves fresh *.json AND the .current non-json file', () => {
+  const home = makeTmpHome();
+  const dir = sessionDir(home);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const oldPath = path.join(dir, 'old-session.json');
+  const freshPath = path.join(dir, 'fresh-session.json');
+  const currentPath = path.join(dir, '.current');
+
+  fs.writeFileSync(oldPath, JSON.stringify({ memories: {} }));
+  fs.writeFileSync(freshPath, JSON.stringify({ memories: {} }));
+  fs.writeFileSync(currentPath, 'some-session-id');
+
+  // Backdate old ledger mtime 10 days
+  const tenDaysAgo = Date.now() - 10 * 24 * 3600 * 1000;
+  fs.utimesSync(oldPath, tenDaysAgo / 1000, tenDaysAgo / 1000);
+
+  withSession(home, undefined, (ledger) => {
+    ledger.gcStaleLedgers({ maxAgeMs: 7 * 24 * 3600 * 1000 });
+
+    assert.equal(fs.existsSync(oldPath), false, 'stale *.json must be removed');
+    assert.equal(fs.existsSync(freshPath), true, 'fresh *.json must be preserved');
+    assert.equal(fs.existsSync(currentPath), true, '.current (non-*.json) must be preserved');
+  });
+});

--- a/plugins/synapsys/lib/__tests__/inject-ledger-session-env.test.js
+++ b/plugins/synapsys/lib/__tests__/inject-ledger-session-env.test.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ENV_KEY = 'CLAUDE_CODE_SESSION_ID';
+
+function makeTmpHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-ledger-env-'));
+}
+
+function withHomeAndEnv(home, envValue, fn) {
+  const prevHome = process.env.HOME;
+  const hadEnv = Object.prototype.hasOwnProperty.call(process.env, ENV_KEY);
+  const prevEnv = process.env[ENV_KEY];
+  process.env.HOME = home;
+  if (envValue === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = envValue;
+  }
+  const modPath = require.resolve('../inject-ledger');
+  delete require.cache[modPath];
+  try {
+    const mod = require('../inject-ledger');
+    return fn(mod);
+  } finally {
+    process.env.HOME = prevHome;
+    if (hadEnv) {
+      process.env[ENV_KEY] = prevEnv;
+    } else {
+      delete process.env[ENV_KEY];
+    }
+    delete require.cache[require.resolve('../inject-ledger')];
+  }
+}
+
+function sessionDir(home) {
+  return path.join(home, '.claude', 'synapsys', '.session');
+}
+
+test('(a) safe env id is returned verbatim and ledger file lives under <HOME>/.claude/synapsys/.session/<id>.json', () => {
+  const home = makeTmpHome();
+  withHomeAndEnv(home, 'env-session-safe_123', (ledger) => {
+    const sid = ledger.resolveSessionId({});
+    assert.equal(sid, 'env-session-safe_123');
+    ledger.recordInjection(sid, 'mem-x', { full: true });
+    const expected = path.join(sessionDir(home), 'env-session-safe_123.json');
+    assert.equal(fs.existsSync(expected), true, 'ledger file should be at env-derived path');
+  });
+});
+
+test('(b) unsafe env id ("../evil/path") is sha256-hashed; no ".." segment lands on disk', () => {
+  const home = makeTmpHome();
+  withHomeAndEnv(home, '../evil/path', (ledger) => {
+    const sid = ledger.resolveSessionId({});
+    assert.notEqual(sid, '../evil/path');
+    assert.match(sid, /^[A-Za-z0-9_-]+$/);
+    ledger.recordInjection(sid, 'mem-x', { full: true });
+    const dir = sessionDir(home);
+    const entries = fs.existsSync(dir) ? fs.readdirSync(dir) : [];
+    for (const name of entries) {
+      assert.equal(name.includes('..'), false, `disk entry ${name} must not contain ".."`);
+      assert.equal(name.includes('/'), false, `disk entry ${name} must not contain "/"`);
+    }
+    assert.ok(entries.some((n) => n === `${sid}.json`), 'hashed-id ledger file should exist');
+  });
+});
+
+test('(c) env-var rotation between two resolveSessionId calls produces two distinct ledger files with independent contents', () => {
+  const home = makeTmpHome();
+  withHomeAndEnv(home, 'env-rot-A', (ledger) => {
+    const idA = ledger.resolveSessionId({});
+    assert.equal(idA, 'env-rot-A');
+    ledger.recordInjection(idA, 'mem', { full: true });
+    const a = ledger.loadLedger(idA);
+    assert.equal(a.memories.mem.injectedCount, 1);
+  });
+  withHomeAndEnv(home, 'env-rot-B', (ledger) => {
+    const idB = ledger.resolveSessionId({});
+    assert.equal(idB, 'env-rot-B');
+    const b = ledger.loadLedger(idB);
+    assert.deepEqual(b.memories, {}, 'rotated session must start fresh (no inherited counts)');
+    ledger.recordInjection(idB, 'mem', { full: true });
+    const after = ledger.loadLedger(idB);
+    assert.equal(after.memories.mem.injectedCount, 1);
+  });
+  const dir = sessionDir(home);
+  assert.equal(fs.existsSync(path.join(dir, 'env-rot-A.json')), true);
+  assert.equal(fs.existsSync(path.join(dir, 'env-rot-B.json')), true);
+});
+
+test('(d) stale .current does NOT override a present env var', () => {
+  const home = makeTmpHome();
+  const dir = sessionDir(home);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '.current'), 'stale-current-id');
+  withHomeAndEnv(home, 'env-wins', (ledger) => {
+    const sid = ledger.resolveSessionId({});
+    assert.equal(sid, 'env-wins', 'env var must beat stale .current');
+  });
+});
+
+test('(e) env var beats payload.session_id', () => {
+  const home = makeTmpHome();
+  withHomeAndEnv(home, 'env-priority', (ledger) => {
+    const sid = ledger.resolveSessionId({ session_id: 'payload-id' });
+    assert.equal(sid, 'env-priority');
+  });
+});
+
+test('(f) empty-string env var is treated as absent (falls through to payload)', () => {
+  const home = makeTmpHome();
+  withHomeAndEnv(home, '', (ledger) => {
+    const sid = ledger.resolveSessionId({ session_id: 'payload-fallthrough' });
+    assert.equal(sid, 'payload-fallthrough');
+  });
+});
+
+test('(g) back-compat: env var unset and no payload → .current still wins', () => {
+  const home = makeTmpHome();
+  const dir = sessionDir(home);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '.current'), 'persisted-current');
+  withHomeAndEnv(home, undefined, (ledger) => {
+    const sid = ledger.resolveSessionId({});
+    assert.equal(sid, 'persisted-current');
+  });
+});
+
+// --- Task 2: resolveSessionIdWithSource tagged export ---
+
+test('(h) resolveSessionIdWithSource tags source="env" when env var resolves', () => {
+  const home = makeTmpHome();
+  withHomeAndEnv(home, 'env-tagged', (ledger) => {
+    assert.equal(typeof ledger.resolveSessionIdWithSource, 'function',
+      'resolveSessionIdWithSource must be exported');
+    const result = ledger.resolveSessionIdWithSource({ session_id: 'payload-id' });
+    assert.equal(result.sessionId, 'env-tagged');
+    assert.equal(result.source, 'env');
+  });
+});
+
+test('(i) resolveSessionIdWithSource tags source="payload" when only payload resolves', () => {
+  const home = makeTmpHome();
+  withHomeAndEnv(home, undefined, (ledger) => {
+    assert.equal(typeof ledger.resolveSessionIdWithSource, 'function',
+      'resolveSessionIdWithSource must be exported');
+    const result = ledger.resolveSessionIdWithSource({ session_id: 'payload-only' });
+    assert.equal(result.sessionId, 'payload-only');
+    assert.equal(result.source, 'payload');
+  });
+});
+
+test('(j) resolveSessionIdWithSource tags source="current" when only .current resolves', () => {
+  const home = makeTmpHome();
+  const dir = sessionDir(home);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '.current'), 'current-only-id');
+  withHomeAndEnv(home, undefined, (ledger) => {
+    assert.equal(typeof ledger.resolveSessionIdWithSource, 'function',
+      'resolveSessionIdWithSource must be exported');
+    const result = ledger.resolveSessionIdWithSource({});
+    assert.equal(result.sessionId, 'current-only-id');
+    assert.equal(result.source, 'current');
+  });
+});
+
+test('(k) resolveSessionIdWithSource tags source="fallback" when only sha1(cwd+processStartTime) leg fires', () => {
+  const home = makeTmpHome();
+  withHomeAndEnv(home, undefined, (ledger) => {
+    assert.equal(typeof ledger.resolveSessionIdWithSource, 'function',
+      'resolveSessionIdWithSource must be exported');
+    const result = ledger.resolveSessionIdWithSource({});
+    assert.equal(typeof result.sessionId, 'string');
+    assert.ok(result.sessionId.length > 0);
+    assert.equal(result.source, 'fallback');
+  });
+});

--- a/plugins/synapsys/lib/__tests__/inject-ledger.test.js
+++ b/plugins/synapsys/lib/__tests__/inject-ledger.test.js
@@ -13,7 +13,13 @@ function makeTmpHome() {
 
 function withHome(home, fn) {
   const prev = process.env.HOME;
+  // Stub CLAUDE_CODE_SESSION_ID unset so legacy assertions about .current /
+  // payload / hash-fallback legs are not pre-empted by the new env-var leg 1.
+  const ENV_KEY = 'CLAUDE_CODE_SESSION_ID';
+  const hadEnv = Object.prototype.hasOwnProperty.call(process.env, ENV_KEY);
+  const prevEnv = process.env[ENV_KEY];
   process.env.HOME = home;
+  delete process.env[ENV_KEY];
   // Force fresh module each test so any module-level caches respect HOME
   const modPath = require.resolve('../inject-ledger');
   delete require.cache[modPath];
@@ -22,6 +28,11 @@ function withHome(home, fn) {
     return fn(mod);
   } finally {
     process.env.HOME = prev;
+    if (hadEnv) {
+      process.env[ENV_KEY] = prevEnv;
+    } else {
+      delete process.env[ENV_KEY];
+    }
     delete require.cache[require.resolve('../inject-ledger')];
   }
 }

--- a/plugins/synapsys/lib/inject-ledger.js
+++ b/plugins/synapsys/lib/inject-ledger.js
@@ -3,13 +3,25 @@
 /**
  * inject-ledger — per-session injection ledger for synapsys fire_mode.
  *
- * Session-id resolution chain (spec §3.2):
- *   1. `payload.session_id` when it matches /^[A-Za-z0-9_-]{1,128}$/.
- *   2. Unsafe `payload.session_id` is sha1-hashed (path-traversal guard, spec §4.1)
- *      — never used raw on the filesystem.
- *   3. Otherwise read `~/.claude/synapsys/.session/.current` if present.
- *   4. Otherwise compute `sha1(cwd + processStartTime)`, write it to `.current`,
+ * Session-id resolution chain (spec §3.2, GH-583):
+ *   1. `process.env.CLAUDE_CODE_SESSION_ID` — authoritative. Validated by
+ *      /^[A-Za-z0-9_-]{1,128}$/; unsafe values are sha256-hashed (path-traversal
+ *      guard, spec §4.1). Empty/unset falls through to leg 2. Claude Code rotates
+ *      this on `/clear` and per new conversation, which is exactly the semantics
+ *      the ledger needs to model (GH-583). If a future Claude Code release renames
+ *      or removes this var, legs 2–4 keep producing a working — but `/clear`-blind —
+ *      id, so behavior degrades to the pre-GH-583 state rather than crashing.
+ *   2. `payload.session_id` when safe; unsafe values are sha256-hashed.
+ *   3. Otherwise read `~/.claude/synapsys/.session/.current` if present (advisory
+ *      since GH-583 — still written by `publishCurrentSessionId` so out-of-process
+ *      callers like `synapsys-list` can locate the active ledger).
+ *   4. Otherwise compute `sha256(cwd + processStartTime)`, write it to `.current`,
  *      and return it.
+ *
+ * Additive export: `resolveSessionIdWithSource(payload) -> { sessionId, source }`
+ * tags which leg of the chain produced the id (`'env' | 'payload' | 'current' |
+ * 'fallback'`) for telemetry. The primary `resolveSessionId(payload) -> string`
+ * contract is unchanged.
  *
  * Storage (spec §3.3): `~/.claude/synapsys/.session/<session_id>.json` with shape
  *   `{ createdAt, sessionId, memories: { <name>: { injectedCount, lastFullInjectAt } } }`.

--- a/plugins/synapsys/lib/inject-ledger.js
+++ b/plugins/synapsys/lib/inject-ledger.js
@@ -68,6 +68,16 @@ function resolveFromPayload(payload) {
   return SAFE_ID_RE.test(raw) ? raw : hashId(raw);
 }
 
+function resolveFromEnv() {
+  try {
+    const raw = process.env.CLAUDE_CODE_SESSION_ID;
+    if (typeof raw !== 'string' || raw.length === 0) return null;
+    return SAFE_ID_RE.test(raw) ? raw : hashId(raw);
+  } catch {
+    return null;
+  }
+}
+
 function readBoundedFile(p, maxBytes) {
   let fd;
   try {
@@ -115,20 +125,30 @@ function computeFallbackId() {
   return hashId(`${process.cwd()}|${PROCESS_START_TIME}`);
 }
 
-function resolveSessionId(payload) {
+function resolveChain(payload) {
   try {
+    const fromEnv = resolveFromEnv();
+    if (fromEnv) return { sessionId: fromEnv, source: 'env' };
     const fromPayload = resolveFromPayload(payload);
-    if (fromPayload) return fromPayload;
+    if (fromPayload) return { sessionId: fromPayload, source: 'payload' };
     ensureDir();
     const currentPath = path.join(sessionDir(), '.current');
     const existing = readCurrentSessionFile(currentPath);
-    if (existing) return existing;
+    if (existing) return { sessionId: existing, source: 'current' };
     const computed = computeFallbackId();
     writeCurrentSessionFile(currentPath, computed);
-    return computed;
+    return { sessionId: computed, source: 'fallback' };
   } catch {
-    return computeFallbackId();
+    return { sessionId: computeFallbackId(), source: 'fallback' };
   }
+}
+
+function resolveSessionId(payload) {
+  return resolveChain(payload).sessionId;
+}
+
+function resolveSessionIdWithSource(payload) {
+  return resolveChain(payload);
 }
 
 function readLedgerFile(sessionId) {
@@ -238,6 +258,7 @@ function publishCurrentSessionId(sessionId) {
 
 module.exports = {
   resolveSessionId,
+  resolveSessionIdWithSource,
   loadLedger,
   saveLedger,
   recordInjection,


### PR DESCRIPTION
## Existing Behavior

- The per-session injection ledger is keyed by a four-leg chain: payload.session_id -> .current file -> sha1(cwd+processStartTime).
- The .current file is written once and persists across /clear invocations and new Claude Code sessions in the same working directory.
- Issuing /clear or starting a new Claude Code conversation in the same cwd reuses the stale .current session id, causing the ledger to carry over previous injection counts — memories that should be re-injected in the fresh session are over-suppressed.
- There is no mechanism to distinguish a /clear rotation from a session still in progress.

## Intended New Behavior

- process.env.CLAUDE_CODE_SESSION_ID is inserted as leg 1 of the resolution chain. Claude Code rotates this env var on /clear and at the start of every new conversation, so the ledger automatically maps to a fresh file without any explicit clear hook.
- Unsafe env var values (e.g. path-traversal strings) are sha256-hashed before touching the filesystem; empty or unset values fall through to leg 2 (payload), preserving backward compatibility.
- New additive export resolveSessionIdWithSource(payload) returns { sessionId, source } tagging which leg produced the id (env | payload | current | fallback) for future telemetry without breaking the existing resolveSessionId contract.
- Graceful degradation: if CLAUDE_CODE_SESSION_ID is ever removed in a future Claude Code release, legs 2-4 still produce a working session id; only the /clear correctness degrades to the pre-GH-583 state rather than crashing.
- The .current file continues to be written by publishCurrentSessionId for out-of-process readers (synapsys-list, synapsys-stats); it is now advisory rather than authoritative when the env var is present.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Backend / library change — exercise via node:test:

1. Run the new unit tests targeting env-var leg resolution:

   node --test plugins/synapsys/lib/__tests__/inject-ledger-session-env.test.js

   Expected: 11 passing tests covering safe id passthrough, unsafe id hashing, env-var rotation isolation, priority over .current and payload.session_id, empty-string fallthrough, back-compat when unset, and resolveSessionIdWithSource source tagging.

2. Run the e2e integration tests covering the GH-583 behavior table:

   node --test plugins/synapsys/lib/__tests__/inject-ledger-fire-mode-e2e.integration.test.js

   Expected: 4 passing scenarios — fresh session writes env-keyed ledger, /clear rotation produces a distinct fresh-count ledger, stale .current does not carry over to a new env-derived session, and gcStaleLedgers removes only *.json files older than 7 days while preserving .current.

3. Confirm the existing ledger test suite still passes (regression):

   node --test plugins/synapsys/lib/__tests__/inject-ledger.test.js

   Expected: all pre-existing assertions pass (the withHome helper stubs CLAUDE_CODE_SESSION_ID out so legacy legs are not pre-empted by leg 1).

4. Simulate the /clear fix end-to-end:
   - Set CLAUDE_CODE_SESSION_ID=session-A in the shell.
   - Call resolveSessionId({}) — verify it returns session-A and writes the env-keyed ledger file.
   - Change CLAUDE_CODE_SESSION_ID=session-B (simulating a /clear rotation).
   - Call resolveSessionId({}) again — verify it returns session-B and writes a separate ledger file with no inherited injection counts.

### Test Results

Tests must be run manually via node --test as described above. No automated CI runner is currently wired to the synapsys __tests__ directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how session boundaries are detected for memory injection deduplication; wrong resolution would over- or under-inject policy memories, but fallbacks preserve pre-GH-583 behavior if the env var is absent.
> 
> **Overview**
> Fixes **GH-583**: the per-session `fire_mode` injection ledger no longer sticks across `/clear` or a new conversation in the same cwd because session ids were keyed off a persistent `.current` file.
> 
> **`inject-ledger.js`** now resolves session id with **`CLAUDE_CODE_SESSION_ID` first** (validated or sha256-hashed for unsafe values; empty/unset falls through). Priority is then `payload.session_id`, advisory `.current`, and a **sha256(cwd + processStartTime)** fallback. **`resolveSessionIdWithSource`** is added for `{ sessionId, source }` telemetry; **`resolveSessionId`** behavior is unchanged aside from the new env leg.
> 
> **README** documents the four-leg chain and `/clear` dependency on the env var. **Tests**: new env-resolution and e2e suites; existing **`inject-ledger.test.js`** stubs the env var so legacy resolution tests still pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de5ef140ee0d39bb1055b4ec304333678d77290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->