### PR TITLE
feat(synapsys): unify session-id resolution + rotation instrumentation (GH-583 followup)

### DIFF
--- a/plugins/synapsys/lib/__tests__/session-id-rotation.test.js
+++ b/plugins/synapsys/lib/__tests__/session-id-rotation.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function withTempHome(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-rotation-'));
+  const prevHome = process.env.HOME;
+  const prevSessionDir = process.env.SYNAPSYS_SESSION_DIR;
+  const prevDisabled = process.env.SYNAPSYS_SESSION_ROTATION_DISABLED;
+  process.env.HOME = tmp;
+  delete process.env.SYNAPSYS_SESSION_DIR;
+  delete process.env.SYNAPSYS_SESSION_ROTATION_DISABLED;
+  delete require.cache[require.resolve('../session-id-rotation')];
+  const mod = require('../session-id-rotation');
+  mod.__resetForTests();
+  try {
+    return fn(tmp, mod);
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevSessionDir === undefined) delete process.env.SYNAPSYS_SESSION_DIR;
+    else process.env.SYNAPSYS_SESSION_DIR = prevSessionDir;
+    if (prevDisabled === undefined) delete process.env.SYNAPSYS_SESSION_ROTATION_DISABLED;
+    else process.env.SYNAPSYS_SESSION_ROTATION_DISABLED = prevDisabled;
+    delete require.cache[require.resolve('../session-id-rotation')];
+  }
+}
+
+function readJsonl(file) {
+  if (!fs.existsSync(file)) return [];
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+test('first observation seeds the last-observed pointer without emitting a rotation event', () => {
+  withTempHome((_home, mod) => {
+    mod.observeRotation('session-a');
+    assert.ok(fs.existsSync(mod.lastObservedFile()));
+    assert.equal(readJsonl(mod.rotationsFile()).length, 0);
+  });
+});
+
+test('idempotent: same id observed twice records nothing', () => {
+  withTempHome((_home, mod) => {
+    mod.observeRotation('session-a');
+    mod.observeRotation('session-a');
+    mod.observeRotation('session-a');
+    assert.equal(readJsonl(mod.rotationsFile()).length, 0);
+  });
+});
+
+test('distinct id observation appends a rotation event with prev/next/delta', () => {
+  withTempHome((_home, mod) => {
+    mod.observeRotation('session-a');
+    mod.observeRotation('session-b');
+    const records = readJsonl(mod.rotationsFile());
+    assert.equal(records.length, 1);
+    assert.equal(records[0].prevId, 'session-a');
+    assert.equal(records[0].nextId, 'session-b');
+    assert.ok(typeof records[0].deltaMs === 'number');
+    assert.ok(records[0].deltaMs >= 0);
+    assert.equal(records[0].pid, process.pid);
+  });
+});
+
+test('records appear for each rotation in a chain', () => {
+  withTempHome((_home, mod) => {
+    mod.observeRotation('a');
+    mod.observeRotation('b');
+    mod.observeRotation('c');
+    const records = readJsonl(mod.rotationsFile());
+    assert.equal(records.length, 2);
+    assert.equal(records[0].prevId, 'a');
+    assert.equal(records[0].nextId, 'b');
+    assert.equal(records[1].prevId, 'b');
+    assert.equal(records[1].nextId, 'c');
+  });
+});
+
+test('fast rotation under threshold flags fastRotation: true and warns on stderr (once per process)', () => {
+  withTempHome((_home, mod) => {
+    const captured = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk) => {
+      captured.push(String(chunk));
+      return true;
+    };
+    try {
+      mod.observeRotation('alpha-12345678');
+      // Force a rapid second observation by patching readLastObserved-source.
+      mod.observeRotation('beta-12345678');
+      mod.observeRotation('gamma-12345678');
+    } finally {
+      process.stderr.write = orig;
+    }
+    const records = readJsonl(mod.rotationsFile());
+    assert.equal(records.length, 2);
+    // Both records should be flagged fast (test runs in milliseconds).
+    assert.equal(records[0].fastRotation, true);
+    assert.equal(records[1].fastRotation, true);
+    // Warning emitted exactly once.
+    const warnings = captured.filter((s) => s.includes('CLAUDE_CODE_SESSION_ID rotated'));
+    assert.equal(warnings.length, 1);
+  });
+});
+
+test('disabled via env var SYNAPSYS_SESSION_ROTATION_DISABLED=1 short-circuits', () => {
+  withTempHome((_home, mod) => {
+    process.env.SYNAPSYS_SESSION_ROTATION_DISABLED = '1';
+    mod.observeRotation('session-a');
+    mod.observeRotation('session-b');
+    assert.equal(fs.existsSync(mod.lastObservedFile()), false);
+    assert.equal(readJsonl(mod.rotationsFile()).length, 0);
+  });
+});
+
+test('empty / null / non-string ids are no-ops', () => {
+  withTempHome((_home, mod) => {
+    mod.observeRotation('');
+    mod.observeRotation(null);
+    mod.observeRotation(undefined);
+    mod.observeRotation(123);
+    assert.equal(fs.existsSync(mod.lastObservedFile()), false);
+    assert.equal(readJsonl(mod.rotationsFile()).length, 0);
+  });
+});
+
+test('inject-ledger resolveSessionId integrates with rotation tracker', () => {
+  withTempHome((_home, mod) => {
+    const prevEnv = process.env.CLAUDE_CODE_SESSION_ID;
+    try {
+      delete require.cache[require.resolve('../inject-ledger')];
+      process.env.CLAUDE_CODE_SESSION_ID = 'conv-1-abcd';
+      const ledger = require('../inject-ledger');
+      ledger.resolveSessionId({});
+      process.env.CLAUDE_CODE_SESSION_ID = 'conv-2-abcd';
+      ledger.resolveSessionId({});
+      const records = readJsonl(mod.rotationsFile());
+      assert.equal(records.length, 1);
+      assert.equal(records[0].prevId, 'conv-1-abcd');
+      assert.equal(records[0].nextId, 'conv-2-abcd');
+    } finally {
+      if (prevEnv === undefined) delete process.env.CLAUDE_CODE_SESSION_ID;
+      else process.env.CLAUDE_CODE_SESSION_ID = prevEnv;
+      delete require.cache[require.resolve('../inject-ledger')];
+    }
+  });
+});

--- a/plugins/synapsys/lib/__tests__/session-id-rotation.test.js
+++ b/plugins/synapsys/lib/__tests__/session-id-rotation.test.js
@@ -11,9 +11,11 @@ function withTempHome(fn) {
   const prevHome = process.env.HOME;
   const prevSessionDir = process.env.SYNAPSYS_SESSION_DIR;
   const prevDisabled = process.env.SYNAPSYS_SESSION_ROTATION_DISABLED;
+  const prevDebug = process.env.SYNAPSYS_DEBUG;
   process.env.HOME = tmp;
   delete process.env.SYNAPSYS_SESSION_DIR;
   delete process.env.SYNAPSYS_SESSION_ROTATION_DISABLED;
+  delete process.env.SYNAPSYS_DEBUG;
   delete require.cache[require.resolve('../session-id-rotation')];
   const mod = require('../session-id-rotation');
   mod.__resetForTests();
@@ -26,7 +28,27 @@ function withTempHome(fn) {
     else process.env.SYNAPSYS_SESSION_DIR = prevSessionDir;
     if (prevDisabled === undefined) delete process.env.SYNAPSYS_SESSION_ROTATION_DISABLED;
     else process.env.SYNAPSYS_SESSION_ROTATION_DISABLED = prevDisabled;
+    if (prevDebug === undefined) delete process.env.SYNAPSYS_DEBUG;
+    else process.env.SYNAPSYS_DEBUG = prevDebug;
     delete require.cache[require.resolve('../session-id-rotation')];
+  }
+}
+
+// Deterministic Date.now stub so fast-rotation timing assertions don't depend
+// on wall-clock or system load. Returns monotonically increasing values
+// `stepMs` apart starting at `startMs`.
+function withFakeNow(startMs, stepMs, fn) {
+  const realNow = Date.now;
+  let cur = startMs;
+  Date.now = () => {
+    const v = cur;
+    cur += stepMs;
+    return v;
+  };
+  try {
+    return fn();
+  } finally {
+    Date.now = realNow;
   }
 }
 
@@ -84,7 +106,41 @@ test('records appear for each rotation in a chain', () => {
   });
 });
 
-test('fast rotation under threshold flags fastRotation: true and warns on stderr (once per process)', () => {
+test('fast rotation under threshold flags fastRotation: true with deterministic 1s steps; warns on stderr only when SYNAPSYS_DEBUG=1', () => {
+  withTempHome((_home, mod) => {
+    process.env.SYNAPSYS_DEBUG = '1';
+    const captured = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk) => {
+      captured.push(String(chunk));
+      return true;
+    };
+    try {
+      withFakeNow(1_000_000, 1000, () => {
+        mod.observeRotation('alpha-12345678');
+        mod.observeRotation('beta-12345678');
+        mod.observeRotation('gamma-12345678');
+      });
+    } finally {
+      process.stderr.write = orig;
+    }
+    const records = readJsonl(mod.rotationsFile());
+    assert.equal(records.length, 2);
+    assert.equal(records[0].fastRotation, true);
+    assert.equal(records[1].fastRotation, true);
+    // Time pinned at 1000ms per step → deltaMs locked.
+    assert.equal(records[0].deltaMs, 1000);
+    assert.equal(records[1].deltaMs, 1000);
+    // Warning emitted exactly once with SYNAPSYS_DEBUG=1.
+    const warnings = captured.filter((s) => s.includes('CLAUDE_CODE_SESSION_ID rotated'));
+    assert.equal(warnings.length, 1);
+  });
+});
+
+// Blocker 2 — stderr is gated. JSONL audit is unconditional; stderr only fires
+// when SYNAPSYS_DEBUG=1. Default-off means production hooks stay quiet even
+// during a rapid rotation regression.
+test('fast rotation: SYNAPSYS_DEBUG unset → JSONL still records, NO stderr write', () => {
   withTempHome((_home, mod) => {
     const captured = [];
     const orig = process.stderr.write.bind(process.stderr);
@@ -93,21 +149,19 @@ test('fast rotation under threshold flags fastRotation: true and warns on stderr
       return true;
     };
     try {
-      mod.observeRotation('alpha-12345678');
-      // Force a rapid second observation by patching readLastObserved-source.
-      mod.observeRotation('beta-12345678');
-      mod.observeRotation('gamma-12345678');
+      withFakeNow(2_000_000, 1000, () => {
+        mod.observeRotation('p-1');
+        mod.observeRotation('p-2');
+      });
     } finally {
       process.stderr.write = orig;
     }
     const records = readJsonl(mod.rotationsFile());
-    assert.equal(records.length, 2);
-    // Both records should be flagged fast (test runs in milliseconds).
+    assert.equal(records.length, 1);
     assert.equal(records[0].fastRotation, true);
-    assert.equal(records[1].fastRotation, true);
-    // Warning emitted exactly once.
+    assert.equal(records[0].deltaMs, 1000);
     const warnings = captured.filter((s) => s.includes('CLAUDE_CODE_SESSION_ID rotated'));
-    assert.equal(warnings.length, 1);
+    assert.equal(warnings.length, 0);
   });
 });
 

--- a/plugins/synapsys/lib/__tests__/session-id.test.js
+++ b/plugins/synapsys/lib/__tests__/session-id.test.js
@@ -111,3 +111,36 @@ test('inject-ledger and telemetry use the same env-var resolution', () => {
     delete require.cache[require.resolve('../telemetry')];
   });
 });
+
+// Blocker 1 regression — payload-path divergence: telemetry's legacy regex
+// (SAFE_SESSION_ID with dot) once accepted "a.b" verbatim while inject-ledger
+// hashed it via SAFE_ID_RE (no dot). After unification both must agree.
+test('inject-ledger and telemetry agree on payload-path resolution (dotted ids hashed in both)', () => {
+  withEnv(() => {
+    delete require.cache[require.resolve('../inject-ledger')];
+    delete require.cache[require.resolve('../telemetry')];
+    const injectLedger = require('../inject-ledger');
+    const telemetry = require('../telemetry');
+    // Dotted id — previously diverged.
+    assert.equal(
+      injectLedger.resolveSessionId({ session_id: 'a.b' }),
+      telemetry.resolveSessionId({ session_id: 'a.b' })
+    );
+    // Safe id — agree, raw passthrough.
+    assert.equal(
+      injectLedger.resolveSessionId({ session_id: 'plain-uuid-1234' }),
+      telemetry.resolveSessionId({ session_id: 'plain-uuid-1234' })
+    );
+    assert.equal(
+      injectLedger.resolveSessionId({ session_id: 'plain-uuid-1234' }),
+      'plain-uuid-1234'
+    );
+    // Path-traversal — both produce identical hash (filesystem-safe).
+    assert.equal(
+      injectLedger.resolveSessionId({ session_id: '../evil' }),
+      telemetry.resolveSessionId({ session_id: '../evil' })
+    );
+    delete require.cache[require.resolve('../inject-ledger')];
+    delete require.cache[require.resolve('../telemetry')];
+  });
+});

--- a/plugins/synapsys/lib/__tests__/session-id.test.js
+++ b/plugins/synapsys/lib/__tests__/session-id.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function withEnv(fn) {
+  const prev = process.env.CLAUDE_CODE_SESSION_ID;
+  delete process.env.CLAUDE_CODE_SESSION_ID;
+  delete require.cache[require.resolve('../session-id')];
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env.CLAUDE_CODE_SESSION_ID;
+    else process.env.CLAUDE_CODE_SESSION_ID = prev;
+    delete require.cache[require.resolve('../session-id')];
+  }
+}
+
+test('SAFE_ID_RE matches Claude Code UUIDs and rejects unsafe values', () => {
+  withEnv(() => {
+    const { SAFE_ID_RE } = require('../session-id');
+    assert.ok(SAFE_ID_RE.test('b3b7b63e-9a11-4832-ab0c-387d1e8929b4'));
+    assert.ok(SAFE_ID_RE.test('abc_123-XYZ'));
+    assert.ok(!SAFE_ID_RE.test('../evil'));
+    assert.ok(!SAFE_ID_RE.test('a/b'));
+    assert.ok(!SAFE_ID_RE.test(''));
+    assert.ok(!SAFE_ID_RE.test('x'.repeat(129)));
+    assert.ok(!SAFE_ID_RE.test('with.dot'));
+  });
+});
+
+test('hashId is deterministic, 32 hex chars, and equal for equal input', () => {
+  withEnv(() => {
+    const { hashId } = require('../session-id');
+    const a = hashId('hello');
+    const b = hashId('hello');
+    assert.equal(a, b);
+    assert.equal(a.length, 32);
+    assert.match(a, /^[0-9a-f]{32}$/);
+    assert.notEqual(a, hashId('world'));
+  });
+});
+
+test('sanitizeSessionId: null on empty, raw on safe, hash on unsafe', () => {
+  withEnv(() => {
+    const { sanitizeSessionId, hashId } = require('../session-id');
+    assert.equal(sanitizeSessionId(undefined), null);
+    assert.equal(sanitizeSessionId(null), null);
+    assert.equal(sanitizeSessionId(''), null);
+    assert.equal(sanitizeSessionId('abc_123'), 'abc_123');
+    assert.equal(sanitizeSessionId('../evil'), hashId('../evil'));
+    assert.equal(sanitizeSessionId('/etc/passwd'), hashId('/etc/passwd'));
+  });
+});
+
+test('resolveFromEnv returns null when env var absent', () => {
+  withEnv(() => {
+    const { resolveFromEnv } = require('../session-id');
+    assert.equal(resolveFromEnv(), null);
+  });
+});
+
+test('resolveFromEnv returns raw safe id when present', () => {
+  withEnv(() => {
+    process.env.CLAUDE_CODE_SESSION_ID = 'b3b7b63e-9a11-4832-ab0c-387d1e8929b4';
+    const { resolveFromEnv } = require('../session-id');
+    assert.equal(resolveFromEnv(), 'b3b7b63e-9a11-4832-ab0c-387d1e8929b4');
+  });
+});
+
+test('resolveFromEnv hashes unsafe env value', () => {
+  withEnv(() => {
+    process.env.CLAUDE_CODE_SESSION_ID = '../evil/path';
+    const { resolveFromEnv, hashId } = require('../session-id');
+    assert.equal(resolveFromEnv(), hashId('../evil/path'));
+  });
+});
+
+test('resolveFromEnv treats empty string as absent', () => {
+  withEnv(() => {
+    process.env.CLAUDE_CODE_SESSION_ID = '';
+    const { resolveFromEnv } = require('../session-id');
+    assert.equal(resolveFromEnv(), null);
+  });
+});
+
+test('resolveFromPayload mirrors sanitizeSessionId for payload.session_id', () => {
+  withEnv(() => {
+    const { resolveFromPayload, hashId } = require('../session-id');
+    assert.equal(resolveFromPayload(null), null);
+    assert.equal(resolveFromPayload({}), null);
+    assert.equal(resolveFromPayload({ session_id: '' }), null);
+    assert.equal(resolveFromPayload({ session_id: 'abc' }), 'abc');
+    assert.equal(resolveFromPayload({ session_id: '../evil' }), hashId('../evil'));
+  });
+});
+
+test('inject-ledger and telemetry use the same env-var resolution', () => {
+  withEnv(() => {
+    process.env.CLAUDE_CODE_SESSION_ID = 'shared-session-xyz';
+    delete require.cache[require.resolve('../inject-ledger')];
+    delete require.cache[require.resolve('../telemetry')];
+    const injectLedger = require('../inject-ledger');
+    const telemetry = require('../telemetry');
+    const ledgerId = injectLedger.resolveSessionId({});
+    const telemetryId = telemetry.resolveSessionId({});
+    assert.equal(ledgerId, 'shared-session-xyz');
+    assert.equal(telemetryId, 'shared-session-xyz');
+    assert.equal(ledgerId, telemetryId);
+    delete require.cache[require.resolve('../inject-ledger')];
+    delete require.cache[require.resolve('../telemetry')];
+  });
+});

--- a/plugins/synapsys/lib/__tests__/synapsys-stats-sidecar-filter.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-stats-sidecar-filter.test.js
@@ -1,9 +1,11 @@
 'use strict';
 
 // Blocker 3 regression — synapsys-stats.listJsonlFiles must skip
-// underscore-prefixed sidecar files in the telemetry dir so files like
-// `_session-rotations.jsonl` (from session-id-rotation.js) don't get
-// mis-parsed as per-memory event rows.
+// DOUBLE-underscore sidecar files in the telemetry dir so files like
+// `__session-rotations.jsonl` (from session-id-rotation.js) don't get
+// mis-parsed as per-memory event rows. Single-underscore names like
+// `_unknown-session.jsonl` and SAFE_ID_RE-allowed `_`-prefixed session
+// ids ARE real telemetry data and must remain in scope.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
@@ -13,19 +15,27 @@ const path = require('node:path');
 
 const STATS = path.resolve(__dirname, '..', '..', 'scripts', 'synapsys-stats.js');
 
-test('listJsonlFiles excludes leading-underscore sidecars', () => {
+test('listJsonlFiles excludes double-underscore sidecars but KEEPS single-underscore telemetry buckets', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-stats-sidecar-'));
   try {
     fs.writeFileSync(path.join(dir, 'real-session.jsonl'), '');
-    fs.writeFileSync(path.join(dir, '_session-rotations.jsonl'), '');
-    fs.writeFileSync(path.join(dir, '_test-sidecar.jsonl'), '');
+    // Single-underscore — legitimate telemetry data (must NOT be filtered):
+    fs.writeFileSync(path.join(dir, '_unknown-session.jsonl'), '');
+    fs.writeFileSync(path.join(dir, '_user_id_with_underscore.jsonl'), '');
+    // Double-underscore — sidecars (filtered out):
+    fs.writeFileSync(path.join(dir, '__session-rotations.jsonl'), '');
+    fs.writeFileSync(path.join(dir, '__test-sidecar.jsonl'), '');
     fs.writeFileSync(path.join(dir, 'not-jsonl.txt'), '');
     delete require.cache[require.resolve(STATS)];
     const { listJsonlFiles } = require(STATS);
     const files = listJsonlFiles(dir)
       .map((p) => path.basename(p))
       .sort();
-    assert.deepEqual(files, ['real-session.jsonl']);
+    assert.deepEqual(files, [
+      '_unknown-session.jsonl',
+      '_user_id_with_underscore.jsonl',
+      'real-session.jsonl',
+    ]);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/plugins/synapsys/lib/__tests__/synapsys-stats-sidecar-filter.test.js
+++ b/plugins/synapsys/lib/__tests__/synapsys-stats-sidecar-filter.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+// Blocker 3 regression — synapsys-stats.listJsonlFiles must skip
+// underscore-prefixed sidecar files in the telemetry dir so files like
+// `_session-rotations.jsonl` (from session-id-rotation.js) don't get
+// mis-parsed as per-memory event rows.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const STATS = path.resolve(__dirname, '..', '..', 'scripts', 'synapsys-stats.js');
+
+test('listJsonlFiles excludes leading-underscore sidecars', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-stats-sidecar-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'real-session.jsonl'), '');
+    fs.writeFileSync(path.join(dir, '_session-rotations.jsonl'), '');
+    fs.writeFileSync(path.join(dir, '_test-sidecar.jsonl'), '');
+    fs.writeFileSync(path.join(dir, 'not-jsonl.txt'), '');
+    delete require.cache[require.resolve(STATS)];
+    const { listJsonlFiles } = require(STATS);
+    const files = listJsonlFiles(dir)
+      .map((p) => path.basename(p))
+      .sort();
+    assert.deepEqual(files, ['real-session.jsonl']);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('listJsonlFiles tolerates missing telemetry dir', () => {
+  delete require.cache[require.resolve(STATS)];
+  const { listJsonlFiles } = require(STATS);
+  const result = listJsonlFiles(path.join(os.tmpdir(), 'definitely-does-not-exist-' + Date.now()));
+  assert.deepEqual(result, []);
+});

--- a/plugins/synapsys/lib/__tests__/telemetry.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/telemetry.integration.test.js
@@ -10,8 +10,10 @@ function withTempHome(fn) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-telemetry-int-'));
   const prevHome = process.env.HOME;
   const prevDisable = process.env.SYNAPSYS_TELEMETRY;
+  const prevSessionEnv = process.env.CLAUDE_CODE_SESSION_ID;
   process.env.HOME = tmp;
   delete process.env.SYNAPSYS_TELEMETRY;
+  delete process.env.CLAUDE_CODE_SESSION_ID;
   delete require.cache[require.resolve('../telemetry')];
   try {
     return fn(tmp);
@@ -20,6 +22,8 @@ function withTempHome(fn) {
     else process.env.HOME = prevHome;
     if (prevDisable === undefined) delete process.env.SYNAPSYS_TELEMETRY;
     else process.env.SYNAPSYS_TELEMETRY = prevDisable;
+    if (prevSessionEnv === undefined) delete process.env.CLAUDE_CODE_SESSION_ID;
+    else process.env.CLAUDE_CODE_SESSION_ID = prevSessionEnv;
     delete require.cache[require.resolve('../telemetry')];
   }
 }

--- a/plugins/synapsys/lib/__tests__/telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/telemetry.test.js
@@ -251,20 +251,32 @@ test('extractSignals honors top-level memory.citeSignals (scalar normalized to a
   });
 });
 
-// PR #524 cursor[bot] Medium — session_id sanitization (path traversal defense)
-test('resolveSessionId rejects unsafe values (path separators, dotdot, absolute)', () => {
+// PR #524 cursor[bot] Medium — session_id sanitization (path traversal defense).
+// After GH-583 followup: telemetry and inject-ledger share resolveFromPayload, so
+// unsafe values are sha256-hashed (path-traversal still impossible — hex hash
+// contains no path separators) rather than bucketed into _unknown-session. Empty/
+// missing payload still falls through to _unknown-session.
+test('resolveSessionId: safe ids pass, unsafe ids are sha256-hashed (no _unknown-session for non-empty)', () => {
   withTempHome(() => {
     const telemetry = require('../telemetry');
-    // Allowed
+    const { hashId } = require('../session-id');
+    // Allowed verbatim
     assert.equal(telemetry.resolveSessionId({ session_id: 'abc123' }), 'abc123');
-    assert.equal(telemetry.resolveSessionId({ session_id: 'a-b_c.1' }), 'a-b_c.1');
-    // Disallowed — fall back to _unknown-session
-    assert.equal(telemetry.resolveSessionId({ session_id: '../evil' }), '_unknown-session');
-    assert.equal(telemetry.resolveSessionId({ session_id: '/etc/passwd' }), '_unknown-session');
-    assert.equal(telemetry.resolveSessionId({ session_id: 'a/b' }), '_unknown-session');
-    assert.equal(telemetry.resolveSessionId({ session_id: 'a\\b' }), '_unknown-session');
-    assert.equal(telemetry.resolveSessionId({ session_id: '..' }), '_unknown-session');
-    assert.equal(telemetry.resolveSessionId({ session_id: '.hidden' }), '_unknown-session');
-    assert.equal(telemetry.resolveSessionId({ session_id: 'x'.repeat(200) }), '_unknown-session');
+    // Dot is no longer in SAFE_ID_RE — hashed instead.
+    assert.equal(telemetry.resolveSessionId({ session_id: 'a-b_c.1' }), hashId('a-b_c.1'));
+    // Path-traversal characters → hashed (hex output contains no '/', '\\', '..').
+    assert.equal(telemetry.resolveSessionId({ session_id: '../evil' }), hashId('../evil'));
+    assert.equal(telemetry.resolveSessionId({ session_id: '/etc/passwd' }), hashId('/etc/passwd'));
+    assert.equal(telemetry.resolveSessionId({ session_id: 'a/b' }), hashId('a/b'));
+    assert.equal(telemetry.resolveSessionId({ session_id: 'a\\b' }), hashId('a\\b'));
+    assert.equal(telemetry.resolveSessionId({ session_id: '..' }), hashId('..'));
+    assert.equal(telemetry.resolveSessionId({ session_id: '.hidden' }), hashId('.hidden'));
+    assert.equal(
+      telemetry.resolveSessionId({ session_id: 'x'.repeat(200) }),
+      hashId('x'.repeat(200))
+    );
+    // Hashed output is filesystem-safe (32 hex chars).
+    const hashed = telemetry.resolveSessionId({ session_id: '../evil' });
+    assert.match(hashed, /^[0-9a-f]{32}$/);
   });
 });

--- a/plugins/synapsys/lib/__tests__/telemetry.test.js
+++ b/plugins/synapsys/lib/__tests__/telemetry.test.js
@@ -10,8 +10,13 @@ function withTempHome(fn) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-telemetry-unit-'));
   const prevHome = process.env.HOME;
   const prevDisable = process.env.SYNAPSYS_TELEMETRY;
+  const prevSessionEnv = process.env.CLAUDE_CODE_SESSION_ID;
   process.env.HOME = tmp;
   delete process.env.SYNAPSYS_TELEMETRY;
+  // Default: stub CLAUDE_CODE_SESSION_ID as unset so payload-only tests keep
+  // exercising the payload path. Tests that exercise env-var precedence opt in
+  // by setting it after withTempHome enters fn.
+  delete process.env.CLAUDE_CODE_SESSION_ID;
   delete require.cache[require.resolve('../telemetry')];
   try {
     return fn(tmp);
@@ -20,6 +25,8 @@ function withTempHome(fn) {
     else process.env.HOME = prevHome;
     if (prevDisable === undefined) delete process.env.SYNAPSYS_TELEMETRY;
     else process.env.SYNAPSYS_TELEMETRY = prevDisable;
+    if (prevSessionEnv === undefined) delete process.env.CLAUDE_CODE_SESSION_ID;
+    else process.env.CLAUDE_CODE_SESSION_ID = prevSessionEnv;
     delete require.cache[require.resolve('../telemetry')];
   }
 }

--- a/plugins/synapsys/lib/inject-ledger.js
+++ b/plugins/synapsys/lib/inject-ledger.js
@@ -37,10 +37,11 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const crypto = require('node:crypto');
+const sharedSessionId = require('./session-id');
+const sessionIdRotation = require('./session-id-rotation');
 
 const MAX_FILE_BYTES = 64 * 1024;
-const SAFE_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+const SAFE_ID_RE = sharedSessionId.SAFE_ID_RE;
 const PROCESS_START_TIME = Date.now();
 
 function sessionDir() {
@@ -70,25 +71,9 @@ function ensureDir() {
   }
 }
 
-function hashId(value) {
-  return crypto.createHash('sha256').update(String(value)).digest('hex').slice(0, 32);
-}
-
-function resolveFromPayload(payload) {
-  const raw = payload && payload.session_id;
-  if (typeof raw !== 'string' || raw.length === 0) return null;
-  return SAFE_ID_RE.test(raw) ? raw : hashId(raw);
-}
-
-function resolveFromEnv() {
-  try {
-    const raw = process.env.CLAUDE_CODE_SESSION_ID;
-    if (typeof raw !== 'string' || raw.length === 0) return null;
-    return SAFE_ID_RE.test(raw) ? raw : hashId(raw);
-  } catch {
-    return null;
-  }
-}
+const hashId = sharedSessionId.hashId;
+const resolveFromPayload = sharedSessionId.resolveFromPayload;
+const resolveFromEnv = sharedSessionId.resolveFromEnv;
 
 function readBoundedFile(p, maxBytes) {
   let fd;
@@ -140,7 +125,13 @@ function computeFallbackId() {
 function resolveChain(payload) {
   try {
     const fromEnv = resolveFromEnv();
-    if (fromEnv) return { sessionId: fromEnv, source: 'env' };
+    if (fromEnv) {
+      // Instrumentation pin (GH-583 follow-up): record env-var rotations to a
+      // JSONL audit file so we can verify the once-per-conversation contract
+      // post-hoc and warn if rotations come faster than a human `/clear`.
+      sessionIdRotation.observeRotation(fromEnv);
+      return { sessionId: fromEnv, source: 'env' };
+    }
     const fromPayload = resolveFromPayload(payload);
     if (fromPayload) return { sessionId: fromPayload, source: 'payload' };
     ensureDir();

--- a/plugins/synapsys/lib/session-id-rotation.js
+++ b/plugins/synapsys/lib/session-id-rotation.js
@@ -52,14 +52,17 @@ function lastObservedFile() {
 }
 
 /**
- * Path to the rotation audit JSONL. The leading underscore is intentional
- * and load-bearing: every reader that iterates the telemetry directory
- * MUST skip files starting with `_` so these sidecar rows don't get
- * mis-parsed as per-session memory events. Any future sidecar file in
- * this directory should follow the same `_<purpose>.jsonl` convention.
+ * Path to the rotation audit JSONL. The leading DOUBLE underscore is
+ * intentional and load-bearing: every reader that iterates the telemetry
+ * directory MUST skip files starting with `__` so these sidecar rows
+ * don't get mis-parsed as per-session memory events. Single-underscore
+ * names (e.g. `_unknown-session.jsonl`, or any session id starting with
+ * `_` per SAFE_ID_RE) are legitimate telemetry buckets and must NOT be
+ * filtered out. Any future sidecar file in this directory should follow
+ * the same `__<purpose>.jsonl` convention.
  */
 function rotationsFile() {
-  return path.join(telemetryDir(), '_session-rotations.jsonl');
+  return path.join(telemetryDir(), '__session-rotations.jsonl');
 }
 
 function readLastObserved() {

--- a/plugins/synapsys/lib/session-id-rotation.js
+++ b/plugins/synapsys/lib/session-id-rotation.js
@@ -13,10 +13,12 @@
  * so `fire_mode: once` becomes `fire_mode: always` and no test catches it.
  *
  * This module persists each rotation it observes to a JSONL file so the
- * cadence is auditable after the fact, and prints a one-line stderr warning
- * the first time a rotation is detected within < 5 s of the previous one
- * (i.e. faster than a human would `/clear`). Operators can `tail` the
- * file or `grep` for the warning to see if cadence has drifted.
+ * cadence is auditable after the fact. The JSONL audit (with
+ * `fastRotation: true` on sub-threshold rows) is the durable signal and
+ * is always written. A complementary one-shot stderr warning fires only
+ * when `SYNAPSYS_DEBUG=1` is set — Claude Code surfaces hook stderr to
+ * operators in some UI configurations, so we keep it opt-in to avoid
+ * default-on noise the day Anthropic changes rotation cadence.
  *
  * Everything is fail-open and synchronous to preserve the sub-millisecond
  * hot-path invariant.
@@ -49,6 +51,13 @@ function lastObservedFile() {
   return path.join(sessionDir(), '.last-observed-id');
 }
 
+/**
+ * Path to the rotation audit JSONL. The leading underscore is intentional
+ * and load-bearing: every reader that iterates the telemetry directory
+ * MUST skip files starting with `_` so these sidecar rows don't get
+ * mis-parsed as per-session memory events. Any future sidecar file in
+ * this directory should follow the same `_<purpose>.jsonl` convention.
+ */
 function rotationsFile() {
   return path.join(telemetryDir(), '_session-rotations.jsonl');
 }
@@ -106,6 +115,13 @@ function emitBurstWarningOnce(prevId, currentId, deltaMs) {
  * Record a rotation if `currentId` differs from the last-observed id.
  * Idempotent: same id → no-op. Distinct id → JSONL append + maybe stderr.
  *
+ * NOT atomic across processes: the read-then-write between
+ * `readLastObserved()` and `writeLastObserved()` can race with a concurrent
+ * hook invocation, so under heavy concurrency a rotation row may be
+ * double-logged or skipped. This is acceptable for best-effort
+ * instrumentation — readers MUST NOT base any anti-bypass or enforcement
+ * decision on this signal.
+ *
  * @param {string|null|undefined} currentId
  */
 function observeRotation(currentId) {
@@ -128,7 +144,7 @@ function observeRotation(currentId) {
     deltaMs,
     fastRotation: deltaMs < FAST_ROTATION_THRESHOLD_MS,
   });
-  if (deltaMs < FAST_ROTATION_THRESHOLD_MS) {
+  if (deltaMs < FAST_ROTATION_THRESHOLD_MS && process.env.SYNAPSYS_DEBUG === '1') {
     emitBurstWarningOnce(prev.id, currentId, deltaMs);
   }
   writeLastObserved(currentId, now);

--- a/plugins/synapsys/lib/session-id-rotation.js
+++ b/plugins/synapsys/lib/session-id-rotation.js
@@ -1,0 +1,147 @@
+'use strict';
+
+/**
+ * session-id-rotation — instrumentation pin for CLAUDE_CODE_SESSION_ID rotation cadence.
+ *
+ * Why this exists
+ * ---------------
+ * GH-583's fix assumes Claude Code rotates `CLAUDE_CODE_SESSION_ID` exactly
+ * once per conversation (on `/clear` and on opening a new session) — and never
+ * per prompt within the same conversation. If that contract ever changes (an
+ * Anthropic refactor, an opt-in beta, a regression), the symptom is silent
+ * over-injection: every prompt sees a fresh ledger because the id rotated,
+ * so `fire_mode: once` becomes `fire_mode: always` and no test catches it.
+ *
+ * This module persists each rotation it observes to a JSONL file so the
+ * cadence is auditable after the fact, and prints a one-line stderr warning
+ * the first time a rotation is detected within < 5 s of the previous one
+ * (i.e. faster than a human would `/clear`). Operators can `tail` the
+ * file or `grep` for the warning to see if cadence has drifted.
+ *
+ * Everything is fail-open and synchronous to preserve the sub-millisecond
+ * hot-path invariant.
+ *
+ * Public API:
+ *   - observeRotation(currentId) — call once per resolveSessionId; idempotent
+ *   - rotationsFile()            — path to the JSONL audit file
+ *   - lastObservedFile()         — path to the single-id pointer file
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+// Fast-rotation threshold: anything below this between two consecutive
+// rotations triggers the stderr warning. 5 s is well below a human reaction
+// time for `/clear` + first prompt, so the false-positive rate is low.
+const FAST_ROTATION_THRESHOLD_MS = 5_000;
+
+function telemetryDir() {
+  return path.join(os.homedir(), '.claude', 'synapsys', '.telemetry');
+}
+
+function sessionDir() {
+  if (process.env.SYNAPSYS_SESSION_DIR) return process.env.SYNAPSYS_SESSION_DIR;
+  return path.join(os.homedir(), '.claude', 'synapsys', '.session');
+}
+
+function lastObservedFile() {
+  return path.join(sessionDir(), '.last-observed-id');
+}
+
+function rotationsFile() {
+  return path.join(telemetryDir(), '_session-rotations.jsonl');
+}
+
+function readLastObserved() {
+  try {
+    const raw = fs.readFileSync(lastObservedFile(), 'utf8');
+    if (raw.length === 0 || raw.length > 4096) return null;
+    const obj = JSON.parse(raw);
+    if (!obj || typeof obj.id !== 'string' || typeof obj.at !== 'number') return null;
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+function writeLastObserved(id, atMs) {
+  try {
+    fs.mkdirSync(sessionDir(), { recursive: true });
+    fs.writeFileSync(lastObservedFile(), JSON.stringify({ id, at: atMs }));
+  } catch {
+    /* fail-open */
+  }
+}
+
+function appendRotation(record) {
+  try {
+    fs.mkdirSync(telemetryDir(), { recursive: true });
+    fs.appendFileSync(rotationsFile(), JSON.stringify(record) + '\n');
+  } catch {
+    /* fail-open */
+  }
+}
+
+// Module-level flag so we emit the burst warning at most once per process —
+// hooks are short-lived (one process per UserPromptSubmit) but we still don't
+// want a noisy stderr if some downstream caller hits this twice.
+let burstWarningEmitted = false;
+
+function emitBurstWarningOnce(prevId, currentId, deltaMs) {
+  if (burstWarningEmitted) return;
+  burstWarningEmitted = true;
+  try {
+    process.stderr.write(
+      `[synapsys] CLAUDE_CODE_SESSION_ID rotated in ${deltaMs}ms ` +
+        `(prev=${prevId.slice(0, 8)}… next=${currentId.slice(0, 8)}…); ` +
+        `expected once-per-conversation cadence. See ${rotationsFile()} for history.\n`
+    );
+  } catch {
+    /* fail-open */
+  }
+}
+
+/**
+ * Record a rotation if `currentId` differs from the last-observed id.
+ * Idempotent: same id → no-op. Distinct id → JSONL append + maybe stderr.
+ *
+ * @param {string|null|undefined} currentId
+ */
+function observeRotation(currentId) {
+  if (typeof currentId !== 'string' || currentId.length === 0) return;
+  if (process.env.SYNAPSYS_SESSION_ROTATION_DISABLED === '1') return;
+  const now = Date.now();
+  const prev = readLastObserved();
+  if (!prev) {
+    writeLastObserved(currentId, now);
+    return;
+  }
+  if (prev.id === currentId) return;
+  const deltaMs = now - prev.at;
+  appendRotation({
+    at: new Date(now).toISOString(),
+    pid: process.pid,
+    prevId: prev.id,
+    nextId: currentId,
+    prevSeenAt: new Date(prev.at).toISOString(),
+    deltaMs,
+    fastRotation: deltaMs < FAST_ROTATION_THRESHOLD_MS,
+  });
+  if (deltaMs < FAST_ROTATION_THRESHOLD_MS) {
+    emitBurstWarningOnce(prev.id, currentId, deltaMs);
+  }
+  writeLastObserved(currentId, now);
+}
+
+function __resetForTests() {
+  burstWarningEmitted = false;
+}
+
+module.exports = {
+  observeRotation,
+  rotationsFile,
+  lastObservedFile,
+  FAST_ROTATION_THRESHOLD_MS,
+  __resetForTests,
+};

--- a/plugins/synapsys/lib/session-id.js
+++ b/plugins/synapsys/lib/session-id.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * session-id — shared session-id primitives for synapsys.
+ *
+ * Both `inject-ledger.js` (per-session injection ledger) and `telemetry.js`
+ * (per-session JSONL writer) need to resolve a session id from the same
+ * sources in the same way, or they end up keying their state files on
+ * different ids — a memory could fire (ledger entry created) but the
+ * matching telemetry event would land in a different session bucket.
+ *
+ * GH-583 added the `CLAUDE_CODE_SESSION_ID` env-var leg to inject-ledger
+ * but left telemetry on its old payload-only path. This module is the
+ * single source of truth so both consumers stay aligned.
+ *
+ * Public API:
+ *   - SAFE_ID_RE                     — `/^[A-Za-z0-9_-]{1,128}$/`
+ *   - hashId(value)                  — sha256 → hex(32) for unsafe values
+ *   - sanitizeSessionId(raw)         — safe-passthrough or hashed; null on empty
+ *   - resolveFromEnv()               — reads `process.env.CLAUDE_CODE_SESSION_ID`
+ *   - resolveFromPayload(payload)    — reads `payload.session_id`
+ *
+ * All exports are pure and synchronous to preserve the sub-millisecond
+ * hot-path invariant inherited from inject-ledger. Env-var reads are
+ * wrapped in `try/catch` for fail-open behavior on hardened sandboxes
+ * that throw on `process.env` access.
+ */
+
+const crypto = require('node:crypto');
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+function hashId(value) {
+  return crypto.createHash('sha256').update(String(value)).digest('hex').slice(0, 32);
+}
+
+function sanitizeSessionId(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  return SAFE_ID_RE.test(raw) ? raw : hashId(raw);
+}
+
+function resolveFromEnv() {
+  try {
+    return sanitizeSessionId(process.env.CLAUDE_CODE_SESSION_ID);
+  } catch {
+    return null;
+  }
+}
+
+function resolveFromPayload(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  return sanitizeSessionId(payload.session_id);
+}
+
+module.exports = {
+  SAFE_ID_RE,
+  hashId,
+  sanitizeSessionId,
+  resolveFromEnv,
+  resolveFromPayload,
+};

--- a/plugins/synapsys/lib/telemetry.js
+++ b/plugins/synapsys/lib/telemetry.js
@@ -38,29 +38,17 @@ function isDisabled(memory) {
   return false;
 }
 
-// Whitelist filename characters so an attacker-controlled session_id (or one
-// containing path separators / "..") can never make appendFileSync escape
-// the telemetry directory. Anything containing characters outside [A-Za-z0-9._-]
-// — including '/', '\\', or "..", and leading dots used to hide files — falls
-// back to the unknown-session bucket.
-const SAFE_SESSION_ID = /^[A-Za-z0-9._-]{1,128}$/;
-
 function resolveSessionId(payload) {
-  // Prefer `process.env.CLAUDE_CODE_SESSION_ID` so telemetry events key on the
-  // same id as the inject-ledger (GH-583) — without this, a memory fire would
-  // increment the ledger under one id and write its telemetry row under a
-  // different one, splitting per-session analytics across two buckets.
+  // Both legs go through the shared resolver so inject-ledger and telemetry
+  // always produce the SAME id for the same input. Env-var first (GH-583),
+  // then payload — both legs apply SAFE_ID_RE (no dot) and sha256-hash unsafe
+  // values via hashId, so an id like "sess.v1" becomes the same hashed value
+  // in both modules instead of diverging on the regex.
   const fromEnv = sharedSessionId.resolveFromEnv();
   if (fromEnv) return fromEnv;
-  if (!payload || typeof payload.session_id !== 'string' || !payload.session_id) {
-    return '_unknown-session';
-  }
-  const candidate = payload.session_id;
-  if (!SAFE_SESSION_ID.test(candidate)) return '_unknown-session';
-  if (candidate.startsWith('.') || candidate === '..' || candidate.includes('..')) {
-    return '_unknown-session';
-  }
-  return candidate;
+  const fromPayload = sharedSessionId.resolveFromPayload(payload);
+  if (fromPayload) return fromPayload;
+  return '_unknown-session';
 }
 
 function unknownSessionToken() {

--- a/plugins/synapsys/lib/telemetry.js
+++ b/plugins/synapsys/lib/telemetry.js
@@ -19,6 +19,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const sharedSessionId = require('./session-id');
 
 const PROCESS_START_MS = Date.now();
 const MATCH_CAP = 200;
@@ -45,6 +46,12 @@ function isDisabled(memory) {
 const SAFE_SESSION_ID = /^[A-Za-z0-9._-]{1,128}$/;
 
 function resolveSessionId(payload) {
+  // Prefer `process.env.CLAUDE_CODE_SESSION_ID` so telemetry events key on the
+  // same id as the inject-ledger (GH-583) — without this, a memory fire would
+  // increment the ledger under one id and write its telemetry row under a
+  // different one, splitting per-session analytics across two buckets.
+  const fromEnv = sharedSessionId.resolveFromEnv();
+  if (fromEnv) return fromEnv;
   if (!payload || typeof payload.session_id !== 'string' || !payload.session_id) {
     return '_unknown-session';
   }

--- a/plugins/synapsys/scripts/synapsys-stats.js
+++ b/plugins/synapsys/scripts/synapsys-stats.js
@@ -32,12 +32,15 @@ function listJsonlFiles(telDir) {
   } catch {
     return [];
   }
-  // Skip leading-underscore sidecars (e.g. `_session-rotations.jsonl`) — those
+  // Skip DOUBLE-underscore sidecars (e.g. `__session-rotations.jsonl`) — those
   // store cross-session instrumentation rows that do NOT follow the per-memory
   // event schema and would crash or skew stats if parsed as memory events.
+  // Single-underscore names like `_unknown-session.jsonl` (legitimate fallback
+  // bucket from telemetry.resolveSessionId) and any session id starting with
+  // `_` (allowed by SAFE_ID_RE) ARE real telemetry data and stay in scope.
   // See session-id-rotation.js::rotationsFile for the convention.
   return entries
-    .filter((n) => n.endsWith('.jsonl') && !n.startsWith('_'))
+    .filter((n) => n.endsWith('.jsonl') && !n.startsWith('__'))
     .map((n) => path.join(telDir, n));
 }
 

--- a/plugins/synapsys/scripts/synapsys-stats.js
+++ b/plugins/synapsys/scripts/synapsys-stats.js
@@ -32,7 +32,13 @@ function listJsonlFiles(telDir) {
   } catch {
     return [];
   }
-  return entries.filter((n) => n.endsWith('.jsonl')).map((n) => path.join(telDir, n));
+  // Skip leading-underscore sidecars (e.g. `_session-rotations.jsonl`) — those
+  // store cross-session instrumentation rows that do NOT follow the per-memory
+  // event schema and would crash or skew stats if parsed as memory events.
+  // See session-id-rotation.js::rotationsFile for the convention.
+  return entries
+    .filter((n) => n.endsWith('.jsonl') && !n.startsWith('_'))
+    .map((n) => path.join(telDir, n));
 }
 
 function readJsonlInWindow(file, cutoffMs) {
@@ -195,6 +201,7 @@ module.exports = {
   readJsonlInWindow,
   aggregate,
   formatSections,
+  listJsonlFiles,
 };
 
 if (require.main === module) {


### PR DESCRIPTION
## Existing Behavior

- `inject-ledger.js` and `telemetry.js` each contained their own copy of session-id resolution logic (`SAFE_ID_RE`, `hashId`, `resolveFromEnv`, `resolveFromPayload`), diverging silently over time.
- After GH-583 added the `CLAUDE_CODE_SESSION_ID` env-var leg to `inject-ledger`, `telemetry.js` remained on its old payload-only path — so a memory fire would key its ledger entry under the env-var id but write its telemetry row under `payload.session_id`, splitting analytics across two buckets.
- No audit trail existed for session-id rotation cadence; a future change to the rotation contract would cause silent over-injection with no observable signal.

## Intended New Behavior

- Both `inject-ledger.js` and `telemetry.js` now consume `plugins/synapsys/lib/session-id.js` — a single source of truth for `SAFE_ID_RE`, `hashId`, `sanitizeSessionId`, `resolveFromEnv`, and `resolveFromPayload`.
- `telemetry.resolveSessionId` now checks `CLAUDE_CODE_SESSION_ID` first (consistent with inject-ledger); the `_unknown-session` fallback is preserved for payload-only callers.
- New `plugins/synapsys/lib/session-id-rotation.js` appends each env-var rotation to a JSONL audit file (prev/next/deltaMs/pid/fastRotation) and emits a one-shot stderr warning when two rotations occur within 5 s. Opt-out via `SYNAPSYS_SESSION_ROTATION_DISABLED=1`.
- The rotation observer is hooked into `inject-ledger`'s env leg so every session resolution is automatically instrumented.
- `telemetry.resolveSessionId` payload-leg unification side effect: payload `session_id` values that previously fell back to `_unknown-session` (path-traversal characters, leading dot, `..`, dotted ids, overlong strings) are now sha256-hashed to a 32-char hex id — same treatment as inject-ledger. Output remains filesystem-safe (hex contains no `/`, `\`, or `..`). Operators reading `synapsys-stats` will see `_unknown-session.jsonl` traffic shift into short-hex-named per-hash buckets after this PR lands; that's the fix, not a regression.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a follow-up to merged PR #586. All changes are internal to the synapsys plugin (no public API surface).

**Verify session-id unification:**
1. Set `CLAUDE_CODE_SESSION_ID=test-session-abc` in env and trigger a memory hook that calls both `inject-ledger` and `telemetry`. Both should produce entries keyed on `test-session-abc`.
2. Unset `CLAUDE_CODE_SESSION_ID` and trigger with a payload containing `session_id`. Both modules should fall through to payload resolution and agree on the same value.

**Verify rotation instrumentation:**
1. With `CLAUDE_CODE_SESSION_ID` set, call `inject-ledger.resolveSessionId` twice with the same value — confirm `.last-observed-id` is written and `_session-rotations.jsonl` remains empty.
2. Change `CLAUDE_CODE_SESSION_ID` to a new value and call again — confirm a new line is appended to `_session-rotations.jsonl` with correct `prevId`, `nextId`, `deltaMs`, and `pid`.
3. Rotate again within 5 s with `SYNAPSYS_DEBUG=1` set — confirm a rotation warning is written to stderr (once only).
4. Set `SYNAPSYS_SESSION_ROTATION_DISABLED=1` and confirm no files are created.

**Run the synapsys suite:**
```bash
cd plugins/synapsys && node --test lib/__tests__
```
Expected: 490 tests pass, 22 new test cases.

### Test Results

490/490 synapsys suite green locally. 22 new test cases added across:
- `plugins/synapsys/lib/__tests__/session-id.test.js` (10 new tests)
- `plugins/synapsys/lib/__tests__/session-id-rotation.test.js` (9 new tests)
- `plugins/synapsys/lib/__tests__/synapsys-stats-sidecar-filter.test.js` (2 new tests)
- `plugins/synapsys/lib/__tests__/telemetry.test.js` (1 net-new test block; unsafe-values test updated to assert hashed output)
- `plugins/synapsys/lib/__tests__/telemetry.integration.test.js` (harness-only changes — 0 net-new test blocks)

## Post-review fixes

Resolved after initial review of this PR:

**Blocker 1 — Payload-path regex divergence:** Routed `telemetry.resolveSessionId` payload leg through `sharedSessionId.resolveFromPayload`, deleting the legacy `SAFE_SESSION_ID` (dot-allowing) regex. Dotted ids such as `a.b` are now sha256-hashed identically in both telemetry and inject-ledger; path-traversal inputs are hashed rather than bucketed to `_unknown-session`. Parity verified by a new test in `session-id.test.js`.

**Blocker 2 — Default-on stderr noise:** `session-id-rotation.js` fast-rotation stderr warning is now gated on `SYNAPSYS_DEBUG=1`. JSONL audit entry (`fastRotation: true`) remains unconditional — durable signal preserved, default-on UI noise removed. Added "no stderr when SYNAPSYS_DEBUG unset" test; existing fast-rotation test now sets the var and pins time via `withFakeNow`.

**Blocker 3 — Sidecar file poisoning:** Added `!n.startsWith('_')` filter to `synapsys-stats.listJsonlFiles` so `_session-rotations.jsonl` (and any future underscore sidecar) is excluded from session enumeration. `cite-scan.js` reads by name and is unaffected. Exported `listJsonlFiles` and added `synapsys-stats-sidecar-filter.test.js` with 2 covering tests. Added JSDoc to `rotationsFile()` documenting the `_<purpose>.jsonl` sidecar convention.

**Blocker 4 — PR body test count:** Corrected "25 new tests" to 22 new test cases (session-id.test.js: 10, session-id-rotation.test.js: 9, synapsys-stats-sidecar-filter.test.js: 2, telemetry.test.js: 1 net-new, telemetry.integration.test.js: 0 harness-only).

**Nice-to-have 1:** Added JSDoc above `observeRotation` noting the read-then-write race is non-atomic, acceptable for best-effort instrumentation, and MUST NOT be relied upon for anti-bypass logic.

**Nice-to-have 2:** Introduced `withFakeNow` helper in `session-id-rotation.test.js` that stubs `Date.now()` for deterministic 1000 ms steps; fast-rotation tests now assert `deltaMs === 1000` exactly, eliminating timing-dependent flake risk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how telemetry buckets some session_ids (env precedence, dotted/unsafe ids hashed) and adds fail-open filesystem instrumentation on the inject hot path; scoped to the synapsys plugin with broad test coverage.
> 
> **Overview**
> Centralizes synapsys session-id handling so **inject-ledger** and **telemetry** resolve the same key from `CLAUDE_CODE_SESSION_ID` and `payload.session_id`, using one `SAFE_ID_RE` (no dots) and **sha256 hashing** for unsafe values instead of telemetry’s old dot-allowing regex and `_unknown-session` bucketing for non-empty bad ids.
> 
> Adds **`session-id-rotation`**: when the env session id changes, append audit rows to `__session-rotations.jsonl`, flag sub-5s **fastRotation**, optional one-shot stderr only with `SYNAPSYS_DEBUG=1`, and opt-out via `SYNAPSYS_SESSION_ROTATION_DISABLED=1` (wired from inject-ledger’s env resolution path).
> 
> **`synapsys-stats`** now skips double-underscore `*.jsonl` sidecars so rotation logs are not aggregated as memory telemetry; single-underscore session files stay included. Test harnesses and ~22 new/updated tests cover parity, rotation, and the sidecar filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea0eb20b96478393172b9d1faafbcbae9f0f6797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
