### PR TITLE
test(work-followup): remove pointless regression guard for deleted flag

### DIFF
--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
@@ -55,15 +55,4 @@ describe('fix-reviews delegate block (Task 7)', () => {
       'expected NO remaining references to --skip-comment'
     );
   });
-
-  // GH-537 followup — the opt-in GitHub-resolve flag was withdrawn entirely
-  // (the autonomous /work agent must never act on external state per
-  // [[never-solve-bot-comments]] and [[never-comment-external-systems]]).
-  // This regression guard prevents the concept from being re-advertised.
-  it('does NOT advertise --also-resolve-on-github to agents', () => {
-    assert.ok(
-      !SOURCE.includes('--also-resolve-on-github'),
-      'delegate block must not reintroduce the withdrawn opt-in GitHub-resolve flag'
-    );
-  });
 });


### PR DESCRIPTION
## Existing Behavior

A regression test in `fix-reviews.test.js` asserted that the delegate block does not contain the string `--also-resolve-on-github`, guarding against the flag being re-advertised to agents.

## Intended New Behavior

The test is deleted. PR #552 removed `--also-resolve-on-github` and all its plumbing from the codebase. With the flag gone, the assertion tests nothing meaningful — it would need to be removed the moment any future ticket legitimately reuses that name. No signal is lost.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

No functional change. Verify the test file no longer contains the removed `it` block:

1. `grep -n 'also-resolve-on-github' plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js` — should return no output
2. Run the test suite: `pnpm dev:test` — all remaining tests in the file pass

### Test Results

Removed 1 test (`does NOT advertise --also-resolve-on-github to agents`). Remaining tests in the describe block pass with no regressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletion with no production or workflow behavior changes.
> 
> **Overview**
> Removes the **`does NOT advertise --also-resolve-on-github to agents`** regression test from `fix-reviews.test.js`.
> 
> That test only checked that the delegate-block source text did not mention a flag that was already removed in PR #552. With no remaining references in the repo, the assertion adds no meaningful signal and could block harmless reuse of the string later.
> 
> All other tests in the describe block (e.g. `--mark-locally-solved` / `--mark-locally-skipped` vs legacy `--solve-comment` / `--skip-comment`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3346ea107bcf8a4fc8c368c9ece8b68ab1a4f55f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->