### PR TITLE
feat(quality): touch-to-fix ratchet for allowlisted files

### DIFF
--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -16,6 +16,21 @@
 #     lint checks — only from the six quality rules in quality.js.
 #   - See docs/quality.md (Task 14) for full rule thresholds and rationale.
 #
+# Touch-to-fix ratchet (GH-592):
+#   - The "(allowlisted)" downgrade only applies to files NOT touched by the
+#     current PR. If `git diff --name-only $BASE_BRANCH...HEAD` includes a
+#     listed path, every violation on it stays severity:error and the gate
+#     fails until the file has zero violations across all six rules — partial
+#     fixes do not pass.
+#   - Editing a listed file is therefore a commitment to either drive its
+#     violation count to zero (and ideally remove it from this list in the
+#     same PR) or revert your change. The runner tags such errors with
+#     "(allowlisted but touched in this PR — fix or remove from .quality-exceptions)".
+#   - Untouched listed files continue to behave as before: their violations
+#     are downgraded to warnings tagged "(allowlisted)" and do not fail the
+#     gate. This is the touch-to-fix ratchet: a hard, code-enforced version
+#     of the burn-down policy above.
+#
 # Format:
 #   - One path per line, repo-relative (POSIX separators).
 #   - Lines starting with '#' and blank lines are ignored.

--- a/plugins/work/scripts/workflows/lib/scripts/quality/__tests__/quality-touch-forfeit.test.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/__tests__/quality-touch-forfeit.test.js
@@ -1,0 +1,246 @@
+'use strict';
+
+/**
+ * Integration tests for the touch-to-fix ratchet in `quality.js`.
+ *
+ * Six scenarios mirroring `tasks/GH-592/gherkin.feature` AC1–AC6.
+ *
+ * Each test spawns the CLI against a temp git repo populated with synthetic
+ * source files. Tests do NOT mock — they exercise the full wiring of
+ * AllowlistLoader, config.getBaseBranch, and the new touchedFiles helper.
+ *
+ * Pattern (mkRepo / runCli / write) mirrors `quality.test.js`.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const CLI = path.resolve(__dirname, '..', 'quality.js');
+
+function mkRepo(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'quality-touch-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function write(dir, rel, contents) {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, contents);
+  return full;
+}
+
+function runCli(cwd, args = [], extraEnv = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, BIOME_BRIDGE_DISABLE: '1', ...extraEnv },
+  });
+}
+
+function bigLines(n) {
+  const out = [];
+  for (let i = 0; i < n; i++) out.push(`// line ${i}`);
+  return out.join('\n');
+}
+
+function git(cwd, args, env = {}) {
+  const res = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'T',
+      GIT_AUTHOR_EMAIL: 't@t',
+      GIT_COMMITTER_NAME: 'T',
+      GIT_COMMITTER_EMAIL: 't@t',
+      ...env,
+    },
+  });
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${res.stderr || res.stdout}`);
+  }
+  return res;
+}
+
+/**
+ * Initialize a git repo with a base branch that represents the PR base
+ * (synthesized as `refs/remotes/origin/main`). After this returns,
+ * HEAD is on a `feature` branch whose diff against `origin/main` is empty;
+ * additional commits on `feature` will appear in `${base}...HEAD`.
+ */
+function initRepo(dir) {
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  // First commit on main (empty so the base ref points somewhere stable).
+  write(dir, '.gitkeep', '');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  // Synthesize `origin/main` so config.getBaseBranch's `git rev-parse --verify origin/main` succeeds.
+  const mainSha = git(dir, ['rev-parse', 'HEAD']).stdout.trim();
+  git(dir, ['update-ref', 'refs/remotes/origin/main', mainSha]);
+  // Move onto a feature branch so future commits aren't on main itself.
+  git(dir, ['checkout', '-q', '-b', 'feature']);
+}
+
+function commitAll(dir, msg) {
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', msg]);
+}
+
+// -----------------------------------------------------------------------------
+// AC1 — Untouched allowlisted file with violations: downgraded to warning.
+// -----------------------------------------------------------------------------
+test('AC1: allowlisted file not touched in PR → downgraded to warning, exit 0', (t) => {
+  const repo = mkRepo(t);
+  initRepo(repo);
+
+  // Put the legacy file + allowlist into the BASE commit (origin/main).
+  git(repo, ['checkout', '-q', 'main']);
+  write(repo, 'src/legacy.js', bigLines(500));
+  write(repo, '.quality-exceptions', 'src/legacy.js\n');
+  commitAll(repo, 'add legacy + allowlist on base');
+  const mainSha = git(repo, ['rev-parse', 'HEAD']).stdout.trim();
+  git(repo, ['update-ref', 'refs/remotes/origin/main', mainSha]);
+
+  // Back to feature; add an unrelated file so HEAD != base but legacy.js is untouched.
+  git(repo, ['checkout', '-q', 'feature']);
+  git(repo, ['merge', '-q', 'main', '--no-edit']);
+  write(repo, 'src/other.js', "'use strict';\nmodule.exports = 1;\n");
+  commitAll(repo, 'unrelated change');
+
+  const res = runCli(repo);
+  assert.equal(res.status, 0, `stdout=${res.stdout}\nstderr=${res.stderr}`);
+  assert.match(res.stdout + res.stderr, /\(allowlisted\)/);
+  assert.doesNotMatch(res.stdout + res.stderr, /allowlisted but touched/);
+});
+
+// -----------------------------------------------------------------------------
+// AC2 — Touched allowlisted file with remaining violations: stays error, tagged.
+// -----------------------------------------------------------------------------
+test('AC2: allowlisted file touched in PR with violations → error, tagged, exit 1', (t) => {
+  const repo = mkRepo(t);
+  initRepo(repo);
+
+  // Base: legacy.js exists clean + allowlist (allowlist on base).
+  git(repo, ['checkout', '-q', 'main']);
+  write(repo, 'src/legacy.js', "'use strict';\nmodule.exports = 1;\n");
+  write(repo, '.quality-exceptions', 'src/legacy.js\n');
+  commitAll(repo, 'base');
+  const mainSha = git(repo, ['rev-parse', 'HEAD']).stdout.trim();
+  git(repo, ['update-ref', 'refs/remotes/origin/main', mainSha]);
+
+  // Feature: rewrite legacy.js to a violating file (touched in PR).
+  git(repo, ['checkout', '-q', 'feature']);
+  git(repo, ['merge', '-q', 'main', '--no-edit']);
+  write(repo, 'src/legacy.js', bigLines(500));
+  commitAll(repo, 'touch legacy');
+
+  const res = runCli(repo);
+  assert.equal(res.status, 1, `stdout=${res.stdout}\nstderr=${res.stderr}`);
+  assert.match(
+    res.stdout + res.stderr,
+    /allowlisted but touched in this PR — fix or remove from \.quality-exceptions/
+  );
+});
+
+// -----------------------------------------------------------------------------
+// AC3 — Touched allowlisted file with zero violations: no violation reported.
+// -----------------------------------------------------------------------------
+test('AC3: allowlisted file touched and now clean → no violation, exit 0', (t) => {
+  const repo = mkRepo(t);
+  initRepo(repo);
+
+  git(repo, ['checkout', '-q', 'main']);
+  // Base has legacy.js large + allowlisted.
+  write(repo, 'src/legacy.js', bigLines(500));
+  write(repo, '.quality-exceptions', 'src/legacy.js\n');
+  commitAll(repo, 'base');
+  const mainSha = git(repo, ['rev-parse', 'HEAD']).stdout.trim();
+  git(repo, ['update-ref', 'refs/remotes/origin/main', mainSha]);
+
+  // Feature: refactor legacy.js to satisfy every rule (touched in PR).
+  git(repo, ['checkout', '-q', 'feature']);
+  git(repo, ['merge', '-q', 'main', '--no-edit']);
+  write(repo, 'src/legacy.js', "'use strict';\nmodule.exports = 1;\n");
+  commitAll(repo, 'refactor legacy');
+
+  const res = runCli(repo);
+  assert.equal(res.status, 0, `stdout=${res.stdout}\nstderr=${res.stderr}`);
+  assert.doesNotMatch(res.stdout + res.stderr, /legacy\.js/);
+});
+
+// -----------------------------------------------------------------------------
+// AC4 — Non-allowlisted file with violations (touched): error, no allowlist tag.
+// -----------------------------------------------------------------------------
+test('AC4: non-allowlisted file touched with violations → error, no tag, exit 1', (t) => {
+  const repo = mkRepo(t);
+  initRepo(repo);
+
+  git(repo, ['checkout', '-q', 'main']);
+  write(repo, '.quality-exceptions', '# empty\n');
+  commitAll(repo, 'base');
+  const mainSha = git(repo, ['rev-parse', 'HEAD']).stdout.trim();
+  git(repo, ['update-ref', 'refs/remotes/origin/main', mainSha]);
+
+  git(repo, ['checkout', '-q', 'feature']);
+  git(repo, ['merge', '-q', 'main', '--no-edit']);
+  write(repo, 'src/new.js', bigLines(500));
+  commitAll(repo, 'add new big file');
+
+  const res = runCli(repo);
+  assert.equal(res.status, 1, `stdout=${res.stdout}\nstderr=${res.stderr}`);
+  assert.match(res.stdout + res.stderr, /new\.js/);
+  assert.doesNotMatch(res.stdout + res.stderr, /allowlisted/);
+});
+
+// -----------------------------------------------------------------------------
+// AC5 — Git unavailable / base ref unresolvable: fail-open, legacy downgrade.
+// -----------------------------------------------------------------------------
+test('AC5: git diff unavailable → touched set empty (fail-open), legacy downgrade, exit 0', (t) => {
+  // No git init — the directory is NOT a repo, so every git command fails.
+  const repo = mkRepo(t);
+  write(repo, 'src/legacy.js', bigLines(500));
+  write(repo, '.quality-exceptions', 'src/legacy.js\n');
+
+  const res = runCli(repo);
+  assert.equal(res.status, 0, `stdout=${res.stdout}\nstderr=${res.stderr}`);
+  assert.match(res.stdout + res.stderr, /\(allowlisted\)/);
+  assert.doesNotMatch(res.stdout + res.stderr, /allowlisted but touched/);
+});
+
+// -----------------------------------------------------------------------------
+// AC6 — BASE_BRANCH override is respected; touched set reflects custom base.
+// -----------------------------------------------------------------------------
+test('AC6: BASE_BRANCH override → touched set includes file diffed against custom base, exit 1', (t) => {
+  const repo = mkRepo(t);
+  initRepo(repo);
+
+  // Build a custom base ref that does NOT contain legacy.js. Then on feature,
+  // commit legacy.js — so diff(custom-base...HEAD) includes legacy.js.
+  git(repo, ['checkout', '-q', 'main']);
+  // The custom base = current main (no legacy.js, has allowlist).
+  write(repo, '.quality-exceptions', 'src/legacy.js\n');
+  commitAll(repo, 'base with allowlist only');
+  const customSha = git(repo, ['rev-parse', 'HEAD']).stdout.trim();
+  git(repo, ['update-ref', 'refs/remotes/origin/custom-base', customSha]);
+  // Also keep origin/main valid for the default-path safety.
+  git(repo, ['update-ref', 'refs/remotes/origin/main', customSha]);
+
+  git(repo, ['checkout', '-q', 'feature']);
+  git(repo, ['merge', '-q', 'main', '--no-edit']);
+  // On feature: introduce a violating allowlisted legacy.js.
+  write(repo, 'src/legacy.js', bigLines(500));
+  commitAll(repo, 'add legacy on feature');
+
+  const res = runCli(repo, [], { BASE_BRANCH: 'custom-base' });
+  assert.equal(res.status, 1, `stdout=${res.stdout}\nstderr=${res.stderr}`);
+  assert.match(
+    res.stdout + res.stderr,
+    /allowlisted but touched in this PR — fix or remove from \.quality-exceptions/
+  );
+});

--- a/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
@@ -196,7 +196,7 @@ function touchedFiles(repoRoot) {
     const out = new Set();
     for (const line of res.stdout.split('\n')) {
       const trimmed = line.trim();
-      if (trimmed.length > 0) out.add(trimmed);
+      if (trimmed.length > 0) out.add(path.normalize(trimmed));
     }
     return out;
   } catch {

--- a/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
@@ -63,8 +63,7 @@ function shouldSkipDir(name, isRoot, parentRelative) {
   // (`plugins/<name>/external_scripts`, `plugins/<name>/docs`, etc.).
   // The plugin root is functionally equivalent to the repo root for these
   // dev-only directories.
-  if (SKIP_DIRS_ROOT_ONLY.has(name) && /^plugins[\\/][^\\/]+$/.test(parentRelative))
-    return true;
+  if (SKIP_DIRS_ROOT_ONLY.has(name) && /^plugins[\\/][^\\/]+$/.test(parentRelative)) return true;
   return false;
 }
 
@@ -178,12 +177,54 @@ function collectViolations(absFiles, repoRoot) {
   return violations;
 }
 
-function applyAllowlist(violations, allowlist) {
-  if (!(allowlist instanceof Set) || allowlist.size === 0) return violations;
-  return violations.map((v) => (allowlist.has(v.file) ? { ...v, severity: 'warning' } : v));
+/**
+ * Compute the set of files touched by the current branch against its base
+ * (`${base}...HEAD`). Returns repo-relative POSIX paths.
+ *
+ * Fail-open: any non-zero git exit, missing `git`, unresolved base, or
+ * thrown exception → returns `new Set()`. The gate stays green when the
+ * diff cannot be computed (mirrors shallow-clone CI environments).
+ */
+function touchedFiles(repoRoot) {
+  try {
+    const base = config.getBaseBranch({ cwd: repoRoot }) || 'origin/main';
+    const res = spawnSync('git', ['diff', '--name-only', `${base}...HEAD`], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (!res || res.status !== 0) return new Set();
+    const out = new Set();
+    for (const line of res.stdout.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.length > 0) out.add(trimmed);
+    }
+    return out;
+  } catch {
+    return new Set();
+  }
 }
 
-function formatHuman(violations) {
+function applyAllowlist(violations, allowlist, touched) {
+  if (!(allowlist instanceof Set) || allowlist.size === 0) return violations;
+  const touchedSet = touched instanceof Set ? touched : new Set();
+  return violations.map((v) => {
+    if (!allowlist.has(v.file)) return v;
+    if (touchedSet.has(v.file)) return v; // touched + allowlisted → stays error
+    return { ...v, severity: 'warning' }; // legacy downgrade
+  });
+}
+
+function violationTag(v, allowlist, touched) {
+  const onAllowlist = allowlist instanceof Set && allowlist.has(v.file);
+  const wasTouched = touched instanceof Set && touched.has(v.file);
+  if (onAllowlist && wasTouched) {
+    return ' (allowlisted but touched in this PR — fix or remove from .quality-exceptions)';
+  }
+  if (v.severity === 'warning' && onAllowlist) return ' (allowlisted)';
+  return '';
+}
+
+function formatHuman(violations, allowlist, touched) {
   if (violations.length === 0) return 'quality: clean\n';
   const byRule = new Map();
   for (const v of violations) {
@@ -194,8 +235,7 @@ function formatHuman(violations) {
   for (const [rule, list] of byRule) {
     lines.push(`# ${rule}`);
     for (const v of list) {
-      const tag = v.severity === 'warning' ? ' (allowlisted)' : '';
-      lines.push(`  ${v.file}:${v.line}  ${v.message}${tag}`);
+      lines.push(`  ${v.file}:${v.line}  ${v.message}${violationTag(v, allowlist, touched)}`);
     }
   }
   return `${lines.join('\n')}\n`;
@@ -233,8 +273,11 @@ function main(argv) {
     return 2;
   }
 
-  violations = applyAllowlist(violations, allowlist);
-  process.stdout.write(opts.json ? formatJson(violations) : formatHuman(violations));
+  const touched = touchedFiles(repoRoot);
+  violations = applyAllowlist(violations, allowlist, touched);
+  process.stdout.write(
+    opts.json ? formatJson(violations) : formatHuman(violations, allowlist, touched)
+  );
   return violations.some((v) => v.severity === 'error') ? 1 : 0;
 }
 


### PR DESCRIPTION
## Existing Behavior

- `applyAllowlist` unconditionally downgrades every violation on an allowlisted file to `severity: warning`, regardless of whether the current PR modified the file.
- `formatHuman` appends a static `(allowlisted)` tag to all downgraded violations.
- No distinction exists between files that were silently carrying debt versus files actively being edited in this PR.
- A developer could touch an allowlisted legacy file, introduce or leave violations, and still pass the quality gate with only warnings.

## Intended New Behavior

- A new `touchedFiles(repoRoot)` helper computes `git diff --name-only ${base}...HEAD` via `config.getBaseBranch` to determine which files the current PR modified; fails open (returns empty set) when git is unavailable or the base ref cannot be resolved, preserving the existing warning behavior in shallow-clone CI environments.
- `applyAllowlist(violations, allowlist, touched)` now implements a three-branch matrix: non-allowlisted files are unchanged, untouched allowlisted files keep the `severity: warning` downgrade, and touched allowlisted files retain `severity: error` — forfeiting the legacy exception.
- `formatHuman(violations, allowlist, touched)` emits `(allowlisted but touched in this PR — fix or remove from .quality-exceptions)` for any touched-and-still-violating allowlisted entry, replacing the generic `(allowlisted)` tag for that case.
- The `.quality-exceptions` header documents the touch-to-fix ratchet semantics, including the commitment it implies and the partial-fix rule.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / CLI validation:**

1. Check out this branch and run the quality test suite:
   ```
   node --test plugins/work/scripts/workflows/lib/scripts/quality/__tests__/quality-touch-forfeit.test.js
   ```
   All 6 node:test cases (AC1–AC6) should pass.

2. Simulate AC2 (touched allowlisted file with violations) manually:
   - Add a file path to `.quality-exceptions`
   - Introduce a line-count violation in that file and commit it on a feature branch
   - Run `node plugins/work/scripts/workflows/lib/scripts/quality/quality.js`
   - Expected: exit code 1, output contains `(allowlisted but touched in this PR — fix or remove from .quality-exceptions)`

3. Simulate AC1 (untouched allowlisted file) manually:
   - Leave an allowlisted file unmodified in the current branch
   - Run the same CLI command
   - Expected: exit code 0, output contains `(allowlisted)` with no mention of "touched"

4. Simulate AC5 (fail-open) by running outside a git repo:
   - Copy `quality.js`, a `.quality-exceptions`, and a violating source file to a temp non-git directory
   - Run `node quality.js` from that directory
   - Expected: exit code 0, violations downgraded to warnings (fail-open behavior preserved)

5. Verify `BASE_BRANCH` override (AC6):
   - Set `BASE_BRANCH=my-custom-base` in env and run the CLI on a branch where the custom base ref exists
   - Confirm the touched set is computed against the custom base, not `origin/main`

### Test Results

6 new integration tests in `quality-touch-forfeit.test.js` covering all 6 acceptance criteria (AC1–AC6). Run with `node --test` directly against the test file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when CI fails for PRs that edit `.quality-exceptions` paths; behavior is intentional but can surprise developers until they fix or revert touched legacy files.
> 
> **Overview**
> Adds a **touch-to-fix ratchet** to the static quality gate: allowlisted legacy debt still downgrades to warnings only when the file is **not** in the PR diff.
> 
> `quality.js` now computes PR-touched paths via `git diff --name-only ${base}...HEAD` (using `config.getBaseBranch`, with **fail-open** to an empty set when git or the base ref is unavailable). `applyAllowlist` keeps **errors** on allowlisted files that appear in that set; untouched allowlisted files still become warnings. Human output uses a new tag for touched-and-still-violating allowlist entries: `(allowlisted but touched in this PR — fix or remove from .quality-exceptions)`.
> 
> `.quality-exceptions` documents the ratchet (partial fixes on touched files do not pass). Six integration tests in `quality-touch-forfeit.test.js` cover untouched vs touched allowlist, clean refactors, non-allowlisted files, fail-open, and `BASE_BRANCH` override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a01abaf4434e0bd44b23b987c51176ad66fad66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->