### PR TITLE
GH-594 - fix(lint-type-ac-consistency): use shared glob-aware classifier for tdd-code

### DIFF
--- a/plugins/work/skills/split-in-tasks/__tests__/pass-d-type-scope.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/pass-d-type-scope.test.js
@@ -79,6 +79,69 @@ describe('Pass D — tdd-code contract', () => {
     );
     assert.equal(ws.length, 0, `expected zero warnings, got: ${JSON.stringify(ws)}`);
   });
+
+  // GH-594: Pass D Type=tdd-code uses the shared glob-aware classifier
+  // scopeEntryAdmitsOnlyTestFiles (same one tests-only uses). Test globs
+  // that constrain to test files must satisfy the "has test file" check.
+  it('GH-594: test-constrained glob src/**/*.test.js satisfies the test-file check', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tdd-code',
+        scope: ['src/**/*.test.js', 'src/foo.js'],
+        acLines: ['Behavior X'],
+      })
+    );
+    assert.equal(
+      ws.filter((w) => /no `\*\.test\.\*`/.test(w.message)).length,
+      0,
+      `glob test-constrained scope must satisfy hasTest; got: ${JSON.stringify(ws)}`
+    );
+  });
+
+  it('GH-594: test-constrained glob **/*.spec.ts satisfies the test-file check', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tdd-code',
+        scope: ['**/*.spec.ts', 'lib/foo.ts'],
+        acLines: ['Behavior X'],
+      })
+    );
+    assert.equal(
+      ws.filter((w) => /no `\*\.test\.\*`/.test(w.message)).length,
+      0,
+      `**/*.spec.ts must satisfy hasTest; got: ${JSON.stringify(ws)}`
+    );
+  });
+
+  it('GH-594: open-ended glob src/** does NOT satisfy hasTest (still warns)', () => {
+    // Open-ended globs admit non-test files too; the contract must keep
+    // warning so the planner is forced to enumerate a real test surface.
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tdd-code',
+        scope: ['src/**'],
+        acLines: ['Behavior X'],
+      })
+    );
+    assert.ok(
+      ws.some((w) => /no `\*\.test\.\*`/.test(w.message)),
+      `open-ended glob must still warn; got: ${JSON.stringify(ws)}`
+    );
+  });
+
+  it('GH-594: test-only glob (no source) STILL warns about missing source', () => {
+    const ws = lintAllPassD(
+      buildModel({
+        type: 'tdd-code',
+        scope: ['src/**/*.test.js'],
+        acLines: ['Behavior X'],
+      })
+    );
+    assert.ok(
+      ws.some((w) => /no non-test source file/.test(w.message)),
+      `test-only glob must warn about missing source; got: ${JSON.stringify(ws)}`
+    );
+  });
 });
 
 describe('Pass D — tests-only contract', () => {

--- a/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
+++ b/plugins/work/skills/split-in-tasks/lib/lint-type-ac-consistency.js
@@ -168,8 +168,15 @@ function checkDocsExemptionTypeMismatch({ file, taskNumber, section, acceptanceC
 function checkTddCodeContract({ file, taskNumber, type, filesInScope, acceptanceCriteria }) {
   if (type !== 'tdd-code') return [];
   const warnings = [];
-  const hasTest = filesInScope.some(isTestFilePath);
-  const hasSource = filesInScope.some((p) => p && !isTestFilePath(p));
+  // GH-594 (Cursor[bot] follow-up): use the shared glob-aware classifier
+  // scopeEntryAdmitsOnlyTestFiles for both checks. Tests-only already uses
+  // it (line ~217); tdd-code did its own thing with isTestFilePath which
+  // happens to agree empirically (the TEST_FILE_PATTERN regex anchors at
+  // end-of-string, so `src/**/*.test.js` matches both), but the asymmetry
+  // is a drift hazard — any future refactor of either helper risks
+  // diverging the two contract checks. Lock them to the same source.
+  const hasTest = filesInScope.some(scopeEntryAdmitsOnlyTestFiles);
+  const hasSource = filesInScope.some((p) => p && !scopeEntryAdmitsOnlyTestFiles(p));
   if (!hasTest) {
     warnings.push(
       makeWarning({


### PR DESCRIPTION
Closes #594. Refactor tdd-code contract check to use the same shared glob-aware classifier (scopeEntryAdmitsOnlyTestFiles) that the tests-only contract uses. Empirically both helpers agree today via end-of-string regex, but the asymmetric code is a drift hazard. Includes 4 regression tests pinning the contract. Branch rebased on current main, clean 2-file diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Planner-time lint only in split-in-tasks; behavior is intended to match today with tests pinning edge cases.
> 
> **Overview**
> **Pass D `tdd-code` scope checks** now use the same glob-aware helper `scopeEntryAdmitsOnlyTestFiles` that **`tests-only`** already uses, instead of `isTestFilePath` on each path. **Test vs source** detection is inverted through that helper (`hasSource` = any entry that does *not* admit only test files), so planner lint and implement-time gates stay aligned and future refactors cannot diverge the two contract paths.
> 
> **Four GH-594 regression tests** lock the behavior: test-constrained globs like `src/**/*.test.js` and `**/*.spec.ts` satisfy the “has test” rule; open-ended `src/**` still warns; a test-only glob still warns about missing source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a34be6e35513b454417ae71921f4e40757c2d921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->