### PR TITLE
fix(synapsys): replace silent 8k drop cap with 16k reverse-walk demotion budget

### DIFF
--- a/plugins/synapsys/hooks/synapsys.js
+++ b/plugins/synapsys/hooks/synapsys.js
@@ -25,8 +25,32 @@ const { saveStickyState } = require(path.join(__dirname, '..', 'lib', 'sticky-st
 const injectLedger = require('../lib/inject-ledger');
 const { recordFired } = require(path.join(__dirname, '..', 'lib', 'telemetry'));
 const { runCiteScan } = require(path.join(__dirname, '..', 'lib', 'cite-scan'));
+const { demoteToFit } = require('../lib/budget');
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Budget constants (brief P0 R1 / R3 / spec §P0 #1).
+//
+// MAX_INJECT_CHARS — soft cap on total injected text. Memories that cause the
+//   matched set to exceed this limit are demoted to summary form (reverse-walk),
+//   never silently dropped (brief P0 R8 / spec §P0 #8).
+// SKIP_DEMOTION_BELOW — memories whose full body is below this size are never
+//   chosen for demotion: their full text is small enough to always inject
+//   in full (brief P0 R3 / spec §P0 #3).
+//
+// Both may be overridden at runtime via `SYNAPSYS_INJECT_BUDGET` (positive
+// integer; brief P2 R12 / spec §P2 #1). See `resolveActiveBudget`.
+// ─────────────────────────────────────────────────────────────────────────────
+const MAX_INJECT_CHARS = 16000;
+const SKIP_DEMOTION_BELOW = 2000;
+
+function resolveActiveBudget() {
+  const raw = process.env.SYNAPSYS_INJECT_BUDGET;
+  if (raw == null || raw === '') return MAX_INJECT_CHARS;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : MAX_INJECT_CHARS;
+}
 
 /**
  * decideInjection — pure helper implementing the brief AC-5 renderer policy.
@@ -82,42 +106,80 @@ function commitInjection(ledger, sessionId, memory, isFull) {
   }
 }
 
-// Cap-aware renderer. Only memories whose rendered text fits within
-// MAX_INJECT_CHARS are recorded in the ledger — anything truncated by the cap
-// keeps its prior injectedCount so it can re-fire (full body) on a later match.
+// Budget-aware renderer (brief P0 R1/R2/R4–R8). After the per-memory
+// decideInjection pass, run a reverse-walk demotion to bring the total under
+// `activeBudget`. Ledger semantics (brief P0 R6):
+//   initialKind='full'  && finalKind='full'     → commitInjection(..., true)
+//   initialKind='reminder'                       → commitInjection(..., false)
+//   initialKind='full'  && finalKind='reminder' → NO commitInjection (re-fires
+//                                                  in full on the next match).
+// The whole call is wrapped in `try` so any throw falls open to the plain
+// formatMemory join — memory injection must never block the user (spec §Security).
 function renderMatchedMemories(matched, sessionId) {
   try {
     const ledger = injectLedger.loadLedger(sessionId);
     if (!ledger.memories || typeof ledger.memories !== 'object') {
       ledger.memories = {};
     }
-    const pieces = [];
-    let used = 0;
-    let truncated = false;
-    for (const m of matched) {
+    const activeBudget = resolveActiveBudget();
+    // Build entries with initialKind from decideInjection. finalKind starts
+    // equal to initialKind; demoteToFit flips it to 'reminder' where needed.
+    const entries = matched.map((m) => {
       const decision = decideInjection(m, ledger.memories[m.name]);
-      const isFull = decision.kind === 'full';
-      const text = isFull ? formatMemory(m) : reminderLine(m);
-      const sepLen = pieces.length ? SEP.length : 0;
-      if (used + sepLen + text.length > MAX_INJECT_CHARS) {
-        truncated = true;
-        break;
+      const kind = decision.kind;
+      return {
+        memory: m,
+        initialKind: kind,
+        finalKind: kind,
+        fullText: formatMemory(m),
+        summaryText: reminderLine(m),
+      };
+    });
+    demoteToFit(entries, {
+      limit: activeBudget,
+      sep: SEP,
+      skipBelow: SKIP_DEMOTION_BELOW,
+    });
+
+    let demotedCount = 0;
+    const pieces = [];
+    for (const e of entries) {
+      const isFull = e.finalKind === 'full';
+      pieces.push(isFull ? e.fullText : e.summaryText);
+      if (e.initialKind === 'full' && e.finalKind === 'reminder') {
+        // Budget-induced demotion: do NOT bump the ledger so the memory
+        // re-fires in full on the next match (brief P0 R6 / G5).
+        demotedCount += 1;
+        continue;
       }
-      pieces.push(text);
-      used += sepLen + text.length;
-      commitInjection(ledger, sessionId, m, isFull);
+      commitInjection(ledger, sessionId, e.memory, isFull);
     }
     const body = pieces.join(SEP);
-    return truncated
-      ? `${body}${SEP}[synapsys: output truncated at ${MAX_INJECT_CHARS} chars]`
-      : body;
+    // Stderr alert (brief P0 R7 / spec §Security: count-only, no names/bodies).
+    if (demotedCount > 0) {
+      try {
+        process.stderr.write(
+          `[synapsys] ${demotedCount} memories summarized to fit ${activeBudget}-char budget — they will inject in full on next match.\n`
+        );
+      } catch {
+        /* fail-open */
+      }
+    }
+    // Debug stderr line when SYNAPSYS_DEBUG=1 (brief P1 R11).
+    if (process.env.SYNAPSYS_DEBUG === '1') {
+      try {
+        process.stderr.write(`[synapsys:debug] budget ${body.length}/${activeBudget}\n`);
+      } catch {
+        /* fail-open */
+      }
+    }
+    return body;
   } catch {
     return matched.map(formatMemory).join(SEP);
   }
 }
 
 const VALID_EVENTS = new Set(['SessionStart', 'UserPromptSubmit', 'PreToolUse', 'Stop']);
-const MAX_INJECT_CHARS = 8000;
 
 async function readStdin() {
   if (process.stdin.isTTY) return '';
@@ -191,10 +253,11 @@ function buildActiveDomainsForPayload(event, payload) {
   return activeDomains ? { activeDomains } : undefined;
 }
 
+// Pass-through wrapper retained for call-site symmetry. The renderer now owns
+// the budget pass (demote-instead-of-drop), so no slice fallback is needed —
+// brief P0 R8 / spec §P0 #8 explicitly forbids silent truncation.
 function formatMatchedOutput(matched, sessionId) {
-  const out = renderMatchedMemories(matched, sessionId);
-  if (out.length <= MAX_INJECT_CHARS) return out;
-  return `${out.slice(0, MAX_INJECT_CHARS)}\n\n[synapsys: output truncated at ${MAX_INJECT_CHARS} chars]`;
+  return renderMatchedMemories(matched, sessionId);
 }
 
 function emitMatched(matched, payload, event) {

--- a/plugins/synapsys/hooks/synapsys.js
+++ b/plugins/synapsys/hooks/synapsys.js
@@ -115,6 +115,55 @@ function commitInjection(ledger, sessionId, memory, isFull) {
 //                                                  in full on the next match).
 // The whole call is wrapped in `try` so any throw falls open to the plain
 // formatMemory join — memory injection must never block the user (spec §Security).
+function buildEntry(memory, ledgerMemories) {
+  const kind = decideInjection(memory, ledgerMemories[memory.name]).kind;
+  return {
+    memory,
+    initialKind: kind,
+    finalKind: kind,
+    fullText: formatMemory(memory),
+    summaryText: reminderLine(memory),
+  };
+}
+
+function emitEntries(entries, ledger, sessionId) {
+  let demotedCount = 0;
+  const pieces = [];
+  for (const e of entries) {
+    const isFull = e.finalKind === 'full';
+    pieces.push(isFull ? e.fullText : e.summaryText);
+    if (e.initialKind === 'full' && e.finalKind === 'reminder') {
+      // Budget-induced demotion: do NOT bump the ledger so the memory
+      // re-fires in full on the next match (brief P0 R6 / G5).
+      demotedCount += 1;
+      continue;
+    }
+    commitInjection(ledger, sessionId, e.memory, isFull);
+  }
+  return { body: pieces.join(SEP), demotedCount };
+}
+
+function writeStderrLine(line) {
+  try {
+    process.stderr.write(line);
+  } catch {
+    /* fail-open */
+  }
+}
+
+function emitBudgetAlerts(demotedCount, bodyLength, activeBudget) {
+  // Stderr alert (brief P0 R7 / spec §Security: count-only, no names/bodies).
+  if (demotedCount > 0) {
+    writeStderrLine(
+      `[synapsys] ${demotedCount} memories summarized to fit ${activeBudget}-char budget — they will inject in full on next match.\n`
+    );
+  }
+  // Debug stderr line when SYNAPSYS_DEBUG=1 (brief P1 R11).
+  if (process.env.SYNAPSYS_DEBUG === '1') {
+    writeStderrLine(`[synapsys:debug] budget ${bodyLength}/${activeBudget}\n`);
+  }
+}
+
 function renderMatchedMemories(matched, sessionId) {
   try {
     const ledger = injectLedger.loadLedger(sessionId);
@@ -122,57 +171,14 @@ function renderMatchedMemories(matched, sessionId) {
       ledger.memories = {};
     }
     const activeBudget = resolveActiveBudget();
-    // Build entries with initialKind from decideInjection. finalKind starts
-    // equal to initialKind; demoteToFit flips it to 'reminder' where needed.
-    const entries = matched.map((m) => {
-      const decision = decideInjection(m, ledger.memories[m.name]);
-      const kind = decision.kind;
-      return {
-        memory: m,
-        initialKind: kind,
-        finalKind: kind,
-        fullText: formatMemory(m),
-        summaryText: reminderLine(m),
-      };
-    });
+    const entries = matched.map((m) => buildEntry(m, ledger.memories));
     demoteToFit(entries, {
       limit: activeBudget,
       sep: SEP,
       skipBelow: SKIP_DEMOTION_BELOW,
     });
-
-    let demotedCount = 0;
-    const pieces = [];
-    for (const e of entries) {
-      const isFull = e.finalKind === 'full';
-      pieces.push(isFull ? e.fullText : e.summaryText);
-      if (e.initialKind === 'full' && e.finalKind === 'reminder') {
-        // Budget-induced demotion: do NOT bump the ledger so the memory
-        // re-fires in full on the next match (brief P0 R6 / G5).
-        demotedCount += 1;
-        continue;
-      }
-      commitInjection(ledger, sessionId, e.memory, isFull);
-    }
-    const body = pieces.join(SEP);
-    // Stderr alert (brief P0 R7 / spec §Security: count-only, no names/bodies).
-    if (demotedCount > 0) {
-      try {
-        process.stderr.write(
-          `[synapsys] ${demotedCount} memories summarized to fit ${activeBudget}-char budget — they will inject in full on next match.\n`
-        );
-      } catch {
-        /* fail-open */
-      }
-    }
-    // Debug stderr line when SYNAPSYS_DEBUG=1 (brief P1 R11).
-    if (process.env.SYNAPSYS_DEBUG === '1') {
-      try {
-        process.stderr.write(`[synapsys:debug] budget ${body.length}/${activeBudget}\n`);
-      } catch {
-        /* fail-open */
-      }
-    }
+    const { body, demotedCount } = emitEntries(entries, ledger, sessionId);
+    emitBudgetAlerts(demotedCount, body.length, activeBudget);
     return body;
   } catch {
     return matched.map(formatMemory).join(SEP);

--- a/plugins/synapsys/lib/__tests__/budget.test.js
+++ b/plugins/synapsys/lib/__tests__/budget.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { demoteToFit, SKIP_DEMOTION_BELOW_DEFAULT } = require('../budget');
+
+function makeEntry(name, fullLen, summaryLen) {
+  return {
+    memory: { name },
+    initialKind: 'full',
+    finalKind: 'full',
+    fullText: 'F'.repeat(fullLen),
+    summaryText: 'S'.repeat(summaryLen),
+  };
+}
+
+function totalSize(entries, sep) {
+  const rendered = entries.map((e) =>
+    e.finalKind === 'full' ? e.fullText.length : e.summaryText.length
+  );
+  if (rendered.length === 0) return 0;
+  return rendered.reduce((a, b) => a + b, 0) + sep.length * (rendered.length - 1);
+}
+
+test('SKIP_DEMOTION_BELOW_DEFAULT exported as 2000', () => {
+  assert.equal(SKIP_DEMOTION_BELOW_DEFAULT, 2000);
+});
+
+test('no-op when total is already under the limit', () => {
+  const entries = [
+    makeEntry('a', 3000, 50),
+    makeEntry('b', 4000, 50),
+    makeEntry('c', 2500, 50),
+  ];
+  const sep = '\n\n';
+  const result = demoteToFit(entries, { limit: 16000, sep, skipBelow: 2000 });
+  assert.equal(result.length, 3);
+  for (const e of result) {
+    assert.equal(e.finalKind, 'full');
+  }
+});
+
+test('reverse-walk order: demotes from last to first', () => {
+  const entries = [
+    makeEntry('m1', 7000, 50),
+    makeEntry('m2', 7000, 50),
+    makeEntry('m3', 7000, 50),
+  ];
+  const sep = '\n\n';
+  const result = demoteToFit(entries, { limit: 16000, sep, skipBelow: 2000 });
+  // total full = 21000+4 = 21004; demote m3 → 14000+50+4 = 14054 ≤ 16000
+  assert.equal(result[0].finalKind, 'full', 'm1 should remain full');
+  assert.equal(result[1].finalKind, 'full', 'm2 should remain full');
+  assert.equal(result[2].finalKind, 'reminder', 'm3 should be demoted first');
+});
+
+test('skip threshold: entries with fullText.length < skipBelow are never demoted', () => {
+  const entries = [
+    makeEntry('big', 9000, 50),
+    makeEntry('tiny', 1500, 50),
+  ];
+  const sep = '\n\n';
+  // total = 9000 + 1500 + 2 = 10502 ≤ 16000 → no demotion needed
+  // Force an overflow by using a small limit
+  const result = demoteToFit(entries, { limit: 8000, sep, skipBelow: 2000 });
+  // tiny is below skipBelow and must NOT be demoted.
+  // big is the only demotable, but it's the last remaining full → rotation guarantee prevents demotion.
+  assert.equal(result[1].finalKind, 'full', 'tiny under skipBelow must stay full');
+  assert.equal(result[0].finalKind, 'full', 'big must stay full (terminal rotation guarantee)');
+});
+
+test('terminal rotation guarantee: never demote the last remaining full entry', () => {
+  const entries = [
+    makeEntry('only', 20000, 50),
+  ];
+  const sep = '\n\n';
+  const result = demoteToFit(entries, { limit: 16000, sep, skipBelow: 2000 });
+  assert.equal(result[0].finalKind, 'full', 'single oversized entry must stay full');
+});
+
+test('worked example: 8000,6000,6000,1000,5000 → full,full,reminder,full,reminder', () => {
+  const entries = [
+    makeEntry('a', 8000, 50),
+    makeEntry('b', 6000, 50),
+    makeEntry('c', 6000, 50),
+    makeEntry('d', 1000, 50),
+    makeEntry('e', 5000, 50),
+  ];
+  const sep = '\n\n';
+  const result = demoteToFit(entries, { limit: 16000, sep, skipBelow: 2000 });
+  assert.equal(result[0].finalKind, 'full', 'a stays full');
+  assert.equal(result[1].finalKind, 'full', 'b stays full');
+  assert.equal(result[2].finalKind, 'reminder', 'c demoted');
+  assert.equal(result[3].finalKind, 'full', 'd skipped (under threshold)');
+  assert.equal(result[4].finalKind, 'reminder', 'e demoted first (reverse walk)');
+  assert.ok(totalSize(result, sep) <= 16000, 'final total must fit under limit');
+});

--- a/plugins/synapsys/lib/__tests__/dispatcher-budget.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/dispatcher-budget.integration.test.js
@@ -86,7 +86,8 @@ function injectedCount(ledger, name) {
 // Write `n` memories named `a`, `b`, … that all match the prompt token
 // `BUDGETTRIGGER`. Each body is sized to `sizes[i]` and stamped with a unique
 // sentinel `SENTINEL-<name>`.
-function seedMatchedMemories(storeDir, names, sizes) {
+function seedMatchedMemories(storeDir, names, sizes, opts = {}) {
+  const fireMode = opts.fireMode || 'always';
   names.forEach((name, i) => {
     writeMemory(
       storeDir,
@@ -97,7 +98,7 @@ function seedMatchedMemories(storeDir, names, sizes) {
         events: 'UserPromptSubmit',
         trigger_prompt: 'BUDGETTRIGGER',
         inject: 'full',
-        fire_mode: 'always',
+        fire_mode: fireMode,
       },
       makeBody(`SENTINEL-${name}`, sizes[i])
     );
@@ -208,9 +209,13 @@ describe('dispatcher 16k budget + demote-instead-of-drop (GH-588 Task 2)', () =>
     );
   });
 
-  it('G5 demotion does not bump ledger; same matched set re-fires the demoted memory as full next time', () => {
-    // Three 7000-char memories → total 21000, must demote two on round 1.
-    seedMatchedMemories(fixture.storeDir, ['m1', 'm2', 'm3'], [7000, 7000, 7000]);
+  it('G5 demotion does not bump ledger; demoted memory injects full on next match', () => {
+    // fire_mode: once + two 9000-char memories. Round 1: total 18000 > 16000,
+    // reverse-walk demotes m2 (m1 stays full because rotation guarantee +
+    // reverse order). Round 2: decideInjection sees m1.count=1 → reminder,
+    // m2.count=0 → full. Total = full(m2≈9000) + reminderLine(m1) ≈ 9100,
+    // well under 16000 → no demotion → m2 emitted in FULL, proving rotation.
+    seedMatchedMemories(fixture.storeDir, ['m1', 'm2'], [9000, 9000], { fireMode: 'once' });
     const round1 = runDispatcher({
       event: 'UserPromptSubmit',
       payload: promptPayload('BUDGETTRIGGER round1', fixture.cwd),
@@ -218,25 +223,32 @@ describe('dispatcher 16k budget + demote-instead-of-drop (GH-588 Task 2)', () =>
     });
     assert.equal(round1.status, 0);
     assert.match(round1.stderr, /memories summarized to fit/);
+    assert.match(round1.stdout, /SENTINEL-m1/, 'm1 full body in round 1');
+    assert.match(
+      round1.stdout,
+      /\[synapsys:active\] m2 \(fired earlier; full body in this session\)/,
+      'm2 demoted to reminder in round 1'
+    );
     const ledger1 = readLedger(fixture.home);
-    // Reverse-walk: m3 demoted first, then m2; m1 stays full.
     assert.equal(injectedCount(ledger1, 'm1'), 1, 'm1 full → ledger bump');
-    assert.equal(injectedCount(ledger1, 'm3'), 0, 'm3 demoted → no ledger bump');
+    assert.equal(injectedCount(ledger1, 'm2'), 0, 'm2 demoted → no ledger bump');
 
-    // Round 2 with the same matched set: demoted entry's injectedCount is still
-    // 0 so decideInjection (fire_mode=always here, count irrelevant) emits full,
-    // budget demotion happens again from a clean ledger slate for the demoted.
+    // Round 2 — same matched set, same session
     const round2 = runDispatcher({
       event: 'UserPromptSubmit',
       payload: promptPayload('BUDGETTRIGGER round2', fixture.cwd),
       home: fixture.home,
     });
     assert.equal(round2.status, 0);
-    // m3's stable sentinel can appear in round-2 stdout when budget permits,
-    // OR appears as full when reverse-walk demotes someone else. Either way
-    // round 2's ledger for m3 is still 0 (because it gets demoted again) OR 1
-    // (because it got promoted). Critical: m3 was NOT bumped after round 1.
-    void round2; // placeholder, real assertion is the round-1 zero above
+    assert.doesNotMatch(round2.stderr, /memories summarized to fit/, 'round 2 fits — no alert');
+    assert.match(round2.stdout, /SENTINEL-m2/, 'm2 now injects FULL (rotation guarantee)');
+    assert.match(
+      round2.stdout,
+      /\[synapsys:active\] m1 \(fired earlier; full body in this session\)/,
+      'm1 now reminder via decideInjection (once + count=1)'
+    );
+    const ledger2 = readLedger(fixture.home);
+    assert.equal(injectedCount(ledger2, 'm2'), 1, 'm2 full in round 2 → ledger bump');
   });
 
   it('G6 decideInjection-driven reminder still bumps the ledger; stderr lacks demotion alert', () => {

--- a/plugins/synapsys/lib/__tests__/dispatcher-budget.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/dispatcher-budget.integration.test.js
@@ -1,0 +1,354 @@
+'use strict';
+
+// Integration tests for the synapsys dispatcher 16k injection budget pass with
+// demote-instead-of-drop semantics (GH-588 Task 2). Mirrors the spawn pattern
+// from dispatcher-fire-mode.integration.test.js: the dispatcher runs end-to-end
+// in a child process against an isolated tmp HOME/cwd fixture so the per-session
+// inject ledger is read/written on disk and stderr can be observed.
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const DISPATCHER = path.resolve(__dirname, '..', '..', 'hooks', 'synapsys.js');
+
+// Sentinel substring stamped into every fixture body. The actual body bulk is
+// padded `.` characters so we can dial the exact rendered size while keeping a
+// stable substring to grep for in stdout. Body sizing is approximate — header
+// chars added by `formatMemory` are small relative to the budget.
+function makeBody(sentinel, totalChars) {
+  const padLen = Math.max(0, totalChars - sentinel.length);
+  return `${sentinel}${'.'.repeat(padLen)}`;
+}
+
+function writeMemory(dir, file, frontmatter, body) {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  fs.writeFileSync(path.join(dir, file), `---\n${fm}\n---\n${body}`);
+}
+
+function runDispatcher({ event, payload, home, env = {} }) {
+  // Strip CLAUDE_CODE_SESSION_ID from the inherited env so the dispatcher's
+  // `resolveFromEnv` leg cannot hijack the payload's `session_id`. Otherwise
+  // every test under an interactive Claude Code session would land in the
+  // host session's ledger file instead of our fixture's. Mirrors the
+  // dispatcher-fire-mode pattern (it spawns inside an isolated tmp HOME).
+  const baseEnv = { ...process.env };
+  delete baseEnv.CLAUDE_CODE_SESSION_ID;
+  const res = spawnSync(process.execPath, [DISPATCHER, event], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    env: {
+      ...baseEnv,
+      HOME: home,
+      SYNAPSYS_NO_SETUP_HINT: '1',
+      ...env,
+    },
+  });
+  return { stdout: res.stdout || '', stderr: res.stderr || '', status: res.status };
+}
+
+function setupFixture() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-budget-'));
+  const home = path.join(base, 'home');
+  const cwd = path.join(base, 'project');
+  const storeDir = path.join(cwd, '.claude', 'synapsys');
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storeDir, '.synapsys.json'),
+    JSON.stringify({ kind: 'local', projectName: 'budget-fixture', schemaVersion: 1 })
+  );
+  return { base, home, cwd, storeDir };
+}
+
+const SESSION_ID = 'budget-session-abc';
+
+function promptPayload(prompt, cwd) {
+  return { cwd, session_id: SESSION_ID, prompt };
+}
+
+function readLedger(home) {
+  const ledgerPath = path.join(home, '.claude', 'synapsys', '.session', `${SESSION_ID}.json`);
+  if (!fs.existsSync(ledgerPath)) return { memories: {} };
+  return JSON.parse(fs.readFileSync(ledgerPath, 'utf8'));
+}
+
+function injectedCount(ledger, name) {
+  const e = ledger.memories && ledger.memories[name];
+  return Number(e && e.injectedCount) || 0;
+}
+
+// Write `n` memories named `a`, `b`, … that all match the prompt token
+// `BUDGETTRIGGER`. Each body is sized to `sizes[i]` and stamped with a unique
+// sentinel `SENTINEL-<name>`.
+function seedMatchedMemories(storeDir, names, sizes) {
+  names.forEach((name, i) => {
+    writeMemory(
+      storeDir,
+      `${name}.md`,
+      {
+        name,
+        description: `mem-${name}`,
+        events: 'UserPromptSubmit',
+        trigger_prompt: 'BUDGETTRIGGER',
+        inject: 'full',
+        fire_mode: 'always',
+      },
+      makeBody(`SENTINEL-${name}`, sizes[i])
+    );
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('dispatcher 16k budget + demote-instead-of-drop (GH-588 Task 2)', () => {
+  let fixture;
+
+  beforeEach(() => {
+    fixture = setupFixture();
+  });
+
+  it('G1 under-budget: all full bodies, no alert, ledger bumps every memory', () => {
+    // 5x 1000-char bodies total ≈ 5000 chars — comfortably below 16000.
+    seedMatchedMemories(
+      fixture.storeDir,
+      ['a', 'b', 'c', 'd', 'e'],
+      [1000, 1000, 1000, 1000, 1000]
+    );
+    const r = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER please', fixture.cwd),
+      home: fixture.home,
+    });
+    assert.equal(r.status, 0, `exit ${r.status}; stderr=${r.stderr}`);
+    for (const name of ['a', 'b', 'c', 'd', 'e']) {
+      assert.match(r.stdout, new RegExp(`SENTINEL-${name}`), `${name} must appear as full body`);
+    }
+    assert.doesNotMatch(r.stderr, /memories summarized to fit/);
+    assert.doesNotMatch(r.stdout, /output truncated at/);
+    const ledger = readLedger(fixture.home);
+    for (const name of ['a', 'b', 'c', 'd', 'e']) {
+      assert.equal(injectedCount(ledger, name), 1, `ledger must bump ${name}`);
+    }
+  });
+
+  it('G2 worked example overflow (8000,6000,6000,1000,5000) → a,b,d full; c,e reminders; alert count=2', () => {
+    seedMatchedMemories(
+      fixture.storeDir,
+      ['a', 'b', 'c', 'd', 'e'],
+      [8000, 6000, 6000, 1000, 5000]
+    );
+    const r = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER worked example', fixture.cwd),
+      home: fixture.home,
+    });
+    assert.equal(r.status, 0);
+    // a, b, d full bodies present
+    assert.match(r.stdout, /SENTINEL-a/);
+    assert.match(r.stdout, /SENTINEL-b/);
+    assert.match(r.stdout, /SENTINEL-d/);
+    // c, e appear as reminder lines (and NOT as full body sentinels)
+    assert.match(r.stdout, /\[synapsys:active\] c \(fired earlier; full body in this session\)/);
+    assert.match(r.stdout, /\[synapsys:active\] e \(fired earlier; full body in this session\)/);
+    assert.doesNotMatch(r.stdout, /SENTINEL-c/);
+    assert.doesNotMatch(r.stdout, /SENTINEL-e/);
+    // Stderr alert with exact count and budget
+    assert.match(
+      r.stderr,
+      /\[synapsys\] 2 memories summarized to fit 16000-char budget — they will inject in full on next match\./
+    );
+    // No truncation trailer
+    assert.doesNotMatch(r.stdout, /output truncated at/);
+    // Ledger bumps only a, b, d
+    const ledger = readLedger(fixture.home);
+    assert.equal(injectedCount(ledger, 'a'), 1);
+    assert.equal(injectedCount(ledger, 'b'), 1);
+    assert.equal(injectedCount(ledger, 'd'), 1);
+    assert.equal(injectedCount(ledger, 'c'), 0, 'demoted c must NOT bump ledger');
+    assert.equal(injectedCount(ledger, 'e'), 0, 'demoted e must NOT bump ledger');
+  });
+
+  it('G3 single 18000-char memory: full body emitted, no truncation trailer, no demotion alert, ledger bumped', () => {
+    seedMatchedMemories(fixture.storeDir, ['big'], [18000]);
+    const r = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER big one', fixture.cwd),
+      home: fixture.home,
+    });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /SENTINEL-big/, 'full body must be present');
+    assert.ok(r.stdout.length > 16000, `stdout length ${r.stdout.length} must exceed 16000`);
+    assert.doesNotMatch(r.stdout, /output truncated at/);
+    assert.doesNotMatch(r.stderr, /memories summarized to fit/);
+    const ledger = readLedger(fixture.home);
+    assert.equal(injectedCount(ledger, 'big'), 1);
+  });
+
+  it('G4 skip threshold: 1500-char memory is never demoted even alongside a 9000-char one', () => {
+    // 9000 + 1500 = 10500 — fits under 16k anyway, but the 1500 must remain full.
+    seedMatchedMemories(fixture.storeDir, ['big', 'small'], [9000, 1500]);
+    const r = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER skip threshold', fixture.cwd),
+      home: fixture.home,
+    });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /SENTINEL-small/, '1500-char memory must be full body');
+    // Whichever path big takes (full or reminder), the small one must never
+    // appear as a reminder line — that's the skip threshold guarantee.
+    assert.doesNotMatch(
+      r.stdout,
+      /\[synapsys:active\] small \(fired earlier; full body in this session\)/
+    );
+  });
+
+  it('G5 demotion does not bump ledger; same matched set re-fires the demoted memory as full next time', () => {
+    // Three 7000-char memories → total 21000, must demote two on round 1.
+    seedMatchedMemories(fixture.storeDir, ['m1', 'm2', 'm3'], [7000, 7000, 7000]);
+    const round1 = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER round1', fixture.cwd),
+      home: fixture.home,
+    });
+    assert.equal(round1.status, 0);
+    assert.match(round1.stderr, /memories summarized to fit/);
+    const ledger1 = readLedger(fixture.home);
+    // Reverse-walk: m3 demoted first, then m2; m1 stays full.
+    assert.equal(injectedCount(ledger1, 'm1'), 1, 'm1 full → ledger bump');
+    assert.equal(injectedCount(ledger1, 'm3'), 0, 'm3 demoted → no ledger bump');
+
+    // Round 2 with the same matched set: demoted entry's injectedCount is still
+    // 0 so decideInjection (fire_mode=always here, count irrelevant) emits full,
+    // budget demotion happens again from a clean ledger slate for the demoted.
+    const round2 = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER round2', fixture.cwd),
+      home: fixture.home,
+    });
+    assert.equal(round2.status, 0);
+    // m3's stable sentinel can appear in round-2 stdout when budget permits,
+    // OR appears as full when reverse-walk demotes someone else. Either way
+    // round 2's ledger for m3 is still 0 (because it gets demoted again) OR 1
+    // (because it got promoted). Critical: m3 was NOT bumped after round 1.
+    void round2; // placeholder, real assertion is the round-1 zero above
+  });
+
+  it('G6 decideInjection-driven reminder still bumps the ledger; stderr lacks demotion alert', () => {
+    // fire_mode: once + ledger.injectedCount=1 forces reminder regardless of
+    // budget. Single small memory so the budget pass has nothing to demote.
+    writeMemory(
+      fixture.storeDir,
+      'y.md',
+      {
+        name: 'y',
+        description: 'reminder-path memory',
+        events: 'UserPromptSubmit',
+        trigger_prompt: 'BUDGETTRIGGER',
+        inject: 'full',
+        fire_mode: 'once',
+      },
+      makeBody('SENTINEL-y', 1000)
+    );
+    // Pre-seed ledger so decideInjection picks the reminder branch.
+    const sessionDir = path.join(fixture.home, '.claude', 'synapsys', '.session');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionDir, `${SESSION_ID}.json`),
+      JSON.stringify({
+        createdAt: Date.now(),
+        sessionId: SESSION_ID,
+        memories: { y: { injectedCount: 1, lastFullInjectAt: 1 } },
+      })
+    );
+    const r = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER reminder-path', fixture.cwd),
+      home: fixture.home,
+    });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /\[synapsys:active\] y \(fired earlier; full body in this session\)/);
+    assert.doesNotMatch(r.stderr, /memories summarized to fit/);
+    const ledger = readLedger(fixture.home);
+    assert.equal(injectedCount(ledger, 'y'), 2, 'decideInjection reminder must bump ledger');
+  });
+
+  it('G7 reverse-walk order: 3 equally-sized demotable memories → m1 full, m2+m3 reminders, alert count=2', () => {
+    // Size each body so 3*full > budget AND 2*full > budget after one demotion,
+    // forcing two reverse-walk demotions (m3 then m2) to land under 16000.
+    seedMatchedMemories(fixture.storeDir, ['m1', 'm2', 'm3'], [8500, 8500, 8500]);
+    const r = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER reverse-walk', fixture.cwd),
+      home: fixture.home,
+    });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /SENTINEL-m1/);
+    assert.doesNotMatch(r.stdout, /SENTINEL-m2/);
+    assert.doesNotMatch(r.stdout, /SENTINEL-m3/);
+    assert.match(r.stdout, /\[synapsys:active\] m2 \(fired earlier; full body in this session\)/);
+    assert.match(r.stdout, /\[synapsys:active\] m3 \(fired earlier; full body in this session\)/);
+    assert.match(r.stderr, /\[synapsys\] 2 memories summarized to fit 16000-char budget/);
+  });
+
+  it('G8 E2E hook invocation: exit 0; stdout contains both full bodies and summary lines; stderr begins with [synapsys]', () => {
+    seedMatchedMemories(
+      fixture.storeDir,
+      ['a', 'b', 'c', 'd', 'e'],
+      [8000, 6000, 6000, 1000, 5000]
+    );
+    const r = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER e2e', fixture.cwd),
+      home: fixture.home,
+    });
+    assert.equal(r.status, 0);
+    assert.ok(r.stdout.length > 0, 'stdout must be non-empty');
+    // Both rendering modes present.
+    assert.match(r.stdout, /SENTINEL-a/, 'full body present');
+    assert.match(r.stdout, /fired earlier; full body in this session/, 'summary line present');
+    // Stderr begins with [synapsys].
+    assert.ok(r.stderr.startsWith('[synapsys]'), `stderr must start with [synapsys], got ${JSON.stringify(r.stderr.slice(0, 40))}`);
+  });
+
+  it('R11 SYNAPSYS_DEBUG=1 emits "[synapsys:debug] budget <used>/<limit>" to stderr', () => {
+    seedMatchedMemories(fixture.storeDir, ['a', 'b'], [3000, 3000]);
+    const r = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER debug', fixture.cwd),
+      home: fixture.home,
+      env: { SYNAPSYS_DEBUG: '1' },
+    });
+    assert.equal(r.status, 0);
+    assert.match(
+      r.stderr,
+      /\[synapsys:debug\] budget \d+\/16000/,
+      'debug line must report used/limit'
+    );
+  });
+
+  it('R12 SYNAPSYS_INJECT_BUDGET=24000 override: alert text reads "to fit 24000-char budget"', () => {
+    // Three 7000 memories = 21000 chars. Under the default 16000 budget the
+    // dispatcher would demote two; under a 24000 budget all three fit full.
+    // To still force a demotion at budget=24000, bump to 9000 each = 27000.
+    seedMatchedMemories(fixture.storeDir, ['m1', 'm2', 'm3'], [9000, 9000, 9000]);
+    const r = runDispatcher({
+      event: 'UserPromptSubmit',
+      payload: promptPayload('BUDGETTRIGGER override', fixture.cwd),
+      home: fixture.home,
+      env: { SYNAPSYS_INJECT_BUDGET: '24000' },
+    });
+    assert.equal(r.status, 0);
+    assert.match(
+      r.stderr,
+      /memories summarized to fit 24000-char budget/,
+      'alert must reflect the overridden budget'
+    );
+    assert.doesNotMatch(r.stderr, /16000-char budget/, 'alert must NOT mention the default budget');
+  });
+});

--- a/plugins/synapsys/lib/budget.js
+++ b/plugins/synapsys/lib/budget.js
@@ -1,0 +1,102 @@
+'use strict';
+
+/**
+ * Default skip threshold: entries whose `fullText.length` is below this value
+ * are never demoted (their full body is small enough to always inject in full).
+ * See spec §P0 #3 / brief P0 R3.
+ */
+const SKIP_DEMOTION_BELOW_DEFAULT = 2000;
+
+/**
+ * Compute the rendered character size of `entries`, joining the rendered
+ * piece of each entry (its `fullText` when `finalKind === 'full'`, otherwise
+ * its `summaryText`) with `sep` between adjacent entries.
+ *
+ * @param {ReadonlyArray<Entry>} entries
+ * @param {string} sep
+ * @returns {number}
+ */
+function renderedSize(entries, sep) {
+  if (entries.length === 0) return 0;
+  let total = 0;
+  for (const e of entries) {
+    total += e.finalKind === 'full' ? e.fullText.length : e.summaryText.length;
+  }
+  total += sep.length * (entries.length - 1);
+  return total;
+}
+
+/**
+ * Reverse-walk demotion: flip `finalKind` from `'full'` to `'reminder'` on
+ * demotable entries (last to first) until the total rendered size is `≤ limit`
+ * or no demotable entries remain. Pure: mutates the supplied `entries` array
+ * in place (and returns it) without performing I/O, reading env vars, or
+ * writing to stderr.
+ *
+ * Invariants:
+ *  - **Reverse-walk order**: among demotable entries, the one with the
+ *    highest index is demoted first.
+ *  - **Skip threshold**: an entry whose `fullText.length < skipBelow` is
+ *    never demoted (brief P0 R3).
+ *  - **Terminal rotation guarantee**: at least one demotable entry is always
+ *    retained in `'full'` form, so the matched set never collapses to
+ *    summaries only even when the total still exceeds `limit`
+ *    (brief P0 R4 / spec §P0 #4).
+ *
+ * Entry shape:
+ *   {
+ *     memory:       object,        // opaque, passed through
+ *     initialKind:  'full' | 'reminder',
+ *     finalKind:    'full' | 'reminder',  // mutated by this helper
+ *     fullText:     string,        // rendered full body
+ *     summaryText:  string,        // rendered reminder line
+ *   }
+ *
+ * @template {{ memory: unknown, initialKind: 'full'|'reminder',
+ *   finalKind: 'full'|'reminder', fullText: string, summaryText: string }} Entry
+ * @param {Entry[]} entries
+ * @param {{ limit: number, sep: string, skipBelow?: number }} options
+ * @returns {Entry[]} The same `entries` array, with `finalKind` mutated as needed.
+ */
+function demoteToFit(entries, options) {
+  const opts = options || {};
+  const limit = opts.limit;
+  const sep = opts.sep != null ? opts.sep : '';
+  const skipBelow = opts.skipBelow != null ? opts.skipBelow : SKIP_DEMOTION_BELOW_DEFAULT;
+
+  if (!Array.isArray(entries) || entries.length === 0) return entries;
+
+  // Walk REVERSE; demote one demotable entry at a time until total ≤ limit
+  // or no demotable entries remain. Demotable requires:
+  //   - finalKind === 'full'
+  //   - fullText.length >= skipBelow
+  //   - not the LAST remaining 'full' entry (terminal rotation guarantee)
+  while (renderedSize(entries, sep) > limit) {
+    // Demotable = finalKind 'full' AND fullText.length >= skipBelow.
+    const demotableIndices = [];
+    for (let i = 0; i < entries.length; i++) {
+      const e = entries[i];
+      if (e.finalKind === 'full' && e.fullText.length >= skipBelow) {
+        demotableIndices.push(i);
+      }
+    }
+    // Terminal rotation guarantee: keep at least one demotable entry in 'full'
+    // form so the set never collapses to summaries only.
+    if (demotableIndices.length <= 1) break;
+
+    let demotedThisPass = false;
+    for (let k = demotableIndices.length - 1; k >= 0; k--) {
+      const i = demotableIndices[k];
+      // Reserve the FIRST demotable (lowest index) as the rotation anchor.
+      if (i === demotableIndices[0]) continue;
+      entries[i].finalKind = 'reminder';
+      demotedThisPass = true;
+      break;
+    }
+    if (!demotedThisPass) break;
+  }
+
+  return entries;
+}
+
+module.exports = { demoteToFit, SKIP_DEMOTION_BELOW_DEFAULT };

--- a/plugins/synapsys/lib/budget.js
+++ b/plugins/synapsys/lib/budget.js
@@ -58,6 +58,29 @@ function renderedSize(entries, sep) {
  * @param {{ limit: number, sep: string, skipBelow?: number }} options
  * @returns {Entry[]} The same `entries` array, with `finalKind` mutated as needed.
  */
+function findDemotableIndices(entries, skipBelow) {
+  const out = [];
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (e.finalKind === 'full' && e.fullText.length >= skipBelow) out.push(i);
+  }
+  return out;
+}
+
+// Demote the highest-indexed demotable entry, reserving the lowest-indexed
+// demotable as the rotation anchor (terminal rotation guarantee). Returns
+// true iff an entry was demoted in this pass.
+function demoteOnePass(entries, demotableIndices) {
+  const anchor = demotableIndices[0];
+  for (let k = demotableIndices.length - 1; k >= 0; k--) {
+    const i = demotableIndices[k];
+    if (i === anchor) continue;
+    entries[i].finalKind = 'reminder';
+    return true;
+  }
+  return false;
+}
+
 function demoteToFit(entries, options) {
   const opts = options || {};
   const limit = opts.limit;
@@ -67,33 +90,12 @@ function demoteToFit(entries, options) {
   if (!Array.isArray(entries) || entries.length === 0) return entries;
 
   // Walk REVERSE; demote one demotable entry at a time until total ≤ limit
-  // or no demotable entries remain. Demotable requires:
-  //   - finalKind === 'full'
-  //   - fullText.length >= skipBelow
-  //   - not the LAST remaining 'full' entry (terminal rotation guarantee)
+  // or no demotable entries remain. The terminal rotation guarantee (P0 R4)
+  // is enforced by reserving the lowest-indexed demotable as anchor.
   while (renderedSize(entries, sep) > limit) {
-    // Demotable = finalKind 'full' AND fullText.length >= skipBelow.
-    const demotableIndices = [];
-    for (let i = 0; i < entries.length; i++) {
-      const e = entries[i];
-      if (e.finalKind === 'full' && e.fullText.length >= skipBelow) {
-        demotableIndices.push(i);
-      }
-    }
-    // Terminal rotation guarantee: keep at least one demotable entry in 'full'
-    // form so the set never collapses to summaries only.
-    if (demotableIndices.length <= 1) break;
-
-    let demotedThisPass = false;
-    for (let k = demotableIndices.length - 1; k >= 0; k--) {
-      const i = demotableIndices[k];
-      // Reserve the FIRST demotable (lowest index) as the rotation anchor.
-      if (i === demotableIndices[0]) continue;
-      entries[i].finalKind = 'reminder';
-      demotedThisPass = true;
-      break;
-    }
-    if (!demotedThisPass) break;
+    const demotable = findDemotableIndices(entries, skipBelow);
+    if (demotable.length <= 1) break;
+    if (!demoteOnePass(entries, demotable)) break;
   }
 
   return entries;


### PR DESCRIPTION
## Existing Behavior

- The synapsys dispatcher enforced a hard 8000-char cap. Any matched memory whose rendered text caused the running total to exceed this limit was silently dropped — it would not appear in the injected output at all, nor receive a reminder line.
- A `[synapsys: output truncated at 8000 chars]` trailer was appended to the output body whenever truncation occurred.
- A secondary hard-slice in `formatMatchedOutput` further capped the final output string at 8000 chars, truncating mid-content if needed.
- No user-facing or programmatic signal existed to distinguish "memory was omitted because of the budget" from "memory had no match this turn."

## Intended New Behavior

- The injection budget is raised to a 16000-char soft cap. When the matched set exceeds it, a pure `demoteToFit` helper performs a reverse-walk demotion: entries are flipped from `full` to `reminder` (last to first) until the total fits, or until only one demotable entry remains (terminal rotation guarantee — at least one memory always stays full).
- Memories whose `fullText.length < 2000` (`SKIP_DEMOTION_BELOW`) are never chosen for demotion; their full body is always injected.
- Budget-demoted memories do not advance the inject ledger (`commitInjection` is skipped), so they re-fire in full on the next prompt match — no memory is ever permanently dropped.
- A stderr alert `[synapsys] N memories summarized to fit <budget>-char budget — they will inject in full on next match.` is emitted whenever at least one demotion occurred. `SYNAPSYS_DEBUG=1` additionally emits `[synapsys:debug] budget <used>/<limit>`.
- `SYNAPSYS_INJECT_BUDGET=<N>` overrides the default 16000 at runtime.
- The legacy `[synapsys: output truncated at ...]` trailer and the hard-slice fallback in `formatMatchedOutput` are removed.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / hook behavior — manual verification:**

1. Create two synapsys memories totalling more than 16000 chars (e.g., two `inject: full` memories with bodies of ~9000 chars each, both triggered by the same prompt keyword).
2. Send a prompt containing the trigger keyword in a session that has synapsys enabled.
3. Observe that **both** memories appear in the injected context — the first as a full body, the second as a `[synapsys:active] <name> (fired earlier; full body in this session)` reminder line.
4. Observe that stderr contains `[synapsys] 1 memories summarized to fit 16000-char budget — they will inject in full on next match.`
5. Send the same trigger keyword again in the same session. Observe that the second memory now injects as a full body (rotation guarantee), and the first becomes the reminder.
6. To verify the `SYNAPSYS_INJECT_BUDGET` override: set `SYNAPSYS_INJECT_BUDGET=24000` and repeat with three ~9000-char memories — all three should fit without demotion unless they exceed 24000 chars combined.
7. To verify the debug line: set `SYNAPSYS_DEBUG=1` and confirm `[synapsys:debug] budget <used>/16000` appears in stderr on each prompt.

**Automated test coverage (16 passing tests):**

```
# Unit tests (6)
node --test plugins/synapsys/lib/__tests__/budget.test.js

# Integration tests (10)
node --test plugins/synapsys/lib/__tests__/dispatcher-budget.integration.test.js
```

Tests cover: G1 under-budget (all full, no alert), G2 worked example (8000,6000,6000,1000,5000 → a,b,d full; c,e reminder; alert count=2), G3 single oversized memory (terminal rotation guarantee), G4 skip threshold (1500-char memory never demoted), G5 demotion→no ledger bump→full on round 2, G6 decideInjection-driven reminder still bumps ledger, G7 reverse-walk order, G8 E2E hook invocation, R11 `SYNAPSYS_DEBUG=1`, R12 `SYNAPSYS_INJECT_BUDGET` override.

### Test Results

All 16 tests pass; lint clean (complexity ≤10).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hook injection volume and ledger semantics for matched memories (user-visible context and rotation), though behavior is fail-open with broad test coverage.
> 
> **Overview**
> Replaces the synapsys dispatcher’s **8k hard cap** (stop injecting, drop remaining matches, append a truncation trailer) with a **16k soft budget** that **demotes** overflow memories to one-line reminders instead of omitting them.
> 
> Injection rendering now builds per-match entries (`decideInjection` → full vs reminder), runs **`demoteToFit`** (reverse-walk from last match; skip demotion for bodies under 2k chars; keep at least one demotable entry full), then emits output. **Budget demotions skip inject-ledger updates** so those memories can inject full again on the next match; policy-driven reminders still bump the ledger. Stderr alerts report how many were summarized; **`SYNAPSYS_INJECT_BUDGET`** overrides the limit and **`SYNAPSYS_DEBUG=1`** logs used/limit. The **`formatMatchedOutput` hard slice** and **`[synapsys: output truncated …]`** path are removed.
> 
> Adds **`lib/budget.js`** plus unit and end-to-end dispatcher integration tests for demotion order, rotation, ledger behavior, and env overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a4d60c3146382f626ae62b84c0ce65db4d39224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Structured Test Results

| Test | Status | Notes |
|------|--------|-------|
| budget.test.js — 6 unit tests (demoteToFit pure fn, worked example, skip threshold, terminal rotation guarantee, reverse-walk order) | PASS | node --test plugins/synapsys/lib/__tests__/budget.test.js → 6 pass / 0 fail |
| dispatcher-budget.integration.test.js — 10 integration tests (G1–G8 Gherkin scenarios, R11 SYNAPSYS_DEBUG=1, R12 SYNAPSYS_INJECT_BUDGET override) | PASS | node --test plugins/synapsys/lib/__tests__/dispatcher-budget.integration.test.js → 10 pass / 0 fail |

> Source: completion.check.md (GH-588) — verbatim test runner output.

## Visual Documentation

This is a backend-only change (synapsys hook). No UI screenshots are applicable. See the Testing Plan / Demo section above for manual verification steps.