### PR TITLE
chore(synapsys): GH-588 follow-up — JSDoc placement fix + injectedCount semantics

### DIFF
--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -375,4 +375,4 @@ When upgrading existing memories:
 - Procedural / workflow rules (the agent only needs to read once) — leave the default `once`. No frontmatter change required.
 - Diagnostic playbooks that the agent might forget over a long session — consider `fire_mode: occasionally` with a tuned `fire_cadence`.
 
-The `synapsys:list` skill displays each memory's `fire_mode` (and `fire_cadence` when `occasionally`) plus the current session's `injectedCount`.
+The `synapsys:list` skill displays each memory's `fire_mode` (and `fire_cadence` when `occasionally`) plus the current session's `injectedCount`. `injectedCount` counts ledger-committed emissions (full body + policy-driven reminders); budget-demoted matches (see GH-588) are excluded by design so they re-fire in full on the next match.

--- a/plugins/synapsys/lib/budget.js
+++ b/plugins/synapsys/lib/budget.js
@@ -26,6 +26,31 @@ function renderedSize(entries, sep) {
   return total;
 }
 
+// Collect indices of entries currently eligible for demotion (finalKind 'full'
+// AND fullText length at or above the skip threshold).
+function findDemotableIndices(entries, skipBelow) {
+  const out = [];
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (e.finalKind === 'full' && e.fullText.length >= skipBelow) out.push(i);
+  }
+  return out;
+}
+
+// Demote the highest-indexed demotable entry, reserving the lowest-indexed
+// demotable as the rotation anchor (terminal rotation guarantee). Returns
+// true iff an entry was demoted in this pass.
+function demoteOnePass(entries, demotableIndices) {
+  const anchor = demotableIndices[0];
+  for (let k = demotableIndices.length - 1; k >= 0; k--) {
+    const i = demotableIndices[k];
+    if (i === anchor) continue;
+    entries[i].finalKind = 'reminder';
+    return true;
+  }
+  return false;
+}
+
 /**
  * Reverse-walk demotion: flip `finalKind` from `'full'` to `'reminder'` on
  * demotable entries (last to first) until the total rendered size is `≤ limit`
@@ -58,29 +83,6 @@ function renderedSize(entries, sep) {
  * @param {{ limit: number, sep: string, skipBelow?: number }} options
  * @returns {Entry[]} The same `entries` array, with `finalKind` mutated as needed.
  */
-function findDemotableIndices(entries, skipBelow) {
-  const out = [];
-  for (let i = 0; i < entries.length; i++) {
-    const e = entries[i];
-    if (e.finalKind === 'full' && e.fullText.length >= skipBelow) out.push(i);
-  }
-  return out;
-}
-
-// Demote the highest-indexed demotable entry, reserving the lowest-indexed
-// demotable as the rotation anchor (terminal rotation guarantee). Returns
-// true iff an entry was demoted in this pass.
-function demoteOnePass(entries, demotableIndices) {
-  const anchor = demotableIndices[0];
-  for (let k = demotableIndices.length - 1; k >= 0; k--) {
-    const i = demotableIndices[k];
-    if (i === anchor) continue;
-    entries[i].finalKind = 'reminder';
-    return true;
-  }
-  return false;
-}
-
 function demoteToFit(entries, options) {
   const opts = options || {};
   const limit = opts.limit;

--- a/plugins/synapsys/scripts/synapsys-list.js
+++ b/plugins/synapsys/scripts/synapsys-list.js
@@ -51,6 +51,9 @@ try {
 } catch {
   __ledger = { memories: {} };
 }
+// Reads ledger `injectedCount`: emissions this session that bumped the ledger
+// (full body + policy-driven reminders). Budget-demoted matches are excluded
+// by design (GH-588) so they re-fire in full on the next match.
 function injectedCountFor(name) {
   try {
     const e = __ledger && __ledger.memories && __ledger.memories[name];


### PR DESCRIPTION
## Existing Behavior

- In `budget.js`, the long JSDoc block (Invariants, Entry shape, `@template`/`@param`/`@returns`) sits above `findDemotableIndices` after the complexity-refactor commit in PR #597, even though it documents `demoteToFit`.
- `synapsys-list.js` has no comment on `injectedCountFor()` explaining why budget-demoted matches are absent from the count.
- `README.md` describes `injectedCount` without clarifying that budget-demoted matches are excluded by design.

## Intended New Behavior

- The JSDoc block is moved to sit directly above `demoteToFit` (its correct target). `findDemotableIndices` and `demoteOnePass` retain their existing short inline comments. No logic is changed.
- A three-line comment above `injectedCountFor()` in `synapsys-list.js` explains that ledger-committed emissions (full body + policy-driven reminders) are what the count reflects, and that budget-demoted matches re-fire in full on the next match (GH-588 semantics).
- A sentence appended to the `synapsys:list` paragraph in `README.md` surfaces the same semantics for users.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

No behavior change — this is documentation/comment cleanup only. Existing budget tests (16/16) continue to pass.

To verify the JSDoc is correctly placed:
1. Open `plugins/synapsys/lib/budget.js`
2. Confirm the `/** Reverse-walk demotion … */` JSDoc block appears immediately above `function demoteToFit`
3. Confirm `findDemotableIndices` and `demoteOnePass` each have only their short one-line inline comments

To verify the semantics note is present:
1. Open `plugins/synapsys/scripts/synapsys-list.js` — confirm the three-line comment above `injectedCountFor()` references GH-588 and budget-demoted matches
2. Open `plugins/synapsys/README.md` — confirm the `synapsys:list` paragraph ends with the sentence about budget-demoted matches re-firing in full on the next match

Related: GH-588, PR #597

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and README updates only; no changes to injection, budget, or ledger logic.
> 
> **Overview**
> Documentation-only follow-up to GH-588: no runtime behavior changes.
> 
> In **`budget.js`**, the long JSDoc for reverse-walk demotion is moved to sit directly above **`demoteToFit`** (after a refactor had left it on **`findDemotableIndices`**). **`findDemotableIndices`** and **`demoteOnePass`** keep short inline comments only; demotion logic is unchanged.
> 
> **`synapsys-list.js`** and **`README.md`** now document that **`injectedCount`** reflects ledger-committed injections (full bodies and policy-driven reminders), not budget-demoted matches, so demoted matches can re-fire in full on the next trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e1458d826b59da590554a2c0073b79128f43b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->