### PR TITLE
feat(work): default WORK_TEST_STRATEGY_VALIDATOR on — GH-590 + GH-610 both landed

### DIFF
--- a/plugins/work/CLAUDE.md
+++ b/plugins/work/CLAUDE.md
@@ -60,12 +60,13 @@ See **[AGENTS.md](./AGENTS.md)** for the agent catalog. See **[docs/README.md](.
 
 ### Feature Flags
 
-- `WORK_TEST_STRATEGY_VALIDATOR` (default `0`) — gates the GH-590 tasks-draft
+- `WORK_TEST_STRATEGY_VALIDATOR` (default `1`) — gates the GH-590 tasks-draft
   Test Strategy validator (enum-driven `### Test Strategy` blocks, command-
-  existence dispatcher, and TDD-ownership graph). Set to `1` to enable the new
-  draft-time validators in `work-tasks` draft phase; leave at `0` (the default)
-  to preserve the legacy `### Test Command` path so in-flight `tasks.md` files
-  are not blocked mid-stream. Read via `getConfig('WORK_TEST_STRATEGY_VALIDATOR')`.
+  existence dispatcher, and TDD-ownership graph) plus the GH-610 implement-side
+  synthesis/citation consumer. Default `1` (on) now that both GH-590 and GH-610
+  have landed. Set to `0` to fall back to the legacy `### Test Command` path
+  (e.g. for in-flight `tasks.md` files authored before GH-590). Read via
+  `getConfig('WORK_TEST_STRATEGY_VALIDATOR')`.
 
   **Implement-side synthesis flow.** When the flag is ON and a task carries a
   `### Test Strategy` block but no legacy `### Test Command`, the implement side

--- a/plugins/work/docs/test-strategy-kinds.md
+++ b/plugins/work/docs/test-strategy-kinds.md
@@ -58,4 +58,4 @@ cites: server/api/admin/general-settings.router.ts
 
 ## Feature flag
 
-The draft-time enum validator is gated by `WORK_TEST_STRATEGY_VALIDATOR=1` (default `0`). Until set in `.envrc`, in-flight tasks using the legacy `### Test Command` shell line continue to validate so authors are not blocked mid-stream.
+The draft-time enum validator (and the GH-610 implement-side synthesis/citation consumer) is gated by `WORK_TEST_STRATEGY_VALIDATOR` (default `1`, on, now that GH-590 and GH-610 have landed). Set `WORK_TEST_STRATEGY_VALIDATOR=0` in `.envrc` to fall back to the legacy `### Test Command` shell line for in-flight tasks authored before GH-590.

--- a/plugins/work/scripts/workflows/lib/__tests__/config-test-strategy-flag.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/config-test-strategy-flag.test.js
@@ -84,12 +84,12 @@ describe('config — WORK_TEST_STRATEGY_VALIDATOR feature flag (AC17)', () => {
     }
   });
 
-  it('defaults to "0" when WORK_TEST_STRATEGY_VALIDATOR is unset', () => {
+  it('defaults to "1" when WORK_TEST_STRATEGY_VALIDATOR is unset', () => {
     const config = freshRequire({ [FLAG_KEY]: undefined });
     assert.equal(
       config.WORK_TEST_STRATEGY_VALIDATOR,
-      '0',
-      'flag should default to "0" (off) when env var is not set',
+      '1',
+      'flag should default to "1" (on) when env var is not set — GH-590 + GH-610 have landed',
     );
   });
 

--- a/plugins/work/scripts/workflows/lib/config.js
+++ b/plugins/work/scripts/workflows/lib/config.js
@@ -140,10 +140,13 @@ const config = {
   SCRIPT_RUN_AFFECTED_INTEGRATION: process.env.SCRIPT_RUN_AFFECTED_INTEGRATION || '',
   SCRIPT_RUN_AFFECTED_E2E: process.env.SCRIPT_RUN_AFFECTED_E2E || '',
 
-  // GH-590 (AC17) — feature flag for the new tasks-draft Test Strategy validator
-  // (enum + command-existence dispatcher + TDD-ownership graph). Default '0' (off)
-  // so in-flight tasks.md files are not blocked mid-stream. Set to '1' to enable.
-  WORK_TEST_STRATEGY_VALIDATOR: process.env.WORK_TEST_STRATEGY_VALIDATOR || '0',
+  // GH-590 (AC17) — feature flag for the tasks-draft Test Strategy validator
+  // (enum + command-existence dispatcher + TDD-ownership graph) and the GH-610
+  // implement-side synthesis/citation consumer. Default '1' (on) now that both
+  // the draft validator (GH-590) and the implement-gate/tdd-phase-state/stop-hook
+  // wiring (GH-610) have landed. Set to '0' to fall back to the legacy
+  // `### Test Command` path (e.g. for in-flight tasks.md authored pre-GH-590).
+  WORK_TEST_STRATEGY_VALIDATOR: process.env.WORK_TEST_STRATEGY_VALIDATOR || '1',
 
   // Web apps list — each repo defines its own via WEB_APPS env var (JSON)
   // Example .env: WEB_APPS='[{"name":"my-app","defaultPort":3000,"type":"vite"}]'

--- a/plugins/work/scripts/workflows/work-tasks/__tests__/draft-shared-component.test.js
+++ b/plugins/work/scripts/workflows/work-tasks/__tests__/draft-shared-component.test.js
@@ -8,6 +8,25 @@ const path = require('node:path');
 
 const draft = require('../lib/phases/draft');
 
+// These tests exercise the legacy shared-scaffold rule in isolation, with
+// minimal fixtures that carry no `### Test Strategy` block. Now that
+// WORK_TEST_STRATEGY_VALIDATOR defaults to `1`, the unrelated GH-590
+// TDD-ownership-graph validator would otherwise fire on these fixtures and
+// add spurious errors. Pin the flag off so this suite tests only the
+// shared-scaffold rule it is about. (Test Strategy validation has its own
+// dedicated suites.)
+const ORIGINAL_STRATEGY_FLAG = process.env.WORK_TEST_STRATEGY_VALIDATOR;
+test.before(() => {
+  process.env.WORK_TEST_STRATEGY_VALIDATOR = '0';
+});
+test.after(() => {
+  if (ORIGINAL_STRATEGY_FLAG === undefined) {
+    delete process.env.WORK_TEST_STRATEGY_VALIDATOR;
+  } else {
+    process.env.WORK_TEST_STRATEGY_VALIDATOR = ORIGINAL_STRATEGY_FLAG;
+  }
+});
+
 function mkDir(files) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'draft-shared-'));
   const tasksDir = path.join(root, 'ECHO-9999');


### PR DESCRIPTION
## Existing Behavior

- `WORK_TEST_STRATEGY_VALIDATOR` defaults to `'0'` (off) in `plugins/work/scripts/workflows/lib/config.js`, keeping the Test Strategy validator and implement-side synthesis disabled for all users.
- The draft-time validator (GH-590: enum `### Test Strategy` blocks, command-existence dispatcher, TDD-ownership graph, peer-citation validation) and the implement-side consumer (GH-610: `resolveTaskTestExecution` synthesis, citation evidence in `tdd-phase-state`, `enforce-tdd-on-stop` hook) are both wired but inactive by default.
- Docs and tests assert the flag defaults to `'0'`.

## Intended New Behavior

- `WORK_TEST_STRATEGY_VALIDATOR` defaults to `'1'` (on) — both the draft-time validator (GH-590) and the implement-side synthesis/citation consumer (GH-610) are now active for all plugin users out of the box.
- Setting `WORK_TEST_STRATEGY_VALIDATOR=0` in `.envrc` restores the legacy `### Test Command` path for in-flight `tasks.md` files authored before GH-590.
- `CLAUDE.md` and `docs/test-strategy-kinds.md` updated to document the new default and escape hatch.
- The test asserting the unset default now expects `'1'`.

## Dev Checks
- [Y] Functionality can be toggled on/off — `WORK_TEST_STRATEGY_VALIDATOR=0` restores legacy path
- [Y] New code is covered by unit/integration tests — `config-test-strategy-flag.test.js` updated to assert `'1'`
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work — `CLAUDE.md` and `docs/test-strategy-kinds.md` updated
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

`node --test` across the touched-area suites (lib, work-tasks/phases, work-implement, work) with the new default active: **2559 passed, 0 failed**.

To verify the flag flip locally:

1. Pull `main`, check out this branch.
2. Confirm default is on: `node -e "const c = require('./plugins/work/scripts/workflows/lib/config.js'); console.log(c.WORK_TEST_STRATEGY_VALIDATOR)"` — should print `1`.
3. Run the unit test directly: `node --test plugins/work/scripts/workflows/lib/__tests__/config-test-strategy-flag.test.js` — all cases pass.
4. To verify the opt-out path: set `WORK_TEST_STRATEGY_VALIDATOR=0` in `.envrc` (or inline: `WORK_TEST_STRATEGY_VALIDATOR=0 node -e "..."`) — value reads `0`, validator + synthesis skipped, legacy `### Test Command` path active.

**Risk note:** medium blast radius — activates the validator and implement-side synthesis for all plugin users by default. Reversible per-environment via `WORK_TEST_STRATEGY_VALIDATOR=0` in `.envrc`. Closes the enablement step for GH-590 and GH-610.

Closes #590. Relates to #610 (PR #612).

### Test Results

```
node --test (lib + work-tasks/phases + work-implement + work suites)
2559 passed, 0 failed
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on activates draft validation and implement TDD wiring for every consumer; legacy `tasks.md` without Test Strategy may fail until `WORK_TEST_STRATEGY_VALIDATOR=0` is set.
> 
> **Overview**
> Turns on **`WORK_TEST_STRATEGY_VALIDATOR` by default** (`'1'` in `config.js` when the env var is unset), so GH-590 draft-time `### Test Strategy` validation and GH-610 implement-side command synthesis / citation evidence run for all plugin users without opting in.
> 
> **`WORK_TEST_STRATEGY_VALIDATOR=0`** in `.envrc` remains the escape hatch for legacy `### Test Command`–only `tasks.md`. **`CLAUDE.md`** and **`docs/test-strategy-kinds.md`** now describe default-on behavior and that opt-out.
> 
> **`draft-shared-component.test.js`** sets the flag to `'0'` in `before`/`after` so minimal fixtures without Test Strategy blocks are not failed by the TDD-ownership graph while this suite still tests only the shared-scaffold rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360d00b29ba7a99d2987f0a54586e49e77c21365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->