### PR TITLE
refactor(follow-up): clear /follow-up subsystem from quality allowlist

### DIFF
--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -68,7 +68,6 @@ plugins/work/scripts/workflows/check/hooks/check-start-env.js
 plugins/work/scripts/workflows/work/engine/transition-step.js
 plugins/work/scripts/workflows/work/hooks/work-suggestion-replies.js
 plugins/work/scripts/workflows/check/hooks/check-validate-reports.js
-plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
 plugins/work/scripts/workflows/lib/hooks/enforce-ui-imports.js
 plugins/work/scripts/workflows/work-spec/lib/phases/surface_audit.js
 plugins/work/scripts/workflows/work/agents/commit-writer/commit-writer-block-write.js
@@ -81,7 +80,6 @@ plugins/work/scripts/workflows/work/work-state/parallel-workers.js
 plugins/work/scripts/workflows/work/gates/check-gate.js
 plugins/work/scripts/workflows/lib/config.js
 plugins/work/scripts/workflows/work/lib/parse-gherkin.js
-plugins/work/scripts/workflows/follow-up/follow-up-next.js
 plugins/work/scripts/workflows/work-spec/lib/phases/reuse_audit.js
 plugins/work/scripts/workflows/work/engine/unstick-complete.js
 plugins/work/scripts/workflows/work/lib/gherkin-task-refs.js
@@ -91,7 +89,6 @@ plugins/work/scripts/workflows/work/engine/cli.js
 plugins/work/scripts/workflows/work/lib/work-actions.js
 plugins/work/scripts/workflows/lib/agent-detection.js
 plugins/work/scripts/workflows/lib/hooks/enforce-screenshot-requirement.js
-plugins/work/scripts/workflows/follow-up/lib/steps/fix-ci.js
 plugins/work/scripts/workflows/work/hooks/protect-task-scope.js
 plugins/work/scripts/workflows/check/hooks/enforce-env-start-failure.js
 plugins/work/scripts/workflows/work/steps/implement.js
@@ -102,7 +99,6 @@ plugins/work/scripts/workflows/check/hooks/check-generate-summary.js
 plugins/work/scripts/workflows/lib/request-index.js
 plugins/work/scripts/workflows/lib/hooks/policies/task-description-quality.js
 plugins/work/scripts/workflows/work/engine/inspect.js
-plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
 plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
 plugins/work/scripts/workflows/work/work-state/task-readiness.js
 plugins/work/scripts/workflows/work/work-state/graph-validation.js
@@ -154,7 +150,6 @@ plugins/work/scripts/workflows/work-pr/agents/pr-generator/pr-generator-validato
 plugins/work/scripts/workflows/check2/lib/steps/phase1-agents.js
 plugins/work/scripts/workflows/work-spec/lib/phases/kind_checks.js
 plugins/work/scripts/workflows/check/scripts/write-completion-report.js
-plugins/work/scripts/workflows/follow-up/lib/steps/triage.js
 plugins/work/scripts/workflows/work-ci/lib/phases/wait_merge.js
 plugins/work/scripts/workflows/work-completion-checker/lib/phases/kind_checks.js
 plugins/work/scripts/workflows/work-task-review/lib/phases/kind_checks.js
@@ -174,7 +169,6 @@ plugins/work/scripts/workflows/work/lib/task-graph.js
 plugins/work/scripts/workflows/work-brief/lib/phases/inputs.js
 plugins/work/scripts/workflows/check2/hooks/check-auto-advance.js
 plugins/work/scripts/workflows/work-tasks/lib/phases/requirements_extract.js
-plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
 plugins/work/scripts/workflows/work/lib/debug-log.js
 plugins/work/scripts/workflows/work/agents/commit-writer/commit-writer-precommit-guard.js
 plugins/work/scripts/workflows/work-task-review/lib/phases/reuse_check.js
@@ -204,7 +198,6 @@ plugins/work/scripts/workflows/work/agents/developer-quality-gate.js
 plugins/work/scripts/workflows/work-code-checker/lib/kind-checks/devops.js
 plugins/work/scripts/workflows/work-task-review/lib/kind-checks/shared.js
 plugins/work/scripts/workflows/work-task-review/lib/phases/report.js
-plugins/work/scripts/workflows/follow-up/lib/steps/push-retry.js
 plugins/work/scripts/workflows/lib/hooks/policies/step-gate.js
 plugins/work/scripts/workflows/lib/scripts/get-ticket-id.js
 plugins/work/scripts/workflows/work-tasks/lib/phases/memorize.js
@@ -221,7 +214,6 @@ plugins/work/scripts/workflows/work/lib/git-utils.js
 plugins/work/scripts/workflows/work-pr-reviewer/lib/kind-checks/e2e.js
 plugins/work/scripts/workflows/check2/lib/steps/run-e2e.js
 plugins/work/scripts/workflows/check2/lib/steps/run-integration.js
-plugins/work/scripts/workflows/follow-up/lib/steps/report.js
 plugins/work/scripts/workflows/work-task-review/lib/kind-checks/wiring.js
 plugins/work/scripts/workflows/work/scripts/gh-exec.js
 plugins/work/scripts/workflows/work/steps/task-advance.js

--- a/plugins/work/scripts/workflows/check2/check-next.js
+++ b/plugins/work/scripts/workflows/check2/check-next.js
@@ -16,40 +16,14 @@ const fs = require('fs');
 const path = require('path');
 
 if (require.main === module) {
-  process.on('uncaughtException', (err) => {
-    console.error(
-      JSON.stringify({
-        type: 'check_instruction',
-        action: 'blocked',
-        reason: `Uncaught exception: ${err.message}`,
-        stack: err.stack,
-      })
-    );
-    process.exit(1);
-  });
-  process.on('unhandledRejection', (err) => {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(
-      JSON.stringify({
-        type: 'check_instruction',
-        action: 'blocked',
-        reason: `Unhandled rejection: ${msg}`,
-      })
-    );
-    process.exit(1);
-  });
+  require('../lib/instruction-guards').installInstructionGuards('check_instruction');
 }
 
 // ─── Resolve paths ──────────────────────────────────────────────────────────
-const { resolvePluginPaths } = require(
-  path.join(__dirname, '..', 'work', 'lib', 'resolve-plugin-root')
+const { resolvePluginConfig } = require('../lib/plugin-config');
+const { workDir, libDir, getConfig, WORKTREES_BASE, TASKS_BASE } = resolvePluginConfig(
+  path.join(__dirname, '..', 'work')
 );
-const { workDir, libDir } = resolvePluginPaths(path.join(__dirname, '..', 'work'), 2);
-const getConfig = require(path.join(libDir, 'get-config'));
-
-const WORKTREES_BASE = getConfig('WORKTREES_BASE') || '';
-const TASKS_BASE =
-  getConfig('TASKS_BASE') || (WORKTREES_BASE ? path.join(WORKTREES_BASE, 'tasks') : '');
 
 if (!TASKS_BASE) {
   console.log(

--- a/plugins/work/scripts/workflows/check2/check-next.js
+++ b/plugins/work/scripts/workflows/check2/check-next.js
@@ -21,9 +21,7 @@ if (require.main === module) {
 
 // ─── Resolve paths ──────────────────────────────────────────────────────────
 const { resolvePluginConfig } = require('../lib/plugin-config');
-const { workDir, libDir, getConfig, WORKTREES_BASE, TASKS_BASE } = resolvePluginConfig(
-  path.join(__dirname, '..', 'work')
-);
+const { libDir, TASKS_BASE } = resolvePluginConfig(path.join(__dirname, '..', 'work'));
 
 if (!TASKS_BASE) {
   console.log(

--- a/plugins/work/scripts/workflows/check2/hooks/check-auto-advance.js
+++ b/plugins/work/scripts/workflows/check2/hooks/check-auto-advance.js
@@ -33,14 +33,8 @@ function main() {
   if (transcriptPath.includes('/subagents/')) process.exit(0);
 
   // Guard: find active /check2 session via marker file
-  const { resolvePluginPaths } = require(
-    path.join(__dirname, '..', '..', 'work', 'lib', 'resolve-plugin-root')
-  );
-  const { libDir } = resolvePluginPaths(path.join(__dirname, '..', '..', 'work'), 2);
-  const getConfig = require(path.join(libDir, 'get-config'));
-  const WORKTREES_BASE = getConfig('WORKTREES_BASE') || '';
-  const TASKS_BASE =
-    getConfig('TASKS_BASE') || (WORKTREES_BASE ? path.join(WORKTREES_BASE, 'tasks') : '');
+  const { resolvePluginConfig } = require('../../lib/plugin-config');
+  const { TASKS_BASE } = resolvePluginConfig(path.join(__dirname, '..', '..', 'work'));
   if (!TASKS_BASE) process.exit(0);
 
   // Find THIS terminal's .check2-orchestrator.pid marker. findActiveMarker scopes

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -29,40 +29,14 @@ const { detectDefaultBranch, loadPrDiffFiles } = require('./lib/repo-meta');
 const { buildClassifierCtx } = require('./lib/classifier-ctx');
 
 if (require.main === module) {
-  process.on('uncaughtException', (err) => {
-    console.error(
-      JSON.stringify({
-        type: 'follow_up_instruction',
-        action: 'blocked',
-        reason: `Uncaught exception: ${err.message}`,
-        stack: err.stack,
-      })
-    );
-    process.exit(1);
-  });
-  process.on('unhandledRejection', (err) => {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(
-      JSON.stringify({
-        type: 'follow_up_instruction',
-        action: 'blocked',
-        reason: `Unhandled rejection: ${msg}`,
-      })
-    );
-    process.exit(1);
-  });
+  require('../lib/instruction-guards').installInstructionGuards('follow_up_instruction');
 }
 
 // ─── Resolve paths ──────────────────────────────────────────────────────────
-const { resolvePluginPaths } = require(
-  path.join(__dirname, '..', 'work', 'lib', 'resolve-plugin-root')
+const { resolvePluginConfig } = require('../lib/plugin-config');
+const { libDir, WORKTREES_BASE, TASKS_BASE } = resolvePluginConfig(
+  path.join(__dirname, '..', 'work')
 );
-const { libDir } = resolvePluginPaths(path.join(__dirname, '..', 'work'), 2);
-const getConfig = require(path.join(libDir, 'get-config'));
-
-const WORKTREES_BASE = getConfig('WORKTREES_BASE') || '';
-const TASKS_BASE =
-  getConfig('TASKS_BASE') || (WORKTREES_BASE ? path.join(WORKTREES_BASE, 'tasks') : '');
 const MAIN_WORKTREE_FOLDER = process.env.REPO_NAME || 'my-project';
 
 if (!TASKS_BASE) {
@@ -99,78 +73,168 @@ const { isInfraFailure, isStale } = require(path.join(__dirname, 'lib', 'infra-p
 
 // ─── State management ───────────────────────────────────────────────────────
 
-function stateFile(ticketId) {
-  return path.join(TASKS_BASE, ticketId, '.follow-up-state.json');
-}
-
-function loadState(ticketId) {
-  try {
-    return JSON.parse(fs.readFileSync(stateFile(ticketId), 'utf8'));
-  } catch {
-    return null;
-  }
-}
-
-function saveState(ticketId, state) {
-  const dir = path.join(TASKS_BASE, ticketId);
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(stateFile(ticketId), JSON.stringify(state, null, 2));
-}
-
-function initState(ticketId, prNumber) {
-  return {
-    ticketId,
-    prNumber: prNumber || null,
-    currentStep: STEPS[0],
-    status: 'in_progress',
-    dispatched: null,
-    attempt: 0,
-    maxAttempts: 40,
-    // monitor cache (see infra-patterns.js for invalidation rules)
-    // GH-531 Task 6 (AC10): explicitly reset the push-retry counter so the
-    // cap-exhausted recovery path can't immediately re-trigger after
-    // `reset-follow-up`. Was previously `undefined` (incremented to 1 on
-    // first push-retry), which matches the same observable behavior; the
-    // explicit `0` makes the recovery guarantee inspectable by operators.
-    _pushRetryCount: 0,
-    lastMonitorResult: null,
-    lastMonitorAt: null,
-    failureCategory: null,
-    // Infra-retry telemetry (GH-508 Task 4). `count` tracks how many
-    // infra-retry attempts have been performed for the current PR; `attempts`
-    // records per-attempt diagnostics for the report step (Task 6).
-    infraRetry: { count: 0, attempts: [] },
-    startTime: new Date().toISOString(),
-  };
-}
-
-/**
- * Build a fresh /follow-up state object for `ticketId`, persist it to the
- * canonical state-file path (`TASKS_BASE/<ticket>/.follow-up-state.json`),
- * and return the new state.
- *
- * Idempotent: calling twice overwrites the on-disk state with a fresh one.
- * Used both by the existing init code path in this module and by the
- * `/reset-follow-up` command (Task 2) to re-initialize after push-retry
- * exhaustion (GH-531).
- *
- * @param {string} ticketId — sanitized ticket id (e.g. `GH-999`).
- * @param {object} [opts] — optional overrides.
- * @param {number|null} [opts.prNumber] — preserve an existing PR number across reset.
- * @returns {object} the freshly-initialized state object.
- */
-function initFreshState(ticketId, opts) {
-  const prNumber = opts && opts.prNumber != null ? opts.prNumber : null;
-  const state = initState(ticketId, prNumber);
-  saveState(ticketId, state);
-  return state;
-}
+const { loadState, saveState, initState, initFreshState } =
+  require('./lib/follow-up-state')(TASKS_BASE);
 
 // ─── Core orchestrator loop ─────────────────────────────────────────────────
 
-function getNextInstruction(ticketId, prNumber) {
-  let state = loadState(ticketId) || initState(ticketId, prNumber);
+// Re-verify a saved "complete"/invalid-step state against live GitHub before
+// honoring it. The saved state is a cache of a prior run's decision; if
+// anything changed (new pushes, checks now running, merge state now blocked)
+// we must NOT silently return "Already complete" — that's how PR #1929 cleared
+// its session guard with 9 in-progress checks and 2 unpushed commits.
+//
+// Returns { loop: true } to rewind+continue, or { result } to return.
+function reconcileSavedComplete(state, ticketId) {
+  if (state.prNumber) {
+    let actionable = false;
+    let realBlockers = [];
+    try {
+      const { assessMergeable, hasActionableBlockers } = require(
+        path.join(__dirname, '..', 'work', 'lib', 'pr-mergeable.js')
+      );
+      // hasActionableBlockers centralises the two guards (filter out gh_error
+      // transients, require prState=OPEN) shared with ci-gate.js.
+      const action = hasActionableBlockers(assessMergeable(state.prNumber));
+      actionable = action.actionable;
+      realBlockers = action.realBlockers;
+    } catch {
+      actionable = false;
+    }
+    if (actionable) {
+      const blockerSummary = realBlockers.map((b) => b.kind).join(', ');
+      process.stderr.write(
+        `[follow-up-next] saved state said complete but PR #${state.prNumber} is not mergeable (${blockerSummary}); rewinding and resuming.\n`
+      );
+      state.status = 'in_progress';
+      // Always rewind to 'monitor' (the live CI-rollup read). Hardcoded rather
+      // than STEPS[0] so a future reorder of the step registry can't silently
+      // rewind to whatever happens to be first.
+      state.currentStep = 'monitor';
+      state.dispatched = null;
+      saveState(ticketId, state);
+      return { loop: true };
+    }
+  }
+  saveState(ticketId, state);
+  return {
+    result: { type: 'follow_up_instruction', action: 'complete', summary: 'Already complete.' },
+  };
+}
+
+// Auto-clear stale infra-failure cache before ANY step runs (GH-536 #551
+// round-2 fix). The monitor step's own clearStaleInfraCache only fires when the
+// workflow re-enters monitor — but triage blocks on exitCode 2 without
+// advancing, so subsequent runs only re-execute triage and the cache is never
+// invalidated. Lifting the check here ensures downstream steps (triage, fix-ci,
+// report) also benefit and route the flow back to monitor for a fresh run.
+// Returns true when it rewound to monitor (caller should `continue`).
+function maybeClearStaleInfra(state, ticketId) {
+  const cached = state.lastMonitorResult;
+  if (cached && isInfraFailure(cached.output || '') && isStale(state.lastMonitorAt)) {
+    delete state.lastMonitorResult;
+    delete state.lastMonitorAt;
+    // Rewind to 'monitor' explicitly — see rationale above.
+    state.currentStep = 'monitor';
+    state.dispatched = null;
+    saveState(ticketId, state);
+    return true;
+  }
+  return false;
+}
+
+// action:'surface' is terminal (spec API/Interface Changes — GH-508). Mutate
+// state to route to report and attach a diagnostic summary, but do NOT mark
+// status='complete' so the next /follow-up invocation resumes from a live
+// re-evaluation rather than the cache.
+// The reason may live on the top-level result (legacy shape) or under
+// result.payload.reason (newer shape).
+function surfaceReasonOf(result) {
+  return (result.payload && result.payload.reason) || result.reason || null;
+}
+
+function summaryOf(reportResult) {
+  if (!reportResult) return null;
+  return reportResult.summary || (reportResult.payload && reportResult.payload.summary) || null;
+}
+
+function applySurface(result, state, ctx) {
+  state.currentStep = 'report';
+  // Persist the surface reason as a failureCategory so the next /follow-up
+  // cycle's report step recognises the workflow is still stuck and does NOT
+  // mark status=complete.
+  const reason = surfaceReasonOf(result);
+  if (reason) state.failureCategory = reason;
+
+  // Bug 542-10: build the diagnostic summary BEFORE returning so the
+  // auto-advance hook (which treats `surface` as terminal) shows the
+  // per-attempt GitHub Actions URLs without requiring a second invocation.
+  try {
+    const summary = summaryOf(runStep('report', state, ctx));
+    if (summary) result.payload = Object.assign({}, result.payload || {}, { summary });
+  } catch (_e) {
+    /* fail open — surface still terminal; user can re-run /follow-up */
+  }
+}
+
+// A step returned null → advance. Returns { loop: true } when the step set its
+// own currentStep (looping), or { result } on workflow completion, or
+// { loop: true } after advancing to the next step.
+function advanceStep(state, ticketId, stepIdx) {
+  // Step changed currentStep (e.g., triage → fix-ci, or push-retry → monitor)
+  if (state.currentStep !== STEPS[stepIdx]) {
+    state.dispatched = null;
+    saveState(ticketId, state);
+    return { loop: true };
+  }
+
+  const nextIdx = stepIdx + 1;
+  if (nextIdx >= STEPS.length) {
+    state.status = 'complete';
+    saveState(ticketId, state);
+    return {
+      result: {
+        type: 'follow_up_instruction',
+        action: 'complete',
+        summary: `Follow-up complete for ${ticketId}.`,
+      },
+    };
+  }
+
+  state.currentStep = STEPS[nextIdx];
+  state.dispatched = null;
+  saveState(ticketId, state);
+  return { loop: true };
+}
+
+function loadOrInitState(ticketId, prNumber) {
+  const state = loadState(ticketId) || initState(ticketId, prNumber);
   if (prNumber && !state.prNumber) state.prNumber = prNumber;
+  return state;
+}
+
+function isTerminalState(state) {
+  return state.status === 'complete' || !STEPS.includes(state.currentStep);
+}
+
+// Run a single orchestrator iteration. Returns { loop: true } to continue the
+// loop, or { result } to return that instruction to the caller.
+function stepOnce(state, ticketId, ctx) {
+  if (isTerminalState(state)) return reconcileSavedComplete(state, ticketId);
+  if (maybeClearStaleInfra(state, ticketId)) return { loop: true };
+
+  const stepIdx = STEPS.indexOf(state.currentStep);
+  const result = runStep(state.currentStep, state, ctx);
+  if (result) {
+    if (result.action === 'surface') applySurface(result, state, ctx);
+    saveState(ticketId, state);
+    return { result };
+  }
+  return advanceStep(state, ticketId, stepIdx);
+}
+
+function getNextInstruction(ticketId, prNumber) {
+  const state = loadOrInitState(ticketId, prNumber);
 
   const tasksDir = path.join(TASKS_BASE, ticketId);
   const candidateWorktree = path.join(WORKTREES_BASE, `${MAIN_WORKTREE_FOLDER}-${ticketId}`);
@@ -190,139 +254,9 @@ function getNextInstruction(ticketId, prNumber) {
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const ctx = freshCtx();
-    if (state.status === 'complete' || !STEPS.includes(state.currentStep)) {
-      // Re-verify against GitHub before honoring a saved "complete". The
-      // saved state is a cache of a prior run's decision; if anything has
-      // changed (new pushes, checks now running, merge state now blocked)
-      // we must NOT silently return "Already complete" — that's how PR
-      // #1929 cleared its session guard with 9 in-progress checks and 2
-      // unpushed commits.
-      //
-      // Rule: honor the cache only when the PR mirrors a clickable
-      // Squash-and-merge button (mergeable === true). Otherwise rewind
-      // status to in_progress and let the loop re-evaluate the current
-      // step from live GitHub state.
-      if (state.prNumber) {
-        let liveMergeable = null;
-        let actionable = false;
-        let realBlockers = [];
-        try {
-          const { assessMergeable, hasActionableBlockers } = require(
-            path.join(__dirname, '..', 'work', 'lib', 'pr-mergeable.js')
-          );
-          liveMergeable = assessMergeable(state.prNumber);
-          // hasActionableBlockers centralises the two guards (filter out
-          // gh_error transients, require prState=OPEN) shared with
-          // ci-gate.js. See pr-mergeable.js for the full rationale.
-          const action = hasActionableBlockers(liveMergeable);
-          actionable = action.actionable;
-          realBlockers = action.realBlockers;
-        } catch {
-          liveMergeable = null;
-        }
-        if (actionable) {
-          const blockerSummary = realBlockers.map((b) => b.kind).join(', ');
-          process.stderr.write(
-            `[follow-up-next] saved state said complete but PR #${state.prNumber} is not mergeable (${blockerSummary}); rewinding and resuming.\n`
-          );
-          state.status = 'in_progress';
-          // Always rewind to 'monitor' (the live CI-rollup read). Hardcoded
-          // rather than STEPS[0] so a future reorder of the step registry
-          // can't silently rewind to whatever happens to be first.
-          state.currentStep = 'monitor';
-          state.dispatched = null;
-          saveState(ticketId, state);
-          continue;
-        }
-      }
-      saveState(ticketId, state);
-      return { type: 'follow_up_instruction', action: 'complete', summary: 'Already complete.' };
-    }
-
-    // Auto-clear stale infra-failure cache before ANY step runs (GH-536 #551
-    // round-2 fix). The monitor step's own clearStaleInfraCache only fires
-    // when the workflow re-enters monitor — but triage blocks on exitCode 2
-    // without advancing, so subsequent runs only re-execute triage and the
-    // cache is never invalidated. Lifting the check here ensures downstream
-    // steps (triage, fix-ci, report) also benefit and route the flow back
-    // to monitor for a fresh execution.
-    const cached = state.lastMonitorResult;
-    if (cached && isInfraFailure(cached.output || '') && isStale(state.lastMonitorAt)) {
-      delete state.lastMonitorResult;
-      delete state.lastMonitorAt;
-      // Rewind to 'monitor' explicitly — see rationale above.
-      state.currentStep = 'monitor';
-      state.dispatched = null;
-      saveState(ticketId, state);
-      continue;
-    }
-
-    const stepIdx = STEPS.indexOf(state.currentStep);
-    const result = runStep(state.currentStep, state, ctx);
-
-    if (result) {
-      // action:'surface' is terminal (spec API/Interface Changes — GH-508).
-      // Stop the loop without marking status='complete' so the next /follow-up
-      // invocation can resume from a live re-evaluation rather than the cache.
-      if (result.action === 'surface') {
-        state.currentStep = 'report';
-        // Persist the surface reason as a failureCategory so the next
-        // /follow-up cycle's report step recognises the workflow is still
-        // stuck and does NOT mark status=complete. The reason may live on
-        // the top-level result (legacy shape) or under result.payload.reason
-        // (newer shape, mirrors auto-advance hook).
-        const surfaceReason = (result.payload && result.payload.reason) || result.reason || null;
-        if (surfaceReason) {
-          state.failureCategory = surfaceReason;
-        }
-        // Bug 542-10: build the diagnostic summary BEFORE returning so the
-        // auto-advance hook (which treats `surface` as terminal) shows the
-        // per-attempt GitHub Actions URLs without requiring a second
-        // /follow-up invocation.
-        try {
-          const reportResult = runStep('report', state, ctx);
-          const summary =
-            (reportResult &&
-              (reportResult.summary || (reportResult.payload && reportResult.payload.summary))) ||
-            null;
-          if (summary) {
-            result.payload = Object.assign({}, result.payload || {}, { summary });
-          }
-        } catch (_e) {
-          /* fail open — surface still terminal; user can re-run /follow-up */
-        }
-        saveState(ticketId, state);
-        return result;
-      }
-      saveState(ticketId, state);
-      return result;
-    }
-
-    // null → advance (unless step set currentStep for looping)
-    const currentStepAfter = state.currentStep;
-    if (currentStepAfter !== STEPS[stepIdx]) {
-      // Step changed currentStep (e.g., triage → fix-ci, or push-retry → monitor)
-      state.dispatched = null;
-      saveState(ticketId, state);
-      continue;
-    }
-
-    // Normal advance to next step
-    const nextIdx = stepIdx + 1;
-    if (nextIdx >= STEPS.length) {
-      state.status = 'complete';
-      saveState(ticketId, state);
-      return {
-        type: 'follow_up_instruction',
-        action: 'complete',
-        summary: `Follow-up complete for ${ticketId}.`,
-      };
-    }
-
-    state.currentStep = STEPS[nextIdx];
-    state.dispatched = null;
-    saveState(ticketId, state);
+    const outcome = stepOnce(state, ticketId, freshCtx());
+    if (outcome.loop) continue;
+    return outcome.result;
   }
 }
 

--- a/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
+++ b/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
@@ -10,70 +10,57 @@
 const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { resolvePluginConfig } = require('../../lib/plugin-config');
 
 process.on('uncaughtException', () => process.exit(0));
 process.on('unhandledRejection', () => process.exit(0));
 
-function main() {
-  let hookData;
+// Parse the PostToolUse hook payload from stdin. Returns null on any error.
+function readHookData() {
   try {
-    const input = fs.readFileSync(0, 'utf8');
-    hookData = JSON.parse(input);
+    return JSON.parse(fs.readFileSync(0, 'utf8'));
   } catch {
-    process.exit(0);
+    return null;
   }
+}
 
-  const transcriptPath = hookData?.transcript_path || '';
-  if (transcriptPath.includes('/subagents/')) process.exit(0);
-
-  const { resolvePluginPaths } = require(
-    path.join(__dirname, '..', '..', 'work', 'lib', 'resolve-plugin-root')
-  );
-  const { libDir } = resolvePluginPaths(path.join(__dirname, '..', '..', 'work'), 2);
-  const getConfig = require(path.join(libDir, 'get-config'));
-  const WORKTREES_BASE = getConfig('WORKTREES_BASE') || '';
-  const TASKS_BASE =
-    getConfig('TASKS_BASE') || (WORKTREES_BASE ? path.join(WORKTREES_BASE, 'tasks') : '');
-  if (!TASKS_BASE) process.exit(0);
-
-  // Find THIS terminal's .follow-up-orchestrator.pid marker. findActiveMarker
-  // scopes by owning session id + worktree root so a hook firing in one agent
-  // never advances another agent's workflow.
+// Find THIS terminal's .follow-up-orchestrator.pid marker. findActiveMarker
+// scopes by owning session id + worktree root so a hook firing in one agent
+// never advances another agent's workflow. Returns null when missing or stale.
+function findMarker(TASKS_BASE) {
   const { findActiveMarker } = require(path.join(__dirname, '..', '..', 'work', 'lib', 'marker'));
   const marker = findActiveMarker(TASKS_BASE, '.follow-up-orchestrator.pid');
-  if (!marker) process.exit(0);
-
+  if (!marker) return null;
   const markerAge = Date.now() - new Date(marker.startedAt).getTime();
-  if (markerAge > 12 * 60 * 60 * 1000) process.exit(0);
+  if (markerAge > 12 * 60 * 60 * 1000) return null;
+  return marker;
+}
 
+// Run the orchestrator for `ticket` and return its parsed instruction, or null.
+function runFollowUpNext(ticket) {
   // Test seam: an absolute path override lets the surface/blocked test stub
   // follow-up-next.js without staging the entire plugin tree. Production code
   // never sets FOLLOW_UP_NEXT_PATH; default resolves siblings as before.
   const nextPath =
     process.env.FOLLOW_UP_NEXT_PATH || path.join(__dirname, '..', 'follow-up-next.js');
-  let result;
   try {
-    result = execFileSync(process.execPath, [nextPath, marker.ticket], {
+    const result = execFileSync(process.execPath, [nextPath, ticket], {
       encoding: 'utf8',
       timeout: 130000, // monitor can take up to 2 min
       stdio: ['pipe', 'pipe', 'pipe'],
     });
+    return JSON.parse(result);
   } catch {
-    process.exit(0);
+    return null;
   }
+}
 
-  let instruction;
+// Persist the latest instruction so the Stop hook (session-guard) can surface
+// it inline when the agent tries to stop. Without this the agent gets only
+// "go run follow-up-next.js again" with no context. Fail-open.
+function persistInstruction(TASKS_BASE, ticket, instruction) {
   try {
-    instruction = JSON.parse(result);
-  } catch {
-    process.exit(0);
-  }
-
-  // Persist the latest instruction so the Stop hook (session-guard) can
-  // surface it inline when the agent tries to stop. Without this the agent
-  // gets only "go run follow-up-next.js again" with no context.
-  try {
-    const instructionPath = path.join(TASKS_BASE, marker.ticket, '.follow-up-next.json');
+    const instructionPath = path.join(TASKS_BASE, ticket, '.follow-up-next.json');
     if (instruction.action === 'complete') {
       // Clean up so a future run doesn't surface a stale completion blob
       if (fs.existsSync(instructionPath)) fs.unlinkSync(instructionPath);
@@ -83,30 +70,47 @@ function main() {
   } catch {
     /* fail-open */
   }
+}
 
-  if (instruction.action === 'execute') {
-    console.log('\n═══ FOLLOW-UP2: NEXT STEP ═══');
-    console.log(JSON.stringify(instruction, null, 2));
-    console.log('══════════════════════════════\n');
-  } else if (instruction.action === 'complete') {
-    console.log('\n═══ FOLLOW-UP2: COMPLETE ═══');
-    console.log(JSON.stringify(instruction, null, 2));
-    console.log('════════════════════════════\n');
-  } else if (instruction.action === 'blocked') {
-    console.log('\n═══ FOLLOW-UP2: BLOCKED ═══');
-    console.log(JSON.stringify(instruction, null, 2));
-    console.log('═══════════════════════════\n');
-  } else if (instruction.action === 'surface') {
-    // R13: Treat 'surface' as terminal (same as 'blocked'). The orchestrator
-    // emits this when it needs manual user intervention — e.g. infra-stuck
-    // after 3 retries. We stop the auto-advance loop and surface the reason.
+const BANNERS = {
+  execute: ['═══ FOLLOW-UP2: NEXT STEP ═══', '══════════════════════════════'],
+  complete: ['═══ FOLLOW-UP2: COMPLETE ═══', '════════════════════════════'],
+  blocked: ['═══ FOLLOW-UP2: BLOCKED ═══', '═══════════════════════════'],
+  // R13: 'surface' is terminal (same as 'blocked'). The orchestrator emits it
+  // when it needs manual user intervention — e.g. infra-stuck after 3 retries.
+  surface: ['═══ FOLLOW-UP2: SURFACE ═══', '═══════════════════════════'],
+};
+
+function printInstruction(instruction) {
+  const banner = BANNERS[instruction.action];
+  if (!banner) return;
+  console.log('\n' + banner[0]);
+  if (instruction.action === 'surface') {
     const reason = (instruction.payload && instruction.payload.reason) || 'unknown';
-    console.log('\n═══ FOLLOW-UP2: SURFACE ═══');
     console.log(`reason: ${reason}`);
-    console.log(JSON.stringify(instruction, null, 2));
-    console.log('═══════════════════════════\n');
   }
+  console.log(JSON.stringify(instruction, null, 2));
+  console.log(banner[1] + '\n');
+}
 
+function main() {
+  const hookData = readHookData();
+  if (!hookData) process.exit(0);
+
+  const transcriptPath = hookData?.transcript_path || '';
+  if (transcriptPath.includes('/subagents/')) process.exit(0);
+
+  const { TASKS_BASE } = resolvePluginConfig(path.join(__dirname, '..', '..', 'work'));
+  if (!TASKS_BASE) process.exit(0);
+
+  const marker = findMarker(TASKS_BASE);
+  if (!marker) process.exit(0);
+
+  const instruction = runFollowUpNext(marker.ticket);
+  if (!instruction) process.exit(0);
+
+  persistInstruction(TASKS_BASE, marker.ticket, instruction);
+  printInstruction(instruction);
   process.exit(0);
 }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/follow-up-state.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/follow-up-state.js
@@ -1,0 +1,84 @@
+/**
+ * follow-up-state.js — persistence for the /follow-up orchestrator.
+ *
+ * Factory bound to a TASKS_BASE so the state-file path is resolved once.
+ * Extracted from follow-up-next.js to keep that module under the size budget;
+ * `initState` / `initFreshState` are re-exported from follow-up-next.js for
+ * backward-compatible test + /reset-follow-up access.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { STEPS } = require('./step-registry');
+
+module.exports = function createStateStore(TASKS_BASE) {
+  function stateFile(ticketId) {
+    return path.join(TASKS_BASE, ticketId, '.follow-up-state.json');
+  }
+
+  function loadState(ticketId) {
+    try {
+      return JSON.parse(fs.readFileSync(stateFile(ticketId), 'utf8'));
+    } catch {
+      return null;
+    }
+  }
+
+  function saveState(ticketId, state) {
+    const dir = path.join(TASKS_BASE, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(stateFile(ticketId), JSON.stringify(state, null, 2));
+  }
+
+  function initState(ticketId, prNumber) {
+    return {
+      ticketId,
+      prNumber: prNumber || null,
+      currentStep: STEPS[0],
+      status: 'in_progress',
+      dispatched: null,
+      attempt: 0,
+      maxAttempts: 40,
+      // monitor cache (see infra-patterns.js for invalidation rules)
+      // GH-531 Task 6 (AC10): explicitly reset the push-retry counter so the
+      // cap-exhausted recovery path can't immediately re-trigger after
+      // `reset-follow-up`. Was previously `undefined` (incremented to 1 on
+      // first push-retry), which matches the same observable behavior; the
+      // explicit `0` makes the recovery guarantee inspectable by operators.
+      _pushRetryCount: 0,
+      lastMonitorResult: null,
+      lastMonitorAt: null,
+      failureCategory: null,
+      // Infra-retry telemetry (GH-508 Task 4). `count` tracks how many
+      // infra-retry attempts have been performed for the current PR; `attempts`
+      // records per-attempt diagnostics for the report step (Task 6).
+      infraRetry: { count: 0, attempts: [] },
+      startTime: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Build a fresh /follow-up state object for `ticketId`, persist it to the
+   * canonical state-file path (`TASKS_BASE/<ticket>/.follow-up-state.json`),
+   * and return the new state.
+   *
+   * Idempotent: calling twice overwrites the on-disk state with a fresh one.
+   * Used both by the existing init code path and by the `/reset-follow-up`
+   * command (Task 2) to re-initialize after push-retry exhaustion (GH-531).
+   *
+   * @param {string} ticketId — sanitized ticket id (e.g. `GH-999`).
+   * @param {object} [opts] — optional overrides.
+   * @param {number|null} [opts.prNumber] — preserve an existing PR number across reset.
+   * @returns {object} the freshly-initialized state object.
+   */
+  function initFreshState(ticketId, opts) {
+    const prNumber = opts && opts.prNumber != null ? opts.prNumber : null;
+    const state = initState(ticketId, prNumber);
+    saveState(ticketId, state);
+    return state;
+  }
+
+  return { stateFile, loadState, saveState, initState, initFreshState };
+};

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/monitor.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/monitor.test.js
@@ -21,6 +21,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const MONITOR_PATH = path.resolve(__dirname, '..', 'monitor.js');
+// Sibling modules extracted from monitor.js for the file-size budget. Several
+// structural assertions below now target whichever module a helper lives in.
+const CI_CONTEXT_PATH = path.resolve(__dirname, '..', 'monitor-ci-context.js');
+const INFRA_CACHE_PATH = path.resolve(__dirname, '..', 'monitor-infra-cache.js');
 const SOURCE = fs.readFileSync(MONITOR_PATH, 'utf8');
 const LINES = SOURCE.split('\n');
 
@@ -64,6 +68,14 @@ function phraseNearHelper(helperName, pattern) {
 
 const CHILD_PROCESS_ID = require.resolve('child_process');
 const MONITOR_ID = require.resolve('../monitor.js');
+// monitor.js re-exports helpers from these siblings (which destructure
+// child_process at load). To make a child_process stub reach them, their cache
+// must be busted alongside monitor.js so they re-bind to the stubbed module.
+const MONITOR_SIBLING_IDS = [
+  require.resolve('../monitor-ci-context.js'),
+  require.resolve('../monitor-status-line.js'),
+  require.resolve('../monitor-infra-cache.js'),
+];
 
 function freshLoadMonitor() {
   delete require.cache[MONITOR_ID];
@@ -75,6 +87,7 @@ function withStubbedChildProcess(stub, fn) {
   const stubModule = { exports: stub };
   require.cache[CHILD_PROCESS_ID] = stubModule;
   delete require.cache[MONITOR_ID];
+  for (const id of MONITOR_SIBLING_IDS) delete require.cache[id];
   try {
     const monitor = require('../monitor.js');
     return fn(monitor);
@@ -82,6 +95,7 @@ function withStubbedChildProcess(stub, fn) {
     if (originalCp) require.cache[CHILD_PROCESS_ID] = originalCp;
     else delete require.cache[CHILD_PROCESS_ID];
     delete require.cache[MONITOR_ID];
+    for (const id of MONITOR_SIBLING_IDS) delete require.cache[id];
   }
 }
 
@@ -105,9 +119,15 @@ describe('monitor.js retains the four load-bearing comments', () => {
   });
 
   it('j.url || j.link ordering rationale lives near buildInitialFailedJobs', () => {
+    // buildInitialFailedJobs + its rationale moved together to monitor-ci-context.js.
+    const src = fs.readFileSync(CI_CONTEXT_PATH, 'utf8');
     assert.ok(
-      phraseNearHelper('buildInitialFailedJobs', /j\.url \|\| j\.link/),
-      'expected /j.url || j.link/ comment within ±10 lines of buildInitialFailedJobs'
+      /function\s+buildInitialFailedJobs\s*\(/.test(src),
+      'expected buildInitialFailedJobs to live in monitor-ci-context.js'
+    );
+    assert.ok(
+      /\/\/.*j\.url \|\| j\.link/.test(src),
+      'expected /j.url || j.link/ rationale comment in monitor-ci-context.js'
     );
   });
 
@@ -437,24 +457,26 @@ describe('writeMonitorResult routing in monitor.js (GH-536 Task 2)', () => {
   });
 
   it('defines writeMonitorResult and calls it at least 4 times', () => {
-    const src = fs.readFileSync(MONITOR_PATH, 'utf8');
+    // The chokepoint is defined in monitor-infra-cache.js and called by monitor.js.
+    const cacheSrc = fs.readFileSync(INFRA_CACHE_PATH, 'utf8');
     assert.ok(
-      /function\s+writeMonitorResult\s*\(/.test(src),
-      'expected `function writeMonitorResult(` declaration in monitor.js'
+      /function\s+writeMonitorResult\s*\(/.test(cacheSrc),
+      'expected `function writeMonitorResult(` declaration in monitor-infra-cache.js'
     );
+    const src = fs.readFileSync(MONITOR_PATH, 'utf8');
     const calls = src.match(/writeMonitorResult\s*\(/g) || [];
-    // ≥5 = 1 declaration + 4 call sites
     assert.ok(
-      calls.length >= 5,
-      `expected ≥5 occurrences of writeMonitorResult( (1 decl + 4 calls), found ${calls.length}`
+      calls.length >= 4,
+      `expected ≥4 writeMonitorResult( call sites in monitor.js, found ${calls.length}`
     );
   });
 
   it('requires ../infra-patterns', () => {
-    const src = fs.readFileSync(MONITOR_PATH, 'utf8');
+    // isInfraFailure/isStale are consumed by the infra-cache chokepoint module.
+    const src = fs.readFileSync(INFRA_CACHE_PATH, 'utf8');
     assert.ok(
       /require\(['"]\.\.\/infra-patterns['"]\)/.test(src),
-      'expected monitor.js to require("../infra-patterns")'
+      'expected monitor-infra-cache.js to require("../infra-patterns")'
     );
   });
 });
@@ -608,17 +630,20 @@ describe('clearStaleInfraCache wired via orchestrator (GH-536 round-2)', () => {
   // monitor was reached, which never happened when triage blocked on
   // exitCode 2. These assertions pin the round-2 lift in place.
   it('declares clearStaleInfraCache but does NOT call it from inside monitor.js', () => {
-    const src = fs.readFileSync(MONITOR_PATH, 'utf8');
+    // Declaration lives in monitor-infra-cache.js; monitor.js must not invoke it
+    // (the orchestrator owns invocation). monitor.js only re-exports the symbol.
+    const cacheSrc = fs.readFileSync(INFRA_CACHE_PATH, 'utf8');
     assert.ok(
-      /function\s+clearStaleInfraCache\s*\(/.test(src),
-      'expected `function clearStaleInfraCache(` declaration in monitor.js'
+      /function\s+clearStaleInfraCache\s*\(/.test(cacheSrc),
+      'expected `function clearStaleInfraCache(` declaration in monitor-infra-cache.js'
     );
+    const src = fs.readFileSync(MONITOR_PATH, 'utf8');
     const callCount = (src.match(/clearStaleInfraCache\s*\(/g) || []).length;
-    // 1 occurrence = the function declaration itself, no call sites.
+    // 0 call sites — monitor.js references the symbol only in import + __test__.
     assert.equal(
       callCount,
-      1,
-      `expected exactly 1 occurrence of clearStaleInfraCache( (the declaration; orchestrator owns invocation), found ${callCount}`
+      0,
+      `expected monitor.js to NOT call clearStaleInfraCache( (orchestrator owns invocation), found ${callCount}`
     );
   });
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-ci.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-ci.js
@@ -11,30 +11,213 @@ const { execFileSync } = require('child_process');
 const { buildChildEnv } = require('../../../work/scripts/gh-exec');
 const { filterLogs } = require('../log-utils');
 
+function shellSafe(s) {
+  return String(s || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function pushGhErr(errors, stage, err) {
+  const msg = shellSafe(err?.stderr || err?.stdout || err?.message || 'unknown');
+  errors.push(`[${stage}] ${msg.substring(0, 300)}`);
+}
+
+// NOTE: gh's `--job` flag requires a numeric job ID (not a name). We don't have
+// job IDs here — only check-run names — so we run `--log-failed` for the entire
+// run. That already filters to failing steps; our filterLogs() strips the rest.
+function fetchRunLogs(runId, ctx, errors) {
+  try {
+    return execFileSync('gh', ['run', 'view', String(runId), '--log-failed'], {
+      encoding: 'utf8',
+      timeout: 30000,
+      cwd: ctx.worktreeDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 10 * 1024 * 1024,
+      env: buildChildEnv(),
+    });
+  } catch (err) {
+    pushGhErr(errors, `run-view ${runId}`, err);
+    return '';
+  }
+}
+
+function parseCheckLine(line) {
+  const [name, link] = line.split('\t');
+  const m = String(link || '').match(/runs\/(\d+)/);
+  return name && m ? { name: name.trim(), runId: m[1] } : null;
+}
+
+// Strategy 2 (fallback): re-query `gh pr checks` for failed jobs + links.
+function queryPrChecksTargets(prNum, ctx, errors) {
+  const targets = [];
+  let linksOutput;
+  try {
+    linksOutput = execFileSync(
+      'gh',
+      [
+        'pr',
+        'checks',
+        String(prNum),
+        '--json',
+        'name,state,link',
+        '--jq',
+        '.[] | select(.state == "FAILURE") | "\(.name)\t\(.link)"',
+      ],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: ctx.worktreeDir,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: buildChildEnv(),
+      }
+    );
+  } catch (err) {
+    pushGhErr(errors, 'pr-checks', err);
+    return targets;
+  }
+  for (const line of linksOutput.split('\n').filter(Boolean)) {
+    const t = parseCheckLine(line);
+    if (t) targets.push(t);
+  }
+  return targets;
+}
+
+// Strategy 1 (preferred): use the structured failed-job list captured by
+// monitor.js — exact job names + runIds derived from the check `link`. Falls
+// back to strategy 2 when monitor reported nothing.
+function collectFailedTargets(prNum, ctx, failedJobs, errors) {
+  const targets = [];
+  for (const j of failedJobs) {
+    if (j && j.name && j.runId) targets.push({ name: j.name, runId: j.runId });
+  }
+  if (targets.length > 0) return targets;
+  return queryPrChecksTargets(prNum, ctx, errors);
+}
+
+// Fetch logs only for the actually-failed jobs (up to 3 distinct runIds).
+function fetchRunLogChunks(targets, ctx, errors) {
+  const seenRuns = new Set();
+  const chunks = [];
+  for (const t of targets) {
+    if (seenRuns.has(t.runId)) continue;
+    seenRuns.add(t.runId);
+    const raw = fetchRunLogs(t.runId, ctx, errors);
+    if (raw) chunks.push(`### Failed job: ${t.name}\n` + filterLogs(raw));
+    if (chunks.join('\n').length > 8000) break;
+    if (seenRuns.size >= 3) break;
+  }
+  return chunks;
+}
+
+function buildNoLogsMessage(targets, errors) {
+  const errLines = errors.length
+    ? errors.map((e) => `  - ${e}`).join('\n')
+    : '  - no failed jobs reported by monitor or gh pr checks';
+  const jobsHint = targets.length
+    ? '\nFailed jobs (from monitor): ' + targets.map((t) => t.name).join(', ')
+    : '';
+  return '(Could not fetch CI logs automatically)\nCommands attempted:\n' + errLines + jobsHint;
+}
+
+// Fetch the actual failed-run logs. Strategy:
+//   1. Use monitor.js's structured failed-job list (exact names + runIds).
+//   2. Fall back to `gh pr checks --json` for FAILURE links.
+//   3. For each candidate run, fetch `--log-failed`, filtered to test/assert
+//      lines, truncated to fit the prompt budget.
+//   4. Surface real fetch errors instead of swallowing them.
+function fetchCiLogs(prNum, ctx, failedJobs) {
+  const errors = [];
+  const targets = collectFailedTargets(prNum, ctx, failedJobs, errors);
+  const chunks = fetchRunLogChunks(targets, ctx, errors);
+  if (chunks.length > 0) return chunks.join('\n\n').substring(0, 8000);
+  return buildNoLogsMessage(targets, errors);
+}
+
+// ── HARD STOP on merge conflict ───────────────────────────────────────────
+// Conflicts are NOT auto-resolved. Halt the workflow and tell the agent (and
+// the user) to sync the branch before continuing. This prevents auto-rebase
+// delegates from silently dropping upstream changes that need human judgement
+// (big sibling-PR merges, conflicting schema migrations, etc).
+function buildConflictBlocked(state) {
+  const prNum = state.prNumber || 'unknown';
+  const files = Array.isArray(state._mergeStatus && state._mergeStatus.localConflictFiles)
+    ? state._mergeStatus.localConflictFiles
+    : [];
+  const baseBranch = state._mergeStatus && state._mergeStatus.baseBranch;
+  const fileSuffix = files.length
+    ? ` Conflicting file${files.length > 1 ? 's' : ''}: ${files.join(', ')}.`
+    : '';
+  const baseSuffix = baseBranch ? ` (target: ${baseBranch})` : '';
+  return {
+    type: 'follow_up_instruction',
+    action: 'blocked',
+    reason: `Merge conflicts found on PR #${prNum}${baseSuffix} — sync your branch with the target branch before proceeding.${fileSuffix} Then re-run /follow-up ${state.ticketId || ''}.`,
+    state: { ticket: state.ticketId, currentStep: 'fix-ci', attempt: state.attempt || 0 },
+  };
+}
+
+function buildConflictPrompt(prNum, monitorOutput) {
+  return [
+    `## Merge Conflict on PR #${prNum}`,
+    '',
+    '### Monitor output:',
+    '```',
+    monitorOutput,
+    '```',
+    '',
+    '### Instructions:',
+    '1. Resolve the merge conflict',
+    '2. Run tests locally: `pnpm test`',
+    '3. Commit the resolution',
+    '4. Do NOT push',
+  ].join('\n');
+}
+
+function buildCiFailurePrompt(prNum, ciStatusLine, ciStatusDetail, ciLogs) {
+  return [
+    `## CI Failure on PR #${prNum}`,
+    '',
+    ...(ciStatusLine ? [ciStatusLine] : []),
+    ...(ciStatusDetail ? [ciStatusDetail] : []),
+    '',
+    '### Failed CI logs:',
+    '```',
+    ciLogs || '(no logs captured)',
+    '```',
+    '',
+    '### Instructions:',
+    '1. Read the error above — the root cause is in the logs',
+    '2. Fix the failing code',
+    '3. Run tests locally to verify: `pnpm test`',
+    '4. Commit the fix',
+    '5. Do NOT push',
+  ].join('\n');
+}
+
+function buildExecuteInstruction(state, prNum, isConflict, monitorOutput, ciLogs) {
+  const ciStatusLine = state._ciStatusLine || '';
+  const ciStatusDetail = state._ciStatusDetail || '';
+  return {
+    type: 'follow_up_instruction',
+    action: 'execute',
+    state: { ticket: state.ticketId, currentStep: 'fix-ci', attempt: state.attempt },
+    continue: true,
+    delegate: {
+      type: 'task',
+      agentType: 'work-workflow:developer-nodejs-tdd',
+      description: `Fix ${isConflict ? 'merge conflict' : 'CI failure'} on PR #${prNum} (attempt ${state.attempt})`,
+      prompt: isConflict
+        ? buildConflictPrompt(prNum, monitorOutput)
+        : buildCiFailurePrompt(prNum, ciStatusLine, ciStatusDetail, ciLogs),
+      note: 'Pass the prompt directly to the agent.',
+    },
+  };
+}
+
 module.exports = function registerFixCi(register) {
   register('fix-ci', (state, ctx) => {
-    // ── HARD STOP on merge conflict ─────────────────────────────────────
-    // Conflicts are NOT auto-resolved. Halt the workflow and tell the
-    // agent (and the user) to sync the branch before continuing. This
-    // prevents auto-rebase delegates from silently dropping upstream
-    // changes that need human judgement (big sibling-PR merges, conflicting
-    // schema migrations, etc).
     if (state._isConflicting || state.failureCategory === 'conflict') {
-      const prNum = state.prNumber || 'unknown';
-      const files = Array.isArray(state._mergeStatus && state._mergeStatus.localConflictFiles)
-        ? state._mergeStatus.localConflictFiles
-        : [];
-      const baseBranch = state._mergeStatus && state._mergeStatus.baseBranch;
-      const fileSuffix = files.length
-        ? ` Conflicting file${files.length > 1 ? 's' : ''}: ${files.join(', ')}.`
-        : '';
-      const baseSuffix = baseBranch ? ` (target: ${baseBranch})` : '';
-      return {
-        type: 'follow_up_instruction',
-        action: 'blocked',
-        reason: `Merge conflicts found on PR #${prNum}${baseSuffix} — sync your branch with the target branch before proceeding.${fileSuffix} Then re-run /follow-up ${state.ticketId || ''}.`,
-        state: { ticket: state.ticketId, currentStep: 'fix-ci', attempt: state.attempt || 0 },
-      };
+      return buildConflictBlocked(state);
     }
 
     if (state.dispatched === 'fix-ci') return null; // already ran → advance to push-retry
@@ -42,167 +225,14 @@ module.exports = function registerFixCi(register) {
     state.dispatched = 'fix-ci';
     const category = state.failureCategory || 'ci_failure';
     const prNum = state.prNumber || 'unknown';
-    const monitorOutput = (state.lastMonitorResult?.output || '').substring(0, 1500);
     const isConflict = category === 'conflict';
-    const ciStatusLine = state._ciStatusLine || '';
-    const ciStatusDetail = state._ciStatusDetail || '';
+    const monitorOutput = (state.lastMonitorResult?.output || '').substring(0, 1500);
     const failedJobs = Array.isArray(state._ciFailedJobs) ? state._ciFailedJobs : [];
-
-    // For CI failures: fetch the actual failed run logs.
-    // Strategy:
-    //   1. Try `gh pr checks --json` to get FAILURE links.
-    //   2. Fall back to `gh run list --branch <branch>` for the latest failed run.
-    //   3. For each candidate run, fetch `--log-failed` (with optional --job filter
-    //      using the failing job name extracted from monitor output).
-    //   4. Filter to test/assert lines only; truncate to fit prompt budget.
-    //   5. Surface real fetch errors instead of swallowing them.
-    let ciLogs = '';
-    const ciFetchErrors = [];
 
     // `stripGhPrefix` / `filterLogs` are imported from `../log-utils` so the
     // infra-classifier can reuse the same Signal 4 raw-log scanning logic.
+    const ciLogs = isConflict ? '' : fetchCiLogs(prNum, ctx, failedJobs);
 
-    function shellSafe(s) {
-      return String(s || '')
-        .replace(/\s+/g, ' ')
-        .trim();
-    }
-
-    function ghErr(stage, err) {
-      const msg = shellSafe(err?.stderr || err?.stdout || err?.message || 'unknown');
-      ciFetchErrors.push(`[${stage}] ${msg.substring(0, 300)}`);
-    }
-
-    // NOTE: gh's `--job` flag requires a numeric job ID (not a name). We don't
-    // have job IDs here — only check-run names — so we run `--log-failed` for
-    // the entire run. That already filters to failing steps; our filterLogs()
-    // strips the rest of the noise.
-    function fetchRunLogs(runId) {
-      try {
-        return execFileSync('gh', ['run', 'view', String(runId), '--log-failed'], {
-          encoding: 'utf8',
-          timeout: 30000,
-          cwd: ctx.worktreeDir,
-          stdio: ['pipe', 'pipe', 'pipe'],
-          maxBuffer: 10 * 1024 * 1024,
-          env: buildChildEnv(),
-        });
-      } catch (err) {
-        ghErr(`run-view ${runId}`, err);
-        return '';
-      }
-    }
-
-    if (!isConflict) {
-      // Strategy 1 (preferred): use the structured failed-job list captured
-      // by monitor.js — exact job names + runIds derived from the check `link`.
-      const targets = [];
-      for (const j of failedJobs) {
-        if (j && j.name && j.runId) targets.push({ name: j.name, runId: j.runId });
-      }
-
-      // Strategy 2 (fallback): re-query gh pr checks for failed jobs+links
-      if (targets.length === 0) {
-        try {
-          const linksOutput = execFileSync(
-            'gh',
-            [
-              'pr',
-              'checks',
-              String(prNum),
-              '--json',
-              'name,state,link',
-              '--jq',
-              '.[] | select(.state == "FAILURE") | "\(.name)\t\(.link)"',
-            ],
-            {
-              encoding: 'utf8',
-              timeout: 15000,
-              cwd: ctx.worktreeDir,
-              stdio: ['pipe', 'pipe', 'pipe'],
-              env: buildChildEnv(),
-            }
-          );
-          for (const line of linksOutput.split('\n').filter(Boolean)) {
-            const [name, link] = line.split('\t');
-            const m = String(link || '').match(/runs\/(\d+)/);
-            if (name && m) targets.push({ name: name.trim(), runId: m[1] });
-          }
-        } catch (err) {
-          ghErr('pr-checks', err);
-        }
-      }
-
-      // Fetch logs only for the actually-failed jobs (up to 3 distinct runIds)
-      const seenRuns = new Set();
-      const chunks = [];
-      for (const t of targets) {
-        if (seenRuns.has(t.runId)) continue;
-        seenRuns.add(t.runId);
-        const raw = fetchRunLogs(t.runId);
-        if (raw) chunks.push(`### Failed job: ${t.name}\n` + filterLogs(raw));
-        if (chunks.join('\n').length > 8000) break;
-        if (seenRuns.size >= 3) break;
-      }
-
-      if (chunks.length > 0) {
-        ciLogs = chunks.join('\n\n').substring(0, 8000);
-      } else {
-        const errLines = ciFetchErrors.length
-          ? ciFetchErrors.map((e) => `  - ${e}`).join('\n')
-          : '  - no failed jobs reported by monitor or gh pr checks';
-        const jobsHint = targets.length
-          ? '\nFailed jobs (from monitor): ' + targets.map((t) => t.name).join(', ')
-          : '';
-        ciLogs =
-          '(Could not fetch CI logs automatically)\nCommands attempted:\n' + errLines + jobsHint;
-      }
-    }
-
-    return {
-      type: 'follow_up_instruction',
-      action: 'execute',
-      state: { ticket: state.ticketId, currentStep: 'fix-ci', attempt: state.attempt },
-      continue: true,
-      delegate: {
-        type: 'task',
-        agentType: 'work-workflow:developer-nodejs-tdd',
-        description: `Fix ${isConflict ? 'merge conflict' : 'CI failure'} on PR #${prNum} (attempt ${state.attempt})`,
-        prompt: isConflict
-          ? [
-              `## Merge Conflict on PR #${prNum}`,
-              '',
-              '### Monitor output:',
-              '```',
-              monitorOutput,
-              '```',
-              '',
-              '### Instructions:',
-              '1. Resolve the merge conflict',
-              '2. Run tests locally: `pnpm test`',
-              '3. Commit the resolution',
-              '4. Do NOT push',
-            ].join('\n')
-          : [
-              `## CI Failure on PR #${prNum}`,
-              '',
-              ...(ciStatusLine ? [ciStatusLine] : []),
-              ...(ciStatusDetail ? [ciStatusDetail] : []),
-              '',
-              '### Failed CI logs:',
-              '```',
-              ciLogs || '(no logs captured)',
-              '```',
-              '',
-              '### Instructions:',
-              '1. Read the error above — the root cause is in the logs',
-              '2. Fix the failing code',
-              '3. Run tests locally to verify: `pnpm test`',
-              '4. Commit the fix',
-              '5. Do NOT push',
-            ].join('\n'),
-        note: 'Pass the prompt directly to the agent.',
-      },
-    };
+    return buildExecuteInstruction(state, prNum, isConflict, monitorOutput, ciLogs);
   });
 };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
@@ -114,13 +114,39 @@ function computeCounts(st) {
   };
 }
 
+// Remove HTML comments (`<!-- ... -->`) by scanning with indexOf rather than a
+// regex. A regex HTML-comment filter is hard to make complete (it must also
+// treat `--!>` as a terminator and can leave a stray `<!--`), so we slice the
+// markers out directly: everything from a `<!--` up to and including the next
+// `-->` is dropped, and an unterminated `<!--` drops the remainder. This leaves
+// no `<!--` behind and uses no regex sanitizer for CodeQL to flag as incomplete.
+function stripHtmlComments(s) {
+  let out = '';
+  let i = 0;
+  while (i < s.length) {
+    const start = s.indexOf('<!--', i);
+    if (start === -1) {
+      out += s.slice(i);
+      break;
+    }
+    out += s.slice(i, start);
+    const end = s.indexOf('-->', start + 4);
+    if (end === -1) break; // unterminated comment — drop the rest
+    i = end + 3;
+  }
+  return out;
+}
+
 // Strip noise from Cursor Bugbot comments: HTML links, base64 URLs, metadata.
+// This is cosmetic markdown cleanup for CLI/agent-prompt display — NOT HTML
+// sanitization for a browser (the output is never rendered as HTML).
 function cleanCommentBody(rawBody) {
-  return rawBody
+  let body = rawBody
     .replace(/<div>[\s\S]*?<\/div>/g, '') // cursor fix-in-cursor/fix-in-web buttons
     .replace(/<details>[\s\S]*?<\/details>/g, '') // collapsed additional locations
-    .replace(/<sup>[\s\S]*?<\/sup>/g, '') // "Reviewed by Cursor Bugbot" footer
-    .replace(/<!--[\s\S]*?-->/g, '') // HTML comments (BUGBOT_BUG_ID, LOCATIONS, DESCRIPTION markers)
+    .replace(/<sup>[\s\S]*?<\/sup>/g, ''); // "Reviewed by Cursor Bugbot" footer
+  body = stripHtmlComments(body); // HTML comments (BUGBOT_BUG_ID, LOCATIONS markers)
+  return body
     .replace(/<\/?picture>|<source[^>]*>|<img[^>]*>/g, '') // image tags
     .replace(/<a[^>]*>[\s\S]*?<\/a>/g, '') // remaining anchor tags
     .replace(/\n{3,}/g, '\n\n') // collapse excessive blank lines

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
@@ -20,15 +20,193 @@
 const path = require('path');
 const { execFileSync } = require('child_process');
 
+function blocked(reason) {
+  return { type: 'follow_up_instruction', action: 'blocked', reason };
+}
+
+// Single chokepoint for invoking follow-up-pr-comments.js. `timeout` varies by
+// subcommand; everything else (cwd, env, pipe stdio) is shared.
+function runComments(commentsScript, args, ctx, scriptEnv, timeout) {
+  return execFileSync(process.execPath, [commentsScript, ...args], {
+    encoding: 'utf8',
+    timeout,
+    cwd: ctx.worktreeDir,
+    env: scriptEnv,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+// Parse `--status` JSON ({ remaining, total, solved, skipped }). Returns null
+// on any error. Shared by the done-path skip check and the "N of M" counter.
+function readCommentsStatus(commentsScript, ctx, scriptEnv) {
+  try {
+    return JSON.parse(runComments(commentsScript, ['--status'], ctx, scriptEnv, 10000));
+  } catch {
+    return null;
+  }
+}
+
+// First call: always take a fresh snapshot to catch new comments. The
+// --snapshot command preserves solved/skipped state from previous runs via
+// previousStatusMap (GH-358), so no data is lost. Returns a blocked
+// instruction on failure, else null (snapshot recorded on state).
+function ensureSnapshot(state, commentsScript, prNum, ctx, scriptEnv) {
+  if (state._reviewSnapshotDone) return null;
+  try {
+    runComments(commentsScript, ['--snapshot', '--pr', prNum], ctx, scriptEnv, 30000);
+  } catch (err) {
+    const msg = err.stderr || err.stdout || err.message || 'unknown error';
+    return blocked(`Snapshot failed: ${String(msg).substring(0, 500)}`);
+  }
+  state._reviewSnapshotDone = true;
+  return null;
+}
+
+// Get the next unsolved comment. Returns one of:
+//   { blocked }      — script error (exit 1)
+//   { advance: true } — parse error on a valid exit = no comments → return null
+//   { comment }      — parsed comment (may be null or have .done)
+function fetchNextComment(state, commentsScript, ctx, scriptEnv) {
+  try {
+    const result = runComments(commentsScript, ['--next-comment'], ctx, scriptEnv, 15000);
+    return { comment: JSON.parse(result) };
+  } catch (err) {
+    // Exit 0 + {"done":true} is handled by the caller via the parsed object.
+    // Any other error (exit 1, parse error) = script failure.
+    const exitCode = typeof err.status === 'number' ? err.status : -1;
+    if (exitCode === 1) {
+      // Script error — snapshot may not exist or was corrupted
+      delete state._reviewSnapshotDone;
+      const msg = err.stderr || err.stdout || err.message || 'unknown error';
+      return { blocked: blocked(`--next-comment failed: ${String(msg).substring(0, 500)}`) };
+    }
+    // JSON parse error on valid exit = no comments
+    delete state._reviewSnapshotDone;
+    return { advance: true };
+  }
+}
+
+// No more actionable comments. When all remaining comments are terminal (solved
+// or skipped), advance directly to `report` and let the workflow finish — the
+// rationale for each skip is preserved in follow-up-comments.json for later
+// review. Previously this returned `action: 'blocked'` which forced a manual
+// "I have reviewed, re-run" ack-loop even after the user had approved the skips.
+//
+// Loop-break invariant: routing to `report` marks the workflow `status:
+// complete`, so re-running /follow-up without --init returns "Already complete"
+// instead of cycling back here. Always returns null (advance / loop).
+function handleNoMoreComments(state, commentsScript, ctx, scriptEnv) {
+  delete state._reviewSnapshotDone;
+  const statusResult = readCommentsStatus(commentsScript, ctx, scriptEnv);
+  if (statusResult && statusResult.skipped > 0) {
+    state._skippedReviewsCount = statusResult.skipped;
+    state._solvedReviewsCount = statusResult.solved || 0;
+    state.currentStep = 'report';
+  }
+  return null;
+}
+
+function computeCounts(st) {
+  if (!st) return { totalComments: '?', currentIndex: '?' };
+  return {
+    totalComments: st.remaining || st.total || '?',
+    currentIndex: (st.solved || 0) + (st.skipped || 0) + 1,
+  };
+}
+
+// Strip noise from Cursor Bugbot comments: HTML links, base64 URLs, metadata.
+function cleanCommentBody(rawBody) {
+  return rawBody
+    .replace(/<div>[\s\S]*?<\/div>/g, '') // cursor fix-in-cursor/fix-in-web buttons
+    .replace(/<details>[\s\S]*?<\/details>/g, '') // collapsed additional locations
+    .replace(/<sup>[\s\S]*?<\/sup>/g, '') // "Reviewed by Cursor Bugbot" footer
+    .replace(/<!--[\s\S]*?-->/g, '') // HTML comments (BUGBOT_BUG_ID, LOCATIONS, DESCRIPTION markers)
+    .replace(/<\/?picture>|<source[^>]*>|<img[^>]*>/g, '') // image tags
+    .replace(/<a[^>]*>[\s\S]*?<\/a>/g, '') // remaining anchor tags
+    .replace(/\n{3,}/g, '\n\n') // collapse excessive blank lines
+    .trim();
+}
+
+function buildReviewPrompt(comment, fileRef, counts, commands) {
+  const author = comment.author || 'unknown';
+  const priority = comment.priority || 'unknown';
+  const body = cleanCommentBody(comment.body || '');
+  const codeContext = comment.codeContext || '';
+  return [
+    `## Review Comment ${counts.currentIndex} of ${counts.totalComments}`,
+    '',
+    `**Author:** ${author} | **Priority:** ${priority} | **File:** ${fileRef}`,
+    '',
+    body,
+    '',
+    codeContext ? `### Current code:\n\`\`\`\n${codeContext}\n\`\`\`\n` : '',
+    '---',
+    '',
+    '## You MUST do exactly ONE of these:',
+    '',
+    '### Option A — Fix the code:',
+    '1. Fix the issue in the specified file',
+    '2. Stage and commit: `git add <files> && git commit -m "fix(review): <what you fixed>"`',
+    '3. Then mark as addressed:',
+    '```',
+    commands.solveCmd,
+    '```',
+    '',
+    '### Option B — Skip with reason:',
+    '```',
+    commands.skipCmd,
+    '```',
+    'Valid reasons: "Outside scope of brief/spec", "Conflicts with ticket requirements", "Conflicts with user instruction"',
+    '',
+    '---',
+    '',
+    `When done, call: \`${commands.nextCmd}\``,
+    '',
+    '**Do NOT pipe the output** (no `| head`, `| tail`, `| grep`, `> file`, `2>&1 |`). Piping truncates the JSON delegate block and hides next-step instructions. Run the command raw.',
+  ].join('\n');
+}
+
+function buildReviewExecute(state, comment, commentsScript, counts) {
+  const filePath = comment.path || 'general';
+  const line = comment.line || '';
+  const fileRef = line ? `${filePath}:${line}` : filePath;
+  const commentId = comment.id;
+
+  // Build the solve/skip commands the agent must use. The new flag names
+  // (GH-537) make the local-only scope explicit; the legacy aliases still work
+  // but emit a deprecation warning. The opt-in GitHub-resolve flag is
+  // intentionally NOT surfaced to the agent here — it stays reachable only for
+  // humans invoking the CLI directly.
+  const commands = {
+    solveCmd: `node "${commentsScript}" --mark-locally-solved "${commentId}" "<COMMIT_SHA>" "<description of what you fixed>"`,
+    skipCmd: `node "${commentsScript}" --mark-locally-skipped "${commentId}" "<reason>"`,
+    nextCmd: `node "${path.join(__dirname, '..', '..', 'follow-up-next.js')}" "${state.ticketId}"${state.prNumber ? ` --pr ${state.prNumber}` : ''}`,
+  };
+
+  return {
+    type: 'follow_up_instruction',
+    action: 'execute',
+    state: { ticket: state.ticketId, currentStep: 'fix-reviews', attempt: state.attempt },
+    continue: true,
+    delegate: {
+      type: 'task',
+      agentType: 'work-workflow:developer-nodejs-tdd',
+      description: `Review comment ${counts.currentIndex} of ${counts.totalComments}: ${fileRef}`,
+      prompt: buildReviewPrompt(comment, fileRef, counts, commands),
+      note: 'Pass the prompt directly to the agent.',
+    },
+  };
+}
+
 module.exports = function registerFixReviews(register) {
   register('fix-reviews', (state, ctx) => {
     // ── PRIORITY 0 guard: never process reviews against a conflicted branch.
     // Conflict was either detected on the current monitor cycle (state
     // ._isConflicting set by monitor.js) or persisted from a prior cycle.
     // Sending the agent to fix reviews against a branch that won't merge
-    // wastes a round-trip and risks the "blocked: review skipped, ask
-    // user" instruction when the real issue is "rebase first". Re-route
-    // to fix-ci so the agent resolves the conflict before any review work.
+    // wastes a round-trip and risks the "blocked: review skipped, ask user"
+    // instruction when the real issue is "rebase first". Re-route to fix-ci so
+    // the agent resolves the conflict before any review work.
     if (state._isConflicting) {
       state.failureCategory = 'conflict';
       state.currentStep = 'fix-ci';
@@ -39,196 +217,23 @@ module.exports = function registerFixReviews(register) {
     const prNum = String(state.prNumber || '');
     const scriptEnv = { ...process.env, WORK_TICKET_ID: state.ticketId };
 
-    // First call: always take fresh snapshot to catch new comments.
-    // The --snapshot command preserves solved/skipped state from previous
-    // runs via previousStatusMap (GH-358), so no data is lost.
-    if (!state._reviewSnapshotDone) {
-      try {
-        execFileSync(process.execPath, [commentsScript, '--snapshot', '--pr', prNum], {
-          encoding: 'utf8',
-          timeout: 30000,
-          cwd: ctx.worktreeDir,
-          env: scriptEnv,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        });
-      } catch (err) {
-        const msg = err.stderr || err.stdout || err.message || 'unknown error';
-        return {
-          type: 'follow_up_instruction',
-          action: 'blocked',
-          reason: `Snapshot failed: ${String(msg).substring(0, 500)}`,
-        };
-      }
-      state._reviewSnapshotDone = true;
-    }
+    const snapshotBlocked = ensureSnapshot(state, commentsScript, prNum, ctx, scriptEnv);
+    if (snapshotBlocked) return snapshotBlocked;
 
     // After agent returned from previous comment — clear dispatch, get next
-    if (state.dispatched === 'fix-reviews') {
-      state.dispatched = null;
-    }
+    if (state.dispatched === 'fix-reviews') state.dispatched = null;
 
-    // Get next unsolved comment
-    let comment = null;
-    try {
-      const result = execFileSync(process.execPath, [commentsScript, '--next-comment'], {
-        encoding: 'utf8',
-        timeout: 15000,
-        cwd: ctx.worktreeDir,
-        env: scriptEnv,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      comment = JSON.parse(result);
-    } catch (err) {
-      // Exit 0 + {"done":true} is handled above via JSON.parse
-      // Any other error (exit 1, parse error) = script failure
-      const exitCode = typeof err.status === 'number' ? err.status : -1;
-      if (exitCode === 1) {
-        // Script error — snapshot may not exist or was corrupted
-        delete state._reviewSnapshotDone;
-        const msg = err.stderr || err.stdout || err.message || 'unknown error';
-        return {
-          type: 'follow_up_instruction',
-          action: 'blocked',
-          reason: `--next-comment failed: ${String(msg).substring(0, 500)}`,
-        };
-      }
-      // JSON parse error on valid exit = no comments
-      delete state._reviewSnapshotDone;
-      return null;
-    }
+    const next = fetchNextComment(state, commentsScript, ctx, scriptEnv);
+    if (next.blocked) return next.blocked;
+    if (next.advance) return null;
+    const comment = next.comment;
 
     if (!comment || comment.done) {
-      delete state._reviewSnapshotDone;
-
-      // Check for skipped comments → prompt user
-      let statusResult = null;
-      try {
-        const raw = execFileSync(process.execPath, [commentsScript, '--status'], {
-          encoding: 'utf8',
-          timeout: 10000,
-          cwd: ctx.worktreeDir,
-          env: scriptEnv,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        });
-        statusResult = JSON.parse(raw);
-      } catch {
-        /* ignore */
-      }
-
-      // When all remaining comments are terminal (solved or skipped),
-      // advance directly to `report` and let the workflow finish. The
-      // rationale for each skipped comment is preserved in
-      // follow-up-comments.json for later review. Previously this returned
-      // `action: 'blocked'` which forced a manual "I have reviewed, re-run"
-      // ack-loop every time — even when the user had already approved the
-      // skips. The reason for each skip is the agent's responsibility to
-      // make defensible (per `feedback_review_comments_judgment`).
-      //
-      // Loop-break invariant: routing to `report` marks the workflow
-      // `status: complete`, so re-running /follow-up without --init
-      // returns "Already complete" instead of cycling back here.
-      if (statusResult && statusResult.skipped > 0) {
-        state._skippedReviewsCount = statusResult.skipped;
-        state._solvedReviewsCount = statusResult.solved || 0;
-        state.currentStep = 'report';
-        return null;
-      }
-
-      return null; // all solved → advance to push-retry
+      return handleNoMoreComments(state, commentsScript, ctx, scriptEnv);
     }
 
     state.dispatched = 'fix-reviews';
-
-    // Get total count for "N of M" display
-    let totalComments = '?';
-    let currentIndex = '?';
-    try {
-      const raw = execFileSync(process.execPath, [commentsScript, '--status'], {
-        encoding: 'utf8',
-        timeout: 10000,
-        cwd: ctx.worktreeDir,
-        env: scriptEnv,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      const st = JSON.parse(raw);
-      totalComments = st.remaining || st.total || '?';
-      currentIndex = (st.solved || 0) + (st.skipped || 0) + 1;
-    } catch {
-      /* ignore */
-    }
-
-    const author = comment.author || 'unknown';
-    const filePath = comment.path || 'general';
-    const line = comment.line || '';
-    const rawBody = comment.body || '';
-    const priority = comment.priority || 'unknown';
-
-    // Strip noise from Cursor Bugbot comments: HTML links, base64 URLs, metadata
-    const body = rawBody
-      .replace(/<div>[\s\S]*?<\/div>/g, '') // cursor fix-in-cursor/fix-in-web buttons
-      .replace(/<details>[\s\S]*?<\/details>/g, '') // collapsed additional locations
-      .replace(/<sup>[\s\S]*?<\/sup>/g, '') // "Reviewed by Cursor Bugbot" footer
-      .replace(/<!--[\s\S]*?-->/g, '') // HTML comments (BUGBOT_BUG_ID, LOCATIONS, DESCRIPTION markers)
-      .replace(/<\/?picture>|<source[^>]*>|<img[^>]*>/g, '') // image tags
-      .replace(/<a[^>]*>[\s\S]*?<\/a>/g, '') // remaining anchor tags
-      .replace(/\n{3,}/g, '\n\n') // collapse excessive blank lines
-      .trim();
-    const codeContext = comment.codeContext || '';
-    const commentId = comment.id;
-    const fileRef = line ? `${filePath}:${line}` : filePath;
-
-    // Build the solve/skip commands the agent must use.
-    // The new flag names (GH-537) make the local-only scope explicit; the
-    // legacy aliases still work but emit a deprecation warning. The opt-in
-    // GitHub-resolve flag is intentionally NOT surfaced to the agent here —
-    // it stays reachable only for humans invoking the CLI directly.
-    const solveCmd = `node "${commentsScript}" --mark-locally-solved "${commentId}" "<COMMIT_SHA>" "<description of what you fixed>"`;
-    const skipCmd = `node "${commentsScript}" --mark-locally-skipped "${commentId}" "<reason>"`;
-    const nextCmd = `node "${path.join(__dirname, '..', '..', 'follow-up-next.js')}" "${state.ticketId}"${state.prNumber ? ` --pr ${state.prNumber}` : ''}`;
-
-    return {
-      type: 'follow_up_instruction',
-      action: 'execute',
-      state: { ticket: state.ticketId, currentStep: 'fix-reviews', attempt: state.attempt },
-      continue: true,
-      delegate: {
-        type: 'task',
-        agentType: 'work-workflow:developer-nodejs-tdd',
-        description: `Review comment ${currentIndex} of ${totalComments}: ${fileRef}`,
-        prompt: [
-          `## Review Comment ${currentIndex} of ${totalComments}`,
-          '',
-          `**Author:** ${author} | **Priority:** ${priority} | **File:** ${fileRef}`,
-          '',
-          body,
-          '',
-          codeContext ? `### Current code:\n\`\`\`\n${codeContext}\n\`\`\`\n` : '',
-          '---',
-          '',
-          '## You MUST do exactly ONE of these:',
-          '',
-          '### Option A — Fix the code:',
-          '1. Fix the issue in the specified file',
-          '2. Stage and commit: `git add <files> && git commit -m "fix(review): <what you fixed>"`',
-          '3. Then mark as addressed:',
-          '```',
-          solveCmd,
-          '```',
-          '',
-          '### Option B — Skip with reason:',
-          '```',
-          skipCmd,
-          '```',
-          'Valid reasons: "Outside scope of brief/spec", "Conflicts with ticket requirements", "Conflicts with user instruction"',
-          '',
-          '---',
-          '',
-          `When done, call: \`${nextCmd}\``,
-          '',
-          '**Do NOT pipe the output** (no `| head`, `| tail`, `| grep`, `> file`, `2>&1 |`). Piping truncates the JSON delegate block and hides next-step instructions. Run the command raw.',
-        ].join('\n'),
-        note: 'Pass the prompt directly to the agent.',
-      },
-    };
+    const counts = computeCounts(readCommentsStatus(commentsScript, ctx, scriptEnv));
+    return buildReviewExecute(state, comment, commentsScript, counts);
   });
 };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor-ci-context.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor-ci-context.js
@@ -1,0 +1,184 @@
+/**
+ * monitor-ci-context.js — CI failed-job + infra-classifier context helpers.
+ *
+ * Extracted from monitor.js (which exceeded the file-size budget). These build
+ * the `_ciFailedJobs` / `_ciAllJobs` / `_ciFailedLogs` / `_ciFailedTests`
+ * signals the infra-classifier (GH-508) reads. monitor.js re-exports them via
+ * its `__test__` object for backward-compatible unit access.
+ */
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+const { buildChildEnv } = require('../../../work/scripts/gh-exec');
+
+// Order matters: read `j.url || j.link`. `checkCI()` renames `link → url` for
+// failed jobs that have been normalized, but legacy/un-normalized entries still
+// carry only `link`. Probing `url` first preserves the canonical name when
+// present and falls back to `link` so we never drop a runId.
+function buildInitialFailedJobs(ci) {
+  return (ci.failed || []).map((j) => {
+    const m = String(j.url || j.link || '').match(/runs\/(\d+)/);
+    return { name: j.name || '', runId: m ? m[1] : null };
+  });
+}
+
+// Resolve missing runIds via the check-runs API at HEAD SHA. Matrix parent
+// checks ("🧪 Run Integration Tests [tests]") often have no `link` in
+// `gh pr checks`, so fix-ci would have nothing to fetch.
+function resolveMissingRunIds(failedJobs, worktreeDir) {
+  if (!failedJobs.some((j) => !j.runId && j.name)) return;
+  try {
+    const headSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      timeout: 5000,
+      cwd: worktreeDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const apiOut = execFileSync(
+      'gh',
+      [
+        'api',
+        `repos/{owner}/{repo}/commits/${headSha}/check-runs`,
+        '--paginate',
+        '--jq',
+        '.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled" or .conclusion == "action_required" or .conclusion == "stale" or .conclusion == "startup_failure") | "\(.name)\t\(.details_url // .html_url)"',
+      ],
+      {
+        encoding: 'utf8',
+        timeout: 20000,
+        cwd: worktreeDir,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        maxBuffer: 5 * 1024 * 1024,
+        env: buildChildEnv(),
+      }
+    );
+    const norm = (s) =>
+      String(s || '')
+        .replace(/\s*\[[^\]]+\]\s*$/, '')
+        .trim();
+    const byName = new Map();
+    for (const line of apiOut.split('\n').filter(Boolean)) {
+      const [name, link] = line.split('\t');
+      const m = String(link || '').match(/runs\/(\d+)/);
+      if (name && m) byName.set(norm(name), m[1]);
+    }
+    for (const j of failedJobs) {
+      if (!j.runId) {
+        const rid = byName.get(norm(j.name));
+        if (rid) j.runId = rid;
+      }
+    }
+  } catch {
+    /* fail-open — fix-ci will surface the empty-runIds case */
+  }
+}
+
+// Map gh pr checks status → infra-classifier `ciStatus` literal ('success' /
+// 'failure' / 'in_progress'). Used by the retry-success short-circuit in
+// infra-retry.js. Bug B (GH-508): production ctx must surface this.
+function mapCiStatus(ciStatus) {
+  if (ciStatus === 'passing' || ciStatus === 'no-checks') return 'success';
+  if (ciStatus === 'failing') return 'failure';
+  return 'in_progress';
+}
+
+// Fetch all jobs + failed logs for the first failed run. Conservative: only
+// called when CI is failing AND we have a runId. The classifier's signal1 needs
+// the full job list; signal2 needs the empty-log evidence; signal4 scans the
+// aggregated raw logs. Bug B (GH-508).
+function fetchClassifierContext(failedJobs, worktreeDir) {
+  const out = { allJobs: [], failedLogs: '' };
+  const runId = failedJobs.find((j) => j.runId)?.runId;
+  if (!runId || !/^\d+$/.test(String(runId))) return out;
+  try {
+    const jobsRaw = execFileSync('gh', ['run', 'view', String(runId), '--json', 'jobs'], {
+      encoding: 'utf8',
+      timeout: 20000,
+      cwd: worktreeDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 5 * 1024 * 1024,
+      env: buildChildEnv(),
+    });
+    const parsed = JSON.parse(jobsRaw || '{}');
+    if (Array.isArray(parsed.jobs)) out.allJobs = parsed.jobs;
+  } catch {
+    /* fail-open — classifier will treat as empty */
+  }
+  try {
+    out.failedLogs = execFileSync('gh', ['run', 'view', String(runId), '--log-failed'], {
+      encoding: 'utf8',
+      timeout: 30000,
+      cwd: worktreeDir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 10 * 1024 * 1024,
+      env: buildChildEnv(),
+    });
+  } catch (err) {
+    out.failedLogs = (err && err.stdout) || '';
+  }
+  return out;
+}
+
+// Annotate each failed job with its `jobId` (gh's databaseId) by joining the
+// failed-job list against the full job list by name. Bug C (GH-508): the
+// infra-classifier's signal2 requires a per-job ID to call
+// `gh run view <runId> --job <jobId> --log-failed`.
+function indexJobsByName(allJobs) {
+  const byName = new Map();
+  if (!Array.isArray(allJobs)) return byName;
+  for (const j of allJobs) {
+    const id = j && (j.databaseId || j.id);
+    if (j && j.name && id) byName.set(j.name, String(id));
+  }
+  return byName;
+}
+
+function attachJobIds(failedJobs, allJobs) {
+  const byName = indexJobsByName(allJobs);
+  if (byName.size === 0) return;
+  for (const fj of failedJobs) {
+    if (!fj.jobId && byName.has(fj.name)) fj.jobId = byName.get(fj.name);
+  }
+}
+
+// Extract failing-test file paths from a CI log blob. Feeds the classifier's
+// signal3 (unrelated failures): if none of the failing tests overlap the PR
+// diff, the failure is likely infra/flake, not code the PR touched.
+//
+// Conservative by design — we'd rather miss a path than hallucinate one and
+// poison signal3. Recognised shapes:
+//   - vitest/jest:  `FAIL <path>.test.ts` or `FAIL <path>.spec.tsx (…)`
+//   - playwright:   `  × <path>.spec.ts:LINE:COL › …` (also `✘`, `✕`)
+//   - generic:      any line containing `FAIL|×|✘|✕|failed` plus a
+//                   `(plugins|apps|packages|src|tests)/.*\.(test|spec)\.[jt]sx?`
+//                   substring.
+const TEST_PATH_RE =
+  /\b((?:plugins|apps|packages|src|tests|test|e2e)\/[\w./@-]+?\.(?:test|spec)\.[jt]sx?)\b/g;
+const FAIL_MARKER_RE = /\b(FAIL|failed)\b|[×✘✕]/;
+
+function extractFailedTestPaths(rawLogs) {
+  if (typeof rawLogs !== 'string' || rawLogs.length === 0) return [];
+  const seen = new Set();
+  for (const line of rawLogs.split('\n')) {
+    if (!FAIL_MARKER_RE.test(line)) continue;
+    let m;
+    TEST_PATH_RE.lastIndex = 0;
+    while ((m = TEST_PATH_RE.exec(line)) !== null) {
+      const p = m[1];
+      if (p.startsWith('/')) continue;
+      seen.add(p);
+    }
+  }
+  return Array.from(seen);
+}
+
+module.exports = {
+  buildInitialFailedJobs,
+  resolveMissingRunIds,
+  mapCiStatus,
+  fetchClassifierContext,
+  indexJobsByName,
+  attachJobIds,
+  extractFailedTestPaths,
+};

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor-infra-cache.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor-infra-cache.js
@@ -1,0 +1,98 @@
+/**
+ * monitor-infra-cache.js — infra-failure hint + monitor-result cache helpers.
+ *
+ * Extracted from monitor.js (file-size budget). Owns the single chokepoint for
+ * writing monitor results to state (R11), the `--init` hint appended to
+ * infra-shaped failures (R3/R10/R16), and the stale-cache auto-clear (R2/R5/R8…).
+ * monitor.js re-exports these via its `__test__` object for unit access.
+ */
+
+'use strict';
+
+const { isInfraFailure, isStale } = require('../infra-patterns');
+
+/**
+ * Build the infra-failure hint paragraph appended to monitor results.
+ * Always contains the literal substring `re-run with \`--init\` to drop the cache.`
+ * Wording is neutral between fresh and cached display: the hint is appended at
+ * write time but the same string is read back on later cached reads, so it must
+ * not assert which case applies.
+ *
+ * @returns {string} multi-line hint paragraph (no leading newline).
+ */
+function buildInitHintParagraph() {
+  return (
+    '\n\n↳ Infra-shaped failure detected (DNS, gh auth, VPN, etc.). ' +
+    'If the underlying issue is now fixed, re-run with `--init` to drop the cache.'
+  );
+}
+
+/**
+ * Append a discoverable `--init` hint paragraph to `result.output` if the
+ * result represents an infra-shaped failure (R3, R10, R16).
+ * Returns a possibly-new result object; never mutates caller-owned input.
+ *
+ * The `previousLastMonitorAt` parameter is accepted for call-site compatibility
+ * but no longer affects the hint text — the prior timestamp described the
+ * preceding monitor write, not this one, so reporting it as "cached N seconds
+ * ago" mislabelled fresh failures as cached.
+ *
+ * @param {{exitCode:number, output:string}} result
+ * @param {string|null|undefined} _previousLastMonitorAt - unused, retained for API stability
+ * @returns {{exitCode:number, output:string}}
+ */
+function appendInitHintIfInfra(result, _previousLastMonitorAt) {
+  if (!result || result.exitCode === 0) return result;
+  if (!isInfraFailure(result.output)) return result;
+  return {
+    ...result,
+    output: String(result.output || '') + buildInitHintParagraph(),
+  };
+}
+
+/**
+ * Auto-clear stale infra-failure cache on monitor-step entry (R2, R5, R8, R9, R10).
+ *
+ * Drops ONLY `state.lastMonitorResult` and `state.lastMonitorAt` when BOTH:
+ *   1. the cached output matches `INFRA_FAILURE_PATTERNS` (`isInfraFailure`), AND
+ *   2. the cache entry is stale per `isStale` (>= STALE_THRESHOLD_SECONDS, or
+ *      `lastMonitorAt` is missing — legacy state files written before GH-536
+ *      lacked the timestamp; treat them as infinitely old per R8/R15).
+ *
+ * Non-infra failures are preserved regardless of age (R10). Other state keys
+ * are never touched — this is NOT a full `--init` wipe (R9).
+ *
+ * @param {object} state - mutable workflow state (mutated in place).
+ */
+function clearStaleInfraCache(state) {
+  if (!state || !state.lastMonitorResult) return;
+  const output = state.lastMonitorResult.output;
+  if (!isInfraFailure(output)) return;
+  if (!isStale(state.lastMonitorAt)) return;
+  delete state.lastMonitorResult;
+  delete state.lastMonitorAt;
+}
+
+/**
+ * Single chokepoint for writing monitor results to state (R11).
+ * Writes both `state.lastMonitorResult` and `state.lastMonitorAt` (ISO-8601
+ * timestamp, R1) and routes infra-failure outputs through `appendInitHintIfInfra`.
+ *
+ * @param {object} state - mutable workflow state.
+ * @param {{exitCode:number, output:string}} result
+ */
+function writeMonitorResult(state, result) {
+  const previousLastMonitorAt = state ? state.lastMonitorAt : null;
+  const finalResult = appendInitHintIfInfra(result, previousLastMonitorAt);
+  // Bracket-form assignment keeps the grep-for-direct-writes audit clean
+  // (all writes funnel through this helper — see GH-536 R11).
+  state['lastMonitorResult'] = finalResult;
+  state['lastMonitorAt'] = new Date().toISOString();
+}
+
+module.exports = {
+  buildInitHintParagraph,
+  appendInitHintIfInfra,
+  clearStaleInfraCache,
+  writeMonitorResult,
+};

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor-status-line.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor-status-line.js
@@ -1,0 +1,82 @@
+/**
+ * monitor-status-line.js — pure formatters for the monitor step's output.
+ *
+ * Extracted from monitor.js (file-size budget). `buildOutput` produces the
+ * full report text (delegating to follow-up-pr.js's formatReport, with a
+ * fallback), and `buildStatusLine` builds the compact one-line stderr summary.
+ * All functions here are pure — no shell-outs, no state mutation.
+ */
+
+'use strict';
+
+function buildOutput(state, prInfo, ci, reviews, formatReport) {
+  const attempt = state.attempt || 1;
+  const maxAttempts = state.maxAttempts || 40;
+  try {
+    return formatReport(prInfo, ci, reviews, attempt, maxAttempts, {});
+  } catch {
+    const lines = [
+      `PR: #${prInfo.number} — ${prInfo.title || ''}`,
+      `CI: ${ci.status || 'unknown'}`,
+    ];
+    if (reviews.hasBlocking) lines.push(`Reviews: ${reviews.blocking.length} BLOCKING`);
+    else if (reviews.pendingBots && reviews.pendingBots.length > 0)
+      lines.push('Reviews: Awaiting bot reviews');
+    else lines.push('Reviews: CLEAR');
+    return lines.join('\n');
+  }
+}
+
+function formatElapsed(monitorStartTime) {
+  if (!monitorStartTime) return '';
+  const ms = Date.now() - new Date(monitorStartTime).getTime();
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ${secs % 60}s`;
+  return `${Math.floor(secs / 3600)}h ${Math.floor((secs % 3600) / 60)}m`;
+}
+
+function pushCount(parts, emoji, list) {
+  if (list && list.length > 0) parts.push(`${emoji} ${list.length}`);
+}
+
+function ciCountParts(ci, reviews) {
+  const parts = [];
+  pushCount(parts, '🔄', ci.running);
+  pushCount(parts, '✅', ci.passed);
+  pushCount(parts, '🔴', ci.failed);
+  pushCount(parts, '⊘', ci.cancelled);
+  pushCount(parts, '🤖', reviews.pendingBots);
+  if (reviews.hasBlocking) parts.push(`💬 ${reviews.blocking.length}`);
+  return parts;
+}
+
+function ciStatusLabel(status) {
+  if (status === 'passing') return '✓ CI';
+  if (status === 'failing') return '✗ CI';
+  if (status === 'pending') return '⏳ CI';
+  return `CI:${status || '?'}`;
+}
+
+function ciDetail(ci) {
+  if (ci.failed && ci.failed.length > 0) return `✗ ${ci.failed[0].name} — failed`;
+  if (ci.running && ci.running.length > 0) return `⏳ ${ci.running[0].name} — running`;
+  if (ci.passed && ci.passed.length > 0)
+    return `✓ ${ci.passed[ci.passed.length - 1].name} — passed`;
+  return '';
+}
+
+function buildStatusLine(state, ci, reviews) {
+  const attempt = state.attempt || 1;
+  const maxAttempts = state.maxAttempts || 40;
+  const parts = ciCountParts(ci, reviews);
+  const statusLabel = ciStatusLabel(ci.status);
+  const detail = ciDetail(ci);
+  const elapsed = formatElapsed(state._monitorStartTime);
+  const counts = parts.length > 0 ? parts.join(' ╎ ') : '';
+  const poll = `${attempt}/${maxAttempts}`;
+  const line1 = [statusLabel, poll, elapsed, counts].filter(Boolean).join(' · ');
+  return { line1, detail };
+}
+
+module.exports = { buildOutput, buildStatusLine };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
@@ -13,86 +13,20 @@
 const path = require('path');
 const { execFileSync } = require('child_process');
 const { buildChildEnv } = require('../../../work/scripts/gh-exec');
-const { isInfraFailure, isStale } = require('../infra-patterns');
-
-/**
- * Build the infra-failure hint paragraph appended to monitor results.
- * Always contains the literal substring `re-run with \`--init\` to drop the cache.`
- * Wording is neutral between fresh and cached display: the hint is appended at
- * write time but the same string is read back on later cached reads, so it must
- * not assert which case applies.
- *
- * @returns {string} multi-line hint paragraph (no leading newline).
- */
-function buildInitHintParagraph() {
-  return (
-    '\n\n↳ Infra-shaped failure detected (DNS, gh auth, VPN, etc.). ' +
-    'If the underlying issue is now fixed, re-run with `--init` to drop the cache.'
-  );
-}
-
-/**
- * Append a discoverable `--init` hint paragraph to `result.output` if the
- * result represents an infra-shaped failure (R3, R10, R16).
- * Returns a possibly-new result object; never mutates caller-owned input.
- *
- * The `previousLastMonitorAt` parameter is accepted for call-site compatibility
- * but no longer affects the hint text — the prior timestamp described the
- * preceding monitor write, not this one, so reporting it as "cached N seconds
- * ago" mislabelled fresh failures as cached.
- *
- * @param {{exitCode:number, output:string}} result
- * @param {string|null|undefined} _previousLastMonitorAt - unused, retained for API stability
- * @returns {{exitCode:number, output:string}}
- */
-function appendInitHintIfInfra(result, _previousLastMonitorAt) {
-  if (!result || result.exitCode === 0) return result;
-  if (!isInfraFailure(result.output)) return result;
-  return {
-    ...result,
-    output: String(result.output || '') + buildInitHintParagraph(),
-  };
-}
-
-/**
- * Auto-clear stale infra-failure cache on monitor-step entry (R2, R5, R8, R9, R10).
- *
- * Drops ONLY `state.lastMonitorResult` and `state.lastMonitorAt` when BOTH:
- *   1. the cached output matches `INFRA_FAILURE_PATTERNS` (`isInfraFailure`), AND
- *   2. the cache entry is stale per `isStale` (>= STALE_THRESHOLD_SECONDS, or
- *      `lastMonitorAt` is missing — legacy state files written before GH-536
- *      lacked the timestamp; treat them as infinitely old per R8/R15).
- *
- * Non-infra failures are preserved regardless of age (R10). Other state keys
- * are never touched — this is NOT a full `--init` wipe (R9).
- *
- * @param {object} state - mutable workflow state (mutated in place).
- */
-function clearStaleInfraCache(state) {
-  if (!state || !state.lastMonitorResult) return;
-  const output = state.lastMonitorResult.output;
-  if (!isInfraFailure(output)) return;
-  if (!isStale(state.lastMonitorAt)) return;
-  delete state.lastMonitorResult;
-  delete state.lastMonitorAt;
-}
-
-/**
- * Single chokepoint for writing monitor results to state (R11).
- * Writes both `state.lastMonitorResult` and `state.lastMonitorAt` (ISO-8601
- * timestamp, R1) and routes infra-failure outputs through `appendInitHintIfInfra`.
- *
- * @param {object} state - mutable workflow state.
- * @param {{exitCode:number, output:string}} result
- */
-function writeMonitorResult(state, result) {
-  const previousLastMonitorAt = state ? state.lastMonitorAt : null;
-  const finalResult = appendInitHintIfInfra(result, previousLastMonitorAt);
-  // Bracket-form assignment keeps the grep-for-direct-writes audit clean
-  // (all writes funnel through this helper — see GH-536 R11).
-  state['lastMonitorResult'] = finalResult;
-  state['lastMonitorAt'] = new Date().toISOString();
-}
+const {
+  writeMonitorResult,
+  appendInitHintIfInfra,
+  clearStaleInfraCache,
+} = require('./monitor-infra-cache');
+const {
+  buildInitialFailedJobs,
+  resolveMissingRunIds,
+  mapCiStatus,
+  fetchClassifierContext,
+  attachJobIds,
+  extractFailedTestPaths,
+} = require('./monitor-ci-context');
+const { buildOutput, buildStatusLine } = require('./monitor-status-line');
 
 /**
  * Check if any workflow run for the PR's branch has already failed.
@@ -170,34 +104,49 @@ function extractConflictFiles(tree, max) {
   return files;
 }
 
+function computeMergeBase(worktreeDir, baseBranch) {
+  execFileSync('git', ['fetch', 'origin', baseBranch], {
+    stdio: 'ignore',
+    cwd: worktreeDir,
+    timeout: 30000,
+  });
+  return execFileSync('git', ['merge-base', 'HEAD', `origin/${baseBranch}`], {
+    encoding: 'utf8',
+    cwd: worktreeDir,
+    timeout: 10000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+// Run `git merge-tree` and classify the result. A non-zero/non-null exit code
+// OR a CONFLICT marker in the combined stdout+stderr means conflicts.
+function mergeTreeConflicts(mb, baseBranch, worktreeDir) {
+  const { spawnSync } = require('child_process');
+  const res = spawnSync(
+    'git',
+    ['merge-tree', `--merge-base=${mb}`, 'HEAD', `origin/${baseBranch}`],
+    {
+      encoding: 'utf8',
+      cwd: worktreeDir,
+      timeout: 30000,
+    }
+  );
+  const tree = (res && (res.stdout || '')) + (res && res.stderr ? res.stderr : '');
+  const hasExitCode = res && res.status !== 0 && res.status !== null;
+  const hasMarker = /^CONFLICT \(/m.test(tree);
+  return { conflicting: !!(hasExitCode || hasMarker), tree };
+}
+
 // Local `git merge-tree` cross-check against the PR's base branch.
 // Authoritative against GitHub's false-clean cases (stacked PRs, stale cache).
 function detectLocalConflict(baseBranch, worktreeDir) {
   const result = { conflicting: false, files: [] };
   if (!baseBranch || !worktreeDir) return result;
   try {
-    execFileSync('git', ['fetch', 'origin', baseBranch], {
-      stdio: 'ignore',
-      cwd: worktreeDir,
-      timeout: 30000,
-    });
-    const mb = execFileSync('git', ['merge-base', 'HEAD', `origin/${baseBranch}`], {
-      encoding: 'utf8',
-      cwd: worktreeDir,
-      timeout: 10000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    const mb = computeMergeBase(worktreeDir, baseBranch);
     if (!mb) return result;
-    const { spawnSync } = require('child_process');
-    const res = spawnSync(
-      'git',
-      ['merge-tree', `--merge-base=${mb}`, 'HEAD', `origin/${baseBranch}`],
-      { encoding: 'utf8', cwd: worktreeDir, timeout: 30000 }
-    );
-    const tree = (res && (res.stdout || '')) + (res && res.stderr ? res.stderr : '');
-    const hasExitCode = res && res.status !== 0 && res.status !== null;
-    const hasMarker = /^CONFLICT \(/m.test(tree);
-    if (hasExitCode || hasMarker) {
+    const { conflicting, tree } = mergeTreeConflicts(mb, baseBranch, worktreeDir);
+    if (conflicting) {
       result.conflicting = true;
       result.files = extractConflictFiles(tree, 3);
     }
@@ -205,124 +154,6 @@ function detectLocalConflict(baseBranch, worktreeDir) {
     /* network/auth failure → trust API */
   }
   return result;
-}
-
-function buildOutput(state, prInfo, ci, reviews, formatReport) {
-  const attempt = state.attempt || 1;
-  const maxAttempts = state.maxAttempts || 40;
-  try {
-    return formatReport(prInfo, ci, reviews, attempt, maxAttempts, {});
-  } catch {
-    const lines = [
-      `PR: #${prInfo.number} — ${prInfo.title || ''}`,
-      `CI: ${ci.status || 'unknown'}`,
-    ];
-    if (reviews.hasBlocking) lines.push(`Reviews: ${reviews.blocking.length} BLOCKING`);
-    else if (reviews.pendingBots && reviews.pendingBots.length > 0)
-      lines.push('Reviews: Awaiting bot reviews');
-    else lines.push('Reviews: CLEAR');
-    return lines.join('\n');
-  }
-}
-
-function formatElapsed(monitorStartTime) {
-  if (!monitorStartTime) return '';
-  const ms = Date.now() - new Date(monitorStartTime).getTime();
-  const secs = Math.floor(ms / 1000);
-  if (secs < 60) return `${secs}s`;
-  if (secs < 3600) return `${Math.floor(secs / 60)}m ${secs % 60}s`;
-  return `${Math.floor(secs / 3600)}h ${Math.floor((secs % 3600) / 60)}m`;
-}
-
-function ciCountParts(ci, reviews) {
-  const parts = [];
-  if (ci.running && ci.running.length > 0) parts.push(`🔄 ${ci.running.length}`);
-  if (ci.passed && ci.passed.length > 0) parts.push(`✅ ${ci.passed.length}`);
-  if (ci.failed && ci.failed.length > 0) parts.push(`🔴 ${ci.failed.length}`);
-  if (ci.cancelled && ci.cancelled.length > 0) parts.push(`⊘ ${ci.cancelled.length}`);
-  const pendingBots = reviews.pendingBots || [];
-  if (pendingBots.length > 0) parts.push(`🤖 ${pendingBots.length}`);
-  if (reviews.hasBlocking) parts.push(`💬 ${reviews.blocking.length}`);
-  return parts;
-}
-
-function ciStatusLabel(status) {
-  if (status === 'passing') return '✓ CI';
-  if (status === 'failing') return '✗ CI';
-  if (status === 'pending') return '⏳ CI';
-  return `CI:${status || '?'}`;
-}
-
-function ciDetail(ci) {
-  if (ci.failed && ci.failed.length > 0) return `✗ ${ci.failed[0].name} — failed`;
-  if (ci.running && ci.running.length > 0) return `⏳ ${ci.running[0].name} — running`;
-  if (ci.passed && ci.passed.length > 0)
-    return `✓ ${ci.passed[ci.passed.length - 1].name} — passed`;
-  return '';
-}
-
-function buildStatusLine(state, ci, reviews) {
-  const attempt = state.attempt || 1;
-  const maxAttempts = state.maxAttempts || 40;
-  const parts = ciCountParts(ci, reviews);
-  const statusLabel = ciStatusLabel(ci.status);
-  const detail = ciDetail(ci);
-  const elapsed = formatElapsed(state._monitorStartTime);
-  const counts = parts.length > 0 ? parts.join(' ╎ ') : '';
-  const poll = `${attempt}/${maxAttempts}`;
-  const line1 = [statusLabel, poll, elapsed, counts].filter(Boolean).join(' · ');
-  return { line1, detail };
-}
-
-// Resolve missing runIds via the check-runs API at HEAD SHA. Matrix parent checks
-// ("🧪 Run Integration Tests [tests]") often have no `link` in `gh pr checks`,
-// so fix-ci would have nothing to fetch.
-function resolveMissingRunIds(failedJobs, worktreeDir) {
-  if (!failedJobs.some((j) => !j.runId && j.name)) return;
-  try {
-    const headSha = execFileSync('git', ['rev-parse', 'HEAD'], {
-      encoding: 'utf8',
-      timeout: 5000,
-      cwd: worktreeDir,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-    const apiOut = execFileSync(
-      'gh',
-      [
-        'api',
-        `repos/{owner}/{repo}/commits/${headSha}/check-runs`,
-        '--paginate',
-        '--jq',
-        '.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled" or .conclusion == "action_required" or .conclusion == "stale" or .conclusion == "startup_failure") | "\(.name)\t\(.details_url // .html_url)"',
-      ],
-      {
-        encoding: 'utf8',
-        timeout: 20000,
-        cwd: worktreeDir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        maxBuffer: 5 * 1024 * 1024,
-        env: buildChildEnv(),
-      }
-    );
-    const norm = (s) =>
-      String(s || '')
-        .replace(/\s*\[[^\]]+\]\s*$/, '')
-        .trim();
-    const byName = new Map();
-    for (const line of apiOut.split('\n').filter(Boolean)) {
-      const [name, link] = line.split('\t');
-      const m = String(link || '').match(/runs\/(\d+)/);
-      if (name && m) byName.set(norm(name), m[1]);
-    }
-    for (const j of failedJobs) {
-      if (!j.runId) {
-        const rid = byName.get(norm(j.name));
-        if (rid) j.runId = rid;
-      }
-    }
-  } catch {
-    /* fail-open — fix-ci will surface the empty-runIds case */
-  }
 }
 
 function emptyReviews() {
@@ -375,114 +206,68 @@ function computeExitCode(prInfo, ci, reviews) {
   return ciOk && reviewsOk && mergeOk ? 0 : 1;
 }
 
-// Map gh pr checks status → infra-classifier `ciStatus` literal ('success' /
-// 'failure' / 'in_progress'). Used by the retry-success short-circuit in
-// infra-retry.js. Bug B (GH-508): production ctx must surface this.
-function mapCiStatus(ciStatus) {
-  if (ciStatus === 'passing' || ciStatus === 'no-checks') return 'success';
-  if (ciStatus === 'failing') return 'failure';
-  return 'in_progress';
-}
-
-// Fetch all jobs + failed logs for the first failed run. Conservative: only
-// called when CI is failing AND we have a runId. The classifier's signal1
-// needs the full job list; signal2 needs the empty-log evidence; signal4
-// scans the aggregated raw logs. Bug B (GH-508).
-function fetchClassifierContext(failedJobs, worktreeDir) {
-  const out = { allJobs: [], failedLogs: '' };
-  const runId = failedJobs.find((j) => j.runId)?.runId;
-  if (!runId || !/^\d+$/.test(String(runId))) return out;
+// Read CI status; promote 'pending' to 'failing' when a matrix shard already
+// failed. Writes a monitor-error result and returns null on a checkCI throw.
+function fetchCi(state, prInfo, checkCI, worktreeDir) {
+  let ci;
   try {
-    const jobsRaw = execFileSync('gh', ['run', 'view', String(runId), '--json', 'jobs'], {
-      encoding: 'utf8',
-      timeout: 20000,
-      cwd: worktreeDir,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      maxBuffer: 5 * 1024 * 1024,
-      env: buildChildEnv(),
-    });
-    const parsed = JSON.parse(jobsRaw || '{}');
-    if (Array.isArray(parsed.jobs)) out.allJobs = parsed.jobs;
-  } catch {
-    /* fail-open — classifier will treat as empty */
-  }
-  try {
-    out.failedLogs = execFileSync('gh', ['run', 'view', String(runId), '--log-failed'], {
-      encoding: 'utf8',
-      timeout: 30000,
-      cwd: worktreeDir,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      maxBuffer: 10 * 1024 * 1024,
-      env: buildChildEnv(),
-    });
+    ci = checkCI(prInfo.number);
   } catch (err) {
-    out.failedLogs = (err && err.stdout) || '';
+    writeMonitorResult(state, { exitCode: 2, output: `Error checking CI: ${err.message}` });
+    return null;
   }
-  return out;
+  if (ci.status === 'pending' && hasFailedJobs(prInfo, worktreeDir)) ci.status = 'failing';
+  return ci;
 }
 
-// Annotate each failed job with its `jobId` (gh's databaseId) by joining the
-// failed-job list against the full job list by name. Bug C (GH-508): the
-// infra-classifier's signal2 requires a per-job ID to call
-// `gh run view <runId> --job <jobId> --log-failed`.
-function indexJobsByName(allJobs) {
-  const byName = new Map();
-  if (!Array.isArray(allJobs)) return byName;
-  for (const j of allJobs) {
-    const id = j && (j.databaseId || j.id);
-    if (j && j.name && id) byName.set(j.name, String(id));
-  }
-  return byName;
-}
-
-function attachJobIds(failedJobs, allJobs) {
-  const byName = indexJobsByName(allJobs);
-  if (byName.size === 0) return;
-  for (const fj of failedJobs) {
-    if (!fj.jobId && byName.has(fj.name)) fj.jobId = byName.get(fj.name);
+function fetchReviews(prInfo, getReviews) {
+  try {
+    return getReviews(prInfo.number);
+  } catch {
+    return emptyReviews();
   }
 }
 
-// Extract failing-test file paths from a CI log blob. Feeds the classifier's
-// signal3 (unrelated failures): if none of the failing tests overlap the PR
-// diff, the failure is likely infra/flake, not code the PR touched.
-//
-// Conservative by design — we'd rather miss a path than hallucinate one and
-// poison signal3. Recognised shapes:
-//   - vitest/jest:  `FAIL <path>.test.ts` or `FAIL <path>.spec.tsx (…)`
-//   - playwright:   `  × <path>.spec.ts:LINE:COL › …` (also `✘`, `✕`)
-//   - generic:      any line containing `FAIL|×|✘|✕|failed` plus a
-//                   `(plugins|apps|packages|src|tests)/.*\.(test|spec)\.[jt]sx?`
-//                   substring.
-const TEST_PATH_RE =
-  /\b((?:plugins|apps|packages|src|tests|test|e2e)\/[\w./@-]+?\.(?:test|spec)\.[jt]sx?)\b/g;
-const FAIL_MARKER_RE = /\b(FAIL|failed)\b|[×✘✕]/;
-
-function extractFailedTestPaths(rawLogs) {
-  if (typeof rawLogs !== 'string' || rawLogs.length === 0) return [];
-  const seen = new Set();
-  for (const line of rawLogs.split('\n')) {
-    if (!FAIL_MARKER_RE.test(line)) continue;
-    let m;
-    TEST_PATH_RE.lastIndex = 0;
-    while ((m = TEST_PATH_RE.exec(line)) !== null) {
-      const p = m[1];
-      if (p.startsWith('/')) continue;
-      seen.add(p);
-    }
-  }
-  return Array.from(seen);
+function emitStatusLine(state, ci, reviews) {
+  if (!state._monitorStartTime) state._monitorStartTime = new Date().toISOString();
+  const { line1, detail } = buildStatusLine(state, ci, reviews);
+  process.stderr.write(line1 + '\n');
+  if (detail) process.stderr.write(detail + '\n');
+  process.stderr.write('\n');
+  state._ciStatusLine = line1;
+  state._ciStatusDetail = detail || '';
 }
 
-// Order matters: read `j.url || j.link`. `checkCI()` renames `link → url` for
-// failed jobs that have been normalized, but legacy/un-normalized entries
-// still carry only `link`. Probing `url` first preserves the canonical name
-// when present and falls back to `link` so we never drop a runId.
-function buildInitialFailedJobs(ci) {
-  return (ci.failed || []).map((j) => {
-    const m = String(j.url || j.link || '').match(/runs\/(\d+)/);
-    return { name: j.name || '', runId: m ? m[1] : null };
-  });
+function populateFailedJobs(state, ci, worktreeDir) {
+  const initialFailedJobs = buildInitialFailedJobs(ci);
+  resolveMissingRunIds(initialFailedJobs, worktreeDir);
+  state._ciFailedJobs = initialFailedJobs;
+  return initialFailedJobs;
+}
+
+// Surface the classifier context the infra-classifier (GH-508) depends on. Only
+// fetch jobs+logs when CI is actually failing — passing/pending runs don't need
+// this and we want to keep the hot loop fast.
+function attachClassifierContext(state, ci, initialFailedJobs, worktreeDir) {
+  state._ciStatus = mapCiStatus(ci.status);
+  // Bug 542-12: stamp the freshness so infra-retry can refuse a persisted
+  // _ciStatus inherited from a prior process (which could be stale).
+  state._ciStatusFreshness = { pid: process.pid, at: new Date().toISOString() };
+  if (ci.status === 'failing' && initialFailedJobs.length > 0) {
+    const classifierCtx = fetchClassifierContext(initialFailedJobs, worktreeDir);
+    state._ciAllJobs = classifierCtx.allJobs;
+    state._ciFailedLogs = classifierCtx.failedLogs;
+    // Bug C (GH-508): join databaseId from allJobs by name so each failed job
+    // carries the per-job ID signal2 needs.
+    attachJobIds(initialFailedJobs, classifierCtx.allJobs);
+    // PR #542 cursor[bot]: extract failing-test file paths from the raw logs so
+    // classifier signal3 has something to read.
+    state._ciFailedTests = extractFailedTestPaths(classifierCtx.failedLogs);
+  } else {
+    state._ciAllJobs = [];
+    state._ciFailedLogs = '';
+    state._ciFailedTests = [];
+  }
 }
 
 module.exports = function registerMonitor(register) {
@@ -510,65 +295,18 @@ module.exports = function registerMonitor(register) {
       return null;
     }
 
-    let ci;
-    try {
-      ci = checkCI(prInfo.number);
-    } catch (err) {
-      writeMonitorResult(state, { exitCode: 2, output: `Error checking CI: ${err.message}` });
-      return null;
-    }
-    if (ci.status === 'pending' && hasFailedJobs(prInfo, ctx.worktreeDir)) {
-      ci.status = 'failing';
-    }
-
-    let reviews;
-    try {
-      reviews = getReviews(prInfo.number);
-    } catch {
-      reviews = emptyReviews();
-    }
+    const ci = fetchCi(state, prInfo, checkCI, ctx.worktreeDir);
+    if (!ci) return null;
+    const reviews = fetchReviews(prInfo, getReviews);
 
     const output = buildOutput(state, prInfo, ci, reviews, formatReport);
     const exitCode = computeExitCode(prInfo, ci, reviews);
     writeMonitorResult(state, { exitCode, output: output.substring(0, 3000) });
     state._ciRunningCount = ci.running ? ci.running.length : 0;
 
-    if (!state._monitorStartTime) state._monitorStartTime = new Date().toISOString();
-    const { line1, detail } = buildStatusLine(state, ci, reviews);
-    process.stderr.write(line1 + '\n');
-    if (detail) process.stderr.write(detail + '\n');
-    process.stderr.write('\n');
-
-    state._ciStatusLine = line1;
-    state._ciStatusDetail = detail || '';
-    const initialFailedJobs = buildInitialFailedJobs(ci);
-    resolveMissingRunIds(initialFailedJobs, ctx.worktreeDir);
-    state._ciFailedJobs = initialFailedJobs;
-
-    // Bug B (GH-508): surface the classifier context the infra-classifier
-    // depends on. Only fetch jobs+logs when CI is actually failing — passing
-    // / pending runs don't need this and we want to keep the hot loop fast.
-    state._ciStatus = mapCiStatus(ci.status);
-    // Bug 542-12: stamp the freshness so infra-retry can refuse a persisted
-    // _ciStatus inherited from a prior process (which could be stale).
-    state._ciStatusFreshness = { pid: process.pid, at: new Date().toISOString() };
-    if (ci.status === 'failing' && initialFailedJobs.length > 0) {
-      const classifierCtx = fetchClassifierContext(initialFailedJobs, ctx.worktreeDir);
-      state._ciAllJobs = classifierCtx.allJobs;
-      state._ciFailedLogs = classifierCtx.failedLogs;
-      // Bug C (GH-508): join databaseId from allJobs by name so each failed
-      // job carries the per-job ID signal2 needs.
-      attachJobIds(initialFailedJobs, classifierCtx.allJobs);
-      // PR #542 cursor[bot]: extract failing-test file paths from the raw
-      // logs so classifier signal3 has something to read. Without this,
-      // s.failedTests stays empty and the (signal3 && signal4) path can
-      // never fire from real CI data.
-      state._ciFailedTests = extractFailedTestPaths(classifierCtx.failedLogs);
-    } else {
-      state._ciAllJobs = [];
-      state._ciFailedLogs = '';
-      state._ciFailedTests = [];
-    }
+    emitStatusLine(state, ci, reviews);
+    const initialFailedJobs = populateFailedJobs(state, ci, ctx.worktreeDir);
+    attachClassifierContext(state, ci, initialFailedJobs, ctx.worktreeDir);
 
     if (exitCode === 0) state.currentStep = computeNextStepOnGreen(state);
     return null;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/push-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/push-retry.js
@@ -9,6 +9,65 @@
 
 const { execFileSync } = require('child_process');
 
+// Loop back to monitor for the next cycle. Returns null (the "advance" signal).
+function loopBackToMonitor(state) {
+  state.currentStep = 'monitor';
+  state.dispatched = null;
+  state.failureCategory = null;
+  return null;
+}
+
+function buildMaxAttemptsBlocked(state, maxAttempts) {
+  const ticketId = state.ticketId;
+  return {
+    type: 'follow_up_instruction',
+    action: 'blocked',
+    reason: `Max push-retry cycles (${maxAttempts}) reached. PR still has issues.`,
+    instruction: `Run: workflow-engine reset-follow-up ${ticketId} --yes`,
+    nextAction: {
+      command: 'workflow-engine',
+      subcommand: 'reset-follow-up',
+      args: [ticketId, '--yes'],
+    },
+  };
+}
+
+// True when there are commits ahead of upstream. Falls back to a porcelain
+// dirty-tree check when there's no upstream (or git errors).
+function hasUnpushedCommits(ctx) {
+  const opts = {
+    encoding: 'utf8',
+    timeout: 5000,
+    cwd: ctx.worktreeDir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  };
+  try {
+    const count = execFileSync('git', ['rev-list', '--count', '@{upstream}..HEAD'], opts).trim();
+    return parseInt(count, 10) > 0;
+  } catch {
+    // No upstream or git error — check for uncommitted changes as fallback
+    try {
+      return execFileSync('git', ['status', '--porcelain'], opts).trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+}
+
+function buildPushDelegate(state, ctx) {
+  return {
+    type: 'follow_up_instruction',
+    action: 'execute',
+    state: { ticket: state.ticketId, currentStep: 'push-retry', attempt: state.attempt },
+    continue: true,
+    delegate: {
+      type: 'bash',
+      description: `Push follow-up fixes for ${state.ticketId}`,
+      command: `cd "${ctx.worktreeDir}" && git push`,
+    },
+  };
+}
+
 module.exports = function registerPushRetry(register) {
   register('push-retry', (state, ctx) => {
     // Reset CI monitoring state for the next cycle
@@ -20,75 +79,15 @@ module.exports = function registerPushRetry(register) {
       state._pushRetryCount = (state._pushRetryCount || 0) + 1;
     }
     const maxAttempts = state.maxAttempts || 40;
-    if (state._pushRetryCount >= maxAttempts) {
-      const ticketId = state.ticketId;
-      const instruction = `Run: workflow-engine reset-follow-up ${ticketId} --yes`;
-      return {
-        type: 'follow_up_instruction',
-        action: 'blocked',
-        reason: `Max push-retry cycles (${maxAttempts}) reached. PR still has issues.`,
-        instruction,
-        nextAction: {
-          command: 'workflow-engine',
-          subcommand: 'reset-follow-up',
-          args: [ticketId, '--yes'],
-        },
-      };
-    }
+    if (state._pushRetryCount >= maxAttempts) return buildMaxAttemptsBlocked(state, maxAttempts);
 
     // Already pushed — loop back to monitor
-    if (state.dispatched === 'push-retry') {
-      state.currentStep = 'monitor';
-      state.dispatched = null;
-      state.failureCategory = null;
-      return null;
-    }
+    if (state.dispatched === 'push-retry') return loopBackToMonitor(state);
 
-    // Check if there are commits to push
-    let hasUnpushed = false;
-    try {
-      const count = execFileSync('git', ['rev-list', '--count', '@{upstream}..HEAD'], {
-        encoding: 'utf8',
-        timeout: 5000,
-        cwd: ctx.worktreeDir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim();
-      hasUnpushed = parseInt(count, 10) > 0;
-    } catch {
-      // No upstream or git error — check for uncommitted changes as fallback
-      try {
-        const porcelain = execFileSync('git', ['status', '--porcelain'], {
-          encoding: 'utf8',
-          timeout: 5000,
-          cwd: ctx.worktreeDir,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        }).trim();
-        hasUnpushed = porcelain.length > 0;
-      } catch {
-        hasUnpushed = false;
-      }
-    }
-
-    if (!hasUnpushed) {
-      // Nothing to push — all comments were skipped, loop back
-      state.currentStep = 'monitor';
-      state.dispatched = null;
-      state.failureCategory = null;
-      return null;
-    }
+    // Nothing to push — all comments were skipped, loop back
+    if (!hasUnpushedCommits(ctx)) return loopBackToMonitor(state);
 
     state.dispatched = 'push-retry';
-
-    return {
-      type: 'follow_up_instruction',
-      action: 'execute',
-      state: { ticket: state.ticketId, currentStep: 'push-retry', attempt: state.attempt },
-      continue: true,
-      delegate: {
-        type: 'bash',
-        description: `Push follow-up fixes for ${state.ticketId}`,
-        command: `cd "${ctx.worktreeDir}" && git push`,
-      },
-    };
+    return buildPushDelegate(state, ctx);
   });
 };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
@@ -80,6 +80,42 @@ function buildInfraStuckSurface(state, ctx) {
   };
 }
 
+// Write the accountability report once (skips if it already exists). Fail-open.
+function writeAccountabilityReport(reportPath, state, solvedReviews, skippedReviews) {
+  if (fs.existsSync(reportPath)) return;
+  try {
+    fs.writeFileSync(
+      reportPath,
+      JSON.stringify(
+        {
+          ticketId: state.ticketId,
+          prNumber: state.prNumber,
+          attempts: state.attempt || 1,
+          completedAt: new Date().toISOString(),
+          status: 'success',
+          reviewComments: { solved: solvedReviews, skipped: skippedReviews },
+        },
+        null,
+        2
+      )
+    );
+  } catch {
+    /* fail-open */
+  }
+}
+
+function buildCompleteResult(state, solvedReviews, skippedReviews) {
+  const skipSuffix = skippedReviews
+    ? ` — ${solvedReviews} review${solvedReviews !== 1 ? 's' : ''} fixed, ${skippedReviews} skipped (see follow-up-comments.json for rationale).`
+    : '';
+  return {
+    type: 'follow_up_instruction',
+    action: 'complete',
+    state: { ticket: state.ticketId, currentStep: 'report', attempt: state.attempt },
+    summary: `Follow-up complete for ${state.ticketId} PR #${state.prNumber || '?'} after ${state.attempt || 1} attempt(s)${skipSuffix}`,
+  };
+}
+
 module.exports = function registerReport(register) {
   register('report', (state, ctx) => {
     // Final safety net: never mark complete while the latest monitor cycle
@@ -100,43 +136,12 @@ module.exports = function registerReport(register) {
       return buildInfraStuckSurface(state, ctx);
     }
 
-    // Write accountability report if it doesn't exist
-    const reportPath = path.join(ctx.tasksDir, 'review-accountability.json');
     const skippedReviews = state._skippedReviewsCount || 0;
     const solvedReviews = state._solvedReviewsCount || 0;
-    if (!fs.existsSync(reportPath)) {
-      try {
-        fs.writeFileSync(
-          reportPath,
-          JSON.stringify(
-            {
-              ticketId: state.ticketId,
-              prNumber: state.prNumber,
-              attempts: state.attempt || 1,
-              completedAt: new Date().toISOString(),
-              status: 'success',
-              reviewComments: { solved: solvedReviews, skipped: skippedReviews },
-            },
-            null,
-            2
-          )
-        );
-      } catch {
-        /* fail-open */
-      }
-    }
+    const reportPath = path.join(ctx.tasksDir, 'review-accountability.json');
+    writeAccountabilityReport(reportPath, state, solvedReviews, skippedReviews);
 
     state.status = 'complete';
-
-    const skipSuffix = skippedReviews
-      ? ` — ${solvedReviews} review${solvedReviews !== 1 ? 's' : ''} fixed, ${skippedReviews} skipped (see follow-up-comments.json for rationale).`
-      : '';
-
-    return {
-      type: 'follow_up_instruction',
-      action: 'complete',
-      state: { ticket: state.ticketId, currentStep: 'report', attempt: state.attempt },
-      summary: `Follow-up complete for ${state.ticketId} PR #${state.prNumber || '?'} after ${state.attempt || 1} attempt(s)${skipSuffix}`,
-    };
+    return buildCompleteResult(state, solvedReviews, skippedReviews);
   });
 };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
@@ -80,9 +80,11 @@ function buildInfraStuckSurface(state, ctx) {
   };
 }
 
-// Write the accountability report once (skips if it already exists). Fail-open.
+// Write the accountability report once (never overwrites an existing one).
+// Uses the write-exclusive 'wx' flag so the create-once check is atomic — no
+// check-then-write race — and fails open if the file already exists or the
+// write errors.
 function writeAccountabilityReport(reportPath, state, solvedReviews, skippedReviews) {
-  if (fs.existsSync(reportPath)) return;
   try {
     fs.writeFileSync(
       reportPath,
@@ -97,10 +99,11 @@ function writeAccountabilityReport(reportPath, state, solvedReviews, skippedRevi
         },
         null,
         2
-      )
+      ),
+      { flag: 'wx' }
     );
   } catch {
-    /* fail-open */
+    /* fail-open — report already exists or write failed */
   }
 }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/triage.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/triage.js
@@ -22,114 +22,126 @@ function waitSeconds(seconds) {
   });
 }
 
+function buildBlocked(reason) {
+  return { type: 'follow_up_instruction', action: 'blocked', reason };
+}
+
+// Unrecoverable guards: max polling attempts exhausted, or a monitor exit-2.
+// Returns a blocked instruction, or null when neither applies.
+function checkBlocked(state, result, output) {
+  // Attempt is incremented only for wait-loops (pending CI, bot reviews)
+  // not for actionable routes (fix-ci, fix-reviews, report).
+  const maxAttempts = state.maxAttempts || 40;
+  if ((state.attempt || 0) >= maxAttempts) {
+    return buildBlocked(
+      `Max polling attempts (${maxAttempts}) reached. CI still not resolved.\nLast status: ${output.substring(0, 300)}`
+    );
+  }
+  if (result.exitCode === 2) {
+    return buildBlocked(`Monitor error: ${output.substring(0, 500)}`);
+  }
+  return null;
+}
+
+// Parse the monitor output into the structured routing signals. Compound
+// conditions are pre-computed here so routeTriage stays single-branch.
+function extractSignals(output, state) {
+  const hasBlockingReviews = /Reviews:.*BLOCKING/i.test(output);
+  const hasOngoingReview = /awaiting bot reviews/i.test(output);
+  const botStillRunning = /Cursor Bugbot.*running/i.test(output);
+  const hasCiCancelled = /CI:\s*CANCELLED/i.test(output);
+  const isMergeBlocked = /MERGE STATUS:\s*BLOCKED/i.test(output);
+  return {
+    // Structured signal `state._isConflicting` is set by monitor.js after a
+    // bounded retry on `mergeable: UNKNOWN`; regex fallback covers older state
+    // files written before this field existed.
+    hasConflict: !!state._isConflicting || /merge conflict|cannot be merged/i.test(output),
+    hasCiFailure: /CI:\s*FAILING/i.test(output),
+    hasCiPending: /CI:\s*PENDING/i.test(output),
+    hasBlockingReviews,
+    hasOngoingReview,
+    // Blocking reviews are actionable only once the bot has finished reviewing
+    // (it may still dismiss old comments while running).
+    reviewsActionable: hasBlockingReviews && !hasOngoingReview && !botStillRunning,
+    reviewsWaiting: hasBlockingReviews && botStillRunning,
+    ciCancelledBlocking: hasCiCancelled && isMergeBlocked && !hasBlockingReviews,
+  };
+}
+
+// Adaptive CI-pending poll interval: shorter when few checks remain.
+function ciPendingInterval(state) {
+  const running = state._ciRunningCount || 0;
+  if (running <= 2) return 15;
+  if (state.attempt <= 5) return 30;
+  return 60;
+}
+
+function bumpAttempt(state) {
+  state.attempt = (state.attempt || 0) + 1;
+}
+
+function ongoingReviewInterval(state) {
+  return state.attempt <= 5 ? 30 : 60;
+}
+
+// Wait, then route back to monitor for a fresh read. Returns null (advance).
+function waitAndMonitor(state, seconds) {
+  waitSeconds(seconds);
+  state.currentStep = 'monitor';
+  return null;
+}
+
+function routeTo(state, step, failureCategory) {
+  if (failureCategory) state.failureCategory = failureCategory;
+  state.currentStep = step;
+  return null;
+}
+
+function routeTriage(state, signals) {
+  // PRIORITY 0: conflict ALWAYS preempts everything else.
+  if (signals.hasConflict) return routeTo(state, 'fix-ci', 'conflict');
+
+  // Bug A (GH-508): route CI failures to infra-retry first. When its feature
+  // flag is off, infra-retry falls through to fix-ci; routing to fix-ci
+  // directly would skip infra-retry entirely when the flag is on.
+  if (signals.hasCiFailure) return routeTo(state, 'infra-retry', 'ci_failure');
+
+  // Blocking reviews take priority over waiting for CI.
+  if (signals.reviewsActionable) return routeTo(state, 'fix-reviews', 'reviews');
+
+  // Bot check still running with blocking reviews — wait for it to finish.
+  if (signals.reviewsWaiting) {
+    bumpAttempt(state);
+    return waitAndMonitor(state, 15);
+  }
+
+  // CI still running — wait before re-checking.
+  if (signals.hasCiPending) {
+    bumpAttempt(state);
+    return waitAndMonitor(state, ciPendingInterval(state));
+  }
+
+  // CI cancelled: only care if it blocks the merge.
+  if (signals.ciCancelledBlocking) return routeTo(state, 'infra-retry', 'ci_cancelled_blocking');
+
+  // Bot still reviewing — wait before re-checking.
+  if (signals.hasOngoingReview) {
+    bumpAttempt(state);
+    return waitAndMonitor(state, ongoingReviewInterval(state));
+  }
+
+  // Only reach report when CI passed AND no blocking reviews.
+  return routeTo(state, 'report');
+}
+
 module.exports = function registerTriage(register) {
   register('triage', (state) => {
     const result = state.lastMonitorResult || {};
     const output = result.output || '';
 
-    // Max attempts guard — prevent infinite polling
-    // Attempt is incremented only for wait-loops (pending CI, bot reviews)
-    // not for actionable routes (fix-ci, fix-reviews, report)
-    const maxAttempts = state.maxAttempts || 40;
-    if ((state.attempt || 0) >= maxAttempts) {
-      return {
-        type: 'follow_up_instruction',
-        action: 'blocked',
-        reason: `Max polling attempts (${maxAttempts}) reached. CI still not resolved.\nLast status: ${output.substring(0, 300)}`,
-      };
-    }
+    const blocked = checkBlocked(state, result, output);
+    if (blocked) return blocked;
 
-    // Error (exit 2) — unrecoverable
-    if (result.exitCode === 2) {
-      return {
-        type: 'follow_up_instruction',
-        action: 'blocked',
-        reason: `Monitor error: ${output.substring(0, 500)}`,
-      };
-    }
-
-    // ── PRIORITY 0: merge conflict ──────────────────────────────────────
-    // Conflict ALWAYS preempts everything else (CI status, reviews, etc).
-    // Structured signal `state._isConflicting` is set by monitor.js after
-    // a bounded retry on `mergeable: UNKNOWN`, so it survives the case
-    // where formatReport didn't emit a "CONFLICTS:" line yet (e.g. when
-    // GitHub was mid-recompute). Regex fallback covers older state files
-    // written before this field existed.
-    const structuredConflict = !!state._isConflicting;
-    const hasConflict = structuredConflict || /merge conflict|cannot be merged/i.test(output);
-    if (hasConflict) {
-      state.failureCategory = 'conflict';
-      state.currentStep = 'fix-ci';
-      return null;
-    }
-
-    const hasCiFailure = /CI:\s*FAILING/i.test(output);
-    const hasCiPending = /CI:\s*PENDING/i.test(output);
-    const hasCiCancelled = /CI:\s*CANCELLED/i.test(output);
-    const isMergeBlocked = /MERGE STATUS:\s*BLOCKED/i.test(output);
-    const hasBlockingReviews = /Reviews:.*BLOCKING/i.test(output);
-    const hasOngoingReview = /awaiting bot reviews/i.test(output);
-
-    if (hasCiFailure) {
-      state.failureCategory = 'ci_failure';
-      // Bug A (GH-508): route CI failures to infra-retry first. infra-retry's
-      // shouldBypass returns null (advance to fix-ci) when the feature flag is
-      // off, so the loop naturally falls through to fix-ci. Routing to fix-ci
-      // directly would skip infra-retry entirely when the flag is on.
-      state.currentStep = 'infra-retry';
-      return null;
-    }
-
-    // Blocking reviews take priority over waiting for CI —
-    // but only when the bot has finished reviewing (check completed).
-    // While the bot check is still running, it may dismiss old comments.
-    const botStillRunning = /Cursor Bugbot.*running/i.test(output);
-    if (hasBlockingReviews && !hasOngoingReview && !botStillRunning) {
-      state.failureCategory = 'reviews';
-      state.currentStep = 'fix-reviews';
-      return null;
-    }
-
-    // Bot check still running with blocking reviews — wait for it to finish
-    if (hasBlockingReviews && botStillRunning) {
-      state.attempt = (state.attempt || 0) + 1;
-      waitSeconds(15);
-      state.currentStep = 'monitor';
-      return null;
-    }
-
-    // CI still running — wait before re-checking.
-    // Adaptive interval: shorter when few checks remain.
-    if (hasCiPending) {
-      state.attempt = (state.attempt || 0) + 1;
-      const running = state._ciRunningCount || 0;
-      let interval = 60;
-      if (running <= 2) interval = 15;
-      else if (state.attempt <= 5) interval = 30;
-      waitSeconds(interval);
-      state.currentStep = 'monitor';
-      return null;
-    }
-
-    // CI cancelled: only care if it blocks the merge
-    if (hasCiCancelled && isMergeBlocked && !hasBlockingReviews) {
-      state.failureCategory = 'ci_cancelled_blocking';
-      // Bug A (GH-508): same as ci_failure — visit infra-retry first.
-      state.currentStep = 'infra-retry';
-      return null;
-    }
-
-    // Bot still reviewing — wait before re-checking
-    if (hasOngoingReview) {
-      state.attempt = (state.attempt || 0) + 1;
-      const interval = state.attempt <= 5 ? 30 : 60;
-      waitSeconds(interval);
-      state.currentStep = 'monitor';
-      return null;
-    }
-
-    // Only reach report when CI passed AND no blocking reviews
-    state.currentStep = 'report';
-    return null;
+    return routeTriage(state, extractSignals(output, state));
   });
 };

--- a/plugins/work/scripts/workflows/lib/instruction-guards.js
+++ b/plugins/work/scripts/workflows/lib/instruction-guards.js
@@ -1,0 +1,42 @@
+/**
+ * instruction-guards.js — shared process-level crash guards for orchestrators.
+ *
+ * Installs `uncaughtException` / `unhandledRejection` handlers that print a
+ * single JSON workflow instruction (`{ type, action: 'blocked', reason }`) to
+ * stderr and exit 1, so a crashing orchestrator still emits a parseable
+ * blocked-instruction rather than a raw stack trace. Shared by the /follow-up
+ * and /check2 orchestrators (previously a cross-file duplicate-block).
+ */
+
+'use strict';
+
+/**
+ * @param {string} instructionType - the `type` field on the emitted instruction
+ *   (e.g. `'follow_up_instruction'`, `'check_instruction'`).
+ */
+function installInstructionGuards(instructionType) {
+  process.on('uncaughtException', (err) => {
+    console.error(
+      JSON.stringify({
+        type: instructionType,
+        action: 'blocked',
+        reason: `Uncaught exception: ${err.message}`,
+        stack: err.stack,
+      })
+    );
+    process.exit(1);
+  });
+  process.on('unhandledRejection', (err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        type: instructionType,
+        action: 'blocked',
+        reason: `Unhandled rejection: ${msg}`,
+      })
+    );
+    process.exit(1);
+  });
+}
+
+module.exports = { installInstructionGuards };

--- a/plugins/work/scripts/workflows/lib/plugin-config.js
+++ b/plugins/work/scripts/workflows/lib/plugin-config.js
@@ -1,0 +1,29 @@
+/**
+ * plugin-config.js — shared resolver for the /work plugin's dirs + config.
+ *
+ * The /follow-up and /check2 orchestrators (and their auto-advance hooks) all
+ * need the same boilerplate: resolve the plugin root from the /work directory,
+ * load `get-config`, and derive WORKTREES_BASE / TASKS_BASE. Centralising it
+ * here keeps the call sites in sync and removes the duplicate-block the quality
+ * gate flagged across follow-up + check2.
+ */
+
+'use strict';
+
+const path = require('path');
+
+/**
+ * @param {string} fromWorkDir - absolute path to the plugin's `work` directory.
+ * @returns {{workDir:string, libDir:string, getConfig:Function, WORKTREES_BASE:string, TASKS_BASE:string}}
+ */
+function resolvePluginConfig(fromWorkDir) {
+  const { resolvePluginPaths } = require(path.join(fromWorkDir, 'lib', 'resolve-plugin-root'));
+  const { workDir, libDir } = resolvePluginPaths(fromWorkDir, 2);
+  const getConfig = require(path.join(libDir, 'get-config'));
+  const WORKTREES_BASE = getConfig('WORKTREES_BASE') || '';
+  const TASKS_BASE =
+    getConfig('TASKS_BASE') || (WORKTREES_BASE ? path.join(WORKTREES_BASE, 'tasks') : '');
+  return { workDir, libDir, getConfig, WORKTREES_BASE, TASKS_BASE };
+}
+
+module.exports = { resolvePluginConfig };


### PR DESCRIPTION
## Summary

First PR in the `.quality-exceptions` burn-down effort. Clears the **entire `/follow-up` subsystem** (8 files) from the static-quality allowlist by refactoring each file to satisfy all six rules (`max-lines`, `max-lines-per-function`, `cyclomatic-complexity`, `cognitive-complexity`, `max-depth`, `duplicate-blocks`).

This is a **conservative, behavior-preserving** refactor: pure helper extraction and module splits. No logic changes.

## What changed

**Refactored in place** (extract helpers to cut function length / complexity / nesting):
- `lib/steps/push-retry.js`, `report.js`, `triage.js`, `fix-ci.js`, `fix-reviews.js`

**Split orchestrator + hook:**
- `follow-up-next.js` — orchestrator loop broken into `stepOnce`/`reconcileSavedComplete`/`applySurface`/`advanceStep`; state management moved to new `lib/follow-up-state.js` factory (gets the file under 400 lines)
- `hooks/follow-up-auto-advance.js` — `main()` split into `readHookData`/`findMarker`/`runFollowUpNext`/`persistInstruction`/`printInstruction`

**`monitor.js` split** to fit the 400-line budget (609 → 347 lines), into three new siblings:
- `lib/steps/monitor-ci-context.js` — CI failed-job + classifier-context helpers
- `lib/steps/monitor-status-line.js` — pure output formatters
- `lib/steps/monitor-infra-cache.js` — infra-hint + monitor-result cache writers
- plus flattened `detectLocalConflict` and `ciCountParts`

**De-duplicated boilerplate shared with `/check2`** into two new shared modules:
- `lib/plugin-config.js` (`resolvePluginConfig`) — the resolve-plugin-root + config dance
- `lib/instruction-guards.js` (`installInstructionGuards`) — the uncaught/unhandled JSON-blocked handlers
- Rewired `follow-up-next.js`, `follow-up-auto-advance.js`, **and** `check2/check-next.js` + `check2/hooks/check-auto-advance.js` to import them. The two check2 files stay allowlisted (they keep other violations) but lose their duplicate-block debt.

**Allowlist:** removed the 8 `/follow-up` paths from `.quality-exceptions`.

**Tests:** updated `monitor.test.js` structural assertions to track the relocated helpers (same intent, new module locations) and made the `child_process` stub bust the sibling caches.

## Testing

- `node --test` over follow-up + check2: **237 pass, 0 fail**
- Full-repo quality gate (`quality.js`): **exit 0** (allowlist now 211 entries, down from 219)
- `biome check` clean on all changed files

## Notes

- Net diff is +1504 / −1273 across 18 files; the large `monitor.js` delta is code *moving* to siblings, not new logic.
- Part of a larger burn-down (~20 PRs planned, grouped by subsystem). This `/follow-up` PR is the pilot validating the approach.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, structural edits across PR follow-up orchestration (monitor, triage, CI/review fixes) where subtle regressions would affect merge automation; mitigated by described behavior parity and broad tests.
> 
> **Overview**
> Burns down **eight** `/follow-up` paths from `.quality-exceptions` by refactoring for static quality rules (line limits, complexity, duplicate blocks) without intended behavior changes.
> 
> **Shared workflow plumbing:** Adds `lib/plugin-config.js` (`resolvePluginConfig`) and `lib/instruction-guards.js` (`installInstructionGuards`), then wires `/follow-up` and `/check2` orchestrators and auto-advance hooks to them instead of inlined copies.
> 
> **Orchestrator & state:** Moves follow-up persistence into `lib/follow-up-state.js` and reshapes `follow-up-next.js` around `stepOnce`, `reconcileSavedComplete`, `maybeClearStaleInfra`, and related helpers. Splits `follow-up-auto-advance.js` into small read/run/persist/print functions (including a `surface` banner).
> 
> **Monitor split:** Breaks `monitor.js` into `monitor-ci-context.js`, `monitor-infra-cache.js`, and `monitor-status-line.js`; step modules (`triage`, `fix-ci`, `fix-reviews`, `push-retry`, `report`) get helper extraction. `monitor.test.js` assertions follow the new module layout.
> 
> **Small deltas:** `report.js` uses atomic `wx` for accountability JSON; `fix-reviews.js` strips HTML comments via `indexOf` instead of a regex.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31828f25a395e80e1d0030be078c77fde7bffdaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->