### PR TITLE
refactor(check2): clear /check2 subsystem from quality allowlist

### DIFF
--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -106,9 +106,7 @@ plugins/work/scripts/workflows/lib/quality-check.js
 plugins/work/scripts/workflows/check/lib/app-access.js
 plugins/work/scripts/workflows/work/lib/work-enforcement-context.js
 plugins/work/scripts/workflows/check/agents/qa-feature-tester/qa-pretooluse-hooks.js
-plugins/work/scripts/workflows/check2/lib/step-enrichments/completion-context.js
 plugins/work/scripts/workflows/work-spec/lib/component-shape.js
-plugins/work/scripts/workflows/check2/check-next.js
 plugins/work/scripts/workflows/check/scripts/write-code-review.js
 plugins/work/scripts/workflows/work/hooks/enforce-screenshot-gate.js
 plugins/work/scripts/workflows/work/lib/step-enrichments/implement.js
@@ -124,7 +122,6 @@ plugins/work/scripts/workflows/work/lib/mark-task-progress.js
 plugins/work/scripts/workflows/lib/hooks/agent-hook-dispatcher.js
 plugins/work/scripts/workflows/work-spec/lib/kind-checks/e2e.js
 plugins/work/scripts/workflows/lib/allocate-output-folder.js
-plugins/work/scripts/workflows/check2/lib/steps/run-tests.js
 plugins/work/scripts/workflows/check/scripts/write-tests-report.js
 plugins/work/scripts/listen-all.js
 plugins/work/scripts/workflows/work/hooks/enforce-review-accountability.js
@@ -147,7 +144,6 @@ plugins/work/scripts/workflows/lib/hooks/inject-inbox-messages.js
 plugins/work/scripts/workflows/work-ci/lib/phases/wait.js
 plugins/work/scripts/workflows/work-brief/lib/phases/draft.js
 plugins/work/scripts/workflows/work-pr/agents/pr-generator/pr-generator-validator.js
-plugins/work/scripts/workflows/check2/lib/steps/phase1-agents.js
 plugins/work/scripts/workflows/work-spec/lib/phases/kind_checks.js
 plugins/work/scripts/workflows/check/scripts/write-completion-report.js
 plugins/work/scripts/workflows/work-ci/lib/phases/wait_merge.js
@@ -167,7 +163,6 @@ plugins/work/scripts/workflows/work/hooks/work-auto-advance.js
 plugins/work/scripts/workflows/lib/hooks/enforce-dev-commands.js
 plugins/work/scripts/workflows/work/lib/task-graph.js
 plugins/work/scripts/workflows/work-brief/lib/phases/inputs.js
-plugins/work/scripts/workflows/check2/hooks/check-auto-advance.js
 plugins/work/scripts/workflows/work-tasks/lib/phases/requirements_extract.js
 plugins/work/scripts/workflows/work/lib/debug-log.js
 plugins/work/scripts/workflows/work/agents/commit-writer/commit-writer-precommit-guard.js
@@ -179,7 +174,6 @@ plugins/work/scripts/workflows/work-brief/lib/phases/overlap.js
 plugins/work/scripts/workflows/work-ci/lib/phases/fix_or_document.js
 plugins/work/scripts/workflows/work/lib/work-helpers.js
 plugins/work/scripts/workflows/work-cleanup/lib/phases/inputs.js
-plugins/work/scripts/workflows/check2/lib/steps/phase2-consensus.js
 plugins/work/scripts/workflows/work-brief/lib/phases/validate.js
 plugins/work/scripts/workflows/work-reports/lib/phases/emit.js
 plugins/work/scripts/workflows/check/agents/qa-feature-tester/screenshot-size-validator.js
@@ -212,8 +206,6 @@ plugins/work/scripts/workflows/work-completion-checker/lib/phases/memorize.js
 plugins/work/scripts/workflows/work-qa-feature-tester/lib/kind-checks/shared.js
 plugins/work/scripts/workflows/work/lib/git-utils.js
 plugins/work/scripts/workflows/work-pr-reviewer/lib/kind-checks/e2e.js
-plugins/work/scripts/workflows/check2/lib/steps/run-e2e.js
-plugins/work/scripts/workflows/check2/lib/steps/run-integration.js
 plugins/work/scripts/workflows/work-task-review/lib/kind-checks/wiring.js
 plugins/work/scripts/workflows/work/scripts/gh-exec.js
 plugins/work/scripts/workflows/work/steps/task-advance.js

--- a/plugins/work/scripts/workflows/check2/hooks/check-auto-advance.js
+++ b/plugins/work/scripts/workflows/check2/hooks/check-auto-advance.js
@@ -11,85 +11,22 @@
 
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
-const { execFileSync } = require('child_process');
+const { runAutoAdvance } = require('../../lib/auto-advance');
 
-process.on('uncaughtException', () => process.exit(0));
-process.on('unhandledRejection', () => process.exit(0));
+const BANNERS = {
+  execute: ['═══ CHECK2: NEXT STEP ═══', '═════════════════════════'],
+  display: ['═══ CHECK2: NEXT STEP ═══', '═════════════════════════'],
+  complete: ['═══ CHECK2: COMPLETE ═══', '════════════════════════'],
+  blocked: ['═══ CHECK2: BLOCKED ═══', '═══════════════════════'],
+};
 
-function main() {
-  // Read hook input from stdin
-  let hookData;
-  try {
-    const input = fs.readFileSync(0, 'utf8');
-    hookData = JSON.parse(input);
-  } catch {
-    process.exit(0);
-  }
-
-  // Guard: do NOT fire inside sub-agents
-  const transcriptPath = hookData?.transcript_path || '';
-  if (transcriptPath.includes('/subagents/')) process.exit(0);
-
-  // Guard: find active /check2 session via marker file
-  const { resolvePluginConfig } = require('../../lib/plugin-config');
-  const { TASKS_BASE } = resolvePluginConfig(path.join(__dirname, '..', '..', 'work'));
-  if (!TASKS_BASE) process.exit(0);
-
-  // Find THIS terminal's .check2-orchestrator.pid marker. findActiveMarker scopes
-  // by owning session id + worktree root so a hook firing in one agent never
-  // advances another agent's workflow.
-  const { findActiveMarker } = require(path.join(__dirname, '..', '..', 'work', 'lib', 'marker'));
-  const marker = findActiveMarker(TASKS_BASE, '.check2-orchestrator.pid');
-  if (!marker) process.exit(0);
-
-  // Guard: marker must be recent (less than 12 hours)
-  const markerAge = Date.now() - new Date(marker.startedAt).getTime();
-  if (markerAge > 12 * 60 * 60 * 1000) process.exit(0);
-
-  // Call check-next.js
-  const checkNextPath = path.join(__dirname, '..', 'check-next.js');
-  let result;
-  try {
-    result = execFileSync(process.execPath, [checkNextPath, marker.ticket], {
-      encoding: 'utf8',
-      timeout: 25000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-  } catch {
-    process.exit(0);
-  }
-
-  // Parse and output instruction
-  let instruction;
-  try {
-    instruction = JSON.parse(result);
-  } catch {
-    process.exit(0);
-  }
-
-  if (instruction.action === 'execute' || instruction.action === 'display') {
-    console.log('');
-    console.log('═══ CHECK2: NEXT STEP ═══');
-    console.log(JSON.stringify(instruction, null, 2));
-    console.log('═════════════════════════');
-    console.log('');
-  } else if (instruction.action === 'complete') {
-    console.log('');
-    console.log('═══ CHECK2: COMPLETE ═══');
-    console.log(JSON.stringify(instruction, null, 2));
-    console.log('════════════════════════');
-    console.log('');
-  } else if (instruction.action === 'blocked') {
-    console.log('');
-    console.log('═══ CHECK2: BLOCKED ═══');
-    console.log(JSON.stringify(instruction, null, 2));
-    console.log('═══════════════════════');
-    console.log('');
-  }
-
-  process.exit(0);
+if (require.main === module) {
+  runAutoAdvance({
+    workDir: path.join(__dirname, '..', '..', 'work'),
+    markerFile: '.check2-orchestrator.pid',
+    scriptPath: path.join(__dirname, '..', 'check-next.js'),
+    timeout: 25000,
+    banners: BANNERS,
+  });
 }
-
-main();

--- a/plugins/work/scripts/workflows/check2/lib/run-affected-suite.js
+++ b/plugins/work/scripts/workflows/check2/lib/run-affected-suite.js
@@ -10,17 +10,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
-
-// Run the suite command, capturing combined stdout/stderr. Never throws — a
-// non-zero exit is reported via the returned exitCode.
-function runSuiteCommand(cmd, timeout) {
-  try {
-    return { output: execSync(`${cmd} 2>&1`, { encoding: 'utf8', timeout }), exitCode: 0 };
-  } catch (err) {
-    return { output: (err.stdout || '') + (err.stderr || ''), exitCode: err.status || 1 };
-  }
-}
+// Reuse the single command runner from run-tests.js rather than spawning here —
+// one combined-output exec site for the whole /check2 subsystem.
+const { runCommand } = require('./steps/run-tests');
 
 // Pull pass/fail counts out of the runner output (best-effort; '?' when absent).
 function parseCounts(output) {
@@ -57,7 +49,7 @@ function runAffectedSuite({ envVar, stepName, reportFile, label, timeout }) {
     const reportFolder = state.setupResult?.reportFolder || ctx.tasksDir;
     const reportPath = path.join(reportFolder, reportFile);
 
-    const { output, exitCode } = runSuiteCommand(cmd, timeout);
+    const { output, exitCode } = runCommand(cmd, timeout);
     const { passCount, failCount } = parseCounts(output);
     const status = exitCode === 0 ? 'APPROVED' : 'NEEDS_WORK';
 

--- a/plugins/work/scripts/workflows/check2/lib/run-affected-suite.js
+++ b/plugins/work/scripts/workflows/check2/lib/run-affected-suite.js
@@ -1,0 +1,84 @@
+/**
+ * Shared step body for the "run affected suite" check steps
+ * (8_run_integration, 9_run_e2e). The two steps differ only in env var,
+ * step id, report filename, label, and timeout — everything else (skip when
+ * unconfigured, run the command, parse pass/fail counts, write the report,
+ * fail on non-zero exit) is identical, so it lives here once.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Run the suite command, capturing combined stdout/stderr. Never throws — a
+// non-zero exit is reported via the returned exitCode.
+function runSuiteCommand(cmd, timeout) {
+  try {
+    return { output: execSync(`${cmd} 2>&1`, { encoding: 'utf8', timeout }), exitCode: 0 };
+  } catch (err) {
+    return { output: (err.stdout || '') + (err.stderr || ''), exitCode: err.status || 1 };
+  }
+}
+
+// Pull pass/fail counts out of the runner output (best-effort; '?' when absent).
+function parseCounts(output) {
+  const passMatch = output.match(/pass\s+(\d+)/i);
+  const failMatch = output.match(/fail\s+(\d+)/i);
+  return {
+    passCount: passMatch ? passMatch[1] : '?',
+    failCount: failMatch ? failMatch[1] : '?',
+  };
+}
+
+function buildReport({ status, label, envVar, exitCode, passCount, failCount, output }) {
+  return [
+    `Status: ${status}`,
+    '',
+    `# ${label} Test Results`,
+    '',
+    `**Runner:** ${envVar}`,
+    `**Exit code:** ${exitCode}`,
+    `**Pass:** ${passCount} | **Fail:** ${failCount}`,
+    '',
+    '## Output',
+    '```',
+    output.substring(0, 5000),
+    '```',
+  ].join('\n');
+}
+
+function runAffectedSuite({ envVar, stepName, reportFile, label, timeout }) {
+  return (state, ctx) => {
+    const cmd = process.env[envVar];
+    if (!cmd) return null; // not configured → skip
+
+    const reportFolder = state.setupResult?.reportFolder || ctx.tasksDir;
+    const reportPath = path.join(reportFolder, reportFile);
+
+    const { output, exitCode } = runSuiteCommand(cmd, timeout);
+    const { passCount, failCount } = parseCounts(output);
+    const status = exitCode === 0 ? 'APPROVED' : 'NEEDS_WORK';
+
+    fs.writeFileSync(
+      reportPath,
+      buildReport({ status, label, envVar, exitCode, passCount, failCount, output })
+    );
+
+    if (exitCode !== 0) {
+      state.testsFailed = true;
+      return {
+        type: 'check_instruction',
+        action: 'failed',
+        state: { ticket: state.ticketId, currentStep: stepName },
+        reason: `${label} tests failed (${failCount} failing).`,
+        report: reportPath,
+      };
+    }
+
+    return null;
+  };
+}
+
+module.exports = { runAffectedSuite };

--- a/plugins/work/scripts/workflows/check2/lib/step-enrichments/completion-context.js
+++ b/plugins/work/scripts/workflows/check2/lib/step-enrichments/completion-context.js
@@ -19,6 +19,176 @@
 const fs = require('fs');
 const path = require('path');
 
+// Read a file, returning '' when it is missing or unreadable (layer skipped).
+function readFileOrEmpty(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+// Return the full matched section (group 0), trimmed, or '' when absent.
+function extractSection(content, regex) {
+  const m = content.match(regex);
+  return m ? m[0].trim() : '';
+}
+
+// ── Layer 1: Ticket ─────────────────────────────────────────────────────────
+function buildTicketLayer(tasksDir) {
+  let ticketTitle = '';
+  let ticketBody = '';
+  try {
+    const ticket = JSON.parse(fs.readFileSync(path.join(tasksDir, 'ticket.json'), 'utf8'));
+    ticketTitle = ticket.title || '';
+    ticketBody = ticket.body || ticket.description || '';
+  } catch {
+    return []; // No ticket.json — skip layer
+  }
+
+  if (!ticketTitle && !ticketBody) return [];
+  return [
+    '## Layer 1: Ticket Requirements',
+    '',
+    `**Title:** ${ticketTitle}`,
+    '',
+    ticketBody ? ticketBody.substring(0, 2000) : '(no description)',
+    '',
+    '**Verify:** Does the code change address what the ticket asked for?',
+    '',
+  ];
+}
+
+// ── Layer 2: Brief ──────────────────────────────────────────────────────────
+function buildBriefLayer(tasksDir) {
+  const briefContent = readFileOrEmpty(path.join(tasksDir, 'brief.md'));
+  if (!briefContent) return [];
+
+  const requirements = extractSection(
+    briefContent,
+    /## Requirements[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
+  );
+  const acceptanceCriteria = extractSection(
+    briefContent,
+    /## (?:Acceptance Criteria|Success Metrics)[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
+  );
+
+  return [
+    '## Layer 2: Brief Requirements',
+    '',
+    requirements || '(no requirements section found in brief.md)',
+    '',
+    acceptanceCriteria || '',
+    '',
+    '**Verify:** For EACH P0/P1 requirement, grep the code diff to confirm it was implemented.',
+    '',
+  ];
+}
+
+// ── Layer 3: Spec ───────────────────────────────────────────────────────────
+function buildSpecLayer(tasksDir) {
+  const specContent = readFileOrEmpty(path.join(tasksDir, 'spec.md'));
+  if (!specContent) return [];
+
+  const architecture = extractSection(
+    specContent,
+    /## Architecture Decisions[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
+  );
+  const reuseAudit = extractSection(
+    specContent,
+    /## Reuse Audit[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
+  );
+  const filesToModify = extractSection(
+    specContent,
+    /## Files to Create\/Modify[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
+  );
+
+  return [
+    '## Layer 3: Spec Verification',
+    '',
+    architecture || '(no architecture decisions found)',
+    '',
+    reuseAudit ? reuseAudit.substring(0, 1500) : '',
+    '',
+    filesToModify || '',
+    '',
+    '**Verify:**',
+    '- Were existing components reused (not duplicated)?',
+    '- Were architecture decisions followed?',
+    '- Were all listed files actually modified?',
+    '',
+  ];
+}
+
+// ── Layer 4: Tasks ──────────────────────────────────────────────────────────
+// Build the verification block for a single `## Task N` section.
+function buildTaskVerification(num, body) {
+  const titleMatch = body.match(/^[\s]*[—–-]+\s*(.+?)$/m);
+  const title = titleMatch ? titleMatch[1].trim() : `Task ${num}`;
+
+  const typeMatch = body.match(/### Type\s*\n([^\n#]+)/);
+  const type = typeMatch ? typeMatch[1].trim().toLowerCase() : 'unknown';
+
+  const acMatch = body.match(/### Acceptance Criteria\s*\n([\s\S]*?)(?=\n###|\n## |$)/);
+  const ac = acMatch ? acMatch[1].trim() : '';
+
+  const scopeMatch = body.match(/### Suggested Scope[^\n]*\n([\s\S]*?)(?=\n###|\n## |$)/);
+  const scope = scopeMatch ? scopeMatch[1].trim() : '';
+
+  return [
+    `### Task ${num} — ${title} (${type})`,
+    ac ? `**Acceptance Criteria:**\n${ac}` : '(no acceptance criteria)',
+    scope
+      ? `**Files:** ${scope
+          .split('\n')
+          .map((l) => l.trim())
+          .filter(Boolean)
+          .join(', ')}`
+      : '',
+    `**Verify:** Check each criterion against the code diff for this task's files.`,
+    '',
+  ];
+}
+
+function buildTasksLayer(tasksDir) {
+  const tasksContent = readFileOrEmpty(path.join(tasksDir, 'tasks.md'));
+  if (!tasksContent) return [];
+
+  const out = [];
+
+  // Parse each task's acceptance criteria
+  const taskBlocks = tasksContent.split(/^## Task (\d+)/m);
+  const taskVerifications = [];
+  for (let i = 1; i < taskBlocks.length; i += 2) {
+    taskVerifications.push(...buildTaskVerification(taskBlocks[i], taskBlocks[i + 1] || ''));
+  }
+
+  if (taskVerifications.length > 0) {
+    out.push(
+      '## Layer 4: Per-Task Verification',
+      '',
+      'For EACH task below, verify acceptance criteria against the actual code:',
+      '',
+      ...taskVerifications
+    );
+  }
+
+  // Extract requirement coverage table
+  const coverageMatch = tasksContent.match(/## Requirement Coverage[\s\S]*$/i);
+  if (coverageMatch) {
+    out.push(
+      '## Requirement Coverage Table',
+      '',
+      coverageMatch[0].trim(),
+      '',
+      '**Verify:** Every requirement in this table must be DELIVERED with code evidence.',
+      ''
+    );
+  }
+
+  return out;
+}
+
 /**
  * Build completion-checker context from planning artifacts.
  *
@@ -27,180 +197,12 @@ const path = require('path');
  * @returns {string} structured prompt section with all context
  */
 function buildCompletionContext(tasksDir, ticketId) {
-  const sections = [];
-
-  // ── Layer 1: Ticket ────────────────────────────────────────────────────────
-  const ticketPath = path.join(tasksDir, 'ticket.json');
-  let ticketTitle = '';
-  let ticketBody = '';
-  try {
-    const ticket = JSON.parse(fs.readFileSync(ticketPath, 'utf8'));
-    ticketTitle = ticket.title || '';
-    ticketBody = ticket.body || ticket.description || '';
-  } catch {
-    // No ticket.json — skip layer
-  }
-
-  if (ticketTitle || ticketBody) {
-    sections.push(
-      '## Layer 1: Ticket Requirements',
-      '',
-      `**Title:** ${ticketTitle}`,
-      '',
-      ticketBody ? ticketBody.substring(0, 2000) : '(no description)',
-      '',
-      '**Verify:** Does the code change address what the ticket asked for?',
-      ''
-    );
-  }
-
-  // ── Layer 2: Brief ─────────────────────────────────────────────────────────
-  const briefPath = path.join(tasksDir, 'brief.md');
-  let briefContent = '';
-  try {
-    briefContent = fs.readFileSync(briefPath, 'utf8');
-  } catch {
-    // No brief — skip layer
-  }
-
-  if (briefContent) {
-    // Extract requirements section
-    const reqMatch = briefContent.match(/## Requirements[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i);
-    const requirements = reqMatch ? reqMatch[0].trim() : '';
-
-    // Extract acceptance criteria / success metrics
-    const acMatch = briefContent.match(
-      /## (?:Acceptance Criteria|Success Metrics)[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
-    );
-    const acceptanceCriteria = acMatch ? acMatch[0].trim() : '';
-
-    sections.push(
-      '## Layer 2: Brief Requirements',
-      '',
-      requirements || '(no requirements section found in brief.md)',
-      '',
-      acceptanceCriteria || '',
-      '',
-      '**Verify:** For EACH P0/P1 requirement, grep the code diff to confirm it was implemented.',
-      ''
-    );
-  }
-
-  // ── Layer 3: Spec ──────────────────────────────────────────────────────────
-  const specPath = path.join(tasksDir, 'spec.md');
-  let specContent = '';
-  try {
-    specContent = fs.readFileSync(specPath, 'utf8');
-  } catch {
-    // No spec — skip layer
-  }
-
-  if (specContent) {
-    // Extract architecture decisions
-    const archMatch = specContent.match(
-      /## Architecture Decisions[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
-    );
-    const architecture = archMatch ? archMatch[0].trim() : '';
-
-    // Extract reuse audit
-    const reuseMatch = specContent.match(/## Reuse Audit[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i);
-    const reuseAudit = reuseMatch ? reuseMatch[0].trim() : '';
-
-    // Extract files to modify
-    const filesMatch = specContent.match(
-      /## Files to Create\/Modify[\s\S]*?(?=\n## [A-Z]|\n---|\n# |$)/i
-    );
-    const filesToModify = filesMatch ? filesMatch[0].trim() : '';
-
-    sections.push(
-      '## Layer 3: Spec Verification',
-      '',
-      architecture || '(no architecture decisions found)',
-      '',
-      reuseAudit ? reuseAudit.substring(0, 1500) : '',
-      '',
-      filesToModify || '',
-      '',
-      '**Verify:**',
-      '- Were existing components reused (not duplicated)?',
-      '- Were architecture decisions followed?',
-      '- Were all listed files actually modified?',
-      ''
-    );
-  }
-
-  // ── Layer 4: Tasks ─────────────────────────────────────────────────────────
-  const tasksPath = path.join(tasksDir, 'tasks.md');
-  let tasksContent = '';
-  try {
-    tasksContent = fs.readFileSync(tasksPath, 'utf8');
-  } catch {
-    // No tasks — skip layer
-  }
-
-  if (tasksContent) {
-    // Parse each task's acceptance criteria
-    const taskBlocks = tasksContent.split(/^## Task (\d+)/m);
-    const taskVerifications = [];
-
-    for (let i = 1; i < taskBlocks.length; i += 2) {
-      const num = taskBlocks[i];
-      const body = taskBlocks[i + 1] || '';
-
-      // Extract title
-      const titleMatch = body.match(/^[\s]*[—–-]+\s*(.+?)$/m);
-      const title = titleMatch ? titleMatch[1].trim() : `Task ${num}`;
-
-      // Extract type
-      const typeMatch = body.match(/### Type\s*\n([^\n#]+)/);
-      const type = typeMatch ? typeMatch[1].trim().toLowerCase() : 'unknown';
-
-      // Extract acceptance criteria
-      const acMatch = body.match(/### Acceptance Criteria\s*\n([\s\S]*?)(?=\n###|\n## |$)/);
-      const ac = acMatch ? acMatch[1].trim() : '';
-
-      // Extract suggested scope
-      const scopeMatch = body.match(/### Suggested Scope[^\n]*\n([\s\S]*?)(?=\n###|\n## |$)/);
-      const scope = scopeMatch ? scopeMatch[1].trim() : '';
-
-      taskVerifications.push(
-        `### Task ${num} — ${title} (${type})`,
-        ac ? `**Acceptance Criteria:**\n${ac}` : '(no acceptance criteria)',
-        scope
-          ? `**Files:** ${scope
-              .split('\n')
-              .map((l) => l.trim())
-              .filter(Boolean)
-              .join(', ')}`
-          : '',
-        `**Verify:** Check each criterion against the code diff for this task's files.`,
-        ''
-      );
-    }
-
-    if (taskVerifications.length > 0) {
-      sections.push(
-        '## Layer 4: Per-Task Verification',
-        '',
-        'For EACH task below, verify acceptance criteria against the actual code:',
-        '',
-        ...taskVerifications
-      );
-    }
-
-    // Extract requirement coverage table
-    const coverageMatch = tasksContent.match(/## Requirement Coverage[\s\S]*$/i);
-    if (coverageMatch) {
-      sections.push(
-        '## Requirement Coverage Table',
-        '',
-        coverageMatch[0].trim(),
-        '',
-        '**Verify:** Every requirement in this table must be DELIVERED with code evidence.',
-        ''
-      );
-    }
-  }
+  const sections = [
+    ...buildTicketLayer(tasksDir),
+    ...buildBriefLayer(tasksDir),
+    ...buildSpecLayer(tasksDir),
+    ...buildTasksLayer(tasksDir),
+  ];
 
   if (sections.length === 0) {
     return '(No planning artifacts found — verify against the original request only)';

--- a/plugins/work/scripts/workflows/check2/lib/steps/phase1-agents.js
+++ b/plugins/work/scripts/workflows/check2/lib/steps/phase1-agents.js
@@ -12,115 +12,130 @@
 const fs = require('fs');
 const path = require('path');
 
+// After dispatch: both reports present → mark verified tasks and advance.
+// Returns true when the step is done (reports exist), false otherwise.
+function phase1ReportsReady(reportFolder, ctx) {
+  const hasCodeReview = fs.existsSync(path.join(reportFolder, 'code-review.check.md'));
+  const completionPath = path.join(reportFolder, 'completion.check.md');
+  if (!hasCodeReview || !fs.existsSync(completionPath)) return false;
+
+  // Mark tasks as verified [v] if completion-checker says COMPLETE
+  try {
+    const completionReport = fs.readFileSync(completionPath, 'utf8');
+    const { hasVerdict } = require(
+      path.join(__dirname, '..', '..', '..', 'lib', 'parse-completion-status')
+    );
+    if (hasVerdict(completionReport, ['COMPLETE'])) {
+      const { markVerified } = require(
+        path.join(__dirname, '..', '..', '..', 'work', 'lib', 'mark-task-progress')
+      );
+      markVerified(ctx.tasksDir);
+    }
+  } catch {
+    /* fail-open */
+  }
+  return true;
+}
+
+// Build structured verification context from planning artifacts (best-effort).
+function loadCompletionContext(ctx, state) {
+  try {
+    const { buildCompletionContext } = require(
+      path.join(__dirname, '..', 'step-enrichments', 'completion-context')
+    );
+    return buildCompletionContext(ctx.tasksDir, state.ticketId);
+  } catch {
+    return '(Could not load planning artifacts — verify against PR diff only)';
+  }
+}
+
+function buildCodeReviewDelegate(state, changesHash, codeReviewReport) {
+  return {
+    type: 'task',
+    agentType: 'work-workflow:code-checker',
+    description: `Code review — ${state.ticketId}`,
+    prompt: [
+      `## Code Review for ${state.ticketId}`,
+      '',
+      '### MANDATORY: self-paced runner',
+      '',
+      `Drive the review through the code-next.js runner. It phases inputs → change_classify → file_coverage → standards_audit → kind_checks → report → memorize → done and writes your verdict into ${codeReviewReport}.`,
+      '',
+      '```',
+      `node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-code-checker/code-next.js ${state.ticketId}`,
+      '```',
+      '',
+      "Follow the runner output verbatim. Re-invoke after performing each phase's action — stop only when it prints `NEXT_ACTION: DONE`.",
+      '',
+      `Changes hash: ${changesHash}`,
+      '',
+      '### What to check',
+      '- Bugs, logic errors, security vulnerabilities',
+      '- Code quality, naming, patterns adherence',
+      '- Missing error handling at system boundaries',
+      '',
+      '### Rules',
+      '- Do NOT run tests (already handled by deterministic script)',
+      '- Do NOT modify any code — only review and report',
+    ].join('\n'),
+    note: 'Pass the prompt directly to the agent.',
+  };
+}
+
+function buildCompletionDelegate(state, changesHash, completionReport, completionContext) {
+  return {
+    type: 'task',
+    agentType: 'work-workflow:completion-checker',
+    description: `Verify requirements — ${state.ticketId}`,
+    prompt: [
+      `## Verify ALL requirements for ${state.ticketId}`,
+      '',
+      '### MANDATORY: self-paced runner',
+      '',
+      `Drive verification through the completion-next.js runner. It phases inputs → requirements_extract → diff_scope → coverage_check → kind_checks → report → memorize → done and writes your verdict into ${completionReport}.`,
+      '',
+      '```',
+      `node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-completion-checker/completion-next.js ${state.ticketId}`,
+      '```',
+      '',
+      "Follow the runner output verbatim. Re-invoke after performing each phase's action — stop only when it prints `NEXT_ACTION: DONE`.",
+      '',
+      `Changes hash: ${changesHash}`,
+      '',
+      '# Verification Context (pre-loaded from planning artifacts)',
+      '',
+      completionContext,
+      '',
+      '# Instructions',
+      '',
+      'Verify each layer in order (ticket → brief → spec → tasks).',
+      'For EACH requirement/deliverable: grep or read the actual code to find evidence.',
+      'Mark DELIVERED only with a code citation (file:line or diff excerpt).',
+      'Mark INCOMPLETE if any P0 requirement lacks code evidence.',
+    ].join('\n'),
+    note: 'Pass the prompt directly to the agent.',
+  };
+}
+
 module.exports = function registerPhase1(register) {
   register('5_phase1_agents', (state, ctx) => {
     const reportFolder = state.setupResult?.reportFolder || ctx.tasksDir;
     const changesHash = state.changesHash || 'unknown';
 
     // Already dispatched — check if reports exist
-    if (state.dispatched === '5_phase1_agents') {
-      const hasCodeReview = fs.existsSync(path.join(reportFolder, 'code-review.check.md'));
-      const completionPath = path.join(reportFolder, 'completion.check.md');
-      const hasCompletion = fs.existsSync(completionPath);
-      if (hasCodeReview && hasCompletion) {
-        // Mark tasks as verified [v] if completion-checker says COMPLETE
-        try {
-          const completionReport = fs.readFileSync(completionPath, 'utf8');
-          const { hasVerdict } = require(
-            path.join(__dirname, '..', '..', '..', 'lib', 'parse-completion-status')
-          );
-          if (hasVerdict(completionReport, ['COMPLETE'])) {
-            const { markVerified } = require(
-              path.join(__dirname, '..', '..', '..', 'work', 'lib', 'mark-task-progress')
-            );
-            markVerified(ctx.tasksDir);
-          }
-        } catch {
-          /* fail-open */
-        }
-        return null; // all reports present → auto-advance
-      }
+    if (state.dispatched === '5_phase1_agents' && phase1ReportsReady(reportFolder, ctx)) {
+      return null; // all reports present → auto-advance
     }
 
     state.dispatched = '5_phase1_agents';
 
-    // Build structured verification context from planning artifacts
-    let completionContext = '';
-    try {
-      const { buildCompletionContext } = require(
-        path.join(__dirname, '..', 'step-enrichments', 'completion-context')
-      );
-      completionContext = buildCompletionContext(ctx.tasksDir, state.ticketId);
-    } catch {
-      completionContext = '(Could not load planning artifacts — verify against PR diff only)';
-    }
-
+    const completionContext = loadCompletionContext(ctx, state);
     const codeReviewReport = path.join(reportFolder, 'code-review.check.md');
     const completionReport = path.join(reportFolder, 'completion.check.md');
 
     const delegates = [
-      {
-        type: 'task',
-        agentType: 'work-workflow:code-checker',
-        description: `Code review — ${state.ticketId}`,
-        prompt: [
-          `## Code Review for ${state.ticketId}`,
-          '',
-          '### MANDATORY: self-paced runner',
-          '',
-          `Drive the review through the code-next.js runner. It phases inputs → change_classify → file_coverage → standards_audit → kind_checks → report → memorize → done and writes your verdict into ${codeReviewReport}.`,
-          '',
-          '```',
-          `node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-code-checker/code-next.js ${state.ticketId}`,
-          '```',
-          '',
-          "Follow the runner output verbatim. Re-invoke after performing each phase's action — stop only when it prints `NEXT_ACTION: DONE`.",
-          '',
-          `Changes hash: ${changesHash}`,
-          '',
-          '### What to check',
-          '- Bugs, logic errors, security vulnerabilities',
-          '- Code quality, naming, patterns adherence',
-          '- Missing error handling at system boundaries',
-          '',
-          '### Rules',
-          '- Do NOT run tests (already handled by deterministic script)',
-          '- Do NOT modify any code — only review and report',
-        ].join('\n'),
-        note: 'Pass the prompt directly to the agent.',
-      },
-      {
-        type: 'task',
-        agentType: 'work-workflow:completion-checker',
-        description: `Verify requirements — ${state.ticketId}`,
-        prompt: [
-          `## Verify ALL requirements for ${state.ticketId}`,
-          '',
-          '### MANDATORY: self-paced runner',
-          '',
-          `Drive verification through the completion-next.js runner. It phases inputs → requirements_extract → diff_scope → coverage_check → kind_checks → report → memorize → done and writes your verdict into ${completionReport}.`,
-          '',
-          '```',
-          `node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-completion-checker/completion-next.js ${state.ticketId}`,
-          '```',
-          '',
-          "Follow the runner output verbatim. Re-invoke after performing each phase's action — stop only when it prints `NEXT_ACTION: DONE`.",
-          '',
-          `Changes hash: ${changesHash}`,
-          '',
-          '# Verification Context (pre-loaded from planning artifacts)',
-          '',
-          completionContext,
-          '',
-          '# Instructions',
-          '',
-          'Verify each layer in order (ticket → brief → spec → tasks).',
-          'For EACH requirement/deliverable: grep or read the actual code to find evidence.',
-          'Mark DELIVERED only with a code citation (file:line or diff excerpt).',
-          'Mark INCOMPLETE if any P0 requirement lacks code evidence.',
-        ].join('\n'),
-        note: 'Pass the prompt directly to the agent.',
-      },
+      buildCodeReviewDelegate(state, changesHash, codeReviewReport),
+      buildCompletionDelegate(state, changesHash, completionReport, completionContext),
     ];
 
     return {

--- a/plugins/work/scripts/workflows/check2/lib/steps/phase2-consensus.js
+++ b/plugins/work/scripts/workflows/check2/lib/steps/phase2-consensus.js
@@ -14,88 +14,103 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
+// True when the code review flags unresolved IMPORTANT/CRITICAL items and is
+// not already APPROVED. Missing/unreadable report → no suggestions (skip).
+function reviewHasSuggestions(crPath) {
+  try {
+    const cr = fs.readFileSync(crPath, 'utf8');
+    return /🟡\s*IMPORTANT|🔴\s*CRITICAL/i.test(cr) && !/Status:\s*APPROVED/i.test(cr);
+  } catch {
+    return false; // no code review → skip
+  }
+}
+
+// Pick the developer agent from affected-file analysis, falling back to the
+// node TDD developer when the helper is unavailable or returns nothing.
+function resolveDeveloperAgent(ctx, state) {
+  try {
+    const result = execFileSync(
+      process.execPath,
+      [
+        path.join(ctx.checkHooksDir, 'check-determine-developers.js'),
+        JSON.stringify(state.setupResult?.affectedFiles || {}),
+      ],
+      { encoding: 'utf8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+    const devResult = JSON.parse(result);
+    if (devResult.developers && devResult.developers.length > 0) {
+      return `work-workflow:${devResult.developers[0]}`;
+    }
+  } catch {
+    /* fallback */
+  }
+  return 'work-workflow:developer-nodejs-tdd';
+}
+
+// Archive the current review report → code-review.run${iteration}.md. Fail-open.
+function archiveReport(crPath, reportFolder, iteration) {
+  try {
+    fs.renameSync(crPath, path.join(reportFolder, `code-review.run${iteration}.md`));
+  } catch {
+    /* fail-open */
+  }
+}
+
+function buildDevFixDelegate(state, crPath, developerAgent) {
+  return {
+    type: 'check_instruction',
+    action: 'execute',
+    state: { ticket: state.ticketId, currentStep: '6_phase2_consensus', progress: '6/9' },
+    continue: true,
+    delegate: {
+      type: 'task',
+      agentType: developerAgent,
+      description: `Fix code review suggestions (round ${state.consensusIteration + 1})`,
+      prompt: `Fix code review suggestions for ${state.ticketId}. Read ${crPath}. For each suggestion: IMPLEMENT if valid, SKIP with reason if not.`,
+      note: 'Pass the prompt directly to the agent.',
+    },
+  };
+}
+
+function buildFreshReviewDelegate(state, crPath, changesHash) {
+  return {
+    type: 'check_instruction',
+    action: 'execute',
+    state: { ticket: state.ticketId, currentStep: '6_phase2_consensus', progress: '6/9' },
+    continue: true,
+    delegate: {
+      type: 'task',
+      agentType: 'work-workflow:code-checker',
+      description: `Fresh code review (round ${state.consensusIteration + 1})`,
+      prompt: `Review code changes for ${state.ticketId}. Write report to ${crPath}. Changes hash: ${changesHash}. This is a fresh review — evaluate current code state.`,
+      note: 'Pass the prompt directly to the agent.',
+    },
+  };
+}
+
 module.exports = function registerPhase2(register) {
   register('6_phase2_consensus', (state, ctx) => {
     const reportFolder = state.setupResult?.reportFolder || ctx.tasksDir;
     const crPath = path.join(reportFolder, 'code-review.check.md');
     const changesHash = state.changesHash || 'unknown';
 
-    // Check if code review has suggestions
-    let hasSuggestions = false;
-    try {
-      const cr = fs.readFileSync(crPath, 'utf8');
-      hasSuggestions = /🟡\s*IMPORTANT|🔴\s*CRITICAL/i.test(cr) && !/Status:\s*APPROVED/i.test(cr);
-    } catch {
-      /* no code review → skip */
-    }
-
-    if (!hasSuggestions) return null; // auto-advance
+    if (!reviewHasSuggestions(crPath)) return null; // auto-advance
     if (state.consensusIteration >= 3) return null; // max iterations → advance
 
-    // Determine developer agent
-    let developerAgent = 'work-workflow:developer-nodejs-tdd';
-    try {
-      const result = execFileSync(
-        process.execPath,
-        [
-          path.join(ctx.checkHooksDir, 'check-determine-developers.js'),
-          JSON.stringify(state.setupResult?.affectedFiles || {}),
-        ],
-        { encoding: 'utf8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }
-      );
-      const devResult = JSON.parse(result);
-      if (devResult.developers && devResult.developers.length > 0) {
-        developerAgent = `work-workflow:${devResult.developers[0]}`;
-      }
-    } catch {
-      /* fallback */
-    }
+    const developerAgent = resolveDeveloperAgent(ctx, state);
 
     // Sub-step 1: dispatch developer to fix suggestions
     if (!state.dispatched || state.dispatched === '6_consensus_reviewed') {
       state.dispatched = '6_consensus_dev';
-      return {
-        type: 'check_instruction',
-        action: 'execute',
-        state: { ticket: state.ticketId, currentStep: '6_phase2_consensus', progress: '6/9' },
-        continue: true,
-        delegate: {
-          type: 'task',
-          agentType: developerAgent,
-          description: `Fix code review suggestions (round ${state.consensusIteration + 1})`,
-          prompt: `Fix code review suggestions for ${state.ticketId}. Read ${crPath}. For each suggestion: IMPLEMENT if valid, SKIP with reason if not.`,
-          note: 'Pass the prompt directly to the agent.',
-        },
-      };
+      return buildDevFixDelegate(state, crPath, developerAgent);
     }
 
     // Sub-step 2: archive old report + request fresh review
     if (state.dispatched === '6_consensus_dev') {
       state.consensusIteration++;
-
-      // Archive old report
-      try {
-        const archiveName = `code-review.run${state.consensusIteration}.md`;
-        fs.renameSync(crPath, path.join(reportFolder, archiveName));
-      } catch {
-        /* fail-open */
-      }
-
+      archiveReport(crPath, reportFolder, state.consensusIteration);
       state.dispatched = '6_consensus_reviewed';
-
-      return {
-        type: 'check_instruction',
-        action: 'execute',
-        state: { ticket: state.ticketId, currentStep: '6_phase2_consensus', progress: '6/9' },
-        continue: true,
-        delegate: {
-          type: 'task',
-          agentType: 'work-workflow:code-checker',
-          description: `Fresh code review (round ${state.consensusIteration + 1})`,
-          prompt: `Review code changes for ${state.ticketId}. Write report to ${crPath}. Changes hash: ${changesHash}. This is a fresh review — evaluate current code state.`,
-          note: 'Pass the prompt directly to the agent.',
-        },
-      };
+      return buildFreshReviewDelegate(state, crPath, changesHash);
     }
 
     return null;

--- a/plugins/work/scripts/workflows/check2/lib/steps/run-e2e.js
+++ b/plugins/work/scripts/workflows/check2/lib/steps/run-e2e.js
@@ -6,59 +6,17 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+const { runAffectedSuite } = require('../run-affected-suite');
 
 module.exports = function registerRunE2e(register) {
-  register('9_run_e2e', (state, ctx) => {
-    const cmd = process.env.SCRIPT_RUN_AFFECTED_E2E;
-    if (!cmd) return null; // not configured → skip
-
-    const reportFolder = state.setupResult?.reportFolder || ctx.tasksDir;
-    const reportPath = path.join(reportFolder, 'e2e-tests.check.md');
-
-    let output = '';
-    let exitCode = 0;
-    try {
-      output = execSync(`${cmd} 2>&1`, { encoding: 'utf8', timeout: 900000 }); // 15min for e2e
-    } catch (err) {
-      exitCode = err.status || 1;
-      output = (err.stdout || '') + (err.stderr || '');
-    }
-
-    const passMatch = output.match(/pass\s+(\d+)/i);
-    const failMatch = output.match(/fail\s+(\d+)/i);
-    const passCount = passMatch ? passMatch[1] : '?';
-    const failCount = failMatch ? failMatch[1] : '?';
-    const status = exitCode === 0 ? 'APPROVED' : 'NEEDS_WORK';
-
-    fs.writeFileSync(reportPath, [
-      `Status: ${status}`,
-      '',
-      '# E2E Test Results',
-      '',
-      `**Runner:** SCRIPT_RUN_AFFECTED_E2E`,
-      `**Exit code:** ${exitCode}`,
-      `**Pass:** ${passCount} | **Fail:** ${failCount}`,
-      '',
-      '## Output',
-      '```',
-      output.substring(0, 5000),
-      '```',
-    ].join('\n'));
-
-    if (exitCode !== 0) {
-      state.testsFailed = true;
-      return {
-        type: 'check_instruction',
-        action: 'failed',
-        state: { ticket: state.ticketId, currentStep: '9_run_e2e' },
-        reason: `E2E tests failed (${failCount} failing).`,
-        report: reportPath,
-      };
-    }
-
-    return null;
-  });
+  register(
+    '9_run_e2e',
+    runAffectedSuite({
+      envVar: 'SCRIPT_RUN_AFFECTED_E2E',
+      stepName: '9_run_e2e',
+      reportFile: 'e2e-tests.check.md',
+      label: 'E2E',
+      timeout: 900000, // 15min for e2e
+    })
+  );
 };

--- a/plugins/work/scripts/workflows/check2/lib/steps/run-integration.js
+++ b/plugins/work/scripts/workflows/check2/lib/steps/run-integration.js
@@ -6,59 +6,17 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+const { runAffectedSuite } = require('../run-affected-suite');
 
 module.exports = function registerRunIntegration(register) {
-  register('8_run_integration', (state, ctx) => {
-    const cmd = process.env.SCRIPT_RUN_AFFECTED_INTEGRATION;
-    if (!cmd) return null; // not configured → skip
-
-    const reportFolder = state.setupResult?.reportFolder || ctx.tasksDir;
-    const reportPath = path.join(reportFolder, 'integration-tests.check.md');
-
-    let output = '';
-    let exitCode = 0;
-    try {
-      output = execSync(`${cmd} 2>&1`, { encoding: 'utf8', timeout: 600000 });
-    } catch (err) {
-      exitCode = err.status || 1;
-      output = (err.stdout || '') + (err.stderr || '');
-    }
-
-    const passMatch = output.match(/pass\s+(\d+)/i);
-    const failMatch = output.match(/fail\s+(\d+)/i);
-    const passCount = passMatch ? passMatch[1] : '?';
-    const failCount = failMatch ? failMatch[1] : '?';
-    const status = exitCode === 0 ? 'APPROVED' : 'NEEDS_WORK';
-
-    fs.writeFileSync(reportPath, [
-      `Status: ${status}`,
-      '',
-      '# Integration Test Results',
-      '',
-      `**Runner:** SCRIPT_RUN_AFFECTED_INTEGRATION`,
-      `**Exit code:** ${exitCode}`,
-      `**Pass:** ${passCount} | **Fail:** ${failCount}`,
-      '',
-      '## Output',
-      '```',
-      output.substring(0, 5000),
-      '```',
-    ].join('\n'));
-
-    if (exitCode !== 0) {
-      state.testsFailed = true;
-      return {
-        type: 'check_instruction',
-        action: 'failed',
-        state: { ticket: state.ticketId, currentStep: '8_run_integration' },
-        reason: `Integration tests failed (${failCount} failing).`,
-        report: reportPath,
-      };
-    }
-
-    return null;
-  });
+  register(
+    '8_run_integration',
+    runAffectedSuite({
+      envVar: 'SCRIPT_RUN_AFFECTED_INTEGRATION',
+      stepName: '8_run_integration',
+      reportFile: 'integration-tests.check.md',
+      label: 'Integration',
+      timeout: 600000,
+    })
+  );
 };

--- a/plugins/work/scripts/workflows/check2/lib/steps/run-tests.js
+++ b/plugins/work/scripts/workflows/check2/lib/steps/run-tests.js
@@ -29,46 +29,63 @@ function runCommand(cmd, timeout) {
 }
 
 /**
- * Run quality gate and return { output, exitCode, tier }.
- *
- * Tier 0 (preferred): per-suite SCRIPT_RUN_AFFECTED_* env vars. Each set
- *   suite is run in sequence; the first non-zero exit short-circuits.
- *   This lets repos plug in their own affected-detection (nx, turbo, custom).
- * Tier 1: $LINT_COMMAND / $TYPECHECK_COMMAND / $TEST_COMMAND env vars routed
- *   through the bundled dev-check.sh which evaluates them with $CHANGED_FILES.
- * Tier 2: pnpm dev:check
- * Tier 3: bundled dev-check.sh
- * Tier 4: pnpm test fallback
+ * Tier 0 (preferred): per-suite SCRIPT_RUN_AFFECTED_* env vars. Each set suite
+ * is run in sequence; the first non-zero exit short-circuits. This lets repos
+ * plug in their own affected-detection (nx, turbo, custom). Returns a result,
+ * or null when no affected-suite env vars are configured.
  */
-function runQualityGate(checkHooksDir) {
-  // Tier 0: per-suite SCRIPT_RUN_AFFECTED_* — run each defined suite, stop on first failure
+function runAffectedSuites() {
   const suites = [
     { name: 'unit', cmd: process.env.SCRIPT_RUN_AFFECTED_UNIT },
     { name: 'integration', cmd: process.env.SCRIPT_RUN_AFFECTED_INTEGRATION },
     { name: 'e2e', cmd: process.env.SCRIPT_RUN_AFFECTED_E2E },
   ].filter((s) => s.cmd);
 
-  if (suites.length > 0) {
-    const outputs = [];
-    for (const { name, cmd } of suites) {
-      outputs.push(`### ${name} (${cmd})`);
-      const result = runCommand(cmd, 600000);
-      outputs.push(result.output);
-      if (result.exitCode !== 0) {
-        return {
-          output: outputs.join('\n'),
-          exitCode: result.exitCode,
-          tier: `affected-${name} (failed)`,
-        };
-      }
-    }
-    return {
-      output: outputs.join('\n'),
-      exitCode: 0,
-      tier: `affected (${suites.map((s) => s.name).join('+')})`,
-    };
-  }
+  if (suites.length === 0) return null;
 
+  const outputs = [];
+  for (const { name, cmd } of suites) {
+    outputs.push(`### ${name} (${cmd})`);
+    const result = runCommand(cmd, 600000);
+    outputs.push(result.output);
+    if (result.exitCode !== 0) {
+      return {
+        output: outputs.join('\n'),
+        exitCode: result.exitCode,
+        tier: `affected-${name} (failed)`,
+      };
+    }
+  }
+  return {
+    output: outputs.join('\n'),
+    exitCode: 0,
+    tier: `affected (${suites.map((s) => s.name).join('+')})`,
+  };
+}
+
+// Tier 2: pnpm dev:check (project-defined). Returns a result, or null when the
+// repo has no package.json or no dev:check script.
+function tryPnpmDevCheck() {
+  try {
+    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+    if (pkg.scripts && pkg.scripts['dev:check']) {
+      return { ...runCommand('pnpm dev:check', 120000), tier: 'pnpm dev:check' };
+    }
+  } catch {
+    /* no package.json */
+  }
+  return null;
+}
+
+/**
+ * Tiers 1-4 (fallback when no affected-suite env vars are set):
+ * Tier 1: $LINT_COMMAND / $TYPECHECK_COMMAND / $TEST_COMMAND routed through the
+ *   bundled dev-check.sh (which evaluates them with $CHANGED_FILES).
+ * Tier 2: pnpm dev:check
+ * Tier 3: bundled dev-check.sh
+ * Tier 4: pnpm test / node --test fallback
+ */
+function runDevCheckTiers(checkHooksDir) {
   const devCheckScript = path.join(
     checkHooksDir,
     '..',
@@ -84,30 +101,31 @@ function runQualityGate(checkHooksDir) {
   const envOverridesPresent =
     process.env.LINT_COMMAND || process.env.TYPECHECK_COMMAND || process.env.TEST_COMMAND;
   if (envOverridesPresent && fs.existsSync(devCheckScript)) {
-    const result = runCommand(`bash "${devCheckScript}"`, 120000);
-    return { ...result, tier: 'dev-check.sh ($LINT/$TYPECHECK/$TEST_COMMAND)' };
+    return {
+      ...runCommand(`bash "${devCheckScript}"`, 120000),
+      tier: 'dev-check.sh ($LINT/$TYPECHECK/$TEST_COMMAND)',
+    };
   }
 
-  // Tier 2: pnpm dev:check
-  try {
-    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-    if (pkg.scripts && pkg.scripts['dev:check']) {
-      const result = runCommand('pnpm dev:check', 120000);
-      return { ...result, tier: 'pnpm dev:check' };
-    }
-  } catch {
-    /* no package.json */
-  }
+  const pnpmResult = tryPnpmDevCheck();
+  if (pnpmResult) return pnpmResult;
 
   // Tier 3: bundled dev-check script
   if (fs.existsSync(devCheckScript)) {
-    const result = runCommand(`bash "${devCheckScript}"`, 120000);
-    return { ...result, tier: 'dev-check.sh' };
+    return { ...runCommand(`bash "${devCheckScript}"`, 120000), tier: 'dev-check.sh' };
   }
 
   // Tier 4: pnpm test or node --test
-  const result = runCommand('pnpm test || node --test', 120000);
-  return { ...result, tier: 'pnpm test' };
+  return { ...runCommand('pnpm test || node --test', 120000), tier: 'pnpm test' };
+}
+
+/**
+ * Run quality gate and return { output, exitCode, tier }. Tier 0
+ * (affected-suite env vars) wins when configured; otherwise fall back through
+ * the dev-check tiers.
+ */
+function runQualityGate(checkHooksDir) {
+  return runAffectedSuites() || runDevCheckTiers(checkHooksDir);
 }
 
 function registerRunTests(register) {

--- a/plugins/work/scripts/workflows/check2/lib/steps/run-tests.js
+++ b/plugins/work/scripts/workflows/check2/lib/steps/run-tests.js
@@ -183,3 +183,6 @@ function registerRunTests(register) {
 
 module.exports = registerRunTests;
 module.exports.runQualityGate = runQualityGate;
+// Shared single command runner — also used by lib/run-affected-suite.js so the
+// whole /check2 subsystem has one combined-stdout/stderr exec site.
+module.exports.runCommand = runCommand;

--- a/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
+++ b/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
@@ -9,51 +9,12 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execFileSync } = require('child_process');
-const { resolvePluginConfig } = require('../../lib/plugin-config');
+const { runAutoAdvance } = require('../../lib/auto-advance');
 
-process.on('uncaughtException', () => process.exit(0));
-process.on('unhandledRejection', () => process.exit(0));
-
-// Parse the PostToolUse hook payload from stdin. Returns null on any error.
-function readHookData() {
-  try {
-    return JSON.parse(fs.readFileSync(0, 'utf8'));
-  } catch {
-    return null;
-  }
-}
-
-// Find THIS terminal's .follow-up-orchestrator.pid marker. findActiveMarker
-// scopes by owning session id + worktree root so a hook firing in one agent
-// never advances another agent's workflow. Returns null when missing or stale.
-function findMarker(TASKS_BASE) {
-  const { findActiveMarker } = require(path.join(__dirname, '..', '..', 'work', 'lib', 'marker'));
-  const marker = findActiveMarker(TASKS_BASE, '.follow-up-orchestrator.pid');
-  if (!marker) return null;
-  const markerAge = Date.now() - new Date(marker.startedAt).getTime();
-  if (markerAge > 12 * 60 * 60 * 1000) return null;
-  return marker;
-}
-
-// Run the orchestrator for `ticket` and return its parsed instruction, or null.
-function runFollowUpNext(ticket) {
-  // Test seam: an absolute path override lets the surface/blocked test stub
-  // follow-up-next.js without staging the entire plugin tree. Production code
-  // never sets FOLLOW_UP_NEXT_PATH; default resolves siblings as before.
-  const nextPath =
-    process.env.FOLLOW_UP_NEXT_PATH || path.join(__dirname, '..', 'follow-up-next.js');
-  try {
-    const result = execFileSync(process.execPath, [nextPath, ticket], {
-      encoding: 'utf8',
-      timeout: 130000, // monitor can take up to 2 min
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return JSON.parse(result);
-  } catch {
-    return null;
-  }
-}
+// Test seam: an absolute path override lets the surface/blocked test stub
+// follow-up-next.js without staging the entire plugin tree. Production code
+// never sets FOLLOW_UP_NEXT_PATH; default resolves siblings as before.
+const nextPath = process.env.FOLLOW_UP_NEXT_PATH || path.join(__dirname, '..', 'follow-up-next.js');
 
 // Persist the latest instruction so the Stop hook (session-guard) can surface
 // it inline when the agent tries to stop. Without this the agent gets only
@@ -81,37 +42,23 @@ const BANNERS = {
   surface: ['═══ FOLLOW-UP2: SURFACE ═══', '═══════════════════════════'],
 };
 
-function printInstruction(instruction) {
-  const banner = BANNERS[instruction.action];
-  if (!banner) return;
-  console.log('\n' + banner[0]);
+// Surface instructions print their reason just under the opening banner.
+// 'surface' is a terminal action handled alongside 'blocked'.
+function surfaceReason(instruction) {
   if (instruction.action === 'surface') {
-    const reason = (instruction.payload && instruction.payload.reason) || 'unknown';
-    console.log(`reason: ${reason}`);
+    return `reason: ${(instruction.payload && instruction.payload.reason) || 'unknown'}`;
   }
-  console.log(JSON.stringify(instruction, null, 2));
-  console.log(banner[1] + '\n');
+  return null;
 }
 
-function main() {
-  const hookData = readHookData();
-  if (!hookData) process.exit(0);
-
-  const transcriptPath = hookData?.transcript_path || '';
-  if (transcriptPath.includes('/subagents/')) process.exit(0);
-
-  const { TASKS_BASE } = resolvePluginConfig(path.join(__dirname, '..', '..', 'work'));
-  if (!TASKS_BASE) process.exit(0);
-
-  const marker = findMarker(TASKS_BASE);
-  if (!marker) process.exit(0);
-
-  const instruction = runFollowUpNext(marker.ticket);
-  if (!instruction) process.exit(0);
-
-  persistInstruction(TASKS_BASE, marker.ticket, instruction);
-  printInstruction(instruction);
-  process.exit(0);
+if (require.main === module && !process.env.NODE_TEST_CONTEXT) {
+  runAutoAdvance({
+    workDir: path.join(__dirname, '..', '..', 'work'),
+    markerFile: '.follow-up-orchestrator.pid',
+    scriptPath: nextPath,
+    timeout: 130000, // monitor can take up to 2 min
+    banners: BANNERS,
+    surfaceExtra: surfaceReason,
+    afterInstruction: persistInstruction,
+  });
 }
-
-if (require.main === module && !process.env.NODE_TEST_CONTEXT) main();

--- a/plugins/work/scripts/workflows/lib/auto-advance.js
+++ b/plugins/work/scripts/workflows/lib/auto-advance.js
@@ -1,0 +1,110 @@
+/**
+ * Shared runner for the PostToolUse auto-advance hooks
+ * (follow-up/hooks/follow-up-auto-advance.js, check2/hooks/check-auto-advance.js).
+ *
+ * Both hooks do the same thing — install fail-open guards, read the hook
+ * payload from stdin, find this terminal's orchestrator pid marker, run the
+ * orchestrator for the ticket, and print the returned instruction inside an
+ * action-keyed banner. They differ only in marker filename, orchestrator
+ * script, timeout, banner text, and (for follow-up) an instruction-persist
+ * side effect plus a surface-reason line — all passed in as options. Keeping
+ * the flow here once avoids a cross-file duplicate-block.
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+const { resolvePluginConfig } = require('./plugin-config');
+
+// Parse the PostToolUse hook payload from stdin. Returns null on any error.
+function readHookData() {
+  try {
+    return JSON.parse(fs.readFileSync(0, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+// Find THIS terminal's orchestrator pid marker. findActiveMarker scopes by
+// owning session id + worktree root so a hook firing in one agent never
+// advances another agent's workflow. Returns null when missing or stale.
+function findMarker(TASKS_BASE, markerFile, workLibDir) {
+  const { findActiveMarker } = require(path.join(workLibDir, 'marker'));
+  const marker = findActiveMarker(TASKS_BASE, markerFile);
+  if (!marker) return null;
+  const markerAge = Date.now() - new Date(marker.startedAt).getTime();
+  if (markerAge > 12 * 60 * 60 * 1000) return null;
+  return marker;
+}
+
+// Run an orchestrator script for `ticket` and return its parsed instruction, or
+// null on any spawn/parse error (fail-open).
+function runOrchestrator(scriptPath, ticket, timeout) {
+  try {
+    const result = execFileSync(process.execPath, [scriptPath, ticket], {
+      encoding: 'utf8',
+      timeout,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return JSON.parse(result);
+  } catch {
+    return null;
+  }
+}
+
+// Print an instruction wrapped in its action's banner. `banners` maps an action
+// to a [top, bottom] pair; unknown actions print nothing. `extra`, when given,
+// returns an optional line inserted after the opening banner (e.g. a surface
+// reason).
+function printInstruction(instruction, banners, extra) {
+  const banner = banners[instruction.action];
+  if (!banner) return;
+  console.log('\n' + banner[0]);
+  if (extra) {
+    const line = extra(instruction);
+    if (line) console.log(line);
+  }
+  console.log(JSON.stringify(instruction, null, 2));
+  console.log(banner[1] + '\n');
+}
+
+/**
+ * Drive one auto-advance cycle, then exit 0 (fail-open at every guard).
+ *
+ * @param {object} opts
+ * @param {string} opts.workDir     — path to the plugin's work dir (config + marker lib root)
+ * @param {string} opts.markerFile  — orchestrator pid marker filename
+ * @param {string} opts.scriptPath  — orchestrator script to run for the ticket
+ * @param {number} opts.timeout     — orchestrator spawn timeout (ms)
+ * @param {object} opts.banners     — action → [top, bottom] banner map
+ * @param {function} [opts.surfaceExtra]     — instruction → optional banner line
+ * @param {function} [opts.afterInstruction] — (TASKS_BASE, ticket, instruction) side effect
+ */
+function runAutoAdvance(opts) {
+  process.on('uncaughtException', () => process.exit(0));
+  process.on('unhandledRejection', () => process.exit(0));
+
+  const hookData = readHookData();
+  if (!hookData) process.exit(0);
+
+  // Guard: do NOT fire inside sub-agents
+  const transcriptPath = hookData?.transcript_path || '';
+  if (transcriptPath.includes('/subagents/')) process.exit(0);
+
+  const { TASKS_BASE } = resolvePluginConfig(opts.workDir);
+  if (!TASKS_BASE) process.exit(0);
+
+  const marker = findMarker(TASKS_BASE, opts.markerFile, path.join(opts.workDir, 'lib'));
+  if (!marker) process.exit(0);
+
+  const instruction = runOrchestrator(opts.scriptPath, marker.ticket, opts.timeout);
+  if (!instruction) process.exit(0);
+
+  if (opts.afterInstruction) opts.afterInstruction(TASKS_BASE, marker.ticket, instruction);
+  printInstruction(instruction, opts.banners, opts.surfaceExtra);
+  process.exit(0);
+}
+
+module.exports = { readHookData, findMarker, runOrchestrator, printInstruction, runAutoAdvance };


### PR DESCRIPTION
## Summary

This is the next step of the `.quality-exceptions` burn-down, following the merged /follow-up pilot (PR #614). It refactors all 8 /check2 files to pass the 6 static-quality rules (max-lines-per-function, cyclomatic complexity, cognitive complexity, max-depth, duplicate-blocks) and removes their entries from the root `.quality-exceptions` allowlist (253 → 245 lines).

## Changes

- **`completion-context.js`** — split large functions into focused helpers; complexity and line-count now within limits.
- **`phase1-agents.js`** — extracted helper functions to reduce cyclomatic and cognitive complexity.
- **`phase2-consensus.js`** — refactored nested logic into smaller units.
- **`run-tests.js`** — helper extractions to bring function line counts into compliance.
- **`run-e2e.js` / `run-integration.js`** — duplicate body collapsed into new shared `lib/run-affected-suite.js`; each file now delegates to the shared module.
- **`check-auto-advance.js`** — auto-advance orchestration logic extracted into new shared `lib/auto-advance.js`.
- **`follow-up-auto-advance.js`** — now uses the same shared `lib/auto-advance.js`; cross-file hook duplicate removed.
- **`.quality-exceptions`** — 8 /check2 entries removed (253 → 245 lines); `check-next.js` entry removed as it was already compliant.

All changes are conservative, behavior-preserving helper extractions and module splits — no logic changes.

## Notable

- Created `plugins/work/scripts/workflows/check2/lib/run-affected-suite.js` — shared module that de-duplicates `run-integration.js` and `run-e2e.js`.
- Created `plugins/work/scripts/workflows/lib/auto-advance.js` — shared `runAutoAdvance()` used by both `check-auto-advance.js` and `follow-up-auto-advance.js`, eliminating the cross-file duplicate that was previously flagged.
- `follow-up-auto-advance.js` is touched solely to adopt the shared module; it remains clean post-change.
- `check-next.js` had a stale allowlist entry (it was already compliant) — entry simply removed.

## Verification

- All 237 check2 + follow-up tests pass.
- Full static-quality gate exits 0 with no hard errors.
- Biome clean on all changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactoring-only changes to internal workflow hooks and check steps; behavior is intended to be preserved and risk is limited to orchestration edge cases (markers, timeouts, test reporting).
> 
> **Overview**
> Shrinks **`.quality-exceptions`** by dropping eight `/check2` paths (and a stale `check-next.js` entry) after refactors bring those files under the six static-quality rules.
> 
> **`/check2` orchestration** is split into smaller helpers without changing behavior: completion-checker prompt building (`completion-context.js`), phase-1 parallel agents and phase-2 review consensus loops, and the quality-gate runner in `run-tests.js` (affected suites vs dev-check fallbacks). Integration and E2E steps now delegate to new **`run-affected-suite.js`**, which shares **`runCommand`** from `run-tests.js` for a single exec path.
> 
> **PostToolUse auto-advance** for `/check2` and `/follow-up` is centralized in **`lib/auto-advance.js`**; both hooks are thin wrappers (follow-up keeps instruction persistence and surface-reason output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d528cf72fb59a56ded8906170505d60c9b25a9f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->