### PR TITLE
refactor(work-pr): clear /work-pr subsystem from quality allowlist

### DIFF
--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -63,7 +63,6 @@ plugins/work/scripts/workflows/work/lib/work-claims.js
 plugins/work/scripts/workflows/check/hooks/check-setup.js
 plugins/work/scripts/workflows/lib/protect-state-files.js
 plugins/work/scripts/workflows/check/check.workflow.js
-plugins/work/scripts/workflows/work-pr/work-pr.workflow.js
 plugins/work/scripts/workflows/check/hooks/check-start-env.js
 plugins/work/scripts/workflows/work/engine/transition-step.js
 plugins/work/scripts/workflows/work/hooks/work-suggestion-replies.js
@@ -99,7 +98,6 @@ plugins/work/scripts/workflows/check/hooks/check-generate-summary.js
 plugins/work/scripts/workflows/lib/request-index.js
 plugins/work/scripts/workflows/lib/hooks/policies/task-description-quality.js
 plugins/work/scripts/workflows/work/engine/inspect.js
-plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
 plugins/work/scripts/workflows/work/work-state/task-readiness.js
 plugins/work/scripts/workflows/work/work-state/graph-validation.js
 plugins/work/scripts/workflows/lib/quality-check.js
@@ -127,7 +125,6 @@ plugins/work/scripts/listen-all.js
 plugins/work/scripts/workflows/work/hooks/enforce-review-accountability.js
 plugins/work/scripts/workflows/lib/hook-error-log.js
 plugins/work/scripts/workflows/work/steps/brief-gate.js
-plugins/work/scripts/workflows/work-pr/agents/pr-generator/pr-generator-readonly-guard.js
 plugins/work/scripts/communicate.js
 plugins/work/scripts/workflows/work/lib/artifact-archival.js
 plugins/work/scripts/workflows/work/lib/gherkin-coverage.js
@@ -143,7 +140,6 @@ plugins/work/scripts/workflows/lib/hooks/policies/agent-authorization.js
 plugins/work/scripts/workflows/lib/hooks/inject-inbox-messages.js
 plugins/work/scripts/workflows/work-ci/lib/phases/wait.js
 plugins/work/scripts/workflows/work-brief/lib/phases/draft.js
-plugins/work/scripts/workflows/work-pr/agents/pr-generator/pr-generator-validator.js
 plugins/work/scripts/workflows/work-spec/lib/phases/kind_checks.js
 plugins/work/scripts/workflows/check/scripts/write-completion-report.js
 plugins/work/scripts/workflows/work-ci/lib/phases/wait_merge.js

--- a/plugins/work/scripts/workflows/check/check.workflow.js
+++ b/plugins/work/scripts/workflows/check/check.workflow.js
@@ -27,6 +27,7 @@ const { execSync } = require('child_process');
 
 const config = require(path.join(__dirname, '..', 'lib', 'config'));
 const { normalizeTicketId } = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
+const { normalizeTicketArg } = require(path.join(__dirname, '..', 'lib', 'ticket-args'));
 const { discoverApps } = require(path.join(__dirname, 'lib', 'app-access'));
 const TASKS_BASE = config.TASKS_BASE;
 const REPO_DIR = config.repoDir();
@@ -316,18 +317,12 @@ module.exports = {
    */
   params(args) {
     const raw = args.trim();
-    let ticketId = raw;
-
-    if (!ticketId) {
-      // Use branch name as fallback
-      ticketId = safeExec('git branch --show-current') || 'unknown';
-    } else if (/^\d+$/.test(ticketId)) {
-      ticketId = `${process.env.TICKET_PROJECT_KEY || process.env.JIRA_PROJECT_KEY || 'PROJ'}-${ticketId}`;
+    if (!raw) {
+      // Use branch name as fallback (not project-key prefixed)
+      const ticketId = normalizeTicketId(safeExec('git branch --show-current') || 'unknown');
+      return { instanceId: ticketId, ticketId };
     }
-
-    // Uppercase only the ticket base, preserve suffix case (GH-146)
-    ticketId = normalizeTicketId(ticketId);
-
+    const ticketId = normalizeTicketArg(raw);
     return { instanceId: ticketId, ticketId };
   },
 

--- a/plugins/work/scripts/workflows/lib/ticket-args.js
+++ b/plugins/work/scripts/workflows/lib/ticket-args.js
@@ -1,0 +1,26 @@
+/**
+ * Shared ticket-argument normalization for workflow params() parsers
+ * (work-pr.workflow.js, check.workflow.js). Both prefix a bare numeric id with
+ * the default project key, then normalize — keeping it here once avoids a
+ * cross-file duplicate-block.
+ */
+
+'use strict';
+
+const path = require('path');
+const { normalizeTicketId } = require(path.join(__dirname, 'ticket-provider'));
+
+/**
+ * Prefix a bare numeric ticket id with the configured project key, then
+ * normalize (uppercase the base, preserve suffix case — GH-146).
+ * @param {string} ticketId
+ * @returns {string}
+ */
+function normalizeTicketArg(ticketId) {
+  if (/^\d+$/.test(ticketId)) {
+    ticketId = `${process.env.TICKET_PROJECT_KEY || process.env.JIRA_PROJECT_KEY || 'PROJ'}-${ticketId}`;
+  }
+  return normalizeTicketId(ticketId);
+}
+
+module.exports = { normalizeTicketArg };

--- a/plugins/work/scripts/workflows/work-pr/agents/lib/hook-io.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/lib/hook-io.js
@@ -1,0 +1,46 @@
+/**
+ * Shared stdin/hook-payload helpers for the work-pr SubagentStop validators
+ * (pr-generator-validator.js, pr-post-generator-validator.js). Both read the
+ * entire hook payload from stdin and parse it the same way; keeping that here
+ * once avoids a cross-file duplicate-block.
+ */
+
+'use strict';
+
+// Read all of stdin to a string.
+async function readStdin() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+  return input;
+}
+
+// Read + parse the SubagentStop hook payload. On malformed JSON, write a
+// labelled error to stderr and exit 2 (block the agent).
+async function readHookDataStrict(label) {
+  const input = await readStdin();
+  try {
+    return JSON.parse(input);
+  } catch (err) {
+    process.stderr.write(`${label}: Failed to parse hook input: ${err.message}\n`);
+    process.exit(2);
+  }
+}
+
+// Resolve the subagent name from the hook payload (lowercased for matching).
+function resolveAgentName(hookData) {
+  return (hookData.agent_name || hookData.subagent_type || '').toLowerCase();
+}
+
+// Resolve the agent's textual output across the payload field variants.
+function resolveAgentOutput(hookData) {
+  return hookData.agent_output || hookData.response || hookData.result || '';
+}
+
+module.exports = {
+  readStdin,
+  readHookDataStrict,
+  resolveAgentName,
+  resolveAgentOutput,
+};

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-generator/pr-generator-readonly-guard.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-generator/pr-generator-readonly-guard.js
@@ -12,9 +12,9 @@
  * If it fails, the agent must stop — not fix anything.
  */
 
-const { logHookError } = require(
-  require('path').join(__dirname, '..', '..', '..', 'lib', 'hook-error-log')
-);
+const path = require('path');
+const { logHookError } = require(path.join(__dirname, '..', '..', '..', 'lib', 'hook-error-log'));
+const { readStdin, resolveAgentName } = require(path.join(__dirname, '..', 'lib', 'hook-io'));
 
 // Patterns for commands that modify files
 const FILE_MODIFY_PATTERNS = [
@@ -53,7 +53,8 @@ const FIX_ATTEMPT_PATTERNS = [
 ];
 
 // Allowed git subcommands — read-only + commit + push (no merge, rebase, reset, etc.)
-const ALLOWED_GIT_SUBCOMMANDS = /^\s*git\s+(diff|log|show|status|branch|rev-parse|ls-files|fetch|commit|push)\b/;
+const ALLOWED_GIT_SUBCOMMANDS =
+  /^\s*git\s+(diff|log|show|status|branch|rev-parse|ls-files|fetch|commit|push)\b/;
 
 // Explicitly allowed commands (quality gate + git/gh)
 const ALLOWED_COMMANDS = [
@@ -104,11 +105,14 @@ function isBlockedCommand(command) {
   return null;
 }
 
+// Extract the Bash command from the hook payload's tool input ('' when absent).
+function extractCommand(hookData) {
+  const toolInput = hookData.tool_input || hookData.input || {};
+  return toolInput.command || '';
+}
+
 async function main() {
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
+  const input = await readStdin();
 
   let hookData;
   try {
@@ -119,18 +123,12 @@ async function main() {
   }
 
   // Only guard pr-generator agent
-  const agentName = hookData.agent_name || hookData.subagent_type || '';
-  if (
-    !agentName.toLowerCase().includes('pr-generator') ||
-    agentName.toLowerCase().includes('post')
-  ) {
+  const agentName = resolveAgentName(hookData);
+  if (!agentName.includes('pr-generator') || agentName.includes('post')) {
     process.exit(0);
   }
 
-  // Extract the Bash command from the tool input
-  const toolInput = hookData.tool_input || hookData.input || {};
-  const command = toolInput.command || '';
-
+  const command = extractCommand(hookData);
   if (!command) {
     process.exit(0);
   }

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-generator/pr-generator-validator.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-generator/pr-generator-validator.js
@@ -11,6 +11,13 @@
  * 5. Has no emojis (professional requirement)
  */
 
+'use strict';
+
+const path = require('path');
+const { readHookDataStrict, resolveAgentName, resolveAgentOutput } = require(
+  path.join(__dirname, '..', 'lib', 'hook-io')
+);
+
 // More lenient patterns that handle potential wrapping or variations
 const REQUIRED_SECTIONS = [
   { name: 'Existing Behavior', pattern: /(?:^|\n)##?\s*Existing\s*Behavior/i },
@@ -29,34 +36,7 @@ const FORBIDDEN_PATTERNS = [
 // More comprehensive than manual ranges and auto-updates with Unicode versions
 const EMOJI_PATTERN = /\p{Emoji_Presentation}|\p{Extended_Pictographic}/u;
 
-async function main() {
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
-
-  let hookData;
-  try {
-    hookData = JSON.parse(input);
-  } catch (err) {
-    process.stderr.write(`PR-GENERATOR VALIDATOR: Failed to parse hook input: ${err.message}\n`);
-    process.exit(2);
-  }
-
-  // Only validate pr-generator subagent
-  const agentName = hookData.agent_name || hookData.subagent_type || '';
-  if (
-    !agentName.toLowerCase().includes('pr-generator') ||
-    agentName.toLowerCase().includes('post')
-  ) {
-    process.exit(0);
-  }
-
-  // Get the agent's output/response
-  const agentOutput = hookData.agent_output || hookData.response || hookData.result || '';
-
-  if (!agentOutput || agentOutput.length < 100) {
-    process.stderr.write(`
+const SHORT_OUTPUT_BOX = `
 ╔══════════════════════════════════════════════════════════════════════╗
 ║  🛑 PR-GENERATOR: OUTPUT TOO SHORT                                   ║
 ╠══════════════════════════════════════════════════════════════════════╣
@@ -66,56 +46,10 @@ async function main() {
 ║  Expected: Complete PR template with all required sections           ║
 ║                                                                      ║
 ╚══════════════════════════════════════════════════════════════════════╝
-`);
-    process.exit(2);
-  }
+`;
 
-  const issues = [];
-
-  // Check required sections
-  for (const section of REQUIRED_SECTIONS) {
-    if (!section.pattern.test(agentOutput)) {
-      issues.push(`Missing section: "${section.name}"`);
-    }
-  }
-
-  // Check forbidden patterns
-  for (const forbidden of FORBIDDEN_PATTERNS) {
-    if (forbidden.pattern.test(agentOutput)) {
-      issues.push(`Found ${forbidden.name}`);
-    }
-  }
-
-  // Check for emojis
-  if (EMOJI_PATTERN.test(agentOutput)) {
-    issues.push('Contains emojis (not allowed in PR descriptions)');
-  }
-
-  // Check Testing Plan has actual content
-  const testingPlanMatch = agentOutput.match(/##\s*Testing\s*Plan[^\n]*\n([\s\S]*?)(?=##|$)/i);
-  if (testingPlanMatch) {
-    const testingPlanContent = testingPlanMatch[1].trim();
-    // Strip markdown list markers, whitespace, and newlines to get substantive content
-    const strippedContent = testingPlanContent.replace(/[-*\s\n]/g, '');
-    // Must have at least 30 chars of actual content
-    if (strippedContent.length < 30) {
-      issues.push('Testing Plan section lacks substantive content');
-    }
-  }
-
-  // Check Dev Checks has proper checkbox format
-  const devChecksMatch = agentOutput.match(/##\s*Dev\s*Checks[^\n]*\n([\s\S]*?)(?=##|$)/i);
-  if (devChecksMatch) {
-    const devChecksContent = devChecksMatch[1];
-    const checkboxes = devChecksContent.match(/\[.\]/g) || [];
-    const validCheckboxes = checkboxes.filter((cb) => cb === '[Y]' || cb === '[ ]');
-    if (checkboxes.length > 0 && validCheckboxes.length !== checkboxes.length) {
-      issues.push('Dev Checks has invalid checkbox format (use [Y] or [ ] only)');
-    }
-  }
-
-  if (issues.length > 0) {
-    process.stderr.write(`
+function buildFailureBox(issues) {
+  return `
 ╔══════════════════════════════════════════════════════════════════════╗
 ║  🛑 PR-GENERATOR: VALIDATION FAILED                                  ║
 ╠══════════════════════════════════════════════════════════════════════╣
@@ -125,7 +59,66 @@ ${issues.map((i) => `║  ❌ ${i.padEnd(64)}║`).join('\n')}
 ║  Fix these issues and regenerate the PR description.                 ║
 ║                                                                      ║
 ╚══════════════════════════════════════════════════════════════════════╝
-`);
+`;
+}
+
+function checkRequiredSections(output) {
+  return REQUIRED_SECTIONS.filter((s) => !s.pattern.test(output)).map(
+    (s) => `Missing section: "${s.name}"`
+  );
+}
+
+function checkForbiddenPatterns(output) {
+  return FORBIDDEN_PATTERNS.filter((f) => f.pattern.test(output)).map((f) => `Found ${f.name}`);
+}
+
+// Testing Plan must carry ≥30 chars of substantive content (markers stripped).
+function checkTestingPlan(output) {
+  const match = output.match(/##\s*Testing\s*Plan[^\n]*\n([\s\S]*?)(?=##|$)/i);
+  if (!match) return [];
+  const stripped = match[1].trim().replace(/[-*\s\n]/g, '');
+  return stripped.length < 30 ? ['Testing Plan section lacks substantive content'] : [];
+}
+
+// Dev Checks checkboxes must all be [Y] or [ ] (no [x]/[X]).
+function checkDevChecks(output) {
+  const match = output.match(/##\s*Dev\s*Checks[^\n]*\n([\s\S]*?)(?=##|$)/i);
+  if (!match) return [];
+  const checkboxes = match[1].match(/\[.\]/g) || [];
+  const valid = checkboxes.filter((cb) => cb === '[Y]' || cb === '[ ]');
+  return checkboxes.length > 0 && valid.length !== checkboxes.length
+    ? ['Dev Checks has invalid checkbox format (use [Y] or [ ] only)']
+    : [];
+}
+
+function collectIssues(output) {
+  const issues = [...checkRequiredSections(output), ...checkForbiddenPatterns(output)];
+  if (EMOJI_PATTERN.test(output)) {
+    issues.push('Contains emojis (not allowed in PR descriptions)');
+  }
+  return [...issues, ...checkTestingPlan(output), ...checkDevChecks(output)];
+}
+
+async function main() {
+  const hookData = await readHookDataStrict('PR-GENERATOR VALIDATOR');
+
+  // Only validate pr-generator subagent
+  const agentName = resolveAgentName(hookData);
+  if (!agentName.includes('pr-generator') || agentName.includes('post')) {
+    process.exit(0);
+  }
+
+  // Get the agent's output/response
+  const agentOutput = resolveAgentOutput(hookData);
+
+  if (!agentOutput || agentOutput.length < 100) {
+    process.stderr.write(SHORT_OUTPUT_BOX);
+    process.exit(2);
+  }
+
+  const issues = collectIssues(agentOutput);
+  if (issues.length > 0) {
+    process.stderr.write(buildFailureBox(issues));
     process.exit(2);
   }
 

--- a/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/pr-post-generator/pr-post-generator-validator.js
@@ -15,6 +15,9 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+const { readHookDataStrict, resolveAgentName, resolveAgentOutput } = require(
+  path.join(__dirname, '..', 'lib', 'hook-io')
+);
 const getConfig = require(path.join(__dirname, '..', '..', '..', 'lib', 'get-config'));
 const { detectFabrication } = require('./fabrication-detector');
 const { appendAction } = require(
@@ -153,36 +156,7 @@ function hasWikiLink(text) {
   return wikiLinkPattern.test(text);
 }
 
-async function main() {
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
-
-  let hookData;
-  try {
-    hookData = JSON.parse(input);
-  } catch (err) {
-    process.stderr.write(
-      `PR-POST-GENERATOR VALIDATOR: Failed to parse hook input: ${err.message}\n`
-    );
-    process.exit(2);
-  }
-
-  // Only validate pr-post-generator subagent
-  const agentName = hookData.agent_name || hookData.subagent_type || '';
-  if (
-    !agentName.toLowerCase().includes('pr-post-generator') &&
-    !agentName.toLowerCase().includes('post-pr')
-  ) {
-    process.exit(0);
-  }
-
-  // Get the agent's output/response
-  const agentOutput = hookData.agent_output || hookData.response || hookData.result || '';
-
-  if (!agentOutput || agentOutput.length < 50) {
-    process.stderr.write(`
+const NO_OUTPUT_BOX = `
 ╔══════════════════════════════════════════════════════════════════════╗
 ║  POST-PR-GENERATOR: NO OUTPUT                                       ║
 ╠══════════════════════════════════════════════════════════════════════╣
@@ -192,22 +166,9 @@ async function main() {
 ║  Expected: Confirmation of screenshots uploaded and PR updated       ║
 ║                                                                      ║
 ╚══════════════════════════════════════════════════════════════════════╝
-`);
-    process.exit(2);
-  }
+`;
 
-  const issues = [];
-  const warnings = [];
-
-  // ========== FABRICATION CHECK (runs FIRST, regardless of frontend status) ==========
-  const prBody = getPRBody();
-  const ticketId = getCurrentTaskId();
-  const tasksBase = getConfig('TASKS_BASE');
-  // Fail-closed when the PR body cannot be fetched: a transient `gh` failure
-  // must not become a silent bypass for fabricated test evidence. Empty body
-  // (`""`) is fine — nothing to scan — but `null` means we never saw the body.
-  if (prBody === null) {
-    process.stderr.write(`
+const NO_PR_BODY_BOX = `
 ╔══════════════════════════════════════════════════════════════════════╗
 ║  POST-PR-GENERATOR: COULD NOT FETCH PR BODY                          ║
 ╠══════════════════════════════════════════════════════════════════════╣
@@ -218,13 +179,26 @@ async function main() {
 ║  Re-run after confirming \`gh\` auth and PR association.               ║
 ║                                                                      ║
 ╚══════════════════════════════════════════════════════════════════════╝
-`);
-    process.exit(2);
-  }
-  // Run the fabrication check unconditionally. Missing TASKS_BASE or ticketId
-  // must not become a silent bypass — without a task folder the detector sees
-  // no artifacts, so unsourced stability/PASS/FAIL claims still trip. Only the
-  // audit-log appendAction is skipped when ticketId is absent.
+`;
+
+function buildFailureBox(issues, warnings) {
+  return `
+╔══════════════════════════════════════════════════════════════════════╗
+║  POST-PR-GENERATOR: VALIDATION FAILED                               ║
+╠══════════════════════════════════════════════════════════════════════╣
+║                                                                      ║
+${issues.map((i) => `║  ${i.padEnd(66)}║`).join('\n')}
+${warnings.length > 0 ? warnings.map((w) => `║  ${w.padEnd(66)}║`).join('\n') : ''}
+║                                                                      ║
+║  Ensure screenshots are uploaded to wiki and PR has a wiki link.     ║
+║                                                                      ║
+╚══════════════════════════════════════════════════════════════════════╝
+`;
+}
+
+// Fabrication check must run even without a task folder/ticket — only the audit
+// log is skipped. Surface why via stderr (never a silent bypass).
+function warnMissingAuditContext(tasksBase, ticketId) {
   if (!tasksBase) {
     process.stderr.write(
       'PR-POST-GENERATOR VALIDATOR: TASKS_BASE not configured; running fabrication check without task folder (no audit log).\n'
@@ -234,8 +208,96 @@ async function main() {
       'PR-POST-GENERATOR VALIDATOR: could not resolve ticket ID; running fabrication check without audit log.\n'
     );
   }
+}
+
+// Verify visual documentation for frontend changes. Returns { issues, warnings }.
+function collectVisualIssues(agentOutput, prBody, affectedFrontendApps) {
+  const issues = [];
+  const warnings = [];
+
+  if (prBody) {
+    if (!hasWikiLink(prBody)) {
+      issues.push(
+        `PR body has no wiki link for visual documentation (frontend apps affected: ${affectedFrontendApps.join(', ')}). Add a wiki link.`
+      );
+    }
+  } else {
+    warnings.push('Could not fetch PR body to verify visual documentation');
+  }
+
+  const hasWikiMention = /wiki|github\.com.*wiki/i.test(agentOutput);
+  if (!hasWikiMention) {
+    issues.push('No wiki upload confirmation found');
+  }
+
+  // Local file paths are a negative indicator (should be wiki URLs)
+  const localPathPattern = /!\[.*\]\(\.\/|!\[.*\]\(tasks\/|!\[.*\]\(screenshots\//;
+  if (localPathPattern.test(agentOutput)) {
+    issues.push('Found local file paths instead of wiki URLs');
+  }
+
+  const prUpdatePatterns = [
+    /PR.*updated/i,
+    /updated.*PR/i,
+    /gh pr edit/i,
+    /pull request.*updated/i,
+  ];
+  if (!prUpdatePatterns.some((p) => p.test(agentOutput))) {
+    warnings.push('No PR update confirmation found');
+  }
+
+  const genericTestPatterns = [
+    /Page loads.*PASS/i,
+    /Navigation works.*PASS/i,
+    /Theme toggle.*PASS/i,
+    /Common functionality/i,
+  ];
+  if (genericTestPatterns.some((p) => p.test(agentOutput))) {
+    warnings.push('Contains generic page tests (should focus on feature-specific)');
+  }
+
+  return { issues, warnings };
+}
+
+// Fetch the PR body, run the fabrication check (fail-closed when the body can't
+// be fetched), and return the PR body for downstream visual-doc checks. Exits 2
+// on a fetch failure or detected fabrication.
+function runFabricationGate() {
+  const prBody = getPRBody();
+  const ticketId = getCurrentTaskId();
+  const tasksBase = getConfig('TASKS_BASE');
+  // Fail-closed when the PR body cannot be fetched: a transient `gh` failure
+  // must not become a silent bypass for fabricated test evidence. Empty body
+  // (`""`) is fine — nothing to scan — but `null` means we never saw the body.
+  if (prBody === null) {
+    process.stderr.write(NO_PR_BODY_BOX);
+    process.exit(2);
+  }
+  warnMissingAuditContext(tasksBase, ticketId);
   const taskDir = tasksBase && ticketId ? path.join(tasksBase, ticketId) : '';
   runFabricationCheck(prBody, taskDir, ticketId);
+  return prBody;
+}
+
+async function main() {
+  const hookData = await readHookDataStrict('PR-POST-GENERATOR VALIDATOR');
+
+  // Only validate pr-post-generator subagent
+  const agentName = resolveAgentName(hookData);
+  if (!agentName.includes('pr-post-generator') && !agentName.includes('post-pr')) {
+    process.exit(0);
+  }
+
+  // Get the agent's output/response
+  const agentOutput = resolveAgentOutput(hookData);
+
+  if (!agentOutput || agentOutput.length < 50) {
+    process.stderr.write(NO_OUTPUT_BOX);
+    process.exit(2);
+  }
+
+  // ========== FABRICATION CHECK (runs FIRST, regardless of frontend status) ==========
+  const prBody = runFabricationGate();
 
   // ========== CHECK IF FRONTEND APPS ARE AFFECTED ==========
   const affectedApps = getAffectedApps();
@@ -247,69 +309,10 @@ async function main() {
   }
 
   // ========== VERIFY VISUAL DOCUMENTATION (frontend only) ==========
-  if (prBody) {
-    const hasLink = hasWikiLink(prBody);
-
-    if (!hasLink) {
-      issues.push(
-        `PR body has no wiki link for visual documentation (frontend apps affected: ${affectedFrontendApps.join(', ')}). Add a wiki link.`
-      );
-    }
-  } else {
-    warnings.push('Could not fetch PR body to verify visual documentation');
-  }
-
-  // Check if wiki upload was mentioned
-  const hasWikiMention = /wiki|github\.com.*wiki/i.test(agentOutput);
-  if (!hasWikiMention) {
-    issues.push('No wiki upload confirmation found');
-  }
-
-  // Check for local file paths (negative indicator)
-  const localPathPattern = /!\[.*\]\(\.\/|!\[.*\]\(tasks\/|!\[.*\]\(screenshots\//;
-  const hasLocalPaths = localPathPattern.test(agentOutput);
-
-  if (hasLocalPaths) {
-    issues.push('Found local file paths instead of wiki URLs');
-  }
-
-  // Check if PR was updated
-  const prUpdatePatterns = [
-    /PR.*updated/i,
-    /updated.*PR/i,
-    /gh pr edit/i,
-    /pull request.*updated/i,
-  ];
-  const hasPRUpdate = prUpdatePatterns.some((p) => p.test(agentOutput));
-  if (!hasPRUpdate) {
-    warnings.push('No PR update confirmation found');
-  }
-
-  // Check for generic test results (should focus on feature-specific)
-  const genericTestPatterns = [
-    /Page loads.*PASS/i,
-    /Navigation works.*PASS/i,
-    /Theme toggle.*PASS/i,
-    /Common functionality/i,
-  ];
-  const hasGenericTests = genericTestPatterns.some((p) => p.test(agentOutput));
-  if (hasGenericTests) {
-    warnings.push('Contains generic page tests (should focus on feature-specific)');
-  }
+  const { issues, warnings } = collectVisualIssues(agentOutput, prBody, affectedFrontendApps);
 
   if (issues.length > 0) {
-    process.stderr.write(`
-╔══════════════════════════════════════════════════════════════════════╗
-║  POST-PR-GENERATOR: VALIDATION FAILED                               ║
-╠══════════════════════════════════════════════════════════════════════╣
-║                                                                      ║
-${issues.map((i) => `║  ${i.padEnd(66)}║`).join('\n')}
-${warnings.length > 0 ? warnings.map((w) => `║  ${w.padEnd(66)}║`).join('\n') : ''}
-║                                                                      ║
-║  Ensure screenshots are uploaded to wiki and PR has a wiki link.     ║
-║                                                                      ║
-╚══════════════════════════════════════════════════════════════════════╝
-`);
+    process.stderr.write(buildFailureBox(issues, warnings));
     process.exit(2);
   }
 

--- a/plugins/work/scripts/workflows/work-pr/work-pr-inspect.js
+++ b/plugins/work/scripts/workflows/work-pr/work-pr-inspect.js
@@ -66,23 +66,28 @@ function collectScreenshotFiles(dir, base) {
 // Stream a file in 64KB chunks → sha256 hex; null if not a regular file,
 // oversized (>50MB), or unreadable.
 function hashFile(fullPath) {
+  let fd;
   try {
-    const stat = fs.statSync(fullPath);
-    if (!stat.isFile() || stat.size > 50 * 1024 * 1024) return null;
-    const fd = fs.openSync(fullPath, 'r');
-    try {
-      const fileHash = crypto.createHash('sha256');
-      const buf = Buffer.alloc(65536);
-      let bytesRead;
-      while ((bytesRead = fs.readSync(fd, buf, 0, buf.length)) > 0) {
-        fileHash.update(buf.subarray(0, bytesRead));
-      }
-      return fileHash.digest('hex');
-    } finally {
-      fs.closeSync(fd);
-    }
+    fd = fs.openSync(fullPath, 'r');
   } catch {
     return null;
+  }
+  try {
+    // fstat the open descriptor (not statSync on the path) so the size/type
+    // check and the read operate on the same file — no check-then-use race.
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || stat.size > 50 * 1024 * 1024) return null;
+    const fileHash = crypto.createHash('sha256');
+    const buf = Buffer.alloc(65536);
+    let bytesRead;
+    while ((bytesRead = fs.readSync(fd, buf, 0, buf.length)) > 0) {
+      fileHash.update(buf.subarray(0, bytesRead));
+    }
+    return fileHash.digest('hex');
+  } catch {
+    return null;
+  } finally {
+    fs.closeSync(fd);
   }
 }
 

--- a/plugins/work/scripts/workflows/work-pr/work-pr-inspect.js
+++ b/plugins/work/scripts/workflows/work-pr/work-pr-inspect.js
@@ -1,0 +1,236 @@
+/**
+ * work-pr-inspect.js
+ *
+ * Filesystem/git inspection helpers for work-pr.workflow.js — screenshot
+ * hashing and the per-instance `inspect()` data gathering. Extracted from the
+ * workflow file to keep it under the size/complexity limits; pure helpers, no
+ * workflow state.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { execSync } = require('child_process');
+
+const SCREENSHOT_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
+// sha256 of empty input — `find … | sha256sum` yields this when nothing matches.
+const EMPTY_SHA256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
+function safeExec(cmd, options = {}) {
+  try {
+    return execSync(cmd, { encoding: 'utf8', ...options }).trim();
+  } catch {
+    return '';
+  }
+}
+
+// Read a recorded SHA file, trimmed; '' when missing or unreadable.
+function readShaFile(filePath) {
+  if (!fs.existsSync(filePath)) return '';
+  try {
+    return fs.readFileSync(filePath, 'utf8').trim();
+  } catch {
+    return '';
+  }
+}
+
+// Recursively collect screenshot file paths (relative to root), unsorted.
+// Manual traversal — avoids reliance on { recursive: true } (Node 18.17+).
+function collectScreenshotFiles(dir, base) {
+  let results = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      process.stderr.write(`[work-pr] computeScreenshotHash: cannot read ${dir}: ${err.message}\n`);
+    }
+    return results;
+  }
+  for (const entry of entries) {
+    const rel = base ? `${base}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      results = results.concat(collectScreenshotFiles(path.join(dir, entry.name), rel));
+    } else if (
+      entry.isFile() &&
+      SCREENSHOT_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
+    ) {
+      results.push(rel);
+    }
+  }
+  return results;
+}
+
+// Stream a file in 64KB chunks → sha256 hex; null if not a regular file,
+// oversized (>50MB), or unreadable.
+function hashFile(fullPath) {
+  try {
+    const stat = fs.statSync(fullPath);
+    if (!stat.isFile() || stat.size > 50 * 1024 * 1024) return null;
+    const fd = fs.openSync(fullPath, 'r');
+    try {
+      const fileHash = crypto.createHash('sha256');
+      const buf = Buffer.alloc(65536);
+      let bytesRead;
+      while ((bytesRead = fs.readSync(fd, buf, 0, buf.length)) > 0) {
+        fileHash.update(buf.subarray(0, bytesRead));
+      }
+      return fileHash.digest('hex');
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compute a deterministic hash of screenshot files in a directory.
+ * Uses Node.js crypto to avoid shell injection risks entirely.
+ * @param {string} screenshotDir - Absolute path to screenshots directory
+ * @returns {string} SHA256 hash or 'none' if no screenshots
+ */
+function computeScreenshotHash(screenshotDir) {
+  if (!fs.existsSync(screenshotDir)) return 'none';
+  const files = collectScreenshotFiles(screenshotDir, '').sort();
+  if (files.length === 0) return 'none';
+  const hash = crypto.createHash('sha256');
+  let filesHashed = 0;
+  for (const file of files) {
+    const hex = hashFile(path.join(screenshotDir, file));
+    if (hex === null) continue;
+    hash.update(`${hex}  ${file}\n`);
+    filesHashed++;
+  }
+  return filesHashed === 0 ? 'none' : hash.digest('hex');
+}
+
+// Resolve the base branch for diffs/guards from the shared config helper,
+// defaulting to origin/main when unavailable.
+function resolveBaseBranch(worktreeDir) {
+  try {
+    return require(path.join(__dirname, '..', 'lib', 'config')).getBaseBranch({ cwd: worktreeDir });
+  } catch {
+    return 'origin/main';
+  }
+}
+
+// Rebase guard: how many commits the worktree is behind base (opt-in via
+// REBASE_GUARD_ENABLED=1). Returns { commitsBehindMain } and, when actually
+// measured, { commitsBehindMainCapped }.
+function computeRebaseGuard(worktreeDir, baseBranch, worktreeExists) {
+  if (!worktreeExists || process.env.REBASE_GUARD_ENABLED !== '1') {
+    return { commitsBehindMain: 0 };
+  }
+  const parts = baseBranch.split('/');
+  const remote = parts.length > 1 ? parts[0] : 'origin';
+  const branch = parts.length > 1 ? parts.slice(1).join('/') : parts[0];
+  // Validate remote/branch to prevent command injection
+  const validRef = /^[a-zA-Z0-9_\-./]+$/.test(remote) && /^[a-zA-Z0-9_\-./]+$/.test(branch);
+  if (!validRef) {
+    process.stderr.write(`[work-pr] rebase guard: invalid baseBranch "${baseBranch}" — skipping\n`);
+    return { commitsBehindMain: 0 };
+  }
+  const guardThreshold = parseInt(process.env.REBASE_GUARD_THRESHOLD || '0', 10);
+  const fetchDepth = Math.max((Number.isFinite(guardThreshold) ? guardThreshold : 0) + 2, 2);
+  safeExec(`git fetch ${remote} ${branch} --quiet --depth=${fetchDepth} --no-tags`, {
+    cwd: worktreeDir,
+    timeout: 5000,
+  });
+  const fetchedRef = `${remote}/${branch}`;
+  const behind = safeExec(`git rev-list --count --max-count=${fetchDepth} HEAD..${fetchedRef}`, {
+    cwd: worktreeDir,
+  });
+  const commitsBehindMain = parseInt(behind || '0', 10); // capped by fetchDepth
+  return { commitsBehindMain, commitsBehindMainCapped: commitsBehindMain >= fetchDepth };
+}
+
+// Count screenshot files via find (best-effort; 0 on any failure).
+function countScreenshots(screenshotDir) {
+  if (!fs.existsSync(screenshotDir)) return 0;
+  try {
+    const files = safeExec(
+      `find "${screenshotDir}" -type f \\( -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' -o -name '*.gif' -o -name '*.webp' \\) 2>/dev/null`
+    );
+    return files ? files.split('\n').filter(Boolean).length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+// Content SHA for post-pr gating: all top-level *.check.md + every screenshot.
+function computeContentSha(tasksDir) {
+  return safeExec(
+    `(
+        find "${tasksDir}" -maxdepth 1 -name '*.check.md' -print0 2>/dev/null | sort -z | xargs -0 sha256sum 2>/dev/null
+        find "${tasksDir}/screenshots" -type f -print0 2>/dev/null | sort -z | xargs -0 sha256sum 2>/dev/null
+      ) | sha256sum | cut -d' ' -f1`
+  );
+}
+
+/**
+ * Gather all inspection data for an instance from its tasks + worktree dirs.
+ * @param {string} tasksDir
+ * @param {string} worktreeDir
+ * @returns {object} inspection data
+ */
+function buildInspectData(tasksDir, worktreeDir) {
+  const data = {
+    tasksDir,
+    tasksDirExists: fs.existsSync(tasksDir),
+    worktreeDir,
+    worktreeExists: fs.existsSync(worktreeDir),
+  };
+
+  // Current HEAD SHA (from ticket worktree)
+  data.headSha = safeExec('git rev-parse HEAD', { cwd: worktreeDir });
+
+  // .pr-update-sha (stores compound key: HEAD_SHA|SCREENSHOT_HASH)
+  data.prShaFile = path.join(tasksDir, '.pr-update-sha');
+  data.lastPrSha = readShaFile(data.prShaFile);
+
+  // TSX/JSX changes vs base (from ticket worktree)
+  const baseBranch = resolveBaseBranch(worktreeDir);
+  data.tsxChanged = safeExec(`git diff --name-only ${baseBranch}...HEAD -- '*.tsx' '*.jsx'`, {
+    cwd: worktreeDir,
+  });
+  data.hasTsxChanges = data.tsxChanged.length > 0;
+
+  // Rebase guard
+  data.baseBranch = baseBranch;
+  const guard = computeRebaseGuard(worktreeDir, baseBranch, data.worktreeExists);
+  data.commitsBehindMain = guard.commitsBehindMain;
+  if (guard.commitsBehindMainCapped !== undefined) {
+    data.commitsBehindMainCapped = guard.commitsBehindMainCapped;
+  }
+
+  // Screenshots
+  const screenshotDir = path.join(tasksDir, 'screenshots');
+  data.screenshotDir = screenshotDir;
+  data.screenshotCount = countScreenshots(screenshotDir);
+  data.screenshotsExist = data.screenshotCount > 0;
+  data.screenshotHash = computeScreenshotHash(screenshotDir);
+
+  // Compound pr-gen gating key: HEAD_SHA|SCREENSHOT_HASH
+  data.prKey = `${data.headSha}|${data.screenshotHash}`;
+  data.prUpToDate = !!(data.prKey && data.prKey === data.lastPrSha);
+
+  // Content SHA for post-pr (all *.check.md + screenshots)
+  data.contentSha = computeContentSha(tasksDir);
+  data.postPrShaFile = path.join(tasksDir, '.post-pr-update-sha');
+  data.lastPostPrSha = readShaFile(data.postPrShaFile);
+  data.postPrUpToDate = !!(data.contentSha && data.contentSha === data.lastPostPrSha);
+
+  // SKIP 5_post_pr_gen if no content to post
+  data.hasContent = !!(data.contentSha && data.contentSha !== EMPTY_SHA256);
+
+  return data;
+}
+
+module.exports = {
+  safeExec,
+  computeScreenshotHash,
+  buildInspectData,
+};

--- a/plugins/work/scripts/workflows/work-pr/work-pr.workflow.js
+++ b/plugins/work/scripts/workflows/work-pr/work-pr.workflow.js
@@ -18,7 +18,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -26,8 +25,11 @@ const config = require(path.join(__dirname, '..', 'lib', 'config'));
 const getConfig = require(path.join(__dirname, '..', 'lib', 'get-config'));
 const WORKTREES_BASE = getConfig.require('WORKTREES_BASE');
 const TASKS_BASE = getConfig('TASKS_BASE') || path.join(WORKTREES_BASE, 'tasks');
-const { normalizeTicketId } = require(path.join(__dirname, '..', 'lib', 'ticket-provider'));
+const { normalizeTicketArg } = require(path.join(__dirname, '..', 'lib', 'ticket-args'));
 const safeTicketId = config.safeTicketId;
+const { safeExec, computeScreenshotHash, buildInspectData } = require(
+  path.join(__dirname, 'work-pr-inspect')
+);
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -40,77 +42,84 @@ function getWorktreeDir(ticketId) {
   return config.worktreeDir(safe) || path.join(WORKTREES_BASE, `${config.REPO_NAME}-${safe}`);
 }
 
-function safeExec(cmd, options = {}) {
-  try {
-    return execSync(cmd, { encoding: 'utf8', ...options }).trim();
-  } catch {
-    return '';
+// ─── Step deciders (detectStepState helpers) ────────────────────────────────
+
+// Rebase guard: BLOCKED when the worktree is behind base beyond threshold.
+function prGenRebaseBlock(d) {
+  const parsed = parseInt(process.env.REBASE_GUARD_THRESHOLD || '0', 10);
+  const threshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+  if (d.commitsBehindMain > threshold) {
+    return {
+      action: 'BLOCKED',
+      reason: `Worktree is ${d.commitsBehindMainCapped ? '>= ' : ''}${d.commitsBehindMain} commit(s) behind ${d.baseBranch || 'origin/main'}. Rebase before creating PR.`,
+    };
   }
+  return null;
 }
 
-/**
- * Compute a deterministic hash of screenshot files in a directory.
- * Uses Node.js crypto to avoid shell injection risks entirely.
- * @param {string} screenshotDir - Absolute path to screenshots directory
- * @returns {string} SHA256 hash or 'none' if no screenshots
- */
-function computeScreenshotHash(screenshotDir) {
-  if (!fs.existsSync(screenshotDir)) return 'none';
-  const crypto = require('crypto');
-  const extensions = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
-  // Manual recursive traversal — avoids reliance on { recursive: true } (Node 18.17+)
-  function walkDir(dir, base) {
-    let results = [];
-    let entries;
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch (err) {
-      if (err.code !== 'ENOENT')
-        process.stderr.write(
-          `[work-pr] computeScreenshotHash: cannot read ${dir}: ${err.message}\n`
-        );
-      return results;
-    }
-    for (const entry of entries) {
-      const rel = base ? `${base}/${entry.name}` : entry.name;
-      if (entry.isDirectory()) {
-        results = results.concat(walkDir(path.join(dir, entry.name), rel));
-      } else if (entry.isFile() && extensions.has(path.extname(entry.name).toLowerCase())) {
-        results.push(rel);
-      }
-    }
-    return results;
+// SHA-skip: compound key unchanged and not forced.
+function prGenSkip(d, force) {
+  if (!force && d.prUpToDate) {
+    return {
+      action: 'SKIP',
+      reason: `Compound key matches (${d.headSha?.slice(0, 8)}|${d.screenshotHash?.slice(0, 8)})`,
+    };
   }
-  const files = walkDir(screenshotDir, '').sort();
-  if (files.length === 0) return 'none';
-  const hash = crypto.createHash('sha256');
-  let filesHashed = 0;
-  for (const file of files) {
-    const fullPath = path.join(screenshotDir, file);
-    try {
-      const stat = fs.statSync(fullPath);
-      if (!stat.isFile() || stat.size > 50 * 1024 * 1024) continue;
-      // Stream file in 64KB chunks to bound memory usage
-      const fd = fs.openSync(fullPath, 'r');
-      try {
-        const fileHash = crypto.createHash('sha256');
-        const buf = Buffer.alloc(65536);
-        let bytesRead;
-        while ((bytesRead = fs.readSync(fd, buf, 0, buf.length)) > 0) {
-          fileHash.update(buf.subarray(0, bytesRead));
-        }
-        hash.update(`${fileHash.digest('hex')}  ${file}\n`);
-        filesHashed++;
-      } finally {
-        fs.closeSync(fd);
-      }
-    } catch {
-      /* skip unreadable files */
-    }
-  }
-  if (filesHashed === 0) return 'none';
-  return hash.digest('hex');
+  return null;
 }
+
+function prGenRunReason(d, force) {
+  if (force) return 'Force mode — regenerating PR description';
+  if (d.lastPrSha) return `Key changed: ${d.lastPrSha?.slice(0, 16)}… → ${d.prKey?.slice(0, 16)}…`;
+  return 'No previous PR update recorded';
+}
+
+// 3_pr_gen: rebase-guard block → SHA-skip → run.
+function decidePrGen(d, force) {
+  return (
+    prGenRebaseBlock(d) ||
+    prGenSkip(d, force) || {
+      action: 'RUN',
+      reason: prGenRunReason(d, force),
+      command: 'Task(pr-generator)',
+    }
+  );
+}
+
+// 4_screenshot_gate: skip unless TSX/JSX changed without screenshots.
+function decideScreenshotGate(d) {
+  if (!d.hasTsxChanges) {
+    return { action: 'SKIP', reason: 'No TSX/JSX files changed' };
+  }
+  if (d.screenshotsExist) {
+    return { action: 'SKIP', reason: `${d.screenshotCount} screenshot(s) found` };
+  }
+  return {
+    action: 'RUN',
+    reason: 'TSX/JSX changed but no screenshots — gate required',
+    command: 'AskUserQuestion',
+  };
+}
+
+// 5_post_pr_gen: skip when no content or content SHA unchanged.
+function decidePostPrGen(d, force) {
+  if (!d.hasContent) {
+    return { action: 'SKIP', reason: 'No content to post (no check reports or screenshots)' };
+  }
+  if (!force && d.postPrUpToDate) {
+    return { action: 'SKIP', reason: 'Content SHA matches .post-pr-update-sha' };
+  }
+  return {
+    action: 'RUN',
+    reason: force
+      ? 'Force mode — regenerating post-PR content'
+      : d.lastPostPrSha
+        ? 'Content changed since last run'
+        : 'No previous post-PR update recorded',
+    command: 'Task(pr-post-generator)',
+  };
+}
+
 // ─── Workflow Definition ────────────────────────────────────────────────────
 
 module.exports = {
@@ -149,14 +158,7 @@ module.exports = {
     }
 
     const force = parts.includes('--force');
-    let ticketId = parts[0];
-
-    // Prefix with project key if just a number
-    if (/^\d+$/.test(ticketId)) {
-      ticketId = `${process.env.TICKET_PROJECT_KEY || process.env.JIRA_PROJECT_KEY || 'PROJ'}-${ticketId}`;
-    }
-    // Uppercase only the ticket base, preserve suffix case (GH-146)
-    ticketId = normalizeTicketId(ticketId);
+    const ticketId = normalizeTicketArg(parts[0]);
 
     return { instanceId: ticketId, ticketId, force };
   },
@@ -168,126 +170,7 @@ module.exports = {
    * @returns {object} Inspection data
    */
   inspect(instanceId) {
-    const tasksDir = getTasksDir(instanceId);
-    const worktreeDir = getWorktreeDir(instanceId);
-    const data = {
-      tasksDir,
-      tasksDirExists: fs.existsSync(tasksDir),
-      worktreeDir,
-      worktreeExists: fs.existsSync(worktreeDir),
-    };
-
-    // Current HEAD SHA (from ticket worktree)
-    data.headSha = safeExec('git rev-parse HEAD', { cwd: worktreeDir });
-
-    // .pr-update-sha (stores compound key: HEAD_SHA|SCREENSHOT_HASH)
-    const prShaFile = path.join(tasksDir, '.pr-update-sha');
-    data.prShaFile = prShaFile;
-    data.lastPrSha = '';
-    if (fs.existsSync(prShaFile)) {
-      try {
-        data.lastPrSha = fs.readFileSync(prShaFile, 'utf8').trim();
-      } catch {
-        /* */
-      }
-    }
-
-    // TSX/JSX changes vs main (from ticket worktree)
-    let baseBranch = 'origin/main';
-    try {
-      baseBranch = require(path.join(__dirname, '..', 'lib', 'config')).getBaseBranch({
-        cwd: worktreeDir,
-      });
-    } catch {
-      /* */
-    }
-    data.tsxChanged = safeExec(`git diff --name-only ${baseBranch}...HEAD -- '*.tsx' '*.jsx'`, {
-      cwd: worktreeDir,
-    });
-    data.hasTsxChanges = data.tsxChanged.length > 0;
-
-    // Rebase guard: count commits behind base branch (opt-in via REBASE_GUARD_ENABLED=1)
-    data.baseBranch = baseBranch;
-    data.commitsBehindMain = 0;
-    if (data.worktreeExists && process.env.REBASE_GUARD_ENABLED === '1') {
-      const parts = baseBranch.split('/');
-      const remote = parts.length > 1 ? parts[0] : 'origin';
-      const branch = parts.length > 1 ? parts.slice(1).join('/') : parts[0];
-      // Validate remote/branch to prevent command injection
-      const validRef = /^[a-zA-Z0-9_\-./]+$/.test(remote) && /^[a-zA-Z0-9_\-./]+$/.test(branch);
-      if (!validRef) {
-        process.stderr.write(
-          `[work-pr] rebase guard: invalid baseBranch "${baseBranch}" — skipping\n`
-        );
-      } else {
-        const guardThreshold = parseInt(process.env.REBASE_GUARD_THRESHOLD || '0', 10);
-        const fetchDepth = Math.max((Number.isFinite(guardThreshold) ? guardThreshold : 0) + 2, 2);
-        safeExec(`git fetch ${remote} ${branch} --quiet --depth=${fetchDepth} --no-tags`, {
-          cwd: worktreeDir,
-          timeout: 5000,
-        });
-        const fetchedRef = `${remote}/${branch}`;
-        const behind = safeExec(
-          `git rev-list --count --max-count=${fetchDepth} HEAD..${fetchedRef}`,
-          { cwd: worktreeDir }
-        );
-        data.commitsBehindMain = parseInt(behind || '0', 10); // capped by fetchDepth, flagged via commitsBehindMainCapped
-        data.commitsBehindMainCapped = data.commitsBehindMain >= fetchDepth;
-      }
-    }
-
-    // Screenshot count
-    const screenshotDir = path.join(tasksDir, 'screenshots');
-    data.screenshotDir = screenshotDir;
-    data.screenshotCount = 0;
-    if (fs.existsSync(screenshotDir)) {
-      try {
-        const files = safeExec(
-          `find "${screenshotDir}" -type f \\( -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' -o -name '*.gif' -o -name '*.webp' \\) 2>/dev/null`
-        );
-        data.screenshotCount = files ? files.split('\n').filter(Boolean).length : 0;
-      } catch {
-        /* */
-      }
-    }
-    data.screenshotsExist = data.screenshotCount > 0;
-
-    // Screenshot hash for compound gating key
-    const screenshotHash = computeScreenshotHash(screenshotDir);
-    data.screenshotHash = screenshotHash;
-
-    // Compound pr-gen gating key: HEAD_SHA|SCREENSHOT_HASH
-    data.prKey = `${data.headSha}|${data.screenshotHash}`;
-    data.prUpToDate = !!(data.prKey && data.prKey === data.lastPrSha);
-
-    // Content SHA for post-pr (all *.check.md + screenshots)
-    data.contentSha = safeExec(
-      `(
-        find "${tasksDir}" -maxdepth 1 -name '*.check.md' -print0 2>/dev/null | sort -z | xargs -0 sha256sum 2>/dev/null
-        find "${tasksDir}/screenshots" -type f -print0 2>/dev/null | sort -z | xargs -0 sha256sum 2>/dev/null
-      ) | sha256sum | cut -d' ' -f1`
-    );
-
-    // .post-pr-update-sha
-    const postPrShaFile = path.join(tasksDir, '.post-pr-update-sha');
-    data.postPrShaFile = postPrShaFile;
-    data.lastPostPrSha = '';
-    if (fs.existsSync(postPrShaFile)) {
-      try {
-        data.lastPostPrSha = fs.readFileSync(postPrShaFile, 'utf8').trim();
-      } catch {
-        /* */
-      }
-    }
-    data.postPrUpToDate = !!(data.contentSha && data.contentSha === data.lastPostPrSha);
-
-    // SKIP 5_post_pr_gen if no content to post
-    data.hasContent = !!(
-      data.contentSha &&
-      data.contentSha !== 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-    );
-
-    return data;
+    return buildInspectData(getTasksDir(instanceId), getWorktreeDir(instanceId));
   },
 
   /**
@@ -306,79 +189,16 @@ module.exports = {
     switch (stepId) {
       case '1_preflight':
         return { action: 'RUN', reason: 'Check memory & zombie processes' };
-
       case '2_setup':
         return { action: 'RUN', reason: 'Parse args and set variables' };
-
-      case '3_pr_gen': {
-        // Rebase guard: block if worktree is behind main
-        const parsed = parseInt(process.env.REBASE_GUARD_THRESHOLD || '0', 10);
-        const threshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
-        if (d.commitsBehindMain > threshold) {
-          return {
-            action: 'BLOCKED',
-            reason: `Worktree is ${d.commitsBehindMainCapped ? '>= ' : ''}${d.commitsBehindMain} commit(s) behind ${d.baseBranch || 'origin/main'}. Rebase before creating PR.`,
-          };
-        }
-        if (!force && d.prUpToDate) {
-          return {
-            action: 'SKIP',
-            reason: `Compound key matches (${d.headSha?.slice(0, 8)}|${d.screenshotHash?.slice(0, 8)})`,
-          };
-        }
-        return {
-          action: 'RUN',
-          reason: force
-            ? 'Force mode — regenerating PR description'
-            : d.lastPrSha
-              ? `Key changed: ${d.lastPrSha?.slice(0, 16)}… → ${d.prKey?.slice(0, 16)}…`
-              : 'No previous PR update recorded',
-          command: 'Task(pr-generator)',
-        };
-      }
-
+      case '3_pr_gen':
+        return decidePrGen(d, force);
       case '4_screenshot_gate':
-        if (!d.hasTsxChanges) {
-          return { action: 'SKIP', reason: 'No TSX/JSX files changed' };
-        }
-        if (d.screenshotsExist) {
-          return {
-            action: 'SKIP',
-            reason: `${d.screenshotCount} screenshot(s) found`,
-          };
-        }
-        return {
-          action: 'RUN',
-          reason: 'TSX/JSX changed but no screenshots — gate required',
-          command: 'AskUserQuestion',
-        };
-
+        return decideScreenshotGate(d);
       case '5_post_pr_gen':
-        if (!d.hasContent) {
-          return {
-            action: 'SKIP',
-            reason: 'No content to post (no check reports or screenshots)',
-          };
-        }
-        if (!force && d.postPrUpToDate) {
-          return {
-            action: 'SKIP',
-            reason: 'Content SHA matches .post-pr-update-sha',
-          };
-        }
-        return {
-          action: 'RUN',
-          reason: force
-            ? 'Force mode — regenerating post-PR content'
-            : d.lastPostPrSha
-              ? 'Content changed since last run'
-              : 'No previous post-PR update recorded',
-          command: 'Task(pr-post-generator)',
-        };
-
+        return decidePostPrGen(d, force);
       case '6_summary':
         return { action: 'RUN', reason: 'Print completion summary' };
-
       default:
         return { action: 'RUN', reason: 'Unknown step' };
     }


### PR DESCRIPTION
## Summary

This is the next step of the `.quality-exceptions` burn-down (following the merged /follow-up #614 and /check2 #615). It refactors all 4 `/work-pr` files to pass the 6 static-quality rules (max-lines, max-lines-per-function, cyclomatic complexity, cognitive complexity, max-depth, duplicate-blocks) and removes their entries from the root `.quality-exceptions` allowlist (245 → 241 lines). All changes are conservative, behavior-preserving helper extraction and module splits — no logic changes.

## Key Changes

1. **New shared `agents/lib/hook-io.js`** — de-duplicates the two SubagentStop validators (`pr-generator-validator`, `pr-post-generator-validator`) and trims their `main()` complexity via `collectIssues` / `collectVisualIssues` / `runFabricationGate` helpers.

2. **New `work-pr-inspect.js`** — extracts screenshot hashing (decomposed into `collectScreenshotFiles` + `hashFile`) and `buildInspectData`, shrinking `work-pr.workflow.js` from 423 → 235 lines, with `detectStepState` delegating to per-step deciders.

3. **New `lib/ticket-args.js` (`normalizeTicketArg`)** — removes a pre-existing cross-file duplicate-block that the `params()` parser shared with `check.workflow.js` — both parsers rewired to the shared helper, behavior preserved. `check.workflow.js` stays allowlisted for its other pre-existing violations.

## Reviewer Notes

CodeQL may surface an 'indirect uncontrolled command line' note on the screenshot/find exec in `work-pr-inspect.js` — that is a pre-existing, by-design accepted pattern (operator-config commands; 6 accepted instances on main), not introduced here.

## Verification

- 129 work-pr tests + 1875 lib tests pass
- Full static-quality gate exits 0
- biome clean on all changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only extraction and deduplication in workflow hooks and PR orchestration; validation and gating logic is preserved, with tests cited in the PR description.
> 
> **Overview**
> Burn-down on `.quality-exceptions`: four `/work-pr` paths are removed after refactors that satisfy the six static-quality rules, with no intended behavior change.
> 
> **Shared helpers** — `lib/ticket-args.js` (`normalizeTicketArg`) replaces duplicated numeric-ticket prefix + normalize logic in `work-pr.workflow.js` and `check.workflow.js`. `work-pr/agents/lib/hook-io.js` centralizes SubagentStop stdin/JSON parsing and agent name/output resolution for the pr-generator and pr-post-generator validators (and the readonly guard’s stdin read).
> 
> **`/work-pr` split** — `work-pr-inspect.js` holds screenshot hashing (`collectScreenshotFiles` / `hashFile`), rebase guard, content SHA, and `buildInspectData`; the workflow file delegates `inspect()` there and routes `detectStepState` through `decidePrGen`, `decideScreenshotGate`, and `decidePostPrGen`. Validators are decomposed into `collectIssues` / `runFabricationGate` / `collectVisualIssues` style helpers without changing validation rules.
> 
> `check.workflow.js` only picks up the shared ticket-arg helper; it remains on the allowlist for other violations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ab0701d69c906c86c086d8780ab532a27c8de8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->