### PR TITLE
fix(heimdall): exclude mv from direction-sensitive read heuristic

### DIFF
--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -214,6 +214,21 @@ describe('evaluate: bash', () => {
     assert.equal(r.exitCode, 2);
   });
 
+  it('blocks moving a protected file OUT to an unprotected dest (mv removes the source)', () => {
+    const r = run(`mv ${path.join(baseDir, '.claude', 'settings.json')} /tmp/heimdall-stash.bak`);
+    assert.equal(r.exitCode, 2, 'mv of a protected source is destructive, not a read');
+  });
+
+  it('blocks moving a protected file OUT via a relative path', () => {
+    const r = run('mv .claude/settings.json /tmp/heimdall-stash.bak');
+    assert.equal(r.exitCode, 2);
+  });
+
+  it('still allows cp of a protected file as source (source survives — a read)', () => {
+    const r = run(`cp ${path.join(baseDir, '.claude', 'settings.json')} /tmp/heimdall-copy.bak`);
+    assert.equal(r.exitCode, 0, 'cp leaves the protected source intact, so it is a read');
+  });
+
   it('blocks when a compound command also targets a still-locked entry (.claude unlocked, package.json not)', () => {
     // .claude is unlocked via transcript; the command also writes package.json
     // (locked under a different phrase) — must still block on package.json.

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -101,11 +101,19 @@ function hasGenericWriteIntent(command) {
   return GENERIC_WRITE_RE.test(stripFdRedirects(command.replace(/\s*\n+\s*/g, ' ')));
 }
 
-/** For cp/mv/rsync/ln/install: is the protected path only the SOURCE (a read)? */
+/**
+ * For cp/rsync/ln/install: is the protected path only the SOURCE (a read)?
+ *
+ * `mv` is deliberately excluded: it REMOVES the source, so moving a protected
+ * file out (`mv <protected> /tmp/dest`) is a destructive write to the protected
+ * path, not a read. Letting `mv` qualify here was a bypass — a protected file
+ * could be relocated away with no unlock. The remaining commands leave the
+ * source intact, so source-only references stay genuine reads.
+ */
 function isDirectionSensitiveRead(command, expanded, marker) {
   command = command.replace(/\s*\n+\s*/g, ' ');
   expanded = expanded.replace(/\s*\n+\s*/g, ' ');
-  if (!/\b(?:cp|mv|rsync|ln|install)\b/i.test(command)) return false;
+  if (!/\b(?:cp|rsync|ln|install)\b/i.test(command)) return false;
   if (/\b(?:find\s+.*-exec|xargs|sh\s+-c|bash\s+-c|eval)\b/i.test(command)) return false;
   // Any shell separator/operator (| || & && ;) means the "last arg is the
   // destination" heuristic is unreliable — fail closed (not a pure read) so the


### PR DESCRIPTION
## Existing Behavior

- `isDirectionSensitiveRead` in `plugins/heimdall/lib/guard/bash.js` classified a protected path as a harmless read when it appeared only as the source argument of `cp`, `mv`, `rsync`, `ln`, or `install`.
- `mv <protected> /tmp/dest` was therefore allowed without an unlock, because the guard treated the protected path as a read-only source operand.
- Moving a protected file out (e.g. `.husky/pre-commit`) is destructive: `mv` removes the source, making the operation a write to the protected path, not a read.

## Intended New Behavior

- `mv` is dropped from the direction-sensitive read command set. Only `cp`, `rsync`, `ln`, and `install` remain — commands that leave the source intact.
- `mv <protected> <dest>` (absolute or relative path) now triggers the guard and exits with code 2, matching the same block behavior as a direct write.
- `cp <protected> <dest>` continues to be allowed as a source-only read since the source file survives.
- All 77 heimdall guard tests pass.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The fix is verified by 3 new regression tests in `plugins/heimdall/lib/__tests__/guard.test.js`.

Run the scoped heimdall test suite:

```bash
pnpm test plugins/heimdall/lib/__tests__/guard.test.js
```

Expected: all tests pass, including the 3 new regression cases:

- `blocks moving a protected file OUT to an unprotected dest (mv removes the source)` — exits 2
- `blocks moving a protected file OUT via a relative path` — exits 2
- `still allows cp of a protected file as source (source survives — a read)` — exits 0

### Test Results

3 new regression cases added; full heimdall suite: 77/77 pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Bash write-detection heuristics for a security guard; scope is narrow (mv vs cp) and covered by new tests, but incorrect classification could block or allow sensitive paths.
> 
> **Overview**
> Closes a **Heimdall Bash guard bypass** where `mv <protected> <dest>` was treated like a harmless read because the protected path appeared only as the source.
> 
> **`isDirectionSensitiveRead`** no longer includes `mv`—only `cp`, `rsync`, `ln`, and `install` still get the “source-only = read” heuristic, since those leave the source in place. Moving a protected file out (absolute or relative path) now blocks with exit code 2 like other writes; **`cp` from a protected source** remains allowed.
> 
> Three regression tests in `guard.test.js` cover blocked `mv` and allowed `cp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2415a5284fb6977bc18a99fe42a72bbeea97c5d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->