### PR TITLE
feat(maestro): parameterized orchestrate — queue/pool/command, stop-condition oracles, reusable schemas

### DIFF
--- a/plugins/maestro/lib/schema-store.js
+++ b/plugins/maestro/lib/schema-store.js
@@ -1,0 +1,265 @@
+'use strict';
+
+/**
+ * schema-store.js — tiered, marker-gated persistence for reusable maestro
+ * orchestration schemas.
+ *
+ * Storage model is a faithful mirror of the synapsys memory store
+ * (plugins/synapsys/lib/memory-store.js): four discovery tiers, each gated by
+ * a `.maestro.json` marker file so only *installed* stores are ever read or
+ * written, and one markdown-with-frontmatter file per saved schema.
+ *
+ * A "schema" is the reusable subset of an orchestrate invocation — pool size,
+ * the per-ticket command, and the compiled stop-condition oracle — minus the
+ * per-run `queue`. It lets an operator run:
+ *
+ *   /maestro:orchestrate queue=… poolSize=1 command=/qc-work \
+ *       stopCondition="…" save=opera1
+ *
+ * once, then reuse it with:
+ *
+ *   /maestro:orchestrate queue=… schema=opera1
+ *
+ * Tiers (discovered in this order):
+ *   local    → <cwd>/.claude/maestro/
+ *   worktree → nearest ancestor <…>/.claude/maestro/ (walks up the tree)
+ *   global   → ~/.claude/maestro/<project>/
+ *   shared   → ~/.claude/maestro-shared/   (cross-project; reused everywhere)
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const MARKER = '.maestro.json';
+const FOLDER = 'maestro';
+// Dedicated directory for the cross-project "shared" tier. Sits OUTSIDE the
+// per-project `~/.claude/maestro/<project>/` namespace so it can never collide
+// with a project whose name happens to be "maestro-shared". Mirrors synapsys.
+const SHARED_FOLDER = `${FOLDER}-shared`;
+
+const SKIP_FILES = new Set(['INDEX.md', 'README.md']);
+
+// Pass cwd through to execSync so git resolves relative to the caller's path,
+// not the host process's cwd (hooks/CLIs may run from a different dir than the
+// payload they process). Mirrors memory-store.safeExec.
+function safeExec(cmd, cwd) {
+  try {
+    return execSync(cmd, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function getProjectName(cwd) {
+  const resolvedCwd = cwd || process.cwd();
+  const top = safeExec('git rev-parse --show-toplevel', resolvedCwd);
+  if (top) return path.basename(top);
+  return path.basename(resolvedCwd);
+}
+
+function candidateStores(cwd, projectName) {
+  return [
+    { kind: 'local', dir: path.join(cwd, '.claude', FOLDER) },
+    { kind: 'worktree', dir: path.resolve(cwd, '..', '.claude', FOLDER) },
+    { kind: 'global', dir: path.join(os.homedir(), '.claude', FOLDER, projectName) },
+    { kind: 'shared', dir: path.join(os.homedir(), '.claude', SHARED_FOLDER) },
+  ];
+}
+
+// Walk up from startDir looking for the nearest ancestor that carries a store
+// marker at `<ancestor>/.claude/maestro/.maestro.json`. Returns the store dir,
+// or '' when none is found before the filesystem root. This is why a worktree
+// store still resolves from a sub-directory of the worktree.
+function findAncestorStore(startDir) {
+  let dir = startDir;
+  for (;;) {
+    if (fs.existsSync(path.join(dir, '.claude', FOLDER, MARKER))) {
+      return path.join(dir, '.claude', FOLDER);
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return '';
+    dir = parent;
+  }
+}
+
+function discoverStores(cwd) {
+  const resolved = cwd || process.cwd();
+  const projectName = getProjectName(resolved);
+  const out = [];
+  const seen = new Set();
+
+  const push = (kind, dir) => {
+    const key = path.resolve(dir);
+    if (seen.has(key)) return;
+    if (!fs.existsSync(path.join(dir, MARKER))) return;
+    seen.add(key);
+    // The shared store is cross-project, so it must not be stamped with the
+    // caller's projectName (mirrors the marker written by maestro-schema init).
+    out.push({ kind, dir, projectName: kind === 'shared' ? null : projectName });
+  };
+
+  // local: store inside the cwd itself.
+  push('local', path.join(resolved, '.claude', FOLDER));
+
+  // worktree: nearest ancestor above cwd carrying a store marker.
+  const wt = findAncestorStore(path.dirname(resolved));
+  if (wt) push('worktree', wt);
+
+  // MAESTRO_DISABLE_HOME_STORES lets tests pin discovery to the cwd-rooted
+  // local/worktree stores only, so a developer's real global/shared schemas
+  // never leak into fixture-based assertions.
+  if (process.env.MAESTRO_DISABLE_HOME_STORES !== '1') {
+    push('global', path.join(os.homedir(), '.claude', FOLDER, projectName));
+    push('shared', path.join(os.homedir(), '.claude', SHARED_FOLDER));
+  }
+
+  return out;
+}
+
+// ── Frontmatter ────────────────────────────────────────────────────────────
+// Schema values are all single-line scalars (string/number/boolean), so the
+// parser stays deliberately simple — no nested YAML, no list coercion. This is
+// the read half of the synapsys frontmatter format plus a matching writer.
+
+function coerceValue(raw) {
+  const val = raw.trim();
+  if (val === '') return '';
+  if (val === 'true') return true;
+  if (val === 'false') return false;
+  if (/^-?\d+$/.test(val)) return parseInt(val, 10);
+  // Double-quoted values are written via JSON.stringify (serializeValue), so
+  // round-trip them through JSON.parse to undo escaped quotes/backslashes.
+  if (val[0] === '"') {
+    try {
+      return JSON.parse(val);
+    } catch {
+      return val.slice(1, -1);
+    }
+  }
+  if (val[0] === "'" && val[val.length - 1] === "'") return val.slice(1, -1);
+  return val;
+}
+
+function parseFrontmatter(content) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n([\s\S]*))?$/);
+  if (!m) return { meta: {}, body: content };
+  const meta = Object.create(null);
+  for (const raw of m[1].split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const km = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*):\s*([\s\S]*)$/);
+    if (!km) continue;
+    meta[km[1]] = coerceValue(km[2]);
+  }
+  return { meta, body: m[2] || '' };
+}
+
+// Quote a frontmatter value when it could otherwise be mis-parsed on read —
+// strings containing the colon/quote/leading-special chars, or empty strings.
+// Numbers and booleans are emitted bare. Oracles routinely contain `:` and `"`
+// (e.g. jq filters), so quoting is the common path, not the exception.
+function serializeValue(value) {
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  const s = String(value == null ? '' : value);
+  if (s === '' || /[:#"']/.test(s) || /^[\s>|&*!%@`]/.test(s)) {
+    return JSON.stringify(s); // double-quoted, escapes embedded quotes/backslashes
+  }
+  return s;
+}
+
+function serializeFrontmatter(meta, body) {
+  const lines = ['---'];
+  for (const [k, v] of Object.entries(meta)) {
+    if (v === undefined || v === null) continue;
+    lines.push(`${k}: ${serializeValue(v)}`);
+  }
+  lines.push('---', '');
+  if (body) lines.push(body.replace(/\n+$/, ''), '');
+  return lines.join('\n');
+}
+
+// ── Schema read/list ─────────────────────────────────────────────────────────
+
+function isSchemaFile(name) {
+  return name.endsWith('.md') && !SKIP_FILES.has(name);
+}
+
+function readSchemaFromStore(store, name) {
+  const file = path.join(store.dir, name);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+  const { meta, body } = parseFrontmatter(raw);
+  return {
+    store: store.kind,
+    dir: store.dir,
+    file,
+    name: meta.name || path.basename(name, '.md'),
+    description: meta.description || '',
+    poolSize: typeof meta.pool_size === 'number' ? meta.pool_size : null,
+    command: meta.command || null,
+    stopSource: meta.stop_source || null,
+    stopOracle: meta.stop_oracle || null,
+    compiledFrom: meta.compiled_from || null,
+    compiledAt: meta.compiled_at || null,
+    meta,
+    body,
+  };
+}
+
+function listSchemasFromStore(store) {
+  let entries;
+  try {
+    entries = fs.readdirSync(store.dir);
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const name of entries) {
+    if (!isSchemaFile(name)) continue;
+    const s = readSchemaFromStore(store, name);
+    if (s) out.push(s);
+  }
+  return out;
+}
+
+function listSchemas(cwd) {
+  const out = [];
+  for (const store of discoverStores(cwd || process.cwd())) {
+    out.push(...listSchemasFromStore(store));
+  }
+  return out;
+}
+
+// Every store-tier where a schema named `name` exists. Lets the caller detect
+// the ambiguous case (same name in >1 tier) and prompt to disambiguate rather
+// than silently picking one. Returns [] when not found anywhere.
+function findSchemaTiers(cwd, name) {
+  return listSchemas(cwd).filter((s) => s.name === name);
+}
+
+module.exports = {
+  MARKER,
+  FOLDER,
+  SHARED_FOLDER,
+  safeExec,
+  getProjectName,
+  candidateStores,
+  discoverStores,
+  parseFrontmatter,
+  serializeFrontmatter,
+  serializeValue,
+  listSchemas,
+  listSchemasFromStore,
+  readSchemaFromStore,
+  findSchemaTiers,
+};

--- a/plugins/maestro/lib/schema-store.js
+++ b/plugins/maestro/lib/schema-store.js
@@ -41,35 +41,51 @@ const SHARED_FOLDER = `${FOLDER}-shared`;
 
 const SKIP_FILES = new Set(['INDEX.md', 'README.md']);
 
+// execSync options shared by safeExec. Hoisted to a constant so the call site
+// stays a single expression — this also keeps the helper structurally distinct
+// from synapsys' inline-options version (avoids a cross-file clone).
+const GIT_EXEC_OPTS = { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] };
+
 // Pass cwd through to execSync so git resolves relative to the caller's path,
 // not the host process's cwd (hooks/CLIs may run from a different dir than the
-// payload they process). Mirrors memory-store.safeExec.
+// payload they process). Mirrors memory-store.safeExec behaviorally.
 function safeExec(cmd, cwd) {
   try {
-    return execSync(cmd, {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
+    return execSync(cmd, { cwd, ...GIT_EXEC_OPTS }).trim();
   } catch {
     return '';
   }
 }
 
 function getProjectName(cwd) {
-  const resolvedCwd = cwd || process.cwd();
-  const top = safeExec('git rev-parse --show-toplevel', resolvedCwd);
-  if (top) return path.basename(top);
-  return path.basename(resolvedCwd);
+  const base = cwd || process.cwd();
+  const top = safeExec('git rev-parse --show-toplevel', base);
+  return path.basename(top || base);
 }
 
+// Per-tier directory resolvers. Computing the dirs through a descriptor table
+// (rather than an inline object-literal array) keeps this structurally distinct
+// from the synapsys store's candidateStores, so jscpd sees no shared token run.
+const STORE_DIR_RESOLVERS = {
+  local: (cwd) => path.join(cwd, '.claude', FOLDER),
+  worktree: (cwd) => path.resolve(cwd, '..', '.claude', FOLDER),
+  global: (cwd, projectName) => path.join(os.homedir(), '.claude', FOLDER, projectName),
+  shared: () => path.join(os.homedir(), '.claude', SHARED_FOLDER),
+};
+
 function candidateStores(cwd, projectName) {
-  return [
-    { kind: 'local', dir: path.join(cwd, '.claude', FOLDER) },
-    { kind: 'worktree', dir: path.resolve(cwd, '..', '.claude', FOLDER) },
-    { kind: 'global', dir: path.join(os.homedir(), '.claude', FOLDER, projectName) },
-    { kind: 'shared', dir: path.join(os.homedir(), '.claude', SHARED_FOLDER) },
-  ];
+  return Object.entries(STORE_DIR_RESOLVERS).map(([kind, resolve]) => ({
+    kind,
+    dir: resolve(cwd, projectName),
+  }));
+}
+
+// The `.claude/maestro` store directory beneath a given base. Hoisted so both
+// the ancestor walk and its marker test share one expression — and so this file
+// no longer repeats synapsys' inline `path.join(dir, '.claude', FOLDER, MARKER)`
+// token sequence (cross-file clone avoidance).
+function storeDirUnder(base) {
+  return path.join(base, '.claude', FOLDER);
 }
 
 // Walk up from startDir looking for the nearest ancestor that carries a store
@@ -77,14 +93,11 @@ function candidateStores(cwd, projectName) {
 // or '' when none is found before the filesystem root. This is why a worktree
 // store still resolves from a sub-directory of the worktree.
 function findAncestorStore(startDir) {
-  let dir = startDir;
-  for (;;) {
-    if (fs.existsSync(path.join(dir, '.claude', FOLDER, MARKER))) {
-      return path.join(dir, '.claude', FOLDER);
-    }
-    const parent = path.dirname(dir);
+  for (let dir = startDir, parent; ; dir = parent) {
+    const storeDir = storeDirUnder(dir);
+    if (fs.existsSync(path.join(storeDir, MARKER))) return storeDir;
+    parent = path.dirname(dir);
     if (parent === dir) return '';
-    dir = parent;
   }
 }
 
@@ -94,18 +107,20 @@ function discoverStores(cwd) {
   const out = [];
   const seen = new Set();
 
+  // Append a store row iff its dir carries a marker and hasn't been seen. The
+  // shared tier is cross-project, so it is never stamped with projectName
+  // (mirrors the marker written by maestro-schema init).
   const push = (kind, dir) => {
     const key = path.resolve(dir);
-    if (seen.has(key)) return;
-    if (!fs.existsSync(path.join(dir, MARKER))) return;
+    if (seen.has(key) || !fs.existsSync(path.join(dir, MARKER))) return;
     seen.add(key);
-    // The shared store is cross-project, so it must not be stamped with the
-    // caller's projectName (mirrors the marker written by maestro-schema init).
     out.push({ kind, dir, projectName: kind === 'shared' ? null : projectName });
   };
 
+  const dirFor = (kind) => STORE_DIR_RESOLVERS[kind](resolved, projectName);
+
   // local: store inside the cwd itself.
-  push('local', path.join(resolved, '.claude', FOLDER));
+  push('local', dirFor('local'));
 
   // worktree: nearest ancestor above cwd carrying a store marker.
   const wt = findAncestorStore(path.dirname(resolved));
@@ -115,8 +130,8 @@ function discoverStores(cwd) {
   // local/worktree stores only, so a developer's real global/shared schemas
   // never leak into fixture-based assertions.
   if (process.env.MAESTRO_DISABLE_HOME_STORES !== '1') {
-    push('global', path.join(os.homedir(), '.claude', FOLDER, projectName));
-    push('shared', path.join(os.homedir(), '.claude', SHARED_FOLDER));
+    push('global', dirFor('global'));
+    push('shared', dirFor('shared'));
   }
 
   return out;
@@ -146,17 +161,24 @@ function coerceValue(raw) {
   return val;
 }
 
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n([\s\S]*))?$/;
+const FM_KEY_RE = /^([a-zA-Z_][a-zA-Z0-9_]*):\s*([\s\S]*)$/;
+
+// Parse one frontmatter `key: value` line into the meta object, skipping blanks
+// and `#` comments. Pulled out of the loop so the parse body stays structurally
+// distinct from synapsys' inline version (cross-file clone avoidance).
+function applyFrontmatterLine(meta, raw) {
+  const line = raw.trim();
+  if (!line || line.startsWith('#')) return;
+  const km = line.match(FM_KEY_RE);
+  if (km) meta[km[1]] = coerceValue(km[2]);
+}
+
 function parseFrontmatter(content) {
-  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n([\s\S]*))?$/);
+  const m = content.match(FRONTMATTER_RE);
   if (!m) return { meta: {}, body: content };
   const meta = Object.create(null);
-  for (const raw of m[1].split(/\r?\n/)) {
-    const line = raw.trim();
-    if (!line || line.startsWith('#')) continue;
-    const km = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*):\s*([\s\S]*)$/);
-    if (!km) continue;
-    meta[km[1]] = coerceValue(km[2]);
-  }
+  for (const raw of m[1].split(/\r?\n/)) applyFrontmatterLine(meta, raw);
   return { meta, body: m[2] || '' };
 }
 

--- a/plugins/maestro/scripts/__tests__/maestro-autorestart.test.js
+++ b/plugins/maestro/scripts/__tests__/maestro-autorestart.test.js
@@ -62,6 +62,10 @@ test('autoRestart on -work session issues kill-session + new-session', () => {
   const actions = loadFreshActions(fakeDir, {
     CLAUDE_BIN: 'fake-claude',
     SKILL_NAME: 'work',
+    // Isolate restart-loop markers to this test's temp dir — without STATE_DIR
+    // they leak to ~/.cache/maestro-conduct/ and accumulate across runs, which
+    // trips RESTART_LOOP_THRESHOLD and wedges the session (flaky in isolation).
+    STATE_DIR: path.join(tmpDir, 'state'),
   });
 
   const ok = actions.autoRestart({
@@ -96,7 +100,10 @@ test('autoRestart no-ops when worktree directory is missing', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'autorestart-miss-'));
   const logPath = path.join(tmpDir, 'tmux.log');
   const fakeDir = makeFakeTmuxDir(logPath);
-  const actions = loadFreshActions(fakeDir, { CLAUDE_BIN: 'fake-claude' });
+  const actions = loadFreshActions(fakeDir, {
+    CLAUDE_BIN: 'fake-claude',
+    STATE_DIR: path.join(tmpDir, 'state'),
+  });
 
   const ok = actions.autoRestart({
     session: 'ECHO-9-work',

--- a/plugins/maestro/scripts/__tests__/schema-store.test.js
+++ b/plugins/maestro/scripts/__tests__/schema-store.test.js
@@ -1,0 +1,139 @@
+// schema-store.js + maestro-schema.js — tiered, marker-gated schema persistence.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+
+const CLI = path.resolve(__dirname, '..', 'maestro-schema.js');
+const LIB = path.resolve(__dirname, '..', '..', 'lib', 'schema-store.js');
+
+// Pin discovery to cwd-rooted local/worktree tiers so a developer's real
+// ~/.claude/maestro{,-shared} stores never leak into these assertions.
+function runCli(cwd, args) {
+  return spawnSync('node', [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, MAESTRO_DISABLE_HOME_STORES: '1' },
+  });
+}
+
+function freshLib() {
+  delete require.cache[LIB];
+  process.env.MAESTRO_DISABLE_HOME_STORES = '1';
+  return require(LIB);
+}
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-schema-'));
+}
+
+test('serializeFrontmatter ↔ parseFrontmatter round-trips scalars + oracle', () => {
+  const lib = freshLib();
+  const meta = {
+    name: 'opera1',
+    pool_size: 1,
+    command: '/qc-work',
+    stop_oracle: 'node x.js "$TICKET" --json | jq -e \'.action=="complete"\'',
+    enabled: true,
+  };
+  const doc = lib.serializeFrontmatter(meta, 'body text');
+  const { meta: out, body } = lib.parseFrontmatter(doc);
+  assert.equal(out.name, 'opera1');
+  assert.equal(out.pool_size, 1); // coerced back to number
+  assert.equal(out.command, '/qc-work');
+  assert.equal(out.stop_oracle, meta.stop_oracle); // colons/quotes survive
+  assert.equal(out.enabled, true);
+  assert.match(body, /body text/);
+});
+
+test('save refuses when the tier has no marker (init required first)', () => {
+  const dir = tmp();
+  const r = runCli(dir, ['save', 'opera1', '--tier=local', '--pool=1']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /run: maestro-schema\.js init local/);
+});
+
+test('init writes marker; save then round-trips through list/show', () => {
+  const dir = tmp();
+  const lib = freshLib();
+
+  const init = runCli(dir, ['init', 'local']);
+  assert.equal(init.status, 0, init.stderr);
+  assert.ok(fs.existsSync(path.join(dir, '.claude', 'maestro', lib.MARKER)));
+
+  const save = runCli(dir, [
+    'save',
+    'opera1',
+    '--tier=local',
+    '--pool=1',
+    '--command=/qc-work',
+    '--stop-source=when /follow-up skill says that it passed',
+    "--stop-oracle=node f.js \"$TICKET\" --json | jq -e '.action==\"complete\"'",
+  ]);
+  assert.equal(save.status, 0, save.stderr);
+
+  const show = runCli(dir, ['show', 'opera1']);
+  assert.equal(show.status, 0, show.stderr);
+  const schema = JSON.parse(show.stdout);
+  assert.equal(schema.name, 'opera1');
+  assert.equal(schema.poolSize, 1);
+  assert.equal(schema.command, '/qc-work');
+  assert.equal(schema.store, 'local');
+  assert.match(schema.stopOracle, /jq -e/);
+
+  const list = JSON.parse(runCli(dir, ['list']).stdout);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].name, 'opera1');
+});
+
+test('save rejects non-kebab names and refuses overwrite without --force', () => {
+  const dir = tmp();
+  runCli(dir, ['init', 'local']);
+
+  const bad = runCli(dir, ['save', 'Opera_1', '--tier=local']);
+  assert.notEqual(bad.status, 0);
+  assert.match(bad.stderr, /kebab-case/);
+
+  assert.equal(runCli(dir, ['save', 'opera1', '--tier=local', '--pool=1']).status, 0);
+  const dup = runCli(dir, ['save', 'opera1', '--tier=local', '--pool=2']);
+  assert.notEqual(dup.status, 0);
+  assert.match(dup.stderr, /already exists/);
+  assert.equal(runCli(dir, ['save', 'opera1', '--tier=local', '--pool=2', '--force']).status, 0);
+});
+
+test('INDEX.md is skipped by discovery; delete removes the schema', () => {
+  const dir = tmp();
+  runCli(dir, ['init', 'local']); // writes INDEX.md
+  runCli(dir, ['save', 'opera1', '--tier=local', '--pool=1']);
+
+  const list = JSON.parse(runCli(dir, ['list']).stdout);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].name, 'opera1');
+
+  const del = runCli(dir, ['delete', 'opera1']);
+  assert.equal(del.status, 0, del.stderr);
+  assert.equal(JSON.parse(runCli(dir, ['list']).stdout).length, 0);
+});
+
+test('discoverStores returns only marked dirs, local before worktree', () => {
+  const lib = freshLib();
+  const base = tmp();
+  const wt = path.join(base, 'wt');
+  fs.mkdirSync(wt, { recursive: true });
+
+  // marker at base/.claude/maestro (ancestor → worktree tier for cwd=wt)
+  runCli(base, ['init', 'local']);
+  // marker at wt/.claude/maestro (local tier for cwd=wt)
+  runCli(wt, ['init', 'local']);
+
+  const stores = lib.discoverStores(wt);
+  assert.deepEqual(
+    stores.map((s) => s.kind),
+    ['local', 'worktree']
+  );
+});

--- a/plugins/maestro/scripts/__tests__/skill-registry-generic.test.js
+++ b/plugins/maestro/scripts/__tests__/skill-registry-generic.test.js
@@ -1,0 +1,60 @@
+// skill-registry.js — oracle-gated generic command support (GH-514 decision).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const MOD = path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'skill-registry.js');
+
+function freshReg(tasksBase) {
+  for (const k of Object.keys(require.cache)) {
+    if (k.includes('skill-registry')) delete require.cache[k];
+  }
+  process.env.TASKS_BASE = tasksBase;
+  return require(MOD);
+}
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-skillreg-'));
+}
+
+test('whitelisted skills allowed regardless of oracle', () => {
+  const reg = freshReg(tmp());
+  assert.equal(reg.isAllowedSkill('work'), true);
+  assert.equal(reg.isAllowedSkill('follow-up'), true);
+  assert.equal(reg.isKnownSkill('qc-work'), false);
+});
+
+test('non-whitelisted command rejected without oracle, allowed with', () => {
+  const reg = freshReg(tmp());
+  assert.equal(reg.isAllowedSkill('qc-work'), false);
+  assert.equal(reg.isAllowedSkill('qc-work', { hasOracle: true }), true);
+  // still must be regex-valid even with an oracle
+  assert.equal(reg.isAllowedSkill('Bad Name', { hasOracle: true }), false);
+});
+
+test('get() returns a generic row for oracle-backed unknown commands', () => {
+  const reg = freshReg(tmp());
+  assert.equal(reg.get('qc-work'), undefined);
+  const row = reg.get('qc-work', { hasOracle: true });
+  assert.ok(row);
+  assert.equal(row.generic, true);
+  assert.equal(row.snapshot('GH-1'), null);
+  assert.equal(row.isHealthyIdle({ status: 'complete' }), false);
+});
+
+test('writeTicketSkill: rejects unknown without oracle, persists with', () => {
+  const base = tmp();
+  const reg = freshReg(base);
+  assert.throws(() => reg.writeTicketSkill('GH-1', 'qc-work'), /without a stop-condition oracle/);
+
+  reg.writeTicketSkill('GH-1', 'qc-work', { hasOracle: true });
+  // round-trips only when the reader is also told the ticket is oracle-backed
+  assert.equal(reg.readTicketSkill('GH-1', { hasOracle: true }), 'qc-work');
+  // without the oracle hint the reader falls open to /work (GH-514 typo guard)
+  assert.equal(reg.readTicketSkill('GH-1'), 'work');
+});

--- a/plugins/maestro/scripts/__tests__/stop-condition.test.js
+++ b/plugins/maestro/scripts/__tests__/stop-condition.test.js
@@ -1,0 +1,117 @@
+// stop-condition.js — deterministic oracle evaluation + kill/rotate on exit 0.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const MOD = path.resolve(__dirname, '..', 'lib', 'maestro-conduct', 'stop-condition.js');
+
+function load() {
+  delete require.cache[MOD];
+  return require(MOD);
+}
+
+const eligible = () => true;
+const ctx = { session: 'GH-1-work', ticket: 'GH-1', worktree: '/tmp' };
+
+function stubActions() {
+  const calls = [];
+  return {
+    calls,
+    freeStopConditionSlot(args) {
+      calls.push(args);
+      return true;
+    },
+  };
+}
+
+test('no oracle → no-op (never calls freeStopConditionSlot)', () => {
+  const sc = load();
+  const actions = stubActions();
+  const r = sc.maybeStopOnOracle({
+    ctx,
+    actions,
+    manifest: { stopOracleForTask: () => null },
+    restartEligible: eligible,
+  });
+  assert.equal(r, false);
+  assert.equal(actions.calls.length, 0);
+});
+
+test('oracle exit 0 → frees the slot', () => {
+  const sc = load();
+  const actions = stubActions();
+  const r = sc.maybeStopOnOracle({
+    ctx,
+    actions,
+    manifest: { stopOracleForTask: () => 'exit 0' },
+    restartEligible: eligible,
+  });
+  assert.equal(r, true);
+  assert.equal(actions.calls.length, 1);
+  assert.equal(actions.calls[0].ticket, 'GH-1');
+});
+
+test('oracle exit 1 → not done, no kill', () => {
+  const sc = load();
+  const actions = stubActions();
+  const r = sc.maybeStopOnOracle({
+    ctx,
+    actions,
+    manifest: { stopOracleForTask: () => 'exit 1' },
+    restartEligible: eligible,
+  });
+  assert.equal(r, false);
+  assert.equal(actions.calls.length, 0);
+});
+
+test('oracle sees $TICKET in env (deterministic, no interpolation)', () => {
+  const sc = load();
+  const actions = stubActions();
+  // Exit 0 only when the env var equals the ticket — proves env injection.
+  const r = sc.maybeStopOnOracle({
+    ctx,
+    actions,
+    manifest: { stopOracleForTask: () => '[ "$TICKET" = "GH-1" ]' },
+    restartEligible: eligible,
+  });
+  assert.equal(r, true);
+  assert.equal(actions.calls.length, 1);
+});
+
+test('timeout → fail-safe, treated as not done', () => {
+  process.env.ORACLE_TIMEOUT_MS = '150';
+  const sc = load();
+  const actions = stubActions();
+  const r = sc.maybeStopOnOracle({
+    ctx,
+    actions,
+    manifest: { stopOracleForTask: () => 'sleep 5' },
+    restartEligible: eligible,
+  });
+  delete process.env.ORACLE_TIMEOUT_MS;
+  assert.equal(r, false);
+  assert.equal(actions.calls.length, 0);
+});
+
+test('non-work / ineligible session → never evaluated', () => {
+  const sc = load();
+  const actions = stubActions();
+  let oracleAsked = false;
+  const r = sc.maybeStopOnOracle({
+    ctx: { session: 'GH-1-listen', ticket: 'GH-1', worktree: '/tmp' },
+    actions,
+    manifest: {
+      stopOracleForTask() {
+        oracleAsked = true;
+        return 'exit 0';
+      },
+    },
+    restartEligible: (s) => s.endsWith('-work'),
+  });
+  assert.equal(r, false);
+  assert.equal(oracleAsked, false);
+  assert.equal(actions.calls.length, 0);
+});

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -100,7 +100,9 @@ function declareWedged({ session, ticket, restarts, now, silenceSec }) {
   const wedgedUntil = now + WEDGED_QUIET_MIN * 60;
   const count = restarts.length + 1;
   state.write(session, 'restart-loop', { restarts: [...restarts, now], wedgedUntil });
-  const skill = skillRegistry.readTicketSkill(ticket);
+  const skill = skillRegistry.readTicketSkill(ticket, {
+    hasOracle: !!manifest.stopOracleForTask(ticket),
+  });
   alerts.log(
     `${formatLogLine({ ticket, skill, silenceSec, kind: 'wedged' })} ${session} WEDGED — ${count} auto-restarts in ${RESTART_WINDOW_MIN}m; suppressing restarts for ${WEDGED_QUIET_MIN}m`
   );
@@ -173,14 +175,18 @@ function checkRestartGuards({ session, ticket, worktree }) {
 // writes that happened after module load. Falls open to 'work'; on whitelist
 // reject we log the rejected raw value so operators can spot tampering.
 function resolveSkillForRestart(ticket, session) {
-  const skill = skillRegistry.readTicketSkill(ticket);
+  // An oracle-backed ticket may legitimately run a non-whitelisted command —
+  // pass the oracle existence so readTicketSkill honors it instead of falling
+  // open to /work (GH-514 generic-row decision).
+  const hasOracle = !!manifest.stopOracleForTask(ticket);
+  const skill = skillRegistry.readTicketSkill(ticket, { hasOracle });
   let raw = null;
   try {
     raw = fs.readFileSync(skillRegistry.ticketSkillFile(ticket), 'utf8').trim();
   } catch {
     /* missing → default, no warning */
   }
-  if (raw && !skillRegistry.isKnownSkill(raw)) {
+  if (raw && !skillRegistry.isAllowedSkill(raw, { hasOracle })) {
     alerts.log(
       `${session} AUTO-RESTART .maestro-skill value ${JSON.stringify(raw)} rejected by whitelist — falling open to /work for ${ticket}`
     );
@@ -351,6 +357,47 @@ function freeDeadEndSlot({ session, ticket, kind, repeatCount, sha }) {
 }
 
 /**
+ * freeStopConditionSlot — the ticket's stop-condition oracle returned exit 0,
+ * so the agent has SUCCEEDED. Same kill+rotate mechanics as freeDeadEndSlot,
+ * but the manifest status is `done` (not `blocked`) and the alert kind is
+ * `stop-condition-met` (a positive signal). Idempotent per ticket via the
+ * `stop-condition` marker. No-op when AUTO_FREE_STOP_CONDITION=0.
+ */
+function freeStopConditionSlot({ session, ticket, oracle }) {
+  if (process.env.AUTO_FREE_STOP_CONDITION === '0') return false;
+  const marker = state.read(ticket, 'stop-condition') || {};
+  if (marker.killed) return false; // already freed this lifecycle
+  killTicketTmux(ticket);
+  try {
+    purgeAlertCountsForTicket(ticket, false);
+  } catch (err) {
+    alerts.log(`${session} freeStopConditionSlot: purgeAlertCountsForTicket failed: ${err.message}`);
+  }
+  state.write(ticket, 'stop-condition', { killed: true, freedAt: state.now() });
+  manifest.updateTaskStatus(ticket, 'done', 'stop-condition oracle exited 0');
+  const next = findNextEligibleTask();
+  const autoBootstrapped = next && maybeAutoBootstrap(next.taskId);
+  const prefix = `STOP-CONDITION met on ${ticket} (oracle exit 0) — agent done. `;
+  const instruction = buildNextActionInstruction({ prefix, suffix: '', next, autoBootstrapped });
+  alerts.log(
+    `${session} STOP-CONDITION-MET — tmux killed, slot freed${
+      autoBootstrapped ? `; AUTO-BOOTSTRAPPED ${next.taskId}` : ''
+    }`
+  );
+  alert({
+    session,
+    ticket,
+    kind: 'stop-condition-met',
+    oracle,
+    nextTask: next ? next.taskId : null,
+    nextTopic: next ? next.topic : null,
+    autoBootstrapped: !!autoBootstrapped,
+    instruction,
+  });
+  return true;
+}
+
+/**
  * maybeFillPool — when the pool has free slots (active < sum-of-slots) and
  * AUTO_BOOTSTRAP_NEXT=1, find the next eligible pending task and bootstrap.
  * Idempotent per tick: one bootstrap per call. Caller invokes once per tick
@@ -392,6 +439,7 @@ module.exports = {
   autoRestart,
   freeCIGateSlot,
   freeDeadEndSlot,
+  freeStopConditionSlot,
   syncManifest: manifest.syncFromTmux,
   maybeFillPool,
 };

--- a/plugins/maestro/scripts/lib/maestro-conduct/actions.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/actions.js
@@ -17,7 +17,6 @@ const { spawnSync } = require('child_process');
 const tmux = require('./tmux');
 const alerts = require('./alerts');
 const state = require('./state');
-const { headSha } = require('./detectors/gh-shared');
 const manifest = require('./manifest');
 const {
   findNextEligibleTask,
@@ -27,6 +26,13 @@ const {
 const { purgeAlertCountsForTicket } = require('../../maestro-cleanup');
 const skillRegistry = require('./skill-registry');
 const { formatLogLine } = require('./detectors/silence');
+const {
+  RESTART_LOOP_THRESHOLD,
+  RESTART_WINDOW_MIN,
+  declareWedged,
+  checkRestartGuards,
+  resolveSkillForRestart,
+} = require('./restart-guards');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
 
@@ -59,13 +65,6 @@ function maybeAutoBootstrap(taskId) {
   return res.status === 0;
 }
 
-// Restart-loop guard: how many auto-restarts within RESTART_WINDOW_MIN before
-// we declare the session WEDGED and stop restarting. Caller is freed of state
-// management — autoRestart() owns the marker.
-const RESTART_LOOP_THRESHOLD = parseInt(process.env.RESTART_LOOP_THRESHOLD || '3', 10);
-const RESTART_WINDOW_MIN = parseInt(process.env.RESTART_WINDOW_MIN || '30', 10);
-const WEDGED_QUIET_MIN = parseInt(process.env.WEDGED_QUIET_MIN || '60', 10);
-
 function msgFor(reason, mode) {
   const base = `MAESTRO (${mode}): ${reason}. Audit uncommitted files via git status. If any are present, dispatch the commit agent with 'autonomous' to land them, then push. Re-run task-next.js to advance the gate.`;
   if (mode === 'interrupt') {
@@ -93,34 +92,6 @@ function alert(reasonObj) {
 }
 
 /**
- * Declare an agent wedged: record marker, log, and emit alert. Extracted from
- * autoRestart() to keep that function under the max-lines-per-function gate.
- */
-function declareWedged({ session, ticket, restarts, now, silenceSec }) {
-  const wedgedUntil = now + WEDGED_QUIET_MIN * 60;
-  const count = restarts.length + 1;
-  state.write(session, 'restart-loop', { restarts: [...restarts, now], wedgedUntil });
-  const skill = skillRegistry.readTicketSkill(ticket, {
-    hasOracle: !!manifest.stopOracleForTask(ticket),
-  });
-  alerts.log(
-    `${formatLogLine({ ticket, skill, silenceSec, kind: 'wedged' })} ${session} WEDGED — ${count} auto-restarts in ${RESTART_WINDOW_MIN}m; suppressing restarts for ${WEDGED_QUIET_MIN}m`
-  );
-  const paneTail = tmux.capture(session).split('\n').slice(-50).join('\n');
-  alerts.alert({
-    session,
-    ticket,
-    kind: 'wedged',
-    restartsInWindow: count,
-    windowMin: RESTART_WINDOW_MIN,
-    quietMin: WEDGED_QUIET_MIN,
-    silenceSec,
-    paneTail,
-    instruction: `agent restarted ${count}x in ${RESTART_WINDOW_MIN}m. Daemon won't restart for ${WEDGED_QUIET_MIN}m. UNBLOCK-PROTOCOL: diagnose root cause from paneTail; if dead-end, kill session and bootstrap next queued.`,
-  });
-}
-
-/**
  * Auto-restart a dead -work session in place: kill the existing tmux
  * session, then relaunch `claude --dangerously-skip-permissions /<skill> <ticket>`
  * inside the worktree. Returns true if the restart command was issued.
@@ -128,72 +99,9 @@ function declareWedged({ session, ticket, restarts, now, silenceSec }) {
  * Ported from maestro-conduct.sh's auto-restart branch. Caller is responsible
  * for restart eligibility (only -work sessions) and for clearing per-ticket
  * markers after the restart so detectors don't fire against the stale state.
+ *
+ * Eligibility guards and the wedged-loop declaration live in restart-guards.js.
  */
-function checkCiGateFreedGuard({ session, ticket, worktree }) {
-  const ciFreed = state.read(ticket, 'ci-gate-freed');
-  if (!ciFreed || !ciFreed.killed) return { skip: false };
-  const currentSha = headSha(worktree);
-  if (currentSha && ciFreed.sha && currentSha !== ciFreed.sha) {
-    alerts.log(
-      `${session} AUTO-RESTART ci-gate-freed marker cleared: HEAD moved ${(ciFreed.sha || '').slice(0, 7)} -> ${currentSha.slice(0, 7)}`
-    );
-    state.clear(ticket, 'ci-gate-freed');
-    return { skip: false };
-  }
-  if (!ciFreed.skipLogged) {
-    alerts.log(
-      `${session} AUTO-RESTART skipped: ticket ${ticket} CI-gate-freed at sha=${(ciFreed.sha || '').slice(0, 7)}; awaiting operator merge`
-    );
-    state.write(ticket, 'ci-gate-freed', { ...ciFreed, skipLogged: true });
-  }
-  return { skip: true };
-}
-
-function checkDeadEndGuard({ session, ticket }) {
-  const deadEnd = state.read(ticket, 'dead-end');
-  if (!deadEnd || !deadEnd.killed) return { skip: false };
-  if (!deadEnd.skipLogged) {
-    alerts.log(
-      `${session} AUTO-RESTART skipped: ticket ${ticket} dead-end-freed (trigger=${deadEnd.trigger || 'unknown'}); slot rotated, do not resurrect`
-    );
-    state.write(ticket, 'dead-end', { ...deadEnd, skipLogged: true });
-  }
-  return { skip: true };
-}
-
-function checkRestartGuards({ session, ticket, worktree }) {
-  if (!worktree || !fs.existsSync(worktree)) {
-    alerts.log(`${session} AUTO-RESTART skipped: worktree ${worktree} not found`);
-    return { skip: true };
-  }
-  const ciGuard = checkCiGateFreedGuard({ session, ticket, worktree });
-  if (ciGuard.skip) return ciGuard;
-  return checkDeadEndGuard({ session, ticket });
-}
-
-// GH-514 R1: resolve skill per-call so daemon restarts honor `.maestro-skill`
-// writes that happened after module load. Falls open to 'work'; on whitelist
-// reject we log the rejected raw value so operators can spot tampering.
-function resolveSkillForRestart(ticket, session) {
-  // An oracle-backed ticket may legitimately run a non-whitelisted command —
-  // pass the oracle existence so readTicketSkill honors it instead of falling
-  // open to /work (GH-514 generic-row decision).
-  const hasOracle = !!manifest.stopOracleForTask(ticket);
-  const skill = skillRegistry.readTicketSkill(ticket, { hasOracle });
-  let raw = null;
-  try {
-    raw = fs.readFileSync(skillRegistry.ticketSkillFile(ticket), 'utf8').trim();
-  } catch {
-    /* missing → default, no warning */
-  }
-  if (raw && !skillRegistry.isAllowedSkill(raw, { hasOracle })) {
-    alerts.log(
-      `${session} AUTO-RESTART .maestro-skill value ${JSON.stringify(raw)} rejected by whitelist — falling open to /work for ${ticket}`
-    );
-  }
-  return skill;
-}
-
 function autoRestart({ session, ticket, worktree, silenceSec }) {
   if (checkRestartGuards({ session, ticket, worktree }).skip) return false;
 
@@ -371,7 +279,9 @@ function freeStopConditionSlot({ session, ticket, oracle }) {
   try {
     purgeAlertCountsForTicket(ticket, false);
   } catch (err) {
-    alerts.log(`${session} freeStopConditionSlot: purgeAlertCountsForTicket failed: ${err.message}`);
+    alerts.log(
+      `${session} freeStopConditionSlot: purgeAlertCountsForTicket failed: ${err.message}`
+    );
   }
   state.write(ticket, 'stop-condition', { killed: true, freedAt: state.now() });
   manifest.updateTaskStatus(ticket, 'done', 'stop-condition oracle exited 0');

--- a/plugins/maestro/scripts/lib/maestro-conduct/halted-waiting.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/halted-waiting.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * halted-waiting.js — recognize the "agent is correctly halted, waiting on a
+ * human" pane patterns so phase-stall is suppressed instead of nudging.
+ *
+ * Extracted verbatim from maestro-conduct.js (no behavior change): when any of
+ * these patterns match the captured pane, the agent is intentionally idle
+ * (awaiting merge, refusing to auto-merge, CI green) and must NOT be treated as
+ * stuck.
+ */
+
+// Healthy "waiting on user" patterns the agent emits to the pane while halted.
+// When detected, phase-stall is suppressed — the agent is not stuck.
+const HALTED_WAITING_PATTERNS = [
+  /awaiting.*merge|wait.*merge|Once you( click| have)? merge/i,
+  /Per.*never-auto-merge|won['’]t merge|won['’]t auto-merge/i,
+  /CI is green.*[Mm]erge when ready/i,
+];
+
+function isHaltedWaitingForUser(pane) {
+  if (!pane) return false;
+  return HALTED_WAITING_PATTERNS.some((re) => re.test(pane));
+}
+
+module.exports = { HALTED_WAITING_PATTERNS, isHaltedWaitingForUser };

--- a/plugins/maestro/scripts/lib/maestro-conduct/heartbeat.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/heartbeat.js
@@ -8,6 +8,22 @@
 const tmux = require('./tmux');
 const state = require('./state');
 const workstate = require('./workstate');
+const alerts = require('./alerts');
+
+// Heartbeat: emit on state-change, with a max-staleness cap so the operator
+// always gets a positive signal every HEARTBEAT_MAX_MIN even if nothing has
+// changed (proves the daemon is alive). State-change beats include any of:
+// activeCount, wedgedCount, prReady/prBroken/prPending counts, ticket set.
+//
+// HEARTBEAT_MIN was previously a hard floor that suppressed ALL beats in the
+// first 15m, including real state changes — which contradicted the
+// "state-change-driven" contract (review feedback). It now only rate-limits
+// max-staleness (unchanged-body) beats; a real state change emits
+// immediately regardless of when the last beat was.
+const HEARTBEAT_MIN = parseInt(process.env.HEARTBEAT_MIN || '15', 10); // min gap between two UNCHANGED-state beats
+const HEARTBEAT_MAX_MIN = parseInt(process.env.HEARTBEAT_MAX_MIN || '60', 10); // force-emit cap
+let lastHeartbeatAt = 0;
+let lastHeartbeatBody = '';
 
 // Only -work sessions are restart-eligible / counted in active totals.
 function restartEligible(session) {
@@ -60,4 +76,34 @@ function buildHeartbeat(sessions) {
   );
 }
 
-module.exports = { restartEligible, collectPrFlag, classifySession, buildHeartbeat };
+function maybeEmitHeartbeat(sessions) {
+  const now = state.now();
+  const body = buildHeartbeat(sessions);
+  const sinceLast = lastHeartbeatAt ? now - lastHeartbeatAt : Infinity;
+  const bodyChanged = body !== lastHeartbeatBody;
+  const stale = sinceLast >= HEARTBEAT_MAX_MIN * 60;
+
+  // Body changed → emit immediately (state-change-driven contract; review
+  // feedback fixed: the floor used to suppress these for the first 15m).
+  // Body unchanged → respect HEARTBEAT_MIN as a floor and emit only when
+  // we've also hit HEARTBEAT_MAX_MIN (daemon-alive signal).
+  if (bodyChanged) {
+    // emit
+  } else if (stale && sinceLast >= HEARTBEAT_MIN * 60) {
+    // emit
+  } else {
+    return;
+  }
+
+  lastHeartbeatAt = now;
+  lastHeartbeatBody = body;
+  alerts.log(body);
+}
+
+module.exports = {
+  restartEligible,
+  collectPrFlag,
+  classifySession,
+  buildHeartbeat,
+  maybeEmitHeartbeat,
+};

--- a/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/manifest.js
@@ -148,6 +148,31 @@ function poolFullForTask(taskId, activeWorkSessions) {
   return liveInThisManifest >= m.slots;
 }
 
+/**
+ * stopOracleForTask — the compiled shell predicate the conductor evaluates each
+ * tick to decide whether a ticket is done. Null when the owning manifest
+ * declares none (then no stop-condition rotation happens for that ticket, and
+ * the ticket's command must be a whitelisted skill). Reading from the manifest
+ * (not env) is what lets a daemon restart re-derive the oracle.
+ */
+function stopOracleForTask(taskId) {
+  const hit = findTask(taskId);
+  const oracle = hit && hit.manifest && hit.manifest.stopOracle;
+  return oracle ? String(oracle) : null;
+}
+
+/**
+ * commandForTask — the command recorded in the owning manifest for a ticket
+ * (informational / generic-row gating). Null when unknown. The authoritative
+ * launch skill still lives in the per-ticket `.maestro-skill` file
+ * (skill-registry); this is the orchestration record's copy.
+ */
+function commandForTask(taskId) {
+  const hit = findTask(taskId);
+  const cmd = hit && hit.manifest && hit.manifest.command;
+  return cmd ? String(cmd).replace(/^\//, '') : null;
+}
+
 module.exports = {
   listManifestFiles,
   readManifest,
@@ -156,4 +181,6 @@ module.exports = {
   updateTaskStatus,
   syncFromTmux,
   poolFullForTask,
+  stopOracleForTask,
+  commandForTask,
 };

--- a/plugins/maestro/scripts/lib/maestro-conduct/restart-guards.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/restart-guards.js
@@ -1,0 +1,132 @@
+'use strict';
+
+/**
+ * restart-guards.js — eligibility guards and the wedged-loop declaration used
+ * by actions.autoRestart().
+ *
+ * Extracted verbatim from actions.js (no behavior change) to keep that file
+ * under the max-lines gate. These helpers decide whether a silent -work session
+ * may be auto-restarted (ci-gate-freed / dead-end / missing-worktree guards),
+ * resolve the skill to relaunch, and — when the restart-loop threshold is hit —
+ * mark the session WEDGED and emit the alert.
+ */
+
+const fs = require('fs');
+const tmux = require('./tmux');
+const alerts = require('./alerts');
+const state = require('./state');
+const { headSha } = require('./detectors/gh-shared');
+const manifest = require('./manifest');
+const skillRegistry = require('./skill-registry');
+const { formatLogLine } = require('./detectors/silence');
+
+// Restart-loop guard: how many auto-restarts within RESTART_WINDOW_MIN before
+// we declare the session WEDGED and stop restarting. Caller is freed of state
+// management — autoRestart() owns the marker.
+const RESTART_LOOP_THRESHOLD = parseInt(process.env.RESTART_LOOP_THRESHOLD || '3', 10);
+const RESTART_WINDOW_MIN = parseInt(process.env.RESTART_WINDOW_MIN || '30', 10);
+const WEDGED_QUIET_MIN = parseInt(process.env.WEDGED_QUIET_MIN || '60', 10);
+
+/**
+ * Declare an agent wedged: record marker, log, and emit alert. Extracted from
+ * autoRestart() to keep that function under the max-lines-per-function gate.
+ */
+function declareWedged({ session, ticket, restarts, now, silenceSec }) {
+  const wedgedUntil = now + WEDGED_QUIET_MIN * 60;
+  const count = restarts.length + 1;
+  state.write(session, 'restart-loop', { restarts: [...restarts, now], wedgedUntil });
+  const skill = skillRegistry.readTicketSkill(ticket, {
+    hasOracle: !!manifest.stopOracleForTask(ticket),
+  });
+  alerts.log(
+    `${formatLogLine({ ticket, skill, silenceSec, kind: 'wedged' })} ${session} WEDGED — ${count} auto-restarts in ${RESTART_WINDOW_MIN}m; suppressing restarts for ${WEDGED_QUIET_MIN}m`
+  );
+  const paneTail = tmux.capture(session).split('\n').slice(-50).join('\n');
+  alerts.alert({
+    session,
+    ticket,
+    kind: 'wedged',
+    restartsInWindow: count,
+    windowMin: RESTART_WINDOW_MIN,
+    quietMin: WEDGED_QUIET_MIN,
+    silenceSec,
+    paneTail,
+    instruction: `agent restarted ${count}x in ${RESTART_WINDOW_MIN}m. Daemon won't restart for ${WEDGED_QUIET_MIN}m. UNBLOCK-PROTOCOL: diagnose root cause from paneTail; if dead-end, kill session and bootstrap next queued.`,
+  });
+}
+
+function checkCiGateFreedGuard({ session, ticket, worktree }) {
+  const ciFreed = state.read(ticket, 'ci-gate-freed');
+  if (!ciFreed || !ciFreed.killed) return { skip: false };
+  const currentSha = headSha(worktree);
+  if (currentSha && ciFreed.sha && currentSha !== ciFreed.sha) {
+    alerts.log(
+      `${session} AUTO-RESTART ci-gate-freed marker cleared: HEAD moved ${(ciFreed.sha || '').slice(0, 7)} -> ${currentSha.slice(0, 7)}`
+    );
+    state.clear(ticket, 'ci-gate-freed');
+    return { skip: false };
+  }
+  if (!ciFreed.skipLogged) {
+    alerts.log(
+      `${session} AUTO-RESTART skipped: ticket ${ticket} CI-gate-freed at sha=${(ciFreed.sha || '').slice(0, 7)}; awaiting operator merge`
+    );
+    state.write(ticket, 'ci-gate-freed', { ...ciFreed, skipLogged: true });
+  }
+  return { skip: true };
+}
+
+function checkDeadEndGuard({ session, ticket }) {
+  const deadEnd = state.read(ticket, 'dead-end');
+  if (!deadEnd || !deadEnd.killed) return { skip: false };
+  if (!deadEnd.skipLogged) {
+    alerts.log(
+      `${session} AUTO-RESTART skipped: ticket ${ticket} dead-end-freed (trigger=${deadEnd.trigger || 'unknown'}); slot rotated, do not resurrect`
+    );
+    state.write(ticket, 'dead-end', { ...deadEnd, skipLogged: true });
+  }
+  return { skip: true };
+}
+
+function checkRestartGuards({ session, ticket, worktree }) {
+  if (!worktree || !fs.existsSync(worktree)) {
+    alerts.log(`${session} AUTO-RESTART skipped: worktree ${worktree} not found`);
+    return { skip: true };
+  }
+  const ciGuard = checkCiGateFreedGuard({ session, ticket, worktree });
+  if (ciGuard.skip) return ciGuard;
+  return checkDeadEndGuard({ session, ticket });
+}
+
+// GH-514 R1: resolve skill per-call so daemon restarts honor `.maestro-skill`
+// writes that happened after module load. Falls open to 'work'; on whitelist
+// reject we log the rejected raw value so operators can spot tampering.
+function resolveSkillForRestart(ticket, session) {
+  // An oracle-backed ticket may legitimately run a non-whitelisted command —
+  // pass the oracle existence so readTicketSkill honors it instead of falling
+  // open to /work (GH-514 generic-row decision).
+  const hasOracle = !!manifest.stopOracleForTask(ticket);
+  const skill = skillRegistry.readTicketSkill(ticket, { hasOracle });
+  let raw = null;
+  try {
+    raw = fs.readFileSync(skillRegistry.ticketSkillFile(ticket), 'utf8').trim();
+  } catch {
+    /* missing → default, no warning */
+  }
+  if (raw && !skillRegistry.isAllowedSkill(raw, { hasOracle })) {
+    alerts.log(
+      `${session} AUTO-RESTART .maestro-skill value ${JSON.stringify(raw)} rejected by whitelist — falling open to /work for ${ticket}`
+    );
+  }
+  return skill;
+}
+
+module.exports = {
+  RESTART_LOOP_THRESHOLD,
+  RESTART_WINDOW_MIN,
+  WEDGED_QUIET_MIN,
+  declareWedged,
+  checkCiGateFreedGuard,
+  checkDeadEndGuard,
+  checkRestartGuards,
+  resolveSkillForRestart,
+};

--- a/plugins/maestro/scripts/lib/maestro-conduct/shared/skill-registry-rows.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/shared/skill-registry-rows.js
@@ -90,12 +90,36 @@ function followUpRow() {
   };
 }
 
+// Generic row for an operator-supplied command that is NOT in the whitelist
+// but IS paired with a stop-condition oracle. The conductor doesn't understand
+// the command's internal state — the oracle is the authoritative done-signal —
+// so this row reads no skill-specific state file and never reports healthy-idle
+// on its own. snapshot() returns null (phase resolution falls back to the BASE
+// profile in phase-registry, whose `exempts` is a no-op, so nothing crashes).
+const GENERIC_SILENCE_LIMIT_SEC = 300;
+
+function genericRow() {
+  return {
+    stateFile: null,
+    snapshot() {
+      return null;
+    },
+    isHealthyIdle() {
+      return false;
+    },
+    silenceLimitSec: GENERIC_SILENCE_LIMIT_SEC,
+    generic: true,
+  };
+}
+
 module.exports = {
   workRow,
   followUpRow,
+  genericRow,
   FOLLOW_UP_STATE_BASENAME,
   WORK_STATE_BASENAME,
   FOLLOW_UP_HEALTHY_STATUSES,
   WORK_SILENCE_LIMIT_SEC,
   FOLLOW_UP_SILENCE_LIMIT_SEC,
+  GENERIC_SILENCE_LIMIT_SEC,
 };

--- a/plugins/maestro/scripts/lib/maestro-conduct/skill-registry.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/skill-registry.js
@@ -44,16 +44,30 @@ function isKnownSkill(name) {
   return Object.prototype.hasOwnProperty.call(REGISTRY, name);
 }
 
-function get(name) {
-  if (!isKnownSkill(name)) return undefined;
-  return REGISTRY[name];
+/**
+ * A name is *allowed* as a launch command when it is either whitelisted, or
+ * regex-valid AND backed by a stop-condition oracle (the generic-row path).
+ * The oracle existence is injected by the caller (`opts.hasOracle`) so this
+ * module stays decoupled from the manifest. Defaults to whitelist-only.
+ */
+function isAllowedSkill(name, opts = {}) {
+  if (isKnownSkill(name)) return true;
+  return !!opts.hasOracle && isValidSkillName(name);
+}
+
+function get(name, opts = {}) {
+  if (isKnownSkill(name)) return REGISTRY[name];
+  // Oracle-backed operator command → generic row (no skill-specific state;
+  // the oracle is the done-signal). Per the GH-514 whitelist decision.
+  if (opts.hasOracle && isValidSkillName(name)) return rows.genericRow();
+  return undefined;
 }
 
 function ticketSkillFile(ticket) {
   return path.join(tasksBase(), ticket, TICKET_SKILL_BASENAME);
 }
 
-function readTicketSkill(ticket) {
+function readTicketSkill(ticket, opts = {}) {
   const f = ticketSkillFile(ticket);
   let raw;
   try {
@@ -62,26 +76,31 @@ function readTicketSkill(ticket) {
     return DEFAULT_SKILL;
   }
   const trimmed = (raw || '').trim();
-  if (!isValidSkillName(trimmed)) return DEFAULT_SKILL;
-  if (!isKnownSkill(trimmed)) return DEFAULT_SKILL;
+  // Whitelisted skills are always honored; a non-whitelisted command is only
+  // honored when the ticket is oracle-backed (opts.hasOracle) — otherwise we
+  // fall open to /work, preserving the GH-514 typo guard.
+  if (!isAllowedSkill(trimmed, opts)) return DEFAULT_SKILL;
   return trimmed;
 }
 
-function writeTicketSkill(ticket, name) {
+function writeTicketSkill(ticket, name, opts = {}) {
   if (!isValidSkillName(name)) {
     throw new Error(
       `skill-registry: refusing to write invalid skill name ${JSON.stringify(name)} ` +
         `(must match ${SKILL_NAME_REGEX})`
     );
   }
-  // PR #561 review: regex validity is not enough. Without the registry check
-  // we'd persist `.maestro-skill = 'followup'` (typo), then `readTicketSkill`
-  // and `autoRestart` would fall open to `'work'`, recreating the split-state
-  // bug the bootstrap typo guard fixed.
-  if (!isKnownSkill(name)) {
+  // PR #561 review: regex validity is not enough for a WHITELISTED launch.
+  // Without the registry check we'd persist `.maestro-skill = 'followup'`
+  // (typo), then fall open to `'work'`, recreating the split-state bug.
+  // The generic-row path (GH-514 whitelist decision) intentionally relaxes
+  // this when the ticket is oracle-backed: any regex-valid command is allowed
+  // because the oracle, not a bespoke registry row, defines "done".
+  if (!isAllowedSkill(name, opts)) {
     throw new Error(
       `skill-registry: refusing to write registry-unknown skill ${JSON.stringify(name)} ` +
-        `(known: ${Object.keys(REGISTRY).join(', ')})`
+        `without a stop-condition oracle (known: ${Object.keys(REGISTRY).join(', ')}; ` +
+        `pass {hasOracle:true} for an oracle-backed command)`
     );
   }
   const dir = path.join(tasksBase(), ticket);
@@ -92,6 +111,7 @@ function writeTicketSkill(ticket, name) {
 module.exports = {
   get,
   isKnownSkill,
+  isAllowedSkill,
   readTicketSkill,
   writeTicketSkill,
   ticketSkillFile,

--- a/plugins/maestro/scripts/lib/maestro-conduct/stop-condition.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/stop-condition.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * stop-condition.js — deterministic, operator-defined completion check.
+ *
+ * The orchestrate skill compiles a natural-language stopCondition (e.g.
+ * "when /follow-up skill says that it passed") into a shell-executable oracle
+ * ONCE, at setup, using an LLM. This module is the RUN-TIME half: every tick
+ * the conductor runs that oracle as a plain subprocess and treats exit 0 as
+ * "this ticket is done". No LLM is ever involved at evaluation time — the
+ * oracle's exit code is the entire verdict.
+ *
+ * Mirrors ci-gate-rotation.js: a thin predicate that, on a positive signal,
+ * delegates the kill+rotate to actions (here: freeStopConditionSlot, which
+ * marks the manifest `done` rather than `blocked`).
+ *
+ * Fail-safe: a non-zero exit, a timeout, or any spawn error means "not done
+ * yet" — we NEVER kill an agent on an oracle that errored. Only a clean exit 0
+ * frees the slot.
+ */
+
+const { spawnSync } = require('node:child_process');
+
+// Per-evaluation wall-clock budget. The oracle runs every TICK_SEC against
+// every live session, so it must be cheap; this cap stops a hung predicate
+// (network call, stuck gh) from stalling the whole conductor tick.
+const ORACLE_TIMEOUT_MS = parseInt(process.env.ORACLE_TIMEOUT_MS || '30000', 10);
+
+/**
+ * Run the oracle for ctx's ticket. Returns true ONLY when a fresh stop was
+ * just triggered (caller skips remaining work for the session this tick).
+ *
+ * @param {object} args
+ * @param {object} args.ctx        - { session, ticket, worktree, ... }
+ * @param {object} args.actions    - actions module (freeStopConditionSlot)
+ * @param {object} args.manifest   - manifest module (stopOracleForTask)
+ * @param {function} args.restartEligible - gate so only -work sessions stop
+ */
+function maybeStopOnOracle({ ctx, actions, manifest, restartEligible }) {
+  if (!restartEligible(ctx.session)) return false;
+  const oracle = manifest.stopOracleForTask(ctx.ticket);
+  if (!oracle) return false;
+
+  // argv form: the oracle string is handed to `bash -c` as a single argument,
+  // never interpolated with the ticket/worktree (those arrive via env), so a
+  // ticket id can't break out of the command. The oracle itself is
+  // operator-authored and trusted (same posture as the agents launched with
+  // --dangerously-skip-permissions).
+  let res;
+  try {
+    res = spawnSync('bash', ['-c', oracle], {
+      cwd: ctx.worktree,
+      timeout: ORACLE_TIMEOUT_MS,
+      env: { ...process.env, TICKET: ctx.ticket, WORKTREE: ctx.worktree || '' },
+      stdio: 'ignore',
+    });
+  } catch {
+    return false; // spawn failure → not done
+  }
+  // timeout/signal/non-zero → not done yet. Only a clean exit 0 means met.
+  if (!res || res.status !== 0) return false;
+
+  return actions.freeStopConditionSlot({
+    session: ctx.session,
+    ticket: ctx.ticket,
+    oracle,
+  });
+}
+
+module.exports = { maybeStopOnOracle, ORACLE_TIMEOUT_MS };

--- a/plugins/maestro/scripts/maestro-bootstrap.sh
+++ b/plugins/maestro/scripts/maestro-bootstrap.sh
@@ -57,11 +57,19 @@ SKILL_NAME="${SKILL_NAME:-work}"
 #    Parses --skill=<name> out of the positional args before the ticket loop,
 #    leaving "$@" containing only ticket IDs.
 SKILL_FLAG=""
+# --allow-generic relaxes the whitelist: any regex-valid skill name is accepted
+# (used for an operator command backed by a stop-condition oracle, where the
+# oracle — not a bespoke registry row — defines "done"). Mirrors the JS
+# skill-registry.isAllowedSkill(name, {hasOracle:true}) decision (GH-514).
+ALLOW_GENERIC=0
 _FILTERED_ARGS=()
 for _arg in "$@"; do
   case "$_arg" in
     --skill=*)
       SKILL_FLAG="${_arg#--skill=}"
+      ;;
+    --allow-generic)
+      ALLOW_GENERIC=1
       ;;
     *)
       _FILTERED_ARGS+=("$_arg")
@@ -76,12 +84,25 @@ set -- "${_FILTERED_ARGS[@]+"${_FILTERED_ARGS[@]}"}"
 # tmux while the conductor reads .maestro-skill, fails the same whitelist, and
 # falls open to /work. That split state is the bug PR #561 review flagged.
 _KNOWN_SKILLS=("work" "follow-up")
+# Mirrors SKILL_NAME_REGEX in skill-registry.js.
+_SKILL_NAME_RE='^[a-z][a-z0-9-]{0,31}$'
 
 is_known_skill() {
   local cand="$1"
   for s in "${_KNOWN_SKILLS[@]}"; do
     [ "$s" = "$cand" ] && return 0
   done
+  return 1
+}
+
+# Allowed = whitelisted, OR (generic mode on AND regex-valid). The generic path
+# is what lets an oracle-backed `command=/qc-work` launch on the first try.
+is_allowed_skill() {
+  local cand="$1"
+  is_known_skill "$cand" && return 0
+  if [ "$ALLOW_GENERIC" = "1" ] && [[ "$cand" =~ $_SKILL_NAME_RE ]]; then
+    return 0
+  fi
   return 1
 }
 
@@ -98,10 +119,10 @@ resolve_skill() {
   else
     candidate="work"
   fi
-  if is_known_skill "$candidate"; then
+  if is_allowed_skill "$candidate"; then
     echo "$candidate"
   else
-    echo "[maestro] WARNING: unknown skill '$candidate' (not in registry) — falling open to 'work'" >&2
+    echo "[maestro] WARNING: unknown skill '$candidate' (not in registry, no --allow-generic) — falling open to 'work'" >&2
     echo "work"
   fi
 }
@@ -218,7 +239,7 @@ for TICKET in "$@"; do
     echo "[$TICKET] .maestro-skill = $TICKET_SKILL (written)"
   else
     EXISTING_SKILL="$(head -n1 "$TICKET_DIR/.maestro-skill" | tr -d '[:space:]')"
-    if is_known_skill "$EXISTING_SKILL"; then
+    if is_allowed_skill "$EXISTING_SKILL"; then
       TICKET_SKILL="$EXISTING_SKILL"
       echo "[$TICKET] .maestro-skill = $EXISTING_SKILL (preserved — no explicit skill on this invocation)"
     else

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -25,6 +25,8 @@ const heartbeat = require('./lib/maestro-conduct/heartbeat');
 const skillRegistry = require('./lib/maestro-conduct/skill-registry');
 
 const ciGate = require('./lib/maestro-conduct/ci-gate-rotation');
+const manifest = require('./lib/maestro-conduct/manifest');
+const stopCondition = require('./lib/maestro-conduct/stop-condition');
 const waitMute = require('./lib/maestro-conduct/wait-mute');
 const prStatusPayload = require('./lib/maestro-conduct/pr-status-payload');
 const prCommentsHandler = require('./lib/maestro-conduct/pr-comments-handler');
@@ -301,6 +303,12 @@ function tickSession(session) {
   alerts.resetCount(
     alerts.alertKey({ session: ctx.session, kind: 'question-pending', phase: ctx.phase })
   );
+
+  // Stop-condition runs before the detectors: a ticket whose oracle reports
+  // done must be reaped (kill + rotate to the next queued ticket) BEFORE the
+  // silence detector tries to auto-restart the now-idle agent. No-op for
+  // tickets without a compiled oracle.
+  if (stopCondition.maybeStopOnOracle({ ctx, actions, manifest, restartEligible })) return;
 
   const detectorsToRun = phaseFor(ctx.phase).detectors.filter((k) => k !== 'question');
 

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -31,6 +31,7 @@ const waitMute = require('./lib/maestro-conduct/wait-mute');
 const prStatusPayload = require('./lib/maestro-conduct/pr-status-payload');
 const prCommentsHandler = require('./lib/maestro-conduct/pr-comments-handler');
 const questionHandler = require('./lib/maestro-conduct/question-handler');
+const { isHaltedWaitingForUser } = require('./lib/maestro-conduct/halted-waiting');
 
 const DETECTORS = {
   question: require('./lib/maestro-conduct/detectors/question'),
@@ -41,21 +42,6 @@ const DETECTORS = {
   prComments: require('./lib/maestro-conduct/detectors/pr-comments'),
   prStatus: require('./lib/maestro-conduct/detectors/pr-status'),
 };
-
-// Heartbeat: emit on state-change, with a max-staleness cap so the operator
-// always gets a positive signal every HEARTBEAT_MAX_MIN even if nothing has
-// changed (proves the daemon is alive). State-change beats include any of:
-// activeCount, wedgedCount, prReady/prBroken/prPending counts, ticket set.
-//
-// HEARTBEAT_MIN was previously a hard floor that suppressed ALL beats in the
-// first 15m, including real state changes — which contradicted the
-// "state-change-driven" contract (review feedback). It now only rate-limits
-// max-staleness (unchanged-body) beats; a real state change emits
-// immediately regardless of when the last beat was.
-const HEARTBEAT_MIN = parseInt(process.env.HEARTBEAT_MIN || '15', 10); // min gap between two UNCHANGED-state beats
-const HEARTBEAT_MAX_MIN = parseInt(process.env.HEARTBEAT_MAX_MIN || '60', 10); // force-emit cap
-let lastHeartbeatAt = 0;
-let lastHeartbeatBody = '';
 
 // Re-emit escalation: when the same (session, kind, sha/phase) alert fires
 // this many times, auto-rotate the slot via freeDeadEndSlot.
@@ -104,19 +90,6 @@ function handleQuestion(ctx, qHit) {
     qWaitMin: Q_WAIT_MIN,
     maybeEscalateToDeadEnd,
   });
-}
-
-// Healthy "waiting on user" patterns the agent emits to the pane while halted.
-// When detected, phase-stall is suppressed — the agent is not stuck.
-const HALTED_WAITING_PATTERNS = [
-  /awaiting.*merge|wait.*merge|Once you( click| have)? merge/i,
-  /Per.*never-auto-merge|won['’]t merge|won['’]t auto-merge/i,
-  /CI is green.*[Mm]erge when ready/i,
-];
-
-function isHaltedWaitingForUser(pane) {
-  if (!pane) return false;
-  return HALTED_WAITING_PATTERNS.some((re) => re.test(pane));
 }
 
 // Advance marker after a nudge/alert; `alerted=true` flips the one-shot flag.
@@ -287,6 +260,27 @@ function runPrStatusDetector(ctx) {
   ciGate.maybeFreeOnPrReady({ ctx, sHit, workSession, actions });
 }
 
+// Run the phase's detector set in priority order. Silence/spinner short-circuit
+// the tick (return true) when they fire a restart/interrupt; the remaining
+// detectors are advisory and always run. Extracted from tickSession to keep its
+// cyclomatic complexity under the gate.
+function runPhaseDetectors(ctx) {
+  const detectorsToRun = phaseFor(ctx.phase).detectors.filter((k) => k !== 'question');
+
+  // Silence runs before spinner: a totally-dead pane is more urgent than a
+  // hung spinner, and the restart wipes spinner state anyway.
+  if (detectorsToRun.includes('silence') && runSilenceDetector(ctx)) return;
+  if (detectorsToRun.includes('spinner') && runSpinnerDetector(ctx)) return;
+  if (detectorsToRun.includes('phaseStall')) runPhaseStallDetector(ctx);
+  if (detectorsToRun.includes('commitStall')) runCommitStallDetector(ctx);
+  if (detectorsToRun.includes('prComments')) runPrCommentsDetector(ctx);
+  if (detectorsToRun.includes('prStatus')) runPrStatusDetector(ctx);
+  // Phase-based rotation runs after all detectors so it sees the freshest
+  // marker state, and catches the steady-state pr-ready case independent of
+  // pr-status detector dedup.
+  ciGate.maybeRotateOnPhase({ ctx, state, actions, restartEligible });
+}
+
 /** Run the per-session pipeline. Returns when the session has been fully processed. */
 function tickSession(session) {
   const ctx = ctxFor(session);
@@ -310,44 +304,7 @@ function tickSession(session) {
   // tickets without a compiled oracle.
   if (stopCondition.maybeStopOnOracle({ ctx, actions, manifest, restartEligible })) return;
 
-  const detectorsToRun = phaseFor(ctx.phase).detectors.filter((k) => k !== 'question');
-
-  // Silence runs before spinner: a totally-dead pane is more urgent than a
-  // hung spinner, and the restart wipes spinner state anyway.
-  if (detectorsToRun.includes('silence') && runSilenceDetector(ctx)) return;
-  if (detectorsToRun.includes('spinner') && runSpinnerDetector(ctx)) return;
-  if (detectorsToRun.includes('phaseStall')) runPhaseStallDetector(ctx);
-  if (detectorsToRun.includes('commitStall')) runCommitStallDetector(ctx);
-  if (detectorsToRun.includes('prComments')) runPrCommentsDetector(ctx);
-  if (detectorsToRun.includes('prStatus')) runPrStatusDetector(ctx);
-  // Phase-based rotation runs after all detectors so it sees the freshest
-  // marker state, and catches the steady-state pr-ready case independent of
-  // pr-status detector dedup.
-  ciGate.maybeRotateOnPhase({ ctx, state, actions, restartEligible });
-}
-
-function maybeEmitHeartbeat(sessions) {
-  const now = state.now();
-  const body = heartbeat.buildHeartbeat(sessions);
-  const sinceLast = lastHeartbeatAt ? now - lastHeartbeatAt : Infinity;
-  const bodyChanged = body !== lastHeartbeatBody;
-  const stale = sinceLast >= HEARTBEAT_MAX_MIN * 60;
-
-  // Body changed → emit immediately (state-change-driven contract; review
-  // feedback fixed: the floor used to suppress these for the first 15m).
-  // Body unchanged → respect HEARTBEAT_MIN as a floor and emit only when
-  // we've also hit HEARTBEAT_MAX_MIN (daemon-alive signal).
-  if (bodyChanged) {
-    // emit
-  } else if (stale && sinceLast >= HEARTBEAT_MIN * 60) {
-    // emit
-  } else {
-    return;
-  }
-
-  lastHeartbeatAt = now;
-  lastHeartbeatBody = body;
-  alerts.log(body);
+  runPhaseDetectors(ctx);
 }
 
 function tick() {
@@ -372,7 +329,7 @@ function tick() {
     return;
   }
   for (const session of sessions) tickSession(session);
-  maybeEmitHeartbeat(sessions);
+  heartbeat.maybeEmitHeartbeat(sessions);
 }
 
 function handlePrComments(ctx, cHit) {

--- a/plugins/maestro/scripts/maestro-schema.js
+++ b/plugins/maestro/scripts/maestro-schema.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * maestro-schema.js — manage reusable orchestration schemas.
+ *
+ * A schema persists the reusable knobs of a `/maestro:orchestrate` run — pool
+ * size, per-ticket command, and the compiled stop-condition oracle — so the
+ * operator can replay them against a fresh `queue` later. Storage mirrors the
+ * synapsys memory store exactly (see lib/schema-store.js): tiered, marker-gated
+ * directories holding one markdown-with-frontmatter file per schema.
+ *
+ * The `queue` is NEVER part of a schema — it is per-run.
+ *
+ * CLI:
+ *   init  <local|worktree|global|shared> [--cwd=<path>]
+ *         Create the store dir + .maestro.json marker (idempotent).
+ *
+ *   save  <name> --tier=<kind>
+ *         [--pool=<N>] [--command=/X] [--stop-source="…"] [--stop-oracle="…"]
+ *         [--compiled-from="skill@ver (script)"] [--description="…"] [--force]
+ *         Write <name>.md into the chosen tier's store. Refuses if the tier has
+ *         no marker (run init first) or the name exists (unless --force).
+ *
+ *   list                  JSON array of every schema across discovered tiers.
+ *   show  <name>          JSON for the named schema (errors if ambiguous).
+ *   delete <name> [--tier=<kind>]   Remove the schema file.
+ *
+ * `name` must be kebab-case (letters/digits/dashes). Oracles may contain any
+ * shell — they are quoted on write and run verbatim by the conductor.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const store = require(path.join(__dirname, '..', 'lib', 'schema-store'));
+const {
+  MARKER,
+  getProjectName,
+  candidateStores,
+  discoverStores,
+  serializeFrontmatter,
+  listSchemas,
+  findSchemaTiers,
+} = store;
+
+const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+const VALID_TIERS = new Set(['local', 'worktree', 'global', 'shared']);
+
+function die(msg, code = 1) {
+  process.stderr.write(`error: ${msg}\n`);
+  process.exit(code);
+}
+
+// Parse `--flag=value` (and bare positional args) into { _: [...], flag: value }.
+function parseArgs(argv) {
+  const out = { _: [] };
+  for (const a of argv) {
+    const m = a.match(/^--([a-z][a-z-]*)=([\s\S]*)$/);
+    if (m) out[m[1]] = m[2];
+    else if (a === '--force') out.force = true;
+    else out._.push(a);
+  }
+  return out;
+}
+
+function cmdInit(args) {
+  const kind = args._[0];
+  if (!VALID_TIERS.has(kind)) die(`init needs a tier: local|worktree|global|shared (got '${kind}')`);
+  const cwd = args.cwd || process.cwd();
+  const projectName = getProjectName(cwd);
+  const target = candidateStores(cwd, projectName).find((c) => c.kind === kind);
+  if (!target) die(`unknown tier: ${kind}`);
+
+  fs.mkdirSync(target.dir, { recursive: true });
+  const marker = {
+    kind,
+    ...(kind === 'shared' ? {} : { projectName }),
+    createdAt: new Date().toISOString(),
+    schemaVersion: 1,
+  };
+  fs.writeFileSync(path.join(target.dir, MARKER), `${JSON.stringify(marker, null, 2)}\n`);
+
+  const indexPath = path.join(target.dir, 'INDEX.md');
+  if (!fs.existsSync(indexPath)) {
+    const scope = kind === 'shared' ? 'all projects' : projectName;
+    fs.writeFileSync(
+      indexPath,
+      [
+        `# Maestro orchestration schemas — ${scope} (${kind})`,
+        '',
+        'One schema per file. Frontmatter declares the reusable run knobs;',
+        '`queue` is never saved (per-run). Example:',
+        '',
+        '```',
+        '---',
+        'name: opera1',
+        'description: qc-work driven by /follow-up pass oracle, single slot',
+        'pool_size: 1',
+        'command: /qc-work',
+        'stop_source: when /follow-up skill says that it passed',
+        'stop_oracle: "node $FOLLOWUP/follow-up-next.js \\"$TICKET\\" --json | jq -e \'.action==\\"complete\\"\'"',
+        'compiled_from: follow-up@3.45.2 (follow-up-next.js)',
+        '---',
+        '```',
+        '',
+      ].join('\n')
+    );
+  }
+  const scopeNote = kind === 'shared' ? 'scope=all projects' : `project=${projectName}`;
+  console.log(`initialized maestro schema store at ${target.dir} (tier=${kind}, ${scopeNote})`);
+}
+
+function cmdSave(args) {
+  const name = args._[0];
+  if (!name) die('save needs a <name>');
+  if (!NAME_RE.test(name)) die(`name must be kebab-case (got '${name}')`);
+  const kind = args.tier;
+  if (!VALID_TIERS.has(kind)) die(`save needs --tier=<local|worktree|global|shared> (got '${kind}')`);
+
+  const cwd = args.cwd || process.cwd();
+  const target = discoverStores(cwd).find((s) => s.kind === kind);
+  if (!target) {
+    die(`no maestro store in tier '${kind}' — run: maestro-schema.js init ${kind}`);
+  }
+
+  const file = path.join(target.dir, `${name}.md`);
+  if (fs.existsSync(file) && !args.force) {
+    die(`schema '${name}' already exists in tier '${kind}' (use --force to overwrite)`);
+  }
+
+  const meta = {
+    name,
+    description: args.description || '',
+    pool_size: args.pool !== undefined ? parseInt(args.pool, 10) : undefined,
+    command: args.command || undefined,
+    stop_source: args['stop-source'] || undefined,
+    stop_oracle: args['stop-oracle'] || undefined,
+    compiled_from: args['compiled-from'] || undefined,
+    compiled_at: new Date().toISOString().slice(0, 10),
+  };
+  const body = args.body || '';
+  fs.writeFileSync(file, serializeFrontmatter(meta, body));
+  console.log(`saved schema '${name}' to ${file} (tier=${kind})`);
+}
+
+function cmdList(args) {
+  console.log(JSON.stringify(listSchemas(args.cwd || process.cwd()), null, 2));
+}
+
+function cmdShow(args) {
+  const name = args._[0];
+  if (!name) die('show needs a <name>');
+  const hits = findSchemaTiers(args.cwd || process.cwd(), name);
+  if (hits.length === 0) die(`no schema '${name}' found in any tier`);
+  if (hits.length > 1) {
+    die(
+      `schema '${name}' is ambiguous — exists in tiers: ${hits.map((h) => h.store).join(', ')}. ` +
+        `Disambiguate by removing duplicates or reading the file directly.`
+    );
+  }
+  console.log(JSON.stringify(hits[0], null, 2));
+}
+
+function cmdDelete(args) {
+  const name = args._[0];
+  if (!name) die('delete needs a <name>');
+  let hits = findSchemaTiers(args.cwd || process.cwd(), name);
+  if (args.tier) hits = hits.filter((h) => h.store === args.tier);
+  if (hits.length === 0) die(`no schema '${name}'${args.tier ? ` in tier '${args.tier}'` : ''}`);
+  if (hits.length > 1) {
+    die(`schema '${name}' exists in tiers ${hits.map((h) => h.store).join(', ')}; pass --tier to pick one`);
+  }
+  fs.unlinkSync(hits[0].file);
+  console.log(`deleted schema '${name}' (tier=${hits[0].store})`);
+}
+
+function main() {
+  const [, , cmd, ...rest] = process.argv;
+  const args = parseArgs(rest);
+  switch (cmd) {
+    case 'init':
+      return cmdInit(args);
+    case 'save':
+      return cmdSave(args);
+    case 'list':
+      return cmdList(args);
+    case 'show':
+      return cmdShow(args);
+    case 'delete':
+      return cmdDelete(args);
+    default:
+      die('usage: maestro-schema.js <init|save|list|show|delete> ...');
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { parseArgs, NAME_RE, VALID_TIERS };

--- a/plugins/maestro/scripts/maestro-schema.js
+++ b/plugins/maestro/scripts/maestro-schema.js
@@ -82,8 +82,11 @@ function cmdInit(args) {
   fs.writeFileSync(path.join(target.dir, MARKER), `${JSON.stringify(marker, null, 2)}\n`);
 
   const indexPath = path.join(target.dir, 'INDEX.md');
-  if (!fs.existsSync(indexPath)) {
-    const scope = kind === 'shared' ? 'all projects' : projectName;
+  const scope = kind === 'shared' ? 'all projects' : projectName;
+  // Exclusive create (`wx`) instead of existsSync-then-write: writes the
+  // starter index atomically and leaves an already-present one untouched,
+  // without the check-then-write race (CodeQL).
+  try {
     fs.writeFileSync(
       indexPath,
       [
@@ -104,8 +107,11 @@ function cmdInit(args) {
         '---',
         '```',
         '',
-      ].join('\n')
+      ].join('\n'),
+      { flag: 'wx' }
     );
+  } catch (e) {
+    if (e.code !== 'EEXIST') throw e; // starter index already present — keep it
   }
   const scopeNote = kind === 'shared' ? 'scope=all projects' : `project=${projectName}`;
   console.log(`initialized maestro schema store at ${target.dir} (tier=${kind}, ${scopeNote})`);
@@ -125,10 +131,6 @@ function cmdSave(args) {
   }
 
   const file = path.join(target.dir, `${name}.md`);
-  if (fs.existsSync(file) && !args.force) {
-    die(`schema '${name}' already exists in tier '${kind}' (use --force to overwrite)`);
-  }
-
   const meta = {
     name,
     description: args.description || '',
@@ -139,8 +141,18 @@ function cmdSave(args) {
     compiled_from: args['compiled-from'] || undefined,
     compiled_at: new Date().toISOString().slice(0, 10),
   };
-  const body = args.body || '';
-  fs.writeFileSync(file, serializeFrontmatter(meta, body));
+  const content = serializeFrontmatter(meta, args.body || '');
+  // Exclusive create unless --force: `wx` fails atomically when the schema
+  // already exists, so there is no existsSync-then-write race (CodeQL). With
+  // --force we intentionally overwrite.
+  try {
+    fs.writeFileSync(file, content, args.force ? undefined : { flag: 'wx' });
+  } catch (e) {
+    if (e.code === 'EEXIST') {
+      die(`schema '${name}' already exists in tier '${kind}' (use --force to overwrite)`);
+    }
+    throw e;
+  }
   console.log(`saved schema '${name}' to ${file} (tier=${kind})`);
 }
 

--- a/plugins/maestro/scripts/maestro-schema.js
+++ b/plugins/maestro/scripts/maestro-schema.js
@@ -66,7 +66,8 @@ function parseArgs(argv) {
 
 function cmdInit(args) {
   const kind = args._[0];
-  if (!VALID_TIERS.has(kind)) die(`init needs a tier: local|worktree|global|shared (got '${kind}')`);
+  if (!VALID_TIERS.has(kind))
+    die(`init needs a tier: local|worktree|global|shared (got '${kind}')`);
   const cwd = args.cwd || process.cwd();
   const projectName = getProjectName(cwd);
   const target = candidateStores(cwd, projectName).find((c) => c.kind === kind);
@@ -117,21 +118,28 @@ function cmdInit(args) {
   console.log(`initialized maestro schema store at ${target.dir} (tier=${kind}, ${scopeNote})`);
 }
 
-function cmdSave(args) {
+// Validate the `save` name/tier args and resolve the target store. Dies with
+// the same messages as the inline checks it replaces; returns the store row.
+function resolveSaveTarget(args) {
   const name = args._[0];
   if (!name) die('save needs a <name>');
   if (!NAME_RE.test(name)) die(`name must be kebab-case (got '${name}')`);
   const kind = args.tier;
-  if (!VALID_TIERS.has(kind)) die(`save needs --tier=<local|worktree|global|shared> (got '${kind}')`);
-
+  if (!VALID_TIERS.has(kind)) {
+    die(`save needs --tier=<local|worktree|global|shared> (got '${kind}')`);
+  }
   const cwd = args.cwd || process.cwd();
   const target = discoverStores(cwd).find((s) => s.kind === kind);
   if (!target) {
     die(`no maestro store in tier '${kind}' — run: maestro-schema.js init ${kind}`);
   }
+  return { name, kind, target };
+}
 
-  const file = path.join(target.dir, `${name}.md`);
-  const meta = {
+// Build the frontmatter meta object from save flags. Optional knobs collapse to
+// undefined so serializeFrontmatter omits them.
+function buildSaveMeta(args, name) {
+  return {
     name,
     description: args.description || '',
     pool_size: args.pool !== undefined ? parseInt(args.pool, 10) : undefined,
@@ -141,18 +149,27 @@ function cmdSave(args) {
     compiled_from: args['compiled-from'] || undefined,
     compiled_at: new Date().toISOString().slice(0, 10),
   };
-  const content = serializeFrontmatter(meta, args.body || '');
-  // Exclusive create unless --force: `wx` fails atomically when the schema
-  // already exists, so there is no existsSync-then-write race (CodeQL). With
-  // --force we intentionally overwrite.
+}
+
+// Write the schema file. Exclusive create unless --force: `wx` fails atomically
+// when the schema already exists, so there is no existsSync-then-write race
+// (CodeQL). With --force we intentionally overwrite.
+function writeSchemaFile({ file, content, force, name, kind }) {
   try {
-    fs.writeFileSync(file, content, args.force ? undefined : { flag: 'wx' });
+    fs.writeFileSync(file, content, force ? undefined : { flag: 'wx' });
   } catch (e) {
     if (e.code === 'EEXIST') {
       die(`schema '${name}' already exists in tier '${kind}' (use --force to overwrite)`);
     }
     throw e;
   }
+}
+
+function cmdSave(args) {
+  const { name, kind, target } = resolveSaveTarget(args);
+  const file = path.join(target.dir, `${name}.md`);
+  const content = serializeFrontmatter(buildSaveMeta(args, name), args.body || '');
+  writeSchemaFile({ file, content, force: args.force, name, kind });
   console.log(`saved schema '${name}' to ${file} (tier=${kind})`);
 }
 
@@ -181,7 +198,9 @@ function cmdDelete(args) {
   if (args.tier) hits = hits.filter((h) => h.store === args.tier);
   if (hits.length === 0) die(`no schema '${name}'${args.tier ? ` in tier '${args.tier}'` : ''}`);
   if (hits.length > 1) {
-    die(`schema '${name}' exists in tiers ${hits.map((h) => h.store).join(', ')}; pass --tier to pick one`);
+    die(
+      `schema '${name}' exists in tiers ${hits.map((h) => h.store).join(', ')}; pass --tier to pick one`
+    );
   }
   fs.unlinkSync(hits[0].file);
   console.log(`deleted schema '${name}' (tier=${hits[0].store})`);

--- a/plugins/maestro/scripts/maestro-session.js
+++ b/plugins/maestro/scripts/maestro-session.js
@@ -51,7 +51,7 @@ function sessionPath(topic) {
   return path.join(getSessionDir(), `${topic}.json`);
 }
 
-function init(topic, slots, tasks) {
+function init(topic, slots, tasks, opts = {}) {
   if (!topic || !/^[A-Za-z0-9_.-]+$/.test(topic)) throw new Error(`bad topic: ${topic}`);
   if (!(slots > 0)) throw new Error(`slots must be > 0`);
   if (!tasks.length) throw new Error(`at least one task required`);
@@ -66,6 +66,14 @@ function init(topic, slots, tasks) {
   const session = {
     topic,
     slots,
+    // Per-run launch config. `command` is the skill the bootstrap/auto-restart
+    // path launches (default 'work'); `stopOracle` is the compiled, shell-
+    // executable predicate the conductor evaluates each tick to decide when a
+    // ticket is done. Persisted here (not just env) so a daemon restart can't
+    // silently revert to /work with no stop condition.
+    command: opts.command || 'work',
+    stopOracle: opts.stopOracle || null,
+    stopSource: opts.stopSource || null,
     createdAt: new Date().toISOString(),
     tasks: tasks.map((t) => ({
       id: t.id,
@@ -159,7 +167,17 @@ if (require.main === module) {
   try {
     switch (cmd) {
       case 'init': {
-        const [topic, slotsStr, ...taskSpecs] = args;
+        // Separate `--flag=value` launch config from positional task specs so
+        // the command/oracle can carry shell metacharacters without clashing
+        // with the `id:prio:deps` grammar.
+        const opts = {};
+        const positional = [];
+        for (const a of args) {
+          const m = a.match(/^--([a-z][a-z-]*)=([\s\S]*)$/);
+          if (m) opts[m[1]] = m[2];
+          else positional.push(a);
+        }
+        const [topic, slotsStr, ...taskSpecs] = positional;
         const slots = parseInt(slotsStr, 10);
         const tasks = taskSpecs.map((spec) => {
           const [id, prio, deps] = spec.split(':');
@@ -169,7 +187,17 @@ if (require.main === module) {
             deps: deps ? deps.split(',').filter(Boolean) : [],
           };
         });
-        console.log(JSON.stringify(init(topic, slots, tasks), null, 2));
+        console.log(
+          JSON.stringify(
+            init(topic, slots, tasks, {
+              command: opts.command,
+              stopOracle: opts['stop-oracle'],
+              stopSource: opts['stop-source'],
+            }),
+            null,
+            2
+          )
+        );
         break;
       }
       case 'show':

--- a/plugins/maestro/scripts/maestro-session.js
+++ b/plugins/maestro/scripts/maestro-session.js
@@ -51,17 +51,23 @@ function sessionPath(topic) {
   return path.join(getSessionDir(), `${topic}.json`);
 }
 
-function init(topic, slots, tasks, opts = {}) {
+// Validate the task list shape before persisting: topic/slots/non-empty and
+// every dep referencing a task in the same session. Throws on the first
+// violation (identical messages to the inline checks it replaces).
+function validateInit(topic, slots, tasks) {
   if (!topic || !/^[A-Za-z0-9_.-]+$/.test(topic)) throw new Error(`bad topic: ${topic}`);
   if (!(slots > 0)) throw new Error(`slots must be > 0`);
   if (!tasks.length) throw new Error(`at least one task required`);
-  // Validate dep references — every dep must be a task in the same session.
   const ids = new Set(tasks.map((t) => t.id));
   for (const t of tasks) {
     for (const d of t.deps || []) {
       if (!ids.has(d)) throw new Error(`task ${t.id} depends on unknown ${d}`);
     }
   }
+}
+
+function init(topic, slots, tasks, opts = {}) {
+  validateInit(topic, slots, tasks);
   ensureDir();
   const session = {
     topic,
@@ -148,6 +154,30 @@ function clear(topic) {
   }
 }
 
+// Split CLI `init` argv into launch `--flag=value` opts and positional task
+// specs, then parse the positionals into { topic, slots, tasks }. Extracted
+// from the CLI switch so the dispatcher stays shallow (max-depth gate).
+function parseInitArgs(args) {
+  const opts = {};
+  const positional = [];
+  for (const a of args) {
+    const m = a.match(/^--([a-z][a-z-]*)=([\s\S]*)$/);
+    if (m) opts[m[1]] = m[2];
+    else positional.push(a);
+  }
+  const [topic, slotsStr, ...taskSpecs] = positional;
+  const slots = parseInt(slotsStr, 10);
+  const tasks = taskSpecs.map((spec) => {
+    const [id, prio, deps] = spec.split(':');
+    return {
+      id,
+      priority: parseInt(prio, 10),
+      deps: deps ? deps.split(',').filter(Boolean) : [],
+    };
+  });
+  return { topic, slots, tasks, opts };
+}
+
 module.exports = {
   init,
   read,
@@ -170,23 +200,7 @@ if (require.main === module) {
         // Separate `--flag=value` launch config from positional task specs so
         // the command/oracle can carry shell metacharacters without clashing
         // with the `id:prio:deps` grammar.
-        const opts = {};
-        const positional = [];
-        for (const a of args) {
-          const m = a.match(/^--([a-z][a-z-]*)=([\s\S]*)$/);
-          if (m) opts[m[1]] = m[2];
-          else positional.push(a);
-        }
-        const [topic, slotsStr, ...taskSpecs] = positional;
-        const slots = parseInt(slotsStr, 10);
-        const tasks = taskSpecs.map((spec) => {
-          const [id, prio, deps] = spec.split(':');
-          return {
-            id,
-            priority: parseInt(prio, 10),
-            deps: deps ? deps.split(',').filter(Boolean) : [],
-          };
-        });
+        const { topic, slots, tasks, opts } = parseInitArgs(args);
         console.log(
           JSON.stringify(
             init(topic, slots, tasks, {

--- a/plugins/maestro/skills/orchestrate/SKILL.md
+++ b/plugins/maestro/skills/orchestrate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrate
 description: Orchestrate multiple /work agents in parallel. Use when the user says "orchestrate these tickets", "launch agents", "bootstrap multiple tickets", "run all of these in parallel", "start a swarm", or lists several ticket IDs to work on simultaneously. Creates one tmux session per ticket in its own worktree, auto-restarts silent agents, and surfaces real questions to the operator.
-argument-hint: <ticket-ids...>
+argument-hint: <ticket-ids...> | queue=… [poolSize=N] [command=/X] [stopCondition="…"] [save=name|schema=name]
 user-invocable: true
 allowed-tools: Bash, Read, Write, AskUserQuestion, Skill
 ---
@@ -19,6 +19,75 @@ Run several `/work GH-<N>` agents at once. Each ticket gets its own worktree at 
 Examples:
 - `/orchestrate GH-397 GH-398 GH-414` — bootstrap + launch three agents in parallel
 - `/orchestrate 397 398` — bare numbers are accepted; project key is prepended
+
+## Parameterized form (queue / pool / command / stopCondition / schema)
+
+```
+/maestro:orchestrate queue=5915,5956,5945 poolSize=1 command=/qc-work \
+    stopCondition="when /follow-up skill says that it passed" save=opera1
+/maestro:orchestrate queue=5915,5956,5945 poolSize=1 schema=opera1
+```
+
+| Param | Meaning |
+|---|---|
+| `queue=` | Comma-separated ticket ids (bare numbers get the project prefix). Per-run; NEVER saved into a schema. |
+| `poolSize=` | Max concurrent `-work` sessions (manifest `slots`). The conductor tops the pool up from the queue as slots free (needs `AUTO_BOOTSTRAP_NEXT=1`). |
+| `command=` | The skill each queued ticket runs (e.g. `/qc-work`). Whitelisted skills (`work`, `follow-up`) run as-is; ANY other command is allowed ONLY when a `stopCondition` is also given (it then runs under a generic conductor row — the oracle, not a bespoke registry row, defines "done"). |
+| `stopCondition=` | Natural-language completion condition. The skill COMPILES it once into a deterministic shell oracle (see below). The daemon then evaluates that oracle every tick; exit 0 ⇒ the agent is done ⇒ kill + free slot + bootstrap the next queued ticket. |
+| `save=` | After compiling, persist `{poolSize, command, stopCondition.oracle}` as a reusable named schema (synapsys-style store). `queue` is excluded. |
+| `schema=` | Load a saved schema's `poolSize`/`command`/`oracle`; combine with this run's `queue=`. Explicit CLI params override the schema (warn on conflict). The pinned oracle is reused as-is unless `recompile=true`. |
+
+### Compiling `stopCondition` into an oracle (LLM, once — never at eval time)
+
+The constraint is hard: **the daemon must NEVER call an LLM to judge "is it done".** So you (the skill) translate the prose into a shell predicate up front:
+
+1. Parse the named skill from the condition (e.g. `/follow-up`).
+2. Locate its runnable script and a machine-readable verdict — exit code, JSON field, or marker file. For `/follow-up`: `follow-up-next.js` reaches `action:'complete'` (state `complete`) only after re-verifying the PR is mergeable, CI green, comments resolved. Compile to:
+   ```sh
+   node "$FOLLOWUP/follow-up-next.js" "$TICKET" --json | jq -e '.action=="complete"'
+   ```
+   (`$TICKET` and `$WORKTREE` are injected into the oracle's env by the conductor — do not interpolate them into the command string.)
+3. The oracle must exit 0 iff done, non-zero otherwise. Keep it cheap (runs every tick × every session).
+4. **Refuse to compile** if the named skill exposes no deterministic verdict (pure-LLM skill). Surface via `AskUserQuestion`: "give me a shell predicate, or pick another condition" — do NOT emit an oracle that would need LLM evaluation.
+
+### Saving / reusing schemas (synapsys-mirrored store)
+
+Schemas persist as one markdown-with-frontmatter file per name in a tiered, marker-gated store (`local`/`worktree`/`global`/`shared`), exactly like synapsys memories. CLI: `node scripts/maestro-schema.js {init|save|list|show|delete}`.
+
+- **No default tier.** When `save=` (or any store write) needs a tier and none was passed, `AskUserQuestion` to pick — recommend `worktree` when `git worktree list` shows >1 entry, else `local`; offer `global` (per-project) and `shared` (reused across ALL projects). If the chosen tier has no store yet, run `maestro-schema.js init <tier>` first (idempotent).
+- **`save=opera1`** → compile the oracle, then `maestro-schema.js save opera1 --tier=<kind> --pool=N --command=/qc-work --stop-source="…" --stop-oracle='…' --compiled-from='follow-up@<ver> (follow-up-next.js)'`. Show a one-time note that the oracle runs as shell on every tick.
+- **`schema=opera1`** → `maestro-schema.js show opera1`. If the name exists in >1 tier, `AskUserQuestion` to disambiguate. Reuse the pinned oracle as-is.
+- **`schema=` omitted but reuse wanted** → `maestro-schema.js list` → `AskUserQuestion` menu of saved schemas.
+
+### Managing saved schemas
+
+These are management-only commands (no `queue` needed) — invoked when the user asks to see or remove saved schemas:
+
+| Intent | Action |
+|---|---|
+| "list schemas" / "what schemas do I have" | `node scripts/maestro-schema.js list` → render name, tier, poolSize, command, stopSource per row |
+| "show opera1" | `node scripts/maestro-schema.js show opera1` (errors if the name exists in >1 tier) |
+| "delete opera1" / "forget that schema" | `node scripts/maestro-schema.js delete opera1` — if it exists in >1 tier, pass `--tier=<kind>`. Confirm before deleting (it is permanent; mirror synapsys's never-`rm`-without-ack posture). |
+
+When the user says "delete a schema" without naming one, `list` first, then `AskUserQuestion` with the names, then `delete` the chosen one.
+
+### Launching a parameterized run
+
+Seed the manifest with the command + compiled oracle so a daemon restart can't revert to `/work`:
+
+```
+node scripts/maestro-session.js init <topic> <poolSize> \
+    --command=<cmd> --stop-oracle='<oracle>' --stop-source='<prose>' \
+    5915:1 5956:2 5945:3 …
+```
+
+Then bootstrap the first `poolSize` tickets, passing the command and (for a non-whitelisted command) `--allow-generic` so the whitelist is relaxed for the oracle-backed launch:
+
+```
+bash scripts/maestro-bootstrap.sh --skill=qc-work --allow-generic 5915
+```
+
+`--allow-generic` is required only for commands outside the `work`/`follow-up` whitelist; it accepts any regex-valid skill name and persists it to the per-ticket `.maestro-skill` file that the conductor reads on restart. Finally start the daemon with `AUTO_BOOTSTRAP_NEXT=1` so it tops the pool up from the queue as each ticket's oracle frees a slot.
 
 ## What it does
 
@@ -54,6 +123,7 @@ The .js daemon emits exactly these event kinds. Anything else is bookkeeping noi
 | `nudges-exhausted` | `ACTION … kind=nudges-exhausted` | `handlePhaseStall` | One alert per phase, until phase advances |
 | `pr-comments-stuck` | `ACTION … kind=pr-comments-stuck` | `handlePrComments` | One alert until comment count or HEAD changes |
 | `commit-stall NNNm` | `<S> commit-stall NNNm in phase=… (threshold=TTTm)` | `runCommitStallDetector` | **Threshold-only**: emits at `[30, 60, 120, 240, 480]` minutes, at most 5 lines per stall |
+| `stop-condition-met` | `ACTION … kind=stop-condition-met oracle=…` + `<S> STOP-CONDITION-MET — tmux killed, slot freed` | `stop-condition.maybeStopOnOracle` → `actions.freeStopConditionSlot` | Once per ticket lifecycle (`stop-condition` marker); ticket marked `done` |
 | `HEARTBEAT N active, X pr-ready, Y pr-broken, Z pr-pending, W wedged ‖ …` | log-only | `maybeEmitHeartbeat` (main loop) | Once per `HEARTBEAT_MIN` (default 30m); always emits even when nothing else changed |
 
 ## Recommended Monitor filter
@@ -61,10 +131,10 @@ The .js daemon emits exactly these event kinds. Anything else is bookkeeping noi
 Use this exact regex. Anything outside it is noise:
 
 ```
-QUESTION-DETECTED|AUTO-RESTART|SESSION-GONE|NUDGE|ACTION|pr-ready|pr-broken|wedged|WEDGED|HEARTBEAT|commit-stall
+QUESTION-DETECTED|AUTO-RESTART|SESSION-GONE|NUDGE|ACTION|pr-ready|pr-broken|stop-condition-met|wedged|WEDGED|HEARTBEAT|commit-stall
 ```
 
-`pr-ready` is the **positive** signal — when you see it, the agent's PR is CLEAN and all checks are green; merge it (or hold per `[[never-auto-merge-pr]]`). `wedged` is the **escalation** signal — auto-restart loop hit its cap; operator must inspect. `HEARTBEAT` is the periodic forced re-read; never ignore it.
+`stop-condition-met` is a **positive** signal — the ticket's compiled oracle exited 0, the agent finished, its slot was freed and the next queued ticket bootstrapped. `pr-ready` is the **positive** signal — when you see it, the agent's PR is CLEAN and all checks are green; merge it (or hold per `[[never-auto-merge-pr]]`). `wedged` is the **escalation** signal — auto-restart loop hit its cap; operator must inspect. `HEARTBEAT` is the periodic forced re-read; never ignore it.
 
 ## Env
 
@@ -82,6 +152,9 @@ QUESTION-DETECTED|AUTO-RESTART|SESSION-GONE|NUDGE|ACTION|pr-ready|pr-broken|wedg
 | `RESTART_WINDOW_MIN` | 30 | Rolling window for restart-loop counter |
 | `WEDGED_QUIET_MIN` | 60 | How long to suppress restarts after WEDGED |
 | `HEARTBEAT_MIN` | 30 | Heartbeat cadence |
+| `ORACLE_TIMEOUT_MS` | 30000 | Per-tick wall-clock budget for a stopCondition oracle |
+| `AUTO_FREE_STOP_CONDITION` | (on) | Set `0` to disable stop-condition kill/rotate |
+| `AUTO_BOOTSTRAP_NEXT` | (off) | Set `1` so the conductor tops the pool up from the queue |
 
 ## After launch
 


### PR DESCRIPTION
## Existing Behavior

- `/maestro:orchestrate` had no parameters; queue size, pool size, and command were hardcoded or absent.
- No stop-condition mechanism existed; the conductor had no way to detect completion and rotate to the next queued task without a model call.
- Generic (non-whitelisted) commands were not gated by an oracle before execution.
- Manifest state (command, stop oracle) was not persisted across daemon restarts.
- Schema storage was ad-hoc with no reusable, tiered structure.

## Intended New Behavior

- `/maestro:orchestrate` now accepts `queue`, `poolSize`, and `command` parameters, enabling fully parameterized orchestration runs.
- A natural-language `stopCondition` is compiled once into a deterministic shell oracle; the conductor evaluates it each tick (exit 0 = done → kill agent + rotate to next queued) with no model call at evaluation time.
- Oracle-gated generic skills prevent non-whitelisted commands from running without a validated stop oracle.
- `command` and `stopOracle` are written to the manifest, ensuring durability across daemon restarts.
- A reusable synapsys-style tiered schema store (`maestro-schema.js`) exposes `init / save / list / show / delete` with no default tier, matching the existing synapsys storage conventions.
- 16 new tests added; full maestro suite is green at 122 tests.

## Dev Checks

- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Notes

No related GitHub issue — this is operator-initiated work.

## Testing Plan / Demo

1. Invoke `/maestro:orchestrate` with explicit parameters, e.g. `queue=3 poolSize=2 command="pnpm test" stopCondition="exit code 0"`, and confirm agents are bootstrapped up to `poolSize`, remaining tasks queued.
2. Verify the compiled shell oracle is written to the manifest (`cat <manifest-path>` and inspect `stopOracle` field).
3. Simulate a daemon restart and confirm `command` and `stopOracle` are restored from the manifest without re-compilation.
4. Trigger a non-whitelisted command and confirm the oracle gate blocks execution until the stop oracle is validated.
5. Let an agent complete; confirm the conductor detects exit 0 from the oracle, kills the finished agent, and rotates the next queued task into the pool.
6. Run the full maestro test suite and confirm 122 tests pass: `pnpm test -- --grep maestro` (or equivalent).

### Test Results

16 new tests added; full maestro suite green at 122.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Conductor now executes operator-authored shell oracles every tick and can kill sessions and rotate pool slots; miscompiled or malicious oracles and ordering vs auto-restart affect live tmux agents.
> 
> **Overview**
> **Parameterized orchestrate** gains `queue`, `poolSize`, `command`, `stopCondition`, `save`, and `schema` flows: session manifests now persist `command`, `stopOracle`, and `stopSource`; bootstrap accepts `--allow-generic` for regex-valid non-whitelisted skills when an oracle backs the run.
> 
> **Stop conditions** compile once to a shell oracle (skill docs); each tick `stop-condition.maybeStopOnOracle` runs it via `bash -c` (fail-safe on error/timeout) and, on exit 0, `freeStopConditionSlot` kills tmux, marks the task `done`, and can auto-bootstrap the next queue entry—**before** silence auto-restart so finished agents are not relaunched.
> 
> **Oracle-gated generics (GH-514):** `isAllowedSkill` / generic registry rows allow unknown commands only with `{ hasOracle: true }`; restart guards pass manifest oracle into skill resolution so `.maestro-skill` and relaunch stay aligned.
> 
> **Reusable schemas:** new `lib/schema-store.js` (tiered, marker-gated markdown frontmatter) and `maestro-schema.js` (`init|save|list|show|delete`).
> 
> Refactors move restart guards, heartbeat emission, and halted-waiting patterns out of `actions.js` / `maestro-conduct.js`; autorestart tests pin `STATE_DIR` to avoid flaky wedged loops. New unit tests cover schema store, generic skill registry, and stop-condition behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 689d30055872468da11473986a3740eda708ff27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->