### PR TITLE
feat(maestro): namespace mismatch guard, quoting hardening, operator docs (GH-622 follow-up)

### DIFF
--- a/plugins/maestro/docs/OPERATOR_PLAYBOOK.md
+++ b/plugins/maestro/docs/OPERATOR_PLAYBOOK.md
@@ -136,6 +136,46 @@ over the NS-derived default if you need to pin a single sink.
 > Unset `MAESTRO_NS` reproduces the historical machine-global behaviour exactly,
 > so existing single-project setups need no change.
 
+### The inbox channel — keep both halves on the same namespace
+
+The mailbox is a **human coordination channel**, not an agent pipe. For the
+agent's listener and your `/signal` to meet, both must resolve the **same**
+inbox dir. Under maestro orchestration this is automatic — bootstrap exports
+`CLAUDE_AGENT_INBOX_DIR=/tmp/claude-agent-inbox/<ns>` into the agent (and the
+`-listen` pane), and your operator shell resolves the same path from `MAESTRO_NS`
+in `.envrc`.
+
+> **The one footgun:** a *mismatched* config inside what should be one namespace.
+> If the agent runs under `MAESTRO_NS=proj-a` but you run `/signal` from a shell
+> where `MAESTRO_NS` is unset, the signal lands in the global dir, the agent tails
+> `proj-a/`, and the message is **silently dropped**. `/signal` now detects this:
+> when it finds **0 listeners** but an agent session for that channel exists under
+> a different namespace, it prints a `⚠️` pointing at the namespace to set. Heed it.
+>
+> Mitigation: put `MAESTRO_NS` (and, for **standalone `/work`** launched outside
+> maestro, `CLAUDE_AGENT_INBOX_DIR=/tmp/claude-agent-inbox/$MAESTRO_NS`) in each
+> project's `.envrc` so every shell — orchestrator, agent, and operator — agrees.
+
+**Coordination vs isolation, decided by the namespace:**
+
+- **Agents must coordinate?** Keep them in the **same** namespace (or both unset →
+  global, or point both at the same `MAESTRO_INBOX_DIR`).
+- **Agents must be walled off?** Give them **different** namespaces — exactly what
+  this delivers. (Cross-*project* coordination is explicitly out of scope; maestro
+  isolates, it does not bridge namespaces.)
+
+### Known limitation — `-dev` / check-agent sessions are not namespaced
+
+Only the sessions maestro owns (`-work`, `-listen`) and the resources it writes
+carry the namespace. The `<ticket>-dev` and `<ticket>-<agent>` (e.g.
+`<ticket>-code-checker`) tmux sessions are created by an **external operator
+convention**, not by either plugin — `check-gate.js`/`cleanup.js`/`inspect.js`
+only *check or kill* them by their bare names. Prefixing those references would
+break the match, so they stay bare. Practical impact under `MAESTRO_NS`: if you
+run the **same ticket number** concurrently across two repos, those helper
+sessions can alias. Avoid by giving concurrent batches distinct ticket-number
+ranges (or distinct prefixes), which the rest of the isolation already assumes.
+
 ## When you're unsure
 
 Ask the operator. Do not invent state. Do not edit `.work-state.json` directly. Do not call `work-state.js set-step`. Those are bypass attempts and the next bypass-check will catch them.

--- a/plugins/maestro/scripts/__tests__/maestro-signal-mismatch.test.js
+++ b/plugins/maestro/scripts/__tests__/maestro-signal-mismatch.test.js
@@ -42,7 +42,7 @@ test('no warning when no session matches the channel', () => {
   assert.equal(w, null);
 });
 
-test('warns the other way: namespaced signaler, agent in global (or another ns)', () => {
+test('namespaced signaler, agent in GLOBAL ns → tells operator to UNSET MAESTRO_NS', () => {
   const w = buildMismatchWarning({
     channel: 'ECHO-7',
     inboxDir: '/tmp/claude-agent-inbox/proj-b',
@@ -51,7 +51,10 @@ test('warns the other way: namespaced signaler, agent in global (or another ns)'
   });
   assert.ok(w);
   assert.match(w, /ECHO-7-work/);
-  assert.match(w, /<their-namespace>/); // global session has no ns segment
+  // The fix for a global agent is to unset — NOT "set MAESTRO_NS=<placeholder>".
+  assert.match(w, /unset MAESTRO_NS/);
+  assert.doesNotMatch(w, /set MAESTRO_NS=/);
+  assert.doesNotMatch(w, /<their-namespace>/);
 });
 
 test('channel with regex-special chars is matched literally (no injection)', () => {

--- a/plugins/maestro/scripts/__tests__/maestro-signal-mismatch.test.js
+++ b/plugins/maestro/scripts/__tests__/maestro-signal-mismatch.test.js
@@ -57,6 +57,28 @@ test('namespaced signaler, agent in GLOBAL ns → tells operator to UNSET MAESTR
   assert.doesNotMatch(w, /<their-namespace>/);
 });
 
+test('no false warning when our-namespace -work exists alongside a bare global -dev', () => {
+  // Regression: a bare <ticket>-dev (un-namespaced by design) must NOT trigger a
+  // mismatch when the operator's MAESTRO_NS already matches the -work session.
+  const w = buildMismatchWarning({
+    channel: 'GH-42',
+    inboxDir: '/tmp/claude-agent-inbox/proj-a',
+    ownNs: 'proj-a',
+    sessionNames: ['proj-a/GH-42-work', 'GH-42-dev'],
+  });
+  assert.equal(w, null);
+});
+
+test('-dev sessions are ignored entirely (never the basis for a warning)', () => {
+  const w = buildMismatchWarning({
+    channel: 'GH-42',
+    inboxDir: '/tmp/claude-agent-inbox',
+    ownNs: '',
+    sessionNames: ['proj-a/GH-42-dev'], // only a dev session, in another ns
+  });
+  assert.equal(w, null);
+});
+
 test('channel with regex-special chars is matched literally (no injection)', () => {
   const w = buildMismatchWarning({
     channel: 'GH-1.0',

--- a/plugins/maestro/scripts/__tests__/maestro-signal-mismatch.test.js
+++ b/plugins/maestro/scripts/__tests__/maestro-signal-mismatch.test.js
@@ -1,0 +1,65 @@
+// maestro-signal.js footgun guard (GH-622 follow-up): a /signal that finds no
+// listener must warn LOUDLY when the agent is running under a different
+// namespace, instead of silently dropping the message.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { buildMismatchWarning } = require(path.resolve(__dirname, '..', 'maestro-signal.js'));
+
+test('warns when an agent for the channel runs under a different namespace', () => {
+  const w = buildMismatchWarning({
+    channel: 'GH-42',
+    inboxDir: '/tmp/claude-agent-inbox',
+    ownNs: '', // signaling from a global/unnamespaced shell
+    sessionNames: ['proj-a/GH-42-work', 'proj-a/GH-42-listen', 'maestro-alerts'],
+  });
+  assert.ok(w, 'expected a warning');
+  assert.match(w, /different namespace/);
+  assert.match(w, /proj-a\/GH-42-work/);
+  assert.match(w, /set MAESTRO_NS=proj-a/);
+});
+
+test('no warning when the matching session is in OUR namespace', () => {
+  const w = buildMismatchWarning({
+    channel: 'GH-42',
+    inboxDir: '/tmp/claude-agent-inbox/proj-a',
+    ownNs: 'proj-a',
+    sessionNames: ['proj-a/GH-42-work'], // same namespace — just no -listen pane
+  });
+  assert.equal(w, null);
+});
+
+test('no warning when no session matches the channel', () => {
+  const w = buildMismatchWarning({
+    channel: 'GH-99',
+    inboxDir: '/tmp/claude-agent-inbox',
+    ownNs: '',
+    sessionNames: ['proj-a/GH-42-work', 'unrelated'],
+  });
+  assert.equal(w, null);
+});
+
+test('warns the other way: namespaced signaler, agent in global (or another ns)', () => {
+  const w = buildMismatchWarning({
+    channel: 'ECHO-7',
+    inboxDir: '/tmp/claude-agent-inbox/proj-b',
+    ownNs: 'proj-b',
+    sessionNames: ['ECHO-7-work'], // bare = global namespace ≠ proj-b
+  });
+  assert.ok(w);
+  assert.match(w, /ECHO-7-work/);
+  assert.match(w, /<their-namespace>/); // global session has no ns segment
+});
+
+test('channel with regex-special chars is matched literally (no injection)', () => {
+  const w = buildMismatchWarning({
+    channel: 'GH-1.0',
+    inboxDir: '/tmp/claude-agent-inbox',
+    ownNs: '',
+    sessionNames: ['proj-a/GH-1X0-work'], // '.' must NOT match 'X'
+  });
+  assert.equal(w, null);
+});

--- a/plugins/maestro/scripts/maestro-signal.js
+++ b/plugins/maestro/scripts/maestro-signal.js
@@ -55,13 +55,17 @@ function buildMismatchWarning({ channel, inboxDir, ownNs, sessionNames }) {
   const re = new RegExp(`(?:^|/)${escapeRe(channel)}-(work|listen|dev)$`);
   const elsewhere = (sessionNames || []).filter((s) => re.test(s) && sessionNsOf(s) !== ownNs);
   if (!elsewhere.length) return null;
-  const theirNs = sessionNsOf(elsewhere[0]) || '<their-namespace>';
+  const theirNs = sessionNsOf(elsewhere[0]);
   const here = ownNs ? `MAESTRO_NS=${ownNs}` : 'the global';
+  // The agent's side dictates the fix: a namespaced agent → set MAESTRO_NS to it;
+  // a bare (global) agent → UNSET MAESTRO_NS so /signal uses the global mailbox.
+  const fix = theirNs
+    ? `set MAESTRO_NS=${theirNs} (e.g. in .envrc)`
+    : 'unset MAESTRO_NS so /signal uses the global mailbox';
   return (
     `⚠️  0 listeners on ${inboxDir}, but agent session(s) exist in a different namespace: ` +
     `${elsewhere.join(', ')}.\n   This signal went to ${here} mailbox and will NOT reach them. ` +
-    `Align namespaces — set MAESTRO_NS=${theirNs} (e.g. in .envrc), or point both halves at one ` +
-    `CLAUDE_AGENT_INBOX_DIR / MAESTRO_INBOX_DIR.`
+    `Align namespaces — ${fix}, or point both halves at one CLAUDE_AGENT_INBOX_DIR / MAESTRO_INBOX_DIR.`
   );
 }
 

--- a/plugins/maestro/scripts/maestro-signal.js
+++ b/plugins/maestro/scripts/maestro-signal.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// maestro-signal.js — append a line to /tmp/claude-agent-inbox/<CHANNEL>.log
+// maestro-signal.js — append a line to <inbox>/<CHANNEL>.log
 //
 // Usage: node maestro-signal.js <CHANNEL> <message...>
 //
@@ -12,14 +12,15 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { INBOX_DIR, validateChannelOrExit, ensureChannelFile } = require('../lib/inbox');
+const namespace = require('./lib/maestro-conduct/namespace');
 
 function listListeners(channel) {
   // Best-effort: list pids holding <inbox>/<channel>.log open. Use spawnSync
   // argv (no shell) so the INBOX_DIR path (which can carry MAESTRO_NS) and the
   // channel can never be interpreted by a shell (js/indirect-command-line-injection).
   try {
-    const { spawnSync } = require('node:child_process');
     const res = spawnSync('lsof', ['-t', path.join(INBOX_DIR, `${channel}.log`)], {
       encoding: 'utf8',
       timeout: 2000,
@@ -27,6 +28,53 @@ function listListeners(channel) {
     const out = (res.stdout || '').trim();
     if (!out) return [];
     return out.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+// Namespace segment of a tmux session name: "proj-a/GH-42-work" → "proj-a";
+// a bare "GH-42-work" → "" (global).
+function sessionNsOf(name) {
+  const i = name.indexOf('/');
+  return i >= 0 ? name.slice(0, i) : '';
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * GH-622 footgun guard (pure): when a signal finds NO listener on the resolved
+ * mailbox, warn if an agent session for this channel is running under a
+ * DIFFERENT namespace — that is the silent-drop case (operator's MAESTRO_NS
+ * doesn't match the agent's, so the message lands in the wrong dir). Returns the
+ * warning string, or null when there's nothing to flag.
+ */
+function buildMismatchWarning({ channel, inboxDir, ownNs, sessionNames }) {
+  const re = new RegExp(`(?:^|/)${escapeRe(channel)}-(work|listen|dev)$`);
+  const elsewhere = (sessionNames || []).filter((s) => re.test(s) && sessionNsOf(s) !== ownNs);
+  if (!elsewhere.length) return null;
+  const theirNs = sessionNsOf(elsewhere[0]) || '<their-namespace>';
+  const here = ownNs ? `MAESTRO_NS=${ownNs}` : 'the global';
+  return (
+    `⚠️  0 listeners on ${inboxDir}, but agent session(s) exist in a different namespace: ` +
+    `${elsewhere.join(', ')}.\n   This signal went to ${here} mailbox and will NOT reach them. ` +
+    `Align namespaces — set MAESTRO_NS=${theirNs} (e.g. in .envrc), or point both halves at one ` +
+    `CLAUDE_AGENT_INBOX_DIR / MAESTRO_INBOX_DIR.`
+  );
+}
+
+function tmuxSessionNames() {
+  try {
+    const res = spawnSync('tmux', ['ls', '-F', '#{session_name}'], {
+      encoding: 'utf8',
+      timeout: 2000,
+    });
+    return (res.stdout || '')
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
   } catch {
     return [];
   }
@@ -46,6 +94,17 @@ function main() {
   process.stdout.write(
     `sent → ${file} (${pids.length} listener(s)${pids.length ? `, pids: ${pids.join(', ')}` : ''})\n`
   );
+  if (pids.length === 0) {
+    const warn = buildMismatchWarning({
+      channel,
+      inboxDir: INBOX_DIR,
+      ownNs: namespace.ns(),
+      sessionNames: tmuxSessionNames(),
+    });
+    if (warn) process.stderr.write(`${warn}\n`);
+  }
 }
 
-main();
+if (require.main === module) main();
+
+module.exports = { buildMismatchWarning, sessionNsOf };

--- a/plugins/maestro/scripts/maestro-signal.js
+++ b/plugins/maestro/scripts/maestro-signal.js
@@ -52,10 +52,16 @@ function escapeRe(s) {
  * warning string, or null when there's nothing to flag.
  */
 function buildMismatchWarning({ channel, inboxDir, ownNs, sessionNames }) {
-  const re = new RegExp(`(?:^|/)${escapeRe(channel)}-(work|listen|dev)$`);
-  const elsewhere = (sessionNames || []).filter((s) => re.test(s) && sessionNsOf(s) !== ownNs);
-  if (!elsewhere.length) return null;
-  const theirNs = sessionNsOf(elsewhere[0]);
+  // Only -work / -listen carry the namespace and correlate with the mailbox.
+  // -dev is intentionally un-namespaced (a separate known limitation) and says
+  // nothing about which inbox the agent uses, so it must not trigger a warning.
+  const re = new RegExp(`(?:^|/)${escapeRe(channel)}-(work|listen)$`);
+  const matches = (sessionNames || []).filter((s) => re.test(s));
+  // If a channel session already lives in OUR namespace the operator is aligned
+  // with the agent — 0 listeners then just means no -listen pane, not a wrong
+  // mailbox — so don't cry mismatch on an unrelated session in another namespace.
+  if (!matches.length || matches.some((s) => sessionNsOf(s) === ownNs)) return null;
+  const theirNs = sessionNsOf(matches[0]);
   const here = ownNs ? `MAESTRO_NS=${ownNs}` : 'the global';
   // The agent's side dictates the fix: a namespaced agent → set MAESTRO_NS to it;
   // a bare (global) agent → UNSET MAESTRO_NS so /signal uses the global mailbox.
@@ -64,7 +70,7 @@ function buildMismatchWarning({ channel, inboxDir, ownNs, sessionNames }) {
     : 'unset MAESTRO_NS so /signal uses the global mailbox';
   return (
     `⚠️  0 listeners on ${inboxDir}, but agent session(s) exist in a different namespace: ` +
-    `${elsewhere.join(', ')}.\n   This signal went to ${here} mailbox and will NOT reach them. ` +
+    `${matches.join(', ')}.\n   This signal went to ${here} mailbox and will NOT reach them. ` +
     `Align namespaces — ${fix}, or point both halves at one CLAUDE_AGENT_INBOX_DIR / MAESTRO_INBOX_DIR.`
   );
 }

--- a/plugins/work/open-channel.md
+++ b/plugins/work/open-channel.md
@@ -19,9 +19,15 @@ SESS="${NS_SEG}${TICKET}-listen"
 # GH-622: a new tmux session doesn't inherit this shell's env, so forward
 # CLAUDE_AGENT_INBOX_DIR (set by maestro-bootstrap under a namespace) into the
 # listener command — else it tails the global mailbox while maestro /signal uses
-# the per-namespace one. Empty when unset (standalone /work).
+# the per-namespace one. Empty when unset (standalone /work). Single quotes in
+# the value are escaped ('\'') so a quoted path can't break out of the assignment.
+INBOX_FWD=""
+if [ -n "${CLAUDE_AGENT_INBOX_DIR:-}" ]; then
+  _esc=${CLAUDE_AGENT_INBOX_DIR//\'/\'\\\'\'}
+  INBOX_FWD="CLAUDE_AGENT_INBOX_DIR='${_esc}' "
+fi
 tmux has-session -t "$SESS" 2>/dev/null || \
-  tmux new-session -d -s "$SESS" "${CLAUDE_AGENT_INBOX_DIR:+CLAUDE_AGENT_INBOX_DIR='${CLAUDE_AGENT_INBOX_DIR}' }exec node ${CLAUDE_PLUGIN_ROOT}/scripts/listen-all.js"
+  tmux new-session -d -s "$SESS" "${INBOX_FWD}exec node ${CLAUDE_PLUGIN_ROOT}/scripts/listen-all.js"
 tmux list-sessions | grep "$SESS"
 ```
 

--- a/plugins/work/skills/work/SKILL.md
+++ b/plugins/work/skills/work/SKILL.md
@@ -44,9 +44,16 @@ LISTEN_SESSION="${NS_SEG}${ARGUMENTS%% *}-listen"
 # CLAUDE_AGENT_INBOX_DIR (set by maestro-bootstrap under a namespace) into the
 # listener's command — otherwise it tails the global mailbox while maestro
 # /signal uses the per-namespace one. Empty when unset (standalone /work).
+# Single quotes in the value are escaped ('\'') so an inbox path containing a
+# quote can't break out of the single-quoted assignment.
+INBOX_FWD=""
+if [ -n "${CLAUDE_AGENT_INBOX_DIR:-}" ]; then
+  _esc=${CLAUDE_AGENT_INBOX_DIR//\'/\'\\\'\'}
+  INBOX_FWD="CLAUDE_AGENT_INBOX_DIR='${_esc}' "
+fi
 if ! tmux has-session -t "$LISTEN_SESSION" 2>/dev/null; then
   tmux new-session -d -s "$LISTEN_SESSION" \
-    "${CLAUDE_AGENT_INBOX_DIR:+CLAUDE_AGENT_INBOX_DIR='${CLAUDE_AGENT_INBOX_DIR}' }node \"${CLAUDE_PLUGIN_ROOT}/scripts/listen-communication.js\" ${ARGUMENTS%% *}"
+    "${INBOX_FWD}node \"${CLAUDE_PLUGIN_ROOT}/scripts/listen-communication.js\" ${ARGUMENTS%% *}"
   echo "  ✓ listener started: tmux session $LISTEN_SESSION"
 else
   echo "  ✓ listener already running: tmux session $LISTEN_SESSION"


### PR DESCRIPTION
## Existing Behavior

- `maestro-signal.js` silently drops messages when the operator's `MAESTRO_NS` differs from the agent's: the signal lands in the wrong inbox dir with no warning or error.
- The listener-forwarding blocks in `SKILL.md` and `open-channel.md` use an unescaped bash parameter expansion that breaks if `CLAUDE_AGENT_INBOX_DIR` contains a single quote.
- `OPERATOR_PLAYBOOK.md` has no guidance on inbox-channel coordination, namespace mismatch footguns, or the known limitation of unnamespaced `-dev`/check-agent tmux sessions.

## Intended New Behavior

- `maestro-signal.js` detects the silent-drop case: when `/signal` finds 0 listeners but an agent session for that channel exists under a different namespace, it prints a `⚠️` to stderr naming the mismatched session(s) and the `MAESTRO_NS` to set. The pure detection function `buildMismatchWarning()` is exported and covered by 5 unit tests; channel matching uses literal string escaping (no regex injection).
- The listener-forwarding blocks in `SKILL.md` and `open-channel.md` now single-quote-escape `CLAUDE_AGENT_INBOX_DIR` via `${var//\'/\'\\\'\'}` before injecting it into the tmux command, so a quoted path cannot break out of the assignment.
- `OPERATOR_PLAYBOOK.md` gains an inbox-channel subsection covering: the footgun and `/signal` warning, `.envrc` mitigation (including `CLAUDE_AGENT_INBOX_DIR` for standalone `/work`), coordination-vs-isolation semantics (same namespace to coordinate, different to wall off; cross-project bridging is out of scope by design), and a documented known limitation that `-dev`/check-agent sessions are not namespaced because they have no plugin-controlled creation site — mitigate with distinct ticket-number ranges across concurrent same-machine batches.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Mismatch warning (backend behaviour):**

1. Start an agent under a namespace so a tmux session named `proj-a/GH-42-work` exists.
2. From a shell where `MAESTRO_NS` is unset, run `/signal GH-42 hello`.
3. Observe on stderr: `⚠️  0 listeners on /tmp/claude-agent-inbox, but agent session(s) exist in a different namespace: proj-a/GH-42-work. ... set MAESTRO_NS=proj-a`. No silent drop.

**Unit tests:**

```bash
node --test plugins/maestro/scripts/__tests__/maestro-signal-mismatch.test.js
```

5 cases: warning path, no-warning paths (same namespace, no matching session), reverse mismatch (namespaced signaler / global agent), and literal channel matching (`.` must not regex-match `X` in `GH-1.0` vs `GH-1X0`).

**Quoting hardening:**

Set `CLAUDE_AGENT_INBOX_DIR` to a path containing a single quote (e.g. `/tmp/it's-inbox`) and run the listener-start block from `SKILL.md` or `open-channel.md`. The tmux command launches correctly without a shell syntax error.

**Quality gate:** eslint passes clean; 148 maestro tests pass.

**Related:** GH-622 (per-namespace maestro isolation, shipped in #623).

### Test Results

148 maestro tests pass. 5 new unit tests for `buildMismatchWarning()` covering all mismatch and no-warning branches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operator-facing diagnostics and shell quoting/docs only; signal delivery behavior is unchanged except for new warnings when listeners are absent.
> 
> **Overview**
> Follow-up to per-namespace maestro isolation: **`/signal` no longer fails silently** when the operator’s mailbox dir doesn’t match the agent’s. After appending, if `lsof` finds **0 listeners**, `maestro-signal.js` lists tmux sessions and runs **`buildMismatchWarning()`** — it only considers `*-work` / `*-listen` (not `-dev`), escapes channel names for regex safety, and prints a **`⚠️` on stderr** with whether to **`set MAESTRO_NS`** or **`unset MAESTRO_NS`**. The helper is exported for tests.
> 
> **Listener bootstrap** in `work/SKILL.md` and `open-channel.md` now builds `INBOX_FWD` with **single-quote escaping** on `CLAUDE_AGENT_INBOX_DIR` before starting the tmux listener, so odd inbox paths can’t break the shell assignment.
> 
> **`OPERATOR_PLAYBOOK.md`** adds inbox/namespace coordination guidance (the mismatch footgun and `/signal` warning, `.envrc` alignment, same vs different namespace semantics) and documents that **`-dev` / check-agent tmux sessions stay un-namespaced** and can alias across concurrent same-ticket batches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb6363cf675dd6dc876acdb211a1c2b2af430250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->