### PR TITLE
fix(check): QA validator no longer requires Playwright for no-web-app projects (#280)

### DIFF
--- a/plugins/work/scripts/workflows/check/hooks/__tests__/check-validate-reports.integration.test.js
+++ b/plugins/work/scripts/workflows/check/hooks/__tests__/check-validate-reports.integration.test.js
@@ -6,7 +6,8 @@ const os = require('os');
 const { spawnSync } = require('child_process');
 
 const SCRIPT = path.resolve(__dirname, '..', 'check-validate-reports.js');
-const TEMP = path.join(os.tmpdir(), 'check-validate-reports-integ-' + process.pid);
+// Created with mkdtempSync in before() so the path is unpredictable (js/insecure-temporary-file).
+let TEMP;
 
 /** QA report missing Playwright section + screenshots, with standard markers. */
 function buildQAReportNoPlaywright(statusToken) {
@@ -40,7 +41,7 @@ function runCli(reportFolder, impactedAppsJson, playwrightSkippedArg) {
 }
 
 before(() => {
-  fs.mkdirSync(TEMP, { recursive: true });
+  TEMP = fs.mkdtempSync(path.join(os.tmpdir(), 'check-validate-reports-integ-'));
 });
 
 after(() => {

--- a/plugins/work/scripts/workflows/check/hooks/__tests__/check-validate-reports.integration.test.js
+++ b/plugins/work/scripts/workflows/check/hooks/__tests__/check-validate-reports.integration.test.js
@@ -1,0 +1,105 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const SCRIPT = path.resolve(__dirname, '..', 'check-validate-reports.js');
+const TEMP = path.join(os.tmpdir(), 'check-validate-reports-integ-' + process.pid);
+
+/** QA report missing Playwright section + screenshots, with standard markers. */
+function buildQAReportNoPlaywright(statusToken) {
+  return ['**Changes Hash:** abc123', '', `Status: ${statusToken}`, ''].join('\n');
+}
+
+function seedReports(dir) {
+  fs.writeFileSync(path.join(dir, 'tests.check.md'), '**Changes Hash:** x\n✅ PASS');
+  fs.writeFileSync(path.join(dir, 'code-review.check.md'), '**Changes Hash:** x\nNo issues');
+  fs.writeFileSync(path.join(dir, 'completion.check.md'), '**Changes Hash:** x\nCOMPLETE');
+  fs.writeFileSync(path.join(dir, 'README.md'), 'readme');
+}
+
+function setupDir(name) {
+  const dir = path.join(TEMP, name);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function runCli(reportFolder, impactedAppsJson, playwrightSkippedArg) {
+  const args = [SCRIPT, reportFolder, impactedAppsJson];
+  if (playwrightSkippedArg !== undefined) args.push(playwrightSkippedArg);
+  const res = spawnSync('node', args, { encoding: 'utf-8', timeout: 10000 });
+  let result = null;
+  try {
+    result = JSON.parse(res.stdout);
+  } catch (_) {
+    /* ignore */
+  }
+  return { exitCode: res.status, result };
+}
+
+before(() => {
+  fs.mkdirSync(TEMP, { recursive: true });
+});
+
+after(() => {
+  fs.rmSync(TEMP, { recursive: true, force: true });
+});
+
+describe('check-validate-reports.js CLI — PLAYWRIGHT_SKIPPED_JSON 3rd arg', () => {
+  it('boolean true relaxes Playwright checks for every app', () => {
+    const dir = setupDir('bool-true');
+    seedReports(dir);
+    fs.writeFileSync(path.join(dir, 'qa-app.check.md'), buildQAReportNoPlaywright('APPROVED'));
+
+    const { result } = runCli(dir, JSON.stringify(['app']), 'true');
+    assert.equal(result.reports.qa.app.playwrightSkipped, true);
+    assert.ok(
+      !result.reports.qa.app.issues.includes('Missing "## Playwright Verification" section')
+    );
+  });
+
+  it('per-app map relaxes only the named app', () => {
+    const dir = setupDir('per-app-map');
+    seedReports(dir);
+    fs.writeFileSync(path.join(dir, 'qa-app.check.md'), buildQAReportNoPlaywright('APPROVED'));
+    fs.writeFileSync(path.join(dir, 'qa-web.check.md'), buildQAReportNoPlaywright('APPROVED'));
+
+    const { result } = runCli(
+      dir,
+      JSON.stringify(['app', 'web']),
+      JSON.stringify({ app: true, web: false })
+    );
+    assert.equal(result.reports.qa.app.playwrightSkipped, true);
+    assert.equal(result.reports.qa.web.playwrightSkipped, false);
+    assert.ok(
+      result.reports.qa.web.issues.includes('Missing "## Playwright Verification" section')
+    );
+  });
+
+  it('malformed JSON fails closed (playwrightSkipped false)', () => {
+    const dir = setupDir('malformed');
+    seedReports(dir);
+    fs.writeFileSync(path.join(dir, 'qa-app.check.md'), buildQAReportNoPlaywright('APPROVED'));
+
+    const { result } = runCli(dir, JSON.stringify(['app']), '{not json');
+    assert.equal(result.reports.qa.app.playwrightSkipped, false);
+    assert.ok(
+      result.reports.qa.app.issues.includes('Missing "## Playwright Verification" section'),
+      'fail-closed: Playwright still required on malformed signal'
+    );
+  });
+
+  it('legacy 2-arg invocation preserved (defaults to not skipped)', () => {
+    const dir = setupDir('legacy-2arg');
+    seedReports(dir);
+    fs.writeFileSync(path.join(dir, 'qa-app.check.md'), buildQAReportNoPlaywright('APPROVED'));
+
+    const { result } = runCli(dir, JSON.stringify(['app']));
+    assert.equal(result.reports.qa.app.playwrightSkipped, false);
+    assert.ok(
+      result.reports.qa.app.issues.includes('Missing "## Playwright Verification" section')
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/check/hooks/__tests__/check-validate-reports.test.js
+++ b/plugins/work/scripts/workflows/check/hooks/__tests__/check-validate-reports.test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after } = require('node:test');
+const { describe, it, test, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
@@ -6,6 +6,7 @@ const os = require('os');
 const { execFileSync } = require('child_process');
 
 const SCRIPT = path.resolve(__dirname, '..', 'check-validate-reports.js');
+const { validateQAReport } = require(SCRIPT);
 const TEMP = path.join(os.tmpdir(), 'check-validate-reports-test-' + process.pid);
 
 /**
@@ -33,11 +34,30 @@ function buildQAReport(statusToken, opts = {}) {
 }
 
 /**
- * Run the validate-reports script and return parsed JSON + exit code.
+ * Build a minimal QA report that is MISSING the Playwright Verification section
+ * and screenshots, but still carries the standard markers.
  */
-function runScript(reportFolder, impactedApps) {
+function buildQAReportNoPlaywright(statusToken, opts = {}) {
+  const lines = ['**Changes Hash:** abc123', '', `Status: ${statusToken}`, ''];
+  if (opts.omitChangesHash) {
+    lines.shift(); // drop "**Changes Hash:**"
+    lines.shift(); // drop the blank line after it
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Run the validate-reports script and return parsed JSON + exit code.
+ * Optionally pass a 3rd CLI arg (PLAYWRIGHT_SKIPPED_JSON) verbatim.
+ */
+function runScript(reportFolder, impactedApps, playwrightSkippedArg) {
+  const args = [SCRIPT, reportFolder];
+  args.push(typeof impactedApps === 'string' ? impactedApps : JSON.stringify(impactedApps));
+  if (playwrightSkippedArg !== undefined) {
+    args.push(playwrightSkippedArg);
+  }
   try {
-    const stdout = execFileSync('node', [SCRIPT, reportFolder, JSON.stringify(impactedApps)], {
+    const stdout = execFileSync('node', args, {
       encoding: 'utf-8',
       timeout: 10000,
     });
@@ -170,4 +190,105 @@ describe('check-validate-reports.js — validateQAReport canonical status matchi
     const statusIssues = result.reports.qa.myapp.issues.filter((i) => i.includes('Missing'));
     assert.deepEqual(statusIssues, [], 'NEEDS_WORK should be recognized as a valid status');
   });
+});
+
+const PLAYWRIGHT_ISSUE = 'Missing "## Playwright Verification" section';
+const SCREENSHOT_ISSUE = 'No screenshots found - QA reports must include visual evidence';
+const CHANGES_HASH_ISSUE = 'Missing "**Changes Hash:**" at top of report';
+
+// --- Task 2: playwrightSkipped support ---
+
+test('P0 #1 — QA report without Playwright section is APPROVED when playwright-skipped flag is set', () => {
+  const dir = setupDir('pw-skipped-valid');
+  const file = path.join(dir, 'qa-app.check.md');
+  fs.writeFileSync(file, buildQAReportNoPlaywright('APPROVED'));
+
+  const result = validateQAReport(file, 'app', true);
+  assert.ok(result.valid, 'report should be valid when playwright is skipped');
+  assert.ok(
+    !result.issues.includes(PLAYWRIGHT_ISSUE),
+    'should not flag missing Playwright section when skipped'
+  );
+  assert.ok(
+    !result.issues.includes(SCREENSHOT_ISSUE),
+    'should not flag missing screenshots when skipped'
+  );
+});
+
+test('P0 #4 — Web-app QA report still requires Playwright section when not skipped', () => {
+  const dir = setupDir('pw-not-skipped-invalid');
+  const file = path.join(dir, 'qa-app.check.md');
+  fs.writeFileSync(file, buildQAReportNoPlaywright('APPROVED'));
+
+  const result = validateQAReport(file, 'app', false);
+  assert.ok(!result.valid, 'report should be invalid when playwright is required');
+  assert.ok(
+    result.issues.includes(PLAYWRIGHT_ISSUE),
+    'should flag missing Playwright section when not skipped'
+  );
+  assert.ok(
+    result.issues.includes(SCREENSHOT_ISSUE),
+    'should flag missing screenshots when not skipped'
+  );
+});
+
+test('P0 #3 — Standard markers still required when Playwright is skipped', () => {
+  const dir = setupDir('pw-skipped-no-hash');
+  const file = path.join(dir, 'qa-app.check.md');
+  fs.writeFileSync(file, buildQAReportNoPlaywright('APPROVED', { omitChangesHash: true }));
+
+  const result = validateQAReport(file, 'app', true);
+  assert.ok(!result.valid, 'report missing Changes Hash should be invalid even when skipped');
+  assert.ok(
+    result.issues.includes(CHANGES_HASH_ISSUE),
+    'should flag missing Changes Hash even when playwright is skipped'
+  );
+});
+
+test('P1 — JSON output records playwrightSkipped per app', () => {
+  const dir = setupDir('pw-skipped-flag');
+  const file = path.join(dir, 'qa-app.check.md');
+  fs.writeFileSync(file, buildQAReportNoPlaywright('APPROVED'));
+
+  assert.equal(validateQAReport(file, 'app', true).playwrightSkipped, true);
+  assert.equal(validateQAReport(file, 'app', false).playwrightSkipped, false);
+  assert.equal(validateQAReport(file, 'app').playwrightSkipped, false);
+});
+
+test('CLI: 3rd arg "true" relaxes Playwright checks and records playwrightSkipped per app', () => {
+  const dir = setupDir('cli-skip-true');
+  fs.writeFileSync(path.join(dir, 'tests.check.md'), '**Changes Hash:** x\n✅ PASS');
+  fs.writeFileSync(path.join(dir, 'code-review.check.md'), '**Changes Hash:** x\nNo issues');
+  fs.writeFileSync(path.join(dir, 'completion.check.md'), '**Changes Hash:** x\nCOMPLETE');
+  fs.writeFileSync(path.join(dir, 'README.md'), 'readme');
+  fs.writeFileSync(path.join(dir, 'qa-app.check.md'), buildQAReportNoPlaywright('APPROVED'));
+
+  const { result } = runScript(dir, ['app'], 'true');
+  assert.equal(result.reports.qa.app.playwrightSkipped, true);
+  assert.ok(
+    !result.reports.qa.app.issues.includes(PLAYWRIGHT_ISSUE),
+    'no Playwright issue when skipped via CLI'
+  );
+});
+
+test('CLI: 3rd arg per-app map relaxes only the named app', () => {
+  const dir = setupDir('cli-skip-map');
+  fs.writeFileSync(path.join(dir, 'tests.check.md'), '**Changes Hash:** x\n✅ PASS');
+  fs.writeFileSync(path.join(dir, 'code-review.check.md'), '**Changes Hash:** x\nNo issues');
+  fs.writeFileSync(path.join(dir, 'completion.check.md'), '**Changes Hash:** x\nCOMPLETE');
+  fs.writeFileSync(path.join(dir, 'README.md'), 'readme');
+  fs.writeFileSync(path.join(dir, 'qa-app.check.md'), buildQAReportNoPlaywright('APPROVED'));
+  fs.writeFileSync(path.join(dir, 'qa-other.check.md'), buildQAReportNoPlaywright('APPROVED'));
+
+  const { result } = runScript(dir, ['app', 'other'], JSON.stringify({ app: true, other: false }));
+  assert.equal(result.reports.qa.app.playwrightSkipped, true);
+  assert.equal(result.reports.qa.other.playwrightSkipped, false);
+  assert.ok(
+    !result.reports.qa.app.issues.includes(PLAYWRIGHT_ISSUE),
+    'app should be relaxed in per-app map'
+  );
+  assert.ok(
+    result.reports.qa.other.issues.includes(PLAYWRIGHT_ISSUE),
+    'other should still require Playwright section'
+  );
 });

--- a/plugins/work/scripts/workflows/check/hooks/__tests__/check-validate-reports.test.js
+++ b/plugins/work/scripts/workflows/check/hooks/__tests__/check-validate-reports.test.js
@@ -7,7 +7,8 @@ const { execFileSync } = require('child_process');
 
 const SCRIPT = path.resolve(__dirname, '..', 'check-validate-reports.js');
 const { validateQAReport } = require(SCRIPT);
-const TEMP = path.join(os.tmpdir(), 'check-validate-reports-test-' + process.pid);
+// Created with mkdtempSync in before() so the path is unpredictable (js/insecure-temporary-file).
+let TEMP;
 
 /**
  * Build a minimal QA report with the given status token.
@@ -81,7 +82,7 @@ function setupDir(name) {
 }
 
 before(() => {
-  fs.mkdirSync(TEMP, { recursive: true });
+  TEMP = fs.mkdtempSync(path.join(os.tmpdir(), 'check-validate-reports-test-'));
 });
 
 after(() => {

--- a/plugins/work/scripts/workflows/check/hooks/check-validate-reports.js
+++ b/plugins/work/scripts/workflows/check/hooks/check-validate-reports.js
@@ -274,7 +274,9 @@ function main() {
   };
 
   if (!REPORT_FOLDER) {
-    console.error('Usage: node check-validate-reports.js <REPORT_FOLDER> <IMPACTED_APPS_JSON>');
+    console.error(
+      'Usage: node check-validate-reports.js <REPORT_FOLDER> <IMPACTED_APPS_JSON> [PLAYWRIGHT_SKIPPED_JSON]'
+    );
     process.exit(1);
   }
 

--- a/plugins/work/scripts/workflows/check/hooks/check-validate-reports.js
+++ b/plugins/work/scripts/workflows/check/hooks/check-validate-reports.js
@@ -33,9 +33,12 @@ function readFile(filePath) {
 }
 
 /**
- * Validate QA report has required content
+ * Validate QA report has required content.
+ * When `playwrightSkipped` is true (no web apps per the check plan), the
+ * mandatory "## Playwright Verification" section + screenshot checks are
+ * relaxed; all other markers remain required.
  */
-function validateQAReport(filePath, appName) {
+function validateQAReport(filePath, appName, playwrightSkipped = false) {
   const content = readFile(filePath);
 
   if (!content) {
@@ -78,9 +81,9 @@ function validateQAReport(filePath, appName) {
     };
   }
 
-  // Check for Playwright Verification section (MANDATORY)
+  // Check for Playwright Verification section (MANDATORY unless skipped)
   const hasPlaywrightVerification = content.includes('## Playwright Verification');
-  if (!hasPlaywrightVerification) {
+  if (!playwrightSkipped && !hasPlaywrightVerification) {
     issues.push('Missing "## Playwright Verification" section');
   }
 
@@ -89,9 +92,9 @@ function validateQAReport(filePath, appName) {
     issues.push('Missing "**Changes Hash:**" at top of report');
   }
 
-  // Check for screenshots (required for QA)
+  // Check for screenshots (required for QA unless Playwright is skipped)
   const hasScreenshots = content.includes('![') || content.includes('./screenshots/');
-  if (!hasScreenshots) {
+  if (!playwrightSkipped && !hasScreenshots) {
     issues.push('No screenshots found - QA reports must include visual evidence');
   }
 
@@ -124,6 +127,7 @@ function validateQAReport(filePath, appName) {
     issues,
     failed,
     hasScreenshots,
+    playwrightSkipped: Boolean(playwrightSkipped),
     infrastructureFailure: false,
     accessFailed: false,
   };
@@ -252,6 +256,23 @@ function main() {
   const REPORT_FOLDER = process.argv[2];
   const IMPACTED_APPS = JSON.parse(process.argv[3] || '[]');
 
+  // Optional 3rd positional arg: PLAYWRIGHT_SKIPPED_JSON (bool or per-app map).
+  // Sourced deterministically from the check plan, NOT the QA report.
+  // Malformed input fails closed (skip = false → Playwright still required).
+  let playwrightSkippedParsed = false;
+  try {
+    playwrightSkippedParsed = JSON.parse(process.argv[4] || 'false');
+  } catch (_) {
+    playwrightSkippedParsed = false;
+  }
+  const resolveSkip = (appName) => {
+    if (typeof playwrightSkippedParsed === 'boolean') return playwrightSkippedParsed;
+    if (playwrightSkippedParsed && typeof playwrightSkippedParsed === 'object') {
+      return Boolean(playwrightSkippedParsed[appName]);
+    }
+    return false;
+  };
+
   if (!REPORT_FOLDER) {
     console.error('Usage: node check-validate-reports.js <REPORT_FOLDER> <IMPACTED_APPS_JSON>');
     process.exit(1);
@@ -279,7 +300,7 @@ function main() {
 
   for (const app of IMPACTED_APPS) {
     const qaPath = path.join(REPORT_FOLDER, `qa-${app}.check.md`);
-    const validation = validateQAReport(qaPath, app);
+    const validation = validateQAReport(qaPath, app, resolveSkip(app));
     results.reports.qa[app] = validation;
 
     // Check for infrastructure failure FIRST
@@ -390,4 +411,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { validateCodeReview };
+module.exports = { validateCodeReview, validateQAReport };

--- a/plugins/work/scripts/workflows/check/lib/__tests__/has-web-apps.test.js
+++ b/plugins/work/scripts/workflows/check/lib/__tests__/has-web-apps.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+let hasWebApps;
+try {
+  ({ hasWebApps } = require('../has-web-apps'));
+} catch {
+  // Module not yet implemented (RED phase) — assertions below will fail.
+  hasWebApps = () => undefined;
+}
+
+test('returns false when impactedApps is an empty array', () => {
+  assert.equal(hasWebApps([], { WEB_APPS: 'app' }), false);
+});
+
+test('returns false when env.WEB_APPS is unset', () => {
+  assert.equal(hasWebApps(['app'], {}), false);
+});
+
+test('returns false when env.WEB_APPS is an empty string', () => {
+  assert.equal(hasWebApps(['app'], { WEB_APPS: '' }), false);
+});
+
+test('returns true when impactedApps is non-empty AND env.WEB_APPS is a non-empty string', () => {
+  assert.equal(hasWebApps(['app'], { WEB_APPS: '["app"]' }), true);
+});
+
+test('returns false for null impactedApps (defensive)', () => {
+  assert.equal(hasWebApps(null, { WEB_APPS: 'app' }), false);
+});
+
+test('returns false for undefined impactedApps (defensive)', () => {
+  assert.equal(hasWebApps(undefined, { WEB_APPS: 'app' }), false);
+});
+
+test('returns false for null/undefined env (defensive)', () => {
+  assert.equal(hasWebApps(['app'], null), false);
+  assert.equal(hasWebApps(['app'], undefined), false);
+});

--- a/plugins/work/scripts/workflows/check/lib/has-web-apps.js
+++ b/plugins/work/scripts/workflows/check/lib/has-web-apps.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/** Single source of truth: true only when impactedApps is non-empty AND env.WEB_APPS is set. */
+function hasWebApps(impactedApps, env) {
+  return (impactedApps?.length ?? 0) > 0 && Boolean(env?.WEB_APPS);
+}
+
+module.exports = { hasWebApps };

--- a/plugins/work/scripts/workflows/check2/check-next.js
+++ b/plugins/work/scripts/workflows/check2/check-next.js
@@ -32,10 +32,15 @@ const { libDir, TASKS_BASE } = resolvePluginConfig(path.join(__dirname, '..', 'w
 // eager load a real web-app project can be mis-detected as Playwright-skipped
 // and QA reports accepted without the Playwright section/screenshots. Mirrors
 // legacy check.workflow.js. (GH-280 review: cursor[bot] — skip signal & dotenv)
+const configPath = path.join(libDir, 'config');
 try {
-  require(path.join(libDir, 'config'));
-} catch {
-  /* fail-open: config.js is optional; steps fall back to ambient process.env */
+  require(configPath);
+} catch (err) {
+  // Fail-open ONLY when config.js itself is absent (optional module). A runtime
+  // error inside config.js (e.g. a malformed `.env`) or a missing transitive
+  // dep must surface — swallowing it would leave WEB_APPS unset and silently
+  // re-introduce the mis-skip bug this load prevents. Mirrors get-config.js.
+  if (!(err?.code === 'MODULE_NOT_FOUND' && err.message?.includes(configPath))) throw err;
 }
 
 if (!TASKS_BASE) {

--- a/plugins/work/scripts/workflows/check2/check-next.js
+++ b/plugins/work/scripts/workflows/check2/check-next.js
@@ -23,6 +23,21 @@ if (require.main === module) {
 const { resolvePluginConfig } = require('../lib/plugin-config');
 const { libDir, TASKS_BASE } = resolvePluginConfig(path.join(__dirname, '..', 'work'));
 
+// Load lib/config.js for its side-effect: it reads the repo `.env` into
+// process.env (WEB_APPS, etc.). resolvePluginConfig() above uses getConfig(),
+// which loads config lazily and is short-circuited when WORKTREES_BASE is
+// already exported (the direnv case) — so config.js's `.env` loader may never
+// run. The deterministic playwright-skip signal in 3_verify_playwright and
+// 10_validate_summary reads process.env.WEB_APPS via hasWebApps(); without this
+// eager load a real web-app project can be mis-detected as Playwright-skipped
+// and QA reports accepted without the Playwright section/screenshots. Mirrors
+// legacy check.workflow.js. (GH-280 review: cursor[bot] — skip signal & dotenv)
+try {
+  require(path.join(libDir, 'config'));
+} catch {
+  /* fail-open: config.js is optional; steps fall back to ambient process.env */
+}
+
 if (!TASKS_BASE) {
   console.log(
     JSON.stringify({

--- a/plugins/work/scripts/workflows/check2/lib/steps/__tests__/validate-summary.integration.test.js
+++ b/plugins/work/scripts/workflows/check2/lib/steps/__tests__/validate-summary.integration.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * Integration test for `validate-summary.js` (GH-280, Task 3).
+ *
+ * Scenario — P0 #2: the playwright-skip signal threaded to the validator CLI is
+ * sourced deterministically from the check plan / runtime state
+ * (`state.setupResult`), NOT from a human edit to the QA report.
+ *
+ * We exercise the exported args-builder seam, which derives the 3rd positional
+ * argument (`<PLAYWRIGHT_SKIPPED_JSON>`) for `check-validate-reports.js` via the
+ * canonical `hasWebApps()` helper.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const validateSummaryModule = require('../validate-summary');
+
+const ORIGINAL_WEB_APPS = process.env.WEB_APPS;
+
+function restoreEnv() {
+  if (ORIGINAL_WEB_APPS === undefined) {
+    delete process.env.WEB_APPS;
+  } else {
+    process.env.WEB_APPS = ORIGINAL_WEB_APPS;
+  }
+}
+
+test('P0 #2 — Signal sourced deterministically from the check plan', async (t) => {
+  await t.test('exposes an args-builder seam (no human-edit source)', () => {
+    assert.equal(
+      typeof validateSummaryModule.buildValidateReportsArgs,
+      'function',
+      'validate-summary.js must export buildValidateReportsArgs for deterministic signal threading'
+    );
+  });
+
+  await t.test('no web apps → 3rd arg is JSON "true" (playwright skipped)', () => {
+    delete process.env.WEB_APPS;
+    const state = { setupResult: { impactedApps: ['plugin'], reportFolder: '/tmp/reports' } };
+    const args = validateSummaryModule.buildValidateReportsArgs(state, process.env);
+
+    // [ reportFolder, impactedAppsJson, playwrightSkippedJson ]
+    assert.equal(args.length, 3, 'expected exactly 3 positional args');
+    assert.equal(args[2], 'true', 'no web apps → skip signal must be JSON "true"');
+    restoreEnv();
+  });
+
+  await t.test('web apps present → 3rd arg is JSON "false" (not skipped)', () => {
+    process.env.WEB_APPS = '["app"]';
+    const state = { setupResult: { impactedApps: ['app'], reportFolder: '/tmp/reports' } };
+    const args = validateSummaryModule.buildValidateReportsArgs(state, process.env);
+
+    assert.equal(args[2], 'false', 'web apps present → skip signal must be JSON "false"');
+    restoreEnv();
+  });
+
+  await t.test('signal is derived from setupResult, not from the QA report', () => {
+    delete process.env.WEB_APPS;
+    const stateNoApps = { setupResult: { impactedApps: [], reportFolder: '/tmp/reports' } };
+    const args = validateSummaryModule.buildValidateReportsArgs(stateNoApps, process.env);
+    assert.equal(args[2], 'true', 'empty impactedApps + no WEB_APPS → skipped');
+    restoreEnv();
+  });
+});

--- a/plugins/work/scripts/workflows/check2/lib/steps/validate-summary.js
+++ b/plugins/work/scripts/workflows/check2/lib/steps/validate-summary.js
@@ -6,16 +6,41 @@
 
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { hasWebApps } = require('../../../check/lib/has-web-apps');
 
-module.exports = function registerValidateSummary(register) {
+/**
+ * Build the positional args for `check-validate-reports.js`. The 3rd arg
+ * (`<PLAYWRIGHT_SKIPPED_JSON>`) is derived deterministically from the check
+ * plan's `state.setupResult` via the canonical `hasWebApps()` helper — never
+ * from a human edit to the QA report (GH-280, P0 #2).
+ *
+ * @returns {[string, string, string]} [reportFolder, impactedAppsJson, playwrightSkippedJson]
+ */
+function buildValidateReportsArgs(state, env, tasksDir) {
+  const reportFolder = state.setupResult?.reportFolder || tasksDir;
+  const apps = JSON.stringify(state.setupResult?.impactedApps || []);
+  const playwrightSkipped = !hasWebApps(state.setupResult?.impactedApps ?? [], env);
+  return [reportFolder, apps, JSON.stringify(playwrightSkipped)];
+}
+
+function registerValidateSummary(register) {
   register('10_validate_summary', (state, ctx) => {
-    const reportFolder = state.setupResult?.reportFolder || ctx.tasksDir;
-    const apps = JSON.stringify(state.setupResult?.impactedApps || []);
+    // GH-280: thread a deterministic playwright-skip signal as the 3rd arg.
+    const [reportFolder, apps, playwrightSkippedJson] = buildValidateReportsArgs(
+      state,
+      process.env,
+      ctx.tasksDir
+    );
 
     try {
       execFileSync(
         process.execPath,
-        [path.join(ctx.checkHooksDir, 'check-validate-reports.js'), reportFolder, apps],
+        [
+          path.join(ctx.checkHooksDir, 'check-validate-reports.js'),
+          reportFolder,
+          apps,
+          playwrightSkippedJson,
+        ],
         { encoding: 'utf8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] }
       );
     } catch {
@@ -40,4 +65,7 @@ module.exports = function registerValidateSummary(register) {
 
     return null; // auto-advance
   });
-};
+}
+
+module.exports = registerValidateSummary;
+module.exports.buildValidateReportsArgs = buildValidateReportsArgs;

--- a/plugins/work/scripts/workflows/check2/lib/steps/verify-playwright.js
+++ b/plugins/work/scripts/workflows/check2/lib/steps/verify-playwright.js
@@ -4,12 +4,13 @@
 
 'use strict';
 
+const { hasWebApps } = require('../../../check/lib/has-web-apps');
+
 module.exports = function registerVerifyPlaywright(register) {
   register('3_verify_playwright', (state) => {
     // Skip if no web apps configured
     const apps = state.setupResult?.impactedApps || [];
-    const hasWebApps = apps.length > 0 && process.env.WEB_APPS;
-    if (!hasWebApps) return null; // auto-advance
+    if (!hasWebApps(apps, process.env)) return null; // auto-advance
 
     // TODO: verify playwright connection for web apps
     return null;


### PR DESCRIPTION
## Existing Behavior

- `check-validate-reports.js` always required a `## Playwright Verification` section and screenshots in every QA report, regardless of whether the project has a web app.
- When the check plan skipped `3_verify_playwright` with reason \"No web apps configured\", the validator still failed with \"Missing '## Playwright Verification' section\" and \"No screenshots found\".
- `verify-playwright.js` inlined its own `hasWebApps` check (`apps.length > 0 && process.env.WEB_APPS`) with no shared helper, making the signal non-reusable.
- `module.exports` of `check-validate-reports.js` exposed only `validateCodeReview`, not `validateQAReport`, preventing unit-level testing of the QA validation path.

## Intended New Behavior

- A new `has-web-apps.js` helper is the single source of truth for determining whether a project has web apps; both `verify-playwright.js` and `validate-summary.js` consume it.
- `validateQAReport(filePath, appName, playwrightSkipped = false)` accepts an explicit boolean signal. When `true`, the Playwright section + screenshot checks are skipped; all other markers (`**Changes Hash:**`, status token) remain mandatory.
- `validate-summary.js` computes `!hasWebApps(impactedApps, env)` and passes the result as a 3rd positional JSON arg to the `check-validate-reports.js` CLI. The signal is sourced deterministically from the check plan — not from the QA report itself.
- The CLI parses the optional 3rd arg as a bool or per-app map; malformed JSON fails closed (Playwright still required).
- `validateQAReport` is now exported, enabling direct unit testing.

## Brief P0 coverage

- **P0 #1:** QA report without Playwright section approved when playwright-skipped flag is set — implemented in `plugins/work/scripts/workflows/check/hooks/check-validate-reports.js:84-97` + test `check-validate-reports.test.js:202`
- **P0 #2:** Signal sourced deterministically from the check plan, not a human QA edit — implemented in `check2/lib/steps/validate-summary.js:19-28` via `buildValidateReportsArgs` seam + integration test `validate-summary.integration.test.js:43`
- **P0 #3:** Standard markers still required when Playwright is skipped — `check-validate-reports.js:88-96` still enforces `**Changes Hash:**` unconditionally + test `check-validate-reports.test.js:228`
- **P0 #4:** Web-app QA report still requires Playwright section when not skipped — `check-validate-reports.js:84` guards on `!playwrightSkipped` + test `check-validate-reports.test.js:213`

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / CLI changes — verification steps:**

1. Confirm a no-web-app project no longer errors on QA validation:
   ```bash
   # Create a minimal QA report without Playwright section
   echo -e "**Changes Hash:** abc123\n\nStatus: APPROVED" > /tmp/qa-plugin.check.md
   echo -e "**Changes Hash:** x\n✅ PASS" > /tmp/tests.check.md
   echo -e "**Changes Hash:** x\nNo issues" > /tmp/code-review.check.md
   echo -e "**Changes Hash:** x\nCOMPLETE" > /tmp/completion.check.md

   # Pass playwrightSkipped=true (no web apps)
   node plugins/work/scripts/workflows/check/hooks/check-validate-reports.js \
     /tmp '["plugin"]' 'true'
   # Expected: exit 0, JSON with reports.qa.plugin.valid=true, playwrightSkipped=true
   ```

2. Confirm web-app projects still require Playwright:
   ```bash
   node plugins/work/scripts/workflows/check/hooks/check-validate-reports.js \
     /tmp '["plugin"]' 'false'
   # Expected: exit non-0, issues includes "Missing ## Playwright Verification section"
   ```

3. Confirm the `has-web-apps.js` helper logic:
   ```bash
   node -e "const {hasWebApps}=require('./plugins/work/scripts/workflows/check/lib/has-web-apps'); console.log(hasWebApps(['app'],{WEB_APPS:'[\"app\"]'}));"
   # Expected: true
   node -e "const {hasWebApps}=require('./plugins/work/scripts/workflows/check/lib/has-web-apps'); console.log(hasWebApps(['app'],{}));"
   # Expected: false
   ```

4. Run the full test suite for the changed modules:
   ```bash
   pnpm dev:check
   # Expected: 28/28 tests pass
   ```

### Test Results

28/28 tests pass (check2 passed, verified locally before PR creation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes QA gate rules and env-dependent skip signaling; incorrect `WEB_APPS` detection could accept reports without Playwright on web projects, though eager config load and fail-closed parsing mitigate that.
> 
> **Overview**
> **No-web-app check runs** can pass QA validation without a `## Playwright Verification` section or screenshots when the check plan skips Playwright; **web-app runs** still require those markers.
> 
> A shared **`hasWebApps()`** helper drives **`3_verify_playwright`** and **`10_validate_summary`**, which passes a deterministic third CLI arg (`PLAYWRIGHT_SKIPPED_JSON`) into **`check-validate-reports.js`**—derived from `setupResult` / `WEB_APPS`, not from the QA report. **`validateQAReport`** accepts an explicit skip flag (bool or per-app map via CLI); malformed JSON **fails closed** (Playwright still required). Legacy two-arg CLI behavior is unchanged.
> 
> **`check-next.js`** eagerly loads **`config.js`** so `WEB_APPS` is populated when direnv short-circuits lazy config, avoiding false “skip Playwright” on real web projects. **`validateQAReport`** is exported for unit tests; coverage adds CLI integration and args-builder tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15848f7268234671d1d3b4454a06c47bf20ebc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Test Results (Automated)

| Test | Status | Notes |
|------|--------|-------|
| PLAYWRIGHT_SKIPPED_JSON 3rd arg — boolean true relaxes Playwright checks for every app | PASS | tests.check.md |
| PLAYWRIGHT_SKIPPED_JSON 3rd arg — per-app map relaxes only the named app | PASS | tests.check.md |
| PLAYWRIGHT_SKIPPED_JSON 3rd arg — malformed JSON fails closed (playwrightSkipped false) | PASS | tests.check.md |
| PLAYWRIGHT_SKIPPED_JSON 3rd arg — legacy 2-arg invocation preserved | PASS | tests.check.md |
| validateQAReport — accepts a QA report with legacy PASS status | PASS | tests.check.md |
| validateQAReport — detects a QA report with legacy FAIL status as failed | PASS | tests.check.md |
| validateQAReport — accepts a QA report with canonical APPROVED status | PASS | tests.check.md |
| validateQAReport — detects a QA report with canonical NEEDS_WORK status as failed | PASS | tests.check.md |
| validateQAReport — does not false-positive when stale NEEDS_WORK appears in Previous Run section | PASS | tests.check.md |
| validateQAReport — recognizes NEEDS_WORK in Status: line as a valid status | PASS | tests.check.md |
| P0 #1 — QA report without Playwright section is APPROVED when playwright-skipped flag is set | PASS | tests.check.md |
| P0 #4 — Web-app QA report still requires Playwright section when not skipped | PASS | tests.check.md |
| P0 #3 — Standard markers still required when Playwright is skipped | PASS | tests.check.md |
| P1 — JSON output records playwrightSkipped per app | PASS | tests.check.md |
| P0 #2 — Signal sourced deterministically from the check plan — exposes an args-builder seam | PASS | tests.check.md |
| P0 #2 — no web apps → 3rd arg is JSON "true" (playwright skipped) | PASS | tests.check.md |
| P0 #2 — web apps present → 3rd arg is JSON "false" (not skipped) | PASS | tests.check.md |
| P0 #2 — signal is derived from setupResult, not from the QA report | PASS | tests.check.md |
| hasWebApps — returns false when impactedApps is an empty array | PASS | tests.check.md |
| hasWebApps — returns false when env.WEB_APPS is unset | PASS | tests.check.md |
| hasWebApps — returns false when env.WEB_APPS is an empty string | PASS | tests.check.md |
| hasWebApps — returns true when impactedApps is non-empty AND env.WEB_APPS is a non-empty string | PASS | tests.check.md |
| hasWebApps — returns false for null impactedApps (defensive) | PASS | tests.check.md |
| hasWebApps — returns false for undefined impactedApps (defensive) | PASS | tests.check.md |
| hasWebApps — returns false for null/undefined env (defensive) | PASS | tests.check.md |
| CLI: 3rd arg "true" relaxes Playwright checks and records playwrightSkipped per app | PASS | tests.check.md |
| CLI: 3rd arg per-app map relaxes only the named app | PASS | tests.check.md |

**Exit code:** 0 | **Pass:** 28 | **Fail:** 0

_No screenshots — this is a non-visual backend/validator change._