### PR TITLE
feat(follow-up): add mandatory judgment/triage step before solving/skipping bot review comments (GH-352)

### DIFF
--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
@@ -90,10 +90,15 @@ describe('fix-reviews judgment step (Task 1, GH-352)', () => {
 
   it('instructs the agent to read the referenced code at fileRef', () => {
     assert.ok(
-      /read the (referenced )?code/i.test(SOURCE),
-      'expected an instruction to read the referenced code'
+      /read the (referenced )?code/i.test(PROMPT),
+      'expected an instruction to read the referenced code in the assembled prompt'
     );
-    assert.ok(SOURCE.includes('fileRef'), 'expected the judgment step to reference fileRef');
+    // Assert the actual fileRef VALUE reaches the prompt, not just that the
+    // parameter name 'fileRef' appears in source (which is always true).
+    assert.ok(
+      PROMPT.includes('a.js:12'),
+      'expected the assembled prompt to reference the concrete file:line the agent must read'
+    );
   });
 
   it("instructs the agent to verify the bot's claim against the current code", () => {

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
@@ -14,6 +14,28 @@ const path = require('node:path');
 const FIX_REVIEWS_PATH = path.resolve(__dirname, '..', 'fix-reviews.js');
 const SOURCE = fs.readFileSync(FIX_REVIEWS_PATH, 'utf8');
 
+// Build the ACTUAL assembled prompt so ordering/spread assertions test the
+// emitted string, not the raw source-file layout (a source-text check passes
+// even if reviewJudgmentBlock is never spread into the prompt array).
+const { buildReviewPrompt } = require('../fix-reviews.js');
+const PROMPT = buildReviewPrompt(
+  {
+    author: 'cursor',
+    priority: 'Medium',
+    body: 'body',
+    codeContext: 'code',
+    path: 'a.js',
+    line: 12,
+  },
+  'a.js:12',
+  { currentIndex: 1, totalComments: 1 },
+  {
+    solveCmd: 'node c --mark-locally-solved',
+    skipCmd: 'node c --mark-locally-skipped',
+    nextCmd: 'node n',
+  }
+);
+
 describe('fix-reviews delegate block (Task 7)', () => {
   it('Delegate-block text in fix-reviews.js uses the new flag names', () => {
     assert.ok(
@@ -83,10 +105,12 @@ describe('fix-reviews judgment step (Task 1, GH-352)', () => {
   });
 
   it('places the judgment step before the Option A / Option B action block', () => {
-    const judgmentIdx = SOURCE.search(/Before you act/i);
-    const actionIdx = SOURCE.indexOf('## You MUST do exactly ONE of these:');
-    assert.ok(judgmentIdx !== -1, 'expected a judgment heading');
-    assert.ok(actionIdx !== -1, 'expected the existing action block');
+    // Assert against the ASSEMBLED prompt, not source layout: this fails if
+    // reviewJudgmentBlock is removed from buildReviewPrompt's prompt array.
+    const judgmentIdx = PROMPT.search(/Before you act/i);
+    const actionIdx = PROMPT.indexOf('## You MUST do exactly ONE of these:');
+    assert.ok(judgmentIdx !== -1, 'expected a judgment heading in the assembled prompt');
+    assert.ok(actionIdx !== -1, 'expected the action block in the assembled prompt');
     assert.ok(
       judgmentIdx < actionIdx,
       'expected the judgment step to appear before the action block'

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
@@ -56,3 +56,113 @@ describe('fix-reviews delegate block (Task 7)', () => {
     );
   });
 });
+
+describe('fix-reviews judgment step (Task 1, GH-352)', () => {
+  // 1.1 — Verify-the-code judgment step before the fix-or-skip choice
+  it('prompts the agent to judge the comment before acting (heading present)', () => {
+    assert.ok(
+      /Before you act/i.test(SOURCE),
+      'expected a judgment heading like "Before you act" in the prompt'
+    );
+  });
+
+  it('instructs the agent to read the referenced code at fileRef', () => {
+    assert.ok(
+      /read the (referenced )?code/i.test(SOURCE),
+      'expected an instruction to read the referenced code'
+    );
+    assert.ok(SOURCE.includes('fileRef'), 'expected the judgment step to reference fileRef');
+  });
+
+  it("instructs the agent to verify the bot's claim against the current code", () => {
+    assert.ok(/[Vv]erify.*claim/.test(SOURCE), "expected an instruction to verify the bot's claim");
+    assert.ok(
+      /current code/i.test(SOURCE),
+      'expected the verification to be against the current code'
+    );
+  });
+
+  it('places the judgment step before the Option A / Option B action block', () => {
+    const judgmentIdx = SOURCE.search(/Before you act/i);
+    const actionIdx = SOURCE.indexOf('## You MUST do exactly ONE of these:');
+    assert.ok(judgmentIdx !== -1, 'expected a judgment heading');
+    assert.ok(actionIdx !== -1, 'expected the existing action block');
+    assert.ok(
+      judgmentIdx < actionIdx,
+      'expected the judgment step to appear before the action block'
+    );
+  });
+
+  // 1.2 — Six-category classification taxonomy with prescribed actions
+  it('lists all six classification categories', () => {
+    assert.ok(/real bug/i.test(SOURCE), 'expected "real bug" category');
+    assert.ok(/real improvement/i.test(SOURCE), 'expected "real improvement" category');
+    assert.ok(/style\/naming/i.test(SOURCE), 'expected "style/naming preference" category');
+    assert.ok(/false positive/i.test(SOURCE), 'expected "false positive" category');
+    assert.ok(
+      /conflicts with (the )?user intent/i.test(SOURCE),
+      'expected "conflicts with user intent" category'
+    );
+    assert.ok(/ambiguous/i.test(SOURCE), 'expected "ambiguous" category');
+  });
+
+  it('states the prescribed action for false positive (skip with evidence)', () => {
+    assert.ok(
+      /false positive[\s\S]{0,80}skip[\s\S]{0,40}evidence/i.test(SOURCE),
+      'expected "false positive" to prescribe skip with evidence'
+    );
+  });
+
+  it('states the prescribed action for ambiguous (ask the user)', () => {
+    assert.ok(
+      /ambiguous[\s\S]{0,80}ask the user/i.test(SOURCE),
+      'expected "ambiguous" to prescribe asking the user'
+    );
+  });
+
+  // 1.3 — Record the classification inside the solve/skip reason
+  it('requires the chosen category in the skip reason string', () => {
+    assert.ok(
+      /classification|category/i.test(SOURCE),
+      'expected an instruction referencing the chosen classification/category'
+    );
+    assert.ok(
+      /<reason>/.test(SOURCE),
+      'expected the skip reason placeholder <reason> to be referenced'
+    );
+    assert.ok(/\[<category>\]/.test(SOURCE), 'expected a leading [<category>] token instruction');
+  });
+
+  it('requires the chosen category in the solve description string', () => {
+    assert.ok(
+      /<description>/.test(SOURCE),
+      'expected the solve description placeholder <description> to be referenced'
+    );
+    assert.ok(
+      /--mark-locally-solved/.test(SOURCE),
+      'expected the solve command to remain referenced'
+    );
+  });
+});
+
+describe('fix-reviews preserved action contract (Task 1, GH-352)', () => {
+  // 1.4 — Preserve the existing action contract
+  it('still presents exactly one of Option A / Option B', () => {
+    assert.ok(SOURCE.includes('Option A'), 'expected Option A to remain');
+    assert.ok(SOURCE.includes('Option B'), 'expected Option B to remain');
+  });
+
+  it('still references both --mark-locally-* flags', () => {
+    assert.ok(SOURCE.includes('--mark-locally-solved'));
+    assert.ok(SOURCE.includes('--mark-locally-skipped'));
+  });
+
+  it('still contains the Do NOT pipe the output guidance', () => {
+    assert.ok(SOURCE.includes('Do NOT pipe the output'), 'expected the no-pipe guidance to remain');
+  });
+
+  it('does not reintroduce the legacy flag names', () => {
+    assert.ok(!SOURCE.includes('--solve-comment'));
+    assert.ok(!SOURCE.includes('--skip-comment'));
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
@@ -122,29 +122,31 @@ describe('fix-reviews judgment step (Task 1, GH-352)', () => {
     );
   });
 
-  // 1.2 — Six-category classification taxonomy with prescribed actions
+  // 1.2 — Six-category classification taxonomy with prescribed actions.
+  // Assert against PROMPT (the assembled string) so the taxonomy is proven to
+  // actually reach the agent, not merely exist in a comment or dead branch.
   it('lists all six classification categories', () => {
-    assert.ok(/real bug/i.test(SOURCE), 'expected "real bug" category');
-    assert.ok(/real improvement/i.test(SOURCE), 'expected "real improvement" category');
-    assert.ok(/style\/naming/i.test(SOURCE), 'expected "style/naming preference" category');
-    assert.ok(/false positive/i.test(SOURCE), 'expected "false positive" category');
+    assert.ok(/real bug/i.test(PROMPT), 'expected "real bug" category');
+    assert.ok(/real improvement/i.test(PROMPT), 'expected "real improvement" category');
+    assert.ok(/style\/naming/i.test(PROMPT), 'expected "style/naming preference" category');
+    assert.ok(/false positive/i.test(PROMPT), 'expected "false positive" category');
     assert.ok(
-      /conflicts with (the )?user intent/i.test(SOURCE),
+      /conflicts with (the )?user intent/i.test(PROMPT),
       'expected "conflicts with user intent" category'
     );
-    assert.ok(/ambiguous/i.test(SOURCE), 'expected "ambiguous" category');
+    assert.ok(/ambiguous/i.test(PROMPT), 'expected "ambiguous" category');
   });
 
   it('states the prescribed action for false positive (skip with evidence)', () => {
     assert.ok(
-      /false positive[\s\S]{0,80}skip[\s\S]{0,40}evidence/i.test(SOURCE),
+      /false positive[\s\S]{0,80}skip[\s\S]{0,40}evidence/i.test(PROMPT),
       'expected "false positive" to prescribe skip with evidence'
     );
   });
 
   it('states the prescribed action for ambiguous (ask the user)', () => {
     assert.ok(
-      /ambiguous[\s\S]{0,80}ask the user/i.test(SOURCE),
+      /ambiguous[\s\S]{0,80}ask the user/i.test(PROMPT),
       'expected "ambiguous" to prescribe asking the user'
     );
   });
@@ -152,23 +154,23 @@ describe('fix-reviews judgment step (Task 1, GH-352)', () => {
   // 1.3 — Record the classification inside the solve/skip reason
   it('requires the chosen category in the skip reason string', () => {
     assert.ok(
-      /classification|category/i.test(SOURCE),
+      /classification|category/i.test(PROMPT),
       'expected an instruction referencing the chosen classification/category'
     );
     assert.ok(
-      /<reason>/.test(SOURCE),
+      /<reason>/.test(PROMPT),
       'expected the skip reason placeholder <reason> to be referenced'
     );
-    assert.ok(/\[<category>\]/.test(SOURCE), 'expected a leading [<category>] token instruction');
+    assert.ok(/\[<category>\]/.test(PROMPT), 'expected a leading [<category>] token instruction');
   });
 
   it('requires the chosen category in the solve description string', () => {
     assert.ok(
-      /<description>/.test(SOURCE),
+      /<description>/.test(PROMPT),
       'expected the solve description placeholder <description> to be referenced'
     );
     assert.ok(
-      /--mark-locally-solved/.test(SOURCE),
+      /--mark-locally-solved/.test(PROMPT),
       'expected the solve command to remain referenced'
     );
   });

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
@@ -290,3 +290,8 @@ module.exports = function registerFixReviews(register) {
     return buildReviewExecute(state, comment, commentsScript, counts);
   });
 };
+
+// Exposed for tests so ordering/content assertions run against the ACTUAL
+// assembled prompt string rather than the raw source-file layout.
+module.exports.buildReviewPrompt = buildReviewPrompt;
+module.exports.reviewJudgmentBlock = reviewJudgmentBlock;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
@@ -292,6 +292,7 @@ module.exports = function registerFixReviews(register) {
 };
 
 // Exposed for tests so ordering/content assertions run against the ACTUAL
-// assembled prompt string rather than the raw source-file layout.
+// assembled prompt string rather than the raw source-file layout. The judgment
+// block's content is covered transitively via buildReviewPrompt, so it is not
+// exported separately.
 module.exports.buildReviewPrompt = buildReviewPrompt;
-module.exports.reviewJudgmentBlock = reviewJudgmentBlock;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
@@ -153,6 +153,32 @@ function cleanCommentBody(rawBody) {
     .trim();
 }
 
+// Mandatory judgment/triage step (GH-352). Lifted to module scope so
+// buildReviewPrompt stays under the 80-line/function cap (R8). The agent must
+// read the referenced code and verify the bot's claim BEFORE choosing Option
+// A / Option B, classify into one of six categories, and record the chosen
+// category inside the solve/skip reason so it persists in comment.resolution.
+function reviewJudgmentBlock(fileRef) {
+  return [
+    '## Before you act — judge the comment:',
+    `1. **Read the referenced code** at \`${fileRef}\` (the file/line above).`,
+    "2. **Verify the bot's claim** is accurate against the current code — do not trust it blindly.",
+    '3. **Classify** the comment into exactly one category and take the prescribed action:',
+    '   - **real bug** → fix (Option A)',
+    '   - **real improvement** (perf/maintainability, related to this PR) → fix (Option A)',
+    '   - **style/naming preference** → skip with reason (Option B)',
+    '   - **false positive** (bot misread the code) → skip with evidence (Option B)',
+    '   - **conflicts with user intent / ticket requirements** → skip with reason (Option B)',
+    '   - **ambiguous** (unsure whether it applies) → ask the user',
+    '4. **Record the classification**: put a leading `[<category>]` token at the start of the',
+    '   `<reason>` you pass to `--mark-locally-skipped` and the `<description>` you pass to',
+    '   `--mark-locally-solved`, so the category persists in the comment resolution.',
+    '',
+    '---',
+    '',
+  ];
+}
+
 function buildReviewPrompt(comment, fileRef, counts, commands) {
   const author = comment.author || 'unknown';
   const priority = comment.priority || 'unknown';
@@ -168,6 +194,7 @@ function buildReviewPrompt(comment, fileRef, counts, commands) {
     codeContext ? `### Current code:\n\`\`\`\n${codeContext}\n\`\`\`\n` : '',
     '---',
     '',
+    ...reviewJudgmentBlock(fileRef),
     '## You MUST do exactly ONE of these:',
     '',
     '### Option A — Fix the code:',

--- a/plugins/work/skills/follow-up/SKILL.md
+++ b/plugins/work/skills/follow-up/SKILL.md
@@ -24,3 +24,30 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/workflows/follow-up/follow-up-next.js" <TICK
 - After executing, re-run follow-up-next.js (without --init) for the next instruction.
 - Repeat until `action: "complete"` or `action: "blocked"`.
 - **Never stop early.** If the script is running, it is working. Wait for it.
+
+## Judging bot review comments
+
+When the script dispatches a review comment for you to address, do **not** blindly
+apply the bot's suggestion. Before choosing to fix (Option A) or skip (Option B):
+
+1. **Read the referenced code** at the file/line the comment points to (`fileRef`).
+2. **Verify the bot's claim** against the *current* code — bots frequently misread
+   context, flag already-handled cases, or comment on stale lines.
+3. **Classify** the comment into exactly one of these six categories, each with its
+   prescribed action:
+   - **real bug** → fix (Option A)
+   - **real improvement** (perf/maintainability, related to this PR) → fix (Option A)
+   - **style/naming preference** → skip with reason (Option B)
+   - **false positive** (bot misread the code) → skip with evidence (Option B)
+   - **conflicts with user intent / ticket requirements** → skip with reason (Option B)
+   - **ambiguous** (unsure whether it applies) → ask the user
+
+### Record the classification
+
+Persist the chosen category so it survives in `comment.resolution`: put a leading
+`[<category>]` token at the start of the `<reason>` you pass to
+`--mark-locally-skipped` and the `<description>` you pass to `--mark-locally-solved`.
+For example: `[false positive] guard already handles null at line 42` or
+`[real bug] off-by-one in loop bound`. The classification is written verbatim into
+the comment resolution, so the audit trail shows *why* each comment was fixed or
+skipped.


### PR DESCRIPTION
## Summary

- Inserts a mandatory `reviewJudgmentBlock` into `buildReviewPrompt` (`fix-reviews.js`) that forces the agent to read the referenced code, verify the bot's claim, and classify the comment into one of six categories before choosing fix or skip.
- Adds a six-category taxonomy (real bug, real improvement, style/naming preference, false positive, conflicts with user intent, ambiguous) with prescribed actions — eliminating both the "blind-implement" and "rationalized-skip" failure modes seen in PR #349.
- Requires the chosen classification to be recorded as a leading `[<category>]` token in the `--mark-locally-skipped` reason and `--mark-locally-solved` description, making the audit trail in `follow-up-comments.json` show the judgment not just the action.

## Existing Behavior

- `buildReviewPrompt` presented bot review comments with an immediate binary choice: fix (Option A) or skip (Option B), with no structured step to verify the comment first.
- Agents could blindly implement bot suggestions that conflicted with ticket requirements, or rationalize skipping real bugs as "safe/deferred."
- Solve/skip reasons carried free-form text with no classification, making the audit trail opaque.

## Intended New Behavior

- A mandatory judgment block is injected before the Option A / Option B action block, instructing the agent to read the referenced code, verify the bot's claim, and classify before acting.
- The six-category taxonomy prescribes the correct action for each category, with **ambiguous** routing to ask the user rather than guess.
- Classification persists in `comment.resolution` as a `[<category>]` prefix so reviewers can audit why each comment was fixed or skipped.
- `SKILL.md` mirrors the taxonomy so the behavior is documented for engineers and agents alike.

## Brief P0 coverage

- **P0 #1:** Mandatory judgment step in `buildReviewPrompt` with read-and-verify instructions — implemented in `plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js` (`reviewJudgmentBlock` function + splice before the action block)
- **P0 #2:** Six-category classification taxonomy with prescribed actions — implemented in `fix-reviews.js` (`reviewJudgmentBlock`) + documented in `plugins/work/skills/follow-up/SKILL.md`
- **P0 #3:** Classification recorded as `[<category>]` token in solve/skip reason — implemented in step 4 of `reviewJudgmentBlock`
- **P0 #4:** Existing action contract preserved (Option A / Option B, `--mark-locally-*` flags, no-pipe guidance) — verified by `fix-reviews.test.js` preserved action contract describe block

## Scope notes

`git diff --name-only origin/main...HEAD` returns exactly **3 files**, all within this ticket's declared scope:

- `plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js`
- `plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js`
- `plugins/work/skills/follow-up/SKILL.md`

The 65 "unaccounted" files flagged by the prior scope-diff run were produced against a stale base (a feature-heavy base commit, not `origin/main`). There are no sibling-owned or out-of-scope files. The brief explicitly confirms no sibling overlap: tickets #349 and #286 are closed and own different surfaces.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Test plan

1. Run the unit tests:
   ```
   node --test plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
   ```
   All tests in the two new describe blocks (`fix-reviews judgment step` and `fix-reviews preserved action contract`) should pass.

2. Confirm judgment block ordering: call `buildReviewPrompt` with a sample comment and verify that `## Before you act — judge the comment:` appears before `## You MUST do exactly ONE of these:` in the output.

3. Run a follow-up session against a branch with bot review comments and inspect `follow-up-comments.json` to confirm each resolved comment's `reason` / `description` starts with a `[<category>]` token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and documentation changes only in the follow-up workflow; no API or runtime behavior changes beyond what agents are instructed to do when marking comments.
> 
> **Overview**
> Adds a **mandatory judgment step** to the follow-up `fix-reviews` delegate prompt so agents must read the referenced `fileRef`, verify the bot’s claim, and classify the comment **before** choosing Option A (fix) or Option B (skip).
> 
> `fix-reviews.js` introduces `reviewJudgmentBlock` and splices it into `buildReviewPrompt` ahead of the existing fix/skip block. The block defines a **six-category taxonomy** (real bug, real improvement, style/naming, false positive, conflicts with intent, ambiguous) with prescribed actions, and requires a leading **`[<category>]`** prefix on `--mark-locally-skipped` reasons and `--mark-locally-solved` descriptions for auditability in comment resolution.
> 
> `SKILL.md` documents the same judgment flow for `/follow-up` agents. Tests now build the **assembled** prompt via exported `buildReviewPrompt` and assert ordering, taxonomy, and that the prior Option A/B and `--mark-locally-*` contract is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83618f1c25d503a5832574ab6574ade1ef775b26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->