### PR TITLE
fix(completion-checker): accept comma/whitespace-separated requirement IDs in subsection bullets (GH-498)

### DIFF
--- a/plugins/work/agents/completion-checker.md
+++ b/plugins/work/agents/completion-checker.md
@@ -200,3 +200,5 @@ The completion-checker parser accepts two formats for requirement coverage in `t
 The parser (`lib/kind-checks/shared.js::readRequirementCoverage`) tries the top-level table first. When the table is absent OR header-only (header + separator rows with zero data rows), it falls through to the subsection aggregator. When neither path resolves any rows, `coverage_check.validate` returns `ok:false` with an error pointing the operator at `/work-workflow:split-in-tasks`.
 
 The split-in-tasks skill mandates emitting BOTH formats so the rollup table stays authoritative and the fallback is rarely exercised.
+
+**Bullet lines in `### Requirements Covered` accept either one ID per bullet (canonical, recommended) or multiple IDs separated by commas/whitespace on a single bullet. Both forms synthesize identical rows. Emitters in `split-in-tasks` should produce the canonical form.** (GH-498)

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/coverage-fallback.integration.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/coverage-fallback.integration.test.js
@@ -189,6 +189,102 @@ test('coverage_check passes when tasks.md has only subsections', () => {
   }
 });
 
+// Case F — comma-separated multi-ID bullet synthesizes one row per ID (GH-498)
+test('comma-separated multi-ID bullet synthesizes one row per ID', () => {
+  const tasks = [
+    '# Tasks',
+    '',
+    '## Task 1 — Foo',
+    '',
+    '### Requirements Covered',
+    '- R1, R6, R7, R8, R9, R10',
+    '',
+  ].join('\n');
+  const brief = [
+    '# Brief',
+    '',
+    '## Requirements',
+    '',
+    '- **P0** R1 — must do thing one',
+    '- **P0** R6 — must do thing six',
+    '- **P0** R7 — must do thing seven',
+    '- **P0** R8 — must do thing eight',
+    '- **P0** R9 — must do thing nine',
+    '- **P0** R10 — must do thing ten',
+    '',
+  ].join('\n');
+  const { root, tasksDir } = makeTasksDir({ tasks });
+  fs.writeFileSync(path.join(tasksDir, 'brief.md'), brief);
+  try {
+    const rows = readRequirementCoverage(tasksDir);
+    assert.equal(rows.length, 6, 'expected 6 synthesized rows from one comma-separated bullet');
+    const ids = rows.map((r) => r.id).sort();
+    assert.deepEqual(ids, ['R1', 'R10', 'R6', 'R7', 'R8', 'R9']);
+    for (const row of rows) {
+      assert.equal(row.status, 'DELIVERED', `row ${row.id} must default to DELIVERED`);
+      assert.match(
+        row.evidence,
+        /tasks\.md:Task 1/,
+        `row ${row.id} evidence must reference tasks.md:Task 1`
+      );
+    }
+    const result = coverageCheck.validate({ tasksDir });
+    assert.equal(
+      result.ok,
+      true,
+      `coverage_check.validate must pass on comma-separated bullet; got errors=${JSON.stringify(result.errors)}`
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Whitespace variant — space-separated IDs on one bullet synthesize one row each (GH-498)
+test('whitespace-separated multi-ID bullet synthesizes one row per ID', () => {
+  const tasks = [
+    '# Tasks',
+    '',
+    '## Task 1 — Foo',
+    '',
+    '### Requirements Covered',
+    '- R1 R2 R3',
+    '',
+  ].join('\n');
+  const { root, tasksDir } = makeTasksDir({ tasks });
+  try {
+    const rows = readRequirementCoverage(tasksDir);
+    assert.equal(rows.length, 3, 'expected 3 synthesized rows from one space-separated bullet');
+    const ids = rows.map((r) => r.id).sort();
+    assert.deepEqual(ids, ['R1', 'R2', 'R3']);
+    for (const row of rows) {
+      assert.equal(row.status, 'DELIVERED', `row ${row.id} must default to DELIVERED`);
+      assert.match(row.evidence, /tasks\.md:Task 1/, `row ${row.id} evidence must reference task`);
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Prose guard — a prose bullet with a trailing stop must NOT over-synthesize (GH-498)
+test('prose bullet does not over-synthesize rows', () => {
+  const tasks = [
+    '# Tasks',
+    '',
+    '## Task 1 — Foo',
+    '',
+    '### Requirements Covered',
+    '- some prose with a stop.',
+    '',
+  ].join('\n');
+  const { root, tasksDir } = makeTasksDir({ tasks });
+  try {
+    const rows = readRequirementCoverage(tasksDir);
+    assert.equal(rows.length, 0, 'prose bullet (with trailing period) must synthesize 0 rows');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 // Case B — backward compatibility - top-level table preserved
 test('backward compatibility - top-level table preserved', () => {
   const tasks = [

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
@@ -78,10 +78,25 @@ function readRequirementCoverageFromSubsections(tasksText) {
     const nextHeading = reqAfter.match(/^#{2,3}\s/m);
     const reqBlock = nextHeading ? reqAfter.slice(0, nextHeading.index) : reqAfter;
     for (const line of reqBlock.split('\n')) {
-      const m = line.match(/^\s*[-*]\s+([A-Za-z0-9_-]+)\s*$/);
-      if (m) {
+      const bulletMatch = line.match(/^\s*[-*]\s+(.+?)\s*$/);
+      if (!bulletMatch) continue;
+      // GH-498: accept comma/whitespace-separated IDs on one bullet (compat
+      // fallback). A single trailing `\s*$` anchor previously rejected any
+      // bullet carrying more than one token (e.g. `- R1, R6, R7`), yielding
+      // zero rows and re-triggering the GH-462 requirement_coverage_missing
+      // deadlock. Tokenize the payload on commas/whitespace. To avoid
+      // over-synthesizing on prose bullets (e.g. `- some prose with a stop.`),
+      // EVERY token must be ID-shaped; a single non-ID token (a word ending in
+      // punctuation, lowercase prose) disqualifies the whole bullet. Requirement
+      // IDs are alphanumeric/`-`/`_` and carry at least one digit (R1, R10,
+      // REUSE-1) — plain English words do not.
+      const tokens = bulletMatch[1].split(/[\s,]+/).filter(Boolean);
+      const isIdToken = (t) => /^[A-Za-z0-9_-]+$/.test(t) && /\d/.test(t);
+      if (tokens.length === 0 || !tokens.every(isIdToken)) continue;
+      const ids = tokens;
+      for (const id of ids) {
         rows.push({
-          id: m[1],
+          id,
           description: '',
           status: 'DELIVERED',
           evidence: `tasks.md:Task ${taskNum}`,

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
@@ -57,6 +57,29 @@ function readChangedFiles(ctx) {
 }
 
 /**
+ * Extract requirement IDs from a single `### Requirements Covered` bullet line.
+ * Returns one ID per comma/whitespace-separated token, or [] when the line is
+ * not a bullet OR any token is not ID-shaped (prose guard).
+ *
+ * GH-498: accept comma/whitespace-separated IDs on one bullet (compat fallback).
+ * A single trailing `\s*$` anchor previously rejected any bullet carrying more
+ * than one token (e.g. `- R1, R6, R7`), yielding zero rows and re-triggering the
+ * GH-462 requirement_coverage_missing deadlock. To avoid over-synthesizing on
+ * prose bullets (e.g. `- some prose with a stop.`), EVERY token must be
+ * ID-shaped; a single non-ID token disqualifies the whole bullet. Requirement
+ * IDs are alphanumeric/`-`/`_` and carry at least one digit (R1, R10, REUSE-1)
+ * — plain English words do not.
+ */
+function extractBulletIds(line) {
+  const bulletMatch = line.match(/^\s*[-*]\s+(.+?)\s*$/);
+  if (!bulletMatch) return [];
+  const tokens = bulletMatch[1].split(/[\s,]+/).filter(Boolean);
+  const isIdToken = (t) => /^[A-Za-z0-9_-]+$/.test(t) && /\d/.test(t);
+  if (tokens.length === 0 || !tokens.every(isIdToken)) return [];
+  return tokens;
+}
+
+/**
  * Walk `## Task N — <title>` blocks and synthesize coverage rows from each
  * block's `### Requirements Covered` bullet list. Used as a fallback when
  * the top-level `## Requirement Coverage` table is absent. Synthesized rows
@@ -78,23 +101,7 @@ function readRequirementCoverageFromSubsections(tasksText) {
     const nextHeading = reqAfter.match(/^#{2,3}\s/m);
     const reqBlock = nextHeading ? reqAfter.slice(0, nextHeading.index) : reqAfter;
     for (const line of reqBlock.split('\n')) {
-      const bulletMatch = line.match(/^\s*[-*]\s+(.+?)\s*$/);
-      if (!bulletMatch) continue;
-      // GH-498: accept comma/whitespace-separated IDs on one bullet (compat
-      // fallback). A single trailing `\s*$` anchor previously rejected any
-      // bullet carrying more than one token (e.g. `- R1, R6, R7`), yielding
-      // zero rows and re-triggering the GH-462 requirement_coverage_missing
-      // deadlock. Tokenize the payload on commas/whitespace. To avoid
-      // over-synthesizing on prose bullets (e.g. `- some prose with a stop.`),
-      // EVERY token must be ID-shaped; a single non-ID token (a word ending in
-      // punctuation, lowercase prose) disqualifies the whole bullet. Requirement
-      // IDs are alphanumeric/`-`/`_` and carry at least one digit (R1, R10,
-      // REUSE-1) — plain English words do not.
-      const tokens = bulletMatch[1].split(/[\s,]+/).filter(Boolean);
-      const isIdToken = (t) => /^[A-Za-z0-9_-]+$/.test(t) && /\d/.test(t);
-      if (tokens.length === 0 || !tokens.every(isIdToken)) continue;
-      const ids = tokens;
-      for (const id of ids) {
+      for (const id of extractBulletIds(line)) {
         rows.push({
           id,
           description: '',

--- a/plugins/work/skills/split-in-tasks/SKILL.md
+++ b/plugins/work/skills/split-in-tasks/SKILL.md
@@ -126,14 +126,14 @@ After generating all tasks, verify coverage:
 - R7
 ```
 
-The **non-canonical** comma-separated form (multiple IDs on one bullet) is rejected:
+The **non-canonical** comma-separated form (multiple IDs on one bullet) is accepted as a compatibility fallback:
 
 ```markdown
 ### Requirements Covered
-- R1, R6, R7   <!-- NOT canonical — splitter emits a SPLIT-WARNING -->
+- R1, R6, R7   <!-- non-canonical but parsed — splitter still emits a SPLIT-WARNING -->
 ```
 
-This is the one canonical contract for the subsection fallback parser (see GH-498). Comma-separated bullets are historically ambiguous and were silently dropped by the fallback parser, re-triggering the GH-462 `requirement_coverage_missing` deadlock. Always emit one ID per line.
+One ID per line remains the one canonical contract for the subsection fallback parser. As of GH-498 the parser also accepts comma/whitespace-separated IDs on a single bullet and synthesizes identical rows (one per ID), so the historically ambiguous form is no longer silently dropped and no longer re-triggers the GH-462 `requirement_coverage_missing` deadlock. Prefer one ID per line; the comma-separated form is tolerated only for backward compatibility.
 
 ### Step 5: Quality review pass (MANDATORY — do this BEFORE saving)
 

--- a/plugins/work/skills/split-in-tasks/SKILL.md
+++ b/plugins/work/skills/split-in-tasks/SKILL.md
@@ -117,6 +117,24 @@ After generating all tasks, verify coverage:
 
 **The trailing `## Requirement Coverage` table MUST be emitted in every `tasks.md`** even when per-task `### Requirements Covered` subsections are also present. The completion-checker parser primarily reads the top-level table; the subsection fallback exists as a safety net (see GH-462) but the table is still the source of truth. Omitting it forces the parser into the fallback path and obscures rollup status.
 
+**Canonical `### Requirements Covered` bullet format — one ID per line.** Each requirement ID listed in a per-task `### Requirements Covered` subsection MUST be its own bullet:
+
+```markdown
+### Requirements Covered
+- R1
+- R6
+- R7
+```
+
+The **non-canonical** comma-separated form (multiple IDs on one bullet) is rejected:
+
+```markdown
+### Requirements Covered
+- R1, R6, R7   <!-- NOT canonical — splitter emits a SPLIT-WARNING -->
+```
+
+This is the one canonical contract for the subsection fallback parser (see GH-498). Comma-separated bullets are historically ambiguous and were silently dropped by the fallback parser, re-triggering the GH-462 `requirement_coverage_missing` deadlock. Always emit one ID per line.
+
 ### Step 5: Quality review pass (MANDATORY — do this BEFORE saving)
 
 Review all generated tasks and check:
@@ -130,6 +148,7 @@ Review all generated tasks and check:
 - TDD ordering is correct (RED before GREEN before REFACTOR in every non-exempt implementation task — see Rule 10 in [docs/decomposition-rules.md](./docs/decomposition-rules.md) for exemptions)
 - Every non-checkpoint implementation task has a `### Test Command` with a real, runnable test command (see [docs/test-command.md](./docs/test-command.md))
 - Gherkin coverage: every scenario from `gherkin.feature` is referenced by at least one task (if `gherkin.feature` exists)
+- Canonical `### Requirements Covered` bullets: every per-task subsection lists exactly one requirement ID per bullet (see Step 4.3). Any comma-separated multi-ID bullet is non-canonical — the splitter emits a `SPLIT-WARNING` for it, and the operator MUST split it to one ID per line before saving.
 - Anti-patterns are absent (see anti-pattern blocklist in [docs/decomposition-rules.md](./docs/decomposition-rules.md))
 - Split-Warning Passes (Pass A / Pass B / Pass C / Pass D — see [docs/split-warning-passes.md](./docs/split-warning-passes.md)) emit no unresolved `SPLIT-WARNING` lines, or each emitted warning has an operator-resolution decision recorded. Pass D is invoked deterministically as `node "${CLAUDE_PLUGIN_ROOT}/plugins/work/skills/split-in-tasks/lib/emit-warnings.js" "${TASKS_DIR}"` and exits non-zero when any kind-D violation is emitted; treat its exit code as a gate alongside Pass A/B/C. **Severity asymmetry:** Pass A/B/C are advisory (operator resolves inline); Pass D is a hard gate (non-zero exit blocks the commit). See [Severity model](./docs/split-warning-passes.md#severity-model--why-d-is-blocking-and-abc-are-advisory) for the rationale.
 


### PR DESCRIPTION
## Summary

- Fixes the recurrence of the GH-462 `requirement_coverage_missing` deadlock caused by comma/whitespace-separated IDs on a single `### Requirements Covered` bullet being silently dropped.
- Adds `extractBulletIds` helper to `shared.js` that tokenizes multi-ID bullets and synthesizes one coverage row per ID, with a prose guard to prevent over-synthesis.
- Documents the canonical one-ID-per-line bullet format in `SKILL.md` and `completion-checker.md`, marking the multi-ID form as an accepted compatibility fallback.

## Test plan

- [ ] Run `node --test plugins/work/scripts/workflows/work-completion-checker/__tests__/coverage-fallback.integration.test.js` — expect 8/8 pass including the 3 new GH-498 cases.
- [ ] Verify a task dir with a comma-separated bullet (`- R1, R6, R7`) passes `coverage_check.validate` and synthesizes 3 rows.
- [ ] Verify a prose bullet (`- some prose description.`) synthesizes 0 rows (prose guard).

## Existing Behavior

- The subsection fallback parser in `shared.js` only accepted bullets with exactly one requirement ID per line (regex anchored with a trailing whitespace anchor).
- Bullets listing multiple IDs (e.g. `- R1, R6, R7`) were silently dropped, producing zero synthesized rows.
- Zero rows caused `coverage_check.validate` to return `ok:false` with a `requirement_coverage_missing` error, re-triggering the GH-462 deadlock even when the author had correctly listed all IDs.
- The `split-in-tasks` SKILL.md and `completion-checker.md` agent doc did not document the canonical one-ID-per-line format or the acceptance of the comma-separated fallback.

## Intended New Behavior

- A new `extractBulletIds` helper tokenizes each bullet by comma/whitespace, validates every token is ID-shaped (alphanumeric/`-`/`_` with at least one digit), and synthesizes one coverage row per token.
- A prose guard ensures non-ID tokens (plain English words, trailing periods) disqualify the entire bullet, preventing over-synthesis.
- `SKILL.md` now documents the canonical one-ID-per-line format and marks the comma/whitespace form as a non-canonical but accepted compatibility fallback with a SPLIT-WARNING.
- `completion-checker.md` documents that bullet lines accept both one-ID-per-bullet and multi-ID-per-bullet, with the canonical form preferred.

## Brief P0 coverage

- **P0 #1:** Comma/whitespace-separated multi-ID bullets synthesize one coverage row per ID — implemented in `plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js` (`extractBulletIds` helper + updated `readRequirementCoverageFromSubsections` loop) + tested in `plugins/work/scripts/workflows/work-completion-checker/__tests__/coverage-fallback.integration.test.js` (Cases F, whitespace variant, prose guard)
- **P0 #2:** Prose guard prevents over-synthesis on plain English bullets — implemented in `shared.js:extractBulletIds` (every token must be ID-shaped) + test `coverage-fallback.integration.test.js` ("prose bullet does not over-synthesize rows")
- **P0 #3:** Canonical format documented — implemented in `plugins/work/skills/split-in-tasks/SKILL.md` (Step 4.3 + Step 5 quality checklist) and `plugins/work/agents/completion-checker.md`

## Out-of-scope changes

**Scope note:** A scope-diff tool reports approximately 65 "unaccounted" files (heimdall/*, maestro/*, etc.). This is a stale-base false positive — those files pre-exist on the branch base and were NOT introduced by this work. The genuine change set is 4 files, all owned by GH-498:

- `plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js` — core fix
- `plugins/work/scripts/workflows/work-completion-checker/__tests__/coverage-fallback.integration.test.js` — new tests
- `plugins/work/skills/split-in-tasks/SKILL.md` — canonical format docs
- `plugins/work/agents/completion-checker.md` — dual-format acceptance docs

The 65-file count from the scope-diff tool reflects the stale base, not sibling-owned changes.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend/parser change — verify via test suite:**

1. In the worktree root, run the integration test directly:
   ```bash
   node --test plugins/work/scripts/workflows/work-completion-checker/__tests__/coverage-fallback.integration.test.js
   ```
   Expected: 8/8 tests pass, including the 3 new GH-498 cases (comma-separated, whitespace-separated, prose guard).

2. To manually reproduce the fix, create a task file with a comma-separated bullet in a `### Requirements Covered` subsection, then run the completion-checker against that task dir. The `coverage_check.validate` call should return `ok:true` and synthesize one row per ID instead of the previous 0 rows / `requirement_coverage_missing` error.

3. To verify the prose guard, use a bullet like `- some prose description.` — the checker should synthesize 0 rows (non-ID token with trailing period disqualifies the bullet).

### Test Results

8/8 integration tests pass (including 3 new GH-498 cases: comma-separated Case F, whitespace variant, prose guard).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized markdown parsing in the completion-checker fallback path; behavior change only affects subsection bullets without a top-level coverage table, with integration tests covering edge cases.
> 
> **Overview**
> Fixes **GH-462-style `requirement_coverage_missing` deadlocks** when `tasks.md` only has per-task `### Requirements Covered` bullets that list **multiple requirement IDs on one line** (comma- or space-separated). Those bullets were previously ignored by the subsection fallback parser, so coverage looked empty even when IDs were present.
> 
> **Parser (`shared.js`):** Adds `extractBulletIds` and uses it in `readRequirementCoverageFromSubsections` to emit **one synthesized row per ID** (same `DELIVERED` / `tasks.md:Task N` behavior as single-ID bullets). A **prose guard** rejects the whole bullet if any token is not ID-shaped (must include a digit), so plain-English bullets do not spawn fake rows.
> 
> **Tests:** Three integration cases cover comma-separated lists, whitespace-separated lists, and prose bullets.
> 
> **Docs:** `split-in-tasks` and `completion-checker` now state **one ID per bullet is canonical**; multi-ID lines are a **tolerated compatibility fallback** (split-in-tasks still treats comma-separated bullets as non-canonical / SPLIT-WARNING).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4faa04f86bfcc18af5895a7a250a60826d1394c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->