### PR TITLE
fix(heimdall): make the secrets OS boundary actually enforceable (escalation gates + rootless docker + reminder hook)

### DIFF
--- a/plugins/heimdall/hooks/heimdall-secrets-reminder.js
+++ b/plugins/heimdall/hooks/heimdall-secrets-reminder.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/*
+ * heimdall-secrets-reminder.js — SessionStart nag.
+ *
+ * If THIS project (or an ancestor) declares a secret for protection in
+ * heimdall-conceal.json but the OS boundary is NOT actually installed (the agent
+ * can still read it / the broker is missing / a rootful-docker bypass is open),
+ * inject a blunt reminder at session start. It repeats every session until the
+ * privileged install is done — so "I ran /heimdall:install but skipped the sudo
+ * step" can never quietly look protected.
+ *
+ * Decision is delegated to heimdall-conceal-status.js (single source of truth):
+ *   exit 2 -> NOT PROTECTED -> remind.   exit 0 -> protected/absent -> silent.
+ */
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+function projectDir() {
+  if (process.env.CLAUDE_PROJECT_DIR) return process.env.CLAUDE_PROJECT_DIR;
+  try {
+    const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+    if (input && typeof input.cwd === 'string') return input.cwd;
+  } catch {
+    /* no/!json stdin — fall through to cwd */
+  }
+  return process.cwd();
+}
+
+function main() {
+  const dir = projectDir();
+  const status = path.join(__dirname, '..', 'scripts', 'heimdall-conceal-status.js');
+  // The status script owns the verdict AND the case-specific message (install
+  // not run vs. installed-but-docker-bypassable) via --reminder. Single source
+  // of truth: the hook just forwards its text. Args passed as argv (no shell).
+  const r = spawnSync(process.execPath, [status, dir, '--reminder'], { encoding: 'utf8' });
+  if (r.status !== 2 || !r.stdout || !r.stdout.trim()) return; // protected / no config / nothing to say
+
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: r.stdout.trim() },
+    })
+  );
+}
+
+main();

--- a/plugins/heimdall/hooks/hooks.json
+++ b/plugins/heimdall/hooks/hooks.json
@@ -37,6 +37,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/heimdall-secrets-reminder.js\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/heimdall/scripts/heimdall-conceal-status.js
+++ b/plugins/heimdall/scripts/heimdall-conceal-status.js
@@ -8,7 +8,10 @@ const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
 
-const startDir = path.resolve(process.argv[2] || process.env.CLAUDE_PROJECT_DIR || process.cwd());
+// First non-flag arg is the repo dir; flags like --reminder are filtered out so
+// `node status.js --reminder` doesn't mistake the flag for a path.
+const posArgs = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const startDir = path.resolve(posArgs[0] || process.env.CLAUDE_PROJECT_DIR || process.cwd());
 
 // Resolve uid/gid → name from /etc/passwd /etc/group (plain file reads). We
 // deliberately avoid spawning `stat`/`id`: passing env/argv-derived paths to a
@@ -109,6 +112,11 @@ function pick(out, key, value) {
 // defined value.
 function mergeOne(out, dir, cfg) {
   for (const f of cfg.secretsFiles || []) out.secretsFiles.push(absUnder(dir, f));
+  // CLI consumers (injectCommands) lock their own secretsFile — count those too,
+  // else an inject-only repo audits as "conceal-only" and hides the real secret.
+  for (const c of cfg.injectCommands || []) {
+    if (c && c.secretsFile) out.secretsFiles.push(absUnder(dir, c.secretsFile));
+  }
   pick(out, 'wrapper', cfg.wrapper && absUnder(dir, cfg.wrapper));
   pick(out, 'mcpJson', cfg.mcpJson && absUnder(dir, cfg.mcpJson));
   pick(out, 'brokerPath', cfg.brokerPath);
@@ -123,7 +131,11 @@ function mergeForAudit(configs) {
   // nearest config. Use that dir so the audit reports the broker path harden
   // installed, even when run from a subdirectory under a guard-only config.
   const sb = configs.find(
-    (c) => (c.cfg.secretsFiles || []).length || c.cfg.wrapper || c.cfg.brokerPath
+    (c) =>
+      (c.cfg.secretsFiles || []).length ||
+      (c.cfg.injectCommands || []).length ||
+      c.cfg.wrapper ||
+      c.cfg.brokerPath
   );
   out.secretsBase = sb ? sb.dir : undefined;
   return out;
@@ -155,6 +167,61 @@ function reportSecretsFiles(secretsFiles) {
   return protectedCount;
 }
 
+// Escalation check (runs AS the agent uid): a file-ownership boundary is void if
+// the agent can become root. The dominant non-interactive path is a ROOTFUL
+// docker socket reachable via the 'docker' group. We detect it WITHOUT spawning
+// docker (CodeQL-safe): agent is in the docker group AND the system socket is
+// accessible. A rootless socket lives under /run/user/<uid>/ and is not flagged.
+// Passwordless sudo can't be probed from here without spawning sudo, so it's
+// left to the installer's gate; we note it.
+function dockerGid() {
+  try {
+    for (const line of fs.readFileSync('/etc/group', 'utf8').split('\n')) {
+      const f = line.split(':');
+      if (f[0] === 'docker' && f.length > 2) return Number(f[2]);
+    }
+  } catch {
+    /* no /etc/group → treat as no docker group */
+  }
+  return null;
+}
+
+function agentDockerBypass() {
+  const gid = dockerGid();
+  if (gid === null) return false;
+  let groups = [];
+  try {
+    groups = process.getgroups();
+  } catch {
+    return false;
+  }
+  if (!groups.includes(gid)) return false;
+  // In the docker group — is the ROOTFUL system socket actually reachable?
+  try {
+    fs.accessSync('/var/run/docker.sock', fs.constants.R_OK | fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function reportEscalation() {
+  const bypass = agentDockerBypass();
+  if (bypass) {
+    console.log(
+      "Escalation:  BYPASSABLE — agent is in the 'docker' group with a reachable rootful socket (root-equivalent)."
+    );
+    console.log(
+      '             Fix: sudo bash setup-rootless-docker.sh <you> + dockerd-rootless-setuptool.sh install + wsl --shutdown.'
+    );
+  } else {
+    console.log(
+      'Escalation:  no docker-group bypass (sudo password requirement checked by the installer).'
+    );
+  }
+  return bypass;
+}
+
 function reportMcpWiring(mcpJson, broker) {
   if (!mcpJson) {
     console.log('.mcp.json:   not configured');
@@ -171,8 +238,63 @@ function reportMcpWiring(mcpJson, broker) {
   }
 }
 
+// Non-printing count of locked (present + agent-denied) secrets files — used by
+// the reminder path, which must compute the verdict without emitting the report.
+function countProtected(secretsFiles) {
+  let n = 0;
+  for (const p of secretsFiles) {
+    if (fs.existsSync(p) && !canAgentRead(p)) n++;
+  }
+  return n;
+}
+
+// Case-specific reminder text (SessionStart hook). null = nothing to nag about.
+// Critically, it names the ACTUAL remaining step: "install not run" vs "installed
+// but docker bypass still open" point at different fixes.
+function buildReminder(total, protectedCount, bypassable) {
+  if (total === 0) return null; // no secrets configured
+  if (protectedCount < total) {
+    return (
+      '⚠️  HEIMDALL: a secret here is NOT PROTECTED — the LLM/agent can read it. ' +
+      'The privileged OS install has not been run.\n' +
+      '   Fix: /heimdall:harden (one sudo). This repeats every session until done.'
+    );
+  }
+  if (bypassable) {
+    return (
+      '⚠️  HEIMDALL: the secret file IS locked, but the rootful-docker bypass is OPEN — ' +
+      'the LLM/agent can still read it via `docker run -v /:/host`.\n' +
+      '   Fix (NOT a re-install): sudo bash setup-rootless-docker.sh <you> + ' +
+      'dockerd-rootless-setuptool.sh install + wsl --shutdown.\n' +
+      '   This repeats every session until docker can no longer reach the secret.'
+    );
+  }
+  return null; // protected, no docker bypass
+}
+
+// SessionStart reminder path: silent unless a configured secret is reachable.
+function runReminder(found) {
+  if (found.state !== 'ok') {
+    process.exitCode = 0;
+    return;
+  }
+  const m = mergeForAudit(found.configs);
+  const total = m.secretsFiles.length;
+  const text = buildReminder(total, countProtected(m.secretsFiles), agentDockerBypass());
+  if (text) {
+    console.log(text);
+    process.exitCode = 2;
+  } else {
+    process.exitCode = 0;
+  }
+}
+
 function main() {
   const found = collectConfigs(startDir);
+  if (process.argv.includes('--reminder')) {
+    runReminder(found);
+    return;
+  }
   if (found.state === 'absent') {
     console.log(`heimdall: no config at or above ${startDir} → guard inactive for this project.`);
     process.exit(0);
@@ -207,19 +329,48 @@ function main() {
   console.log(`Broker conf: ${brokerConf}  [${stat(brokerConf)}]`);
 
   reportMcpWiring(m.mcpJson, broker);
+  const bypassable = reportEscalation();
 
   console.log('');
-  if (m.secretsFiles.length === 0) {
-    // Conceal-only project: hook-level deny patterns with no MCP secrets to lock.
-    // There is nothing for harden to do, so don't suggest it.
+  reportStatus(m.secretsFiles.length, protectedCount, bypassable);
+}
+
+// Final verdict + exit code. Exit codes let the install/harden flow GATE on real
+// protection rather than trusting the user ran the privileged step: 0 = protected
+// (or n/a), 2 = secrets are reachable by the agent/LLM (NOT protected).
+function reportStatus(total, protectedCount, bypassable) {
+  if (total === 0) {
+    // Conceal-only: hook-level deny patterns, no MCP secrets to lock.
     console.log(
       'STATUS: conceal-only — hook-level deny patterns active; no secretsFiles configured, so /heimdall:harden does not apply.'
     );
-  } else if (protectedCount === m.secretsFiles.length) {
-    console.log('STATUS: boundary ACTIVE — agent uid is denied on all (existing) secrets files.');
-  } else {
-    console.log('STATUS: boundary NOT fully active — run /heimdall:harden (sudo setup).');
+    process.exitCode = 0;
+    return;
   }
+  if (protectedCount === total && !bypassable) {
+    console.log(
+      'STATUS: PROTECTED — the agent/LLM is denied on all secrets files, with no rootful-docker escalation path.'
+    );
+    process.exitCode = 0;
+    return;
+  }
+  if (protectedCount === total && bypassable) {
+    console.log(
+      'STATUS: NOT PROTECTED (BYPASSABLE) — the OS install IS done (files locked, broker installed), but the agent/LLM can still become root via the rootful docker socket and read them.'
+    );
+    console.log(
+      '        Close the docker path: sudo bash setup-rootless-docker.sh <you> + dockerd-rootless-setuptool.sh install + wsl --shutdown. (No need to re-run the secrets install.)'
+    );
+    process.exitCode = 2;
+    return;
+  }
+  console.log(
+    'STATUS: NOT PROTECTED — the agent/LLM CAN READ these secrets right now. The privileged OS install has NOT been run,'
+  );
+  console.log(
+    '        so Heimdall is doing NOTHING to block reads. You MUST run /heimdall:harden and authenticate (sudo) for this to work.'
+  );
+  process.exitCode = 2;
 }
 
 main();

--- a/plugins/heimdall/scripts/heimdall-run-privileged.sh
+++ b/plugins/heimdall/scripts/heimdall-run-privileged.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# heimdall-run-privileged.sh — run a privileged Heimdall script, escalating as
+# automatically as the host allows so callers (install/harden skills) don't have
+# to hand-roll the sudo dance. A privilege boundary inherently needs ONE auth to
+# create, so the worst case is a single password prompt — never silent.
+#
+# Escalation order:
+#   1. already root            -> run directly
+#   2. sudo -n works           -> cached creds / NOPASSWD, run silently
+#   3. pkexec + a display      -> polkit GUI auth dialog (no TTY needed)
+#   4. otherwise               -> print the exact `! sudo …` line for the user's
+#                                 terminal and exit 10 (NEEDS_PASSWORD)
+#
+# Usage: heimdall-run-privileged.sh <script.sh> [args...]
+#
+set -euo pipefail
+
+TARGET="${1:-}"
+shift || true
+[ -n "${TARGET}" ] && [ -f "${TARGET}" ] || { echo "ERROR: script not found: ${TARGET}" >&2; exit 2; }
+
+if [ "$(id -u)" -eq 0 ]; then
+  exec bash "${TARGET}" "$@"
+fi
+
+if sudo -n true >/dev/null 2>&1; then
+  echo ">> escalating via cached/NOPASSWD sudo" >&2
+  exec sudo -n bash "${TARGET}" "$@"
+fi
+
+if command -v pkexec >/dev/null 2>&1 && [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]; then
+  echo ">> escalating via pkexec (a desktop auth dialog will appear)" >&2
+  exec pkexec bash "${TARGET}" "$@"
+fi
+
+# No non-interactive path. Build the exact command the user should run in their
+# OWN terminal, where sudo can prompt for the password.
+CMD="sudo bash $(printf '%q' "${TARGET}")"
+for a in "$@"; do CMD="${CMD} $(printf '%q' "$a")"; done
+{
+  echo "NEEDS_PASSWORD"
+  echo "This installs root-owned files and must authenticate once. Run it in your"
+  echo "terminal so sudo can prompt — type the following (the leading '!' runs it"
+  echo "inside your Claude session):"
+  echo
+  echo "  ! ${CMD}"
+} >&2
+exit 10

--- a/plugins/heimdall/scripts/heimdall-run-privileged.sh
+++ b/plugins/heimdall/scripts/heimdall-run-privileged.sh
@@ -31,7 +31,19 @@ fi
 
 if command -v pkexec >/dev/null 2>&1 && [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]; then
   echo ">> escalating via pkexec (a desktop auth dialog will appear)" >&2
-  exec pkexec bash "${TARGET}" "$@"
+  # Do NOT `exec` here: if the user dismisses the polkit dialog, pkexec exits
+  # 126/127 and would terminate us before the NEEDS_PASSWORD fallback. Run it,
+  # then decide: 126/127 = auth cancelled/denied -> fall through to instructions;
+  # any other code = auth succeeded and the wrapped script ran, so propagate ITS
+  # real exit code (0 ok, 1 bypassable, 10 needs-password, ...).
+  set +e
+  pkexec bash "${TARGET}" "$@"
+  rc=$?
+  set -e
+  if [ "${rc}" -ne 126 ] && [ "${rc}" -ne 127 ]; then
+    exit "${rc}"
+  fi
+  echo ">> pkexec auth was cancelled/denied — falling back to terminal instructions" >&2
 fi
 
 # No non-interactive path. Build the exact command the user should run in their

--- a/plugins/heimdall/scripts/setup-rootless-docker.sh
+++ b/plugins/heimdall/scripts/setup-rootless-docker.sh
@@ -42,14 +42,22 @@ else
 fi
 
 # 2. Ensure subuid/subgid ranges exist (rootless maps container uids into these).
-if ! grep -q "^${AGENT_USER}:" /etc/subuid 2>/dev/null; then
-  echo "${AGENT_USER}:100000:65536" >>/etc/subuid
-  echo ">> Added /etc/subuid range for ${AGENT_USER}"
-fi
-if ! grep -q "^${AGENT_USER}:" /etc/subgid 2>/dev/null; then
-  echo "${AGENT_USER}:100000:65536" >>/etc/subgid
-  echo ">> Added /etc/subgid range for ${AGENT_USER}"
-fi
+#    Do NOT hardcode 100000:65536 — on a multi-user host that range is usually
+#    already claimed by the first system user, and a collision makes newuidmap
+#    fail with an opaque "invalid mapping". Allocate the next free block instead:
+#    start just past the highest existing (start+count) end in the file.
+SUBID_COUNT=65536
+add_subid_range() {
+  local file="$1"
+  if grep -q "^${AGENT_USER}:" "$file" 2>/dev/null; then return 0; fi
+  local start
+  start=$(awk -F: 'NF>=3 {e=$2+$3; if (e>m) m=e} END {print (m>0?m:100000)}' "$file" 2>/dev/null)
+  [ -n "$start" ] || start=100000
+  echo "${AGENT_USER}:${start}:${SUBID_COUNT}" >>"$file"
+  echo ">> Added ${file##*/} range for ${AGENT_USER} (${start}:${SUBID_COUNT})"
+}
+add_subid_range /etc/subuid
+add_subid_range /etc/subgid
 
 # 3. Remove the agent from the rootful docker group — this is the escalation we
 #    are closing. After this the agent can only use the rootless socket.

--- a/plugins/heimdall/scripts/setup-rootless-docker.sh
+++ b/plugins/heimdall/scripts/setup-rootless-docker.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# setup-rootless-docker.sh — neutralize the docker escalation path for the agent.
+#
+# WHY: a setuid/ownership secrets boundary is meaningless if the agent uid can
+# reach a ROOTFUL docker socket, because the docker daemon runs as root and will
+# read any file (`docker run -v /:/host …`). The fix is NOT to remove docker —
+# it is to give the agent ROOTLESS docker, where the daemon runs as the user and
+# container-root maps to the user's own (sub)uids, so it cannot read a different
+# uid's 0600 secret. The agent keeps full container functionality for its apps.
+#
+# This script does the ROOT-only half (packages, subuid/subgid, group removal,
+# linger); the rootless daemon itself MUST be installed by the target user (it
+# needs their user/systemd session), so we print that one user-level command at
+# the end instead of fragile `su` gymnastics.
+#
+# Usage (run as root):
+#   sudo bash setup-rootless-docker.sh <agent-user>
+#
+set -euo pipefail
+
+AGENT_USER="${1:-}"
+die() { echo "ERROR: $*" >&2; exit 1; }
+[ "$(id -u)" -eq 0 ] || die "must run as root (use sudo)"
+[ -n "${AGENT_USER}" ] || die "usage: sudo bash setup-rootless-docker.sh <agent-user>"
+id -u "${AGENT_USER}" >/dev/null 2>&1 || die "user '${AGENT_USER}' not found"
+
+echo ">> Configuring rootless docker for ${AGENT_USER}"
+
+# 1. Install rootless prerequisites (best-effort across apt / dnf).
+PKGS_APT="uidmap slirp4netns dbus-user-session docker-ce-rootless-extras"
+PKGS_DNF="shadow-utils slirp4netns fuse-overlayfs"
+if command -v apt-get >/dev/null 2>&1; then
+  apt-get update -y || true
+  # docker-ce-rootless-extras may be absent if docker came from distro repos;
+  # install what is available and continue (the setuptool reports any gap).
+  for p in ${PKGS_APT}; do apt-get install -y "$p" 2>/dev/null || echo "   (skipped unavailable pkg: $p)"; done
+elif command -v dnf >/dev/null 2>&1; then
+  for p in ${PKGS_DNF}; do dnf install -y "$p" 2>/dev/null || echo "   (skipped unavailable pkg: $p)"; done
+else
+  echo "   WARNING: no apt-get/dnf — install rootless deps (uidmap, slirp4netns) manually"
+fi
+
+# 2. Ensure subuid/subgid ranges exist (rootless maps container uids into these).
+if ! grep -q "^${AGENT_USER}:" /etc/subuid 2>/dev/null; then
+  echo "${AGENT_USER}:100000:65536" >>/etc/subuid
+  echo ">> Added /etc/subuid range for ${AGENT_USER}"
+fi
+if ! grep -q "^${AGENT_USER}:" /etc/subgid 2>/dev/null; then
+  echo "${AGENT_USER}:100000:65536" >>/etc/subgid
+  echo ">> Added /etc/subgid range for ${AGENT_USER}"
+fi
+
+# 3. Remove the agent from the rootful docker group — this is the escalation we
+#    are closing. After this the agent can only use the rootless socket.
+if id -nG "${AGENT_USER}" | tr ' ' '\n' | grep -qx docker; then
+  gpasswd -d "${AGENT_USER}" docker >/dev/null && echo ">> Removed ${AGENT_USER} from the 'docker' group"
+else
+  echo ">> ${AGENT_USER} not in the 'docker' group (good)"
+fi
+
+# 4. Keep the rootless daemon alive without an active login session.
+if command -v loginctl >/dev/null 2>&1; then
+  loginctl enable-linger "${AGENT_USER}" 2>/dev/null && echo ">> Enabled linger for ${AGENT_USER}" || true
+fi
+
+UID_NUM="$(id -u "${AGENT_USER}")"
+echo
+echo "=============================================================="
+echo " Root-side rootless setup done for ${AGENT_USER}."
+echo
+echo " FINISH AS ${AGENT_USER} (not root) — installs the rootless daemon:"
+echo "     dockerd-rootless-setuptool.sh install"
+echo "     docker context use rootless"
+echo "   (or: export DOCKER_HOST=unix:///run/user/${UID_NUM}/docker.sock)"
+echo
+echo " Then re-run the secrets verify to confirm the bypass is closed:"
+echo "     docker run --rm -v /:/host:ro alpine cat /host/path/to/.secrets   # must FAIL"
+echo
+echo " NOTE: rootless docker does not support --privileged, host networking, or"
+echo " ports <1024 without setcap. If an app needs those, use a docker-socket"
+echo " proxy instead and keep the agent off the raw socket."
+echo "=============================================================="

--- a/plugins/heimdall/scripts/setup-secrets-heimdall.sh
+++ b/plugins/heimdall/scripts/setup-secrets-heimdall.sh
@@ -27,9 +27,15 @@ BROKER_PREBUILT="${SCRIPT_DIR}/bin/mcp-pg-broker.linux-$(uname -m)"
 # either order (`--revert <repo>`, `<repo> --revert`, `<repo>`, `--revert`, none).
 REVERT=
 REPO_ARG=
-for a in "${1:-}" "${2:-}"; do
+# By default we REFUSE to report success when the agent uid can still reach the
+# secret via a root-equivalent path (rootful docker socket / passwordless sudo) —
+# the file boundary is meaningless against root. --allow-escalation downgrades
+# that hard failure to a loud warning for operators who accept the residual risk.
+ALLOW_ESCALATION=
+for a in "${1:-}" "${2:-}" "${3:-}"; do
   case "$a" in
     --revert) REVERT=1 ;;
+    --allow-escalation) ALLOW_ESCALATION=1 ;;
     "") : ;;
     *) [ -z "${REPO_ARG}" ] && REPO_ARG="$a" ;;
   esac
@@ -105,6 +111,10 @@ out.push(`REWRITE_MCP=${q(cfg.rewriteMcpJson === false || hasInject ? '' : '1')}
 out.push(`SECRETS_FILES=(${secretsFiles.map((f) => q(abs(f))).join(' ')})`);
 out.push(`HAS_INJECT=${q(hasInject ? '1' : '')}`);
 out.push(`INJECT_GROUPS=${q(groups.join(','))}`);
+// Exec targets the broker will run as RUN_USER. These MUST be root-owned, else
+// the agent could rewrite one to dump the (runner-readable) secret. Emit them so
+// step 5b can lock them down.
+out.push(`EXEC_TARGETS=(${inject.map((c) => q(abs(c.exec))).join(' ')})`);
 out.push(`COMMANDS_JSON_B64=${q(Buffer.from(JSON.stringify(commandsMap, null, 2)).toString('base64'))}`);
 process.stdout.write(out.join('\n') + '\n');
 NODE
@@ -226,6 +236,16 @@ if [ -n "${HAS_INJECT}" ]; then
   chown root:root "${COMMANDS_JSON}"
   chmod 0644 "${COMMANDS_JSON}"
   echo ">> Wrote ${COMMANDS_JSON} (root:root 0644)"
+  # Root-own each exec target. The broker runs these as RUN_USER (which CAN read
+  # the secret), so an agent-writable exec would be a trivial exfil path: rewrite
+  # it to `cat <secret>`. Locking to root:root 0755 keeps it agent-runnable (via
+  # the broker) but not agent-modifiable. The agent never edits these directly.
+  for x in "${EXEC_TARGETS[@]}"; do
+    [ -e "$x" ] || die "injectCommands exec not found: $x"
+    chown root:root "$x"
+    chmod 0755 "$x"
+    echo ">> Hardened exec ${x} -> root:root 0755 (agent cannot rewrite it)"
+  done
   if [ -n "${INJECT_GROUPS}" ]; then
     IFS=',' read -ra _grps <<<"${INJECT_GROUPS}"
     for g in "${_grps[@]}"; do
@@ -289,7 +309,50 @@ for f in "${SECRETS_FILES[@]}"; do
     die "agent uid CAN still read $f — boundary FAILED"
   fi
 done
-echo "   OK: ${AGENT_USER} is denied on all secrets files"
+echo "   OK: ${AGENT_USER} is denied a direct read on all secrets files"
+
+# 8b. The direct-read denial above is worthless if the agent uid can become root.
+#     A rootful docker socket and passwordless sudo are each root-equivalent and
+#     read any file regardless of ownership. Detect both; by default FAIL (an
+#     honest boundary refuses to claim success it cannot deliver), or WARN under
+#     --allow-escalation.
+echo ">> Checking the agent uid has no root-equivalent escalation path..."
+ESCALATION_FOUND=
+
+# Rootful docker socket: agent can reach /var/run/docker.sock AND the daemon is
+# rootful (rootless docker maps container-root to the user, so it CANNOT read a
+# foreign uid's 0600 file — that variant is fine and is not flagged).
+if sudo -n -u "${AGENT_USER}" test -r /var/run/docker.sock 2>/dev/null; then
+  DSEC="$(sudo -n -u "${AGENT_USER}" docker -H unix:///var/run/docker.sock info --format '{{.SecurityOptions}}' 2>/dev/null || true)"
+  case "${DSEC}" in
+    *rootless*) echo "   docker: agent reaches a ROOTLESS daemon — not a bypass (OK)" ;;
+    *)
+      ESCALATION_FOUND=1
+      echo "   !! docker: ${AGENT_USER} can reach the ROOTFUL docker socket — root-equivalent, can read the secret"
+      ;;
+  esac
+fi
+
+# Passwordless sudo (cached creds or NOPASSWD) lets the agent read anything now.
+# Password-required sudo is fine: the agent cannot supply it non-interactively.
+if sudo -n -u "${AGENT_USER}" sudo -n true >/dev/null 2>&1; then
+  ESCALATION_FOUND=1
+  echo "   !! sudo: ${AGENT_USER} has PASSWORDLESS sudo — root-equivalent, can read the secret"
+fi
+
+if [ -n "${ESCALATION_FOUND}" ]; then
+  echo
+  echo "   The file boundary holds, but ${AGENT_USER} can become root and walk around it."
+  echo "   To close it (keeps docker for your apps):"
+  echo "     - rootless docker:  sudo bash ${SCRIPT_DIR}/setup-rootless-docker.sh ${AGENT_USER}"
+  echo "     - or remove the agent from the 'docker' group / revoke passwordless sudo"
+  if [ -z "${ALLOW_ESCALATION}" ]; then
+    die "agent uid has a root-equivalent escalation path — boundary is BYPASSABLE. Close it (above), or re-run with --allow-escalation to accept the risk."
+  fi
+  echo "   WARNING: --allow-escalation set — proceeding with a BYPASSABLE boundary."
+else
+  echo "   OK: no rootful-docker / passwordless-sudo escalation path for ${AGENT_USER}"
+fi
 
 echo
 echo "=============================================================="

--- a/plugins/heimdall/scripts/setup-secrets-heimdall.sh
+++ b/plugins/heimdall/scripts/setup-secrets-heimdall.sh
@@ -326,6 +326,14 @@ if sudo -n -u "${AGENT_USER}" test -r /var/run/docker.sock 2>/dev/null; then
   DSEC="$(sudo -n -u "${AGENT_USER}" docker -H unix:///var/run/docker.sock info --format '{{.SecurityOptions}}' 2>/dev/null || true)"
   case "${DSEC}" in
     *rootless*) echo "   docker: agent reaches a ROOTLESS daemon — not a bypass (OK)" ;;
+    "")
+      # Empty = the query itself failed (docker CLI not in PATH, or daemon
+      # unreachable) — we could NOT confirm the daemon type. The agent can still
+      # reach the socket (raw HTTP works without the CLI), so fail CLOSED, but
+      # say so honestly instead of asserting a confirmed rootful socket.
+      ESCALATION_FOUND=1
+      echo "   !! docker: ${AGENT_USER} can reach /var/run/docker.sock but the daemon type could not be queried (docker CLI missing / daemon down) — treating as ROOTFUL (fail-closed)"
+      ;;
     *)
       ESCALATION_FOUND=1
       echo "   !! docker: ${AGENT_USER} can reach the ROOTFUL docker socket — root-equivalent, can read the secret"

--- a/plugins/heimdall/skills/harden/SKILL.md
+++ b/plugins/heimdall/skills/harden/SKILL.md
@@ -35,21 +35,70 @@ repo basename plus a short hash of its absolute path) that the script writes.
    `wrapper`/`allowlist` (see "CLI consumers" below). Confirm values with the
    user before proceeding.
 
-## Phase 2 — privileged install (user runs)
+## Phase 2 — privileged install (auto-escalating)
 
-The plugin cannot run sudo. Tell the user to run, and explain each step:
+Do NOT hand the user a raw `sudo` line. Run the install through the bootstrap,
+which escalates as automatically as the host allows (root → cached/NOPASSWD sudo
+→ pkexec GUI → else a single `!`-prefixed command for the user's terminal):
 ```bash
-sudo bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-secrets-heimdall.sh" "<repo>"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-run-privileged.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/setup-secrets-heimdall.sh" "<repo>"
 ```
-This creates the runner uid, locks the secrets file (0600), hardens the wrapper,
-compiles+installs the setuid broker, rewrites `.mcp.json`, and verifies the
-agent uid is denied.
+The wrapped installer creates the runner uid, locks each secrets file (0600),
+installs the setuid broker + (for `injectCommands`) the shipped wrapper, command
+map, and **root-owns every `exec` target** (so the agent cannot rewrite one to
+dump the secret), rewrites `.mcp.json` when applicable, and verifies the agent
+uid is denied — both a direct read AND any root-equivalent escalation path.
 
-## Phase 3 — after
+**If the bootstrap exits 10 (`NEEDS_PASSWORD`)**: it printed the exact
+`! sudo …` line. Surface that line verbatim and tell the user to run it in their
+terminal (the `!` prefix runs it in-session so sudo can prompt). Then continue.
 
-1. Restart Claude Code so MCP reloads `.mcp.json`.
-2. Confirm an MCP query works (proves the broker can read).
-3. Advise rotating the secrets — old values may have leaked before the install.
+**If the installer dies with "boundary is BYPASSABLE"** (the agent uid can reach
+a rootful docker socket or has passwordless sudo): the file lock is in place but
+root can walk around it. Do NOT report success. Close the gap, keeping docker for
+the user's apps, by switching the agent to **rootless docker**:
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-run-privileged.sh" \
+  "${CLAUDE_PLUGIN_ROOT}/scripts/setup-rootless-docker.sh" "<agent-user>"
+```
+That does the root half (deps, subuid/subgid, removes the agent from the `docker`
+group, linger). Then tell the user to finish as themselves:
+`dockerd-rootless-setuptool.sh install && docker context use rootless`. Re-run
+the Phase 2 install; the escalation gate now passes. Only if the user explicitly
+accepts the residual risk, re-run the installer with a trailing
+`--allow-escalation` to downgrade the hard failure to a warning.
+
+> An app that needs `--privileged` or host networking can't use rootless — use a
+> docker-socket proxy that denies host bind-mounts instead, and keep the agent
+> off the raw socket.
+
+## Phase 3 — ENFORCE: verify, or tell the user it does NOT work
+
+You cannot type the user's password, but you MUST NOT let the flow end pretending
+the secret is protected when it isn't. After Phase 2, ALWAYS verify and gate:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-conceal-status.js" "<repo>"; echo "exit=$?"
+```
+- **exit 0 (PROTECTED)** → done. Then: restart Claude Code (MCP reload), confirm a
+  broker query works, advise rotating the secrets (old values may have pre-leaked).
+- **exit 2 (NOT PROTECTED)** → the user did NOT complete the privileged install (or
+  the docker path is still open). Do **not** report success. Tell the user verbatim
+  and bluntly:
+
+  > ⚠️ NOT PROTECTED. You did not run the privileged install, so Heimdall is doing
+  > **nothing** — the LLM/agent can still read `<secrets file>`. This is hook-and-OS
+  > theatre until you run the sudo step. Run the `! sudo …` command above and
+  > authenticate; I will re-verify and will keep telling you it's unprotected until
+  > the audit passes.
+
+  Then re-emit the `! sudo …` line and stop — re-verify on the next turn. Never
+  downgrade this to a soft "you may want to…". The whole point is the boundary is
+  worthless unless the privileged step actually ran.
+
+This is the enforcement: the flow refuses to claim protection until the audit exits
+0, and states plainly that an un-installed Heimdall blocks nothing.
 
 ## CLI consumers (injectCommands) — a secret for a command, not an MCP server
 
@@ -81,8 +130,17 @@ command path or the secret — and cannot read the secret file or the command's
 `/proc/<pid>/environ`. Undo with the same `--revert` (removes the wrapper, command
 map, broker, and restores the secrets).
 
-## Caveat to surface
+## The escalation gate (enforced, not advisory)
 
-The boundary holds only if the agent uid has **no** sudo or docker-socket
-access (both are root-equivalent and bypass file permissions). State this
-explicitly.
+A file-ownership boundary is worthless if the agent uid can become root, because
+root reads every file. The installer therefore **refuses to report success**
+while the agent uid has a root-equivalent path:
+- **rootful docker socket** — `docker run -v /:/host …` reads anything. Fixed by
+  rootless docker (above); a *rootless* daemon is fine and is not flagged.
+- **passwordless sudo** (cached creds or NOPASSWD) — reads anything now.
+  Password-required sudo is fine: the agent can't supply it non-interactively.
+
+This is physics, not a Heimdall limitation: "the agent has the rootful docker
+socket" and "a host file the agent can't read" cannot both be true on one host.
+The honest resolutions are rootless/proxied docker, or running Claude as a uid
+with neither sudo nor docker. `/heimdall:audit` re-checks this each time.

--- a/plugins/heimdall/skills/install/SKILL.md
+++ b/plugins/heimdall/skills/install/SKILL.md
@@ -51,3 +51,45 @@ user opt each one in behind a passphrase.
 6. Finish by running `/heimdall:list` (or the list script) and showing the resulting protection.
 
 The user can always add more later with `/heimdall:protect` or remove with `/heimdall:unprotect`.
+
+## Phase 3 — offer the OS boundary (first-time root bootstrap)
+
+Phases 1–2 are hook-level (no sudo). For a **secrets/credentials** file the agent
+must never read even via a non-hooked process, offer the OS boundary too. If the
+scan/config shows a secrets file (or the user asks to "really" lock a secret):
+
+1. Ensure an OS-layer config exists (`/heimdall:harden` builds `heimdall-conceal.json`
+   with `injectCommands`/`wrapper`; reuse it if present).
+2. Run the privileged install through the bootstrap — it does NOT require the user
+   to hand-author a sudo line. It escalates automatically: already-root → cached/
+   NOPASSWD sudo → `pkexec` GUI → else it prints one `! sudo …` line to run in the
+   user's terminal:
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-run-privileged.sh" \
+     "${CLAUDE_PLUGIN_ROOT}/scripts/setup-secrets-heimdall.sh" "<repo>"
+   ```
+   On exit code 10 (`NEEDS_PASSWORD`), surface the printed `! sudo …` line verbatim.
+3. **ENFORCE — verify, or block.** After the privileged step, gate on the audit
+   exit code:
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-conceal-status.js" "<repo>"; echo "exit=$?"
+   ```
+   - **exit 0** → protected; finish.
+   - **exit 2** → NOT installed (user skipped sudo) or docker still open. You MUST
+     NOT report success. Use **`AskUserQuestion`** to force an explicit choice — do
+     not just print a note the user can scroll past:
+     - question: *"`.secrets` is NOT protected — the LLM can still read it. The sudo
+       install hasn't run. What now?"*
+     - options: `I ran it — re-verify` · `Show the sudo command again` · `Leave it
+       UNPROTECTED (I accept the LLM can read it)`
+     On `re-verify`, re-run the audit; if still 2, ask again. On `show command`,
+     re-emit the `! sudo …` line. Only `Leave it UNPROTECTED` ends the loop — and
+     then say plainly it is unprotected.
+
+4. **Persistent reminder.** A SessionStart hook (`heimdall-secrets-reminder.js`)
+   re-emits a blunt NOT-PROTECTED warning every session while a configured secret
+   is still readable — so a skipped install can never quietly look done.
+
+This is the "find a way to run root stuff" path: the only unavoidable cost is one
+authentication, because an OS boundary needs root once — but the flow refuses to
+report protection until verified, asks at install time, and nags every session.


### PR DESCRIPTION
## Existing Behavior

- `heimdall-conceal-status.js` reports protection status but always exits 0 — callers cannot gate on whether secrets are genuinely safe, so the install/harden flow could claim success while secrets remain readable.
- `setup-secrets-heimdall.sh` locks the secrets file by uid/ownership but never checks whether the agent uid can become root via a rootful docker socket or passwordless sudo. Either path bypasses file permissions entirely, rendering the file boundary meaningless.
- `injectCommands` exec targets are left agent-writable after install. Because the broker runs them as the runner uid (which can read the secret), an agent can overwrite the target binary to exfiltrate the secret on the next broker invocation.
- The privileged install hands the user a raw `sudo bash ...` line with no fallback for cached credentials, pkexec, or a clear NEEDS_PASSWORD signal.
- There is no persistent notification when a configured secret is still readable. A skipped install silently appears complete until the next manual `/heimdall:audit` run.

## Intended New Behavior

- `setup-secrets-heimdall.sh` root-owns every `injectCommands` exec target (`root:root 0755`) immediately after install, closing the agent-rewrite exfil path — the agent can invoke the target via the broker but cannot modify it.
- The installer runs an escalation gate that **fails closed**: if the agent uid can reach a rootful docker socket or has passwordless sudo, the install exits non-zero and refuses to claim protection. Pass `--allow-escalation` to downgrade to a loud warning for operators who accept the residual risk.
- `setup-rootless-docker.sh` (new) closes the docker bypass by converting the agent to rootless docker: installs deps (`uidmap`, `slirp4netns`), provisions `/etc/subuid`/`subgid`, removes the agent from the `docker` group, and enables linger. The user runs one user-level command (`dockerd-rootless-setuptool.sh install`) to complete; the agent retains full container functionality for its apps, but container-root maps to the user's own subuid range and cannot read a different uid's `0600` secret.
- `heimdall-run-privileged.sh` (new) auto-escalates the install without requiring the user to type a sudo line: already root → cached/NOPASSWD sudo → pkexec GUI → exits 10 (`NEEDS_PASSWORD`) with the exact `! sudo ...` command for the user's terminal.
- `heimdall-conceal-status.js` now emits real exit codes (0 = PROTECTED, 2 = NOT PROTECTED), detects the rootful docker bypass via pure file-read of `/etc/group` + `process.getgroups()` (no subprocess, CodeQL-safe), and counts `injectCommands` `secretsFile` entries so inject-only repos audit correctly. A `--reminder` mode emits case-specific text distinguishing "install not run" from "installed but docker-bypassable".
- `heimdall-secrets-reminder.js` (new) + `hooks.json`: a `SessionStart` hook that nags every session while a configured secret is still readable, forwarding the status script's case-specific message. A skipped install can never quietly look done.
- `harden/SKILL.md` and `install/SKILL.md` now orchestrate the auto-escalating bootstrap, enforce an `AskUserQuestion` gate that refuses to report success until the audit exits 0, and document the full rootless docker remediation flow.

Follow-up to #639.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [ ] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify exec-target hardening (prevents agent-rewrite exfil):**
1. Configure an `injectCommands` entry in `heimdall-conceal.json` pointing at a real exec target.
2. Run the install: `bash setup-secrets-heimdall.sh <repo>`
3. Confirm: `stat -c '%U %a' <exec-target>` returns `root 755` — the agent uid cannot write to it.

**Verify escalation gate fails closed on rootful docker:**
1. Ensure the agent uid is in the `docker` group and `/var/run/docker.sock` is accessible.
2. Run the install (after secrets file is locked): `bash setup-secrets-heimdall.sh <repo>`
3. Confirm the installer exits non-zero with a clear `"boundary is BYPASSABLE"` error — it does NOT report success.
4. Re-run with `--allow-escalation`; confirm it prints a loud warning and proceeds.

**Verify rootless docker remediation closes the gate:**
1. Run: `sudo bash setup-rootless-docker.sh <agent-user>`
2. As the agent user: `dockerd-rootless-setuptool.sh install && docker context use rootless`
3. Re-run the install: `bash setup-secrets-heimdall.sh <repo>`
4. Confirm escalation gate now passes (`OK: no rootful-docker / passwordless-sudo escalation path`).

**Verify status exit codes and reminder mode:**
1. With protection not installed: `node heimdall-conceal-status.js <repo>; echo "exit=$?"` prints `STATUS: NOT PROTECTED` and exits 2.
2. With protection installed and no docker bypass: same command exits 0 with `STATUS: PROTECTED`.
3. `node heimdall-conceal-status.js <repo> --reminder` when unprotected prints case-specific nag text and exits 2.
4. `node heimdall-conceal-status.js <repo> --reminder` when protected exits 0, no output.

**Verify auto-escalating bootstrap:**
1. `bash heimdall-run-privileged.sh setup-secrets-heimdall.sh <repo>` as a user without cached sudo — confirm it prints `NEEDS_PASSWORD` and the `! sudo ...` line, exits 10.
2. With cached sudo creds: re-run — confirm it escalates silently and the install completes.

**Verify SessionStart reminder hook:**
1. Install heimdall hooks but leave secrets unprotected.
2. Start a new session in a project with a `heimdall-conceal.json` secrets entry.
3. Confirm the `HEIMDALL: a secret here is NOT PROTECTED` warning appears at session start.
4. Complete the privileged install. Start another session — confirm the reminder is silent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes privileged install behavior, setuid broker hardening, and security gating around secrets, docker, and sudo; misconfiguration could block installs or leave a false sense of protection, though the intent is fail-closed enforcement.
> 
> **Overview**
> Makes Heimdall’s **secrets OS boundary** something install/harden flows and hooks can **trust**, not just report optimistically.
> 
> **`heimdall-conceal-status.js`** now exits **0** when protected and **2** when the agent can still reach secrets (including **rootful-docker bypass** detection via `/etc/group` + `process.getgroups()`, no subprocess). It counts **`injectCommands` `secretsFile`** paths in audits, adds **`--reminder`** with distinct messages for “install not run” vs “locked but docker bypass open”, and centralizes the final **PROTECTED / NOT PROTECTED** verdict.
> 
> **`setup-secrets-heimdall.sh`** **root-owns `injectCommands` exec targets** after install, runs a **fail-closed escalation gate** (rootful docker socket + passwordless sudo; optional **`--allow-escalation`**), and refuses to claim success while bypass paths remain.
> 
> New **`heimdall-run-privileged.sh`** auto-escalates privileged work (root → cached sudo → pkexec → exit **10** with a **`! sudo …`** line). New **`setup-rootless-docker.sh`** does the root half of closing the docker bypass (deps, subuid/subgid, remove agent from `docker` group, linger).
> 
> **`heimdall-secrets-reminder.js`** plus **`SessionStart`** in **`hooks.json`** injects session-start context when status exits **2**. **`harden`** and **`install`** skills route installs through the bootstrap, **gate on audit exit codes**, document rootless remediation, and (install) **`AskUserQuestion`** when still unprotected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a872198ac49dbd97a6ac2a5d7dcafcea112965d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->