### PR TITLE
feat(work): honor explicit GH_TOKEN/GITHUB_TOKEN in gh wrapper

### DIFF
--- a/plugins/work/docs/README.md
+++ b/plugins/work/docs/README.md
@@ -73,10 +73,14 @@ follow_up → ci → cleanup → reports → complete
 
 ### `gh` calls fail with "Could not resolve to a Repository"
 
-`ghExec` (`scripts/workflows/work/scripts/gh-exec.js`) scrubs `GH_TOKEN` and
-`GITHUB_TOKEN` from the child env so `gh` falls back to the keyring's **active**
-`hosts.yml` account. When that active account lacks access to the target repo,
-every gh call fails with the GraphQL message
+`ghExec` (`scripts/workflows/work/scripts/gh-exec.js`) resolves the child env's
+gh credentials with this precedence: explicit **`GH_TOKEN`** > **`GITHUB_TOKEN`**
+> keyring **active** `hosts.yml` account. A non-empty `GH_TOKEN` in your shell is
+now honored and passed through to `gh` (with `GITHUB_TOKEN` dropped so it wins);
+if only `GITHUB_TOKEN` is set, it is honored instead. When neither token is set,
+both are removed from the child env and `gh` falls back to the keyring's active
+account. (Empty-string tokens are treated as absent.) When the resolved account
+lacks access to the target repo, every gh call fails with the GraphQL message
 `Could not resolve to a Repository with the name '<owner>/<repo>'` — even
 though the repo exists.
 
@@ -87,11 +91,16 @@ to the thrown error containing the active gh account, other configured
 accounts, and a `gh auth switch --user <correct-account>` hint.
 
 **If you see the diagnostic block:**
-1. Run `gh auth status` locally to confirm the active account.
-2. Switch to the account that owns the target repo:
-   `gh auth switch --user <correct-account>`
-3. Or unset `GH_TOKEN` / `GITHUB_TOKEN` in your shell so `gh` resolves
-   authentication from the keyring consistently.
+1. **Primary fix — set `GH_TOKEN` for the account that owns the repo.** Export a
+   token for the correct account (`export GH_TOKEN=<token>`); it is now honored
+   and takes precedence over `GITHUB_TOKEN` and the keyring active account.
+2. **Fallback — switch the keyring active account.** If you rely on the keyring
+   rather than an explicit token, run `gh auth status` to confirm the active
+   account, then `gh auth switch --user <correct-account>` to change it.
+3. **Isolated config — set `GH_CONFIG_DIR`.** `GH_CONFIG_DIR` passes through
+   `ghExec` unchanged, so you can point it at a per-worktree gh config
+   (`export GH_CONFIG_DIR=/path/to/worktree/.gh`) to keep credentials isolated
+   from your global `gh` setup.
 
 **Opt-out:** Set `GH_EXEC_NO_DIAG=1` (strict match) to suppress the
 diagnostic block — e.g. in CI environments where the raw error is preferred.

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/gh-exec.integration.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/gh-exec.integration.test.js
@@ -97,6 +97,31 @@ function readCalls(callLog) {
     .filter((line) => line.length > 0);
 }
 
+/**
+ * Run `fn` with the token/config env vars set to `vars` (any key not listed is
+ * deleted), restoring the real values afterward. Lets the precedence tests
+ * drive `buildChildEnv()` deterministically without leaking into sibling tests.
+ */
+function withTokenEnv(vars, fn) {
+  const keys = ['GH_TOKEN', 'GITHUB_TOKEN', 'GH_CONFIG_DIR'];
+  const saved = {};
+  for (const k of keys) {
+    saved[k] = Object.prototype.hasOwnProperty.call(process.env, k)
+      ? process.env[k]
+      : undefined;
+    delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(vars)) process.env[k] = v;
+  try {
+    return fn();
+  } finally {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
 const AUTH_STATUS_OUTPUT_TWO_ACCOUNTS = [
   'github.com',
   '  ✓ Logged in to github.com account thomfilg (keyring)',
@@ -106,6 +131,70 @@ const AUTH_STATUS_OUTPUT_TWO_ACCOUNTS = [
   '  - Active account: false',
   '',
 ].join('\n');
+
+describe('gh-exec.js — buildChildEnv token precedence', () => {
+  it('(a) honors an explicit GH_TOKEN and drops GITHUB_TOKEN', () => {
+    withTokenEnv({ GH_TOKEN: 'tok-a', GITHUB_TOKEN: 'tok-b' }, () => {
+      const { buildChildEnv } = freshRequire();
+      const env = buildChildEnv();
+      assert.equal(env.GH_TOKEN, 'tok-a');
+      assert.equal('GITHUB_TOKEN' in env, false);
+    });
+  });
+
+  it('(b) honors a GITHUB_TOKEN-only env', () => {
+    withTokenEnv({ GITHUB_TOKEN: 'tok-b' }, () => {
+      const { buildChildEnv } = freshRequire();
+      const env = buildChildEnv();
+      assert.equal(env.GITHUB_TOKEN, 'tok-b');
+      assert.equal('GH_TOKEN' in env, false);
+    });
+  });
+
+  it('(c) GH_TOKEN wins when both are set', () => {
+    withTokenEnv({ GH_TOKEN: 'tok-a', GITHUB_TOKEN: 'tok-b' }, () => {
+      const { buildChildEnv } = freshRequire();
+      const env = buildChildEnv();
+      assert.equal(env.GH_TOKEN, 'tok-a');
+      assert.equal('GITHUB_TOKEN' in env, false);
+    });
+  });
+
+  it('(d) deletes both when neither is set (keyring fallback)', () => {
+    withTokenEnv({}, () => {
+      const { buildChildEnv } = freshRequire();
+      const env = buildChildEnv();
+      assert.equal('GH_TOKEN' in env, false);
+      assert.equal('GITHUB_TOKEN' in env, false);
+    });
+  });
+
+  it('(e) treats an empty-string GH_TOKEN as absent', () => {
+    withTokenEnv({ GH_TOKEN: '' }, () => {
+      const { buildChildEnv } = freshRequire();
+      const env = buildChildEnv();
+      assert.equal('GH_TOKEN' in env, false);
+      assert.equal('GITHUB_TOKEN' in env, false);
+    });
+  });
+
+  it('(f) passes GH_CONFIG_DIR through unchanged', () => {
+    withTokenEnv({ GH_CONFIG_DIR: '/iso/path' }, () => {
+      const { buildChildEnv } = freshRequire();
+      const env = buildChildEnv();
+      assert.equal(env.GH_CONFIG_DIR, '/iso/path');
+    });
+  });
+
+  it('returns a fresh object (no mutation of process.env)', () => {
+    withTokenEnv({ GH_TOKEN: 'tok-a' }, () => {
+      const { buildChildEnv } = freshRequire();
+      const env = buildChildEnv();
+      assert.notEqual(env, process.env);
+      assert.equal(process.env.GH_TOKEN, 'tok-a');
+    });
+  });
+});
 
 describe('gh-exec.js — auth diagnostic', () => {
   describe('clean success path', () => {
@@ -181,7 +270,7 @@ describe('gh-exec.js — auth diagnostic', () => {
             assert.match(err.message, /Active gh account:\s*thomfilg/);
             assert.match(err.message, /gh auth switch --user otherbot/);
             assert.match(err.message, /GH_TOKEN/);
-            assert.match(err.message, /GITHUB_TOKEN/);
+            assert.doesNotMatch(err.message, /unset (your )?(GH_TOKEN|GITHUB_TOKEN)/i);
             return true;
           }
         );
@@ -190,6 +279,32 @@ describe('gh-exec.js — auth diagnostic', () => {
           calls.some((c) => c.startsWith('auth status')),
           true,
           'gh auth status MUST be spawned to build diagnostic'
+        );
+      } finally {
+        clearFakeGhEnv();
+      }
+    });
+
+    it('reconciled advice honors GH_TOKEN and never tells users to unset it', () => {
+      installFakeGh();
+      setFakeGhEnv({
+        mainStderr:
+          "GraphQL: Could not resolve to a Repository with the name 'foo/bar' (repository)",
+        mainExit: 1,
+        authStdout: AUTH_STATUS_OUTPUT_TWO_ACCOUNTS,
+        authExit: 0,
+      });
+      try {
+        const { ghExec } = freshRequire();
+        assert.throws(
+          () => ghExec(['api', 'repos/foo/bar']),
+          (err) => {
+            assert.match(err.message, /Likely auth issue/);
+            assert.match(err.message, /GH_TOKEN/);
+            assert.match(err.message, /now honored/i);
+            assert.doesNotMatch(err.message, /unset (your )?(GH_TOKEN|GITHUB_TOKEN)/i);
+            return true;
+          }
         );
       } finally {
         clearFakeGhEnv();

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/gh-exec.integration.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/gh-exec.integration.test.js
@@ -178,6 +178,15 @@ describe('gh-exec.js — buildChildEnv token precedence', () => {
     });
   });
 
+  it('(g) treats empty GH_TOKEN as absent and honors GITHUB_TOKEN', () => {
+    withTokenEnv({ GH_TOKEN: '', GITHUB_TOKEN: 'tok-b' }, () => {
+      const { buildChildEnv } = freshRequire();
+      const env = buildChildEnv();
+      assert.equal(env.GITHUB_TOKEN, 'tok-b');
+      assert.equal('GH_TOKEN' in env, false);
+    });
+  });
+
   it('(f) passes GH_CONFIG_DIR through unchanged', () => {
     withTokenEnv({ GH_CONFIG_DIR: '/iso/path' }, () => {
       const { buildChildEnv } = freshRequire();

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/gh-exec.integration.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/gh-exec.integration.test.js
@@ -133,8 +133,8 @@ const AUTH_STATUS_OUTPUT_TWO_ACCOUNTS = [
 ].join('\n');
 
 describe('gh-exec.js — buildChildEnv token precedence', () => {
-  it('(a) honors an explicit GH_TOKEN and drops GITHUB_TOKEN', () => {
-    withTokenEnv({ GH_TOKEN: 'tok-a', GITHUB_TOKEN: 'tok-b' }, () => {
+  it('(a) honors a GH_TOKEN-only env (GITHUB_TOKEN absent)', () => {
+    withTokenEnv({ GH_TOKEN: 'tok-a' }, () => {
       const { buildChildEnv } = freshRequire();
       const env = buildChildEnv();
       assert.equal(env.GH_TOKEN, 'tok-a');

--- a/plugins/work/scripts/workflows/work/scripts/gh-exec.js
+++ b/plugins/work/scripts/workflows/work/scripts/gh-exec.js
@@ -4,23 +4,42 @@
  * Executes `gh` commands via execFileSync with JSON parsing,
  * error handling, and optional non-zero exit tolerance.
  *
+ * Token precedence (buildChildEnv): an explicit non-empty GH_TOKEN wins, else
+ * an explicit non-empty GITHUB_TOKEN is honored, else both are dropped so gh
+ * falls back to the keyring active account (GH_TOKEN > GITHUB_TOKEN > keyring,
+ * matching gh's own resolution). Empty-string tokens are treated as absent.
+ *
  * Auth diagnostic: when `gh` exits non-zero with an auth-shaped stderr
- * (matched by AUTH_ERROR_REGEX), `ghExec` spawns `gh auth status` with a
- * scrubbed env (no GH_TOKEN/GITHUB_TOKEN) and appends a diagnostic block to
- * the thrown Error.message listing the active gh account, other configured
- * accounts, the `gh auth switch --user <other>` hint, and a reminder to
- * unset GH_TOKEN/GITHUB_TOKEN. Set `GH_EXEC_NO_DIAG=1` (strict string match)
- * to opt out and restore today's raw-error behavior.
+ * (matched by AUTH_ERROR_REGEX), `ghExec` spawns `gh auth status` and appends a
+ * diagnostic block to the thrown Error.message listing the active gh account,
+ * other configured accounts, the `gh auth switch --user <other>` hint, and
+ * guidance to set GH_TOKEN (now honored) for the owning account. Set
+ * `GH_EXEC_NO_DIAG=1` (strict string match) to opt out and restore today's
+ * raw-error behavior.
  */
 const { execFileSync } = require('child_process');
 
 const AUTH_ERROR_REGEX =
   /Could not resolve to a Repository|Resource not accessible|HTTP 40[134]|requires authentication/i;
 
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
 function buildChildEnv() {
   const env = { ...process.env };
-  delete env.GH_TOKEN;
-  delete env.GITHUB_TOKEN;
+  // Token precedence mirrors gh: explicit GH_TOKEN > explicit GITHUB_TOKEN >
+  // keyring active account. Honor whichever explicit token is set (empty
+  // strings count as absent); when neither is set, drop both so gh falls back
+  // to the keyring. GH_CONFIG_DIR and all other vars pass through untouched.
+  if (isNonEmptyString(process.env.GH_TOKEN)) {
+    delete env.GITHUB_TOKEN;
+  } else if (isNonEmptyString(process.env.GITHUB_TOKEN)) {
+    delete env.GH_TOKEN;
+  } else {
+    delete env.GH_TOKEN;
+    delete env.GITHUB_TOKEN;
+  }
   return env;
 }
 
@@ -97,7 +116,7 @@ function buildAuthDiagnostic(parsed) {
     }
   }
   lines.push(
-    '   If GH_TOKEN or GITHUB_TOKEN is set in your env, unset them so gh uses the keyring.'
+    '   Set GH_TOKEN to the account that owns this repo (it is now honored); otherwise run `gh auth switch --user <other>` to change the keyring active account.'
   );
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary

- `buildChildEnv()` in `gh-exec.js` unconditionally deleted `GH_TOKEN`/`GITHUB_TOKEN`, forcing all `gh` calls onto the keyring active account and causing cross-terminal account races.
- Now honors explicit tokens with precedence `GH_TOKEN` > `GITHUB_TOKEN` > keyring fallback (empty-string tokens treated as absent); `GH_CONFIG_DIR` passes through unchanged for per-worktree isolation.
- Reconciles the GH-535 auth diagnostic: replaces the "unset your token" advice with "set `GH_TOKEN` for the owning account" and adds 7 token-precedence integration tests (14 total).

## Test plan

- [ ] `export GH_TOKEN=<token>` then run a `/work` workflow step — confirm it uses the explicit token rather than the keyring account.
- [ ] `unset GH_TOKEN && unset GITHUB_TOKEN` — confirm keyring fallback still works as before.
- [ ] `export GH_CONFIG_DIR=/tmp/test-gh-cfg` — confirm it passes through to `gh` without error.
- [ ] Run `node --test plugins/work/scripts/workflows/work/scripts/__tests__/gh-exec.integration.test.js` — all 14 tests pass.
- [ ] Trigger an auth failure with `GH_TOKEN` set — confirm the diagnostic says "Set GH_TOKEN ... (it is now honored)" and no longer says "unset".

## Existing Behavior

- `buildChildEnv()` unconditionally deleted both `GH_TOKEN` and `GITHUB_TOKEN`, forcing `gh` to use the keyring active account even when an explicit token was set.
- Cross-terminal races occurred when multiple worktrees needed different GitHub accounts.
- The auth diagnostic instructed users to unset their tokens, conflicting with the correct isolation strategy.

## Intended New Behavior

- `buildChildEnv()` now applies `GH_TOKEN` > `GITHUB_TOKEN` > keyring precedence at a single chokepoint; empty-string tokens are treated as absent.
- `GH_CONFIG_DIR` passes through unchanged, enabling per-worktree credential isolation.
- Auth diagnostic guidance is reconciled — no longer tells users to unset tokens; instead advises setting `GH_TOKEN` for the owning account.
- 7 new token-precedence integration tests (cases a–g) are added; 14 tests total pass.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every workflow `gh` subprocess authenticates; wrong tokens could hit the wrong account, but behavior now matches `gh` and explicit env control is the intended fix for multi-account worktrees.
> 
> **Overview**
> **`gh-exec.js` no longer strips shell tokens** — `buildChildEnv()` now passes through a non-empty `GH_TOKEN` or `GITHUB_TOKEN` using precedence **`GH_TOKEN` > `GITHUB_TOKEN` > keyring** (empty strings count as unset; when neither is set, both are removed so `gh` uses the keyring). **`GH_CONFIG_DIR` is left unchanged** for per-worktree credential isolation.
> 
> Auth-failure diagnostics are aligned with that behavior: they **recommend setting `GH_TOKEN` for the repo owner** instead of telling users to unset tokens, and integration tests cover precedence cases plus the updated messaging. The work plugin **README troubleshooting** section documents the new resolution order and fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b811ad7bbbfa97240d6abd53246cae46151a1f32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->