### PR TITLE
feat(maestro): agent-free fleet status line

### DIFF
--- a/plugins/maestro/skills/install/SKILL.md
+++ b/plugins/maestro/skills/install/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: install
+description: Register (or remove) the maestro fleet status line — a live, agent-free 🎼 bar in Claude Code showing per-topic done/active/pending/broken counts from the conductor's manifests. Use when the user says "install the maestro statusline", "set up the maestro status bar", "show fleet status in the status line", "register the maestro statusline", or "remove the maestro statusline".
+argument-hint: "[--print | --remove]"
+user-invocable: true
+allowed-tools: Bash
+---
+
+# Maestro fleet status line
+
+Registers a Claude Code `statusLine` that renders the live state of every maestro
+orchestration topic — agent-free. The conductor already updates its session
+manifests every tick; the status line just reads them, so it stays current with
+zero agent involvement (Claude re-runs it on `refreshInterval`).
+
+Line format (one segment per topic that still has active/pending work; fully-done
+topics disappear):
+
+```
+🎼 <topic> <done>/<total>✓ ▶<active>(<ids>) ⏳<pending> ✅<pr-ready> ⚠<pr-broken>
+```
+
+It **chains** any previously-registered status line (e.g. the qc calibration bar)
+beneath the maestro line, so installing this does not lose your existing one.
+
+## Commands
+
+- **Install:** `node "$CLAUDE_PLUGIN_ROOT/skills/install/scripts/install-statusline.js"`
+- **Show resolved paths + current config:** `... install-statusline.js --print`
+- **Remove (restore the chained line):** `... install-statusline.js --remove`
+
+After installing, run `/reload-plugins` (or just wait for the next refresh tick).
+
+## How it fits together
+
+- **Renderer:** `skills/lib/maestro-statusline.sh` → calls `maestro-statusline.js`.
+- **Data source:** `~/.cache/maestro/sessions/*.json` (manifests) + `/tmp/maestro-alerts.jsonl`.
+- **Chain file:** `~/.cache/maestro/statusline-chain.cmd` holds the prior status
+  line command; the renderer appends its output beneath the maestro line.

--- a/plugins/maestro/skills/install/SKILL.md
+++ b/plugins/maestro/skills/install/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: install
 description: Register (or remove) the maestro fleet status line — a live, agent-free 🎼 bar in Claude Code showing per-topic done/active/pending/broken counts from the conductor's manifests. Use when the user says "install the maestro statusline", "set up the maestro status bar", "show fleet status in the status line", "register the maestro statusline", or "remove the maestro statusline".
-argument-hint: "[--print | --remove]"
+argument-hint: "[--print | --remove | --unpin]"
 user-invocable: true
 allowed-tools: Bash
 ---

--- a/plugins/maestro/skills/install/scripts/install-statusline.js
+++ b/plugins/maestro/skills/install/scripts/install-statusline.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * install-statusline.js — register the maestro fleet status line as the Claude
+ * Code statusLine, mirroring the qc-tasks installer.
+ *
+ * Usage:
+ *   node install-statusline.js            register (default)
+ *   node install-statusline.js --print    show resolved paths + current config
+ *   node install-statusline.js --remove   unregister and restore the chained line
+ *
+ * Behavior:
+ *   - Resolves the renderer to this plugin's own skills/lib/maestro-statusline.sh
+ *     ($CLAUDE_PLUGIN_ROOT at runtime, else relative to this file).
+ *   - Writes settings.json .statusLine = { type:"command", command:<renderer>,
+ *     padding:0, refreshInterval:3 } so the 🎼 bar updates live even while idle.
+ *   - If an existing NON-maestro status line is registered, it is preserved into
+ *     the chain file so the renderer shows it BENEATH the maestro line. --remove
+ *     restores it as the sole status line.
+ */
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const HOME = os.homedir();
+const SETTINGS = path.join(HOME, '.claude', 'settings.json');
+const CHAIN_FILE = path.join(HOME, '.cache', 'maestro', 'statusline-chain.cmd');
+const PIN_FILE = path.join(HOME, '.cache', 'maestro', 'statusline-session.pin');
+
+function clearPin() {
+  try {
+    fs.unlinkSync(PIN_FILE);
+  } catch {
+    /* none */
+  }
+}
+
+function rendererPath() {
+  // Prefer $CLAUDE_PLUGIN_ROOT (correct at plugin runtime), but only if it
+  // actually resolves to the renderer — when run by hand the env var may be a
+  // generic default. Fall back to this file's own location (the live source).
+  const candidates = [];
+  if (process.env.CLAUDE_PLUGIN_ROOT) {
+    candidates.push(
+      path.join(process.env.CLAUDE_PLUGIN_ROOT, 'skills', 'lib', 'maestro-statusline.sh')
+    );
+  }
+  // this file: <plugin>/skills/install/scripts/install-statusline.js
+  candidates.push(path.join(__dirname, '..', '..', 'lib', 'maestro-statusline.sh'));
+  for (const c of candidates) {
+    try {
+      if (fs.existsSync(c)) return c;
+    } catch {
+      /* try next */
+    }
+  }
+  return candidates[candidates.length - 1];
+}
+
+function readSettings() {
+  try {
+    return JSON.parse(fs.readFileSync(SETTINGS, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeSettings(obj) {
+  fs.mkdirSync(path.dirname(SETTINGS), { recursive: true });
+  fs.writeFileSync(SETTINGS, JSON.stringify(obj, null, 2) + '\n');
+}
+
+function block(cmd) {
+  return { type: 'command', command: cmd, padding: 0, refreshInterval: 3 };
+}
+
+function isMaestro(cmd) {
+  return typeof cmd === 'string' && cmd.includes('maestro-statusline.sh');
+}
+
+function print() {
+  const renderer = rendererPath();
+  const s = readSettings();
+  const cur = s.statusLine && s.statusLine.command;
+  let chain = null;
+  try {
+    chain = fs.readFileSync(CHAIN_FILE, 'utf8').trim();
+  } catch {
+    /* none */
+  }
+  console.log('renderer:      ' + renderer);
+  console.log('exists:        ' + fs.existsSync(renderer));
+  console.log('settings:      ' + SETTINGS);
+  console.log('current line:  ' + (cur || '(none)'));
+  console.log('registered:    ' + (isMaestro(cur) ? 'yes (maestro)' : 'no'));
+  console.log('chained line:  ' + (chain || '(none)'));
+}
+
+function install() {
+  const renderer = rendererPath();
+  const s = readSettings();
+  const existing = s.statusLine && s.statusLine.command;
+
+  // Preserve a non-maestro existing line so it renders beneath the maestro line.
+  if (existing && !isMaestro(existing)) {
+    fs.mkdirSync(path.dirname(CHAIN_FILE), { recursive: true });
+    fs.writeFileSync(CHAIN_FILE, existing + '\n');
+    console.log('chained existing status line: ' + existing);
+  }
+
+  s.statusLine = block(renderer);
+  writeSettings(s);
+  clearPin(); // fresh claim: the next orchestrator session to render owns the line
+  console.log('registered maestro status line -> ' + renderer);
+  console.log('pin reset — the first non-worktree (orchestrator) session to render claims it.');
+  console.log('run /reload-plugins or restart the statusLine refresh to see it.');
+}
+
+function remove() {
+  const s = readSettings();
+  let restored = null;
+  try {
+    restored = fs.readFileSync(CHAIN_FILE, 'utf8').trim();
+  } catch {
+    /* none */
+  }
+  if (restored) {
+    s.statusLine = block(restored);
+    console.log('restored chained status line: ' + restored);
+  } else {
+    delete s.statusLine;
+    console.log('removed status line (no chained line to restore).');
+  }
+  writeSettings(s);
+  try {
+    fs.unlinkSync(CHAIN_FILE);
+  } catch {
+    /* none */
+  }
+}
+
+const arg = process.argv[2];
+if (arg === '--print') print();
+else if (arg === '--remove') {
+  remove();
+  clearPin();
+} else if (arg === '--unpin') {
+  clearPin();
+  console.log('pin cleared — the next non-worktree session to render will claim the status line.');
+} else install();

--- a/plugins/maestro/skills/install/scripts/install-statusline.js
+++ b/plugins/maestro/skills/install/scripts/install-statusline.js
@@ -36,25 +36,10 @@ function clearPin() {
 }
 
 function rendererPath() {
-  // Prefer $CLAUDE_PLUGIN_ROOT (correct at plugin runtime), but only if it
-  // actually resolves to the renderer — when run by hand the env var may be a
-  // generic default. Fall back to this file's own location (the live source).
-  const candidates = [];
-  if (process.env.CLAUDE_PLUGIN_ROOT) {
-    candidates.push(
-      path.join(process.env.CLAUDE_PLUGIN_ROOT, 'skills', 'lib', 'maestro-statusline.sh')
-    );
-  }
+  // Resolve relative to this file's own location so the registered command
+  // always points at this plugin's renderer, regardless of install layout.
   // this file: <plugin>/skills/install/scripts/install-statusline.js
-  candidates.push(path.join(__dirname, '..', '..', 'lib', 'maestro-statusline.sh'));
-  for (const c of candidates) {
-    try {
-      if (fs.existsSync(c)) return c;
-    } catch {
-      /* try next */
-    }
-  }
-  return candidates[candidates.length - 1];
+  return path.join(__dirname, '..', '..', 'lib', 'maestro-statusline.sh');
 }
 
 function readSettings() {

--- a/plugins/maestro/skills/lib/maestro-statusline.js
+++ b/plugins/maestro/skills/lib/maestro-statusline.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * maestro-statusline.js — agent-free renderer for the maestro fleet status line.
+ *
+ * Reads the conductor's session manifests (updated every tick) and the alert
+ * log, and prints ONE compact line per active topic. No agent, no polling —
+ * Claude Code re-runs the parent .sh on its refreshInterval and shows stdout.
+ *
+ * Data sources (all written by maestro itself):
+ *   - $SESSION_DIR/*.json         manifest per topic {topic,slots,tasks[{id,status}]}
+ *   - $ALERTS (jsonl)             ACTION rows {ticket,kind}; latest kind per ticket
+ *
+ * Output (per topic with any active/pending task; fully-done topics are hidden):
+ *   🎼 <topic> <done>/<total>✓ ▶<active>(<ids>) ⏳<pending> [⚠<broken>]
+ */
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+
+const WORKTREES_BASE =
+  process.env.WORKTREES_BASE || path.join(os.homedir(), 'p', 'w-claude-plugin');
+const REPO_NAME = process.env.REPO_NAME || 'claude-plugin-work';
+
+// Two-word label for an active ticket, taken from its worktree's last commit
+// subject (local git — instant, no network, keeps the statusline agent-free).
+// Only used when the fleet is quiet (≤2 active) so there's room to show it.
+function twoWords(ticket) {
+  try {
+    const wt = path.join(WORKTREES_BASE, `${REPO_NAME}-${ticket}`);
+    const subj = execSync(`git -C ${JSON.stringify(wt)} log -1 --format=%s`, {
+      encoding: 'utf8',
+      timeout: 1500,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!subj) return '';
+    const stripped = subj.replace(/^[a-z]+(\([^)]*\))?!?:\s*/i, ''); // drop type(scope):
+    return stripped.split(/\s+/).slice(0, 2).join(' ');
+  } catch {
+    return '';
+  }
+}
+
+const SESSION_DIR =
+  process.env.MAESTRO_SESSION_DIR ||
+  process.env.SESSION_DIR ||
+  path.join(os.homedir(), '.cache', 'maestro', 'sessions');
+const ALERTS = process.env.MAESTRO_ALERTS || process.env.ALERTS || '/tmp/maestro-alerts.jsonl';
+
+function readManifests() {
+  let files = [];
+  try {
+    files = fs.readdirSync(SESSION_DIR).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const f of files) {
+    try {
+      const j = JSON.parse(fs.readFileSync(path.join(SESSION_DIR, f), 'utf8'));
+      if (j && Array.isArray(j.tasks) && j.topic) out.push(j);
+    } catch {
+      /* skip unreadable/partial manifest */
+    }
+  }
+  return out;
+}
+
+// Most-recent alert kind per ticket — lets us flag pr-broken tickets live.
+function latestKindByTicket() {
+  const m = {};
+  let lines = [];
+  try {
+    lines = fs.readFileSync(ALERTS, 'utf8').trim().split('\n');
+  } catch {
+    return m;
+  }
+  for (const l of lines) {
+    try {
+      const j = JSON.parse(l);
+      if (j && j.ticket && j.kind) m[j.ticket] = j.kind;
+    } catch {
+      /* skip */
+    }
+  }
+  return m;
+}
+
+// --- Session scoping: show the maestro line ONLY in the orchestrator session.
+// Claude runs this statusLine command in EVERY session, so we gate on the
+// session JSON piped in on stdin. The first non-worktree session to render
+// claims the pin; agents (cwd = <repo>-<ticket> worktree) never claim it and
+// never match, so the line disappears from their tabs and other projects.
+function readCtx() {
+  let s = '';
+  try {
+    s = fs.readFileSync(0, 'utf8');
+  } catch {
+    /* no stdin */
+  }
+  try {
+    return JSON.parse(s || '{}');
+  } catch {
+    return {};
+  }
+}
+const CTX = readCtx();
+const SESSION_ID = CTX.session_id || CTX.sessionId || '';
+const CWD =
+  CTX.cwd || (CTX.workspace && (CTX.workspace.current_dir || CTX.workspace.project_dir)) || '';
+const PIN_FILE =
+  process.env.MAESTRO_STATUSLINE_PIN ||
+  path.join(os.homedir(), '.cache', 'maestro', 'statusline-session.pin');
+
+function isWorktreeCwd(c) {
+  if (!c) return false;
+  const esc = REPO_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp('/' + esc + '-[^/]+(?:/|$)').test(c);
+}
+
+// True only for the orchestrator session. Auto-claims the pin for the first
+// non-worktree session that renders; thereafter only that session matches.
+// Falls back to a cwd rule when session_id isn't provided by the host.
+function isOperatorSession() {
+  let pin = '';
+  try {
+    pin = fs.readFileSync(PIN_FILE, 'utf8').trim();
+  } catch {
+    /* none yet */
+  }
+  if (pin) return !!SESSION_ID && SESSION_ID === pin;
+  if (isWorktreeCwd(CWD)) return false; // an agent tab must never claim the pin
+  if (SESSION_ID) {
+    try {
+      fs.mkdirSync(path.dirname(PIN_FILE), { recursive: true });
+      fs.writeFileSync(PIN_FILE, SESSION_ID + '\n');
+    } catch {
+      /* best effort */
+    }
+    return true;
+  }
+  // No session_id from host → fall back to cwd (non-worktree only).
+  return !isWorktreeCwd(CWD);
+}
+
+function render() {
+  if (!isOperatorSession()) return '';
+  const kinds = latestKindByTicket();
+  const segs = [];
+  for (const j of readManifests()) {
+    const t = j.tasks;
+    const total = t.length;
+    const done = t.filter((x) => x.status === 'done').length;
+    const active = t.filter((x) => x.status === 'in_progress');
+    const pending = t.filter((x) => x.status === 'pending').length;
+    // Hide fully-done / idle topics so the line disappears when work finishes.
+    if (active.length === 0 && pending === 0) continue;
+    const broken = t.filter((x) => x.status !== 'done' && kinds[x.id] === 'pr-broken').length;
+    const ready = active.filter((x) => kinds[x.id] === 'pr-ready').length;
+
+    let seg = `🎼 ${j.topic}   ${done}/${total} ✓`;
+    if (active.length === 1) {
+      const w = twoWords(active[0].id);
+      seg += `   ▶  1  (${active[0].id}${w ? ` — ${w}` : ''})`;
+    } else if (active.length > 1) {
+      // Rotate one active ticket per refresh so the label stays readable.
+      // Stateless: the index comes from wall-clock time (statusLine re-runs
+      // ~every refreshInterval seconds), so it advances one slot each tick.
+      const i = Math.floor(Date.now() / 3000) % active.length;
+      const a = active[i];
+      const w = twoWords(a.id);
+      seg += `   ▶  ${active.length}  [${i + 1}/${active.length}] ${a.id}${w ? ` — ${w}` : ''}`;
+    }
+    if (pending) seg += `   ⏳ ${pending}`;
+    if (ready) seg += `   ✅ ${ready}`;
+    if (broken) seg += `   ⚠  ${broken}`;
+    segs.push(seg);
+  }
+  return segs.join('      |      ');
+}
+
+process.stdout.write(render());

--- a/plugins/maestro/skills/lib/maestro-statusline.js
+++ b/plugins/maestro/skills/lib/maestro-statusline.js
@@ -17,7 +17,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 const WORKTREES_BASE =
   process.env.WORKTREES_BASE || path.join(os.homedir(), 'p', 'w-claude-plugin');
@@ -25,11 +25,15 @@ const REPO_NAME = process.env.REPO_NAME || 'claude-plugin-work';
 
 // Two-word label for an active ticket, taken from its worktree's last commit
 // subject (local git — instant, no network, keeps the statusline agent-free).
-// Only used when the fleet is quiet (≤2 active) so there's room to show it.
+// Called only for the ONE ticket currently displayed (the single active ticket,
+// or the rotation's current slot), so at most one git call fires per render.
 function twoWords(ticket) {
   try {
     const wt = path.join(WORKTREES_BASE, `${REPO_NAME}-${ticket}`);
-    const subj = execSync(`git -C ${JSON.stringify(wt)} log -1 --format=%s`, {
+    // execFileSync (no shell) — args are passed directly to git, so ticket /
+    // env-derived paths can't be interpreted as shell commands (CodeQL: no
+    // indirect uncontrolled command line).
+    const subj = execFileSync('git', ['-C', wt, 'log', '-1', '--format=%s'], {
       encoding: 'utf8',
       timeout: 1500,
       stdio: ['ignore', 'pipe', 'ignore'],
@@ -134,11 +138,18 @@ function isOperatorSession() {
   if (SESSION_ID) {
     try {
       fs.mkdirSync(path.dirname(PIN_FILE), { recursive: true });
-      fs.writeFileSync(PIN_FILE, SESSION_ID + '\n');
+      // Atomic claim: 'wx' fails if a racing session already created the pin,
+      // so exactly one writer wins — no two-sessions-both-operator window.
+      fs.writeFileSync(PIN_FILE, SESSION_ID + '\n', { flag: 'wx' });
+      return true;
     } catch {
-      /* best effort */
+      // Lost the race (or write failed) — honor whoever actually holds the pin.
+      try {
+        return fs.readFileSync(PIN_FILE, 'utf8').trim() === SESSION_ID;
+      } catch {
+        return false;
+      }
     }
-    return true;
   }
   // No session_id from host → fall back to cwd (non-worktree only).
   return !isWorktreeCwd(CWD);

--- a/plugins/maestro/skills/lib/maestro-statusline.js
+++ b/plugins/maestro/skills/lib/maestro-statusline.js
@@ -144,40 +144,42 @@ function isOperatorSession() {
   return !isWorktreeCwd(CWD);
 }
 
+// Render the "▶ …" active portion. One active ticket shows inline with its
+// two-word label; multiple rotate one-per-refresh ([i/N]) via wall-clock time
+// (statusLine re-runs ~every refreshInterval second) so the label stays readable.
+function formatActive(active) {
+  const i = active.length === 1 ? 0 : Math.floor(Date.now() / 3000) % active.length;
+  const a = active[i];
+  const w = twoWords(a.id);
+  const label = `${a.id}${w ? ` — ${w}` : ''}`;
+  if (active.length === 1) return `   ▶  1  (${label})`;
+  return `   ▶  ${active.length}  [${i + 1}/${active.length}] ${label}`;
+}
+
+// One status segment for a topic, or null when it has no active/pending work.
+function topicSegment(j, kinds) {
+  const t = j.tasks;
+  const active = t.filter((x) => x.status === 'in_progress');
+  const pending = t.filter((x) => x.status === 'pending').length;
+  if (active.length === 0 && pending === 0) return null;
+  const done = t.filter((x) => x.status === 'done').length;
+  const broken = t.filter((x) => x.status !== 'done' && kinds[x.id] === 'pr-broken').length;
+  const ready = active.filter((x) => kinds[x.id] === 'pr-ready').length;
+  let seg = `🎼 ${j.topic}   ${done}/${t.length} ✓`;
+  if (active.length) seg += formatActive(active);
+  if (pending) seg += `   ⏳ ${pending}`;
+  if (ready) seg += `   ✅ ${ready}`;
+  if (broken) seg += `   ⚠  ${broken}`;
+  return seg;
+}
+
 function render() {
   if (!isOperatorSession()) return '';
   const kinds = latestKindByTicket();
-  const segs = [];
-  for (const j of readManifests()) {
-    const t = j.tasks;
-    const total = t.length;
-    const done = t.filter((x) => x.status === 'done').length;
-    const active = t.filter((x) => x.status === 'in_progress');
-    const pending = t.filter((x) => x.status === 'pending').length;
-    // Hide fully-done / idle topics so the line disappears when work finishes.
-    if (active.length === 0 && pending === 0) continue;
-    const broken = t.filter((x) => x.status !== 'done' && kinds[x.id] === 'pr-broken').length;
-    const ready = active.filter((x) => kinds[x.id] === 'pr-ready').length;
-
-    let seg = `🎼 ${j.topic}   ${done}/${total} ✓`;
-    if (active.length === 1) {
-      const w = twoWords(active[0].id);
-      seg += `   ▶  1  (${active[0].id}${w ? ` — ${w}` : ''})`;
-    } else if (active.length > 1) {
-      // Rotate one active ticket per refresh so the label stays readable.
-      // Stateless: the index comes from wall-clock time (statusLine re-runs
-      // ~every refreshInterval seconds), so it advances one slot each tick.
-      const i = Math.floor(Date.now() / 3000) % active.length;
-      const a = active[i];
-      const w = twoWords(a.id);
-      seg += `   ▶  ${active.length}  [${i + 1}/${active.length}] ${a.id}${w ? ` — ${w}` : ''}`;
-    }
-    if (pending) seg += `   ⏳ ${pending}`;
-    if (ready) seg += `   ✅ ${ready}`;
-    if (broken) seg += `   ⚠  ${broken}`;
-    segs.push(seg);
-  }
-  return segs.join('      |      ');
+  return readManifests()
+    .map((j) => topicSegment(j, kinds))
+    .filter(Boolean)
+    .join('      |      ');
 }
 
 process.stdout.write(render());

--- a/plugins/maestro/skills/lib/maestro-statusline.sh
+++ b/plugins/maestro/skills/lib/maestro-statusline.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# maestro-statusline.sh — Claude Code statusLine command for the maestro fleet.
+#
+# Agent-free: renders live conductor state from the session manifests (which the
+# daemon updates every tick), then CHAINS any previously-registered status line
+# (e.g. the qc calibration bar) beneath it so nothing is lost.
+#
+# Registered by skills/install/scripts/install-statusline.js. Data written by
+# maestro itself (maestro-session.js manifests + /tmp/maestro-alerts.jsonl).
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHAIN_FILE="${MAESTRO_STATUSLINE_CHAIN:-$HOME/.cache/maestro/statusline-chain.cmd}"
+
+# Claude passes session JSON on stdin; capture it to forward to the chained line.
+STDIN_JSON="$(cat 2>/dev/null || true)"
+
+# 1) The maestro fleet line (fed the session JSON so it can gate to the
+#    orchestrator session only — agents/other tabs get nothing from it).
+MAESTRO_LINE="$(printf '%s' "$STDIN_JSON" | node "$DIR/maestro-statusline.js" 2>/dev/null || true)"
+
+# 2) The chained previous status line (fed the same stdin), if one was saved.
+CHAIN_OUT=""
+if [ -s "$CHAIN_FILE" ]; then
+  CHAIN_CMD="$(cat "$CHAIN_FILE" 2>/dev/null || true)"
+  # Guard against chaining ourselves into a loop.
+  case "$CHAIN_CMD" in
+    *maestro-statusline.sh*) CHAIN_CMD="" ;;
+  esac
+  if [ -n "$CHAIN_CMD" ]; then
+    CHAIN_OUT="$(printf '%s' "$STDIN_JSON" | eval "$CHAIN_CMD" 2>/dev/null || true)"
+  fi
+fi
+
+if [ -n "$MAESTRO_LINE" ] && [ -n "$CHAIN_OUT" ]; then
+  printf '%s\n%s\n' "$MAESTRO_LINE" "$CHAIN_OUT"
+elif [ -n "$MAESTRO_LINE" ]; then
+  printf '%s\n' "$MAESTRO_LINE"
+elif [ -n "$CHAIN_OUT" ]; then
+  printf '%s\n' "$CHAIN_OUT"
+fi

--- a/plugins/maestro/skills/lib/maestro-statusline.sh
+++ b/plugins/maestro/skills/lib/maestro-statusline.sh
@@ -27,8 +27,12 @@ if [ -s "$CHAIN_FILE" ]; then
   case "$CHAIN_CMD" in
     *maestro-statusline.sh*) CHAIN_CMD="" ;;
   esac
-  if [ -n "$CHAIN_CMD" ]; then
-    CHAIN_OUT="$(printf '%s' "$STDIN_JSON" | eval "$CHAIN_CMD" 2>/dev/null || true)"
+  # Invoke the previously-registered status line directly (NO eval) so a
+  # tampered chain file can't run arbitrary shell. The common case — a bare
+  # executable path like the qc bar — is supported; commands needing shell
+  # parsing are intentionally not chained.
+  if [ -n "$CHAIN_CMD" ] && [ -x "$CHAIN_CMD" ]; then
+    CHAIN_OUT="$(printf '%s' "$STDIN_JSON" | "$CHAIN_CMD" 2>/dev/null || true)"
   fi
 fi
 


### PR DESCRIPTION
## Existing Behavior

Maestro has no live fleet display. Operators watch `/orchestrate` progress via the conductor's Monitor event stream or one-shot `/pulse` snapshots — nothing shows persistently at a glance.

## Intended New Behavior

Adds a `statusLine` skill for maestro orchestration that renders live conductor state **without spawning an agent** (the IDE re-runs the renderer on `refreshInterval`; no agent, no polling loop).

- **Renderer** `skills/lib/maestro-statusline.js` — reads the session manifests the daemon updates every tick (+ `/tmp/maestro-alerts.jsonl`) and prints one compact segment per topic with active/pending work; fully-done topics are hidden: `🎼 <topic> <done>/<total> ✓ ▶ <active> (…) ⏳ <pending> ✅ <pr-ready> ⚠ <broken>`
- **Entrypoint** `skills/lib/maestro-statusline.sh` — chains any previously-registered status line (e.g. the qc bar) beneath the maestro line, so installing this loses nothing.
- **Session-scoped** — renders only in the orchestrator session (pinned to the first non-worktree session to render). Agent worktree tabs (`<repo>-<ticket>`) and other projects are suppressed.
- **Rotation** — with >1 active ticket it shows one per refresh (`[i/N]`) so labels stay readable; ≤2 active tickets get a two-word label from the worktree's last commit subject (local git, no network).
- **Install skill** `/maestro:install` + `install-statusline.js` — `register` / `--print` / `--remove` / `--unpin`; resolves the renderer to the plugin's own path with `padding:0, refreshInterval:3`.

## Testing

- Renderer verified against a live `prfollowup` manifest: single-active, ≤2 (labels), and >2 (rotation frames).
- Session gating verified: pinned orchestrator session renders; worktree/other-project stdin suppressed.
- `--print` / `--remove` / `--unpin` exercised.

No linked GitHub issue — ad-hoc operator feature requested in-session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The installer mutates local Claude `settings.json` and runs user-configured chained status-line executables from cache; behavior is confined to the operator machine with deliberate guards against shell injection on the chain file.
> 
> **Overview**
> Introduces a **live maestro fleet status bar** in Claude Code that refreshes from conductor session manifests and alerts—no agent or polling loop.
> 
> **Install path:** `/maestro:install` and `install-statusline.js` set `~/.claude/settings.json` `statusLine` to the plugin’s `maestro-statusline.sh` (`refreshInterval: 3`). If another status line is already registered, its command is saved to `~/.cache/maestro/statusline-chain.cmd` and rendered **below** the maestro line; `--remove` restores it, `--unpin` clears the session pin.
> 
> **Rendering:** `maestro-statusline.js` prints compact per-topic segments (done/active/pending, pr-ready/broken from alerts); hides topics with no active or pending work. Output is **orchestrator-only** via stdin session JSON and an atomic pin file so agent worktree tabs stay blank. Multiple active tickets rotate one label per refresh; a single active ticket can show a two-word label from local `git log` in the worktree.
> 
> **Shell wrapper:** `maestro-statusline.sh` forwards stdin to the JS renderer and to the chained prior line using direct execution of an executable path (no `eval`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbf764aedc6ae6598e1da0358c3fc0c7efd6a95f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->