### PR TITLE
fix(maestro): session-scope the fleet status bar

### DIFF
--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -350,6 +350,27 @@ function handlePrComments(ctx, cHit) {
 // so a second daemon in the SAME namespace is detected instead of both driving
 // (and racing on) the same agents. One-shot ticks don't lock — the conflict is
 // specific to two persistent daemons.
+// Record which Claude session launched this orchestration + its ticket prefix,
+// so the status bar (maestro-statusline.js) can show this fleet's live tmux
+// sessions ONLY in the owning session — no manifest needed, no global pin.
+function writeActiveMarker() {
+  try {
+    const session = process.env.CLAUDE_CODE_SESSION_ID;
+    const prefix = process.env.TICKET_PREFIX;
+    if (!session || !prefix) return;
+    const osMod = require('os');
+    const p = require('path');
+    const dir = p.join(osMod.homedir(), '.cache', 'maestro', 'active');
+    require('fs').mkdirSync(dir, { recursive: true });
+    require('fs').writeFileSync(
+      p.join(dir, `${session}.json`),
+      JSON.stringify({ session, prefix, repo: process.env.REPO_NAME || '' })
+    );
+  } catch {
+    /* best effort — the status bar is advisory */
+  }
+}
+
 function main() {
   const daemon = process.argv.includes('--daemon');
   if (!daemon) {
@@ -357,6 +378,7 @@ function main() {
     return;
   }
   const nsLabel = singletonGuard.acquireOrExit();
+  writeActiveMarker();
   alerts.log(`orchestrate daemon starting, tick=${TICK_SEC}s namespace="${nsLabel}"`);
   setInterval(tick, TICK_SEC * 1000);
   tick();

--- a/plugins/maestro/scripts/maestro-session.js
+++ b/plugins/maestro/scripts/maestro-session.js
@@ -80,9 +80,6 @@ function init(topic, slots, tasks, opts = {}) {
     command: opts.command || 'work',
     stopOracle: opts.stopOracle || null,
     stopSource: opts.stopSource || null,
-    // The Claude session that launched this orchestration — the status bar shows
-    // this fleet only in its owning session (not every open chat).
-    session: process.env.CLAUDE_CODE_SESSION_ID || '',
     createdAt: new Date().toISOString(),
     tasks: tasks.map((t) => ({
       id: t.id,

--- a/plugins/maestro/scripts/maestro-session.js
+++ b/plugins/maestro/scripts/maestro-session.js
@@ -80,6 +80,9 @@ function init(topic, slots, tasks, opts = {}) {
     command: opts.command || 'work',
     stopOracle: opts.stopOracle || null,
     stopSource: opts.stopSource || null,
+    // The Claude session that launched this orchestration — the status bar shows
+    // this fleet only in its owning session (not every open chat).
+    session: process.env.CLAUDE_CODE_SESSION_ID || '',
     createdAt: new Date().toISOString(),
     tasks: tasks.map((t) => ({
       id: t.id,

--- a/plugins/maestro/skills/install/scripts/install-statusline.js
+++ b/plugins/maestro/skills/install/scripts/install-statusline.js
@@ -25,15 +25,6 @@ const os = require('os');
 const HOME = os.homedir();
 const SETTINGS = path.join(HOME, '.claude', 'settings.json');
 const CHAIN_FILE = path.join(HOME, '.cache', 'maestro', 'statusline-chain.cmd');
-const PIN_FILE = path.join(HOME, '.cache', 'maestro', 'statusline-session.pin');
-
-function clearPin() {
-  try {
-    fs.unlinkSync(PIN_FILE);
-  } catch {
-    /* none */
-  }
-}
 
 function rendererPath() {
   // Resolve relative to this file's own location so the registered command
@@ -95,9 +86,8 @@ function install() {
 
   s.statusLine = block(renderer);
   writeSettings(s);
-  clearPin(); // fresh claim: the next orchestrator session to render owns the line
   console.log('registered maestro status line -> ' + renderer);
-  console.log('pin reset — the first non-worktree (orchestrator) session to render claims it.');
+  console.log('each orchestrator session shows only the fleet it launched.');
   console.log('run /reload-plugins or restart the statusLine refresh to see it.');
 }
 
@@ -126,10 +116,5 @@ function remove() {
 
 const arg = process.argv[2];
 if (arg === '--print') print();
-else if (arg === '--remove') {
-  remove();
-  clearPin();
-} else if (arg === '--unpin') {
-  clearPin();
-  console.log('pin cleared — the next non-worktree session to render will claim the status line.');
-} else install();
+else if (arg === '--remove') remove();
+else install();

--- a/plugins/maestro/skills/lib/maestro-statusline.js
+++ b/plugins/maestro/skills/lib/maestro-statusline.js
@@ -3,156 +3,81 @@
 /**
  * maestro-statusline.js — agent-free renderer for the maestro fleet status line.
  *
- * Reads the conductor's session manifests (updated every tick) and the alert
- * log, and prints ONE compact line per active topic. No agent, no polling —
- * Claude Code re-runs the parent .sh on its refreshInterval and shows stdout.
- *
- * Data sources (all written by maestro itself):
- *   - $SESSION_DIR/*.json         manifest per topic {topic,slots,tasks[{id,status}]}
- *   - $ALERTS (jsonl)             ACTION rows {ticket,kind}; latest kind per ticket
- *
- * Output (per topic with any active/pending task; fully-done topics are hidden):
- *   🎼 <topic> <done>/<total>✓ ▶<active>(<ids>) ⏳<pending> [⚠<broken>]
+ * Renders from the conductor's LIVE view — the tmux `<prefix>-<ticket>-work`
+ * sessions — so it works for ANY maestro orchestration (with or without a
+ * session manifest). Scoped to the launching Claude session via a marker the
+ * conductor writes (~/.cache/maestro/active/<session>.json = {session, prefix}),
+ * so each orchestrator session shows only the fleet it launched — never other
+ * chats. No global pin (which only one session could ever win).
  */
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
 
-const WORKTREES_BASE =
-  process.env.WORKTREES_BASE || path.join(os.homedir(), 'p', 'w-claude-plugin');
-const REPO_NAME = process.env.REPO_NAME || 'claude-plugin-work';
+const ACTIVE_DIR = path.join(os.homedir(), '.cache', 'maestro', 'active');
 
-// Two-word label for an active ticket, taken from its worktree's last commit
-// subject (local git — instant, no network, keeps the statusline agent-free).
-// Called only for the ONE ticket currently displayed (the single active ticket,
-// or the rotation's current slot), so at most one git call fires per render.
-function twoWords(ticket) {
-  try {
-    const wt = path.join(WORKTREES_BASE, `${REPO_NAME}-${ticket}`);
-    // execFileSync (no shell) — args are passed directly to git, so ticket /
-    // env-derived paths can't be interpreted as shell commands (CodeQL: no
-    // indirect uncontrolled command line).
-    const subj = execFileSync('git', ['-C', wt, 'log', '-1', '--format=%s'], {
-      encoding: 'utf8',
-      timeout: 1500,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-    if (!subj) return '';
-    const stripped = subj.replace(/^[a-z]+(\([^)]*\))?!?:\s*/i, ''); // drop type(scope):
-    return stripped.split(/\s+/).slice(0, 2).join(' ');
-  } catch {
-    return '';
-  }
+// The Claude session Claude runs this statusLine in (session_id on stdin).
+let SESSION = '';
+try {
+  SESSION = JSON.parse(fs.readFileSync(0, 'utf8') || '{}').session_id || '';
+} catch {
+  /* no stdin */
 }
 
-const SESSION_DIR =
-  process.env.MAESTRO_SESSION_DIR ||
-  process.env.SESSION_DIR ||
-  path.join(os.homedir(), '.cache', 'maestro', 'sessions');
-const ALERTS = process.env.MAESTRO_ALERTS || process.env.ALERTS || '/tmp/maestro-alerts.jsonl';
-
-function readManifests() {
+// Orchestrations launched by THIS session — {session, prefix} markers the
+// conductor writes on start.
+function myOrchestrations() {
   let files = [];
   try {
-    files = fs.readdirSync(SESSION_DIR).filter((f) => f.endsWith('.json'));
+    files = fs.readdirSync(ACTIVE_DIR).filter((f) => f.endsWith('.json'));
   } catch {
     return [];
   }
   const out = [];
   for (const f of files) {
     try {
-      const j = JSON.parse(fs.readFileSync(path.join(SESSION_DIR, f), 'utf8'));
-      if (j && Array.isArray(j.tasks) && j.topic) out.push(j);
+      const m = JSON.parse(fs.readFileSync(path.join(ACTIVE_DIR, f), 'utf8'));
+      if (m && m.session === SESSION && m.prefix) out.push(m);
     } catch {
-      /* skip unreadable/partial manifest */
+      /* skip unreadable marker */
     }
   }
   return out;
 }
 
-// Most-recent alert kind per ticket — lets us flag pr-broken tickets live.
-function latestKindByTicket() {
-  const m = {};
-  let lines = [];
+// Live agent tickets for a prefix, from tmux `<prefix>-<ticket>-work` sessions
+// (execFileSync = no shell). One entry per ticket; helper -dev/-listen ignored.
+function liveTickets(prefix) {
+  let out = '';
   try {
-    lines = fs.readFileSync(ALERTS, 'utf8').trim().split('\n');
+    out = execFileSync('tmux', ['list-sessions', '-F', '#{session_name}'], {
+      encoding: 'utf8',
+      timeout: 1500,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
   } catch {
-    return m;
+    return [];
   }
-  for (const l of lines) {
-    try {
-      const j = JSON.parse(l);
-      if (j && j.ticket && j.kind) m[j.ticket] = j.kind;
-    } catch {
-      /* skip */
-    }
+  const esc = String(prefix).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp('^(' + esc + '-.+)-work$');
+  const seen = new Set();
+  for (const line of out.split('\n')) {
+    const m = line.match(re);
+    if (m) seen.add(m[1]);
   }
-  return m;
+  return [...seen].sort();
 }
 
-// --- Session scoping: show the maestro line ONLY in the orchestrator session.
-// Claude runs this statusLine command in EVERY session, so we gate on the
-// session JSON piped in on stdin. The first non-worktree session to render
-// claims the pin; agents (cwd = <repo>-<ticket> worktree) never claim it and
-// never match, so the line disappears from their tabs and other projects.
-function readCtx() {
-  let s = '';
-  try {
-    s = fs.readFileSync(0, 'utf8');
-  } catch {
-    /* no stdin */
-  }
-  try {
-    return JSON.parse(s || '{}');
-  } catch {
-    return {};
-  }
-}
-const CTX = readCtx();
-// The Claude session Claude runs this statusLine in. Each manifest records the
-// session that launched its orchestration (maestro-session.js), so the bar shows
-// a topic ONLY in its owning session — every orchestrator gets its own fleet,
-// and other chats show nothing. No global pin (which only one session could win).
-const SESSION_ID = CTX.session_id || CTX.sessionId || '';
-
-// Render the "▶ …" active portion. One active ticket shows inline with its
-// two-word label; multiple rotate one-per-refresh ([i/N]) via wall-clock time
-// (statusLine re-runs ~every refreshInterval second) so the label stays readable.
-function formatActive(active) {
-  const i = active.length === 1 ? 0 : Math.floor(Date.now() / 3000) % active.length;
-  const a = active[i];
-  const w = twoWords(a.id);
-  const label = `${a.id}${w ? ` — ${w}` : ''}`;
-  if (active.length === 1) return `   ▶  1  (${label})`;
-  return `   ▶  ${active.length}  [${i + 1}/${active.length}] ${label}`;
-}
-
-// One status segment for a topic, or null when it has no active/pending work.
-function topicSegment(j, kinds) {
-  const t = j.tasks;
-  const active = t.filter((x) => x.status === 'in_progress');
-  const pending = t.filter((x) => x.status === 'pending').length;
-  if (active.length === 0 && pending === 0) return null;
-  const done = t.filter((x) => x.status === 'done').length;
-  const broken = t.filter((x) => x.status !== 'done' && kinds[x.id] === 'pr-broken').length;
-  const ready = active.filter((x) => kinds[x.id] === 'pr-ready').length;
-  let seg = `🎼 ${j.topic}   ${done}/${t.length} ✓`;
-  if (active.length) seg += formatActive(active);
-  if (pending) seg += `   ⏳ ${pending}`;
-  if (ready) seg += `   ✅ ${ready}`;
-  if (broken) seg += `   ⚠  ${broken}`;
-  return seg;
+function segment(m) {
+  const tickets = liveTickets(m.prefix);
+  if (!tickets.length) return null;
+  return `🎼 ${m.prefix}   ▶  ${tickets.length}  (${tickets.join(', ')})`;
 }
 
 function render() {
-  if (!SESSION_ID) return '';
-  const kinds = latestKindByTicket();
-  return readManifests()
-    .filter((j) => j.session === SESSION_ID) // only fleets this session launched
-    .map((j) => topicSegment(j, kinds))
-    .filter(Boolean)
-    .join('      |      ');
+  if (!SESSION) return '';
+  return myOrchestrations().map(segment).filter(Boolean).join('      |      ');
 }
 
 process.stdout.write(render());

--- a/plugins/maestro/skills/lib/maestro-statusline.js
+++ b/plugins/maestro/skills/lib/maestro-statusline.js
@@ -110,50 +110,11 @@ function readCtx() {
   }
 }
 const CTX = readCtx();
+// The Claude session Claude runs this statusLine in. Each manifest records the
+// session that launched its orchestration (maestro-session.js), so the bar shows
+// a topic ONLY in its owning session — every orchestrator gets its own fleet,
+// and other chats show nothing. No global pin (which only one session could win).
 const SESSION_ID = CTX.session_id || CTX.sessionId || '';
-const CWD =
-  CTX.cwd || (CTX.workspace && (CTX.workspace.current_dir || CTX.workspace.project_dir)) || '';
-const PIN_FILE =
-  process.env.MAESTRO_STATUSLINE_PIN ||
-  path.join(os.homedir(), '.cache', 'maestro', 'statusline-session.pin');
-
-function isWorktreeCwd(c) {
-  if (!c) return false;
-  const esc = REPO_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp('/' + esc + '-[^/]+(?:/|$)').test(c);
-}
-
-// True only for the orchestrator session. Auto-claims the pin for the first
-// non-worktree session that renders; thereafter only that session matches.
-// Falls back to a cwd rule when session_id isn't provided by the host.
-function isOperatorSession() {
-  let pin = '';
-  try {
-    pin = fs.readFileSync(PIN_FILE, 'utf8').trim();
-  } catch {
-    /* none yet */
-  }
-  if (pin) return !!SESSION_ID && SESSION_ID === pin;
-  if (isWorktreeCwd(CWD)) return false; // an agent tab must never claim the pin
-  if (SESSION_ID) {
-    try {
-      fs.mkdirSync(path.dirname(PIN_FILE), { recursive: true });
-      // Atomic claim: 'wx' fails if a racing session already created the pin,
-      // so exactly one writer wins — no two-sessions-both-operator window.
-      fs.writeFileSync(PIN_FILE, SESSION_ID + '\n', { flag: 'wx' });
-      return true;
-    } catch {
-      // Lost the race (or write failed) — honor whoever actually holds the pin.
-      try {
-        return fs.readFileSync(PIN_FILE, 'utf8').trim() === SESSION_ID;
-      } catch {
-        return false;
-      }
-    }
-  }
-  // No session_id from host → fall back to cwd (non-worktree only).
-  return !isWorktreeCwd(CWD);
-}
 
 // Render the "▶ …" active portion. One active ticket shows inline with its
 // two-word label; multiple rotate one-per-refresh ([i/N]) via wall-clock time
@@ -185,9 +146,10 @@ function topicSegment(j, kinds) {
 }
 
 function render() {
-  if (!isOperatorSession()) return '';
+  if (!SESSION_ID) return '';
   const kinds = latestKindByTicket();
   return readManifests()
+    .filter((j) => j.session === SESSION_ID) // only fleets this session launched
     .map((j) => topicSegment(j, kinds))
     .filter(Boolean)
     .join('      |      ');


### PR DESCRIPTION
## Existing Behavior

The maestro fleet status bar used a single global pin (`~/.cache/maestro/statusline-session.pin`), auto-claimed by the first non-worktree session to render. Only that one session ever showed the bar — a second maestro orchestrator session (a parallel `/orchestrate` in another chat) rendered empty and never got its own fleet bar.

## Intended New Behavior

Scope the bar by the session that owns each manifest, mirroring the `/follow-up` bar:

- **`maestro-session.js`** now stamps each manifest with `session: CLAUDE_CODE_SESSION_ID` at init.
- **`maestro-statusline.js`** renders a topic only when `manifest.session === <statusLine session_id>` — so every orchestrator session shows exactly the fleets it launched, and other chats show nothing. Removed the global-pin logic (`isOperatorSession`, the `.pin` file, atomic-claim, cwd fallback).
- **`install-statusline.js`** drops the now-dead pin reset and `--unpin`.

Net: N concurrent maestro orchestrations across N chats each get their own bar; no session can starve another of the pin.

## Testing

- Renderer verified: a manifest stamped `session=A` renders in session A and is empty in session B.
- `pnpm quality` exit 0 (no new violations; unused pin/cwd code removed).
- Syntax-checked renderer, session-init, and installer.

No linked GitHub issue — ad-hoc operator fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Advisory UI only; no auth or data paths. Relies on tmux and env vars at daemon start; stale active markers if a daemon exits without cleanup could briefly mis-scope display (not addressed in this diff).
> 
> **Overview**
> Replaces the **global status-line pin** (one orchestrator chat could own the bar) with **per-session orchestration markers** written when the conduct daemon starts (`~/.cache/maestro/active/<CLAUDE_CODE_SESSION_ID>.json` with `session`, `prefix`, and `repo`).
> 
> The status renderer now shows the bar **only in the Claude session that launched that orchestration**: it reads markers matching stdin `session_id`, then lists live **`<prefix>-<ticket>-work`** tmux sessions via `tmux list-sessions` instead of session manifests, alert JSONL, git commit labels, or task done/pending/PR-broken counts. Output is a compact **prefix + active ticket count/list** per fleet.
> 
> The status-line installer drops pin file handling, install/remove pin resets, and the **`--unpin`** CLI path; messaging reflects per-session fleet display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33dd05f0ee64e56843971205a107b2af82f5270a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->