### PR TITLE
fix(work): enforce type/scope contracts at generation to prevent implement-gate wedging

### DIFF
--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -148,7 +148,6 @@ plugins/work/scripts/workflows/work-task-review/lib/phases/diff_audit.js
 plugins/work/scripts/workflows/work-pr-reviewer/lib/kind-checks/shared.js
 plugins/work/scripts/workflows/work-pr-reviewer/lib/phases/kind_checks.js
 plugins/work/scripts/workflows/work-ci/lib/phases/rerun_check.js
-plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
 plugins/work/scripts/workflows/work-qa-feature-tester/lib/phases/kind_checks.js
 plugins/work/scripts/workflows/work/hooks/protect-gherkin.js
 plugins/work/scripts/workflows/work-ci/lib/phases/triage.js

--- a/plugins/work/agents/spec-writer.md
+++ b/plugins/work/agents/spec-writer.md
@@ -84,7 +84,7 @@ When designing API / schema changes, also enumerate every consumer of a modified
       - **Extend**: Component exists but needs minor additions → extend/wrap it
       - **Extract & refactor**: Multiple pages have similar inline implementations but no shared component → propose extracting into a shared component as part of this task
       - **Create new**: Nothing similar exists → create new, but explain why existing code can't be reused
-   d. Document findings in the Reuse Audit tables BEFORE writing Architecture Decisions. The Reuse Audit text MUST include evidence of the broad searches you ran — the spec gate looks for the substrings `codegraph_search`, an explicit `Codebase search:` / `Filesystem search:` subheading, and a `Linear search:` / `Jira search:` / `Issue search:` subheading (whichever matches your provider).
+   d. Document findings in the Reuse Audit tables BEFORE writing Architecture Decisions, then distill them into the machine-parsed `### Reuse Declarations` bullets (grammar in the template — the completion gate reads only those bullets). The Reuse Audit text MUST include evidence of the broad searches you ran — the spec gate looks for the substrings `codegraph_search`, an explicit `Codebase search:` / `Filesystem search:` subheading, and a `Linear search:` / `Jira search:` / `Issue search:` subheading (whichever matches your provider).
    e. **Agnostic component decision** — for every NEW UI component you propose, fill the `## Component Shape Decision` table (see template below). The default for layout/list/sidebar/table/panel components that consume a typed data array is **Generic** (data-shape-agnostic, lives in `shared/` or `ui/`). Choosing **Specific** requires a one-sentence rationale naming a hard constraint (e.g., "uses page-local hooks that cannot be lifted"). The table is mandatory even when there is only one new component — its purpose is to force the "could this be agnostic?" question that was skipped on the Lineage tickets.
 3. **Explore the codebase** - Use Grep and Glob to understand:
    - Project structure and file organization
@@ -124,7 +124,19 @@ When designing API / schema changes, also enumerate every consumer of a modified
 |---|---|---|---|
 | {Existing component/utility/pattern} | `{file path}` | Reuse / Extend / Extract / Create New | {why this decision} |
 
-{If nothing reusable was found, state: "No existing patterns found that match this feature's requirements." with evidence of what was searched.}
+### Reuse Declarations
+**MANDATORY, machine-parsed.** The completion checker's `reuse_audit_enforcement` gate parses ONLY this bullet grammar (tables above are for humans; the parser cannot read them — an unparseable section hard-blocks the ticket at `check`, where spec.md is locked). One bullet per Reuse/Extend row from the table above, in EXACTLY this shape — symbol backtick first, verb immediately after (a parenthesized path between them is tolerated but not preferred):
+
+- `{Symbol}` MUST be reused from `{path/to/file.ext:line}` — {one-line reason}
+- `{PatternName}` may be reused from `{path}` — {mirrored pattern, not imported}
+
+Verb semantics — get this right or the gate false-fails:
+- **`MUST be reused`** — ONLY for symbols the implementation will literally reference (import/require/call). The gate verifies each MUST symbol appears on the PR's added lines and fails the ticket if it doesn't.
+- **`may be reused`** — for patterns/conventions that are *mirrored* but not imported by symbol (a dispatcher shape, a logging convention, a naming scheme). Never mark these MUST.
+
+If nothing reusable was found, emit exactly:
+
+- None — no reusable symbols found (see Broad Search Evidence)
 
 ### Broad Search Evidence
 Show the queries you ran and where (one line each). Required substrings for the spec gate are noted in parentheses.

--- a/plugins/work/scripts/workflows/lib/__tests__/task-scope.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/task-scope.test.js
@@ -15,6 +15,7 @@ describe('validateTask', () => {
   it('passes when both sections are populated', () => {
     const errors = ts.validateTask({
       num: 1,
+      type: 'tdd-code',
       filesInScope: ['lib/x.ts'],
       filesOutOfScope: ['lib/y.ts'],
     });
@@ -24,6 +25,7 @@ describe('validateTask', () => {
   it('passes with empty filesOutOfScope (no siblings)', () => {
     const errors = ts.validateTask({
       num: 1,
+      type: 'tdd-code',
       filesInScope: ['lib/x.ts'],
       filesOutOfScope: [],
     });
@@ -31,7 +33,7 @@ describe('validateTask', () => {
   });
 
   it('fails when both filesInScope and suggestedScope are missing', () => {
-    const errors = ts.validateTask({ num: 2, filesOutOfScope: [] });
+    const errors = ts.validateTask({ num: 2, type: 'tdd-code', filesOutOfScope: [] });
     assert.equal(errors.length, 1);
     assert.match(errors[0], /Task 2/);
     assert.match(errors[0], /Files in scope/);
@@ -40,6 +42,7 @@ describe('validateTask', () => {
   it('fails when both filesInScope and suggestedScope are empty', () => {
     const errors = ts.validateTask({
       num: 3,
+      type: 'tdd-code',
       filesInScope: [],
       suggestedScope: '',
       filesOutOfScope: [],
@@ -50,6 +53,7 @@ describe('validateTask', () => {
   it('accepts legacy suggestedScope as fallback when filesInScope is missing', () => {
     const errors = ts.validateTask({
       num: 5,
+      type: 'tdd-code',
       filesInScope: [],
       suggestedScope: '- lib/x.ts',
       filesOutOfScope: [],
@@ -63,7 +67,7 @@ describe('validateTask', () => {
   });
 
   it('tolerates missing filesOutOfScope (legacy task)', () => {
-    const errors = ts.validateTask({ num: 6, filesInScope: ['x.ts'] });
+    const errors = ts.validateTask({ num: 6, type: 'tdd-code', filesInScope: ['x.ts'] });
     assert.deepEqual(errors, []);
   });
 
@@ -75,7 +79,7 @@ describe('validateTask', () => {
   it('exempts checkpoint tasks from the Files-in-scope requirement', () => {
     // Checkpoint tasks don't ship code, so they don't need a scope envelope.
     assert.deepEqual(ts.validateTask({ num: 9, type: 'checkpoint' }), []);
-    assert.deepEqual(ts.validateTask({ num: 10, isCheckpoint: true }), []);
+    assert.deepEqual(ts.validateTask({ num: 10, type: 'checkpoint', isCheckpoint: true }), []);
   });
 
   // GH-392 follow-up: cross-task deps must be repo-relative.
@@ -101,10 +105,51 @@ describe('validateTask', () => {
   it('accepts repo-relative crossTaskDeps', () => {
     const errors = ts.validateTask({
       num: 13,
+      type: 'tdd-code',
       filesInScope: ['src/a.ts'],
       crossTaskDeps: ['src/shared/schema.ts', 'lib/**/*.ts'],
     });
     assert.deepEqual(errors, []);
+  });
+
+  // GH-498-shape defense: unknown/missing `### Type` falls back to the
+  // strictest tdd-code contract at implement and wedges non-code tasks at
+  // RED. Catch it at tasks_gate where tasks.md is still editable.
+  it('rejects a task with a missing Type', () => {
+    const errors = ts.validateTask({ num: 20, filesInScope: ['src/a.ts'] });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Task 20 is missing `### Type`/);
+    assert.match(errors[0], /tdd-code/);
+  });
+
+  it('rejects a task with a legacy domain-kind Type (devops)', () => {
+    const errors = ts.validateTask({
+      num: 21,
+      type: 'devops',
+      filesInScope: ['scripts/deploy.yml'],
+    });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /"devops" is not in the closed enum/);
+    assert.match(errors[0], /strictest tdd-code gate contract/);
+  });
+
+  it('accepts every member of the closed Type enum', () => {
+    for (const type of [
+      'tdd-code',
+      'tests-only',
+      'docs',
+      'config',
+      'ci',
+      'mechanical-refactor',
+      'file-move',
+      'checkpoint',
+    ]) {
+      const errors = ts.validateTask({ num: 22, type, filesInScope: ['src/a.ts'] });
+      assert.ok(
+        !errors.some((e) => /### Type/.test(e)),
+        `Type "${type}" should be accepted; got: ${errors.join(' | ')}`
+      );
+    }
   });
 
   it('rejects absolute path in filesInScope and filesOutOfScope', () => {
@@ -131,7 +176,7 @@ describe('validateCrossTaskDepsOwnership', () => {
     assert.match(errors[0], /no other task lists it in/);
   });
 
-  it('accepts a crossTaskDep that literally appears in another task\'s scope', () => {
+  it("accepts a crossTaskDep that literally appears in another task's scope", () => {
     const tasks = [
       { num: 1, filesInScope: ['src/a.ts'], crossTaskDeps: ['src/shared/schema.ts'] },
       { num: 2, filesInScope: ['src/shared/schema.ts', 'src/b.ts'] },
@@ -139,7 +184,7 @@ describe('validateCrossTaskDepsOwnership', () => {
     assert.deepEqual(ts.validateCrossTaskDepsOwnership(tasks), []);
   });
 
-  it('accepts a crossTaskDep covered by another task\'s glob scope', () => {
+  it("accepts a crossTaskDep covered by another task's glob scope", () => {
     const tasks = [
       { num: 1, filesInScope: ['src/a.ts'], crossTaskDeps: ['src/shared/schema.ts'] },
       { num: 2, filesInScope: ['src/shared/**'] },
@@ -186,8 +231,8 @@ describe('validateCrossTaskDepsOwnership', () => {
 describe('validateAll', () => {
   it('returns valid:true when all tasks pass', () => {
     const result = ts.validateAll([
-      { num: 1, filesInScope: ['a.ts'], filesOutOfScope: [] },
-      { num: 2, filesInScope: ['b.ts'], filesOutOfScope: ['c.ts'] },
+      { num: 1, type: 'tdd-code', filesInScope: ['a.ts'], filesOutOfScope: [] },
+      { num: 2, type: 'tdd-code', filesInScope: ['b.ts'], filesOutOfScope: ['c.ts'] },
     ]);
     assert.equal(result.valid, true);
     assert.deepEqual(result.errors, []);

--- a/plugins/work/scripts/workflows/lib/kind-checks-shared-base.js
+++ b/plugins/work/scripts/workflows/lib/kind-checks-shared-base.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * kind-checks-shared-base.js — helpers common to the per-subsystem
+ * kind-check `shared.js` modules (work-completion-checker, work-code-checker).
+ *
+ * Both subsystems previously carried byte-identical copies of
+ * `readFile` / `readChangedFiles` and the work-spec re-export tail; the
+ * copies drifted into jscpd duplicate-block debt. One definition here, both
+ * sides require it.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const config = require('./config');
+
+function readFile(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the changed-file list. Prefer the snapshot pr-context.json (written
+ * by pr-next.js diff_audit) so checkers see the same diff the PR phase
+ * locked in. Fall back to git diff if absent.
+ */
+function readChangedFiles(ctx) {
+  const ctxPath = path.join(ctx.tasksDir, 'pr-context.json');
+  if (fs.existsSync(ctxPath)) {
+    try {
+      const j = JSON.parse(fs.readFileSync(ctxPath, 'utf8'));
+      if (Array.isArray(j.files)) return j.files.slice();
+    } catch {
+      /* fall through */
+    }
+  }
+  const root = ctx.worktreeRoot || process.cwd();
+  // Honor BASE_BRANCH / symbolic-ref so dev-based repos don't fall back to
+  // origin/main (which is behind merges and surfaces phantom files).
+  for (const base of config.getDiffBaseCandidates({ cwd: root })) {
+    const r = spawnSync('git', ['diff', '--name-only', `${base}...HEAD`], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    if (r.status === 0) {
+      return r.stdout
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+  }
+  return [];
+}
+
+/**
+ * The work-spec kind-checks helpers every consumer re-exports verbatim.
+ * Spread the result into the consumer's module.exports.
+ */
+function specSharedReexports(specShared) {
+  return {
+    readBrief: specShared.readBrief,
+    readSpec: specShared.readSpec,
+    readTasks: specShared.readTasks,
+    sliceSection: specShared.sliceSection,
+    filesInFilesToModify: specShared.filesInFilesToModify,
+    detectKinds: specShared.detectKinds,
+    MalformedTasksError: specShared.MalformedTasksError,
+    preflightTasksManifest: specShared.preflightTasksManifest,
+    briefForbidsBackend: specShared.briefForbidsBackend,
+    isBackendFile: specShared.isBackendFile,
+    isFrontendFile: specShared.isFrontendFile,
+    isE2eFile: specShared.isE2eFile,
+    isDevopsFile: specShared.isDevopsFile,
+    isAppSourceFile: specShared.isAppSourceFile,
+    KIND_NAMES: specShared.KIND_NAMES,
+  };
+}
+
+module.exports = { readFile, readChangedFiles, specSharedReexports };

--- a/plugins/work/scripts/workflows/lib/requirement-ids.js
+++ b/plugins/work/scripts/workflows/lib/requirement-ids.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * requirement-ids.js — canonical requirement-ID grammar.
+ *
+ * Single source of truth shared by the generator side
+ * (work-tasks/lib/phases/requirements_extract.js — extraction + traceability)
+ * and the consumer side (work-completion-checker subsection coverage
+ * fallback). The two sides previously carried different grammars: the
+ * generator matched IDs anywhere in text while the completion-checker
+ * fallback demanded exactly one bare token per bullet — so a tasks.md with
+ * `- R1, R6, R7` passed tasks_gate and then deadlocked the check step with
+ * `requirement_coverage_missing` (issue #498). One grammar, both sides.
+ *
+ * Matches "R1", "R-3", "AC1", "AC-2", "spec §2.1", "brief AC-3".
+ */
+const REQUIREMENT_ID_RE_SOURCE = '\\b(R-?\\d+|AC-?\\d+|spec\\s*§[\\d.]+|brief\\s+AC-\\d+)\\b';
+
+function requirementIdRe() {
+  return new RegExp(REQUIREMENT_ID_RE_SOURCE, 'gi');
+}
+
+/**
+ * Every canonical requirement ID found in `text`, deduped, in first-seen
+ * order. Liberal by design: IDs are recognized inside prose, comma lists,
+ * and one-per-line bullets alike.
+ */
+function listRequirementIds(text) {
+  if (!text) return [];
+  const out = new Set();
+  const re = requirementIdRe();
+  let m;
+  while ((m = re.exec(text)) !== null) out.add(m[0]);
+  return [...out];
+}
+
+/**
+ * Requirement IDs from a `### Requirements Covered` bullet block. Canonical
+ * IDs are extracted with the shared grammar; additionally, a bullet whose
+ * ENTIRE content is one bare identifier token (the shape the old
+ * completion-checker fallback required, e.g. `- REQ_CUSTOM_1`) is kept for
+ * backward compatibility with non-canonical ID conventions.
+ */
+function extractRequirementIdsFromBulletBlock(blockText) {
+  if (!blockText) return [];
+  const out = new Set(listRequirementIds(blockText));
+  for (const line of blockText.split('\n')) {
+    const m = line.match(/^\s*[-*]\s+([A-Za-z0-9_-]+)\s*$/);
+    if (m) out.add(m[1]);
+  }
+  return [...out];
+}
+
+module.exports = {
+  REQUIREMENT_ID_RE_SOURCE,
+  requirementIdRe,
+  listRequirementIds,
+  extractRequirementIdsFromBulletBlock,
+};

--- a/plugins/work/scripts/workflows/lib/task-scope-validators.js
+++ b/plugins/work/scripts/workflows/lib/task-scope-validators.js
@@ -98,6 +98,11 @@ function validateTask(task) {
   if (!task || typeof task !== 'object') return ['task must be an object'];
   const errors = [];
   const label = `Task ${task.num ?? '?'}`;
+  // Runs BEFORE the checkpoint early-return on purpose: a title-derived
+  // checkpoint (`isCheckpoint: true`) with no `### Type` line is NOT safe —
+  // the implement-side isCheckpointTask() (exception-validator.js) honors
+  // only `type === 'checkpoint'`, so without the explicit line the task
+  // falls to the strictest tdd-code contract and wedges. Require the line.
   _checkTypeKnown(task, label, errors);
   if (_isCheckpointTask(task)) return errors;
 

--- a/plugins/work/scripts/workflows/lib/task-scope-validators.js
+++ b/plugins/work/scripts/workflows/lib/task-scope-validators.js
@@ -14,6 +14,7 @@
 'use strict';
 
 const { _isAbsolutePathEntry, fileMatchesScope } = require('./task-scope-globs');
+const { TASK_TYPES, isKnownTaskType } = require('../../../skills/split-in-tasks/lib/task-types');
 
 // ---------------------------------------------------------------------------
 // validateTask
@@ -22,6 +23,28 @@ const { _isAbsolutePathEntry, fileMatchesScope } = require('./task-scope-globs')
 function _isCheckpointTask(task) {
   const taskType = typeof task.type === 'string' ? task.type.toLowerCase().trim() : null;
   return taskType === 'checkpoint' || task.isCheckpoint === true;
+}
+
+/**
+ * `### Type` must be a member of the closed gate-contract enum
+ * (task-types.js). An unknown value is not cosmetic: `gateContractFor()`
+ * falls back to the strictest tdd-code contract at implement, so a docs or
+ * config task carrying a freeform Type wedges at RED demanding test files
+ * (GH-498 shape). Catch it here — at tasks_gate, where tasks.md is still
+ * editable — instead of at implement where it is hook-locked.
+ */
+function _checkTypeKnown(task, label, errors) {
+  const t = typeof task.type === 'string' ? task.type.trim() : '';
+  if (!t) {
+    errors.push(`${label} is missing \`### Type\` — must be one of: ${TASK_TYPES.join(', ')}.`);
+    return;
+  }
+  if (!isKnownTaskType(t)) {
+    errors.push(
+      `${label} \`### Type\` "${task.type}" is not in the closed enum (${TASK_TYPES.join(', ')}). ` +
+        'Unknown Types fall back to the strictest tdd-code gate contract at implement and wedge non-code tasks at RED.'
+    );
+  }
 }
 
 function _checkScopePresence(task, label, errors) {
@@ -75,6 +98,7 @@ function validateTask(task) {
   if (!task || typeof task !== 'object') return ['task must be an object'];
   const errors = [];
   const label = `Task ${task.num ?? '?'}`;
+  _checkTypeKnown(task, label, errors);
   if (_isCheckpointTask(task)) return errors;
 
   _checkScopePresence(task, label, errors);

--- a/plugins/work/scripts/workflows/work-code-checker/lib/kind-checks/shared.js
+++ b/plugins/work/scripts/workflows/work-code-checker/lib/kind-checks/shared.js
@@ -9,46 +9,13 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
 
 const specShared = require('../../../work-spec/lib/kind-checks/shared');
-const config = require('../../../lib/config');
-
-function readFile(p) {
-  try {
-    return fs.readFileSync(p, 'utf8');
-  } catch {
-    return null;
-  }
-}
-
-function readChangedFiles(ctx) {
-  const ctxPath = path.join(ctx.tasksDir, 'pr-context.json');
-  if (fs.existsSync(ctxPath)) {
-    try {
-      const j = JSON.parse(fs.readFileSync(ctxPath, 'utf8'));
-      if (Array.isArray(j.files)) return j.files.slice();
-    } catch {
-      /* fall through */
-    }
-  }
-  const root = ctx.worktreeRoot || process.cwd();
-  // Honor BASE_BRANCH / symbolic-ref so dev-based repos don't fall back to
-  // origin/main (which is behind merges and surfaces phantom files).
-  for (const base of config.getDiffBaseCandidates({ cwd: root })) {
-    const r = spawnSync('git', ['diff', '--name-only', `${base}...HEAD`], {
-      cwd: root,
-      encoding: 'utf8',
-    });
-    if (r.status === 0) {
-      return r.stdout
-        .split('\n')
-        .map((s) => s.trim())
-        .filter(Boolean);
-    }
-  }
-  return [];
-}
+const {
+  readFile,
+  readChangedFiles,
+  specSharedReexports,
+} = require('../../../lib/kind-checks-shared-base');
 
 function readFileFromWorktree(ctx, relPath) {
   const root = ctx.worktreeRoot || process.cwd();
@@ -111,19 +78,5 @@ module.exports = {
   hasCompanionTest,
   TS_VIOLATIONS,
   // Re-exports from spec-side shared:
-  readBrief: specShared.readBrief,
-  readSpec: specShared.readSpec,
-  readTasks: specShared.readTasks,
-  sliceSection: specShared.sliceSection,
-  filesInFilesToModify: specShared.filesInFilesToModify,
-  detectKinds: specShared.detectKinds,
-  MalformedTasksError: specShared.MalformedTasksError,
-  preflightTasksManifest: specShared.preflightTasksManifest,
-  briefForbidsBackend: specShared.briefForbidsBackend,
-  isBackendFile: specShared.isBackendFile,
-  isFrontendFile: specShared.isFrontendFile,
-  isE2eFile: specShared.isE2eFile,
-  isDevopsFile: specShared.isDevopsFile,
-  isAppSourceFile: specShared.isAppSourceFile,
-  KIND_NAMES: specShared.KIND_NAMES,
+  ...specSharedReexports(specShared),
 };

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/coverage-fallback.integration.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/coverage-fallback.integration.test.js
@@ -227,3 +227,56 @@ test('backward compatibility - top-level table preserved', () => {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+// Case F (#498) — comma-separated multi-ID bullets synthesize one row per ID
+test('comma-separated Requirements Covered bullets synthesize one row per ID (#498)', () => {
+  const tasks = [
+    '# Tasks',
+    '',
+    '## Task 1 — Foo',
+    '',
+    '### Requirements Covered',
+    '- R1, R6, R7, AC1',
+    '',
+    '## Task 2 — Bar',
+    '',
+    '### Requirements Covered',
+    '- R2',
+    '',
+  ].join('\n');
+  const { root, tasksDir } = makeTasksDir({ tasks });
+  try {
+    const rows = readRequirementCoverage(tasksDir);
+    const task1Ids = rows
+      .filter((r) => /Task 1/.test(r.evidence))
+      .map((r) => r.id)
+      .sort();
+    assert.deepEqual(task1Ids, ['AC1', 'R1', 'R6', 'R7']);
+    const task2Ids = rows.filter((r) => /Task 2/.test(r.evidence)).map((r) => r.id);
+    assert.deepEqual(task2Ids, ['R2']);
+    for (const row of rows) assert.equal(row.source, 'subsection');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Case G — legacy bare-token bullet (non-canonical ID convention) still parses
+test('legacy single-bare-token bullet is preserved for backward compatibility', () => {
+  const tasks = [
+    '# Tasks',
+    '',
+    '## Task 1 — Foo',
+    '',
+    '### Requirements Covered',
+    '- REQ_CUSTOM_1',
+    '',
+  ].join('\n');
+  const { root, tasksDir } = makeTasksDir({ tasks });
+  try {
+    const rows = readRequirementCoverage(tasksDir);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].id, 'REQ_CUSTOM_1');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
@@ -27,7 +27,7 @@ function buildCtx({ spec, changedFiles = [], fileContents = {} }) {
   fs.writeFileSync(
     path.join(tasksDir, 'pr-context.json'),
     JSON.stringify({ files: changedFiles }, null, 2),
-    'utf8',
+    'utf8'
   );
   // Write content for each changed file under worktreeRoot
   for (const [rel, body] of Object.entries(fileContents)) {
@@ -99,7 +99,7 @@ test.describe('reuse_audit_enforcement phase', () => {
       assert.equal(
         ctx.failures.filter((f) => f.checkType === 'reuse_audit').length,
         0,
-        'no failure record should be pushed',
+        'no failure record should be pushed'
       );
     } finally {
       cleanup();
@@ -148,7 +148,7 @@ test.describe('reuse_audit_enforcement phase', () => {
       assert.match(
         rec.observed,
         /found ExploreBulkToolbar in diff — did you mean to extend ContentPageToolbar\?/,
-        'observed must include the suffix-candidate hint string',
+        'observed must include the suffix-candidate hint string'
       );
     } finally {
       cleanup();
@@ -183,10 +183,7 @@ test.describe('reuse_audit_enforcement phase', () => {
     try {
       const result = await phase.validate(ctx);
       assert.equal(result.ok, true, 'literal Object.create in diff must satisfy the audit');
-      assert.equal(
-        ctx.failures.filter((f) => f.checkType === 'reuse_audit').length,
-        0,
-      );
+      assert.equal(ctx.failures.filter((f) => f.checkType === 'reuse_audit').length, 0);
     } finally {
       cleanup();
     }
@@ -213,7 +210,7 @@ test.describe('reuse_audit_enforcement phase', () => {
       assert.equal(
         result.ok,
         false,
-        'wildcard match must NOT count — `.` must be escaped to a literal dot',
+        'wildcard match must NOT count — `.` must be escaped to a literal dot'
       );
       const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
       assert.ok(rec, 'failure record should be pushed for missing literal symbol');
@@ -248,7 +245,7 @@ test.describe('reuse_audit_enforcement phase', () => {
       const errs = Array.isArray(result.errors) ? result.errors : [];
       assert.ok(
         !errs.some((e) => /SyntaxError|Invalid regular expression/i.test(String(e))),
-        `must not surface a regex SyntaxError; got errors=${JSON.stringify(errs)}`,
+        `must not surface a regex SyntaxError; got errors=${JSON.stringify(errs)}`
       );
     } finally {
       cleanup();
@@ -269,14 +266,109 @@ test.describe('reuse_audit_enforcement phase', () => {
       assert.ok(Array.isArray(result.errors));
       assert.ok(
         result.errors.some((e) => /^parser threw:/.test(String(e))),
-        'errors must include a "parser threw: ..." entry',
+        'errors must include a "parser threw: ..." entry'
       );
       // Parser failure must also be surfaced through the failure-store so
       // report.js can include it in completion-verdict.json.
       const parserFailure = ctx.failures.find(
-        (f) => f.checkType === 'reuse_audit' && f.requirementId === 'REUSE-PARSER',
+        (f) => f.checkType === 'reuse_audit' && f.requirementId === 'REUSE-PARSER'
       );
       assert.ok(parserFailure, 'parser failure must be pushed onto ctx.failures');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// --- #629: grammar tolerance + explicit none-marker --------------------------
+
+test.describe('readReuseAudit grammar (#629)', () => {
+  const { readReuseAudit } = require('../lib/kind-checks/shared');
+
+  function specDirWith(body) {
+    const root = mkTmp();
+    const dir = path.join(root, 'tasks', 'GH-629');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'spec.md'), body, 'utf8');
+    return { dir, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+  }
+
+  test('accepts the parenthesized-path variant `Symbol` (`path`) MUST be reused', () => {
+    const { dir, cleanup } = specDirWith(
+      [
+        '# Spec',
+        '',
+        '## Reuse Audit',
+        '',
+        '- `distance` (`plugins/lib/levenshtein.js:46`) MUST be reused — typo suggestions',
+        '- `nearest` (`plugins/lib/levenshtein.js:96`) may be reused — mirrored only',
+        '',
+      ].join('\n')
+    );
+    try {
+      const entries = readReuseAudit(dir);
+      assert.equal(entries.length, 2);
+      assert.equal(entries[0].symbol, 'distance');
+      assert.equal(entries[0].mustReuse, true);
+      assert.equal(entries[1].symbol, 'nearest');
+      assert.equal(entries[1].mustReuse, false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('explicit none-marker returns an empty (valid) declaration set', () => {
+    const { dir, cleanup } = specDirWith(
+      [
+        '# Spec',
+        '',
+        '## Reuse Audit',
+        '',
+        '- None — no reusable symbols found (see Broad Search Evidence)',
+        '',
+      ].join('\n')
+    );
+    try {
+      assert.deepEqual(readReuseAudit(dir), []);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('prose-only section still throws with the grammar in the message', () => {
+    const { dir, cleanup } = specDirWith(
+      [
+        '# Spec',
+        '',
+        '## Reuse Audit',
+        '',
+        '- `plugins/lib/levenshtein.js:46` and `:96` — pure helpers. Reused directly.',
+        '',
+      ].join('\n')
+    );
+    try {
+      assert.throws(() => readReuseAudit(dir), /MUST be reused from/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('none-marker plus real entries keeps the real entries', () => {
+    const { dir, cleanup } = specDirWith(
+      [
+        '# Spec',
+        '',
+        '## Reuse Audit',
+        '',
+        '- None of the legacy helpers apply here',
+        '- `distance` MUST be reused from `plugins/lib/levenshtein.js:46` — typo suggestions',
+        '',
+      ].join('\n')
+    );
+    try {
+      const entries = readReuseAudit(dir);
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].symbol, 'distance');
     } finally {
       cleanup();
     }

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
@@ -14,6 +14,7 @@ const { spawnSync } = require('node:child_process');
 
 const specShared = require('../../../work-spec/lib/kind-checks/shared');
 const config = require('../../../lib/config');
+const { extractRequirementIdsFromBulletBlock } = require('../../../lib/requirement-ids');
 
 function readFile(p) {
   try {
@@ -77,20 +78,21 @@ function readRequirementCoverageFromSubsections(tasksText) {
     const reqAfter = block.slice(reqMatch.index + reqMatch[0].length);
     const nextHeading = reqAfter.match(/^#{2,3}\s/m);
     const reqBlock = nextHeading ? reqAfter.slice(0, nextHeading.index) : reqAfter;
-    for (const line of reqBlock.split('\n')) {
-      const m = line.match(/^\s*[-*]\s+([A-Za-z0-9_-]+)\s*$/);
-      if (m) {
-        rows.push({
-          id: m[1],
-          description: '',
-          status: 'DELIVERED',
-          evidence: `tasks.md:Task ${taskNum}`,
-          // Tag synthesized rows so downstream gates (test_pass_crossref B2)
-          // can avoid forcing test citations on the R4 fallback, which has
-          // no concept of per-row test evidence by design.
-          source: 'subsection',
-        });
-      }
+    // #498: parse with the SAME canonical grammar the tasks-phase generator
+    // uses (shared lib/requirement-ids.js), so comma-separated bullets like
+    // `- R1, R6, R7` synthesize one row per ID instead of silently yielding
+    // zero rows and re-triggering the requirement_coverage_missing deadlock.
+    for (const id of extractRequirementIdsFromBulletBlock(reqBlock)) {
+      rows.push({
+        id,
+        description: '',
+        status: 'DELIVERED',
+        evidence: `tasks.md:Task ${taskNum}`,
+        // Tag synthesized rows so downstream gates (test_pass_crossref B2)
+        // can avoid forcing test citations on the R4 fallback, which has
+        // no concept of per-row test evidence by design.
+        source: 'subsection',
+      });
     }
   }
   return rows;
@@ -153,13 +155,18 @@ function readBriefRequirements(tasksDir) {
 /**
  * Parse the `## Reuse Audit` section of spec.md and return an array of
  * `{ symbol, line, mustReuse }` records. Returns `null` when the section
- * is absent (signals "spec doesn't declare reuse"). Throws when the
- * section is present but contains no parseable entries (signals
- * malformed authoring rather than absence).
+ * is absent (signals "spec doesn't declare reuse"), and `[]` when the
+ * section carries an explicit none-marker bullet (`- None — ...`), which
+ * declares "audited, nothing reusable found". Throws when the section is
+ * present but contains no parseable entries (signals malformed authoring
+ * rather than absence).
  *
- * Recognized bullet shape:
- *   - `Symbol` MUST be reused from `path/to/file.ext`
- * Soft-reuse lines (without MUST) are captured with `mustReuse: false`.
+ * Recognized bullet shapes (#629 — grammar must match what spec-writer is
+ * instructed to emit; see agents/spec-writer.md "Reuse Declarations"):
+ *   - `Symbol` MUST be reused from `path/to/file.ext` — reason
+ *   - `Symbol` (`path/to/file.ext`) MUST be reused — reason
+ *   - `Symbol` may be reused from `path` — reason (soft, mustReuse: false)
+ *   - None — no reusable symbols found (explicit empty declaration)
  */
 function readReuseAudit(specDir) {
   const text = specShared.readSpec(specDir);
@@ -174,10 +181,17 @@ function readReuseAudit(specDir) {
   const headingLine = text.slice(0, headingOffset).split('\n').length;
   const entries = [];
   const blockLines = (block || '').split('\n');
+  let sawNoneMarker = false;
   for (let i = 0; i < blockLines.length; i += 1) {
     const raw = blockLines[i];
+    if (/^\s*[-*]\s+None\b/i.test(raw)) {
+      sawNoneMarker = true;
+      continue;
+    }
+    // Optional parenthesized path between the symbol and the verb tolerates
+    // the common `` `Symbol` (`path`) MUST be reused `` ordering (#629).
     const m = raw.match(
-      /^\s*[-*]\s+`([^`]+)`\s+(MUST\s+be\s+reused|be\s+reused|may\s+be\s+reused)/i
+      /^\s*[-*]\s+`([^`]+)`\s*(?:\([^)]*\)\s*)?(MUST\s+be\s+reused|be\s+reused|may\s+be\s+reused)/i
     );
     if (!m) continue;
     const mustReuse = /MUST/i.test(m[2]);
@@ -197,8 +211,11 @@ function readReuseAudit(specDir) {
     });
   }
   if (entries.length === 0) {
+    if (sawNoneMarker) return entries; // audited, nothing reusable — valid empty
     throw new Error(
-      `readReuseAudit: '## Reuse Audit' section in ${path.join(specDir, 'spec.md')} contains no parseable entries`
+      `readReuseAudit: '## Reuse Audit' section in ${path.join(specDir, 'spec.md')} contains no parseable entries. ` +
+        'Expected bullets shaped `- \\`Symbol\\` MUST be reused from \\`path\\` — reason` ' +
+        '(or `may be reused` for mirrored patterns), or `- None — no reusable symbols found`.'
     );
   }
   return entries;

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
@@ -10,52 +10,14 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
 
 const specShared = require('../../../work-spec/lib/kind-checks/shared');
-const config = require('../../../lib/config');
+const {
+  readFile,
+  readChangedFiles,
+  specSharedReexports,
+} = require('../../../lib/kind-checks-shared-base');
 const { extractRequirementIdsFromBulletBlock } = require('../../../lib/requirement-ids');
-
-function readFile(p) {
-  try {
-    return fs.readFileSync(p, 'utf8');
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Get the changed-file list. Prefer the snapshot pr-context.json (written
- * by pr-next.js diff_audit) so completion-checker sees the same diff the
- * PR phase locked in. Fall back to git diff if absent.
- */
-function readChangedFiles(ctx) {
-  const ctxPath = path.join(ctx.tasksDir, 'pr-context.json');
-  if (fs.existsSync(ctxPath)) {
-    try {
-      const j = JSON.parse(fs.readFileSync(ctxPath, 'utf8'));
-      if (Array.isArray(j.files)) return j.files.slice();
-    } catch {
-      /* fall through */
-    }
-  }
-  const root = ctx.worktreeRoot || process.cwd();
-  // Honor BASE_BRANCH / symbolic-ref so dev-based repos don't fall back to
-  // origin/main (which is behind merges and surfaces phantom files).
-  for (const base of config.getDiffBaseCandidates({ cwd: root })) {
-    const r = spawnSync('git', ['diff', '--name-only', `${base}...HEAD`], {
-      cwd: root,
-      encoding: 'utf8',
-    });
-    if (r.status === 0) {
-      return r.stdout
-        .split('\n')
-        .map((s) => s.trim())
-        .filter(Boolean);
-    }
-  }
-  return [];
-}
 
 /**
  * Walk `## Task N — <title>` blocks and synthesize coverage rows from each
@@ -302,19 +264,5 @@ module.exports = {
   readSuggestedScopeFiles,
   readTestReport,
   // Re-exports from spec-side shared:
-  readBrief: specShared.readBrief,
-  readSpec: specShared.readSpec,
-  readTasks: specShared.readTasks,
-  sliceSection: specShared.sliceSection,
-  filesInFilesToModify: specShared.filesInFilesToModify,
-  detectKinds: specShared.detectKinds,
-  MalformedTasksError: specShared.MalformedTasksError,
-  preflightTasksManifest: specShared.preflightTasksManifest,
-  briefForbidsBackend: specShared.briefForbidsBackend,
-  isBackendFile: specShared.isBackendFile,
-  isFrontendFile: specShared.isFrontendFile,
-  isE2eFile: specShared.isE2eFile,
-  isDevopsFile: specShared.isDevopsFile,
-  isAppSourceFile: specShared.isAppSourceFile,
-  KIND_NAMES: specShared.KIND_NAMES,
+  ...specSharedReexports(specShared),
 };

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
@@ -99,36 +99,38 @@ function readRequirementCoverageFromSubsections(tasksText) {
 }
 
 /**
+ * Parse one `| id | desc | status | evidence |` table line into a coverage
+ * row, or null for non-row lines (separators, headers, prose).
+ */
+function parseCoverageTableRow(line) {
+  if (!/^\|/.test(line)) return null;
+  const cells = line
+    .split('|')
+    .slice(1, -1)
+    .map((c) => c.trim());
+  if (cells.length < 2) return null;
+  if (/^-+$/.test(cells[0])) return null;
+  if (/^(id|requirement|req)$/i.test(cells[0])) return null;
+  return {
+    id: cells[0],
+    description: cells[1] || '',
+    status: cells[2] || '',
+    evidence: cells[3] || '',
+    source: 'table',
+  };
+}
+
+/**
  * Parse `## Requirement Coverage` table out of tasks.md.
  * Returns array of { id, description, status, evidence } records.
  * Falls back to per-task `### Requirements Covered` subsections when the
  * top-level table is absent (R4).
  */
-// eslint-disable-next-line complexity -- allowlisted pre-existing complexity; see .quality-exceptions
 function readRequirementCoverage(tasksDir) {
   const text = specShared.readTasks(tasksDir);
   if (!text) return [];
   const block = specShared.sliceSection(text, /^##\s+Requirement Coverage\b/im);
-  const rows = [];
-  if (block) {
-    for (const line of block.split('\n')) {
-      if (!/^\|/.test(line)) continue;
-      const cells = line
-        .split('|')
-        .slice(1, -1)
-        .map((c) => c.trim());
-      if (cells.length < 2) continue;
-      if (/^-+$/.test(cells[0])) continue;
-      if (/^(id|requirement|req)$/i.test(cells[0])) continue;
-      rows.push({
-        id: cells[0],
-        description: cells[1] || '',
-        status: cells[2] || '',
-        evidence: cells[3] || '',
-        source: 'table',
-      });
-    }
-  }
+  const rows = (block ? block.split('\n') : []).map(parseCoverageTableRow).filter(Boolean);
   if (rows.length === 0) return readRequirementCoverageFromSubsections(text);
   return rows;
 }

--- a/plugins/work/scripts/workflows/work-tasks/__tests__/phases.test.js
+++ b/plugins/work/scripts/workflows/work-tasks/__tests__/phases.test.js
@@ -111,7 +111,7 @@ test('traceability flags orphan requirement and unknown task ref', () => {
   fs.rmSync(root, { recursive: true, force: true });
 });
 
-test('kind_assign blocks wiring task that touches backend (ECHO-4579 defense)', () => {
+test('kind_assign rejects legacy domain kind (wiring) with a migration hint', () => {
   const { root, tasksDir } = mkTasksDir({
     'tasks.md': [
       '## Task 1',
@@ -135,17 +135,18 @@ test('kind_assign blocks wiring task that touches backend (ECHO-4579 defense)', 
   });
   const r = kindAssign.validate({ tasksDir });
   assert.equal(r.ok, false);
-  assert.ok(r.errors.some((e) => /ECHO-4579/.test(e)));
+  assert.ok(r.errors.some((e) => /must be one of: tdd-code/.test(e)));
+  assert.ok(r.errors.some((e) => /mechanical-refactor/.test(e)));
   fs.rmSync(root, { recursive: true, force: true });
 });
 
-test('kind_assign blocks backend task missing integration test in scope', () => {
+test('kind_assign blocks tdd-code task missing a test-authorship entry in scope', () => {
   const { root, tasksDir } = mkTasksDir({
     'tasks.md': [
       '## Task 1',
       '',
       '### Type',
-      'backend',
+      'tdd-code',
       '',
       '### Files in scope',
       '- `app/api/trpc/routers/foo.ts`',
@@ -154,7 +155,7 @@ test('kind_assign blocks backend task missing integration test in scope', () => 
   });
   const r = kindAssign.validate({ tasksDir });
   assert.equal(r.ok, false);
-  assert.ok(r.errors.some((e) => /integration\.test/.test(e)));
+  assert.ok(r.errors.some((e) => /RED gate is unsatisfiable/.test(e)));
   fs.rmSync(root, { recursive: true, force: true });
 });
 

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/__tests__/draft-test-strategy.integration.test.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/__tests__/draft-test-strategy.integration.test.js
@@ -299,3 +299,72 @@ test('parser-failure surfacing (cursor[bot] 3423427166): flag-on parseTasks fail
     else process.env.WORK_TEST_STRATEGY_VALIDATOR = prev;
   }
 });
+
+// --- #606 defense: missing verification block -------------------------------
+
+function tasksMdWithoutVerification(type) {
+  return [
+    '## Extracted Requirements',
+    '',
+    '- R1',
+    '',
+    `## Task 1 — ${type} task with no Test Strategy at all`,
+    '',
+    '### Type',
+    type,
+    '',
+    '### Dependencies',
+    'none',
+    '',
+    '### Requirements Covered',
+    '- R1',
+    '',
+    '### Acceptance Criteria',
+    '- content updated',
+    '',
+    '### Files in scope',
+    '- `README.md`',
+    '',
+  ].join('\n');
+}
+
+test('flag-on: docs task with neither Test Strategy nor Test Command is blocked (#606)', () => {
+  const dir = mkTasksDir();
+  writeSpec(dir);
+  writeTasks(dir, tasksMdWithoutVerification('docs'));
+
+  const errors = withFlag('1', () => draft.validateArtifacts(dir), dir);
+  const joined = errors.join('\n');
+  assert.ok(
+    /has neither `### Test Strategy` nor legacy `### Test Command`/.test(joined),
+    `expected missing-verification error; got: ${JSON.stringify(errors)}`
+  );
+  assert.ok(
+    /kind: custom/.test(joined),
+    `error should carry the docs-task remediation hint; got: ${JSON.stringify(errors)}`
+  );
+});
+
+test('flag-on: checkpoint task without a Test Strategy stays exempt', () => {
+  const dir = mkTasksDir();
+  writeSpec(dir);
+  writeTasks(dir, tasksMdWithoutVerification('checkpoint'));
+
+  const errors = withFlag('1', () => draft.validateArtifacts(dir), dir);
+  assert.ok(
+    !errors.some((e) => /has neither/.test(e)),
+    `checkpoint should not require a verification block; got: ${JSON.stringify(errors)}`
+  );
+});
+
+test('flag-off: missing verification block is not enforced (legacy path unchanged)', () => {
+  const dir = mkTasksDir();
+  writeSpec(dir);
+  writeTasks(dir, tasksMdWithoutVerification('docs'));
+
+  const errors = withFlag('0', () => draft.validateArtifacts(dir));
+  assert.ok(
+    !errors.some((e) => /has neither/.test(e)),
+    `flag-off must stay byte-for-byte legacy; got: ${JSON.stringify(errors)}`
+  );
+});

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/__tests__/gherkin-link-satisfiability.test.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/__tests__/gherkin-link-satisfiability.test.js
@@ -1,0 +1,168 @@
+/**
+ * gherkin_link — @task:N scenario satisfiability (#489 / #491 class).
+ *
+ * A task that owns @task:N-tagged scenarios but whose `### Files in scope`
+ * cannot match any test file is unimplementable at RED: the implement gate
+ * requires each tagged scenario to appear in a test file under the task's
+ * scope, while protect-task-scope blocks creating test files outside it.
+ *
+ * Run: node --test scripts/workflows/work-tasks/lib/phases/__tests__/gherkin-link-satisfiability.test.js
+ */
+
+'use strict';
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const gherkinLink = require('../gherkin_link');
+
+const dirs = [];
+function makeDir(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gherkin-link-test-'));
+  dirs.push(dir);
+  for (const [name, body] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), body);
+  }
+  return dir;
+}
+
+function taskBlock(num, type, scopeEntries, opts = {}) {
+  const lines = [
+    `## Task ${num} — fixture task ${num}`,
+    '',
+    '### Type',
+    type,
+    '',
+    '### Acceptance Criteria',
+    `- covers scenario for task ${num}`,
+    '',
+    '### Files in scope',
+    ...scopeEntries.map((e) => `- \`${e}\``),
+    '',
+  ];
+  if (opts.scenarios) {
+    lines.push('### Scenarios', ...opts.scenarios.map((s) => `- ${s}`), '');
+  }
+  return lines.join('\n');
+}
+
+// A scenario block that satisfies the canonical gherkin-task-refs validator:
+// steps present, @test tag present. The satisfiability check under test here
+// is orthogonal (scope shape), so keep the rest canonical-valid.
+function scenario(taskNum, title) {
+  return [
+    `@task:${taskNum} @test:src/__tests__/fixture.test.js`,
+    `Scenario: ${title}`,
+    '  Given a fixture',
+    '  When it runs',
+    '  Then it passes',
+  ];
+}
+
+function feature(...scenarioLines) {
+  return ['Feature: fixture', '', ...scenarioLines, ''].join('\n');
+}
+
+describe('gherkin_link — @task:N satisfiability', () => {
+  after(() => {
+    for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it('countTaggedScenarios maps task numbers to scenario counts', () => {
+    const counts = gherkinLink.countTaggedScenarios(
+      feature(
+        '@task:1 @integration',
+        'Scenario: first thing covers scenario for task 1',
+        '',
+        '@task:1',
+        'Scenario: second thing covers scenario for task 1',
+        '',
+        '@task:3',
+        'Scenario Outline: third covers scenario for task 3'
+      )
+    );
+    assert.equal(counts.get(1), 2);
+    assert.equal(counts.get(3), 1);
+    assert.equal(counts.has(2), false);
+  });
+
+  it('blocks a docs-only task that owns a @task:N scenario (#489 shape)', () => {
+    const dir = makeDir({
+      'gherkin.feature': feature('@task:1', 'Scenario: covers scenario for task 1'),
+      'tasks.md': taskBlock(1, 'docs', ['SKILL.md']),
+    });
+    const errors = gherkinLink.validateArtifacts(dir);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Task 1 owns 1 @task:1-tagged scenario/);
+    assert.match(errors[0], /RED gate would be unsatisfiable/);
+  });
+
+  it('blocks a source-literal-only scope with tagged scenarios (#491 shape)', () => {
+    const dir = makeDir({
+      'gherkin.feature': feature('@task:2', 'Scenario: covers scenario for task 2'),
+      'tasks.md': [
+        taskBlock(1, 'docs', ['README.md']),
+        taskBlock(2, 'tdd-code', ['src/parser.js']),
+      ].join('\n'),
+    });
+    const errors = gherkinLink.validateArtifacts(dir);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /Task 2/);
+  });
+
+  it('passes when the tagged task has a test-file literal in scope', () => {
+    const dir = makeDir({
+      'gherkin.feature': feature(...scenario(1, 'covers scenario for task 1')),
+      'tasks.md': taskBlock(1, 'tdd-code', ['src/parser.js', 'src/__tests__/parser.test.js'], {
+        scenarios: ['covers scenario for task 1'],
+      }),
+    });
+    assert.deepEqual(gherkinLink.validateArtifacts(dir), []);
+  });
+
+  it('passes when the tagged task scope has a wide glob that admits tests', () => {
+    const dir = makeDir({
+      'gherkin.feature': feature(...scenario(1, 'covers scenario for task 1')),
+      'tasks.md': taskBlock(1, 'tdd-code', ['src/**'], {
+        scenarios: ['covers scenario for task 1'],
+      }),
+    });
+    assert.deepEqual(gherkinLink.validateArtifacts(dir), []);
+  });
+
+  it('passes when a directory-prefix literal is in scope (fail-open)', () => {
+    const dir = makeDir({
+      'gherkin.feature': feature(...scenario(1, 'covers scenario for task 1')),
+      'tasks.md': taskBlock(1, 'tdd-code', ['src/utils'], {
+        scenarios: ['covers scenario for task 1'],
+      }),
+    });
+    assert.deepEqual(gherkinLink.validateArtifacts(dir), []);
+  });
+
+  it('ignores tasks with no tagged scenarios (satisfiability pass is silent)', () => {
+    const dir = makeDir({
+      'gherkin.feature': feature(
+        '@integration @test:src/__tests__/fixture.test.js',
+        'Scenario: covers scenario for task 1',
+        '  Given a fixture',
+        '  When it runs',
+        '  Then it passes'
+      ),
+      'tasks.md': taskBlock(1, 'docs', ['README.md']),
+    });
+    const errors = gherkinLink.validateArtifacts(dir);
+    assert.ok(
+      !errors.some((e) => /unsatisfiable/.test(e)),
+      `no satisfiability error expected; got: ${errors.join(' | ')}`
+    );
+  });
+
+  it('still auto-passes when gherkin.feature is absent', () => {
+    const dir = makeDir({ 'tasks.md': taskBlock(1, 'docs', ['README.md']) });
+    assert.deepEqual(gherkinLink.validateArtifacts(dir), []);
+  });
+});

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/__tests__/kind-assign-closed-taxonomy.test.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/__tests__/kind-assign-closed-taxonomy.test.js
@@ -1,0 +1,157 @@
+/**
+ * kind_assign phase — closed Type taxonomy (GH-498 / #489 / #606 class).
+ *
+ * kind_assign used to validate `### Type` against the legacy domain kinds
+ * (frontend/backend/wiring/e2e/devops/fullstack) while the planner docs and
+ * the implement gate (`gateContractFor`) use the closed gate-contract enum
+ * from skills/split-in-tasks/lib/task-types.js. The mismatch either failed
+ * correctly-authored tasks.md at the tasks phase or let legacy kinds through
+ * to wedge at implement under the strictest fail-closed contract.
+ *
+ * Run: node --test scripts/workflows/work-tasks/lib/phases/__tests__/kind-assign-closed-taxonomy.test.js
+ */
+
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const kindAssign = require('../kind_assign');
+const { TASK_TYPES } = require('../../../../../../skills/split-in-tasks/lib/task-types');
+
+function makeTasksDir(tasksMd) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kind-assign-test-'));
+  fs.writeFileSync(path.join(dir, 'tasks.md'), tasksMd);
+  return dir;
+}
+
+function taskBlock(num, type, scopeEntries) {
+  return [
+    `## Task ${num} — fixture task ${num}`,
+    '',
+    '### Type',
+    type,
+    '',
+    '### Files in scope',
+    ...scopeEntries.map((e) => `- \`${e}\``),
+    '',
+  ].join('\n');
+}
+
+describe('kind_assign — closed Type taxonomy', () => {
+  const dirs = [];
+  after(() => {
+    for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  function validate(tasksMd) {
+    const dir = makeTasksDir(tasksMd);
+    dirs.push(dir);
+    return kindAssign.validateArtifacts(dir);
+  }
+
+  it('VALID_KINDS mirrors the canonical task-types enum', () => {
+    assert.deepEqual([...kindAssign.VALID_KINDS].sort(), [...TASK_TYPES].sort());
+  });
+
+  it('accepts a well-formed tdd-code task (test + source in scope)', () => {
+    const errors = validate(taskBlock(1, 'tdd-code', ['src/a.js', 'src/__tests__/a.test.js']));
+    assert.deepEqual(errors, []);
+  });
+
+  it('accepts a docs task with .md-only scope', () => {
+    const errors = validate(taskBlock(1, 'docs', ['README.md', 'docs/guide.md']));
+    assert.deepEqual(errors, []);
+  });
+
+  it('accepts a tests-only task with test-only scope', () => {
+    const errors = validate(taskBlock(1, 'tests-only', ['src/__tests__/a.test.js']));
+    assert.deepEqual(errors, []);
+  });
+
+  it('accepts checkpoint / mechanical-refactor / file-move without scope constraints', () => {
+    for (const type of ['checkpoint', 'mechanical-refactor', 'file-move']) {
+      const errors = validate(taskBlock(1, type, ['src/anything.js']));
+      assert.deepEqual(errors, [], `Type "${type}" should pass; got: ${errors.join(' | ')}`);
+    }
+  });
+
+  it('rejects legacy domain kinds with a migration hint', () => {
+    for (const [legacy, hintRe] of [
+      ['backend', /tdd-code/],
+      ['frontend', /tdd-code/],
+      ['devops', /`ci` \(CI configs\)/],
+      ['wiring', /mechanical-refactor/],
+      ['e2e', /tests-only/],
+      ['fullstack', /tdd-code/],
+    ]) {
+      const errors = validate(taskBlock(1, legacy, ['src/a.js']));
+      assert.equal(errors.length, 1, `legacy "${legacy}" should produce exactly one error`);
+      assert.match(errors[0], /must be one of: tdd-code/);
+      assert.match(errors[0], hintRe);
+    }
+  });
+
+  it('rejects a freeform Type without a legacy hint', () => {
+    const errors = validate(taskBlock(1, 'feature', ['src/a.js']));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /"feature"/);
+    assert.doesNotMatch(errors[0], /Legacy kind/);
+  });
+
+  it('rejects a docs task whose scope includes a non-.md file', () => {
+    const errors = validate(taskBlock(1, 'docs', ['README.md', 'src/a.js']));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /outside the docs allowlist/);
+    assert.match(errors[0], /`src\/a\.js`/);
+  });
+
+  it('rejects a tdd-code task with no test-authorship surface (#491/#489 class)', () => {
+    const errors = validate(taskBlock(1, 'tdd-code', ['src/a.js']));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /RED gate is unsatisfiable/);
+  });
+
+  it('rejects a tdd-code task with tests but no source entry', () => {
+    const errors = validate(taskBlock(1, 'tdd-code', ['src/__tests__/a.test.js']));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /non-test source entry/);
+  });
+
+  it('accepts a tdd-code task whose test surface is a glob', () => {
+    const errors = validate(taskBlock(1, 'tdd-code', ['src/a.js', 'src/**/*.test.js']));
+    assert.deepEqual(errors, []);
+  });
+
+  it('rejects a tests-only task whose scope includes a source file', () => {
+    const errors = validate(taskBlock(1, 'tests-only', ['src/__tests__/a.test.js', 'src/a.js']));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /outside the tests-only allowlist/);
+  });
+
+  it('rejects a ci task whose scope leaves the CI allowlist', () => {
+    const errors = validate(taskBlock(1, 'ci', ['Jenkinsfile', 'src/a.js']));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /outside the ci allowlist/);
+  });
+
+  it('aggregates errors across multiple tasks', () => {
+    const md = [
+      taskBlock(1, 'devops', ['scripts/deploy.yml']),
+      taskBlock(2, 'docs', ['README.md', 'src/a.js']),
+    ].join('\n');
+    const errors = validate(md);
+    assert.equal(errors.length, 2);
+    assert.match(errors[0], /Task 1/);
+    assert.match(errors[1], /Task 2/);
+  });
+
+  it('instructions mention the closed enum, not the legacy kinds', () => {
+    const text = kindAssign.instructions({ ticket: 'GH-1' });
+    assert.match(text, /tdd-code/);
+    assert.doesNotMatch(text, /\bfullstack\b/);
+  });
+});

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/__tests__/kind-assign-closed-taxonomy.test.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/__tests__/kind-assign-closed-taxonomy.test.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const { describe, it, before, after } = require('node:test');
+const { describe, it, after } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const os = require('os');

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/_legacy-test-command.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/_legacy-test-command.js
@@ -14,4 +14,30 @@ function hasLegacyTestCommand(task) {
   );
 }
 
-module.exports = { hasLegacyTestCommand };
+function isCheckpointTask(task) {
+  if (!task) return false;
+  if (task.isCheckpoint === true) return true;
+  return typeof task.type === 'string' && task.type.trim().toLowerCase() === 'checkpoint';
+}
+
+/**
+ * Error message for a task with NO resolvable Test Strategy, or null when the
+ * task is fine. Two shapes:
+ *  - legacy `### Test Command` present → migration error;
+ *  - neither block present on a non-checkpoint task → missing-verification
+ *    error (#606 defense: with no declared verification the implement gate
+ *    falls back to `node --test $CHANGED_FILES`; for prose/config scopes the
+ *    test-file filter empties CHANGED_FILES, `node --test` exits with
+ *    MODULE_NOT_FOUND, the RED recorder rejects it as structurally broken,
+ *    and the task loops at RED forever — catch it at authoring time, where
+ *    tasks.md is still editable).
+ */
+function noStrategyError(task, heading) {
+  if (hasLegacyTestCommand(task)) {
+    return `${heading}: flag on but task still uses legacy \`### Test Command\`. Convert to \`### Test Strategy\` (kind: unit|integration|e2e|custom|verified-by|wiring-citation). See skills/split-in-tasks/docs/test-strategy.md.`;
+  }
+  if (isCheckpointTask(task)) return null;
+  return `${heading}: has neither \`### Test Strategy\` nor legacy \`### Test Command\`. Every non-checkpoint task must declare its verification (kind: unit|integration|e2e|custom|verified-by|wiring-citation). For docs/config tasks use \`kind: custom\` with a command that FAILS before the change lands and PASSES after (e.g. a grep asserting the new content). See skills/split-in-tasks/docs/test-strategy.md.`;
+}
+
+module.exports = { hasLegacyTestCommand, isCheckpointTask, noStrategyError };

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/draft-test-strategy.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/draft-test-strategy.js
@@ -195,16 +195,13 @@ function _dispatchAndAppend(command, dispatchCtx, heading, errors) {
   }
 }
 
-const { hasLegacyTestCommand: _hasLegacyTestCommand } = require('./_legacy-test-command');
+const { noStrategyError: _noStrategyError } = require('./_legacy-test-command');
 
 function _validateOneTask(task, ctx, errors) {
   const strategy = _resolveStrategy(task);
   if (!strategy) {
-    if (_hasLegacyTestCommand(task)) {
-      errors.push(
-        `${taskHeadingFor(task)}: flag on but task still uses legacy \`### Test Command\`. Convert to \`### Test Strategy\` (kind: unit|integration|e2e|custom|verified-by|wiring-citation). See skills/split-in-tasks/docs/test-strategy.md.`
-      );
-    }
+    const msg = _noStrategyError(task, taskHeadingFor(task));
+    if (msg) errors.push(msg);
     return;
   }
   const heading = taskHeadingFor(task);

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/gherkin_link.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/gherkin_link.js
@@ -92,46 +92,32 @@ function validateScenarioSatisfiability(gherkin, tasksText) {
   return errors;
 }
 
-function validateArtifacts(tasksDir) {
-  const errors = [];
-  const gherkin = readFile(path.join(tasksDir, 'gherkin.feature'));
-  if (!gherkin) {
-    // No gherkin.feature → nothing to link → auto-pass.
-    return errors;
-  }
-  const tasks = readFile(path.join(tasksDir, 'tasks.md'));
-  if (!tasks) {
-    errors.push(`Missing tasks.md.`);
-    return errors;
-  }
-  errors.push(...validateScenarioSatisfiability(gherkin, tasks));
-  if (errors.length) return errors;
-  // Use the canonical validator if available.
-  if (typeof validateConsistency === 'function') {
-    try {
-      const result = validateConsistency({ gherkinText: gherkin, tasksMdText: tasks });
-      if (result && Array.isArray(result.errors) && result.errors.length) {
-        for (const e of result.errors) errors.push(`gherkin-task-refs: ${e}`);
-        return errors;
-      }
-      // Canonical validator passed — trust it and skip the naive fallback,
-      // which can produce false positives by tasks.includes(title) on titles
-      // referenced via Acceptance Criteria or Requirements Covered.
-      if (result && result.valid === true) {
-        return errors;
-      }
-    } catch (e) {
-      // Validator threw — fall through to our own check below.
-      errors.push(`gherkin-task-refs threw: ${e.message}`);
+/**
+ * Run the canonical gherkin-task-refs validator. Returns
+ * `{ done: boolean, errors: string[] }` — `done: true` means the canonical
+ * verdict is final (pass or fail) and the naive fallback must be skipped
+ * (it can produce false positives via tasks.includes(title) on titles
+ * referenced through Acceptance Criteria or Requirements Covered).
+ */
+function runCanonicalConsistency(gherkin, tasks) {
+  if (typeof validateConsistency !== 'function') return { done: false, errors: [] };
+  try {
+    const result = validateConsistency({ gherkinText: gherkin, tasksMdText: tasks });
+    if (result && Array.isArray(result.errors) && result.errors.length) {
+      return { done: true, errors: result.errors.map((e) => `gherkin-task-refs: ${e}`) };
     }
+    if (result && result.valid === true) return { done: true, errors: [] };
+    return { done: false, errors: [] };
+  } catch (e) {
+    // Validator threw — surface it and fall through to the naive check.
+    return { done: false, errors: [`gherkin-task-refs threw: ${e.message}`] };
   }
-  // Fallback: best-effort coverage check.
-  const scenarios = extractScenarioTitles(gherkin);
-  if (!scenarios.length) {
-    return errors;
-  }
-  for (const title of scenarios) {
-    // Look for the scenario title literal in tasks.md.
+}
+
+/** Naive fallback: every scenario title must appear somewhere in tasks.md. */
+function naiveScenarioCoverage(gherkin, tasks) {
+  const errors = [];
+  for (const title of extractScenarioTitles(gherkin)) {
     if (!tasks.includes(title)) {
       errors.push(
         `Scenario "${title}" from gherkin.feature is not referenced by any task in tasks.md. Add the scenario title to the relevant task's \`### Acceptance Criteria\` or \`### Requirements Covered\`.`
@@ -139,6 +125,19 @@ function validateArtifacts(tasksDir) {
     }
   }
   return errors;
+}
+
+function validateArtifacts(tasksDir) {
+  const gherkin = readFile(path.join(tasksDir, 'gherkin.feature'));
+  // No gherkin.feature → nothing to link → auto-pass.
+  if (!gherkin) return [];
+  const tasks = readFile(path.join(tasksDir, 'tasks.md'));
+  if (!tasks) return ['Missing tasks.md.'];
+  const satisfiability = validateScenarioSatisfiability(gherkin, tasks);
+  if (satisfiability.length) return satisfiability;
+  const canonical = runCanonicalConsistency(gherkin, tasks);
+  if (canonical.done) return canonical.errors;
+  return [...canonical.errors, ...naiveScenarioCoverage(gherkin, tasks)];
 }
 
 function validate(ctx) {

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/gherkin_link.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/gherkin_link.js
@@ -1,6 +1,8 @@
 /**
  * Phase: gherkin_link — if gherkin.feature exists, every scenario must be
- * referenced by ≥1 task. Reuses work-orchestrator/lib/gherkin-task-refs when available.
+ * referenced by ≥1 task, AND every task carrying `@task:N` scenarios must
+ * have a scope under which the implement-time RED gate can find/author test
+ * files. Reuses work-orchestrator/lib/gherkin-task-refs when available.
  */
 
 'use strict';
@@ -9,6 +11,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { TASKS_PHASES } = require('../../tasks-phase-registry');
+const { parseBlocks } = require('./kind_assign');
+const {
+  scopeEntryCanMatchTestFiles,
+} = require('../../../../../skills/split-in-tasks/lib/task-types');
 
 let validateConsistency;
 try {
@@ -34,6 +40,58 @@ function extractScenarioTitles(text) {
   return out;
 }
 
+/**
+ * Count `@task:N`-tagged scenarios per task number. Tag semantics mirror the
+ * implement-side parser (task-next.js parseGherkinScenarios): tag lines
+ * accumulate until the next `Scenario:` / `Scenario Outline:` line consumes
+ * them.
+ */
+function countTaggedScenarios(gherkin) {
+  const counts = new Map();
+  let pendingTags = [];
+  for (const raw of gherkin.split('\n')) {
+    const t = raw.trim();
+    if (t.startsWith('@')) {
+      pendingTags = pendingTags.concat(t.split(/\s+/));
+      continue;
+    }
+    if (/^(Scenario|Scenario Outline):/.test(t)) {
+      for (const tag of pendingTags) {
+        const m = tag.match(/^@task:(\d+)$/);
+        if (m) {
+          const n = Number(m[1]);
+          counts.set(n, (counts.get(n) || 0) + 1);
+        }
+      }
+      pendingTags = [];
+    }
+  }
+  return counts;
+}
+
+/**
+ * #489 / #491 defense: a task that owns `@task:N` scenarios but whose
+ * `### Files in scope` cannot match any test file is unimplementable — at
+ * RED, `scenariosCoveredByTests` demands each tagged scenario appear in a
+ * test file under the task's scope, while `protect-task-scope` blocks
+ * creating test files outside it. Catch the contradiction here, where
+ * tasks.md and gherkin.feature are still editable.
+ */
+function validateScenarioSatisfiability(gherkin, tasksText) {
+  const errors = [];
+  const counts = countTaggedScenarios(gherkin);
+  if (!counts.size) return errors;
+  for (const block of parseBlocks(tasksText)) {
+    const n = counts.get(block.num);
+    if (!n) continue;
+    if (block.filesInScope.some(scopeEntryCanMatchTestFiles)) continue;
+    errors.push(
+      `Task ${block.num} owns ${n} @task:${block.num}-tagged scenario(s) in gherkin.feature but its \`### Files in scope\` admits no test files — the RED gate would be unsatisfiable at implement. Either add a \`*.test.*\` entry (or a directory/glob that admits one) to the task's scope, move the @task:${block.num} tag to the task that owns the tests, or drop the tag and verify via the task's \`### Test Strategy\` command.`
+    );
+  }
+  return errors;
+}
+
 function validateArtifacts(tasksDir) {
   const errors = [];
   const gherkin = readFile(path.join(tasksDir, 'gherkin.feature'));
@@ -46,6 +104,8 @@ function validateArtifacts(tasksDir) {
     errors.push(`Missing tasks.md.`);
     return errors;
   }
+  errors.push(...validateScenarioSatisfiability(gherkin, tasks));
+  if (errors.length) return errors;
   // Use the canonical validator if available.
   if (typeof validateConsistency === 'function') {
     try {
@@ -99,6 +159,7 @@ function instructions(ctx) {
     '### What I check',
     '- If `gherkin.feature` exists: every `Scenario:` (and `Scenario Outline:`) is referenced by ≥1 task.',
     '- Reference can be in the task title, `### Acceptance Criteria`, or `### Requirements Covered`.',
+    '- Every task with `@task:N`-tagged scenarios has a `### Files in scope` that admits test files (RED-gate satisfiability).',
     '',
     'If no `gherkin.feature` exists, this phase auto-passes.',
     '',
@@ -119,3 +180,5 @@ module.exports.validate = validate;
 module.exports.instructions = instructions;
 module.exports.validateArtifacts = validateArtifacts;
 module.exports.extractScenarioTitles = extractScenarioTitles;
+module.exports.countTaggedScenarios = countTaggedScenarios;
+module.exports.validateScenarioSatisfiability = validateScenarioSatisfiability;

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/gherkin_link.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/gherkin_link.js
@@ -42,9 +42,13 @@ function extractScenarioTitles(text) {
 
 /**
  * Count `@task:N`-tagged scenarios per task number. Tag semantics mirror the
- * implement-side parser (task-next.js parseGherkinScenarios): tag lines
- * accumulate until the next `Scenario:` / `Scenario Outline:` line consumes
- * them.
+ * implement-side parser (task-next.js parseGherkinScenarios) EXACTLY: tag
+ * lines accumulate until the next `Scenario:` / `Scenario Outline:` line
+ * consumes them, and intervening non-tag lines (blank lines, comments,
+ * `Feature:` headers) do NOT reset the pending set. Deliberately NOT
+ * "improved" here — this validator must predict what the implement gate
+ * will see, so any divergence from task-next.js reintroduces the very
+ * gate-vs-generator drift this phase exists to prevent.
  */
 function countTaggedScenarios(gherkin) {
   const counts = new Map();
@@ -133,6 +137,11 @@ function validateArtifacts(tasksDir) {
   if (!gherkin) return [];
   const tasks = readFile(path.join(tasksDir, 'tasks.md'));
   if (!tasks) return ['Missing tasks.md.'];
+  // Satisfiability failures short-circuit the consistency checks on purpose:
+  // the remediation (moving/dropping @task tags, re-scoping) changes which
+  // task owns which scenario, which invalidates any canonical-consistency
+  // verdict computed against the pre-fix tag layout. Reporting both at once
+  // would surface errors that evaporate after the satisfiability fix.
   const satisfiability = validateScenarioSatisfiability(gherkin, tasks);
   if (satisfiability.length) return satisfiability;
   const canonical = runCanonicalConsistency(gherkin, tasks);

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/kind_assign.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/kind_assign.js
@@ -1,16 +1,24 @@
 /**
  * Phase: kind_assign — every task has a recognized `### Type` value AND
- * per-kind sanity checks pass.
+ * per-Type structural scope checks pass.
  *
- * - backend: at least one `*.integration.test.*` file in scope.
- * - frontend: at least one component / page / hook file in scope.
- * - e2e: at least one tests/e2e Playwright spec file in scope.
- * - wiring: NO file in `Files in scope` matches the backend pattern when
- *   `Files explicitly out of scope` mentions a backend file (the ECHO-4579
- *   defense at task granularity).
- * - devops: only infra/config files (`.github/`, `scripts/`, `*.yml`,
- *   Dockerfile) in scope.
- * - checkpoint: no per-kind sanity (just a synchronization marker).
+ * The `### Type` enum is the closed gate-contract taxonomy defined in
+ * skills/split-in-tasks/lib/task-types.js (tdd-code | tests-only | docs |
+ * config | ci | mechanical-refactor | file-move | checkpoint). It is the
+ * SAME enum the implement gate reads via `gateContractFor()` — validating a
+ * different vocabulary here is exactly the drift that wedged docs/devops
+ * tasks at RED (GH-498 / issues #489, #606): kind_assign used to demand the
+ * legacy domain kinds (frontend/backend/wiring/e2e/devops/fullstack) which
+ * `gateContractFor()` does not know, so every non-checkpoint task fell back
+ * to the strictest fail-closed tdd-code contract at implement.
+ *
+ * Structural checks derive from TYPE_SCOPE_RULES (same source Pass D and
+ * protect-task-scope.js use):
+ *   - scopePatterns  — every `### Files in scope` entry must match the
+ *     Type's allowlist (docs → *.md, config/ci → their allowlists).
+ *   - mustHaveTest   — tdd-code / tests-only need a test-authorship entry,
+ *     otherwise the RED gate is unsatisfiable at implement.
+ *   - mustHaveSource — tdd-code needs at least one non-test source entry.
  */
 
 'use strict';
@@ -18,16 +26,31 @@
 const { TASKS_PHASES } = require('../../tasks-phase-registry');
 const { iterTaskBlocks } = require('./_task-block-iter');
 const { loadTasksMd, readFileSafe, tasksMdPath } = require('./_tasks-md-loader');
+const {
+  TASK_TYPES,
+  isKnownTaskType,
+  scopeRulesFor,
+  matchesTypeScope,
+  scopeEntryAdmitsOnlyTestFiles,
+} = require('../../../../../skills/split-in-tasks/lib/task-types');
 
-const VALID_KINDS = new Set([
-  'frontend',
-  'backend',
-  'wiring',
-  'e2e',
-  'devops',
-  'fullstack',
-  'checkpoint',
-]);
+// Derived from the canonical closed enum — kept exported under the historical
+// name because work-state/task-readiness.js allowlists persisted task kinds
+// against this set.
+const VALID_KINDS = new Set(TASK_TYPES);
+
+// Migration hints for the legacy domain-kind vocabulary this phase used to
+// accept. Emitted alongside the unknown-Type error so the planner converges
+// in one pass instead of guessing.
+const LEGACY_KIND_HINTS = Object.freeze({
+  frontend: '`tdd-code`',
+  backend: '`tdd-code`',
+  fullstack: '`tdd-code`',
+  wiring: '`tdd-code` (or `mechanical-refactor` for pure re-wiring with no behavior change)',
+  e2e: '`tdd-code` (or `tests-only` when the task only adds e2e specs)',
+  devops:
+    '`ci` (CI configs), `config` (inert configuration), or `tdd-code` (scripts that ship behavior)',
+});
 
 function parseBlocks(text) {
   const out = [];
@@ -58,114 +81,44 @@ function extractScopeList(match) {
   return [...out];
 }
 
-function isBackendFile(p) {
-  return (
-    /(^|\/)app\/api\//.test(p) ||
-    /(^|\/)lib\/.*\/schemas?\.(ts|js)$/.test(p) ||
-    /(^|\/)prisma\//.test(p) ||
-    /(^|\/)server\//.test(p)
-  );
-}
-function isFrontendFile(p) {
-  return (
-    /(^|\/)components\//.test(p) ||
-    /(^|\/)app\/.*\.(tsx|jsx)$/.test(p) ||
-    /(^|\/)hooks\//.test(p) ||
-    /(^|\/)pages\//.test(p)
-  );
-}
-function isE2eFile(p) {
-  return /(^|\/)tests\/e2e\//.test(p) || /\.spec\.(ts|tsx|js|jsx)$/.test(p);
-}
-function isIntegrationTest(p) {
-  return /\.integration\.test\.(ts|tsx|js|jsx)$/.test(p);
-}
-function isDevopsFile(p) {
-  return (
-    /^\.github\//.test(p) ||
-    /(^|\/)scripts\//.test(p) ||
-    /\.(yml|yaml)$/.test(p) ||
-    /(^|\/)Dockerfile/.test(p)
-  );
-}
-function isAppSourceFile(p) {
-  return /(^|\/)app\//.test(p) || /(^|\/)lib\//.test(p) || /(^|\/)components\//.test(p);
+function _unknownTypeError(b) {
+  const base = `Task ${b.num} \`### Type\` is "${b.type}" — must be one of: ${TASK_TYPES.join(', ')}.`;
+  const hint = LEGACY_KIND_HINTS[b.type];
+  if (!hint) return base;
+  return `${base} Legacy kind "${b.type}" maps to ${hint}. The \`### Type\` field drives the implement-time gate contract (gateContractFor in task-types.js); unknown values fall back to the strictest tdd-code contract and wedge non-code tasks at RED.`;
 }
 
-// Per-kind validators — each returns an array of error strings for the block.
-// Keeping these as small named functions lets `validateBlock` stay a flat
-// dispatch (cc = 3) instead of a giant if/else ladder.
-
-function _validateBackend(b) {
-  if (b.filesInScope.some(isIntegrationTest)) return [];
+function _scopePatternErrors(b, rules) {
+  if (!rules.scopePatterns) return [];
+  const offenders = b.filesInScope.filter((p) => !matchesTypeScope(b.type, p));
+  if (!offenders.length) return [];
   return [
-    `Task ${b.num} kind=backend but no \`*.integration.test.*\` file in \`### Files in scope\`. Backend tasks must ship with integration test coverage.`,
-  ];
-}
-
-function _validateFrontend(b) {
-  if (b.filesInScope.some(isFrontendFile)) return [];
-  return [`Task ${b.num} kind=frontend but no component/page/hook file in \`### Files in scope\`.`];
-}
-
-function _validateE2e(b) {
-  if (b.filesInScope.some(isE2eFile)) return [];
-  return [
-    `Task ${b.num} kind=e2e but no \`tests/e2e/**/*.spec.*\` file in \`### Files in scope\`.`,
-  ];
-}
-
-function _validateWiring(b) {
-  const backendDrift = b.filesInScope.filter(isBackendFile);
-  if (!backendDrift.length) return [];
-  return [
-    `Task ${b.num} kind=wiring but \`### Files in scope\` includes backend files (${backendDrift
+    `Task ${b.num} Type=${b.type} but \`### Files in scope\` includes entries outside the ${b.type} allowlist (${offenders
       .map((f) => `\`${f}\``)
-      .join(
-        ', '
-      )}). Wiring tasks must not touch backend — escalate to a sibling owner instead. (ECHO-4579 defense at task granularity.)`,
+      .join(', ')}). Move them to a task whose Type covers them, or change this task's Type.`,
   ];
 }
 
-function _validateDevops(b) {
+function _testSurfaceErrors(b, rules) {
   const errors = [];
-  const appDrift = b.filesInScope.filter(isAppSourceFile);
-  if (appDrift.length) {
+  if (rules.mustHaveTest && !b.filesInScope.some(scopeEntryAdmitsOnlyTestFiles)) {
     errors.push(
-      `Task ${b.num} kind=devops but \`### Files in scope\` includes app-source files (${appDrift
-        .map((f) => `\`${f}\``)
-        .join(', ')}). Split into a separate task with a different kind.`
+      `Task ${b.num} Type=${b.type} requires at least one \`*.test.*\` / \`*.spec.*\` entry in \`### Files in scope\` — without a test-authorship surface the RED gate is unsatisfiable at implement.`
     );
   }
-  if (!b.filesInScope.some(isDevopsFile)) {
+  if (rules.mustHaveSource && !b.filesInScope.some((p) => !scopeEntryAdmitsOnlyTestFiles(p))) {
     errors.push(
-      `Task ${b.num} kind=devops but no infra file (\`.github/\`, \`scripts/\`, \`*.yml\`, \`Dockerfile\`) in scope.`
+      `Task ${b.num} Type=${b.type} requires at least one non-test source entry in \`### Files in scope\`.`
     );
   }
   return errors;
 }
 
-// Dispatch table keyed on `### Type`. checkpoint + fullstack have no extra
-// per-kind sanity (fullstack intentionally accepts any mix); both map to a
-// no-op validator.
-const _KIND_VALIDATORS = {
-  backend: _validateBackend,
-  frontend: _validateFrontend,
-  e2e: _validateE2e,
-  wiring: _validateWiring,
-  devops: _validateDevops,
-  fullstack: () => [],
-  checkpoint: () => [],
-};
-
 function validateBlock(b) {
-  if (!VALID_KINDS.has(b.type)) {
-    return [
-      `Task ${b.num} \`### Type\` is "${b.type}" — must be one of: ${[...VALID_KINDS].join(', ')}.`,
-    ];
-  }
-  const validator = _KIND_VALIDATORS[b.type];
-  return validator ? validator(b) : [];
+  if (!isKnownTaskType(b.type)) return [_unknownTypeError(b)];
+  const rules = scopeRulesFor(b.type);
+  if (!rules) return [];
+  return [..._scopePatternErrors(b, rules), ..._testSurfaceErrors(b, rules)];
 }
 
 function validateArtifacts(tasksDir) {
@@ -197,12 +150,12 @@ function instructions(ctx) {
     `Ticket: ${ctx.ticket}`,
     '',
     '### What I check',
-    `- Every task's \`### Type\` is one of: ${[...VALID_KINDS].join(', ')}.`,
-    '- backend tasks have a `*.integration.test.*` in scope.',
-    '- frontend tasks have a component / page / hook file in scope.',
-    '- e2e tasks have a `tests/e2e/**/*.spec.*` file in scope.',
-    '- wiring tasks have NO backend file in scope (ECHO-4579 defense).',
-    '- devops tasks touch only infra/config; no app/lib/components.',
+    `- Every task's \`### Type\` is one of the closed gate-contract enum: ${TASK_TYPES.join(', ')} (see skills/split-in-tasks/docs/output-format.md).`,
+    '- tdd-code tasks have a `*.test.*` / `*.spec.*` entry AND a non-test source entry in scope.',
+    '- tests-only tasks list ONLY test files in scope.',
+    '- docs tasks list ONLY `*.md` files in scope.',
+    '- config / ci tasks stay inside their file allowlists (task-types.js TYPE_SCOPE_RULES).',
+    '- checkpoint / mechanical-refactor / file-move have no scope-pattern constraint.',
     '',
     'Re-invoke me to verify.',
     '',

--- a/plugins/work/scripts/workflows/work-tasks/lib/phases/requirements_extract.js
+++ b/plugins/work/scripts/workflows/work-tasks/lib/phases/requirements_extract.js
@@ -12,16 +12,10 @@ const path = require('node:path');
 const { TASKS_PHASES } = require('../../tasks-phase-registry');
 const { loadTasksMd, readFileSafe, tasksMdPath } = require('./_tasks-md-loader');
 const { sliceSection } = require('../../../work-spec/lib/kind-checks/shared');
-
-function listRequirementIds(text) {
-  if (!text) return [];
-  // Match "R1", "R10", "R-3", "spec §2.1", "brief AC-3", "AC1"
-  const out = new Set();
-  const re = /\b(R-?\d+|AC-?\d+|spec\s*§[\d.]+|brief\s+AC-\d+)\b/gi;
-  let m;
-  while ((m = re.exec(text)) !== null) out.add(m[0]);
-  return [...out];
-}
+// Canonical grammar shared with the completion-checker coverage fallback —
+// keeping both sides on one module prevents the #498 drift (generator
+// accepts a format the checker rejects).
+const { listRequirementIds } = require('../../../lib/requirement-ids');
 
 function validateArtifacts(tasksDir) {
   const { text, errors } = loadTasksMd(

--- a/plugins/work/scripts/workflows/work/__tests__/task-readiness.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/task-readiness.test.js
@@ -34,14 +34,16 @@ function freshTicket(prefix) {
 describe('initTasksMeta — kind persistence (GH-410)', () => {
   it('persists `kind` from descriptor `type` verbatim for every taxonomy kind', () => {
     const ticket = freshTicket('GH-410-KIND-ALL');
+    // Descriptor types come from the closed gate-contract taxonomy
+    // (task-types.js) — the same enum kind_assign validates.
     const descriptors = [
-      { num: 1, type: 'frontend' },
+      { num: 1, type: 'tdd-code' },
       { num: 2, type: 'checkpoint' },
-      { num: 3, type: 'backend' },
-      { num: 4, type: 'e2e' },
-      { num: 5, type: 'devops' },
-      { num: 6, type: 'wiring' },
-      { num: 7, type: 'fullstack' },
+      { num: 3, type: 'tests-only' },
+      { num: 4, type: 'docs' },
+      { num: 5, type: 'config' },
+      { num: 6, type: 'ci' },
+      { num: 7, type: 'mechanical-refactor' },
     ];
 
     const result = initTasksMeta(ticket, descriptors);
@@ -51,13 +53,13 @@ describe('initTasksMeta — kind persistence (GH-410)', () => {
     assert.equal(tasks.length, 7);
 
     // Each entry's kind should equal the descriptor type verbatim.
-    assert.equal(tasks[0].kind, 'frontend');
+    assert.equal(tasks[0].kind, 'tdd-code');
     assert.equal(tasks[1].kind, 'checkpoint');
-    assert.equal(tasks[2].kind, 'backend');
-    assert.equal(tasks[3].kind, 'e2e');
-    assert.equal(tasks[4].kind, 'devops');
-    assert.equal(tasks[5].kind, 'wiring');
-    assert.equal(tasks[6].kind, 'fullstack');
+    assert.equal(tasks[2].kind, 'tests-only');
+    assert.equal(tasks[3].kind, 'docs');
+    assert.equal(tasks[4].kind, 'config');
+    assert.equal(tasks[5].kind, 'ci');
+    assert.equal(tasks[6].kind, 'mechanical-refactor');
 
     // Existing fields preserved.
     assert.equal(tasks[1].id, 'task_2');
@@ -67,10 +69,7 @@ describe('initTasksMeta — kind persistence (GH-410)', () => {
 
   it('omits `kind` when descriptor lacks `type` (legacy descriptor array)', () => {
     const ticket = freshTicket('GH-410-KIND-NONE');
-    const descriptors = [
-      { num: 1 },
-      { num: 2 },
-    ];
+    const descriptors = [{ num: 1 }, { num: 2 }];
 
     const result = initTasksMeta(ticket, descriptors);
     assert.ok(result.success);
@@ -80,12 +79,12 @@ describe('initTasksMeta — kind persistence (GH-410)', () => {
     assert.equal(
       Object.prototype.hasOwnProperty.call(tasks[0], 'kind'),
       false,
-      'tasks[0] must NOT carry a `kind` field when descriptor has no `type`',
+      'tasks[0] must NOT carry a `kind` field when descriptor has no `type`'
     );
     assert.equal(
       Object.prototype.hasOwnProperty.call(tasks[1], 'kind'),
       false,
-      'tasks[1] must NOT carry a `kind` field when descriptor has no `type`',
+      'tasks[1] must NOT carry a `kind` field when descriptor has no `type`'
     );
     assert.equal(tasks[0].kind, undefined);
     assert.equal(tasks[1].kind, undefined);
@@ -102,7 +101,7 @@ describe('initTasksMeta — kind persistence (GH-410)', () => {
       assert.equal(
         Object.prototype.hasOwnProperty.call(t, 'kind'),
         false,
-        `legacy count-only entry ${t.id} must NOT carry a kind field`,
+        `legacy count-only entry ${t.id} must NOT carry a kind field`
       );
     }
   });
@@ -132,7 +131,10 @@ describe('initTasksMeta — kind persistence (GH-410)', () => {
     const result = initTasksMeta(ticket, descriptors);
     assert.ok(result.success);
     assert.equal(result.tasksMeta.tasks[0].title, 'End-to-end verification');
-    assert.equal(result.tasksMeta.tasks[1].title, undefined,
-      'descriptor without title must NOT carry a title field');
+    assert.equal(
+      result.tasksMeta.tasks[1].title,
+      undefined,
+      'descriptor without title must NOT carry a title field'
+    );
   });
 });

--- a/plugins/work/scripts/workflows/work/__tests__/tdd-enforcement.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/tdd-enforcement.test.js
@@ -168,7 +168,7 @@ function writeTaskArtifacts(ticket) {
       '## Task 1 — TDD enforcement fixture',
       '',
       '### Type',
-      'backend',
+      'tdd-code',
       '',
       '### Files in scope',
       '- src/**',

--- a/plugins/work/scripts/workflows/work/__tests__/work-orchestrator.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-orchestrator.test.js
@@ -228,7 +228,7 @@ function writeTaskArtifacts(tasksBase, ticket) {
       '## Task 1 — Test task',
       '',
       '### Type',
-      'backend',
+      'tdd-code',
       '',
       '### Files in scope',
       '- src/**',
@@ -2019,7 +2019,7 @@ describe('GH-211: task_review in plan generation', () => {
     for (let i = 1; i <= taskCount; i++) {
       content += `## Task ${i}\n`;
       content += `— Task ${i} title\n\n`;
-      content += `### Type\nimplementation\n\n`;
+      content += `### Type\ntdd-code\n\n`;
       content += `### Deliverables\n- ${i}.1 Deliverable\n\n`;
     }
     fs.writeFileSync(path.join(dir, 'tasks.md'), content);

--- a/plugins/work/scripts/workflows/work/__tests__/work-state.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-state.test.js
@@ -809,7 +809,6 @@ describe('work-state.js', () => {
     });
   });
 
-
   describe('completeWork checkpoint auto-completion (GH-410)', () => {
     const TICKET_APPROVED = 'TEST-CHK-APPROVED-001';
     const TICKET_NO_REPORT = 'TEST-CHK-NOREPORT-001';
@@ -846,11 +845,11 @@ describe('work-state.js', () => {
       // or `opts.tasksMdKinds` to deliberately desync tasks.md from state
       // (e.g. for the tampering-defense test).
       if (!opts.skipTasksMd) {
-        const kinds = opts.tasksMdKinds || tasks.map((t) => (t && t.kind) || 'backend');
+        const kinds = opts.tasksMdKinds || tasks.map((t) => (t && t.kind) || 'tdd-code');
         const sections = tasks.map((t, i) => {
           const num = i + 1;
           const title = (t && t.title) || `Task ${num}`;
-          return `## Task ${num} — ${title}\n\n### Type\n${kinds[i] || 'backend'}\n`;
+          return `## Task ${num} — ${title}\n\n### Type\n${kinds[i] || 'tdd-code'}\n`;
         });
         fs.writeFileSync(path.join(dir, 'tasks.md'), sections.join('\n'));
       }
@@ -861,9 +860,10 @@ describe('work-state.js', () => {
       // Per-task linkage (security review on PR #470): auto-completion now
       // requires the checkpoint task's id or title to appear in the report.
       // Tests that expect auto-completion must pass the relevant task ids.
-      const names = Array.isArray(namedTasks) && namedTasks.length
-        ? `\nVerified: ${namedTasks.join(', ')}\n`
-        : '';
+      const names =
+        Array.isArray(namedTasks) && namedTasks.length
+          ? `\nVerified: ${namedTasks.join(', ')}\n`
+          : '';
       fs.writeFileSync(
         path.join(dir, 'completion.check.md'),
         `# Completion Report\nStatus: ${status}\n${names}`
@@ -872,7 +872,7 @@ describe('work-state.js', () => {
 
     it('auto-completes a pending checkpoint task when completion.check.md is APPROVED', async () => {
       const dir = seedTicket(TICKET_APPROVED, [
-        { id: 'task_1', status: 'completed', kind: 'backend' },
+        { id: 'task_1', status: 'completed', kind: 'tdd-code' },
         { id: 'task_2', status: 'pending', kind: 'checkpoint', title: 'Wrap-up verification' },
       ]);
       writeReport(dir, 'APPROVED', ['task_2']);
@@ -882,8 +882,11 @@ describe('work-state.js', () => {
       assert.ok(Array.isArray(result.autoCompleted));
       assert.equal(result.autoCompleted.length, 1);
       assert.equal(result.autoCompleted[0].taskId, 'task_2');
-      assert.equal(result.autoCompleted[0].title, 'Wrap-up verification',
-        'audit must capture human-readable title, not just task id');
+      assert.equal(
+        result.autoCompleted[0].title,
+        'Wrap-up verification',
+        'audit must capture human-readable title, not just task id'
+      );
       assert.match(result.autoCompleted[0].reason, /APPROVED/);
     });
 
@@ -891,21 +894,24 @@ describe('work-state.js', () => {
       const TICKET_COMPLETE = 'TEST-CHK-COMPLETE-001';
       cleanupTempWorkState(TICKET_COMPLETE);
       const dir = seedTicket(TICKET_COMPLETE, [
-        { id: 'task_1', status: 'completed', kind: 'backend' },
+        { id: 'task_1', status: 'completed', kind: 'tdd-code' },
         { id: 'task_2', status: 'pending', kind: 'checkpoint', title: 'Wrap-up' },
       ]);
       writeReport(dir, 'COMPLETE', ['task_2']);
       const { result, code } = await runWorkState(['complete', TICKET_COMPLETE]);
       assert.equal(code, 0);
       assert.equal(result.autoCompleted.length, 1);
-      assert.match(result.autoCompleted[0].reason, /^COMPLETE /,
-        'reason must use the actual verdict from the report, not a hardcoded string');
+      assert.match(
+        result.autoCompleted[0].reason,
+        /^COMPLETE /,
+        'reason must use the actual verdict from the report, not a hardcoded string'
+      );
       cleanupTempWorkState(TICKET_COMPLETE);
     });
 
     it('blocks completion when checkpoint task has no completion.check.md', async () => {
       seedTicket(TICKET_NO_REPORT, [
-        { id: 'task_1', status: 'completed', kind: 'backend' },
+        { id: 'task_1', status: 'completed', kind: 'tdd-code' },
         { id: 'task_2', status: 'pending', kind: 'checkpoint' },
       ]);
       const { code, stderr } = await runWorkState(['complete', TICKET_NO_REPORT]);
@@ -925,7 +931,7 @@ describe('work-state.js', () => {
 
     it('does NOT auto-complete non-checkpoint pending tasks even with APPROVED report', async () => {
       const dir = seedTicket(TICKET_NON_CKPT, [
-        { id: 'task_1', status: 'pending', kind: 'backend' },
+        { id: 'task_1', status: 'pending', kind: 'tdd-code' },
       ]);
       writeReport(dir, 'APPROVED');
       const { code, stderr } = await runWorkState(['complete', TICKET_NON_CKPT]);
@@ -934,9 +940,7 @@ describe('work-state.js', () => {
     });
 
     it('does NOT auto-complete tasks lacking a kind field (legacy state)', async () => {
-      const dir = seedTicket(TICKET_LEGACY, [
-        { id: 'task_1', status: 'pending' },
-      ]);
+      const dir = seedTicket(TICKET_LEGACY, [{ id: 'task_1', status: 'pending' }]);
       writeReport(dir, 'APPROVED');
       const { code, stderr } = await runWorkState(['complete', TICKET_LEGACY]);
       assert.notEqual(code, 0);
@@ -985,8 +989,7 @@ describe('work-state.js', () => {
           `# Report\n${cases[i]}\n\nVerified: task_1\n`
         );
         const { code } = await runWorkState(['complete', ticket]);
-        assert.notEqual(code, 0,
-          `verdict prefix "${cases[i]}" must NOT pass the gate`);
+        assert.notEqual(code, 0, `verdict prefix "${cases[i]}" must NOT pass the gate`);
         cleanupTempWorkState(ticket);
       }
     });
@@ -1014,8 +1017,11 @@ describe('work-state.js', () => {
       const { result, code } = await runWorkState(['complete', TICKET_DRIFT]);
       assert.equal(code, 0);
       assert.equal(result.autoCompleted.length, 1);
-      assert.match(result.autoCompleted[0].reason, /^APPROVED /,
-        'audit reason must reflect the authentic line-anchored verdict, not the quoted one');
+      assert.match(
+        result.autoCompleted[0].reason,
+        /^APPROVED /,
+        'audit reason must reflect the authentic line-anchored verdict, not the quoted one'
+      );
       cleanupTempWorkState(TICKET_DRIFT);
     });
 
@@ -1051,12 +1057,11 @@ describe('work-state.js', () => {
       const dir = seedTicket(
         TICKET_TITLE,
         [{ id: 'task_1', status: 'pending', kind: 'checkpoint', title: 'checkpoint review' }],
-        { tasksMdKinds: ['backend'] } // tasks.md says backend, not checkpoint
+        { tasksMdKinds: ['tdd-code'] } // tasks.md says tdd-code, not checkpoint
       );
       writeReport(dir, 'APPROVED', ['task_1']);
       const { code } = await runWorkState(['complete', TICKET_TITLE]);
-      assert.notEqual(code, 0,
-        'title-based heuristic must NOT pass the kind re-verify gate');
+      assert.notEqual(code, 0, 'title-based heuristic must NOT pass the kind re-verify gate');
       cleanupTempWorkState(TICKET_TITLE);
     });
 
@@ -1067,16 +1072,15 @@ describe('work-state.js', () => {
       // the tasks.md re-check defeats that path.
       const TICKET_TAMPER = 'TEST-CHK-TAMPER-001';
       cleanupTempWorkState(TICKET_TAMPER);
-      // tasksMeta claims task_1 is checkpoint, but tasks.md says backend.
+      // tasksMeta claims task_1 is checkpoint, but tasks.md says tdd-code.
       const dir = seedTicket(
         TICKET_TAMPER,
         [{ id: 'task_1', status: 'pending', kind: 'checkpoint', title: 'fake checkpoint' }],
-        { tasksMdKinds: ['backend'] }
+        { tasksMdKinds: ['tdd-code'] }
       );
       writeReport(dir, 'APPROVED', ['task_1']);
       const { code, stderr } = await runWorkState(['complete', TICKET_TAMPER]);
-      assert.notEqual(code, 0,
-        'complete must fail — tasks.md disagrees with state on kind');
+      assert.notEqual(code, 0, 'complete must fail — tasks.md disagrees with state on kind');
       assert.match(stderr, /tasks still pending|checkpoint/i);
       cleanupTempWorkState(TICKET_TAMPER);
     });
@@ -1119,9 +1123,7 @@ describe('work-state.js', () => {
     });
 
     it('emits a checkpoint-directive error when all pending are checkpoint without report', async () => {
-      seedTicket(TICKET_MSG, [
-        { id: 'task_1', status: 'pending', kind: 'checkpoint' },
-      ]);
+      seedTicket(TICKET_MSG, [{ id: 'task_1', status: 'pending', kind: 'checkpoint' }]);
       const { code, stderr } = await runWorkState(['complete', TICKET_MSG]);
       assert.notEqual(code, 0);
       assert.match(stderr, /checkpoint/i);
@@ -1130,7 +1132,7 @@ describe('work-state.js', () => {
 
     it('emits the generic message when at least one pending task is not checkpoint', async () => {
       seedTicket(TICKET_MSG_MIXED, [
-        { id: 'task_1', status: 'pending', kind: 'backend' },
+        { id: 'task_1', status: 'pending', kind: 'tdd-code' },
         { id: 'task_2', status: 'pending', kind: 'checkpoint' },
       ]);
       const { code, stderr } = await runWorkState(['complete', TICKET_MSG_MIXED]);
@@ -1157,9 +1159,9 @@ describe('work-state.js', () => {
     it('accepts descriptor array via stdin and persists kind per entry', async () => {
       await runWorkState(['init', TICKET_STDIN]);
       const descriptors = [
-        { num: 1, type: 'frontend' },
-        { num: 2, type: 'backend' },
-        { num: 3, type: 'e2e' },
+        { num: 1, type: 'docs' },
+        { num: 2, type: 'tdd-code' },
+        { num: 3, type: 'ci' },
       ];
       const { result, code, stderr } = await runWorkState(['task-init', TICKET_STDIN], {
         stdin: JSON.stringify(descriptors),
@@ -1168,9 +1170,9 @@ describe('work-state.js', () => {
       assert.equal(result.success, true);
       assert.ok(Array.isArray(result.tasksMeta.tasks));
       assert.equal(result.tasksMeta.tasks.length, 3);
-      assert.equal(result.tasksMeta.tasks[0].kind, 'frontend');
-      assert.equal(result.tasksMeta.tasks[1].kind, 'backend');
-      assert.equal(result.tasksMeta.tasks[2].kind, 'e2e');
+      assert.equal(result.tasksMeta.tasks[0].kind, 'docs');
+      assert.equal(result.tasksMeta.tasks[1].kind, 'tdd-code');
+      assert.equal(result.tasksMeta.tasks[2].kind, 'ci');
     });
 
     it('ignores TASK_INIT_DESCRIPTORS env var (dropped as security hardening)', async () => {
@@ -1180,7 +1182,7 @@ describe('work-state.js', () => {
       // bypass the TDD gate via auto-completion. Stdin is now the only path.
       await runWorkState(['init', TICKET_ENV]);
       const descriptors = [
-        { num: 1, type: 'backend' },
+        { num: 1, type: 'tdd-code' },
         { num: 2, type: 'docs' },
       ];
       const { result, code, stderr } = await runWorkState(['task-init', TICKET_ENV, '2'], {
@@ -1204,23 +1206,22 @@ describe('work-state.js', () => {
       cleanupTempWorkState(TICKET_UNKNOWN_KIND);
       await runWorkState(['init', TICKET_UNKNOWN_KIND]);
       const descriptors = [
-        { num: 1, type: 'backend' },
+        { num: 1, type: 'tdd-code' },
         { num: 2, type: 'totally-made-up-kind' },
       ];
       const { result, code } = await runWorkState(['task-init', TICKET_UNKNOWN_KIND], {
         stdin: JSON.stringify(descriptors),
       });
       assert.equal(code, 0);
-      assert.equal(result.tasksMeta.tasks[0].kind, 'backend');
-      assert.equal(result.tasksMeta.tasks[1].kind, undefined,
-        'unknown kind must not be persisted');
+      assert.equal(result.tasksMeta.tasks[0].kind, 'tdd-code');
+      assert.equal(result.tasksMeta.tasks[1].kind, undefined, 'unknown kind must not be persisted');
       cleanupTempWorkState(TICKET_UNKNOWN_KIND);
     });
 
     it('persists kind for checkpoint type', async () => {
       await runWorkState(['init', TICKET_CHECKPOINT]);
       const descriptors = [
-        { num: 1, type: 'backend' },
+        { num: 1, type: 'tdd-code' },
         { num: 2, type: 'checkpoint' },
       ];
       const { result, code } = await runWorkState(['task-init', TICKET_CHECKPOINT], {

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/tasks-scope-gate.test.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/tasks-scope-gate.test.js
@@ -30,7 +30,7 @@ const validTaskBody = (num, includeInScope = true, includeOutScope = true) => {
     `## Task ${num} — Sample task`,
     '',
     '### Type',
-    'implementation',
+    'tdd-code',
     '',
     '### Description',
     'A task.',
@@ -94,6 +94,9 @@ describe('tasks-scope-gate', () => {
     // Out-of-scope section header with no items → parser returns [] → validator accepts.
     const body = [
       '## Task 1 — Sample',
+      '',
+      '### Type',
+      'tdd-code',
       '',
       '### Files in scope',
       '- a.ts',

--- a/plugins/work/scripts/workflows/work/steps/__tests__/spec-gate.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/spec-gate.test.js
@@ -376,3 +376,74 @@ describe('spec-gate with standalone gherkin.feature', () => {
     assert.match(entries[0].reason, /2 @integration/);
   });
 });
+
+// ─── #629: Reuse Audit grammar gate (Case 1b) ───────────────────────────────
+
+describe('spec-gate Reuse Audit grammar (#629)', () => {
+  let specGateStep;
+  const createdDirs = [];
+
+  before(() => {
+    const mod = require(path.join(__dirname, '..', 'spec-gate.js'));
+    specGateStep = typeof mod === 'function' ? mod : mod.specGateStep;
+  });
+
+  afterEach(() => {
+    while (createdDirs.length) rmrf(createdDirs.pop());
+  });
+
+  function run(specContent) {
+    const dir = makeTmpTasksDir(specContent, GHERKIN_VALID);
+    createdDirs.push(dir);
+    const { add, entries } = makeAdd();
+    specGateStep(add, makeState(), makeCtx({ tasksDir: dir }));
+    return entries;
+  }
+
+  it('RUNs /spec when the Reuse Audit section is prose-only (unparseable)', () => {
+    const entries = run(
+      [
+        '# Spec',
+        '',
+        '## Reuse Audit',
+        '',
+        '- `plugins/lib/levenshtein.js:46` — pure helper, reused directly.',
+        '',
+      ].join('\n')
+    );
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'RUN');
+    assert.equal(entries[0].command, '/spec');
+    assert.match(entries[0].reason, /Reuse Audit unparseable/);
+    assert.match(entries[0].reason, /MUST be reused from/);
+  });
+
+  it('passes through to gherkin validation when Reuse Audit bullets parse', () => {
+    const entries = run(
+      [
+        '# Spec',
+        '',
+        '## Reuse Audit',
+        '',
+        '- `distance` MUST be reused from `plugins/lib/levenshtein.js:46` — typo suggestions',
+        '',
+      ].join('\n')
+    );
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'DEFER');
+  });
+
+  it('passes with the explicit none-marker', () => {
+    const entries = run(
+      ['# Spec', '', '## Reuse Audit', '', '- None — no reusable symbols found', ''].join('\n')
+    );
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'DEFER');
+  });
+
+  it('skips the check when spec.md has no Reuse Audit section (backward compatible)', () => {
+    const entries = run(SPEC_PROSE);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'DEFER');
+  });
+});

--- a/plugins/work/scripts/workflows/work/steps/spec-gate.js
+++ b/plugins/work/scripts/workflows/work/steps/spec-gate.js
@@ -7,6 +7,10 @@
  *
  * Decision matrix:
  *   1. `!s.hasSpec`                           → DEFER "No spec.md present"
+ *   1b. `## Reuse Audit` present but unparseable → RUN "/spec" with the
+ *       exact grammar (fails HERE, where spec.md is editable — at the
+ *       `check` step the file is hook-locked and the reuse_audit gate
+ *       fail-closes with no self-correction path; issue #629)
  *   2. `gherkin.feature` missing/unreadable   → RUN  "/spec" regenerate spec
  *   3. gherkin-skip override in gherkin.feature → DEFER with override reason
  *   4. parseRaw() + validate() passes         → DEFER with scenario count
@@ -17,6 +21,13 @@
 
 const fs = require('fs');
 const parseGherkin = require('../lib/parse-gherkin');
+
+let readReuseAudit;
+try {
+  ({ readReuseAudit } = require('../../work-completion-checker/lib/kind-checks/shared'));
+} catch {
+  readReuseAudit = null;
+}
 
 /**
  * @param {Function} add
@@ -30,6 +41,26 @@ function specGateStep(add, s, ctx) {
   if (!s || !s.hasSpec) {
     add(STEPS.spec_gate, 'DEFER', null, 'No spec.md present');
     return;
+  }
+
+  // Case 1b: Reuse Audit grammar — run the SAME parser the completion
+  // checker's reuse_audit_enforcement gate will run at `check`, so a
+  // format slip fails here (spec.md editable) instead of there (locked).
+  if (readReuseAudit) {
+    try {
+      readReuseAudit(tasksDir);
+    } catch (err) {
+      add(
+        STEPS.spec_gate,
+        'RUN',
+        '/spec',
+        `Reuse Audit unparseable: ${err.message} Rewrite each entry as a bullet: ` +
+          '`- \\`Symbol\\` MUST be reused from \\`path\\` — reason` (MUST only for symbols the change will actually reference; ' +
+          '`may be reused` for mirrored-but-not-imported patterns), or `- None — no reusable symbols found`.',
+        { agentType: 'skill', agentPrompt: '/spec' }
+      );
+      return;
+    }
   }
 
   // Case 2: gherkin.feature missing/unreadable

--- a/plugins/work/skills/split-in-tasks/docs/output-format.md
+++ b/plugins/work/skills/split-in-tasks/docs/output-format.md
@@ -37,6 +37,8 @@ The closed enum is defined in [`lib/task-types.js`](../lib/task-types.js). Addin
 - <requirement ID from Step 4.0>
 - <requirement ID from Step 4.0>
 
+One requirement ID per bullet is the canonical format. Comma-separated bullets (`- R1, R6, R7`) are tolerated by the parsers (both sides share `lib/requirement-ids.js`), but prefer one-per-line — it keeps diffs reviewable and the coverage table trivially greppable.
+
 ### Deliverables
 - [ ] N.1 <subtask description>
   - Test: <acceptance criterion>

--- a/plugins/work/skills/split-in-tasks/lib/task-types.js
+++ b/plugins/work/skills/split-in-tasks/lib/task-types.js
@@ -273,6 +273,44 @@ function scopeEntryAdmitsOnlyTestFiles(entry) {
   return new RegExp(TEST_FILE_PATTERN).test(basename);
 }
 
+/**
+ * scopeEntryCanMatchTestFiles — true iff a `### Files in scope` entry COULD
+ * match (or allow creating) a test file. Broader than
+ * `scopeEntryAdmitsOnlyTestFiles`: a directory or wide glob admits test
+ * files alongside sources. Used by the gherkin_link tasks-phase to verify
+ * that a task carrying `@task:N` scenarios has a scope under which the RED
+ * gate's test-file discovery (`findTestFilesInScope`) can ever succeed.
+ *
+ * Rules:
+ *   - Test-only entry (literal or glob)                       → true.
+ *   - Glob entry: translate the basename glob to a regex and probe it with
+ *     test filenames (`x.test.js` etc.). `src/**` / `src/*` admit tests;
+ *     `docs/*.md` does not.
+ *   - Literal entry with no extension in its basename → treated as a
+ *     directory prefix → admits tests (fail-open: a false "true" cannot
+ *     wedge anything, it only skips a planner-time warning).
+ *   - Literal non-test file (`src/a.js`, `README.md`)         → false.
+ *
+ * @param {string} entry
+ * @returns {boolean}
+ */
+function scopeEntryCanMatchTestFiles(entry) {
+  if (typeof entry !== 'string' || !entry) return false;
+  if (scopeEntryAdmitsOnlyTestFiles(entry)) return true;
+  const lastSlash = entry.lastIndexOf('/');
+  const basename = lastSlash >= 0 ? entry.slice(lastSlash + 1) : entry;
+  if (!entry.includes('*')) {
+    return !basename.includes('.'); // extension-less literal → directory prefix
+  }
+  if (basename === '*' || basename === '**') return true;
+  const escaped = basename
+    .split('*')
+    .map((s) => s.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*');
+  const re = new RegExp(`^${escaped}$`);
+  return ['x.test.js', 'x.spec.ts', 'x.test.tsx', 'x.spec.jsx'].some((p) => re.test(p));
+}
+
 module.exports = {
   TASK_TYPES,
   TDD_REQUIRED_TYPES,
@@ -288,4 +326,5 @@ module.exports = {
   matchesTypeScope,
   isTestFilePath,
   scopeEntryAdmitsOnlyTestFiles,
+  scopeEntryCanMatchTestFiles,
 };


### PR DESCRIPTION
## Existing Behavior

- `kind_assign.js` validated `### Type` values against a legacy domain-kind set (`frontend`, `backend`, `wiring`, `e2e`, `devops`, `fullstack`, `checkpoint`). The implement gate and planner tooling use the closed contract enum from `task-types.js` (`tdd-code`, `tests-only`, `docs`, `config`, `ci`, `mechanical-refactor`, `file-move`, `checkpoint`); only `checkpoint` overlapped. Correctly-authored docs/config tasks failed `tasks_gate`; legacy-typed tasks hit the strictest `tdd-code` contract at implement and entered infinite RED loops (GH-248: 185 retries; GH-517: 55 retries).
- `validateTask` in `task-scope-validators.js` enforced scope presence but did not validate `### Type` membership, so unknown Type values silently passed the tasks phase and wedged at implement where `tasks.md` is hook-locked.
- `draft_test_strategy.js` did not check for the presence of a verification block (`### Test Strategy` / `### Test Command`). Non-checkpoint tasks without either block generated a `MODULE_NOT_FOUND` crash in `node --test` at implement, producing infinite RED.
- `gherkin_link.js` did not verify that a task owning `@task:N`-tagged scenarios could ever satisfy the implement gate — tasks whose `### Files in scope` contained no test-file-matchable entries were accepted by the tasks phase but were unsatisfiable at RED.
- `requirements_extract.js` and the completion-checker `subsection` fallback used different ID grammars: the generator emitted comma-separated IDs (`- R1, R6, R7`) while the fallback required exactly one bare token per bullet, so multi-ID bullets yielded zero rows and re-triggered `requirement_coverage_missing` deadlocks (GH-498).
- `readReuseAudit` in `kind-checks/shared.js` only matched the canonical bullet shape and had no none-marker; spec-writer.md lacked a machine-parsed `### Reuse Declarations` subsection, causing format slips to fail-close at `check` where `spec.md` is hook-locked.

## Intended New Behavior

- **Type enum unification (keystone):** `kind_assign.js` validates `### Type` against `task-types.js` TASK_TYPES with per-Type structural checks (`TYPE_SCOPE_RULES`) and migration hints for legacy domain kinds. `validateTask` adds Type-membership as a defense-in-depth gate at `tasks_gate`. The `task-readiness` kind allowlist re-points to the same `VALID_KINDS` export — one source of truth for both sides.
- **Missing verification block (#606):** `draft_test_strategy.js` (flag-gated) errors when a non-checkpoint task has neither `### Test Strategy` nor legacy `### Test Command`, stopping the node MODULE_NOT_FOUND infinite RED loop at generation time where `tasks.md` is still editable.
- **Gherkin satisfiability (#489/#491):** `gherkin_link.js` rejects tasks owning `@task:N` scenarios whose `### Files in scope` cannot match any test file, via a new `scopeEntryCanMatchTestFiles` classifier in `task-types.js`. Unsatisfiable tasks fail at `tasks_gate` rather than looping at implement.
- **Requirement-ID grammar (#498):** New shared lib `scripts/workflows/lib/requirement-ids.js` is the single source of truth for ID parsing used by both `requirements_extract.js` and the completion-checker subsection fallback. Comma-separated ID bullets (`- R1, R6, R7`) now synthesize one row per ID on both sides.
- **Reuse Audit grammar (#629):** `spec-writer.md` instructs the exact machine-parsed `### Reuse Declarations` bullet grammar with MUST vs may semantics and an explicit None marker. `readReuseAudit` accepts the parenthesized-path variant and the none-marker; `spec-gate.js` runs the same parser early (case 1b) so format slips fail at `spec_gate` where `spec.md` is editable instead of fail-closing at `check`.
- `.quality-exceptions` shrinks by one: `work-completion-checker/lib/kind-checks/shared.js` is now fully compliant (complexity helper extracted to `parseCoverageTableRow`).

## Out-of-scope changes

None — all changed files are within the five fix areas described above plus their test suites.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

All checks run locally against `fix/work-stuck-issues`. `pnpm quality` and `quality:changed` are clean.

Targeted suites (all green):

| Suite | Count |
|---|---|
| kind-assign-closed-taxonomy | 15 |
| gherkin-link-satisfiability | 8 |
| coverage-fallback (integration) | 7 |
| reuse-audit-enforcement | 13 |
| spec-gate | 17 |
| draft-test-strategy (integration) | 10 |
| task-scope | 97 |
| tdd-enforcement | 48 |
| work-state | 58 |
| work-orchestrator | 110 |
| task-readiness | 5 |
| completion-checker | 85 |

Full-suite failures are the pre-existing synapsys environmental set, verified identical on a clean-HEAD baseline run — not regressions from this branch.

**Breaking-change note:** `tasks.md` documents authored with legacy domain kinds (`frontend`, `backend`, `wiring`, `e2e`, `devops`, `fullstack`) now fail `tasks_gate` with migration hints pointing to the correct closed enum value. This is intentional: those documents were already wedging at implement anyway; failing earlier at a still-editable artifact is strictly better.

**Verify the type-enum fix manually:**
1. Author a `tasks.md` with `### Type` set to `backend`.
2. Run `tasks_gate` — expect a failure citing `"backend" is not in the closed enum` with migration hints.
3. Change `### Type` to `tdd-code` — `tasks_gate` passes.

**Verify the Reuse Declarations fix (#629):**
1. Produce a `spec.md` with `## Reuse Audit` containing only prose (no `### Reuse Declarations` bullets).
2. Run `spec-gate` — expect a failure citing the expected bullet grammar.
3. Add `### Reuse Declarations` bullets matching the documented grammar — `spec-gate` passes.

Closes #498, Closes #629, Closes #491.

References #489 — generation-side prevention landed here; implement-side recovery/rewind paths remain tracked there.
References #606 — generation-side prevention landed here; implement-side recovery/rewind paths remain tracked there.

### Test Results

Suites listed in Testing Plan above were run locally and passed. Full-suite environmental failures (synapsys set) are pre-existing and confirmed identical on a clean `main` baseline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tasks/spec gate behavior and intentionally breaks legacy `### Type` values at `tasks_gate`; broad test coverage limits regression risk but any missed call site could still mis-route tasks at implement.
> 
> **Overview**
> Moves **contract enforcement earlier** in the work pipeline so bad `tasks.md` / `spec.md` fail while artifacts are still editable, instead of looping at implement or fail-closing at `check`.
> 
> **Task type & scope (GH-498):** `kind_assign` now validates `### Type` against the closed `task-types.js` enum with `TYPE_SCOPE_RULES` (replacing legacy `frontend`/`backend`/… checks) and emits migration hints. `validateTask` in `task-scope-validators.js` also requires a known `### Type` before checkpoint scope exemptions. `draft_test_strategy` (flag on) blocks non-checkpoint tasks with neither `### Test Strategy` nor legacy `### Test Command`. `gherkin_link` rejects tasks that own `@task:N` scenarios but whose scope cannot admit test files via new `scopeEntryCanMatchTestFiles`.
> 
> **Shared grammars:** New `lib/requirement-ids.js` aligns tasks-phase extraction and completion-checker subsection fallback (comma-separated `- R1, R6, R7` → one row per ID). `readReuseAudit` gains parenthesized-path bullets and `- None — …`; `spec-gate` runs the same parser before gherkin (case 1b). `spec-writer.md` documents machine-parsed **Reuse Declarations** bullets (MUST vs `may be reused`).
> 
> **Refactor:** Duplicated kind-check helpers move to `kind-checks-shared-base.js`; completion-checker coverage parsing splits into `parseCoverageTableRow` (drops one `.quality-exceptions` entry). Tests and fixtures switch from legacy domain kinds to `tdd-code` / closed enum values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c199f7d95de0892fc9a03880f3b903db8cb6d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->