### PR TITLE
fix(heimdall): close shell-obfuscation bypass + cut write-detection false positives

### DIFF
--- a/plugins/heimdall/hooks/heimdall-conceal.js
+++ b/plugins/heimdall/hooks/heimdall-conceal.js
@@ -22,6 +22,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const {
+  normalizedVariants,
+  commandGlobReferencesMarker,
+  commandGlobReferencesPath,
+} = require('../lib/guard/shell-normalize');
 
 // Try to load the conceal config at <dir>/.claude/heimdall-conceal.json.
 // Returns the parsed config (stamped with __root = dir) when present, null when
@@ -209,10 +214,73 @@ function fileToolCandidates(toolName, input) {
   return candidates.filter(Boolean).map(toPosix);
 }
 
+// Literal path strings a wildcard token could resolve onto: secretsFiles
+// basenames plus the literal core of each deny pattern (leading/trailing anchor
+// groups stripped, regex unescaped). Anything that isn't a plain literal path is
+// skipped — those are matched by the regex-over-variants pass instead.
+function literalCore(pattern) {
+  let s = String(pattern)
+    .replace(/^\([^)]*\)/, '') // drop a leading (^|/) / (^|[^\w.-]) anchor group
+    .replace(/^\^/, '')
+    .replace(/\([^)]*\)$/, '') // drop a trailing (/|$) anchor group
+    .replace(/\\b$/, '')
+    .replace(/\$$/, '');
+  s = s.replace(/\\(.)/g, '$1'); // unescape \x -> x
+  return /^[\w./-]+$/.test(s) ? s : '';
+}
+
+function concealLiterals(cfg) {
+  const out = new Set();
+  for (const f of cfg.secretsFiles || []) {
+    const b = path.basename(String(f));
+    if (b) out.add(b);
+  }
+  for (const key of ['denyFilePatterns', 'denyCommandPatterns']) {
+    for (const p of cfg[key] || []) {
+      const core = literalCore(p);
+      if (core) out.add(core);
+    }
+  }
+  return [...out];
+}
+
+// A wildcard token (`*`, `?`) can't be reduced to a literal, so glob-match
+// command tokens against the known concealed literals. Returns a descriptive
+// match token (truthy) or null. See GH-655.
+function globMatchesConcealed(cfg, variants) {
+  const literals = concealLiterals(cfg);
+  if (!literals.length) return null;
+  for (const variant of variants) {
+    for (const lit of literals) {
+      const ref = lit.includes('/')
+        ? commandGlobReferencesPath(variant, lit)
+        : commandGlobReferencesMarker(variant, lit);
+      if (ref) return `glob:${lit}`;
+    }
+  }
+  return null;
+}
+
 function evaluate(cfg, toolName, input) {
   if (toolName === 'Bash') {
-    const cmd = toPosix(String(input.command || ''));
-    return cmdPatterns(cfg).find((re) => re.test(cmd)) || null;
+    const raw = String(input.command || '');
+    // Deobfuscate the RAW command first (a shell backslash escape must be
+    // resolved before toPosix would rewrite `\`→`/`), then also carry a toPosix
+    // form of each variant for Windows-separator configs. Quote/backslash/brace/
+    // [x] evasions (cat ~/.se[c]rets, .se""crets, {.sec,x}rets) collapse to the
+    // literal path before matching. See GH-655.
+    const variantSet = new Set();
+    for (const v of normalizedVariants(raw)) {
+      variantSet.add(v);
+      variantSet.add(toPosix(v));
+    }
+    const variants = [...variantSet];
+    const pats = cmdPatterns(cfg);
+    for (const variant of variants) {
+      const hit = pats.find((re) => re.test(variant));
+      if (hit) return hit;
+    }
+    return globMatchesConcealed(cfg, variants);
   }
   if (FILE_TOOLS.has(toolName)) {
     // Test each candidate SEPARATELY: joining with a separator would break the

--- a/plugins/heimdall/hooks/heimdall.js
+++ b/plugins/heimdall/hooks/heimdall.js
@@ -25,12 +25,18 @@ async function readStdin() {
   return input;
 }
 
-/** Merge lock blocks from every active store at cwd; '' when none apply. */
+/**
+ * Merge lock blocks from every active store at cwd; [] when none apply. Each
+ * block is tagged with its store kind (`_storeKind`) so a rejection can surface
+ * that it came from the shared (cross-project) store. See GH-585.
+ */
 function collectLocks(cwd) {
   const locks = [];
   for (const store of discoverStores(cwd)) {
     const cfg = readConfig(store.dir);
-    if (cfg && Array.isArray(cfg.locks)) locks.push(...cfg.locks);
+    if (cfg && Array.isArray(cfg.locks)) {
+      for (const lock of cfg.locks) locks.push({ ...lock, _storeKind: store.kind });
+    }
   }
   return locks;
 }

--- a/plugins/heimdall/lib/__tests__/conceal-guard.test.js
+++ b/plugins/heimdall/lib/__tests__/conceal-guard.test.js
@@ -490,3 +490,52 @@ describe('conceal seeding preserves existing secrets coverage', () => {
     assert.equal(guardIn(secretsRepo, bashPayload('cat /proc/123/environ')), 2);
   });
 });
+
+describe('conceal guard resists shell obfuscation (GH-655)', () => {
+  let oRepo;
+  const guardIn = (dir, payload) =>
+    spawnSync('node', [HOOK], {
+      input: JSON.stringify(payload),
+      env: { ...process.env, CLAUDE_PROJECT_DIR: dir },
+      encoding: 'utf8',
+    }).status;
+
+  before(() => {
+    oRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-obf-'));
+    fs.mkdirSync(path.join(oRepo, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(oRepo, 'secret-folder'), { recursive: true });
+    // Folder conceal only (no secretsFiles) so the folder name is the sole marker.
+    fs.writeFileSync(
+      path.join(oRepo, '.claude', 'heimdall-conceal.json'),
+      JSON.stringify({
+        denyFilePatterns: ['secret-folder(/|$)'],
+        denyCommandPatterns: ['(^|[^\\w.-])secret-folder\\b'],
+        secretsFiles: [],
+      })
+    );
+  });
+
+  after(() => fs.rmSync(oRepo, { recursive: true, force: true }));
+
+  const cases = {
+    plain: `cat ${'{r}'}/secret-folder/creds.txt`,
+    'glob-bracket': `cat ${'{r}'}/secret-fold[e]r/creds.txt`,
+    'glob-star': `cat ${'{r}'}/secret-fol*/creds.txt`,
+    'quote-split': `cat ${'{r}'}/secret-fol""der/creds.txt`,
+    backslash: `cat ${'{r}'}/secret-fol\\der/creds.txt`,
+    brace: `cat ${'{r}'}/{secret,x}-folder/creds.txt`,
+  };
+
+  for (const [name, tmpl] of Object.entries(cases)) {
+    it(`blocks obfuscated Bash read: ${name}`, () => {
+      const cmd = tmpl.replace('{r}', oRepo);
+      assert.equal(guardIn(oRepo, bashPayload(cmd)), 2, cmd);
+    });
+  }
+
+  it('still allows unrelated Bash commands', () => {
+    for (const cmd of ['pnpm build', 'ls *.log', `cat ${oRepo}/other/x.txt`]) {
+      assert.equal(guardIn(oRepo, bashPayload(cmd)), 0, cmd);
+    }
+  });
+});

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -399,3 +399,56 @@ describe('evaluate: passthrough', () => {
     assert.equal(r.exitCode, 0);
   });
 });
+
+// ─── Shell-obfuscation resistance + temp-path parity (GH-655 / GH-658) ─────────
+
+describe('evaluate: bash obfuscation (GH-655)', () => {
+  const bash = (command) =>
+    evaluate({
+      toolName: 'Bash',
+      toolInput: { command },
+      transcriptPath: transcriptEmpty,
+      entries: entries(),
+    });
+  const dir = path.join(baseDir, '.claude');
+
+  it('blocks obfuscated writes into a protected dir', () => {
+    for (const command of [
+      `echo x > ${path.join(baseDir, '.cl[a]ude')}/settings.json`,
+      `echo x > ${path.join(baseDir, '.cl""aude')}/settings.json`,
+      `echo x > ${path.join(baseDir, '.cla\\ude')}/settings.json`,
+      `echo x > ${path.dirname(dir)}/.cl*ude/settings.json`,
+      `echo x > ${path.join(baseDir, '{.claude,z}')}/settings.json`,
+    ]) {
+      assert.equal(bash(command).exitCode, 2, `should block: ${command}`);
+    }
+  });
+
+  it('does not flag unrelated globs / build commands', () => {
+    for (const command of ['ls src/*', 'rm *.log', 'pnpm build', 'require("x")']) {
+      assert.equal(bash(command).exitCode, 0, `should allow: ${command}`);
+    }
+  });
+});
+
+describe('evaluate: bash temp-path parity (GH-658)', () => {
+  const os2 = require('node:os');
+  const bash = (command) =>
+    evaluate({
+      toolName: 'Bash',
+      toolInput: { command },
+      transcriptPath: transcriptEmpty,
+      entries: entries(),
+    });
+
+  it('allows a write into a throwaway temp .claude fixture', () => {
+    const tmp = fs.mkdtempSync(path.join(os2.tmpdir(), 'heimdall-fixture-'));
+    const r = bash(`mkdir -p ${tmp}/.claude && echo x > ${tmp}/.claude/settings.json`);
+    fs.rmSync(tmp, { recursive: true, force: true });
+    assert.equal(r.exitCode, 0);
+  });
+
+  it('still blocks a write into the real protected .claude', () => {
+    assert.equal(bash(`echo x > ${path.join(baseDir, '.claude')}/settings.json`).exitCode, 2);
+  });
+});

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -316,6 +316,14 @@ describe('evaluate: bash', () => {
     assert.equal(runB('rm packages/ui/config.json').exitCode, 2);
   });
 
+  it('ui: blocks a `./`-prefixed write `rm ./packages/ui/config.json` (GH-642)', () => {
+    // Settles the skipped review claim that a `./` prefix bypasses the boundary:
+    // the char before `ui` in `./packages/ui/` is `/`, which IS in the boundary
+    // class, so this stays blocked.
+    assert.equal(runB('rm ./packages/ui/config.json').exitCode, 2);
+    assert.equal(runB('rm ./src/config.json').exitCode, 2);
+  });
+
   it('ui: blocks a redirect-write `echo hi > ui/x`', () => {
     assert.equal(runB('echo hi > ui/x').exitCode, 2);
   });
@@ -334,8 +342,13 @@ describe('evaluate: bash', () => {
     assert.equal(runB('rm packages/ui').exitCode, 2);
   });
 
-  it('ui: blocks `node -e "require(\'ui\')"` (quoted path token)', () => {
-    assert.equal(runB(`node -e "require('ui')"`).exitCode, 2);
+  it('ui: allows `node -e "require(\'ui\')"` (a read, not a write) — GH-656', () => {
+    // `require('ui')` reads the package; the lock is a WRITE gate, so this must
+    // NOT be blocked. Genuine interpreter writes (writeFileSync into the dir) are
+    // still caught by BASH_WRITE_GLOBAL. This corrects the GH-642-era assertion
+    // that treated any `node -e` naming the marker as a write.
+    assert.equal(runB(`node -e "require('ui')"`).exitCode, 0);
+    assert.equal(runB(`node -e "require('fs').writeFileSync('packages/ui/x','y')"`).exitCode, 2);
   });
 
   it('db: blocks `rm packages/db/schema.sql`', () => {
@@ -427,6 +440,130 @@ describe('evaluate: bash obfuscation (GH-655)', () => {
   it('does not flag unrelated globs / build commands', () => {
     for (const command of ['ls src/*', 'rm *.log', 'pnpm build', 'require("x")']) {
       assert.equal(bash(command).exitCode, 0, `should allow: ${command}`);
+    }
+  });
+});
+
+describe('evaluate: script-bypass correlates write to the protected path (GH-657)', () => {
+  const os2 = require('node:os');
+  let scriptsDir;
+  let readerScript;
+  let writerScript;
+
+  before(() => {
+    scriptsDir = fs.mkdtempSync(path.join(os2.tmpdir(), 'heimdall-scripts-'));
+    readerScript = path.join(scriptsDir, 'reader.js');
+    writerScript = path.join(scriptsDir, 'writer.js');
+    // Reads a protected path, writes ONLY to /tmp — must be allowed.
+    fs.writeFileSync(
+      readerScript,
+      "const fs = require('fs');\n" +
+        `const d = fs.readFileSync('${path.join(baseDir, '.claude', 'config')}', 'utf8');\n` +
+        "fs.writeFileSync('/tmp/heimdall-reader-out', d);\n"
+    );
+    // Writes INTO the protected path — must still be blocked.
+    fs.writeFileSync(
+      writerScript,
+      "const fs = require('fs');\n" +
+        `fs.writeFileSync('${path.join(baseDir, '.claude', 'settings.json')}', 'x');\n`
+    );
+  });
+
+  after(() => fs.rmSync(scriptsDir, { recursive: true, force: true }));
+
+  const bash = (command) =>
+    evaluate({
+      toolName: 'Bash',
+      toolInput: { command },
+      transcriptPath: transcriptEmpty,
+      entries: entries(),
+    });
+
+  it('allows a script that reads a protected path but writes elsewhere', () => {
+    assert.equal(bash(`node ${readerScript}`).exitCode, 0);
+  });
+
+  it('still blocks a script that writes into the protected path', () => {
+    assert.equal(bash(`node ${writerScript}`).exitCode, 2);
+  });
+});
+
+describe('evaluate: skills subdir is execute-trusted but edit-gated (GH-637)', () => {
+  const os2 = require('node:os');
+  let cfgRoot;
+  let skillScript;
+  const skillLocks = () => [
+    {
+      protect: ['.claude'],
+      unlockPhrase: 'edit .claude',
+      trustedSubdirs: ['hooks', 'plugins', 'external_scripts', 'skills'],
+    },
+  ];
+  const ent = () => buildEntries(skillLocks(), cfgRoot);
+
+  before(() => {
+    cfgRoot = fs.mkdtempSync(path.join(os2.homedir(), '.heimdall-skills-'));
+    skillScript = path.join(cfgRoot, '.claude', 'skills', 'demo', 'run.js');
+    fs.mkdirSync(path.dirname(skillScript), { recursive: true });
+    // Script both references the protected dir and performs a write op — without
+    // the skills trust it would be flagged as a script-bypass write.
+    fs.writeFileSync(
+      skillScript,
+      "const fs = require('fs');\nfs.writeFileSync('/tmp/out', '.claude ran');\n"
+    );
+  });
+
+  after(() => fs.rmSync(cfgRoot, { recursive: true, force: true }));
+
+  it('allows executing a skill script under .claude/skills without unlock', () => {
+    const r = evaluate({
+      toolName: 'Bash',
+      toolInput: { command: `node ${skillScript} --flag` },
+      transcriptPath: transcriptEmpty,
+      entries: ent(),
+    });
+    assert.equal(r.exitCode, 0, r.message);
+  });
+
+  it('still blocks EDITING a file under .claude/skills', () => {
+    const r = evaluate({
+      toolName: 'Edit',
+      toolInput: { file_path: skillScript },
+      transcriptPath: transcriptEmpty,
+      entries: ent(),
+    });
+    assert.equal(r.exitCode, 2);
+  });
+});
+
+describe('evaluate: bash interpreter reads are not writes (GH-656)', () => {
+  const bash = (command) =>
+    evaluate({
+      toolName: 'Bash',
+      toolInput: { command },
+      transcriptPath: transcriptEmpty,
+      entries: entries(),
+    });
+  const dir = path.join(baseDir, '.claude');
+
+  it('allows read-only interpreter idioms that merely name a protected path', () => {
+    for (const command of [
+      `node -e "const c = require('${dir}/config'); console.log(c)"`,
+      `node -e "require('./package.json')"`,
+      `python3 -c "print(open('${dir}/x').read())"`,
+      `node ${dir}/../thing.js --flag`,
+    ]) {
+      assert.equal(bash(command).exitCode, 0, `should allow: ${command}`);
+    }
+  });
+
+  it('still blocks genuine interpreter writes into a protected path', () => {
+    for (const command of [
+      `node -e "require('fs').writeFileSync('${dir}/x','y')"`,
+      `python3 -c "open('${dir}/x','w').write('y')"`,
+      `echo x > ${dir}/x`,
+    ]) {
+      assert.equal(bash(command).exitCode, 2, `should block: ${command}`);
     }
   });
 });

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -486,6 +486,17 @@ describe('evaluate: script-bypass correlates write to the protected path (GH-657
   it('still blocks a script that writes into the protected path', () => {
     assert.equal(bash(`node ${writerScript}`).exitCode, 2);
   });
+
+  it('blocks a script that writes through a variable holding the protected path', () => {
+    const viaVar = path.join(scriptsDir, 'viavar.js');
+    fs.writeFileSync(
+      viaVar,
+      "const fs = require('fs');\n" +
+        `const target = '${path.join(baseDir, '.claude', 'settings.json')}';\n` +
+        "fs.writeFileSync(target, 'x');\n"
+    );
+    assert.equal(bash(`node ${viaVar}`).exitCode, 2);
+  });
 });
 
 describe('evaluate: skills subdir is execute-trusted but edit-gated (GH-637)', () => {
@@ -561,6 +572,7 @@ describe('evaluate: bash interpreter reads are not writes (GH-656)', () => {
     for (const command of [
       `node -e "require('fs').writeFileSync('${dir}/x','y')"`,
       `python3 -c "open('${dir}/x','w').write('y')"`,
+      `python3 -c "open('${dir}/x','r+').write('y')"`,
       `echo x > ${dir}/x`,
     ]) {
       assert.equal(bash(command).exitCode, 2, `should block: ${command}`);

--- a/plugins/heimdall/lib/__tests__/guard.test.js
+++ b/plugins/heimdall/lib/__tests__/guard.test.js
@@ -444,31 +444,13 @@ describe('evaluate: bash obfuscation (GH-655)', () => {
   });
 });
 
-describe('evaluate: script-bypass correlates write to the protected path (GH-657)', () => {
+describe('evaluate: script-bypass stays fail-closed (no indirection bypass)', () => {
   const os2 = require('node:os');
   let scriptsDir;
-  let readerScript;
-  let writerScript;
 
   before(() => {
     scriptsDir = fs.mkdtempSync(path.join(os2.tmpdir(), 'heimdall-scripts-'));
-    readerScript = path.join(scriptsDir, 'reader.js');
-    writerScript = path.join(scriptsDir, 'writer.js');
-    // Reads a protected path, writes ONLY to /tmp — must be allowed.
-    fs.writeFileSync(
-      readerScript,
-      "const fs = require('fs');\n" +
-        `const d = fs.readFileSync('${path.join(baseDir, '.claude', 'config')}', 'utf8');\n` +
-        "fs.writeFileSync('/tmp/heimdall-reader-out', d);\n"
-    );
-    // Writes INTO the protected path — must still be blocked.
-    fs.writeFileSync(
-      writerScript,
-      "const fs = require('fs');\n" +
-        `fs.writeFileSync('${path.join(baseDir, '.claude', 'settings.json')}', 'x');\n`
-    );
   });
-
   after(() => fs.rmSync(scriptsDir, { recursive: true, force: true }));
 
   const bash = (command) =>
@@ -478,24 +460,37 @@ describe('evaluate: script-bypass correlates write to the protected path (GH-657
       transcriptPath: transcriptEmpty,
       entries: entries(),
     });
+  const write = (name, body) => {
+    const p = path.join(scriptsDir, name);
+    fs.writeFileSync(p, body);
+    return p;
+  };
+  const target = path.join(baseDir, '.claude', 'settings.json');
 
-  it('allows a script that reads a protected path but writes elsewhere', () => {
-    assert.equal(bash(`node ${readerScript}`).exitCode, 0);
+  // Every static way to hide the write target must stay BLOCKED — correlating
+  // the write to the protected path via content analysis is not reliable
+  // (variables, path.join, concatenation), so the guard is intentionally
+  // fail-closed: any non-trusted script that references the marker AND writes.
+  it('blocks a direct write into the protected path', () => {
+    const s = write('direct.js', `require('fs').writeFileSync('${target}', 'x');\n`);
+    assert.equal(bash(`node ${s}`).exitCode, 2);
   });
 
-  it('still blocks a script that writes into the protected path', () => {
-    assert.equal(bash(`node ${writerScript}`).exitCode, 2);
+  it('blocks a write through a variable holding the protected path', () => {
+    const s = write('viavar.js', `const t = '${target}';\nrequire('fs').writeFileSync(t, 'x');\n`);
+    assert.equal(bash(`node ${s}`).exitCode, 2);
   });
 
-  it('blocks a script that writes through a variable holding the protected path', () => {
-    const viaVar = path.join(scriptsDir, 'viavar.js');
-    fs.writeFileSync(
-      viaVar,
-      "const fs = require('fs');\n" +
-        `const target = '${path.join(baseDir, '.claude', 'settings.json')}';\n` +
-        "fs.writeFileSync(target, 'x');\n"
+  it('blocks even when the write op sits on a different line from the marker', () => {
+    // Fail-closed: discovery keys off the marker appearing anywhere in content;
+    // once discovered, ANY write op blocks — the write need not be correlated to
+    // the marker on the same statement.
+    const s = write(
+      'split.js',
+      `// touches ${path.join(baseDir, '.claude')}/config\n` +
+        "require('fs').writeFileSync('/tmp/heimdall-split-out', 'x');\n"
     );
-    assert.equal(bash(`node ${viaVar}`).exitCode, 2);
+    assert.equal(bash(`node ${s}`).exitCode, 2);
   });
 });
 

--- a/plugins/heimdall/lib/catalog.js
+++ b/plugins/heimdall/lib/catalog.js
@@ -25,7 +25,11 @@ const CATALOG = [
     description: 'Hooks, settings, agents, commands (mirror of protect-claude-config.js)',
     defaultPhrase: 'edit .claude',
     allowedPaths: ['plans', 'dev', 'projects', 'external_scripts', 'plugins'],
-    trustedSubdirs: ['hooks', 'plugins', 'external_scripts'],
+    // `skills` is trusted-for-EXECUTE (running a plugin skill script under
+    // .claude/skills/**/*.js must not require the unlock phrase) but is
+    // deliberately NOT in allowedPaths, so EDITING a skill file still gates on
+    // the phrase. See GH-637.
+    trustedSubdirs: ['hooks', 'plugins', 'external_scripts', 'skills'],
     targets: [
       { path: '.claude', anchor: 'repo' },
       { path: '~/.claude', anchor: 'home' },

--- a/plugins/heimdall/lib/guard/__tests__/shell-normalize.test.js
+++ b/plugins/heimdall/lib/guard/__tests__/shell-normalize.test.js
@@ -1,0 +1,90 @@
+// Unit tests for the shell-obfuscation normalizer shared by both guards (GH-655).
+//
+// Discovered by plugins/work/scripts/run-tests.sh.
+// Manual: node --test plugins/heimdall/lib/guard/__tests__/shell-normalize.test.js
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  dequote,
+  reduceSingleCharClasses,
+  expandBraces,
+  normalizedVariants,
+  commandGlobReferencesMarker,
+  commandGlobReferencesPath,
+} = require(path.resolve(__dirname, '..', 'shell-normalize'));
+
+describe('dequote', () => {
+  it('collapses empty quote splits', () => {
+    assert.equal(dequote('.cl""aude'), '.claude');
+    assert.equal(dequote(".cl''aude"), '.claude');
+  });
+  it('removes backslash escapes', () => {
+    assert.equal(dequote('.cla\\ude'), '.claude');
+  });
+  it('keeps quoted content', () => {
+    assert.equal(dequote('cat "/a/.claude/x"'), 'cat /a/.claude/x');
+  });
+});
+
+describe('reduceSingleCharClasses', () => {
+  it('reduces single-char classes to the literal', () => {
+    assert.equal(reduceSingleCharClasses('.c[l]aude'), '.claude');
+    assert.equal(reduceSingleCharClasses('secret-fold[e]r'), 'secret-folder');
+  });
+  it('leaves negated and multi-char classes for glob matching', () => {
+    assert.equal(reduceSingleCharClasses('.c[^x]aude'), '.c[^x]aude');
+    assert.equal(reduceSingleCharClasses('.c[la]ude'), '.c[la]ude');
+  });
+});
+
+describe('expandBraces', () => {
+  it('enumerates brace alternatives', () => {
+    assert.deepEqual(expandBraces('.{cl,x}aude').sort(), ['.claude', '.xaude'].sort());
+  });
+  it('is a no-op without a comma list', () => {
+    assert.deepEqual(expandBraces('.claude'), ['.claude']);
+  });
+});
+
+describe('normalizedVariants', () => {
+  it('recovers the literal path across quote/brace/class evasions', () => {
+    for (const cmd of [
+      'cat ~/.c[l]aude/secret',
+      'cat ~/.cl""aude/secret',
+      'cat ~/.cla\\ude/secret',
+      'cat ~/.{cl,x}aude/secret',
+    ]) {
+      assert.ok(
+        normalizedVariants(cmd).some((v) => v.includes('.claude')),
+        `expected a variant of ${cmd} to contain .claude`
+      );
+    }
+  });
+});
+
+describe('commandGlobReferencesMarker', () => {
+  it('matches an anchored wildcard token onto a bare marker', () => {
+    assert.ok(commandGlobReferencesMarker('echo x > secretd*/y', 'secretdir'));
+    assert.ok(commandGlobReferencesMarker('cat .cl*ude/y', '.claude'));
+  });
+  it('does not let a bare/unanchored wildcard match a short marker', () => {
+    assert.ok(!commandGlobReferencesMarker('ls src/*', 'ui'));
+    assert.ok(!commandGlobReferencesMarker('rm *.log', 'ui'));
+    assert.ok(!commandGlobReferencesMarker('pnpm build', 'ui'));
+  });
+});
+
+describe('commandGlobReferencesPath', () => {
+  const dir = '/home/u/.claude';
+  it('matches a wildcard token that resolves onto the dir or a child', () => {
+    assert.ok(commandGlobReferencesPath('echo x > /home/u/.cl*ude/s', dir));
+    assert.ok(commandGlobReferencesPath('echo x > /home/u/.claude/s', dir) === false); // no glob → not counted here
+  });
+  it('ignores unrelated globs', () => {
+    assert.ok(!commandGlobReferencesPath('rm /home/u/tmp/*.log', dir));
+    assert.ok(!commandGlobReferencesPath('ls src/*', dir));
+  });
+});

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -47,20 +47,14 @@ const BASH_WRITE_TEMPLATES = [
   /tar\s+.*-C\s*["']?[^|&;]*MARKER/i,
   /tar\s+.*--directory\s*["']?[^|&;]*MARKER/i,
   /unzip\s+.*-d\s*["']?[^|&;]*MARKER/i,
-  /python[23]?\s+-c\s+.*MARKER/i,
-  /MARKER.*python[23]?\s+-c/i,
-  /node\s+-e\s+.*MARKER/i,
-  /MARKER.*node\s+-e/i,
-  /perl\s+-e\s+.*MARKER/i,
-  /MARKER.*perl\s+-e/i,
-  /ruby\s+-e\s+.*MARKER/i,
-  /MARKER.*ruby\s+-e/i,
+  // Interpreter invocations (node -e, python -c, perl/ruby -e, sh/bash -c, eval)
+  // that merely NAME the marker are NOT writes — `node -e "require('X/.claude/c')"`
+  // and `python -c "print(open('X/.claude/c').read())"` are pure reads. Their
+  // actual writes carry a redirect (`>`, caught by the generic template above) or
+  // a write API (caught by BASH_WRITE_GLOBAL below), so no bare-interpreter marker
+  // template is needed here. Dropping them removes the highest-volume false
+  // positive (read-only introspection). See GH-656.
   /cd\s+.*MARKER.*(?:&&|;|\|\||&)/i,
-  /sh\s+-c\s+.*MARKER/i,
-  /MARKER.*sh\s+-c/i,
-  /bash\s+-c\s+.*MARKER/i,
-  /MARKER.*bash\s+-c/i,
-  /eval\s+.*MARKER/i,
   /git\s+clone\s+.*MARKER/i,
   /git\s+checkout\s+.*MARKER/i,
   /git\s+pull\s+.*MARKER/i,
@@ -73,13 +67,22 @@ const BASH_WRITE_TEMPLATES = [
   /<<.*>\s*["']?[^|&;]*MARKER/i,
 ];
 
+// Interpreter WRITE detection: a `node -e`/`python -c` invocation is a write
+// only when its inline code calls a write API (not merely `open(`/`require`,
+// which are reads). `open(` is required to carry a write mode ('w'/'a'/'x') so a
+// read-open is not flagged. See GH-656.
 const BASH_WRITE_GLOBAL = [
-  /node\s+-e\s+.*(?:writeFileSync|appendFileSync|writeFile|createWriteStream)/i,
-  /python[23]?\s+-c\s+.*(?:open\(|write\(|\.write|write_text|write_bytes|\.unlink|\.rename|\.replace\(|\.mkdir|shutil\.\w*copy|shutil\.move|shutil\.rmtree)/i,
+  /node\s+-e\s+.*(?:writeFileSync|appendFileSync|writeFile\b|createWriteStream|\brmSync|\bunlinkSync|\brenameSync)/i,
+  /python[23]?\s+-c\s+.*(?:open\([^)]*,\s*['"][^'"]*[wax]|write_text|write_bytes|\.write\(|\.unlink|\.rename|\.replace\(|\.mkdir|shutil\.\w*copy|shutil\.move|shutil\.rmtree)/i,
 ];
 
+// Bare interpreter tokens (node -e, python -c, sh -c, eval, …) are deliberately
+// NOT generic write signals: naming a protected path inside an interpreter read
+// (`node -e "require('X/.claude/c')"`) must not count as an absolute-path write.
+// Real interpreter writes carry a redirect (`>`) or a write API (BASH_WRITE_GLOBAL)
+// and are still detected. See GH-656.
 const GENERIC_WRITE_RE =
-  /(?:>{1,2}|>\||\btee\b|\bcp\b|\bmv\b|\brm\b|\brmdir\b|\btouch\b|\bmkdir\b|\bchmod\b|\bchown\b|\bln\b|\binstall\b|\brsync\b|\bdd\b|\btruncate\b|\bsed\s+-i|\bpatch\b|\bsponge\b|\bunlink\b|\bcurl\s+-o|\bcurl\s+--output|\bwget\s+-O|\bwget\s+--output|\btar\s+-C|\btar\s+--directory|\bunzip\s+-d|\bfind\s+.*-exec|\bxargs\b|\bnode\s+-e\b|\bpython[23]?\s+-c\b|\bperl\s+-e\b|\bruby\s+-e\b|\bsh\s+-c\b|\bbash\s+-c\b|\beval\b)/i;
+  /(?:>{1,2}|>\||\btee\b|\bcp\b|\bmv\b|\brm\b|\brmdir\b|\btouch\b|\bmkdir\b|\bchmod\b|\bchown\b|\bln\b|\binstall\b|\brsync\b|\bdd\b|\btruncate\b|\bsed\s+-i|\bpatch\b|\bsponge\b|\bunlink\b|\bcurl\s+-o|\bcurl\s+--output|\bwget\s+-O|\bwget\s+--output|\btar\s+-C|\btar\s+--directory|\bunzip\s+-d|\bfind\s+.*-exec|\bxargs\b)/i;
 
 const _patternCache = new Map();
 function getPatternsForMarker(marker) {

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -8,7 +8,12 @@
  * mirroring the original protect-package-json hook).
  */
 
-const { expandHomePaths, allRefsUnderAllowedPaths } = require('./paths');
+const { expandHomePaths, allRefsUnderAllowedPaths, markerOnlyInTempPaths } = require('./paths');
+const {
+  normalizedVariants,
+  commandGlobReferencesMarker,
+  commandGlobReferencesPath,
+} = require('./shell-normalize');
 
 // Generic write-op templates; `MARKER` is replaced per protected marker.
 const BASH_WRITE_TEMPLATES = [
@@ -148,26 +153,28 @@ function isReadOnlyBashCommand(command) {
   return true;
 }
 
-/** All command variants (raw / expanded / collapsed) for matching. */
+/**
+ * All command variants for matching. `command`/`collapsed`/`expanded`/
+ * `expandedCollapsed` are the named forms other heuristics key off; `all` is the
+ * de-duplicated set of those PLUS shell-deobfuscated forms (dequoted,
+ * single-char-class reduced, brace-expanded) so quote/backslash/brace/`[x]`
+ * evasions collapse back to the literal path before matching. See GH-655.
+ */
 function commandVariants(command) {
   const collapsed = command.replace(/\s*\n+\s*/g, ' ');
-  return {
-    command,
-    collapsed,
-    expanded: expandHomePaths(command),
-    expandedCollapsed: expandHomePaths(collapsed),
-  };
+  const expanded = expandHomePaths(command);
+  const expandedCollapsed = expandHomePaths(collapsed);
+  const all = new Set();
+  for (const base of [command, collapsed, expanded, expandedCollapsed]) {
+    for (const variant of normalizedVariants(base)) all.add(variant);
+  }
+  return { command, collapsed, expanded, expandedCollapsed, all: [...all] };
 }
 
 function anyMatches(patterns, v) {
   for (const p of patterns) {
-    if (
-      p.test(v.command) ||
-      p.test(v.expanded) ||
-      p.test(v.collapsed) ||
-      p.test(v.expandedCollapsed)
-    ) {
-      return true;
+    for (const s of v.all) {
+      if (p.test(s)) return true;
     }
   }
   return false;
@@ -217,24 +224,24 @@ function markerOnPathBoundary(marker, text) {
 
 function markerPresent(marker, v) {
   // Markers containing `/` are already path-qualified — a raw substring match is
-  // safe and intentional (relative-path writes like `sed -i .claude/x`).
+  // safe and intentional (relative-path writes like `sed -i .claude/x`). Tested
+  // over `v.all` so a dequoted/brace-expanded form is also caught, plus a
+  // wildcard token that could expand onto the path (GH-655).
   if (marker.includes('/')) {
-    return (
-      v.command.includes(marker) ||
-      v.expanded.includes(marker) ||
-      v.collapsed.includes(marker) ||
-      v.expandedCollapsed.includes(marker)
-    );
+    for (const s of v.all) {
+      if (s.includes(marker) || commandGlobReferencesPath(s, marker)) return true;
+    }
+    return false;
   }
   // Bare basenames anchor to a path boundary so short names (ui, db, api, lib,
   // src) no longer match a mid-word substring (build → "ui", require → "ui",
-  // glibc → "lib") and wrongly flag unrelated commands. See GH-642.
-  return (
-    markerOnPathBoundary(marker, v.command) ||
-    markerOnPathBoundary(marker, v.expanded) ||
-    markerOnPathBoundary(marker, v.collapsed) ||
-    markerOnPathBoundary(marker, v.expandedCollapsed)
-  );
+  // glibc → "lib") and wrongly flag unrelated commands (GH-642). Wildcard tokens
+  // are matched only when anchored by a substantial literal prefix/suffix, so
+  // `ls src/*` still does not flag `ui` (GH-655).
+  for (const s of v.all) {
+    if (markerOnPathBoundary(marker, s) || commandGlobReferencesMarker(s, marker)) return true;
+  }
+  return false;
 }
 
 /**
@@ -249,6 +256,11 @@ function markerPresent(marker, v) {
  */
 function markerEligible(entry, marker, v) {
   if (!markerPresent(marker, v)) return false;
+  // Temp-path parity with the file-tool guard (findProtectedTarget exempts temp
+  // paths): a write whose only marker hit sits inside a scratch temp path — e.g.
+  // scaffolding `/tmp/x/.claude/fixture` — is not a write to the protected path.
+  // See GH-658.
+  if (markerOnlyInTempPaths(v.expandedCollapsed, marker)) return false;
   if (!entry.isFile && allRefsUnderAllowedPaths(v.expandedCollapsed, entry)) return false;
   return true;
 }
@@ -258,12 +270,15 @@ function absolutePathWrite(entry, v, dirPresent) {
     dirPresent &&
     hasGenericWriteIntent(v.collapsed) &&
     !isDirectionSensitiveRead(v.command, v.expanded, entry.dir) &&
+    !markerOnlyInTempPaths(v.expandedCollapsed, entry.dir) && // GH-658 temp parity
     !allRefsUnderAllowedPaths(v.expandedCollapsed, entry)
   );
 }
 
 function entryWriteMatch(entry, v) {
-  const dirPresent = v.expanded.includes(entry.dir) || v.expandedCollapsed.includes(entry.dir);
+  const dirPresent =
+    v.all.some((s) => s.includes(entry.dir)) ||
+    v.all.some((s) => commandGlobReferencesPath(s, entry.dir));
   if (absolutePathWrite(entry, v, dirPresent)) return 'absolute-path';
   for (const marker of entry.markers) {
     if (!markerEligible(entry, marker, v)) continue;

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -73,7 +73,7 @@ const BASH_WRITE_TEMPLATES = [
 // read-open is not flagged. See GH-656.
 const BASH_WRITE_GLOBAL = [
   /node\s+-e\s+.*(?:writeFileSync|appendFileSync|writeFile\b|createWriteStream|\brmSync|\bunlinkSync|\brenameSync)/i,
-  /python[23]?\s+-c\s+.*(?:open\([^)]*,\s*['"][^'"]*[wax]|write_text|write_bytes|\.write\(|\.unlink|\.rename|\.replace\(|\.mkdir|shutil\.\w*copy|shutil\.move|shutil\.rmtree)/i,
+  /python[23]?\s+-c\s+.*(?:open\([^)]*,\s*['"][^'"]*(?:[wax]|r[^'"]*\+)|write_text|write_bytes|\.write\(|\.unlink|\.rename|\.replace\(|\.mkdir|shutil\.\w*copy|shutil\.move|shutil\.rmtree)/i,
 ];
 
 // Bare interpreter tokens (node -e, python -c, sh -c, eval, …) are deliberately

--- a/plugins/heimdall/lib/guard/entries.js
+++ b/plugins/heimdall/lib/guard/entries.js
@@ -55,6 +55,10 @@ function buildEntry(raw, lock, baseDir) {
     unlockPhrase: String(lock.unlockPhrase || '').trim(),
     allowedPaths: Array.isArray(lock.allowedPaths) ? lock.allowedPaths : null,
     trustedSubdirs: Array.isArray(lock.trustedSubdirs) ? lock.trustedSubdirs : [],
+    // Store kind the block came from (local|worktree|global|shared), tagged by
+    // the hook's collectLocks so a rejection can flag a cross-project origin.
+    // See GH-585.
+    kind: lock._storeKind || null,
   };
 }
 

--- a/plugins/heimdall/lib/guard/evaluate.js
+++ b/plugins/heimdall/lib/guard/evaluate.js
@@ -21,8 +21,16 @@ function blockMessage(reason, entry, matchContext) {
   // Only the USER typing the phrase unlocks (see transcript.js): tool output —
   // including this very message echoed back as a tool_result — is never trusted,
   // so an agent cannot self-unlock by emitting the phrase.
-  let msg = `BLOCKED (heimdall): ${reason}\n`;
+  // Surface a cross-project origin: when the blocking lock came from the shared
+  // store, the user may not expect it (it is not this project's own config). The
+  // literal `(shared)` token is the contract asserted by the cross-project e2e.
+  // See GH-585 (AC8 from GH-541).
+  const origin = entry && entry.kind === 'shared' ? ' (shared)' : '';
+  let msg = `BLOCKED (heimdall)${origin}: ${reason}\n`;
   if (entry) {
+    if (origin) {
+      msg += `This lock comes from your shared (cross-project) heimdall store, not this project.\n`;
+    }
     const phrase = entry.unlockPhrase || `edit ${path.basename(entry.dir)}`;
     msg += `\nACTION REQUIRED: Stop and ask the user to UNLOCK this path. Tell them to reply with the\n`;
     msg += `exact phrase (they must type it themselves — only a user message unlocks it):\n`;

--- a/plugins/heimdall/lib/guard/scripts-bypass.js
+++ b/plugins/heimdall/lib/guard/scripts-bypass.js
@@ -28,45 +28,25 @@ function scriptPatternsFor(entry) {
   return patterns;
 }
 
-const WRITE_OP_LINE =
-  /(?:writeFileSync|appendFileSync|writeFile\b|createWriteStream|\bunlink|\brmSync|\brmdir|renameSync|\brename\b|copyFileSync|\bexec|fs\.promises\.(?:writeFile|rm|rename)|fs\.writeFile|fs\.appendFile|>{1,2}\s*['"]|>\|\s*['"]|\btee\s+-a\b|open\([^)]*['"][^'"]*[wax])/;
+// Any write op in the script content. Kept intentionally BROAD and fail-closed:
+// a script that both references a protected marker and performs a write is
+// blocked, because static content analysis cannot reliably prove which path a
+// write targets (a target can be built via variables, path.join, concatenation,
+// etc.). Correlating "write ↔ marker" was attempted (GH-657) but every static
+// correlation leaves an indirection bypass, so per the fail-closed policy the
+// broad check stands. Legitimate scripts are exempted by location via
+// `trustedSubdirs`, or by the user speaking the unlock phrase once.
+const WRITE_OPS_IN_SCRIPT =
+  /\b(?:writeFileSync|appendFileSync|writeFile|createWriteStream|unlink|unlinkSync|rmSync|renameSync|rename|rmdir|rmdirSync|copyFileSync|exec|execSync|fs\.promises\.writeFile|fs\.promises\.rm|fs\.promises\.rename|fs\.writeFile|fs\.appendFile)\b/;
 
-// Variables assigned a STRING LITERAL that contains a protected marker — a path
-// stored for a later write, e.g. `const target = '/repo/.claude/settings.json'`.
-// Only bare string literals are tainted, NOT calls: `const d =
-// fs.readFileSync('<protected>')` binds file CONTENT, not a path, and writing
-// that content elsewhere is a read, not a protected-path write.
-function taintedPathVars(content, markerPats) {
-  const vars = new Set();
-  const assignRe = /([A-Za-z_$][\w$]*)\s*=\s*(['"`])((?:\\.|(?!\2).)*)\2/g;
-  let m;
-  while ((m = assignRe.exec(content)) !== null) {
-    if (markerPats.some((p) => p.test(m[3]))) vars.add(m[1]);
-  }
-  return vars;
-}
-
-/**
- * Correlate the write op to the protected path: block when a statement both
- * performs a write AND references the protected marker (GH-657) — directly, or
- * via a variable that was assigned a marker-bearing path literal (closes the
- * variable-indirection bypass). This stops the false positive where a script
- * merely READS a protected path and writes elsewhere (e.g. to /tmp), or where a
- * test file names a marker as a fixture while writing to temp dirs, without
- * letting `const t = '<protected>/x'; writeFileSync(t, …)` escape.
- */
-function scriptWritesToProtected(content, entry) {
-  const markerPats = scriptPatternsFor(entry);
-  const tainted = taintedPathVars(content, markerPats);
-  const taintedRe = tainted.size
-    ? new RegExp(`\\b(?:${[...tainted].map((v) => v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})\\b`)
-    : null;
-  for (const stmt of content.split(/[\n;]/)) {
-    if (!WRITE_OP_LINE.test(stmt)) continue;
-    if (markerPats.some((p) => p.test(stmt))) return true;
-    if (taintedRe && taintedRe.test(stmt)) return true;
-  }
-  return false;
+function scriptHasWriteOps(content) {
+  return (
+    WRITE_OPS_IN_SCRIPT.test(content) ||
+    />{1,2}\s*['"]/.test(content) ||
+    />\|\s*['"]/.test(content) ||
+    /\btee\s+-a\b/.test(content) ||
+    /open\(.*['"]w/.test(content)
+  );
 }
 
 /**
@@ -91,11 +71,7 @@ function checkScriptBypass(collapsedCmd, entry, entries) {
   } catch (err) {
     return { blocked: true, error: `Cannot read script "${found.scriptPath}": ${err.message}` };
   }
-  // Require the write op and the protected-path reference to co-occur in one
-  // statement (GH-657). A script that only reads the protected path — or one
-  // (e.g. a test file) that names it as a fixture while writing to temp — is not
-  // a bypass and must not be blocked.
-  return scriptWritesToProtected(content, entry)
+  return scriptHasWriteOps(content)
     ? { blocked: true, scriptPath: found.scriptPath }
     : { blocked: false };
 }

--- a/plugins/heimdall/lib/guard/scripts-bypass.js
+++ b/plugins/heimdall/lib/guard/scripts-bypass.js
@@ -31,21 +31,40 @@ function scriptPatternsFor(entry) {
 const WRITE_OP_LINE =
   /(?:writeFileSync|appendFileSync|writeFile\b|createWriteStream|\bunlink|\brmSync|\brmdir|renameSync|\brename\b|copyFileSync|\bexec|fs\.promises\.(?:writeFile|rm|rename)|fs\.writeFile|fs\.appendFile|>{1,2}\s*['"]|>\|\s*['"]|\btee\s+-a\b|open\([^)]*['"][^'"]*[wax])/;
 
+// Variables assigned a STRING LITERAL that contains a protected marker — a path
+// stored for a later write, e.g. `const target = '/repo/.claude/settings.json'`.
+// Only bare string literals are tainted, NOT calls: `const d =
+// fs.readFileSync('<protected>')` binds file CONTENT, not a path, and writing
+// that content elsewhere is a read, not a protected-path write.
+function taintedPathVars(content, markerPats) {
+  const vars = new Set();
+  const assignRe = /([A-Za-z_$][\w$]*)\s*=\s*(['"`])((?:\\.|(?!\2).)*)\2/g;
+  let m;
+  while ((m = assignRe.exec(content)) !== null) {
+    if (markerPats.some((p) => p.test(m[3]))) vars.add(m[1]);
+  }
+  return vars;
+}
+
 /**
- * Correlate the write op to the protected path: block only when a SINGLE
- * statement both performs a write AND references the protected marker (GH-657).
- * This stops the false positive where a script merely READS a protected path and
- * writes elsewhere (e.g. to /tmp), and where a test file references a marker as a
- * string fixture while writing to temp dirs — without weakening the realistic
- * threat (`fs.writeFileSync('<protected>/x', …)` keeps write + marker on one
- * statement). Known limitation: a write whose target is bound to a variable on a
- * separate line is not correlated here.
+ * Correlate the write op to the protected path: block when a statement both
+ * performs a write AND references the protected marker (GH-657) — directly, or
+ * via a variable that was assigned a marker-bearing path literal (closes the
+ * variable-indirection bypass). This stops the false positive where a script
+ * merely READS a protected path and writes elsewhere (e.g. to /tmp), or where a
+ * test file names a marker as a fixture while writing to temp dirs, without
+ * letting `const t = '<protected>/x'; writeFileSync(t, …)` escape.
  */
 function scriptWritesToProtected(content, entry) {
   const markerPats = scriptPatternsFor(entry);
+  const tainted = taintedPathVars(content, markerPats);
+  const taintedRe = tainted.size
+    ? new RegExp(`\\b(?:${[...tainted].map((v) => v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})\\b`)
+    : null;
   for (const stmt of content.split(/[\n;]/)) {
     if (!WRITE_OP_LINE.test(stmt)) continue;
     if (markerPats.some((p) => p.test(stmt))) return true;
+    if (taintedRe && taintedRe.test(stmt)) return true;
   }
   return false;
 }

--- a/plugins/heimdall/lib/guard/scripts-bypass.js
+++ b/plugins/heimdall/lib/guard/scripts-bypass.js
@@ -9,9 +9,6 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { commandAccessesProtectedPaths } = require('../command-analysis');
 
-const WRITE_OPS_IN_SCRIPT =
-  /\b(?:writeFileSync|appendFileSync|writeFile|createWriteStream|unlink|unlinkSync|rmSync|renameSync|rename|rmdir|rmdirSync|copyFileSync|exec|execSync|fs\.promises\.writeFile|fs\.promises\.rm|fs\.promises\.rename|fs\.writeFile|fs\.appendFile)\b/;
-
 function isTrustedScript(scriptPath, entries) {
   for (const entry of entries) {
     for (const subdir of entry.trustedSubdirs || []) {
@@ -31,14 +28,26 @@ function scriptPatternsFor(entry) {
   return patterns;
 }
 
-function scriptHasWriteOps(content) {
-  return (
-    WRITE_OPS_IN_SCRIPT.test(content) ||
-    />{1,2}\s*['"]/.test(content) ||
-    />\|\s*['"]/.test(content) ||
-    /\btee\s+-a\b/.test(content) ||
-    /open\(.*['"]w/.test(content)
-  );
+const WRITE_OP_LINE =
+  /(?:writeFileSync|appendFileSync|writeFile\b|createWriteStream|\bunlink|\brmSync|\brmdir|renameSync|\brename\b|copyFileSync|\bexec|fs\.promises\.(?:writeFile|rm|rename)|fs\.writeFile|fs\.appendFile|>{1,2}\s*['"]|>\|\s*['"]|\btee\s+-a\b|open\([^)]*['"][^'"]*[wax])/;
+
+/**
+ * Correlate the write op to the protected path: block only when a SINGLE
+ * statement both performs a write AND references the protected marker (GH-657).
+ * This stops the false positive where a script merely READS a protected path and
+ * writes elsewhere (e.g. to /tmp), and where a test file references a marker as a
+ * string fixture while writing to temp dirs — without weakening the realistic
+ * threat (`fs.writeFileSync('<protected>/x', …)` keeps write + marker on one
+ * statement). Known limitation: a write whose target is bound to a variable on a
+ * separate line is not correlated here.
+ */
+function scriptWritesToProtected(content, entry) {
+  const markerPats = scriptPatternsFor(entry);
+  for (const stmt of content.split(/[\n;]/)) {
+    if (!WRITE_OP_LINE.test(stmt)) continue;
+    if (markerPats.some((p) => p.test(stmt))) return true;
+  }
+  return false;
 }
 
 /**
@@ -63,7 +72,11 @@ function checkScriptBypass(collapsedCmd, entry, entries) {
   } catch (err) {
     return { blocked: true, error: `Cannot read script "${found.scriptPath}": ${err.message}` };
   }
-  return scriptHasWriteOps(content)
+  // Require the write op and the protected-path reference to co-occur in one
+  // statement (GH-657). A script that only reads the protected path — or one
+  // (e.g. a test file) that names it as a fixture while writing to temp — is not
+  // a bypass and must not be blocked.
+  return scriptWritesToProtected(content, entry)
     ? { blocked: true, scriptPath: found.scriptPath }
     : { blocked: false };
 }

--- a/plugins/heimdall/lib/guard/shell-normalize.js
+++ b/plugins/heimdall/lib/guard/shell-normalize.js
@@ -33,6 +33,25 @@ const MAX_BRACE_VARIANTS = 64;
  * concatenated with its neighbours, exactly as the shell would: `.cl""aude` and
  * `'.claude'` and `.cla\ude` all collapse to `.claude`.
  */
+// Scan a quoted run starting just after the opening quote `q`; returns the
+// unquoted content and the index just past the closing quote (or end-of-string
+// for an unbalanced quote). Inside double quotes a backslash still escapes;
+// inside single quotes it is literal (bash semantics).
+function scanQuote(s, start, q) {
+  let out = '';
+  let i = start;
+  while (i < s.length && s[i] !== q) {
+    if (q === '"' && s[i] === '\\' && i + 1 < s.length) {
+      out += s[i + 1];
+      i += 2;
+    } else {
+      out += s[i];
+      i += 1;
+    }
+  }
+  return { out, next: i + 1 };
+}
+
 function dequote(s) {
   let out = '';
   for (let i = 0; i < s.length; i++) {
@@ -40,25 +59,13 @@ function dequote(s) {
     if (c === '\\') {
       i += 1;
       if (i < s.length) out += s[i];
-      continue;
+    } else if (c === '"' || c === "'") {
+      const r = scanQuote(s, i + 1, c);
+      out += r.out;
+      i = r.next - 1;
+    } else {
+      out += c;
     }
-    if (c === '"' || c === "'") {
-      const q = c;
-      i += 1;
-      while (i < s.length && s[i] !== q) {
-        // Inside double quotes a backslash still escapes; inside single quotes
-        // it is literal (bash semantics).
-        if (q === '"' && s[i] === '\\' && i + 1 < s.length) {
-          out += s[i + 1];
-          i += 2;
-          continue;
-        }
-        out += s[i];
-        i += 1;
-      }
-      continue; // skip the closing quote (or end-of-string for an unbalanced one)
-    }
-    out += c;
   }
   return out;
 }
@@ -118,6 +125,26 @@ function tokenize(s) {
   return s.split(/[\s"'`,;()|<>&=]+/).filter(Boolean);
 }
 
+// Copy a bracket char-class verbatim from index `i` (which points at `[`).
+// Returns the compiled class and the index of its closing `]`.
+function readCharClass(seg, i) {
+  let j = i + 1;
+  let cls = '[';
+  if (seg[j] === '!' || seg[j] === '^') {
+    cls += '^';
+    j += 1;
+  }
+  if (seg[j] === ']') {
+    cls += '\\]';
+    j += 1;
+  }
+  while (j < seg.length && seg[j] !== ']') {
+    cls += seg[j] === '\\' ? '\\\\' : seg[j];
+    j += 1;
+  }
+  return { cls: `${cls}]`, next: j };
+}
+
 /** Compile one path SEGMENT glob to an anchored regex with `[^/]` semantics. */
 function segGlobToRegExp(seg) {
   let re = '^';
@@ -128,28 +155,14 @@ function segGlobToRegExp(seg) {
     } else if (c === '?') {
       re += '[^/]';
     } else if (c === '[') {
-      let j = i + 1;
-      let cls = '[';
-      if (seg[j] === '!' || seg[j] === '^') {
-        cls += '^';
-        j += 1;
-      }
-      if (seg[j] === ']') {
-        cls += '\\]';
-        j += 1;
-      }
-      while (j < seg.length && seg[j] !== ']') {
-        cls += seg[j] === '\\' ? '\\\\' : seg[j];
-        j += 1;
-      }
-      cls += ']';
-      re += cls;
-      i = j;
+      const r = readCharClass(seg, i);
+      re += r.cls;
+      i = r.next;
     } else {
       re += c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
   }
-  return new RegExp(re + '$');
+  return new RegExp(`${re}$`);
 }
 
 /**
@@ -186,6 +199,24 @@ function commandGlobReferencesMarker(command, marker) {
  * child of it. At least one aligned segment must carry a glob metachar, so pure
  * literals (already handled by substring checks) don't double-count here.
  */
+// Do `litPath`'s segments align onto `tSegs` starting at `start`, using at least
+// one glob metachar (so a pure literal — already handled by substring checks —
+// doesn't double-count here)?
+function segmentsAlignAt(tSegs, lSegs, start) {
+  let usedGlob = false;
+  for (let i = 0; i < lSegs.length; i += 1) {
+    const t = tSegs[start + i];
+    const l = lSegs[i];
+    if (hasGlobMeta(t)) {
+      usedGlob = true;
+      if (!segGlobToRegExp(t).test(l)) return false;
+    } else if (t !== l) {
+      return false;
+    }
+  }
+  return usedGlob;
+}
+
 function commandGlobReferencesPath(command, litPath) {
   if (!litPath) return false;
   const lSegs = litPath.split('/');
@@ -193,23 +224,7 @@ function commandGlobReferencesPath(command, litPath) {
     if (!hasGlobMeta(tok)) continue;
     const tSegs = tok.split('/');
     for (let start = 0; start + lSegs.length <= tSegs.length; start += 1) {
-      let ok = true;
-      let usedGlob = false;
-      for (let i = 0; i < lSegs.length; i += 1) {
-        const t = tSegs[start + i];
-        const l = lSegs[i];
-        if (hasGlobMeta(t)) {
-          usedGlob = true;
-          if (!segGlobToRegExp(t).test(l)) {
-            ok = false;
-            break;
-          }
-        } else if (t !== l) {
-          ok = false;
-          break;
-        }
-      }
-      if (ok && usedGlob) return true;
+      if (segmentsAlignAt(tSegs, lSegs, start)) return true;
     }
   }
   return false;

--- a/plugins/heimdall/lib/guard/shell-normalize.js
+++ b/plugins/heimdall/lib/guard/shell-normalize.js
@@ -1,0 +1,228 @@
+'use strict';
+
+/**
+ * Shell-obfuscation normalization, shared by the lock guard (bash.js) and the
+ * conceal hook (hooks/heimdall-conceal.js).
+ *
+ * Both guards match protected paths against the LITERAL command text (after
+ * `~`/`$HOME` expansion). But the shell expands quotes, backslashes, brace
+ * lists and globs BEFORE running the command, so a protected path can be named
+ * in a form the literal matcher never sees:
+ *
+ *   cat ~/.c[l]aude/x   (single-char class)   cat ~/.cl*ude/x   (wildcard)
+ *   cat ~/.cl""aude/x   (quote split)          cat ~/.cla\ude/x  (backslash)
+ *   cat ~/.{cl,x}aude/x (brace list)
+ *
+ * Strategy (fail-closed): recover the literal(s) each token can denote.
+ *   1. `dequote` removes quoting/backslash escapes (reveals `.cl""aude`→`.claude`).
+ *   2. `reduceSingleCharClasses` turns `[l]`→`l` (a single-char class is lossless).
+ *   3. `expandBraces` enumerates `{a,b}` alternatives.
+ * These feed `normalizedVariants`, which the existing literal patterns run over.
+ *
+ * True wildcards (`*`, `?`, multi-char classes) cannot be collapsed to a
+ * literal, so `commandGlobReferencesMarker` / `commandGlobReferencesPath`
+ * glob-match command tokens against the KNOWN protected marker/dir — precise
+ * (an unrelated glob like `rm *.log` cannot match `.claude`) yet fail-closed
+ * (any token that COULD expand onto the protected path counts as a reference).
+ */
+
+const MAX_BRACE_VARIANTS = 64;
+
+/**
+ * Strip shell quoting that splits or hides a literal. Quote CONTENT is kept and
+ * concatenated with its neighbours, exactly as the shell would: `.cl""aude` and
+ * `'.claude'` and `.cla\ude` all collapse to `.claude`.
+ */
+function dequote(s) {
+  let out = '';
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (c === '\\') {
+      i += 1;
+      if (i < s.length) out += s[i];
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      const q = c;
+      i += 1;
+      while (i < s.length && s[i] !== q) {
+        // Inside double quotes a backslash still escapes; inside single quotes
+        // it is literal (bash semantics).
+        if (q === '"' && s[i] === '\\' && i + 1 < s.length) {
+          out += s[i + 1];
+          i += 2;
+          continue;
+        }
+        out += s[i];
+        i += 1;
+      }
+      continue; // skip the closing quote (or end-of-string for an unbalanced one)
+    }
+    out += c;
+  }
+  return out;
+}
+
+/**
+ * Reduce single-character bracket globs to the character they denote:
+ * `[l]`→`l`, `[.]`→`.`, `[\.]`→`.`. A one-char class is exactly one literal, so
+ * this is lossless and precise — it covers the `.c[l]aude` bypass. Negated
+ * (`[!x]`/`[^x]`) and multi-char classes are left for glob-matching.
+ */
+function reduceSingleCharClasses(s) {
+  return s.replace(/\[(\\?.)\]/g, (m, ch) => {
+    if (ch === '!' || ch === '^') return m; // not a single literal
+    return ch.length === 2 && ch[0] === '\\' ? ch[1] : ch;
+  });
+}
+
+/** Expand `{a,b,c}` brace lists combinatorially, bounded. Ranges are ignored. */
+function expandBraces(s, cap = MAX_BRACE_VARIANTS) {
+  const m = s.match(/\{([^{}]*,[^{}]*)\}/);
+  if (!m) return [s];
+  const pre = s.slice(0, m.index);
+  const post = s.slice(m.index + m[0].length);
+  const out = [];
+  for (const opt of m[1].split(',')) {
+    for (const rest of expandBraces(pre + opt + post, cap)) {
+      out.push(rest);
+      if (out.length >= cap) return out;
+    }
+  }
+  return out;
+}
+
+/** All normalized variants of a command to test literal patterns against. */
+function normalizedVariants(command) {
+  const seen = new Set();
+  const add = (x) => {
+    if (x && !seen.has(x)) seen.add(x);
+  };
+  const dq = dequote(command);
+  for (const base of [command, dq]) {
+    add(base);
+    const reduced = reduceSingleCharClasses(base);
+    add(reduced);
+    for (const b of expandBraces(reduced)) add(b);
+  }
+  return [...seen];
+}
+
+const GLOB_META = /[*?[]/;
+function hasGlobMeta(tok) {
+  return GLOB_META.test(tok);
+}
+
+/** Split a command into path-like tokens on shell boundaries. */
+function tokenize(s) {
+  return s.split(/[\s"'`,;()|<>&=]+/).filter(Boolean);
+}
+
+/** Compile one path SEGMENT glob to an anchored regex with `[^/]` semantics. */
+function segGlobToRegExp(seg) {
+  let re = '^';
+  for (let i = 0; i < seg.length; i++) {
+    const c = seg[i];
+    if (c === '*') {
+      re += '[^/]*';
+    } else if (c === '?') {
+      re += '[^/]';
+    } else if (c === '[') {
+      let j = i + 1;
+      let cls = '[';
+      if (seg[j] === '!' || seg[j] === '^') {
+        cls += '^';
+        j += 1;
+      }
+      if (seg[j] === ']') {
+        cls += '\\]';
+        j += 1;
+      }
+      while (j < seg.length && seg[j] !== ']') {
+        cls += seg[j] === '\\' ? '\\\\' : seg[j];
+        j += 1;
+      }
+      cls += ']';
+      re += cls;
+      i = j;
+    } else {
+      re += c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  return new RegExp(re + '$');
+}
+
+/**
+ * A wildcard-bearing segment plausibly denotes `marker` only when it is ANCHORED
+ * by a substantial literal run — a leading literal that is a prefix of the
+ * marker, or a trailing literal that is its suffix (each ≥2 chars). This keeps
+ * `*`/`*.log`/`src/*` from matching short markers (`ui`, `db`) — the #642
+ * false-positive class — while still catching `.cl*ude` (lead `.cl`) and
+ * `secretd*` (lead `secretd`).
+ */
+function globSegmentPlausiblyMarker(seg, marker) {
+  const lead = (seg.match(/^[^*?[]+/) || [''])[0];
+  const trail = (seg.match(/[^*?[\]]+$/) || [''])[0];
+  const anchored =
+    (lead.length >= 2 && marker.startsWith(lead)) ||
+    (trail.length >= 2 && marker.endsWith(trail));
+  return anchored && segGlobToRegExp(seg).test(marker);
+}
+
+/** True when any glob token has a segment that glob-matches the bare `marker`. */
+function commandGlobReferencesMarker(command, marker) {
+  if (!marker || marker.includes('/')) return false;
+  for (const tok of tokenize(command)) {
+    if (!hasGlobMeta(tok)) continue;
+    for (const seg of tok.split('/')) {
+      if (hasGlobMeta(seg) && globSegmentPlausiblyMarker(seg, marker)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when a glob token denotes `litPath` (a multi-segment/absolute path) or a
+ * child of it. At least one aligned segment must carry a glob metachar, so pure
+ * literals (already handled by substring checks) don't double-count here.
+ */
+function commandGlobReferencesPath(command, litPath) {
+  if (!litPath) return false;
+  const lSegs = litPath.split('/');
+  for (const tok of tokenize(command)) {
+    if (!hasGlobMeta(tok)) continue;
+    const tSegs = tok.split('/');
+    for (let start = 0; start + lSegs.length <= tSegs.length; start += 1) {
+      let ok = true;
+      let usedGlob = false;
+      for (let i = 0; i < lSegs.length; i += 1) {
+        const t = tSegs[start + i];
+        const l = lSegs[i];
+        if (hasGlobMeta(t)) {
+          usedGlob = true;
+          if (!segGlobToRegExp(t).test(l)) {
+            ok = false;
+            break;
+          }
+        } else if (t !== l) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok && usedGlob) return true;
+    }
+  }
+  return false;
+}
+
+module.exports = {
+  dequote,
+  reduceSingleCharClasses,
+  expandBraces,
+  normalizedVariants,
+  hasGlobMeta,
+  tokenize,
+  segGlobToRegExp,
+  commandGlobReferencesMarker,
+  commandGlobReferencesPath,
+};

--- a/plugins/heimdall/skills/protect/SKILL.md
+++ b/plugins/heimdall/skills/protect/SKILL.md
@@ -27,8 +27,14 @@ Adds (or extends) a lock block: a set of protected paths paired with one unlock 
    node "${CLAUDE_PLUGIN_ROOT}/scripts/heimdall-protect.js" --phrase="<phrase>" --paths="<comma,separated,paths>"
    ```
    Optional flags for directory locks:
-   - `--allowed="sub1,sub2"` — subdirs always writable (e.g. `plans,projects` under `.claude`)
-   - `--trusted="hooks,scripts"` — subdirs whose internal scripts are trusted (script-bypass exemption)
+   - `--allowed="sub1,sub2"` — subdirs always **writable** without the phrase (e.g. `plans,projects` under `.claude`)
+   - `--trusted="hooks,scripts"` — subdirs whose scripts may be **executed** without the phrase, while EDITS to them stay gated (script-bypass exemption)
+
+   `--allowed` lifts the edit gate for a subtree; `--trusted` lifts only the
+   execute gate (running a script under it) and keeps edits gated. For the
+   `.claude` config lock, `hooks`, `plugins`, `external_scripts` and `skills`
+   are trusted-for-execute by default (so plugin skill scripts run without an
+   unlock; editing them still requires the phrase — see GH-637).
 
 5. Print the script output verbatim.
 

--- a/plugins/heimdall/tests/e2e/shared-cross-project.spec.js
+++ b/plugins/heimdall/tests/e2e/shared-cross-project.spec.js
@@ -118,12 +118,10 @@ describe('shared lock from project A blocks op invoked from project B', () => {
       /edit shared target/,
       `stderr should reference unlock phrase: ${res.stderr}`
     );
-    // Note: Operator-authorized contract loosening — earlier draft asserted
-    // a literal "(shared)" token and a case-insensitive /shared/i match in
-    // the rejection stderr. Production rejection format does not emit those
-    // tokens, and Task 11 forbids production edits, so the cross-project-
-    // origin contract here is reduced to "block + unlock phrase surfaces".
-    // The remaining assertions (exit 2, no-block / override paths in other
-    // tests) still prove the shared store gated project B.
+    // AC8 (GH-585): the rejection must surface that the blocking lock came from
+    // the shared (cross-project) store, so the user isn't confused by a block
+    // with no origin in project B's own config.
+    assert.match(res.stderr, /\(shared\)/, `stderr should carry the (shared) token: ${res.stderr}`);
+    assert.match(res.stderr, /shared/i, `stderr should mention shared origin: ${res.stderr}`);
   });
 });


### PR DESCRIPTION
## Summary

Comprehensive Heimdall hardening from a 4-source review (conversation transcripts, `../tasks`, open issues, open PRs). Closes a real security bypass and cuts the false positives that were wedging agents.

Closes #655
Closes #656
Closes #658
Closes #585
Closes #637
Closes #642

(#657 intentionally NOT closed — see Notes.)

## Security — obfuscation bypass (#655)

Both guards matched protected paths against the **literal** command text after only `~`/`$HOME` expansion, but the shell expands globs/quotes/braces/backslashes first — so a protected path could be named in a form the guard never saw. Reproduced against **both** the lock guard and the conceal guard (all returned exit 0):

- glob bracket `…/.c[l]aude/…`, wildcard `…/.cl*ude/…`, quote-split `…/.cl""aude/…`, backslash `…/.cla\ude/…`, brace `…/.{cl,x}aude/…`

New `lib/guard/shell-normalize.js` (dequote, single-char-class reduction, brace expansion, anchored glob→marker/path matching) is wired into `bash.js` and the conceal hook, **fail-closed**. Wildcard matches are anchored on a substantial literal prefix/suffix so short markers (`ui`, `db`) are not re-flagged — no #642 regression.

## False positives (over-blocking)

- **#656** — interpreter reads that merely name a protected path (`node -e "require('X/config')"`, `require('./package.json')`) are no longer treated as writes. Genuine interpreter writes (redirect or write API, incl. python `r+` update mode) still block.
- **#658** — the file-tool temp-path exemption now also applies on the bash marker path, so writing into a throwaway `/tmp/**/.claude` fixture is not blocked.

## UX / config

- **#585** — the store kind is threaded through to the rejection message; a block from the shared (cross-project) store now emits a `(shared)` origin token. Loosened cross-project e2e assertions restored (AC8 from #541).
- **#637** — `skills` added to the `claude-config` catalog `trustedSubdirs` (execute-trusted, **edit still gated**); execute-vs-edit distinction documented in the protect skill.
- **#642** — regression test proving a `./`-prefixed write stays blocked; corrected an assertion that treated `node -e "require('ui')"` (a read) as a write.

## Tests

Full Heimdall suite: **173 passing** (was 83). New: shell-normalize unit tests; engine + conceal obfuscation matrices; temp-path parity; interpreter-read; script-bypass correlation; skills execute-vs-edit; shared-origin e2e; `./`-prefix boundary.

## Notes

**#657 kept fail-closed (not fixed here).** Correlating a script's write op to the protected path via static content analysis is not bypass-proof — the target can be stored in a variable, built with `path.join`, or concatenated, so every static heuristic leaves an indirection gap (confirmed in review). Per the fail-closed policy, `scripts-bypass` keeps its original broad rule: a non-trusted script that references a protected marker and performs any write is blocked. Legitimate scripts are exempted by location (`trustedSubdirs`) or a one-time unlock. #657 stays open; a safe fix needs runtime, not static, analysis.

Also deferred (needs config/allow-list design, not a matcher change): the conceal guard flagging a sanctioned broker read (`sudo run-qc.sh`) as a block — tracked in #658.
