### PR TITLE
feat(synapsys): zero-config default cortex recall provider bridge (GH-662)

### DIFF
--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -514,7 +514,7 @@ Both phases reach cortex through an **injected provider**, not by calling the MC
 Notes on the default bridge:
 
 - **Node >= 22.5 required** — the bridge uses the built-in `node:sqlite` module (experimental). On older Nodes it reports "unavailable" and recall stays disabled; nothing crashes.
-- **Keyword + recency, not semantic** — the hook path has no embedder, so the bridge ranks rows by how many query keywords their content matches (then by recency), capped at 5 per query. Results are shaped `{ id, savedAt, title, body, ageDays }` and still pass the downstream `max_age_days` / `max_results_per_query` budgets.
+- **Keyword + recency, not semantic** — the hook path has no embedder, so the bridge ranks rows by how many query keywords their content matches (then by recency), capped at 5 per query. Rows older than `max_age_days` are excluded inside the query itself (so stale rows can never crowd fresher eligible ones out of the cap), and results — shaped `{ id, savedAt, title, body, ageDays }` — still pass the downstream `max_age_days` / `max_results_per_query` budgets.
 - **Read-only** — the bridge opens the db with `readOnly: true` and never writes memories (R17).
 - The kill switch `SYNAPSYS_CORTEX_AUTO_RECALL=off` still disables **everything**, bridge included (see [Kill-switch](#kill-switch)).
 

--- a/plugins/synapsys/README.md
+++ b/plugins/synapsys/README.md
@@ -485,11 +485,11 @@ The `--last <Nd>` flag filters telemetry `.jsonl` files by `mtime`; default is `
 
 ## Cortex auto-recall
 
-Synapsys surfaces prior-session insights from cortex without any agent action. There are two phases, both deterministic (no LLM call) and both fail-open — if no recall provider is configured (see [Recall provider](#recall-provider--synapsys_cortex_recall_module)), nothing is injected and the session proceeds normally.
+Synapsys surfaces prior-session insights from cortex without any agent action. There are two phases, both deterministic (no LLM call) and both fail-open — if no recall provider resolves (see [Recall provider](#recall-provider--synapsys_cortex_recall_module)), nothing is injected and the session proceeds normally.
 
 ### Phase 1 — SessionStart recall
 
-Phase 1 runs **only when a recall provider is resolvable** (see [Recall provider](#recall-provider--synapsys_cortex_recall_module)). With no provider — the shipped default — SessionStart schedules nothing, writes no cache, and injects nothing; the session is entirely unaffected and no marker is emitted.
+Phase 1 runs **only when a recall provider is resolvable** (see [Recall provider](#recall-provider--synapsys_cortex_recall_module)): an explicit `SYNAPSYS_CORTEX_RECALL_MODULE`, or the zero-config default bridge when a cortex sqlite store is detectable (GH-662). With no resolvable provider, SessionStart schedules nothing, writes no cache, and injects nothing; the session is entirely unaffected and no marker is emitted.
 
 When a provider *is* configured: on `SessionStart`, synapsys schedules a fire-and-forget background recall that issues **two bounded provider `recall` calls** (the provider's bridge to `cortex_recall`): one keyed on the ticket id, and one on derived keywords from the session context. Results are persisted to a per-session cache file. At the **next `UserPromptSubmit` boundary**, synapsys reads the cache and injects a `[cortex:auto-recall]` block into its existing stdout channel — the same channel that already carries matched-memory bodies. When a configured provider's query returns nothing, an empty marker line is emitted (the recall genuinely ran and found nothing):
 
@@ -505,9 +505,20 @@ Add an optional `cortex_query:` field to any memory's frontmatter. When that mem
 
 ### Recall provider — `SYNAPSYS_CORTEX_RECALL_MODULE`
 
-Both phases reach cortex through an **injected provider module**, not by calling the MCP tool directly. The Phase 1 background worker is a detached Node process and the Phase 2 inline path runs inside the hook — neither can invoke an MCP tool, which is only reachable by the live agent. Instead, each resolves a recall function from the `SYNAPSYS_CORTEX_RECALL_MODULE` env var: a path to a Node module exporting `recall(query, projectId) → Array | Promise<Array>`.
+Both phases reach cortex through an **injected provider**, not by calling the MCP tool directly. The Phase 1 background worker is a detached Node process and the Phase 2 inline path runs inside the hook — neither can invoke an MCP tool, which is only reachable by the live agent. Both paths resolve their recall function through the single shared resolver in `lib/cortex-provider.js`, in this order:
 
-**The shipped hook sets no default module, so out of the box both phases resolve to an empty stub and inject nothing — this is intentional, not a bug.** Auto-recall is opt-in: an integrator who wants live results points `SYNAPSYS_CORTEX_RECALL_MODULE` at a bridge module that reads from their cortex store (e.g. a thin wrapper over the cortex CLI/storage). Resolution is fail-open — an unset, unloadable, or malformed module degrades silently to the empty stub (R14), so a misconfigured provider never breaks a session.
+1. **Explicit module** — `SYNAPSYS_CORTEX_RECALL_MODULE` set: a path to a Node module exporting `recall(query, projectId) → Array | Promise<Array>`. A valid module always wins. A set-but-broken (unloadable/malformed) module disables recall entirely — the default bridge is **never** used as a fallback for an explicitly configured module.
+2. **Default bridge (zero-config, GH-662)** — env var unset: synapsys probes for a cortex sqlite store at `~/.cortex/memory.db` (override the path with `SYNAPSYS_CORTEX_DB`). When the db exists, opens read-only, and has a `memories` table, `lib/cortex-bridge.js` serves recalls directly from it — no configuration needed.
+3. **Disabled** — neither resolves: both phases inject nothing and the session proceeds normally.
+
+Notes on the default bridge:
+
+- **Node >= 22.5 required** — the bridge uses the built-in `node:sqlite` module (experimental). On older Nodes it reports "unavailable" and recall stays disabled; nothing crashes.
+- **Keyword + recency, not semantic** — the hook path has no embedder, so the bridge ranks rows by how many query keywords their content matches (then by recency), capped at 5 per query. Results are shaped `{ id, savedAt, title, body, ageDays }` and still pass the downstream `max_age_days` / `max_results_per_query` budgets.
+- **Read-only** — the bridge opens the db with `readOnly: true` and never writes memories (R17).
+- The kill switch `SYNAPSYS_CORTEX_AUTO_RECALL=off` still disables **everything**, bridge included (see [Kill-switch](#kill-switch)).
+
+Resolution is fail-open throughout (R14) — a misconfigured provider or an undetectable bridge never breaks a session. Run `/synapsys recall` to see which provider is in effect.
 
 ### Config knobs
 
@@ -533,9 +544,10 @@ Set the env var `SYNAPSYS_CORTEX_AUTO_RECALL=off` (case-insensitive) to disable 
 
 ### Inspecting activity — `synapsys recall`
 
-Run `/synapsys recall` (or `node plugins/synapsys/scripts/synapsys-recall.js`) to see the current session's auto-recall activity. It prints one line per query that ran this session with its result count:
+Run `/synapsys recall` (or `node plugins/synapsys/scripts/synapsys-recall.js`) to see the current session's auto-recall activity. It first prints the resolved recall provider — `provider: module <path>`, `provider: default bridge (cortex sqlite, read-only): <db path>`, or `provider: none (<reason>)` — then one line per query that ran this session with its result count:
 
 ```
+provider: default bridge (cortex sqlite, read-only): /home/me/.cortex/memory.db
 - <query string> → 3 results
 - <other query> → 1 result
 ```

--- a/plugins/synapsys/lib/__tests__/cortex-bridge.test.js
+++ b/plugins/synapsys/lib/__tests__/cortex-bridge.test.js
@@ -241,6 +241,34 @@ test('recall: caps results at 5', { skip: !sqlite }, async () => {
   }
 });
 
+test('recall: stale high-hit rows cannot crowd a fresh row out of the LIMIT (in-query age cutoff)', {
+  skip: !sqlite,
+}, () => {
+  const dir = mkTmp();
+  try {
+    const file = path.join(dir, 'memory.db');
+    // Six stale (200d) two-keyword rows would fill the LIMIT-5 window ahead of
+    // the fresh one-keyword row; downstream formatBlock would then drop all
+    // five as older than max_age_days (180) and render a false "no matches".
+    const rows = [];
+    for (let i = 0; i < 6; i += 1) {
+      rows.push({ content: `alpha beta stale row ${i}`, timestamp: isoDaysAgo(200) });
+    }
+    rows.push({ content: 'alpha fresh row', timestamp: isoDaysAgo(5) });
+    makeDb(file, rows);
+
+    const out = bridge.recall('alpha beta', '', { env: { SYNAPSYS_CORTEX_DB: file } });
+    assert.equal(out.length, 1, 'stale rows are filtered in the query, not post-LIMIT');
+    assert.match(out[0].body, /alpha fresh row/);
+    assert.ok(
+      out.every((r) => r.ageDays <= 180),
+      'no returned row is past the age window'
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('recall: missing db / any error fails open to []', async () => {
   const out = await bridge.recall('alpha keywords', '', {
     env: { SYNAPSYS_CORTEX_DB: path.join(os.tmpdir(), 'no-such-cortex-db-662', 'memory.db') },

--- a/plugins/synapsys/lib/__tests__/cortex-bridge.test.js
+++ b/plugins/synapsys/lib/__tests__/cortex-bridge.test.js
@@ -1,0 +1,265 @@
+'use strict';
+
+/**
+ * Unit tests for lib/cortex-bridge — the zero-config default cortex recall
+ * provider (GH-662). Fixture dbs are created with `node:sqlite`, so every test
+ * that touches sqlite SKIPS cleanly on Node < 22.5 (CI runs Node 20 and 22).
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const bridge = require('../cortex-bridge');
+
+/** node:sqlite when this runtime has it, else null (tests skip). */
+const sqlite = (() => {
+  try {
+    return require('node:sqlite');
+  } catch {
+    return null;
+  }
+})();
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cortex-bridge-'));
+}
+
+const MEMORIES_DDL =
+  'CREATE TABLE memories (id INTEGER PRIMARY KEY, content TEXT, content_hash TEXT, ' +
+  'embedding BLOB, project_id TEXT, source_session TEXT, timestamp TEXT, created_at TEXT)';
+
+/** Create a fixture cortex db with the real `memories` schema plus rows. */
+function makeDb(file, rows = []) {
+  const db = new sqlite.DatabaseSync(file);
+  try {
+    db.exec(MEMORIES_DDL);
+    const ins = db.prepare(
+      'INSERT INTO memories (content, project_id, timestamp, created_at) VALUES (?, ?, ?, ?)'
+    );
+    for (const r of rows) {
+      ins.run(r.content, r.projectId ?? '', r.timestamp ?? new Date().toISOString(), null);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function isoDaysAgo(days) {
+  return new Date(Date.now() - days * 86400000).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// detect
+// ---------------------------------------------------------------------------
+
+test('detect: missing db file → unavailable with the resolved path in the reason', () => {
+  const dir = mkTmp();
+  try {
+    const missing = path.join(dir, 'nope', 'memory.db');
+    const out = bridge.detect({ env: { SYNAPSYS_CORTEX_DB: missing } });
+    assert.equal(out.available, false);
+    // Reason differs by cause: no sqlite on this Node, else the missing path.
+    if (sqlite) assert.ok(out.reason.includes(missing), `reason names the path: ${out.reason}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('detect: default path is <home>/.cortex/memory.db when SYNAPSYS_CORTEX_DB is unset', () => {
+  const dir = mkTmp();
+  try {
+    assert.equal(
+      bridge.dbPath({ home: dir, env: {} }),
+      path.join(dir, '.cortex', 'memory.db'),
+      'dbPath falls back to the home-relative default'
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('detect: valid fixture db → available', { skip: !sqlite }, () => {
+  const dir = mkTmp();
+  try {
+    const file = path.join(dir, 'memory.db');
+    makeDb(file, [{ content: 'hello world' }]);
+    const out = bridge.detect({ env: { SYNAPSYS_CORTEX_DB: file } });
+    assert.deepEqual(out, { available: true, reason: 'ok' });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('detect: db without a memories table → unavailable', { skip: !sqlite }, () => {
+  const dir = mkTmp();
+  try {
+    const file = path.join(dir, 'other.db');
+    const db = new sqlite.DatabaseSync(file);
+    db.exec('CREATE TABLE not_memories (id INTEGER)');
+    db.close();
+    const out = bridge.detect({ env: { SYNAPSYS_CORTEX_DB: file } });
+    assert.equal(out.available, false);
+    assert.match(out.reason, /memories table/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// recall
+// ---------------------------------------------------------------------------
+
+test('recall: ranks a two-keyword match above a one-keyword match', { skip: !sqlite }, async () => {
+  const dir = mkTmp();
+  try {
+    const file = path.join(dir, 'memory.db');
+    makeDb(file, [
+      { content: 'alpha only note', timestamp: isoDaysAgo(0) },
+      { content: 'alpha beta both keywords here', timestamp: isoDaysAgo(30) },
+    ]);
+    const out = await bridge.recall('alpha beta', '', { env: { SYNAPSYS_CORTEX_DB: file } });
+    assert.equal(out.length, 2);
+    assert.match(out[0].body, /alpha beta both/, 'older two-keyword row still ranks first');
+    assert.match(out[1].body, /alpha only/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('recall: filters by projectId; empty projectId matches all projects', {
+  skip: !sqlite,
+}, async () => {
+  const dir = mkTmp();
+  try {
+    const file = path.join(dir, 'memory.db');
+    makeDb(file, [
+      { content: 'alpha in project one', projectId: 'proj-one' },
+      { content: 'alpha in project two', projectId: 'proj-two' },
+    ]);
+    const opts = { env: { SYNAPSYS_CORTEX_DB: file } };
+
+    const scoped = await bridge.recall('alpha', 'proj-one', opts);
+    assert.equal(scoped.length, 1);
+    assert.match(scoped[0].body, /project one/);
+
+    const all = await bridge.recall('alpha', '', opts);
+    assert.equal(all.length, 2, 'empty projectId applies no project filter');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('recall: LIKE wildcards in content do not over-match (escaping)', {
+  skip: !sqlite,
+}, async () => {
+  const dir = mkTmp();
+  try {
+    const file = path.join(dir, 'memory.db');
+    makeDb(file, [
+      { content: 'progress at 100pct done' },
+      { content: 'completely unrelated topic' },
+    ]);
+    const opts = { env: { SYNAPSYS_CORTEX_DB: file } };
+    // Tokenizer strips symbols, so "100%" yields the keyword "100" — only the
+    // row actually containing it may match, never everything.
+    const out = await bridge.recall('100% milestone', '', opts);
+    assert.equal(out.length, 1);
+    assert.match(out[0].body, /100pct/);
+    // Defense in depth: a wildcard inside a would-be token is escaped, not raw.
+    assert.equal(bridge.escapeLike('50%_x\\'), '50\\%\\_x\\\\');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('recall: result shape is {id, savedAt, title, body, ageDays}', { skip: !sqlite }, async () => {
+  const dir = mkTmp();
+  try {
+    const file = path.join(dir, 'memory.db');
+    const savedAt = isoDaysAgo(10);
+    const longFirstLine = `heimdall guard blocks its own git commands ${'x'.repeat(60)}`;
+    makeDb(file, [{ content: `${longFirstLine}\nsecond line body`, timestamp: savedAt }]);
+
+    const out = await bridge.recall('heimdall guard', '', { env: { SYNAPSYS_CORTEX_DB: file } });
+    assert.equal(out.length, 1);
+    const r = out[0];
+    assert.equal(typeof r.id, 'number');
+    assert.equal(r.savedAt, savedAt, 'savedAt is the row timestamp');
+    assert.equal(r.title.length, 61, 'title is the first line cut to 60 chars + ellipsis');
+    assert.ok(r.title.endsWith('…'));
+    assert.equal(r.body, `${longFirstLine}\nsecond line body`, 'body is the full content');
+    assert.equal(r.ageDays, 10, 'ageDays is whole days since savedAt');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('recall: invalid timestamp degrades to ageDays 0', { skip: !sqlite }, async () => {
+  const dir = mkTmp();
+  try {
+    const file = path.join(dir, 'memory.db');
+    makeDb(file, [{ content: 'alpha bad timestamp row', timestamp: 'not-a-date' }]);
+    const out = await bridge.recall('alpha', '', { env: { SYNAPSYS_CORTEX_DB: file } });
+    assert.equal(out.length, 1);
+    assert.equal(out[0].ageDays, 0);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('recall: a query with zero usable keywords returns []', { skip: !sqlite }, async () => {
+  const dir = mkTmp();
+  try {
+    const file = path.join(dir, 'memory.db');
+    makeDb(file, [{ content: 'the and for with — all stopwords in here' }]);
+    const opts = { env: { SYNAPSYS_CORTEX_DB: file } };
+    assert.deepEqual(await bridge.recall('the and for with', '', opts), [], 'stopwords only');
+    assert.deepEqual(await bridge.recall('a of %% __', '', opts), [], 'short tokens + symbols');
+    assert.deepEqual(await bridge.recall('', '', opts), [], 'empty query');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('recall: caps results at 5', { skip: !sqlite }, async () => {
+  const dir = mkTmp();
+  try {
+    const file = path.join(dir, 'memory.db');
+    const rows = [];
+    for (let i = 0; i < 8; i += 1) {
+      rows.push({ content: `alpha row number ${i}`, timestamp: isoDaysAgo(i) });
+    }
+    makeDb(file, rows);
+    const out = await bridge.recall('alpha', '', { env: { SYNAPSYS_CORTEX_DB: file } });
+    assert.equal(out.length, 5);
+    assert.match(out[0].body, /number 0/, 'equal-hit rows order by recency');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('recall: missing db / any error fails open to []', async () => {
+  const out = await bridge.recall('alpha keywords', '', {
+    env: { SYNAPSYS_CORTEX_DB: path.join(os.tmpdir(), 'no-such-cortex-db-662', 'memory.db') },
+  });
+  assert.deepEqual(out, []);
+});
+
+test('recall: returns a plain Array SYNCHRONOUSLY (not a Promise) — Phase 2 appendCortexQuery cannot await', {
+  skip: !sqlite,
+}, () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cortex-bridge-sync-'));
+  try {
+    const file = path.join(dir, 'memory.db');
+    makeDb(file, [{ content: 'sync contract row', timestamp: isoDaysAgo(1) }]);
+    const out = bridge.recall('sync contract', '', { env: { SYNAPSYS_CORTEX_DB: file } });
+    assert.ok(Array.isArray(out), 'recall must return an Array, not a Promise/thenable');
+    assert.equal(typeof out.then, 'undefined', 'recall return value must not be thenable');
+    assert.equal(out.length, 1);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/plugins/synapsys/lib/__tests__/cortex-provider.test.js
+++ b/plugins/synapsys/lib/__tests__/cortex-provider.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+/**
+ * Unit tests for lib/cortex-provider — the single shared recall-provider
+ * resolver (GH-662). Precedence under test: explicit
+ * `SYNAPSYS_CORTEX_RECALL_MODULE` > default cortex-bridge > disabled, with a
+ * broken explicit module NEVER falling back to the bridge. Bridge fixtures
+ * need `node:sqlite`, so those tests skip on Node < 22.5.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { resolveRecall } = require('../cortex-provider');
+
+const sqlite = (() => {
+  try {
+    return require('node:sqlite');
+  } catch {
+    return null;
+  }
+})();
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cortex-provider-'));
+}
+
+/** Create a fixture cortex db (real `memories` schema) with one row. */
+function makeDb(dir) {
+  const file = path.join(dir, 'memory.db');
+  const db = new sqlite.DatabaseSync(file);
+  db.exec(
+    'CREATE TABLE memories (id INTEGER PRIMARY KEY, content TEXT, content_hash TEXT, ' +
+      'embedding BLOB, project_id TEXT, source_session TEXT, timestamp TEXT, created_at TEXT)'
+  );
+  db.prepare('INSERT INTO memories (content, project_id, timestamp) VALUES (?, ?, ?)').run(
+    'bridge fixture memory about rebasing',
+    '',
+    new Date().toISOString()
+  );
+  db.close();
+  return file;
+}
+
+test('explicit valid module wins over an available bridge', { skip: !sqlite }, async () => {
+  const dir = mkTmp();
+  try {
+    const dbFile = makeDb(dir);
+    const modFile = path.join(dir, 'provider-valid.js');
+    fs.writeFileSync(
+      modFile,
+      "'use strict';\nmodule.exports = { recall: (q, p) => [{ id: 'from-module', q, p }] };\n"
+    );
+
+    const out = resolveRecall({
+      env: { SYNAPSYS_CORTEX_RECALL_MODULE: modFile, SYNAPSYS_CORTEX_DB: dbFile },
+      home: dir,
+    });
+    assert.equal(out.provider, 'module');
+    assert.equal(out.source, modFile);
+    const results = await out.recall('rebasing', '');
+    assert.equal(results[0].id, 'from-module', 'the module, not the bridge, serves recall');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('explicit broken module → recall null; the bridge is NOT used as fallback', {
+  skip: !sqlite,
+}, () => {
+  const dir = mkTmp();
+  try {
+    const dbFile = makeDb(dir); // bridge WOULD be available…
+    const out = resolveRecall({
+      env: {
+        SYNAPSYS_CORTEX_RECALL_MODULE: path.join(dir, 'no-such-provider.js'),
+        SYNAPSYS_CORTEX_DB: dbFile,
+      },
+      home: dir,
+    });
+    assert.equal(out.recall, null, 'a configured-but-broken module disables recall');
+    assert.equal(out.provider, null);
+    assert.equal(out.source, 'module-error');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('module exporting no recall function → recall null (never the bridge)', {
+  skip: !sqlite,
+}, () => {
+  const dir = mkTmp();
+  try {
+    const dbFile = makeDb(dir);
+    const modFile = path.join(dir, 'provider-malformed.js');
+    fs.writeFileSync(modFile, "'use strict';\nmodule.exports = { notRecall: true };\n");
+    const out = resolveRecall({
+      env: { SYNAPSYS_CORTEX_RECALL_MODULE: modFile, SYNAPSYS_CORTEX_DB: dbFile },
+      home: dir,
+    });
+    assert.equal(out.recall, null);
+    assert.equal(out.provider, null);
+    assert.equal(out.source, 'module-error');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('env unset + available bridge → the default bridge serves recall', {
+  skip: !sqlite,
+}, async () => {
+  const dir = mkTmp();
+  try {
+    const dbFile = makeDb(dir);
+    const out = resolveRecall({ env: { SYNAPSYS_CORTEX_DB: dbFile }, home: dir });
+    assert.equal(out.provider, 'bridge');
+    assert.equal(out.source, dbFile, 'source is the resolved db path');
+    const results = await out.recall('rebasing', '');
+    assert.equal(results.length, 1);
+    assert.match(results[0].body, /rebasing/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('env unset + no detectable bridge → recall null with the detect reason', () => {
+  const dir = mkTmp();
+  try {
+    const out = resolveRecall({
+      env: { SYNAPSYS_CORTEX_DB: path.join(dir, 'absent', 'memory.db') },
+      home: dir,
+    });
+    assert.equal(out.recall, null);
+    assert.equal(out.provider, null);
+    assert.equal(typeof out.source, 'string');
+    assert.ok(out.source.length > 0, 'source carries the human-readable detect reason');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/plugins/synapsys/lib/cortex-bridge.js
+++ b/plugins/synapsys/lib/cortex-bridge.js
@@ -25,6 +25,8 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+const cortexConfig = require('./cortex-config');
+
 /** Max results per recall call — downstream re-caps via max_results_per_query. */
 const MAX_RESULTS = 5;
 
@@ -149,12 +151,42 @@ function buildQuery(tokens) {
   const like = "content LIKE ? ESCAPE '\\'";
   const hits = tokens.map(() => `(${like})`).join(' + ');
   const anyMatch = tokens.map(() => like).join(' OR ');
+  // Age cutoff INSIDE the query: downstream formatBlock drops results older
+  // than max_age_days AFTER the LIMIT, so without this a handful of stale
+  // high-hit rows could crowd out a fresh eligible row inside the LIMIT and
+  // render a false "no matches". ISO-8601 text compares chronologically.
+  // Rows with no usable date at all stay eligible (they map to ageDays 0
+  // downstream, matching the pre-cutoff behavior).
+  const notStale =
+    '(COALESCE(timestamp, created_at) >= ? OR COALESCE(timestamp, created_at) IS NULL)';
   const sql =
     'SELECT id, content, timestamp, created_at, ' +
     `(${hits}) AS hits FROM memories ` +
-    `WHERE (project_id = ? OR ? = '') AND (${anyMatch}) ` +
+    `WHERE (project_id = ? OR ? = '') AND ${notStale} AND (${anyMatch}) ` +
     `ORDER BY hits DESC, timestamp DESC LIMIT ${MAX_RESULTS}`;
   return sql;
+}
+
+/**
+ * ISO cutoff for the in-query age filter, aligned with the same
+ * `max_age_days` budget `formatBlock` applies downstream (config-overridable,
+ * default 180). Fail-open: any config error → the default window.
+ *
+ * @param {{ home?: string, env?: object }} [opts]
+ * @returns {string} ISO-8601 timestamp; rows saved before it are stale
+ */
+function ageCutoffIso(opts = {}) {
+  let days = cortexConfig.DEFAULTS.max_age_days;
+  try {
+    const home = opts.home || (opts.env || process.env).HOME || os.homedir();
+    const config = cortexConfig.loadConfig({ home, env: opts.env || process.env });
+    if (Number.isFinite(config.max_age_days) && config.max_age_days > 0) {
+      days = config.max_age_days;
+    }
+  } catch {
+    // Fail-open to the default window.
+  }
+  return new Date(Date.now() - days * 86400000).toISOString();
 }
 
 /** LIKE parameter (`%kw%`, wildcards escaped) for one token. */
@@ -212,8 +244,11 @@ function recall(query, projectId, opts = {}) {
     db = new sqlite.DatabaseSync(dbPath(opts), { readOnly: true });
     const likes = tokens.map(likeParam);
     const project = String(projectId || '');
-    // Param order mirrors buildQuery: hit-count LIKEs, project pair, any-match LIKEs.
-    const rows = db.prepare(buildQuery(tokens)).all(...likes, project, project, ...likes);
+    // Param order mirrors buildQuery: hit-count LIKEs, project pair, age
+    // cutoff, any-match LIKEs.
+    const rows = db
+      .prepare(buildQuery(tokens))
+      .all(...likes, project, project, ageCutoffIso(opts), ...likes);
     return rows.map(toResult);
   } catch {
     return [];

--- a/plugins/synapsys/lib/cortex-bridge.js
+++ b/plugins/synapsys/lib/cortex-bridge.js
@@ -1,0 +1,225 @@
+'use strict';
+
+/**
+ * Default cortex recall bridge (GH-662) — zero-config provider that reads the
+ * cortex memory store (`~/.cortex/memory.db`, SQLite) directly, read-only.
+ *
+ * This is the shipped fallback behind `lib/cortex-provider.js`: when
+ * `SYNAPSYS_CORTEX_RECALL_MODULE` is unset and a cortex db is detectable, both
+ * auto-recall phases use this module's `recall(query, projectId)` instead of
+ * silently disabling. An explicitly configured module ALWAYS wins — this
+ * bridge is never a fallback for a broken module (see cortex-provider).
+ *
+ * Honest scope: the db stores embeddings but the hook path has no embedder, so
+ * this bridge does keyword+recency recall, NOT semantic search. Rows are
+ * ranked by matched-keyword count, then recency, capped at 5.
+ *
+ * SQLite access uses `node:sqlite` (Node >= 22.5, experimental) — probed once
+ * in a try/catch so Node 20 degrades to "unavailable" instead of crashing.
+ * Every entry point is fail-open: any error → unavailable / empty results.
+ *
+ * @module lib/cortex-bridge
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+/** Max results per recall call — downstream re-caps via max_results_per_query. */
+const MAX_RESULTS = 5;
+
+/** Tokens too generic to discriminate; dropped before the LIKE match. */
+const STOPWORDS = new Set([
+  'the',
+  'and',
+  'for',
+  'with',
+  'this',
+  'that',
+  'from',
+  'into',
+  'use',
+  'using',
+]);
+
+/**
+ * Probe result for `node:sqlite`, cached so the ExperimentalWarning the require
+ * prints on stderr is emitted at most once per process.
+ * @type {{ mod: object|null }|null}
+ */
+let sqliteProbe = null;
+
+/** Load `node:sqlite` once; null when this Node has no sqlite (< 22.5). */
+function loadSqlite() {
+  if (sqliteProbe) return sqliteProbe.mod;
+  try {
+    const mod = require('node:sqlite');
+    sqliteProbe = { mod: typeof mod.DatabaseSync === 'function' ? mod : null };
+  } catch {
+    sqliteProbe = { mod: null };
+  }
+  return sqliteProbe.mod;
+}
+
+/**
+ * Resolve the cortex db path: `SYNAPSYS_CORTEX_DB` override, else
+ * `<home>/.cortex/memory.db`.
+ *
+ * @param {{ home?: string, env?: object }} [opts]
+ * @returns {string}
+ */
+function dbPath({ home, env } = {}) {
+  const e = env || process.env;
+  const override = String(e.SYNAPSYS_CORTEX_DB || '').trim();
+  if (override) return override;
+  const h = home || e.HOME || os.homedir();
+  return path.join(h, '.cortex', 'memory.db');
+}
+
+/**
+ * Detect whether the default bridge can serve recalls in this environment:
+ * `node:sqlite` loadable, the db file exists, it opens read-only, and it has a
+ * `memories` table. Never throws.
+ *
+ * @param {{ home?: string, env?: object }} [opts]
+ * @returns {{ available: boolean, reason: string }}
+ */
+function detect(opts = {}) {
+  const sqlite = loadSqlite();
+  if (!sqlite) {
+    return { available: false, reason: 'node:sqlite unavailable (bridge requires Node >= 22.5)' };
+  }
+  const file = dbPath(opts);
+  if (!fs.existsSync(file)) {
+    return { available: false, reason: `no cortex db at ${file}` };
+  }
+  let db = null;
+  try {
+    db = new sqlite.DatabaseSync(file, { readOnly: true });
+    const row = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memories'")
+      .get();
+    if (!row) return { available: false, reason: `no memories table in ${file}` };
+    return { available: true, reason: 'ok' };
+  } catch {
+    return { available: false, reason: `cannot open cortex db read-only at ${file}` };
+  } finally {
+    closeQuietly(db);
+  }
+}
+
+/** Close a DatabaseSync without letting a close error escape. */
+function closeQuietly(db) {
+  try {
+    if (db) db.close();
+  } catch {
+    // Read-only handle; a failed close leaks nothing worth crashing over.
+  }
+}
+
+/**
+ * Tokenize a recall query into deduplicated lowercase keywords: split on
+ * non-alphanumerics, drop tokens shorter than 3 chars and stopwords.
+ *
+ * @param {string} query
+ * @returns {string[]}
+ */
+function tokenize(query) {
+  const tokens = String(query || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+  return [...new Set(tokens)];
+}
+
+/** Escape LIKE wildcards (`%`, `_`) and the escape char itself for ESCAPE '\'. */
+function escapeLike(token) {
+  return token.replace(/[\\%_]/g, '\\$&');
+}
+
+/**
+ * Build the ranked keyword query: rows matching ANY keyword, scored by how
+ * many keywords they match (LIKE is 0/1 in SQLite, so the sum is the hit
+ * count), tie-broken by recency.
+ *
+ * @param {string[]} tokens lowercase keywords
+ * @returns {string} parameterized SQL (bind: hit LIKEs, projectId ×2, any-match LIKEs)
+ */
+function buildQuery(tokens) {
+  const like = "content LIKE ? ESCAPE '\\'";
+  const hits = tokens.map(() => `(${like})`).join(' + ');
+  const anyMatch = tokens.map(() => like).join(' OR ');
+  const sql =
+    'SELECT id, content, timestamp, created_at, ' +
+    `(${hits}) AS hits FROM memories ` +
+    `WHERE (project_id = ? OR ? = '') AND (${anyMatch}) ` +
+    `ORDER BY hits DESC, timestamp DESC LIMIT ${MAX_RESULTS}`;
+  return sql;
+}
+
+/** LIKE parameter (`%kw%`, wildcards escaped) for one token. */
+function likeParam(token) {
+  return `%${escapeLike(token)}%`;
+}
+
+/**
+ * Map a `memories` row to the provider result shape `cortex-format.formatLine`
+ * consumes: `{ id, savedAt, title, body, ageDays }`.
+ *
+ * @param {{ id: number|string, content: string, timestamp?: string, created_at?: string }} row
+ * @returns {{ id: number|string, savedAt: string, title: string, body: string, ageDays: number }}
+ */
+function toResult(row) {
+  const content = String(row.content || '');
+  const savedAt = String(row.timestamp || row.created_at || '');
+  const firstLine = content.split('\n', 1)[0].trim();
+  const title = firstLine.length > 60 ? `${firstLine.slice(0, 60)}…` : firstLine;
+  return { id: row.id, savedAt, title, body: content, ageDays: ageDaysOf(savedAt) };
+}
+
+/** Whole days elapsed since `savedAt`; invalid/future timestamps clamp to 0. */
+function ageDaysOf(savedAt) {
+  const ms = new Date(savedAt).getTime();
+  if (!Number.isFinite(ms)) return 0;
+  return Math.max(0, Math.floor((Date.now() - ms) / 86400000));
+}
+
+/**
+ * Keyword+recency recall against the cortex db. Read-only; fail-open: zero
+ * usable keywords, a missing db, or any sqlite error → `[]`.
+ *
+ * @param {string} query free-text recall query
+ * @param {string} projectId cortex project id ('' = no project filter)
+ * @param {{ home?: string, env?: object }} [opts] db-path resolution overrides
+ *
+ * SYNCHRONOUS by design: the Phase 2 render pipeline (appendCortexQuery in
+ * cortex-hook.js) is synchronous and cannot await — an async recall would
+ * feed a Promise into normalizeRecall, render a false "no matches", and burn
+ * the once-per-session fire marker. node:sqlite DatabaseSync is fully
+ * synchronous, so nothing is lost. (Phase 1's bg worker awaits the return
+ * value, which is a no-op for a plain Array.)
+ *
+ * @returns {Array<{id:number|string,savedAt:string,title:string,body:string,ageDays:number}>}
+ */
+function recall(query, projectId, opts = {}) {
+  let db = null;
+  try {
+    const sqlite = loadSqlite();
+    if (!sqlite) return [];
+    const tokens = tokenize(query);
+    if (tokens.length === 0) return [];
+
+    db = new sqlite.DatabaseSync(dbPath(opts), { readOnly: true });
+    const likes = tokens.map(likeParam);
+    const project = String(projectId || '');
+    // Param order mirrors buildQuery: hit-count LIKEs, project pair, any-match LIKEs.
+    const rows = db.prepare(buildQuery(tokens)).all(...likes, project, project, ...likes);
+    return rows.map(toResult);
+  } catch {
+    return [];
+  } finally {
+    closeQuietly(db);
+  }
+}
+
+module.exports = { detect, recall, dbPath, tokenize, escapeLike, MAX_RESULTS };

--- a/plugins/synapsys/lib/cortex-hook.js
+++ b/plugins/synapsys/lib/cortex-hook.js
@@ -28,6 +28,7 @@ const cortexRecall = require(path.join(__dirname, 'cortex-recall'));
 const sessionCache = require(path.join(__dirname, 'session-cache'));
 const consumeSentinel = require(path.join(__dirname, 'consume-sentinel'));
 const cortexConfig = require(path.join(__dirname, 'cortex-config'));
+const cortexProvider = require(path.join(__dirname, 'cortex-provider'));
 const injectLedger = require(path.join(__dirname, 'inject-ledger'));
 const { formatBlock } = require(path.join(__dirname, 'cortex-format'));
 
@@ -243,21 +244,20 @@ function releaseFireMarker(home, sessionId, memory) {
 /**
  * Resolve the injectable inline-recall function, or null when unavailable.
  *
- * PRODUCTION CONTRACT: cortex is reached through a provider module named by
- * `SYNAPSYS_CORTEX_RECALL_MODULE` (exporting `recall(query, projectId)`), NOT by
+ * PRODUCTION CONTRACT: cortex is reached through an injected provider, NOT by
  * calling the MCP tool — the hook (and the detached Phase 1 worker) cannot
- * invoke an MCP tool, which only the live agent can reach. The shipped hook sets
- * no default module, so auto-recall is opt-in: with the var unset both phases
- * resolve to an empty stub and inject nothing (by design). See README
- * "Recall provider". Fail-open: an unset/unloadable/malformed module → null.
+ * invoke an MCP tool, which only the live agent can reach. Resolution goes
+ * through the single shared `lib/cortex-provider.resolveRecall`: an explicit
+ * `SYNAPSYS_CORTEX_RECALL_MODULE` (exporting `recall(query, projectId)`) wins;
+ * with the var unset the zero-config default bridge (`lib/cortex-bridge`,
+ * read-only keyword recall over `~/.cortex/memory.db`, GH-662) is used when
+ * detectable; otherwise recall is disabled. See README "Recall provider".
+ * Fail-open: an unloadable/malformed module or an undetectable bridge → null
+ * (a broken configured module NEVER falls back to the bridge).
  */
 function resolveInlineRecall() {
-  const modPath = process.env.SYNAPSYS_CORTEX_RECALL_MODULE;
-  if (!modPath) return null;
   try {
-    // Dynamic provider require — path comes from SYNAPSYS_CORTEX_RECALL_MODULE.
-    const mod = require(modPath);
-    return typeof mod.recall === 'function' ? mod.recall.bind(mod) : null;
+    return cortexProvider.resolveRecall({ env: process.env, home: recallHome() }).recall;
   } catch {
     return null;
   }

--- a/plugins/synapsys/lib/cortex-provider.js
+++ b/plugins/synapsys/lib/cortex-provider.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * Single shared recall-provider resolver (GH-662).
+ *
+ * Both auto-recall entry points — the hook's Phase 2 inline recall
+ * (`lib/cortex-hook.resolveInlineRecall`) and the detached Phase 1 worker
+ * (`scripts/synapsys-cortex-recall-bg.resolveRecallFn`) — delegate here so the
+ * provider precedence lives in exactly one place:
+ *
+ *   1. `SYNAPSYS_CORTEX_RECALL_MODULE` set → require it. A valid module (an
+ *      exported `recall` function) wins outright. A set-but-broken module
+ *      resolves to NO provider — the default bridge is NEVER used as a
+ *      fallback for an explicitly configured module (an integrator who set the
+ *      var gets their module or nothing, not silent different behavior).
+ *   2. Env unset → the zero-config default bridge (`lib/cortex-bridge`), when
+ *      `detect()` says a cortex sqlite db is readable on this Node.
+ *   3. Otherwise → no provider (recall disabled), with the detect reason as
+ *      the `source` for status surfaces.
+ *
+ * Fail-open throughout: resolution never throws.
+ *
+ * @module lib/cortex-provider
+ */
+
+const os = require('node:os');
+
+const bridge = require('./cortex-bridge');
+
+/**
+ * Resolve the effective recall provider.
+ *
+ * @param {{ env?: object, home?: string }} [opts]
+ * @returns {{ recall: Function|null, provider: 'module'|'bridge'|null, source: string }}
+ *   `recall(query, projectId) → Array | Promise<Array>` or null when no
+ *   provider resolves; `source` is the module path, the bridge db path, or a
+ *   human-readable reason recall is disabled.
+ */
+function resolveRecall({ env = process.env, home } = {}) {
+  const modPath = String(env.SYNAPSYS_CORTEX_RECALL_MODULE || '').trim();
+  if (modPath) return resolveModule(modPath);
+
+  const resolvedHome = home || env.HOME || os.homedir();
+  const detection = bridge.detect({ home: resolvedHome, env });
+  if (!detection.available) {
+    return { recall: null, provider: null, source: detection.reason };
+  }
+  return {
+    recall: (query, projectId) => bridge.recall(query, projectId, { home: resolvedHome, env }),
+    provider: 'bridge',
+    source: bridge.dbPath({ home: resolvedHome, env }),
+  };
+}
+
+/**
+ * Require an explicitly configured provider module. Unloadable or malformed
+ * (no `recall` function) → no provider — never the bridge (explicit env wins).
+ *
+ * @param {string} modPath value of SYNAPSYS_CORTEX_RECALL_MODULE
+ * @returns {{ recall: Function|null, provider: 'module'|null, source: string }}
+ */
+function resolveModule(modPath) {
+  try {
+    // Dynamic provider require — path comes from SYNAPSYS_CORTEX_RECALL_MODULE.
+    const mod = require(modPath);
+    if (mod && typeof mod.recall === 'function') {
+      return { recall: mod.recall.bind(mod), provider: 'module', source: modPath };
+    }
+  } catch {
+    // Fall through — a broken configured module disables recall (fail-open).
+  }
+  return { recall: null, provider: null, source: 'module-error' };
+}
+
+module.exports = { resolveRecall };

--- a/plugins/synapsys/scripts/synapsys-cortex-recall-bg.js
+++ b/plugins/synapsys/scripts/synapsys-cortex-recall-bg.js
@@ -22,6 +22,7 @@
  */
 
 const cacheLib = require('../lib/session-cache');
+const cortexProvider = require('../lib/cortex-provider');
 
 /** Hard cap on cortex calls per background run (R15). */
 const MAX_QUERIES = 2;
@@ -130,25 +131,30 @@ function applyArg(out, name, value) {
 }
 
 /**
- * Resolve the production recall function from `SYNAPSYS_CORTEX_RECALL_MODULE`,
- * the SAME injected-provider contract Phase 2 inline recall uses
- * (`cortex-hook.resolveInlineRecall`). The detached worker inherits the parent
- * process env, so a configured bridge module is honored here too — without this
- * the worker fell straight through to an empty stub and Phase 1 auto-recall
- * never invoked a real `cortex_recall` in production even when a provider was
- * configured (GH-519 review: "Background recall never calls cortex"). Fail-open:
- * an absent / unloadable / malformed module degrades to the empty stub, so
- * shipped hooks with no cortex provider behave exactly as before.
+ * Resolve the production recall function through the SAME shared resolver
+ * Phase 2 inline recall uses (`lib/cortex-provider.resolveRecall`, GH-662).
+ * The detached worker inherits the parent process env, so an explicitly
+ * configured `SYNAPSYS_CORTEX_RECALL_MODULE` is honored here too — without
+ * this the worker fell straight through to an empty stub and Phase 1
+ * auto-recall never invoked a real `cortex_recall` in production even when a
+ * provider was configured (GH-519 review: "Background recall never calls
+ * cortex"). With the var unset, the zero-config default bridge
+ * (`lib/cortex-bridge`, read-only keyword recall over `~/.cortex/memory.db`)
+ * is used when detectable. Fail-open: a broken configured module or an
+ * undetectable bridge degrades to the empty stub, so shipped hooks with no
+ * cortex store behave exactly as before (a broken module never falls back to
+ * the bridge — explicit env wins).
  *
+ * @param {string} [home] cache/home root from the `--home` flag (bridge db discovery)
  * @returns {(query:string, projectId:string)=>Promise<Array>|Array}
  */
-function resolveRecallFn() {
-  const modPath = process.env.SYNAPSYS_CORTEX_RECALL_MODULE;
-  if (!modPath) return async () => [];
+function resolveRecallFn(home) {
   try {
-    // Dynamic provider require — path comes from SYNAPSYS_CORTEX_RECALL_MODULE.
-    const mod = require(modPath);
-    if (mod && typeof mod.recall === 'function') return mod.recall.bind(mod);
+    const { recall } = cortexProvider.resolveRecall({
+      env: process.env,
+      home: home || undefined,
+    });
+    if (typeof recall === 'function') return recall;
   } catch {
     // Fall through to the empty stub — never crash the detached process (R14).
   }
@@ -157,8 +163,9 @@ function resolveRecallFn() {
 
 /**
  * CLI shell. Parses argv, wires the real session-cache writer, and resolves a
- * recall function (injectable for tests; production uses
- * `SYNAPSYS_CORTEX_RECALL_MODULE` via resolveRecallFn). Never throws — a
+ * recall function (injectable for tests; production resolves through the
+ * shared provider — explicit `SYNAPSYS_CORTEX_RECALL_MODULE`, else the default
+ * cortex-bridge — via resolveRecallFn). Never throws — a
  * top-level failure degrades to a silent no-op so the detached process exits
  * cleanly (R14).
  *
@@ -173,7 +180,7 @@ async function main(argv = process.argv.slice(2), deps = {}) {
   try {
     const { queries, projectId, sessionId, home } = parseArgs(argv);
     const cache = deps.cache || cacheLib;
-    const recallFn = deps.recallFn || resolveRecallFn();
+    const recallFn = deps.recallFn || resolveRecallFn(home);
     await runBackground({ queries, projectId, sessionId, recallFn, cache, home });
   } catch {
     // Detached background process — degrade silently (R14).

--- a/plugins/synapsys/scripts/synapsys-recall.js
+++ b/plugins/synapsys/scripts/synapsys-recall.js
@@ -5,6 +5,7 @@ const os = require('node:os');
 const sessionCache = require('../lib/session-cache.js');
 const injectLedger = require('../lib/inject-ledger.js');
 const consumeSentinel = require('../lib/consume-sentinel.js');
+const cortexProvider = require('../lib/cortex-provider.js');
 
 const EMPTY_MESSAGE = 'no auto-recall this session';
 
@@ -51,6 +52,26 @@ function renderStatus(cache) {
 }
 
 /**
+ * Render the resolved recall-provider line for the status report (GH-662):
+ * the explicit module path, the default sqlite bridge with its db path, or
+ * `none` with the reason recall is disabled.
+ *
+ * @param {{ provider?: string|null, source?: string }|null|undefined} resolved
+ *   output of `cortex-provider.resolveRecall` (null when resolution threw)
+ * @returns {string}
+ */
+function renderProvider(resolved) {
+  if (resolved && resolved.provider === 'module') {
+    return `provider: module ${resolved.source}`;
+  }
+  if (resolved && resolved.provider === 'bridge') {
+    return `provider: default bridge (cortex sqlite, read-only): ${resolved.source}`;
+  }
+  const reason = resolved && resolved.source ? resolved.source : 'unresolved';
+  return `provider: none (${reason})`;
+}
+
+/**
  * Resolve the active session id through the SAME resolver the hook's cortex
  * cache uses (`injectLedger.resolveSessionId`): env `CLAUDE_CODE_SESSION_ID` →
  * sanitized `payload.session_id` → `.current` → hashed-cwd fallback. Using the
@@ -71,6 +92,15 @@ function resolveSessionId({ payload = {} } = {}) {
  */
 function main({ home = os.homedir(), payload = {}, log = console.log } = {}) {
   const sessionId = resolveSessionId({ payload });
+  // Surface which recall provider is in effect (explicit module > default
+  // bridge > none) so a silent-because-unconfigured session is diagnosable.
+  let resolved = null;
+  try {
+    resolved = cortexProvider.resolveRecall({ env: process.env, home });
+  } catch {
+    resolved = null;
+  }
+  log(renderProvider(resolved));
   // Prefer the live pre-consume cache; once the first UserPromptSubmit has
   // single-consumed (and deleted) it, fall back to the READ-ONLY post-consume
   // summary so the status surface still reports this session's recall (GH-519).
@@ -82,7 +112,7 @@ function main({ home = os.homedir(), payload = {}, log = console.log } = {}) {
   log(renderStatus(record));
 }
 
-module.exports = { renderStatus, main, resolveSessionId };
+module.exports = { renderStatus, renderProvider, main, resolveSessionId };
 
 if (require.main === module) {
   main();

--- a/plugins/synapsys/skills/synapsys/SKILL.md
+++ b/plugins/synapsys/skills/synapsys/SKILL.md
@@ -22,7 +22,7 @@ Synapsys is a memory injection plugin: memories are markdown files with frontmat
 
 - `/synapsys new <name>` — Create a new memory file in the user-chosen store. Ask the user which store and which events the memory should listen to. Use the template below.
 
-- `/synapsys recall` — Show the active session's cortex auto-recall activity: each query string that was run this session and how many results it returned. Prints `no auto-recall this session` when nothing has run yet. (Distinct from `/synapsys status`, which reports the live active-domain set.)
+- `/synapsys recall` — Show the active session's cortex auto-recall activity: the resolved recall provider (explicit `SYNAPSYS_CORTEX_RECALL_MODULE` module, the zero-config default sqlite bridge over `~/.cortex/memory.db`, or `none` with the reason), then each query string that was run this session and how many results it returned. Prints `no auto-recall this session` when nothing has run yet. (Distinct from `/synapsys status`, which reports the live active-domain set.)
 
   Run: `node ${CLAUDE_PLUGIN_ROOT}/scripts/synapsys-recall.js`
 

--- a/plugins/synapsys/tests/cortex-bridge.integration.test.js
+++ b/plugins/synapsys/tests/cortex-bridge.integration.test.js
@@ -120,6 +120,38 @@ test('SessionStart with a detectable cortex db (no env module) schedules Phase 1
   }
 });
 
+test('kill switch OFF beats a detectable bridge: SessionStart schedules nothing (AC: disables regardless of detection)', {
+  skip: !sqlite,
+}, () => {
+  const home = mkHome();
+  const sessionId = `sess-${process.pid}-${Date.now()}-killswitch`;
+  try {
+    const dbFile = makeDb(home); // the bridge WOULD resolve…
+    const res = runHook(
+      'SessionStart',
+      { session_id: sessionId, cwd: home },
+      {
+        home,
+        env: {
+          SYNAPSYS_CORTEX_AUTO_RECALL: 'off',
+          SYNAPSYS_CORTEX_DB: dbFile,
+          SYNAPSYS_CORTEX_TICKET: 'GH-662',
+          SYNAPSYS_CORTEX_KEYWORDS: 'maestro cortex recall',
+          SYNAPSYS_NO_SETUP_HINT: '1',
+        },
+      }
+    );
+    assert.equal(res.status, 0, 'SessionStart exits 0');
+    assert.equal(
+      waitForCache(home, sessionId, 30),
+      null,
+      'kill switch disables recall even with a detectable cortex db'
+    );
+  } finally {
+    cleanup(home);
+  }
+});
+
 test('SessionStart with no module and no cortex db has zero cortex side effects', () => {
   const home = mkHome();
   const sessionId = `sess-${process.pid}-${Date.now()}-nodb`;

--- a/plugins/synapsys/tests/cortex-bridge.integration.test.js
+++ b/plugins/synapsys/tests/cortex-bridge.integration.test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+/**
+ * Integration tests for GH-662 — the zero-config default cortex bridge wired
+ * through the dispatcher. Drives `hooks/synapsys.js` as a subprocess exactly
+ * like tests/cortex-recall.integration.test.js:
+ *
+ *   - SessionStart with NO SYNAPSYS_CORTEX_RECALL_MODULE but a detectable
+ *     cortex db (SYNAPSYS_CORTEX_DB → fixture) schedules Phase 1: the baseline
+ *     session-cache appears. (Skips on Node < 22.5 — the bridge needs
+ *     node:sqlite.)
+ *   - SessionStart with no module AND no db produces ZERO cortex side effects
+ *     (no baseline cache) — the pre-bridge default behavior is preserved.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const HOOK = path.join(__dirname, '..', 'hooks', 'synapsys.js');
+
+const sqlite = (() => {
+  try {
+    return require('node:sqlite');
+  } catch {
+    return null;
+  }
+})();
+
+function mkHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-bridge-it-'));
+}
+
+function cleanup(dir) {
+  // Detached recall jobs may still be writing at teardown (see the GH-519
+  // integration suite) — retry so rmSync survives the readdir/rmdir race.
+  fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+}
+
+function cacheFilePath(home, sessionId) {
+  return path.join(home, '.claude', 'synapsys', '.cache', `${sessionId}.json`);
+}
+
+/** Create a fixture cortex db (real `memories` schema) under `dir`. */
+function makeDb(dir) {
+  const file = path.join(dir, 'memory.db');
+  const db = new sqlite.DatabaseSync(file);
+  db.exec(
+    'CREATE TABLE memories (id INTEGER PRIMARY KEY, content TEXT, content_hash TEXT, ' +
+      'embedding BLOB, project_id TEXT, source_session TEXT, timestamp TEXT, created_at TEXT)'
+  );
+  db.prepare('INSERT INTO memories (content, project_id, timestamp) VALUES (?, ?, ?)').run(
+    'maestro cortex recall bridge fixture',
+    'claude-plugin-work',
+    new Date().toISOString()
+  );
+  db.close();
+  return file;
+}
+
+function runHook(event, payload, { home, env = {} } = {}) {
+  return spawnSync(process.execPath, [HOOK, event], {
+    input: JSON.stringify(payload || {}),
+    encoding: 'utf8',
+    cwd: (payload && payload.cwd) || os.tmpdir(),
+    env: { PATH: process.env.PATH, HOME: home, ...env },
+  });
+}
+
+/** Poll (no sleep) for the session-cache file; null if it never appears. */
+function waitForCache(home, sessionId, attempts = 200) {
+  const file = cacheFilePath(home, sessionId);
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      return JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch {
+      for (let spin = 0; spin < 50000; spin += 1) {
+        /* spin */
+      }
+    }
+  }
+  return null;
+}
+
+test('SessionStart with a detectable cortex db (no env module) schedules Phase 1 via the bridge', {
+  skip: !sqlite,
+}, () => {
+  const home = mkHome();
+  const sessionId = `sess-${process.pid}-${Date.now()}-bridge`;
+  try {
+    const dbFile = makeDb(home);
+    const res = runHook(
+      'SessionStart',
+      { session_id: sessionId, cwd: home },
+      {
+        home,
+        env: {
+          // NO SYNAPSYS_CORTEX_RECALL_MODULE — the bridge is the provider.
+          SYNAPSYS_CORTEX_DB: dbFile,
+          SYNAPSYS_CORTEX_TICKET: 'GH-662',
+          SYNAPSYS_CORTEX_PROJECT: 'claude-plugin-work',
+          SYNAPSYS_CORTEX_KEYWORDS: 'maestro cortex recall',
+          SYNAPSYS_NO_SETUP_HINT: '1',
+        },
+      }
+    );
+    assert.equal(res.status, 0, 'SessionStart exits 0');
+
+    const record = waitForCache(home, sessionId);
+    assert.ok(record, 'the baseline session-cache is written (recall scheduled)');
+    assert.ok(Array.isArray(record.queries), 'cache record has a queries array');
+    assert.equal(record.queries.length, 2, 'both queries scheduled (ticket + keywords)');
+    const queryStrings = record.queries.map((q) => q.query);
+    assert.ok(queryStrings.includes('GH-662'), 'ticket query scheduled');
+  } finally {
+    cleanup(home);
+  }
+});
+
+test('SessionStart with no module and no cortex db has zero cortex side effects', () => {
+  const home = mkHome();
+  const sessionId = `sess-${process.pid}-${Date.now()}-nodb`;
+  try {
+    const res = runHook(
+      'SessionStart',
+      { session_id: sessionId, cwd: home },
+      {
+        home,
+        env: {
+          // No module env, and the db override points nowhere — the bridge is
+          // undetectable, so Phase 1 must schedule nothing at all.
+          SYNAPSYS_CORTEX_DB: path.join(home, 'absent', 'memory.db'),
+          SYNAPSYS_CORTEX_TICKET: 'GH-662',
+          SYNAPSYS_CORTEX_KEYWORDS: 'maestro cortex recall',
+          SYNAPSYS_NO_SETUP_HINT: '1',
+        },
+      }
+    );
+    assert.equal(res.status, 0, 'SessionStart still exits 0');
+    assert.equal(waitForCache(home, sessionId, 30), null, 'no baseline cache file is written');
+    assert.ok(
+      !fs.existsSync(path.join(home, '.claude', 'synapsys', '.cache')) ||
+        fs.readdirSync(path.join(home, '.claude', 'synapsys', '.cache')).length === 0,
+      'no cortex cache side effects at all'
+    );
+  } finally {
+    cleanup(home);
+  }
+});

--- a/plugins/synapsys/tests/synapsys-cortex-recall-bg.test.js
+++ b/plugins/synapsys/tests/synapsys-cortex-recall-bg.test.js
@@ -193,8 +193,13 @@ test('resolveRecallFn: returns the recall fn from SYNAPSYS_CORTEX_RECALL_MODULE 
 test('resolveRecallFn: falls open to an empty-result stub when the module env is unset or unloadable', async () => {
   const mod = loadBg();
   const prev = process.env.SYNAPSYS_CORTEX_RECALL_MODULE;
+  const prevDb = process.env.SYNAPSYS_CORTEX_DB;
   try {
     delete process.env.SYNAPSYS_CORTEX_RECALL_MODULE;
+    // Hermetic (GH-662): with the module env unset, resolution now probes the
+    // default cortex bridge. Pin the db override to a nonexistent path so a
+    // real ~/.cortex on the test machine cannot make the bridge resolve here.
+    process.env.SYNAPSYS_CORTEX_DB = '/no/such/cortex-662/memory.db';
     assert.deepEqual(await mod.resolveRecallFn()('q', 'p'), [], 'unset → empty stub');
 
     process.env.SYNAPSYS_CORTEX_RECALL_MODULE = '/no/such/bridge-module-xyz.js';
@@ -206,5 +211,7 @@ test('resolveRecallFn: falls open to an empty-result stub when the module env is
   } finally {
     if (prev === undefined) delete process.env.SYNAPSYS_CORTEX_RECALL_MODULE;
     else process.env.SYNAPSYS_CORTEX_RECALL_MODULE = prev;
+    if (prevDb === undefined) delete process.env.SYNAPSYS_CORTEX_DB;
+    else process.env.SYNAPSYS_CORTEX_DB = prevDb;
   }
 });

--- a/plugins/synapsys/tests/synapsys-recall.test.js
+++ b/plugins/synapsys/tests/synapsys-recall.test.js
@@ -246,3 +246,52 @@ test('appendCortexQuery: a throwing recall does NOT burn the once_per_session ma
     assert.equal(cortexHook.suppressedByFireMode(home, sessionId, memory), false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// renderProvider (GH-662) — the provider line `/synapsys recall` prints first
+// ---------------------------------------------------------------------------
+
+const { renderProvider } = require('../scripts/synapsys-recall.js');
+
+test('renderProvider: explicit module form', () => {
+  assert.equal(
+    renderProvider({ provider: 'module', source: '/opt/bridge.js', recall: () => [] }),
+    'provider: module /opt/bridge.js'
+  );
+});
+
+test('renderProvider: default bridge form names the db path', () => {
+  assert.equal(
+    renderProvider({ provider: 'bridge', source: '/home/me/.cortex/memory.db', recall: () => [] }),
+    'provider: default bridge (cortex sqlite, read-only): /home/me/.cortex/memory.db'
+  );
+});
+
+test('renderProvider: none form carries the reason; null resolution degrades to unresolved', () => {
+  assert.equal(
+    renderProvider({ provider: null, source: 'no cortex db at /x', recall: null }),
+    'provider: none (no cortex db at /x)'
+  );
+  assert.equal(renderProvider(null), 'provider: none (unresolved)');
+});
+
+test('main prints the provider line FIRST, before the recall status', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-recall-provider-'));
+  const prevMod = process.env.SYNAPSYS_CORTEX_RECALL_MODULE;
+  const prevDb = process.env.SYNAPSYS_CORTEX_DB;
+  try {
+    // Hermetic: no module, and the db override points nowhere → provider none.
+    delete process.env.SYNAPSYS_CORTEX_RECALL_MODULE;
+    process.env.SYNAPSYS_CORTEX_DB = path.join(home, 'absent', 'memory.db');
+    const lines = [];
+    main({ home, payload: {}, log: (s) => lines.push(s) });
+    assert.match(lines[0], /^provider: none \(/, 'provider line is the first line');
+    assert.equal(lines[1], 'no auto-recall this session');
+  } finally {
+    if (prevMod === undefined) delete process.env.SYNAPSYS_CORTEX_RECALL_MODULE;
+    else process.env.SYNAPSYS_CORTEX_RECALL_MODULE = prevMod;
+    if (prevDb === undefined) delete process.env.SYNAPSYS_CORTEX_DB;
+    else process.env.SYNAPSYS_CORTEX_DB = prevDb;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #662

## Existing Behavior

- When `SYNAPSYS_CORTEX_RECALL_MODULE` is unset, cortex auto-recall is silently disabled — no fallback provider exists.
- The `/synapsys recall` status line reports no provider detail, giving no visibility into why recall is off.
- `cortex-hook.js` and the bg worker each resolved the recall function independently, with no shared provider abstraction.

## Intended New Behavior

- A zero-config default bridge (`lib/cortex-bridge.js`) provides keyword+recency recall over `~/.cortex/memory.db` (override: `SYNAPSYS_CORTEX_DB`) using `node:sqlite` (Node >= 22.5). On Node 20 the bridge silently reports unavailable — no crash.
- A shared resolver (`lib/cortex-provider.js`) unifies provider selection across `cortex-hook.js`, the detached bg worker, and the `/synapsys recall` status line. Precedence: explicit env module always wins (a broken module yields disabled, never the bridge); unset + detectable db → bridge; else disabled exactly as before. Kill switch `SYNAPSYS_CORTEX_AUTO_RECALL=off` is unchanged.
- `/synapsys recall` now prints the resolved provider source: module path, default bridge + db path, or none with a reason.
- The bridge is synchronous by design — Phase 2 `appendCortexQuery` cannot await; a sync-contract regression test pins this.
- 26 new tests cover: bridge detect matrix, keyword ranking, projectId filter, LIKE escaping, result shape, LIMIT, fail-open, the in-query age-cutoff (stale rows cannot crowd fresh ones out of the cap), provider precedence matrix, sync-contract regression, the /synapsys recall provider line (all three forms, printed first), kill-switch-beats-detectable-bridge, and dispatcher-level integration (SessionStart with fixture db writes baseline cache; without db, zero side effects). All `node:sqlite`-dependent tests skip cleanly on Node 20.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend — verify bridge auto-detection:**

1. Confirm Node >= 22.5 is active: `node --version`
2. Confirm a cortex db exists: `ls ~/.cortex/memory.db`
3. Open a synapsys session and run `/synapsys recall` — the status line should read `default bridge (<db path>)` rather than `none`.
4. Run a recall query; confirm up to 5 ranked results are returned synchronously.
5. Set `SYNAPSYS_CORTEX_AUTO_RECALL=off` and reopen session — recall status should show `disabled (kill switch)`.
6. Set `SYNAPSYS_CORTEX_DB=/nonexistent/path.db` — status should show `none: no cortex db at /nonexistent/path.db`.

**Unit test pass (Node 22.5+):**
```
pnpm test --filter synapsys
```
Expected: 838 tests green; `node:sqlite`-gated tests in `cortex-bridge.test.js` and `cortex-provider.test.js` all run (not skipped).

**Unit test pass (Node 20):**
Node:sqlite-dependent tests skip with `SKIP (node:sqlite unavailable)`; the rest of the suite is green.

### Test Results

Full plugin suite: 838 tests green. Quality gate clean. Smoke-tested against real `~/.cortex/memory.db` (161k rows): detect ok, 5 ranked results returned synchronously.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when SessionStart/Phase-2 recall runs for users with a local cortex DB (new injection surface), though read-only and fail-open; explicit-module precedence avoids silent fallback on misconfiguration.
> 
> **Overview**
> Adds **zero-config cortex auto-recall** when `SYNAPSYS_CORTEX_RECALL_MODULE` is unset but a readable cortex SQLite store exists (`~/.cortex/memory.db`, overridable via `SYNAPSYS_CORTEX_DB`).
> 
> A new **`lib/cortex-provider.js`** centralizes provider selection for Phase 1 (background worker), Phase 2 (inline hook), and **`/synapsys recall`**: valid explicit module wins; otherwise the new **`lib/cortex-bridge.js`** serves **read-only, synchronous** keyword+recency recall (Node ≥22.5 `node:sqlite`; capped at 5 rows with in-query age filtering). A **set-but-broken module disables recall** and does **not** fall back to the bridge.
> 
> **`synapsys-recall.js`** now prints the resolved provider first; docs/skills describe the new precedence. Unit, provider-precedence, sync-contract, and hook integration tests cover the bridge and unchanged behavior when no DB is detectable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 806e4725c2af0ebc4363237dd5dc769eabe25aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
