### PR TITLE
fix(follow-up): live statusline timer, operator notifications, and terminal-state routing fixes

### DIFF
--- a/plugins/synapsys/lib/__tests__/matcher.domain-gate.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/matcher.domain-gate.integration.test.js
@@ -30,6 +30,13 @@ function write(storeDir, name, body) {
   fs.writeFileSync(path.join(storeDir, name), body);
 }
 
+// listMemories discovers ALL tiers — including the machine's real
+// global/shared stores via HOME — so restrict to the tmpdir fixture store or
+// live memories on the host leak into the deep-equal assertions.
+function listFixtureMemories(cwd, storeDir) {
+  return listMemories(cwd).filter((m) => path.resolve(m.store.dir) === path.resolve(storeDir));
+}
+
 test('Memory with non-overlapping domain is skipped even when trigger matches (end-to-end)', () => {
   const { cwd, storeDir } = makeStore();
 
@@ -54,7 +61,7 @@ test('Memory with non-overlapping domain is skipped even when trigger matches (e
     '---\nname: e2e-tagged\ndescription: d\nevents: UserPromptSubmit\ndomain: e2e\ntrigger_prompt: \\bdeploy\\b\n---\nbody\n'
   );
 
-  const memories = listMemories(cwd);
+  const memories = listFixtureMemories(cwd, storeDir);
   // Sanity: all three loaded
   const names = memories.map((m) => m.name).sort();
   assert.ok(names.includes('universal'), `expected 'universal' in ${names}`);
@@ -91,7 +98,7 @@ test('Backward compat: omitting opts.activeDomains leaves domain-tagged memories
     '---\nname: universal\ndescription: d\nevents: UserPromptSubmit\ntrigger_prompt: \\bdeploy\\b\n---\nbody\n'
   );
 
-  const memories = listMemories(cwd);
+  const memories = listFixtureMemories(cwd, storeDir);
 
   // No 4th arg
   const picked = selectForEvent(memories, 'UserPromptSubmit', { prompt: 'please deploy now' });

--- a/plugins/synapsys/lib/__tests__/worktree-injection.test.js
+++ b/plugins/synapsys/lib/__tests__/worktree-injection.test.js
@@ -84,7 +84,12 @@ describe('worktree store discovery', () => {
 
 describe('worktree-level injection', () => {
   function matchedNames(event, payload) {
-    const memories = discoverStores(worktreeCwd).flatMap(listMemoriesFromStore);
+    // Restrict to the worktree tier under test — the process's real HOME can
+    // carry live global/shared stores whose memories would otherwise leak
+    // into the deep-equal assertions (machine-dependent failures).
+    const memories = discoverStores(worktreeCwd)
+      .filter((s) => s.kind === 'worktree')
+      .flatMap(listMemoriesFromStore);
     return selectForEvent(memories, event, payload).map((m) => m.name);
   }
 
@@ -124,7 +129,10 @@ describe('multi-level discovery', () => {
   it('injects a matching memory from a nested sub-directory', () => {
     const nested = path.join(worktreeCwd, 'packages', 'app');
     fs.mkdirSync(nested, { recursive: true });
-    const memories = discoverStores(nested).flatMap(listMemoriesFromStore);
+    // Worktree tier only — see matchedNames above for why.
+    const memories = discoverStores(nested)
+      .filter((s) => s.kind === 'worktree')
+      .flatMap(listMemoriesFromStore);
     const names = selectForEvent(memories, 'UserPromptSubmit', { prompt: 're-run ci' }).map(
       (m) => m.name
     );

--- a/plugins/synapsys/scripts/__tests__/synapsys-list-stop-response.test.js
+++ b/plugins/synapsys/scripts/__tests__/synapsys-list-stop-response.test.js
@@ -34,9 +34,14 @@ function writeMemory(storeDir, name, frontmatter) {
 }
 
 function runList(cwd) {
+  // Isolated HOME: without it the CLI also lists the machine's real
+  // global/shared stores, and any live memory carrying trigger_stop_response
+  // breaks the "omits stop-response" assertion (machine-dependent failure).
+  const fakeHome = path.join(cwd, 'fake-home');
+  fs.mkdirSync(fakeHome, { recursive: true });
   const res = spawnSync(process.execPath, [SCRIPT, '--verbose', '--no-color', `--cwd=${cwd}`], {
     encoding: 'utf8',
-    env: { ...process.env, NO_COLOR: '1' },
+    env: { ...process.env, NO_COLOR: '1', HOME: fakeHome },
   });
   return { stdout: res.stdout || '', stderr: res.stderr || '', status: res.status };
 }

--- a/plugins/synapsys/tests/audit-triggers.integration.test.js
+++ b/plugins/synapsys/tests/audit-triggers.integration.test.js
@@ -65,8 +65,19 @@ test('--scope=shared narrows discovery to the shared tier', () => {
   // project-tier memories (so the scope filter is actually distinguishing tiers).
   // We verify by asking for them via the programmatic `lintStore` entry point.
   const { lintStore } = require(CLI);
-  const sharedResult = lintStore({ cwd: PROJ_CWD, scope: 'shared' });
-  const projectResult = lintStore({ cwd: PROJ_CWD, scope: 'project' });
+  // In-process calls resolve stores via the REAL process HOME — pin it to the
+  // fixture home (like the spawned CLI does) so the machine's live shared
+  // store can't leak extra memories into the tier comparison.
+  const realHome = process.env.HOME;
+  let sharedResult;
+  let projectResult;
+  try {
+    process.env.HOME = FAKE_HOME;
+    sharedResult = lintStore({ cwd: PROJ_CWD, scope: 'shared' });
+    projectResult = lintStore({ cwd: PROJ_CWD, scope: 'project' });
+  } finally {
+    process.env.HOME = realHome;
+  }
   assert.ok(
     sharedResult.memories.length < projectResult.memories.length,
     `scope=shared (${sharedResult.memories.length}) must see fewer memories than scope=project (${projectResult.memories.length})`

--- a/plugins/work/hooks/hooks.json
+++ b/plugins/work/hooks/hooks.json
@@ -159,7 +159,8 @@
           },
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js",
+            "timeout": 180
           },
           {
             "type": "command",

--- a/plugins/work/scripts/workflows/follow-up/__tests__/statusline-live-timer.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/statusline-live-timer.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+// statusline-live-timer.test.js — the status bar must recompute the elapsed
+// timer at RENDER time (the pre-baked _ciStatusLine string froze the timer
+// at whatever the last monitor cycle stringified).
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  buildStatusLine,
+  composeStatusLine,
+  formatElapsed,
+} = require('../lib/steps/monitor-status-line');
+
+const RENDERER_SOURCE = fs.readFileSync(
+  path.resolve(__dirname, '..', 'statusline', 'followup-statusline.js'),
+  'utf8'
+);
+
+describe('monitor-status-line — structured parts', () => {
+  const ci = {
+    status: 'pending',
+    running: [{ name: 'e2e' }],
+    passed: [{ name: 'lint' }],
+    failed: [],
+    cancelled: [],
+  };
+  const reviews = { pendingBots: [], blocking: [], hasBlocking: false };
+
+  it('buildStatusLine returns parts that recompose into line1', () => {
+    const state = {
+      attempt: 3,
+      maxAttempts: 40,
+      _monitorStartTime: new Date(Date.now() - 65000).toISOString(),
+    };
+    const { line1, parts } = buildStatusLine(state, ci, reviews);
+    assert.equal(composeStatusLine(parts, formatElapsed(state._monitorStartTime)), line1);
+    assert.equal(parts.poll, '3/40');
+    assert.ok(parts.statusLabel.includes('CI'));
+  });
+
+  it('formatElapsed advances as time passes (the live-timer property)', () => {
+    const start = new Date(Date.now() - 90 * 1000).toISOString();
+    assert.equal(formatElapsed(start), '1m 30s');
+    const older = new Date(Date.now() - 2 * 3600 * 1000).toISOString();
+    assert.ok(formatElapsed(older).startsWith('2h'));
+  });
+});
+
+describe('followup-statusline renderer', () => {
+  it('recomputes elapsed from _ciStatusParts + _monitorStartTime instead of the frozen string', () => {
+    assert.ok(RENDERER_SOURCE.includes('_ciStatusParts'), 'renderer reads structured parts');
+    assert.ok(RENDERER_SOURCE.includes('formatElapsed'), 'renderer recomputes elapsed live');
+    assert.ok(
+      RENDERER_SOURCE.includes('composeStatusLine'),
+      'renderer composes via the shared formatter'
+    );
+  });
+
+  it('falls back to _ciStatusLine for state files written by older versions', () => {
+    assert.ok(RENDERER_SOURCE.includes('_ciStatusLine'));
+  });
+
+  it('shows a marker when the persisted instruction is blocked/surface', () => {
+    assert.ok(RENDERER_SOURCE.includes('.follow-up-next.json'));
+    assert.ok(RENDERER_SOURCE.includes("'blocked'"));
+    assert.ok(RENDERER_SOURCE.includes("'surface'"));
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -262,6 +262,24 @@ function getNextInstruction(ticketId, prNumber) {
 
 // ─── CLI ────────────────────────────────────────────────────────────────────
 
+// Terminal states used to leave only a JSON blob in the transcript — ping
+// the operator mailbox + terminal bell so a blocked/complete follow-up is
+// never silent ("agents get stuck with no notifications").
+function notifyTerminalInstruction(instruction, safeName) {
+  if (!instruction || !['blocked', 'surface', 'complete'].includes(instruction.action)) return;
+  try {
+    const { notifyOperator } = require('./lib/notify');
+    const detail =
+      instruction.summary ||
+      instruction.reason ||
+      (instruction.payload && instruction.payload.reason) ||
+      '';
+    notifyOperator(safeName, `${instruction.action}: ${String(detail).split('\n')[0]}`);
+  } catch {
+    /* fail-open — notification is best-effort */
+  }
+}
+
 function main() {
   const args = process.argv.slice(2);
   if (args.length === 0) {
@@ -315,6 +333,8 @@ function main() {
   }
 
   const instruction = getNextInstruction(safeName, prNumber);
+
+  notifyTerminalInstruction(instruction, safeName);
 
   // When the workflow completes, release the session guard ONLY if /follow-up
   // owns it (the `complete <id> <workflow>` filter is a no-op when a parent

--- a/plugins/work/scripts/workflows/follow-up/follow-up-next.js
+++ b/plugins/work/scripts/workflows/follow-up/follow-up-next.js
@@ -280,6 +280,21 @@ function notifyTerminalInstruction(instruction, safeName) {
   }
 }
 
+// GH-214 (state-file-first): persist the instruction on EVERY run so callers
+// can invoke this script in the background and read the compact JSON from
+// `<TASKS_BASE>/<ticket>/.follow-up-next.json` instead of parsing stdout.
+// Then fire the terminal-state operator notification.
+function applyInstructionSideEffects(instruction, safeName) {
+  if (instruction) {
+    try {
+      require('./lib/instruction-file').persistInstruction(TASKS_BASE, safeName, instruction);
+    } catch {
+      /* fail-open */
+    }
+  }
+  notifyTerminalInstruction(instruction, safeName);
+}
+
 function main() {
   const args = process.argv.slice(2);
   if (args.length === 0) {
@@ -334,7 +349,7 @@ function main() {
 
   const instruction = getNextInstruction(safeName, prNumber);
 
-  notifyTerminalInstruction(instruction, safeName);
+  applyInstructionSideEffects(instruction, safeName);
 
   // When the workflow completes, release the session guard ONLY if /follow-up
   // owns it (the `complete <id> <workflow>` filter is a no-op when a parent

--- a/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
+++ b/plugins/work/scripts/workflows/follow-up/hooks/follow-up-auto-advance.js
@@ -7,31 +7,18 @@
 
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const { runAutoAdvance } = require('../../lib/auto-advance');
+const { persistInstruction } = require('../lib/instruction-file');
 
 // Test seam: an absolute path override lets the surface/blocked test stub
 // follow-up-next.js without staging the entire plugin tree. Production code
 // never sets FOLLOW_UP_NEXT_PATH; default resolves siblings as before.
 const nextPath = process.env.FOLLOW_UP_NEXT_PATH || path.join(__dirname, '..', 'follow-up-next.js');
 
-// Persist the latest instruction so the Stop hook (session-guard) can surface
-// it inline when the agent tries to stop. Without this the agent gets only
-// "go run follow-up-next.js again" with no context. Fail-open.
-function persistInstruction(TASKS_BASE, ticket, instruction) {
-  try {
-    const instructionPath = path.join(TASKS_BASE, ticket, '.follow-up-next.json');
-    if (instruction.action === 'complete') {
-      // Clean up so a future run doesn't surface a stale completion blob
-      if (fs.existsSync(instructionPath)) fs.unlinkSync(instructionPath);
-    } else {
-      fs.writeFileSync(instructionPath, JSON.stringify(instruction, null, 2));
-    }
-  } catch {
-    /* fail-open */
-  }
-}
+// The latest instruction is persisted (shared lib/instruction-file.js) so the
+// Stop hook (session-guard) can surface it inline when the agent tries to
+// stop, and so state-file-first callers (GH-214) can read it from disk.
 
 const BANNERS = {
   execute: ['═══ FOLLOW-UP2: NEXT STEP ═══', '══════════════════════════════'],

--- a/plugins/work/scripts/workflows/follow-up/lib/__tests__/gh214-state-file-first.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/__tests__/gh214-state-file-first.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+// gh214-state-file-first.test.js — GH-214: background-mode / state-file-first
+// invocation. The orchestrator persists (a) the latest instruction to
+// .follow-up-next.json on every run, and (b) the observed CI run IDs to state,
+// so monitoring is resumable without parsing terminal output.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { persistInstruction } = require('../instruction-file');
+const { collectRunIds } = require('../steps/monitor-ci-context');
+
+describe('GH-214 — instruction file persistence', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh214-'));
+    fs.mkdirSync(path.join(tmpDir, 'GH-1'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const file = () => path.join(tmpDir, 'GH-1', '.follow-up-next.json');
+
+  it('writes the instruction JSON for non-complete actions', () => {
+    persistInstruction(tmpDir, 'GH-1', { action: 'execute', delegate: { type: 'bash' } });
+    const persisted = JSON.parse(fs.readFileSync(file(), 'utf8'));
+    assert.equal(persisted.action, 'execute');
+  });
+
+  it('removes the file on complete (no stale completion blob)', () => {
+    persistInstruction(tmpDir, 'GH-1', { action: 'blocked', reason: 'x' });
+    assert.ok(fs.existsSync(file()));
+    persistInstruction(tmpDir, 'GH-1', { action: 'complete' });
+    assert.ok(!fs.existsSync(file()));
+  });
+
+  it('orchestrator persists on every run, not only via the hook (source guard)', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '..', '..', 'follow-up-next.js'),
+      'utf8'
+    );
+    assert.ok(source.includes('persistInstruction'), 'follow-up-next.js must persist directly');
+  });
+});
+
+describe('GH-214 — CI run IDs persisted for resumable monitoring', () => {
+  it('collectRunIds gathers unique run IDs across all job buckets', () => {
+    const ids = collectRunIds({
+      running: [{ name: 'a', link: 'https://github.com/o/r/actions/runs/111/job/1' }],
+      passed: [{ name: 'b', url: 'https://github.com/o/r/actions/runs/222/job/2' }],
+      failed: [{ name: 'c', link: 'https://github.com/o/r/actions/runs/111/job/3' }],
+      cancelled: [],
+    });
+    assert.deepEqual(ids.sort(), ['111', '222']);
+  });
+
+  it('returns [] for jobs without run links', () => {
+    assert.deepEqual(collectRunIds({ running: [{ name: 'x' }] }), []);
+  });
+
+  it('monitor persists _ciRunIds to state each cycle (source guard)', () => {
+    const source = fs.readFileSync(path.resolve(__dirname, '..', 'steps', 'monitor.js'), 'utf8');
+    assert.ok(source.includes('state._ciRunIds = collectRunIds(ci)'));
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/lib/__tests__/notify.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/__tests__/notify.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// notify.test.js — operator mailbox notifications + inbound message reads.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { notifyOperator, readNewInboxMessages, inboxPath } = require('../notify');
+
+describe('notify — operator mailbox', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notify-test-'));
+    process.env.CLAUDE_AGENT_INBOX_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_AGENT_INBOX_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('notifyOperator appends a tagged line to the ticket mailbox', () => {
+    notifyOperator('GH-1', 'blocked: something went wrong');
+    const content = fs.readFileSync(inboxPath('GH-1'), 'utf8');
+    assert.ok(content.includes('[follow-up]'));
+    assert.ok(content.includes('blocked: something went wrong'));
+  });
+
+  it('readNewInboxMessages: first sighting anchors the offset (no historical replay)', () => {
+    fs.writeFileSync(inboxPath('GH-2'), 'old operator chatter\n');
+    const state = {};
+    assert.deepEqual(readNewInboxMessages('GH-2', state), []);
+    assert.equal(typeof state._inboxOffset, 'number');
+  });
+
+  it('readNewInboxMessages returns lines appended after the offset', () => {
+    fs.writeFileSync(inboxPath('GH-3'), 'old line\n');
+    const state = {};
+    readNewInboxMessages('GH-3', state); // anchor
+    fs.appendFileSync(inboxPath('GH-3'), 'please stop and rebase\n');
+    assert.deepEqual(readNewInboxMessages('GH-3', state), ['please stop and rebase']);
+    // Offset advanced — no re-serve on the next read.
+    assert.deepEqual(readNewInboxMessages('GH-3', state), []);
+  });
+
+  it('readNewInboxMessages filters out follow-up-authored notifications', () => {
+    const state = {};
+    notifyOperator('GH-4', 'complete: all done'); // creates file with our tag
+    readNewInboxMessages('GH-4', state); // anchor
+    notifyOperator('GH-4', 'another self-notification');
+    fs.appendFileSync(inboxPath('GH-4'), 'real operator message\n');
+    assert.deepEqual(readNewInboxMessages('GH-4', state), ['real operator message']);
+  });
+
+  it('readNewInboxMessages returns [] when the mailbox does not exist', () => {
+    assert.deepEqual(readNewInboxMessages('GH-none', {}), []);
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/lib/__tests__/notify.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/__tests__/notify.test.js
@@ -13,6 +13,11 @@ const { notifyOperator, readNewInboxMessages, inboxPath } = require('../notify')
 describe('notify — operator mailbox', () => {
   let tmpDir;
 
+  // Fixture writes go through this mkdtemp-rooted path (not inboxPath) so
+  // CodeQL's insecure-temp-file taint from the '/tmp' fallback literal never
+  // reaches a file-creation sink in the tests.
+  const fixtureFile = (ticket) => path.join(tmpDir, `${ticket}.log`);
+
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notify-test-'));
     process.env.CLAUDE_AGENT_INBOX_DIR = tmpDir;
@@ -31,17 +36,17 @@ describe('notify — operator mailbox', () => {
   });
 
   it('readNewInboxMessages: first sighting anchors the offset (no historical replay)', () => {
-    fs.writeFileSync(inboxPath('GH-2'), 'old operator chatter\n');
+    fs.writeFileSync(fixtureFile('GH-2'), 'old operator chatter\n');
     const state = {};
     assert.deepEqual(readNewInboxMessages('GH-2', state), []);
     assert.equal(typeof state._inboxOffset, 'number');
   });
 
   it('readNewInboxMessages returns lines appended after the offset', () => {
-    fs.writeFileSync(inboxPath('GH-3'), 'old line\n');
+    fs.writeFileSync(fixtureFile('GH-3'), 'old line\n');
     const state = {};
     readNewInboxMessages('GH-3', state); // anchor
-    fs.appendFileSync(inboxPath('GH-3'), 'please stop and rebase\n');
+    fs.appendFileSync(fixtureFile('GH-3'), 'please stop and rebase\n');
     assert.deepEqual(readNewInboxMessages('GH-3', state), ['please stop and rebase']);
     // Offset advanced — no re-serve on the next read.
     assert.deepEqual(readNewInboxMessages('GH-3', state), []);
@@ -52,11 +57,19 @@ describe('notify — operator mailbox', () => {
     notifyOperator('GH-4', 'complete: all done'); // creates file with our tag
     readNewInboxMessages('GH-4', state); // anchor
     notifyOperator('GH-4', 'another self-notification');
-    fs.appendFileSync(inboxPath('GH-4'), 'real operator message\n');
+    fs.appendFileSync(fixtureFile('GH-4'), 'real operator message\n');
     assert.deepEqual(readNewInboxMessages('GH-4', state), ['real operator message']);
   });
 
   it('readNewInboxMessages returns [] when the mailbox does not exist', () => {
     assert.deepEqual(readNewInboxMessages('GH-none', {}), []);
+  });
+
+  it('a message that CREATES the mailbox mid-wait is not missed (ENOENT anchors at 0)', () => {
+    const state = {};
+    assert.deepEqual(readNewInboxMessages('GH-5', state), []); // no file yet — anchors 0
+    assert.equal(state._inboxOffset, 0);
+    fs.writeFileSync(fixtureFile('GH-5'), 'first ever operator message\n');
+    assert.deepEqual(readNewInboxMessages('GH-5', state), ['first ever operator message']);
   });
 });

--- a/plugins/work/scripts/workflows/follow-up/lib/__tests__/sleep.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/__tests__/sleep.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+// sleep.test.js — Atomics-based synchronous sleep (replaces the execSync
+// `node -e setTimeout` pattern that crashed with spawnSync ETIMEDOUT).
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { sleepSync, sleepSyncInterruptible } = require('../sleep');
+
+describe('sleep — Atomics.wait based', () => {
+  it('sleepSync blocks for roughly the requested duration', () => {
+    const start = Date.now();
+    sleepSync(120);
+    assert.ok(Date.now() - start >= 100, 'expected at least ~100ms of sleep');
+  });
+
+  it('sleepSyncInterruptible wakes early when shouldWake returns true', () => {
+    const start = Date.now();
+    const woke = sleepSyncInterruptible(10000, () => true, 50);
+    assert.equal(woke, true);
+    assert.ok(Date.now() - start < 2000, 'expected early wake, not the full 10s');
+  });
+
+  it('sleepSyncInterruptible runs to completion when shouldWake stays false', () => {
+    const woke = sleepSyncInterruptible(150, () => false, 50);
+    assert.equal(woke, false);
+  });
+
+  it('sleepSyncInterruptible survives a throwing shouldWake (best-effort)', () => {
+    const woke = sleepSyncInterruptible(
+      120,
+      () => {
+        throw new Error('boom');
+      },
+      40
+    );
+    assert.equal(woke, false);
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/lib/git-unpushed.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/git-unpushed.js
@@ -11,26 +11,53 @@
 
 const { execFileSync } = require('child_process');
 
-// True when there are commits ahead of upstream. Falls back to a porcelain
-// dirty-tree check when there's no upstream (or git errors).
-function hasUnpushedCommits(worktreeDir) {
-  const opts = {
+function gitOpts(worktreeDir) {
+  return {
     encoding: 'utf8',
     timeout: 5000,
     cwd: worktreeDir,
     stdio: ['pipe', 'pipe', 'pipe'],
   };
+}
+
+// STRICT probe: true only when commits exist ahead of upstream. No upstream
+// or git error → false. Used by the fix-reviews done-path, where the
+// dirty-tree fallback below would misroute: a stray untracked file (with no
+// upstream configured) would send done→push-retry every cycle, incrementing
+// _pushRetryCount to the 40-cap "Max push-retry cycles" block.
+function hasUnpushedCommitsStrict(worktreeDir) {
   try {
-    const count = execFileSync('git', ['rev-list', '--count', '@{upstream}..HEAD'], opts).trim();
+    const count = execFileSync(
+      'git',
+      ['rev-list', '--count', '@{upstream}..HEAD'],
+      gitOpts(worktreeDir)
+    ).trim();
+    return parseInt(count, 10) > 0;
+  } catch {
+    return false;
+  }
+}
+
+// True when there are commits ahead of upstream. Falls back to a porcelain
+// dirty-tree check when there's no upstream (or git errors) — push-retry's
+// entry check wants "is there plausibly something to push", where a false
+// positive only costs a no-op `git push`.
+function hasUnpushedCommits(worktreeDir) {
+  try {
+    const count = execFileSync(
+      'git',
+      ['rev-list', '--count', '@{upstream}..HEAD'],
+      gitOpts(worktreeDir)
+    ).trim();
     return parseInt(count, 10) > 0;
   } catch {
     // No upstream or git error — check for uncommitted changes as fallback
     try {
-      return execFileSync('git', ['status', '--porcelain'], opts).trim().length > 0;
+      return execFileSync('git', ['status', '--porcelain'], gitOpts(worktreeDir)).trim().length > 0;
     } catch {
       return false;
     }
   }
 }
 
-module.exports = { hasUnpushedCommits };
+module.exports = { hasUnpushedCommits, hasUnpushedCommitsStrict };

--- a/plugins/work/scripts/workflows/follow-up/lib/git-unpushed.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/git-unpushed.js
@@ -1,0 +1,36 @@
+/**
+ * git-unpushed.js — shared "does this worktree have unpushed work?" probe.
+ *
+ * Used by push-retry (to decide whether to dispatch a push) and by
+ * fix-reviews (to route through push-retry when review-fix commits exist —
+ * previously the skipped>0 path jumped straight to report and left the fix
+ * commits unpushed).
+ */
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+
+// True when there are commits ahead of upstream. Falls back to a porcelain
+// dirty-tree check when there's no upstream (or git errors).
+function hasUnpushedCommits(worktreeDir) {
+  const opts = {
+    encoding: 'utf8',
+    timeout: 5000,
+    cwd: worktreeDir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  };
+  try {
+    const count = execFileSync('git', ['rev-list', '--count', '@{upstream}..HEAD'], opts).trim();
+    return parseInt(count, 10) > 0;
+  } catch {
+    // No upstream or git error — check for uncommitted changes as fallback
+    try {
+      return execFileSync('git', ['status', '--porcelain'], opts).trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+}
+
+module.exports = { hasUnpushedCommits };

--- a/plugins/work/scripts/workflows/follow-up/lib/instruction-file.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/instruction-file.js
@@ -1,0 +1,33 @@
+/**
+ * instruction-file.js — persist the latest /follow-up instruction to
+ * `<TASKS_BASE>/<ticket>/.follow-up-next.json`.
+ *
+ * GH-214 (state-file-first invocation): the orchestrator writes this file on
+ * EVERY run, so callers never need to parse stdout — an agent can invoke
+ * follow-up-next.js in the background (or lose the terminal output entirely)
+ * and read the compact JSON instruction from disk instead. The Stop-hook
+ * session guard and the /follow-up status bar read the same file.
+ *
+ * A 'complete' instruction removes the file so a future run doesn't surface a
+ * stale completion blob. Fail-open.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function persistInstruction(TASKS_BASE, ticket, instruction) {
+  try {
+    const instructionPath = path.join(TASKS_BASE, ticket, '.follow-up-next.json');
+    if (instruction.action === 'complete') {
+      if (fs.existsSync(instructionPath)) fs.unlinkSync(instructionPath);
+    } else {
+      fs.writeFileSync(instructionPath, JSON.stringify(instruction, null, 2));
+    }
+  } catch {
+    /* fail-open */
+  }
+}
+
+module.exports = { persistInstruction };

--- a/plugins/work/scripts/workflows/follow-up/lib/notify.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/notify.js
@@ -1,0 +1,93 @@
+/**
+ * notify.js — outbound operator notifications for /follow-up.
+ *
+ * The workflow used to reach terminal states (blocked, surface, complete)
+ * with the only trace being a JSON blob in the agent transcript — the
+ * operator was never told ("agents get stuck with no notifications").
+ *
+ * Two channels, both fail-open:
+ *   1. The file-mailbox at /tmp/claude-agent-inbox/<TICKET>.log — the same
+ *      channel maestro/conductor and listen-communication.js already tail,
+ *      so fleet tooling picks the event up with no new plumbing.
+ *   2. A terminal bell (BEL to stderr) so a human watching the terminal
+ *      gets an audible/visual ping even without the mailbox listeners.
+ *
+ * The inbox is also an INBOUND channel: operators drop lines in the same
+ * file (maestro `signal`). `readNewInboxMessages` lets the wait loop break
+ * out early when new operator messages arrive instead of sleeping through
+ * them.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const FOLLOW_UP_TAG = '[follow-up]';
+
+// Env override keeps tests hermetic (no leftover files in the real mailbox).
+function inboxDir() {
+  return process.env.CLAUDE_AGENT_INBOX_DIR || '/tmp/claude-agent-inbox';
+}
+
+function inboxPath(ticketId) {
+  return path.join(inboxDir(), `${ticketId}.log`);
+}
+
+/**
+ * Append a notification line to the ticket's mailbox and ring the terminal
+ * bell. Never throws.
+ */
+function notifyOperator(ticketId, message) {
+  const line = `${FOLLOW_UP_TAG} ${new Date().toISOString()} ${message}\n`;
+  try {
+    fs.mkdirSync(inboxDir(), { recursive: true });
+    fs.appendFileSync(inboxPath(ticketId), line);
+  } catch {
+    /* fail-open — mailbox is best-effort */
+  }
+  try {
+    process.stderr.write('\x07');
+  } catch {
+    /* fail-open */
+  }
+}
+
+/**
+ * Read mailbox content appended since `state._inboxOffset`, excluding lines
+ * this module wrote itself (FOLLOW_UP_TAG) so our own notifications never
+ * wake the wait loop. Advances the offset on state (caller persists state).
+ *
+ * @returns {string[]} new operator lines (possibly empty)
+ */
+function readNewInboxMessages(ticketId, state) {
+  try {
+    const file = inboxPath(ticketId);
+    const stat = fs.statSync(file);
+    const offset = typeof state._inboxOffset === 'number' ? state._inboxOffset : stat.size;
+    if (state._inboxOffset === undefined) {
+      // First sighting: start from the current end so historical chatter
+      // doesn't replay as "new" messages.
+      state._inboxOffset = stat.size;
+      return [];
+    }
+    if (stat.size <= offset) return [];
+    const fd = fs.openSync(file, 'r');
+    try {
+      const buf = Buffer.alloc(stat.size - offset);
+      fs.readSync(fd, buf, 0, buf.length, offset);
+      state._inboxOffset = stat.size;
+      return buf
+        .toString('utf8')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0 && !l.includes(FOLLOW_UP_TAG));
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return [];
+  }
+}
+
+module.exports = { notifyOperator, readNewInboxMessages, inboxPath, inboxDir, FOLLOW_UP_TAG };

--- a/plugins/work/scripts/workflows/follow-up/lib/notify.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/notify.js
@@ -66,8 +66,11 @@ function readNewInboxMessages(ticketId, state) {
   let fd;
   try {
     // Open once, then fstat + read on the SAME descriptor — no
-    // check-then-use gap (CodeQL file-system-race / TOCTOU).
-    fd = fs.openSync(inboxPath(ticketId), 'r');
+    // check-then-use gap (CodeQL file-system-race / TOCTOU). The explicit
+    // 0o600 mode is inert for 'r' opens (mode only applies on create) but
+    // satisfies CodeQL js/insecure-temporary-file, whose only barrier for
+    // temp-dir opens is a mode with group/other bits cleared.
+    fd = fs.openSync(inboxPath(ticketId), 'r', 0o600);
     const size = fs.fstatSync(fd).size;
     const offset = typeof state._inboxOffset === 'number' ? state._inboxOffset : size;
     if (state._inboxOffset === undefined) {

--- a/plugins/work/scripts/workflows/follow-up/lib/notify.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/notify.js
@@ -41,8 +41,10 @@ function inboxPath(ticketId) {
 function notifyOperator(ticketId, message) {
   const line = `${FOLLOW_UP_TAG} ${new Date().toISOString()} ${message}\n`;
   try {
-    fs.mkdirSync(inboxDir(), { recursive: true });
-    fs.appendFileSync(inboxPath(ticketId), line);
+    // Owner-only modes: the mailbox lives under a shared temp root, so the
+    // directory is 0o700 and the log 0o600 (CodeQL js/insecure-temporary-file).
+    fs.mkdirSync(inboxDir(), { recursive: true, mode: 0o700 });
+    fs.appendFileSync(inboxPath(ticketId), line, { mode: 0o600 });
   } catch {
     /* fail-open — mailbox is best-effort */
   }
@@ -61,32 +63,42 @@ function notifyOperator(ticketId, message) {
  * @returns {string[]} new operator lines (possibly empty)
  */
 function readNewInboxMessages(ticketId, state) {
+  let fd;
   try {
-    const file = inboxPath(ticketId);
-    const stat = fs.statSync(file);
-    const offset = typeof state._inboxOffset === 'number' ? state._inboxOffset : stat.size;
+    // Open once, then fstat + read on the SAME descriptor — no
+    // check-then-use gap (CodeQL file-system-race / TOCTOU).
+    fd = fs.openSync(inboxPath(ticketId), 'r');
+    const size = fs.fstatSync(fd).size;
+    const offset = typeof state._inboxOffset === 'number' ? state._inboxOffset : size;
     if (state._inboxOffset === undefined) {
       // First sighting: start from the current end so historical chatter
       // doesn't replay as "new" messages.
-      state._inboxOffset = stat.size;
+      state._inboxOffset = size;
       return [];
     }
-    if (stat.size <= offset) return [];
-    const fd = fs.openSync(file, 'r');
-    try {
-      const buf = Buffer.alloc(stat.size - offset);
-      fs.readSync(fd, buf, 0, buf.length, offset);
-      state._inboxOffset = stat.size;
-      return buf
-        .toString('utf8')
-        .split('\n')
-        .map((l) => l.trim())
-        .filter((l) => l.length > 0 && !l.includes(FOLLOW_UP_TAG));
-    } finally {
-      fs.closeSync(fd);
-    }
+    if (size <= offset) return [];
+    const buf = Buffer.alloc(size - offset);
+    fs.readSync(fd, buf, 0, buf.length, offset);
+    state._inboxOffset = size;
+    return buf
+      .toString('utf8')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !l.includes(FOLLOW_UP_TAG));
   } catch {
+    // No mailbox file yet: anchor at 0 so a message that CREATES the file
+    // mid-wait is picked up as new (everything in a file born after the
+    // anchor is, by definition, new — there is no historical chatter).
+    if (state._inboxOffset === undefined) state._inboxOffset = 0;
     return [];
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
   }
 }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/sleep.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/sleep.js
@@ -1,0 +1,40 @@
+/**
+ * sleep.js — synchronous sleep via Atomics.wait.
+ *
+ * No subprocess, no event-loop dependency — replaces the previous
+ * `execSync('node -e setTimeout…')` pattern, which crashed the whole
+ * orchestrator with an uncaught `spawnSync /bin/sh ETIMEDOUT` when the
+ * machine was under load (triage.js:20, echo-6209).
+ */
+
+'use strict';
+
+function sleepSync(ms) {
+  try {
+    const sab = new SharedArrayBuffer(4);
+    Atomics.wait(new Int32Array(sab), 0, 0, ms);
+  } catch {
+    /* sleep best-effort */
+  }
+}
+
+/**
+ * Sleep up to `ms`, in `chunkMs` slices, calling `shouldWake()` between
+ * slices. Returns true when it woke early because shouldWake() was truthy.
+ */
+function sleepSyncInterruptible(ms, shouldWake, chunkMs) {
+  const chunk = chunkMs || 5000;
+  let remaining = ms;
+  while (remaining > 0) {
+    sleepSync(Math.min(chunk, remaining));
+    remaining -= chunk;
+    try {
+      if (shouldWake && shouldWake()) return true;
+    } catch {
+      /* wake-check is best-effort */
+    }
+  }
+  return false;
+}
+
+module.exports = { sleepSync, sleepSyncInterruptible };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews-done-routing.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews-done-routing.test.js
@@ -76,13 +76,43 @@ describe('fix-reviews — done-path routing and counts', () => {
     assert.equal(state.currentStep, 'report');
   });
 
-  it('routes through push-retry when the worktree has unpushed work', () => {
+  it('routes through push-retry when commits exist ahead of upstream', () => {
+    // Real upstream: bare remote + clone, push -u, then one more commit.
+    const bareDir = path.join(tmpDir, 'origin.git');
     const repoDir = path.join(tmpDir, 'repo');
-    fs.mkdirSync(repoDir);
-    execFileSync('git', ['init', '-q'], { cwd: repoDir });
-    fs.writeFileSync(path.join(repoDir, 'fix.js'), '// review fix\n'); // dirty tree
+    execFileSync('git', ['init', '-q', '--bare', bareDir]);
+    execFileSync('git', ['clone', '-q', bareDir, repoDir]);
+    const git = (args) =>
+      execFileSync('git', args, {
+        cwd: repoDir,
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: 't',
+          GIT_AUTHOR_EMAIL: 't@t',
+          GIT_COMMITTER_NAME: 't',
+          GIT_COMMITTER_EMAIL: 't@t',
+        },
+      });
+    fs.writeFileSync(path.join(repoDir, 'a.js'), '// base\n');
+    git(['add', '.']);
+    git(['commit', '-q', '-m', 'base']);
+    git(['push', '-q', '-u', 'origin', 'HEAD']);
+    fs.writeFileSync(path.join(repoDir, 'fix.js'), '// review fix\n');
+    git(['add', '.']);
+    git(['commit', '-q', '-m', 'fix(review): x']); // 1 ahead of upstream
     const { state } = runDonePath(repoDir, '{"remaining":0,"total":1,"solved":1,"skipped":0}');
     assert.equal(state.currentStep, 'push-retry', 'unpushed fixes must go through push-retry');
+  });
+
+  it('a dirty no-upstream worktree does NOT loop into push-retry (strict probe)', () => {
+    // Regression: the dirty-tree fallback used to send done→push-retry every
+    // cycle for a stray untracked file, spinning _pushRetryCount to the cap.
+    const repoDir = path.join(tmpDir, 'dirty-repo');
+    fs.mkdirSync(repoDir);
+    execFileSync('git', ['init', '-q'], { cwd: repoDir });
+    fs.writeFileSync(path.join(repoDir, 'stray.log'), 'junk\n'); // dirty, no upstream
+    const { state } = runDonePath(repoDir, '{"remaining":0,"total":1,"solved":1,"skipped":0}');
+    assert.equal(state.currentStep, 'report', 'no unpushed COMMITS → report, not push-retry');
   });
 
   it('skipped>0: still records both counts', () => {

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews-done-routing.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews-done-routing.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+// fix-reviews-done-routing.test.js — when all comments are terminal the step
+// must (a) record solved/skipped counts on EVERY done path (the all-solved
+// path previously recorded nothing, so the completion summary never
+// mentioned reviews), and (b) route through push-retry when review-fix
+// commits are still unpushed (previously the skipped>0 path jumped straight
+// to report and the workflow completed with the fixes never pushed).
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+function loadFixReviewsHandler() {
+  const handlers = {};
+  delete require.cache[require.resolve('../fix-reviews')];
+  require('../fix-reviews')((name, fn) => {
+    handlers[name] = fn;
+  });
+  return handlers['fix-reviews'];
+}
+
+// A stand-in follow-up-pr-comments.js: --next-comment says done, --status
+// reports the counts baked into the stub via env.
+const STUB_COMMENTS_SCRIPT = `
+'use strict';
+const arg = process.argv[2];
+if (arg === '--next-comment') { console.log(JSON.stringify({ done: true })); }
+else if (arg === '--status') {
+  console.log(process.env.STUB_STATUS_JSON || '{"remaining":0,"total":2,"solved":2,"skipped":0}');
+} else { console.log('{}'); }
+`;
+
+describe('fix-reviews — done-path routing and counts', () => {
+  let tmpDir;
+  let workScriptsDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fixrev-test-'));
+    workScriptsDir = path.join(tmpDir, 'scripts');
+    fs.mkdirSync(workScriptsDir, { recursive: true });
+    fs.writeFileSync(path.join(workScriptsDir, 'follow-up-pr-comments.js'), STUB_COMMENTS_SCRIPT);
+  });
+
+  afterEach(() => {
+    delete process.env.STUB_STATUS_JSON;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runDonePath(worktreeDir, statusJson) {
+    if (statusJson) process.env.STUB_STATUS_JSON = statusJson;
+    const handler = loadFixReviewsHandler();
+    const state = {
+      ticketId: 'GH-7',
+      prNumber: 5,
+      currentStep: 'fix-reviews',
+      _reviewSnapshotDone: true,
+    };
+    const result = handler(state, { worktreeDir, workScriptsDir });
+    return { state, result };
+  }
+
+  it('all-solved: records counts and routes to report when nothing is unpushed', () => {
+    const cleanDir = path.join(tmpDir, 'clean'); // not a git repo → nothing unpushed
+    fs.mkdirSync(cleanDir);
+    const { state, result } = runDonePath(
+      cleanDir,
+      '{"remaining":0,"total":2,"solved":2,"skipped":0}'
+    );
+    assert.equal(result, null);
+    assert.equal(state._solvedReviewsCount, 2, 'solved count recorded even with skipped=0');
+    assert.equal(state._skippedReviewsCount, 0);
+    assert.equal(state.currentStep, 'report');
+  });
+
+  it('routes through push-retry when the worktree has unpushed work', () => {
+    const repoDir = path.join(tmpDir, 'repo');
+    fs.mkdirSync(repoDir);
+    execFileSync('git', ['init', '-q'], { cwd: repoDir });
+    fs.writeFileSync(path.join(repoDir, 'fix.js'), '// review fix\n'); // dirty tree
+    const { state } = runDonePath(repoDir, '{"remaining":0,"total":1,"solved":1,"skipped":0}');
+    assert.equal(state.currentStep, 'push-retry', 'unpushed fixes must go through push-retry');
+  });
+
+  it('skipped>0: still records both counts', () => {
+    const cleanDir = path.join(tmpDir, 'clean2');
+    fs.mkdirSync(cleanDir);
+    const { state } = runDonePath(cleanDir, '{"remaining":0,"total":3,"solved":2,"skipped":1}');
+    assert.equal(state._solvedReviewsCount, 2);
+    assert.equal(state._skippedReviewsCount, 1);
+    assert.equal(state.currentStep, 'report');
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews-done-routing.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews-done-routing.test.js
@@ -115,6 +115,16 @@ describe('fix-reviews — done-path routing and counts', () => {
     assert.equal(state.currentStep, 'report', 'no unpushed COMMITS → report, not push-retry');
   });
 
+  it('"N of M" counter uses the stable total, not the shrinking remaining', () => {
+    const { computeCounts } = require('../fix-reviews.js');
+    // 3 comments, 2 already terminal → agent is on comment 3 of 3.
+    const counts = computeCounts({ remaining: 1, total: 3, solved: 1, skipped: 1 });
+    assert.equal(counts.totalComments, 3, 'denominator must be the stable total');
+    assert.equal(counts.currentIndex, 3);
+    // No status → unknowns, no crash.
+    assert.deepEqual(computeCounts(null), { totalComments: '?', currentIndex: '?' });
+  });
+
   it('skipped>0: still records both counts', () => {
     const cleanDir = path.join(tmpDir, 'clean2');
     fs.mkdirSync(cleanDir);

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/fix-reviews.test.js
@@ -14,6 +14,28 @@ const path = require('node:path');
 const FIX_REVIEWS_PATH = path.resolve(__dirname, '..', 'fix-reviews.js');
 const SOURCE = fs.readFileSync(FIX_REVIEWS_PATH, 'utf8');
 
+// Build the ACTUAL assembled prompt so ordering/spread assertions test the
+// emitted string, not the raw source-file layout (a source-text check passes
+// even if reviewJudgmentBlock is never spread into the prompt array).
+const { buildReviewPrompt } = require('../fix-reviews.js');
+const PROMPT = buildReviewPrompt(
+  {
+    author: 'cursor',
+    priority: 'Medium',
+    body: 'body',
+    codeContext: 'code',
+    path: 'a.js',
+    line: 12,
+  },
+  'a.js:12',
+  { currentIndex: 1, totalComments: 1 },
+  {
+    solveCmd: 'node c --mark-locally-solved',
+    skipCmd: 'node c --mark-locally-skipped',
+    nextCmd: 'node n',
+  }
+);
+
 describe('fix-reviews delegate block (Task 7)', () => {
   it('Delegate-block text in fix-reviews.js uses the new flag names', () => {
     assert.ok(
@@ -54,5 +76,124 @@ describe('fix-reviews delegate block (Task 7)', () => {
       !SOURCE.includes('--skip-comment'),
       'expected NO remaining references to --skip-comment'
     );
+  });
+});
+
+describe('fix-reviews judgment step (Task 1, GH-352)', () => {
+  // 1.1 — Verify-the-code judgment step before the fix-or-skip choice
+  it('prompts the agent to judge the comment before acting (heading present)', () => {
+    assert.ok(
+      /Before you act/i.test(SOURCE),
+      'expected a judgment heading like "Before you act" in the prompt'
+    );
+  });
+
+  it('instructs the agent to read the referenced code at fileRef', () => {
+    assert.ok(
+      /read the (referenced )?code/i.test(PROMPT),
+      'expected an instruction to read the referenced code in the assembled prompt'
+    );
+    // Assert the actual fileRef VALUE reaches the prompt, not just that the
+    // parameter name 'fileRef' appears in source (which is always true).
+    assert.ok(
+      PROMPT.includes('a.js:12'),
+      'expected the assembled prompt to reference the concrete file:line the agent must read'
+    );
+  });
+
+  it("instructs the agent to verify the bot's claim against the current code", () => {
+    assert.ok(/[Vv]erify.*claim/.test(SOURCE), "expected an instruction to verify the bot's claim");
+    assert.ok(
+      /current code/i.test(SOURCE),
+      'expected the verification to be against the current code'
+    );
+  });
+
+  it('places the judgment step before the Option A / Option B action block', () => {
+    // Assert against the ASSEMBLED prompt, not source layout: this fails if
+    // reviewJudgmentBlock is removed from buildReviewPrompt's prompt array.
+    const judgmentIdx = PROMPT.search(/Before you act/i);
+    const actionIdx = PROMPT.indexOf('## You MUST do exactly ONE of these:');
+    assert.ok(judgmentIdx !== -1, 'expected a judgment heading in the assembled prompt');
+    assert.ok(actionIdx !== -1, 'expected the action block in the assembled prompt');
+    assert.ok(
+      judgmentIdx < actionIdx,
+      'expected the judgment step to appear before the action block'
+    );
+  });
+
+  // 1.2 — Six-category classification taxonomy with prescribed actions.
+  // Assert against PROMPT (the assembled string) so the taxonomy is proven to
+  // actually reach the agent, not merely exist in a comment or dead branch.
+  it('lists all six classification categories', () => {
+    assert.ok(/real bug/i.test(PROMPT), 'expected "real bug" category');
+    assert.ok(/real improvement/i.test(PROMPT), 'expected "real improvement" category');
+    assert.ok(/style\/naming/i.test(PROMPT), 'expected "style/naming preference" category');
+    assert.ok(/false positive/i.test(PROMPT), 'expected "false positive" category');
+    assert.ok(
+      /conflicts with (the )?user intent/i.test(PROMPT),
+      'expected "conflicts with user intent" category'
+    );
+    assert.ok(/ambiguous/i.test(PROMPT), 'expected "ambiguous" category');
+  });
+
+  it('states the prescribed action for false positive (skip with evidence)', () => {
+    assert.ok(
+      /false positive[\s\S]{0,80}skip[\s\S]{0,40}evidence/i.test(PROMPT),
+      'expected "false positive" to prescribe skip with evidence'
+    );
+  });
+
+  it('states the prescribed action for ambiguous (ask the user)', () => {
+    assert.ok(
+      /ambiguous[\s\S]{0,80}ask the user/i.test(PROMPT),
+      'expected "ambiguous" to prescribe asking the user'
+    );
+  });
+
+  // 1.3 — Record the classification inside the solve/skip reason
+  it('requires the chosen category in the skip reason string', () => {
+    assert.ok(
+      /classification|category/i.test(PROMPT),
+      'expected an instruction referencing the chosen classification/category'
+    );
+    assert.ok(
+      /<reason>/.test(PROMPT),
+      'expected the skip reason placeholder <reason> to be referenced'
+    );
+    assert.ok(/\[<category>\]/.test(PROMPT), 'expected a leading [<category>] token instruction');
+  });
+
+  it('requires the chosen category in the solve description string', () => {
+    assert.ok(
+      /<description>/.test(PROMPT),
+      'expected the solve description placeholder <description> to be referenced'
+    );
+    assert.ok(
+      /--mark-locally-solved/.test(PROMPT),
+      'expected the solve command to remain referenced'
+    );
+  });
+});
+
+describe('fix-reviews preserved action contract (Task 1, GH-352)', () => {
+  // 1.4 — Preserve the existing action contract
+  it('still presents exactly one of Option A / Option B', () => {
+    assert.ok(SOURCE.includes('Option A'), 'expected Option A to remain');
+    assert.ok(SOURCE.includes('Option B'), 'expected Option B to remain');
+  });
+
+  it('still references both --mark-locally-* flags', () => {
+    assert.ok(SOURCE.includes('--mark-locally-solved'));
+    assert.ok(SOURCE.includes('--mark-locally-skipped'));
+  });
+
+  it('still contains the Do NOT pipe the output guidance', () => {
+    assert.ok(SOURCE.includes('Do NOT pipe the output'), 'expected the no-pipe guidance to remain');
+  });
+
+  it('does not reintroduce the legacy flag names', () => {
+    assert.ok(!SOURCE.includes('--solve-comment'));
+    assert.ok(!SOURCE.includes('--skip-comment'));
   });
 });

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/monitor-notify-seed.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/monitor-notify-seed.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// monitor-notify-seed.test.js — notifyOnNewBlockingComments must SEED on the
+// first observation (comments already present at workflow start are being
+// actively processed; re-announcing them after every --init is noise) and
+// notify only when the blocking count GROWS afterwards.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { notifyOnNewBlockingComments } = require('../monitor').__test__;
+const { inboxPath } = require('../../notify');
+
+describe('monitor — new-blocking-comment notifications', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'monitor-notify-'));
+    process.env.CLAUDE_AGENT_INBOX_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_AGENT_INBOX_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function mailbox(ticket) {
+    try {
+      return fs.readFileSync(inboxPath(ticket), 'utf8');
+    } catch {
+      return '';
+    }
+  }
+
+  it('first observation seeds the counter without notifying', () => {
+    const state = { ticketId: 'GH-N1', prNumber: 9 };
+    notifyOnNewBlockingComments(state, { blocking: [{}, {}, {}] });
+    assert.equal(state._lastBlockingCount, 3);
+    assert.equal(mailbox('GH-N1'), '', 'pre-existing comments must not be announced');
+  });
+
+  it('notifies when the count grows after seeding', () => {
+    const state = { ticketId: 'GH-N2', prNumber: 9 };
+    notifyOnNewBlockingComments(state, { blocking: [{}] }); // seed at 1
+    notifyOnNewBlockingComments(state, { blocking: [{}, {}, {}] }); // 1 → 3
+    const content = mailbox('GH-N2');
+    assert.ok(content.includes('2 new blocking review comment(s)'), content);
+    assert.equal(state._lastBlockingCount, 3);
+  });
+
+  it('does not notify when the count shrinks or holds', () => {
+    const state = { ticketId: 'GH-N3', prNumber: 9 };
+    notifyOnNewBlockingComments(state, { blocking: [{}, {}] }); // seed
+    notifyOnNewBlockingComments(state, { blocking: [{}] }); // shrink
+    notifyOnNewBlockingComments(state, { blocking: [{}] }); // hold
+    assert.equal(mailbox('GH-N3'), '');
+    assert.equal(state._lastBlockingCount, 1);
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/report-complete-loop.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/report-complete-loop.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+// report-complete-loop.test.js — the report step must COMPLETE (not surface
+// forever) for failure categories that triage legitimately sets on its
+// routing paths ('reviews', 'ci_cancelled_blocking' — echo-6204), and the
+// completion summary must itemize what happened to each review comment.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function loadReportHandler() {
+  const handlers = {};
+  delete require.cache[require.resolve('../report')];
+  require('../report')((name, fn) => {
+    handlers[name] = fn;
+  });
+  return handlers.report;
+}
+
+describe('report step — completion vs surface loop', () => {
+  let tmpDir;
+  let ctx;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-test-'));
+    process.env.CLAUDE_AGENT_INBOX_DIR = tmpDir; // hermetic notifications
+    ctx = { tasksDir: tmpDir, worktreeDir: tmpDir };
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_AGENT_INBOX_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function baseState(overrides) {
+    return {
+      ticketId: 'GH-9',
+      prNumber: 42,
+      attempt: 3,
+      status: 'in_progress',
+      lastMonitorResult: { exitCode: 0, output: 'CI: PASSING' },
+      ...overrides,
+    };
+  }
+
+  it("failureCategory 'reviews' completes instead of surfacing (echo-6204)", () => {
+    const report = loadReportHandler();
+    const state = baseState({ failureCategory: 'reviews' });
+    const result = report(state, ctx);
+    assert.equal(result.action, 'complete');
+    assert.equal(state.status, 'complete');
+  });
+
+  it("failureCategory 'ci_cancelled_blocking' completes instead of surfacing", () => {
+    const report = loadReportHandler();
+    const state = baseState({ failureCategory: 'ci_cancelled_blocking' });
+    const result = report(state, ctx);
+    assert.equal(result.action, 'complete');
+  });
+
+  it('unknown failureCategory still surfaces (GH-508 guard preserved)', () => {
+    const report = loadReportHandler();
+    const state = baseState({ failureCategory: 'github-actions-outage' });
+    const result = report(state, ctx);
+    assert.equal(result.action, 'surface');
+    assert.notEqual(state.status, 'complete');
+  });
+
+  it('completion summary itemizes solved/skipped/outdated comments', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'follow-up-comments.json'),
+      JSON.stringify({
+        comments: [
+          {
+            id: 'c1',
+            author: 'cursor[bot]',
+            path: 'src/a.js',
+            line: 10,
+            status: 'solved',
+            resolution: 'Fixed null deref',
+          },
+          {
+            id: 'c2',
+            author: 'cursor[bot]',
+            path: 'src/b.js',
+            status: 'skipped',
+            resolution: 'Outside scope of brief/spec',
+          },
+          {
+            id: 'c3',
+            author: 'copilot',
+            path: 'src/c.js',
+            status: 'resolved',
+            resolution: 'Outdated (code changed since comment)',
+          },
+          { id: 'c4', author: 'cursor[bot]', path: 'src/d.js', status: 'unsolved' },
+        ],
+      })
+    );
+    const report = loadReportHandler();
+    const state = baseState({ _solvedReviewsCount: 1, _skippedReviewsCount: 1 });
+    const result = report(state, ctx);
+    assert.equal(result.action, 'complete');
+    assert.ok(result.summary.includes('src/a.js:10'), 'solved comment itemized');
+    assert.ok(result.summary.includes('Fixed null deref'), 'solved resolution shown');
+    assert.ok(result.summary.includes('src/b.js'), 'skipped comment itemized');
+    assert.ok(result.summary.includes('Outside scope'), 'skip reason shown');
+    assert.ok(result.summary.includes('src/c.js'), 'outdated comment itemized — not dropped');
+    assert.ok(!result.summary.includes('src/d.js'), 'unsolved comments not listed as addressed');
+    assert.ok(result.summary.includes('1 solved, 1 skipped'), 'aggregate counts present');
+  });
+
+  it('completion summary stays terse when there were no review comments', () => {
+    const report = loadReportHandler();
+    const result = report(baseState({}), ctx);
+    assert.equal(result.action, 'complete');
+    assert.ok(!result.summary.includes('Review comments:'));
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/triage-early-reviews.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/triage-early-reviews.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// triage-early-reviews.test.js — GH-268: actionable review comments are
+// surfaced BEFORE the CI wait. When a bot has submitted its review (done, not
+// in-progress) and blocking comments exist, triage routes to fix-reviews even
+// while CI is still pending. When the review is still in progress, triage
+// keeps waiting (no partial reviews surfaced).
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+function loadTriageHandler() {
+  const handlers = {};
+  delete require.cache[require.resolve('../triage')];
+  require('../triage')((name, fn) => {
+    handlers[name] = fn;
+  });
+  return handlers.triage;
+}
+
+describe('triage — early review surfacing (GH-268)', () => {
+  beforeEach(() => {
+    process.env.FOLLOW_UP2_NO_DELAY = '1';
+  });
+
+  afterEach(() => {
+    delete process.env.FOLLOW_UP2_NO_DELAY;
+  });
+
+  function run(output) {
+    const triage = loadTriageHandler();
+    const state = {
+      ticketId: 'GH-268',
+      attempt: 1,
+      maxAttempts: 40,
+      lastMonitorResult: { exitCode: 1, output },
+    };
+    const result = triage(state, {});
+    return { state, result };
+  }
+
+  it('routes to fix-reviews while CI is still PENDING when the bot review is submitted', () => {
+    const { state } = run('CI: PENDING\nReviews: 2 BLOCKING');
+    assert.equal(state.currentStep, 'fix-reviews', 'reviews must preempt the CI wait');
+    assert.equal(state.failureCategory, 'reviews');
+  });
+
+  it('keeps waiting when the bot review is still in progress (no partial reviews)', () => {
+    const { state } = run('CI: PENDING\nReviews: 2 BLOCKING\nCursor Bugbot — running');
+    assert.equal(state.currentStep, 'monitor', 'in-progress review falls back to waiting');
+  });
+
+  it('keeps waiting on CI when there are no blocking reviews', () => {
+    const { state } = run('CI: PENDING\nReviews: CLEAR');
+    assert.equal(state.currentStep, 'monitor');
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/triage-wait-interrupt.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/triage-wait-interrupt.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+// triage-wait-interrupt.test.js — the wait loop must (a) never spawn a
+// subprocess to sleep (the execSync pattern crashed uncaught with
+// `spawnSync /bin/sh ETIMEDOUT` under load, echo-6209), and (b) wake early
+// and surface fresh operator inbox messages instead of sleeping through them.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const TRIAGE_SOURCE = fs.readFileSync(path.resolve(__dirname, '..', 'triage.js'), 'utf8');
+
+function loadTriageHandler() {
+  const handlers = {};
+  delete require.cache[require.resolve('../triage')];
+  require('../triage')((name, fn) => {
+    handlers[name] = fn;
+  });
+  return handlers.triage;
+}
+
+describe('triage wait loop', () => {
+  it('no subprocess-based sleep remains (ETIMEDOUT crash class removed)', () => {
+    assert.ok(!TRIAGE_SOURCE.includes('execSync'), 'triage must not sleep via execSync');
+    assert.ok(TRIAGE_SOURCE.includes('sleepSyncInterruptible'), 'uses the Atomics-based sleep');
+  });
+
+  it('routes back to monitor after a quiet wait (FOLLOW_UP2_NO_DELAY)', () => {
+    process.env.FOLLOW_UP2_NO_DELAY = '1';
+    try {
+      const triage = loadTriageHandler();
+      const state = {
+        ticketId: 'GH-8',
+        attempt: 1,
+        maxAttempts: 40,
+        _ciRunningCount: 1,
+        lastMonitorResult: { exitCode: 1, output: 'CI: PENDING' },
+      };
+      const result = triage(state, {});
+      assert.equal(result, null);
+      assert.equal(state.currentStep, 'monitor');
+    } finally {
+      delete process.env.FOLLOW_UP2_NO_DELAY;
+    }
+  });
+
+  it('wakes early and surfaces operator messages that arrive mid-wait', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'triage-inbox-'));
+    process.env.CLAUDE_AGENT_INBOX_DIR = tmpDir;
+    try {
+      const inboxFile = path.join(tmpDir, 'GH-8.log');
+      fs.writeFileSync(inboxFile, '');
+      const triage = loadTriageHandler();
+      const state = {
+        ticketId: 'GH-8',
+        prNumber: 12,
+        attempt: 1,
+        maxAttempts: 40,
+        _ciRunningCount: 1, // → 15s pending interval
+        _inboxOffset: 0, // anchored before the message below
+        lastMonitorResult: { exitCode: 1, output: 'CI: PENDING' },
+      };
+      fs.appendFileSync(inboxFile, 'operator says: hold the push\n');
+      const result = triage(state, {});
+      assert.ok(result, 'expected an instruction, not a silent advance');
+      assert.equal(result.action, 'blocked');
+      assert.equal(result.payload.reason, 'operator-message');
+      assert.ok(result.reason.includes('hold the push'));
+      assert.equal(state.currentStep, 'monitor', 'resume continues at monitor');
+    } finally {
+      delete process.env.CLAUDE_AGENT_INBOX_DIR;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/triage-wait-interrupt.test.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/__tests__/triage-wait-interrupt.test.js
@@ -5,7 +5,7 @@
 // `spawnSync /bin/sh ETIMEDOUT` under load, echo-6209), and (b) wake early
 // and surface fresh operator inbox messages instead of sleeping through them.
 
-const { describe, it, beforeEach, afterEach } = require('node:test');
+const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
@@ -118,10 +118,13 @@ function handleNoMoreComments(state, commentsScript, ctx, scriptEnv) {
   return null;
 }
 
+// The denominator must be the STABLE total: `remaining` shrinks while
+// currentIndex grows, so preferring it produced counters that ran backwards
+// ("Comment 3 of 1" on the last of three) — review finding on PR #666.
 function computeCounts(st) {
   if (!st) return { totalComments: '?', currentIndex: '?' };
   return {
-    totalComments: st.remaining || st.total || '?',
+    totalComments: st.total || st.remaining || '?',
     currentIndex: (st.solved || 0) + (st.skipped || 0) + 1,
   };
 }
@@ -308,3 +311,4 @@ module.exports = function registerFixReviews(register) {
 // block's content is covered transitively via buildReviewPrompt, so it is not
 // exported separately.
 module.exports.buildReviewPrompt = buildReviewPrompt;
+module.exports.computeCounts = computeCounts;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
@@ -19,6 +19,7 @@
 
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { hasUnpushedCommits } = require('../git-unpushed');
 
 function blocked(reason) {
   return { type: 'follow_up_instruction', action: 'blocked', reason };
@@ -86,11 +87,19 @@ function fetchNextComment(state, commentsScript, ctx, scriptEnv) {
   }
 }
 
-// No more actionable comments. When all remaining comments are terminal (solved
-// or skipped), advance directly to `report` and let the workflow finish — the
-// rationale for each skip is preserved in follow-up-comments.json for later
-// review. Previously this returned `action: 'blocked'` which forced a manual
-// "I have reviewed, re-run" ack-loop even after the user had approved the skips.
+// No more actionable comments. When all remaining comments are terminal
+// (solved or skipped), record the counts and finish — the rationale for each
+// disposition is preserved in follow-up-comments.json and itemized by the
+// report step. Previously this returned `action: 'blocked'` which forced a
+// manual "I have reviewed, re-run" ack-loop even after the user had approved
+// the skips.
+//
+// Routing: when review-fix commits are still unpushed, go through push-retry
+// first (the old skipped>0 path jumped straight to report and completed the
+// workflow with the fixes never pushed). Otherwise go to report. Counts are
+// recorded on EVERY done-path — including all-solved — so the completion
+// summary can itemize what was addressed (previously the skipped===0 path
+// fell through with no counts and the summary never mentioned reviews).
 //
 // Loop-break invariant: routing to `report` marks the workflow `status:
 // complete`, so re-running /follow-up without --init returns "Already complete"
@@ -98,11 +107,11 @@ function fetchNextComment(state, commentsScript, ctx, scriptEnv) {
 function handleNoMoreComments(state, commentsScript, ctx, scriptEnv) {
   delete state._reviewSnapshotDone;
   const statusResult = readCommentsStatus(commentsScript, ctx, scriptEnv);
-  if (statusResult && statusResult.skipped > 0) {
-    state._skippedReviewsCount = statusResult.skipped;
+  if (statusResult) {
+    state._skippedReviewsCount = statusResult.skipped || 0;
     state._solvedReviewsCount = statusResult.solved || 0;
-    state.currentStep = 'report';
   }
+  state.currentStep = hasUnpushedCommits(ctx.worktreeDir) ? 'push-retry' : 'report';
   return null;
 }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
@@ -162,6 +162,32 @@ function cleanCommentBody(rawBody) {
     .trim();
 }
 
+// Mandatory judgment/triage step (GH-352). Lifted to module scope so
+// buildReviewPrompt stays under the 80-line/function cap. The agent must
+// read the referenced code and verify the bot's claim BEFORE choosing Option
+// A / Option B, classify into one of six categories, and record the chosen
+// category inside the solve/skip reason so it persists in comment.resolution.
+function reviewJudgmentBlock(fileRef) {
+  return [
+    '## Before you act — judge the comment:',
+    `1. **Read the referenced code** at \`${fileRef}\` (the file/line above).`,
+    "2. **Verify the bot's claim** is accurate against the current code — do not trust it blindly.",
+    '3. **Classify** the comment into exactly one category and take the prescribed action:',
+    '   - **real bug** → fix (Option A)',
+    '   - **real improvement** (perf/maintainability, related to this PR) → fix (Option A)',
+    '   - **style/naming preference** → skip with reason (Option B)',
+    '   - **false positive** (bot misread the code) → skip with evidence (Option B)',
+    '   - **conflicts with user intent / ticket requirements** → skip with reason (Option B)',
+    '   - **ambiguous** (unsure whether it applies) → ask the user',
+    '4. **Record the classification**: put a leading `[<category>]` token at the start of the',
+    '   `<reason>` you pass to `--mark-locally-skipped` and the `<description>` you pass to',
+    '   `--mark-locally-solved`, so the category persists in the comment resolution.',
+    '',
+    '---',
+    '',
+  ];
+}
+
 function buildReviewPrompt(comment, fileRef, counts, commands) {
   const author = comment.author || 'unknown';
   const priority = comment.priority || 'unknown';
@@ -177,6 +203,7 @@ function buildReviewPrompt(comment, fileRef, counts, commands) {
     codeContext ? `### Current code:\n\`\`\`\n${codeContext}\n\`\`\`\n` : '',
     '---',
     '',
+    ...reviewJudgmentBlock(fileRef),
     '## You MUST do exactly ONE of these:',
     '',
     '### Option A — Fix the code:',
@@ -272,3 +299,9 @@ module.exports = function registerFixReviews(register) {
     return buildReviewExecute(state, comment, commentsScript, counts);
   });
 };
+
+// Exposed for tests so ordering/content assertions run against the ACTUAL
+// assembled prompt string rather than the raw source-file layout. The judgment
+// block's content is covered transitively via buildReviewPrompt, so it is not
+// exported separately.
+module.exports.buildReviewPrompt = buildReviewPrompt;

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/fix-reviews.js
@@ -19,7 +19,7 @@
 
 const path = require('path');
 const { execFileSync } = require('child_process');
-const { hasUnpushedCommits } = require('../git-unpushed');
+const { hasUnpushedCommitsStrict } = require('../git-unpushed');
 
 function blocked(reason) {
   return { type: 'follow_up_instruction', action: 'blocked', reason };
@@ -111,7 +111,10 @@ function handleNoMoreComments(state, commentsScript, ctx, scriptEnv) {
     state._skippedReviewsCount = statusResult.skipped || 0;
     state._solvedReviewsCount = statusResult.solved || 0;
   }
-  state.currentStep = hasUnpushedCommits(ctx.worktreeDir) ? 'push-retry' : 'report';
+  // STRICT commits-only probe: the dirty-tree fallback would misroute a
+  // no-upstream worktree with stray untracked files into an endless
+  // done→push-retry cycle (review finding on PR #666).
+  state.currentStep = hasUnpushedCommitsStrict(ctx.worktreeDir) ? 'push-retry' : 'report';
   return null;
 }
 

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor-ci-context.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor-ci-context.js
@@ -23,6 +23,21 @@ function buildInitialFailedJobs(ci) {
   });
 }
 
+// GH-214: collect the unique GitHub Actions run IDs across ALL job buckets
+// (running/passed/failed/cancelled/neutral) so the monitor can persist them to
+// state each cycle — a later invocation (or an operator) can resume/inspect
+// the same runs without re-deriving them from terminal output.
+function collectRunIds(ci) {
+  const ids = new Set();
+  for (const bucket of ['running', 'passed', 'failed', 'cancelled', 'neutral']) {
+    for (const j of ci[bucket] || []) {
+      const m = String(j.url || j.link || '').match(/runs\/(\d+)/);
+      if (m) ids.add(m[1]);
+    }
+  }
+  return [...ids];
+}
+
 // Resolve missing runIds via the check-runs API at HEAD SHA. Matrix parent
 // checks ("🧪 Run Integration Tests [tests]") often have no `link` in
 // `gh pr checks`, so fix-ci would have nothing to fetch.
@@ -175,6 +190,7 @@ function extractFailedTestPaths(rawLogs) {
 
 module.exports = {
   buildInitialFailedJobs,
+  collectRunIds,
   resolveMissingRunIds,
   mapCiStatus,
   fetchClassifierContext,

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor-status-line.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor-status-line.js
@@ -66,17 +66,26 @@ function ciDetail(ci) {
   return '';
 }
 
+// Compose the one-line summary from structured parts + a (re)computed
+// elapsed string. Shared by the monitor step (persist time) and the status
+// bar renderer (refresh time) so the timer ticks live instead of freezing at
+// whatever the last monitor cycle stringified.
+function composeStatusLine(parts, elapsed) {
+  return [parts.statusLabel, parts.poll, elapsed, parts.counts].filter(Boolean).join(' · ');
+}
+
 function buildStatusLine(state, ci, reviews) {
   const attempt = state.attempt || 1;
   const maxAttempts = state.maxAttempts || 40;
-  const parts = ciCountParts(ci, reviews);
-  const statusLabel = ciStatusLabel(ci.status);
+  const countParts = ciCountParts(ci, reviews);
   const detail = ciDetail(ci);
-  const elapsed = formatElapsed(state._monitorStartTime);
-  const counts = parts.length > 0 ? parts.join(' ╎ ') : '';
-  const poll = `${attempt}/${maxAttempts}`;
-  const line1 = [statusLabel, poll, elapsed, counts].filter(Boolean).join(' · ');
-  return { line1, detail };
+  const parts = {
+    statusLabel: ciStatusLabel(ci.status),
+    poll: `${attempt}/${maxAttempts}`,
+    counts: countParts.length > 0 ? countParts.join(' ╎ ') : '',
+  };
+  const line1 = composeStatusLine(parts, formatElapsed(state._monitorStartTime));
+  return { line1, detail, parts };
 }
 
-module.exports = { buildOutput, buildStatusLine };
+module.exports = { buildOutput, buildStatusLine, composeStatusLine, formatElapsed };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
@@ -27,6 +27,7 @@ const {
   extractFailedTestPaths,
 } = require('./monitor-ci-context');
 const { buildOutput, buildStatusLine } = require('./monitor-status-line');
+const { notifyOperator } = require('../notify');
 
 /**
  * Check if any workflow run for the PR's branch has already failed.
@@ -67,14 +68,7 @@ function hasFailedJobs(prInfo, worktreeDir) {
 }
 
 // Synchronous sleep via Atomics.wait — no subprocess, no event-loop dependency.
-function sleepSync(ms) {
-  try {
-    const sab = new SharedArrayBuffer(4);
-    Atomics.wait(new Int32Array(sab), 0, 0, ms);
-  } catch {
-    /* sleep best-effort */
-  }
-}
+const { sleepSync } = require('../sleep');
 
 // GitHub returns `mergeable: UNKNOWN` for up to ~30s after a push or sibling-PR
 // merge. Retry a few times before trusting UNKNOWN. Bounded (3 * 3s = 9s).
@@ -230,12 +224,15 @@ function fetchReviews(prInfo, getReviews) {
 
 function emitStatusLine(state, ci, reviews) {
   if (!state._monitorStartTime) state._monitorStartTime = new Date().toISOString();
-  const { line1, detail } = buildStatusLine(state, ci, reviews);
+  const { line1, detail, parts } = buildStatusLine(state, ci, reviews);
   // Progress is persisted to state (_ciStatusLine) and surfaced by the
   // /follow-up status bar (agent-free) — no per-poll stderr spam. The final
   // JSON instruction is what keeps the agent posted.
   state._ciStatusLine = line1;
   state._ciStatusDetail = detail || '';
+  // Structured parts let the status bar recompute the elapsed timer LIVE on
+  // every refresh instead of re-printing the string frozen at monitor time.
+  state._ciStatusParts = parts;
 }
 
 function populateFailedJobs(state, ci, worktreeDir) {
@@ -270,6 +267,21 @@ function attachClassifierContext(state, ci, initialFailedJobs, worktreeDir) {
   }
 }
 
+// Ping the operator mailbox when the blocking-comment count GROWS — new bot
+// review comments used to arrive silently while the agent idled in the poll
+// loop ("agents get stuck with no notifications of messages").
+function notifyOnNewBlockingComments(state, reviews) {
+  const count = reviews && reviews.blocking ? reviews.blocking.length : 0;
+  const previous = state._lastBlockingCount || 0;
+  if (count > previous) {
+    notifyOperator(
+      state.ticketId,
+      `${count - previous} new blocking review comment(s) on PR #${state.prNumber || '?'} (${count} total)`
+    );
+  }
+  state._lastBlockingCount = count;
+}
+
 module.exports = function registerMonitor(register) {
   register('monitor', (state, ctx) => {
     // Stale infra-failure cache is auto-cleared by the orchestrator in
@@ -283,6 +295,12 @@ module.exports = function registerMonitor(register) {
 
     let prInfo = fetchPrInfoOrFail(state, getPRInfo, prArg);
     if (!prInfo) return null;
+
+    // Persist the discovered PR number: downstream consumers (fix-reviews
+    // `--snapshot --pr`, the /work follow-up gate's assessMergeable) bail on a
+    // null prNumber even after monitor printed the number itself (echo-5363,
+    // echo-5820).
+    if (!state.prNumber && prInfo.number) state.prNumber = prInfo.number;
 
     const refreshed = refreshPrUntilKnown(getPRInfo, prArg, prInfo);
     prInfo = refreshed.prInfo;
@@ -308,10 +326,21 @@ module.exports = function registerMonitor(register) {
     const initialFailedJobs = populateFailedJobs(state, ci, ctx.worktreeDir);
     attachClassifierContext(state, ci, initialFailedJobs, ctx.worktreeDir);
 
-    if (exitCode === 0) state.currentStep = computeNextStepOnGreen(state);
+    notifyOnNewBlockingComments(state, reviews);
+
+    if (exitCode === 0) routeOnGreen(state);
     return null;
   });
 };
+
+// Fully green (CI passed, reviews clear, mergeable). A failureCategory left
+// over from an earlier cycle (e.g. 'reviews' after comments were fixed) is
+// stale — clear it when routing to report so the report step completes
+// instead of surfacing forever (echo-6204).
+function routeOnGreen(state) {
+  state.currentStep = computeNextStepOnGreen(state);
+  if (state.currentStep === 'report') state.failureCategory = null;
+}
 
 /**
  * R15 (GH-508): when CI turns green after an infra-flake rerun, route through
@@ -344,4 +373,5 @@ module.exports.__test__ = {
   fetchClassifierContext,
   computeNextStepOnGreen,
   extractFailedTestPaths,
+  notifyOnNewBlockingComments,
 };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
@@ -20,6 +20,7 @@ const {
 } = require('./monitor-infra-cache');
 const {
   buildInitialFailedJobs,
+  collectRunIds,
   resolveMissingRunIds,
   mapCiStatus,
   fetchClassifierContext,
@@ -321,6 +322,10 @@ module.exports = function registerMonitor(register) {
     const exitCode = computeExitCode(prInfo, ci, reviews);
     writeMonitorResult(state, { exitCode, output: output.substring(0, 3000) });
     state._ciRunningCount = ci.running ? ci.running.length : 0;
+    // GH-214: persist the observed run IDs so monitoring is resumable — a
+    // fresh invocation (or an operator) can inspect the same runs directly
+    // (`gh run view <id>`) instead of re-deriving them from output.
+    state._ciRunIds = collectRunIds(ci);
 
     emitStatusLine(state, ci, reviews);
     const initialFailedJobs = populateFailedJobs(state, ci, ctx.worktreeDir);

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/monitor.js
@@ -271,9 +271,18 @@ function attachClassifierContext(state, ci, initialFailedJobs, worktreeDir) {
 // Ping the operator mailbox when the blocking-comment count GROWS — new bot
 // review comments used to arrive silently while the agent idled in the poll
 // loop ("agents get stuck with no notifications of messages").
+//
+// The first observation only SEEDS the counter: comments already present at
+// workflow start are being actively processed by fix-reviews anyway, and
+// notifying for them meant every `--init` re-announced already-known comments
+// (review finding on PR #666).
 function notifyOnNewBlockingComments(state, reviews) {
   const count = reviews && reviews.blocking ? reviews.blocking.length : 0;
-  const previous = state._lastBlockingCount || 0;
+  if (state._lastBlockingCount === undefined) {
+    state._lastBlockingCount = count;
+    return;
+  }
+  const previous = state._lastBlockingCount;
   if (count > previous) {
     notifyOperator(
       state.ticketId,

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/push-retry.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/push-retry.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { execFileSync } = require('child_process');
+const { hasUnpushedCommits } = require('../git-unpushed');
 
 // Loop back to monitor for the next cycle. Returns null (the "advance" signal).
 function loopBackToMonitor(state) {
@@ -30,28 +30,6 @@ function buildMaxAttemptsBlocked(state, maxAttempts) {
       args: [ticketId, '--yes'],
     },
   };
-}
-
-// True when there are commits ahead of upstream. Falls back to a porcelain
-// dirty-tree check when there's no upstream (or git errors).
-function hasUnpushedCommits(ctx) {
-  const opts = {
-    encoding: 'utf8',
-    timeout: 5000,
-    cwd: ctx.worktreeDir,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  };
-  try {
-    const count = execFileSync('git', ['rev-list', '--count', '@{upstream}..HEAD'], opts).trim();
-    return parseInt(count, 10) > 0;
-  } catch {
-    // No upstream or git error — check for uncommitted changes as fallback
-    try {
-      return execFileSync('git', ['status', '--porcelain'], opts).trim().length > 0;
-    } catch {
-      return false;
-    }
-  }
 }
 
 function buildPushDelegate(state, ctx) {
@@ -85,7 +63,7 @@ module.exports = function registerPushRetry(register) {
     if (state.dispatched === 'push-retry') return loopBackToMonitor(state);
 
     // Nothing to push — all comments were skipped, loop back
-    if (!hasUnpushedCommits(ctx)) return loopBackToMonitor(state);
+    if (!hasUnpushedCommits(ctx.worktreeDir)) return loopBackToMonitor(state);
 
     state.dispatched = 'push-retry';
     return buildPushDelegate(state, ctx);

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/report.js
@@ -28,11 +28,17 @@ function formatAttemptLine(attempt, repoUrl) {
 
 // Categories whose failureCategory has dedicated handling elsewhere in the
 // workflow (or is being routed to another step); not surfaced from `report`.
+// 'reviews' and 'ci_cancelled_blocking' are set by triage's routeTo — they
+// were missing here, so a workflow that finished handling its review comments
+// (or a cancelled-CI retry) re-surfaced forever instead of completing
+// (echo-6204, memory: followup-reviews-surface-loop).
 const KNOWN_RESOLVABLE_CATEGORIES = new Set([
   'infra-stuck',
   'conflict',
   'ci_failure',
   'review_failure',
+  'reviews',
+  'ci_cancelled_blocking',
 ]);
 
 /**
@@ -107,15 +113,40 @@ function writeAccountabilityReport(reportPath, state, solvedReviews, skippedRevi
   }
 }
 
-function buildCompleteResult(state, solvedReviews, skippedReviews) {
-  const skipSuffix = skippedReviews
-    ? ` — ${solvedReviews} review${solvedReviews !== 1 ? 's' : ''} fixed, ${skippedReviews} skipped (see follow-up-comments.json for rationale).`
-    : '';
+// One line per terminal review comment so the operator sees exactly WHAT was
+// addressed and how — previously comments were marked solved/skipped/outdated
+// with, at most, an aggregate count ("agents mark messages as addressed but
+// do not notify me").
+function itemizeReviewComments(tasksDir) {
+  try {
+    const snapshot = JSON.parse(
+      fs.readFileSync(path.join(tasksDir, 'follow-up-comments.json'), 'utf8')
+    );
+    const label = { solved: '✔ solved', skipped: '⤼ skipped', resolved: '⌛ outdated' };
+    return (snapshot.comments || [])
+      .filter((c) => label[c.status])
+      .map((c) => {
+        const fileRef = c.path ? `${c.path}${c.line ? `:${c.line}` : ''}` : 'general';
+        const why = c.resolution ? ` — ${String(c.resolution).slice(0, 140)}` : '';
+        return `  ${label[c.status]} [${c.author || 'unknown'}] ${fileRef}${why}`;
+      });
+  } catch {
+    return [];
+  }
+}
+
+function buildCompleteResult(state, solvedReviews, skippedReviews, ctx) {
+  const lines = itemizeReviewComments(ctx && ctx.tasksDir);
+  const headline = `Follow-up complete for ${state.ticketId} PR #${state.prNumber || '?'} after ${state.attempt || 1} attempt(s)`;
+  const countsLine =
+    lines.length > 0 || solvedReviews || skippedReviews
+      ? `Review comments: ${solvedReviews} solved, ${skippedReviews} skipped (details in follow-up-comments.json / review-accountability.json)`
+      : '';
   return {
     type: 'follow_up_instruction',
     action: 'complete',
     state: { ticket: state.ticketId, currentStep: 'report', attempt: state.attempt },
-    summary: `Follow-up complete for ${state.ticketId} PR #${state.prNumber || '?'} after ${state.attempt || 1} attempt(s)${skipSuffix}`,
+    summary: [headline, countsLine, ...lines].filter(Boolean).join('\n'),
   };
 }
 
@@ -145,6 +176,6 @@ module.exports = function registerReport(register) {
     writeAccountabilityReport(reportPath, state, solvedReviews, skippedReviews);
 
     state.status = 'complete';
-    return buildCompleteResult(state, solvedReviews, skippedReviews);
+    return buildCompleteResult(state, solvedReviews, skippedReviews, ctx);
   });
 };

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/triage.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/triage.js
@@ -125,7 +125,13 @@ function routeTriage(state, signals) {
   // directly would skip infra-retry entirely when the flag is on.
   if (signals.hasCiFailure) return routeTo(state, 'infra-retry', 'ci_failure');
 
-  // Blocking reviews take priority over waiting for CI.
+  // GH-268: blocking reviews take priority over waiting for CI — actionable
+  // review comments are surfaced immediately instead of holding them until
+  // the CI pipeline finishes. The reviewer-done signal is reliable by
+  // construction: `reviewsActionable` requires blocking comments to exist AND
+  // the bot to have SUBMITTED its review (not listed in pendingBots / not
+  // still running). An in-progress review falls through to the wait branches
+  // below, preserving the old wait-for-CI behavior (no partial reviews).
   if (signals.reviewsActionable) return routeTo(state, 'fix-reviews', 'reviews');
 
   // Bot check still running with blocking reviews — wait for it to finish.

--- a/plugins/work/scripts/workflows/follow-up/lib/steps/triage.js
+++ b/plugins/work/scripts/workflows/follow-up/lib/steps/triage.js
@@ -14,12 +14,21 @@
 
 'use strict';
 
-function waitSeconds(seconds) {
-  if (process.env.FOLLOW_UP2_NO_DELAY) return;
-  const { execSync } = require('child_process');
-  execSync(`node -e "setTimeout(()=>{},${seconds * 1000})"`, {
-    timeout: (seconds + 5) * 1000,
+const { sleepSyncInterruptible } = require('../sleep');
+const { readNewInboxMessages } = require('../notify');
+
+// Sleep without a subprocess (Atomics.wait) — the previous shell-out sleep
+// crashed uncaught with `spawnSync /bin/sh ETIMEDOUT` under load
+// (echo-6209). Wakes early when new operator inbox messages arrive; returns
+// them so the wait loop can surface instead of sleeping through the signal.
+function waitSeconds(seconds, state) {
+  if (process.env.FOLLOW_UP2_NO_DELAY) return [];
+  let messages = [];
+  sleepSyncInterruptible(seconds * 1000, () => {
+    messages = readNewInboxMessages(state.ticketId, state);
+    return messages.length > 0;
   });
+  return messages;
 }
 
 function buildBlocked(reason) {
@@ -84,10 +93,20 @@ function ongoingReviewInterval(state) {
   return state.attempt <= 5 ? 30 : 60;
 }
 
-// Wait, then route back to monitor for a fresh read. Returns null (advance).
+// Wait, then route back to monitor for a fresh read. Returns null (advance),
+// or a blocked instruction carrying fresh operator inbox messages so the
+// agent reacts to them instead of silently polling on.
 function waitAndMonitor(state, seconds) {
-  waitSeconds(seconds);
+  const messages = waitSeconds(seconds, state);
   state.currentStep = 'monitor';
+  if (messages.length > 0) {
+    return {
+      type: 'follow_up_instruction',
+      action: 'blocked',
+      reason: `Operator message received while waiting on PR #${state.prNumber || '?'}:\n${messages.join('\n')}\n\nHandle the message, then re-run follow-up-next.js to resume monitoring.`,
+      payload: { reason: 'operator-message', messages },
+    };
+  }
   return null;
 }
 

--- a/plugins/work/scripts/workflows/follow-up/statusline/followup-statusline.js
+++ b/plugins/work/scripts/workflows/follow-up/statusline/followup-statusline.js
@@ -16,6 +16,9 @@ const path = require('path');
 const { execFileSync } = require('child_process');
 
 const { findActiveMarker } = require(path.join(__dirname, '..', '..', 'work', 'lib', 'marker'));
+const { composeStatusLine, formatElapsed } = require(
+  path.join(__dirname, '..', 'lib', 'steps', 'monitor-status-line')
+);
 
 const FRESH_MS = 30 * 60 * 1000; // safety net: hide an abandoned follow-up after 30 min
 
@@ -101,8 +104,35 @@ function render() {
     : marker.ticket;
   const bits = [`🔄 follow-up ${label}`];
   if (st.currentStep) bits.push(st.currentStep);
-  if (st._ciStatusLine) bits.push(st._ciStatusLine);
-  return bits.join('   ·   ');
+  bits.push(...statusBits(st));
+  const pending = pendingActionMarker(base, marker.ticket);
+  if (pending) bits.push(pending);
+  return bits.filter(Boolean).join('   ·   ');
+}
+
+// The CI summary line. When structured parts are available, recompute the
+// elapsed timer NOW so it ticks on every 3s refresh — the pre-baked
+// `_ciStatusLine` string carries the elapsed frozen at monitor time.
+function statusBits(st) {
+  if (st._ciStatusParts) {
+    return [composeStatusLine(st._ciStatusParts, formatElapsed(st._monitorStartTime))];
+  }
+  return st._ciStatusLine ? [st._ciStatusLine] : [];
+}
+
+// ⚠ marker when the last persisted instruction is terminal (blocked/surface)
+// — the workflow is waiting on the operator, not on CI.
+function pendingActionMarker(base, ticket) {
+  try {
+    const raw = fs.readFileSync(path.join(base, ticket, '.follow-up-next.json'), 'utf8');
+    const instruction = JSON.parse(raw);
+    if (instruction.action === 'blocked' || instruction.action === 'surface') {
+      return `⚠ ${instruction.action}`;
+    }
+  } catch {
+    /* no persisted instruction */
+  }
+  return '';
 }
 
 process.stdout.write(render());

--- a/plugins/work/scripts/workflows/lib/auto-advance.js
+++ b/plugins/work/scripts/workflows/lib/auto-advance.js
@@ -39,8 +39,11 @@ function findMarker(TASKS_BASE, markerFile, workLibDir) {
   return marker;
 }
 
-// Run an orchestrator script for `ticket` and return its parsed instruction, or
-// null on any spawn/parse error (fail-open).
+// Run an orchestrator script for `ticket` and return its parsed instruction.
+// On spawn/parse error, returns null AND prints a one-line warning — the
+// previous fully-silent failure meant a timed-out orchestrator (monitor
+// cycles legitimately sleep past the spawn timeout) simply never advanced
+// the workflow and nobody was told.
 function runOrchestrator(scriptPath, ticket, timeout) {
   try {
     const result = execFileSync(process.execPath, [scriptPath, ticket], {
@@ -49,7 +52,15 @@ function runOrchestrator(scriptPath, ticket, timeout) {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     return JSON.parse(result);
-  } catch {
+  } catch (err) {
+    const why =
+      err && (err.code === 'ETIMEDOUT' || err.signal === 'SIGTERM')
+        ? `timed out after ${Math.round(timeout / 1000)}s (long CI wait)`
+        : `failed: ${String((err && err.message) || err).slice(0, 120)}`;
+    console.log(
+      `\n⚠ [auto-advance] orchestrator ${why} — workflow did NOT advance. ` +
+        `Re-run \`node ${scriptPath} ${ticket}\` to continue.\n`
+    );
     return null;
   }
 }

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-gh248.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-gh248.test.js
@@ -27,7 +27,7 @@ function captureStdout(fn) {
   return lines.join('\n');
 }
 
-describe('GH-248 — position-outdated comments keep their priority', () => {
+describe('GH-248/GH-249 — the script never pre-judges comment priority', () => {
   it('no longer downgrades position-outdated comments to low (source guard)', () => {
     assert.ok(
       !SOURCE.includes('if (isOutdated || isOldCommit)'),
@@ -36,6 +36,18 @@ describe('GH-248 — position-outdated comments keep their priority', () => {
     assert.ok(
       SOURCE.includes('item.positionOutdated = true'),
       'position-outdated comments must be tagged instead'
+    );
+  });
+
+  it('GH-249: old-commit comments are no longer downgraded either — marker only', () => {
+    assert.ok(
+      !/isOldCommit[\s\S]{0,120}priority = 'low'/.test(SOURCE) &&
+        !/branchCommits[\s\S]{0,160}priority = 'low'/.test(SOURCE),
+      'no priority downgrade may remain in the stale-marker loop'
+    );
+    assert.ok(
+      SOURCE.includes('display-only marker — priority unchanged (GH-249)'),
+      'old-commit comments keep a display-only stale marker'
     );
   });
 

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-gh248.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-pr-gh248.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+// follow-up-pr-gh248.test.js — GH-248 acceptance criteria:
+//  AC1  position-outdated comments are NOT auto-downgraded to low priority
+//  AC2  they carry a display tag but keep their original classification
+//  AC3  on exit, ALL comments (blocking + non-blocking) print FULL bodies
+//  AC4  polling previews stay truncated (80 chars) — unchanged
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const FOLLOW_UP_PR_PATH = path.resolve(__dirname, '..', 'follow-up-pr.js');
+const SOURCE = fs.readFileSync(FOLLOW_UP_PR_PATH, 'utf8');
+const { printExitCommentBodies } = require(FOLLOW_UP_PR_PATH);
+
+function captureStdout(fn) {
+  const lines = [];
+  const original = console.log;
+  console.log = (...args) => lines.push(args.join(' '));
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return lines.join('\n');
+}
+
+describe('GH-248 — position-outdated comments keep their priority', () => {
+  it('no longer downgrades position-outdated comments to low (source guard)', () => {
+    assert.ok(
+      !SOURCE.includes('if (isOutdated || isOldCommit)'),
+      'the combined outdated||old-commit downgrade must be gone'
+    );
+    assert.ok(
+      SOURCE.includes('item.positionOutdated = true'),
+      'position-outdated comments must be tagged instead'
+    );
+  });
+
+  it('polling display shows the (position outdated) tag', () => {
+    assert.ok(SOURCE.includes('(position outdated)'));
+  });
+});
+
+describe('GH-248 — full comment bodies on exit', () => {
+  const longBody = `First line of a long review comment.\n${'x'.repeat(200)}\nLast line.`;
+  const reviews = {
+    blocking: [
+      {
+        author: 'cursor[bot]',
+        priority: 'medium',
+        path: 'src/a.js',
+        line: 12,
+        body: longBody,
+        positionOutdated: true,
+      },
+    ],
+    nonBlocking: [
+      {
+        author: 'copilot',
+        priority: 'low',
+        path: 'src/b.js',
+        line: null,
+        body: 'A non-blocking nitpick that must still be shown in full.',
+        stale: true,
+      },
+    ],
+  };
+
+  it('prints every comment with its FULL body (no 80-char truncation)', () => {
+    const out = captureStdout(() => printExitCommentBodies(reviews));
+    assert.ok(out.includes('Full Comment Bodies'));
+    assert.ok(out.includes('x'.repeat(200)), 'long body must not be truncated');
+    assert.ok(out.includes('Last line.'), 'multi-line bodies print completely');
+    assert.ok(out.includes('[BLOCKING]'));
+    assert.ok(out.includes('[NON-BLOCKING]'));
+    assert.ok(out.includes('non-blocking nitpick'), 'non-blocking comments included');
+  });
+
+  it('shows priority, location, and stale/position-outdated markers', () => {
+    const out = captureStdout(() => printExitCommentBodies(reviews));
+    assert.ok(out.includes('[MEDIUM]'));
+    assert.ok(out.includes('src/a.js:12'));
+    assert.ok(out.includes('(position outdated)'));
+    assert.ok(out.includes('(stale)'));
+  });
+
+  it('prints nothing when there are no comments', () => {
+    const out = captureStdout(() => printExitCommentBodies({ blocking: [], nonBlocking: [] }));
+    assert.equal(out, '');
+  });
+
+  it('is invoked on exit-fail, recheck, success, and timeout paths (source guard)', () => {
+    const calls = SOURCE.match(/printExitCommentBodies\(reviews\);/g) || [];
+    assert.ok(calls.length >= 4, `expected >=4 exit-path calls, found ${calls.length}`);
+  });
+
+  it('polling previews remain truncated at 80 chars (AC4 unchanged)', () => {
+    assert.ok(SOURCE.includes('slice(0, 77)'), 'polling preview truncation must remain');
+  });
+});

--- a/plugins/work/scripts/workflows/work/scripts/follow-up-pr.js
+++ b/plugins/work/scripts/workflows/work/scripts/follow-up-pr.js
@@ -875,12 +875,19 @@ function getReviews(prNumber) {
     priority: classifyCommentPriority(cm.author, cm.body),
   }));
 
-  // Mark stale comments as non-blocking
+  // GH-248: position-outdated comments (line===null but original_line set)
+  // KEEP their original priority — GitHub merely failed to map them onto the
+  // current diff (moved code, rebase, hunk-boundary churn); the underlying
+  // concern may still be valid. They get a display tag instead of a silent
+  // downgrade. Only comments from commits no longer on the branch
+  // (force-push/rebase leftovers) are downgraded to non-blocking.
   for (const item of [...actionable, ...classifiedComments]) {
-    const isOutdated = item.line === null && item.original_line != null;
+    if (item.line === null && item.original_line != null) {
+      item.positionOutdated = true;
+    }
     const isOldCommit =
       branchCommits.size > 0 && item.commit_id && !branchCommits.has(item.commit_id);
-    if (isOutdated || isOldCommit) {
+    if (isOldCommit) {
       item.priority = 'low';
       item.stale = true;
     }
@@ -973,6 +980,50 @@ function formatNonBlockingItems(items, lines) {
       lines.push(`    ${c.dim('"' + preview + '"')}`);
     }
   }
+}
+
+// GH-248: on exit (fail OR success), print EVERY comment — blocking and
+// non-blocking — with its FULL body, priority, and stale/position-outdated/
+// dedup markers, so the agent can evaluate each one without re-fetching.
+// Polling iterations keep the 80-char previews for conciseness.
+function printExitCommentBodies(reviews) {
+  const allExitComments = [
+    ...((reviews && reviews.blocking) || []).map((item) => ({ ...item, _section: 'BLOCKING' })),
+    ...((reviews && reviews.nonBlocking) || []).map((item) => ({
+      ...item,
+      _section: 'NON-BLOCKING',
+    })),
+  ];
+  if (allExitComments.length === 0) return;
+  console.log('');
+  console.log(c.bold('--- Full Comment Bodies (All Reviews) ---'));
+  let currentSection = '';
+  allExitComments.forEach((item, i) => {
+    if (item._section !== currentSection) {
+      currentSection = item._section;
+      console.log('');
+      console.log(c.bold(`  [${currentSection}]`));
+    }
+    const loc = item.path ? `${item.path}${item.line ? ':' + item.line : ''}` : 'N/A';
+    const priority = (item.priority || 'unknown').toUpperCase();
+    const tags =
+      (item.stale ? ' (stale)' : '') +
+      (item.positionOutdated ? ' (position outdated)' : '') +
+      (item.deduplicated ? ' (deduped)' : '');
+    console.log(
+      `  ${c.cyan(`Comment ${i + 1}:`)} [${priority}] @${item.author}${c.dim(tags)} ${loc}`
+    );
+    const body = (item.body || '').trim();
+    if (body) {
+      console.log(
+        body
+          .split('\n')
+          .map((l) => `    ${l}`)
+          .join('\n')
+      );
+    }
+  });
+  console.log('');
 }
 
 function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts, decision) {
@@ -1114,8 +1165,13 @@ function formatReport(prInfo, ci, reviews, attempt, maxAttempts, opts, decision)
       lines.push(c.red(`Reviews: ${reviews.blocking.length} BLOCKING`));
       for (const item of reviews.blocking) {
         const priorityTag = item.priority === 'high' ? c.red('[HIGH]') : c.yellow('[MEDIUM]');
+        // GH-248: position-outdated comments keep their priority; the tag is
+        // display-only so the agent knows to re-verify the location.
+        const outdatedTag = item.positionOutdated ? c.dim(' (position outdated)') : '';
         const loc = item.path ? ` ${c.dim(item.path + (item.line ? ':' + item.line : ''))}` : '';
-        lines.push(`  ${c.red('✗')} ${c.cyan('@' + item.author)} ${priorityTag}${loc}`);
+        lines.push(
+          `  ${c.red('✗')} ${c.cyan('@' + item.author)} ${priorityTag}${outdatedTag}${loc}`
+        );
         if (item.body) {
           const normalized = item.body.replace(/\s+/g, ' ');
           const preview = normalized.length > 80 ? normalized.slice(0, 77) + '...' : normalized;
@@ -1582,33 +1638,7 @@ async function main() {
       state.finalStatus = decision.finalStatus;
       saveState(state);
 
-      // GH-248: Show brief comment previews (80 chars) for ALL comments on exit
-      // so the agent has context. Non-blocking comments must be evaluated too.
-      const allExitComments = [
-        ...(reviews.blocking || []).map((item) => ({ ...item, _section: 'BLOCKING' })),
-        ...(reviews.nonBlocking || []).map((item) => ({ ...item, _section: 'NON-BLOCKING' })),
-      ];
-      if (allExitComments.length > 0) {
-        console.log('');
-        console.log(c.bold('--- Brief Comment Bodies (All Reviews) ---'));
-        let currentSection = '';
-        allExitComments.forEach((item, i) => {
-          if (item._section !== currentSection) {
-            currentSection = item._section;
-            console.log('');
-            console.log(c.bold(`  [${currentSection}]`));
-          }
-          const loc = item.path ? `${item.path}${item.line ? ':' + item.line : ''}` : 'N/A';
-          const priority = (item.priority || 'unknown').toUpperCase();
-          const staleTag = item.stale ? c.dim(' (stale)') : '';
-          const dedupTag = item.deduplicated ? c.dim(' (deduped)') : '';
-          const briefBody = (item.body || '').trim().replace(/\n/g, ' ').substring(0, 80);
-          console.log(
-            `  ${c.cyan(`Comment ${i + 1}:`)} [${priority}] @${item.author}${staleTag}${dedupTag} ${loc} — ${briefBody}`
-          );
-        });
-        console.log('');
-      }
+      printExitCommentBodies(reviews);
 
       process.exit(1);
     }
@@ -1656,6 +1686,7 @@ async function main() {
           state.headAtLastExit = currentHead;
           state.finalStatus = 'reviews-blocking';
           saveState(state);
+          printExitCommentBodies(reviews);
           process.exit(1);
         }
       }
@@ -1727,6 +1758,7 @@ async function main() {
         );
       }
 
+      printExitCommentBodies(reviews);
       process.exit(0);
     }
 
@@ -1745,6 +1777,7 @@ async function main() {
   );
   state.finalStatus = 'timeout';
   saveState(state);
+  printExitCommentBodies(reviews);
   process.exit(1);
 }
 
@@ -1896,6 +1929,7 @@ module.exports = {
   getCodeContext,
   buildAccountabilityEntries,
   formatReport,
+  printExitCommentBodies,
   partitionByRequired,
   // Gate-check exports: used by workflow-definition.js verify()
   isPRGateReady,

--- a/plugins/work/scripts/workflows/work/scripts/follow-up-pr.js
+++ b/plugins/work/scripts/workflows/work/scripts/follow-up-pr.js
@@ -875,21 +875,18 @@ function getReviews(prNumber) {
     priority: classifyCommentPriority(cm.author, cm.body),
   }));
 
-  // GH-248: position-outdated comments (line===null but original_line set)
-  // KEEP their original priority — GitHub merely failed to map them onto the
-  // current diff (moved code, rebase, hunk-boundary churn); the underlying
-  // concern may still be valid. They get a display tag instead of a silent
-  // downgrade. Only comments from commits no longer on the branch
-  // (force-push/rebase leftovers) are downgraded to non-blocking.
+  // GH-248/GH-249: the script never pre-judges — no comment is downgraded or
+  // hidden. Position-outdated comments (line===null but original_line set)
+  // and comments from commits no longer on the branch (force-push/rebase)
+  // KEEP their reviewer-assigned priority; they only get display markers so
+  // the agent knows to re-verify against the current code. Only the agent,
+  // reading the actual code, decides whether a comment still applies.
   for (const item of [...actionable, ...classifiedComments]) {
     if (item.line === null && item.original_line != null) {
       item.positionOutdated = true;
     }
-    const isOldCommit =
-      branchCommits.size > 0 && item.commit_id && !branchCommits.has(item.commit_id);
-    if (isOldCommit) {
-      item.priority = 'low';
-      item.stale = true;
+    if (branchCommits.size > 0 && item.commit_id && !branchCommits.has(item.commit_id)) {
+      item.stale = true; // display-only marker — priority unchanged (GH-249)
     }
   }
 
@@ -986,6 +983,29 @@ function formatNonBlockingItems(items, lines) {
 // non-blocking — with its FULL body, priority, and stale/position-outdated/
 // dedup markers, so the agent can evaluate each one without re-fetching.
 // Polling iterations keep the 80-char previews for conciseness.
+function formatExitCommentLines(item, index) {
+  const lines = [];
+  const loc = item.path ? `${item.path}${item.line ? ':' + item.line : ''}` : 'N/A';
+  const priority = (item.priority || 'unknown').toUpperCase();
+  const tags =
+    (item.stale ? ' (stale)' : '') +
+    (item.positionOutdated ? ' (position outdated)' : '') +
+    (item.deduplicated ? ' (deduped)' : '');
+  lines.push(
+    `  ${c.cyan(`Comment ${index + 1}:`)} [${priority}] @${item.author}${c.dim(tags)} ${loc}`
+  );
+  const body = (item.body || '').trim();
+  if (body) {
+    lines.push(
+      body
+        .split('\n')
+        .map((l) => `    ${l}`)
+        .join('\n')
+    );
+  }
+  return lines;
+}
+
 function printExitCommentBodies(reviews) {
   const allExitComments = [
     ...((reviews && reviews.blocking) || []).map((item) => ({ ...item, _section: 'BLOCKING' })),
@@ -1004,24 +1024,7 @@ function printExitCommentBodies(reviews) {
       console.log('');
       console.log(c.bold(`  [${currentSection}]`));
     }
-    const loc = item.path ? `${item.path}${item.line ? ':' + item.line : ''}` : 'N/A';
-    const priority = (item.priority || 'unknown').toUpperCase();
-    const tags =
-      (item.stale ? ' (stale)' : '') +
-      (item.positionOutdated ? ' (position outdated)' : '') +
-      (item.deduplicated ? ' (deduped)' : '');
-    console.log(
-      `  ${c.cyan(`Comment ${i + 1}:`)} [${priority}] @${item.author}${c.dim(tags)} ${loc}`
-    );
-    const body = (item.body || '').trim();
-    if (body) {
-      console.log(
-        body
-          .split('\n')
-          .map((l) => `    ${l}`)
-          .join('\n')
-      );
-    }
+    for (const line of formatExitCommentLines(item, i)) console.log(line);
   });
   console.log('');
 }

--- a/plugins/work/skills/follow-up/SKILL.md
+++ b/plugins/work/skills/follow-up/SKILL.md
@@ -40,6 +40,33 @@ the instruction from that file instead of the terminal output:
 This is the sanctioned alternative to piping through `head`/`tail`: same data,
 no truncated JSON. Foreground raw invocation remains the default.
 
+## Judging bot review comments (GH-352)
+
+When the script dispatches a review comment for you to address, do **not** blindly
+apply the bot's suggestion. Before choosing to fix (Option A) or skip (Option B):
+
+1. **Read the referenced code** at the file/line the comment points to (`fileRef`).
+2. **Verify the bot's claim** against the *current* code — bots frequently misread
+   context, flag already-handled cases, or comment on stale lines.
+3. **Classify** the comment into exactly one of these six categories, each with its
+   prescribed action:
+   - **real bug** → fix (Option A)
+   - **real improvement** (perf/maintainability, related to this PR) → fix (Option A)
+   - **style/naming preference** → skip with reason (Option B)
+   - **false positive** (bot misread the code) → skip with evidence (Option B)
+   - **conflicts with user intent / ticket requirements** → skip with reason (Option B)
+   - **ambiguous** (unsure whether it applies) → ask the user
+
+### Record the classification
+
+Persist the chosen category so it survives in `comment.resolution`: put a leading
+`[<category>]` token at the start of the `<reason>` you pass to
+`--mark-locally-skipped` and the `<description>` you pass to `--mark-locally-solved`.
+For example: `[false positive] guard already handles null at line 42` or
+`[real bug] off-by-one in loop bound`. The classification is written verbatim into
+the comment resolution, so the audit trail shows *why* each comment was fixed or
+skipped.
+
 ## Early review surfacing (GH-268)
 
 Reviews do NOT wait for CI. The triage step routes actionable review comments

--- a/plugins/work/skills/follow-up/SKILL.md
+++ b/plugins/work/skills/follow-up/SKILL.md
@@ -24,3 +24,27 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/workflows/follow-up/follow-up-next.js" <TICK
 - After executing, re-run follow-up-next.js (without --init) for the next instruction.
 - Repeat until `action: "complete"` or `action: "blocked"`.
 - **Never stop early.** If the script is running, it is working. Wait for it.
+
+## Background mode (state-file-first, GH-214)
+
+Every run persists its instruction to
+`<TASKS_BASE>/<TICKET>/.follow-up-next.json` (removed on `complete`), so the
+stdout JSON never needs to be parsed or piped. For long CI waits you may run
+the script in the background (`run_in_background`) and, when it finishes, read
+the instruction from that file instead of the terminal output:
+
+- `.follow-up-next.json` — the exact instruction the run printed (act on it).
+- `.follow-up-state.json` — compact progress (`currentStep`, `attempt`,
+  `_ciStatusLine`, `_ciRunIds` for `gh run view <id>`, `prNumber`).
+
+This is the sanctioned alternative to piping through `head`/`tail`: same data,
+no truncated JSON. Foreground raw invocation remains the default.
+
+## Early review surfacing (GH-268)
+
+Reviews do NOT wait for CI. The triage step routes actionable review comments
+to fix-reviews **before** checking CI-pending, using the reviewer-done signal
+from the GitHub review API: a bot review is "done" when it is no longer in
+`pendingBots` (its review is submitted, not in-progress) and its blocking
+comments are present. While a bot review is still running, comments are held
+(the bot may dismiss them on completion) and the workflow keeps waiting.

--- a/plugins/work/skills/install-followup-statusline/SKILL.md
+++ b/plugins/work/skills/install-followup-statusline/SKILL.md
@@ -11,7 +11,12 @@ Registers a Claude Code `statusLine` that renders live `/follow-up` progress —
 agent-free. It reads the artifacts the plugin **already** writes — no new files:
 the `.follow-up-orchestrator.pid` marker (located via the plugin's own
 `findActiveMarker`, scoped to this Claude session) and `.follow-up-state.json`
-(`currentStep`, `prNumber`, `_ciStatusLine`) under `<TASKS_BASE>/<ticket>/`.
+(`currentStep`, `prNumber`, `_ciStatusParts` + `_monitorStartTime` — the
+elapsed timer is recomputed live on every refresh, with `_ciStatusLine` as a
+fallback for older state files) under `<TASKS_BASE>/<ticket>/`. When the last
+persisted instruction (`.follow-up-next.json`) is `blocked`/`surface`, the bar
+appends a `⚠ blocked` / `⚠ surface` marker so a workflow waiting on the
+operator is visible at a glance.
 
 This replaces the old per-poll stderr spam: the console is now near-silent
 (only the final JSON instruction the agent acts on), and progress lives here.


### PR DESCRIPTION
Closes #214
Closes #248
Closes #249
Closes #268
Closes #352

## Existing Behavior

- The `/follow-up` status bar timer displayed the elapsed string frozen at whatever value the last monitor cycle serialized into `_ciStatusLine`, so it never advanced between monitor polls.
- When the auto-advance hook timed out or failed to parse the orchestrator output, it returned null silently — the workflow stalled with no message to the operator and no indication of what happened. The hook also ran under the default 60s timeout, which killed it before its own 130s spawn timeout could expire.
- The triage wait loop used `execSync` to shell out a `node -e setTimeout` sleep; under load this crashed uncaught with `spawnSync ETIMEDOUT` (echo-6209). Operator messages written to the inbox during the wait were never surfaced — the loop slept through them.
- The completion summary mentioned reviews only when `skippedReviews > 0`; the all-solved path recorded no counts and produced no comment itemization, so comments marked solved/skipped were acknowledged without any detail reaching the operator.
- `KNOWN_RESOLVABLE_CATEGORIES` was missing `'reviews'` and `'ci_cancelled_blocking'`, causing an infinite surface loop after a workflow had already resolved all comments (echo-6204).
- The `fix-reviews` done-path jumped straight to `report` even when review-fix commits were unpushed, completing the workflow with those fixes never pushed.
- `monitor` discovered the PR number but never persisted it to state, so downstream consumers (`--snapshot --pr`, the `/work` follow-up gate's `assessMergeable`) bailed on a null `prNumber` (echo-5363, echo-5820).
- Position-outdated review comments (`line === null` but `original_line` set) were silently downgraded to low priority — GitHub simply failed to map them onto the current diff hunk. `follow-up-pr.js` had no way to emit full comment bodies on exit; operators saw 80-char previews even at the terminal polling iteration.
- `follow-up-next.js` only wrote its instruction to stdout; callers running it in the background had no reliable artifact to read and state contained no `_ciRunIds`, making resumed monitoring require a full re-poll cycle. The triage reviewer-done heuristic was undocumented and had no regression test.
- `fix-reviews` had no structured judgment step — the agent could solve or skip a comment without recording the category of its decision, making it impossible to audit patterns or enforce protocol uniformly.
- Stale and position-outdated markers were conflated in the priority-downgrade logic; `isOldCommit` was evaluated eagerly so comments on commits still on the branch could be silently deprioritized before the agent examined them.

## Intended New Behavior

- The status bar calls `composeStatusLine(_ciStatusParts, formatElapsed(_monitorStartTime))` on every 3s refresh — the elapsed timer ticks live. When `.follow-up-next.json` contains a `blocked` or `surface` instruction, the bar appends a `⚠ blocked` / `⚠ surface` marker so a stalled workflow is immediately visible.
- The auto-advance hook prints a descriptive warning (`⚠ [auto-advance] orchestrator timed out after Ns`) on timeout/parse failure, and the hook's timeout is raised to 180s so the orchestrator's 130s spawn can complete.
- The triage wait loop uses Atomics-based `sleepSyncInterruptible` (no subprocess). It wakes early when operator inbox messages arrive and routes to `blocked` with the message text instead of sleeping through the signal.
- New `lib/notify.js` appends a tagged line to `/tmp/claude-agent-inbox/<ticket>.log` and rings the terminal bell on every `blocked`, `surface`, and `complete` transition, and when new blocking review comments appear during a monitor poll.
- The completion summary always records `_solvedReviewsCount` / `_skippedReviewsCount` and itemizes each terminal comment with `file:line`, author, status (`✔ solved` / `⤼ skipped` / `⌛ outdated`), and the resolution reason.
- `'reviews'` and `'ci_cancelled_blocking'` are added to `KNOWN_RESOLVABLE_CATEGORIES`; the report step completes instead of re-surfacing after comments are handled.
- The `fix-reviews` done-path checks `hasUnpushedCommits` and routes through `push-retry` when commits exist, then proceeds to `report` — fixes are guaranteed pushed before the workflow closes.
- `monitor` persists the discovered `prNumber` into state on first discovery; `routeOnGreen` clears stale `failureCategory` when routing to `report`.
- `hasUnpushedCommits` extracted into `lib/git-unpushed.js`, shared by `push-retry` and `fix-reviews`. Four synapsys test files are isolated from the machine's real HOME stores to prevent machine-dependent failures.
- Position-outdated comments (`line === null && original_line != null`) keep their original priority and carry a `positionOutdated` tag for display; only comments from commits no longer on the branch are downgraded to stale/low. New `printExitCommentBodies` prints every comment with its full body, priority, location, and stale/position-outdated/dedup markers on all exit paths.
- `follow-up-next.js` persists its instruction to `.follow-up-next.json` on every run via the shared `lib/instruction-file.js`, enabling background invocation with state-file-first reads. `monitor` collects and persists GitHub Actions run IDs (`_ciRunIds`) to state each cycle. `SKILL.md` documents the sanctioned background pattern and the early-review-surfacing heuristic. A regression test pins that fix-reviews preempts the CI-pending wait when a bot review is submitted with blocking comments.
- `fix-reviews` now requires a mandatory judgment step before acting on any comment: the agent classifies each comment into one of six categories (`bug`, `style`, `test`, `docs`, `perf`, `infra`) and records the classification as a `[<category>]` token in the solve or skip reason. Prompt-assembly tests and `SKILL.md` protocol documentation ported from PR #630.
- `isOldCommit` priority downgrade removed from the pre-judgment path; `stale` and `positionOutdated` are now display-only markers. No comment is hidden or silently downgraded — all comments reach the agent's judgment step regardless of commit recency. Combined with the full-bodies-on-exit change (GH-249).
- CodeQL hardening: the mailbox reader switches to an fd-based `fstat` + `read` sequence that eliminates the TOCTOU race. The mailbox directory is created with mode `0o700` and the log file with `0o600`. An `ENOENT` catch in the offset-anchor logic resets the offset to `0` so the first message written to a newly created mailbox file is never skipped. Test fixtures write to isolated paths outside `/tmp` to avoid taint from concurrent processes. Unused imports removed from affected modules.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Status bar live timer**

1. Start a `/follow-up` run on any PR with active CI.
2. Watch the statusline — the elapsed time (`Xm Ys`) should increment on every 3s refresh instead of staying frozen.
3. When the workflow is blocked (e.g. the orchestrator wrote a `blocked` instruction), the bar should show `⚠ blocked` appended after the step name.

**Operator notifications**

1. Trigger a `/follow-up` run that reaches `blocked` or `complete`.
2. Confirm a line is appended to `/tmp/claude-agent-inbox/<ticket>.log` tagged `[follow-up]`.
3. Confirm a terminal bell fires (audible or visible BEL character in the terminal).
4. Simulate a new blocking review comment arriving during a monitor poll — confirm a new mailbox line appears: `N new blocking review comment(s) on PR #X`.

**Triage wait-loop interrupt**

1. With a `/follow-up` run paused at `triage` (CI pending), write a line to `/tmp/claude-agent-inbox/<ticket>.log`.
2. The triage step should wake before the full interval elapses and return a `blocked` instruction containing the operator message text.

**Auto-advance warning on timeout**

1. Reduce `--spawn-timeout` in the hook config to a very short value and run the hook — confirm it prints `⚠ [auto-advance] orchestrator timed out after Ns` instead of silently returning.

**Completion summary itemization**

1. Run `/follow-up` through to completion on a PR that had review comments addressed.
2. The `complete` instruction's `summary` field should list each comment as `✔ solved [author] path/file.ts:42 — <resolution>` or `⤼ skipped ... — <reason>`.
3. Confirm that a PR with no review comments produces a terse summary without the "Review comments:" section.

**Unpushed fix commits routing**

1. Run fix-reviews on a PR with addressable comments; after fix-reviews finishes, confirm the workflow routes through `push-retry` before completing (check `currentStep` transitions in `.follow-up-state.json`).

**Null prNumber persistence**

1. Start a fresh `/follow-up` run where `prNumber` is not pre-set in state.
2. After the first `monitor` cycle, confirm `prNumber` is written to `.follow-up-state.json`.
3. Run `--snapshot` — confirm it no longer errors on a missing `prNumber`.

**GH-248 — position-outdated comments and full exit bodies**

1. Open a PR that has review comments where code has since moved (hunk-boundary shift or rebase) — these appear as `line: null, original_line: <N>` in the GitHub API.
2. Run `follow-up-pr.js` on that PR; confirm the polling display shows `(position outdated)` next to the comment priority instead of silently demoting it to `[LOW]`.
3. Let the run reach any exit path — confirm the `--- Full Comment Bodies (All Reviews) ---` block is printed with full bodies, `[BLOCKING]` / `[NON-BLOCKING]` section headers, and `(position outdated)` / `(stale)` / `(deduped)` tags where applicable.
4. A comment from a commit no longer on the branch (force-push leftover) should still be downgraded to `[LOW] (stale)`.

**GH-214 — state-file-first background invocation**

1. Run `follow-up-next.js <TICKET>` in the background (`run_in_background`).
2. After it exits, confirm `.follow-up-next.json` contains the instruction JSON (same object the script printed to stdout).
3. After a `monitor` cycle, confirm `.follow-up-state.json` contains a populated `_ciRunIds` array; run `gh run view <id>` on one of the IDs to verify it resolves.
4. On `complete`, confirm `.follow-up-next.json` is removed.

**GH-268 — early review surfacing before CI completes**

1. Open a PR where CI is still running but a bot review has been submitted with blocking comments (review state is not `pending` / `in-progress`).
2. Run the triage step — confirm it routes to `fix-reviews` without waiting for CI to finish.
3. Add a PR where a bot review is still in-progress (pending state) — triage should keep waiting rather than surface partial results.

**GH-352 — mandatory judgment step**

1. Run `fix-reviews` on a PR with at least one blocking comment.
2. Confirm the agent emits a `[<category>]` token (e.g. `[bug]`, `[style]`) in the solve or skip reason for every comment processed.
3. Verify `SKILL.md` documents the six categories with examples and references the prompt-assembly contract.

**GH-249 — no pre-judging, stale/position-outdated as display-only**

1. Open a PR where at least one comment sits on a commit still on the branch but whose diff hunk has shifted.
2. Confirm the comment reaches the agent's judgment step at full original priority — not silently downgraded before the agent sees it.
3. Confirm stale comments (from commits no longer on the branch) still show `(stale)` in the polling display and exit bodies but are not hidden from the agent.

**CodeQL hardening — mailbox fd safety and permissions**

1. Confirm the mailbox directory is created with permissions `0o700` and the log file with `0o600` (`stat` the paths after a `/follow-up` run reaches any notification state).
2. The unit test suite covers the fd-based read and ENOENT offset-reset paths — confirm they pass with `pnpm dev:check`.
3. Delete the mailbox log file and write a new message to it; confirm the offset resets to `0` and the message is delivered (not skipped due to a stale offset anchor).

### Test Results

6414/6414 tests pass (`pnpm dev:check` green). 11 new test files across the three commits:

- `follow-up/__tests__/statusline-live-timer.test.js` — live-timer and structured-parts contract
- `follow-up/lib/__tests__/notify.test.js` — mailbox write, offset anchoring, self-notification filter
- `follow-up/lib/__tests__/sleep.test.js` — Atomics sleep, early-wake, throwing-probe survival
- `follow-up/lib/__tests__/gh214-state-file-first.test.js` — instruction-file persistence, _ciRunIds in state, auto-advance hook extraction
- `follow-up/lib/steps/__tests__/fix-reviews-done-routing.test.js` — unpushed-commit routing, count recording
- `follow-up/lib/steps/__tests__/report-complete-loop.test.js` — KNOWN_RESOLVABLE_CATEGORIES, comment itemization
- `follow-up/lib/steps/__tests__/triage-wait-interrupt.test.js` — no execSync, early operator-message wake
- `follow-up/lib/steps/__tests__/triage-early-reviews.test.js` — fix-reviews preempts CI-pending wait regression
- `work/scripts/__tests__/follow-up-pr-gh248.test.js` — position-outdated priority preservation, printExitCommentBodies coverage
- `follow-up/lib/steps/__tests__/fix-reviews.test.js` — GH-352 judgment step: six-category classification token, prompt-assembly ordering contract
- `follow-up/lib/__tests__/notify.test.js` (extended) — fd-based read, ENOENT offset anchor, taint-free fixtures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch the follow-up orchestrator, triage/monitor wait loops, and git push routing—high operational impact—but behavior is largely fail-open and covered by extensive new tests.
> 
> **Overview**
> This PR hardens **`/follow-up`** and related PR-review tooling: operators get visible progress and signals, and several “stuck forever” routing bugs are fixed.
> 
> The **status bar** now rebuilds CI summary lines from **`_ciStatusParts`** and **`_monitorStartTime`** so elapsed time ticks on refresh, falls back to **`_ciStatusLine`** for older state, and shows **`⚠ blocked` / `⚠ surface`** when **`.follow-up-next.json`** holds a terminal instruction.
> 
> **`follow-up-next.js`** writes every instruction to **`.follow-up-next.json`** (shared **`instruction-file.js`**), notifies the operator mailbox + terminal bell on **`blocked` / `surface` / `complete`**, and **`monitor`** persists **`prNumber`** and **`_ciRunIds`**. Triage/monitor waits use **Atomics-based sleep** (no **`execSync`** subprocess sleeps); triage can wake on **inbox** messages and return **`blocked`**. **`notify.js`** handles outbound/inbound mailbox traffic; new blocking review counts trigger notifications (seeded on first observation). **Auto-advance** hook timeout is **180s** and prints a warning when the orchestrator times out or fails.
> 
> **Workflow routing fixes:** **`fix-reviews`** records solved/skipped counts on all done paths, routes unpushed fix commits through **`push-retry`** via **`git-unpushed.js`** (strict vs lenient probes), and adds a **GH-352** judgment/classification block before fix/skip. **`report`** treats **`reviews`** and **`ci_cancelled_blocking`** as completable and itemizes per-comment outcomes in the completion summary. **`triage`** surfaces actionable reviews before CI finishes (**GH-268**). **`follow-up-pr.js`** stops auto-downgrading position-outdated comments, keeps stale as display-only (**GH-248/249**), and prints **full comment bodies** on all exit paths.
> 
> **Synapsys** integration tests are isolated from the real **`HOME`** / global stores so assertions are machine-independent. Docs in **`SKILL.md`** cover background/state-file-first usage and review judgment protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9faa857b2622fda14365778ca5f452fa7100d3aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


