### PR TITLE
feat(config): declarative env-config system — per-plugin schemas, startup validation, drift detection, .envrc generator, update banner

### DIFF
--- a/factories/envConfig/__tests__/cli.test.js
+++ b/factories/envConfig/__tests__/cli.test.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { parseArgs, writeTarget, varInventory } = require('../cli');
+
+const CLI = path.join(__dirname, '..', 'cli.js');
+
+const schema = {
+  plugin: 'demo',
+  prefixes: ['DEMO_'],
+  vars: {
+    DEMO_NAME: {
+      type: 'string',
+      default: '',
+      description: 'name',
+      section: 'Core',
+      required: true,
+    },
+    DEMO_FLAG: { type: 'bool01', default: '0', description: 'flag', section: 'Core' },
+  },
+};
+
+let tmp;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'envcfg-cli-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function makePluginDir() {
+  const pluginRoot = path.join(tmp, 'plugin');
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  fs.writeFileSync(path.join(pluginRoot, 'config-schema.json'), JSON.stringify(schema));
+  return pluginRoot;
+}
+
+test('parseArgs handles flags with and without values', () => {
+  const args = parseArgs(['plan', '--plugin-root', '/x', '--all', '--cwd', '/y']);
+  assert.deepEqual(args._, ['plan']);
+  assert.equal(args['plugin-root'], '/x');
+  assert.equal(args.all, true);
+  assert.equal(args.cwd, '/y');
+});
+
+test('varInventory reflects current values and sources', () => {
+  const inventory = varInventory([schema], {
+    DEMO_NAME: { value: 'set', dynamic: false, source: 'envrc' },
+  });
+  const byName = Object.fromEntries(inventory.map((v) => [v.name, v]));
+  assert.equal(byName.DEMO_NAME.current, 'set');
+  assert.equal(byName.DEMO_NAME.source, 'envrc');
+  assert.equal(byName.DEMO_NAME.required, true);
+  assert.equal(byName.DEMO_FLAG.current, null);
+});
+
+test('writeTarget renders a fresh .envrc, merges an existing one', () => {
+  const envrcPath = path.join(tmp, 'wrapper', '.envrc');
+  const rendered = writeTarget(
+    {
+      target: 'envrc',
+      envrcPath,
+      ghUser: 'someone',
+      gitIdentity: { mode: 'default' },
+      values: { DEMO_NAME: 'fresh' },
+    },
+    [schema]
+  );
+  assert.equal(rendered.mode, 'render');
+  const content = fs.readFileSync(envrcPath, 'utf8');
+  assert.match(content, /gh auth token -u someone/);
+  assert.match(content, /export DEMO_NAME=fresh/);
+
+  const merged = writeTarget({ target: 'envrc', envrcPath, values: { DEMO_FLAG: '1' } }, [schema]);
+  assert.equal(merged.mode, 'merge');
+  assert.ok(merged.backup && fs.existsSync(merged.backup), 'backup kept');
+  const after = fs.readFileSync(envrcPath, 'utf8');
+  assert.match(after, /export DEMO_NAME=fresh/, 'existing content preserved');
+  assert.match(after, /^export DEMO_FLAG=1$/m);
+  fs.rmSync(merged.backup);
+});
+
+test('writeTarget merges into .env without export prefixes', () => {
+  const envPath = path.join(tmp, '.env');
+  fs.writeFileSync(envPath, 'EXISTING=1\n');
+  writeTarget({ target: 'env', envPath, values: { DEMO_NAME: 'x' } }, [schema]);
+  const content = fs.readFileSync(envPath, 'utf8');
+  assert.match(content, /^EXISTING=1$/m);
+  assert.match(content, /^DEMO_NAME=x$/m);
+});
+
+test('cli plan/detect/validate round-trip against a fixture plugin', () => {
+  const pluginRoot = makePluginDir();
+  const home = path.join(tmp, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  const env = { PATH: process.env.PATH, HOME: home };
+
+  const plan = spawnSync(
+    process.execPath,
+    [CLI, 'plan', '--plugin-root', pluginRoot, '--cwd', tmp],
+    {
+      encoding: 'utf8',
+      env,
+    }
+  );
+  assert.equal(plan.status, 0, plan.stderr);
+  const parsed = JSON.parse(plan.stdout);
+  assert.deepEqual(parsed.plugins, ['demo']);
+  assert.equal(parsed.vars.length, 2);
+
+  const detect = spawnSync(
+    process.execPath,
+    [CLI, 'detect', '--plugin-root', pluginRoot, '--cwd', tmp],
+    { encoding: 'utf8', env }
+  );
+  assert.equal(detect.status, 0, detect.stderr);
+  const detected = JSON.parse(detect.stdout);
+  assert.equal(detected.changed, true);
+  assert.deepEqual(detected.missing, ['DEMO_NAME', 'DEMO_FLAG']);
+
+  fs.writeFileSync(path.join(tmp, '.envrc'), 'export DEMO_FLAG=maybe\n');
+  const validate = spawnSync(
+    process.execPath,
+    [CLI, 'validate', '--plugin-root', pluginRoot, '--cwd', tmp],
+    { encoding: 'utf8', env }
+  );
+  assert.equal(validate.status, 0, validate.stderr);
+  assert.match(validate.stdout, /DEMO_FLAG=maybe is invalid — expected 0 or 1/);
+});

--- a/factories/envConfig/__tests__/detect.test.js
+++ b/factories/envConfig/__tests__/detect.test.js
@@ -58,6 +58,7 @@ test('markConfigured enables the fast path until the schema changes', () => {
   assert.deepEqual(detect({ schema, cachePath, projectRoot, values: {} }), {
     changed: false,
     hash: first.hash,
+    acknowledgedVars: [],
   });
 
   const grown = JSON.parse(JSON.stringify(schema));

--- a/factories/envConfig/__tests__/detect.test.js
+++ b/factories/envConfig/__tests__/detect.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { detect, markConfigured, loadCache } = require('../detect');
+const { schemaHash } = require('../schema');
+
+const schema = {
+  plugin: 'demo',
+  prefixes: ['DEMO_'],
+  vars: {
+    DEMO_REQUIRED: { type: 'string', default: '', description: 'r', section: 'S', required: true },
+    DEMO_OPTIONAL: { type: 'string', default: '', description: 'o', section: 'S' },
+    DEMO_ADVANCED: { type: 'string', default: '', description: 'a', section: 'S', advanced: true },
+  },
+};
+
+let tmp;
+let cachePath;
+const projectRoot = '/fake/project';
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'envcfg-detect-'));
+  cachePath = path.join(tmp, 'cache', 'envconfig.json');
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('first run reports non-advanced unset vars as missing', () => {
+  const result = detect({ schema, cachePath, projectRoot, values: {} });
+  assert.equal(result.changed, true);
+  assert.equal(result.firstRun, true);
+  assert.deepEqual(result.missing, ['DEMO_REQUIRED', 'DEMO_OPTIONAL']);
+});
+
+test('set values and acknowledged vars are not missing', () => {
+  markConfigured({
+    cachePath,
+    projectRoot,
+    plugin: 'demo',
+    hash: 'stale-hash',
+    acknowledgedVars: ['DEMO_OPTIONAL'],
+  });
+  const values = { DEMO_REQUIRED: { value: 'x', dynamic: false, source: 'envrc' } };
+  const result = detect({ schema, cachePath, projectRoot, values });
+  assert.equal(result.changed, true);
+  assert.equal(result.firstRun, false);
+  assert.deepEqual(result.missing, []);
+});
+
+test('markConfigured enables the fast path until the schema changes', () => {
+  const first = detect({ schema, cachePath, projectRoot, values: {} });
+  markConfigured({ cachePath, projectRoot, plugin: 'demo', hash: first.hash });
+  assert.deepEqual(detect({ schema, cachePath, projectRoot, values: {} }), {
+    changed: false,
+    hash: first.hash,
+  });
+
+  const grown = JSON.parse(JSON.stringify(schema));
+  grown.vars.DEMO_NEW = { type: 'string', default: '', description: 'n', section: 'S' };
+  const redetect = detect({ schema: grown, cachePath, projectRoot, values: {} });
+  assert.equal(redetect.changed, true);
+  assert.ok(redetect.missing.includes('DEMO_NEW'));
+});
+
+test('acknowledged vars accumulate across configure passes', () => {
+  markConfigured({
+    cachePath,
+    projectRoot,
+    plugin: 'demo',
+    hash: 'h1',
+    acknowledgedVars: ['DEMO_REQUIRED'],
+  });
+  markConfigured({
+    cachePath,
+    projectRoot,
+    plugin: 'demo',
+    hash: 'h2',
+    acknowledgedVars: ['DEMO_OPTIONAL'],
+  });
+  const entry = loadCache(cachePath).projects[projectRoot].demo;
+  assert.deepEqual(entry.acknowledgedVars.sort(), ['DEMO_OPTIONAL', 'DEMO_REQUIRED']);
+  assert.equal(entry.schemaHash, 'h2');
+});
+
+test('corrupt cache is treated as first run, then recovers', () => {
+  fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+  fs.writeFileSync(cachePath, '{ not json');
+  const result = detect({ schema, cachePath, projectRoot, values: {} });
+  assert.equal(result.firstRun, true);
+  markConfigured({ cachePath, projectRoot, plugin: 'demo', hash: schemaHash(schema) });
+  assert.equal(detect({ schema, cachePath, projectRoot, values: {} }).changed, false);
+});

--- a/factories/envConfig/__tests__/env-files.test.js
+++ b/factories/envConfig/__tests__/env-files.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { parseEnvContent, findUp, readValues } = require('../envFiles');
+
+let tmp;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'envcfg-files-'));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('parseEnvContent handles export, quotes, comments, and dynamic values', () => {
+  const parsed = parseEnvContent(
+    [
+      '# comment',
+      'PLAIN=value',
+      'export EXPORTED=yes',
+      'QUOTED="two words"',
+      "SINGLE='one'",
+      'DYNAMIC=$(git config user.name)',
+      'REF=$HOME/worktrees',
+      'not a var line',
+      'lower=skipped',
+    ].join('\n')
+  );
+  assert.equal(parsed.PLAIN.value, 'value');
+  assert.equal(parsed.EXPORTED.value, 'yes');
+  assert.equal(parsed.QUOTED.value, 'two words');
+  assert.equal(parsed.SINGLE.value, 'one');
+  assert.equal(parsed.DYNAMIC.dynamic, true);
+  assert.equal(parsed.REF.dynamic, true);
+  assert.equal(parsed.PLAIN.dynamic, false);
+  assert.ok(!('lower' in parsed));
+});
+
+test('findUp locates the nearest file walking parents', () => {
+  const nested = path.join(tmp, 'a', 'b', 'c');
+  fs.mkdirSync(nested, { recursive: true });
+  fs.writeFileSync(path.join(tmp, 'a', '.envrc'), 'export X=1\n');
+  assert.equal(findUp(nested, ['.envrc']), path.join(tmp, 'a', '.envrc'));
+  assert.equal(findUp(nested, ['.does-not-exist'], 3), null);
+});
+
+test('readValues layers global < .env < .envrc < process env', () => {
+  const home = path.join(tmp, 'home');
+  const project = path.join(tmp, 'project');
+  fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+  fs.mkdirSync(project, { recursive: true });
+  fs.writeFileSync(path.join(home, '.claude', '.env'), 'LAYER=global\nONLY_GLOBAL=g\n');
+  fs.writeFileSync(path.join(project, '.env'), 'LAYER=env\nONLY_ENV=e\n');
+  fs.writeFileSync(path.join(project, '.envrc'), 'export LAYER=envrc\nexport ONLY_ENVRC=r\n');
+  const { values, files } = readValues({
+    cwd: project,
+    home,
+    env: { LAYER: 'process', ONLY_PROCESS: 'p' },
+  });
+  assert.equal(values.LAYER.value, 'process');
+  assert.equal(values.ONLY_GLOBAL.value, 'g');
+  assert.equal(values.ONLY_ENV.value, 'e');
+  assert.equal(values.ONLY_ENVRC.value, 'r');
+  assert.equal(values.ONLY_PROCESS.value, 'p');
+  assert.equal(files.envrc, path.join(project, '.envrc'));
+});

--- a/factories/envConfig/__tests__/render.test.js
+++ b/factories/envConfig/__tests__/render.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  renderGhTokenBlock,
+  renderGitIdentityBlock,
+  renderVarLine,
+  renderEnvrc,
+  mergeEnvContent,
+} = require('../render');
+
+const schema = {
+  plugin: 'demo',
+  prefixes: ['DEMO_'],
+  vars: {
+    DEMO_NAME: { type: 'string', default: 'fallback', description: 'The name', section: 'Core' },
+    DEMO_FLAG: { type: 'bool01', default: '0', description: 'A flag', section: 'Core' },
+    DEMO_TUNE: {
+      type: 'number',
+      default: '9',
+      description: 'Tunable',
+      section: 'Core',
+      advanced: true,
+    },
+  },
+};
+
+test('gh token block pins the account and fails loudly', () => {
+  const block = renderGhTokenBlock('thomfilg');
+  assert.match(block, /_gh_token=\$\(gh auth token -u thomfilg 2>\/dev\/null\)/);
+  assert.match(block, /export GH_TOKEN="\$_gh_token"/);
+  assert.match(block, /unset GH_TOKEN/);
+  assert.match(
+    block,
+    /log_status "⚠ GH_TOKEN unset: 'gh auth token -u thomfilg' failed — run 'gh auth login -u thomfilg' \(gh is using stored creds for now\)"/
+  );
+  assert.match(block, /unset _gh_token$/);
+});
+
+test('git identity block: default defers to git config, custom pins literals', () => {
+  const def = renderGitIdentityBlock({ mode: 'default' });
+  assert.match(def, /export GIT_AUTHOR_NAME="\$\(git config user\.name\)"/);
+  assert.match(def, /export GIT_COMMITTER_EMAIL="\$\(git config user\.email\)"/);
+  const custom = renderGitIdentityBlock({ mode: 'custom', name: 'Jane', email: 'j@x.dev' });
+  assert.match(custom, /export GIT_AUTHOR_NAME="Jane"/);
+  assert.match(custom, /export GIT_COMMITTER_EMAIL="j@x\.dev"/);
+});
+
+test('renderVarLine exports set values and comments unset ones', () => {
+  const def = schema.vars.DEMO_NAME;
+  assert.equal(renderVarLine('DEMO_NAME', def, 'plain'), 'export DEMO_NAME=plain');
+  assert.equal(renderVarLine('DEMO_NAME', def, 'two words'), "export DEMO_NAME='two words'");
+  assert.equal(renderVarLine('DEMO_NAME', def, undefined), '# export DEMO_NAME=fallback');
+});
+
+test('renderEnvrc assembles gh block, identity, and plugin sections', () => {
+  const out = renderEnvrc({
+    ghUser: 'someone',
+    gitIdentity: { mode: 'default' },
+    schemas: [schema],
+    values: { DEMO_NAME: 'set-me' },
+  });
+  assert.match(out, /# ─── Git \/ GitHub /);
+  assert.match(out, /gh auth token -u someone/);
+  assert.match(out, /# ─── demo: Core /);
+  assert.match(out, /export DEMO_NAME=set-me/);
+  assert.match(out, /# export DEMO_FLAG=0/);
+  assert.ok(!out.includes('DEMO_TUNE'), 'unset advanced vars are omitted');
+});
+
+test('mergeEnvContent updates in place, uncomments, and appends', () => {
+  const existing = ['# header', 'KEEP=1', '# KNOWN=old', 'CHANGE=old', ''].join('\n');
+  const merged = mergeEnvContent(existing, { CHANGE: 'new', KNOWN: 'now-set', ADDED: 'x' });
+  assert.match(merged, /KEEP=1/);
+  assert.match(merged, /^KNOWN=now-set$/m);
+  assert.match(merged, /^CHANGE=new$/m);
+  assert.match(merged, /^ADDED=x$/m);
+});
+
+test('mergeEnvContent exportPrefix preserves .envrc form', () => {
+  const merged = mergeEnvContent('export A=1\n', { A: '2', B: '3' }, { exportPrefix: true });
+  assert.match(merged, /^export A=2$/m);
+  assert.match(merged, /^export B=3$/m);
+});

--- a/factories/envConfig/__tests__/render.test.js
+++ b/factories/envConfig/__tests__/render.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const {
   renderGhTokenBlock,
   renderGitIdentityBlock,
+  quoteEnvValue,
   renderVarLine,
   renderEnvrc,
   mergeEnvContent,
@@ -50,8 +51,22 @@ test('git identity block: default defers to git config, custom pins literals', (
 test('renderVarLine exports set values and comments unset ones', () => {
   const def = schema.vars.DEMO_NAME;
   assert.equal(renderVarLine('DEMO_NAME', def, 'plain'), 'export DEMO_NAME=plain');
-  assert.equal(renderVarLine('DEMO_NAME', def, 'two words'), "export DEMO_NAME='two words'");
+  assert.equal(renderVarLine('DEMO_NAME', def, 'two words'), 'export DEMO_NAME="two words"');
   assert.equal(renderVarLine('DEMO_NAME', def, undefined), '# export DEMO_NAME=fallback');
+});
+
+test('quoting: $VAR refs expand (double quotes), command types stay literal', () => {
+  const pathDef = { type: 'path', default: '', description: 'p', section: 'S' };
+  const cmdDef = { type: 'command', default: '', description: 'c', section: 'S' };
+  assert.equal(
+    renderVarLine('DEMO_DIR', pathDef, '$HOME/my worktrees'),
+    'export DEMO_DIR="$HOME/my worktrees"'
+  );
+  assert.equal(
+    renderVarLine('DEMO_CMD', cmdDef, 'pnpm test $CHANGED_FILES'),
+    "export DEMO_CMD='pnpm test $CHANGED_FILES'"
+  );
+  assert.equal(quoteEnvValue('say "hi"'), '"say \\"hi\\""');
 });
 
 test('renderEnvrc assembles gh block, identity, and plugin sections', () => {
@@ -82,4 +97,14 @@ test('mergeEnvContent exportPrefix preserves .envrc form', () => {
   const merged = mergeEnvContent('export A=1\n', { A: '2', B: '3' }, { exportPrefix: true });
   assert.match(merged, /^export A=2$/m);
   assert.match(merged, /^export B=3$/m);
+});
+
+test('mergeEnvContent quotes values that need it (spaces stay one assignment)', () => {
+  const merged = mergeEnvContent(
+    'export DIR=/old\n',
+    { DIR: '/home/user/my worktrees', REF: '$HOME/tasks' },
+    { exportPrefix: true }
+  );
+  assert.match(merged, /^export DIR="\/home\/user\/my worktrees"$/m);
+  assert.match(merged, /^export REF="\$HOME\/tasks"$/m);
 });

--- a/factories/envConfig/__tests__/scan.test.js
+++ b/factories/envConfig/__tests__/scan.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { expandGlob, scanVar, scanFulfillable } = require('../scan');
+
+let tmp;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'envcfg-scan-'));
+  fs.mkdirSync(path.join(tmp, '.rulesync', 'rules'), { recursive: true });
+  fs.mkdirSync(path.join(tmp, '.rulesync', 'subagents'), { recursive: true });
+  for (const name of ['code-quality.md', 'types.md', 'e2e-testing.md', 'testing.local.md']) {
+    fs.writeFileSync(path.join(tmp, '.rulesync', 'rules', name), `# ${name}\n`);
+  }
+  fs.writeFileSync(path.join(tmp, '.rulesync', 'subagents', 'qa.md'), '# qa\n');
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('expandGlob matches basename wildcards and exact paths', () => {
+  assert.deepEqual(expandGlob(tmp, '.rulesync/rules/*.md'), [
+    '.rulesync/rules/code-quality.md',
+    '.rulesync/rules/e2e-testing.md',
+    '.rulesync/rules/testing.local.md',
+    '.rulesync/rules/types.md',
+  ]);
+  assert.deepEqual(expandGlob(tmp, '.rulesync/subagents/qa.md'), ['.rulesync/subagents/qa.md']);
+  assert.deepEqual(expandGlob(tmp, 'docs/*.md'), []);
+  assert.deepEqual(expandGlob(tmp, 'docs/ARCH.md'), []);
+});
+
+test('scanVar filters suggestions by names, keeps all candidates', () => {
+  const def = {
+    scan: {
+      globs: ['.rulesync/rules/*.md', '.rulesync/subagents/qa.md'],
+      names: ['e2e-testing', 'testing.local', 'qa'],
+    },
+  };
+  const result = scanVar(tmp, def);
+  assert.equal(result.candidates.length, 5);
+  assert.deepEqual(result.suggested, [
+    '.rulesync/rules/e2e-testing.md',
+    '.rulesync/rules/testing.local.md',
+    '.rulesync/subagents/qa.md',
+  ]);
+  assert.equal(scanVar(tmp, { scan: { globs: ['nowhere/*.md'] } }), null);
+  assert.equal(scanVar(tmp, {}), null);
+});
+
+const schema = {
+  plugin: 'demo',
+  prefixes: ['READ_DOCS_'],
+  vars: {
+    READ_DOCS_A: {
+      type: 'string',
+      default: '',
+      description: 'a',
+      section: 'Docs',
+      advanced: true,
+      scan: { globs: ['.rulesync/rules/*.md'], names: ['types', 'code-quality'] },
+    },
+    READ_DOCS_B: {
+      type: 'string',
+      default: '',
+      description: 'b',
+      section: 'Docs',
+      advanced: true,
+      scan: { globs: ['docs/*.md'] },
+    },
+    PLAIN_VAR: { type: 'string', default: '', description: 'p', section: 'Core' },
+  },
+};
+
+test('scanFulfillable proposes CSV values for unset scannable vars only', () => {
+  const out = scanFulfillable({ schema, projectRoot: tmp, values: {} });
+  assert.equal(out.length, 1, 'B has no matches, PLAIN_VAR has no scan block');
+  assert.equal(out[0].name, 'READ_DOCS_A');
+  assert.equal(out[0].value, '.rulesync/rules/code-quality.md,.rulesync/rules/types.md');
+});
+
+test('scanFulfillable skips set and acknowledged vars', () => {
+  const set = scanFulfillable({
+    schema,
+    projectRoot: tmp,
+    values: { READ_DOCS_A: { value: 'x.md', dynamic: false, source: 'envrc' } },
+  });
+  assert.deepEqual(set, []);
+  const acked = scanFulfillable({
+    schema,
+    projectRoot: tmp,
+    values: {},
+    acknowledged: new Set(['READ_DOCS_A']),
+  });
+  assert.deepEqual(acked, []);
+  // Empty-string value still counts as unset — that's the nag the user asked for.
+  const empty = scanFulfillable({
+    schema,
+    projectRoot: tmp,
+    values: { READ_DOCS_A: { value: '', dynamic: false, source: 'envrc' } },
+  });
+  assert.equal(empty.length, 1);
+});
+
+test('work schema: READ_DOCS scan blocks resolve against a .rulesync fixture', () => {
+  const workSchema = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, '..', '..', '..', 'plugins', 'work', 'config-schema.json'),
+      'utf8'
+    )
+  );
+  const out = scanFulfillable({ schema: workSchema, projectRoot: tmp, values: {} });
+  const byName = Object.fromEntries(out.map((entry) => [entry.name, entry.value]));
+  assert.match(byName.READ_DOCS_ON_REVIEW, /code-quality\.md/);
+  assert.match(byName.READ_DOCS_ON_QA, /qa\.md/);
+  assert.match(byName.READ_DOCS_ON_TEST, /types\.md/);
+  assert.ok(!byName.READ_DOCS_ON_TEST.includes('e2e-testing'), 'TEST excludes e2e docs');
+});

--- a/factories/envConfig/__tests__/scan.test.js
+++ b/factories/envConfig/__tests__/scan.test.js
@@ -105,6 +105,50 @@ test('scanFulfillable skips set and acknowledged vars', () => {
   assert.equal(empty.length, 1);
 });
 
+test('agentFillable: unset vars with satisfied signals, hint carried through', () => {
+  const { agentFillable } = require('../scan');
+  const fillSchema = {
+    plugin: 'demo',
+    prefixes: ['DEMO_'],
+    vars: {
+      DEMO_CMD: {
+        type: 'command',
+        default: '',
+        description: 'c',
+        section: 'S',
+        agentFill: { hint: 'read package.json scripts', signals: ['package.json'] },
+      },
+      DEMO_MISSING_SIGNAL: {
+        type: 'command',
+        default: '',
+        description: 'm',
+        section: 'S',
+        agentFill: { hint: 'x', signals: ['nonexistent.toml'] },
+      },
+      DEMO_NO_SIGNALS: {
+        type: 'string',
+        default: '',
+        description: 'n',
+        section: 'S',
+        agentFill: { hint: 'always eligible' },
+      },
+    },
+  };
+  fs.writeFileSync(path.join(tmp, 'package.json'), '{"scripts":{"test":"node --test"}}');
+  const out = agentFillable({ schema: fillSchema, projectRoot: tmp, values: {} });
+  assert.deepEqual(out, [
+    { name: 'DEMO_CMD', hint: 'read package.json scripts' },
+    { name: 'DEMO_NO_SIGNALS', hint: 'always eligible' },
+  ]);
+  const filtered = agentFillable({
+    schema: fillSchema,
+    projectRoot: tmp,
+    values: { DEMO_CMD: { value: 'pnpm test', dynamic: false, source: 'envrc' } },
+    acknowledged: new Set(['DEMO_NO_SIGNALS']),
+  });
+  assert.deepEqual(filtered, []);
+});
+
 test('work schema: READ_DOCS scan blocks resolve against a .rulesync fixture', () => {
   const workSchema = JSON.parse(
     fs.readFileSync(

--- a/factories/envConfig/__tests__/schema.test.js
+++ b/factories/envConfig/__tests__/schema.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  loadSchema,
+  validateSchemaShape,
+  schemaHash,
+  mergeSchemas,
+  discoverSchemas,
+  findMarketplaceRoot,
+} = require('../schema');
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..');
+
+function minimalSchema(overrides = {}) {
+  return {
+    plugin: 'demo',
+    prefixes: ['DEMO_'],
+    vars: {
+      DEMO_FLAG: { type: 'bool01', default: '0', description: 'a flag', section: 'Flags' },
+    },
+    ...overrides,
+  };
+}
+
+test('validateSchemaShape accepts a minimal schema', () => {
+  assert.equal(validateSchemaShape(minimalSchema()).plugin, 'demo');
+});
+
+test('validateSchemaShape rejects bad shapes precisely', () => {
+  assert.throws(() => validateSchemaShape({}), /missing "plugin"/);
+  assert.throws(() => validateSchemaShape(minimalSchema({ prefixes: null })), /prefixes/);
+  assert.throws(
+    () =>
+      validateSchemaShape(
+        minimalSchema({ vars: { BAD: { type: 'nope', description: 'x', section: 's' } } })
+      ),
+    /unknown type/
+  );
+  assert.throws(
+    () =>
+      validateSchemaShape(
+        minimalSchema({ vars: { X_ENUM: { type: 'enum', description: 'x', section: 's' } } })
+      ),
+    /values/
+  );
+});
+
+test('loadSchema returns null for a missing file', () => {
+  assert.equal(loadSchema(path.join(os.tmpdir(), 'no-such-schema.json')), null);
+});
+
+test('schemaHash is stable under key reordering', () => {
+  const a = minimalSchema();
+  const b = {
+    vars: { DEMO_FLAG: { section: 'Flags', description: 'a flag', default: '0', type: 'bool01' } },
+    prefixes: ['DEMO_'],
+    plugin: 'demo',
+  };
+  assert.equal(schemaHash(a), schemaHash(b));
+  const c = minimalSchema();
+  c.vars.DEMO_NEW = { type: 'string', default: '', description: 'new', section: 'Flags' };
+  assert.notEqual(schemaHash(a), schemaHash(c));
+});
+
+test('mergeSchemas unions prefixes/internal, first declaration wins', () => {
+  const a = minimalSchema({ internal: ['DEMO_RUNTIME'] });
+  const b = minimalSchema({ plugin: 'other', prefixes: ['OTHER_'] });
+  b.vars = {
+    DEMO_FLAG: { type: 'string', default: 'x', description: 'conflict', section: 'S' },
+    OTHER_VAR: { type: 'string', default: '', description: 'other', section: 'S' },
+  };
+  const merged = mergeSchemas([a, b]);
+  assert.deepEqual(merged.plugins, ['demo', 'other']);
+  assert.deepEqual(merged.prefixes, ['DEMO_', 'OTHER_']);
+  assert.ok(merged.internal.has('DEMO_RUNTIME'));
+  assert.equal(merged.vars.DEMO_FLAG.type, 'bool01');
+  assert.equal(merged.varPlugin.OTHER_VAR, 'other');
+});
+
+test('self-test: every marketplace plugin ships a valid schema', () => {
+  const schemas = discoverSchemas(REPO_ROOT);
+  const names = schemas.map((s) => s.plugin).sort();
+  assert.deepEqual(names, ['heimdall', 'maestro', 'synapsys', 'work-workflow']);
+});
+
+test('findMarketplaceRoot walks up from a plugin dir', () => {
+  assert.equal(findMarketplaceRoot(path.join(REPO_ROOT, 'plugins', 'work', 'hooks')), REPO_ROOT);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'envcfg-'));
+  try {
+    assert.equal(findMarketplaceRoot(tmp), null);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/factories/envConfig/__tests__/schema.test.js
+++ b/factories/envConfig/__tests__/schema.test.js
@@ -84,8 +84,11 @@ test('mergeSchemas unions prefixes/internal, first declaration wins', () => {
 
 test('self-test: every marketplace plugin ships a valid schema', () => {
   const schemas = discoverSchemas(REPO_ROOT);
-  const names = schemas.map((s) => s.plugin).sort();
-  assert.deepEqual(names, ['heimdall', 'maestro', 'synapsys', 'work-workflow']);
+  const names = schemas.map((s) => s.plugin);
+  // Subset assertion: a future fifth plugin must not break this test.
+  for (const plugin of ['heimdall', 'maestro', 'synapsys', 'work-workflow']) {
+    assert.ok(names.includes(plugin), `missing schema for ${plugin}`);
+  }
 });
 
 test('findMarketplaceRoot walks up from a plugin dir', () => {

--- a/factories/envConfig/__tests__/session-hook.test.js
+++ b/factories/envConfig/__tests__/session-hook.test.js
@@ -78,6 +78,48 @@ test('run is silent once all vars are set (auto-acknowledge) and cached', () => 
   assert.equal(run({ pluginRoot, configureCommand: '/d', cachePath, cwd: tmp }), '');
 });
 
+test('run nudges for scannable vars until acknowledged, even on the fast path', () => {
+  const { markConfigured, projectKey } = require('../detect');
+  const scanSchema = {
+    plugin: 'demo',
+    prefixes: ['DEMO_'],
+    vars: {
+      DEMO_DOCS: {
+        type: 'string',
+        default: '',
+        description: 'docs',
+        section: 'Docs',
+        advanced: true,
+        scan: { globs: ['.rulesync/rules/*.md'] },
+      },
+    },
+  };
+  const pluginRoot = path.join(tmp, 'scan-plugin');
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  fs.writeFileSync(path.join(pluginRoot, 'config-schema.json'), JSON.stringify(scanSchema));
+  fs.mkdirSync(path.join(tmp, '.rulesync', 'rules'), { recursive: true });
+  fs.writeFileSync(path.join(tmp, '.rulesync', 'rules', 'types.md'), '# types\n');
+
+  // First run: no non-advanced vars missing → hash auto-absorbed, but the
+  // scan nudge still fires (that's the "set to empty and forgotten" signal).
+  const first = run({ pluginRoot, configureCommand: '/demo:configure', cachePath, cwd: tmp });
+  assert.match(first, /📄 demo: 1 var\(s\) can be auto-filled .*DEMO_DOCS/);
+  // Fast path (hash cached): still nudging.
+  const second = run({ pluginRoot, configureCommand: '/demo:configure', cachePath, cwd: tmp });
+  assert.match(second, /📄 demo/);
+  // Acknowledged as keep-unset via a configure pass: silent.
+  const { schemaHash } = require('../schema');
+  markConfigured({
+    cachePath,
+    projectRoot: projectKey(tmp),
+    plugin: 'demo',
+    hash: schemaHash(scanSchema),
+    acknowledgedVars: ['DEMO_DOCS'],
+  });
+  const third = run({ pluginRoot, configureCommand: '/demo:configure', cachePath, cwd: tmp });
+  assert.ok(!third.includes('📄'), `expected no scan nudge, got: ${third}`);
+});
+
 test('run returns empty when the plugin has no schema', () => {
   const emptyRoot = path.join(tmp, 'no-schema');
   fs.mkdirSync(emptyRoot, { recursive: true });

--- a/factories/envConfig/__tests__/session-hook.test.js
+++ b/factories/envConfig/__tests__/session-hook.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { run } = require('../sessionHook');
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..');
+
+const schema = {
+  plugin: 'demo',
+  prefixes: ['DEMO_'],
+  vars: {
+    DEMO_NAME: {
+      type: 'string',
+      default: '',
+      description: 'name',
+      section: 'Core',
+      required: true,
+    },
+    DEMO_FLAG: { type: 'bool01', default: '0', description: 'flag', section: 'Core' },
+  },
+};
+
+let tmp;
+let cachePath;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'envcfg-hook-'));
+  cachePath = path.join(tmp, 'cache.json');
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function makePluginDir() {
+  const pluginRoot = path.join(tmp, 'plugin');
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  fs.writeFileSync(path.join(pluginRoot, 'config-schema.json'), JSON.stringify(schema));
+  return pluginRoot;
+}
+
+test('run nudges on first run and lists missing vars', () => {
+  const output = run({
+    pluginRoot: makePluginDir(),
+    configureCommand: '/demo:configure',
+    cachePath,
+    cwd: tmp,
+  });
+  assert.match(output, /⚙ demo: 2 unconfigured config var\(s\): DEMO_NAME, DEMO_FLAG/);
+  assert.match(output, /\/demo:configure/);
+  assert.match(output, /first run/);
+});
+
+test('run warns on invalid values and prefixed typos', () => {
+  fs.writeFileSync(
+    path.join(tmp, '.envrc'),
+    'export DEMO_NAME=x\nexport DEMO_FLAG=nope\nexport DEMO_FLAO=1\n'
+  );
+  const output = run({
+    pluginRoot: makePluginDir(),
+    configureCommand: '/demo:configure',
+    cachePath,
+    cwd: tmp,
+  });
+  assert.match(output, /DEMO_FLAG=nope is invalid — expected 0 or 1/);
+  assert.match(output, /unknown config var DEMO_FLAO — did you mean DEMO_FLAG\?/);
+});
+
+test('run is silent once all vars are set (auto-acknowledge) and cached', () => {
+  const pluginRoot = makePluginDir();
+  fs.writeFileSync(path.join(tmp, '.envrc'), 'export DEMO_NAME=x\nexport DEMO_FLAG=1\n');
+  assert.equal(run({ pluginRoot, configureCommand: '/d', cachePath, cwd: tmp }), '');
+  // Cache now holds the hash — even with values gone, the fast path is silent.
+  fs.rmSync(path.join(tmp, '.envrc'));
+  assert.equal(run({ pluginRoot, configureCommand: '/d', cachePath, cwd: tmp }), '');
+});
+
+test('run returns empty when the plugin has no schema', () => {
+  const emptyRoot = path.join(tmp, 'no-schema');
+  fs.mkdirSync(emptyRoot, { recursive: true });
+  assert.equal(run({ pluginRoot: emptyRoot, configureCommand: '/d', cachePath, cwd: tmp }), '');
+});
+
+test('every plugin config-detect hook exits 0 and stays fail-open', () => {
+  const home = path.join(tmp, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  for (const plugin of ['work', 'heimdall', 'synapsys', 'maestro']) {
+    const hook = path.join(REPO_ROOT, 'plugins', plugin, 'hooks', 'config-detect.js');
+    const result = spawnSync(process.execPath, [hook], {
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH, HOME: home, CLAUDE_PROJECT_DIR: tmp },
+    });
+    assert.equal(result.status, 0, `${plugin}: ${result.stderr}`);
+  }
+});

--- a/factories/envConfig/__tests__/update-check.test.js
+++ b/factories/envConfig/__tests__/update-check.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  compareSemver,
+  check,
+  refresh,
+  writeState,
+  isFresh,
+  DEFAULT_TTL_MS,
+} = require('../updateCheck');
+
+let tmp;
+let cachePath;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'envcfg-update-'));
+  cachePath = path.join(tmp, 'update.json');
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('compareSemver orders numerically, tolerates v-prefix', () => {
+  assert.ok(compareSemver('3.10.0', '3.9.9') > 0);
+  assert.ok(compareSemver('v3.0.0', '3.0.1') < 0);
+  assert.equal(compareSemver('1.2.3', '1.2.3'), 0);
+});
+
+test('check: banner only when cached latest is newer', () => {
+  const now = Date.now();
+  writeState(cachePath, { checkedAt: new Date(now).toISOString(), latest: '9.9.9', source: 'npm' });
+  const newer = check({
+    cachePath,
+    packageName: 'pkg',
+    current: '1.0.0',
+    updateHint: 'git pull',
+    now,
+  });
+  assert.match(newer.banner, /pkg v9\.9\.9 available \(current: v1\.0\.0\)/);
+  assert.match(newer.banner, /git pull/);
+  assert.equal(newer.needsRefresh, false);
+
+  writeState(cachePath, { checkedAt: new Date(now).toISOString(), latest: '1.0.0', source: 'npm' });
+  assert.equal(check({ cachePath, packageName: 'pkg', current: '1.0.0', now }).banner, null);
+});
+
+test('check: stale or absent cache requests a refresh, never blocks', () => {
+  const now = Date.now();
+  assert.equal(check({ cachePath, packageName: 'pkg', current: '1.0.0', now }).needsRefresh, true);
+  writeState(cachePath, {
+    checkedAt: new Date(now - DEFAULT_TTL_MS - 1000).toISOString(),
+    latest: null,
+    source: null,
+  });
+  const result = check({ cachePath, packageName: 'pkg', current: '1.0.0', now });
+  assert.equal(result.needsRefresh, true);
+  assert.equal(result.banner, null);
+});
+
+test('isFresh honors the TTL boundary', () => {
+  const now = Date.now();
+  const state = { checkedAt: new Date(now - 1000).toISOString() };
+  assert.equal(isFresh(state, DEFAULT_TTL_MS, now), true);
+  assert.equal(isFresh(state, 500, now), false);
+  assert.equal(isFresh(null, DEFAULT_TTL_MS, now), false);
+});
+
+test('update-check hook prints a banner from a fresh cache, never blocks', () => {
+  const { spawnSync } = require('node:child_process');
+  const repoRoot = path.join(__dirname, '..', '..', '..');
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  const home = path.join(tmp, 'home');
+  const hookCache = path.join(home, '.claude', '.cache', `update-${pkg.name}.json`);
+  fs.mkdirSync(path.dirname(hookCache), { recursive: true });
+  // Fresh cache with a newer version: banner expected, no refresh spawned.
+  writeState(hookCache, {
+    checkedAt: new Date().toISOString(),
+    latest: '999.0.0',
+    source: 'npm',
+  });
+  const result = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, 'plugins', 'work', 'hooks', 'update-check.js')],
+    { encoding: 'utf8', env: { PATH: process.env.PATH, HOME: home }, timeout: 10000 }
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /v999\.0\.0 available/);
+});
+
+test('refresh: npm hit wins, git raw is the fallback, offline is silent', async () => {
+  const okJson = (body) => ({ ok: true, json: async () => body });
+  const notFound = { ok: false, json: async () => ({}) };
+
+  let result = await refresh({
+    cachePath,
+    packageName: 'pkg',
+    fallbackRawUrl: 'https://raw.example/package.json',
+    fetchImpl: async (url) =>
+      url.includes('registry.npmjs.org') ? okJson({ version: '2.0.0' }) : notFound,
+  });
+  assert.deepEqual(result, { latest: '2.0.0', source: 'npm' });
+
+  result = await refresh({
+    cachePath,
+    packageName: 'pkg',
+    fallbackRawUrl: 'https://raw.example/package.json',
+    fetchImpl: async (url) =>
+      url.includes('registry.npmjs.org') ? notFound : okJson({ version: '3.0.0' }),
+  });
+  assert.deepEqual(result, { latest: '3.0.0', source: 'git' });
+
+  result = await refresh({
+    cachePath,
+    packageName: 'pkg',
+    fallbackRawUrl: 'https://raw.example/package.json',
+    fetchImpl: async () => {
+      throw new Error('offline');
+    },
+  });
+  assert.deepEqual(result, { latest: null, source: null });
+  const state = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  assert.equal(state.latest, null);
+  assert.ok(state.checkedAt);
+});

--- a/factories/envConfig/__tests__/update-check.test.js
+++ b/factories/envConfig/__tests__/update-check.test.js
@@ -100,7 +100,7 @@ test('refresh: npm hit wins, git raw is the fallback, offline is silent', async 
     packageName: 'pkg',
     fallbackRawUrl: 'https://raw.example/package.json',
     fetchImpl: async (url) =>
-      url.includes('registry.npmjs.org') ? okJson({ version: '2.0.0' }) : notFound,
+      url.startsWith('https://registry.npmjs.org/') ? okJson({ version: '2.0.0' }) : notFound,
   });
   assert.deepEqual(result, { latest: '2.0.0', source: 'npm' });
 
@@ -109,7 +109,7 @@ test('refresh: npm hit wins, git raw is the fallback, offline is silent', async 
     packageName: 'pkg',
     fallbackRawUrl: 'https://raw.example/package.json',
     fetchImpl: async (url) =>
-      url.includes('registry.npmjs.org') ? notFound : okJson({ version: '3.0.0' }),
+      url.startsWith('https://registry.npmjs.org/') ? notFound : okJson({ version: '3.0.0' }),
   });
   assert.deepEqual(result, { latest: '3.0.0', source: 'git' });
 

--- a/factories/envConfig/__tests__/validate.test.js
+++ b/factories/envConfig/__tests__/validate.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { levenshtein, findUnknownKeys, validateValues } = require('../validate');
+const { mergeSchemas } = require('../schema');
+
+const merged = mergeSchemas([
+  {
+    plugin: 'demo',
+    prefixes: ['ENABLE_', 'DEMO_'],
+    internal: ['DEMO_RUNTIME_ID'],
+    vars: {
+      ENABLE_DRAFT_PR: { type: 'bool01', default: '0', description: 'f', section: 'S' },
+      DEMO_MODE: { type: 'enum', values: ['a', 'b'], default: 'a', description: 'm', section: 'S' },
+      DEMO_PORT: { type: 'number', default: '', description: 'p', section: 'S' },
+      DEMO_APPS: { type: 'json', default: '', description: 'j', section: 'S' },
+      DEMO_FLAG2: { type: 'boolean', default: 'true', description: 'b', section: 'S' },
+      DEMO_NAME: { type: 'string', default: '', description: 's', section: 'S' },
+    },
+  },
+]);
+
+function vals(pairs) {
+  return Object.fromEntries(
+    Object.entries(pairs).map(([k, v]) => [k, { value: v, dynamic: false, source: 'test' }])
+  );
+}
+
+test('levenshtein distances', () => {
+  assert.equal(levenshtein('ENABLE_X', 'ENABLE_X'), 0);
+  assert.equal(levenshtein('ENABEL_DRAFT_PR', 'ENABLE_DRAFT_PR'), 2);
+  assert.ok(levenshtein('COMPLETELY', 'DIFFERENT') > 2);
+});
+
+test('findUnknownKeys flags prefixed typos with a suggestion', () => {
+  const unknown = findUnknownKeys(merged, ['ENABEL_DRAFT_PR', 'ENABLE_DRAFT_PR', 'UNRELATED']);
+  assert.equal(unknown.length, 1);
+  assert.equal(unknown[0].name, 'ENABEL_DRAFT_PR');
+  assert.equal(unknown[0].suggestion, 'ENABLE_DRAFT_PR');
+});
+
+test('findUnknownKeys ignores internal vars and unmatched prefixes', () => {
+  assert.deepEqual(findUnknownKeys(merged, ['DEMO_RUNTIME_ID', 'PATH', 'HOME']), []);
+  const noSuggestion = findUnknownKeys(merged, ['DEMO_ZZZZZZZZZ']);
+  assert.equal(noSuggestion[0].suggestion, null);
+});
+
+test('findUnknownKeys skips the fuzzy path for process-env names', () => {
+  const values = {
+    // Typo'd prefix from the process env: NOT flagged (fuzzy is file-only).
+    ENABEL_DRAFT_PR: { source: 'process' },
+    // Near-miss of DEMO_MODE from the process env: NOT flagged either.
+    NEMO_MODE: { source: 'process' },
+    // Exact declared prefix from the process env: still flagged.
+    ENABLE_TYPO_XYZ: { source: 'process' },
+    // Near-miss written in a config file: flagged with a hint.
+    DEMO_MODEE: { source: 'envrc' },
+  };
+  assert.deepEqual(findUnknownKeys(merged, values), [
+    { name: 'ENABLE_TYPO_XYZ', suggestion: null },
+    { name: 'DEMO_MODEE', suggestion: 'DEMO_MODE' },
+  ]);
+});
+
+test('validateValues warns per declared type', () => {
+  const warnings = validateValues(
+    merged,
+    vals({
+      ENABLE_DRAFT_PR: 'yes',
+      DEMO_MODE: 'c',
+      DEMO_PORT: 'eighty',
+      DEMO_APPS: '{not json',
+      DEMO_FLAG2: 'TRUE',
+      DEMO_NAME: 'anything goes',
+    })
+  );
+  const byName = Object.fromEntries(warnings.map((w) => [w.name, w.expected]));
+  assert.equal(byName.ENABLE_DRAFT_PR, '0 or 1');
+  assert.match(byName.DEMO_MODE, /one of: a, b/);
+  assert.equal(byName.DEMO_PORT, 'a number');
+  assert.equal(byName.DEMO_APPS, 'valid JSON');
+  assert.ok(!('DEMO_FLAG2' in byName), 'boolean is case-insensitive');
+  assert.ok(!('DEMO_NAME' in byName), 'strings are never warned');
+});
+
+test('validateValues skips dynamic and empty values', () => {
+  const warnings = validateValues(merged, {
+    ENABLE_DRAFT_PR: { value: '$(compute)', dynamic: true, source: 'envrc' },
+    DEMO_PORT: { value: '', dynamic: false, source: 'env-file' },
+  });
+  assert.deepEqual(warnings, []);
+});

--- a/factories/envConfig/cli.js
+++ b/factories/envConfig/cli.js
@@ -33,6 +33,7 @@ const { readValues } = require('./envFiles');
 const { detect, projectKey, markConfigured } = require('./detect');
 const { findUnknownKeys, validateValues } = require('./validate');
 const { renderEnvrc, mergeEnvContent } = require('./render');
+const { scanFulfillable } = require('./scan');
 const { defaultCachePath } = require('./sessionHook');
 
 function parseArgs(argv) {
@@ -129,6 +130,12 @@ function cmdPlan(args) {
     ghAccounts: ghAccounts(),
     gitIdentity: gitIdentity(cwd),
     vars: varInventory(schemas, values),
+    fulfillable: schemas.flatMap((schema) =>
+      scanFulfillable({ schema, projectRoot, values }).map((entry) => ({
+        plugin: schema.plugin,
+        ...entry,
+      }))
+    ),
   };
   process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
 }

--- a/factories/envConfig/cli.js
+++ b/factories/envConfig/cli.js
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * cli.js — configure-flow backend for the per-plugin /…:configure skills.
+ *
+ * Commands (all print JSON unless noted):
+ *   plan     --plugin-root <dir> [--all] [--cwd <dir>]
+ *            Inventory for the interactive setup: every declared var with
+ *            its current value/source, gh accounts, git identity, and the
+ *            suggested .envrc path.
+ *   write    --plugin-root <dir> [--all] --answers <file.json>
+ *            Apply answers: render/merge the chosen target file and
+ *            acknowledge the schema hash in the detection cache.
+ *   validate --plugin-root <dir> [--all]
+ *            Print startup-style warnings (text, exit 0 always).
+ *
+ * The skill collects answers via AskUserQuestion; this CLI stays
+ * non-interactive so it is scriptable and testable.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const {
+  loadSchema,
+  mergeSchemas,
+  schemaHash,
+  findMarketplaceRoot,
+  discoverSchemas,
+} = require('./schema');
+const { readValues } = require('./envFiles');
+const { detect, projectKey, markConfigured } = require('./detect');
+const { findUnknownKeys, validateValues } = require('./validate');
+const { renderEnvrc, mergeEnvContent } = require('./render');
+const { defaultCachePath } = require('./sessionHook');
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--')) {
+      const key = argv[i].slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        args[key] = next;
+        i++;
+      } else {
+        args[key] = true;
+      }
+    } else {
+      args._.push(argv[i]);
+    }
+  }
+  return args;
+}
+
+function resolveSchemas(pluginRoot, all) {
+  const own = loadSchema(path.join(pluginRoot, 'config-schema.json'));
+  if (!own) throw new Error(`no config-schema.json under ${pluginRoot}`);
+  if (!all) return [own];
+  const marketplaceRoot = findMarketplaceRoot(pluginRoot);
+  if (!marketplaceRoot) return [own];
+  const schemas = discoverSchemas(marketplaceRoot);
+  // Own plugin first so its sections lead the rendered .envrc.
+  schemas.sort((a, b) => (a.plugin === own.plugin ? -1 : b.plugin === own.plugin ? 1 : 0));
+  return schemas;
+}
+
+function tryExec(cmd, args) {
+  try {
+    return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Parse `gh auth status` for logged-in account names (all hosts). */
+function ghAccounts() {
+  const output = tryExec('gh', ['auth', 'status']);
+  const accounts = [];
+  for (const match of output.matchAll(/account\s+(\S+)/g)) {
+    if (!accounts.includes(match[1])) accounts.push(match[1]);
+  }
+  return accounts;
+}
+
+function gitIdentity(cwd) {
+  return {
+    name: tryExec('git', ['-C', cwd, 'config', 'user.name']),
+    email: tryExec('git', ['-C', cwd, 'config', 'user.email']),
+  };
+}
+
+function varInventory(schemas, values) {
+  const vars = [];
+  for (const schema of schemas) {
+    for (const [name, def] of Object.entries(schema.vars)) {
+      const current = values[name];
+      vars.push({
+        name,
+        plugin: schema.plugin,
+        section: def.section,
+        type: def.type,
+        description: def.description,
+        default: def.default ?? '',
+        example: def.example ?? '',
+        values: def.values ?? null,
+        required: Boolean(def.required),
+        advanced: Boolean(def.advanced),
+        current: current ? current.value : null,
+        source: current ? current.source : null,
+      });
+    }
+  }
+  return vars;
+}
+
+function cmdPlan(args) {
+  const cwd = args.cwd || process.cwd();
+  const schemas = resolveSchemas(path.resolve(args['plugin-root']), Boolean(args.all));
+  const { values, files } = readValues({ cwd });
+  const projectRoot = projectKey(cwd);
+  const suggestedEnvrcPath = files.envrc || path.join(path.dirname(projectRoot), '.envrc');
+  const plan = {
+    plugins: schemas.map((s) => s.plugin),
+    projectRoot,
+    files,
+    suggestedEnvrcPath,
+    ghAccounts: ghAccounts(),
+    gitIdentity: gitIdentity(cwd),
+    vars: varInventory(schemas, values),
+  };
+  process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+}
+
+function backupIfExists(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  const backup = `${filePath}.bak-${Date.now()}`;
+  fs.copyFileSync(filePath, backup);
+  return backup;
+}
+
+function writeEnvrcTarget(answers, schemas, values) {
+  const target = answers.envrcPath;
+  if (!target) throw new Error('answers.envrcPath is required for target "envrc"');
+  const exists = fs.existsSync(target);
+  const backup = backupIfExists(target);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  if (exists && !answers.regenerate) {
+    // Preserve hand-edited content (dynamic values, comments): merge exports.
+    const existing = fs.readFileSync(`${backup}`, 'utf8');
+    fs.writeFileSync(target, mergeEnvContent(existing, values, { exportPrefix: true }));
+    return { written: target, backup, mode: 'merge' };
+  }
+  fs.writeFileSync(
+    target,
+    renderEnvrc({ ghUser: answers.ghUser, gitIdentity: answers.gitIdentity, schemas, values })
+  );
+  return { written: target, backup, mode: 'render' };
+}
+
+function writeTarget(answers, schemas) {
+  const values = answers.values || {};
+  if (answers.target === 'envrc') return writeEnvrcTarget(answers, schemas, values);
+  const target = answers.envPath;
+  if (!target) throw new Error('answers.envPath is required for env targets');
+  const existing = fs.existsSync(target) ? fs.readFileSync(target, 'utf8') : '';
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, mergeEnvContent(existing, values));
+  return { written: target, backup: null, mode: 'merge' };
+}
+
+function acknowledge(answers, schemas, cachePath, projectRoot) {
+  const touched = new Set([...Object.keys(answers.values || {}), ...(answers.acknowledged || [])]);
+  for (const schema of schemas) {
+    markConfigured({
+      cachePath,
+      projectRoot,
+      plugin: schema.plugin,
+      hash: schemaHash(schema),
+      acknowledgedVars: [...touched].filter((name) => name in schema.vars),
+    });
+  }
+}
+
+function cmdWrite(args) {
+  const schemas = resolveSchemas(path.resolve(args['plugin-root']), Boolean(args.all));
+  const answers = JSON.parse(fs.readFileSync(args.answers, 'utf8'));
+  const cwd = args.cwd || process.cwd();
+  const result = writeTarget(answers, schemas);
+  const cachePath = args.cache || defaultCachePath();
+  acknowledge(answers, schemas, cachePath, projectKey(cwd));
+  process.stdout.write(`${JSON.stringify({ ...result, cacheUpdated: true }, null, 2)}\n`);
+}
+
+function cmdValidate(args) {
+  const cwd = args.cwd || process.cwd();
+  const schemas = resolveSchemas(path.resolve(args['plugin-root']), Boolean(args.all));
+  const merged = mergeSchemas(schemas);
+  const { values } = readValues({ cwd });
+  const lines = [];
+  for (const unknown of findUnknownKeys(merged, values)) {
+    const hint = unknown.suggestion ? ` — did you mean ${unknown.suggestion}?` : '';
+    lines.push(`⚠ unknown config var ${unknown.name}${hint}`);
+  }
+  for (const bad of validateValues(merged, values)) {
+    lines.push(`⚠ ${bad.name}=${bad.value} is invalid — expected ${bad.expected}`);
+  }
+  process.stdout.write(lines.length ? `${lines.join('\n')}\n` : 'config OK — no warnings\n');
+}
+
+function cmdDetect(args) {
+  const cwd = args.cwd || process.cwd();
+  const pluginRoot = path.resolve(args['plugin-root']);
+  const schema = loadSchema(path.join(pluginRoot, 'config-schema.json'));
+  if (!schema) throw new Error(`no config-schema.json under ${pluginRoot}`);
+  const { values } = readValues({ cwd });
+  const result = detect({
+    schema,
+    cachePath: args.cache || defaultCachePath(),
+    projectRoot: projectKey(cwd),
+    values,
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const COMMANDS = { plan: cmdPlan, write: cmdWrite, validate: cmdValidate, detect: cmdDetect };
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const command = COMMANDS[args._[0]];
+  if (!command || !args['plugin-root']) {
+    process.stderr.write(
+      'usage: cli.js <plan|write|validate|detect> --plugin-root <dir> [--all] [--answers <file>] [--cwd <dir>]\n'
+    );
+    process.exit(1);
+  }
+  try {
+    command(args);
+  } catch (err) {
+    process.stderr.write(`envConfig: ${err.message}\n`);
+    process.exit(1);
+  }
+}
+
+/** One-line per-plugin entrypoint: scriptDir is the plugin's scripts/ dir. */
+function mainFor(scriptDir) {
+  if (!process.argv.includes('--plugin-root')) {
+    process.argv.push('--plugin-root', path.join(scriptDir, '..'));
+  }
+  main();
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  parseArgs,
+  resolveSchemas,
+  ghAccounts,
+  varInventory,
+  writeTarget,
+  main,
+  mainFor,
+};

--- a/factories/envConfig/cli.js
+++ b/factories/envConfig/cli.js
@@ -33,7 +33,7 @@ const { readValues } = require('./envFiles');
 const { detect, projectKey, markConfigured } = require('./detect');
 const { findUnknownKeys, validateValues } = require('./validate');
 const { renderEnvrc, mergeEnvContent } = require('./render');
-const { scanFulfillable } = require('./scan');
+const { scanFulfillable, agentFillable } = require('./scan');
 const { defaultCachePath } = require('./sessionHook');
 
 function parseArgs(argv) {
@@ -132,6 +132,12 @@ function cmdPlan(args) {
     vars: varInventory(schemas, values),
     fulfillable: schemas.flatMap((schema) =>
       scanFulfillable({ schema, projectRoot, values }).map((entry) => ({
+        plugin: schema.plugin,
+        ...entry,
+      }))
+    ),
+    agentFill: schemas.flatMap((schema) =>
+      agentFillable({ schema, projectRoot, values }).map((entry) => ({
         plugin: schema.plugin,
         ...entry,
       }))

--- a/factories/envConfig/cli.js
+++ b/factories/envConfig/cli.js
@@ -133,22 +133,26 @@ function cmdPlan(args) {
   process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
 }
 
-function backupIfExists(filePath) {
-  if (!fs.existsSync(filePath)) return null;
-  const backup = `${filePath}.bak-${Date.now()}`;
-  fs.copyFileSync(filePath, backup);
-  return backup;
+function readIfExists(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
 }
 
 function writeEnvrcTarget(answers, schemas, values) {
   const target = answers.envrcPath;
   if (!target) throw new Error('answers.envrcPath is required for target "envrc"');
-  const exists = fs.existsSync(target);
-  const backup = backupIfExists(target);
+  const existing = readIfExists(target);
+  let backup = null;
+  if (existing !== null) {
+    backup = `${target}.bak-${Date.now()}`;
+    fs.writeFileSync(backup, existing);
+  }
   fs.mkdirSync(path.dirname(target), { recursive: true });
-  if (exists && !answers.regenerate) {
+  if (existing !== null && !answers.regenerate) {
     // Preserve hand-edited content (dynamic values, comments): merge exports.
-    const existing = fs.readFileSync(`${backup}`, 'utf8');
     fs.writeFileSync(target, mergeEnvContent(existing, values, { exportPrefix: true }));
     return { written: target, backup, mode: 'merge' };
   }

--- a/factories/envConfig/cli.js
+++ b/factories/envConfig/cli.js
@@ -141,6 +141,14 @@ function readIfExists(filePath) {
   }
 }
 
+/** Atomic write (tmp + rename): no check-then-write window, no torn files. */
+function writeFileAtomic(target, content) {
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const tmp = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, content);
+  fs.renameSync(tmp, target);
+}
+
 function writeEnvrcTarget(answers, schemas, values) {
   const target = answers.envrcPath;
   if (!target) throw new Error('answers.envrcPath is required for target "envrc"');
@@ -150,13 +158,12 @@ function writeEnvrcTarget(answers, schemas, values) {
     backup = `${target}.bak-${Date.now()}`;
     fs.writeFileSync(backup, existing);
   }
-  fs.mkdirSync(path.dirname(target), { recursive: true });
   if (existing !== null && !answers.regenerate) {
     // Preserve hand-edited content (dynamic values, comments): merge exports.
-    fs.writeFileSync(target, mergeEnvContent(existing, values, { exportPrefix: true }));
+    writeFileAtomic(target, mergeEnvContent(existing, values, { exportPrefix: true }));
     return { written: target, backup, mode: 'merge' };
   }
-  fs.writeFileSync(
+  writeFileAtomic(
     target,
     renderEnvrc({ ghUser: answers.ghUser, gitIdentity: answers.gitIdentity, schemas, values })
   );
@@ -168,9 +175,8 @@ function writeTarget(answers, schemas) {
   if (answers.target === 'envrc') return writeEnvrcTarget(answers, schemas, values);
   const target = answers.envPath;
   if (!target) throw new Error('answers.envPath is required for env targets');
-  const existing = fs.existsSync(target) ? fs.readFileSync(target, 'utf8') : '';
-  fs.mkdirSync(path.dirname(target), { recursive: true });
-  fs.writeFileSync(target, mergeEnvContent(existing, values));
+  const existing = readIfExists(target) ?? '';
+  writeFileAtomic(target, mergeEnvContent(existing, values));
   return { written: target, backup: null, mode: 'merge' };
 }
 

--- a/factories/envConfig/detect.js
+++ b/factories/envConfig/detect.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * detect.js — new-variable detection with a persistent hash cache (GH-70).
+ *
+ * The cache lives under ~/.claude/.cache/ and stores, per project root and
+ * per plugin, the schema hash last acknowledged by the user plus the vars
+ * they explicitly configured or skipped. The fast path is one hash compare:
+ * when the stored hash matches the current schema, detection is O(1) and
+ * silent. Only the configure flow updates the cache (a detection hook never
+ * self-acknowledges, so the nudge persists until the user acts).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { schemaHash } = require('./schema');
+
+const CACHE_VERSION = 1;
+
+function loadCache(cachePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    if (parsed && parsed.version === CACHE_VERSION && parsed.projects) return parsed;
+  } catch {
+    /* first run or corrupt cache — start fresh */
+  }
+  return { version: CACHE_VERSION, projects: {} };
+}
+
+/** Atomic write (tmp + rename) so concurrent sessions never see torn JSON. */
+function saveCache(cachePath, cache) {
+  fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+  const tmp = `${cachePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(cache, null, 2)}\n`);
+  fs.renameSync(tmp, cachePath);
+}
+
+/** Stable per-project key: git toplevel when available, else cwd. */
+function projectKey(cwd = process.cwd()) {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return path.resolve(cwd);
+  }
+}
+
+function cacheEntry(cache, projectRoot, plugin) {
+  return (cache.projects[projectRoot] || {})[plugin] || null;
+}
+
+/**
+ * Compare a plugin schema against the cache + currently-visible values.
+ *
+ * Returns:
+ *   { changed: false }                                    — fast path
+ *   { changed: true, firstRun, hash, missing: [names] }   — action needed
+ *
+ * `missing` = declared, non-advanced vars that are neither set in any env
+ * source nor previously acknowledged. Advanced vars never nag.
+ */
+function detect({ schema, cachePath, projectRoot, values }) {
+  const hash = schemaHash(schema);
+  const cache = loadCache(cachePath);
+  const entry = cacheEntry(cache, projectRoot, schema.plugin);
+  if (entry && entry.schemaHash === hash) return { changed: false, hash };
+
+  const acknowledged = new Set(entry ? entry.acknowledgedVars || [] : []);
+  const missing = Object.entries(schema.vars)
+    .filter(([name, def]) => !def.advanced && !(name in values) && !acknowledged.has(name))
+    .map(([name]) => name);
+  return { changed: true, firstRun: !entry, hash, missing };
+}
+
+/**
+ * Record a completed configure pass: store the schema hash and the union of
+ * previously + newly acknowledged vars for this project/plugin pair.
+ */
+function markConfigured({ cachePath, projectRoot, plugin, hash, acknowledgedVars = [] }) {
+  const cache = loadCache(cachePath);
+  const project = cache.projects[projectRoot] || (cache.projects[projectRoot] = {});
+  const prior = project[plugin] ? project[plugin].acknowledgedVars || [] : [];
+  project[plugin] = {
+    schemaHash: hash,
+    lastChecked: new Date().toISOString(),
+    acknowledgedVars: [...new Set([...prior, ...acknowledgedVars])],
+  };
+  saveCache(cachePath, cache);
+}
+
+module.exports = { loadCache, saveCache, projectKey, detect, markConfigured };

--- a/factories/envConfig/detect.js
+++ b/factories/envConfig/detect.js
@@ -67,13 +67,14 @@ function detect({ schema, cachePath, projectRoot, values }) {
   const hash = schemaHash(schema);
   const cache = loadCache(cachePath);
   const entry = cacheEntry(cache, projectRoot, schema.plugin);
-  if (entry && entry.schemaHash === hash) return { changed: false, hash };
+  const acknowledgedVars = entry ? entry.acknowledgedVars || [] : [];
+  if (entry && entry.schemaHash === hash) return { changed: false, hash, acknowledgedVars };
 
-  const acknowledged = new Set(entry ? entry.acknowledgedVars || [] : []);
+  const acknowledged = new Set(acknowledgedVars);
   const missing = Object.entries(schema.vars)
     .filter(([name, def]) => !def.advanced && !(name in values) && !acknowledged.has(name))
     .map(([name]) => name);
-  return { changed: true, firstRun: !entry, hash, missing };
+  return { changed: true, firstRun: !entry, hash, missing, acknowledgedVars };
 }
 
 /**

--- a/factories/envConfig/envFiles.js
+++ b/factories/envConfig/envFiles.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * envFiles.js — read the layered env-value sources a session actually sees.
+ *
+ * Merges, lowest precedence first:
+ *   1. global ~/.claude/.env
+ *   2. nearest .env       (walk-up from cwd)
+ *   3. nearest .envrc     (walk-up from cwd — direnv convention)
+ *   4. process env
+ *
+ * Parsing is static — no shell execution. `export KEY=value` and `KEY=value`
+ * lines are read; values containing command/variable substitution are kept
+ * but flagged `dynamic: true` so validators skip value checks on them.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const LINE_RE = /^(?:export\s+)?([A-Z][A-Z0-9_]*)=(.*)$/;
+const QUOTE_RE = /^(['"])([\s\S]*)\1$/;
+
+function isDynamic(rawValue) {
+  return /\$\(|\$\{|`|\$[A-Za-z_]/.test(rawValue);
+}
+
+/** Parse .env / .envrc content into { NAME: { value, dynamic } }. */
+function parseEnvContent(content) {
+  const out = Object.create(null);
+  for (const line of String(content).split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const match = trimmed.match(LINE_RE);
+    if (!match) continue;
+    const raw = match[2].trim();
+    const quoted = raw.match(QUOTE_RE);
+    const value = quoted ? quoted[2] : raw;
+    out[match[1]] = { value, dynamic: isDynamic(raw) };
+  }
+  return out;
+}
+
+/** Walk up from startDir looking for the first existing file among names. */
+function findUp(startDir, names, maxDepth = 8) {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < maxDepth; i++) {
+    for (const name of names) {
+      const candidate = path.join(dir, name);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function readFileValues(filePath, source, into) {
+  if (!filePath) return;
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return;
+  }
+  for (const [name, entry] of Object.entries(parseEnvContent(content))) {
+    into[name] = { ...entry, source };
+  }
+}
+
+/**
+ * Collect the merged env values visible from cwd.
+ * Returns { values: { NAME: { value, dynamic, source } }, files: {...} }.
+ */
+function readValues({ cwd = process.cwd(), home = os.homedir(), env = process.env } = {}) {
+  const values = Object.create(null);
+  const globalEnv = path.join(home, '.claude', '.env');
+  const files = {
+    globalEnv: fs.existsSync(globalEnv) ? globalEnv : null,
+    dotEnv: findUp(cwd, ['.env']),
+    envrc: findUp(cwd, ['.envrc']),
+  };
+  readFileValues(files.globalEnv, 'global-env', values);
+  readFileValues(files.dotEnv, 'env-file', values);
+  readFileValues(files.envrc, 'envrc', values);
+  for (const [name, value] of Object.entries(env)) {
+    if (/^[A-Z][A-Z0-9_]*$/.test(name) && value !== undefined) {
+      values[name] = { value: String(value), dynamic: false, source: 'process' };
+    }
+  }
+  return { values, files };
+}
+
+module.exports = { parseEnvContent, findUp, readValues };

--- a/factories/envConfig/index.js
+++ b/factories/envConfig/index.js
@@ -16,6 +16,7 @@ module.exports = {
   ...require('./validate'),
   ...require('./detect'),
   ...require('./render'),
+  ...require('./scan'),
   sessionHook: require('./sessionHook'),
   updateCheck: require('./updateCheck'),
 };

--- a/factories/envConfig/index.js
+++ b/factories/envConfig/index.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * factories/envConfig — declarative env-var configuration for plugins.
+ *
+ * A plugin declares its user-facing environment variables once, in a
+ * `config-schema.json` at its root; this factory provides everything the
+ * table enables: startup validation with typo suggestions, new-variable
+ * detection against a persistent hash cache, .envrc/.env generation, a
+ * shared SessionStart hook runner, and a non-blocking update banner.
+ */
+
+module.exports = {
+  ...require('./schema'),
+  ...require('./envFiles'),
+  ...require('./validate'),
+  ...require('./detect'),
+  ...require('./render'),
+  sessionHook: require('./sessionHook'),
+  updateCheck: require('./updateCheck'),
+};

--- a/factories/envConfig/render.js
+++ b/factories/envConfig/render.js
@@ -27,6 +27,8 @@ function renderGhTokenBlock(ghUser) {
     '# returns empty (token expired / logged out), do NOT export an empty GH_TOKEN —',
     '# that silently breaks auth. Unset it so gh falls back to stored creds',
     '# (hosts.yml) and surface the degradation via a visible warning.',
+    '# log_status is the direnv stdlib logger; shim it when the file is sourced directly.',
+    'command -v log_status >/dev/null 2>&1 || log_status() { echo "$*" >&2; }',
     `_gh_token=$(gh auth token -u ${ghUser} 2>/dev/null)`,
     'if [ -n "$_gh_token" ]; then',
     '  export GH_TOKEN="$_gh_token"',
@@ -44,11 +46,13 @@ function renderGhTokenBlock(ghUser) {
  */
 function renderGitIdentityBlock(identity = { mode: 'default' }) {
   if (identity.mode === 'custom') {
+    const name = dquoteEscape(identity.name);
+    const email = dquoteEscape(identity.email);
     return [
-      `export GIT_AUTHOR_NAME="${identity.name}"`,
-      `export GIT_COMMITTER_NAME="${identity.name}"`,
-      `export GIT_AUTHOR_EMAIL="${identity.email}"`,
-      `export GIT_COMMITTER_EMAIL="${identity.email}"`,
+      `export GIT_AUTHOR_NAME="${name}"`,
+      `export GIT_COMMITTER_NAME="${name}"`,
+      `export GIT_AUTHOR_EMAIL="${email}"`,
+      `export GIT_COMMITTER_EMAIL="${email}"`,
     ].join('\n');
   }
   return [
@@ -63,12 +67,25 @@ function needsQuoting(value) {
   return /[\s"'`$#\\]/.test(value);
 }
 
+function dquoteEscape(value) {
+  return String(value).replace(/[\\"]/g, '\\$&');
+}
+
+/**
+ * Quote a value for a shell assignment. Default is double-quoting so
+ * `$HOME`-style references still expand at source time; `literal: true`
+ * (command-type vars) single-quotes so expansion is deferred to run time.
+ */
+function quoteEnvValue(value, { literal = false } = {}) {
+  const str = String(value);
+  if (!needsQuoting(str)) return str;
+  if (literal) return `'${str.replace(/'/g, "'\\''")}'`;
+  return `"${dquoteEscape(str)}"`;
+}
+
 function renderVarLine(name, def, value) {
   if (value !== undefined && value !== null && value !== '') {
-    const rendered = needsQuoting(String(value))
-      ? `'${String(value).replace(/'/g, "'\\''")}'`
-      : value;
-    return `export ${name}=${rendered}`;
+    return `export ${name}=${quoteEnvValue(value, { literal: def.type === 'command' })}`;
   }
   const hint = def.example || def.default || '';
   return `# export ${name}=${hint}`;
@@ -145,13 +162,13 @@ function mergeEnvContent(existing, updates, { exportPrefix = false } = {}) {
     if (match && match[1] in pending) {
       const value = pending[match[1]];
       delete pending[match[1]];
-      return `${prefix}${match[1]}=${value}`;
+      return `${prefix}${match[1]}=${quoteEnvValue(value)}`;
     }
     return line;
   });
   while (merged.length && merged[merged.length - 1] === '') merged.pop();
   for (const [name, value] of Object.entries(pending)) {
-    merged.push(`${prefix}${name}=${value}`);
+    merged.push(`${prefix}${name}=${quoteEnvValue(value)}`);
   }
   return `${merged.join('\n')}\n`;
 }
@@ -160,6 +177,7 @@ module.exports = {
   sectionHeader,
   renderGhTokenBlock,
   renderGitIdentityBlock,
+  quoteEnvValue,
   renderVarLine,
   renderPluginSections,
   renderEnvrc,

--- a/factories/envConfig/render.js
+++ b/factories/envConfig/render.js
@@ -1,0 +1,167 @@
+'use strict';
+
+/**
+ * render.js — generate .envrc / .env content from schemas + answers.
+ *
+ * The .envrc layout mirrors the field-proven worktree wrapper convention:
+ *   Git / GitHub  → account-pinned GH_TOKEN block + git identity exports
+ *   per-plugin sections → one header per schema section, set vars exported,
+ *   unset vars emitted as commented defaults so the file self-documents.
+ */
+
+const HEADER_WIDTH = 65;
+
+function sectionHeader(title) {
+  const label = `# ─── ${title} `;
+  return label + '─'.repeat(Math.max(3, HEADER_WIDTH - label.length));
+}
+
+/**
+ * Account-pinned GH_TOKEN block. Fails loudly: an expired login never
+ * exports an empty GH_TOKEN (that silently breaks auth) — it unsets it and
+ * surfaces a direnv warning instead.
+ */
+function renderGhTokenBlock(ghUser) {
+  return [
+    '# Pin gh + git ops to the ' + ghUser + ' account. Fail LOUDLY: if `gh auth token`',
+    '# returns empty (token expired / logged out), do NOT export an empty GH_TOKEN —',
+    '# that silently breaks auth. Unset it so gh falls back to stored creds',
+    '# (hosts.yml) and surface the degradation via a visible warning.',
+    `_gh_token=$(gh auth token -u ${ghUser} 2>/dev/null)`,
+    'if [ -n "$_gh_token" ]; then',
+    '  export GH_TOKEN="$_gh_token"',
+    'else',
+    '  unset GH_TOKEN',
+    `  log_status "⚠ GH_TOKEN unset: 'gh auth token -u ${ghUser}' failed — run 'gh auth login -u ${ghUser}' (gh is using stored creds for now)"`,
+    'fi',
+    'unset _gh_token',
+  ].join('\n');
+}
+
+/**
+ * Git identity exports. mode "default" defers to `git config` at direnv
+ * time; mode "custom" pins literal name/email.
+ */
+function renderGitIdentityBlock(identity = { mode: 'default' }) {
+  if (identity.mode === 'custom') {
+    return [
+      `export GIT_AUTHOR_NAME="${identity.name}"`,
+      `export GIT_COMMITTER_NAME="${identity.name}"`,
+      `export GIT_AUTHOR_EMAIL="${identity.email}"`,
+      `export GIT_COMMITTER_EMAIL="${identity.email}"`,
+    ].join('\n');
+  }
+  return [
+    'export GIT_AUTHOR_NAME="$(git config user.name)"',
+    'export GIT_COMMITTER_NAME="$(git config user.name)"',
+    'export GIT_AUTHOR_EMAIL="$(git config user.email)"',
+    'export GIT_COMMITTER_EMAIL="$(git config user.email)"',
+  ].join('\n');
+}
+
+function needsQuoting(value) {
+  return /[\s"'`$#\\]/.test(value);
+}
+
+function renderVarLine(name, def, value) {
+  if (value !== undefined && value !== null && value !== '') {
+    const rendered = needsQuoting(String(value))
+      ? `'${String(value).replace(/'/g, "'\\''")}'`
+      : value;
+    return `export ${name}=${rendered}`;
+  }
+  const hint = def.example || def.default || '';
+  return `# export ${name}=${hint}`;
+}
+
+function groupVarsBySection(schema) {
+  const sections = new Map();
+  for (const [name, def] of Object.entries(schema.vars)) {
+    const key = `${def.section}${def.advanced ? ' (advanced)' : ''}`;
+    if (!sections.has(key)) sections.set(key, []);
+    sections.get(key).push([name, def]);
+  }
+  return sections;
+}
+
+function renderSectionLines(vars, values, isAdvanced) {
+  const lines = [];
+  for (const [name, def] of vars) {
+    const value = values[name];
+    if (isAdvanced && (value === undefined || value === '')) continue;
+    lines.push(`# ${def.description}`, renderVarLine(name, def, value));
+  }
+  return lines;
+}
+
+/**
+ * Render one plugin's sections. Unset advanced vars are skipped entirely
+ * unless another var in their section is set — the file stays readable.
+ */
+function renderPluginSections(schema, values) {
+  const chunks = [];
+  for (const [section, vars] of groupVarsBySection(schema)) {
+    const isAdvanced = section.endsWith('(advanced)');
+    const lines = renderSectionLines(vars, values, isAdvanced);
+    const hasExports = lines.some((line) => !line.startsWith('#'));
+    if (hasExports || !isAdvanced) {
+      chunks.push([sectionHeader(`${schema.plugin}: ${section}`), ...lines].join('\n'));
+    }
+  }
+  return chunks;
+}
+
+/**
+ * Render the complete .envrc.
+ * @param {object} opts
+ * @param {string} opts.ghUser          gh account to pin GH_TOKEN to
+ * @param {object} opts.gitIdentity     { mode: 'default' } | { mode: 'custom', name, email }
+ * @param {object[]} opts.schemas       plugin schemas, render order preserved
+ * @param {object} opts.values          { VAR: value } chosen by the user
+ */
+function renderEnvrc({ ghUser, gitIdentity, schemas, values }) {
+  const parts = [
+    sectionHeader('Git / GitHub'),
+    renderGhTokenBlock(ghUser),
+    renderGitIdentityBlock(gitIdentity),
+  ];
+  for (const schema of schemas) {
+    parts.push(...renderPluginSections(schema, values));
+  }
+  return `${parts.join('\n\n')}\n`;
+}
+
+/**
+ * Merge KEY=value pairs into existing .env/.envrc content: in-place update
+ * for keys already present (commented or not), append the rest. With
+ * exportPrefix (the .envrc form) lines are written as `export KEY=value`.
+ */
+function mergeEnvContent(existing, updates, { exportPrefix = false } = {}) {
+  const prefix = exportPrefix ? 'export ' : '';
+  const lines = String(existing || '').split('\n');
+  const pending = { ...updates };
+  const merged = lines.map((line) => {
+    const match = line.match(/^(?:#\s*)?(?:export\s+)?([A-Z][A-Z0-9_]*)=/);
+    if (match && match[1] in pending) {
+      const value = pending[match[1]];
+      delete pending[match[1]];
+      return `${prefix}${match[1]}=${value}`;
+    }
+    return line;
+  });
+  while (merged.length && merged[merged.length - 1] === '') merged.pop();
+  for (const [name, value] of Object.entries(pending)) {
+    merged.push(`${prefix}${name}=${value}`);
+  }
+  return `${merged.join('\n')}\n`;
+}
+
+module.exports = {
+  sectionHeader,
+  renderGhTokenBlock,
+  renderGitIdentityBlock,
+  renderVarLine,
+  renderPluginSections,
+  renderEnvrc,
+  mergeEnvContent,
+};

--- a/factories/envConfig/scan.js
+++ b/factories/envConfig/scan.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * scan.js — propose values for scannable vars from files in the repo.
+ *
+ * A schema var may declare a `scan` block:
+ *
+ *   "scan": {
+ *     "globs": [".rulesync/rules/*.md", "docs/ARCH.md"],
+ *     "names": ["code-quality", "types"]        // optional basename filter
+ *   }
+ *
+ * When such a var is unset (and not explicitly acknowledged as keep-unset),
+ * scanFulfillable() expands the globs against the project root and proposes
+ * a comma-separated value from the matches. The SessionStart hook uses this
+ * to tell the user the var can be auto-filled; the configure skill uses it
+ * to let the assistant scan the docs and propose the mapping.
+ *
+ * Globbing is intentionally minimal (no deps): `*` is supported in the
+ * basename segment only — exactly what doc-folder patterns need.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Expand one pattern relative to projectRoot; returns relative paths. */
+function expandGlob(projectRoot, pattern) {
+  if (!pattern.includes('*')) {
+    return fs.existsSync(path.join(projectRoot, pattern)) ? [pattern] : [];
+  }
+  const dir = path.dirname(pattern);
+  const baseRe = new RegExp(`^${path.basename(pattern).split('*').map(escapeRegExp).join('.*')}$`);
+  let entries;
+  try {
+    entries = fs.readdirSync(path.join(projectRoot, dir), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isFile() && baseRe.test(entry.name))
+    .map((entry) => path.posix.join(dir, entry.name))
+    .sort();
+}
+
+function baseName(relPath) {
+  return path.basename(relPath).replace(/\.[^.]+$/, '');
+}
+
+/** Resolve one var's scan block. Returns null when nothing matches. */
+function scanVar(projectRoot, def) {
+  const scan = def.scan;
+  if (!scan || !Array.isArray(scan.globs)) return null;
+  const candidates = [...new Set(scan.globs.flatMap((g) => expandGlob(projectRoot, g)))];
+  if (candidates.length === 0) return null;
+  const names = Array.isArray(scan.names) && scan.names.length > 0 ? new Set(scan.names) : null;
+  const suggested = names ? candidates.filter((c) => names.has(baseName(c))) : candidates;
+  return { candidates, suggested };
+}
+
+/**
+ * All scannable vars of a schema that are unset, unacknowledged, and have
+ * at least one suggestion in this repo.
+ * Returns [{ name, candidates, suggested, value }].
+ */
+function scanFulfillable({ schema, projectRoot, values = {}, acknowledged = new Set() }) {
+  const out = [];
+  for (const [name, def] of Object.entries(schema.vars)) {
+    if (!def.scan) continue;
+    const current = values[name];
+    if (current && current.value !== '') continue;
+    if (acknowledged.has(name)) continue;
+    const result = scanVar(projectRoot, def);
+    if (result && result.suggested.length > 0) {
+      out.push({ name, ...result, value: result.suggested.join(',') });
+    }
+  }
+  return out;
+}
+
+module.exports = { expandGlob, scanVar, scanFulfillable };

--- a/factories/envConfig/scan.js
+++ b/factories/envConfig/scan.js
@@ -61,6 +61,11 @@ function scanVar(projectRoot, def) {
   return { candidates, suggested };
 }
 
+function isUnset(values, name) {
+  const current = values[name];
+  return !current || current.value === '';
+}
+
 /**
  * All scannable vars of a schema that are unset, unacknowledged, and have
  * at least one suggestion in this repo.
@@ -70,9 +75,7 @@ function scanFulfillable({ schema, projectRoot, values = {}, acknowledged = new 
   const out = [];
   for (const [name, def] of Object.entries(schema.vars)) {
     if (!def.scan) continue;
-    const current = values[name];
-    if (current && current.value !== '') continue;
-    if (acknowledged.has(name)) continue;
+    if (!isUnset(values, name) || acknowledged.has(name)) continue;
     const result = scanVar(projectRoot, def);
     if (result && result.suggested.length > 0) {
       out.push({ name, ...result, value: result.suggested.join(',') });
@@ -81,4 +84,31 @@ function scanFulfillable({ schema, projectRoot, values = {}, acknowledged = new 
   return out;
 }
 
-module.exports = { expandGlob, scanVar, scanFulfillable };
+/**
+ * Vars whose value needs repo-specific INTERPRETATION (custom commands,
+ * app JSON, bootstrap scripts): schema marks them with an `agentFill`
+ * block — `{ "hint": "how to derive it", "signals": ["package.json"] }` —
+ * and the configure assistant derives a proposal from the repo instead of
+ * asking blind. Included when unset, unacknowledged, and at least one
+ * signal path exists (no signals declared → always eligible).
+ * Returns [{ name, hint }].
+ */
+function signalsPresent(projectRoot, fill) {
+  const signals = Array.isArray(fill.signals) ? fill.signals : [];
+  if (signals.length === 0) return true;
+  return signals.some((signal) => expandGlob(projectRoot, signal).length > 0);
+}
+
+function agentFillable({ schema, projectRoot, values = {}, acknowledged = new Set() }) {
+  const out = [];
+  for (const [name, def] of Object.entries(schema.vars)) {
+    const fill = def.agentFill;
+    if (!fill) continue;
+    if (!isUnset(values, name) || acknowledged.has(name)) continue;
+    if (!signalsPresent(projectRoot, fill)) continue;
+    out.push({ name, hint: fill.hint || '' });
+  }
+  return out;
+}
+
+module.exports = { expandGlob, scanVar, scanFulfillable, agentFillable };

--- a/factories/envConfig/schema.js
+++ b/factories/envConfig/schema.js
@@ -1,0 +1,171 @@
+'use strict';
+
+/**
+ * schema.js — load, validate, merge, and fingerprint env-config schemas.
+ *
+ * A config schema is a per-plugin JSON file (`config-schema.json` at the
+ * plugin root) declaring every user-configurable environment variable the
+ * plugin reads. The declarative table is the single source of truth for
+ * startup validation, new-variable detection, and .envrc generation.
+ *
+ * Shape:
+ * {
+ *   "plugin": "<plugin name>",
+ *   "prefixes": ["FOO_", ...],        // namespaces scanned for unknown keys
+ *   "internal": ["FOO_RUNTIME_X"],    // known-but-not-user-facing vars
+ *   "vars": {
+ *     "FOO_BAR": {
+ *       "type": "string|bool01|boolean|enum|number|path|json|command",
+ *       "default": "",                // rendered as the commented default
+ *       "description": "...",         // one-liner shown in prompts/.envrc
+ *       "section": "Feature Flags",   // .envrc grouping header
+ *       "values": ["a","b"],          // enum only
+ *       "required": false,            // must be set for the plugin to work
+ *       "advanced": false,            // documented but never prompted
+ *       "example": "my-value"         // optional richer example
+ *     }
+ *   }
+ * }
+ */
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const VALID_TYPES = new Set([
+  'string',
+  'bool01',
+  'boolean',
+  'enum',
+  'number',
+  'path',
+  'json',
+  'command',
+]);
+
+const VAR_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
+
+function fail(source, message) {
+  throw new Error(`envConfig schema (${source}): ${message}`);
+}
+
+function requireNonEmptyString(value, source, message) {
+  if (typeof value !== 'string' || !value) fail(source, message);
+}
+
+function validateVarType(name, def, source) {
+  if (!VAR_NAME_RE.test(name)) fail(source, `invalid var name "${name}"`);
+  if (!def || typeof def !== 'object') fail(source, `var "${name}" must be an object`);
+  if (!VALID_TYPES.has(def.type)) fail(source, `var "${name}" has unknown type "${def.type}"`);
+  if (def.type === 'enum' && (!Array.isArray(def.values) || def.values.length === 0)) {
+    fail(source, `enum var "${name}" needs a non-empty "values" array`);
+  }
+}
+
+function validateVarDef(name, def, source) {
+  validateVarType(name, def, source);
+  requireNonEmptyString(def.description, source, `var "${name}" needs a description`);
+  requireNonEmptyString(def.section, source, `var "${name}" needs a section`);
+}
+
+function validateSchemaHeader(schema, source) {
+  if (!schema || typeof schema !== 'object') fail(source, 'schema must be an object');
+  requireNonEmptyString(schema.plugin, source, 'missing "plugin" name');
+  if (!Array.isArray(schema.prefixes)) fail(source, 'missing "prefixes" array');
+  if (schema.internal && !Array.isArray(schema.internal)) {
+    fail(source, '"internal" must be an array when present');
+  }
+  if (!schema.vars || typeof schema.vars !== 'object') fail(source, 'missing "vars" object');
+}
+
+/** Validate a parsed schema object. Throws with a precise message on drift. */
+function validateSchemaShape(schema, source = 'inline') {
+  validateSchemaHeader(schema, source);
+  for (const [name, def] of Object.entries(schema.vars)) {
+    validateVarDef(name, def, source);
+  }
+  return schema;
+}
+
+/** Load and validate a single config-schema.json. Returns null when absent. */
+function loadSchema(schemaPath) {
+  if (!fs.existsSync(schemaPath)) return null;
+  const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+  return validateSchemaShape(schema, schemaPath);
+}
+
+/** Stable content hash of a schema (key-sorted) — the #70 drift fingerprint. */
+function schemaHash(schema) {
+  const canonical = JSON.stringify(schema, (_key, value) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)));
+    }
+    return value;
+  });
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+/** Walk up from startDir to the nearest .claude-plugin/marketplace.json. */
+function findMarketplaceRoot(startDir, maxDepth = 6) {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < maxDepth; i++) {
+    if (fs.existsSync(path.join(dir, '.claude-plugin', 'marketplace.json'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Discover every sibling plugin schema declared by the marketplace manifest.
+ * Plugin-agnostic: names come from marketplace.json, never hardcoded.
+ */
+function discoverSchemas(marketplaceRoot) {
+  const manifestPath = path.join(marketplaceRoot, '.claude-plugin', 'marketplace.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const schemas = [];
+  for (const entry of manifest.plugins || []) {
+    if (!entry || typeof entry.source !== 'string') continue;
+    const schema = loadSchema(path.join(marketplaceRoot, entry.source, 'config-schema.json'));
+    if (schema) schemas.push(schema);
+  }
+  return schemas;
+}
+
+/**
+ * Merge schemas into one lookup: first declaration of a var wins.
+ * Returns { plugins, prefixes, internal:Set, vars, varPlugin }.
+ */
+function mergeSchemas(schemas) {
+  const merged = {
+    plugins: [],
+    prefixes: [],
+    internal: new Set(),
+    vars: {},
+    varPlugin: {},
+  };
+  for (const schema of schemas) {
+    merged.plugins.push(schema.plugin);
+    for (const prefix of schema.prefixes) {
+      if (!merged.prefixes.includes(prefix)) merged.prefixes.push(prefix);
+    }
+    for (const name of schema.internal || []) merged.internal.add(name);
+    for (const [name, def] of Object.entries(schema.vars)) {
+      if (merged.vars[name]) continue;
+      merged.vars[name] = def;
+      merged.varPlugin[name] = schema.plugin;
+    }
+  }
+  return merged;
+}
+
+module.exports = {
+  VALID_TYPES,
+  loadSchema,
+  validateSchemaShape,
+  schemaHash,
+  findMarketplaceRoot,
+  discoverSchemas,
+  mergeSchemas,
+};

--- a/factories/envConfig/sessionHook.js
+++ b/factories/envConfig/sessionHook.js
@@ -1,0 +1,136 @@
+'use strict';
+
+/**
+ * sessionHook.js — shared SessionStart runner for per-plugin config hooks.
+ *
+ * Each plugin's hooks/config-detect.js is a 10-line wrapper around run().
+ * Behavior (all fail-open — a config nudge must never break a session):
+ *
+ *   1. Fast path: schema hash matches the cache → validate values only.
+ *   2. Drift/first-run: emit a nudge listing missing vars and pointing at
+ *      the plugin's configure skill. The cache is NOT updated here — only
+ *      a configure pass acknowledges, so the nudge persists until acted on.
+ *   3. Always: warn on unknown prefixed keys (typo suggestions) and on
+ *      invalid literal values. Warnings only; exit code is always 0.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { loadSchema, mergeSchemas } = require('./schema');
+const { readValues } = require('./envFiles');
+const { detect, projectKey, markConfigured } = require('./detect');
+const { findUnknownKeys, validateValues } = require('./validate');
+
+const MAX_LISTED_VARS = 8;
+const MAX_WARNINGS = 10;
+
+function defaultCachePath(home = os.homedir()) {
+  return path.join(home, '.claude', '.cache', 'envconfig.json');
+}
+
+function readStdinCwd() {
+  let payload = '';
+  try {
+    payload = fs.readFileSync(0, 'utf8');
+  } catch {
+    return null; // no stdin attached
+  }
+  try {
+    const cwd = JSON.parse(payload).cwd;
+    return typeof cwd === 'string' ? cwd : null;
+  } catch {
+    return null; // non-JSON stdin
+  }
+}
+
+/** Project dir per hook convention: CLAUDE_PROJECT_DIR → stdin cwd → cwd. */
+function resolveHookCwd() {
+  return process.env.CLAUDE_PROJECT_DIR || readStdinCwd() || process.cwd();
+}
+
+function formatMissing(missing) {
+  const shown = missing.slice(0, MAX_LISTED_VARS).join(', ');
+  const extra =
+    missing.length > MAX_LISTED_VARS ? ` (+${missing.length - MAX_LISTED_VARS} more)` : '';
+  return `${shown}${extra}`;
+}
+
+function driftLines({ schema, result, configureCommand }) {
+  const lines = [];
+  if (result.missing.length > 0) {
+    const kind = result.firstRun ? 'unconfigured' : 'new/unset';
+    lines.push(
+      `⚙ ${schema.plugin}: ${result.missing.length} ${kind} config var(s): ${formatMissing(result.missing)}`
+    );
+    lines.push(
+      `  Run ${configureCommand} to set them up${result.firstRun ? ' (first run — it can generate your .envrc)' : ''}, or ask the assistant to walk you through it now.`
+    );
+  }
+  return lines;
+}
+
+function warningLines({ merged, values }) {
+  const lines = [];
+  for (const unknown of findUnknownKeys(merged, values)) {
+    const hint = unknown.suggestion ? ` — did you mean ${unknown.suggestion}?` : '';
+    lines.push(`⚠ ${schemaLabel(merged)}: unknown config var ${unknown.name}${hint}`);
+  }
+  for (const bad of validateValues(merged, values)) {
+    lines.push(`⚠ config: ${bad.name}=${bad.value} is invalid — expected ${bad.expected}`);
+  }
+  return lines.slice(0, MAX_WARNINGS);
+}
+
+function schemaLabel(merged) {
+  return merged.plugins ? merged.plugins.join('+') : 'config';
+}
+
+/**
+ * Run detection + validation for one plugin. Prints nudges/warnings to
+ * stdout (SessionStart context injection) and always exits 0 via caller.
+ */
+function run({
+  pluginRoot,
+  configureCommand,
+  cachePath = defaultCachePath(),
+  cwd = process.cwd(),
+}) {
+  const schema = loadSchema(path.join(pluginRoot, 'config-schema.json'));
+  if (!schema) return '';
+
+  const { values } = readValues({ cwd });
+  const projectRoot = projectKey(cwd);
+  const result = detect({ schema, cachePath, projectRoot, values });
+  const merged = mergeSchemas([schema]);
+
+  const lines = [];
+  if (result.changed) {
+    if (result.missing.length === 0) {
+      // Nothing to configure — silently absorb the schema change.
+      markConfigured({ cachePath, projectRoot, plugin: schema.plugin, hash: result.hash });
+    } else {
+      lines.push(...driftLines({ schema, result, configureCommand }));
+    }
+  }
+  lines.push(...warningLines({ merged, values }));
+  return lines.join('\n');
+}
+
+/** Wrapper for hook entrypoints: never throws, prints, exits 0. */
+function main(options) {
+  try {
+    const output = run({ cwd: resolveHookCwd(), ...options });
+    if (output) process.stdout.write(`${output}\n`);
+  } catch {
+    /* fail-open: config nudges must never break session start */
+  }
+  process.exit(0);
+}
+
+/** One-line per-plugin entrypoint: hookDir is the plugin's hooks/ dir. */
+function tryMain(hookDir, configureCommand) {
+  main({ pluginRoot: path.join(hookDir, '..'), configureCommand });
+}
+
+module.exports = { run, main, tryMain, defaultCachePath, resolveHookCwd };

--- a/factories/envConfig/sessionHook.js
+++ b/factories/envConfig/sessionHook.js
@@ -21,7 +21,7 @@ const { loadSchema, mergeSchemas } = require('./schema');
 const { readValues } = require('./envFiles');
 const { detect, projectKey, markConfigured } = require('./detect');
 const { findUnknownKeys, validateValues } = require('./validate');
-const { scanFulfillable } = require('./scan');
+const { scanFulfillable, agentFillable } = require('./scan');
 
 const MAX_LISTED_VARS = 8;
 const MAX_WARNINGS = 10;
@@ -120,23 +120,40 @@ function run({
 }
 
 /**
- * Nudge for scannable vars that sit empty while the repo has the docs to
- * fill them. Fires on the fast path too — an acknowledged (keep-unset) var
- * is the only off switch, so "set to empty and forgotten" cannot go silent.
+ * Nudges for vars the configure assistant can fulfill: scannable vars
+ * (repo docs match their globs) and agent-fill vars (repo-specific values
+ * the assistant derives — commands, app JSON, bootstrap scripts). Fires on
+ * the fast path too — an acknowledged (keep-unset) var is the only off
+ * switch, so "set to empty and forgotten" cannot go silent. Names already
+ * nagged by the drift missing-list are not repeated here.
  */
 function scanLines({ schema, projectRoot, values, result, configureCommand }) {
-  const fulfillable = scanFulfillable({
-    schema,
-    projectRoot,
-    values,
-    acknowledged: new Set(result.acknowledgedVars || []),
-  });
-  if (fulfillable.length === 0) return [];
-  const names = fulfillable.map((entry) => entry.name);
-  return [
-    `📄 ${schema.plugin}: ${names.length} var(s) can be auto-filled from files in this repo: ${formatMissing(names)}`,
-    `  Run ${configureCommand} — the assistant can scan the matched docs and propose the values.`,
-  ];
+  const acknowledged = new Set(result.acknowledgedVars || []);
+  const alreadyNagged = new Set(result.missing || []);
+  const lines = [];
+
+  const scannable = scanFulfillable({ schema, projectRoot, values, acknowledged }).filter(
+    (entry) => !alreadyNagged.has(entry.name)
+  );
+  if (scannable.length > 0) {
+    const names = scannable.map((entry) => entry.name);
+    lines.push(
+      `📄 ${schema.plugin}: ${names.length} var(s) can be auto-filled from files in this repo: ${formatMissing(names)}`,
+      `  Run ${configureCommand} — the assistant can scan the matched docs and propose the values.`
+    );
+  }
+
+  const derivable = agentFillable({ schema, projectRoot, values, acknowledged }).filter(
+    (entry) => !alreadyNagged.has(entry.name)
+  );
+  if (derivable.length > 0) {
+    const names = derivable.map((entry) => entry.name);
+    lines.push(
+      `🛠 ${schema.plugin}: ${names.length} repo-specific var(s) unset: ${formatMissing(names)}`,
+      `  Run ${configureCommand} — the assistant can derive them from this repo (package.json scripts, framework, wrapper layout).`
+    );
+  }
+  return lines;
 }
 
 /** Wrapper for hook entrypoints: never throws, prints, exits 0. */

--- a/factories/envConfig/sessionHook.js
+++ b/factories/envConfig/sessionHook.js
@@ -21,6 +21,7 @@ const { loadSchema, mergeSchemas } = require('./schema');
 const { readValues } = require('./envFiles');
 const { detect, projectKey, markConfigured } = require('./detect');
 const { findUnknownKeys, validateValues } = require('./validate');
+const { scanFulfillable } = require('./scan');
 
 const MAX_LISTED_VARS = 8;
 const MAX_WARNINGS = 10;
@@ -113,8 +114,29 @@ function run({
       lines.push(...driftLines({ schema, result, configureCommand }));
     }
   }
+  lines.push(...scanLines({ schema, projectRoot, values, result, configureCommand }));
   lines.push(...warningLines({ merged, values }));
   return lines.join('\n');
+}
+
+/**
+ * Nudge for scannable vars that sit empty while the repo has the docs to
+ * fill them. Fires on the fast path too — an acknowledged (keep-unset) var
+ * is the only off switch, so "set to empty and forgotten" cannot go silent.
+ */
+function scanLines({ schema, projectRoot, values, result, configureCommand }) {
+  const fulfillable = scanFulfillable({
+    schema,
+    projectRoot,
+    values,
+    acknowledged: new Set(result.acknowledgedVars || []),
+  });
+  if (fulfillable.length === 0) return [];
+  const names = fulfillable.map((entry) => entry.name);
+  return [
+    `📄 ${schema.plugin}: ${names.length} var(s) can be auto-filled from files in this repo: ${formatMissing(names)}`,
+    `  Run ${configureCommand} — the assistant can scan the matched docs and propose the values.`,
+  ];
 }
 
 /** Wrapper for hook entrypoints: never throws, prints, exits 0. */

--- a/factories/envConfig/updateCheck.js
+++ b/factories/envConfig/updateCheck.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * updateCheck.js — non-blocking version-update banner (GH-314).
+ *
+ * Design: the SessionStart hook ONLY reads the cache — it never touches the
+ * network. When the cache is stale (>TTL) the hook spawns a detached
+ * `--refresh` child and exits immediately; the banner (if any) appears from
+ * the refreshed cache on the next session. Offline refreshes write a
+ * null-latest cache entry so nothing retries more than once per TTL.
+ *
+ * Latest-version sources, in order: npm registry, then the marketplace git
+ * remote's raw package.json (marketplace installs are not npm installs).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 5000;
+
+/** Numeric semver compare on major.minor.patch; ignores pre-release tags. */
+function compareSemver(a, b) {
+  const pa = String(a)
+    .replace(/^v/, '')
+    .split('.')
+    .map((n) => Number.parseInt(n, 10) || 0);
+  const pb = String(b)
+    .replace(/^v/, '')
+    .split('.')
+    .map((n) => Number.parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) !== (pb[i] || 0)) return (pa[i] || 0) - (pb[i] || 0);
+  }
+  return 0;
+}
+
+function readState(cachePath) {
+  try {
+    return JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeState(cachePath, state) {
+  fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+  const tmp = `${cachePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
+  fs.renameSync(tmp, cachePath);
+}
+
+function isFresh(state, ttlMs, now) {
+  return Boolean(state && state.checkedAt && now - Date.parse(state.checkedAt) < ttlMs);
+}
+
+async function fetchJson(url, fetchImpl) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetchImpl(url, { signal: controller.signal });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve the latest published version: npm registry first, raw-git
+ * package.json fallback. Returns a version string or null (offline/404).
+ */
+async function fetchLatestVersion({ packageName, fallbackRawUrl, fetchImpl = fetch }) {
+  const npm = await fetchJson(
+    `https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`,
+    fetchImpl
+  );
+  if (npm && typeof npm.version === 'string') return { latest: npm.version, source: 'npm' };
+  if (fallbackRawUrl) {
+    const pkg = await fetchJson(fallbackRawUrl, fetchImpl);
+    if (pkg && typeof pkg.version === 'string') return { latest: pkg.version, source: 'git' };
+  }
+  return { latest: null, source: null };
+}
+
+/** Refresh the cache (network). Called from the detached child only. */
+async function refresh({ cachePath, packageName, fallbackRawUrl, fetchImpl = fetch }) {
+  const { latest, source } = await fetchLatestVersion({ packageName, fallbackRawUrl, fetchImpl });
+  writeState(cachePath, { checkedAt: new Date().toISOString(), latest, source });
+  return { latest, source };
+}
+
+function bannerText({ packageName, current, latest, updateHint }) {
+  return [
+    `📦 ${packageName} v${latest} available (current: v${current})`,
+    updateHint ? `   Update: ${updateHint}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+/**
+ * Cache-only check used by the SessionStart hook.
+ * Returns { banner: string|null, needsRefresh: boolean }.
+ */
+function check({
+  cachePath,
+  packageName,
+  current,
+  updateHint,
+  ttlMs = DEFAULT_TTL_MS,
+  now = Date.now(),
+}) {
+  const state = readState(cachePath);
+  const needsRefresh = !isFresh(state, ttlMs, now);
+  const banner =
+    state && state.latest && compareSemver(state.latest, current) > 0
+      ? bannerText({ packageName, current, latest: state.latest, updateHint })
+      : null;
+  return { banner, needsRefresh };
+}
+
+/** Fire-and-forget detached refresh; never blocks the calling hook. */
+function spawnDetachedRefresh({ scriptPath, args = [] }) {
+  const child = spawn(process.execPath, [scriptPath, '--refresh', ...args], {
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+}
+
+module.exports = {
+  DEFAULT_TTL_MS,
+  compareSemver,
+  readState,
+  writeState,
+  isFresh,
+  fetchLatestVersion,
+  refresh,
+  bannerText,
+  check,
+  spawnDetachedRefresh,
+};

--- a/factories/envConfig/validate.js
+++ b/factories/envConfig/validate.js
@@ -1,0 +1,108 @@
+'use strict';
+
+/**
+ * validate.js — startup env validation (warnings only, never blocking).
+ *
+ * Two checks over a merged schema (see schema.js#mergeSchemas):
+ *   1. Unknown keys — env vars matching a declared prefix that no plugin
+ *      declares. Likely typos: a Levenshtein-≤2 neighbor is suggested.
+ *   2. Invalid values — set vars whose literal value fails the declared
+ *      type (bool01, boolean, enum, number, json).
+ */
+
+const MAX_SUGGEST_DISTANCE = 2;
+
+/** Levenshtein distance with an early bail once `limit` is exceeded. */
+function levenshtein(a, b, limit = MAX_SUGGEST_DISTANCE) {
+  if (Math.abs(a.length - b.length) > limit) return limit + 1;
+  let prev = Array.from({ length: b.length + 1 }, (_v, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    let rowMin = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+      if (curr[j] < rowMin) rowMin = curr[j];
+    }
+    if (rowMin > limit) return limit + 1;
+    prev = curr;
+  }
+  return prev[b.length];
+}
+
+function nearestKnownKey(name, knownKeys) {
+  let best = null;
+  let bestDist = MAX_SUGGEST_DISTANCE + 1;
+  for (const known of knownKeys) {
+    const dist = levenshtein(name, known);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = known;
+    }
+  }
+  return bestDist <= MAX_SUGGEST_DISTANCE ? best : null;
+}
+
+/**
+ * Scan env values for likely typos. Two detection paths:
+ *   - exact-prefix: undeclared names carrying a declared prefix (any source);
+ *   - fuzzy: names within edit-distance 2 of a declared var — catches typos
+ *     inside the prefix itself (e.g. ENABEL_DRAFT_PR), but ONLY for values
+ *     sourced from config files. Process-env names skip the fuzzy path:
+ *     unrelated session vars would otherwise collide with declared names.
+ *
+ * Accepts the readValues() map ({ NAME: { source } }) or a plain array of
+ * names (treated as file-sourced).
+ * Returns [{ name, suggestion }] — suggestion may be null.
+ */
+function findUnknownKeys(merged, envValues) {
+  const entries = Array.isArray(envValues)
+    ? envValues.map((name) => [name, { source: 'env-file' }])
+    : Object.entries(envValues);
+  const known = new Set([...Object.keys(merged.vars), ...merged.internal]);
+  const knownKeys = [...known];
+  const unknown = [];
+  for (const [name, entry] of entries) {
+    if (known.has(name)) continue;
+    const fromFile = entry.source !== 'process';
+    const suggestion = fromFile ? nearestKnownKey(name, knownKeys) : null;
+    if (suggestion || merged.prefixes.some((prefix) => name.startsWith(prefix))) {
+      unknown.push({ name, suggestion });
+    }
+  }
+  return unknown;
+}
+
+const TYPE_CHECKS = {
+  bool01: (value) => (value === '0' || value === '1' ? null : '0 or 1'),
+  boolean: (value) => (['true', 'false'].includes(value.toLowerCase()) ? null : 'true or false'),
+  number: (value) => (/^-?\d+(\.\d+)?$/.test(value) ? null : 'a number'),
+  enum: (value, def) => (def.values.includes(value) ? null : `one of: ${def.values.join(', ')}`),
+  json: (value) => {
+    try {
+      JSON.parse(value);
+      return null;
+    } catch {
+      return 'valid JSON';
+    }
+  },
+};
+
+/**
+ * Check every set, statically-known value against its declared type.
+ * Returns [{ name, value, expected }].
+ */
+function validateValues(merged, values) {
+  const warnings = [];
+  for (const [name, def] of Object.entries(merged.vars)) {
+    const entry = values[name];
+    if (!entry || entry.dynamic || entry.value === '') continue;
+    const check = TYPE_CHECKS[def.type];
+    if (!check) continue;
+    const expected = check(entry.value, def);
+    if (expected) warnings.push({ name, value: entry.value, expected });
+  }
+  return warnings;
+}
+
+module.exports = { levenshtein, findUnknownKeys, validateValues };

--- a/plugins/heimdall/config-schema.json
+++ b/plugins/heimdall/config-schema.json
@@ -1,0 +1,20 @@
+{
+  "plugin": "heimdall",
+  "prefixes": ["HEIMDALL_"],
+  "internal": ["HEIMDALL_CALLER_UID", "HEIMDALL_TEST_SKIP_OWNER_CHECK"],
+  "vars": {
+    "HEIMDALL_COMMANDS_JSON": {
+      "type": "path",
+      "default": "",
+      "description": "Path to a JSON file defining custom lock/conceal command patterns",
+      "section": "Guards"
+    },
+    "HEIMDALL_DISABLE_SHIM": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Disable the LD_PRELOAD write-deny shim for this session",
+      "section": "Guards",
+      "advanced": true
+    }
+  }
+}

--- a/plugins/heimdall/hooks/config-detect.js
+++ b/plugins/heimdall/hooks/config-detect.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// Fail-open SessionStart config nudge for heimdall — logic in factories/envConfig.
+try {
+  require('../../../factories/envConfig/sessionHook').tryMain(__dirname, '/heimdall:configure');
+} catch {
+  process.exit(0);
+}

--- a/plugins/heimdall/hooks/hooks.json
+++ b/plugins/heimdall/hooks/hooks.json
@@ -44,6 +44,10 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/heimdall-secrets-reminder.js\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/config-detect.js\""
           }
         ]
       }

--- a/plugins/heimdall/scripts/config-cli.js
+++ b/plugins/heimdall/scripts/config-cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// heimdall config CLI — shared implementation in factories/envConfig.
+require('../../../factories/envConfig/cli.js').mainFor(__dirname);

--- a/plugins/heimdall/skills/configure/SKILL.md
+++ b/plugins/heimdall/skills/configure/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: configure
+description: Interactive env-var setup for the heimdall plugin. Use when the user says "configure heimdall", "set heimdall env vars", or when the session-start hook reports new/unset heimdall config vars. For a full multi-plugin .envrc generation use /work-workflow:configure instead.
+argument-hint: ""
+user-invocable: true
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Configure (heimdall)
+
+Interactive setup for the env vars declared in this plugin's
+`config-schema.json`, backed by the shared `factories/envConfig` engine.
+
+## Steps
+
+1. **Plan.** Run and parse the JSON:
+
+   ```bash
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" plan --cwd "$PWD"
+   ```
+
+2. **Interview with AskUserQuestion** (max 4 per call): for every `vars[]`
+   entry with `advanced: false` and `current: null`, offer the schema
+   `default` (Recommended when sensible), "Keep unset", and let "Other"
+   capture a custom value. Then ask for the save target: merge into the
+   existing `.envrc` (`plan.files.envrc`, Recommended when present), the
+   repo `.env`, or the global env file in the user's Claude home directory.
+
+3. **Write the answers file** (Write tool) to `/tmp/envconfig-answers-$$.json`:
+
+   ```json
+   {
+     "target": "envrc",
+     "envrcPath": "<plan.files.envrc>",
+     "values": { "VAR": "value" },
+     "acknowledged": ["VAR_KEPT_UNSET"]
+   }
+   ```
+
+   For `.env` targets use `"target": "env"` (or `"global-env"`) with
+   `"envPath"`. An existing `.envrc` is merged in place (timestamped backup
+   kept) — it is never regenerated from a single-plugin skill.
+
+4. **Apply and verify:**
+
+   ```bash
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" write --answers /tmp/envconfig-answers-$$.json
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" validate --cwd "$PWD"
+   ```
+
+5. **Report** the written file, any backup, remaining warnings, and delete
+   the temporary answers file. For `.envrc` targets remind the user to run
+   `direnv allow`.

--- a/plugins/maestro/config-schema.json
+++ b/plugins/maestro/config-schema.json
@@ -1,0 +1,77 @@
+{
+  "plugin": "maestro",
+  "prefixes": ["MAESTRO_"],
+  "internal": [
+    "MAESTRO_FORCE",
+    "MAESTRO_RESTART_MODE",
+    "MAESTRO_STATE_DIR",
+    "MAESTRO_SESSION_DIR",
+    "MAESTRO_STOP_GUARD",
+    "MAESTRO_STOP_GUARD_STATE",
+    "MAESTRO_LINE"
+  ],
+  "vars": {
+    "MAESTRO_SKILL": {
+      "type": "string",
+      "default": "work",
+      "description": "Skill launched per ticket session (work, follow-up, or custom)",
+      "section": "Orchestration"
+    },
+    "MAESTRO_BRANCH_TEMPLATE": {
+      "type": "string",
+      "default": "{ticket}",
+      "example": "feature/{ticket_lower}",
+      "description": "Branch naming template for agent worktrees",
+      "section": "Orchestration"
+    },
+    "MAESTRO_NS": {
+      "type": "string",
+      "default": "",
+      "description": "Namespace segment isolating concurrent orchestrations",
+      "section": "Orchestration",
+      "advanced": true
+    },
+    "MAESTRO_INBOX_DIR": {
+      "type": "path",
+      "default": "",
+      "description": "File-mailbox directory for signal/listen IPC",
+      "section": "Orchestration",
+      "advanced": true
+    },
+    "MAESTRO_TASKS_BASE": {
+      "type": "path",
+      "default": "",
+      "description": "Where per-ticket .maestro-skill files persist",
+      "section": "Orchestration",
+      "advanced": true
+    },
+    "MAESTRO_DISABLE_HOME_STORES": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Ignore home-directory session stores",
+      "section": "Orchestration",
+      "advanced": true
+    },
+    "MAESTRO_GROOM_DELAY_SEC": {
+      "type": "number",
+      "default": "3",
+      "description": "Delay before session grooming (seconds)",
+      "section": "Conductor Tuning",
+      "advanced": true
+    },
+    "MAESTRO_SEND_VERIFY_DELAY_SEC": {
+      "type": "number",
+      "default": "0.7",
+      "description": "Delay when sending keys to tmux (seconds)",
+      "section": "Conductor Tuning",
+      "advanced": true
+    },
+    "MAESTRO_PENDING_WINDOW_MIN": {
+      "type": "number",
+      "default": "",
+      "description": "Window (min) a pending task may wait before alerting",
+      "section": "Conductor Tuning",
+      "advanced": true
+    }
+  }
+}

--- a/plugins/maestro/hooks/config-detect.js
+++ b/plugins/maestro/hooks/config-detect.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// Fail-open SessionStart config nudge for maestro — logic in factories/envConfig.
+try {
+  require('../../../factories/envConfig/sessionHook').tryMain(__dirname, '/maestro:configure');
+} catch {
+  process.exit(0);
+}

--- a/plugins/maestro/hooks/hooks.json
+++ b/plugins/maestro/hooks/hooks.json
@@ -29,6 +29,10 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/active-session-reminder.js\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/config-detect.js\""
           }
         ]
       }

--- a/plugins/maestro/scripts/config-cli.js
+++ b/plugins/maestro/scripts/config-cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// maestro config CLI — shared implementation in factories/envConfig.
+require('../../../factories/envConfig/cli.js').mainFor(__dirname);

--- a/plugins/maestro/skills/configure/SKILL.md
+++ b/plugins/maestro/skills/configure/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: configure
+description: Interactive env-var setup for the maestro plugin. Use when the user says "configure maestro", "set maestro env vars", or when the session-start hook reports new/unset maestro config vars. For a full multi-plugin .envrc generation use /work-workflow:configure instead.
+argument-hint: ""
+user-invocable: true
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Configure (maestro)
+
+Interactive setup for the env vars declared in this plugin's
+`config-schema.json`, backed by the shared `factories/envConfig` engine.
+
+## Steps
+
+1. **Plan.** Run and parse the JSON:
+
+   ```bash
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" plan --cwd "$PWD"
+   ```
+
+2. **Interview with AskUserQuestion** (max 4 per call): for every `vars[]`
+   entry with `advanced: false` and `current: null`, offer the schema
+   `default` (Recommended when sensible), "Keep unset", and let "Other"
+   capture a custom value. Then ask for the save target: merge into the
+   existing `.envrc` (`plan.files.envrc`, Recommended when present), the
+   repo `.env`, or the global env file in the user's Claude home directory.
+
+3. **Write the answers file** (Write tool) to `/tmp/envconfig-answers-$$.json`:
+
+   ```json
+   {
+     "target": "envrc",
+     "envrcPath": "<plan.files.envrc>",
+     "values": { "VAR": "value" },
+     "acknowledged": ["VAR_KEPT_UNSET"]
+   }
+   ```
+
+   For `.env` targets use `"target": "env"` (or `"global-env"`) with
+   `"envPath"`. An existing `.envrc` is merged in place (timestamped backup
+   kept) — it is never regenerated from a single-plugin skill.
+
+4. **Apply and verify:**
+
+   ```bash
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" write --answers /tmp/envconfig-answers-$$.json
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" validate --cwd "$PWD"
+   ```
+
+5. **Report** the written file, any backup, remaining warnings, and delete
+   the temporary answers file. For `.envrc` targets remind the user to run
+   `direnv allow`.

--- a/plugins/synapsys/config-schema.json
+++ b/plugins/synapsys/config-schema.json
@@ -1,0 +1,88 @@
+{
+  "plugin": "synapsys",
+  "prefixes": ["SYNAPSYS_"],
+  "internal": [
+    "SYNAPSYS_HOME",
+    "SYNAPSYS_PRETOOL_DIR",
+    "SYNAPSYS_PROFILES_DIR_FOR_TEST",
+    "SYNAPSYS_CONSOLIDATE_PROFILES_DIR_FOR_TEST",
+    "SYNAPSYS_CONSOLIDATE_BIN_FOR_TEST"
+  ],
+  "vars": {
+    "SYNAPSYS_TELEMETRY": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Memory-injection telemetry (0 disables)",
+      "section": "Memory"
+    },
+    "SYNAPSYS_INJECT_BUDGET": {
+      "type": "number",
+      "default": "",
+      "description": "Max characters injected per event",
+      "section": "Memory",
+      "advanced": true
+    },
+    "SYNAPSYS_DISABLE_HOME_STORES": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Use only project-local memory stores",
+      "section": "Memory"
+    },
+    "SYNAPSYS_NO_SETUP_HINT": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Suppress the first-run setup hint",
+      "section": "Memory",
+      "advanced": true
+    },
+    "SYNAPSYS_SESSION_ROTATION_DISABLED": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Disable session-id rotation",
+      "section": "Memory",
+      "advanced": true
+    },
+    "SYNAPSYS_DEBUG": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Verbose hook debugging output",
+      "section": "Memory",
+      "advanced": true
+    },
+    "SYNAPSYS_SESSION_DIR": {
+      "type": "path",
+      "default": "",
+      "description": "Override session-id storage directory",
+      "section": "Memory",
+      "advanced": true
+    },
+    "SYNAPSYS_PRESETS_PATH": {
+      "type": "path",
+      "default": "",
+      "description": "Override path to presets.json",
+      "section": "Memory",
+      "advanced": true
+    },
+    "SYNAPSYS_CORTEX_DB": {
+      "type": "path",
+      "default": "",
+      "description": "Cortex database path override",
+      "section": "Cortex",
+      "advanced": true
+    },
+    "SYNAPSYS_CORTEX_RECALL_MODULE": {
+      "type": "path",
+      "default": "",
+      "description": "Cortex auto-recall module override",
+      "section": "Cortex",
+      "advanced": true
+    },
+    "SYNAPSYS_CORTEX_KEYWORDS": {
+      "type": "string",
+      "default": "",
+      "description": "Extra keywords steering Cortex auto-recall",
+      "section": "Cortex",
+      "advanced": true
+    }
+  }
+}

--- a/plugins/synapsys/hooks/config-detect.js
+++ b/plugins/synapsys/hooks/config-detect.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// Fail-open SessionStart config nudge for synapsys — logic in factories/envConfig.
+try {
+  require('../../../factories/envConfig/sessionHook').tryMain(__dirname, '/synapsys:configure');
+} catch {
+  process.exit(0);
+}

--- a/plugins/synapsys/hooks/hooks.json
+++ b/plugins/synapsys/hooks/hooks.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/synapsys.js\" SessionStart"
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/config-detect.js\""
           }
         ]
       }

--- a/plugins/synapsys/scripts/config-cli.js
+++ b/plugins/synapsys/scripts/config-cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// synapsys config CLI — shared implementation in factories/envConfig.
+require('../../../factories/envConfig/cli.js').mainFor(__dirname);

--- a/plugins/synapsys/skills/configure/SKILL.md
+++ b/plugins/synapsys/skills/configure/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: configure
+description: Interactive env-var setup for the synapsys plugin. Use when the user says "configure synapsys", "set synapsys env vars", or when the session-start hook reports new/unset synapsys config vars. For a full multi-plugin .envrc generation use /work-workflow:configure instead.
+argument-hint: ""
+user-invocable: true
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Configure (synapsys)
+
+Interactive setup for the env vars declared in this plugin's
+`config-schema.json`, backed by the shared `factories/envConfig` engine.
+
+## Steps
+
+1. **Plan.** Run and parse the JSON:
+
+   ```bash
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" plan --cwd "$PWD"
+   ```
+
+2. **Interview with AskUserQuestion** (max 4 per call): for every `vars[]`
+   entry with `advanced: false` and `current: null`, offer the schema
+   `default` (Recommended when sensible), "Keep unset", and let "Other"
+   capture a custom value. Then ask for the save target: merge into the
+   existing `.envrc` (`plan.files.envrc`, Recommended when present), the
+   repo `.env`, or the global env file in the user's Claude home directory.
+
+3. **Write the answers file** (Write tool) to `/tmp/envconfig-answers-$$.json`:
+
+   ```json
+   {
+     "target": "envrc",
+     "envrcPath": "<plan.files.envrc>",
+     "values": { "VAR": "value" },
+     "acknowledged": ["VAR_KEPT_UNSET"]
+   }
+   ```
+
+   For `.env` targets use `"target": "env"` (or `"global-env"`) with
+   `"envPath"`. An existing `.envrc` is merged in place (timestamped backup
+   kept) — it is never regenerated from a single-plugin skill.
+
+4. **Apply and verify:**
+
+   ```bash
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" write --answers /tmp/envconfig-answers-$$.json
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" validate --cwd "$PWD"
+   ```
+
+5. **Report** the written file, any backup, remaining warnings, and delete
+   the temporary answers file. For `.envrc` targets remind the user to run
+   `direnv allow`.

--- a/plugins/work/config-schema.json
+++ b/plugins/work/config-schema.json
@@ -1,0 +1,431 @@
+{
+  "plugin": "work-workflow",
+  "prefixes": [
+    "WORK_",
+    "TICKET_",
+    "JIRA_",
+    "LINEAR_",
+    "FOLLOW_UP_",
+    "READ_DOCS_ON_",
+    "SESSION_GUARD_",
+    "TASK_REVIEW_",
+    "REBASE_GUARD_",
+    "CHECK_",
+    "ENABLE_",
+    "SCRIPT_RUN_AFFECTED_",
+    "BOOTSTRAP_"
+  ],
+  "internal": [
+    "WORK_TICKET_ID",
+    "WORK_TASK_NUM",
+    "WORK_PR_SLOT",
+    "WORK_OPERATOR_TOKEN",
+    "WORK_DRAFT_WORKDIR",
+    "WORK_WORKTREE_DIR",
+    "WORK_STATE_PATH",
+    "WORK_TEST_STRATEGY_VALIDATOR",
+    "WORK_TDD_TOKEN_SKIP",
+    "WORK_TDD_SKIP_WORKSPACE_CHECK",
+    "WORK_TDD_ENFORCE",
+    "TICKET_ID",
+    "FOLLOW_UP_NEXT_PATH",
+    "SESSION_GUARD_DIR",
+    "SESSION_GUARD_PATH",
+    "SESSION_GUARD_TICKET_ID"
+  ],
+  "vars": {
+    "TICKET_PROVIDER": {
+      "type": "enum",
+      "values": ["jira", "linear", "github", "none"],
+      "default": "jira",
+      "description": "Ticket provider backend",
+      "section": "Ticket Provider",
+      "required": true
+    },
+    "TICKET_PROJECT_KEY": {
+      "type": "string",
+      "default": "PROJ",
+      "description": "Provider-agnostic issue prefix (e.g. MYPROJ)",
+      "section": "Ticket Provider"
+    },
+    "JIRA_PROJECT_KEY": {
+      "type": "string",
+      "default": "PROJ",
+      "description": "Jira project key; also the TICKET_PROJECT_KEY fallback",
+      "section": "Ticket Provider"
+    },
+    "JIRA_BASE_URL": {
+      "type": "string",
+      "default": "your-org.atlassian.net",
+      "description": "Jira instance domain, without https://",
+      "section": "Ticket Provider"
+    },
+    "JIRA_ASSIGNEE_EMAIL": {
+      "type": "string",
+      "default": "",
+      "description": "Default assignee email for new Jira tickets",
+      "section": "Ticket Provider"
+    },
+    "LINEAR_TEAM_ID": {
+      "type": "string",
+      "default": "",
+      "description": "Linear team UUID (when TICKET_PROVIDER=linear)",
+      "section": "Ticket Provider"
+    },
+    "REPO_NAME": {
+      "type": "string",
+      "default": "",
+      "example": "my-project",
+      "description": "Repository name — used for worktree folder naming",
+      "section": "Configuration",
+      "required": true
+    },
+    "GITHUB_ORG": {
+      "type": "string",
+      "default": "",
+      "description": "GitHub org/user for PR URLs and wiki links",
+      "section": "Configuration"
+    },
+    "BASE_BRANCH": {
+      "type": "string",
+      "default": "",
+      "example": "main",
+      "description": "Base branch for diffs/PRs (auto-detected if unset)",
+      "section": "Configuration"
+    },
+    "WORKTREES_BASE": {
+      "type": "path",
+      "default": "",
+      "example": "$HOME/worktrees",
+      "description": "Base directory holding all per-ticket worktrees",
+      "section": "Folders",
+      "required": true
+    },
+    "TASKS_BASE": {
+      "type": "path",
+      "default": "",
+      "example": "$WORKTREES_BASE/tasks",
+      "description": "Base directory for per-ticket task artifacts",
+      "section": "Folders"
+    },
+    "BOOTSTRAP_SCRIPT": {
+      "type": "path",
+      "default": "",
+      "description": "Script run after each worktree creation: <worktree> <ticket>",
+      "section": "Bootstrap"
+    },
+    "BOOTSTRAP_SCRIPT_TIMEOUT": {
+      "type": "number",
+      "default": "120",
+      "description": "Bootstrap script timeout in seconds",
+      "section": "Bootstrap",
+      "advanced": true
+    },
+    "ENABLE_SYMLINK": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Allow symlink creation during worktree bootstrap",
+      "section": "Feature Flags"
+    },
+    "ENABLE_RESOLVE_OUTDATED_COMMENTS": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Auto-resolve outdated PR comments in follow-up",
+      "section": "Feature Flags"
+    },
+    "ENABLE_DRAFT_PR": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Create PRs as drafts (worktree-wrapper bootstrap convention)",
+      "section": "Feature Flags",
+      "advanced": true
+    },
+    "ENABLE_EMPTY_COMMIT": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Seed worktrees with an empty commit (bootstrap-script convention)",
+      "section": "Feature Flags",
+      "advanced": true
+    },
+    "WORK_BRIEF_ENABLED": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Run the brief step in /work",
+      "section": "Feature Flags"
+    },
+    "WORK_SPEC_ENABLED": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Run the spec step in /work",
+      "section": "Feature Flags"
+    },
+    "WORK_TASKS_ENABLED": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Run the task-split step in /work",
+      "section": "Feature Flags"
+    },
+    "WORK_ARCHITECT_ENABLED": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Enable code-architect routing in /work-implement",
+      "section": "Feature Flags"
+    },
+    "TASK_REVIEW_ENABLED": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Per-task review step between commit and check",
+      "section": "Feature Flags"
+    },
+    "TASK_REVIEW_MAX_FIXES": {
+      "type": "number",
+      "default": "3",
+      "description": "Max fix iterations per task review",
+      "section": "Feature Flags",
+      "advanced": true
+    },
+    "SESSION_GUARD_ENABLED": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Workflow session locking",
+      "section": "Feature Flags"
+    },
+    "FOLLOW_UP_PR_POLL_REVIEWS": {
+      "type": "boolean",
+      "default": "true",
+      "description": "Poll PR review comments during /follow-up",
+      "section": "Follow-up"
+    },
+    "FOLLOW_UP_PR_BOT_REVIEWERS": {
+      "type": "string",
+      "default": "",
+      "example": "copilot-pull-request-reviewer,cursor-ai[bot]",
+      "description": "Comma-separated bot reviewer names for /follow-up",
+      "section": "Follow-up"
+    },
+    "DEV_COMMAND": {
+      "type": "command",
+      "default": "",
+      "description": "Custom dev-environment startup command",
+      "section": "Test Commands"
+    },
+    "TEST_COMMAND": {
+      "type": "command",
+      "default": "",
+      "description": "Full test-suite runner (legacy; prefer TEST_*_COMMAND)",
+      "section": "Test Commands"
+    },
+    "LINT_COMMAND": {
+      "type": "command",
+      "default": "",
+      "description": "Linter invocation",
+      "section": "Test Commands"
+    },
+    "TYPECHECK_COMMAND": {
+      "type": "command",
+      "default": "",
+      "description": "Type checker invocation",
+      "section": "Test Commands"
+    },
+    "TEST_UNIT_COMMAND": {
+      "type": "command",
+      "default": "",
+      "description": "Unit test runner; $CHANGED_FILES placeholder supported",
+      "section": "Test Commands"
+    },
+    "TEST_INTEGRATION_COMMAND": {
+      "type": "command",
+      "default": "",
+      "description": "Integration test runner; $CHANGED_FILES supported",
+      "section": "Test Commands"
+    },
+    "TEST_E2E_COMMAND": {
+      "type": "command",
+      "default": "",
+      "description": "E2E test runner; $CHANGED_FILES supported",
+      "section": "Test Commands"
+    },
+    "SCRIPT_RUN_AFFECTED_UNIT": {
+      "type": "command",
+      "default": "",
+      "description": "/check affected-unit-tests script (full diff vs base)",
+      "section": "Test Commands",
+      "advanced": true
+    },
+    "SCRIPT_RUN_AFFECTED_INTEGRATION": {
+      "type": "command",
+      "default": "",
+      "description": "/check affected-integration-tests script",
+      "section": "Test Commands",
+      "advanced": true
+    },
+    "SCRIPT_RUN_AFFECTED_E2E": {
+      "type": "command",
+      "default": "",
+      "description": "/check affected-e2e-tests script",
+      "section": "Test Commands",
+      "advanced": true
+    },
+    "WEB_APPS": {
+      "type": "json",
+      "default": "",
+      "example": "[{\"name\":\"my-app\",\"defaultPort\":3000,\"type\":\"vite\"}]",
+      "description": "JSON array of web apps for QA testing",
+      "section": "Web Apps"
+    },
+    "LOW_CONCURRENCY": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Force single concurrency for dev checks",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "TDD_PHASE_TEST_TIMEOUT_MS": {
+      "type": "number",
+      "default": "",
+      "description": "Timeout (ms) for TDD phase test runs",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "REBASE_GUARD_ENABLED": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Guard against risky rebases during follow-up",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "REBASE_GUARD_THRESHOLD": {
+      "type": "number",
+      "default": "0",
+      "description": "Rebase guard commit-count threshold",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "CHECK_IMPACT_TESTS": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Run impact-selected tests during /check",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "CHECK_TESTS_BASELINE": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Compare /check test failures against a base-branch baseline",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "CHECK_GHERKIN_SCOPE": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Scope /check gherkin verification to the diff",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "CHECK_FLAKE_RETRY": {
+      "type": "bool01",
+      "default": "1",
+      "description": "Retry suspected-flaky tests during /check",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "CHECK_FLAKE_RETRY_MAX": {
+      "type": "number",
+      "default": "",
+      "description": "Max flake retries during /check",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "CHECK_E2E_SPEC_TIMEOUT_MS": {
+      "type": "number",
+      "default": "",
+      "description": "Per-spec E2E timeout (ms) during /check",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "CHECK_ENV_APP_TIMEOUT_MS": {
+      "type": "number",
+      "default": "",
+      "description": "App startup timeout (ms) for /check env verification",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "CHECK_ENV_READY_WAIT_MS": {
+      "type": "number",
+      "default": "",
+      "description": "Readiness wait (ms) for /check env verification",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "CHECK_ENV_DB_TIMEOUT_MS": {
+      "type": "number",
+      "default": "",
+      "description": "DB readiness timeout (ms) for /check env verification",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "READ_DOCS_ON_REVIEW": {
+      "type": "string",
+      "default": "",
+      "description": "Docs (csv paths) for the code-review agent",
+      "section": "Agent Docs",
+      "advanced": true
+    },
+    "READ_DOCS_ON_QA": {
+      "type": "string",
+      "default": "",
+      "description": "Docs for QA agents",
+      "section": "Agent Docs",
+      "advanced": true
+    },
+    "READ_DOCS_ON_DEV": {
+      "type": "string",
+      "default": "",
+      "description": "Docs for developer agents",
+      "section": "Agent Docs",
+      "advanced": true
+    },
+    "READ_DOCS_ON_E2E": {
+      "type": "string",
+      "default": "",
+      "description": "Docs for E2E test writing",
+      "section": "Agent Docs",
+      "advanced": true
+    },
+    "READ_DOCS_ON_TEST": {
+      "type": "string",
+      "default": "",
+      "description": "Docs for unit test writing",
+      "section": "Agent Docs",
+      "advanced": true
+    },
+    "READ_DOCS_ON_STORYBOOK": {
+      "type": "string",
+      "default": "",
+      "description": "Docs for Storybook story writing",
+      "section": "Agent Docs",
+      "advanced": true
+    },
+    "READ_DOCS_ON_PR": {
+      "type": "string",
+      "default": "",
+      "description": "Docs for PR creation",
+      "section": "Agent Docs",
+      "advanced": true
+    },
+    "READ_DOCS_ON_BRIEF": {
+      "type": "string",
+      "default": "",
+      "description": "Docs for the brief-writer agent",
+      "section": "Agent Docs",
+      "advanced": true
+    },
+    "READ_DOCS_ON_SPEC": {
+      "type": "string",
+      "default": "",
+      "description": "Docs for the spec-writer agent",
+      "section": "Agent Docs",
+      "advanced": true
+    }
+  }
+}

--- a/plugins/work/config-schema.json
+++ b/plugins/work/config-schema.json
@@ -27,6 +27,8 @@
     "WORK_TDD_TOKEN_SKIP",
     "WORK_TDD_SKIP_WORKSPACE_CHECK",
     "WORK_TDD_ENFORCE",
+    "WORK_AUTO_RETRY_INFRA",
+    "ENFORCE_HOOK_DEBUG",
     "TICKET_ID",
     "FOLLOW_UP_NEXT_PATH",
     "SESSION_GUARD_DIR",
@@ -78,13 +80,21 @@
       "example": "my-project",
       "description": "Repository name — used for worktree folder naming",
       "section": "Configuration",
-      "required": true
+      "required": true,
+      "agentFill": {
+        "hint": "basename of `git rev-parse --show-toplevel` (strip any worktree suffix)",
+        "signals": [".git"]
+      }
     },
     "GITHUB_ORG": {
       "type": "string",
       "default": "",
       "description": "GitHub org/user for PR URLs and wiki links",
-      "section": "Configuration"
+      "section": "Configuration",
+      "agentFill": {
+        "hint": "owner segment of `git remote get-url origin`",
+        "signals": [".git"]
+      }
     },
     "BASE_BRANCH": {
       "type": "string",
@@ -112,7 +122,11 @@
       "type": "path",
       "default": "",
       "description": "Script run after each worktree creation: <worktree> <ticket>",
-      "section": "Bootstrap"
+      "section": "Bootstrap",
+      "agentFill": {
+        "hint": "look for a wrapper-level bootstrap/new-worktree script (../scripts/*.sh or scripts/*bootstrap*)",
+        "signals": ["../scripts", "scripts"]
+      }
     },
     "BOOTSTRAP_SCRIPT_TIMEOUT": {
       "type": "number",
@@ -207,71 +221,115 @@
       "type": "command",
       "default": "",
       "description": "Custom dev-environment startup command",
-      "section": "Test Commands"
+      "section": "Test Commands",
+      "agentFill": {
+        "hint": "package.json scripts.dev/start, or a repo-convention dev script under scripts/",
+        "signals": ["package.json"]
+      }
     },
     "TEST_COMMAND": {
       "type": "command",
       "default": "",
       "description": "Full test-suite runner (legacy; prefer TEST_*_COMMAND)",
-      "section": "Test Commands"
+      "section": "Test Commands",
+      "agentFill": {
+        "hint": "package.json scripts.test; append the $CHANGED_FILES placeholder when the runner accepts file args",
+        "signals": ["package.json"]
+      }
     },
     "LINT_COMMAND": {
       "type": "command",
       "default": "",
       "description": "Linter invocation",
-      "section": "Test Commands"
+      "section": "Test Commands",
+      "agentFill": {
+        "hint": "package.json scripts.lint; append $CHANGED_FILES when the linter accepts file args",
+        "signals": ["package.json"]
+      }
     },
     "TYPECHECK_COMMAND": {
       "type": "command",
       "default": "",
       "description": "Type checker invocation",
-      "section": "Test Commands"
+      "section": "Test Commands",
+      "agentFill": {
+        "hint": "package.json scripts.typecheck, else `tsc --noEmit` when tsconfig.json exists",
+        "signals": ["package.json"]
+      }
     },
     "TEST_UNIT_COMMAND": {
       "type": "command",
       "default": "",
       "description": "Unit test runner; $CHANGED_FILES placeholder supported",
-      "section": "Test Commands"
+      "section": "Test Commands",
+      "agentFill": {
+        "hint": "package.json scripts.test:unit (or scripts.test) with the $CHANGED_FILES placeholder",
+        "signals": ["package.json"]
+      }
     },
     "TEST_INTEGRATION_COMMAND": {
       "type": "command",
       "default": "",
       "description": "Integration test runner; $CHANGED_FILES supported",
-      "section": "Test Commands"
+      "section": "Test Commands",
+      "agentFill": {
+        "hint": "package.json scripts.test:integration with the $CHANGED_FILES placeholder",
+        "signals": ["package.json"]
+      }
     },
     "TEST_E2E_COMMAND": {
       "type": "command",
       "default": "",
       "description": "E2E test runner; $CHANGED_FILES supported",
-      "section": "Test Commands"
+      "section": "Test Commands",
+      "agentFill": {
+        "hint": "package.json scripts.test:e2e or the Playwright/Cypress runner detected from config files",
+        "signals": ["package.json"]
+      }
     },
     "SCRIPT_RUN_AFFECTED_UNIT": {
       "type": "command",
       "default": "",
       "description": "/check affected-unit-tests script (full diff vs base)",
       "section": "Test Commands",
-      "advanced": true
+      "advanced": true,
+      "agentFill": {
+        "hint": "repo affected-tests script if present (e.g. scripts/run-affected-tests.* --unit)",
+        "signals": ["scripts"]
+      }
     },
     "SCRIPT_RUN_AFFECTED_INTEGRATION": {
       "type": "command",
       "default": "",
       "description": "/check affected-integration-tests script",
       "section": "Test Commands",
-      "advanced": true
+      "advanced": true,
+      "agentFill": {
+        "hint": "repo affected-tests script if present (e.g. scripts/run-affected-tests.* --integration)",
+        "signals": ["scripts"]
+      }
     },
     "SCRIPT_RUN_AFFECTED_E2E": {
       "type": "command",
       "default": "",
       "description": "/check affected-e2e-tests script",
       "section": "Test Commands",
-      "advanced": true
+      "advanced": true,
+      "agentFill": {
+        "hint": "repo affected-e2e script if present (e.g. scripts/run-affected-e2e.*)",
+        "signals": ["scripts"]
+      }
     },
     "WEB_APPS": {
       "type": "json",
       "default": "",
       "example": "[{\"name\":\"my-app\",\"defaultPort\":3000,\"type\":\"vite\"}]",
       "description": "JSON array of web apps for QA testing",
-      "section": "Web Apps"
+      "section": "Web Apps",
+      "agentFill": {
+        "hint": "detect app name + framework (next/vite/remix) + default port from package.json and framework config; emit [{name,defaultPort,type,appType}]",
+        "signals": ["package.json"]
+      }
     },
     "LOW_CONCURRENCY": {
       "type": "bool01",
@@ -284,6 +342,27 @@
       "type": "number",
       "default": "",
       "description": "Timeout (ms) for TDD phase test runs",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "TASK_NEXT_TEST_TIMEOUT_MS": {
+      "type": "number",
+      "default": "300000",
+      "description": "task-next.js hard-kill timeout (ms) for task test commands",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "WORK_SKIP_E2E_TESTS": {
+      "type": "bool01",
+      "default": "0",
+      "description": "Skip E2E suites during implement-gate test runs",
+      "section": "Tuning",
+      "advanced": true
+    },
+    "ENFORCE_HOOK_SUFFIX": {
+      "type": "string",
+      "default": "",
+      "description": "Suffix selecting an enforce-step-workflow hook variant",
       "section": "Tuning",
       "advanced": true
     },

--- a/plugins/work/config-schema.json
+++ b/plugins/work/config-schema.json
@@ -369,63 +369,130 @@
       "default": "",
       "description": "Docs (csv paths) for the code-review agent",
       "section": "Agent Docs",
-      "advanced": true
+      "advanced": true,
+      "scan": {
+        "globs": [".rulesync/rules/*.md"]
+      }
     },
     "READ_DOCS_ON_QA": {
       "type": "string",
       "default": "",
       "description": "Docs for QA agents",
       "section": "Agent Docs",
-      "advanced": true
+      "advanced": true,
+      "scan": {
+        "globs": [".rulesync/rules/*.md", ".rulesync/subagents/qa.md"],
+        "names": [
+          "e2e-testing",
+          "state-api",
+          "ui-ux",
+          "qa",
+          "testing.local",
+          "security",
+          "performance",
+          "database"
+        ]
+      }
     },
     "READ_DOCS_ON_DEV": {
       "type": "string",
       "default": "",
       "description": "Docs for developer agents",
       "section": "Agent Docs",
-      "advanced": true
+      "advanced": true,
+      "scan": {
+        "globs": [".rulesync/rules/*.md"],
+        "names": [
+          "architecture",
+          "code-quality",
+          "types",
+          "react-components",
+          "react-hooks",
+          "database",
+          "pattern-first",
+          "security",
+          "performance",
+          "ui-ux",
+          "hard-cutover",
+          "state-api",
+          "testing.local"
+        ]
+      }
     },
     "READ_DOCS_ON_E2E": {
       "type": "string",
       "default": "",
       "description": "Docs for E2E test writing",
       "section": "Agent Docs",
-      "advanced": true
+      "advanced": true,
+      "scan": {
+        "globs": [".rulesync/rules/*.md"],
+        "names": ["e2e-testing", "state-api", "testing.local", "ui-ux", "database"]
+      }
     },
     "READ_DOCS_ON_TEST": {
       "type": "string",
       "default": "",
       "description": "Docs for unit test writing",
       "section": "Agent Docs",
-      "advanced": true
+      "advanced": true,
+      "scan": {
+        "globs": [".rulesync/rules/*.md"],
+        "names": ["unit-testing", "types", "testing.local", "database"]
+      }
     },
     "READ_DOCS_ON_STORYBOOK": {
       "type": "string",
       "default": "",
       "description": "Docs for Storybook story writing",
       "section": "Agent Docs",
-      "advanced": true
+      "advanced": true,
+      "scan": {
+        "globs": [".rulesync/rules/*.md"],
+        "names": ["react-components", "ui-ux", "react-hooks"]
+      }
     },
     "READ_DOCS_ON_PR": {
       "type": "string",
       "default": "",
       "description": "Docs for PR creation",
       "section": "Agent Docs",
-      "advanced": true
+      "advanced": true,
+      "scan": {
+        "globs": [".rulesync/rules/*.md"]
+      }
     },
     "READ_DOCS_ON_BRIEF": {
       "type": "string",
       "default": "",
       "description": "Docs for the brief-writer agent",
       "section": "Agent Docs",
-      "advanced": true
+      "advanced": true,
+      "scan": {
+        "globs": [".rulesync/subagents/product-owner.md", ".rulesync/rules/*.md", "docs/ARCH.md"],
+        "names": ["product-owner", "architecture", "integrations", "state-api", "ARCH"]
+      }
     },
     "READ_DOCS_ON_SPEC": {
       "type": "string",
       "default": "",
       "description": "Docs for the spec-writer agent",
       "section": "Agent Docs",
-      "advanced": true
+      "advanced": true,
+      "scan": {
+        "globs": [".rulesync/rules/*.md", ".rulesync/subagents/architect.md", "docs/ARCH.md"],
+        "names": [
+          "architecture",
+          "database",
+          "state-api",
+          "pattern-first",
+          "types",
+          "integrations",
+          "security",
+          "architect",
+          "ARCH"
+        ]
+      }
     }
   }
 }

--- a/plugins/work/hooks/config-detect.js
+++ b/plugins/work/hooks/config-detect.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// Fail-open SessionStart config nudge for work — logic in factories/envConfig.
+try {
+  require('../../../factories/envConfig/sessionHook').tryMain(
+    __dirname,
+    '/work-workflow:configure'
+  );
+} catch {
+  process.exit(0);
+}

--- a/plugins/work/hooks/hooks.json
+++ b/plugins/work/hooks/hooks.json
@@ -278,6 +278,21 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/config-detect.js\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/update-check.js\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/work/hooks/update-check.js
+++ b/plugins/work/hooks/update-check.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * update-check.js — SessionStart version banner (GH-314). Fail-open.
+ *
+ * Cache-only on the hook path: reads ~/.claude/.cache/, prints a banner when
+ * a newer version is cached, and — at most once per 24h — spawns a detached
+ * `--refresh` child to re-query the npm registry (falling back to the
+ * marketplace git remote's raw package.json). The hook itself never touches
+ * the network, so session start is never delayed and offline is silent.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const PLUGIN_ROOT = path.join(__dirname, '..');
+
+function marketplaceInfo() {
+  const root = path.join(PLUGIN_ROOT, '..', '..');
+  const pkgPath = path.join(root, 'package.json');
+  if (!fs.existsSync(pkgPath)) return null;
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  let rawUrl = null;
+  let pullHint = null;
+  try {
+    const remote = execFileSync('git', ['-C', root, 'remote', 'get-url', 'origin'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const match = remote.match(/github\.com[:/]([^/]+\/[^/.]+)/);
+    if (match) rawUrl = `https://raw.githubusercontent.com/${match[1]}/main/package.json`;
+    pullHint = `git -C ${root} pull`;
+  } catch {
+    /* not a git checkout — npm-only check */
+  }
+  return { root, name: pkg.name, version: pkg.version, rawUrl, pullHint };
+}
+
+async function main() {
+  const updateCheck = require(
+    path.join(PLUGIN_ROOT, '..', '..', 'factories', 'envConfig', 'updateCheck')
+  );
+  const info = marketplaceInfo();
+  if (!info || !info.name || !info.version) return;
+  const cachePath = path.join(os.homedir(), '.claude', '.cache', `update-${info.name}.json`);
+
+  if (process.argv.includes('--refresh')) {
+    await updateCheck.refresh({
+      cachePath,
+      packageName: info.name,
+      fallbackRawUrl: info.rawUrl,
+    });
+    return;
+  }
+
+  const { banner, needsRefresh } = updateCheck.check({
+    cachePath,
+    packageName: info.name,
+    current: info.version,
+    updateHint: info.pullHint || `npm update -g ${info.name}`,
+  });
+  if (banner) process.stdout.write(`${banner}\n`);
+  if (needsRefresh) updateCheck.spawnDetachedRefresh({ scriptPath: __filename });
+}
+
+main()
+  .catch(() => {})
+  .finally(() => process.exit(0));

--- a/plugins/work/scripts/config-cli.js
+++ b/plugins/work/scripts/config-cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// work config CLI — shared implementation in factories/envConfig.
+require('../../../factories/envConfig/cli.js').mainFor(__dirname);

--- a/plugins/work/skills/configure/SKILL.md
+++ b/plugins/work/skills/configure/SKILL.md
@@ -48,6 +48,23 @@ at direnv time via `gh auth token`.
    sensible), "Keep unset", and let "Other" capture a custom value. Never
    prompt for `advanced` vars — they render as commented defaults.
 
+3b. **Auto-fill scannable vars from repo docs.** When `plan.fulfillable` is
+   non-empty (e.g. the `READ_DOCS_ON_*` family with `.rulesync/` docs present
+   in the repo), scan and propose instead of asking blind:
+
+   - Each entry carries `name`, `candidates` (every matched file),
+     `suggested` (schema-filtered subset), and `value` (the suggested CSV).
+   - Skim the candidate files' titles/headings to sanity-check the mapping —
+     move a doc between categories when its content clearly belongs elsewhere,
+     and consider unmatched `candidates` for inclusion.
+   - Ask ONE AskUserQuestion per batch (multiSelect or grouped): "Auto-fill
+     doc vars from repo scan?" with options "Accept proposed mapping"
+     (Recommended — show the per-var value in the description/preview),
+     "Let me adjust", and "Keep unset".
+   - Accepted values go into `answers.values`; declined vars go into
+     `answers.acknowledged` — acknowledging is what stops the session-start
+     "can be auto-filled" reminder from repeating.
+
 4. **Write the answers file** (use the Write tool) to
    `/tmp/envconfig-answers-$$.json`:
 

--- a/plugins/work/skills/configure/SKILL.md
+++ b/plugins/work/skills/configure/SKILL.md
@@ -65,6 +65,22 @@ at direnv time via `gh auth token`.
      `answers.acknowledged` — acknowledging is what stops the session-start
      "can be auto-filled" reminder from repeating.
 
+3c. **Derive repo-specific vars (`plan.agentFill`).** These need interpretation,
+   not globbing — commands, app JSON, bootstrap scripts. For each entry
+   (`name` + `hint`), YOU derive a proposal from the repo before asking:
+
+   - Follow the entry's `hint`: read `package.json` scripts, framework config
+     files (next/vite/remix/playwright), the wrapper `../scripts/` directory,
+     and the git remote as directed.
+   - Preserve placeholder semantics: `$CHANGED_FILES` must stay literal in
+     command values (the write path single-quotes `command`-type vars so it
+     is not expanded at direnv time).
+   - Present the derived values grouped in AskUserQuestion batches (≤4) with
+     the proposal as the Recommended option, "Keep unset" as an option, and
+     "Other" for manual override. Show the exact value in the description.
+   - Accepted → `answers.values`; declined → `answers.acknowledged` (silences
+     the 🛠 session-start reminder).
+
 4. **Write the answers file** (use the Write tool) to
    `/tmp/envconfig-answers-$$.json`:
 

--- a/plugins/work/skills/configure/SKILL.md
+++ b/plugins/work/skills/configure/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: configure
+description: Interactive env-var setup for the whole plugin family — generates or updates your .envrc (GH_TOKEN account pinning, git identity, and every var declared by work-workflow, heimdall, synapsys, maestro). Use when the user says "configure the plugin", "set up my env vars", "generate my .envrc", "configure work-workflow", or when the session-start hook reports new/unset config vars.
+argument-hint: ""
+user-invocable: true
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Configure
+
+Interactive setup for every config var the plugin family declares. Backed by
+`config-schema.json` files (one per plugin) and the shared `factories/envConfig`
+engine. Never stores secrets: the generated GH_TOKEN block resolves the token
+at direnv time via `gh auth token`.
+
+## Steps
+
+1. **Plan.** Run and parse the JSON:
+
+   ```bash
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" plan --all --cwd "$PWD"
+   ```
+
+   It returns: `plugins`, `projectRoot`, `files` (existing .envrc/.env/global),
+   `suggestedEnvrcPath`, `ghAccounts`, `gitIdentity`, and `vars[]` (each with
+   `current`/`source`/`required`/`advanced`/`default`/`description`).
+
+2. **Interview the user with AskUserQuestion** (max 4 questions per call):
+
+   - **GitHub account** — which `gh` account to pin `GH_TOKEN` to. Options =
+     `plan.ghAccounts` (first one Recommended). The generated block runs
+     `gh auth token -u <account>` at direnv time and unsets `GH_TOKEN` loudly
+     when the login expired — it never exports an empty token.
+   - **Git identity** — "Use git config defaults" (Recommended; show the
+     current `plan.gitIdentity.name` / `.email` in the description) vs
+     "Custom name/email". Custom pins literal values into the .envrc; default
+     defers to `$(git config user.name)` / `$(git config user.email)`.
+   - **Save target** — `.envrc` at `plan.suggestedEnvrcPath` (Recommended for
+     worktree setups), the repo `.env`, or global `~/.claude/.env`.
+   - **If the target .envrc already exists** — "Merge new vars in"
+     (Recommended; preserves hand-edits, a timestamped backup is kept) vs
+     "Regenerate from scratch".
+
+3. **Collect values for missing vars.** For every `vars[]` entry with
+   `advanced: false` and `current: null`, ask in batches of ≤4, grouped by
+   `section`. Required vars (`REPO_NAME`, `WORKTREES_BASE`, `TICKET_PROVIDER`)
+   come first. Per var offer: the schema `default`/`example` (Recommended when
+   sensible), "Keep unset", and let "Other" capture a custom value. Never
+   prompt for `advanced` vars — they render as commented defaults.
+
+4. **Write the answers file** (use the Write tool) to
+   `/tmp/envconfig-answers-$$.json`:
+
+   ```json
+   {
+     "target": "envrc",
+     "envrcPath": "<chosen path>",
+     "regenerate": false,
+     "ghUser": "<account>",
+     "gitIdentity": { "mode": "default" },
+     "values": { "REPO_NAME": "my-repo", "TICKET_PROVIDER": "github" },
+     "acknowledged": ["JIRA_ASSIGNEE_EMAIL"]
+   }
+   ```
+
+   - `values` = vars the user set (or accepted a non-empty default for).
+   - `acknowledged` = vars the user chose to keep unset (stops future nags).
+   - For `.env` targets use `"target": "env"` (or `"global-env"`) with
+     `"envPath"` instead of `envrcPath`; gh/git blocks apply only to `.envrc`.
+   - Custom git identity: `{ "mode": "custom", "name": "…", "email": "…" }`.
+
+5. **Apply and verify:**
+
+   ```bash
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" write --all --answers /tmp/envconfig-answers-$$.json
+   node "$CLAUDE_PLUGIN_ROOT/scripts/config-cli.js" validate --all --cwd "$PWD"
+   ```
+
+6. **Report**: the written file (and backup path if any), remaining warnings
+   from `validate`, and — for `.envrc` targets — remind the user to run
+   `direnv allow <path>`.
+
+## Notes
+
+- Writing also updates the detection cache (`~/.claude/.cache/envconfig.json`),
+  which silences the session-start nudge until a plugin schema changes again.
+- Single-plugin variants exist as `/heimdall:configure`, `/synapsys:configure`,
+  and `/maestro:configure`; this skill configures all installed plugins at once.


### PR DESCRIPTION
## Existing Behavior

- No unified way for users to discover which environment variables each plugin expects; variables were documented only informally with no machine-readable schema.
- SessionStart hooks performed no validation of env-var values and gave no feedback on typos, unknown keys, or missing required variables.
- No detection mechanism existed to notice when a plugin schema grew new variables after a user had already configured their environment; first-run and drift both went silently unnoticed.
- No automated version-update banner: users had no in-session signal that a newer release of the plugin family was available.
- No interactive configure skill existed; users had to hand-write .envrc files by reading scattered documentation.

## Intended New Behavior

- `factories/envConfig/` introduces a plugin-agnostic engine (schema loader, env-file parser, validator, drift detector, renderer, update-check, and a CLI backend) shared across all four plugins without duplication.
- Each plugin ships a `config-schema.json` declaring every user-facing env var with type, default, description, section, and required/advanced flags; the engine validates this shape at load time.
- **SessionStart validation (GH-310):** `sessionHook.js` runs on every session start — checks for unknown prefixed keys with Levenshtein-2 typo suggestions (fuzzy path restricted to file-sourced values; exact-prefix scan covers process env), and per-type value checks (`bool01`, `boolean`, `enum`, `number`, `json`). Warnings only, fail-open, exit 0 always.
- **New-variable detection (GH-70):** `detect.js` stores a sha256 schema hash per project+plugin in `.claude/.cache/envconfig.json`; O(1) fast path when hashes match. On drift or first run, a nudge lists missing non-advanced vars and points at the configure skill. Only a configure pass (via `markConfigured`) silences the nudge — the hook never self-acknowledges.
- **Update-check SessionStart hook (GH-314):** `plugins/work/hooks/update-check.js` is cache-only on the hook path; a detached background `--refresh` child queries npm (with raw-git fallback) at most once per 24 h. Hook exits immediately (offline-silent, non-blocking); banner appears on the next session when a newer version is cached.
- **/work-workflow:configure skill and per-plugin variants** (`/heimdall:configure`, `/synapsys:configure`, `/maestro:configure`): fully interactive setup via AskUserQuestion — gh account selection with a fail-loud GH_TOKEN block (never exports an empty token), git identity (git-config defaults or custom literals), per-section var prompts batched by section, and target selection (`.envrc` / repo `.env` / global env file). Renders a complete `.envrc` for all four plugins or safely merges into an existing one (timestamped backup; full regenerate requires explicit opt-in).
- All four plugins register a fail-open `SessionStart` `config-detect` hook; thin `config-cli.js` wrappers delegate plan/write/validate/detect commands to the shared CLI.
- 43 new `node:test` cases cover schema shape validation, env-file parsing (layering, dynamic detection, findUp), value validation, detection cache lifecycle, rendering and merging, update-check (semver, TTL, npm+git fallback, offline), CLI round-trip, and hook spawn tests; full suite 6969 pass; `pnpm quality` clean.

## Reviewer Notes

- maestro unprefixed conductor tunables (SILENCE_LIMIT_SEC etc.) are deliberately not schema-declared to avoid generic-name collisions.
- ENABLE_DRAFT_PR / ENABLE_EMPTY_COMMIT are declared as advanced bootstrap-script conventions.
- WORK_TDD_ENFORCE is recognized as internal (legacy, unread by plugin code).

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

### Session hook validation

1. From any project directory with no `.envrc`, open a new Claude session. The config-detect hook should print a nudge listing unconfigured vars and pointing at `/work-workflow:configure`.
2. Add a `.envrc` with a deliberate typo (e.g. `export REPO_NAEM=my-repo`) and start a new session. The hook should warn: `unknown config var REPO_NAEM — did you mean REPO_NAME?`
3. Add an invalid value (e.g. `export WORK_ENABLE_DRAFT_PR=yes`) and start a session. The hook should warn: `WORK_ENABLE_DRAFT_PR=yes is invalid — expected 0 or 1`.
4. Run `/work-workflow:configure`, follow the prompts, confirm a `.envrc` is written/merged with a timestamped backup; run `direnv allow` and verify a clean new session produces no config nudges.

### Update-check hook

5. Seed a fabricated newer version into the update cache and start a new session — confirm the banner `work-workflow v999.0.0 available (current: vX.Y.Z)` appears.
6. Confirm offline-silent behavior: run the hook with an empty HOME — should exit 0 with no output.

### CLI round-trip

7. `node factories/envConfig/cli.js plan --plugin-root plugins/work --cwd "$PWD"` — returns JSON with `plugins: ["work-workflow"]` and `vars[]` listing all declared schema vars with current values and sources.
8. `node factories/envConfig/cli.js validate --plugin-root plugins/work --cwd "$PWD"` — prints active warnings or exits cleanly (exit 0 always).

### Test Results

Full suite: **6969 pass** (43 new cases across `factories/envConfig/__tests__/`).

Run with: `pnpm test`

Closes #70
Closes #310
Closes #314

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hooks run on every session and the configure path writes user `.envrc`/`.env` and cache files, but behavior is warning-only/fail-open with broad test coverage; GH_TOKEN is resolved at direnv time, not stored in answers.
> 
> **Overview**
> Introduces **`factories/envConfig`**, a shared engine so plugins declare env vars once in **`config-schema.json`** and get validation, drift detection, rendering, and configure CLI behavior without duplicating logic.
> 
> **SessionStart (fail-open):** Each plugin adds **`config-detect.js`**, which nudges on first run or schema drift (hash cache under `~/.claude/.cache/envconfig.json`), warns on prefixed typos and invalid types, and can suggest repo **scan** / **agentFill** vars. **work** also adds **`update-check.js`** — cache-only banner with detached npm/git refresh.
> 
> **Configure flow:** **`plan` / `write` / `validate` / `detect`** CLI backs **`/…:configure`** skills (per-plugin plus **`/work-workflow:configure`** with `--all`), including GH account–pinned **`GH_TOKEN`** blocks, git identity, merge-or-regenerate **`.envrc`**, and detection-cache acknowledgment on write.
> 
> **Schemas shipped** for heimdall, maestro, synapsys, and work-workflow (large work schema with ticket paths, test commands, **`READ_DOCS_ON_*`** scan blocks). **43** new **`node:test`** cases cover the factory and hook spawn behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d275fc94c9d8c2bf93730890e13806a32b46a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->