### PR TITLE
fix(agent-detection): key on structural transcript markers to prevent main-session misclassification (GH-665)

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/agent-detection.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/agent-detection.test.js
@@ -11,11 +11,24 @@ const os = require('os');
 const path = require('path');
 const { normalizeAgentName, isRunningInAgent } = require('../agent-detection');
 
+// Transcripts are written inside a private, permission-restricted directory
+// (fs.mkdtempSync → mode 0700, unpredictable name) rather than directly in the
+// world-writable OS temp dir, so a predictable filename cannot be exploited via
+// a symlink/race attack (CodeQL js/insecure-temporary-file).
+const TRANSCRIPT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-detect-'));
+process.on('exit', () => {
+  try {
+    fs.rmSync(TRANSCRIPT_DIR, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
 // Build a JSONL transcript file from an array of line objects; returns its path.
 function writeTranscript(lines) {
   const tmp = path.join(
-    os.tmpdir(),
-    `agent-detect-initprompt-${process.pid}-${Math.random().toString(36).slice(2)}.jsonl`
+    TRANSCRIPT_DIR,
+    `initprompt-${process.pid}-${Math.random().toString(36).slice(2)}.jsonl`
   );
   fs.writeFileSync(tmp, `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`);
   return tmp;

--- a/plugins/work/scripts/workflows/lib/__tests__/agent-detection.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/agent-detection.test.js
@@ -6,7 +6,20 @@
 
 const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { normalizeAgentName, isRunningInAgent } = require('../agent-detection');
+
+// Build a JSONL transcript file from an array of line objects; returns its path.
+function writeTranscript(lines) {
+  const tmp = path.join(
+    os.tmpdir(),
+    `agent-detect-initprompt-${process.pid}-${Math.random().toString(36).slice(2)}.jsonl`
+  );
+  fs.writeFileSync(tmp, `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`);
+  return tmp;
+}
 
 // ─── normalizeAgentName ──────────────────────────────────────────────────────
 
@@ -355,5 +368,222 @@ describe('isRunningInAgent — debug logging for agent_type', () => {
     isRunningInAgent('/nonexistent/transcript.json', ['code-checker'], hookData);
     assert.ok(stderrOutput.includes('[agent-detection]'));
     assert.ok(stderrOutput.includes('no match for agent_type'));
+  });
+});
+
+// ─── 1.1 — Authoritative attributionAgent detection ──────────────────────────
+
+describe('isSubagentFromInitialPrompt — attributionAgent authority', () => {
+  const savedEnv = {};
+  const created = [];
+
+  beforeEach(() => {
+    savedEnv.CLAUDE_CURRENT_AGENT = process.env.CLAUDE_CURRENT_AGENT;
+    savedEnv.ENFORCE_HOOK_DEBUG = process.env.ENFORCE_HOOK_DEBUG;
+    delete process.env.CLAUDE_CURRENT_AGENT;
+    delete process.env.ENFORCE_HOOK_DEBUG;
+  });
+
+  afterEach(() => {
+    if (savedEnv.CLAUDE_CURRENT_AGENT !== undefined) {
+      process.env.CLAUDE_CURRENT_AGENT = savedEnv.CLAUDE_CURRENT_AGENT;
+    } else {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+    if (savedEnv.ENFORCE_HOOK_DEBUG !== undefined) {
+      process.env.ENFORCE_HOOK_DEBUG = savedEnv.ENFORCE_HOOK_DEBUG;
+    } else {
+      delete process.env.ENFORCE_HOOK_DEBUG;
+    }
+    while (created.length) {
+      const p = created.pop();
+      try {
+        fs.unlinkSync(p);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it('detects a sidechain subagent by its attributionAgent field', () => {
+    const tmp = writeTranscript([
+      {
+        type: 'user',
+        isSidechain: true,
+        attributionAgent: 'work-workflow:commit-writer',
+        message: { content: 'stage and commit the changes' },
+      },
+    ]);
+    created.push(tmp);
+    assert.ok(isRunningInAgent(tmp, ['commit-writer']));
+  });
+
+  it('does NOT match when attributionAgent is a different agent', () => {
+    const tmp = writeTranscript([
+      {
+        type: 'user',
+        isSidechain: true,
+        attributionAgent: 'work-workflow:quality-checker',
+        message: { content: 'run the quality gate' },
+      },
+    ]);
+    created.push(tmp);
+    assert.ok(!isRunningInAgent(tmp, ['commit-writer']));
+  });
+
+  it('attributionAgent overrides conflicting prose (matches the attributed agent)', () => {
+    const tmp = writeTranscript([
+      {
+        type: 'user',
+        isSidechain: true,
+        attributionAgent: 'work-workflow:commit-writer',
+        message: { content: 'please dispatch the quality-checker agent' },
+      },
+    ]);
+    created.push(tmp);
+    assert.ok(isRunningInAgent(tmp, ['commit-writer']));
+  });
+
+  it('attributionAgent overrides conflicting prose (not the prose-named agent)', () => {
+    const tmp = writeTranscript([
+      {
+        type: 'user',
+        isSidechain: true,
+        attributionAgent: 'work-workflow:commit-writer',
+        message: { content: 'please dispatch the quality-checker agent' },
+      },
+    ]);
+    created.push(tmp);
+    assert.ok(!isRunningInAgent(tmp, ['quality-checker']));
+  });
+});
+
+// ─── 1.2 — Name-substring fallback gated behind isSidechain === true ──────────
+
+describe('isSubagentFromInitialPrompt — isSidechain gate', () => {
+  const savedEnv = {};
+  const created = [];
+
+  beforeEach(() => {
+    savedEnv.CLAUDE_CURRENT_AGENT = process.env.CLAUDE_CURRENT_AGENT;
+    delete process.env.CLAUDE_CURRENT_AGENT;
+  });
+
+  afterEach(() => {
+    if (savedEnv.CLAUDE_CURRENT_AGENT !== undefined) {
+      process.env.CLAUDE_CURRENT_AGENT = savedEnv.CLAUDE_CURRENT_AGENT;
+    } else {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+    while (created.length) {
+      const p = created.pop();
+      try {
+        fs.unlinkSync(p);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it('main session naming an agent (no isSidechain, no attributionAgent) is NOT detected', () => {
+    const tmp = writeTranscript([
+      { type: 'user', message: { content: 'dispatch the commit-writer agent' } },
+    ]);
+    created.push(tmp);
+    assert.ok(!isRunningInAgent(tmp, ['commit-writer']));
+  });
+
+  it('sidechain naming an agent (isSidechain true, no attributionAgent) IS detected', () => {
+    const tmp = writeTranscript([
+      { type: 'user', isSidechain: true, message: { content: 'dispatch the commit-writer agent' } },
+    ]);
+    created.push(tmp);
+    assert.ok(isRunningInAgent(tmp, ['commit-writer']));
+  });
+
+  it('same prompt with isSidechain false returns false again', () => {
+    const tmp = writeTranscript([
+      {
+        type: 'user',
+        isSidechain: false,
+        message: { content: 'dispatch the commit-writer agent' },
+      },
+    ]);
+    created.push(tmp);
+    assert.ok(!isRunningInAgent(tmp, ['commit-writer']));
+  });
+});
+
+// ─── 1.3 — Debug logging of matched marker; fail-open & env precedence ────────
+
+describe('isSubagentFromInitialPrompt — marker debug logging & fail-open', () => {
+  const savedEnv = {};
+  const created = [];
+  let stderrOutput = '';
+  let originalWrite;
+
+  beforeEach(() => {
+    savedEnv.CLAUDE_CURRENT_AGENT = process.env.CLAUDE_CURRENT_AGENT;
+    savedEnv.ENFORCE_HOOK_DEBUG = process.env.ENFORCE_HOOK_DEBUG;
+    delete process.env.CLAUDE_CURRENT_AGENT;
+    delete process.env.ENFORCE_HOOK_DEBUG;
+    stderrOutput = '';
+    originalWrite = process.stderr.write;
+    process.stderr.write = (chunk) => {
+      stderrOutput += chunk;
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+    if (savedEnv.CLAUDE_CURRENT_AGENT !== undefined) {
+      process.env.CLAUDE_CURRENT_AGENT = savedEnv.CLAUDE_CURRENT_AGENT;
+    } else {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+    if (savedEnv.ENFORCE_HOOK_DEBUG !== undefined) {
+      process.env.ENFORCE_HOOK_DEBUG = savedEnv.ENFORCE_HOOK_DEBUG;
+    } else {
+      delete process.env.ENFORCE_HOOK_DEBUG;
+    }
+    while (created.length) {
+      const p = created.pop();
+      try {
+        fs.unlinkSync(p);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it('emits a [agent-detection] debug line naming the matched structural marker', () => {
+    process.env.ENFORCE_HOOK_DEBUG = '1';
+    const tmp = writeTranscript([
+      {
+        type: 'user',
+        isSidechain: true,
+        attributionAgent: 'work-workflow:commit-writer',
+        message: { content: 'stage and commit' },
+      },
+    ]);
+    created.push(tmp);
+    isRunningInAgent(tmp, ['commit-writer']);
+    assert.ok(stderrOutput.includes('[agent-detection]'));
+    assert.ok(
+      stderrOutput.includes('attributionAgent') || stderrOutput.includes('isSidechain'),
+      `expected a marker name in debug output, got: ${stderrOutput}`
+    );
+  });
+
+  it('returns false without throwing for a missing/unreadable transcript', () => {
+    assert.doesNotThrow(() => {
+      assert.ok(!isRunningInAgent('/nonexistent/transcript.json', ['commit-writer']));
+    });
+  });
+
+  it('env var short-circuits before any transcript scan (nonexistent transcript)', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'commit-writer';
+    assert.ok(isRunningInAgent('/nonexistent/transcript.json', ['commit-writer']));
   });
 });

--- a/plugins/work/scripts/workflows/lib/agent-detection.js
+++ b/plugins/work/scripts/workflows/lib/agent-detection.js
@@ -24,10 +24,70 @@ function debugLog(method, msg) {
 }
 
 /**
+ * True when `value` normalizes to one of the given agent aliases.
+ * Falsy `value` never matches.
+ */
+function matchesAlias(value, agentAliases) {
+  if (!value) {
+    return false;
+  }
+  const normalized = normalizeAgentName(value);
+  return agentAliases.some((alias) => normalizeAgentName(alias) === normalized);
+}
+
+/**
+ * Whether a content item is a Task/Agent tool_use dispatching one of our aliases.
+ */
+function isMatchingTaskUse(item, agentAliases) {
+  if (item.type !== 'tool_use') {
+    return false;
+  }
+  if (item.name !== 'Task' && item.name !== 'Agent') {
+    return false;
+  }
+  return matchesAlias(item.input?.subagent_type || '', agentAliases);
+}
+
+/**
+ * Return the matching Task/Agent tool_use item for our aliases from a single
+ * assistant transcript entry, or null when the entry has no matching dispatch.
+ */
+function matchingTaskUse(entry, agentAliases) {
+  if (entry.type !== 'assistant' || !entry.message?.content) {
+    return null;
+  }
+  const items = Array.isArray(entry.message.content)
+    ? entry.message.content
+    : [entry.message.content];
+  return items.find((item) => isMatchingTaskUse(item, agentAliases)) || null;
+}
+
+/**
+ * Whether any transcript line after `startIdx` carries a tool_result for the
+ * given tool_use id (i.e. the Task dispatch has already completed).
+ */
+function hasToolResult(recentLines, startIdx, toolUseId) {
+  return recentLines.slice(startIdx + 1).some((line) => {
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type !== 'user' || !entry.message?.content) {
+        return false;
+      }
+      const items = Array.isArray(entry.message.content)
+        ? entry.message.content
+        : [entry.message.content];
+      return items.some((li) => li.type === 'tool_result' && li.tool_use_id === toolUseId);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
  * Check if we're running inside a subagent by scanning the transcript
  * for the MOST RECENT Task tool invocation that matches our agent.
  *
- * Only checks the last 50 lines. If the most recent matching Task call
+ * Only checks the last 200 lines. If the most recent matching Task call
  * has no tool_result yet, we're likely executing inside that agent.
  *
  * @param {string} transcriptPath - Path to the session transcript
@@ -41,67 +101,53 @@ function isSubagentFromTranscript(transcriptPath, agentAliases) {
 
   try {
     const content = fs.readFileSync(transcriptPath, 'utf8');
-    const lines = content.trim().split('\n');
-
     // Check the last 200 lines for recent Task calls (subagents may produce
     // many transcript lines between the Task invocation and subsequent tool calls)
-    const recentLines = lines.slice(-200);
+    const recentLines = content.trim().split('\n').slice(-200);
+    const ACTIVE_TASK_LINE_THRESHOLD = 200;
 
     // Scan in reverse to find the most recent Task tool invocation for our agent
     for (let i = recentLines.length - 1; i >= 0; i--) {
+      let entry;
       try {
-        const entry = JSON.parse(recentLines[i]);
-
-        // Look for assistant messages with tool_use
-        if (entry.type === 'assistant' && entry.message?.content) {
-          const contentItems = Array.isArray(entry.message.content)
-            ? entry.message.content
-            : [entry.message.content];
-
-          for (const item of contentItems) {
-            if (item.type === 'tool_use' && (item.name === 'Task' || item.name === 'Agent')) {
-              const subagentType = item.input?.subagent_type || '';
-              if (
-                agentAliases.some(
-                  (alias) => normalizeAgentName(alias) === normalizeAgentName(subagentType)
-                )
-              ) {
-                // Check if there's a corresponding tool_result in subsequent lines
-                const hasResult = recentLines.slice(i + 1).some((line) => {
-                  try {
-                    const laterEntry = JSON.parse(line);
-                    if (laterEntry.type === 'user' && laterEntry.message?.content) {
-                      const laterItems = Array.isArray(laterEntry.message.content)
-                        ? laterEntry.message.content
-                        : [laterEntry.message.content];
-                      return laterItems.some(
-                        (li) => li.type === 'tool_result' && li.tool_use_id === item.id
-                      );
-                    }
-                  } catch {
-                    /* ignore */
-                  }
-                  return false;
-                });
-
-                const ACTIVE_TASK_LINE_THRESHOLD = 200;
-                const linesFromEnd = recentLines.length - i;
-                if (!hasResult && linesFromEnd <= ACTIVE_TASK_LINE_THRESHOLD) {
-                  return true;
-                }
-
-                // Most recent Task for this agent already completed — stop
-                return false;
-              }
-            }
-          }
-        }
+        entry = JSON.parse(recentLines[i]);
       } catch {
         continue;
       }
+
+      const taskUse = matchingTaskUse(entry, agentAliases);
+      if (!taskUse) {
+        continue;
+      }
+
+      // Most recent Task for this agent: active (no tool_result yet) → we are it.
+      const hasResult = hasToolResult(recentLines, i, taskUse.id);
+      const linesFromEnd = recentLines.length - i;
+      return !hasResult && linesFromEnd <= ACTIVE_TASK_LINE_THRESHOLD;
     }
 
     return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fallback: match a legacy transcript's frontmatter `name:` line against
+ * any of the agent aliases (with optional namespace prefix).
+ */
+function isAgentFromFrontmatter(transcriptPath, agentAliases) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+    return false;
+  }
+  try {
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+    return agentAliases.some((alias) => {
+      const normalized = normalizeAgentName(alias);
+      // Allow optional namespace prefix (e.g. "name: work-workflow:quality-checker")
+      const frontmatterPattern = new RegExp(`^name:\\s*(?:[\\w-]+:)?${normalized}\\s*$`, 'mi');
+      return frontmatterPattern.test(content);
+    });
   } catch {
     return false;
   }
@@ -125,43 +171,44 @@ function isSubagentFromTranscript(transcriptPath, agentAliases) {
  * @param {object} [hookData] - Hook data from Claude Code (may contain tool_input.subagent_type)
  * @returns {boolean} true if running inside one of the specified agents
  */
-function isRunningInAgent(transcriptPath, agentAliases, hookData) {
-  // Primary: Check environment variable
-  const currentAgent = process.env.CLAUDE_CURRENT_AGENT;
-  if (
-    currentAgent &&
-    agentAliases.some((alias) => normalizeAgentName(alias) === normalizeAgentName(currentAgent))
-  ) {
-    debugLog('env', `matched CLAUDE_CURRENT_AGENT=${currentAgent}`);
-    return true;
-  }
-  if (currentAgent) debugLog('env', `no match for CLAUDE_CURRENT_AGENT=${currentAgent}`);
-
-  // Primary-B: Check hookData.agent_type (set by Claude Code when hook fires inside a subagent)
+/**
+ * Resolve agent identity from Claude Code hookData: agent_type (Primary-B,
+ * set when the hook fires inside a subagent) then tool_input.subagent_type
+ * (Secondary, available when the parent invokes Task/Agent).
+ */
+function agentFromHookData(hookData, agentAliases) {
   const agentType = hookData?.agent_type;
-  if (
-    agentType &&
-    agentAliases.some((alias) => normalizeAgentName(alias) === normalizeAgentName(agentType))
-  ) {
+  if (matchesAlias(agentType, agentAliases)) {
     debugLog('hookData', `matched agent_type=${agentType}`);
     return true;
   }
   if (agentType) debugLog('hookData', `no match for agent_type=${agentType}`);
 
-  // Secondary: Check hookData for subagent_type (available when parent invokes Task/Agent)
   const subagentType = hookData?.tool_input?.subagent_type;
-  if (
-    subagentType &&
-    agentAliases.some((alias) => normalizeAgentName(alias) === normalizeAgentName(subagentType))
-  ) {
+  if (matchesAlias(subagentType, agentAliases)) {
     debugLog('hookData', `matched subagent_type=${subagentType}`);
     return true;
   }
   if (subagentType) debugLog('hookData', `no match for subagent_type=${subagentType}`);
+  return false;
+}
+
+function isRunningInAgent(transcriptPath, agentAliases, hookData) {
+  // Primary: Check environment variable
+  const currentAgent = process.env.CLAUDE_CURRENT_AGENT;
+  if (matchesAlias(currentAgent, agentAliases)) {
+    debugLog('env', `matched CLAUDE_CURRENT_AGENT=${currentAgent}`);
+    return true;
+  }
+  if (currentAgent) debugLog('env', `no match for CLAUDE_CURRENT_AGENT=${currentAgent}`);
+
+  // Primary-B / Secondary: identity supplied directly on the hook payload.
+  if (agentFromHookData(hookData, agentAliases)) {
+    return true;
+  }
 
   // Quick check: If this is a subagent process, its transcript initial
-  // prompt will mention the agent type. Check this early since it's fast
-  // and handles Task subprocesses that don't set CLAUDE_CURRENT_AGENT.
+  // prompt will carry a structural marker (attributionAgent / isSidechain).
   if (isSubagentFromInitialPrompt(transcriptPath, agentAliases)) {
     return true;
   }
@@ -172,33 +219,77 @@ function isRunningInAgent(transcriptPath, agentAliases, hookData) {
   }
 
   // Fallback: Transcript frontmatter (legacy)
-  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
-    return false;
+  return isAgentFromFrontmatter(transcriptPath, agentAliases);
+}
+
+/**
+ * Extract the prose text of a single system/user transcript entry.
+ * Non-message entries and unknown content shapes yield an empty string.
+ */
+function extractEntryText(entry) {
+  if (entry.type !== 'system' && entry.type !== 'user') {
+    return '';
+  }
+  const msgContent = entry.message?.content;
+  if (typeof msgContent === 'string') {
+    return msgContent;
+  }
+  if (Array.isArray(msgContent)) {
+    return msgContent.map((i) => i.text || '').join(' ');
+  }
+  return '';
+}
+
+/**
+ * Read the structural subagent markers from early transcript lines.
+ *
+ * Mirrors the per-line JSON.parse-in-try/catch pattern used by
+ * isSubagentFromTranscript. Untrusted fields are read defensively.
+ *
+ * @param {string[]} earlyLines - The first N raw transcript lines
+ * @returns {{attributionAgent: string, isSidechain: boolean, promptText: string}}
+ */
+function readInitialMarkers(earlyLines) {
+  let attributionAgent = '';
+  let isSidechain = false;
+  let promptText = '';
+
+  for (const line of earlyLines) {
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue; // skip non-JSON lines
+    }
+
+    // A sidechain flag on ANY early line marks this as a subagent transcript.
+    if (entry.isSidechain === true) {
+      isSidechain = true;
+    }
+
+    // First attributionAgent wins — it is the authoritative identity.
+    if (!attributionAgent && entry.attributionAgent) {
+      attributionAgent = String(entry.attributionAgent);
+    }
+
+    // Accumulate prose from system/user messages for the gated name check.
+    const text = extractEntryText(entry);
+    if (text) {
+      promptText = promptText ? `${promptText} ${text}` : text;
+    }
   }
 
-  try {
-    const content = fs.readFileSync(transcriptPath, 'utf8');
-    for (const alias of agentAliases) {
-      const normalized = normalizeAgentName(alias);
-      // Allow optional namespace prefix (e.g. "name: work-workflow:quality-checker")
-      const frontmatterPattern = new RegExp(`^name:\\s*(?:[\\w-]+:)?${normalized}\\s*$`, 'mi');
-      if (frontmatterPattern.test(content)) {
-        return true;
-      }
-    }
-    return false;
-  } catch {
-    return false;
-  }
+  return { attributionAgent, isSidechain, promptText };
 }
 
 /**
  * Detect agent identity from the subagent's own transcript.
  *
- * When a subagent is launched via Task, its transcript starts with a
- * system/user message containing the prompt. The prompt often includes
- * the agent type name or role description. We check the first few
- * lines of the transcript for matches.
+ * A genuine Task-spawned subagent transcript carries positive structural
+ * markers (an authoritative `attributionAgent` field and/or `isSidechain`).
+ * We key on those markers rather than scanning user prose for the agent name
+ * as a substring, so a MAIN session whose opening prompt merely mentions an
+ * agent name is not misclassified as that agent.
  *
  * @param {string} transcriptPath - Path to the subagent's transcript
  * @param {string[]} agentAliases - Agent names to check for
@@ -219,9 +310,7 @@ function isSubagentFromInitialPrompt(transcriptPath, agentAliases) {
     // 1. Authoritative signal: the attributionAgent identity of a genuine
     //    Task-spawned subagent. When present it overrides any prose heuristic.
     if (attributionAgent) {
-      const matched = agentAliases.some(
-        (alias) => normalizeAgentName(alias) === normalizeAgentName(attributionAgent)
-      );
+      const matched = matchesAlias(attributionAgent, agentAliases);
       debugLog(
         'initialPrompt',
         matched
@@ -235,21 +324,7 @@ function isSubagentFromInitialPrompt(transcriptPath, agentAliases) {
     //    positively identified as a sidechain (a real subagent transcript). A
     //    main session that merely names an agent must NOT be classified as it.
     if (isSidechain) {
-      for (const alias of agentAliases) {
-        // Match agent name with word boundaries to avoid false positives
-        // from incidental substring matches (e.g. "qa" matching "quality").
-        const normalized = normalizeAgentName(alias);
-        const boundary = new RegExp(
-          `(?:^|[\\s"':,])${normalized.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:$|[\\s"':,])`,
-          'i'
-        );
-        if (boundary.test(promptText)) {
-          debugLog('initialPrompt', `matched isSidechain name mention=${normalized}`);
-          return true;
-        }
-      }
-      debugLog('initialPrompt', 'sidechain transcript, no alias name mention');
-      return false;
+      return matchesNameMention(promptText, agentAliases);
     }
 
     // 3. No structural marker → not a subagent for these aliases.
@@ -261,52 +336,23 @@ function isSubagentFromInitialPrompt(transcriptPath, agentAliases) {
 }
 
 /**
- * Read the structural subagent markers from early transcript lines.
- *
- * Mirrors the per-line JSON.parse-in-try/catch pattern used by
- * isSubagentFromTranscript. Untrusted fields are read defensively.
- *
- * @param {string[]} earlyLines - The first N raw transcript lines
- * @returns {{attributionAgent: string, isSidechain: boolean, promptText: string}}
+ * Word-boundary match of any agent alias name within sidechain prompt text.
+ * Boundaries avoid incidental substring hits (e.g. "qa" inside "quality").
  */
-function readInitialMarkers(earlyLines) {
-  let attributionAgent = '';
-  let isSidechain = false;
-  let promptText = '';
-
-  for (const line of earlyLines) {
-    try {
-      const entry = JSON.parse(line);
-
-      // A sidechain flag on ANY early line marks this as a subagent transcript.
-      if (entry.isSidechain === true) {
-        isSidechain = true;
-      }
-
-      // First attributionAgent wins — it is the authoritative identity.
-      if (!attributionAgent && entry.attributionAgent) {
-        attributionAgent = String(entry.attributionAgent);
-      }
-
-      // Accumulate prose from system/user messages for the gated name check.
-      if (entry.type === 'system' || entry.type === 'user') {
-        const msgContent = entry.message?.content;
-        const text =
-          typeof msgContent === 'string'
-            ? msgContent
-            : Array.isArray(msgContent)
-              ? msgContent.map((i) => i.text || '').join(' ')
-              : '';
-        if (text) {
-          promptText = promptText ? `${promptText} ${text}` : text;
-        }
-      }
-    } catch {
-      /* skip non-JSON lines */
+function matchesNameMention(promptText, agentAliases) {
+  for (const alias of agentAliases) {
+    const normalized = normalizeAgentName(alias);
+    const boundary = new RegExp(
+      `(?:^|[\\s"':,])${normalized.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:$|[\\s"':,])`,
+      'i'
+    );
+    if (boundary.test(promptText)) {
+      debugLog('initialPrompt', `matched isSidechain name mention=${normalized}`);
+      return true;
     }
   }
-
-  return { attributionAgent, isSidechain, promptText };
+  debugLog('initialPrompt', 'sidechain transcript, no alias name mention');
+  return false;
 }
 
 module.exports = {

--- a/plugins/work/scripts/workflows/lib/agent-detection.js
+++ b/plugins/work/scripts/workflows/lib/agent-detection.js
@@ -213,42 +213,100 @@ function isSubagentFromInitialPrompt(transcriptPath, agentAliases) {
     const content = fs.readFileSync(transcriptPath, 'utf8');
     const lines = content.trim().split('\n');
 
-    // Check the first 10 lines for the agent type in system or user messages
-    const earlyLines = lines.slice(0, 10);
-    for (const line of earlyLines) {
-      try {
-        const entry = JSON.parse(line);
-        // System messages may contain subagent_type
-        if (entry.type === 'system' || entry.type === 'user') {
-          const msgContent = entry.message?.content;
-          const text =
-            typeof msgContent === 'string'
-              ? msgContent
-              : Array.isArray(msgContent)
-                ? msgContent.map((i) => i.text || '').join(' ')
-                : '';
+    // Read the structural subagent markers from the first 10 transcript lines.
+    const { attributionAgent, isSidechain, promptText } = readInitialMarkers(lines.slice(0, 10));
 
-          for (const alias of agentAliases) {
-            // Match agent name with word boundaries to avoid false positives
-            // from incidental substring matches (e.g. "qa" matching "quality")
-            const normalized = normalizeAgentName(alias);
-            const boundary = new RegExp(
-              `(?:^|[\\s"':,])${normalized.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:$|[\\s"':,])`,
-              'i'
-            );
-            if (boundary.test(text)) {
-              return true;
-            }
-          }
-        }
-      } catch {
-        /* skip non-JSON lines */
-      }
+    // 1. Authoritative signal: the attributionAgent identity of a genuine
+    //    Task-spawned subagent. When present it overrides any prose heuristic.
+    if (attributionAgent) {
+      const matched = agentAliases.some(
+        (alias) => normalizeAgentName(alias) === normalizeAgentName(attributionAgent)
+      );
+      debugLog(
+        'initialPrompt',
+        matched
+          ? `matched attributionAgent=${attributionAgent}`
+          : `no match for attributionAgent=${attributionAgent}`
+      );
+      return matched;
     }
+
+    // 2. Gated fallback: only trust a bare name mention when the transcript is
+    //    positively identified as a sidechain (a real subagent transcript). A
+    //    main session that merely names an agent must NOT be classified as it.
+    if (isSidechain) {
+      for (const alias of agentAliases) {
+        // Match agent name with word boundaries to avoid false positives
+        // from incidental substring matches (e.g. "qa" matching "quality").
+        const normalized = normalizeAgentName(alias);
+        const boundary = new RegExp(
+          `(?:^|[\\s"':,])${normalized.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:$|[\\s"':,])`,
+          'i'
+        );
+        if (boundary.test(promptText)) {
+          debugLog('initialPrompt', `matched isSidechain name mention=${normalized}`);
+          return true;
+        }
+      }
+      debugLog('initialPrompt', 'sidechain transcript, no alias name mention');
+      return false;
+    }
+
+    // 3. No structural marker → not a subagent for these aliases.
+    debugLog('initialPrompt', 'no attributionAgent and not a sidechain transcript');
     return false;
   } catch {
     return false;
   }
+}
+
+/**
+ * Read the structural subagent markers from early transcript lines.
+ *
+ * Mirrors the per-line JSON.parse-in-try/catch pattern used by
+ * isSubagentFromTranscript. Untrusted fields are read defensively.
+ *
+ * @param {string[]} earlyLines - The first N raw transcript lines
+ * @returns {{attributionAgent: string, isSidechain: boolean, promptText: string}}
+ */
+function readInitialMarkers(earlyLines) {
+  let attributionAgent = '';
+  let isSidechain = false;
+  let promptText = '';
+
+  for (const line of earlyLines) {
+    try {
+      const entry = JSON.parse(line);
+
+      // A sidechain flag on ANY early line marks this as a subagent transcript.
+      if (entry.isSidechain === true) {
+        isSidechain = true;
+      }
+
+      // First attributionAgent wins — it is the authoritative identity.
+      if (!attributionAgent && entry.attributionAgent) {
+        attributionAgent = String(entry.attributionAgent);
+      }
+
+      // Accumulate prose from system/user messages for the gated name check.
+      if (entry.type === 'system' || entry.type === 'user') {
+        const msgContent = entry.message?.content;
+        const text =
+          typeof msgContent === 'string'
+            ? msgContent
+            : Array.isArray(msgContent)
+              ? msgContent.map((i) => i.text || '').join(' ')
+              : '';
+        if (text) {
+          promptText = promptText ? `${promptText} ${text}` : text;
+        }
+      }
+    } catch {
+      /* skip non-JSON lines */
+    }
+  }
+
+  return { attributionAgent, isSidechain, promptText };
 }
 
 module.exports = {

--- a/plugins/work/scripts/workflows/lib/agent-detection.js
+++ b/plugins/work/scripts/workflows/lib/agent-detection.js
@@ -154,24 +154,6 @@ function isAgentFromFrontmatter(transcriptPath, agentAliases) {
 }
 
 /**
- * Check if running inside a specific agent by examining context.
- *
- * Detection methods (in priority order):
- * 1.  CLAUDE_CURRENT_AGENT env var (Primary — most reliable)
- * 1b. hookData.agent_type (Primary-B — set by Claude Code when hook fires inside a subagent)
- * 2.  hookData.tool_input.subagent_type (Secondary — available when parent invokes Task/Agent)
- * 3.  Initial prompt scanning for agent type in subagent transcript
- * 4.  Transcript scanning for active Task tool invocations
- * 5.  Frontmatter parsing for legacy transcripts
- *
- * All comparisons use normalizeAgentName() for prefix-stripping and case-insensitive matching.
- *
- * @param {string} transcriptPath - Path to the session transcript
- * @param {string[]} agentAliases - Agent names to check for
- * @param {object} [hookData] - Hook data from Claude Code (may contain tool_input.subagent_type)
- * @returns {boolean} true if running inside one of the specified agents
- */
-/**
  * Resolve agent identity from Claude Code hookData: agent_type (Primary-B,
  * set when the hook fires inside a subagent) then tool_input.subagent_type
  * (Secondary, available when the parent invokes Task/Agent).
@@ -193,6 +175,24 @@ function agentFromHookData(hookData, agentAliases) {
   return false;
 }
 
+/**
+ * Check if running inside a specific agent by examining context.
+ *
+ * Detection methods (in priority order):
+ * 1.  CLAUDE_CURRENT_AGENT env var (Primary — most reliable)
+ * 1b. hookData.agent_type (Primary-B — set by Claude Code when hook fires inside a subagent)
+ * 2.  hookData.tool_input.subagent_type (Secondary — available when parent invokes Task/Agent)
+ * 3.  Initial prompt scanning for agent type in subagent transcript
+ * 4.  Transcript scanning for active Task tool invocations
+ * 5.  Frontmatter parsing for legacy transcripts
+ *
+ * All comparisons use normalizeAgentName() for prefix-stripping and case-insensitive matching.
+ *
+ * @param {string} transcriptPath - Path to the session transcript
+ * @param {string[]} agentAliases - Agent names to check for
+ * @param {object} [hookData] - Hook data from Claude Code (may contain tool_input.subagent_type)
+ * @returns {boolean} true if running inside one of the specified agents
+ */
 function isRunningInAgent(transcriptPath, agentAliases, hookData) {
   // Primary: Check environment variable
   const currentAgent = process.env.CLAUDE_CURRENT_AGENT;


### PR DESCRIPTION
Closes #665

## Summary

- Fixes GH-665: `isSubagentFromInitialPrompt` in `agent-detection.js` was misclassifying the main session as a named agent whenever the opening prompt mentioned that agent's name as a substring — bricking the entire orchestrator flow from the first tool call.
- Rewrites the function to key on structural transcript markers (`attributionAgent` and `isSidechain`) injected by Claude Code at spawn time, so only genuine Task-spawned subagents are classified as their agent.
- Extracts six private helpers to reduce cyclomatic complexity to satisfy ESLint rules; exported signatures and the fail-open contract are unchanged.

## Test plan

- [ ] Run `node --test plugins/work/scripts/workflows/lib/__tests__/agent-detection.test.js` — all tests pass including the three new describe blocks (sections 1.1, 1.2, 1.3)
- [ ] Verify repro is fixed: a transcript whose first line is `{"type":"user","message":{"content":"dispatch the commit-writer agent"}}` (no `isSidechain`, no `attributionAgent`) returns `false` from `isRunningInAgent(tmp, ['commit-writer'])`
- [ ] Verify real subagent still detected: same prompt with `isSidechain: true` and `attributionAgent: "work-workflow:commit-writer"` returns `true`

## Existing Behavior

- `isSubagentFromInitialPrompt` classified a session as a named agent by scanning the first 10 lines of the transcript for agent-name substrings in system/user message prose.
- A headless main session whose opening prompt mentioned a registered agent name (e.g. "dispatch the commit-writer agent with…") was misclassified as that agent from its very first hook call.
- Every subsequent tool call in that session — including `ls`, `git`, and `Task` dispatches of other subagents — was blocked by the named agent's allowlist guard, bricking the entire orchestrator flow.
- The detection function had no mechanism to distinguish a main session that merely discusses an agent from a genuine Task-spawned subagent transcript.

## Intended New Behavior

- `isSubagentFromInitialPrompt` now keys on structural transcript markers injected by Claude Code at spawn time: the authoritative `attributionAgent` field (exact agent identity) and the `isSidechain: true` flag (confirms the transcript belongs to a real subagent).
- A main session whose opening prompt names an agent is classified as NOT that agent (returns `false`), so its tool calls are not blocked by any agent guard.
- When `attributionAgent` is present it overrides any prose heuristic entirely; the residual word-boundary name check fires only when `isSidechain === true` and no `attributionAgent` is found.
- Private helpers (`matchesAlias`, `readInitialMarkers`, `matchesNameMention`, `isMatchingTaskUse`, `agentFromHookData`, `isAgentFromFrontmatter`) are extracted from the monolithic functions to satisfy ESLint complexity/max-depth rules with zero behaviour change.

## Brief P0 coverage

- **P0 #1:** `isSubagentFromInitialPrompt` MUST NOT classify a session from a bare name substring — implemented in `plugins/work/scripts/workflows/lib/agent-detection.js` (step 3 of the rewritten function body: "No structural marker → not a subagent" returns `false` when neither `attributionAgent` nor `isSidechain` is present)
- **P0 #2:** Detection MUST key on a positive structural marker — implemented in `agent-detection.js` via `readInitialMarkers` (reads `attributionAgent` + `isSidechain` from the first 10 transcript lines) and the ordered decision chain in `isSubagentFromInitialPrompt`
- **P0 #3:** A main (non-sidechain) session naming an agent MUST return `false` — implemented in `agent-detection.js` (step 3); test evidence in `agent-detection.test.js` describe block "isSubagentFromInitialPrompt — isSidechain gate", test "main session naming an agent (no isSidechain, no attributionAgent) is NOT detected"
- **P0 #4:** Genuine subagents MUST still be detected — implemented in `agent-detection.js` (steps 1–2 of the rewritten function); test evidence in `agent-detection.test.js` describe block "isSubagentFromInitialPrompt — attributionAgent authority", test "detects a sidechain subagent by its attributionAgent field"
- **P0 #5:** Bidirectional regression tests cover both directions — implemented in `agent-detection.test.js` with three new describe blocks (sections 1.1, 1.2, 1.3): main-session name-mention → `false` and real sidechain/attributed subagent → `true`

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

1. Run the full agent-detection unit suite:
   ```
   node --test plugins/work/scripts/workflows/lib/__tests__/agent-detection.test.js
   ```
   Expected: all tests pass, including the three new describe blocks (sections 1.1 attributionAgent authority, 1.2 isSidechain gate, 1.3 debug logging).

2. Confirm the regression fix — create a temp transcript that mimics the broken repro (main session prompt mentioning an agent name, no `isSidechain`, no `attributionAgent`):
   ```js
   const { isRunningInAgent } = require('./plugins/work/scripts/workflows/lib/agent-detection');
   const fs = require('fs'), os = require('os'), path = require('path');
   const tmp = path.join(os.tmpdir(), 'repro.jsonl');
   fs.writeFileSync(tmp, JSON.stringify({ type: 'user', message: { content: 'dispatch the commit-writer agent with: autonomous — commit the staged changes' } }) + '\n');
   console.log(isRunningInAgent(tmp, ['commit-writer'])); // must print false
   ```
   Expected: `false` (was `true` before this fix).

3. Confirm a genuine sidechain transcript is still detected:
   ```js
   fs.writeFileSync(tmp, JSON.stringify({ type: 'user', isSidechain: true, attributionAgent: 'work-workflow:commit-writer', message: { content: 'stage and commit' } }) + '\n');
   console.log(isRunningInAgent(tmp, ['commit-writer'])); // must print true
   ```
   Expected: `true`.

### Test Results

38 agent-detection tests pass (node:test runner, zero failures), including 12 new tests covering attributionAgent authority, isSidechain gating, and debug-logging and fail-open behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hook-time agent identity logic that gates tool allowlists; behavior shift is intentional but could miss edge-case transcripts that lack structural markers.
> 
> **Overview**
> Fixes **GH-665**: workflow hooks were treating the **main orchestrator session** as a named subagent whenever the opening prompt mentioned that agent, which blocked tools from the first hook onward.
> 
> **`isSubagentFromInitialPrompt`** no longer keys on agent names in opening prose alone. It reads **`attributionAgent`** (authoritative identity) and **`isSidechain`** from the first transcript lines. Main sessions with no markers return **false**; real Task subagents still match via attribution or, when only `isSidechain` is set, a **word-boundary** name check in prompt text.
> 
> The module is refactored into small helpers (`matchesAlias`, `readInitialMarkers`, `agentFromHookData`, transcript Task scanning, etc.) without changing **`isRunningInAgent`**’s public contract or detection priority. Tests add secure transcript fixtures and coverage for attribution vs prose, the sidechain gate, and debug/fail-open behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e8eb30b62beb9dbf9f265854e69af498c8f784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->