### PR TITLE
fix(kind-checks): app-source modules under scripts/ are not devops

### DIFF
--- a/plugins/work/scripts/workflows/work-spec/__tests__/kind-checks.test.js
+++ b/plugins/work/scripts/workflows/work-spec/__tests__/kind-checks.test.js
@@ -412,6 +412,42 @@ test('detectKinds derives devops from CI/deploy scope paths AND from Type: ci', 
   fs.rmSync(fixture2.root, { recursive: true, force: true });
 });
 
+test('isDevopsFile: app-source module under a scripts/ ancestor is NOT devops', () => {
+  // Regression: this repo's own source lives at plugins/work/scripts/workflows/lib/...,
+  // which matches both the `scripts/` devops heuristic and the `lib/` app-source
+  // heuristic. Before the fix that made kind_checks unresolvable (devops kind +
+  // app-source drift against the same files). App-source now wins over the
+  // generic scripts/ signal.
+  const pluginSource = 'plugins/work/scripts/workflows/lib/agent-detection.js';
+  assert.equal(specShared.isAppSourceFile(pluginSource), true, 'still app-source');
+  assert.equal(specShared.isDevopsFile(pluginSource), false, 'no longer devops');
+  // It carries no other domain signal, so it evidences no kind (not devops).
+  assert.deepEqual(specShared.classifyScopeEntry(pluginSource), []);
+
+  // Unambiguous infra signals still classify as devops even under a scripts/ tree
+  // or an app-source ancestor.
+  assert.equal(specShared.isDevopsFile('scripts/release.js'), true, 'plain script → devops');
+  assert.equal(specShared.isDevopsFile('.github/workflows/ci.yml'), true, '.github → devops');
+  assert.equal(specShared.isDevopsFile('lib/deploy/pipeline.yml'), true, 'yaml wins under lib/');
+  assert.equal(specShared.isDevopsFile('services/api/Dockerfile'), true, 'Dockerfile → devops');
+});
+
+test('detectKinds does not derive devops from an app-source file under scripts/', () => {
+  const { root, tasksDir } = makeTasksDir({
+    tasks: [
+      '# Tasks',
+      '## Task 1',
+      '### Type: tdd-code',
+      '### Files in scope',
+      '- `plugins/work/scripts/workflows/lib/agent-detection.js`',
+    ].join('\n'),
+  });
+  // The scope path evidences no domain kind (not devops), so kind_checks'
+  // devops handler never applies and cannot false-positive on app-source drift.
+  assert.deepEqual(specShared.detectKinds(tasksDir).sort(), []);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
 test('detectKinds unions multiple tasks and composes frontend+backend → fullstack+wiring', () => {
   const { root, tasksDir } = makeTasksDir({
     tasks: [

--- a/plugins/work/scripts/workflows/work-spec/lib/kind-checks/shared.js
+++ b/plugins/work/scripts/workflows/work-spec/lib/kind-checks/shared.js
@@ -350,13 +350,23 @@ function isE2eFile(p) {
 
 /** Heuristic: is a file path "devops/infra-like"? */
 function isDevopsFile(p) {
-  return (
+  // Unambiguous infra signals classify a file as devops regardless of where it
+  // lives in the tree.
+  if (
     /^\.github\//.test(p) ||
-    /(^|\/)scripts\//.test(p) ||
     /(^|\/)\.?ci\//.test(p) ||
     /\.(yml|yaml)$/.test(p) ||
     /(^|\/)Dockerfile/.test(p)
-  );
+  ) {
+    return true;
+  }
+  // The generic `scripts/` signal is overbroad: a plugin whose own source tree
+  // lives under a `scripts/` ancestor (e.g. this repo's own
+  // plugins/work/scripts/workflows/lib/...) would otherwise be classified as
+  // devops AND flagged as app-source drift against itself, wedging kind_checks.
+  // Only treat a `scripts/` path as devops when it is not an app-source module.
+  // (Mirrors the e2e-wins-over-devops carve-out in classifyScopeEntry.)
+  return /(^|\/)scripts\//.test(p) && !isAppSourceFile(p);
 }
 
 /** Heuristic: is a file path an "app-source" path (so devops should NOT touch it)? */


### PR DESCRIPTION
## Summary

The kind_checks devops heuristic (`isDevopsFile`) matched any path containing `scripts/`, and the app-source heuristic (`isAppSourceFile`) matched any path containing `lib/`. This repo's own plugin source lives at `plugins/work/scripts/workflows/lib/...`, so a change to it was classified BOTH as `devops` and as `app-source` — the devops cross-kind check then flagged the change as "DevOps kind but diff contains app-source files" against its own files, wedging kind_checks with no resolvable action. This was observed live on the GH-665 (PR #674) code-review and completion runners.

## Change

- Narrowed `isDevopsFile` in `plugins/work/scripts/workflows/work-spec/lib/kind-checks/shared.js` (the single source of truth; all sibling runners re-export it): unambiguous infra signals (`.github/`, `.ci/`, `*.yml`/`*.yaml`, `Dockerfile`) still classify as devops regardless of location; the generic `scripts/` signal now only fires when the path is NOT an app-source module (`lib/` | `app/` | `components/`). Mirrors the existing e2e-wins-over-devops carve-out in `classifyScopeEntry`.

## Test plan

- Added regression tests in `work-spec/__tests__/kind-checks.test.js`: the plugin's own source path is app-source and NOT devops (evidences no kind); plain `scripts/release.js`, `.github/workflows/ci.yml`, `lib/deploy/pipeline.yml`, and `services/api/Dockerfile` still classify as devops; `detectKinds` derives no devops kind for such a scope entry.
- `node --test` on the spec kind-checks suite (44 pass), all sibling runner kind-checks suites (24 pass), and pr-reviewer kind-checks (5 pass). Eslint clean on the changed source.

## Context

Follow-up hardening surfaced during the GH-665 /work run — the kind_checks classifier false-positive is not specific to GH-665; it affects any change to this repo's own plugin source under `scripts/workflows/lib/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small heuristic change in workflow kind classification with targeted regression tests; no auth, data, or runtime product behavior.
> 
> **Overview**
> Fixes **kind_checks** wedging when scope includes this repo’s plugin source under `plugins/work/scripts/workflows/lib/...`, which previously matched both the broad `scripts/` devops heuristic and the `lib/` app-source heuristic.
> 
> **`isDevopsFile`** in `shared.js` now treats `.github/`, `.ci/`, `*.yml`/`*.yaml`, and `Dockerfile` as devops everywhere; the generic **`scripts/`** signal applies only when the path is **not** an app-source module (`app/`, `lib/`, `components/`). Scope entries like `plugins/work/scripts/workflows/lib/agent-detection.js` no longer derive the **devops** kind, so the devops handler does not false-positive on “app-source drift” against the same files.
> 
> Regression tests cover the plugin path, unchanged infra paths (`scripts/release.js`, CI yaml under `lib/`, etc.), and **`detectKinds`** returning no devops for that scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d56efdbbeeada4e860fa82f53fad34e99038c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->