### PR TITLE
feat(maestro): per-agent status glyphs + session-runtime heat badge on the fleet status line

### DIFF
--- a/plugins/maestro/skills/lib/__tests__/maestro-statusline.test.js
+++ b/plugins/maestro/skills/lib/__tests__/maestro-statusline.test.js
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the maestro fleet status-line renderer's pure logic:
+ *   - resolveTicketIcon: marker/status -> single status glyph, severity order,
+ *     freshness gating, nudge escalation.
+ *   - formatSegment: per-ticket glyph placement + the done/total✓ ⏳ envelope.
+ *
+ * Pure functions only — no tmux, no live conductor. Run with:
+ *   node --test maestro-statusline.test.js
+ */
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  ICON,
+  NUDGE_WINDOW_SEC,
+  SILENCE_LIMIT_SEC,
+  OVERLAY_FRESH_SEC,
+  resolveTicketIcon,
+  formatSegment,
+} = require('../maestro-statusline.js');
+
+const NOW = 1_800_000_000; // fixed clock (seconds)
+
+describe('resolveTicketIcon — severity + freshness', () => {
+  it('working when the silence heartbeat is fresh', () => {
+    const m = { silence: { lastActiveAt: NOW - 10, tokens: 100 } };
+    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.working);
+  });
+
+  it('stalled when the heartbeat is older than the silence limit', () => {
+    const m = { silence: { lastActiveAt: NOW - (SILENCE_LIMIT_SEC + 5) } };
+    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.stalled);
+  });
+
+  it('question outranks a fresh working heartbeat', () => {
+    const m = {
+      question: { startedAt: NOW - 30, lastAlertAt: NOW - 5 },
+      silence: { lastActiveAt: NOW - 5 },
+    };
+    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.question);
+  });
+
+  it('a stale question marker does NOT render (freshness gate)', () => {
+    const m = {
+      question: { startedAt: NOW - 99999, lastAlertAt: NOW - (OVERLAY_FRESH_SEC + 60) },
+      silence: { lastActiveAt: NOW - 5 },
+    };
+    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.working);
+  });
+
+  it('nudge escalation: 1 -> ⚠, 2 -> ⚠⚠, 3+ -> 💀', () => {
+    const one = { restartLoop: { restarts: [NOW - 60] } };
+    const two = { restartLoop: { restarts: [NOW - 120, NOW - 60] } };
+    const three = { restartLoop: { restarts: [NOW - 180, NOW - 120, NOW - 60] } };
+    assert.equal(resolveTicketIcon(one, 'in_progress', NOW), ICON.nudge1);
+    assert.equal(resolveTicketIcon(two, 'in_progress', NOW), ICON.nudge2);
+    assert.equal(resolveTicketIcon(three, 'in_progress', NOW), ICON.wedged);
+  });
+
+  it('nudges outside the restart window are ignored', () => {
+    const m = {
+      restartLoop: { restarts: [NOW - (NUDGE_WINDOW_SEC + 100)] },
+      silence: { lastActiveAt: NOW - 5 },
+    };
+    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.working);
+  });
+
+  it('dead-end killed -> 💀', () => {
+    const m = { deadEnd: { killed: true, freedAt: NOW - 60, trigger: 'question-pending' } };
+    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.wedged);
+  });
+
+  it('pr-broken outranks nudges and working', () => {
+    const m = {
+      prStatus: { lastState: 'pr-broken', lastEmittedAt: NOW - 4000 },
+      restartLoop: { restarts: [NOW - 60] },
+      silence: { lastActiveAt: NOW - 5 },
+    };
+    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.prBroken);
+  });
+
+  it('pr-ready shows ✅ when otherwise idle', () => {
+    const m = { prStatus: { lastState: 'pr-ready', lastEmittedAt: NOW - 100 } };
+    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.prReady);
+  });
+
+  it('stuck-input -> ✎', () => {
+    const m = { stuckInput: { text: 'ping me', firstSeenAt: NOW - 30 } };
+    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.stuck);
+  });
+
+  it('status fallbacks: awaiting-merge / stopped / done', () => {
+    assert.equal(resolveTicketIcon({}, 'awaiting-merge', NOW), ICON.prReady);
+    assert.equal(resolveTicketIcon({}, 'stopped', NOW), ICON.stopped);
+    assert.equal(resolveTicketIcon({}, 'blocked', NOW), ICON.stopped);
+    assert.equal(resolveTicketIcon({}, 'done', NOW), ICON.done);
+  });
+
+  it('no markers, in-progress -> working default', () => {
+    assert.equal(resolveTicketIcon({}, 'in_progress', NOW), ICON.working);
+    assert.equal(resolveTicketIcon(null, undefined, NOW), ICON.working);
+  });
+});
+
+describe('formatSegment — glyph placement + counts envelope', () => {
+  const icons = { 'ECHO-6305': ICON.question, 'ECHO-6306': ICON.working };
+  const iconFor = (id) => icons[id] || '';
+
+  it('prefixes each id with its glyph and keeps the done/total ⏳ envelope', () => {
+    const line = formatSegment(
+      'ECHO',
+      ['ECHO-6305', 'ECHO-6306'],
+      { done: 2, total: 8, pending: 4 },
+      iconFor
+    );
+    assert.equal(
+      line,
+      `🎼 ECHO   2/8✓  ▶2 (${ICON.question} ECHO-6305, ${ICON.working} ECHO-6306)  ⏳4`
+    );
+  });
+
+  it('falls back to the count-less format when no manifest matches', () => {
+    const line = formatSegment('ECHO', ['ECHO-6305'], null, iconFor);
+    assert.equal(line, `🎼 ECHO   ▶  1  (${ICON.question} ECHO-6305)`);
+  });
+
+  it('renders a bare id when no glyph resolves', () => {
+    const line = formatSegment('ECHO', ['ECHO-9999'], { done: 0, total: 1, pending: 0 }, () => '');
+    assert.equal(line, '🎼 ECHO   0/1✓  ▶1 (ECHO-9999)  ⏳0');
+  });
+});

--- a/plugins/maestro/skills/lib/__tests__/maestro-statusline.test.js
+++ b/plugins/maestro/skills/lib/__tests__/maestro-statusline.test.js
@@ -15,7 +15,12 @@ const {
   NUDGE_WINDOW_SEC,
   SILENCE_LIMIT_SEC,
   OVERLAY_FRESH_SEC,
+  HEAT_MIN_MIN,
+  ANSI_RESET,
   resolveTicketIcon,
+  heatAnsi,
+  formatElapsed,
+  elapsedBadge,
   formatSegment,
 } = require('../maestro-statusline.js');
 
@@ -102,6 +107,50 @@ describe('resolveTicketIcon — severity + freshness', () => {
   });
 });
 
+describe('runtime heat — per-band shade walk', () => {
+  it('below the heat floor: no color, bare label', () => {
+    assert.equal(heatAnsi(0, true), '');
+    assert.equal(heatAnsi(HEAT_MIN_MIN - 1, true), '');
+    assert.equal(elapsedBadge(12, true), '12m');
+  });
+
+  it('truecolor walks SHADES within a band, then jumps hue at the boundary', () => {
+    // Yellow band start (30m) = light yellow (255,255,180).
+    assert.equal(heatAnsi(30, true), '\x1b[38;2;255;255;180m');
+    // Just before the orange boundary the yellow has deepened (G/B dropped).
+    const yellowLate = heatAnsi(44, true);
+    assert.match(yellowLate, /^\x1b\[38;2;255;\d+;\d+m$/);
+    assert.notEqual(yellowLate, heatAnsi(30, true));
+    // 45m enters the orange band at its LIGHT shade — a hue jump, not a continuation.
+    assert.equal(heatAnsi(45, true), '\x1b[38;2;255;200;120m');
+    // 60m enters the red band at its light shade.
+    assert.equal(heatAnsi(60, true), '\x1b[38;2;255;90;90m');
+  });
+
+  it('past the last band pins to the deepest red', () => {
+    assert.equal(heatAnsi(90, true), '\x1b[38;2;170;0;0m');
+    assert.equal(heatAnsi(999, true), '\x1b[38;2;170;0;0m');
+  });
+
+  it('256-color fallback emits a per-band ramp index', () => {
+    assert.equal(heatAnsi(30, false), '\x1b[38;5;229m'); // yellow band, lightest
+    assert.equal(heatAnsi(60, false), '\x1b[38;5;210m'); // red band, lightest
+    assert.equal(heatAnsi(999, false), '\x1b[38;5;124m'); // deepest red
+  });
+
+  it('elapsedBadge wraps the label in the heat SGR + reset', () => {
+    assert.equal(elapsedBadge(30, true), `\x1b[38;2;255;255;180m30m${ANSI_RESET}`);
+  });
+
+  it('formatElapsed: minutes then h/m', () => {
+    assert.equal(formatElapsed(5), '5m');
+    assert.equal(formatElapsed(59), '59m');
+    assert.equal(formatElapsed(60), '1h');
+    assert.equal(formatElapsed(72), '1h12m');
+    assert.equal(formatElapsed(125), '2h05m');
+  });
+});
+
 describe('formatSegment — glyph placement + counts envelope', () => {
   const icons = { 'ECHO-6305': ICON.question, 'ECHO-6306': ICON.working };
   const iconFor = (id) => icons[id] || '';
@@ -127,5 +176,17 @@ describe('formatSegment — glyph placement + counts envelope', () => {
   it('renders a bare id when no glyph resolves', () => {
     const line = formatSegment('ECHO', ['ECHO-9999'], { done: 0, total: 1, pending: 0 }, () => '');
     assert.equal(line, '🎼 ECHO   0/1✓  ▶1 (ECHO-9999)  ⏳0');
+  });
+
+  it('appends the runtime badge after the id when badgeFor returns one', () => {
+    const badge = elapsedBadge(72, true);
+    const line = formatSegment(
+      'ECHO',
+      ['ECHO-6309'],
+      { done: 7, total: 8, pending: 0 },
+      () => ICON.working,
+      () => badge
+    );
+    assert.equal(line, `🎼 ECHO   7/8✓  ▶1 (${ICON.working} ECHO-6309 ${badge})  ⏳0`);
   });
 });

--- a/plugins/maestro/skills/lib/maestro-statusline.js
+++ b/plugins/maestro/skills/lib/maestro-statusline.js
@@ -245,6 +245,67 @@ function readTicketMarkers(id, dir) {
   };
 }
 
+// `ts` is a marker timestamp (epoch sec); fresh within `win` seconds of `now`.
+function freshTs(ts, win, now) {
+  return typeof ts === 'number' && ts > 0 && now - ts <= win;
+}
+
+// Auto-restart ("nudge") escalation level — restarts[] grows once per restart;
+// 0 when the last restart is outside the window (stale).
+function nudgeLevelOf(m, nowSec) {
+  const restarts =
+    m.restartLoop && Array.isArray(m.restartLoop.restarts) ? m.restartLoop.restarts : [];
+  if (!restarts.length) return 0;
+  const last = restarts[restarts.length - 1];
+  return freshTs(last, NUDGE_WINDOW_SEC, nowSec) ? restarts.length : 0;
+}
+
+// Ordered marker rules — first matching predicate wins, so each agent shows
+// exactly one glyph, highest-severity-first. Each predicate is its own function
+// (ctx = { m, nowSec, nudge }) so the dispatcher stays flat. PR state is
+// persisted (lastEmittedAt marks the last TRANSITION), so trust lastState
+// directly rather than gating it on freshness.
+const ICON_RULES = [
+  {
+    icon: ICON.wedged,
+    test: (c) =>
+      (c.m.deadEnd &&
+        c.m.deadEnd.killed &&
+        freshTs(c.m.deadEnd.freedAt, NUDGE_WINDOW_SEC, c.nowSec)) ||
+      c.nudge >= 3,
+  },
+  {
+    icon: ICON.question,
+    test: (c) =>
+      c.m.question &&
+      freshTs(c.m.question.lastAlertAt || c.m.question.startedAt, OVERLAY_FRESH_SEC, c.nowSec),
+  },
+  { icon: ICON.prBroken, test: (c) => c.m.prStatus && c.m.prStatus.lastState === 'pr-broken' },
+  {
+    icon: ICON.stuck,
+    test: (c) => c.m.stuckInput && freshTs(c.m.stuckInput.firstSeenAt, OVERLAY_FRESH_SEC, c.nowSec),
+  },
+  { icon: ICON.nudge2, test: (c) => c.nudge === 2 },
+  { icon: ICON.nudge1, test: (c) => c.nudge === 1 },
+  { icon: ICON.prReady, test: (c) => c.m.prStatus && c.m.prStatus.lastState === 'pr-ready' },
+];
+
+// Working vs stalled from the silence heartbeat (lastActiveAt bumps whenever the
+// pane hash or token count moves). '' when there is no heartbeat marker.
+function livenessIcon(m, nowSec) {
+  const s = m.silence;
+  if (!s || typeof s.lastActiveAt !== 'number' || s.lastActiveAt <= 0) return '';
+  return nowSec - s.lastActiveAt >= SILENCE_LIMIT_SEC ? ICON.stalled : ICON.working;
+}
+
+// Manifest-status fallback when no live marker has an opinion yet.
+function statusIcon(status) {
+  if (status === 'awaiting-merge') return ICON.prReady;
+  if (status === 'stopped' || status === 'blocked') return ICON.stopped;
+  if (status === 'done') return ICON.done;
+  return ICON.working; // live, in-progress, no signal yet
+}
+
 /**
  * Map a ticket's markers + manifest status to a single status glyph.
  * Highest-severity-first so one agent shows exactly one icon. Pure: all
@@ -252,41 +313,11 @@ function readTicketMarkers(id, dir) {
  */
 function resolveTicketIcon(markers, status, nowSec) {
   const m = markers || {};
-  const fresh = (ts, win) => typeof ts === 'number' && ts > 0 && nowSec - ts <= win;
-
-  // Auto-restart ("nudge") escalation — restarts[] grows once per restart.
-  const restarts =
-    m.restartLoop && Array.isArray(m.restartLoop.restarts) ? m.restartLoop.restarts : [];
-  const lastRestart = restarts.length ? restarts[restarts.length - 1] : 0;
-  const nudgeLevel = fresh(lastRestart, NUDGE_WINDOW_SEC) ? restarts.length : 0;
-
-  const killed = m.deadEnd && m.deadEnd.killed && fresh(m.deadEnd.freedAt, NUDGE_WINDOW_SEC);
-  if (killed || nudgeLevel >= 3) return ICON.wedged;
-
-  if (m.question && fresh(m.question.lastAlertAt || m.question.startedAt, OVERLAY_FRESH_SEC)) {
-    return ICON.question;
+  const ctx = { m, nowSec, nudge: nudgeLevelOf(m, nowSec) };
+  for (const rule of ICON_RULES) {
+    if (rule.test(ctx)) return rule.icon;
   }
-  // PR state is persisted (lastEmittedAt marks the last TRANSITION, not the last
-  // check), so trust lastState directly rather than gating on freshness.
-  if (m.prStatus && m.prStatus.lastState === 'pr-broken') return ICON.prBroken;
-  if (m.stuckInput && fresh(m.stuckInput.firstSeenAt, OVERLAY_FRESH_SEC)) return ICON.stuck;
-
-  if (nudgeLevel === 2) return ICON.nudge2;
-  if (nudgeLevel === 1) return ICON.nudge1;
-
-  if (m.prStatus && m.prStatus.lastState === 'pr-ready') return ICON.prReady;
-
-  // Working vs stalled from the silence heartbeat (lastActiveAt bumps whenever
-  // the pane hash or token count moves).
-  if (m.silence && typeof m.silence.lastActiveAt === 'number' && m.silence.lastActiveAt > 0) {
-    return nowSec - m.silence.lastActiveAt >= SILENCE_LIMIT_SEC ? ICON.stalled : ICON.working;
-  }
-
-  // Manifest-status fallbacks when no live marker has an opinion yet.
-  if (status === 'awaiting-merge') return ICON.prReady;
-  if (status === 'stopped' || status === 'blocked') return ICON.stopped;
-  if (status === 'done') return ICON.done;
-  return ICON.working; // live, in-progress, no signal yet
+  return livenessIcon(m, nowSec) || statusIcon(status);
 }
 
 /**

--- a/plugins/maestro/skills/lib/maestro-statusline.js
+++ b/plugins/maestro/skills/lib/maestro-statusline.js
@@ -58,6 +58,71 @@ const ICON = {
   done: '✓',
 };
 
+const ANSI_RESET = '\x1b[0m';
+
+// Session-runtime "heat": how long an agent has been running, encoded as a
+// colored elapsed badge. Below HEAT_MIN_MIN it stays the terminal default
+// (calm); past it the badge walks through SHADES OF ONE HUE, then jumps hue at
+// each band boundary — yellow deepens, then orange deepens, then red deepens.
+// Each band lerps between a light and a dark shade of that hue.
+const HEAT_MIN_MIN = 30;
+const HEAT_BANDS = [
+  { start: 30, end: 45, from: [255, 255, 180], to: [255, 214, 0] }, // yellows
+  { start: 45, end: 60, from: [255, 200, 120], to: [255, 120, 0] }, // oranges
+  { start: 60, end: 90, from: [255, 90, 90], to: [170, 0, 0] }, // reds (then pinned)
+];
+// Discrete 256-color ramp per band for terminals without 24-bit color.
+const HEAT_256 = [
+  { start: 30, end: 45, codes: [229, 226, 220] },
+  { start: 45, end: 60, codes: [214, 208, 202] },
+  { start: 60, end: 90, codes: [210, 196, 160, 124] },
+];
+
+function terminalTruecolor() {
+  return /^(truecolor|24bit)$/i.test(process.env.COLORTERM || '');
+}
+
+// Pick the band covering `min` (or the last band, saturated, once past it).
+function heatBand(bands, min) {
+  const hit = bands.find((b) => min >= b.start && min < b.end);
+  if (hit) return { band: hit, t: (min - hit.start) / (hit.end - hit.start) };
+  return { band: bands[bands.length - 1], t: 1 }; // past the last band → deepest
+}
+
+function lerp(a, b, t) {
+  return Math.round(a + (b - a) * t);
+}
+
+// ANSI SGR prefix for the runtime heat at `min` minutes, or '' below the floor.
+function heatAnsi(min, truecolor) {
+  if (typeof min !== 'number' || min < HEAT_MIN_MIN) return '';
+  if (truecolor) {
+    const { band, t } = heatBand(HEAT_BANDS, min);
+    const [r, g, b] = [0, 1, 2].map((i) => lerp(band.from[i], band.to[i], t));
+    return `\x1b[38;2;${r};${g};${b}m`;
+  }
+  const { band, t } = heatBand(HEAT_256, min);
+  const idx = Math.min(band.codes.length - 1, Math.floor(t * band.codes.length));
+  return `\x1b[38;5;${band.codes[idx]}m`;
+}
+
+// "33m" / "1h02m" — compact elapsed label.
+function formatElapsed(min) {
+  const m = Math.max(0, Math.floor(min));
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  const rem = m % 60;
+  return rem ? `${h}h${String(rem).padStart(2, '0')}m` : `${h}h`;
+}
+
+// Colored elapsed badge (label + heat SGR + reset), or the bare label below the
+// heat floor. Pure: caller injects `min` and truecolor so it is testable.
+function elapsedBadge(min, truecolor) {
+  const label = formatElapsed(min);
+  const color = heatAnsi(min, truecolor);
+  return color ? `${color}${label}${ANSI_RESET}` : label;
+}
+
 // The Claude session Claude runs this statusLine in (session_id on stdin). Read
 // lazily so `require()`ing this module (tests) never blocks on fd 0.
 function readSession() {
@@ -90,26 +155,34 @@ function myOrchestrations(session) {
 }
 
 // Live agent tickets for a prefix, from tmux `<prefix>-<ticket>-work` sessions
-// (execFileSync = no shell). One entry per ticket; helper -dev/-listen ignored.
+// (execFileSync = no shell). Returns { ids: sorted ticket ids, createdById:
+// id -> tmux session_created epoch (survives auto-restarts, which reuse the
+// session) } so the renderer can heat-color each agent by how long it has run.
+// Helper -dev/-listen sessions are ignored.
 function liveTickets(prefix) {
   let out = '';
   try {
-    out = execFileSync('tmux', ['list-sessions', '-F', '#{session_name}'], {
+    out = execFileSync('tmux', ['list-sessions', '-F', '#{session_name}\t#{session_created}'], {
       encoding: 'utf8',
       timeout: 1500,
       stdio: ['ignore', 'pipe', 'ignore'],
     });
   } catch {
-    return [];
+    return { ids: [], createdById: {} };
   }
   const esc = String(prefix).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const re = new RegExp('^(' + esc + '-.+)-work$');
   const seen = new Set();
+  const createdById = {};
   for (const line of out.split('\n')) {
-    const m = line.match(re);
-    if (m) seen.add(m[1]);
+    const [name, created] = line.split('\t');
+    const m = (name || '').match(re);
+    if (!m) continue;
+    seen.add(m[1]);
+    const c = parseInt(created, 10);
+    if (!Number.isNaN(c)) createdById[m[1]] = c;
   }
-  return [...seen].sort();
+  return { ids: [...seen].sort(), createdById };
 }
 
 // Manifest counts + per-task status for the topic whose tasks overlap the live
@@ -218,14 +291,17 @@ function resolveTicketIcon(markers, status, nowSec) {
 
 /**
  * Render one orchestration's status-line segment. `iconFor` maps a ticket id to
- * its status glyph (or '' for none). Kept pure/injected so tests exercise the
- * formatting without touching tmux or the marker store.
+ * its status glyph (or '' for none); `badgeFor` maps it to a colored runtime
+ * badge (or '' for none). Both injected so tests exercise the formatting
+ * without touching tmux or the marker store.
  */
-function formatSegment(prefix, tickets, info, iconFor) {
+function formatSegment(prefix, tickets, info, iconFor, badgeFor = () => '') {
   const labelled = tickets
     .map((id) => {
       const icon = iconFor(id);
-      return icon ? `${icon} ${id}` : id;
+      const badge = badgeFor(id);
+      const left = icon ? `${icon} ${id}` : id;
+      return badge ? `${left} ${badge}` : left;
     })
     .join(', ');
   if (info) {
@@ -236,14 +312,20 @@ function formatSegment(prefix, tickets, info, iconFor) {
 }
 
 function segment(m) {
-  const tickets = liveTickets(m.prefix);
-  if (!tickets.length) return null;
-  const info = manifestInfo(tickets);
+  const { ids, createdById } = liveTickets(m.prefix);
+  if (!ids.length) return null;
+  const info = manifestInfo(ids);
   const dir = markerDir();
   const nowSec = Math.floor(Date.now() / 1000);
   const statusById = (info && info.statusById) || {};
+  const truecolor = terminalTruecolor();
   const iconFor = (id) => resolveTicketIcon(readTicketMarkers(id, dir), statusById[id], nowSec);
-  return formatSegment(m.prefix, tickets, info, iconFor);
+  const badgeFor = (id) => {
+    const created = createdById[id];
+    if (!created) return '';
+    return elapsedBadge((nowSec - created) / 60, truecolor);
+  };
+  return formatSegment(m.prefix, ids, info, iconFor, badgeFor);
 }
 
 function render() {
@@ -261,10 +343,16 @@ module.exports = {
   OVERLAY_FRESH_SEC,
   NUDGE_WINDOW_SEC,
   SILENCE_LIMIT_SEC,
+  HEAT_MIN_MIN,
+  HEAT_BANDS,
+  ANSI_RESET,
   markerDir,
   manifestInfo,
   readTicketMarkers,
   resolveTicketIcon,
+  heatAnsi,
+  formatElapsed,
+  elapsedBadge,
   formatSegment,
   render,
 };

--- a/plugins/maestro/skills/lib/maestro-statusline.js
+++ b/plugins/maestro/skills/lib/maestro-statusline.js
@@ -9,6 +9,13 @@
  * conductor writes (~/.cache/maestro/active/<session>.json = {session, prefix}),
  * so each orchestrator session shows only the fleet it launched — never other
  * chats. No global pin (which only one session could ever win).
+ *
+ * Per-agent status: each live ticket is prefixed with a glyph derived from the
+ * conductor's per-ticket markers under ~/.cache/maestro-conduct/ (question,
+ * silence heartbeat, restart-loop nudges, dead-end, stuck-input, pr-status), so
+ * the operator can see at a glance which agent is working, asking, nudged, or
+ * dead — without opening a single pane. Pure/exported helpers keep the icon
+ * logic unit-testable without tmux or a live conductor.
  */
 const fs = require('fs');
 const path = require('path');
@@ -16,18 +23,54 @@ const os = require('os');
 const { execFileSync } = require('child_process');
 
 const ACTIVE_DIR = path.join(os.homedir(), '.cache', 'maestro', 'active');
+const SESSIONS_DIR = path.join(os.homedir(), '.cache', 'maestro', 'sessions');
 
-// The Claude session Claude runs this statusLine in (session_id on stdin).
-let SESSION = '';
-try {
-  SESSION = JSON.parse(fs.readFileSync(0, 'utf8') || '{}').session_id || '';
-} catch {
-  /* no stdin */
+// Per-ticket conductor markers live under the same store state.js writes to.
+// Mirror maestro-conduct/namespace.stateDir() so a MAESTRO_NS run reads its own
+// per-namespace markers, and STATE_DIR (tests) always wins.
+const NS_RE = /^[A-Za-z0-9_-]+$/;
+function markerDir() {
+  if (process.env.STATE_DIR) return process.env.STATE_DIR;
+  const base = path.join(os.homedir(), '.cache', 'maestro-conduct');
+  const ns = (process.env.MAESTRO_NS || '').trim();
+  return NS_RE.test(ns) ? path.join(base, ns) : base;
+}
+
+// Freshness windows (seconds). Markers persist on disk after the condition
+// clears, so a timestamp gate keeps a stale question/heartbeat from rendering a
+// false status. Defaults mirror the conductor's own thresholds.
+const OVERLAY_FRESH_SEC = 300; // question / stuck-input re-alert cadence
+const NUDGE_WINDOW_SEC = 30 * 60; // restart-loop / dead-end recency (RESTART_WINDOW_MIN)
+const SILENCE_LIMIT_SEC = 300; // stall threshold (silence DEFAULT_SILENCE_LIMIT_SEC)
+
+// Single glyph per ticket, highest-severity-first (see resolveTicketIcon).
+const ICON = {
+  wedged: '💀', // dead-end killed, or nudged past the restart-loop threshold
+  question: '❓', // blocked on an operator answer
+  prBroken: '🔴', // PR checks failing / mergeable DIRTY
+  stuck: '✎', // text sitting unsubmitted in the composer
+  nudge2: '⚠⚠', // second auto-restart in the window
+  nudge1: '⚠', // first auto-restart in the window
+  prReady: '✅', // PR green + mergeable — ready to merge
+  stalled: '💤', // alive session but no activity past the silence limit
+  working: '🔨', // active: worktree/tokens moving
+  stopped: '⛔', // session died / blocked
+  done: '✓',
+};
+
+// The Claude session Claude runs this statusLine in (session_id on stdin). Read
+// lazily so `require()`ing this module (tests) never blocks on fd 0.
+function readSession() {
+  try {
+    return JSON.parse(fs.readFileSync(0, 'utf8') || '{}').session_id || '';
+  } catch {
+    return '';
+  }
 }
 
 // Orchestrations launched by THIS session — {session, prefix} markers the
 // conductor writes on start.
-function myOrchestrations() {
+function myOrchestrations(session) {
   let files = [];
   try {
     files = fs.readdirSync(ACTIVE_DIR).filter((f) => f.endsWith('.json'));
@@ -38,7 +81,7 @@ function myOrchestrations() {
   for (const f of files) {
     try {
       const m = JSON.parse(fs.readFileSync(path.join(ACTIVE_DIR, f), 'utf8'));
-      if (m && m.session === SESSION && m.prefix) out.push(m);
+      if (m && m.session === session && m.prefix) out.push(m);
     } catch {
       /* skip unreadable marker */
     }
@@ -69,15 +112,159 @@ function liveTickets(prefix) {
   return [...seen].sort();
 }
 
+// Manifest counts + per-task status for the topic whose tasks overlap the live
+// tmux tickets. Returns {total, done, pending, statusById} or null.
+function manifestInfo(liveIds) {
+  if (!liveIds.length) return null;
+  let files = [];
+  try {
+    files = fs.readdirSync(SESSIONS_DIR).filter((f) => f.endsWith('.json'));
+  } catch {
+    return null;
+  }
+  const liveSet = new Set(liveIds);
+  for (const f of files) {
+    try {
+      const mf = JSON.parse(fs.readFileSync(path.join(SESSIONS_DIR, f), 'utf8'));
+      const tasks = Array.isArray(mf.tasks) ? mf.tasks : [];
+      if (!tasks.some((t) => liveSet.has(t.id))) continue;
+      const statusById = {};
+      for (const t of tasks) if (t && t.id) statusById[t.id] = t.status;
+      return {
+        total: tasks.length,
+        done: tasks.filter((t) => t.status === 'done').length,
+        pending: tasks.filter((t) => t.status === 'pending').length,
+        statusById,
+      };
+    } catch {
+      /* skip unreadable manifest */
+    }
+  }
+  return null;
+}
+
+function readJson(p) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function readMarker(dir, key, kind) {
+  // Flatten any "<ns>/" segment — the store is already per-namespace (state.js).
+  const flat = String(key).replace(/^.*\//, '');
+  return readJson(path.join(dir, `${flat}.${kind}.json`));
+}
+
+// The markers the conductor writes per ticket. Silence/question/restart-loop/
+// stuck-input are keyed by the tmux SESSION (`<id>-work`); dead-end and
+// pr-status are keyed by the bare ticket id (see state.js call sites).
+function readTicketMarkers(id, dir) {
+  const s = `${id}-work`;
+  return {
+    question: readMarker(dir, s, 'question'),
+    silence: readMarker(dir, s, 'silence'),
+    restartLoop: readMarker(dir, s, 'restart-loop'),
+    stuckInput: readMarker(dir, s, 'stuck-input'),
+    deadEnd: readMarker(dir, id, 'dead-end'),
+    prStatus: readMarker(dir, id, 'pr-status'),
+  };
+}
+
+/**
+ * Map a ticket's markers + manifest status to a single status glyph.
+ * Highest-severity-first so one agent shows exactly one icon. Pure: all
+ * time-dependence flows through `nowSec` so it is deterministic under test.
+ */
+function resolveTicketIcon(markers, status, nowSec) {
+  const m = markers || {};
+  const fresh = (ts, win) => typeof ts === 'number' && ts > 0 && nowSec - ts <= win;
+
+  // Auto-restart ("nudge") escalation — restarts[] grows once per restart.
+  const restarts =
+    m.restartLoop && Array.isArray(m.restartLoop.restarts) ? m.restartLoop.restarts : [];
+  const lastRestart = restarts.length ? restarts[restarts.length - 1] : 0;
+  const nudgeLevel = fresh(lastRestart, NUDGE_WINDOW_SEC) ? restarts.length : 0;
+
+  const killed = m.deadEnd && m.deadEnd.killed && fresh(m.deadEnd.freedAt, NUDGE_WINDOW_SEC);
+  if (killed || nudgeLevel >= 3) return ICON.wedged;
+
+  if (m.question && fresh(m.question.lastAlertAt || m.question.startedAt, OVERLAY_FRESH_SEC)) {
+    return ICON.question;
+  }
+  // PR state is persisted (lastEmittedAt marks the last TRANSITION, not the last
+  // check), so trust lastState directly rather than gating on freshness.
+  if (m.prStatus && m.prStatus.lastState === 'pr-broken') return ICON.prBroken;
+  if (m.stuckInput && fresh(m.stuckInput.firstSeenAt, OVERLAY_FRESH_SEC)) return ICON.stuck;
+
+  if (nudgeLevel === 2) return ICON.nudge2;
+  if (nudgeLevel === 1) return ICON.nudge1;
+
+  if (m.prStatus && m.prStatus.lastState === 'pr-ready') return ICON.prReady;
+
+  // Working vs stalled from the silence heartbeat (lastActiveAt bumps whenever
+  // the pane hash or token count moves).
+  if (m.silence && typeof m.silence.lastActiveAt === 'number' && m.silence.lastActiveAt > 0) {
+    return nowSec - m.silence.lastActiveAt >= SILENCE_LIMIT_SEC ? ICON.stalled : ICON.working;
+  }
+
+  // Manifest-status fallbacks when no live marker has an opinion yet.
+  if (status === 'awaiting-merge') return ICON.prReady;
+  if (status === 'stopped' || status === 'blocked') return ICON.stopped;
+  if (status === 'done') return ICON.done;
+  return ICON.working; // live, in-progress, no signal yet
+}
+
+/**
+ * Render one orchestration's status-line segment. `iconFor` maps a ticket id to
+ * its status glyph (or '' for none). Kept pure/injected so tests exercise the
+ * formatting without touching tmux or the marker store.
+ */
+function formatSegment(prefix, tickets, info, iconFor) {
+  const labelled = tickets
+    .map((id) => {
+      const icon = iconFor(id);
+      return icon ? `${icon} ${id}` : id;
+    })
+    .join(', ');
+  if (info) {
+    // Lead with progress (done/total), then active agents + pending queue.
+    return `🎼 ${prefix}   ${info.done}/${info.total}✓  ▶${tickets.length} (${labelled})  ⏳${info.pending}`;
+  }
+  return `🎼 ${prefix}   ▶  ${tickets.length}  (${labelled})`;
+}
+
 function segment(m) {
   const tickets = liveTickets(m.prefix);
   if (!tickets.length) return null;
-  return `🎼 ${m.prefix}   ▶  ${tickets.length}  (${tickets.join(', ')})`;
+  const info = manifestInfo(tickets);
+  const dir = markerDir();
+  const nowSec = Math.floor(Date.now() / 1000);
+  const statusById = (info && info.statusById) || {};
+  const iconFor = (id) => resolveTicketIcon(readTicketMarkers(id, dir), statusById[id], nowSec);
+  return formatSegment(m.prefix, tickets, info, iconFor);
 }
 
 function render() {
-  if (!SESSION) return '';
-  return myOrchestrations().map(segment).filter(Boolean).join('      |      ');
+  const session = readSession();
+  if (!session) return '';
+  return myOrchestrations(session).map(segment).filter(Boolean).join('      |      ');
 }
 
-process.stdout.write(render());
+if (require.main === module) {
+  process.stdout.write(render());
+}
+
+module.exports = {
+  ICON,
+  OVERLAY_FRESH_SEC,
+  NUDGE_WINDOW_SEC,
+  SILENCE_LIMIT_SEC,
+  markerDir,
+  manifestInfo,
+  readTicketMarkers,
+  resolveTicketIcon,
+  formatSegment,
+  render,
+};


### PR DESCRIPTION
## Summary

Enriches the maestro fleet status line (the 🎼 bar) with **per-agent status** and a **session-runtime heat badge**, so the operator can read each agent's state at a glance without opening a pane.

```
🎼 ECHO  7/8✓  ▶1 (🔨 ECHO-6309 1h12m)  ⏳0
                   │          └─ elapsed, color = how long it's run
                   └─ per-agent status glyph
```

No linked issue — ad-hoc improvement to the maestro statusline.

## What changed

### 1. Per-agent status glyphs (`5ce22914`)
Each live ticket is prefixed with a single, highest-severity-first glyph derived from the conductor's per-ticket markers under `~/.cache/maestro-conduct/`:

| Glyph | State | Source |
|---|---|---|
| 🔨 | working (tokens/worktree moving) | `silence.lastActiveAt` fresh |
| 💤 | stalled (past silence limit) | `silence` stale |
| ❓ | question pending | `question` marker (fresh) |
| ⚠ / ⚠⚠ | nudged 1× / 2× | `restart-loop.restarts[]` |
| 💀 | wedged (dead-end or 3rd+ restart) | `dead-end` / restarts ≥3 |
| 🔴 / ✅ | PR broken / ready | `pr-status.lastState` |
| ✎ | stuck input | `stuck-input` (fresh) |
| ⛔ | stopped / blocked | manifest status |

A freshness gate (timestamps embedded in each marker) keeps stale, resolved-condition markers from rendering a false status.

This commit also **ports the `manifestCounts` envelope** (`done/total✓ … ⏳pending`) into the committed renderer. That logic previously existed **only in the installed plugin cache** and in no git ref — main shipped a simpler `▶ N` renderer.

### 2. Session-runtime heat badge (`4ae2f25d`)
Appends a colored elapsed badge (e.g. `1h12m`) after each id. Color encodes session age (from tmux `#{session_created}`, which survives auto-restarts). Below 30m it's the terminal default; past it the badge walks through **shades of one hue**, then jumps hue at each band boundary:

| Window | Hue walk (light → dark) |
|---|---|
| 30–45m | yellows `(255,255,180) → (255,214,0)` |
| 45–60m | oranges `(255,200,120) → (255,120,0)` |
| 60–90m | reds `(255,90,90) → (170,0,0)`, then pinned |

Truecolor (24-bit) by default for a smooth walk; a per-band 256-color ramp (`229/226/220 → 214/208/202 → 210/196/160/124`) is used when `$COLORTERM` isn't truecolor.

## Testing

- **22 `node:test` cases** covering: icon severity ordering, freshness gating, nudge escalation, intra-band shade walk, boundary hue-jumps, the saturated pin past the last band, the 256-color fallback, and badge placement in the segment.
- All color/icon logic is **pure and exported** (`resolveTicketIcon`, `heatAnsi`, `formatElapsed`, `elapsedBadge`, `formatSegment`) — testable with no tmux or live conductor.
- Adjacent `install-statusline` runtime suite still green; biome clean.
- Live smoke-tested against the running fleet (`🎼 ECHO 7/8✓ ▶1 (🔨 ECHO-6309) ⏳0`) and the heat walk verified across 12m→2h.

## Notes

- Reads markers from the same store `state.js` writes (`STATE_DIR` / `MAESTRO_NS` aware).
- The live status bar won't reflect this until the plugin is reinstalled/repointed — the running renderer is the cached copy.
- Heat currently tracks **session age**; switching it to **stall time** (`silence.lastActiveAt`) is a one-line change if a long productive run reading red proves noisy.
