### PR TITLE
feat(maestro): configurable fleet statusline — colors, clock, glyphs, ns, legend

### DIFF
--- a/plugins/maestro/skills/lib/__tests__/maestro-statusline.test.js
+++ b/plugins/maestro/skills/lib/__tests__/maestro-statusline.test.js
@@ -1,8 +1,10 @@
 /**
  * Unit tests for the maestro fleet status-line renderer's pure logic:
- *   - resolveTicketIcon: marker/status -> single status glyph, severity order,
- *     freshness gating, nudge escalation.
- *   - formatSegment: per-ticket glyph placement + the done/total✓ ⏳ envelope.
+ *   - resolveTicketStatus: marker/status -> single STATUS key, severity order,
+ *     freshness gating, nudge escalation, presence-based stuck-input.
+ *   - runtime heat: per-band shade walk, hue jumps, 256 fallback, clock modes.
+ *   - renderTicketCell: severity color placement (emoji vs text glyph modes).
+ *   - formatSegment / readConfig / legendLine.
  *
  * Pure functions only — no tmux, no live conductor. Run with:
  *   node --test maestro-statusline.test.js
@@ -11,182 +13,240 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
-  ICON,
-  NUDGE_WINDOW_SEC,
-  SILENCE_LIMIT_SEC,
-  OVERLAY_FRESH_SEC,
-  HEAT_MIN_MIN,
+  C,
+  STATUS,
   ANSI_RESET,
-  resolveTicketIcon,
+  readConfig,
   heatAnsi,
   formatElapsed,
   elapsedBadge,
+  elapsedMinutes,
+  stuckActive,
+  resolveTicketStatus,
+  renderTicketCell,
   formatSegment,
+  legendLine,
 } = require('../maestro-statusline.js');
 
 const NOW = 1_800_000_000; // fixed clock (seconds)
 
-describe('resolveTicketIcon — severity + freshness', () => {
+// Baseline config (emoji, truecolor, default thresholds) for the pure helpers.
+const CFG = {
+  glyphs: 'emoji',
+  clock: 'age',
+  truecolor: true,
+  silenceLimitSec: 300,
+  nudgeWindowSec: 30 * 60,
+  overlayFreshSec: 300,
+  stuckSanitySec: 12 * 3600,
+  heatBounds: [30, 45, 60, 90],
+};
+const cfg = (over) => ({ ...CFG, ...over });
+
+describe('resolveTicketStatus — severity + freshness', () => {
   it('working when the silence heartbeat is fresh', () => {
-    const m = { silence: { lastActiveAt: NOW - 10, tokens: 100 } };
-    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.working);
+    const m = { silence: { lastActiveAt: NOW - 10 } };
+    assert.equal(resolveTicketStatus(m, 'in_progress', NOW, CFG), 'working');
   });
 
   it('stalled when the heartbeat is older than the silence limit', () => {
-    const m = { silence: { lastActiveAt: NOW - (SILENCE_LIMIT_SEC + 5) } };
-    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.stalled);
+    const m = { silence: { lastActiveAt: NOW - 305 } };
+    assert.equal(resolveTicketStatus(m, 'in_progress', NOW, CFG), 'stalled');
   });
 
   it('question outranks a fresh working heartbeat', () => {
-    const m = {
-      question: { startedAt: NOW - 30, lastAlertAt: NOW - 5 },
-      silence: { lastActiveAt: NOW - 5 },
-    };
-    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.question);
+    const m = { question: { lastAlertAt: NOW - 5 }, silence: { lastActiveAt: NOW - 5 } };
+    assert.equal(resolveTicketStatus(m, 'in_progress', NOW, CFG), 'question');
   });
 
   it('a stale question marker does NOT render (freshness gate)', () => {
-    const m = {
-      question: { startedAt: NOW - 99999, lastAlertAt: NOW - (OVERLAY_FRESH_SEC + 60) },
-      silence: { lastActiveAt: NOW - 5 },
-    };
-    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.working);
+    const m = { question: { lastAlertAt: NOW - 400 }, silence: { lastActiveAt: NOW - 5 } };
+    assert.equal(resolveTicketStatus(m, 'in_progress', NOW, CFG), 'working');
   });
 
-  it('nudge escalation: 1 -> ⚠, 2 -> ⚠⚠, 3+ -> 💀', () => {
+  it('nudge escalation: 1 -> nudge1, 2 -> nudge2, 3+ -> wedged', () => {
     const one = { restartLoop: { restarts: [NOW - 60] } };
     const two = { restartLoop: { restarts: [NOW - 120, NOW - 60] } };
     const three = { restartLoop: { restarts: [NOW - 180, NOW - 120, NOW - 60] } };
-    assert.equal(resolveTicketIcon(one, 'in_progress', NOW), ICON.nudge1);
-    assert.equal(resolveTicketIcon(two, 'in_progress', NOW), ICON.nudge2);
-    assert.equal(resolveTicketIcon(three, 'in_progress', NOW), ICON.wedged);
+    assert.equal(resolveTicketStatus(one, 'in_progress', NOW, CFG), 'nudge1');
+    assert.equal(resolveTicketStatus(two, 'in_progress', NOW, CFG), 'nudge2');
+    assert.equal(resolveTicketStatus(three, 'in_progress', NOW, CFG), 'wedged');
   });
 
   it('nudges outside the restart window are ignored', () => {
     const m = {
-      restartLoop: { restarts: [NOW - (NUDGE_WINDOW_SEC + 100)] },
+      restartLoop: { restarts: [NOW - (CFG.nudgeWindowSec + 100)] },
       silence: { lastActiveAt: NOW - 5 },
     };
-    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.working);
+    assert.equal(resolveTicketStatus(m, 'in_progress', NOW, CFG), 'working');
   });
 
-  it('dead-end killed -> 💀', () => {
-    const m = { deadEnd: { killed: true, freedAt: NOW - 60, trigger: 'question-pending' } };
-    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.wedged);
-  });
-
-  it('pr-broken outranks nudges and working', () => {
+  it('dead-end killed -> wedged; pr-broken outranks nudges/working', () => {
+    assert.equal(
+      resolveTicketStatus(
+        { deadEnd: { killed: true, freedAt: NOW - 60 } },
+        'in_progress',
+        NOW,
+        CFG
+      ),
+      'wedged'
+    );
     const m = {
-      prStatus: { lastState: 'pr-broken', lastEmittedAt: NOW - 4000 },
+      prStatus: { lastState: 'pr-broken' },
       restartLoop: { restarts: [NOW - 60] },
       silence: { lastActiveAt: NOW - 5 },
     };
-    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.prBroken);
+    assert.equal(resolveTicketStatus(m, 'in_progress', NOW, CFG), 'prBroken');
   });
 
-  it('pr-ready shows ✅ when otherwise idle', () => {
-    const m = { prStatus: { lastState: 'pr-ready', lastEmittedAt: NOW - 100 } };
-    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.prReady);
-  });
-
-  it('stuck-input -> ✎', () => {
-    const m = { stuckInput: { text: 'ping me', firstSeenAt: NOW - 30 } };
-    assert.equal(resolveTicketIcon(m, 'in_progress', NOW), ICON.stuck);
-  });
-
-  it('status fallbacks: awaiting-merge / stopped / done', () => {
-    assert.equal(resolveTicketIcon({}, 'awaiting-merge', NOW), ICON.prReady);
-    assert.equal(resolveTicketIcon({}, 'stopped', NOW), ICON.stopped);
-    assert.equal(resolveTicketIcon({}, 'blocked', NOW), ICON.stopped);
-    assert.equal(resolveTicketIcon({}, 'done', NOW), ICON.done);
-  });
-
-  it('no markers, in-progress -> working default', () => {
-    assert.equal(resolveTicketIcon({}, 'in_progress', NOW), ICON.working);
-    assert.equal(resolveTicketIcon(null, undefined, NOW), ICON.working);
-  });
-});
-
-describe('runtime heat — per-band shade walk', () => {
-  it('below the heat floor: no color, bare label', () => {
-    assert.equal(heatAnsi(0, true), '');
-    assert.equal(heatAnsi(HEAT_MIN_MIN - 1, true), '');
-    assert.equal(elapsedBadge(12, true), '12m');
-  });
-
-  it('truecolor walks SHADES within a band, then jumps hue at the boundary', () => {
-    // Yellow band start (30m) = light yellow (255,255,180).
-    assert.equal(heatAnsi(30, true), '\x1b[38;2;255;255;180m');
-    // Just before the orange boundary the yellow has deepened (G/B dropped).
-    const yellowLate = heatAnsi(44, true);
-    assert.match(yellowLate, /^\x1b\[38;2;255;\d+;\d+m$/);
-    assert.notEqual(yellowLate, heatAnsi(30, true));
-    // 45m enters the orange band at its LIGHT shade — a hue jump, not a continuation.
-    assert.equal(heatAnsi(45, true), '\x1b[38;2;255;200;120m');
-    // 60m enters the red band at its light shade.
-    assert.equal(heatAnsi(60, true), '\x1b[38;2;255;90;90m');
-  });
-
-  it('past the last band pins to the deepest red', () => {
-    assert.equal(heatAnsi(90, true), '\x1b[38;2;170;0;0m');
-    assert.equal(heatAnsi(999, true), '\x1b[38;2;170;0;0m');
-  });
-
-  it('256-color fallback emits a per-band ramp index', () => {
-    assert.equal(heatAnsi(30, false), '\x1b[38;5;229m'); // yellow band, lightest
-    assert.equal(heatAnsi(60, false), '\x1b[38;5;210m'); // red band, lightest
-    assert.equal(heatAnsi(999, false), '\x1b[38;5;124m'); // deepest red
-  });
-
-  it('elapsedBadge wraps the label in the heat SGR + reset', () => {
-    assert.equal(elapsedBadge(30, true), `\x1b[38;2;255;255;180m30m${ANSI_RESET}`);
-  });
-
-  it('formatElapsed: minutes then h/m', () => {
-    assert.equal(formatElapsed(5), '5m');
-    assert.equal(formatElapsed(59), '59m');
-    assert.equal(formatElapsed(60), '1h');
-    assert.equal(formatElapsed(72), '1h12m');
-    assert.equal(formatElapsed(125), '2h05m');
-  });
-});
-
-describe('formatSegment — glyph placement + counts envelope', () => {
-  const icons = { 'ECHO-6305': ICON.question, 'ECHO-6306': ICON.working };
-  const iconFor = (id) => icons[id] || '';
-
-  it('prefixes each id with its glyph and keeps the done/total ⏳ envelope', () => {
-    const line = formatSegment(
-      'ECHO',
-      ['ECHO-6305', 'ECHO-6306'],
-      { done: 2, total: 8, pending: 4 },
-      iconFor
-    );
+  it('pr-ready + status fallbacks', () => {
     assert.equal(
-      line,
-      `🎼 ECHO   2/8✓  ▶2 (${ICON.question} ECHO-6305, ${ICON.working} ECHO-6306)  ⏳4`
+      resolveTicketStatus({ prStatus: { lastState: 'pr-ready' } }, 'in_progress', NOW, CFG),
+      'prReady'
     );
+    assert.equal(resolveTicketStatus({}, 'awaiting-merge', NOW, CFG), 'prReady');
+    assert.equal(resolveTicketStatus({}, 'stopped', NOW, CFG), 'stopped');
+    assert.equal(resolveTicketStatus({}, 'done', NOW, CFG), 'done');
+    assert.equal(resolveTicketStatus({}, 'in_progress', NOW, CFG), 'working');
+  });
+});
+
+describe('stuck-input is presence-based (#4)', () => {
+  it('still flags after 40 min stuck (firstSeenAt does not refresh)', () => {
+    const m = {
+      stuckInput: { text: 'ping', firstSeenAt: NOW - 40 * 60 },
+      silence: { lastActiveAt: NOW - 5 },
+    };
+    // Fresh heartbeat would otherwise say working; stuck outranks it and is not
+    // gated by the short overlay window.
+    assert.equal(resolveTicketStatus(m, 'in_progress', NOW, CFG), 'stuck');
+    assert.equal(stuckActive(m.stuckInput, CFG, NOW), true);
   });
 
-  it('falls back to the count-less format when no manifest matches', () => {
-    const line = formatSegment('ECHO', ['ECHO-6305'], null, iconFor);
-    assert.equal(line, `🎼 ECHO   ▶  1  (${ICON.question} ECHO-6305)`);
+  it('drops a marker older than the sanity cap (orphaned by a dead conductor)', () => {
+    const mk = { text: 'ping', firstSeenAt: NOW - (CFG.stuckSanitySec + 60) };
+    assert.equal(stuckActive(mk, CFG, NOW), false);
+  });
+});
+
+describe('runtime heat — per-band shade walk + clock (#2/#6)', () => {
+  it('below the floor: no color', () => {
+    assert.equal(heatAnsi(0, CFG), '');
+    assert.equal(heatAnsi(29, CFG), '');
   });
 
-  it('renders a bare id when no glyph resolves', () => {
-    const line = formatSegment('ECHO', ['ECHO-9999'], { done: 0, total: 1, pending: 0 }, () => '');
-    assert.equal(line, '🎼 ECHO   0/1✓  ▶1 (ECHO-9999)  ⏳0');
+  it('truecolor walks shades within a band, then jumps hue at boundaries', () => {
+    assert.equal(heatAnsi(30, CFG), '\x1b[38;2;255;255;180m'); // yellow light
+    assert.notEqual(heatAnsi(44, CFG), heatAnsi(30, CFG)); // yellow deepened
+    assert.equal(heatAnsi(45, CFG), '\x1b[38;2;255;200;120m'); // hue jump → orange
+    assert.equal(heatAnsi(60, CFG), '\x1b[38;2;255;90;90m'); // hue jump → red
+    assert.equal(heatAnsi(999, CFG), '\x1b[38;2;170;0;0m'); // pinned deepest
   });
 
-  it('appends the runtime badge after the id when badgeFor returns one', () => {
-    const badge = elapsedBadge(72, true);
+  it('256-color fallback emits per-band ramp indices', () => {
+    const c = cfg({ truecolor: false });
+    assert.equal(heatAnsi(30, c), '\x1b[38;5;229m');
+    assert.equal(heatAnsi(60, c), '\x1b[38;5;210m');
+    assert.equal(heatAnsi(999, c), '\x1b[38;5;124m');
+  });
+
+  it('configurable boundaries shift the floor', () => {
+    const c = cfg({ heatBounds: [10, 20, 30, 40] });
+    assert.equal(heatAnsi(9, c), '');
+    assert.equal(heatAnsi(10, c), '\x1b[38;2;255;255;180m');
+  });
+
+  it('elapsedMinutes: age vs stall clock', () => {
+    const src = { created: NOW - 3600, lastActiveAt: NOW - 600 };
+    assert.equal(elapsedMinutes(cfg({ clock: 'age' }), src, NOW), 60);
+    assert.equal(elapsedMinutes(cfg({ clock: 'stall' }), src, NOW), 10);
+    // stall with no heartbeat falls back to age
+    assert.equal(elapsedMinutes(cfg({ clock: 'stall' }), { created: NOW - 1800 }, NOW), 30);
+    assert.equal(elapsedMinutes(CFG, {}, NOW), null);
+  });
+
+  it('elapsedBadge wraps label in heat SGR + reset; formatElapsed h/m', () => {
+    assert.equal(elapsedBadge(30, CFG), `\x1b[38;2;255;255;180m30m${ANSI_RESET}`);
+    assert.equal(elapsedBadge(12, CFG), '12m');
+    assert.equal(formatElapsed(72), '1h12m');
+    assert.equal(formatElapsed(60), '1h');
+  });
+});
+
+describe('renderTicketCell — severity color placement (#1/#3)', () => {
+  it('emoji mode: id tinted, emoji left uncolored', () => {
+    const cell = renderTicketCell('working', 'ECHO-1', '', CFG);
+    assert.equal(cell, `🔨 ${C.green}ECHO-1${C.reset}`);
+  });
+
+  it('text mode: both the glyph and the id are tinted', () => {
+    const cell = renderTicketCell('wedged', 'ECHO-2', '', cfg({ glyphs: 'text' }));
+    assert.equal(cell, `${C.red}x${C.reset} ${C.red}ECHO-2${C.reset}`);
+  });
+
+  it('appends the heat badge; bare id when status is empty', () => {
+    const badge = elapsedBadge(72, CFG);
+    assert.equal(
+      renderTicketCell('working', 'ECHO-3', badge, CFG),
+      `🔨 ${C.green}ECHO-3${C.reset} ${badge}`
+    );
+    assert.equal(renderTicketCell('', 'ECHO-4', '', CFG), 'ECHO-4');
+  });
+});
+
+describe('formatSegment — envelope', () => {
+  const cellFor = (id) => renderTicketCell('working', id, '', cfg({ glyphs: 'text' }));
+
+  it('keeps the done/total ⏳ envelope with colored cells', () => {
     const line = formatSegment(
       'ECHO',
-      ['ECHO-6309'],
-      { done: 7, total: 8, pending: 0 },
-      () => ICON.working,
-      () => badge
+      ['ECHO-1', 'ECHO-2'],
+      { done: 2, total: 8, pending: 4 },
+      cellFor
     );
-    assert.equal(line, `🎼 ECHO   7/8✓  ▶1 (${ICON.working} ECHO-6309 ${badge})  ⏳0`);
+    const c1 = `${C.green}●${C.reset} ${C.green}ECHO-1${C.reset}`;
+    const c2 = `${C.green}●${C.reset} ${C.green}ECHO-2${C.reset}`;
+    assert.equal(line, `🎼 ECHO   2/8✓  ▶2 (${c1}, ${c2})  ⏳4`);
+  });
+
+  it('count-less fallback when no manifest matches', () => {
+    const line = formatSegment('ECHO', ['ECHO-1'], null, cellFor);
+    assert.equal(line, `🎼 ECHO   ▶  1  (${C.green}●${C.reset} ${C.green}ECHO-1${C.reset})`);
+  });
+});
+
+describe('readConfig + legendLine', () => {
+  it('parses env knobs with defaults', () => {
+    const saved = { ...process.env };
+    try {
+      delete process.env.MAESTRO_STATUSLINE_GLYPHS;
+      delete process.env.MAESTRO_HEAT_CLOCK;
+      const d = readConfig();
+      assert.equal(d.glyphs, 'emoji');
+      assert.equal(d.clock, 'age');
+      assert.deepEqual(d.heatBounds, [30, 45, 60, 90]);
+
+      process.env.MAESTRO_STATUSLINE_GLYPHS = 'text';
+      process.env.MAESTRO_HEAT_CLOCK = 'stall';
+      process.env.MAESTRO_HEAT_WARN_MIN = '15';
+      process.env.SILENCE_LIMIT_SEC = '120';
+      const o = readConfig();
+      assert.equal(o.glyphs, 'text');
+      assert.equal(o.clock, 'stall');
+      assert.equal(o.heatBounds[0], 15);
+      assert.equal(o.silenceLimitSec, 120);
+    } finally {
+      process.env = saved;
+    }
+  });
+
+  it('legendLine lists every status glyph', () => {
+    const emoji = legendLine(CFG);
+    assert.match(emoji, /🔨 working/);
+    assert.match(emoji, /💀 wedged/);
+    const text = legendLine(cfg({ glyphs: 'text' }));
+    assert.match(text, /● working/);
+    assert.match(text, /x wedged/);
+    assert.equal(Object.keys(STATUS).length, 11);
   });
 });

--- a/plugins/maestro/skills/lib/maestro-statusline-lib.js
+++ b/plugins/maestro/skills/lib/maestro-statusline-lib.js
@@ -1,0 +1,292 @@
+'use strict';
+/**
+ * maestro-statusline-lib.js — pure, tmux/fs-free logic for the fleet status
+ * line: env config, per-ticket status resolution, runtime-heat coloring, and
+ * cell/segment formatting. The I/O entry point (tmux + marker reads) lives in
+ * maestro-statusline.js, which re-exports this module's helpers.
+ *
+ * Configurable via env (all optional): see maestro-statusline.js header.
+ */
+const path = require('path');
+const os = require('os');
+
+const NS_RE = /^[A-Za-z0-9_-]+$/;
+
+// Basic-ANSI severity palette (universal). Orange uses a 256-color index — the
+// one non-basic code, but widely supported and gracefully approximated.
+const C = {
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  orange: '\x1b[38;5;208m',
+  dim: '\x1b[90m',
+  reset: '\x1b[0m',
+};
+const ANSI_RESET = C.reset;
+
+// One entry per status: the emoji glyph, a recolorable text glyph, and the
+// severity color used to tint the ticket id (and the text glyph in text mode).
+const STATUS = {
+  wedged: { emoji: '💀', text: 'x', color: C.red }, // dead-end killed / nudged past threshold
+  question: { emoji: '❓', text: '?', color: C.yellow }, // blocked on an operator answer
+  prBroken: { emoji: '🔴', text: '✗', color: C.red }, // PR checks failing / mergeable DIRTY
+  stuck: { emoji: '✎', text: '✎', color: C.yellow }, // text unsubmitted in the composer
+  nudge2: { emoji: '⚠⚠', text: '!!', color: C.orange }, // second auto-restart in the window
+  nudge1: { emoji: '⚠', text: '!', color: C.yellow }, // first auto-restart in the window
+  prReady: { emoji: '✅', text: '◆', color: C.green }, // PR green + mergeable — ready to merge
+  stalled: { emoji: '💤', text: '◦', color: C.dim }, // alive but no activity past silence limit
+  working: { emoji: '🔨', text: '●', color: C.green }, // active: worktree/tokens moving
+  stopped: { emoji: '⛔', text: '■', color: C.red }, // session died / blocked
+  done: { emoji: '✓', text: '✓', color: C.green },
+};
+
+// Runtime-heat hue endpoints per band (light → dark shade of one hue); band
+// boundary minutes are configurable, color endpoints fixed. 256-color ramp is
+// the fallback for terminals without 24-bit color.
+const HEAT_FROM_TO = [
+  { from: [255, 255, 180], to: [255, 214, 0] }, // yellows
+  { from: [255, 200, 120], to: [255, 120, 0] }, // oranges
+  { from: [255, 90, 90], to: [170, 0, 0] }, // reds (then pinned)
+];
+const HEAT_256_CODES = [
+  [229, 226, 220],
+  [214, 208, 202],
+  [210, 196, 160, 124],
+];
+
+function intEnv(name, def) {
+  const v = parseInt(process.env[name], 10);
+  return Number.isNaN(v) ? def : v;
+}
+
+// Snapshot all env-driven knobs once so a render pass is internally consistent.
+function readConfig() {
+  const b = [
+    intEnv('MAESTRO_HEAT_WARN_MIN', 30),
+    intEnv('MAESTRO_HEAT_HOT_MIN', 45),
+    intEnv('MAESTRO_HEAT_MAX_MIN', 60),
+    intEnv('MAESTRO_HEAT_PIN_MIN', 90),
+  ];
+  return {
+    glyphs: process.env.MAESTRO_STATUSLINE_GLYPHS === 'text' ? 'text' : 'emoji',
+    clock: process.env.MAESTRO_HEAT_CLOCK === 'stall' ? 'stall' : 'age',
+    truecolor: /^(truecolor|24bit)$/i.test(process.env.COLORTERM || ''),
+    silenceLimitSec: intEnv('SILENCE_LIMIT_SEC', 300),
+    nudgeWindowSec: intEnv('MAESTRO_NUDGE_WINDOW_SEC', 30 * 60),
+    overlayFreshSec: intEnv('MAESTRO_OVERLAY_FRESH_SEC', 300),
+    stuckSanitySec: intEnv('MAESTRO_STUCK_SANITY_SEC', 12 * 3600),
+    heatBounds: b,
+  };
+}
+
+// Per-namespace stores (mirror maestro-conduct/namespace.js). STATE_DIR /
+// MAESTRO_SESSION_DIR override; MAESTRO_NS nests under a subdir.
+function nsDir(envOverride, ...base) {
+  if (process.env[envOverride]) return process.env[envOverride];
+  const root = path.join(os.homedir(), ...base);
+  const ns = (process.env.MAESTRO_NS || '').trim();
+  return NS_RE.test(ns) ? path.join(root, ns) : root;
+}
+const markerDir = () => nsDir('STATE_DIR', '.cache', 'maestro-conduct');
+const sessionsDir = () => nsDir('MAESTRO_SESSION_DIR', '.cache', 'maestro', 'sessions');
+
+// `ts` is a marker timestamp (epoch sec); fresh within `win` seconds of `now`.
+function freshTs(ts, win, now) {
+  return typeof ts === 'number' && ts > 0 && now - ts <= win;
+}
+
+// ── runtime heat ────────────────────────────────────────────────────────────
+
+function heatBandsFor(cfg, endpoints) {
+  const b = cfg.heatBounds;
+  return endpoints.map((e, i) => ({ start: b[i], end: b[i + 1], e }));
+}
+
+// Pick the band covering `min` (or the last band, saturated, once past it).
+function heatBand(bands, min) {
+  const hit = bands.find((b) => min >= b.start && min < b.end);
+  if (hit) return { band: hit, t: (min - hit.start) / (hit.end - hit.start) };
+  return { band: bands[bands.length - 1], t: 1 }; // past the last band → deepest
+}
+
+function lerp(a, b, t) {
+  return Math.round(a + (b - a) * t);
+}
+
+// ANSI SGR prefix for the runtime heat at `min` minutes, or '' below the floor.
+function heatAnsi(min, cfg) {
+  if (typeof min !== 'number' || min < cfg.heatBounds[0]) return '';
+  if (cfg.truecolor) {
+    const { band, t } = heatBand(heatBandsFor(cfg, HEAT_FROM_TO), min);
+    const [r, g, b] = [0, 1, 2].map((i) => lerp(band.e.from[i], band.e.to[i], t));
+    return `\x1b[38;2;${r};${g};${b}m`;
+  }
+  const { band, t } = heatBand(heatBandsFor(cfg, HEAT_256_CODES), min);
+  const idx = Math.min(band.e.length - 1, Math.floor(t * band.e.length));
+  return `\x1b[38;5;${band.e[idx]}m`;
+}
+
+// "33m" / "1h02m" — compact elapsed label.
+function formatElapsed(min) {
+  const m = Math.max(0, Math.floor(min));
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  const rem = m % 60;
+  return rem ? `${h}h${String(rem).padStart(2, '0')}m` : `${h}h`;
+}
+
+// Colored elapsed badge (label + heat SGR + reset), or the bare label below the
+// heat floor. Pure: caller injects `min` and cfg so it is testable.
+function elapsedBadge(min, cfg) {
+  const label = formatElapsed(min);
+  const color = heatAnsi(min, cfg);
+  return color ? `${color}${label}${ANSI_RESET}` : label;
+}
+
+// Elapsed minutes the heat badge should time: session age, or (in stall mode)
+// time since last activity, falling back to age when there is no heartbeat.
+// Returns null when no clock source is available.
+function elapsedMinutes(cfg, src, nowSec) {
+  const stall =
+    cfg.clock === 'stall' && typeof src.lastActiveAt === 'number' && src.lastActiveAt > 0;
+  const base = stall ? src.lastActiveAt : src.created;
+  if (typeof base !== 'number' || base <= 0) return null;
+  return (nowSec - base) / 60;
+}
+
+// ── status resolution ───────────────────────────────────────────────────────
+
+// Auto-restart ("nudge") escalation level — restarts[] grows once per restart;
+// 0 when the last restart is outside the window (stale).
+function nudgeLevelOf(m, cfg, nowSec) {
+  const restarts =
+    m.restartLoop && Array.isArray(m.restartLoop.restarts) ? m.restartLoop.restarts : [];
+  if (!restarts.length) return 0;
+  const last = restarts[restarts.length - 1];
+  return freshTs(last, cfg.nudgeWindowSec, nowSec) ? restarts.length : 0;
+}
+
+// Stuck-input is presence-based: the detector CLEARS the marker the moment the
+// composer clears (detectors/stuck-input.js), so its presence means "currently
+// stuck". Only a generous sanity cap guards against a marker orphaned by a dead
+// conductor — firstSeenAt does not refresh, so a short freshness gate would hide
+// a genuinely long-stuck composer.
+function stuckActive(mk, cfg, nowSec) {
+  return Boolean(mk) && freshTs(mk.firstSeenAt, cfg.stuckSanitySec, nowSec);
+}
+
+// Ordered marker rules — first matching predicate wins, so each agent shows
+// exactly one status, highest-severity-first. Each predicate is its own function
+// (ctx = { m, nowSec, nudge, cfg }) so the dispatcher stays flat. PR state is
+// persisted (lastEmittedAt marks the last TRANSITION), so trust lastState.
+const STATUS_RULES = [
+  {
+    key: 'wedged',
+    test: (c) =>
+      (c.m.deadEnd &&
+        c.m.deadEnd.killed &&
+        freshTs(c.m.deadEnd.freedAt, c.cfg.nudgeWindowSec, c.nowSec)) ||
+      c.nudge >= 3,
+  },
+  {
+    key: 'question',
+    test: (c) =>
+      c.m.question &&
+      freshTs(c.m.question.lastAlertAt || c.m.question.startedAt, c.cfg.overlayFreshSec, c.nowSec),
+  },
+  { key: 'prBroken', test: (c) => c.m.prStatus && c.m.prStatus.lastState === 'pr-broken' },
+  { key: 'stuck', test: (c) => stuckActive(c.m.stuckInput, c.cfg, c.nowSec) },
+  { key: 'nudge2', test: (c) => c.nudge === 2 },
+  { key: 'nudge1', test: (c) => c.nudge === 1 },
+  { key: 'prReady', test: (c) => c.m.prStatus && c.m.prStatus.lastState === 'pr-ready' },
+];
+
+// Working vs stalled from the silence heartbeat (lastActiveAt bumps whenever the
+// pane hash or token count moves). '' when there is no heartbeat marker.
+function livenessStatus(m, cfg, nowSec) {
+  const s = m.silence;
+  if (!s || typeof s.lastActiveAt !== 'number' || s.lastActiveAt <= 0) return '';
+  return nowSec - s.lastActiveAt >= cfg.silenceLimitSec ? 'stalled' : 'working';
+}
+
+// Manifest-status fallback when no live marker has an opinion yet.
+function statusFallback(status) {
+  if (status === 'awaiting-merge') return 'prReady';
+  if (status === 'stopped' || status === 'blocked') return 'stopped';
+  if (status === 'done') return 'done';
+  return 'working'; // live, in-progress, no signal yet
+}
+
+/**
+ * Map a ticket's markers + manifest status to a single STATUS key (or '').
+ * Highest-severity-first so one agent shows exactly one status. Pure: all
+ * time-dependence flows through `nowSec` so it is deterministic under test.
+ */
+function resolveTicketStatus(markers, status, nowSec, cfg) {
+  const m = markers || {};
+  const ctx = { m, nowSec, cfg, nudge: nudgeLevelOf(m, cfg, nowSec) };
+  for (const rule of STATUS_RULES) {
+    if (rule.test(ctx)) return rule.key;
+  }
+  return livenessStatus(m, cfg, nowSec) || statusFallback(status);
+}
+
+// ── rendering ───────────────────────────────────────────────────────────────
+
+function tint(color, s) {
+  return color ? `${color}${s}${C.reset}` : s;
+}
+
+// One ticket cell: severity-colored glyph + id (+ heat badge). Emoji glyphs are
+// font-colored and ignore ANSI, so in emoji mode only the id is tinted; in text
+// mode the (recolorable) glyph is tinted too.
+function renderTicketCell(statusKey, id, badge, cfg) {
+  const s = statusKey ? STATUS[statusKey] : null;
+  const color = s ? s.color : '';
+  const glyph = s ? (cfg.glyphs === 'text' ? s.text : s.emoji) : '';
+  const shownGlyph = cfg.glyphs === 'text' ? tint(color, glyph) : glyph;
+  const head = glyph ? `${shownGlyph} ${tint(color, id)}` : tint(color, id);
+  return badge ? `${head} ${badge}` : head;
+}
+
+/**
+ * Render one orchestration's status-line segment. `cellFor` maps a ticket id to
+ * its fully-rendered cell (glyph + id + badge). Injected so tests exercise the
+ * envelope formatting without touching tmux or the marker store.
+ */
+function formatSegment(prefix, tickets, info, cellFor) {
+  const labelled = tickets.map(cellFor).join(', ');
+  if (info) {
+    // Lead with progress (done/total), then active agents + pending queue.
+    return `🎼 ${prefix}   ${info.done}/${info.total}✓  ▶${tickets.length} (${labelled})  ⏳${info.pending}`;
+  }
+  return `🎼 ${prefix}   ▶  ${tickets.length}  (${labelled})`;
+}
+
+// One-line glyph legend for `--legend`.
+function legendLine(cfg) {
+  return Object.entries(STATUS)
+    .map(([k, s]) => `${cfg.glyphs === 'text' ? s.text : s.emoji} ${k}`)
+    .join('   ');
+}
+
+module.exports = {
+  C,
+  STATUS,
+  ANSI_RESET,
+  readConfig,
+  markerDir,
+  sessionsDir,
+  freshTs,
+  heatAnsi,
+  formatElapsed,
+  elapsedBadge,
+  elapsedMinutes,
+  nudgeLevelOf,
+  stuckActive,
+  livenessStatus,
+  resolveTicketStatus,
+  renderTicketCell,
+  formatSegment,
+  legendLine,
+};

--- a/plugins/maestro/skills/lib/maestro-statusline.js
+++ b/plugins/maestro/skills/lib/maestro-statusline.js
@@ -8,120 +8,45 @@
  * session manifest). Scoped to the launching Claude session via a marker the
  * conductor writes (~/.cache/maestro/active/<session>.json = {session, prefix}),
  * so each orchestrator session shows only the fleet it launched — never other
- * chats. No global pin (which only one session could ever win).
+ * chats.
  *
- * Per-agent status: each live ticket is prefixed with a glyph derived from the
- * conductor's per-ticket markers under ~/.cache/maestro-conduct/ (question,
- * silence heartbeat, restart-loop nudges, dead-end, stuck-input, pr-status), so
- * the operator can see at a glance which agent is working, asking, nudged, or
- * dead — without opening a single pane. Pure/exported helpers keep the icon
- * logic unit-testable without tmux or a live conductor.
+ * Each live ticket carries a severity-colored status glyph (from the conductor's
+ * per-ticket markers) plus a runtime-heat badge, so the operator sees which
+ * agent is working, asking, nudged, or dead — without opening a pane. The pure
+ * status/heat/format logic lives in maestro-statusline-lib.js (unit-tested);
+ * this file is the tmux + marker-store I/O and wiring.
+ *
+ * Configurable via env (all optional):
+ *   MAESTRO_STATUSLINE_GLYPHS  emoji|text   glyph set (default emoji)
+ *   MAESTRO_HEAT_CLOCK         age|stall    what the heat badge times (default age)
+ *   MAESTRO_HEAT_WARN_MIN/HOT_MIN/MAX_MIN/PIN_MIN  heat band boundaries (30/45/60/90)
+ *   SILENCE_LIMIT_SEC          working→stalled threshold (default 300, shared w/ conductor)
+ *   MAESTRO_NUDGE_WINDOW_SEC   restart/dead-end recency (default 1800)
+ *   MAESTRO_OVERLAY_FRESH_SEC  question re-alert freshness (default 300)
+ *   MAESTRO_STUCK_SANITY_SEC   stuck-input max age guard (default 43200)
+ *   COLORTERM=truecolor        enables the 24-bit heat gradient (else 256-color)
+ *   MAESTRO_NS                 per-namespace marker/manifest store
+ * Run with `--legend` to print the glyph legend and exit.
  */
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execFileSync } = require('child_process');
+const lib = require('./maestro-statusline-lib');
+
+const {
+  readConfig,
+  markerDir,
+  sessionsDir,
+  resolveTicketStatus,
+  elapsedMinutes,
+  elapsedBadge,
+  renderTicketCell,
+  formatSegment,
+  legendLine,
+} = lib;
 
 const ACTIVE_DIR = path.join(os.homedir(), '.cache', 'maestro', 'active');
-const SESSIONS_DIR = path.join(os.homedir(), '.cache', 'maestro', 'sessions');
-
-// Per-ticket conductor markers live under the same store state.js writes to.
-// Mirror maestro-conduct/namespace.stateDir() so a MAESTRO_NS run reads its own
-// per-namespace markers, and STATE_DIR (tests) always wins.
-const NS_RE = /^[A-Za-z0-9_-]+$/;
-function markerDir() {
-  if (process.env.STATE_DIR) return process.env.STATE_DIR;
-  const base = path.join(os.homedir(), '.cache', 'maestro-conduct');
-  const ns = (process.env.MAESTRO_NS || '').trim();
-  return NS_RE.test(ns) ? path.join(base, ns) : base;
-}
-
-// Freshness windows (seconds). Markers persist on disk after the condition
-// clears, so a timestamp gate keeps a stale question/heartbeat from rendering a
-// false status. Defaults mirror the conductor's own thresholds.
-const OVERLAY_FRESH_SEC = 300; // question / stuck-input re-alert cadence
-const NUDGE_WINDOW_SEC = 30 * 60; // restart-loop / dead-end recency (RESTART_WINDOW_MIN)
-const SILENCE_LIMIT_SEC = 300; // stall threshold (silence DEFAULT_SILENCE_LIMIT_SEC)
-
-// Single glyph per ticket, highest-severity-first (see resolveTicketIcon).
-const ICON = {
-  wedged: '💀', // dead-end killed, or nudged past the restart-loop threshold
-  question: '❓', // blocked on an operator answer
-  prBroken: '🔴', // PR checks failing / mergeable DIRTY
-  stuck: '✎', // text sitting unsubmitted in the composer
-  nudge2: '⚠⚠', // second auto-restart in the window
-  nudge1: '⚠', // first auto-restart in the window
-  prReady: '✅', // PR green + mergeable — ready to merge
-  stalled: '💤', // alive session but no activity past the silence limit
-  working: '🔨', // active: worktree/tokens moving
-  stopped: '⛔', // session died / blocked
-  done: '✓',
-};
-
-const ANSI_RESET = '\x1b[0m';
-
-// Session-runtime "heat": how long an agent has been running, encoded as a
-// colored elapsed badge. Below HEAT_MIN_MIN it stays the terminal default
-// (calm); past it the badge walks through SHADES OF ONE HUE, then jumps hue at
-// each band boundary — yellow deepens, then orange deepens, then red deepens.
-// Each band lerps between a light and a dark shade of that hue.
-const HEAT_MIN_MIN = 30;
-const HEAT_BANDS = [
-  { start: 30, end: 45, from: [255, 255, 180], to: [255, 214, 0] }, // yellows
-  { start: 45, end: 60, from: [255, 200, 120], to: [255, 120, 0] }, // oranges
-  { start: 60, end: 90, from: [255, 90, 90], to: [170, 0, 0] }, // reds (then pinned)
-];
-// Discrete 256-color ramp per band for terminals without 24-bit color.
-const HEAT_256 = [
-  { start: 30, end: 45, codes: [229, 226, 220] },
-  { start: 45, end: 60, codes: [214, 208, 202] },
-  { start: 60, end: 90, codes: [210, 196, 160, 124] },
-];
-
-function terminalTruecolor() {
-  return /^(truecolor|24bit)$/i.test(process.env.COLORTERM || '');
-}
-
-// Pick the band covering `min` (or the last band, saturated, once past it).
-function heatBand(bands, min) {
-  const hit = bands.find((b) => min >= b.start && min < b.end);
-  if (hit) return { band: hit, t: (min - hit.start) / (hit.end - hit.start) };
-  return { band: bands[bands.length - 1], t: 1 }; // past the last band → deepest
-}
-
-function lerp(a, b, t) {
-  return Math.round(a + (b - a) * t);
-}
-
-// ANSI SGR prefix for the runtime heat at `min` minutes, or '' below the floor.
-function heatAnsi(min, truecolor) {
-  if (typeof min !== 'number' || min < HEAT_MIN_MIN) return '';
-  if (truecolor) {
-    const { band, t } = heatBand(HEAT_BANDS, min);
-    const [r, g, b] = [0, 1, 2].map((i) => lerp(band.from[i], band.to[i], t));
-    return `\x1b[38;2;${r};${g};${b}m`;
-  }
-  const { band, t } = heatBand(HEAT_256, min);
-  const idx = Math.min(band.codes.length - 1, Math.floor(t * band.codes.length));
-  return `\x1b[38;5;${band.codes[idx]}m`;
-}
-
-// "33m" / "1h02m" — compact elapsed label.
-function formatElapsed(min) {
-  const m = Math.max(0, Math.floor(min));
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  const rem = m % 60;
-  return rem ? `${h}h${String(rem).padStart(2, '0')}m` : `${h}h`;
-}
-
-// Colored elapsed badge (label + heat SGR + reset), or the bare label below the
-// heat floor. Pure: caller injects `min` and truecolor so it is testable.
-function elapsedBadge(min, truecolor) {
-  const label = formatElapsed(min);
-  const color = heatAnsi(min, truecolor);
-  return color ? `${color}${label}${ANSI_RESET}` : label;
-}
 
 // The Claude session Claude runs this statusLine in (session_id on stdin). Read
 // lazily so `require()`ing this module (tests) never blocks on fd 0.
@@ -155,9 +80,9 @@ function myOrchestrations(session) {
 }
 
 // Live agent tickets for a prefix, from tmux `<prefix>-<ticket>-work` sessions
-// (execFileSync = no shell). Returns { ids: sorted ticket ids, createdById:
-// id -> tmux session_created epoch (survives auto-restarts, which reuse the
-// session) } so the renderer can heat-color each agent by how long it has run.
+// (execFileSync = no shell). An optional "<ns>/" session-name segment (MAESTRO_NS)
+// is tolerated and stripped. Returns { ids: sorted ticket ids, createdById: id ->
+// tmux session_created epoch (survives auto-restarts, which reuse the session) }.
 // Helper -dev/-listen sessions are ignored.
 function liveTickets(prefix) {
   let out = '';
@@ -171,7 +96,7 @@ function liveTickets(prefix) {
     return { ids: [], createdById: {} };
   }
   const esc = String(prefix).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const re = new RegExp('^(' + esc + '-.+)-work$');
+  const re = new RegExp('^(?:[A-Za-z0-9_-]+/)?(' + esc + '-.+)-work$');
   const seen = new Set();
   const createdById = {};
   for (const line of out.split('\n')) {
@@ -189,16 +114,17 @@ function liveTickets(prefix) {
 // tmux tickets. Returns {total, done, pending, statusById} or null.
 function manifestInfo(liveIds) {
   if (!liveIds.length) return null;
+  const dir = sessionsDir();
   let files = [];
   try {
-    files = fs.readdirSync(SESSIONS_DIR).filter((f) => f.endsWith('.json'));
+    files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
   } catch {
     return null;
   }
   const liveSet = new Set(liveIds);
   for (const f of files) {
     try {
-      const mf = JSON.parse(fs.readFileSync(path.join(SESSIONS_DIR, f), 'utf8'));
+      const mf = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'));
       const tasks = Array.isArray(mf.tasks) ? mf.tasks : [];
       if (!tasks.some((t) => liveSet.has(t.id))) continue;
       const statusById = {};
@@ -245,145 +171,45 @@ function readTicketMarkers(id, dir) {
   };
 }
 
-// `ts` is a marker timestamp (epoch sec); fresh within `win` seconds of `now`.
-function freshTs(ts, win, now) {
-  return typeof ts === 'number' && ts > 0 && now - ts <= win;
-}
-
-// Auto-restart ("nudge") escalation level — restarts[] grows once per restart;
-// 0 when the last restart is outside the window (stale).
-function nudgeLevelOf(m, nowSec) {
-  const restarts =
-    m.restartLoop && Array.isArray(m.restartLoop.restarts) ? m.restartLoop.restarts : [];
-  if (!restarts.length) return 0;
-  const last = restarts[restarts.length - 1];
-  return freshTs(last, NUDGE_WINDOW_SEC, nowSec) ? restarts.length : 0;
-}
-
-// Ordered marker rules — first matching predicate wins, so each agent shows
-// exactly one glyph, highest-severity-first. Each predicate is its own function
-// (ctx = { m, nowSec, nudge }) so the dispatcher stays flat. PR state is
-// persisted (lastEmittedAt marks the last TRANSITION), so trust lastState
-// directly rather than gating it on freshness.
-const ICON_RULES = [
-  {
-    icon: ICON.wedged,
-    test: (c) =>
-      (c.m.deadEnd &&
-        c.m.deadEnd.killed &&
-        freshTs(c.m.deadEnd.freedAt, NUDGE_WINDOW_SEC, c.nowSec)) ||
-      c.nudge >= 3,
-  },
-  {
-    icon: ICON.question,
-    test: (c) =>
-      c.m.question &&
-      freshTs(c.m.question.lastAlertAt || c.m.question.startedAt, OVERLAY_FRESH_SEC, c.nowSec),
-  },
-  { icon: ICON.prBroken, test: (c) => c.m.prStatus && c.m.prStatus.lastState === 'pr-broken' },
-  {
-    icon: ICON.stuck,
-    test: (c) => c.m.stuckInput && freshTs(c.m.stuckInput.firstSeenAt, OVERLAY_FRESH_SEC, c.nowSec),
-  },
-  { icon: ICON.nudge2, test: (c) => c.nudge === 2 },
-  { icon: ICON.nudge1, test: (c) => c.nudge === 1 },
-  { icon: ICON.prReady, test: (c) => c.m.prStatus && c.m.prStatus.lastState === 'pr-ready' },
-];
-
-// Working vs stalled from the silence heartbeat (lastActiveAt bumps whenever the
-// pane hash or token count moves). '' when there is no heartbeat marker.
-function livenessIcon(m, nowSec) {
-  const s = m.silence;
-  if (!s || typeof s.lastActiveAt !== 'number' || s.lastActiveAt <= 0) return '';
-  return nowSec - s.lastActiveAt >= SILENCE_LIMIT_SEC ? ICON.stalled : ICON.working;
-}
-
-// Manifest-status fallback when no live marker has an opinion yet.
-function statusIcon(status) {
-  if (status === 'awaiting-merge') return ICON.prReady;
-  if (status === 'stopped' || status === 'blocked') return ICON.stopped;
-  if (status === 'done') return ICON.done;
-  return ICON.working; // live, in-progress, no signal yet
-}
-
-/**
- * Map a ticket's markers + manifest status to a single status glyph.
- * Highest-severity-first so one agent shows exactly one icon. Pure: all
- * time-dependence flows through `nowSec` so it is deterministic under test.
- */
-function resolveTicketIcon(markers, status, nowSec) {
-  const m = markers || {};
-  const ctx = { m, nowSec, nudge: nudgeLevelOf(m, nowSec) };
-  for (const rule of ICON_RULES) {
-    if (rule.test(ctx)) return rule.icon;
-  }
-  return livenessIcon(m, nowSec) || statusIcon(status);
-}
-
-/**
- * Render one orchestration's status-line segment. `iconFor` maps a ticket id to
- * its status glyph (or '' for none); `badgeFor` maps it to a colored runtime
- * badge (or '' for none). Both injected so tests exercise the formatting
- * without touching tmux or the marker store.
- */
-function formatSegment(prefix, tickets, info, iconFor, badgeFor = () => '') {
-  const labelled = tickets
-    .map((id) => {
-      const icon = iconFor(id);
-      const badge = badgeFor(id);
-      const left = icon ? `${icon} ${id}` : id;
-      return badge ? `${left} ${badge}` : left;
-    })
-    .join(', ');
-  if (info) {
-    // Lead with progress (done/total), then active agents + pending queue.
-    return `🎼 ${prefix}   ${info.done}/${info.total}✓  ▶${tickets.length} (${labelled})  ⏳${info.pending}`;
-  }
-  return `🎼 ${prefix}   ▶  ${tickets.length}  (${labelled})`;
-}
-
-function segment(m) {
+function segment(m, cfg, nowSec) {
   const { ids, createdById } = liveTickets(m.prefix);
   if (!ids.length) return null;
   const info = manifestInfo(ids);
   const dir = markerDir();
-  const nowSec = Math.floor(Date.now() / 1000);
   const statusById = (info && info.statusById) || {};
-  const truecolor = terminalTruecolor();
-  const iconFor = (id) => resolveTicketIcon(readTicketMarkers(id, dir), statusById[id], nowSec);
-  const badgeFor = (id) => {
-    const created = createdById[id];
-    if (!created) return '';
-    return elapsedBadge((nowSec - created) / 60, truecolor);
+  const cellFor = (id) => {
+    const markers = readTicketMarkers(id, dir);
+    const key = resolveTicketStatus(markers, statusById[id], nowSec, cfg);
+    const lastActiveAt = markers.silence && markers.silence.lastActiveAt;
+    const min = elapsedMinutes(cfg, { created: createdById[id], lastActiveAt }, nowSec);
+    const badge = min === null ? '' : elapsedBadge(min, cfg);
+    return renderTicketCell(key, id, badge, cfg);
   };
-  return formatSegment(m.prefix, ids, info, iconFor, badgeFor);
+  return formatSegment(m.prefix, ids, info, cellFor);
 }
 
 function render() {
   const session = readSession();
   if (!session) return '';
-  return myOrchestrations(session).map(segment).filter(Boolean).join('      |      ');
+  const cfg = readConfig();
+  const nowSec = Math.floor(Date.now() / 1000);
+  return myOrchestrations(session)
+    .map((m) => segment(m, cfg, nowSec))
+    .filter(Boolean)
+    .join('      |      ');
 }
 
 if (require.main === module) {
-  process.stdout.write(render());
+  if (process.argv.includes('--legend')) {
+    process.stdout.write(legendLine(readConfig()) + '\n');
+  } else {
+    process.stdout.write(render());
+  }
 }
 
 module.exports = {
-  ICON,
-  OVERLAY_FRESH_SEC,
-  NUDGE_WINDOW_SEC,
-  SILENCE_LIMIT_SEC,
-  HEAT_MIN_MIN,
-  HEAT_BANDS,
-  ANSI_RESET,
-  markerDir,
+  ...lib,
   manifestInfo,
   readTicketMarkers,
-  resolveTicketIcon,
-  heatAnsi,
-  formatElapsed,
-  elapsedBadge,
-  formatSegment,
   render,
 };


### PR DESCRIPTION
## Summary

Makes the maestro fleet status line configurable and fills the gaps left after the initial per-agent-status + heat-badge work (#682). Addresses 7 improvements in one pass.

No linked issue — follow-on polish to the maestro statusline.

## The 7

1. **Severity color on the ticket id** — emoji glyphs are font-colored and ignore ANSI, so the *id* is tinted by state instead: green working, yellow question/nudge, orange nudge2, red wedged/pr-broken, dim stalled.
2. **Configurable heat clock** — `MAESTRO_HEAT_CLOCK=age|stall` (default `age`). Stall mode times since last activity (`silence.lastActiveAt`) so a long *productive* run doesn't read red; falls back to age when there's no heartbeat.
3. **Text-glyph mode** — `MAESTRO_STATUSLINE_GLYPHS=text` swaps emoji for ANSI-colored symbols (`● ! !! x ? ✗ ◆ ◦ ■ ✓`) so both glyph *and* id carry color.
4. **`✎` stuck-input is now presence-based** — the detector clears the marker the instant the composer clears (`detectors/stuck-input.js:61`), so presence = currently stuck. The old 5-min `firstSeenAt` gate hid genuinely long-stuck composers; now only a generous sanity cap (`MAESTRO_STUCK_SANITY_SEC`, 12h) guards orphaned markers.
5. **`MAESTRO_NS` aware** — `sessionsDir()` nests per-namespace and `liveTickets()` tolerates/strips a `<ns>/` session-name segment (`markerDir()` already did). A namespaced conductor's bar now renders.
6. **Env-overridable thresholds** — `SILENCE_LIMIT_SEC` (shared with the conductor), `MAESTRO_NUDGE_WINDOW_SEC`, `MAESTRO_OVERLAY_FRESH_SEC`, `MAESTRO_STUCK_SANITY_SEC`, and the heat band boundaries (`MAESTRO_HEAT_WARN_MIN/HOT_MIN/MAX_MIN/PIN_MIN`).
7. **`--legend` flag** — prints the glyph vocabulary (honors glyph mode).

## Structure

Pure logic — env config, status resolution, runtime heat, cell/segment formatting, legend — extracted to **`maestro-statusline-lib.js`** (unit-tested, no tmux/fs). The entry file `maestro-statusline.js` keeps the tmux + marker-store I/O and re-exports the lib. This also kept both files under the 400-line gate and dropped `renderTicketCell` under the complexity gate.

## Testing

- **23 `node:test` cases**: status severity ordering + freshness gating, nudge escalation, presence-based stuck-input (flags at 40 min, drops past the sanity cap), heat shade-walk + hue jumps + 256 fallback + configurable boundaries, age-vs-stall clock, emoji-vs-text color placement, segment envelope, `readConfig` env parsing, and `legendLine`.
- Quality gate (complexity / max-lines / duplicate-blocks) clean; biome clean.
- Smoke-tested `--legend` (both modes), colored cells (raw ANSI verified), and the no-session path (empty, no crash).

## Notes

- Emoji still can't be recolored (font-rendered) — that's why color lands on the id in emoji mode; text mode gives full glyph color.
- Live bar reflects this after the plugin updates to the new version (registered path is version-resolved).
