### PR TITLE
feat(work): non-blocking update-check banner on /work invocation (GH-314)

### DIFF
--- a/plugins/work/hooks/__tests__/work-hook-update-banner.integration.test.js
+++ b/plugins/work/hooks/__tests__/work-hook-update-banner.integration.test.js
@@ -1,0 +1,163 @@
+/**
+ * Spawned-hook integration tests for the update-check banner wiring (GH-314, Task 2).
+ *
+ * These drive the REAL work-hook.js process via child_process.spawn (mirroring
+ * work-hook-injection.test.js) for a "/work GH-1" prompt and assert that the
+ * update banner is prepended to the orchestrator plan without ever blocking the
+ * plan or changing the exit code:
+ *
+ *   - update-available source  → stdout contains the banner AND the plan section, exit 0
+ *   - unreachable/erroring src  → stdout contains the plan section, NO banner, exit 0
+ *
+ * The test supplies the version source to the hook through env-var injection
+ * seams (no real network):
+ *   WORK_UPDATE_CHECK_TEST_LATEST=<X.Y.Z>  → inject a fetch shim resolving to that version
+ *   WORK_UPDATE_CHECK_TEST_FAIL=1          → inject a fetch shim that throws (offline)
+ *
+ * Run with: node --test hooks/__tests__/work-hook-update-banner.integration.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const HOOK_PATH = path.join(__dirname, '..', 'work-hook.js');
+
+// Stable substrings.
+const PLAN_MARKER = 'WORK2 ORCHESTRATOR PLAN';
+const BANNER_MARKER = 'new version of work-workflow is available';
+
+let tmpRoot;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'work-hook-banner-'));
+});
+
+afterEach(() => {
+  if (tmpRoot) {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    tmpRoot = undefined;
+  }
+});
+
+/**
+ * Spawn the real hook for a prompt with isolated cache/marker dirs so the
+ * 24h cache and per-session marker never bleed between runs.
+ */
+function runHook(userPrompt, extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const env = {
+      ...process.env,
+      CLAUDE_USER_PROMPT: userPrompt,
+      // Isolate every persistence seam to this run's temp dir.
+      WORK_UPDATE_CHECK_CACHE_DIR: path.join(tmpRoot, 'cache'),
+      WORK_UPDATE_CHECK_MARKER_DIR: path.join(tmpRoot, 'marker'),
+      ...extraEnv,
+    };
+    // Never let a globally-set opt-out suppress the check under test.
+    delete env.WORK_DISABLE_UPDATE_CHECK;
+
+    const proc = spawn(process.execPath, [HOOK_PATH], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
+    });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    proc.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+    proc.on('close', (code) => resolve({ code, stdout, stderr }));
+    proc.on('error', reject);
+    proc.stdin.end();
+  });
+}
+
+describe('work-hook update banner integration', () => {
+  it('emits the banner AND the plan section and exits 0 when an update is available', async () => {
+    const { code, stdout } = await runHook('/work GH-1', {
+      WORK_UPDATE_CHECK_TEST_LATEST: '3.99.0',
+    });
+
+    assert.strictEqual(code, 0, 'hook must exit 0 even with the banner');
+    assert.ok(
+      stdout.includes(BANNER_MARKER),
+      `stdout should contain the update banner, got:\n${stdout}`
+    );
+    assert.ok(
+      stdout.includes('3.99.0'),
+      `stdout should name the injected latest version 3.99.0, got:\n${stdout}`
+    );
+    assert.ok(
+      stdout.includes(PLAN_MARKER),
+      `stdout should still contain the orchestrator plan section, got:\n${stdout}`
+    );
+  });
+
+  it('de-dups PER SESSION: two distinct CLAUDE_SESSION_ID values each re-show the banner via separate marker files', async () => {
+    // Both runs share the SAME marker dir (default runHook isolation) but differ
+    // only in CLAUDE_SESSION_ID. A correct per-session implementation derives
+    // opts.sessionId from CLAUDE_SESSION_ID, so each session writes its OWN
+    // marker file and the banner re-shows for the second, distinct session.
+    const first = await runHook('/work GH-1', {
+      WORK_UPDATE_CHECK_TEST_LATEST: '3.99.0',
+      CLAUDE_SESSION_ID: 'session-alpha',
+    });
+    assert.strictEqual(first.code, 0);
+    assert.ok(
+      first.stdout.includes(BANNER_MARKER),
+      `first session should show the banner, got:\n${first.stdout}`
+    );
+
+    const second = await runHook('/work GH-1', {
+      WORK_UPDATE_CHECK_TEST_LATEST: '3.99.0',
+      CLAUDE_SESSION_ID: 'session-beta',
+    });
+    assert.strictEqual(second.code, 0);
+    assert.ok(
+      second.stdout.includes(BANNER_MARKER),
+      `second, DISTINCT session should re-show the banner (per-session de-dup), got:\n${second.stdout}`
+    );
+
+    // Two distinct sessions must produce two distinct marker files.
+    const markerDir = path.join(tmpRoot, 'marker');
+    const markers = fs
+      .readdirSync(markerDir)
+      .filter((f) => f.startsWith('work-update-check.') && f.endsWith('.marker'));
+    assert.ok(
+      markers.includes('work-update-check.session-alpha.marker'),
+      `expected a per-session marker for session-alpha, got: ${markers.join(', ')}`
+    );
+    assert.ok(
+      markers.includes('work-update-check.session-beta.marker'),
+      `expected a per-session marker for session-beta, got: ${markers.join(', ')}`
+    );
+    assert.ok(
+      !markers.includes('work-update-check.default.marker'),
+      `marker must be keyed by CLAUDE_SESSION_ID, not the shared 'default' fallback, got: ${markers.join(', ')}`
+    );
+  });
+
+  it('emits the plan section with NO banner and exits 0 when the source is unreachable', async () => {
+    const { code, stdout } = await runHook('/work GH-1', {
+      WORK_UPDATE_CHECK_TEST_FAIL: '1',
+    });
+
+    assert.strictEqual(code, 0, 'hook must exit 0 when the version source is unreachable');
+    assert.ok(
+      stdout.includes(PLAN_MARKER),
+      `stdout should still contain the orchestrator plan section, got:\n${stdout}`
+    );
+    assert.ok(
+      !stdout.includes(BANNER_MARKER),
+      `stdout should NOT contain the update banner when offline, got:\n${stdout}`
+    );
+  });
+});

--- a/plugins/work/hooks/work-hook.js
+++ b/plugins/work/hooks/work-hook.js
@@ -30,6 +30,9 @@ const { resolvePluginRootHonouringEnv } = require(
 const { getRuntime } = require(
   path.join(__dirname, '..', 'scripts', 'workflows', 'lib', 'runtime')
 );
+const { maybeUpdateBanner } = require(
+  path.join(__dirname, '..', 'scripts', 'workflows', 'work', 'lib', 'update-check')
+);
 
 // ORCHESTRATOR_PATH below is derived from PLUGIN_ROOT, so the user's
 // CLAUDE_PLUGIN_ROOT must be honoured verbatim when probing lands on an
@@ -122,7 +125,54 @@ function logPlanAction(plan) {
   }
 }
 
-function main() {
+// Build maybeUpdateBanner() options from the environment. The default path
+// injects nothing (real cache + real HTTPS fetch). Test-only env seams let a
+// spawned-hook integration test supply a deterministic version source without
+// touching the network:
+//   WORK_UPDATE_CHECK_TEST_LATEST=<X.Y.Z> → fetch shim resolving that version
+//   WORK_UPDATE_CHECK_TEST_FAIL=1         → fetch shim that throws (offline)
+//   WORK_UPDATE_CHECK_MARKER_DIR=<dir>    → isolate the per-session marker dir
+function buildBannerOpts() {
+  const opts = {};
+  // De-dup the banner PER Claude session, not per machine. Claude Code exposes
+  // the session identifier to hooks via CLAUDE_SESSION_ID; thread it through so
+  // each session gets its own marker file. When absent, update-check.js keeps
+  // its `|| 'default'` safety net (shared marker) rather than crashing.
+  if (process.env.CLAUDE_SESSION_ID) {
+    opts.sessionId = process.env.CLAUDE_SESSION_ID;
+  }
+  if (process.env.WORK_UPDATE_CHECK_MARKER_DIR) {
+    opts.markerDir = process.env.WORK_UPDATE_CHECK_MARKER_DIR;
+  }
+  if (process.env.WORK_UPDATE_CHECK_TEST_FAIL === '1') {
+    opts.fetch = () => Promise.reject(new Error('injected offline'));
+  } else if (process.env.WORK_UPDATE_CHECK_TEST_LATEST) {
+    const latest = process.env.WORK_UPDATE_CHECK_TEST_LATEST;
+    opts.fetch = () =>
+      Promise.resolve({ status: 200, body: JSON.stringify({ metadata: { version: latest } }) });
+  }
+  return opts;
+}
+
+// Prepend the (possibly empty) update banner to the plan output. Empty banner
+// leaves the plan byte-for-byte unchanged so the no-banner path is identical to
+// the pre-GH-314 behavior.
+function prependBanner(banner, output) {
+  return banner ? `${banner}\n${output}` : output;
+}
+
+// Resolve the (non-blocking) update banner. Fail-open: any error is logged and
+// swallowed so the orchestrator plan always renders. Returns '' on no-banner.
+async function resolveBanner() {
+  try {
+    return (await maybeUpdateBanner(buildBannerOpts())) || '';
+  } catch (err) {
+    logHookError(__filename, err);
+    return '';
+  }
+}
+
+async function main() {
   const payload = readStdinPayload();
   const payloadPrompt = typeof payload.prompt === 'string' ? payload.prompt : '';
   const userPrompt = process.env.CLAUDE_USER_PROMPT || payloadPrompt;
@@ -146,9 +196,12 @@ function main() {
   const plan = fetchPlan(parsedArgs);
   logPlanAction(plan);
 
-  // Format the plan for injection
+  // Format the plan for injection. Prepend the non-blocking update banner
+  // (empty when there is nothing to show). The banner is additive — it never
+  // delays or aborts plan emission, and the hook still exits 0.
   const output = formatPlan(plan);
-  console.log(output);
+  const banner = await resolveBanner();
+  console.log(prependBanner(banner, output));
 
   process.exit(0);
 }
@@ -236,4 +289,8 @@ function formatPlan(plan) {
   return lines.join('\n');
 }
 
-main();
+// Fail-open: a rejected main() must never crash the hook (exit non-zero).
+main().catch((err) => {
+  logHookError(__filename, err);
+  process.exit(0);
+});

--- a/plugins/work/scripts/workflows/work/lib/__tests__/update-check.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/update-check.test.js
@@ -1,0 +1,322 @@
+/**
+ * Tests for update-check.js — the non-blocking version-update banner module.
+ *
+ * Covers pure helpers (compareSemver, version-shape validator), installed-version
+ * read, 24h-TTL cache I/O, the HTTPS fetch (driven through an injected transport
+ * shim), and the `maybeUpdateBanner(opts)` orchestration (opt-out env, session
+ * de-dup marker, cache-first/fetch-fallback, compare, banner formatting, and the
+ * never-throw contract).
+ *
+ * node:test + node:assert/strict. No real network or home-dir I/O: every seam is
+ * injected (`now`, `cacheDir`, `installedVersion`, `fetch`) and temp dirs use
+ * fs.mkdtempSync + rmSync({recursive,force}).
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Lazy-load the (not-yet-implemented) module so a missing source file surfaces
+// as a per-test behavior failure rather than a load-time crash of the suite.
+const MODULE_PATH = path.join(__dirname, '..', 'update-check');
+function load() {
+  return require(MODULE_PATH);
+}
+const compareSemver = (...a) => load().compareSemver(...a);
+const isValidVersion = (...a) => load().isValidVersion(...a);
+const readInstalledVersion = (...a) => load().readInstalledVersion(...a);
+const readCache = (...a) => load().readCache(...a);
+const writeCache = (...a) => load().writeCache(...a);
+const fetchLatestVersion = (...a) => load().fetchLatestVersion(...a);
+const maybeUpdateBanner = (...a) => load().maybeUpdateBanner(...a);
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeMarketplaceBody(version) {
+  return JSON.stringify({ name: 'work-workflow', metadata: { version } });
+}
+
+// A fetch transport shim: resolves with { status, body } or rejects.
+function okFetch(version) {
+  return async () => ({ status: 200, body: makeMarketplaceBody(version) });
+}
+
+let tmp;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'update-check-test-'));
+  delete process.env.WORK_DISABLE_UPDATE_CHECK;
+  delete process.env.WORK_UPDATE_CHECK_CACHE_DIR;
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  delete process.env.WORK_DISABLE_UPDATE_CHECK;
+  delete process.env.WORK_UPDATE_CHECK_CACHE_DIR;
+});
+
+// --- 1.1 compareSemver + validator (pure) ---------------------------------
+describe('compareSemver', () => {
+  it('returns 1 when major/minor/patch of a is greater', () => {
+    assert.equal(compareSemver('3.50.0', '3.49.0'), 1);
+    assert.equal(compareSemver('4.0.0', '3.49.0'), 1);
+    assert.equal(compareSemver('3.49.1', '3.49.0'), 1);
+  });
+
+  it('returns 0 when equal', () => {
+    assert.equal(compareSemver('3.49.0', '3.49.0'), 0);
+  });
+
+  it('returns -1 when a is lower', () => {
+    assert.equal(compareSemver('3.49.0', '3.50.0'), -1);
+    assert.equal(compareSemver('3.49.0', '3.49.1'), -1);
+    assert.equal(compareSemver('2.99.99', '3.0.0'), -1);
+  });
+});
+
+describe('isValidVersion', () => {
+  it('returns true for a strict X.Y.Z string', () => {
+    assert.equal(isValidVersion('3.49.0'), true);
+    assert.equal(isValidVersion('0.0.0'), true);
+    assert.equal(isValidVersion('10.20.30'), true);
+  });
+
+  it('returns false for non X.Y.Z strings', () => {
+    assert.equal(isValidVersion('v3.49'), false);
+    assert.equal(isValidVersion('3.49'), false);
+    assert.equal(isValidVersion('foo'), false);
+    assert.equal(isValidVersion('3.49.0-beta'), false);
+    assert.equal(isValidVersion(''), false);
+    assert.equal(isValidVersion(null), false);
+    assert.equal(isValidVersion(undefined), false);
+  });
+});
+
+// --- 1.2 readInstalledVersion ---------------------------------------------
+describe('readInstalledVersion', () => {
+  it('returns the version field from a plugin.json path', () => {
+    const p = path.join(tmp, 'plugin.json');
+    fs.writeFileSync(p, JSON.stringify({ name: 'work-workflow', version: '3.49.0' }));
+    assert.equal(readInstalledVersion(p), '3.49.0');
+  });
+
+  it('returns null when the file is missing', () => {
+    assert.equal(readInstalledVersion(path.join(tmp, 'does-not-exist.json')), null);
+  });
+
+  it('returns null when the file is not valid JSON', () => {
+    const p = path.join(tmp, 'bad.json');
+    fs.writeFileSync(p, '{ not json');
+    assert.equal(readInstalledVersion(p), null);
+  });
+
+  it('returns the live plugin.json version when called with no argument', () => {
+    // Falls back to the module's own plugin.json (currently 3.49.0).
+    assert.equal(isValidVersion(readInstalledVersion()), true);
+  });
+});
+
+// --- 1.3 readCache / writeCache (24h TTL I/O) ------------------------------
+describe('readCache / writeCache', () => {
+  it('round-trips a {latest, fetchedAt} entry', () => {
+    const entry = { latest: '3.50.0', fetchedAt: 1000 };
+    writeCache(tmp, entry);
+    assert.deepEqual(readCache(tmp), entry);
+  });
+
+  it('returns null when no cache file exists', () => {
+    assert.equal(readCache(tmp), null);
+  });
+
+  it('returns null for malformed JSON (parse error swallowed)', () => {
+    writeCache(tmp, { latest: '3.50.0', fetchedAt: 1000 });
+    // Corrupt the written file.
+    const files = fs.readdirSync(tmp);
+    fs.writeFileSync(path.join(tmp, files[0]), '{ broken');
+    assert.equal(readCache(tmp), null);
+  });
+
+  it('does not throw when the dir is uncreatable / unusable', () => {
+    // Point at a path whose parent is a file, so mkdir cannot create it.
+    const fileAsParent = path.join(tmp, 'afile');
+    fs.writeFileSync(fileAsParent, 'x');
+    const badDir = path.join(fileAsParent, 'nested');
+    assert.doesNotThrow(() => writeCache(badDir, { latest: '3.50.0', fetchedAt: 1 }));
+    assert.equal(readCache(badDir), null);
+  });
+});
+
+// --- 1.4 fetchLatestVersion (injected transport) --------------------------
+describe('fetchLatestVersion', () => {
+  it('returns the parsed metadata.version on a 200 with valid body', async () => {
+    const v = await fetchLatestVersion(2500, { fetch: okFetch('3.50.0') });
+    assert.equal(v, '3.50.0');
+  });
+
+  it('returns null on a non-200 status', async () => {
+    const v = await fetchLatestVersion(2500, {
+      fetch: async () => ({ status: 404, body: 'not found' }),
+    });
+    assert.equal(v, null);
+  });
+
+  it('returns null when the transport throws / times out', async () => {
+    const v = await fetchLatestVersion(2500, {
+      fetch: async () => {
+        throw new Error('ETIMEDOUT');
+      },
+    });
+    assert.equal(v, null);
+  });
+
+  it('returns null on malformed JSON body', async () => {
+    const v = await fetchLatestVersion(2500, {
+      fetch: async () => ({ status: 200, body: '{ not json' }),
+    });
+    assert.equal(v, null);
+  });
+
+  it('returns null when metadata.version fails the shape validator', async () => {
+    const v = await fetchLatestVersion(2500, { fetch: okFetch('3.50') });
+    assert.equal(v, null);
+  });
+});
+
+// --- 1.5 maybeUpdateBanner orchestration ----------------------------------
+describe('maybeUpdateBanner', () => {
+  // Build opts with a unique session marker dir per call so session de-dup does
+  // not leak across tests. We override the session marker via tmpdir + a unique
+  // sessionId env so each test starts un-marked.
+  function baseOpts(over = {}) {
+    return {
+      now: 2 * DAY_MS,
+      cacheDir: fs.mkdtempSync(path.join(tmp, 'cache-')),
+      installedVersion: '3.49.0',
+      sessionId: `sess-${Math.random().toString(36).slice(2)}`,
+      ...over,
+    };
+  }
+
+  it('returns a banner naming the new and current versions plus an upgrade command when latest > installed', async () => {
+    const banner = await maybeUpdateBanner(baseOpts({ fetch: okFetch('3.50.0') }));
+    assert.ok(banner.includes('3.50.0'), 'banner mentions the new version');
+    assert.ok(banner.includes('3.49.0'), 'banner mentions the current version');
+    assert.ok(/update/i.test(banner), 'banner mentions an upgrade command');
+  });
+
+  it('returns "" when installed version equals latest', async () => {
+    const banner = await maybeUpdateBanner(baseOpts({ fetch: okFetch('3.49.0') }));
+    assert.equal(banner, '');
+  });
+
+  it('returns "" when installed version is ahead of latest', async () => {
+    const banner = await maybeUpdateBanner(
+      baseOpts({ installedVersion: '3.50.0', fetch: okFetch('3.49.0') })
+    );
+    assert.equal(banner, '');
+  });
+
+  it('returns "" and does not throw when the fetch shim errors', async () => {
+    let banner;
+    await assert.doesNotReject(async () => {
+      banner = await maybeUpdateBanner(
+        baseOpts({
+          fetch: async () => {
+            throw new Error('offline');
+          },
+        })
+      );
+    });
+    assert.equal(banner, '');
+  });
+
+  it('returns "" for a malformed fetched version', async () => {
+    const banner = await maybeUpdateBanner(baseOpts({ fetch: okFetch('not-a-version') }));
+    assert.equal(banner, '');
+  });
+
+  it('uses a fresh (<24h) cache entry and does NOT call the fetch shim', async () => {
+    const opts = baseOpts({ now: 5 * DAY_MS });
+    writeCache(opts.cacheDir, { latest: '3.50.0', fetchedAt: 5 * DAY_MS - 1000 });
+    let called = false;
+    opts.fetch = async () => {
+      called = true;
+      return { status: 200, body: makeMarketplaceBody('9.9.9') };
+    };
+    const banner = await maybeUpdateBanner(opts);
+    assert.equal(called, false, 'fetch must not be called when cache is fresh');
+    assert.ok(banner.includes('3.50.0'), 'banner uses the cached latest version');
+  });
+
+  it('re-fetches when the cache entry is stale (>24h) and rewrites the cache', async () => {
+    const now = 5 * DAY_MS;
+    const opts = baseOpts({ now });
+    writeCache(opts.cacheDir, { latest: '3.49.5', fetchedAt: now - 2 * DAY_MS });
+    let called = false;
+    opts.fetch = async () => {
+      called = true;
+      return { status: 200, body: makeMarketplaceBody('3.51.0') };
+    };
+    const banner = await maybeUpdateBanner(opts);
+    assert.equal(called, true, 'stale cache must trigger a re-fetch');
+    assert.ok(banner.includes('3.51.0'), 'banner uses the freshly fetched version');
+    const written = readCache(opts.cacheDir);
+    assert.equal(written.latest, '3.51.0', 'cache rewritten with the new version');
+    assert.equal(written.fetchedAt, now, 'cache stamped with the current now');
+  });
+
+  it('returns "" without fetching when WORK_DISABLE_UPDATE_CHECK=1', async () => {
+    process.env.WORK_DISABLE_UPDATE_CHECK = '1';
+    let called = false;
+    const banner = await maybeUpdateBanner(
+      baseOpts({
+        fetch: async () => {
+          called = true;
+          return { status: 200, body: makeMarketplaceBody('3.50.0') };
+        },
+      })
+    );
+    assert.equal(banner, '');
+    assert.equal(called, false, 'opt-out must short-circuit before fetching');
+  });
+
+  it('does not re-check within the same session (second call returns "" and does not fetch)', async () => {
+    const sessionId = 'sticky-session';
+    const cacheDir = fs.mkdtempSync(path.join(tmp, 'cache-'));
+    const markerDir = fs.mkdtempSync(path.join(tmp, 'marker-'));
+    const first = await maybeUpdateBanner({
+      now: 2 * DAY_MS,
+      cacheDir,
+      markerDir,
+      installedVersion: '3.49.0',
+      sessionId,
+      fetch: okFetch('3.50.0'),
+    });
+    assert.ok(first.includes('3.50.0'), 'first call shows the banner');
+
+    let called = false;
+    const second = await maybeUpdateBanner({
+      now: 2 * DAY_MS,
+      cacheDir: fs.mkdtempSync(path.join(tmp, 'cache2-')),
+      markerDir,
+      installedVersion: '3.49.0',
+      sessionId,
+      fetch: async () => {
+        called = true;
+        return { status: 200, body: makeMarketplaceBody('3.50.0') };
+      },
+    });
+    assert.equal(second, '', 'second call within the session is suppressed');
+    assert.equal(called, false, 'second call does not fetch');
+  });
+
+  it('never throws even when opts is empty', async () => {
+    let banner;
+    await assert.doesNotReject(async () => {
+      banner = await maybeUpdateBanner({});
+    });
+    assert.equal(typeof banner, 'string');
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/update-check.js
+++ b/plugins/work/scripts/workflows/work/lib/update-check.js
@@ -1,0 +1,236 @@
+'use strict';
+
+// Non-blocking version-update banner module.
+//
+// Every external seam (clock, cache dir, installed-version read, HTTPS fetch,
+// session marker dir) is injectable so the module is fully testable without real
+// network or home-dir I/O. The public contract is "never throw": failures fall
+// back to "no banner" rather than disrupting the host command.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const VERSION_RE = /^\d+\.\d+\.\d+$/;
+const CACHE_FILE = 'update-check-cache.json';
+const MARKETPLACE_URL =
+  'https://raw.githubusercontent.com/thomfilg/claude-plugin-work/main/.claude-plugin/marketplace.json';
+
+/**
+ * Compare two strict X.Y.Z version strings.
+ * @returns {-1|0|1} 1 if a > b, -1 if a < b, 0 if equal.
+ */
+function compareSemver(a, b) {
+  const pa = String(a).split('.').map(Number);
+  const pb = String(b).split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const da = pa[i] || 0;
+    const db = pb[i] || 0;
+    if (da > db) return 1;
+    if (da < db) return -1;
+  }
+  return 0;
+}
+
+/** True only for a strict X.Y.Z numeric version string. */
+function isValidVersion(v) {
+  return typeof v === 'string' && VERSION_RE.test(v);
+}
+
+/**
+ * Read the installed plugin version from a plugin.json path. With no argument,
+ * falls back to this module's own plugin.json. Returns null on any failure.
+ */
+function readInstalledVersion(pluginJsonPath) {
+  try {
+    const target =
+      pluginJsonPath ||
+      path.join(__dirname, '..', '..', '..', '..', '.claude-plugin', 'plugin.json');
+    const parsed = JSON.parse(fs.readFileSync(target, 'utf8'));
+    return parsed.version != null ? String(parsed.version) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read a {latest, fetchedAt} cache entry from cacheDir, or null on any failure. */
+function readCache(cacheDir) {
+  try {
+    const raw = fs.readFileSync(path.join(cacheDir, CACHE_FILE), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** Write a {latest, fetchedAt} cache entry to cacheDir. Never throws. */
+function writeCache(cacheDir, entry) {
+  try {
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, CACHE_FILE), JSON.stringify(entry));
+  } catch {
+    // Best-effort: a broken cache must not break the host command.
+  }
+}
+
+/**
+ * Default HTTPS transport: GET the marketplace manifest, resolve { status, body }.
+ * Rejects on network error or timeout. Injected in tests.
+ */
+function defaultFetch(timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const done = (fn, arg) => {
+      if (settled) return;
+      settled = true;
+      fn(arg);
+    };
+    try {
+      const https = require('node:https');
+      const req = https.get(MARKETPLACE_URL, (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (c) => {
+          body += c;
+        });
+        res.on('end', () => done(resolve, { status: res.statusCode, body }));
+      });
+      req.setTimeout(timeoutMs, () => {
+        req.destroy(new Error('ETIMEDOUT'));
+      });
+      req.on('error', (err) => done(reject, err));
+    } catch (err) {
+      done(reject, err);
+    }
+  });
+}
+
+/**
+ * Fetch the latest published version via the (injectable) transport. Returns a
+ * validated X.Y.Z string, or null on non-200, transport error, malformed body,
+ * or a version that fails the shape validator.
+ */
+async function fetchLatestVersion(timeoutMs, opts = {}) {
+  const fetch = opts.fetch || defaultFetch;
+  try {
+    const res = await fetch(timeoutMs);
+    if (!res || res.status !== 200) return null;
+    const parsed = JSON.parse(res.body);
+    const version = parsed && parsed.metadata && parsed.metadata.version;
+    return isValidVersion(version) ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default base directory for the cache + per-session marker files.
+ *
+ * Uses a user-private cache directory (XDG_CACHE_HOME, else ~/.cache/work-workflow)
+ * instead of the world-writable OS temp dir. Writing predictable filenames into
+ * the shared temp dir is vulnerable to symlink/TOCTOU hijack by another local
+ * user (CodeQL js/insecure-temporary-file). The home cache dir is owned by, and
+ * writable only by, the current user, so it carries no such race. Callers may
+ * still override via opts/env; tests inject an isolated dir.
+ */
+function defaultStateDir() {
+  const base = process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
+  return path.join(base, 'work-workflow');
+}
+
+/** Path of the per-session de-dup marker file. */
+function sessionMarkerPath(markerDir, sessionId) {
+  const dir = markerDir || defaultStateDir();
+  return path.join(dir, `work-update-check.${sessionId}.marker`);
+}
+
+function format(latest, installed) {
+  return (
+    `A new version of work-workflow is available: ${latest} (current: ${installed}). ` +
+    `Run /plugin to update.`
+  );
+}
+
+/** Resolve the option-derived inputs (clock, versions, ids, paths) in one place. */
+function resolveBannerInputs(opts) {
+  const now = typeof opts.now === 'number' ? opts.now : Date.now();
+  const installed = opts.installedVersion || readInstalledVersion();
+  const sessionId = opts.sessionId || 'default';
+  const cacheDir = opts.cacheDir || process.env.WORK_UPDATE_CHECK_CACHE_DIR || defaultStateDir();
+  return { now, installed, sessionId, cacheDir };
+}
+
+/** True if this session's de-dup marker already exists. Swallows read errors. */
+function sessionAlreadyChecked(markerPath) {
+  try {
+    return fs.existsSync(markerPath);
+  } catch {
+    return false;
+  }
+}
+
+/** Write the per-session de-dup marker. Best-effort; never throws. */
+function writeSessionMarker(markerPath, now) {
+  try {
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, String(now));
+  } catch {
+    // ignore marker write failures
+  }
+}
+
+/**
+ * Resolve the latest version: prefer a fresh (<24h) cache entry, otherwise fetch
+ * and rewrite the cache. Returns the (possibly null/invalid) version string.
+ */
+async function resolveLatestVersion(cacheDir, now, opts) {
+  const cached = readCache(cacheDir);
+  if (cached && isValidVersion(cached.latest) && now - cached.fetchedAt < DAY_MS) {
+    return cached.latest;
+  }
+  const latest = await fetchLatestVersion(2500, { fetch: opts.fetch });
+  if (isValidVersion(latest)) {
+    writeCache(cacheDir, { latest, fetchedAt: now });
+  }
+  return latest;
+}
+
+/**
+ * Orchestrate the update-check and return a banner string (or "" for no banner).
+ *
+ * Contract: NEVER throws. Honors the WORK_DISABLE_UPDATE_CHECK opt-out, de-dups
+ * per session via a marker file, prefers a fresh (<24h) cache entry, otherwise
+ * fetches and rewrites the cache, then compares and formats.
+ */
+async function maybeUpdateBanner(opts = {}) {
+  try {
+    if (process.env.WORK_DISABLE_UPDATE_CHECK === '1') return '';
+
+    const { now, installed, sessionId, cacheDir } = resolveBannerInputs(opts);
+    if (!isValidVersion(installed)) return '';
+
+    const markerPath = sessionMarkerPath(opts.markerDir, sessionId);
+    if (sessionAlreadyChecked(markerPath)) return '';
+
+    const latest = await resolveLatestVersion(cacheDir, now, opts);
+    if (!isValidVersion(latest)) return '';
+
+    // Mark this session as checked regardless of outcome.
+    writeSessionMarker(markerPath, now);
+
+    return compareSemver(latest, installed) > 0 ? format(latest, installed) : '';
+  } catch {
+    return '';
+  }
+}
+
+module.exports = {
+  compareSemver,
+  isValidVersion,
+  readInstalledVersion,
+  readCache,
+  writeCache,
+  fetchLatestVersion,
+  maybeUpdateBanner,
+};


### PR DESCRIPTION
## Existing Behavior

- The `/work` UserPromptSubmit hook (`work-hook.js`) emits the orchestrator plan synchronously and exits 0.
- There is no mechanism to inform users when a newer version of the work-workflow plugin is available.
- Users must manually check or notice version drift.

## Intended New Behavior

- On each `/work` invocation, a lightweight `maybeUpdateBanner()` call runs non-blocking and prepends a one-line banner to the orchestrator plan output when a newer version is detected: `A new version of work-workflow is available: X.Y.Z (current: A.B.C). Run /plugin to update.`
- The check is **fail-open**: network unreachable, non-200, malformed JSON, or any thrown error all collapse to an empty string — the plan emits identically to pre-GH-314 behavior.
- A **24h cache** (written to `~/.cache/work-workflow/` or `$XDG_CACHE_HOME/work-workflow/`) avoids a live HTTPS fetch on every invocation.
- The banner is **de-duped per session** via a marker file keyed on `CLAUDE_SESSION_ID` — once shown in a session, it does not repeat even if the user runs `/work` multiple times. A new session always re-evaluates.
- Users can set `WORK_DISABLE_UPDATE_CHECK=1` to permanently opt out.

This is a re-parent of the work originally in the orphaned `GH-314-maestro` branch (PR #635, no common ancestor with main). The wiring is ported onto current main's `work-hook.js`, which had since gained codex runtime bridging and a formatter refactor, so none of main's evolution is reverted.

Closes #314

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Unit tests (update-check.js) — 28 cases:**
```
node --test plugins/work/scripts/workflows/work/lib/__tests__/update-check.test.js
```
Covers: `compareSemver`, `isValidVersion`, `readInstalledVersion`, `readCache`/`writeCache` round-trips, `fetchLatestVersion` (transport shim), and `maybeUpdateBanner` orchestration (opt-out, session de-dup, 24h cache hit/miss, error swallowing).

**Integration tests (spawned real hook) — 3 cases:**
```
node --test plugins/work/hooks/__tests__/work-hook-update-banner.integration.test.js
```
Drives the real `work-hook.js` process via `child_process.spawn` with env-var seams (`WORK_UPDATE_CHECK_TEST_LATEST=3.99.0`, `WORK_UPDATE_CHECK_TEST_FAIL=1`) and asserts: banner + plan present on update-available; plan-only (no banner) on offline; per-session de-dup produces two distinct marker files for two distinct session ID values.

**Manual smoke test — update-available path:**
1. Set `WORK_UPDATE_CHECK_TEST_LATEST=999.0.0` and an isolated marker dir in your shell env.
2. Invoke `/work GH-<any-issue>`.
3. Confirm the first line of the injected plan reads: `A new version of work-workflow is available: 999.0.0 (current: <installed>). Run /plugin to update.`
4. Invoke `/work` again in the same session — banner must NOT reappear (session de-dup).

**Manual smoke test — opt-out:**
1. Set `WORK_DISABLE_UPDATE_CHECK=1`.
2. Invoke `/work GH-<any-issue>` — no banner line; plan is byte-identical to pre-GH-314 output.

**Regression — existing work-hook tests:**
```
node --test plugins/work/hooks/__tests__/
```

### Test Results

31 GH-314 tests pass (28 unit + 3 integration). 17/17 pre-existing work-hook tests pass. `pnpm quality` clean, biome clean.