### PR TITLE
refactor(factories): adopt vendored modules across remaining call sites (#686)

### DIFF
--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -59,13 +59,11 @@ plugins/work/scripts/workflows/check/check.workflow.js
 plugins/work/scripts/workflows/check/hooks/check-start-env.js
 plugins/work/scripts/workflows/work/engine/transition-step.js
 plugins/work/scripts/workflows/check/hooks/check-validate-reports.js
-plugins/work/scripts/workflows/lib/hooks/enforce-ui-imports.js
 plugins/work/scripts/workflows/work-spec/lib/phases/surface_audit.js
 plugins/work/scripts/workflows/work/agents/commit-writer/commit-writer-block-write.js
 plugins/work/scripts/workflows/work/lib/task-parser.js
 plugins/work/scripts/workflows/lib/workflow-state.js
 plugins/work/scripts/workflows/work/hooks/work-require-implement.js
-plugins/work/scripts/workflows/lib/scripts/write-report.js
 plugins/work/scripts/workflows/work/work-state/parallel-workers.js
 plugins/work/scripts/workflows/work/gates/check-gate.js
 plugins/work/scripts/workflows/lib/config.js
@@ -74,7 +72,6 @@ plugins/work/scripts/workflows/work-spec/lib/phases/reuse_audit.js
 plugins/work/scripts/workflows/work/engine/unstick-complete.js
 plugins/work/scripts/workflows/work/lib/gherkin-task-refs.js
 plugins/work/scripts/workflows/check/agents/qa-feature-tester/qa-screenshot-validator.js
-plugins/work/scripts/workflows/lib/ticket-validation.js
 plugins/work/scripts/workflows/work/engine/cli.js
 plugins/work/scripts/workflows/work/lib/work-actions.js
 plugins/work/scripts/workflows/lib/agent-detection.js
@@ -110,7 +107,6 @@ plugins/work/scripts/communicate.js
 plugins/work/scripts/workflows/work/lib/artifact-archival.js
 plugins/work/scripts/workflows/work/lib/gherkin-coverage.js
 plugins/work/scripts/workflows/work/lib/tdd-enforcement.js
-plugins/work/scripts/workflows/lib/hooks/workflow-router-hook.js
 plugins/work/scripts/workflows/work/hooks/protect-orchestrator-state.js
 plugins/work/scripts/workflows/check/lib/severity-detection.js
 plugins/work/scripts/workflows/lib/scripts/quality/rules/biome-bridge.js

--- a/factories/runtime/__tests__/vendored-parity.spec.js
+++ b/factories/runtime/__tests__/vendored-parity.spec.js
@@ -109,13 +109,19 @@ describe('VENDOR_SETS table shape', () => {
     'factories/storeDiscovery': [
       'plugins/synapsys/lib/storeDiscovery',
       'plugins/heimdall/lib/storeDiscovery',
+      'plugins/maestro/lib/storeDiscovery',
     ],
     'factories/safeIO': ['plugins/work/scripts/workflows/lib/safeIO'],
     'factories/hookEntrypoint': [
       'plugins/synapsys/lib/hookEntrypoint',
       'plugins/work/scripts/workflows/lib/hookEntrypoint',
+      'plugins/heimdall/lib/hookEntrypoint',
     ],
-    'factories/safeSubprocess': ['plugins/work/scripts/workflows/lib/safeSubprocess'],
+    'factories/safeSubprocess': [
+      'plugins/work/scripts/workflows/lib/safeSubprocess',
+      'plugins/synapsys/lib/safeSubprocess',
+      'plugins/heimdall/lib/safeSubprocess',
+    ],
     'factories/pathSafe': ['plugins/heimdall/lib/pathSafe'],
   };
 

--- a/plugins/heimdall/hooks/heimdall-secrets-reminder.js
+++ b/plugins/heimdall/hooks/heimdall-secrets-reminder.js
@@ -16,7 +16,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
+const { safeSpawnSync } = require(path.join(__dirname, '..', 'lib', 'safeSubprocess'));
 
 function projectDir() {
   if (process.env.CLAUDE_PROJECT_DIR) return process.env.CLAUDE_PROJECT_DIR;
@@ -35,7 +35,9 @@ function main() {
   // The status script owns the verdict AND the case-specific message (install
   // not run vs. installed-but-docker-bypassable) via --reminder. Single source
   // of truth: the hook just forwards its text. Args passed as argv (no shell).
-  const r = spawnSync(process.execPath, [status, dir, '--reminder'], { encoding: 'utf8' });
+  // safeSubprocess adds the default 15s deadline; a timed-out status probe
+  // yields status null !== 2 and the reminder stays silent (fail-open nag).
+  const r = safeSpawnSync(process.execPath, [status, dir, '--reminder'], { encoding: 'utf8' });
   if (r.status !== 2 || !r.stdout || !r.stdout.trim()) return; // protected / no config / nothing to say
 
   process.stdout.write(

--- a/plugins/heimdall/hooks/heimdall.js
+++ b/plugins/heimdall/hooks/heimdall.js
@@ -19,11 +19,24 @@ const { discoverStores, readConfig, getRepoRoot } = require(
 );
 const { buildEntries, evaluate } = require(path.join(__dirname, '..', 'lib', 'guard'));
 const { getRuntime } = require(path.join(__dirname, '..', 'lib', 'runtime'));
+const { parsePayload } = require(path.join(__dirname, '..', 'lib', 'hookEntrypoint'));
 
-async function readStdin() {
-  let input = '';
-  for await (const chunk of process.stdin) input += chunk;
-  return input;
+/**
+ * Strict stdin reader for this fail-closed hook. The vendored hookEntrypoint
+ * readStdin resolves '' on a stream error — fail-open semantics built for
+ * advisory hooks. Here a stdin READ ERROR means a possibly-blockable payload
+ * was lost, so it must reject into main().catch and block for safety (exit 2),
+ * preserving the pre-adoption contract. Empty/malformed stdin still allows.
+ */
+function readStdinStrict() {
+  if (process.stdin.isTTY) return Promise.resolve('');
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => chunks.push(chunk));
+    process.stdin.on('end', () => resolve(chunks.join('')));
+    process.stdin.on('error', reject);
+  });
 }
 
 /**
@@ -43,15 +56,11 @@ function collectLocks(cwd) {
 }
 
 async function main() {
-  const raw = await readStdin();
-
-  let hookData;
-  try {
-    hookData = JSON.parse(raw);
-  } catch {
-    // Can't parse payload → nothing to enforce against. Allow.
-    process.exit(0);
-  }
+  // Empty/malformed stdin parses to {} — nothing to enforce against. The
+  // empty payload normalizes to a tool call with no name, which no guard
+  // handler matches, so it falls through to allow (exit 0) below. A stdin
+  // stream ERROR is different: readStdinStrict rejects it into main().catch.
+  const hookData = parsePayload(await readStdinStrict());
 
   const rt = getRuntime(hookData);
   const evt = rt.normalizeHookPayload(hookData, { event: 'PreToolUse' });

--- a/plugins/heimdall/lib/guard/paths.js
+++ b/plugins/heimdall/lib/guard/paths.js
@@ -31,6 +31,17 @@ function isTempPath(filePath) {
   return false;
 }
 
+/**
+ * Free-text scanner over an arbitrary command string: globally replaces EVERY
+ * `~` / `$HOME` / `${HOME}` occurrence, anywhere in the text (even mid-word),
+ * so protected-entry matching sees home-relative references no matter where
+ * they appear in a command. Deliberately NOT converged on the vendored
+ * pathSafe.expandHome (GH-686/GH-582): that helper is anchored (start-of-string
+ * only), and anchoring here would weaken the guard — mid-string references
+ * like `cat $HOME/.claude/settings.json` would stop matching protected
+ * entries. Single-path callers should use pathSafe.expandHome; this stays
+ * intentionally lossy because it feeds substring matching, not path resolution.
+ */
 function expandHomePaths(text) {
   return text
     .replace(/~/g, os.homedir())

--- a/plugins/heimdall/lib/hookEntrypoint/hookEntrypoint.js
+++ b/plugins/heimdall/lib/hookEntrypoint/hookEntrypoint.js
@@ -1,0 +1,144 @@
+// GENERATED — edit factories/hookEntrypoint/hookEntrypoint.js and run scripts/sync-vendored.js
+
+'use strict';
+
+/**
+ * hookEntrypoint — the canonical entry protocol for hook scripts:
+ * read stdin → parse the JSON payload → run a guarded handler → always end
+ * the process with a deliberate exit code.
+ *
+ * A hook process is judged by its exit code and its stderr bytes, not by a
+ * return value, so the protocol *around* a handler matters as much as the
+ * handler itself. `runHook(handler, opts)` pins that protocol down:
+ *
+ * - Stdin is read event-based with a TTY guard: an interactive invocation
+ *   (nothing piped) reads as '', and a stream error also resolves to ''
+ *   instead of throwing. The handler always receives a payload object.
+ * - The payload is parsed with `parsePayload`, which returns its fallback
+ *   (`{}` by default) for empty or malformed input and never throws — a
+ *   hook must not die on the shape of its stdin.
+ * - The handler runs inside try/catch and may be sync or async. Handlers
+ *   are allowed to call `process.exit` themselves (dispatchers that emit a
+ *   deny envelope do exactly that); runHook's own exit is the fallthrough.
+ * - A handler that resolves without exiting → `process.exit(0)`.
+ * - A handler that throws with `opts.onError` 'open' (the default) → the
+ *   error goes to the file logger (`logHookError(opts.file, err)`) and the
+ *   process exits 0 with NOTHING on stderr. The host runtime treats any
+ *   stderr byte as a hook failure, so a fail-open hook must stay silent;
+ *   this exit-0 contract is load-bearing enforcement surface. The log call
+ *   itself is guarded — logging must never break fail-open (an unhandled
+ *   rejection would print a stack to stderr and exit 1).
+ * - A handler that throws with `opts.onError` 'closed' → a NON-EMPTY line
+ *   on stderr (padded with a default when the error carries no message,
+ *   because an empty stderr can flip an exit-2 hook back to fail-open on
+ *   some host runtimes), then `process.exit(2)`.
+ */
+
+const { logHookError } = require('./logHookError');
+
+/** Drain a readable stream into a utf8 string; a stream error resolves ''. */
+function collectStream(stream) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => chunks.push(chunk));
+    stream.on('end', () => resolve(chunks.join('')));
+    stream.on('error', () => resolve(''));
+  });
+}
+
+/**
+ * Read the full hook payload text from stdin.
+ *
+ * TTY guard: when the script is run interactively (no piped payload) this
+ * resolves '' immediately instead of hanging on a stdin that never ends.
+ *
+ * @returns {Promise<string>} raw stdin text; '' on TTY or stream error.
+ */
+async function readStdin() {
+  if (process.stdin.isTTY) return '';
+  return collectStream(process.stdin);
+}
+
+/**
+ * Parse a hook payload. Never throws.
+ *
+ * @param {string} text - Raw stdin text.
+ * @param {object} [fallback] - Returned for empty or malformed input.
+ * @returns {object} the parsed payload, or `fallback`.
+ */
+function parsePayload(text, fallback = {}) {
+  if (!text) return fallback;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return fallback;
+  }
+}
+
+function assertRunHookConfig(handler, opts) {
+  if (typeof handler !== 'function') {
+    throw new TypeError('hookEntrypoint: missing "handler"');
+  }
+  const mode = opts.onError === undefined ? 'open' : opts.onError;
+  if (mode !== 'open' && mode !== 'closed') {
+    throw new TypeError("hookEntrypoint: \"onError\" must be 'open' or 'closed'");
+  }
+  return mode;
+}
+
+/** Fail-closed exit: stderr must be non-empty or the block may not register. */
+function exitClosed(err) {
+  let message = '';
+  try {
+    const raw = err && err.message ? String(err.message) : '';
+    if (raw.trim()) message = raw;
+  } catch {
+    // Building the message threw (throwing getter, unstringable value) —
+    // fall through to the fixed fallback line. An EMPTY stderr can flip an
+    // exit-2 hook back to fail-open on some host runtimes, so a non-empty
+    // write is mandatory here.
+  }
+  if (!message) message = 'hook handler failed without an error message';
+  process.stderr.write(`${message}\n`);
+  process.exit(2);
+}
+
+async function dispatch(handler, mode, sourceFile) {
+  const payload = parsePayload(await readStdin());
+  try {
+    await handler(payload);
+  } catch (err) {
+    if (mode === 'closed') exitClosed(err);
+    try {
+      // Logging must never break fail-open: if logHookError throws (exotic
+      // error object, deleted cwd) the async dispatch promise would reject
+      // unhandled — Node prints a stack to stderr and exits 1, the exact
+      // failure the exit-0 contract exists to prevent.
+      logHookError(sourceFile, err);
+    } catch {
+      /* swallow: fail-open means exit 0 with silent stderr, no matter what */
+    }
+    process.exit(0);
+  }
+  process.exit(0);
+}
+
+/**
+ * Run a hook handler under the canonical entry protocol. Always ends the
+ * process (see the decision matrix in the file header); the returned promise
+ * only settles in the config-error case, which throws synchronously.
+ *
+ * @param {(payload: object) => any} handler - Sync or async payload handler.
+ * @param {object} [opts]
+ * @param {'open'|'closed'} [opts.onError] - Failure policy (default 'open').
+ * @param {string} [opts.file] - Source label for the error log; pass
+ *   `__filename` from the hook script. Defaults to 'hookEntrypoint'.
+ */
+function runHook(handler, opts) {
+  const options = opts || {};
+  const mode = assertRunHookConfig(handler, options);
+  return dispatch(handler, mode, options.file || 'hookEntrypoint');
+}
+
+module.exports = { readStdin, parsePayload, runHook };

--- a/plugins/heimdall/lib/hookEntrypoint/index.js
+++ b/plugins/heimdall/lib/hookEntrypoint/index.js
@@ -1,0 +1,4 @@
+// GENERATED — edit factories/hookEntrypoint/index.js and run scripts/sync-vendored.js
+
+'use strict';
+module.exports = { ...require('./hookEntrypoint'), ...require('./logHookError') };

--- a/plugins/heimdall/lib/hookEntrypoint/logHookError.js
+++ b/plugins/heimdall/lib/hookEntrypoint/logHookError.js
@@ -1,0 +1,225 @@
+// GENERATED — edit factories/hookEntrypoint/logHookError.js and run scripts/sync-vendored.js
+
+'use strict';
+
+/**
+ * logHookError — production-grade file error logger for hook scripts.
+ *
+ * Logs hook errors to a file instead of stderr, preventing false
+ * "hook error" noise in the host runtime (which treats any stderr as an
+ * error).
+ *
+ * When ENFORCE_HOOK_DEBUG=1: writes to stderr (for interactive debugging)
+ * Otherwise: appends to /tmp/claude-hook-errors.log (silent, reviewable later)
+ *
+ * TOCTOU-safe: opens the log file ONCE via file descriptor with O_CREAT |
+ * O_APPEND | O_WRONLY and mode 0o600. All subsequent writes use the fd
+ * directly — no path-based reopens after the initial open.
+ *
+ * Auto-rotates: truncates via fd when file exceeds MAX_LOG_SIZE (1MB).
+ *
+ * Usage (basic -- error message only):
+ *   const { logHookError } = require('./logHookError');
+ *   main().catch(err => { logHookError(__filename, err); process.exit(0); });
+ *
+ * Usage (with session context -- for richer debugging):
+ *   main().catch(err => {
+ *     logHookError(__filename, err, { tool: hookData.tool_name, input: hookData.tool_input });
+ *     process.exit(0);
+ *   });
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Default log path -- overridable via HOOK_ERROR_LOG env var.
+// File is created with 0o600 permissions (owner-only read/write) to mitigate /tmp security risks.
+const LOG_FILE = process.env.HOOK_ERROR_LOG || '/tmp/claude-hook-errors.log';
+const MAX_LOG_SIZE = 1024 * 1024; // 1MB cap before auto-rotation
+
+// File descriptor for the log file -- opened once, reused for all writes.
+// Using an fd eliminates TOCTOU races: no path-based reopens after initial open.
+let _logFd = null;
+
+/**
+ * Open the log file once and return the fd. Subsequent calls return the cached fd.
+ * Returns -1 sentinel if the open failed (caller should silently discard).
+ */
+/**
+ * Open the log path, refusing symlinks atomically. O_NOFOLLOW makes the open
+ * itself fail with ELOOP when a symlink sits at the path — no check-then-open
+ * window exists (POSIX-only; harmless 0 where undefined). On ELOOP the
+ * hostile/stale link is removed and the open retried once so the log
+ * self-heals instead of caching the -1 sentinel forever.
+ */
+function openLogFdNoFollow() {
+  // O_APPEND ensures atomic-ish writes; 0o600 = owner-only permissions.
+  const flags =
+    fs.constants.O_CREAT |
+    fs.constants.O_APPEND |
+    fs.constants.O_WRONLY |
+    (fs.constants.O_NOFOLLOW || 0);
+  try {
+    return fs.openSync(LOG_FILE, flags, 0o600);
+  } catch (err) {
+    if (!err || err.code !== 'ELOOP') throw err;
+    fs.unlinkSync(LOG_FILE);
+    return fs.openSync(LOG_FILE, flags, 0o600);
+  }
+}
+
+function getLogFd() {
+  if (_logFd !== null) return _logFd;
+  try {
+    _logFd = openLogFdNoFollow();
+  } catch {
+    _logFd = -1; // sentinel: open failed, don't retry on subsequent calls
+  }
+  return _logFd;
+}
+
+// Cache branch detection per process (hooks are short-lived, branch won't change mid-run)
+let _branch;
+function getBranch() {
+  if (_branch !== undefined) return _branch;
+  try {
+    _branch =
+      execSync('git branch --show-current 2>/dev/null', {
+        encoding: 'utf8',
+        timeout: 2000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim() || null;
+  } catch {
+    _branch = null;
+  }
+  return _branch;
+}
+
+function truncateCommand(cmd) {
+  return cmd.length > 200 ? cmd.slice(0, 200) + '...' : cmd;
+}
+
+/**
+ * Extract a printable message from an arbitrary thrown value. Never throws:
+ * `String(err)` throws for prototype-less objects (no toString / no
+ * Symbol.toPrimitive), and `err.message` may be a throwing getter or itself
+ * unstringable — an error logger must swallow all of those.
+ */
+function safeErrorMessage(err) {
+  try {
+    return String(err?.message || String(err));
+  } catch {
+    return '[unstringable error]';
+  }
+}
+
+/**
+ * process.cwd() throws ENOENT when the cwd was deleted out from under the
+ * process (real scenario: hooks firing in cleaned-up worktrees).
+ */
+function safeCwd() {
+  try {
+    return process.cwd();
+  } catch {
+    return '[unavailable]';
+  }
+}
+
+const INPUT_FIELD_MAP = [
+  ['file_path', 'file', (v) => v],
+  ['command', 'cmd', truncateCommand],
+  ['skill', 'skill', (v) => v],
+  ['subagent_type', 'agent', (v) => v],
+];
+
+function buildInputParts(input) {
+  const parts = [];
+  if (!input) return parts;
+  for (const [key, label, transform] of INPUT_FIELD_MAP) {
+    if (input[key]) parts.push(`${label}=${transform(input[key])}`);
+  }
+  return parts;
+}
+
+function buildContextParts(context) {
+  const parts = [`pid=${process.pid}`];
+  // getBranch already fail-opens: the execSync is try/caught and resolves to
+  // null on any subprocess failure (including a deleted cwd).
+  const branch = getBranch();
+  if (branch) parts.push(`branch=${branch}`);
+  parts.push(`cwd=${safeCwd()}`);
+  if (context?.tool) parts.push(`tool=${context.tool}`);
+  parts.push(...buildInputParts(context?.input));
+  return parts;
+}
+
+function sanitizeLine(line) {
+  const MAX_BYTES = 3800;
+  const safeLine = line.replace(/\n/g, ' ').replace(/\r/g, '');
+  let finalLine = safeLine + '\n';
+  if (Buffer.byteLength(finalLine, 'utf8') > MAX_BYTES) {
+    let truncated = safeLine;
+    while (Buffer.byteLength(truncated + '...\n', 'utf8') > MAX_BYTES && truncated.length > 0) {
+      truncated = truncated.slice(0, -100);
+    }
+    finalLine = truncated + '...\n';
+  }
+  return finalLine;
+}
+
+function writeLogLine(fd, line, timestamp) {
+  try {
+    const stat = fs.fstatSync(fd);
+    if (stat.size > MAX_LOG_SIZE) {
+      fs.ftruncateSync(fd, 0);
+      fs.writeSync(fd, `[${timestamp}] --- log rotated ---\n`);
+    }
+    fs.writeSync(fd, sanitizeLine(line));
+  } catch {
+    // Can't log -- silently discard. Never write to stderr from hooks.
+  }
+}
+
+function writeErrorLine(sourceFile, err, context) {
+  const name = path.basename(sourceFile);
+  const message = safeErrorMessage(err);
+  const timestamp = new Date().toISOString();
+  const ctx = buildContextParts(context).join(' ');
+  const line = `[${timestamp}] ${name} | ${ctx} | ${message}`;
+
+  if (process.env.ENFORCE_HOOK_DEBUG) {
+    const stack = err?.stack?.split('\n')[1]?.trim() || '';
+    process.stderr.write(`[${name}] ${ctx} | ${message}${stack ? '\n  ' + stack : ''}\n`);
+    return;
+  }
+
+  const fd = getLogFd();
+  if (fd <= 0) return;
+  writeLogLine(fd, line, timestamp);
+}
+
+/**
+ * Log a hook error to file (or stderr when ENFORCE_HOOK_DEBUG=1).
+ *
+ * NEVER throws, for any input: callers sit in the bare `catch` of a fail-open
+ * hook, so a throw here would surface as an unhandled rejection (stack on
+ * stderr, exit 1) and break the fail-open contract.
+ *
+ * @param {string} sourceFile - Pass __filename
+ * @param {Error|string} err - The caught error
+ * @param {object} [context] - Optional session context for richer debugging
+ * @param {string} [context.tool] - Tool name (e.g. "Edit", "Bash", "Task")
+ * @param {object} [context.input] - Tool input (file_path, command, etc.)
+ */
+function logHookError(sourceFile, err, context) {
+  try {
+    writeErrorLine(sourceFile, err, context);
+  } catch {
+    // Defense in depth: logging must never break fail-open. A failed log
+    // line is silently discarded — never write to stderr from hooks.
+  }
+}
+
+/** @see __tests__/hookEntrypoint.test.js for tests covering fd-based writes, rotation, symlink guard, and truncation */
+module.exports = { logHookError, LOG_FILE };

--- a/plugins/heimdall/lib/safeSubprocess/index.js
+++ b/plugins/heimdall/lib/safeSubprocess/index.js
@@ -1,0 +1,4 @@
+// GENERATED — edit factories/safeSubprocess/index.js and run scripts/sync-vendored.js
+
+'use strict';
+module.exports = require('./safeSubprocess');

--- a/plugins/heimdall/lib/safeSubprocess/safeSubprocess.js
+++ b/plugins/heimdall/lib/safeSubprocess/safeSubprocess.js
@@ -1,0 +1,123 @@
+// GENERATED — edit factories/safeSubprocess/safeSubprocess.js and run scripts/sync-vendored.js
+
+'use strict';
+
+/**
+ * safeSubprocess — synchronous subprocess wrappers that make timeouts
+ * non-optional and shell interpolation impossible.
+ *
+ * A synchronous child-process call with no deadline can freeze the entire
+ * event loop of whatever host invoked it. These wrappers exist so a call
+ * site can never *silently* opt out of a deadline: every invocation either
+ * runs under a positive finite timeout (default 15000 ms) or carries an
+ * explicit, human-readable justification for running without one.
+ *
+ * Decision matrix, in prose:
+ *
+ * - `command` must be a non-empty string, `args` an array of strings, and
+ *   `opts` a plain object; anything else throws a TypeError immediately.
+ * - When `opts.timeout` is absent, the default of 15000 ms is applied.
+ * - When `opts.timeout` is a positive integer, it is used as-is.
+ * - When `opts.timeout` is anything else — null, 0, a negative number,
+ *   NaN, Infinity, a non-integer like 15.5 or 5e-324 (which Node itself
+ *   would only reject later with a less actionable RangeError), or a
+ *   non-number — the call throws a TypeError. There is no value that
+ *   means "no timeout".
+ * - The only way to run without a deadline is `opts.noTimeout` set to a
+ *   non-empty justification string; the timeout key is then omitted from
+ *   the final options entirely. A `noTimeout` that is not a non-empty
+ *   string throws a TypeError.
+ * - `opts.shell` is always stripped and replaced with `shell: false`;
+ *   arguments are passed positionally and shell metacharacters stay
+ *   literal. There is no opt-out.
+ * - Every other option (`cwd`, `encoding`, `env`, `input`, `stdio`, ...)
+ *   passes through untouched.
+ *
+ * The two exports differ only in failure semantics, mirroring their
+ * `node:child_process` counterparts:
+ *
+ * - `safeSpawnSync` returns the raw `spawnSync` result object. It never
+ *   throws for runtime failures (nonzero exit, missing binary, timeout) —
+ *   callers keep their own success predicates over `status` / `stdout` /
+ *   `signal` / `error`.
+ * - `safeExecFileSync` returns `execFileSync`'s return value and throws
+ *   on any failure, exactly like the native call.
+ */
+
+const { execFileSync, spawnSync } = require('node:child_process');
+
+const DEFAULT_TIMEOUT_MS = 15000;
+
+function assertCommand(command) {
+  if (typeof command === 'string' && command.length > 0) return;
+  throw new TypeError('safeSubprocess: command must be a non-empty string');
+}
+
+function assertArgs(args) {
+  const ok = Array.isArray(args) && args.every((arg) => typeof arg === 'string');
+  if (!ok) throw new TypeError('safeSubprocess: args must be an array of strings');
+}
+
+function assertOpts(opts) {
+  if (opts === null || typeof opts !== 'object' || Array.isArray(opts)) {
+    throw new TypeError('safeSubprocess: opts must be an object');
+  }
+}
+
+/**
+ * Resolve the effective timeout for a call, or `undefined` when the caller
+ * supplied a valid `noTimeout` justification. Throws on every shape that
+ * would disable the deadline without saying why.
+ */
+function resolveTimeout(opts) {
+  if (opts.noTimeout !== undefined) {
+    if (typeof opts.noTimeout !== 'string' || opts.noTimeout.trim().length === 0) {
+      throw new TypeError('safeSubprocess: "noTimeout" must be a non-empty justification string');
+    }
+    return undefined;
+  }
+  const timeout = opts.timeout === undefined ? DEFAULT_TIMEOUT_MS : opts.timeout;
+  if (!Number.isInteger(timeout) || timeout <= 0) {
+    throw new TypeError(
+      'safeSubprocess: "timeout" must be a positive integer number of milliseconds; ' +
+        'pass { noTimeout: "<justification>" } to run without a deadline'
+    );
+  }
+  return timeout;
+}
+
+/** Build the options object actually handed to child_process. */
+function buildFinalOpts(opts) {
+  const timeout = resolveTimeout(opts);
+  const final = { ...opts, shell: false };
+  delete final.noTimeout;
+  delete final.timeout;
+  if (timeout !== undefined) final.timeout = timeout;
+  return final;
+}
+
+function invoke(runner, command, args, opts) {
+  assertCommand(command);
+  assertArgs(args);
+  assertOpts(opts);
+  return runner(command, args, buildFinalOpts(opts));
+}
+
+/**
+ * `spawnSync` under the timeout policy above. Returns the raw result
+ * object — status, stdout, stderr, signal, error — untouched, so callers
+ * keep their own success predicates (e.g. `r.status === 0 && r.stdout`).
+ */
+function safeSpawnSync(command, args = [], opts = {}) {
+  return invoke(spawnSync, command, args, opts);
+}
+
+/**
+ * `execFileSync` under the timeout policy above. Native semantics:
+ * returns stdout on success, throws on nonzero exit / signal / timeout.
+ */
+function safeExecFileSync(command, args = [], opts = {}) {
+  return invoke(execFileSync, command, args, opts);
+}
+
+module.exports = { safeSpawnSync, safeExecFileSync };

--- a/plugins/heimdall/lib/scan.js
+++ b/plugins/heimdall/lib/scan.js
@@ -6,22 +6,22 @@
  *
  * Walks the default catalog and keeps only targets that actually EXIST:
  *   - 'repo' targets are resolved against the repo root and must exist there.
- *   - 'home' targets are resolved against the home dir and are suggested only
- *     for a `global` install (a home path is not "in the repository").
+ *   - 'home' targets get anchored ~ / $HOME / ${HOME} expansion via the
+ *     vendored pathSafe ('~user' stays untouched → dropped by existsSync).
  * Targets already covered by an existing lock in the active store(s) are
  * dropped, so re-running install never re-suggests what's already protected.
  */
 
 const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
 const { CATALOG } = require('./catalog');
 const { getRepoRoot, discoverStores, readConfig } = require('./lock-store');
 const { buildEntries } = require('./guard');
+const { expandHome } = require('./pathSafe');
 
 function resolveTarget(target, repoRoot) {
   if (target.anchor === 'home') {
-    return path.join(os.homedir(), target.path.replace(/^~\/?/, ''));
+    return expandHome(target.path);
   }
   return path.resolve(repoRoot, target.path);
 }

--- a/plugins/heimdall/scripts/heimdall-init.js
+++ b/plugins/heimdall/scripts/heimdall-init.js
@@ -16,8 +16,8 @@
 
 const fs = require('node:fs');
 const os = require('node:os');
-const { spawnSync } = require('node:child_process');
 const path = require('node:path');
+const { safeSpawnSync } = require(path.join(__dirname, '..', 'lib', 'safeSubprocess'));
 const { parseArgs } = require(path.join(__dirname, '..', 'lib', 'cli'));
 const {
   MARKER,
@@ -70,11 +70,16 @@ function ensureFsguardBuilt() {
     const arch = archMap[process.arch] || process.arch;
     const so = path.join(__dirname, 'bin', `heimdall-fsguard.linux-${arch}.so`);
     if (fs.existsSync(so)) return;
-    const r = spawnSync('bash', [path.join(__dirname, 'build-fsguard.sh')], { encoding: 'utf8' });
+    const r = safeSpawnSync('bash', [path.join(__dirname, 'build-fsguard.sh')], {
+      encoding: 'utf8',
+      noTimeout: 'cc compile of the fsguard shim can legitimately exceed the 15s default',
+    });
     if (r.status === 0 && fs.existsSync(so)) {
       console.log(`built runtime write-guard: ${so}`);
     } else {
-      console.log('note: runtime write-guard not built (no cc?); using static fail-closed fallback');
+      console.log(
+        'note: runtime write-guard not built (no cc?); using static fail-closed fallback'
+      );
     }
   } catch {
     /* non-fatal */

--- a/plugins/maestro/lib/schema-store.js
+++ b/plugins/maestro/lib/schema-store.js
@@ -4,10 +4,10 @@
  * schema-store.js — tiered, marker-gated persistence for reusable maestro
  * orchestration schemas.
  *
- * Storage model is a faithful mirror of the synapsys memory store
- * (plugins/synapsys/lib/memory-store.js): four discovery tiers, each gated by
- * a `.maestro.json` marker file so only *installed* stores are ever read or
- * written, and one markdown-with-frontmatter file per saved schema.
+ * Store discovery (tiers, marker gating, ancestor walk, project naming) is
+ * delegated to the vendored storeDiscovery factory; this module keeps only
+ * the schema-specific layer: frontmatter parse/serialize and schema
+ * read/list on top of the discovered stores.
  *
  * A "schema" is the reusable subset of an orchestrate invocation — pool size,
  * the per-ticket command, and the compiled stop-condition oracle — minus the
@@ -28,114 +28,23 @@
  */
 
 const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
-const { execSync } = require('node:child_process');
+const { createStoreDiscovery } = require('./storeDiscovery');
 
-const MARKER = '.maestro.json';
-const FOLDER = 'maestro';
-// Dedicated directory for the cross-project "shared" tier. Sits OUTSIDE the
-// per-project `~/.claude/maestro/<project>/` namespace so it can never collide
-// with a project whose name happens to be "maestro-shared". Mirrors synapsys.
-const SHARED_FOLDER = `${FOLDER}-shared`;
+const discovery = createStoreDiscovery({
+  folder: 'maestro',
+  marker: '.maestro.json',
+  // basename(toplevel || cwd) — schema stores are per-checkout, so a linked
+  // worktree keeps its own global-tier namespace.
+  projectNameStrategy: 'toplevel',
+  // Walk to the filesystem root: a marker above $HOME stays discoverable.
+  ancestorWalkStopsAtHome: false,
+  // Lets tests pin discovery to the cwd-rooted local/worktree stores only, so
+  // a developer's real global/shared schemas never leak into fixtures.
+  disableHomeStoresEnvVar: 'MAESTRO_DISABLE_HOME_STORES',
+});
 
 const SKIP_FILES = new Set(['INDEX.md', 'README.md']);
-
-// execSync options shared by safeExec. Hoisted to a constant so the call site
-// stays a single expression — this also keeps the helper structurally distinct
-// from synapsys' inline-options version (avoids a cross-file clone).
-const GIT_EXEC_OPTS = { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] };
-
-// Pass cwd through to execSync so git resolves relative to the caller's path,
-// not the host process's cwd (hooks/CLIs may run from a different dir than the
-// payload they process). Mirrors memory-store.safeExec behaviorally.
-function safeExec(cmd, cwd) {
-  try {
-    return execSync(cmd, { cwd, ...GIT_EXEC_OPTS }).trim();
-  } catch {
-    return '';
-  }
-}
-
-function getProjectName(cwd) {
-  const base = cwd || process.cwd();
-  const top = safeExec('git rev-parse --show-toplevel', base);
-  return path.basename(top || base);
-}
-
-// Per-tier directory resolvers. Computing the dirs through a descriptor table
-// (rather than an inline object-literal array) keeps this structurally distinct
-// from the synapsys store's candidateStores, so jscpd sees no shared token run.
-const STORE_DIR_RESOLVERS = {
-  local: (cwd) => path.join(cwd, '.claude', FOLDER),
-  worktree: (cwd) => path.resolve(cwd, '..', '.claude', FOLDER),
-  global: (cwd, projectName) => path.join(os.homedir(), '.claude', FOLDER, projectName),
-  shared: () => path.join(os.homedir(), '.claude', SHARED_FOLDER),
-};
-
-function candidateStores(cwd, projectName) {
-  return Object.entries(STORE_DIR_RESOLVERS).map(([kind, resolve]) => ({
-    kind,
-    dir: resolve(cwd, projectName),
-  }));
-}
-
-// The `.claude/maestro` store directory beneath a given base. Hoisted so both
-// the ancestor walk and its marker test share one expression — and so this file
-// no longer repeats synapsys' inline `path.join(dir, '.claude', FOLDER, MARKER)`
-// token sequence (cross-file clone avoidance).
-function storeDirUnder(base) {
-  return path.join(base, '.claude', FOLDER);
-}
-
-// Walk up from startDir looking for the nearest ancestor that carries a store
-// marker at `<ancestor>/.claude/maestro/.maestro.json`. Returns the store dir,
-// or '' when none is found before the filesystem root. This is why a worktree
-// store still resolves from a sub-directory of the worktree.
-function findAncestorStore(startDir) {
-  for (let dir = startDir, parent; ; dir = parent) {
-    const storeDir = storeDirUnder(dir);
-    if (fs.existsSync(path.join(storeDir, MARKER))) return storeDir;
-    parent = path.dirname(dir);
-    if (parent === dir) return '';
-  }
-}
-
-function discoverStores(cwd) {
-  const resolved = cwd || process.cwd();
-  const projectName = getProjectName(resolved);
-  const out = [];
-  const seen = new Set();
-
-  // Append a store row iff its dir carries a marker and hasn't been seen. The
-  // shared tier is cross-project, so it is never stamped with projectName
-  // (mirrors the marker written by maestro-schema init).
-  const push = (kind, dir) => {
-    const key = path.resolve(dir);
-    if (seen.has(key) || !fs.existsSync(path.join(dir, MARKER))) return;
-    seen.add(key);
-    out.push({ kind, dir, projectName: kind === 'shared' ? null : projectName });
-  };
-
-  const dirFor = (kind) => STORE_DIR_RESOLVERS[kind](resolved, projectName);
-
-  // local: store inside the cwd itself.
-  push('local', dirFor('local'));
-
-  // worktree: nearest ancestor above cwd carrying a store marker.
-  const wt = findAncestorStore(path.dirname(resolved));
-  if (wt) push('worktree', wt);
-
-  // MAESTRO_DISABLE_HOME_STORES lets tests pin discovery to the cwd-rooted
-  // local/worktree stores only, so a developer's real global/shared schemas
-  // never leak into fixture-based assertions.
-  if (process.env.MAESTRO_DISABLE_HOME_STORES !== '1') {
-    push('global', dirFor('global'));
-    push('shared', dirFor('shared'));
-  }
-
-  return out;
-}
 
 // ── Frontmatter ────────────────────────────────────────────────────────────
 // Schema values are all single-line scalars (string/number/boolean), so the
@@ -256,7 +165,7 @@ function listSchemasFromStore(store) {
 
 function listSchemas(cwd) {
   const out = [];
-  for (const store of discoverStores(cwd || process.cwd())) {
+  for (const store of discovery.discoverStores(cwd || process.cwd())) {
     out.push(...listSchemasFromStore(store));
   }
   return out;
@@ -270,13 +179,13 @@ function findSchemaTiers(cwd, name) {
 }
 
 module.exports = {
-  MARKER,
-  FOLDER,
-  SHARED_FOLDER,
-  safeExec,
-  getProjectName,
-  candidateStores,
-  discoverStores,
+  MARKER: discovery.MARKER,
+  FOLDER: discovery.FOLDER,
+  SHARED_FOLDER: discovery.SHARED_FOLDER,
+  safeExec: discovery.safeExec,
+  getProjectName: discovery.getProjectName,
+  candidateStores: discovery.candidateStores,
+  discoverStores: discovery.discoverStores,
   parseFrontmatter,
   serializeFrontmatter,
   serializeValue,

--- a/plugins/maestro/lib/storeDiscovery/index.js
+++ b/plugins/maestro/lib/storeDiscovery/index.js
@@ -1,0 +1,4 @@
+// GENERATED — edit factories/storeDiscovery/index.js and run scripts/sync-vendored.js
+
+'use strict';
+module.exports = require('./storeDiscovery');

--- a/plugins/maestro/lib/storeDiscovery/storeDiscovery.js
+++ b/plugins/maestro/lib/storeDiscovery/storeDiscovery.js
@@ -1,0 +1,252 @@
+// GENERATED — edit factories/storeDiscovery/storeDiscovery.js and run scripts/sync-vendored.js
+
+'use strict';
+
+/**
+ * storeDiscovery — factory for tiered, marker-gated store discovery.
+ *
+ * Plugins persist per-project artifacts in a "store": a directory under
+ * `.claude/<folder>` gated by a marker file, so only explicitly installed
+ * locations are ever read. Stores are discovered across four tiers and
+ * returned in a fixed precedence order:
+ *
+ *   local    → <cwd>/.claude/<folder>
+ *   worktree → nearest ancestor above cwd carrying the marker
+ *   global   → ~/.claude/<folder>/<projectName>
+ *   shared   → ~/.claude/<folder>-shared   (cross-project)
+ *
+ * The decision matrix IS the config:
+ *
+ * - `folder` / `marker` name the store directory and its gate file. The
+ *   shared tier always lives at `<folder>-shared`, a SIBLING of the
+ *   per-project namespace, so a project whose name happens to match the
+ *   shared folder can never shadow it.
+ * - `projectNameStrategy` picks how the global tier derives its name.
+ *   'git-common-dir' prefers the git common dir so a linked worktree
+ *   resolves to the MAIN repo name (the common dir is `<main>/.git` for the
+ *   main checkout and every linked worktree), falling back to the toplevel
+ *   basename, then basename(cwd). 'toplevel' is basename(toplevel || cwd).
+ * - `ancestorWalkStopsAtHome` bounds the worktree ancestor walk. When true,
+ *   each directory's marker is checked FIRST and the walk then stops at the
+ *   user's home directory: a marker AT `$HOME/.claude/<folder>` stays
+ *   discoverable, but the walk never continues PAST home (a sandboxed $HOME
+ *   cannot leak the real user's store). When false the walk continues to
+ *   the filesystem root. Either way exhaustion returns ''.
+ * - `disableHomeStoresEnvVar` optionally names an env var that, when set to
+ *   '1' at discovery time, skips the home-rooted tiers (global + shared) —
+ *   used by test suites to pin discovery to cwd-rooted fixtures.
+ *
+ * Invariants preserved for every caller:
+ * - `os.homedir()` is resolved per call, never cached at module load, so
+ *   suites that reassign `process.env.HOME` observe the override (POSIX).
+ * - IO fails open: `safeExec` returns '' on any failure, discovery never
+ *   throws for missing directories, and nothing is written to stderr.
+ * - `discoverStores` is data-driven off PRECEDENCE_ORDER, gates every tier
+ *   on marker existence, tolerates a falsy tier dir, de-duplicates by
+ *   resolved dir, and stamps the shared tier with `projectName: null`
+ *   (it is cross-project by design).
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+// Discovery/precedence order shared by every store instance. When the same
+// artifact exists in multiple tiers, earlier kinds win downstream.
+const PRECEDENCE_ORDER = Object.freeze(['local', 'worktree', 'global', 'shared']);
+// Tiers rooted under os.homedir() — the ones the env gate can switch off.
+const HOME_TIERS = new Set(['global', 'shared']);
+const PROJECT_NAME_STRATEGIES = new Set(['git-common-dir', 'toplevel']);
+const CLAUDE_DIR = '.claude';
+
+// ── config validation ────────────────────────────────────────────────────────
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requiredString(config, key) {
+  const value = config[key];
+  if (value === undefined) throw new TypeError(`storeDiscovery: missing "${key}"`);
+  if (typeof value !== 'string' || value === '') {
+    throw new TypeError(`storeDiscovery: "${key}" must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalBoolean(config, key) {
+  const value = config[key];
+  if (value === undefined) return false;
+  if (typeof value !== 'boolean') {
+    throw new TypeError(`storeDiscovery: "${key}" must be a boolean`);
+  }
+  return value;
+}
+
+function optionalEnvVarName(config, key) {
+  const value = config[key];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string' || value === '') {
+    throw new TypeError(`storeDiscovery: "${key}" must be a non-empty string or null`);
+  }
+  return value;
+}
+
+function assertConfig(config) {
+  if (!isPlainObject(config)) throw new TypeError('storeDiscovery: config object required');
+  const folder = requiredString(config, 'folder');
+  const marker = requiredString(config, 'marker');
+  const strategy = requiredString(config, 'projectNameStrategy');
+  if (!PROJECT_NAME_STRATEGIES.has(strategy)) {
+    throw new TypeError(
+      'storeDiscovery: invalid "projectNameStrategy" — expected "git-common-dir" or "toplevel"'
+    );
+  }
+  return Object.freeze({
+    folder,
+    marker,
+    sharedFolder: `${folder}-shared`,
+    strategy,
+    stopsAtHome: optionalBoolean(config, 'ancestorWalkStopsAtHome'),
+    envVar: optionalEnvVarName(config, 'disableHomeStoresEnvVar'),
+  });
+}
+
+// ── git helpers ──────────────────────────────────────────────────────────────
+
+// Pass cwd through to execSync so git resolves relative to the caller's path,
+// not the host process's cwd — hooks may be invoked from one cwd while
+// processing a payload with a different one. Fails open to ''.
+function safeExec(cmd, cwd) {
+  const opts = { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] };
+  try {
+    return execSync(cmd, opts).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Git toplevel of cwd, or cwd itself when not in a repo. */
+function getRepoRoot(cwd) {
+  const base = cwd || process.cwd();
+  return safeExec('git rev-parse --show-toplevel', base) || base;
+}
+
+// 'git-common-dir': inside a linked worktree, --show-toplevel returns the
+// worktree directory, which would derive a divergent global-store name. The
+// common dir is `<main-checkout>/.git` for the main checkout and every linked
+// worktree, so its parent's basename is the real repo name. Guarded on the
+// `.git` basename so bare repos and exotic GIT_DIR layouts fall through to
+// the toplevel/cwd fallback.
+function projectNameOf(spec, cwd) {
+  const base = cwd || process.cwd();
+  if (spec.strategy === 'git-common-dir') {
+    const commonDir = safeExec('git rev-parse --path-format=absolute --git-common-dir', base);
+    if (commonDir && path.basename(commonDir) === '.git') {
+      return path.basename(path.dirname(commonDir));
+    }
+  }
+  return path.basename(getRepoRoot(base));
+}
+
+// ── tier geometry ────────────────────────────────────────────────────────────
+
+// Canonical directory for one tier. os.homedir() is deliberately read here,
+// at call time, so a reassigned $HOME is honored per call.
+function tierDirOf(spec, kind, cwd, projectName) {
+  switch (kind) {
+    case 'local':
+      return path.join(cwd, CLAUDE_DIR, spec.folder);
+    case 'worktree':
+      return path.resolve(cwd, '..', CLAUDE_DIR, spec.folder);
+    case 'global':
+      return path.join(os.homedir(), CLAUDE_DIR, spec.folder, projectName);
+    case 'shared':
+      return path.join(os.homedir(), CLAUDE_DIR, spec.sharedFolder);
+    default:
+      return '';
+  }
+}
+
+function candidateRows(spec, cwd, projectName) {
+  return PRECEDENCE_ORDER.map((kind) => ({ kind, dir: tierDirOf(spec, kind, cwd, projectName) }));
+}
+
+// ── ancestor walk ────────────────────────────────────────────────────────────
+
+// Nearest ancestor of startDir carrying `<ancestor>/.claude/<folder>/<marker>`.
+// Returns the store dir, or '' on exhaustion (filesystem root — or the home
+// directory when the walk is home-bounded; the marker AT home is still
+// checked before stopping). The walk is why a store at a worktree base still
+// resolves from a sub-directory of the worktree.
+function ancestorStore(spec, startDir) {
+  const home = spec.stopsAtHome ? os.homedir() : null;
+  let dir = startDir;
+  for (;;) {
+    const storeDir = path.join(dir, CLAUDE_DIR, spec.folder);
+    if (fs.existsSync(path.join(storeDir, spec.marker))) return storeDir;
+    if (dir === home) return '';
+    const parent = path.dirname(dir);
+    if (parent === dir) return '';
+    dir = parent;
+  }
+}
+
+// ── discovery ────────────────────────────────────────────────────────────────
+
+function homeTiersDisabled(spec) {
+  return spec.envVar !== null && process.env[spec.envVar] === '1';
+}
+
+// Active stores (those with a marker) in PRECEDENCE_ORDER, de-duplicated by
+// resolved dir. The worktree tier comes from the ancestor walk starting at
+// dirname(cwd) — NOT from the fixed candidate row — so nested worktree
+// layouts resolve; the falsy-dir guard absorbs a walk miss ('').
+function discover(spec, cwd) {
+  const resolved = cwd || process.cwd();
+  const projectName = projectNameOf(spec, resolved);
+  const skipHome = homeTiersDisabled(spec);
+  const found = [];
+  const seen = new Set();
+
+  const push = (kind, dir) => {
+    if (!dir || !fs.existsSync(path.join(dir, spec.marker))) return;
+    const key = path.resolve(dir);
+    if (seen.has(key)) return;
+    seen.add(key);
+    // The shared store is cross-project, so it is never stamped with the
+    // caller's projectName.
+    found.push({ kind, dir, projectName: kind === 'shared' ? null : projectName });
+  };
+
+  for (const kind of PRECEDENCE_ORDER) {
+    if (skipHome && HOME_TIERS.has(kind)) continue;
+    if (kind === 'worktree') {
+      push(kind, ancestorStore(spec, path.dirname(resolved)));
+    } else {
+      push(kind, tierDirOf(spec, kind, resolved, projectName));
+    }
+  }
+  return found;
+}
+
+// ── factory ──────────────────────────────────────────────────────────────────
+
+function createStoreDiscovery(config) {
+  const spec = assertConfig(config);
+  return Object.freeze({
+    MARKER: spec.marker,
+    FOLDER: spec.folder,
+    SHARED_FOLDER: spec.sharedFolder,
+    PRECEDENCE_ORDER,
+    safeExec,
+    getRepoRoot,
+    getProjectName: (cwd) => projectNameOf(spec, cwd),
+    candidateStores: (cwd, projectName) => candidateRows(spec, cwd, projectName),
+    findAncestorStore: (startDir) => ancestorStore(spec, startDir),
+    discoverStores: (cwd) => discover(spec, cwd),
+  });
+}
+
+module.exports = { createStoreDiscovery };

--- a/plugins/synapsys/lib/safeSubprocess/index.js
+++ b/plugins/synapsys/lib/safeSubprocess/index.js
@@ -1,0 +1,4 @@
+// GENERATED — edit factories/safeSubprocess/index.js and run scripts/sync-vendored.js
+
+'use strict';
+module.exports = require('./safeSubprocess');

--- a/plugins/synapsys/lib/safeSubprocess/safeSubprocess.js
+++ b/plugins/synapsys/lib/safeSubprocess/safeSubprocess.js
@@ -1,0 +1,123 @@
+// GENERATED — edit factories/safeSubprocess/safeSubprocess.js and run scripts/sync-vendored.js
+
+'use strict';
+
+/**
+ * safeSubprocess — synchronous subprocess wrappers that make timeouts
+ * non-optional and shell interpolation impossible.
+ *
+ * A synchronous child-process call with no deadline can freeze the entire
+ * event loop of whatever host invoked it. These wrappers exist so a call
+ * site can never *silently* opt out of a deadline: every invocation either
+ * runs under a positive finite timeout (default 15000 ms) or carries an
+ * explicit, human-readable justification for running without one.
+ *
+ * Decision matrix, in prose:
+ *
+ * - `command` must be a non-empty string, `args` an array of strings, and
+ *   `opts` a plain object; anything else throws a TypeError immediately.
+ * - When `opts.timeout` is absent, the default of 15000 ms is applied.
+ * - When `opts.timeout` is a positive integer, it is used as-is.
+ * - When `opts.timeout` is anything else — null, 0, a negative number,
+ *   NaN, Infinity, a non-integer like 15.5 or 5e-324 (which Node itself
+ *   would only reject later with a less actionable RangeError), or a
+ *   non-number — the call throws a TypeError. There is no value that
+ *   means "no timeout".
+ * - The only way to run without a deadline is `opts.noTimeout` set to a
+ *   non-empty justification string; the timeout key is then omitted from
+ *   the final options entirely. A `noTimeout` that is not a non-empty
+ *   string throws a TypeError.
+ * - `opts.shell` is always stripped and replaced with `shell: false`;
+ *   arguments are passed positionally and shell metacharacters stay
+ *   literal. There is no opt-out.
+ * - Every other option (`cwd`, `encoding`, `env`, `input`, `stdio`, ...)
+ *   passes through untouched.
+ *
+ * The two exports differ only in failure semantics, mirroring their
+ * `node:child_process` counterparts:
+ *
+ * - `safeSpawnSync` returns the raw `spawnSync` result object. It never
+ *   throws for runtime failures (nonzero exit, missing binary, timeout) —
+ *   callers keep their own success predicates over `status` / `stdout` /
+ *   `signal` / `error`.
+ * - `safeExecFileSync` returns `execFileSync`'s return value and throws
+ *   on any failure, exactly like the native call.
+ */
+
+const { execFileSync, spawnSync } = require('node:child_process');
+
+const DEFAULT_TIMEOUT_MS = 15000;
+
+function assertCommand(command) {
+  if (typeof command === 'string' && command.length > 0) return;
+  throw new TypeError('safeSubprocess: command must be a non-empty string');
+}
+
+function assertArgs(args) {
+  const ok = Array.isArray(args) && args.every((arg) => typeof arg === 'string');
+  if (!ok) throw new TypeError('safeSubprocess: args must be an array of strings');
+}
+
+function assertOpts(opts) {
+  if (opts === null || typeof opts !== 'object' || Array.isArray(opts)) {
+    throw new TypeError('safeSubprocess: opts must be an object');
+  }
+}
+
+/**
+ * Resolve the effective timeout for a call, or `undefined` when the caller
+ * supplied a valid `noTimeout` justification. Throws on every shape that
+ * would disable the deadline without saying why.
+ */
+function resolveTimeout(opts) {
+  if (opts.noTimeout !== undefined) {
+    if (typeof opts.noTimeout !== 'string' || opts.noTimeout.trim().length === 0) {
+      throw new TypeError('safeSubprocess: "noTimeout" must be a non-empty justification string');
+    }
+    return undefined;
+  }
+  const timeout = opts.timeout === undefined ? DEFAULT_TIMEOUT_MS : opts.timeout;
+  if (!Number.isInteger(timeout) || timeout <= 0) {
+    throw new TypeError(
+      'safeSubprocess: "timeout" must be a positive integer number of milliseconds; ' +
+        'pass { noTimeout: "<justification>" } to run without a deadline'
+    );
+  }
+  return timeout;
+}
+
+/** Build the options object actually handed to child_process. */
+function buildFinalOpts(opts) {
+  const timeout = resolveTimeout(opts);
+  const final = { ...opts, shell: false };
+  delete final.noTimeout;
+  delete final.timeout;
+  if (timeout !== undefined) final.timeout = timeout;
+  return final;
+}
+
+function invoke(runner, command, args, opts) {
+  assertCommand(command);
+  assertArgs(args);
+  assertOpts(opts);
+  return runner(command, args, buildFinalOpts(opts));
+}
+
+/**
+ * `spawnSync` under the timeout policy above. Returns the raw result
+ * object — status, stdout, stderr, signal, error — untouched, so callers
+ * keep their own success predicates (e.g. `r.status === 0 && r.stdout`).
+ */
+function safeSpawnSync(command, args = [], opts = {}) {
+  return invoke(spawnSync, command, args, opts);
+}
+
+/**
+ * `execFileSync` under the timeout policy above. Native semantics:
+ * returns stdout on success, throws on nonzero exit / signal / timeout.
+ */
+function safeExecFileSync(command, args = [], opts = {}) {
+  return invoke(execFileSync, command, args, opts);
+}
+
+module.exports = { safeSpawnSync, safeExecFileSync };

--- a/plugins/synapsys/lib/ticket-id.js
+++ b/plugins/synapsys/lib/ticket-id.js
@@ -11,20 +11,21 @@
  * @module lib/ticket-id
  */
 
-const { execSync } = require('node:child_process');
+const { safeExecFileSync } = require('./safeSubprocess');
 
 const TICKET_PATTERN = /([A-Z]+-\d+)/i;
 const GH_PATTERN = /GH-(\d+)/i;
 
 /**
- * Default branch reader — shells out to git in `cwd`. Injectable via the
- * `exec` option so unit tests never touch a real repository.
+ * Default branch reader — runs git in `cwd` (no shell, default 15s deadline;
+ * throws on failure like the native call). Injectable via the `exec` option
+ * so unit tests never touch a real repository.
  *
  * @param {string} cwd
  * @returns {string} current branch name (trimmed) or '' on failure
  */
 function readGitBranch(cwd) {
-  return execSync('git branch --show-current', {
+  return safeExecFileSync('git', ['branch', '--show-current'], {
     cwd,
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/plugins/synapsys/scripts/synapsys-replay.js
+++ b/plugins/synapsys/scripts/synapsys-replay.js
@@ -26,7 +26,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
+const { safeSpawnSync } = require('../lib/safeSubprocess');
 const cliShared = require('../lib/replay-cli-shared');
 const events = require('../lib/replay-events');
 const aggregate = require('../lib/replay-aggregate');
@@ -92,8 +92,10 @@ function lastJsonLine(stdout) {
 // verbatim. Exits the process on a spawn error; otherwise returns the child's
 // exit status plus the last JSON envelope it printed (or null).
 function runPhaseTurn(childArgs) {
-  const result = spawnSync(process.execPath, [NEXT_RUNNER, ...childArgs], {
+  const result = safeSpawnSync(process.execPath, [NEXT_RUNNER, ...childArgs], {
     encoding: 'utf8',
+    noTimeout:
+      'walk turns replay the entire transcript window in one child run; runtime scales with history size, so no fixed deadline is safe',
   });
   if (result.error) {
     process.stderr.write(`synapsys-replay: ${result.error.message}\n`);

--- a/plugins/synapsys/scripts/synapsys-staleness-check.js
+++ b/plugins/synapsys/scripts/synapsys-staleness-check.js
@@ -26,7 +26,7 @@
 
 // nodePath is needed before bootstrap is loaded to construct the require paths below.
 const nodePath = require('node:path');
-const { spawnSync } = require('node:child_process');
+const { safeSpawnSync } = require(nodePath.join(__dirname, '..', 'lib', 'safeSubprocess'));
 const { fs, path, setupCli, discoverStores, listMemoriesFromStore } = require(
   nodePath.join(__dirname, '..', 'lib', 'script-bootstrap')
 );
@@ -228,7 +228,9 @@ function dispatchReconsolidate(grouped, opts) {
     // Route child stdout to stderr when --json is active so the parent's
     // JSON payload remains the only thing on stdout.
     const childStdio = opts.json ? ['inherit', process.stderr, 'inherit'] : 'inherit';
-    const result = spawnSync(process.execPath, [consolidateBin, '--profile=' + profile.name], {
+    // Default 15s deadline (safeSpawnSync); a timed-out child surfaces as a
+    // nonzero/null status and is reported via the existing warning path.
+    const result = safeSpawnSync(process.execPath, [consolidateBin, '--profile=' + profile.name], {
       stdio: childStdio,
     });
     if (result.status !== 0) {

--- a/plugins/synapsys/scripts/synapsys-test.js
+++ b/plugins/synapsys/scripts/synapsys-test.js
@@ -14,7 +14,7 @@
  */
 
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
+const { safeSpawnSync } = require(path.join(__dirname, '..', 'lib', 'safeSubprocess'));
 const { makeFlag } = require(path.join(__dirname, '..', 'lib', 'cli-args'));
 
 const flag = makeFlag(process.argv.slice(2));
@@ -38,7 +38,8 @@ if (event === 'UserPromptSubmit') {
 }
 
 const dispatcher = path.join(__dirname, '..', 'hooks', 'synapsys.js');
-const result = spawnSync('node', [dispatcher, event], {
+// Default 15s deadline (safeSpawnSync) — the dispatcher is a fast local hook.
+const result = safeSpawnSync('node', [dispatcher, event], {
   input: JSON.stringify(payload),
   encoding: 'utf8',
 });

--- a/plugins/synapsys/tests/cortex-recall.integration.test.js
+++ b/plugins/synapsys/tests/cortex-recall.integration.test.js
@@ -41,9 +41,21 @@ function mkHome() {
 function cleanup(dir) {
   // Detached background recall jobs may still be writing into the store when a
   // test reaches teardown, so a plain recursive rmSync can lose the rmdir/readdir
-  // race and throw ENOTEMPTY (observed only under Node 20's timing). maxRetries
-  // makes rmSync re-walk the tree until the writer settles.
-  fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  // race and throw ENOTEMPTY (observed under Node 20 and 22 CI timing). rmSync's
+  // own maxRetries only re-attempts the failing rmdir — if the writer creates a
+  // NEW file between re-walks it can still lose, so wrap it in an outer settle
+  // loop that re-walks the whole tree until the writer finishes (bounded, then
+  // rethrows so a truly stuck writer still fails loudly).
+  const deadline = Date.now() + 10000;
+  for (;;) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+      return;
+    } catch (err) {
+      if (err.code !== 'ENOTEMPTY' || Date.now() > deadline) throw err;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+    }
+  }
 }
 
 function cacheFilePath(home, sessionId) {

--- a/plugins/work/hooks/work-hook.js
+++ b/plugins/work/hooks/work-hook.js
@@ -7,7 +7,6 @@
  * when /work is invoked, injecting the plan into the context.
  */
 
-const fs = require('fs');
 const path = require('path');
 // Resolve paths via the canonical scripts/workflows/... layout. The plugin root
 // historically also exposed `workflows -> scripts/workflows` as a committed
@@ -15,6 +14,9 @@ const path = require('path');
 // MODULE_NOT_FOUND (loader:1459) if the symlink is ever missing (clean clone
 // without symlinks, copy to a filesystem that strips them, refactor that
 // removes it). Use the real path so the hook never depends on the symlink.
+const { runHook } = require(
+  path.join(__dirname, '..', 'scripts', 'workflows', 'lib', 'hookEntrypoint')
+);
 const { appendAction } = require(
   path.join(__dirname, '..', 'scripts', 'workflows', 'work', 'lib', 'work-actions')
 );
@@ -53,17 +55,6 @@ const ORCHESTRATOR_PATH = path.join(
 // shell tokenization behavior.
 function tokenizeArgs(rawArgs) {
   return rawArgs.split(/\s+/).filter((token) => token.length > 0);
-}
-
-// Parse the UserPromptSubmit payload from stdin. Codex never sets
-// CLAUDE_USER_PROMPT, so payload.prompt is the only prompt source there;
-// on claude the env leg stays first (byte-identity).
-function readStdinPayload() {
-  try {
-    return JSON.parse(fs.readFileSync(0, 'utf8'));
-  } catch {
-    return {};
-  }
 }
 
 // Bridge runtime identity to the orchestrator child (and any libs reading
@@ -172,8 +163,10 @@ async function resolveBanner() {
   }
 }
 
-async function main() {
-  const payload = readStdinPayload();
+// The payload is read/parsed by runHook (hookEntrypoint). Codex never sets
+// CLAUDE_USER_PROMPT, so payload.prompt is the only prompt source there;
+// on claude the env leg stays first (byte-identity).
+async function main(payload) {
   const payloadPrompt = typeof payload.prompt === 'string' ? payload.prompt : '';
   const userPrompt = process.env.CLAUDE_USER_PROMPT || payloadPrompt;
 
@@ -289,8 +282,9 @@ function formatPlan(plan) {
   return lines.join('\n');
 }
 
-// Fail-open: a rejected main() must never crash the hook (exit non-zero).
-main().catch((err) => {
-  logHookError(__filename, err);
-  process.exit(0);
-});
+// Canonical entry protocol (stdin read, payload parse, fail-open error
+// handling: unexpected errors — including a rejected async main() — are
+// logged via logHookError and exit 0). The handler's own
+// console.log-then-exit(0) failure paths in fetchPlan are untouched —
+// runHook never intercepts stdout or an explicit process.exit.
+runHook(main, { file: __filename });

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -1041,7 +1041,9 @@ describe('enforce-step-workflow', () => {
       assert.equal(evidence['check']?.tool, 'Skill');
 
       const files = fs.readdirSync(TASKS_DIR);
-      const tmpFiles = files.filter((f) => f.includes('.tmp.'));
+      // Covers both tmp namings: the legacy `<target>.tmp.<pid>` and the
+      // vendored safeIO `<target>.<pid>.tmp` the writer now uses.
+      const tmpFiles = files.filter((f) => f.endsWith('.tmp') || f.includes('.tmp.'));
       assert.equal(tmpFiles.length, 0, 'No temp files should remain');
     });
   });

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-agent-usage.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-agent-usage.js
@@ -22,7 +22,7 @@
 const path = require('path');
 const { isRunningInAgent } = require('../agent-detection');
 const { commandAccessesProtectedPaths } = require('../command-analysis');
-const { logHookError } = require('../hook-error-log');
+const { runHook } = require('../hookEntrypoint');
 // Vendored dual-runtime adapter: runtime detection for the per-runtime block
 // texts (codex has no Task tool — required agents run as INLINE personas).
 const { getRuntime } = require('../runtime');
@@ -275,10 +275,7 @@ function enforceScriptBypass(toolName, toolInput, transcriptPath, hookData, runt
   process.exit(2);
 }
 
-async function main() {
-  let input = '';
-  for await (const chunk of process.stdin) input += chunk;
-  const hookData = JSON.parse(input);
+function main(hookData) {
   const runtime = getRuntime(hookData).name;
   const toolName = hookData.tool_name;
   const toolInput = hookData.tool_input || {};
@@ -290,14 +287,11 @@ async function main() {
   process.exit(0);
 }
 
-// Only read stdin / run when invoked directly as the hook; stay importable for tests.
+// Only read stdin / run when invoked directly as the hook; stay importable for
+// tests. runHook is fail open — internal errors are logged (logHookError) and
+// exit 0, never blocking legitimate operations.
 if (require.main === module) {
-  main().catch((err) => {
-    try {
-      logHookError(__filename, err);
-    } catch {}
-    process.exit(0); // fail open — never block legitimate operations on internal error
-  });
+  runHook(main, { file: __filename });
 }
 
 module.exports = {

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-ui-imports.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-ui-imports.js
@@ -17,7 +17,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
+const { runHook } = require(path.join(__dirname, '..', 'hookEntrypoint'));
 
 // UI documentation files that indicate a project has its own UI package
 const UI_DOC_FILES = [
@@ -261,13 +261,57 @@ function getFilePathFromToolInput(toolName, toolInput) {
   }
 }
 
-async function main() {
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
+/**
+ * Emit the block message for forbidden imports and exit 2.
+ * The message text is byte-identical to the historical inline version.
+ */
+function blockForbiddenImports(forbiddenImports, allowedImports) {
+  const importsList = forbiddenImports
+    .map((f) => `  - ${f.framework}: ${f.components.join(', ')}`)
+    .join('\n');
 
-  const hookData = JSON.parse(input);
+  const allowedList = allowedImports.slice(0, 10).join(', ') + '...';
+
+  process.stderr.write(`╔══════════════════════════════════════════════════════════════════════╗
+║  ❌ FORBIDDEN UI FRAMEWORK IMPORTS DETECTED                          ║
+╠══════════════════════════════════════════════════════════════════════╣
+║                                                                      ║
+║  This repository has a UI component library. You MUST use it.        ║
+║                                                                      ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+🚫 Blocked imports:
+${importsList}
+
+✅ Allowed MUI primitives: ${allowedList}
+
+📖 UI Documentation found in this repo - READ FIRST:
+   - packages/ui/components-catalog.md
+   - packages/shared-ui/README.md
+
+╔══════════════════════════════════════════════════════════════════════╗
+║  YOUR OPTIONS:                                                       ║
+╠══════════════════════════════════════════════════════════════════════╣
+║                                                                      ║
+║  1. USE PROJECT UI PACKAGE (Recommended)                             ║
+║     Import from your project UI package or similar                    ║
+║     Read components-catalog.md to find equivalent components         ║
+║                                                                      ║
+║  2. ASK USER FOR PERMISSION                                          ║
+║     Use AskUserQuestion tool to ask:                                 ║
+║     "The UI package doesn't have X component. May I import           ║
+║      directly from @mui/material for this specific case?"            ║
+║                                                                      ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+⚠️ This hook enforces UI consistency. If you're building the UI package
+   itself (packages/ui or packages/shared-ui), this restriction doesn't apply.
+`);
+  process.exit(2);
+}
+
+// The payload is read/parsed by runHook (hookEntrypoint).
+function main(hookData) {
   const toolName = hookData.tool_name;
   const toolInput = hookData.tool_input || {};
 
@@ -316,7 +360,6 @@ async function main() {
   // Determine which allowed list to use based on folder
   const isSharedUI = reactFiles.some((fp) => isInSharedUIFolder(fp, gitRoot));
   const allowedImports = isSharedUI ? ALLOWED_MUI_IMPORTS_SHARED_UI : ALLOWED_MUI_IMPORTS_APPS;
-  const folderContext = isSharedUI ? 'shared-ui' : 'apps';
 
   // Check for forbidden imports
   const forbiddenImports = extractForbiddenImports(content, allowedImports);
@@ -326,53 +369,9 @@ async function main() {
     process.exit(0);
   }
 
-  // Build detailed error message
-  const importsList = forbiddenImports
-    .map((f) => `  - ${f.framework}: ${f.components.join(', ')}`)
-    .join('\n');
-
-  const allowedList = allowedImports.slice(0, 10).join(', ') + '...';
-
-  process.stderr.write(`╔══════════════════════════════════════════════════════════════════════╗
-║  ❌ FORBIDDEN UI FRAMEWORK IMPORTS DETECTED                          ║
-╠══════════════════════════════════════════════════════════════════════╣
-║                                                                      ║
-║  This repository has a UI component library. You MUST use it.        ║
-║                                                                      ║
-╚══════════════════════════════════════════════════════════════════════╝
-
-🚫 Blocked imports:
-${importsList}
-
-✅ Allowed MUI primitives: ${allowedList}
-
-📖 UI Documentation found in this repo - READ FIRST:
-   - packages/ui/components-catalog.md
-   - packages/shared-ui/README.md
-
-╔══════════════════════════════════════════════════════════════════════╗
-║  YOUR OPTIONS:                                                       ║
-╠══════════════════════════════════════════════════════════════════════╣
-║                                                                      ║
-║  1. USE PROJECT UI PACKAGE (Recommended)                             ║
-║     Import from your project UI package or similar                    ║
-║     Read components-catalog.md to find equivalent components         ║
-║                                                                      ║
-║  2. ASK USER FOR PERMISSION                                          ║
-║     Use AskUserQuestion tool to ask:                                 ║
-║     "The UI package doesn't have X component. May I import           ║
-║      directly from @mui/material for this specific case?"            ║
-║                                                                      ║
-╚══════════════════════════════════════════════════════════════════════╝
-
-⚠️ This hook enforces UI consistency. If you're building the UI package
-   itself (packages/ui or packages/shared-ui), this restriction doesn't apply.
-`);
-  process.exit(2);
+  blockForbiddenImports(forbiddenImports, allowedImports);
 }
 
-main().catch((err) => {
-  logHookError(__filename, err);
-  // On error, approve to avoid blocking legitimate operations
-  process.exit(0);
-});
+// Canonical entry protocol: on internal error runHook logs via logHookError
+// and exits 0 — approve, to avoid blocking legitimate operations.
+runHook(main, { file: __filename });

--- a/plugins/work/scripts/workflows/lib/hooks/inject-inbox-messages.js
+++ b/plugins/work/scripts/workflows/lib/hooks/inject-inbox-messages.js
@@ -26,6 +26,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 const { getRuntime } = require('../runtime');
+const { writeJsonAtomic } = require('../safeIO');
 
 function fail() {
   process.exit(0);
@@ -79,10 +80,7 @@ function readCursors() {
 
 function writeCursors(c) {
   try {
-    const f = cursorFile();
-    const tmp = `${f}.${process.pid}.tmp`;
-    fs.writeFileSync(tmp, JSON.stringify(c), { mode: 0o644 });
-    fs.renameSync(tmp, f);
+    writeJsonAtomic(cursorFile(), c, { mode: 0o644, compact: true });
   } catch {
     /* ignore */
   }

--- a/plugins/work/scripts/workflows/lib/hooks/policies/evidence-recorder.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/evidence-recorder.js
@@ -5,7 +5,7 @@
  *
  * Provides:
  *   - loadEvidence({ tasksBase, ticketId, evidenceFile, safeTicketPath }): read evidence file
- *   - saveEvidence({ ... evidence }): atomic write via tmp+rename
+ *   - saveEvidence({ ... evidence }): atomic write via the vendored safeIO writer
  *   - recordEvidenceEntry({ toolName, toolInput }): build an evidence row from a tool call
  *   - clearBackwardEvidence({ evidence, steps, currentStep, targetStep }): clear on rewind
  *
@@ -14,6 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { writeJsonAtomic } = require('../../safeIO');
 
 function loadEvidence({ tasksBase, ticketId, evidenceFile, safeTicketPath }) {
   const p = path.join(tasksBase, safeTicketPath(ticketId), evidenceFile);
@@ -25,22 +26,12 @@ function loadEvidence({ tasksBase, ticketId, evidenceFile, safeTicketPath }) {
 }
 
 function saveEvidence({ tasksBase, ticketId, evidenceFile, evidence, safeTicketPath }) {
-  const dir = path.join(tasksBase, safeTicketPath(ticketId));
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  const target = path.join(dir, evidenceFile);
-  const tmp = `${target}.tmp.${process.pid}`;
-  fs.writeFileSync(tmp, JSON.stringify(evidence, null, 2));
-  try {
-    fs.renameSync(tmp, target);
-  } catch (err) {
-    // Windows fs.renameSync can fail when target exists — use copy+unlink as fallback
-    if (err.code === 'EEXIST' || err.code === 'EPERM') {
-      fs.copyFileSync(tmp, target);
-      fs.unlinkSync(tmp);
-    } else {
-      throw err;
-    }
-  }
+  const target = path.join(tasksBase, safeTicketPath(ticketId), evidenceFile);
+  // Vendored safeIO handles dir creation and the Windows rename-over-existing
+  // case (win32-only unlink+retry). Deliberate change: the old any-platform
+  // copyFile fallback is gone, so a pathological EPERM rename on POSIX
+  // (immutable dir) now throws instead of degrading to a non-atomic copy.
+  writeJsonAtomic(target, evidence, { mode: 0o666 });
 }
 
 /**

--- a/plugins/work/scripts/workflows/lib/hooks/workflow-router-hook.js
+++ b/plugins/work/scripts/workflows/lib/hooks/workflow-router-hook.js
@@ -15,16 +15,8 @@
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', 'hook-error-log'));
+const { runHook } = require(path.join(__dirname, '..', 'hookEntrypoint'));
 const { safeExec } = require(path.join(__dirname, '..', 'safe-exec'));
-
-process.on('uncaughtException', (err) => {
-  logHookError(__filename, err);
-  process.exit(0);
-});
-process.on('unhandledRejection', (err) => {
-  logHookError(__filename, err);
-  process.exit(0);
-});
 
 const WORKFLOWS_DIR = path.join(__dirname, '..', '..');
 const ENGINE_PATH = path.join(__dirname, '..', 'workflow-engine.js');
@@ -107,6 +99,17 @@ function main() {
   process.exit(0);
 }
 
+/** Whether a workflows-dir entry is a subdirectory worth scanning. */
+function isWorkflowSearchDir(entry) {
+  return (
+    entry.isDirectory() &&
+    !entry.name.startsWith('.') &&
+    entry.name !== 'node_modules' &&
+    entry.name !== 'lib' &&
+    entry.name !== '__tests__'
+  );
+}
+
 /**
  * Scan workflows directory and build command → name map.
  * @returns {{ [command: string]: string }}
@@ -119,13 +122,7 @@ function buildCommandMap() {
   // Scan the workflows dir and one level of subdirectories for *.workflow.js
   const searchDirs = [WORKFLOWS_DIR];
   for (const entry of fs.readdirSync(WORKFLOWS_DIR, { withFileTypes: true })) {
-    if (
-      entry.isDirectory() &&
-      !entry.name.startsWith('.') &&
-      entry.name !== 'node_modules' &&
-      entry.name !== 'lib' &&
-      entry.name !== '__tests__'
-    ) {
+    if (isWorkflowSearchDir(entry)) {
       searchDirs.push(path.join(WORKFLOWS_DIR, entry.name));
     }
   }
@@ -147,8 +144,9 @@ function buildCommandMap() {
   return map;
 }
 
-try {
-  main();
-} catch {
-  process.exit(0);
-}
+// Canonical entry protocol: stdin is drained/parsed by runHook (this hook
+// reads the prompt from CLAUDE_USER_PROMPT, so the payload is unused) and
+// unexpected errors are logged via logHookError and exit 0 (fail open).
+// NOTE: draining means the hook now waits for stdin EOF — hook runtimes pipe
+// the payload and close the stream; a custom spawner must not hold it open.
+runHook(main, { file: __filename });

--- a/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
@@ -45,12 +45,16 @@ const TEST_FILE_RE = /(?:^|[\\/])__tests__[\\/]|\.test\.js$|\.spec\.js$/;
 // the static rules and jscpd — while the masters under factories/ stay
 // covered. Mirror any change in scripts/sync-vendored.js VENDOR_SETS.
 const VENDORED_DIRS = [
+  'plugins/heimdall/lib/hookEntrypoint',
   'plugins/heimdall/lib/pathSafe',
   'plugins/heimdall/lib/runtime',
+  'plugins/heimdall/lib/safeSubprocess',
   'plugins/heimdall/lib/storeDiscovery',
+  'plugins/maestro/lib/storeDiscovery',
   'plugins/maestro/scripts/lib/runtime',
   'plugins/synapsys/lib/hookEntrypoint',
   'plugins/synapsys/lib/runtime',
+  'plugins/synapsys/lib/safeSubprocess',
   'plugins/synapsys/lib/storeDiscovery',
   'plugins/work/scripts/workflows/lib/hookEntrypoint',
   'plugins/work/scripts/workflows/lib/runtime',

--- a/plugins/work/scripts/workflows/lib/scripts/write-report.js
+++ b/plugins/work/scripts/workflows/lib/scripts/write-report.js
@@ -19,7 +19,7 @@
  *      - Timestamp is a finite number within TOKEN_MAX_AGE_MS (prevents replay)
  *      - Agent name is a non-empty string matching allowedAgents
  *   4. Required fields are validated before writing
- *   5. The report is written atomically (tmp + rename)
+ *   5. The report is written atomically (tmp + rename via the vendored safeIO writer)
  *
  * Why not CLAUDE_CURRENT_AGENT?
  *   Any agent can spoof it: `CLAUDE_CURRENT_AGENT=x node script.js`
@@ -33,6 +33,7 @@
 const fs = require('fs');
 const path = require('path');
 const { normalizeAgentName } = require('../agent-detection');
+const { writeFileAtomic } = require('../safeIO');
 
 /** Max age for a token to be considered valid (10 seconds) */
 const TOKEN_MAX_AGE_MS = 10_000;
@@ -137,6 +138,166 @@ function consumeToken(scriptBasename, ticketId) {
  * @property {string} [reportType] — Report type for post-write status validation (e.g. 'tests', 'codeReview', 'completion')
  */
 
+/** Read stdin to completion and parse it as JSON — exits 1 on invalid input. */
+async function readInputFromStdin(name) {
+  let rawInput = '';
+  for await (const chunk of process.stdin) {
+    rawInput += chunk;
+  }
+  try {
+    return JSON.parse(rawInput);
+  } catch (e) {
+    process.stderr.write(`[${name}] ERROR: Invalid JSON input.\n${e.message}\n`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Enforcement 1: Hook-issued token verification.
+ * The PreToolUse hook (Rule 5) writes a token file after verifying agent
+ * identity via Claude Code's internal hookData. We consume that token here.
+ * This cannot be spoofed because the token is written by the hook process,
+ * not by the Bash command the agent executes.
+ * Exits 2 on any failure; returns the verified token on success.
+ */
+function requireVerifiedToken(name, allowedAgents) {
+  const scriptBasename = path.basename(process.argv[1] || '');
+  const token = consumeToken(scriptBasename); // reads + deletes token atomically
+
+  if (!token) {
+    process.stderr.write(
+      `[${name}] BLOCKED: No valid write token found.\n` +
+        `  Expected token at: ${tokenPath(scriptBasename)}\n` +
+        `  The PreToolUse hook must approve this call first.\n` +
+        `  This script can only be called through Claude Code's agent system.\n`
+    );
+    process.exit(2);
+  }
+
+  // Validate token structure: timestamp must be a finite number, agent must be a string
+  if (typeof token.timestamp !== 'number' || !Number.isFinite(token.timestamp)) {
+    process.stderr.write(`[${name}] BLOCKED: Token has invalid or missing timestamp.\n`);
+    process.exit(2);
+  }
+  if (typeof token.agent !== 'string' || !token.agent) {
+    process.stderr.write(`[${name}] BLOCKED: Token has invalid or missing agent field.\n`);
+    process.exit(2);
+  }
+
+  // Check token freshness — prevents replay with pre-placed token files
+  // Reject expired AND future timestamps (clock skew / tampered tokens)
+  const age = Date.now() - token.timestamp;
+  if (age < 0 || age > TOKEN_MAX_AGE_MS) {
+    process.stderr.write(
+      `[${name}] BLOCKED: Write token expired (${age}ms old, max ${TOKEN_MAX_AGE_MS}ms).\n` +
+        `  Token was issued at ${new Date(token.timestamp).toISOString()}\n`
+    );
+    process.exit(2);
+  }
+
+  // Check agent in token matches allowedAgents
+  const agentMatch = allowedAgents.some(
+    (a) => normalizeAgentName(a) === normalizeAgentName(token.agent)
+  );
+  if (!agentMatch) {
+    process.stderr.write(
+      `[${name}] BLOCKED: Token agent "${token.agent}" is not authorized.\n` +
+        `  Allowed agents: ${allowedAgents.join(', ')}\n` +
+        `  Only these agents can use this writer.\n`
+    );
+    process.exit(2);
+  }
+
+  return token;
+}
+
+/** Enforcement 2 + 3: required fields + writer-specific validation. Exits 1 on errors. */
+function requireValidInput(name, input, requiredFields, validate) {
+  const errors = [];
+  for (const field of requiredFields) {
+    if (input[field] === undefined || input[field] === null || input[field] === '') {
+      errors.push(`Missing required field: "${field}"`);
+    }
+  }
+  if (validate) {
+    const extra = validate(input);
+    if (extra && extra.length > 0) {
+      errors.push(...extra);
+    }
+  }
+  if (errors.length > 0) {
+    process.stderr.write(
+      `[${name}] VALIDATION FAILED:\n` + errors.map((e, i) => `  ${i + 1}. ${e}`).join('\n') + '\n'
+    );
+    process.exit(1);
+  }
+}
+
+/** reportPath must be a non-empty absolute path inside the token's tasksBase. Exits 1/2. */
+function requireSafeReportPath(name, input, token) {
+  const reportPath = input.reportPath;
+  if (typeof reportPath !== 'string' || !reportPath.trim()) {
+    process.stderr.write(`[${name}] ERROR: "reportPath" must be a non-empty string.\n`);
+    process.exit(1);
+  }
+  // Guard against path traversal — reportPath must be absolute
+  if (!path.isAbsolute(reportPath)) {
+    process.stderr.write(`[${name}] ERROR: "reportPath" must be an absolute path.\n`);
+    process.exit(1);
+  }
+  // Scope reportPath to the ticket's task folder (bound into token by hook)
+  if (token.tasksBase) {
+    const resolved = path.resolve(reportPath);
+    if (!resolved.startsWith(token.tasksBase + path.sep) && resolved !== token.tasksBase) {
+      process.stderr.write(
+        `[${name}] BLOCKED: reportPath is outside the ticket's task folder.\n` +
+          `  reportPath: ${resolved}\n` +
+          `  Allowed folder: ${token.tasksBase}/\n`
+      );
+      process.exit(2);
+    }
+  }
+  return reportPath;
+}
+
+/** Post-write validation: formatted output must have a parseable Status line (GH-326). */
+function requireStatusLine(name, newContent, reportType) {
+  if (!reportType) return;
+  const { STATUS_LINE_RE, resolveAlias } = require('../parse-report-status');
+  const statusMatch = newContent.match(STATUS_LINE_RE);
+  const hasValidStatus = statusMatch && resolveAlias(statusMatch[1].toUpperCase(), reportType);
+  if (!hasValidStatus) {
+    process.stderr.write(
+      `[${name}] VALIDATION FAILED: Formatted report has no parseable Status line.\n` +
+        `  parseReportStatus returned: ${hasValidStatus ? 'valid' : 'UNKNOWN'}\n` +
+        `  The formatReport() function must include a "Status: <VALUE>" line.\n` +
+        `  This is a bug in the report writer, not in the agent input.\n`
+    );
+    process.exit(1);
+  }
+}
+
+/** Prepend strategy: if file exists, preserve old content with separator. */
+function composeFinalContent(reportPath, newContent) {
+  if (!fs.existsSync(reportPath)) return newContent;
+  const oldContent = fs.readFileSync(reportPath, 'utf8');
+  const timestamp = new Date().toISOString();
+  return newContent + `\n\n---\n## Previous Run: ${timestamp}\n---\n\n` + oldContent;
+}
+
+/** Reject symlink targets — prevents overwriting unexpected files. Exits 2. */
+function rejectSymlinkTarget(name, reportPath) {
+  try {
+    const stat = fs.lstatSync(reportPath);
+    if (stat.isSymbolicLink()) {
+      process.stderr.write(`[${name}] BLOCKED: reportPath is a symlink — refusing to write.\n`);
+      process.exit(2);
+    }
+  } catch {
+    /* file doesn't exist yet — fine */
+  }
+}
+
 /**
  * Create a report writer instance.
  *
@@ -147,177 +308,30 @@ function createReportWriter(config) {
   const { name, allowedAgents, requiredFields, formatReport, validate, reportType } = config;
 
   async function run() {
-    // Parse input from stdin (JSON)
-    let rawInput = '';
-    for await (const chunk of process.stdin) {
-      rawInput += chunk;
-    }
-
-    let input;
-    try {
-      input = JSON.parse(rawInput);
-    } catch (e) {
-      process.stderr.write(`[${name}] ERROR: Invalid JSON input.\n${e.message}\n`);
-      process.exit(1);
-    }
-
-    // --- Enforcement 1: Hook-issued token verification ---
-    // The PreToolUse hook (Rule 5) writes a token file after verifying agent
-    // identity via Claude Code's internal hookData. We consume that token here.
-    // This cannot be spoofed because the token is written by the hook process,
-    // not by the Bash command the agent executes.
-    const errors = [];
-
-    const scriptBasename = path.basename(process.argv[1] || '');
-    const token = consumeToken(scriptBasename); // reads + deletes token atomically
-    let verifiedAgent = null;
-
-    if (!token) {
-      process.stderr.write(
-        `[${name}] BLOCKED: No valid write token found.\n` +
-          `  Expected token at: ${tokenPath(scriptBasename)}\n` +
-          `  The PreToolUse hook must approve this call first.\n` +
-          `  This script can only be called through Claude Code's agent system.\n`
-      );
-      process.exit(2);
-    }
-
-    // Validate token structure: timestamp must be a finite number, agent must be a string
-    if (typeof token.timestamp !== 'number' || !Number.isFinite(token.timestamp)) {
-      process.stderr.write(`[${name}] BLOCKED: Token has invalid or missing timestamp.\n`);
-      process.exit(2);
-    }
-    if (typeof token.agent !== 'string' || !token.agent) {
-      process.stderr.write(`[${name}] BLOCKED: Token has invalid or missing agent field.\n`);
-      process.exit(2);
-    }
-
-    // Check token freshness — prevents replay with pre-placed token files
-    // Reject expired AND future timestamps (clock skew / tampered tokens)
-    const age = Date.now() - token.timestamp;
-    if (age < 0 || age > TOKEN_MAX_AGE_MS) {
-      process.stderr.write(
-        `[${name}] BLOCKED: Write token expired (${age}ms old, max ${TOKEN_MAX_AGE_MS}ms).\n` +
-          `  Token was issued at ${new Date(token.timestamp).toISOString()}\n`
-      );
-      process.exit(2);
-    }
-
-    // Check agent in token matches allowedAgents
-    verifiedAgent = token.agent;
-    const agentMatch = allowedAgents.some(
-      (a) => normalizeAgentName(a) === normalizeAgentName(verifiedAgent)
-    );
-
-    if (!agentMatch) {
-      process.stderr.write(
-        `[${name}] BLOCKED: Token agent "${verifiedAgent}" is not authorized.\n` +
-          `  Allowed agents: ${allowedAgents.join(', ')}\n` +
-          `  Only these agents can use this writer.\n`
-      );
-      process.exit(2);
-    }
-
-    // --- Enforcement 2: Required fields ---
-    for (const field of requiredFields) {
-      if (input[field] === undefined || input[field] === null || input[field] === '') {
-        errors.push(`Missing required field: "${field}"`);
-      }
-    }
-
-    // --- Enforcement 3: Custom validation ---
-    if (validate) {
-      const extra = validate(input);
-      if (extra && extra.length > 0) {
-        errors.push(...extra);
-      }
-    }
-
-    if (errors.length > 0) {
-      process.stderr.write(
-        `[${name}] VALIDATION FAILED:\n` +
-          errors.map((e, i) => `  ${i + 1}. ${e}`).join('\n') +
-          '\n'
-      );
-      process.exit(1);
-    }
-
-    // --- Format and write ---
-    const reportPath = input.reportPath;
-    if (typeof reportPath !== 'string' || !reportPath.trim()) {
-      process.stderr.write(`[${name}] ERROR: "reportPath" must be a non-empty string.\n`);
-      process.exit(1);
-    }
-    // Guard against path traversal — reportPath must be absolute
-    if (!path.isAbsolute(reportPath)) {
-      process.stderr.write(`[${name}] ERROR: "reportPath" must be an absolute path.\n`);
-      process.exit(1);
-    }
-    // Scope reportPath to the ticket's task folder (bound into token by hook)
-    if (token.tasksBase) {
-      const resolved = path.resolve(reportPath);
-      if (!resolved.startsWith(token.tasksBase + path.sep) && resolved !== token.tasksBase) {
-        process.stderr.write(
-          `[${name}] BLOCKED: reportPath is outside the ticket's task folder.\n` +
-            `  reportPath: ${resolved}\n` +
-            `  Allowed folder: ${token.tasksBase}/\n`
-        );
-        process.exit(2);
-      }
-    }
+    const input = await readInputFromStdin(name);
+    const token = requireVerifiedToken(name, allowedAgents);
+    requireValidInput(name, input, requiredFields, validate);
+    const reportPath = requireSafeReportPath(name, input, token);
 
     const newContent = formatReport(input);
+    requireStatusLine(name, newContent, reportType);
+    const finalContent = composeFinalContent(reportPath, newContent);
+    rejectSymlinkTarget(name, reportPath);
 
-    // Post-write validation: verify formatted output has a parseable Status line (GH-326)
-    if (reportType) {
-      const { STATUS_LINE_RE, resolveAlias } = require('../parse-report-status');
-      const statusMatch = newContent.match(STATUS_LINE_RE);
-      const hasValidStatus = statusMatch && resolveAlias(statusMatch[1].toUpperCase(), reportType);
-      if (!hasValidStatus) {
-        process.stderr.write(
-          `[${name}] VALIDATION FAILED: Formatted report has no parseable Status line.\n` +
-            `  parseReportStatus returned: ${hasValidStatus ? 'valid' : 'UNKNOWN'}\n` +
-            `  The formatReport() function must include a "Status: <VALUE>" line.\n` +
-            `  This is a bug in the report writer, not in the agent input.\n`
-        );
-        process.exit(1);
-      }
-    }
-
-    // Prepend strategy: if file exists, preserve old content with separator
-    let finalContent = newContent;
-    if (fs.existsSync(reportPath)) {
-      const oldContent = fs.readFileSync(reportPath, 'utf8');
-      const timestamp = new Date().toISOString();
-      finalContent = newContent + `\n\n---\n## Previous Run: ${timestamp}\n---\n\n` + oldContent;
-    }
-
-    // Reject symlink targets — prevents overwriting unexpected files
-    try {
-      const stat = fs.lstatSync(reportPath);
-      if (stat.isSymbolicLink()) {
-        process.stderr.write(`[${name}] BLOCKED: reportPath is a symlink — refusing to write.\n`);
-        process.exit(2);
-      }
-    } catch {
-      /* file doesn't exist yet — fine */
-    }
-
-    // Atomic write: write to tmp then rename (prevents partial reads)
+    // Atomic write via vendored safeIO (tmp + rename prevents partial reads);
+    // mode 0o666 keeps the pre-migration writeFileSync default permissions.
     const dir = path.dirname(reportPath);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
-    const tmp = `${reportPath}.tmp.${process.pid}`;
-    fs.writeFileSync(tmp, finalContent, 'utf8');
-    fs.renameSync(tmp, reportPath);
+    writeFileAtomic(reportPath, finalContent, { mode: 0o666 });
 
     // Output success info as JSON (for the calling agent to parse)
     const result = {
       success: true,
       reportPath,
       size: Buffer.byteLength(finalContent, 'utf8'),
-      agent: verifiedAgent,
+      agent: token.agent,
     };
     process.stdout.write(JSON.stringify(result, null, 2) + '\n');
   }

--- a/plugins/work/scripts/workflows/lib/ticket-validation.js
+++ b/plugins/work/scripts/workflows/lib/ticket-validation.js
@@ -34,88 +34,91 @@ const UNSAFE_TICKET_RE = /\.\.|[\\:\0]/;
  * @returns {{ code: string, message: string, remediation: string[] } | null}
  */
 function validateTicketIdStructured(ticketId) {
+  return (
+    validateTicketShape(ticketId) || validateTicketChars(ticketId) || validateTicketSuffix(ticketId)
+  );
+}
+
+/** Build the structured INVALID_TICKET_ID error object. */
+function invalidTicket(message, remediation) {
+  return { code: 'INVALID_TICKET_ID', message, remediation };
+}
+
+/** Reject non-strings, empty/whitespace-only, and whitespace-padded inputs. */
+function validateTicketShape(ticketId) {
   if (typeof ticketId !== 'string') {
-    return {
-      code: 'INVALID_TICKET_ID',
-      message: `ticketId must be a non-empty string (received ${ticketId === null ? 'null' : typeof ticketId}).`,
-      remediation: [
+    return invalidTicket(
+      `ticketId must be a non-empty string (received ${ticketId === null ? 'null' : typeof ticketId}).`,
+      [
         'Pass a ticket id like "GH-219" or "PROJ-123".',
         'Hooks should resolve ticket id via workflows/lib/scripts/get-ticket-id.js before calling.',
-      ],
-    };
+      ]
+    );
   }
 
   const trimmed = ticketId.trim();
   if (trimmed === '') {
-    return {
-      code: 'INVALID_TICKET_ID',
-      message: 'ticketId must be a non-empty string (received empty/whitespace).',
-      remediation: ['Pass a ticket id like "GH-219" or "PROJ-123".'],
-    };
+    return invalidTicket('ticketId must be a non-empty string (received empty/whitespace).', [
+      'Pass a ticket id like "GH-219" or "PROJ-123".',
+    ]);
   }
 
-  // Reject whitespace-padded inputs
   if (ticketId !== trimmed) {
-    return {
-      code: 'INVALID_TICKET_ID',
-      message: `ticketId ${JSON.stringify(ticketId)} contains leading/trailing whitespace.`,
-      remediation: ['Trim the ticket id before passing it.'],
-    };
+    return invalidTicket(
+      `ticketId ${JSON.stringify(ticketId)} contains leading/trailing whitespace.`,
+      ['Trim the ticket id before passing it.']
+    );
   }
 
-  // Reject bare dot segments
+  return null;
+}
+
+/** Reject bare dot segments, unsafe characters, and leading slashes. */
+function validateTicketChars(ticketId) {
   if (ticketId === '.' || ticketId === './') {
-    return {
-      code: 'INVALID_TICKET_ID',
-      message: '"." is not a valid ticket ID.',
-      remediation: ['Use a proper ticket id like "GH-219" or "PROJ-123".'],
-    };
+    return invalidTicket('"." is not a valid ticket ID.', [
+      'Use a proper ticket id like "GH-219" or "PROJ-123".',
+    ]);
   }
 
-  // Reject unsafe characters (traversal, backslash, colon, null byte)
+  // Traversal, backslash, colon, null byte
   if (UNSAFE_TICKET_RE.test(ticketId)) {
-    return {
-      code: 'INVALID_TICKET_ID',
-      message: `ticketId ${JSON.stringify(ticketId)} contains unsafe characters (path traversal, backslash, colon, or null byte).`,
-      remediation: [
+    return invalidTicket(
+      `ticketId ${JSON.stringify(ticketId)} contains unsafe characters (path traversal, backslash, colon, or null byte).`,
+      [
         'Remove any "\\", "..", colon, or null bytes from the ticket id.',
         'Ticket ids are bare provider keys like "GH-219" or "PROJ-123" — not paths.',
-      ],
-    };
+      ]
+    );
   }
 
-  // Reject leading slash (absolute path)
+  // Leading slash (absolute path)
   if (ticketId.startsWith('/')) {
-    return {
-      code: 'INVALID_TICKET_ID',
-      message: `ticketId ${JSON.stringify(ticketId)} must not start with "/".`,
-      remediation: ['Ticket ids must not start with "/".'],
-    };
+    return invalidTicket(`ticketId ${JSON.stringify(ticketId)} must not start with "/".`, [
+      'Ticket ids must not start with "/".',
+    ]);
   }
 
-  // Reject multiple slashes
+  return null;
+}
+
+/** Reject multiple slashes and empty / dot / unsafe-char "/" suffixes. */
+function validateTicketSuffix(ticketId) {
   const slashCount = (ticketId.match(/\//g) || []).length;
   if (slashCount > 1) {
-    return {
-      code: 'INVALID_TICKET_ID',
-      message: `ticketId has ${slashCount} slashes — at most one "/" is allowed.`,
-      remediation: ['Use format like "PROJ-123/phase1" — at most one "/".'],
-    };
+    return invalidTicket(`ticketId has ${slashCount} slashes — at most one "/" is allowed.`, [
+      'Use format like "PROJ-123/phase1" — at most one "/".',
+    ]);
   }
 
-  // Reject trailing slash or dot-suffix
   if (slashCount === 1) {
     const suffix = ticketId.slice(ticketId.indexOf('/') + 1);
     if (!suffix || suffix === '.' || suffix === '..' || UNSAFE_TICKET_RE.test(suffix)) {
-      return {
-        code: 'INVALID_TICKET_ID',
-        message: `ticketId ${JSON.stringify(ticketId)} has invalid suffix after "/".`,
-        remediation: [
-          'Either remove the trailing "/" or add a valid suffix like "PROJ-123/phase1".',
-        ],
-      };
+      return invalidTicket(`ticketId ${JSON.stringify(ticketId)} has invalid suffix after "/".`, [
+        'Either remove the trailing "/" or add a valid suffix like "PROJ-123/phase1".',
+      ]);
     }
-  } // end suffix validation — rejects empty, dot, and unsafe-char suffixes
+  }
 
   return null;
 }
@@ -163,6 +166,27 @@ function sanitizeTicketId(ticketId) {
 // ─── TASKS_BASE resolution ───────────────────────────────────────────────────
 
 /**
+ * Shared TASKS_BASE lookup: the environment first, then the config module.
+ * Returns null when neither provides a value; only a missing config module
+ * is swallowed — any other config error is rethrown.
+ *
+ * @returns {string|null} Absolute path, or null when unset
+ */
+function tasksBaseFromEnvOrConfig() {
+  if (process.env.TASKS_BASE) return path.resolve(process.env.TASKS_BASE);
+  try {
+    const config = require('./config');
+    if (config && config.TASKS_BASE) return path.resolve(config.TASKS_BASE);
+  } catch (err) {
+    // Deliberate unification onto the stricter rethrow-falsy guard (legacy
+    // resolveTasksBase behavior); the WithFallback caller previously swallowed
+    // falsy thrown values, which nothing in ./config can actually produce.
+    if (!err || err.code !== 'MODULE_NOT_FOUND') throw err; // only swallow missing config
+  }
+  return null;
+}
+
+/**
  * Resolve TASKS_BASE from environment or config module.
  * Returns an absolute path (always path.resolve'd).
  *
@@ -170,13 +194,8 @@ function sanitizeTicketId(ticketId) {
  * @throws {Error} if TASKS_BASE cannot be resolved
  */
 function resolveTasksBase() {
-  if (process.env.TASKS_BASE) return path.resolve(process.env.TASKS_BASE);
-  try {
-    const config = require('./config');
-    if (config && config.TASKS_BASE) return path.resolve(config.TASKS_BASE);
-  } catch (err) {
-    if (!err || err.code !== 'MODULE_NOT_FOUND') throw err; // only swallow missing config
-  }
+  const base = tasksBaseFromEnvOrConfig();
+  if (base) return base;
   throw new Error('TASKS_BASE is not configured. Set TASKS_BASE (or WORKTREES_BASE in .envrc).');
 }
 
@@ -208,13 +227,8 @@ function resolveTasksBaseOrNull() {
  * @returns {string} Absolute path
  */
 function resolveTasksBaseWithFallback(fallback) {
-  if (process.env.TASKS_BASE) return path.resolve(process.env.TASKS_BASE);
-  try {
-    const config = require('./config');
-    if (config && config.TASKS_BASE) return path.resolve(config.TASKS_BASE);
-  } catch (err) {
-    if (err && err.code !== 'MODULE_NOT_FOUND') throw err;
-  }
+  const base = tasksBaseFromEnvOrConfig();
+  if (base) return base;
   if (fallback) return path.resolve(fallback);
   return path.join(require('os').homedir(), 'worktrees', 'tasks');
 }
@@ -230,11 +244,14 @@ function resolveTasksBaseWithFallback(fallback) {
  */
 function resolveWorktreeRoot() {
   try {
-    const { spawnSync } = require('child_process');
-    const r = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    const { safeSpawnSync } = require('./safeSubprocess');
+    const r = safeSpawnSync('git', ['rev-parse', '--show-toplevel'], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
     });
+    // Deliberate divergence from resolve-ticket-worktree.js `gitToplevel`:
+    // that helper maps an empty stdout to null; this one keeps the legacy
+    // contract of returning the trimmed stdout (possibly '') on status 0.
     return r.status === 0 ? r.stdout.trim() : null;
   } catch {
     return null;

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state/state-path.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state/state-path.js
@@ -5,13 +5,16 @@
  *
  * Ticket-ID sanitization, state-file path resolution, and state read/write
  * extracted from tdd-phase-state.js (GH-610 static-quality refactor).
- * Behavior — including thrown error messages, traversal rejection, atomic
- * write semantics, and the workspace-marker requirement — is unchanged.
+ * Behavior — including thrown error messages, traversal rejection, and the
+ * workspace-marker requirement — is unchanged. The atomic write is delegated
+ * to the vendored safeIO writer (GH-686): direct rename on POSIX replaces the
+ * old pre-unlink, so that failure mode simply no longer exists.
  */
 
 const fs = require('fs');
 const path = require('path');
 const { resolveTasksBaseWithFallback } = require('../../lib/ticket-validation');
+const { writeJsonAtomic } = require('../../lib/safeIO');
 
 function sanitizeId(ticketId) {
   try {
@@ -162,23 +165,15 @@ function readState(ticketId, opts) {
 }
 
 /**
- * Atomic JSON write at an explicit path: tmp file + rename so readers never
- * observe a torn/empty state file. Shared by `writeState` (recorder path,
- * TASKS_BASE-resolved) and the gate-writer (W11 — the implement gate resolves
- * its own evidence path from ctx.tasksDir and must use the SAME atomic
- * semantics instead of a raw writeFileSync).
+ * Atomic JSON write at an explicit path, delegated to the vendored safeIO
+ * writer (tmp file + direct rename) so readers never observe a torn/empty
+ * state file. Shared by `writeState` (recorder path, TASKS_BASE-resolved)
+ * and the gate-writer (W11 — the implement gate resolves its own evidence
+ * path from ctx.tasksDir and must use the SAME atomic semantics instead of
+ * a raw writeFileSync).
  */
 function writeStateAtomic(statePath, state) {
-  const dir = path.dirname(statePath);
-  fs.mkdirSync(dir, { recursive: true });
-  const tmpPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
-  fs.writeFileSync(tmpPath, JSON.stringify(state, null, 2));
-  try {
-    fs.unlinkSync(statePath);
-  } catch (e) {
-    if (e && e.code !== 'ENOENT') throw e;
-  }
-  fs.renameSync(tmpPath, statePath);
+  writeJsonAtomic(statePath, state, { mode: 0o666 });
 }
 
 function writeState(ticketId, state, opts) {

--- a/scripts/sync-vendored.js
+++ b/scripts/sync-vendored.js
@@ -47,7 +47,11 @@ const VENDOR_SETS = [
   },
   {
     master: 'factories/storeDiscovery',
-    vendorDirs: ['plugins/synapsys/lib/storeDiscovery', 'plugins/heimdall/lib/storeDiscovery'],
+    vendorDirs: [
+      'plugins/synapsys/lib/storeDiscovery',
+      'plugins/heimdall/lib/storeDiscovery',
+      'plugins/maestro/lib/storeDiscovery',
+    ],
   },
   {
     master: 'factories/safeIO',
@@ -58,11 +62,16 @@ const VENDOR_SETS = [
     vendorDirs: [
       'plugins/synapsys/lib/hookEntrypoint',
       'plugins/work/scripts/workflows/lib/hookEntrypoint',
+      'plugins/heimdall/lib/hookEntrypoint',
     ],
   },
   {
     master: 'factories/safeSubprocess',
-    vendorDirs: ['plugins/work/scripts/workflows/lib/safeSubprocess'],
+    vendorDirs: [
+      'plugins/work/scripts/workflows/lib/safeSubprocess',
+      'plugins/synapsys/lib/safeSubprocess',
+      'plugins/heimdall/lib/safeSubprocess',
+    ],
   },
   {
     master: 'factories/pathSafe',


### PR DESCRIPTION
## Existing Behavior

- `safeIO`, `hookEntrypoint`, `pathSafe`, `storeDiscovery`, and `safeSubprocess` factory modules existed (introduced in PR #684) but most call sites across heimdall, maestro, synapsys, and /work still used inline copies of the same logic.
- `schema-store.js` in maestro contained ~143 lines of store-discovery logic duplicated from the factory.
- Four atomic-write sites (write-report.js, state-path.js, evidence-recorder.js, inject-inbox-messages.js) used bare `fs.rename` without mode preservation.
- `.quality-exceptions` listed four files (write-report.js, ticket-validation.js, enforce-ui-imports.js, workflow-router-hook.js) that had not yet been driven clean under the touch-to-fix ratchet.
- `VENDOR_SETS` in the parity spec tracked only the initial wave of vendored directories from PR #684; heimdall/hookEntrypoint, maestro/storeDiscovery, synapsys/safeSubprocess, and heimdall/safeSubprocess were absent.

## Intended New Behavior

- All remaining adoption call sites are migrated: safeIO (4 sites), hookEntrypoint (heimdall + 4 /work hooks), storeDiscovery (maestro), safeSubprocess (synapsys, /work ticket-validation, heimdall-secrets-reminder, heimdall-init). `secret-inject-wrapper.js` is deliberately excluded — it is installed as a standalone copy outside the plugin tree and must remain dependency-free.
- `schema-store.js` is a thin facade (-91 lines); export surface and insertion order are proven identical to main via the parity spec.
- `write-report.js` is decomposed into 7 phase helpers with a 17-scenario differential harness proving stderr/exit/output byte-identical to main. Previously-modeless atomic-write sites pass `0o666` (umask-masked); cursor/compact-JSON sites keep `0o644`.
- `heimdall.js` adopts factory `parsePayload` but retains a LOCAL strict stdin reader: the factory `readStdin` resolves `''` on stream error (fail-open, correct for advisory hooks), while heimdall must fail closed — a stdin read error rejects into `main().catch` → non-empty stderr + exit 2. This contract is verified by a repro reproducing the adversarial-review catch fixed before this PR.
- `pathSafe` scan.js `resolveTarget` delegates to `expandHome`: `$HOME` is now supported; `~user` is no longer mangled (documented improvement — scan produces suggestions, not enforcement). `guard/paths.js` gains a comment explaining why its free-text scanner must never converge to the factory helper.
- `.quality-exceptions` shrinks by four entries; `VENDOR_SETS` grows to 73 vendored files across 15 dirs with byte-parity enforced by the extended parity spec; a spec asserts the exclusion list stays in lockstep with VENDOR_SETS.

Closes #686. Refs #577 (delivered epic), follows PR #684.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Full suite: 8 000 tests / 0 failures.

```
pnpm quality          # exit 0
node scripts/sync-vendored.js --check   # 73 files / 15 dirs, all byte-parity
pnpm dev:check        # lint → typecheck → tests on changed files, exit 0
```

Heimdall stdin contract repro (stream error must fail closed):

```bash
# Simulate stream error into heimdall — must exit 2 with "Blocking for safety"
node plugins/heimdall/hooks/heimdall.js <<< ""    # empty → exit 0 (parse error, advisory)
# destroy stream mid-read → exit 2, stderr non-empty
```

/work hook block-banner preservation — spawn-based differential run confirms stdout bytes identical to main for work-hook.js, workflow-router-hook.js, enforce-ui-imports.js, enforce-agent-usage.js.

Static probe: `node scripts/lint-symlink-paths.js` clean; stripped-tree dynamic probe also clean.

An adversarial multi-agent review ran pre-PR — zero confirmed findings; all six minor observations were fixed or documented in this commit.

## Follow-ups

- /work subprocess long tail (~165 sites) and maestro long tail (~25 sites) remain future increments.
- Enforcement-critical /work hooks (session-guard, protect-*, work-implement-enforce) are deliberately not migrated to `hookEntrypoint` yet.
- A factory-side `readStdin({ onStreamError })` option could let heimdall drop its local strict reader once masters are unfrozen in a future PR.

### Test Results

Full suite: 8 000 tests / 0 failures. `pnpm quality` exit 0. `sync-vendored --check` 73 files / 15 dirs parity clean.
