### PR TITLE
chore(quality): enforce biome formatting in CI + duplicate-adjacent-assertion rule

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,40 +14,21 @@
       "source": "./plugins/work",
       "description": "Orchestrated /work command with pre-computed action plans",
       "category": "workflow",
-      "tags": [
-        "workflow",
-        "jira",
-        "orchestrator",
-        "state-machine",
-        "automation"
-      ]
+      "tags": ["workflow", "jira", "orchestrator", "state-machine", "automation"]
     },
     {
       "name": "synapsys",
       "source": "./plugins/synapsys",
       "description": "Context-triggered memory injection — memories declare event hooks + trigger patterns and are injected when matched",
       "category": "memory",
-      "tags": [
-        "memory",
-        "hooks",
-        "injection",
-        "context",
-        "recall"
-      ]
+      "tags": ["memory", "hooks", "injection", "context", "recall"]
     },
     {
       "name": "maestro",
       "source": "./plugins/maestro",
       "description": "Multi-agent orchestrator — bootstraps per-ticket tmux sessions, conducts them (silence detection + auto-restart), and surfaces real prompts to the operator",
       "category": "orchestration",
-      "tags": [
-        "orchestrate",
-        "conduct",
-        "agents",
-        "tmux",
-        "workflow",
-        "multi-agent"
-      ]
+      "tags": ["orchestrate", "conduct", "agents", "tmux", "workflow", "multi-agent"]
     },
     {
       "name": "heimdall",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,5 +122,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --ignore-scripts
 
+      - name: Check formatting (biome)
+        run: pnpm format:check
+
       - name: Run static code quality gate
         run: pnpm quality

--- a/factories/pathSafe/__tests__/pathSafe.test.js
+++ b/factories/pathSafe/__tests__/pathSafe.test.js
@@ -184,6 +184,8 @@ describe('validateIdentifier', () => {
   it('is not confused by a global-flagged allow pattern', () => {
     const allow = /^[a-z]+$/g;
     assert.equal(validateIdentifier('abc/abc', { allow }), null);
+    // Repeated on purpose: a /g-flagged pattern carries lastIndex state — the
+    // second call must not be skewed by the first call's match position.
     assert.equal(validateIdentifier('abc/abc', { allow }), null);
   });
 

--- a/plugins/maestro/.claude-plugin/plugin.json
+++ b/plugins/maestro/.claude-plugin/plugin.json
@@ -6,12 +6,5 @@
     "name": "Custom",
     "email": "custom@local"
   },
-  "keywords": [
-    "orchestrate",
-    "conduct",
-    "agents",
-    "tmux",
-    "workflow",
-    "multi-agent"
-  ]
+  "keywords": ["orchestrate", "conduct", "agents", "tmux", "workflow", "multi-agent"]
 }

--- a/plugins/synapsys/.claude-plugin/plugin.json
+++ b/plugins/synapsys/.claude-plugin/plugin.json
@@ -6,11 +6,5 @@
     "name": "Custom",
     "email": "custom@local"
   },
-  "keywords": [
-    "memory",
-    "hooks",
-    "injection",
-    "context",
-    "recall"
-  ]
+  "keywords": ["memory", "hooks", "injection", "context", "recall"]
 }

--- a/plugins/synapsys/lib/__tests__/memory-store.integration.test.js
+++ b/plugins/synapsys/lib/__tests__/memory-store.integration.test.js
@@ -12,10 +12,7 @@ function makeTempStore() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synapsys-memstore-'));
   const storeDir = path.join(dir, '.claude', 'synapsys');
   fs.mkdirSync(storeDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(storeDir, '.synapsys.json'),
-    JSON.stringify({ projectName: 'test' })
-  );
+  fs.writeFileSync(path.join(storeDir, '.synapsys.json'), JSON.stringify({ projectName: 'test' }));
   return { cwd: dir, storeDir };
 }
 
@@ -88,8 +85,6 @@ test('existing triggerPretoolContent parsing behavior unchanged (regression)', (
 });
 
 test('parseFrontmatter exposes raw trigger_pretool_content_not value', () => {
-  const { meta } = parseFrontmatter(
-    '---\ntrigger_pretool_content_not: [x, y]\n---\nbody\n'
-  );
+  const { meta } = parseFrontmatter('---\ntrigger_pretool_content_not: [x, y]\n---\nbody\n');
   assert.deepEqual(meta.trigger_pretool_content_not, ['x', 'y']);
 });

--- a/plugins/synapsys/lib/__tests__/shared-store.test.js
+++ b/plugins/synapsys/lib/__tests__/shared-store.test.js
@@ -85,7 +85,9 @@ describe('shared store discovery', { skip: !HOME_DRIVEN }, () => {
   });
 });
 
-describe('shared store does not collide with the per-project namespace', { skip: !HOME_DRIVEN }, () => {
+describe('shared store does not collide with the per-project namespace', {
+  skip: !HOME_DRIVEN,
+}, () => {
   it('keeps global and shared distinct even for a project named like the shared folder', () => {
     // A project whose basename matches SHARED_FOLDER must NOT shadow the shared
     // store: global lives under `synapsys/<name>/`, shared is a sibling of
@@ -120,9 +122,10 @@ describe('shared store injection', { skip: !HOME_DRIVEN }, () => {
   }
 
   it('injects a matching memory on UserPromptSubmit from any project', () => {
-    assert.deepEqual(matchedNames(projectA, 'UserPromptSubmit', { prompt: 'should I force-push?' }), [
-      'no-force-push',
-    ]);
+    assert.deepEqual(
+      matchedNames(projectA, 'UserPromptSubmit', { prompt: 'should I force-push?' }),
+      ['no-force-push']
+    );
   });
 
   it('injects a matching memory on PreToolUse from any project', () => {

--- a/plugins/synapsys/tests/synapsys-recall.test.js
+++ b/plugins/synapsys/tests/synapsys-recall.test.js
@@ -194,7 +194,10 @@ test('suppressedByFireMode: memory with fire_mode: always is NOT suppressed and 
     };
 
     assert.equal(cortexHook.suppressedByFireMode(home, sessionId, memory), false);
+    // Repeated on purpose: each call may write a fired-marker; 'always' mode
+    // must stay unsuppressed across successive calls in the same session.
     assert.equal(cortexHook.suppressedByFireMode(home, sessionId, memory), false);
+    // Third call: still not suppressed.
     assert.equal(cortexHook.suppressedByFireMode(home, sessionId, memory), false);
   });
 });

--- a/plugins/work/scripts/workflows/follow-up/__tests__/ci-log-fetch.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/ci-log-fetch.test.js
@@ -286,8 +286,7 @@ describe('monitor CI log fetch — j.url field + broadened conclusion filter', (
     setGhMocks({
       checks: [{ name: 'Run Lint', bucket: 'fail', link: null }],
     });
-    apiOutForCheckRuns =
-      'Run Lint\thttps://github.com/test/repo/actions/runs/888222333/job/4\n';
+    apiOutForCheckRuns = 'Run Lint\thttps://github.com/test/repo/actions/runs/888222333/job/4\n';
 
     delete require.cache[followUpPrPath];
     delete require.cache[monitorPath];

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -1280,7 +1280,6 @@ describe('enforce-step-workflow', () => {
 
       const evidence = readEvidence();
       assert.ok(evidence['implement']?.executed, 'Evidence should be untouched');
-      assert.ok(evidence['implement']?.executed, 'Evidence should be untouched');
       assert.ok(evidence['commit']?.executed, 'Evidence should be untouched');
     });
   });

--- a/plugins/work/scripts/workflows/lib/__tests__/related-tickets-siblingids-self.integration.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/related-tickets-siblingids-self.integration.test.js
@@ -39,7 +39,10 @@ describe('siblingIds() filters self.id defensively from a legacy manifest', () =
 
     const ids = rt.siblingIds(m);
 
-    assert.ok(!ids.includes(SELF_ID), `expected self.id "${SELF_ID}" to be filtered, got: ${ids.join(',')}`);
+    assert.ok(
+      !ids.includes(SELF_ID),
+      `expected self.id "${SELF_ID}" to be filtered, got: ${ids.join(',')}`
+    );
     assert.ok(ids.includes('GH-280'), 'expected GH-280 preserved');
     assert.ok(ids.includes('GH-281'), 'expected GH-281 preserved');
   });
@@ -54,7 +57,10 @@ describe('siblingIds() filters self.id defensively from a legacy manifest', () =
 
     const ids = rt.siblingIds(m);
 
-    assert.ok(!ids.includes(SELF_ID), `expected self.id "${SELF_ID}" to be filtered from all buckets, got: ${ids.join(',')}`);
+    assert.ok(
+      !ids.includes(SELF_ID),
+      `expected self.id "${SELF_ID}" to be filtered from all buckets, got: ${ids.join(',')}`
+    );
     assert.deepEqual(
       ids.sort(),
       ['GH-300', 'GH-301', 'GH-302', 'GH-303'].sort(),

--- a/plugins/work/scripts/workflows/lib/__tests__/ticket-provider-prompt-exclude-self.integration.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/ticket-provider-prompt-exclude-self.integration.test.js
@@ -24,7 +24,10 @@ const MANIFEST_PATH = '/tmp/tasks/GH-415/related-tickets.json';
 const BUCKETS = ['siblings', 'blockedBy', 'dependsOn', 'relatedTo', 'parent'];
 
 function assertSchemaBlockExcludesSelf(prompt, providerLabel) {
-  assert.ok(prompt && typeof prompt === 'string', `${providerLabel}: prompt must be a non-empty string`);
+  assert.ok(
+    prompt && typeof prompt === 'string',
+    `${providerLabel}: prompt must be a non-empty string`
+  );
 
   // Must mention the current ticket id
   assert.ok(
@@ -41,10 +44,7 @@ function assertSchemaBlockExcludesSelf(prompt, providerLabel) {
 
   // All five bucket names must appear in conjunction with a prohibition on the current ticket
   for (const bucket of BUCKETS) {
-    assert.ok(
-      prompt.includes(bucket),
-      `${providerLabel}: prompt must mention bucket "${bucket}"`
-    );
+    assert.ok(prompt.includes(bucket), `${providerLabel}: prompt must mention bucket "${bucket}"`);
   }
 
   // The literal `_related/<self>.md` must appear paired with `never`

--- a/plugins/work/scripts/workflows/lib/hooks/agent-hook-dispatcher.js
+++ b/plugins/work/scripts/workflows/lib/hooks/agent-hook-dispatcher.js
@@ -30,9 +30,7 @@ const { spawnSync } = require('child_process');
 const { logHookError } = require(path.join(__dirname, '..', 'hook-error-log'));
 const { isRunningInAgent } = require(path.join(__dirname, '..', 'agent-detection'));
 const { REGISTRY } = require(path.join(__dirname, 'agent-hook-registry'));
-const {
-  resolvePluginRootHonouringEnv,
-} = require('../../work/lib/resolve-plugin-root');
+const { resolvePluginRootHonouringEnv } = require('../../work/lib/resolve-plugin-root');
 
 const VALID_HOOK_TYPES = new Set(['PreToolUse', 'PostToolUse', 'Stop']);
 
@@ -79,8 +77,7 @@ function resolvePluginRoot() {
   // install (which is exactly what happens in test fixtures and in the
   // marketplace-nesting case tracked by GH-526).
   return (
-    resolvePluginRootHonouringEnv(__dirname, 4) ||
-    path.resolve(__dirname, '..', '..', '..', '..')
+    resolvePluginRootHonouringEnv(__dirname, 4) || path.resolve(__dirname, '..', '..', '..', '..')
   );
 }
 

--- a/plugins/work/scripts/workflows/lib/phase-runner/__tests__/migrated-runners.integration.test.js
+++ b/plugins/work/scripts/workflows/lib/phase-runner/__tests__/migrated-runners.integration.test.js
@@ -81,10 +81,7 @@ describe('Task 4 — migrated *-next.js runners delegate to createPhaseRunner', 
       it('is a thin wrapper (< 60 lines)', () => {
         const src = fs.readFileSync(fullPath, 'utf8');
         const lines = src.split('\n').length;
-        assert.ok(
-          lines < 60,
-          `${runner.file} should be a thin wrapper < 60 lines, got ${lines}`
-        );
+        assert.ok(lines < 60, `${runner.file} should be a thin wrapper < 60 lines, got ${lines}`);
       });
     });
   }

--- a/plugins/work/scripts/workflows/lib/phase-state/__tests__/migrated-phase-states.integration.test.js
+++ b/plugins/work/scripts/workflows/lib/phase-state/__tests__/migrated-phase-states.integration.test.js
@@ -147,11 +147,7 @@ const MIGRATIONS = [
   },
   {
     workflow: 'completion',
-    scriptPath: path.join(
-      WORKFLOWS_ROOT,
-      'work-completion-checker',
-      'completion-phase-state.js'
-    ),
+    scriptPath: path.join(WORKFLOWS_ROOT, 'work-completion-checker', 'completion-phase-state.js'),
     basename: 'completion-phase-state.js',
     allowedAgent: 'completion-checker',
     stateFile: 'completion-phase.json',
@@ -226,7 +222,10 @@ for (const m of MIGRATIONS) {
   describe(`${m.basename} (factory delegator)`, () => {
     let tmp;
     let tasksBase;
-    const ticket = `GH-99${m.workflow.replace(/[^a-z0-9]/gi, '').slice(0, 4).padEnd(4, '0')}`;
+    const ticket = `GH-99${m.workflow
+      .replace(/[^a-z0-9]/gi, '')
+      .slice(0, 4)
+      .padEnd(4, '0')}`;
 
     before(() => {
       tmp = fs.mkdtempSync(path.join(os.tmpdir(), `migrated-${m.workflow}-`));
@@ -268,10 +267,7 @@ for (const m of MIGRATIONS) {
         );
       }
       assert.ok(Array.isArray(mod.PHASES), 'PHASES must be an array');
-      assert.ok(
-        mod.PHASES.includes(m.initialPhase),
-        `PHASES must include "${m.initialPhase}"`
-      );
+      assert.ok(mod.PHASES.includes(m.initialPhase), `PHASES must include "${m.initialPhase}"`);
       assert.ok(mod.PHASES.includes('done'), 'PHASES must include "done"');
       assert.equal(typeof mod[m.transitionFnExportName], 'function');
       assert.equal(typeof mod[m.nextFnExportName], 'function');

--- a/plugins/work/scripts/workflows/lib/scripts/__tests__/dev-lint-config-resolution.integration.test.js
+++ b/plugins/work/scripts/workflows/lib/scripts/__tests__/dev-lint-config-resolution.integration.test.js
@@ -16,12 +16,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-const DEV_LINT_SH = path.join(
-  __dirname,
-  '..',
-  'dev-check',
-  'dev-lint.sh'
-);
+const DEV_LINT_SH = path.join(__dirname, '..', 'dev-check', 'dev-lint.sh');
 const QUALITY_LINT_RULES = path.join(
   __dirname,
   '..',
@@ -41,8 +36,7 @@ function makeTempDir() {
  */
 function initRepo({ withRootEslintConfig = false } = {}) {
   const dir = makeTempDir();
-  const run = (cmd) =>
-    execSync(cmd, { cwd: dir, encoding: 'utf8', stdio: 'pipe' });
+  const run = (cmd) => execSync(cmd, { cwd: dir, encoding: 'utf8', stdio: 'pipe' });
 
   run('git init -b main');
   run('git config user.email "t@t.com"');
@@ -54,10 +48,7 @@ function initRepo({ withRootEslintConfig = false } = {}) {
   fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
 
   if (withRootEslintConfig) {
-    fs.writeFileSync(
-      path.join(dir, 'eslint.config.js'),
-      'module.exports = [];\n'
-    );
+    fs.writeFileSync(path.join(dir, 'eslint.config.js'), 'module.exports = [];\n');
   }
 
   run('git add -A');
@@ -65,10 +56,7 @@ function initRepo({ withRootEslintConfig = false } = {}) {
   run('git checkout -b feature');
 
   // Trivially clean JS file — untracked, so get_changed_files picks it up.
-  fs.writeFileSync(
-    path.join(dir, 'changed.js'),
-    'module.exports = 1;\n'
-  );
+  fs.writeFileSync(path.join(dir, 'changed.js'), 'module.exports = 1;\n');
 
   return dir;
 }
@@ -82,10 +70,7 @@ function initRepo({ withRootEslintConfig = false } = {}) {
 function makeNpxStubBin() {
   const binDir = makeTempDir();
   const shim = path.join(binDir, 'npx');
-  fs.writeFileSync(
-    shim,
-    '#!/bin/bash\necho "NPX_ARGV: $*"\nexit 0\n'
-  );
+  fs.writeFileSync(shim, '#!/bin/bash\necho "NPX_ARGV: $*"\nexit 0\n');
   fs.chmodSync(shim, 0o755);
   return binDir;
 }
@@ -111,10 +96,7 @@ function runDevLint(repoDir, stubBinDir, scriptPath = DEV_LINT_SH) {
 function makeNpxStubBinExiting(exitCode) {
   const binDir = makeTempDir();
   const shim = path.join(binDir, 'npx');
-  fs.writeFileSync(
-    shim,
-    `#!/bin/bash\necho "NPX_ARGV: $*"\nexit ${exitCode}\n`
-  );
+  fs.writeFileSync(shim, `#!/bin/bash\necho "NPX_ARGV: $*"\nexit ${exitCode}\n`);
   fs.chmodSync(shim, 0o755);
   return binDir;
 }
@@ -140,8 +122,7 @@ function copyDevLintToIsolatedDir() {
  */
 function initRepoWithLinter(linterName) {
   const dir = makeTempDir();
-  const run = (cmd) =>
-    execSync(cmd, { cwd: dir, encoding: 'utf8', stdio: 'pipe' });
+  const run = (cmd) => execSync(cmd, { cwd: dir, encoding: 'utf8', stdio: 'pipe' });
 
   run('git init -b main');
   run('git config user.email "t@t.com"');
@@ -157,10 +138,7 @@ function initRepoWithLinter(linterName) {
   run('git commit -m "initial"');
   run('git checkout -b feature');
 
-  fs.writeFileSync(
-    path.join(dir, 'changed.js'),
-    'module.exports = 1;\n'
-  );
+  fs.writeFileSync(path.join(dir, 'changed.js'), 'module.exports = 1;\n');
 
   return dir;
 }
@@ -193,11 +171,7 @@ describe('dev-lint.sh config resolution', () => {
     const result = runDevLint(repoDir, stubBinDir);
     const combined = `${result.stdout || ''}\n${result.stderr || ''}`;
 
-    assert.equal(
-      result.status,
-      0,
-      `expected exit 0, got ${result.status}. Output:\n${combined}`
-    );
+    assert.equal(result.status, 0, `expected exit 0, got ${result.status}. Output:\n${combined}`);
     assert.ok(
       !/couldn't find an eslint\.config/i.test(combined),
       `unexpected missing-config error in output:\n${combined}`
@@ -208,10 +182,7 @@ describe('dev-lint.sh config resolution', () => {
       `expected eslint invocation with --config <quality-lint-rules.js>; got:\n${combined}`
     );
     // Sanity: the resolved fallback path must point at the real shipped file.
-    assert.ok(
-      fs.existsSync(QUALITY_LINT_RULES),
-      `expected ${QUALITY_LINT_RULES} to exist on disk`
-    );
+    assert.ok(fs.existsSync(QUALITY_LINT_RULES), `expected ${QUALITY_LINT_RULES} to exist on disk`);
   });
 
   // T-2 — Scenario: Repo has a root eslint.config.js — script uses it unchanged
@@ -222,18 +193,10 @@ describe('dev-lint.sh config resolution', () => {
     const result = runDevLint(repoDir, stubBinDir);
     const combined = `${result.stdout || ''}\n${result.stderr || ''}`;
 
-    assert.equal(
-      result.status,
-      0,
-      `expected exit 0, got ${result.status}. Output:\n${combined}`
-    );
+    assert.equal(result.status, 0, `expected exit 0, got ${result.status}. Output:\n${combined}`);
     // The invocation log must show eslint was called, but NOT with our
     // plugin-shipped quality-lint-rules.js fallback config.
-    assert.match(
-      combined,
-      /NPX_ARGV: eslint\b/,
-      `expected eslint invocation; got:\n${combined}`
-    );
+    assert.match(combined, /NPX_ARGV: eslint\b/, `expected eslint invocation; got:\n${combined}`);
     assert.ok(
       !/--config\s+\S*quality-lint-rules\.js/.test(combined),
       `expected NO --config <quality-lint-rules.js> when root flat config is present; got:\n${combined}`
@@ -300,16 +263,8 @@ describe('dev-lint.sh config resolution', () => {
     const result = runDevLint(repoDir, stubBinDir);
     const combined = `${result.stdout || ''}\n${result.stderr || ''}`;
 
-    assert.equal(
-      result.status,
-      0,
-      `expected exit 0, got ${result.status}. Output:\n${combined}`
-    );
-    assert.match(
-      combined,
-      /NPX_ARGV: oxlint\b/,
-      `expected oxlint invocation; got:\n${combined}`
-    );
+    assert.equal(result.status, 0, `expected exit 0, got ${result.status}. Output:\n${combined}`);
+    assert.match(combined, /NPX_ARGV: oxlint\b/, `expected oxlint invocation; got:\n${combined}`);
     assert.ok(
       !/--config\s+\S*quality-lint-rules\.js/.test(combined),
       `expected NO eslint fallback --config when linter is oxlint; got:\n${combined}`

--- a/plugins/work/scripts/workflows/lib/scripts/quality/__tests__/adjacent-assertions.test.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/__tests__/adjacent-assertions.test.js
@@ -1,0 +1,139 @@
+/**
+ * Tests for rules/adjacent-assertions.js — consecutive duplicate assertion
+ * detector (the wrapped-vs-unwrapped merge-artifact rule).
+ *
+ * Run: node --test plugins/work/scripts/workflows/lib/scripts/quality/__tests__/adjacent-assertions.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { checkAll } = require('../rules/adjacent-assertions');
+
+let dir;
+
+function writeFixture(name, content) {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+describe('adjacent-assertions rule', () => {
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adj-assert-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('flags an identical assertion repeated on the next line', () => {
+    const f = writeFixture(
+      'dup.test.js',
+      [
+        "assert.match(out, /export HEIMDALL_PROTECTED='\\/repo';/);",
+        "assert.match(out, /export HEIMDALL_PROTECTED='\\/repo';/);",
+      ].join('\n')
+    );
+    const v = checkAll([f], dir);
+    assert.equal(v.length, 1);
+    assert.equal(v[0].rule, 'duplicate-adjacent-assertions');
+    assert.equal(v[0].severity, 'error');
+    assert.equal(v[0].line, 2);
+    assert.match(v[0].message, /line 1/);
+  });
+
+  it('flags the wrapped + single-line pair (the merge-artifact shape)', () => {
+    const f = writeFixture(
+      'wrapped.test.js',
+      [
+        'it("x", () => {',
+        "  assert.match(out, /export LD_PRELOAD='\\/x\\/fsguard\\.so';/);",
+        '  assert.match(',
+        '    out,',
+        "    /export LD_PRELOAD='\\/x\\/fsguard\\.so';/",
+        '  );',
+        '});',
+      ].join('\n')
+    );
+    const v = checkAll([f], dir);
+    assert.equal(v.length, 1, JSON.stringify(v));
+    assert.equal(v[0].line, 3);
+  });
+
+  it('flags a duplicate pair separated only by a blank line', () => {
+    const f = writeFixture(
+      'blank.test.js',
+      ['assert.equal(a, 1);', '', 'assert.equal(a, 1);'].join('\n')
+    );
+    const v = checkAll([f], dir);
+    assert.equal(v.length, 1);
+  });
+
+  it('does NOT flag identical assertions separated by other code', () => {
+    const f = writeFixture(
+      'separated.test.js',
+      ['assert.equal(count(), 1);', 'doThing();', 'assert.equal(count(), 1);'].join('\n')
+    );
+    assert.deepEqual(checkAll([f], dir), []);
+  });
+
+  it('does NOT flag assertions differing only inside a string literal', () => {
+    const f = writeFixture(
+      'string-ws.test.js',
+      ["assert.equal(classify(''), 'unknown');", "assert.equal(classify('   '), 'unknown');"].join(
+        '\n'
+      )
+    );
+    assert.deepEqual(checkAll([f], dir), []);
+  });
+
+  it('does NOT flag an intentional repeat documented by a comment between', () => {
+    const f = writeFixture(
+      'intentional.test.js',
+      [
+        'assert.equal(validateIdentifier("abc", { allow }), null);',
+        '// repeated on purpose: /g regex lastIndex must not leak into the second call',
+        'assert.equal(validateIdentifier("abc", { allow }), null);',
+      ].join('\n')
+    );
+    assert.deepEqual(checkAll([f], dir), []);
+  });
+
+  it('does NOT flag different adjacent assertions', () => {
+    const f = writeFixture(
+      'different.test.js',
+      ['assert.equal(a, 1);', 'assert.equal(b, 2);'].join('\n')
+    );
+    assert.deepEqual(checkAll([f], dir), []);
+  });
+
+  it('does NOT flag adjacent identical non-assertion statements', () => {
+    const f = writeFixture('calls.test.js', ['retryOnce();', 'retryOnce();'].join('\n'));
+    assert.deepEqual(checkAll([f], dir), []);
+  });
+
+  it('handles expect()-style assertions', () => {
+    const f = writeFixture(
+      'expect.test.js',
+      ['expect(out).toContain("x");', 'expect(out).toContain("x");'].join('\n')
+    );
+    assert.equal(checkAll([f], dir).length, 1);
+  });
+
+  it('ignores non-JS files and unreadable paths', () => {
+    const md = writeFixture('notes.md', 'assert.equal(a, 1);\nassert.equal(a, 1);');
+    assert.deepEqual(checkAll([md, path.join(dir, 'missing.js')], dir), []);
+  });
+
+  it('reports repo-relative POSIX paths', () => {
+    const sub = path.join(dir, 'nested');
+    fs.mkdirSync(sub);
+    const f = path.join(sub, 'p.test.js');
+    fs.writeFileSync(f, 'assert.ok(x);\nassert.ok(x);');
+    const v = checkAll([f], dir);
+    assert.equal(v[0].file, 'nested/p.test.js');
+  });
+});

--- a/plugins/work/scripts/workflows/lib/scripts/quality/__tests__/allowlist.test.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/__tests__/allowlist.test.js
@@ -62,10 +62,7 @@ test('allowlist: normalizes paths via path.normalize', () => {
   const { AllowlistLoader } = loadAllowlist();
   const repo = mkRepo();
   try {
-    fs.writeFileSync(
-      path.join(repo, '.quality-exceptions'),
-      'scripts//foo/./bar.js\n'
-    );
+    fs.writeFileSync(path.join(repo, '.quality-exceptions'), 'scripts//foo/./bar.js\n');
     const result = AllowlistLoader.load(repo);
     // path.normalize('scripts//foo/./bar.js') === 'scripts/foo/bar.js'
     assert.ok(result.has(path.normalize('scripts/foo/bar.js')));
@@ -78,14 +75,8 @@ test('allowlist: rejects entries containing ".."', () => {
   const { AllowlistLoader } = loadAllowlist();
   const repo = mkRepo();
   try {
-    fs.writeFileSync(
-      path.join(repo, '.quality-exceptions'),
-      '../escape.js\n'
-    );
-    assert.throws(
-      () => AllowlistLoader.load(repo),
-      /\.\./
-    );
+    fs.writeFileSync(path.join(repo, '.quality-exceptions'), '../escape.js\n');
+    assert.throws(() => AllowlistLoader.load(repo), /\.\./);
   } finally {
     cleanup(repo);
   }
@@ -95,14 +86,8 @@ test('allowlist: rejects absolute paths', () => {
   const { AllowlistLoader } = loadAllowlist();
   const repo = mkRepo();
   try {
-    fs.writeFileSync(
-      path.join(repo, '.quality-exceptions'),
-      '/etc/passwd\n'
-    );
-    assert.throws(
-      () => AllowlistLoader.load(repo),
-      /absolute/i
-    );
+    fs.writeFileSync(path.join(repo, '.quality-exceptions'), '/etc/passwd\n');
+    assert.throws(() => AllowlistLoader.load(repo), /absolute/i);
   } finally {
     cleanup(repo);
   }

--- a/plugins/work/scripts/workflows/lib/scripts/quality/__tests__/biome-bridge.test.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/__tests__/biome-bridge.test.js
@@ -45,10 +45,9 @@ test('biome-bridge: one cognitive-complexity diagnostic folds into one violation
     stdout: Buffer.from(JSON.stringify(biomeJson)),
     stderr: Buffer.from(''),
   });
-  const violations = rule.checkAll(
-    [{ path: 'src/big.js', source: 'function bigFn(){}' }],
-    { spawnSync: spawn },
-  );
+  const violations = rule.checkAll([{ path: 'src/big.js', source: 'function bigFn(){}' }], {
+    spawnSync: spawn,
+  });
   assert.equal(violations.length, 1);
   const v = violations[0];
   assert.equal(v.rule, 'cognitive-complexity');
@@ -67,10 +66,9 @@ test('biome-bridge: empty diagnostics → empty violations', () => {
     stdout: Buffer.from(JSON.stringify({ diagnostics: [] })),
     stderr: Buffer.from(''),
   });
-  const violations = rule.checkAll(
-    [{ path: 'src/clean.js', source: 'const x = 1;' }],
-    { spawnSync: spawn },
-  );
+  const violations = rule.checkAll([{ path: 'src/clean.js', source: 'const x = 1;' }], {
+    spawnSync: spawn,
+  });
   assert.deepEqual(violations, []);
 });
 
@@ -95,7 +93,7 @@ test('biome-bridge: malformed JSON output → throws config error', () => {
   });
   assert.throws(
     () => rule.checkAll([{ path: 'a.js', source: '' }], { spawnSync: spawn }),
-    /biome|json|parse/i,
+    /biome|json|parse/i
   );
 });
 
@@ -109,7 +107,7 @@ test('biome-bridge: spawn failure (error or null status) → throws config error
   });
   assert.throws(
     () => rule.checkAll([{ path: 'a.js', source: '' }], { spawnSync: spawn }),
-    /biome|spawn|npx/i,
+    /biome|spawn|npx/i
   );
 });
 
@@ -136,10 +134,7 @@ test('biome-bridge: ignores non-cognitive-complexity diagnostics', () => {
     stdout: Buffer.from(JSON.stringify(biomeJson)),
     stderr: Buffer.from(''),
   });
-  const violations = rule.checkAll(
-    [{ path: 'a.js', source: 'x' }],
-    { spawnSync: spawn },
-  );
+  const violations = rule.checkAll([{ path: 'a.js', source: 'x' }], { spawnSync: spawn });
   assert.equal(violations.length, 1);
   assert.equal(violations[0].rule, 'cognitive-complexity');
 });
@@ -160,7 +155,7 @@ test('biome-bridge: invokes npx biome lint --reporter=json with files', () => {
       { path: 'a.js', source: '' },
       { path: 'b.js', source: '' },
     ],
-    { spawnSync: spawn },
+    { spawnSync: spawn }
   );
   assert.ok(captured, 'spawn should have been called');
   assert.equal(captured.cmd, 'npx');

--- a/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
@@ -23,6 +23,7 @@ const { spawnSync } = require('node:child_process');
 
 const { AllowlistLoader } = require('./shared/allowlist');
 const config = require('../../config');
+const adjacentAssertions = require('./rules/adjacent-assertions');
 const biomeBridge = require('./rules/biome-bridge');
 const eslintBridge = require('./rules/eslint-bridge');
 const jscpdBridge = require('./rules/jscpd-bridge');
@@ -205,6 +206,9 @@ function collectViolations(absFiles, repoRoot) {
   violations.push(...eslintBridge.checkAll(lintable, repoRoot));
   violations.push(...jscpdBridge.checkAll(lintable, repoRoot));
   violations.push(...runBiomeBridge(lintable, repoRoot));
+  // Runs on ALL files (tests included) — the duplicated-assertion merge
+  // artifact this rule exists for lives almost exclusively in test files.
+  violations.push(...adjacentAssertions.checkAll(absFiles, repoRoot));
   return violations;
 }
 

--- a/plugins/work/scripts/workflows/lib/scripts/quality/rules/adjacent-assertions.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/rules/adjacent-assertions.js
@@ -1,0 +1,154 @@
+'use strict';
+
+/**
+ * `adjacent-assertions` — flags consecutive duplicate assertion statements.
+ *
+ * Targets a recurring merge artifact: when a branch carries an assertion in
+ * its long single-line form and another carries the same assertion
+ * biome-wrapped across lines, conflict resolution (human or agent) keeps
+ * BOTH copies. The pair survives every other gate — biome formats both
+ * happily, the test still passes (assertions are idempotent), and jscpd's
+ * 50-token floor ignores 2-line clones.
+ *
+ * Scope is deliberately narrow — statements starting with `assert`/`expect` —
+ * because an adjacent identical assertion is rarely meaningful, while adjacent
+ * identical *calls* can be (idempotency / accumulation tests). Statements are
+ * compared whitespace-normalized so the wrapped and unwrapped shapes of the
+ * same assertion match. Only blank lines may sit between the pair.
+ *
+ * Intentional repeats DO exist (asserting a stateful call twice — e.g. a
+ * `/g`-flagged regex's lastIndex, or a fire-mode suppressor that must stay
+ * false across calls). The escape hatch is the fix you'd want anyway: put a
+ * comment between the repeats explaining WHY — a comment line breaks
+ * adjacency, so the pair is not flagged, and the intent is documented.
+ *
+ * Pure JS, no external tool.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ASSERT_START_RE = /^(?:await\s+)?(?:assert[.(]|expect\s*\()/;
+// A biome-formatted statement always terminates with `;` — cap the
+// accumulation window so an unterminated match can't swallow the file.
+const MAX_STATEMENT_LINES = 15;
+
+/**
+ * Strip whitespace OUTSIDE string literals so wrapped and single-line forms
+ * compare equal — biome puts line breaks inside the argument list
+ * (`match(\n  out,\n  …\n)`), so a collapsed-space compare would still differ
+ * from the inline form. Whitespace inside `'`/`"`/`` ` `` literals is
+ * semantic (`classify('')` vs `classify('   ')`) and must be preserved.
+ * Escapes are honored; regex literals are not quote-tracked (an odd number
+ * of quotes inside one could skew normalization of the remainder — accepted:
+ * the worst case is a missed or spurious *comparison*, on already-adjacent
+ * assertions).
+ */
+function isQuote(ch) {
+  return ch === "'" || ch === '"' || ch === '`';
+}
+
+/**
+ * Index of the closing quote for the literal opening at `start`; honors
+ * backslash escapes. Unterminated literal → last index (copy the rest).
+ */
+function endOfQuoted(stmt, start) {
+  const quote = stmt[start];
+  for (let i = start + 1; i < stmt.length; i++) {
+    if (stmt[i] === '\\') i++;
+    else if (stmt[i] === quote) return i;
+  }
+  return stmt.length - 1;
+}
+
+function normalize(stmt) {
+  let out = '';
+  for (let i = 0; i < stmt.length; i++) {
+    const ch = stmt[i];
+    if (isQuote(ch)) {
+      const end = endOfQuoted(stmt, i);
+      out += stmt.slice(i, end + 1);
+      i = end;
+    } else if (!/\s/.test(ch)) {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract assertion statements from a file's lines.
+ * @returns {Array<{line: number, endIdx: number, text: string}>}
+ *   `line` is 1-based start line; `endIdx` the 0-based index of the last line.
+ */
+function extractAssertions(lines) {
+  const out = [];
+  let i = 0;
+  while (i < lines.length) {
+    const trimmed = lines[i].trim();
+    if (!ASSERT_START_RE.test(trimmed)) {
+      i++;
+      continue;
+    }
+    let stmt = trimmed;
+    let end = i;
+    while (
+      !/;\s*$/.test(lines[end].trim()) &&
+      end - i < MAX_STATEMENT_LINES &&
+      end < lines.length - 1
+    ) {
+      end++;
+      stmt += ` ${lines[end].trim()}`;
+    }
+    out.push({ line: i + 1, endIdx: end, text: normalize(stmt) });
+    i = end + 1;
+  }
+  return out;
+}
+
+/** True when every line strictly between the two statements is blank. */
+function onlyBlankBetween(lines, prevEndIdx, nextStartLine) {
+  for (let i = prevEndIdx + 1; i < nextStartLine - 1; i++) {
+    if (lines[i].trim() !== '') return false;
+  }
+  return true;
+}
+
+function checkFile(absFile, repoRoot) {
+  let source;
+  try {
+    source = fs.readFileSync(absFile, 'utf8');
+  } catch {
+    return [];
+  }
+  const lines = source.split('\n');
+  const assertions = extractAssertions(lines);
+  const violations = [];
+
+  for (let i = 1; i < assertions.length; i++) {
+    const prev = assertions[i - 1];
+    const curr = assertions[i];
+    if (prev.text !== curr.text) continue;
+    if (!onlyBlankBetween(lines, prev.endIdx, curr.line)) continue;
+    violations.push({
+      file: path.relative(repoRoot, absFile).split(path.sep).join('/'),
+      line: curr.line,
+      rule: 'duplicate-adjacent-assertions',
+      severity: 'error',
+      message: `duplicate-adjacent-assertions — identical assertion already on line ${prev.line} (merge artifact; delete one copy)`,
+    });
+  }
+  return violations;
+}
+
+function checkAll(absFiles, repoRoot) {
+  if (!Array.isArray(absFiles)) return [];
+  const violations = [];
+  for (const f of absFiles) {
+    if (!f.endsWith('.js')) continue;
+    violations.push(...checkFile(f, repoRoot));
+  }
+  return violations;
+}
+
+module.exports = { checkAll };

--- a/plugins/work/scripts/workflows/lib/scripts/quality/rules/biome-bridge.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/rules/biome-bridge.js
@@ -83,8 +83,9 @@ function offsetToLine(source, offset) {
 function parseComplexityFromDescription(description) {
   if (typeof description !== 'string') return { value: null, name: null };
   const valueMatch = description.match(/Complexity of (\d+)/i) || description.match(/\((\d+)\)/);
-  const nameMatch = description.match(/in (?:function|method)\s+([A-Za-z_$][\w$]*)/i)
-    || description.match(/\bin\s+([A-Za-z_$][\w$]*)/);
+  const nameMatch =
+    description.match(/in (?:function|method)\s+([A-Za-z_$][\w$]*)/i) ||
+    description.match(/\bin\s+([A-Za-z_$][\w$]*)/);
   return {
     value: valueMatch ? Number(valueMatch[1]) : null,
     name: nameMatch ? nameMatch[1] : null,

--- a/plugins/work/scripts/workflows/lib/scripts/quality/shared/allowlist.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/shared/allowlist.js
@@ -37,9 +37,7 @@ const AllowlistLoader = {
       if (trimmed.startsWith('#')) continue;
 
       if (path.isAbsolute(trimmed)) {
-        throw new Error(
-          `AllowlistLoader: absolute paths are not allowed (got "${trimmed}")`
-        );
+        throw new Error(`AllowlistLoader: absolute paths are not allowed (got "${trimmed}")`);
       }
       if (trimmed.split(/[\\/]/).includes('..')) {
         throw new Error(

--- a/plugins/work/scripts/workflows/work-brief/__tests__/brief-next.integration.test.js
+++ b/plugins/work/scripts/workflows/work-brief/__tests__/brief-next.integration.test.js
@@ -102,7 +102,11 @@ describe('brief-next.js integration (factory delegator)', () => {
     assert.equal(r.status, 0, `expected exit 0, got ${r.status}. Output:\n${combined}`);
 
     // Header shape (baseline from createPhaseRunner)
-    assert.match(r.stdout, /^brief-next: GH-99982\n/, 'header line should start with script:ticket');
+    assert.match(
+      r.stdout,
+      /^brief-next: GH-99982\n/,
+      'header line should start with script:ticket'
+    );
     assert.match(r.stdout, /  tasks dir: /, 'header should include tasks dir line');
     assert.match(
       r.stdout,
@@ -124,11 +128,7 @@ describe('brief-next.js integration (factory delegator)', () => {
 
   it('brief-next.js delegates to createPhaseRunner factory', () => {
     const src = fs.readFileSync(BRIEF_NEXT, 'utf8');
-    assert.match(
-      src,
-      /createPhaseRunner\s*\(/,
-      'brief-next.js must call createPhaseRunner(...)'
-    );
+    assert.match(src, /createPhaseRunner\s*\(/, 'brief-next.js must call createPhaseRunner(...)');
     assert.match(
       src,
       /require\(['"][^'"]*lib\/phase-runner\/create-phase-runner['"]\)/,

--- a/plugins/work/scripts/workflows/work-brief/__tests__/inputs-validate-artifacts-self.integration.test.js
+++ b/plugins/work/scripts/workflows/work-brief/__tests__/inputs-validate-artifacts-self.integration.test.js
@@ -39,15 +39,9 @@ describe('inputs.validateArtifacts() — _related/<self>.md rejection', () => {
     root = made.root;
     tasksDir = made.tasksDir;
     // Linked ticket file (satisfies existing happy-path requirement).
-    fs.writeFileSync(
-      path.join(tasksDir, '_related', `${LINKED_ID}.md`),
-      VALID_BODY
-    );
+    fs.writeFileSync(path.join(tasksDir, '_related', `${LINKED_ID}.md`), VALID_BODY);
     // Offending self-file inside _related/.
-    fs.writeFileSync(
-      path.join(tasksDir, '_related', `${SELF_ID}.md`),
-      VALID_BODY
-    );
+    fs.writeFileSync(path.join(tasksDir, '_related', `${SELF_ID}.md`), VALID_BODY);
   });
 
   after(() => {
@@ -83,10 +77,7 @@ describe('inputs.validateArtifacts() — _related/<self>.md rejection', () => {
     const isoTasksDir = path.join(isoRoot, SELF_ID);
     fs.mkdirSync(path.join(isoTasksDir, '_related'), { recursive: true });
     // Only the offending self-file exists — no linked tickets at all.
-    fs.writeFileSync(
-      path.join(isoTasksDir, '_related', `${SELF_ID}.md`),
-      VALID_BODY
-    );
+    fs.writeFileSync(path.join(isoTasksDir, '_related', `${SELF_ID}.md`), VALID_BODY);
     const manifest = {
       self: { id: SELF_ID, title: 'Self ticket' },
       parent: null,
@@ -105,10 +96,7 @@ describe('inputs.validateArtifacts() — _related/<self>.md rejection', () => {
     const cleanRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'inputs-validate-self-clean-'));
     const cleanTasksDir = path.join(cleanRoot, SELF_ID);
     fs.mkdirSync(path.join(cleanTasksDir, '_related'), { recursive: true });
-    fs.writeFileSync(
-      path.join(cleanTasksDir, '_related', `${LINKED_ID}.md`),
-      VALID_BODY
-    );
+    fs.writeFileSync(path.join(cleanTasksDir, '_related', `${LINKED_ID}.md`), VALID_BODY);
     const manifest = {
       self: { id: SELF_ID, title: 'Self ticket' },
       parent: null,

--- a/plugins/work/scripts/workflows/work-ci/lib/phases/rerun_check.js
+++ b/plugins/work/scripts/workflows/work-ci/lib/phases/rerun_check.js
@@ -29,7 +29,11 @@ function readJson(p) {
 function isAddressed(t) {
   if (!t) return false;
   if (t.category === 'pre-existing' && t.documentation) return true;
-  if (t.category === 'cache-miss' && typeof t.rerunRunId === 'string' && /^\d{6,}$/.test(t.rerunRunId)) {
+  if (
+    t.category === 'cache-miss' &&
+    typeof t.rerunRunId === 'string' &&
+    /^\d{6,}$/.test(t.rerunRunId)
+  ) {
     return true;
   }
   return false;

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/failure-store-bridges-invocations.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/failure-store-bridges-invocations.test.js
@@ -31,7 +31,7 @@ function mkTasksDir() {
       '### Final Status:',
       '[COMPLETE]',
       '',
-    ].join('\n'),
+    ].join('\n')
   );
   return { root, tasksDir };
 }
@@ -51,13 +51,11 @@ test('report.buildVerdictDocument folds persisted failures with empty ctx.failur
           observed: 'Bar imported instead',
         },
       ],
-      { reuseChecked: 1 },
+      { reuseChecked: 1 }
     );
     // Later invocation: fresh ctx, ctx.failures is empty.
     report.validate({ ticket: 'GH-282', tasksDir, failures: [] });
-    const doc = JSON.parse(
-      fs.readFileSync(path.join(tasksDir, 'completion-verdict.json'), 'utf8'),
-    );
+    const doc = JSON.parse(fs.readFileSync(path.join(tasksDir, 'completion-verdict.json'), 'utf8'));
     assert.equal(doc.ok, false, 'verdict must be ok:false because store has a failure');
     assert.equal(doc.failures.length, 1);
     assert.equal(doc.failures[0].requirementId, 'REUSE-1');
@@ -81,7 +79,7 @@ test('resetStore at inputs phase clears previously persisted failures', () => {
           observed: 'y',
         },
       ],
-      { reuseChecked: 1 },
+      { reuseChecked: 1 }
     );
     store.resetStore(tasksDir);
     const state = store.readState(tasksDir);
@@ -106,7 +104,7 @@ test('appendForCheckType replaces records of the same checkType on re-run', () =
           observed: 'b',
         },
       ],
-      { scopeChecked: 1 },
+      { scopeChecked: 1 }
     );
     // Re-run of the same phase replaces, not duplicates.
     store.appendForCheckType(
@@ -120,7 +118,7 @@ test('appendForCheckType replaces records of the same checkType on re-run', () =
           observed: 'd',
         },
       ],
-      { scopeChecked: 1 },
+      { scopeChecked: 1 }
     );
     const state = store.readState(tasksDir);
     assert.equal(state.failures.length, 1);
@@ -143,9 +141,7 @@ test('failures from store + ctx are deduped on exact match', () => {
     };
     store.appendForCheckType(tasksDir, 'reuse_audit', [failure], { reuseChecked: 1 });
     report.validate({ ticket: 'GH-282', tasksDir, failures: [failure] });
-    const doc = JSON.parse(
-      fs.readFileSync(path.join(tasksDir, 'completion-verdict.json'), 'utf8'),
-    );
+    const doc = JSON.parse(fs.readFileSync(path.join(tasksDir, 'completion-verdict.json'), 'utf8'));
     assert.equal(doc.failures.length, 1, 'identical failure must be deduped');
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/phase-registry-order.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/phase-registry-order.test.js
@@ -13,7 +13,7 @@ test('completion-phase-registry exports REUSE_AUDIT_ENFORCEMENT constant', () =>
   assert.equal(
     COMPLETION_PHASES.reuse_audit_enforcement,
     'reuse_audit_enforcement',
-    'expected COMPLETION_PHASES.reuse_audit_enforcement to be defined',
+    'expected COMPLETION_PHASES.reuse_audit_enforcement to be defined'
   );
 });
 
@@ -21,7 +21,7 @@ test('completion-phase-registry exports SUGGESTED_SCOPE_ENFORCEMENT constant', (
   assert.equal(
     COMPLETION_PHASES.suggested_scope_enforcement,
     'suggested_scope_enforcement',
-    'expected COMPLETION_PHASES.suggested_scope_enforcement to be defined',
+    'expected COMPLETION_PHASES.suggested_scope_enforcement to be defined'
   );
 });
 
@@ -29,7 +29,7 @@ test('completion-phase-registry exports TEST_PASS_CROSSREF constant', () => {
   assert.equal(
     COMPLETION_PHASES.test_pass_crossref,
     'test_pass_crossref',
-    'expected COMPLETION_PHASES.test_pass_crossref to be defined',
+    'expected COMPLETION_PHASES.test_pass_crossref to be defined'
   );
 });
 
@@ -47,9 +47,21 @@ test('phase order places the three new phases between coverage_check and kind_ch
   assert.ok(idxCrossref >= 0, 'test_pass_crossref must be in order');
   assert.ok(idxKind >= 0, 'kind_checks must be in order');
 
-  assert.equal(idxReuse, idxCoverage + 1, 'reuse_audit_enforcement must immediately follow coverage_check');
-  assert.equal(idxSuggested, idxReuse + 1, 'suggested_scope_enforcement must immediately follow reuse_audit_enforcement');
-  assert.equal(idxCrossref, idxSuggested + 1, 'test_pass_crossref must immediately follow suggested_scope_enforcement');
+  assert.equal(
+    idxReuse,
+    idxCoverage + 1,
+    'reuse_audit_enforcement must immediately follow coverage_check'
+  );
+  assert.equal(
+    idxSuggested,
+    idxReuse + 1,
+    'suggested_scope_enforcement must immediately follow reuse_audit_enforcement'
+  );
+  assert.equal(
+    idxCrossref,
+    idxSuggested + 1,
+    'test_pass_crossref must immediately follow suggested_scope_enforcement'
+  );
   assert.equal(idxKind, idxCrossref + 1, 'kind_checks must immediately follow test_pass_crossref');
 });
 
@@ -57,21 +69,21 @@ test('transitions form the chain coverage_check → reuse_audit_enforcement → 
   assert.deepEqual(
     [...(COMPLETION_PHASE_TRANSITIONS.coverage_check || [])],
     ['reuse_audit_enforcement'],
-    'coverage_check.next should be [reuse_audit_enforcement]',
+    'coverage_check.next should be [reuse_audit_enforcement]'
   );
   assert.deepEqual(
     [...(COMPLETION_PHASE_TRANSITIONS.reuse_audit_enforcement || [])],
     ['suggested_scope_enforcement'],
-    'reuse_audit_enforcement.next should be [suggested_scope_enforcement]',
+    'reuse_audit_enforcement.next should be [suggested_scope_enforcement]'
   );
   assert.deepEqual(
     [...(COMPLETION_PHASE_TRANSITIONS.suggested_scope_enforcement || [])],
     ['test_pass_crossref'],
-    'suggested_scope_enforcement.next should be [test_pass_crossref]',
+    'suggested_scope_enforcement.next should be [test_pass_crossref]'
   );
   assert.deepEqual(
     [...(COMPLETION_PHASE_TRANSITIONS.test_pass_crossref || [])],
     ['kind_checks'],
-    'test_pass_crossref.next should be [kind_checks]',
+    'test_pass_crossref.next should be [kind_checks]'
   );
 });

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-requirement-id.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-requirement-id.test.js
@@ -38,7 +38,7 @@ test('readReuseAudit synthesizes REUSE-<n> ids for each entry', () => {
         '- `Bar` MUST be reused from `b.ts`',
         '- `Baz` may be reused from `c.ts`',
         '',
-      ].join('\n'),
+      ].join('\n')
     );
     const result = shared.readReuseAudit(dir);
     assert.equal(result.length, 3);
@@ -65,11 +65,11 @@ test('failure record carries the synthesized REUSE-<n> id, not the legacy R1 def
         '- `AlphaWidget` MUST be reused from `a.ts`',
         '- `BetaWidget` MUST be reused from `b.ts`',
         '',
-      ].join('\n'),
+      ].join('\n')
     );
     fs.writeFileSync(
       path.join(tasksDir, 'pr-context.json'),
-      JSON.stringify({ files: ['x.ts'] }, null, 2),
+      JSON.stringify({ files: ['x.ts'] }, null, 2)
     );
     fs.writeFileSync(path.join(root, 'x.ts'), 'export const z = 1;\n');
     const ctx = { tasksDir, worktreeRoot: root, failures: [] };

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/test-pass-crossref.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/test-pass-crossref.test.js
@@ -53,12 +53,7 @@ test.describe('test_pass_crossref phase', () => {
     const tasks = coverageTasks([
       { id: 'R4', status: 'DELIVERED', evidence: 'foo.test.js:test_R4' },
     ]);
-    const testReport = [
-      '# Tests Check',
-      '',
-      '- test_R4 — Status: FAIL',
-      '',
-    ].join('\n');
+    const testReport = ['# Tests Check', '', '- test_R4 — Status: FAIL', ''].join('\n');
     const { ctx, cleanup } = buildCtx({ tasks, testReport });
     try {
       const result = await phase.validate(ctx);
@@ -76,12 +71,7 @@ test.describe('test_pass_crossref phase', () => {
     const tasks = coverageTasks([
       { id: 'R4', status: 'DELIVERED', evidence: 'foo.test.js:test_R4' },
     ]);
-    const testReport = [
-      '# Tests Check',
-      '',
-      '- test_R4 — Status: PASS',
-      '',
-    ].join('\n');
+    const testReport = ['# Tests Check', '', '- test_R4 — Status: PASS', ''].join('\n');
     const { ctx, cleanup } = buildCtx({ tasks, testReport });
     try {
       const result = await phase.validate(ctx);
@@ -89,7 +79,7 @@ test.describe('test_pass_crossref phase', () => {
       assert.equal(
         ctx.failures.filter((f) => f.checkType === 'test_pass').length,
         0,
-        'no test_pass failure should be pushed',
+        'no test_pass failure should be pushed'
       );
     } finally {
       cleanup();
@@ -107,10 +97,7 @@ test.describe('test_pass_crossref phase', () => {
       assert.equal(result.ok, false, 'phase must fail when tests.check.md is missing');
       const rec = ctx.failures.find((f) => f.checkType === 'test_pass');
       assert.ok(rec, 'a test_pass failure record must be pushed');
-      assert.equal(
-        rec.observed,
-        'tests.check.md not found — cannot verify test pass',
-      );
+      assert.equal(rec.observed, 'tests.check.md not found — cannot verify test pass');
     } finally {
       cleanup();
     }
@@ -120,12 +107,7 @@ test.describe('test_pass_crossref phase', () => {
     const tasks = coverageTasks([
       { id: 'R4', status: 'DELIVERED', evidence: 'foo.test.js:test_R4' },
     ]);
-    const testReport = [
-      '# Tests Check',
-      '',
-      '- test_other — Status: PASS',
-      '',
-    ].join('\n');
+    const testReport = ['# Tests Check', '', '- test_other — Status: PASS', ''].join('\n');
     const { ctx, cleanup } = buildCtx({ tasks, testReport });
     try {
       const result = await phase.validate(ctx);
@@ -136,7 +118,7 @@ test.describe('test_pass_crossref phase', () => {
       assert.match(
         rec.observed,
         /not found in tests\.check\.md/,
-        'observed must distinguish "not found" from FAIL',
+        'observed must distinguish "not found" from FAIL'
       );
       assert.doesNotMatch(rec.observed, /FAIL in tests\.check\.md/);
     } finally {
@@ -145,9 +127,7 @@ test.describe('test_pass_crossref phase', () => {
   });
 
   test('(d) DELIVERED rows but none cite a test ⇒ ok:false (B2: gate has teeth)', async () => {
-    const tasks = coverageTasks([
-      { id: 'R4', status: 'DELIVERED', evidence: 'tasks.md:Task 4' },
-    ]);
+    const tasks = coverageTasks([{ id: 'R4', status: 'DELIVERED', evidence: 'tasks.md:Task 4' }]);
     const { ctx, cleanup } = buildCtx({ tasks });
     try {
       const result = await phase.validate(ctx);
@@ -179,10 +159,18 @@ test('word-boundary match: test_R1 must NOT match test_R10 substring (no false-p
   const { ctx, cleanup } = buildCtx({ tasks, testReport: report });
   try {
     const result = await phase.validate(ctx);
-    assert.equal(result.ok, false, 'must NOT silently pass when test_R1 fails (only test_R10 passes)');
+    assert.equal(
+      result.ok,
+      false,
+      'must NOT silently pass when test_R1 fails (only test_R10 passes)'
+    );
     const failed = ctx.failures.find((f) => f.checkType === 'test_pass');
     assert.ok(failed, 'expected a test_pass failure record');
-    assert.match(failed.observed, /FAIL in tests\.check\.md/, 'observed must cite FAIL, not pass via substring');
+    assert.match(
+      failed.observed,
+      /FAIL in tests\.check\.md/,
+      'observed must cite FAIL, not pass via substring'
+    );
   } finally {
     cleanup();
   }
@@ -259,11 +247,7 @@ test('DELIVERED row citing two tests verifies both — second failing flips ok:f
   const tasks = coverageTasks([
     { id: 'R9', status: 'DELIVERED', evidence: '`foo.test.js:test_A, bar.test.js:test_B`' },
   ]);
-  const report = [
-    '- test_A — Status: PASS',
-    '- test_B — Status: FAIL',
-    '',
-  ].join('\n');
+  const report = ['- test_A — Status: PASS', '- test_B — Status: FAIL', ''].join('\n');
   const { ctx, cleanup } = buildCtx({ tasks, testReport: report });
   try {
     const result = await phase.validate(ctx);
@@ -284,7 +268,9 @@ test('Missing tests.check.md collapses multi-citation row to one failure (not on
   try {
     const result = await phase.validate(ctx);
     assert.equal(result.ok, false);
-    const failing = ctx.failures.filter((f) => f.checkType === 'test_pass' && f.requirementId === 'R9');
+    const failing = ctx.failures.filter(
+      (f) => f.checkType === 'test_pass' && f.requirementId === 'R9'
+    );
     assert.equal(failing.length, 1);
   } finally {
     cleanup();

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/fullstack.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/fullstack.js
@@ -21,7 +21,6 @@ function appliesTo(ctx) {
   return changed.some(isFrontendFile) && changed.some(isBackendFile);
 }
 
-
 function validate(ctx) {
   const fr = frontend.validate(ctx);
   const be = backend.validate(ctx);

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/wiring.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/wiring.js
@@ -27,7 +27,6 @@ function appliesTo(ctx) {
   return readChangedFiles(ctx).some(isBackendFile);
 }
 
-
 function validate(ctx) {
   const brief = readBrief(ctx.tasksDir);
   const changed = readChangedFiles(ctx);

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-colocated.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-colocated.test.js
@@ -23,36 +23,27 @@ test('P0 #1 — colocated test discovery: finds <basename>.test.js next to sourc
   assert.equal(
     typeof findTestFilesInScope,
     'function',
-    'findTestFilesInScope must be exported from task-next.js',
+    'findTestFilesInScope must be exported from task-next.js'
   );
 
   const tmp = makeTmp();
   try {
     fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
     fs.writeFileSync(path.join(tmp, 'src', 'foo.js'), '// source\n');
-    fs.writeFileSync(
-      path.join(tmp, 'src', 'foo.test.js'),
-      "require('node:test');\n",
-    );
+    fs.writeFileSync(path.join(tmp, 'src', 'foo.test.js'), "require('node:test');\n");
 
     const result = findTestFilesInScope(tmp, ['src/foo.js']);
 
-    assert.ok(
-      result instanceof Set,
-      'findTestFilesInScope must return a Set',
-    );
+    assert.ok(result instanceof Set, 'findTestFilesInScope must return a Set');
 
     const colocated = path.join(tmp, 'src', 'foo.test.js');
     const source = path.join(tmp, 'src', 'foo.js');
 
     assert.ok(
       result.has(colocated),
-      `expected result to contain colocated test ${colocated}, got ${[...result].join(', ')}`,
+      `expected result to contain colocated test ${colocated}, got ${[...result].join(', ')}`
     );
-    assert.ok(
-      !result.has(source),
-      'result must not include the non-test source file',
-    );
+    assert.ok(!result.has(source), 'result must not include the non-test source file');
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
@@ -70,7 +61,7 @@ test('P0 #1 — colocated test discovery: also supports .spec.ts colocated along
     const colocated = path.join(tmp, 'pkg', 'bar.spec.ts');
     assert.ok(
       result.has(colocated),
-      `expected colocated .spec.ts at ${colocated}, got ${[...result].join(', ')}`,
+      `expected colocated .spec.ts at ${colocated}, got ${[...result].join(', ')}`
     );
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
@@ -82,10 +73,7 @@ test('P0 #1 control case — existing __tests__/ sibling walk still works', () =
   try {
     fs.mkdirSync(path.join(tmp, 'src', '__tests__'), { recursive: true });
     fs.writeFileSync(path.join(tmp, 'src', 'baz.js'), '// source\n');
-    fs.writeFileSync(
-      path.join(tmp, 'src', '__tests__', 'baz.test.js'),
-      '// test\n',
-    );
+    fs.writeFileSync(path.join(tmp, 'src', '__tests__', 'baz.test.js'), '// test\n');
 
     // Scope on the directory exercises the directory-walk branch, which
     // must continue to find tests under __tests__/.
@@ -94,7 +82,7 @@ test('P0 #1 control case — existing __tests__/ sibling walk still works', () =
     const walked = path.join(tmp, 'src', '__tests__', 'baz.test.js');
     assert.ok(
       result.has(walked),
-      `expected directory walk to find ${walked}, got ${[...result].join(', ')}`,
+      `expected directory walk to find ${walked}, got ${[...result].join(', ')}`
     );
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-filter-to-test-files.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-filter-to-test-files.test.js
@@ -18,7 +18,7 @@ describe('filterToTestFiles (P0 #2 — CHANGED_FILES sanitized in RED)', () => {
     assert.equal(
       typeof taskNext.filterToTestFiles,
       'function',
-      'filterToTestFiles must be a named export of task-next.js',
+      'filterToTestFiles must be a named export of task-next.js'
     );
   });
 

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-scope-regex.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-scope-regex.test.js
@@ -18,21 +18,26 @@ test('extractField ignores in-prose backticked heading mentions', () => {
     '',
     '### Test Command',
     '',
-  ].join('\n').replace(/BACKTICK/g, String.fromCharCode(96));
+  ]
+    .join('\n')
+    .replace(/BACKTICK/g, String.fromCharCode(96));
   const scope = parseSuggestedScope(section);
-  assert.deepEqual(scope, [
-    'plugins/work/lib/foo.js',
-    'plugins/work/__tests__/foo.test.js',
-  ]);
+  assert.deepEqual(scope, ['plugins/work/lib/foo.js', 'plugins/work/__tests__/foo.test.js']);
 });
 
 test('extractField matches a heading at start-of-string', () => {
-  const section = '### Files in scope\n- BACKTICKfoo/bar.jsBACKTICK\n\n### Test Command\n'.replace(/BACKTICK/g, String.fromCharCode(96));
+  const section = '### Files in scope\n- BACKTICKfoo/bar.jsBACKTICK\n\n### Test Command\n'.replace(
+    /BACKTICK/g,
+    String.fromCharCode(96)
+  );
   assert.equal(extractField(section, 'Files in scope').trim().includes('foo/bar.js'), true);
 });
 
 test('extractField does NOT match heading-like substring without leading newline', () => {
-  const section = 'prefix BACKTICK### Files in scopeBACKTICK inline\n### Other\n'.replace(/BACKTICK/g, String.fromCharCode(96));
+  const section = 'prefix BACKTICK### Files in scopeBACKTICK inline\n### Other\n'.replace(
+    /BACKTICK/g,
+    String.fromCharCode(96)
+  );
   assert.equal(extractField(section, 'Files in scope'), '');
 });
 
@@ -50,11 +55,13 @@ test('parseSuggestedScope: when BOTH headings are present, `Files in scope` wins
     '',
     '### Test Command',
     '',
-  ].join('\n').replace(/BACKTICK/g, String.fromCharCode(96));
+  ]
+    .join('\n')
+    .replace(/BACKTICK/g, String.fromCharCode(96));
   const scope = parseSuggestedScope(section);
   assert.deepEqual(
     scope,
     ['canonical/new-path.js', 'canonical/new-test.test.js'],
-    '`Files in scope` is the canonical heading and must override `Suggested Scope` when both are present',
+    '`Files in scope` is the canonical heading and must override `Suggested Scope` when both are present'
   );
 });

--- a/plugins/work/scripts/workflows/work-implement/__tests__/task-next-strict-mode.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/task-next-strict-mode.test.js
@@ -20,57 +20,53 @@ const assert = require('node:assert/strict');
 const { spawnSync } = require('node:child_process');
 const path = require('node:path');
 
-const TASK_NEXT_PATH = path.resolve(
-	__dirname,
-	'..',
-	'task-next.js',
-);
+const TASK_NEXT_PATH = path.resolve(__dirname, '..', 'task-next.js');
 
 test('P0 #3 — strict-mode multiline command: wrapStrictMode is exported from task-next.js', () => {
-	const mod = require(TASK_NEXT_PATH);
-	assert.equal(
-		typeof mod.wrapStrictMode,
-		'function',
-		'expected task-next.js to export wrapStrictMode()',
-	);
+  const mod = require(TASK_NEXT_PATH);
+  assert.equal(
+    typeof mod.wrapStrictMode,
+    'function',
+    'expected task-next.js to export wrapStrictMode()'
+  );
 });
 
 test('P0 #3 — strict-mode multiline command: chained command gets set -euo pipefail prefix', () => {
-	const { wrapStrictMode } = require(TASK_NEXT_PATH);
-	const wrapped = wrapStrictMode('echo a && false && echo b');
-	assert.equal(typeof wrapped, 'string');
-	assert.ok(
-		wrapped.startsWith('set -euo pipefail;'),
-		`expected wrapped command to start with 'set -euo pipefail;', got: ${wrapped}`,
-	);
-	assert.ok(
-		wrapped.includes('echo a && false && echo b'),
-		'expected wrapped command to retain the original chain',
-	);
+  const { wrapStrictMode } = require(TASK_NEXT_PATH);
+  const wrapped = wrapStrictMode('echo a && false && echo b');
+  assert.equal(typeof wrapped, 'string');
+  assert.ok(
+    wrapped.startsWith('set -euo pipefail;'),
+    `expected wrapped command to start with 'set -euo pipefail;', got: ${wrapped}`
+  );
+  assert.ok(
+    wrapped.includes('echo a && false && echo b'),
+    'expected wrapped command to retain the original chain'
+  );
 });
 
 test('P0 #3 — strict-mode multiline command: newline-separated commands also get strict prefix', () => {
-	const { wrapStrictMode } = require(TASK_NEXT_PATH);
-	const multiline = 'echo a\nfalse\necho b';
-	const wrapped = wrapStrictMode(multiline);
-	assert.ok(
-		wrapped.startsWith('set -euo pipefail;'),
-		`expected multiline command to be wrapped, got: ${wrapped}`,
-	);
+  const { wrapStrictMode } = require(TASK_NEXT_PATH);
+  const multiline = 'echo a\nfalse\necho b';
+  const wrapped = wrapStrictMode(multiline);
+  assert.ok(
+    wrapped.startsWith('set -euo pipefail;'),
+    `expected multiline command to be wrapped, got: ${wrapped}`
+  );
 });
 
 test('P0 #3 — strict-mode multiline command: single-command invocation is unchanged', () => {
-	const { wrapStrictMode } = require(TASK_NEXT_PATH);
-	assert.equal(wrapStrictMode('echo solo'), 'echo solo');
+  const { wrapStrictMode } = require(TASK_NEXT_PATH);
+  assert.equal(wrapStrictMode('echo solo'), 'echo solo');
 });
 
 test('P0 #3 — strict-mode multiline command: wrapped chained failure exits non-zero under bash -lc', () => {
-	const { wrapStrictMode } = require(TASK_NEXT_PATH);
-	const wrapped = wrapStrictMode('echo a && false && echo b');
-	const result = spawnSync('bash', ['-lc', wrapped], { encoding: 'utf8' });
-	assert.notEqual(
-		result.status,
-		0,
-		`expected non-zero exit for wrapped chain with middle failure, got status=${result.status} stdout=${result.stdout} stderr=${result.stderr}`,
-	);
+  const { wrapStrictMode } = require(TASK_NEXT_PATH);
+  const wrapped = wrapStrictMode('echo a && false && echo b');
+  const result = spawnSync('bash', ['-lc', wrapped], { encoding: 'utf8' });
+  assert.notEqual(
+    result.status,
+    0,
+    `expected non-zero exit for wrapped chain with middle failure, got status=${result.status} stdout=${result.stdout} stderr=${result.stderr}`
+  );
 });

--- a/plugins/work/scripts/workflows/work-pr-reviewer/lib/kind-checks/wiring.js
+++ b/plugins/work/scripts/workflows/work-pr-reviewer/lib/kind-checks/wiring.js
@@ -22,10 +22,7 @@ function appliesTo(ctx) {
   // silence wiring on the exact ECHO-4579 case (brief forbids backend +
   // tasks declare frontend).
   if (detectKinds(ctx.tasksDir).includes('wiring')) return true;
-  return (
-    briefForbidsBackend(readBrief(ctx.tasksDir)) &&
-    readChangedFiles(ctx).some(isBackendFile)
-  );
+  return briefForbidsBackend(readBrief(ctx.tasksDir)) && readChangedFiles(ctx).some(isBackendFile);
 }
 
 function validate(ctx) {

--- a/plugins/work/scripts/workflows/work-task-review/lib/kind-checks/wiring.js
+++ b/plugins/work/scripts/workflows/work-task-review/lib/kind-checks/wiring.js
@@ -27,7 +27,6 @@ function appliesTo(ctx) {
   return readChangedFiles(ctx).some(isBackendFile);
 }
 
-
 function validate(ctx) {
   const brief = readBrief(ctx.tasksDir);
   const changed = readChangedFiles(ctx);

--- a/plugins/work/scripts/workflows/work/__tests__/implement-step.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/implement-step.test.js
@@ -447,7 +447,10 @@ describe('implement step — dependency-aware messaging (GH-219 Task 16)', () =>
 
       const taskInit = calls.find((c) => Array.isArray(c.args) && c.args.includes('task-init'));
       assert.ok(taskInit, 'task-init invocation should occur');
-      assert.ok(typeof taskInit.input === 'string' && taskInit.input.length > 0, 'task-init must receive descriptor JSON via stdin');
+      assert.ok(
+        typeof taskInit.input === 'string' && taskInit.input.length > 0,
+        'task-init must receive descriptor JSON via stdin'
+      );
       const parsed = JSON.parse(taskInit.input);
       assert.ok(Array.isArray(parsed));
       assert.equal(parsed.length, 2);

--- a/plugins/work/scripts/workflows/work/__tests__/tasks-gate-intra-ticket.integration.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/tasks-gate-intra-ticket.integration.test.js
@@ -94,16 +94,24 @@ describe('tasks-gate intra-ticket scope routing', () => {
     const add = (step, decision, agent, reason, opts) =>
       calls.push({ step, decision, agent, reason, opts });
 
-    tasksGateStep(add, { hasTasks: true }, {
-      STEPS,
-      tasksDir: tmpDir,
-      path,
-    });
+    tasksGateStep(
+      add,
+      { hasTasks: true },
+      {
+        STEPS,
+        tasksDir: tmpDir,
+        path,
+      }
+    );
 
     assert.equal(calls.length, 1, `expected exactly one add() call; got ${JSON.stringify(calls)}`);
     const [c] = calls;
     assert.equal(c.step, 'tasks_gate');
-    assert.equal(c.decision, 'RUN', `gate must RUN split-in-tasks, not DEFER; got ${JSON.stringify(c)}`);
+    assert.equal(
+      c.decision,
+      'RUN',
+      `gate must RUN split-in-tasks, not DEFER; got ${JSON.stringify(c)}`
+    );
     assert.equal(c.agent, '/work-workflow:split-in-tasks');
     assert.match(
       c.reason,

--- a/plugins/work/scripts/workflows/work/__tests__/work-next-resume.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-next-resume.test.js
@@ -100,10 +100,7 @@ function writeState(tmpBase, ticket, overrides = {}) {
     ...overrides,
     stepStatus,
   };
-  fs.writeFileSync(
-    pathMod.join(ticketDir, '.work-state.json'),
-    JSON.stringify(state, null, 2)
-  );
+  fs.writeFileSync(pathMod.join(ticketDir, '.work-state.json'), JSON.stringify(state, null, 2));
   return state;
 }
 
@@ -166,10 +163,7 @@ describe('work-next.js — dispatcher early-return on terminal completed state (
           // intentionally NO 'complete' key
         },
       };
-      fs.writeFileSync(
-        pathMod.join(ticketDir, '.work-state.json'),
-        JSON.stringify(state, null, 2)
-      );
+      fs.writeFileSync(pathMod.join(ticketDir, '.work-state.json'), JSON.stringify(state, null, 2));
 
       const { parsed } = runWorkNext('ECHO-4666', tmpBase);
       assert.ok(parsed, 'expected JSON output');

--- a/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
@@ -744,7 +744,6 @@ describe('workflow-definition: tasks.md contentGuard', () => {
   });
 });
 
-
 // ─── GH-326 Task 1.2: .check.md contentGuard ─────────────────────────────────
 describe('workflow-definition: .check.md contentGuard', () => {
   const { artifactRules } = createWorkflowDefinition(stubDeps);

--- a/plugins/work/scripts/workflows/work/engine/__tests__/transition-step-gate-fingerprint.test.js
+++ b/plugins/work/scripts/workflows/work/engine/__tests__/transition-step-gate-fingerprint.test.js
@@ -119,7 +119,9 @@ describe('transition-step gateFingerprints (GH-398 Task 7)', () => {
     const fp = savedRef.ws.gateFingerprints.brief_gate;
     assert.ok(fp, 'fingerprint for brief_gate must exist');
     // __dirname = plugins/work/scripts/workflows/work/engine/__tests__ → repo root is 7 levels up
-    const pkg = require(path.join(__dirname, '..', '..', '..', '..', '..', '..', '..', 'package.json'));
+    const pkg = require(
+      path.join(__dirname, '..', '..', '..', '..', '..', '..', '..', 'package.json')
+    );
     assert.equal(fp.pluginVersion, pkg.version, 'pluginVersion must equal package.json version');
     assert.match(
       fp.satisfiedAt,

--- a/plugins/work/scripts/workflows/work/hooks/protect-gherkin.js
+++ b/plugins/work/scripts/workflows/work/hooks/protect-gherkin.js
@@ -186,8 +186,7 @@ async function main() {
             ? toolInput.edits
             : [{ old_string: toolInput.old_string, new_string: toolInput.new_string }];
         const allTagOnly =
-          edits.length > 0 &&
-          edits.every((e) => isTagOnlyGherkinEdit(e.old_string, e.new_string));
+          edits.length > 0 && edits.every((e) => isTagOnlyGherkinEdit(e.old_string, e.new_string));
         if (allTagOnly) {
           process.exit(0);
         }

--- a/plugins/work/scripts/workflows/work/lib/__tests__/gherkin-coverage.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/gherkin-coverage.test.js
@@ -18,9 +18,33 @@ const { validateTaskCoverage, validateTestCoverage } = require('../gherkin-cover
 describe('gherkin-coverage: validateTaskCoverage', () => {
   it('detects uncovered scenarios', () => {
     const scenarios = [
-      { name: 'Scenario A', tags: ['@integration'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] },
-      { name: 'Scenario B', tags: ['@unit'], steps: [{ keyword: 'Given', text: 'a' }, { keyword: 'When', text: 'b' }, { keyword: 'Then', text: 'c' }] },
-      { name: 'Scenario C', tags: ['@e2e'], steps: [{ keyword: 'Given', text: 'd' }, { keyword: 'When', text: 'e' }, { keyword: 'Then', text: 'f' }] },
+      {
+        name: 'Scenario A',
+        tags: ['@integration'],
+        steps: [
+          { keyword: 'Given', text: 'x' },
+          { keyword: 'When', text: 'y' },
+          { keyword: 'Then', text: 'z' },
+        ],
+      },
+      {
+        name: 'Scenario B',
+        tags: ['@unit'],
+        steps: [
+          { keyword: 'Given', text: 'a' },
+          { keyword: 'When', text: 'b' },
+          { keyword: 'Then', text: 'c' },
+        ],
+      },
+      {
+        name: 'Scenario C',
+        tags: ['@e2e'],
+        steps: [
+          { keyword: 'Given', text: 'd' },
+          { keyword: 'When', text: 'e' },
+          { keyword: 'Then', text: 'f' },
+        ],
+      },
     ];
     const tasksContent = [
       '## Task 1',
@@ -38,13 +62,26 @@ describe('gherkin-coverage: validateTaskCoverage', () => {
 
   it('passes when all scenarios are covered', () => {
     const scenarios = [
-      { name: 'Scenario A', tags: ['@integration'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] },
-      { name: 'Scenario B', tags: ['@unit'], steps: [{ keyword: 'Given', text: 'a' }, { keyword: 'When', text: 'b' }, { keyword: 'Then', text: 'c' }] },
+      {
+        name: 'Scenario A',
+        tags: ['@integration'],
+        steps: [
+          { keyword: 'Given', text: 'x' },
+          { keyword: 'When', text: 'y' },
+          { keyword: 'Then', text: 'z' },
+        ],
+      },
+      {
+        name: 'Scenario B',
+        tags: ['@unit'],
+        steps: [
+          { keyword: 'Given', text: 'a' },
+          { keyword: 'When', text: 'b' },
+          { keyword: 'Then', text: 'c' },
+        ],
+      },
     ];
-    const tasksContent = [
-      '## Task 1',
-      'Covers Scenario A and Scenario B',
-    ].join('\n');
+    const tasksContent = ['## Task 1', 'Covers Scenario A and Scenario B'].join('\n');
 
     const result = validateTaskCoverage(scenarios, tasksContent);
     assert.equal(result.valid, true);
@@ -56,7 +93,8 @@ describe('gherkin-coverage: validateTaskCoverage', () => {
       { name: 'User Can Login', tags: ['@integration'] },
       { name: 'Admin Dashboard Loads', tags: ['@e2e'] },
     ];
-    const tasksContent = '## Task 1\nImplement user can login\n## Task 2\nImplement admin dashboard loads';
+    const tasksContent =
+      '## Task 1\nImplement user can login\n## Task 2\nImplement admin dashboard loads';
     const result = validateTaskCoverage(scenarios, tasksContent);
     assert.equal(result.valid, true);
     assert.deepEqual(result.uncovered, []);
@@ -68,10 +106,21 @@ describe('gherkin-coverage: validateTaskCoverage', () => {
 describe('gherkin-coverage: validateTestCoverage', () => {
   it('matches scenario to correct test type with tag match', () => {
     const scenarios = [
-      { name: 'Request password reset email', tags: ['@e2e'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] },
+      {
+        name: 'Request password reset email',
+        tags: ['@e2e'],
+        steps: [
+          { keyword: 'Given', text: 'x' },
+          { keyword: 'When', text: 'y' },
+          { keyword: 'Then', text: 'z' },
+        ],
+      },
     ];
     const testFiles = [
-      { path: 'src/__tests__/password-reset.e2e.test.js', content: 'test("Request password reset email", () => {})' },
+      {
+        path: 'src/__tests__/password-reset.e2e.test.js',
+        content: 'test("Request password reset email", () => {})',
+      },
     ];
 
     const result = validateTestCoverage(scenarios, testFiles);
@@ -83,7 +132,10 @@ describe('gherkin-coverage: validateTestCoverage', () => {
   it('matches scenario to correct test type with @integration tag', () => {
     const scenarios = [{ name: 'Data persists after save', tags: ['@integration'] }];
     const testFiles = [
-      { path: 'src/__tests__/save.integration.test.js', content: 'test("Data persists after save", () => {})' },
+      {
+        path: 'src/__tests__/save.integration.test.js',
+        content: 'test("Data persists after save", () => {})',
+      },
     ];
     const result = validateTestCoverage(scenarios, testFiles);
     assert.equal(result.valid, true);
@@ -93,10 +145,21 @@ describe('gherkin-coverage: validateTestCoverage', () => {
 
   it('rejects wrong test type for tag — @e2e scenario only in unit test file', () => {
     const scenarios = [
-      { name: 'Request password reset email', tags: ['@e2e'], steps: [{ keyword: 'Given', text: 'x' }, { keyword: 'When', text: 'y' }, { keyword: 'Then', text: 'z' }] },
+      {
+        name: 'Request password reset email',
+        tags: ['@e2e'],
+        steps: [
+          { keyword: 'Given', text: 'x' },
+          { keyword: 'When', text: 'y' },
+          { keyword: 'Then', text: 'z' },
+        ],
+      },
     ];
     const testFiles = [
-      { path: 'src/__tests__/password-reset.test.js', content: 'test("Request password reset email", () => {})' },
+      {
+        path: 'src/__tests__/password-reset.test.js',
+        content: 'test("Request password reset email", () => {})',
+      },
     ];
 
     const result = validateTestCoverage(scenarios, testFiles);

--- a/plugins/work/scripts/workflows/work/lib/__tests__/print-current-step.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/print-current-step.test.js
@@ -42,11 +42,15 @@ test('print-current-step: single state file → prints mapped step name', () => 
   try {
     const implementIndex = ALL_STEPS.indexOf('implement');
     assert.ok(implementIndex >= 0, 'step registry must contain `implement`');
-    writeStateFile(tmp, 'TKT-1', JSON.stringify({
-      ticketId: 'TKT-1',
-      currentStep: implementIndex + 1, // 1-indexed
-      status: 'in_progress',
-    }));
+    writeStateFile(
+      tmp,
+      'TKT-1',
+      JSON.stringify({
+        ticketId: 'TKT-1',
+        currentStep: implementIndex + 1, // 1-indexed
+        status: 'in_progress',
+      })
+    );
 
     const res = runWithTasksBase(tmp);
     assert.equal(res.status, 0, `stderr=${res.stderr}`);
@@ -63,12 +67,20 @@ test('print-current-step: newest mtime wins across multiple state files', () => 
     const briefIndex = ALL_STEPS.indexOf('brief');
     assert.ok(ciIndex >= 0 && briefIndex >= 0);
 
-    const olderPath = writeStateFile(tmp, 'OLD-1', JSON.stringify({
-      currentStep: briefIndex + 1,
-    }));
-    const newerPath = writeStateFile(tmp, 'NEW-1', JSON.stringify({
-      currentStep: ciIndex + 1,
-    }));
+    const olderPath = writeStateFile(
+      tmp,
+      'OLD-1',
+      JSON.stringify({
+        currentStep: briefIndex + 1,
+      })
+    );
+    const newerPath = writeStateFile(
+      tmp,
+      'NEW-1',
+      JSON.stringify({
+        currentStep: ciIndex + 1,
+      })
+    );
 
     // Force mtimes so the test is independent of write order timing.
     const past = new Date(Date.now() - 60_000);
@@ -100,11 +112,15 @@ test('print-current-step: malformed JSON → exit 0, stdout empty (fail-silent)'
 test('print-current-step: missing currentStep → exit 0, stdout empty (fail-silent, no fallback to step 1)', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pcs-missing-step-'));
   try {
-    writeStateFile(tmp, 'TKT-NO-STEP', JSON.stringify({
-      ticketId: 'TKT-NO-STEP',
-      status: 'in_progress',
-      // currentStep intentionally omitted
-    }));
+    writeStateFile(
+      tmp,
+      'TKT-NO-STEP',
+      JSON.stringify({
+        ticketId: 'TKT-NO-STEP',
+        status: 'in_progress',
+        // currentStep intentionally omitted
+      })
+    );
 
     const res = runWithTasksBase(tmp);
     assert.equal(res.status, 0, `stderr=${res.stderr}`);

--- a/plugins/work/scripts/workflows/work/lib/cost-report.js
+++ b/plugins/work/scripts/workflows/work/lib/cost-report.js
@@ -98,42 +98,50 @@ function renderCostReport({ ticket, usageRecords, stepDurations, model, pricingT
   lines.push('');
   lines.push('## Grand total (estimated)');
   lines.push('');
-  lines.push(markdownTable(
-    ['Total tokens', 'Total tool_uses', 'Total duration', 'Estimated USD'],
-    [[
-      fmtNum(totals.tokens),
-      fmtNum(totals.toolUses),
-      fmtMs(totals.durationMs),
-      `$${fmtUsd(totalUsd)} (estimated)`,
-    ]]
-  ));
+  lines.push(
+    markdownTable(
+      ['Total tokens', 'Total tool_uses', 'Total duration', 'Estimated USD'],
+      [
+        [
+          fmtNum(totals.tokens),
+          fmtNum(totals.toolUses),
+          fmtMs(totals.durationMs),
+          `$${fmtUsd(totalUsd)} (estimated)`,
+        ],
+      ]
+    )
+  );
 
   lines.push('');
   lines.push('## Per-step breakdown');
   lines.push('');
-  lines.push(markdownTable(
-    ['Step', 'Tokens', 'Tool uses', 'Duration', 'Estimated USD'],
-    Object.keys(byStep).map((step) => [
-      step,
-      fmtNum(byStep[step].tokens),
-      fmtNum(byStep[step].toolUses),
-      durations[step] || fmtMs(byStep[step].durationMs),
-      `$${fmtUsd(estimateCostUsd(byStep[step].tokens, model, pricingTable))}`,
-    ])
-  ));
+  lines.push(
+    markdownTable(
+      ['Step', 'Tokens', 'Tool uses', 'Duration', 'Estimated USD'],
+      Object.keys(byStep).map((step) => [
+        step,
+        fmtNum(byStep[step].tokens),
+        fmtNum(byStep[step].toolUses),
+        durations[step] || fmtMs(byStep[step].durationMs),
+        `$${fmtUsd(estimateCostUsd(byStep[step].tokens, model, pricingTable))}`,
+      ])
+    )
+  );
 
   lines.push('');
   lines.push('## Per-agent breakdown');
   lines.push('');
-  lines.push(markdownTable(
-    ['Agent', 'Tokens', 'Tool uses', 'Estimated USD'],
-    Object.keys(byAgent).map((agent) => [
-      agent,
-      fmtNum(byAgent[agent].tokens),
-      fmtNum(byAgent[agent].toolUses),
-      `$${fmtUsd(estimateCostUsd(byAgent[agent].tokens, model, pricingTable))}`,
-    ])
-  ));
+  lines.push(
+    markdownTable(
+      ['Agent', 'Tokens', 'Tool uses', 'Estimated USD'],
+      Object.keys(byAgent).map((agent) => [
+        agent,
+        fmtNum(byAgent[agent].tokens),
+        fmtNum(byAgent[agent].toolUses),
+        `$${fmtUsd(estimateCostUsd(byAgent[agent].tokens, model, pricingTable))}`,
+      ])
+    )
+  );
 
   const topStep = mostExpensive(byStep);
   const topAgent = mostExpensive(byAgent);

--- a/plugins/work/scripts/workflows/work/lib/gherkin-coverage.js
+++ b/plugins/work/scripts/workflows/work/lib/gherkin-coverage.js
@@ -129,7 +129,8 @@ function validateTestCoverage(scenarios, testFiles) {
           correctMatch = { scenario: scenario.name, file: file.path, tagMatch: true };
           break; // correct type found — stop searching
         } else if (!wrongMatch) {
-          const tag = (scenario.tags || []).find((t) => t === '@e2e' || t === '@integration') || '@unit';
+          const tag =
+            (scenario.tags || []).find((t) => t === '@e2e' || t === '@integration') || '@unit';
           wrongMatch = { scenario: scenario.name, tag, file: file.path, actualType: actual };
         }
       }

--- a/plugins/work/scripts/workflows/work/lib/print-current-step.js
+++ b/plugins/work/scripts/workflows/work/lib/print-current-step.js
@@ -66,7 +66,7 @@ try {
   const num = Number(raw);
   if (!Number.isFinite(num) || num < 1) process.exit(0);
   const idx = num - 1;
-  const stepName = (idx >= 0 && idx < ALL_STEPS.length) ? ALL_STEPS[idx] : '';
+  const stepName = idx >= 0 && idx < ALL_STEPS.length ? ALL_STEPS[idx] : '';
   if (stepName) process.stdout.write(stepName);
 } catch {
   // Any unexpected error → fail silent, statusline must never break.

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/complete.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/complete.js
@@ -57,7 +57,7 @@ module.exports = function registerComplete(register) {
       const patterns = ['*.check.md', 'tdd-phase.json', '.step-evidence.json'];
       for (const pattern of patterns) {
         const prefix = pattern.replace('*', '');
-        const files = fs.readdirSync(tasksDir).filter(f => f.endsWith(prefix) || f === pattern);
+        const files = fs.readdirSync(tasksDir).filter((f) => f.endsWith(prefix) || f === pattern);
         for (const file of files) {
           const src = path.join(tasksDir, file);
           const dst = path.join(archiveDir, file);

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/follow-up.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/follow-up.js
@@ -32,9 +32,7 @@ function buildClosedPrBlocker(ticket) {
     hint: [
       'To re-plan:',
       '  1. Archive the current run (move brief.md / spec.md / tasks.md into `.archive/` under tasksDir).',
-      '  2. Re-run `/work ' +
-        (ticket || '<ticket>') +
-        '` — the workflow will re-enter at `brief`.',
+      '  2. Re-run `/work ' + (ticket || '<ticket>') + '` — the workflow will re-enter at `brief`.',
       '  3. The brief-writer will fetch a fresh related-tickets manifest and you can choose a different scope.',
     ].join('\n'),
   };

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/bootstrap-branch.integration.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/bootstrap-branch.integration.test.js
@@ -42,13 +42,20 @@ describe('bootstrap-branch.js — Task 1 (CLI contract + resolver)', () => {
     it('returns --git-branch-name value verbatim on stdout with exit 0 when TICKET_PROVIDER=linear', () => {
       const result = runResult(
         [
-          '--ticket-id', 'ECHO-4454',
-          '--summary', 'Fix Foo Bar',
-          '--git-branch-name', 'feature/echo-4454-foo',
+          '--ticket-id',
+          'ECHO-4454',
+          '--summary',
+          'Fix Foo Bar',
+          '--git-branch-name',
+          'feature/echo-4454-foo',
         ],
-        { TICKET_PROVIDER: 'linear' },
+        { TICKET_PROVIDER: 'linear' }
       );
-      assert.equal(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+      assert.equal(
+        result.status,
+        0,
+        `expected exit 0, got ${result.status}. stderr: ${result.stderr}`
+      );
       assert.equal(result.stdout.trim(), 'feature/echo-4454-foo');
       // stdout must contain only the resolved name (no trailing diagnostics)
       assert.equal(result.stdout.replace(/\n$/, ''), 'feature/echo-4454-foo');
@@ -57,22 +64,28 @@ describe('bootstrap-branch.js — Task 1 (CLI contract + resolver)', () => {
 
   describe('Fallback constructs <BRANCH_PREFIX><TICKET-ID>-<kebab-summary> when gitBranchName is absent', () => {
     it('with BRANCH_PREFIX=feature/ produces feature/echo-4454-fix-foo-bar (ticket-ID lowercased)', () => {
-      const result = runResult(
-        ['--ticket-id', 'ECHO-4454', '--summary', 'Fix Foo Bar'],
-        { BRANCH_PREFIX: 'feature/' },
+      const result = runResult(['--ticket-id', 'ECHO-4454', '--summary', 'Fix Foo Bar'], {
+        BRANCH_PREFIX: 'feature/',
+      });
+      assert.equal(
+        result.status,
+        0,
+        `expected exit 0, got ${result.status}. stderr: ${result.stderr}`
       );
-      assert.equal(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
       assert.equal(result.stdout.trim(), 'feature/echo-4454-fix-foo-bar');
     });
   });
 
   describe('Fallback works with empty BRANCH_PREFIX for backward compatibility', () => {
     it('with empty BRANCH_PREFIX produces echo-4454-fix-foo-bar', () => {
-      const result = runResult(
-        ['--ticket-id', 'ECHO-4454', '--summary', 'Fix Foo Bar'],
-        { BRANCH_PREFIX: '' },
+      const result = runResult(['--ticket-id', 'ECHO-4454', '--summary', 'Fix Foo Bar'], {
+        BRANCH_PREFIX: '',
+      });
+      assert.equal(
+        result.status,
+        0,
+        `expected exit 0, got ${result.status}. stderr: ${result.stderr}`
       );
-      assert.equal(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
       assert.equal(result.stdout.trim(), 'echo-4454-fix-foo-bar');
     });
   });
@@ -81,7 +94,11 @@ describe('bootstrap-branch.js — Task 1 (CLI contract + resolver)', () => {
     it('exits 1 with stderr explaining the missing flag when --ticket-id is absent', () => {
       const result = runResult(['--summary', 'Fix Foo Bar']);
       assert.equal(result.status, 1, `expected exit 1, got ${result.status}`);
-      assert.match(result.stderr, /--ticket-id/, `expected stderr to mention --ticket-id, got: ${result.stderr}`);
+      assert.match(
+        result.stderr,
+        /--ticket-id/,
+        `expected stderr to mention --ticket-id, got: ${result.stderr}`
+      );
     });
   });
 });
@@ -89,20 +106,31 @@ describe('bootstrap-branch.js — Task 1 (CLI contract + resolver)', () => {
 describe('bootstrap-branch.js — Task 2 (BRANCH_NAME_REGEX gate + safety + prefix suggestion)', () => {
   describe('Helper aborts BEFORE git worktree add when name fails BRANCH_NAME_REGEX', () => {
     it('(a) BRANCH_NAME_REGEX=^(feature|fix)/.+$ rejects echo-4454-foo with stderr containing name and regex', () => {
-      const result = runResult(
-        ['--ticket-id', 'ECHO-4454', '--summary', 'Foo'],
-        { BRANCH_NAME_REGEX: '^(feature|fix)/.+$' },
+      const result = runResult(['--ticket-id', 'ECHO-4454', '--summary', 'Foo'], {
+        BRANCH_NAME_REGEX: '^(feature|fix)/.+$',
+      });
+      assert.equal(
+        result.status,
+        1,
+        `expected exit 1, got ${result.status}. stderr: ${result.stderr}`
       );
-      assert.equal(result.status, 1, `expected exit 1, got ${result.status}. stderr: ${result.stderr}`);
-      assert.match(result.stderr, /echo-4454-foo/, `expected stderr to mention offending name, got: ${result.stderr}`);
-      assert.match(result.stderr, /\^\(feature\|fix\)\/\.\+\$/, `expected stderr to mention regex source, got: ${result.stderr}`);
+      assert.match(
+        result.stderr,
+        /echo-4454-foo/,
+        `expected stderr to mention offending name, got: ${result.stderr}`
+      );
+      assert.match(
+        result.stderr,
+        /\^\(feature\|fix\)\/\.\+\$/,
+        `expected stderr to mention regex source, got: ${result.stderr}`
+      );
     });
 
     it('(e) regex mismatch + BRANCH_PREFIX would have matched: stderr suggests setting BRANCH_PREFIX', () => {
-      const result = runResult(
-        ['--ticket-id', 'ECHO-4454', '--summary', 'Foo'],
-        { BRANCH_NAME_REGEX: '^feature/.+$', BRANCH_PREFIX: 'feature/' },
-      );
+      const result = runResult(['--ticket-id', 'ECHO-4454', '--summary', 'Foo'], {
+        BRANCH_NAME_REGEX: '^feature/.+$',
+        BRANCH_PREFIX: 'feature/',
+      });
       // With BRANCH_PREFIX set the name is already feature/echo-4454-foo → would pass.
       // To exercise the suggestion path, BRANCH_PREFIX is configured but the test
       // simulates the mismatch case where prepending the configured prefix would help.
@@ -110,25 +138,34 @@ describe('bootstrap-branch.js — Task 2 (BRANCH_NAME_REGEX gate + safety + pref
       // Here we invert: set regex requiring feature/ and BRANCH_PREFIX empty but configured
       // via a separate run.
       // Re-run with empty prefix to actually trigger suggestion:
-      const r2 = runResult(
-        ['--ticket-id', 'ECHO-4454', '--summary', 'Foo'],
-        { BRANCH_NAME_REGEX: '^feature/.+$', BRANCH_PREFIX: '' },
-      );
+      const r2 = runResult(['--ticket-id', 'ECHO-4454', '--summary', 'Foo'], {
+        BRANCH_NAME_REGEX: '^feature/.+$',
+        BRANCH_PREFIX: '',
+      });
       assert.equal(r2.status, 1, `expected exit 1, got ${r2.status}`);
       // Suggestion line per AC 1.2.1(e):
-      assert.match(r2.stderr, /BRANCH_PREFIX/, `expected suggestion mentioning BRANCH_PREFIX, got: ${r2.stderr}`);
+      assert.match(
+        r2.stderr,
+        /BRANCH_PREFIX/,
+        `expected suggestion mentioning BRANCH_PREFIX, got: ${r2.stderr}`
+      );
       // Also verify the first run (which would have passed) actually does pass:
-      assert.equal(result.status, 0, `expected exit 0 when prefix already matches, got ${result.status}. stderr: ${result.stderr}`);
+      assert.equal(
+        result.status,
+        0,
+        `expected exit 0 when prefix already matches, got ${result.status}. stderr: ${result.stderr}`
+      );
     });
   });
 
   describe('Validation is skipped when BRANCH_NAME_REGEX is unset', () => {
     it('(b) unset BRANCH_NAME_REGEX resolves echo-4454-foo with exit 0 (backward compat)', () => {
-      const result = runResult(
-        ['--ticket-id', 'ECHO-4454', '--summary', 'Foo'],
-        {},
+      const result = runResult(['--ticket-id', 'ECHO-4454', '--summary', 'Foo'], {});
+      assert.equal(
+        result.status,
+        0,
+        `expected exit 0, got ${result.status}. stderr: ${result.stderr}`
       );
-      assert.equal(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
       assert.equal(result.stdout.trim(), 'echo-4454-foo');
     });
 
@@ -137,9 +174,13 @@ describe('bootstrap-branch.js — Task 2 (BRANCH_NAME_REGEX gate + safety + pref
       // it would be used verbatim, so safety regex must still reject it.
       const result = runResult(
         ['--ticket-id', 'ECHO-4454', '--summary', 'Foo', '--git-branch-name', 'feature/bad;name'],
-        { TICKET_PROVIDER: 'linear' },
+        { TICKET_PROVIDER: 'linear' }
       );
-      assert.equal(result.status, 1, `expected exit 1 (shell metachar), got ${result.status}. stderr: ${result.stderr}`);
+      assert.equal(
+        result.status,
+        1,
+        `expected exit 1 (shell metachar), got ${result.status}. stderr: ${result.stderr}`
+      );
     });
   });
 
@@ -147,9 +188,13 @@ describe('bootstrap-branch.js — Task 2 (BRANCH_NAME_REGEX gate + safety + pref
     it('(c) --git-branch-name=bad name! with BRANCH_NAME_REGEX=^feature/.+$ exits 1 (regex wins over Linear)', () => {
       const result = runResult(
         ['--ticket-id', 'ECHO-4454', '--summary', 'Foo', '--git-branch-name', 'bad name!'],
-        { TICKET_PROVIDER: 'linear', BRANCH_NAME_REGEX: '^feature/.+$' },
+        { TICKET_PROVIDER: 'linear', BRANCH_NAME_REGEX: '^feature/.+$' }
       );
-      assert.equal(result.status, 1, `expected exit 1 (regex wins), got ${result.status}. stderr: ${result.stderr}`);
+      assert.equal(
+        result.status,
+        1,
+        `expected exit 1 (regex wins), got ${result.status}. stderr: ${result.stderr}`
+      );
     });
   });
 });

--- a/plugins/work/scripts/workflows/work/scripts/bootstrap-branch.js
+++ b/plugins/work/scripts/workflows/work/scripts/bootstrap-branch.js
@@ -87,8 +87,9 @@ const SAFETY_REGEX = /^[A-Za-z0-9._\-/]+$/;
  */
 function inferPrefixCandidates(regex) {
   const candidates = [];
-  const groupHead = /^\^\(\?:?([A-Za-z0-9_|\\\-]+)\)\\?\//.exec(regex)
-    || /^\^\(([A-Za-z0-9_|\\\-]+)\)\\?\//.exec(regex);
+  const groupHead =
+    /^\^\(\?:?([A-Za-z0-9_|\\\-]+)\)\\?\//.exec(regex) ||
+    /^\^\(([A-Za-z0-9_|\\\-]+)\)\\?\//.exec(regex);
   if (groupHead) {
     for (const alt of groupHead[1].split('|')) {
       candidates.push(`${alt.replace(/\\/g, '')}/`);
@@ -163,7 +164,9 @@ function main() {
   // --summary is only required when there is no Linear verbatim path.
   const providerIsLinear = (getConfig('TICKET_PROVIDER') || '').toLowerCase() === 'linear';
   if (!args.summary && !(args.gitBranchName && providerIsLinear)) {
-    fail('missing required flag --summary (required unless --git-branch-name is provided with TICKET_PROVIDER=linear)');
+    fail(
+      'missing required flag --summary (required unless --git-branch-name is provided with TICKET_PROVIDER=linear)'
+    );
   }
   const name = resolveBranchName(args);
   const regex = getConfig('BRANCH_NAME_REGEX') || '';

--- a/plugins/work/scripts/workflows/work/steps/__tests__/ci.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/ci.test.js
@@ -70,10 +70,7 @@ describe('ci step', () => {
     // The prompt must be directly runnable: cd && gh pr checks --watch
     assert.match(prompt, /cd "\/tmp\/wt\/GH-395" && gh pr checks --watch --interval 60/);
     // ci-next.js call should have the ticket interpolated
-    assert.ok(
-      prompt.includes('GH-395'),
-      'ci-next.js invocation should include the ticket id'
-    );
+    assert.ok(prompt.includes('GH-395'), 'ci-next.js invocation should include the ticket id');
     assert.equal(entries[0].step, STEPS.ci);
     assert.equal(entries[0].action, 'RUN');
   });

--- a/plugins/work/scripts/workflows/work/steps/implement.js
+++ b/plugins/work/scripts/workflows/work/steps/implement.js
@@ -215,7 +215,12 @@ module.exports = function implementStep(add, s, ctx) {
         const statePath = pathMod.join(tasksDir, '.work-state.json');
         const raw = fs.readFileSync(statePath, 'utf8');
         const st = JSON.parse(raw);
-        if (st && st.tasksMeta && Array.isArray(st.tasksMeta.tasks) && st.tasksMeta.tasks.length > 0) {
+        if (
+          st &&
+          st.tasksMeta &&
+          Array.isArray(st.tasksMeta.tasks) &&
+          st.tasksMeta.tasks.length > 0
+        ) {
           alreadyInitialized = true;
         }
       } catch {
@@ -227,7 +232,8 @@ module.exports = function implementStep(add, s, ctx) {
       // and that has security implications for auto-completion. The audit
       // row goes through appendAction so it shares schema + concurrency
       // handling with the rest of the workflow's audit trail.
-      const reason = descriptorErr && descriptorErr.message ? descriptorErr.message : String(descriptorErr);
+      const reason =
+        descriptorErr && descriptorErr.message ? descriptorErr.message : String(descriptorErr);
       try {
         appendAction(safeName, {
           step: 'implement',
@@ -246,11 +252,15 @@ module.exports = function implementStep(add, s, ctx) {
       if (!alreadyInitialized) {
         try {
           const wsPathFallback = ctx.workStatePath;
-          execFileSync(process.execPath, [wsPathFallback, 'task-init', safeName, String(taskData.length)], {
-            encoding: 'utf-8',
-            timeout: 5000,
-            stdio: 'pipe',
-          });
+          execFileSync(
+            process.execPath,
+            [wsPathFallback, 'task-init', safeName, String(taskData.length)],
+            {
+              encoding: 'utf-8',
+              timeout: 5000,
+              stdio: 'pipe',
+            }
+          );
         } catch {
           /* fail-open: task tracking init failure should not block plan */
         }

--- a/plugins/work/skills/bootstrap/SKILL.test.js
+++ b/plugins/work/skills/bootstrap/SKILL.test.js
@@ -2,35 +2,35 @@
 // via findTestFilesInScope colocated-sibling rule (basename SKILL + .test.js).
 // These tests assert that SKILL.md wires in bootstrap-branch.js correctly.
 
-const { describe, it } = require("node:test");
-const assert = require("node:assert/strict");
-const fs = require("fs");
-const path = require("path");
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
 
-const SKILL_MD = path.join(__dirname, "SKILL.md");
+const SKILL_MD = path.join(__dirname, 'SKILL.md');
 
-describe("bootstrap SKILL.md — Task 3 wiring", () => {
-  describe("SKILL.md invokes the helper and aborts the skill on non-zero exit", () => {
-    it("Step 4 invokes bootstrap-branch.js, captures stdout into BRANCH_NAME, and aborts on non-zero exit", () => {
-      const md = fs.readFileSync(SKILL_MD, "utf8");
-      assert.match(md, /bootstrap-branch\.js/, "SKILL.md must reference bootstrap-branch.js");
-      assert.match(md, /BRANCH_NAME=/, "SKILL.md must capture stdout into BRANCH_NAME");
+describe('bootstrap SKILL.md — Task 3 wiring', () => {
+  describe('SKILL.md invokes the helper and aborts the skill on non-zero exit', () => {
+    it('Step 4 invokes bootstrap-branch.js, captures stdout into BRANCH_NAME, and aborts on non-zero exit', () => {
+      const md = fs.readFileSync(SKILL_MD, 'utf8');
+      assert.match(md, /bootstrap-branch\.js/, 'SKILL.md must reference bootstrap-branch.js');
+      assert.match(md, /BRANCH_NAME=/, 'SKILL.md must capture stdout into BRANCH_NAME');
       assert.match(
         md,
         /(abort|exit\s+(?:non-zero|1)|\$\?\s*!=\s*0|exit\s+\$\?)/i,
-        "SKILL.md must abort on non-zero helper exit",
+        'SKILL.md must abort on non-zero helper exit'
       );
     });
   });
 
-  describe("SKILL.md does not create a worktree when validation fails", () => {
-    it("git worktree add is gated behind helper exit-0 and uses validated BRANCH_NAME", () => {
-      const md = fs.readFileSync(SKILL_MD, "utf8");
-      assert.match(md, /git worktree add/, "SKILL.md must contain git worktree add");
-      assert.match(md, /\$BRANCH_NAME/, "git worktree add must use $BRANCH_NAME");
-      assert.match(md, /BRANCH_NAME_REGEX/, "SKILL.md must document BRANCH_NAME_REGEX");
-      assert.match(md, /BRANCH_PREFIX/, "SKILL.md must document BRANCH_PREFIX");
-      assert.match(md, /gitBranchName/, "SKILL.md must document Linear gitBranchName precedence");
+  describe('SKILL.md does not create a worktree when validation fails', () => {
+    it('git worktree add is gated behind helper exit-0 and uses validated BRANCH_NAME', () => {
+      const md = fs.readFileSync(SKILL_MD, 'utf8');
+      assert.match(md, /git worktree add/, 'SKILL.md must contain git worktree add');
+      assert.match(md, /\$BRANCH_NAME/, 'git worktree add must use $BRANCH_NAME');
+      assert.match(md, /BRANCH_NAME_REGEX/, 'SKILL.md must document BRANCH_NAME_REGEX');
+      assert.match(md, /BRANCH_PREFIX/, 'SKILL.md must document BRANCH_PREFIX');
+      assert.match(md, /gitBranchName/, 'SKILL.md must document Linear gitBranchName precedence');
     });
   });
 });

--- a/plugins/work/skills/cleanup-worktrees/__tests__/skill-md-content.test.js
+++ b/plugins/work/skills/cleanup-worktrees/__tests__/skill-md-content.test.js
@@ -121,11 +121,7 @@ describe('cleanup-worktrees SKILL.md — fresh-data preamble (GH-90)', () => {
     });
 
     it('contains ## Philosophy section', () => {
-      assert.match(
-        content,
-        /^## Philosophy/m,
-        'SKILL.md must contain the "## Philosophy" section'
-      );
+      assert.match(content, /^## Philosophy/m, 'SKILL.md must contain the "## Philosophy" section');
     });
 
     it('contains ## Instructions section', () => {

--- a/plugins/work/skills/split-in-tasks/__tests__/chronological-simulator.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/chronological-simulator.test.js
@@ -120,7 +120,11 @@ describe('chronological-simulator — Pass A', () => {
       const { tasks, initialTree } = loadFixture('echo-5361');
       const result = simulate({ tasks, initialTree });
       const rendered = formatWarnings(result.warnings);
-      assert.match(rendered, /^> ⚠️ SPLIT-WARNING:/m, 'rendered output must use SPLIT-WARNING blockquote');
+      assert.match(
+        rendered,
+        /^> ⚠️ SPLIT-WARNING:/m,
+        'rendered output must use SPLIT-WARNING blockquote'
+      );
       assert.match(rendered, /Pass A/, 'rendered output must cite Pass A');
     });
   });

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361-clean/initial-tree.json
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361-clean/initial-tree.json
@@ -1,8 +1,4 @@
 {
   "_description": "Initial tree snapshot for the ECHO-5361 clean fixture. Task 1 mutates a.ts, Task 2 asserts on b.ts — disjoint files, no collision.",
-  "files": [
-    "a.ts",
-    "b.ts",
-    "package.json"
-  ]
+  "files": ["a.ts", "b.ts", "package.json"]
 }

--- a/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361/initial-tree.json
+++ b/plugins/work/skills/split-in-tasks/__tests__/fixtures/echo-5361/initial-tree.json
@@ -1,8 +1,4 @@
 {
   "_description": "Initial working-tree snapshot for the ECHO-5361 chronological-collision fixture. Pass A simulates Task 1 GREEN deleting surfaces/foo.ts, then checks Task 2 RED against the projected tree.",
-  "files": [
-    "surfaces/foo.ts",
-    "surfaces/bar.ts",
-    "package.json"
-  ]
+  "files": ["surfaces/foo.ts", "surfaces/bar.ts", "package.json"]
 }

--- a/plugins/work/skills/split-in-tasks/__tests__/lint-blast-radius.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/lint-blast-radius.test.js
@@ -87,7 +87,11 @@ describe('lint-blast-radius — scan on echo-5353 fixture (static-parse fallback
     });
     const w = out.warnings[0];
     const blob = `${w.message || ''} ${w.hint || ''}`;
-    assert.match(blob, /Searched:\s*\S*eslint-output\.json/, 'expected Searched: note with path to eslint-output.json');
+    assert.match(
+      blob,
+      /Searched:\s*\S*eslint-output\.json/,
+      'expected Searched: note with path to eslint-output.json'
+    );
   });
 
   it('suppresses warning when violating file IS in scope', () => {
@@ -115,7 +119,9 @@ describe('lint-blast-radius — fail-open subprocess behavior', () => {
     }, 'scan must not throw on subprocess failure');
     assert.ok(out, 'scan must still return a result');
     assert.ok(Array.isArray(out.warnings), 'expected warnings array');
-    const skipped = out.warnings.find((w) => /lint pre-check skipped:/i.test(`${w.message || ''} ${w.hint || ''}`));
+    const skipped = out.warnings.find((w) =>
+      /lint pre-check skipped:/i.test(`${w.message || ''} ${w.hint || ''}`)
+    );
     assert.ok(skipped, 'expected a `lint pre-check skipped:` warning');
   });
 
@@ -128,7 +134,9 @@ describe('lint-blast-radius — fail-open subprocess behavior', () => {
     });
     assert.ok(out, 'scan must return a result');
     assert.ok(Array.isArray(out.warnings), 'expected warnings array');
-    const skipped = out.warnings.find((w) => /lint pre-check skipped:/i.test(`${w.message || ''} ${w.hint || ''}`));
+    const skipped = out.warnings.find((w) =>
+      /lint pre-check skipped:/i.test(`${w.message || ''} ${w.hint || ''}`)
+    );
     assert.ok(skipped, 'expected a `lint pre-check skipped:` warning for unsafe command');
   });
 });

--- a/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-warnings.test.js
+++ b/plugins/work/skills/split-in-tasks/__tests__/split-in-tasks-warnings.test.js
@@ -70,7 +70,11 @@ describe('split-in-tasks warnings — Pass A integration', () => {
     const { tasks, initialTree } = loadChronoFixture('echo-5361');
     const result = simulate({ tasks, initialTree });
     assert.ok(Array.isArray(result.warnings), 'warnings must be an array');
-    assert.equal(result.warnings.length, 1, `expected 1 Pass A warning, got ${result.warnings.length}`);
+    assert.equal(
+      result.warnings.length,
+      1,
+      `expected 1 Pass A warning, got ${result.warnings.length}`
+    );
     const w = result.warnings[0];
     assert.equal(w.kind, 'A', 'expected kind=A');
     const blob = `${w.message} ${w.hint} ${w.file}`;
@@ -120,7 +124,10 @@ describe('split-in-tasks warnings — Pass C integration', () => {
       lintCommand: null,
       filesInScope: new Set(),
     });
-    assert.ok(Array.isArray(out.warnings) && out.warnings.length >= 1, 'expected ≥1 Pass C warning');
+    assert.ok(
+      Array.isArray(out.warnings) && out.warnings.length >= 1,
+      'expected ≥1 Pass C warning'
+    );
     const w = out.warnings[0];
     assert.equal(w.kind, 'C');
     const blob = `${w.message} ${w.hint}`;
@@ -148,7 +155,12 @@ describe('split-in-tasks warnings — dedupe across passes', () => {
     const sharedFile = 'shared/contract.ts';
     const warnings = [
       { kind: 'A', file: sharedFile, message: 'empty RED', hint: 'merge-or-checkpoint' },
-      { kind: 'B', file: sharedFile, message: 'contract mismatch', hint: 'coordinate-with-siblings' },
+      {
+        kind: 'B',
+        file: sharedFile,
+        message: 'contract mismatch',
+        hint: 'coordinate-with-siblings',
+      },
       { kind: 'C', file: sharedFile, message: 'lint violation', hint: '(a)/(b)/(c)' },
       { kind: 'A', file: 'other/path.ts', message: 'distinct', hint: 'distinct' },
     ];
@@ -156,7 +168,11 @@ describe('split-in-tasks warnings — dedupe across passes', () => {
     assert.equal(merged.length, 2, `expected 2 entries after dedupe, got ${merged.length}`);
     const sharedEntry = merged.find((w) => w.file === sharedFile);
     assert.ok(sharedEntry, 'expected merged entry for the shared file');
-    assert.match(sharedEntry.kind, /A.*B.*C|A\+B\+C/, `expected union kind A+B+C; got ${sharedEntry.kind}`);
+    assert.match(
+      sharedEntry.kind,
+      /A.*B.*C|A\+B\+C/,
+      `expected union kind A+B+C; got ${sharedEntry.kind}`
+    );
     assert.match(sharedEntry.message, /empty RED/);
     assert.match(sharedEntry.message, /contract mismatch/);
     assert.match(sharedEntry.message, /lint violation/);
@@ -205,8 +221,20 @@ describe('split-in-tasks warnings — operator end-to-end (combined synthetic fi
     // sub-fixture so an operator can trace which pass any warning came
     // from (Scenario 8 traceability requirement).
     const combinedMd = fs.readFileSync(path.join(COMBINED, 'tasks.md'), 'utf8');
-    assert.match(combinedMd, /echo-5361/i, 'combined tasks.md must reference echo-5361 sub-fixture');
-    assert.match(combinedMd, /echo-5362/i, 'combined tasks.md must reference echo-5362 sub-fixture');
-    assert.match(combinedMd, /echo-5353/i, 'combined tasks.md must reference echo-5353 sub-fixture');
+    assert.match(
+      combinedMd,
+      /echo-5361/i,
+      'combined tasks.md must reference echo-5361 sub-fixture'
+    );
+    assert.match(
+      combinedMd,
+      /echo-5362/i,
+      'combined tasks.md must reference echo-5362 sub-fixture'
+    );
+    assert.match(
+      combinedMd,
+      /echo-5353/i,
+      'combined tasks.md must reference echo-5353 sub-fixture'
+    );
   });
 });


### PR DESCRIPTION
## Existing Behavior

- `main` is biome-dirty: many files diverge from what `biome format --write` would produce. This creates a dual shape for the same line (single-line on one branch, wrapped across multiple lines on another), which causes merge artifacts where both copies are kept.
- The CI quality job does not check formatting; unformatted files pass the gate silently.
- No quality rule detects consecutive identical assertions — the most common form of the wrapped-vs-unwrapped merge artifact. These pairs survive every existing gate: biome formats both, the test still passes (assertions are idempotent), and jscpd's 50-token floor ignores 2-line clones.

## Intended New Behavior

- A one-time `biome format --write` sweep across 55 files establishes a biome-clean baseline on `main`. All future branches cut from `main` start in the formatted shape, eliminating the dual-shape divergence at the root.
- CI's quality job now runs `pnpm format:check` before `pnpm quality`; any unformatted file fails the PR immediately.
- A new `duplicate-adjacent-assertions` quality rule (`rules/adjacent-assertions.js`) flags consecutive identical `assert`/`expect` statements (separated only by blank lines) across all JS files including tests. Whitespace is normalized outside string literals so the wrapped and unwrapped shapes of the same assertion compare equal, while `classify('')` vs `classify('   ')` remain distinct. Intentional repeats opt out by placing an explanatory comment between the two assertions (a comment line breaks adjacency). 11 unit tests cover all cases.
- Sweep fixes: one genuine duplicate deleted in `enforce-step-workflow.test.js`; two intentional repeats in `pathSafe.test.js` and `synapsys-recall.test.js` documented with inline comments explaining the stateful-call intent.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify the format gate blocks unformatted files:**

1. On a new branch, edit any JS file to add trailing whitespace or inconsistent indentation that biome would reformat.
2. Push the branch and open a PR against `main`.
3. Confirm the CI quality job fails at the `Check formatting (biome)` step before reaching `Run static code quality gate`.

**Verify the adjacent-assertions rule catches merge artifacts:**

1. Add a duplicate adjacent assertion to any `.js` test file (two identical `assert.equal(...)` lines with no comment between them).
2. Run `pnpm quality` locally.
3. Confirm a `duplicate-adjacent-assertions` violation is reported at the second assertion's line number with a message pointing to the first copy.

**Verify the comment escape hatch works:**

1. Between two otherwise-identical adjacent assertions, add any comment line explaining the intent.
2. Run `pnpm quality` — no violation should be reported for that pair.

**Verify the unit tests for the new rule:**

```bash
node --test plugins/work/scripts/workflows/lib/scripts/quality/__tests__/adjacent-assertions.test.js
```

Expected: 11 tests pass.

### Test Results

Full suite: 8076/8076 passing locally. `pnpm quality` exits 0. `pnpm format:check` exits 0.
