### PR TITLE
fix(heimdall): classify foreign path tokens before marker match (#689)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,40 +14,21 @@
       "source": "./plugins/work",
       "description": "Orchestrated /work command with pre-computed action plans",
       "category": "workflow",
-      "tags": [
-        "workflow",
-        "jira",
-        "orchestrator",
-        "state-machine",
-        "automation"
-      ]
+      "tags": ["workflow", "jira", "orchestrator", "state-machine", "automation"]
     },
     {
       "name": "synapsys",
       "source": "./plugins/synapsys",
       "description": "Context-triggered memory injection — memories declare event hooks + trigger patterns and are injected when matched",
       "category": "memory",
-      "tags": [
-        "memory",
-        "hooks",
-        "injection",
-        "context",
-        "recall"
-      ]
+      "tags": ["memory", "hooks", "injection", "context", "recall"]
     },
     {
       "name": "maestro",
       "source": "./plugins/maestro",
       "description": "Multi-agent orchestrator — bootstraps per-ticket tmux sessions, conducts them (silence detection + auto-restart), and surfaces real prompts to the operator",
       "category": "orchestration",
-      "tags": [
-        "orchestrate",
-        "conduct",
-        "agents",
-        "tmux",
-        "workflow",
-        "multi-agent"
-      ]
+      "tags": ["orchestrate", "conduct", "agents", "tmux", "workflow", "multi-agent"]
     },
     {
       "name": "heimdall",

--- a/plugins/heimdall/README.md
+++ b/plugins/heimdall/README.md
@@ -134,6 +134,29 @@ elsewhere (e.g. `/tmp`) and reads pass, so this also clears the old
 false positives (a script that reads a protected path and writes elsewhere, or
 running a test file that merely names a protected path).
 
+#### The rewrite shape (stable, classifier-recognizable)
+
+The rewritten command always has the same four parts, in this order:
+
+1. the stable marker `: 'heimdall-fsguard-rewrite-v1';` — a POSIX `:` no-op,
+   so prepending it never changes command semantics, and it stays stable
+   across heimdall versions;
+2. `export LD_PRELOAD='<plugin>/scripts/bin/heimdall-fsguard.linux-<arch>.so'`
+   (an existing `LD_PRELOAD` is preserved — the guard's `.so` is prepended);
+3. `export HEIMDALL_PROTECTED='<dir>:<dir>'` (plus an optional
+   `HEIMDALL_ALLOWED` export when a locked dir has allow-listed subpaths);
+4. the original command, byte-identical.
+
+The interposer only **narrows** permissions (`EACCES` on writes under the
+protected dirs) — it never widens them. External harness/auto-mode classifiers
+that flag `LD_PRELOAD` exports as bypass attempts can recognize the leading
+marker as heimdall guard output and allow-list the rewrite; that allow-listing
+is documented here, not enforced by heimdall. Operators whose harness
+classifiers still veto the rewrite can set `HEIMDALL_DISABLE_SHIM=1` to skip
+the rewrite entirely and fall back to the static fail-closed script check.
+
+#### Scope and fallback
+
 The guard is scoped **per command** to the entries still locked this session, so
 speaking an unlock phrase lifts it for that agent only — a uid-level OS boundary
 could not do that. On hosts where the shim can't run (non-Linux, non-glibc,
@@ -142,6 +165,17 @@ fail-closed check. Set `HEIMDALL_DISABLE_SHIM=1` to force that fallback. A
 prebuilt `linux-x86_64` `.so` is committed; other Linux arches build from source
 at `/heimdall:install` (rebuild manually with
 `bash plugins/heimdall/scripts/build-fsguard.sh`).
+
+### Runtime verdict parity (Claude Code vs Codex CLI)
+
+The guard engine is runtime-agnostic: both runtimes feed the same engine
+(`lib/guard/`) through the canonical tool-kind mapping in
+`lib/runtime/tools.js`, so the guard's two-direction verdict matrix — block
+writes that resolve into locked paths, allow everything else — produces the
+same verdicts under Claude Code and codex, and the exit codes agree pairwise
+for every fixture in the matrix (the Step-7 dual-runtime gate). This parity is
+pinned by `lib/__tests__/guard-codex.test.js`, which follows the dual-runtime
+fixture conventions in `docs/codex-support/`.
 
 ## Conceal & the secrets boundary
 

--- a/plugins/heimdall/lib/__tests__/guard-codex.test.js
+++ b/plugins/heimdall/lib/__tests__/guard-codex.test.js
@@ -271,3 +271,153 @@ describe('spawn_agent prompt gate', () => {
     assert.equal(r.exitCode, 0);
   });
 });
+
+// ─── GH-689 verdict parity (R8): codex mirrors claude on the foreign-path ────
+// two-direction matrix. Each fixture from guard-foreign-path.test.js is run
+// under BOTH runtimes — claude via the native tool names (Bash, Task) and
+// codex via the canonical kind mapping (Bash→shell, spawn_agent→agent per
+// lib/runtime/tools.js:22-30) — asserting pairwise exitCode equality plus the
+// claude baseline direction, so a parity-preserving regression (both runtimes
+// flipping together) still fails.
+
+describe('GH-689 verdict parity: codex runtime matches claude on the two-direction matrix', () => {
+  const PARITY_LOCKS = [{ protect: ['.claude'], unlockPhrase: 'edit .claude' }];
+
+  let parityRoot; // home-scratch base, NOT under os.tmpdir() (engine exempts temp paths)
+  let parityHome; // foreign home-config stand-in: <parityRoot>/home
+  let parityRepo; // the locked project base: <parityRoot>/repo
+  let parityCacheScript; // <parityHome>/.claude/plugins/cache/task/run.js
+  let parityClaudeTx; // claude-dialect transcript, no unlock phrase
+
+  before(() => {
+    parityRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.homedir(), '.heimdall-codex-parity-'))
+    );
+    parityHome = path.join(parityRoot, 'home');
+    parityRepo = path.join(parityRoot, 'repo');
+    parityCacheScript = path.join(parityHome, '.claude', 'plugins', 'cache', 'task', 'run.js');
+    fs.mkdirSync(path.dirname(parityCacheScript), { recursive: true });
+    fs.mkdirSync(path.join(parityRepo, '.claude'), { recursive: true });
+    fs.writeFileSync(parityCacheScript, "console.log('ok');\n");
+    // The codex side reuses the file-scope emptyRollout; the claude side gets
+    // its own claude-dialect transcript (also phrase-free) in the same txDir.
+    parityClaudeTx = path.join(txDir, 'parity-claude.jsonl');
+    fs.writeFileSync(
+      parityClaudeTx,
+      `${JSON.stringify({ type: 'user', message: { content: 'hello' } })}\n`
+    );
+  });
+
+  after(() => {
+    fs.rmSync(parityRoot, { recursive: true, force: true });
+  });
+
+  const parityEntries = () => buildEntries(PARITY_LOCKS, parityRepo);
+
+  // One fixture, both runtimes: identical command/entries/cwd — only the
+  // runtime, the native tool name, and the transcript dialect differ.
+  const shellPair = (command) => ({
+    claude: evaluate({
+      toolName: 'Bash',
+      toolInput: { command },
+      transcriptPath: parityClaudeTx,
+      entries: parityEntries(),
+      cwd: parityRepo,
+    }),
+    codex: evaluate({
+      toolName: 'Bash',
+      toolInput: { command },
+      transcriptPath: emptyRollout,
+      entries: parityEntries(),
+      runtime: 'codex',
+      cwd: parityRepo,
+    }),
+  });
+
+  const agentPair = (prompt) => ({
+    claude: evaluate({
+      toolName: 'Task',
+      toolInput: { prompt },
+      transcriptPath: parityClaudeTx,
+      entries: parityEntries(),
+      cwd: parityRepo,
+    }),
+    codex: evaluate({
+      toolName: 'spawn_agent',
+      toolInput: { prompt },
+      transcriptPath: emptyRollout,
+      entries: parityEntries(),
+      runtime: 'codex',
+      cwd: parityRepo,
+    }),
+  });
+
+  const assertParity = (pair, expectedExit, label) => {
+    assert.equal(
+      pair.codex.exitCode,
+      pair.claude.exitCode,
+      `${label}: codex verdict must equal the claude verdict ` +
+        `(codex="${pair.codex.message}" claude="${pair.claude.message}")`
+    );
+    assert.equal(
+      pair.claude.exitCode,
+      expectedExit,
+      `${label}: claude baseline direction — ${pair.claude.message}`
+    );
+  };
+
+  it('shell: home-config write is allowed under a project .claude lock on both runtimes', () => {
+    const pair = shellPair(`cp /tmp/settings.bak ${parityHome}/.claude/settings.json`);
+    assertParity(pair, 0, 'foreign home-config write');
+  });
+
+  it('shell: protected absolute write blocks on both runtimes', () => {
+    const pair = shellPair(`cp /tmp/settings.bak ${parityRepo}/.claude/settings.json`);
+    assertParity(pair, 2, 'protected absolute write');
+    assert.match(pair.codex.message, /edit \.claude/, 'codex block must name the unlock phrase');
+  });
+
+  it('shell: relative .claude write stays fail-closed on both runtimes', () => {
+    const pair = shellPair("sed -i 's/a/b/' .claude/settings.json");
+    assertParity(pair, 2, 'relative marker write');
+  });
+
+  it('shell: cd-template verdicts agree across runtimes with a trailing separator', () => {
+    const pair = shellPair(`cd ${parityRepo} && node ${parityCacheScript}; echo done`);
+    assertParity(pair, 0, 'cd-template with trailing separator');
+  });
+
+  it('shell: cd-template verdicts agree across runtimes without a trailing separator', () => {
+    const pair = shellPair(`cd ${parityRepo} && node ${parityCacheScript}`);
+    assertParity(pair, 0, 'cd-template without trailing separator');
+  });
+
+  it('shell: obfuscated pair — dequoted foreign write allowed, dequoted protected write blocked, on both runtimes', () => {
+    const foreign = shellPair(`mkdir -p ${parityHome}/.cl""aude/plugins/state`);
+    assertParity(foreign, 0, 'dequoted foreign write');
+    const locked = shellPair(`echo x > ${parityRepo}/.cl""aude/settings.json`);
+    assertParity(locked, 2, 'dequoted protected write (GH-655)');
+  });
+
+  it('agent: home plugin-cache script prompt is allowed on both runtimes', () => {
+    const pair = agentPair(`Update the flags in ${parityCacheScript} and rerun the job`);
+    assertParity(pair, 0, 'home plugin-cache prompt');
+  });
+
+  it('agent: protected-dir prompt blocks on both runtimes', () => {
+    const pair = agentPair(`Update the settings in ${parityRepo}/.claude/config and save`);
+    assertParity(pair, 2, 'protected-dir prompt');
+    assert.match(
+      pair.codex.message,
+      /task-prompt \.claude/,
+      'codex block must carry the match context'
+    );
+  });
+
+  it('agent: mid-word marker prompt is not a reference on either runtime', () => {
+    const pair = agentPair(
+      'Rewrite the overview in myproject.clauderc-notes.md to mention the new flags'
+    );
+    assertParity(pair, 0, 'mid-word boundary negative');
+  });
+});

--- a/plugins/heimdall/lib/__tests__/guard-foreign-path.test.js
+++ b/plugins/heimdall/lib/__tests__/guard-foreign-path.test.js
@@ -1,0 +1,347 @@
+// GH-689: basename-marker collisions — classify path tokens before counting a
+// marker hit as a reference to a protected entry.
+//
+// A lock on <repo>/.claude must not block the agent toolchain under the HOME
+// config dir (~/.claude/plugins/cache/**, settings, commit scripts) or any
+// other foreign absolute path. Every lane (bash write, Task prompt,
+// script-bypass content scan) is pinned in BOTH directions — foreign ALLOW and
+// protected BLOCK — so the fix can never silently widen into a bypass.
+//
+// Discovered by plugins/work/scripts/run-tests.sh (searches plugins/heimdall/).
+// Manual: node --test plugins/heimdall/lib/__tests__/guard-foreign-path.test.js
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { buildEntries, evaluate } = require(path.resolve(__dirname, '..', 'guard'));
+const { markerOnlyInForeignPaths, markerOnPathBoundary } = require(
+  path.resolve(__dirname, '..', 'guard', 'paths')
+);
+const fsguard = require(path.resolve(__dirname, '..', 'guard', 'fsguard'));
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+// Home-scratch base dir, mirroring guard.test.js: NOT under os.tmpdir() (the
+// engine exempts temp paths by design — GH-658), realpath'd so token
+// resolution and entry.dir agree byte-for-byte. The lock set protects the
+// PROJECT `.claude` only — it does NOT protect `~/.claude`.
+
+const LOCKS = [{ protect: ['.claude'], unlockPhrase: 'edit .claude' }];
+const SHORT_LOCKS = [{ protect: ['.github', 'ui', 'src'], unlockPhrase: 'edit protected dirs' }];
+
+let root; // scratch OUTSIDE any temp prefix
+let fakeHome; // stand-in for a foreign home config parent: <root>/home
+let repo; // the locked project base: <root>/repo
+let repoShort; // base dir for the short-marker lock set: <root>/repo2
+let foreignRoot; // unrelated absolute location: <root>/elsewhere
+let scriptsDir; // interpreter scripts living outside any marker-named path
+let cacheScript; // <fakeHome>/.claude/plugins/cache/task/run.js
+let transcriptEmpty;
+
+before(() => {
+  root = fs.realpathSync(fs.mkdtempSync(path.join(os.homedir(), '.heimdall-gh689-')));
+  fakeHome = path.join(root, 'home');
+  repo = path.join(root, 'repo');
+  repoShort = path.join(root, 'repo2');
+  foreignRoot = path.join(root, 'elsewhere');
+  scriptsDir = path.join(root, 'scripts');
+  cacheScript = path.join(fakeHome, '.claude', 'plugins', 'cache', 'task', 'run.js');
+  fs.mkdirSync(path.dirname(cacheScript), { recursive: true });
+  fs.mkdirSync(path.join(repo, '.claude'), { recursive: true });
+  fs.mkdirSync(repoShort, { recursive: true });
+  fs.mkdirSync(foreignRoot, { recursive: true });
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.writeFileSync(cacheScript, "console.log('ok');\n");
+  const txDir = fs.mkdtempSync(path.join(os.tmpdir(), 'heimdall-gh689-tx-'));
+  transcriptEmpty = path.join(txDir, 'empty.jsonl');
+  fs.writeFileSync(
+    transcriptEmpty,
+    JSON.stringify({ type: 'user', message: { content: 'hello' } }) + '\n'
+  );
+});
+
+after(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.rmSync(path.dirname(transcriptEmpty), { recursive: true, force: true });
+});
+
+const claudeEntry = () => buildEntries(LOCKS, repo)[0];
+const run = (toolName, toolInput) =>
+  evaluate({
+    toolName,
+    toolInput,
+    transcriptPath: transcriptEmpty,
+    entries: buildEntries(LOCKS, repo),
+  });
+const bash = (command) => run('Bash', { command });
+const bashShort = (command) =>
+  evaluate({
+    toolName: 'Bash',
+    toolInput: { command },
+    transcriptPath: transcriptEmpty,
+    entries: buildEntries(SHORT_LOCKS, repoShort),
+  });
+// Force the static script-bypass fallback (no runtime shim) for one call.
+const staticBash = (command) => {
+  process.env.HEIMDALL_DISABLE_SHIM = '1';
+  try {
+    return bash(command);
+  } finally {
+    delete process.env.HEIMDALL_DISABLE_SHIM;
+  }
+};
+const script = (name, body) => {
+  const p = path.join(scriptsDir, name);
+  fs.writeFileSync(p, body);
+  return p;
+};
+
+// ─── paths.js export surface (R1) ────────────────────────────────────────────
+
+describe('paths.js exports the GH-689 classifier surface', () => {
+  it('exports markerOnlyInForeignPaths as a function', () => {
+    assert.equal(
+      typeof markerOnlyInForeignPaths,
+      'function',
+      'markerOnlyInForeignPaths must be exported from guard/paths'
+    );
+  });
+
+  it('re-exports markerOnPathBoundary (moved from bash.js)', () => {
+    assert.equal(
+      typeof markerOnPathBoundary,
+      'function',
+      'markerOnPathBoundary must be exported from guard/paths'
+    );
+  });
+});
+
+// ─── markerOnlyInForeignPaths: four classification clauses (R1/R3/R13) ───────
+
+describe('markerOnlyInForeignPaths classifier', () => {
+  it('clause 1: an absolute token under the home config dir is foreign when entry.dir is elsewhere', () => {
+    const text = `mkdir -p ${os.homedir()}/.claude/plugins/cache/job-1`;
+    assert.equal(markerOnlyInForeignPaths(text, '.claude', claudeEntry()), true, text);
+  });
+
+  it('clause 2: an absolute token under a temp prefix is foreign (GH-658 parity)', () => {
+    const text = 'echo x > /tmp/heimdall-scratch/.claude/settings.json';
+    assert.equal(markerOnlyInForeignPaths(text, '.claude', claudeEntry()), true, text);
+  });
+
+  it('clause 3: a statically-clean absolute token resolving elsewhere is foreign', () => {
+    const text = `cp /tmp/settings.bak ${foreignRoot}/.claude/settings.json`;
+    assert.equal(markerOnlyInForeignPaths(text, '.claude', claudeEntry()), true, text);
+  });
+
+  it('clause 3: a token under entry.dir is a reference, not foreign', () => {
+    const entry = claudeEntry();
+    const text = `echo x > ${entry.dir}/settings.json`;
+    assert.equal(markerOnlyInForeignPaths(text, '.claude', entry), false, text);
+  });
+
+  it('clause 3: a token exactly equal to entry.dir is a reference', () => {
+    const entry = claudeEntry();
+    const text = `rm -rf ${entry.dir}`;
+    assert.equal(markerOnlyInForeignPaths(text, '.claude', entry), false, text);
+  });
+
+  it('fail-closed: a relative token never exonerates', () => {
+    const text = 'sed -i s/a/b/ .claude/settings.json';
+    assert.equal(markerOnlyInForeignPaths(text, '.claude', claudeEntry()), false, text);
+  });
+
+  it('fail-closed: a $VAR-bearing token is unresolvable', () => {
+    const text = 'cp x $DIR/.claude/y';
+    assert.equal(markerOnlyInForeignPaths(text, '.claude', claudeEntry()), false, text);
+  });
+
+  it('fail-closed: a backtick-delimited concatenation fragment stays a reference', () => {
+    // `pwd`/.claude/y: the extracted token is `/.claude/y` — a fragment glued
+    // onto a runtime base, not a real root path. Must NOT classify as foreign.
+    const text = 'cp x `pwd`/.claude/y';
+    assert.equal(markerOnlyInForeignPaths(text, '.claude', claudeEntry()), false, text);
+  });
+
+  it('fail-closed: a glob-bearing token is unresolvable', () => {
+    const text = 'cp x /a/*/.claude/y';
+    assert.equal(markerOnlyInForeignPaths(text, '.claude', claudeEntry()), false, text);
+  });
+
+  it('fail-closed: a bare marker token is a reference', () => {
+    const text = 'touch .claude';
+    assert.equal(markerOnlyInForeignPaths(text, '.claude', claudeEntry()), false, text);
+  });
+
+  it('returns false when the marker does not occur in the text', () => {
+    assert.equal(markerOnlyInForeignPaths('ls -la /tmp', '.claude', claudeEntry()), false);
+  });
+});
+
+describe('markerOnPathBoundary (GH-642 helper moved to paths.js)', () => {
+  it('a mid-word token like myui.clauderc does not sit on a path boundary', () => {
+    assert.equal(markerOnPathBoundary('.claude', 'myui.clauderc'), false);
+  });
+
+  it('a slash-delimited path token sits on a path boundary', () => {
+    assert.equal(markerOnPathBoundary('.claude', `rm -rf ${os.homedir()}/.claude/x`), true);
+  });
+});
+
+// ─── Bash lane: two-direction matrix through buildEntries + evaluate (R2/R6) ─
+
+describe('bash lane: foreign paths no longer collide with the basename marker', () => {
+  it('Bash write into the home config dir is allowed under a project .claude lock', () => {
+    const tilde = bash('mkdir -p ~/.claude/plugins/cache/job-1');
+    assert.equal(tilde.exitCode, 0, `tilde form should be allowed: ${tilde.message}`);
+    const absolute = bash(`cp /tmp/settings.bak ${fakeHome}/.claude/settings.json`);
+    assert.equal(
+      absolute.exitCode,
+      0,
+      `absolute foreign form should be allowed: ${absolute.message}`
+    );
+  });
+
+  it('Bash write into the protected .claude dir by absolute path still blocks', () => {
+    const r = bash(`cp /tmp/settings.bak ${repo}/.claude/settings.json`);
+    assert.equal(r.exitCode, 2, 'protected absolute write must block');
+    assert.match(r.message, /edit \.claude/, 'block message must name the unlock phrase');
+  });
+
+  it('Bash write via a relative .claude path stays fail-closed', () => {
+    const r = bash("sed -i 's/a/b/' .claude/settings.json");
+    assert.equal(r.exitCode, 2, 'relative marker write must stay blocked');
+  });
+
+  it('cd-template verdicts agree with and without a trailing separator', () => {
+    const invoke = `cd ${repo} && node ${cacheScript}`;
+    const withTail = bash(`${invoke}; echo done`);
+    const withoutTail = bash(invoke);
+    assert.equal(withTail.exitCode, 0, `trailing separator form: ${withTail.message}`);
+    assert.equal(withoutTail.exitCode, 0, `bare form: ${withoutTail.message}`);
+    assert.equal(
+      withTail.exitCode,
+      withoutTail.exitCode,
+      'a trailing `;` must not flip the verdict'
+    );
+  });
+
+  it('cd-template still blocks when the named script path is repo-local', () => {
+    const r = bash(`cd ${fakeHome} && node ${repo}/.claude/cache/job.js; echo done`);
+    assert.equal(r.exitCode, 2, 'repo-local script path under cd-template must block');
+  });
+
+  it('Obfuscated home-path write is allowed while obfuscated protected write still blocks', () => {
+    const home = bash(`mkdir -p ${fakeHome}/.cl""aude/plugins/state`);
+    assert.equal(home.exitCode, 0, `dequoted foreign write should be allowed: ${home.message}`);
+    const homeClass = bash(`mkdir -p ${fakeHome}/.cl[a]ude/plugins/state`);
+    assert.equal(
+      homeClass.exitCode,
+      0,
+      `char-class foreign write should be allowed: ${homeClass.message}`
+    );
+    const repoObf = bash(`echo x > ${repo}/.cl""aude/settings.json`);
+    assert.equal(repoObf.exitCode, 2, 'dequoted protected write must still block (GH-655)');
+  });
+
+  it('short marker .github: foreign absolute path is allowed, lock-base write still blocks', () => {
+    const allow = bashShort(`cp /tmp/ci.yml ${foreignRoot}/.github/workflows/ci.yml`);
+    assert.equal(allow.exitCode, 0, `foreign .github write: ${allow.message}`);
+    const block = bashShort(`cp /tmp/ci.yml ${repoShort}/.github/workflows/ci.yml`);
+    assert.equal(block.exitCode, 2, 'lock-base .github write must block');
+  });
+
+  it('short marker ui: foreign absolute path is allowed, lock-base write still blocks', () => {
+    const allow = bashShort(`mkdir -p ${foreignRoot}/ui/components`);
+    assert.equal(allow.exitCode, 0, `foreign ui write: ${allow.message}`);
+    const block = bashShort(`mkdir -p ${repoShort}/ui/components`);
+    assert.equal(block.exitCode, 2, 'lock-base ui write must block');
+  });
+
+  it('short marker src: foreign absolute path is allowed, lock-base write still blocks', () => {
+    const allow = bashShort(`touch ${foreignRoot}/src/index.js`);
+    assert.equal(allow.exitCode, 0, `foreign src write: ${allow.message}`);
+    const block = bashShort(`touch ${repoShort}/src/index.js`);
+    assert.equal(block.exitCode, 2, 'lock-base src write must block');
+  });
+});
+
+// ─── Task lane: prompts naming foreign paths are not references (R4/R6) ──────
+
+describe('task lane: boundary floor + foreign exemption', () => {
+  it('Task prompt naming a home plugin-cache script is allowed', () => {
+    const r = run('Task', { prompt: `Update the flags in ${cacheScript} and rerun the job` });
+    assert.equal(r.exitCode, 0, r.message);
+  });
+
+  it('Task prompt asking to modify the protected dir still blocks', () => {
+    const r = run('Task', { prompt: `Update the settings in ${repo}/.claude/config and save` });
+    assert.equal(r.exitCode, 2, 'protected-dir prompt must block');
+  });
+
+  it('Task prompt with the basename buried mid-word is not a reference', () => {
+    const r = run('Task', {
+      prompt: 'Rewrite the overview in myproject.clauderc-notes.md to mention the new flags',
+    });
+    assert.equal(r.exitCode, 0, r.message);
+  });
+});
+
+// ─── Script-bypass lane: content scan with the shim unavailable (R5/R6) ──────
+
+describe('script-bypass lane: content refs are classified (shim disabled)', () => {
+  it('Script whose source only references the home config dir is allowed when the shim is unavailable', () => {
+    const s = script(
+      'foreign-write.js',
+      `require('fs').writeFileSync('${fakeHome}/.claude/plugins/state.json', 'x');\n`
+    );
+    const r = staticBash(`node ${s}`);
+    assert.equal(r.exitCode, 0, r.message);
+  });
+
+  it('Script whose source writes under the protected dir still blocks when the shim is unavailable', () => {
+    const s = script(
+      'repo-write.js',
+      `require('fs').writeFileSync('${repo}/.claude/state.json', 'x');\n`
+    );
+    assert.equal(staticBash(`node ${s}`).exitCode, 2, 'protected-dir script write must block');
+  });
+
+  it('Script source with a relative .claude reference stays fail-closed', () => {
+    const s = script(
+      'relative-write.js',
+      `require('fs').writeFileSync('.claude/state.json', 'x');\n`
+    );
+    assert.equal(staticBash(`node ${s}`).exitCode, 2, 'relative script ref must stay blocked');
+  });
+});
+
+// ─── Shim rewrite marker (R10, vector 4) ─────────────────────────────────────
+
+describe('shim rewrite: classifier-recognizable prefix', () => {
+  it('Shim rewrite carries the stable heimdall marker prefix', () => {
+    assert.equal(
+      typeof fsguard.SHIM_REWRITE_MARKER,
+      'string',
+      'fsguard must export SHIM_REWRITE_MARKER'
+    );
+    assert.equal(
+      fsguard.SHIM_REWRITE_MARKER,
+      ": 'heimdall-fsguard-rewrite-v1';",
+      'marker must be the pinned POSIX no-op'
+    );
+    const rewrite = fsguard.buildShimRewrite(
+      'node build.js',
+      [{ dir: `${repo}/.claude`, isFile: false, allowedPaths: null }],
+      '/x/heimdall-fsguard.so'
+    );
+    assert.ok(
+      rewrite.startsWith(fsguard.SHIM_REWRITE_MARKER),
+      'rewrite must start with the stable marker'
+    );
+    assert.match(rewrite, /LD_PRELOAD=.*heimdall-fsguard/, 'existing LD_PRELOAD pin must survive');
+    assert.ok(rewrite.endsWith('node build.js'), 'original command must stay the suffix');
+  });
+});

--- a/plugins/heimdall/lib/guard/bash.js
+++ b/plugins/heimdall/lib/guard/bash.js
@@ -8,7 +8,13 @@
  * mirroring the original protect-package-json hook).
  */
 
-const { expandHomePaths, allRefsUnderAllowedPaths, markerOnlyInTempPaths } = require('./paths');
+const {
+  expandHomePaths,
+  allRefsUnderAllowedPaths,
+  markerOnlyInTempPaths,
+  markerOnlyInForeignPaths,
+  markerOnPathBoundary,
+} = require('./paths');
 const {
   normalizedVariants,
   commandGlobReferencesMarker,
@@ -193,37 +199,8 @@ function markerWriteMatch(marker, v) {
   return false;
 }
 
-/**
- * Does `marker` appear in `text` sitting on a path-like boundary? The marker is
- * regex-escaped (same escape as the cp/rsync read check above) and must be
- * preceded by start-of-string, `/`, whitespace, a quote, or `>`, and followed
- * by end-of-string, `/`, whitespace, a quote, or `.`.
- *
- * The `>` leading boundary covers no-space redirect-writes (`>ui/x`). A second
- * alternative (`=marker/`) covers `flag=path` writes such as dd's
- * `of=src/output.dat`, where the marker is preceded by `=`.
- */
-const _boundaryCache = new Map();
-function getBoundaryPattern(marker) {
-  if (_boundaryCache.has(marker)) return _boundaryCache.get(marker);
-  const esc = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  // Leading boundary also accepts `>` so a no-space redirect into the protected
-  // dir (`>ui/x`) stays blocked — a genuine path-token write, fail-closed like
-  // its spaced form `> ui/x`. See GH-642.
-  //
-  // The `=${esc}/` alternative restores blocking of `flag=path` writes (dd's
-  // `of=src/output.dat`) that String.includes caught before the boundary anchor.
-  // It requires a trailing `/` so it only fires on a path INTO the protected dir
-  // — a bare assignment like `x=ui` (marker at end, no `/`) is not a path token
-  // and must stay allowed. See GH-642.
-  const pattern = new RegExp(`(?:^|[/\\s"'>])${esc}(?:$|[/\\s"'.])|=${esc}/`);
-  _boundaryCache.set(marker, pattern);
-  return pattern;
-}
-
-function markerOnPathBoundary(marker, text) {
-  return getBoundaryPattern(marker).test(text);
-}
+// GH-642 boundary anchoring (getBoundaryPattern/markerOnPathBoundary) moved to
+// ./paths so the Task-prompt and script-content lanes share it (GH-689).
 
 function markerPresent(marker, v) {
   // Markers containing `/` are already path-qualified — a raw substring match is
@@ -257,13 +234,27 @@ function markerPresent(marker, v) {
  * Fail-closed: an unrelated same-named dir may occasionally match, but the user
  * can unlock — that is safer than silently missing a write.
  */
+/**
+ * GH-689 all-variant foreign exemption: the marker hit is exonerated only when
+ * at least one variant of `v.all` contains the literal marker AND every
+ * variant containing it classifies as foreign-only. Zero literal occurrences
+ * (glob/quote-obfuscated presence) fail closed. Subsumes the GH-658 temp-path
+ * exemption (classifier clause 2) and eliminates the cd-template trailing-
+ * separator asymmetry.
+ */
+function markerForeignAcrossVariants(entry, marker, v) {
+  let sawLiteral = false;
+  for (const s of v.all) {
+    if (!s.includes(marker)) continue;
+    sawLiteral = true;
+    if (!markerOnlyInForeignPaths(s, marker, entry)) return false;
+  }
+  return sawLiteral;
+}
+
 function markerEligible(entry, marker, v) {
   if (!markerPresent(marker, v)) return false;
-  // Temp-path parity with the file-tool guard (findProtectedTarget exempts temp
-  // paths): a write whose only marker hit sits inside a scratch temp path — e.g.
-  // scaffolding `/tmp/x/.claude/fixture` — is not a write to the protected path.
-  // See GH-658.
-  if (markerOnlyInTempPaths(v.expandedCollapsed, marker)) return false;
+  if (markerForeignAcrossVariants(entry, marker, v)) return false; // GH-689
   if (!entry.isFile && allRefsUnderAllowedPaths(v.expandedCollapsed, entry)) return false;
   return true;
 }

--- a/plugins/heimdall/lib/guard/fsguard.js
+++ b/plugins/heimdall/lib/guard/fsguard.js
@@ -69,14 +69,37 @@ function allowedAbsPaths(lockedDirEntries) {
  * tool calls, so exporting here scopes it to THIS command while preserving cwd
  * and compound-command semantics (no nested shell). An existing LD_PRELOAD is
  * preserved (our .so is prepended).
+ *
+ * Recognizable rewrite shape (GH-689 vector 4), always in this order:
+ *   1. `SHIM_REWRITE_MARKER` (POSIX no-op, stable across versions);
+ *   2. `export LD_PRELOAD='<plugin>/scripts/bin/heimdall-fsguard.linux-<arch>.so'`;
+ *   3. `export HEIMDALL_PROTECTED='<dir:dir>'` (+ optional HEIMDALL_ALLOWED);
+ *   4. the original command, byte-identical.
+ * The interposer only NARROWS permissions (EACCES on writes under the
+ * protected dirs), never widens them. Operators whose harness classifiers
+ * still veto the rewrite can set HEIMDALL_DISABLE_SHIM=1 to fall back to the
+ * static fail-closed script check.
  */
+// Stable, classifier-recognizable prefix for the shim rewrite (GH-689 vector
+// 4): a POSIX `:` no-op, so prepending it never changes command semantics.
+// External harness/auto-mode classifiers that flag LD_PRELOAD exports as
+// bypass attempts can recognize this marker as heimdall guard output.
+const SHIM_REWRITE_MARKER = ": 'heimdall-fsguard-rewrite-v1';";
+
 function buildShimRewrite(command, lockedDirEntries, so) {
   const protectedCsv = lockedDirEntries.map((e) => e.dir).join(':');
   const allowedCsv = allowedAbsPaths(lockedDirEntries).join(':');
-  let pre = `export LD_PRELOAD=${shQuote(so)}\${LD_PRELOAD:+:$LD_PRELOAD}; `;
+  let pre = `${SHIM_REWRITE_MARKER} `;
+  pre += `export LD_PRELOAD=${shQuote(so)}\${LD_PRELOAD:+:$LD_PRELOAD}; `;
   pre += `export HEIMDALL_PROTECTED=${shQuote(protectedCsv)}; `;
   if (allowedCsv) pre += `export HEIMDALL_ALLOWED=${shQuote(allowedCsv)}; `;
   return pre + command;
 }
 
-module.exports = { shimPath, runsExternalScript, buildShimRewrite, allowedAbsPaths };
+module.exports = {
+  shimPath,
+  runsExternalScript,
+  buildShimRewrite,
+  allowedAbsPaths,
+  SHIM_REWRITE_MARKER,
+};

--- a/plugins/heimdall/lib/guard/paths.js
+++ b/plugins/heimdall/lib/guard/paths.js
@@ -8,6 +8,10 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+// Anchored single-token home expansion (~, $HOME, ${HOME} at start-of-string
+// only) — correct for an extracted path token, unlike the free-text global
+// expandHomePaths below.
+const { expandHome } = require('../pathSafe');
 
 const TEMP_PREFIXES = (() => {
   const raw = new Set([os.tmpdir(), '/tmp', '/var/tmp']);
@@ -78,10 +82,142 @@ function markerOnlyInTempPaths(text, marker) {
   return found;
 }
 
+// ─── GH-642 boundary helpers (moved from bash.js so every lane shares them) ──
+
+/**
+ * Does `marker` appear in `text` sitting on a path-like boundary? The marker is
+ * regex-escaped (same escape as the cp/rsync read check in bash.js) and must be
+ * preceded by start-of-string, `/`, whitespace, a quote, or `>`, and followed
+ * by end-of-string, `/`, whitespace, a quote, or `.`.
+ *
+ * The `>` leading boundary covers no-space redirect-writes (`>ui/x`). A second
+ * alternative (`=marker/`) covers `flag=path` writes such as dd's
+ * `of=src/output.dat`, where the marker is preceded by `=`.
+ */
+const _boundaryCache = new Map();
+function getBoundaryPattern(marker) {
+  if (_boundaryCache.has(marker)) return _boundaryCache.get(marker);
+  const esc = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Leading boundary also accepts `>` so a no-space redirect into the protected
+  // dir (`>ui/x`) stays blocked — a genuine path-token write, fail-closed like
+  // its spaced form `> ui/x`. See GH-642.
+  //
+  // The `=${esc}/` alternative restores blocking of `flag=path` writes (dd's
+  // `of=src/output.dat`) that String.includes caught before the boundary anchor.
+  // It requires a trailing `/` so it only fires on a path INTO the protected dir
+  // — a bare assignment like `x=ui` (marker at end, no `/`) is not a path token
+  // and must stay allowed. See GH-642.
+  const pattern = new RegExp(`(?:^|[/\\s"'>])${esc}(?:$|[/\\s"'.])|=${esc}/`);
+  _boundaryCache.set(marker, pattern);
+  return pattern;
+}
+
+function markerOnPathBoundary(marker, text) {
+  return getBoundaryPattern(marker).test(text);
+}
+
+// ─── GH-689: foreign-path token classifier ───────────────────────────────────
+// Basename markers collide with same-named dirs elsewhere on the machine: a
+// lock on <repo>/.claude must not match the agent toolchain under the user's
+// HOME config dir (~/.claude/plugins/cache/**) — or any other foreign absolute
+// path. Each marker occurrence is classified by resolving the path token
+// around it (pathSegmentAt): only affirmative proof of foreignness exempts;
+// everything resolution cannot see through stays fail-closed.
+
+/** Dynamic/glob/backtick characters static resolution cannot see through. */
+const UNRESOLVABLE_TOKEN_RE = /[$*?`]/;
+
+/** `flag=path` tokens (dd `of=/x`, curl `--output=~/x`): classify the rooted tail. */
+function stripFlagAssignment(token, marker) {
+  const eq = token.lastIndexOf('=', token.indexOf(marker));
+  if (eq === -1) return token;
+  const tail = token.slice(eq + 1);
+  return tail.startsWith('/') || tail.startsWith('~') ? tail : token;
+}
+
+/** `p` is `dir` itself or nested under it. */
+function underDir(p, dir) {
+  return p === dir || p.startsWith(dir + path.sep);
+}
+
+/**
+ * Clause 1 — foreign-home short-circuit: a token under the home config dir
+ * never matches a lock rooted elsewhere; protecting home .claude still works
+ * via its own entry, matched by prefix in clause 3. See GH-689.
+ */
+function isForeignHomeToken(token, entry) {
+  const homeConfig = path.join(os.homedir(), '.claude');
+  return underDir(token, homeConfig) && !underDir(entry.dir, homeConfig);
+}
+
+function tokenIsForeignPath(rawToken, marker, entry) {
+  const token = expandHome(stripFlagAssignment(rawToken, marker));
+  if (UNRESOLVABLE_TOKEN_RE.test(token)) return false;
+  if (!path.isAbsolute(token)) return false;
+  if (isForeignHomeToken(token, entry)) return true;
+  // Clause 2 — temp scratch paths are never the protected target (GH-658 parity).
+  if (isTempPath(token)) return true;
+  // Clause 3 — absolute resolution: foreign only when the resolved token is
+  // neither entry.dir, nor under it, nor an ancestor of it (parent-dir write).
+  const resolved = resolvePathSafe(token);
+  // An absolute token whose FIRST segment is the marker (`/.claude/x`) is a
+  // concatenation fragment glued onto a runtime base, not a root path.
+  if (underDir(resolved, path.sep + marker)) return false;
+  if (underDir(resolved, entry.dir)) return false;
+  if (entry.dir.startsWith(resolved + path.sep)) return false;
+  return true;
+}
+
+/**
+ * True only when `marker` occurs in `text` AND every occurrence sits inside a
+ * foreign path token, classified in clause order:
+ *   1. foreign-home short-circuit — token under `$HOME/.claude` never matches
+ *      a lock rooted elsewhere (protecting home .claude works via its own
+ *      entry, matched by prefix);
+ *   2. temp path — scratch space is never the protected target (GH-658);
+ *   3. absolute resolution — a statically-clean absolute token whose
+ *      `resolvePathSafe` result is neither `entry.dir`, under it, nor an
+ *      ancestor of it is foreign;
+ *   4. fail-closed default — relative tokens, `$VAR`/backtick/glob-bearing
+ *      tokens, bare markers, and concatenation fragments are references.
+ * Returns false when the marker does not occur (no affirmative proof, no
+ * exemption). Symlink direction guarantee: clause 3 resolves through
+ * symlinks, so a foreign-side symlink pointing INTO the protected dir still
+ * realpath-resolves under `entry.dir` and stays a reference — resolution can
+ * only prove foreignness, never hide a protected target.
+ */
+function markerOnlyInForeignPaths(text, marker, entry) {
+  let idx = 0;
+  let found = false;
+  while ((idx = text.indexOf(marker, idx)) !== -1) {
+    found = true;
+    const token = pathSegmentAt(text, idx, marker.length);
+    if (!tokenIsForeignPath(token, marker, entry)) return false;
+    idx += marker.length;
+  }
+  return found;
+}
+
+/**
+ * Boundary floor for free-text marker hits: markers containing `/` keep the
+ * raw substring semantics (bash.js markerPresent parity — path-qualified
+ * relative refs like `config/settings.json`); bare basenames must sit on a
+ * path boundary (GH-642 semantics extended beyond the bash lane), killing
+ * mid-word hits like `myproject.clauderc`. Task inputs arrive JSON-stringified:
+ * the `"` quoting counts as a boundary via `isPathBoundary`, so quoted path
+ * tokens still terminate cleanly for `pathSegmentAt` extraction.
+ */
+function markerOccurs(expanded, marker) {
+  if (marker.includes('/')) return expanded.includes(marker);
+  return markerOnPathBoundary(marker, expanded);
+}
+
 function textReferencesEntry(expanded, entry) {
   if (expanded.includes(entry.dir)) return true;
   for (const marker of entry.markers) {
-    if (expanded.includes(marker) && !markerOnlyInTempPaths(expanded, marker)) return true;
+    if (!markerOccurs(expanded, marker)) continue;
+    // GH-689: a text naming only foreign paths does not reference the entry.
+    if (!markerOnlyInForeignPaths(expanded, marker, entry)) return true;
   }
   return false;
 }
@@ -155,6 +291,9 @@ module.exports = {
   expandHomePaths,
   isPathBoundary,
   markerOnlyInTempPaths,
+  getBoundaryPattern,
+  markerOnPathBoundary,
+  markerOnlyInForeignPaths,
   findProtectedPathRef,
   findProtectedPathRefs,
   findProtectedTarget,

--- a/plugins/heimdall/lib/guard/scripts-bypass.js
+++ b/plugins/heimdall/lib/guard/scripts-bypass.js
@@ -8,6 +8,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { commandAccessesProtectedPaths } = require('../command-analysis');
+const { expandHomePaths, markerOnlyInForeignPaths } = require('./paths');
 
 function isTrustedScript(scriptPath, entries) {
   for (const entry of entries) {
@@ -53,6 +54,27 @@ function scriptHasWriteOps(content) {
 }
 
 /**
+ * GH-689: does the script CONTENT actually reference this entry once its path
+ * tokens are resolved? A script whose only marker hits are foreign absolute
+ * paths (e.g. the agent toolchain under ~/.claude while the lock protects
+ * <repo>/.claude) is not a bypass of THIS entry. A pattern hit with no literal
+ * marker occurrence in the home-expanded content stays fail-closed. Relative
+ * refs in script SOURCE also stay fail-closed: a script's runtime cwd is
+ * unknowable from static analysis (the invoking command or the script itself
+ * may chdir), so `.claude/x` in source must keep counting as a reference.
+ */
+function contentReferencesEntry(content, entry) {
+  const scanText = expandHomePaths(content);
+  let sawMarker = false;
+  for (const marker of entry.markers) {
+    if (!scanText.includes(marker)) continue;
+    sawMarker = true;
+    if (!markerOnlyInForeignPaths(scanText, marker, entry)) return true;
+  }
+  return !sawMarker;
+}
+
+/**
  * Inspect a command for script-driven writes to a protected dir entry.
  *
  * Fires for ANY non-trusted script the command runs whose content references
@@ -74,6 +96,7 @@ function checkScriptBypass(collapsedCmd, entry, entries) {
   } catch (err) {
     return { blocked: true, error: `Cannot read script "${found.scriptPath}": ${err.message}` };
   }
+  if (!contentReferencesEntry(content, entry)) return { blocked: false }; // GH-689
   return scriptHasWriteOps(content)
     ? { blocked: true, scriptPath: found.scriptPath }
     : { blocked: false };

--- a/plugins/maestro/.claude-plugin/plugin.json
+++ b/plugins/maestro/.claude-plugin/plugin.json
@@ -6,12 +6,5 @@
     "name": "Custom",
     "email": "custom@local"
   },
-  "keywords": [
-    "orchestrate",
-    "conduct",
-    "agents",
-    "tmux",
-    "workflow",
-    "multi-agent"
-  ]
+  "keywords": ["orchestrate", "conduct", "agents", "tmux", "workflow", "multi-agent"]
 }

--- a/plugins/synapsys/.claude-plugin/plugin.json
+++ b/plugins/synapsys/.claude-plugin/plugin.json
@@ -6,11 +6,5 @@
     "name": "Custom",
     "email": "custom@local"
   },
-  "keywords": [
-    "memory",
-    "hooks",
-    "injection",
-    "context",
-    "recall"
-  ]
+  "keywords": ["memory", "hooks", "injection", "context", "recall"]
 }


### PR DESCRIPTION
## Summary

Fixes the basename-marker collision class in the heimdall guard: a lock protecting a directory *named* `.claude` (or any short/common name — `.github`, `ui`, `src`) false-positive-blocked every command, subagent prompt, or script that merely *mentioned* a same-named path anywhere else on the machine — most damagingly the sanctioned agent toolchain under the **home** config dir (`~/.claude/plugins/cache/**`: commit-and-push.js, follow-up scripts, plugin-cache runners).

The fix resolves path tokens **before** marker matching: a new four-clause classifier `markerOnlyInForeignPaths` (`lib/guard/paths.js`) extracts the path token around each marker hit (`pathSegmentAt`), expands `~`/`$HOME`, and exempts the occurrence **only on affirmative proof of foreignness**:

1. **Foreign-home short-circuit** — token under `os.homedir()/.claude` never matches a lock rooted elsewhere (protecting home `.claude` still works via its own entry, matched by prefix).
2. **Temp path** — scratch space is never the protected target (GH-658 parity; the old `markerOnlyInTempPaths` is generalized into this classifier).
3. **Absolute resolution** — a statically-clean absolute token whose `resolvePathSafe()` result is neither `entry.dir`, under it, nor an ancestor of it is foreign (realpath-based, so a symlink pointing INTO the protected dir stays a reference).
4. **Fail-closed default** — relative tokens (`.claude/x`), `$VAR`/backtick/glob-bearing tokens, bare markers, and root-concatenation fragments (`/.claude/x`) remain references. Under-protection is a bypass; resolution can only prove foreignness, never hide a protected target.

## Lanes wired

- **Bash marker-write lane** (`bash.js markerEligible`): all-variant scan (`markerForeignAcrossVariants` over the GH-655 dequoted/normalized variants) — every variant containing the literal marker must be all-foreign; zero literal occurrences fail closed, so quote-splicing cannot fake a foreign path. This also eliminates the `cd`-template trailing-separator asymmetry (same command ± trailing `;` now agree).
- **Task-prompt lane** (`paths.js textReferencesEntry`): GH-642 boundary anchoring extended as the floor (mid-word `includes` hits like `myproject.clauderc` no longer match), then the same foreign classifier — a subagent prompt naming a home plugin-cache script no longer bricks orchestrator→agent handoffs, while prompts naming the protected dir still block.
- **Script-bypass static lane** (`scripts-bypass.js`): home-expanded script content scanned with the same classifier — `node <script>` whose source references only foreign paths passes on shim-unavailable hosts; relative refs in script source stay fail-closed.
- **Vector 4 (classifier interaction)**: `SHIM_REWRITE_MARKER` (`: 'heimdall-fsguard-rewrite-v1';` POSIX no-op) exported from `fsguard.js` and prepended in `buildShimRewrite`, so external harness classifiers can recognize the guard's own rewrite; README documents the stable rewrite shape and the `HEIMDALL_DISABLE_SHIM=1` operator workaround.

## Contract stability

- `evaluate`/`bashTargets`/`findProtectedPathRef(s)`/`checkScriptBypass` signatures unchanged; `guard.js` facade unchanged.
- `entries.js`, `hooks/heimdall.js`, `hooks.json` byte-identical vs main (PR #688 surfaces; exit-2-non-empty-stderr contract preserved).
- No `allowedPaths`/`trustedSubdirs` mechanism used (structurally unable to exempt paths outside `entry.dir` — ticket-declared dead end).
- Relative tokens deliberately never exonerate against `ctx.cwd`: an in-command `cd` moves the shell before the write, so cwd-based exoneration would be a bypass vector; the pinned relative-write block tests stay green.

## Testing

- **NEW** `guard-foreign-path.test.js` — 31 two-direction tests across all three lanes: home-config ALLOW vs protected BLOCK (absolute and relative), `cd`-template ± trailing-`;` asymmetry pin, GH-655 obfuscation interplay pair, mid-word boundary negative, short-marker fixtures (`.github`, `ui`, `src`), shim-rewrite marker pin. 7+ of these fail on the pre-fix engine (verified red before implementation).
- `guard-codex.test.js` +9 parity tests: the two-direction shell + agent matrix re-run with `runtime: 'codex'`, asserting pairwise exit-code equality with the claude verdicts (Step-7 dual-runtime gate; README parity note included).
- Full heimdall suite 266/266; full repo suite 8116/8116; zero edits to existing assertions (no true-positive block weakened).
- Quality gate exit 0; `pnpm format:check` clean; `lint-symlink-paths` (stripped-tree probe) and `lint-hooks-json` clean. Node 20/22 via CI matrix.

## Out-of-scope changes (declared)

Three formatting-only hunks ship in this PR because main's CI Quality job is currently **red** on exactly these files (`pnpm format:check` fails on the 3.68.1 release commit — the #691 full-repo sweep missed dot-directories), and the house rule is to fix CI failures in the flight PR:

- `.claude-plugin/marketplace.json`
- `plugins/maestro/.claude-plugin/plugin.json`
- `plugins/synapsys/.claude-plugin/plugin.json`

Hunks are biome array-collapse only; values byte-identical. No sibling-owned surfaces touched.

Closes #689
