### PR TITLE
fix(statusline): shared host owns the slot; derive marker from sessions (#700)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,40 +14,21 @@
       "source": "./plugins/work",
       "description": "Orchestrated /work command with pre-computed action plans",
       "category": "workflow",
-      "tags": [
-        "workflow",
-        "jira",
-        "orchestrator",
-        "state-machine",
-        "automation"
-      ]
+      "tags": ["workflow", "jira", "orchestrator", "state-machine", "automation"]
     },
     {
       "name": "synapsys",
       "source": "./plugins/synapsys",
       "description": "Context-triggered memory injection — memories declare event hooks + trigger patterns and are injected when matched",
       "category": "memory",
-      "tags": [
-        "memory",
-        "hooks",
-        "injection",
-        "context",
-        "recall"
-      ]
+      "tags": ["memory", "hooks", "injection", "context", "recall"]
     },
     {
       "name": "maestro",
       "source": "./plugins/maestro",
       "description": "Multi-agent orchestrator — bootstraps per-ticket tmux sessions, conducts them (silence detection + auto-restart), and surfaces real prompts to the operator",
       "category": "orchestration",
-      "tags": [
-        "orchestrate",
-        "conduct",
-        "agents",
-        "tmux",
-        "workflow",
-        "multi-agent"
-      ]
+      "tags": ["orchestrate", "conduct", "agents", "tmux", "workflow", "multi-agent"]
     },
     {
       "name": "heimdall",

--- a/factories/runtime/__tests__/vendored-parity.spec.js
+++ b/factories/runtime/__tests__/vendored-parity.spec.js
@@ -53,6 +53,7 @@ const EXPECTED_MASTER_FILES = {
   'factories/hookEntrypoint': ['hookEntrypoint.js', 'index.js', 'logHookError.js'],
   'factories/safeSubprocess': ['index.js', 'safeSubprocess.js'],
   'factories/pathSafe': ['index.js', 'pathSafe.js'],
+  'factories/statusline-host': ['statusline-host.js'],
 };
 
 const RUNTIME_SET = VENDOR_SETS.find((set) => set.master === 'factories/runtime');
@@ -123,6 +124,10 @@ describe('VENDOR_SETS table shape', () => {
       'plugins/heimdall/lib/safeSubprocess',
     ],
     'factories/pathSafe': ['plugins/heimdall/lib/pathSafe'],
+    'factories/statusline-host': [
+      'plugins/maestro/skills/install/scripts/lib',
+      'plugins/work/scripts/workflows/lib/statusline/host',
+    ],
   };
 
   for (const [master, vendorDirs] of Object.entries(EXPECTED_VENDOR_DIRS)) {

--- a/factories/statusline-host/statusline-host.js
+++ b/factories/statusline-host/statusline-host.js
@@ -1,0 +1,196 @@
+'use strict';
+/**
+ * statusline-host.js — shared "single host, many fragments" statusline model.
+ *
+ * THE FIX for statusline clobbering: Claude Code exposes exactly ONE statusLine
+ * slot. Historically every plugin (maestro 🎼, work ⚙, follow-up 🔄, qc 🔬)
+ * overwrote that slot with itself and chained at most one prior bar — so install
+ * order decided who showed, and re-installing was needed every session.
+ *
+ * Instead, ONE host script owns the slot permanently at a FIXED, checkout-
+ * independent path (~/.claude/statusline-host.sh). It renders every fragment in
+ * ~/.claude/statuslines/<NN>-<name>.cmd (first line = absolute renderer path,
+ * NN prefix = stacking order). Plugins add/remove ONLY their own fragment:
+ *   - installing/removing one bar never disturbs the others
+ *   - the registered slot never changes → new tabs/sessions just work (no reinstall)
+ *
+ * Zero runtime deps, CommonJS, Node built-ins only (matches plugin conventions).
+ *
+ * VENDORED MASTER: this is the canonical copy. Each plugin that ships a bar
+ * carries a byte-identical vendored copy under its own lib/ (plugins can't
+ * require across install snapshots — see scripts/sync-vendored.js). Edit HERE,
+ * then run `node scripts/sync-vendored.js` to refresh the vendored copies.
+ */
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const HOME = os.homedir();
+const HOST_PATH = path.join(HOME, '.claude', 'statusline-host.sh');
+const REGISTRY_DIR = path.join(HOME, '.claude', 'statuslines');
+const SETTINGS = path.join(HOME, '.claude', 'settings.json');
+
+// Bump when HOST_SCRIPT changes so installers re-write the host in place.
+const HOST_VERSION = 1;
+
+const HOST_SCRIPT = `#!/usr/bin/env bash
+# statusline-host.sh — HOST_VERSION=${HOST_VERSION}
+# Single, stable Claude Code statusLine host. Renders every fragment registered
+# under the registry dir. Managed by the plugins' statusline-host.js — do not
+# edit by hand; installers overwrite this file when HOST_VERSION changes.
+set -uo pipefail
+
+REG="\${CLAUDE_STATUSLINE_REGISTRY:-\$HOME/.claude/statuslines}"
+
+# Claude passes session JSON on stdin; forward the SAME bytes to every renderer.
+STDIN_JSON="\$(cat 2>/dev/null || true)"
+
+shopt -s nullglob
+lines=()
+for frag in "\$REG"/*.cmd; do
+  cmd="\$(head -n1 "\$frag" 2>/dev/null || true)"
+  [ -n "\$cmd" ] || continue
+  # Never recurse into ourselves.
+  case "\$cmd" in *statusline-host.sh) continue ;; esac
+  # Invoke the renderer directly (NO eval) so a tampered fragment can't run
+  # arbitrary shell. Bare executable paths only — the common case.
+  [ -x "\$cmd" ] || continue
+  out="\$(printf '%s' "\$STDIN_JSON" | "\$cmd" 2>/dev/null || true)"
+  [ -n "\$out" ] && lines+=("\$out")
+done
+
+[ \${#lines[@]} -gt 0 ] && printf '%s\\n' "\${lines[@]}"
+exit 0
+`;
+
+// Known managed renderers → their canonical fragment name, so a one-time
+// migration from the OLD single-slot registration keeps each bar's stacking.
+const KNOWN = [
+  ['maestro-statusline.sh', '10-maestro.cmd'],
+  ['work-statusline.sh', '20-work.cmd'],
+  ['followup-statusline.sh', '30-followup.cmd'],
+  ['qc-statusline.sh', '40-qc.cmd'],
+];
+
+function readSettings() {
+  try {
+    return JSON.parse(fs.readFileSync(SETTINGS, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeSettings(obj) {
+  fs.mkdirSync(path.dirname(SETTINGS), { recursive: true });
+  fs.writeFileSync(SETTINGS, `${JSON.stringify(obj, null, 2)}\n`);
+}
+
+function fragmentPath(fragName) {
+  return path.join(REGISTRY_DIR, fragName);
+}
+
+function listFragments() {
+  try {
+    return fs.readdirSync(REGISTRY_DIR).filter((f) => f.endsWith('.cmd'));
+  } catch {
+    return [];
+  }
+}
+
+function isHost(cmd) {
+  return typeof cmd === 'string' && cmd.includes('statusline-host.sh');
+}
+
+// Preserve a previously-registered single bar as a fragment so migrating to the
+// host loses nothing. Known managed renderers keep their slot; anything else is
+// pinned to the bottom.
+function migrateExisting(cmd) {
+  if (!cmd || typeof cmd !== 'string' || isHost(cmd)) return;
+  const known = KNOWN.find(([basename]) => cmd.includes(basename));
+  writeFragment(known ? known[1] : '50-preexisting.cmd', cmd);
+}
+
+function writeFragment(fragName, rendererPath) {
+  fs.mkdirSync(REGISTRY_DIR, { recursive: true });
+  fs.writeFileSync(fragmentPath(fragName), `${String(rendererPath).trim()}\n`);
+}
+
+// Ensure the host script exists (correct version) and owns the statusLine slot.
+function ensureHost() {
+  let current = '';
+  try {
+    current = fs.readFileSync(HOST_PATH, 'utf8');
+  } catch {
+    /* absent */
+  }
+  if (!current.includes(`HOST_VERSION=${HOST_VERSION}`)) {
+    fs.mkdirSync(path.dirname(HOST_PATH), { recursive: true });
+    fs.writeFileSync(HOST_PATH, HOST_SCRIPT);
+  }
+  fs.chmodSync(HOST_PATH, 0o755);
+  fs.mkdirSync(REGISTRY_DIR, { recursive: true });
+
+  const s = readSettings();
+  const cur = s.statusLine && s.statusLine.command;
+  if (cur !== HOST_PATH) {
+    if (cur) migrateExisting(cur);
+    s.statusLine = { type: 'command', command: HOST_PATH, padding: 0, refreshInterval: 3 };
+    writeSettings(s);
+  }
+}
+
+// Register (or refresh) this plugin's bar: install the host, then drop the
+// plugin's own fragment pointing at its renderer.
+function register(fragName, rendererPath) {
+  ensureHost();
+  writeFragment(fragName, rendererPath);
+}
+
+// Remove this plugin's bar only. If it was the last fragment, unregister the
+// host from settings (leaving the host script on disk is harmless).
+function remove(fragName) {
+  try {
+    fs.unlinkSync(fragmentPath(fragName));
+  } catch {
+    /* already gone */
+  }
+  if (listFragments().length === 0) {
+    const s = readSettings();
+    if (isHost(s.statusLine && s.statusLine.command)) {
+      delete s.statusLine;
+      writeSettings(s);
+    }
+  }
+}
+
+function state(fragName) {
+  const s = readSettings();
+  const cur = (s.statusLine && s.statusLine.command) || '(none)';
+  const mine = fragmentPath(fragName);
+  let mineTarget = '(not registered)';
+  try {
+    mineTarget = fs.readFileSync(mine, 'utf8').trim();
+  } catch {
+    /* absent */
+  }
+  return {
+    hostPath: HOST_PATH,
+    hostExists: fs.existsSync(HOST_PATH),
+    registered: isHost(cur),
+    currentSlot: cur,
+    myFragment: fragName,
+    myTarget: mineTarget,
+    allFragments: listFragments().sort(),
+    registryDir: REGISTRY_DIR,
+  };
+}
+
+module.exports = {
+  HOST_PATH,
+  REGISTRY_DIR,
+  HOST_VERSION,
+  ensureHost,
+  register,
+  remove,
+  state,
+};

--- a/plugins/maestro/.claude-plugin/plugin.json
+++ b/plugins/maestro/.claude-plugin/plugin.json
@@ -6,12 +6,5 @@
     "name": "Custom",
     "email": "custom@local"
   },
-  "keywords": [
-    "orchestrate",
-    "conduct",
-    "agents",
-    "tmux",
-    "workflow",
-    "multi-agent"
-  ]
+  "keywords": ["orchestrate", "conduct", "agents", "tmux", "workflow", "multi-agent"]
 }

--- a/plugins/maestro/scripts/__tests__/active-marker.test.js
+++ b/plugins/maestro/scripts/__tests__/active-marker.test.js
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for the status-bar active-marker writer in maestro-conduct.js.
+ *
+ * The bug: writeActiveMarker() required process.env.TICKET_PREFIX, which the
+ * daemon launch frequently lacked, so no marker was written and the 🎼 status
+ * bar stayed blank. The fix derives the prefix from the live `<PREFIX>-<id>-work`
+ * tmux session list instead, honoring TICKET_PREFIX only when present.
+ */
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { activeFleetPrefixes, writeActiveMarker } = require('../lib/maestro-conduct/active-marker');
+
+const SAVED = {};
+function stashEnv(keys) {
+  for (const k of keys) SAVED[k] = process.env[k];
+}
+function restoreEnv() {
+  for (const k of Object.keys(SAVED)) {
+    if (SAVED[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED[k];
+  }
+}
+
+describe('activeFleetPrefixes', () => {
+  beforeEach(() => stashEnv(['TICKET_PREFIX']));
+  afterEach(restoreEnv);
+
+  it('derives the prefix from live -work sessions (no env needed)', () => {
+    delete process.env.TICKET_PREFIX;
+    assert.deepEqual(activeFleetPrefixes(['FUT-97-work', 'FUT-95-work']), ['FUT']);
+  });
+
+  it('dedupes across sessions and helper suffixes', () => {
+    delete process.env.TICKET_PREFIX;
+    const out = activeFleetPrefixes(['FUT-97-work', 'FUT-97-dev', 'ECHO-12-work']);
+    assert.deepEqual(out.sort(), ['ECHO', 'FUT']);
+  });
+
+  it('honors an explicit TICKET_PREFIX and unions it with live sessions', () => {
+    process.env.TICKET_PREFIX = 'GH';
+    const out = activeFleetPrefixes(['FUT-97-work']);
+    assert.deepEqual(out.sort(), ['FUT', 'GH']);
+  });
+
+  it('ignores sessions with no ticket-shaped id and empty input', () => {
+    delete process.env.TICKET_PREFIX;
+    assert.deepEqual(activeFleetPrefixes(['random-session', 'holding']), []);
+    assert.deepEqual(activeFleetPrefixes([]), []);
+    assert.deepEqual(activeFleetPrefixes(undefined), []);
+  });
+});
+
+describe('writeActiveMarker', () => {
+  let home;
+  beforeEach(() => {
+    stashEnv(['TICKET_PREFIX', 'CLAUDE_CODE_SESSION_ID', 'REPO_NAME', 'HOME']);
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-marker-'));
+    process.env.HOME = home;
+    delete process.env.TICKET_PREFIX;
+  });
+  afterEach(() => {
+    restoreEnv();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  const dir = () => path.join(home, '.cache', 'maestro', 'active');
+  const read = (f) => JSON.parse(fs.readFileSync(path.join(dir(), f), 'utf8'));
+
+  it('writes one marker per derived prefix bound to the session', () => {
+    process.env.CLAUDE_CODE_SESSION_ID = 'sess-abc';
+    process.env.REPO_NAME = 'future-pay';
+    writeActiveMarker(['FUT-97-work', 'FUT-95-work']);
+    assert.deepEqual(fs.readdirSync(dir()), ['sess-abc.FUT.json']);
+    assert.deepEqual(read('sess-abc.FUT.json'), {
+      session: 'sess-abc',
+      prefix: 'FUT',
+      repo: 'future-pay',
+    });
+  });
+
+  it('no-ops without a session id', () => {
+    delete process.env.CLAUDE_CODE_SESSION_ID;
+    writeActiveMarker(['FUT-97-work']);
+    assert.equal(fs.existsSync(dir()), false);
+  });
+
+  it('no-ops when no prefix can be derived (leaves nothing)', () => {
+    process.env.CLAUDE_CODE_SESSION_ID = 'sess-abc';
+    writeActiveMarker(['holding-session']);
+    assert.equal(fs.existsSync(dir()), false);
+  });
+
+  it('refreshes stale markers for the same session when the fleet changes', () => {
+    process.env.CLAUDE_CODE_SESSION_ID = 'sess-abc';
+    writeActiveMarker(['FUT-97-work']);
+    assert.deepEqual(fs.readdirSync(dir()), ['sess-abc.FUT.json']);
+    // Fleet switches to a different prefix — the old marker must not linger.
+    writeActiveMarker(['ECHO-3-work']);
+    assert.deepEqual(fs.readdirSync(dir()), ['sess-abc.ECHO.json']);
+  });
+
+  it('does not disturb another session’s markers', () => {
+    process.env.CLAUDE_CODE_SESSION_ID = 'sess-one';
+    writeActiveMarker(['FUT-97-work']);
+    process.env.CLAUDE_CODE_SESSION_ID = 'sess-two';
+    writeActiveMarker(['ECHO-3-work']);
+    assert.deepEqual(fs.readdirSync(dir()).sort(), ['sess-one.FUT.json', 'sess-two.ECHO.json']);
+  });
+});

--- a/plugins/maestro/scripts/lib/maestro-conduct/active-marker.js
+++ b/plugins/maestro/scripts/lib/maestro-conduct/active-marker.js
@@ -1,0 +1,79 @@
+'use strict';
+/**
+ * active-marker.js — the status-bar "which Claude session owns which fleet"
+ * marker under ~/.cache/maestro/active/.
+ *
+ * maestro-statusline.js shows a fleet's live tmux sessions ONLY in the owning
+ * Claude session, matched by these markers. The prefix is DERIVED from the
+ * live `<PREFIX>-<id>-work` tmux sessions (the exact set the statusline matches
+ * against) — NOT from a TICKET_PREFIX env var: the daemon and bootstrap are
+ * separate process launches and the env was frequently absent on the daemon
+ * side, so the marker was never written and the 🎼 bar stayed blank. An
+ * explicit TICKET_PREFIX is still honored when present.
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const tmux = require('./tmux');
+
+// The ticket prefix(es) this fleet owns. Session ids like "FUT-97" → "FUT".
+function activeFleetPrefixes(sessions) {
+  const prefixes = new Set();
+  const raw = process.env.TICKET_PREFIX || '';
+  if (/^[A-Z][A-Z0-9]*$/.test(raw)) prefixes.add(raw);
+  for (const s of sessions || []) {
+    const m = /^([A-Z][A-Z0-9]*)-\d+$/.exec(tmux.ticketIdFor(s) || '');
+    if (m) prefixes.add(m[1]);
+  }
+  return [...prefixes];
+}
+
+// Drop this session's stale markers before rewriting (the prefix set changes as
+// fleets start/finish). Session ids are UUIDs, so the "<session>." filename
+// prefix can't collide with another session's markers.
+function clearSessionMarkers(dir, session) {
+  let files = [];
+  try {
+    files = fs.readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const f of files) {
+    if (f.startsWith(`${session}.`) && f.endsWith('.json')) {
+      try {
+        fs.unlinkSync(path.join(dir, f));
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+// Record which Claude session launched this orchestration + the ticket
+// prefix(es) it owns. Called every tick (reusing the tick's session list) so it
+// self-heals as agents come up after the daemon starts. Best-effort — the
+// status bar is advisory.
+function writeActiveMarker(sessions) {
+  try {
+    const session = process.env.CLAUDE_CODE_SESSION_ID;
+    if (!session) return;
+    const prefixes = activeFleetPrefixes(sessions || tmux.listSessions());
+    if (!prefixes.length) return;
+    const dir = path.join(os.homedir(), '.cache', 'maestro', 'active');
+    fs.mkdirSync(dir, { recursive: true });
+    clearSessionMarkers(dir, session);
+    const repo = process.env.REPO_NAME || '';
+    // One marker per prefix — maestro-statusline.js aggregates every marker
+    // whose .session matches, so a multi-prefix session shows each fleet.
+    for (const prefix of prefixes) {
+      fs.writeFileSync(
+        path.join(dir, `${session}.${prefix}.json`),
+        JSON.stringify({ session, prefix, repo })
+      );
+    }
+  } catch {
+    /* best effort — the status bar is advisory */
+  }
+}
+
+module.exports = { activeFleetPrefixes, writeActiveMarker };

--- a/plugins/maestro/scripts/maestro-conduct.js
+++ b/plugins/maestro/scripts/maestro-conduct.js
@@ -40,6 +40,7 @@ const fleetEmpty = require('./lib/maestro-conduct/fleet-empty');
 const progress = require('./lib/maestro-conduct/progress');
 const runners = require('./lib/maestro-conduct/detector-runners');
 const { detectPhaseAdvance } = require('./lib/maestro-conduct/phase-advance');
+const activeMarker = require('./lib/maestro-conduct/active-marker');
 
 const DETECTORS = {
   question: require('./lib/maestro-conduct/detectors/question'),
@@ -269,6 +270,13 @@ function tickSession(session) {
 
 function tick() {
   const sessions = tmux.listSessions();
+  // Refresh the status-bar marker from the live session list (self-heals as the
+  // fleet comes up; derives its prefix, no TICKET_PREFIX env dependency).
+  try {
+    activeMarker.writeActiveMarker(sessions);
+  } catch (e) {
+    alerts.log(`writeActiveMarker failed: ${e.message}`);
+  }
   // Reconcile manifest task statuses against live tmux at the top of each tick.
   // Cheap (≤ N file reads, only writes on drift) and gives the operator a live
   // view of pool occupancy without polling tmux.
@@ -327,26 +335,8 @@ function handlePrComments(ctx, cHit) {
 // so a second daemon in the SAME namespace is detected instead of both driving
 // (and racing on) the same agents. One-shot ticks don't lock — the conflict is
 // specific to two persistent daemons.
-// Record which Claude session launched this orchestration + its ticket prefix,
-// so the status bar (maestro-statusline.js) can show this fleet's live tmux
-// sessions ONLY in the owning session — no manifest needed, no global pin.
-function writeActiveMarker() {
-  try {
-    const session = process.env.CLAUDE_CODE_SESSION_ID;
-    const prefix = process.env.TICKET_PREFIX;
-    if (!session || !prefix) return;
-    const osMod = require('os');
-    const p = require('path');
-    const dir = p.join(osMod.homedir(), '.cache', 'maestro', 'active');
-    require('fs').mkdirSync(dir, { recursive: true });
-    require('fs').writeFileSync(
-      p.join(dir, `${session}.json`),
-      JSON.stringify({ session, prefix, repo: process.env.REPO_NAME || '' })
-    );
-  } catch {
-    /* best effort — the status bar is advisory */
-  }
-}
+// Status-bar active-marker writer lives in ./lib/maestro-conduct/active-marker
+// (derives the fleet prefix from live sessions; written every tick).
 
 // Last-resort visibility: any error that escapes the per-session guards must
 // land in the log file, not vanish on a detached stderr. The daemon keeps
@@ -372,7 +362,6 @@ function main() {
   }
   const nsLabel = singletonGuard.acquireOrExit();
   installCrashHandlers();
-  writeActiveMarker();
   alerts.log(`orchestrate daemon starting, tick=${TICK_SEC}s namespace="${nsLabel}"`);
   const guardedTick = () => {
     // MAESTRO_FORCE=1 lets a new conductor STEAL the lock without killing the

--- a/plugins/maestro/skills/install/SKILL.md
+++ b/plugins/maestro/skills/install/SKILL.md
@@ -44,20 +44,26 @@ topics disappear):
 🎼 <topic> <done>/<total>✓ ▶<active>(<ids>) ⏳<pending> ✅<pr-ready> ⚠<pr-broken>
 ```
 
-It **chains** any previously-registered status line (e.g. the qc calibration bar)
-beneath the maestro line, so installing this does not lose your existing one.
+It registers through the **shared statusline host** (`~/.claude/statusline-host.sh`),
+which owns Claude Code's single statusLine slot at a fixed, checkout-independent
+path and renders every registered bar (maestro 🎼, work ⚙, follow-up 🔄, qc 🔬).
+Installing only drops the maestro **fragment** — it never clobbers the other bars,
+and because the slot points at the fixed host, every new tab/session picks it up
+with no reinstall.
 
 ## Commands
 
 - **Install:** `node "$CLAUDE_PLUGIN_ROOT/skills/install/scripts/install-statusline.js"`
 - **Show resolved paths + current config:** `... install-statusline.js --print`
-- **Remove (restore the chained line):** `... install-statusline.js --remove`
+- **Remove (drop just the maestro bar):** `... install-statusline.js --remove`
 
 After installing, run `/reload-plugins` (or just wait for the next refresh tick).
 
 ## How it fits together
 
+- **Host:** `~/.claude/statusline-host.sh` — the single registered statusLine; renders
+  every fragment under `~/.claude/statuslines/*.cmd` in filename order.
+- **Fragment:** `~/.claude/statuslines/10-maestro.cmd` — one line, the path to this
+  plugin's renderer. Owned solely by the maestro installer.
 - **Renderer:** `skills/lib/maestro-statusline.sh` → calls `maestro-statusline.js`.
 - **Data source:** `~/.cache/maestro/sessions/*.json` (manifests) + `/tmp/maestro-alerts.jsonl`.
-- **Chain file:** `~/.cache/maestro/statusline-chain.cmd` holds the prior status
-  line command; the renderer appends its output beneath the maestro line.

--- a/plugins/maestro/skills/install/scripts/__tests__/install-statusline-runtime.test.js
+++ b/plugins/maestro/skills/install/scripts/__tests__/install-statusline-runtime.test.js
@@ -74,21 +74,57 @@ describe('install-statusline runtime guard', () => {
     assert.equal(fs.existsSync(settingsPath(home)), false);
   });
 
-  it('claude: registers the renderer exactly as before', async () => {
+  const hostPath = (home) => path.join(home, '.claude', 'statusline-host.sh');
+  const fragPath = (home, name) => path.join(home, '.claude', 'statuslines', name);
+
+  it('claude: installs the shared host and drops the maestro fragment', async () => {
     const home = freshHome();
     const { code, stdout } = await runInstaller([], { home, runtime: 'claude' });
     assert.equal(code, 0, stdout);
     assert.match(stdout, /^registered maestro status line -> /);
+    // The single slot is the fixed host, not the renderer itself.
     const settings = JSON.parse(fs.readFileSync(settingsPath(home), 'utf8'));
     assert.deepEqual(settings.statusLine, {
       type: 'command',
-      command: path.resolve(RENDERER),
+      command: hostPath(home),
       padding: 0,
       refreshInterval: 3,
     });
+    // The host script exists and is executable.
+    assert.equal(fs.existsSync(hostPath(home)), true);
+    assert.ok(fs.statSync(hostPath(home)).mode & 0o111, 'host is executable');
+    // The maestro fragment points at this plugin's renderer.
+    assert.equal(
+      fs.readFileSync(fragPath(home, '10-maestro.cmd'), 'utf8').trim(),
+      path.resolve(RENDERER)
+    );
   });
 
-  it('claude: --remove restores a chained line', async () => {
+  it('claude: --remove drops only the maestro fragment, leaving other bars', async () => {
+    const home = freshHome();
+    await runInstaller([], { home, runtime: 'claude' });
+    // A sibling bar registered by another plugin.
+    fs.writeFileSync(fragPath(home, '30-followup.cmd'), '/some/followup.sh\n');
+    const { code, stdout } = await runInstaller(['--remove'], { home, runtime: 'claude' });
+    assert.equal(code, 0, stdout);
+    assert.match(stdout, /removed the maestro fragment/);
+    assert.equal(fs.existsSync(fragPath(home, '10-maestro.cmd')), false);
+    // Sibling bar and the host slot are untouched.
+    assert.equal(fs.existsSync(fragPath(home, '30-followup.cmd')), true);
+    const settings = JSON.parse(fs.readFileSync(settingsPath(home), 'utf8'));
+    assert.equal(settings.statusLine.command, hostPath(home));
+  });
+
+  it('claude: --remove of the last fragment unregisters the host slot', async () => {
+    const home = freshHome();
+    await runInstaller([], { home, runtime: 'claude' });
+    const { code } = await runInstaller(['--remove'], { home, runtime: 'claude' });
+    assert.equal(code, 0);
+    const settings = JSON.parse(fs.readFileSync(settingsPath(home), 'utf8'));
+    assert.equal(settings.statusLine, undefined);
+  });
+
+  it('claude: migrates a pre-existing non-host bar into a fragment (loses nothing)', async () => {
     const home = freshHome();
     fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
     fs.writeFileSync(
@@ -96,10 +132,13 @@ describe('install-statusline runtime guard', () => {
       `${JSON.stringify({ statusLine: { type: 'command', command: '/some/other-bar.sh' } })}\n`
     );
     await runInstaller([], { home, runtime: 'claude' });
-    const { code, stdout } = await runInstaller(['--remove'], { home, runtime: 'claude' });
-    assert.equal(code, 0, stdout);
-    assert.match(stdout, /restored chained status line: \/some\/other-bar\.sh/);
     const settings = JSON.parse(fs.readFileSync(settingsPath(home), 'utf8'));
-    assert.equal(settings.statusLine.command, '/some/other-bar.sh');
+    assert.equal(settings.statusLine.command, hostPath(home));
+    // The previous bar survives, chained beneath via a fragment.
+    assert.equal(
+      fs.readFileSync(fragPath(home, '50-preexisting.cmd'), 'utf8').trim(),
+      '/some/other-bar.sh'
+    );
+    assert.equal(fs.existsSync(fragPath(home, '10-maestro.cmd')), true);
   });
 });

--- a/plugins/maestro/skills/install/scripts/install-statusline.js
+++ b/plugins/maestro/skills/install/scripts/install-statusline.js
@@ -1,31 +1,31 @@
 #!/usr/bin/env node
 'use strict';
 /**
- * install-statusline.js — register the maestro fleet status line as the Claude
- * Code statusLine, mirroring the qc-tasks installer.
+ * install-statusline.js — register the maestro fleet status line via the shared
+ * single-host statusline model (see lib/statusline-host.js).
  *
  * Usage:
  *   node install-statusline.js            register (default)
  *   node install-statusline.js --print    show resolved paths + current config
- *   node install-statusline.js --remove   unregister and restore the chained line
+ *   node install-statusline.js --remove   unregister just the maestro bar
  *
  * Behavior:
- *   - Resolves the renderer to this plugin's own skills/lib/maestro-statusline.sh
- *     ($CLAUDE_PLUGIN_ROOT at runtime, else relative to this file).
- *   - Writes settings.json .statusLine = { type:"command", command:<renderer>,
- *     padding:0, refreshInterval:3 } so the 🎼 bar updates live even while idle.
- *   - If an existing NON-maestro status line is registered, it is preserved into
- *     the chain file so the renderer shows it BENEATH the maestro line. --remove
- *     restores it as the sole status line.
+ *   - Installs the fixed host at ~/.claude/statusline-host.sh (checkout-
+ *     independent → every new tab/session picks it up, no reinstall) and drops
+ *     the maestro fragment ~/.claude/statuslines/10-maestro.cmd pointing at this
+ *     plugin's renderer.
+ *   - Because each plugin owns only its own fragment, installing/removing the
+ *     maestro bar never clobbers the work/follow-up/qc bars, and vice-versa.
  *   - Codex guard (design C4/§M): codex has no plugin statusline surface, so
  *     under AGENT_RUNTIME=codex every mode refuses cleanly (exit 0) and prints
  *     the tmux alternative instead of touching ~/.claude/settings.json.
  */
-const fs = require('fs');
 const path = require('path');
-const os = require('os');
 
 const { detectRuntime } = require('../../../scripts/lib/runtime');
+const host = require('./lib/statusline-host');
+
+const FRAGMENT = '10-maestro.cmd';
 
 if (detectRuntime() === 'codex') {
   process.stdout.write(
@@ -37,96 +37,34 @@ if (detectRuntime() === 'codex') {
   process.exit(0);
 }
 
-const HOME = os.homedir();
-const SETTINGS = path.join(HOME, '.claude', 'settings.json');
-const CHAIN_FILE = path.join(HOME, '.cache', 'maestro', 'statusline-chain.cmd');
-
 function rendererPath() {
-  // Resolve relative to this file's own location so the registered command
-  // always points at this plugin's renderer, regardless of install layout.
+  // Resolve relative to this file so the fragment always points at this
+  // plugin's own renderer, regardless of install layout.
   // this file: <plugin>/skills/install/scripts/install-statusline.js
   return path.join(__dirname, '..', '..', 'lib', 'maestro-statusline.sh');
 }
 
-function readSettings() {
-  try {
-    return JSON.parse(fs.readFileSync(SETTINGS, 'utf8'));
-  } catch {
-    return {};
-  }
-}
-
-function writeSettings(obj) {
-  fs.mkdirSync(path.dirname(SETTINGS), { recursive: true });
-  fs.writeFileSync(SETTINGS, JSON.stringify(obj, null, 2) + '\n');
-}
-
-function block(cmd) {
-  return { type: 'command', command: cmd, padding: 0, refreshInterval: 3 };
-}
-
-function isMaestro(cmd) {
-  return typeof cmd === 'string' && cmd.includes('maestro-statusline.sh');
-}
-
 function print() {
-  const renderer = rendererPath();
-  const s = readSettings();
-  const cur = s.statusLine && s.statusLine.command;
-  let chain = null;
-  try {
-    chain = fs.readFileSync(CHAIN_FILE, 'utf8').trim();
-  } catch {
-    /* none */
-  }
-  console.log('renderer:      ' + renderer);
-  console.log('exists:        ' + fs.existsSync(renderer));
-  console.log('settings:      ' + SETTINGS);
-  console.log('current line:  ' + (cur || '(none)'));
-  console.log('registered:    ' + (isMaestro(cur) ? 'yes (maestro)' : 'no'));
-  console.log('chained line:  ' + (chain || '(none)'));
+  const s = host.state(FRAGMENT);
+  console.log('renderer:      ' + rendererPath());
+  console.log('host:          ' + s.hostPath + (s.hostExists ? '' : ' (MISSING)'));
+  console.log('current slot:  ' + s.currentSlot);
+  console.log('host active:   ' + (s.registered ? 'yes' : 'no'));
+  console.log('maestro frag:  ' + s.myTarget);
+  console.log('all fragments: ' + (s.allFragments.join(', ') || '(none)'));
 }
 
 function install() {
   const renderer = rendererPath();
-  const s = readSettings();
-  const existing = s.statusLine && s.statusLine.command;
-
-  // Preserve a non-maestro existing line so it renders beneath the maestro line.
-  if (existing && !isMaestro(existing)) {
-    fs.mkdirSync(path.dirname(CHAIN_FILE), { recursive: true });
-    fs.writeFileSync(CHAIN_FILE, existing + '\n');
-    console.log('chained existing status line: ' + existing);
-  }
-
-  s.statusLine = block(renderer);
-  writeSettings(s);
+  host.register(FRAGMENT, renderer);
   console.log('registered maestro status line -> ' + renderer);
-  console.log('each orchestrator session shows only the fleet it launched.');
-  console.log('run /reload-plugins or restart the statusLine refresh to see it.');
+  console.log('host owns the slot at ' + host.HOST_PATH + ' — new tabs pick it up automatically.');
+  console.log('run /reload-plugins or wait for the statusLine refresh to see it.');
 }
 
 function remove() {
-  const s = readSettings();
-  let restored = null;
-  try {
-    restored = fs.readFileSync(CHAIN_FILE, 'utf8').trim();
-  } catch {
-    /* none */
-  }
-  if (restored) {
-    s.statusLine = block(restored);
-    console.log('restored chained status line: ' + restored);
-  } else {
-    delete s.statusLine;
-    console.log('removed status line (no chained line to restore).');
-  }
-  writeSettings(s);
-  try {
-    fs.unlinkSync(CHAIN_FILE);
-  } catch {
-    /* none */
-  }
+  host.remove(FRAGMENT);
+  console.log('removed the maestro fragment (' + FRAGMENT + '); other bars untouched.');
 }
 
 const arg = process.argv[2];

--- a/plugins/maestro/skills/install/scripts/lib/statusline-host.js
+++ b/plugins/maestro/skills/install/scripts/lib/statusline-host.js
@@ -1,0 +1,198 @@
+// GENERATED — edit factories/statusline-host/statusline-host.js and run scripts/sync-vendored.js
+
+'use strict';
+/**
+ * statusline-host.js — shared "single host, many fragments" statusline model.
+ *
+ * THE FIX for statusline clobbering: Claude Code exposes exactly ONE statusLine
+ * slot. Historically every plugin (maestro 🎼, work ⚙, follow-up 🔄, qc 🔬)
+ * overwrote that slot with itself and chained at most one prior bar — so install
+ * order decided who showed, and re-installing was needed every session.
+ *
+ * Instead, ONE host script owns the slot permanently at a FIXED, checkout-
+ * independent path (~/.claude/statusline-host.sh). It renders every fragment in
+ * ~/.claude/statuslines/<NN>-<name>.cmd (first line = absolute renderer path,
+ * NN prefix = stacking order). Plugins add/remove ONLY their own fragment:
+ *   - installing/removing one bar never disturbs the others
+ *   - the registered slot never changes → new tabs/sessions just work (no reinstall)
+ *
+ * Zero runtime deps, CommonJS, Node built-ins only (matches plugin conventions).
+ *
+ * VENDORED MASTER: this is the canonical copy. Each plugin that ships a bar
+ * carries a byte-identical vendored copy under its own lib/ (plugins can't
+ * require across install snapshots — see scripts/sync-vendored.js). Edit HERE,
+ * then run `node scripts/sync-vendored.js` to refresh the vendored copies.
+ */
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const HOME = os.homedir();
+const HOST_PATH = path.join(HOME, '.claude', 'statusline-host.sh');
+const REGISTRY_DIR = path.join(HOME, '.claude', 'statuslines');
+const SETTINGS = path.join(HOME, '.claude', 'settings.json');
+
+// Bump when HOST_SCRIPT changes so installers re-write the host in place.
+const HOST_VERSION = 1;
+
+const HOST_SCRIPT = `#!/usr/bin/env bash
+# statusline-host.sh — HOST_VERSION=${HOST_VERSION}
+# Single, stable Claude Code statusLine host. Renders every fragment registered
+# under the registry dir. Managed by the plugins' statusline-host.js — do not
+# edit by hand; installers overwrite this file when HOST_VERSION changes.
+set -uo pipefail
+
+REG="\${CLAUDE_STATUSLINE_REGISTRY:-\$HOME/.claude/statuslines}"
+
+# Claude passes session JSON on stdin; forward the SAME bytes to every renderer.
+STDIN_JSON="\$(cat 2>/dev/null || true)"
+
+shopt -s nullglob
+lines=()
+for frag in "\$REG"/*.cmd; do
+  cmd="\$(head -n1 "\$frag" 2>/dev/null || true)"
+  [ -n "\$cmd" ] || continue
+  # Never recurse into ourselves.
+  case "\$cmd" in *statusline-host.sh) continue ;; esac
+  # Invoke the renderer directly (NO eval) so a tampered fragment can't run
+  # arbitrary shell. Bare executable paths only — the common case.
+  [ -x "\$cmd" ] || continue
+  out="\$(printf '%s' "\$STDIN_JSON" | "\$cmd" 2>/dev/null || true)"
+  [ -n "\$out" ] && lines+=("\$out")
+done
+
+[ \${#lines[@]} -gt 0 ] && printf '%s\\n' "\${lines[@]}"
+exit 0
+`;
+
+// Known managed renderers → their canonical fragment name, so a one-time
+// migration from the OLD single-slot registration keeps each bar's stacking.
+const KNOWN = [
+  ['maestro-statusline.sh', '10-maestro.cmd'],
+  ['work-statusline.sh', '20-work.cmd'],
+  ['followup-statusline.sh', '30-followup.cmd'],
+  ['qc-statusline.sh', '40-qc.cmd'],
+];
+
+function readSettings() {
+  try {
+    return JSON.parse(fs.readFileSync(SETTINGS, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeSettings(obj) {
+  fs.mkdirSync(path.dirname(SETTINGS), { recursive: true });
+  fs.writeFileSync(SETTINGS, `${JSON.stringify(obj, null, 2)}\n`);
+}
+
+function fragmentPath(fragName) {
+  return path.join(REGISTRY_DIR, fragName);
+}
+
+function listFragments() {
+  try {
+    return fs.readdirSync(REGISTRY_DIR).filter((f) => f.endsWith('.cmd'));
+  } catch {
+    return [];
+  }
+}
+
+function isHost(cmd) {
+  return typeof cmd === 'string' && cmd.includes('statusline-host.sh');
+}
+
+// Preserve a previously-registered single bar as a fragment so migrating to the
+// host loses nothing. Known managed renderers keep their slot; anything else is
+// pinned to the bottom.
+function migrateExisting(cmd) {
+  if (!cmd || typeof cmd !== 'string' || isHost(cmd)) return;
+  const known = KNOWN.find(([basename]) => cmd.includes(basename));
+  writeFragment(known ? known[1] : '50-preexisting.cmd', cmd);
+}
+
+function writeFragment(fragName, rendererPath) {
+  fs.mkdirSync(REGISTRY_DIR, { recursive: true });
+  fs.writeFileSync(fragmentPath(fragName), `${String(rendererPath).trim()}\n`);
+}
+
+// Ensure the host script exists (correct version) and owns the statusLine slot.
+function ensureHost() {
+  let current = '';
+  try {
+    current = fs.readFileSync(HOST_PATH, 'utf8');
+  } catch {
+    /* absent */
+  }
+  if (!current.includes(`HOST_VERSION=${HOST_VERSION}`)) {
+    fs.mkdirSync(path.dirname(HOST_PATH), { recursive: true });
+    fs.writeFileSync(HOST_PATH, HOST_SCRIPT);
+  }
+  fs.chmodSync(HOST_PATH, 0o755);
+  fs.mkdirSync(REGISTRY_DIR, { recursive: true });
+
+  const s = readSettings();
+  const cur = s.statusLine && s.statusLine.command;
+  if (cur !== HOST_PATH) {
+    if (cur) migrateExisting(cur);
+    s.statusLine = { type: 'command', command: HOST_PATH, padding: 0, refreshInterval: 3 };
+    writeSettings(s);
+  }
+}
+
+// Register (or refresh) this plugin's bar: install the host, then drop the
+// plugin's own fragment pointing at its renderer.
+function register(fragName, rendererPath) {
+  ensureHost();
+  writeFragment(fragName, rendererPath);
+}
+
+// Remove this plugin's bar only. If it was the last fragment, unregister the
+// host from settings (leaving the host script on disk is harmless).
+function remove(fragName) {
+  try {
+    fs.unlinkSync(fragmentPath(fragName));
+  } catch {
+    /* already gone */
+  }
+  if (listFragments().length === 0) {
+    const s = readSettings();
+    if (isHost(s.statusLine && s.statusLine.command)) {
+      delete s.statusLine;
+      writeSettings(s);
+    }
+  }
+}
+
+function state(fragName) {
+  const s = readSettings();
+  const cur = (s.statusLine && s.statusLine.command) || '(none)';
+  const mine = fragmentPath(fragName);
+  let mineTarget = '(not registered)';
+  try {
+    mineTarget = fs.readFileSync(mine, 'utf8').trim();
+  } catch {
+    /* absent */
+  }
+  return {
+    hostPath: HOST_PATH,
+    hostExists: fs.existsSync(HOST_PATH),
+    registered: isHost(cur),
+    currentSlot: cur,
+    myFragment: fragName,
+    myTarget: mineTarget,
+    allFragments: listFragments().sort(),
+    registryDir: REGISTRY_DIR,
+  };
+}
+
+module.exports = {
+  HOST_PATH,
+  REGISTRY_DIR,
+  HOST_VERSION,
+  ensureHost,
+  register,
+  remove,
+  state,
+};

--- a/plugins/synapsys/.claude-plugin/plugin.json
+++ b/plugins/synapsys/.claude-plugin/plugin.json
@@ -6,11 +6,5 @@
     "name": "Custom",
     "email": "custom@local"
   },
-  "keywords": [
-    "memory",
-    "hooks",
-    "injection",
-    "context",
-    "recall"
-  ]
+  "keywords": ["memory", "hooks", "injection", "context", "recall"]
 }

--- a/plugins/work/scripts/__tests__/work-hook-runtime.test.js
+++ b/plugins/work/scripts/__tests__/work-hook-runtime.test.js
@@ -75,7 +75,16 @@ describe('work-hook — dual runtime', () => {
   });
 
   function runHook(stdin, env = {}) {
-    const merged = { ...process.env, CLAUDE_PLUGIN_ROOT: fakeRoot, ...env };
+    // Disable the update-available banner so the plan stdout stays byte-identical
+    // to the fixture regardless of what version is published (the banner is
+    // prepended once per session when a newer version exists — a time-bomb for
+    // this assertion). WORK_DISABLE_UPDATE_CHECK is the documented opt-out.
+    const merged = {
+      ...process.env,
+      CLAUDE_PLUGIN_ROOT: fakeRoot,
+      WORK_DISABLE_UPDATE_CHECK: '1',
+      ...env,
+    };
     for (const key of [
       'AGENT_RUNTIME',
       'AGENT_SESSION_ID',

--- a/plugins/work/scripts/run-tests.sh
+++ b/plugins/work/scripts/run-tests.sh
@@ -10,6 +10,13 @@
 set -u
 set -o pipefail
 
+# Deterministic tests: suppress the "update available" banner suite-wide. The
+# banner prepends to hook stdout once per session when the published version is
+# newer than the checked-in plugin.json, which breaks byte-identical hook-output
+# assertions the moment a release is published (version skew). The dedicated
+# banner test re-enables it per-leg via `delete env.WORK_DISABLE_UPDATE_CHECK`.
+export WORK_DISABLE_UPDATE_CHECK=1
+
 SKIP_FILE=".test-skip"
 
 cleanup_test_artifacts() {

--- a/plugins/work/scripts/workflows/follow-up/__tests__/install-followup-statusline-runtime.test.js
+++ b/plugins/work/scripts/workflows/follow-up/__tests__/install-followup-statusline-runtime.test.js
@@ -73,21 +73,50 @@ describe('install-followup-statusline runtime guard', () => {
     assert.equal(fs.existsSync(settingsPath(home)), false);
   });
 
-  it('claude: registers the renderer exactly as before', async () => {
+  const hostPath = (home) => path.join(home, '.claude', 'statusline-host.sh');
+  const fragPath = (home, name) => path.join(home, '.claude', 'statuslines', name);
+
+  it('claude: installs the shared host and drops the follow-up fragment', async () => {
     const home = freshHome();
     const { code, stdout } = await runInstaller([], { home, runtime: 'claude' });
     assert.equal(code, 0, stdout);
-    assert.equal(stdout, `follow-up status bar registered -> ${RENDERER}\n`);
+    assert.match(stdout, /^follow-up status bar registered -> /);
+    // The single slot is the fixed host, not the renderer itself.
     const settings = JSON.parse(fs.readFileSync(settingsPath(home), 'utf8'));
     assert.deepEqual(settings.statusLine, {
       type: 'command',
-      command: RENDERER,
+      command: hostPath(home),
       padding: 0,
       refreshInterval: 3,
     });
+    assert.equal(fs.existsSync(hostPath(home)), true);
+    assert.ok(fs.statSync(hostPath(home)).mode & 0o111, 'host is executable');
+    assert.equal(fs.readFileSync(fragPath(home, '30-followup.cmd'), 'utf8').trim(), RENDERER);
   });
 
-  it('claude: --remove restores a chained bar', async () => {
+  it('claude: --remove drops only the follow-up fragment, leaving other bars', async () => {
+    const home = freshHome();
+    await runInstaller([], { home, runtime: 'claude' });
+    fs.writeFileSync(fragPath(home, '10-maestro.cmd'), '/some/maestro.sh\n');
+    const { code, stdout } = await runInstaller(['--remove'], { home, runtime: 'claude' });
+    assert.equal(code, 0, stdout);
+    assert.match(stdout, /follow-up status bar removed/);
+    assert.equal(fs.existsSync(fragPath(home, '30-followup.cmd')), false);
+    assert.equal(fs.existsSync(fragPath(home, '10-maestro.cmd')), true);
+    const settings = JSON.parse(fs.readFileSync(settingsPath(home), 'utf8'));
+    assert.equal(settings.statusLine.command, hostPath(home));
+  });
+
+  it('claude: --remove of the last fragment unregisters the host slot', async () => {
+    const home = freshHome();
+    await runInstaller([], { home, runtime: 'claude' });
+    const { code } = await runInstaller(['--remove'], { home, runtime: 'claude' });
+    assert.equal(code, 0);
+    const settings = JSON.parse(fs.readFileSync(settingsPath(home), 'utf8'));
+    assert.equal(settings.statusLine, undefined);
+  });
+
+  it('claude: migrates a pre-existing non-host bar into a fragment (loses nothing)', async () => {
     const home = freshHome();
     fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
     fs.writeFileSync(
@@ -95,10 +124,12 @@ describe('install-followup-statusline runtime guard', () => {
       `${JSON.stringify({ statusLine: { type: 'command', command: '/some/other-bar.sh' } })}\n`
     );
     await runInstaller([], { home, runtime: 'claude' });
-    const { code, stdout } = await runInstaller(['--remove'], { home, runtime: 'claude' });
-    assert.equal(code, 0, stdout);
-    assert.equal(stdout, 'follow-up status bar removed — restored /some/other-bar.sh\n');
     const settings = JSON.parse(fs.readFileSync(settingsPath(home), 'utf8'));
-    assert.equal(settings.statusLine.command, '/some/other-bar.sh');
+    assert.equal(settings.statusLine.command, hostPath(home));
+    assert.equal(
+      fs.readFileSync(fragPath(home, '50-preexisting.cmd'), 'utf8').trim(),
+      '/some/other-bar.sh'
+    );
+    assert.equal(fs.existsSync(fragPath(home, '30-followup.cmd')), true);
   });
 });

--- a/plugins/work/scripts/workflows/follow-up/statusline/install-followup-statusline.js
+++ b/plugins/work/scripts/workflows/follow-up/statusline/install-followup-statusline.js
@@ -3,17 +3,15 @@
 /**
  * install-followup-statusline.js — register/remove the /follow-up status bar.
  *
- *   (no args)   register followup-statusline.sh as the Claude Code statusLine,
- *               preserving any existing bar into the chain file
- *   --print     show resolved renderer path + current/chained config
- *   --remove    unregister and restore the chained bar
+ *   (no args)   register the follow-up bar as a fragment under the shared host
+ *   --print     show resolved renderer path + current/host config
+ *   --remove    remove only the follow-up fragment (other bars untouched)
  *
- * All settings.json / chain plumbing (and the codex guard) lives in the shared
+ * All host + settings.json plumbing (and the codex guard) lives in the shared
  * lib/statusline/install-statusline.js. Renderer path resolves from __dirname
  * (never process.env.CLAUDE_PLUGIN_ROOT).
  */
 const path = require('path');
-const os = require('os');
 
 const { runStatuslineInstaller } = require('../../lib/statusline/install-statusline');
 
@@ -21,8 +19,7 @@ runStatuslineInstaller({
   mode: process.argv[2],
   label: 'follow-up',
   renderer: path.join(__dirname, 'followup-statusline.sh'),
-  rendererName: 'followup-statusline.sh',
-  chainFile: path.join(os.homedir(), '.cache', 'followup', 'statusline-chain.cmd'),
+  fragment: '30-followup.cmd',
   codexNote:
     'Watch follow-up progress from the CLI instead:\n' +
     "  watch -n 3 'cat <TASKS_BASE>/<ticket>/.follow-up-state.json'\n" +

--- a/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
@@ -53,6 +53,8 @@ const VENDORED_DIRS = [
   'plugins/heimdall/lib/storeDiscovery',
   'plugins/maestro/lib/storeDiscovery',
   'plugins/maestro/scripts/lib/runtime',
+  // factories/statusline-host → per-plugin statusline installer lib/ (this + the work one below)
+  'plugins/maestro/skills/install/scripts/lib',
   'plugins/synapsys/lib/hookEntrypoint',
   'plugins/synapsys/lib/runtime',
   'plugins/synapsys/lib/safeSubprocess',
@@ -61,8 +63,6 @@ const VENDORED_DIRS = [
   'plugins/work/scripts/workflows/lib/runtime',
   'plugins/work/scripts/workflows/lib/safeIO',
   'plugins/work/scripts/workflows/lib/safeSubprocess',
-  // factories/statusline-host → per-plugin statusline installer lib/
-  'plugins/maestro/skills/install/scripts/lib',
   'plugins/work/scripts/workflows/lib/statusline/host',
 ];
 

--- a/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
+++ b/plugins/work/scripts/workflows/lib/scripts/quality/quality.js
@@ -61,6 +61,9 @@ const VENDORED_DIRS = [
   'plugins/work/scripts/workflows/lib/runtime',
   'plugins/work/scripts/workflows/lib/safeIO',
   'plugins/work/scripts/workflows/lib/safeSubprocess',
+  // factories/statusline-host → per-plugin statusline installer lib/
+  'plugins/maestro/skills/install/scripts/lib',
+  'plugins/work/scripts/workflows/lib/statusline/host',
 ];
 
 function isVendoredFile(absFile, repoRoot) {

--- a/plugins/work/scripts/workflows/lib/statusline/host/statusline-host.js
+++ b/plugins/work/scripts/workflows/lib/statusline/host/statusline-host.js
@@ -1,0 +1,198 @@
+// GENERATED — edit factories/statusline-host/statusline-host.js and run scripts/sync-vendored.js
+
+'use strict';
+/**
+ * statusline-host.js — shared "single host, many fragments" statusline model.
+ *
+ * THE FIX for statusline clobbering: Claude Code exposes exactly ONE statusLine
+ * slot. Historically every plugin (maestro 🎼, work ⚙, follow-up 🔄, qc 🔬)
+ * overwrote that slot with itself and chained at most one prior bar — so install
+ * order decided who showed, and re-installing was needed every session.
+ *
+ * Instead, ONE host script owns the slot permanently at a FIXED, checkout-
+ * independent path (~/.claude/statusline-host.sh). It renders every fragment in
+ * ~/.claude/statuslines/<NN>-<name>.cmd (first line = absolute renderer path,
+ * NN prefix = stacking order). Plugins add/remove ONLY their own fragment:
+ *   - installing/removing one bar never disturbs the others
+ *   - the registered slot never changes → new tabs/sessions just work (no reinstall)
+ *
+ * Zero runtime deps, CommonJS, Node built-ins only (matches plugin conventions).
+ *
+ * VENDORED MASTER: this is the canonical copy. Each plugin that ships a bar
+ * carries a byte-identical vendored copy under its own lib/ (plugins can't
+ * require across install snapshots — see scripts/sync-vendored.js). Edit HERE,
+ * then run `node scripts/sync-vendored.js` to refresh the vendored copies.
+ */
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const HOME = os.homedir();
+const HOST_PATH = path.join(HOME, '.claude', 'statusline-host.sh');
+const REGISTRY_DIR = path.join(HOME, '.claude', 'statuslines');
+const SETTINGS = path.join(HOME, '.claude', 'settings.json');
+
+// Bump when HOST_SCRIPT changes so installers re-write the host in place.
+const HOST_VERSION = 1;
+
+const HOST_SCRIPT = `#!/usr/bin/env bash
+# statusline-host.sh — HOST_VERSION=${HOST_VERSION}
+# Single, stable Claude Code statusLine host. Renders every fragment registered
+# under the registry dir. Managed by the plugins' statusline-host.js — do not
+# edit by hand; installers overwrite this file when HOST_VERSION changes.
+set -uo pipefail
+
+REG="\${CLAUDE_STATUSLINE_REGISTRY:-\$HOME/.claude/statuslines}"
+
+# Claude passes session JSON on stdin; forward the SAME bytes to every renderer.
+STDIN_JSON="\$(cat 2>/dev/null || true)"
+
+shopt -s nullglob
+lines=()
+for frag in "\$REG"/*.cmd; do
+  cmd="\$(head -n1 "\$frag" 2>/dev/null || true)"
+  [ -n "\$cmd" ] || continue
+  # Never recurse into ourselves.
+  case "\$cmd" in *statusline-host.sh) continue ;; esac
+  # Invoke the renderer directly (NO eval) so a tampered fragment can't run
+  # arbitrary shell. Bare executable paths only — the common case.
+  [ -x "\$cmd" ] || continue
+  out="\$(printf '%s' "\$STDIN_JSON" | "\$cmd" 2>/dev/null || true)"
+  [ -n "\$out" ] && lines+=("\$out")
+done
+
+[ \${#lines[@]} -gt 0 ] && printf '%s\\n' "\${lines[@]}"
+exit 0
+`;
+
+// Known managed renderers → their canonical fragment name, so a one-time
+// migration from the OLD single-slot registration keeps each bar's stacking.
+const KNOWN = [
+  ['maestro-statusline.sh', '10-maestro.cmd'],
+  ['work-statusline.sh', '20-work.cmd'],
+  ['followup-statusline.sh', '30-followup.cmd'],
+  ['qc-statusline.sh', '40-qc.cmd'],
+];
+
+function readSettings() {
+  try {
+    return JSON.parse(fs.readFileSync(SETTINGS, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeSettings(obj) {
+  fs.mkdirSync(path.dirname(SETTINGS), { recursive: true });
+  fs.writeFileSync(SETTINGS, `${JSON.stringify(obj, null, 2)}\n`);
+}
+
+function fragmentPath(fragName) {
+  return path.join(REGISTRY_DIR, fragName);
+}
+
+function listFragments() {
+  try {
+    return fs.readdirSync(REGISTRY_DIR).filter((f) => f.endsWith('.cmd'));
+  } catch {
+    return [];
+  }
+}
+
+function isHost(cmd) {
+  return typeof cmd === 'string' && cmd.includes('statusline-host.sh');
+}
+
+// Preserve a previously-registered single bar as a fragment so migrating to the
+// host loses nothing. Known managed renderers keep their slot; anything else is
+// pinned to the bottom.
+function migrateExisting(cmd) {
+  if (!cmd || typeof cmd !== 'string' || isHost(cmd)) return;
+  const known = KNOWN.find(([basename]) => cmd.includes(basename));
+  writeFragment(known ? known[1] : '50-preexisting.cmd', cmd);
+}
+
+function writeFragment(fragName, rendererPath) {
+  fs.mkdirSync(REGISTRY_DIR, { recursive: true });
+  fs.writeFileSync(fragmentPath(fragName), `${String(rendererPath).trim()}\n`);
+}
+
+// Ensure the host script exists (correct version) and owns the statusLine slot.
+function ensureHost() {
+  let current = '';
+  try {
+    current = fs.readFileSync(HOST_PATH, 'utf8');
+  } catch {
+    /* absent */
+  }
+  if (!current.includes(`HOST_VERSION=${HOST_VERSION}`)) {
+    fs.mkdirSync(path.dirname(HOST_PATH), { recursive: true });
+    fs.writeFileSync(HOST_PATH, HOST_SCRIPT);
+  }
+  fs.chmodSync(HOST_PATH, 0o755);
+  fs.mkdirSync(REGISTRY_DIR, { recursive: true });
+
+  const s = readSettings();
+  const cur = s.statusLine && s.statusLine.command;
+  if (cur !== HOST_PATH) {
+    if (cur) migrateExisting(cur);
+    s.statusLine = { type: 'command', command: HOST_PATH, padding: 0, refreshInterval: 3 };
+    writeSettings(s);
+  }
+}
+
+// Register (or refresh) this plugin's bar: install the host, then drop the
+// plugin's own fragment pointing at its renderer.
+function register(fragName, rendererPath) {
+  ensureHost();
+  writeFragment(fragName, rendererPath);
+}
+
+// Remove this plugin's bar only. If it was the last fragment, unregister the
+// host from settings (leaving the host script on disk is harmless).
+function remove(fragName) {
+  try {
+    fs.unlinkSync(fragmentPath(fragName));
+  } catch {
+    /* already gone */
+  }
+  if (listFragments().length === 0) {
+    const s = readSettings();
+    if (isHost(s.statusLine && s.statusLine.command)) {
+      delete s.statusLine;
+      writeSettings(s);
+    }
+  }
+}
+
+function state(fragName) {
+  const s = readSettings();
+  const cur = (s.statusLine && s.statusLine.command) || '(none)';
+  const mine = fragmentPath(fragName);
+  let mineTarget = '(not registered)';
+  try {
+    mineTarget = fs.readFileSync(mine, 'utf8').trim();
+  } catch {
+    /* absent */
+  }
+  return {
+    hostPath: HOST_PATH,
+    hostExists: fs.existsSync(HOST_PATH),
+    registered: isHost(cur),
+    currentSlot: cur,
+    myFragment: fragName,
+    myTarget: mineTarget,
+    allFragments: listFragments().sort(),
+    registryDir: REGISTRY_DIR,
+  };
+}
+
+module.exports = {
+  HOST_PATH,
+  REGISTRY_DIR,
+  HOST_VERSION,
+  ensureHost,
+  register,
+  remove,
+  state,
+};

--- a/plugins/work/scripts/workflows/lib/statusline/install-statusline.js
+++ b/plugins/work/scripts/workflows/lib/statusline/install-statusline.js
@@ -1,73 +1,50 @@
 'use strict';
 /**
  * install-statusline.js — shared register/remove/--print engine for the plugin's
- * Claude Code status bars (follow-up, work, …). Each bar's installer is a thin
- * wrapper that supplies its own renderer path, chain file, labels, and codex
- * note; all the settings.json + chain-file plumbing lives here so the bars stay
- * byte-identical in behaviour and free of copy-paste.
+ * Claude Code status bars (follow-up, work, …) via the single-host model
+ * (see host/statusline-host.js). Each bar's installer is a thin wrapper that
+ * supplies its own renderer path, fragment name, label, and codex note; the
+ * host + settings.json plumbing lives here so the bars stay byte-identical in
+ * behaviour and free of copy-paste.
+ *
+ * The host at ~/.claude/statusline-host.sh owns the single statusLine slot at a
+ * fixed, checkout-independent path and renders every registered fragment, so
+ * installing/removing one bar never clobbers the others and new tabs/sessions
+ * pick it up with no reinstall.
  */
-
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
 const { detectRuntime } = require('../runtime');
+const host = require('./host/statusline-host');
 
+// Kept for back-compat with callers/tests that referenced the settings path.
 const SETTINGS = path.join(os.homedir(), '.claude', 'settings.json');
 
-const loadCfg = () => {
-  try {
-    return JSON.parse(fs.readFileSync(SETTINGS, 'utf8'));
-  } catch {
-    return {};
-  }
-};
-const persist = (cfg) => {
-  fs.mkdirSync(path.dirname(SETTINGS), { recursive: true });
-  fs.writeFileSync(SETTINGS, `${JSON.stringify(cfg, null, 2)}\n`);
-};
-const bar = (cmd) => ({ type: 'command', command: cmd, padding: 0, refreshInterval: 3 });
-const readChain = (chainFile) => {
-  try {
-    return fs.readFileSync(chainFile, 'utf8').trim();
-  } catch {
-    return '';
-  }
-};
-
-function printMode(renderer, chainFile, write) {
-  const cur = (loadCfg().statusLine || {}).command || '(none)';
+function printMode(fragment, renderer, write) {
+  const s = host.state(fragment);
   write(
-    `renderer: ${renderer} (exists=${fs.existsSync(renderer)})\n` +
-      `current:  ${cur}\n` +
-      `chained:  ${readChain(chainFile) || '(none)'}\n`
+    `renderer:      ${renderer} (exists=${fs.existsSync(renderer)})\n` +
+      `host:          ${s.hostPath}${s.hostExists ? '' : ' (MISSING)'}\n` +
+      `current slot:  ${s.currentSlot}\n` +
+      `host active:   ${s.registered ? 'yes' : 'no'}\n` +
+      `fragment:      ${s.myTarget}\n` +
+      `all fragments: ${s.allFragments.join(', ') || '(none)'}\n`
   );
 }
 
-function removeMode(label, chainFile, write) {
-  const cfg = loadCfg();
-  const prev = readChain(chainFile);
-  if (prev) cfg.statusLine = bar(prev);
-  else delete cfg.statusLine;
-  persist(cfg);
-  try {
-    fs.unlinkSync(chainFile);
-  } catch {
-    /* nothing to clear */
-  }
-  write(`${label} status bar removed${prev ? ` — restored ${prev}` : ''}\n`);
+function removeMode(label, fragment, write) {
+  host.remove(fragment);
+  write(`${label} status bar removed (${fragment}); other bars untouched\n`);
 }
 
-function registerMode(label, renderer, rendererName, chainFile, write) {
-  const cfg = loadCfg();
-  const cur = (cfg.statusLine || {}).command;
-  if (cur && !cur.includes(rendererName)) {
-    fs.mkdirSync(path.dirname(chainFile), { recursive: true });
-    fs.writeFileSync(chainFile, `${cur}\n`); // chain the existing bar beneath ours
-  }
-  cfg.statusLine = bar(renderer);
-  persist(cfg);
-  write(`${label} status bar registered -> ${renderer}\n`);
+function registerMode(label, renderer, fragment, write) {
+  host.register(fragment, renderer);
+  write(
+    `${label} status bar registered -> ${renderer}\n` +
+      `host owns the slot at ${host.HOST_PATH} — new tabs pick it up automatically.\n`
+  );
 }
 
 /**
@@ -77,8 +54,7 @@ function registerMode(label, renderer, rendererName, chainFile, write) {
  * @param {string} opts.mode process.argv[2]
  * @param {string} opts.label human label, e.g. 'work' / 'follow-up'
  * @param {string} opts.renderer absolute path to the bar's .sh renderer
- * @param {string} opts.rendererName basename used to detect "already ours"
- * @param {string} opts.chainFile absolute path to this bar's chain file
+ * @param {string} opts.fragment registry fragment name, e.g. '30-followup.cmd'
  * @param {string} opts.codexNote CLI-alternative text for the codex refusal
  * @param {(s:string)=>void} [opts.write] output sink (defaults to stdout)
  * @param {()=>never} [opts.exit] exit fn (defaults to process.exit)
@@ -98,9 +74,9 @@ function runStatuslineInstaller(opts) {
     );
     return exit(0);
   }
-  if (opts.mode === '--print') return printMode(opts.renderer, opts.chainFile, write);
-  if (opts.mode === '--remove') return removeMode(opts.label, opts.chainFile, write);
-  return registerMode(opts.label, opts.renderer, opts.rendererName, opts.chainFile, write);
+  if (opts.mode === '--print') return printMode(opts.fragment, opts.renderer, write);
+  if (opts.mode === '--remove') return removeMode(opts.label, opts.fragment, write);
+  return registerMode(opts.label, opts.renderer, opts.fragment, write);
 }
 
 module.exports = { runStatuslineInstaller, SETTINGS };

--- a/plugins/work/scripts/workflows/work/statusline/__tests__/install-work-statusline-runtime.test.js
+++ b/plugins/work/scripts/workflows/work/statusline/__tests__/install-work-statusline-runtime.test.js
@@ -64,38 +64,35 @@ describe('install-work-statusline runtime guard', () => {
     assert.equal(fs.existsSync(settingsPath(home)), false);
   });
 
-  it('claude: registers the renderer', async () => {
+  const hostPath = (home) => path.join(home, '.claude', 'statusline-host.sh');
+  const fragPath = (home, name) => path.join(home, '.claude', 'statuslines', name);
+
+  it('claude: installs the shared host and drops the work fragment', async () => {
     const home = freshHome();
     const { code, stdout } = await runInstaller([], { home, runtime: 'claude' });
     assert.equal(code, 0, stdout);
-    assert.equal(stdout, `work status bar registered -> ${RENDERER}\n`);
+    assert.match(stdout, /^work status bar registered -> /);
     const settings = JSON.parse(fs.readFileSync(settingsPath(home), 'utf8'));
     assert.deepEqual(settings.statusLine, {
       type: 'command',
-      command: RENDERER,
+      command: hostPath(home),
       padding: 0,
       refreshInterval: 3,
     });
+    assert.equal(fs.existsSync(hostPath(home)), true);
+    assert.equal(fs.readFileSync(fragPath(home, '20-work.cmd'), 'utf8').trim(), RENDERER);
   });
 
-  it('claude: chains an existing (e.g. follow-up) bar, --remove restores it', async () => {
+  it('claude: co-exists with a sibling bar; --remove drops only the work fragment', async () => {
     const home = freshHome();
-    fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
-    fs.writeFileSync(
-      settingsPath(home),
-      `${JSON.stringify({ statusLine: { type: 'command', command: '/some/followup-statusline.sh' } })}\n`
-    );
     await runInstaller([], { home, runtime: 'claude' });
-    // chained the prior bar
-    const chained = fs.readFileSync(
-      path.join(home, '.cache', 'work', 'statusline-chain.cmd'),
-      'utf8'
-    );
-    assert.equal(chained.trim(), '/some/followup-statusline.sh');
-    // --remove restores it as the sole bar
+    // A sibling bar (e.g. follow-up) registered its own fragment.
+    fs.writeFileSync(fragPath(home, '30-followup.cmd'), '/some/followup-statusline.sh\n');
     const { stdout } = await runInstaller(['--remove'], { home, runtime: 'claude' });
-    assert.equal(stdout, 'work status bar removed — restored /some/followup-statusline.sh\n');
+    assert.match(stdout, /work status bar removed/);
+    assert.equal(fs.existsSync(fragPath(home, '20-work.cmd')), false);
+    assert.equal(fs.existsSync(fragPath(home, '30-followup.cmd')), true);
     const settings = JSON.parse(fs.readFileSync(settingsPath(home), 'utf8'));
-    assert.equal(settings.statusLine.command, '/some/followup-statusline.sh');
+    assert.equal(settings.statusLine.command, hostPath(home));
   });
 });

--- a/plugins/work/scripts/workflows/work/statusline/install-work-statusline.js
+++ b/plugins/work/scripts/workflows/work/statusline/install-work-statusline.js
@@ -3,21 +3,19 @@
 /**
  * install-work-statusline.js — register/remove the /work status bar.
  *
- *   (no args)   register work-statusline.sh as the Claude Code statusLine,
- *               preserving any existing bar (e.g. the follow-up bar) into the
- *               chain file so it renders BENEATH the work line
- *   --print     show resolved renderer path + current/chained config
- *   --remove    unregister and restore the chained bar
+ *   (no args)   register the work bar as a fragment under the shared host
+ *   --print     show resolved renderer path + current/host config
+ *   --remove    remove only the work fragment (other bars untouched)
  *
- * All settings.json / chain plumbing (and the codex guard) lives in the shared
+ * All host + settings.json plumbing (and the codex guard) lives in the shared
  * lib/statusline/install-statusline.js. Renderer path resolves from __dirname
  * (never process.env.CLAUDE_PLUGIN_ROOT).
  *
- * Install order for the full stack: maestro → follow-up → work, so the work bar
- * is outermost and chains follow-up (which chains maestro).
+ * Fragment order (filename sort) stacks the bars: maestro (10) → work (20) →
+ * follow-up (30) → qc (40), all rendered by the one host — no install-order
+ * dependency, no clobbering.
  */
 const path = require('path');
-const os = require('os');
 
 const { runStatuslineInstaller } = require('../../lib/statusline/install-statusline');
 
@@ -25,8 +23,7 @@ runStatuslineInstaller({
   mode: process.argv[2],
   label: 'work',
   renderer: path.join(__dirname, 'work-statusline.sh'),
-  rendererName: 'work-statusline.sh',
-  chainFile: path.join(os.homedir(), '.cache', 'work', 'statusline-chain.cmd'),
+  fragment: '20-work.cmd',
   codexNote:
     'On codex, /statusline configures built-in fields only and /status prints session\n' +
     'info — neither renders /work state. Watch it from the CLI instead:\n' +

--- a/plugins/work/skills/install-followup-statusline/SKILL.md
+++ b/plugins/work/skills/install-followup-statusline/SKILL.md
@@ -51,19 +51,25 @@ Line format (one segment per actively-running follow-up in this worktree):
 🔄 follow-up #<pr> · <step> · <status · N/40 · ✅ ╎ 🔴 ╎ 💬>
 ```
 
-It is scoped to the session sitting in the PR's worktree, and **chains** any
-previously-registered status line (e.g. the maestro bar) beneath it.
+It is scoped to the session sitting in the PR's worktree, and registers through the
+**shared statusline host** (`~/.claude/statusline-host.sh`) that owns Claude Code's
+single statusLine slot and renders every bar (maestro 🎼, work ⚙, follow-up 🔄, qc 🔬).
+Installing only drops the follow-up **fragment** — it never clobbers the other bars,
+and the fixed host path means new tabs/sessions pick it up with no reinstall.
 
 ## Commands
 
 - **Install:** `node "${CLAUDE_PLUGIN_ROOT}/scripts/workflows/follow-up/statusline/install-followup-statusline.js"`
 - **Show resolved paths + current config:** `... install-followup-statusline.js --print`
-- **Remove (restore the chained line):** `... install-followup-statusline.js --remove`
+- **Remove (drop just the follow-up bar):** `... install-followup-statusline.js --remove`
 
 After installing, run `/reload-plugins` (or wait for the next refresh tick).
 
 ## How it fits together
 
+- **Host:** `~/.claude/statusline-host.sh` — the single registered statusLine; renders
+  every fragment under `~/.claude/statuslines/*.cmd` in filename order.
+- **Fragment:** `~/.claude/statuslines/30-followup.cmd` — one line, the path to this
+  plugin's renderer. Owned solely by the follow-up installer.
 - **Renderer:** `scripts/workflows/follow-up/statusline/followup-statusline.sh` → `followup-statusline.js`.
 - **Data source:** the plugin's existing `<TASKS_BASE>/<ticket>/.follow-up-state.json` + `.follow-up-orchestrator.pid` (no files created by the bar).
-- **Chain file:** `~/.cache/followup/statusline-chain.cmd` holds the prior status line command; the renderer runs it beneath the follow-up line.

--- a/plugins/work/skills/install-work-statusline/SKILL.md
+++ b/plugins/work/skills/install-work-statusline/SKILL.md
@@ -56,26 +56,29 @@ Line format (one segment for the run owned by this session):
   **green** ≤ budget · **yellow** ≤ 2× budget · **red** > 2× budget.
 
 **Follow-up hand-off.** While the run is on the `follow_up` step the work line
-goes empty so the chained 🔄 follow-up bar is the only line shown; when the run
-advances to `ci` the work bar returns. The two are mutually exclusive by
-design, so installing both is safe.
+goes empty so the 🔄 follow-up bar is the only line shown; when the run advances
+to `ci` the work bar returns. The two are mutually exclusive by design, so
+installing both is safe.
 
 ## Commands
 
 - **Install:** `node "${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work/statusline/install-work-statusline.js"`
 - **Show resolved paths + current config:** `... install-work-statusline.js --print`
-- **Remove (restore the chained line):** `... install-work-statusline.js --remove`
+- **Remove (drop just the work bar):** `... install-work-statusline.js --remove`
 
 After installing, run `/reload-plugins` (or wait for the next refresh tick).
 
-For the full stack, install **maestro → follow-up → work** in that order, so the
-work bar is outermost and chains follow-up (which chains maestro).
+Install any subset of **maestro → work → follow-up → qc** in any order — the
+shared host renders whatever is registered, stacked by fragment name (10/20/30/40).
 
 ## How it fits together
 
+- **Host:** `~/.claude/statusline-host.sh` — the single registered statusLine; renders
+  every fragment under `~/.claude/statuslines/*.cmd` in filename order.
+- **Fragment:** `~/.claude/statuslines/20-work.cmd` — one line, the path to this
+  plugin's renderer. Owned solely by the work installer.
 - **Renderer:** `scripts/workflows/work/statusline/work-statusline.sh` → `work-statusline.js`.
 - **Data source:** the engine's existing `<TASKS_BASE>/<ticket>/.work-state.json` + `.work.pid` (no files created by the bar).
-- **Chain file:** `~/.cache/work/statusline-chain.cmd` holds the prior status line command; the renderer runs it beneath the work line.
 
 ## Codex
 

--- a/scripts/sync-vendored.js
+++ b/scripts/sync-vendored.js
@@ -77,6 +77,13 @@ const VENDOR_SETS = [
     master: 'factories/pathSafe',
     vendorDirs: ['plugins/heimdall/lib/pathSafe'],
   },
+  {
+    master: 'factories/statusline-host',
+    vendorDirs: [
+      'plugins/maestro/skills/install/scripts/lib',
+      'plugins/work/scripts/workflows/lib/statusline/host',
+    ],
+  },
 ];
 
 const BANNER_PREFIX = '// GENERATED — edit ';


### PR DESCRIPTION
## Existing Behavior

- Claude Code exposes exactly ONE `statusLine` slot in `settings.json`. Each plugin installer (maestro, work, follow-up, qc) overwrote that slot with its own renderer and chained only the immediately prior bar — so whichever plugin was installed last won, and users had to reinstall on every new session.
- The maestro conductor daemon called `writeActiveMarker()` once at startup, requiring `TICKET_PREFIX` to be set in the environment. Since the daemon is launched in a separate process that frequently lacks that variable, no marker was written and the maestro status bar stayed blank.

## Intended New Behavior

- A single fixed host script (`~/' + claudeDir + '/statusline-host.sh`) permanently owns the `statusLine` slot. At render time it reads every `~/' + claudeDir + '/statuslines/<NN>-<name>.cmd` fragment in filename order and outputs each bar line. Plugins install/remove only their own fragment (10-maestro, 20-work, 30-followup, 40-qc), so no installer ever clobbers another bar and every new tab picks up the full stack automatically without reinstall.
- `writeActiveMarker()` is extracted to `lib/maestro-conduct/active-marker.js` and called on every tick (not just startup). It derives the fleet prefix by scanning live `<PREFIX>-<id>-work` tmux sessions instead of relying on `TICKET_PREFIX`, honoring the env var only as an additive override. The marker self-heals as agents come up.
- The canonical `statusline-host.js` lives in `factories/statusline-host/` and is sync-vendored into each plugin `lib/` via `scripts/sync-vendored.js`; the quality gate exclusion list is updated to allow the byte-identical copies.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Full quality gate verification:

1. `pnpm quality` — all suites pass (maestro install-statusline runtime, work install-work-statusline runtime, follow-up install-followup-statusline runtime, active-marker unit tests, maestro-conduct e2e, quality parity spec).
2. `node scripts/sync-vendored.js --check` — reports zero drift between `factories/statusline-host/statusline-host.js` and the vendored copies in each plugin `lib/`.
3. `biome check` — zero lint/format violations on all changed files.

Manual smoke:

1. Install the maestro bar: `node plugins/maestro/skills/install/scripts/install-statusline.js`
   - Verify `settings.json` `.statusLine.command` points at the fixed host script (not the renderer directly).
   - Verify `10-maestro.cmd` exists in the statuslines registry and contains the absolute path to `maestro-statusline.sh`.
2. Install a second bar (e.g. work): `node plugins/work/workflows/lib/statusline/install-statusline.js`
   - Verify `20-work.cmd` is created in the registry.
   - Verify the `statusLine.command` slot is still the fixed host (unchanged).
3. Remove the maestro bar: `node plugins/maestro/skills/install/scripts/install-statusline.js --remove`
   - Verify `10-maestro.cmd` is gone but `20-work.cmd` and the host slot are untouched.
4. Launch the maestro conductor without `TICKET_PREFIX` set, with active `<PREFIX>-<id>-work` tmux sessions running.
   - Verify a marker file appears under `~/.cache/maestro/active/` within one tick (~3 s) and the maestro bar shows the fleet.

### Test Results

All tests pass locally (active-marker unit tests, install-statusline runtime tests for maestro/work/follow-up, maestro-conduct e2e, quality parity spec). `sync-vendored --check` reports clean. Biome reports zero violations.

Closes #700