### PR TITLE
fix(work): pin biome in pre-commit + bump, end manifest churn (#704)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,40 +14,21 @@
       "source": "./plugins/work",
       "description": "Orchestrated /work command with pre-computed action plans",
       "category": "workflow",
-      "tags": [
-        "workflow",
-        "jira",
-        "orchestrator",
-        "state-machine",
-        "automation"
-      ]
+      "tags": ["workflow", "jira", "orchestrator", "state-machine", "automation"]
     },
     {
       "name": "synapsys",
       "source": "./plugins/synapsys",
       "description": "Context-triggered memory injection — memories declare event hooks + trigger patterns and are injected when matched",
       "category": "memory",
-      "tags": [
-        "memory",
-        "hooks",
-        "injection",
-        "context",
-        "recall"
-      ]
+      "tags": ["memory", "hooks", "injection", "context", "recall"]
     },
     {
       "name": "maestro",
       "source": "./plugins/maestro",
       "description": "Multi-agent orchestrator — bootstraps per-ticket tmux sessions, conducts them (silence detection + auto-restart), and surfaces real prompts to the operator",
       "category": "orchestration",
-      "tags": [
-        "orchestrate",
-        "conduct",
-        "agents",
-        "tmux",
-        "workflow",
-        "multi-agent"
-      ]
+      "tags": ["orchestrate", "conduct", "agents", "tmux", "workflow", "multi-agent"]
     },
     {
       "name": "heimdall",

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -28,6 +28,19 @@ jobs:
         with:
           node-version: 20
 
+      # Install deps so bump-version.js can re-format the rewritten manifests
+      # with the REPO-PINNED biome. Without node_modules the bump would push
+      # JSON.stringify's multi-line arrays straight to main — which CI's format
+      # gate then rejects on the next PR — the manifest-format churn (#704).
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts
+
       - name: Determine bump type from commit message
         id: bump-type
         # Conventional Commits → semver:
@@ -58,6 +71,13 @@ jobs:
           # push range. Workspace + marketplace manifests bump unconditionally.
           BUMP_RANGE: ${{ github.event.before }}..${{ github.sha }}
         run: node plugins/work/scripts/workflows/lib/scripts/bump-version.js ${{ steps.bump-type.outputs.type }}
+
+      # The SAME format gate CI runs on PRs (`biome format .`), here as a hard
+      # gate BEFORE the release commit — so a mis-formatted manifest can never
+      # be pushed to main. bump-version.js already formats what it writes; this
+      # fails the workflow if anything is still unformatted (#704).
+      - name: Verify formatting (biome)
+        run: pnpm format:check
 
       - name: Commit and push
         run: |

--- a/plugins/maestro/.claude-plugin/plugin.json
+++ b/plugins/maestro/.claude-plugin/plugin.json
@@ -6,12 +6,5 @@
     "name": "Custom",
     "email": "custom@local"
   },
-  "keywords": [
-    "orchestrate",
-    "conduct",
-    "agents",
-    "tmux",
-    "workflow",
-    "multi-agent"
-  ]
+  "keywords": ["orchestrate", "conduct", "agents", "tmux", "workflow", "multi-agent"]
 }

--- a/plugins/synapsys/.claude-plugin/plugin.json
+++ b/plugins/synapsys/.claude-plugin/plugin.json
@@ -6,11 +6,5 @@
     "name": "Custom",
     "email": "custom@local"
   },
-  "keywords": [
-    "memory",
-    "hooks",
-    "injection",
-    "context",
-    "recall"
-  ]
+  "keywords": ["memory", "hooks", "injection", "context", "recall"]
 }

--- a/plugins/work/scripts/hooks/pre-commit
+++ b/plugins/work/scripts/hooks/pre-commit
@@ -1,6 +1,32 @@
-#!/bin/sh
-# Pre-commit hook: format staged JS/JSON files with biome
-# Install: git config core.hooksPath scripts/hooks
+#!/usr/bin/env bash
+# Pre-commit hook: format staged JS/JSON files with the REPO-PINNED biome.
+# Install: git config core.hooksPath plugins/work/scripts/hooks
+#
+# Runs under bash (not /bin/sh): the partial-stage guard reads a NUL-delimited
+# list with `read -d ''`, which is a bash builtin option — under dash it errors
+# "Illegal option -d" and the guard silently no-ops.
+#
+# CRITICAL — use the workspace-pinned @biomejs/biome, never `npx biome`.
+# `npx biome` resolves the BARE name `biome` from the registry whenever
+# node_modules is absent (a fresh clone, the release-bump bot, or any commit
+# made without a prior `pnpm install`) and fetches an UNRELATED squatted
+# `biome@0.3.x` package. That wrong tool formats JSON differently — it does not
+# collapse short arrays the way CI's pinned @biomejs/biome@2.x does — so a
+# commit formatted by the hook could still be rejected by CI's format gate.
+# Combined with `bump-version.js` writing manifests via JSON.stringify (which
+# expands every array multi-line), that mismatch made the plugin manifests
+# churn between multi-line and single-line `keywords`/`typesVersions` arrays on
+# every release bump. This hook now resolves the pinned binary explicitly and
+# FAILS LOUDLY when it is missing — it never formats with an unpinned tool, and
+# never lets unformatted JSON ship. Bypass the whole hook with SKIP_PRECOMMIT=1.
+
+if [ "${SKIP_PRECOMMIT:-}" = "1" ]; then
+  echo "[pre-commit] skipped (SKIP_PRECOMMIT=1)"
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+BIOME="$REPO_ROOT/node_modules/.bin/biome"
 
 # Collect staged JS/JSON files (NUL-delimited for safe filename handling)
 STAGED_FILE=$(mktemp)
@@ -23,13 +49,29 @@ if [ -n "$PARTIAL" ]; then
   exit 1
 fi
 
-# Format staged files in place (NUL-delimited)
-if ! xargs -0 npx biome format --write <"$STAGED_FILE"; then
+# Refuse to format with anything but the pinned biome. Failing here blocks the
+# commit with a clear remedy instead of silently using the wrong `npx biome`.
+if [ ! -x "$BIOME" ]; then
+  echo "pre-commit: pinned biome not found at node_modules/.bin/biome."
+  echo "Run 'pnpm install' first — refusing to format with an unpinned 'npx biome'."
+  exit 1
+fi
+
+# Format staged files in place (NUL-delimited) with the pinned biome.
+if ! xargs -0 "$BIOME" format --write <"$STAGED_FILE"; then
   echo "pre-commit: biome format failed — commit blocked"
   exit 1
 fi
 
 # Re-stage formatted files (NUL-delimited)
 xargs -0 git add <"$STAGED_FILE"
+
+# Belt-and-suspenders: verify the staged snapshot is byte-clean per the pinned
+# biome, so a commit can NEVER carry formatting CI's format gate would reject.
+if ! xargs -0 "$BIOME" format <"$STAGED_FILE" >/dev/null 2>&1; then
+  echo "pre-commit: staged files still not biome-clean after format — commit blocked."
+  echo "This should not happen; run 'node_modules/.bin/biome format --write' on the listed files."
+  exit 1
+fi
 
 exit 0

--- a/plugins/work/scripts/workflows/lib/scripts/bump-version.js
+++ b/plugins/work/scripts/workflows/lib/scripts/bump-version.js
@@ -220,16 +220,47 @@ function main() {
   logBumpPlan({ range, touched, allPlugins, pluginsToBump, skippedPlugins });
 
   const allTargets = [...ALWAYS_BUMP, ...pluginsToBump];
+  const writtenPaths = [];
   for (const file of allTargets) {
     const filePath = path.join(ROOT, file.path);
     const content = JSON.parse(fs.readFileSync(filePath, 'utf8'));
     const old = file.get(content);
     file.set(content, newVersion);
     fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + '\n');
+    writtenPaths.push(filePath);
     console.log(`  ${file.label}: ${old} → ${newVersion}`);
   }
 
+  formatManifests(writtenPaths);
   console.log(`\nBumped ${current} → ${newVersion}`);
+}
+
+// Re-format the rewritten manifests with the REPO-PINNED biome so the emitted
+// JSON is byte-identical to what CI's format gate (`biome format`) expects.
+// JSON.stringify(…, null, 2) expands every array onto multiple lines, but biome
+// collapses short arrays under its lineWidth — so without this step a bump
+// produces manifests CI flags as unformatted, and the next hand-format re-
+// collapses them, churning the `keywords`/`typesVersions` arrays on every
+// release. Using the pinned binary (never `npx biome`, which fetches an
+// unrelated squatted package when node_modules is absent) keeps the generator
+// in lockstep with CI and the pre-commit hook. Best-effort: a missing binary
+// warns rather than failing the bump, and the pre-commit/CI gates still catch
+// any drift.
+function formatManifests(paths) {
+  if (paths.length === 0) return;
+  const biome = path.join(ROOT, 'node_modules', '.bin', 'biome');
+  if (!fs.existsSync(biome)) {
+    console.warn(
+      `  ⚠ pinned biome not found at node_modules/.bin/biome — skipping manifest format.\n` +
+        `    Run 'pnpm install' so bumped manifests match the CI format gate.`
+    );
+    return;
+  }
+  try {
+    execFileSync(biome, ['format', '--write', ...paths], { stdio: 'inherit' });
+  } catch (err) {
+    console.warn(`  ⚠ biome format of bumped manifests failed: ${err.message}`);
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary

Plugin manifests (`.claude-plugin/marketplace.json`, `plugins/*/.claude-plugin/plugin.json`) churned between multi-line and single-line array formatting (`keywords`, `typesVersions`) on essentially every release bump — the same diff reappearing repeatedly and intermittently red-lighting the CI format gate.

## Root cause — three parts

1. **`bump-version.js` wrote manifests via `JSON.stringify(content, null, 2)`**, expanding every array multi-line. CI's biome (`@biomejs/biome@2.4.x`) collapses short arrays under its `lineWidth`, so every `chore(release): bump version` re-expanded them, CI wanted them collapsed, a hand-format collapsed them, and the next bump re-expanded — eternal flip-flop (biome CI enforcement landed in #691).
2. **The pre-commit hook formatted with `npx biome`**, which resolves the bare name `biome` from the registry whenever `node_modules` is absent (fresh clone, the release-bump bot, any commit without a prior `pnpm install`) and fetches an **unrelated squatted `biome@0.3.x` package** — a different tool that does not format like `@biomejs/biome`, so the hook could "format" with the wrong tool and still ship JSON CI rejects.
3. **The `bump-version.yml` workflow never installed dependencies**, so the bot's release commit was made with no `node_modules`: no biome to format with, no pre-commit hook, and no format check — pushing the unformatted multi-line manifests straight to main. That was the path that actually shipped the churn.
4. Latent: the hook's partial-stage guard used `read -d ''` under `#!/bin/sh` — a bashism that errors "Illegal option -d" under dash, silently disabling the guard.

## Fix — the same pinned-biome format gate at every layer

- **Pre-commit hook** (`plugins/work/scripts/hooks/pre-commit`): resolve and use the repo-pinned `node_modules/.bin/biome`; **fail loudly** if it is missing (never silently `npx` a random package); verify the staged snapshot is biome-clean before allowing the commit; switch the shebang to bash so the partial-stage guard runs.
- **`bump-version.js`**: after writing the manifests, re-format them with the pinned biome so the generator's output is already CI-canonical (best-effort — warns if the binary is absent).
- **`bump-version.yml` workflow**: install deps (so the pinned biome exists and `bump-version.js` can format), then run the **same `pnpm format:check` gate CI runs on PRs** as a hard step **before** the release commit — a mis-formatted manifest can no longer be pushed to main.
- Normalized the 3 currently-dirty manifests to biome-canonical form.

Now the generator, the pre-commit hook, the release workflow, and PR CI all use the same pinned biome and agree on formatting — the churn can no longer be produced or shipped.

## Testing

- Pre-commit hook, three scenarios: (a) dirty JSON → formatted + re-staged, exit 0, no "Illegal option"; (b) partial-staged file → blocked; (c) pinned biome missing → blocked with a clear message (no silent npx).
- `bump-version.js` run to a sentinel version → `formatManifests` fixed the manifests and `biome format .` reports the whole repo clean.
- Whole-repo `biome format .` clean; `pnpm quality` exit 0.

Closes #704
