### PR TITLE
fix(work): push -u origin HEAD so fresh worktrees push (#697)

### DIFF
--- a/plugins/work/scripts/workflows/work/scripts/__tests__/commit-and-push-first-push.integration.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/commit-and-push-first-push.integration.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// GH-697: /bootstrap creates worktrees with
+//   `git worktree add <path> -b <branch> origin/<base>`
+// which sets the new branch's upstream to origin/<base>. commit-and-push's
+// plain `git push` then dies with "The upstream branch of your current branch
+// does not match the name of your current branch" — the commit lands but the
+// push fails. The fix pushes with `git push -u origin HEAD`, which publishes
+// the branch under its own name and sets tracking (idempotent for branches
+// that already track their same-name remote branch).
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+const SCRIPT = path.join(__dirname, '..', 'commit-and-push.js');
+const BRANCH = 'gh-697-first-push';
+
+let TMP;
+let BARE;
+let SEED;
+let WORKTREE;
+let ENV;
+
+function sh(cmd, cwd) {
+  return cp
+    .execSync(cmd, { cwd, encoding: 'utf8', env: ENV, stdio: ['pipe', 'pipe', 'pipe'] })
+    .trim();
+}
+
+/** Run commit-and-push.js as a subprocess; returns { status, stdout, stderr }. */
+function runScript(args) {
+  return cp.spawnSync(process.execPath, [SCRIPT, ...args], {
+    encoding: 'utf8',
+    env: ENV,
+    timeout: 30000,
+  });
+}
+
+describe('commit-and-push — fresh /bootstrap worktree first push (GH-697)', () => {
+  before(() => {
+    TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'cap-first-push-'));
+    // Isolate git from the developer's global/system config so push.default,
+    // hooksPath, and identity are deterministic. TICKET_PROVIDER=github makes
+    // the message validator accept the `(#697)` ticket reference.
+    ENV = {
+      ...process.env,
+      HOME: TMP,
+      GIT_CONFIG_GLOBAL: os.devNull,
+      GIT_CONFIG_SYSTEM: os.devNull,
+      TICKET_PROVIDER: 'github',
+    };
+
+    BARE = path.join(TMP, 'origin.git');
+    SEED = path.join(TMP, 'seed');
+    WORKTREE = path.join(TMP, 'wt');
+    fs.mkdirSync(BARE);
+    fs.mkdirSync(SEED);
+    sh('git init --bare --initial-branch=main .', BARE);
+
+    sh('git init --initial-branch=main .', SEED);
+    sh('git config user.email "human@example.com"', SEED);
+    sh('git config user.name "Test Human"', SEED);
+    fs.writeFileSync(path.join(SEED, 'base.txt'), 'base\n');
+    sh('git add base.txt', SEED);
+    sh('git commit -m base', SEED);
+    sh(`git remote add origin ${BARE}`, SEED);
+    sh('git push origin main', SEED);
+    sh('git fetch origin', SEED);
+
+    // Create the worktree EXACTLY the way /bootstrap does (SKILL.md:120) —
+    // this is what leaves the new branch tracking origin/main.
+    sh(`git worktree add ${WORKTREE} -b ${BRANCH} origin/main`, SEED);
+  });
+
+  after(() => {
+    if (TMP && fs.existsSync(TMP)) fs.rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('repro premise: the bootstrap-style worktree tracks origin/<base>, so plain `git push` fails', () => {
+    assert.equal(sh('git rev-parse --abbrev-ref @{upstream}', WORKTREE), 'origin/main');
+    let failed = null;
+    try {
+      sh('git push', WORKTREE);
+    } catch (err) {
+      failed = err;
+    }
+    assert.ok(failed, 'expected plain `git push` to fail with an upstream mismatch');
+    assert.match(String(failed.stderr), /does not match/);
+  });
+
+  it('first push from the fresh worktree succeeds and sets same-name tracking', () => {
+    fs.writeFileSync(path.join(WORKTREE, 'change.txt'), 'change\n');
+    const r = runScript(['--cwd', WORKTREE, '-m', 'fix(work): push new branch upstream (#697)']);
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. stderr: ${r.stderr}`);
+    assert.match(r.stdout, /committed and pushed/);
+
+    // The commit reached origin under the branch's own name…
+    assert.equal(
+      sh(`git rev-parse refs/heads/${BRANCH}`, BARE),
+      sh('git rev-parse HEAD', WORKTREE)
+    );
+    // …and the worktree now tracks origin/<branch>, not origin/main.
+    assert.equal(sh('git rev-parse --abbrev-ref @{upstream}', WORKTREE), `origin/${BRANCH}`);
+  });
+
+  it('regression: a second push on the now-tracking branch still works', () => {
+    fs.writeFileSync(path.join(WORKTREE, 'change2.txt'), 'more\n');
+    const r = runScript([
+      '--cwd',
+      WORKTREE,
+      '-m',
+      'fix(work): push again on tracking branch (#697)',
+    ]);
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}. stderr: ${r.stderr}`);
+    assert.equal(
+      sh(`git rev-parse refs/heads/${BRANCH}`, BARE),
+      sh('git rev-parse HEAD', WORKTREE)
+    );
+    assert.equal(sh('git rev-parse --abbrev-ref @{upstream}', WORKTREE), `origin/${BRANCH}`);
+  });
+});

--- a/plugins/work/scripts/workflows/work/scripts/commit-and-push.js
+++ b/plugins/work/scripts/workflows/work/scripts/commit-and-push.js
@@ -99,7 +99,11 @@ function git(cwd, args) {
 function commitAndPush({ message, cwd, push }) {
   git(cwd, ['add', '-A']);
   git(cwd, ['commit', '-m', message]);
-  if (push) git(cwd, ['push']);
+  // `-u origin HEAD` publishes the branch under its own name and sets
+  // tracking. A bare `git push` dies in fresh /bootstrap worktrees, whose
+  // branch is created tracking origin/<base> (GH-697); this form is
+  // idempotent for branches already tracking their same-name remote branch.
+  if (push) git(cwd, ['push', '-u', 'origin', 'HEAD']);
 }
 
 /** CLI entry point. */


### PR DESCRIPTION
## Existing Behavior

`commit-and-push.js` pushes via a bare `git push`. When `/bootstrap` creates a worktree with `git worktree add <path> -b <branch> origin/<base>`, the new branch's upstream is set to `origin/<base>` (the base branch), not `origin/<branch>`. A bare `git push` in that context exits with "The upstream branch of your current branch does not match the name of your current branch" (exit 2). The commit lands locally but the push step silently fails, and the driver records nothing — requiring a manual `git push -u origin HEAD` to recover.

## Intended New Behavior

`commit-and-push.js` now pushes with `git push -u origin HEAD`. This publishes the branch under its own name on first push from any fresh `/bootstrap` worktree and sets tracking to `origin/<branch>`. The form is idempotent: branches that already track their same-name remote branch are unaffected.

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The fix is exercised by a new integration test that replicates the exact `/bootstrap` worktree creation sequence:

1. A bare repo and a seed clone are created in a temp directory.
2. A worktree is added with `git worktree add <path> -b <branch> origin/main` — identical to `SKILL.md:120` — leaving the new branch tracking `origin/main`.
3. Test 1 (repro premise): asserts that a bare `git push` from that worktree fails with the upstream-mismatch error.
4. Test 2 (fix): runs `commit-and-push.js --cwd <worktree> -m "..."` and asserts exit 0, the commit reaching the bare remote under the branch's own ref, and `@{upstream}` now pointing to `origin/<branch>`.
5. Test 3 (regression): runs a second push on the now-tracking branch and asserts the same success conditions.

To run locally:

```bash
node --test plugins/work/scripts/workflows/work/scripts/__tests__/commit-and-push-first-push.integration.test.js
```

### Test Results

New integration test file added: `plugins/work/scripts/workflows/work/scripts/__tests__/commit-and-push-first-push.integration.test.js`

- **repro premise** — plain `git push` fails with upstream mismatch in a bootstrap-style worktree
- **first push** — `commit-and-push.js` succeeds, sets tracking to `origin/<branch>`
- **regression** — second push on the already-tracking branch still succeeds

Closes #697