### PR TITLE
fix(work): gate session-guard reuse banner on state transitions (GH-540)

### DIFF
--- a/plugins/work/docs/hooks.md
+++ b/plugins/work/docs/hooks.md
@@ -197,6 +197,15 @@ Prevents concurrent `/work` sessions:
 - Cleans up on PreCompact/Stop events
 - Controlled by `SESSION_GUARD_ENABLED` env var
 
+The guard banner prints on state transitions only (GH-540): the first claim,
+a cwd/owner update, or any change to the persisted announce-state fingerprint.
+Repeat `init` calls with unchanged state are silent — pass `--show-guard` to
+`init` to print the current guard status on demand:
+
+```bash
+node session-guard.js init TICKET-123 /work --show-guard
+```
+
 ## Error Logging
 
 **File:** `scripts/workflows/lib/hook-error-log.js`

--- a/plugins/work/scripts/workflows/lib/__tests__/session-guard.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/session-guard.test.js
@@ -166,6 +166,74 @@ describe('session-guard', () => {
     });
   });
 
+  // ─── CLI: init — reuse banner gated on guard transitions (GH-540) ───
+
+  describe('CLI: init — guard banner prints on transitions only', () => {
+    it('first init prints the claim banner', async () => {
+      const r = await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      assert.equal(r.code, 0);
+      assert.ok(
+        r.stderr.includes(`Session guard active for ${TEST_TICKET}`),
+        'first claim should print the guard banner'
+      );
+    });
+
+    it('persists the announce-state fingerprint in the guard file', async () => {
+      await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      const session = readSession(TEST_TICKET);
+      assert.equal(typeof session.announcedState, 'string');
+      assert.ok(session.announcedState.includes(TEST_TICKET), 'fingerprint should encode ticket');
+    });
+
+    it('repeat init with unchanged state is silent', async () => {
+      await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      const r = await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      assert.equal(r.code, 0);
+      assert.equal(r.stderr.trim(), '', 'unchanged reuse tick should print nothing');
+    });
+
+    it('prints again when the guard state changes (cwd moved)', async () => {
+      await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      // Simulate the guard having been claimed from another directory.
+      const session = readSession(TEST_TICKET);
+      session.cwd = '/some/other/directory';
+      fs.writeFileSync(sessionFilePath(TEST_TICKET), JSON.stringify(session));
+
+      const r = await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      assert.equal(r.code, 0);
+      assert.ok(
+        r.stderr.includes(`Session guard for ${TEST_TICKET} updated`),
+        'state change should print the update banner'
+      );
+    });
+
+    it('announces once for a legacy guard file (no fingerprint), then goes silent', async () => {
+      await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      const session = readSession(TEST_TICKET);
+      delete session.announcedState;
+      fs.writeFileSync(sessionFilePath(TEST_TICKET), JSON.stringify(session));
+
+      const first = await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      assert.ok(
+        first.stderr.includes('already active'),
+        'legacy guard file should announce reuse once'
+      );
+      const second = await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      assert.equal(second.stderr.trim(), '', 'follow-up tick should be silent');
+    });
+
+    it('--show-guard prints the guard status even when state is unchanged', async () => {
+      await runCli(['init', TEST_TICKET, TEST_WORKFLOW]);
+      await runCli(['init', TEST_TICKET, TEST_WORKFLOW]); // now silent
+      const r = await runCli(['init', TEST_TICKET, TEST_WORKFLOW, '--show-guard']);
+      assert.equal(r.code, 0);
+      assert.ok(
+        r.stderr.includes(`Session guard active for ${TEST_TICKET}`),
+        '--show-guard should print the guard status on demand'
+      );
+    });
+  });
+
   // ─── CLI: reveal ───
 
   describe('CLI: reveal', () => {

--- a/plugins/work/scripts/workflows/lib/__tests__/session-guard.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/session-guard.test.js
@@ -11,7 +11,9 @@ const assert = require('node:assert/strict');
 const { spawnHook } = require('./_helpers/run-hook');
 
 const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'session-guard.js');
-const SESSION_DIR = path.join(require('os').tmpdir(), 'session-guard-test-' + process.pid);
+// Private per-run temp root (mkdtemp → mode 0700, unpredictable name) —
+// never write directly into the shared os.tmpdir() (insecure-temporary-file).
+const SESSION_DIR = fs.mkdtempSync(path.join(require('os').tmpdir(), 'session-guard-test-'));
 const TEST_TICKET = 'TEST-999';
 const TEST_WORKFLOW = '/work';
 

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard.js
@@ -9,7 +9,10 @@
  * 3. Blocking premature session stops via Stop hook
  *
  * CLI subcommands (called by orchestrator):
- *   init <ticketId> <workflow>   — Create session with passphrase
+ *   init <ticketId> <workflow> [--show-guard]
+ *                                — Create session with passphrase; reuse ticks
+ *                                  are silent unless the guard state changed
+ *                                  (--show-guard prints the status on demand)
  *   reveal <ticketId>            — Reveal passphrase (sets revealed=true)
  *   complete <ticketId>          — Remove session file (cleanup)
  *   finish <ticketId>            — Atomic teardown: reveal + complete
@@ -83,26 +86,30 @@ async function runHookMode(hookType) {
 }
 
 function runCli(args) {
-  switch (args[0]) {
+  // GH-540: reuse ticks are silent by default; `--show-guard` opts back into
+  // printing the guard status even when the announce-state is unchanged.
+  const showGuard = args.includes('--show-guard');
+  const positional = args.filter((arg) => arg !== '--show-guard');
+  switch (positional[0]) {
     case 'init':
-      commands.cmdInit(args[1], args[2]);
+      commands.cmdInit(positional[1], positional[2], { showGuard });
       break;
     case 'reveal':
-      commands.cmdReveal(args[1]);
+      commands.cmdReveal(positional[1]);
       break;
     case 'complete':
-      commands.cmdComplete(args[1], args[2]);
+      commands.cmdComplete(positional[1], positional[2]);
       break;
     case 'finish':
-      commands.cmdFinish(args[1]);
+      commands.cmdFinish(positional[1]);
       break;
     case 'status':
-      commands.cmdStatus(args[1]);
+      commands.cmdStatus(positional[1]);
       break;
     default:
       process.stderr.write(
         'Usage: session-guard.js <init|reveal|complete|finish|status> [args]\n' +
-          '  init <ticketId> <workflow>  — Start session guard\n' +
+          '  init <ticketId> <workflow> [--show-guard]  — Start session guard\n' +
           '  reveal <ticketId>           — Reveal passphrase\n' +
           '  complete <ticketId> [wf]    — Clear session (optional workflow filter)\n' +
           '  finish <ticketId>           — Reveal + complete (atomic teardown)\n' +

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard/commands.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard/commands.js
@@ -42,42 +42,40 @@ function guardAnnounceState(session) {
 }
 
 /**
- * Idempotent init path: an existing session for the ticket is reused, only
- * refreshing cwd and backfilling owner metadata on legacy/unstamped sessions.
- *
- * The "already active / reusing" banner is gated on guard transitions (GH-540):
- * it prints only when the announce-state fingerprint changed since the last
- * print. An unchanged tick is silent unless `showGuard` opts back in.
+ * Refresh mutable metadata on a reused session in place. Updates cwd when it
+ * changed (same ticket, different directory) and backfills owner metadata on
+ * legacy/unstamped sessions:
+ *   - owning Claude session id, so the Stop hook can scope the lock to this
+ *     terminal (prevents cross-terminal lock bleed when two sessions share
+ *     one cwd);
+ *   - owning git worktree root, so the Stop hook can scope the lock to this
+ *     checkout (prevents bleed across sibling ticket worktrees).
+ * Returns true when anything was mutated (i.e. the session needs persisting).
  */
-function refreshExistingSession(ticketId, existing, ownerSessionId, worktreeRoot, showGuard) {
-  // Update cwd if it changed (same ticket, different directory)
+function refreshSessionMetadata(existing, ownerSessionId, worktreeRoot) {
   const currentCwd = process.cwd();
   let dirty = false;
   if (existing.cwd !== currentCwd) {
     existing.cwd = currentCwd;
     dirty = true;
   }
-  // Backfill owning Claude session id on a legacy/unstamped session so the
-  // Stop hook can scope the lock to this terminal (prevents cross-terminal
-  // lock bleed when two sessions share one cwd).
   if (!existing.ownerSessionId && ownerSessionId) {
     existing.ownerSessionId = ownerSessionId;
     dirty = true;
   }
-  // Backfill the owning worktree root so the Stop hook can scope the lock to
-  // this checkout (prevents bleed across sibling ticket worktrees).
   if (!existing.worktreeRoot && worktreeRoot) {
     existing.worktreeRoot = worktreeRoot;
     dirty = true;
   }
-  const announceState = guardAnnounceState(existing);
-  const announceChanged = existing.announcedState !== announceState;
-  if (announceChanged) {
-    existing.announcedState = announceState;
-  }
-  if (dirty || announceChanged) {
-    writeSessionAtomic(ticketId, existing);
-  }
+  return dirty;
+}
+
+/**
+ * Print the reuse banner for an existing session, gated on guard transitions
+ * (GH-540): a metadata refresh or a changed announce fingerprint prints; an
+ * unchanged tick is silent unless `showGuard` opts back in.
+ */
+function printReuseBanner(ticketId, existing, dirty, announceChanged, showGuard) {
   if (dirty) {
     process.stderr.write(`Session guard for ${ticketId} updated (cwd/owner).\n`);
   } else if (announceChanged) {
@@ -89,6 +87,27 @@ function refreshExistingSession(ticketId, existing, ownerSessionId, worktreeRoot
       `Session guard active for ${ticketId} (${existing.workflow}) since ${existing.startTime}. Reusing existing session.\n`
     );
   }
+}
+
+/**
+ * Idempotent init path: an existing session for the ticket is reused, only
+ * refreshing cwd and backfilling owner metadata on legacy/unstamped sessions.
+ *
+ * The "already active / reusing" banner is gated on guard transitions (GH-540):
+ * it prints only when the announce-state fingerprint changed since the last
+ * print. An unchanged tick is silent unless `showGuard` opts back in.
+ */
+function refreshExistingSession(ticketId, existing, ownerSessionId, worktreeRoot, showGuard) {
+  const dirty = refreshSessionMetadata(existing, ownerSessionId, worktreeRoot);
+  const announceState = guardAnnounceState(existing);
+  const announceChanged = existing.announcedState !== announceState;
+  if (announceChanged) {
+    existing.announcedState = announceState;
+  }
+  if (dirty || announceChanged) {
+    writeSessionAtomic(ticketId, existing);
+  }
+  printReuseBanner(ticketId, existing, dirty, announceChanged, showGuard);
   process.exit(0);
 }
 

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard/commands.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard/commands.js
@@ -2,7 +2,9 @@
 
 /**
  * session-guard/commands.js — CLI subcommands (called by orchestrator):
- *   init <ticketId> <workflow>   — Create session with passphrase
+ *   init <ticketId> <workflow>   — Create session with passphrase (reuse ticks
+ *                                  are silent unless the guard state changed;
+ *                                  --show-guard prints the status on demand)
  *   reveal <ticketId>            — Reveal passphrase (sets revealed=true)
  *   complete <ticketId>          — Remove session file (cleanup)
  *   finish <ticketId>            — Atomic teardown: reveal + complete
@@ -24,10 +26,30 @@ const {
 } = require(path.join(__dirname, 'store'));
 
 /**
+ * Announce-state fingerprint for the guard banner (GH-540). The reuse banner
+ * prints only when this string differs from the persisted `announcedState`,
+ * i.e. on genuine guard transitions — not on every "still active" tick.
+ */
+function guardAnnounceState(session) {
+  return [
+    session.ticketId,
+    session.workflow,
+    session.startTime,
+    session.cwd,
+    session.ownerSessionId || '',
+    session.worktreeRoot || '',
+  ].join(':');
+}
+
+/**
  * Idempotent init path: an existing session for the ticket is reused, only
  * refreshing cwd and backfilling owner metadata on legacy/unstamped sessions.
+ *
+ * The "already active / reusing" banner is gated on guard transitions (GH-540):
+ * it prints only when the announce-state fingerprint changed since the last
+ * print. An unchanged tick is silent unless `showGuard` opts back in.
  */
-function refreshExistingSession(ticketId, existing, ownerSessionId, worktreeRoot) {
+function refreshExistingSession(ticketId, existing, ownerSessionId, worktreeRoot, showGuard) {
   // Update cwd if it changed (same ticket, different directory)
   const currentCwd = process.cwd();
   let dirty = false;
@@ -48,18 +70,29 @@ function refreshExistingSession(ticketId, existing, ownerSessionId, worktreeRoot
     existing.worktreeRoot = worktreeRoot;
     dirty = true;
   }
-  if (dirty) {
+  const announceState = guardAnnounceState(existing);
+  const announceChanged = existing.announcedState !== announceState;
+  if (announceChanged) {
+    existing.announcedState = announceState;
+  }
+  if (dirty || announceChanged) {
     writeSessionAtomic(ticketId, existing);
+  }
+  if (dirty) {
     process.stderr.write(`Session guard for ${ticketId} updated (cwd/owner).\n`);
-  } else {
+  } else if (announceChanged) {
     process.stderr.write(
       `Session guard already active for ${ticketId} (${existing.workflow}). Reusing existing session.\n`
+    );
+  } else if (showGuard) {
+    process.stderr.write(
+      `Session guard active for ${ticketId} (${existing.workflow}) since ${existing.startTime}. Reusing existing session.\n`
     );
   }
   process.exit(0);
 }
 
-function cmdInit(ticketId, workflow) {
+function cmdInit(ticketId, workflow, opts = {}) {
   if (!ticketId || !workflow) {
     process.stderr.write('Usage: session-guard.js init <ticketId> <workflow>\n');
     process.exit(1);
@@ -71,7 +104,7 @@ function cmdInit(ticketId, workflow) {
   // Idempotent: reuse existing session if one exists for this ticket
   const existing = readSessionFile(ticketId);
   if (existing && existing.ticketId === ticketId) {
-    refreshExistingSession(ticketId, existing, ownerSessionId, worktreeRoot);
+    refreshExistingSession(ticketId, existing, ownerSessionId, worktreeRoot, opts.showGuard);
     return;
   }
 
@@ -90,6 +123,8 @@ function cmdInit(ticketId, workflow) {
     startTime: new Date().toISOString(),
     revealed: false,
   };
+  // Stamp the announce fingerprint so the next reuse tick stays silent (GH-540).
+  session.announcedState = guardAnnounceState(session);
 
   writeSessionAtomic(ticketId, session);
   process.stderr.write(


### PR DESCRIPTION
## Existing Behavior

The session guard's `init` subcommand printed `Session guard already active for <TICKET> (/work). Reusing existing session.` on **every** call while the guard was held — regardless of whether anything had changed. In a typical long `/follow-up` cycle (push → monitor → fix review → push → monitor) this produced 8–20 identical stderr lines with zero information density, burying the rare actionable events (claim, conflict, takeover) in a wall of identical noise.

## Intended New Behavior

The reuse banner is now gated on genuine guard **state transitions**:

- **First claim** — always prints (`Session guard active for <TICKET> (/work). Locked until all steps complete.`).
- **State change** (cwd moved, owner backfilled, worktree root backfilled) — prints an update notice (`Session guard for <TICKET> updated (cwd/owner).`).
- **Unchanged tick** — **silent** by default.
- **Legacy guard file** (no `announcedState` fingerprint) — announces once on the first encounter, then stays silent.
- **`--show-guard` flag** — opts back into unconditional status printing for debugging (`node session-guard.js init <TICKET> <WF> --show-guard`).

The transition is tracked via an `announcedState` fingerprint field persisted in the guard JSON file itself. The fingerprint encodes `ticketId:workflow:startTime:cwd:ownerSessionId:worktreeRoot`; subsequent invocations compare the live fingerprint against the persisted value and print only on a mismatch.

Hook semantics (Stop, PreCompact), passphrase handling, and gate-state are untouched — this is a pure stderr observability change.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The change is in `plugins/work/scripts/workflows/lib/hooks/session-guard/commands.js` and its entrypoint `session-guard.js`. Verify manually:

1. Start a fresh `/work` session for any ticket — confirm the claim banner prints exactly once.
2. Re-invoke `node session-guard.js init <TICKET> /work` a second and third time — confirm **no output** on stderr.
3. Run `node session-guard.js init <TICKET> /work --show-guard` — confirm the status line prints even though state is unchanged.
4. Manually edit the guard file (`/tmp/claude-session-guard-<TICKET>.json`) to change `cwd` to a different path, then re-run `init` — confirm the update banner (`Session guard for <TICKET> updated (cwd/owner).`) prints.
5. Delete `announcedState` from the guard file to simulate a legacy file, re-run `init` twice — confirm the reuse message prints on the first call only, then goes silent.

### Test Results

The GH-540 transition logic is exercised by a dedicated `describe` block in `plugins/work/scripts/workflows/lib/__tests__/session-guard.test.js` (`CLI: init — guard banner prints on transitions only`, lines 171–235), covering:

- First claim prints the banner.
- `announcedState` fingerprint is persisted after first claim.
- Repeat init with unchanged state produces empty stderr.
- State change (cwd mutation) re-triggers the update banner.
- Legacy guard file (no fingerprint) announces once then goes silent.
- `--show-guard` prints the status on demand regardless of state.

A complementary dual-runtime suite (`session-guard-runtime.test.js`) pins the byte-identical Stop block message and verifies `AGENT_SESSION_ID` fallback for non-Claude runtimes.

Closes #540