### PR TITLE
feat(work): inline multi-part commit messages + auto-format (#711)

### DIFF
--- a/plugins/work/scripts/workflows/lib/hooks/enforce-agent-usage.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-agent-usage.js
@@ -104,12 +104,19 @@ This ensures consistent PR descriptions with proper analysis.`,
     message: `❌ Direct \`git commit\` is not allowed.
 
 ✅ Author your semantic message, then commit + push through the guard script — it
-   validates the format, blocks AI attribution, enforces a human git identity,
-   and pushes. It is the ONLY sanctioned commit path; nothing commits around it:
+   auto-formats whitespace/wrapping, validates the format, blocks AI attribution,
+   enforces a human git identity, and pushes. It is the ONLY sanctioned commit
+   path; it runs non-interactively (no approval step) and needs NO temp file —
+   repeat -m once per body paragraph, git-style:
 
-     node "${COMMIT_SCRIPT}" -m "type(scope): summary (#123)"
+     node "${COMMIT_SCRIPT}" -m "type(scope): imperative summary (#123)" -m "optional body paragraph"
 
-   (Use \`-F <file>\` for a multi-line message, or \`--no-push\` to commit only.)
+   Message contract (rejections repeat this):
+   • header ≤72 chars: type(scope): imperative summary — no trailing period, no emoji
+   • types: feat | fix | docs | style | refactor | test | chore | perf | ci | build
+   • a ticket ref (e.g. "(#123)") must appear somewhere in the message
+   • body lines auto-wrap at 100 chars — write freely
+   (Also accepted: --header "<title>", -F <file>, -F - for stdin, --no-push, --cwd <dir>.)
 
 💡 Amend / fixup / empty commits are exempt via --amend / --allow-empty / fixup! / squash!.`,
   },

--- a/plugins/work/scripts/workflows/work/hooks/commit-msg-rules.js
+++ b/plugins/work/scripts/workflows/work/hooks/commit-msg-rules.js
@@ -268,4 +268,12 @@ function validateMessage(message, ctx) {
   return { ok: true };
 }
 
-module.exports = { rules, validateMessage, ALLOWED_TYPES, PASS, AI_TOOL_NAMES };
+module.exports = {
+  rules,
+  validateMessage,
+  ALLOWED_TYPES,
+  PASS,
+  AI_TOOL_NAMES,
+  MAX_TITLE_LEN,
+  MAX_BODY_LINE_LEN,
+};

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/commit-and-push.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/commit-and-push.test.js
@@ -13,9 +13,12 @@ const { spawnSync } = require('child_process');
 
 const {
   parseArgs,
+  formatMessage,
+  wrapLine,
   validate,
   formatValidationFailure,
   formatIdentityFailure,
+  FORMAT_HELP,
 } = require('../commit-and-push');
 
 const SCRIPT = path.join(__dirname, '..', 'commit-and-push.js');
@@ -42,6 +45,68 @@ describe('commit-and-push — parseArgs', () => {
   it('throws a usage error when no message is provided', () => {
     assert.throws(() => parseArgs([]), /usage: commit-and-push.js/);
     assert.throws(() => parseArgs(['--no-push']), /usage: commit-and-push.js/);
+  });
+
+  it('joins repeated -m git-style: first -m is the header, the rest are body paragraphs', () => {
+    const opts = parseArgs(['-m', 'feat(x): add thing (#1)', '-m', 'first para', '-m', 'second']);
+    assert.equal(opts.message, 'feat(x): add thing (#1)\n\nfirst para\n\nsecond');
+  });
+
+  it('accepts an explicit --header with -m body paragraphs', () => {
+    const opts = parseArgs(['--header', 'fix(y): patch thing (#2)', '-m', 'why it broke']);
+    assert.equal(opts.message, 'fix(y): patch thing (#2)\n\nwhy it broke');
+  });
+
+  it('rejects mixing -F with -m/--header (which message would win is ambiguous)', () => {
+    assert.throws(() => parseArgs(['-F', '/dev/null', '-m', 'feat(x): thing (#1)']), /do not mix/);
+  });
+
+  it('throws a usage error naming the flag when a value is missing', () => {
+    assert.throws(() => parseArgs(['-m']), /-m needs a value/);
+    assert.throws(() => parseArgs(['--header']), /--header needs a value/);
+  });
+
+  it('usage errors carry the full message contract so agents pass on the first retry', () => {
+    try {
+      parseArgs([]);
+      assert.fail('expected a usage error');
+    } catch (err) {
+      assert.match(err.message, /Message contract/);
+      assert.match(err.message, /MAX 72 chars/);
+      assert.match(err.message, /feat \| fix \| docs/);
+    }
+  });
+});
+
+describe('commit-and-push — formatMessage (auto-format)', () => {
+  it('normalizes CRLF, trailing spaces, header whitespace, and blank-line runs', () => {
+    const raw =
+      '  feat(x):   add   thing (#1)  \r\n\r\n\r\nbody line  \r\n\r\n\r\n\r\nnext para\r\n\r\n';
+    assert.equal(formatMessage(raw), 'feat(x): add thing (#1)\n\nbody line\n\nnext para');
+  });
+
+  it('ensures exactly one blank line between header and body', () => {
+    assert.equal(formatMessage('feat(x): a (#1)\nbody'), 'feat(x): a (#1)\n\nbody');
+  });
+
+  it('wraps long body prose at 100 columns, preserving bullet indentation', () => {
+    const long = `- ${'word '.repeat(30).trim()}`;
+    const out = formatMessage(`feat(x): a (#1)\n\n${long}`);
+    const bodyLines = out.split('\n').slice(2);
+    assert.ok(bodyLines.length > 1, 'the long bullet is wrapped');
+    for (const line of bodyLines) assert.ok(line.length <= 100, `<=100: "${line}"`);
+    assert.match(bodyLines[0], /^- word/);
+    assert.match(bodyLines[1], /^ {2}word/, 'continuation lines align under the bullet text');
+  });
+
+  it('never rewrites the header beyond whitespace (over-long headers still reject)', () => {
+    const header = `feat(x): ${'y'.repeat(80)} (#1)`;
+    assert.equal(formatMessage(header), header);
+  });
+
+  it('wrapLine leaves unbreakable tokens (URLs) on their own line', () => {
+    const url = `https://example.com/${'a'.repeat(120)}`;
+    assert.deepEqual(wrapLine(url, 100), [url]);
   });
 });
 
@@ -82,5 +147,24 @@ describe('commit-and-push — CLI exit codes', () => {
     const r = spawnSync('node', [SCRIPT, '-m', 'not a semantic commit'], { encoding: 'utf8' });
     assert.equal(r.status, 1);
     assert.match(r.stderr, /commit rejected:/);
+  });
+
+  it('every rejection restates the full message contract (FORMAT_HELP)', () => {
+    const r = spawnSync('node', [SCRIPT, '-m', 'not a semantic commit'], { encoding: 'utf8' });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /Message contract/);
+    assert.match(r.stderr, /MAX 72 chars/);
+    assert.ok(FORMAT_HELP.includes('no approval step'));
+  });
+
+  it('reads the full message from stdin via -F - (no temp file)', () => {
+    // Invalid TYPE on purpose: proves the stdin text reached the validator
+    // (parse succeeded) without ever touching git.
+    const r = spawnSync('node', [SCRIPT, '-F', '-'], {
+      encoding: 'utf8',
+      input: 'nope(x): reach the validator (#1)\n\nbody\n',
+    });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /not an allowed commit type/);
   });
 });

--- a/plugins/work/scripts/workflows/work/scripts/commit-and-push.js
+++ b/plugins/work/scripts/workflows/work/scripts/commit-and-push.js
@@ -9,14 +9,21 @@
  * the commit contract.
  *
  * The session agent authors the message; this script is the guard that:
- *   1. validates it against the shared rules (`commit-msg-rules.js`) — semantic
- *      format, no AI attribution, ticket ID, <=72 title, imperative mood, ...;
- *   2. rejects an AI git identity (claude/codex/gemini/...) via `git-identity.js`;
- *   3. stages everything, commits under the human identity, and pushes.
+ *   1. auto-formats it mechanically (CRLF/whitespace normalization, one blank
+ *      line after the header, body lines wrapped at the validator's limit) so
+ *      agents are never bounced for formatting they could not predict;
+ *   2. validates it against the shared rules (`commit-msg-rules.js`) — semantic
+ *      format, no AI attribution, ticket ID, <=72 header, imperative mood, ...;
+ *   3. rejects an AI git identity (claude/codex/gemini/...) via `git-identity.js`;
+ *   4. stages everything, commits under the human identity, and pushes.
  *
- * Usage:
+ * Runs non-interactively: there is no confirmation/approval step.
+ *
+ * Usage (no temp file needed — git-style repeated -m):
  *   node commit-and-push.js -m "feat(scope): add thing (#123)"
- *   node commit-and-push.js -F <message-file>
+ *   node commit-and-push.js -m "feat(scope): add thing (#123)" -m "body paragraph" -m "another"
+ *   node commit-and-push.js --header "fix(scope): patch thing (#123)" -m "body paragraph"
+ *   node commit-and-push.js -F <message-file>      (or `-F -` to read stdin)
  *   node commit-and-push.js "feat(scope): add thing (#123)"   (positional)
  * Flags: --cwd <dir> (default cwd), --no-push (commit only).
  *
@@ -26,40 +33,159 @@
 
 const fs = require('fs');
 const { execFileSync } = require('child_process');
-const { validateMessage } = require('../hooks/commit-msg-rules');
+const {
+  validateMessage,
+  ALLOWED_TYPES,
+  MAX_TITLE_LEN,
+  MAX_BODY_LINE_LEN,
+} = require('../hooks/commit-msg-rules');
 const { getProviderConfig } = require('../../lib/ticket-provider');
 const { resolveGitUser, isAiIdentity } = require('../../lib/git-identity');
 
-const USAGE = 'usage: commit-and-push.js -m "<semantic message>" [--cwd <dir>] [--no-push]';
+const USAGE =
+  'usage: commit-and-push.js -m "<header>" [-m "<body paragraph>" ...] [--cwd <dir>] [--no-push]';
 
-/** Read a `-F` message file. Throws a usage error when the path is unreadable. */
+// The full message contract, printed with every usage/validation failure so an
+// agent can compose a passing message on the FIRST retry instead of probing
+// the rules one rejection at a time.
+const FORMAT_HELP = [
+  'Message contract (validated; whitespace/wrapping is auto-formatted):',
+  `  header : type(scope): imperative summary (#123) — MAX ${MAX_TITLE_LEN} chars, no trailing period, no emoji`,
+  `  types  : ${[...ALLOWED_TYPES].join(' | ')}`,
+  '  ticket : a ticket ref for the configured provider (e.g. "(#123)") must appear in the message',
+  `  body   : optional — repeat -m once per paragraph; lines are auto-wrapped at ${MAX_BODY_LINE_LEN} chars`,
+  '',
+  'Input forms (inline — no temp file; runs non-interactively, no approval step):',
+  '  -m "<header>" [-m "<body paragraph>" ...]        git-style: the FIRST -m is the header',
+  '  --header "<header>" [-m "<body paragraph>" ...]  explicit header form',
+  '  -F <file> | -F -                                 full message from a file or stdin',
+  'Flags: --cwd <dir>   --no-push (commit only)',
+].join('\n');
+
+/** Read a `-F` message file; `-` reads stdin so no temp file is ever needed. */
 function readFileArg(file) {
-  if (!file) throw new Error(USAGE);
+  if (file === '-') return fs.readFileSync(0, 'utf8');
   return fs.readFileSync(file, 'utf8');
 }
 
+// Flags that consume the next argv token.
+const VALUE_FLAGS = {
+  '-m': (opts, v) => opts.parts.push(v),
+  '--message': (opts, v) => opts.parts.push(v),
+  '--header': (opts, v) => {
+    opts.header = v;
+  },
+  '--title': (opts, v) => {
+    opts.header = v;
+  },
+  '-F': (opts, v) => {
+    opts.fileText = readFileArg(v);
+  },
+  '--file': (opts, v) => {
+    opts.fileText = readFileArg(v);
+  },
+  '--cwd': (opts, v) => {
+    opts.cwd = v;
+  },
+};
+
+/** A bare first token is the header (legacy positional form). */
+function isFirstPositional(opts) {
+  return opts.fileText === null && opts.header === null && opts.parts.length === 0;
+}
+
 /**
- * Apply the argv token at `i` to `opts`, returning the (possibly advanced) index
- * so flags that consume a value skip it on the next iteration.
+ * Apply the argv token at `i` to `opts`, returning the (possibly advanced)
+ * index so flags that consume a value skip it on the next iteration.
  */
 function applyArg(argv, i, opts) {
   const arg = argv[i];
-  if (arg === '-m' || arg === '--message') opts.message = argv[++i];
-  else if (arg === '-F' || arg === '--file') opts.message = readFileArg(argv[++i]);
-  else if (arg === '--cwd') opts.cwd = argv[++i];
-  else if (arg === '--no-push') opts.push = false;
-  else if (opts.message === null && !arg.startsWith('-')) opts.message = arg;
+  const handler = VALUE_FLAGS[arg];
+  if (handler) {
+    const value = argv[++i];
+    if (value === undefined) throw new Error(`${arg} needs a value\n${USAGE}\n\n${FORMAT_HELP}`);
+    handler(opts, value);
+    return i;
+  }
+  if (arg === '--no-push') {
+    opts.push = false;
+    return i;
+  }
+  if (!arg.startsWith('-') && isFirstPositional(opts)) opts.parts.push(arg);
   return i;
+}
+
+/** Join header + `-m` body paragraphs (or take the `-F` text verbatim). */
+function assembleMessage(opts) {
+  if (opts.fileText !== null) {
+    if (opts.header !== null || opts.parts.length) {
+      throw new Error(`-F carries the full message — do not mix it with -m/--header\n${USAGE}`);
+    }
+    return opts.fileText;
+  }
+  const parts = [...opts.parts];
+  const header = opts.header !== null ? opts.header : parts.shift();
+  if (!header || !header.trim()) throw new Error(`${USAGE}\n\n${FORMAT_HELP}`);
+  return [header, ...parts].join('\n\n');
+}
+
+/** Greedy word-wrap of one body line at `max`, keeping an indent/bullet prefix. */
+function wrapLine(line, max) {
+  if (line.length <= max) return [line];
+  const prefix = (line.match(/^\s*(?:[-*]\s+)?/) || [''])[0];
+  const cont = ' '.repeat(prefix.length);
+  const words = line.slice(prefix.length).split(/\s+/);
+  const out = [];
+  let cur = prefix + words[0];
+  for (const word of words.slice(1)) {
+    const joined = `${cur} ${word}`;
+    if (joined.length > max) {
+      out.push(cur);
+      cur = cont + word;
+    } else {
+      cur = joined;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+/**
+ * Mechanical auto-format so agents are never bounced for whitespace they could
+ * not predict: CRLF→LF, trailing-space strip, collapsed header whitespace,
+ * exactly one blank line between header and body, single blank line between
+ * paragraphs, body lines wrapped at the validator's limit. The HEADER is never
+ * rewritten beyond whitespace — shortening a semantic title is lossy, so an
+ * over-long header still rejects (with the contract printed).
+ */
+function formatMessage(raw) {
+  const lines = String(raw)
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((l) => l.replace(/\s+$/, ''));
+  while (lines.length && !lines[0]) lines.shift();
+  const header = (lines.shift() || '').replace(/\s+/g, ' ').trim();
+  const body = [];
+  let pendingBlank = false;
+  for (const line of lines) {
+    if (!line) {
+      pendingBlank = true;
+      continue;
+    }
+    if (pendingBlank && body.length) body.push('');
+    pendingBlank = false;
+    body.push(...wrapLine(line, MAX_BODY_LINE_LEN));
+  }
+  return body.length ? `${header}\n\n${body.join('\n')}` : header;
 }
 
 /** Parse argv into `{ message, cwd, push }`. Throws a usage error on bad input. */
 function parseArgs(argv) {
-  const opts = { message: null, cwd: process.cwd(), push: true };
+  const opts = { parts: [], header: null, fileText: null, cwd: process.cwd(), push: true };
   for (let i = 0; i < argv.length; i++) {
     i = applyArg(argv, i, opts);
   }
-  if (!opts.message || !opts.message.trim()) throw new Error(USAGE);
-  return opts;
+  return { message: formatMessage(assembleMessage(opts)), cwd: opts.cwd, push: opts.push };
 }
 
 /** Render a rule-validation failure into the two-line stderr block. */
@@ -119,7 +245,7 @@ function main() {
 
   const failure = validate(opts.message, opts.cwd);
   if (failure) {
-    process.stderr.write(failure);
+    process.stderr.write(`${failure}\n${FORMAT_HELP}\n`);
     process.exit(1);
     return;
   }
@@ -141,4 +267,12 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { parseArgs, validate, formatValidationFailure, formatIdentityFailure };
+module.exports = {
+  parseArgs,
+  formatMessage,
+  wrapLine,
+  validate,
+  formatValidationFailure,
+  formatIdentityFailure,
+  FORMAT_HELP,
+};


### PR DESCRIPTION
## Existing Behavior

- `commit-and-push.js` accepts only a single `-m` value or a `-F <file>`, requiring a temp file for multi-line commit messages.
- Validation failures print only the specific rule violation — agents must probe the contract incrementally across multiple rejections.
- `commit-msg-rules.js` keeps `MAX_TITLE_LEN` and `MAX_BODY_LINE_LEN` as module-private constants, preventing other scripts from importing the authoritative limits.
- The `enforce-agent-usage.js` Semantic Commits block message gives minimal guidance, omitting the full contract, body-paragraph form, and non-interactive nature of the script.

## Intended New Behavior

- Repeated `-m` flags join git-style (first `-m` = header, each subsequent `-m` = body paragraph), plus `--header`/`--title` as an explicit header flag and `-F -` for stdin — no temp file ever needed.
- A new `formatMessage` step runs before validation: CRLF→LF, trailing-space strip, collapsed header whitespace, exactly one blank line after the header, single blank lines between paragraphs, body lines word-wrapped at the validator's 100-char limit with bullet indentation preserved. The header is never rewritten beyond whitespace.
- Every usage or validation failure now appends `FORMAT_HELP` — the full message contract (header ≤72, allowed types, ticket-ref rule, all input forms) — so an agent can compose a passing message on the first retry.
- `MAX_TITLE_LEN` and `MAX_BODY_LINE_LEN` are exported from `commit-msg-rules.js` as the single source of truth consumed by `FORMAT_HELP`.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The new inline multi-`-m` form (no temp file):

1. In any repo governed by the plugin, run:
   ```
   node plugins/work/scripts/workflows/work/scripts/commit-and-push.js \
     -m "feat(x): describe the change (#711)" \
     -m "First body paragraph explaining motivation." \
     -m "Second body paragraph with extra detail." \
     --no-push
   ```
   Expected: the commit is created; `git log -1 --format=%B` shows the header, a blank line, and each paragraph separated by a blank line.

2. Verify stdin form:
   ```
   printf 'feat(x): stdin test (#711)\n\nbody paragraph\n' | \
     node plugins/work/scripts/workflows/work/scripts/commit-and-push.js -F - --no-push
   ```
   Expected: commit created with the full message.

3. Verify auto-format: pass a message with CRLF line endings or trailing spaces — the script should normalize and pass validation rather than reject.

4. Verify rejection contract: pass a non-semantic message (e.g. `-m "bad message"`); the stderr output must include `Message contract`, `MAX 72 chars`, and the allowed types list.

5. Verify `-F` + `-m` mixing rejects: `node commit-and-push.js -F somefile -m "feat(x): thing (#1)"` must exit 1 with `do not mix`.

### Test Results

```
node --test plugins/work/scripts/workflows/work/scripts/__tests__/commit-and-push.test.js \
  plugins/work/scripts/workflows/lib/hooks/__tests__/enforce-agent-usage*.test.js \
  plugins/work/scripts/workflows/work/hooks/__tests__/commit-msg-rules.test.js

tests 58 | pass 58 | fail 0
```

Closes #711
