### PR TITLE
fix(work): gate terminal state bypass for dispatched agents (GH-695)

### DIFF
--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -74,7 +74,6 @@ plugins/work/scripts/workflows/work/lib/gherkin-task-refs.js
 plugins/work/scripts/workflows/check/agents/qa-feature-tester/qa-screenshot-validator.js
 plugins/work/scripts/workflows/work/engine/cli.js
 plugins/work/scripts/workflows/work/lib/work-actions.js
-plugins/work/scripts/workflows/lib/agent-detection.js
 plugins/work/scripts/workflows/lib/hooks/enforce-screenshot-requirement.js
 plugins/work/scripts/workflows/work/steps/implement.js
 plugins/work/scripts/workflows/work-tasks/lib/phases/draft.js

--- a/plugins/work/agents/pr-generator.md
+++ b/plugins/work/agents/pr-generator.md
@@ -62,6 +62,9 @@ You are a **read-only** agent. You can read and analyze code, but you must NEVER
 - Report the failure in your output and return control to the parent agent
 - The parent agent or user is responsible for fixing code issues
 
+## HARD BOUNDARIES — WORKFLOW STATE
+If a runner or state transition wedges, STOP and report `BLOCKED: <detail>` to the orchestrator — never invoke `work-state.js`, `session-guard.js`, or `work.workflow.js` mutating subcommands.
+
 **ALLOWED actions:**
 - Reading files (Read, Grep, Glob tools)
 - Running git commands (git diff, git log, git show, git fetch, git rebase, git push)

--- a/plugins/work/agents/pr-post-generator.md
+++ b/plugins/work/agents/pr-post-generator.md
@@ -28,6 +28,9 @@ You enhance PR descriptions with visual documentation and test results AFTER the
 - Screenshots are uploaded to the wiki page ONLY
 - The PR gets a **link** to the wiki page, NOT embedded images
 
+## HARD BOUNDARIES — WORKFLOW STATE
+If a runner or state transition wedges, STOP and report `BLOCKED: <detail>` to the orchestrator — never invoke `work-state.js`, `session-guard.js`, or `work.workflow.js` mutating subcommands.
+
 ## FABRICATION GUARD
 
 **Test-evidence rule (zero tolerance):** every `PASS`, `FAIL`, "stability run",

--- a/plugins/work/scripts/workflows/lib/__tests__/agent-detection.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/agent-detection.test.js
@@ -9,7 +9,11 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { normalizeAgentName, isRunningInAgent } = require('../agent-detection');
+const {
+  normalizeAgentName,
+  isRunningInAgent,
+  isDispatchedAgentContext,
+} = require('../agent-detection');
 
 // Transcripts are written inside a private, permission-restricted directory
 // (fs.mkdtempSync → mode 0700, unpredictable name) rather than directly in the
@@ -598,5 +602,105 @@ describe('isSubagentFromInitialPrompt — marker debug logging & fail-open', () 
   it('env var short-circuits before any transcript scan (nonexistent transcript)', () => {
     process.env.CLAUDE_CURRENT_AGENT = 'commit-writer';
     assert.ok(isRunningInAgent('/nonexistent/transcript.json', ['commit-writer']));
+  });
+});
+
+// ─── isDispatchedAgentContext — GH-695 alias-agnostic dispatched-agent gate ──
+
+describe('isDispatchedAgentContext', () => {
+  const savedEnv = {};
+  const created = [];
+
+  beforeEach(() => {
+    savedEnv.CLAUDE_CURRENT_AGENT = process.env.CLAUDE_CURRENT_AGENT;
+    delete process.env.CLAUDE_CURRENT_AGENT;
+  });
+
+  afterEach(() => {
+    if (savedEnv.CLAUDE_CURRENT_AGENT !== undefined) {
+      process.env.CLAUDE_CURRENT_AGENT = savedEnv.CLAUDE_CURRENT_AGENT;
+    } else {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+    while (created.length) {
+      const p = created.pop();
+      try {
+        fs.unlinkSync(p);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it('true when hookData.agent_type is set (known agent)', () => {
+    assert.ok(isDispatchedAgentContext(null, { agent_type: 'pr-generator' }));
+  });
+
+  it('true when hookData.agent_type is set (ANY value — alias-agnostic)', () => {
+    assert.ok(isDispatchedAgentContext(null, { agent_type: 'some-brand-new-agent' }));
+  });
+
+  it('true when CLAUDE_CURRENT_AGENT is set (any value)', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'whatever-agent';
+    assert.ok(isDispatchedAgentContext(null, {}));
+  });
+
+  it('true when the transcript path contains /subagents/', () => {
+    assert.ok(isDispatchedAgentContext('/nonexistent/subagents/agent_x.jsonl', {}));
+  });
+
+  it('true for a sidechain transcript (isSidechain marker, no attributionAgent)', () => {
+    const tmp = writeTranscript([
+      { type: 'user', isSidechain: true, message: { content: 'do the thing' } },
+    ]);
+    created.push(tmp);
+    assert.ok(isDispatchedAgentContext(tmp, {}));
+  });
+
+  it('true for a transcript carrying an attributionAgent marker', () => {
+    const tmp = writeTranscript([
+      {
+        type: 'user',
+        attributionAgent: 'work-workflow:pr-generator',
+        message: { content: 'generate the PR' },
+      },
+    ]);
+    created.push(tmp);
+    assert.ok(isDispatchedAgentContext(tmp, {}));
+  });
+
+  it('false for a bare main-session context (no env, no payload identity, plain transcript)', () => {
+    const tmp = writeTranscript([
+      { type: 'user', message: { content: 'please dispatch the pr-generator agent' } },
+    ]);
+    created.push(tmp);
+    assert.ok(!isDispatchedAgentContext(tmp, {}));
+  });
+
+  it('false when transcript is missing (fail-open at the hook)', () => {
+    assert.ok(!isDispatchedAgentContext('/nonexistent/transcript.jsonl', {}));
+  });
+
+  it('false when transcript is unparseable garbage (fail-open at the hook)', () => {
+    const tmp = path.join(TRANSCRIPT_DIR, `garbage-${process.pid}.jsonl`);
+    fs.writeFileSync(tmp, 'not json at all\n binary-ish\n{broken');
+    created.push(tmp);
+    assert.ok(!isDispatchedAgentContext(tmp, {}));
+  });
+
+  it('false when the sidechain marker sits beyond the first 10 lines (initial-markers window)', () => {
+    const lines = [];
+    for (let i = 0; i < 11; i++) {
+      lines.push({ type: 'user', message: { content: `line ${i}` } });
+    }
+    lines.push({ type: 'user', isSidechain: true, message: { content: 'late marker' } });
+    const tmp = writeTranscript(lines);
+    created.push(tmp);
+    assert.ok(!isDispatchedAgentContext(tmp, {}));
+  });
+
+  it('false for null transcript and empty hookData', () => {
+    assert.ok(!isDispatchedAgentContext(null, {}));
+    assert.ok(!isDispatchedAgentContext(undefined, undefined));
   });
 });

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -2352,6 +2352,148 @@ describe('enforce-step-workflow', () => {
       assert.ok(stderr.includes('BLOCKED'));
     });
 
+    // ─── GH-695: task-advance dropped from SAFE_SUBCOMMANDS ─────────────────
+    // advanceTask blind-marks the current task completed; its legitimate
+    // callers are driver-internal execFileSync spawns that never traverse
+    // PreToolUse. A Bash call is never legitimate — in ANY context.
+
+    it('blocks direct work-state.js task-advance call at implement step (GH-695)', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} task-advance ${TEST_TICKET}` },
+        },
+        'PreToolUse'
+      );
+      assert.equal(code, 2, 'direct task-advance should be blocked');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('blocks direct work-state.js task-advance call even at terminal step (GH-695)', async () => {
+      writeWorkState(makeStepStatus('complete', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} task-advance ${TEST_TICKET}` },
+        },
+        'PreToolUse'
+      );
+      assert.equal(code, 2, 'task-advance has no terminal bypass — blocked in every context');
+      assert.ok(stderr.includes('BLOCKED'));
+    });
+
+    it('still allows work-state.js task-current command (GH-695 regression)', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} task-current ${TEST_TICKET}` },
+        },
+        'PreToolUse'
+      );
+      assert.equal(code, 0, 'task-current is read-only and stays allowed');
+    });
+
+    it('still allows work-state.js task-get command (GH-695 regression)', async () => {
+      writeWorkState(makeStepStatus('implement', WORK_STEPS));
+
+      const { code } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} task-get ${TEST_TICKET} 1` },
+        },
+        'PreToolUse'
+      );
+      assert.equal(code, 0, 'task-get is read-only and stays allowed');
+    });
+
+    // ─── GH-695: terminal complete bypass rejects dispatched-agent contexts ──
+    // The GH-276 bypass is orchestrator-only. Any dispatched-agent signal
+    // (payload agent_type, CLAUDE_CURRENT_AGENT, /subagents/ path, sidechain
+    // transcript markers) rejects the bypass even at the genuine terminal step.
+
+    it('blocks work-state.js complete at terminal step when payload carries agent_type (GH-695)', async () => {
+      writeWorkState(makeStepStatus('complete', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          agent_type: 'pr-generator',
+          tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET}` },
+        },
+        'PreToolUse'
+      );
+      assert.equal(code, 2, 'dispatched-agent payload must reject the terminal bypass');
+      assert.ok(stderr.includes('BLOCKED'), `expected BLOCKED in stderr, got: ${stderr}`);
+      assert.ok(
+        stderr.includes('orchestrator'),
+        `block message should direct the agent to report BLOCKED to the orchestrator, got: ${stderr}`
+      );
+      assert.ok(
+        stderr.includes('CLAUDE_CURRENT_AGENT'),
+        `block message should name CLAUDE_CURRENT_AGENT for misclassified orchestrators, got: ${stderr}`
+      );
+    });
+
+    it('blocks work-state.js complete at terminal step when CLAUDE_CURRENT_AGENT is set (GH-695)', async () => {
+      writeWorkState(makeStepStatus('complete', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET}` },
+        },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'pr-generator' }
+      );
+      assert.equal(code, 2, 'CLAUDE_CURRENT_AGENT must reject the terminal bypass');
+      assert.ok(stderr.includes('BLOCKED'), `expected BLOCKED in stderr, got: ${stderr}`);
+    });
+
+    it('blocks work-state.js complete at terminal step from a sidechain transcript (GH-695)', async () => {
+      writeWorkState(makeStepStatus('complete', WORK_STEPS));
+      const transcriptPath = path.join(TASKS_DIR, 'sidechain-transcript.jsonl');
+      fs.writeFileSync(
+        transcriptPath,
+        `${JSON.stringify({
+          type: 'user',
+          isSidechain: true,
+          attributionAgent: 'work-workflow:pr-generator',
+          message: { content: 'generate the PR' },
+        })}\n`
+      );
+
+      const { code, stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          transcript_path: transcriptPath,
+          tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET}` },
+        },
+        'PreToolUse'
+      );
+      assert.equal(code, 2, 'sidechain transcript markers must reject the terminal bypass');
+      assert.ok(stderr.includes('BLOCKED'), `expected BLOCKED in stderr, got: ${stderr}`);
+    });
+
+    it('blocks work-state.js complete at terminal step when transcript path is under /subagents/ (GH-695)', async () => {
+      writeWorkState(makeStepStatus('complete', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          transcript_path: '/nonexistent/subagents/agent_x.jsonl',
+          tool_input: { command: `node ${WORK_STATE_PATH} complete ${TEST_TICKET}` },
+        },
+        'PreToolUse'
+      );
+      assert.equal(code, 2, 'a /subagents/ transcript path must reject the terminal bypass');
+      assert.ok(stderr.includes('BLOCKED'), `expected BLOCKED in stderr, got: ${stderr}`);
+    });
+
     it('blocks work-state.js init-subtask command', async () => {
       writeWorkState(makeStepStatus('implement', WORK_STEPS));
 
@@ -4784,6 +4926,38 @@ describe('enforce-step-workflow', () => {
         'PreToolUse'
       );
       assert.equal(code, 0, `complete should be allowed at complete step. stderr: ${stderr}`);
+    });
+
+    // ─── GH-695: terminal bypass rejects dispatched-agent contexts ──────────
+
+    it('blocks session-guard.js finish at complete step when payload carries agent_type (GH-695)', async () => {
+      writeWorkState(makeStepStatus('complete', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          agent_type: 'pr-generator',
+          tool_input: { command: `node ${SESSION_GUARD_PATH} finish ${TEST_TICKET}` },
+        },
+        'PreToolUse'
+      );
+      assert.equal(code, 2, 'dispatched-agent payload must reject the session-guard bypass');
+      assert.ok(stderr.includes('BLOCKED'), `expected BLOCKED in stderr, got: ${stderr}`);
+    });
+
+    it('blocks session-guard.js complete at complete step when CLAUDE_CURRENT_AGENT is set (GH-695)', async () => {
+      writeWorkState(makeStepStatus('complete', WORK_STEPS));
+
+      const { code, stderr } = await runHook(
+        {
+          tool_name: 'Bash',
+          tool_input: { command: `node ${SESSION_GUARD_PATH} complete ${TEST_TICKET}` },
+        },
+        'PreToolUse',
+        { CLAUDE_CURRENT_AGENT: 'pr-generator' }
+      );
+      assert.equal(code, 2, 'CLAUDE_CURRENT_AGENT must reject the session-guard bypass');
+      assert.ok(stderr.includes('BLOCKED'), `expected BLOCKED in stderr, got: ${stderr}`);
     });
 
     // ─── R1/R7: Allow safe subcommands (init, status) at any step ───────────

--- a/plugins/work/scripts/workflows/lib/agent-detection.js
+++ b/plugins/work/scripts/workflows/lib/agent-detection.js
@@ -11,6 +11,9 @@ const fs = require('fs');
 // scan). The claude scanning helpers below stay byte-for-byte — they are the
 // characterization-locked claude leg.
 const { sniffFormat, detectAgentContext } = require('./runtime/transcript');
+// Structural marker helpers + the GH-695 dispatched-agent predicate — moved
+// verbatim to ./transcript-markers (file-size burndown); re-exported below.
+const { readInitialMarkers, isDispatchedAgentContext } = require('./transcript-markers');
 
 /**
  * Normalize an agent name by stripping optional namespace prefixes and lowercasing.
@@ -239,66 +242,6 @@ function isRunningInAgent(transcriptPath, agentAliases, hookData) {
 }
 
 /**
- * Extract the prose text of a single system/user transcript entry.
- * Non-message entries and unknown content shapes yield an empty string.
- */
-function extractEntryText(entry) {
-  if (entry.type !== 'system' && entry.type !== 'user') {
-    return '';
-  }
-  const msgContent = entry.message?.content;
-  if (typeof msgContent === 'string') {
-    return msgContent;
-  }
-  if (Array.isArray(msgContent)) {
-    return msgContent.map((i) => i.text || '').join(' ');
-  }
-  return '';
-}
-
-/**
- * Read the structural subagent markers from early transcript lines.
- *
- * Mirrors the per-line JSON.parse-in-try/catch pattern used by
- * isSubagentFromTranscript. Untrusted fields are read defensively.
- *
- * @param {string[]} earlyLines - The first N raw transcript lines
- * @returns {{attributionAgent: string, isSidechain: boolean, promptText: string}}
- */
-function readInitialMarkers(earlyLines) {
-  let attributionAgent = '';
-  let isSidechain = false;
-  let promptText = '';
-
-  for (const line of earlyLines) {
-    let entry;
-    try {
-      entry = JSON.parse(line);
-    } catch {
-      continue; // skip non-JSON lines
-    }
-
-    // A sidechain flag on ANY early line marks this as a subagent transcript.
-    if (entry.isSidechain === true) {
-      isSidechain = true;
-    }
-
-    // First attributionAgent wins — it is the authoritative identity.
-    if (!attributionAgent && entry.attributionAgent) {
-      attributionAgent = String(entry.attributionAgent);
-    }
-
-    // Accumulate prose from system/user messages for the gated name check.
-    const text = extractEntryText(entry);
-    if (text) {
-      promptText = promptText ? `${promptText} ${text}` : text;
-    }
-  }
-
-  return { attributionAgent, isSidechain, promptText };
-}
-
-/**
  * Detect agent identity from the subagent's own transcript.
  *
  * A genuine Task-spawned subagent transcript carries positive structural
@@ -352,60 +295,6 @@ function isSubagentFromInitialPrompt(transcriptPath, agentAliases) {
 }
 
 /**
- * GH-695: True when the current hook context belongs to ANY dispatched
- * (sub)agent, regardless of which one — alias-agnostic, no allowlist to
- * maintain. Used by the terminal state-script bypasses, which are
- * orchestrator-only: a dispatched agent must report BLOCKED instead of
- * finishing the workflow itself.
- *
- * Signals (any one suffices):
- *   - hookData.agent_type set (any value — set by Claude Code inside a subagent)
- *   - CLAUDE_CURRENT_AGENT env var set (any value)
- *   - transcriptPath contains '/subagents/' (subagent transcript location)
- *   - structural markers (attributionAgent / isSidechain) in the first 10
- *     transcript lines, via the existing readInitialMarkers helper
- *
- * Fail direction: read/parse errors → false (fail-open at the hook). Failing
- * closed here would deadlock the terminal step with no in-band repair; the
- * completeWork script-side precondition is the backstop.
- *
- * @param {string} [transcriptPath] - Path to the session transcript
- * @param {object} [hookData] - Hook payload from Claude Code
- * @returns {boolean} true when this context is a dispatched agent
- */
-function isDispatchedAgentContext(transcriptPath, hookData) {
-  if (hookData?.agent_type) {
-    debugLog('dispatchedContext', `agent_type=${hookData.agent_type}`);
-    return true;
-  }
-  if (process.env.CLAUDE_CURRENT_AGENT) {
-    debugLog('dispatchedContext', `CLAUDE_CURRENT_AGENT=${process.env.CLAUDE_CURRENT_AGENT}`);
-    return true;
-  }
-  if (!transcriptPath) return false;
-  if (String(transcriptPath).includes('/subagents/')) {
-    debugLog('dispatchedContext', 'transcript path contains /subagents/');
-    return true;
-  }
-  try {
-    if (!fs.existsSync(transcriptPath)) return false;
-    const content = fs.readFileSync(transcriptPath, 'utf8');
-    const lines = content.trim().split('\n');
-    const { attributionAgent, isSidechain } = readInitialMarkers(lines.slice(0, 10));
-    if (attributionAgent || isSidechain === true) {
-      debugLog(
-        'dispatchedContext',
-        attributionAgent ? `attributionAgent=${attributionAgent}` : 'isSidechain marker'
-      );
-      return true;
-    }
-    return false;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Word-boundary match of any agent alias name within sidechain prompt text.
  * Boundaries avoid incidental substring hits (e.g. "qa" inside "quality").
  */
@@ -429,6 +318,6 @@ module.exports = {
   isRunningInAgent,
   isSubagentFromTranscript,
   isSubagentFromInitialPrompt,
-  isDispatchedAgentContext,
+  isDispatchedAgentContext, // GH-695 — lives in ./transcript-markers, re-exported
   normalizeAgentName,
 };

--- a/plugins/work/scripts/workflows/lib/agent-detection.js
+++ b/plugins/work/scripts/workflows/lib/agent-detection.js
@@ -352,6 +352,60 @@ function isSubagentFromInitialPrompt(transcriptPath, agentAliases) {
 }
 
 /**
+ * GH-695: True when the current hook context belongs to ANY dispatched
+ * (sub)agent, regardless of which one — alias-agnostic, no allowlist to
+ * maintain. Used by the terminal state-script bypasses, which are
+ * orchestrator-only: a dispatched agent must report BLOCKED instead of
+ * finishing the workflow itself.
+ *
+ * Signals (any one suffices):
+ *   - hookData.agent_type set (any value — set by Claude Code inside a subagent)
+ *   - CLAUDE_CURRENT_AGENT env var set (any value)
+ *   - transcriptPath contains '/subagents/' (subagent transcript location)
+ *   - structural markers (attributionAgent / isSidechain) in the first 10
+ *     transcript lines, via the existing readInitialMarkers helper
+ *
+ * Fail direction: read/parse errors → false (fail-open at the hook). Failing
+ * closed here would deadlock the terminal step with no in-band repair; the
+ * completeWork script-side precondition is the backstop.
+ *
+ * @param {string} [transcriptPath] - Path to the session transcript
+ * @param {object} [hookData] - Hook payload from Claude Code
+ * @returns {boolean} true when this context is a dispatched agent
+ */
+function isDispatchedAgentContext(transcriptPath, hookData) {
+  if (hookData?.agent_type) {
+    debugLog('dispatchedContext', `agent_type=${hookData.agent_type}`);
+    return true;
+  }
+  if (process.env.CLAUDE_CURRENT_AGENT) {
+    debugLog('dispatchedContext', `CLAUDE_CURRENT_AGENT=${process.env.CLAUDE_CURRENT_AGENT}`);
+    return true;
+  }
+  if (!transcriptPath) return false;
+  if (String(transcriptPath).includes('/subagents/')) {
+    debugLog('dispatchedContext', 'transcript path contains /subagents/');
+    return true;
+  }
+  try {
+    if (!fs.existsSync(transcriptPath)) return false;
+    const content = fs.readFileSync(transcriptPath, 'utf8');
+    const lines = content.trim().split('\n');
+    const { attributionAgent, isSidechain } = readInitialMarkers(lines.slice(0, 10));
+    if (attributionAgent || isSidechain === true) {
+      debugLog(
+        'dispatchedContext',
+        attributionAgent ? `attributionAgent=${attributionAgent}` : 'isSidechain marker'
+      );
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Word-boundary match of any agent alias name within sidechain prompt text.
  * Boundaries avoid incidental substring hits (e.g. "qa" inside "quality").
  */
@@ -375,5 +429,6 @@ module.exports = {
   isRunningInAgent,
   isSubagentFromTranscript,
   isSubagentFromInitialPrompt,
+  isDispatchedAgentContext,
   normalizeAgentName,
 };

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -46,8 +46,8 @@ process.on('unhandledRejection', (err) => {
   process.exit(didBlock ? 2 : 0);
 });
 
-// Agent detection for report file protection
-const { isRunningInAgent, normalizeAgentName } = require(
+// Agent detection for report file protection + GH-695 dispatched-agent gate
+const { isRunningInAgent, isDispatchedAgentContext, normalizeAgentName } = require(
   path.join(__dirname, '..', 'agent-detection')
 );
 const { logHookError } = require(path.join(__dirname, '..', 'hook-error-log'));
@@ -144,6 +144,7 @@ const {
   workSteps: WORK_STEPS,
   getTicketId: () => getTicketId(),
   isRunningInAgent,
+  isDispatchedAgentContext, // GH-695: terminal bypasses reject dispatched agents
   normalizeAgentName,
   hookFilename: __filename,
 });
@@ -289,14 +290,13 @@ function exitBlocked(message) {
 function runPreBlockingRules(toolName, toolInput, hookData, ticketId) {
   const cmd = String(toolInput?.command || '');
 
-  // Rule 3: Block direct writes to workflow state files (+ terminal-step bypasses)
-  const rule3 = checkStateFileRule(toolName, toolInput, ticketId);
+  // Rule 3: block state-file writes; hookData → terminal bypasses reject dispatched agents (GH-695)
+  const rule3 = checkStateFileRule(toolName, toolInput, ticketId, hookData);
   if (rule3.blocked) exitBlocked(rule3.message);
 
-  // Rule 3b: Block unsafe sub-commands on state scripts invoked via node (GH-89)
-  // Fail-open when no ticket context — nothing to protect without a workflow.
+  // Rule 3b (GH-89): unsafe state-script sub-commands. Fail-open without a ticket context.
   if (toolName === 'Bash' && ticketId) {
-    const rule3b = checkUnsafeSubcommands(cmd.trim(), ticketId);
+    const rule3b = checkUnsafeSubcommands(cmd.trim(), ticketId, hookData);
     if (rule3b) exitBlocked(rule3b.message);
   }
 

--- a/plugins/work/scripts/workflows/lib/hooks/policies/hook-config.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/hook-config.js
@@ -53,7 +53,11 @@ const SAFE_SUBCOMMANDS = {
     'add-error',
     'task-init',
     'task-current',
-    'task-advance',
+    // 'task-advance' removed (GH-695): advanceTask blind-marks the current
+    // task completed. Its legitimate callers are driver-internal execFileSync
+    // spawns (advance-gate.js, next-instruction.js, task-next.js) that never
+    // traverse PreToolUse — a Bash call is never legitimate. exemptPatterns
+    // in workflows/work/workflow-definition.js is kept aligned.
     'task-get',
   ]),
   'workflow-state.js': new Set(['get', 'resume-info', 'add-error']), // init excluded: not idempotent (resets all steps). exemptPatterns aligned.

--- a/plugins/work/scripts/workflows/lib/hooks/policies/hook-wiring.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/hook-wiring.js
@@ -21,7 +21,7 @@ const {
 } = require('./state-protection');
 const { SAFE_SUBCOMMANDS, TRUSTED_SCRIPT_DIRS, debugLogCandidatePath } = require('./hook-config');
 const { createStateLoader, getCurrentStep } = require('./workflow-context');
-const { createStateScriptGate } = require('./state-script-gate');
+const { createStateScriptGate, DISPATCHED_AGENT_GUIDANCE } = require('./state-script-gate');
 const { createAgentGateRule } = require('./agent-gate-rule');
 const { mergeAgentGatedScripts } = require('./workflow-discovery');
 
@@ -56,17 +56,26 @@ function buildProtectors(deps, loadStateFile, exemptScripts) {
   return { artifactProtector, stateFileProtector, followUpStateProtector };
 }
 
+// Command shapes covered by the terminal-step bypasses (GH-276/GH-338) — used
+// only to decide whether a still-blocked Rule 3 result deserves the GH-695
+// dispatched-agent guidance in its message.
+const TERMINAL_BYPASS_SHAPE =
+  /(?:work-state\.js['"]?\s+['"]?complete|session-guard\.js['"]?\s+['"]?(?:finish|reveal|complete))\b/;
+
 // Apply the terminal-step bypasses to a blocked Rule 3 result (Bash only).
-function applyTerminalBypasses(rule3, gate, toolName, toolInput, ticketId) {
+function applyTerminalBypasses(rule3, gate, toolName, toolInput, ticketId, hookData) {
   if (toolName !== 'Bash') return;
   const cmd = String(toolInput?.command || '').trim();
   // Step-conditional bypass: work-state.js complete is allowed at the terminal step (GH-276)
-  if (rule3.match === '.work-state.json' && gate.isTerminalCompleteBypass(cmd, ticketId)) {
+  if (
+    rule3.match === '.work-state.json' &&
+    gate.isTerminalCompleteBypass(cmd, ticketId, hookData)
+  ) {
     rule3.blocked = false;
   }
   // Step-conditional bypass: session-guard.js finish/reveal/complete at terminal step (GH-338)
   // Not gated on rule3.match — session-guard.js may trigger Rule 3 via different state files
-  if (rule3.blocked && gate.isTerminalSessionGuardBypass(cmd, ticketId)) {
+  if (rule3.blocked && gate.isTerminalSessionGuardBypass(cmd, ticketId, hookData)) {
     rule3.blocked = false;
   }
 }
@@ -77,13 +86,22 @@ function applyTerminalBypasses(rule3, gate, toolName, toolInput, ticketId) {
  * protect, and the hook should not block tool use it cannot reason about.
  */
 function makeStateFileRule({ stateFileProtector, gate, basenameToHint, workflows }) {
-  return function checkStateFileRule(toolName, toolInput, ticketId) {
+  return function checkStateFileRule(toolName, toolInput, ticketId, hookData) {
     const rule3 = ticketId ? stateFileProtector.check(toolName, toolInput) : { blocked: false };
     if (!rule3.blocked) return rule3;
-    applyTerminalBypasses(rule3, gate, toolName, toolInput, ticketId);
+    applyTerminalBypasses(rule3, gate, toolName, toolInput, ticketId, hookData);
     if (rule3.blocked) {
       const hint = basenameToHint[rule3.match] || workflows[0].transitionHint;
       rule3.message = rule3.message + `Use: ${hint} ${ticketId} <step>\n`;
+      // GH-695: name the correct move for a dispatched agent that attempted
+      // the terminal bypass (and the leaked-env cause for an orchestrator).
+      if (
+        toolName === 'Bash' &&
+        TERMINAL_BYPASS_SHAPE.test(String(toolInput?.command || '')) &&
+        gate.isDispatchedContext(hookData)
+      ) {
+        rule3.message += DISPATCHED_AGENT_GUIDANCE;
+      }
     }
     return rule3;
   };
@@ -113,6 +131,7 @@ function makeProtectorsRule(protectors) {
  * @param {string[]} deps.workSteps — /work ALL_STEPS
  * @param {Function} deps.getTicketId
  * @param {Function} deps.isRunningInAgent
+ * @param {Function} deps.isDispatchedAgentContext — GH-695 dispatched-agent detector
  * @param {Function} deps.normalizeAgentName
  * @param {string} deps.hookFilename — enforce-step-workflow.js path
  */
@@ -152,6 +171,8 @@ function createHookWiring(deps) {
     tasksBase: deps.tasksBase,
     safeTicketPath: deps.safeTicketPath,
     debugLogCandidatePath,
+    // GH-695: terminal bypasses reject any dispatched-agent context
+    isDispatchedAgentContext: deps.isDispatchedAgentContext,
   });
 
   // Rule 5: agent-gated writer scripts (agent identity + step + token mint)

--- a/plugins/work/scripts/workflows/lib/hooks/policies/shell-tokenize.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/shell-tokenize.js
@@ -1,0 +1,68 @@
+/**
+ * policies/shell-tokenize.js
+ *
+ * Quote-aware shell tokenizer for the strict terminal-bypass parser.
+ * Extracted verbatim from state-script-gate.js (file-size burndown, GH-695
+ * change set) — behavior unchanged; state-script-gate re-exports it so
+ * existing consumers keep their import path.
+ */
+
+/**
+ * Quote-aware shell tokenizer for the strict bypass parser.
+ *
+ * Splits on whitespace EXCEPT within balanced ASCII single or double quotes,
+ * so paths containing spaces (e.g. `/Users/John Smith/...`) remain a single
+ * token. Surrounding quotes are stripped from each token before return.
+ *
+ * Rejects (returns null) on:
+ *   - Unbalanced quotes (open `"` or `'` with no matching close).
+ *   - Nested/mixed quotes within a token are simply treated literally — we do
+ *     not support shell-style escaping (`\"`, `$'..'`, etc.); the bypass is
+ *     for the orchestrator's strict, direct invocation only.
+ *
+ * @param {string} input
+ * @returns {string[] | null}
+ */
+function shellTokenize(input) {
+  const tokens = [];
+  let current = '';
+  let inToken = false;
+  let quote = null; // either '"' or "'" when inside a quoted run
+
+  for (let idx = 0; idx < input.length; idx++) {
+    const ch = input[idx];
+
+    if (quote) {
+      if (ch === quote) {
+        quote = null; // close quote — token continues (allows `a"b"c` style)
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      inToken = true;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      if (inToken) {
+        tokens.push(current);
+        current = '';
+        inToken = false;
+      }
+      continue;
+    }
+
+    current += ch;
+    inToken = true;
+  }
+
+  if (quote) return null; // unbalanced
+  if (inToken) tokens.push(current);
+  return tokens;
+}
+
+module.exports = { shellTokenize };

--- a/plugins/work/scripts/workflows/lib/hooks/policies/state-script-gate.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/state-script-gate.js
@@ -4,7 +4,8 @@
  * Strict Bash-command gating for state scripts, extracted from
  * enforce-step-workflow.js:
  *
- *   - shellTokenize(): quote-aware tokenizer for the strict bypass parser
+ *   - shellTokenize(): quote-aware tokenizer (lives in ./shell-tokenize,
+ *     re-exported here)
  *   - isTerminalCompleteBypass(): `work-state.js complete` allowed only at
  *     the terminal `complete` step (GH-276)
  *   - isTerminalSessionGuardBypass(): session-guard.js finish/reveal/complete
@@ -21,64 +22,9 @@ const {
   extractSubCommand,
   isSafeSubCommand,
 } = require('./agent-authorization');
-
-/**
- * Quote-aware shell tokenizer for the strict bypass parser.
- *
- * Splits on whitespace EXCEPT within balanced ASCII single or double quotes,
- * so paths containing spaces (e.g. `/Users/John Smith/...`) remain a single
- * token. Surrounding quotes are stripped from each token before return.
- *
- * Rejects (returns null) on:
- *   - Unbalanced quotes (open `"` or `'` with no matching close).
- *   - Nested/mixed quotes within a token are simply treated literally — we do
- *     not support shell-style escaping (`\"`, `$'..'`, etc.); the bypass is
- *     for the orchestrator's strict, direct invocation only.
- *
- * @param {string} input
- * @returns {string[] | null}
- */
-function shellTokenize(input) {
-  const tokens = [];
-  let current = '';
-  let inToken = false;
-  let quote = null; // either '"' or "'" when inside a quoted run
-
-  for (let idx = 0; idx < input.length; idx++) {
-    const ch = input[idx];
-
-    if (quote) {
-      if (ch === quote) {
-        quote = null; // close quote — token continues (allows `a"b"c` style)
-      } else {
-        current += ch;
-      }
-      continue;
-    }
-
-    if (ch === '"' || ch === "'") {
-      quote = ch;
-      inToken = true;
-      continue;
-    }
-
-    if (/\s/.test(ch)) {
-      if (inToken) {
-        tokens.push(current);
-        current = '';
-        inToken = false;
-      }
-      continue;
-    }
-
-    current += ch;
-    inToken = true;
-  }
-
-  if (quote) return null; // unbalanced
-  if (inToken) tokens.push(current);
-  return tokens;
-}
+// Quote-aware tokenizer — extracted verbatim to ./shell-tokenize (file-size
+// burndown); re-exported below so consumers keep this import path.
+const { shellTokenize } = require('./shell-tokenize');
 
 // Strict token walk for `node <path>/work-state.js complete <ticket>`.
 // Env-assignment prefixes (FOO=bar node ...) are DISALLOWED entirely — they
@@ -172,20 +118,49 @@ function extractSessionGuardArgs(tokens) {
   return { scriptPath, targetTicket };
 }
 
-function makeTrace(enabled) {
+function makeTrace(enabled, label = 'isTerminalCompleteBypass') {
   return (reason, extra) => {
     if (enabled) {
       try {
         process.stderr.write(
-          `[isTerminalCompleteBypass] ${reason}` +
-            (extra ? ` | ${JSON.stringify(extra)}` : '') +
-            '\n'
+          `[${label}] ${reason}` + (extra ? ` | ${JSON.stringify(extra)}` : '') + '\n'
         );
       } catch {
         /* never throw from debug */
       }
     }
   };
+}
+
+// GH-695: guidance appended to block messages when a dispatched agent attempts
+// a terminal bypass. The mechanical block must be legible — the agent's correct
+// move is reporting the wedge, and a misclassified orchestrator gets the most
+// common cause (a leaked env var) named.
+const DISPATCHED_AGENT_GUIDANCE =
+  'Dispatched-agent context detected: the terminal bypass is orchestrator-only (GH-695).\n' +
+  'Report `BLOCKED: <detail>` to the orchestrator instead of finishing the workflow yourself.\n' +
+  'If you ARE the orchestrator, check for a leaked CLAUDE_CURRENT_AGENT env var in this session.\n';
+
+// GH-695: whether this (scriptBase, subCmd) pair is one of the terminal
+// bypasses — the only allowlist entries the dispatched-agent rejection guards.
+function isTerminalBypassEligible(scriptBase, subCmd) {
+  if (scriptBase === 'work-state.js') return subCmd === 'complete';
+  if (scriptBase === 'session-guard.js') {
+    return subCmd === 'finish' || subCmd === 'reveal' || subCmd === 'complete';
+  }
+  return false;
+}
+
+// GH-695: true when the hook context belongs to ANY dispatched agent.
+// Errors → false (fail-open at the hook; the completeWork script-side
+// precondition is the backstop). Missing dep keeps legacy behavior.
+function isDispatchedContext(deps, hookData) {
+  try {
+    if (typeof deps.isDispatchedAgentContext !== 'function') return false;
+    return deps.isDispatchedAgentContext(hookData?.transcript_path, hookData) === true;
+  } catch {
+    return false;
+  }
 }
 
 // Verify the /work workflow is at the terminal `complete` step — reuses the
@@ -215,16 +190,24 @@ function isAtTerminalStep(deps, ticketId, trace, debugBypass) {
 /**
  * Step-conditional bypass for `work-state.js complete` at the terminal step (GH-276).
  * Returns true ONLY when ALL conditions are met:
- *   1. Command is a strict `node <path>/work-state.js complete <ticketId>` invocation
- *   2. No shell operators, substitutions, or extra arguments
- *   3. Target ticket matches the active ticket
- *   4. The workflow is at the terminal `complete` step
+ *   1. The context is NOT a dispatched agent (GH-695 — orchestrator-only)
+ *   2. Command is a strict `node <path>/work-state.js complete <ticketId>` invocation
+ *   3. No shell operators, substitutions, or extra arguments
+ *   4. Target ticket matches the active ticket
+ *   5. The workflow is at the terminal `complete` step
  */
-function isTerminalCompleteBypass(deps, cmd, ticketId) {
+function isTerminalCompleteBypass(deps, cmd, ticketId, hookData) {
   const DEBUG_BYPASS = process.env.ENFORCE_HOOK_DEBUG === '1';
   const trace = makeTrace(DEBUG_BYPASS);
 
-  // Reject shell operators and substitutions FIRST — cheapest fail-fast.
+  // GH-695: reject FIRST when the caller is ANY dispatched agent — gates that
+  // only bind the orchestrator are not gates.
+  if (isDispatchedContext(deps, hookData)) {
+    trace('reject: dispatched-agent context');
+    return false;
+  }
+
+  // Reject shell operators and substitutions — cheapest syntactic fail-fast.
   if (/[;&|$`<>(){}\n]/.test(cmd)) {
     trace('reject: shell metachars');
     return false;
@@ -273,8 +256,17 @@ function isTerminalCompleteBypass(deps, cmd, ticketId) {
  * the terminal step (GH-338). Mirrors isTerminalCompleteBypass() but for
  * session-guard.js subcommands.
  */
-function isTerminalSessionGuardBypass(deps, cmd, ticketId) {
-  // Reject shell operators and substitutions FIRST — cheapest fail-fast.
+function isTerminalSessionGuardBypass(deps, cmd, ticketId, hookData) {
+  // GH-695: reject FIRST when the caller is ANY dispatched agent.
+  if (isDispatchedContext(deps, hookData)) {
+    makeTrace(
+      process.env.ENFORCE_HOOK_DEBUG === '1',
+      'isTerminalSessionGuardBypass'
+    )('reject: dispatched-agent context');
+    return false;
+  }
+
+  // Reject shell operators and substitutions — cheapest syntactic fail-fast.
   if (/[;&|$`<>(){}\n]/.test(cmd)) return false;
 
   // Normalize by stripping balanced surrounding quote pairs (see
@@ -303,17 +295,17 @@ function isTerminalSessionGuardBypass(deps, cmd, ticketId) {
 }
 
 // Step-conditional bypasses shared by Rule 3 and Rule 3b.
-function isTerminalBypassAllowed(deps, scriptBase, subCmd, cmd, ticketId) {
+function isTerminalBypassAllowed(deps, scriptBase, subCmd, cmd, ticketId, hookData) {
   // work-state.js complete at terminal step (GH-276)
   if (scriptBase === 'work-state.js' && subCmd === 'complete') {
-    return isTerminalCompleteBypass(deps, cmd, ticketId);
+    return isTerminalCompleteBypass(deps, cmd, ticketId, hookData);
   }
   // session-guard.js finish/reveal/complete at terminal step (GH-338)
   if (
     scriptBase === 'session-guard.js' &&
     (subCmd === 'finish' || subCmd === 'reveal' || subCmd === 'complete')
   ) {
-    return isTerminalSessionGuardBypass(deps, cmd, ticketId);
+    return isTerminalSessionGuardBypass(deps, cmd, ticketId, hookData);
   }
   return false;
 }
@@ -326,7 +318,7 @@ function isTerminalBypassAllowed(deps, scriptBase, subCmd, cmd, ticketId) {
  *
  * @returns {{ blocked: true, message: string } | null}
  */
-function checkUnsafeSubcommands(deps, cmd, ticketId) {
+function checkUnsafeSubcommands(deps, cmd, ticketId, hookData) {
   const stateMatches = getNodeInvocations(cmd);
   for (const m of stateMatches) {
     const scriptPath = m[1] || m[2] || m[3];
@@ -340,13 +332,16 @@ function checkUnsafeSubcommands(deps, cmd, ticketId) {
 
     const subCmd = extractSubCommand(cmd, m, scriptBase);
     if (isSafeSubCommand(scriptBase, subCmd, deps.safeSubcommands)) continue;
-    if (isTerminalBypassAllowed(deps, scriptBase, subCmd, cmd, ticketId)) continue;
-    return {
-      blocked: true,
-      message:
-        `BLOCKED: Direct Bash call to ${scriptBase} with sub-command '${subCmd}' is not allowed.\n` +
-        `State files must only be modified through the orchestrator/workflow-engine scripts.\n`,
-    };
+    if (isTerminalBypassAllowed(deps, scriptBase, subCmd, cmd, ticketId, hookData)) continue;
+    let message =
+      `BLOCKED: Direct Bash call to ${scriptBase} with sub-command '${subCmd}' is not allowed.\n` +
+      `State files must only be modified through the orchestrator/workflow-engine scripts.\n`;
+    // GH-695: a dispatched agent attempting a terminal bypass gets told the
+    // correct move (report the wedge) instead of a mysterious denial.
+    if (isTerminalBypassEligible(scriptBase, subCmd) && isDispatchedContext(deps, hookData)) {
+      message += DISPATCHED_AGENT_GUIDANCE;
+    }
+    return { blocked: true, message };
   }
   return null;
 }
@@ -363,17 +358,25 @@ function checkUnsafeSubcommands(deps, cmd, ticketId) {
  * @param {string} deps.tasksBase — TASKS_BASE (debug traces only)
  * @param {Function} deps.safeTicketPath — ticket sanitizer (debug traces only)
  * @param {Function} deps.debugLogCandidatePath — GH-452 diagnostic
+ * @param {Function} [deps.isDispatchedAgentContext] — GH-695 dispatched-agent
+ *   detector (transcriptPath, hookData) => boolean; when absent the terminal
+ *   bypasses keep their pre-GH-695 (orchestrator-assumed) behavior
  */
 function createStateScriptGate(deps) {
   return {
-    isTerminalCompleteBypass: (cmd, ticketId) => isTerminalCompleteBypass(deps, cmd, ticketId),
-    isTerminalSessionGuardBypass: (cmd, ticketId) =>
-      isTerminalSessionGuardBypass(deps, cmd, ticketId),
-    checkUnsafeSubcommands: (cmd, ticketId) => checkUnsafeSubcommands(deps, cmd, ticketId),
+    isTerminalCompleteBypass: (cmd, ticketId, hookData) =>
+      isTerminalCompleteBypass(deps, cmd, ticketId, hookData),
+    isTerminalSessionGuardBypass: (cmd, ticketId, hookData) =>
+      isTerminalSessionGuardBypass(deps, cmd, ticketId, hookData),
+    checkUnsafeSubcommands: (cmd, ticketId, hookData) =>
+      checkUnsafeSubcommands(deps, cmd, ticketId, hookData),
+    isDispatchedContext: (hookData) => isDispatchedContext(deps, hookData),
   };
 }
 
 module.exports = {
   shellTokenize, // quote-aware tokenizer (exported for reuse/tests)
   createStateScriptGate, // terminal bypasses + Rule 3b sub-command gate
+  DISPATCHED_AGENT_GUIDANCE, // GH-695 block-message guidance (reused by Rule 3)
+  isTerminalBypassEligible, // GH-695 terminal-bypass (script, subCmd) predicate
 };

--- a/plugins/work/scripts/workflows/lib/transcript-markers.js
+++ b/plugins/work/scripts/workflows/lib/transcript-markers.js
@@ -1,0 +1,148 @@
+/**
+ * transcript-markers.js
+ *
+ * Structural subagent-marker helpers for claude JSONL transcripts, extracted
+ * verbatim from agent-detection.js (file-size burndown, GH-695 change set):
+ *
+ *   - extractEntryText / readInitialMarkers: scan the first transcript lines
+ *     for the structural markers of a Task-spawned subagent
+ *     (attributionAgent / isSidechain)
+ *   - isDispatchedAgentContext (GH-695): alias-agnostic "am I in ANY
+ *     dispatched agent" predicate used by the terminal state-script bypasses
+ *
+ * agent-detection.js requires and re-exports these, so consumers keep their
+ * existing import path.
+ */
+
+const fs = require('fs');
+
+function debugLog(method, msg) {
+  if (process.env.ENFORCE_HOOK_DEBUG) {
+    process.stderr.write(`[agent-detection] ${method}: ${msg}\n`);
+  }
+}
+
+/**
+ * Extract the prose text of a single system/user transcript entry.
+ * Non-message entries and unknown content shapes yield an empty string.
+ */
+function extractEntryText(entry) {
+  if (entry.type !== 'system' && entry.type !== 'user') {
+    return '';
+  }
+  const msgContent = entry.message?.content;
+  if (typeof msgContent === 'string') {
+    return msgContent;
+  }
+  if (Array.isArray(msgContent)) {
+    return msgContent.map((i) => i.text || '').join(' ');
+  }
+  return '';
+}
+
+/**
+ * Read the structural subagent markers from early transcript lines.
+ *
+ * Mirrors the per-line JSON.parse-in-try/catch pattern used by
+ * isSubagentFromTranscript. Untrusted fields are read defensively.
+ *
+ * @param {string[]} earlyLines - The first N raw transcript lines
+ * @returns {{attributionAgent: string, isSidechain: boolean, promptText: string}}
+ */
+function readInitialMarkers(earlyLines) {
+  let attributionAgent = '';
+  let isSidechain = false;
+  let promptText = '';
+
+  for (const line of earlyLines) {
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue; // skip non-JSON lines
+    }
+
+    // A sidechain flag on ANY early line marks this as a subagent transcript.
+    if (entry.isSidechain === true) {
+      isSidechain = true;
+    }
+
+    // First attributionAgent wins — it is the authoritative identity.
+    if (!attributionAgent && entry.attributionAgent) {
+      attributionAgent = String(entry.attributionAgent);
+    }
+
+    // Accumulate prose from system/user messages for the gated name check.
+    const text = extractEntryText(entry);
+    if (text) {
+      promptText = promptText ? `${promptText} ${text}` : text;
+    }
+  }
+
+  return { attributionAgent, isSidechain, promptText };
+}
+
+/**
+ * True when the first 10 transcript lines carry a structural subagent marker
+ * (attributionAgent or isSidechain). Read/parse errors → false.
+ */
+function hasInitialSubagentMarkers(transcriptPath) {
+  try {
+    if (!fs.existsSync(transcriptPath)) return false;
+    const lines = fs.readFileSync(transcriptPath, 'utf8').trim().split('\n');
+    const { attributionAgent, isSidechain } = readInitialMarkers(lines.slice(0, 10));
+    if (!attributionAgent && isSidechain !== true) return false;
+    debugLog(
+      'dispatchedContext',
+      attributionAgent ? `attributionAgent=${attributionAgent}` : 'isSidechain marker'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * GH-695: True when the current hook context belongs to ANY dispatched
+ * (sub)agent, regardless of which one — alias-agnostic, no allowlist to
+ * maintain. Used by the terminal state-script bypasses, which are
+ * orchestrator-only: a dispatched agent must report BLOCKED instead of
+ * finishing the workflow itself.
+ *
+ * Signals (any one suffices):
+ *   - hookData.agent_type set (any value — set by Claude Code inside a subagent)
+ *   - CLAUDE_CURRENT_AGENT env var set (any value)
+ *   - transcriptPath contains '/subagents/' (subagent transcript location)
+ *   - structural markers (attributionAgent / isSidechain) in the first 10
+ *     transcript lines, via readInitialMarkers
+ *
+ * Fail direction: read/parse errors → false (fail-open at the hook). Failing
+ * closed here would deadlock the terminal step with no in-band repair; the
+ * completeWork script-side precondition is the backstop.
+ *
+ * @param {string} [transcriptPath] - Path to the session transcript
+ * @param {object} [hookData] - Hook payload from Claude Code
+ * @returns {boolean} true when this context is a dispatched agent
+ */
+function isDispatchedAgentContext(transcriptPath, hookData) {
+  if (hookData?.agent_type) {
+    debugLog('dispatchedContext', `agent_type=${hookData.agent_type}`);
+    return true;
+  }
+  if (process.env.CLAUDE_CURRENT_AGENT) {
+    debugLog('dispatchedContext', `CLAUDE_CURRENT_AGENT=${process.env.CLAUDE_CURRENT_AGENT}`);
+    return true;
+  }
+  if (!transcriptPath) return false;
+  if (String(transcriptPath).includes('/subagents/')) {
+    debugLog('dispatchedContext', 'transcript path contains /subagents/');
+    return true;
+  }
+  return hasInitialSubagentMarkers(transcriptPath);
+}
+
+module.exports = {
+  extractEntryText,
+  readInitialMarkers,
+  isDispatchedAgentContext,
+};

--- a/plugins/work/scripts/workflows/work/__tests__/complete-deadlock.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/complete-deadlock.test.js
@@ -18,6 +18,7 @@ const fs = require('fs');
 const os = require('os');
 
 const WORK_STATE_PATH = path.join(__dirname, '..', 'work-state.js');
+const { ALL_STEPS } = require(path.join(__dirname, '..', 'step-registry'));
 const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'complete-deadlock-test-'));
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -69,6 +70,17 @@ function cleanupTicket(ticketId) {
   try {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {}
+}
+
+// GH-695: completeWork now validates step preconditions — the legit flow
+// arrives at terminal with every non-complete step already completed. This
+// builds that genuine terminal shape for tests exercising `complete`.
+function markAllStepsCompleted(ticketId) {
+  const state = readState(ticketId);
+  for (const step of ALL_STEPS) {
+    state.stepStatus[step] = step === 'complete' ? 'in_progress' : 'completed';
+  }
+  writeState(ticketId, state);
 }
 
 // ─── Global Cleanup ─────────────────────────────────────────────────────────
@@ -129,12 +141,13 @@ describe('GH-106: complete step deadlock fix', () => {
       assert.ok(stderr.length > 0, 'complete should write error to stderr');
     });
 
-    it('complete exits 0 and marks status completed on valid state', async () => {
+    it('complete exits 0 and marks status completed on valid terminal state', async () => {
       const ticket = 'DEADLOCK-VALID';
       cleanupTicket(ticket);
 
-      // Initialize state first
+      // Initialize state, then bring it to the genuine terminal shape (GH-695)
       await runWorkState(['init', ticket, 'test ticket']);
+      markAllStepsCompleted(ticket);
       const { code, result } = await runWorkState(['complete', ticket]);
 
       assert.equal(code, 0, 'complete should exit 0 on success');
@@ -147,12 +160,94 @@ describe('GH-106: complete step deadlock fix', () => {
       cleanupTicket(ticket);
 
       await runWorkState(['init', ticket, 'test ticket']);
+      markAllStepsCompleted(ticket);
       await runWorkState(['complete', ticket]);
 
       // Second call should also succeed
       const { code, result } = await runWorkState(['complete', ticket]);
       assert.equal(code, 0, 'second complete should exit 0');
       assert.equal(result.status, 'completed', 'status should remain completed');
+    });
+  });
+
+  // ─── Test 3b: GH-695 — complete validates step preconditions ──────────────
+
+  describe('3b. GH-695: completeWork step-status precondition', () => {
+    it('refuses completion and lists the offending steps when steps are not completed', async () => {
+      const ticket = 'DEADLOCK-PRECONDITION';
+      cleanupTicket(ticket);
+
+      await runWorkState(['init', ticket, 'test ticket']);
+      const state = readState(ticket);
+      state.stepStatus.ticket = 'completed';
+      state.stepStatus.implement = 'in_progress';
+      writeState(ticket, state);
+
+      const { code, stderr } = await runWorkState(['complete', ticket]);
+      assert.equal(code, 1, 'complete should exit 1 when steps are not completed');
+      assert.ok(stderr.includes('implement'), `offender list should name implement: ${stderr}`);
+      assert.ok(
+        stderr.includes('work-next.js'),
+        `repair route should name work-next.js: ${stderr}`
+      );
+
+      const after = readState(ticket);
+      assert.notEqual(after.status, 'completed', 'status must not flip to completed');
+      assert.notEqual(
+        after.stepStatus.implement,
+        'completed',
+        'refusal must not blind-stamp steps completed'
+      );
+    });
+
+    it('WORK_OPERATOR_TOKEN=1 overrides the precondition and appends an audit row', async () => {
+      const ticket = 'DEADLOCK-OPERATOR';
+      cleanupTicket(ticket);
+
+      await runWorkState(['init', ticket, 'test ticket']);
+      const state = readState(ticket);
+      state.stepStatus.ticket = 'completed';
+      state.stepStatus.implement = 'in_progress';
+      writeState(ticket, state);
+
+      const { code, result } = await runWorkState(['complete', ticket], {
+        env: { WORK_OPERATOR_TOKEN: '1' },
+      });
+      assert.equal(code, 0, 'operator override should exit 0');
+      assert.equal(result.status, 'completed', 'operator override should complete the workflow');
+
+      const actionsPath = path.join(TEMP_TASKS_BASE, ticket, '.work-actions.json');
+      const actions = JSON.parse(fs.readFileSync(actionsPath, 'utf-8'));
+      const auditRow = actions.find(
+        (row) => row.step === 'complete' && /operator-override/.test(String(row.what || ''))
+      );
+      assert.ok(
+        auditRow,
+        `expected an operator-override audit row, got: ${JSON.stringify(actions)}`
+      );
+      assert.ok(
+        /WORK_OPERATOR_TOKEN/.test(String(auditRow.what)),
+        'audit row should name WORK_OPERATOR_TOKEN'
+      );
+    });
+
+    it('refuses when stepStatus is missing entirely (fail closed)', async () => {
+      const ticket = 'DEADLOCK-NO-STEPSTATUS';
+      cleanupTicket(ticket);
+
+      writeState(ticket, {
+        ticketId: ticket,
+        description: '',
+        currentStep: 1,
+        status: 'in_progress',
+        checkProgress: {},
+        errors: [],
+        startTime: new Date().toISOString(),
+        lastUpdate: new Date().toISOString(),
+      });
+
+      const { code } = await runWorkState(['complete', ticket]);
+      assert.equal(code, 1, 'missing stepStatus must fail closed');
     });
   });
 
@@ -234,7 +329,7 @@ describe('GH-106: complete step deadlock fix', () => {
   // If the module cannot load, the setup test FAILS (not silently skipped).
 
   describe('8-10. unstick-complete.js helpers', () => {
-    let sanitizeTicketId, isStuckInComplete, archiveArtifacts;
+    let sanitizeTicketId, isStuckInComplete, archiveArtifacts, unstickTicket;
     const origEnv = { ...process.env };
 
     it('setup — require unstick-complete.js', () => {
@@ -247,9 +342,11 @@ describe('GH-106: complete step deadlock fix', () => {
       sanitizeTicketId = mod.sanitizeTicketId;
       isStuckInComplete = mod.isStuckInComplete;
       archiveArtifacts = mod.archiveArtifacts;
+      unstickTicket = mod.unstickTicket;
       assert.ok(sanitizeTicketId, 'sanitizeTicketId must be exported');
       assert.ok(isStuckInComplete, 'isStuckInComplete must be exported');
       assert.ok(archiveArtifacts, 'archiveArtifacts must be exported');
+      assert.ok(unstickTicket, 'unstickTicket must be exported');
     });
 
     // ─── sanitizeTicketId ──────────────────────────────────────────────────
@@ -366,6 +463,63 @@ describe('GH-106: complete step deadlock fix', () => {
       const files = fs.readdirSync(archiveDir);
       assert.ok(files.length >= 2, 'Should have original + timestamped file');
       fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    // ─── unstickTicket × GH-695 precondition ───────────────────────────────
+
+    it('unstick: corrupted shape (complete in_progress, earlier steps pending) records completeWork ok:false', () => {
+      const ticket = 'TEST-UNSTICK-CORRUPT';
+      cleanupTicket(ticket);
+      const stepStatus = {};
+      for (const step of ALL_STEPS) stepStatus[step] = 'pending';
+      stepStatus.ticket = 'completed';
+      stepStatus.complete = 'in_progress';
+      writeState(ticket, {
+        ticketId: ticket,
+        description: '',
+        currentStep: ALL_STEPS.length,
+        status: 'in_progress',
+        stepStatus,
+        checkProgress: {},
+        errors: [],
+        startTime: new Date().toISOString(),
+        lastUpdate: new Date().toISOString(),
+      });
+
+      const result = unstickTicket(ticket);
+      const cw = result.actions.find((a) => a.step === 'completeWork');
+      assert.ok(cw, 'unstick must record a completeWork action row');
+      assert.equal(cw.ok, false, 'completeWork must fail closed on the corrupted shape');
+      const after = readState(ticket);
+      assert.notEqual(after.status, 'completed', 'corrupted shape must not be force-completed');
+      cleanupTicket(ticket);
+    });
+
+    it('unstick: all-others-completed recovery shape still completes', () => {
+      const ticket = 'TEST-UNSTICK-RECOVERY';
+      cleanupTicket(ticket);
+      const stepStatus = {};
+      for (const step of ALL_STEPS) stepStatus[step] = 'completed';
+      stepStatus.complete = 'pending';
+      writeState(ticket, {
+        ticketId: ticket,
+        description: '',
+        currentStep: ALL_STEPS.length,
+        status: 'in_progress',
+        stepStatus,
+        checkProgress: {},
+        errors: [],
+        startTime: new Date().toISOString(),
+        lastUpdate: new Date().toISOString(),
+      });
+
+      const result = unstickTicket(ticket);
+      const cw = result.actions.find((a) => a.step === 'completeWork');
+      assert.ok(cw, 'unstick must record a completeWork action row');
+      assert.equal(cw.ok, true, 'the GH-106 recovery shape must still complete');
+      const after = readState(ticket);
+      assert.equal(after.status, 'completed', 'recovery shape completes as before');
+      cleanupTicket(ticket);
     });
 
     after(() => {

--- a/plugins/work/scripts/workflows/work/__tests__/work-state.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-state.test.js
@@ -13,6 +13,7 @@ const fs = require('fs');
 const os = require('os');
 
 const HOOK_PATH = path.join(__dirname, '..', 'work-state.js');
+const { ALL_STEPS } = require(path.join(__dirname, '..', 'step-registry'));
 const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'work-state-test-'));
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -58,6 +59,19 @@ function cleanupTempWorkState(ticket) {
   try {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch {}
+}
+
+// GH-695: completeWork validates step preconditions — tests exercising a
+// SUCCESSFUL `complete` must first bring the state to the genuine terminal
+// shape (every non-complete step already completed, as the legit flow does).
+function markStepsTerminal(ticket) {
+  const statePath = path.join(TEMP_TASKS_BASE, ticket, '.work-state.json');
+  const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+  state.stepStatus = state.stepStatus || {};
+  for (const step of ALL_STEPS) {
+    if (step !== 'complete') state.stepStatus[step] = 'completed';
+  }
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
 }
 
 // ─── Global Cleanup ─────────────────────────────────────────────────────────
@@ -267,6 +281,7 @@ describe('work-state.js', () => {
 
     it('should mark all steps completed and set completedTime', async () => {
       await runWorkState(['init', TICKET_OK]);
+      markStepsTerminal(TICKET_OK); // GH-695: complete validates preconditions
       const { result, code } = await runWorkState(['complete', TICKET_OK]);
 
       assert.equal(code, 0);
@@ -793,6 +808,7 @@ describe('work-state.js', () => {
       // Advance both tasks to completed
       await runWorkState(['task-advance', TICKET_DONE]);
       await runWorkState(['task-advance', TICKET_DONE]);
+      markStepsTerminal(TICKET_DONE); // GH-695: complete validates preconditions
 
       const { result, code } = await runWorkState(['complete', TICKET_DONE]);
       assert.equal(code, 0, 'Should exit with code 0 when all tasks completed');
@@ -802,6 +818,7 @@ describe('work-state.js', () => {
     it('should succeed when no tasksMeta exists (backward compat)', async () => {
       // Init state without task tracking
       await runWorkState(['init', TICKET_NO_META]);
+      markStepsTerminal(TICKET_NO_META); // GH-695: complete validates preconditions
 
       const { result, code } = await runWorkState(['complete', TICKET_NO_META]);
       assert.equal(code, 0, 'Should exit with code 0 when no tasksMeta exists');
@@ -831,10 +848,16 @@ describe('work-state.js', () => {
     function seedTicket(ticket, tasks, opts = {}) {
       const dir = path.join(TEMP_TASKS_BASE, ticket);
       fs.mkdirSync(dir, { recursive: true });
+      // GH-695: seed a genuine terminal step shape so `complete` exercises the
+      // checkpoint auto-close path, not the new step-status precondition.
+      const stepStatus = {};
+      for (const step of ALL_STEPS) {
+        if (step !== 'complete') stepStatus[step] = 'completed';
+      }
       const state = {
         ticketId: ticket,
         status: 'in_progress',
-        stepStatus: {},
+        stepStatus,
         tasksMeta: { totalTasks: tasks.length, currentTaskIndex: tasks.length, tasks },
       };
       fs.writeFileSync(path.join(dir, '.work-state.json'), JSON.stringify(state));

--- a/plugins/work/scripts/workflows/work/work-state/steps.js
+++ b/plugins/work/scripts/workflows/work/work-state/steps.js
@@ -9,6 +9,7 @@
 
 const { STEPS, loadState, saveState, initState, autoInitTdd } = require('./core');
 const { autoCompleteCheckpointTasks } = require('./checkpoints');
+const { appendAction } = require('../lib/work-actions');
 
 /**
  * Set step status
@@ -79,8 +80,51 @@ function addError(ticketId, step, error) {
 }
 
 /**
+ * Terminal guard (GH-245): error message when tasksMeta has pending tasks,
+ * null otherwise. GH-410: directive message when the only pending tasks are
+ * checkpoint-kind without an APPROVED completion.check.md report.
+ */
+function pendingTasksMessage(state) {
+  if (!state.tasksMeta || !Array.isArray(state.tasksMeta.tasks)) return null;
+  const pendingTasks = state.tasksMeta.tasks.filter((t) => t.status !== 'completed');
+  if (pendingTasks.length === 0) return null;
+  const allCheckpoint = pendingTasks.every((t) => t && t.kind === 'checkpoint');
+  return allCheckpoint
+    ? `Cannot complete workflow: ${pendingTasks.length} checkpoint task(s) still pending — expected APPROVED completion.check.md to auto-close them (see GH-410)`
+    : `Cannot complete workflow: ${pendingTasks.length} tasks still pending`;
+}
+
+/**
+ * GH-695 step-status precondition: error message when any non-complete step
+ * is not 'completed', null when the shape is genuinely terminal. Missing
+ * stepStatus fails closed. WORK_OPERATOR_TOKEN=1 overrides (returns null)
+ * and leaves an appendAction audit row — the documented human-shell repair
+ * route (hooks reject env-prefixed agent commands, so agents can't use it).
+ */
+function stepPreconditionMessage(state, ticketId) {
+  const stepStatus = state.stepStatus || {};
+  const offenders = STEPS.filter((step) => step !== 'complete' && stepStatus[step] !== 'completed');
+  if (offenders.length === 0) return null;
+  if (process.env.WORK_OPERATOR_TOKEN !== '1') {
+    return (
+      `Cannot complete workflow: step(s) not completed: ${offenders.join(', ')} — ` +
+      `drive them with work-next.js (operator repair route: WORK_OPERATOR_TOKEN=1 from a human shell, audited)`
+    );
+  }
+  appendAction(ticketId, {
+    step: 'complete',
+    what: 'operator-override completion (WORK_OPERATOR_TOKEN)',
+    meta: { offenders },
+  });
+  return null;
+}
+
+/**
  * Mark work as complete.
  * GH-106: Made idempotent — if already completed, returns existing state.
+ * GH-695: Validates step preconditions — every non-complete step must already
+ * be 'completed' (the legit flow always arrives at terminal in this shape;
+ * transitions mark each step as they pass).
  * Returns { error: ... } when no state found (caller must check).
  */
 function completeWork(ticketId) {
@@ -102,22 +146,17 @@ function completeWork(ticketId) {
     saveState(ticketId, state);
   }
 
-  // Terminal guard: block completion if tasks are still pending (GH-245).
-  // GH-410: emit a directive message when the only pending tasks are
-  // checkpoint-kind without an APPROVED completion.check.md report.
-  if (state.tasksMeta && Array.isArray(state.tasksMeta.tasks)) {
-    const pendingTasks = state.tasksMeta.tasks.filter((t) => t.status !== 'completed');
-    if (pendingTasks.length > 0) {
-      const allCheckpoint = pendingTasks.every((t) => t && t.kind === 'checkpoint');
-      const msg = allCheckpoint
-        ? `Cannot complete workflow: ${pendingTasks.length} checkpoint task(s) still pending — expected APPROVED completion.check.md to auto-close them (see GH-410)`
-        : `Cannot complete workflow: ${pendingTasks.length} tasks still pending`;
-      return { error: msg };
-    }
-  }
+  const pendingMsg = pendingTasksMessage(state);
+  if (pendingMsg) return { error: pendingMsg };
+
+  const preconditionMsg = stepPreconditionMessage(state, ticketId);
+  if (preconditionMsg) return { error: preconditionMsg };
 
   state.status = 'completed';
   state.completedTime = new Date().toISOString();
+  if (!state.stepStatus) state.stepStatus = {};
+  // No-op normalization in the legit flow (every step already 'completed');
+  // only the audited operator override can stamp anything here.
   STEPS.forEach((step) => {
     state.stepStatus[step] = 'completed';
   });

--- a/plugins/work/scripts/workflows/work/workflow-definition.js
+++ b/plugins/work/scripts/workflows/work/workflow-definition.js
@@ -177,7 +177,10 @@ module.exports = function createWorkflowDefinition({ TASKS_BASE, safeTicketPath,
     transitionPattern: /work\.workflow\.js\s+transition\s+(\S+)\s+(\S+)/,
     exemptPatterns: [
       /work\.workflow\.js\s+(plan|transitions|graph)/,
-      /work-state\.js\s+(get|resume-info|init|task-current|task-advance|task-get|task-init)/,
+      // task-advance dropped (GH-695) — aligned with SAFE_SUBCOMMANDS in
+      // lib/hooks/policies/hook-config.js: a Rule-1/2-exempt command that
+      // Rule 3b blocks is dead config.
+      /work-state\.js\s+(get|resume-info|init|task-current|task-get|task-init)/,
     ],
     transitionHint: `node ${path.join(__dirname, 'work.workflow.js')} transition`,
   };


### PR DESCRIPTION
## Existing Behavior

- `work-state.js complete` and `work-state.js task-advance` are callable from any context — including dispatched subagents — that can invoke a Bash tool. The `enforce-step-workflow` hook's terminal bypasses (GH-276, GH-338) verify only that the workflow is at the correct step; they do not distinguish an orchestrator session from a Task-spawned subagent.
- `work-state.js complete` blindly stamps every step `completed` and sets `status: completed` without verifying that the upstream steps actually ran. A subagent that learns the CLI can silently skip all remaining workflow phases (follow_up, ci, cleanup, reports).
- `task-advance` is listed in `SAFE_SUBCOMMANDS`, so it passes Rule 3b even though its only legitimate callers are driver-internal `execFileSync` spawns that never traverse `PreToolUse`.
- `agent-detection.js` and `state-script-gate.js` are large files; shared logic (transcript-marker readers, shell tokenizer) is inlined rather than separated.

## Intended New Behavior

- `isDispatchedAgentContext` (new function in `lib/transcript-markers.js`) detects any dispatched-agent context via four independent signals: `hookData.agent_type`, `CLAUDE_CURRENT_AGENT` env var, a `/subagents/` transcript path, or `isSidechain`/`attributionAgent` markers in the first 10 transcript lines. It is alias-agnostic — no allowlist to maintain as new agents are added.
- Both terminal bypasses (`isTerminalCompleteBypass` for `work-state.js complete` and `isTerminalSessionGuardBypass` for `session-guard.js finish/reveal/complete`) reject immediately when `isDispatchedAgentContext` returns true, before any step-check. The dispatched agent's block message includes `DISPATCHED_AGENT_GUIDANCE` naming the correct move (report `BLOCKED: <detail>` to the orchestrator) and the most common misclassification cause (a leaked `CLAUDE_CURRENT_AGENT`).
- `task-advance` is removed from `SAFE_SUBCOMMANDS` (and from `workflow-definition.js` `exemptPatterns`). Rule 3b now blocks it in every context; the driver-internal spawns that legitimately call it never traverse `PreToolUse`.
- `completeWork` validates step preconditions (GH-695): every non-`complete` step must already be `completed` before `status` is flipped. Missing `stepStatus` fails closed. The operator repair route (`WORK_OPERATOR_TOKEN=1` from a human shell) overrides the check and appends an audit row to `.work-actions.json`; the hook's env-prefix rejection prevents agents from using it.
- `shellTokenize` moves to `lib/hooks/policies/shell-tokenize.js` and `readInitialMarkers`/`extractEntryText`/`isDispatchedAgentContext` move to `lib/transcript-markers.js`. Both old import paths keep working via re-exports. `agent-detection.js` is removed from `.quality-exceptions` (file-size burndown now passes).
- Agent persona files (`pr-generator.md`, `pr-post-generator.md`) gain a `HARD BOUNDARIES — WORKFLOW STATE` section instructing agents to report `BLOCKED: <detail>` rather than invoking state-mutating CLIs when a runner wedges.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify dispatched-agent context is blocked at the terminal bypass:**

1. At the `complete` step, invoke `work-state.js complete <ticket>` with `agent_type` set in the hook payload. Expected: exit 2, stderr contains `BLOCKED` and `CLAUDE_CURRENT_AGENT`.
2. Repeat with `CLAUDE_CURRENT_AGENT=pr-generator` in the environment. Expected: exit 2, stderr contains `BLOCKED`.
3. Repeat with a transcript path containing `/subagents/`. Expected: exit 2, stderr contains `BLOCKED`.
4. Repeat with a transcript whose first line carries `isSidechain: true`. Expected: exit 2, stderr contains `BLOCKED`.
5. Invoke `work-state.js complete <ticket>` from the orchestrator (no agent signals, genuine terminal shape). Expected: exit 0, workflow marked completed.

**Verify task-advance is blocked everywhere:**

6. Invoke `node work-state.js task-advance <ticket>` via Bash at any step. Expected: exit 2, stderr contains `BLOCKED`.
7. Invoke `node work-state.js task-current <ticket>` and `task-get <ticket> 1` via Bash. Expected: exit 0 (read-only subcommands remain allowed).

**Verify completeWork step-status precondition:**

8. Initialize a ticket, leave `implement` as `in_progress`, invoke `work-state.js complete`. Expected: exit 1, stderr names `implement` and `work-next.js`.
9. Same scenario with `WORK_OPERATOR_TOKEN=1`. Expected: exit 0, `.work-actions.json` contains an `operator-override` audit row.
10. Initialize a ticket with all non-`complete` steps set to `completed`, invoke `work-state.js complete`. Expected: exit 0, status flips to `completed`.

### Test Results

Tests covering all new paths are included in the diff:

- `lib/__tests__/agent-detection.test.js` — 11 new cases for `isDispatchedAgentContext` (all four signals, fail-open on missing/corrupt transcript, initial-marker window boundary)
- `lib/__tests__/enforce-step-workflow.test.js` — 8 new cases: `task-advance` blocked at `implement` and `complete` steps; `task-current`/`task-get` regression; `work-state.js complete` and `session-guard.js finish/complete` blocked when `agent_type`, `CLAUDE_CURRENT_AGENT`, sidechain transcript, or `/subagents/` path is present
- `work/__tests__/complete-deadlock.test.js` — 5 new cases: precondition refusal with offender list; `WORK_OPERATOR_TOKEN=1` override with audit row; missing `stepStatus` fails closed; `unstickTicket` with corrupted shape records `ok:false`; `unstickTicket` with recovery shape still completes
- `work/__tests__/work-state.test.js` — existing `complete` success cases updated to supply genuine terminal step shape

Closes #695