### PR TITLE
feat(work): brief-gate answers file transport + kind routing (GH-543)

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/brief-sibling-gaps.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/brief-sibling-gaps.test.js
@@ -97,4 +97,14 @@ describe('buildSiblingGapQuestions', () => {
   it('returns [] for non-array input', () => {
     assert.deepEqual(buildSiblingGapQuestions(null, 'X'), []);
   });
+
+  it('tags each question with kind/applyKey/options for envelope routing (GH-543)', () => {
+    const r = findUnresolvedSiblingGaps(fixture());
+    const qs = buildSiblingGapQuestions(r.unresolved, 'ECHO-4553');
+    for (const q of qs) {
+      assert.equal(q.kind, 'sibling-gap');
+      assert.deepEqual(q.options, ['implement-here', 'wait-for-sibling']);
+    }
+    assert.equal(qs[0].applyKey, r.unresolved[0].surface);
+  });
 });

--- a/plugins/work/scripts/workflows/lib/__tests__/discrepancy.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/discrepancy.test.js
@@ -82,6 +82,15 @@ describe('buildDiscrepancyQuestions', () => {
   it('returns [] for null comparison', () => {
     assert.deepEqual(buildDiscrepancyQuestions(null, 'a', 'b'), []);
   });
+
+  it('tags both question shapes with kind/applyKey for envelope routing (GH-543)', () => {
+    const cmp = { missingInLower: ['x.ts'], extraInLower: ['y.ts'] };
+    const qs = buildDiscrepancyQuestions(cmp, 'user prompt', 'brief');
+    assert.equal(qs[0].kind, 'discrepancy');
+    assert.equal(qs[0].applyKey, 'x.ts');
+    assert.equal(qs[1].kind, 'discrepancy');
+    assert.equal(qs[1].applyKey, 'y.ts');
+  });
 });
 
 describe('extractRecordedDecisions + filterUnresolved', () => {

--- a/plugins/work/scripts/workflows/lib/brief-sibling-gaps.js
+++ b/plugins/work/scripts/workflows/lib/brief-sibling-gaps.js
@@ -118,7 +118,8 @@ function findUnresolvedSiblingGaps(briefText) {
  *
  * @param {Array<{surface:string, ticketId:string|null, raw:string}>} unresolved
  * @param {string} currentTicketId
- * @returns {Array<{questionText:string, scope:'user', rationale:string}>}
+ * @returns {Array<{questionText:string, scope:'user', rationale:string,
+ *   kind:'sibling-gap', applyKey:string, options:string[]}>}
  */
 function buildSiblingGapQuestions(unresolved, currentTicketId) {
   if (!Array.isArray(unresolved)) return [];
@@ -131,6 +132,11 @@ function buildSiblingGapQuestions(unresolved, currentTicketId) {
         `Implement the gap here as an exception, or complete ${owner} first?`,
       scope: 'user',
       rationale: u.raw,
+      // Envelope routing (GH-543): the driver files the answer under
+      // `siblingGaps: [{ surface: applyKey, decision: <option> }]`.
+      kind: 'sibling-gap',
+      applyKey: u.surface,
+      options: ['implement-here', 'wait-for-sibling'],
     };
   });
 }

--- a/plugins/work/scripts/workflows/lib/discrepancy.js
+++ b/plugins/work/scripts/workflows/lib/discrepancy.js
@@ -106,11 +106,14 @@ function compareClaims(higher, lower) {
  * @param {{missingInLower:string[], extraInLower:string[]}} comparison
  * @param {string} higherLabel - e.g. 'user prompt'
  * @param {string} lowerLabel  - e.g. 'brief'
- * @returns {Array<{questionText:string, scope:'user', rationale:string}>}
+ * @returns {Array<{questionText:string, scope:'user', rationale:string,
+ *   kind:'discrepancy', applyKey:string}>}
  */
 function buildDiscrepancyQuestions(comparison, higherLabel, lowerLabel) {
   if (!comparison) return [];
   const qs = [];
+  // Envelope routing (GH-543): the driver files the answer under
+  // `discrepancies: [{ claim: applyKey, decision: <answer> }]`.
   for (const claim of comparison.missingInLower) {
     qs.push({
       questionText:
@@ -118,6 +121,8 @@ function buildDiscrepancyQuestions(comparison, higherLabel, lowerLabel) {
         `Is this a drop in ${lowerLabel} that needs to be added, or was the ${higherLabel} mention out-of-date?`,
       scope: 'user',
       rationale: `Discrepancy: claim "${claim}" present in ${higherLabel}, absent in ${lowerLabel}.`,
+      kind: 'discrepancy',
+      applyKey: claim,
     });
   }
   for (const claim of comparison.extraInLower) {
@@ -127,6 +132,8 @@ function buildDiscrepancyQuestions(comparison, higherLabel, lowerLabel) {
         `Is this a legitimate ${lowerLabel}-level decision, or scope creep that should be removed?`,
       scope: 'user',
       rationale: `Discrepancy: claim "${claim}" absent in ${higherLabel}, present in ${lowerLabel}.`,
+      kind: 'discrepancy',
+      applyKey: claim,
     });
   }
   return qs;

--- a/plugins/work/scripts/workflows/work/lib/__tests__/apply-gate-resolutions.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/apply-gate-resolutions.test.js
@@ -1,0 +1,284 @@
+/**
+ * Tests for apply-gate-resolutions.js (GH-543, PR1) — the kind-routing
+ * persistence library behind the brief_gate answers-file transport.
+ *
+ * Covers:
+ *   - envelope routing per question kind, in parser-round-trip format
+ *     (open-questions.parse / findUnresolvedSiblingGaps /
+ *     extractRecordedDecisions all see the item as resolved afterwards)
+ *   - creation of missing decision sections
+ *   - idempotency (double-apply is byte-identical; re-applied keys skipped)
+ *   - injection-class answers (single quotes, backticks, newlines, leading #)
+ *   - flat string-map back-compat coercion to { openQuestions }
+ *   - library-level step guard (refuse only on positive mismatch)
+ *
+ * Run: node --test scripts/workflows/work/lib/__tests__/apply-gate-resolutions.test.js
+ */
+
+'use strict';
+
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { applyGateResolutions, isFullyApplied } = require('../apply-gate-resolutions');
+const openQuestions = require('../open-questions');
+const { findUnresolvedSiblingGaps } = require('../../../lib/brief-sibling-gaps');
+const { extractRecordedDecisions } = require('../../../lib/discrepancy');
+
+const OPEN_Q = 'Which queue backend should we adopt for cross-service jobs?';
+
+const BRIEF_MIXED = [
+  '# Brief',
+  '',
+  '## Open Questions',
+  '',
+  `- **Question:** ${OPEN_Q}`,
+  '  - `scope: architectural`',
+  '  - `rationale: affects all downstream services`',
+  '  - `resolved: false`',
+  '',
+  '## Out of scope (sibling-owned)',
+  '- `lib/x.ts` — owned by GH-100 (status: Done, PR: #50). Reason: read path missing.',
+  '',
+].join('\n');
+
+const createdDirs = [];
+
+function makeBrief(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'apply-gate-res-'));
+  createdDirs.push(dir);
+  const briefPath = path.join(dir, 'brief.md');
+  fs.writeFileSync(briefPath, content, 'utf8');
+  return { dir, briefPath };
+}
+
+function writeState(dir, stepStatus) {
+  fs.writeFileSync(path.join(dir, '.work-state.json'), JSON.stringify({ stepStatus }), 'utf8');
+}
+
+afterEach(() => {
+  while (createdDirs.length) {
+    fs.rmSync(createdDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('applyGateResolutions — kind routing (parser round-trip)', () => {
+  it('routes openQuestions to Resolution lines that open-questions.parse sees as resolved', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    const result = applyGateResolutions(briefPath, {
+      openQuestions: { [OPEN_Q]: 'Use SQS for all cross-service jobs.' },
+    });
+    assert.equal(result.changed, true);
+    assert.equal(result.refused, null);
+    const updated = fs.readFileSync(briefPath, 'utf8');
+    const parsed = openQuestions.parse(updated);
+    assert.equal(openQuestions.findBlocking(parsed).length, 0, 'question must no longer block');
+    const q = parsed.find((p) => p.questionText === OPEN_Q);
+    assert.ok(q && q.resolved === true, 'question must be resolved on re-parse');
+    assert.match(q.resolution || '', /Use SQS/);
+  });
+
+  it('routes siblingGaps to ## Sibling-gap decisions in the format findUnresolvedSiblingGaps parses', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    assert.equal(
+      findUnresolvedSiblingGaps(fs.readFileSync(briefPath, 'utf8')).unresolved.length,
+      1
+    );
+    const result = applyGateResolutions(briefPath, {
+      siblingGaps: [{ surface: 'lib/x.ts', decision: 'wait-for-sibling' }],
+    });
+    assert.equal(result.changed, true);
+    const updated = fs.readFileSync(briefPath, 'utf8');
+    const gaps = findUnresolvedSiblingGaps(updated);
+    assert.equal(gaps.unresolved.length, 0, 'gap must be resolved on re-parse');
+    assert.equal(gaps.decisions.length, 1);
+    assert.equal(gaps.decisions[0].surface, 'lib/x.ts');
+    assert.match(updated, /## Sibling-gap decisions/);
+    assert.match(updated, /- `lib\/x\.ts` — decision: wait-for-sibling; timestamp: /);
+  });
+
+  it('routes discrepancies to ## Discrepancy decisions in the format extractRecordedDecisions parses', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    const result = applyGateResolutions(briefPath, {
+      discrepancies: [{ claim: 'lib/legacy.ts', decision: 'out-of-date mention, drop it' }],
+    });
+    assert.equal(result.changed, true);
+    const updated = fs.readFileSync(briefPath, 'utf8');
+    const recorded = extractRecordedDecisions(updated);
+    assert.ok(recorded.has('lib/legacy.ts'), 'claim must be recorded on re-parse');
+    assert.match(updated, /## Discrepancy decisions/);
+    assert.match(updated, /- `lib\/legacy\.ts` — out-of-date mention, drop it/);
+  });
+
+  it('applies all three kinds from one envelope and reports each key applied', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    const result = applyGateResolutions(briefPath, {
+      openQuestions: { [OPEN_Q]: 'Use SQS.' },
+      siblingGaps: [{ surface: 'lib/x.ts', decision: 'implement-here' }],
+      discrepancies: [{ claim: 'lib/legacy.ts', decision: 'drop it' }],
+    });
+    assert.equal(result.changed, true);
+    assert.equal(result.applied.length, 3);
+    assert.deepEqual(result.skipped, []);
+    assert.equal(isFullyApplied(result), true);
+    const updated = fs.readFileSync(briefPath, 'utf8');
+    assert.equal(openQuestions.findBlocking(openQuestions.parse(updated)).length, 0);
+    assert.equal(findUnresolvedSiblingGaps(updated).unresolved.length, 0);
+    assert.ok(extractRecordedDecisions(updated).has('lib/legacy.ts'));
+  });
+
+  it('creates missing decision sections when the brief has none', () => {
+    const { briefPath } = makeBrief('# Brief\n\nBody only.\n');
+    const result = applyGateResolutions(briefPath, {
+      siblingGaps: [{ surface: 'lib/y.ts', decision: 'wait-for-sibling' }],
+      discrepancies: [{ claim: 'lib/z.ts', decision: 'keep' }],
+    });
+    assert.equal(result.changed, true);
+    const updated = fs.readFileSync(briefPath, 'utf8');
+    assert.match(updated, /## Sibling-gap decisions/);
+    assert.match(updated, /## Discrepancy decisions/);
+    assert.equal(findUnresolvedSiblingGaps(updated).decisions.length, 1);
+    assert.ok(extractRecordedDecisions(updated).has('lib/z.ts'));
+  });
+});
+
+describe('applyGateResolutions — idempotency', () => {
+  it('double-apply is byte-identical and reports keys as already-recorded', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    const envelope = {
+      openQuestions: { [OPEN_Q]: 'Use SQS.' },
+      siblingGaps: [{ surface: 'lib/x.ts', decision: 'implement-here' }],
+      discrepancies: [{ claim: 'lib/legacy.ts', decision: 'drop it' }],
+    };
+    const first = applyGateResolutions(briefPath, envelope);
+    assert.equal(first.changed, true);
+    const afterFirst = fs.readFileSync(briefPath, 'utf8');
+
+    const second = applyGateResolutions(briefPath, envelope);
+    assert.equal(second.changed, false);
+    assert.equal(second.applied.length, 0);
+    assert.equal(second.skipped.length, 3);
+    for (const s of second.skipped) assert.equal(s.reason, 'already-recorded');
+    assert.equal(isFullyApplied(second), true, 'already-recorded skips count as success');
+
+    const afterSecond = fs.readFileSync(briefPath, 'utf8');
+    assert.equal(afterSecond, afterFirst, 'double-apply must be byte-identical');
+  });
+
+  it('reports unknown open-question keys as skipped (not already-recorded)', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    const before = fs.readFileSync(briefPath, 'utf8');
+    const result = applyGateResolutions(briefPath, {
+      openQuestions: { 'A question that is not in the brief?': 'answer' },
+    });
+    assert.equal(result.changed, false);
+    assert.equal(result.applied.length, 0);
+    assert.equal(result.skipped.length, 1);
+    assert.equal(result.skipped[0].reason, 'unknown-question');
+    assert.equal(isFullyApplied(result), false);
+    assert.equal(fs.readFileSync(briefPath, 'utf8'), before, 'brief.md must be untouched');
+  });
+});
+
+describe('applyGateResolutions — injection-class answers', () => {
+  it('persists answers with single quotes, backticks, newlines, and leading # safely', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    const before = openQuestions.parse(fs.readFileSync(briefPath, 'utf8')).length;
+    const nasty = "# Heading\nit's a `tricky` answer\n```\nfenced\n```";
+    const result = applyGateResolutions(briefPath, {
+      openQuestions: { [OPEN_Q]: nasty },
+      siblingGaps: [{ surface: 'lib/x.ts', decision: "don't wait\n## Injected" }],
+      discrepancies: [{ claim: 'lib/legacy.ts', decision: "it's fine\n# nope" }],
+    });
+    assert.equal(result.changed, true);
+    const updated = fs.readFileSync(briefPath, 'utf8');
+    // Structure preserved: same question count, question resolved, no fences.
+    const parsed = openQuestions.parse(updated);
+    assert.equal(parsed.length, before, 'question count must survive the rewrite');
+    assert.equal(parsed.find((q) => q.questionText === OPEN_Q).resolved, true);
+    assert.ok(!updated.includes('```'), 'no markdown fence may survive escaping');
+    assert.ok(!/^## Injected/m.test(updated), 'answers must not inject new headings');
+    assert.ok(!/^# nope/m.test(updated), 'answers must not inject new headings');
+    // Sibling gap + discrepancy still round-trip as resolved.
+    assert.equal(findUnresolvedSiblingGaps(updated).unresolved.length, 0);
+    assert.ok(extractRecordedDecisions(updated).has('lib/legacy.ts'));
+  });
+});
+
+describe('applyGateResolutions — flat string-map back-compat', () => {
+  it('coerces a flat questionText→answer map to { openQuestions }', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    const result = applyGateResolutions(briefPath, { [OPEN_Q]: 'Use SQS.' });
+    assert.equal(result.changed, true);
+    const updated = fs.readFileSync(briefPath, 'utf8');
+    assert.equal(openQuestions.findBlocking(openQuestions.parse(updated)).length, 0);
+  });
+
+  it('coerces a Map to { openQuestions }', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    const result = applyGateResolutions(briefPath, new Map([[OPEN_Q, 'Use SQS.']]));
+    assert.equal(result.changed, true);
+  });
+
+  it('returns an all-empty result for nullish / empty / primitive payloads without touching brief.md', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    const before = fs.readFileSync(briefPath, 'utf8');
+    for (const payload of [undefined, null, {}, 42, 'nope', true]) {
+      const result = applyGateResolutions(briefPath, payload);
+      assert.equal(result.changed, false);
+      assert.equal(result.applied.length, 0);
+      assert.equal(result.refused, null);
+    }
+    assert.equal(fs.readFileSync(briefPath, 'utf8'), before);
+  });
+});
+
+describe('applyGateResolutions — step guard', () => {
+  const envelope = () => ({ openQuestions: { [OPEN_Q]: 'Use SQS.' } });
+
+  it('refuses when .work-state.json shows spec in_progress', () => {
+    const { dir, briefPath } = makeBrief(BRIEF_MIXED);
+    writeState(dir, { brief: 'completed', brief_gate: 'completed', spec: 'in_progress' });
+    const before = fs.readFileSync(briefPath, 'utf8');
+    const result = applyGateResolutions(briefPath, envelope());
+    assert.equal(result.changed, false);
+    assert.equal(result.refused, 'step');
+    assert.match(result.message, /brief_gate/);
+    assert.match(result.message, /work-next\.js/, 'refusal must point at the repair route');
+    assert.equal(fs.readFileSync(briefPath, 'utf8'), before, 'brief.md must be untouched');
+  });
+
+  it('allows when brief_gate is in_progress', () => {
+    const { dir, briefPath } = makeBrief(BRIEF_MIXED);
+    writeState(dir, { brief: 'completed', brief_gate: 'in_progress' });
+    const result = applyGateResolutions(briefPath, envelope());
+    assert.equal(result.refused, null);
+    assert.equal(result.changed, true);
+  });
+
+  it('allows when no .work-state.json exists (unit tests / ad-hoc use)', () => {
+    const { briefPath } = makeBrief(BRIEF_MIXED);
+    const result = applyGateResolutions(briefPath, envelope());
+    assert.equal(result.refused, null);
+    assert.equal(result.changed, true);
+  });
+
+  it('allows when the state file has NO step in_progress (transition window)', () => {
+    const { dir, briefPath } = makeBrief(BRIEF_MIXED);
+    writeState(dir, { brief: 'completed' });
+    const result = applyGateResolutions(briefPath, envelope());
+    assert.equal(result.refused, null);
+    assert.equal(result.changed, true);
+  });
+
+  it('allows when corrupt state shows BOTH brief and brief_gate in_progress (allow-first)', () => {
+    const { dir, briefPath } = makeBrief(BRIEF_MIXED);
+    writeState(dir, { brief: 'in_progress', brief_gate: 'in_progress' });
+    const result = applyGateResolutions(briefPath, envelope());
+    assert.equal(result.refused, null, 'corrupt states must fail toward the sanctioned path');
+    assert.equal(result.changed, true);
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/apply-gate-resolutions.js
+++ b/plugins/work/scripts/workflows/work/lib/apply-gate-resolutions.js
@@ -1,0 +1,331 @@
+/**
+ * workflows/work/lib/apply-gate-resolutions.js (GH-543)
+ *
+ * Kind-routing persistence for brief_gate answers. One envelope carries the
+ * user's answers for every question kind the gate can emit, and each kind is
+ * persisted into brief.md in the exact format its parser reads back:
+ *
+ *   - `openQuestions`  — { questionText → answer } map, routed through
+ *     `open-questions.applyResolutions` (Resolution lines, `resolved: true`).
+ *   - `siblingGaps`    — [{ surface, decision }], appended as
+ *     '- `<surface>` — decision: <decision>; timestamp: <ISO>' bullets under
+ *     `## Sibling-gap decisions` (the format `_decomposeDecisionEntry` in
+ *     brief-sibling-gaps.js parses).
+ *   - `discrepancies`  — [{ claim, decision }], appended as
+ *     '- `<claim>` — <decision>' bullets under `## Discrepancy decisions`
+ *     (the format `extractRecordedDecisions` in discrepancy.js parses).
+ *
+ * A flat string-map payload (the legacy applyBriefResolutions shape) coerces
+ * to `{ openQuestions: map }` for back-compat.
+ *
+ * All user answers pass through `escapeResolution` so a quote, backtick,
+ * newline, or leading `#` can never break the markdown structure (the
+ * argv-injection regression class this module replaces). Already-recorded
+ * keys are skipped, so double-apply is byte-identical.
+ *
+ * Step guard (fail-open, refuse only on positive mismatch): if
+ * `.work-state.json` exists next to brief.md and a step OTHER than
+ * brief_gate is positively `in_progress`, the write is refused with a
+ * pointer at the work-next.js repair route. The check is allow-first on
+ * `stepStatus.brief_gate === 'in_progress'`, so corrupt states that show
+ * several steps in_progress still fail toward the sanctioned path. No state
+ * file (unit tests, ad-hoc use) → allow.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const openQuestions = require('./open-questions');
+const { findUnresolvedSiblingGaps } = require('../../lib/brief-sibling-gaps');
+const { extractRecordedDecisions } = require('../../lib/discrepancy');
+
+/** Consume-once transport buffer written by the driver, read by the CLI. */
+const DEFAULT_ANSWERS_BASENAME = '.brief-gate-answers.json';
+
+const ENVELOPE_KEYS = ['openQuestions', 'siblingGaps', 'discrepancies'];
+
+const SECTION_HEADERS = {
+  siblingGaps: 'Sibling-gap decisions',
+  discrepancies: 'Discrepancy decisions',
+};
+
+/**
+ * Mirror of discrepancy.js `_normalize` (not exported there): the claim-token
+ * normalization `extractRecordedDecisions` applies to recorded bullets, so
+ * idempotency matching sees exactly what the parser sees.
+ */
+function normalizeClaimToken(token) {
+  return String(token || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[.,;:!?]+$/, '');
+}
+
+/** Coerce a Map/object of string→string into a plain Map (drop non-strings). */
+function toStringMap(value) {
+  const out = new Map();
+  if (!value || typeof value !== 'object') return out;
+  const entries = value instanceof Map ? value.entries() : Object.entries(value);
+  for (const [k, v] of entries) {
+    if (typeof k === 'string' && typeof v === 'string') out.set(k, v);
+  }
+  return out;
+}
+
+/**
+ * Normalize any accepted payload into
+ * `{ openQuestions: Map, siblingGaps: [], discrepancies: [] }`.
+ * A Map, or a plain object carrying NONE of the envelope keys, is treated as
+ * the legacy flat questionText→answer map.
+ */
+function normalizeEnvelope(payload) {
+  const empty = { openQuestions: new Map(), siblingGaps: [], discrepancies: [] };
+  if (!payload || typeof payload !== 'object') return empty;
+  const isFlatMap = payload instanceof Map || !ENVELOPE_KEYS.some((k) => Object.hasOwn(payload, k));
+  if (isFlatMap) return { ...empty, openQuestions: toStringMap(payload) };
+  return {
+    openQuestions: toStringMap(payload.openQuestions),
+    siblingGaps: Array.isArray(payload.siblingGaps) ? payload.siblingGaps : [],
+    discrepancies: Array.isArray(payload.discrepancies) ? payload.discrepancies : [],
+  };
+}
+
+function countEntries(envelope) {
+  return envelope.openQuestions.size + envelope.siblingGaps.length + envelope.discrepancies.length;
+}
+
+/**
+ * Library-level step guard. Returns a refusal message string, or null to
+ * allow. See the module doc for the allow-first contract.
+ */
+function checkStepGuard(briefPath) {
+  const statePath = path.join(path.dirname(briefPath), '.work-state.json');
+  let state;
+  try {
+    state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  } catch {
+    return null; // no state file / unreadable / unparseable → no positive evidence → allow
+  }
+  const stepStatus = state && typeof state === 'object' ? state.stepStatus : null;
+  if (!stepStatus || typeof stepStatus !== 'object') return null;
+  // Allow-first: brief_gate positively in_progress wins even when a corrupt
+  // state shows other steps in_progress alongside it.
+  if (stepStatus.brief_gate === 'in_progress') return null;
+  const other = Object.keys(stepStatus).find((s) => stepStatus[s] === 'in_progress');
+  if (!other) return null; // transition window — nothing positively in_progress
+  return (
+    `apply-gate-resolutions: refusing to modify brief.md — brief_gate is not in progress ` +
+    `(current step: ${other}). This is not a hard block: brief_gate already re-derives ` +
+    `pending questions from brief.md, so if these answers are stale simply delete the ` +
+    `answers file and re-run work-next.js.`
+  );
+}
+
+/** Sanitize a key destined for a backtick-wrapped bullet token. */
+function sanitizeBulletKey(key) {
+  if (typeof key !== 'string') return '';
+  return openQuestions.escapeResolution(key).replace(/`/g, '').trim();
+}
+
+/**
+ * Append bullets to a `## <headerText>` section, creating the section at the
+ * end of the document when absent. Insertion goes after the section's last
+ * non-blank line so existing bullets keep their order.
+ */
+function appendBulletsToSection(markdown, headerText, bullets) {
+  if (bullets.length === 0) return markdown;
+  const lines = markdown.split('\n');
+  const headerRe = new RegExp(
+    `^##\\s+${headerText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`,
+    'i'
+  );
+  const headerIdx = lines.findIndex((l) => headerRe.test(l));
+
+  if (headerIdx === -1) {
+    const insertAt = lines[lines.length - 1] === '' ? lines.length - 1 : lines.length;
+    const block = [];
+    if (insertAt > 0 && lines[insertAt - 1].trim() !== '') block.push('');
+    block.push(`## ${headerText}`, '', ...bullets);
+    lines.splice(insertAt, 0, ...block);
+    return lines.join('\n');
+  }
+
+  let sectionEnd = lines.length;
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    if (/^##\s/.test(lines[i])) {
+      sectionEnd = i;
+      break;
+    }
+  }
+  let insertAt = sectionEnd;
+  while (insertAt > headerIdx + 1 && lines[insertAt - 1].trim() === '') insertAt -= 1;
+  lines.splice(insertAt, 0, ...bullets);
+  return lines.join('\n');
+}
+
+/** Route the openQuestions map. Mutates `applied`/`skipped`; returns markdown. */
+function applyOpenQuestions(markdown, resolutionsMap, applied, skipped) {
+  if (resolutionsMap.size === 0) return markdown;
+  const parsed = openQuestions.parse(markdown);
+  const applicable = new Map();
+  for (const [key, answer] of resolutionsMap) {
+    const q = parsed.find((p) => p.questionText === key);
+    if (!q) {
+      skipped.push({ kind: 'open-question', key, reason: 'unknown-question' });
+    } else if (q.resolved === true) {
+      skipped.push({ kind: 'open-question', key, reason: 'already-recorded' });
+    } else if (openQuestions.escapeResolution(answer) === '') {
+      skipped.push({ kind: 'open-question', key, reason: 'empty-answer' });
+    } else {
+      applicable.set(key, answer);
+      applied.push({ kind: 'open-question', key });
+    }
+  }
+  if (applicable.size === 0) return markdown;
+  // applyResolutions owns escaping + idempotency for the block rewrite.
+  return openQuestions.applyResolutions(markdown, applicable);
+}
+
+/** Route the siblingGaps list. Mutates `applied`/`skipped`; returns markdown. */
+function applySiblingGaps(markdown, gaps, applied, skipped) {
+  if (gaps.length === 0) return markdown;
+  const decided = new Set(
+    findUnresolvedSiblingGaps(markdown).decisions.map((d) => d.surface.toLowerCase())
+  );
+  const bullets = [];
+  const timestamp = new Date().toISOString();
+  for (const gap of gaps) {
+    const surface = sanitizeBulletKey(gap && gap.surface);
+    const decision = openQuestions.escapeResolution(gap && gap.decision);
+    if (!surface || !decision) {
+      skipped.push({
+        kind: 'sibling-gap',
+        key: (gap && gap.surface) || '',
+        reason: 'invalid-entry',
+      });
+      continue;
+    }
+    if (decided.has(surface.toLowerCase())) {
+      skipped.push({ kind: 'sibling-gap', key: surface, reason: 'already-recorded' });
+      continue;
+    }
+    decided.add(surface.toLowerCase());
+    // Exact format _decomposeDecisionEntry parses (surface token in backticks).
+    bullets.push(`- \`${surface}\` — decision: ${decision}; timestamp: ${timestamp}`);
+    applied.push({ kind: 'sibling-gap', key: surface });
+  }
+  return appendBulletsToSection(markdown, SECTION_HEADERS.siblingGaps, bullets);
+}
+
+/** Route the discrepancies list. Mutates `applied`/`skipped`; returns markdown. */
+function applyDiscrepancies(markdown, discrepancies, applied, skipped) {
+  if (discrepancies.length === 0) return markdown;
+  const recorded = extractRecordedDecisions(markdown);
+  const bullets = [];
+  for (const item of discrepancies) {
+    const claim = sanitizeBulletKey(item && item.claim);
+    const decision = openQuestions.escapeResolution(item && item.decision);
+    if (!claim || !decision) {
+      skipped.push({
+        kind: 'discrepancy',
+        key: (item && item.claim) || '',
+        reason: 'invalid-entry',
+      });
+      continue;
+    }
+    const normalized = normalizeClaimToken(claim);
+    if (recorded.has(normalized)) {
+      skipped.push({ kind: 'discrepancy', key: claim, reason: 'already-recorded' });
+      continue;
+    }
+    recorded.add(normalized);
+    // Exact format extractRecordedDecisions parses (claim token in backticks).
+    bullets.push(`- \`${claim}\` — ${decision}`);
+    applied.push({ kind: 'discrepancy', key: claim });
+  }
+  return appendBulletsToSection(markdown, SECTION_HEADERS.discrepancies, bullets);
+}
+
+/** Mark every envelope entry as skipped with one shared reason. */
+function skipAllEntries(envelope, reason) {
+  const skipped = [];
+  for (const [key] of envelope.openQuestions) {
+    skipped.push({ kind: 'open-question', key, reason });
+  }
+  for (const gap of envelope.siblingGaps) {
+    skipped.push({ kind: 'sibling-gap', key: (gap && gap.surface) || '', reason });
+  }
+  for (const item of envelope.discrepancies) {
+    skipped.push({ kind: 'discrepancy', key: (item && item.claim) || '', reason });
+  }
+  return skipped;
+}
+
+/**
+ * Apply a resolutions envelope to brief.md, routing each kind to its section.
+ *
+ * @param {string} briefPath
+ * @param {object|Map|null|undefined} payload — envelope
+ *   `{ openQuestions?, siblingGaps?, discrepancies? }` or a legacy flat
+ *   questionText→answer map.
+ * @returns {{ changed: boolean,
+ *             applied: Array<{kind: string, key: string}>,
+ *             skipped: Array<{kind: string, key: string, reason: string}>,
+ *             refused: 'step'|null,
+ *             message?: string }}
+ */
+function applyGateResolutions(briefPath, payload) {
+  const result = { changed: false, applied: [], skipped: [], refused: null };
+  const envelope = normalizeEnvelope(payload);
+  // Cancellation / empty payload — no I/O at all (not even the guard probe).
+  if (countEntries(envelope) === 0) return result;
+
+  const guardMessage = checkStepGuard(briefPath);
+  if (guardMessage) {
+    return { ...result, refused: 'step', message: guardMessage };
+  }
+
+  let markdown;
+  try {
+    markdown = fs.readFileSync(briefPath, 'utf8');
+  } catch {
+    return { ...result, skipped: skipAllEntries(envelope, 'brief-unreadable') };
+  }
+
+  let updated = markdown;
+  updated = applyOpenQuestions(updated, envelope.openQuestions, result.applied, result.skipped);
+  updated = applySiblingGaps(updated, envelope.siblingGaps, result.applied, result.skipped);
+  updated = applyDiscrepancies(updated, envelope.discrepancies, result.applied, result.skipped);
+
+  if (updated === markdown) return result;
+
+  try {
+    fs.writeFileSync(briefPath, updated, 'utf8');
+  } catch {
+    // Fail-closed no-throw contract: nothing persisted, report every
+    // would-be-applied entry as skipped so the caller retains the answers.
+    result.skipped.push(
+      ...result.applied.map((a) => ({ kind: a.kind, key: a.key, reason: 'write-failed' }))
+    );
+    result.applied = [];
+    return result;
+  }
+  result.changed = true;
+  return result;
+}
+
+/**
+ * True when every envelope entry was applied or was already recorded — the
+ * condition under which the answers file may be consumed (deleted).
+ */
+function isFullyApplied(result) {
+  if (!result || result.refused) return false;
+  return (result.skipped || []).every((s) => s && s.reason === 'already-recorded');
+}
+
+module.exports = {
+  applyGateResolutions,
+  isFullyApplied,
+  DEFAULT_ANSWERS_BASENAME,
+};

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/brief-gate.test.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/brief-gate.test.js
@@ -199,3 +199,84 @@ describe('brief-gate open-questions handling (regression)', () => {
     assert.match(entry._overrideInstruction.reason, /user input/);
   });
 });
+
+describe('brief-gate answers-file transport (GH-543)', () => {
+  beforeEach(() => {
+    fs.writeFileSync(path.join(tmp, 'related-tickets.json'), JSON.stringify(validManifest()));
+  });
+
+  function blockedEntry() {
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = {
+      step: 'brief_gate',
+      askUserQuestionPayload: {
+        questions: [
+          {
+            questionText: 'Cross-ticket Q?',
+            scope: 'user',
+            kind: 'open-question',
+            applyKey: 'Cross-ticket Q?',
+          },
+        ],
+      },
+    };
+    reg.run('brief_gate', entry, ctx());
+    assert.ok(entry._overrideInstruction, 'expected blocked override');
+    return entry._overrideInstruction;
+  }
+
+  it('applyCommand invokes the answers-file CLI with no inline JSON placeholder', () => {
+    const override = blockedEntry();
+    assert.match(override.applyCommand, /apply-brief-gate-answers\.js/);
+    assert.ok(
+      override.applyCommand.includes(path.join(tmp, 'brief.md')),
+      'applyCommand must carry the brief path'
+    );
+    assert.ok(
+      !override.applyCommand.includes('<JSON_MAP>'),
+      'applyCommand must not carry an inline JSON placeholder'
+    );
+    assert.ok(
+      !override.applyCommand.includes('node -e'),
+      'applyCommand must not be a node -e one-liner'
+    );
+  });
+
+  it('hint documents the envelope shape and the answers-file path', () => {
+    const override = blockedEntry();
+    assert.match(override.hint, /\.brief-gate-answers\.json/);
+    assert.match(override.hint, /openQuestions/);
+    assert.match(override.hint, /siblingGaps/);
+    assert.match(override.hint, /discrepancies/);
+    assert.match(override.hint, /work-next\.js/);
+  });
+
+  it('userQuestions carry kind and applyKey for envelope routing', () => {
+    const override = blockedEntry();
+    assert.equal(override.userQuestions.length, 1);
+    assert.equal(override.userQuestions[0].kind, 'open-question');
+    assert.equal(override.userQuestions[0].applyKey, 'Cross-ticket Q?');
+  });
+
+  it('injected sibling-gap questions carry kind/applyKey/options through to userQuestions', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'brief.md'),
+      [
+        '## Out of scope (sibling-owned)',
+        '- `lib/x.ts` — owned by GH-100 (status: Done, PR: #50). Reason: read path missing.',
+        '',
+      ].join('\n')
+    );
+    const reg = makeRegistry();
+    registerBriefGate(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.ok(entry._overrideInstruction);
+    const qs = entry._overrideInstruction.userQuestions;
+    assert.equal(qs.length, 1);
+    assert.equal(qs[0].kind, 'sibling-gap');
+    assert.equal(qs[0].applyKey, 'lib/x.ts');
+    assert.deepEqual(qs[0].options, ['implement-here', 'wait-for-sibling']);
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/brief-gate.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/brief-gate.js
@@ -64,6 +64,43 @@ function buildRelatedTicketsBlocker(ticket, tasksDir, pathMod, fs, providerConfi
   };
 }
 
+/**
+ * Blocked instruction for cross-ticket/user questions (GH-543 file
+ * transport): answers travel via a consume-once JSON envelope file, so
+ * quotes/backticks/newlines in an answer can never break (or execute on) a
+ * shell command line the way the old inline '<JSON_MAP>' argv did.
+ */
+function buildUserQuestionsBlocker(userQs, localQs, briefPath, ctx) {
+  const { tasksDir, workDir, path: pathMod } = ctx;
+  const answersPath = pathMod.join(tasksDir, '.brief-gate-answers.json');
+  const applyCliPath = pathMod.join(workDir, 'scripts', 'apply-brief-gate-answers.js');
+  return {
+    type: 'work_instruction',
+    action: 'blocked',
+    reason: 'brief_gate requires user input for cross-ticket questions',
+    userQuestions: userQs.map((q, i) => ({
+      index: i + 1,
+      question: q.questionText,
+      rationale: q.rationale || '',
+      scope: q.scope,
+      // Envelope routing keys (GH-543). Questions from producers that
+      // predate tagging default to the open-question lane.
+      kind: q.kind || 'open-question',
+      applyKey: q.applyKey || q.questionText,
+      ...(Array.isArray(q.options) ? { options: q.options } : {}),
+    })),
+    localQuestions: localQs.map((q) => q.questionText),
+    applyCommand: `node "${applyCliPath}" "${briefPath}"`,
+    hint:
+      `Ask the userQuestions, then Write the answers to ${answersPath} as a JSON envelope ` +
+      `routed by each question's kind: {"openQuestions": {"<applyKey>": "<answer>", ...}, ` +
+      `"siblingGaps": [{"surface": "<applyKey>", "decision": "implement-here|wait-for-sibling"}, ...], ` +
+      `"discrepancies": [{"claim": "<applyKey>", "decision": "<answer>"}, ...]}. ` +
+      'Then run the applyCommand (it persists every kind into brief.md and consumes the ' +
+      'answers file on full apply) and re-run work-next.js after.',
+  };
+}
+
 module.exports = function registerBriefGate(register) {
   register('brief_gate', (entry, ctx) => {
     const { tasksDir, ticket, workDir, path, fs } = ctx;
@@ -128,19 +165,6 @@ module.exports = function registerBriefGate(register) {
     entry._briefPath = briefPath;
 
     // Return a blocked instruction instead — the orchestrator must ask the user
-    entry._overrideInstruction = {
-      type: 'work_instruction',
-      action: 'blocked',
-      reason: 'brief_gate requires user input for cross-ticket questions',
-      userQuestions: userQs.map((q, i) => ({
-        index: i + 1,
-        question: q.questionText,
-        rationale: q.rationale || '',
-        scope: q.scope,
-      })),
-      localQuestions: localQs.map((q) => q.questionText),
-      applyCommand: `node -e "require('${briefGatePath}').applyBriefResolutions('${briefPath}', JSON.parse(process.argv[1]))" '<JSON_MAP>'`,
-      hint: 'Answer the userQuestions, then run the applyCommand with a JSON map of questionText → answer. Re-run work-next.js after.',
-    };
+    entry._overrideInstruction = buildUserQuestionsBlocker(userQs, localQs, briefPath, ctx);
   });
 };

--- a/plugins/work/scripts/workflows/work/scripts/__tests__/apply-brief-gate-answers.test.js
+++ b/plugins/work/scripts/workflows/work/scripts/__tests__/apply-brief-gate-answers.test.js
@@ -1,0 +1,181 @@
+/**
+ * Tests for apply-brief-gate-answers.js (GH-543, PR1) — the file/stdin CLI
+ * transport that replaces both argv-JSON resolution transports.
+ *
+ * Covers:
+ *   - default answers-file path (<dirname(briefPath)>/.brief-gate-answers.json)
+ *   - --stdin transport
+ *   - answers file deleted ONLY on full apply (partial apply keeps it and
+ *     reports skipped keys)
+ *   - exit codes 0/1
+ *   - malformed JSON → exit 1, brief.md untouched
+ *
+ * Run: node --test scripts/workflows/work/scripts/__tests__/apply-brief-gate-answers.test.js
+ */
+
+'use strict';
+
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const CLI = path.join(__dirname, '..', 'apply-brief-gate-answers.js');
+
+const OPEN_Q = 'Which queue backend should we adopt for cross-service jobs?';
+
+const BRIEF = [
+  '# Brief',
+  '',
+  '## Open Questions',
+  '',
+  `- **Question:** ${OPEN_Q}`,
+  '  - `scope: architectural`',
+  '  - `rationale: affects all downstream services`',
+  '  - `resolved: false`',
+  '',
+  '## Out of scope (sibling-owned)',
+  '- `lib/x.ts` — owned by GH-100. Reason: read path missing.',
+  '',
+].join('\n');
+
+const createdDirs = [];
+
+function makeFixture({ answers } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'apply-answers-cli-'));
+  createdDirs.push(dir);
+  const briefPath = path.join(dir, 'brief.md');
+  fs.writeFileSync(briefPath, BRIEF, 'utf8');
+  const answersPath = path.join(dir, '.brief-gate-answers.json');
+  if (answers !== undefined) {
+    fs.writeFileSync(answersPath, answers, 'utf8');
+  }
+  return { dir, briefPath, answersPath };
+}
+
+function runCli(args, opts = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8', ...opts });
+}
+
+afterEach(() => {
+  while (createdDirs.length) {
+    fs.rmSync(createdDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('apply-brief-gate-answers CLI', () => {
+  it('reads the default .brief-gate-answers.json, applies it, deletes it, exits 0', () => {
+    const envelope = {
+      openQuestions: { [OPEN_Q]: 'Use SQS.' },
+      siblingGaps: [{ surface: 'lib/x.ts', decision: 'wait-for-sibling' }],
+    };
+    const { briefPath, answersPath } = makeFixture({ answers: JSON.stringify(envelope) });
+
+    const res = runCli([briefPath]);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+
+    const updated = fs.readFileSync(briefPath, 'utf8');
+    assert.match(updated, /\*\*Resolution:\*\* Use SQS\./);
+    assert.match(updated, /- `lib\/x\.ts` — decision: wait-for-sibling/);
+    assert.equal(fs.existsSync(answersPath), false, 'answers file must be consumed on full apply');
+
+    const summary = JSON.parse(res.stdout);
+    assert.equal(summary.changed, true);
+    assert.equal(summary.deletedAnswersFile, true);
+  });
+
+  it('reads the envelope from --stdin without touching any answers file', () => {
+    const { briefPath, answersPath } = makeFixture();
+    const envelope = { openQuestions: { [OPEN_Q]: 'Use SQS.' } };
+
+    const res = runCli([briefPath, '--stdin'], { input: JSON.stringify(envelope) });
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+    assert.match(fs.readFileSync(briefPath, 'utf8'), /\*\*Resolution:\*\* Use SQS\./);
+    assert.equal(fs.existsSync(answersPath), false);
+  });
+
+  it('reads from an explicit --file path', () => {
+    const { dir, briefPath } = makeFixture();
+    const altPath = path.join(dir, 'alt-answers.json');
+    fs.writeFileSync(altPath, JSON.stringify({ openQuestions: { [OPEN_Q]: 'Use SQS.' } }));
+
+    const res = runCli([briefPath, '--file', altPath]);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+    assert.equal(fs.existsSync(altPath), false, 'explicit answers file is consumed too');
+  });
+
+  it('keeps the answers file and lists skipped keys on partial apply, exits 1', () => {
+    const envelope = {
+      openQuestions: {
+        [OPEN_Q]: 'Use SQS.',
+        'A question the brief does not contain?': 'orphan answer',
+      },
+    };
+    const { briefPath, answersPath } = makeFixture({ answers: JSON.stringify(envelope) });
+
+    const res = runCli([briefPath]);
+    assert.equal(res.status, 1, 'partial apply must exit 1');
+    assert.equal(fs.existsSync(answersPath), true, 'answers file must survive a partial apply');
+
+    const summary = JSON.parse(res.stdout);
+    assert.equal(summary.deletedAnswersFile, false);
+    const skippedKeys = summary.skipped.map((s) => s.key);
+    assert.ok(skippedKeys.includes('A question the brief does not contain?'));
+    // The applicable answer still persisted — partial apply is not all-or-nothing.
+    assert.match(fs.readFileSync(briefPath, 'utf8'), /\*\*Resolution:\*\* Use SQS\./);
+  });
+
+  it('is idempotent end-to-end: re-running with already-recorded keys exits 0 and consumes the file', () => {
+    const envelope = { openQuestions: { [OPEN_Q]: 'Use SQS.' } };
+    const { briefPath, answersPath } = makeFixture({ answers: JSON.stringify(envelope) });
+    assert.equal(runCli([briefPath]).status, 0);
+
+    // Simulate a crash-recovery re-run with the same answers file re-written.
+    fs.writeFileSync(answersPath, JSON.stringify(envelope), 'utf8');
+    const res = runCli([briefPath]);
+    assert.equal(res.status, 0, 'already-recorded keys count as success');
+    assert.equal(fs.existsSync(answersPath), false, 'file must still be consumed');
+  });
+
+  it('exits 1 on malformed JSON and leaves brief.md and the answers file untouched', () => {
+    const { briefPath, answersPath } = makeFixture({ answers: '{not json' });
+    const before = fs.readFileSync(briefPath, 'utf8');
+
+    const res = runCli([briefPath]);
+    assert.equal(res.status, 1);
+    assert.equal(fs.readFileSync(briefPath, 'utf8'), before, 'brief.md must be untouched');
+    assert.equal(fs.existsSync(answersPath), true, 'malformed file must be kept for inspection');
+  });
+
+  it('exits 1 when the answers file is missing', () => {
+    const { briefPath } = makeFixture();
+    const res = runCli([briefPath]);
+    assert.equal(res.status, 1);
+  });
+
+  it('exits 1 with usage when briefPath is missing', () => {
+    const res = runCli([]);
+    assert.equal(res.status, 1);
+    assert.match(res.stderr, /Usage/i);
+  });
+
+  it('exits 1 and keeps the answers file when the step guard refuses (spec in_progress)', () => {
+    const envelope = { openQuestions: { [OPEN_Q]: 'Use SQS.' } };
+    const { dir, briefPath, answersPath } = makeFixture({ answers: JSON.stringify(envelope) });
+    fs.writeFileSync(
+      path.join(dir, '.work-state.json'),
+      JSON.stringify({ stepStatus: { brief_gate: 'completed', spec: 'in_progress' } }),
+      'utf8'
+    );
+    const before = fs.readFileSync(briefPath, 'utf8');
+
+    const res = runCli([briefPath]);
+    assert.equal(res.status, 1);
+    assert.equal(fs.readFileSync(briefPath, 'utf8'), before);
+    assert.equal(fs.existsSync(answersPath), true);
+    const summary = JSON.parse(res.stdout);
+    assert.equal(summary.refused, 'step');
+  });
+});

--- a/plugins/work/scripts/workflows/work/scripts/apply-brief-gate-answers.js
+++ b/plugins/work/scripts/workflows/work/scripts/apply-brief-gate-answers.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * apply-brief-gate-answers.js (GH-543)
+ *
+ * File/stdin transport for brief_gate answer persistence. Replaces both
+ * argv-JSON transports (`'<JSON_MAP>'` argv and `"$RESOLUTIONS_JSON"`
+ * interpolation), which broke — or worse, executed — on a single quote in a
+ * user answer. Answer content never touches a shell command line.
+ *
+ * CLI contract:
+ *   node apply-brief-gate-answers.js <briefPath> [--file <answersPath>|--stdin]
+ *
+ *   - Default answers path: <dirname(briefPath)>/.brief-gate-answers.json
+ *   - Envelope shape: { openQuestions: {questionText: answer, ...},
+ *                       siblingGaps: [{surface, decision}, ...],
+ *                       discrepancies: [{claim, decision}, ...] }
+ *     (a flat questionText→answer map is accepted for back-compat)
+ *   - Prints a JSON summary to stdout.
+ *   - Deletes the answers file ONLY when every entry was applied or already
+ *     recorded; a partial apply keeps the file and lists the skipped keys.
+ *   - Exit 0 on full apply, 1 otherwise (partial, refused, malformed JSON —
+ *     malformed input leaves brief.md and the answers file untouched).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  applyGateResolutions,
+  isFullyApplied,
+  DEFAULT_ANSWERS_BASENAME,
+} = require('../lib/apply-gate-resolutions');
+
+const USAGE = 'Usage: node apply-brief-gate-answers.js <briefPath> [--file <answersPath>|--stdin]';
+
+function parseArgs(argv) {
+  const positional = [];
+  let file = null;
+  let stdin = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--stdin') {
+      stdin = true;
+    } else if (arg === '--file') {
+      file = argv[i + 1];
+      i++;
+      if (!file) return { error: '--file requires a path' };
+    } else {
+      positional.push(arg);
+    }
+  }
+  if (stdin && file) return { error: '--file and --stdin are mutually exclusive' };
+  if (positional.length !== 1) return { error: 'exactly one <briefPath> argument is required' };
+  return { briefPath: positional[0], file, stdin };
+}
+
+/** Answers-file path for the file transport, or null for --stdin. */
+function resolveAnswersPath(args) {
+  if (args.stdin) return null;
+  return args.file || path.join(path.dirname(args.briefPath), DEFAULT_ANSWERS_BASENAME);
+}
+
+/** fd 0 = stdin; both transports keep answers off the command line. */
+function readAnswersRaw(answersPath) {
+  return answersPath === null ? fs.readFileSync(0, 'utf8') : fs.readFileSync(answersPath, 'utf8');
+}
+
+/**
+ * Delete the consume-once answers file after a full apply. A failed unlink is
+ * non-fatal: a leftover copy of fully-applied answers is harmless because
+ * re-apply is idempotent.
+ */
+function consumeAnswersFile(answersPath) {
+  if (!answersPath) return false;
+  try {
+    fs.unlinkSync(answersPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.error) {
+    process.stderr.write(`${args.error}\n${USAGE}\n`);
+    return 1;
+  }
+
+  const { briefPath } = args;
+  const answersPath = resolveAnswersPath(args);
+  const answersSource = answersPath === null ? 'stdin' : answersPath;
+
+  let raw;
+  try {
+    raw = readAnswersRaw(answersPath);
+  } catch (e) {
+    process.stderr.write(`apply-brief-gate-answers: cannot read ${answersSource}: ${e.message}\n`);
+    return 1;
+  }
+
+  let envelope;
+  try {
+    envelope = JSON.parse(raw);
+  } catch (e) {
+    // Malformed JSON: brief.md untouched, file (if any) kept for inspection.
+    process.stderr.write(
+      `apply-brief-gate-answers: invalid JSON in ${answersSource}: ${e.message}\n`
+    );
+    return 1;
+  }
+
+  const result = applyGateResolutions(briefPath, envelope);
+  const fullyApplied = isFullyApplied(result);
+  const deletedAnswersFile = fullyApplied ? consumeAnswersFile(answersPath) : false;
+
+  process.stdout.write(
+    `${JSON.stringify({ briefPath, answersSource, ...result, deletedAnswersFile }, null, 2)}\n`
+  );
+  if (result.refused && result.message) {
+    process.stderr.write(`${result.message}\n`);
+  }
+  return fullyApplied ? 0 : 1;
+}
+
+process.exit(main());

--- a/plugins/work/scripts/workflows/work/steps/__tests__/brief-gate.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/brief-gate.test.js
@@ -201,7 +201,7 @@ describe('brief-gate step', () => {
     );
   });
 
-  it('RUN entry includes postResolveCommand referencing applyBriefResolutions', () => {
+  it('RUN entry postResolveCommand uses the file transport (GH-543: no argv-JSON)', () => {
     const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
     createdDirs.push(dir);
     const { add, entries } = makeAdd();
@@ -216,29 +216,36 @@ describe('brief-gate step', () => {
     );
     assert.match(
       entry.postResolveCommand,
-      /applyBriefResolutions/,
-      'postResolveCommand must reference applyBriefResolutions'
+      /apply-brief-gate-answers\.js/,
+      'postResolveCommand must invoke the answers-file CLI'
     );
-    assert.match(
-      entry.postResolveCommand,
-      /brief-gate\.js/,
-      'postResolveCommand must require brief-gate.js'
+    assert.ok(
+      !entry.postResolveCommand.includes('$RESOLUTIONS_JSON'),
+      'postResolveCommand must not interpolate answer JSON on the command line'
     );
-    assert.match(
-      entry.postResolveCommand,
-      /\$RESOLUTIONS_JSON/,
-      'postResolveCommand must reference $RESOLUTIONS_JSON placeholder'
-    );
-    assert.match(
-      entry.postResolveCommand,
-      /node -e/,
-      'postResolveCommand must be a node -e one-liner'
+    assert.ok(
+      !entry.postResolveCommand.includes('node -e'),
+      'postResolveCommand must not be a node -e one-liner'
     );
     // Verify the path includes the actual briefPath (tasks dir + brief.md)
     const expectedBriefPath = path.join(dir, 'brief.md');
     assert.ok(
       entry.postResolveCommand.includes(expectedBriefPath),
       `postResolveCommand must include briefPath: ${expectedBriefPath}`
+    );
+  });
+
+  it('tags every payload question with kind and applyKey (GH-543 envelope routing)', () => {
+    const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+    createdDirs.push(dir);
+    const { add, entries } = makeAdd();
+    briefGateStep(add, makeState(), makeCtx({ tasksDir: dir }));
+    const questions = entries[0].askUserQuestionPayload.questions;
+    assert.equal(questions.length, 1);
+    assert.equal(questions[0].kind, 'open-question');
+    assert.equal(
+      questions[0].applyKey,
+      'Which queue backend should we adopt for cross-service jobs?'
     );
   });
 
@@ -340,6 +347,56 @@ describe('brief-gate step', () => {
       // brief.md must be byte-equal — no partial write, no crash.
       const after = fs.readFileSync(briefPath, 'utf8');
       assert.equal(after, before, 'brief.md must remain byte-identical after write failure');
+    });
+
+    it('refuses outside brief_gate when .work-state.json exists (GH-543 step guard)', () => {
+      const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+      createdDirs.push(dir);
+      const briefPath = path.join(dir, 'brief.md');
+      fs.writeFileSync(
+        path.join(dir, '.work-state.json'),
+        JSON.stringify({ stepStatus: { brief_gate: 'completed', spec: 'in_progress' } }),
+        'utf8'
+      );
+      const before = fs.readFileSync(briefPath, 'utf8');
+
+      const result = applyBriefResolutions(
+        briefPath,
+        new Map([
+          [
+            'Which queue backend should we adopt for cross-service jobs?',
+            'Use SQS for all cross-service jobs.',
+          ],
+        ])
+      );
+
+      assert.equal(result, false, 'wrapper must refuse when another step is in_progress');
+      const after = fs.readFileSync(briefPath, 'utf8');
+      assert.equal(after, before, 'brief.md must be untouched on refusal');
+    });
+
+    it('still applies when .work-state.json shows brief_gate in_progress', () => {
+      const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+      createdDirs.push(dir);
+      const briefPath = path.join(dir, 'brief.md');
+      fs.writeFileSync(
+        path.join(dir, '.work-state.json'),
+        JSON.stringify({ stepStatus: { brief: 'completed', brief_gate: 'in_progress' } }),
+        'utf8'
+      );
+
+      const result = applyBriefResolutions(
+        briefPath,
+        new Map([
+          [
+            'Which queue backend should we adopt for cross-service jobs?',
+            'Use SQS for all cross-service jobs.',
+          ],
+        ])
+      );
+
+      assert.equal(result, true);
+      assert.match(fs.readFileSync(briefPath, 'utf8'), /\*\*Resolution:\*\*\s*Use SQS/);
     });
 
     it('returns false without touching brief.md for non-object resolutions (number/string/boolean)', () => {

--- a/plugins/work/scripts/workflows/work/steps/brief-gate.js
+++ b/plugins/work/scripts/workflows/work/steps/brief-gate.js
@@ -16,16 +16,20 @@
  * The RUN payload instructs the orchestrator to invoke AskUserQuestion
  * inline (hooks are non-interactive — the gate step is a planning-time
  * declaration, not a runtime prompt). Once the orchestrator has collected
- * answers, it calls the exported `applyBriefResolutions(briefPath, resolutions)`
- * post-resolve handler, which delegates to `openQuestions.applyResolutions`
- * and writes the result back to `brief.md`. Cancellations (undefined/empty
- * resolutions) are no-ops so the next planner pass re-prompts.
+ * answers, it writes them to the answers file and runs `postResolveCommand`
+ * (the apply-brief-gate-answers.js CLI — GH-543 file transport, so answer
+ * content never rides a shell command line). The exported
+ * `applyBriefResolutions(briefPath, resolutions)` handler is kept as a thin
+ * wrapper delegating to `applyGateResolutions` (kind-routing persistence +
+ * brief_gate step guard). Cancellations (undefined/empty resolutions) are
+ * no-ops so the next planner pass re-prompts.
  */
 
 'use strict';
 
 const fs = require('fs');
 const openQuestions = require('../lib/open-questions');
+const { applyGateResolutions } = require('../lib/apply-gate-resolutions');
 const { T, renderQuestionText, getRuntime } = require('../../lib/instruction-vocab');
 
 /**
@@ -42,6 +46,10 @@ function buildAskUserQuestionPayload(blocking) {
       questionText: q.questionText,
       scope: q.scope,
       rationale: q.rationale,
+      // Envelope routing key (GH-543): the driver files the answer under
+      // `openQuestions[applyKey]` in the answers-file envelope.
+      kind: 'open-question',
+      applyKey: q.questionText,
       // Orchestrator-facing hint: the answer must be persisted back into
       // the brief.md block identified by `questionText`.
       persistTo: 'brief.md',
@@ -108,7 +116,9 @@ function briefGateStep(add, s, ctx) {
       ),
       askUserQuestionPayload: buildAskUserQuestionPayload(blocking),
       onResolve: 'rewrite brief.md',
-      postResolveCommand: `node -e "var r=process.argv[3];if(!r)process.exit(0);require(process.argv[1]).applyBriefResolutions(process.argv[2],JSON.parse(r))" "${path.join(__dirname, 'brief-gate.js')}" "${briefPath}" "$RESOLUTIONS_JSON"`,
+      // GH-543 file transport: the CLI reads the default answers file
+      // (<tasksDir>/.brief-gate-answers.json) — no answer JSON on the argv.
+      postResolveCommand: `node "${path.join(__dirname, '..', 'scripts', 'apply-brief-gate-answers.js')}" "${briefPath}"`,
     }
   );
 }
@@ -133,9 +143,12 @@ function hasResolutionData(resolutions) {
 
 /**
  * Post-resolve handler — invoked by the orchestrator after AskUserQuestion
- * returns. Rewrites `brief.md` in place with the user-supplied resolutions,
- * delegating all parsing/idempotency/injection-escape invariants to
- * `openQuestions.applyResolutions`.
+ * returns. Thin wrapper (GH-543): delegates to `applyGateResolutions`,
+ * which coerces the flat questionText→answer map to an `{ openQuestions }`
+ * envelope, keeps all parsing/idempotency/injection-escape invariants, and
+ * adds the brief_gate step guard — when `.work-state.json` exists next to
+ * brief.md and a step other than brief_gate is positively in_progress, the
+ * write is refused (returns false).
  *
  * Cancellation path: if the caller passes `undefined`, `null`, or an empty
  * map/object, the handler is a no-op — brief.md is unchanged and the next
@@ -143,29 +156,11 @@ function hasResolutionData(resolutions) {
  *
  * @param {string} briefPath
  * @param {Map<string,string>|Record<string,string>|null|undefined} resolutions
- * @returns {boolean} true if brief.md was rewritten, false if skipped.
+ * @returns {boolean} true if brief.md was rewritten, false if skipped/refused.
  */
 function applyBriefResolutions(briefPath, resolutions) {
   if (!hasResolutionData(resolutions)) return false;
-
-  let markdown;
-  try {
-    markdown = fs.readFileSync(briefPath, 'utf8');
-  } catch (_e) {
-    return false;
-  }
-
-  const rewritten = openQuestions.applyResolutions(markdown, resolutions);
-  if (rewritten === markdown) return false;
-
-  try {
-    fs.writeFileSync(briefPath, rewritten, 'utf8');
-  } catch (_e) {
-    // Fail-closed: mirror the read-failure contract so EACCES/ENOSPC/etc
-    // never propagate as an uncaught exception to the orchestrator.
-    return false;
-  }
-  return true;
+  return applyGateResolutions(briefPath, resolutions).changed === true;
 }
 
 module.exports = briefGateStep;


### PR DESCRIPTION
## Existing Behavior

- `brief_gate` persisted user answers by interpolating a JSON map directly onto the shell command line: `node -e "...require(...).applyBriefResolutions(..., JSON.parse(process.argv[1]))" '$RESOLUTIONS_JSON'`. A single quote, backtick, or newline in any answer broke parsing or executed arbitrary shell code.
- `buildSiblingGapQuestions` and `buildDiscrepancyQuestions` returned question objects with no `kind` or `applyKey` fields, so the orchestrator had no routing metadata to know which persistence section each answer belonged to.
- The `_overrideInstruction` blocked-state payload exposed `applyCommand` as a `node -e` one-liner with `'<JSON_MAP>'` as a literal argv placeholder — requiring the caller to JSON-stringify and shell-escape the entire answer map inline.
- `applyBriefResolutions` in `brief-gate.js` handled only `openQuestions` (plain markdown resolution lines); sibling-gap and discrepancy answers had no persistence path at all.

## Intended New Behavior

- All three answer kinds — `openQuestions`, `siblingGaps`, and `discrepancies` — are persisted through a single `applyGateResolutions` library (`work/lib/apply-gate-resolutions.js`) that writes each kind into the exact markdown section its parser reads back (`open-questions.parse`, `findUnresolvedSiblingGaps`, `extractRecordedDecisions`).
- Answer content never rides a shell command line. The orchestrator writes a consume-once JSON envelope to `<tasksDir>/.brief-gate-answers.json`; `postResolveCommand` and `applyCommand` now invoke `node apply-brief-gate-answers.js <briefPath>` — a standalone CLI that reads the file (or `--stdin`), applies every kind, and deletes the answers file only on full apply.
- Every question object emitted by `buildSiblingGapQuestions`, `buildDiscrepancyQuestions`, and `buildAskUserQuestionPayload` now carries `kind` and `applyKey` fields, giving the driver unambiguous routing metadata without inspecting question text.
- A step guard in `applyGateResolutions` refuses writes when `.work-state.json` shows a step other than `brief_gate` positively `in_progress`, preventing out-of-window mutations; it fails open (allows) when the state file is absent or ambiguous.
- `applyBriefResolutions` in `brief-gate.js` is preserved as a thin back-compat wrapper that delegates to `applyGateResolutions` and coerces the legacy flat map to `{ openQuestions }`.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a backend/workflow change — no running server required.

1. Confirm `apply-gate-resolutions` kind routing and idempotency:
   ```bash
   node --test plugins/work/scripts/workflows/work/lib/__tests__/apply-gate-resolutions.test.js
   ```
   All suites (kind routing, idempotency, injection-class answers, flat back-compat, step guard) should pass.

2. Confirm `apply-brief-gate-answers` CLI contract:
   ```bash
   node --test plugins/work/scripts/workflows/work/scripts/__tests__/apply-brief-gate-answers.test.js
   ```

3. Confirm `brief-gate` step emits the new `postResolveCommand` shape and question envelope tags:
   ```bash
   node --test plugins/work/scripts/workflows/work/steps/__tests__/brief-gate.test.js
   ```
   The test named "RUN entry postResolveCommand uses the file transport" must pass; the `$RESOLUTIONS_JSON` and `node -e` assertions must be gone.

4. Confirm sibling-gap and discrepancy question builders emit routing fields:
   ```bash
   node --test plugins/work/scripts/workflows/lib/__tests__/brief-sibling-gaps.test.js
   node --test plugins/work/scripts/workflows/lib/__tests__/discrepancy.test.js
   ```

5. End-to-end smoke — write a three-kind envelope with a single-quote in an answer and verify `apply-brief-gate-answers.js` exits 0 and the answers file is deleted:
   ```bash
   TMPDIR=$(mktemp -d)
   # brief.md with one blocking open question and one sibling-gap entry
   # Write envelope
   cat > "$TMPDIR/.brief-gate-answers.json" <<'JSON'
   {
     "openQuestions": { "Which queue backend should we adopt for cross-service jobs?": "Use SQS — it's managed." },
     "siblingGaps": [{ "surface": "lib/x.ts", "decision": "wait-for-sibling" }]
   }
   JSON
   node plugins/work/scripts/workflows/work/scripts/apply-brief-gate-answers.js "$TMPDIR/brief.md"
   echo "exit: $?"
   ls "$TMPDIR/.brief-gate-answers.json" 2>/dev/null || echo "answers file consumed (expected)"
   ```

### Test Results

| Suite | File |
|---|---|
| apply-gate-resolutions (kind routing, idempotency, injection, back-compat, step guard) | `work/lib/__tests__/apply-gate-resolutions.test.js` |
| apply-brief-gate-answers CLI (file transport, stdin, partial apply, malformed JSON) | `work/scripts/__tests__/apply-brief-gate-answers.test.js` |
| brief-gate step (postResolveCommand shape, question envelope tags, step guard) | `work/steps/__tests__/brief-gate.test.js` |
| brief-sibling-gaps (envelope routing tags) | `lib/__tests__/brief-sibling-gaps.test.js` |
| discrepancy (envelope routing tags) | `lib/__tests__/discrepancy.test.js` |

---

Stacked on: targets `main` directly (this is stage 1 of 2; stage 2 wires the driver to write the answers file and call the CLI).

Refs #543