### PR TITLE
feat(work): batch brief_gate questions at ≤4 per AskUserQuestion call (GH-543 stage 2)

### DIFF
--- a/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
@@ -237,6 +237,37 @@ describe('workflow-definition: verify[STEPS.brief_gate]', () => {
     assert.equal(verify(ticketId), true);
   });
 
+  it('returns false when the brief has an undecided sibling-gap entry (GH-543)', () => {
+    writeBrief(
+      [
+        '# Brief',
+        '',
+        '## Out of scope (sibling-owned)',
+        '- `lib/x.ts` — owned by GH-100 (status: Open, PR: none). Reason: shared surface.',
+        '',
+      ].join('\n')
+    );
+    const verify = getBriefGateVerify();
+    assert.equal(verify(ticketId), false);
+  });
+
+  it('returns true when every sibling-gap entry has a recorded decision (GH-543)', () => {
+    writeBrief(
+      [
+        '# Brief',
+        '',
+        '## Out of scope (sibling-owned)',
+        '- `lib/x.ts` — owned by GH-100 (status: Open, PR: none). Reason: shared surface.',
+        '',
+        '## Sibling-gap decisions',
+        '- `lib/x.ts` — decision: wait-for-sibling; timestamp: 2026-07-11T00:00:00Z',
+        '',
+      ].join('\n')
+    );
+    const verify = getBriefGateVerify();
+    assert.equal(verify(ticketId), true);
+  });
+
   it('returns false for a malformed brief read error (fail-closed)', () => {
     // Remove the brief and place a directory at its path so read/parse fails.
     removeBrief();

--- a/plugins/work/scripts/workflows/work/lib/__tests__/question-batching.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/question-batching.test.js
@@ -1,0 +1,104 @@
+/**
+ * Tests for lib/question-batching.js (GH-543) — the ≤4 AskUserQuestion
+ * batch-cap helper shared by every question-gate delivery site.
+ *
+ * Run: node --test scripts/workflows/work/lib/__tests__/question-batching.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { MAX_PER_ASK, takeBatch } = require('../question-batching');
+
+function makeQuestions(n) {
+  return Array.from({ length: n }, (_, i) => ({
+    questionText: `Q${i + 1}?`,
+    applyKey: `Q${i + 1}?`,
+  }));
+}
+
+/**
+ * Simulate the driver loop: take a batch, resolve it (drop it from the
+ * pending set), re-derive the rest. Returns the successive batch sizes.
+ */
+function batchSizes(n) {
+  let pending = makeQuestions(n);
+  const sizes = [];
+  while (pending.length > 0) {
+    const { batch } = takeBatch(pending);
+    sizes.push(batch.length);
+    pending = pending.slice(batch.length);
+  }
+  return sizes;
+}
+
+describe('question-batching takeBatch', () => {
+  it('exports MAX_PER_ASK = 4 (mirrors the AskUserQuestion hard cap)', () => {
+    assert.equal(MAX_PER_ASK, 4);
+  });
+
+  it('batches 5 questions as 4+1', () => {
+    assert.deepEqual(batchSizes(5), [4, 1]);
+  });
+
+  it('batches 8 questions as 4+4', () => {
+    assert.deepEqual(batchSizes(8), [4, 4]);
+  });
+
+  it('batches 9 questions as 4+4+1', () => {
+    assert.deepEqual(batchSizes(9), [4, 4, 1]);
+  });
+
+  it('never emits a batch larger than 4', () => {
+    for (let n = 0; n <= 23; n++) {
+      const { batch } = takeBatch(makeQuestions(n));
+      assert.ok(batch.length <= MAX_PER_ASK, `n=${n} produced a batch of ${batch.length}`);
+    }
+  });
+
+  it('preserves input order and slices from the front (restart-resume invariant)', () => {
+    const qs = makeQuestions(9);
+    const a = takeBatch(qs);
+    const b = takeBatch(qs);
+    assert.deepEqual(a.batch, qs.slice(0, 4), 'batch must be the front slice, in order');
+    assert.deepEqual(a.batch, b.batch, 'same input must re-derive the identical batch');
+  });
+
+  it('reports total/thisBatch/remaining arithmetic over the pending set', () => {
+    const { batch, total, remaining } = takeBatch(makeQuestions(9));
+    assert.equal(total, 9);
+    assert.equal(batch.length, 4);
+    assert.equal(remaining, 5);
+  });
+
+  it('batchNumber/totalBatches are remaining-set-relative: 9 questions render 1/3 → 1/2 → 1/1', () => {
+    let pending = makeQuestions(9);
+    const rendered = [];
+    while (pending.length > 0) {
+      const { batch, batchNumber, totalBatches } = takeBatch(pending);
+      rendered.push(`${batchNumber}/${totalBatches}`);
+      pending = pending.slice(batch.length);
+    }
+    assert.deepEqual(rendered, ['1/3', '1/2', '1/1']);
+  });
+
+  it('delivers a ≤4 set whole: total==thisBatch, remaining 0, one batch', () => {
+    const { batch, total, remaining, batchNumber, totalBatches } = takeBatch(makeQuestions(3));
+    assert.equal(batch.length, 3);
+    assert.equal(total, 3);
+    assert.equal(remaining, 0);
+    assert.equal(batchNumber, 1);
+    assert.equal(totalBatches, 1);
+  });
+
+  it('returns an empty batch for empty or non-array input', () => {
+    for (const input of [[], null, undefined, 'nope', 42]) {
+      const res = takeBatch(input);
+      assert.deepEqual(res.batch, []);
+      assert.equal(res.total, 0);
+      assert.equal(res.remaining, 0);
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/question-batching.js
+++ b/plugins/work/scripts/workflows/work/lib/question-batching.js
@@ -1,0 +1,54 @@
+/**
+ * workflows/work/lib/question-batching.js (GH-543)
+ *
+ * Single source of truth for the AskUserQuestion batch cap. The harness
+ * hard-rejects AskUserQuestion payloads with more than 4 questions
+ * (InputValidationError), so every question-gate delivery site slices the
+ * pending set through `takeBatch()` before building an instruction.
+ *
+ * Deterministic by design: input order is preserved and the batch is always
+ * the FRONT slice of the pending set. Because brief.md is the store of
+ * record (answers persist per batch), a daemon restart re-derives the
+ * identical next batch — the loop resumes instead of restarting.
+ *
+ * `batchNumber`/`totalBatches` are STATELESS, remaining-set-relative values:
+ * each planner pass sees only what is still unresolved, so 9 pending
+ * questions render 1/3 → 1/2 → 1/1 across passes (never 2/3 or 3/3).
+ *
+ * No env override for the cap: the harness limit is not plugin-configurable,
+ * and a knob would let config drift re-trigger the exact loop this fixes.
+ */
+
+'use strict';
+
+/** Hard cap mirroring AskUserQuestion's maximum questions per call. */
+const MAX_PER_ASK = 4;
+
+/**
+ * Slice the next deliverable batch from the front of `questions`.
+ *
+ * @param {Array<object>} questions — pending questions in deterministic order
+ * @param {number} [max=MAX_PER_ASK] — batch size ceiling (callers other than
+ *   tests should not pass this; the cap is fixed by design)
+ * @returns {{ batch: Array<object>, batchNumber: number, totalBatches: number,
+ *             total: number, remaining: number }}
+ *   `total` counts the questions passed in (the remaining set), `remaining`
+ *   what is left AFTER this batch. `batchNumber` is always 1 relative to the
+ *   remaining set; `totalBatches` is how many passes the remaining set still
+ *   needs (stateless per-pass values — see module doc).
+ */
+function takeBatch(questions, max = MAX_PER_ASK) {
+  const list = Array.isArray(questions) ? questions : [];
+  const cap = Number.isInteger(max) && max > 0 ? max : MAX_PER_ASK;
+  const batch = list.slice(0, cap);
+  const total = list.length;
+  return {
+    batch,
+    total,
+    remaining: total - batch.length,
+    batchNumber: 1,
+    totalBatches: Math.max(1, Math.ceil(total / cap)),
+  };
+}
+
+module.exports = { MAX_PER_ASK, takeBatch };

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/brief-gate-batching-loop.test.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/brief-gate-batching-loop.test.js
@@ -1,0 +1,190 @@
+/**
+ * Integration test for the brief_gate batching loop (GH-543).
+ *
+ * Drives the real planner step (steps/brief-gate.js) + the real enrichment
+ * chain in index.js registration order (brief-gate injector → question-router
+ * → discrepancy-gate) through a simulated driver loop:
+ *
+ *   derive → auto-answer the ≤4 batch → apply the envelope → re-derive
+ *
+ * brief.md is the store of record, so every pass statelessly re-derives the
+ * remaining set — the crash-resume test pins that a restart between batches
+ * yields the identical next batch.
+ *
+ * Run: node --test scripts/workflows/work/lib/step-enrichments/__tests__/brief-gate-batching-loop.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { STEPS } = require('../../../step-registry');
+const briefGateStep = require('../../../steps/brief-gate.js');
+const registerBriefGate = require('../brief-gate');
+const registerQuestionRouter = require('../question-router');
+const registerDiscrepancyGate = require('../discrepancy-gate');
+const { applyGateResolutions } = require('../../apply-gate-resolutions');
+
+function makeRegistry() {
+  const byStep = {};
+  return {
+    register: (step, fn) => {
+      if (!byStep[step]) byStep[step] = [];
+      byStep[step].push(fn);
+    },
+    run: (step, entry, ctx) => (byStep[step] || []).forEach((fn) => fn(entry, ctx)),
+  };
+}
+
+function briefWith({ open = 0, gaps = 0 }) {
+  const lines = ['# Brief', ''];
+  if (open > 0) {
+    lines.push('## Open Questions', '');
+    for (let i = 1; i <= open; i++) {
+      lines.push(`- **Question:** Cross-ticket question ${i}?`);
+      lines.push('  - `scope: cross-ticket`');
+      lines.push(`  - \`rationale: affects sibling ${i}\``);
+      lines.push('  - `resolved: false`');
+      lines.push('');
+    }
+  }
+  if (gaps > 0) {
+    lines.push('## Out of scope (sibling-owned)');
+    for (let i = 1; i <= gaps; i++) {
+      lines.push(
+        `- \`lib/surface-${i}.ts\` — owned by GH-10${i} (status: Open, PR: none). Reason: shared surface ${i}.`
+      );
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+let tmp;
+let savedProvider;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'brief-gate-loop-'));
+  savedProvider = process.env.TICKET_PROVIDER;
+  // Skip Gate 0 (related-tickets manifest) — this suite tests question delivery.
+  process.env.TICKET_PROVIDER = 'none';
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  if (savedProvider === undefined) delete process.env.TICKET_PROVIDER;
+  else process.env.TICKET_PROVIDER = savedProvider;
+});
+
+/** One planner pass: step decision + enrichment chain in index.js order. */
+function derive(dir) {
+  const entries = [];
+  const add = (step, action, command, reason, extra) =>
+    entries.push({ step, action, command, reason, ...(extra || {}) });
+  briefGateStep(add, { hasBrief: true }, { STEPS, ticket: 'GH-543', tasksDir: dir, path });
+  const entry = entries[0];
+  if (entry.action !== 'RUN') return { entry, override: null };
+  const reg = makeRegistry();
+  registerBriefGate(reg.register);
+  registerQuestionRouter(reg.register);
+  registerDiscrepancyGate(reg.register);
+  reg.run('brief_gate', entry, { tasksDir: dir, ticket: 'GH-543', workDir: dir, path, fs });
+  return { entry, override: entry._overrideInstruction || null };
+}
+
+/** Auto-answer every question in the batch, routed by kind. */
+function answerBatch(override) {
+  const envelope = { openQuestions: {}, siblingGaps: [], discrepancies: [] };
+  for (const q of override.userQuestions) {
+    if (q.kind === 'sibling-gap') {
+      envelope.siblingGaps.push({ surface: q.applyKey, decision: 'implement-here' });
+    } else if (q.kind === 'discrepancy') {
+      envelope.discrepancies.push({ claim: q.applyKey, decision: 'keep as specified' });
+    } else {
+      envelope.openQuestions[q.applyKey] = `Answered: ${q.applyKey}`;
+    }
+  }
+  return envelope;
+}
+
+describe('brief-gate batching loop (GH-543 integration)', () => {
+  it('5 open + 3 sibling-gap questions terminate in exactly 2 batches, all 8 persisted', () => {
+    const briefPath = path.join(tmp, 'brief.md');
+    fs.writeFileSync(briefPath, briefWith({ open: 5, gaps: 3 }), 'utf8');
+
+    const batchSizes = [];
+    let guard = 0;
+    for (;;) {
+      guard += 1;
+      assert.ok(guard <= 10, 'driver loop did not terminate');
+      const { entry, override } = derive(tmp);
+      if (entry.action === 'DEFER') break;
+      assert.equal(entry.action, 'RUN');
+      assert.ok(override, 'RUN pass must produce a blocked override');
+      assert.ok(
+        override.userQuestions.length <= 4,
+        `batch of ${override.userQuestions.length} exceeds the AskUserQuestion cap`
+      );
+      batchSizes.push(override.userQuestions.length);
+      const result = applyGateResolutions(briefPath, answerBatch(override));
+      assert.equal(result.changed, true, 'every batch must persist into brief.md');
+    }
+
+    assert.deepEqual(batchSizes, [4, 4], 'expected exactly 2 batches of 4');
+
+    const { entry } = derive(tmp);
+    assert.equal(entry.action, 'DEFER');
+    assert.match(entry.reason, /All blocking questions resolved/);
+
+    const final = fs.readFileSync(briefPath, 'utf8');
+    for (let i = 1; i <= 5; i++) {
+      assert.ok(
+        final.includes(`Answered: Cross-ticket question ${i}?`),
+        `open question ${i} resolution must be persisted`
+      );
+    }
+    for (let i = 1; i <= 3; i++) {
+      assert.ok(
+        final.includes(`- \`lib/surface-${i}.ts\` — decision: implement-here`),
+        `sibling-gap decision ${i} must be persisted`
+      );
+    }
+  });
+
+  it('crash between batches resumes with the identical next batch (stateless re-derive)', () => {
+    const briefPath = path.join(tmp, 'brief.md');
+    fs.writeFileSync(briefPath, briefWith({ open: 5, gaps: 3 }), 'utf8');
+
+    const first = derive(tmp);
+    assert.ok(first.override);
+    applyGateResolutions(briefPath, answerBatch(first.override));
+
+    // "Crash" here: no in-memory state survives — every derive() is a fresh
+    // pass over brief.md. Two consecutive re-derivations must agree.
+    const passA = derive(tmp).override.userQuestions.map((q) => q.applyKey);
+    const passB = derive(tmp).override.userQuestions.map((q) => q.applyKey);
+    assert.deepEqual(passA, passB, 'restart must resume at the same batch');
+    assert.ok(passA.length > 0 && passA.length <= 4);
+  });
+
+  it('delivers trailing sibling-gap batches: gate stays RUN when only gaps remain', () => {
+    const briefPath = path.join(tmp, 'brief.md');
+    fs.writeFileSync(briefPath, briefWith({ open: 0, gaps: 2 }), 'utf8');
+
+    const { entry, override } = derive(tmp);
+    assert.equal(entry.action, 'RUN', 'sibling gaps alone must keep the gate RUN, not DEFER');
+    assert.ok(
+      entry.agentType && entry.agentPrompt,
+      'RUN entry must delegate so enrichAndReturn executes the enrichment chain'
+    );
+    assert.ok(override, 'sibling-gap questions must reach the user');
+    assert.equal(override.userQuestions.length, 2);
+    assert.ok(override.userQuestions.every((q) => q.kind === 'sibling-gap'));
+
+    const result = applyGateResolutions(briefPath, answerBatch(override));
+    assert.equal(result.changed, true);
+    assert.equal(derive(tmp).entry.action, 'DEFER');
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/brief-gate.test.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/brief-gate.test.js
@@ -14,6 +14,7 @@ const path = require('node:path');
 const os = require('node:os');
 
 const registerBriefGate = require('../brief-gate');
+const registerQuestionRouter = require('../question-router');
 
 function makeRegistry() {
   const byStep = {};
@@ -24,6 +25,15 @@ function makeRegistry() {
     },
     run: (step, entry, ctx) => (byStep[step] || []).forEach((fn) => fn(entry, ctx)),
   };
+}
+
+/**
+ * Register the brief_gate chain in index.js order (GH-543): the brief-gate
+ * injector runs first, the question-router routes/batches after it.
+ */
+function registerChain(reg) {
+  registerBriefGate(reg.register);
+  registerQuestionRouter(reg.register);
 }
 
 const validManifest = () => ({
@@ -126,7 +136,7 @@ describe('brief-gate Gate A sibling-gap injection', () => {
       ].join('\n')
     );
     const reg = makeRegistry();
-    registerBriefGate(reg.register);
+    registerChain(reg);
     const entry = { step: 'brief_gate' };
     reg.run('brief_gate', entry, ctx());
     assert.ok(entry._overrideInstruction);
@@ -134,6 +144,29 @@ describe('brief-gate Gate A sibling-gap injection', () => {
     const qs = entry._overrideInstruction.userQuestions || [];
     assert.equal(qs.length, 1);
     assert.match(qs[0].question, /GH-100/);
+  });
+
+  it('injector only merges into the payload — routing is the question-router job (GH-543)', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'brief.md'),
+      [
+        '## Out of scope (sibling-owned)',
+        '- `lib/x.ts` — owned by GH-100 (status: Done, PR: #50). Reason: read path missing.',
+        '',
+      ].join('\n')
+    );
+    const reg = makeRegistry();
+    registerBriefGate(reg.register); // injector alone, no router
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.equal(
+      entry._overrideInstruction,
+      undefined,
+      'the injector must not set _overrideInstruction itself'
+    );
+    const qs = (entry.askUserQuestionPayload || {}).questions || [];
+    assert.equal(qs.length, 1);
+    assert.equal(qs[0].kind, 'sibling-gap');
   });
 
   it('passes when every gap has a matching decision', () => {
@@ -172,7 +205,7 @@ describe('brief-gate open-questions handling (regression)', () => {
 
   it('emits local-questions note when only local questions present', () => {
     const reg = makeRegistry();
-    registerBriefGate(reg.register);
+    registerChain(reg);
     const entry = {
       step: 'brief_gate',
       askUserQuestionPayload: {
@@ -186,7 +219,7 @@ describe('brief-gate open-questions handling (regression)', () => {
 
   it('builds blocked override for cross-ticket / user questions', () => {
     const reg = makeRegistry();
-    registerBriefGate(reg.register);
+    registerChain(reg);
     const entry = {
       step: 'brief_gate',
       askUserQuestionPayload: {
@@ -207,7 +240,7 @@ describe('brief-gate answers-file transport (GH-543)', () => {
 
   function blockedEntry() {
     const reg = makeRegistry();
-    registerBriefGate(reg.register);
+    registerChain(reg);
     const entry = {
       step: 'brief_gate',
       askUserQuestionPayload: {
@@ -269,7 +302,7 @@ describe('brief-gate answers-file transport (GH-543)', () => {
       ].join('\n')
     );
     const reg = makeRegistry();
-    registerBriefGate(reg.register);
+    registerChain(reg);
     const entry = { step: 'brief_gate' };
     reg.run('brief_gate', entry, ctx());
     assert.ok(entry._overrideInstruction);

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/question-router.test.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/question-router.test.js
@@ -1,0 +1,223 @@
+/**
+ * Tests for step-enrichments/question-router.js (GH-543) — brief_gate
+ * question DELIVERY: local/user routing extracted from the brief-gate
+ * injector, plus batching to AskUserQuestion's 4-question hard cap.
+ *
+ * Run: node --test scripts/workflows/work/lib/step-enrichments/__tests__/question-router.test.js
+ */
+
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+
+const registerQuestionRouter = require('../question-router');
+const { MAX_PER_ASK } = require('../../question-batching');
+
+function makeRegistry() {
+  const byStep = {};
+  return {
+    register: (step, fn) => {
+      if (!byStep[step]) byStep[step] = [];
+      byStep[step].push(fn);
+    },
+    run: (step, entry, ctx) => (byStep[step] || []).forEach((fn) => fn(entry, ctx)),
+  };
+}
+
+// Placeholder roots — the router never touches the disk.
+const FAKE_ROOT = path.join(os.tmpdir(), 'question-router-fake');
+
+function ctx(overrides = {}) {
+  return { tasksDir: FAKE_ROOT, workDir: FAKE_ROOT, ticket: 'GH-543', path, ...overrides };
+}
+
+function openQ(i) {
+  return {
+    questionText: `Open Q${i}?`,
+    scope: 'user',
+    rationale: `open rationale ${i}`,
+    kind: 'open-question',
+    applyKey: `Open Q${i}?`,
+  };
+}
+
+function gapQ(i) {
+  return {
+    questionText: `Gap Q${i}?`,
+    scope: 'user',
+    rationale: `gap rationale ${i}`,
+    kind: 'sibling-gap',
+    applyKey: `lib/x${i}.ts`,
+    options: ['implement-here', 'wait-for-sibling'],
+  };
+}
+
+function discQ(i) {
+  return {
+    questionText: `Disc Q${i}?`,
+    scope: 'user',
+    rationale: `disc rationale ${i}`,
+    kind: 'discrepancy',
+    applyKey: `claim-${i}`,
+  };
+}
+
+function route(questions, entryOverrides = {}) {
+  const reg = makeRegistry();
+  registerQuestionRouter(reg.register);
+  const entry = {
+    step: 'brief_gate',
+    askUserQuestionPayload: { questions },
+    ...entryOverrides,
+  };
+  reg.run('brief_gate', entry, ctx());
+  return entry;
+}
+
+describe('question-router batching (GH-543)', () => {
+  const SIX_MIXED = [openQ(1), openQ(2), openQ(3), gapQ(1), gapQ(2), discQ(1)];
+
+  it('caps a 6-question mixed-kind set at exactly 4 in the override', () => {
+    const entry = route(SIX_MIXED);
+    assert.ok(entry._overrideInstruction, 'expected blocked override');
+    const qs = entry._overrideInstruction.userQuestions;
+    assert.equal(qs.length, MAX_PER_ASK);
+    // Front slice, in order, each with index/kind/applyKey
+    assert.deepEqual(
+      qs.map((q) => q.applyKey),
+      ['Open Q1?', 'Open Q2?', 'Open Q3?', 'lib/x1.ts']
+    );
+    assert.deepEqual(
+      qs.map((q) => q.index),
+      [1, 2, 3, 4]
+    );
+    assert.deepEqual(
+      qs.map((q) => q.kind),
+      ['open-question', 'open-question', 'open-question', 'sibling-gap']
+    );
+  });
+
+  it('adds questionProgress {total:6, thisBatch:4, remaining:2} for the 6-question set', () => {
+    const entry = route(SIX_MIXED);
+    assert.deepEqual(entry._overrideInstruction.questionProgress, {
+      total: 6,
+      thisBatch: 4,
+      remaining: 2,
+      batchNumber: 1,
+      totalBatches: 2,
+    });
+  });
+
+  it('questionProgress is remaining-set-relative (9 pending renders 1/3)', () => {
+    const entry = route([...Array(9).keys()].map((i) => openQ(i + 1)));
+    const p = entry._overrideInstruction.questionProgress;
+    assert.equal(p.batchNumber, 1);
+    assert.equal(p.totalBatches, 3);
+    assert.equal(p.remaining, 5);
+  });
+
+  it('keeps the reason string byte-identical to the pre-batching pin', () => {
+    const entry = route(SIX_MIXED);
+    assert.equal(
+      entry._overrideInstruction.reason,
+      'brief_gate requires user input for cross-ticket questions'
+    );
+  });
+
+  it('delivers a ≤4 set whole (remaining 0, single batch)', () => {
+    const entry = route([openQ(1), gapQ(1)]);
+    const override = entry._overrideInstruction;
+    assert.equal(override.userQuestions.length, 2);
+    assert.deepEqual(override.questionProgress, {
+      total: 2,
+      thisBatch: 2,
+      remaining: 0,
+      batchNumber: 1,
+      totalBatches: 1,
+    });
+  });
+
+  it('never exceeds the cap when discrepancy questions ride along', () => {
+    const entry = route([discQ(1), discQ(2), discQ(3), discQ(4), discQ(5), discQ(6)]);
+    const qs = entry._overrideInstruction.userQuestions;
+    assert.equal(qs.length, MAX_PER_ASK);
+    assert.ok(qs.every((q) => q.kind === 'discrepancy'));
+  });
+
+  it('preserves options on batched sibling-gap questions', () => {
+    const entry = route([gapQ(1)]);
+    assert.deepEqual(entry._overrideInstruction.userQuestions[0].options, [
+      'implement-here',
+      'wait-for-sibling',
+    ]);
+  });
+
+  it('applyCommand is the answers-file CLI with no inline JSON placeholder', () => {
+    const entry = route(SIX_MIXED);
+    const override = entry._overrideInstruction;
+    assert.match(override.applyCommand, /apply-brief-gate-answers\.js/);
+    assert.ok(override.applyCommand.includes(path.join(FAKE_ROOT, 'brief.md')));
+    assert.ok(!override.applyCommand.includes('<JSON_MAP>'));
+    assert.ok(!override.applyCommand.includes('$RESOLUTIONS_JSON'));
+    assert.ok(!override.applyCommand.includes('node -e'));
+  });
+
+  it('hint documents the batch loop: crash-recovery step 0, ONE call, envelope, re-run', () => {
+    const entry = route(SIX_MIXED);
+    const hint = entry._overrideInstruction.hint;
+    assert.match(hint, /already exists \(crash recovery\)/);
+    assert.match(hint, /ONE AskUserQuestion call/);
+    assert.match(hint, /never more than 4/);
+    assert.match(hint, /\.brief-gate-answers\.json/);
+    assert.match(hint, /openQuestions/);
+    assert.match(hint, /siblingGaps/);
+    assert.match(hint, /discrepancies/);
+    assert.match(hint, /work-next\.js/);
+    assert.match(hint, /next batch/);
+  });
+
+  it('emits the non-blocking note when only local questions are present', () => {
+    const entry = route([{ questionText: 'Local Q?', scope: 'local' }]);
+    assert.match(entry.agentPrompt || '', /Local Questions/);
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+
+  it('lists local questions alongside a capped user batch', () => {
+    const entry = route([
+      { questionText: 'Local Q?', scope: 'local' },
+      openQ(1),
+      openQ(2),
+      openQ(3),
+      openQ(4),
+      openQ(5),
+    ]);
+    const override = entry._overrideInstruction;
+    assert.deepEqual(override.localQuestions, ['Local Q?']);
+    assert.equal(override.userQuestions.length, 4);
+    assert.equal(override.questionProgress.total, 5);
+  });
+
+  it('defers when another blocker already set _overrideInstruction', () => {
+    const preset = { type: 'work_instruction', action: 'blocked', reason: 'gate 0 wins' };
+    const entry = route(SIX_MIXED, { _overrideInstruction: preset });
+    assert.equal(entry._overrideInstruction, preset, 'router must not replace an earlier blocker');
+    assert.equal(entry._overrideInstruction.questionProgress, undefined);
+  });
+
+  it('is a no-op without an askUserQuestionPayload', () => {
+    const reg = makeRegistry();
+    registerQuestionRouter(reg.register);
+    const entry = { step: 'brief_gate' };
+    reg.run('brief_gate', entry, ctx());
+    assert.equal(entry._overrideInstruction, undefined);
+    assert.equal(entry.agentType, undefined);
+  });
+
+  it('is a no-op for an empty questions list', () => {
+    const entry = route([]);
+    assert.equal(entry._overrideInstruction, undefined);
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/brief-gate.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/brief-gate.js
@@ -1,11 +1,11 @@
 /**
- * Brief-gate step enrichment.
+ * Brief-gate step enrichment — INJECTOR ONLY (GH-543).
  *
- * When there are cross-ticket/user questions → returns a blocked instruction
- * that forces the orchestrator to stop and ask the user directly.
- * The agent CANNOT answer cross-ticket questions on its own.
- *
- * When there are only local questions → auto-passes (resolved during spec).
+ * Owns Gate 0 (related-tickets manifest validation) and Gate A (sibling-gap
+ * question injection into `askUserQuestionPayload`). Question DELIVERY —
+ * local/user routing, the blocked instruction, and batching to the
+ * AskUserQuestion 4-question cap — lives in ./question-router.js, which
+ * registers after this injector (see ./index.js).
  */
 
 'use strict';
@@ -64,43 +64,6 @@ function buildRelatedTicketsBlocker(ticket, tasksDir, pathMod, fs, providerConfi
   };
 }
 
-/**
- * Blocked instruction for cross-ticket/user questions (GH-543 file
- * transport): answers travel via a consume-once JSON envelope file, so
- * quotes/backticks/newlines in an answer can never break (or execute on) a
- * shell command line the way the old inline '<JSON_MAP>' argv did.
- */
-function buildUserQuestionsBlocker(userQs, localQs, briefPath, ctx) {
-  const { tasksDir, workDir, path: pathMod } = ctx;
-  const answersPath = pathMod.join(tasksDir, '.brief-gate-answers.json');
-  const applyCliPath = pathMod.join(workDir, 'scripts', 'apply-brief-gate-answers.js');
-  return {
-    type: 'work_instruction',
-    action: 'blocked',
-    reason: 'brief_gate requires user input for cross-ticket questions',
-    userQuestions: userQs.map((q, i) => ({
-      index: i + 1,
-      question: q.questionText,
-      rationale: q.rationale || '',
-      scope: q.scope,
-      // Envelope routing keys (GH-543). Questions from producers that
-      // predate tagging default to the open-question lane.
-      kind: q.kind || 'open-question',
-      applyKey: q.applyKey || q.questionText,
-      ...(Array.isArray(q.options) ? { options: q.options } : {}),
-    })),
-    localQuestions: localQs.map((q) => q.questionText),
-    applyCommand: `node "${applyCliPath}" "${briefPath}"`,
-    hint:
-      `Ask the userQuestions, then Write the answers to ${answersPath} as a JSON envelope ` +
-      `routed by each question's kind: {"openQuestions": {"<applyKey>": "<answer>", ...}, ` +
-      `"siblingGaps": [{"surface": "<applyKey>", "decision": "implement-here|wait-for-sibling"}, ...], ` +
-      `"discrepancies": [{"claim": "<applyKey>", "decision": "<answer>"}, ...]}. ` +
-      'Then run the applyCommand (it persists every kind into brief.md and consumes the ' +
-      'answers file on full apply) and re-run work-next.js after.',
-  };
-}
-
 module.exports = function registerBriefGate(register) {
   register('brief_gate', (entry, ctx) => {
     const { tasksDir, ticket, workDir, path, fs } = ctx;
@@ -125,46 +88,8 @@ module.exports = function registerBriefGate(register) {
     }
 
     // Gate A — surface unresolved sibling-gap entries from the brief as
-    // user-scoped questions BEFORE the open-question routing below decides
-    // whether to block.
+    // user-scoped questions BEFORE the question-router (registered after
+    // this injector) decides whether to block.
     _injectSiblingGapQuestions(entry, ctx);
-
-    if (!entry.askUserQuestionPayload) return;
-
-    const questions = entry.askUserQuestionPayload.questions || [];
-    if (questions.length === 0) return;
-
-    const localQs = questions.filter((q) => q.scope === 'local');
-    const userQs = questions.filter((q) => q.scope !== 'local');
-    const briefGatePath = path.join(workDir, 'steps', 'brief-gate.js');
-    const briefPath = path.join(tasksDir, 'brief.md');
-
-    // Only local questions — non-blocking, resolved during spec phase
-    if (userQs.length === 0) {
-      const lines = ['## brief_gate: Local Questions (non-blocking)\n'];
-      lines.push(
-        'These questions will be answered by the spec-writer when it analyzes the codebase.'
-      );
-      lines.push('No action needed — the gate passes automatically.\n');
-      localQs.forEach((q, i) => {
-        lines.push(`${i + 1}. "${q.questionText}" → deferred to spec`);
-      });
-      entry.agentPrompt = lines.join('\n');
-      return;
-    }
-
-    // Cross-ticket/user questions — MUST ask the user, not delegate to agent
-    // Override the delegate type to force a blocked instruction
-    entry.agentType = 'Bash';
-    entry.agentPrompt = 'echo "brief_gate: waiting for user answers"';
-
-    // Store the questions and paths for the orchestrator to use
-    entry._briefGateUserQuestions = userQs;
-    entry._briefGateLocalQuestions = localQs;
-    entry._briefGatePath = briefGatePath;
-    entry._briefPath = briefPath;
-
-    // Return a blocked instruction instead — the orchestrator must ask the user
-    entry._overrideInstruction = buildUserQuestionsBlocker(userQs, localQs, briefPath, ctx);
   });
 };

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/index.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/index.js
@@ -69,6 +69,13 @@ require('./ticket')(register);
 require('./related-tickets-inject')(register);
 require('./brief')(register);
 require('./brief-gate')(register);
+// GH-543: the question-router owns brief_gate question DELIVERY (local/user
+// routing + batching to AskUserQuestion's 4-question cap). Registered right
+// after the brief-gate injector — the position the routing was extracted
+// from — and BEFORE discrepancy-gate, so brief_gate discrepancy delivery
+// stays opportunistic (surfacing it at every gate is follow-up work; the
+// router caps any discrepancy questions that do ride along in the payload).
+require('./question-router')(register);
 require('./spec-gate')(register);
 require('./context-inject')(register);
 require('./tasks-scope-gate')(register);

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/question-router.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/question-router.js
@@ -1,0 +1,126 @@
+/**
+ * Question-router enrichment for brief_gate (GH-543).
+ *
+ * Owns question DELIVERY: the routing block extracted from ./brief-gate.js
+ * (which keeps Gate 0 manifest validation and the sibling-gap injector).
+ * It splits the merged `askUserQuestionPayload` into local vs user scope;
+ * local-only sets auto-pass with an informational note, user-scoped sets
+ * become a blocked instruction the driver must resolve via AskUserQuestion.
+ *
+ * Batching: AskUserQuestion hard-caps at 4 questions per call
+ * (InputValidationError above that), so the override carries AT MOST 4
+ * questions — the front slice of the pending set via `takeBatch()` — plus
+ * `questionProgress` metadata. The driver asks ONE batch, persists it
+ * through the answers-file CLI, and re-runs work-next.js; brief.md itself
+ * records resolutions, so the next planner pass statelessly re-derives the
+ * next batch (a crash or daemon restart resumes instead of restarting).
+ *
+ * Registration order (see ./index.js): after the brief-gate injector and
+ * BEFORE discrepancy-gate — the position routing was extracted from.
+ * brief_gate discrepancy delivery stays opportunistic: when discrepancy
+ * questions do ride along in the payload they are batched under the same
+ * cap, but surfacing them at every gate is follow-up work (GH-543 design,
+ * open question 2).
+ */
+
+'use strict';
+
+const { takeBatch, MAX_PER_ASK } = require('../question-batching');
+
+/**
+ * Blocked instruction for cross-ticket/user questions (GH-543 file
+ * transport + batching): answers travel via a consume-once JSON envelope
+ * file, and `userQuestions` carries at most MAX_PER_ASK questions.
+ */
+function buildUserQuestionsBlocker(userQs, localQs, briefPath, ctx) {
+  const { tasksDir, workDir, path: pathMod } = ctx;
+  const answersPath = pathMod.join(tasksDir, '.brief-gate-answers.json');
+  const applyCliPath = pathMod.join(workDir, 'scripts', 'apply-brief-gate-answers.js');
+  const { batch, batchNumber, totalBatches, total, remaining } = takeBatch(userQs);
+  return {
+    type: 'work_instruction',
+    action: 'blocked',
+    reason: 'brief_gate requires user input for cross-ticket questions',
+    userQuestions: batch.map((q, i) => ({
+      // Global index within the pending set — batches are front slices, so
+      // the batch-local position IS the global position.
+      index: i + 1,
+      question: q.questionText,
+      rationale: q.rationale || '',
+      scope: q.scope,
+      // Envelope routing keys (GH-543). Questions from producers that
+      // predate tagging default to the open-question lane.
+      kind: q.kind || 'open-question',
+      applyKey: q.applyKey || q.questionText,
+      ...(Array.isArray(q.options) ? { options: q.options } : {}),
+    })),
+    // Stateless, remaining-set-relative progress: brief.md records the
+    // resolutions, so each pass re-derives progress over what is still
+    // unanswered (9 pending renders 1/3 → 1/2 → 1/1 across passes).
+    questionProgress: {
+      total,
+      thisBatch: batch.length,
+      remaining,
+      batchNumber,
+      totalBatches,
+    },
+    localQuestions: localQs.map((q) => q.questionText),
+    applyCommand: `node "${applyCliPath}" "${briefPath}"`,
+    hint:
+      `(0) If ${answersPath} already exists (crash recovery), run the applyCommand first ` +
+      `and re-run work-next.js. ` +
+      `(1) Ask THESE questions via ONE AskUserQuestion call (never more than ${MAX_PER_ASK}). ` +
+      `(2) Write the answers to ${answersPath} as a JSON envelope routed by each question's ` +
+      `kind: {"openQuestions": {"<applyKey>": "<answer>", ...}, ` +
+      `"siblingGaps": [{"surface": "<applyKey>", "decision": "implement-here|wait-for-sibling"}, ...], ` +
+      `"discrepancies": [{"claim": "<applyKey>", "decision": "<answer>"}, ...]}. ` +
+      `(3) Run the applyCommand (it persists every kind into brief.md and consumes the ` +
+      `answers file on full apply). ` +
+      `(4) Re-run work-next.js — it presents the next batch until none remain.`,
+  };
+}
+
+module.exports = function registerQuestionRouter(register) {
+  register('brief_gate', (entry, ctx) => {
+    // Defer to whichever blocker already won — Gate 0 manifest failure, etc.
+    if (entry._overrideInstruction) return;
+    if (!entry.askUserQuestionPayload) return;
+
+    const { tasksDir, workDir, path } = ctx;
+    const questions = entry.askUserQuestionPayload.questions || [];
+    if (questions.length === 0) return;
+
+    const localQs = questions.filter((q) => q.scope === 'local');
+    const userQs = questions.filter((q) => q.scope !== 'local');
+    const briefGatePath = path.join(workDir, 'steps', 'brief-gate.js');
+    const briefPath = path.join(tasksDir, 'brief.md');
+
+    // Only local questions — non-blocking, resolved during spec phase
+    if (userQs.length === 0) {
+      const lines = ['## brief_gate: Local Questions (non-blocking)\n'];
+      lines.push(
+        'These questions will be answered by the spec-writer when it analyzes the codebase.'
+      );
+      lines.push('No action needed — the gate passes automatically.\n');
+      localQs.forEach((q, i) => {
+        lines.push(`${i + 1}. "${q.questionText}" → deferred to spec`);
+      });
+      entry.agentPrompt = lines.join('\n');
+      return;
+    }
+
+    // Cross-ticket/user questions — MUST ask the user, not delegate to agent
+    // Override the delegate type to force a blocked instruction
+    entry.agentType = 'Bash';
+    entry.agentPrompt = 'echo "brief_gate: waiting for user answers"';
+
+    // Store the questions and paths for the orchestrator to use
+    entry._briefGateUserQuestions = userQs;
+    entry._briefGateLocalQuestions = localQs;
+    entry._briefGatePath = briefGatePath;
+    entry._briefPath = briefPath;
+
+    // Return a blocked instruction instead — the orchestrator must ask the user
+    entry._overrideInstruction = buildUserQuestionsBlocker(userQs, localQs, briefPath, ctx);
+  });
+};

--- a/plugins/work/scripts/workflows/work/steps/__tests__/brief-gate.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/brief-gate.test.js
@@ -86,6 +86,37 @@ const BRIEF_ONE_BLOCKING_ARCH = [
   '',
 ].join('\n');
 
+// GH-543: five blocking questions — one over the AskUserQuestion 4-cap.
+const BRIEF_FIVE_BLOCKING = [
+  '# Brief',
+  '',
+  '## Open Questions',
+  '',
+  ...[1, 2, 3, 4, 5].flatMap((i) => [
+    `- **Question:** Cross-ticket question ${i}?`,
+    '  - `scope: cross-ticket`',
+    `  - \`rationale: affects sibling ${i}\``,
+    '  - `resolved: false`',
+    '',
+  ]),
+].join('\n');
+
+// GH-543: no open questions, one undecided sibling-gap entry.
+const BRIEF_ONE_SIBLING_GAP = [
+  '# Brief',
+  '',
+  '## Out of scope (sibling-owned)',
+  '- `lib/x.ts` — owned by GH-100 (status: Open, PR: none). Reason: shared surface.',
+  '',
+].join('\n');
+
+const BRIEF_SIBLING_GAP_DECIDED = [
+  BRIEF_ONE_SIBLING_GAP,
+  '## Sibling-gap decisions',
+  '- `lib/x.ts` — decision: wait-for-sibling; timestamp: 2026-07-11T00:00:00Z',
+  '',
+].join('\n');
+
 function makeTmpTasksDir(briefContent) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'brief-gate-test-'));
   if (briefContent !== null) {
@@ -247,6 +278,54 @@ describe('brief-gate step', () => {
       questions[0].applyKey,
       'Which queue backend should we adopt for cross-service jobs?'
     );
+  });
+
+  it('appends the batching suffix to the prompt when more than 4 questions block (GH-543)', () => {
+    const dir = makeTmpTasksDir(BRIEF_FIVE_BLOCKING);
+    createdDirs.push(dir);
+    const { add, entries } = makeAdd();
+    briefGateStep(add, makeState(), makeCtx({ tasksDir: dir }));
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'RUN');
+    assert.match(entries[0].agentPrompt, /\(in batches of at most 4\)/);
+  });
+
+  it('does NOT append the batching suffix for 4 or fewer blocking questions (pin: byte-identical prompt)', () => {
+    const dir = makeTmpTasksDir(BRIEF_ONE_BLOCKING_ARCH);
+    createdDirs.push(dir);
+    const { add, entries } = makeAdd();
+    briefGateStep(add, makeState(), makeCtx({ tasksDir: dir }));
+    assert.ok(!entries[0].agentPrompt.includes('(in batches of at most 4)'));
+  });
+
+  describe('sibling-gap RUN extension (GH-543 trailing-batch delivery)', () => {
+    it('stays RUN when open questions are resolved but sibling gaps remain undecided', () => {
+      const dir = makeTmpTasksDir(BRIEF_ONE_SIBLING_GAP);
+      createdDirs.push(dir);
+      const { add, entries } = makeAdd();
+      briefGateStep(add, makeState(), makeCtx({ tasksDir: dir }));
+      assert.equal(entries.length, 1);
+      const entry = entries[0];
+      assert.equal(entry.action, 'RUN', 'undecided sibling gaps must keep the gate RUN');
+      assert.match(entry.reason, /1 .*sibling-gap/i);
+      // Same delegate shape as the open-question branch so enrichAndReturn
+      // executes the enrichment chain (injector → question-router).
+      assert.equal(entry.agentType, 'general-purpose');
+      assert.equal(typeof entry.agentPrompt, 'string');
+      assert.ok(entry.askUserQuestionPayload, 'RUN entry must carry askUserQuestionPayload');
+      assert.equal(entry.onResolve, 'rewrite brief.md');
+      assert.match(entry.postResolveCommand, /apply-brief-gate-answers\.js/);
+    });
+
+    it('DEFERs when every sibling gap has a recorded decision', () => {
+      const dir = makeTmpTasksDir(BRIEF_SIBLING_GAP_DECIDED);
+      createdDirs.push(dir);
+      const { add, entries } = makeAdd();
+      briefGateStep(add, makeState(), makeCtx({ tasksDir: dir }));
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].action, 'DEFER');
+      assert.match(entries[0].reason, /resolved/i);
+    });
   });
 
   it('emits RUN (not SKIP) when brief.md is unreadable so planner shows gate needs attention', () => {

--- a/plugins/work/scripts/workflows/work/steps/__tests__/question-gates-runtime.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/question-gates-runtime.test.js
@@ -83,10 +83,25 @@ const BRIEF_BLOCKING = [
   '',
 ].join('\n');
 
-function runBriefGate() {
+// GH-543: 5 blocking questions — one over the AskUserQuestion 4-cap.
+const BRIEF_BLOCKING_FIVE = [
+  '# Brief',
+  '',
+  '## Open Questions',
+  '',
+  ...[1, 2, 3, 4, 5].flatMap((i) => [
+    `- **Question:** Which backend should service ${i} adopt?`,
+    '  - `scope: architectural`',
+    '  - `rationale: affects all downstream services`',
+    '  - `resolved: false`',
+    '',
+  ]),
+].join('\n');
+
+function runBriefGate(brief = BRIEF_BLOCKING) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qgate-rt-'));
   createdDirs.push(dir);
-  fs.writeFileSync(path.join(dir, 'brief.md'), BRIEF_BLOCKING, 'utf8');
+  fs.writeFileSync(path.join(dir, 'brief.md'), brief, 'utf8');
   const { add, entries } = makeAdd();
   briefGateStep(add, { hasBrief: true }, { STEPS, ticket: 'TEST-1', tasksDir: dir, path });
   return entries[0];
@@ -101,6 +116,22 @@ describe('brief-gate question site', () => {
       entry.agentPrompt,
       'Use AskUserQuestion to resolve 1 unresolved open question(s) in brief.md, then call applyBriefResolutions() to persist the answers.'
     );
+  });
+
+  it('claude: >4-question prompt gains the batching suffix (GH-543)', () => {
+    pin('claude');
+    const entry = runBriefGate(BRIEF_BLOCKING_FIVE);
+    assert.equal(
+      entry.agentPrompt,
+      'Use AskUserQuestion to resolve 5 unresolved open question(s) in brief.md (in batches of at most 4), then call applyBriefResolutions() to persist the answers.'
+    );
+  });
+
+  it('codex exec: parked notice stays terminal even with the batching suffix (GH-543)', () => {
+    pin('codex', 'exec');
+    const entry = runBriefGate(BRIEF_BLOCKING_FIVE);
+    assert.ok(entry.agentPrompt.endsWith(PARKED_NOTICE));
+    assert.match(entry.agentPrompt, /\(in batches of at most 4\)/);
   });
 
   it('codex interactive: plain-chat numbered-options prose, no parked notice', () => {

--- a/plugins/work/scripts/workflows/work/steps/brief-gate.js
+++ b/plugins/work/scripts/workflows/work/steps/brief-gate.js
@@ -9,9 +9,12 @@
  * Decision matrix:
  *   1. `!s.hasBrief`                           → DEFER "No brief.md present"
  *   2. `brief.md` unreadable (fail-closed)      → RUN   "brief.md unreadable — regenerate brief"
- *   3. Parser returns zero blocking questions  → DEFER "All blocking questions resolved"
+ *   3. Zero blocking questions AND zero
+ *      undecided sibling gaps (GH-543)          → DEFER "All blocking questions resolved"
  *   4. Otherwise                               → RUN with an AskUserQuestion
  *                                                payload + `onResolve: 'rewrite brief.md'`
+ *                                                (sibling-gap-only briefs emit an empty
+ *                                                payload; the enrichment injector fills it)
  *
  * The RUN payload instructs the orchestrator to invoke AskUserQuestion
  * inline (hooks are non-interactive — the gate step is a planning-time
@@ -30,6 +33,8 @@
 const fs = require('fs');
 const openQuestions = require('../lib/open-questions');
 const { applyGateResolutions } = require('../lib/apply-gate-resolutions');
+const { findUnresolvedSiblingGaps } = require('../../lib/brief-sibling-gaps');
+const { MAX_PER_ASK } = require('../lib/question-batching');
 const { T, renderQuestionText, getRuntime } = require('../../lib/instruction-vocab');
 
 /**
@@ -94,8 +99,13 @@ function briefGateStep(add, s, ctx) {
 
   const questions = openQuestions.parse(markdown);
   const blocking = openQuestions.findBlocking(questions);
+  // GH-543: undecided sibling-gap entries block the gate too. Without this
+  // the gate would DEFER the moment open questions deplete, enrichments
+  // would never run (they require a delegating RUN entry), and any trailing
+  // sibling-gap batches would be silently dropped instead of delivered.
+  const unresolvedGaps = findUnresolvedSiblingGaps(markdown).unresolved;
 
-  if (blocking.length === 0) {
+  if (blocking.length === 0 && unresolvedGaps.length === 0) {
     add(STEPS.brief_gate, 'DEFER', null, 'All blocking questions resolved');
     return;
   }
@@ -103,24 +113,62 @@ function briefGateStep(add, s, ctx) {
   // The question renderer keeps claude byte-identical and swaps the codex
   // vocabulary (request_user_input prose / parked-gate notice per mode, C3).
   const rt = getRuntime();
-  add(
-    STEPS.brief_gate,
-    'RUN',
-    T('tool.question', {}, rt.name),
-    `Resolve ${blocking.length} unresolved cross-ticket/architectural question(s)`,
-    {
-      agentType: 'general-purpose',
-      agentPrompt: renderQuestionText(
-        `Use AskUserQuestion to resolve ${blocking.length} unresolved open question(s) in brief.md, then call applyBriefResolutions() to persist the answers.`,
+
+  if (blocking.length === 0) {
+    // Only sibling-gap decisions remain. Same delegate shape as the
+    // open-question branch so enrichAndReturn executes the enrichment chain
+    // (sibling-gap injector → question-router) and the questions — batched
+    // to the AskUserQuestion cap — actually reach the user. The step emits
+    // an empty payload; the injector fills it.
+    addQuestionRun(add, ctx, rt, {
+      reason: `Resolve ${unresolvedGaps.length} unresolved sibling-gap decision(s)`,
+      prompt: renderQuestionText(
+        `Use AskUserQuestion to resolve ${unresolvedGaps.length} unresolved sibling-gap decision(s) in brief.md${batchingSuffix(unresolvedGaps.length)}, then call applyBriefResolutions() to persist the answers.`,
         rt
       ),
-      askUserQuestionPayload: buildAskUserQuestionPayload(blocking),
-      onResolve: 'rewrite brief.md',
-      // GH-543 file transport: the CLI reads the default answers file
-      // (<tasksDir>/.brief-gate-answers.json) — no answer JSON on the argv.
-      postResolveCommand: `node "${path.join(__dirname, '..', 'scripts', 'apply-brief-gate-answers.js')}" "${briefPath}"`,
-    }
-  );
+      payload: buildAskUserQuestionPayload([]),
+      briefPath,
+    });
+    return;
+  }
+
+  addQuestionRun(add, ctx, rt, {
+    reason: `Resolve ${blocking.length} unresolved cross-ticket/architectural question(s)`,
+    prompt: renderQuestionText(
+      `Use AskUserQuestion to resolve ${blocking.length} unresolved open question(s) in brief.md${batchingSuffix(blocking.length)}, then call applyBriefResolutions() to persist the answers.`,
+      rt
+    ),
+    payload: buildAskUserQuestionPayload(blocking),
+    briefPath,
+  });
+}
+
+/**
+ * Emit the AskUserQuestion RUN entry shared by the open-question and
+ * sibling-gap branches. `prompt` arrives pre-rendered through
+ * renderQuestionText at the construction site (the vocab lint requires the
+ * tool literal inside the renderer call). The postResolveCommand is the
+ * GH-543 file-transport CLI: it reads the default answers file
+ * (<tasksDir>/.brief-gate-answers.json) — no answer JSON ever rides the argv.
+ */
+function addQuestionRun(add, ctx, rt, { reason, prompt, payload, briefPath }) {
+  const { STEPS, path } = ctx;
+  add(STEPS.brief_gate, 'RUN', T('tool.question', {}, rt.name), reason, {
+    agentType: 'general-purpose',
+    agentPrompt: prompt,
+    askUserQuestionPayload: payload,
+    onResolve: 'rewrite brief.md',
+    postResolveCommand: `node "${path.join(__dirname, '..', 'scripts', 'apply-brief-gate-answers.js')}" "${briefPath}"`,
+  });
+}
+
+/**
+ * GH-543: batching note appended to the gate prompt ONLY above the
+ * AskUserQuestion cap, keeping the ≤4-question claude prompts byte-identical
+ * to the pre-batching pins (question-gates-runtime.test.js).
+ */
+function batchingSuffix(count) {
+  return count > MAX_PER_ASK ? ` (in batches of at most ${MAX_PER_ASK})` : '';
 }
 
 /**

--- a/plugins/work/scripts/workflows/work/workflow-def/gate-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/gate-verifiers.js
@@ -40,8 +40,12 @@ function verifyBootstrap(deps, ticketId) {
 /**
  * GH-215: Helper for STEPS.brief_gate verify. Returns true iff brief.md
  * exists for `ticketId` AND openQuestions.findBlocking(parse(brief)) is
- * empty. Fail-closed on any read/parse error — we never claim verified
- * unless we can prove it.
+ * empty AND (GH-543) every `## Out of scope (sibling-owned)` entry has a
+ * recorded sibling-gap decision — fail-closed consistency with
+ * steps/brief-gate.js, which stays RUN while gaps are undecided. Legacy
+ * briefs without that section yield zero unresolved gaps, so nothing
+ * retroactively blocks. Fail-closed on any read/parse error — we never
+ * claim verified unless we can prove it.
  * @param {GateDeps} deps
  */
 function verifyBriefGate(deps, ticketId) {
@@ -49,9 +53,13 @@ function verifyBriefGate(deps, ticketId) {
     const briefPath = path.join(deps.TASKS_BASE, deps.safeTicketPath(ticketId), 'brief.md');
     if (!fs.existsSync(briefPath)) return false;
     const openQuestions = require(path.join(deps.workRoot, 'lib', 'open-questions'));
+    const { findUnresolvedSiblingGaps } = require(
+      path.join(deps.workRoot, '..', 'lib', 'brief-sibling-gaps')
+    );
     const markdown = fs.readFileSync(briefPath, 'utf-8');
     const blocking = openQuestions.findBlocking(openQuestions.parse(markdown));
-    return Array.isArray(blocking) && blocking.length === 0;
+    if (!Array.isArray(blocking) || blocking.length !== 0) return false;
+    return findUnresolvedSiblingGaps(markdown).unresolved.length === 0;
   } catch {
     return false;
   }

--- a/plugins/work/skills/brief/SKILL.md
+++ b/plugins/work/skills/brief/SKILL.md
@@ -115,7 +115,7 @@ Every entry under `## Open Questions` in the generated brief is emitted as a str
 
 Between the `brief` step and the `spec` step, the workflow runs a `brief_gate` check over the brief's Open Questions:
 
-- Unresolved questions with `scope: cross-ticket` or `scope: architectural` **block** the transition from brief to spec. The planner emits a `RUN` action that prompts you interactively via `AskUserQuestion`; your answer is written back into the brief as a `Resolution:` line and the question is flipped to `resolved: true`. The gate re-runs until no blocking questions remain.
+- Unresolved questions with `scope: cross-ticket` or `scope: architectural` **block** the transition from brief to spec. The planner emits a `RUN` action that prompts you interactively via `AskUserQuestion`; your answer is written back into the brief as a `Resolution:` line and the question is flipped to `resolved: true`. The gate re-runs until no blocking questions remain. When more than 4 blocking questions exist, the gate presents them in batches of at most 4 (the AskUserQuestion per-call cap) and answers persist per batch, so an interrupted session resumes at the first unanswered batch.
 - Unresolved questions with `scope: local` **do not block** the gate. They are clarifications that do not affect sibling tickets or architecture, so they can carry forward into spec and be resolved in context.
 
 If a question was mis-classified at emission time, you can downgrade it to `local` with a written justification (or upgrade it) by editing the brief directly before re-running the gate.

--- a/plugins/work/skills/work/SKILL.md
+++ b/plugins/work/skills/work/SKILL.md
@@ -128,6 +128,20 @@ If the instruction has `parallel: true` with `delegates` array: launch ALL agent
 
 - The **only** command you run directly is `work-next.js`. Everything else comes from its instructions.
 - If `action: "blocked"` → show the reason to the user and wait. Do NOT re-run automatically.
+- **Question gates** (`action: "blocked"` with `userQuestions`): AskUserQuestion
+  accepts at most 4 questions per call and the instruction is pre-batched —
+  `userQuestions` never carries more than 4 (`questionProgress` shows
+  total/thisBatch/remaining for the pending set). The loop:
+  (0) if the answers file (`.brief-gate-answers.json` next to `brief.md`)
+  already exists from a crash, run the `applyCommand` first and re-run
+  `work-next.js`; (1) ask exactly the questions in `userQuestions` via ONE
+  AskUserQuestion call — never merge in extra questions; (2) Write the answers
+  envelope `{"openQuestions": {"<applyKey>": "<answer>"}, "siblingGaps":
+  [{"surface": "<applyKey>", "decision": "implement-here|wait-for-sibling"}],
+  "discrepancies": [{"claim": "<applyKey>", "decision": "<answer>"}]}` to the
+  answers file; (3) run the `applyCommand` (persists every kind into brief.md
+  and consumes the file on full apply); (4) re-run `work-next.js` — it
+  presents the next batch until none remain.
 - **Some steps take a long time (CI monitoring can take 20+ minutes). This is normal. Do NOT cancel, interrupt, or give up.**
 - Never stop until `action: "complete"`.
 
@@ -156,5 +170,10 @@ only the dispatch surface changes:
   does not exist. Interactive sessions use `request_user_input`; unattended
   exec parks the gate — answers arrive via the maestro `/signal` inbox or
   `codex exec resume --last "<answer>"` (verified; `--last` is cwd-filtered — run it from the agent worktree, or pass the session id).
+  The ≤4 batch loop from the Rules section applies identically: ask only the
+  pre-batched `userQuestions` (via `request_user_input` or the parked-gate
+  channel), persist each batch through the same answers file + `applyCommand`,
+  then re-run the driver for the next batch — including crash-recovery step 0
+  when a leftover `.brief-gate-answers.json` exists.
 - Instructions carrying `[work:codex-degraded]` notices are informational —
   they explain the fallback in effect, not an error.


### PR DESCRIPTION
## Existing Behavior

- `brief_gate` builds its blocked instruction inside `brief-gate.js` (the injector), coupling question routing and batching to the same enrichment that handles Gate 0 manifest validation and sibling-gap injection.
- AskUserQuestion payloads are assembled without a cap — briefs with 5+ blocking questions produce a payload that the tool hard-rejects (`InputValidationError: Too big: expected array to have <=4 items`), causing an infinite loop: daemon restarts, re-reads the unresolved brief, fails again.
- Once open questions are exhausted the gate unconditionally DEFERs, so any trailing unresolved sibling-gap entries are silently dropped — the enrichment chain never runs to deliver them.
- The `brief_gate` verify function in `gate-verifiers.js` only checks that blocking open questions are empty; it ignores undecided `## Out of scope (sibling-owned)` entries, allowing the gate to pass the completion-check while sibling-gap decisions remain outstanding.

## Intended New Behavior

- A new `lib/question-batching.js` module owns the `MAX_PER_ASK = 4` constant and a stateless `takeBatch()` helper that slices the front of the pending question set. Because `brief.md` is the store of record, a daemon restart or crash between batches re-derives the identical next batch — the loop resumes rather than restarting.
- Question routing and batching are extracted from `brief-gate.js` into a new `step-enrichments/question-router.js` enrichment registered immediately after the injector in `index.js`. The injector retains Gate 0 and Gate A (sibling-gap injection); the router owns the local/user split, the capped blocked instruction, and `questionProgress` metadata (`total`, `thisBatch`, `remaining`, `batchNumber`, `totalBatches`).
- `steps/brief-gate.js` now checks `findUnresolvedSiblingGaps()` alongside blocking open questions. When open questions are gone but sibling-gap entries remain undecided, the step emits a RUN entry (same delegate shape) so the enrichment chain executes and the remaining questions are batched and delivered.
- `gate-verifiers.js` `verifyBriefGate` is updated to match: it returns `false` when unresolved sibling gaps remain, keeping completion-check logic consistent with the planner step.
- `SKILL.md` (brief and work) documents the ≤4 batch loop, crash-recovery step 0, and the answers-envelope format so orchestrators follow the correct protocol.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

This is a backend/workflow-engine change. No UI surface.

**Unit — `lib/question-batching.js`**
```
node --test plugins/work/scripts/workflows/work/lib/__tests__/question-batching.test.js
```
Covers: `MAX_PER_ASK` export, 5→4+1, 8→4+4, 9→4+4+1, never-exceeds-cap, order preservation, arithmetic, stateless batchNumber/totalBatches, empty/non-array guard.

**Unit — `step-enrichments/question-router.js`**
```
node --test plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/question-router.test.js
```
Covers: 6-question mixed-kind cap at 4, `questionProgress` shape, remaining-set-relative batchNumber, reason string byte-identity, ≤4 sets delivered whole, discrepancy questions capped, sibling-gap options preserved, `applyCommand` points to the answers-file CLI with no inline JSON placeholder, hint documents the crash-recovery step and batch loop, local-only non-blocking note, local + user coexistence, earlier-blocker deference, no-payload no-op, empty-payload no-op.

**Integration — brief_gate batching loop**
```
node --test plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/brief-gate-batching-loop.test.js
```
Covers: 5 open + 3 sibling-gap questions terminate in exactly 2 batches of 4, all 8 persisted into `brief.md`, final DEFER with "All blocking questions resolved"; crash-resume invariant (two consecutive re-derivations after a mid-loop "crash" agree on the next batch); trailing sibling-gap batches delivered when only gaps remain.

**Step-level regression — `steps/brief-gate.js`**
```
node --test plugins/work/scripts/workflows/work/steps/__tests__/brief-gate.test.js
node --test plugins/work/scripts/workflows/work/steps/__tests__/question-gates-runtime.test.js
```
Covers: batching suffix appended only above the 4-cap, byte-identical prompts for ≤4, sibling-gap-only RUN entry shape (agentType, agentPrompt, askUserQuestionPayload, onResolve, postResolveCommand), DEFER when every gap has a recorded decision, >4-question claude/codex-exec prompt pins.

**Workflow-definition regression — `gate-verifiers.js`**
```
node --test plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
```
Covers: `verifyBriefGate` returns false for an undecided sibling-gap entry and true once a `## Sibling-gap decisions` section records the decision.

### Test Results

New test files added in this stage:
- `lib/__tests__/question-batching.test.js` — 9 cases
- `lib/step-enrichments/__tests__/question-router.test.js` — 13 cases
- `lib/step-enrichments/__tests__/brief-gate-batching-loop.test.js` — 3 integration cases

Existing test files extended:
- `steps/__tests__/brief-gate.test.js` — 6 new cases
- `steps/__tests__/question-gates-runtime.test.js` — 2 new cases
- `__tests__/workflow-definition.test.js` — 2 new cases

---

Stacked on: `feat/gh-543-resolutions-transport` (stage 1 — answers-file transport CLI and `applyGateResolutions`). Merge that branch first; this PR targets it directly.

Closes #543