### PR TITLE
fix(work): require commit evidence before commit/task_review steps can complete (GH-693)

### DIFF
--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -119,7 +119,6 @@ plugins/work/scripts/workflows/check/scripts/write-completion-report.js
 plugins/work/scripts/workflows/work-ci/lib/phases/wait_merge.js
 plugins/work/scripts/workflows/work-completion-checker/lib/phases/kind_checks.js
 plugins/work/scripts/workflows/work-task-review/lib/phases/kind_checks.js
-plugins/work/scripts/workflows/work-task-review/lib/phases/diff_audit.js
 plugins/work/scripts/workflows/work-pr-reviewer/lib/kind-checks/shared.js
 plugins/work/scripts/workflows/work-pr-reviewer/lib/phases/kind_checks.js
 plugins/work/scripts/workflows/work-ci/lib/phases/rerun_check.js

--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -88,7 +88,6 @@ plugins/work/scripts/workflows/work/lib/work-enforcement-context.js
 plugins/work/scripts/workflows/check/agents/qa-feature-tester/qa-pretooluse-hooks.js
 plugins/work/scripts/workflows/work-spec/lib/component-shape.js
 plugins/work/scripts/workflows/check/scripts/write-code-review.js
-plugins/work/scripts/workflows/work/hooks/enforce-screenshot-gate.js
 plugins/work/scripts/workflows/work/lib/pr-mergeable.js
 plugins/work/scripts/workflows/work-brief/lib/memory-plugin-config.js
 plugins/work/scripts/workflows/lib/related-tickets.js

--- a/plugins/work/scripts/workflows/lib/__tests__/config.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/config.test.js
@@ -315,6 +315,62 @@ describe('config', () => {
       assert.equal(branch, 'origin/main');
     });
 
+    // ─── getExplicitBase (GH-693 / PR #716) ─────────────────────────────────
+    // Strict consumers (the commit-evidence gate) must be able to tell
+    // "no explicit base configured" apart from "explicit base configured
+    // but unresolvable" — the latter must fail closed, never silently
+    // degrade to auto-detected origin/main.
+
+    it('getExplicitBase reports configured:false when BASE_BRANCH is unset', () => {
+      const config = freshRequire();
+      assert.deepEqual(config.getExplicitBase(), { configured: false });
+    });
+
+    it('getExplicitBase reports a null ref when the configured base does not resolve', () => {
+      const config = freshRequire({ BASE_BRANCH: 'nonexistent-branch-xyz-999' });
+      const res = config.getExplicitBase();
+      assert.equal(res.configured, true);
+      assert.equal(res.ref, null, 'unresolvable base must NOT be silently replaced');
+      assert.equal(res.sanitized, 'nonexistent-branch-xyz-999');
+    });
+
+    it('getExplicitBase resolves an explicit base that exists as origin/<name>', () => {
+      const cp = require('child_process');
+      const fs = require('fs');
+      const os = require('os');
+      const path = require('path');
+      const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'gh716-explicit-'));
+      const git = (args) =>
+        cp.execFileSync('git', args, { cwd: repo, stdio: ['pipe', 'pipe', 'pipe'] });
+      try {
+        git(['init', '-q']);
+        git([
+          '-c',
+          'user.email=t@example.com',
+          '-c',
+          'user.name=t',
+          'commit',
+          '--allow-empty',
+          '-m',
+          'x',
+          '-q',
+        ]);
+        git(['update-ref', 'refs/remotes/origin/stable', 'HEAD']);
+        const config = freshRequire({ BASE_BRANCH: 'stable' });
+        const res = config.getExplicitBase({ cwd: repo });
+        assert.equal(res.configured, true);
+        assert.equal(res.ref, 'origin/stable');
+      } finally {
+        fs.rmSync(repo, { recursive: true, force: true });
+      }
+    });
+
+    it('getExplicitBase sanitizes an origin/-prefixed BASE_BRANCH like getBaseBranch', () => {
+      const config = freshRequire({ BASE_BRANCH: 'origin/nonexistent-branch-xyz-999' });
+      const res = config.getExplicitBase();
+      assert.equal(res.sanitized, 'nonexistent-branch-xyz-999');
+    });
+
     it('honors BASE_BRANCH set AFTER config module was loaded (ECHO-4450)', () => {
       // Load config with no BASE_BRANCH set — simulates the case where the
       // parent process exports BASE_BRANCH only later (or via a wrapper).

--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -3353,10 +3353,10 @@ describe('enforce-step-workflow', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // commit verify: branch-name fallback (GH-191)
+  // commit verify: commits-ahead evidence (GH-191 branch-name fallback DELETED, GH-693)
   // ═══════════════════════════════════════════════════════════════════════════
 
-  describe('commit verify branch-name fallback (GH-191)', () => {
+  describe('commit verify commits-ahead evidence (GH-191 fallback deleted, GH-693)', () => {
     const FAKE_GIT_DIR = path.join(os.tmpdir(), `fake-git-commit-${process.pid}`);
     const FAKE_GIT_PATH = path.join(FAKE_GIT_DIR, 'git');
     const FAKE_GH_DIR = path.join(os.tmpdir(), `fake-gh-commit-${process.pid}`);
@@ -3430,13 +3430,16 @@ describe('enforce-step-workflow', () => {
       cleanup();
     });
 
-    it('allows transition via branch-name fallback when commit messages lack ticket ID', async () => {
+    it('blocks when branch matches ticket but zero commits are ahead of base (GH-693: fallback deleted)', async () => {
+      // GH-693 pin: the GH-191 branch-name fallback was DELETED. Its only
+      // reachable pass case was the false positive — empty base..HEAD with a
+      // two-dot diff fabricated by a moved base. This exact shape must block.
       writeFakeGit({
         'rev-parse --show-toplevel': process.cwd(),
         'symbolic-ref': 'EXIT1',
         'rev-parse --verify': 'EXIT1',
         'rev-parse HEAD': 'abc123',
-        'log --oneline': '', // No commits with ticket ID
+        'log --oneline': '', // zero commits ahead of base
         'branch --show-current': `${TEST_TICKET}-fix-something`,
         'diff --shortstat': '1 file changed, 10 insertions(+)',
       });
@@ -3444,9 +3447,24 @@ describe('enforce-step-workflow', () => {
       const { code } = await transitionFromCommit();
       assert.equal(
         code,
-        0,
-        'Should allow transition when branch contains ticket ID and diff is non-empty'
+        2,
+        'Zero commits ahead must block even when the branch name matches the ticket'
       );
+    });
+
+    it('allows transition when commits exist ahead of base regardless of branch name', async () => {
+      writeFakeGit({
+        'rev-parse --show-toplevel': process.cwd(),
+        'symbolic-ref': 'EXIT1',
+        'rev-parse --verify': 'EXIT1',
+        'rev-parse HEAD': 'abc123',
+        'log --oneline': 'abc123 fix: improve reliability', // commits ahead of base
+        'branch --show-current': 'some-unrelated-branch',
+        'diff --shortstat': '1 file changed, 10 insertions(+)',
+      });
+
+      const { code } = await transitionFromCommit();
+      assert.equal(code, 0, 'Commits ahead of base prove the commit step (GH-693)');
     });
 
     it('blocks transition when branch does not contain ticket ID', async () => {

--- a/plugins/work/scripts/workflows/lib/__tests__/write-phase-context.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/write-phase-context.test.js
@@ -1,0 +1,57 @@
+/**
+ * write-phase-context.test.js — shared phase-context snapshot writer used by
+ * the work-task-review diff_audit and work-reports collect_artifacts phases
+ * (extracted to remove their duplicated writeContext boilerplate, GH-693).
+ */
+
+'use strict';
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { writePhaseContext } = require('../write-phase-context');
+
+const TEMP = fs.mkdtempSync(path.join(os.tmpdir(), 'write-phase-context-'));
+
+after(() => fs.rmSync(TEMP, { recursive: true, force: true }));
+
+describe('writePhaseContext', () => {
+  it('writes extra fields plus fileCount/files/capturedAt to the named file', () => {
+    const dir = path.join(TEMP, 'ok');
+    fs.mkdirSync(dir, { recursive: true });
+    writePhaseContext(dir, 'task-review-context.json', ['a.js', 'b.js'], {
+      ticket: 'GH-1',
+      base: 'abc',
+      head: 'HEAD',
+      fallback: false,
+    });
+    const parsed = JSON.parse(fs.readFileSync(path.join(dir, 'task-review-context.json'), 'utf8'));
+    assert.equal(parsed.ticket, 'GH-1');
+    assert.equal(parsed.base, 'abc');
+    assert.equal(parsed.head, 'HEAD');
+    assert.equal(parsed.fallback, false);
+    assert.equal(parsed.fileCount, 2);
+    assert.deepEqual(parsed.files, ['a.js', 'b.js']);
+    assert.ok(!Number.isNaN(Date.parse(parsed.capturedAt)), 'capturedAt must be a timestamp');
+  });
+
+  it('works without extra fields', () => {
+    const dir = path.join(TEMP, 'noextra');
+    fs.mkdirSync(dir, { recursive: true });
+    writePhaseContext(dir, 'reports-context.json', []);
+    const parsed = JSON.parse(fs.readFileSync(path.join(dir, 'reports-context.json'), 'utf8'));
+    assert.equal(parsed.fileCount, 0);
+    assert.deepEqual(parsed.files, []);
+  });
+
+  it('swallows write errors (hook-gated snapshot is non-fatal)', () => {
+    const missing = path.join(TEMP, 'does', 'not', 'exist');
+    assert.doesNotThrow(() =>
+      writePhaseContext(missing, 'reports-context.json', ['x'], { ticket: 'GH-2' })
+    );
+    assert.equal(fs.existsSync(path.join(missing, 'reports-context.json')), false);
+  });
+});

--- a/plugins/work/scripts/workflows/lib/config.js
+++ b/plugins/work/scripts/workflows/lib/config.js
@@ -245,6 +245,47 @@ config.webAppsMap = () => {
 };
 
 /**
+ * GH-693 (PR #716): resolve the EXPLICITLY configured base branch, reporting
+ * whether one is configured and whether `origin/<name>` actually resolves.
+ * Strict consumers (the commit-evidence gate) must fail closed on a
+ * configured-but-unresolvable base instead of silently counting commits
+ * against an auto-detected fallback (origin/main), which can fabricate
+ * commit evidence for a branch with zero commits ahead of its real base.
+ *
+ * Reads env dynamically, not via the cached config.BASE_BRANCH snapshot:
+ * a parent process may export BASE_BRANCH after this module is first
+ * loaded, and ECHO-4450 hit that case (BASE_BRANCH=dev was set but ignored).
+ *
+ * @param {object} [options] - Optional settings
+ * @param {string} [options.cwd] - Working directory for git commands
+ * @returns {{configured: false} | {configured: true, raw: string, sanitized: string, ref: string|null}}
+ */
+config.getExplicitBase = (options = {}) => {
+  const explicitBase = process.env.BASE_BRANCH || config.BASE_BRANCH;
+  if (!explicitBase) return { configured: false };
+  // Sanitize to prevent shell injection; strip ".."/"..." revspec operators.
+  const sanitized = explicitBase
+    .replace(/^refs\/remotes\//, '')
+    .replace(/^origin\//, '')
+    .replace(/[^a-zA-Z0-9._\-/]/g, '')
+    .replace(/\.{2,}/g, '');
+  let ref = null;
+  if (sanitized) {
+    const candidate = `origin/${sanitized}`;
+    try {
+      const out = execSync(`git rev-parse --verify ${candidate} 2>/dev/null`, {
+        encoding: 'utf8',
+        cwd: options.cwd || undefined,
+      }).trim();
+      if (out) ref = candidate;
+    } catch {
+      /* unresolvable — caller decides whether to fall back or fail closed */
+    }
+  }
+  return { configured: true, raw: explicitBase, sanitized, ref };
+};
+
+/**
  * Detect the correct base branch for the repository.
  * Priority: repo config (BASE_BRANCH) → git symbolic-ref → probe common names → fallback
  * @param {object} [options] - Optional settings
@@ -260,23 +301,12 @@ config.getBaseBranch = (options = {}) => {
     }
   };
 
-  // 1. Explicit repo config (highest priority) — sanitize to prevent shell injection.
-  // Read env dynamically here, not via the cached config.BASE_BRANCH snapshot:
-  // a parent process may export BASE_BRANCH after this module is first loaded,
-  // and ECHO-4450 hit that case (BASE_BRANCH=dev was set but ignored).
-  const explicitBase = process.env.BASE_BRANCH || config.BASE_BRANCH;
-  if (explicitBase) {
-    const sanitized = explicitBase
-      .replace(/^refs\/remotes\//, '')
-      .replace(/^origin\//, '')
-      .replace(/[^a-zA-Z0-9._\-/]/g, '')
-      .replace(/\.{2,}/g, ''); // reject git revspec operators (.., ...)
-    if (sanitized) {
-      const ref = `origin/${sanitized}`;
-      if (safeExec(`git rev-parse --verify ${ref} 2>/dev/null`)) return ref;
-    }
-    // Invalid or non-existent BASE_BRANCH — fall through to auto-detection
-  }
+  // 1. Explicit repo config (highest priority). Invalid or non-existent
+  // BASE_BRANCH falls through to auto-detection here (lenient, historical
+  // behavior for scope-diff callers); strict consumers use getExplicitBase
+  // directly and fail closed instead (PR #716).
+  const explicit = config.getExplicitBase({ cwd });
+  if (explicit.configured && explicit.ref) return explicit.ref;
 
   // 2. Git symbolic ref detection
   const headRef = safeExec('git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null');

--- a/plugins/work/scripts/workflows/lib/config.js
+++ b/plugins/work/scripts/workflows/lib/config.js
@@ -12,7 +12,7 @@
  *   console.log(config.REPO_NAME);        // e.g., 'my-project'
  */
 
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -273,9 +273,12 @@ config.getExplicitBase = (options = {}) => {
   if (sanitized) {
     const candidate = `origin/${sanitized}`;
     try {
-      const out = execSync(`git rev-parse --verify ${candidate} 2>/dev/null`, {
+      // execFileSync array args (no shell) + --end-of-options: an
+      // env-derived ref can never be parsed as a git option.
+      const out = execFileSync('git', ['rev-parse', '--verify', '--end-of-options', candidate], {
         encoding: 'utf8',
         cwd: options.cwd || undefined,
+        stdio: ['pipe', 'pipe', 'pipe'],
       }).trim();
       if (out) ref = candidate;
     } catch {

--- a/plugins/work/scripts/workflows/lib/write-phase-context.js
+++ b/plugins/work/scripts/workflows/lib/write-phase-context.js
@@ -1,0 +1,36 @@
+/**
+ * Shared phase-context snapshot writer.
+ *
+ * Phase runners snapshot their computed inputs into `<name>-context.json`
+ * inside the ticket's tasks dir for downstream phases (work-task-review
+ * diff_audit, work-reports collect_artifacts). The write is advisory —
+ * hooks may gate it — so failures are swallowed.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Write `<fileName>` into tasksDir with the shared bookkeeping fields.
+ * @param {string} tasksDir - Ticket tasks directory
+ * @param {string} fileName - Snapshot file name (e.g. 'reports-context.json')
+ * @param {string[]} files - File list recorded as `files` + `fileCount`
+ * @param {Object} [extra] - Leading payload fields (ticket, base, head, ...)
+ */
+function writePhaseContext(tasksDir, fileName, files, extra = {}) {
+  const payload = {
+    ...extra,
+    fileCount: files.length,
+    files,
+    capturedAt: new Date().toISOString(),
+  };
+  try {
+    fs.writeFileSync(path.join(tasksDir, fileName), JSON.stringify(payload, null, 2));
+  } catch {
+    /* hook-gated; non-fatal */
+  }
+}
+
+module.exports = { writePhaseContext };

--- a/plugins/work/scripts/workflows/work-reports/lib/phases/collect_artifacts.js
+++ b/plugins/work/scripts/workflows/work-reports/lib/phases/collect_artifacts.js
@@ -6,9 +6,9 @@
 'use strict';
 
 const fs = require('node:fs');
-const path = require('node:path');
 
 const { REPORTS_PHASES } = require('../../reports-phase-registry');
+const { writePhaseContext } = require('../../../lib/write-phase-context');
 
 const ARTIFACT_PATTERNS = [
   /^brief\.md$/,
@@ -36,18 +36,7 @@ function listArtifacts(tasksDir) {
 }
 
 function writeContext(ctx, files) {
-  const p = path.join(ctx.tasksDir, 'reports-context.json');
-  const payload = {
-    ticket: ctx.ticket,
-    fileCount: files.length,
-    files,
-    capturedAt: new Date().toISOString(),
-  };
-  try {
-    fs.writeFileSync(p, JSON.stringify(payload, null, 2));
-  } catch {
-    /* hook-gated; non-fatal */
-  }
+  writePhaseContext(ctx.tasksDir, 'reports-context.json', files, { ticket: ctx.ticket });
 }
 
 function validate(ctx) {

--- a/plugins/work/scripts/workflows/work-task-review/__tests__/diff-audit.test.js
+++ b/plugins/work/scripts/workflows/work-task-review/__tests__/diff-audit.test.js
@@ -1,0 +1,77 @@
+/**
+ * diff-audit.test.js — GH-693 blocked-state propagation for the diff_audit
+ * phase of the task-review runner.
+ *
+ * When computeTaskDiff blocks (zero commits ahead of base and no valid
+ * .last-commit-sha), validate() must surface that exact reason instead of
+ * auditing an empty range and misattributing it to a stale SHA.
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { validate } = require('../lib/phases/diff_audit');
+
+const TEMP = fs.mkdtempSync(path.join(os.tmpdir(), 'diff-audit-test-'));
+
+after(() => fs.rmSync(TEMP, { recursive: true, force: true }));
+
+describe('diff_audit validate (GH-693 blocked propagation)', () => {
+  // computeTaskDiff uses a dynamic require('child_process').execFileSync, so
+  // patching the module property makes the commits-ahead answer deterministic.
+  const cp = require('node:child_process');
+  let origExecFileSync;
+  let revList;
+
+  beforeEach(() => {
+    revList = '0\n';
+    origExecFileSync = cp.execFileSync;
+    cp.execFileSync = (cmd, args, opts) => {
+      if (cmd === 'git' && args[0] === 'rev-list' && args[1] === '--count') {
+        if (revList instanceof Error) throw revList;
+        return revList;
+      }
+      if (cmd === 'git' && args[0] === 'merge-base' && args[1] !== '--is-ancestor') {
+        return `${'a'.repeat(40)}\n`;
+      }
+      return origExecFileSync(cmd, args, opts);
+    };
+  });
+
+  afterEach(() => {
+    cp.execFileSync = origExecFileSync;
+  });
+
+  function makeCtx(name) {
+    const tasksDir = path.join(TEMP, name);
+    fs.mkdirSync(tasksDir, { recursive: true });
+    // worktreeRoot is a plain temp dir (not a git repo) so any real
+    // `git diff --name-only` deterministically yields an empty file list.
+    return { ticket: name, tasksDir, worktreeRoot: tasksDir };
+  }
+
+  it('surfaces the blocked reason when zero commits are ahead and no .last-commit-sha exists', () => {
+    const ctx = makeCtx('T-BLOCKED');
+    const res = validate(ctx);
+    assert.equal(res.ok, false);
+    assert.match(res.errors[0], /no commits ahead/, 'must surface the gate reason verbatim');
+    assert.equal(
+      fs.existsSync(path.join(ctx.tasksDir, 'task-review-context.json')),
+      false,
+      'no context snapshot may be written for a blocked range'
+    );
+  });
+
+  it('keeps the empty-file-list rejection for non-blocked ranges (belt and braces)', () => {
+    revList = '1\n';
+    const ctx = makeCtx('T-EMPTY');
+    const res = validate(ctx);
+    assert.equal(res.ok, false);
+    assert.match(res.errors[0], /task diff empty/);
+  });
+});

--- a/plugins/work/scripts/workflows/work-task-review/__tests__/diff-audit.test.js
+++ b/plugins/work/scripts/workflows/work-task-review/__tests__/diff-audit.test.js
@@ -74,4 +74,44 @@ describe('diff_audit validate (GH-693 blocked propagation)', () => {
     assert.equal(res.ok, false);
     assert.match(res.errors[0], /task diff empty/);
   });
+
+  // ─── PR #716: a failed audit must not leave a previous snapshot behind ────
+  // Later phases (reuse_check, kind-checks shared.js) read
+  // task-review-context.json; a retry after an earlier successful audit
+  // must not let them analyze the STALE file list.
+
+  function writeStaleContext(ctx) {
+    const p = path.join(ctx.tasksDir, 'task-review-context.json');
+    fs.writeFileSync(
+      p,
+      JSON.stringify({ ticket: ctx.ticket, files: ['stale-old-file.js'], fileCount: 1 })
+    );
+    return p;
+  }
+
+  it('removes a stale task-review-context.json when the range is blocked', () => {
+    const ctx = makeCtx('T-STALE-BLOCKED');
+    const stale = writeStaleContext(ctx);
+    const res = validate(ctx); // revList '0\n' -> blocked
+    assert.equal(res.ok, false);
+    assert.equal(
+      fs.existsSync(stale),
+      false,
+      'stale snapshot must not survive a blocked audit for later phases to read'
+    );
+  });
+
+  it('removes a stale task-review-context.json when the current range yields no files', () => {
+    revList = '1\n';
+    const ctx = makeCtx('T-STALE-EMPTY');
+    const stale = writeStaleContext(ctx);
+    const res = validate(ctx);
+    assert.equal(res.ok, false);
+    assert.match(res.errors[0], /task diff empty/);
+    assert.equal(
+      fs.existsSync(stale),
+      false,
+      'stale snapshot must not survive an empty-range audit either'
+    );
+  });
 });

--- a/plugins/work/scripts/workflows/work-task-review/__tests__/diff-audit.test.js
+++ b/plugins/work/scripts/workflows/work-task-review/__tests__/diff-audit.test.js
@@ -33,7 +33,7 @@ describe('diff_audit validate (GH-693 blocked propagation)', () => {
     origExecFileSync = cp.execFileSync;
     cp.execFileSync = (cmd, args, opts) => {
       if (cmd === 'git' && args[0] === 'rev-list' && args[1] === '--count') {
-        if (revList instanceof Error) throw revList;
+        if (typeof revList !== 'string') throw revList;
         return revList;
       }
       if (cmd === 'git' && args[0] === 'merge-base' && args[1] !== '--is-ancestor') {

--- a/plugins/work/scripts/workflows/work-task-review/lib/phases/diff_audit.js
+++ b/plugins/work/scripts/workflows/work-task-review/lib/phases/diff_audit.js
@@ -83,6 +83,11 @@ function writeContext(ctx, diff, files) {
 
 function validate(ctx) {
   const diff = computeDiff(ctx);
+  if (diff && diff.blocked) {
+    // GH-693: surface the same blocked state as the plan-time gate instead
+    // of auditing an empty range (validator-unification invariant).
+    return { ok: false, errors: [diff.reason] };
+  }
   const root = ctx.worktreeRoot || process.cwd();
   const files = gitDiffNameOnly(diff.base, diff.head, root);
   if (!files.length) {

--- a/plugins/work/scripts/workflows/work-task-review/lib/phases/diff_audit.js
+++ b/plugins/work/scripts/workflows/work-task-review/lib/phases/diff_audit.js
@@ -6,11 +6,10 @@
 
 'use strict';
 
-const fs = require('node:fs');
-const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const { TASK_REVIEW_PHASES } = require('../../task-review-phase-registry');
+const { writePhaseContext } = require('../../../lib/write-phase-context');
 
 let taskReviewGate;
 try {
@@ -64,21 +63,12 @@ function computeDiff(ctx) {
 }
 
 function writeContext(ctx, diff, files) {
-  const p = path.join(ctx.tasksDir, 'task-review-context.json');
-  const payload = {
+  writePhaseContext(ctx.tasksDir, 'task-review-context.json', files, {
     ticket: ctx.ticket,
     base: diff.base,
     head: diff.head,
     fallback: !!diff.fallback,
-    fileCount: files.length,
-    files,
-    capturedAt: new Date().toISOString(),
-  };
-  try {
-    fs.writeFileSync(p, JSON.stringify(payload, null, 2));
-  } catch {
-    /* hook-gated; non-fatal */
-  }
+  });
 }
 
 function validate(ctx) {

--- a/plugins/work/scripts/workflows/work-task-review/lib/phases/diff_audit.js
+++ b/plugins/work/scripts/workflows/work-task-review/lib/phases/diff_audit.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+const fs = require('node:fs');
+const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const { TASK_REVIEW_PHASES } = require('../../task-review-phase-registry');
@@ -71,16 +73,33 @@ function writeContext(ctx, diff, files) {
   });
 }
 
+/**
+ * PR #716: a failed audit must not leave a previous snapshot behind — later
+ * phases (reuse_check, kind-checks shared.js) read task-review-context.json
+ * and would analyze the STALE file list on a retry after an earlier
+ * successful audit. Missing file = "no snapshot", which those readers
+ * already handle.
+ */
+function clearStaleContext(ctx) {
+  try {
+    fs.rmSync(path.join(ctx.tasksDir, 'task-review-context.json'), { force: true });
+  } catch {
+    /* hook-gated; non-fatal */
+  }
+}
+
 function validate(ctx) {
   const diff = computeDiff(ctx);
   if (diff && diff.blocked) {
     // GH-693: surface the same blocked state as the plan-time gate instead
     // of auditing an empty range (validator-unification invariant).
+    clearStaleContext(ctx);
     return { ok: false, errors: [diff.reason] };
   }
   const root = ctx.worktreeRoot || process.cwd();
   const files = gitDiffNameOnly(diff.base, diff.head, root);
   if (!files.length) {
+    clearStaleContext(ctx);
     return {
       ok: false,
       errors: [

--- a/plugins/work/scripts/workflows/work/__tests__/task-review-gate.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/task-review-gate.test.js
@@ -53,51 +53,115 @@ describe('computeTaskDiff', () => {
     }
   });
 
-  it('falls back to base branch when .last-commit-sha file is missing', () => {
-    const { computeTaskDiff } = require('../gates/task-review-gate');
-    // No .last-commit-sha file written
-    const result = computeTaskDiff(tasksDir, 'T-2');
-    assert.strictEqual(result.head, 'HEAD');
-    // base should be a branch reference (e.g., origin/main), not a 40-char SHA
-    assert.ok(
-      result.base.includes('/') || result.base === 'origin/main',
-      `Expected base branch fallback, got: ${result.base}`
-    );
-    assert.ok(result.fallback === true, 'Should indicate fallback was used');
-  });
+  // ─── GH-693: fallback matrix — missing/invalid/non-ancestor SHA must never
+  // pass on an empty diff. Zero commits ahead of base (or a git failure)
+  // blocks; commits ahead re-derive the base from the merge-base. ───────────
 
-  it('falls back to base branch when SHA is not 40-char hex', () => {
-    const { computeTaskDiff } = require('../gates/task-review-gate');
-    fs.writeFileSync(path.join(tasksDir, '.last-commit-sha'), 'not-a-valid-sha');
-    const result = computeTaskDiff(tasksDir, 'T-3');
-    assert.strictEqual(result.head, 'HEAD');
-    assert.ok(result.fallback === true, 'Should indicate fallback was used');
-  });
-
-  it('falls back to base branch when SHA is not an ancestor of HEAD', () => {
-    const { computeTaskDiff } = require('../gates/task-review-gate');
-    const fakeSha = 'b'.repeat(40);
-    fs.writeFileSync(path.join(tasksDir, '.last-commit-sha'), fakeSha);
-
-    // Mock execFileSync to simulate non-ancestor (exit code 1)
+  /**
+   * Mock git for the GH-693 fallback matrix:
+   *   - revList: number, or an Error to simulate `git rev-list` failing
+   *   - mergeBase: 40-char SHA, or an Error to simulate `git merge-base` failing
+   *   - isAncestor: whether `merge-base --is-ancestor` succeeds (default false)
+   */
+  function withGitMock({ revList, mergeBase, isAncestor = false } = {}, fn) {
     const cp = require('child_process');
     const origExecFileSync = cp.execFileSync;
     cp.execFileSync = (cmd, args, opts) => {
+      if (cmd === 'git' && args[0] === 'rev-list' && args[1] === '--count') {
+        if (revList instanceof Error) throw revList;
+        return `${revList}\n`;
+      }
       if (cmd === 'git' && args[0] === 'merge-base' && args[1] === '--is-ancestor') {
+        if (isAncestor) return '';
         const err = new Error('not ancestor');
         err.status = 1;
         throw err;
       }
+      if (cmd === 'git' && args[0] === 'merge-base') {
+        if (mergeBase instanceof Error) throw mergeBase;
+        return `${mergeBase}\n`;
+      }
       return origExecFileSync(cmd, args, opts);
     };
-
     try {
-      const result = computeTaskDiff(tasksDir, 'T-4');
-      assert.strictEqual(result.head, 'HEAD');
-      assert.ok(result.fallback === true, 'Should indicate fallback was used');
+      return fn();
     } finally {
       cp.execFileSync = origExecFileSync;
     }
+  }
+
+  it('blocks when .last-commit-sha is missing and zero commits are ahead of base (GH-693)', () => {
+    const { computeTaskDiff } = require('../gates/task-review-gate');
+    // No .last-commit-sha file written
+    withGitMock({ revList: 0 }, () => {
+      const result = computeTaskDiff(tasksDir, 'T-2');
+      assert.strictEqual(result.blocked, true, 'Zero commits ahead must block, not fall back');
+      assert.match(result.reason, /no commits ahead/);
+      assert.match(result.reason, /\.last-commit-sha/);
+      assert.strictEqual(result.base, undefined, 'Blocked result must not carry a diff range');
+    });
+  });
+
+  it('re-derives the base from the merge-base when SHA is missing but commits are ahead', () => {
+    const { computeTaskDiff } = require('../gates/task-review-gate');
+    const mergeBase = 'd'.repeat(40);
+    withGitMock({ revList: 2, mergeBase }, () => {
+      const result = computeTaskDiff(tasksDir, 'T-2b');
+      assert.deepStrictEqual(result, { base: mergeBase, head: 'HEAD', fallback: true });
+    });
+  });
+
+  it('falls back to the base branch name when merge-base fails but commits are ahead', () => {
+    const { computeTaskDiff } = require('../gates/task-review-gate');
+    withGitMock({ revList: 1, mergeBase: new Error('merge-base failed') }, () => {
+      const result = computeTaskDiff(tasksDir, 'T-2c');
+      assert.strictEqual(result.head, 'HEAD');
+      assert.ok(result.fallback === true, 'Should indicate fallback was used');
+      assert.ok(
+        result.base.includes('/') || result.base === 'origin/main',
+        `Expected base branch fallback, got: ${result.base}`
+      );
+    });
+  });
+
+  it('blocks when git rev-list fails (fail closed)', () => {
+    const { computeTaskDiff } = require('../gates/task-review-gate');
+    withGitMock({ revList: new Error('git failed') }, () => {
+      const result = computeTaskDiff(tasksDir, 'T-2d');
+      assert.strictEqual(result.blocked, true, 'git failure must block, not fall back');
+    });
+  });
+
+  it('invalid SHA follows the same matrix: blocked at zero, merge-base with commits ahead', () => {
+    const { computeTaskDiff } = require('../gates/task-review-gate');
+    fs.writeFileSync(path.join(tasksDir, '.last-commit-sha'), 'not-a-valid-sha');
+    withGitMock({ revList: 0 }, () => {
+      assert.strictEqual(computeTaskDiff(tasksDir, 'T-3').blocked, true);
+    });
+    const mergeBase = 'e'.repeat(40);
+    withGitMock({ revList: 1, mergeBase }, () => {
+      assert.deepStrictEqual(computeTaskDiff(tasksDir, 'T-3'), {
+        base: mergeBase,
+        head: 'HEAD',
+        fallback: true,
+      });
+    });
+  });
+
+  it('non-ancestor SHA follows the same matrix: blocked at zero, merge-base with commits ahead', () => {
+    const { computeTaskDiff } = require('../gates/task-review-gate');
+    fs.writeFileSync(path.join(tasksDir, '.last-commit-sha'), 'b'.repeat(40));
+    withGitMock({ revList: 0, isAncestor: false }, () => {
+      assert.strictEqual(computeTaskDiff(tasksDir, 'T-4').blocked, true);
+    });
+    const mergeBase = 'f'.repeat(40);
+    withGitMock({ revList: 3, mergeBase, isAncestor: false }, () => {
+      assert.deepStrictEqual(computeTaskDiff(tasksDir, 'T-4'), {
+        base: mergeBase,
+        head: 'HEAD',
+        fallback: true,
+      });
+    });
   });
 
   it('trims whitespace from SHA file contents', () => {

--- a/plugins/work/scripts/workflows/work/__tests__/task-review-gate.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/task-review-gate.test.js
@@ -14,7 +14,9 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-const TEMP = path.join(os.tmpdir(), 'task-review-gate-test-' + process.pid);
+// Private per-run temp root (mkdtemp → mode 0700, unpredictable name) —
+// never write directly into the shared os.tmpdir() (insecure-temporary-file).
+const TEMP = fs.mkdtempSync(path.join(os.tmpdir(), 'task-review-gate-test-'));
 let testCount = 0;
 let tasksDir;
 

--- a/plugins/work/scripts/workflows/work/__tests__/transition-step.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/transition-step.test.js
@@ -11,7 +11,7 @@
  * Uses node:test + node:assert/strict.
  */
 
-const { describe, it, beforeEach } = require('node:test');
+const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 
 // Minimal deps stub for transitionStep
@@ -851,6 +851,26 @@ describe('transition-step.js (GH-329): check-drift archives stale check reports'
 });
 
 describe('transition-step.js (GH-693): commit-evidence gate', () => {
+  // Pin BASE_BRANCH unset (env + config snapshot) so a leaked value from the
+  // host environment cannot flip the gate into the explicit-base paths
+  // (PR #716) and the auto-detection tests stay deterministic.
+  const cfgModule = require('../../lib/config');
+  let savedBaseBranchEnv;
+  let savedBaseBranchCfg;
+
+  beforeEach(() => {
+    savedBaseBranchEnv = process.env.BASE_BRANCH;
+    savedBaseBranchCfg = cfgModule.BASE_BRANCH;
+    delete process.env.BASE_BRANCH;
+    cfgModule.BASE_BRANCH = '';
+  });
+
+  afterEach(() => {
+    if (savedBaseBranchEnv === undefined) delete process.env.BASE_BRANCH;
+    else process.env.BASE_BRANCH = savedBaseBranchEnv;
+    cfgModule.BASE_BRANCH = savedBaseBranchCfg;
+  });
+
   // The gate shells out via a dynamic require('child_process').execFileSync,
   // so monkey-patching the module property intercepts the rev-list call and
   // keeps these tests independent of the repo's real commits-ahead count.
@@ -940,5 +960,67 @@ describe('transition-step.js (GH-693): commit-evidence gate', () => {
       assert.equal(result.success, true, `expected success, got ${JSON.stringify(result)}`);
       assert.equal(calls.length, 0, 'rev-list must not run for backward transitions');
     });
+  });
+
+  // ─── PR #716: explicit BASE_BRANCH must never degrade to a fallback ───────
+
+  it('blocks with a distinct message when configured BASE_BRANCH cannot be resolved', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    process.env.BASE_BRANCH = 'gh716-no-such-base';
+    withRevList('5\n', (calls) => {
+      const deps = depsAt(STEPS.commit);
+      const result = transitionStep('TEST-693', STEPS.task_review, deps);
+      assert.equal(result.error, true, 'unresolvable explicit base must fail closed');
+      assert.equal(result.gate, 'commit-evidence');
+      assert.match(result.message, /BASE_BRANCH/, 'message must name the config knob');
+      assert.match(result.message, /gh716-no-such-base/, 'message must name the configured base');
+      assert.match(result.message, /git fetch/, 'message must name the fetch repair');
+      assert.doesNotMatch(result.message, /zero commits/, 'distinct from the no-commits block');
+      assert.doesNotMatch(result.message, /git failed/, 'distinct from the git-failed block');
+      assert.equal(calls.length, 0, 'commits must NOT be counted against a fallback base');
+    });
+  });
+
+  it('counts commits against the explicitly configured base when it resolves', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    const cp = require('child_process');
+    const fs = require('fs');
+    const os = require('os');
+    const path = require('path');
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'gh716-base-'));
+    const git = (args) =>
+      cp.execFileSync('git', args, { cwd: repo, stdio: ['pipe', 'pipe', 'pipe'] });
+    git(['init', '-q']);
+    git([
+      '-c',
+      'user.email=t@example.com',
+      '-c',
+      'user.name=t',
+      'commit',
+      '--allow-empty',
+      '-m',
+      'x',
+      '-q',
+    ]);
+    git(['update-ref', 'refs/remotes/origin/stable', 'HEAD']);
+    const prevCwd = process.cwd();
+    process.env.BASE_BRANCH = 'stable';
+    try {
+      process.chdir(repo);
+      withRevList('1\n', (calls) => {
+        const deps = depsAt(STEPS.commit);
+        const result = transitionStep('TEST-693', STEPS.task_review, deps);
+        assert.equal(result.success, true, `expected success, got ${JSON.stringify(result)}`);
+        assert.ok(
+          calls.some((args) => args.includes('origin/stable..HEAD')),
+          `rev-list must count against the configured base, got ${JSON.stringify(calls)}`
+        );
+      });
+    } finally {
+      process.chdir(prevCwd);
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/work/scripts/workflows/work/__tests__/transition-step.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/transition-step.test.js
@@ -849,3 +849,96 @@ describe('transition-step.js (GH-329): check-drift archives stale check reports'
     assert.equal(success.success, true, 'check -> pr succeeds after fresh reports written');
   });
 });
+
+describe('transition-step.js (GH-693): commit-evidence gate', () => {
+  // The gate shells out via a dynamic require('child_process').execFileSync,
+  // so monkey-patching the module property intercepts the rev-list call and
+  // keeps these tests independent of the repo's real commits-ahead count.
+  function withRevList(response, fn) {
+    const cp = require('child_process');
+    const orig = cp.execFileSync;
+    const calls = [];
+    cp.execFileSync = (cmd, args, opts) => {
+      if (cmd === 'git' && args[0] === 'rev-list' && args[1] === '--count') {
+        calls.push(args);
+        if (response instanceof Error) throw response;
+        return response;
+      }
+      return orig(cmd, args, opts);
+    };
+    try {
+      return fn(calls);
+    } finally {
+      cp.execFileSync = orig;
+    }
+  }
+
+  function depsAt(step) {
+    const { ALL_STEPS } = require('../step-registry');
+    const deps = createDeps({ workflowCanTransition: () => true });
+    const ws = deps.loadWorkState('TEST-693');
+    ws.currentStep = ALL_STEPS.indexOf(step) + 1;
+    ws.stepStatus[step] = 'in_progress';
+    deps._savedStates['TEST-693'] = ws;
+    return deps;
+  }
+
+  it('blocks forward commit -> task_review with zero commits ahead of base', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    withRevList('0\n', () => {
+      const deps = depsAt(STEPS.commit);
+      const result = transitionStep('TEST-693', STEPS.task_review, deps);
+      assert.equal(result.error, true, 'zero commits ahead must block');
+      assert.equal(result.gate, 'commit-evidence');
+      assert.match(result.message, /rev-list --count/, 'message must name the git invocation');
+      assert.match(result.message, /git fetch/, 'message must name the base-ref repair');
+    });
+  });
+
+  it('blocks forward task_review -> check with zero commits ahead of base', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    withRevList('0\n', () => {
+      const deps = depsAt(STEPS.task_review);
+      const result = transitionStep('TEST-693', STEPS.check, deps);
+      assert.equal(result.error, true, 'zero commits ahead must block');
+      assert.equal(result.gate, 'commit-evidence');
+      assert.match(result.message, /rev-list --count/);
+    });
+  });
+
+  it('allows forward commit -> task_review with a commit ahead', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    withRevList('1\n', () => {
+      const deps = depsAt(STEPS.commit);
+      const result = transitionStep('TEST-693', STEPS.task_review, deps);
+      assert.equal(result.success, true, `expected success, got ${JSON.stringify(result)}`);
+    });
+  });
+
+  it('blocks with a distinct git-failed message when git errors', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    withRevList(new Error('spawn git ENOENT'), () => {
+      const deps = depsAt(STEPS.commit);
+      const result = transitionStep('TEST-693', STEPS.task_review, deps);
+      assert.equal(result.error, true, 'git failure must block (fail closed)');
+      assert.equal(result.gate, 'commit-evidence');
+      assert.match(result.message, /git failed/, 'git failure needs its own diagnosable message');
+      assert.doesNotMatch(result.message, /zero commits/);
+    });
+  });
+
+  it('does not gate backward task_review -> implement', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    withRevList('0\n', (calls) => {
+      const deps = depsAt(STEPS.task_review);
+      const result = transitionStep('TEST-693', STEPS.implement, deps);
+      assert.equal(result.success, true, `expected success, got ${JSON.stringify(result)}`);
+      assert.equal(calls.length, 0, 'rev-list must not run for backward transitions');
+    });
+  });
+});

--- a/plugins/work/scripts/workflows/work/__tests__/work-workflow-defer-guard.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-workflow-defer-guard.test.js
@@ -321,7 +321,11 @@ describe('DEFER step re-evaluation guard (GH-154)', () => {
     gitCommit('base');
     git('update-ref', 'refs/remotes/origin/main', git('rev-parse', 'HEAD').trim());
     gitCommit('task work');
-    const gitOpts = { cwd: repoDir, env: { BASE_BRANCH: 'main' } };
+    // Pin TASKS_BASE explicitly: with cwd inside the throwaway repo, config.js
+    // would otherwise re-derive WORKTREES_BASE from that repo's toplevel and
+    // the orchestrator would look for state under /tmp/tasks (CI has no
+    // TASKS_BASE env, unlike local runs).
+    const gitOpts = { cwd: repoDir, env: { BASE_BRANCH: 'main', TASKS_BASE } };
 
     try {
       // First transition: task_review -> check (check is deferred, plan is fresh) — should succeed

--- a/plugins/work/scripts/workflows/work/__tests__/work-workflow-defer-guard.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-workflow-defer-guard.test.js
@@ -290,20 +290,56 @@ describe('DEFER step re-evaluation guard (GH-154)', () => {
     });
     putWorkState(ticket, state);
 
-    // First transition: task_review -> check (check is deferred, plan is fresh) — should succeed
-    // task_review is soft — no verify gate
-    const { result: r1 } = await runOrchestrator(['transition', ticket, 'check']);
-    assert.ok(r1.success, `First transition should succeed: ${JSON.stringify(r1)}`);
+    // GH-693: forward transitions out of task_review now require commit
+    // evidence (commits ahead of base). Run the orchestrator inside a
+    // throwaway git repo with one commit ahead of origin/main so the
+    // commit-evidence gate passes deterministically regardless of the host
+    // repo's branch state.
+    const { execFileSync } = require('child_process');
+    const repoDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'defer-guard-git-'));
+    const git = (...args) =>
+      execFileSync('git', args, {
+        cwd: repoDir,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    const gitCommit = (msg) =>
+      git(
+        '-c',
+        'user.email=t@example.com',
+        '-c',
+        'user.name=T',
+        '-c',
+        'commit.gpgsign=false',
+        'commit',
+        '--allow-empty',
+        '-q',
+        '-m',
+        msg
+      );
+    git('init', '-q');
+    gitCommit('base');
+    git('update-ref', 'refs/remotes/origin/main', git('rev-parse', 'HEAD').trim());
+    gitCommit('task work');
+    const gitOpts = { cwd: repoDir, env: { BASE_BRANCH: 'main' } };
 
-    // After transition, lastTransitionTimestamp is updated, making plan stale.
-    // check -> pr: pr IS in deferredSteps, plan is now stale — should block
-    // (DEFER gate fires before verify gate)
-    const { result: r3 } = await runOrchestrator(['transition', ticket, 'pr']);
-    assert.ok(r3.error, 'check -> pr should be blocked (stale plan)');
-    assert.equal(r3.gate, 'defer-reeval');
-    assert.equal(r3.deferStep, 'pr');
+    try {
+      // First transition: task_review -> check (check is deferred, plan is fresh) — should succeed
+      // task_review is soft — no verify gate; commit evidence supplied above
+      const { result: r1 } = await runOrchestrator(['transition', ticket, 'check'], gitOpts);
+      assert.ok(r1.success, `First transition should succeed: ${JSON.stringify(r1)}`);
 
-    cleanupTicket(ticket);
+      // After transition, lastTransitionTimestamp is updated, making plan stale.
+      // check -> pr: pr IS in deferredSteps, plan is now stale — should block
+      // (DEFER gate fires before verify gate)
+      const { result: r3 } = await runOrchestrator(['transition', ticket, 'pr'], gitOpts);
+      assert.ok(r3.error, 'check -> pr should be blocked (stale plan)');
+      assert.equal(r3.gate, 'defer-reeval');
+      assert.equal(r3.deferStep, 'pr');
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+      cleanupTicket(ticket);
+    }
   });
 
   it('10. failed plan (no timestamp update) blocks transition', async () => {

--- a/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
@@ -364,6 +364,100 @@ describe('workflow-definition: softSteps includes task_review', () => {
   });
 });
 
+// ─── GH-693: verify[STEPS.commit] — commits ahead of base is the sole proof ──
+
+describe('workflow-definition: verify[STEPS.commit] (GH-693)', () => {
+  const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-commit-693-'));
+  const { workflow: commitWf } = createWorkflowDefinition({
+    TASKS_BASE: tmpBase,
+    safeTicketPath: (id) => id,
+    resolveGitHead: () => 'ref: refs/heads/stub',
+  });
+  const verifyCommit = commitWf.commandMap.find((c) => c.step === STEPS.commit).verify;
+  const HEAD_SHA = 'e'.repeat(40);
+
+  after(() => {
+    fs.rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  function shaFileFor(ticketId) {
+    return path.join(tmpBase, ticketId, '.last-commit-sha');
+  }
+
+  /**
+   * Mock git for verifyCommit:
+   *   - log: `git log --oneline base..HEAD` output ('' = zero commits ahead)
+   *   - branch: `git branch --show-current` output
+   *   - twoDotDiff: `git diff --shortstat <a> <b>` output (two-dot / pairwise)
+   *   - threeDotDiff: `git diff --shortstat base...HEAD` output (merge-base)
+   */
+  function withGit(responses, fn) {
+    const cp = require('child_process');
+    const orig = cp.execFileSync;
+    cp.execFileSync = (cmd, args, opts) => {
+      if (cmd !== 'git') return orig(cmd, args, opts);
+      if (args[0] === 'rev-parse') return `${HEAD_SHA}\n`;
+      if (args[0] === 'log') return responses.log ?? '';
+      if (args[0] === 'branch') return responses.branch ?? '';
+      if (args[0] === 'diff') {
+        const threeDot = args.some((a) => typeof a === 'string' && a.includes('...'));
+        return threeDot ? (responses.threeDotDiff ?? '') : (responses.twoDotDiff ?? '');
+      }
+      return orig(cmd, args, opts);
+    };
+    try {
+      return fn();
+    } finally {
+      cp.execFileSync = orig;
+    }
+  }
+
+  it('returns false at 0 commits ahead even when the branch name matches the ticket and the two-dot diff is non-empty (GH-191 fallback deleted)', () => {
+    const ticket = 'T-693A';
+    fs.mkdirSync(path.join(tmpBase, ticket), { recursive: true });
+    withGit({ log: '', branch: `fix/${ticket}-thing\n`, twoDotDiff: ' 3 files changed\n' }, () => {
+      assert.equal(verifyCommit(ticket), false);
+      assert.equal(
+        fs.existsSync(shaFileFor(ticket)),
+        false,
+        '.last-commit-sha must NOT be written on a false path'
+      );
+    });
+  });
+
+  it('returns true with >=1 commit ahead and a non-empty merge-base (three-dot) diff, recording .last-commit-sha', () => {
+    const ticket = 'T-693B';
+    fs.mkdirSync(path.join(tmpBase, ticket), { recursive: true });
+    withGit({ log: 'abc123 fix: work\n', threeDotDiff: ' 1 file changed\n' }, () => {
+      assert.equal(verifyCommit(ticket), true);
+      assert.equal(fs.readFileSync(shaFileFor(ticket), 'utf-8').trim(), HEAD_SHA);
+    });
+  });
+
+  it('returns false for an empty commit atop a moved base (three-dot diff empty, two-dot non-empty)', () => {
+    const ticket = 'T-693C';
+    fs.mkdirSync(path.join(tmpBase, ticket), { recursive: true });
+    withGit({ log: 'abc123 empty\n', threeDotDiff: '', twoDotDiff: ' 2 files changed\n' }, () => {
+      assert.equal(verifyCommit(ticket), false);
+      assert.equal(
+        fs.existsSync(shaFileFor(ticket)),
+        false,
+        '.last-commit-sha must NOT be written for an empty commit'
+      );
+    });
+  });
+
+  it('saved-SHA path unchanged: new commit after the saved SHA with a non-empty diff passes', () => {
+    const ticket = 'T-693D';
+    fs.mkdirSync(path.join(tmpBase, ticket), { recursive: true });
+    fs.writeFileSync(shaFileFor(ticket), 'a'.repeat(40));
+    withGit({ twoDotDiff: ' 1 file changed\n' }, () => {
+      assert.equal(verifyCommit(ticket), true);
+      assert.equal(fs.readFileSync(shaFileFor(ticket), 'utf-8').trim(), HEAD_SHA);
+    });
+  });
+});
+
 // ─── GH-219: brief.md contentGuard ───────────────────────────────────────────
 
 describe('workflow-definition: brief.md contentGuard', () => {

--- a/plugins/work/scripts/workflows/work/engine/commit-evidence-gate.js
+++ b/plugins/work/scripts/workflows/work/engine/commit-evidence-gate.js
@@ -1,0 +1,118 @@
+/**
+ * commit-evidence-gate.js (GH-693)
+ *
+ * Commit-evidence gate for transition-step.js: forward transitions out of
+ * commit or task_review require >=1 commit ahead of the resolved base
+ * (`git rev-list --count`). task_review deliberately STAYS a softStep
+ * (GH-211 advisory), so stepVerifyGate never consults it — this additive
+ * gate makes "completed with zero commits" impossible for both steps on
+ * every transition path.
+ *
+ * Fail-closed with THREE distinct block messages (PR #716):
+ *   - zero commits ahead of the resolved base,
+ *   - git failed while counting,
+ *   - explicitly configured BASE_BRANCH that does not resolve — never
+ *     silently counted against a fallback base, which could fabricate
+ *     evidence for a branch with zero commits ahead of its real base.
+ */
+
+'use strict';
+
+const path = require('path');
+
+function loadConfigModule() {
+  try {
+    return require(path.join(__dirname, '..', '..', 'lib', 'config'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Explicit-base info in config.getExplicitBase's shape. When the config
+ * module is unavailable but a raw env BASE_BRANCH is set, report it as
+ * configured-but-unverified so the gate fails closed rather than degrading.
+ */
+function resolveExplicitGateBase(cfg) {
+  if (cfg && typeof cfg.getExplicitBase === 'function') return cfg.getExplicitBase();
+  const raw = process.env.BASE_BRANCH;
+  return raw ? { configured: true, raw, sanitized: raw, ref: null } : { configured: false };
+}
+
+/** Auto-detection default (symbolic-ref → probe → origin/main). */
+function autoDetectGateBase(cfg) {
+  try {
+    return (cfg && cfg.getBaseBranch()) || 'origin/main';
+  } catch {
+    return 'origin/main';
+  }
+}
+
+/**
+ * Resolve the base branch for the commit-evidence gate.
+ *
+ * Returns { base } on success. When an EXPLICITLY configured BASE_BRANCH
+ * cannot be resolved to an origin/ ref, returns { unresolvable, fetchName }
+ * so the gate fails closed (PR #716). With no explicit config,
+ * auto-detection is the documented repo behavior and is kept.
+ */
+function resolveGateBase() {
+  const cfg = loadConfigModule();
+  const explicit = resolveExplicitGateBase(cfg);
+  if (explicit.configured) {
+    if (explicit.ref) return { base: explicit.ref };
+    return { unresolvable: explicit.raw, fetchName: explicit.sanitized || explicit.raw };
+  }
+  return { base: autoDetectGateBase(cfg) };
+}
+
+const GATE_EXEC_OPTS = { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] };
+
+/** Commits ahead of base; throws when git fails or output is unparseable. */
+function gateCommitsAhead(baseBranch) {
+  // Dynamic require so tests can mock child_process.execFileSync.
+  const output = require('child_process')
+    .execFileSync('git', ['rev-list', '--count', `${baseBranch}..HEAD`], GATE_EXEC_OPTS)
+    .trim();
+  const count = Number.parseInt(output, 10);
+  if (!Number.isFinite(count)) throw new Error(`unparseable output "${output}"`);
+  return count;
+}
+
+/**
+ * The gate itself. No deadlock: task_review only runs after commit, which
+ * proved commits ahead. See the module doc for the three block messages.
+ */
+function commitEvidenceGate(ctx) {
+  const { currentStep, targetStep, isForward, deps } = ctx;
+  const gated = currentStep === deps.STEPS.commit || currentStep === deps.STEPS.task_review;
+  if (!isForward || !gated) return null;
+  const resolved = resolveGateBase();
+  if (resolved.unresolvable) {
+    return {
+      error: true,
+      gate: 'commit-evidence',
+      message: `BLOCKED: configured base branch "${resolved.unresolvable}" (BASE_BRANCH) does not resolve to an origin/ ref in this worktree — refusing to count commit evidence for ${currentStep} → ${targetStep} against a fallback base. Run \`git fetch origin ${resolved.fetchName}\` or fix BASE_BRANCH, then retry.`,
+    };
+  }
+  const baseBranch = resolved.base;
+  let count;
+  try {
+    count = gateCommitsAhead(baseBranch);
+  } catch (err) {
+    const detail = err && typeof err.message === 'string' ? err.message : String(err);
+    return {
+      error: true,
+      gate: 'commit-evidence',
+      message: `BLOCKED: git failed while checking commit evidence for ${currentStep} → ${targetStep} — \`git rev-list --count ${baseBranch}..HEAD\` errored (${detail}). Repair the worktree (git fetch origin main, verify BASE_BRANCH) and retry.`,
+    };
+  }
+  if (count >= 1) return null;
+  return {
+    error: true,
+    gate: 'commit-evidence',
+    message: `BLOCKED: cannot leave ${currentStep} with zero commits ahead of ${baseBranch} — \`git rev-list --count ${baseBranch}..HEAD\` returned ${count}. Run the commit step to commit the task work first, or \`git fetch\` the base ref if ${baseBranch} is stale.`,
+  };
+}
+
+module.exports = { commitEvidenceGate };

--- a/plugins/work/scripts/workflows/work/engine/transition-gates.js
+++ b/plugins/work/scripts/workflows/work/engine/transition-gates.js
@@ -192,7 +192,7 @@ function gateCommitsAhead(baseBranch) {
 function commitEvidenceGate(ctx) {
   const { currentStep, targetStep, isForward, deps } = ctx;
   const gated = currentStep === deps.STEPS.commit || currentStep === deps.STEPS.task_review;
-  if (!isForward || !gated || currentStep === targetStep) return null;
+  if (!isForward || !gated) return null;
   const baseBranch = resolveGateBase();
   let count;
   try {

--- a/plugins/work/scripts/workflows/work/engine/transition-gates.js
+++ b/plugins/work/scripts/workflows/work/engine/transition-gates.js
@@ -2,9 +2,9 @@
  * transition-gates.js
  *
  * The gate checks run by transition-step.js before a transition is applied:
- * TDD evidence, multi-task completion, DEFER re-evaluation, the check-to-PR
- * quality gate, check-drift detection (GH-299), and the generic step-verify
- * gate (GH-260).
+ * TDD evidence, multi-task completion, commit evidence (GH-693), DEFER
+ * re-evaluation, the check-to-PR quality gate, check-drift detection
+ * (GH-299), and the generic step-verify gate (GH-260).
  *
  * Each gate takes the shared transition context and returns an error result
  * to surface, or null to proceed. `runTransitionGates` chains them in order.
@@ -154,6 +154,62 @@ function multiTaskGate(ctx) {
     error: true,
     message: `Cannot leave implement: task ${currentIdx + 1}/${totalTasks} done, ${totalTasks - currentIdx - 1} tasks remaining. Advance to next task first.`,
     gate: 'multi-task',
+  };
+}
+
+/** Resolve the configured base branch for the commit-evidence gate. */
+function resolveGateBase() {
+  try {
+    const { getBaseBranch } = require(path.join(__dirname, '..', '..', 'lib', 'config'));
+    return getBaseBranch() || 'origin/main';
+  } catch {
+    return 'origin/main';
+  }
+}
+
+const GATE_EXEC_OPTS = { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] };
+
+/** Commits ahead of base; throws when git fails or output is unparseable. */
+function gateCommitsAhead(baseBranch) {
+  // Dynamic require so tests can mock child_process.execFileSync.
+  const output = require('child_process')
+    .execFileSync('git', ['rev-list', '--count', `${baseBranch}..HEAD`], GATE_EXEC_OPTS)
+    .trim();
+  const count = Number.parseInt(output, 10);
+  if (!Number.isFinite(count)) throw new Error(`unparseable output "${output}"`);
+  return count;
+}
+
+/**
+ * GH-693: Commit-evidence gate — forward transitions out of commit or
+ * task_review require >=1 commit ahead of base (`git rev-list --count`).
+ * task_review deliberately STAYS a softStep (GH-211 advisory), so
+ * stepVerifyGate never consults it — this additive gate makes "completed
+ * with zero commits" impossible for both steps on every transition path.
+ * No deadlock: task_review only runs after commit, which proved commits
+ * ahead. Fail-closed on git errors with a DISTINCT "git failed" message.
+ */
+function commitEvidenceGate(ctx) {
+  const { currentStep, targetStep, isForward, deps } = ctx;
+  const gated = currentStep === deps.STEPS.commit || currentStep === deps.STEPS.task_review;
+  if (!isForward || !gated || currentStep === targetStep) return null;
+  const baseBranch = resolveGateBase();
+  let count;
+  try {
+    count = gateCommitsAhead(baseBranch);
+  } catch (err) {
+    const detail = err && typeof err.message === 'string' ? err.message : String(err);
+    return {
+      error: true,
+      gate: 'commit-evidence',
+      message: `BLOCKED: git failed while checking commit evidence for ${currentStep} → ${targetStep} — \`git rev-list --count ${baseBranch}..HEAD\` errored (${detail}). Repair the worktree (git fetch origin main, verify BASE_BRANCH) and retry.`,
+    };
+  }
+  if (count >= 1) return null;
+  return {
+    error: true,
+    gate: 'commit-evidence',
+    message: `BLOCKED: cannot leave ${currentStep} with zero commits ahead of ${baseBranch} — \`git rev-list --count ${baseBranch}..HEAD\` returned ${count}. Run the commit step to commit the task work first, or \`git fetch\` the base ref if ${baseBranch} is stale.`,
   };
 }
 
@@ -312,6 +368,7 @@ function runTransitionGates(ctx) {
   return (
     tddGate(ctx) ||
     multiTaskGate(ctx) ||
+    commitEvidenceGate(ctx) ||
     deferGate(ctx) ||
     checkToPrGate(ctx) ||
     checkDriftGate(ctx) ||

--- a/plugins/work/scripts/workflows/work/engine/transition-gates.js
+++ b/plugins/work/scripts/workflows/work/engine/transition-gates.js
@@ -22,6 +22,10 @@ const { resolveTaskType } = require(path.join(__dirname, '..', 'lib', 'resolve-t
 const { validateTddEvidenceForType } = require(
   path.join(__dirname, '..', 'lib', 'tdd-enforcement')
 );
+// GH-693 commit-evidence gate (extracted module, PR #716): >=1 commit ahead
+// of the resolved base to leave commit/task_review; fails closed on git
+// errors AND on an explicitly configured but unresolvable BASE_BRANCH.
+const { commitEvidenceGate } = require(path.join(__dirname, 'commit-evidence-gate'));
 
 /**
  * Derive the set of steps that come after `check` in the workflow.
@@ -154,62 +158,6 @@ function multiTaskGate(ctx) {
     error: true,
     message: `Cannot leave implement: task ${currentIdx + 1}/${totalTasks} done, ${totalTasks - currentIdx - 1} tasks remaining. Advance to next task first.`,
     gate: 'multi-task',
-  };
-}
-
-/** Resolve the configured base branch for the commit-evidence gate. */
-function resolveGateBase() {
-  try {
-    const { getBaseBranch } = require(path.join(__dirname, '..', '..', 'lib', 'config'));
-    return getBaseBranch() || 'origin/main';
-  } catch {
-    return 'origin/main';
-  }
-}
-
-const GATE_EXEC_OPTS = { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] };
-
-/** Commits ahead of base; throws when git fails or output is unparseable. */
-function gateCommitsAhead(baseBranch) {
-  // Dynamic require so tests can mock child_process.execFileSync.
-  const output = require('child_process')
-    .execFileSync('git', ['rev-list', '--count', `${baseBranch}..HEAD`], GATE_EXEC_OPTS)
-    .trim();
-  const count = Number.parseInt(output, 10);
-  if (!Number.isFinite(count)) throw new Error(`unparseable output "${output}"`);
-  return count;
-}
-
-/**
- * GH-693: Commit-evidence gate — forward transitions out of commit or
- * task_review require >=1 commit ahead of base (`git rev-list --count`).
- * task_review deliberately STAYS a softStep (GH-211 advisory), so
- * stepVerifyGate never consults it — this additive gate makes "completed
- * with zero commits" impossible for both steps on every transition path.
- * No deadlock: task_review only runs after commit, which proved commits
- * ahead. Fail-closed on git errors with a DISTINCT "git failed" message.
- */
-function commitEvidenceGate(ctx) {
-  const { currentStep, targetStep, isForward, deps } = ctx;
-  const gated = currentStep === deps.STEPS.commit || currentStep === deps.STEPS.task_review;
-  if (!isForward || !gated) return null;
-  const baseBranch = resolveGateBase();
-  let count;
-  try {
-    count = gateCommitsAhead(baseBranch);
-  } catch (err) {
-    const detail = err && typeof err.message === 'string' ? err.message : String(err);
-    return {
-      error: true,
-      gate: 'commit-evidence',
-      message: `BLOCKED: git failed while checking commit evidence for ${currentStep} → ${targetStep} — \`git rev-list --count ${baseBranch}..HEAD\` errored (${detail}). Repair the worktree (git fetch origin main, verify BASE_BRANCH) and retry.`,
-    };
-  }
-  if (count >= 1) return null;
-  return {
-    error: true,
-    gate: 'commit-evidence',
-    message: `BLOCKED: cannot leave ${currentStep} with zero commits ahead of ${baseBranch} — \`git rev-list --count ${baseBranch}..HEAD\` returned ${count}. Run the commit step to commit the task work first, or \`git fetch\` the base ref if ${baseBranch} is stale.`,
   };
 }
 

--- a/plugins/work/scripts/workflows/work/gates/task-review-gate.js
+++ b/plugins/work/scripts/workflows/work/gates/task-review-gate.js
@@ -122,15 +122,15 @@ function computeTaskDiff(tasksDir, ticketId) {
       return { base: rawContent, head: 'HEAD' };
     }
     process.stderr.write(
-      `task-review-gate: SHA ${rawContent.slice(0, 8)}... is not an ancestor of HEAD for ${ticketId}, falling back to base branch\n`
+      `task-review-gate: SHA ${rawContent.slice(0, 8)}... is not an ancestor of HEAD for ${ticketId}, checking commits ahead of base\n`
     );
   } else if (rawContent) {
     process.stderr.write(
-      `task-review-gate: Invalid SHA format in ${LAST_COMMIT_SHA_FILE} for ${ticketId}, falling back to base branch\n`
+      `task-review-gate: Invalid SHA format in ${LAST_COMMIT_SHA_FILE} for ${ticketId}, checking commits ahead of base\n`
     );
   } else {
     process.stderr.write(
-      `task-review-gate: No ${LAST_COMMIT_SHA_FILE} found for ${ticketId}, falling back to base branch\n`
+      `task-review-gate: No ${LAST_COMMIT_SHA_FILE} found for ${ticketId}, checking commits ahead of base\n`
     );
   }
 

--- a/plugins/work/scripts/workflows/work/gates/task-review-gate.js
+++ b/plugins/work/scripts/workflows/work/gates/task-review-gate.js
@@ -52,18 +52,64 @@ function isAncestorOfHead(sha) {
   }
 }
 
+/**
+ * Count commits ahead of the base branch (`git rev-list --count base..HEAD`).
+ * Uses dynamic require to allow test mocking of child_process.execFileSync.
+ * @param {string} baseBranch
+ * @returns {number|null} commit count, or null when git fails
+ */
+function countCommitsAhead(baseBranch) {
+  try {
+    const out = require('child_process')
+      .execFileSync('git', ['rev-list', '--count', `${baseBranch}..HEAD`], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      .trim();
+    const count = Number.parseInt(out, 10);
+    return Number.isFinite(count) ? count : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Re-derive the review base as the merge-base of the base branch and HEAD,
+ * keeping the range direction-correct when the per-task SHA was lost.
+ * Uses dynamic require to allow test mocking of child_process.execFileSync.
+ * @param {string} baseBranch
+ * @returns {string|null} merge-base SHA, or null when git fails
+ */
+function deriveMergeBase(baseBranch) {
+  try {
+    const out = require('child_process')
+      .execFileSync('git', ['merge-base', baseBranch, 'HEAD'], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      .trim();
+    return SHA_REGEX.test(out) ? out : null;
+  } catch {
+    return null;
+  }
+}
+
 // ─── computeTaskDiff ────────────────────────────────────────────────────────
 
 /**
  * Compute the diff range for reviewing a task's changes.
  *
  * Reads `.last-commit-sha` from tasksDir, validates it as a 40-char hex SHA
- * that is an ancestor of HEAD. Falls back to the configured base branch
- * (e.g., origin/main) when the SHA is missing, invalid, or not an ancestor.
+ * that is an ancestor of HEAD. When the SHA is missing, invalid, or not an
+ * ancestor (GH-693): blocks when the branch has zero commits ahead of the
+ * configured base branch — "no SHA" must never become "pass on an empty
+ * diff" — and otherwise falls back to the merge-base of base and HEAD.
  *
  * @param {string} tasksDir - Path to the ticket's tasks directory
  * @param {string} ticketId - Ticket identifier (for logging)
- * @returns {{ base: string, head: string, fallback?: boolean }}
+ * @returns {{ base: string, head: string, fallback?: boolean } | { blocked: true, reason: string }}
  */
 function computeTaskDiff(tasksDir, ticketId) {
   const shaFile = path.join(tasksDir, LAST_COMMIT_SHA_FILE);
@@ -88,9 +134,19 @@ function computeTaskDiff(tasksDir, ticketId) {
     );
   }
 
-  // Fallback to base branch
+  // GH-693: a review of base..HEAD with zero commits ahead is vacuous —
+  // block unless real commits exist (the legitimate lost-SHA recovery),
+  // then review the whole-branch diff from the merge-base.
   const baseBranch = config.getBaseBranch();
-  return { base: baseBranch, head: 'HEAD', fallback: true };
+  const commitsAhead = countCommitsAhead(baseBranch);
+  if (commitsAhead === null || commitsAhead < 1) {
+    return {
+      blocked: true,
+      reason: `no commits ahead of ${baseBranch} and no valid ${LAST_COMMIT_SHA_FILE} — commit the task work first (or git fetch the base ref)`,
+    };
+  }
+  const mergeBase = deriveMergeBase(baseBranch);
+  return { base: mergeBase || baseBranch, head: 'HEAD', fallback: true };
 }
 
 // ─── executeTaskReview ──────────────────────────────────────────────────────

--- a/plugins/work/scripts/workflows/work/hooks/enforce-screenshot-gate.js
+++ b/plugins/work/scripts/workflows/work/hooks/enforce-screenshot-gate.js
@@ -10,7 +10,7 @@
  * If both true, blocks and requires screenshots before marking complete.
  */
 
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
@@ -86,12 +86,18 @@ async function main() {
   let tsxChanged = [];
   try {
     const baseBranch = config ? config.getBaseBranch({ cwd: gitRoot }) : 'origin/main';
-    const diff = execSync(`git diff --name-only ${baseBranch}...HEAD -- "*.tsx" "*.jsx"`, {
-      encoding: 'utf8',
-      timeout: 10000,
-      cwd: gitRoot,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    // execFileSync array args (no shell): the env-derived base branch can
+    // never be parsed as a git option or shell metacharacters.
+    const diff = execFileSync(
+      'git',
+      ['diff', '--name-only', `${baseBranch}...HEAD`, '--', '*.tsx', '*.jsx'],
+      {
+        encoding: 'utf8',
+        timeout: 10000,
+        cwd: gitRoot,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    ).trim();
 
     if (diff) {
       tsxChanged = diff

--- a/plugins/work/scripts/workflows/work/hooks/enforce-screenshot-gate.js
+++ b/plugins/work/scripts/workflows/work/hooks/enforce-screenshot-gate.js
@@ -10,7 +10,7 @@
  * If both true, blocks and requires screenshots before marking complete.
  */
 
-const { execSync, execFileSync } = require('child_process');
+const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
@@ -86,18 +86,12 @@ async function main() {
   let tsxChanged = [];
   try {
     const baseBranch = config ? config.getBaseBranch({ cwd: gitRoot }) : 'origin/main';
-    // execFileSync array args (no shell): the env-derived base branch can
-    // never be parsed as a git option or shell metacharacters.
-    const diff = execFileSync(
-      'git',
-      ['diff', '--name-only', `${baseBranch}...HEAD`, '--', '*.tsx', '*.jsx'],
-      {
-        encoding: 'utf8',
-        timeout: 10000,
-        cwd: gitRoot,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }
-    ).trim();
+    const diff = execSync(`git diff --name-only ${baseBranch}...HEAD -- "*.tsx" "*.jsx"`, {
+      encoding: 'utf8',
+      timeout: 10000,
+      cwd: gitRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
 
     if (diff) {
       tsxChanged = diff

--- a/plugins/work/scripts/workflows/work/hooks/enforce-screenshot-gate.js
+++ b/plugins/work/scripts/workflows/work/hooks/enforce-screenshot-gate.js
@@ -10,112 +10,93 @@
  * If both true, blocks and requires screenshots before marking complete.
  */
 
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
+const { readStdin } = require(path.join(__dirname, '..', '..', 'lib', 'hookEntrypoint'));
 
-let didBlock = false;
-process.on('uncaughtException', (err) => {
-  logHookError(__filename, err);
-  process.exit(didBlock ? 2 : 0);
-});
-process.on('unhandledRejection', (err) => {
-  logHookError(__filename, err);
-  process.exit(didBlock ? 2 : 0);
-});
+process.on('uncaughtException', (err) => (logHookError(__filename, err), process.exit(0)));
+process.on('unhandledRejection', (err) => (logHookError(__filename, err), process.exit(0)));
 
-let config;
-try {
-  config = require('../../lib/config');
-} catch (err) {
-  if (
-    err &&
-    err.code === 'MODULE_NOT_FOUND' &&
-    /['"]\.\.\/\.\.\/lib\/config['"]/.test(err.message)
-  ) {
-    config = null;
-  } else {
+function loadConfigOrNull() {
+  try {
+    return require('../../lib/config');
+  } catch (err) {
+    const isConfigMiss =
+      err?.code === 'MODULE_NOT_FOUND' && /['"]\.\.\/\.\.\/lib\/config['"]/.test(err.message);
+    if (isConfigMiss) return null;
     throw err;
   }
 }
+
+const config = loadConfigOrNull();
 if (!config) process.exit(0);
 
-async function main() {
-  let input = '';
-  for await (const chunk of process.stdin) {
-    input += chunk;
-  }
-
-  let hookData;
+/** Exit 2 on malformed input — this fail-fast contract is pinned by tests. */
+function parseInputOrExit(raw) {
   try {
-    hookData = JSON.parse(input);
+    return JSON.parse(raw);
   } catch (err) {
     process.stderr.write(`SCREENSHOT GATE: Failed to parse hook input: ${err.message}\n`);
-    didBlock = true;
     process.exit(2);
   }
+}
 
-  // Only run for work-pr skill
-  const toolName = hookData.tool_name || '';
-  const skillName = hookData.tool_input?.skill || hookData.input?.skill || '';
+function skillInputField(hookData, field) {
+  return hookData.tool_input?.[field] || hookData.input?.[field] || '';
+}
 
-  if (toolName !== 'Skill' || skillName !== 'work-pr') {
-    process.exit(0);
-  }
+/** Gate only /work-pr skill invocations without --force. */
+function isGatedInvocation(hookData) {
+  if ((hookData.tool_name || '') !== 'Skill') return false;
+  if (skillInputField(hookData, 'skill') !== 'work-pr') return false;
+  return !skillInputField(hookData, 'args').includes('--force');
+}
 
-  // Check if --force was passed as args
-  const skillArgs = hookData.tool_input?.args || hookData.input?.args || '';
-  if (skillArgs.includes('--force')) {
-    process.exit(0);
-  }
-
-  // Get the current working directory / git root
-  let gitRoot;
+function resolveGitRoot() {
   try {
-    gitRoot = execSync('git rev-parse --show-toplevel', {
+    return execSync('git rev-parse --show-toplevel', {
       encoding: 'utf8',
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
   } catch {
-    process.exit(0);
+    return null;
   }
+}
 
-  // Check for TSX/JSX source file changes (exclude test files)
-  let tsxChanged = [];
+/**
+ * Changed non-test TSX/JSX sources vs the base branch; null when git fails
+ * (the gate stands down rather than blocking on a broken repo).
+ * execFileSync array args (no shell): the env-derived base branch can never
+ * be parsed as a git option or shell metacharacters.
+ */
+function changedUiSources(gitRoot) {
   try {
-    const baseBranch = config ? config.getBaseBranch({ cwd: gitRoot }) : 'origin/main';
-    const diff = execSync(`git diff --name-only ${baseBranch}...HEAD -- "*.tsx" "*.jsx"`, {
-      encoding: 'utf8',
-      timeout: 10000,
-      cwd: gitRoot,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-
-    if (diff) {
-      tsxChanged = diff
-        .split('\n')
-        .filter(
-          (f) =>
-            !f.includes('.test.') &&
-            !f.includes('.spec.') &&
-            !f.includes('.stories.') &&
-            !f.includes('__tests__') &&
-            !f.includes('.d.ts')
-        );
-    }
+    const baseBranch = config.getBaseBranch({ cwd: gitRoot });
+    const diff = execFileSync(
+      'git',
+      ['diff', '--name-only', `${baseBranch}...HEAD`, '--', '*.tsx', '*.jsx'],
+      { encoding: 'utf8', timeout: 10000, cwd: gitRoot, stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+    if (!diff) return [];
+    return diff
+      .split('\n')
+      .filter(
+        (f) =>
+          !f.includes('.test.') &&
+          !f.includes('.spec.') &&
+          !f.includes('.stories.') &&
+          !f.includes('__tests__') &&
+          !f.includes('.d.ts')
+      );
   } catch {
-    process.exit(0);
+    return null;
   }
+}
 
-  // No UI source files changed — no screenshots required
-  if (tsxChanged.length === 0) {
-    process.exit(0);
-  }
-
-  // Extract ticket ID from branch name
-  let ticketId;
+function ticketIdFromBranch() {
   try {
     const branch = execSync('git branch --show-current', {
       encoding: 'utf8',
@@ -123,42 +104,34 @@ async function main() {
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
     const match = branch.match(new RegExp(config.TICKET_PROJECT_KEY + '-\\d+'));
-    ticketId = match ? match[0] : null;
+    return match ? match[0] : null;
   } catch {
-    ticketId = null;
+    return null;
   }
+}
 
-  // Check for screenshots in tasks folder
-  const tasksDir = ticketId ? config.tasksDir(ticketId) : null;
-  let screenshotCount = 0;
-
-  if (tasksDir) {
-    const screenshotDir = path.join(tasksDir, 'screenshots');
-    try {
-      if (fs.existsSync(screenshotDir)) {
-        const files = fs.readdirSync(screenshotDir, { recursive: true });
-        screenshotCount = files.filter((f) => {
-          const ext = path.extname(String(f)).toLowerCase();
-          return ['.png', '.jpg', '.jpeg', '.gif', '.webp'].includes(ext);
-        }).length;
-      }
-    } catch {
-      // ignore
-    }
+function countScreenshots(tasksDir) {
+  if (!tasksDir) return 0;
+  const screenshotDir = path.join(tasksDir, 'screenshots');
+  try {
+    if (!fs.existsSync(screenshotDir)) return 0;
+    const files = fs.readdirSync(screenshotDir, { recursive: true });
+    return files.filter((f) => {
+      const ext = path.extname(String(f)).toLowerCase();
+      return ['.png', '.jpg', '.jpeg', '.gif', '.webp'].includes(ext);
+    }).length;
+  } catch {
+    return 0;
   }
+}
 
-  if (screenshotCount > 0) {
-    process.exit(0);
-  }
-
-  // BLOCK: TSX changed but no screenshots
+function screenshotBanner(tsxChanged, tasksDir) {
   const fileList = tsxChanged
     .slice(0, 10)
     .map((f) => `  - ${f}`)
     .join('\n');
   const moreFiles = tsxChanged.length > 10 ? `\n  ... and ${tsxChanged.length - 10} more` : '';
-
-  process.stderr.write(`
+  return `
 ╔══════════════════════════════════════════════════════════════════════╗
 ║  📸 SCREENSHOT GATE: UI changes require visual documentation         ║
 ╠══════════════════════════════════════════════════════════════════════╣
@@ -179,12 +152,29 @@ ${fileList}${moreFiles}
 ║    /work-pr <TICKET> --force                                         ║
 ║                                                                      ║
 ╚══════════════════════════════════════════════════════════════════════╝
-`);
-  didBlock = true;
+`;
+}
+
+async function main() {
+  const hookData = parseInputOrExit(await readStdin());
+  if (!isGatedInvocation(hookData)) process.exit(0);
+
+  const gitRoot = resolveGitRoot();
+  if (!gitRoot) process.exit(0);
+
+  const tsxChanged = changedUiSources(gitRoot);
+  if (!tsxChanged || tsxChanged.length === 0) process.exit(0);
+
+  const ticketId = ticketIdFromBranch();
+  const tasksDir = ticketId ? config.tasksDir(ticketId) : null;
+  if (countScreenshots(tasksDir) > 0) process.exit(0);
+
+  // BLOCK: TSX changed but no screenshots
+  process.stderr.write(screenshotBanner(tsxChanged, tasksDir));
   process.exit(2);
 }
 
 main().catch((err) => {
   logHookError(__filename, err);
-  process.exit(didBlock ? 2 : 0);
+  process.exit(0);
 });

--- a/plugins/work/scripts/workflows/work/steps/__tests__/task-review-step.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/task-review-step.test.js
@@ -59,6 +59,14 @@ describe('task-review step', () => {
   let taskReviewStep;
   const savedEnv = {};
 
+  // GH-693: computeTaskDiff shells out to git (rev-list/merge-base) when no
+  // .last-commit-sha exists. Stub the dynamic execFileSync so step planning
+  // stays hermetic — the host repo's real commits-ahead count must not leak
+  // into these tests. Defaults simulate one commit ahead (review proceeds).
+  const cp = require('child_process');
+  let gitMock;
+  let origExecFileSync;
+
   before(() => {
     taskReviewStep = require(path.join(__dirname, '..', 'task-review.js'));
   });
@@ -68,9 +76,22 @@ describe('task-review step', () => {
     savedEnv.TASK_REVIEW_MAX_FIXES = process.env.TASK_REVIEW_MAX_FIXES;
     delete process.env.TASK_REVIEW_ENABLED;
     delete process.env.TASK_REVIEW_MAX_FIXES;
+    gitMock = { revList: '1\n', mergeBase: `${'f'.repeat(40)}\n` };
+    origExecFileSync = cp.execFileSync;
+    cp.execFileSync = (cmd, args, opts) => {
+      if (cmd === 'git' && args[0] === 'rev-list' && args[1] === '--count') {
+        if (gitMock.revList instanceof Error) throw gitMock.revList;
+        return gitMock.revList;
+      }
+      if (cmd === 'git' && args[0] === 'merge-base' && args[1] !== '--is-ancestor') {
+        return gitMock.mergeBase;
+      }
+      return origExecFileSync(cmd, args, opts);
+    };
   });
 
   afterEach(() => {
+    cp.execFileSync = origExecFileSync;
     if (savedEnv.TASK_REVIEW_ENABLED === undefined) delete process.env.TASK_REVIEW_ENABLED;
     else process.env.TASK_REVIEW_ENABLED = savedEnv.TASK_REVIEW_ENABLED;
     if (savedEnv.TASK_REVIEW_MAX_FIXES === undefined) delete process.env.TASK_REVIEW_MAX_FIXES;
@@ -309,6 +330,79 @@ describe('task-review step', () => {
     assert.equal(entries.length, 1);
     // Default max is 2, fix rounds is 1, so should NOT escalate
     assert.notEqual(entries[0].command, 'AskUserQuestion');
+  });
+
+  // ─── GH-693: blocked commit evidence — escalate, never schedule ───────────
+
+  function makeIntermediateFixture() {
+    const taskData = [
+      { num: 1, title: 'Task A', isCheckpoint: false },
+      { num: 2, title: 'Task B', isCheckpoint: false },
+      { num: 3, title: 'Task C', isCheckpoint: false },
+    ];
+    const s = makeState({
+      hasTasks: true,
+      workState: {
+        tasksMeta: {
+          currentTaskIndex: 0,
+          tasks: [{ id: 'task-1', taskReviewFixRounds: 0 }, { id: 'task-2' }, { id: 'task-3' }],
+        },
+      },
+    });
+    return { taskData, s };
+  }
+
+  it('escalates via AskUserQuestion instead of scheduling review when commit evidence is missing', () => {
+    gitMock.revList = '0\n'; // zero commits ahead -> computeTaskDiff blocks
+    const { add, entries } = makeAdd();
+    const { taskData, s } = makeIntermediateFixture();
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].step, STEPS.task_review);
+    assert.equal(entries[0].action, 'RUN');
+    assert.equal(entries[0].command, 'AskUserQuestion');
+    assert.match(entries[0].reason, /commit evidence/i);
+    assert.match(entries[0].agentPrompt, /AskUserQuestion/);
+    assert.doesNotMatch(
+      entries[0].agentPrompt,
+      /tests-review/,
+      'a vacuous review must NOT be scheduled'
+    );
+  });
+
+  it('escalates when git fails while checking commit evidence (fail closed)', () => {
+    gitMock.revList = new Error('git failed');
+    const { add, entries } = makeAdd();
+    const { taskData, s } = makeIntermediateFixture();
+    const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+    taskReviewStep(add, s, ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].command, 'AskUserQuestion');
+    assert.match(entries[0].reason, /commit evidence/i);
+  });
+
+  it('appends a blocked audit row when commit evidence is missing', () => {
+    const fs = require('fs');
+    const getConfig = require(path.join(__dirname, '..', '..', '..', 'lib', 'get-config'));
+    const TASKS_BASE = getConfig.require('TASKS_BASE');
+    const ticket = 'TEST-693-AUDIT';
+    gitMock.revList = '0\n';
+    const { add } = makeAdd();
+    const { taskData, s } = makeIntermediateFixture();
+    const ctx = makeCtx({ ticket, _taskData: taskData, _currentTaskIdx: 0 });
+    try {
+      taskReviewStep(add, s, ctx);
+      const rows = JSON.parse(
+        fs.readFileSync(path.join(TASKS_BASE, ticket, '.work-actions.json'), 'utf-8')
+      );
+      assert.ok(
+        rows.some((r) => r.step === STEPS.task_review && /commit evidence/i.test(r.what || '')),
+        `expected a blocked audit row, got ${JSON.stringify(rows)}`
+      );
+    } finally {
+      fs.rmSync(path.join(TASKS_BASE, ticket), { recursive: true, force: true });
+    }
   });
 
   // ─── GH-259: reportFolder in plan entry metadata ─────────────────────────

--- a/plugins/work/scripts/workflows/work/steps/__tests__/task-review-step.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/task-review-step.test.js
@@ -382,6 +382,37 @@ describe('task-review step', () => {
     assert.match(entries[0].reason, /commit evidence/i);
   });
 
+  it('escalates when computeTaskDiff throws — exceptions fail closed (PR #716)', () => {
+    // computeTaskDiff catches git/fs failures internally, so a throw is an
+    // unverifiable state — it must route to the blocked escalation, never
+    // schedule a review with no valid diff range. Simulate by making the
+    // shared config module's getBaseBranch throw (same require-cache
+    // instance task-review-gate.js holds).
+    const config = require(path.join(__dirname, '..', '..', '..', 'lib', 'config'));
+    const origGetBaseBranch = config.getBaseBranch;
+    config.getBaseBranch = () => {
+      throw new Error('config exploded');
+    };
+    try {
+      const { add, entries } = makeAdd();
+      const { taskData, s } = makeIntermediateFixture();
+      const ctx = makeCtx({ _taskData: taskData, _currentTaskIdx: 0 });
+      taskReviewStep(add, s, ctx);
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].action, 'RUN');
+      assert.equal(entries[0].command, 'AskUserQuestion');
+      assert.match(entries[0].reason, /commit evidence/i);
+      assert.match(entries[0].reason, /config exploded/, 'reason must carry the failure detail');
+      assert.doesNotMatch(
+        entries[0].agentPrompt,
+        /tests-review/,
+        'a review with an unverifiable range must NOT be scheduled'
+      );
+    } finally {
+      config.getBaseBranch = origGetBaseBranch;
+    }
+  });
+
   it('appends a blocked audit row when commit evidence is missing', () => {
     const fs = require('fs');
     const getConfig = require(path.join(__dirname, '..', '..', '..', 'lib', 'get-config'));

--- a/plugins/work/scripts/workflows/work/steps/task-review.js
+++ b/plugins/work/scripts/workflows/work/steps/task-review.js
@@ -12,6 +12,8 @@
  *   3. Final task (current == last)           -> DEFER "Final task -- /check handles review"
  *   4. Fix rounds exhausted (>= max)          -> RUN  AskUserQuestion escalation
  *   5. Intermediate task needing review       -> RUN  parallel /tests-review + /code-review
+ *      (unless commit evidence is missing — GH-693 — then RUN AskUserQuestion
+ *      escalation instead of scheduling a vacuous review)
  */
 
 'use strict';
@@ -75,10 +77,51 @@ function addEscalation(add, ctx, { currentIdx, totalTasks, fixRounds, maxFixRoun
 }
 
 /**
+ * GH-693: commit evidence missing — computeTaskDiff returned { blocked }.
+ * Never schedule a vacuous review; escalate to the user via the same
+ * AskUserQuestion shape as the fix-rounds escalation, and audit the block.
+ */
+function addBlockedEscalation(add, ctx, { currentIdx, totalTasks, reason }) {
+  const { STEPS } = ctx;
+  const rt = getRuntime();
+  add(
+    STEPS.task_review,
+    'RUN',
+    T('tool.question', {}, rt.name),
+    `Task ${currentIdx + 1}/${totalTasks} blocked: commit evidence missing (${reason}) -- escalating to user`,
+    {
+      agentType: 'general-purpose',
+      agentPrompt: renderQuestionText(
+        `Task ${currentIdx + 1} cannot be reviewed: ${reason}. Use AskUserQuestion to ask the user whether to run the commit step now, fetch the base ref, or abort.`,
+        rt
+      ),
+    }
+  );
+  appendAction(ctx.ticket, {
+    step: STEPS.task_review,
+    what: `task ${currentIdx + 1}/${totalTasks} review blocked: commit evidence missing (${reason}) -- escalating`,
+  });
+}
+
+/**
+ * Compute the task-scoped diff range for the review. GH-693 blocked results
+ * ({ blocked, reason }) pass through; genuine exceptions -> null (the review
+ * proceeds with the "computed from .last-commit-sha" note, as before).
+ */
+function computeDiffRange(reviewTasksDir, ticket) {
+  try {
+    return computeTaskDiff(reviewTasksDir, ticket);
+  } catch (_e) {
+    return null;
+  }
+}
+
+/**
  * Decision 5: intermediate task -- run parallel tests-review + code-review.
  */
 function addReviewRun(add, ctx, { currentIdx, totalTasks, currentTask }) {
   const { STEPS } = ctx;
+  const taskTitle = currentTask?.title || 'unknown';
   // Override tasksDir to per-task subfolder when task context is available.
   // ctx._currentTaskIdx is set by the implement step; when present (not undefined/null),
   // use taskSegment() to construct the per-task path for artifact resolution.
@@ -87,30 +130,31 @@ function addReviewRun(add, ctx, { currentIdx, totalTasks, currentTask }) {
       ? path.join(ctx.tasksDir, taskSegment(currentIdx + 1))
       : ctx.tasksDir;
   // Compute task-scoped diff range via computeTaskDiff (reads .last-commit-sha,
-  // validates, falls back to base branch on missing/invalid SHA). The range is
-  // passed to the orchestrator in plan-entry metadata so /tests-review and
+  // validates, falls back to the merge-base on missing/invalid SHA). The range
+  // is passed to the orchestrator in plan-entry metadata so /tests-review and
   // /code-review receive the task-specific diff, not the full branch diff.
-  let diffRange;
-  try {
-    diffRange = computeTaskDiff(reviewTasksDir, ctx.ticket);
-  } catch (_e) {
-    diffRange = null;
+  const diffRange = computeDiffRange(reviewTasksDir, ctx.ticket);
+  // GH-693: zero commits ahead of base (or git failure) — the diff range is
+  // vacuous. Escalate instead of scheduling a review that reviews nothing.
+  if (diffRange && diffRange.blocked) {
+    addBlockedEscalation(add, ctx, { currentIdx, totalTasks, reason: diffRange.reason });
+    return;
   }
   add(
     STEPS.task_review,
     'RUN',
     'Skill(tests-review) + Skill(code-review)',
-    `Task ${currentIdx + 1}/${totalTasks}: review "${currentTask?.title || 'unknown'}" before advancing`,
+    `Task ${currentIdx + 1}/${totalTasks}: review "${taskTitle}" before advancing`,
     {
       agentType: 'skill',
-      agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${currentTask?.title || 'unknown'}"). Scope both reviews to the task diff range${diffRange ? ` (base=${diffRange.base}, head=${diffRange.head})` : ' (computed from .last-commit-sha)'}. Set REPORT_FOLDER=${reviewTasksDir} for both skills. Aggregate results and fail the gate if either review fails.`,
+      agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${taskTitle}"). Scope both reviews to the task diff range${diffRange ? ` (base=${diffRange.base}, head=${diffRange.head})` : ' (computed from .last-commit-sha)'}. Set REPORT_FOLDER=${reviewTasksDir} for both skills. Aggregate results and fail the gate if either review fails.`,
       diffRange,
       reportFolder: reviewTasksDir,
     }
   );
   appendAction(ctx.ticket, {
     step: STEPS.task_review,
-    what: `task ${currentIdx + 1}/${totalTasks} review scheduled for "${currentTask?.title || 'unknown'}"`,
+    what: `task ${currentIdx + 1}/${totalTasks} review scheduled for "${taskTitle}"`,
   });
 }
 

--- a/plugins/work/scripts/workflows/work/steps/task-review.js
+++ b/plugins/work/scripts/workflows/work/steps/task-review.js
@@ -105,14 +105,20 @@ function addBlockedEscalation(add, ctx, { currentIdx, totalTasks, reason }) {
 
 /**
  * Compute the task-scoped diff range for the review. GH-693 blocked results
- * ({ blocked, reason }) pass through; genuine exceptions -> null (the review
- * proceeds with the "computed from .last-commit-sha" note, as before).
+ * ({ blocked, reason }) pass through; exceptions ALSO fail closed as a
+ * blocked result (PR #716) — computeTaskDiff catches git/fs failures
+ * internally, so a throw means the range is unverifiable and must route to
+ * the escalation, never to a scheduled review with no valid diff range.
  */
 function computeDiffRange(reviewTasksDir, ticket) {
   try {
     return computeTaskDiff(reviewTasksDir, ticket);
-  } catch (_e) {
-    return null;
+  } catch (e) {
+    const detail = e && typeof e.message === 'string' ? e.message : String(e);
+    return {
+      blocked: true,
+      reason: `commit evidence check failed while computing task diff: ${detail}`,
+    };
   }
 }
 

--- a/plugins/work/scripts/workflows/work/workflow-def/delivery-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/delivery-verifiers.js
@@ -60,37 +60,25 @@ function commitProvenBySavedSha(execFileSync, shaFile, headSha) {
 function commitProvenByBranchLog(execFileSync, baseBranch, shaFile, headSha) {
   const log = execFileSync('git', ['log', '--oneline', `${baseBranch}..HEAD`], EXEC_OPTS).trim();
   if (!log) return null;
-  // Verify diff vs main is non-empty
-  const diff = execFileSync('git', ['diff', '--shortstat', baseBranch, 'HEAD'], EXEC_OPTS).trim();
+  // Verify the merge-base (three-dot) diff vs base is non-empty — a moved
+  // base cannot fabricate changes for an empty commit (GH-693).
+  const diff = execFileSync(
+    'git',
+    ['diff', '--shortstat', `${baseBranch}...HEAD`],
+    EXEC_OPTS
+  ).trim();
   if (!diff) return false; // No actual changes -- reject
   fs.writeFileSync(shaFile, headSha);
   return true;
 }
 
-/** 3. Branch-name fallback: branch contains ticketId + committed changes exist (GH-191). */
-function commitProvenByBranchName(execFileSync, ctx) {
-  const { baseBranch, shaFile, headSha, ticketId } = ctx;
-  try {
-    const branch = execFileSync('git', ['branch', '--show-current'], EXEC_OPTS).trim();
-    const escapedTicketId = ticketId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const branchTicketPattern = new RegExp(`(?:^|[/-])${escapedTicketId}(?:$|[/-])`);
-    if (!branch || !branchTicketPattern.test(branch)) return false;
-    const diff = execFileSync('git', ['diff', '--shortstat', baseBranch, 'HEAD'], EXEC_OPTS).trim();
-    if (!diff) return false;
-    if (process.env.ENFORCE_HOOK_DEBUG) {
-      process.stderr.write(
-        `[enforce-hook] commit verify: branch-name fallback matched (branch=${branch}, ticketId=${ticketId})\n`
-      );
-    }
-    fs.writeFileSync(shaFile, headSha);
-    return true;
-  } catch {
-    return false; /* detached HEAD or other error -- skip fallback */
-  }
-}
-
 /**
- * Commit is proven if HEAD has new commits with ticketId (not empty commits).
+ * Commit is proven only by commits ahead of the base branch (not empty
+ * commits). The GH-191 branch-name fallback was DELETED (GH-693): it only
+ * ran when `base..HEAD` was empty, so its sole reachable pass case was the
+ * false positive — zero commits ahead with a two-dot diff fabricated by a
+ * moved base. `.last-commit-sha` is now written only after commits ahead
+ * are proven.
  * @param {DeliveryDeps} deps
  */
 function verifyCommit(deps, ticketId) {
@@ -103,8 +91,19 @@ function verifyCommit(deps, ticketId) {
     if (proven === null) {
       proven = commitProvenByBranchLog(execFileSync, baseBranch, shaFile, headSha);
     }
-    if (proven !== null) return proven;
-    return commitProvenByBranchName(execFileSync, { baseBranch, shaFile, headSha, ticketId });
+    if (proven === null) {
+      // Zero commits ahead of the resolved base — missing work, not an
+      // excuse to fall back. Repair: commit the work, or fix the base ref.
+      if (process.env.ENFORCE_HOOK_DEBUG) {
+        process.stderr.write(
+          `[enforce-hook] commit verify: 0 commits ahead of ${baseBranch} — ` +
+            `commit the work first, or repair the base ref ` +
+            `(git fetch origin main / check BASE_BRANCH)\n`
+        );
+      }
+      return false;
+    }
+    return proven;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Existing Behavior

- The `commit` step verifier accepted a branch-name fallback (GH-191): if `base..HEAD` was empty but the branch name contained the ticket ID and a two-dot diff was non-empty (possible when the base ref moved), the step was marked completed — no actual commit required.
- `computeTaskDiff` (task-review gate) fell back to `origin/main` as the review base whenever `.last-commit-sha` was missing, invalid, or not an ancestor of HEAD. With zero commits ahead this produced a vacuous diff, yet the gate returned a result rather than blocking.
- `diff_audit` propagated whatever `computeTaskDiff` returned; a blocked/empty range was misattributed to a stale SHA rather than surfacing the real cause.
- The `writeContext` boilerplate (ticket, fileCount, files, capturedAt snapshot) was duplicated independently in both `work-task-review/lib/phases/diff_audit.js` and `work-reports/lib/phases/collect_artifacts.js`.

## Intended New Behavior

- **Commit step verifier** — the GH-191 branch-name fallback is deleted. Proof of commit is strictly `git log base..HEAD` returning at least one entry AND the three-dot merge-base diff being non-empty (prevents a moved-base from fabricating changes for an empty commit). `.last-commit-sha` is only written after both conditions pass.
- **Transition gate** — a new `commitEvidenceGate` in `transition-gates.js` runs on every forward transition out of `commit` or `task_review`. It shells out to `git rev-list --count base..HEAD`; zero commits or a git failure blocks the transition with a distinct, diagnosable message. Fail-closed: a git error produces `"git failed"`, not a pass.
- **`computeTaskDiff`** — when `.last-commit-sha` is missing/invalid/non-ancestor, the function now checks commits-ahead first. Zero commits → returns `{ blocked: true, reason }`. Commits present → re-derives the review base from `git merge-base` (exact SHA), falling back to the branch name only if `merge-base` itself fails.
- **`diff_audit` validate** — detects the `blocked` sentinel from `computeTaskDiff` and surfaces the reason directly, skipping the vacuous file-list audit and not writing the context snapshot.
- **`task-review.js` step planner** — when `computeDiffRange` returns a blocked result, `addBlockedEscalation` fires an `AskUserQuestion` plan entry instead of scheduling `/tests-review` + `/code-review`, and appends an audit row to `.work-actions.json`.
- **Shared `writePhaseContext` module** — the duplicated snapshot-writing boilerplate is extracted to `plugins/work/scripts/workflows/lib/write-phase-context.js` and both callers updated to use it.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Transition gate (zero commits ahead blocks):**
1. Check out a branch with no commits ahead of `origin/main`.
2. Advance the work state to `commit` in progress: edit `.work-state/<ticket>.json` so `currentStep` points to `commit`.
3. Run `work transition <ticket> task_review`.
4. Expected: exit with `gate: commit-evidence` error and a message containing `rev-list --count` and `git fetch`.

**Commit step verifier (branch-name fallback removed):**
1. On a branch named `fix/TICKET-123-something` with zero commits ahead of base, trigger the commit verify hook.
2. Expected: `verifyCommit` returns `false`; `.last-commit-sha` is not written.
3. Add one real commit, re-trigger verify.
4. Expected: returns `true`; `.last-commit-sha` is written with the current HEAD SHA.

**`computeTaskDiff` blocked propagation:**
1. Delete `.last-commit-sha` for a ticket and ensure the branch has zero commits ahead.
2. Call `computeTaskDiff(tasksDir, ticketId)`.
3. Expected: returns `{ blocked: true, reason: /no commits ahead/ }`.
4. Add a commit; call again.
5. Expected: returns `{ base: <merge-base SHA>, head: 'HEAD', fallback: true }`.

**`diff_audit` blocked surface:**
1. Arrange the above blocked state and call `validate(ctx)` on `diff_audit`.
2. Expected: `{ ok: false, errors: [/no commits ahead/] }` and no `task-review-context.json` written.

**Task-review step planner escalation:**
1. Arrange zero commits ahead and invoke `taskReviewStep` for an intermediate task.
2. Expected: single plan entry with `command: AskUserQuestion` and `reason` matching `/commit evidence/i`; no `tests-review` entry in the plan.

Targets main directly — the former base (GH-695, PR #713) merged; the stack was rebased onto main.

Closes #693