### PR TITLE
fix(work): refuse implement completion with unsatisfied tasks (GH-694)

### DIFF
--- a/factories/runtime/__tests__/payload.spec.js
+++ b/factories/runtime/__tests__/payload.spec.js
@@ -156,6 +156,67 @@ describe('normalizeHookPayload — claude fixtures (byte-compat surface)', () =>
     assert.equal(isSubagentContext(evt), true);
     assert.equal(isSubagentContext(normalize('claude', 'stop')), false);
   });
+
+  // GH-696: claude payloads fired inside a subagent can carry agent identity
+  // in the RAW payload without a /subagents/ transcript path.
+  it('claude native agent_type/agent_id in the raw payload marks subagent context (GH-696)', () => {
+    const byType = normalizeHookPayload(
+      { tool_name: 'Bash', transcript_path: '/tmp/t.jsonl', agent_type: 'pr-generator' },
+      { runtime: 'claude' }
+    );
+    assert.equal(isSubagentContext(byType), true);
+    const byId = normalizeHookPayload(
+      { tool_name: 'Bash', transcript_path: '/tmp/t.jsonl', agent_id: 'agent-42' },
+      { runtime: 'claude' }
+    );
+    assert.equal(isSubagentContext(byId), true);
+  });
+
+  // GH-696 scoping pin: never read env-folded evt.agent.type — CLAUDE_AGENT_TYPE
+  // leaks via tmux global env and would permanently mute a main session.
+  it('claude env-folded CLAUDE_AGENT_TYPE alone is NOT a subagent context (GH-696)', () => {
+    process.env.CLAUDE_AGENT_TYPE = 'developer-nodejs-tdd';
+    try {
+      const evt = normalizeHookPayload(
+        { tool_name: 'Bash', transcript_path: '/tmp/t.jsonl' },
+        { runtime: 'claude' }
+      );
+      assert.equal(evt.agent.type, 'developer-nodejs-tdd'); // env fold still surfaces it
+      assert.equal(isSubagentContext(evt), false);
+    } finally {
+      delete process.env.CLAUDE_AGENT_TYPE;
+    }
+  });
+
+  // GH-696 (PR #718): CLAUDE_CURRENT_AGENT is the SAME tmux global-env leak
+  // class — an env-only signal must never mute auto-advance in a main session.
+  // Subagent identity comes from the raw payload or the /subagents/ transcript
+  // path, never from the process environment.
+  it('claude env CLAUDE_CURRENT_AGENT alone is NOT a subagent context (GH-696)', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'pr-generator';
+    try {
+      const evt = normalizeHookPayload(
+        { tool_name: 'Bash', transcript_path: '/tmp/t.jsonl' },
+        { runtime: 'claude' }
+      );
+      assert.equal(isSubagentContext(evt), false);
+    } finally {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+  });
+
+  it('claude env CLAUDE_CURRENT_AGENT plus native payload identity IS a subagent context', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'pr-generator';
+    try {
+      const evt = normalizeHookPayload(
+        { tool_name: 'Bash', transcript_path: '/tmp/t.jsonl', agent_type: 'pr-generator' },
+        { runtime: 'claude' }
+      );
+      assert.equal(isSubagentContext(evt), true);
+    } finally {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+  });
 });
 
 describe('normalizeHookPayload — defensive shapes', () => {

--- a/factories/runtime/payload.js
+++ b/factories/runtime/payload.js
@@ -151,15 +151,32 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/ or CLAUDE_CURRENT_AGENT set. Codex: payload agent identity
+ * /subagents/ or raw payload agent identity. Codex: payload agent identity
  * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
+ *
+ * GH-696: the claude leg reads the RAW payload (evt.native) and the
+ * transcript path ONLY — never the env-folded evt.agent.type and never
+ * process.env directly. resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, and BOTH leak via tmux global env; any env-derived
+ * signal here would permanently mute auto-advance in a main session
+ * (PR #718). Enforcement-side dispatched-agent detection
+ * (lib/agent-detection.js isDispatchedAgentContext) deliberately still reads
+ * CLAUDE_CURRENT_AGENT — there a false positive only blocks a terminal
+ * bypass with a message naming the leaked var, while here it would be a
+ * silent liveness failure.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
   if (evt.runtime === 'codex') return Boolean(evt.agent && (evt.agent.id || evt.agent.type));
+  return isClaudeSubagentContext(evt);
+}
+
+/** Claude leg of isSubagentContext — see the GH-696 note above. */
+function isClaudeSubagentContext(evt) {
+  const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
-    Boolean(process.env.CLAUDE_CURRENT_AGENT)
+    Boolean(str(native.agent_type) || str(native.agent_id))
   );
 }
 

--- a/plugins/heimdall/lib/runtime/payload.js
+++ b/plugins/heimdall/lib/runtime/payload.js
@@ -153,15 +153,32 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/ or CLAUDE_CURRENT_AGENT set. Codex: payload agent identity
+ * /subagents/ or raw payload agent identity. Codex: payload agent identity
  * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
+ *
+ * GH-696: the claude leg reads the RAW payload (evt.native) and the
+ * transcript path ONLY — never the env-folded evt.agent.type and never
+ * process.env directly. resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, and BOTH leak via tmux global env; any env-derived
+ * signal here would permanently mute auto-advance in a main session
+ * (PR #718). Enforcement-side dispatched-agent detection
+ * (lib/agent-detection.js isDispatchedAgentContext) deliberately still reads
+ * CLAUDE_CURRENT_AGENT — there a false positive only blocks a terminal
+ * bypass with a message naming the leaked var, while here it would be a
+ * silent liveness failure.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
   if (evt.runtime === 'codex') return Boolean(evt.agent && (evt.agent.id || evt.agent.type));
+  return isClaudeSubagentContext(evt);
+}
+
+/** Claude leg of isSubagentContext — see the GH-696 note above. */
+function isClaudeSubagentContext(evt) {
+  const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
-    Boolean(process.env.CLAUDE_CURRENT_AGENT)
+    Boolean(str(native.agent_type) || str(native.agent_id))
   );
 }
 

--- a/plugins/maestro/scripts/lib/runtime/payload.js
+++ b/plugins/maestro/scripts/lib/runtime/payload.js
@@ -153,15 +153,32 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/ or CLAUDE_CURRENT_AGENT set. Codex: payload agent identity
+ * /subagents/ or raw payload agent identity. Codex: payload agent identity
  * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
+ *
+ * GH-696: the claude leg reads the RAW payload (evt.native) and the
+ * transcript path ONLY — never the env-folded evt.agent.type and never
+ * process.env directly. resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, and BOTH leak via tmux global env; any env-derived
+ * signal here would permanently mute auto-advance in a main session
+ * (PR #718). Enforcement-side dispatched-agent detection
+ * (lib/agent-detection.js isDispatchedAgentContext) deliberately still reads
+ * CLAUDE_CURRENT_AGENT — there a false positive only blocks a terminal
+ * bypass with a message naming the leaked var, while here it would be a
+ * silent liveness failure.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
   if (evt.runtime === 'codex') return Boolean(evt.agent && (evt.agent.id || evt.agent.type));
+  return isClaudeSubagentContext(evt);
+}
+
+/** Claude leg of isSubagentContext — see the GH-696 note above. */
+function isClaudeSubagentContext(evt) {
+  const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
-    Boolean(process.env.CLAUDE_CURRENT_AGENT)
+    Boolean(str(native.agent_type) || str(native.agent_id))
   );
 }
 

--- a/plugins/synapsys/lib/runtime/payload.js
+++ b/plugins/synapsys/lib/runtime/payload.js
@@ -153,15 +153,32 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/ or CLAUDE_CURRENT_AGENT set. Codex: payload agent identity
+ * /subagents/ or raw payload agent identity. Codex: payload agent identity
  * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
+ *
+ * GH-696: the claude leg reads the RAW payload (evt.native) and the
+ * transcript path ONLY — never the env-folded evt.agent.type and never
+ * process.env directly. resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, and BOTH leak via tmux global env; any env-derived
+ * signal here would permanently mute auto-advance in a main session
+ * (PR #718). Enforcement-side dispatched-agent detection
+ * (lib/agent-detection.js isDispatchedAgentContext) deliberately still reads
+ * CLAUDE_CURRENT_AGENT — there a false positive only blocks a terminal
+ * bypass with a message naming the leaked var, while here it would be a
+ * silent liveness failure.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
   if (evt.runtime === 'codex') return Boolean(evt.agent && (evt.agent.id || evt.agent.type));
+  return isClaudeSubagentContext(evt);
+}
+
+/** Claude leg of isSubagentContext — see the GH-696 note above. */
+function isClaudeSubagentContext(evt) {
+  const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
-    Boolean(process.env.CLAUDE_CURRENT_AGENT)
+    Boolean(str(native.agent_type) || str(native.agent_id))
   );
 }
 

--- a/plugins/work/scripts/workflows/lib/runtime/payload.js
+++ b/plugins/work/scripts/workflows/lib/runtime/payload.js
@@ -153,15 +153,32 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/ or CLAUDE_CURRENT_AGENT set. Codex: payload agent identity
+ * /subagents/ or raw payload agent identity. Codex: payload agent identity
  * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
+ *
+ * GH-696: the claude leg reads the RAW payload (evt.native) and the
+ * transcript path ONLY — never the env-folded evt.agent.type and never
+ * process.env directly. resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, and BOTH leak via tmux global env; any env-derived
+ * signal here would permanently mute auto-advance in a main session
+ * (PR #718). Enforcement-side dispatched-agent detection
+ * (lib/agent-detection.js isDispatchedAgentContext) deliberately still reads
+ * CLAUDE_CURRENT_AGENT — there a false positive only blocks a terminal
+ * bypass with a message naming the leaked var, while here it would be a
+ * silent liveness failure.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
   if (evt.runtime === 'codex') return Boolean(evt.agent && (evt.agent.id || evt.agent.type));
+  return isClaudeSubagentContext(evt);
+}
+
+/** Claude leg of isSubagentContext — see the GH-696 note above. */
+function isClaudeSubagentContext(evt) {
+  const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
-    Boolean(process.env.CLAUDE_CURRENT_AGENT)
+    Boolean(str(native.agent_type) || str(native.agent_id))
   );
 }
 

--- a/plugins/work/scripts/workflows/work-implement/__tests__/changed-test-files.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/changed-test-files.test.js
@@ -1,0 +1,127 @@
+/**
+ * GH-694 — extraction parity for lib/changed-test-files.js.
+ *
+ * filterChangedTestFilesByScope and detectChangedTestFilesInScope moved
+ * VERBATIM from task-next.js into the shared module (same sibling pattern as
+ * lib/red-load-failure.js) so the implement gate's tests-only GREEN trap can
+ * apply the exact GH-528 recorder rule (unification invariant). task-next.js
+ * requires and re-exports both, so this suite pins:
+ *   - re-export identity (the gate and the recorder share ONE function object)
+ *   - scope-filter parity against the fixtures from
+ *     task-next-changed-test-files-scope.test.js
+ *   - the git-aware wrapper's changed-set semantics (untracked counts,
+ *     committed-unchanged does not)
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const lib = require('../lib/changed-test-files');
+const taskNext = require('../task-next');
+
+describe('changed-test-files.js — re-export identity (GH-694)', () => {
+  it('task-next.js re-exports the SAME function objects', () => {
+    assert.equal(
+      taskNext.filterChangedTestFilesByScope,
+      lib.filterChangedTestFilesByScope,
+      'filterChangedTestFilesByScope must be the shared module function'
+    );
+    assert.equal(
+      taskNext.detectChangedTestFilesInScope,
+      lib.detectChangedTestFilesInScope,
+      'detectChangedTestFilesInScope must be the shared module function'
+    );
+  });
+});
+
+describe('changed-test-files.js — filterChangedTestFilesByScope parity', () => {
+  const f = lib.filterChangedTestFilesByScope;
+
+  it('keeps a changed test file matched by an exact scope entry', () => {
+    assert.deepEqual(
+      f(['plugins/work/scripts/foo.test.js'], ['plugins/work/scripts/foo.test.js']),
+      ['plugins/work/scripts/foo.test.js']
+    );
+  });
+
+  it('keeps a changed test file matched by a directory-prefix scope entry', () => {
+    assert.deepEqual(f(['plugins/work/scripts/sub/foo.test.js'], ['plugins/work/scripts/sub']), [
+      'plugins/work/scripts/sub/foo.test.js',
+    ]);
+  });
+
+  it('keeps a changed test file matched by a `**` glob scope entry', () => {
+    assert.deepEqual(
+      f(
+        ['plugins/work/scripts/workflows/work-implement/__tests__/x.test.js'],
+        ['plugins/work/**/*.test.js']
+      ),
+      ['plugins/work/scripts/workflows/work-implement/__tests__/x.test.js']
+    );
+  });
+
+  it('excludes a non-test file even when it matches the scope glob', () => {
+    assert.deepEqual(
+      f(['plugins/work/scripts/foo.js', 'plugins/work/scripts/foo.test.js'], ['plugins/work/**']),
+      ['plugins/work/scripts/foo.test.js']
+    );
+  });
+
+  it('excludes a changed test file outside the scope glob', () => {
+    assert.deepEqual(f(['unrelated/elsewhere/bar.test.js'], ['plugins/work/**/*.test.js']), []);
+  });
+
+  it('falls back to "any changed test file" when scope is empty', () => {
+    assert.deepEqual(f(['anywhere/x.test.js', 'anywhere/y.js'], []), ['anywhere/x.test.js']);
+  });
+});
+
+describe('changed-test-files.js — detectChangedTestFilesInScope (git-aware wrapper)', () => {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'ctf-git-'));
+
+  after(() => {
+    try {
+      fs.rmSync(repo, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+
+  function git(...args) {
+    return execFileSync('git', args, { cwd: repo, encoding: 'utf8' });
+  }
+
+  it('committed-unchanged suite yields none; a new untracked in-scope test file counts', () => {
+    git('init', '-q');
+    fs.mkdirSync(path.join(repo, 'tests'), { recursive: true });
+    fs.writeFileSync(path.join(repo, 'tests', 'existing.test.js'), 'pre-existing\n');
+    git('add', '.');
+    git(
+      '-c',
+      'user.email=fixture@example.com',
+      '-c',
+      'user.name=fixture',
+      'commit',
+      '-q',
+      '-m',
+      'seed'
+    );
+
+    assert.deepEqual(
+      lib.detectChangedTestFilesInScope(repo, ['tests']),
+      [],
+      'byte-identical committed test files are not "changed"'
+    );
+
+    fs.writeFileSync(path.join(repo, 'tests', 'new-parity.test.js'), 'new test\n');
+    assert.deepEqual(
+      lib.detectChangedTestFilesInScope(repo, ['tests']),
+      ['tests/new-parity.test.js'],
+      'untracked in-scope test files count as changed'
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/lib/changed-test-files.js
+++ b/plugins/work/scripts/workflows/work-implement/lib/changed-test-files.js
@@ -1,0 +1,132 @@
+/**
+ * changed-test-files.js
+ *
+ * GH-694 — the tests-only "declared test files actually changed" rule
+ * (GH-528), extracted VERBATIM from task-next.js so the implement gate's
+ * GREEN writer (tdd-phase-state/gate-writer.js) applies the SAME function
+ * the recorder path uses (unification invariant). Extracted as a sibling
+ * module (same pattern as lib/red-load-failure.js) rather than exported
+ * directly from task-next.js, which would create the circular require
+ * gate-writer ← task-next → recordEvidence → tdd-phase-state → gate-writer.
+ *
+ * task-next.js requires and re-exports both functions, so its public
+ * surface and existing tests stay byte-compatible.
+ */
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+
+const { fileMatchesScope } = require('../../lib/task-scope');
+
+/**
+ * Pure helper: filter a list of changed POSIX paths down to those that are
+ * test/spec files AND fall under the task's declared scope.
+ *
+ * Scope match delegates to `fileMatchesScope` from `../../lib/task-scope`
+ * (the same matcher used by the production scope-protection layer), so glob
+ * patterns like `src/**` or `plugins/work/**\/*.test.js` are honored.
+ * Bare-directory entries (no glob meta, no trailing `/`) keep their legacy
+ * "directory prefix" semantics so existing task definitions don't regress.
+ *
+ * Scope behaviors preserved:
+ *   - exact path entry          → matches that path
+ *   - directory entry (`a/b`)   → matches `a/b/**` (legacy prefix)
+ *   - directory entry (`a/b/`)  → matches `a/b/**` (via fileMatchesScope)
+ *   - glob entry  (`a/**\/*.test.js`) → standard glob match
+ *   - empty scope               → any changed test file passes through
+ *
+ * The test-file extension filter always applies last: a file matched by
+ * scope but not ending in `.test.<ext>` / `.spec.<ext>` is excluded.
+ *
+ * @param {string[]} changedPaths POSIX-style paths relative to repoRoot.
+ * @param {string[]} scope        `### Files in scope` entries from tasks.md.
+ * @returns {string[]}            The subset that should count as "agent
+ *                                actually wrote in-scope test code".
+ */
+function filterChangedTestFilesByScope(changedPaths, scope) {
+  const out = [];
+  const scopeList = Array.isArray(scope) ? scope.filter((s) => typeof s === 'string' && s) : [];
+  for (const rel of Array.isArray(changedPaths) ? changedPaths : []) {
+    if (typeof rel !== 'string' || !rel) continue;
+    if (!/\.(test|spec)\.[jt]sx?$/i.test(rel)) continue;
+    if (scopeList.length === 0) {
+      out.push(rel);
+      continue;
+    }
+    const inScope = scopeList.some((s) => {
+      if (rel === s) return true;
+      // Legacy bare-directory prefix: `a/b` matches `a/b/...`. We keep this
+      // because fileMatchesScope would compile `a/b` as a literal glob and
+      // miss the descendants.
+      if (rel.startsWith(s.replace(/\/+$/, '') + '/')) return true;
+      // Delegate everything else (exact match was handled above) to the
+      // shared glob-aware matcher — this is the regression fix for `**`
+      // and `*` segment patterns.
+      return fileMatchesScope(rel, [s]);
+    });
+    if (inScope) out.push(rel);
+  }
+  return out;
+}
+
+/**
+ * Return the subset of changed (vs HEAD + staged + untracked) files that are
+ * test/spec files AND fall under the task's declared scope. Used by the
+ * tests-only GREEN gate to ensure the agent actually wrote new test code
+ * (not a no-op cycle).
+ *
+ * Scope-match semantics live in `filterChangedTestFilesByScope` (pure,
+ * unit-tested). This function is the git-aware wrapper that collects the
+ * "changed" set from working tree + index + untracked files.
+ */
+function detectChangedTestFilesInScope(repoRoot, scope) {
+  const out = [];
+  let diff = '';
+  let staged = '';
+  let untracked = '';
+  // GH-528 round-2 follow-up note: check `git` exit status so a real git
+  // failure (corrupt repo, mid-rebase, missing git binary) is distinguishable
+  // from "no changes" downstream. Without this, all three sources silently
+  // return '' on error and the tests-only GREEN gate fires with the
+  // misleading "No *.test.* file under scope has changes" message.
+  let gitFailed = false;
+  try {
+    const r1 = spawnSync('git', ['diff', '--name-only'], { cwd: repoRoot, encoding: 'utf8' });
+    if (r1.status !== 0) gitFailed = true;
+    diff = r1.stdout || '';
+    const r2 = spawnSync('git', ['diff', '--cached', '--name-only'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (r2.status !== 0) gitFailed = true;
+    staged = r2.stdout || '';
+    const r3 = spawnSync('git', ['ls-files', '--others', '--exclude-standard'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (r3.status !== 0) gitFailed = true;
+    untracked = r3.stdout || '';
+  } catch {
+    gitFailed = true;
+  }
+  if (gitFailed) {
+    process.stderr.write(
+      'changed-test-files: git change detection failed (corrupt repo or detached state?); ' +
+        'treating changed-files as empty. Downstream gate may block with a misleading message.\n'
+    );
+  }
+  const changed = [
+    ...new Set(
+      [...diff.split('\n'), ...staged.split('\n'), ...untracked.split('\n')]
+        .map((s) => s.trim())
+        .filter(Boolean)
+    ),
+  ];
+  return filterChangedTestFilesByScope(changed, scope).reduce((acc, rel) => {
+    acc.push(rel);
+    return acc;
+  }, out);
+}
+
+module.exports = { filterChangedTestFilesByScope, detectChangedTestFilesInScope };

--- a/plugins/work/scripts/workflows/work-implement/task-next.js
+++ b/plugins/work/scripts/workflows/work-implement/task-next.js
@@ -419,115 +419,16 @@ function mintCompanionToken() {
   }
 }
 
-/**
- * Pure helper: filter a list of changed POSIX paths down to those that are
- * test/spec files AND fall under the task's declared scope.
- *
- * Scope match delegates to `fileMatchesScope` from `../lib/task-scope` (the
- * same matcher used by the production scope-protection layer), so glob
- * patterns like `src/**` or `plugins/work/**\/*.test.js` are honored.
- * Bare-directory entries (no glob meta, no trailing `/`) keep their legacy
- * "directory prefix" semantics so existing task definitions don't regress.
- *
- * Scope behaviors preserved:
- *   - exact path entry          → matches that path
- *   - directory entry (`a/b`)   → matches `a/b/**` (legacy prefix)
- *   - directory entry (`a/b/`)  → matches `a/b/**` (via fileMatchesScope)
- *   - glob entry  (`a/**\/*.test.js`) → standard glob match (NEW)
- *   - empty scope               → any changed test file passes through
- *
- * The test-file extension filter always applies last: a file matched by
- * scope but not ending in `.test.<ext>` / `.spec.<ext>` is excluded.
- *
- * @param {string[]} changedPaths POSIX-style paths relative to repoRoot.
- * @param {string[]} scope        `### Files in scope` entries from tasks.md.
- * @returns {string[]}            The subset that should count as "agent
- *                                actually wrote in-scope test code".
- */
-function filterChangedTestFilesByScope(changedPaths, scope) {
-  const out = [];
-  const scopeList = Array.isArray(scope) ? scope.filter((s) => typeof s === 'string' && s) : [];
-  for (const rel of Array.isArray(changedPaths) ? changedPaths : []) {
-    if (typeof rel !== 'string' || !rel) continue;
-    if (!/\.(test|spec)\.[jt]sx?$/i.test(rel)) continue;
-    if (scopeList.length === 0) {
-      out.push(rel);
-      continue;
-    }
-    const inScope = scopeList.some((s) => {
-      if (rel === s) return true;
-      // Legacy bare-directory prefix: `a/b` matches `a/b/...`. We keep this
-      // because fileMatchesScope would compile `a/b` as a literal glob and
-      // miss the descendants.
-      if (rel.startsWith(s.replace(/\/+$/, '') + '/')) return true;
-      // Delegate everything else (exact match was handled above) to the
-      // shared glob-aware matcher — this is the regression fix for `**`
-      // and `*` segment patterns.
-      return fileMatchesScope(rel, [s]);
-    });
-    if (inScope) out.push(rel);
-  }
-  return out;
-}
-
-/**
- * Return the subset of changed (vs HEAD + staged + untracked) files that are
- * test/spec files AND fall under the task's declared scope. Used by the
- * tests-only GREEN gate to ensure the agent actually wrote new test code
- * (not a no-op cycle).
- *
- * Scope-match semantics live in `filterChangedTestFilesByScope` (pure,
- * unit-tested). This function is the git-aware wrapper that collects the
- * "changed" set from working tree + index + untracked files.
- */
-function detectChangedTestFilesInScope(repoRoot, scope) {
-  const out = [];
-  let diff = '';
-  let staged = '';
-  let untracked = '';
-  // GH-528 round-2 follow-up note: check `git` exit status so a real git
-  // failure (corrupt repo, mid-rebase, missing git binary) is distinguishable
-  // from "no changes" downstream. Without this, all three sources silently
-  // return '' on error and the tests-only GREEN gate fires with the
-  // misleading "No *.test.* file under scope has changes" message.
-  let gitFailed = false;
-  try {
-    const r1 = spawnSync('git', ['diff', '--name-only'], { cwd: repoRoot, encoding: 'utf8' });
-    if (r1.status !== 0) gitFailed = true;
-    diff = r1.stdout || '';
-    const r2 = spawnSync('git', ['diff', '--cached', '--name-only'], {
-      cwd: repoRoot,
-      encoding: 'utf8',
-    });
-    if (r2.status !== 0) gitFailed = true;
-    staged = r2.stdout || '';
-    const r3 = spawnSync('git', ['ls-files', '--others', '--exclude-standard'], {
-      cwd: repoRoot,
-      encoding: 'utf8',
-    });
-    if (r3.status !== 0) gitFailed = true;
-    untracked = r3.stdout || '';
-  } catch {
-    gitFailed = true;
-  }
-  if (gitFailed) {
-    process.stderr.write(
-      'task-next: git change detection failed (corrupt repo or detached state?); ' +
-        'treating changed-files as empty. Downstream gate may block with a misleading message.\n'
-    );
-  }
-  const changed = [
-    ...new Set(
-      [...diff.split('\n'), ...staged.split('\n'), ...untracked.split('\n')]
-        .map((s) => s.trim())
-        .filter(Boolean)
-    ),
-  ];
-  return filterChangedTestFilesByScope(changed, scope).reduce((acc, rel) => {
-    acc.push(rel);
-    return acc;
-  }, out);
-}
+// GH-694: filterChangedTestFilesByScope + detectChangedTestFilesInScope moved
+// VERBATIM to lib/changed-test-files.js so the implement gate's GREEN writer
+// applies the SAME tests-only rule (GH-528) as this recorder path — extracted
+// (not exported from here) to avoid the circular require gate-writer ←
+// task-next → recordEvidence → tdd-phase-state → gate-writer. Re-exported
+// below so this module's public surface stays byte-compatible.
+const {
+  filterChangedTestFilesByScope,
+  detectChangedTestFilesInScope,
+} = require('./lib/changed-test-files');
 
 /** Spawn a tdd-phase-state.js subcommand with a freshly minted companion token. */
 function _spawnTdd(args, cwd, env) {
@@ -1720,6 +1621,7 @@ module.exports = {
   filterToTestFiles,
   scopeEntryAdmitsOnlyTestFiles,
   filterChangedTestFilesByScope,
+  detectChangedTestFilesInScope,
   findTestFilesInScope,
   countTestBlocksInFiles,
   wrapStrictMode,

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state/gate-rejections.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state/gate-rejections.js
@@ -1,0 +1,211 @@
+'use strict';
+
+/**
+ * tdd-phase-state/gate-rejections.js
+ *
+ * The gate writer's rejection builders, extracted VERBATIM from
+ * gate-writer.js (file-size burndown — same pattern as the GH-694
+ * commit-evidence-gate extraction). Each builder appends its enforcement
+ * audit row and returns the `{ rejected: true, kind, reason, ... }` shape
+ * the gate turns into a retry / operator-hold; they never `process.exit`.
+ *
+ * gate-writer.js remains the ONE atomic evidence writer and the module that
+ * decides WHEN a rejection fires; this module only owns the audit + message
+ * bodies.
+ */
+
+const { formatTestTimeout } = require('./io');
+const { extractLoadFailureSnippet } = require('../lib/red-load-failure');
+
+/** Best-effort enforcement audit row scoped to the gate's own tasks base. */
+function appendGateAudit(tasksBase, ticketId, entry) {
+  try {
+    const { appendEnforcementAuditAt } = require('../../work/lib/work-actions');
+    appendEnforcementAuditAt(tasksBase, ticketId, entry);
+  } catch {
+    /* fail-open on audit write — the gate decision is the source of truth */
+  }
+}
+
+/**
+ * W5 §4 + W3 message policy — hang rejection shared by the gate's pre- and
+ * post-implement paths. A timed-out run is a HANG, not a test outcome: the
+ * killed process's non-zero exit must never record as RED, and it can never
+ * legitimately record as GREEN. Appends a `tdd-<phase>-hang-rejected` audit
+ * row and returns the planner-defect rejection the gate turns into an
+ * operator-hold retry.
+ *
+ * @param {object} p - { tasksBase, ticketId, taskNum, phase, cmd, timeoutMs }
+ * @returns {{ rejected: true, kind: 'hang', plannerDefect: true, reason: string }}
+ */
+function gateHangRejection(p) {
+  appendGateAudit(p.tasksBase, p.ticketId, {
+    origin: 'workflow',
+    task: p.taskNum || null,
+    phase: p.phase,
+    action: `tdd-${p.phase}-hang-rejected`,
+    allow: false,
+    reason: 'test-command-timeout',
+    outputPath: null,
+    meta: { testCommand: p.cmd, timeoutMs: p.timeoutMs, capturedByGate: true },
+  });
+  const label = formatTestTimeout(p.timeoutMs);
+  return {
+    rejected: true,
+    kind: 'hang',
+    plannerDefect: true,
+    reason:
+      `Test command for task ${p.taskNum} timed out (${label}) at the gate. ` +
+      'A hang is not a test outcome — the command must run to completion. ' +
+      'This usually means a watch-mode or interactive command in the ' +
+      '`### Test Strategy` block, which is a planner defect. tasks.md is ' +
+      'planner-owned and LOCKED during implement — do NOT edit it. STOP and ' +
+      'report `BLOCKED (planner-defect): test command hangs ' +
+      '(watch-mode/interactive)` back to the orchestrator.',
+  };
+}
+
+/** Load-failure rejection: audit row + agent-actionable reason (fix the test file). */
+function gateLoadFailureRejection(p, loadFailure) {
+  appendGateAudit(p.tasksBase, p.ticketId, {
+    origin: 'workflow',
+    task: p.taskNum || null,
+    phase: 'red',
+    action: 'tdd-red-load-failure-rejected',
+    allow: false,
+    reason: loadFailure.signature,
+    outputPath: null,
+    meta: {
+      testCommand: p.cmd,
+      signature: loadFailure.signature,
+      snippet: extractLoadFailureSnippet(loadFailure.line),
+      capturedByGate: true,
+    },
+  });
+  return {
+    rejected: true,
+    kind: 'load-failure',
+    reason:
+      `Rejected RED at the gate: detected ${loadFailure.signature} in the test ` +
+      'runner output. The test file is structurally broken (load-time error or ' +
+      'zero tests collected), not a behavior gap — this exact crash would repeat ' +
+      'regardless of source edits and wedge GREEN. Fix the test file so it loads ' +
+      'and fails on assertions; the gate re-runs the command on the next pass.',
+  };
+}
+
+/**
+ * RC-D rejection at the gate: an exit-0 run with zero stdout+stderr proves
+ * nothing (the recorder refuses the identical run via GREEN_EMPTY_MSG).
+ * Re-running a silent-success command is always empty again, so this is a
+ * planner defect (noisy command needed) — W3 policy: never suggest editing
+ * tasks.md. Audited as `tdd-green-empty-rejected` so the refusal is visible.
+ */
+function gateEmptyOutputRejection(p) {
+  appendGateAudit(p.tasksBase, p.ticketId, {
+    origin: 'workflow',
+    task: p.taskNum || null,
+    phase: 'green',
+    action: 'tdd-green-empty-rejected',
+    allow: false,
+    reason: 'empty-output-exit-0',
+    outputPath: null,
+    meta: { testCommand: p.cmd, taskType: p.taskType || null, capturedByGate: true },
+  });
+  return {
+    rejected: true,
+    kind: 'empty-output',
+    plannerDefect: true,
+    reason:
+      `GREEN for task ${p.taskNum} exited 0 with NO stdout/stderr output at ` +
+      'the gate. Real test runs always emit output — this is the RC-D ' +
+      'empty-output trap the recorder applies to the identical run. A ' +
+      'command that is legitimately silent on success (e.g. a bare grep ' +
+      'verifier) can never satisfy this check — the `### Test Strategy` ' +
+      'needs a noisy command that emits output on success. That is a ' +
+      'planner defect: tasks.md is planner-owned and LOCKED during ' +
+      'implement — do NOT edit it. STOP and report `BLOCKED ' +
+      '(planner-defect): silent-success test command` back to the ' +
+      'orchestrator.',
+  };
+}
+
+/**
+ * GH-694 rejection: a Type=tests-only GREEN whose in-scope test files are all
+ * byte-identical to HEAD proves nothing — the GH-689 gate recorded GREEN by
+ * re-running an untouched pre-existing suite while the task's actual
+ * deliverable never existed. NOT a planner defect: the rejection flows into
+ * the existing dispatch-retry and the developer fixes it by writing the
+ * declared tests. Audited as `tdd-green-tests-only-unchanged-rejected`.
+ */
+function gateTestsOnlyUnchangedRejection(p) {
+  appendGateAudit(p.tasksBase, p.ticketId, {
+    origin: 'workflow',
+    task: p.taskNum || null,
+    phase: 'green',
+    action: 'tdd-green-tests-only-unchanged-rejected',
+    allow: false,
+    reason: 'tests-only-no-changed-test-files',
+    outputPath: null,
+    meta: { testCommand: p.cmd, taskType: p.taskType || null, capturedByGate: true },
+  });
+  return {
+    rejected: true,
+    kind: 'tests-only-unchanged',
+    reason:
+      'Type=tests-only GREEN requires at least one declared in-scope ' +
+      '*.test.* / *.spec.* file modified vs HEAD — running an unchanged ' +
+      `pre-existing suite is not evidence (task ${p.taskNum}). Write the ` +
+      'tests the task declares, then re-run. Note: committing the test ' +
+      'files mid-implement also empties this diff (detection is vs HEAD, ' +
+      'recorder parity per GH-528).',
+  };
+}
+
+/**
+ * PR #717 rejection: a Type=tests-only GREEN whose `### Files in scope`
+ * could not be resolved (unreadable/unparseable tasks.md, or the task block
+ * is missing from it) must fail CLOSED — the shared changed-test-files rule
+ * treats an empty scope as "any changed test file counts", so degrading a
+ * resolution failure to `[]` would let an unrelated test change satisfy the
+ * gate. Audited as `tdd-green-tests-only-scope-unresolved-rejected`.
+ */
+function gateTestsOnlyScopeUnresolvedRejection(p) {
+  appendGateAudit(p.tasksBase, p.ticketId, {
+    origin: 'workflow',
+    task: p.taskNum || null,
+    phase: 'green',
+    action: 'tdd-green-tests-only-scope-unresolved-rejected',
+    allow: false,
+    reason: 'tests-only-scope-unresolved',
+    outputPath: null,
+    meta: {
+      testCommand: p.cmd,
+      taskType: p.taskType || null,
+      capturedByGate: true,
+      scopeError: p.scopeError || null,
+    },
+  });
+  return {
+    rejected: true,
+    kind: 'tests-only-scope-unresolved',
+    reason:
+      `Type=tests-only GREEN for task ${p.taskNum}: the task's declared ` +
+      '`### Files in scope` could not be resolved' +
+      (p.scopeError ? ` (${p.scopeError})` : '') +
+      ' — failing closed instead of widening to "any changed test file ' +
+      'counts". tasks.md is planner-owned and locked during implement: ' +
+      'restore a parseable tasks.md containing this task (e.g. `git ' +
+      'checkout -- tasks.md` from the plan commit) or STOP and report ' +
+      'BLOCKED to the orchestrator, then re-run.',
+  };
+}
+
+module.exports = {
+  appendGateAudit,
+  gateHangRejection,
+  gateLoadFailureRejection,
+  gateEmptyOutputRejection,
+  gateTestsOnlyUnchangedRejection,
+  gateTestsOnlyScopeUnresolvedRejection,
+};

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state/gate-writer.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state/gate-writer.js
@@ -34,9 +34,8 @@
 const path = require('path');
 
 const { writeStateAtomic } = require('./state-path');
-const { formatTestTimeout } = require('./io');
 // GH-532 — same RED load-failure heuristic the recorder applies.
-const { detectRedLoadFailure, extractLoadFailureSnippet } = require('../lib/red-load-failure');
+const { detectRedLoadFailure } = require('../lib/red-load-failure');
 // RC-D — same empty-output trap the recorder applies (record-cycle.js
 // GREEN_EMPTY_MSG), armed per-Type by the SAME gateContractFor().rcdEmptyTrap
 // flag the recorder's --docs-exempt path honors (active-task.js).
@@ -48,83 +47,16 @@ const { detectChangedTestFilesInScope } = require('../lib/changed-test-files');
 const { gateContractFor } = require(
   path.join(__dirname, '..', '..', '..', '..', 'skills', 'split-in-tasks', 'lib', 'task-types')
 );
-
-/** Best-effort enforcement audit row scoped to the gate's own tasks base. */
-function appendGateAudit(tasksBase, ticketId, entry) {
-  try {
-    const { appendEnforcementAuditAt } = require('../../work/lib/work-actions');
-    appendEnforcementAuditAt(tasksBase, ticketId, entry);
-  } catch {
-    /* fail-open on audit write — the gate decision is the source of truth */
-  }
-}
-
-/**
- * W5 §4 + W3 message policy — hang rejection shared by the gate's pre- and
- * post-implement paths. A timed-out run is a HANG, not a test outcome: the
- * killed process's non-zero exit must never record as RED, and it can never
- * legitimately record as GREEN. Appends a `tdd-<phase>-hang-rejected` audit
- * row and returns the planner-defect rejection the gate turns into an
- * operator-hold retry.
- *
- * @param {object} p - { tasksBase, ticketId, taskNum, phase, cmd, timeoutMs }
- * @returns {{ rejected: true, kind: 'hang', plannerDefect: true, reason: string }}
- */
-function gateHangRejection(p) {
-  appendGateAudit(p.tasksBase, p.ticketId, {
-    origin: 'workflow',
-    task: p.taskNum || null,
-    phase: p.phase,
-    action: `tdd-${p.phase}-hang-rejected`,
-    allow: false,
-    reason: 'test-command-timeout',
-    outputPath: null,
-    meta: { testCommand: p.cmd, timeoutMs: p.timeoutMs, capturedByGate: true },
-  });
-  const label = formatTestTimeout(p.timeoutMs);
-  return {
-    rejected: true,
-    kind: 'hang',
-    plannerDefect: true,
-    reason:
-      `Test command for task ${p.taskNum} timed out (${label}) at the gate. ` +
-      'A hang is not a test outcome — the command must run to completion. ' +
-      'This usually means a watch-mode or interactive command in the ' +
-      '`### Test Strategy` block, which is a planner defect. tasks.md is ' +
-      'planner-owned and LOCKED during implement — do NOT edit it. STOP and ' +
-      'report `BLOCKED (planner-defect): test command hangs ' +
-      '(watch-mode/interactive)` back to the orchestrator.',
-  };
-}
-
-/** Load-failure rejection: audit row + agent-actionable reason (fix the test file). */
-function gateLoadFailureRejection(p, loadFailure) {
-  appendGateAudit(p.tasksBase, p.ticketId, {
-    origin: 'workflow',
-    task: p.taskNum || null,
-    phase: 'red',
-    action: 'tdd-red-load-failure-rejected',
-    allow: false,
-    reason: loadFailure.signature,
-    outputPath: null,
-    meta: {
-      testCommand: p.cmd,
-      signature: loadFailure.signature,
-      snippet: extractLoadFailureSnippet(loadFailure.line),
-      capturedByGate: true,
-    },
-  });
-  return {
-    rejected: true,
-    kind: 'load-failure',
-    reason:
-      `Rejected RED at the gate: detected ${loadFailure.signature} in the test ` +
-      'runner output. The test file is structurally broken (load-time error or ' +
-      'zero tests collected), not a behavior gap — this exact crash would repeat ' +
-      'regardless of source edits and wedge GREEN. Fix the test file so it loads ' +
-      'and fails on assertions; the gate re-runs the command on the next pass.',
-  };
-}
+// Rejection builders (audit row + message bodies) — extracted verbatim to
+// gate-rejections.js (file-size burndown); this module decides WHEN they fire.
+const {
+  appendGateAudit,
+  gateHangRejection,
+  gateLoadFailureRejection,
+  gateEmptyOutputRejection,
+  gateTestsOnlyUnchangedRejection,
+  gateTestsOnlyScopeUnresolvedRejection,
+} = require('./gate-rejections');
 
 /**
  * Write authentic gate-captured RED evidence, applying the recorder's traps
@@ -176,74 +108,6 @@ function writeGateRed(p) {
 }
 
 /**
- * RC-D rejection at the gate: an exit-0 run with zero stdout+stderr proves
- * nothing (the recorder refuses the identical run via GREEN_EMPTY_MSG).
- * Re-running a silent-success command is always empty again, so this is a
- * planner defect (noisy command needed) — W3 policy: never suggest editing
- * tasks.md. Audited as `tdd-green-empty-rejected` so the refusal is visible.
- */
-function gateEmptyOutputRejection(p) {
-  appendGateAudit(p.tasksBase, p.ticketId, {
-    origin: 'workflow',
-    task: p.taskNum || null,
-    phase: 'green',
-    action: 'tdd-green-empty-rejected',
-    allow: false,
-    reason: 'empty-output-exit-0',
-    outputPath: null,
-    meta: { testCommand: p.cmd, taskType: p.taskType || null, capturedByGate: true },
-  });
-  return {
-    rejected: true,
-    kind: 'empty-output',
-    plannerDefect: true,
-    reason:
-      `GREEN for task ${p.taskNum} exited 0 with NO stdout/stderr output at ` +
-      'the gate. Real test runs always emit output — this is the RC-D ' +
-      'empty-output trap the recorder applies to the identical run. A ' +
-      'command that is legitimately silent on success (e.g. a bare grep ' +
-      'verifier) can never satisfy this check — the `### Test Strategy` ' +
-      'needs a noisy command that emits output on success. That is a ' +
-      'planner defect: tasks.md is planner-owned and LOCKED during ' +
-      'implement — do NOT edit it. STOP and report `BLOCKED ' +
-      '(planner-defect): silent-success test command` back to the ' +
-      'orchestrator.',
-  };
-}
-
-/**
- * GH-694 rejection: a Type=tests-only GREEN whose in-scope test files are all
- * byte-identical to HEAD proves nothing — the GH-689 gate recorded GREEN by
- * re-running an untouched pre-existing suite while the task's actual
- * deliverable never existed. NOT a planner defect: the rejection flows into
- * the existing dispatch-retry and the developer fixes it by writing the
- * declared tests. Audited as `tdd-green-tests-only-unchanged-rejected`.
- */
-function gateTestsOnlyUnchangedRejection(p) {
-  appendGateAudit(p.tasksBase, p.ticketId, {
-    origin: 'workflow',
-    task: p.taskNum || null,
-    phase: 'green',
-    action: 'tdd-green-tests-only-unchanged-rejected',
-    allow: false,
-    reason: 'tests-only-no-changed-test-files',
-    outputPath: null,
-    meta: { testCommand: p.cmd, taskType: p.taskType || null, capturedByGate: true },
-  });
-  return {
-    rejected: true,
-    kind: 'tests-only-unchanged',
-    reason:
-      'Type=tests-only GREEN requires at least one declared in-scope ' +
-      '*.test.* / *.spec.* file modified vs HEAD — running an unchanged ' +
-      `pre-existing suite is not evidence (task ${p.taskNum}). Write the ` +
-      'tests the task declares, then re-run. Note: committing the test ' +
-      'files mid-implement also empties this diff (detection is vs HEAD, ' +
-      'recorder parity per GH-528).',
-  };
-}
-
-/**
  * Atomically persist prebuilt GREEN-augmented evidence (built by the gate's
  * `buildGreenEvidence`). Defensively rejects a timed-out run — a hang is not
  * a pass — mirroring the recorder-side W5 policy. Applies the recorder's
@@ -260,10 +124,15 @@ function gateTestsOnlyUnchangedRejection(p) {
  * (audit-only field — validateTddEvidenceForType deliberately does NOT
  * check it, so pre-change gate evidence keeps validating).
  *
+ * PR #717: `scope` must be an ARRAY for tests-only — `[]` means the task
+ * legitimately declared no scope (recorder's empty-scope semantics), while
+ * a non-array (null) means the caller could not RESOLVE the scope and the
+ * GREEN is rejected fail-closed (`scopeError` carries the cause).
+ *
  * @param {object} p - { tasksBase, ticketId, taskNum, evidencePath, evidence,
  *                       cmd, output?, taskType?, workingDir?, scope?,
- *                       timedOut?, timeoutMs? }
- * @returns {{ written: true } | { rejected: true, kind: 'hang'|'empty-output'|'tests-only-unchanged', reason: string, plannerDefect?: true }}
+ *                       scopeError?, timedOut?, timeoutMs? }
+ * @returns {{ written: true } | { rejected: true, kind: 'hang'|'empty-output'|'tests-only-unchanged'|'tests-only-scope-unresolved', reason: string, plannerDefect?: true }}
  */
 function writeGateGreen(p) {
   if (p.timedOut) {
@@ -274,17 +143,31 @@ function writeGateGreen(p) {
     return gateEmptyOutputRejection(p);
   }
   if (contract.kind === 'tests-only') {
-    const changedTestFiles = detectChangedTestFilesInScope(p.workingDir, p.scope);
-    if (changedTestFiles.length === 0) {
-      return gateTestsOnlyUnchangedRejection(p);
-    }
-    const greenCycle = Array.isArray(p.evidence?.cycles)
-      ? p.evidence.cycles.find((c) => c && c.green)
-      : null;
-    if (greenCycle) greenCycle.green.testsOnlyChangedFiles = changedTestFiles;
+    const rejection = applyTestsOnlyGreenTrap(p);
+    if (rejection) return rejection;
   }
   writeStateAtomic(p.evidencePath, p.evidence);
   return { written: true };
+}
+
+/**
+ * The GH-694 / PR #717 tests-only GREEN trap: unresolved scope → fail-closed
+ * rejection; no changed in-scope test file → unchanged-suite rejection; else
+ * stamp `green.testsOnlyChangedFiles` on the evidence and return null.
+ */
+function applyTestsOnlyGreenTrap(p) {
+  if (!Array.isArray(p.scope)) {
+    return gateTestsOnlyScopeUnresolvedRejection(p);
+  }
+  const changedTestFiles = detectChangedTestFilesInScope(p.workingDir, p.scope);
+  if (changedTestFiles.length === 0) {
+    return gateTestsOnlyUnchangedRejection(p);
+  }
+  const greenCycle = Array.isArray(p.evidence?.cycles)
+    ? p.evidence.cycles.find((c) => c && c.green)
+    : null;
+  if (greenCycle) greenCycle.green.testsOnlyChangedFiles = changedTestFiles;
+  return null;
 }
 
 /** Build the WORK_SKIP_E2E full-cycle stub (red+green share the stub entry). */

--- a/plugins/work/scripts/workflows/work-implement/tdd-phase-state/gate-writer.js
+++ b/plugins/work/scripts/workflows/work-implement/tdd-phase-state/gate-writer.js
@@ -41,6 +41,10 @@ const { detectRedLoadFailure, extractLoadFailureSnippet } = require('../lib/red-
 // GREEN_EMPTY_MSG), armed per-Type by the SAME gateContractFor().rcdEmptyTrap
 // flag the recorder's --docs-exempt path honors (active-task.js).
 const { isEmptyTestOutput } = require('./record-helpers');
+// GH-694 — the recorder's exact tests-only "declared test files actually
+// changed" rule (GH-528), shared via the extracted module so the gate and
+// task-next.js can never drift (unification invariant).
+const { detectChangedTestFilesInScope } = require('../lib/changed-test-files');
 const { gateContractFor } = require(
   path.join(__dirname, '..', '..', '..', '..', 'skills', 'split-in-tasks', 'lib', 'task-types')
 );
@@ -208,6 +212,38 @@ function gateEmptyOutputRejection(p) {
 }
 
 /**
+ * GH-694 rejection: a Type=tests-only GREEN whose in-scope test files are all
+ * byte-identical to HEAD proves nothing — the GH-689 gate recorded GREEN by
+ * re-running an untouched pre-existing suite while the task's actual
+ * deliverable never existed. NOT a planner defect: the rejection flows into
+ * the existing dispatch-retry and the developer fixes it by writing the
+ * declared tests. Audited as `tdd-green-tests-only-unchanged-rejected`.
+ */
+function gateTestsOnlyUnchangedRejection(p) {
+  appendGateAudit(p.tasksBase, p.ticketId, {
+    origin: 'workflow',
+    task: p.taskNum || null,
+    phase: 'green',
+    action: 'tdd-green-tests-only-unchanged-rejected',
+    allow: false,
+    reason: 'tests-only-no-changed-test-files',
+    outputPath: null,
+    meta: { testCommand: p.cmd, taskType: p.taskType || null, capturedByGate: true },
+  });
+  return {
+    rejected: true,
+    kind: 'tests-only-unchanged',
+    reason:
+      'Type=tests-only GREEN requires at least one declared in-scope ' +
+      '*.test.* / *.spec.* file modified vs HEAD — running an unchanged ' +
+      `pre-existing suite is not evidence (task ${p.taskNum}). Write the ` +
+      'tests the task declares, then re-run. Note: committing the test ' +
+      'files mid-implement also empties this diff (detection is vs HEAD, ' +
+      'recorder parity per GH-528).',
+  };
+}
+
+/**
  * Atomically persist prebuilt GREEN-augmented evidence (built by the gate's
  * `buildGreenEvidence`). Defensively rejects a timed-out run — a hang is not
  * a pass — mirroring the recorder-side W5 policy. Applies the recorder's
@@ -218,9 +254,16 @@ function gateEmptyOutputRejection(p) {
  * mechanical-refactor, unknown → fail closed) refuses a zero-output exit-0
  * GREEN instead of recording it.
  *
+ * GH-694: tests-only GREENs additionally require a changed in-scope test
+ * file (the recorder's GH-528 rule, via the SAME shared function). On
+ * success the changed set is stamped as `green.testsOnlyChangedFiles`
+ * (audit-only field — validateTddEvidenceForType deliberately does NOT
+ * check it, so pre-change gate evidence keeps validating).
+ *
  * @param {object} p - { tasksBase, ticketId, taskNum, evidencePath, evidence,
- *                       cmd, output?, taskType?, timedOut?, timeoutMs? }
- * @returns {{ written: true } | { rejected: true, kind: 'hang'|'empty-output', reason: string, plannerDefect: true }}
+ *                       cmd, output?, taskType?, workingDir?, scope?,
+ *                       timedOut?, timeoutMs? }
+ * @returns {{ written: true } | { rejected: true, kind: 'hang'|'empty-output'|'tests-only-unchanged', reason: string, plannerDefect?: true }}
  */
 function writeGateGreen(p) {
   if (p.timedOut) {
@@ -229,6 +272,16 @@ function writeGateGreen(p) {
   const contract = gateContractFor(p.taskType);
   if (contract.rcdEmptyTrap && isEmptyTestOutput(String(p.output ?? ''), '')) {
     return gateEmptyOutputRejection(p);
+  }
+  if (contract.kind === 'tests-only') {
+    const changedTestFiles = detectChangedTestFilesInScope(p.workingDir, p.scope);
+    if (changedTestFiles.length === 0) {
+      return gateTestsOnlyUnchangedRejection(p);
+    }
+    const greenCycle = Array.isArray(p.evidence?.cycles)
+      ? p.evidence.cycles.find((c) => c && c.green)
+      : null;
+    if (greenCycle) greenCycle.green.testsOnlyChangedFiles = changedTestFiles;
   }
   writeStateAtomic(p.evidencePath, p.evidence);
   return { written: true };

--- a/plugins/work/scripts/workflows/work/__tests__/implement-gate-tests-only-green.integration.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/implement-gate-tests-only-green.integration.test.js
@@ -319,6 +319,52 @@ describe('GH-694 — tests-only scope resolution fails closed (PR #717)', () => 
     assert.match(String(res.reason || ''), /Files in scope.*could not be resolved/i);
   });
 
+  it('task block parses but omits ### Files in scope → passed:false (no widening)', () => {
+    // The block exists and parses fine — only the scope section is missing.
+    // Passing [] through here would let rogue.test.js satisfy the GREEN gate.
+    fs.writeFileSync(
+      path.join(tasksDir, 'tasks.md'),
+      ['## Task 1 — Add tests', '', '### Type', 'tests-only', ''].join('\n')
+    );
+    writeRedEvidence(1, 'tests-only');
+    addUnrelatedChangedTestFile();
+    const res = runTestAndRecord(
+      'echo tests-pass',
+      'GH-TEST',
+      1,
+      worktreeDir,
+      process.env,
+      tasksBase,
+      'tests-only'
+    );
+    assert.equal(res.passed, false, 'declared-scope-less tests-only task must fail closed');
+    assert.match(String(res.reason || ''), /declares no.*Files in scope/i);
+    const ev = JSON.parse(fs.readFileSync(evidencePath(1), 'utf8'));
+    assert.ok(!ev.cycles[0].green, 'GREEN must not be persisted');
+  });
+
+  it('empty ### Files in scope section → passed:false (no widening)', () => {
+    fs.writeFileSync(
+      path.join(tasksDir, 'tasks.md'),
+      ['## Task 1 — Add tests', '', '### Type', 'tests-only', '', '### Files in scope', ''].join(
+        '\n'
+      )
+    );
+    writeRedEvidence(1, 'tests-only');
+    addUnrelatedChangedTestFile();
+    const res = runTestAndRecord(
+      'echo tests-pass',
+      'GH-TEST',
+      1,
+      worktreeDir,
+      process.env,
+      tasksBase,
+      'tests-only'
+    );
+    assert.equal(res.passed, false, 'empty declared scope must fail closed');
+    assert.match(String(res.reason || ''), /declares no.*Files in scope/i);
+  });
+
   it('tdd-code task with missing tasks.md still records GREEN (regression)', () => {
     // Scope only feeds the tests-only trap — other types must not start
     // failing on an unreadable plan (they never consumed scope).

--- a/plugins/work/scripts/workflows/work/__tests__/implement-gate-tests-only-green.integration.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/implement-gate-tests-only-green.integration.test.js
@@ -1,0 +1,283 @@
+/**
+ * GH-694 failure 1 — tests-only GREEN must prove authorship at the gate.
+ *
+ * buildNonTddStub legitimately skips RED for Type=tests-only, but the gate's
+ * GREEN then passed by re-running an untouched pre-existing suite (GH-689
+ * task 2: `guard-codex.test.js` ran green with zero modified test files and
+ * the task's actual deliverable never existed). writeGateGreen — the ONE
+ * atomic gate evidence writer — now applies the recorder's exact GH-528 rule
+ * via the shared lib/changed-test-files module:
+ *
+ *   - zero changed in-scope *.test.* / *.spec.* files → rejected with a
+ *     `tdd-green-tests-only-unchanged-rejected` audit row; NOT a
+ *     plannerDefect (flows into dispatch-retry — the developer fixes it by
+ *     writing the declared tests).
+ *   - with a changed in-scope test file (untracked counts) → GREEN written
+ *     with the audit-only `testsOnlyChangedFiles` stamp.
+ *   - tdd-code / docs GREENs are unaffected (regression).
+ *   - validateTddEvidenceForType is deliberately UNCHANGED: pre-change gate
+ *     evidence (capturedByGate, no testsOnlyChangedFiles) must still
+ *     validate, or in-flight tickets would dead-end (unification invariant).
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const gateWriter = require('../../work-implement/tdd-phase-state/gate-writer');
+const { runTestAndRecord } = require('../lib/step-enrichments/implement-gate/test-runner');
+const { validateTddEvidenceForType } = require('../lib/tdd-enforcement');
+
+// Built by concatenation so the live plugin's state-file protection hooks
+// never see the literal names next to write calls in this fixture script.
+const TDD_EVIDENCE_FILE = ['tdd-phase', 'json'].join('.');
+const ACTIONS_FILE = ['.work-actions', 'json'].join('.');
+
+let tmp;
+let tasksBase;
+let tasksDir;
+let worktreeDir;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh694-tests-only-'));
+  tasksBase = path.join(tmp, 'tasks');
+  tasksDir = path.join(tasksBase, 'GH-TEST');
+  worktreeDir = path.join(tmp, 'wt');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  fs.mkdirSync(worktreeDir, { recursive: true });
+  // Seed a git worktree whose pre-existing in-scope suite is committed and
+  // byte-identical — the exact GH-689 "unchanged suite" shape.
+  git('init', '-q');
+  fs.mkdirSync(path.join(worktreeDir, 'tests'), { recursive: true });
+  fs.writeFileSync(path.join(worktreeDir, 'tests', 'existing.test.js'), 'pre-existing suite\n');
+  git('add', '.');
+  git(
+    '-c',
+    'user.email=fixture@example.com',
+    '-c',
+    'user.name=fixture',
+    'commit',
+    '-q',
+    '-m',
+    'seed'
+  );
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function git(...args) {
+  return execFileSync('git', args, { cwd: worktreeDir, encoding: 'utf8' });
+}
+
+function writeTasksMd(type) {
+  fs.writeFileSync(
+    path.join(tasksDir, 'tasks.md'),
+    [
+      '## Task 1 — Fixture task 1',
+      '',
+      '### Type',
+      type,
+      '',
+      '### Files in scope',
+      '- tests',
+      '',
+    ].join('\n')
+  );
+}
+
+function evidencePath(taskNum) {
+  return path.join(tasksDir, `task${taskNum}`, TDD_EVIDENCE_FILE);
+}
+
+function redStub(taskType) {
+  return {
+    testCommand: 'node --test tests/',
+    testExitCode: 0,
+    timestamp: '2026-07-11T00:00:00.000Z',
+    capturedByGate: true,
+    note: `RED skipped: task type "${taskType}" does not require TDD.`,
+  };
+}
+
+function writeRedEvidence(taskNum, taskType) {
+  fs.mkdirSync(path.dirname(evidencePath(taskNum)), { recursive: true });
+  fs.writeFileSync(
+    evidencePath(taskNum),
+    JSON.stringify({
+      currentPhase: 'green',
+      currentCycle: 1,
+      cycles: [{ cycle: 1, red: redStub(taskType) }],
+    })
+  );
+}
+
+function auditRowsFor(action) {
+  let rows;
+  try {
+    rows = JSON.parse(fs.readFileSync(path.join(tasksDir, ACTIONS_FILE), 'utf8'));
+  } catch {
+    rows = [];
+  }
+  return rows.filter((r) => r && r.kind === 'enforcement' && r.action === action);
+}
+
+// Directory-prefix scope entry (legacy `a/b` → `a/b/**` semantics shared by
+// filterChangedTestFilesByScope) — matches everything under tests/.
+const SCOPE = ['tests'];
+
+function greenParams(extra) {
+  return {
+    tasksBase,
+    ticketId: 'GH-TEST',
+    taskNum: 1,
+    evidencePath: evidencePath(1),
+    evidence: {
+      currentPhase: 'refactor',
+      currentCycle: 1,
+      cycles: [
+        {
+          cycle: 1,
+          red: redStub('tests-only'),
+          green: { testCommand: 'node --test tests/', testExitCode: 0 },
+        },
+      ],
+    },
+    cmd: 'node --test tests/',
+    output: 'ok 1 - existing\n# pass 1\n',
+    taskType: 'tests-only',
+    workingDir: worktreeDir,
+    scope: SCOPE,
+    ...extra,
+  };
+}
+
+describe('GH-694 — writeGateGreen tests-only trap', () => {
+  it('rejects an unchanged pre-existing suite (audited, NOT a planner defect)', () => {
+    const r = gateWriter.writeGateGreen(greenParams());
+    assert.equal(r.rejected, true, 'unchanged suite must not record GREEN');
+    assert.ok(!r.plannerDefect, 'dispatch-retry shape — the developer fixes it, not the planner');
+    assert.match(r.reason, /tests-only GREEN requires/i);
+    assert.match(r.reason, /unchanged pre-existing suite is not evidence/);
+    assert.equal(fs.existsSync(evidencePath(1)), false, 'no GREEN evidence written');
+    const rows = auditRowsFor('tdd-green-tests-only-unchanged-rejected');
+    assert.equal(rows.length, 1, 'rejection is audit-logged');
+    assert.equal(rows[0].allow, false);
+    assert.equal(rows[0].meta.taskType, 'tests-only');
+  });
+
+  it('accepts with a new in-scope test file (untracked counts) and stamps testsOnlyChangedFiles', () => {
+    fs.writeFileSync(path.join(worktreeDir, 'tests', 'new-parity.test.js'), 'new describe block\n');
+    const r = gateWriter.writeGateGreen(greenParams());
+    assert.deepEqual(r, { written: true });
+    const ev = JSON.parse(fs.readFileSync(evidencePath(1), 'utf8'));
+    assert.deepEqual(
+      ev.cycles[0].green.testsOnlyChangedFiles,
+      ['tests/new-parity.test.js'],
+      'audit-only stamp names the changed in-scope test files'
+    );
+    assert.equal(auditRowsFor('tdd-green-tests-only-unchanged-rejected').length, 0);
+  });
+
+  it('does not trap tdd-code or docs GREENs (regression)', () => {
+    for (const taskType of ['tdd-code', 'docs']) {
+      try {
+        fs.rmSync(evidencePath(1));
+      } catch {
+        /* first iteration */
+      }
+      const r = gateWriter.writeGateGreen(greenParams({ taskType }));
+      assert.deepEqual(r, { written: true }, `${taskType} must not hit the tests-only trap`);
+    }
+    assert.equal(auditRowsFor('tdd-green-tests-only-unchanged-rejected').length, 0);
+  });
+});
+
+describe('GH-694 — persistGateGreen threads workingDir + scope (via runTestAndRecord)', () => {
+  it('unchanged suite → passed:false dispatch-retry with the tests-only reason', () => {
+    writeTasksMd('tests-only');
+    writeRedEvidence(1, 'tests-only');
+    const res = runTestAndRecord(
+      'echo tests-pass',
+      'GH-TEST',
+      1,
+      worktreeDir,
+      process.env,
+      tasksBase,
+      'tests-only'
+    );
+    assert.equal(res.passed, false, 'unchanged suite must not pass the gate');
+    assert.ok(!res.plannerDefect, 'NOT plannerDefect — flows into dispatch-retry');
+    assert.match(String(res.reason || ''), /tests-only GREEN requires/i);
+    assert.equal(auditRowsFor('tdd-green-tests-only-unchanged-rejected').length, 1);
+  });
+
+  it('new in-scope test file → passed:true with the evidence stamped', () => {
+    writeTasksMd('tests-only');
+    writeRedEvidence(1, 'tests-only');
+    fs.writeFileSync(path.join(worktreeDir, 'tests', 'new-parity.test.js'), 'new describe block\n');
+    const res = runTestAndRecord(
+      'echo tests-pass',
+      'GH-TEST',
+      1,
+      worktreeDir,
+      process.env,
+      tasksBase,
+      'tests-only'
+    );
+    assert.equal(res.passed, true, `expected pass, got ${JSON.stringify(res)}`);
+    const ev = JSON.parse(fs.readFileSync(evidencePath(1), 'utf8'));
+    assert.deepEqual(ev.cycles[0].green.testsOnlyChangedFiles, ['tests/new-parity.test.js']);
+  });
+
+  it('tdd-code task with an unchanged tree still records GREEN (regression)', () => {
+    writeTasksMd('tdd-code');
+    writeRedEvidence(1, 'tdd-code');
+    const res = runTestAndRecord(
+      'echo tests-pass',
+      'GH-TEST',
+      1,
+      worktreeDir,
+      process.env,
+      tasksBase,
+      'tdd-code'
+    );
+    assert.equal(res.passed, true, `expected pass, got ${JSON.stringify(res)}`);
+  });
+});
+
+describe('GH-694 — validator unchanged (unification-invariant pin)', () => {
+  it('validateTddEvidenceForType still accepts pre-change tests-only gate evidence', () => {
+    // Evidence recorded by the gate BEFORE this change: capturedByGate, no
+    // testsOnlyChangedFiles stamp. A retroactive validator rule would
+    // dead-end every in-flight ticket at the next downstream re-validation.
+    const preChange = {
+      currentPhase: 'refactor',
+      currentCycle: 1,
+      cycles: [
+        {
+          cycle: 1,
+          red: redStub('tests-only'),
+          green: {
+            testCommand: 'node --test tests/',
+            testExitCode: 0,
+            timestamp: '2026-07-01T00:00:00.000Z',
+            capturedByGate: true,
+          },
+        },
+      ],
+    };
+    const v = validateTddEvidenceForType(preChange, 'tests-only');
+    assert.equal(v.valid, true, `pre-change gate evidence must stay valid (got: ${v.reason})`);
+  });
+});

--- a/plugins/work/scripts/workflows/work/__tests__/implement-gate-tests-only-green.integration.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/implement-gate-tests-only-green.integration.test.js
@@ -256,6 +256,86 @@ describe('GH-694 — persistGateGreen threads workingDir + scope (via runTestAnd
   });
 });
 
+describe('GH-694 — tests-only scope resolution fails closed (PR #717)', () => {
+  // A changed test file that WOULD count under widened (empty) scope
+  // semantics — proves the gate is failing closed, not just "no changes".
+  function addUnrelatedChangedTestFile() {
+    fs.writeFileSync(path.join(worktreeDir, 'tests', 'rogue.test.js'), 'unrelated new suite\n');
+  }
+
+  it('writeGateGreen rejects a tests-only GREEN with unresolved (null) scope', () => {
+    addUnrelatedChangedTestFile();
+    const r = gateWriter.writeGateGreen(
+      greenParams({ scope: null, scopeError: 'tasks.md unreadable (fixture)' })
+    );
+    assert.equal(r.rejected, true, 'unresolved scope must not record GREEN');
+    assert.equal(r.kind, 'tests-only-scope-unresolved');
+    assert.match(r.reason, /failing closed/i);
+    assert.match(r.reason, /tasks\.md unreadable \(fixture\)/);
+    assert.equal(fs.existsSync(evidencePath(1)), false, 'no GREEN evidence written');
+    const rows = auditRowsFor('tdd-green-tests-only-scope-unresolved-rejected');
+    assert.equal(rows.length, 1, 'rejection is audit-logged');
+    assert.equal(rows[0].allow, false);
+  });
+
+  it('missing tasks.md + unrelated changed test file → passed:false (no widening)', () => {
+    // No writeTasksMd(): parseTasks returns null. Today the scope degrades
+    // to [] and rogue.test.js counts — the exact widening in the finding.
+    writeRedEvidence(1, 'tests-only');
+    addUnrelatedChangedTestFile();
+    const res = runTestAndRecord(
+      'echo tests-pass',
+      'GH-TEST',
+      1,
+      worktreeDir,
+      process.env,
+      tasksBase,
+      'tests-only'
+    );
+    assert.equal(res.passed, false, 'unresolvable scope must fail closed, not widen');
+    assert.match(String(res.reason || ''), /Files in scope.*could not be resolved/i);
+    const ev = JSON.parse(fs.readFileSync(evidencePath(1), 'utf8'));
+    assert.ok(!ev.cycles[0].green, 'GREEN must not be persisted');
+    assert.equal(auditRowsFor('tdd-green-tests-only-scope-unresolved-rejected').length, 1);
+  });
+
+  it('tasks.md without the gated task number → passed:false for tests-only', () => {
+    fs.writeFileSync(
+      path.join(tasksDir, 'tasks.md'),
+      ['## Task 2 — Some other task', '', '### Type', 'tests-only', ''].join('\n')
+    );
+    writeRedEvidence(1, 'tests-only');
+    addUnrelatedChangedTestFile();
+    const res = runTestAndRecord(
+      'echo tests-pass',
+      'GH-TEST',
+      1,
+      worktreeDir,
+      process.env,
+      tasksBase,
+      'tests-only'
+    );
+    assert.equal(res.passed, false, 'task missing from the plan must fail closed');
+    assert.match(String(res.reason || ''), /Files in scope.*could not be resolved/i);
+  });
+
+  it('tdd-code task with missing tasks.md still records GREEN (regression)', () => {
+    // Scope only feeds the tests-only trap — other types must not start
+    // failing on an unreadable plan (they never consumed scope).
+    writeRedEvidence(1, 'tdd-code');
+    const res = runTestAndRecord(
+      'echo tests-pass',
+      'GH-TEST',
+      1,
+      worktreeDir,
+      process.env,
+      tasksBase,
+      'tdd-code'
+    );
+    assert.equal(res.passed, true, `expected pass, got ${JSON.stringify(res)}`);
+  });
+});
+
 describe('GH-694 — validator unchanged (unification-invariant pin)', () => {
   it('validateTddEvidenceForType still accepts pre-change tests-only gate evidence', () => {
     // Evidence recorded by the gate BEFORE this change: capturedByGate, no

--- a/plugins/work/scripts/workflows/work/__tests__/phase-ledger.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/phase-ledger.test.js
@@ -1,0 +1,255 @@
+'use strict';
+
+/**
+ * Tests for lib/phase-ledger.js (GH-696) — the ONE shared "inner phase ledger
+ * is terminal" predicate — plus its verifier consumers: step verifiers
+ * (verifyBrief/verifySpec/verifyTasks) and gate verifiers (verifyBriefGate/
+ * verifySpecGate) must refuse to vouch while the step's *-phase.json ledger
+ * is mid-flight (the GH-689 race: outer auto-advance closed the artifact
+ * window while the writer agent was mid-DRAFT).
+ *
+ * Contract:
+ *   - absent ledger file      → not blocked (legacy/pre-phase-driver tickets)
+ *   - currentPhase terminal   → not blocked
+ *   - currentPhase non-terminal → blocked
+ *   - unreadable/corrupt JSON → blocked, currentPhase UNPARSEABLE_PHASE (fail
+ *     closed; repair = operator escalation — re-dispatch cannot fix a corrupt
+ *     ledger, the runner dies reading the same file; the plan matrix routes
+ *     to AskUserQuestion instead, PR #718)
+ *
+ * Run: node --test workflows/work/__tests__/phase-ledger.test.js
+ */
+
+const { describe, it, beforeEach, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { phaseLedgerBlocked, STEP_LEDGERS, UNPARSEABLE_PHASE } = require('../lib/phase-ledger');
+const { createStepVerifiers } = require('../workflow-def/step-verifiers');
+const { createGateVerifiers } = require('../workflow-def/gate-verifiers');
+
+const workRoot = path.join(__dirname, '..');
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'phase-ledger-'));
+const ticketId = 'GH-696';
+const ticketDir = path.join(tmpRoot, ticketId);
+fs.mkdirSync(ticketDir, { recursive: true });
+
+function writeLedger(file, currentPhase) {
+  fs.writeFileSync(path.join(ticketDir, file), JSON.stringify({ currentPhase }), 'utf-8');
+}
+
+function clearTicketDir() {
+  for (const f of fs.readdirSync(ticketDir)) {
+    fs.rmSync(path.join(ticketDir, f), { recursive: true, force: true });
+  }
+}
+
+after(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+// ─── phaseLedgerBlocked truth table ─────────────────────────────────────────
+
+describe('phase-ledger: phaseLedgerBlocked (GH-696)', () => {
+  beforeEach(clearTicketDir);
+
+  it('maps brief/spec/tasks to their ledger files with terminal "done"', () => {
+    assert.equal(STEP_LEDGERS.brief.file, 'brief-phase.json');
+    assert.equal(STEP_LEDGERS.spec.file, 'spec-phase.json');
+    assert.equal(STEP_LEDGERS.tasks.file, 'tasks-phase.json');
+    for (const step of ['brief', 'spec', 'tasks']) {
+      assert.equal(STEP_LEDGERS[step].terminal, 'done');
+    }
+  });
+
+  it('absent ledger file → not blocked (legacy/pre-phase-driver tickets)', () => {
+    for (const step of ['brief', 'spec', 'tasks']) {
+      assert.deepEqual(phaseLedgerBlocked(ticketDir, step), {
+        blocked: false,
+        currentPhase: null,
+      });
+    }
+  });
+
+  it('non-terminal currentPhase → blocked, phase surfaced', () => {
+    writeLedger('brief-phase.json', 'draft');
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'brief'), {
+      blocked: true,
+      currentPhase: 'draft',
+    });
+    writeLedger('spec-phase.json', 'surface_audit');
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'spec'), {
+      blocked: true,
+      currentPhase: 'surface_audit',
+    });
+    writeLedger('tasks-phase.json', 'requirements_extract');
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'tasks'), {
+      blocked: true,
+      currentPhase: 'requirements_extract',
+    });
+  });
+
+  it('terminal currentPhase "done" → not blocked', () => {
+    for (const [step, file] of [
+      ['brief', 'brief-phase.json'],
+      ['spec', 'spec-phase.json'],
+      ['tasks', 'tasks-phase.json'],
+    ]) {
+      writeLedger(file, 'done');
+      assert.deepEqual(phaseLedgerBlocked(ticketDir, step), {
+        blocked: false,
+        currentPhase: 'done',
+      });
+    }
+  });
+
+  it('corrupt ledger JSON → blocked with currentPhase UNPARSEABLE_PHASE (fail closed; repair: operator escalation — the plan matrix asks the user to delete/restore the ledger, PR #718)', () => {
+    fs.writeFileSync(path.join(ticketDir, 'brief-phase.json'), '{not json', 'utf-8');
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'brief'), {
+      blocked: true,
+      currentPhase: UNPARSEABLE_PHASE,
+    });
+    assert.equal(UNPARSEABLE_PHASE, 'unparseable'); // sentinel pinned — steps key on it
+  });
+
+  it('parseable ledger without a string currentPhase → blocked "unparseable" (refusal to vouch)', () => {
+    fs.writeFileSync(path.join(ticketDir, 'spec-phase.json'), JSON.stringify({}), 'utf-8');
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'spec'), {
+      blocked: true,
+      currentPhase: 'unparseable',
+    });
+  });
+
+  it('steps without a registered ledger → never blocked (map-driven)', () => {
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'pr'), { blocked: false, currentPhase: null });
+  });
+});
+
+// ─── Step verifiers consume the predicate ───────────────────────────────────
+
+describe('phase-ledger: step verifiers refuse mid-flight ledgers (GH-696)', () => {
+  const v = createStepVerifiers({ TASKS_BASE: tmpRoot, safeTicketPath: (id) => id, workRoot });
+
+  beforeEach(clearTicketDir);
+
+  const MATRIX = [
+    ['verifyBrief', 'brief.md', 'brief-phase.json', 'draft'],
+    ['verifySpec', 'spec.md', 'spec-phase.json', 'surface_audit'],
+    ['verifyTasks', 'tasks.md', 'tasks-phase.json', 'draft'],
+  ];
+
+  for (const [verifier, artifact, ledgerFile, midPhase] of MATRIX) {
+    it(`${verifier}: artifact + no ledger → true (regression: legacy tickets advance as today)`, () => {
+      fs.writeFileSync(path.join(ticketDir, artifact), '# content\n', 'utf-8');
+      assert.equal(v[verifier](ticketId), true);
+    });
+
+    it(`${verifier}: artifact + ${ledgerFile} at "${midPhase}" → false (mid-flight)`, () => {
+      fs.writeFileSync(path.join(ticketDir, artifact), '# content\n', 'utf-8');
+      writeLedger(ledgerFile, midPhase);
+      assert.equal(v[verifier](ticketId), false);
+    });
+
+    it(`${verifier}: artifact + ${ledgerFile} at "done" → true`, () => {
+      fs.writeFileSync(path.join(ticketDir, artifact), '# content\n', 'utf-8');
+      writeLedger(ledgerFile, 'done');
+      assert.equal(v[verifier](ticketId), true);
+    });
+
+    it(`${verifier}: artifact + corrupt ${ledgerFile} → false (fail closed; repair: operator escalation via the plan matrix, PR #718)`, () => {
+      fs.writeFileSync(path.join(ticketDir, artifact), '# content\n', 'utf-8');
+      fs.writeFileSync(path.join(ticketDir, ledgerFile), '{not json', 'utf-8');
+      assert.equal(v[verifier](ticketId), false);
+    });
+
+    it(`${verifier}: missing artifact → false regardless of ledger`, () => {
+      writeLedger(ledgerFile, 'done');
+      assert.equal(v[verifier](ticketId), false);
+    });
+  }
+
+  it('does not consult sibling ledgers (brief ignores spec-phase.json)', () => {
+    fs.writeFileSync(path.join(ticketDir, 'brief.md'), '# content\n', 'utf-8');
+    writeLedger('spec-phase.json', 'surface_audit');
+    assert.equal(v.verifyBrief(ticketId), true);
+  });
+});
+
+// ─── Gate verifiers consume the predicate ───────────────────────────────────
+
+describe('phase-ledger: gate verifiers refuse mid-flight ledgers (GH-696)', () => {
+  const g = createGateVerifiers({
+    TASKS_BASE: tmpRoot,
+    safeTicketPath: (id) => id,
+    resolveGitHead: () => 'ref: refs/heads/stub',
+    workRoot,
+  });
+
+  beforeEach(clearTicketDir);
+
+  function writePassingBrief() {
+    fs.writeFileSync(path.join(ticketDir, 'brief.md'), '# Brief\n\nNo open questions.\n', 'utf-8');
+  }
+
+  function writePassingSpec() {
+    fs.writeFileSync(path.join(ticketDir, 'spec.md'), '# Spec\n', 'utf-8');
+    fs.writeFileSync(
+      path.join(ticketDir, 'gherkin.feature'),
+      '<!-- gherkin-skip: test fixture -->\nFeature: F\n  Scenario: S\n    Given g\n    When w\n    Then t\n',
+      'utf-8'
+    );
+  }
+
+  it('verifyBriefGate: valid brief + no ledger → true (regression)', () => {
+    writePassingBrief();
+    assert.equal(g.verifyBriefGate(ticketId), true);
+  });
+
+  it('verifyBriefGate: valid brief + brief-phase.json at "draft" → false (GH-689 window pin)', () => {
+    writePassingBrief();
+    writeLedger('brief-phase.json', 'draft');
+    assert.equal(g.verifyBriefGate(ticketId), false);
+  });
+
+  it('verifyBriefGate: valid brief + brief-phase.json at "done" → true', () => {
+    writePassingBrief();
+    writeLedger('brief-phase.json', 'done');
+    assert.equal(g.verifyBriefGate(ticketId), true);
+  });
+
+  it('verifyBriefGate: corrupt brief-phase.json → false (fail closed)', () => {
+    writePassingBrief();
+    fs.writeFileSync(path.join(ticketDir, 'brief-phase.json'), '{not json', 'utf-8');
+    assert.equal(g.verifyBriefGate(ticketId), false);
+  });
+
+  it('verifySpecGate: valid spec + no ledger → true (regression)', () => {
+    writePassingSpec();
+    assert.equal(g.verifySpecGate(ticketId), true);
+  });
+
+  it('verifySpecGate: valid spec + spec-phase.json at "surface_audit" → false (GH-689 window pin)', () => {
+    writePassingSpec();
+    writeLedger('spec-phase.json', 'surface_audit');
+    assert.equal(g.verifySpecGate(ticketId), false);
+  });
+
+  it('verifySpecGate: valid spec + spec-phase.json at "done" → true', () => {
+    writePassingSpec();
+    writeLedger('spec-phase.json', 'done');
+    assert.equal(g.verifySpecGate(ticketId), true);
+  });
+
+  it('verifySpecGate: corrupt spec-phase.json → false (fail closed)', () => {
+    writePassingSpec();
+    fs.writeFileSync(path.join(ticketDir, 'spec-phase.json'), '{not json', 'utf-8');
+    assert.equal(g.verifySpecGate(ticketId), false);
+  });
+});

--- a/plugins/work/scripts/workflows/work/__tests__/transition-step.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/transition-step.test.js
@@ -1024,3 +1024,89 @@ describe('transition-step.js (GH-693): commit-evidence gate', () => {
     }
   });
 });
+
+describe('transition-step.js (GH-694): multiTaskGate all-statuses', () => {
+  const TICKET = 'TEST-694';
+
+  function depsWithTasks(tasks, currentTaskIndex) {
+    const { STEPS, ALL_STEPS } = require('../step-registry');
+    const deps = createDeps({ workflowCanTransition: () => true });
+    const ws = deps.loadWorkState(TICKET);
+    ws.currentStep = ALL_STEPS.indexOf(STEPS.implement) + 1;
+    ws.stepStatus[STEPS.implement] = 'in_progress';
+    if (tasks) {
+      ws.tasksMeta = { totalTasks: tasks.length, currentTaskIndex, tasks };
+    }
+    deps._savedStates[TICKET] = ws;
+    return deps;
+  }
+
+  it('blocks implement -> commit with the pointer AT a pending last task (off-by-one pin)', () => {
+    // GH-689 shape: currentTaskIndex points at the last task, which is still
+    // pending — the old pointer-only check (currentIdx >= totalTasks - 1)
+    // returned null here and let implement close over the dangling task.
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    const deps = depsWithTasks(
+      [
+        { id: 'task_1', status: 'completed' },
+        { id: 'task_2', status: 'completed' },
+        { id: 'task_3', status: 'pending' },
+      ],
+      2
+    );
+    const result = transitionStep(TICKET, STEPS.commit, deps);
+    assert.equal(result.error, true, 'pending last task must block leaving implement');
+    assert.equal(result.gate, 'multi-task');
+    assert.match(result.message, /task_3/, 'message must list the pending task id');
+    assert.match(result.message, /work-next\.js/, 'message must name the work-next repair');
+  });
+
+  it('blocks implement -> commit with a pending checkpoint task (checkpoints NOT exempt)', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    const deps = depsWithTasks(
+      [
+        { id: 'task_1', status: 'completed' },
+        { id: 'task_2', status: 'pending', kind: 'checkpoint' },
+      ],
+      2
+    );
+    const result = transitionStep(TICKET, STEPS.commit, deps);
+    assert.equal(result.error, true, 'pending checkpoint task must block leaving implement');
+    assert.equal(result.gate, 'multi-task');
+    assert.match(result.message, /task_2/, 'message must list the pending checkpoint id');
+  });
+
+  it('treats a malformed entry with no status as pending (fail closed)', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    const deps = depsWithTasks([{ id: 'task_1' }], 1);
+    const result = transitionStep(TICKET, STEPS.commit, deps);
+    assert.equal(result.error, true, 'missing status must count as pending');
+    assert.equal(result.gate, 'multi-task');
+    assert.match(result.message, /task_1/);
+  });
+
+  it('passes when every task status is completed', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    const deps = depsWithTasks(
+      [
+        { id: 'task_1', status: 'completed' },
+        { id: 'task_2', status: 'completed' },
+      ],
+      2
+    );
+    const result = transitionStep(TICKET, STEPS.commit, deps);
+    assert.equal(result.success, true, `expected success, got ${JSON.stringify(result)}`);
+  });
+
+  it('single-task mode (no tasksMeta) is unchanged', () => {
+    const { transitionStep } = require('../engine/transition-step');
+    const { STEPS } = require('../step-registry');
+    const deps = depsWithTasks(null);
+    const result = transitionStep(TICKET, STEPS.commit, deps);
+    assert.equal(result.success, true, `expected success, got ${JSON.stringify(result)}`);
+  });
+});

--- a/plugins/work/scripts/workflows/work/__tests__/work-auto-advance-runtime.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-auto-advance-runtime.test.js
@@ -78,7 +78,14 @@ describe('work-auto-advance — dual runtime', () => {
   function runHook(payload, env = {}) {
     const merged = { ...process.env, ...envBase, ...env };
     // Scrub ambient runtime signals so each row controls detection fully.
-    for (const key of ['AGENT_RUNTIME', 'AGENT_SESSION_ID', 'CODEX_THREAD_ID', 'PLUGIN_ROOT']) {
+    for (const key of [
+      'AGENT_RUNTIME',
+      'AGENT_SESSION_ID',
+      'CODEX_THREAD_ID',
+      'PLUGIN_ROOT',
+      'CLAUDE_AGENT_TYPE',
+      'CLAUDE_CURRENT_AGENT',
+    ]) {
       if (!(key in env)) delete merged[key];
     }
     const r = spawnSync(process.execPath, [HOOK], {
@@ -173,5 +180,59 @@ describe('work-auto-advance — dual runtime', () => {
     );
     assert.equal(r.code, 0);
     assert.equal(r.stdout, '');
+  });
+
+  // GH-696: claude PostToolUse payloads fired during a subagent's tool calls
+  // carry agent identity in the RAW payload (agent_type/agent_id) even when
+  // the transcript path lacks /subagents/ — auto-advance must abstain.
+  it('subagent guard (GH-696): claude payload with native agent_type is silent — work-next never invoked', () => {
+    const r = runHook(
+      {
+        tool_name: 'Task',
+        transcript_path: '/tmp/t.jsonl',
+        session_id: 'sess-1',
+        agent_type: 'pr-generator',
+      },
+      { AGENT_RUNTIME: 'claude' }
+    );
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout, '');
+  });
+
+  it('subagent guard (GH-696): claude payload with native agent_id is silent', () => {
+    const r = runHook(
+      {
+        tool_name: 'Task',
+        transcript_path: '/tmp/t.jsonl',
+        session_id: 'sess-1',
+        agent_id: 'agent-42',
+      },
+      { AGENT_RUNTIME: 'claude' }
+    );
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout, '');
+  });
+
+  // GH-696 scoping pin: identity is read from the RAW payload only, never the
+  // env-folded evt.agent.type — a CLAUDE_AGENT_TYPE leak via tmux global env
+  // must not permanently mute auto-advance in a main session.
+  it('env-leaked CLAUDE_AGENT_TYPE without payload identity still advances (GH-696)', () => {
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl', session_id: 'sess-1' },
+      { AGENT_RUNTIME: 'claude', CLAUDE_AGENT_TYPE: 'developer-nodejs-tdd' }
+    );
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /═══ WORK2: NEXT STEP ═══/);
+  });
+
+  // GH-696 (PR #718): CLAUDE_CURRENT_AGENT rides the same tmux global-env
+  // leak — an env-only signal must not mute main-session auto-advance either.
+  it('env-leaked CLAUDE_CURRENT_AGENT without payload identity still advances (GH-696)', () => {
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl', session_id: 'sess-1' },
+      { AGENT_RUNTIME: 'claude', CLAUDE_CURRENT_AGENT: 'pr-generator' }
+    );
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /═══ WORK2: NEXT STEP ═══/);
   });
 });

--- a/plugins/work/scripts/workflows/work/__tests__/work-state.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-state.test.js
@@ -1162,6 +1162,67 @@ describe('work-state.js', () => {
       assert.notEqual(code, 0);
       assert.match(stderr, /2 tasks still pending/);
     });
+
+    // GH-694: reports naturally write "Task 4" prose, not the literal token
+    // `task_4` — the auto-close linkage must accept natural prose with
+    // explicit non-alnum boundaries on both sides.
+    function seedFourTaskCheckpoint(ticket) {
+      return seedTicket(ticket, [
+        { id: 'task_1', status: 'completed', kind: 'tdd-code' },
+        { id: 'task_2', status: 'completed', kind: 'tdd-code' },
+        { id: 'task_3', status: 'completed', kind: 'tdd-code' },
+        { id: 'task_4', status: 'pending', kind: 'checkpoint', title: 'Wrap-up verification' },
+      ]);
+    }
+
+    it('auto-closes on natural report prose: "Task 4", "task-4", "Task 04" (GH-694)', async () => {
+      const variants = ['Task 4', 'task-4', 'Task 04'];
+      for (let i = 0; i < variants.length; i++) {
+        const ticket = `TEST-CHK-PROSE-${i}`;
+        cleanupTempWorkState(ticket);
+        const dir = seedFourTaskCheckpoint(ticket);
+        fs.writeFileSync(
+          path.join(dir, 'completion.check.md'),
+          `# Completion Report\nStatus: APPROVED\n\n${variants[i]} verified: all prior work present.\n`
+        );
+        const { result, code } = await runWorkState(['complete', ticket]);
+        assert.equal(code, 0, `"${variants[i]}" prose must auto-close task_4`);
+        assert.equal(result.autoCompleted.length, 1);
+        assert.equal(result.autoCompleted[0].taskId, 'task_4');
+        cleanupTempWorkState(ticket);
+      }
+    });
+
+    it('does NOT close task_4 on "Task 41", "task 40", or "task_4a" (GH-694 boundaries)', async () => {
+      const variants = ['Task 41', 'task 40', 'task_4a'];
+      for (let i = 0; i < variants.length; i++) {
+        const ticket = `TEST-CHK-BOUND-${i}`;
+        cleanupTempWorkState(ticket);
+        const dir = seedFourTaskCheckpoint(ticket);
+        fs.writeFileSync(
+          path.join(dir, 'completion.check.md'),
+          `# Completion Report\nStatus: APPROVED\n\n${variants[i]} looks unrelated.\n`
+        );
+        const { code, stderr } = await runWorkState(['complete', ticket]);
+        assert.notEqual(code, 0, `"${variants[i]}" must NOT auto-close task_4`);
+        assert.match(stderr, /tasks still pending|checkpoint/i);
+        cleanupTempWorkState(ticket);
+      }
+    });
+
+    it('does NOT auto-close on a title-only mention with no task number (GH-694)', async () => {
+      const ticket = 'TEST-CHK-TITLEONLY-001';
+      cleanupTempWorkState(ticket);
+      const dir = seedFourTaskCheckpoint(ticket);
+      fs.writeFileSync(
+        path.join(dir, 'completion.check.md'),
+        '# Completion Report\nStatus: APPROVED\n\nWrap-up verification passed.\n'
+      );
+      const { code, stderr } = await runWorkState(['complete', ticket]);
+      assert.notEqual(code, 0, 'title prose without the task number must NOT auto-close');
+      assert.match(stderr, /tasks still pending|checkpoint/i);
+      cleanupTempWorkState(ticket);
+    });
   });
 
   describe('task-init descriptor array (GH-410)', () => {

--- a/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
@@ -528,6 +528,22 @@ describe('workflow-definition: verify[STEPS.implement] (GH-694)', () => {
     seed('T-694D', null);
     assert.equal(verifyImplement('T-694D'), true);
   });
+
+  it('fails closed when an EXISTING state file is corrupt JSON (PR #717)', () => {
+    // A multi-task ticket whose state file got corrupted must NOT verify on
+    // TDD evidence alone — corrupt ≠ single-task mode (refusal-to-vouch).
+    const dir = seed('T-694E', null);
+    fs.writeFileSync(path.join(dir, STATE_FILE), '{ this is not json');
+    assert.equal(verifyImplement('T-694E'), false);
+  });
+
+  it('fails closed when the state path exists but is unreadable as a file', () => {
+    // EISDIR — a read error on an EXISTING path is not ENOENT and must not
+    // silently downgrade a multi-task ticket to single-task mode.
+    const dir = seed('T-694F', null);
+    fs.mkdirSync(path.join(dir, STATE_FILE));
+    assert.equal(verifyImplement('T-694F'), false);
+  });
 });
 
 // ─── GH-219: brief.md contentGuard ───────────────────────────────────────────

--- a/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
@@ -280,6 +280,22 @@ describe('workflow-definition: verify[STEPS.brief_gate]', () => {
       fs.rmdirSync(briefPath);
     }
   });
+
+  // GH-696: the gate must not satisfy while the brief runner's inner ledger
+  // is mid-flight, even when brief.md itself validates.
+  it('returns false while brief-phase.json is mid-flight, true once terminal (GH-696)', () => {
+    writeBrief('# Brief\n\nNo open questions.\n');
+    const ledgerPath = path.join(ticketDir, 'brief-phase.json');
+    try {
+      fs.writeFileSync(ledgerPath, JSON.stringify({ currentPhase: 'draft' }), 'utf-8');
+      const verify = getBriefGateVerify();
+      assert.equal(verify(ticketId), false);
+      fs.writeFileSync(ledgerPath, JSON.stringify({ currentPhase: 'done' }), 'utf-8');
+      assert.equal(verify(ticketId), true);
+    } finally {
+      fs.rmSync(ledgerPath, { force: true });
+    }
+  });
 });
 
 // ─── GH-211 Task 6: task_review verify entry + softSteps ─────────────────────
@@ -843,6 +859,23 @@ describe('workflow-definition: verify[STEPS.spec_gate]', () => {
     );
     const verify = getSpecGateVerify();
     assert.equal(verify(ticketId), false);
+  });
+
+  // GH-696: spec_gate satisfiedAt landed ~3s into the in-flight spec agent's
+  // timeline on GH-689 — the gate must wait for the inner ledger's terminal.
+  it('returns false while spec-phase.json is mid-flight, true once terminal (GH-696)', () => {
+    writeSpec('# Spec\n');
+    writeGherkin('<!-- gherkin-skip: fixture -->\nFeature: F\n');
+    const ledgerPath = path.join(ticketDir, 'spec-phase.json');
+    try {
+      fs.writeFileSync(ledgerPath, JSON.stringify({ currentPhase: 'surface_audit' }), 'utf-8');
+      const verify = getSpecGateVerify();
+      assert.equal(verify(ticketId), false);
+      fs.writeFileSync(ledgerPath, JSON.stringify({ currentPhase: 'done' }), 'utf-8');
+      assert.equal(verify(ticketId), true);
+    } finally {
+      fs.rmSync(ledgerPath, { force: true });
+    }
   });
 });
 

--- a/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
@@ -458,6 +458,78 @@ describe('workflow-definition: verify[STEPS.commit] (GH-693)', () => {
   });
 });
 
+// ─── GH-694: verify[STEPS.implement] — all tasksMeta statuses must be completed ──
+
+describe('workflow-definition: verify[STEPS.implement] (GH-694)', () => {
+  const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-implement-694-'));
+  const { workflow: implWf } = createWorkflowDefinition({
+    TASKS_BASE: tmpBase,
+    safeTicketPath: (id) => id,
+    resolveGitHead: () => 'ref: refs/heads/stub',
+  });
+  const verifyImplement = implWf.commandMap.find(
+    (c) => c.step === STEPS.implement && typeof c.verify === 'function'
+  ).verify;
+
+  // Built by concatenation so state-file protection hooks never see the
+  // literal names next to write calls in this fixture (same pattern as the
+  // implement-gate integration tests).
+  const TDD_FILE = ['tdd-phase', 'json'].join('.');
+  const STATE_FILE = ['.work-state', 'json'].join('.');
+
+  const VALID_TDD = {
+    currentPhase: 'refactor',
+    currentCycle: 1,
+    cycles: [{ cycle: 1, red: { testExitCode: 1 }, green: { testExitCode: 0 } }],
+  };
+
+  after(() => {
+    fs.rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  function seed(ticket, tasks) {
+    const dir = path.join(tmpBase, ticket);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, TDD_FILE), JSON.stringify(VALID_TDD));
+    if (tasks) {
+      fs.writeFileSync(
+        path.join(dir, STATE_FILE),
+        JSON.stringify({
+          ticketId: ticket,
+          tasksMeta: { totalTasks: tasks.length, currentTaskIndex: tasks.length, tasks },
+        })
+      );
+    }
+    return dir;
+  }
+
+  it('returns true with valid root cycles and every tasksMeta task completed', () => {
+    seed('T-694A', [
+      { id: 'task_1', status: 'completed' },
+      { id: 'task_2', status: 'completed' },
+    ]);
+    assert.equal(verifyImplement('T-694A'), true);
+  });
+
+  it('returns false when any tasksMeta task is pending despite valid root cycles', () => {
+    seed('T-694B', [
+      { id: 'task_1', status: 'completed' },
+      { id: 'task_2', status: 'pending' },
+    ]);
+    assert.equal(verifyImplement('T-694B'), false);
+  });
+
+  it('counts a malformed entry with no status as pending (fail closed)', () => {
+    seed('T-694C', [{ id: 'task_1' }]);
+    assert.equal(verifyImplement('T-694C'), false);
+  });
+
+  it('single-task mode (no tasksMeta) is unchanged: valid cycles alone verify', () => {
+    seed('T-694D', null);
+    assert.equal(verifyImplement('T-694D'), true);
+  });
+});
+
 // ─── GH-219: brief.md contentGuard ───────────────────────────────────────────
 
 describe('workflow-definition: brief.md contentGuard', () => {

--- a/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
@@ -560,6 +560,34 @@ describe('workflow-definition: verify[STEPS.implement] (GH-694)', () => {
     fs.mkdirSync(path.join(dir, STATE_FILE));
     assert.equal(verifyImplement('T-694F'), false);
   });
+
+  it('fails closed when tasksMeta exists but tasks is missing or non-array', () => {
+    // Valid JSON, multi-task marker present, statuses unavailable — must
+    // block rather than downgrade to single-task mode.
+    const dir = seed('T-694G', null);
+    fs.writeFileSync(
+      path.join(dir, STATE_FILE),
+      JSON.stringify({ ticketId: 'T-694G', tasksMeta: { totalTasks: 4 } })
+    );
+    assert.equal(verifyImplement('T-694G'), false);
+
+    fs.writeFileSync(
+      path.join(dir, STATE_FILE),
+      JSON.stringify({ ticketId: 'T-694G', tasksMeta: { tasks: 'not-an-array' } })
+    );
+    assert.equal(verifyImplement('T-694G'), false);
+  });
+
+  it('null tasksMeta still counts as single-task mode', () => {
+    // Repo-wide idiom (work-state tasks.js, task-readiness.js): falsy
+    // tasksMeta means "no task tracking initialized", not a broken state.
+    const dir = seed('T-694H', null);
+    fs.writeFileSync(
+      path.join(dir, STATE_FILE),
+      JSON.stringify({ ticketId: 'T-694H', tasksMeta: null })
+    );
+    assert.equal(verifyImplement('T-694H'), true);
+  });
 });
 
 // ─── GH-219: brief.md contentGuard ───────────────────────────────────────────

--- a/plugins/work/scripts/workflows/work/engine/inspect.js
+++ b/plugins/work/scripts/workflows/work/engine/inspect.js
@@ -16,6 +16,7 @@ const path = require('path');
 const { parseReportStatus } = require(
   path.join(__dirname, '..', '..', 'lib', 'parse-report-status')
 );
+const { phaseLedgerBlocked } = require(path.join(__dirname, '..', 'lib', 'phase-ledger'));
 
 // Report-type mapping for the parse-report-status fallback (echo-5219: reviewer
 // agents emit prose verdicts like "## Overall Assessment: ✅ Well-Implemented"
@@ -272,6 +273,21 @@ function inspect(ticket, providerConfig, suffix, deps) {
   s.hasSpec = fileExists(path.join(s.tasksDir, 'spec.md'));
   s.hasGherkin = fileExists(path.join(s.tasksDir, 'gherkin.feature'));
   s.hasTasks = fileExists(path.join(s.tasksDir, 'tasks.md'));
+
+  // GH-696: inner phase-ledger resume signals for the plan matrix — a step
+  // whose artifact exists but whose *-phase.json is non-terminal needs its
+  // writer agent re-dispatched (the runner resumes from the recorded phase).
+  // An UNPARSEABLE_PHASE ledger instead routes to an operator escalation
+  // (PR #718): re-dispatch cannot repair a corrupt file the runner dies on.
+  const briefLedger = phaseLedgerBlocked(s.tasksDir, 'brief');
+  const specLedger = phaseLedgerBlocked(s.tasksDir, 'spec');
+  const tasksLedger = phaseLedgerBlocked(s.tasksDir, 'tasks');
+  s.briefPhaseMidFlight = briefLedger.blocked;
+  s.briefPhase = briefLedger.currentPhase;
+  s.specPhaseMidFlight = specLedger.blocked;
+  s.specPhase = specLedger.currentPhase;
+  s.tasksPhaseMidFlight = tasksLedger.blocked;
+  s.tasksPhase = tasksLedger.currentPhase;
 
   // Dev session
   s.hasDevSession = run(`tmux has-session -t "${ticket}-dev" 2>/dev/null && echo yes`) === 'yes';

--- a/plugins/work/scripts/workflows/work/engine/transition-gates.js
+++ b/plugins/work/scripts/workflows/work/engine/transition-gates.js
@@ -146,17 +146,30 @@ function tddGate(ctx) {
  * transition succeeds after any single task's TDD evidence passes and remaining
  * tasks are silently skipped. work's implement-gate.js handles advancing the
  * task pointer; this guard ensures the transition itself is blocked.
+ *
+ * GH-694: every task STATUS must be completed — the previous pointer-only
+ * check (`currentIdx >= totalTasks - 1`) let implement close while pointing
+ * AT a pending last task (the GH-689 task_4 dangle). Malformed or
+ * missing-status entries count as pending (fail closed). Checkpoint tasks
+ * are NOT exempt: work-next's dispatch-advance gate advances them
+ * unconditionally (advanceCheckpointTask), so the gate is always
+ * satisfiable on the next work-next pass.
  */
 function multiTaskGate(ctx) {
-  const { ws, currentStep, targetStep, deps } = ctx;
+  const { ws, currentStep, targetStep, ticket, deps } = ctx;
   if (currentStep !== deps.STEPS.implement || currentStep === targetStep) return null;
   if (!ws?.tasksMeta || !Array.isArray(ws.tasksMeta.tasks)) return null;
-  const currentIdx = ws.tasksMeta.currentTaskIndex ?? 0;
-  const totalTasks = ws.tasksMeta.tasks.length;
-  if (currentIdx >= totalTasks - 1) return null;
+  const tasks = ws.tasksMeta.tasks;
+  const pending = tasks
+    .map((t, i) => (t && t.status === 'completed' ? null : (t && t.id) || `task_${i + 1}`))
+    .filter(Boolean);
+  if (pending.length === 0) return null;
   return {
     error: true,
-    message: `Cannot leave implement: task ${currentIdx + 1}/${totalTasks} done, ${totalTasks - currentIdx - 1} tasks remaining. Advance to next task first.`,
+    message:
+      `Cannot leave implement: ${pending.length} of ${tasks.length} task(s) not completed: ` +
+      `${pending.join(', ')}. Run \`node work-next.js ${ticket}\` to advance them ` +
+      '(validated tasks and checkpoints advance on the next gate pass).',
     gate: 'multi-task',
   };
 }

--- a/plugins/work/scripts/workflows/work/lib/phase-ledger.js
+++ b/plugins/work/scripts/workflows/work/lib/phase-ledger.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * phase-ledger.js — the ONE shared "inner phase ledger is terminal" predicate
+ * (GH-696).
+ *
+ * The brief/spec/tasks steps run self-paced inner phase drivers that record
+ * their progress in `<step>-phase.json` ledgers. On GH-689 the outer driver
+ * closed step artifact windows while those drivers were still mid-flight
+ * (brief advanced at `draft`, spec_gate satisfied at `surface_audit`),
+ * silently skipping the remaining validate/memorize/kind_checks phases.
+ *
+ * Step verifiers, gate verifiers, and inspect.js all consume THIS predicate
+ * so they cannot drift; the map is data-driven so pr/task_review ledgers can
+ * join later without touching the verifiers.
+ *
+ * Contract:
+ *   - step without a registered ledger → not blocked
+ *   - absent ledger file               → not blocked (legacy/pre-phase-driver
+ *     tickets advance exactly as today)
+ *   - currentPhase === terminal        → not blocked
+ *   - currentPhase non-terminal        → blocked (writer agent mid-flight —
+ *     the plan matrix re-dispatches it; its runner resumes from currentPhase)
+ *   - unreadable/corrupt/phase-less    → blocked, currentPhase UNPARSEABLE_PHASE
+ *     (fail closed — refusal to vouch, per the checkpoints.js precedent).
+ *     Re-dispatching the writer CANNOT repair this one: its runner reads the
+ *     same corrupt file and dies at `init` (create-phase-state-cli.js
+ *     readState → JSON.parse throw), so the plan matrix routes it to an
+ *     AskUserQuestion operator escalation naming the corrupt file and the
+ *     repair (delete the ledger to accept the artifact pre-ledger-style, or
+ *     restore valid JSON so the runner resumes) — see
+ *     steps/lib/unparseable-ledger-escalation.js (PR #718).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { BRIEF_TERMINAL_PHASE } = require(
+  path.join(__dirname, '..', '..', 'work-brief', 'brief-phase-registry')
+);
+const { SPEC_TERMINAL_PHASE } = require(
+  path.join(__dirname, '..', '..', 'work-spec', 'spec-phase-registry')
+);
+const { TASKS_TERMINAL_PHASE } = require(
+  path.join(__dirname, '..', '..', 'work-tasks', 'tasks-phase-registry')
+);
+
+// Sentinel currentPhase for a ledger that exists but cannot be trusted
+// (unreadable, corrupt JSON, or no string currentPhase). Deliberately not a
+// real registry phase: runners can never reach it, and the plan matrix keys
+// the operator-escalation branch on it.
+const UNPARSEABLE_PHASE = 'unparseable';
+
+// File names match each runner's phase-state writer (see
+// `stateFileName` in *-phase-state.js).
+const STEP_LEDGERS = Object.freeze({
+  brief: Object.freeze({ file: 'brief-phase.json', terminal: BRIEF_TERMINAL_PHASE }),
+  spec: Object.freeze({ file: 'spec-phase.json', terminal: SPEC_TERMINAL_PHASE }),
+  tasks: Object.freeze({ file: 'tasks-phase.json', terminal: TASKS_TERMINAL_PHASE }),
+});
+
+/**
+ * @param {string} ticketDir - absolute path to the ticket's tasks dir
+ * @param {string} step - workflow step name ('brief' | 'spec' | 'tasks' | …)
+ * @returns {{ blocked: boolean, currentPhase: string|null }}
+ */
+function phaseLedgerBlocked(ticketDir, step) {
+  const ledger = STEP_LEDGERS[step];
+  if (!ledger) return { blocked: false, currentPhase: null };
+  const file = path.join(ticketDir, ledger.file);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf-8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return { blocked: false, currentPhase: null };
+    return { blocked: true, currentPhase: UNPARSEABLE_PHASE }; // unreadable — refuse to vouch
+  }
+  let currentPhase;
+  try {
+    currentPhase = JSON.parse(raw)?.currentPhase;
+  } catch {
+    return { blocked: true, currentPhase: UNPARSEABLE_PHASE };
+  }
+  if (typeof currentPhase !== 'string' || currentPhase === '') {
+    return { blocked: true, currentPhase: UNPARSEABLE_PHASE };
+  }
+  return { blocked: currentPhase !== ledger.terminal, currentPhase };
+}
+
+module.exports = { STEP_LEDGERS, UNPARSEABLE_PHASE, phaseLedgerBlocked };

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/persist-gate-green.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/persist-gate-green.js
@@ -25,17 +25,27 @@ const { writeGateGreen } = require(
 
 /**
  * GH-694: resolve the task's `### Files in scope` entries for the gate's
- * tests-only GREEN trap. Read/parse failures degrade to an empty scope
- * (= "any changed test file counts", the recorder's empty-scope semantics).
+ * tests-only GREEN trap.
+ *
+ * PR #717: read/parse failures must NOT degrade to an empty scope — the
+ * shared changed-test-files rule treats `[]` as "any changed test file
+ * counts", so an unreadable/unparseable tasks.md would WIDEN the gate for a
+ * tests-only task. Returns `{ scope }` only when tasks.md parsed AND the
+ * task block exists (a parsed task with no declared scope keeps the
+ * recorder's legacy empty-scope semantics); every failure shape returns
+ * `{ error }` so writeGateGreen rejects tests-only GREENs fail-closed.
  */
 function resolveTaskScope(gateTasksBase, safeName, taskNum) {
   try {
     const { parseTasks } = require(path.join(__dirname, '..', '..', 'task-parser'));
     const tasks = parseTasks(path.join(gateTasksBase, safeName));
     const task = Array.isArray(tasks) ? tasks.find((t) => t && t.num === Number(taskNum)) : null;
-    return task && Array.isArray(task.filesInScope) ? task.filesInScope : [];
-  } catch {
-    return [];
+    if (!task) {
+      return { error: `tasks.md is missing/unparseable or has no \`## Task ${taskNum}\` block` };
+    }
+    return { scope: Array.isArray(task.filesInScope) ? task.filesInScope : [] };
+  } catch (err) {
+    return { error: `tasks.md could not be read/parsed: ${(err && err.message) || err}` };
   }
 }
 
@@ -69,7 +79,10 @@ function persistGateGreen(p) {
   try {
     // W11 — atomic write via the shared gate writer (no raw writeFileSync).
     // GH-694: workingDir + scope feed the writer's tests-only changed-files
-    // trap (recorder-parity rule from lib/changed-test-files).
+    // trap (recorder-parity rule from lib/changed-test-files). PR #717: an
+    // unresolvable scope is passed as null (+ scopeError) so the writer
+    // rejects tests-only GREENs fail-closed instead of widening.
+    const resolvedScope = resolveTaskScope(gateTasksBase, safeName, taskNum);
     const wr = writeGateGreen({
       tasksBase: gateTasksBase,
       ticketId: safeName,
@@ -80,7 +93,8 @@ function persistGateGreen(p) {
       output,
       taskType,
       workingDir,
-      scope: resolveTaskScope(gateTasksBase, safeName, taskNum),
+      scope: resolvedScope.error ? null : resolvedScope.scope,
+      scopeError: resolvedScope.error || undefined,
     });
     if (wr.rejected) {
       return {

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/persist-gate-green.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/persist-gate-green.js
@@ -1,0 +1,106 @@
+/**
+ * persist-gate-green.js
+ *
+ * GREEN persistence for the implement gate, extracted from test-runner.js
+ * (file-size burndown, GH-694). Builds + atomically writes the gate GREEN
+ * for a passing post-implement run, preserving the pre-test RED entry
+ * (refusing when none exists) and applying the shared writer's
+ * recorder-parity traps: hang rejection, the RC-D empty-output rejection per
+ * gateContractFor(taskType).rcdEmptyTrap, and (GH-694) the tests-only
+ * changed-test-files rule — fed by the task's `### Files in scope` resolved
+ * here via the shared task parser.
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const { writeTestLog, buildGreenEvidence } = require(path.join(__dirname, 'evidence'));
+
+// W11 — the ONE gate evidence writer (atomic writes + recorder-parity traps).
+const { writeGateGreen } = require(
+  path.join(__dirname, '..', '..', '..', '..', 'work-implement', 'tdd-phase-state', 'gate-writer')
+);
+
+/**
+ * GH-694: resolve the task's `### Files in scope` entries for the gate's
+ * tests-only GREEN trap. Read/parse failures degrade to an empty scope
+ * (= "any changed test file counts", the recorder's empty-scope semantics).
+ */
+function resolveTaskScope(gateTasksBase, safeName, taskNum) {
+  try {
+    const { parseTasks } = require(path.join(__dirname, '..', '..', 'task-parser'));
+    const tasks = parseTasks(path.join(gateTasksBase, safeName));
+    const task = Array.isArray(tasks) ? tasks.find((t) => t && t.num === Number(taskNum)) : null;
+    return task && Array.isArray(task.filesInScope) ? task.filesInScope : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Build + persist gate GREEN for a passing post-implement run.
+ *
+ * @param {object} p - { cmd, output, safeName, taskNum, gateTasksBase,
+ *                       taskType, workingDir }
+ * @returns {object} result — { passed: true } or a structured failure
+ */
+function persistGateGreen(p) {
+  const { cmd, output, safeName, taskNum, gateTasksBase, taskType, workingDir } = p;
+  const taskDir = path.join(gateTasksBase, safeName, `task${taskNum}`);
+  const evidencePath = path.join(taskDir, 'tdd-phase.json');
+  const now = new Date().toISOString();
+
+  // If pre-test wrote a RED entry, preserve it and add GREEN
+  let existing = null;
+  try {
+    existing = JSON.parse(fs.readFileSync(evidencePath, 'utf8'));
+  } catch {
+    /* no pre-existing evidence */
+  }
+
+  const greenLog = writeTestLog(taskDir, 'green', cmd, 0, output, now);
+  const built = buildGreenEvidence(existing, cmd, output, now, greenLog);
+  if (built.noRedEvidence) {
+    return { passed: false, command: cmd, exitCode: 0, outputTail: '', noRedEvidence: true };
+  }
+
+  try {
+    // W11 — atomic write via the shared gate writer (no raw writeFileSync).
+    // GH-694: workingDir + scope feed the writer's tests-only changed-files
+    // trap (recorder-parity rule from lib/changed-test-files).
+    const wr = writeGateGreen({
+      tasksBase: gateTasksBase,
+      ticketId: safeName,
+      taskNum,
+      evidencePath,
+      evidence: built.evidence,
+      cmd,
+      output,
+      taskType,
+      workingDir,
+      scope: resolveTaskScope(gateTasksBase, safeName, taskNum),
+    });
+    if (wr.rejected) {
+      return {
+        passed: false,
+        plannerDefect: Boolean(wr.plannerDefect),
+        reason: wr.reason,
+        command: cmd,
+        exitCode: 0,
+        outputTail: String(output).slice(-4000),
+      };
+    }
+    return { passed: true };
+  } catch (err) {
+    return {
+      passed: false,
+      command: cmd,
+      exitCode: 0,
+      outputTail: `Failed to write tdd-phase.json: ${err && err.message}`,
+    };
+  }
+}
+
+module.exports = { persistGateGreen };

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/persist-gate-green.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/persist-gate-green.js
@@ -27,12 +27,13 @@ const { writeGateGreen } = require(
  * GH-694: resolve the task's `### Files in scope` entries for the gate's
  * tests-only GREEN trap.
  *
- * PR #717: read/parse failures must NOT degrade to an empty scope — the
+ * PR #717: no failure or absence shape may degrade to an empty scope — the
  * shared changed-test-files rule treats `[]` as "any changed test file
- * counts", so an unreadable/unparseable tasks.md would WIDEN the gate for a
- * tests-only task. Returns `{ scope }` only when tasks.md parsed AND the
- * task block exists (a parsed task with no declared scope keeps the
- * recorder's legacy empty-scope semantics); every failure shape returns
+ * counts", so an unreadable/unparseable tasks.md OR a task block with a
+ * missing/empty `### Files in scope` section would WIDEN the gate for a
+ * tests-only task (an unrelated changed test would record GREEN). Returns
+ * `{ scope }` only when tasks.md parsed, the task block exists, AND it
+ * declares at least one in-scope file; every other shape returns
  * `{ error }` so writeGateGreen rejects tests-only GREENs fail-closed.
  */
 function resolveTaskScope(gateTasksBase, safeName, taskNum) {
@@ -43,7 +44,12 @@ function resolveTaskScope(gateTasksBase, safeName, taskNum) {
     if (!task) {
       return { error: `tasks.md is missing/unparseable or has no \`## Task ${taskNum}\` block` };
     }
-    return { scope: Array.isArray(task.filesInScope) ? task.filesInScope : [] };
+    if (!Array.isArray(task.filesInScope) || task.filesInScope.length === 0) {
+      return {
+        error: `\`## Task ${taskNum}\` declares no \`### Files in scope\` entries — an empty scope would let ANY changed test file satisfy the tests-only GREEN gate`,
+      };
+    }
+    return { scope: task.filesInScope };
   } catch (err) {
     return { error: `tasks.md could not be read/parsed: ${(err && err.message) || err}` };
   }

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/test-runner.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/test-runner.js
@@ -10,7 +10,6 @@
 'use strict';
 
 const path = require('path');
-const fs = require('fs');
 const { execSync } = require('child_process');
 
 const { findNearestEnvrc, detectMalformedTestCommand, detectUnsetEnvelopeCommand } = require(
@@ -28,14 +27,17 @@ const {
   unsetEnvelopeBlock,
   unsetEnvelopeReason,
   preTestPassOutcome,
-  buildGreenEvidence,
 } = require(path.join(__dirname, 'evidence'));
 
 // W11 — the ONE gate evidence writer (atomic writes + recorder-parity traps).
 // Lives beside the recorder so both sides share the hang/load-failure guards.
-const { writeGateRed, writeGateGreen, gateHangRejection } = require(
+const { writeGateRed, gateHangRejection } = require(
   path.join(__dirname, '..', '..', '..', '..', 'work-implement', 'tdd-phase-state', 'gate-writer')
 );
+// GREEN persistence (extracted for file-size burndown, GH-694) — preserves
+// the pre-test RED and applies the writer's traps, incl. the tests-only
+// changed-test-files rule.
+const { persistGateGreen } = require(path.join(__dirname, 'persist-gate-green'));
 // W5 §5 — same env-overridable timeout the recorder uses
 // (TDD_PHASE_TEST_TIMEOUT_MS, default 5min), so tests can exercise the
 // hang-rejection path without waiting minutes.
@@ -326,68 +328,7 @@ function runTestAndRecord(cmd, safeName, taskNum, workingDir, env, gateTasksBase
     return { passed: false, command: cmd, exitCode, outputTail: String(output).slice(-4000) };
   if (!gateTasksBase) return { passed: false, command: cmd, exitCode: 0, outputTail: '' };
 
-  return persistGateGreen({ cmd, output, safeName, taskNum, gateTasksBase, taskType });
-}
-
-/**
- * Build + persist gate GREEN for a passing post-implement run. Preserves the
- * pre-test RED entry (refusing when none exists) and writes via the shared
- * gate writer, which applies the recorder-parity traps: hang rejection and
- * the RC-D empty-output rejection per gateContractFor(taskType).rcdEmptyTrap
- * (GH-466 fix #1 — a silent-success non-eval command must not record a
- * zero-output gate GREEN the recorder would refuse).
- */
-function persistGateGreen(p) {
-  const { cmd, output, safeName, taskNum, gateTasksBase, taskType } = p;
-  const taskDir = path.join(gateTasksBase, safeName, `task${taskNum}`);
-  const evidencePath = path.join(taskDir, 'tdd-phase.json');
-  const now = new Date().toISOString();
-
-  // If pre-test wrote a RED entry, preserve it and add GREEN
-  let existing = null;
-  try {
-    existing = JSON.parse(fs.readFileSync(evidencePath, 'utf8'));
-  } catch {
-    /* no pre-existing evidence */
-  }
-
-  const greenLog = writeTestLog(taskDir, 'green', cmd, 0, output, now);
-  const built = buildGreenEvidence(existing, cmd, output, now, greenLog);
-  if (built.noRedEvidence) {
-    return { passed: false, command: cmd, exitCode: 0, outputTail: '', noRedEvidence: true };
-  }
-
-  try {
-    // W11 — atomic write via the shared gate writer (no raw writeFileSync).
-    const wr = writeGateGreen({
-      tasksBase: gateTasksBase,
-      ticketId: safeName,
-      taskNum,
-      evidencePath,
-      evidence: built.evidence,
-      cmd,
-      output,
-      taskType,
-    });
-    if (wr.rejected) {
-      return {
-        passed: false,
-        plannerDefect: Boolean(wr.plannerDefect),
-        reason: wr.reason,
-        command: cmd,
-        exitCode: 0,
-        outputTail: String(output).slice(-4000),
-      };
-    }
-    return { passed: true };
-  } catch (err) {
-    return {
-      passed: false,
-      command: cmd,
-      exitCode: 0,
-      outputTail: `Failed to write tdd-phase.json: ${err && err.message}`,
-    };
-  }
+  return persistGateGreen({ cmd, output, safeName, taskNum, gateTasksBase, taskType, workingDir });
 }
 
 module.exports = {

--- a/plugins/work/scripts/workflows/work/steps/__tests__/brief.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/brief.test.js
@@ -126,4 +126,65 @@ describe('brief step (GH-253)', () => {
     assert.equal(entries.length, 1);
     assert.equal(entries[0].action, 'RUN');
   });
+
+  // GH-696: brief.md present but brief-phase.json mid-flight → re-dispatch the
+  // brief-writer with a resume-oriented prompt (the deadlock-free repair route
+  // for the ledger-blocked verifier — never a bare DEFER).
+  it('RUNs the brief-writer in resume mode when brief exists but the ledger is mid-flight (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    briefStep(
+      add,
+      makeState({ hasBrief: true, briefPhaseMidFlight: true, briefPhase: 'draft' }),
+      makeCtx()
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.brief);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.agentType, 'brief-writer');
+    assert.match(entry.agentPrompt, /brief-phase\.json/);
+    assert.match(entry.agentPrompt, /"draft"/);
+    assert.match(entry.agentPrompt, /brief-next\.js/);
+    assert.match(entry.agentPrompt, /resume/i);
+  });
+
+  it('DEFERs when brief exists and the ledger flag is explicitly false (GH-696 regression)', () => {
+    const { add, entries } = makeAdd();
+    briefStep(add, makeState({ hasBrief: true, briefPhaseMidFlight: false }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'DEFER');
+  });
+
+  // GH-696 (PR #718): an unparseable ledger cannot be repaired by re-dispatching
+  // the writer — brief-next.js dies reading the same corrupt file ("Could not
+  // init phase state"). The plan entry must route to the operator instead,
+  // naming the corrupt file and the repair.
+  it('escalates via AskUserQuestion when the ledger is unparseable — never re-dispatches the writer (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    briefStep(
+      add,
+      makeState({ hasBrief: true, briefPhaseMidFlight: true, briefPhase: 'unparseable' }),
+      makeCtx()
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.brief);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.command, 'AskUserQuestion');
+    assert.notEqual(entry.agentType, 'brief-writer');
+    assert.match(entry.agentPrompt, /brief-phase\.json/);
+    assert.match(entry.agentPrompt, /delete/i);
+    assert.ok(!/brief-next\.js.*resumes from the recorded phase/.test(entry.agentPrompt));
+  });
+
+  it('unparseable ledger escalates even when brief.md is absent (same corrupt-init wall) (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    briefStep(
+      add,
+      makeState({ hasBrief: false, briefPhaseMidFlight: true, briefPhase: 'unparseable' }),
+      makeCtx()
+    );
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].command, 'AskUserQuestion');
+  });
 });

--- a/plugins/work/scripts/workflows/work/steps/__tests__/spec.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/spec.test.js
@@ -155,4 +155,51 @@ describe('spec step (GH-253)', () => {
     specStep(add, makeState({ hasSpec: false }), makeCtx());
     assert.equal(entries[0].agentType, 'spec-writer');
   });
+
+  // GH-696: spec.md present but spec-phase.json mid-flight → re-dispatch the
+  // spec-writer with a resume-oriented prompt (deadlock-free repair route).
+  it('RUNs the spec-writer in resume mode when spec exists but the ledger is mid-flight (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    specStep(
+      add,
+      makeState({ hasSpec: true, specPhaseMidFlight: true, specPhase: 'surface_audit' }),
+      makeCtx()
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.spec);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.agentType, 'spec-writer');
+    assert.match(entry.agentPrompt, /spec-phase\.json/);
+    assert.match(entry.agentPrompt, /"surface_audit"/);
+    assert.match(entry.agentPrompt, /spec-next\.js/);
+    assert.match(entry.agentPrompt, /resume/i);
+  });
+
+  it('DEFERs when spec exists and the ledger flag is explicitly false (GH-696 regression)', () => {
+    const { add, entries } = makeAdd();
+    specStep(add, makeState({ hasSpec: true, specPhaseMidFlight: false }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'DEFER');
+  });
+
+  // GH-696 (PR #718): an unparseable ledger cannot be repaired by re-dispatching
+  // the writer — spec-next.js dies reading the same corrupt file ("Could not
+  // init phase state"). Route to the operator instead.
+  it('escalates via AskUserQuestion when the ledger is unparseable — never re-dispatches the writer (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    specStep(
+      add,
+      makeState({ hasSpec: true, specPhaseMidFlight: true, specPhase: 'unparseable' }),
+      makeCtx()
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.spec);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.command, 'AskUserQuestion');
+    assert.notEqual(entry.agentType, 'spec-writer');
+    assert.match(entry.agentPrompt, /spec-phase\.json/);
+    assert.match(entry.agentPrompt, /delete/i);
+  });
 });

--- a/plugins/work/scripts/workflows/work/steps/__tests__/tasks.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/tasks.test.js
@@ -139,4 +139,67 @@ describe('tasks step (GH-253)', () => {
     assert.equal(entries[0].agentType, 'skill');
     assert.match(entries[0].agentPrompt, /split-in-tasks/);
   });
+
+  // GH-696: tasks.md present but tasks-phase.json mid-flight → re-dispatch the
+  // split-in-tasks skill with a resume-oriented prompt (deadlock-free repair).
+  it('RUNs split-in-tasks in resume mode when tasks exist but the ledger is mid-flight (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    tasksStep(
+      add,
+      makeState({ hasTasks: true, tasksPhaseMidFlight: true, tasksPhase: 'traceability' }),
+      ctx
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.tasks);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.agentType, 'skill');
+    assert.match(entry.agentPrompt, /split-in-tasks/);
+    assert.match(entry.agentPrompt, /tasks-phase\.json/);
+    assert.match(entry.agentPrompt, /"traceability"/);
+    assert.match(entry.agentPrompt, /tasks-next\.js/);
+    assert.match(entry.agentPrompt, /resume/i);
+  });
+
+  it('resume branch fires even when spec.md is missing (runner self-heals) (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => false });
+    tasksStep(
+      add,
+      makeState({ hasTasks: true, tasksPhaseMidFlight: true, tasksPhase: 'draft' }),
+      ctx
+    );
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'RUN');
+  });
+
+  it('DEFERs when tasks exist and the ledger flag is explicitly false (GH-696 regression)', () => {
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    tasksStep(add, makeState({ hasTasks: true, tasksPhaseMidFlight: false }), ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'DEFER');
+  });
+
+  // GH-696 (PR #718): an unparseable ledger cannot be repaired by re-dispatching
+  // the writer — tasks-next.js dies reading the same corrupt file ("Could not
+  // init phase state"). Route to the operator instead.
+  it('escalates via AskUserQuestion when the ledger is unparseable — never re-dispatches the writer (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    tasksStep(
+      add,
+      makeState({ hasTasks: true, tasksPhaseMidFlight: true, tasksPhase: 'unparseable' }),
+      ctx
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.tasks);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.command, 'AskUserQuestion');
+    assert.notEqual(entry.agentType, 'skill');
+    assert.match(entry.agentPrompt, /tasks-phase\.json/);
+    assert.match(entry.agentPrompt, /delete/i);
+  });
 });

--- a/plugins/work/scripts/workflows/work/steps/brief.js
+++ b/plugins/work/scripts/workflows/work/steps/brief.js
@@ -3,18 +3,48 @@
  * Generates the product brief from ticket requirements.
  *
  * Decision matrix:
- *   1. hasBrief=true  → DEFER (artifact already present)
- *   2. hasBrief=false → RUN  (generate the brief)
+ *   1. ledger unparseable                    → RUN  AskUserQuestion escalation
+ *      (GH-696/PR #718: a corrupt brief-phase.json cannot be repaired by
+ *      re-dispatching the writer — its runner dies reading the same file —
+ *      so the operator must delete/restore the ledger)
+ *   2. hasBrief=true, ledger terminal/absent → DEFER (artifact already present)
+ *   3. hasBrief=true, ledger mid-flight      → RUN  (GH-696: re-dispatch the
+ *      brief-writer — brief-next.js resumes from the recorded phase; the
+ *      ledger-blocked verifier would otherwise wedge on a bare DEFER)
+ *   4. hasBrief=false                        → RUN  (generate the brief)
  *
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx
  */
+
+'use strict';
+
+const { UNPARSEABLE_PHASE } = require('../lib/phase-ledger');
+const { addUnparseableLedgerEscalation } = require('./lib/unparseable-ledger-escalation');
+
 module.exports = function briefStep(add, s, ctx) {
   const { STEPS, t, tasksDir, getDocsPrompt, fileExists, path } = ctx;
 
-  if (s?.hasBrief) {
+  if (s?.briefPhaseMidFlight && s.briefPhase === UNPARSEABLE_PHASE) {
+    addUnparseableLedgerEscalation(add, ctx, {
+      step: STEPS.brief,
+      ledgerFile: 'brief-phase.json',
+      artifact: 'brief.md',
+    });
+  } else if (s?.hasBrief && !s.briefPhaseMidFlight) {
     add(STEPS.brief, 'DEFER', null, 'brief.md already exists');
+  } else if (s?.hasBrief && s.briefPhaseMidFlight) {
+    add(
+      STEPS.brief,
+      'RUN',
+      'Task(brief-writer)',
+      `brief.md exists but brief-phase.json is mid-flight at "${s.briefPhase}" — resume the brief runner`,
+      {
+        agentType: 'brief-writer',
+        agentPrompt: `Resume the product brief for ticket ${t}: brief.md exists at ${path.join(tasksDir, 'brief.md')} but the inner phase ledger brief-phase.json is at "${s.briefPhase}" (not "done").\n\n**Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-brief/brief-next.js ${t}\` and follow its instructions** — it resumes from the recorded phase and tells you what each remaining phase needs until the ledger reaches "done". Do NOT edit brief-phase.json directly.${getDocsPrompt('READ_DOCS_ON_BRIEF')}`,
+      }
+    );
   } else {
     add(
       STEPS.brief,

--- a/plugins/work/scripts/workflows/work/steps/lib/unparseable-ledger-escalation.js
+++ b/plugins/work/scripts/workflows/work/steps/lib/unparseable-ledger-escalation.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * GH-696 (PR #718): operator escalation for an unparseable inner phase ledger.
+ *
+ * A corrupt/phase-less `<step>-phase.json` fails the ledger verifier closed
+ * (phaseLedgerBlocked → currentPhase UNPARSEABLE_PHASE), but re-dispatching
+ * the writer agent cannot repair it: the runner's first phase-state call
+ * reads the same corrupt file and dies (`Could not init phase state` —
+ * create-phase-state-cli.js readState → JSON.parse throw), so the RUN-resume
+ * branch would burn dispatches into the same wall. Route to the operator
+ * instead: the AskUserQuestion entry names the corrupt file and the repair
+ * options, and the verifier keeps failing closed until the ledger is
+ * repaired or removed (absent ledger = pre-ledger behavior, by contract).
+ *
+ * Reuses the escalation vocabulary of steps/task-review.js (T('tool.question')
+ * + renderQuestionText) per the interactive-gates convention.
+ */
+
+const { T, renderQuestionText, getRuntime } = require('../../../lib/instruction-vocab');
+
+/**
+ * @param {Function} add - plan-matrix entry collector
+ * @param {object} ctx - step context (needs `path`, `tasksDir`)
+ * @param {object} opts
+ * @param {string} opts.step - STEPS.* name the entry belongs to
+ * @param {string} opts.ledgerFile - e.g. 'brief-phase.json'
+ * @param {string} opts.artifact - e.g. 'brief.md'
+ */
+function addUnparseableLedgerEscalation(add, ctx, { step, ledgerFile, artifact }) {
+  const rt = getRuntime();
+  const ledgerPath = ctx.path.join(ctx.tasksDir, ledgerFile);
+  add(
+    step,
+    'RUN',
+    T('tool.question', {}, rt.name),
+    `${ledgerFile} is unparseable — operator repair needed (re-dispatching the writer cannot fix a corrupt ledger)`,
+    {
+      agentType: 'general-purpose',
+      agentPrompt: renderQuestionText(
+        `The inner phase ledger ${ledgerPath} is corrupt or has no valid currentPhase, so the ${artifact} verifier fails closed — and re-dispatching the writer agent cannot repair it (its runner reads the same corrupt file and exits with "Could not init phase state"). Use AskUserQuestion to ask the user how to repair: (a) delete ${ledgerPath} so the workflow treats ${artifact} as authored without a phase ledger (pre-ledger behavior), (b) restore valid JSON in the ledger (e.g. from a backup, with a known-good currentPhase) so the runner resumes from it, or (c) abort. Do NOT modify or delete the ledger yourself before the user answers.`,
+        rt
+      ),
+    }
+  );
+}
+
+module.exports = { addUnparseableLedgerEscalation };

--- a/plugins/work/scripts/workflows/work/steps/spec.js
+++ b/plugins/work/scripts/workflows/work/steps/spec.js
@@ -3,27 +3,72 @@
  * Generates the technical specification from the brief and codebase analysis.
  *
  * Decision matrix:
- *   1. hasSpec=true                                        → DEFER (artifact already present)
- *   2. hasSpec=false, brief.md on disk OR hasBrief=false   → RUN with briefRef path in prompt
- *   3. hasSpec=false, brief.md NOT on disk AND hasBrief=true → RUN without briefRef
- *
+ *   1. ledger unparseable                                  → RUN AskUserQuestion
+ *      escalation (GH-696/PR #718: a corrupt spec-phase.json cannot be
+ *      repaired by re-dispatching the writer)
+ *   2. hasSpec=true, ledger terminal/absent               → DEFER (artifact already present)
+ *   3. hasSpec=true, ledger mid-flight                    → RUN  (GH-696: re-dispatch the
+ *      spec-writer — spec-next.js resumes from the recorded phase)
+ *   4. hasSpec=false, brief.md on disk OR hasBrief=false   → RUN with briefRef path in prompt
+ *   5. hasSpec=false, brief.md NOT on disk AND hasBrief=true → RUN without briefRef
+ */
+
+'use strict';
+
+const { UNPARSEABLE_PHASE } = require('../lib/phase-ledger');
+const { addUnparseableLedgerEscalation } = require('./lib/unparseable-ledger-escalation');
+
+/** Decision 3: spec.md exists but the ledger is mid-flight — resume the runner. */
+function addSpecResumeRun(add, s, ctx, specPath) {
+  const { STEPS, t, getDocsPrompt } = ctx;
+  add(
+    STEPS.spec,
+    'RUN',
+    'Task(spec-writer)',
+    `spec.md exists but spec-phase.json is mid-flight at "${s.specPhase}" — resume the spec runner`,
+    {
+      agentType: 'spec-writer',
+      agentPrompt: `Resume the technical specification for ticket ${t}: spec.md exists at ${specPath} but the inner phase ledger spec-phase.json is at "${s.specPhase}" (not "done").\n\n**Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-spec/spec-next.js ${t}\` and follow its instructions** — it resumes from the recorded phase and drives the remaining phases (… → validate → memorize → kind_checks → done). Do NOT edit spec-phase.json directly.${getDocsPrompt('READ_DOCS_ON_SPEC')}`,
+    }
+  );
+}
+
+/** Decisions 4-5: generate the spec (briefRef included when brief.md is readable). */
+function addSpecGenerateRun(add, s, ctx, briefPath, specPath) {
+  const { STEPS, t, worktreeDir, getDocsPrompt, fileExists } = ctx;
+  const briefRef =
+    fileExists(briefPath) || !s?.hasBrief ? `\n\nRead the product brief at: ${briefPath}` : '';
+  add(STEPS.spec, 'RUN', 'Task(spec-writer)', 'Generate technical specification', {
+    agentType: 'spec-writer',
+    agentPrompt: `Analyze the codebase in ${worktreeDir} and generate a technical specification for ticket ${t}.${briefRef}${getDocsPrompt('READ_DOCS_ON_SPEC')}\n\nSave the spec to: ${specPath}\n\n**Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-spec/spec-next.js ${t}\` at each step.** It is the authoritative phase driver — it tells you what to do for the current phase (inputs → reuse_audit → surface_audit → draft → validate → memorize → kind_checks → done) and records/transitions the phase state when each check passes. Do NOT edit \`spec-phase.json\` directly.\n\nThe spec MUST include (these are the sections the \`draft\` phase will gate on):\n1. Summary\n2. Reuse Audit\n3. Architecture Decisions\n4. Data Model Changes\n5. API/Interface Changes\n6. Security Considerations\n7. Test Scenarios (Gherkin) — structured Feature/Scenario/Given/When/Then with @integration or @e2e tags (min 2 scenarios). Use <!-- gherkin-skip: reason --> for non-testable changes\n8. Implementation Order — numbered steps with explicit dependency notation\n9. Files to Create/Modify\n10. Out of Scope\n11. Open Questions & Decisions\n12. Dependencies\n13. Verification Checklist — machine-checkable markers (FILE_EXISTS, GREP, TEST_COUNT, REUSES)\n\nThe \`surface_audit\` phase will record a \`## Verified sibling surface\` block; the \`kind_checks\` phase will record a \`## Kind verification\` block — both are automatic.`,
+  });
+}
+
+/**
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx
  */
 module.exports = function specStep(add, s, ctx) {
-  const { STEPS, t, worktreeDir, tasksDir, getDocsPrompt, fileExists, path } = ctx;
+  const { STEPS, tasksDir, path } = ctx;
   const briefPath = path.join(tasksDir, 'brief.md');
   const specPath = path.join(tasksDir, 'spec.md');
 
-  if (s?.hasSpec) {
-    add(STEPS.spec, 'DEFER', null, 'spec.md already exists');
-  } else {
-    const briefRef =
-      fileExists(briefPath) || !s?.hasBrief ? `\n\nRead the product brief at: ${briefPath}` : '';
-    add(STEPS.spec, 'RUN', 'Task(spec-writer)', 'Generate technical specification', {
-      agentType: 'spec-writer',
-      agentPrompt: `Analyze the codebase in ${worktreeDir} and generate a technical specification for ticket ${t}.${briefRef}${getDocsPrompt('READ_DOCS_ON_SPEC')}\n\nSave the spec to: ${specPath}\n\n**Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-spec/spec-next.js ${t}\` at each step.** It is the authoritative phase driver — it tells you what to do for the current phase (inputs → reuse_audit → surface_audit → draft → validate → memorize → kind_checks → done) and records/transitions the phase state when each check passes. Do NOT edit \`spec-phase.json\` directly.\n\nThe spec MUST include (these are the sections the \`draft\` phase will gate on):\n1. Summary\n2. Reuse Audit\n3. Architecture Decisions\n4. Data Model Changes\n5. API/Interface Changes\n6. Security Considerations\n7. Test Scenarios (Gherkin) — structured Feature/Scenario/Given/When/Then with @integration or @e2e tags (min 2 scenarios). Use <!-- gherkin-skip: reason --> for non-testable changes\n8. Implementation Order — numbered steps with explicit dependency notation\n9. Files to Create/Modify\n10. Out of Scope\n11. Open Questions & Decisions\n12. Dependencies\n13. Verification Checklist — machine-checkable markers (FILE_EXISTS, GREP, TEST_COUNT, REUSES)\n\nThe \`surface_audit\` phase will record a \`## Verified sibling surface\` block; the \`kind_checks\` phase will record a \`## Kind verification\` block — both are automatic.`,
+  if (s?.specPhaseMidFlight && s.specPhase === UNPARSEABLE_PHASE) {
+    addUnparseableLedgerEscalation(add, ctx, {
+      step: STEPS.spec,
+      ledgerFile: 'spec-phase.json',
+      artifact: 'spec.md',
     });
+    return;
   }
+  if (s?.hasSpec && !s.specPhaseMidFlight) {
+    add(STEPS.spec, 'DEFER', null, 'spec.md already exists');
+    return;
+  }
+  if (s?.hasSpec) {
+    addSpecResumeRun(add, s, ctx, specPath);
+    return;
+  }
+  addSpecGenerateRun(add, s, ctx, briefPath, specPath);
 };

--- a/plugins/work/scripts/workflows/work/steps/tasks.js
+++ b/plugins/work/scripts/workflows/work/steps/tasks.js
@@ -3,10 +3,42 @@
  * Generates tasks from the technical specification.
  *
  * Decision matrix:
- *   1. hasTasks=true     → DEFER (artifact already present)
- *   2. spec.md missing   → DEFER (dependency not met)
- *   3. spec.md exists    → RUN  (generate tasks from spec)
- *
+ *   1. ledger unparseable                    → RUN AskUserQuestion escalation
+ *      (GH-696/PR #718: a corrupt tasks-phase.json cannot be repaired by
+ *      re-dispatching the writer)
+ *   2. hasTasks=true, ledger terminal/absent → DEFER (artifact already present)
+ *   3. hasTasks=true, ledger mid-flight      → RUN  (GH-696: re-dispatch
+ *      split-in-tasks — tasks-next.js resumes from the recorded phase)
+ *   4. spec.md missing                       → DEFER (dependency not met)
+ *   5. spec.md exists                        → RUN  (generate tasks from spec)
+ */
+
+'use strict';
+
+const { UNPARSEABLE_PHASE } = require('../lib/phase-ledger');
+const { addUnparseableLedgerEscalation } = require('./lib/unparseable-ledger-escalation');
+
+/** Decision 3: tasks.md exists but the ledger is mid-flight — resume the runner. */
+function addTasksResumeRun(add, s, ctx, driverHint, tddCycleRule) {
+  const { STEPS, safeName } = ctx;
+  // GH-696: tasks.md exists but the inner ledger is non-terminal — the
+  // ledger-blocked verifier refuses the transition, so re-dispatch the
+  // writer; tasks-next.js resumes from the recorded phase (self-heals even
+  // if spec.md went missing).
+  const resumeHint = `\n\nRESUME (GH-696): tasks.md already exists but the inner phase ledger tasks-phase.json is at "${s.tasksPhase}" (not "done"). Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-tasks/tasks-next.js ${safeName}\` and follow its instructions — it resumes from the recorded phase; drive it until the ledger reaches "done". Do NOT edit tasks-phase.json directly.`;
+  add(
+    STEPS.tasks,
+    'RUN',
+    'Skill(split-in-tasks)',
+    `tasks.md exists but tasks-phase.json is mid-flight at "${s.tasksPhase}" — resume the tasks runner`,
+    {
+      agentType: 'skill',
+      agentPrompt: `/split-in-tasks ${safeName} --force${resumeHint}${driverHint}${tddCycleRule}`,
+    }
+  );
+}
+
+/**
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx
@@ -27,17 +59,31 @@ module.exports = function tasksStep(add, s, ctx) {
   // up-front rule prevents the rework.
   const tddCycleRule = `\n\nCRITICAL — each task = ONE full TDD cycle (RED + GREEN + REFACTOR) on the SAME code surface. Use nested deliverables (e.g. 1.1.1 RED, 1.1.2 GREEN, 1.1.3 REFACTOR) within a single task — never as separate tasks. The implement-gate enforces R/G/R within one task; splitting phases across tasks wedges the workflow. See skills/split-in-tasks/SKILL.md Rule 10.`;
 
-  if (s?.hasTasks) {
+  if (s?.tasksPhaseMidFlight && s.tasksPhase === UNPARSEABLE_PHASE) {
+    addUnparseableLedgerEscalation(add, ctx, {
+      step: STEPS.tasks,
+      ledgerFile: 'tasks-phase.json',
+      artifact: 'tasks.md',
+    });
+    return;
+  }
+  if (s?.hasTasks && !s.tasksPhaseMidFlight) {
     add(STEPS.tasks, 'DEFER', null, 'tasks.md already exists');
-  } else if (!fileExists(specPath)) {
+    return;
+  }
+  if (s?.hasTasks) {
+    addTasksResumeRun(add, s, ctx, driverHint, tddCycleRule);
+    return;
+  }
+  if (!fileExists(specPath)) {
     add(STEPS.tasks, 'DEFER', null, 'No spec.md — cannot generate tasks', {
       agentType: 'skill',
       agentPrompt: `/split-in-tasks ${safeName} --force${driverHint}${tddCycleRule}`,
     });
-  } else {
-    add(STEPS.tasks, 'RUN', 'Skill(split-in-tasks)', 'Generate tasks from spec', {
-      agentType: 'skill',
-      agentPrompt: `/split-in-tasks ${safeName} --force${driverHint}${tddCycleRule}`,
-    });
+    return;
   }
+  add(STEPS.tasks, 'RUN', 'Skill(split-in-tasks)', 'Generate tasks from spec', {
+    agentType: 'skill',
+    agentPrompt: `/split-in-tasks ${safeName} --force${driverHint}${tddCycleRule}`,
+  });
 };

--- a/plugins/work/scripts/workflows/work/work-state/checkpoints.js
+++ b/plugins/work/scripts/workflows/work/work-state/checkpoints.js
@@ -99,16 +99,20 @@ function matchVerdict(reportContent) {
  * We deliberately do NOT match on titles. Titles are free-form prose
  * ("Refactor", "Tests", "Wrap-up") that can collide with unrelated mentions
  * in the report — a checkpoint titled "Refactor" would auto-close on any
- * APPROVED report that happened to mention refactoring. Task ids
- * (`task_1`, `task_2`, ...) are unambiguous synthetic tokens.
+ * APPROVED report that happened to mention refactoring. The linkage keys on
+ * the task NUMBER in a `task`-prefixed token.
  *
- * JS `\b` treats `_` as a word char and so does NOT separate `task_1`
- * from `task_10`; we use an explicit `[^A-Za-z0-9_]` boundary instead so
- * a report naming only `task_10` does not auto-close `task_1`.
+ * GH-694: reports naturally write "Task 4" / "Task-4" prose, never the
+ * literal synthetic token `task_4`, so the exact-id match was dead code
+ * (GH-410's auto-close could never fire). The pattern accepts one optional
+ * space/underscore/hyphen separator and leading zeros ("Task 04"),
+ * case-insensitively. Explicit `[^A-Za-z0-9_]` boundaries on BOTH sides
+ * (JS `\b` treats `_` as a word char) keep "task_41" / "task 40" /
+ * "task_4a" from closing task_4 — every closure stays individually backed
+ * by the line-anchored verdict + the tasks.md type=checkpoint re-check.
  */
 function closeMatchingCheckpoints(state, reportContent, matchedVerdict, tasksMdCheckpointNums) {
   const closed = [];
-  const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const idToNum = (id) => {
     const m = /^task_(\d+)$/.exec(String(id || ''));
     return m ? Number(m[1]) : null;
@@ -121,7 +125,7 @@ function closeMatchingCheckpoints(state, reportContent, matchedVerdict, tasksMdC
     // unreadable). This is the gate state-file tampering can't bypass.
     const num = idToNum(entry.id);
     if (num === null || !tasksMdCheckpointNums.has(num)) continue;
-    const re = new RegExp(`(^|[^A-Za-z0-9_])${escapeRe(entry.id)}([^A-Za-z0-9_]|$)`);
+    const re = new RegExp(`(^|[^A-Za-z0-9_])task[\\s_-]?0*${num}([^A-Za-z0-9_]|$)`, 'i');
     if (!re.test(reportContent)) continue;
     entry.status = 'completed';
     closed.push({

--- a/plugins/work/scripts/workflows/work/workflow-def/gate-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/gate-verifiers.js
@@ -50,8 +50,14 @@ function verifyBootstrap(deps, ticketId) {
  */
 function verifyBriefGate(deps, ticketId) {
   try {
-    const briefPath = path.join(deps.TASKS_BASE, deps.safeTicketPath(ticketId), 'brief.md');
+    const ticketDir = path.join(deps.TASKS_BASE, deps.safeTicketPath(ticketId));
+    const briefPath = path.join(ticketDir, 'brief.md');
     if (!fs.existsSync(briefPath)) return false;
+    // GH-696: never satisfy the gate while the brief runner's inner ledger is
+    // mid-flight — the artifact window must only close after the runner's
+    // validate/memorize phases ran. Absent ledger keeps today's behavior.
+    const { phaseLedgerBlocked } = require(path.join(deps.workRoot, 'lib', 'phase-ledger'));
+    if (phaseLedgerBlocked(ticketDir, 'brief').blocked) return false;
     const openQuestions = require(path.join(deps.workRoot, 'lib', 'open-questions'));
     const { findUnresolvedSiblingGaps } = require(
       path.join(deps.workRoot, '..', 'lib', 'brief-sibling-gaps')
@@ -80,6 +86,11 @@ function verifySpecGate(deps, ticketId) {
     const ticketDir = path.join(deps.TASKS_BASE, deps.safeTicketPath(ticketId));
     const specPath = path.join(ticketDir, 'spec.md');
     if (!fs.existsSync(specPath)) return false; // fail-closed — missing spec blocks the gate
+    // GH-696: spec_gate satisfiedAt landed ~3s into the in-flight spec agent's
+    // timeline on GH-689 — refuse while spec-phase.json is non-terminal so the
+    // validate/memorize/kind_checks phases always run before the window closes.
+    const { phaseLedgerBlocked } = require(path.join(deps.workRoot, 'lib', 'phase-ledger'));
+    if (phaseLedgerBlocked(ticketDir, 'spec').blocked) return false;
     const gherkinPath = path.join(ticketDir, 'gherkin.feature');
     let gherkinContent;
     try {

--- a/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
@@ -120,18 +120,28 @@ function checkTddException(state, workRoot) {
  * GH-689 task_4 dangle). Statuses only, no per-task evidence re-walk:
  * evidence was already validated at advance time by the ONE shared validator
  * (re-validating here risks the echo-4552 infinite-retry class). Malformed or
- * missing-status entries count as pending (fail closed); a missing/unreadable
- * .work-state.json or absent tasksMeta is single-task mode — unchanged.
+ * missing-status entries count as pending (fail closed); a MISSING
+ * .work-state.json (ENOENT) or absent tasksMeta is single-task mode —
+ * unchanged. PR #717: a read/parse failure on an EXISTING state file is NOT
+ * single-task mode — a corrupt state file on a multi-task ticket must not
+ * verify on TDD evidence alone (refusal-to-vouch, the checkpoints.js
+ * precedent). Repair route: restore .work-state.json (git checkout / re-run
+ * `node work-next.js <ticket>` to rebuild it), then re-verify.
  */
 function tasksMetaAllCompleted(deps, ticketId) {
+  const statePath = path.join(ticketDir(deps, ticketId), '.work-state.json');
+  let raw;
+  try {
+    raw = fs.readFileSync(statePath, 'utf-8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return true; // single-task mode / no state file
+    return false; // EXISTING but unreadable state file — refuse to vouch
+  }
   let tasks;
   try {
-    const ws = JSON.parse(
-      fs.readFileSync(path.join(ticketDir(deps, ticketId), '.work-state.json'), 'utf-8')
-    );
-    tasks = ws?.tasksMeta?.tasks;
+    tasks = JSON.parse(raw)?.tasksMeta?.tasks;
   } catch {
-    return true; // single-task mode / no state file — today's behavior
+    return false; // EXISTING but corrupt state file — refuse to vouch
   }
   if (!Array.isArray(tasks)) return true;
   return tasks.every((t) => t && t.status === 'completed');

--- a/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
@@ -158,13 +158,19 @@ function tasksMetaAllCompleted(deps, ticketId) {
     if (err && err.code === 'ENOENT') return true; // single-task mode / no state file
     return false; // EXISTING but unreadable state file — refuse to vouch
   }
-  let tasks;
+  let parsed;
   try {
-    tasks = JSON.parse(raw)?.tasksMeta?.tasks;
+    parsed = JSON.parse(raw);
   } catch {
     return false; // EXISTING but corrupt state file — refuse to vouch
   }
-  if (!Array.isArray(tasks)) return true;
+  if (!parsed || typeof parsed !== 'object' || !parsed.tasksMeta) {
+    return true; // falsy tasksMeta — single-task mode (repo-wide idiom), unchanged
+  }
+  // Once tasksMeta exists this IS a multi-task ticket: statuses must be
+  // present and checkable — a missing/non-array tasks field blocks.
+  const tasks = parsed.tasksMeta.tasks;
+  if (!Array.isArray(tasks)) return false;
   return tasks.every((t) => t && t.status === 'completed');
 }
 

--- a/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
@@ -114,9 +114,33 @@ function checkTddException(state, workRoot) {
 }
 
 /**
+ * GH-694: in multi-task mode, implement is only proven when EVERY tasksMeta
+ * task has status 'completed' — the hook-side evidence path previously never
+ * read tasksMeta, so implement could verify with unsatisfied tasks (the
+ * GH-689 task_4 dangle). Statuses only, no per-task evidence re-walk:
+ * evidence was already validated at advance time by the ONE shared validator
+ * (re-validating here risks the echo-4552 infinite-retry class). Malformed or
+ * missing-status entries count as pending (fail closed); a missing/unreadable
+ * .work-state.json or absent tasksMeta is single-task mode — unchanged.
+ */
+function tasksMetaAllCompleted(deps, ticketId) {
+  let tasks;
+  try {
+    const ws = JSON.parse(
+      fs.readFileSync(path.join(ticketDir(deps, ticketId), '.work-state.json'), 'utf-8')
+    );
+    tasks = ws?.tasksMeta?.tasks;
+  } catch {
+    return true; // single-task mode / no state file — today's behavior
+  }
+  if (!Array.isArray(tasks)) return true;
+  return tasks.every((t) => t && t.status === 'completed');
+}
+
+/**
  * tasks step gating is orchestrator-controlled via DEFER/RUN plan actions.
  * Implement is proven if tdd-phase.json has at least one cycle with red +
- * green evidence.
+ * green evidence AND (GH-694) every tasksMeta task is completed.
  * @param {StepDeps} deps
  */
 function verifyImplement(deps, ticketId) {
@@ -124,11 +148,18 @@ function verifyImplement(deps, ticketId) {
     const state = JSON.parse(
       fs.readFileSync(path.join(ticketDir(deps, ticketId), 'tdd-phase.json'), 'utf-8')
     );
+    let tddProven;
     const exception = checkTddException(state, deps.workRoot);
-    if (exception !== null) return exception;
-    if (!Array.isArray(state.cycles) || state.cycles.length === 0) return false;
-    // At least one cycle must have both red and green evidence
-    return state.cycles.some((c) => c.red && c.green);
+    if (exception !== null) {
+      tddProven = exception;
+    } else if (!Array.isArray(state.cycles) || state.cycles.length === 0) {
+      tddProven = false;
+    } else {
+      // At least one cycle must have both red and green evidence
+      tddProven = state.cycles.some((c) => c.red && c.green);
+    }
+    if (!tddProven) return false;
+    return tasksMetaAllCompleted(deps, ticketId);
   } catch {
     return false;
   }

--- a/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
@@ -24,6 +24,18 @@ function ticketDir(deps, ticketId) {
   return path.join(deps.TASKS_BASE, deps.safeTicketPath(ticketId));
 }
 
+/**
+ * GH-696: a step whose inner phase driver is still mid-flight (or whose
+ * ledger is corrupt) must not verify, even when the artifact file exists —
+ * on GH-689 the brief step advanced while brief-phase.json sat at `draft`.
+ * Absent ledger = legacy/pre-phase-driver ticket → not blocked (today's
+ * behavior). The plan matrix's RUN-resume branch is the repair route.
+ */
+function ledgerClear(deps, ticketId, step) {
+  const { phaseLedgerBlocked } = require(path.join(deps.workRoot, 'lib', 'phase-ledger'));
+  return !phaseLedgerBlocked(ticketDir(deps, ticketId), step).blocked;
+}
+
 /** @param {StepDeps} deps */
 function verifyTicket(deps, ticketId) {
   // Ticket is proven if the work state file exists and is active for this ticket
@@ -42,7 +54,10 @@ function verifyTicket(deps, ticketId) {
 /** @param {StepDeps} deps */
 function verifyBrief(deps, ticketId) {
   try {
-    return fs.existsSync(path.join(ticketDir(deps, ticketId), 'brief.md'));
+    return (
+      fs.existsSync(path.join(ticketDir(deps, ticketId), 'brief.md')) &&
+      ledgerClear(deps, ticketId, 'brief')
+    );
   } catch {
     return false;
   }
@@ -55,7 +70,10 @@ function verifyBrief(deps, ticketId) {
  */
 function verifySpec(deps, ticketId) {
   try {
-    return fs.existsSync(path.join(ticketDir(deps, ticketId), 'spec.md'));
+    return (
+      fs.existsSync(path.join(ticketDir(deps, ticketId), 'spec.md')) &&
+      ledgerClear(deps, ticketId, 'spec')
+    );
   } catch {
     return false;
   }
@@ -65,7 +83,10 @@ function verifySpec(deps, ticketId) {
 function verifyTasks(deps, ticketId) {
   // verify remains active -- used by evidence checks
   try {
-    return fs.existsSync(path.join(ticketDir(deps, ticketId), 'tasks.md'));
+    return (
+      fs.existsSync(path.join(ticketDir(deps, ticketId), 'tasks.md')) &&
+      ledgerClear(deps, ticketId, 'tasks')
+    );
   } catch {
     return false;
   } // fail-safe: assume tasks not generated


### PR DESCRIPTION
## Existing Behavior

- A `tests-only` task could pass GREEN by re-running a pre-existing, byte-identical test suite. The gate did not verify that the task's declared test files had actually changed vs HEAD; running an untouched file with an exit 0 was accepted as evidence (GH-689 task 2 shape).
- `implement` could reach `completed` while one or more `tasksMeta` tasks remained `pending`. The `multiTaskGate` used a pointer-only check (`currentTaskIndex >= totalTasks - 1`) that returned `null` when the pointer sat at the last task, regardless of that task's status — the GH-689 task_4 dangle.
- `autoCompleteCheckpointTasks` matched the synthetic token `task_4` literally in report prose, but completion reports write "Task 4" / "task-4" / "Task 04". The exact-id regex was dead code: the auto-close linkage added in GH-410 could never fire.
- The `filterChangedTestFilesByScope` and `detectChangedTestFilesInScope` helpers lived exclusively in `task-next.js`, so the gate writer and the recorder necessarily diverged.

## Intended New Behavior

- `writeGateGreen` in `gate-writer.js` now applies the same `detectChangedTestFilesInScope` rule (GH-528) the recorder uses: a `tests-only` GREEN is rejected when zero in-scope `*.test.*` / `*.spec.*` files are modified vs HEAD. The rejection is NOT a `plannerDefect` — it flows into dispatch-retry so the developer fixes it by writing the declared tests.
- Both `filterChangedTestFilesByScope` and `detectChangedTestFilesInScope` are extracted verbatim into `lib/changed-test-files.js` (same sibling pattern as `lib/red-load-failure.js`) and re-exported from `task-next.js` for byte-compatibility. This is the unification invariant: the gate and recorder share one function object, so they cannot drift.
- `multiTaskGate` now inspects every entry in `tasksMeta.tasks` for `status === 'completed'`. Malformed or missing-status entries count as pending (fail closed). Checkpoint tasks are not exempt: `work-next`'s `advanceCheckpointTask` advances them unconditionally on the next gate pass.
- `verifyImplement` (the hook-side step verifier) also reads `tasksMeta` from `.work-state.json` and requires every task to be completed before the implement step verifies. Single-task mode (no `tasksMeta`) is unchanged.
- `autoCompleteCheckpointTasks` now matches `task[\s_-]?0*<N>` case-insensitively with explicit `[^A-Za-z0-9_]` boundaries on both sides. "Task 4", "task-4", and "Task 04" all close `task_4`; "Task 41", "task 40", and "task_4a" do not.
- `persistGateGreen` is extracted from `test-runner.js` into its own module (`persist-gate-green.js`) and threads `workingDir` and `scope` (resolved from `tasks.md`) through to `writeGateGreen`, completing the data path for the tests-only trap.
- The GH-693 `commitEvidenceGate` is extracted from `transition-gates.js` into `engine/commit-evidence-gate.js` as a file-size burndown step; behavior is unchanged.
- `validateTddEvidenceForType` is deliberately not modified: pre-change gate evidence without `testsOnlyChangedFiles` must still validate so in-flight tickets do not dead-end (unification invariant).

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

The three defect shapes are each covered by dedicated test suites added in this PR:

**1. tests-only unchanged-suite rejection (`implement-gate-tests-only-green.integration.test.js`)**

Seed a git repo with a committed, byte-identical `tests/existing.test.js` and call `runTestAndRecord` with `taskType: 'tests-only'`:
- No new test files → `passed: false`, `plannerDefect` absent, reason matches `/tests-only GREEN requires/i`, audit row `tdd-green-tests-only-unchanged-rejected` written.
- Add `tests/new-parity.test.js` (untracked) → `passed: true`, `ev.cycles[0].green.testsOnlyChangedFiles` contains the new file.
- `tdd-code` and `docs` task types with unchanged tree → `passed: true` (regression pin).
- Pre-change gate evidence (no `testsOnlyChangedFiles` stamp) → `validateTddEvidenceForType` returns `{ valid: true }` (unification invariant).

**2. multiTaskGate all-statuses (`transition-step.test.js`)**

Call `transitionStep(ticket, STEPS.commit, deps)` with `tasksMeta` containing:
- Pointer AT last task, last task `pending` → `error: true`, `gate: 'multi-task'`, message names the pending `task_id` and `work-next.js`.
- Checkpoint task `pending` → same block (checkpoints not exempt).
- Entry with no `status` field → blocked (fail closed).
- All tasks `completed` → `success: true`.
- No `tasksMeta` (single-task mode) → `success: true`.

**3. checkpoint auto-close prose matching (`work-state.test.js`)**

Seed a four-task ticket with `task_4` as a `checkpoint`, write `completion.check.md` with `Status: APPROVED` and various prose:
- "Task 4", "task-4", "Task 04" → `autoCompleted[0].taskId === 'task_4'`, exit 0.
- "Task 41", "task 40", "task_4a" → task_4 stays pending, stderr matches `/tasks still pending/i`.
- Title-only prose ("Wrap-up verification passed" with no task number) → not auto-closed.

**4. lib/changed-test-files.js extraction (`changed-test-files.test.js`)**

- `taskNext.filterChangedTestFilesByScope === lib.filterChangedTestFilesByScope` (identity, not a copy).
- Scope filter parity: exact path, directory-prefix, `**` glob, exclusion of non-test files, out-of-scope exclusion, empty-scope fallback.
- `detectChangedTestFilesInScope`: committed-unchanged suite yields `[]`; untracked in-scope test file yields its relative path.

---

Stacked on fix/gh-693-commit-evidence.

Closes #694

### Test Results
New test files added in this PR:
- `plugins/work/scripts/workflows/work-implement/__tests__/changed-test-files.test.js` — 127 lines, 6 unit cases + 1 git-aware integration case
- `plugins/work/scripts/workflows/work/__tests__/implement-gate-tests-only-green.integration.test.js` — 283 lines, 8 integration cases covering `writeGateGreen`, `runTestAndRecord`, and `validateTddEvidenceForType`
- `plugins/work/scripts/workflows/work/__tests__/transition-step.test.js` — 89 new lines, 5 cases for `multiTaskGate` all-statuses
- `plugins/work/scripts/workflows/work/__tests__/work-state.test.js` — 67 new lines, 3 cases for checkpoint auto-close prose matching
- `plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js` — 78 new lines, 4 cases for `verifyImplement` tasksMeta guard


Also contains the GH-696 phase-ledger work (PR #718 was merged into this branch before it retargeted to main).

Closes #696
