### PR TITLE
fix(work): gate brief/spec/tasks on terminal phase ledgers (GH-696)

### DIFF
--- a/factories/runtime/__tests__/payload.spec.js
+++ b/factories/runtime/__tests__/payload.spec.js
@@ -156,6 +156,37 @@ describe('normalizeHookPayload — claude fixtures (byte-compat surface)', () =>
     assert.equal(isSubagentContext(evt), true);
     assert.equal(isSubagentContext(normalize('claude', 'stop')), false);
   });
+
+  // GH-696: claude payloads fired inside a subagent can carry agent identity
+  // in the RAW payload without a /subagents/ transcript path.
+  it('claude native agent_type/agent_id in the raw payload marks subagent context (GH-696)', () => {
+    const byType = normalizeHookPayload(
+      { tool_name: 'Bash', transcript_path: '/tmp/t.jsonl', agent_type: 'pr-generator' },
+      { runtime: 'claude' }
+    );
+    assert.equal(isSubagentContext(byType), true);
+    const byId = normalizeHookPayload(
+      { tool_name: 'Bash', transcript_path: '/tmp/t.jsonl', agent_id: 'agent-42' },
+      { runtime: 'claude' }
+    );
+    assert.equal(isSubagentContext(byId), true);
+  });
+
+  // GH-696 scoping pin: never read env-folded evt.agent.type — CLAUDE_AGENT_TYPE
+  // leaks via tmux global env and would permanently mute a main session.
+  it('claude env-folded CLAUDE_AGENT_TYPE alone is NOT a subagent context (GH-696)', () => {
+    process.env.CLAUDE_AGENT_TYPE = 'developer-nodejs-tdd';
+    try {
+      const evt = normalizeHookPayload(
+        { tool_name: 'Bash', transcript_path: '/tmp/t.jsonl' },
+        { runtime: 'claude' }
+      );
+      assert.equal(evt.agent.type, 'developer-nodejs-tdd'); // env fold still surfaces it
+      assert.equal(isSubagentContext(evt), false);
+    } finally {
+      delete process.env.CLAUDE_AGENT_TYPE;
+    }
+  });
 });
 
 describe('normalizeHookPayload — defensive shapes', () => {

--- a/factories/runtime/__tests__/payload.spec.js
+++ b/factories/runtime/__tests__/payload.spec.js
@@ -187,6 +187,36 @@ describe('normalizeHookPayload — claude fixtures (byte-compat surface)', () =>
       delete process.env.CLAUDE_AGENT_TYPE;
     }
   });
+
+  // GH-696 (PR #718): CLAUDE_CURRENT_AGENT is the SAME tmux global-env leak
+  // class — an env-only signal must never mute auto-advance in a main session.
+  // Subagent identity comes from the raw payload or the /subagents/ transcript
+  // path, never from the process environment.
+  it('claude env CLAUDE_CURRENT_AGENT alone is NOT a subagent context (GH-696)', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'pr-generator';
+    try {
+      const evt = normalizeHookPayload(
+        { tool_name: 'Bash', transcript_path: '/tmp/t.jsonl' },
+        { runtime: 'claude' }
+      );
+      assert.equal(isSubagentContext(evt), false);
+    } finally {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+  });
+
+  it('claude env CLAUDE_CURRENT_AGENT plus native payload identity IS a subagent context', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'pr-generator';
+    try {
+      const evt = normalizeHookPayload(
+        { tool_name: 'Bash', transcript_path: '/tmp/t.jsonl', agent_type: 'pr-generator' },
+        { runtime: 'claude' }
+      );
+      assert.equal(isSubagentContext(evt), true);
+    } finally {
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+  });
 });
 
 describe('normalizeHookPayload — defensive shapes', () => {

--- a/factories/runtime/payload.js
+++ b/factories/runtime/payload.js
@@ -151,14 +151,27 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/ or CLAUDE_CURRENT_AGENT set. Codex: payload agent identity
- * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
+ * /subagents/, raw payload agent identity, or CLAUDE_CURRENT_AGENT set.
+ * Codex: payload agent identity (agent_id/agent_type present when inside a
+ * subagent — ground truth §2.5.1).
+ *
+ * GH-696: the claude leg reads the RAW payload (evt.native), NOT the
+ * env-folded evt.agent.type — resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, which can leak via tmux global env and would
+ * permanently mute auto-advance in a main session.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
   if (evt.runtime === 'codex') return Boolean(evt.agent && (evt.agent.id || evt.agent.type));
+  return isClaudeSubagentContext(evt);
+}
+
+/** Claude leg of isSubagentContext — see the GH-696 note above. */
+function isClaudeSubagentContext(evt) {
+  const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
+    Boolean(str(native.agent_type) || str(native.agent_id)) ||
     Boolean(process.env.CLAUDE_CURRENT_AGENT)
   );
 }

--- a/factories/runtime/payload.js
+++ b/factories/runtime/payload.js
@@ -151,14 +151,19 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/, raw payload agent identity, or CLAUDE_CURRENT_AGENT set.
- * Codex: payload agent identity (agent_id/agent_type present when inside a
- * subagent — ground truth §2.5.1).
+ * /subagents/ or raw payload agent identity. Codex: payload agent identity
+ * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
  *
- * GH-696: the claude leg reads the RAW payload (evt.native), NOT the
- * env-folded evt.agent.type — resolveAgent folds in CLAUDE_AGENT_TYPE/
- * CLAUDE_CURRENT_AGENT, which can leak via tmux global env and would
- * permanently mute auto-advance in a main session.
+ * GH-696: the claude leg reads the RAW payload (evt.native) and the
+ * transcript path ONLY — never the env-folded evt.agent.type and never
+ * process.env directly. resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, and BOTH leak via tmux global env; any env-derived
+ * signal here would permanently mute auto-advance in a main session
+ * (PR #718). Enforcement-side dispatched-agent detection
+ * (lib/agent-detection.js isDispatchedAgentContext) deliberately still reads
+ * CLAUDE_CURRENT_AGENT — there a false positive only blocks a terminal
+ * bypass with a message naming the leaked var, while here it would be a
+ * silent liveness failure.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
@@ -171,8 +176,7 @@ function isClaudeSubagentContext(evt) {
   const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
-    Boolean(str(native.agent_type) || str(native.agent_id)) ||
-    Boolean(process.env.CLAUDE_CURRENT_AGENT)
+    Boolean(str(native.agent_type) || str(native.agent_id))
   );
 }
 

--- a/plugins/heimdall/lib/runtime/payload.js
+++ b/plugins/heimdall/lib/runtime/payload.js
@@ -153,14 +153,27 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/ or CLAUDE_CURRENT_AGENT set. Codex: payload agent identity
- * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
+ * /subagents/, raw payload agent identity, or CLAUDE_CURRENT_AGENT set.
+ * Codex: payload agent identity (agent_id/agent_type present when inside a
+ * subagent — ground truth §2.5.1).
+ *
+ * GH-696: the claude leg reads the RAW payload (evt.native), NOT the
+ * env-folded evt.agent.type — resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, which can leak via tmux global env and would
+ * permanently mute auto-advance in a main session.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
   if (evt.runtime === 'codex') return Boolean(evt.agent && (evt.agent.id || evt.agent.type));
+  return isClaudeSubagentContext(evt);
+}
+
+/** Claude leg of isSubagentContext — see the GH-696 note above. */
+function isClaudeSubagentContext(evt) {
+  const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
+    Boolean(str(native.agent_type) || str(native.agent_id)) ||
     Boolean(process.env.CLAUDE_CURRENT_AGENT)
   );
 }

--- a/plugins/heimdall/lib/runtime/payload.js
+++ b/plugins/heimdall/lib/runtime/payload.js
@@ -153,14 +153,19 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/, raw payload agent identity, or CLAUDE_CURRENT_AGENT set.
- * Codex: payload agent identity (agent_id/agent_type present when inside a
- * subagent — ground truth §2.5.1).
+ * /subagents/ or raw payload agent identity. Codex: payload agent identity
+ * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
  *
- * GH-696: the claude leg reads the RAW payload (evt.native), NOT the
- * env-folded evt.agent.type — resolveAgent folds in CLAUDE_AGENT_TYPE/
- * CLAUDE_CURRENT_AGENT, which can leak via tmux global env and would
- * permanently mute auto-advance in a main session.
+ * GH-696: the claude leg reads the RAW payload (evt.native) and the
+ * transcript path ONLY — never the env-folded evt.agent.type and never
+ * process.env directly. resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, and BOTH leak via tmux global env; any env-derived
+ * signal here would permanently mute auto-advance in a main session
+ * (PR #718). Enforcement-side dispatched-agent detection
+ * (lib/agent-detection.js isDispatchedAgentContext) deliberately still reads
+ * CLAUDE_CURRENT_AGENT — there a false positive only blocks a terminal
+ * bypass with a message naming the leaked var, while here it would be a
+ * silent liveness failure.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
@@ -173,8 +178,7 @@ function isClaudeSubagentContext(evt) {
   const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
-    Boolean(str(native.agent_type) || str(native.agent_id)) ||
-    Boolean(process.env.CLAUDE_CURRENT_AGENT)
+    Boolean(str(native.agent_type) || str(native.agent_id))
   );
 }
 

--- a/plugins/maestro/scripts/lib/runtime/payload.js
+++ b/plugins/maestro/scripts/lib/runtime/payload.js
@@ -153,14 +153,27 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/ or CLAUDE_CURRENT_AGENT set. Codex: payload agent identity
- * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
+ * /subagents/, raw payload agent identity, or CLAUDE_CURRENT_AGENT set.
+ * Codex: payload agent identity (agent_id/agent_type present when inside a
+ * subagent — ground truth §2.5.1).
+ *
+ * GH-696: the claude leg reads the RAW payload (evt.native), NOT the
+ * env-folded evt.agent.type — resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, which can leak via tmux global env and would
+ * permanently mute auto-advance in a main session.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
   if (evt.runtime === 'codex') return Boolean(evt.agent && (evt.agent.id || evt.agent.type));
+  return isClaudeSubagentContext(evt);
+}
+
+/** Claude leg of isSubagentContext — see the GH-696 note above. */
+function isClaudeSubagentContext(evt) {
+  const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
+    Boolean(str(native.agent_type) || str(native.agent_id)) ||
     Boolean(process.env.CLAUDE_CURRENT_AGENT)
   );
 }

--- a/plugins/maestro/scripts/lib/runtime/payload.js
+++ b/plugins/maestro/scripts/lib/runtime/payload.js
@@ -153,14 +153,19 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/, raw payload agent identity, or CLAUDE_CURRENT_AGENT set.
- * Codex: payload agent identity (agent_id/agent_type present when inside a
- * subagent — ground truth §2.5.1).
+ * /subagents/ or raw payload agent identity. Codex: payload agent identity
+ * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
  *
- * GH-696: the claude leg reads the RAW payload (evt.native), NOT the
- * env-folded evt.agent.type — resolveAgent folds in CLAUDE_AGENT_TYPE/
- * CLAUDE_CURRENT_AGENT, which can leak via tmux global env and would
- * permanently mute auto-advance in a main session.
+ * GH-696: the claude leg reads the RAW payload (evt.native) and the
+ * transcript path ONLY — never the env-folded evt.agent.type and never
+ * process.env directly. resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, and BOTH leak via tmux global env; any env-derived
+ * signal here would permanently mute auto-advance in a main session
+ * (PR #718). Enforcement-side dispatched-agent detection
+ * (lib/agent-detection.js isDispatchedAgentContext) deliberately still reads
+ * CLAUDE_CURRENT_AGENT — there a false positive only blocks a terminal
+ * bypass with a message naming the leaked var, while here it would be a
+ * silent liveness failure.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
@@ -173,8 +178,7 @@ function isClaudeSubagentContext(evt) {
   const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
-    Boolean(str(native.agent_type) || str(native.agent_id)) ||
-    Boolean(process.env.CLAUDE_CURRENT_AGENT)
+    Boolean(str(native.agent_type) || str(native.agent_id))
   );
 }
 

--- a/plugins/synapsys/lib/runtime/payload.js
+++ b/plugins/synapsys/lib/runtime/payload.js
@@ -153,14 +153,27 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/ or CLAUDE_CURRENT_AGENT set. Codex: payload agent identity
- * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
+ * /subagents/, raw payload agent identity, or CLAUDE_CURRENT_AGENT set.
+ * Codex: payload agent identity (agent_id/agent_type present when inside a
+ * subagent — ground truth §2.5.1).
+ *
+ * GH-696: the claude leg reads the RAW payload (evt.native), NOT the
+ * env-folded evt.agent.type — resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, which can leak via tmux global env and would
+ * permanently mute auto-advance in a main session.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
   if (evt.runtime === 'codex') return Boolean(evt.agent && (evt.agent.id || evt.agent.type));
+  return isClaudeSubagentContext(evt);
+}
+
+/** Claude leg of isSubagentContext — see the GH-696 note above. */
+function isClaudeSubagentContext(evt) {
+  const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
+    Boolean(str(native.agent_type) || str(native.agent_id)) ||
     Boolean(process.env.CLAUDE_CURRENT_AGENT)
   );
 }

--- a/plugins/synapsys/lib/runtime/payload.js
+++ b/plugins/synapsys/lib/runtime/payload.js
@@ -153,14 +153,19 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/, raw payload agent identity, or CLAUDE_CURRENT_AGENT set.
- * Codex: payload agent identity (agent_id/agent_type present when inside a
- * subagent — ground truth §2.5.1).
+ * /subagents/ or raw payload agent identity. Codex: payload agent identity
+ * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
  *
- * GH-696: the claude leg reads the RAW payload (evt.native), NOT the
- * env-folded evt.agent.type — resolveAgent folds in CLAUDE_AGENT_TYPE/
- * CLAUDE_CURRENT_AGENT, which can leak via tmux global env and would
- * permanently mute auto-advance in a main session.
+ * GH-696: the claude leg reads the RAW payload (evt.native) and the
+ * transcript path ONLY — never the env-folded evt.agent.type and never
+ * process.env directly. resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, and BOTH leak via tmux global env; any env-derived
+ * signal here would permanently mute auto-advance in a main session
+ * (PR #718). Enforcement-side dispatched-agent detection
+ * (lib/agent-detection.js isDispatchedAgentContext) deliberately still reads
+ * CLAUDE_CURRENT_AGENT — there a false positive only blocks a terminal
+ * bypass with a message naming the leaked var, while here it would be a
+ * silent liveness failure.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
@@ -173,8 +178,7 @@ function isClaudeSubagentContext(evt) {
   const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
-    Boolean(str(native.agent_type) || str(native.agent_id)) ||
-    Boolean(process.env.CLAUDE_CURRENT_AGENT)
+    Boolean(str(native.agent_type) || str(native.agent_id))
   );
 }
 

--- a/plugins/work/scripts/workflows/lib/runtime/payload.js
+++ b/plugins/work/scripts/workflows/lib/runtime/payload.js
@@ -153,14 +153,27 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/ or CLAUDE_CURRENT_AGENT set. Codex: payload agent identity
- * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
+ * /subagents/, raw payload agent identity, or CLAUDE_CURRENT_AGENT set.
+ * Codex: payload agent identity (agent_id/agent_type present when inside a
+ * subagent — ground truth §2.5.1).
+ *
+ * GH-696: the claude leg reads the RAW payload (evt.native), NOT the
+ * env-folded evt.agent.type — resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, which can leak via tmux global env and would
+ * permanently mute auto-advance in a main session.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
   if (evt.runtime === 'codex') return Boolean(evt.agent && (evt.agent.id || evt.agent.type));
+  return isClaudeSubagentContext(evt);
+}
+
+/** Claude leg of isSubagentContext — see the GH-696 note above. */
+function isClaudeSubagentContext(evt) {
+  const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
+    Boolean(str(native.agent_type) || str(native.agent_id)) ||
     Boolean(process.env.CLAUDE_CURRENT_AGENT)
   );
 }

--- a/plugins/work/scripts/workflows/lib/runtime/payload.js
+++ b/plugins/work/scripts/workflows/lib/runtime/payload.js
@@ -153,14 +153,19 @@ function normalizeHookPayload(raw, opts = {}) {
 
 /**
  * Whether the event fired inside a subagent. Claude: transcript under
- * /subagents/, raw payload agent identity, or CLAUDE_CURRENT_AGENT set.
- * Codex: payload agent identity (agent_id/agent_type present when inside a
- * subagent — ground truth §2.5.1).
+ * /subagents/ or raw payload agent identity. Codex: payload agent identity
+ * (agent_id/agent_type present when inside a subagent — ground truth §2.5.1).
  *
- * GH-696: the claude leg reads the RAW payload (evt.native), NOT the
- * env-folded evt.agent.type — resolveAgent folds in CLAUDE_AGENT_TYPE/
- * CLAUDE_CURRENT_AGENT, which can leak via tmux global env and would
- * permanently mute auto-advance in a main session.
+ * GH-696: the claude leg reads the RAW payload (evt.native) and the
+ * transcript path ONLY — never the env-folded evt.agent.type and never
+ * process.env directly. resolveAgent folds in CLAUDE_AGENT_TYPE/
+ * CLAUDE_CURRENT_AGENT, and BOTH leak via tmux global env; any env-derived
+ * signal here would permanently mute auto-advance in a main session
+ * (PR #718). Enforcement-side dispatched-agent detection
+ * (lib/agent-detection.js isDispatchedAgentContext) deliberately still reads
+ * CLAUDE_CURRENT_AGENT — there a false positive only blocks a terminal
+ * bypass with a message naming the leaked var, while here it would be a
+ * silent liveness failure.
  */
 function isSubagentContext(evt) {
   if (!evt || typeof evt !== 'object') return false;
@@ -173,8 +178,7 @@ function isClaudeSubagentContext(evt) {
   const native = asObject(evt.native) || {};
   return (
     (typeof evt.transcriptPath === 'string' && evt.transcriptPath.includes('/subagents/')) ||
-    Boolean(str(native.agent_type) || str(native.agent_id)) ||
-    Boolean(process.env.CLAUDE_CURRENT_AGENT)
+    Boolean(str(native.agent_type) || str(native.agent_id))
   );
 }
 

--- a/plugins/work/scripts/workflows/work/__tests__/phase-ledger.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/phase-ledger.test.js
@@ -1,0 +1,253 @@
+'use strict';
+
+/**
+ * Tests for lib/phase-ledger.js (GH-696) — the ONE shared "inner phase ledger
+ * is terminal" predicate — plus its verifier consumers: step verifiers
+ * (verifyBrief/verifySpec/verifyTasks) and gate verifiers (verifyBriefGate/
+ * verifySpecGate) must refuse to vouch while the step's *-phase.json ledger
+ * is mid-flight (the GH-689 race: outer auto-advance closed the artifact
+ * window while the writer agent was mid-DRAFT).
+ *
+ * Contract:
+ *   - absent ledger file      → not blocked (legacy/pre-phase-driver tickets)
+ *   - currentPhase terminal   → not blocked
+ *   - currentPhase non-terminal → blocked
+ *   - unreadable/corrupt JSON → blocked, currentPhase 'unparseable' (fail
+ *     closed; repair = re-dispatch the writer agent, whose runner resumes
+ *     from the recorded phase)
+ *
+ * Run: node --test workflows/work/__tests__/phase-ledger.test.js
+ */
+
+const { describe, it, beforeEach, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { phaseLedgerBlocked, STEP_LEDGERS } = require('../lib/phase-ledger');
+const { createStepVerifiers } = require('../workflow-def/step-verifiers');
+const { createGateVerifiers } = require('../workflow-def/gate-verifiers');
+
+const workRoot = path.join(__dirname, '..');
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'phase-ledger-'));
+const ticketId = 'GH-696';
+const ticketDir = path.join(tmpRoot, ticketId);
+fs.mkdirSync(ticketDir, { recursive: true });
+
+function writeLedger(file, currentPhase) {
+  fs.writeFileSync(path.join(ticketDir, file), JSON.stringify({ currentPhase }), 'utf-8');
+}
+
+function clearTicketDir() {
+  for (const f of fs.readdirSync(ticketDir)) {
+    fs.rmSync(path.join(ticketDir, f), { recursive: true, force: true });
+  }
+}
+
+after(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+// ─── phaseLedgerBlocked truth table ─────────────────────────────────────────
+
+describe('phase-ledger: phaseLedgerBlocked (GH-696)', () => {
+  beforeEach(clearTicketDir);
+
+  it('maps brief/spec/tasks to their ledger files with terminal "done"', () => {
+    assert.equal(STEP_LEDGERS.brief.file, 'brief-phase.json');
+    assert.equal(STEP_LEDGERS.spec.file, 'spec-phase.json');
+    assert.equal(STEP_LEDGERS.tasks.file, 'tasks-phase.json');
+    for (const step of ['brief', 'spec', 'tasks']) {
+      assert.equal(STEP_LEDGERS[step].terminal, 'done');
+    }
+  });
+
+  it('absent ledger file → not blocked (legacy/pre-phase-driver tickets)', () => {
+    for (const step of ['brief', 'spec', 'tasks']) {
+      assert.deepEqual(phaseLedgerBlocked(ticketDir, step), {
+        blocked: false,
+        currentPhase: null,
+      });
+    }
+  });
+
+  it('non-terminal currentPhase → blocked, phase surfaced', () => {
+    writeLedger('brief-phase.json', 'draft');
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'brief'), {
+      blocked: true,
+      currentPhase: 'draft',
+    });
+    writeLedger('spec-phase.json', 'surface_audit');
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'spec'), {
+      blocked: true,
+      currentPhase: 'surface_audit',
+    });
+    writeLedger('tasks-phase.json', 'requirements_extract');
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'tasks'), {
+      blocked: true,
+      currentPhase: 'requirements_extract',
+    });
+  });
+
+  it('terminal currentPhase "done" → not blocked', () => {
+    for (const [step, file] of [
+      ['brief', 'brief-phase.json'],
+      ['spec', 'spec-phase.json'],
+      ['tasks', 'tasks-phase.json'],
+    ]) {
+      writeLedger(file, 'done');
+      assert.deepEqual(phaseLedgerBlocked(ticketDir, step), {
+        blocked: false,
+        currentPhase: 'done',
+      });
+    }
+  });
+
+  it('corrupt ledger JSON → blocked with currentPhase "unparseable" (fail closed; repair: re-dispatch the writer agent — its runner resumes from the recorded phase)', () => {
+    fs.writeFileSync(path.join(ticketDir, 'brief-phase.json'), '{not json', 'utf-8');
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'brief'), {
+      blocked: true,
+      currentPhase: 'unparseable',
+    });
+  });
+
+  it('parseable ledger without a string currentPhase → blocked "unparseable" (refusal to vouch)', () => {
+    fs.writeFileSync(path.join(ticketDir, 'spec-phase.json'), JSON.stringify({}), 'utf-8');
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'spec'), {
+      blocked: true,
+      currentPhase: 'unparseable',
+    });
+  });
+
+  it('steps without a registered ledger → never blocked (map-driven)', () => {
+    assert.deepEqual(phaseLedgerBlocked(ticketDir, 'pr'), { blocked: false, currentPhase: null });
+  });
+});
+
+// ─── Step verifiers consume the predicate ───────────────────────────────────
+
+describe('phase-ledger: step verifiers refuse mid-flight ledgers (GH-696)', () => {
+  const v = createStepVerifiers({ TASKS_BASE: tmpRoot, safeTicketPath: (id) => id, workRoot });
+
+  beforeEach(clearTicketDir);
+
+  const MATRIX = [
+    ['verifyBrief', 'brief.md', 'brief-phase.json', 'draft'],
+    ['verifySpec', 'spec.md', 'spec-phase.json', 'surface_audit'],
+    ['verifyTasks', 'tasks.md', 'tasks-phase.json', 'draft'],
+  ];
+
+  for (const [verifier, artifact, ledgerFile, midPhase] of MATRIX) {
+    it(`${verifier}: artifact + no ledger → true (regression: legacy tickets advance as today)`, () => {
+      fs.writeFileSync(path.join(ticketDir, artifact), '# content\n', 'utf-8');
+      assert.equal(v[verifier](ticketId), true);
+    });
+
+    it(`${verifier}: artifact + ${ledgerFile} at "${midPhase}" → false (mid-flight)`, () => {
+      fs.writeFileSync(path.join(ticketDir, artifact), '# content\n', 'utf-8');
+      writeLedger(ledgerFile, midPhase);
+      assert.equal(v[verifier](ticketId), false);
+    });
+
+    it(`${verifier}: artifact + ${ledgerFile} at "done" → true`, () => {
+      fs.writeFileSync(path.join(ticketDir, artifact), '# content\n', 'utf-8');
+      writeLedger(ledgerFile, 'done');
+      assert.equal(v[verifier](ticketId), true);
+    });
+
+    it(`${verifier}: artifact + corrupt ${ledgerFile} → false (fail closed; repair: re-dispatch the writer agent)`, () => {
+      fs.writeFileSync(path.join(ticketDir, artifact), '# content\n', 'utf-8');
+      fs.writeFileSync(path.join(ticketDir, ledgerFile), '{not json', 'utf-8');
+      assert.equal(v[verifier](ticketId), false);
+    });
+
+    it(`${verifier}: missing artifact → false regardless of ledger`, () => {
+      writeLedger(ledgerFile, 'done');
+      assert.equal(v[verifier](ticketId), false);
+    });
+  }
+
+  it('does not consult sibling ledgers (brief ignores spec-phase.json)', () => {
+    fs.writeFileSync(path.join(ticketDir, 'brief.md'), '# content\n', 'utf-8');
+    writeLedger('spec-phase.json', 'surface_audit');
+    assert.equal(v.verifyBrief(ticketId), true);
+  });
+});
+
+// ─── Gate verifiers consume the predicate ───────────────────────────────────
+
+describe('phase-ledger: gate verifiers refuse mid-flight ledgers (GH-696)', () => {
+  const g = createGateVerifiers({
+    TASKS_BASE: tmpRoot,
+    safeTicketPath: (id) => id,
+    resolveGitHead: () => 'ref: refs/heads/stub',
+    workRoot,
+  });
+
+  beforeEach(clearTicketDir);
+
+  function writePassingBrief() {
+    fs.writeFileSync(path.join(ticketDir, 'brief.md'), '# Brief\n\nNo open questions.\n', 'utf-8');
+  }
+
+  function writePassingSpec() {
+    fs.writeFileSync(path.join(ticketDir, 'spec.md'), '# Spec\n', 'utf-8');
+    fs.writeFileSync(
+      path.join(ticketDir, 'gherkin.feature'),
+      '<!-- gherkin-skip: test fixture -->\nFeature: F\n  Scenario: S\n    Given g\n    When w\n    Then t\n',
+      'utf-8'
+    );
+  }
+
+  it('verifyBriefGate: valid brief + no ledger → true (regression)', () => {
+    writePassingBrief();
+    assert.equal(g.verifyBriefGate(ticketId), true);
+  });
+
+  it('verifyBriefGate: valid brief + brief-phase.json at "draft" → false (GH-689 window pin)', () => {
+    writePassingBrief();
+    writeLedger('brief-phase.json', 'draft');
+    assert.equal(g.verifyBriefGate(ticketId), false);
+  });
+
+  it('verifyBriefGate: valid brief + brief-phase.json at "done" → true', () => {
+    writePassingBrief();
+    writeLedger('brief-phase.json', 'done');
+    assert.equal(g.verifyBriefGate(ticketId), true);
+  });
+
+  it('verifyBriefGate: corrupt brief-phase.json → false (fail closed)', () => {
+    writePassingBrief();
+    fs.writeFileSync(path.join(ticketDir, 'brief-phase.json'), '{not json', 'utf-8');
+    assert.equal(g.verifyBriefGate(ticketId), false);
+  });
+
+  it('verifySpecGate: valid spec + no ledger → true (regression)', () => {
+    writePassingSpec();
+    assert.equal(g.verifySpecGate(ticketId), true);
+  });
+
+  it('verifySpecGate: valid spec + spec-phase.json at "surface_audit" → false (GH-689 window pin)', () => {
+    writePassingSpec();
+    writeLedger('spec-phase.json', 'surface_audit');
+    assert.equal(g.verifySpecGate(ticketId), false);
+  });
+
+  it('verifySpecGate: valid spec + spec-phase.json at "done" → true', () => {
+    writePassingSpec();
+    writeLedger('spec-phase.json', 'done');
+    assert.equal(g.verifySpecGate(ticketId), true);
+  });
+
+  it('verifySpecGate: corrupt spec-phase.json → false (fail closed)', () => {
+    writePassingSpec();
+    fs.writeFileSync(path.join(ticketDir, 'spec-phase.json'), '{not json', 'utf-8');
+    assert.equal(g.verifySpecGate(ticketId), false);
+  });
+});

--- a/plugins/work/scripts/workflows/work/__tests__/phase-ledger.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/phase-ledger.test.js
@@ -12,9 +12,10 @@
  *   - absent ledger file      → not blocked (legacy/pre-phase-driver tickets)
  *   - currentPhase terminal   → not blocked
  *   - currentPhase non-terminal → blocked
- *   - unreadable/corrupt JSON → blocked, currentPhase 'unparseable' (fail
- *     closed; repair = re-dispatch the writer agent, whose runner resumes
- *     from the recorded phase)
+ *   - unreadable/corrupt JSON → blocked, currentPhase UNPARSEABLE_PHASE (fail
+ *     closed; repair = operator escalation — re-dispatch cannot fix a corrupt
+ *     ledger, the runner dies reading the same file; the plan matrix routes
+ *     to AskUserQuestion instead, PR #718)
  *
  * Run: node --test workflows/work/__tests__/phase-ledger.test.js
  */
@@ -25,7 +26,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { phaseLedgerBlocked, STEP_LEDGERS } = require('../lib/phase-ledger');
+const { phaseLedgerBlocked, STEP_LEDGERS, UNPARSEABLE_PHASE } = require('../lib/phase-ledger');
 const { createStepVerifiers } = require('../workflow-def/step-verifiers');
 const { createGateVerifiers } = require('../workflow-def/gate-verifiers');
 
@@ -109,12 +110,13 @@ describe('phase-ledger: phaseLedgerBlocked (GH-696)', () => {
     }
   });
 
-  it('corrupt ledger JSON → blocked with currentPhase "unparseable" (fail closed; repair: re-dispatch the writer agent — its runner resumes from the recorded phase)', () => {
+  it('corrupt ledger JSON → blocked with currentPhase UNPARSEABLE_PHASE (fail closed; repair: operator escalation — the plan matrix asks the user to delete/restore the ledger, PR #718)', () => {
     fs.writeFileSync(path.join(ticketDir, 'brief-phase.json'), '{not json', 'utf-8');
     assert.deepEqual(phaseLedgerBlocked(ticketDir, 'brief'), {
       blocked: true,
-      currentPhase: 'unparseable',
+      currentPhase: UNPARSEABLE_PHASE,
     });
+    assert.equal(UNPARSEABLE_PHASE, 'unparseable'); // sentinel pinned — steps key on it
   });
 
   it('parseable ledger without a string currentPhase → blocked "unparseable" (refusal to vouch)', () => {
@@ -161,7 +163,7 @@ describe('phase-ledger: step verifiers refuse mid-flight ledgers (GH-696)', () =
       assert.equal(v[verifier](ticketId), true);
     });
 
-    it(`${verifier}: artifact + corrupt ${ledgerFile} → false (fail closed; repair: re-dispatch the writer agent)`, () => {
+    it(`${verifier}: artifact + corrupt ${ledgerFile} → false (fail closed; repair: operator escalation via the plan matrix, PR #718)`, () => {
       fs.writeFileSync(path.join(ticketDir, artifact), '# content\n', 'utf-8');
       fs.writeFileSync(path.join(ticketDir, ledgerFile), '{not json', 'utf-8');
       assert.equal(v[verifier](ticketId), false);

--- a/plugins/work/scripts/workflows/work/__tests__/work-auto-advance-runtime.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-auto-advance-runtime.test.js
@@ -78,7 +78,14 @@ describe('work-auto-advance — dual runtime', () => {
   function runHook(payload, env = {}) {
     const merged = { ...process.env, ...envBase, ...env };
     // Scrub ambient runtime signals so each row controls detection fully.
-    for (const key of ['AGENT_RUNTIME', 'AGENT_SESSION_ID', 'CODEX_THREAD_ID', 'PLUGIN_ROOT']) {
+    for (const key of [
+      'AGENT_RUNTIME',
+      'AGENT_SESSION_ID',
+      'CODEX_THREAD_ID',
+      'PLUGIN_ROOT',
+      'CLAUDE_AGENT_TYPE',
+      'CLAUDE_CURRENT_AGENT',
+    ]) {
       if (!(key in env)) delete merged[key];
     }
     const r = spawnSync(process.execPath, [HOOK], {
@@ -173,5 +180,48 @@ describe('work-auto-advance — dual runtime', () => {
     );
     assert.equal(r.code, 0);
     assert.equal(r.stdout, '');
+  });
+
+  // GH-696: claude PostToolUse payloads fired during a subagent's tool calls
+  // carry agent identity in the RAW payload (agent_type/agent_id) even when
+  // the transcript path lacks /subagents/ — auto-advance must abstain.
+  it('subagent guard (GH-696): claude payload with native agent_type is silent — work-next never invoked', () => {
+    const r = runHook(
+      {
+        tool_name: 'Task',
+        transcript_path: '/tmp/t.jsonl',
+        session_id: 'sess-1',
+        agent_type: 'pr-generator',
+      },
+      { AGENT_RUNTIME: 'claude' }
+    );
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout, '');
+  });
+
+  it('subagent guard (GH-696): claude payload with native agent_id is silent', () => {
+    const r = runHook(
+      {
+        tool_name: 'Task',
+        transcript_path: '/tmp/t.jsonl',
+        session_id: 'sess-1',
+        agent_id: 'agent-42',
+      },
+      { AGENT_RUNTIME: 'claude' }
+    );
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout, '');
+  });
+
+  // GH-696 scoping pin: identity is read from the RAW payload only, never the
+  // env-folded evt.agent.type — a CLAUDE_AGENT_TYPE leak via tmux global env
+  // must not permanently mute auto-advance in a main session.
+  it('env-leaked CLAUDE_AGENT_TYPE without payload identity still advances (GH-696)', () => {
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl', session_id: 'sess-1' },
+      { AGENT_RUNTIME: 'claude', CLAUDE_AGENT_TYPE: 'developer-nodejs-tdd' }
+    );
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /═══ WORK2: NEXT STEP ═══/);
   });
 });

--- a/plugins/work/scripts/workflows/work/__tests__/work-auto-advance-runtime.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/work-auto-advance-runtime.test.js
@@ -224,4 +224,15 @@ describe('work-auto-advance — dual runtime', () => {
     assert.equal(r.code, 0);
     assert.match(r.stdout, /═══ WORK2: NEXT STEP ═══/);
   });
+
+  // GH-696 (PR #718): CLAUDE_CURRENT_AGENT rides the same tmux global-env
+  // leak — an env-only signal must not mute main-session auto-advance either.
+  it('env-leaked CLAUDE_CURRENT_AGENT without payload identity still advances (GH-696)', () => {
+    const r = runHook(
+      { tool_name: 'Task', transcript_path: '/tmp/t.jsonl', session_id: 'sess-1' },
+      { AGENT_RUNTIME: 'claude', CLAUDE_CURRENT_AGENT: 'pr-generator' }
+    );
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /═══ WORK2: NEXT STEP ═══/);
+  });
 });

--- a/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
+++ b/plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
@@ -280,6 +280,22 @@ describe('workflow-definition: verify[STEPS.brief_gate]', () => {
       fs.rmdirSync(briefPath);
     }
   });
+
+  // GH-696: the gate must not satisfy while the brief runner's inner ledger
+  // is mid-flight, even when brief.md itself validates.
+  it('returns false while brief-phase.json is mid-flight, true once terminal (GH-696)', () => {
+    writeBrief('# Brief\n\nNo open questions.\n');
+    const ledgerPath = path.join(ticketDir, 'brief-phase.json');
+    try {
+      fs.writeFileSync(ledgerPath, JSON.stringify({ currentPhase: 'draft' }), 'utf-8');
+      const verify = getBriefGateVerify();
+      assert.equal(verify(ticketId), false);
+      fs.writeFileSync(ledgerPath, JSON.stringify({ currentPhase: 'done' }), 'utf-8');
+      assert.equal(verify(ticketId), true);
+    } finally {
+      fs.rmSync(ledgerPath, { force: true });
+    }
+  });
 });
 
 // ─── GH-211 Task 6: task_review verify entry + softSteps ─────────────────────
@@ -843,6 +859,23 @@ describe('workflow-definition: verify[STEPS.spec_gate]', () => {
     );
     const verify = getSpecGateVerify();
     assert.equal(verify(ticketId), false);
+  });
+
+  // GH-696: spec_gate satisfiedAt landed ~3s into the in-flight spec agent's
+  // timeline on GH-689 — the gate must wait for the inner ledger's terminal.
+  it('returns false while spec-phase.json is mid-flight, true once terminal (GH-696)', () => {
+    writeSpec('# Spec\n');
+    writeGherkin('<!-- gherkin-skip: fixture -->\nFeature: F\n');
+    const ledgerPath = path.join(ticketDir, 'spec-phase.json');
+    try {
+      fs.writeFileSync(ledgerPath, JSON.stringify({ currentPhase: 'surface_audit' }), 'utf-8');
+      const verify = getSpecGateVerify();
+      assert.equal(verify(ticketId), false);
+      fs.writeFileSync(ledgerPath, JSON.stringify({ currentPhase: 'done' }), 'utf-8');
+      assert.equal(verify(ticketId), true);
+    } finally {
+      fs.rmSync(ledgerPath, { force: true });
+    }
   });
 });
 

--- a/plugins/work/scripts/workflows/work/engine/inspect.js
+++ b/plugins/work/scripts/workflows/work/engine/inspect.js
@@ -16,6 +16,7 @@ const path = require('path');
 const { parseReportStatus } = require(
   path.join(__dirname, '..', '..', 'lib', 'parse-report-status')
 );
+const { phaseLedgerBlocked } = require(path.join(__dirname, '..', 'lib', 'phase-ledger'));
 
 // Report-type mapping for the parse-report-status fallback (echo-5219: reviewer
 // agents emit prose verdicts like "## Overall Assessment: ✅ Well-Implemented"
@@ -272,6 +273,19 @@ function inspect(ticket, providerConfig, suffix, deps) {
   s.hasSpec = fileExists(path.join(s.tasksDir, 'spec.md'));
   s.hasGherkin = fileExists(path.join(s.tasksDir, 'gherkin.feature'));
   s.hasTasks = fileExists(path.join(s.tasksDir, 'tasks.md'));
+
+  // GH-696: inner phase-ledger resume signals for the plan matrix — a step
+  // whose artifact exists but whose *-phase.json is non-terminal needs its
+  // writer agent re-dispatched (the runner resumes from the recorded phase).
+  const briefLedger = phaseLedgerBlocked(s.tasksDir, 'brief');
+  const specLedger = phaseLedgerBlocked(s.tasksDir, 'spec');
+  const tasksLedger = phaseLedgerBlocked(s.tasksDir, 'tasks');
+  s.briefPhaseMidFlight = briefLedger.blocked;
+  s.briefPhase = briefLedger.currentPhase;
+  s.specPhaseMidFlight = specLedger.blocked;
+  s.specPhase = specLedger.currentPhase;
+  s.tasksPhaseMidFlight = tasksLedger.blocked;
+  s.tasksPhase = tasksLedger.currentPhase;
 
   // Dev session
   s.hasDevSession = run(`tmux has-session -t "${ticket}-dev" 2>/dev/null && echo yes`) === 'yes';

--- a/plugins/work/scripts/workflows/work/engine/inspect.js
+++ b/plugins/work/scripts/workflows/work/engine/inspect.js
@@ -277,6 +277,8 @@ function inspect(ticket, providerConfig, suffix, deps) {
   // GH-696: inner phase-ledger resume signals for the plan matrix — a step
   // whose artifact exists but whose *-phase.json is non-terminal needs its
   // writer agent re-dispatched (the runner resumes from the recorded phase).
+  // An UNPARSEABLE_PHASE ledger instead routes to an operator escalation
+  // (PR #718): re-dispatch cannot repair a corrupt file the runner dies on.
   const briefLedger = phaseLedgerBlocked(s.tasksDir, 'brief');
   const specLedger = phaseLedgerBlocked(s.tasksDir, 'spec');
   const tasksLedger = phaseLedgerBlocked(s.tasksDir, 'tasks');

--- a/plugins/work/scripts/workflows/work/lib/phase-ledger.js
+++ b/plugins/work/scripts/workflows/work/lib/phase-ledger.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * phase-ledger.js — the ONE shared "inner phase ledger is terminal" predicate
+ * (GH-696).
+ *
+ * The brief/spec/tasks steps run self-paced inner phase drivers that record
+ * their progress in `<step>-phase.json` ledgers. On GH-689 the outer driver
+ * closed step artifact windows while those drivers were still mid-flight
+ * (brief advanced at `draft`, spec_gate satisfied at `surface_audit`),
+ * silently skipping the remaining validate/memorize/kind_checks phases.
+ *
+ * Step verifiers, gate verifiers, and inspect.js all consume THIS predicate
+ * so they cannot drift; the map is data-driven so pr/task_review ledgers can
+ * join later without touching the verifiers.
+ *
+ * Contract:
+ *   - step without a registered ledger → not blocked
+ *   - absent ledger file               → not blocked (legacy/pre-phase-driver
+ *     tickets advance exactly as today)
+ *   - currentPhase === terminal        → not blocked
+ *   - currentPhase non-terminal        → blocked (writer agent mid-flight —
+ *     the plan matrix re-dispatches it; its runner resumes from currentPhase)
+ *   - unreadable/corrupt/phase-less    → blocked, currentPhase 'unparseable'
+ *     (fail closed — refusal to vouch, per the checkpoints.js precedent;
+ *     repair: re-dispatch the writer agent)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { BRIEF_TERMINAL_PHASE } = require(
+  path.join(__dirname, '..', '..', 'work-brief', 'brief-phase-registry')
+);
+const { SPEC_TERMINAL_PHASE } = require(
+  path.join(__dirname, '..', '..', 'work-spec', 'spec-phase-registry')
+);
+const { TASKS_TERMINAL_PHASE } = require(
+  path.join(__dirname, '..', '..', 'work-tasks', 'tasks-phase-registry')
+);
+
+// File names match each runner's phase-state writer (see
+// `stateFileName` in *-phase-state.js).
+const STEP_LEDGERS = Object.freeze({
+  brief: Object.freeze({ file: 'brief-phase.json', terminal: BRIEF_TERMINAL_PHASE }),
+  spec: Object.freeze({ file: 'spec-phase.json', terminal: SPEC_TERMINAL_PHASE }),
+  tasks: Object.freeze({ file: 'tasks-phase.json', terminal: TASKS_TERMINAL_PHASE }),
+});
+
+/**
+ * @param {string} ticketDir - absolute path to the ticket's tasks dir
+ * @param {string} step - workflow step name ('brief' | 'spec' | 'tasks' | …)
+ * @returns {{ blocked: boolean, currentPhase: string|null }}
+ */
+function phaseLedgerBlocked(ticketDir, step) {
+  const ledger = STEP_LEDGERS[step];
+  if (!ledger) return { blocked: false, currentPhase: null };
+  const file = path.join(ticketDir, ledger.file);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf-8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return { blocked: false, currentPhase: null };
+    return { blocked: true, currentPhase: 'unparseable' }; // unreadable — refuse to vouch
+  }
+  let currentPhase;
+  try {
+    currentPhase = JSON.parse(raw)?.currentPhase;
+  } catch {
+    return { blocked: true, currentPhase: 'unparseable' };
+  }
+  if (typeof currentPhase !== 'string' || currentPhase === '') {
+    return { blocked: true, currentPhase: 'unparseable' };
+  }
+  return { blocked: currentPhase !== ledger.terminal, currentPhase };
+}
+
+module.exports = { STEP_LEDGERS, phaseLedgerBlocked };

--- a/plugins/work/scripts/workflows/work/lib/phase-ledger.js
+++ b/plugins/work/scripts/workflows/work/lib/phase-ledger.js
@@ -21,9 +21,15 @@
  *   - currentPhase === terminal        → not blocked
  *   - currentPhase non-terminal        → blocked (writer agent mid-flight —
  *     the plan matrix re-dispatches it; its runner resumes from currentPhase)
- *   - unreadable/corrupt/phase-less    → blocked, currentPhase 'unparseable'
- *     (fail closed — refusal to vouch, per the checkpoints.js precedent;
- *     repair: re-dispatch the writer agent)
+ *   - unreadable/corrupt/phase-less    → blocked, currentPhase UNPARSEABLE_PHASE
+ *     (fail closed — refusal to vouch, per the checkpoints.js precedent).
+ *     Re-dispatching the writer CANNOT repair this one: its runner reads the
+ *     same corrupt file and dies at `init` (create-phase-state-cli.js
+ *     readState → JSON.parse throw), so the plan matrix routes it to an
+ *     AskUserQuestion operator escalation naming the corrupt file and the
+ *     repair (delete the ledger to accept the artifact pre-ledger-style, or
+ *     restore valid JSON so the runner resumes) — see
+ *     steps/lib/unparseable-ledger-escalation.js (PR #718).
  */
 
 const fs = require('fs');
@@ -38,6 +44,12 @@ const { SPEC_TERMINAL_PHASE } = require(
 const { TASKS_TERMINAL_PHASE } = require(
   path.join(__dirname, '..', '..', 'work-tasks', 'tasks-phase-registry')
 );
+
+// Sentinel currentPhase for a ledger that exists but cannot be trusted
+// (unreadable, corrupt JSON, or no string currentPhase). Deliberately not a
+// real registry phase: runners can never reach it, and the plan matrix keys
+// the operator-escalation branch on it.
+const UNPARSEABLE_PHASE = 'unparseable';
 
 // File names match each runner's phase-state writer (see
 // `stateFileName` in *-phase-state.js).
@@ -61,18 +73,18 @@ function phaseLedgerBlocked(ticketDir, step) {
     raw = fs.readFileSync(file, 'utf-8');
   } catch (err) {
     if (err && err.code === 'ENOENT') return { blocked: false, currentPhase: null };
-    return { blocked: true, currentPhase: 'unparseable' }; // unreadable — refuse to vouch
+    return { blocked: true, currentPhase: UNPARSEABLE_PHASE }; // unreadable — refuse to vouch
   }
   let currentPhase;
   try {
     currentPhase = JSON.parse(raw)?.currentPhase;
   } catch {
-    return { blocked: true, currentPhase: 'unparseable' };
+    return { blocked: true, currentPhase: UNPARSEABLE_PHASE };
   }
   if (typeof currentPhase !== 'string' || currentPhase === '') {
-    return { blocked: true, currentPhase: 'unparseable' };
+    return { blocked: true, currentPhase: UNPARSEABLE_PHASE };
   }
   return { blocked: currentPhase !== ledger.terminal, currentPhase };
 }
 
-module.exports = { STEP_LEDGERS, phaseLedgerBlocked };
+module.exports = { STEP_LEDGERS, UNPARSEABLE_PHASE, phaseLedgerBlocked };

--- a/plugins/work/scripts/workflows/work/steps/__tests__/brief.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/brief.test.js
@@ -126,4 +126,32 @@ describe('brief step (GH-253)', () => {
     assert.equal(entries.length, 1);
     assert.equal(entries[0].action, 'RUN');
   });
+
+  // GH-696: brief.md present but brief-phase.json mid-flight → re-dispatch the
+  // brief-writer with a resume-oriented prompt (the deadlock-free repair route
+  // for the ledger-blocked verifier — never a bare DEFER).
+  it('RUNs the brief-writer in resume mode when brief exists but the ledger is mid-flight (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    briefStep(
+      add,
+      makeState({ hasBrief: true, briefPhaseMidFlight: true, briefPhase: 'draft' }),
+      makeCtx()
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.brief);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.agentType, 'brief-writer');
+    assert.match(entry.agentPrompt, /brief-phase\.json/);
+    assert.match(entry.agentPrompt, /"draft"/);
+    assert.match(entry.agentPrompt, /brief-next\.js/);
+    assert.match(entry.agentPrompt, /resume/i);
+  });
+
+  it('DEFERs when brief exists and the ledger flag is explicitly false (GH-696 regression)', () => {
+    const { add, entries } = makeAdd();
+    briefStep(add, makeState({ hasBrief: true, briefPhaseMidFlight: false }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'DEFER');
+  });
 });

--- a/plugins/work/scripts/workflows/work/steps/__tests__/brief.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/brief.test.js
@@ -154,4 +154,37 @@ describe('brief step (GH-253)', () => {
     assert.equal(entries.length, 1);
     assert.equal(entries[0].action, 'DEFER');
   });
+
+  // GH-696 (PR #718): an unparseable ledger cannot be repaired by re-dispatching
+  // the writer — brief-next.js dies reading the same corrupt file ("Could not
+  // init phase state"). The plan entry must route to the operator instead,
+  // naming the corrupt file and the repair.
+  it('escalates via AskUserQuestion when the ledger is unparseable — never re-dispatches the writer (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    briefStep(
+      add,
+      makeState({ hasBrief: true, briefPhaseMidFlight: true, briefPhase: 'unparseable' }),
+      makeCtx()
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.brief);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.command, 'AskUserQuestion');
+    assert.notEqual(entry.agentType, 'brief-writer');
+    assert.match(entry.agentPrompt, /brief-phase\.json/);
+    assert.match(entry.agentPrompt, /delete/i);
+    assert.ok(!/brief-next\.js.*resumes from the recorded phase/.test(entry.agentPrompt));
+  });
+
+  it('unparseable ledger escalates even when brief.md is absent (same corrupt-init wall) (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    briefStep(
+      add,
+      makeState({ hasBrief: false, briefPhaseMidFlight: true, briefPhase: 'unparseable' }),
+      makeCtx()
+    );
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].command, 'AskUserQuestion');
+  });
 });

--- a/plugins/work/scripts/workflows/work/steps/__tests__/spec.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/spec.test.js
@@ -182,4 +182,24 @@ describe('spec step (GH-253)', () => {
     assert.equal(entries.length, 1);
     assert.equal(entries[0].action, 'DEFER');
   });
+
+  // GH-696 (PR #718): an unparseable ledger cannot be repaired by re-dispatching
+  // the writer — spec-next.js dies reading the same corrupt file ("Could not
+  // init phase state"). Route to the operator instead.
+  it('escalates via AskUserQuestion when the ledger is unparseable — never re-dispatches the writer (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    specStep(
+      add,
+      makeState({ hasSpec: true, specPhaseMidFlight: true, specPhase: 'unparseable' }),
+      makeCtx()
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.spec);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.command, 'AskUserQuestion');
+    assert.notEqual(entry.agentType, 'spec-writer');
+    assert.match(entry.agentPrompt, /spec-phase\.json/);
+    assert.match(entry.agentPrompt, /delete/i);
+  });
 });

--- a/plugins/work/scripts/workflows/work/steps/__tests__/spec.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/spec.test.js
@@ -155,4 +155,31 @@ describe('spec step (GH-253)', () => {
     specStep(add, makeState({ hasSpec: false }), makeCtx());
     assert.equal(entries[0].agentType, 'spec-writer');
   });
+
+  // GH-696: spec.md present but spec-phase.json mid-flight → re-dispatch the
+  // spec-writer with a resume-oriented prompt (deadlock-free repair route).
+  it('RUNs the spec-writer in resume mode when spec exists but the ledger is mid-flight (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    specStep(
+      add,
+      makeState({ hasSpec: true, specPhaseMidFlight: true, specPhase: 'surface_audit' }),
+      makeCtx()
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.spec);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.agentType, 'spec-writer');
+    assert.match(entry.agentPrompt, /spec-phase\.json/);
+    assert.match(entry.agentPrompt, /"surface_audit"/);
+    assert.match(entry.agentPrompt, /spec-next\.js/);
+    assert.match(entry.agentPrompt, /resume/i);
+  });
+
+  it('DEFERs when spec exists and the ledger flag is explicitly false (GH-696 regression)', () => {
+    const { add, entries } = makeAdd();
+    specStep(add, makeState({ hasSpec: true, specPhaseMidFlight: false }), makeCtx());
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'DEFER');
+  });
 });

--- a/plugins/work/scripts/workflows/work/steps/__tests__/tasks.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/tasks.test.js
@@ -181,4 +181,25 @@ describe('tasks step (GH-253)', () => {
     assert.equal(entries.length, 1);
     assert.equal(entries[0].action, 'DEFER');
   });
+
+  // GH-696 (PR #718): an unparseable ledger cannot be repaired by re-dispatching
+  // the writer — tasks-next.js dies reading the same corrupt file ("Could not
+  // init phase state"). Route to the operator instead.
+  it('escalates via AskUserQuestion when the ledger is unparseable — never re-dispatches the writer (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    tasksStep(
+      add,
+      makeState({ hasTasks: true, tasksPhaseMidFlight: true, tasksPhase: 'unparseable' }),
+      ctx
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.tasks);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.command, 'AskUserQuestion');
+    assert.notEqual(entry.agentType, 'skill');
+    assert.match(entry.agentPrompt, /tasks-phase\.json/);
+    assert.match(entry.agentPrompt, /delete/i);
+  });
 });

--- a/plugins/work/scripts/workflows/work/steps/__tests__/tasks.test.js
+++ b/plugins/work/scripts/workflows/work/steps/__tests__/tasks.test.js
@@ -139,4 +139,46 @@ describe('tasks step (GH-253)', () => {
     assert.equal(entries[0].agentType, 'skill');
     assert.match(entries[0].agentPrompt, /split-in-tasks/);
   });
+
+  // GH-696: tasks.md present but tasks-phase.json mid-flight → re-dispatch the
+  // split-in-tasks skill with a resume-oriented prompt (deadlock-free repair).
+  it('RUNs split-in-tasks in resume mode when tasks exist but the ledger is mid-flight (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    tasksStep(
+      add,
+      makeState({ hasTasks: true, tasksPhaseMidFlight: true, tasksPhase: 'traceability' }),
+      ctx
+    );
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.step, STEPS.tasks);
+    assert.equal(entry.action, 'RUN');
+    assert.equal(entry.agentType, 'skill');
+    assert.match(entry.agentPrompt, /split-in-tasks/);
+    assert.match(entry.agentPrompt, /tasks-phase\.json/);
+    assert.match(entry.agentPrompt, /"traceability"/);
+    assert.match(entry.agentPrompt, /tasks-next\.js/);
+    assert.match(entry.agentPrompt, /resume/i);
+  });
+
+  it('resume branch fires even when spec.md is missing (runner self-heals) (GH-696)', () => {
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => false });
+    tasksStep(
+      add,
+      makeState({ hasTasks: true, tasksPhaseMidFlight: true, tasksPhase: 'draft' }),
+      ctx
+    );
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'RUN');
+  });
+
+  it('DEFERs when tasks exist and the ledger flag is explicitly false (GH-696 regression)', () => {
+    const { add, entries } = makeAdd();
+    const ctx = makeCtx({ fileExists: () => true });
+    tasksStep(add, makeState({ hasTasks: true, tasksPhaseMidFlight: false }), ctx);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].action, 'DEFER');
+  });
 });

--- a/plugins/work/scripts/workflows/work/steps/brief.js
+++ b/plugins/work/scripts/workflows/work/steps/brief.js
@@ -3,8 +3,11 @@
  * Generates the product brief from ticket requirements.
  *
  * Decision matrix:
- *   1. hasBrief=true  → DEFER (artifact already present)
- *   2. hasBrief=false → RUN  (generate the brief)
+ *   1. hasBrief=true, ledger terminal/absent → DEFER (artifact already present)
+ *   2. hasBrief=true, ledger mid-flight      → RUN  (GH-696: re-dispatch the
+ *      brief-writer — brief-next.js resumes from the recorded phase; the
+ *      ledger-blocked verifier would otherwise wedge on a bare DEFER)
+ *   3. hasBrief=false                        → RUN  (generate the brief)
  *
  * @param {Function} add
  * @param {object} s
@@ -13,8 +16,19 @@
 module.exports = function briefStep(add, s, ctx) {
   const { STEPS, t, tasksDir, getDocsPrompt, fileExists, path } = ctx;
 
-  if (s?.hasBrief) {
+  if (s?.hasBrief && !s.briefPhaseMidFlight) {
     add(STEPS.brief, 'DEFER', null, 'brief.md already exists');
+  } else if (s?.hasBrief && s.briefPhaseMidFlight) {
+    add(
+      STEPS.brief,
+      'RUN',
+      'Task(brief-writer)',
+      `brief.md exists but brief-phase.json is mid-flight at "${s.briefPhase}" — resume the brief runner`,
+      {
+        agentType: 'brief-writer',
+        agentPrompt: `Resume the product brief for ticket ${t}: brief.md exists at ${path.join(tasksDir, 'brief.md')} but the inner phase ledger brief-phase.json is at "${s.briefPhase}" (not "done").\n\n**Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-brief/brief-next.js ${t}\` and follow its instructions** — it resumes from the recorded phase and tells you what each remaining phase needs until the ledger reaches "done". Do NOT edit brief-phase.json directly.${getDocsPrompt('READ_DOCS_ON_BRIEF')}`,
+      }
+    );
   } else {
     add(
       STEPS.brief,

--- a/plugins/work/scripts/workflows/work/steps/brief.js
+++ b/plugins/work/scripts/workflows/work/steps/brief.js
@@ -3,20 +3,36 @@
  * Generates the product brief from ticket requirements.
  *
  * Decision matrix:
- *   1. hasBrief=true, ledger terminal/absent → DEFER (artifact already present)
- *   2. hasBrief=true, ledger mid-flight      → RUN  (GH-696: re-dispatch the
+ *   1. ledger unparseable                    → RUN  AskUserQuestion escalation
+ *      (GH-696/PR #718: a corrupt brief-phase.json cannot be repaired by
+ *      re-dispatching the writer — its runner dies reading the same file —
+ *      so the operator must delete/restore the ledger)
+ *   2. hasBrief=true, ledger terminal/absent → DEFER (artifact already present)
+ *   3. hasBrief=true, ledger mid-flight      → RUN  (GH-696: re-dispatch the
  *      brief-writer — brief-next.js resumes from the recorded phase; the
  *      ledger-blocked verifier would otherwise wedge on a bare DEFER)
- *   3. hasBrief=false                        → RUN  (generate the brief)
+ *   4. hasBrief=false                        → RUN  (generate the brief)
  *
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx
  */
+
+'use strict';
+
+const { UNPARSEABLE_PHASE } = require('../lib/phase-ledger');
+const { addUnparseableLedgerEscalation } = require('./lib/unparseable-ledger-escalation');
+
 module.exports = function briefStep(add, s, ctx) {
   const { STEPS, t, tasksDir, getDocsPrompt, fileExists, path } = ctx;
 
-  if (s?.hasBrief && !s.briefPhaseMidFlight) {
+  if (s?.briefPhaseMidFlight && s.briefPhase === UNPARSEABLE_PHASE) {
+    addUnparseableLedgerEscalation(add, ctx, {
+      step: STEPS.brief,
+      ledgerFile: 'brief-phase.json',
+      artifact: 'brief.md',
+    });
+  } else if (s?.hasBrief && !s.briefPhaseMidFlight) {
     add(STEPS.brief, 'DEFER', null, 'brief.md already exists');
   } else if (s?.hasBrief && s.briefPhaseMidFlight) {
     add(

--- a/plugins/work/scripts/workflows/work/steps/lib/unparseable-ledger-escalation.js
+++ b/plugins/work/scripts/workflows/work/steps/lib/unparseable-ledger-escalation.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * GH-696 (PR #718): operator escalation for an unparseable inner phase ledger.
+ *
+ * A corrupt/phase-less `<step>-phase.json` fails the ledger verifier closed
+ * (phaseLedgerBlocked → currentPhase UNPARSEABLE_PHASE), but re-dispatching
+ * the writer agent cannot repair it: the runner's first phase-state call
+ * reads the same corrupt file and dies (`Could not init phase state` —
+ * create-phase-state-cli.js readState → JSON.parse throw), so the RUN-resume
+ * branch would burn dispatches into the same wall. Route to the operator
+ * instead: the AskUserQuestion entry names the corrupt file and the repair
+ * options, and the verifier keeps failing closed until the ledger is
+ * repaired or removed (absent ledger = pre-ledger behavior, by contract).
+ *
+ * Reuses the escalation vocabulary of steps/task-review.js (T('tool.question')
+ * + renderQuestionText) per the interactive-gates convention.
+ */
+
+const { T, renderQuestionText, getRuntime } = require('../../../lib/instruction-vocab');
+
+/**
+ * @param {Function} add - plan-matrix entry collector
+ * @param {object} ctx - step context (needs `path`, `tasksDir`)
+ * @param {object} opts
+ * @param {string} opts.step - STEPS.* name the entry belongs to
+ * @param {string} opts.ledgerFile - e.g. 'brief-phase.json'
+ * @param {string} opts.artifact - e.g. 'brief.md'
+ */
+function addUnparseableLedgerEscalation(add, ctx, { step, ledgerFile, artifact }) {
+  const rt = getRuntime();
+  const ledgerPath = ctx.path.join(ctx.tasksDir, ledgerFile);
+  add(
+    step,
+    'RUN',
+    T('tool.question', {}, rt.name),
+    `${ledgerFile} is unparseable — operator repair needed (re-dispatching the writer cannot fix a corrupt ledger)`,
+    {
+      agentType: 'general-purpose',
+      agentPrompt: renderQuestionText(
+        `The inner phase ledger ${ledgerPath} is corrupt or has no valid currentPhase, so the ${artifact} verifier fails closed — and re-dispatching the writer agent cannot repair it (its runner reads the same corrupt file and exits with "Could not init phase state"). Use AskUserQuestion to ask the user how to repair: (a) delete ${ledgerPath} so the workflow treats ${artifact} as authored without a phase ledger (pre-ledger behavior), (b) restore valid JSON in the ledger (e.g. from a backup, with a known-good currentPhase) so the runner resumes from it, or (c) abort. Do NOT modify or delete the ledger yourself before the user answers.`,
+        rt
+      ),
+    }
+  );
+}
+
+module.exports = { addUnparseableLedgerEscalation };

--- a/plugins/work/scripts/workflows/work/steps/spec.js
+++ b/plugins/work/scripts/workflows/work/steps/spec.js
@@ -3,40 +3,72 @@
  * Generates the technical specification from the brief and codebase analysis.
  *
  * Decision matrix:
- *   1. hasSpec=true, ledger terminal/absent               → DEFER (artifact already present)
- *   2. hasSpec=true, ledger mid-flight                    → RUN  (GH-696: re-dispatch the
+ *   1. ledger unparseable                                  → RUN AskUserQuestion
+ *      escalation (GH-696/PR #718: a corrupt spec-phase.json cannot be
+ *      repaired by re-dispatching the writer)
+ *   2. hasSpec=true, ledger terminal/absent               → DEFER (artifact already present)
+ *   3. hasSpec=true, ledger mid-flight                    → RUN  (GH-696: re-dispatch the
  *      spec-writer — spec-next.js resumes from the recorded phase)
- *   3. hasSpec=false, brief.md on disk OR hasBrief=false   → RUN with briefRef path in prompt
- *   4. hasSpec=false, brief.md NOT on disk AND hasBrief=true → RUN without briefRef
- *
+ *   4. hasSpec=false, brief.md on disk OR hasBrief=false   → RUN with briefRef path in prompt
+ *   5. hasSpec=false, brief.md NOT on disk AND hasBrief=true → RUN without briefRef
+ */
+
+'use strict';
+
+const { UNPARSEABLE_PHASE } = require('../lib/phase-ledger');
+const { addUnparseableLedgerEscalation } = require('./lib/unparseable-ledger-escalation');
+
+/** Decision 3: spec.md exists but the ledger is mid-flight — resume the runner. */
+function addSpecResumeRun(add, s, ctx, specPath) {
+  const { STEPS, t, getDocsPrompt } = ctx;
+  add(
+    STEPS.spec,
+    'RUN',
+    'Task(spec-writer)',
+    `spec.md exists but spec-phase.json is mid-flight at "${s.specPhase}" — resume the spec runner`,
+    {
+      agentType: 'spec-writer',
+      agentPrompt: `Resume the technical specification for ticket ${t}: spec.md exists at ${specPath} but the inner phase ledger spec-phase.json is at "${s.specPhase}" (not "done").\n\n**Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-spec/spec-next.js ${t}\` and follow its instructions** — it resumes from the recorded phase and drives the remaining phases (… → validate → memorize → kind_checks → done). Do NOT edit spec-phase.json directly.${getDocsPrompt('READ_DOCS_ON_SPEC')}`,
+    }
+  );
+}
+
+/** Decisions 4-5: generate the spec (briefRef included when brief.md is readable). */
+function addSpecGenerateRun(add, s, ctx, briefPath, specPath) {
+  const { STEPS, t, worktreeDir, getDocsPrompt, fileExists } = ctx;
+  const briefRef =
+    fileExists(briefPath) || !s?.hasBrief ? `\n\nRead the product brief at: ${briefPath}` : '';
+  add(STEPS.spec, 'RUN', 'Task(spec-writer)', 'Generate technical specification', {
+    agentType: 'spec-writer',
+    agentPrompt: `Analyze the codebase in ${worktreeDir} and generate a technical specification for ticket ${t}.${briefRef}${getDocsPrompt('READ_DOCS_ON_SPEC')}\n\nSave the spec to: ${specPath}\n\n**Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-spec/spec-next.js ${t}\` at each step.** It is the authoritative phase driver — it tells you what to do for the current phase (inputs → reuse_audit → surface_audit → draft → validate → memorize → kind_checks → done) and records/transitions the phase state when each check passes. Do NOT edit \`spec-phase.json\` directly.\n\nThe spec MUST include (these are the sections the \`draft\` phase will gate on):\n1. Summary\n2. Reuse Audit\n3. Architecture Decisions\n4. Data Model Changes\n5. API/Interface Changes\n6. Security Considerations\n7. Test Scenarios (Gherkin) — structured Feature/Scenario/Given/When/Then with @integration or @e2e tags (min 2 scenarios). Use <!-- gherkin-skip: reason --> for non-testable changes\n8. Implementation Order — numbered steps with explicit dependency notation\n9. Files to Create/Modify\n10. Out of Scope\n11. Open Questions & Decisions\n12. Dependencies\n13. Verification Checklist — machine-checkable markers (FILE_EXISTS, GREP, TEST_COUNT, REUSES)\n\nThe \`surface_audit\` phase will record a \`## Verified sibling surface\` block; the \`kind_checks\` phase will record a \`## Kind verification\` block — both are automatic.`,
+  });
+}
+
+/**
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx
  */
 module.exports = function specStep(add, s, ctx) {
-  const { STEPS, t, worktreeDir, tasksDir, getDocsPrompt, fileExists, path } = ctx;
+  const { STEPS, tasksDir, path } = ctx;
   const briefPath = path.join(tasksDir, 'brief.md');
   const specPath = path.join(tasksDir, 'spec.md');
 
+  if (s?.specPhaseMidFlight && s.specPhase === UNPARSEABLE_PHASE) {
+    addUnparseableLedgerEscalation(add, ctx, {
+      step: STEPS.spec,
+      ledgerFile: 'spec-phase.json',
+      artifact: 'spec.md',
+    });
+    return;
+  }
   if (s?.hasSpec && !s.specPhaseMidFlight) {
     add(STEPS.spec, 'DEFER', null, 'spec.md already exists');
-  } else if (s?.hasSpec && s.specPhaseMidFlight) {
-    add(
-      STEPS.spec,
-      'RUN',
-      'Task(spec-writer)',
-      `spec.md exists but spec-phase.json is mid-flight at "${s.specPhase}" — resume the spec runner`,
-      {
-        agentType: 'spec-writer',
-        agentPrompt: `Resume the technical specification for ticket ${t}: spec.md exists at ${specPath} but the inner phase ledger spec-phase.json is at "${s.specPhase}" (not "done").\n\n**Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-spec/spec-next.js ${t}\` and follow its instructions** — it resumes from the recorded phase and drives the remaining phases (… → validate → memorize → kind_checks → done). Do NOT edit spec-phase.json directly.${getDocsPrompt('READ_DOCS_ON_SPEC')}`,
-      }
-    );
-  } else {
-    const briefRef =
-      fileExists(briefPath) || !s?.hasBrief ? `\n\nRead the product brief at: ${briefPath}` : '';
-    add(STEPS.spec, 'RUN', 'Task(spec-writer)', 'Generate technical specification', {
-      agentType: 'spec-writer',
-      agentPrompt: `Analyze the codebase in ${worktreeDir} and generate a technical specification for ticket ${t}.${briefRef}${getDocsPrompt('READ_DOCS_ON_SPEC')}\n\nSave the spec to: ${specPath}\n\n**Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-spec/spec-next.js ${t}\` at each step.** It is the authoritative phase driver — it tells you what to do for the current phase (inputs → reuse_audit → surface_audit → draft → validate → memorize → kind_checks → done) and records/transitions the phase state when each check passes. Do NOT edit \`spec-phase.json\` directly.\n\nThe spec MUST include (these are the sections the \`draft\` phase will gate on):\n1. Summary\n2. Reuse Audit\n3. Architecture Decisions\n4. Data Model Changes\n5. API/Interface Changes\n6. Security Considerations\n7. Test Scenarios (Gherkin) — structured Feature/Scenario/Given/When/Then with @integration or @e2e tags (min 2 scenarios). Use <!-- gherkin-skip: reason --> for non-testable changes\n8. Implementation Order — numbered steps with explicit dependency notation\n9. Files to Create/Modify\n10. Out of Scope\n11. Open Questions & Decisions\n12. Dependencies\n13. Verification Checklist — machine-checkable markers (FILE_EXISTS, GREP, TEST_COUNT, REUSES)\n\nThe \`surface_audit\` phase will record a \`## Verified sibling surface\` block; the \`kind_checks\` phase will record a \`## Kind verification\` block — both are automatic.`,
-    });
+    return;
   }
+  if (s?.hasSpec) {
+    addSpecResumeRun(add, s, ctx, specPath);
+    return;
+  }
+  addSpecGenerateRun(add, s, ctx, briefPath, specPath);
 };

--- a/plugins/work/scripts/workflows/work/steps/spec.js
+++ b/plugins/work/scripts/workflows/work/steps/spec.js
@@ -3,9 +3,11 @@
  * Generates the technical specification from the brief and codebase analysis.
  *
  * Decision matrix:
- *   1. hasSpec=true                                        → DEFER (artifact already present)
- *   2. hasSpec=false, brief.md on disk OR hasBrief=false   → RUN with briefRef path in prompt
- *   3. hasSpec=false, brief.md NOT on disk AND hasBrief=true → RUN without briefRef
+ *   1. hasSpec=true, ledger terminal/absent               → DEFER (artifact already present)
+ *   2. hasSpec=true, ledger mid-flight                    → RUN  (GH-696: re-dispatch the
+ *      spec-writer — spec-next.js resumes from the recorded phase)
+ *   3. hasSpec=false, brief.md on disk OR hasBrief=false   → RUN with briefRef path in prompt
+ *   4. hasSpec=false, brief.md NOT on disk AND hasBrief=true → RUN without briefRef
  *
  * @param {Function} add
  * @param {object} s
@@ -16,8 +18,19 @@ module.exports = function specStep(add, s, ctx) {
   const briefPath = path.join(tasksDir, 'brief.md');
   const specPath = path.join(tasksDir, 'spec.md');
 
-  if (s?.hasSpec) {
+  if (s?.hasSpec && !s.specPhaseMidFlight) {
     add(STEPS.spec, 'DEFER', null, 'spec.md already exists');
+  } else if (s?.hasSpec && s.specPhaseMidFlight) {
+    add(
+      STEPS.spec,
+      'RUN',
+      'Task(spec-writer)',
+      `spec.md exists but spec-phase.json is mid-flight at "${s.specPhase}" — resume the spec runner`,
+      {
+        agentType: 'spec-writer',
+        agentPrompt: `Resume the technical specification for ticket ${t}: spec.md exists at ${specPath} but the inner phase ledger spec-phase.json is at "${s.specPhase}" (not "done").\n\n**Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-spec/spec-next.js ${t}\` and follow its instructions** — it resumes from the recorded phase and drives the remaining phases (… → validate → memorize → kind_checks → done). Do NOT edit spec-phase.json directly.${getDocsPrompt('READ_DOCS_ON_SPEC')}`,
+      }
+    );
   } else {
     const briefRef =
       fileExists(briefPath) || !s?.hasBrief ? `\n\nRead the product brief at: ${briefPath}` : '';

--- a/plugins/work/scripts/workflows/work/steps/tasks.js
+++ b/plugins/work/scripts/workflows/work/steps/tasks.js
@@ -3,9 +3,11 @@
  * Generates tasks from the technical specification.
  *
  * Decision matrix:
- *   1. hasTasks=true     → DEFER (artifact already present)
- *   2. spec.md missing   → DEFER (dependency not met)
- *   3. spec.md exists    → RUN  (generate tasks from spec)
+ *   1. hasTasks=true, ledger terminal/absent → DEFER (artifact already present)
+ *   2. hasTasks=true, ledger mid-flight      → RUN  (GH-696: re-dispatch
+ *      split-in-tasks — tasks-next.js resumes from the recorded phase)
+ *   3. spec.md missing                       → DEFER (dependency not met)
+ *   4. spec.md exists                        → RUN  (generate tasks from spec)
  *
  * @param {Function} add
  * @param {object} s
@@ -27,8 +29,24 @@ module.exports = function tasksStep(add, s, ctx) {
   // up-front rule prevents the rework.
   const tddCycleRule = `\n\nCRITICAL — each task = ONE full TDD cycle (RED + GREEN + REFACTOR) on the SAME code surface. Use nested deliverables (e.g. 1.1.1 RED, 1.1.2 GREEN, 1.1.3 REFACTOR) within a single task — never as separate tasks. The implement-gate enforces R/G/R within one task; splitting phases across tasks wedges the workflow. See skills/split-in-tasks/SKILL.md Rule 10.`;
 
-  if (s?.hasTasks) {
+  if (s?.hasTasks && !s.tasksPhaseMidFlight) {
     add(STEPS.tasks, 'DEFER', null, 'tasks.md already exists');
+  } else if (s?.hasTasks && s.tasksPhaseMidFlight) {
+    // GH-696: tasks.md exists but the inner ledger is non-terminal — the
+    // ledger-blocked verifier refuses the transition, so re-dispatch the
+    // writer; tasks-next.js resumes from the recorded phase (self-heals even
+    // if spec.md went missing).
+    const resumeHint = `\n\nRESUME (GH-696): tasks.md already exists but the inner phase ledger tasks-phase.json is at "${s.tasksPhase}" (not "done"). Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-tasks/tasks-next.js ${safeName}\` and follow its instructions — it resumes from the recorded phase; drive it until the ledger reaches "done". Do NOT edit tasks-phase.json directly.`;
+    add(
+      STEPS.tasks,
+      'RUN',
+      'Skill(split-in-tasks)',
+      `tasks.md exists but tasks-phase.json is mid-flight at "${s.tasksPhase}" — resume the tasks runner`,
+      {
+        agentType: 'skill',
+        agentPrompt: `/split-in-tasks ${safeName} --force${resumeHint}${driverHint}${tddCycleRule}`,
+      }
+    );
   } else if (!fileExists(specPath)) {
     add(STEPS.tasks, 'DEFER', null, 'No spec.md — cannot generate tasks', {
       agentType: 'skill',

--- a/plugins/work/scripts/workflows/work/steps/tasks.js
+++ b/plugins/work/scripts/workflows/work/steps/tasks.js
@@ -3,12 +3,42 @@
  * Generates tasks from the technical specification.
  *
  * Decision matrix:
- *   1. hasTasks=true, ledger terminal/absent → DEFER (artifact already present)
- *   2. hasTasks=true, ledger mid-flight      → RUN  (GH-696: re-dispatch
+ *   1. ledger unparseable                    → RUN AskUserQuestion escalation
+ *      (GH-696/PR #718: a corrupt tasks-phase.json cannot be repaired by
+ *      re-dispatching the writer)
+ *   2. hasTasks=true, ledger terminal/absent → DEFER (artifact already present)
+ *   3. hasTasks=true, ledger mid-flight      → RUN  (GH-696: re-dispatch
  *      split-in-tasks — tasks-next.js resumes from the recorded phase)
- *   3. spec.md missing                       → DEFER (dependency not met)
- *   4. spec.md exists                        → RUN  (generate tasks from spec)
- *
+ *   4. spec.md missing                       → DEFER (dependency not met)
+ *   5. spec.md exists                        → RUN  (generate tasks from spec)
+ */
+
+'use strict';
+
+const { UNPARSEABLE_PHASE } = require('../lib/phase-ledger');
+const { addUnparseableLedgerEscalation } = require('./lib/unparseable-ledger-escalation');
+
+/** Decision 3: tasks.md exists but the ledger is mid-flight — resume the runner. */
+function addTasksResumeRun(add, s, ctx, driverHint, tddCycleRule) {
+  const { STEPS, safeName } = ctx;
+  // GH-696: tasks.md exists but the inner ledger is non-terminal — the
+  // ledger-blocked verifier refuses the transition, so re-dispatch the
+  // writer; tasks-next.js resumes from the recorded phase (self-heals even
+  // if spec.md went missing).
+  const resumeHint = `\n\nRESUME (GH-696): tasks.md already exists but the inner phase ledger tasks-phase.json is at "${s.tasksPhase}" (not "done"). Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-tasks/tasks-next.js ${safeName}\` and follow its instructions — it resumes from the recorded phase; drive it until the ledger reaches "done". Do NOT edit tasks-phase.json directly.`;
+  add(
+    STEPS.tasks,
+    'RUN',
+    'Skill(split-in-tasks)',
+    `tasks.md exists but tasks-phase.json is mid-flight at "${s.tasksPhase}" — resume the tasks runner`,
+    {
+      agentType: 'skill',
+      agentPrompt: `/split-in-tasks ${safeName} --force${resumeHint}${driverHint}${tddCycleRule}`,
+    }
+  );
+}
+
+/**
  * @param {Function} add
  * @param {object} s
  * @param {object} ctx
@@ -29,33 +59,31 @@ module.exports = function tasksStep(add, s, ctx) {
   // up-front rule prevents the rework.
   const tddCycleRule = `\n\nCRITICAL — each task = ONE full TDD cycle (RED + GREEN + REFACTOR) on the SAME code surface. Use nested deliverables (e.g. 1.1.1 RED, 1.1.2 GREEN, 1.1.3 REFACTOR) within a single task — never as separate tasks. The implement-gate enforces R/G/R within one task; splitting phases across tasks wedges the workflow. See skills/split-in-tasks/SKILL.md Rule 10.`;
 
+  if (s?.tasksPhaseMidFlight && s.tasksPhase === UNPARSEABLE_PHASE) {
+    addUnparseableLedgerEscalation(add, ctx, {
+      step: STEPS.tasks,
+      ledgerFile: 'tasks-phase.json',
+      artifact: 'tasks.md',
+    });
+    return;
+  }
   if (s?.hasTasks && !s.tasksPhaseMidFlight) {
     add(STEPS.tasks, 'DEFER', null, 'tasks.md already exists');
-  } else if (s?.hasTasks && s.tasksPhaseMidFlight) {
-    // GH-696: tasks.md exists but the inner ledger is non-terminal — the
-    // ledger-blocked verifier refuses the transition, so re-dispatch the
-    // writer; tasks-next.js resumes from the recorded phase (self-heals even
-    // if spec.md went missing).
-    const resumeHint = `\n\nRESUME (GH-696): tasks.md already exists but the inner phase ledger tasks-phase.json is at "${s.tasksPhase}" (not "done"). Run \`node $CLAUDE_PLUGIN_ROOT/scripts/workflows/work-tasks/tasks-next.js ${safeName}\` and follow its instructions — it resumes from the recorded phase; drive it until the ledger reaches "done". Do NOT edit tasks-phase.json directly.`;
-    add(
-      STEPS.tasks,
-      'RUN',
-      'Skill(split-in-tasks)',
-      `tasks.md exists but tasks-phase.json is mid-flight at "${s.tasksPhase}" — resume the tasks runner`,
-      {
-        agentType: 'skill',
-        agentPrompt: `/split-in-tasks ${safeName} --force${resumeHint}${driverHint}${tddCycleRule}`,
-      }
-    );
-  } else if (!fileExists(specPath)) {
+    return;
+  }
+  if (s?.hasTasks) {
+    addTasksResumeRun(add, s, ctx, driverHint, tddCycleRule);
+    return;
+  }
+  if (!fileExists(specPath)) {
     add(STEPS.tasks, 'DEFER', null, 'No spec.md — cannot generate tasks', {
       agentType: 'skill',
       agentPrompt: `/split-in-tasks ${safeName} --force${driverHint}${tddCycleRule}`,
     });
-  } else {
-    add(STEPS.tasks, 'RUN', 'Skill(split-in-tasks)', 'Generate tasks from spec', {
-      agentType: 'skill',
-      agentPrompt: `/split-in-tasks ${safeName} --force${driverHint}${tddCycleRule}`,
-    });
+    return;
   }
+  add(STEPS.tasks, 'RUN', 'Skill(split-in-tasks)', 'Generate tasks from spec', {
+    agentType: 'skill',
+    agentPrompt: `/split-in-tasks ${safeName} --force${driverHint}${tddCycleRule}`,
+  });
 };

--- a/plugins/work/scripts/workflows/work/workflow-def/gate-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/gate-verifiers.js
@@ -50,8 +50,14 @@ function verifyBootstrap(deps, ticketId) {
  */
 function verifyBriefGate(deps, ticketId) {
   try {
-    const briefPath = path.join(deps.TASKS_BASE, deps.safeTicketPath(ticketId), 'brief.md');
+    const ticketDir = path.join(deps.TASKS_BASE, deps.safeTicketPath(ticketId));
+    const briefPath = path.join(ticketDir, 'brief.md');
     if (!fs.existsSync(briefPath)) return false;
+    // GH-696: never satisfy the gate while the brief runner's inner ledger is
+    // mid-flight — the artifact window must only close after the runner's
+    // validate/memorize phases ran. Absent ledger keeps today's behavior.
+    const { phaseLedgerBlocked } = require(path.join(deps.workRoot, 'lib', 'phase-ledger'));
+    if (phaseLedgerBlocked(ticketDir, 'brief').blocked) return false;
     const openQuestions = require(path.join(deps.workRoot, 'lib', 'open-questions'));
     const { findUnresolvedSiblingGaps } = require(
       path.join(deps.workRoot, '..', 'lib', 'brief-sibling-gaps')
@@ -80,6 +86,11 @@ function verifySpecGate(deps, ticketId) {
     const ticketDir = path.join(deps.TASKS_BASE, deps.safeTicketPath(ticketId));
     const specPath = path.join(ticketDir, 'spec.md');
     if (!fs.existsSync(specPath)) return false; // fail-closed — missing spec blocks the gate
+    // GH-696: spec_gate satisfiedAt landed ~3s into the in-flight spec agent's
+    // timeline on GH-689 — refuse while spec-phase.json is non-terminal so the
+    // validate/memorize/kind_checks phases always run before the window closes.
+    const { phaseLedgerBlocked } = require(path.join(deps.workRoot, 'lib', 'phase-ledger'));
+    if (phaseLedgerBlocked(ticketDir, 'spec').blocked) return false;
     const gherkinPath = path.join(ticketDir, 'gherkin.feature');
     let gherkinContent;
     try {

--- a/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
@@ -24,6 +24,18 @@ function ticketDir(deps, ticketId) {
   return path.join(deps.TASKS_BASE, deps.safeTicketPath(ticketId));
 }
 
+/**
+ * GH-696: a step whose inner phase driver is still mid-flight (or whose
+ * ledger is corrupt) must not verify, even when the artifact file exists —
+ * on GH-689 the brief step advanced while brief-phase.json sat at `draft`.
+ * Absent ledger = legacy/pre-phase-driver ticket → not blocked (today's
+ * behavior). The plan matrix's RUN-resume branch is the repair route.
+ */
+function ledgerClear(deps, ticketId, step) {
+  const { phaseLedgerBlocked } = require(path.join(deps.workRoot, 'lib', 'phase-ledger'));
+  return !phaseLedgerBlocked(ticketDir(deps, ticketId), step).blocked;
+}
+
 /** @param {StepDeps} deps */
 function verifyTicket(deps, ticketId) {
   // Ticket is proven if the work state file exists and is active for this ticket
@@ -42,7 +54,10 @@ function verifyTicket(deps, ticketId) {
 /** @param {StepDeps} deps */
 function verifyBrief(deps, ticketId) {
   try {
-    return fs.existsSync(path.join(ticketDir(deps, ticketId), 'brief.md'));
+    return (
+      fs.existsSync(path.join(ticketDir(deps, ticketId), 'brief.md')) &&
+      ledgerClear(deps, ticketId, 'brief')
+    );
   } catch {
     return false;
   }
@@ -55,7 +70,10 @@ function verifyBrief(deps, ticketId) {
  */
 function verifySpec(deps, ticketId) {
   try {
-    return fs.existsSync(path.join(ticketDir(deps, ticketId), 'spec.md'));
+    return (
+      fs.existsSync(path.join(ticketDir(deps, ticketId), 'spec.md')) &&
+      ledgerClear(deps, ticketId, 'spec')
+    );
   } catch {
     return false;
   }
@@ -65,7 +83,10 @@ function verifySpec(deps, ticketId) {
 function verifyTasks(deps, ticketId) {
   // verify remains active -- used by evidence checks
   try {
-    return fs.existsSync(path.join(ticketDir(deps, ticketId), 'tasks.md'));
+    return (
+      fs.existsSync(path.join(ticketDir(deps, ticketId), 'tasks.md')) &&
+      ledgerClear(deps, ticketId, 'tasks')
+    );
   } catch {
     return false;
   } // fail-safe: assume tasks not generated


### PR DESCRIPTION
## Existing Behavior

- `verifyBrief`, `verifySpec`, and `verifyTasks` returned `true` as soon as the corresponding artifact file (`brief.md`, `spec.md`, `tasks.md`) existed on disk, regardless of whether the inner phase driver had finished.
- `verifyBriefGate` and `verifySpecGate` satisfied their gates solely on artifact content; there was no check against the phase-state ledger (`*-phase.json`).
- `isSubagentContext` on the Claude runtime path relied on the env-folded `evt.agent.type`, which folds in `CLAUDE_AGENT_TYPE` from the process environment — a variable that leaks across tmux sessions via the global environment.
- When a step's artifact was complete enough to pass content checks but the inner runner was still mid-flight, the outer driver closed the artifact window, leaving the phase ledger permanently stuck at an intermediate phase (e.g. `brief-phase.json` at `draft`, `spec-phase.json` at `surface_audit`), silently skipping the remaining validate / memorize / kind_checks phases.

## Intended New Behavior

- A new shared predicate `phaseLedgerBlocked(ticketDir, step)` in `plugins/work/scripts/workflows/work/lib/phase-ledger.js` is the single source of truth: absent ledger → not blocked (legacy tickets advance exactly as before); `currentPhase === "done"` → not blocked; any other phase → blocked; unreadable / corrupt / missing `currentPhase` field → blocked with `currentPhase: "unparseable"` (fail-closed).
- `verifyBrief`, `verifySpec`, and `verifyTasks` each AND the existing file-existence check with `ledgerClear(…)`, so a step cannot be verified while its inner runner is mid-flight.
- `verifyBriefGate` and `verifySpecGate` call `phaseLedgerBlocked` before the artifact-content check, refusing to satisfy the gate until the ledger is terminal.
- `inspect.js` surfaces `briefPhaseMidFlight`, `specPhaseMidFlight`, and `tasksPhaseMidFlight` (plus the current phase name) in the plan-matrix state object.
- The brief, spec, and tasks plan-matrix steps each grow a mid-flight branch: when the artifact exists but the ledger is non-terminal, the step emits a `RUN` entry (re-dispatch the writer agent in resume mode) instead of `DEFER`, providing a deadlock-free repair path. The writer's runner (`brief-next.js` / `spec-next.js` / `tasks-next.js`) resumes from the recorded phase and drives remaining phases to `done`.
- `isSubagentContext` on the Claude leg now reads the raw payload (`evt.native.agent_type` / `evt.native.agent_id`) rather than the env-folded `evt.agent.type`, preventing a leaked `CLAUDE_AGENT_TYPE` tmux global from permanently muting auto-advance in a main session. The same fix is mirrored across all five payload copies (factories/runtime, plugins/heimdall, plugins/maestro, plugins/synapsys, plugins/work/scripts/workflows/lib).

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

Backend / workflow engine changes — verify via the unit tests added in this PR:

1. Run the new dedicated ledger suite:
   ```
   node --test plugins/work/scripts/workflows/work/__tests__/phase-ledger.test.js
   ```
   All `phaseLedgerBlocked` truth-table cases (absent, terminal, mid-flight, corrupt) and all step-verifier / gate-verifier matrix rows should pass.

2. Run the updated workflow-definition suite to confirm the `brief_gate` and `spec_gate` mid-flight cases:
   ```
   node --test plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js
   ```

3. Run the plan-matrix step suites to confirm the new RUN-resume branch for each step:
   ```
   node --test plugins/work/scripts/workflows/work/steps/__tests__/brief.test.js
   node --test plugins/work/scripts/workflows/work/steps/__tests__/spec.test.js
   node --test plugins/work/scripts/workflows/work/steps/__tests__/tasks.test.js
   ```

4. Run the dual-runtime auto-advance suite to verify the `CLAUDE_AGENT_TYPE` env-leak fix and the new native `agent_type`/`agent_id` subagent-guard cases:
   ```
   node --test plugins/work/scripts/workflows/work/__tests__/work-auto-advance-runtime.test.js
   ```

5. Regression check — simulate a legacy ticket (no `*-phase.json` present) and confirm the step advances exactly as before (expected: `verifyBrief` → `true`, `brief_gate` satisfied once `brief.md` content is clean).

---

Stacked on `fix/gh-694-implement-verifiers`.

Closes #696

### Test Results

New test file: `plugins/work/scripts/workflows/work/__tests__/phase-ledger.test.js` (253 lines, 20 cases covering the full `phaseLedgerBlocked` truth table, step-verifier matrix, and gate-verifier matrix).

Updated test files:
- `plugins/work/scripts/workflows/work/__tests__/workflow-definition.test.js` — 2 new cases for `brief_gate` and `spec_gate` mid-flight gating.
- `plugins/work/scripts/workflows/work/__tests__/work-auto-advance-runtime.test.js` — 3 new cases: native `agent_type` silent, native `agent_id` silent, env-leaked `CLAUDE_AGENT_TYPE` still advances.
- `plugins/work/scripts/workflows/work/steps/__tests__/brief.test.js` — 2 new cases (resume RUN + regression DEFER).
- `plugins/work/scripts/workflows/work/steps/__tests__/spec.test.js` — 2 new cases (resume RUN + regression DEFER).
- `plugins/work/scripts/workflows/work/steps/__tests__/tasks.test.js` — 3 new cases (resume RUN, resume fires without spec.md, regression DEFER).
- `factories/runtime/__tests__/payload.spec.js` — 2 new cases for raw-payload subagent detection and env-fold non-detection.