### PR TITLE
fix(completion-checker): relax reuse audit false-negatives (GH-607)

### DIFF
--- a/plugins/work/docs/README.md
+++ b/plugins/work/docs/README.md
@@ -88,8 +88,13 @@ the declaring surface, so the fail-closed / anti-gaming guarantee is preserved:
   only in some *other* modified file does not satisfy the audit.
 - **Config-file (non-JS/TS) reuse entries (P0.2).** When the declared path is a
   non-`.js`/`.ts` file (e.g. a `.json` config), the importable-symbol heuristic is
-  bypassed and the entry is matched by its declared path/block literally appearing
-  on the added lines — gated on that path being in the change set.
+  bypassed and the entry is matched by its declared **symbol** appearing as a whole
+  token on that file's **own** added lines — gated on that path being in the change
+  set. The declared path/filename text is never accepted as evidence (mentioning the
+  config filename cannot satisfy the entry) and the match is word-bounded (`my-hookish`
+  cannot satisfy `my-hook`) — the same token strength as the importable-symbol paths.
+  When the added-lines diff is unavailable the config entry fails closed rather than
+  falling back to bare file-wide presence.
 
 **Fail-closed / anti-gaming preserved.** The relaxations never turn the gate into
 a rubber-stamp: a symbol present **only** in a pre-existing, unmodified file still

--- a/plugins/work/docs/README.md
+++ b/plugins/work/docs/README.md
@@ -69,6 +69,46 @@ follow_up → ci → cleanup → reports → complete
 | `tasks.md` | `TASKS_BASE/<ticket>/` | Task decomposition |
 | `*.check.md` | `TASKS_BASE/<ticket>/` | Quality reports |
 
+## Completion-Checker Reuse Audit
+
+The completion-checker's `reuse_audit_enforcement` phase verifies that every
+`MUST be reused` symbol declared in a spec's `## Reuse Audit` section is actually
+reused by the change. The strict default requires the symbol to appear on a line
+the PR **added** (`git diff -U0` scoped to the changed files), so incidental
+mentions in pre-existing/unmodified code cannot satisfy the gate.
+
+Two guarded relaxations (GH-607) cover false-negative classes the strict
+added-line check missed. Each fires **only** when the change genuinely touches
+the declaring surface, so the fail-closed / anti-gaming guarantee is preserved:
+
+- **In-place extension of a modified symbol (P0.1).** When a MUST-reuse symbol is
+  absent from the added lines but its declaring `.js`/`.ts` file was modified in
+  this change (present in the change set with non-empty content), a blob check
+  **scoped to that single declaring file** counts it as reused. A symbol present
+  only in some *other* modified file does not satisfy the audit.
+- **Config-file (non-JS/TS) reuse entries (P0.2).** When the declared path is a
+  non-`.js`/`.ts` file (e.g. a `.json` config), the importable-symbol heuristic is
+  bypassed and the entry is matched by its declared path/block literally appearing
+  on the added lines — gated on that path being in the change set.
+
+**Fail-closed / anti-gaming preserved.** The relaxations never turn the gate into
+a rubber-stamp: a symbol present **only** in a pre-existing, unmodified file still
+fails (the negative-control guarantee), deletion-only/no-op changes still fail, and
+any parser/IO error still fails closed with a `REUSE-PARSER` failure record.
+Failure `observed` messages distinguish a symbol "declared in an unmodified file
+(not reused here)" from one that "no changed file references."
+
+**Additive `path` field.** `readReuseAudit` records now expose the declared source
+`path` (or `null` when absent) — additively; no existing field was renamed or
+removed. The config-file branch consumes this to classify non-JS/TS entries without
+re-parsing.
+
+**Deferred: R6 auditable override.** An optional sanctioned, evidence-gated
+override path (an audited `.work-actions.json` row that lets an operator waive a
+reuse miss) is **deferred** per the spec's Open Questions default — only the two
+relaxations above (P0.1 + P0.2) ship in GH-607. R6 is recorded here (not silently
+dropped) and would only be revisited if a residual false-negative class remains.
+
 ## Troubleshooting
 
 ### `gh` calls fail with "Could not resolve to a Repository"

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
@@ -385,6 +385,13 @@ test.describe('GH-607 Task 2 — pure helpers (2.1)', () => {
     for (const js of ['a.js', 'b.ts', 'c.jsx', 'd.tsx', 'e.mjs', 'f.cjs']) {
       assert.equal(phase.isConfigPath(js), false, `${js} must NOT be a config path`);
     }
+    // GH-607 review fix (Greptile P1): extensionless declared paths are never
+    // importable JS/TS, so they count as config and take the scoped per-file
+    // branch — otherwise Dockerfile/Makefile/CODEOWNERS entries would fall
+    // through to the combined-diff importable check and leak from unrelated files.
+    for (const cfg of ['Dockerfile', 'Makefile', 'CODEOWNERS', 'path/to/Procfile', '.gitignore']) {
+      assert.equal(phase.isConfigPath(cfg), true, `${cfg} (extensionless) must be a config path`);
+    }
     assert.equal(phase.isConfigPath(null), false, 'null is not a config path');
     assert.equal(phase.isConfigPath(undefined), false, 'undefined is not a config path');
     assert.equal(phase.isConfigPath(''), false, 'empty string is not a config path');
@@ -1055,6 +1062,52 @@ test.describe('GH-607 P0.1 — in-place extension under real git', () => {
       );
       const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
       assert.ok(rec, 'failure record must be pushed for the leaked config entry');
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Greptile P1 (isConfigPath extensionless): an extensionless declared path
+  // (Dockerfile/Makefile/CODEOWNERS) must be treated as config and scoped to its
+  // own file — otherwise it falls through to the importable-symbol branch and the
+  // symbol text in an UNRELATED changed file leaks a false pass. Here `my-target`
+  // is added in src/other.js while the declared Dockerfile is untouched.
+  test('extensionless config (Dockerfile) symbol in an unrelated file does NOT satisfy an untouched entry', async () => {
+    const cfgSpec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `my-target` MUST be reused from `Dockerfile`',
+      '',
+    ].join('\n');
+    const { ctx, cleanup } = buildInPlaceGitCtx({
+      spec: cfgSpec,
+      changedFiles: ['src/other.js'],
+      files: {
+        Dockerfile: { base: 'FROM node:22\n', head: 'FROM node:22\n' },
+        'src/other.js': {
+          base: 'const base = 0;\n',
+          head: 'const base = 0;\nconst wire = "my-target";\n',
+        },
+      },
+    });
+    try {
+      const combined = git(ctx.worktreeRoot, ['diff', '-U0', 'main...HEAD', '--', 'src/other.js']);
+      assert.match(
+        combined,
+        /my-target/,
+        'guard: unrelated file added lines must contain the symbol'
+      );
+
+      const result = await phase.validate(ctx);
+      assert.equal(
+        result.ok,
+        false,
+        'extensionless config entry must NOT pass when the symbol is only in an unrelated file'
+      );
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record must be pushed for the leaked extensionless config entry');
     } finally {
       cleanup();
     }

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
@@ -642,3 +642,131 @@ test.describe('GH-607 Task 2 — refined message + regression + negative control
     }
   });
 });
+
+// --- GH-607 review fix: config-entry match must be scoped to entry.path -------
+//
+// Regression for the cross-file leak reported on
+// reuse_audit_enforcement.js:162 — `addedLines` was the COMBINED `git diff -U0`
+// for every changed file, so a config MUST-reuse entry could be satisfied by a
+// needle that appears only on the added lines of an UNRELATED changed file. The
+// `changedSet.has(entry.path)` gate confirmed the declared path was touched, but
+// the block/path content match was not scoped to that file. These tests build a
+// real git repo so `readAddedLines` runs and its per-file scoping is exercised.
+
+test.describe('GH-607 review fix — config match scoped to declared file', () => {
+  const childProcess = require('node:child_process');
+
+  function git(cwd, args) {
+    const r = childProcess.spawnSync('git', args, { cwd, encoding: 'utf8' });
+    if (r.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+  }
+
+  // Build a git repo whose base branch (`main`) has an initial commit, then a
+  // working tree that has ADDED `hooks.json` (without the needle) and an
+  // unrelated changed file (with the needle) relative to that base.
+  function buildGitCtx({ spec, hooksJsonAdded, otherFileAdded }) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gh607-scoped-'));
+    git(root, ['init', '-q', '-b', 'main']);
+    git(root, ['config', 'user.email', 'test@example.com']);
+    git(root, ['config', 'user.name', 'Test']);
+    // Base commit: files exist but WITHOUT the added content under test.
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'hooks.json'), '{\n}\n', 'utf8');
+    fs.writeFileSync(path.join(root, 'src', 'other.js'), 'const base = 0;\n', 'utf8');
+    git(root, ['add', '-A']);
+    git(root, ['commit', '-q', '-m', 'base']);
+    // Working-tree changes (HEAD is still the base commit; readAddedLines
+    // diffs `main...HEAD`, and getDiffBaseCandidates resolves base = current
+    // branch's tracked base → 'main'. We instead advance HEAD with a second
+    // commit so `main...HEAD` shows the new lines).
+    fs.writeFileSync(path.join(root, 'hooks.json'), hooksJsonAdded, 'utf8');
+    fs.writeFileSync(path.join(root, 'src', 'other.js'), otherFileAdded, 'utf8');
+    // Diff base is 'main'; put the new work on a different branch so main...HEAD
+    // is a real ahead-diff.
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    git(root, ['add', '-A']);
+    git(root, ['commit', '-q', '-m', 'work']);
+
+    const tasksDir = path.join(root, 'tasks', 'GH-607');
+    fs.mkdirSync(tasksDir, { recursive: true });
+    fs.writeFileSync(path.join(tasksDir, 'spec.md'), spec, 'utf8');
+    fs.writeFileSync(
+      path.join(tasksDir, 'pr-context.json'),
+      JSON.stringify({ files: ['hooks.json', 'src/other.js'] }, null, 2),
+      'utf8'
+    );
+    return {
+      ctx: { tasksDir, worktreeRoot: root, failures: [] },
+      cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+    };
+  }
+
+  test('needle only in an UNRELATED changed file does NOT satisfy the config entry', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `my-hook` MUST be reused from `hooks.json`',
+      '',
+    ].join('\n');
+    // hooks.json is added-to but WITHOUT the `my-hook` symbol OR the `hooks.json`
+    // path string; the `hooks.json` PATH needle appears only on added lines of the
+    // unrelated src/other.js. `configEntryPresent` matches EITHER needle (symbol
+    // or path), so pre-fix the combined diff let the path needle from the other
+    // file satisfy the entry. Post-fix, the per-file scoped read of hooks.json —
+    // which contains neither needle — fails it. (We avoid the `my-hook` symbol in
+    // the other file so the PRIMARY symbol-in-added check can't confound the test.)
+    const { ctx, cleanup } = buildGitCtx({
+      spec,
+      hooksJsonAdded: '{\n  "unrelated": { "command": "node z.js" }\n}\n',
+      otherFileAdded: 'const base = 0;\n// see config in hooks.json for wiring\n',
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(
+        result.ok,
+        false,
+        'config entry must NOT pass when the needle is only in another changed file'
+      );
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record must be pushed for the leaked config entry');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('needle on the declared file’s own added lines DOES satisfy the config entry', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `my-hook` MUST be reused from `hooks.json`',
+      '',
+    ].join('\n');
+    const { ctx, cleanup } = buildGitCtx({
+      spec,
+      hooksJsonAdded: '{\n  "my-hook": { "command": "node x.js" }\n}\n',
+      otherFileAdded: 'const base = 0;\nconst extra = 1;\n',
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(
+        result.ok,
+        true,
+        'config entry must pass when its block is on the declared file’s own added lines'
+      );
+      assert.equal(
+        ctx.failures.filter((f) => f.checkType === 'reuse_audit').length,
+        0,
+        'no failure record when the config block is genuinely present in the declared file'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
@@ -769,4 +769,95 @@ test.describe('GH-607 review fix — config match scoped to declared file', () =
       cleanup();
     }
   });
+
+  // GH-607 review fix: the spec author writes `./hooks.json` (equivalent
+  // repo-relative spelling) but git's --name-only / pr-context list carries the
+  // canonical `hooks.json`. Pre-fix the raw `changedSet.has(entry.path)` gate
+  // rejected the reuse; post-fix both sides normalize and it is recognized.
+  test('`./hooks.json` spec spelling matches canonical `hooks.json` change (config gate)', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `my-hook` MUST be reused from `./hooks.json`',
+      '',
+    ].join('\n');
+    const { ctx, cleanup } = buildGitCtx({
+      spec,
+      hooksJsonAdded: '{\n  "my-hook": { "command": "node x.js" }\n}\n',
+      otherFileAdded: 'const base = 0;\nconst extra = 1;\n',
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(
+        result.ok,
+        true,
+        '`./hooks.json` spec spelling must be recognized as the reused `hooks.json` change'
+      );
+      assert.equal(
+        ctx.failures.filter((f) => f.checkType === 'reuse_audit').length,
+        0,
+        'no failure record when the equivalent-spelling config block is genuinely present'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Anti-gaming negative control preserved under the new normalization: the
+  // `./hooks.json` spelling still fails when the needle lives only in an
+  // unrelated changed file (nothing on hooks.json's own added lines).
+  test('`./hooks.json` spelling still fails when needle only in an unrelated file (anti-gaming)', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `my-hook` MUST be reused from `./hooks.json`',
+      '',
+    ].join('\n');
+    const { ctx, cleanup } = buildGitCtx({
+      spec,
+      hooksJsonAdded: '{\n  "unrelated": { "command": "node z.js" }\n}\n',
+      otherFileAdded: 'const base = 0;\n// see config in hooks.json for wiring\n',
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(
+        result.ok,
+        false,
+        'normalization must not let an unrelated-file needle satisfy the `./hooks.json` entry'
+      );
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record must still be pushed for the leaked config entry');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+test.describe('GH-607 — normalizeRepoPath canonicalization', () => {
+  test('strips ./ prefix, leading slash, redundant separators, trailing slash', () => {
+    assert.equal(phase.normalizeRepoPath('./hooks.json'), 'hooks.json');
+    assert.equal(phase.normalizeRepoPath('/hooks.json'), 'hooks.json');
+    assert.equal(phase.normalizeRepoPath('src//other.js'), 'src/other.js');
+    assert.equal(phase.normalizeRepoPath('.//src/nested.js'), 'src/nested.js');
+    assert.equal(phase.normalizeRepoPath('src/dir/'), 'src/dir');
+    assert.equal(phase.normalizeRepoPath('src\\win\\path.js'), 'src/win/path.js');
+  });
+
+  test('already-canonical paths are unchanged and nullish input is passed through', () => {
+    assert.equal(phase.normalizeRepoPath('hooks.json'), 'hooks.json');
+    assert.equal(phase.normalizeRepoPath('src/other.js'), 'src/other.js');
+    assert.equal(phase.normalizeRepoPath(''), '');
+    assert.equal(phase.normalizeRepoPath(null), null);
+    assert.equal(phase.normalizeRepoPath(undefined), undefined);
+  });
+
+  test('does NOT resolve `..` outside the repo (conservative)', () => {
+    // A `..` segment is left intact so an out-of-tree path cannot silently
+    // normalize onto an in-tree change-set entry.
+    assert.equal(phase.normalizeRepoPath('../hooks.json'), '../hooks.json');
+  });
 });

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
@@ -374,3 +374,271 @@ test.describe('readReuseAudit grammar (#629)', () => {
     }
   });
 });
+
+// --- GH-607 Task 2: in-place extension + config-file relaxations -------------
+
+test.describe('GH-607 Task 2 — pure helpers (2.1)', () => {
+  test('isConfigPath: config extension true; JS/TS extensions and nullish false', () => {
+    assert.equal(typeof phase.isConfigPath, 'function', 'isConfigPath must be exported');
+    assert.equal(phase.isConfigPath('hooks.json'), true, '.json is a config path');
+    assert.equal(phase.isConfigPath('config/settings.yaml'), true, '.yaml is a config path');
+    for (const js of ['a.js', 'b.ts', 'c.jsx', 'd.tsx', 'e.mjs', 'f.cjs']) {
+      assert.equal(phase.isConfigPath(js), false, `${js} must NOT be a config path`);
+    }
+    assert.equal(phase.isConfigPath(null), false, 'null is not a config path');
+    assert.equal(phase.isConfigPath(undefined), false, 'undefined is not a config path');
+    assert.equal(phase.isConfigPath(''), false, 'empty string is not a config path');
+  });
+
+  test('symbolPresentInBlobsScoped: matches only in the blob whose rel === relPath', () => {
+    assert.equal(
+      typeof phase.symbolPresentInBlobsScoped,
+      'function',
+      'symbolPresentInBlobsScoped must be exported'
+    );
+    const blobs = [
+      { rel: 'a.js', content: 'const MATCHED_LABELS = [];\n' },
+      { rel: 'b.js', content: 'nothing here\n' },
+    ];
+    assert.equal(
+      phase.symbolPresentInBlobsScoped('MATCHED_LABELS', blobs, 'a.js'),
+      true,
+      'symbol present in the scoped file returns true'
+    );
+    const otherOnly = [
+      { rel: 'a.js', content: 'nothing here\n' },
+      { rel: 'b.js', content: 'const MATCHED_LABELS = [];\n' },
+    ];
+    assert.equal(
+      phase.symbolPresentInBlobsScoped('MATCHED_LABELS', otherOnly, 'a.js'),
+      false,
+      'symbol present ONLY in another modified file must NOT satisfy the scoped check'
+    );
+    assert.equal(
+      phase.symbolPresentInBlobsScoped('MATCHED_LABELS', otherOnly, 'missing.js'),
+      false,
+      'no blob matching relPath returns false'
+    );
+  });
+});
+
+test.describe('GH-607 Task 2 — configEntryPresent + guarded branches (2.2)', () => {
+  test('configEntryPresent: true only when entry.path in changedSet AND its block on addedLines', () => {
+    assert.equal(
+      typeof phase.configEntryPresent,
+      'function',
+      'configEntryPresent must be exported'
+    );
+    const entry = { symbol: 'my-hook', path: 'hooks.json' };
+    const addedLines = '  "my-hook": { "command": "node x.js" }\n';
+    const changedSet = new Set(['hooks.json']);
+    assert.equal(
+      phase.configEntryPresent(entry, addedLines, changedSet),
+      true,
+      'present when path in changedSet and block on added lines'
+    );
+    assert.equal(
+      phase.configEntryPresent(entry, addedLines, new Set(['other.json'])),
+      false,
+      'absent when entry.path not in changedSet'
+    );
+    assert.equal(
+      phase.configEntryPresent(entry, 'unrelated added content\n', changedSet),
+      false,
+      'absent when in changedSet but block not on added lines'
+    );
+  });
+
+  test('validate: in-place extension of a modified .js symbol (context line) ⇒ 0 missing', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `MATCHED_LABELS` MUST be reused from `lib/labels.js`',
+      '',
+    ].join('\n');
+    // The declaration line is a CONTEXT line (already-present), but the file
+    // WAS modified in this change (added a new element). symbolPresentInAdded
+    // returns false for the symbol, yet the declaring file is in changedSet
+    // with non-empty content → P0.1 relaxation must fire.
+    const { ctx, cleanup } = buildCtx({
+      spec,
+      changedFiles: ['lib/labels.js'],
+      fileContents: {
+        'lib/labels.js': "const MATCHED_LABELS = ['a', 'b', 'newlyAdded'];\n",
+      },
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(
+        result.ok,
+        true,
+        'in-place extension of a modified .js symbol must pass the audit'
+      );
+      assert.equal(
+        ctx.failures.filter((f) => f.checkType === 'reuse_audit').length,
+        0,
+        'no failure record for in-place extension'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('validate: hooks.json config MUST-reuse entry present in the change ⇒ 0 missing', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `my-hook` MUST be reused from `hooks.json`',
+      '',
+    ].join('\n');
+    const { ctx, cleanup } = buildCtx({
+      spec,
+      changedFiles: ['hooks.json'],
+      fileContents: {
+        'hooks.json': '{\n  "my-hook": { "command": "node x.js" }\n}\n',
+      },
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(result.ok, true, 'config-file entry present in change must pass');
+      assert.equal(
+        ctx.failures.filter((f) => f.checkType === 'reuse_audit').length,
+        0,
+        'no failure record for present config entry'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+test.describe('GH-607 Task 2 — refined message + regression + negative control (2.3)', () => {
+  test('config MUST-reuse entry ABSENT from the change fails', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `my-hook` MUST be reused from `hooks.json`',
+      '',
+    ].join('\n');
+    // hooks.json is NOT in the changed set; an unrelated file changed instead.
+    const { ctx, cleanup } = buildCtx({
+      spec,
+      changedFiles: ['src/other.js'],
+      fileContents: {
+        'src/other.js': 'const x = 1;\n',
+      },
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(result.ok, false, 'config entry absent from change must fail');
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record must be pushed for absent config entry');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('NEGATIVE CONTROL: symbol present only in an unmodified file still fails (anti-gaming)', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `MATCHED_LABELS` MUST be reused from `lib/labels.js`',
+      '',
+    ].join('\n');
+    // The symbol lives in lib/labels.js, but that file is NOT in the changed
+    // set (an unrelated file was modified). The P0.1 relaxation must NOT fire
+    // because the declaring file was not modified — anti-gaming guarantee.
+    const { ctx, cleanup } = buildCtx({
+      spec,
+      changedFiles: ['src/unrelated.js'],
+      fileContents: {
+        'src/unrelated.js': 'const y = 2;\n',
+        'lib/labels.js': "const MATCHED_LABELS = ['a', 'b'];\n",
+      },
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(
+        result.ok,
+        false,
+        'symbol only in an unmodified file must STILL fail (anti-gaming)'
+      );
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record must be pushed for unmodified-only symbol');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('refined observed: "unmodified file" wording when declaring path NOT in changedSet', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `MATCHED_LABELS` MUST be reused from `lib/labels.js`',
+      '',
+    ].join('\n');
+    // Declaring file lib/labels.js is NOT modified; a different file changed.
+    const { ctx, cleanup } = buildCtx({
+      spec,
+      changedFiles: ['src/unrelated.js'],
+      fileContents: {
+        'src/unrelated.js': 'const y = 2;\n',
+        'lib/labels.js': "const MATCHED_LABELS = ['a', 'b'];\n",
+      },
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(result.ok, false);
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record exists');
+      assert.match(
+        rec.observed,
+        /unmodified file/i,
+        'observed must distinguish the unmodified-file miss class'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('refined observed: "no changed file references" wording when no changed file references the symbol', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `ContentPageToolbar` MUST be reused from `apps/web/src/components/ContentPageToolbar.tsx`',
+      '',
+    ].join('\n');
+    const { ctx, cleanup } = buildCtx({
+      spec,
+      changedFiles: ['apps/web/src/pages/Other.tsx'],
+      fileContents: {
+        'apps/web/src/pages/Other.tsx': 'import { SomethingElse } from "./x";\n',
+      },
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(result.ok, false);
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record exists');
+      assert.match(
+        rec.observed,
+        /no changed file references/i,
+        'observed must distinguish the no-changed-file-reference miss class'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
@@ -1008,4 +1008,55 @@ test.describe('GH-607 P0.1 — in-place extension under real git', () => {
       cleanup();
     }
   });
+
+  // Greptile P1 (reuse_audit_enforcement.js:282): for a config-path entry the
+  // primary symbol check ran against the COMBINED diff before the scoped config
+  // check, so the config symbol text added in an UNRELATED file made present=true
+  // and skipped isConfigEntryReused(). Here `my-hook` is added in src/other.js
+  // while the declared config file hooks.json is UNTOUCHED (byte-identical, not in
+  // the change set) — it must stay non-reused; config entries are judged only
+  // against their own declared file.
+  test('config symbol text in an unrelated changed file does NOT satisfy an untouched config entry (P1)', async () => {
+    const cfgSpec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `my-hook` MUST be reused from `hooks.json`',
+      '',
+    ].join('\n');
+    const { ctx, cleanup } = buildInPlaceGitCtx({
+      spec: cfgSpec,
+      changedFiles: ['src/other.js'],
+      files: {
+        'hooks.json': { base: '{\n}\n', head: '{\n}\n' },
+        'src/other.js': {
+          base: 'const base = 0;\n',
+          head: 'const base = 0;\nconst wire = "my-hook";\n',
+        },
+      },
+    });
+    try {
+      // Guard: the combined diff DOES contain the symbol text (the exact bait the
+      // pre-fix primary check swallowed), so it is the per-file SCOPING — not an
+      // absent needle — that fails the entry.
+      const combined = git(ctx.worktreeRoot, ['diff', '-U0', 'main...HEAD', '--', 'src/other.js']);
+      assert.match(
+        combined,
+        /my-hook/,
+        'guard: unrelated file added lines must contain the symbol'
+      );
+
+      const result = await phase.validate(ctx);
+      assert.equal(
+        result.ok,
+        false,
+        'config entry must NOT pass when the symbol text is only in an unrelated changed file'
+      );
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record must be pushed for the leaked config entry');
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
@@ -493,7 +493,18 @@ test.describe('GH-607 Task 2 — configEntryPresent + guarded branches (2.2)', (
     }
   });
 
-  test('validate: hooks.json config MUST-reuse entry present in the change ⇒ 0 missing', async () => {
+  // Greptile P1 (reuse_audit_enforcement.js isConfigEntryReused fallback): when the
+  // added-lines diff is UNAVAILABLE, a config MUST-reuse entry must NOT be satisfied
+  // by bare file-wide presence. The declared symbol pre-exists in its own config
+  // file, so an unrelated edit to that file (it IS in the change set) plus the
+  // symbol living anywhere in the full blob would otherwise falsely pass — stale
+  // config satisfying the audit. buildCtx is a NON-git tmpdir, so `readAddedLines`
+  // returns null (added portion unknowable); the conservative fallback must fail it.
+  //
+  // The positive path (config block on the declared file's OWN added lines ⇒ pass)
+  // is covered under REAL git by
+  //   'needle on the declared file’s own added lines DOES satisfy the config entry'.
+  test('config entry with the diff UNAVAILABLE does NOT count as reused (Greptile P1 stale-file guard)', async () => {
     const spec = [
       '# Spec',
       '',
@@ -502,20 +513,28 @@ test.describe('GH-607 Task 2 — configEntryPresent + guarded branches (2.2)', (
       '- `my-hook` MUST be reused from `hooks.json`',
       '',
     ].join('\n');
+    // hooks.json is in the change set (an unrelated edit touched it — `"touched"`)
+    // and `my-hook` PRE-EXISTS in the file; but the change never added the my-hook
+    // block. With the diff unavailable, this must fail-closed rather than pass on
+    // full-file presence.
     const { ctx, cleanup } = buildCtx({
       spec,
       changedFiles: ['hooks.json'],
       fileContents: {
-        'hooks.json': '{\n  "my-hook": { "command": "node x.js" }\n}\n',
+        'hooks.json': '{\n  "my-hook": { "command": "node x.js" },\n  "touched": true\n}\n',
       },
     });
     try {
       const result = await phase.validate(ctx);
-      assert.equal(result.ok, true, 'config-file entry present in change must pass');
       assert.equal(
-        ctx.failures.filter((f) => f.checkType === 'reuse_audit').length,
-        0,
-        'no failure record for present config entry'
+        result.ok,
+        false,
+        'config entry must NOT pass on bare file-wide presence when the added-lines diff is unavailable'
+      );
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(
+        rec,
+        'failure record must be pushed when the config entry cannot be verified from the diff'
       );
     } finally {
       cleanup();

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
@@ -861,3 +861,151 @@ test.describe('GH-607 — normalizeRepoPath canonicalization', () => {
     assert.equal(phase.normalizeRepoPath('../hooks.json'), '../hooks.json');
   });
 });
+
+// --- GH-607 review fix: P0.1 in-place extension under REAL git ---------------
+//
+// The tmpdir fixtures in buildCtx are NOT git repos, so `readAddedLines`
+// returns null and the phase satisfies a MUST-reuse symbol via the LEGACY
+// full-blob proxy (`symbolPresentInBlobs`) — the P0.1 `isInPlaceExtension`
+// branch never executes there. These tests build a real git repo so
+// `readAddedLines` yields a genuine `main...HEAD` diff whose added lines do
+// NOT contain the symbol token (the declaration sits on a context line),
+// forcing `symbolPresentInAdded` to return false and making
+// `isInPlaceExtension` the ONLY thing that can pass the audit.
+
+test.describe('GH-607 P0.1 — in-place extension under real git', () => {
+  const childProcess = require('node:child_process');
+
+  function git(cwd, args) {
+    const r = childProcess.spawnSync('git', args, { cwd, encoding: 'utf8' });
+    if (r.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+  }
+
+  // `files` maps repo-relative path → { base, head }. The base commit lands on
+  // `main`; the working change lands on a `feature` commit so `main...HEAD` is a
+  // real ahead-diff. Only `changedFiles` are recorded in pr-context.json.
+  function buildInPlaceGitCtx({ spec, files, changedFiles }) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gh607-inplace-'));
+    git(root, ['init', '-q', '-b', 'main']);
+    git(root, ['config', 'user.email', 'test@example.com']);
+    git(root, ['config', 'user.name', 'Test']);
+    for (const [rel, { base }] of Object.entries(files)) {
+      const abs = path.join(root, rel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, base, 'utf8');
+    }
+    git(root, ['add', '-A']);
+    git(root, ['commit', '-q', '-m', 'base']);
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    for (const [rel, { head }] of Object.entries(files)) {
+      fs.writeFileSync(path.join(root, rel), head, 'utf8');
+    }
+    git(root, ['add', '-A']);
+    git(root, ['commit', '-q', '-m', 'work']);
+
+    const tasksDir = path.join(root, 'tasks', 'GH-607');
+    fs.mkdirSync(tasksDir, { recursive: true });
+    fs.writeFileSync(path.join(tasksDir, 'spec.md'), spec, 'utf8');
+    fs.writeFileSync(
+      path.join(tasksDir, 'pr-context.json'),
+      JSON.stringify({ files: changedFiles }, null, 2),
+      'utf8'
+    );
+    return {
+      ctx: { tasksDir, worktreeRoot: root, failures: [] },
+      cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+    };
+  }
+
+  const spec = [
+    '# Spec',
+    '',
+    '## Reuse Audit',
+    '',
+    '- `MATCHED_LABELS` MUST be reused from `lib/labels.js`',
+    '',
+  ].join('\n');
+
+  test('symbol on a context line of a genuinely-modified .js file passes via isInPlaceExtension', async () => {
+    // Base already declares MATCHED_LABELS across multiple lines; the feature
+    // commit only ADDS a new array element. `git diff -U0` therefore contains no
+    // MATCHED_LABELS token on a `+` line, so symbolPresentInAdded is false and
+    // ONLY the P0.1 branch (declaring file modified + scoped blob) can pass it.
+    const { ctx, cleanup } = buildInPlaceGitCtx({
+      spec,
+      changedFiles: ['lib/labels.js'],
+      files: {
+        'lib/labels.js': {
+          base: "const MATCHED_LABELS = [\n  'a',\n  'b',\n];\n",
+          head: "const MATCHED_LABELS = [\n  'a',\n  'b',\n  'c',\n];\n",
+        },
+      },
+    });
+    try {
+      // Guard: prove the symbol is NOT on an added line, so a green result can
+      // only come from isInPlaceExtension — not the primary added-line check.
+      const added = phase.symbolPresentInAdded(
+        'MATCHED_LABELS',
+        // reproduce what validate() passes: the scoped added lines for the file
+        require('node:child_process')
+          .spawnSync('git', ['diff', '-U0', 'main...HEAD', '--', 'lib/labels.js'], {
+            cwd: ctx.worktreeRoot,
+            encoding: 'utf8',
+          })
+          .stdout.split('\n')
+          .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+          .map((l) => l.slice(1))
+          .join('\n')
+      );
+      assert.equal(added, false, 'guard: MATCHED_LABELS must NOT appear on an added line');
+
+      const result = await phase.validate(ctx);
+      assert.equal(result.ok, true, 'in-place extension under real git must pass via P0.1');
+      assert.equal(
+        ctx.failures.filter((f) => f.checkType === 'reuse_audit').length,
+        0,
+        'no failure record for a genuine in-place extension'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('symbol only in an UNMODIFIED declaring file still fails under real git (anti-gaming)', async () => {
+    // lib/labels.js is unchanged (base === head) so git omits it from the diff
+    // and it is NOT in changedFiles; only an unrelated file changed. The P0.1
+    // relaxation must NOT fire and the audit must fail — anti-gaming holds even
+    // when git IS available (the exact condition the tmpdir negative control
+    // could not reach).
+    const { ctx, cleanup } = buildInPlaceGitCtx({
+      spec,
+      changedFiles: ['src/unrelated.js'],
+      files: {
+        'lib/labels.js': {
+          base: "const MATCHED_LABELS = ['a', 'b'];\n",
+          head: "const MATCHED_LABELS = ['a', 'b'];\n",
+        },
+        'src/unrelated.js': {
+          base: 'const base = 0;\n',
+          head: 'const base = 0;\nconst extra = 1;\n',
+        },
+      },
+    });
+    try {
+      const result = await phase.validate(ctx);
+      assert.equal(result.ok, false, 'unmodified declaring file must still fail under real git');
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record must be pushed for the unmodified-only symbol');
+      assert.match(
+        rec.observed,
+        /unmodified file/i,
+        'observed must name the unmodified-file miss class'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/reuse-audit-enforcement.test.js
@@ -739,13 +739,12 @@ test.describe('GH-607 review fix — config match scoped to declared file', () =
       '- `my-hook` MUST be reused from `hooks.json`',
       '',
     ].join('\n');
-    // hooks.json is added-to but WITHOUT the `my-hook` symbol OR the `hooks.json`
-    // path string; the `hooks.json` PATH needle appears only on added lines of the
-    // unrelated src/other.js. `configEntryPresent` matches EITHER needle (symbol
-    // or path), so pre-fix the combined diff let the path needle from the other
-    // file satisfy the entry. Post-fix, the per-file scoped read of hooks.json —
-    // which contains neither needle — fails it. (We avoid the `my-hook` symbol in
-    // the other file so the PRIMARY symbol-in-added check can't confound the test.)
+    // hooks.json is added-to but WITHOUT the `my-hook` symbol; the `hooks.json`
+    // path text appears only on added lines of the unrelated src/other.js. The
+    // config entry is judged SOLELY by its own file's added lines and ONLY by the
+    // symbol token (path text is not evidence), so the symbol — absent from
+    // hooks.json's own added lines — fails it. (We avoid the `my-hook` symbol in
+    // the other file so the primary symbol-in-added check can't confound the test.)
     const { ctx, cleanup } = buildGitCtx({
       spec,
       hooksJsonAdded: '{\n  "unrelated": { "command": "node z.js" }\n}\n',
@@ -857,6 +856,81 @@ test.describe('GH-607 review fix — config match scoped to declared file', () =
       );
       const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
       assert.ok(rec, 'failure record must still be pushed for the leaked config entry');
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Greptile P1 (configEntryPresent evidence strength): a change that merely
+  // MENTIONS the declared config filename on the config file's OWN added lines —
+  // without the required symbol — must NOT satisfy the entry. Pre-fix `entry.path`
+  // was a match needle, so the path text `hooks.json` counted as reuse evidence.
+  test('config filename text on the declared file’s own added lines does NOT satisfy (no path-as-evidence)', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `my-hook` MUST be reused from `hooks.json`',
+      '',
+    ].join('\n');
+    // hooks.json's own added lines contain the PATH text `hooks.json` but NOT the
+    // `my-hook` symbol; src/other.js also does not reference the symbol.
+    const { ctx, cleanup } = buildGitCtx({
+      spec,
+      hooksJsonAdded: '{\n  "note": "see hooks.json for wiring"\n}\n',
+      otherFileAdded: 'const base = 0;\nconst extra = 1;\n',
+    });
+    try {
+      // Guard: hooks.json's own added lines DO contain the path text, so it is the
+      // removal of path-as-evidence — not an absent needle — that fails the entry.
+      const own = git(ctx.worktreeRoot, ['diff', '-U0', 'main...HEAD', '--', 'hooks.json']);
+      assert.match(
+        own,
+        /hooks\.json/,
+        'guard: hooks.json own added lines must contain the path text'
+      );
+
+      const result = await phase.validate(ctx);
+      assert.equal(result.ok, false, 'the config filename text must not count as reuse evidence');
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record must be pushed when only the path text is present');
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Greptile P1 (configEntryPresent evidence strength): a SUPERSTRING of the symbol
+  // on the declared file's own added lines must NOT satisfy the entry — the match is
+  // word-bounded, so `my-hookish` cannot stand in for the `my-hook` token.
+  test('a superstring of the symbol does NOT satisfy the config entry (word-bounded, no substring)', async () => {
+    const spec = [
+      '# Spec',
+      '',
+      '## Reuse Audit',
+      '',
+      '- `my-hook` MUST be reused from `hooks.json`',
+      '',
+    ].join('\n');
+    const { ctx, cleanup } = buildGitCtx({
+      spec,
+      hooksJsonAdded: '{\n  "my-hookish": { "command": "node x.js" }\n}\n',
+      otherFileAdded: 'const base = 0;\nconst extra = 1;\n',
+    });
+    try {
+      // Guard: the symbol text appears as a SUBSTRING on hooks.json's own added
+      // lines, so it is the word boundary — not an absent needle — that fails it.
+      const own = git(ctx.worktreeRoot, ['diff', '-U0', 'main...HEAD', '--', 'hooks.json']);
+      assert.match(
+        own,
+        /my-hookish/,
+        'guard: hooks.json own added lines must contain the superstring'
+      );
+
+      const result = await phase.validate(ctx);
+      assert.equal(result.ok, false, 'a substring (my-hookish) must not satisfy the my-hook token');
+      const rec = ctx.failures.find((f) => f.checkType === 'reuse_audit');
+      assert.ok(rec, 'failure record must be pushed when only a superstring is present');
     } finally {
       cleanup();
     }

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/shared-readers.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/shared-readers.test.js
@@ -234,6 +234,81 @@ test.describe('readReuseAudit(specDir)', () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // GH-607 review fix: `mustReuse` is derived from the VERB capture group, not
+  // the whole matched bullet. A `may be reused` (soft) entry whose SYMBOL or
+  // declared PATH merely contains the substring "must" must stay
+  // `mustReuse: false` — testing `m[0]` mis-hardened these into enforced
+  // MUST-reuse requirements, manufacturing false-positive gate failures.
+  test('soft `may be reused` entry with "must" in the SYMBOL stays mustReuse:false', () => {
+    const dir = mkTmp();
+    try {
+      writeSpec(
+        dir,
+        [
+          '# Spec',
+          '',
+          '## Reuse Audit',
+          '',
+          '- `MustacheRenderer` may be reused from `src/mustache.js` — mirrored only',
+          '',
+        ].join('\n')
+      );
+      const result = shared.readReuseAudit(dir);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].symbol, 'MustacheRenderer');
+      assert.equal(result[0].mustReuse, false, 'symbol containing "must" must NOT force MUST');
+      assert.equal(result[0].path, 'src/mustache.js');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('soft `may be reused` entry with "must" in the PATH stays mustReuse:false', () => {
+    const dir = mkTmp();
+    try {
+      writeSpec(
+        dir,
+        [
+          '# Spec',
+          '',
+          '## Reuse Audit',
+          '',
+          '- `Helper` may be reused from `plugins/foo/must-reuse-helper.js` — mirrored only',
+          '',
+        ].join('\n')
+      );
+      const result = shared.readReuseAudit(dir);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].symbol, 'Helper');
+      assert.equal(result[0].mustReuse, false, 'path containing "must" must NOT force MUST');
+      assert.equal(result[0].path, 'plugins/foo/must-reuse-helper.js');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('genuine MUST entry with "must" in the path is still mustReuse:true (no false-negative)', () => {
+    const dir = mkTmp();
+    try {
+      writeSpec(
+        dir,
+        [
+          '# Spec',
+          '',
+          '## Reuse Audit',
+          '',
+          '- `Helper` MUST be reused from `plugins/foo/must-reuse-helper.js` — imported',
+          '',
+        ].join('\n')
+      );
+      const result = shared.readReuseAudit(dir);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].mustReuse, true, 'a real MUST verb must remain enforced');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 test.describe('readSuggestedScopeFiles(tasksDir)', () => {

--- a/plugins/work/scripts/workflows/work-completion-checker/__tests__/shared-readers.test.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/__tests__/shared-readers.test.js
@@ -135,6 +135,105 @@ test.describe('readReuseAudit(specDir)', () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // R7 (Task 1) — the declared source `path` is threaded through each record as
+  // an additive field so the config-file branch (Task 2) can classify entries
+  // without re-parsing. Covers all three path-bearing bullet orderings plus the
+  // no-path case (`path: null`).
+  test('threads declared `path` for the canonical ordering: `Symbol` MUST be reused from `path`', () => {
+    const dir = mkTmp();
+    try {
+      writeSpec(
+        dir,
+        [
+          '# Spec',
+          '',
+          '## Reuse Audit',
+          '',
+          '- `readReuseAudit` MUST be reused from `plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js` — parser entry point',
+          '',
+        ].join('\n')
+      );
+      const result = shared.readReuseAudit(dir);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].symbol, 'readReuseAudit');
+      assert.equal(
+        result[0].path,
+        'plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js'
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('threads declared `path` for the path-before-verb ordering: `Symbol` from `path` MUST be reused', () => {
+    const dir = mkTmp();
+    try {
+      writeSpec(
+        dir,
+        [
+          '# Spec',
+          '',
+          '## Reuse Audit',
+          '',
+          '- `readReuseAudit` from `lib/kind-checks/shared.js` MUST be reused — parser entry point',
+          '',
+        ].join('\n')
+      );
+      const result = shared.readReuseAudit(dir);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].symbol, 'readReuseAudit');
+      assert.equal(result[0].path, 'lib/kind-checks/shared.js');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('threads declared `path` for the parenthesized ordering: `Symbol` (`path`) MUST be reused', () => {
+    const dir = mkTmp();
+    try {
+      writeSpec(
+        dir,
+        [
+          '# Spec',
+          '',
+          '## Reuse Audit',
+          '',
+          '- `hooks` (`plugins/work/hooks/hooks.json`) MUST be reused — config entry',
+          '',
+        ].join('\n')
+      );
+      const result = shared.readReuseAudit(dir);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].symbol, 'hooks');
+      assert.equal(result[0].path, 'plugins/work/hooks/hooks.json');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('sets `path: null` when the bullet declares no source path', () => {
+    const dir = mkTmp();
+    try {
+      writeSpec(
+        dir,
+        [
+          '# Spec',
+          '',
+          '## Reuse Audit',
+          '',
+          '- `SomePattern` MUST be reused — mirrored pattern, no explicit path',
+          '',
+        ].join('\n')
+      );
+      const result = shared.readReuseAudit(dir);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].symbol, 'SomePattern');
+      assert.equal(result[0].path, null);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 test.describe('readSuggestedScopeFiles(tasksDir)', () => {

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
@@ -192,11 +192,19 @@ function readReuseAudit(specDir) {
     // `` `Symbol` from `path` MUST be reused `` ordering spec-writer also
     // emits (GH-282 follow-up: the canonical shape puts `from \`path\``
     // AFTER the verb, but the parser must accept either side).
+    //
+    // GH-607 (R7): the declared source path is additionally CAPTURED (not just
+    // tolerated) into an additive `path` field so downstream consumers can
+    // classify config-file entries without re-parsing. Three path orderings
+    // are captured — pre-verb `from \`path\`` (group 2), pre-verb
+    // parenthesized `(\`path\`)` (group 3), and post-verb `from \`path\``
+    // (group 4) — falling back to `null` when the bullet declares no path.
     const m = raw.match(
-      /^\s*[-*]\s+`([^`]+)`\s*(?:from\s+`[^`]+`\s*|\([^)]*\)\s*)?(MUST\s+be\s+reused|be\s+reused|may\s+be\s+reused)/i
+      /^\s*[-*]\s+`([^`]+)`\s*(?:from\s+`([^`]+)`\s*|\(`([^`]+)`\)\s*|\([^)]*\)\s*)?(?:MUST\s+be\s+reused|be\s+reused|may\s+be\s+reused)(?:\s+from\s+`([^`]+)`)?/i
     );
     if (!m) continue;
-    const mustReuse = /MUST/i.test(m[2]);
+    const mustReuse = /MUST/i.test(m[0]);
+    const declaredPath = m[2] || m[3] || m[4] || null;
     entries.push({
       symbol: m[1],
       // headingLine is the 1-indexed line of `## Reuse Audit`; sliceSection
@@ -206,6 +214,9 @@ function readReuseAudit(specDir) {
       // line above its actual location in spec.md (review feedback).
       line: headingLine + 1 + i,
       mustReuse,
+      // GH-607 (R7): declared source path (or `null`). Additive — no existing
+      // field is renamed or removed; existing consumers are unaffected.
+      path: declaredPath,
       // Self-evident, per-entry identifier — Reuse Audit entries in spec.md
       // have no explicit R-ID, so we synthesize one. Used by failure records
       // in lieu of the previously hard-pinned 'R1'.

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
@@ -152,12 +152,13 @@ function readBriefRequirements(tasksDir) {
  * GH-607 (R7): pick the declared source path from a Reuse Audit bullet match.
  * Three path orderings are captured by `readReuseAudit`'s regex — pre-verb
  * `from \`path\`` (group 2), pre-verb parenthesized `(\`path\`)` (group 3),
- * and post-verb `from \`path\`` (group 4) — falling back to `null` when the
- * bullet declares no path. Extracted so the disjunction lives outside
- * `readReuseAudit` (keeps its cyclomatic complexity within the gate).
+ * and post-verb `from \`path\`` (group 5) — falling back to `null` when the
+ * bullet declares no path. (Group 4 is the verb phrase itself, from which
+ * `mustReuse` is derived — never a path.) Extracted so the disjunction lives
+ * outside `readReuseAudit` (keeps its cyclomatic complexity within the gate).
  */
 function pickDeclaredReusePath(match) {
-  return match[2] || match[3] || match[4] || null;
+  return match[2] || match[3] || match[5] || null;
 }
 
 /**
@@ -210,12 +211,17 @@ function readReuseAudit(specDir) {
     // classify config-file entries without re-parsing. Three path orderings
     // are captured — pre-verb `from \`path\`` (group 2), pre-verb
     // parenthesized `(\`path\`)` (group 3), and post-verb `from \`path\``
-    // (group 4) — falling back to `null` when the bullet declares no path.
+    // (group 5) — falling back to `null` when the bullet declares no path.
+    // The verb phrase is its OWN capture group (group 4) so `mustReuse` is
+    // derived from the verb alone — testing the whole match (`m[0]`) would
+    // mis-classify a `may be reused` bullet as MUST whenever the symbol name
+    // or declared path merely contains the substring "must" (e.g.
+    // `MustacheRenderer`, `must-reuse-helper.js`).
     const m = raw.match(
-      /^\s*[-*]\s+`([^`]+)`\s*(?:from\s+`([^`]+)`\s*|\(`([^`]+)`\)\s*|\([^)]*\)\s*)?(?:MUST\s+be\s+reused|be\s+reused|may\s+be\s+reused)(?:\s+from\s+`([^`]+)`)?/i
+      /^\s*[-*]\s+`([^`]+)`\s*(?:from\s+`([^`]+)`\s*|\(`([^`]+)`\)\s*|\([^)]*\)\s*)?(MUST\s+be\s+reused|be\s+reused|may\s+be\s+reused)(?:\s+from\s+`([^`]+)`)?/i
     );
     if (!m) continue;
-    const mustReuse = /MUST/i.test(m[0]);
+    const mustReuse = /MUST/i.test(m[4]);
     const declaredPath = pickDeclaredReusePath(m);
     entries.push({
       symbol: m[1],

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/kind-checks/shared.js
@@ -149,6 +149,18 @@ function readBriefRequirements(tasksDir) {
 }
 
 /**
+ * GH-607 (R7): pick the declared source path from a Reuse Audit bullet match.
+ * Three path orderings are captured by `readReuseAudit`'s regex — pre-verb
+ * `from \`path\`` (group 2), pre-verb parenthesized `(\`path\`)` (group 3),
+ * and post-verb `from \`path\`` (group 4) — falling back to `null` when the
+ * bullet declares no path. Extracted so the disjunction lives outside
+ * `readReuseAudit` (keeps its cyclomatic complexity within the gate).
+ */
+function pickDeclaredReusePath(match) {
+  return match[2] || match[3] || match[4] || null;
+}
+
+/**
  * Parse the `## Reuse Audit` section of spec.md and return an array of
  * `{ symbol, line, mustReuse }` records. Returns `null` when the section
  * is absent (signals "spec doesn't declare reuse"), and `[]` when the
@@ -204,7 +216,7 @@ function readReuseAudit(specDir) {
     );
     if (!m) continue;
     const mustReuse = /MUST/i.test(m[0]);
-    const declaredPath = m[2] || m[3] || m[4] || null;
+    const declaredPath = pickDeclaredReusePath(m);
     entries.push({
       symbol: m[1],
       // headingLine is the 1-indexed line of `## Reuse Audit`; sliceSection

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
@@ -121,22 +121,78 @@ function symbolPresentInAdded(symbol, addedLines) {
   return re.test(addedLines);
 }
 
+// GH-607: shared word-boundary matcher so `symbolPresentInBlobs` and
+// `symbolPresentInBlobsScoped` cannot drift in how they detect a symbol.
+function wordBoundaryRe(symbol) {
+  return new RegExp(`\\b${escapeRegex(symbol)}\\b`);
+}
+
 function symbolPresentInBlobs(symbol, fileBlobs) {
-  const re = new RegExp(`\\b${escapeRegex(symbol)}\\b`);
+  const re = wordBoundaryRe(symbol);
   return fileBlobs.some((f) => re.test(f.content));
+}
+
+// GH-607 (R1): scoped blob check — the symbol must appear in the blob whose
+// `rel` matches `relPath`. Used for the P0.1 in-place-extension relaxation so
+// a symbol present only in some OTHER modified file cannot satisfy the audit.
+function symbolPresentInBlobsScoped(symbol, fileBlobs, relPath) {
+  const re = wordBoundaryRe(symbol);
+  return fileBlobs.some((f) => f.rel === relPath && re.test(f.content));
+}
+
+// GH-607 (R2): non-JS/TS declared paths are treated as config-file entries and
+// matched by path/block presence rather than the importable-symbol heuristic.
+const JS_TS_EXTENSIONS = new Set(['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs']);
+
+function isConfigPath(p) {
+  if (!p || typeof p !== 'string') return false;
+  const ext = path.extname(p).toLowerCase();
+  if (ext === '') return false;
+  return !JS_TS_EXTENSIONS.has(ext);
+}
+
+// GH-607 (R2): a config-file MUST-reuse entry counts as reused only when its
+// declared path is in the change set AND its declared path or symbol block
+// literally appears on the added lines of this change.
+function configEntryPresent(entry, addedLines, changedSet) {
+  if (!entry || !entry.path || !changedSet || !changedSet.has(entry.path)) return false;
+  if (addedLines === null || addedLines === undefined || addedLines === '') return false;
+  const needles = [entry.symbol, entry.path].filter((s) => typeof s === 'string' && s.length > 0);
+  return needles.some((needle) => new RegExp(escapeRegex(needle)).test(addedLines));
 }
 
 function errMessage(err) {
   return err && err.message ? err.message : String(err);
 }
 
-function buildMissingFailure(entry, joined) {
+// GH-607 (R5/P1.1): distinguish the two miss classes when there is no
+// suffix-candidate "did you mean to extend X?" hint — a symbol whose declaring
+// file exists on disk with the symbol but was NOT modified in this change
+// ("unmodified file") vs a symbol no changed file references at all.
+function missClassMessage(symbol, declaredInUnmodifiedFile) {
+  return declaredInUnmodifiedFile
+    ? `${symbol} not found in diff — declared in an unmodified file (not reused here)`
+    : `${symbol} not found in diff — no changed file references it`;
+}
+
+// GH-607 (R5): the symbol's declaring file exists on disk and contains the
+// symbol, yet that file was NOT modified in this change (not in `changedSet`).
+// This is the "declared in an unmodified file" miss class.
+function declaredInUnmodifiedFile(ctx, entry, changedSet) {
+  if (!entry.path || (changedSet && changedSet.has(entry.path))) return false;
+  const root = ctx.worktreeRoot || process.cwd();
+  const abs = path.isAbsolute(entry.path) ? entry.path : path.join(root, entry.path);
+  const content = readFileSafe(abs);
+  return content !== '' && wordBoundaryRe(entry.symbol).test(content);
+}
+
+function buildMissingFailure(entry, joined, declaredElsewhere) {
   const symbol = entry.symbol;
   const candidates = extractSuffixCandidates(symbol, joined);
   const observed =
     candidates.length > 0
       ? `found ${candidates[0]} in diff — did you mean to extend ${symbol}?`
-      : `${symbol} not found in diff — imported instead by no changed file`;
+      : missClassMessage(symbol, declaredElsewhere);
   return makeFailure({
     // requirementId is synthesized by readReuseAudit() as `REUSE-<n>` so each
     // MUST-reuse entry has a stable, self-evident identifier rather than the
@@ -150,7 +206,32 @@ function buildMissingFailure(entry, joined) {
   });
 }
 
-function checkMustReuseEntries(entries, blobs, joined, addedLines, failures) {
+// GH-607: does the declaring file for `entry` appear in the change set with
+// non-empty content? Gate for the P0.1 in-place-extension relaxation and for
+// the refined "unmodified file" miss message.
+function declaringFileModified(entry, changedSet, blobs) {
+  if (!entry.path || !changedSet || !changedSet.has(entry.path)) return false;
+  return blobs.some((b) => b.rel === entry.path && b.content !== '');
+}
+
+// GH-607 (R1/P0.1): in-place extension — the symbol is not on an added line,
+// but its declaring file WAS modified in this change, so a scoped blob check
+// on that single file counts it as reused (anti-gaming: only fires when the
+// declaring file was genuinely modified).
+function isInPlaceExtension(entry, changedSet, blobs) {
+  return (
+    declaringFileModified(entry, changedSet, blobs) &&
+    symbolPresentInBlobsScoped(entry.symbol, blobs, entry.path)
+  );
+}
+
+// GH-607 (R2/P0.2): config-file entry — declared path is a non-JS/TS file and
+// its block genuinely appears in the change set's added lines.
+function isConfigEntryReused(entry, addedLines, changedSet) {
+  return isConfigPath(entry.path) && configEntryPresent(entry, addedLines, changedSet);
+}
+
+function checkMustReuseEntries(ctx, entries, blobs, joined, addedLines, failures, changedSet) {
   let mustChecked = 0;
   let mustMissing = 0;
   for (const entry of entries) {
@@ -161,8 +242,15 @@ function checkMustReuseEntries(entries, blobs, joined, addedLines, failures) {
     const addedHit = symbolPresentInAdded(entry.symbol, addedLines);
     const present = addedHit === null ? symbolPresentInBlobs(entry.symbol, blobs) : addedHit;
     if (present) continue;
+    // GH-607 guarded relaxations (only reachable when the strict added-line
+    // check missed): in-place extension of a modified file, or a config-file
+    // block present in the change.
+    if (isInPlaceExtension(entry, changedSet, blobs)) continue;
+    if (isConfigEntryReused(entry, addedLines, changedSet)) continue;
     mustMissing += 1;
-    failures.push(buildMissingFailure(entry, joined));
+    failures.push(
+      buildMissingFailure(entry, joined, declaredInUnmodifiedFile(ctx, entry, changedSet))
+    );
   }
   return { mustChecked, mustMissing };
 }
@@ -210,15 +298,18 @@ function validate(ctx) {
 
   try {
     const changed = readChangedFiles(ctx) || [];
+    const changedSet = new Set(changed);
     const blobs = loadChangedContents(ctx, changed);
     const joined = blobs.map((b) => b.content).join('\n');
     const addedLines = readAddedLines(ctx, changed);
     const { mustChecked, mustMissing } = checkMustReuseEntries(
+      ctx,
       entries,
       blobs,
       joined,
       addedLines,
-      failures
+      failures,
+      changedSet
     );
     ctx.reuseAuditChecked = mustChecked;
     appendForCheckType(ctx.tasksDir, 'reuse_audit', failures.slice(startLen), {
@@ -262,3 +353,6 @@ module.exports.instructions = instructions;
 module.exports.extractSuffixCandidates = extractSuffixCandidates;
 module.exports.symbolPresentInAdded = symbolPresentInAdded;
 module.exports.symbolPresentInBlobs = symbolPresentInBlobs;
+module.exports.symbolPresentInBlobsScoped = symbolPresentInBlobsScoped;
+module.exports.isConfigPath = isConfigPath;
+module.exports.configEntryPresent = configEntryPresent;

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
@@ -252,21 +252,29 @@ function isInPlaceExtension(entry, changedSet, blobs) {
   );
 }
 
-// GH-607 (R2/P0.2): config-file entry — declared path is a non-JS/TS file and
-// its block genuinely appears in the added lines of THAT declared file.
-//
-// Review fix (GH-607): re-read the added lines scoped to `entry.path` alone
-// (not the repo-wide `addedLines`) so a needle appearing only in some other
-// changed file cannot satisfy this config entry. `readAddedLines` returns:
-//   - a string (possibly empty) → git ran; authoritative scoped result
-//   - null                      → git could not run; fall back to the repo-wide
-//     `addedLines` proxy so we don't fail-closed on missing tooling. The
-//     `changedSet.has(entry.path)` gate inside `configEntryPresent` still holds.
-function isConfigEntryReused(ctx, entry, addedLines, changedSet) {
+// GH-607 (R2/P0.2): config-file entry — declared path is a non-JS/TS file whose
+// block genuinely appears in the change of THAT declared file. Scoped per-file:
+// git available → the declared file's own added lines; git unavailable → its own
+// blob content (never the combined diff / all-blobs set, so a needle in an
+// UNRELATED changed file cannot satisfy the entry — Greptile P1).
+function isConfigEntryReused(ctx, entry, blobs, changedSet) {
   if (!isConfigPath(entry.path)) return false;
-  const scoped = readAddedLines(ctx, [normalizeRepoPath(entry.path)]);
-  const effective = scoped === null ? addedLines : scoped;
+  const norm = normalizeRepoPath(entry.path);
+  const scoped = readAddedLines(ctx, [norm]);
+  const effective = scoped === null ? (blobs.find((b) => b.rel === norm)?.content ?? '') : scoped;
   return configEntryPresent(entry, effective, changedSet);
+}
+
+// Returns true when `entry` counts as reused. Config-path entries are judged
+// SOLELY by their declared file (above); the primary combined-diff / all-blobs
+// symbol check must NOT run for them, or the config symbol text in an unrelated
+// changed file would leak a false pass (Greptile P1). Importable-symbol entries
+// use the added-line check (B3) + legacy full-content fallback + in-place relax.
+function isReuseEntrySatisfied(ctx, entry, blobs, addedLines, changedSet) {
+  if (isConfigPath(entry.path)) return isConfigEntryReused(ctx, entry, blobs, changedSet);
+  const addedHit = symbolPresentInAdded(entry.symbol, addedLines);
+  const present = addedHit === null ? symbolPresentInBlobs(entry.symbol, blobs) : addedHit;
+  return present || isInPlaceExtension(entry, changedSet, blobs);
 }
 
 function checkMustReuseEntries(ctx, entries, blobs, joined, addedLines, failures, changedSet) {
@@ -275,16 +283,7 @@ function checkMustReuseEntries(ctx, entries, blobs, joined, addedLines, failures
   for (const entry of entries) {
     if (!entry || entry.mustReuse !== true) continue;
     mustChecked += 1;
-    // Prefer added-line match (B3). If git was unavailable, fall back to the
-    // legacy full-content proxy so we don't fail-closed on missing tooling.
-    const addedHit = symbolPresentInAdded(entry.symbol, addedLines);
-    const present = addedHit === null ? symbolPresentInBlobs(entry.symbol, blobs) : addedHit;
-    if (present) continue;
-    // GH-607 guarded relaxations (only reachable when the strict added-line
-    // check missed): in-place extension of a modified file, or a config-file
-    // block present in the change.
-    if (isInPlaceExtension(entry, changedSet, blobs)) continue;
-    if (isConfigEntryReused(ctx, entry, addedLines, changedSet)) continue;
+    if (isReuseEntrySatisfied(ctx, entry, blobs, addedLines, changedSet)) continue;
     mustMissing += 1;
     failures.push(
       buildMissingFailure(entry, joined, declaredInUnmodifiedFile(ctx, entry, changedSet))

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
@@ -172,11 +172,9 @@ function isConfigPath(p) {
 // declared path is in the change set AND its declared path or symbol block
 // literally appears on the added lines of THAT declared file.
 //
-// Review fix (GH-607): `scopedAddedLines` MUST be the added lines of
-// `entry.path` alone — not the combined diff of every changed file. Passing the
-// repo-wide `addedLines` here let a needle appearing only in an unrelated
-// changed file satisfy the config entry, defeating the fail-closed anti-gaming
-// guarantee. Callers use `readAddedLines(ctx, [entry.path])` to scope it.
+// Review fix (GH-607): `scopedAddedLines` MUST be `entry.path`'s own added lines
+// (callers pass `readAddedLines(ctx, [entry.path])`) — the repo-wide diff let a
+// needle in an unrelated changed file satisfy the entry, defeating fail-closed.
 function configEntryPresent(entry, scopedAddedLines, changedSet) {
   if (!entry || !entry.path) return false;
   if (!changedSet || !changedSet.has(normalizeRepoPath(entry.path))) return false;

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
@@ -25,6 +25,21 @@ const config = require('../../../lib/config');
 
 const SUFFIX_RE = /([A-Z][a-z0-9]+)$/;
 
+// GH-607: canonicalize a repo-relative path so spec-declared spellings
+// (`./hooks.json`, `foo//bar.json`, a leading `/`) compare equal to git's
+// `--name-only` output (repo-relative, no `./`, single separators). Conservative:
+// a `..` segment is left intact so an out-of-tree path can't silently normalize
+// onto a matching in-tree one.
+function normalizeRepoPath(p) {
+  if (typeof p !== 'string' || p.length === 0) return p;
+  let out = p
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/{2,}/g, '/');
+  while (out.startsWith('./')) out = out.slice(2);
+  return out.replace(/\/$/, '');
+}
+
 /**
  * Extract candidate tokens from `diffContent` that share `symbol`'s
  * trailing PascalCase suffix (e.g. for `ContentPageToolbar`, the suffix
@@ -63,7 +78,9 @@ function loadChangedContents(ctx, changed) {
   const out = [];
   for (const rel of changed) {
     const abs = path.isAbsolute(rel) ? rel : path.join(root, rel);
-    out.push({ rel, content: readFileSafe(abs) });
+    // GH-607: key blobs by canonical repo-relative path so `entry.path`
+    // (spec-declared spelling) matches regardless of `./` prefix etc.
+    out.push({ rel: normalizeRepoPath(rel), content: readFileSafe(abs) });
   }
   return out;
 }
@@ -161,7 +178,8 @@ function isConfigPath(p) {
 // changed file satisfy the config entry, defeating the fail-closed anti-gaming
 // guarantee. Callers use `readAddedLines(ctx, [entry.path])` to scope it.
 function configEntryPresent(entry, scopedAddedLines, changedSet) {
-  if (!entry || !entry.path || !changedSet || !changedSet.has(entry.path)) return false;
+  if (!entry || !entry.path) return false;
+  if (!changedSet || !changedSet.has(normalizeRepoPath(entry.path))) return false;
   if (scopedAddedLines === null || scopedAddedLines === undefined || scopedAddedLines === '') {
     return false;
   }
@@ -187,7 +205,8 @@ function missClassMessage(symbol, declaredInUnmodifiedFile) {
 // symbol, yet that file was NOT modified in this change (not in `changedSet`).
 // This is the "declared in an unmodified file" miss class.
 function declaredInUnmodifiedFile(ctx, entry, changedSet) {
-  if (!entry.path || (changedSet && changedSet.has(entry.path))) return false;
+  if (!entry.path) return false;
+  if (changedSet && changedSet.has(normalizeRepoPath(entry.path))) return false;
   const root = ctx.worktreeRoot || process.cwd();
   const abs = path.isAbsolute(entry.path) ? entry.path : path.join(root, entry.path);
   const content = readFileSafe(abs);
@@ -218,8 +237,10 @@ function buildMissingFailure(entry, joined, declaredElsewhere) {
 // non-empty content? Gate for the P0.1 in-place-extension relaxation and for
 // the refined "unmodified file" miss message.
 function declaringFileModified(entry, changedSet, blobs) {
-  if (!entry.path || !changedSet || !changedSet.has(entry.path)) return false;
-  return blobs.some((b) => b.rel === entry.path && b.content !== '');
+  if (!entry.path || !changedSet) return false;
+  const norm = normalizeRepoPath(entry.path);
+  if (!changedSet.has(norm)) return false;
+  return blobs.some((b) => b.rel === norm && b.content !== '');
 }
 
 // GH-607 (R1/P0.1): in-place extension — the symbol is not on an added line,
@@ -229,7 +250,7 @@ function declaringFileModified(entry, changedSet, blobs) {
 function isInPlaceExtension(entry, changedSet, blobs) {
   return (
     declaringFileModified(entry, changedSet, blobs) &&
-    symbolPresentInBlobsScoped(entry.symbol, blobs, entry.path)
+    symbolPresentInBlobsScoped(entry.symbol, blobs, normalizeRepoPath(entry.path))
   );
 }
 
@@ -245,7 +266,7 @@ function isInPlaceExtension(entry, changedSet, blobs) {
 //     `changedSet.has(entry.path)` gate inside `configEntryPresent` still holds.
 function isConfigEntryReused(ctx, entry, addedLines, changedSet) {
   if (!isConfigPath(entry.path)) return false;
-  const scoped = readAddedLines(ctx, [entry.path]);
+  const scoped = readAddedLines(ctx, [normalizeRepoPath(entry.path)]);
   const effective = scoped === null ? addedLines : scoped;
   return configEntryPresent(entry, effective, changedSet);
 }
@@ -317,7 +338,9 @@ function validate(ctx) {
 
   try {
     const changed = readChangedFiles(ctx) || [];
-    const changedSet = new Set(changed);
+    // GH-607: canonicalize the change-set keys so `entry.path` (spec-declared
+    // spelling like `./hooks.json`) matches git's repo-relative output.
+    const changedSet = new Set(changed.map(normalizeRepoPath));
     const blobs = loadChangedContents(ctx, changed);
     const joined = blobs.map((b) => b.content).join('\n');
     const addedLines = readAddedLines(ctx, changed);
@@ -375,3 +398,4 @@ module.exports.symbolPresentInBlobs = symbolPresentInBlobs;
 module.exports.symbolPresentInBlobsScoped = symbolPresentInBlobsScoped;
 module.exports.isConfigPath = isConfigPath;
 module.exports.configEntryPresent = configEntryPresent;
+module.exports.normalizeRepoPath = normalizeRepoPath;

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
@@ -153,12 +153,20 @@ function isConfigPath(p) {
 
 // GH-607 (R2): a config-file MUST-reuse entry counts as reused only when its
 // declared path is in the change set AND its declared path or symbol block
-// literally appears on the added lines of this change.
-function configEntryPresent(entry, addedLines, changedSet) {
+// literally appears on the added lines of THAT declared file.
+//
+// Review fix (GH-607): `scopedAddedLines` MUST be the added lines of
+// `entry.path` alone — not the combined diff of every changed file. Passing the
+// repo-wide `addedLines` here let a needle appearing only in an unrelated
+// changed file satisfy the config entry, defeating the fail-closed anti-gaming
+// guarantee. Callers use `readAddedLines(ctx, [entry.path])` to scope it.
+function configEntryPresent(entry, scopedAddedLines, changedSet) {
   if (!entry || !entry.path || !changedSet || !changedSet.has(entry.path)) return false;
-  if (addedLines === null || addedLines === undefined || addedLines === '') return false;
+  if (scopedAddedLines === null || scopedAddedLines === undefined || scopedAddedLines === '') {
+    return false;
+  }
   const needles = [entry.symbol, entry.path].filter((s) => typeof s === 'string' && s.length > 0);
-  return needles.some((needle) => new RegExp(escapeRegex(needle)).test(addedLines));
+  return needles.some((needle) => new RegExp(escapeRegex(needle)).test(scopedAddedLines));
 }
 
 function errMessage(err) {
@@ -226,9 +234,20 @@ function isInPlaceExtension(entry, changedSet, blobs) {
 }
 
 // GH-607 (R2/P0.2): config-file entry — declared path is a non-JS/TS file and
-// its block genuinely appears in the change set's added lines.
-function isConfigEntryReused(entry, addedLines, changedSet) {
-  return isConfigPath(entry.path) && configEntryPresent(entry, addedLines, changedSet);
+// its block genuinely appears in the added lines of THAT declared file.
+//
+// Review fix (GH-607): re-read the added lines scoped to `entry.path` alone
+// (not the repo-wide `addedLines`) so a needle appearing only in some other
+// changed file cannot satisfy this config entry. `readAddedLines` returns:
+//   - a string (possibly empty) → git ran; authoritative scoped result
+//   - null                      → git could not run; fall back to the repo-wide
+//     `addedLines` proxy so we don't fail-closed on missing tooling. The
+//     `changedSet.has(entry.path)` gate inside `configEntryPresent` still holds.
+function isConfigEntryReused(ctx, entry, addedLines, changedSet) {
+  if (!isConfigPath(entry.path)) return false;
+  const scoped = readAddedLines(ctx, [entry.path]);
+  const effective = scoped === null ? addedLines : scoped;
+  return configEntryPresent(entry, effective, changedSet);
 }
 
 function checkMustReuseEntries(ctx, entries, blobs, joined, addedLines, failures, changedSet) {
@@ -246,7 +265,7 @@ function checkMustReuseEntries(ctx, entries, blobs, joined, addedLines, failures
     // check missed): in-place extension of a modified file, or a config-file
     // block present in the change.
     if (isInPlaceExtension(entry, changedSet, blobs)) continue;
-    if (isConfigEntryReused(entry, addedLines, changedSet)) continue;
+    if (isConfigEntryReused(ctx, entry, addedLines, changedSet)) continue;
     mustMissing += 1;
     failures.push(
       buildMissingFailure(entry, joined, declaredInUnmodifiedFile(ctx, entry, changedSet))

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
@@ -252,17 +252,17 @@ function isInPlaceExtension(entry, changedSet, blobs) {
   );
 }
 
-// GH-607 (R2/P0.2): config-file entry — declared path is a non-JS/TS file whose
-// block genuinely appears in the change of THAT declared file. Scoped per-file:
-// git available → the declared file's own added lines; git unavailable → its own
-// blob content (never the combined diff / all-blobs set, so a needle in an
-// UNRELATED changed file cannot satisfy the entry — Greptile P1).
-function isConfigEntryReused(ctx, entry, blobs, changedSet) {
+// GH-607 (R2/P0.2): config-file entry — non-JS/TS declared path matched per-file AND
+// per-added-line: only the declared file's OWN `git diff -U0` added lines satisfy it
+// (never the combined/all-blobs set — Greptile P1). Fallback (Greptile P1): when the
+// diff is UNAVAILABLE (readAddedLines null) do NOT use full blob content — the symbol
+// trivially pre-exists in its own config file, so fail toward not-reused (no stale pass).
+function isConfigEntryReused(ctx, entry, changedSet) {
   if (!isConfigPath(entry.path)) return false;
   const norm = normalizeRepoPath(entry.path);
   const scoped = readAddedLines(ctx, [norm]);
-  const effective = scoped === null ? (blobs.find((b) => b.rel === norm)?.content ?? '') : scoped;
-  return configEntryPresent(entry, effective, changedSet);
+  if (scoped === null) return false;
+  return configEntryPresent(entry, scoped, changedSet);
 }
 
 // Returns true when `entry` counts as reused. Config-path entries are judged
@@ -271,7 +271,7 @@ function isConfigEntryReused(ctx, entry, blobs, changedSet) {
 // changed file would leak a false pass (Greptile P1). Importable-symbol entries
 // use the added-line check (B3) + legacy full-content fallback + in-place relax.
 function isReuseEntrySatisfied(ctx, entry, blobs, addedLines, changedSet) {
-  if (isConfigPath(entry.path)) return isConfigEntryReused(ctx, entry, blobs, changedSet);
+  if (isConfigPath(entry.path)) return isConfigEntryReused(ctx, entry, changedSet);
   const addedHit = symbolPresentInAdded(entry.symbol, addedLines);
   const present = addedHit === null ? symbolPresentInBlobs(entry.symbol, blobs) : addedHit;
   return present || isInPlaceExtension(entry, changedSet, blobs);

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
@@ -169,20 +169,20 @@ function isConfigPath(p) {
 }
 
 // GH-607 (R2): a config-file MUST-reuse entry counts as reused only when its
-// declared path is in the change set AND its declared path or symbol block
-// literally appears on the added lines of THAT declared file.
-//
-// Review fix (GH-607): `scopedAddedLines` MUST be `entry.path`'s own added lines
-// (callers pass `readAddedLines(ctx, [entry.path])`) — the repo-wide diff let a
-// needle in an unrelated changed file satisfy the entry, defeating fail-closed.
+// declared path is in the change set AND the declared SYMBOL appears as a whole
+// token on the added lines of THAT declared file (callers pass the file's own
+// `readAddedLines`). Greptile P1 (evidence strength): the match uses the SAME
+// word-boundary token matcher as the importable-symbol paths — never the declared
+// path/filename text (mentioning the config filename must not satisfy the entry)
+// and never a substring (`my-hook` is not satisfied by `my-hookish`).
 function configEntryPresent(entry, scopedAddedLines, changedSet) {
   if (!entry || !entry.path) return false;
+  if (typeof entry.symbol !== 'string' || entry.symbol.length === 0) return false;
   if (!changedSet || !changedSet.has(normalizeRepoPath(entry.path))) return false;
   if (scopedAddedLines === null || scopedAddedLines === undefined || scopedAddedLines === '') {
     return false;
   }
-  const needles = [entry.symbol, entry.path].filter((s) => typeof s === 'string' && s.length > 0);
-  return needles.some((needle) => new RegExp(escapeRegex(needle)).test(scopedAddedLines));
+  return wordBoundaryRe(entry.symbol).test(scopedAddedLines);
 }
 
 function errMessage(err) {

--- a/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
+++ b/plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js
@@ -164,7 +164,7 @@ const JS_TS_EXTENSIONS = new Set(['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs'])
 function isConfigPath(p) {
   if (!p || typeof p !== 'string') return false;
   const ext = path.extname(p).toLowerCase();
-  if (ext === '') return false;
+  if (ext === '') return true; // extensionless (Dockerfile/Makefile/dotfile) → config, not importable
   return !JS_TS_EXTENSIONS.has(ext);
 }
 


### PR DESCRIPTION
## Existing Behavior

- `reuse_audit_enforcement` only counts a MUST-reuse symbol as satisfied when it appears verbatim on a `+`-prefixed added line (`git diff -U0`).
- In-place extension of an existing symbol (e.g. adding an element to an exported array or a branch to an existing function) leaves the declaration token on a context line, so the symbol is genuinely reused but the gate reports it "missing from diff."
- MUST-reuse entries pointing at non-JS/TS paths (e.g. `hooks.json`) are evaluated by the importable-symbol heuristic, which is inapplicable to config files, causing false-negative failures even when the config block appears on added lines.
- Both miss classes produce the same vague `imported instead by no changed file` failure message, giving operators no hint about whether the miss is a real gap or a tooling limitation.

## Intended New Behavior

- **P0.1 — in-place extension:** when a MUST-reuse symbol is absent from added lines but its declaring `.js`/`.ts` file was modified in this change, a scoped blob check on that single declaring file counts the symbol as reused. A symbol present only in some other modified file (not the declaring file) still fails — the anti-gaming guarantee is preserved.
- **P0.2 — config-file entries:** a MUST-reuse entry whose declared path is a non-JS/TS file is matched by literal path/block presence on the added lines of that changed file, bypassing the importable-symbol heuristic.
- **Fail-closed guarantee preserved:** a symbol present only in pre-existing, unmodified code still fails; deletion-only / no-op changes still fail; parser and IO errors still fail closed.
- **Refined failure messages:** misses now distinguish "declared in an unmodified file (not reused here)" from "no changed file references it," so operators can tell a structural miss from a tooling gap.
- **Additive `path` field on audit records:** `readReuseAudit` threads the declared source path through each record as `path` (or `null` when absent), consumed by the config-file branch without re-parsing. No existing field is renamed or removed.

Closes #607

## Brief P0 coverage

- **P0 #1 (detect in-place extension):** implemented in `plugins/work/scripts/workflows/work-completion-checker/lib/phases/reuse_audit_enforcement.js` via `isInPlaceExtension()` + `symbolPresentInBlobsScoped()` + `declaringFileModified()`; tested in `__tests__/reuse-audit-enforcement.test.js` ("validate: in-place extension of a modified .js symbol (context line) ⇒ 0 missing" + negative-control test)
- **P0 #2 (handle config-file reuse entries):** implemented via `isConfigPath()` + `configEntryPresent()` + `isConfigEntryReused()` in `reuse_audit_enforcement.js`; tested ("validate: hooks.json config MUST-reuse entry present in the change ⇒ 0 missing" + "config MUST-reuse entry ABSENT from the change fails")
- **P0 #3 (preserve fail-closed anti-gaming):** negative-control test ("NEGATIVE CONTROL: symbol present only in an unmodified file still fails") asserts `result.ok === false` when declaring file is not in the changed set; `declaringFileModified()` gates the P0.1 relaxation; `configEntryPresent()` requires the path to be in `changedSet`.
- **P0 #4 (regression coverage):** `__tests__/reuse-audit-enforcement.test.js` adds 8 new tests across three describe blocks (2.1 pure helpers, 2.2 guarded branches, 2.3 regression + negative control); `__tests__/shared-readers.test.js` adds 4 new tests for the `path` field threading across all three bullet orderings plus the no-path null case. Round-2 review fixes add `mustReuse`-from-verb regression tests (soft `may be reused` entries whose symbol or path contains the substring "must") and a real-git P0.1 in-place-extension suite (positive + anti-gaming negative control), plus real-git Greptile-P1 negative tests (config symbol text in an unrelated changed file, config file untouched, must stay non-reused) — covering both extensioned (hooks.json) and extensionless (Dockerfile) config paths.

## Out-of-scope changes

None. All five changed files (`reuse_audit_enforcement.js`, `shared.js`, two test files, `docs/README.md`) are within the scope defined in the brief's target file list.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

### Backend / unit verification

The two false-negative shapes are exercised directly by the new test suite. To reproduce locally:

```bash
cd plugins/work/scripts/workflows/work-completion-checker
node --test __tests__/reuse-audit-enforcement.test.js __tests__/shared-readers.test.js
```

Expected: all 59 tests pass, exit 0.

**P0.1 (in-place extension) — manual reproduction:**

1. Create a spec with `- \`MATCHED_LABELS\` MUST be reused from \`lib/labels.js\``.
2. Make a change that modifies `lib/labels.js` in place (adds an element to the array) without putting the `MATCHED_LABELS` declaration token on a `+` line.
3. Run `reuse_audit_enforcement` validate against that context.
4. Expected: `result.ok === true`, zero `reuse_audit` failure records.

**P0.2 (config-file entry) — manual reproduction:**

1. Create a spec with `- \`my-hook\` MUST be reused from \`hooks.json\``.
2. Make a change that adds/modifies a block in `hooks.json` containing `my-hook`.
3. Run `reuse_audit_enforcement` validate.
4. Expected: `result.ok === true`, zero `reuse_audit` failure records.

**Negative control (anti-gaming) — manual reproduction:**

1. Create a spec with `- \`MATCHED_LABELS\` MUST be reused from \`lib/labels.js\``.
2. Make a change that modifies only an unrelated file; `lib/labels.js` is NOT in the changed set.
3. Run `reuse_audit_enforcement` validate.
4. Expected: `result.ok === false`; failure record present; `observed` contains "unmodified file".

### Test Results

Run: `node --test __tests__/reuse-audit-enforcement.test.js __tests__/shared-readers.test.js`
Result: 59 tests pass, 0 failures, exit 0.

## QA / Artifact Summary

| Check | Status | Notes |
|-------|--------|-------|
| Lint + typecheck (`dev:check`) | PASS | 0 errors; 2 warnings (test files in eslint ignore pattern — expected) |
| Unit tests (`node --test`, 59 tests) | PASS | reuse-audit-enforcement.test.js + shared-readers.test.js, exit 0 |
| Requirements verification | COMPLETE | All 7 requirements (R1–R7) delivered with cited code evidence |
| Code review | APPROVED | Round-2 review fixes applied — `mustReuse` is now derived from the verb capture group (was the whole matched bullet, which mis-hardened a `may be reused` entry whenever its symbol or path contained "must"); the P0.1 in-place-extension branch is now covered under real git (positive + anti-gaming negative control), not only via the legacy blob proxy; and config-path entries — including extensionless paths (Dockerfile/Makefile/CODEOWNERS) — are evaluated SOLELY against their own declared file so the config symbol text in an unrelated changed file can no longer leak a false pass (Greptile P1) |
| Screenshots | n/a | Backend/CLI change — no UI |



