### PR TITLE
feat(work-cleanup): add completion_check phase to block cleanup without COMPLETE evidence (GH-283)

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/enforce-step-workflow.test.js
@@ -4602,17 +4602,28 @@ describe('enforce-step-workflow', () => {
 
     it('allows transition when no tmux session exists in test environment', async () => {
       writeWorkState(makeStepStatus('cleanup', WORK_STEPS));
-      // No evidence — cleanup verify checks for tmux session absence
-      // Without mock tmux, the verify function will likely return true (no session exists)
-      // so we just verify the evidence path works
+      // No step evidence — cleanup relies on verifyCleanup instead.
+      // GH-283 R8 strengthened verifyCleanup: tmux-absence alone is no longer
+      // sufficient; the completion_check phase must have written
+      // `completion.check.md` carrying the canonical `**Status:** COMPLETE`
+      // line. Provide that marker so verify passes on tmux-absence.
+      fs.writeFileSync(
+        path.join(TASKS_DIR, 'completion.check.md'),
+        '# Completion Check\n\n**Status:** COMPLETE\n'
+      );
 
       const { code } = await runHook({
         tool_name: 'Bash',
         tool_input: { command: `node ${ORCHESTRATOR_PATH} transition ${TEST_TICKET} reports` },
       });
-      // The cleanup verify function checks for tmux session absence.
-      // In test environment, no tmux session exists for this ticket, so verify passes.
-      assert.equal(code, 0, 'Should pass via verify — no tmux session exists in test environment');
+      // verifyCleanup requires BOTH tmux-session absence AND completion
+      // evidence. In the test environment no tmux session exists for this
+      // ticket and the completion marker is present, so verify passes.
+      assert.equal(
+        code,
+        0,
+        'Should pass via verify — no tmux session + completion evidence present'
+      );
     });
   });
 

--- a/plugins/work/scripts/workflows/lib/scripts/write-report.js
+++ b/plugins/work/scripts/workflows/lib/scripts/write-report.js
@@ -184,18 +184,13 @@ function requireVerifiedToken(name, allowedAgents) {
     process.exit(2);
   }
 
-  // Check token freshness — prevents replay with pre-placed token files
-  // Reject expired AND future timestamps (clock skew / tampered tokens)
-  const age = Date.now() - token.timestamp;
-  if (age < 0 || age > TOKEN_MAX_AGE_MS) {
-    process.stderr.write(
-      `[${name}] BLOCKED: Write token expired (${age}ms old, max ${TOKEN_MAX_AGE_MS}ms).\n` +
-        `  Token was issued at ${new Date(token.timestamp).toISOString()}\n`
-    );
-    process.exit(2);
-  }
-
-  // Check agent in token matches allowedAgents
+  // Check agent in token matches allowedAgents FIRST. Authorization is an
+  // identity property of the token, independent of its age, so an unauthorized
+  // agent must be rejected as "not authorized" regardless of how old the token
+  // is. Checking agent before freshness also makes the outcome deterministic
+  // (a wrong-agent token can never be misreported as merely "expired" when
+  // spawn latency pushes it past the TTL). Both branches exit 2, so this does
+  // not weaken any gate.
   const agentMatch = allowedAgents.some(
     (a) => normalizeAgentName(a) === normalizeAgentName(token.agent)
   );
@@ -204,6 +199,17 @@ function requireVerifiedToken(name, allowedAgents) {
       `[${name}] BLOCKED: Token agent "${token.agent}" is not authorized.\n` +
         `  Allowed agents: ${allowedAgents.join(', ')}\n` +
         `  Only these agents can use this writer.\n`
+    );
+    process.exit(2);
+  }
+
+  // Check token freshness — prevents replay with pre-placed token files
+  // Reject expired AND future timestamps (clock skew / tampered tokens)
+  const age = Date.now() - token.timestamp;
+  if (age < 0 || age > TOKEN_MAX_AGE_MS) {
+    process.stderr.write(
+      `[${name}] BLOCKED: Write token expired (${age}ms old, max ${TOKEN_MAX_AGE_MS}ms).\n` +
+        `  Token was issued at ${new Date(token.timestamp).toISOString()}\n`
     );
     process.exit(2);
   }

--- a/plugins/work/scripts/workflows/work-cleanup/__tests__/cleanup-phase-registry.test.js
+++ b/plugins/work/scripts/workflows/work-cleanup/__tests__/cleanup-phase-registry.test.js
@@ -14,16 +14,22 @@ const {
   isCleanupPhase,
 } = require('../cleanup-phase-registry');
 
-test('CLEANUP_PHASE_ORDER lists 7 phases in declared order', () => {
+test('CLEANUP_PHASE_ORDER lists 8 phases in declared order', () => {
   assert.deepEqual(CLEANUP_PHASE_ORDER, [
     'inputs',
     'pr_merged_check',
+    'completion_check',
     'branch_cleanup',
     'tmux_cleanup',
     'state_archive',
     'memorize',
     'done',
   ]);
+});
+
+test('completion_check sits between pr_merged_check and branch_cleanup', () => {
+  assert.deepEqual(cleanupNextPhases('pr_merged_check'), ['completion_check']);
+  assert.deepEqual(cleanupNextPhases('completion_check'), ['branch_cleanup']);
 });
 
 test('initial is inputs, terminal is done', () => {

--- a/plugins/work/scripts/workflows/work-cleanup/__tests__/phases.test.js
+++ b/plugins/work/scripts/workflows/work-cleanup/__tests__/phases.test.js
@@ -113,7 +113,7 @@ test('branch_cleanup fails closed when completion.check.md is NEEDS_WORK (sentin
 
 test('tmux_cleanup auto-passes when no sessions match ticket', () => {
   const original = tmux_cleanup.listSessionsMatching;
-  const { root, tasksDir } = makeTasksDir();
+  const { root, tasksDir } = makeTasksDir({ 'completion.check.md': '**Status:** COMPLETE\n' });
   tmux_cleanup.listSessionsMatching = () => [];
   try {
     const r = tmux_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
@@ -127,7 +127,7 @@ test('tmux_cleanup auto-passes when no sessions match ticket', () => {
 
 test('tmux_cleanup blocks when matching sessions exist without sentinel', () => {
   const original = tmux_cleanup.listSessionsMatching;
-  const { root, tasksDir } = makeTasksDir();
+  const { root, tasksDir } = makeTasksDir({ 'completion.check.md': '**Status:** COMPLETE\n' });
   tmux_cleanup.listSessionsMatching = () => ['ECHO-7777-dev', 'ECHO-7777-listen'];
   try {
     const r = tmux_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
@@ -141,6 +141,7 @@ test('tmux_cleanup blocks when matching sessions exist without sentinel', () => 
 
 test('state_archive blocks on missing required sections', () => {
   const { root, tasksDir } = makeTasksDir({
+    'completion.check.md': '**Status:** COMPLETE\n',
     'cleanup-summary.md': '## Branch\nx\nStatus: DONE\n',
   });
   const r = state_archive.validate({ tasksDir });
@@ -160,9 +161,71 @@ test('state_archive passes when all sections + Status present', () => {
     '',
     'Status: PARTIAL',
   ].join('\n');
-  const { root, tasksDir } = makeTasksDir({ 'cleanup-summary.md': md });
+  const { root, tasksDir } = makeTasksDir({
+    'completion.check.md': '**Status:** COMPLETE\n',
+    'cleanup-summary.md': md,
+  });
   const r = state_archive.validate({ tasksDir });
   assert.equal(r.ok, true);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+// Resume-past-gate (GH-283): persisted cleanup state saved at a phase LATER
+// than branch_cleanup under the old (no completion_check) order resumes
+// straight into that destructive phase, skipping completion_check entirely.
+// Every post-gate destructive phase must re-assert completion evidence and
+// fail closed when it is absent or non-COMPLETE — mirroring the branch_cleanup
+// resume-skip guard so the persisted-state bypass is closed everywhere.
+test('tmux_cleanup fails closed when completion.check.md is ABSENT (resume past gate)', () => {
+  const original = tmux_cleanup.listSessionsMatching;
+  const { root, tasksDir } = makeTasksDir();
+  // Even on the no-matching-sessions auto-pass path, the completion gate must
+  // block first so a stale-state resume cannot finalize tmux teardown.
+  tmux_cleanup.listSessionsMatching = () => [];
+  try {
+    const r = tmux_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors[0].includes('completion.check.md'));
+    assert.ok(r.errors[0].includes('**Status:** COMPLETE'));
+    assert.ok(r.errors[0].includes('re-run the check step'));
+  } finally {
+    tmux_cleanup.listSessionsMatching = original;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('tmux_cleanup fails closed when completion.check.md is NEEDS_WORK (resume past gate)', () => {
+  const original = tmux_cleanup.listSessionsMatching;
+  const { root, tasksDir } = makeTasksDir({ 'completion.check.md': '**Status:** NEEDS_WORK\n' });
+  tmux_cleanup.listSessionsMatching = () => ['ECHO-7777-dev'];
+  try {
+    const r = tmux_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors[0].includes('completion.check.md'));
+  } finally {
+    tmux_cleanup.listSessionsMatching = original;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('state_archive fails closed when completion.check.md is ABSENT (resume past gate)', () => {
+  // A fully-populated cleanup-summary.md would otherwise pass; the completion
+  // gate must still block a stale-state resume that skipped completion_check.
+  const md = [
+    '## Branch',
+    'deleted feature/x',
+    '## Tmux sessions',
+    'killed ECHO-7777-dev',
+    '## Worktree',
+    'removed',
+    '',
+    'Status: DONE',
+  ].join('\n');
+  const { root, tasksDir } = makeTasksDir({ 'cleanup-summary.md': md });
+  const r = state_archive.validate({ tasksDir });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('completion.check.md'));
+  assert.ok(r.errors[0].includes('**Status:** COMPLETE'));
   fs.rmSync(root, { recursive: true, force: true });
 });
 

--- a/plugins/work/scripts/workflows/work-cleanup/__tests__/phases.test.js
+++ b/plugins/work/scripts/workflows/work-cleanup/__tests__/phases.test.js
@@ -6,6 +6,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+const { isCompletionComplete } = require('../lib/completion-evidence');
 const pr_merged_check = require('../lib/phases/pr_merged_check');
 const branch_cleanup = require('../lib/phases/branch_cleanup');
 const tmux_cleanup = require('../lib/phases/tmux_cleanup');
@@ -60,9 +61,10 @@ test('pr_merged_check HARD-BLOCKS when state=OPEN (not WAITs)', () => {
   }
 });
 
-test('branch_cleanup blocks without sentinel', () => {
+test('branch_cleanup blocks without sentinel (completion evidence present)', () => {
   const { root, tasksDir } = makeTasksDir({
     'cleanup-context.json': JSON.stringify({ branch: 'feature/x' }),
+    'completion.check.md': '**Status:** COMPLETE\n',
   });
   const r = branch_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
   assert.equal(r.ok, false);
@@ -70,13 +72,42 @@ test('branch_cleanup blocks without sentinel', () => {
   fs.rmSync(root, { recursive: true, force: true });
 });
 
-test('branch_cleanup passes with sentinel present', () => {
+test('branch_cleanup passes with sentinel present AND completion evidence', () => {
+  const { root, tasksDir } = makeTasksDir({
+    'cleanup-context.json': JSON.stringify({ branch: 'feature/x' }),
+    'completion.check.md': '**Status:** COMPLETE\n',
+    '.branch-cleaned': 'ok',
+  });
+  const r = branch_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, true);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+// Resume-skip case: persisted state from the old (no completion_check) flow
+// resumes straight at branch_cleanup with the .branch-cleaned sentinel already
+// present. The completion gate must still fail closed BEFORE the sentinel check.
+test('branch_cleanup fails closed when completion.check.md is ABSENT even if sentinel exists', () => {
   const { root, tasksDir } = makeTasksDir({
     'cleanup-context.json': JSON.stringify({ branch: 'feature/x' }),
     '.branch-cleaned': 'ok',
   });
   const r = branch_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
-  assert.equal(r.ok, true);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('completion.check.md'));
+  assert.ok(r.errors[0].includes('**Status:** COMPLETE'));
+  assert.ok(r.errors[0].includes('re-run the check step'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('branch_cleanup fails closed when completion.check.md is NEEDS_WORK (sentinel present)', () => {
+  const { root, tasksDir } = makeTasksDir({
+    'cleanup-context.json': JSON.stringify({ branch: 'feature/x' }),
+    'completion.check.md': '**Status:** NEEDS_WORK\n',
+    '.branch-cleaned': 'ok',
+  });
+  const r = branch_cleanup.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('completion.check.md'));
   fs.rmSync(root, { recursive: true, force: true });
 });
 
@@ -190,5 +221,35 @@ test('completion_check passes when the canonical **Status:** COMPLETE line is pr
   const r = completion_check.validate({ tasksDir, ticket: 'ECHO-7777' });
   assert.equal(r.ok, true);
   assert.ok(r.summary.includes('**Status:** COMPLETE'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('isCompletionComplete returns true for **Status:** COMPLETE', () => {
+  const { root, tasksDir } = makeTasksDir({
+    'completion.check.md': 'preamble\n**Status:** COMPLETE\ntrailing\n',
+  });
+  assert.equal(isCompletionComplete(tasksDir), true);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('isCompletionComplete fails closed when completion.check.md is absent', () => {
+  const { root, tasksDir } = makeTasksDir();
+  assert.equal(isCompletionComplete(tasksDir), false);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('isCompletionComplete returns false for NEEDS_WORK', () => {
+  const { root, tasksDir } = makeTasksDir({
+    'completion.check.md': '**Status:** NEEDS_WORK\n',
+  });
+  assert.equal(isCompletionComplete(tasksDir), false);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('isCompletionComplete rejects the APPROVED alias', () => {
+  const { root, tasksDir } = makeTasksDir({
+    'completion.check.md': '**Status:** APPROVED\n',
+  });
+  assert.equal(isCompletionComplete(tasksDir), false);
   fs.rmSync(root, { recursive: true, force: true });
 });

--- a/plugins/work/scripts/workflows/work-cleanup/__tests__/phases.test.js
+++ b/plugins/work/scripts/workflows/work-cleanup/__tests__/phases.test.js
@@ -134,3 +134,61 @@ test('state_archive passes when all sections + Status present', () => {
   assert.equal(r.ok, true);
   fs.rmSync(root, { recursive: true, force: true });
 });
+
+// Resolve the not-yet-authored module through a try/catch so an absent module
+// surfaces as a per-test assertion failure (a behavior gap: "module not
+// authored yet") rather than a load-time crash whose raw "Cannot find module"
+// string the RED recorder treats as a structurally broken test.
+function loadCompletionCheck() {
+  let mod = null;
+  try {
+    mod = require('../lib/phases/completion_check');
+  } catch {
+    mod = null;
+  }
+  assert.ok(mod, 'completion_check module is authored and exports validate');
+  return mod;
+}
+
+test('completion_check hard-blocks when completion.check.md is absent', () => {
+  const completion_check = loadCompletionCheck();
+  const { root, tasksDir } = makeTasksDir();
+  const r = completion_check.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('completion.check.md'));
+  assert.ok(r.errors[0].includes('re-run the check step'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('completion_check hard-blocks when status line is NEEDS_WORK', () => {
+  const completion_check = loadCompletionCheck();
+  const { root, tasksDir } = makeTasksDir({
+    'completion.check.md': '**Status:** NEEDS_WORK\n',
+  });
+  const r = completion_check.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('**Status:** COMPLETE'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('completion_check hard-blocks when status line is the APPROVED alias', () => {
+  const completion_check = loadCompletionCheck();
+  const { root, tasksDir } = makeTasksDir({
+    'completion.check.md': '**Status:** APPROVED\n',
+  });
+  const r = completion_check.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('**Status:** COMPLETE'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('completion_check passes when the canonical **Status:** COMPLETE line is present', () => {
+  const completion_check = loadCompletionCheck();
+  const { root, tasksDir } = makeTasksDir({
+    'completion.check.md': '**Status:** COMPLETE\n',
+  });
+  const r = completion_check.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, true);
+  assert.ok(r.summary.includes('**Status:** COMPLETE'));
+  fs.rmSync(root, { recursive: true, force: true });
+});

--- a/plugins/work/scripts/workflows/work-cleanup/__tests__/phases.test.js
+++ b/plugins/work/scripts/workflows/work-cleanup/__tests__/phases.test.js
@@ -11,6 +11,8 @@ const pr_merged_check = require('../lib/phases/pr_merged_check');
 const branch_cleanup = require('../lib/phases/branch_cleanup');
 const tmux_cleanup = require('../lib/phases/tmux_cleanup');
 const state_archive = require('../lib/phases/state_archive');
+const memorize = require('../lib/phases/memorize');
+const done = require('../lib/phases/done');
 
 function makeTasksDir(files = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-phases-'));
@@ -226,6 +228,69 @@ test('state_archive fails closed when completion.check.md is ABSENT (resume past
   assert.equal(r.ok, false);
   assert.ok(r.errors[0].includes('completion.check.md'));
   assert.ok(r.errors[0].includes('**Status:** COMPLETE'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+// Resume-past-gate must extend to EVERY phase after completion_check —
+// memorize and done included. A rogue saved state pointing at memorize/done
+// under the old (no completion_check) order resumes straight into the tail of
+// the pipeline; each phase re-asserts completion evidence and fails closed.
+test('memorize fails closed when completion.check.md is ABSENT even if sentinel exists (resume past gate)', () => {
+  const { root, tasksDir } = makeTasksDir();
+  // Old-flow resume: the memorized sentinel is already present, so only the
+  // completion gate stands between a rogue state and a finalized cleanup.
+  fs.writeFileSync(path.join(tasksDir, '.cleanup-memorized'), 'ok');
+  const r = memorize.validate({
+    tasksDir,
+    ticket: 'ECHO-7777',
+    memory: { name: 'cortex', rememberTool: 'remember' },
+  });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('completion.check.md'));
+  assert.ok(r.errors[0].includes('**Status:** COMPLETE'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('memorize fails closed with NO memory plugin when evidence is absent (resume past gate)', () => {
+  const { root, tasksDir } = makeTasksDir();
+  // No memory plugin would normally auto-pass; the completion gate must block
+  // first so a rogue resume cannot finalize memorize without evidence.
+  const r = memorize.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('completion.check.md'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('memorize passes (no memory plugin) when completion evidence is present', () => {
+  const { root, tasksDir } = makeTasksDir({ 'completion.check.md': '**Status:** COMPLETE\n' });
+  const r = memorize.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, true);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('done fails closed when completion.check.md is ABSENT (rogue resume-at-done)', () => {
+  const { root, tasksDir } = makeTasksDir();
+  const r = done.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('completion.check.md'));
+  assert.ok(r.errors[0].includes('**Status:** COMPLETE'));
+  assert.ok(r.errors[0].includes('re-run the check step'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('done fails closed when completion.check.md is NEEDS_WORK (rogue resume-at-done)', () => {
+  const { root, tasksDir } = makeTasksDir({ 'completion.check.md': '**Status:** NEEDS_WORK\n' });
+  const r = done.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors[0].includes('completion.check.md'));
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('done passes when completion evidence is present', () => {
+  const { root, tasksDir } = makeTasksDir({ 'completion.check.md': '**Status:** COMPLETE\n' });
+  const r = done.validate({ tasksDir, ticket: 'ECHO-7777' });
+  assert.equal(r.ok, true);
+  assert.ok(r.summary.includes('terminal'));
   fs.rmSync(root, { recursive: true, force: true });
 });
 

--- a/plugins/work/scripts/workflows/work-cleanup/cleanup-phase-registry.js
+++ b/plugins/work/scripts/workflows/work-cleanup/cleanup-phase-registry.js
@@ -18,6 +18,7 @@
 const CLEANUP_PHASES = Object.freeze({
   inputs: 'inputs',
   pr_merged_check: 'pr_merged_check',
+  completion_check: 'completion_check',
   branch_cleanup: 'branch_cleanup',
   tmux_cleanup: 'tmux_cleanup',
   state_archive: 'state_archive',
@@ -28,6 +29,7 @@ const CLEANUP_PHASES = Object.freeze({
 const CLEANUP_PHASE_ORDER = Object.freeze([
   CLEANUP_PHASES.inputs,
   CLEANUP_PHASES.pr_merged_check,
+  CLEANUP_PHASES.completion_check,
   CLEANUP_PHASES.branch_cleanup,
   CLEANUP_PHASES.tmux_cleanup,
   CLEANUP_PHASES.state_archive,
@@ -37,7 +39,8 @@ const CLEANUP_PHASE_ORDER = Object.freeze([
 
 const CLEANUP_PHASE_TRANSITIONS = Object.freeze({
   [CLEANUP_PHASES.inputs]: Object.freeze([CLEANUP_PHASES.pr_merged_check]),
-  [CLEANUP_PHASES.pr_merged_check]: Object.freeze([CLEANUP_PHASES.branch_cleanup]),
+  [CLEANUP_PHASES.pr_merged_check]: Object.freeze([CLEANUP_PHASES.completion_check]),
+  [CLEANUP_PHASES.completion_check]: Object.freeze([CLEANUP_PHASES.branch_cleanup]),
   [CLEANUP_PHASES.branch_cleanup]: Object.freeze([CLEANUP_PHASES.tmux_cleanup]),
   [CLEANUP_PHASES.tmux_cleanup]: Object.freeze([CLEANUP_PHASES.state_archive]),
   [CLEANUP_PHASES.state_archive]: Object.freeze([CLEANUP_PHASES.memorize]),

--- a/plugins/work/scripts/workflows/work-cleanup/cleanup-phase-registry.js
+++ b/plugins/work/scripts/workflows/work-cleanup/cleanup-phase-registry.js
@@ -3,14 +3,18 @@
  *
  * Phases for the WORK orchestrator's `cleanup` step.
  *
- * Phases (linear):
- *   inputs → pr_merged_check → branch_cleanup → tmux_cleanup →
- *   state_archive → memorize → done
+ * Phases (linear, 8):
+ *   inputs → pr_merged_check → completion_check → branch_cleanup →
+ *   tmux_cleanup → state_archive → memorize → done
  *
  * `pr_merged_check` is a defensive duplicate of ci-step's wait_merge —
  * cleanup must NEVER run on a branch whose PR isn't merged. It blocks
  * (not WAITs) if the PR is OPEN/CLOSED since the workflow shouldn't have
  * reached cleanup at all in those states.
+ *
+ * `completion_check` is a hard block guarding branch cleanup: it refuses to
+ * advance unless `completion.check.md` reads `**Status:** COMPLETE`, so a
+ * destructive branch delete can never run on an incomplete workflow.
  */
 
 'use strict';

--- a/plugins/work/scripts/workflows/work-cleanup/lib/completion-evidence.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/completion-evidence.js
@@ -1,0 +1,49 @@
+/**
+ * completion-evidence.js — shared completion-gate marker test.
+ *
+ * Cleanup is destructive (branch/worktree/tmux teardown), so every phase that
+ * gates on completion evidence must agree on ONE canonical, fail-closed test.
+ *
+ * `isCompletionComplete(tasksDir)` returns true IFF `<tasksDir>/completion.check.md`
+ * exists, is readable, and contains the canonical machine-readable line
+ * `**Status:** COMPLETE`. It fails CLOSED (returns false) on a missing,
+ * unreadable, or unresolvable path, or a present-but-wrong/absent status line.
+ *
+ * The STATUS_COMPLETE_RE is the single source of truth for the marker: it is
+ * intentionally STRICT — the alias-resolving `validateCheckReportStatus` would
+ * accept `APPROVED` / `NOT_APPLICABLE`, but destructive cleanup requires the
+ * exact `**Status:** COMPLETE` marker.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const CHECK_FILE = 'completion.check.md';
+
+// Strict, canonical-only status matcher. Intentionally rejects the `APPROVED`
+// and `NOT_APPLICABLE` aliases that `validateCheckReportStatus` would accept.
+const STATUS_COMPLETE_RE = /^\s*\*\*Status:\*\*\s*COMPLETE\b/im;
+
+/**
+ * @param {string} tasksDir absolute path to the ticket's tasks dir
+ * @returns {boolean} true iff completion.check.md reads `**Status:** COMPLETE`
+ */
+function isCompletionComplete(tasksDir) {
+  let checkPath;
+  try {
+    checkPath = path.join(tasksDir, CHECK_FILE);
+  } catch {
+    return false;
+  }
+  let contents;
+  try {
+    contents = fs.readFileSync(checkPath, 'utf8');
+  } catch {
+    return false;
+  }
+  return STATUS_COMPLETE_RE.test(contents);
+}
+
+module.exports = { isCompletionComplete, STATUS_COMPLETE_RE, CHECK_FILE };

--- a/plugins/work/scripts/workflows/work-cleanup/lib/completion-evidence.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/completion-evidence.js
@@ -46,4 +46,39 @@ function isCompletionComplete(tasksDir) {
   return STATUS_COMPLETE_RE.test(contents);
 }
 
-module.exports = { isCompletionComplete, STATUS_COMPLETE_RE, CHECK_FILE };
+/**
+ * Shared fail-closed guard for the destructive cleanup phases (GH-283).
+ *
+ * `completion_check` only protects runs that reach it via the FORWARD phase
+ * order. A ticket whose persisted cleanup state was saved at `branch_cleanup`
+ * or a LATER phase under the old (pre-`completion_check`) order resumes straight
+ * at that saved phase and never re-enters `completion_check` — so every
+ * destructive phase at/after the gate re-asserts completion evidence on entry,
+ * closing the "persisted state skips the gate" bypass. This is the "re-validate
+ * saved state" repair the gate demands, applied per phase rather than by
+ * migrating the persisted phase pointer.
+ *
+ * Returns a phase BLOCK object (`{ ok:false, errors }`) when evidence is absent
+ * (fail closed), or `null` when `**Status:** COMPLETE` is present so the caller
+ * proceeds with its own checks.
+ *
+ * @param {string} tasksDir absolute path to the ticket's tasks dir
+ * @param {string} phaseLabel calling phase name, surfaced in the block message
+ * @returns {{ ok: false, errors: string[] }|null}
+ */
+function completionGateBlock(tasksDir, phaseLabel) {
+  if (isCompletionComplete(tasksDir)) return null;
+  return {
+    ok: false,
+    errors: [
+      'Cannot verify ticket completion: completion.check.md does not read ' +
+        `**Status:** COMPLETE. ${phaseLabel} refuses destructive cleanup without ` +
+        'completion evidence — persisted cleanup state resumed past the ' +
+        'completion_check gate (e.g. state saved under the old phase order). ' +
+        'Repair: re-run the check step until it reports **Status:** COMPLETE, ' +
+        'or restore the archived report, then re-run cleanup.',
+    ],
+  };
+}
+
+module.exports = { isCompletionComplete, completionGateBlock, STATUS_COMPLETE_RE, CHECK_FILE };

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phase-registry.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phase-registry.js
@@ -10,6 +10,7 @@ const { registerPhase, getPhase, hasPhase } = makePhaseRegistry('cleanup');
 
 require('./phases/inputs')(registerPhase);
 require('./phases/pr_merged_check')(registerPhase);
+require('./phases/completion_check')(registerPhase);
 require('./phases/branch_cleanup')(registerPhase);
 require('./phases/tmux_cleanup')(registerPhase);
 require('./phases/state_archive')(registerPhase);

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/branch_cleanup.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/branch_cleanup.js
@@ -13,6 +13,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+const { isCompletionComplete } = require('../completion-evidence');
 
 const SENTINEL = '.branch-cleaned';
 
@@ -25,6 +26,26 @@ function readContext(tasksDir) {
 }
 
 function validate(ctx) {
+  // Fail CLOSED before the destructive-command sentinel check: a ticket whose
+  // persisted cleanup state resumes at (or past) branch_cleanup — e.g. state
+  // saved by the old flow that had no completion_check phase — must NOT reach
+  // the branch-delete instructions without completion evidence. In the normal
+  // forward flow completion_check already passed immediately before this phase,
+  // so this guard is a no-op; it only bites a resumed old-state ticket or a
+  // tampered/clobbered report.
+  if (!isCompletionComplete(ctx.tasksDir)) {
+    return {
+      ok: false,
+      errors: [
+        'Cannot verify ticket completion: completion.check.md does not read ' +
+          '**Status:** COMPLETE. branch_cleanup refuses destructive branch delete ' +
+          'without completion evidence. ' +
+          'Repair: re-run the check step until it reports **Status:** COMPLETE, ' +
+          'or restore the archived report, then re-run cleanup.',
+      ],
+    };
+  }
+
   const p = path.join(ctx.tasksDir, SENTINEL);
   if (!fs.existsSync(p)) {
     return {
@@ -43,6 +64,11 @@ function instructions(ctx) {
   return [
     '# cleanup-next — Phase 4 of 8: BRANCH CLEANUP',
     `Ticket: ${ctx.ticket}`,
+    '',
+    'Completion gate: this phase fails closed unless completion.check.md reads ' +
+      '**Status:** COMPLETE. If it blocks, re-run the check step (or restore the ' +
+      'archived report) before retrying — the destructive commands below are ' +
+      'withheld until completion evidence is present.',
     '',
     'Run the following from the worktree root, then `touch` the sentinel:',
     '',

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/branch_cleanup.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/branch_cleanup.js
@@ -41,7 +41,7 @@ function instructions(ctx) {
   const c = readContext(ctx.tasksDir);
   const branch = c && c.branch ? c.branch : '<your-branch>';
   return [
-    '# cleanup-next — Phase 3 of 7: BRANCH CLEANUP',
+    '# cleanup-next — Phase 4 of 8: BRANCH CLEANUP',
     `Ticket: ${ctx.ticket}`,
     '',
     'Run the following from the worktree root, then `touch` the sentinel:',

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/branch_cleanup.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/branch_cleanup.js
@@ -13,7 +13,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
-const { isCompletionComplete } = require('../completion-evidence');
+const { completionGateBlock } = require('../completion-evidence');
 
 const SENTINEL = '.branch-cleaned';
 
@@ -32,19 +32,10 @@ function validate(ctx) {
   // the branch-delete instructions without completion evidence. In the normal
   // forward flow completion_check already passed immediately before this phase,
   // so this guard is a no-op; it only bites a resumed old-state ticket or a
-  // tampered/clobbered report.
-  if (!isCompletionComplete(ctx.tasksDir)) {
-    return {
-      ok: false,
-      errors: [
-        'Cannot verify ticket completion: completion.check.md does not read ' +
-          '**Status:** COMPLETE. branch_cleanup refuses destructive branch delete ' +
-          'without completion evidence. ' +
-          'Repair: re-run the check step until it reports **Status:** COMPLETE, ' +
-          'or restore the archived report, then re-run cleanup.',
-      ],
-    };
-  }
+  // tampered/clobbered report. Shared with the other post-gate destructive
+  // phases via completionGateBlock (GH-283).
+  const gate = completionGateBlock(ctx.tasksDir, 'branch_cleanup');
+  if (gate) return gate;
 
   const p = path.join(ctx.tasksDir, SENTINEL);
   if (!fs.existsSync(p)) {

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/completion_check.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/completion_check.js
@@ -1,0 +1,90 @@
+/**
+ * Phase: completion_check — defensive duplicate of the check step's completion gate.
+ *
+ * Hard-blocks (NOT WAITs) unless `<tasksDir>/completion.check.md` exists AND
+ * contains the canonical machine-readable line `**Status:** COMPLETE`. Cleanup
+ * is destructive (branch/worktree/tmux teardown), so we fail CLOSED on a missing
+ * file, an unreadable file, or a present-but-wrong/absent status line.
+ *
+ * Uses a dedicated STRICT regex — NOT the alias-resolving
+ * `validateCheckReportStatus` — so `APPROVED` / `NOT_APPLICABLE` are rejected.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+
+const CHECK_FILE = 'completion.check.md';
+
+// Strict, canonical-only status matcher. Intentionally rejects the `APPROVED`
+// and `NOT_APPLICABLE` aliases that `validateCheckReportStatus` would accept —
+// destructive cleanup requires the exact `**Status:** COMPLETE` marker.
+const STATUS_COMPLETE_RE = /^\s*\*\*Status:\*\*\s*COMPLETE\b/im;
+
+function validate(ctx) {
+  const checkPath = path.join(ctx.tasksDir, CHECK_FILE);
+
+  if (!fs.existsSync(checkPath)) {
+    return {
+      ok: false,
+      errors: [
+        `Cannot verify ticket completion: ${CHECK_FILE} is missing from the tasks dir. ` +
+          'Cleanup refuses destructive teardown without completion evidence. ' +
+          'Repair: re-run the check step to regenerate the report, or restore the archived report.',
+      ],
+    };
+  }
+
+  let contents;
+  try {
+    contents = fs.readFileSync(checkPath, 'utf8');
+  } catch {
+    return {
+      ok: false,
+      errors: [
+        `Cannot read ${CHECK_FILE}. Cleanup fails closed on an unreadable completion report. ` +
+          'Repair: re-run the check step to regenerate the report, or restore the archived report.',
+      ],
+    };
+  }
+
+  if (!STATUS_COMPLETE_RE.test(contents)) {
+    return {
+      ok: false,
+      errors: [
+        `${CHECK_FILE} is missing the canonical **Status:** COMPLETE line ` +
+          '(aliases such as APPROVED / NOT_APPLICABLE are not accepted). ' +
+          'Repair: re-run the check step until it reports **Status:** COMPLETE, ' +
+          'or restore the archived report.',
+      ],
+    };
+  }
+
+  return { ok: true, summary: `${CHECK_FILE} verified: **Status:** COMPLETE` };
+}
+
+function instructions(ctx) {
+  return [
+    '# cleanup-next — Phase 3 of 8: COMPLETION CHECK',
+    `Ticket: ${ctx.ticket}`,
+    '',
+    'Defensive double-check: cleanup must only run on a COMPLETE ticket. If this ' +
+      'blocks, your check step did not finalize completion.check.md — re-run it ' +
+      'or restore the archived report before retrying cleanup.',
+    '',
+  ].join('\n');
+}
+
+module.exports = function register(r) {
+  r(CLEANUP_PHASES.completion_check, {
+    next: CLEANUP_PHASES.branch_cleanup,
+    validate,
+    instructions,
+  });
+};
+
+module.exports.validate = validate;
+module.exports.instructions = instructions;

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/completion_check.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/completion_check.js
@@ -16,13 +16,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
-
-const CHECK_FILE = 'completion.check.md';
-
-// Strict, canonical-only status matcher. Intentionally rejects the `APPROVED`
-// and `NOT_APPLICABLE` aliases that `validateCheckReportStatus` would accept —
-// destructive cleanup requires the exact `**Status:** COMPLETE` marker.
-const STATUS_COMPLETE_RE = /^\s*\*\*Status:\*\*\s*COMPLETE\b/im;
+const { isCompletionComplete, CHECK_FILE } = require('../completion-evidence');
 
 function validate(ctx) {
   const checkPath = path.join(ctx.tasksDir, CHECK_FILE);
@@ -38,20 +32,10 @@ function validate(ctx) {
     };
   }
 
-  let contents;
-  try {
-    contents = fs.readFileSync(checkPath, 'utf8');
-  } catch {
-    return {
-      ok: false,
-      errors: [
-        `Cannot read ${CHECK_FILE}. Cleanup fails closed on an unreadable completion report. ` +
-          'Repair: re-run the check step to regenerate the report, or restore the archived report.',
-      ],
-    };
-  }
-
-  if (!STATUS_COMPLETE_RE.test(contents)) {
+  // The shared helper is the single source of truth for the marker test: it
+  // reads the file and applies the strict canonical-only regex, failing closed
+  // on an unreadable file or a present-but-wrong/absent status line.
+  if (!isCompletionComplete(ctx.tasksDir)) {
     return {
       ok: false,
       errors: [

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/done.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/done.js
@@ -5,8 +5,14 @@
 'use strict';
 
 const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+const { completionGateBlock } = require('../completion-evidence');
 
-function validate() {
+function validate(ctx) {
+  // GH-283: the terminal phase still fails closed if persisted cleanup state
+  // resumed past completion_check without completion evidence — a rogue saved
+  // state at `done` must not let cleanup finalize without **Status:** COMPLETE.
+  const gate = completionGateBlock(ctx && ctx.tasksDir, 'done');
+  if (gate) return gate;
   return { ok: true, summary: 'cleanup terminal phase' };
 }
 

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/done.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/done.js
@@ -12,7 +12,7 @@ function validate() {
 
 function instructions(ctx) {
   return [
-    '# cleanup-next — Phase 7 of 7: DONE',
+    '# cleanup-next — Phase 8 of 8: DONE',
     `Ticket: ${ctx.ticket}`,
     '',
     'Cleanup complete. Workflow can advance to reports.',

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/inputs.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/inputs.js
@@ -80,7 +80,7 @@ function validate(ctx) {
 
 function instructions(ctx) {
   return [
-    '# cleanup-next — Phase 1 of 7: INPUTS',
+    '# cleanup-next — Phase 1 of 8: INPUTS',
     `Ticket: ${ctx.ticket}`,
     '',
     'I record the current branch + PR number into `cleanup-context.json` for downstream phases.',

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/inputs.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/inputs.js
@@ -32,6 +32,23 @@ function detectPrNumber(cwd, branch) {
   }
 }
 
+// Build the blocking-error list for missing branch / PR context. Extracted
+// from validate() to keep that function under the cyclomatic-complexity gate.
+function resolveContextErrors(branch, prNumber) {
+  const errors = [];
+  if (!branch) {
+    errors.push(
+      'Could not resolve current git branch. Ensure you are inside a git worktree (`git rev-parse --abbrev-ref HEAD` must succeed).'
+    );
+  }
+  if (!prNumber) {
+    errors.push(
+      `Could not resolve PR number for branch \`${branch || '(unknown)'}\`. Either (a) create the PR first (\`gh pr create\`), (b) verify \`gh pr view ${branch || '<branch>'} --json number\` succeeds, or (c) abort cleanup — there's nothing to clean up for a branch with no PR.`
+    );
+  }
+  return errors;
+}
+
 function validate(ctx) {
   const root = ctx.worktreeRoot || process.cwd();
   const branch = currentBranch(root);
@@ -54,17 +71,7 @@ function validate(ctx) {
   // BLOCK (don't advance) when branch/prNumber are missing — downstream phases
   // can't recover, and the agent would hit a dead-end "re-run inputs" loop if
   // we advanced past this point with incomplete context.
-  const errors = [];
-  if (!branch) {
-    errors.push(
-      'Could not resolve current git branch. Ensure you are inside a git worktree (`git rev-parse --abbrev-ref HEAD` must succeed).'
-    );
-  }
-  if (!prNumber) {
-    errors.push(
-      `Could not resolve PR number for branch \`${branch || '(unknown)'}\`. Either (a) create the PR first (\`gh pr create\`), (b) verify \`gh pr view ${branch || '<branch>'} --json number\` succeeds, or (c) abort cleanup — there's nothing to clean up for a branch with no PR.`
-    );
-  }
+  const errors = resolveContextErrors(branch, prNumber);
   if (errors.length) {
     return {
       ok: false,

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/memorize.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/memorize.js
@@ -8,10 +8,17 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+const { completionGateBlock } = require('../completion-evidence');
 
 const SENTINEL = '.cleanup-memorized';
 
 function validate(ctx) {
+  // GH-283: fail closed if persisted cleanup state resumed past completion_check
+  // without completion evidence — memorize must not finalize cleanup on an
+  // unproven-complete ticket, even when no memory plugin is configured.
+  const gate = completionGateBlock(ctx.tasksDir, 'memorize');
+  if (gate) return gate;
+
   if (!ctx.memory) return { ok: true, summary: 'no memory plugin detected — skipping' };
   const p = path.join(ctx.tasksDir, SENTINEL);
   if (!fs.existsSync(p)) {

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/memorize.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/memorize.js
@@ -28,14 +28,14 @@ function validate(ctx) {
 function instructions(ctx) {
   if (!ctx.memory) {
     return [
-      '# cleanup-next — Phase 6 of 7: MEMORIZE',
+      '# cleanup-next — Phase 7 of 8: MEMORIZE',
       '',
       'No memory plugin — auto-advance.',
       '',
     ].join('\n');
   }
   return [
-    '# cleanup-next — Phase 6 of 7: MEMORIZE',
+    '# cleanup-next — Phase 7 of 8: MEMORIZE',
     `Ticket: ${ctx.ticket}`,
     '',
     `Memory: **${ctx.memory.name}**`,

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/pr_merged_check.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/pr_merged_check.js
@@ -4,6 +4,9 @@
  * Hard-blocks (NOT WAITs) if PR is OPEN or CLOSED. The workflow shouldn't
  * reach cleanup at all in those states — if it did, something bypassed the
  * ci gate and we refuse to proceed with destructive cleanup actions.
+ *
+ * On success this phase advances to the `completion_check` gate (see the
+ * `next` edge in register()).
  */
 
 'use strict';
@@ -69,7 +72,7 @@ function validate(ctx) {
 
 function instructions(ctx) {
   return [
-    '# cleanup-next — Phase 2 of 7: PR MERGED CHECK',
+    '# cleanup-next — Phase 2 of 8: PR MERGED CHECK',
     `Ticket: ${ctx.ticket}`,
     '',
     'Defensive double-check: cleanup must only run on MERGED PRs. If this blocks, your ci step exited prematurely (likely missing wait_merge).',
@@ -79,7 +82,7 @@ function instructions(ctx) {
 
 module.exports = function register(r) {
   r(CLEANUP_PHASES.pr_merged_check, {
-    next: CLEANUP_PHASES.branch_cleanup,
+    next: CLEANUP_PHASES.completion_check,
     validate,
     instructions,
   });

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/state_archive.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/state_archive.js
@@ -52,7 +52,7 @@ function validate(ctx) {
 
 function instructions(ctx) {
   return [
-    '# cleanup-next — Phase 5 of 7: STATE ARCHIVE',
+    '# cleanup-next — Phase 6 of 8: STATE ARCHIVE',
     `Ticket: ${ctx.ticket}`,
     '',
     'Write `cleanup-summary.md` with:',

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/state_archive.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/state_archive.js
@@ -9,12 +9,19 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+const { completionGateBlock } = require('../completion-evidence');
 
 const SUMMARY_FILE = 'cleanup-summary.md';
 const REQUIRED_SECTIONS = [/^##\s+Branch\b/im, /^##\s+Tmux sessions\b/im, /^##\s+Worktree\b/im];
 const STATUS_RE = /^Status:\s*(DONE|PARTIAL)\b/im;
 
 function validate(ctx) {
+  // GH-283: fail closed if persisted cleanup state resumed past completion_check
+  // without completion evidence — archiving/teardown must not finalize on an
+  // unproven-complete ticket.
+  const gate = completionGateBlock(ctx.tasksDir, 'state_archive');
+  if (gate) return gate;
+
   const p = path.join(ctx.tasksDir, SUMMARY_FILE);
   if (!fs.existsSync(p)) {
     return {

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/tmux_cleanup.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/tmux_cleanup.js
@@ -11,6 +11,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const { CLEANUP_PHASES } = require('../../cleanup-phase-registry');
+const { completionGateBlock } = require('../completion-evidence');
 
 const SENTINEL = '.tmux-cleaned';
 
@@ -28,6 +29,13 @@ function listSessionsMatching(ticketId) {
 }
 
 function validate(ctx) {
+  // GH-283: fail closed if persisted cleanup state resumed past completion_check
+  // (e.g. saved under the old phase order) without completion evidence — killing
+  // the dev tmux session is destructive teardown that must not run on an
+  // unproven-complete ticket.
+  const gate = completionGateBlock(ctx.tasksDir, 'tmux_cleanup');
+  if (gate) return gate;
+
   const p = path.join(ctx.tasksDir, SENTINEL);
   // Indirect via module.exports so tests can monkey-patch listSessionsMatching.
   const sessions = module.exports.listSessionsMatching(ctx.ticket);

--- a/plugins/work/scripts/workflows/work-cleanup/lib/phases/tmux_cleanup.js
+++ b/plugins/work/scripts/workflows/work-cleanup/lib/phases/tmux_cleanup.js
@@ -55,7 +55,7 @@ function instructions(ctx) {
   const sessions = listSessionsMatching(ctx.ticket);
   const killCmds = sessions.map((s) => `tmux kill-session -t ${JSON.stringify(s)}`).join('\n');
   return [
-    '# cleanup-next — Phase 4 of 7: TMUX CLEANUP',
+    '# cleanup-next — Phase 5 of 8: TMUX CLEANUP',
     `Ticket: ${ctx.ticket}`,
     '',
     sessions.length

--- a/plugins/work/scripts/workflows/work/workflow-def/__tests__/step-verifiers.integration.test.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/__tests__/step-verifiers.integration.test.js
@@ -1,0 +1,90 @@
+/**
+ * step-verifiers.integration.test.js — GH-283 Task 6 (R8)
+ *
+ * verifyCleanup must return `true` only when BOTH the tmux dev session is
+ * gone AND `<tasksDir>/completion.check.md` exists with the canonical
+ * `**Status:** COMPLETE` line. A runner bypass that skips the completion_check
+ * phase (so no COMPLETE marker is written) must still fail step verification.
+ *
+ * We reach the "tmux session gone" state naturally by using a random,
+ * never-created ticket id: `tmux has-session -t <id>-dev` exits non-zero,
+ * which the verifier reads as "cleaned up". The completion-evidence assertion
+ * is then the only thing that can flip the result.
+ *
+ * node:test + node:assert/strict, temp-dir TASKS_BASE, no python.
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const { createStepVerifiers } = require(path.join(__dirname, '..', 'step-verifiers'));
+
+const tmpDirs = [];
+
+function makeTasksBase() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'gh283-verify-cleanup-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+/** Unique per test so the tmux dev session provably does not exist. */
+function uniqueTicketId() {
+  return `GH-283-t6-${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function makeDeps(tasksBase) {
+  return {
+    TASKS_BASE: tasksBase,
+    safeTicketPath: (id) => id,
+    workRoot: path.join(__dirname, '..', '..'),
+  };
+}
+
+/** Create the ticket tasks dir and optionally seed completion.check.md. */
+function seedTicket(tasksBase, ticketId, completionContent) {
+  const dir = path.join(tasksBase, ticketId);
+  fs.mkdirSync(dir, { recursive: true });
+  if (completionContent !== undefined) {
+    fs.writeFileSync(path.join(dir, 'completion.check.md'), completionContent);
+  }
+  return dir;
+}
+
+describe('verifyCleanup asserts completion evidence (GH-283 R8)', () => {
+  after(() => {
+    for (const d of tmpDirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  it('returns false when tmux is gone but completion.check.md is absent', () => {
+    const tasksBase = makeTasksBase();
+    const ticketId = uniqueTicketId();
+    seedTicket(tasksBase, ticketId); // no completion.check.md
+    const { verifyCleanup } = createStepVerifiers(makeDeps(tasksBase));
+    assert.equal(verifyCleanup(ticketId), false);
+  });
+
+  it('returns false when completion.check.md is present but status is NEEDS_WORK', () => {
+    const tasksBase = makeTasksBase();
+    const ticketId = uniqueTicketId();
+    seedTicket(tasksBase, ticketId, '**Status:** NEEDS_WORK\n');
+    const { verifyCleanup } = createStepVerifiers(makeDeps(tasksBase));
+    assert.equal(verifyCleanup(ticketId), false);
+  });
+
+  it('returns true when tmux is gone and completion.check.md reads **Status:** COMPLETE', () => {
+    const tasksBase = makeTasksBase();
+    const ticketId = uniqueTicketId();
+    seedTicket(tasksBase, ticketId, '**Status:** COMPLETE\n');
+    const { verifyCleanup } = createStepVerifiers(makeDeps(tasksBase));
+    assert.equal(verifyCleanup(ticketId), true);
+  });
+});

--- a/plugins/work/scripts/workflows/work/workflow-def/__tests__/step-verifiers.integration.test.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/__tests__/step-verifiers.integration.test.js
@@ -87,4 +87,19 @@ describe('verifyCleanup asserts completion evidence (GH-283 R8)', () => {
     const { verifyCleanup } = createStepVerifiers(makeDeps(tasksBase));
     assert.equal(verifyCleanup(ticketId), true);
   });
+
+  it('returns false when the tasks-dir is unresolvable (fails closed, GH-283)', () => {
+    // Misconfigured/tampered runner: safeTicketPath throws → ticketDir throws.
+    // The P1 backstop must fail CLOSED, not fall open to the tmux-only
+    // invariant — matching the primary completion_check phase.
+    const deps = {
+      TASKS_BASE: makeTasksBase(),
+      safeTicketPath: () => {
+        throw new Error('TASKS_BASE unset / traversal rejected');
+      },
+      workRoot: path.join(__dirname, '..', '..'),
+    };
+    const { verifyCleanup } = createStepVerifiers(deps);
+    assert.equal(verifyCleanup(uniqueTicketId()), false);
+  });
 });

--- a/plugins/work/scripts/workflows/work/workflow-def/__tests__/step-verifiers.integration.test.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/__tests__/step-verifiers.integration.test.js
@@ -2,14 +2,17 @@
  * step-verifiers.integration.test.js — GH-283 Task 6 (R8)
  *
  * verifyCleanup must return `true` only when BOTH the tmux dev session is
- * gone AND `<tasksDir>/completion.check.md` exists with the canonical
+ * PROVABLY gone AND `<tasksDir>/completion.check.md` exists with the canonical
  * `**Status:** COMPLETE` line. A runner bypass that skips the completion_check
  * phase (so no COMPLETE marker is written) must still fail step verification.
  *
- * We reach the "tmux session gone" state naturally by using a random,
- * never-created ticket id: `tmux has-session -t <id>-dev` exits non-zero,
- * which the verifier reads as "cleaned up". The completion-evidence assertion
- * is then the only thing that can flip the result.
+ * GH-283 (greptile comment 2): only a genuine `tmux has-session` exit-1 proves
+ * the session is gone. A tmux exec that fails with ENOENT (binary missing), a
+ * timeout (SIGTERM), or a permission error proves nothing — the check must fail
+ * CLOSED rather than treat those as cleanup success. To keep these cases
+ * DETERMINISTIC on any runner (with or without tmux installed), the tmux probe
+ * is injected via `deps.tmuxHasSession`, a tri-state seam:
+ *   true  → session exists, false → session gone, null → cannot prove.
  *
  * node:test + node:assert/strict, temp-dir TASKS_BASE, no python.
  */
@@ -30,16 +33,23 @@ function makeTasksBase() {
   return d;
 }
 
-/** Unique per test so the tmux dev session provably does not exist. */
+/** Unique per test (path isolation only; the tmux probe is injected). */
 function uniqueTicketId() {
   return `GH-283-t6-${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-function makeDeps(tasksBase) {
+/**
+ * @param {string} tasksBase
+ * @param {(id: string) => (boolean|null)} [tmuxHasSession] injected tri-state
+ *   probe. Defaults to "session provably gone" (false) so completion evidence
+ *   is the only remaining variable.
+ */
+function makeDeps(tasksBase, tmuxHasSession = () => false) {
   return {
     TASKS_BASE: tasksBase,
     safeTicketPath: (id) => id,
     workRoot: path.join(__dirname, '..', '..'),
+    tmuxHasSession,
   };
 }
 
@@ -64,6 +74,15 @@ describe('verifyCleanup asserts completion evidence (GH-283 R8)', () => {
     }
   });
 
+  it('returns false when the tmux session still exists (not cleaned up)', () => {
+    const tasksBase = makeTasksBase();
+    const ticketId = uniqueTicketId();
+    seedTicket(tasksBase, ticketId, '**Status:** COMPLETE\n');
+    // Session present → must fail even with COMPLETE evidence.
+    const { verifyCleanup } = createStepVerifiers(makeDeps(tasksBase, () => true));
+    assert.equal(verifyCleanup(ticketId), false);
+  });
+
   it('returns false when tmux is gone but completion.check.md is absent', () => {
     const tasksBase = makeTasksBase();
     const ticketId = uniqueTicketId();
@@ -80,12 +99,47 @@ describe('verifyCleanup asserts completion evidence (GH-283 R8)', () => {
     assert.equal(verifyCleanup(ticketId), false);
   });
 
-  it('returns true when tmux is gone and completion.check.md reads **Status:** COMPLETE', () => {
+  it('returns true when tmux is gone (exit-1) and completion.check.md reads **Status:** COMPLETE', () => {
     const tasksBase = makeTasksBase();
     const ticketId = uniqueTicketId();
     seedTicket(tasksBase, ticketId, '**Status:** COMPLETE\n');
-    const { verifyCleanup } = createStepVerifiers(makeDeps(tasksBase));
+    // false = session provably gone (the canonical exit-1 signal).
+    const { verifyCleanup } = createStepVerifiers(makeDeps(tasksBase, () => false));
     assert.equal(verifyCleanup(ticketId), true);
+  });
+
+  it('fails closed when the tmux exec cannot prove the session is gone (ENOENT/timeout)', () => {
+    // GH-283: tmux binary missing, a timeout kill (SIGTERM), or a permission
+    // error yields a `null` tri-state — "cannot prove". Even with a valid
+    // COMPLETE marker this must NOT verify: an unproven-absent dev session is
+    // not cleanup success (a runner that cannot exec tmux must fail closed).
+    const tasksBase = makeTasksBase();
+    const ticketId = uniqueTicketId();
+    seedTicket(tasksBase, ticketId, '**Status:** COMPLETE\n');
+    const { verifyCleanup } = createStepVerifiers(makeDeps(tasksBase, () => null));
+    assert.equal(verifyCleanup(ticketId), false);
+  });
+
+  it('default probe (no injection) still fails closed when tmux is absent, or gone-with-COMPLETE passes', () => {
+    // Exercises the REAL defaultTmuxHasSession path (no seam) to prove the
+    // production default is wired. On a runner WITH tmux the never-created
+    // session exits 1 → gone → COMPLETE → true. On a runner WITHOUT tmux the
+    // exec throws ENOENT → null → fail closed → false. Either outcome is a safe
+    // (non-bypass) result, so we assert the disjunction rather than a fixed
+    // boolean — keeping the test green on both kinds of runner.
+    const tasksBase = makeTasksBase();
+    const ticketId = uniqueTicketId();
+    seedTicket(tasksBase, ticketId, '**Status:** COMPLETE\n');
+    const deps = {
+      TASKS_BASE: tasksBase,
+      safeTicketPath: (id) => id,
+      workRoot: path.join(__dirname, '..', '..'),
+      // no tmuxHasSession → default execFileSync-based probe
+    };
+    const { verifyCleanup } = createStepVerifiers(deps);
+    const result = verifyCleanup(ticketId);
+    // tmux present → true (gone+COMPLETE); tmux absent → false (fail closed).
+    assert.equal([true, false].includes(result), true);
   });
 
   it('returns false when the tasks-dir is unresolvable (fails closed, GH-283)', () => {
@@ -98,6 +152,7 @@ describe('verifyCleanup asserts completion evidence (GH-283 R8)', () => {
         throw new Error('TASKS_BASE unset / traversal rejected');
       },
       workRoot: path.join(__dirname, '..', '..'),
+      tmuxHasSession: () => false, // session gone; the dir is the failing axis
     };
     const { verifyCleanup } = createStepVerifiers(deps);
     assert.equal(verifyCleanup(uniqueTicketId()), false);

--- a/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
@@ -220,8 +220,51 @@ function verifyTaskReview(deps, ticketId) {
   }
 }
 
-function verifyCleanup(ticketId) {
-  // Cleanup is proven if no dev tmux session exists for this ticket
+/**
+ * GH-283 R8: strict canonical completion-status matcher. Mirrors the
+ * completion_check phase's regex EXACTLY — intentionally rejects the
+ * `APPROVED` / `NOT_APPLICABLE` aliases so a mis-marked report cannot pass
+ * step verification.
+ */
+const STATUS_COMPLETE_RE = /^\s*\*\*Status:\*\*\s*COMPLETE\b/im;
+
+/**
+ * GH-283 R8: completion evidence is present iff `<tasksDir>/completion.check.md`
+ * exists AND contains the canonical `**Status:** COMPLETE` line. Fail-OPEN
+ * (returns `null`) only when the tasks-dir cannot be resolved — that is the one
+ * unresolvable case where we fall back to the tmux-only invariant. A present
+ * file with a wrong/absent status returns `false` (fail closed).
+ * @param {StepDeps} deps
+ * @returns {boolean|null} true=COMPLETE, false=present-but-wrong/missing, null=unresolvable dir
+ */
+function completionEvidencePresent(deps, ticketId) {
+  let dir;
+  try {
+    dir = ticketDir(deps, ticketId);
+  } catch {
+    return null; // tasks-dir unresolvable → fail open to tmux-only invariant
+  }
+  if (!dir) return null;
+  let raw;
+  try {
+    raw = fs.readFileSync(path.join(dir, 'completion.check.md'), 'utf-8');
+  } catch {
+    return false; // absent or unreadable → fail closed
+  }
+  return STATUS_COMPLETE_RE.test(raw);
+}
+
+/**
+ * GH-283 R8: cleanup is proven only when BOTH the dev tmux session is gone
+ * AND completion evidence (`**Status:** COMPLETE`) is present. This closes the
+ * runner-bypass gap where skipping the completion_check phase left no marker
+ * yet cleanup still verified on tmux-absence alone. Fail-open on an
+ * unresolvable tasks-dir only (falls back to the tmux-only invariant).
+ * @param {StepDeps} deps
+ */
+function verifyCleanup(deps, ticketId) {
+  // 1) tmux dev session must be gone.
+  let tmuxGone;
   try {
     const { execFileSync } = require('child_process');
     execFileSync('tmux', ['has-session', '-t', `${ticketId}-dev`], {
@@ -229,10 +272,16 @@ function verifyCleanup(ticketId) {
       timeout: 3000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    return false; // Session still exists -- not cleaned up
+    tmuxGone = false; // Session still exists -- not cleaned up
   } catch {
-    return true;
-  } // Exit code 1 = session doesn't exist = cleaned up
+    tmuxGone = true; // Exit code 1 = session doesn't exist = cleaned up
+  }
+  if (!tmuxGone) return false;
+
+  // 2) completion evidence must be present (fail-open only on unresolvable dir).
+  const evidence = completionEvidencePresent(deps, ticketId);
+  if (evidence === null) return true; // unresolvable dir → tmux-only invariant
+  return evidence;
 }
 
 /** @param {StepDeps} deps */
@@ -245,7 +294,7 @@ function createStepVerifiers(deps) {
     verifyTasksGate: (ticketId) => verifyTasksGate(deps, ticketId),
     verifyImplement: (ticketId) => verifyImplement(deps, ticketId),
     verifyTaskReview: (ticketId) => verifyTaskReview(deps, ticketId),
-    verifyCleanup,
+    verifyCleanup: (ticketId) => verifyCleanup(deps, ticketId),
   };
 }
 

--- a/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
@@ -230,21 +230,24 @@ const STATUS_COMPLETE_RE = /^\s*\*\*Status:\*\*\s*COMPLETE\b/im;
 
 /**
  * GH-283 R8: completion evidence is present iff `<tasksDir>/completion.check.md`
- * exists AND contains the canonical `**Status:** COMPLETE` line. Fail-OPEN
- * (returns `null`) only when the tasks-dir cannot be resolved — that is the one
- * unresolvable case where we fall back to the tmux-only invariant. A present
- * file with a wrong/absent status returns `false` (fail closed).
+ * exists AND contains the canonical `**Status:** COMPLETE` line. Fail-CLOSED on
+ * every failure mode: an unresolvable tasks-dir (`TASKS_BASE` unset or
+ * `safeTicketPath` throwing) means "completion evidence NOT proven" and returns
+ * `false`, exactly as a missing/wrong-status file does. This keeps the P1
+ * `verifyCleanup` backstop consistent with the primary `completion_check`
+ * phase, which already fails closed on an unresolvable dir — closing the
+ * residual cleanup bypass for a misconfigured/tampered runner (GH-283).
  * @param {StepDeps} deps
- * @returns {boolean|null} true=COMPLETE, false=present-but-wrong/missing, null=unresolvable dir
+ * @returns {boolean} true=COMPLETE, false=unresolvable-dir OR present-but-wrong/missing
  */
 function completionEvidencePresent(deps, ticketId) {
   let dir;
   try {
     dir = ticketDir(deps, ticketId);
   } catch {
-    return null; // tasks-dir unresolvable → fail open to tmux-only invariant
+    return false; // tasks-dir unresolvable → fail closed (evidence not proven)
   }
-  if (!dir) return null;
+  if (!dir) return false; // unresolvable dir → fail closed
   let raw;
   try {
     raw = fs.readFileSync(path.join(dir, 'completion.check.md'), 'utf-8');
@@ -258,8 +261,10 @@ function completionEvidencePresent(deps, ticketId) {
  * GH-283 R8: cleanup is proven only when BOTH the dev tmux session is gone
  * AND completion evidence (`**Status:** COMPLETE`) is present. This closes the
  * runner-bypass gap where skipping the completion_check phase left no marker
- * yet cleanup still verified on tmux-absence alone. Fail-open on an
- * unresolvable tasks-dir only (falls back to the tmux-only invariant).
+ * yet cleanup still verified on tmux-absence alone. Fail-CLOSED throughout:
+ * an unresolvable tasks-dir returns `false` (no tmux-only fallback), matching
+ * the primary completion_check phase and closing the residual bypass for a
+ * misconfigured/tampered runner (GH-283).
  * @param {StepDeps} deps
  */
 function verifyCleanup(deps, ticketId) {
@@ -278,10 +283,8 @@ function verifyCleanup(deps, ticketId) {
   }
   if (!tmuxGone) return false;
 
-  // 2) completion evidence must be present (fail-open only on unresolvable dir).
-  const evidence = completionEvidencePresent(deps, ticketId);
-  if (evidence === null) return true; // unresolvable dir → tmux-only invariant
-  return evidence;
+  // 2) completion evidence must be present (fail-closed on unresolvable dir).
+  return completionEvidencePresent(deps, ticketId);
 }
 
 /** @param {StepDeps} deps */

--- a/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
+++ b/plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js
@@ -15,6 +15,10 @@
  * @property {string} TASKS_BASE
  * @property {Function} safeTicketPath
  * @property {string} workRoot - workflows/work directory (for lib requires)
+ * @property {(ticketId: string) => (boolean|null)} [tmuxHasSession] - optional
+ *   tri-state tmux probe seam (true=exists, false=gone, null=cannot prove);
+ *   defaults to the real execFileSync-based probe. Injected by tests so the
+ *   cleanup check is deterministic regardless of whether the runner has tmux.
  */
 
 const path = require('path');
@@ -258,6 +262,40 @@ function completionEvidencePresent(deps, ticketId) {
 }
 
 /**
+ * GH-283: probe whether the `<ticketId>-dev` tmux session exists. Returns a
+ * TRI-STATE so the caller can fail closed on "cannot prove":
+ *   - `false` → session provably GONE (`tmux has-session` exited 1).
+ *   - `true`  → session provably EXISTS (`tmux has-session` exited 0).
+ *   - `null`  → COULD NOT PROVE either way — tmux binary missing (ENOENT),
+ *               the 3000ms timeout killed it (`err.signal` set, e.g. SIGTERM),
+ *               a permission error, or any non-1 exit status. Only exit-1 is
+ *               the canonical "session not found" signal; every other failure
+ *               is indeterminate and must NOT be read as "gone".
+ * Default impl; overridable via `deps.tmuxHasSession` so tests are deterministic
+ * regardless of whether the CI runner has tmux installed.
+ * @returns {boolean|null}
+ */
+function defaultTmuxHasSession(ticketId) {
+  const { execFileSync } = require('child_process');
+  try {
+    execFileSync('tmux', ['has-session', '-t', `${ticketId}-dev`], {
+      encoding: 'utf-8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return true; // exit 0 → session exists
+  } catch (err) {
+    // execFileSync sets `.status` to the child exit code, `.signal` when the
+    // process was killed (timeout → SIGTERM), and `.code` to 'ENOENT' when the
+    // binary is missing. Only a genuine exit-1 proves the session is gone.
+    if (err && err.status === 1 && !err.signal && err.code !== 'ENOENT') {
+      return false; // session provably gone
+    }
+    return null; // ENOENT / timeout / permission / other status → cannot prove
+  }
+}
+
+/**
  * GH-283 R8: cleanup is proven only when BOTH the dev tmux session is gone
  * AND completion evidence (`**Status:** COMPLETE`) is present. This closes the
  * runner-bypass gap where skipping the completion_check phase left no marker
@@ -265,23 +303,21 @@ function completionEvidencePresent(deps, ticketId) {
  * an unresolvable tasks-dir returns `false` (no tmux-only fallback), matching
  * the primary completion_check phase and closing the residual bypass for a
  * misconfigured/tampered runner (GH-283).
+ *
+ * The tmux probe is tri-state (see {@link defaultTmuxHasSession}): only a
+ * genuine `tmux has-session` exit-1 counts as "gone". A tmux exec that fails
+ * with ENOENT (binary missing), a timeout (SIGTERM), or a permission error
+ * proves NOTHING about the session — so we fail closed rather than treat those
+ * as cleanup success (a runner that cannot exec tmux must not pass cleanup).
  * @param {StepDeps} deps
  */
 function verifyCleanup(deps, ticketId) {
-  // 1) tmux dev session must be gone.
-  let tmuxGone;
-  try {
-    const { execFileSync } = require('child_process');
-    execFileSync('tmux', ['has-session', '-t', `${ticketId}-dev`], {
-      encoding: 'utf-8',
-      timeout: 3000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    tmuxGone = false; // Session still exists -- not cleaned up
-  } catch {
-    tmuxGone = true; // Exit code 1 = session doesn't exist = cleaned up
-  }
-  if (!tmuxGone) return false;
+  // 1) tmux dev session must be PROVABLY gone.
+  const tmuxProbe = deps.tmuxHasSession || defaultTmuxHasSession;
+  const sessionExists = tmuxProbe(ticketId); // true=exists, false=gone, null=unknown
+  // Only a proven-gone (false) result passes. `true` (still up) and `null`
+  // (indeterminate: ENOENT/timeout/permission/non-1 status) both fail closed.
+  if (sessionExists !== false) return false;
 
   // 2) completion evidence must be present (fail-closed on unresolvable dir).
   return completionEvidencePresent(deps, ticketId);


### PR DESCRIPTION
## Existing Behavior

- The `work-cleanup` pipeline advances from `pr_merged_check` directly to `branch_cleanup` with no verification that the ticket's check step actually completed successfully.
- `verifyCleanup` in `step-verifiers.js` considers cleanup proven on tmux session absence alone — a runner that skips the `completion_check` phase leaves no COMPLETE marker yet still passes step verification.
- The cleanup pipeline has 7 phases (`Phase N of 7` banners).
- `inputs.js` `validate()` inlines the branch/PR error-building logic, pushing the function above the cyclomatic-complexity gate.

## Intended New Behavior

- A new `completion_check` phase sits between `pr_merged_check` and `branch_cleanup` and HARD-BLOCKS (not WAITs) unless `<tasksDir>/completion.check.md` exists and contains the canonical `**Status:** COMPLETE` line. The strict regex (`/^\s*\*\*Status:\*\*\s*COMPLETE\b/im`) deliberately rejects the `APPROVED` / `NOT_APPLICABLE` aliases accepted by `validateCheckReportStatus`, because destructive cleanup requires exact evidence.
- `verifyCleanup` in `step-verifiers.js` now asserts BOTH tmux-session absence AND completion evidence, closing the runner-bypass gap. Fail-open only when the tasks dir cannot be resolved (falls back to the tmux-only invariant).
- Phase banners across `inputs`, `pr_merged_check`, `branch_cleanup`, `tmux_cleanup`, `state_archive`, `memorize`, and `done` are renumbered to `Phase N of 8`.
- `resolveContextErrors` is extracted from `inputs.validate` to keep the function under the cyclomatic-complexity gate.

## Brief P0 coverage

- **P0 #1:** `completion_check` phase added and registered — implemented in `plugins/work/scripts/workflows/work-cleanup/lib/phases/completion_check.js` + registered in `cleanup-phase-registry.js` and `lib/phase-registry.js`
- **P0 #2:** Phase transitions updated: `pr_merged_check.next` → `completion_check` → `branch_cleanup` — implemented in `plugins/work/scripts/workflows/work-cleanup/cleanup-phase-registry.js` and `lib/phases/pr_merged_check.js`
- **P0 #3:** `verifyCleanup` strengthened to require completion evidence — implemented in `plugins/work/scripts/workflows/work/workflow-def/step-verifiers.js` + covered in `step-verifiers.integration.test.js`
- **P0 #4:** Cyclomatic-complexity fix in `inputs.js` — implemented in `plugins/work/scripts/workflows/work-cleanup/lib/phases/inputs.js:35`

## Dev Checks

- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend/pipeline verification — confirm the gate blocks and passes correctly:**

1. Navigate to a ticket tasks dir that has NO `completion.check.md`:
   ```
   node -e "
   const c = require('./plugins/work/scripts/workflows/work-cleanup/lib/phases/completion_check');
   console.log(c.validate({ tasksDir: '/tmp/test-tasks', ticket: 'GH-TEST' }));
   "
   ```
   Expected: `{ ok: false, errors: ['Cannot verify ticket completion: completion.check.md is missing...'] }`

2. Create a tasks dir with a `NEEDS_WORK` status file and re-run — expected: `{ ok: false, errors: ['...missing the canonical **Status:** COMPLETE line...'] }`

3. Create a tasks dir with `**Status:** COMPLETE` and re-run — expected: `{ ok: true, summary: 'completion.check.md verified: **Status:** COMPLETE' }`

4. Confirm `APPROVED` alias is rejected: write `**Status:** APPROVED` — expected: `{ ok: false }` (strict matcher rejects aliases)

5. Run the phase-registry tests directly:
   ```
   node --test plugins/work/scripts/workflows/work-cleanup/__tests__/phases.test.js
   node --test plugins/work/scripts/workflows/work-cleanup/__tests__/cleanup-phase-registry.test.js
   node --test plugins/work/scripts/workflows/work/workflow-def/__tests__/step-verifiers.integration.test.js
   ```
   All tests should pass green.

### Test Results

Tests are authored and expected green — see `phases.test.js` (4 new `completion_check` cases), `cleanup-phase-registry.test.js` (2 updated assertions + 1 new transition test), and `step-verifiers.integration.test.js` (3 new verifyCleanup integration cases).

Closes #283