### PR TITLE
feat(work): context window usage monitoring and warnings (GH-313)

### DIFF
--- a/plugins/work/docs/hooks.md
+++ b/plugins/work/docs/hooks.md
@@ -165,6 +165,8 @@ All hooks follow a strict fail-open policy:
 | `protect-tasks-md.js` | Block edits to planner-owned tasks.md outside the tasks phase |
 | `protect-task-scope.js` | Block edits outside the active task's `### Files in scope` |
 | `work-require-implement.js` | Block code changes outside implement step (hook script exists and consumes `preflight.js`, but is NOT currently registered in hooks.json) |
+| `capture-usage.js` | PostToolUse (`Task\|Agent`): capture per-dispatch sub-agent token usage (GH-311) |
+| `context-monitor.js` | PostToolUse (`Task\|Agent`): advisory context-usage warning (GH-313) — see [Context Monitor](#context-monitor) |
 
 ### /work-implement hooks (`scripts/workflows/work-implement/hooks/`)
 
@@ -206,6 +208,51 @@ Repeat `init` calls with unchanged state are silent — pass `--show-guard` to
 node session-guard.js init TICKET-123 /work --show-guard
 ```
 
+## Context Monitor
+
+**File:** `scripts/workflows/work/hooks/context-monitor.js`
+
+Registered as a PostToolUse hook on the existing `Task|Agent` lane (alongside
+`capture-usage.js`). After each agent-dispatch tool completes, this **advisory**
+hook warns the operator as the active `/work` session approaches its context
+limit — it **never blocks** a tool call and is strictly **fail-open** (any error
+exits 0 silently via `installFailOpen()`).
+
+What it does per dispatch:
+
+1. Scopes to the active `/work` session via the `.work.pid` marker
+   (`findRecentWorkMarker`). A foreign/missing marker or a sub-agent context is a
+   silent no-op.
+2. Reads cumulative context-token usage (input + output, including cache fields)
+   from the session's own transcript (`context-usage.readCumulativeUsage`).
+3. Computes the integer percent consumed against the model context limit.
+4. Fires **once per newly-crossed threshold** (default 60/70/80), naming the
+   active workflow step, the dispatched agent/tool, and the percent consumed.
+   Crossed thresholds are tracked in a per-ticket ledger at
+   `<TASKS_BASE>/<safeTicketId>/.context-monitor.json` (`{ crossed: number[] }`),
+   so an already-crossed threshold does not re-warn within a session. The ledger
+   is created lazily and is safe to delete (absence re-arms all thresholds).
+5. At the highest (critical) threshold, the warning appends an actionable
+   recommendation: commit current work, summarize progress, and consider
+   spawning a fresh agent for the remainder.
+
+Warnings ride `emit.context('PostToolUse', ...)` (stderr-style on Claude, an
+`additionalContext` envelope on Codex).
+
+### Configuration env vars
+
+| Env var | Default | Behavior |
+|---|---|---|
+| `WORK_CONTEXT_WARN_THRESHOLDS` | `60,70,80` | Comma-separated warning percentages. Read through the canonical `config.get` accessor. Missing, empty, or non-numeric values fall back to the default `[60,70,80]` (parse-with-fallback, no error). |
+| `WORK_CONTEXT_LIMIT` | `200000` | Overrides the model→context-limit map (Opus / Sonnet / Haiku = 200000, with a 200000 safe default for an unknown model). A valid positive integer wins over the map. |
+| `WORK_CONTEXT_MONITOR_ENABLED` | (enabled) | Set to `0` to turn the monitor into a silent no-op without unregistering the hook (mirrors `SESSION_GUARD_ENABLED`). |
+
+**Deferred GH-310 follow-up:** these three keys are **not yet registered** in
+GH-310's config-validation schema. Registering them there is a deferred GH-310
+follow-up and is out of scope for this hook. Until then, operators may see an
+"unknown key" warning from config validation when they set these vars — that
+warning is expected and does not affect the monitor's behavior.
+
 ## Error Logging
 
 **File:** `scripts/workflows/lib/hook-error-log.js`
@@ -230,6 +277,9 @@ export WORK_TDD_TOKEN_SKIP=1
 
 # Disable session guard
 export SESSION_GUARD_ENABLED=0
+
+# Disable the context-usage monitor (silent no-op)
+export WORK_CONTEXT_MONITOR_ENABLED=0
 ```
 
 ## Dual runtime: the same hooks.json on Codex CLI

--- a/plugins/work/docs/hooks.md
+++ b/plugins/work/docs/hooks.md
@@ -223,9 +223,14 @@ What it does per dispatch:
 1. Scopes to the active `/work` session via the `.work.pid` marker
    (`findRecentWorkMarker`). A foreign/missing marker or a sub-agent context is a
    silent no-op.
-2. Reads cumulative context-token usage (input + output, including cache fields)
-   from the session's own transcript (`context-usage.readCumulativeUsage`).
-3. Computes the integer percent consumed against the model context limit.
+2. Reads the **current context occupancy** from the session's own transcript —
+   the **most recent turn's** usage (input + output + cache fields), NOT a sum
+   across turns (summing re-counts the growing, re-sent, cached context and
+   over-counts wildly). On Codex the last `token_count` snapshot's
+   `last_token_usage` is used and its `model_context_window` is surfaced as the
+   real limit (`context-usage.readContextUsage`).
+3. Computes the integer percent consumed against the context limit
+   (`WORK_CONTEXT_LIMIT` override → transcript window → 200000 default).
 4. Fires **once per newly-crossed threshold** (default 60/70/80), naming the
    active workflow step, the dispatched agent/tool, and the percent consumed.
    Crossed thresholds are tracked in a per-ticket ledger at
@@ -244,7 +249,7 @@ Warnings ride `emit.context('PostToolUse', ...)` (stderr-style on Claude, an
 | Env var | Default | Behavior |
 |---|---|---|
 | `WORK_CONTEXT_WARN_THRESHOLDS` | `60,70,80` | Comma-separated warning percentages. Read through the canonical `config.get` accessor. Missing, empty, or non-numeric values fall back to the default `[60,70,80]` (parse-with-fallback, no error). |
-| `WORK_CONTEXT_LIMIT` | `200000` | Overrides the model→context-limit map (Opus / Sonnet / Haiku = 200000, with a 200000 safe default for an unknown model). A valid positive integer wins over the map. |
+| `WORK_CONTEXT_LIMIT` | `200000` | Explicit context-token limit. Resolution order: a valid positive-integer override here wins; otherwise the transcript-reported `model_context_window` (Codex) is used; otherwise a 200000 safe default. Claude transcripts do not report a window, so a Claude session uses this override or the 200000 default. |
 | `WORK_CONTEXT_MONITOR_ENABLED` | (enabled) | Set to `0` to turn the monitor into a silent no-op without unregistering the hook (mirrors `SESSION_GUARD_ENABLED`). |
 
 **Deferred GH-310 follow-up:** these three keys are **not yet registered** in

--- a/plugins/work/hooks/hooks.json
+++ b/plugins/work/hooks/hooks.json
@@ -164,6 +164,10 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work/hooks/capture-usage.js"
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work/hooks/context-monitor.js"
           }
         ]
       },

--- a/plugins/work/scripts/workflows/work/hooks/__tests__/context-monitor.test.js
+++ b/plugins/work/scripts/workflows/work/hooks/__tests__/context-monitor.test.js
@@ -1,0 +1,306 @@
+/**
+ * Integration tests for context-monitor.js — PostToolUse hook for /work
+ * (GH-313, Task 3).
+ *
+ * The monitor is a fail-open PostToolUse hook that, after an agent-dispatch
+ * completion, reads the session's cumulative transcript token usage, compares
+ * it against the model context limit, and emits an advisory warning per newly
+ * crossed threshold (default 60/70/80%). It never blocks a tool call.
+ *
+ * These tests spawn the hook with child_process.execFileSync (the established
+ * exit-code harness, mirroring capture-usage.test.js) against a temp
+ * TASKS_BASE, asserting:
+ *   - fail-open exit 0 for foreign-marker / sub-agent / missing-transcript
+ *   - the hooks.json registration line under the Task|Agent PostToolUse lane
+ *   - first-crossing warning content (step, agent, "62%"), exit 0
+ *   - no-repeat on a second run (crossed-threshold ledger)
+ *   - critical recommendation at the highest threshold
+ *   - the WORK_CONTEXT_MONITOR_ENABLED=0 silent no-op
+ *
+ * node:test + node:assert/strict; temp TASKS_BASE via fs.mkdtempSync.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const HOOKS_DIR = path.join(__dirname, '..');
+const hookPath = path.join(HOOKS_DIR, 'context-monitor.js');
+const { ALL_STEPS } = require(path.join(HOOKS_DIR, '..', 'step-registry'));
+
+const MARKER = '.work.pid';
+const LEDGER = '.context-monitor.json';
+const SESSION = 'sess-ctx-1';
+
+let TASKS_BASE;
+
+/**
+ * Spawn the hook, feeding `hookData` on stdin. Captures exit code + streams.
+ * Warnings ride emit.context which, on the claude leg, prints the message to
+ * stdout — so the emitted warning text is observable via r.stdout.
+ */
+function runHook(hookData, env = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [hookPath], {
+      input: JSON.stringify(hookData),
+      encoding: 'utf8',
+      timeout: 20000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, CLAUDE_CODE_SESSION_ID: '', ...env },
+    });
+    return { exitCode: 0, stdout };
+  } catch (err) {
+    return { exitCode: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+function ownedEnv(extra = {}) {
+  return {
+    TASKS_BASE,
+    WORKTREES_BASE: path.dirname(TASKS_BASE),
+    CLAUDE_CODE_SESSION_ID: SESSION,
+    ...extra,
+  };
+}
+
+function writeMarker(ticket, fields = {}) {
+  const dir = path.join(TASKS_BASE, ticket);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, MARKER),
+    JSON.stringify({
+      ticket,
+      startedAt: new Date().toISOString(),
+      workflow: '/work',
+      sessionId: SESSION,
+      ...fields,
+    })
+  );
+}
+
+function writeState(ticket, stepName) {
+  const dir = path.join(TASKS_BASE, ticket);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.work-state.json'),
+    JSON.stringify({ ticketId: ticket, currentStep: ALL_STEPS.indexOf(stepName) + 1 })
+  );
+}
+
+/**
+ * Write a transcript JSONL whose per-turn `usage` blocks sum to `tokens`
+ * (a single input-token turn is enough — context-usage sums input+output).
+ */
+function writeTranscript(ticket, tokens) {
+  const dir = path.join(TASKS_BASE, ticket);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'transcript.jsonl');
+  const line = JSON.stringify({ message: { usage: { input_tokens: tokens, output_tokens: 0 } } });
+  fs.writeFileSync(file, line + '\n');
+  return file;
+}
+
+function readLedger(ticket) {
+  const file = path.join(TASKS_BASE, ticket, LEDGER);
+  if (!fs.existsSync(file)) return null;
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function writeLedger(ticket, crossed) {
+  const dir = path.join(TASKS_BASE, ticket);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, LEDGER), JSON.stringify({ crossed }));
+}
+
+/** Dispatch payload: a claude Task completion at `tokens` of the limit. */
+function taskPayload(ticket, tokens, overrides = {}) {
+  const transcript = writeTranscript(ticket, tokens);
+  return {
+    tool_name: 'Task',
+    tool_input: { subagent_type: 'developer-nodejs-tdd', prompt: 'do the thing' },
+    tool_response: { content: [{ type: 'text', text: 'done' }], totalTokens: tokens },
+    transcript_path: transcript,
+    session_id: SESSION,
+    ...overrides,
+  };
+}
+
+describe('context-monitor hook — fail-open scoping + hooks.json registration', () => {
+  beforeEach(() => {
+    TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'context-monitor-test-'));
+  });
+  afterEach(() => {
+    fs.rmSync(TASKS_BASE, { recursive: true, force: true });
+  });
+
+  it('is registered in hooks.json under the Task|Agent PostToolUse lane', () => {
+    const hooksJsonPath = path.join(HOOKS_DIR, '..', '..', '..', '..', 'hooks', 'hooks.json');
+    const raw = fs.readFileSync(hooksJsonPath, 'utf8');
+    assert.match(raw, /context-monitor\.js/, 'hooks.json must register context-monitor.js');
+
+    const cfg = JSON.parse(raw);
+    const lane = cfg.hooks.PostToolUse.find(
+      (l) =>
+        l.matcher === 'Task|Agent' && l.hooks.some((h) => /context-monitor\.js/.test(h.command))
+    );
+    assert.ok(lane, 'context-monitor.js must live in the Task|Agent PostToolUse lane');
+    const capture = lane.hooks.some((h) => /capture-usage\.js/.test(h.command));
+    assert.ok(capture, 'must sit alongside capture-usage.js in the same lane');
+  });
+
+  it('is a silent no-op (exit 0, no warning) for a foreign-session marker', () => {
+    writeMarker('GH-800', { sessionId: 'owner-A', worktreeRoot: '/wt/a' });
+    writeState('GH-800', 'implement');
+
+    const r = runHook(taskPayload('GH-800', 124000, { session_id: 'other-B' }), {
+      TASKS_BASE,
+      WORKTREES_BASE: path.dirname(TASKS_BASE),
+      CLAUDE_CODE_SESSION_ID: 'other-B',
+    });
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, '', 'must not warn on a foreign /work session');
+    assert.equal(readLedger('GH-800'), null, 'must not write a ledger for a foreign session');
+  });
+
+  it('is a silent no-op (exit 0, no warning) from within a sub-agent context', () => {
+    writeMarker('GH-801');
+    writeState('GH-801', 'implement');
+
+    const r = runHook(
+      taskPayload('GH-801', 124000, { transcript_path: '/x/subagents/y.jsonl' }),
+      ownedEnv()
+    );
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, '', 'sub-agent context must be suppressed');
+    assert.equal(readLedger('GH-801'), null);
+  });
+
+  it('exits 0 with no warning when the transcript is missing/unreadable', () => {
+    writeMarker('GH-802');
+    writeState('GH-802', 'implement');
+
+    const r = runHook(
+      taskPayload('GH-802', 0, { transcript_path: path.join(TASKS_BASE, 'GH-802', 'nope.jsonl') }),
+      ownedEnv()
+    );
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, '', 'a missing transcript must never block or warn');
+  });
+
+  it('exits 0 silently when no /work marker exists', () => {
+    const r = runHook(taskPayload('GH-803', 124000), ownedEnv());
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, '');
+  });
+});
+
+describe('context-monitor hook — threshold warnings, ledger, critical, disable', () => {
+  beforeEach(() => {
+    TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'context-monitor-test-'));
+  });
+  afterEach(() => {
+    fs.rmSync(TASKS_BASE, { recursive: true, force: true });
+  });
+
+  it('warns once at the first crossed threshold naming step, agent, and percent', () => {
+    writeMarker('GH-810');
+    writeState('GH-810', 'implement');
+
+    // 124000 / 200000 = 62% → crosses the 60% threshold only.
+    const r = runHook(taskPayload('GH-810', 124000), ownedEnv());
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stdout, /62%/, 'warning must name the integer percent consumed');
+    assert.match(r.stdout, /implement/, 'warning must name the active workflow step');
+    assert.match(r.stdout, /developer-nodejs-tdd/, 'warning must name the dispatched agent');
+    assert.ok(!/70%|80%/.test(r.stdout), 'only the 60% threshold should fire at 62%');
+
+    const ledger = readLedger('GH-810');
+    assert.deepEqual(ledger, { crossed: [60] }, 'the crossed threshold is persisted to the ledger');
+  });
+
+  it('does not re-warn a threshold already recorded in the ledger', () => {
+    writeMarker('GH-811');
+    writeState('GH-811', 'implement');
+    writeLedger('GH-811', [60]);
+
+    // Still 62% — 60 already crossed, so nothing new fires.
+    const r = runHook(taskPayload('GH-811', 124000), ownedEnv());
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, '', 'a threshold already in the ledger must not warn twice');
+    assert.deepEqual(readLedger('GH-811'), { crossed: [60] });
+  });
+
+  it('appends the commit + fresh-agent recommendation at the critical threshold', () => {
+    writeMarker('GH-812');
+    writeState('GH-812', 'implement');
+
+    // 170000 / 200000 = 85% → crosses 60, 70, and the critical 80.
+    const r = runHook(taskPayload('GH-812', 170000), ownedEnv());
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stdout, /85%/);
+    assert.match(r.stdout, /commit/i, 'critical warning must recommend committing current work');
+    assert.match(r.stdout, /fresh agent/i, 'critical warning must recommend a fresh agent');
+
+    const ledger = readLedger('GH-812');
+    assert.deepEqual(
+      ledger.crossed.sort((a, b) => a - b),
+      [60, 70, 80]
+    );
+  });
+
+  it('honors WORK_CONTEXT_WARN_THRESHOLDS, firing the configured percentages', () => {
+    writeMarker('GH-813');
+    writeState('GH-813', 'implement');
+
+    // 110000 / 200000 = 55% with thresholds "50,90" → only 50 fires.
+    const r = runHook(
+      taskPayload('GH-813', 110000),
+      ownedEnv({ WORK_CONTEXT_WARN_THRESHOLDS: '50,90' })
+    );
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stdout, /55%/);
+    assert.ok(!/60%/.test(r.stdout), 'the default 60% threshold must not fire when overridden');
+    assert.deepEqual(readLedger('GH-813'), { crossed: [50] });
+  });
+
+  it('falls back to default thresholds when WORK_CONTEXT_WARN_THRESHOLDS is invalid', () => {
+    writeMarker('GH-814');
+    writeState('GH-814', 'implement');
+
+    // 130000 / 200000 = 65%; invalid env → defaults [60,70,80] → only 60 fires.
+    const r = runHook(
+      taskPayload('GH-814', 130000),
+      ownedEnv({ WORK_CONTEXT_WARN_THRESHOLDS: 'not-a-number' })
+    );
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stdout, /65%/);
+    assert.deepEqual(readLedger('GH-814'), { crossed: [60] });
+  });
+
+  it('is a silent no-op when WORK_CONTEXT_MONITOR_ENABLED=0', () => {
+    writeMarker('GH-815');
+    writeState('GH-815', 'implement');
+
+    const r = runHook(
+      taskPayload('GH-815', 170000),
+      ownedEnv({ WORK_CONTEXT_MONITOR_ENABLED: '0' })
+    );
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, '', 'the disable switch must silence the monitor');
+    assert.equal(readLedger('GH-815'), null, 'disabled monitor must not write a ledger');
+  });
+
+  it('honors WORK_CONTEXT_LIMIT when computing percent', () => {
+    writeMarker('GH-816');
+    writeState('GH-816', 'implement');
+
+    // 124000 tokens against a 400000 limit = 31% → below every threshold.
+    const r = runHook(taskPayload('GH-816', 124000), ownedEnv({ WORK_CONTEXT_LIMIT: '400000' }));
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.stdout, '', 'no threshold is crossed at 31% of a raised limit');
+    assert.equal(readLedger('GH-816'), null);
+  });
+});

--- a/plugins/work/scripts/workflows/work/hooks/__tests__/context-monitor.test.js
+++ b/plugins/work/scripts/workflows/work/hooks/__tests__/context-monitor.test.js
@@ -91,8 +91,9 @@ function writeState(ticket, stepName) {
 }
 
 /**
- * Write a transcript JSONL whose per-turn `usage` blocks sum to `tokens`
- * (a single input-token turn is enough — context-usage sums input+output).
+ * Write a transcript JSONL whose last-turn occupancy is `tokens` (a single
+ * turn is both the first and the last, so its input+output IS the current
+ * occupancy that context-usage reports).
  */
 function writeTranscript(ticket, tokens) {
   const dir = path.join(TASKS_BASE, ticket);

--- a/plugins/work/scripts/workflows/work/hooks/capture-usage.js
+++ b/plugins/work/scripts/workflows/work/hooks/capture-usage.js
@@ -21,38 +21,10 @@
  * capture must never break or cross-wire a workflow.
  */
 
-const fs = require('fs');
 const path = require('path');
 const hookCommon = require(path.join(__dirname, '..', 'lib', 'hook-common'));
 
 hookCommon.installFailOpen();
-
-/**
- * Resolve the ticket's active step name from `.work-state.json`.
- * `currentStep` is 1-indexed into ALL_STEPS (see print-current-step.js).
- * Missing/invalid state attributes the row to 'unknown' rather than dropping
- * the usage figures.
- */
-function readStateStep(tasksBase, ticket) {
-  let safe = ticket;
-  try {
-    safe = require(path.join(__dirname, '..', '..', 'lib', 'config')).safeTicketId(ticket);
-  } catch {
-    /* fall back to the raw id */
-  }
-  try {
-    const statePath = path.join(tasksBase, safe, '.work-state.json');
-    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
-    const { ALL_STEPS } = require(path.join(__dirname, '..', 'step-registry'));
-    const num = Number(state && state.currentStep);
-    if (Number.isFinite(num) && num >= 1 && num <= ALL_STEPS.length) {
-      return ALL_STEPS[num - 1];
-    }
-  } catch {
-    /* missing/corrupt state file */
-  }
-  return 'unknown';
-}
 
 /** Finite number or 0. */
 function fin(n) {
@@ -122,7 +94,7 @@ function main() {
 
   const { appendUsage } = require(path.join(__dirname, '..', 'lib', 'work-actions'));
   appendUsage(found.marker.ticket, {
-    step: readStateStep(found.tasksBase, found.marker.ticket),
+    step: hookCommon.readStateStep(found.tasksBase, found.marker.ticket),
     agentType: resolveAgentType(evt),
     totalTokens: usage.totalTokens,
     toolUses: usage.toolUses,

--- a/plugins/work/scripts/workflows/work/hooks/context-monitor.js
+++ b/plugins/work/scripts/workflows/work/hooks/context-monitor.js
@@ -44,26 +44,6 @@ function safeTicket(ticket) {
   }
 }
 
-/**
- * Resolve the ticket's active step name from `.work-state.json`.
- * `currentStep` is 1-indexed into ALL_STEPS (mirrors capture-usage.readStateStep).
- * A missing/invalid state file yields 'unknown' rather than dropping the warning.
- */
-function readStateStep(tasksBase, ticket) {
-  try {
-    const statePath = path.join(tasksBase, safeTicket(ticket), '.work-state.json');
-    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
-    const { ALL_STEPS } = require(path.join(__dirname, '..', 'step-registry'));
-    const num = Number(state && state.currentStep);
-    if (Number.isFinite(num) && num >= 1 && num <= ALL_STEPS.length) {
-      return ALL_STEPS[num - 1];
-    }
-  } catch {
-    /* missing/corrupt state file */
-  }
-  return 'unknown';
-}
-
 /** Dispatched agent type: subagent_type / agentType input field, else tool name. */
 function resolveAgentType(evt) {
   const input = evt.toolInput || {};
@@ -154,7 +134,7 @@ function main() {
     percent,
     thresholds,
     newly,
-    step: readStateStep(found.tasksBase, ticket),
+    step: hookCommon.readStateStep(found.tasksBase, ticket),
     agent: resolveAgentType(evt),
   });
 

--- a/plugins/work/scripts/workflows/work/hooks/context-monitor.js
+++ b/plugins/work/scripts/workflows/work/hooks/context-monitor.js
@@ -7,10 +7,12 @@
  * 1. Scopes to the active /work session (`.work.pid` marker via
  *    `findRecentWorkMarker`) — a foreign/missing marker or a sub-agent context
  *    is a silent no-op.
- * 2. Reads cumulative context-token usage from the session's own transcript
- *    (`context-usage.readCumulativeUsage`, GH-313 Task 2).
- * 3. Computes the integer percent consumed against the model context limit
- *    (`context-policy`, GH-313 Task 1), honoring `WORK_CONTEXT_LIMIT`.
+ * 2. Reads the CURRENT context occupancy from the session's own transcript —
+ *    the most recent turn's usage, plus the transcript-reported context window
+ *    when present (`context-usage.readContextUsage`, GH-313 Task 2).
+ * 3. Computes the integer percent consumed against the context limit
+ *    (`context-policy`, GH-313 Task 1): `WORK_CONTEXT_LIMIT` override, else the
+ *    transcript's `model_context_window` (codex), else a 200000 default.
  * 4. Fires once per newly-crossed warning threshold (default 60/70/80, via
  *    `WORK_CONTEXT_WARN_THRESHOLDS`), tracked in a per-ticket crossed-threshold
  *    ledger (`<TASKS_BASE>/<safeTicketId>/.context-monitor.json`), and emits a
@@ -29,7 +31,7 @@ const path = require('path');
 
 const hookCommon = require(path.join(__dirname, '..', 'lib', 'hook-common'));
 const policy = require(path.join(__dirname, '..', 'lib', 'context-policy'));
-const { readCumulativeUsage } = require(path.join(__dirname, '..', 'lib', 'context-usage'));
+const { readContextUsage } = require(path.join(__dirname, '..', 'lib', 'context-usage'));
 
 hookCommon.installFailOpen();
 
@@ -84,8 +86,8 @@ function limitOverride() {
  * Compute the warning percent + newly-crossed thresholds for a dispatch.
  * @returns {{percent:number, thresholds:number[], newly:number[]}}
  */
-function computeCrossings(tokens, evt, alreadyCrossed) {
-  const limit = policy.modelContextLimit(evt.agent && evt.agent.type, limitOverride());
+function computeCrossings(tokens, contextWindow, alreadyCrossed) {
+  const limit = policy.resolveContextLimit(limitOverride(), contextWindow);
   const percent = policy.percentUsed(tokens, limit);
   const thresholds = policy.parseThresholds(process.env.WORK_CONTEXT_WARN_THRESHOLDS);
   const newly = policy.newlyCrossed(percent, thresholds, alreadyCrossed);
@@ -124,10 +126,10 @@ function main() {
   if (!found || !found.marker.ticket) process.exit(0);
 
   const ticket = found.marker.ticket;
-  const tokens = readCumulativeUsage(evt.transcriptPath);
+  const { tokens, contextWindow } = readContextUsage(evt.transcriptPath);
 
   const alreadyCrossed = readLedger(found.tasksBase, ticket);
-  const { percent, thresholds, newly } = computeCrossings(tokens, evt, alreadyCrossed);
+  const { percent, thresholds, newly } = computeCrossings(tokens, contextWindow, alreadyCrossed);
   if (newly.length === 0) process.exit(0);
 
   emitWarnings(rt, {

--- a/plugins/work/scripts/workflows/work/hooks/context-monitor.js
+++ b/plugins/work/scripts/workflows/work/hooks/context-monitor.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+/**
+ * context-monitor.js — PostToolUse hook for /work (GH-313).
+ *
+ * After each agent-dispatch tool completion (Task/Agent), this advisory hook:
+ * 1. Scopes to the active /work session (`.work.pid` marker via
+ *    `findRecentWorkMarker`) — a foreign/missing marker or a sub-agent context
+ *    is a silent no-op.
+ * 2. Reads cumulative context-token usage from the session's own transcript
+ *    (`context-usage.readCumulativeUsage`, GH-313 Task 2).
+ * 3. Computes the integer percent consumed against the model context limit
+ *    (`context-policy`, GH-313 Task 1), honoring `WORK_CONTEXT_LIMIT`.
+ * 4. Fires once per newly-crossed warning threshold (default 60/70/80, via
+ *    `WORK_CONTEXT_WARN_THRESHOLDS`), tracked in a per-ticket crossed-threshold
+ *    ledger (`<TASKS_BASE>/<safeTicketId>/.context-monitor.json`), and emits a
+ *    warning through `emit.context('PostToolUse', ...)` naming the active step,
+ *    the dispatched agent, and the percent. The highest threshold appends a
+ *    commit + fresh-agent recommendation.
+ *
+ * Fail-open (R6): the hook NEVER blocks a tool call and NEVER throws — any
+ * error exits 0 silently via `installFailOpen()`. `WORK_CONTEXT_MONITOR_ENABLED=0`
+ * short-circuits to a silent no-op (R9), mirroring `SESSION_GUARD_ENABLED`.
+ * Zero runtime dependencies, CommonJS.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const hookCommon = require(path.join(__dirname, '..', 'lib', 'hook-common'));
+const policy = require(path.join(__dirname, '..', 'lib', 'context-policy'));
+const { readCumulativeUsage } = require(path.join(__dirname, '..', 'lib', 'context-usage'));
+
+hookCommon.installFailOpen();
+
+const LEDGER_FILE = '.context-monitor.json';
+
+/** Sanitize a ticket id for a filesystem path (traversal-safe); raw id on failure. */
+function safeTicket(ticket) {
+  try {
+    return require(path.join(__dirname, '..', '..', 'lib', 'config')).safeTicketId(ticket);
+  } catch {
+    return ticket;
+  }
+}
+
+/**
+ * Resolve the ticket's active step name from `.work-state.json`.
+ * `currentStep` is 1-indexed into ALL_STEPS (mirrors capture-usage.readStateStep).
+ * A missing/invalid state file yields 'unknown' rather than dropping the warning.
+ */
+function readStateStep(tasksBase, ticket) {
+  try {
+    const statePath = path.join(tasksBase, safeTicket(ticket), '.work-state.json');
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    const { ALL_STEPS } = require(path.join(__dirname, '..', 'step-registry'));
+    const num = Number(state && state.currentStep);
+    if (Number.isFinite(num) && num >= 1 && num <= ALL_STEPS.length) {
+      return ALL_STEPS[num - 1];
+    }
+  } catch {
+    /* missing/corrupt state file */
+  }
+  return 'unknown';
+}
+
+/** Dispatched agent type: subagent_type / agentType input field, else tool name. */
+function resolveAgentType(evt) {
+  const input = evt.toolInput || {};
+  return input.subagent_type || input.agentType || evt.rawToolName || 'unknown';
+}
+
+/** Absolute path to a ticket's crossed-threshold ledger (traversal-safe). */
+function ledgerPath(tasksBase, ticket) {
+  return path.join(tasksBase, safeTicket(ticket), LEDGER_FILE);
+}
+
+/** Read the crossed-threshold list; [] for a missing/corrupt/absent ledger. */
+function readLedger(tasksBase, ticket) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(ledgerPath(tasksBase, ticket), 'utf8'));
+    return Array.isArray(parsed && parsed.crossed) ? parsed.crossed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Persist the merged crossed-threshold list, sorted ascending. */
+function writeLedger(tasksBase, ticket, crossed) {
+  try {
+    const sorted = [...new Set(crossed)].sort((a, b) => a - b);
+    fs.writeFileSync(ledgerPath(tasksBase, ticket), JSON.stringify({ crossed: sorted }));
+  } catch {
+    /* fail-open: an unwritable ledger must not break the tool call */
+  }
+}
+
+/** The context-limit override from WORK_CONTEXT_LIMIT (or undefined). */
+function limitOverride() {
+  return process.env.WORK_CONTEXT_LIMIT;
+}
+
+/**
+ * Compute the warning percent + newly-crossed thresholds for a dispatch.
+ * @returns {{percent:number, thresholds:number[], newly:number[]}}
+ */
+function computeCrossings(tokens, evt, alreadyCrossed) {
+  const limit = policy.modelContextLimit(evt.agent && evt.agent.type, limitOverride());
+  const percent = policy.percentUsed(tokens, limit);
+  const thresholds = policy.parseThresholds(process.env.WORK_CONTEXT_WARN_THRESHOLDS);
+  const newly = policy.newlyCrossed(percent, thresholds, alreadyCrossed);
+  return { percent, thresholds, newly };
+}
+
+/** Emit one warning per newly-crossed threshold; the top threshold is critical. */
+function emitWarnings(rt, ctx) {
+  const { percent, thresholds, newly, step, agent } = ctx;
+  const critical = Math.max(...thresholds);
+  for (const threshold of newly) {
+    rt.emit.context(
+      'PostToolUse',
+      policy.renderWarning({ percent, step, agent, threshold, isCritical: threshold === critical })
+    );
+  }
+}
+
+function main() {
+  // R9: disable switch — silent no-op, hook stays registered.
+  if (process.env.WORK_CONTEXT_MONITOR_ENABLED === '0') process.exit(0);
+
+  const hookData = hookCommon.readHookData();
+  if (!hookData) process.exit(0);
+
+  const { rt, evt } = hookCommon.normalizePostToolEvent(hookData);
+
+  // R7: never fire inside a sub-agent context.
+  if (rt.isSubagentContext(evt)) process.exit(0);
+
+  // Only agent-dispatch completions carry a meaningful post-dispatch checkpoint.
+  if (evt.toolKind !== 'agent') process.exit(0);
+
+  // R7: scope to this terminal's active /work session marker.
+  const found = hookCommon.findRecentWorkMarker();
+  if (!found || !found.marker.ticket) process.exit(0);
+
+  const ticket = found.marker.ticket;
+  const tokens = readCumulativeUsage(evt.transcriptPath);
+
+  const alreadyCrossed = readLedger(found.tasksBase, ticket);
+  const { percent, thresholds, newly } = computeCrossings(tokens, evt, alreadyCrossed);
+  if (newly.length === 0) process.exit(0);
+
+  emitWarnings(rt, {
+    percent,
+    thresholds,
+    newly,
+    step: readStateStep(found.tasksBase, ticket),
+    agent: resolveAgentType(evt),
+  });
+
+  writeLedger(found.tasksBase, ticket, [...alreadyCrossed, ...newly]);
+  process.exit(0);
+}
+
+main();

--- a/plugins/work/scripts/workflows/work/lib/__tests__/context-policy.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/context-policy.test.js
@@ -67,46 +67,40 @@ test('parseThresholds: returned default is a copy, not a shared mutable referenc
   assert.deepEqual(policy().parseThresholds(undefined), [60, 70, 80]);
 });
 
-// ─── modelContextLimit (R8 model→limit map + override) ───────────────────────
+// ─── resolveContextLimit (R8 override > transcript window > default) ──────────
 
-test('modelContextLimit: Opus → 200000', () => {
-  assert.equal(policy().modelContextLimit('claude-opus-4-8'), 200000);
+test('resolveContextLimit: WORK_CONTEXT_LIMIT override wins over the window', () => {
+  assert.equal(policy().resolveContextLimit(500000, 258400), 500000);
 });
 
-test('modelContextLimit: Sonnet → 200000', () => {
-  assert.equal(policy().modelContextLimit('claude-sonnet-4-5'), 200000);
+test('resolveContextLimit: uses the transcript window when there is no override', () => {
+  assert.equal(policy().resolveContextLimit(undefined, 258400), 258400);
 });
 
-test('modelContextLimit: Haiku → 200000', () => {
-  assert.equal(policy().modelContextLimit('claude-haiku-4'), 200000);
+test('resolveContextLimit: no override and no window → safe default 200000', () => {
+  assert.equal(policy().resolveContextLimit(undefined, 0), 200000);
+  assert.equal(policy().resolveContextLimit(undefined, undefined), 200000);
 });
 
-test('modelContextLimit: unknown model → safe default 200000', () => {
-  assert.equal(policy().modelContextLimit('some-unknown-model'), 200000);
+test('resolveContextLimit: invalid (non-numeric) override is ignored, falls back to the window', () => {
+  assert.equal(policy().resolveContextLimit('not-a-number', 258400), 258400);
 });
 
-test('modelContextLimit: undefined model → safe default 200000', () => {
-  assert.equal(policy().modelContextLimit(undefined), 200000);
+test('resolveContextLimit: zero/negative override is ignored, falls back to the window', () => {
+  assert.equal(policy().resolveContextLimit(0, 258400), 258400);
+  assert.equal(policy().resolveContextLimit(-5, 258400), 258400);
 });
 
-test('modelContextLimit: integer override honored over the map', () => {
-  assert.equal(policy().modelContextLimit('claude-opus-4-8', 500000), 500000);
+test('resolveContextLimit: invalid override AND invalid window → default 200000', () => {
+  assert.equal(policy().resolveContextLimit('nope', 'also-nope'), 200000);
+  assert.equal(policy().resolveContextLimit(-1, -1), 200000);
 });
 
-test('modelContextLimit: override honored even for an unknown model', () => {
-  assert.equal(policy().modelContextLimit('mystery', 123456), 123456);
+test('resolveContextLimit: a large window (>200k) is honored, not clamped to the default', () => {
+  assert.equal(policy().resolveContextLimit(undefined, 1000000), 1000000);
 });
 
-test('modelContextLimit: invalid (non-numeric) override is ignored, falls back to map', () => {
-  assert.equal(policy().modelContextLimit('claude-opus-4-8', 'not-a-number'), 200000);
-});
-
-test('modelContextLimit: zero/negative override is ignored, falls back to map', () => {
-  assert.equal(policy().modelContextLimit('claude-opus-4-8', 0), 200000);
-  assert.equal(policy().modelContextLimit('claude-opus-4-8', -5), 200000);
-});
-
-test('modelContextLimit: DEFAULT_CONTEXT_LIMIT constant is 200000', () => {
+test('resolveContextLimit: DEFAULT_CONTEXT_LIMIT constant is 200000', () => {
   assert.equal(policy().DEFAULT_CONTEXT_LIMIT, 200000);
 });
 

--- a/plugins/work/scripts/workflows/work/lib/__tests__/context-policy.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/context-policy.test.js
@@ -1,0 +1,222 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// Lazily require the module UNDER TEST inside each test body. During the RED
+// phase the source file does not exist yet. A top-level require — or an
+// uncaught require inside a test — surfaces the runtime's "Cannot find module"
+// / "MODULE_NOT_FOUND" text in the runner output, which the RED gate flags as
+// a structural load failure rather than a behavior gap. We catch that specific
+// bootstrap error and re-fail with a clean, signature-free assertion message
+// so the RED failure reflects the missing behavior (unimplemented exports),
+// not a broken test file. Once the source lands (GREEN), the require succeeds
+// and the real assertions run.
+function policy() {
+  try {
+    return require('../context-policy');
+  } catch (err) {
+    if (err && err.code === 'MODULE_NOT_FOUND') {
+      assert.fail('context-policy not implemented yet (unimplemented behavior)');
+    }
+    throw err;
+  }
+}
+
+// ─── parseThresholds (R2 default 60/70/80, R3 parse-with-fallback) ───────────
+
+test('parseThresholds: "50,90" → [50,90]', () => {
+  assert.deepEqual(policy().parseThresholds('50,90'), [50, 90]);
+});
+
+test('parseThresholds: sorts ascending and dedupes → "80,60,70,60" → [60,70,80]', () => {
+  assert.deepEqual(policy().parseThresholds('80,60,70,60'), [60, 70, 80]);
+});
+
+test('parseThresholds: tolerates surrounding whitespace → " 50 , 90 " → [50,90]', () => {
+  assert.deepEqual(policy().parseThresholds(' 50 , 90 '), [50, 90]);
+});
+
+test('parseThresholds: missing (undefined) → default [60,70,80]', () => {
+  assert.deepEqual(policy().parseThresholds(undefined), [60, 70, 80]);
+});
+
+test('parseThresholds: null → default [60,70,80]', () => {
+  assert.deepEqual(policy().parseThresholds(null), [60, 70, 80]);
+});
+
+test('parseThresholds: empty string → default [60,70,80]', () => {
+  assert.deepEqual(policy().parseThresholds(''), [60, 70, 80]);
+});
+
+test('parseThresholds: "not-a-number" → default [60,70,80]', () => {
+  assert.deepEqual(policy().parseThresholds('not-a-number'), [60, 70, 80]);
+});
+
+test('parseThresholds: fully invalid list "abc,,xyz" → default [60,70,80]', () => {
+  assert.deepEqual(policy().parseThresholds('abc,,xyz'), [60, 70, 80]);
+});
+
+test('parseThresholds: DEFAULT_THRESHOLDS constant is [60,70,80]', () => {
+  assert.deepEqual(policy().DEFAULT_THRESHOLDS, [60, 70, 80]);
+});
+
+test('parseThresholds: returned default is a copy, not a shared mutable reference', () => {
+  const first = policy().parseThresholds(undefined);
+  first.push(999);
+  assert.deepEqual(policy().parseThresholds(undefined), [60, 70, 80]);
+});
+
+// ─── modelContextLimit (R8 model→limit map + override) ───────────────────────
+
+test('modelContextLimit: Opus → 200000', () => {
+  assert.equal(policy().modelContextLimit('claude-opus-4-8'), 200000);
+});
+
+test('modelContextLimit: Sonnet → 200000', () => {
+  assert.equal(policy().modelContextLimit('claude-sonnet-4-5'), 200000);
+});
+
+test('modelContextLimit: Haiku → 200000', () => {
+  assert.equal(policy().modelContextLimit('claude-haiku-4'), 200000);
+});
+
+test('modelContextLimit: unknown model → safe default 200000', () => {
+  assert.equal(policy().modelContextLimit('some-unknown-model'), 200000);
+});
+
+test('modelContextLimit: undefined model → safe default 200000', () => {
+  assert.equal(policy().modelContextLimit(undefined), 200000);
+});
+
+test('modelContextLimit: integer override honored over the map', () => {
+  assert.equal(policy().modelContextLimit('claude-opus-4-8', 500000), 500000);
+});
+
+test('modelContextLimit: override honored even for an unknown model', () => {
+  assert.equal(policy().modelContextLimit('mystery', 123456), 123456);
+});
+
+test('modelContextLimit: invalid (non-numeric) override is ignored, falls back to map', () => {
+  assert.equal(policy().modelContextLimit('claude-opus-4-8', 'not-a-number'), 200000);
+});
+
+test('modelContextLimit: zero/negative override is ignored, falls back to map', () => {
+  assert.equal(policy().modelContextLimit('claude-opus-4-8', 0), 200000);
+  assert.equal(policy().modelContextLimit('claude-opus-4-8', -5), 200000);
+});
+
+test('modelContextLimit: DEFAULT_CONTEXT_LIMIT constant is 200000', () => {
+  assert.equal(policy().DEFAULT_CONTEXT_LIMIT, 200000);
+});
+
+// ─── percentUsed (R4 integer floor percent, zero-guard, clamp) ───────────────
+
+test('percentUsed: percentUsed(124000, 200000) → 62 (integer floor)', () => {
+  assert.equal(policy().percentUsed(124000, 200000), 62);
+});
+
+test('percentUsed: floors rather than rounds → 131000/200000 = 65.5 → 65', () => {
+  assert.equal(policy().percentUsed(131000, 200000), 65);
+});
+
+test('percentUsed: divide-by-zero guard → limit 0 → 0', () => {
+  assert.equal(policy().percentUsed(124000, 0), 0);
+});
+
+test('percentUsed: clamps at 100 when usage exceeds the limit', () => {
+  assert.equal(policy().percentUsed(250000, 200000), 100);
+});
+
+test('percentUsed: exactly at the limit → 100', () => {
+  assert.equal(policy().percentUsed(200000, 200000), 100);
+});
+
+test('percentUsed: zero usage → 0', () => {
+  assert.equal(policy().percentUsed(0, 200000), 0);
+});
+
+// ─── newlyCrossed (R2 fire once per crossed threshold) ───────────────────────
+
+test('newlyCrossed: 62% with [60,70,80], none crossed → only [60]', () => {
+  assert.deepEqual(policy().newlyCrossed(62, [60, 70, 80], []), [60]);
+});
+
+test('newlyCrossed: 62% with 60 already crossed → [] (no repeat)', () => {
+  assert.deepEqual(policy().newlyCrossed(62, [60, 70, 80], [60]), []);
+});
+
+test('newlyCrossed: 85% with [60,70,80], 60 already crossed → [70,80] ascending', () => {
+  assert.deepEqual(policy().newlyCrossed(85, [60, 70, 80], [60]), [70, 80]);
+});
+
+test('newlyCrossed: 85% none crossed, unsorted input → [60,70,80] ascending', () => {
+  assert.deepEqual(policy().newlyCrossed(85, [80, 60, 70], []), [60, 70, 80]);
+});
+
+test('newlyCrossed: threshold equal to percent counts as crossed (<=)', () => {
+  assert.deepEqual(policy().newlyCrossed(60, [60, 70, 80], []), [60]);
+});
+
+test('newlyCrossed: below the first threshold → []', () => {
+  assert.deepEqual(policy().newlyCrossed(55, [60, 70, 80], []), []);
+});
+
+test('newlyCrossed: all thresholds already crossed → []', () => {
+  assert.deepEqual(policy().newlyCrossed(85, [60, 70, 80], [60, 70, 80]), []);
+});
+
+// ─── renderWarning (R4 step+agent+percent, R5 critical recommendation) ───────
+
+function warning(overrides = {}) {
+  return policy().renderWarning({
+    percent: 62,
+    step: 'implement',
+    agent: 'developer-nodejs-tdd',
+    threshold: 60,
+    isCritical: false,
+    ...overrides,
+  });
+}
+
+test('renderWarning: contains the step name', () => {
+  assert.match(warning(), /implement/);
+});
+
+test('renderWarning: contains the agent/tool name', () => {
+  assert.match(warning(), /developer-nodejs-tdd/);
+});
+
+test('renderWarning: contains the integer percent as "62%"', () => {
+  assert.match(warning(), /62%/);
+});
+
+test('renderWarning: non-critical does NOT contain the fresh-agent recommendation', () => {
+  assert.doesNotMatch(warning(), /fresh agent/i);
+});
+
+test('renderWarning: critical contains a recommendation to commit current work', () => {
+  assert.match(warning({ percent: 85, threshold: 80, isCritical: true }), /commit/i);
+});
+
+test('renderWarning: critical contains a recommendation to spawn a fresh agent', () => {
+  assert.match(warning({ percent: 85, threshold: 80, isCritical: true }), /fresh agent/i);
+});
+
+test('renderWarning: critical still names step, agent, and percent', () => {
+  const msg = warning({
+    percent: 85,
+    step: 'commit',
+    agent: 'commit-writer',
+    threshold: 80,
+    isCritical: true,
+  });
+  assert.match(msg, /commit-writer/);
+  assert.match(msg, /85%/);
+});
+
+test('renderWarning: returns a non-empty string', () => {
+  const msg = warning();
+  assert.equal(typeof msg, 'string');
+  assert.ok(msg.length > 0);
+});

--- a/plugins/work/scripts/workflows/work/lib/__tests__/context-usage.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/context-usage.test.js
@@ -66,42 +66,72 @@ function claudeTurn({ input = 0, output = 0, cacheRead = 0, cacheCreate = 0 } = 
 }
 
 /**
- * A codex-shaped `token_count` record. `total_token_usage` is CUMULATIVE (a
- * running total re-emitted each turn), mirroring
- * tests/fixtures/runtime/codex/rollout.jsonl.
+ * A codex-shaped `token_count` record. `total_token_usage` is a CUMULATIVE
+ * running total; `last_token_usage` is the MOST RECENT turn's usage (the
+ * current-occupancy signal). `model_context_window` is the real context limit.
+ * Mirrors tests/fixtures/runtime/codex/rollout.jsonl.
+ *
+ *   - `total`      → last_token_usage.total_tokens (this turn's occupancy)
+ *   - `cumulative` → total_token_usage.total_tokens (session running total)
+ *   - `omitLast`   → legacy shape carrying only total_token_usage
  */
-function codexTokenCount({ input = 0, output = 0, cached = 0, reasoning = 0, total } = {}) {
-  const totalTokens = total === undefined ? input + output : total;
-  return {
-    type: 'event_msg',
-    payload: {
-      type: 'token_count',
-      info: {
-        total_token_usage: {
-          input_tokens: input,
-          cached_input_tokens: cached,
-          output_tokens: output,
-          reasoning_output_tokens: reasoning,
-          total_tokens: totalTokens,
-        },
-        model_context_window: 258400,
-      },
+function codexTokenCount({
+  input = 0,
+  output = 0,
+  total,
+  cumulative,
+  window = 258400,
+  omitLast = false,
+} = {}) {
+  const lastTotal = total === undefined ? input + output : total;
+  const info = {
+    total_token_usage: {
+      input_tokens: input,
+      cached_input_tokens: 0,
+      output_tokens: output,
+      reasoning_output_tokens: 0,
+      total_tokens: cumulative === undefined ? lastTotal : cumulative,
     },
+    model_context_window: window,
   };
+  if (!omitLast) {
+    info.last_token_usage = {
+      input_tokens: input,
+      cached_input_tokens: 0,
+      output_tokens: output,
+      reasoning_output_tokens: 0,
+      total_tokens: lastTotal,
+    };
+  }
+  return { type: 'event_msg', payload: { type: 'token_count', info } };
 }
 
-// ─── R1: cumulative per-turn usage summation ─────────────────────────────────
+// ─── R1: current occupancy = the LAST turn, not the cross-turn sum ────────────
 
-test('readCumulativeUsage: sums input+output across turns to the expected total (124000)', () => {
+test('readCumulativeUsage: returns the LAST turn occupancy, not the cross-turn sum', () => {
+  // Summing (40000+20000)+(44000+20000)=124000 is the B1 over-count. The
+  // current occupancy is the most recent turn only: 44000+20000 = 64000.
   const file = writeTranscript([
     { type: 'user', message: { role: 'user' } },
     claudeTurn({ input: 40000, output: 20000 }),
     claudeTurn({ input: 44000, output: 20000 }),
   ]);
-  assert.equal(usage().readCumulativeUsage(file), 124000);
+  assert.equal(usage().readCumulativeUsage(file), 64000);
 });
 
-test('readCumulativeUsage: counts cache token fields when present', () => {
+test('readCumulativeUsage: multi-turn growing cache_read is NOT summed (B1 regression)', () => {
+  // Each turn re-sends the prior context as cache_read — the exact pattern that
+  // makes a cross-turn sum explode. Summing the three occupancies would give
+  // 6000+9500+13500=29000; the correct current occupancy is the last turn only.
+  const file = writeTranscript([
+    claudeTurn({ input: 5000, output: 1000, cacheRead: 0 }), // occ 6000
+    claudeTurn({ input: 2000, output: 1500, cacheRead: 6000 }), // occ 9500
+    claudeTurn({ input: 2000, output: 2000, cacheRead: 9500 }), // occ 13500
+  ]);
+  assert.equal(usage().readCumulativeUsage(file), 13500);
+});
+
+test('readCumulativeUsage: counts cache token fields on the last turn', () => {
   const file = writeTranscript([
     claudeTurn({ input: 1000, output: 500, cacheRead: 2000, cacheCreate: 300 }),
   ]);
@@ -113,13 +143,18 @@ test('readCumulativeUsage: a single turn with only input+output', () => {
   assert.equal(usage().readCumulativeUsage(file), 124000);
 });
 
-test('readCumulativeUsage: turns with no usage block contribute zero', () => {
+test('readCumulativeUsage: trailing non-usage records do not reset the last occupancy', () => {
   const file = writeTranscript([
+    claudeTurn({ input: 100, output: 24 }),
     { type: 'user', message: { role: 'user' } },
     { type: 'summary', summary: 'nothing here' },
-    claudeTurn({ input: 100, output: 24 }),
   ]);
   assert.equal(usage().readCumulativeUsage(file), 124);
+});
+
+test('readContextUsage: claude reports { tokens, contextWindow: 0 } (no window in transcript)', () => {
+  const file = writeTranscript([claudeTurn({ input: 100, output: 24 })]);
+  assert.deepEqual(usage().readContextUsage(file), { tokens: 124, contextWindow: 0 });
 });
 
 // ─── R1/R8/R12: fail-safe reads ──────────────────────────────────────────────
@@ -141,13 +176,18 @@ test('readCumulativeUsage: undefined path → 0 and never throws', () => {
   assert.equal(result, 0);
 });
 
+test('readContextUsage: nonexistent path → { tokens: 0, contextWindow: 0 }', () => {
+  const missing = path.join(tmpDir, 'nope.jsonl');
+  assert.deepEqual(usage().readContextUsage(missing), { tokens: 0, contextWindow: 0 });
+});
+
 test('readCumulativeUsage: empty file → 0', () => {
   const file = path.join(tmpDir, 'empty.jsonl');
   fs.writeFileSync(file, '');
   assert.equal(usage().readCumulativeUsage(file), 0);
 });
 
-test('readCumulativeUsage: a malformed JSONL line is skipped, remaining turns still sum', () => {
+test('readCumulativeUsage: a malformed JSONL line is skipped, last valid turn wins', () => {
   const file = writeTranscript([
     claudeTurn({ input: 1000, output: 200 }),
     '{ this is not valid json',
@@ -157,10 +197,10 @@ test('readCumulativeUsage: a malformed JSONL line is skipped, remaining turns st
   assert.doesNotThrow(() => {
     result = usage().readCumulativeUsage(file);
   });
-  assert.equal(result, 5000);
+  assert.equal(result, 3800);
 });
 
-test('readCumulativeUsage: blank lines are ignored', () => {
+test('readCumulativeUsage: blank lines are ignored, last turn wins', () => {
   const file = path.join(tmpDir, 'blanks.jsonl');
   fs.writeFileSync(
     file,
@@ -168,37 +208,74 @@ test('readCumulativeUsage: blank lines are ignored', () => {
       claudeTurn({ input: 20, output: 5 })
     )}\n`
   );
-  assert.equal(usage().readCumulativeUsage(file), 40);
+  assert.equal(usage().readCumulativeUsage(file), 25);
 });
 
-// ─── Codex leg: cumulative token_count snapshots (last wins, no double-count) ─
+// ─── B3: bounded tail read (last-turn occupancy lives at the file's end) ──────
 
-test('readCumulativeUsage: codex takes the LAST token_count cumulative total, not the sum', () => {
-  // total_token_usage is CUMULATIVE — summing the two snapshots (13043 + 20100)
-  // would over-count. The reader must return only the last snapshot (20100).
+test('readCumulativeUsage: reads the last-turn occupancy from a large transcript (tail scan)', () => {
+  const filler = Array.from({ length: 8000 }, (_, i) =>
+    JSON.stringify({ type: 'noise', i, pad: 'x'.repeat(90) })
+  );
+  const file = path.join(tmpDir, 'big.jsonl');
+  const lastTurn = JSON.stringify(claudeTurn({ input: 5000, output: 1200 }));
+  fs.writeFileSync(file, `${[...filler, lastTurn].join('\n')}\n`);
+  assert.equal(usage().readCumulativeUsage(file), 6200);
+});
+
+test('readCumulativeUsage: falls back to a full read when the only usage turn precedes the tail window', () => {
+  const head = JSON.stringify(claudeTurn({ input: 7000, output: 800 }));
+  const filler = Array.from({ length: 9000 }, (_, i) =>
+    JSON.stringify({ type: 'noise', i, pad: 'x'.repeat(90) })
+  );
+  const file = path.join(tmpDir, 'head-usage.jsonl');
+  fs.writeFileSync(file, `${[head, ...filler].join('\n')}\n`);
+  // The last 512KB (the tail slice) is pure filler — the fallback full read
+  // must still find the head usage turn.
+  assert.equal(usage().readCumulativeUsage(file), 7800);
+});
+
+// ─── Codex leg: last-turn occupancy from last_token_usage (not cumulative) ────
+
+test('readCumulativeUsage: codex uses the last turn last_token_usage, not the cumulative total', () => {
+  // total_token_usage is a running COST total (33143 after two turns); the
+  // current occupancy is the last snapshot's last_token_usage (20100).
   const file = writeTranscript([
     { type: 'session_meta', payload: { session_id: 'x' } },
-    codexTokenCount({ input: 12950, output: 93, total: 13043 }),
+    codexTokenCount({ input: 12950, output: 93, total: 13043, cumulative: 13043 }),
     { type: 'response_item', payload: { type: 'message', role: 'assistant' } },
-    codexTokenCount({ input: 19000, output: 1100, total: 20100 }),
+    codexTokenCount({ input: 19000, output: 1100, total: 20100, cumulative: 33143 }),
   ]);
   assert.equal(usage().readCumulativeUsage(file), 20100);
 });
 
-test('readCumulativeUsage: codex prefers total_tokens over summing the fields', () => {
-  // total_tokens (13043) is authoritative even though input+output (13000+43) differ.
+test('readCumulativeUsage: codex prefers last_token_usage.total_tokens over summing fields', () => {
+  // total_tokens (50000) is authoritative even though input+output (13000+43) differ.
   const file = writeTranscript([
     { type: 'session_meta', payload: { session_id: 'x' } },
-    codexTokenCount({ input: 13000, output: 43, total: 13043 }),
+    codexTokenCount({ input: 13000, output: 43, total: 50000, cumulative: 50000 }),
   ]);
-  assert.equal(usage().readCumulativeUsage(file), 13043);
+  assert.equal(usage().readCumulativeUsage(file), 50000);
 });
 
-test('readCumulativeUsage: codex falls back to summing input+output when total_tokens is absent', () => {
+test('readCumulativeUsage: codex sums input+output when last_token_usage.total_tokens is absent', () => {
   const rec = codexTokenCount({ input: 8000, output: 500 });
-  delete rec.payload.info.total_token_usage.total_tokens;
+  delete rec.payload.info.last_token_usage.total_tokens;
   const file = writeTranscript([{ type: 'session_meta', payload: { session_id: 'x' } }, rec]);
   assert.equal(usage().readCumulativeUsage(file), 8500);
+});
+
+test('readCumulativeUsage: codex falls back to total_token_usage when last_token_usage is absent (legacy)', () => {
+  const rec = codexTokenCount({ input: 7000, output: 0, cumulative: 7000, omitLast: true });
+  const file = writeTranscript([{ type: 'session_meta', payload: { session_id: 'x' } }, rec]);
+  assert.equal(usage().readCumulativeUsage(file), 7000);
+});
+
+test('readContextUsage: codex surfaces the model_context_window as the limit', () => {
+  const file = writeTranscript([
+    codexTokenCount({ input: 100, output: 10, total: 110, cumulative: 110, window: 258400 }),
+  ]);
+  assert.deepEqual(usage().readContextUsage(file), { tokens: 110, contextWindow: 258400 });
 });
 
 test('readCumulativeUsage: codex with no token_count records → 0', () => {
@@ -209,12 +286,12 @@ test('readCumulativeUsage: codex with no token_count records → 0', () => {
   assert.equal(usage().readCumulativeUsage(file), 0);
 });
 
-test('readCumulativeUsage: codex skips a malformed line and still returns the last valid total', () => {
+test('readCumulativeUsage: codex skips a malformed line and still returns the last valid occupancy', () => {
   const file = writeTranscript([
     { type: 'session_meta', payload: { session_id: 'x' } },
-    codexTokenCount({ input: 100, output: 10, total: 110 }),
+    codexTokenCount({ input: 100, output: 10, total: 110, cumulative: 110 }),
     '{ not valid json',
-    codexTokenCount({ input: 200, output: 20, total: 220 }),
+    codexTokenCount({ input: 200, output: 20, total: 220, cumulative: 330 }),
   ]);
   let result;
   assert.doesNotThrow(() => {

--- a/plugins/work/scripts/workflows/work/lib/__tests__/context-usage.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/context-usage.test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Lazily require the module UNDER TEST inside each test body. During the RED
+// phase the source file does not exist yet. A top-level (or uncaught in-test)
+// require surfaces the runtime's "Cannot find module" / "MODULE_NOT_FOUND"
+// text in the runner output, which the RED gate flags as a structural load
+// failure rather than a behavior gap. We catch that specific bootstrap error
+// and re-fail with a clean, signature-free assertion message so the RED
+// failure reflects the missing behavior (unimplemented exports). Once the
+// source lands (GREEN) the require succeeds and the real assertions run.
+function usage() {
+  try {
+    return require('../context-usage');
+  } catch (err) {
+    if (err && err.code === 'MODULE_NOT_FOUND') {
+      assert.fail('context-usage not implemented yet (unimplemented behavior)');
+    }
+    throw err;
+  }
+}
+
+// ─── Temp-fixture helpers ────────────────────────────────────────────────────
+
+let tmpDir;
+
+test.beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctx-usage-'));
+});
+
+test.afterEach(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = null;
+});
+
+/**
+ * Write JSONL lines (objects → JSON, raw strings passed through verbatim so a
+ * test can inject a deliberately corrupt line) to a temp transcript file.
+ */
+function writeTranscript(lines) {
+  const file = path.join(tmpDir, 'transcript.jsonl');
+  const body = lines.map((l) => (typeof l === 'string' ? l : JSON.stringify(l))).join('\n');
+  fs.writeFileSync(file, `${body}\n`);
+  return file;
+}
+
+/** A claude-shaped assistant turn carrying a nested message.usage block. */
+function claudeTurn({ input = 0, output = 0, cacheRead = 0, cacheCreate = 0 } = {}) {
+  return {
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      usage: {
+        input_tokens: input,
+        output_tokens: output,
+        cache_read_input_tokens: cacheRead,
+        cache_creation_input_tokens: cacheCreate,
+      },
+    },
+  };
+}
+
+// ─── R1: cumulative per-turn usage summation ─────────────────────────────────
+
+test('readCumulativeUsage: sums input+output across turns to the expected total (124000)', () => {
+  const file = writeTranscript([
+    { type: 'user', message: { role: 'user' } },
+    claudeTurn({ input: 40000, output: 20000 }),
+    claudeTurn({ input: 44000, output: 20000 }),
+  ]);
+  assert.equal(usage().readCumulativeUsage(file), 124000);
+});
+
+test('readCumulativeUsage: counts cache token fields when present', () => {
+  const file = writeTranscript([
+    claudeTurn({ input: 1000, output: 500, cacheRead: 2000, cacheCreate: 300 }),
+  ]);
+  assert.equal(usage().readCumulativeUsage(file), 3800);
+});
+
+test('readCumulativeUsage: a single turn with only input+output', () => {
+  const file = writeTranscript([claudeTurn({ input: 62000, output: 62000 })]);
+  assert.equal(usage().readCumulativeUsage(file), 124000);
+});
+
+test('readCumulativeUsage: turns with no usage block contribute zero', () => {
+  const file = writeTranscript([
+    { type: 'user', message: { role: 'user' } },
+    { type: 'summary', summary: 'nothing here' },
+    claudeTurn({ input: 100, output: 24 }),
+  ]);
+  assert.equal(usage().readCumulativeUsage(file), 124);
+});
+
+// ─── R1/R8/R12: fail-safe reads ──────────────────────────────────────────────
+
+test('readCumulativeUsage: nonexistent path → 0 and never throws', () => {
+  const missing = path.join(tmpDir, 'does-not-exist.jsonl');
+  let result;
+  assert.doesNotThrow(() => {
+    result = usage().readCumulativeUsage(missing);
+  });
+  assert.equal(result, 0);
+});
+
+test('readCumulativeUsage: undefined path → 0 and never throws', () => {
+  let result;
+  assert.doesNotThrow(() => {
+    result = usage().readCumulativeUsage(undefined);
+  });
+  assert.equal(result, 0);
+});
+
+test('readCumulativeUsage: empty file → 0', () => {
+  const file = path.join(tmpDir, 'empty.jsonl');
+  fs.writeFileSync(file, '');
+  assert.equal(usage().readCumulativeUsage(file), 0);
+});
+
+test('readCumulativeUsage: a malformed JSONL line is skipped, remaining turns still sum', () => {
+  const file = writeTranscript([
+    claudeTurn({ input: 1000, output: 200 }),
+    '{ this is not valid json',
+    claudeTurn({ input: 3000, output: 800 }),
+  ]);
+  let result;
+  assert.doesNotThrow(() => {
+    result = usage().readCumulativeUsage(file);
+  });
+  assert.equal(result, 5000);
+});
+
+test('readCumulativeUsage: blank lines are ignored', () => {
+  const file = path.join(tmpDir, 'blanks.jsonl');
+  fs.writeFileSync(
+    file,
+    `${JSON.stringify(claudeTurn({ input: 10, output: 5 }))}\n\n\n${JSON.stringify(
+      claudeTurn({ input: 20, output: 5 })
+    )}\n`
+  );
+  assert.equal(usage().readCumulativeUsage(file), 40);
+});

--- a/plugins/work/scripts/workflows/work/lib/__tests__/context-usage.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/context-usage.test.js
@@ -65,6 +65,31 @@ function claudeTurn({ input = 0, output = 0, cacheRead = 0, cacheCreate = 0 } = 
   };
 }
 
+/**
+ * A codex-shaped `token_count` record. `total_token_usage` is CUMULATIVE (a
+ * running total re-emitted each turn), mirroring
+ * tests/fixtures/runtime/codex/rollout.jsonl.
+ */
+function codexTokenCount({ input = 0, output = 0, cached = 0, reasoning = 0, total } = {}) {
+  const totalTokens = total === undefined ? input + output : total;
+  return {
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        total_token_usage: {
+          input_tokens: input,
+          cached_input_tokens: cached,
+          output_tokens: output,
+          reasoning_output_tokens: reasoning,
+          total_tokens: totalTokens,
+        },
+        model_context_window: 258400,
+      },
+    },
+  };
+}
+
 // ─── R1: cumulative per-turn usage summation ─────────────────────────────────
 
 test('readCumulativeUsage: sums input+output across turns to the expected total (124000)', () => {
@@ -144,4 +169,56 @@ test('readCumulativeUsage: blank lines are ignored', () => {
     )}\n`
   );
   assert.equal(usage().readCumulativeUsage(file), 40);
+});
+
+// ─── Codex leg: cumulative token_count snapshots (last wins, no double-count) ─
+
+test('readCumulativeUsage: codex takes the LAST token_count cumulative total, not the sum', () => {
+  // total_token_usage is CUMULATIVE — summing the two snapshots (13043 + 20100)
+  // would over-count. The reader must return only the last snapshot (20100).
+  const file = writeTranscript([
+    { type: 'session_meta', payload: { session_id: 'x' } },
+    codexTokenCount({ input: 12950, output: 93, total: 13043 }),
+    { type: 'response_item', payload: { type: 'message', role: 'assistant' } },
+    codexTokenCount({ input: 19000, output: 1100, total: 20100 }),
+  ]);
+  assert.equal(usage().readCumulativeUsage(file), 20100);
+});
+
+test('readCumulativeUsage: codex prefers total_tokens over summing the fields', () => {
+  // total_tokens (13043) is authoritative even though input+output (13000+43) differ.
+  const file = writeTranscript([
+    { type: 'session_meta', payload: { session_id: 'x' } },
+    codexTokenCount({ input: 13000, output: 43, total: 13043 }),
+  ]);
+  assert.equal(usage().readCumulativeUsage(file), 13043);
+});
+
+test('readCumulativeUsage: codex falls back to summing input+output when total_tokens is absent', () => {
+  const rec = codexTokenCount({ input: 8000, output: 500 });
+  delete rec.payload.info.total_token_usage.total_tokens;
+  const file = writeTranscript([{ type: 'session_meta', payload: { session_id: 'x' } }, rec]);
+  assert.equal(usage().readCumulativeUsage(file), 8500);
+});
+
+test('readCumulativeUsage: codex with no token_count records → 0', () => {
+  const file = writeTranscript([
+    { type: 'session_meta', payload: { session_id: 'x' } },
+    { type: 'response_item', payload: { type: 'message', role: 'user' } },
+  ]);
+  assert.equal(usage().readCumulativeUsage(file), 0);
+});
+
+test('readCumulativeUsage: codex skips a malformed line and still returns the last valid total', () => {
+  const file = writeTranscript([
+    { type: 'session_meta', payload: { session_id: 'x' } },
+    codexTokenCount({ input: 100, output: 10, total: 110 }),
+    '{ not valid json',
+    codexTokenCount({ input: 200, output: 20, total: 220 }),
+  ]);
+  let result;
+  assert.doesNotThrow(() => {
+    result = usage().readCumulativeUsage(file);
+  });
+  assert.equal(result, 220);
 });

--- a/plugins/work/scripts/workflows/work/lib/context-policy.js
+++ b/plugins/work/scripts/workflows/work/lib/context-policy.js
@@ -9,29 +9,24 @@
  * call them without a try/catch of its own.
  *
  * Exports:
- *   - parseThresholds(raw)              → sorted, unique, default-on-invalid %s
- *   - modelContextLimit(model, override)→ token limit with a safe 200000 default
- *   - percentUsed(tokens, limit)        → integer floor percent, clamped [0,100]
- *   - newlyCrossed(pct, thresholds, hit)→ once-per-threshold crossing decision
- *   - renderWarning({...})              → human-readable warning string
+ *   - parseThresholds(raw)                 → sorted, unique, default-on-invalid %s
+ *   - resolveContextLimit(override, window)→ token limit: override > window > default
+ *   - percentUsed(tokens, limit)           → integer floor percent, clamped [0,100]
+ *   - newlyCrossed(pct, thresholds, hit)   → once-per-threshold crossing decision
+ *   - renderWarning({...})                 → human-readable warning string
  */
 
 /** Default warning thresholds (percent of context limit). */
 const DEFAULT_THRESHOLDS = Object.freeze([60, 70, 80]);
 
-/** Safe default / per-model context-token limit. */
-const DEFAULT_CONTEXT_LIMIT = 200000;
-
 /**
- * Model → context-token-limit map. Opus / Sonnet / Haiku all currently share a
- * 200000-token window; matching is by lower-cased substring so version-suffixed
- * ids (e.g. `claude-opus-4-8`) resolve without an exhaustive id table.
+ * Safe default context-token limit, used only when neither an explicit
+ * `WORK_CONTEXT_LIMIT` override nor a transcript-reported `model_context_window`
+ * is available. Claude transcripts do not report a window, so a Claude session
+ * falls back to this unless the operator sets `WORK_CONTEXT_LIMIT`; codex
+ * transcripts carry the real window and use it directly.
  */
-const MODEL_LIMITS = Object.freeze([
-  Object.freeze({ match: 'opus', limit: 200000 }),
-  Object.freeze({ match: 'sonnet', limit: 200000 }),
-  Object.freeze({ match: 'haiku', limit: 200000 }),
-]);
+const DEFAULT_CONTEXT_LIMIT = 200000;
 
 /**
  * Coerce a value to a positive, finite integer, or return null.
@@ -72,23 +67,23 @@ function parseThresholds(raw) {
 }
 
 /**
- * Resolve the context-token limit for a model, honoring an explicit override.
- * A valid positive-integer `override` (from `WORK_CONTEXT_LIMIT`) wins over the
- * model map; an invalid override is ignored. An unknown / undefined model
- * falls back to `DEFAULT_CONTEXT_LIMIT`.
+ * Resolve the context-token limit from, in priority order: a valid
+ * positive-integer `override` (from `WORK_CONTEXT_LIMIT`), then the
+ * transcript-reported `transcriptWindow` (codex's `model_context_window`), then
+ * `DEFAULT_CONTEXT_LIMIT`. Invalid / zero / non-numeric inputs are ignored at
+ * each tier. The limit is derived from the transcript, not the agent type —
+ * the dispatched *agent type* is never a model id, so a model-name map would be
+ * dead code that always fell through to the default.
  *
- * @param {string|undefined} model the model id
- * @param {unknown} [override] optional explicit limit
+ * @param {unknown} [override] explicit limit (WORK_CONTEXT_LIMIT)
+ * @param {unknown} [transcriptWindow] window reported by the transcript
  * @returns {number} the token limit
  */
-function modelContextLimit(model, override) {
+function resolveContextLimit(override, transcriptWindow) {
   const overrideLimit = toPositiveInt(override);
   if (overrideLimit !== null) return overrideLimit;
-  if (typeof model === 'string') {
-    const lower = model.toLowerCase();
-    const entry = MODEL_LIMITS.find((m) => lower.includes(m.match));
-    if (entry) return entry.limit;
-  }
+  const windowLimit = toPositiveInt(transcriptWindow);
+  if (windowLimit !== null) return windowLimit;
   return DEFAULT_CONTEXT_LIMIT;
 }
 
@@ -156,7 +151,7 @@ module.exports = {
   DEFAULT_THRESHOLDS,
   DEFAULT_CONTEXT_LIMIT,
   parseThresholds,
-  modelContextLimit,
+  resolveContextLimit,
   percentUsed,
   newlyCrossed,
   renderWarning,

--- a/plugins/work/scripts/workflows/work/lib/context-policy.js
+++ b/plugins/work/scripts/workflows/work/lib/context-policy.js
@@ -1,0 +1,163 @@
+'use strict';
+
+/**
+ * context-policy.js
+ *
+ * Pure decision helpers for the `/work` context-window usage monitor
+ * (GH-313). No side effects, no I/O, no runtime dependencies — every export
+ * is a total function over its inputs so the fail-open PostToolUse hook can
+ * call them without a try/catch of its own.
+ *
+ * Exports:
+ *   - parseThresholds(raw)              → sorted, unique, default-on-invalid %s
+ *   - modelContextLimit(model, override)→ token limit with a safe 200000 default
+ *   - percentUsed(tokens, limit)        → integer floor percent, clamped [0,100]
+ *   - newlyCrossed(pct, thresholds, hit)→ once-per-threshold crossing decision
+ *   - renderWarning({...})              → human-readable warning string
+ */
+
+/** Default warning thresholds (percent of context limit). */
+const DEFAULT_THRESHOLDS = Object.freeze([60, 70, 80]);
+
+/** Safe default / per-model context-token limit. */
+const DEFAULT_CONTEXT_LIMIT = 200000;
+
+/**
+ * Model → context-token-limit map. Opus / Sonnet / Haiku all currently share a
+ * 200000-token window; matching is by lower-cased substring so version-suffixed
+ * ids (e.g. `claude-opus-4-8`) resolve without an exhaustive id table.
+ */
+const MODEL_LIMITS = Object.freeze([
+  Object.freeze({ match: 'opus', limit: 200000 }),
+  Object.freeze({ match: 'sonnet', limit: 200000 }),
+  Object.freeze({ match: 'haiku', limit: 200000 }),
+]);
+
+/**
+ * Coerce a value to a positive, finite integer, or return null.
+ * The shared numeric-validation guard used by the threshold parser and the
+ * context-limit override so both reject NaN / non-finite / non-positive input
+ * identically.
+ *
+ * @param {unknown} value candidate value (string or number)
+ * @returns {number|null} the positive integer, or null when invalid
+ */
+function toPositiveInt(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.floor(n);
+}
+
+/**
+ * Parse a comma-separated threshold list into a sorted, de-duplicated array of
+ * positive integer percentages. Mirrors the `WORK_PRICING` parse-with-fallback
+ * shape: any missing / empty / fully-invalid input yields a fresh copy of the
+ * default `[60,70,80]` (never the shared frozen constant, so callers may
+ * mutate the result safely).
+ *
+ * @param {string|null|undefined} raw e.g. "50,90"
+ * @returns {number[]} sorted unique percentages, or the defaults
+ */
+function parseThresholds(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    return [...DEFAULT_THRESHOLDS];
+  }
+  const parsed = raw
+    .split(',')
+    .map((part) => toPositiveInt(part.trim()))
+    .filter((n) => n !== null);
+  if (parsed.length === 0) return [...DEFAULT_THRESHOLDS];
+  return [...new Set(parsed)].sort((a, b) => a - b);
+}
+
+/**
+ * Resolve the context-token limit for a model, honoring an explicit override.
+ * A valid positive-integer `override` (from `WORK_CONTEXT_LIMIT`) wins over the
+ * model map; an invalid override is ignored. An unknown / undefined model
+ * falls back to `DEFAULT_CONTEXT_LIMIT`.
+ *
+ * @param {string|undefined} model the model id
+ * @param {unknown} [override] optional explicit limit
+ * @returns {number} the token limit
+ */
+function modelContextLimit(model, override) {
+  const overrideLimit = toPositiveInt(override);
+  if (overrideLimit !== null) return overrideLimit;
+  if (typeof model === 'string') {
+    const lower = model.toLowerCase();
+    const entry = MODEL_LIMITS.find((m) => lower.includes(m.match));
+    if (entry) return entry.limit;
+  }
+  return DEFAULT_CONTEXT_LIMIT;
+}
+
+/**
+ * Integer floor percent of `cumulativeTokens` against `limit`, guarded against
+ * a zero/negative limit (→ 0) and clamped to a maximum of 100.
+ *
+ * @param {number} cumulativeTokens tokens consumed so far
+ * @param {number} limit the context-token limit
+ * @returns {number} integer percent in [0, 100]
+ */
+function percentUsed(cumulativeTokens, limit) {
+  if (!Number.isFinite(limit) || limit <= 0) return 0;
+  const tokens = Number.isFinite(cumulativeTokens) && cumulativeTokens > 0 ? cumulativeTokens : 0;
+  const pct = Math.floor((tokens / limit) * 100);
+  return Math.min(pct, 100);
+}
+
+/**
+ * The once-per-threshold decision: which configured thresholds are now crossed
+ * (`<= percent`) but were NOT already recorded as crossed. Result is sorted
+ * ascending so warnings fire lowest-first.
+ *
+ * @param {number} percent current integer percent used
+ * @param {number[]} thresholds configured thresholds
+ * @param {number[]} alreadyCrossed thresholds already fired this session
+ * @returns {number[]} newly-crossed thresholds, ascending
+ */
+function newlyCrossed(percent, thresholds, alreadyCrossed) {
+  const crossed = new Set(Array.isArray(alreadyCrossed) ? alreadyCrossed : []);
+  const list = Array.isArray(thresholds) ? thresholds : [];
+  return list.filter((t) => t <= percent && !crossed.has(t)).sort((a, b) => a - b);
+}
+
+/**
+ * Compose the human-readable context-usage warning. Always names the active
+ * workflow step, the dispatched agent/tool, and the integer percent (e.g.
+ * `62%`). When `isCritical` it appends the actionable recommendation to commit
+ * current work and spawn a fresh agent for the remainder.
+ *
+ * @param {object} params
+ * @param {number} params.percent integer percent consumed
+ * @param {string} params.step active workflow step name
+ * @param {string} params.agent dispatched agent / tool name
+ * @param {number} params.threshold the threshold that fired
+ * @param {boolean} params.isCritical whether this is the highest threshold
+ * @returns {string} the warning message
+ */
+function renderWarning({ percent, step, agent, threshold, isCritical }) {
+  const lines = [
+    `[/work context] ${percent}% of the model context window is used ` +
+      `(crossed the ${threshold}% threshold).`,
+    `Active step: ${step}. Dispatched agent/tool: ${agent}.`,
+  ];
+  if (isCritical) {
+    lines.push(
+      'Recommendation: commit current work now, summarize progress, and ' +
+        'consider spawning a fresh agent to continue the remainder.'
+    );
+  }
+  return lines.join('\n');
+}
+
+module.exports = {
+  DEFAULT_THRESHOLDS,
+  DEFAULT_CONTEXT_LIMIT,
+  parseThresholds,
+  modelContextLimit,
+  percentUsed,
+  newlyCrossed,
+  renderWarning,
+};

--- a/plugins/work/scripts/workflows/work/lib/context-usage.js
+++ b/plugins/work/scripts/workflows/work/lib/context-usage.js
@@ -4,29 +4,44 @@
  * context-usage.js
  *
  * Cumulative context-token reader for the `/work` context-window monitor
- * (GH-313, Task 2). Reads the session's own transcript JSONL and sums the
- * per-turn `usage` token fields (`input_tokens` + `output_tokens`, plus the
- * cache token fields when present) into a single cumulative count.
+ * (GH-313, Task 2). Reads the session's own transcript JSONL and returns a
+ * single cumulative context-token count, branching on the runtime format:
+ *
+ *   - claude / unknown: SUM the per-turn `usage` token fields
+ *     (`input_tokens` + `output_tokens`, plus the cache token fields when
+ *     present) across every turn — the token counts are per-turn deltas.
+ *   - codex: take the LAST `token_count` record's `total_token_usage`, which
+ *     is already a CUMULATIVE running total (summing the per-turn snapshots
+ *     would massively over-count). Prefer its `total_tokens`, else sum the
+ *     recognized fields.
  *
  * Fail-safe by contract: a missing / empty / unreadable transcript, or a
  * corrupt JSONL line, degrades to a safe `0` — it never throws — so the
  * fail-open PostToolUse caller can no-op. Zero runtime dependencies, CommonJS.
  *
  * `sniffFormat` (from the shared runtime transcript facade) is consulted
- * READ-ONLY for claude/codex format detection; no sibling-owned file is
- * modified.
+ * READ-ONLY for claude/codex format detection and is LOAD-BEARING: it selects
+ * the summation strategy. No sibling-owned file is modified.
  */
 
 const fs = require('node:fs');
 const { sniffFormat } = require('../../lib/runtime/transcript');
 
-/** Per-turn `usage` token fields summed into the cumulative total. */
+/** Per-turn `usage` token fields summed into the cumulative total (claude). */
 const USAGE_TOKEN_FIELDS = Object.freeze([
   'input_tokens',
   'output_tokens',
   'cache_read_input_tokens',
   'cache_creation_input_tokens',
 ]);
+
+/**
+ * Codex `total_token_usage` fields summed as a FALLBACK when `total_tokens` is
+ * absent. `cached_input_tokens` is a subset of `input_tokens` on the codex
+ * shape, so it is intentionally NOT summed here (that would double-count);
+ * `reasoning_output_tokens` is a subset of `output_tokens` for the same reason.
+ */
+const CODEX_TOTAL_TOKEN_FIELDS = Object.freeze(['input_tokens', 'output_tokens']);
 
 /**
  * Coerce a candidate token value to a non-negative finite number, or 0.
@@ -90,32 +105,112 @@ function tokensFromLine(line) {
 }
 
 /**
- * Read the transcript at `transcriptPath` and return the cumulative token
- * count summed across every per-turn `usage` block. Returns 0 for a missing,
- * empty, or unreadable transcript, and skips malformed lines — never throws.
+ * Whether a parsed record is a codex `token_count` snapshot.
+ * @param {unknown} record a parsed JSONL record
+ * @returns {boolean}
+ */
+function isCodexTokenCount(record) {
+  if (!record || typeof record !== 'object' || record.type !== 'event_msg') return false;
+  const payload = record.payload;
+  return Boolean(payload) && typeof payload === 'object' && payload.type === 'token_count';
+}
+
+/**
+ * Cumulative total from a codex `total_token_usage` block. Prefers the block's
+ * own `total_tokens` (already cumulative); otherwise sums the recognized
+ * fields. A missing / corrupt block yields 0.
  *
- * `sniffFormat` is consulted read-only for format detection (claude/codex);
- * an `unknown` format still reads (the JSONL/`usage`-block shape is the same
- * across both legs), so the sniff is advisory and does not short-circuit.
+ * @param {unknown} usageTotal `payload.info.total_token_usage`
+ * @returns {number}
+ */
+function codexUsageTotal(usageTotal) {
+  if (!usageTotal || typeof usageTotal !== 'object') return 0;
+  const explicit = toTokenCount(usageTotal.total_tokens);
+  if (explicit > 0) return explicit;
+  let total = 0;
+  for (const field of CODEX_TOTAL_TOKEN_FIELDS) {
+    total += toTokenCount(usageTotal[field]);
+  }
+  return total;
+}
+
+/**
+ * Extract the cumulative token total from a codex `token_count` record.
+ * Returns null when the record is not a `token_count` snapshot (so the caller
+ * can skip it); a `token_count` record with a missing / corrupt total block
+ * contributes 0.
+ *
+ * @param {object} record a parsed JSONL record
+ * @returns {number|null}
+ */
+function codexTokenCountTotal(record) {
+  if (!isCodexTokenCount(record)) return null;
+  return codexUsageTotal(record.payload.info && record.payload.info.total_token_usage);
+}
+
+/**
+ * Codex leg: `total_token_usage` is a CUMULATIVE running total re-emitted each
+ * turn, so the cumulative context size is the LAST `token_count` snapshot — NOT
+ * the sum across snapshots. Malformed lines and non-`token_count` records are
+ * skipped; an absent snapshot degrades to 0.
+ *
+ * @param {string} raw whole-file transcript text
+ * @returns {number} cumulative context tokens (>= 0)
+ */
+function readCodexCumulativeUsage(raw) {
+  let last = 0;
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    let record;
+    try {
+      record = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const total = codexTokenCountTotal(record);
+    if (total !== null) last = total;
+  }
+  return last;
+}
+
+/**
+ * Claude / unknown leg: SUM the per-turn `usage` blocks (the token counts are
+ * per-turn deltas). Malformed and blank lines contribute 0.
+ *
+ * @param {string} raw whole-file transcript text
+ * @returns {number} cumulative context tokens (>= 0)
+ */
+function readClaudeCumulativeUsage(raw) {
+  let total = 0;
+  for (const line of raw.split(/\r?\n/)) {
+    total += tokensFromLine(line);
+  }
+  return total;
+}
+
+/**
+ * Read the transcript at `transcriptPath` and return its cumulative context
+ * token count. Branches on the sniffed runtime format (see the module header):
+ * codex takes the last cumulative `token_count` snapshot; claude/unknown sum
+ * per-turn `usage` blocks. Returns 0 for a missing, empty, or unreadable
+ * transcript, and skips malformed lines — never throws.
  *
  * @param {string|undefined|null} transcriptPath path to the transcript JSONL
  * @returns {number} cumulative context tokens (>= 0)
  */
 function readCumulativeUsage(transcriptPath) {
   if (typeof transcriptPath !== 'string' || transcriptPath === '') return 0;
+  let format;
   let raw;
   try {
-    // Consult the shared sniff read-only; a read error here degrades to 0.
-    sniffFormat(transcriptPath);
+    // Consult the shared sniff read-only; it selects the summation strategy.
+    format = sniffFormat(transcriptPath);
     raw = fs.readFileSync(transcriptPath, 'utf8');
   } catch {
     return 0;
   }
-  let total = 0;
-  for (const line of raw.split(/\r?\n/)) {
-    total += tokensFromLine(line);
-  }
-  return total;
+  return format === 'codex' ? readCodexCumulativeUsage(raw) : readClaudeCumulativeUsage(raw);
 }
 
 module.exports = {

--- a/plugins/work/scripts/workflows/work/lib/context-usage.js
+++ b/plugins/work/scripts/workflows/work/lib/context-usage.js
@@ -1,0 +1,124 @@
+'use strict';
+
+/**
+ * context-usage.js
+ *
+ * Cumulative context-token reader for the `/work` context-window monitor
+ * (GH-313, Task 2). Reads the session's own transcript JSONL and sums the
+ * per-turn `usage` token fields (`input_tokens` + `output_tokens`, plus the
+ * cache token fields when present) into a single cumulative count.
+ *
+ * Fail-safe by contract: a missing / empty / unreadable transcript, or a
+ * corrupt JSONL line, degrades to a safe `0` — it never throws — so the
+ * fail-open PostToolUse caller can no-op. Zero runtime dependencies, CommonJS.
+ *
+ * `sniffFormat` (from the shared runtime transcript facade) is consulted
+ * READ-ONLY for claude/codex format detection; no sibling-owned file is
+ * modified.
+ */
+
+const fs = require('node:fs');
+const { sniffFormat } = require('../../lib/runtime/transcript');
+
+/** Per-turn `usage` token fields summed into the cumulative total. */
+const USAGE_TOKEN_FIELDS = Object.freeze([
+  'input_tokens',
+  'output_tokens',
+  'cache_read_input_tokens',
+  'cache_creation_input_tokens',
+]);
+
+/**
+ * Coerce a candidate token value to a non-negative finite number, or 0.
+ * @param {unknown} value
+ * @returns {number}
+ */
+function toTokenCount(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/**
+ * Locate the `usage` object on a parsed transcript record. Claude records nest
+ * it under `message.usage`; some shapes place it at the top level. Returns the
+ * first plain object found, or null.
+ *
+ * @param {object} record a parsed JSONL record
+ * @returns {object|null}
+ */
+function extractUsageBlock(record) {
+  if (!record || typeof record !== 'object') return null;
+  if (record.usage && typeof record.usage === 'object') return record.usage;
+  if (record.message && typeof record.message.usage === 'object') {
+    return record.message.usage;
+  }
+  return null;
+}
+
+/**
+ * Sum the recognized token fields on a single `usage` block.
+ * @param {object|null} block
+ * @returns {number}
+ */
+function sumUsageBlock(block) {
+  if (!block) return 0;
+  let total = 0;
+  for (const field of USAGE_TOKEN_FIELDS) {
+    total += toTokenCount(block[field]);
+  }
+  return total;
+}
+
+/**
+ * Parse one JSONL line and return its token contribution. A blank or corrupt
+ * line contributes 0 (skipped defensively) so a single bad line never aborts
+ * the whole read.
+ *
+ * @param {string} line raw JSONL line
+ * @returns {number}
+ */
+function tokensFromLine(line) {
+  const trimmed = line.trim();
+  if (trimmed === '') return 0;
+  let record;
+  try {
+    record = JSON.parse(trimmed);
+  } catch {
+    return 0;
+  }
+  return sumUsageBlock(extractUsageBlock(record));
+}
+
+/**
+ * Read the transcript at `transcriptPath` and return the cumulative token
+ * count summed across every per-turn `usage` block. Returns 0 for a missing,
+ * empty, or unreadable transcript, and skips malformed lines — never throws.
+ *
+ * `sniffFormat` is consulted read-only for format detection (claude/codex);
+ * an `unknown` format still reads (the JSONL/`usage`-block shape is the same
+ * across both legs), so the sniff is advisory and does not short-circuit.
+ *
+ * @param {string|undefined|null} transcriptPath path to the transcript JSONL
+ * @returns {number} cumulative context tokens (>= 0)
+ */
+function readCumulativeUsage(transcriptPath) {
+  if (typeof transcriptPath !== 'string' || transcriptPath === '') return 0;
+  let raw;
+  try {
+    // Consult the shared sniff read-only; a read error here degrades to 0.
+    sniffFormat(transcriptPath);
+    raw = fs.readFileSync(transcriptPath, 'utf8');
+  } catch {
+    return 0;
+  }
+  let total = 0;
+  for (const line of raw.split(/\r?\n/)) {
+    total += tokensFromLine(line);
+  }
+  return total;
+}
+
+module.exports = {
+  readCumulativeUsage,
+  USAGE_TOKEN_FIELDS,
+};

--- a/plugins/work/scripts/workflows/work/lib/context-usage.js
+++ b/plugins/work/scripts/workflows/work/lib/context-usage.js
@@ -3,31 +3,47 @@
 /**
  * context-usage.js
  *
- * Cumulative context-token reader for the `/work` context-window monitor
- * (GH-313, Task 2). Reads the session's own transcript JSONL and returns a
- * single cumulative context-token count, branching on the runtime format:
+ * Current context-window occupancy reader for the `/work` context-window
+ * monitor (GH-313, Task 2). Reads the session's own transcript JSONL and
+ * returns the CURRENT occupancy — the size of the most recent turn's context,
+ * NOT a sum across turns.
  *
- *   - claude / unknown: SUM the per-turn `usage` token fields
- *     (`input_tokens` + `output_tokens`, plus the cache token fields when
- *     present) across every turn — the token counts are per-turn deltas.
- *   - codex: take the LAST `token_count` record's `total_token_usage`, which
- *     is already a CUMULATIVE running total (summing the per-turn snapshots
- *     would massively over-count). Prefer its `total_tokens`, else sum the
- *     recognized fields.
+ * Summing the per-turn `usage` blocks over a long session massively
+ * over-counts: each turn re-sends (and re-reports) the growing, cached context,
+ * so the sum is a cumulative-of-cumulatives with no relationship to how full
+ * the window actually is. The occupancy the monitor cares about is the LAST
+ * turn's usage, on both runtimes:
+ *
+ *   - claude / unknown: the LAST `usage` block's `input_tokens` +
+ *     `output_tokens` + the cache token fields (`cache_read_input_tokens` +
+ *     `cache_creation_input_tokens`) — the full prompt + response of the most
+ *     recent turn, i.e. the current window occupancy.
+ *   - codex: the LAST `token_count` snapshot's `last_token_usage.total_tokens`
+ *     (the most recent turn), preferred over `total_token_usage` — which is a
+ *     cumulative running COST total that also grows unbounded over a session.
+ *     The snapshot's `model_context_window` is surfaced as the real limit.
  *
  * Fail-safe by contract: a missing / empty / unreadable transcript, or a
- * corrupt JSONL line, degrades to a safe `0` — it never throws — so the
- * fail-open PostToolUse caller can no-op. Zero runtime dependencies, CommonJS.
+ * corrupt JSONL line, degrades to a safe `{ tokens: 0, contextWindow: 0 }` — it
+ * never throws — so the fail-open PostToolUse caller can no-op. Zero runtime
+ * dependencies, CommonJS.
+ *
+ * Only the transcript TAIL is read (the last-turn occupancy lives at the end of
+ * the file), so cost stays bounded regardless of transcript size; a partial
+ * tail that yields no usage falls back to a full read.
  *
  * `sniffFormat` (from the shared runtime transcript facade) is consulted
  * READ-ONLY for claude/codex format detection and is LOAD-BEARING: it selects
- * the summation strategy. No sibling-owned file is modified.
+ * the occupancy strategy. No sibling-owned file is modified.
  */
 
 const fs = require('node:fs');
 const { sniffFormat } = require('../../lib/runtime/transcript');
 
-/** Per-turn `usage` token fields summed into the cumulative total (claude). */
+/** Bytes of the transcript tail scanned for the last-turn occupancy. */
+const TAIL_BYTES = 512 * 1024;
+
+/** Per-turn `usage` token fields summed into the occupancy total (claude). */
 const USAGE_TOKEN_FIELDS = Object.freeze([
   'input_tokens',
   'output_tokens',
@@ -36,12 +52,17 @@ const USAGE_TOKEN_FIELDS = Object.freeze([
 ]);
 
 /**
- * Codex `total_token_usage` fields summed as a FALLBACK when `total_tokens` is
- * absent. `cached_input_tokens` is a subset of `input_tokens` on the codex
- * shape, so it is intentionally NOT summed here (that would double-count);
+ * Codex token-usage fields summed as a FALLBACK when `total_tokens` is absent.
+ * `cached_input_tokens` is a subset of `input_tokens` on the codex shape, so it
+ * is intentionally NOT summed here (that would double-count);
  * `reasoning_output_tokens` is a subset of `output_tokens` for the same reason.
  */
-const CODEX_TOTAL_TOKEN_FIELDS = Object.freeze(['input_tokens', 'output_tokens']);
+const CODEX_TOKEN_FIELDS = Object.freeze(['input_tokens', 'output_tokens']);
+
+/** A fresh empty (no-usage) result. */
+function emptyUsage() {
+  return { tokens: 0, contextWindow: 0 };
+}
 
 /**
  * Coerce a candidate token value to a non-negative finite number, or 0.
@@ -85,26 +106,6 @@ function sumUsageBlock(block) {
 }
 
 /**
- * Parse one JSONL line and return its token contribution. A blank or corrupt
- * line contributes 0 (skipped defensively) so a single bad line never aborts
- * the whole read.
- *
- * @param {string} line raw JSONL line
- * @returns {number}
- */
-function tokensFromLine(line) {
-  const trimmed = line.trim();
-  if (trimmed === '') return 0;
-  let record;
-  try {
-    record = JSON.parse(trimmed);
-  } catch {
-    return 0;
-  }
-  return sumUsageBlock(extractUsageBlock(record));
-}
-
-/**
  * Whether a parsed record is a codex `token_count` snapshot.
  * @param {unknown} record a parsed JSONL record
  * @returns {boolean}
@@ -116,49 +117,53 @@ function isCodexTokenCount(record) {
 }
 
 /**
- * Cumulative total from a codex `total_token_usage` block. Prefers the block's
- * own `total_tokens` (already cumulative); otherwise sums the recognized
- * fields. A missing / corrupt block yields 0.
+ * Occupancy from a single codex token-usage block. Prefers the block's own
+ * `total_tokens`; otherwise sums the recognized fields. A missing / corrupt
+ * block yields 0.
  *
- * @param {unknown} usageTotal `payload.info.total_token_usage`
+ * @param {unknown} usageBlock a codex `last_token_usage` / `total_token_usage`
  * @returns {number}
  */
-function codexUsageTotal(usageTotal) {
-  if (!usageTotal || typeof usageTotal !== 'object') return 0;
-  const explicit = toTokenCount(usageTotal.total_tokens);
+function codexUsageTotal(usageBlock) {
+  if (!usageBlock || typeof usageBlock !== 'object') return 0;
+  const explicit = toTokenCount(usageBlock.total_tokens);
   if (explicit > 0) return explicit;
   let total = 0;
-  for (const field of CODEX_TOTAL_TOKEN_FIELDS) {
-    total += toTokenCount(usageTotal[field]);
+  for (const field of CODEX_TOKEN_FIELDS) {
+    total += toTokenCount(usageBlock[field]);
   }
   return total;
 }
 
 /**
- * Extract the cumulative token total from a codex `token_count` record.
- * Returns null when the record is not a `token_count` snapshot (so the caller
- * can skip it); a `token_count` record with a missing / corrupt total block
- * contributes 0.
+ * Current-turn occupancy from a codex `token_count` payload.info. Prefers
+ * `last_token_usage` (the most recent turn's usage) over `total_token_usage`
+ * (a cumulative running total that grows unbounded). Returns null when neither
+ * block is present so the caller can skip the record.
  *
- * @param {object} record a parsed JSONL record
+ * @param {unknown} info `payload.info`
  * @returns {number|null}
  */
-function codexTokenCountTotal(record) {
-  if (!isCodexTokenCount(record)) return null;
-  return codexUsageTotal(record.payload.info && record.payload.info.total_token_usage);
+function codexTurnOccupancy(info) {
+  if (!info || typeof info !== 'object') return null;
+  if (info.last_token_usage && typeof info.last_token_usage === 'object') {
+    return codexUsageTotal(info.last_token_usage);
+  }
+  if (info.total_token_usage && typeof info.total_token_usage === 'object') {
+    return codexUsageTotal(info.total_token_usage);
+  }
+  return null;
 }
 
 /**
- * Codex leg: `total_token_usage` is a CUMULATIVE running total re-emitted each
- * turn, so the cumulative context size is the LAST `token_count` snapshot — NOT
- * the sum across snapshots. Malformed lines and non-`token_count` records are
- * skipped; an absent snapshot degrades to 0.
+ * Invoke `onRecord` for every parseable JSONL record in `raw`. Blank lines and
+ * lines that fail to parse are skipped silently — the shared line-scan both
+ * runtime legs walk (so a single bad line never aborts the read).
  *
- * @param {string} raw whole-file transcript text
- * @returns {number} cumulative context tokens (>= 0)
+ * @param {string} raw transcript text (whole file or a tail slice)
+ * @param {(record: object) => void} onRecord
  */
-function readCodexCumulativeUsage(raw) {
-  let last = 0;
+function forEachRecord(raw, onRecord) {
   for (const line of raw.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (trimmed === '') continue;
@@ -168,52 +173,122 @@ function readCodexCumulativeUsage(raw) {
     } catch {
       continue;
     }
-    const total = codexTokenCountTotal(record);
-    if (total !== null) last = total;
+    onRecord(record);
   }
-  return last;
 }
 
 /**
- * Claude / unknown leg: SUM the per-turn `usage` blocks (the token counts are
- * per-turn deltas). Malformed and blank lines contribute 0.
+ * Claude / unknown leg: the CURRENT occupancy is the LAST `usage` block in the
+ * transcript (the most recent turn), NOT the sum across turns. Claude
+ * transcripts carry no window, so `contextWindow` is 0 (the caller applies its
+ * default / env override).
  *
- * @param {string} raw whole-file transcript text
- * @returns {number} cumulative context tokens (>= 0)
+ * @param {string} raw transcript text (whole file or a tail slice)
+ * @returns {{tokens:number, contextWindow:number}}
  */
-function readClaudeCumulativeUsage(raw) {
-  let total = 0;
-  for (const line of raw.split(/\r?\n/)) {
-    total += tokensFromLine(line);
-  }
-  return total;
+function readClaudeContextUsage(raw) {
+  let tokens = 0;
+  forEachRecord(raw, (record) => {
+    const block = extractUsageBlock(record);
+    if (block) tokens = sumUsageBlock(block);
+  });
+  return { tokens, contextWindow: 0 };
 }
 
 /**
- * Read the transcript at `transcriptPath` and return its cumulative context
- * token count. Branches on the sniffed runtime format (see the module header):
- * codex takes the last cumulative `token_count` snapshot; claude/unknown sum
- * per-turn `usage` blocks. Returns 0 for a missing, empty, or unreadable
- * transcript, and skips malformed lines — never throws.
+ * Codex leg: the CURRENT occupancy is the LAST `token_count` snapshot's
+ * `last_token_usage` (the most recent turn), and its `model_context_window` is
+ * the real context limit. Non-`token_count` records are skipped; an absent
+ * snapshot degrades to 0.
+ *
+ * @param {string} raw transcript text (whole file or a tail slice)
+ * @returns {{tokens:number, contextWindow:number}}
+ */
+function readCodexContextUsage(raw) {
+  let tokens = 0;
+  let contextWindow = 0;
+  forEachRecord(raw, (record) => {
+    if (!isCodexTokenCount(record)) return;
+    const info = record.payload.info;
+    const occupancy = codexTurnOccupancy(info);
+    if (occupancy !== null) tokens = occupancy;
+    const window = toTokenCount(info && info.model_context_window);
+    if (window > 0) contextWindow = window;
+  });
+  return { tokens, contextWindow };
+}
+
+/**
+ * Read up to `TAIL_BYTES` from the END of the transcript. Returns the raw slice
+ * and whether it covers the whole file (`complete`). The boundary line of a
+ * partial slice is a mid-record fragment that fails to parse and is skipped —
+ * harmless, since the last-turn occupancy lives at the very end. May throw
+ * (ENOENT etc.); the caller wraps it in fail-open handling.
+ *
+ * @param {string} transcriptPath
+ * @returns {{raw:string, complete:boolean}}
+ */
+function readTranscriptTail(transcriptPath) {
+  const fd = fs.openSync(transcriptPath, 'r');
+  try {
+    const size = fs.fstatSync(fd).size;
+    const start = size > TAIL_BYTES ? size - TAIL_BYTES : 0;
+    const length = size - start;
+    const buf = Buffer.allocUnsafe(length);
+    let read = 0;
+    while (read < length) {
+      const n = fs.readSync(fd, buf, read, length - read, start + read);
+      if (n === 0) break;
+      read += n;
+    }
+    return { raw: buf.toString('utf8', 0, read), complete: start === 0 };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
+ * Read the transcript at `transcriptPath` and return the CURRENT context
+ * occupancy `{ tokens, contextWindow }`. Branches on the sniffed runtime format
+ * (see the module header): both legs take the most recent turn, not a sum. Only
+ * the transcript tail is scanned; a partial tail with no usage falls back to a
+ * full read. Returns `{ tokens: 0, contextWindow: 0 }` for a missing / empty /
+ * unreadable transcript, and skips malformed lines — never throws.
  *
  * @param {string|undefined|null} transcriptPath path to the transcript JSONL
- * @returns {number} cumulative context tokens (>= 0)
+ * @returns {{tokens:number, contextWindow:number}}
+ */
+function readContextUsage(transcriptPath) {
+  if (typeof transcriptPath !== 'string' || transcriptPath === '') return emptyUsage();
+  try {
+    // Consult the shared sniff read-only; it selects the occupancy strategy.
+    const format = sniffFormat(transcriptPath);
+    const parse = format === 'codex' ? readCodexContextUsage : readClaudeContextUsage;
+    const tail = readTranscriptTail(transcriptPath);
+    const result = parse(tail.raw);
+    // A bounded tail that found nothing MIGHT have sliced off the only usage
+    // line — fall back to a full read before giving up.
+    if (result.tokens > 0 || tail.complete) return result;
+    return parse(fs.readFileSync(transcriptPath, 'utf8'));
+  } catch {
+    return emptyUsage();
+  }
+}
+
+/**
+ * Back-compat numeric accessor: the current context occupancy, in tokens, of
+ * the transcript at `transcriptPath` (see `readContextUsage`). Returns 0 for a
+ * missing / empty / unreadable transcript.
+ *
+ * @param {string|undefined|null} transcriptPath
+ * @returns {number} current context tokens (>= 0)
  */
 function readCumulativeUsage(transcriptPath) {
-  if (typeof transcriptPath !== 'string' || transcriptPath === '') return 0;
-  let format;
-  let raw;
-  try {
-    // Consult the shared sniff read-only; it selects the summation strategy.
-    format = sniffFormat(transcriptPath);
-    raw = fs.readFileSync(transcriptPath, 'utf8');
-  } catch {
-    return 0;
-  }
-  return format === 'codex' ? readCodexCumulativeUsage(raw) : readClaudeCumulativeUsage(raw);
+  return readContextUsage(transcriptPath).tokens;
 }
 
 module.exports = {
+  readContextUsage,
   readCumulativeUsage,
   USAGE_TOKEN_FIELDS,
 };

--- a/plugins/work/scripts/workflows/work/lib/hook-common.js
+++ b/plugins/work/scripts/workflows/work/lib/hook-common.js
@@ -1,11 +1,11 @@
 /**
  * hook-common.js — shared plumbing for /work PostToolUse hooks
- * (work-auto-advance.js, capture-usage.js).
+ * (work-auto-advance.js, capture-usage.js, context-monitor.js).
  *
  * Extracted so each hook keeps only its own behavior: stdin parsing, runtime
- * normalization, and the session/worktree-scoped `.work.pid` marker lookup
- * are identical across hooks and must stay identical — a divergence here is
- * how cross-wiring bugs start.
+ * normalization, the session/worktree-scoped `.work.pid` marker lookup, and the
+ * `.work-state.json` → active-step resolution are identical across hooks and
+ * must stay identical — a divergence here is how cross-wiring bugs start.
  */
 
 const fs = require('fs');
@@ -63,4 +63,44 @@ function findRecentWorkMarker() {
   return { marker, tasksBase: TASKS_BASE };
 }
 
-module.exports = { installFailOpen, readHookData, normalizePostToolEvent, findRecentWorkMarker };
+/**
+ * Resolve a ticket's active step name from its `.work-state.json`.
+ *
+ * `currentStep` is 1-indexed into ALL_STEPS (mirrors print-current-step.js).
+ * The ticket id is sanitized via `lib/config` `safeTicketId` (traversal-safe),
+ * falling back to the raw id if that lookup fails. A missing/corrupt state file
+ * — or any other failure — yields `'unknown'` rather than dropping the caller's
+ * record, so usage attribution and context warnings never break a workflow.
+ *
+ * @param {string} tasksBase Absolute TASKS_BASE root.
+ * @param {string} ticket Raw ticket id.
+ * @returns {string} The active step name, or `'unknown'`.
+ */
+function readStateStep(tasksBase, ticket) {
+  let safe = ticket;
+  try {
+    safe = require(path.join(__dirname, '..', '..', 'lib', 'config')).safeTicketId(ticket);
+  } catch {
+    /* fall back to the raw id */
+  }
+  try {
+    const statePath = path.join(tasksBase, safe, '.work-state.json');
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    const { ALL_STEPS } = require(path.join(__dirname, '..', 'step-registry'));
+    const num = Number(state && state.currentStep);
+    if (Number.isFinite(num) && num >= 1 && num <= ALL_STEPS.length) {
+      return ALL_STEPS[num - 1];
+    }
+  } catch {
+    /* missing/corrupt state file */
+  }
+  return 'unknown';
+}
+
+module.exports = {
+  installFailOpen,
+  readHookData,
+  normalizePostToolEvent,
+  findRecentWorkMarker,
+  readStateStep,
+};

--- a/tests/fixtures/hooks-json/work.hooks.baseline.json
+++ b/tests/fixtures/hooks-json/work.hooks.baseline.json
@@ -165,6 +165,10 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work/hooks/capture-usage.js"
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work/hooks/context-monitor.js"
           }
         ]
       },


### PR DESCRIPTION
## Existing Behavior

- The `/work` workflow dispatches sub-agents (Task/Agent tools) without any visibility into how much of the model's context window has been consumed over the course of a session.
- Operators have no way to receive an advisory warning as a long-running session approaches its context limit, and no way to configure or disable such warnings without modifying hook registrations.
- There is no persistent per-session record of which warning thresholds have already fired, so any future monitoring mechanism would risk spamming the same warning repeatedly.

## Intended New Behavior

- A new fail-open `context-monitor.js` PostToolUse hook fires after every `Task|Agent` dispatch. It reads cumulative token usage from the session's own transcript, computes the integer percent consumed against the model context limit, and emits an advisory warning each time a new threshold is crossed (default: 60%, 70%, 80%).
- Warnings name the active workflow step, the dispatched agent/tool, and the percent consumed. At the critical (highest) threshold the warning appends a recommendation to commit current work and spawn a fresh agent for the remainder.
- Each threshold fires **once per session**: crossed thresholds are persisted in a per-ticket ledger (`<TASKS_BASE>/<ticket>/.context-monitor.json`), so re-runs within the same session do not repeat warnings. Deleting the ledger re-arms all thresholds.
- The hook is strictly **fail-open**: any internal error exits 0 silently via `installFailOpen()`. It is also a **silent no-op** in foreign-session marker contexts, sub-agent contexts, and when `WORK_CONTEXT_MONITOR_ENABLED=0` — it never blocks a tool call.
- Three env vars let operators tune behavior without touching hook registrations:

| Env var | Default | Behavior |
|---|---|---|
| `WORK_CONTEXT_WARN_THRESHOLDS` | `60,70,80` | Comma-separated warning percentages. Missing, empty, or non-numeric values fall back to the default. |
| `WORK_CONTEXT_LIMIT` | `200000` | Overrides the model context-limit map. A valid positive integer wins over the map (Opus/Sonnet/Haiku all currently map to 200000). |
| `WORK_CONTEXT_MONITOR_ENABLED` | (enabled) | Set to `0` for a silent no-op without unregistering the hook. |

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

To run all 62 tests:

```bash
node --test \
  plugins/work/scripts/workflows/work/lib/__tests__/context-policy.test.js \
  plugins/work/scripts/workflows/work/lib/__tests__/context-usage.test.js \
  plugins/work/scripts/workflows/work/hooks/__tests__/context-monitor.test.js
```

### Test Results

62 tests pass, 0 failures across 3 suites:

- `context-policy.test.js` — 35 tests covering `parseThresholds`, `modelContextLimit`, `percentUsed`, `newlyCrossed`, `renderWarning`
- `context-usage.test.js` — 9 tests covering cumulative JSONL summation and fail-safe reads (missing/corrupt/empty transcript)
- `context-monitor.test.js` — 18 integration tests covering hooks.json registration, fail-open scoping (foreign session, sub-agent, missing transcript, no marker), threshold warnings, ledger deduplication, critical recommendation, disable switch, and limit override

Closes #313
