### PR TITLE
feat(work): add cancel subcommand for planning-phase abort (GH-339)

### DIFF
--- a/plugins/work/CLAUDE.md
+++ b/plugins/work/CLAUDE.md
@@ -57,6 +57,57 @@ Load-bearing facts when porting:
 - Transitions validated by `workflowCanTransition()` — only declared edges are allowed.
 - `transition-step.js` handles state persistence, artifact archival, and TDD gates.
 
+### Cancelling a workflow (`cancel` subcommand)
+
+`cancel` is a terminal orchestrator verb for aborting a `/work` run **during the
+planning phases** with full bookkeeping (state + audit + guard release +
+archive), instead of an ad-hoc abandon.
+
+- **Invocation:** `node work.workflow.js cancel <TICKET> --reason "<reason>"`.
+  Both `<TICKET>` and `--reason` are required — a parse failure or a missing
+  reason exits 1. The `--reason` string is recorded verbatim (an argv token, no
+  shell interpolation) in state and audit.
+- **Planning-phase-only window:** cancellation is permitted only from `ticket`
+  through `spec_gate`. The boundary is a single named constant
+  `CANCELLABLE_STEP_CEILING = 'spec_gate'` (in `work-state/steps.js`);
+  `isCancellablePhase(step)` derives the cancellable set from a `STEP_ORDER`
+  slice up to that ceiling. At `tasks` and beyond it is not cancellable.
+- **`cancelled` terminal status:** a successful cancel sets `.work-state.json`
+  `status` to a new value `cancelled` — distinct from `in_progress`/`completed`
+  and never reusing `completed` — plus additive `cancelReason` (verbatim) and
+  `cancelledTime` (ISO) fields. The `cancelWork` mutator is idempotent: a second
+  call while already `cancelled` returns the state unchanged.
+- **Release + archive sequence** (on a cancellable phase): the work-state
+  `cancel` mutator marks the state → the sanctioned guard `finish` teardown
+  releases the session guard (reveal + unlink the session file, exactly as the
+  complete step does — no direct bypass) → planning + enforcement artifacts
+  (`brief.md`, `spec.md`, `tasks.md`, `.work-actions.json`, `tdd-phase.json`)
+  are moved from `tasks/<TICKET>/` into `tasks/<TICKET>/archive/` (created +
+  merged into if it already exists, mirroring the complete step's archive
+  convention) → a one-line operator summary (ticket, reason, phase at cancel,
+  archive location) plus a JSON response is printed.
+- **Refuse at/after `implement`:** once code has been written the orchestrator
+  surfaces an **AskUserQuestion confirmation that defaults to refusing**, exits
+  non-zero, and does **not** mutate state or archive anything (status stays
+  `in_progress`). Before `implement` but past the cancel ceiling (e.g. `tasks`)
+  it rejects with a clear message and exits 1.
+- **Auth / gating:** the planning-phase precondition lives inside `cancelWork`
+  (script-side), so a direct state-script call cannot cancel an implement-phase
+  ticket. The work-state `cancel` sub-command is routed through the Rule-3b
+  terminal-bypass path (`isTerminalSessionGuardBypass` additively allows guard
+  release when status is `cancelled`, with the dispatched-agent context still
+  rejected first) so a dispatched subagent cannot invoke it — it is blocked with
+  the dispatched-agent guidance.
+- **Stop-hook allowance:** the session-guard Stop hook allows stopping (exit 0,
+  no "DO NOT ABANDON" block) when an owned session's `.work-state.json` status
+  is `cancelled`, scoped to owned sessions and mirroring the existing
+  allowances. An in-progress non-cancelled owned session still blocks (exit 2).
+- **`abort workflow` keyword redirect:** the legacy `abort workflow` Stop-hook
+  keyword still allows the stop, but now emits operator guidance pointing at the
+  bookkept `cancel` subcommand (`work.workflow.js cancel <TICKET> --reason
+  "<reason>"`) — the keyword is retained, its guidance is redirected, keeping
+  one auditable cancellation route.
+
 ### TDD Enforcement
 - `implement` step is TDD-gated: must record RED → GREEN cycle before transitioning out.
 - `tdd-phase-state.js` is the ONLY way to record evidence — agents cannot self-report.

--- a/plugins/work/scripts/workflows/lib/hooks/policies/__tests__/hook-config.test.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/__tests__/hook-config.test.js
@@ -1,0 +1,92 @@
+/**
+ * Tests for policies/hook-config.js — Task 4 (GH-339)
+ *
+ * Rule 3b must route the work-state `cancel` sub-command through the
+ * terminal-bypass gate rather than treat it as blanket-safe. That means:
+ *
+ *   - `cancel` is NOT a member of SAFE_SUBCOMMANDS['work-state.js'] (a blanket-safe
+ *     read-only entry would let a dispatched subagent invoke it unguarded).
+ *   - hook-config recognizes `cancel` as gated-via-terminal-bypass by listing it
+ *     alongside `complete` in a TERMINAL_BYPASS_SUBCOMMANDS alignment set, so the
+ *     allowlist/exempt-pattern config stays consistent with the Rule-3b bypass
+ *     path in state-script-gate.js (isTerminalBypassEligible).
+ *   - The pre-existing work-state safe set (get, resume-info, init, …) is unchanged.
+ *
+ * Run: node --test workflows/lib/hooks/policies/__tests__/hook-config.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { SAFE_SUBCOMMANDS, TERMINAL_BYPASS_SUBCOMMANDS } = require('../hook-config');
+const { isTerminalBypassEligible } = require('../state-script-gate');
+
+// The read-only/idempotent set that existed before GH-339's cancel work. `cancel`
+// must NOT be added to this set, and none of these entries may be dropped.
+const EXPECTED_WORK_STATE_SAFE = [
+  'get',
+  'resume-info',
+  'init',
+  'active-subtask',
+  'add-error',
+  'task-init',
+  'task-current',
+  'task-get',
+];
+
+describe('hook-config: work-state.js cancel routing (GH-339 Task 4)', () => {
+  it('does NOT list cancel in the blanket-safe SAFE_SUBCOMMANDS set', () => {
+    const safe = SAFE_SUBCOMMANDS['work-state.js'];
+    assert.ok(safe instanceof Set, 'SAFE_SUBCOMMANDS[work-state.js] is a Set');
+    assert.equal(
+      safe.has('cancel'),
+      false,
+      'cancel must be gated via terminal-bypass, never blanket-safe (AC10)'
+    );
+  });
+
+  it('recognizes cancel as gated-via-terminal-bypass, mirroring complete', () => {
+    assert.ok(
+      TERMINAL_BYPASS_SUBCOMMANDS && typeof TERMINAL_BYPASS_SUBCOMMANDS === 'object',
+      'hook-config exports a TERMINAL_BYPASS_SUBCOMMANDS alignment map'
+    );
+    const bypass = TERMINAL_BYPASS_SUBCOMMANDS['work-state.js'];
+    assert.ok(bypass instanceof Set, 'TERMINAL_BYPASS_SUBCOMMANDS[work-state.js] is a Set');
+    assert.equal(bypass.has('cancel'), true, 'cancel is routed through the terminal bypass');
+    assert.equal(
+      bypass.has('complete'),
+      true,
+      'cancel alignment sits alongside complete (both gated-via-bypass)'
+    );
+  });
+
+  it('keeps the bypass alignment consistent with state-script-gate.isTerminalBypassEligible', () => {
+    // hook-config's alignment set must not drift from the actual Rule-3b bypass
+    // predicate: every entry it claims is gated-via-bypass must be eligible there,
+    // and the blanket-safe set must stay disjoint from it.
+    const bypass = TERMINAL_BYPASS_SUBCOMMANDS['work-state.js'];
+    for (const subCmd of bypass) {
+      assert.equal(
+        isTerminalBypassEligible('work-state.js', subCmd),
+        true,
+        `${subCmd} is bypass-eligible in state-script-gate`
+      );
+    }
+    const safe = SAFE_SUBCOMMANDS['work-state.js'];
+    for (const subCmd of bypass) {
+      assert.equal(safe.has(subCmd), false, `${subCmd} is not also blanket-safe`);
+    }
+  });
+
+  it('leaves the pre-existing work-state.js safe set unchanged', () => {
+    const safe = SAFE_SUBCOMMANDS['work-state.js'];
+    for (const entry of EXPECTED_WORK_STATE_SAFE) {
+      assert.equal(safe.has(entry), true, `${entry} remains blanket-safe`);
+    }
+    assert.equal(
+      safe.size,
+      EXPECTED_WORK_STATE_SAFE.length,
+      'no extra sub-commands added to the work-state.js safe set'
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/lib/hooks/policies/__tests__/state-script-gate.test.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/__tests__/state-script-gate.test.js
@@ -1,0 +1,145 @@
+/**
+ * Tests for policies/state-script-gate.js — Task 3 (GH-339)
+ *
+ *   - isTerminalSessionGuardBypass additively allows guard release when the
+ *     work-state status is `cancelled` (GH-339 AC9), while still rejecting a
+ *     dispatched-agent context first (GH-695) and leaving the terminal-`complete`
+ *     allowance intact.
+ *   - The work-state `cancel` sub-command is routed through the Rule-3b
+ *     terminal-bypass path (GH-339 AC10): a dispatched subagent is blocked with
+ *     the dispatched-agent guidance, while a non-dispatched, strict,
+ *     planning-phase invocation is allowed through.
+ *
+ * Run: node --test workflows/lib/hooks/policies/__tests__/state-script-gate.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const {
+  createStateScriptGate,
+  DISPATCHED_AGENT_GUIDANCE,
+  isTerminalBypassEligible,
+} = require('../state-script-gate');
+
+// Real script paths under a trusted dir so isTrustedScriptPath() passes.
+// __tests__ → policies → hooks → lib → workflows, then work/work-state.js.
+const WORK_STATE_JS = path.resolve(__dirname, '..', '..', '..', '..', 'work', 'work-state.js');
+// __tests__ → policies → hooks, then session-guard.js.
+const SESSION_GUARD_JS = path.resolve(__dirname, '..', '..', 'session-guard.js');
+// workflows is a shared ancestor of both scripts above.
+const TRUSTED_DIR = path.resolve(__dirname, '..', '..', '..', '..');
+
+const TICKET = 'GH-339';
+
+/**
+ * Build a deps object for createStateScriptGate.
+ * @param {object} o
+ * @param {string} o.status — work-state status returned by loadStateFile
+ * @param {string} o.step — current step returned by getCurrentStep
+ * @param {boolean} o.dispatched — whether isDispatchedAgentContext returns true
+ */
+function makeDeps({ status = 'in_progress', step = 'spec', dispatched = false } = {}) {
+  return {
+    trustedDirs: [TRUSTED_DIR],
+    safeSubcommands: {
+      'work-state.js': new Set(['get', 'resume-info']),
+      'session-guard.js': new Set(['status']),
+    },
+    loadStateFile: () => ({ status }),
+    getCurrentStep: () => step,
+    workSteps: ['ticket', 'brief', 'spec', 'spec_gate', 'tasks', 'implement', 'complete'],
+    tasksBase: '/tmp/tasks',
+    safeTicketPath: (t) => `/tmp/tasks/${t}`,
+    debugLogCandidatePath: () => {},
+    isDispatchedAgentContext: () => dispatched === true,
+  };
+}
+
+describe('state-script-gate: isTerminalSessionGuardBypass — cancelled guard release (GH-339 AC9)', () => {
+  it('the terminal-bypass predicate allows guard release when status is cancelled', () => {
+    // Status cancelled at a NON-complete step (spec): today only `complete`
+    // is allowed, so this must fail until the additive OR clause lands.
+    const gate = createStateScriptGate(makeDeps({ status: 'cancelled', step: 'spec' }));
+    const cmd = `node ${SESSION_GUARD_JS} finish ${TICKET}`;
+    assert.equal(
+      gate.isTerminalSessionGuardBypass(cmd, TICKET, {}),
+      true,
+      'guard release should be allowed when work-state status is cancelled'
+    );
+  });
+
+  it('still rejects a dispatched-agent context first even when status is cancelled', () => {
+    const gate = createStateScriptGate(
+      makeDeps({ status: 'cancelled', step: 'spec', dispatched: true })
+    );
+    const cmd = `node ${SESSION_GUARD_JS} finish ${TICKET}`;
+    assert.equal(
+      gate.isTerminalSessionGuardBypass(cmd, TICKET, { transcript_path: '/tmp/t.jsonl' }),
+      false,
+      'dispatched-agent context must be rejected before the cancelled allowance'
+    );
+  });
+
+  it('keeps the terminal-complete allowance unchanged (status in_progress at complete)', () => {
+    const gate = createStateScriptGate(makeDeps({ status: 'in_progress', step: 'complete' }));
+    const cmd = `node ${SESSION_GUARD_JS} finish ${TICKET}`;
+    assert.equal(
+      gate.isTerminalSessionGuardBypass(cmd, TICKET, {}),
+      true,
+      'the existing complete-step allowance must remain intact'
+    );
+  });
+
+  it('rejects guard release for a non-cancelled state at a non-complete step', () => {
+    const gate = createStateScriptGate(makeDeps({ status: 'in_progress', step: 'spec' }));
+    const cmd = `node ${SESSION_GUARD_JS} finish ${TICKET}`;
+    assert.equal(
+      gate.isTerminalSessionGuardBypass(cmd, TICKET, {}),
+      false,
+      'a mid-workflow in_progress state must not release the guard'
+    );
+  });
+});
+
+describe('state-script-gate: work-state.js cancel gating (GH-339 AC10)', () => {
+  it('a dispatched subagent cannot invoke work-state.js cancel', () => {
+    // Cancel is routed through Rule 3b: a dispatched context must be blocked and
+    // the block message must carry the dispatched-agent guidance.
+    const gate = createStateScriptGate(
+      makeDeps({ status: 'in_progress', step: 'spec', dispatched: true })
+    );
+    const cmd = `node ${WORK_STATE_JS} cancel ${TICKET} --reason "abc"`;
+    const result = gate.checkUnsafeSubcommands(cmd, TICKET, {
+      transcript_path: '/tmp/t.jsonl',
+    });
+    assert.ok(result, 'cancel from a dispatched context must be blocked');
+    assert.equal(result.blocked, true);
+    assert.ok(
+      result.message.includes(DISPATCHED_AGENT_GUIDANCE),
+      'block message must include the dispatched-agent guidance'
+    );
+  });
+
+  it('allows a non-dispatched strict planning-phase work-state.js cancel', () => {
+    const gate = createStateScriptGate(
+      makeDeps({ status: 'in_progress', step: 'spec', dispatched: false })
+    );
+    const cmd = `node ${WORK_STATE_JS} cancel ${TICKET} --reason "abc"`;
+    const result = gate.checkUnsafeSubcommands(cmd, TICKET, {});
+    assert.equal(
+      result,
+      null,
+      'a non-dispatched planning-phase cancel must be allowed through (not blocked)'
+    );
+  });
+
+  it('cancel is a terminal-bypass-eligible sub-command on work-state.js', () => {
+    assert.equal(
+      isTerminalBypassEligible('work-state.js', 'cancel'),
+      true,
+      'cancel must be terminal-bypass eligible so the dispatched guidance applies'
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/lib/hooks/policies/hook-config.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/hook-config.js
@@ -6,6 +6,8 @@
  *
  *   - EXEMPT_SCRIPTS: legitimate state-file writers exempt from Vector 3
  *   - SAFE_SUBCOMMANDS: read-only/idempotent sub-commands per state script
+ *   - TERMINAL_BYPASS_SUBCOMMANDS: mutating sub-commands gated via the Rule-3b
+ *     terminal-bypass path (GH-276 complete, GH-339 cancel) — not blanket-safe
  *   - CHECK_AGENTS: /check agents that bypass /work step blocking
  *   - TRUSTED_SCRIPT_DIRS: directories where exempt scripts may live,
  *     realpath-normalised at module load (GH-452)
@@ -42,8 +44,10 @@ const EXEMPT_SCRIPTS = new Set([
 // Sub-command filtering for state scripts (GH-89).
 // work-state.js: exempt for get, resume-info, init, active-subtask, add-error.
 // workflow-state.js: exempt for get, resume-info, add-error (init blocked — not idempotent).
-// Mutating sub-commands (set-step, set-check, complete, etc.) must go through the orchestrator.
-// Exception: 'complete' is step-conditionally allowed at the terminal step via strict match (GH-276).
+// Mutating sub-commands (set-step, set-check, complete, cancel, etc.) must go through the orchestrator.
+// Exception: 'complete' (GH-276) and 'cancel' (GH-339) are step-conditionally
+// allowed via strict match — but through the Rule-3b terminal-bypass path, NOT
+// this blanket-safe set. See TERMINAL_BYPASS_SUBCOMMANDS below.
 const SAFE_SUBCOMMANDS = {
   'work-state.js': new Set([
     'get',
@@ -62,6 +66,21 @@ const SAFE_SUBCOMMANDS = {
   ]),
   'workflow-state.js': new Set(['get', 'resume-info', 'add-error']), // init excluded: not idempotent (resets all steps). exemptPatterns aligned.
   'session-guard.js': new Set(['init', 'status']), // SAFE_SUBCOMMANDS session-guard (GH-338)
+};
+
+// Sub-commands routed through the Rule-3b terminal-bypass path rather than the
+// blanket-safe set above (GH-276 complete, GH-339 cancel). These are NOT
+// read-only: they mutate terminal state, so they are gated by a strict-match +
+// planning/terminal-step precondition and rejected first in a dispatched-agent
+// context. They must stay OUT of SAFE_SUBCOMMANDS (a blanket-safe entry would
+// let a dispatched subagent invoke them unguarded) and IN alignment with
+// state-script-gate.js's isTerminalBypassEligible — the single Rule-3b predicate
+// this map mirrors. Kept co-located with the GH-695 task-advance note above.
+const TERMINAL_BYPASS_SUBCOMMANDS = {
+  // 'complete' is step-conditionally allowed at the terminal step (GH-276);
+  // 'cancel' is step-conditionally allowed in a planning phase (GH-339). Both
+  // are gated-via-bypass, never blanket-safe.
+  'work-state.js': new Set(['complete', 'cancel']),
 };
 
 // Agents legitimately used by /check that should bypass /work step blocking
@@ -161,6 +180,7 @@ debugLogTrustedDirs();
 module.exports = {
   EXEMPT_SCRIPTS, // legitimate state-file writers (Vector 3 exempt)
   SAFE_SUBCOMMANDS, // read-only/idempotent sub-commands per state script
+  TERMINAL_BYPASS_SUBCOMMANDS, // gated-via-terminal-bypass sub-commands (GH-276/GH-339)
   CHECK_AGENTS, // /check agents that bypass /work step blocking
   TRUSTED_SCRIPT_DIRS, // realpath-normalised trusted directories (GH-452)
   debugLogCandidatePath, // GH-452 per-call diagnostic

--- a/plugins/work/scripts/workflows/lib/hooks/policies/state-script-gate.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/state-script-gate.js
@@ -1,17 +1,12 @@
 /**
- * policies/state-script-gate.js
- *
- * Strict Bash-command gating for state scripts, extracted from
- * enforce-step-workflow.js:
- *
- *   - shellTokenize(): quote-aware tokenizer (lives in ./shell-tokenize,
- *     re-exported here)
- *   - isTerminalCompleteBypass(): `work-state.js complete` allowed only at
- *     the terminal `complete` step (GH-276)
- *   - isTerminalSessionGuardBypass(): session-guard.js finish/reveal/complete
- *     allowed only at the terminal step (GH-338)
- *   - checkUnsafeSubcommands(): Rule 3b — block unsafe sub-commands on state
- *     scripts invoked via node (GH-89)
+ * policies/state-script-gate.js — strict Bash-command gating for state scripts,
+ * extracted from enforce-step-workflow.js:
+ *   - shellTokenize(): quote-aware tokenizer (./shell-tokenize, re-exported)
+ *   - isTerminalCompleteBypass(): `work-state.js complete` at the terminal step (GH-276)
+ *   - isTerminalCancelBypass(): `work-state.js cancel` in a planning phase (GH-339)
+ *   - isTerminalSessionGuardBypass(): session-guard.js finish/reveal/complete at
+ *     the terminal step, or a cancelled state (GH-338 + GH-339)
+ *   - checkUnsafeSubcommands(): Rule 3b — block unsafe sub-commands (GH-89)
  */
 
 const path = require('path');
@@ -25,29 +20,27 @@ const {
 // Quote-aware tokenizer — extracted verbatim to ./shell-tokenize (file-size
 // burndown); re-exported below so consumers keep this import path.
 const { shellTokenize } = require('./shell-tokenize');
+// GH-339: single source of truth for the planning-phase cancel boundary (the
+// gate must not re-derive the ceiling that work-state's cancelWork enforces).
+const { isCancellablePhase } = require('../../../work/work-state/steps');
 
-// Strict token walk for `node <path>/work-state.js complete <ticket>`.
-// Env-assignment prefixes (FOO=bar node ...) are DISALLOWED entirely — they
-// would let an attacker inject `NODE_OPTIONS=--require=/evil/module` (or
-// NODE_PATH, LD_PRELOAD, DYLD_*, NODE_TLS_REJECT_UNAUTHORIZED, etc.) which
-// Node.js honors before executing the legitimate script. The bypass is for
-// the orchestrator's strict, direct call only — no wrappers, no env prefix.
-function extractCompleteArgs(tokens, trace) {
+// Shared strict token walk for `node <path>/work-state.js <subCmd> <ticket>`.
+// Env-assignment prefixes (FOO=bar node ...) are DISALLOWED entirely — they'd let
+// an attacker inject NODE_OPTIONS/NODE_PATH/LD_PRELOAD/DYLD_* (honored by Node
+// before the script runs). Orchestrator's strict direct call only: no wrappers,
+// env prefix, or node flags. Returns `{ scriptPath, targetTicket, next }` (caller
+// validates trailing tokens from `next`), or null on a bad prefix shape.
+function extractWorkStatePrefix(tokens, subCmd, trace) {
   let i = 0;
   if (!/^(?:node|nodejs)$/.test(tokens[i])) {
     trace('reject: no node token', { i, token: tokens[i] });
     return null;
   }
   i++;
-
-  // Strict bypass: no node flags allowed before the script path.
   if (i < tokens.length && tokens[i].startsWith('-')) {
     trace('reject: node flag before script', { token: tokens[i] });
     return null;
   }
-
-  // Script path token. Quote-stripping is unnecessary after normalization but
-  // kept defensively for nested-quote pathological inputs.
   if (i >= tokens.length) {
     trace('reject: no script token');
     return null;
@@ -58,28 +51,49 @@ function extractCompleteArgs(tokens, trace) {
     trace('reject: not work-state.js', { scriptPath });
     return null;
   }
-
-  // Sub-command must be exactly `complete`.
-  if (i >= tokens.length || tokens[i] !== 'complete') {
-    trace('reject: sub-command not complete', { token: tokens[i] });
+  if (i >= tokens.length || tokens[i] !== subCmd) {
+    trace(`reject: sub-command not ${subCmd}`, { token: tokens[i] });
     return null;
   }
   i++;
-
-  // Ticket arg.
   if (i >= tokens.length) {
     trace('reject: no ticket token');
     return null;
   }
-  const targetTicket = tokens[i];
-  i++;
+  return { scriptPath, targetTicket: tokens[i], next: i + 1 };
+}
 
-  // No trailing tokens allowed — strict format only.
+function extractCompleteArgs(tokens, trace) {
+  const p = extractWorkStatePrefix(tokens, 'complete', trace);
+  if (p === null) return null;
+  if (p.next !== tokens.length) {
+    trace('reject: trailing tokens', { remaining: tokens.slice(p.next) });
+    return null;
+  }
+  return { scriptPath: p.scriptPath, targetTicket: p.targetTicket };
+}
+
+// GH-339: `node <path>/work-state.js cancel <ticket> --reason <text>`. Reuses
+// extractWorkStatePrefix' scaffold, allows exactly one trailing `--reason
+// <value>` pair (the reason value is opaque / recorded verbatim).
+function extractCancelArgs(tokens, trace) {
+  const p = extractWorkStatePrefix(tokens, 'cancel', trace);
+  if (p === null) return null;
+  let i = p.next;
+  if (i >= tokens.length || tokens[i] !== '--reason') {
+    trace('reject: missing --reason', { token: tokens[i] });
+    return null;
+  }
+  i += 2; // consume `--reason` + its value
+  if (i > tokens.length) {
+    trace('reject: --reason without value');
+    return null;
+  }
   if (i !== tokens.length) {
     trace('reject: trailing tokens', { remaining: tokens.slice(i) });
     return null;
   }
-  return { scriptPath, targetTicket };
+  return { scriptPath: p.scriptPath, targetTicket: p.targetTicket };
 }
 
 // Skip env-assignment prefixes and the node token; reject node flags.
@@ -144,7 +158,9 @@ const DISPATCHED_AGENT_GUIDANCE =
 // GH-695: whether this (scriptBase, subCmd) pair is one of the terminal
 // bypasses — the only allowlist entries the dispatched-agent rejection guards.
 function isTerminalBypassEligible(scriptBase, subCmd) {
-  if (scriptBase === 'work-state.js') return subCmd === 'complete';
+  // GH-339: `cancel` joins `complete` as a terminal-bypass sub-command on
+  // work-state.js so a dispatched agent attempting it gets the guidance below.
+  if (scriptBase === 'work-state.js') return subCmd === 'complete' || subCmd === 'cancel';
   if (scriptBase === 'session-guard.js') {
     return subCmd === 'finish' || subCmd === 'reveal' || subCmd === 'complete';
   }
@@ -187,111 +203,109 @@ function isAtTerminalStep(deps, ticketId, trace, debugBypass) {
   return false;
 }
 
-/**
- * Step-conditional bypass for `work-state.js complete` at the terminal step (GH-276).
- * Returns true ONLY when ALL conditions are met:
- *   1. The context is NOT a dispatched agent (GH-695 — orchestrator-only)
- *   2. Command is a strict `node <path>/work-state.js complete <ticketId>` invocation
- *   3. No shell operators, substitutions, or extra arguments
- *   4. Target ticket matches the active ticket
- *   5. The workflow is at the terminal `complete` step
- */
-function isTerminalCompleteBypass(deps, cmd, ticketId, hookData) {
-  const DEBUG_BYPASS = process.env.ENFORCE_HOOK_DEBUG === '1';
-  const trace = makeTrace(DEBUG_BYPASS);
+// Quote-aware tokenizer (work-state bypasses): treats quoted runs as one token
+// so paths with spaces survive; unbalanced quotes → null → reject.
+function tokenizeQuoteAware(cmd) {
+  return shellTokenize(String(cmd).trim());
+}
 
-  // GH-695: reject FIRST when the caller is ANY dispatched agent — gates that
-  // only bind the orchestrator are not gates.
+// GH-338 tokenizer (session-guard bypass): strip balanced quote pairs, then
+// split — quoted and unquoted forms tokenize identically on every Node / OS.
+function tokenizeStripQuotes(cmd) {
+  return String(cmd)
+    .trim()
+    .replace(/"([^"]*)"/g, '$1')
+    .replace(/'([^']*)'/g, '$1')
+    .split(/\s+/);
+}
+
+// Shared strict-invocation checks for the terminal bypasses (GH-276 complete,
+// GH-339 cancel, GH-338 session-guard): dispatched-agent rejection FIRST
+// (GH-695), no shell metachars, tokenize, extractor-parsed strict shape, trusted
+// script path, ticket match. Returns `true` when all pass; the caller then
+// applies its own step/status predicate.
+function passesStrictBypass(deps, cmd, ticketId, hookData, extractArgs, trace, tokenize) {
+  // GH-695: reject FIRST when the caller is ANY dispatched agent.
   if (isDispatchedContext(deps, hookData)) {
     trace('reject: dispatched-agent context');
     return false;
   }
-
-  // Reject shell operators and substitutions — cheapest syntactic fail-fast.
   if (/[;&|$`<>(){}\n]/.test(cmd)) {
     trace('reject: shell metachars');
     return false;
   }
-
-  // Quote-aware tokenizer: split on whitespace BUT treat quoted runs as one
-  // token. This is critical for paths containing spaces (e.g. macOS
-  // `/Users/John Smith/...`). Unbalanced quotes return null → reject.
-  const tokens = shellTokenize(String(cmd).trim());
+  const tokens = tokenize(cmd);
   if (tokens === null) {
     trace('reject: unbalanced quotes');
     return false;
   }
   trace('tokens', { count: tokens.length, tokens });
 
-  // Expect exactly: node <path/work-state.js> complete <ticket>
-  if (tokens.length !== 4) {
-    trace('reject: token count not 4');
-    return false;
-  }
-
-  const args = extractCompleteArgs(tokens, trace);
+  const args = extractArgs(tokens, trace);
   if (args === null) return false;
 
-  // Verify script path is trusted.
   const resolvedPath = expandPluginRoot(args.scriptPath);
   deps.debugLogCandidatePath(resolvedPath);
   if (!isTrustedScriptPath(resolvedPath, deps.trustedDirs)) {
     trace('reject: untrusted script path', { resolvedPath });
     return false;
   }
-
-  // Verify ticket arg matches active ticket.
   if (args.targetTicket !== ticketId) {
     trace('reject: ticket mismatch', { targetTicket: args.targetTicket, ticketId });
     return false;
   }
+  return true;
+}
 
+// Step-conditional bypass for `work-state.js complete` (GH-276): passesStrictBypass
+// (dispatched-rejected, strict shape, trusted path, ticket match) AND the workflow
+// is at the terminal `complete` step.
+function isTerminalCompleteBypass(deps, cmd, ticketId, hookData) {
+  const DEBUG_BYPASS = process.env.ENFORCE_HOOK_DEBUG === '1';
+  const trace = makeTrace(DEBUG_BYPASS);
+  const args = [deps, cmd, ticketId, hookData, extractCompleteArgs, trace, tokenizeQuoteAware];
+  if (!passesStrictBypass(...args)) return false;
   if (!isAtTerminalStep(deps, ticketId, trace, DEBUG_BYPASS)) return false;
   trace('allow');
   return true;
 }
 
-/**
- * Step-conditional bypass for session-guard.js finish/reveal/complete at
- * the terminal step (GH-338). Mirrors isTerminalCompleteBypass() but for
- * session-guard.js subcommands.
- */
-function isTerminalSessionGuardBypass(deps, cmd, ticketId, hookData) {
-  // GH-695: reject FIRST when the caller is ANY dispatched agent.
-  if (isDispatchedContext(deps, hookData)) {
-    makeTrace(
-      process.env.ENFORCE_HOOK_DEBUG === '1',
-      'isTerminalSessionGuardBypass'
-    )('reject: dispatched-agent context');
+// Step-conditional bypass for `work-state.js cancel <ticket> --reason <text>`
+// (GH-339): passesStrictBypass AND the workflow is at a cancellable (planning)
+// step. Gates on isCancellablePhase instead of the terminal `complete` step.
+function isTerminalCancelBypass(deps, cmd, ticketId, hookData) {
+  const trace = makeTrace(process.env.ENFORCE_HOOK_DEBUG === '1', 'isTerminalCancelBypass');
+  const args = [deps, cmd, ticketId, hookData, extractCancelArgs, trace, tokenizeQuoteAware];
+  if (!passesStrictBypass(...args)) return false;
+  const state = deps.loadStateFile(ticketId, '.work-state.json');
+  const currentStep = deps.getCurrentStep(state, deps.workSteps);
+  if (!isCancellablePhase(currentStep)) {
+    trace('reject: not a cancellable (planning) step', { currentStep });
     return false;
   }
+  trace('allow');
+  return true;
+}
 
-  // Reject shell operators and substitutions — cheapest syntactic fail-fast.
-  if (/[;&|$`<>(){}\n]/.test(cmd)) return false;
-
-  // Normalize by stripping balanced surrounding quote pairs (see
-  // isTerminalCompleteBypass for rationale). Keeps quoted and unquoted forms
-  // tokenizing identically on every Node version / OS.
-  const normalized = String(cmd)
-    .trim()
-    .replace(/"([^"]*)"/g, '$1')
-    .replace(/'([^']*)'/g, '$1');
-
-  // Token-based parsing (see isTerminalCompleteBypass for rationale).
-  const tokens = normalized.split(/\s+/);
-  if (tokens.length < 4) return false;
-
-  const args = extractSessionGuardArgs(tokens);
-  if (args === null) return false;
-
-  const resolvedPath = expandPluginRoot(args.scriptPath);
-  deps.debugLogCandidatePath(resolvedPath);
-  if (!isTrustedScriptPath(resolvedPath, deps.trustedDirs)) return false;
-
-  if (args.targetTicket !== ticketId) return false;
-
+// Step-conditional bypass for session-guard.js finish/reveal/complete (GH-338):
+// passesStrictBypass (strip-quote tokenizer, env-prefix-tolerant extractor) AND
+// a released terminal state (complete step, or GH-339 cancelled status).
+function isTerminalSessionGuardBypass(deps, cmd, ticketId, hookData) {
+  const trace = makeTrace(process.env.ENFORCE_HOOK_DEBUG === '1', 'isTerminalSessionGuardBypass');
+  const args = [deps, cmd, ticketId, hookData, extractSessionGuardArgs, trace, tokenizeStripQuotes];
+  if (!passesStrictBypass(...args)) return false;
   const state = deps.loadStateFile(ticketId, '.work-state.json');
-  return deps.getCurrentStep(state, deps.workSteps) === 'complete';
+  // GH-338: the terminal `complete` step releases the guard. GH-339 additively
+  // allows release when the workflow was cancelled (status === 'cancelled'),
+  // WITHOUT weakening the dispatched-agent rejection above or the complete-step
+  // allowance — the cancel path is the sanctioned atomic teardown too.
+  return isReleasedTerminalState(deps.getCurrentStep(state, deps.workSteps), state);
+}
+
+// GH-339: guard release is sanctioned at the terminal `complete` step (GH-338)
+// OR when the state was cancelled — a named predicate keeps the OR additive.
+function isReleasedTerminalState(currentStep, state) {
+  return currentStep === 'complete' || state?.status === 'cancelled';
 }
 
 // Step-conditional bypasses shared by Rule 3 and Rule 3b.
@@ -299,6 +313,10 @@ function isTerminalBypassAllowed(deps, scriptBase, subCmd, cmd, ticketId, hookDa
   // work-state.js complete at terminal step (GH-276)
   if (scriptBase === 'work-state.js' && subCmd === 'complete') {
     return isTerminalCompleteBypass(deps, cmd, ticketId, hookData);
+  }
+  // work-state.js cancel in a planning phase (GH-339) — Rule 3b, dispatched first
+  if (scriptBase === 'work-state.js' && subCmd === 'cancel') {
+    return isTerminalCancelBypass(deps, cmd, ticketId, hookData);
   }
   // session-guard.js finish/reveal/complete at terminal step (GH-338)
   if (

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard/__tests__/hook-handlers.test.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard/__tests__/hook-handlers.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+/**
+ * hook-handlers.test.js — Stop-hook cancelled-status allowance (GH-339 Task 5).
+ *
+ * Spawns the session-guard Stop hook (child_process pattern, per CLAUDE.md) with
+ * an owned active session and a `.work-state.json` fixture. Asserts:
+ *   - status `cancelled`  → exit 0, no "DO NOT ABANDON" block on stderr
+ *   - status `in_progress`→ exit 2, block message on stderr (no regression)
+ *   - `abort workflow` keyword still allows the stop (exit 0) and redirects the
+ *     operator toward the bookkept `work.workflow.js cancel` subcommand.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Stop-hook entrypoint: lib/hooks/session-guard.js (dispatches to handleStop).
+const GUARD = path.resolve(__dirname, '..', '..', 'session-guard.js');
+
+const TICKET = 'AAA-1';
+
+describe('session-guard Stop hook — cancelled-status allowance', () => {
+  let tmp;
+  let cwd;
+  let envBase;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hook-handlers-'));
+    cwd = path.join(tmp, 'cwd');
+    fs.mkdirSync(cwd, { recursive: true });
+    envBase = {
+      SESSION_GUARD_DIR: path.join(tmp, 'sg'),
+      SESSION_GUARD_TICKET_ID: TICKET,
+      TASKS_BASE: path.join(tmp, 'tasks'),
+      WORKTREES_BASE: tmp,
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function run(args, { input, env = {} } = {}) {
+    const merged = { ...process.env, ...envBase, ...env };
+    for (const key of [
+      'AGENT_RUNTIME',
+      'AGENT_SESSION_ID',
+      'CLAUDE_CODE_SESSION_ID',
+      'CLAUDE_HOOK_TYPE',
+    ]) {
+      if (!(key in env)) delete merged[key];
+    }
+    const r = spawnSync(process.execPath, [GUARD, ...args], {
+      input: input === undefined ? '' : input,
+      encoding: 'utf8',
+      cwd,
+      timeout: 15000,
+      env: merged,
+    });
+    return { code: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+  }
+
+  function stop(payload, env = {}) {
+    return run([], { input: JSON.stringify(payload), env: { CLAUDE_HOOK_TYPE: 'Stop', ...env } });
+  }
+
+  /** Write `$TASKS_BASE/<ticket>/.work-state.json` with the given status. */
+  function writeWorkState(status) {
+    const ticketDir = path.join(envBase.TASKS_BASE, TICKET);
+    fs.mkdirSync(ticketDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(ticketDir, '.work-state.json'),
+      JSON.stringify({ ticketId: TICKET, currentStep: 3, status }, null, 2)
+    );
+  }
+
+  it('the Stop hook allows stopping when work state status is cancelled', () => {
+    run(['init', TICKET, '/work'], { env: { CLAUDE_CODE_SESSION_ID: 'owner-A' } });
+    writeWorkState('cancelled');
+    const r = stop(
+      { session_id: 'owner-A', stop_hook_active: false },
+      { CLAUDE_CODE_SESSION_ID: 'owner-A' }
+    );
+    assert.equal(r.code, 0, 'cancelled state must allow the stop');
+    assert.equal(r.stderr, '', 'no DO NOT ABANDON block message for a cancelled ticket');
+  });
+
+  it('the Stop hook still blocks an in-progress owned session (no regression)', () => {
+    run(['init', TICKET, '/work'], { env: { CLAUDE_CODE_SESSION_ID: 'owner-A' } });
+    writeWorkState('in_progress');
+    const r = stop(
+      { session_id: 'owner-A', stop_hook_active: false },
+      { CLAUDE_CODE_SESSION_ID: 'owner-A' }
+    );
+    assert.equal(r.code, 2, 'in-progress state must still block the stop');
+    assert.match(r.stderr, /DO NOT (STOP|ABANDON)/, 'in-progress block message must be present');
+  });
+
+  it('the abort workflow keyword allows the stop and redirects to the cancel subcommand', () => {
+    run(['init', TICKET, '/work'], { env: { CLAUDE_CODE_SESSION_ID: 'owner-A' } });
+    writeWorkState('in_progress');
+    const r = stop(
+      { session_id: 'owner-A', stop_hook_active: false, stop_message: 'please abort workflow now' },
+      { CLAUDE_CODE_SESSION_ID: 'owner-A' }
+    );
+    assert.equal(r.code, 0, 'abort workflow keyword must allow the stop');
+    assert.match(
+      r.stderr,
+      /work\.workflow\.js"? cancel/,
+      'stderr must redirect the operator to the cancel subcommand'
+    );
+  });
+
+  it('a stop message without the abort keyword is unaffected by the redirect', () => {
+    run(['init', TICKET, '/work'], { env: { CLAUDE_CODE_SESSION_ID: 'owner-A' } });
+    writeWorkState('in_progress');
+    const r = stop(
+      { session_id: 'owner-A', stop_hook_active: false, stop_message: 'just a normal message' },
+      { CLAUDE_CODE_SESSION_ID: 'owner-A' }
+    );
+    assert.equal(r.code, 2, 'a non-keyword stop still blocks');
+    assert.doesNotMatch(
+      r.stderr,
+      /work\.workflow\.js"? cancel/,
+      'no cancel redirect for a non-keyword stop'
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard/hook-handlers.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard/hook-handlers.js
@@ -21,6 +21,15 @@ const {
 } = require(path.join(__dirname, 'context'));
 const { findActiveSessions } = require(path.join(__dirname, 'store'));
 
+// Operator guidance printed when a stop carries the `abort workflow` keyword.
+// The keyword still allows the stop; this redirects the operator toward the
+// single bookkept cancellation route (the `cancel` subcommand) so cancellation
+// stays auditable rather than an ad-hoc abandon.
+const ABORT_KEYWORD_GUIDANCE =
+  'Stop allowed via "abort workflow" keyword.\n' +
+  'To cancel this workflow with bookkeeping (state + audit + guard release + archive), run:\n' +
+  '  node "${CLAUDE_PLUGIN_ROOT}/scripts/workflows/work/engine/work.workflow.js" cancel <TICKET> --reason "<reason>"\n';
+
 /**
  * Active sessions owned by THIS terminal/worktree. Sessions owned by a
  * different terminal or worktree are dropped (lock bleed): without this, a
@@ -33,6 +42,23 @@ function ownedActiveSessions(hookData) {
   const csid = currentSessionId(hookData);
   const currentRoot = resolveWorktreeRoot();
   return findActiveSessions().filter((s) => !isOtherOwner(s, csid, currentRoot));
+}
+
+/**
+ * True when the ticket's `.work-state.json` marks the workflow as `cancelled`.
+ * A cancelled workflow is a bookkept terminal state (via the `cancel`
+ * subcommand), so the Stop guard should allow the stop with no block message —
+ * mirroring the `isCheckWorkflowActive` allowance. Fails safe (false) when the
+ * state file is missing or unreadable.
+ */
+function isCancelledWorkState(ticketId) {
+  try {
+    const raw = readTicketArtifact(ticketId, '.work-state.json');
+    if (!raw) return false;
+    return JSON.parse(raw)?.status === 'cancelled';
+  } catch {
+    return false; /* unreadable — fall through to the normal block path */
+  }
 }
 
 function handlePreCompact(hookData) {
@@ -194,6 +220,7 @@ function handleStop(hookData) {
   // Check for abort keyword in stop message
   const stopMessage = hookData?.stop_message || '';
   if (/abort\s+workflow/i.test(stopMessage)) {
+    process.stderr.write(ABORT_KEYWORD_GUIDANCE);
     process.exit(0);
     return;
   }
@@ -208,6 +235,13 @@ function handleStop(hookData) {
   // Check if any owned session is unrevealed (tests: cwd match, no-match, legacy without cwd)
   const unrevealed = ownedSessions.filter((s) => !s.revealed);
   if (unrevealed.length === 0) {
+    process.exit(0);
+    return;
+  }
+
+  // Allow stop when ALL unrevealed sessions are cancelled (bookkept terminal
+  // state via the `cancel` subcommand) — no block message, mirroring /check.
+  if (unrevealed.every((s) => isCancelledWorkState(s.ticketId))) {
     process.exit(0);
     return;
   }

--- a/plugins/work/scripts/workflows/work/engine/__tests__/cli.test.js
+++ b/plugins/work/scripts/workflows/work/engine/__tests__/cli.test.js
@@ -1,0 +1,248 @@
+/**
+ * Tests for work/engine/cli.js — GH-339 `cancel` subcommand (Task 6).
+ *
+ * Uses node:test + node:assert/strict (plugin convention — no Jest/Mocha).
+ * The orchestrator CLI is exercised by spawning `work.workflow.js` via
+ * child_process (the established plugin pattern — "Tests spawn hook scripts
+ * with child_process.spawn to test exit codes"), with env vars set so
+ * lib/config resolves TASKS_BASE/WORKTREES_BASE to a temp dir, SESSION_GUARD_DIR
+ * to a temp dir, and TICKET_PROVIDER=none so ticket parsing is hermetic.
+ *
+ * The `cancel` case delegates the state mutation to the work-state `cancel`
+ * mutator and the guard release to the session-guard `finish` teardown, both
+ * invoked as REAL child processes (this test does not stub them — it is the
+ * integration/e2e coverage the gherkin @e2e:task:6 scenarios describe).
+ *
+ * Run: node --test scripts/workflows/work/engine/__tests__/cli.test.js
+ */
+
+'use strict';
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const WORK_WORKFLOW_JS = path.join(__dirname, '..', 'work.workflow.js');
+const SESSION_GUARD_JS = path.join(__dirname, '..', '..', '..', 'lib', 'hooks', 'session-guard.js');
+const { ALL_STEPS, STEP_ORDER } = require(path.join(__dirname, '..', '..', 'step-registry'));
+
+let TEMP_TASKS_BASE;
+let TEMP_SESSION_DIR;
+const origEnv = { ...process.env };
+
+before(() => {
+  TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'engine-cli-cancel-'));
+  TEMP_SESSION_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'engine-cli-sg-'));
+});
+
+after(() => {
+  Object.assign(process.env, origEnv);
+  for (const dir of [TEMP_TASKS_BASE, TEMP_SESSION_DIR]) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+// ─── State helpers ───────────────────────────────────────────────────────────
+
+// Build a realistic work-state where `activeStep` is the current step: every
+// prior step 'completed', the active step 'in_progress', the rest 'pending'.
+function stateAtStep(ticketId, activeStep) {
+  const activeIndex = STEP_ORDER.indexOf(activeStep);
+  assert.ok(activeIndex >= 0, `unknown step: ${activeStep}`);
+  const stepStatus = {};
+  ALL_STEPS.forEach((step, i) => {
+    if (i < activeIndex) stepStatus[step] = 'completed';
+    else if (i === activeIndex) stepStatus[step] = 'in_progress';
+    else stepStatus[step] = 'pending';
+  });
+  return {
+    ticketId,
+    description: '',
+    currentStep: activeIndex + 1,
+    status: 'in_progress',
+    stepStatus,
+    checkProgress: {},
+    errors: [],
+    startTime: new Date().toISOString(),
+    lastUpdate: new Date().toISOString(),
+  };
+}
+
+function ticketDir(ticketId) {
+  return path.join(TEMP_TASKS_BASE, ticketId);
+}
+
+function writeState(ticketId, state) {
+  const dir = ticketDir(ticketId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '.work-state.json'), JSON.stringify(state, null, 2));
+}
+
+function readState(ticketId) {
+  const fp = path.join(ticketDir(ticketId), '.work-state.json');
+  return JSON.parse(fs.readFileSync(fp, 'utf-8'));
+}
+
+function writePlanningArtifact(ticketId, name, body) {
+  const dir = ticketDir(ticketId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), body);
+}
+
+function sessionFilePath(ticketId) {
+  const sanitized = String(ticketId).replace(/[/\\:\0]/g, '_');
+  return path.join(TEMP_SESSION_DIR, `claude-session-guard-${sanitized}.json`);
+}
+
+function childEnv() {
+  return {
+    ...process.env,
+    TASKS_BASE: TEMP_TASKS_BASE,
+    WORKTREES_BASE: TEMP_TASKS_BASE,
+    SESSION_GUARD_DIR: TEMP_SESSION_DIR,
+    REPO_NAME: 'test',
+    TICKET_PROVIDER: 'none',
+  };
+}
+
+// Spawn `work.workflow.js <args...>` with the temp env.
+function runCli(args) {
+  return spawnSync(process.execPath, [WORK_WORKFLOW_JS, ...args], {
+    encoding: 'utf-8',
+    env: childEnv(),
+  });
+}
+
+// Create a locked session guard file via the sanctioned session-guard init.
+function initSessionGuard(ticketId) {
+  const res = spawnSync(process.execPath, [SESSION_GUARD_JS, 'init', ticketId, 'work'], {
+    encoding: 'utf-8',
+    env: childEnv(),
+  });
+  assert.equal(res.status, 0, `session-guard init must exit 0; stderr=${res.stderr}`);
+  assert.ok(fs.existsSync(sessionFilePath(ticketId)), 'session guard file must exist after init');
+}
+
+// ─── Scenario 1: cancel during brief phase ───────────────────────────────────
+
+describe('GH-339 orchestrator CLI — cancel subcommand', () => {
+  it('orchestrator cancel during brief phase releases the guard and archives artifacts', () => {
+    const ticket = 'CANCEL6-BRIEF';
+    fs.rmSync(ticketDir(ticket), { recursive: true, force: true });
+
+    writeState(ticket, stateAtStep(ticket, 'brief'));
+    writePlanningArtifact(ticket, 'brief.md', '# Brief\nbulk endpoint pattern does not exist\n');
+    writePlanningArtifact(ticket, 'spec.md', '# Spec\n');
+    initSessionGuard(ticket);
+
+    const res = runCli(['cancel', ticket, '--reason', 'bulk endpoint pattern does not exist']);
+    assert.equal(res.status, 0, `cancel at brief must exit 0; stderr=${res.stderr}`);
+
+    // (1) state status becomes cancelled (never completed)
+    const persisted = readState(ticket);
+    assert.equal(persisted.status, 'cancelled', 'state status must be cancelled');
+    assert.notEqual(persisted.status, 'completed', 'must never become completed');
+    assert.equal(
+      persisted.cancelReason,
+      'bulk endpoint pattern does not exist',
+      'reason recorded verbatim in state'
+    );
+
+    // (2) session guard file removed by the finish teardown
+    assert.ok(
+      !fs.existsSync(sessionFilePath(ticket)),
+      'session guard file must be removed after cancel'
+    );
+
+    // (3) brief.md moved under tasks/<TICKET>/archive/
+    const archiveDir = path.join(ticketDir(ticket), 'archive');
+    assert.ok(fs.existsSync(path.join(archiveDir, 'brief.md')), 'brief.md must be archived');
+    assert.ok(
+      !fs.existsSync(path.join(ticketDir(ticket), 'brief.md')),
+      'brief.md must no longer be at the top of the ticket dir'
+    );
+
+    // (4) operator summary line + JSON response reporting ticket/reason/phase/archive
+    const out = res.stdout;
+    assert.match(out, /cancel/i, 'summary must mention cancellation');
+    assert.match(out, /bulk endpoint pattern does not exist/, 'summary must report the reason');
+    assert.match(out, /brief/, 'summary must report the phase-at-cancel (brief)');
+    assert.match(out, /archive/, 'summary must report the archive location');
+
+    // JSON response shape: { ticket, status:'cancelled', reason, phaseAtCancel, archiveLocation }
+    const jsonMatch = out.match(/\{[\s\S]*"status"\s*:\s*"cancelled"[\s\S]*\}/);
+    assert.ok(jsonMatch, 'a JSON response with status cancelled must be printed');
+    const parsed = JSON.parse(jsonMatch[0]);
+    assert.equal(parsed.status, 'cancelled', 'JSON status is cancelled');
+    assert.equal(parsed.reason, 'bulk endpoint pattern does not exist', 'JSON reason recorded');
+    assert.equal(parsed.phaseAtCancel, 'brief', 'JSON phaseAtCancel is brief');
+    assert.ok(parsed.archiveLocation, 'JSON archiveLocation present');
+
+    fs.rmSync(ticketDir(ticket), { recursive: true, force: true });
+  });
+
+  // ─── Scenario 2: cancel at implement refuses by default ────────────────────
+
+  it('orchestrator cancel at the implement step refuses by default', () => {
+    const ticket = 'CANCEL6-IMPL';
+    fs.rmSync(ticketDir(ticket), { recursive: true, force: true });
+
+    writeState(ticket, stateAtStep(ticket, 'implement'));
+    writePlanningArtifact(ticket, 'brief.md', '# Brief\n');
+    writePlanningArtifact(ticket, 'tasks.md', '# Tasks\n');
+    initSessionGuard(ticket);
+
+    const res = runCli(['cancel', ticket, '--reason', 'too late']);
+
+    // Refuse-by-default: exit non-zero without mutating or archiving.
+    assert.notEqual(res.status, 0, 'cancel at implement must exit non-zero');
+
+    // AskUserQuestion confirmation that defaults to refusing is surfaced.
+    const combined = `${res.stdout}\n${res.stderr}`;
+    assert.match(combined, /AskUserQuestion/, 'an AskUserQuestion confirmation must be surfaced');
+
+    // Status stays in_progress — nothing mutated.
+    const after = readState(ticket);
+    assert.equal(after.status, 'in_progress', 'status must remain in_progress at implement');
+    assert.notEqual(after.status, 'cancelled', 'status must not flip to cancelled at implement');
+
+    // Nothing archived.
+    assert.ok(
+      !fs.existsSync(path.join(ticketDir(ticket), 'archive')),
+      'no archive/ directory may be created when cancel is refused'
+    );
+
+    // Session guard file untouched (not released).
+    assert.ok(
+      fs.existsSync(sessionFilePath(ticket)),
+      'session guard file must remain when cancel is refused'
+    );
+
+    fs.rmSync(ticketDir(ticket), { recursive: true, force: true });
+  });
+
+  // ─── Guard: parse/usage failures exit 1 ────────────────────────────────────
+
+  it('exits 1 when --reason is missing', () => {
+    const ticket = 'CANCEL6-NOREASON';
+    fs.rmSync(ticketDir(ticket), { recursive: true, force: true });
+    writeState(ticket, stateAtStep(ticket, 'brief'));
+
+    const res = runCli(['cancel', ticket]);
+    assert.equal(res.status, 1, 'missing --reason must exit 1');
+
+    const after = readState(ticket);
+    assert.equal(after.status, 'in_progress', 'state untouched when reason missing');
+    fs.rmSync(ticketDir(ticket), { recursive: true, force: true });
+  });
+
+  it('exits 1 on a ticket parse failure', () => {
+    const res = runCli(['cancel', '', '--reason', 'r']);
+    assert.equal(res.status, 1, 'ticket parse failure must exit 1');
+  });
+});

--- a/plugins/work/scripts/workflows/work/engine/__tests__/cli.test.js
+++ b/plugins/work/scripts/workflows/work/engine/__tests__/cli.test.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-const { describe, it, before, after, beforeEach } = require('node:test');
+const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const { spawnSync } = require('child_process');
 const path = require('path');

--- a/plugins/work/scripts/workflows/work/engine/cli-cancel.js
+++ b/plugins/work/scripts/workflows/work/engine/cli-cancel.js
@@ -1,0 +1,245 @@
+/**
+ * cli-cancel.js
+ *
+ * GH-339: the `cancel` subcommand machinery for work.workflow.js's cli.
+ * Extracted from cli.js to keep the entry-point module within the static
+ * quality budget (max-lines / max-lines-per-function). `runCancel` is the only
+ * export; every helper here is private to the cancel flow.
+ *
+ * All runtime side effects (state mutation, guard release) are spawned as child
+ * processes through the SANCTIONED entry points — this module never edits their
+ * source and never bypasses a guard directly.
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+
+const { STEP_ORDER } = require(path.join(__dirname, '..', 'step-registry'));
+const { isCancellablePhase } = require(path.join(__dirname, '..', 'work-state', 'steps'));
+const getConfig = require(path.join(__dirname, '..', '..', 'lib', 'get-config'));
+
+// Sibling child-process entry points invoked by the `cancel` subcommand.
+// The mutation runs through the work-state `cancel` mutator and the guard
+// release runs through the SANCTIONED session-guard `finish` teardown (reveal +
+// unlink session file) — exactly as the `complete` step does. Both are spawned
+// as child processes; their source files are never edited here.
+const WORK_STATE_JS = path.join(__dirname, '..', 'work-state.js');
+const SESSION_GUARD_JS = path.join(__dirname, '..', '..', 'lib', 'hooks', 'session-guard.js');
+
+// GH-339: the step-ordered artifact set moved into tasks/<TICKET>/archive/ on a
+// successful cancel — planning docs + enforcement/audit files.
+const ARCHIVE_ARTIFACTS = [
+  'brief.md',
+  'spec.md',
+  'tasks.md',
+  '.work-actions.json',
+  'tdd-phase.json',
+];
+
+/**
+ * Derive the current step from a work-state: the first step flagged
+ * 'in_progress', falling back to state.currentStep (1-indexed). Returns null
+ * when neither yields a known step. Mirrors work-state/steps.js:currentStepOf
+ * (not exported there) so cli-cancel.js can compute phaseAtCancel without
+ * importing a private symbol.
+ * @param {object} state
+ * @returns {string|null}
+ */
+function phaseOfState(state) {
+  const stepStatus = (state && state.stepStatus) || {};
+  const inProgress = STEP_ORDER.find((step) => stepStatus[step] === 'in_progress');
+  if (inProgress) return inProgress;
+  const idx = Number(state && state.currentStep) - 1;
+  return STEP_ORDER[idx] || null;
+}
+
+/**
+ * Parse + sanitize a raw ticket argument into filesystem-safe forms, reusing
+ * the same scaffold the `transition`/`transitions`/`actions` cases use
+ * (parseTicketInput → uppercase base → sanitizeTicketIdForPath → append the
+ * optional suffix). Throws (via parseTicketInput) on a parse failure so the
+ * caller decides how to report + exit.
+ * @param {string} rawTicket
+ * @param {{ parseTicketInput: Function, tp: object, providerCfg: object }} args
+ * @returns {{ safeBase: string, safeName: string, suffix: (string|null) }}
+ */
+function resolveSafeTicket(rawTicket, { parseTicketInput, tp, providerCfg }) {
+  const parsed = parseTicketInput(rawTicket);
+  const base = String(parsed.ticketBase).toUpperCase();
+  const safeBase = tp.sanitizeTicketIdForPath(base, providerCfg);
+  const safeName = safeBase + (parsed.suffix ? '/' + parsed.suffix : '');
+  return { safeBase, safeName, suffix: parsed.suffix || null };
+}
+
+/**
+ * GH-339: Move the planning + enforcement artifact set from `tasksDir` into
+ * `tasksDir/archive/` (created + merged into if it already exists). Each source
+ * path is resolved and prefix-checked to stay under tasksDir before the move.
+ * Returns the resolved archive directory path.
+ * @param {string} tasksDir
+ * @returns {string} archive directory
+ */
+function archivePlanningArtifacts(tasksDir) {
+  const archiveDir = path.join(tasksDir, 'archive');
+  const resolvedTasksDir = path.resolve(tasksDir);
+  const prefix = resolvedTasksDir.endsWith(path.sep)
+    ? resolvedTasksDir
+    : resolvedTasksDir + path.sep;
+  fs.mkdirSync(archiveDir, { recursive: true });
+  for (const name of ARCHIVE_ARTIFACTS) {
+    const src = path.resolve(tasksDir, name);
+    // Resolved-path prefix guard: never move anything outside the ticket dir.
+    if (!src.startsWith(prefix)) continue;
+    if (!fs.existsSync(src) || !fs.statSync(src).isFile()) continue;
+    fs.renameSync(src, path.join(archiveDir, name));
+  }
+  return archiveDir;
+}
+
+// Print a `{ error, message }` JSON envelope and exit(code) (default 1).
+function exitWithError(message, code = 1) {
+  console.log(JSON.stringify({ error: true, message }));
+  process.exit(code);
+}
+
+// True when `phase` sits at or after the `implement` step in STEP_ORDER.
+function isAtOrAfterImplement(phase) {
+  const implementIdx = STEP_ORDER.indexOf('implement');
+  const phaseIdx = STEP_ORDER.indexOf(phase);
+  return phaseIdx >= 0 && implementIdx >= 0 && phaseIdx >= implementIdx;
+}
+
+/**
+ * GH-339: emit the AskUserQuestion refuse-by-default confirmation for a cancel
+ * requested at/after `implement` (code has been written) and exit non-zero.
+ * Never mutates or archives.
+ * @param {string} safeBase
+ * @param {string} phaseAtCancel
+ */
+function emitCancelRefusal(safeBase, phaseAtCancel) {
+  console.log(
+    JSON.stringify(
+      {
+        action: 'blocked',
+        reason: `Cancel refused: code has been written (phase "${phaseAtCancel}" is at/after implement).`,
+        userQuestions: [
+          {
+            tool: 'AskUserQuestion',
+            question: `Cancel /work for ${safeBase} at "${phaseAtCancel}"? Code has already been written. This is refused by default.`,
+            options: ['No — keep working (default)', 'Yes — abandon anyway'],
+            default: 'No — keep working (default)',
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+  process.exit(2);
+}
+
+/**
+ * GH-339: mutate → release → archive → summary on a cancellable phase.
+ *   (1) work-state `cancel` mutator (child process),
+ *   (2) SANCTIONED guard `finish` teardown (child process; non-fatal),
+ *   (3) archive planning + enforcement artifacts,
+ *   (4) print the operator summary line + JSON response.
+ * @param {{ safeBase: string, safeName: string, reason: string, phaseAtCancel: string }} p
+ */
+function runCancelSequence({ safeBase, safeName, reason, phaseAtCancel }) {
+  // (1) Mutate state via the work-state `cancel` mutator (child process).
+  try {
+    execFileSync(process.execPath, [WORK_STATE_JS, 'cancel', safeName, '--reason', reason], {
+      encoding: 'utf8',
+      timeout: 10000,
+      stdio: 'pipe',
+    });
+  } catch (err) {
+    const msg = err.stderr || err.stdout || err.message || String(err);
+    exitWithError(`cancel mutator failed: ${msg}`);
+  }
+
+  // (2) Release the guard via the SANCTIONED `finish` teardown (reveal + unlink
+  // session file). Non-fatal — no session may be active.
+  try {
+    execFileSync(process.execPath, [SESSION_GUARD_JS, 'finish', safeBase], {
+      encoding: 'utf8',
+      timeout: 10000,
+      stdio: 'pipe',
+    });
+  } catch {
+    /* guard may be disabled / already released — non-fatal */
+  }
+
+  // (3) Archive planning + enforcement artifacts to tasks/<TICKET>/archive/.
+  const tasksBase =
+    getConfig('TASKS_BASE') ||
+    (getConfig('WORKTREES_BASE') ? path.join(getConfig('WORKTREES_BASE'), 'tasks') : '');
+  const tasksDir = path.join(tasksBase, safeName);
+  const archiveLocation = archivePlanningArtifacts(tasksDir);
+
+  // (4) Operator summary line + JSON response.
+  console.log(
+    `Cancelled ${safeBase} — reason: ${reason} | phase: ${phaseAtCancel} | archived to: ${archiveLocation}`
+  );
+  console.log(
+    JSON.stringify(
+      { ticket: safeBase, status: 'cancelled', reason, phaseAtCancel, archiveLocation },
+      null,
+      2
+    )
+  );
+}
+
+/**
+ * GH-339: the `cancel` subcommand. Parse ticket + `--reason`, load state,
+ * compute phaseAtCancel; refuse-by-default at/after implement, reject before
+ * implement when past the cancel ceiling, else run the mutate→release→archive→
+ * summary sequence. Exits the process on every terminal branch.
+ * @param {string[]} rest — argv after the `cancel` token
+ * @param {object} deps — the injected cli deps (parseTicketInput, tp, loadWorkState, requirePaths)
+ */
+function runCancel(rest, deps) {
+  const { parseTicketInput, tp, loadWorkState, requirePaths } = deps;
+  requirePaths();
+
+  // Parse ticket via the shared scaffold. Parse failure exits 1 without mutating.
+  const providerCfg = tp.getProviderConfig({ skipPrompt: true });
+  let safeBase;
+  let safeName;
+  try {
+    ({ safeBase, safeName } = resolveSafeTicket(rest[0], { parseTicketInput, tp, providerCfg }));
+  } catch (e) {
+    exitWithError(e.message);
+  }
+
+  // Required --reason (verbatim following argv token — no shell interp).
+  const reasonIdx = rest.indexOf('--reason');
+  const reason = reasonIdx === -1 ? '' : rest[reasonIdx + 1] || '';
+  if (!reason) {
+    exitWithError('Usage: cancel <TICKET> --reason "<reason>"');
+  }
+
+  const state = loadWorkState(safeName);
+  if (!state) {
+    exitWithError(`No state found for ${safeName}`);
+  }
+  const phaseAtCancel = phaseOfState(state);
+
+  // Not a cancellable (planning) phase.
+  if (!isCancellablePhase(phaseAtCancel)) {
+    if (isAtOrAfterImplement(phaseAtCancel)) {
+      // (P2 --force override is out of scope — spec §Non-goals.)
+      emitCancelRefusal(safeBase, phaseAtCancel);
+    }
+    // Before implement but past the cancel ceiling (e.g. tasks): reject.
+    exitWithError(`Cannot cancel workflow: phase "${phaseAtCancel}" is not cancellable`);
+  }
+
+  runCancelSequence({ safeBase, safeName, reason, phaseAtCancel });
+}
+
+module.exports = { runCancel };

--- a/plugins/work/scripts/workflows/work/engine/cli.js
+++ b/plugins/work/scripts/workflows/work/engine/cli.js
@@ -2,266 +2,365 @@
  * cli.js
  *
  * CLI entry-point logic for work.workflow.js — parses argv, dispatches
- * to the appropriate command (plan/transition/transitions/graph/actions),
+ * to the appropriate command (plan/transition/transitions/graph/actions/cancel),
  * and prints JSON output.
  *
  * All runtime side effects (inspect, generatePlan, transitionStep, etc.)
  * are injected via `deps` for testability and to avoid circular imports.
+ * The `cancel` subcommand machinery lives in the sibling `cli-cancel.js` to keep
+ * this entry-point module within the static quality budget.
  */
 
-function main(deps) {
-  const {
-    parseTicketInput,
-    inspect,
-    generatePlan,
-    transitionStep,
-    getAvailableTransitions,
-    loadActions,
-    analyzeActions,
-    loadWorkState,
-    saveWorkState,
-    appendAction,
-    requirePaths,
-    tp,
-    STEPS,
-    ALL_STEPS,
-    STEP_TRANSITIONS,
-  } = deps;
+'use strict';
 
+const path = require('path');
+
+const { runCancel } = require(path.join(__dirname, 'cli-cancel'));
+
+/**
+ * Normalize a raw ticket base: resolve a GitHub URL to `#N` (recording the URL
+ * metadata) and default the provider config to github for a bare `#N` when no
+ * provider is configured. Returns the (possibly rewritten) raw string, the
+ * (possibly defaulted) provider config, and the GitHub URL metadata (or null).
+ * @param {string} raw
+ * @param {object} providerConfig
+ * @param {object} tp
+ */
+function normalizeRawTicket(raw, providerConfig, tp) {
+  const isGitHub = providerConfig?.provider === 'github';
+  let ghUrlMeta = null;
+  const ghParsed = tp.parseGitHubUrl(raw);
+  if (ghParsed && (isGitHub || !providerConfig)) {
+    ghUrlMeta = ghParsed;
+    raw = '#' + ghParsed.number;
+  }
+  if (/^#\d+$/.test(raw) && !isGitHub && !providerConfig) {
+    providerConfig = { provider: 'github', projectKey: '' };
+  }
+  return { raw, providerConfig, ghUrlMeta };
+}
+
+/**
+ * Classify a normalized raw string against the provider config: is it a ticket
+ * (Jira / GitHub issue / GH-prefixed) and, if so, its canonical id (`#N` for
+ * GitHub, uppercased otherwise). isGitHubIssue/isGitHubPrefixed already fold in
+ * the effective-provider check, so the id rewrite needs no re-test.
+ * @param {string} raw
+ * @param {object} providerConfig
+ */
+function classifyTicket(raw, providerConfig) {
+  const isGitHubEffective = providerConfig?.provider === 'github';
+  const isJiraTicket = /^[A-Z]+-\d+$/i.test(raw);
+  const isGitHubIssue = /^#?\d+$/.test(raw) && isGitHubEffective;
+  const isGitHubPrefixed = /^GH-\d+$/i.test(raw) && isGitHubEffective;
+  const isTicket = isJiraTicket || isGitHubIssue || isGitHubPrefixed;
+  let ticket = isTicket ? raw.toUpperCase() : null;
+  if (isGitHubIssue || isGitHubPrefixed) {
+    ticket = '#' + raw.replace(/^#|^GH-/i, '');
+  }
+  return { ticket, isTicket };
+}
+
+/**
+ * Parse + normalize a raw plan argument into a resolved ticket + provider
+ * config. May throw (via parseTicketInput) on a parse failure — the caller
+ * reports + exits. Returns the resolved ticket (or null for a free-text
+ * description), the effective provider config, GitHub URL metadata, whether the
+ * input is a ticket, the optional suffix, and the normalized raw string.
+ * @param {string} rawInput
+ * @param {object} deps
+ */
+function resolvePlanTicket(rawInput, deps) {
+  const { parseTicketInput, tp } = deps;
+  const parsed = parseTicketInput(rawInput);
+  const suffix = parsed.suffix;
+  const initialCfg = tp.getProviderConfig({ skipPrompt: true });
+  const { raw, providerConfig, ghUrlMeta } = normalizeRawTicket(parsed.ticketBase, initialCfg, tp);
+  const { ticket, isTicket } = classifyTicket(raw, providerConfig);
+  if (ghUrlMeta && providerConfig?.provider === 'github') {
+    providerConfig.owner = ghUrlMeta.owner;
+    providerConfig.repo = ghUrlMeta.repo;
+  }
+  return { ticket, providerConfig, ghUrlMeta, isTicket, suffix, raw };
+}
+
+/**
+ * Persist DEFER metadata into work state for the transition guard (GH-154):
+ * refresh an existing state's plan timestamp + deferred steps, or mint a
+ * minimal state when the plan has DEFER steps but no state file yet.
+ * @param {string} ticket
+ * @param {object} result — the generated plan (with .timestamp + .plan)
+ * @param {object} providerConfig
+ * @param {string|null} suffix
+ * @param {object} deps
+ */
+function persistDeferMetadata(ticket, result, providerConfig, suffix, deps) {
+  const { tp, loadWorkState, saveWorkState, appendAction, STEPS, ALL_STEPS } = deps;
+  const safeBase = tp.sanitizeTicketIdForPath(ticket, providerConfig);
+  const safeName = suffix ? safeBase + '/' + suffix : safeBase;
+  const planState = loadWorkState(safeName);
+  if (planState) {
+    planState.lastPlanTimestamp = result.timestamp;
+    planState.deferredSteps = result.plan.filter((s) => s.action === 'DEFER').map((s) => s.step);
+    saveWorkState(safeName, planState);
+    return;
+  }
+  const deferSteps = result.plan.filter((s) => s.action === 'DEFER').map((s) => s.step);
+  if (deferSteps.length === 0) return;
+  const minimalState = {
+    ticketId: safeName,
+    description: '',
+    currentStep: 1,
+    status: 'in_progress',
+    stepStatus: {},
+    checkProgress: {},
+    errors: [],
+    startTime: new Date().toISOString(),
+    lastPlanTimestamp: result.timestamp,
+    deferredSteps: deferSteps,
+  };
+  ALL_STEPS.forEach((s) => {
+    minimalState.stepStatus[s] = 'pending';
+  });
+  saveWorkState(safeName, minimalState);
+  appendAction(safeName, { step: STEPS.ticket, what: 'workflow started' });
+}
+
+/**
+ * Attach the inspected git/PR/report snapshot + allowed transitions onto the
+ * plan result (only when a ticket state was inspected).
+ * @param {object} result
+ * @param {object} state
+ * @param {object} STEP_TRANSITIONS
+ */
+function attachStateSnapshot(result, state, STEP_TRANSITIONS) {
+  result.currentStep = state.currentStep;
+  result.allowedTransitions = STEP_TRANSITIONS[state.currentStep] || [];
+  result.state = {
+    worktreeExists: state.worktreeExists,
+    branch: state.branch,
+    headSha: state.headSha?.substring(0, 8) || null,
+    hasDiffVsMain: state.hasDiffVsMain,
+    diffSummary: state.diffSummary,
+    lastCommitMsg: state.lastCommitMsg,
+    hasUncommitted: state.hasUncommitted,
+    uncommittedCount: state.uncommittedCount,
+    hasUnpushed: state.hasUnpushed,
+    pr: state.pr ? { number: state.pr.number, isDraft: state.pr.isDraft } : null,
+    reports: state.reports,
+    allReportsPass: state.allReportsPass,
+    missingReports: state.missingReports,
+    failedReports: state.failedReports,
+    prEverUpdated: state.prEverUpdated,
+    prShaMatch: state.prShaMatch,
+    hasDevSession: state.hasDevSession,
+    workStateStatus: state.workState?.status || null,
+  };
+}
+
+/**
+ * Stamp + enrich a generated plan result in place: timestamp, persisted DEFER
+ * metadata, ticket URL, inspected-state snapshot, and the RUN/DEFER summary.
+ * The summary object literal is kept inline here (not extracted into a helper)
+ * so the GH-245 source-shape test can locate the assignment; it deliberately
+ * carries only run/defer/pending counters.
+ * @param {object} result
+ * @param {{ticket, providerConfig, ghUrlMeta, suffix, state}} ctx
+ * @param {object} deps
+ */
+function finalizePlanResult(result, ctx, deps) {
+  const { ticket, providerConfig, ghUrlMeta, suffix, state } = ctx;
+  const { tp, STEP_TRANSITIONS } = deps;
+  result.timestamp = new Date().toISOString();
+  if (ticket) persistDeferMetadata(ticket, result, providerConfig, suffix, deps);
+  if (ghUrlMeta && providerConfig) result.ticketUrl = tp.ticketUrl(ticket, providerConfig);
+  if (state) attachStateSnapshot(result, state, STEP_TRANSITIONS);
+  const by = (a) => result.plan.filter((s) => s.action === a);
+  result.summary = {
+    total: result.plan.length,
+    run: by('RUN').length,
+    defer: by('DEFER').length,
+    pending: by('PENDING').length,
+    firstAction: by('RUN')[0]?.step || by('DEFER')[0]?.step || 'none',
+    stepsToRun: by('RUN').map((s) => s.step),
+    stepsDeferred: by('DEFER').map((s) => s.step),
+  };
+}
+
+/**
+ * `plan` subcommand: resolve the ticket, inspect state, generate + persist the
+ * plan, and print it. Exits non-zero on empty input or a parse/generate error.
+ * @param {string[]} rest
+ * @param {object} deps
+ */
+function runPlan(rest, deps) {
+  const { inspect, generatePlan, requirePaths } = deps;
+  requirePaths();
+  const rework = rest.includes('--rework');
+  let raw = rest
+    .filter((a) => a !== '--rework')
+    .join(' ')
+    .trim();
+  if (!raw) {
+    console.log(JSON.stringify({ error: true, message: 'Provide ticket ID or description' }));
+    process.exit(1);
+  }
+
+  let ticket;
+  let providerConfig;
+  let ghUrlMeta;
+  let isTicket;
+  let suffix;
+  try {
+    ({ ticket, providerConfig, ghUrlMeta, isTicket, suffix, raw } = resolvePlanTicket(raw, deps));
+  } catch (err) {
+    console.log(JSON.stringify({ error: true, message: err.message }));
+    process.exit(1);
+  }
+
+  const state = ticket ? inspect(ticket, providerConfig, suffix) : null;
+  let result;
+  try {
+    result = generatePlan(ticket, isTicket ? null : raw, state, rework, providerConfig, suffix);
+  } catch (err) {
+    console.log(JSON.stringify({ error: true, message: err?.message || String(err) }));
+    process.exit(1);
+  }
+
+  finalizePlanResult(result, { ticket, providerConfig, ghUrlMeta, suffix, state }, deps);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+/**
+ * Parse + sanitize a raw ticket argv token into its filesystem-safe form,
+ * shared by the transition/transitions/actions subcommands. Throws (via
+ * parseTicketInput) on a parse failure.
+ * @param {string} rawArg
+ * @param {object} deps
+ * @returns {string}
+ */
+function sanitizeTicketArg(rawArg, deps) {
+  const { parseTicketInput, tp } = deps;
+  const providerCfg = tp.getProviderConfig({ skipPrompt: true });
+  const parsed = parseTicketInput(rawArg);
+  const base = String(parsed.ticketBase).toUpperCase();
+  return tp.sanitizeTicketIdForPath(base, providerCfg) + (parsed.suffix ? '/' + parsed.suffix : '');
+}
+
+/** `transition` subcommand: transition <TICKET> to <step>. */
+function runTransition(rest, deps) {
+  const { transitionStep, requirePaths, ALL_STEPS } = deps;
+  requirePaths();
+  if (rest.length < 2) {
+    console.log(
+      JSON.stringify({
+        error: true,
+        message: 'Usage: transition <TICKET> <step>',
+        validSteps: ALL_STEPS,
+      })
+    );
+    process.exit(1);
+  }
+  let ticket;
+  try {
+    ticket = sanitizeTicketArg(rest[0], deps);
+  } catch (e) {
+    console.log(JSON.stringify({ error: true, message: e.message }));
+    process.exit(1);
+  }
+  console.log(JSON.stringify(transitionStep(ticket, rest[1]), null, 2));
+}
+
+/** `transitions` subcommand: list available transitions for <TICKET>. */
+function runTransitions(rest, deps) {
+  const { getAvailableTransitions, requirePaths } = deps;
+  requirePaths();
+  if (!rest[0]) {
+    console.log(JSON.stringify({ error: true, message: 'Usage: transitions <TICKET>' }));
+    process.exit(1);
+  }
+  let ticket;
+  try {
+    ticket = sanitizeTicketArg(rest[0], deps);
+  } catch (e) {
+    console.log(JSON.stringify({ error: true, message: e.message }));
+    process.exit(1);
+  }
+  console.log(JSON.stringify(getAvailableTransitions(ticket), null, 2));
+}
+
+/** `graph` subcommand: print the full step + transition graph. */
+function runGraph(deps) {
+  const { ALL_STEPS, STEP_TRANSITIONS } = deps;
+  console.log(JSON.stringify({ steps: ALL_STEPS, transitions: STEP_TRANSITIONS }, null, 2));
+}
+
+/** `actions` subcommand: dump (or analyze) the recorded actions for <TICKET>. */
+function runActions(rest, deps) {
+  const { loadActions, analyzeActions, requirePaths } = deps;
+  requirePaths();
+  if (!rest[0]) {
+    console.log(JSON.stringify({ error: true, message: 'Usage: actions <TICKET> [--raw]' }));
+    process.exit(1);
+  }
+  let ticket;
+  try {
+    ticket = sanitizeTicketArg(rest[0], deps);
+  } catch (e) {
+    console.log(JSON.stringify({ error: true, message: e.message }));
+    process.exit(1);
+  }
+  const raw = rest.includes('--raw');
+  const actions = loadActions(ticket);
+  if (raw) {
+    console.log(JSON.stringify({ ticket, actions }, null, 2));
+  } else {
+    const analysis = analyzeActions(actions);
+    console.log(JSON.stringify({ ticket, analysis, actions }, null, 2));
+  }
+}
+
+function main(deps) {
   const args = process.argv.slice(2);
   if (args.length === 0) {
     console.log(
       JSON.stringify({
         error: true,
-        message: 'Usage: work-orchestrator.js [plan|transition|transitions|graph] <args>',
+        message:
+          'Usage: work-orchestrator.js [plan|transition|transitions|graph|actions|cancel] <args>',
       })
     );
     process.exit(1);
   }
 
-  const subcommands = ['plan', 'transition', 'transitions', 'graph', 'actions'];
+  const subcommands = ['plan', 'transition', 'transitions', 'graph', 'actions', 'cancel'];
   const command = subcommands.includes(args[0]) ? args[0] : 'plan';
   const rest = subcommands.includes(args[0]) ? args.slice(1) : args;
 
   switch (command) {
-    case 'plan': {
-      requirePaths();
-      const rework = rest.includes('--rework');
-      let raw = rest
-        .filter((a) => a !== '--rework')
-        .join(' ')
-        .trim();
-      if (!raw) {
-        console.log(JSON.stringify({ error: true, message: 'Provide ticket ID or description' }));
-        process.exit(1);
-      }
-
-      let suffix = null;
-      try {
-        const parsed = parseTicketInput(raw);
-        raw = parsed.ticketBase;
-        suffix = parsed.suffix;
-      } catch (err) {
-        console.log(JSON.stringify({ error: true, message: err.message }));
-        process.exit(1);
-      }
-
-      let providerConfig = tp.getProviderConfig({ skipPrompt: true });
-      const isGitHub = providerConfig?.provider === 'github';
-
-      let ghUrlMeta = null;
-      const ghParsed = tp.parseGitHubUrl(raw);
-      if (ghParsed && (isGitHub || !providerConfig)) {
-        ghUrlMeta = ghParsed;
-        raw = '#' + ghParsed.number;
-      }
-      if (/^#\d+$/.test(raw) && !isGitHub && !providerConfig) {
-        providerConfig = { provider: 'github', projectKey: '' };
-      }
-      const isGitHubEffective = providerConfig?.provider === 'github';
-      const isJiraTicket = /^[A-Z]+-\d+$/i.test(raw);
-      const isGitHubIssue = /^#?\d+$/.test(raw) && isGitHubEffective;
-      const isGitHubPrefixed = /^GH-\d+$/i.test(raw) && isGitHubEffective;
-      const isTicket = isJiraTicket || isGitHubIssue || isGitHubPrefixed;
-      let ticket = isTicket ? raw.toUpperCase() : null;
-      if ((isGitHubIssue || isGitHubPrefixed) && isGitHubEffective) {
-        const num = raw.replace(/^#|^GH-/i, '');
-        ticket = '#' + num;
-      }
-      if (ghUrlMeta && isGitHubEffective) {
-        providerConfig.owner = ghUrlMeta.owner;
-        providerConfig.repo = ghUrlMeta.repo;
-      }
-      const state = ticket ? inspect(ticket, providerConfig, suffix) : null;
-      let result;
-      try {
-        result = generatePlan(ticket, isTicket ? null : raw, state, rework, providerConfig, suffix);
-      } catch (err) {
-        console.log(JSON.stringify({ error: true, message: err?.message || String(err) }));
-        process.exit(1);
-      }
-
-      result.timestamp = new Date().toISOString();
-
-      // Persist DEFER metadata into work state for transition guard (GH-154)
-      if (ticket) {
-        const safeBase_plan = tp.sanitizeTicketIdForPath(ticket, providerConfig);
-        const safeName_plan = suffix ? safeBase_plan + '/' + suffix : safeBase_plan;
-        const planState = loadWorkState(safeName_plan);
-        if (planState) {
-          planState.lastPlanTimestamp = result.timestamp;
-          planState.deferredSteps = result.plan
-            .filter((s) => s.action === 'DEFER')
-            .map((s) => s.step);
-          saveWorkState(safeName_plan, planState);
-        } else {
-          const deferSteps = result.plan.filter((s) => s.action === 'DEFER').map((s) => s.step);
-          if (deferSteps.length > 0) {
-            const minimalState = {
-              ticketId: safeName_plan,
-              description: '',
-              currentStep: 1,
-              status: 'in_progress',
-              stepStatus: {},
-              checkProgress: {},
-              errors: [],
-              startTime: new Date().toISOString(),
-              lastPlanTimestamp: result.timestamp,
-              deferredSteps: deferSteps,
-            };
-            ALL_STEPS.forEach((s) => {
-              minimalState.stepStatus[s] = 'pending';
-            });
-            saveWorkState(safeName_plan, minimalState);
-            appendAction(safeName_plan, { step: STEPS.ticket, what: 'workflow started' });
-          }
-        }
-      }
-
-      if (ghUrlMeta && providerConfig) {
-        result.ticketUrl = tp.ticketUrl(ticket, providerConfig);
-      }
-      if (state) {
-        result.currentStep = state.currentStep;
-        result.allowedTransitions = STEP_TRANSITIONS[state.currentStep] || [];
-        result.state = {
-          worktreeExists: state.worktreeExists,
-          branch: state.branch,
-          headSha: state.headSha?.substring(0, 8) || null,
-          hasDiffVsMain: state.hasDiffVsMain,
-          diffSummary: state.diffSummary,
-          lastCommitMsg: state.lastCommitMsg,
-          hasUncommitted: state.hasUncommitted,
-          uncommittedCount: state.uncommittedCount,
-          hasUnpushed: state.hasUnpushed,
-          pr: state.pr ? { number: state.pr.number, isDraft: state.pr.isDraft } : null,
-          reports: state.reports,
-          allReportsPass: state.allReportsPass,
-          missingReports: state.missingReports,
-          failedReports: state.failedReports,
-          prEverUpdated: state.prEverUpdated,
-          prShaMatch: state.prShaMatch,
-          hasDevSession: state.hasDevSession,
-          workStateStatus: state.workState?.status || null,
-        };
-      }
-      const by = (a) => result.plan.filter((s) => s.action === a);
-      result.summary = {
-        total: result.plan.length,
-        run: by('RUN').length,
-        defer: by('DEFER').length,
-        pending: by('PENDING').length,
-        firstAction: by('RUN')[0]?.step || by('DEFER')[0]?.step || 'none',
-        stepsToRun: by('RUN').map((s) => s.step),
-        stepsDeferred: by('DEFER').map((s) => s.step),
-      };
-      console.log(JSON.stringify(result, null, 2));
+    case 'plan':
+      runPlan(rest, deps);
       break;
-    }
-
-    case 'transition': {
-      requirePaths();
-      if (rest.length < 2) {
-        console.log(
-          JSON.stringify({
-            error: true,
-            message: 'Usage: transition <TICKET> <step>',
-            validSteps: ALL_STEPS,
-          })
-        );
-        process.exit(1);
-      }
-      const transProviderCfg = tp.getProviderConfig({ skipPrompt: true });
-      let transParsed;
-      try {
-        transParsed = parseTicketInput(rest[0]);
-      } catch (e) {
-        console.log(JSON.stringify({ error: true, message: e.message }));
-        process.exit(1);
-      }
-      const transBase = String(transParsed.ticketBase).toUpperCase();
-      const safeTransTicket =
-        tp.sanitizeTicketIdForPath(transBase, transProviderCfg) +
-        (transParsed.suffix ? '/' + transParsed.suffix : '');
-      console.log(JSON.stringify(transitionStep(safeTransTicket, rest[1]), null, 2));
+    case 'transition':
+      runTransition(rest, deps);
       break;
-    }
-
-    case 'transitions': {
-      requirePaths();
-      if (!rest[0]) {
-        console.log(JSON.stringify({ error: true, message: 'Usage: transitions <TICKET>' }));
-        process.exit(1);
-      }
-      const transitionsProviderCfg = tp.getProviderConfig({ skipPrompt: true });
-      let transParsed2;
-      try {
-        transParsed2 = parseTicketInput(rest[0]);
-      } catch (e) {
-        console.log(JSON.stringify({ error: true, message: e.message }));
-        process.exit(1);
-      }
-      const transBase2 = String(transParsed2.ticketBase).toUpperCase();
-      const safeTransitionsTicket =
-        tp.sanitizeTicketIdForPath(transBase2, transitionsProviderCfg) +
-        (transParsed2.suffix ? '/' + transParsed2.suffix : '');
-      console.log(JSON.stringify(getAvailableTransitions(safeTransitionsTicket), null, 2));
+    case 'transitions':
+      runTransitions(rest, deps);
       break;
-    }
-
-    case 'graph': {
-      console.log(JSON.stringify({ steps: ALL_STEPS, transitions: STEP_TRANSITIONS }, null, 2));
+    case 'graph':
+      runGraph(deps);
       break;
-    }
-
-    case 'actions': {
-      requirePaths();
-      if (!rest[0]) {
-        console.log(JSON.stringify({ error: true, message: 'Usage: actions <TICKET> [--raw]' }));
-        process.exit(1);
-      }
-      const actionsProviderCfg = tp.getProviderConfig({ skipPrompt: true });
-      let actionsParsed;
-      try {
-        actionsParsed = parseTicketInput(rest[0]);
-      } catch (e) {
-        console.log(JSON.stringify({ error: true, message: e.message }));
-        process.exit(1);
-      }
-      const actionsBase = String(actionsParsed.ticketBase).toUpperCase();
-      const ticket =
-        tp.sanitizeTicketIdForPath(actionsBase, actionsProviderCfg) +
-        (actionsParsed.suffix ? '/' + actionsParsed.suffix : '');
-      const raw = rest.includes('--raw');
-      const actions = loadActions(ticket);
-      if (raw) {
-        console.log(JSON.stringify({ ticket, actions }, null, 2));
-      } else {
-        const analysis = analyzeActions(actions);
-        console.log(JSON.stringify({ ticket, analysis, actions }, null, 2));
-      }
+    case 'actions':
+      runActions(rest, deps);
       break;
-    }
+    case 'cancel':
+      runCancel(rest, {
+        parseTicketInput: deps.parseTicketInput,
+        tp: deps.tp,
+        loadWorkState: deps.loadWorkState,
+        requirePaths: deps.requirePaths,
+      });
+      break;
   }
 }
 

--- a/plugins/work/scripts/workflows/work/work-state/__tests__/cli.test.js
+++ b/plugins/work/scripts/workflows/work/work-state/__tests__/cli.test.js
@@ -1,0 +1,158 @@
+/**
+ * Tests for work-state/cli.js — GH-339 `cancel` CLI handler.
+ *
+ * Uses node:test + node:assert/strict (plugin convention — no Jest/Mocha).
+ * The CLI is exercised by spawning `work-state.js` via child_process (the
+ * established plugin pattern — see AGENTS/CLAUDE.md "Tests spawn hook scripts
+ * with child_process.spawn to test exit codes"), with env vars set so
+ * lib/config resolves TASKS_BASE to a temp dir. State files are written
+ * directly, mirroring steps.test.js.
+ *
+ * Run: node --test scripts/workflows/work/work-state/__tests__/cli.test.js
+ */
+
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-cancel-test-'));
+const WORK_STATE_JS = path.join(__dirname, '..', '..', 'work-state.js');
+const { ALL_STEPS, STEP_ORDER } = require(path.join(__dirname, '..', '..', 'step-registry'));
+
+const origEnv = { ...process.env };
+
+before(() => {
+  process.env.TASKS_BASE = TEMP_TASKS_BASE;
+  process.env.WORKTREES_BASE = TEMP_TASKS_BASE;
+  process.env.REPO_NAME = 'test';
+});
+
+after(() => {
+  Object.assign(process.env, origEnv);
+  try {
+    fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
+  } catch {}
+});
+
+// ─── State helpers ───────────────────────────────────────────────────────────
+
+// Build a realistic work-state where `activeStep` is the current step: every
+// prior step 'completed', the active step 'in_progress', the rest 'pending'.
+function stateAtStep(ticketId, activeStep, overrides = {}) {
+  const activeIndex = STEP_ORDER.indexOf(activeStep);
+  assert.ok(activeIndex >= 0, `unknown step: ${activeStep}`);
+  const stepStatus = {};
+  ALL_STEPS.forEach((step, i) => {
+    if (i < activeIndex) stepStatus[step] = 'completed';
+    else if (i === activeIndex) stepStatus[step] = 'in_progress';
+    else stepStatus[step] = 'pending';
+  });
+  return {
+    ticketId,
+    description: '',
+    currentStep: activeIndex + 1,
+    status: 'in_progress',
+    stepStatus,
+    checkProgress: {},
+    errors: [],
+    startTime: new Date().toISOString(),
+    lastUpdate: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function writeState(ticketId, state) {
+  const dir = path.join(TEMP_TASKS_BASE, ticketId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '.work-state.json'), JSON.stringify(state, null, 2));
+}
+
+function readState(ticketId) {
+  const fp = path.join(TEMP_TASKS_BASE, ticketId, '.work-state.json');
+  return JSON.parse(fs.readFileSync(fp, 'utf-8'));
+}
+
+function cleanupTicket(ticketId) {
+  try {
+    fs.rmSync(path.join(TEMP_TASKS_BASE, ticketId), { recursive: true, force: true });
+  } catch {}
+}
+
+// Spawn `work-state.js <args...>` with the temp TASKS_BASE env.
+function runCli(args) {
+  return spawnSync(process.execPath, [WORK_STATE_JS, ...args], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      TASKS_BASE: TEMP_TASKS_BASE,
+      WORKTREES_BASE: TEMP_TASKS_BASE,
+      REPO_NAME: 'test',
+    },
+  });
+}
+
+// ─── cancel handler (Deliverable 2.1) ────────────────────────────────────────
+
+describe('GH-339 work-state CLI — cancel handler', () => {
+  it('registers `cancel` in the usage/commands string', () => {
+    // Invoking with no command prints usage to stderr and exits 1.
+    const res = runCli([]);
+    assert.equal(res.status, 1, 'no command must exit 1');
+    assert.match(res.stderr, /\bcancel\b/, 'usage Commands: line must include cancel');
+  });
+
+  it('cancels a planning-phase (brief) ticket: prints cancelled state and exits 0', () => {
+    const ticket = 'CLI-CANCEL-BRIEF';
+    cleanupTicket(ticket);
+    writeState(ticket, stateAtStep(ticket, 'brief'));
+
+    const res = runCli(['cancel', ticket, '--reason', 'operator abort']);
+    assert.equal(res.status, 0, `expected exit 0, got ${res.status}; stderr=${res.stderr}`);
+
+    const printed = JSON.parse(res.stdout);
+    assert.equal(printed.status, 'cancelled', 'printed state status must be cancelled');
+    assert.notEqual(printed.status, 'completed', 'must never print completed');
+    assert.equal(printed.cancelReason, 'operator abort', 'reason recorded verbatim in output');
+    assert.ok(printed.cancelledTime, 'cancelledTime present in printed state');
+
+    const persisted = readState(ticket);
+    assert.equal(persisted.status, 'cancelled', 'state file persisted as cancelled');
+    assert.equal(persisted.cancelReason, 'operator abort', 'reason persisted to state file');
+    cleanupTicket(ticket);
+  });
+
+  it('exits 1 with a usage message when --reason is missing', () => {
+    const ticket = 'CLI-CANCEL-NOREASON';
+    cleanupTicket(ticket);
+    writeState(ticket, stateAtStep(ticket, 'brief'));
+
+    const res = runCli(['cancel', ticket]);
+    assert.equal(res.status, 1, `missing --reason must exit 1, got ${res.status}`);
+    assert.match(res.stderr, /--reason/, 'usage message must mention --reason');
+
+    // Missing reason must NOT mutate the state.
+    const after = readState(ticket);
+    assert.equal(after.status, 'in_progress', 'state must be untouched when reason missing');
+    cleanupTicket(ticket);
+  });
+
+  it('exits 1 with the cancelWork error on a non-planning (implement) state', () => {
+    const ticket = 'CLI-CANCEL-IMPLEMENT';
+    cleanupTicket(ticket);
+    writeState(ticket, stateAtStep(ticket, 'implement'));
+
+    const res = runCli(['cancel', ticket, '--reason', 'too late']);
+    assert.equal(res.status, 1, `implement-phase cancel must exit 1, got ${res.status}`);
+    assert.match(res.stderr, /error/i, 'stderr must carry the cancelWork error');
+
+    const after = readState(ticket);
+    assert.notEqual(after.status, 'cancelled', 'status must not flip to cancelled at implement');
+    assert.equal(after.status, 'in_progress', 'status stays in_progress');
+    cleanupTicket(ticket);
+  });
+});

--- a/plugins/work/scripts/workflows/work/work-state/__tests__/steps.test.js
+++ b/plugins/work/scripts/workflows/work/work-state/__tests__/steps.test.js
@@ -1,0 +1,211 @@
+/**
+ * Tests for work-state/steps.js — GH-339 `cancelWork` mutator +
+ * `isCancellablePhase` planning-phase boundary.
+ *
+ * Uses node:test + node:assert/strict (plugin convention — no Jest/Mocha).
+ * The module is required in-process with env vars set so lib/config resolves
+ * TASKS_BASE to a temp dir; state files are written/read directly, mirroring
+ * the completeWork tests in complete-deadlock.test.js.
+ *
+ * Run: node --test scripts/workflows/work/work-state/__tests__/steps.test.js
+ */
+
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'steps-cancel-test-'));
+const { ALL_STEPS, STEP_ORDER } = require(path.join(__dirname, '..', '..', 'step-registry'));
+
+// ─── Module under test (loaded with config env in place) ────────────────────
+
+let steps;
+const origEnv = { ...process.env };
+
+before(() => {
+  process.env.TASKS_BASE = TEMP_TASKS_BASE;
+  process.env.WORKTREES_BASE = TEMP_TASKS_BASE;
+  process.env.REPO_NAME = 'test';
+  // Force a fresh require so core.js picks up the temp TASKS_BASE.
+  delete require.cache[require.resolve('../steps')];
+  delete require.cache[require.resolve('../core')];
+  steps = require('../steps');
+});
+
+after(() => {
+  Object.assign(process.env, origEnv);
+  try {
+    fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
+  } catch {}
+});
+
+// ─── State helpers ───────────────────────────────────────────────────────────
+
+// Build a realistic work-state where `activeStep` is the current step: every
+// prior step 'completed', the active step 'in_progress', the rest 'pending',
+// and currentStep set to the 1-indexed position. This makes "current step"
+// unambiguous regardless of how cancelWork derives it (state.currentStep or
+// the first in_progress step).
+function stateAtStep(ticketId, activeStep, overrides = {}) {
+  const activeIndex = STEP_ORDER.indexOf(activeStep);
+  assert.ok(activeIndex >= 0, `unknown step: ${activeStep}`);
+  const stepStatus = {};
+  ALL_STEPS.forEach((step, i) => {
+    if (i < activeIndex) stepStatus[step] = 'completed';
+    else if (i === activeIndex) stepStatus[step] = 'in_progress';
+    else stepStatus[step] = 'pending';
+  });
+  return {
+    ticketId,
+    description: '',
+    currentStep: activeIndex + 1,
+    status: 'in_progress',
+    stepStatus,
+    checkProgress: {},
+    errors: [],
+    startTime: new Date().toISOString(),
+    lastUpdate: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function writeState(ticketId, state) {
+  const dir = path.join(TEMP_TASKS_BASE, ticketId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '.work-state.json'), JSON.stringify(state, null, 2));
+}
+
+function readState(ticketId) {
+  const fp = path.join(TEMP_TASKS_BASE, ticketId, '.work-state.json');
+  return JSON.parse(fs.readFileSync(fp, 'utf-8'));
+}
+
+function cleanupTicket(ticketId) {
+  try {
+    fs.rmSync(path.join(TEMP_TASKS_BASE, ticketId), { recursive: true, force: true });
+  } catch {}
+}
+
+// ─── isCancellablePhase boundary (Deliverable 1.1) ──────────────────────────
+
+describe('GH-339 isCancellablePhase — planning-phase boundary', () => {
+  it('exports isCancellablePhase and CANCELLABLE_STEP_CEILING', () => {
+    assert.equal(
+      typeof steps.isCancellablePhase,
+      'function',
+      'isCancellablePhase must be exported'
+    );
+    assert.equal(
+      steps.CANCELLABLE_STEP_CEILING,
+      'spec_gate',
+      'CANCELLABLE_STEP_CEILING must be the spec_gate ceiling'
+    );
+  });
+
+  it('is true for planning steps up to and including spec_gate', () => {
+    assert.equal(steps.isCancellablePhase('brief'), true, 'brief is cancellable');
+    assert.equal(steps.isCancellablePhase('spec_gate'), true, 'spec_gate (ceiling) is cancellable');
+  });
+
+  it('is false at tasks and beyond (implement)', () => {
+    assert.equal(steps.isCancellablePhase('tasks'), false, 'tasks is NOT cancellable');
+    assert.equal(steps.isCancellablePhase('implement'), false, 'implement is NOT cancellable');
+  });
+});
+
+// ─── cancelWork mutator (Deliverable 1.2) ────────────────────────────────────
+
+describe('GH-339 cancelWork — terminal cancel mutator', () => {
+  it('exports cancelWork', () => {
+    assert.equal(typeof steps.cancelWork, 'function', 'cancelWork must be exported');
+  });
+
+  // Scenario: cancelWork marks state cancelled during a planning phase
+  it('marks state cancelled during a planning phase (brief) with reason + ISO time, never completed', () => {
+    const ticket = 'CANCEL-BRIEF';
+    cleanupTicket(ticket);
+    writeState(ticket, stateAtStep(ticket, 'brief'));
+
+    const result = steps.cancelWork(ticket, 'operator abort');
+    assert.ok(!result.error, `expected success, got error: ${result.error}`);
+    assert.equal(result.status, 'cancelled', 'status must be cancelled');
+    assert.notEqual(result.status, 'completed', 'must never become completed');
+    assert.equal(result.cancelReason, 'operator abort', 'cancelReason recorded verbatim');
+    assert.ok(result.cancelledTime, 'cancelledTime must be set');
+    assert.ok(
+      !Number.isNaN(Date.parse(result.cancelledTime)),
+      `cancelledTime must be an ISO timestamp: ${result.cancelledTime}`
+    );
+
+    const persisted = readState(ticket);
+    assert.equal(persisted.status, 'cancelled', 'cancelled status must be persisted');
+    assert.equal(persisted.cancelReason, 'operator abort', 'reason persisted to state file');
+    cleanupTicket(ticket);
+  });
+
+  // Scenario: cancelWork is idempotent when already cancelled
+  it('is idempotent when already cancelled (returns state unchanged, no error)', () => {
+    const ticket = 'CANCEL-IDEMPOTENT';
+    cleanupTicket(ticket);
+    const already = stateAtStep(ticket, 'brief', {
+      status: 'cancelled',
+      cancelledTime: '2020-01-01T00:00:00.000Z',
+      cancelReason: 'first',
+    });
+    writeState(ticket, already);
+
+    const result = steps.cancelWork(ticket, 'second');
+    assert.ok(!result.error, `idempotent call must not error: ${result.error}`);
+    assert.equal(result.status, 'cancelled', 'status stays cancelled');
+    assert.equal(result.cancelReason, 'first', 'original reason preserved on idempotent call');
+    assert.equal(
+      result.cancelledTime,
+      '2020-01-01T00:00:00.000Z',
+      'original cancelledTime preserved on idempotent call'
+    );
+    cleanupTicket(ticket);
+  });
+
+  // Scenario: cancelWork refuses when the workflow is at the implement step
+  it('refuses at the implement step and does not mutate status', () => {
+    const ticket = 'CANCEL-IMPLEMENT';
+    cleanupTicket(ticket);
+    writeState(ticket, stateAtStep(ticket, 'implement'));
+
+    const result = steps.cancelWork(ticket, 'too late');
+    assert.ok(result.error, 'must return an error at implement');
+
+    const after = readState(ticket);
+    assert.notEqual(after.status, 'cancelled', 'status must not flip to cancelled at implement');
+    assert.equal(after.status, 'in_progress', 'status stays in_progress');
+    assert.ok(!after.cancelReason, 'no cancelReason stamped on refusal');
+    cleanupTicket(ticket);
+  });
+
+  // Scenario: cancelWork refuses when the workflow is past spec_gate at tasks
+  it('refuses at the tasks step (past spec_gate) and does not mutate status', () => {
+    const ticket = 'CANCEL-TASKS';
+    cleanupTicket(ticket);
+    writeState(ticket, stateAtStep(ticket, 'tasks'));
+
+    const result = steps.cancelWork(ticket, 'too late');
+    assert.ok(result.error, 'must return an error at tasks');
+
+    const after = readState(ticket);
+    assert.notEqual(after.status, 'cancelled', 'status must not flip to cancelled at tasks');
+    assert.equal(after.status, 'in_progress', 'status stays in_progress');
+    cleanupTicket(ticket);
+  });
+
+  it('returns { error } when no state exists', () => {
+    const ticket = 'CANCEL-NO-STATE';
+    cleanupTicket(ticket);
+    const result = steps.cancelWork(ticket, 'reason');
+    assert.ok(result.error, 'must return an error when no state found');
+    assert.match(String(result.error), /No state found/i, 'error names missing state');
+  });
+});

--- a/plugins/work/scripts/workflows/work/work-state/cli.js
+++ b/plugins/work/scripts/workflows/work/work-state/cli.js
@@ -13,6 +13,7 @@ const {
   setCheckProgress,
   addError,
   completeWork,
+  cancelWork,
   getResumeInfo,
   formatState,
 } = require('./steps');
@@ -39,6 +40,14 @@ function exitIfError(result) {
     console.error(JSON.stringify(result));
     process.exit(1);
   }
+}
+
+// Extract the `--reason <value>` argv token, or '' when absent/empty. The value
+// is taken verbatim from the following argv slot (no shell interpolation).
+function parseReason(args) {
+  const idx = args.indexOf('--reason');
+  if (idx === -1) return '';
+  return args[idx + 1] || '';
 }
 
 const HANDLERS = {
@@ -73,6 +82,21 @@ const HANDLERS = {
 
   complete(_args, ticketId) {
     const result = completeWork(ticketId);
+    exitIfError(result);
+    printResult(result);
+  },
+
+  // GH-339: mark a planning-phase run cancelled. Parses `--reason "<string>"`
+  // from args (verbatim argv token — no shell interpolation), delegates the
+  // mutation to cancelWork (script-side planning-phase precondition lives
+  // there), then error-gates and prints the mutated state.
+  cancel(args, ticketId) {
+    const reason = parseReason(args);
+    if (!reason) {
+      console.error('Usage: node work-state.js cancel <ticket-id> --reason "<reason>"');
+      process.exit(1);
+    }
+    const result = cancelWork(ticketId, reason);
     exitIfError(result);
     printResult(result);
   },
@@ -154,7 +178,7 @@ async function main() {
   if (!command) {
     console.error('Usage: node work-state.js <command> <ticket-id> [args...]');
     console.error(
-      'Commands: init, get, set-step, set-check, add-error, complete, resume-info, init-subtask, complete-subtask, active-subtask, task-init, task-current, task-advance, task-get, task-review-fix-rounds, task-review-fix-rounds-increment, task-review-fix-rounds-reset'
+      'Commands: init, get, set-step, set-check, add-error, complete, cancel, resume-info, init-subtask, complete-subtask, active-subtask, task-init, task-current, task-advance, task-get, task-review-fix-rounds, task-review-fix-rounds-increment, task-review-fix-rounds-reset'
     );
     process.exit(1);
   }

--- a/plugins/work/scripts/workflows/work/work-state/steps.js
+++ b/plugins/work/scripts/workflows/work/work-state/steps.js
@@ -10,6 +10,80 @@
 const { STEPS, loadState, saveState, initState, autoInitTdd } = require('./core');
 const { autoCompleteCheckpointTasks } = require('./checkpoints');
 const { appendAction } = require('../lib/work-actions');
+const { STEP_ORDER } = require('../step-registry');
+
+/**
+ * GH-339: Highest step at which a /work run may still be terminally cancelled.
+ * Planning phases (through the Gherkin spec_gate) are cancellable; once tasks
+ * are drafted and implementation begins, cancel is refused.
+ */
+const CANCELLABLE_STEP_CEILING = 'spec_gate';
+
+/**
+ * GH-339: True when `step` sits at or before the cancellable ceiling
+ * (spec_gate). Steps at `tasks` and beyond (implement, …) are NOT cancellable.
+ * Unknown steps are treated as non-cancellable (fail closed).
+ * @param {string} step
+ * @returns {boolean}
+ */
+function isCancellablePhase(step) {
+  const ceilingIndex = STEP_ORDER.indexOf(CANCELLABLE_STEP_CEILING);
+  const stepIndex = STEP_ORDER.indexOf(step);
+  if (stepIndex < 0) return false;
+  return stepIndex <= ceilingIndex;
+}
+
+/**
+ * Derive the current step from a work-state: the first step flagged
+ * 'in_progress', falling back to state.currentStep (1-indexed). Returns null
+ * when neither yields a known step.
+ * @param {object} state
+ * @returns {string|null}
+ */
+function currentStepOf(state) {
+  const stepStatus = state.stepStatus || {};
+  const inProgress = STEP_ORDER.find((step) => stepStatus[step] === 'in_progress');
+  if (inProgress) return inProgress;
+  const idx = Number(state.currentStep) - 1;
+  return STEP_ORDER[idx] || null;
+}
+
+/**
+ * GH-339: Terminally cancel a /work run during a planning phase.
+ * - Idempotent: if already cancelled, returns state untouched (reason/time
+ *   preserved).
+ * - Refused (returns { error }) once the run is past the spec_gate ceiling
+ *   (tasks, implement, …) — status is never mutated on refusal.
+ * - On success, stamps status='cancelled', cancelReason (verbatim), and an ISO
+ *   cancelledTime, and persists. Never becomes 'completed'.
+ * Returns { error } when no state found (caller must check).
+ * @param {string} ticketId
+ * @param {string} reason
+ */
+function cancelWork(ticketId, reason) {
+  const state = loadState(ticketId);
+  if (!state) {
+    return { error: 'No state found' };
+  }
+
+  // Idempotent: already cancelled — return as-is, preserving original reason/time.
+  if (state.status === 'cancelled') {
+    return state;
+  }
+
+  const step = currentStepOf(state);
+  if (!isCancellablePhase(step)) {
+    return {
+      error: `Cannot cancel workflow: step "${step}" is past the ${CANCELLABLE_STEP_CEILING} cancel ceiling`,
+    };
+  }
+
+  state.status = 'cancelled';
+  state.cancelReason = reason;
+  state.cancelledTime = new Date().toISOString();
+
+  return saveState(ticketId, state);
+}
 
 /**
  * Set step status
@@ -283,6 +357,9 @@ module.exports = {
   setCheckProgress,
   addError,
   completeWork,
+  cancelWork,
+  isCancellablePhase,
+  CANCELLABLE_STEP_CEILING,
   getResumeInfo,
   formatState,
 };


### PR DESCRIPTION
## Summary

Adds a `cancel` subcommand to the `/work` orchestrator — a bookkept, planning-phase-only abort for tickets discovered unnecessary during the brief/spec phases, instead of fighting the session guard or calling `session-guard.js finish` directly.

```
node work.workflow.js cancel <TICKET> --reason "<reason>"
```

## What it does

On a cancellable (planning) phase, the subcommand runs mutate → release → archive → summary:

1. **Mutate** — `cancelWork` sets `.work-state.json` `status` to a new terminal value `cancelled` (distinct from `in_progress`/`completed`, never reusing `completed`), plus `cancelReason` (verbatim) and `cancelledTime`. Idempotent.
2. **Release** — the session guard is released via the sanctioned `session-guard.js finish` teardown (reveal + unlink the session file), exactly as the `complete` step does — no direct bypass.
3. **Archive** — planning + enforcement artifacts (`brief.md`, `spec.md`, `tasks.md`, `.work-actions.json`, `tdd-phase.json`) are moved to `tasks/<TICKET>/archive/`.
4. **Summary** — a one-line operator summary (ticket, reason, phase, archive location) plus a JSON response.

## Guardrails

- **Planning-phase only.** The window is `ticket … spec_gate`, derived from a single named constant `CANCELLABLE_STEP_CEILING` via `isCancellablePhase(step)`. At `tasks` and beyond it is not cancellable.
- **Refuses at/after `implement`.** Once code is written, an AskUserQuestion confirmation is surfaced that defaults to refusing; nothing is mutated or archived.
- **Gated like other state mutators.** An additive `cancelled` clause in `isTerminalSessionGuardBypass` (the dispatched-agent context is still rejected first); `cancel` is routed through the work-state Rule-3b allowlist (not blanket-safe), so a dispatched subagent cannot invoke it.
- **Stop-hook allowance.** The session-guard Stop hook allows stopping when status is `cancelled`; an in-progress non-cancelled session still blocks. The legacy `abort workflow` keyword now redirects operators to the bookkept `cancel` path.

## Notes

- The cancel machinery lives in a sibling module `engine/cli-cancel.js`, extracted from `engine/cli.js` to keep the entry-point module within the static quality budget (max-lines / max-lines-per-function / cyclomatic-complexity). Behavior is preserved.
- Supersedes #742 (closed due to a local branch-history mishap; this PR carries the identical, correctly-parented change).

Closes #339
