### PR TITLE
feat(work): add replay corpus and SLI extractor — outcome verification Phase 0 (GH-751)

### DIFF
--- a/docs/implement-outcome-verification-plan.md
+++ b/docs/implement-outcome-verification-plan.md
@@ -1,0 +1,396 @@
+# Implement Phase — Outcome Verification Plan
+
+**Status:** Draft for review — not yet ticketed
+**Date:** 2026-07-16
+**Scope:** `plugins/work-workflow` implement phase (per-task TDD loop, gates, evidence)
+**Goal:** Reduce implement-phase incidents to near zero while keeping (and strengthening) quality enforcement.
+
+---
+
+## 1. Executive summary
+
+The implement phase currently enforces quality by **choreographing a process**: a per-task
+RED→GREEN→REFACTOR state machine, planner-declared Test Strategy commands, recorded evidence
+files, phase-scoped edit rules, and hook-protected state. Analysis of the issue tracker,
+session transcripts, and cortex memory shows this machinery is itself the dominant source of
+incidents: ~75% of implement-phase issues are false RED/GREEN verdicts, permanent wedges with
+no legal moves, or planner defects surfacing behind locked artifacts.
+
+This plan replaces process choreography with **per-task outcome verification**: agents develop
+freely with advisory test feedback; at each task boundary a stateless verifier checks five
+mechanical invariants derived from the task's actual commits. Blocking happens **only on
+positive evidence of a problem** (contradiction), never on absence of evidence (uncertainty →
+flag and advance). Liveness becomes a provable invariant (every block verdict carries a typed
+exit path). Quality becomes strict **in aggregate** across verifier + task_review + check + CI,
+and both error rates become measured numbers (SLIs + incident replay corpus) instead of hopes.
+
+Net effect: incident classes 1–3 below become structurally impossible (the state that generates
+them no longer exists), ~3–4k LOC of gate machinery is deleted, and fabrication becomes moot
+(there is no recordable evidence left to fake — the verifier observes reality directly).
+
+---
+
+## 2. Problem statement — what the evidence shows
+
+Sources: GitHub issues (open 720–749 cluster + ~20 high-churn closed), ~/.claude session
+transcripts (226 project dirs scanned), cortex memories, and code analysis of
+`plugins/work-workflow/scripts/workflows/` (implement-gate modules, task-next.js,
+tdd-phase-state.js, hooks).
+
+### Incident classes (ranked by frequency)
+
+| # | Class | Evidence | Root cause |
+|---|-------|----------|-----------|
+| 1 | **False GREEN / false RED from exit-code trust** | #749, #737, #736, #725, #720, #694, #653, #606, #584, #532, #466; "No test files found → exit 0" hit 24 project dirs; one run auto-completed 6 tasks with zero code on disk | Gate trusts exit codes; exit-code semantics lie (vitest exit 0 on missing files, whole-suite runs, load crashes recorded as RED, stdout string-scraping) |
+| 2 | **Permanent wedges — no sanctioned recovery** | #721 (green→red rewind requires green evidence), #736 (tasksMeta desync, 34+ retries, hook-protected state), #724 (can't reopen completed task), #722 (tests-only task has no legal phase to author its test), #509, #462 (recurred 3×); epics #392/#398 acknowledge this as systemic | Layered protect-* hooks are individually correct but jointly leave zero legal moves; recovery happens via 20–40 min operator surgery on guarded files |
+| 3 | **Planner defects surface at implement, behind locked tasks.md** | #727 (entry outside scope), #590/#546/#547 (fake commands — 4 tickets for one defect class), FUT-94 (watch-mode command hangs), "Scenarios to cover (0)" in 40 project dirs, GH-539 (glob scope one validator requires, the other can't expand) | Test Strategy is a planner-declared contract the gate depends on; declarations diverge from reality; tasks.md is locked exactly when defects are discovered |
+| 4 | **Vacuous step verification** | #694 (implement closes with pending tasks; autoComplete greps literal `task_4`), #693 (commit/task_review pass with zero commits), #695 (subagent force-completes workflow) | Steps verified by string-matching or absence checks instead of invariants |
+| 5 | **Agent identity misdetection** | #92 (only reopened issue in repo), #272, #665 (mentioning "commit-writer" bricked a session), #538 | Identity heuristics scattered across hooks |
+| 6 | **session-guard stop-hook loops** | 226 "DO NOT STOP" blocks in one GH-690 session, incl. while rate-limited; 23 project dirs affected | Guard re-fires unconditionally; no stand-down on rate limit/abort/abandonment |
+| 7 | **Concurrency & environment** | #720 (parallel waves share worktree, evidence cross-contamination), #611 (check report clobber race), GH-539/GH-690 (plugin-cache vs source skew blocks in-run fixes), fresh-worktree node_modules | — |
+
+### Second-order costs
+
+- **Bypass pressure:** gates strict enough that agents repeatedly propose bypasses; the
+  operator polices it manually ("I'm not asking you to bypass.. I'm asking you to fix").
+  Half the synapsys memory corpus is anti-bypass rules. Missing legitimate escape hatches,
+  not bad agents.
+- **Token burn:** `_tddRetryCount: 43` = 43 full dispatch cycles on one wedged task (~4 h).
+- **Operator babysitting:** maestro dead-end kills, question-pending menus, "agent stuck for
+  hours" discoveries.
+
+### The structural insight
+
+Every quality rule added since #340 fixed a real fraud case and created a new wedge, because
+each rule encodes an assumption about what "real work" looks like (a runner, a task shape, a
+repo layout). Rule-tuning can never converge: the next work-shape breaks the next assumption.
+The fixes that *did* work all moved in one direction — from "agent must behave" to "script
+verifies the result" (#539 commit validator replacing the commit-writer agent, gate-driven
+evidence replacing agent-recorded evidence, validator unification #650/#651/#654). This plan
+completes that trajectory.
+
+---
+
+## 3. Design principles
+
+1. **Verify the product, not the process.** Don't choreograph RED-before-GREEN; prove the same
+   property retroactively: the task's tests fail on base, pass on head. Same fraud resistance,
+   zero mid-loop state.
+2. **Block on contradiction, flag on uncertainty, never block on absence of evidence.**
+   Three verdicts: `VERIFIED` → advance; `UNVERIFIED` (couldn't check: unknown runner, no JSON
+   reporter, tooling absent) → advance **with a flag** consumed downstream; `CONTRADICTED`
+   (0 tests ran, out-of-scope diff, empty diff, tests fail on head) → block **with a typed exit**.
+   Nearly every historical wedge was an absence-of-evidence block; every catastrophic false
+   GREEN was a detectable contradiction.
+3. **Liveness is a provable invariant, not a bug-fixing goal.** Every BLOCK verdict is typed
+   (`retry` / `reopen-artifact` / `escalate`) and every type has a sanctioned exit edge. A gate
+   that can't name its exit edge may not block — it degrades to a flag. A unit test enumerates
+   the verdict table and asserts every entry has an outgoing edge.
+4. **Quality is strict in aggregate.** The per-task verifier is allowed to be merely good;
+   the conjunction of verifier + task_review + check step (which refuses to pass with
+   unresolved flags) + CI is what must be near-perfect. Layered cheap checks with uncorrelated
+   failure modes beat one perfect gate.
+5. **Observe, don't declare.** Derive what to verify from the task's actual commits (diff),
+   not from planner declarations. Declarations that can diverge from reality eventually will
+   (incident class 3).
+6. **Make faking more expensive than doing.** Multi-signal verification means fabricating a
+   pass requires writing a real failing test in scope and making it pass with a real diff —
+   i.e., doing the task. No recordable evidence exists to forge.
+7. **Every incident becomes a fixture before it's fixed.** The replay corpus is the gate's own
+   regression suite.
+
+---
+
+## 4. Decision record — options considered
+
+| Option | Verdict | Why |
+|--------|---------|-----|
+| Keep process enforcement, keep patching rules | **Rejected** | Whack-a-mole is structural (see §2); 4 tickets filed for one defect class; recurrence data (#462 3×, #466→#749) shows non-convergence |
+| Remove TDD enforcement, require **coverage** after development | **Partially adopted** | Right direction, but coverage alone proves execution, not assertion — invites tautology/change-detector tests. Upgraded to full outcome verification (coverage is one of five invariants) |
+| Gate **only at implement-exit** (whole-phase batch verification) | **Rejected by operator (2026-07-16)** | Loses fault localization; task 5 builds on broken task 2; end-of-phase failure smears across all tasks. Per-task verification retained |
+| **Per-task outcome verification** (this plan) | **Adopted** | Wedge factory was the *phase choreography inside* tasks, not the task boundary itself. A stateless check at each boundary keeps localization with none of the phase-machine state |
+| Diff-scoped mutation testing (Stryker) as the anti-tautology check | **Deferred — held in reserve** | Gold-standard but slow + per-repo config burden. Retroactive fail-on-base delivers most of the value; escalate to mutation testing only if escape-rate SLI creeps |
+
+---
+
+## 5. Target architecture
+
+### 5.1 The per-task loop (outcome mode)
+
+```
+dispatch task N
+  └─ agent implements freely (no phases, no evidence recording, no phase-scoped edit rules)
+      ├─ advisory: agent runs tests naturally; harness may run affected tests post-edit,
+      │            failures injected into next dispatch prompt as INFORMATION — never a verdict
+      └─ agent commits (per-task commit(s), ticket-tagged — unchanged)
+implement-gate (outcome verifier) runs on task N's commits
+  ├─ VERIFIED      → task-advance → dispatch task N+1
+  ├─ UNVERIFIED    → flag(s) recorded → task-advance → dispatch task N+1
+  └─ CONTRADICTED  → typed exit:
+        retry            → re-dispatch task N with the contradiction as guidance
+        reopen-artifact  → planner-hold (tasks.md becomes editable at the tasks step)
+        escalate         → operator recovery hatch (AskUserQuestion)
+implement-exit (light aggregate pass — no new authority)
+  ├─ full suite once on head
+  ├─ branch-level diff coverage
+  └─ flag consolidation → check step input
+```
+
+### 5.2 The five invariants (per task)
+
+All inputs are **observed from the task's commits**, not declared.
+
+| # | Invariant | Catches | Failure verdict |
+|---|-----------|---------|-----------------|
+| I1 | **Diff exists and is in scope** — task commits produce a non-empty diff; changed files ⊆ task file scope (glob-expanded by the ONE shared resolver) | zero-code-on-disk completions (#749 aftermath, #466); scope creep | CONTRADICTED |
+| I2 | **Deliverables exist** — files the task promises (kind-aware) are present on head | #724 (completed task carrying unapplied deliverable), #694 | CONTRADICTED |
+| I3 | **Retroactive red** — test files derived from the diff, overlaid onto a base worktree, **fail or fail-to-load on base**; pass-on-base+pass-on-head = tautology | tautology / change-detector tests; vacuous suites; replaces the entire RED phase | FLAG (tautology) — never blocks; fixture-reviewed |
+| I4 | **Tests pass on head** — the task's tests + an affected-tests subset run green; test count parsed from the runner's **structured output** (JSON reporter), must be > 0 for kinds that require tests | "No test files found → exit 0" (#749/#466); whole-suite ambiguity (#737); stdout string-scraping false trips | CONTRADICTED |
+| I5 | **Diff coverage** — changed production lines covered ≥ threshold (per-repo envelope var; threshold configurable) | untested code paths | FLAG below threshold; CONTRADICTED only at 0% with kind requiring tests |
+
+**Mechanism failures are never contradictions.** Can't set up the base worktree, no JSON
+reporter available, coverage tooling absent → `UNVERIFIED` + flag. Only positive evidence of
+a problem blocks.
+
+### 5.3 Derive-tests-from-diff (kills the Test Strategy contract)
+
+The task's test files are identified from `git diff <task-base>..<task-head>` intersected with
+repo test patterns (existing glob conventions). Consequences:
+
+- The planner **no longer declares** per-task test commands, entry files, or scope globs for
+  gating purposes. The #725/#727/#737/#590/#546/#547 defect class (declaration ≠ reality) has
+  no substrate left.
+- `tasks.md` keeps: **scenarios** (Given/When/Then — guidance for writing tests; the design
+  value of test-first lives here) and **file scope** (bounds I1). Test Strategy shrinks to two
+  repo-level envelope vars: `$WORK_SUITE_COMMAND`, `$WORK_COVERAGE_COMMAND` (+ optional
+  affected-tests command).
+
+### 5.4 Retroactive red mechanics (I3)
+
+1. Once per ticket: `git worktree add <tmp>/base-<ticket> <merge-base>`; symlink node_modules
+   from the main checkout (known-good pattern, see heimdall memory).
+2. Per task: `git checkout <task-head> -- <derived test paths>` inside the base worktree
+   (overlay the task's test files and any test helpers in its diff).
+3. Run only those files with the repo runner (JSON reporter).
+4. Interpretation by kind:
+   - **feature/fix:** expected **fail** (assertion) or **fail-to-load** (imports new module —
+     honest state for new-feature tests in the retroactive framing). Pass → tautology flag.
+   - **refactor:** exempt — behavior-preserving; verified by I4 + coverage-maintained instead.
+   - **tests-only:** the tests ARE the deliverable; they may legitimately pass on base
+     (testing existing behavior) → I3 exempt, I1/I4 apply (diff must touch test files, tests
+     pass on head).
+   - **docs:** I2 only (deliverable exists). No test requirements.
+   - **checkpoint / verified-by citation:** unchanged semantics (no test run), but expressed
+     as a kind profile in the verifier rather than special-cased control flow.
+5. Any setup failure → `UNVERIFIED` flag, advance.
+
+### 5.5 Flag consumption (load-bearing, not garnish)
+
+Flags are the quality backstop for everything that advances unverified:
+
+- **task_review** receives the task's flags in its prompt (tautology-flagged tests get
+  assertion-quality scrutiny).
+- **check step refuses to pass with unresolved flags** — resolution = fix + re-verify, or
+  operator waiver (audited). Blocks here are recoverable by design: artifacts editable,
+  operator reachable, loop exists.
+- **PR description** lists waived flags (transparency to reviewers).
+- A unit test asserts the check step actually fails on an unresolved flag (this design is
+  *weaker* than today if flags are ignored — that must be impossible).
+
+### 5.6 What gets decommissioned
+
+| Component | Today | After |
+|-----------|-------|-------|
+| `tdd-phase-state.js` + 14 CLI modules (111 KB) | records/validates phase evidence | **deleted** — nothing to record |
+| `task-next.js` (1,740 LOC phase machine) | drives RED→GREEN→REFACTOR | **deleted or shrunk** to a thin advisory test runner |
+| `tdd-phase.json` per task + hook protection | authoritative evidence | **gone** — verifier observes git + runner output; verifier output is a plain audited report in `.work-actions.json` |
+| Phase-scoped edit hooks (`work-implement-enforce`) | blocks edits by phase | **deleted** (root cause of #722, #720 hook half) |
+| 9 `_tddRetry*` fields + scattered `delete ws[key]` | retry bookkeeping | **gone** — retry context derived from the verifier's last report |
+| `_preTestForTask`, `_work2Dispatched` markers | pre-test dedup | **gone** — verifier is stateless per boundary |
+| Test Strategy synthesis + validation (split-in-tasks Pass D / kind_assign / fake-command detection from #590/#650/#651) | plans per-task commands | **reduced** to scenarios + file scope; two repo-level envelope vars |
+| Planner-hold (W3) | TDD-defect operator hold | **generalized & kept** as the `reopen-artifact` typed exit (its good idea survives; its TDD-specific paths go) |
+| Evidence-location machinery (#172/#284 class) | per-task evidence routing | moot |
+
+Estimated deletion: **~3–4k LOC** across gate modules, CLI, hooks, and their tests.
+
+### 5.7 What is kept unchanged
+
+Per-task commits (ticket-tagged; fault localization + bisect), task_review, check step
+machinery, commit validator (#539/#693 invariants — commits ahead of base), reports/learnings,
+maestro integration, brief/spec/tasks upstream steps (minus Test Strategy weight).
+
+---
+
+## 6. Phased delivery
+
+Each phase ships independently and is /work-ticket-sized per PR. **Order matters for 0→3;
+Phase 1 items can interleave; Phase 5 is parallelizable.**
+
+### Phase 0 — Measurement baseline & replay corpus (1 PR)
+
+The "are we sure?" infrastructure. Everything later is judged against this.
+
+- **Incident replay corpus:** encode ~20 historical incidents as fixtures (captured runner
+  outputs, evidence/state snapshots, diffs) from #749, #737, #736, #727, #725, #724, #722,
+  #721, #720, #694, #693, #653, #606, #584, #532, #509, #466, #462, #248, GH-539.
+  Each fixture labels the **correct** verdict (e.g. #749 → CONTRADICTED "0 tests ran";
+  #248 docs task → UNVERIFIED advance; #737 genuine RED → verifiable failure).
+- **SLI extractor** (`scripts/sli-report.js`) over `.work-actions.json` history + reports:
+  - **Wedge rate:** tasks requiring operator state surgery or > N gate retries.
+  - **Escape rate:** tasks that passed the gate but were caught defective downstream
+    (check/review/CI attributable).
+  - Secondary: retries/task, dispatches/task, time-in-implement, operator interventions.
+- Baseline both SLIs from existing history (GH-590, GH-610, GH-690, FUT-* runs).
+
+**Acceptance:** corpus fixtures load + label; SLI report runs over ≥ 10 historical tickets.
+
+### Phase 1 — Stop the bleeding on the current system (3 PRs, ship immediately)
+
+Valuable now, still required in the target architecture.
+
+1. **session-guard stand-down** — cap identical consecutive blocks (3); detect rate-limit /
+   user-abort / abandoned-workflow and stop re-firing; surface once to conductor instead.
+   (Kills the 226-block class; guard's quality function lives in fires 1–3.)
+2. **Recovery primitive** — `work-state.js recover <ticket> --task N
+   --action abandon-cycle|resync-meta|reopen-task`:
+   - operator-approved via AskUserQuestion (interactive-gates preference), fully audited in
+     `.work-actions.json`;
+   - **consistency-only:** returns state to a re-attemptable configuration; never mints
+     evidence or completion (recovery ≠ completion);
+   - tripwire: > K recoveries on one ticket auto-files a harness/planner defect issue.
+   Resolves the #721/#724/#736/#722/#509 class today; remains the `escalate` exit later.
+3. **Verdict-table liveness test** — enumerate current gate verdicts × workflow states; assert
+   every BLOCK has a sanctioned outgoing edge. Wedges become CI failures, pre- and post-flip.
+
+**Acceptance:** replay #721/#736 scenarios end in recovery, not surgery; liveness test red on
+a deliberately edge-less verdict.
+
+### Phase 2 — Build the outcome verifier behind a flag (2–3 PRs)
+
+- New `implement-exit-verify/` (name TBD: `task-verify/`) module implementing §5.2–§5.4:
+  - `derive-tests-from-diff` resolver (shared glob resolver — the validator-unification
+    invariant applies: ONE implementation);
+  - runner adapters with **JSON/structured reporters first** (vitest, jest, node --test),
+    stdout scraping only as UNVERIFIED-grade fallback;
+  - base-worktree manager (create once per ticket, overlay per task, reap on cleanup);
+  - three-verdict engine + typed exits; per-kind profiles as data, not control flow.
+- **Corpus gate:** every historical false-GREEN fixture → CONTRADICTED; every historical
+  wedge fixture → VERIFIED or UNVERIFIED (never block). A rule change that regresses a
+  fixture in either direction does not ship.
+- **Shadow mode:** verifier runs alongside existing gates on real tickets, logging verdicts
+  with no authority; divergence report (shadow vs. incumbent) per ticket.
+
+**Acceptance:** corpus 100% green; ≥ 3 real tickets shadow-run; divergence report reviewed.
+
+### Phase 3 — The flip (2 PRs)
+
+- `WORK_TDD_MODE=outcome` (default stays `process` until Phase 3 exit criteria met):
+  - task advance = verifier verdict (VERIFIED/UNVERIFIED) + existing commit invariants;
+  - RED/GREEN mid-loop gating and phase enforcement disabled in outcome mode;
+  - advisory per-task test feedback wired (failures → next dispatch prompt);
+  - implement-exit light aggregate pass (§5.1) feeds check step;
+  - check step hard-fails on unresolved flags (+ its unit test).
+- Run 3–5 real tickets in outcome mode; compare SLIs vs Phase 0 baseline.
+
+**Exit criteria (to make `outcome` the default):** wedge rate ≈ 0 on outcome tickets;
+escape rate ≤ baseline; no fixture regressions; token/duration per ticket reduced.
+
+### Phase 4 — Decommission (3–4 PRs, one per subsystem)
+
+Only after outcome mode is default and stable for one release:
+
+1. Delete `tdd-phase-state.js` CLI + evidence files + protection hooks; migrate planner-hold
+   into the `reopen-artifact` exit.
+2. Delete/shrink `task-next.js`; delete phase-edit hooks; purge `_tddRetry*` and dispatch
+   markers (encapsulate what little state remains behind one module).
+3. Shrink split-in-tasks: remove Test Strategy synthesis/validation (Pass D, kind_assign
+   command checks, fake-command detection); keep scenarios + file scope + kinds.
+4. Docs/skills/memories sweep: `work-implement` skill, work.md instructions, agent prompts;
+   retire obsolete synapsys/auto-memories (no-fake-tdd-evidence becomes moot — note this
+   explicitly so the memory corpus doesn't contradict the harness).
+
+**Acceptance:** plugin test suite green; LOC accounting in PR descriptions; one full ticket
+end-to-end on the slimmed system.
+
+### Phase 5 — Orthogonal hardening (3 PRs, parallelizable, any time)
+
+1. **One agent-identity module** consumed by every hook (#92/#272/#665/#538 class).
+2. **Plugin-cache vs source version check** at workflow start — warn on skew (GH-539/GH-690
+   class: mid-run harness bugs unfixable).
+3. **Parallel-wave attribution** — per-task commits give clean diffs; require explicit task
+   attribution for concurrent implement waves (#720). (Mostly moot in outcome mode — no
+   shared per-cycle evidence to contaminate — but scope attribution must stay clean.)
+
+---
+
+## 7. Metrics — how we know it worked
+
+| Metric | Baseline (Phase 0) | Target |
+|--------|--------------------|--------|
+| Wedge rate (operator surgery or > N retries per task) | measure (known: GH-690 3 tasks × 20–40 min; #606 43 retries) | **≈ 0** — structurally: no mid-loop phase state to wedge |
+| Escape rate (gate-passed, caught defective downstream) | measure (known: rest-refactor 6 tasks zero-code) | **≤ baseline**, trending down |
+| Replay corpus | n/a | 100% green, grows with every incident (fixture-before-fix rule) |
+| Dispatches per task | measure | ↓ (no retry storms) |
+| Operator interventions per ticket (recoveries, maestro dead-ends, question-pendings) | measure | ↓ |
+
+SLI report lands in each ticket's `learnings.md` (reports step) so drift is visible per run.
+
+---
+
+## 8. What we give up, honestly — and the mitigations
+
+| Given up | Mitigation |
+|----------|------------|
+| Mechanical test-**first** sequencing | Spec's Given/When/Then scenarios carry the design-thinking value; I3 (fail-on-base) proves tests specify behavior — the *product* of TDD without its choreography |
+| A hard "tests can fail" proof per cycle | I3 provides it per task; tautology flags reviewed by task_review; **diff-scoped mutation testing (Stryker) held in reserve** if escape rate creeps |
+| In-loop hard stops on bad work | Advisory feedback keeps the signal; contradictions still block at the task boundary; check step remains a hard gate at a recoverable location |
+| The comfort of "evidence files" | The verifier's report in `.work-actions.json` is the evidence — computed from observable reality (git + runner output), which is harder to fake than a recordable file |
+
+Residual risks:
+
+- **New-gate teething:** bounded by shadow mode + corpus + block-only-on-contradiction (a
+  verifier bug produces a flag or a recoverable block, never a 43-retry wedge).
+- **Flag fatigue:** if everything flags UNVERIFIED (e.g., a repo with no JSON reporter),
+  quality pressure shifts entirely to check/review. Track flag volume per ticket; add runner
+  adapters where it's high.
+- **Base-worktree cost:** one worktree per ticket + per-task overlay runs. Cheap after first
+  setup; reaped at cleanup. Mechanism failures degrade to UNVERIFIED by design.
+
+---
+
+## 9. Incident-class → design-element map
+
+| Incident class (§2) | Eliminated / mitigated by |
+|---------------------|---------------------------|
+| 1. False GREEN/RED exit-code trust | I1–I5 multi-signal verification; JSON reporters; derive-from-diff (§5.2–5.3) |
+| 2. Permanent wedges | Typed exits + liveness test (P1.3); recovery primitive (P1.2); stateless boundary check (no phase state to corrupt) |
+| 3. Planner defects behind locked tasks.md | Test Strategy contract deleted (§5.3); `reopen-artifact` exit; residual planner value (scenarios/scope) validated statically at tasks step |
+| 4. Vacuous verification | I1/I2 invariants; commit-ahead checks kept; check-step flag hard-fail |
+| 5. Identity misdetection | P5.1 single identity module |
+| 6. session-guard loops | P1.1 stand-down |
+| 7. Concurrency/environment | P5.2 cache-skew check; P5.3 attribution; base-worktree manager owns its env |
+
+---
+
+## 10. Open questions (decide during Phase 2)
+
+1. Affected-tests subset for I4: dedicated command per repo vs. run derived test files only
+   (full suite deferred to implement-exit)? Start with derived-files-only; measure escape rate.
+2. Coverage thresholds: global default vs. per-repo envelope; proposal — flag < X%, contradict
+   only at 0% for test-requiring kinds. Tune with data.
+3. Recovery `reopen-task` semantics for already-merged-upstream tasks (relates #724): reopen
+   creates a new fixup task vs. mutating completed state. Lean: new fixup task (append-only
+   history).
+4. Whether `WORK_TDD_MODE=process` is deleted in Phase 4 or kept one extra release as an
+   emergency fallback.
+
+---
+
+## Appendix A — Referenced issues
+
+Open at time of writing: #749, #737, #736, #727, #725, #724, #722, #721, #720, #719.
+Closed/high-churn: #694, #693, #695, #665, #653, #611, #606, #590, #584, #546/#547, #539,
+#538, #532, #509, #466, #462, #410, #340, #276, #272, #248, #172, #92 (only formally reopened
+issue). Epics acknowledging the systemic themes: #392, #398.
+
+Repo: `thomfilg/ai-plugin-work` (renamed from `claude-plugin-work` 2026-07-08).

--- a/docs/outcome-verification-baseline.md
+++ b/docs/outcome-verification-baseline.md
@@ -1,0 +1,55 @@
+# Outcome verification — Phase 0 SLI baseline
+
+**Issue:** GH-751 (epic GH-750) · **Plan:** `docs/implement-outcome-verification-plan.md` §6 Phase 0, §7
+**Generated:** 2026-07-16 · **Tool:** `plugins/work/scripts/workflows/lib/scripts/sli/sli-report.js`
+
+Regenerate:
+
+```bash
+node plugins/work/scripts/workflows/lib/scripts/sli/sli-report.js \
+  --tasks-base "$TASKS_BASE"          # add --json for machine output
+```
+
+## Aggregate (92 analyzable tickets, 505 tasks)
+
+| SLI | Baseline | Target (plan §7) |
+|-----|----------|------------------|
+| Wedge rate (W1–W4) | **2.0%** of tasks (10/505), 10 tickets affected | ≈ 0 |
+| Escape rate (E1–E2) | **0.0% measured** (0/444 advanced) — see caveats | ≤ baseline, trending down |
+| Retries (gate rejections + state retries + fix rounds) | **461** across 505 tasks | ↓ |
+| Dispatches (usage rows; implement) | 136 (57 implement) | ↓ |
+| Time-in-implement (T1) | 1,773h across history | ↓ |
+| Implement re-entries (E3, ticket-level) | 9 (3 tickets) | ↓ |
+
+Notable tickets (plan-referenced):
+
+| Ticket | Tasks | Wedged | Retries | Time-in-implement |
+|--------|-------|--------|---------|-------------------|
+| GH-462 | 8 | 1 (task 4) | 15 | 27m |
+| GH-590 | 15 | 0 | 3 | 59m |
+| GH-610 | 4 | 0 | 0 | 15h 7m |
+| GH-690 | 10 | 0 | 0 (28 dispatches) | 10h 52m |
+
+## Caveats — what this baseline can and cannot see
+
+All SLIs are documented proxies over `.work-actions.json` + `.work-state.json`
+(`sli-report.js --help` lists W1–W4 / E1–E3 / D1–D2 / T1 verbatim).
+
+1. **Escape rate under-measures today.** `advanceTask` resets
+   `taskReviewFixRounds` to 0 on completion, and `task review failed` rows are
+   rarely attributable, so completed-task escapes are mostly invisible in the
+   trail. Known escapes from the issue tracker (e.g. GH-749's six zero-code
+   auto-completed tasks) also happened in worktrees whose tasks dirs are no
+   longer under this base. The number to beat is therefore the *incident
+   record* (replay corpus), not this 0.0%; the shadow/outcome phases (GH-755,
+   GH-756) add verifier verdict rows that make escapes directly measurable.
+2. **Session-guard loops are invisible.** The GH-690 226-stop-block incident
+   wrote nothing to the audit trail; its cost shows up only as 10h 52m
+   time-in-implement. GH-752 (stand-down) adds an audit row per stand-down,
+   making this class measurable.
+3. **Recovery events (W3) are forward-looking.** The `/recover/i` enforcement
+   action match is designed for GH-753's `work-state.js recover` rows; today
+   it only catches ad-hoc rows that happen to mention recovery.
+4. 87 of 179 dirs under the base are `GH-*` with at least one input file;
+   older `#<n>`-style dirs predate the audit trail and are skipped with
+   warnings (81 warnings on this run).

--- a/plugins/work/scripts/workflows/lib/outcome-verdicts.js
+++ b/plugins/work/scripts/workflows/lib/outcome-verdicts.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/**
+ * outcome-verdicts.js — shared vocabulary for the outcome-verification work
+ * (GH-750 epic; docs/implement-outcome-verification-plan.md §5.2).
+ *
+ * One tiny module so the replay corpus (GH-751), the task verifier (GH-755),
+ * and the flip wiring (GH-756) can never drift on the verdict/exit/invariant
+ * names. Data only — no behavior.
+ */
+
+/**
+ * The three verdicts a task-boundary verification can produce.
+ * - VERIFIED      → advance.
+ * - UNVERIFIED    → advance WITH flags (couldn't check; absence of evidence
+ *                   never blocks).
+ * - CONTRADICTED  → block with a typed exit (positive evidence of a problem).
+ */
+const VERDICTS = Object.freeze({
+  verified: 'VERIFIED',
+  unverified: 'UNVERIFIED',
+  contradicted: 'CONTRADICTED',
+});
+
+/**
+ * Typed exits — every CONTRADICTED verdict must name exactly one, so liveness
+ * is a provable invariant (a block that cannot name its exit may not block).
+ */
+const EXITS = Object.freeze({
+  retry: 'retry',
+  reopenArtifact: 'reopen-artifact',
+  escalate: 'escalate',
+});
+
+/** The five mechanical invariants observed from a task's commits. */
+const INVARIANTS = Object.freeze({
+  diffInScope: 'I1',
+  deliverablesExist: 'I2',
+  failOnBase: 'I3',
+  passOnHead: 'I4',
+  diffCoverage: 'I5',
+});
+
+/**
+ * Flag kinds attached to UNVERIFIED advances (and to soft findings on
+ * otherwise-advancing verdicts). Consumed by task_review and the check step.
+ */
+const FLAG_KINDS = Object.freeze({
+  noStructuredReporter: 'no-structured-reporter',
+  baseSetupFailed: 'base-setup-failed',
+  coverageUnavailable: 'coverage-unavailable',
+  coverageBelowThreshold: 'coverage-below-threshold',
+  tautology: 'tautology',
+  runnerUnknown: 'runner-unknown',
+  scopeResolutionFailed: 'scope-resolution-failed',
+});
+
+/**
+ * Task kinds the verifier profiles over — mirrors the planner's kind
+ * vocabulary (split-in-tasks/lib/task-types.js) so fixtures and profiles
+ * speak the same language.
+ */
+const TASK_KINDS = Object.freeze([
+  'tdd-code',
+  'tests-only',
+  'mechanical-refactor',
+  'docs',
+  'config',
+  'ci',
+  'file-move',
+  'checkpoint',
+  'verified-by',
+  'wiring-citation',
+]);
+
+const VERDICT_VALUES = Object.freeze(Object.values(VERDICTS));
+const EXIT_VALUES = Object.freeze(Object.values(EXITS));
+const INVARIANT_VALUES = Object.freeze(Object.values(INVARIANTS));
+const FLAG_KIND_VALUES = Object.freeze(Object.values(FLAG_KINDS));
+
+module.exports = {
+  VERDICTS,
+  EXITS,
+  INVARIANTS,
+  FLAG_KINDS,
+  TASK_KINDS,
+  VERDICT_VALUES,
+  EXIT_VALUES,
+  INVARIANT_VALUES,
+  FLAG_KIND_VALUES,
+};

--- a/plugins/work/scripts/workflows/lib/replay-corpus/__tests__/replay-corpus.test.js
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/__tests__/replay-corpus.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { loadCorpus, validateFixture, FIXTURES_DIR } = require('..');
+const { VERDICTS } = require('../../outcome-verdicts');
+
+/**
+ * Incidents the plan (§6 Phase 0) requires the corpus to cover. GH-539 is
+ * covered via its planner-defect framing; GH-720 via cross-task attribution.
+ */
+const REQUIRED_INCIDENTS = [
+  'GH-749',
+  'GH-737',
+  'GH-736',
+  'GH-727',
+  'GH-725',
+  'GH-724',
+  'GH-722',
+  'GH-721',
+  'GH-720',
+  'GH-694',
+  'GH-693',
+  'GH-653',
+  'GH-606',
+  'GH-584',
+  'GH-532',
+  'GH-509',
+  'GH-466',
+  'GH-462',
+  'GH-248',
+  'GH-539',
+];
+
+function validFixture(overrides = {}) {
+  return {
+    name: 'test-fixture',
+    incident: 'GH-999',
+    incidentClass: 1,
+    taskKind: 'tdd-code',
+    description: 'synthetic fixture for validator tests',
+    observations: {
+      diff: { empty: false, filesChanged: ['src/a.js'], scopeGlobs: ['src/**'], outOfScope: [] },
+      deliverables: { promised: ['src/a.js'], missing: [] },
+      baseRun: { attempted: true, supported: true, outcome: 'fail', testsRan: 2, failures: 2 },
+      headRun: {
+        attempted: true,
+        supported: true,
+        outcome: 'pass',
+        testsRan: 2,
+        failures: 0,
+        exitCode: 0,
+        reporterKind: 'structured',
+      },
+      coverage: { supported: true, changedLineCoveragePct: 92 },
+    },
+    expected: { verdict: 'VERIFIED', rationale: 'all invariants hold' },
+    provenance: { issue: 'https://github.com/thomfilg/ai-plugin-work/issues/999' },
+    ...overrides,
+  };
+}
+
+describe('replay-corpus — fixture validation', () => {
+  it('accepts a fully-formed fixture', () => {
+    assert.deepEqual(validateFixture(validFixture()), []);
+  });
+
+  it('rejects non-object input', () => {
+    assert.ok(validateFixture(null).length > 0);
+    assert.ok(validateFixture([]).length > 0);
+  });
+
+  it('requires a typed exit and violated invariants for CONTRADICTED', () => {
+    const missingBoth = validFixture({
+      expected: { verdict: 'CONTRADICTED', rationale: 'r' },
+    });
+    const errors = validateFixture(missingBoth);
+    assert.ok(errors.some((e) => e.includes('expected.exit')));
+    assert.ok(errors.some((e) => e.includes('violatedInvariants')));
+
+    const complete = validFixture({
+      expected: {
+        verdict: 'CONTRADICTED',
+        exit: 'retry',
+        violatedInvariants: ['I4'],
+        rationale: 'r',
+      },
+    });
+    assert.deepEqual(validateFixture(complete), []);
+  });
+
+  it('requires flags for UNVERIFIED and forbids exit outside CONTRADICTED', () => {
+    const noFlags = validFixture({ expected: { verdict: 'UNVERIFIED', rationale: 'r' } });
+    assert.ok(validateFixture(noFlags).some((e) => e.includes('expected.flags')));
+
+    const strayExit = validFixture({
+      expected: { verdict: 'VERIFIED', exit: 'retry', rationale: 'r' },
+    });
+    assert.ok(validateFixture(strayExit).some((e) => e.includes('only legal for CONTRADICTED')));
+  });
+
+  it('rejects unknown kinds, verdicts, outcomes, and malformed incidents', () => {
+    assert.ok(validateFixture(validFixture({ taskKind: 'nope' })).length > 0);
+    assert.ok(
+      validateFixture(validFixture({ expected: { verdict: 'MAYBE', rationale: 'r' } })).length > 0
+    );
+    assert.ok(validateFixture(validFixture({ incident: '749' })).length > 0);
+    const badRun = validFixture();
+    badRun.observations.headRun.outcome = 'sideways';
+    assert.ok(validateFixture(badRun).length > 0);
+  });
+});
+
+describe('replay-corpus — loadCorpus over a directory', () => {
+  let dir;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'replay-corpus-test-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reports unparseable JSON and name/filename mismatches', () => {
+    fs.writeFileSync(path.join(dir, 'broken.json'), '{nope');
+    fs.writeFileSync(
+      path.join(dir, 'misnamed.json'),
+      JSON.stringify(validFixture({ name: 'other-name' }))
+    );
+    const { errors } = loadCorpus({ fixturesDir: dir });
+    assert.ok(errors.some((e) => e.startsWith('broken.json: unparseable JSON')));
+    assert.ok(errors.some((e) => e.includes('must equal filename stem')));
+  });
+
+  it('reports duplicate fixture names across files', () => {
+    fs.writeFileSync(path.join(dir, 'a.json'), JSON.stringify(validFixture({ name: 'a' })));
+    fs.writeFileSync(path.join(dir, 'b.json'), JSON.stringify(validFixture({ name: 'a' })));
+    const { errors } = loadCorpus({ fixturesDir: dir });
+    assert.ok(errors.some((e) => e.includes('must equal filename stem')));
+    assert.ok(errors.some((e) => e.includes('duplicate fixture name: a')));
+  });
+
+  it('returns a dir-level error for a missing directory', () => {
+    const { fixtures, errors } = loadCorpus({ fixturesDir: path.join(dir, 'absent') });
+    assert.equal(fixtures.length, 0);
+    assert.equal(errors.length, 1);
+  });
+});
+
+describe('replay-corpus — the shipped corpus', () => {
+  const { fixtures, errors } = loadCorpus();
+
+  it('loads with zero validation errors', () => {
+    assert.deepEqual(errors, []);
+  });
+
+  it('covers every incident the plan requires', () => {
+    const covered = new Set(fixtures.map((f) => f.incident));
+    const missing = REQUIRED_INCIDENTS.filter((i) => !covered.has(i));
+    assert.deepEqual(missing, [], `corpus missing incidents: ${missing.join(', ')}`);
+  });
+
+  it('labels every historical wedge as advancing (never a dead-end block)', () => {
+    // Classes 2 (permanent wedges): the outcome verifier must never reproduce
+    // the dead end — CONTRADICTED is allowed only with a recoverable exit.
+    for (const f of fixtures.filter((x) => x.incidentClass === 2)) {
+      if (f.expected.verdict === VERDICTS.contradicted) {
+        assert.ok(
+          f.expected.exit,
+          `${f.name}: wedge-class CONTRADICTED fixture must carry a typed exit`
+        );
+      }
+    }
+  });
+
+  it('keeps fixtures dir and loader defaults in sync', () => {
+    assert.ok(fs.existsSync(FIXTURES_DIR));
+    assert.ok(fixtures.length >= 18, `expected >= 18 fixtures, got ${fixtures.length}`);
+  });
+});

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-248-docs-profile-framing.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-248-docs-profile-framing.json
@@ -1,0 +1,35 @@
+{
+  "name": "gh-248-docs-profile-framing",
+  "incident": "GH-248",
+  "incidentClass": 4,
+  "taskKind": "docs",
+  "description": "Docs-profile boundary: the deliverable exists and the diff is in scope, but there is nothing mechanically runnable to verify prose content with — the runner cannot interpret a docs verification, so the content-quality judgment belongs to downstream review, carried by a flag with FULL context (never silently downgraded or truncated).",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": ["docs/adr/0009-retry-policy.md"],
+      "scopeGlobs": ["docs/adr/**"],
+      "outOfScope": []
+    },
+    "deliverables": { "promised": ["docs/adr/0009-retry-policy.md"], "missing": [] },
+    "baseRun": { "attempted": false, "supported": false, "outcome": "not-run" },
+    "headRun": {
+      "attempted": false,
+      "supported": false,
+      "outcome": "not-run",
+      "testsRan": 0,
+      "reporterKind": "none",
+      "notes": "no runnable verification exists for prose content"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "UNVERIFIED",
+    "flags": ["runner-unknown"],
+    "rationale": "Deliverable exists (I2 holds) but content cannot be mechanically checked — advance with a flag so task_review scrutinizes the prose; plan §6 Phase 0 labels the docs case 'UNVERIFIED advance'."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/248",
+    "notes": "FRAMING NOTE: the real GH-248 is follow-up-pr comment triage (auto-downgrading position-outdated comments, truncating bodies) — not a task-boundary event. Its transferable lesson is encoded here: evidence handed downstream must keep full fidelity; flags must carry complete context rather than being silently downgraded. The plan's §6 reference to '#248 docs task' does not match the issue's actual content."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-462-artifact-defect-boundary-clean.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-462-artifact-defect-boundary-clean.json
@@ -1,0 +1,44 @@
+{
+  "name": "gh-462-artifact-defect-boundary-clean",
+  "incident": "GH-462",
+  "incidentClass": 2,
+  "taskKind": "tdd-code",
+  "description": "Third occurrence of the Requirement Coverage deadlock: completion-checker required a '## Requirement Coverage' heading in tasks.md, the heading was absent (a planner-artifact defect), and protect-tasks-md blocked every edit path — while the implementing task's own work was entirely sound. Resolved historically by out-of-band manual edits on three tickets in 24h.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": [
+        "src/features/alerts/escalation.js",
+        "src/features/alerts/__tests__/escalation.test.js"
+      ],
+      "scopeGlobs": ["src/features/alerts/**"],
+      "outOfScope": []
+    },
+    "deliverables": { "promised": ["src/features/alerts/escalation.js"], "missing": [] },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "fail",
+      "testsRan": 4,
+      "failures": 4
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 4,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "structured"
+    },
+    "coverage": { "supported": true, "changedLineCoveragePct": 91 }
+  },
+  "expected": {
+    "verdict": "VERIFIED",
+    "rationale": "At the task boundary every invariant holds — the defect lives in tasks.md, not in the task's commits. The verifier must NOT block clean work for an artifact defect; that defect surfaces downstream (check step) and routes through the reopen-artifact exit, where editing tasks.md is legal."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/462",
+    "notes": "Signal name requirement_coverage_missing; recurred on GH-440/GH-445/GH-444. Fixture pins the separation of concerns: boundary verdict judges the task's commits only; artifact-consistency defects get the reopen-artifact edge at the step that discovers them."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-466-empty-command-instant-green.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-466-empty-command-instant-green.json
@@ -1,0 +1,51 @@
+{
+  "name": "gh-466-empty-command-instant-green",
+  "incident": "GH-466",
+  "incidentClass": 1,
+  "taskKind": "tdd-code",
+  "description": "The gate's hook spawned the test command without sourcing .envrc, so $TEST_UNIT_COMMAND was empty and 'eval \"\"' exited 0 instantly with zero output bytes — recorded as an authentic GREEN 1.1 seconds after RED with no source change. Task 1 was marked completed with no implementation.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": [
+        "plugins/work/scripts/workflows/lib/hooks/__tests__/enforce-step-workflow.test.js"
+      ],
+      "scopeGlobs": ["plugins/work/scripts/workflows/lib/hooks/**"],
+      "outOfScope": [],
+      "notes": "test-file-only diff; no source change between the recorded RED and GREEN"
+    },
+    "deliverables": {
+      "promised": ["plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js"],
+      "missing": ["plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js"]
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 0,
+      "failures": 0,
+      "notes": "same empty command; exit 0 with zero output"
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 0,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "none",
+      "notes": "zero stdout bytes; ~1s wall clock; resolved command was empty"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I2", "I4"],
+    "exit": "retry",
+    "rationale": "Zero tests ran for a test-requiring kind (exit-0 with no structured count is not a pass) and the promised implementation is missing from the diff."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/466",
+    "notes": "Green log header: '# command: CHANGED_FILES=\"...\" eval \"$TEST_UNIT_COMMAND\"' / '# exitCode: 0' with zero output bytes; RED->GREEN delta 1.1s; follow-on retry loop reached _tddRetryCount: 8 on task 2."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-509-resume-with-work-already-done.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-509-resume-with-work-already-done.json
@@ -1,0 +1,45 @@
+{
+  "name": "gh-509-resume-with-work-already-done",
+  "incident": "GH-509",
+  "incidentClass": 2,
+  "taskKind": "tdd-code",
+  "description": "Resuming GH-504 after an interrupted session: the task's implementation and tests were already committed and code-reviewed on the branch, but the live gate demanded a fresh chronological RED — impossible since the test command now exits 0. No escape hatch applied; the workflow stalled and the user abandoned /work.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": ["src/alerts.js", "src/__tests__/alerts-escalation.test.js"],
+      "scopeGlobs": ["src/alerts.js", "src/__tests__/alerts-escalation.test.js"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["src/alerts.js", "src/__tests__/alerts-escalation.test.js"],
+      "missing": []
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "fail",
+      "testsRan": 5,
+      "failures": 5,
+      "notes": "reconstructed against a base worktree: the implementation is absent there, so the task's tests genuinely fail"
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 5,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "structured"
+    },
+    "coverage": { "supported": true, "changedLineCoveragePct": 95 }
+  },
+  "expected": {
+    "verdict": "VERIFIED",
+    "rationale": "All five invariants hold; the CHRONOLOGY of when a failing run was observed is irrelevant to a stateless boundary check — retroactive fail-on-base against a base worktree proves the same property the live RED tried to."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/509",
+    "notes": "The strongest argument for boundary-time fail-on-base over live RED recording. Old-system block: 'Your test command exits 0. RED requires a real failing test.' If base-worktree setup fails here, the label degrades to UNVERIFIED + base-setup-failed — never a dead end."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-532-load-crash-as-failing-test.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-532-load-crash-as-failing-test.json
@@ -1,0 +1,50 @@
+{
+  "name": "gh-532-load-crash-as-failing-test",
+  "incident": "GH-532",
+  "incidentClass": 1,
+  "taskKind": "tdd-code",
+  "description": "GH-508 task 6's test file referenced undefined symbols and crashed at load ('ReferenceError: setupStagedHook is not defined', exit 1, 0 tests collected). RED validation only checked exit != 0, so the load crash was recorded as a valid failing test; GREEN could then never pass (same crash regardless of source changes).",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": [
+        "plugins/work/scripts/workflows/work/scripts/__tests__/follow-up-auto-advance-surface.test.js",
+        "plugins/work/scripts/workflows/work/scripts/follow-up-pr.js"
+      ],
+      "scopeGlobs": ["plugins/work/scripts/workflows/work/scripts/**"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["plugins/work/scripts/workflows/work/scripts/follow-up-pr.js"],
+      "missing": []
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "load-failure",
+      "testsRan": 0,
+      "notes": "identical crash on base — only tautologically 'failing'"
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "load-failure",
+      "testsRan": 0,
+      "failures": 0,
+      "exitCode": 1,
+      "reporterKind": "structured",
+      "notes": "ReferenceError: setupStagedHook is not defined; 0 tests collected"
+    },
+    "coverage": { "supported": true, "changedLineCoveragePct": 0 }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I4"],
+    "exit": "retry",
+    "rationale": "Tests fail on head AND zero tests ran for a test-requiring kind — a load crash is not a failing assertion. Structured-reporter count > 0 is exactly the invariant that separates the two."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/532",
+    "notes": "The retry dispatch may rewrite the broken test freely (contrast the old GREEN edit-lock that wedged this)."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-539-scope-glob-unexpandable.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-539-scope-glob-unexpandable.json
@@ -1,0 +1,46 @@
+{
+  "name": "gh-539-scope-glob-unexpandable",
+  "incident": "GH-539",
+  "incidentClass": 3,
+  "taskKind": "tdd-code",
+  "description": "Validator-split class (plan §2 class 3): one validator REQUIRES a scope glob form that the other component cannot expand, so the observer cannot resolve the task's Files-in-scope into concrete paths at the boundary — while the agent's work itself is present and green.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": ["plugins/work/scripts/workflows/work/scripts/commit-and-push.js"],
+      "scopeGlobs": ["plugins/work/scripts/workflows/work/{scripts,hooks}/**"],
+      "outOfScope": [],
+      "notes": "brace-expansion glob accepted by the declaring validator but unsupported by the consuming resolver"
+    },
+    "deliverables": {
+      "promised": ["plugins/work/scripts/workflows/work/scripts/commit-and-push.js"],
+      "missing": []
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "fail",
+      "testsRan": 7,
+      "failures": 2
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 7,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "structured"
+    },
+    "coverage": { "supported": true, "changedLineCoveragePct": 87 }
+  },
+  "expected": {
+    "verdict": "UNVERIFIED",
+    "flags": ["scope-resolution-failed"],
+    "rationale": "I1's scope check cannot be evaluated when the resolver cannot expand the declared glob — a mechanism failure on the observer's side; advance with a flag (the ONE-shared-resolver rule from GH-650/GH-651/GH-654 prevents the split from recurring)."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/539",
+    "notes": "FRAMING NOTE: GH-539 itself is the commit-writer->validator replacement (script-verifies-result trajectory); the plan §2 class-3 row cites it for the glob-split defect class, which is what this fixture encodes. Provenance kept on the issue the plan cites."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-584-head-run-hangs.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-584-head-run-hangs.json
@@ -1,0 +1,43 @@
+{
+  "name": "gh-584-head-run-hangs",
+  "incident": "GH-584",
+  "incidentClass": 1,
+  "taskKind": "tdd-code",
+  "description": "The runner wrote its timeout diagnostic to the host stderr, not the captured stream: a test killed by the 5-minute timeout (SIGTERM) surfaced as exit 1 with empty captured output and was recorded as a valid failing RED. A run that verified nothing counted as evidence. At this boundary the task's tests hang on head.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": ["src/watcher.js", "src/__tests__/watcher.test.js"],
+      "scopeGlobs": ["src/**"],
+      "outOfScope": []
+    },
+    "deliverables": { "promised": ["src/watcher.js"], "missing": [] },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "fail",
+      "testsRan": 1,
+      "failures": 1
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "hang",
+      "testsRan": 0,
+      "exitCode": null,
+      "reporterKind": "none",
+      "notes": "killed by SIGTERM after 300s; zero reporter output; empty captured stderr"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I4"],
+    "exit": "retry",
+    "rationale": "For a test-requiring kind, a hang on head means tests demonstrably do not pass: a hang is neither a pass nor an assertion failure and must never satisfy any invariant. Retry with guidance: the test command timed out."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/584",
+    "notes": "signal SIGTERM, timeout 300s, empty result.stderr, recorded testExitCode 1. Had only the BASE run hung, the label would be UNVERIFIED + base-setup-failed (mechanism failure) instead."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-606-docs-task-43-retries.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-606-docs-task-43-retries.json
@@ -1,0 +1,42 @@
+{
+  "name": "gh-606-docs-task-43-retries",
+  "incident": "GH-606",
+  "incidentClass": 2,
+  "taskKind": "docs",
+  "description": "A Type: docs task (GH-517 documentation review) had its deliverable committed before the gate ran RED; the fallback 'node --test $CHANGED_FILES' filtered .md files out, ran with empty args, crashed MODULE_NOT_FOUND, and rejected RED 43 consecutive times (~4h). The work itself was correct and pushed the whole time.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": ["README.md", "plugins/work/skills/work/SKILL.md"],
+      "scopeGlobs": ["README.md", "plugins/work/skills/work/SKILL.md"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["README.md", "plugins/work/skills/work/SKILL.md"],
+      "missing": []
+    },
+    "baseRun": {
+      "attempted": false,
+      "supported": true,
+      "outcome": "not-run",
+      "notes": "docs profile: no test requirements"
+    },
+    "headRun": {
+      "attempted": false,
+      "supported": true,
+      "outcome": "not-run",
+      "testsRan": 0,
+      "reporterKind": "none",
+      "notes": "docs profile: no test requirements (the old system's 43 rejected runs were harness no-ops)"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "VERIFIED",
+    "rationale": "Docs profile is deliverable-exists-only: non-empty in-scope diff and both promised files present. The old system deadlocked purely on gate traversal (_tddRetryCount: 43) with no real defect anywhere."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/606",
+    "notes": "The canonical wedge->VERIFIED fixture. Old-system strings: '[task-next] RED: filtered 2 non-test scope entries from CHANGED_FILES (README.md, SKILL.md)'; 'Rejected RED: detected MODULE_NOT_FOUND ...'."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-653-custom-kind-harness-noop.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-653-custom-kind-harness-noop.json
@@ -1,0 +1,41 @@
+{
+  "name": "gh-653-custom-kind-harness-noop",
+  "incident": "GH-653",
+  "incidentClass": 1,
+  "taskKind": "docs",
+  "description": "A docs/config (kind: custom) task's .md-only scope filtered CHANGED_FILES empty, so the runner synthesized 'node --test' with no args -> MODULE_NOT_FOUND -> the recorder's structural-failure guard rejected RED forever. The prose deliverable itself was complete and correct.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": ["docs/runbooks/deploy.md"],
+      "scopeGlobs": ["docs/runbooks/deploy.md"],
+      "outOfScope": []
+    },
+    "deliverables": { "promised": ["docs/runbooks/deploy.md"], "missing": [] },
+    "baseRun": {
+      "attempted": true,
+      "supported": false,
+      "outcome": "error",
+      "notes": "same harness no-op crash as head; tooling failure, not signal"
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": false,
+      "outcome": "error",
+      "testsRan": 0,
+      "exitCode": 1,
+      "reporterKind": "none",
+      "notes": "node --test with zero args -> MODULE_NOT_FOUND at load; 0 tests collected"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "UNVERIFIED",
+    "flags": ["runner-unknown", "no-structured-reporter"],
+    "rationale": "Docs profile is deliverable-exists-only and the deliverable is present; the harness MODULE_NOT_FOUND is verifier-side tooling failure, which may flag but never contradict."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/653",
+    "notes": "Old-system rejection: 'Rejected RED: detected MODULE_NOT_FOUND ... structurally broken (load-time error or zero tests collected)'. Command shape: node --test $CHANGED_FILES with CHANGED_FILES=''."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-693-zero-commits-vacuous-steps.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-693-zero-commits-vacuous-steps.json
@@ -1,0 +1,40 @@
+{
+  "name": "gh-693-zero-commits-vacuous-steps",
+  "incident": "GH-693",
+  "incidentClass": 4,
+  "taskKind": "tdd-code",
+  "description": "The driver marked commit and task_review completed while 'git log origin/main..HEAD' was EMPTY and all six implementation files sat uncommitted in the working tree; no .last-commit-sha existed, so the review gate fell back to base branch and reviewed a no-op diff. Both steps verified vacuously.",
+  "observations": {
+    "diff": {
+      "empty": true,
+      "filesChanged": [],
+      "scopeGlobs": ["plugins/work/scripts/workflows/work/**"],
+      "outOfScope": [],
+      "notes": "committed diff empty; work exists only as uncommitted working-tree files, invisible to a commits-only observer"
+    },
+    "deliverables": {
+      "promised": ["plugins/work/scripts/workflows/work/lib/driver-integrity.js"],
+      "missing": ["plugins/work/scripts/workflows/work/lib/driver-integrity.js"]
+    },
+    "baseRun": { "attempted": false, "supported": true, "outcome": "not-run" },
+    "headRun": {
+      "attempted": false,
+      "supported": true,
+      "outcome": "not-run",
+      "testsRan": 0,
+      "reporterKind": "none",
+      "notes": "no test run occurred at the boundary"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I1", "I2"],
+    "exit": "retry",
+    "rationale": "A stateless observer of commits sees literally nothing — an empty branch is positive evidence, not absence of evidence. Retry with guidance: commit the working-tree changes."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/693",
+    "notes": "Log line: 'task-review-gate: No .last-commit-sha found for #689, falling back to base branch'. The commit-ahead invariants from GH-693/GH-539 are kept unchanged in the outcome model (plan 5.7)."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-694-checkpoint-never-dispatched.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-694-checkpoint-never-dispatched.json
@@ -1,0 +1,44 @@
+{
+  "name": "gh-694-checkpoint-never-dispatched",
+  "incident": "GH-694",
+  "incidentClass": 4,
+  "taskKind": "checkpoint",
+  "description": "GH-689 task 4 (checkpoint) was never dispatched: the driver closed the implement step with task_4 pending because autoCompleteCheckpointTasks grepped reports for the literal token 'task_4' while reports write 'Task 4'. At the (never-reached) boundary nothing was delivered.",
+  "observations": {
+    "diff": {
+      "empty": true,
+      "filesChanged": [],
+      "scopeGlobs": ["tasks/GH-689/completion.check.md"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["tasks/GH-689/completion.check.md"],
+      "missing": ["tasks/GH-689/completion.check.md"]
+    },
+    "baseRun": {
+      "attempted": false,
+      "supported": true,
+      "outcome": "not-run",
+      "notes": "checkpoint profile runs no tests"
+    },
+    "headRun": {
+      "attempted": false,
+      "supported": true,
+      "outcome": "not-run",
+      "testsRan": 0,
+      "reporterKind": "none",
+      "notes": "checkpoint profile runs no tests; verification is deliverable-exists"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I2"],
+    "exit": "retry",
+    "rationale": "Even with no test requirements, the checkpoint profile still demands its deliverable exist; a pending task with zero commits and no artifact is positive evidence the step closed vacuously — dispatch it."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/694",
+    "notes": "Root cause was string-matching step verification (literal 'task_4' vs prose 'Task 4') — incident class 4. Kind profiles as data replace that special-casing."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-694-tests-only-untouched-suite-auto-pass.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-694-tests-only-untouched-suite-auto-pass.json
@@ -1,0 +1,47 @@
+{
+  "name": "gh-694-tests-only-untouched-suite-auto-pass",
+  "incident": "GH-694",
+  "incidentClass": 4,
+  "taskKind": "tests-only",
+  "description": "GH-689 task 2 (tests-only): RED auto-skipped and GREEN just re-ran the pre-existing, untouched guard-codex.test.js (exit 0, 20 tests). The promised new parity describe-block was never written; the task was recorded satisfied with a byte-identical test file.",
+  "observations": {
+    "diff": {
+      "empty": true,
+      "filesChanged": [],
+      "scopeGlobs": ["plugins/work/scripts/workflows/lib/__tests__/guard-codex.test.js"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["plugins/work/scripts/workflows/lib/__tests__/guard-codex.test.js"],
+      "missing": ["plugins/work/scripts/workflows/lib/__tests__/guard-codex.test.js"]
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 20,
+      "failures": 0
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 20,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "structured",
+      "notes": "all 20 tests pre-existing; test file byte-identical to base"
+    },
+    "coverage": { "supported": true, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I1", "I2"],
+    "exit": "retry",
+    "rationale": "Tests-only's pass-on-base allowance never excuses an EMPTY diff: the kind requires the diff to touch test files, and the promised describe-block is absent. Exit-0 on an untouched suite is not delivery."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/694",
+    "notes": "Old-system record: 'RED skipped: task type tests-only does not require TDD' followed by a GREEN over pre-existing tests."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-720-parallel-wave-contamination.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-720-parallel-wave-contamination.json
@@ -1,0 +1,48 @@
+{
+  "name": "gh-720-parallel-wave-contamination",
+  "incident": "GH-720",
+  "incidentClass": 7,
+  "taskKind": "tdd-code",
+  "description": "Parallel implement wave shared one worktree and one state file: task 1's uncommitted edit broke a globally-sensitive spec, and task 4's RED probe captured task 1's test file as its own RED evidence (cross-task contamination). Viewed at task 4's boundary against task 4's OWN commits: nothing was ever done.",
+  "observations": {
+    "diff": {
+      "empty": true,
+      "filesChanged": [],
+      "scopeGlobs": ["factories/registryValidator/**"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["factories/registryValidator/registryValidator.js"],
+      "missing": ["factories/registryValidator/registryValidator.js"]
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 0,
+      "failures": 0,
+      "notes": "task 4's own test surface never existed; the recorded RED belonged to a sibling task's file"
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 0,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "structured",
+      "notes": "no derived test files in task 4's diff — there is no diff"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I1", "I3"],
+    "exit": "retry",
+    "rationale": "Per-task verification over the task's own commits is structurally immune to sibling working-tree contamination: task 4 has an empty diff and no genuine fail-on-base, so it is re-dispatched cleanly."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/720",
+    "notes": "Contaminated record: cycles[0].red.testFiles = ['factories/hookEntrypoint/__tests__/hookEntrypoint.test.js'] (task 1's file inside task 4's phase state). Scope attribution for parallel waves remains a Phase 5 item."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-721-broken-test-harness-catch22.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-721-broken-test-harness-catch22.json
@@ -1,0 +1,50 @@
+{
+  "name": "gh-721-broken-test-harness-catch22",
+  "incident": "GH-721",
+  "incidentClass": 2,
+  "taskKind": "tdd-code",
+  "description": "A RED test carried a harness bug (orphaned emit('error') -> uncaughtException): the production code was correct and the assertion passed, but the run always exited nonzero. GREEN could never record; rewinding green->red demanded green evidence (catch-22); fixing the test was blocked by phase edit-locks and ablation byte-pinning. Permanent deadlock.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": [
+        "plugins/work/scripts/workflows/lib/hooks/session-guard/store.js",
+        "plugins/work/scripts/workflows/lib/hooks/__tests__/session-guard-store.test.js"
+      ],
+      "scopeGlobs": ["plugins/work/scripts/workflows/lib/hooks/**"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["plugins/work/scripts/workflows/lib/hooks/session-guard/store.js"],
+      "missing": []
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "fail",
+      "testsRan": 1,
+      "failures": 1
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "fail",
+      "testsRan": 1,
+      "failures": 1,
+      "exitCode": 1,
+      "reporterKind": "structured",
+      "notes": "assertion passes but the process dies on an uncaughtException from the test's own monkeypatched stream"
+    },
+    "coverage": { "supported": true, "changedLineCoveragePct": 85 }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I4"],
+    "exit": "retry",
+    "rationale": "Tests do not pass on head — nonzero exit is nonzero exit even when the assertion itself passes. The retry dispatch may freely rewrite the defective test: no phase state, no pinned bytes, no evidence catch-22. A recoverable block, never a dead end."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/721",
+    "notes": "Old-system error: 'No evidence recorded for green phase. Run record-green first.' The stateless boundary check dissolves the rewind catch-22 by construction."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-722-tests-only-authors-its-test.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-722-tests-only-authors-its-test.json
@@ -1,0 +1,45 @@
+{
+  "name": "gh-722-tests-only-authors-its-test",
+  "incident": "GH-722",
+  "incidentClass": 2,
+  "taskKind": "tests-only",
+  "description": "GH-690 task 7 (tests-only): RED auto-skipped into GREEN, where the phase-edit hook blocks ALL test-file writes ('TDD GREEN phase: test files cannot be modified.') — but the sole deliverable IS a new test file. No phase existed in which authoring it was legal; the task deadlocked. This fixture captures the same task AFTER the agent works freely under the outcome model.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": ["plugins/maestro/scripts/__tests__/conductor-restart.test.js"],
+      "scopeGlobs": ["plugins/maestro/scripts/__tests__/conductor-restart.test.js"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["plugins/maestro/scripts/__tests__/conductor-restart.test.js"],
+      "missing": []
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 6,
+      "failures": 0,
+      "notes": "tests-only tasks test EXISTING behavior; passing on base is legitimate for this kind"
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 6,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "structured"
+    },
+    "coverage": { "supported": true, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "VERIFIED",
+    "rationale": "Tests-only profile: the diff touches only test files, the deliverable exists, tests pass on head with a real count; pass-on-base is exempt (I3) because the tests ARE the deliverable. The old system's deadlock was pure phase-choreography — no outcome invariant was ever at risk."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/722",
+    "notes": "Wedge-class fixture: must never block. The phase-edit hook class (work-implement-enforce) is deleted in outcome mode (plan 5.6)."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-724-completed-task-unapplied-deliverable.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-724-completed-task-unapplied-deliverable.json
@@ -1,0 +1,51 @@
+{
+  "name": "gh-724-completed-task-unapplied-deliverable",
+  "incident": "GH-724",
+  "incidentClass": 2,
+  "taskKind": "tdd-code",
+  "description": "GH-283 task 3 declared deliverable 3.1.3 (banner renumber 'Phase 2 of 7' -> 'of 8' in pr_merged_check.js) but its verifier only grepped a different assertion, so the task completed with the deliverable unapplied. Task 4's gate then failed on the stray banner in a file outside task 4's scope — an unrecoverable downstream wedge.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": [
+        "plugins/work/scripts/workflows/work-cleanup/lib/phases/completion_check.js"
+      ],
+      "scopeGlobs": ["plugins/work/scripts/workflows/work-cleanup/lib/phases/**"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": [
+        "plugins/work/scripts/workflows/work-cleanup/lib/phases/completion_check.js",
+        "plugins/work/scripts/workflows/work-cleanup/lib/phases/pr_merged_check.js"
+      ],
+      "missing": ["plugins/work/scripts/workflows/work-cleanup/lib/phases/pr_merged_check.js"]
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "fail",
+      "testsRan": 4,
+      "failures": 2
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 4,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "structured"
+    },
+    "coverage": { "supported": true, "changedLineCoveragePct": 90 }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I2"],
+    "exit": "retry",
+    "rationale": "A promised deliverable inside the task's own scope is demonstrably absent from the diff; catching it at THIS boundary (retry with guidance) prevents the downstream out-of-scope wedge entirely."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/724",
+    "notes": "Contrast with gh-727: missing deliverable INSIDE scope -> retry; outside scope -> reopen-artifact. Version-skew note in the incident: installed cache 3.68.3 vs repo 3.74.2 (Phase 5 cache-skew check)."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-725-scope-new-marker-resolution.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-725-scope-new-marker-resolution.json
@@ -1,0 +1,52 @@
+{
+  "name": "gh-725-scope-new-marker-resolution",
+  "incident": "GH-725",
+  "incidentClass": 1,
+  "taskKind": "tdd-code",
+  "description": "GH-690 task 3: the scope bullet ended in ' (NEW)'; one resolver stripped the marker, another did not, so the recorder looked for a file literally named '... .integration.test.js (NEW)', found nothing, and rejected RED forever ('no in-scope test/spec file on disk contains it()/test() blocks'). The real test file existed at the correct path.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": [
+        "plugins/heimdall/scripts/__tests__/heimdall-readstdin-reject.integration.test.js",
+        "plugins/heimdall/scripts/lib/readstdin.js"
+      ],
+      "scopeGlobs": [
+        "plugins/heimdall/scripts/__tests__/heimdall-readstdin-reject.integration.test.js (NEW)"
+      ],
+      "outOfScope": [],
+      "notes": "scope entry carries a non-path annotation the observer failed to normalize"
+    },
+    "deliverables": {
+      "promised": [
+        "plugins/heimdall/scripts/__tests__/heimdall-readstdin-reject.integration.test.js"
+      ],
+      "missing": []
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": false,
+      "outcome": "not-run",
+      "notes": "observer could not resolve the annotated scope entry to a runnable path"
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": false,
+      "outcome": "error",
+      "testsRan": 0,
+      "exitCode": 1,
+      "reporterKind": "none",
+      "notes": "Could not find '.../heimdall-readstdin-reject.integration.test.js (NEW)'"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "UNVERIFIED",
+    "flags": ["scope-resolution-failed"],
+    "rationale": "The failure is the observer's own path resolution, not the work; a mechanism failure must advance with a flag, never block (the old recorder wedged the task in RED)."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/725",
+    "notes": "A verifier that normalizes the ' (NEW)' marker itself would label this VERIFIED; the fixture pins the worst-case behavior (resolution fails -> flag, not block)."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-727-strategy-entry-outside-scope.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-727-strategy-entry-outside-scope.json
@@ -1,0 +1,53 @@
+{
+  "name": "gh-727-strategy-entry-outside-scope",
+  "incident": "GH-727",
+  "incidentClass": 3,
+  "taskKind": "tdd-code",
+  "description": "GH-313 task 3: the planner declared a Test Strategy entry file (context-monitor.integration.test.js) that was not in Files-in-scope and never existed; the GREEN command embedded it verbatim and failed forever, while protect-task-scope forbade creating the mis-named file. The agent's real test and source were correct.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": [
+        "plugins/maestro/scripts/lib/context-monitor.js",
+        "plugins/maestro/scripts/__tests__/context-monitor.test.js"
+      ],
+      "scopeGlobs": [
+        "plugins/maestro/scripts/lib/context-monitor.js",
+        "plugins/maestro/scripts/__tests__/context-monitor.test.js"
+      ],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["plugins/maestro/scripts/__tests__/context-monitor.integration.test.js"],
+      "missing": ["plugins/maestro/scripts/__tests__/context-monitor.integration.test.js"]
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "fail",
+      "testsRan": 3,
+      "failures": 3
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 3,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "structured",
+      "notes": "the agent's actual tests pass; only the plan-declared entry file is unrunnable"
+    },
+    "coverage": { "supported": true, "changedLineCoveragePct": 88 }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I2"],
+    "exit": "reopen-artifact",
+    "rationale": "The plan promises a deliverable the task's own scope forbids creating (entry not within Files-in-scope) — a planner defect only editable at the tasks step; retry can never converge."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/727",
+    "notes": "Exit-selection rule pinned here: missing deliverable OUTSIDE the task's scope globs routes to reopen-artifact; missing deliverable inside scope routes to retry (see gh-724). Under derive-tests-from-diff (plan 5.3) the declared-entry substrate disappears entirely."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-736-tasksmeta-desync-retry-storm.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-736-tasksmeta-desync-retry-storm.json
@@ -1,0 +1,47 @@
+{
+  "name": "gh-736-tasksmeta-desync-retry-storm",
+  "incident": "GH-736",
+  "incidentClass": 2,
+  "taskKind": "tdd-code",
+  "description": "Mid-fleet plugin bump regenerated tasks.md but tasksMeta was never rebuilt: the persisted pointer said task 5 was 'context-inject (done)' while tasks.md task 5 was a different task. /work looped 34+ TDD retries pulling a nonexistent test file; the hook-protected state file had no operator bypass.",
+  "observations": {
+    "diff": {
+      "empty": true,
+      "filesChanged": [],
+      "scopeGlobs": ["plugins/work/scripts/workflows/work/hooks/**"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["plugins/work/scripts/workflows/lib/__tests__/context-inject.test.js"],
+      "missing": ["plugins/work/scripts/workflows/lib/__tests__/context-inject.test.js"]
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "error",
+      "testsRan": 0,
+      "notes": "test file from the stale task pointer does not exist under the current plan"
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "error",
+      "testsRan": 0,
+      "failures": 0,
+      "exitCode": 1,
+      "reporterKind": "none",
+      "notes": "could-not-find errors; retry counter climbing with no diff delta (34+ identical retries)"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I2"],
+    "exit": "reopen-artifact",
+    "rationale": "The task-as-recorded references a deliverable that cannot exist under the current plan (missing deliverable outside any resolvable scope); retrying the same dispatch can never succeed — plan state must be reconciled."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/736",
+    "notes": "Version skew 3.69->3.74; recovery required a hand edit (.bak-preresync). GH-753's resync-meta is the escalate-adjacent recovery for this class; the verifier routes it to reopen-artifact instead of infinite retry."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-737-full-suite-string-scrape-misfire.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-737-full-suite-string-scrape-misfire.json
@@ -1,0 +1,47 @@
+{
+  "name": "gh-737-full-suite-string-scrape-misfire",
+  "incident": "GH-737",
+  "incidentClass": 1,
+  "taskKind": "tdd-code",
+  "description": "run-tests.sh ignored its positional file arg so 'pnpm test <entry>' ran the whole suite; a sibling test's TITLE contained the literal string MODULE_NOT_FOUND and the stdout-scraping load-failure guard rejected a genuine assertion-only RED as structurally broken. The agent's work was correct throughout.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": [
+        "plugins/work/scripts/workflows/work-implement/__tests__/strategy-custom.test.js"
+      ],
+      "scopeGlobs": ["plugins/work/scripts/workflows/work-implement/**"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": [
+        "plugins/work/scripts/workflows/work-implement/__tests__/strategy-custom.test.js"
+      ],
+      "missing": []
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "fail",
+      "notes": "whole-suite run; entry-scoped signal drowned in prose output"
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "exitCode": 0,
+      "reporterKind": "exit-code-only",
+      "notes": "runner not scoped to the entry file; test count unavailable; stdout contains a passing test title with the literal string MODULE_NOT_FOUND"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "UNVERIFIED",
+    "flags": ["no-structured-reporter"],
+    "rationale": "The work is fine; the only defect is observational (unscoped run, prose scraping). Absence of clean scoped evidence must advance with a flag, never block — the old gate wedged here."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/737",
+    "notes": "With a structured JSON reporter this same boundary is VERIFIED (fail-on-base, pass-on-head, count>0). Fixture pins the UNVERIFIED-not-CONTRADICTED behavior for stdout-scrape ambiguity."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-749-no-test-files-exit0-false-green.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-749-no-test-files-exit0-false-green.json
@@ -1,0 +1,47 @@
+{
+  "name": "gh-749-no-test-files-exit0-false-green",
+  "incident": "GH-749",
+  "incidentClass": 1,
+  "taskKind": "tdd-code",
+  "description": "FUT-105: pre-implement probe captured a contaminated RED (sibling task's failure, empty testFiles); after the sibling was fixed, the post-test targeted never-authored test files and vitest printed 'No test files found, exiting with code 0' — exit 0 recorded as GREEN. Tasks 3, 4 and 6 auto-completed with zero code on disk.",
+  "observations": {
+    "diff": {
+      "empty": true,
+      "filesChanged": [],
+      "scopeGlobs": ["apps/web/lib/mcp/oauth/**"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["apps/web/lib/mcp/oauth/jwt.ts", "apps/web/lib/mcp/oauth/jwt.test.ts"],
+      "missing": ["apps/web/lib/mcp/oauth/jwt.ts", "apps/web/lib/mcp/oauth/jwt.test.ts"]
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 0,
+      "failures": 0
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 0,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "exit-code-only",
+      "notes": "No test files found, exiting with code 0"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "CONTRADICTED",
+    "violatedInvariants": ["I1", "I2", "I4"],
+    "exit": "retry",
+    "rationale": "Empty diff, missing promised deliverables and 0 tests ran for a test-requiring kind — positive evidence of a vacuous pass, regardless of exit code 0."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/749",
+    "notes": "RED record had testExitCode 1 with empty outputTail and empty testFiles (contamination). The catastrophic false-GREEN fixture; the structured-count>0 invariant (I4) exists for this case."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/index.js
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/index.js
@@ -114,6 +114,11 @@ function validateRun(errors, run, label) {
   );
   pushIf(
     errors,
+    run.failures !== undefined && !Number.isInteger(run.failures),
+    `${label}.failures must be an integer when present`
+  );
+  pushIf(
+    errors,
     run.exitCode !== undefined && run.exitCode !== null && !Number.isInteger(run.exitCode),
     `${label}.exitCode must be an integer or null when present`
   );
@@ -252,8 +257,9 @@ function loadFixtureFile(dir, file, fixtures, errors) {
     errors.push(`${file}: ${problem}`);
   }
   const stem = file.replace(/\.json$/, '');
-  if (parsed && parsed.name !== stem) {
-    errors.push(`${file}: fixture.name "${parsed && parsed.name}" must equal filename stem`);
+  const parsedName = parsed && typeof parsed === 'object' ? parsed.name : null;
+  if (parsedName !== stem) {
+    errors.push(`${file}: fixture.name "${parsedName}" must equal filename stem`);
   }
   fixtures.push(parsed);
 }

--- a/plugins/work/scripts/workflows/lib/replay-corpus/index.js
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/index.js
@@ -1,0 +1,300 @@
+'use strict';
+
+/**
+ * replay-corpus — historical implement-phase incidents encoded as fixtures
+ * (GH-751, outcome-verification Phase 0; plan §6 Phase 0).
+ *
+ * Each fixture captures one incident at the OBSERVATION layer: what a
+ * task-boundary verifier would have seen (diff summary, deliverables,
+ * base/head runner outcomes, coverage), plus the CORRECT verdict under the
+ * outcome model. The corpus is the verifier's own regression suite: every
+ * historical false-GREEN must map to CONTRADICTED and every historical wedge
+ * must map to VERIFIED/UNVERIFIED (never a dead-end block). A rule change
+ * that regresses a fixture in either direction does not ship (GH-755).
+ *
+ * Fixture shape (validated by validateFixture):
+ *   {
+ *     name,                 // kebab-case, must equal the filename stem
+ *     incident,             // "GH-<n>" source issue
+ *     incidentClass,        // 1..7 per plan §2 table
+ *     taskKind,             // planner kind vocabulary (outcome-verdicts.js)
+ *     description,          // what mechanically happened
+ *     observations: { diff, deliverables, baseRun, headRun, coverage },
+ *     expected: { verdict, violatedInvariants?, flags?, exit?, rationale },
+ *     provenance: { issue, notes? }
+ *   }
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  VERDICTS,
+  VERDICT_VALUES,
+  EXIT_VALUES,
+  INVARIANT_VALUES,
+  FLAG_KIND_VALUES,
+  TASK_KINDS,
+} = require('../outcome-verdicts');
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+/** Legal `outcome` values for base/head runner observations. */
+const RUN_OUTCOMES = Object.freeze([
+  'pass',
+  'fail',
+  'load-failure',
+  'hang',
+  'error',
+  'skipped',
+  'not-run',
+]);
+
+/** How the head run's test count was obtained. */
+const REPORTER_KINDS = Object.freeze(['structured', 'exit-code-only', 'none']);
+
+const INCIDENT_RE = /^GH-\d+$/;
+const NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function isStringArray(value) {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string');
+}
+
+function pushIf(errors, condition, message) {
+  if (condition) errors.push(message);
+}
+
+function requireString(errors, obj, key, label) {
+  pushIf(
+    errors,
+    !obj || typeof obj[key] !== 'string' || obj[key].length === 0,
+    `${label}.${key} must be a non-empty string`
+  );
+}
+
+function requireStringArray(errors, obj, key, label) {
+  pushIf(errors, !obj || !isStringArray(obj[key]), `${label}.${key} must be a string array`);
+}
+
+function requireEnum(errors, value, allowed, label) {
+  pushIf(errors, !allowed.includes(value), `${label} must be one of: ${allowed.join(', ')}`);
+}
+
+function validateDiff(errors, diff) {
+  if (!diff || typeof diff !== 'object') {
+    errors.push('observations.diff must be an object');
+    return;
+  }
+  pushIf(errors, typeof diff.empty !== 'boolean', 'observations.diff.empty must be a boolean');
+  requireStringArray(errors, diff, 'filesChanged', 'observations.diff');
+  requireStringArray(errors, diff, 'scopeGlobs', 'observations.diff');
+  requireStringArray(errors, diff, 'outOfScope', 'observations.diff');
+}
+
+function validateDeliverables(errors, deliverables) {
+  if (!deliverables || typeof deliverables !== 'object') {
+    errors.push('observations.deliverables must be an object');
+    return;
+  }
+  requireStringArray(errors, deliverables, 'promised', 'observations.deliverables');
+  requireStringArray(errors, deliverables, 'missing', 'observations.deliverables');
+}
+
+function validateRun(errors, run, label) {
+  if (!run || typeof run !== 'object') {
+    errors.push(`${label} must be an object`);
+    return;
+  }
+  pushIf(errors, typeof run.attempted !== 'boolean', `${label}.attempted must be a boolean`);
+  pushIf(errors, typeof run.supported !== 'boolean', `${label}.supported must be a boolean`);
+  requireEnum(errors, run.outcome, RUN_OUTCOMES, `${label}.outcome`);
+  pushIf(
+    errors,
+    run.testsRan !== undefined && !Number.isInteger(run.testsRan),
+    `${label}.testsRan must be an integer when present`
+  );
+  pushIf(
+    errors,
+    run.exitCode !== undefined && run.exitCode !== null && !Number.isInteger(run.exitCode),
+    `${label}.exitCode must be an integer or null when present`
+  );
+}
+
+function validateHeadRun(errors, run) {
+  validateRun(errors, run, 'observations.headRun');
+  if (run && typeof run === 'object') {
+    requireEnum(errors, run.reporterKind, REPORTER_KINDS, 'observations.headRun.reporterKind');
+  }
+}
+
+function validateCoverage(errors, coverage) {
+  if (!coverage || typeof coverage !== 'object') {
+    errors.push('observations.coverage must be an object');
+    return;
+  }
+  pushIf(
+    errors,
+    typeof coverage.supported !== 'boolean',
+    'observations.coverage.supported must be a boolean'
+  );
+  const pct = coverage.changedLineCoveragePct;
+  pushIf(
+    errors,
+    !(pct === null || (typeof pct === 'number' && pct >= 0 && pct <= 100)),
+    'observations.coverage.changedLineCoveragePct must be null or a number in [0,100]'
+  );
+}
+
+function validateExpected(errors, expected) {
+  if (!expected || typeof expected !== 'object') {
+    errors.push('expected must be an object');
+    return;
+  }
+  requireEnum(errors, expected.verdict, VERDICT_VALUES, 'expected.verdict');
+  requireString(errors, expected, 'rationale', 'expected');
+
+  const invariants = expected.violatedInvariants || [];
+  const flags = expected.flags || [];
+  pushIf(
+    errors,
+    !isStringArray(invariants) || invariants.some((i) => !INVARIANT_VALUES.includes(i)),
+    `expected.violatedInvariants entries must be among: ${INVARIANT_VALUES.join(', ')}`
+  );
+  pushIf(
+    errors,
+    !isStringArray(flags) || flags.some((f) => !FLAG_KIND_VALUES.includes(f)),
+    `expected.flags entries must be among: ${FLAG_KIND_VALUES.join(', ')}`
+  );
+
+  if (expected.verdict === VERDICTS.contradicted) {
+    requireEnum(errors, expected.exit, EXIT_VALUES, 'expected.exit (required for CONTRADICTED)');
+    pushIf(
+      errors,
+      invariants.length === 0,
+      'expected.violatedInvariants must be non-empty for CONTRADICTED'
+    );
+  } else {
+    pushIf(errors, expected.exit !== undefined, 'expected.exit is only legal for CONTRADICTED');
+  }
+  if (expected.verdict === VERDICTS.unverified) {
+    pushIf(errors, flags.length === 0, 'expected.flags must be non-empty for UNVERIFIED');
+  }
+}
+
+/** Validate the top-level identity fields (name/incident/class/kind/description). */
+function validateIdentity(errors, fixture) {
+  requireString(errors, fixture, 'name', 'fixture');
+  pushIf(
+    errors,
+    typeof fixture.name === 'string' && !NAME_RE.test(fixture.name),
+    'fixture.name must be kebab-case'
+  );
+  pushIf(
+    errors,
+    typeof fixture.incident !== 'string' || !INCIDENT_RE.test(fixture.incident),
+    'fixture.incident must match GH-<number>'
+  );
+  pushIf(
+    errors,
+    !Number.isInteger(fixture.incidentClass) ||
+      fixture.incidentClass < 1 ||
+      fixture.incidentClass > 7,
+    'fixture.incidentClass must be an integer 1..7'
+  );
+  requireEnum(errors, fixture.taskKind, TASK_KINDS, 'fixture.taskKind');
+  requireString(errors, fixture, 'description', 'fixture');
+}
+
+/** Validate the observations block (diff/deliverables/runs/coverage). */
+function validateObservations(errors, obs) {
+  if (!obs || typeof obs !== 'object') {
+    errors.push('observations must be an object');
+    return;
+  }
+  validateDiff(errors, obs.diff);
+  validateDeliverables(errors, obs.deliverables);
+  validateRun(errors, obs.baseRun, 'observations.baseRun');
+  validateHeadRun(errors, obs.headRun);
+  validateCoverage(errors, obs.coverage);
+}
+
+/**
+ * Validate one fixture object. Returns an array of human-readable problems
+ * (empty = valid).
+ */
+function validateFixture(fixture) {
+  const errors = [];
+  if (!fixture || typeof fixture !== 'object' || Array.isArray(fixture)) {
+    return ['fixture must be a JSON object'];
+  }
+  validateIdentity(errors, fixture);
+  validateObservations(errors, fixture.observations);
+  validateExpected(errors, fixture.expected);
+
+  const prov = fixture.provenance;
+  pushIf(
+    errors,
+    !prov || typeof prov !== 'object' || typeof prov.issue !== 'string' || prov.issue.length === 0,
+    'provenance.issue must be a non-empty string'
+  );
+  return errors;
+}
+
+/** Parse + validate one fixture file into the accumulators. */
+function loadFixtureFile(dir, file, fixtures, errors) {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+  } catch (err) {
+    errors.push(`${file}: unparseable JSON (${err.message})`);
+    return;
+  }
+  for (const problem of validateFixture(parsed)) {
+    errors.push(`${file}: ${problem}`);
+  }
+  const stem = file.replace(/\.json$/, '');
+  if (parsed && parsed.name !== stem) {
+    errors.push(`${file}: fixture.name "${parsed && parsed.name}" must equal filename stem`);
+  }
+  fixtures.push(parsed);
+}
+
+/**
+ * Load and validate every fixture in the corpus.
+ * @returns {{ fixtures: object[], errors: string[] }} fixtures that parsed
+ *   (valid or not) plus `<file>: <problem>` strings; callers decide severity.
+ */
+function loadCorpus(options = {}) {
+  const dir = options.fixturesDir || FIXTURES_DIR;
+  const fixtures = [];
+  const errors = [];
+
+  let files;
+  try {
+    files = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.json'))
+      .sort();
+  } catch (err) {
+    return { fixtures, errors: [`cannot read fixtures dir ${dir}: ${err.message}`] };
+  }
+
+  for (const file of files) {
+    loadFixtureFile(dir, file, fixtures, errors);
+  }
+
+  const names = fixtures.map((f) => f && f.name);
+  const dupes = names.filter((n, i) => n && names.indexOf(n) !== i);
+  for (const dupe of [...new Set(dupes)]) {
+    errors.push(`duplicate fixture name: ${dupe}`);
+  }
+
+  return { fixtures, errors };
+}
+
+module.exports = {
+  FIXTURES_DIR,
+  RUN_OUTCOMES,
+  REPORTER_KINDS,
+  validateFixture,
+  loadCorpus,
+};

--- a/plugins/work/scripts/workflows/lib/scripts/sli/__tests__/sli-report.test.js
+++ b/plugins/work/scripts/workflows/lib/scripts/sli/__tests__/sli-report.test.js
@@ -1,0 +1,264 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { main, aggregate } = require('../sli-report');
+const { analyzeTicket, DEFAULT_WEDGE_THRESHOLD } = require('../scan');
+
+let BASE;
+
+beforeEach(() => {
+  BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'sli-report-test-'));
+});
+afterEach(() => {
+  fs.rmSync(BASE, { recursive: true, force: true });
+});
+
+function makeTicket(name, { actions, state }) {
+  const dir = path.join(BASE, name);
+  fs.mkdirSync(dir, { recursive: true });
+  if (actions !== undefined) {
+    const payload = typeof actions === 'string' ? actions : JSON.stringify(actions);
+    fs.writeFileSync(path.join(dir, '.work-actions.json'), payload);
+  }
+  if (state !== undefined) {
+    const payload = typeof state === 'string' ? state : JSON.stringify(state);
+    fs.writeFileSync(path.join(dir, '.work-state.json'), payload);
+  }
+  return dir;
+}
+
+function sink() {
+  return {
+    buf: '',
+    write(s) {
+      this.buf += s;
+    },
+  };
+}
+
+function run(argv, env = {}) {
+  const stdout = sink();
+  const stderr = sink();
+  const code = main(argv, { TASKS_BASE: BASE, ...env }, stdout, stderr);
+  return { code, out: stdout.buf, err: stderr.buf };
+}
+
+const T0 = '2026-07-01T10:00:00.000Z';
+const T10 = '2026-07-01T10:10:00.000Z';
+const T20 = '2026-07-01T10:20:00.000Z';
+
+function tasksMeta(statuses, currentTaskIndex = 0, fixRounds = {}) {
+  return {
+    tasks: statuses.map((status, i) => ({
+      id: `task_${i + 1}`,
+      status,
+      taskReviewFixRounds: fixRounds[i + 1] || 0,
+    })),
+    currentTaskIndex,
+    totalTasks: statuses.length,
+  };
+}
+
+describe('sli-report — wedge proxies', () => {
+  it('W1: state retries + gate rejections use max() and respect the threshold', () => {
+    makeTicket('TEST-W1', {
+      actions: [
+        { step: 'implement', timestamp: T0, what: 'step started' },
+        {
+          kind: 'enforcement',
+          timestamp: T0,
+          origin: 'workflow',
+          task: 2,
+          phase: 'green',
+          action: 'tdd-green-empty-rejected',
+          allow: false,
+          reason: 'empty-output-exit-0',
+        },
+        {
+          kind: 'enforcement',
+          timestamp: T10,
+          origin: 'workflow',
+          task: 2,
+          phase: 'green',
+          action: 'tdd-green-empty-rejected',
+          allow: false,
+          reason: 'empty-output-exit-0',
+        },
+        { step: 'implement', timestamp: T10, what: 'step completed' },
+        { kind: 'usage', timestamp: T10, step: 'implement', agentType: 'x', totalTokens: 1 },
+      ],
+      state: {
+        tasksMeta: tasksMeta(['completed', 'in_progress', 'pending'], 1),
+        _tddRetryCount: 5,
+        _tddRetryTask: 2,
+      },
+    });
+    const r = analyzeTicket(BASE, 'TEST-W1', { wedgeThreshold: DEFAULT_WEDGE_THRESHOLD });
+    assert.equal(r.knownTasks, 3);
+    // max(gateRejections=2, stateRetries=5) = 5 > 3 → wedged
+    assert.deepEqual(r.wedgedTasks, [2]);
+    assert.equal(r.retriesTotal, 5);
+    assert.equal(r.timeInImplementMs, 10 * 60 * 1000);
+    assert.equal(r.dispatches.implement, 1);
+  });
+
+  it('W2: an escalation row wedges the named task', () => {
+    makeTicket('TEST-W2', {
+      actions: [
+        {
+          step: 'task_review',
+          timestamp: T0,
+          what: 'task 2/3 fix rounds exhausted (3/3) -- escalating',
+        },
+      ],
+      state: { tasksMeta: tasksMeta(['completed', 'in_progress', 'pending'], 1) },
+    });
+    const r = analyzeTicket(BASE, 'TEST-W2', { wedgeThreshold: DEFAULT_WEDGE_THRESHOLD });
+    assert.deepEqual(r.wedgedTasks, [2]);
+  });
+
+  it('W3: recovery enforcement rows wedge; unattributed ones attach to the current task', () => {
+    makeTicket('TEST-W3', {
+      actions: [
+        {
+          kind: 'enforcement',
+          timestamp: T0,
+          origin: 'user',
+          task: null,
+          phase: null,
+          action: 'recover-reopen-task',
+          allow: true,
+          reason: 'operator recovery',
+        },
+      ],
+      state: { tasksMeta: tasksMeta(['completed', 'in_progress'], 1) },
+    });
+    const r = analyzeTicket(BASE, 'TEST-W3', { wedgeThreshold: DEFAULT_WEDGE_THRESHOLD });
+    assert.deepEqual(r.wedgedTasks, [2]);
+    assert.equal(r.unattributedRecoveries, 0);
+  });
+
+  it('W4: a parked planner hold wedges the retry task', () => {
+    makeTicket('TEST-W4', {
+      actions: [],
+      state: {
+        tasksMeta: tasksMeta(['in_progress'], 0),
+        _tddRetryTask: 1,
+        _tddRetryPlannerDefect: true,
+      },
+    });
+    const r = analyzeTicket(BASE, 'TEST-W4', { wedgeThreshold: DEFAULT_WEDGE_THRESHOLD });
+    assert.deepEqual(r.wedgedTasks, [1]);
+  });
+});
+
+describe('sli-report — escape proxies', () => {
+  it('E1+E2: review-failure rows attribute to the nearest preceding scheduled task', () => {
+    makeTicket('TEST-E1', {
+      actions: [
+        { step: 'task_review', timestamp: T0, what: 'task 1/2 review scheduled for "a"' },
+        { step: 'task_review', timestamp: T10, what: 'task review failed: assertions too weak' },
+        { step: 'task_review', timestamp: T20, what: 'task review passed (tests + code)' },
+      ],
+      state: { tasksMeta: tasksMeta(['completed', 'pending'], 1) },
+    });
+    const r = analyzeTicket(BASE, 'TEST-E1', { wedgeThreshold: DEFAULT_WEDGE_THRESHOLD });
+    assert.deepEqual(r.escapedTasks, [1]);
+    assert.deepEqual(r.advancedTasks, [1]);
+    assert.equal(r.escapeRate, 1);
+  });
+
+  it('E2: taskReviewFixRounds > 0 marks a completed task escaped', () => {
+    makeTicket('TEST-E2', {
+      actions: [],
+      state: { tasksMeta: tasksMeta(['completed'], 0, { 1: 2 }) },
+    });
+    const r = analyzeTicket(BASE, 'TEST-E2', { wedgeThreshold: DEFAULT_WEDGE_THRESHOLD });
+    assert.deepEqual(r.escapedTasks, [1]);
+  });
+
+  it('E3: implement re-entries count at ticket level and mark escape tickets', () => {
+    makeTicket('TEST-E3', {
+      actions: [
+        { step: 'implement', timestamp: T0, what: 'step started' },
+        { step: 'implement', timestamp: T10, what: 'step completed' },
+        { step: 'implement', timestamp: T20, what: 'step started' },
+      ],
+      state: { tasksMeta: tasksMeta(['completed'], 0) },
+    });
+    const r = analyzeTicket(BASE, 'TEST-E3', { wedgeThreshold: DEFAULT_WEDGE_THRESHOLD });
+    assert.equal(r.implementReentries, 1);
+    const agg = aggregate([r]);
+    assert.equal(agg.ticketsWithEscape, 1);
+    assert.equal(agg.implementReentriesTotal, 1);
+  });
+});
+
+describe('sli-report — robustness and CLI', () => {
+  it('malformed inputs degrade to warnings, exit 0', () => {
+    makeTicket('TEST-BAD', { actions: '{nope', state: '[]' });
+    const { code, out, err } = run([]);
+    assert.equal(code, 0);
+    assert.match(err, /TEST-BAD: malformed \.work-actions\.json/);
+    assert.match(err, /TEST-BAD: \.work-state\.json is not a JSON object/);
+    assert.match(out, /no analyzable tickets/);
+  });
+
+  it('empty dirs are skipped with a warning', () => {
+    fs.mkdirSync(path.join(BASE, 'TEST-EMPTY'));
+    const { code, err } = run([]);
+    assert.equal(code, 0);
+    assert.match(err, /TEST-EMPTY: no \.work-actions\.json or \.work-state\.json — skipped/);
+  });
+
+  it('--json emits a parseable document with aggregate SLIs', () => {
+    makeTicket('TEST-J', {
+      actions: [],
+      state: { tasksMeta: tasksMeta(['completed', 'pending'], 1, { 1: 1 }) },
+    });
+    const { code, out } = run(['--json']);
+    assert.equal(code, 0);
+    const doc = JSON.parse(out);
+    assert.equal(doc.aggregate.tickets, 1);
+    assert.equal(doc.aggregate.tasksEscaped, 1);
+    assert.equal(doc.wedgeThreshold, DEFAULT_WEDGE_THRESHOLD);
+  });
+
+  it('positional tickets restrict the report; table renders', () => {
+    makeTicket('TEST-A', { actions: [], state: { tasksMeta: tasksMeta(['completed'], 0) } });
+    makeTicket('TEST-B', { actions: [], state: { tasksMeta: tasksMeta(['completed'], 0) } });
+    const { code, out } = run(['TEST-A']);
+    assert.equal(code, 0);
+    assert.match(out, /TEST-A/);
+    assert.doesNotMatch(out, /TEST-B/);
+    assert.match(out, /aggregate: 1 ticket\(s\)/);
+  });
+
+  it('--wedge-threshold 0 makes a single retry a wedge', () => {
+    makeTicket('TEST-T0', {
+      actions: [],
+      state: { tasksMeta: tasksMeta(['in_progress'], 0), _tddRetryCount: 1, _tddRetryTask: 1 },
+    });
+    const { code, out } = run(['--wedge-threshold', '0', 'TEST-T0']);
+    assert.equal(code, 0);
+    assert.match(out, /wedge rate 100\.0%/);
+  });
+
+  it('flag errors and missing base exit 1; --help exits 0 with heuristics', () => {
+    assert.equal(run(['--bogus']).code, 1);
+    assert.equal(run(['--wedge-threshold', '-1']).code, 1);
+    assert.equal(run(['--tasks-base']).code, 1);
+    const noBase = main([], {}, sink(), sink());
+    assert.equal(noBase, 1);
+    const help = run(['--help']);
+    assert.equal(help.code, 0);
+    assert.match(help.out, /Measurement heuristics/);
+    const missingDir = run(['--tasks-base', path.join(BASE, 'absent')]);
+    assert.equal(missingDir.code, 1);
+  });
+});

--- a/plugins/work/scripts/workflows/lib/scripts/sli/scan.js
+++ b/plugins/work/scripts/workflows/lib/scripts/sli/scan.js
@@ -1,0 +1,372 @@
+'use strict';
+
+/**
+ * scan.js — per-ticket SLI analysis for sli-report.js (GH-751, Phase 0).
+ *
+ * Folds a ticket dir's `.work-actions.json` (append-only audit trail; legacy /
+ * enforcement / usage row shapes coexist) and `.work-state.json` (tasksMeta,
+ * `_tddRetry*` gate-retry fields) into per-task wedge/escape verdicts and
+ * ticket-level counters. Every SLI is a documented PROXY over what the trail
+ * actually records — see HELP in sli-report.js for the full heuristics list
+ * (W1–W4 wedge, E1–E3 escape, D1–D2 dispatch, T1 time-in-implement).
+ *
+ * Contract: read-only; never throws on per-ticket data — malformed inputs
+ * degrade to warnings.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ACTIONS_FILE = '.work-actions.json';
+const STATE_FILE = '.work-state.json';
+const DEFAULT_WEDGE_THRESHOLD = 3;
+
+const REVIEW_SCHEDULED_RE = /^task (\d+)\/(\d+) review scheduled\b/;
+const REVIEW_FAILED_RE = /^task review failed\b/;
+const REVIEW_PASSED_RE = /^task review passed\b/;
+const ESCALATED_RE = /^task (\d+)\/(\d+) fix rounds exhausted\b/;
+const RECOVERY_WHAT_RE = /\brecover(?:y|ed|ing)?\b|\bsurgery\b/i;
+const RECOVERY_TYPE_RE = /recover|surgery/i;
+const RECOVERY_ACTION_RE = /recover/i;
+const GATE_REJECTION_ACTION_RE = /^tdd-/;
+
+/**
+ * Read + parse a JSON file. Never throws.
+ * @returns {{ ok: true, data: * } | { ok: false, reason: 'missing'|'malformed' }}
+ */
+function readJsonFile(filePath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return { ok: false, reason: 'missing' };
+  }
+  try {
+    return { ok: true, data: JSON.parse(raw) };
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+}
+
+/** List direct-child ticket dir names under the base. Never throws. */
+function listTicketDirs(tasksBase) {
+  let dirents;
+  try {
+    dirents = fs.readdirSync(tasksBase, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  return dirents
+    .filter((d) => d.isDirectory() || d.isSymbolicLink())
+    .map((d) => d.name)
+    .filter((name) => !name.includes('/') && !name.includes('..'))
+    .sort();
+}
+
+/** Timestamp → epoch ms, or null when unparseable. */
+function ts(row) {
+  const value = Date.parse(row && row.timestamp);
+  return Number.isFinite(value) ? value : null;
+}
+
+/** Lazily create the per-task accumulator bucket. */
+function taskBucket(perTask, taskNum) {
+  if (!perTask.has(taskNum)) {
+    perTask.set(taskNum, {
+      task: taskNum,
+      gateRejections: 0,
+      fixRounds: 0,
+      stateRetries: 0,
+      reviewFailures: 0,
+      reviewPasses: 0,
+      orchestratorPasses: 0,
+      escalations: 0,
+      recoveries: 0,
+      plannerHold: false,
+      completed: false,
+      advanced: false,
+      retries: 0,
+      wedged: false,
+      escaped: false,
+    });
+  }
+  return perTask.get(taskNum);
+}
+
+/** Is this legacy/enforcement row an operator recovery/surgery event (W3)? */
+function isRecoveryRow(row) {
+  if (row.kind === 'enforcement') {
+    return RECOVERY_ACTION_RE.test(String(row.action || ''));
+  }
+  if (row.kind) return false; // usage rows never are
+  const what = String(row.what || '');
+  const metaType = row.meta && row.meta.type ? String(row.meta.type) : '';
+  return RECOVERY_WHAT_RE.test(what) || RECOVERY_TYPE_RE.test(metaType);
+}
+
+/** Fold one enforcement row into the accumulators. */
+function scanEnforcementRow(row, perTask, signals) {
+  if (row.allow === false && GATE_REJECTION_ACTION_RE.test(String(row.action || ''))) {
+    const taskNum = Number.parseInt(row.task, 10);
+    if (Number.isInteger(taskNum) && taskNum > 0) taskBucket(perTask, taskNum).gateRejections++;
+  }
+  if (isRecoveryRow(row)) {
+    const taskNum = Number.parseInt(row.task, 10);
+    if (Number.isInteger(taskNum) && taskNum > 0) taskBucket(perTask, taskNum).recoveries++;
+    else signals.unattributedRecoveries++;
+  }
+}
+
+/** Fold one implement-step legacy row into the T1/re-entry counters. */
+function scanImplementRow(what, t, signals, timing) {
+  if (what === 'step started') {
+    signals.implementStarts++;
+    if (t !== null) timing.openedAt = t;
+  } else if (what === 'step completed') {
+    if (timing.openedAt !== null && t !== null && t >= timing.openedAt) {
+      signals.timeInImplementMs += t - timing.openedAt;
+    }
+    timing.openedAt = null;
+  } else if (what === 'step reset') {
+    signals.implementStepResets++;
+  } else if (what.startsWith('BLOCKED:')) {
+    signals.implementBlocks++;
+  }
+}
+
+/**
+ * Fold review/escalation signals from a legacy row's `what` text.
+ * @returns {{ handled: boolean, task: number|null }} updated attribution task.
+ */
+function scanReviewSignals(what, perTask, signals, lastScheduledTask) {
+  let match = what.match(REVIEW_SCHEDULED_RE);
+  if (match) {
+    const taskNum = Number.parseInt(match[1], 10);
+    taskBucket(perTask, taskNum).orchestratorPasses++;
+    return { handled: true, task: taskNum };
+  }
+  match = what.match(ESCALATED_RE);
+  if (match) {
+    taskBucket(perTask, Number.parseInt(match[1], 10)).escalations++;
+    return { handled: true, task: lastScheduledTask };
+  }
+  if (REVIEW_FAILED_RE.test(what)) {
+    if (lastScheduledTask !== null) taskBucket(perTask, lastScheduledTask).reviewFailures++;
+    else signals.unattributedReviewFailures++;
+    return { handled: true, task: lastScheduledTask };
+  }
+  if (REVIEW_PASSED_RE.test(what)) {
+    if (lastScheduledTask !== null) taskBucket(perTask, lastScheduledTask).reviewPasses++;
+    return { handled: true, task: lastScheduledTask };
+  }
+  return { handled: false, task: lastScheduledTask };
+}
+
+/** Fold one legacy row into the accumulators. Returns the new lastScheduledTask. */
+function scanLegacyRow(row, perTask, signals, timing, lastScheduledTask) {
+  const t = ts(row);
+  if (t !== null) timing.lastLegacyTs = t;
+  const what = String(row.what || '');
+
+  if (row.step === 'implement') scanImplementRow(what, t, signals, timing);
+
+  const review = scanReviewSignals(what, perTask, signals, lastScheduledTask);
+  if (review.handled) return review.task;
+
+  if (isRecoveryRow(row)) {
+    const metaTask = row.meta ? Number.parseInt(row.meta.task, 10) : Number.NaN;
+    if (Number.isInteger(metaTask) && metaTask > 0) taskBucket(perTask, metaTask).recoveries++;
+    else signals.unattributedRecoveries++;
+  }
+  return review.task;
+}
+
+/** Fold the actions trail into per-task + ticket-level signals. */
+function scanActions(rows, perTask) {
+  const signals = {
+    usageDispatches: 0,
+    implementDispatches: 0,
+    implementStarts: 0,
+    implementStepResets: 0,
+    implementBlocks: 0,
+    unattributedRecoveries: 0,
+    unattributedReviewFailures: 0,
+    timeInImplementMs: 0,
+    implementReentries: 0,
+  };
+
+  // Chronological order: the trail is append-only, but sort defensively so
+  // review-failure attribution (nearest preceding scheduled row) is stable.
+  const ordered = rows
+    .map((row, i) => ({ row, i, t: ts(row) }))
+    .sort((a, b) => (a.t ?? 0) - (b.t ?? 0) || a.i - b.i)
+    .map((e) => e.row);
+
+  const timing = { openedAt: null, lastLegacyTs: null };
+  let lastScheduledTask = null;
+
+  for (const row of ordered) {
+    if (row.kind === 'usage') {
+      signals.usageDispatches++;
+      if (row.step === 'implement') signals.implementDispatches++;
+      continue;
+    }
+    if (row.kind === 'enforcement') {
+      scanEnforcementRow(row, perTask, signals);
+      continue;
+    }
+    if (row.kind) continue; // unknown future kind — ignore
+    lastScheduledTask = scanLegacyRow(row, perTask, signals, timing, lastScheduledTask);
+  }
+
+  // T1: dangling implement start closes at the last legacy timestamp.
+  if (timing.openedAt !== null && timing.lastLegacyTs !== null) {
+    if (timing.lastLegacyTs > timing.openedAt) {
+      signals.timeInImplementMs += timing.lastLegacyTs - timing.openedAt;
+    }
+  }
+  // E3: every implement re-entry after the first is a downstream step
+  // (check / task_review / follow_up) sending the workflow back.
+  signals.implementReentries = Math.max(0, signals.implementStarts - 1);
+  return signals;
+}
+
+/** Fold `_tddRetry*` gate-retry fields into the task buckets (W1/W4). */
+function scanRetryState(state, perTask) {
+  const retryTask = Number.parseInt(state._tddRetryTask, 10);
+  if (!Number.isInteger(retryTask) || retryTask <= 0) return;
+  const retryCount = Number.parseInt(state._tddRetryCount, 10) || 0;
+  if (retryCount > 0) taskBucket(perTask, retryTask).stateRetries = retryCount;
+  if (state._tddRetryPlannerDefect) taskBucket(perTask, retryTask).plannerHold = true;
+}
+
+/** Fold `.work-state.json` into per-task + ticket-level signals. */
+function scanState(state, perTask) {
+  const signals = { currentTask: null, knownTasks: 0 };
+  if (!state || typeof state !== 'object') return signals;
+
+  const meta = state.tasksMeta;
+  const tasks = meta && Array.isArray(meta.tasks) ? meta.tasks : [];
+  signals.knownTasks = tasks.length;
+  if (meta && Number.isInteger(meta.currentTaskIndex)) {
+    signals.currentTask = meta.currentTaskIndex + 1;
+  }
+
+  tasks.forEach((task, idx) => {
+    const bucket = taskBucket(perTask, idx + 1);
+    bucket.fixRounds = Number.parseInt(task && task.taskReviewFixRounds, 10) || 0;
+    if (task && task.status === 'completed') bucket.completed = true;
+  });
+
+  scanRetryState(state, perTask);
+  return signals;
+}
+
+/** Read + shape the two per-ticket inputs, collecting warnings. */
+function readTicketInputs(dir, ticket, warnings) {
+  const actionsRead = readJsonFile(path.join(dir, ACTIONS_FILE));
+  const stateRead = readJsonFile(path.join(dir, STATE_FILE));
+
+  let actions = [];
+  if (actionsRead.ok) {
+    if (Array.isArray(actionsRead.data)) actions = actionsRead.data;
+    else warnings.push(`${ticket}: ${ACTIONS_FILE} is not a JSON array — ignored`);
+  } else if (actionsRead.reason === 'malformed') {
+    warnings.push(`${ticket}: malformed ${ACTIONS_FILE} — ignored`);
+  }
+
+  let state = null;
+  if (stateRead.ok) {
+    if (stateRead.data && typeof stateRead.data === 'object' && !Array.isArray(stateRead.data)) {
+      state = stateRead.data;
+    } else {
+      warnings.push(`${ticket}: ${STATE_FILE} is not a JSON object — ignored`);
+    }
+  } else if (stateRead.reason === 'malformed') {
+    warnings.push(`${ticket}: malformed ${STATE_FILE} — ignored`);
+  }
+
+  const bothMissing = actionsRead.reason === 'missing' && stateRead.reason === 'missing';
+  return { actions, state, bothMissing };
+}
+
+/** Derive W1–W4 / E1–E2 verdicts on each task bucket (mutates buckets). */
+function deriveTaskVerdicts(perTask, threshold) {
+  const taskNums = [...perTask.keys()].sort((a, b) => a - b);
+  for (const n of taskNums) {
+    const b = perTask.get(n);
+    b.retries = b.fixRounds + Math.max(b.gateRejections, b.stateRetries);
+    b.advanced = b.completed || b.orchestratorPasses > 0 || b.reviewFailures > 0;
+    b.wedged =
+      b.retries > threshold || b.escalations > 0 || b.recoveries > 0 || b.plannerHold === true;
+    b.escaped = b.advanced && (b.reviewFailures > 0 || b.fixRounds > 0);
+  }
+  return taskNums;
+}
+
+/**
+ * Analyze one ticket dir. Never throws.
+ * @returns {{ ticket: string, skipped: boolean, warnings: string[] }} plus
+ *   the full per-ticket report fields when not skipped.
+ */
+function analyzeTicket(tasksBase, ticket, options) {
+  const warnings = [];
+  const dir = path.join(tasksBase, ticket);
+  const { actions, state, bothMissing } = readTicketInputs(dir, ticket, warnings);
+
+  if (actions.length === 0 && !state) {
+    if (bothMissing) warnings.push(`${ticket}: no ${ACTIONS_FILE} or ${STATE_FILE} — skipped`);
+    return { ticket, skipped: true, warnings };
+  }
+
+  const perTask = new Map();
+  const actionSignals = scanActions(actions, perTask);
+  const stateSignals = scanState(state, perTask);
+
+  // W3 fallback: unattributed operator events attach to the current task.
+  if (actionSignals.unattributedRecoveries > 0 && stateSignals.currentTask) {
+    taskBucket(perTask, stateSignals.currentTask).recoveries +=
+      actionSignals.unattributedRecoveries;
+    actionSignals.unattributedRecoveries = 0;
+  }
+
+  const taskNums = deriveTaskVerdicts(perTask, options.wedgeThreshold);
+  const knownTasks = Math.max(stateSignals.knownTasks, taskNums.length ? taskNums.at(-1) : 0);
+  const tasks = taskNums.map((n) => perTask.get(n));
+  const wedgedTasks = tasks.filter((t) => t.wedged).map((t) => t.task);
+  const escapedTasks = tasks.filter((t) => t.escaped).map((t) => t.task);
+  const advancedTasks = tasks.filter((t) => t.advanced).map((t) => t.task);
+
+  return {
+    ticket,
+    skipped: false,
+    warnings,
+    knownTasks,
+    advancedTasks,
+    wedgedTasks,
+    escapedTasks,
+    wedgeRate: knownTasks > 0 ? wedgedTasks.length / knownTasks : 0,
+    escapeRate: advancedTasks.length > 0 ? escapedTasks.length / advancedTasks.length : 0,
+    retriesTotal: tasks.reduce((sum, t) => sum + t.retries, 0),
+    perTask: tasks,
+    dispatches: {
+      usageRows: actionSignals.usageDispatches,
+      implement: actionSignals.implementDispatches,
+    },
+    timeInImplementMs: actionSignals.timeInImplementMs,
+    implementStepResets: actionSignals.implementStepResets,
+    implementBlocks: actionSignals.implementBlocks,
+    implementReentries: actionSignals.implementReentries,
+    unattributedReviewFailures: actionSignals.unattributedReviewFailures,
+    unattributedRecoveries: actionSignals.unattributedRecoveries,
+  };
+}
+
+module.exports = {
+  ACTIONS_FILE,
+  STATE_FILE,
+  DEFAULT_WEDGE_THRESHOLD,
+  readJsonFile,
+  listTicketDirs,
+  analyzeTicket,
+};

--- a/plugins/work/scripts/workflows/lib/scripts/sli/sli-report.js
+++ b/plugins/work/scripts/workflows/lib/scripts/sli/sli-report.js
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/**
+ * sli-report.js — implement-phase SLI extractor (GH-751, outcome-verification
+ * Phase 0; plan §6 Phase 0 / §7).
+ *
+ * Reads each `<ticket>/` dir under a tasks base and derives, per ticket and in
+ * aggregate, the SLIs the outcome-verification work is judged against: wedge
+ * rate, escape rate, retries/task, dispatches, time-in-implement. All
+ * heuristics are documented proxies over the audit trail — run --help.
+ *
+ * Usage:
+ *   node sli-report.js [--tasks-base <dir>] [--wedge-threshold <n>] [--json]
+ *                      [ticket ...]
+ *
+ * Contract: read-only, standalone (TASKS_BASE env or --tasks-base); exit 0
+ * with warnings on bad per-ticket data; exit 1 only on unusable input.
+ */
+
+const {
+  ACTIONS_FILE,
+  STATE_FILE,
+  DEFAULT_WEDGE_THRESHOLD,
+  listTicketDirs,
+  analyzeTicket,
+} = require('./scan');
+const { formatDuration } = require('../../../../stats/stats');
+
+/** Aggregate the per-ticket reports. */
+function aggregate(reports) {
+  const agg = {
+    tickets: reports.length,
+    ticketsWithWedge: 0,
+    ticketsWithEscape: 0,
+    tasksKnown: 0,
+    tasksAdvanced: 0,
+    tasksWedged: 0,
+    tasksEscaped: 0,
+    retriesTotal: 0,
+    dispatchesTotal: 0,
+    implementDispatchesTotal: 0,
+    timeInImplementMsTotal: 0,
+    implementReentriesTotal: 0,
+    wedgeRate: 0,
+    escapeRate: 0,
+  };
+  for (const r of reports) {
+    if (r.wedgedTasks.length > 0 || r.unattributedRecoveries > 0) agg.ticketsWithWedge++;
+    if (r.escapedTasks.length > 0 || r.implementReentries > 0) agg.ticketsWithEscape++;
+    agg.tasksKnown += r.knownTasks;
+    agg.tasksAdvanced += r.advancedTasks.length;
+    agg.tasksWedged += r.wedgedTasks.length;
+    agg.tasksEscaped += r.escapedTasks.length;
+    agg.retriesTotal += r.retriesTotal;
+    agg.dispatchesTotal += r.dispatches.usageRows;
+    agg.implementDispatchesTotal += r.dispatches.implement;
+    agg.timeInImplementMsTotal += r.timeInImplementMs;
+    agg.implementReentriesTotal += r.implementReentries;
+  }
+  agg.wedgeRate = agg.tasksKnown > 0 ? agg.tasksWedged / agg.tasksKnown : 0;
+  agg.escapeRate = agg.tasksAdvanced > 0 ? agg.tasksEscaped / agg.tasksAdvanced : 0;
+  return agg;
+}
+
+const HELP = `sli-report — implement-phase SLI extractor (outcome-verification Phase 0)
+
+Usage:
+  node sli-report.js [options] [ticket ...]
+
+Options:
+  --tasks-base <dir>       Tasks base dir containing <ticket>/ dirs with
+                           ${ACTIONS_FILE} + ${STATE_FILE}.
+                           Default: $TASKS_BASE.
+  --wedge-threshold <n>    Retries-per-task count ABOVE which a task counts as
+                           wedged (default ${DEFAULT_WEDGE_THRESHOLD}).
+  --json                   Machine output (single JSON document on stdout).
+  -h, --help               This help.
+
+Positional ticket ids restrict the report to those ticket dirs.
+
+Measurement heuristics (all SLIs are proxies over the audit trail — escape
+attribution in particular is heuristic):
+
+  Wedge (per task) — any of:
+    W1 retries(task) > threshold, where retries(task) =
+       taskReviewFixRounds (state) + max(gate-rejection enforcement rows
+       [action tdd-*, allow:false] attributed to the task, _tddRetryCount
+       attributed via _tddRetryTask). max() avoids double-counting: a gate
+       rejection writes an enforcement row AND bumps _tddRetryCount.
+    W2 escalation row: "task N/M fix rounds exhausted ... escalating".
+    W3 operator recovery/surgery event: legacy what/meta.type matching
+       /recover|surgery/i or enforcement action matching /recover/i
+       ('work-state.js recover' rows land here). Unattributed events attach
+       to the state's current task, else count at ticket level only.
+    W4 planner hold parked in state (_tddRetryPlannerDefect via _tddRetryTask).
+
+  Escape (per task) — advanced AND caught defective downstream:
+    E1 advanced: tasksMeta status 'completed' OR any "task N/M review
+       scheduled" row (task_review only runs after the gate advanced it).
+    E2 defect signal: "task review failed: ..." row attributed to the task
+       via the nearest PRECEDING "review scheduled" row (the failure row
+       carries no task number), OR taskReviewFixRounds > 0.
+    E3 ticket-level only: implement re-entries (implement 'step started'
+       rows beyond the first) mean a downstream step sent the workflow back;
+       reported as implementReentries without naming a task.
+
+  Dispatches:
+    D1 per ticket: usage rows (kind:'usage'); implementDispatches = those
+       with step 'implement'.
+    D2 per task: "review scheduled" rows per task (orchestrator passes —
+       over-counts agent dispatches; only per-task-attributable signal).
+
+  Time-in-implement:
+    T1 sum of implement-step 'step started' -> 'step completed' intervals;
+       a dangling start closes at the last legacy row timestamp.
+
+Rates:
+  wedge rate  = wedged tasks / known tasks
+  escape rate = escaped tasks / advanced tasks
+`;
+
+/** Apply one value-taking flag. Returns an error string or null. */
+function consumeValueFlag(out, flag, value) {
+  if (flag === '--tasks-base') {
+    if (!value) return '--tasks-base requires a directory argument';
+    out.tasksBase = value;
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return '--wedge-threshold requires a non-negative integer';
+  }
+  out.wedgeThreshold = parsed;
+  return null;
+}
+
+/** Parse CLI args. Returns { help, json, tasksBase, wedgeThreshold, tickets, error }. */
+function parseArgs(argv, env) {
+  const out = {
+    help: false,
+    json: false,
+    tasksBase: env.TASKS_BASE || null,
+    wedgeThreshold: DEFAULT_WEDGE_THRESHOLD,
+    tickets: [],
+    error: null,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '-h' || arg === '--help') {
+      out.help = true;
+      continue;
+    }
+    if (arg === '--json') {
+      out.json = true;
+      continue;
+    }
+    if (arg === '--tasks-base' || arg === '--wedge-threshold') {
+      const error = consumeValueFlag(out, arg, argv[++i]);
+      if (error) return { ...out, error };
+      continue;
+    }
+    if (arg.startsWith('-')) return { ...out, error: `unknown option: ${arg}` };
+    out.tickets.push(arg);
+  }
+  return out;
+}
+
+/** Format a 0..1 rate as a percentage. */
+function pct(rate) {
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+/** Render the human table. */
+function renderTable(reports, agg, options) {
+  const header = [
+    'ticket',
+    'tasks',
+    'advanced',
+    'wedged',
+    'escaped',
+    'retries',
+    'disp',
+    'impl-time',
+  ];
+  const rows = reports.map((r) => [
+    r.ticket,
+    String(r.knownTasks),
+    String(r.advancedTasks.length),
+    r.wedgedTasks.length > 0 ? `${r.wedgedTasks.length} (#${r.wedgedTasks.join(',#')})` : '0',
+    r.escapedTasks.length > 0 ? `${r.escapedTasks.length} (#${r.escapedTasks.join(',#')})` : '0',
+    String(r.retriesTotal),
+    String(r.dispatches.usageRows),
+    formatDuration(r.timeInImplementMs),
+  ]);
+  const widths = header.map((h, col) => Math.max(h.length, ...rows.map((row) => row[col].length)));
+  const renderRow = (cells) => cells.map((c, col) => c.padEnd(widths[col])).join('  ');
+
+  const lines = [renderRow(header), renderRow(widths.map((w) => '-'.repeat(w)))];
+  for (const row of rows) lines.push(renderRow(row));
+  lines.push('');
+  lines.push(
+    `aggregate: ${agg.tickets} ticket(s), ${agg.tasksKnown} task(s), ` +
+      `wedge rate ${pct(agg.wedgeRate)} (${agg.tasksWedged}/${agg.tasksKnown} tasks, ` +
+      `${agg.ticketsWithWedge} ticket(s)), ` +
+      `escape rate ${pct(agg.escapeRate)} (${agg.tasksEscaped}/${agg.tasksAdvanced} advanced, ` +
+      `${agg.ticketsWithEscape} ticket(s))`
+  );
+  lines.push(
+    `           retries ${agg.retriesTotal}, dispatches ${agg.dispatchesTotal} ` +
+      `(${agg.implementDispatchesTotal} implement), ` +
+      `time-in-implement ${formatDuration(agg.timeInImplementMsTotal)}, ` +
+      `implement re-entries ${agg.implementReentriesTotal}, ` +
+      `wedge threshold ${options.wedgeThreshold}`
+  );
+  return lines.join('\n');
+}
+
+/** Collect per-ticket reports, folding failures into warnings. */
+function collectReports(requested, options, warnings) {
+  const reports = [];
+  for (const ticket of requested) {
+    let result;
+    try {
+      result = analyzeTicket(options.tasksBase, ticket, options);
+    } catch (err) {
+      // Belt-and-braces: analyzeTicket is designed never to throw, but a
+      // measurement tool must never crash on one bad ticket dir.
+      warnings.push(`${ticket}: analysis failed (${err && err.message}) — skipped`);
+      continue;
+    }
+    warnings.push(...result.warnings);
+    if (!result.skipped) reports.push(result);
+  }
+  return reports;
+}
+
+/** Entry point. @returns {number} exit code */
+function main(argv, env, stdout, stderr) {
+  const options = parseArgs(argv, env);
+  if (options.error) {
+    stderr.write(`error: ${options.error}\n\n${HELP}`);
+    return 1;
+  }
+  if (options.help) {
+    stdout.write(HELP);
+    return 0;
+  }
+  if (!options.tasksBase) {
+    stderr.write('error: no tasks base — set TASKS_BASE or pass --tasks-base <dir>\n');
+    return 1;
+  }
+
+  const requested =
+    options.tickets.length > 0 ? options.tickets : listTicketDirs(options.tasksBase);
+  if (requested === null) {
+    stderr.write(`error: cannot read tasks base dir: ${options.tasksBase}\n`);
+    return 1;
+  }
+
+  const warnings = [];
+  const reports = collectReports(requested, options, warnings);
+  for (const warning of warnings) stderr.write(`warning: ${warning}\n`);
+
+  const agg = aggregate(reports);
+  if (options.json) {
+    const doc = {
+      generatedAt: new Date().toISOString(),
+      tasksBase: options.tasksBase,
+      wedgeThreshold: options.wedgeThreshold,
+      tickets: reports,
+      aggregate: agg,
+      warnings,
+    };
+    stdout.write(`${JSON.stringify(doc, null, 2)}\n`);
+    return 0;
+  }
+  if (reports.length === 0) {
+    stdout.write(`no analyzable tickets under ${options.tasksBase}\n`);
+    return 0;
+  }
+  stdout.write(`${renderTable(reports, agg, options)}\n`);
+  return 0;
+}
+
+if (require.main === module) {
+  process.exitCode = main(process.argv.slice(2), process.env, process.stdout, process.stderr);
+}
+
+module.exports = { parseArgs, renderTable, aggregate, main };

--- a/plugins/work/scripts/workflows/lib/scripts/sli/sli-report.js
+++ b/plugins/work/scripts/workflows/lib/scripts/sli/sli-report.js
@@ -26,7 +26,11 @@ const {
   listTicketDirs,
   analyzeTicket,
 } = require('./scan');
-const { formatDuration } = require('../../../../stats/stats');
+// Shared duration formatter (ONE implementation) — deliberately the tiny
+// standalone statusline module, not stats/stats.js, whose top-level requires
+// pull in the whole workflow-state subsystem and would break this tool's
+// standalone contract on a bare checkout.
+const { formatDurationMs } = require('../../statusline/duration');
 
 /** Aggregate the per-ticket reports. */
 function aggregate(reports) {
@@ -192,7 +196,7 @@ function renderTable(reports, agg, options) {
     r.escapedTasks.length > 0 ? `${r.escapedTasks.length} (#${r.escapedTasks.join(',#')})` : '0',
     String(r.retriesTotal),
     String(r.dispatches.usageRows),
-    formatDuration(r.timeInImplementMs),
+    formatDurationMs(r.timeInImplementMs),
   ]);
   const widths = header.map((h, col) => Math.max(h.length, ...rows.map((row) => row[col].length)));
   const renderRow = (cells) => cells.map((c, col) => c.padEnd(widths[col])).join('  ');
@@ -210,7 +214,7 @@ function renderTable(reports, agg, options) {
   lines.push(
     `           retries ${agg.retriesTotal}, dispatches ${agg.dispatchesTotal} ` +
       `(${agg.implementDispatchesTotal} implement), ` +
-      `time-in-implement ${formatDuration(agg.timeInImplementMsTotal)}, ` +
+      `time-in-implement ${formatDurationMs(agg.timeInImplementMsTotal)}, ` +
       `implement re-entries ${agg.implementReentriesTotal}, ` +
       `wedge threshold ${options.wedgeThreshold}`
   );


### PR DESCRIPTION
## Existing Behavior

- The implement phase has no historical incident regression suite; there is no way to assert that a verifier rule change does not regress a past false-GREEN or wedge case.
- SLI measurements (wedge rate, escape rate, retries, time-in-implement) do not exist as computed numbers — they are anecdote and memory.
- The shared verdict vocabulary (VERIFIED / UNVERIFIED / CONTRADICTED, typed exits, invariant IDs) lives only in the design plan document, not in importable code.

## Intended New Behavior

- **Incident replay corpus** (`plugins/work/scripts/workflows/lib/replay-corpus/`): 21 fixtures encoding 20 historical incidents at the observation layer, each labeled with the correct verdict under the outcome model. Every historical false-GREEN maps to CONTRADICTED; every historical wedge maps to VERIFIED or UNVERIFIED (never a dead-end block). The corpus is the Phase 2 verifier's own regression suite (GH-755) — a rule change that regresses a fixture does not ship.
- **Shared verdict vocabulary** (`lib/outcome-verdicts.js`): single-source-of-truth constants for VERDICTS, EXITS, INVARIANTS, FLAG_KINDS, and TASK_KINDS, imported by the corpus loader, the SLI extractor, and eventually the Phase 2 verifier and Phase 3 flip wiring so none of these can drift on naming.
- **SLI extractor** (`lib/scripts/sli/`): `sli-report.js` CLI + `scan.js` measure wedge rate (W1–W4), escape rate (E1–E3), retries, dispatch counts, and time-in-implement from `.work-actions.json`/`.work-state.json`, with documented proxy heuristics per metric.
- **Phase 0 baseline** (`docs/outcome-verification-baseline.md`): 92 analyzable tickets, 505 tasks; wedge rate 2.0% (10/505); escape rate 0.0% measured with explicit caveats about what the audit trail cannot yet see. This is the number every subsequent phase is judged against.
- **Implementation plan** (`docs/implement-outcome-verification-plan.md`): full architectural spec (§1–10, appendix) covering the seven incident classes, five mechanical invariants, phased delivery (Phase 0–5), and decision record.

Two framing notes for reviewers: fixtures `gh-248-docs-profile-framing` and `gh-539-scope-glob-unexpandable` encode the **defect class** the plan cites (vacuous advance and scope-resolver split, respectively) rather than the literal issue content; the plan's cross-references for those two issues do not match the issues' actual subjects. Each fixture's `provenance.notes` field documents this explicitly.

## Brief P0 coverage

- **P0 #1:** Corpus fixtures load and label (schema-validated, all 21 pass) — implemented in `plugins/work/scripts/workflows/lib/replay-corpus/index.js` + `fixtures/` (21 JSON files); tested in `replay-corpus/__tests__/replay-corpus.test.js`
- **P0 #2:** SLI report runs over ≥ 10 historical tickets — implemented in `lib/scripts/sli/sli-report.js` + `scan.js`; baseline covers 92 tickets / 505 tasks committed in `docs/outcome-verification-baseline.md`

## Dev Checks

- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Corpus loader (backend — node CLI):**

```bash
node -e "
  const { loadCorpus } = require('./plugins/work/scripts/workflows/lib/replay-corpus/index.js');
  const { fixtures, errors } = loadCorpus();
  if (errors.length) throw new Error(errors.join('\n'));
  console.log('Loaded:', fixtures.length, 'fixtures');
  console.log('CONTRADICTED:', fixtures.filter(f => f.expected.verdict === 'CONTRADICTED').length);
  console.log('UNVERIFIED:', fixtures.filter(f => f.expected.verdict === 'UNVERIFIED').length);
  console.log('VERIFIED:', fixtures.filter(f => f.expected.verdict === 'VERIFIED').length);
"
```

Expected: 21 fixtures loaded, 15 CONTRADICTED, 5 UNVERIFIED, 1 VERIFIED (or similar distribution); no validation errors thrown.

**SLI report (backend — requires `$TASKS_BASE` pointing to a history dir):**

```bash
node plugins/work/scripts/workflows/lib/scripts/sli/sli-report.js \
  --tasks-base "$TASKS_BASE"
# Add --json for machine-readable output
```

Expected: tabulated output of wedge rate, escape rate, retry count, dispatch count, time-in-implement over all GH-* ticket dirs under the base. The committed baseline (`docs/outcome-verification-baseline.md`) shows representative output for 92 tickets.

**Test suite (25 node --test cases — 13 SLI + 12 corpus):**

```bash
node --test plugins/work/scripts/workflows/lib/replay-corpus/__tests__/replay-corpus.test.js
node --test plugins/work/scripts/workflows/lib/scripts/sli/__tests__/sli-report.test.js
```

Expected: all 25 tests pass; `dev:check` exits 0.

### Test Results

25 node --test cases pass (13 SLI unit tests + 12 corpus schema/loader tests). `pnpm dev:check` exits 0 (lint clean, no TypeScript files changed).

Closes #751
